### PR TITLE
Add a11y, tabindex, visual cues for dfns and panels

### DIFF
--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -244,6 +244,7 @@ dfnPanelScript = """
         // Find dfn panel
         const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
         if (dfnPanel) {
+            dfn.insertAdjacentElement("afterend", dfnPanel);
             dfn.setAttribute('role', 'button');
             dfn.setAttribute('aria-haspopup', 'menu');
             dfn.setAttribute('aria-expanded', 'false')

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -162,19 +162,12 @@ function queryAll(sel) {
 
 // Add popup behavior to all dfns to show the corresponding dfn-panel.
 var dfns = document.querySelectorAll('.dfn-paneled');
+for (let dfn of dfns) { insertDfnPopupAction(dfn); }
 
 document.body.addEventListener("click", (e) => {
     // If not handled already, just hide all dfn panels.
     hideAllDfnPanels();
 });
-
-// We need to get the createElement method now, or else it is not available!?
-var createElement = document.createElement;
-var makeTag = (tag) => {
-    return createElement.call(document, tag);
-}
-
-for (let dfn of dfns) { insertDfnPopupAction(dfn); }
 
 function hideAllDfnPanels() {
     // Turn off any currently "on" or "activated" panels.
@@ -210,9 +203,7 @@ function insertDfnPopupAction(dfn) {
     // Find dfn panel
     const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
     if (dfnPanel) {
-        const panelId = `dfn-panel-${dfnPanel.getAttribute('data-for')}`;
-        dfnPanel.id = panelId;
-        const dfnId = dfn.id;
+        dfnPanel.id = `dfn-panel-${dfnPanel.getAttribute('data-for')}`;
 
         if (dfnPanel.id)
             dfn.setAttribute('aria-describedby', dfnPanel.id);
@@ -227,8 +218,8 @@ function insertDfnPopupAction(dfn) {
             showDfnPanel(dfnPanel, dfn);
         });
 
-        if (dfnId)
-            dfnPanel.setAttribute('aria-labelledby', dfnId);
+        if (dfn.id)
+            dfnPanel.setAttribute('aria-labelledby', dfn.id);
 
         dfnPanel.setAttribute('aria-hidden', true);
         dfnPanel.addEventListener('click', (event) => {

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -202,15 +202,18 @@ dfnPanelScript = """
         hideAllDfnPanels(); // Only display one at this time.
         dfn.setAttribute("aria-expanded", "true");
         dfnPanel.classList.add("on");
-        const rect = dfn.getBoundingClientRect();
-        dfnPanel.style.left = `${window.scrollX + rect.right + 5}px`;
-        dfnPanel.style.top = `${window.scrollY + rect.top}px`;
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
         const panelRect = dfnPanel.getBoundingClientRect();
         const panelWidth = panelRect.right - panelRect.left;
-        if (panelRect.right > document.body.scrollWidth &&
-            (rect.left - (panelWidth + 5)) > 0) {
-            // Reposition, because the panel is overflowing
-            dfnPanel.style.left = `${window.scrollX + rect.left - (panelWidth + 5)}px`;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
         }
     }
 
@@ -242,7 +245,11 @@ dfnPanelScript = """
         // Find dfn panel
         const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
         if (dfnPanel) {
-            dfn.insertAdjacentElement("afterend", dfnPanel);
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
             dfn.setAttribute('role', 'button');
             dfn.setAttribute('aria-haspopup', 'menu');
             dfn.setAttribute('aria-expanded', 'false')

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -315,14 +315,6 @@ dfnPanelStyle = """
 }
 
 .dfn-paneled { cursor: pointer; }
-
-dfn.has-dfn-panel:hover, .dfn-paneled:hover,
-dfn.has-dfn-panel:focus, .dfn-paneled:focus {
-    outline: 2px outset;
-    outline-color: rgba(152, 200, 254, .9);
-    outline-offset: 1px;
-    border-radius: 2px;
-}
 """
 
 dfnPanelDarkmodeStyle = """

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -47,7 +47,6 @@ def addDfnPanels(doc: t.SpecT, dfns: list[t.ElementT]) -> None:
                 "id": f"infopanel-for-{id}",
                 "role": "dialog",
                 "aria-labelledby": f"infopaneltitle-for-{id}",
-                "aria-hidden": "true",
             },
             h.E.span(
                 {"style": "display:none", "id": f"infopaneltitle-for-{id}"},
@@ -129,7 +128,6 @@ def addExternalDfnPanel(termEl: t.ElementT, ref: r.RefWrapper, doc: t.SpecT) -> 
                 "id": f"infopanel-for-{termID}",
                 "role": "menu",
                 "aria-labelledby": f"infopaneltitle-for-{termID}",
-                "aria-hidden": "true",
             },
             h.E.span(
                 {"style": "display:none", "id": f"infopaneltitle-for-{termID}"},

--- a/bikeshed/dfnpanels.py
+++ b/bikeshed/dfnpanels.py
@@ -274,6 +274,14 @@ dfnPanelScript = """
                 event.stopPropagation();
             });
 
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
         } else {
             console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
         }

--- a/tests/adjacent-boilerplate/adjacent-boilerplate.html
+++ b/tests/adjacent-boilerplate/adjacent-boilerplate.html
@@ -494,14 +494,14 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-response" id="ref-for-concept-response-response">response</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-term">
-   <a href="https://example.test/foo/#term">https://example.test/foo/#term</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-term" class="dfn-panel" data-for="term-for-term" id="infopanel-for-term-for-term" role="menu">
+   <span id="infopaneltitle-for-term-for-term" style="display:none">Info about the 'term' external reference.</span><a href="https://example.test/foo/#term">https://example.test/foo/#term</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-term">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">Unnamed section</a>
    </ul>
@@ -529,57 +529,113 @@ dfn > a.self-link::before      { content: "#"; }
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/css-production-range001.html
+++ b/tests/css-production-range001.html
@@ -505,14 +505,14 @@ dfn > a.self-link::before      { content: "#"; }
 <pre class="prod"><a class="production" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#integer-value" id="ref-for-integer-value⑨">&lt;integer [0,10]></a></pre>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">Unnamed section</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a> <a href="#ref-for-integer-value③">(4)</a> <a href="#ref-for-integer-value④">(5)</a> <a href="#ref-for-integer-value⑤">(6)</a> <a href="#ref-for-integer-value⑥">(7)</a> <a href="#ref-for-integer-value⑦">(8)</a> <a href="#ref-for-integer-value⑧">(9)</a> <a href="#ref-for-integer-value⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">Unnamed section</a> <a href="#ref-for-length-value①">(2)</a>
    </ul>
@@ -534,57 +534,113 @@ dfn > a.self-link::before      { content: "#"; }
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/dict-type.html
+++ b/tests/dict-type.html
@@ -641,14 +641,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-dictwithdefaults-dictwithdefaultempty">dictWithDefaultEmpty</a><span>, in § 1</span>
    <li><a href="#dictdef-dictwithdefaults">DictWithDefaults</a><span>, in § 1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">1. Test</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">1. Test</a>
    </ul>
@@ -675,77 +675,133 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dictdef-dictwithdefaults">
-   <b><a href="#dictdef-dictwithdefaults">#dictdef-dictwithdefaults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dictwithdefaults" class="dfn-panel" data-for="dictdef-dictwithdefaults" id="infopanel-for-dictdef-dictwithdefaults" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dictwithdefaults" style="display:none">Info about the 'DictWithDefaults' definition.</span><b><a href="#dictdef-dictwithdefaults">#dictdef-dictwithdefaults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dictwithdefaults">1. Test</a> <a href="#ref-for-dictdef-dictwithdefaults①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dictwithdefaults-arraywithdefaultempty">
-   <b><a href="#dom-dictwithdefaults-arraywithdefaultempty">#dom-dictwithdefaults-arraywithdefaultempty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dictwithdefaults-arraywithdefaultempty" class="dfn-panel" data-for="dom-dictwithdefaults-arraywithdefaultempty" id="infopanel-for-dom-dictwithdefaults-arraywithdefaultempty" role="dialog">
+   <span id="infopaneltitle-for-dom-dictwithdefaults-arraywithdefaultempty" style="display:none">Info about the 'arrayWithDefaultEmpty' definition.</span><b><a href="#dom-dictwithdefaults-arraywithdefaultempty">#dom-dictwithdefaults-arraywithdefaultempty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dictwithdefaults-arraywithdefaultempty">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dictwithdefaults-dictwithdefaultempty">
-   <b><a href="#dom-dictwithdefaults-dictwithdefaultempty">#dom-dictwithdefaults-dictwithdefaultempty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dictwithdefaults-dictwithdefaultempty" class="dfn-panel" data-for="dom-dictwithdefaults-dictwithdefaultempty" id="infopanel-for-dom-dictwithdefaults-dictwithdefaultempty" role="dialog">
+   <span id="infopaneltitle-for-dom-dictwithdefaults-dictwithdefaultempty" style="display:none">Info about the 'dictWithDefaultEmpty' definition.</span><b><a href="#dom-dictwithdefaults-dictwithdefaultempty">#dom-dictwithdefaults-dictwithdefaultempty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dictwithdefaults-dictwithdefaultempty">1. Test</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/elementdef001.html
+++ b/tests/elementdef001.html
@@ -590,14 +590,14 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#svgtestelement">SVGTestElement</a><span>, in § Unnumbered section</span>
    <li><a href="#elementdef-testelement">testelement</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-flow-content-2">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">https://html.spec.whatwg.org/multipage/dom.html#flow-content-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-content-2" class="dfn-panel" data-for="term-for-flow-content-2" id="infopanel-for-term-for-flow-content-2" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-content-2" style="display:none">Info about the 'flow content' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">https://html.spec.whatwg.org/multipage/dom.html#flow-content-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-content-2">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-graphics-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-graphics-element" class="dfn-panel" data-for="term-for-graphics-element" id="infopanel-for-term-for-graphics-element" role="menu">
+   <span id="infopaneltitle-for-term-for-graphics-element" style="display:none">Info about the 'graphics element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-graphics-element">Unnamed section</a>
    </ul>
@@ -623,113 +623,169 @@ dfn > a.self-link::before      { content: "#"; }
    <dt id="biblio-svg2">[SVG2]
    <dd>Amelia Bellamy-Royds; et al. <a href="https://svgwg.org/svg2-draft/"><cite>Scalable Vector Graphics (SVG) 2</cite></a>. URL: <a href="https://svgwg.org/svg2-draft/">https://svgwg.org/svg2-draft/</a>
   </dl>
-  <aside class="dfn-panel" data-for="element-attrdef-testelement-foo">
-   <b><a href="#element-attrdef-testelement-foo">#element-attrdef-testelement-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-testelement-foo" class="dfn-panel" data-for="element-attrdef-testelement-foo" id="infopanel-for-element-attrdef-testelement-foo" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-testelement-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#element-attrdef-testelement-foo">#element-attrdef-testelement-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-testelement-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-testelement-bar">
-   <b><a href="#element-attrdef-testelement-bar">#element-attrdef-testelement-bar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-testelement-bar" class="dfn-panel" data-for="element-attrdef-testelement-bar" id="infopanel-for-element-attrdef-testelement-bar" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-testelement-bar" style="display:none">Info about the 'bar' definition.</span><b><a href="#element-attrdef-testelement-bar">#element-attrdef-testelement-bar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-testelement-bar">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baz-attributes">
-   <b><a href="#baz-attributes">#baz-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baz-attributes" class="dfn-panel" data-for="baz-attributes" id="infopanel-for-baz-attributes" role="dialog">
+   <span id="infopaneltitle-for-baz-attributes" style="display:none">Info about the 'baz attributes' definition.</span><b><a href="#baz-attributes">#baz-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baz-attributes">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-baz-attributes-baz1">
-   <b><a href="#element-attrdef-baz-attributes-baz1">#element-attrdef-baz-attributes-baz1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-baz-attributes-baz1" class="dfn-panel" data-for="element-attrdef-baz-attributes-baz1" id="infopanel-for-element-attrdef-baz-attributes-baz1" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-baz-attributes-baz1" style="display:none">Info about the 'baz1' definition.</span><b><a href="#element-attrdef-baz-attributes-baz1">#element-attrdef-baz-attributes-baz1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-baz-attributes-baz1">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-baz-attributes-baz2">
-   <b><a href="#element-attrdef-baz-attributes-baz2">#element-attrdef-baz-attributes-baz2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-baz-attributes-baz2" class="dfn-panel" data-for="element-attrdef-baz-attributes-baz2" id="infopanel-for-element-attrdef-baz-attributes-baz2" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-baz-attributes-baz2" style="display:none">Info about the 'baz2' definition.</span><b><a href="#element-attrdef-baz-attributes-baz2">#element-attrdef-baz-attributes-baz2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-baz-attributes-baz2">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quux-attributes">
-   <b><a href="#quux-attributes">#quux-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quux-attributes" class="dfn-panel" data-for="quux-attributes" id="infopanel-for-quux-attributes" role="dialog">
+   <span id="infopaneltitle-for-quux-attributes" style="display:none">Info about the 'quux attributes' definition.</span><b><a href="#quux-attributes">#quux-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quux-attributes">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-quux-attributes-quux1">
-   <b><a href="#element-attrdef-quux-attributes-quux1">#element-attrdef-quux-attributes-quux1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-quux-attributes-quux1" class="dfn-panel" data-for="element-attrdef-quux-attributes-quux1" id="infopanel-for-element-attrdef-quux-attributes-quux1" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-quux-attributes-quux1" style="display:none">Info about the 'quux1' definition.</span><b><a href="#element-attrdef-quux-attributes-quux1">#element-attrdef-quux-attributes-quux1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-quux-attributes-quux1">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-quux-attributes-quux2">
-   <b><a href="#element-attrdef-quux-attributes-quux2">#element-attrdef-quux-attributes-quux2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-quux-attributes-quux2" class="dfn-panel" data-for="element-attrdef-quux-attributes-quux2" id="infopanel-for-element-attrdef-quux-attributes-quux2" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-quux-attributes-quux2" style="display:none">Info about the 'quux2' definition.</span><b><a href="#element-attrdef-quux-attributes-quux2">#element-attrdef-quux-attributes-quux2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-quux-attributes-quux2">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgtestelement">
-   <b><a href="#svgtestelement">#svgtestelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgtestelement" class="dfn-panel" data-for="svgtestelement" id="infopanel-for-svgtestelement" role="dialog">
+   <span id="infopaneltitle-for-svgtestelement" style="display:none">Info about the 'SVGTestElement' definition.</span><b><a href="#svgtestelement">#svgtestelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgtestelement">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/WebApiDevice/managed_config/index.html
+++ b/tests/github/WICG/WebApiDevice/managed_config/index.html
@@ -821,151 +821,151 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#navigatormanageddata">NavigatorManagedData</a><span>, in § 3</span>
    <li><a href="#dom-navigatormanageddata-onmanagedconfigurationchange">onmanagedconfigurationchange</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.2. onmanagedconfigurationchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.2. onmanagedconfigurationchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2. Extensions to the Navigator interface</a> <a href="#ref-for-navigator①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">3.2. onmanagedconfigurationchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.1. getManagedConfiguration() method</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
     <li><a href="#ref-for-concept-relevant-global②">3.2. onmanagedconfigurationchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">1.3. Data model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1.3. Data model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">1.3. Data model</a>
     <li><a href="#ref-for-concept-url-origin①">3.1. getManagedConfiguration() method</a> <a href="#ref-for-concept-url-origin②">(2)</a>
     <li><a href="#ref-for-concept-url-origin③">3.2. onmanagedconfigurationchange attribute</a> <a href="#ref-for-concept-url-origin④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. NavigatorManagedData interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2. Extensions to the Navigator interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2. Extensions to the Navigator interface</a> <a href="#ref-for-SecureContext①">(2)</a>
     <li><a href="#ref-for-SecureContext②">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">3. NavigatorManagedData interface</a>
     <li><a href="#ref-for-idl-record①">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. NavigatorManagedData interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. getManagedConfiguration() method</a> <a href="#ref-for-this①">(2)</a>
    </ul>
@@ -1051,21 +1051,21 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="data-model">
-   <b><a href="#data-model">#data-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-model" class="dfn-panel" data-for="data-model" id="infopanel-for-data-model" role="dialog">
+   <span id="infopaneltitle-for-data-model" style="display:none">Info about the 'Data model' definition.</span><b><a href="#data-model">#data-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-model">1.3. Data model</a>
     <li><a href="#ref-for-data-model①">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-managed">
-   <b><a href="#dom-navigator-managed">#dom-navigator-managed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-managed" class="dfn-panel" data-for="dom-navigator-managed" id="infopanel-for-dom-navigator-managed" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-managed" style="display:none">Info about the 'managed' definition.</span><b><a href="#dom-navigator-managed">#dom-navigator-managed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-managed">2.1. managed attribute</a> <a href="#ref-for-dom-navigator-managed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatormanageddata">
-   <b><a href="#navigatormanageddata">#navigatormanageddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatormanageddata" class="dfn-panel" data-for="navigatormanageddata" id="infopanel-for-navigatormanageddata" role="dialog">
+   <span id="infopaneltitle-for-navigatormanageddata" style="display:none">Info about the 'NavigatorManagedData' definition.</span><b><a href="#navigatormanageddata">#navigatormanageddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatormanageddata">2. Extensions to the Navigator interface</a>
     <li><a href="#ref-for-navigatormanageddata①">2.1. managed attribute</a>
@@ -1073,84 +1073,140 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-navigatormanageddata③">3.2. onmanagedconfigurationchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatormanageddata-onmanagedconfigurationchange">
-   <b><a href="#dom-navigatormanageddata-onmanagedconfigurationchange">#dom-navigatormanageddata-onmanagedconfigurationchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatormanageddata-onmanagedconfigurationchange" class="dfn-panel" data-for="dom-navigatormanageddata-onmanagedconfigurationchange" id="infopanel-for-dom-navigatormanageddata-onmanagedconfigurationchange" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatormanageddata-onmanagedconfigurationchange" style="display:none">Info about the 'onmanagedconfigurationchange' definition.</span><b><a href="#dom-navigatormanageddata-onmanagedconfigurationchange">#dom-navigatormanageddata-onmanagedconfigurationchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatormanageddata-onmanagedconfigurationchange">3.2. onmanagedconfigurationchange attribute</a> <a href="#ref-for-dom-navigatormanageddata-onmanagedconfigurationchange①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="managed-data-task-source">
-   <b><a href="#managed-data-task-source">#managed-data-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-managed-data-task-source" class="dfn-panel" data-for="managed-data-task-source" id="infopanel-for-managed-data-task-source" role="dialog">
+   <span id="infopaneltitle-for-managed-data-task-source" style="display:none">Info about the 'managed data task source' definition.</span><b><a href="#managed-data-task-source">#managed-data-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-managed-data-task-source">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatormanageddata-getmanagedconfiguration">
-   <b><a href="#dom-navigatormanageddata-getmanagedconfiguration">#dom-navigatormanageddata-getmanagedconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatormanageddata-getmanagedconfiguration" class="dfn-panel" data-for="dom-navigatormanageddata-getmanagedconfiguration" id="infopanel-for-dom-navigatormanageddata-getmanagedconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatormanageddata-getmanagedconfiguration" style="display:none">Info about the 'getManagedConfiguration(keys)' definition.</span><b><a href="#dom-navigatormanageddata-getmanagedconfiguration">#dom-navigatormanageddata-getmanagedconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatormanageddata-getmanagedconfiguration">3. NavigatorManagedData interface</a>
     <li><a href="#ref-for-dom-navigatormanageddata-getmanagedconfiguration①">3.1. getManagedConfiguration() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="managedconfigurationchange">
-   <b><a href="#managedconfigurationchange">#managedconfigurationchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-managedconfigurationchange" class="dfn-panel" data-for="managedconfigurationchange" id="infopanel-for-managedconfigurationchange" role="dialog">
+   <span id="infopaneltitle-for-managedconfigurationchange" style="display:none">Info about the 'managedconfigurationchange' definition.</span><b><a href="#managedconfigurationchange">#managedconfigurationchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-managedconfigurationchange">3.2. onmanagedconfigurationchange attribute</a> <a href="#ref-for-managedconfigurationchange①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/aom/spec/custom-element-semantics.html
+++ b/tests/github/WICG/aom/spec/custom-element-semantics.html
@@ -987,87 +987,87 @@ or in a property set on the element.</p>
    <li><a href="#dictdef-elementinternals">ElementInternals</a><span>, in § 1.2</span>
    <li><a href="#semantic-properties">semantic properties</a><span>, in § 1.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-def-accessibilityrole">
-   <a href="https://www.w3.org/TR/wai-aria-1.2/#idl-def-accessibilityrole">https://www.w3.org/TR/wai-aria-1.2/#idl-def-accessibilityrole</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-accessibilityrole" class="dfn-panel" data-for="term-for-idl-def-accessibilityrole" id="infopanel-for-term-for-idl-def-accessibilityrole" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-accessibilityrole" style="display:none">Info about the 'AccessibilityRole' external reference.</span><a href="https://www.w3.org/TR/wai-aria-1.2/#idl-def-accessibilityrole">https://www.w3.org/TR/wai-aria-1.2/#idl-def-accessibilityrole</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-accessibilityrole">1.2. Changes to custom element definition</a> <a href="#ref-for-idl-def-accessibilityrole①">(2)</a> <a href="#ref-for-idl-def-accessibilityrole②">(3)</a> <a href="#ref-for-idl-def-accessibilityrole③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-ariaattributes">
-   <a href="https://www.w3.org/TR/wai-aria-1.2/#idl-def-ariaattributes">https://www.w3.org/TR/wai-aria-1.2/#idl-def-ariaattributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-ariaattributes" class="dfn-panel" data-for="term-for-idl-def-ariaattributes" id="infopanel-for-term-for-idl-def-ariaattributes" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-ariaattributes" style="display:none">Info about the 'AriaAttributes' external reference.</span><a href="https://www.w3.org/TR/wai-aria-1.2/#idl-def-ariaattributes">https://www.w3.org/TR/wai-aria-1.2/#idl-def-ariaattributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-ariaattributes">1.2. Changes to custom element definition</a> <a href="#ref-for-idl-def-ariaattributes①">(2)</a> <a href="#ref-for-idl-def-ariaattributes②">(3)</a> <a href="#ref-for-idl-def-ariaattributes③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-accessibility-tree">
-   <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree">https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-accessibility-tree" class="dfn-panel" data-for="term-for-dfn-accessibility-tree" id="infopanel-for-term-for-dfn-accessibility-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-accessibility-tree" style="display:none">Info about the 'accessibility tree' external reference.</span><a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree">https://www.w3.org/TR/core-aam-1.1/#dfn-accessibility-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-accessibility-tree">1.1.1. Defining custom element semantics as part of the custom element definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-accessible-object">
-   <a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object">https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-accessible-object" class="dfn-panel" data-for="term-for-dfn-accessible-object" id="infopanel-for-term-for-dfn-accessible-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-accessible-object" style="display:none">Info about the 'accessible object' external reference.</span><a href="https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object">https://www.w3.org/TR/core-aam-1.1/#dfn-accessible-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-accessible-object">1.1.1. Defining custom element semantics as part of the custom element definition</a> <a href="#ref-for-dfn-accessible-object①">(2)</a>
     <li><a href="#ref-for-dfn-accessible-object②">1.1.2. Defining per-instance custom element semantics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mapping_general">
-   <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_general">https://www.w3.org/TR/core-aam-1.1/#mapping_general</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mapping_general" class="dfn-panel" data-for="term-for-mapping_general" id="infopanel-for-term-for-mapping_general" role="menu">
+   <span id="infopaneltitle-for-term-for-mapping_general" style="display:none">Info about the 'mapped' external reference.</span><a href="https://www.w3.org/TR/core-aam-1.1/#mapping_general">https://www.w3.org/TR/core-aam-1.1/#mapping_general</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mapping_general">1.1.1. Defining custom element semantics as part of the custom element definition</a>
     <li><a href="#ref-for-mapping_general①">1.1.2. Defining per-instance custom element semantics</a>
     <li><a href="#ref-for-mapping_general②">2.2.1. Rules for exposing semantics of custom elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mapping_role">
-   <a href="https://www.w3.org/TR/core-aam-1.1/#mapping_role">https://www.w3.org/TR/core-aam-1.1/#mapping_role</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mapping_role" class="dfn-panel" data-for="term-for-mapping_role" id="infopanel-for-term-for-mapping_role" role="menu">
+   <span id="infopaneltitle-for-term-for-mapping_role" style="display:none">Info about the 'mapped role' external reference.</span><a href="https://www.w3.org/TR/core-aam-1.1/#mapping_role">https://www.w3.org/TR/core-aam-1.1/#mapping_role</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mapping_role">1.1.1. Defining custom element semantics as part of the custom element definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-custom">
-   <a href="https://dom.spec.whatwg.org/#concept-element-custom">https://dom.spec.whatwg.org/#concept-element-custom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-custom" class="dfn-panel" data-for="term-for-concept-element-custom" id="infopanel-for-term-for-concept-element-custom" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-custom" style="display:none">Info about the 'custom' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-custom">https://dom.spec.whatwg.org/#concept-element-custom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-custom">2.2.1. Rules for exposing semantics of custom elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">2.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-customelementregistry">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry">https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-customelementregistry" class="dfn-panel" data-for="term-for-customelementregistry" id="infopanel-for-term-for-customelementregistry" role="menu">
+   <span id="infopaneltitle-for-term-for-customelementregistry" style="display:none">Info about the 'CustomElementRegistry' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry">https://html.spec.whatwg.org/multipage/custom-elements.html#customelementregistry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-customelementregistry">1.2. Changes to custom element definition</a> <a href="#ref-for-customelementregistry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdefinitionoptions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementdefinitionoptions">https://html.spec.whatwg.org/multipage/custom-elements.html#elementdefinitionoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdefinitionoptions" class="dfn-panel" data-for="term-for-elementdefinitionoptions" id="infopanel-for-term-for-elementdefinitionoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdefinitionoptions" style="display:none">Info about the 'ElementDefinitionOptions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementdefinitionoptions">https://html.spec.whatwg.org/multipage/custom-elements.html#elementdefinitionoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdefinitionoptions">1.1.1. Defining custom element semantics as part of the custom element definition</a> <a href="#ref-for-elementdefinitionoptions①">(2)</a>
     <li><a href="#ref-for-elementdefinitionoptions②">1.2. Changes to custom element definition</a> <a href="#ref-for-elementdefinitionoptions③">(2)</a>
     <li><a href="#ref-for-elementdefinitionoptions④">2. ARIA semantic precedence between ElementDefinitionOptions, ElementInternals and ARIA properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">1. Defining custom element semantics</a>
     <li><a href="#ref-for-custom-element①">1.1.2. Defining per-instance custom element semantics</a>
     <li><a href="#ref-for-custom-element②">2.2.1. Rules for exposing semantics of custom elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element-definition">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element-definition" class="dfn-panel" data-for="term-for-custom-element-definition" id="infopanel-for-term-for-custom-element-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element-definition" style="display:none">Info about the 'custom element definition' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element-definition">1.1. Introduction</a>
     <li><a href="#ref-for-custom-element-definition①">1.1.1. Defining custom element semantics as part of the custom element definition</a>
@@ -1076,16 +1076,16 @@ or in a property set on the element.</p>
     <li><a href="#ref-for-custom-element-definition⑥">2.2.1. Rules for exposing semantics of custom elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-customelementregistry-define">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define">https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-customelementregistry-define" class="dfn-panel" data-for="term-for-dom-customelementregistry-define" id="infopanel-for-term-for-dom-customelementregistry-define" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-customelementregistry-define" style="display:none">Info about the 'define(name, constructor, options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define">https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-define</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-customelementregistry-define">1.1.1. Defining custom element semantics as part of the custom element definition</a>
     <li><a href="#ref-for-dom-customelementregistry-define①">1.2. Changes to custom element definition</a> <a href="#ref-for-dom-customelementregistry-define②">(2)</a>
     <li><a href="#ref-for-dom-customelementregistry-define③">2.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element-definition">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element-definition" class="dfn-panel" data-for="term-for-custom-element-definition" id="infopanel-for-term-for-custom-element-definition①" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element-definition①" style="display:none">Info about the 'defined' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element-definition">1.1. Introduction</a>
     <li><a href="#ref-for-custom-element-definition①">1.1.1. Defining custom element semantics as part of the custom element definition</a>
@@ -1094,21 +1094,21 @@ or in a property set on the element.</p>
     <li><a href="#ref-for-custom-element-definition⑥">2.2.1. Rules for exposing semantics of custom elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-details-id-17">
-   <a href="https://www.w3.org/TR/html-aam-1.0/#details-id-17">https://www.w3.org/TR/html-aam-1.0/#details-id-17</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-details-id-17" class="dfn-panel" data-for="term-for-details-id-17" id="infopanel-for-term-for-details-id-17" role="menu">
+   <span id="infopaneltitle-for-term-for-details-id-17" style="display:none">Info about the 'role of button' external reference.</span><a href="https://www.w3.org/TR/html-aam-1.0/#details-id-17">https://www.w3.org/TR/html-aam-1.0/#details-id-17</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-details-id-17">1.1.1. Defining custom element semantics as part of the custom element definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1.1.1. Defining custom element semantics as part of the custom element definition</a>
     <li><a href="#ref-for-ordered-map①">1.1.2. Defining per-instance custom element semantics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">1.2. Changes to custom element definition</a>
    </ul>
@@ -1203,14 +1203,14 @@ dictionary ElementDefinitionOptions {
 <a data-link-type="idl-name" href="#dictdef-elementinternals"><c- n>ElementInternals</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://www.w3.org/TR/wai-aria-1.2/#idl-def-ariaattributes"><c- n>AriaAttributes</c-></a>;
 
 </pre>
-  <aside class="dfn-panel" data-for="semantic-properties">
-   <b><a href="#semantic-properties">#semantic-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-semantic-properties" class="dfn-panel" data-for="semantic-properties" id="infopanel-for-semantic-properties" role="dialog">
+   <span id="infopaneltitle-for-semantic-properties" style="display:none">Info about the 'semantic properties' definition.</span><b><a href="#semantic-properties">#semantic-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-semantic-properties">1.2. Changes to custom element definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-elementinternals">
-   <b><a href="#dictdef-elementinternals">#dictdef-elementinternals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-elementinternals" class="dfn-panel" data-for="dictdef-elementinternals" id="infopanel-for-dictdef-elementinternals" role="dialog">
+   <span id="infopaneltitle-for-dictdef-elementinternals" style="display:none">Info about the 'ElementInternals' definition.</span><b><a href="#dictdef-elementinternals">#dictdef-elementinternals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-elementinternals">1.1.2. Defining per-instance custom element semantics</a> <a href="#ref-for-dictdef-elementinternals①">(2)</a> <a href="#ref-for-dictdef-elementinternals②">(3)</a> <a href="#ref-for-dictdef-elementinternals③">(4)</a>
     <li><a href="#ref-for-dictdef-elementinternals④">1.2. Changes to custom element definition</a> <a href="#ref-for-dictdef-elementinternals⑤">(2)</a>
@@ -1221,57 +1221,113 @@ dictionary ElementDefinitionOptions {
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/aom/spec/input-events.html
+++ b/tests/github/WICG/aom/spec/input-events.html
@@ -821,20 +821,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
      <li><a href="#inputevent-inputtype">dfn for InputEvent</a><span>, in § 3.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.1. Input event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransfer">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransfer" class="dfn-panel" data-for="term-for-datatransfer" id="infopanel-for-term-for-datatransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransfer" style="display:none">Info about the 'DataTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransfer">3.1. Input event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inputevent">
-   <a href="https://w3c.github.io/uievents/#inputevent">https://w3c.github.io/uievents/#inputevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inputevent" class="dfn-panel" data-for="term-for-inputevent" id="infopanel-for-term-for-inputevent" role="menu">
+   <span id="infopaneltitle-for-term-for-inputevent" style="display:none">Info about the 'InputEvent' external reference.</span><a href="https://w3c.github.io/uievents/#inputevent">https://w3c.github.io/uievents/#inputevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inputevent">3. Input Events</a>
     <li><a href="#ref-for-inputevent①">3.1. Input event interfaces</a> <a href="#ref-for-inputevent②">(2)</a>
@@ -846,52 +846,52 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-inputevent⑧">4. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uievent">
-   <a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uievent" class="dfn-panel" data-for="term-for-uievent" id="infopanel-for-term-for-uievent" role="menu">
+   <span id="infopaneltitle-for-term-for-uievent" style="display:none">Info about the 'UIEvent' external reference.</span><a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uievent">3.1. Input event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-beforeinput">
-   <a href="http://www.w3.org/TR/uievents/#event-type-beforeinput">http://www.w3.org/TR/uievents/#event-type-beforeinput</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-beforeinput" class="dfn-panel" data-for="term-for-event-type-beforeinput" id="infopanel-for-term-for-event-type-beforeinput" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-beforeinput" style="display:none">Info about the 'beforeinput' external reference.</span><a href="http://www.w3.org/TR/uievents/#event-type-beforeinput">http://www.w3.org/TR/uievents/#event-type-beforeinput</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-beforeinput">Unnumbered Section</a>
     <li><a href="#ref-for-event-type-beforeinput①">3. Input Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-input">
-   <a href="http://www.w3.org/TR/uievents/#event-type-input">http://www.w3.org/TR/uievents/#event-type-input</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-input" class="dfn-panel" data-for="term-for-event-type-input" id="infopanel-for-term-for-event-type-input" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-input" style="display:none">Info about the 'input' external reference.</span><a href="http://www.w3.org/TR/uievents/#event-type-input">http://www.w3.org/TR/uievents/#event-type-input</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-input">Unnumbered Section</a>
     <li><a href="#ref-for-event-type-input①">3. Input Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-arrowdown">
-   <a href="http://www.w3.org/TR/uievents-code/#code-arrowdown">http://www.w3.org/TR/uievents-code/#code-arrowdown</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-arrowdown" class="dfn-panel" data-for="term-for-code-arrowdown" id="infopanel-for-term-for-code-arrowdown" role="menu">
+   <span id="infopaneltitle-for-term-for-code-arrowdown" style="display:none">Info about the 'arrowdown' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-arrowdown">http://www.w3.org/TR/uievents-code/#code-arrowdown</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-arrowdown">3.2.2. actionDecrement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-arrowleft">
-   <a href="http://www.w3.org/TR/uievents-code/#code-arrowleft">http://www.w3.org/TR/uievents-code/#code-arrowleft</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-arrowleft" class="dfn-panel" data-for="term-for-code-arrowleft" id="infopanel-for-term-for-code-arrowleft" role="menu">
+   <span id="infopaneltitle-for-term-for-code-arrowleft" style="display:none">Info about the 'arrowleft' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-arrowleft">http://www.w3.org/TR/uievents-code/#code-arrowleft</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-arrowleft">3.2.2. actionDecrement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-arrowright">
-   <a href="http://www.w3.org/TR/uievents-code/#code-arrowright">http://www.w3.org/TR/uievents-code/#code-arrowright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-arrowright" class="dfn-panel" data-for="term-for-code-arrowright" id="infopanel-for-term-for-code-arrowright" role="menu">
+   <span id="infopaneltitle-for-term-for-code-arrowright" style="display:none">Info about the 'arrowright' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-arrowright">http://www.w3.org/TR/uievents-code/#code-arrowright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-arrowright">3.2.1. actionIncrement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-arrowup">
-   <a href="http://www.w3.org/TR/uievents-code/#code-arrowup">http://www.w3.org/TR/uievents-code/#code-arrowup</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-arrowup" class="dfn-panel" data-for="term-for-code-arrowup" id="infopanel-for-term-for-code-arrowup" role="menu">
+   <span id="infopaneltitle-for-term-for-code-arrowup" style="display:none">Info about the 'arrowup' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-arrowup">http://www.w3.org/TR/uievents-code/#code-arrowup</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-arrowup">3.2.1. actionIncrement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.1. Input event interfaces</a>
    </ul>
@@ -954,8 +954,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-inputevent-inputtype">
-   <b><a href="#dom-inputevent-inputtype">#dom-inputevent-inputtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-inputevent-inputtype" class="dfn-panel" data-for="dom-inputevent-inputtype" id="infopanel-for-dom-inputevent-inputtype" role="dialog">
+   <span id="infopaneltitle-for-dom-inputevent-inputtype" style="display:none">Info about the 'inputType' definition.</span><b><a href="#dom-inputevent-inputtype">#dom-inputevent-inputtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-inputevent-inputtype①">3.1. Input event interfaces</a>
     <li><a href="#ref-for-dom-inputevent-inputtype②">3.2.1. actionIncrement</a>
@@ -966,91 +966,147 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-dom-inputevent-inputtype⑦">5. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actionincrement">
-   <b><a href="#actionincrement">#actionincrement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actionincrement" class="dfn-panel" data-for="actionincrement" id="infopanel-for-actionincrement" role="dialog">
+   <span id="infopaneltitle-for-actionincrement" style="display:none">Info about the 'actionIncrement' definition.</span><b><a href="#actionincrement">#actionincrement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actionincrement">3.2.1. actionIncrement</a>
     <li><a href="#ref-for-actionincrement①">3.2.4. actionScrollPageUp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actiondecrement">
-   <b><a href="#actiondecrement">#actiondecrement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actiondecrement" class="dfn-panel" data-for="actiondecrement" id="infopanel-for-actiondecrement" role="dialog">
+   <span id="infopaneltitle-for-actiondecrement" style="display:none">Info about the 'actionDecrement' definition.</span><b><a href="#actiondecrement">#actiondecrement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actiondecrement">3.2.2. actionDecrement</a>
     <li><a href="#ref-for-actiondecrement①">3.2.5. actionScrollPageDown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actiondismiss">
-   <b><a href="#actiondismiss">#actiondismiss</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actiondismiss" class="dfn-panel" data-for="actiondismiss" id="infopanel-for-actiondismiss" role="dialog">
+   <span id="infopaneltitle-for-actiondismiss" style="display:none">Info about the 'actionDismiss' definition.</span><b><a href="#actiondismiss">#actiondismiss</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actiondismiss">3.2.3. actionDismiss</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actionscrollpageup">
-   <b><a href="#actionscrollpageup">#actionscrollpageup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actionscrollpageup" class="dfn-panel" data-for="actionscrollpageup" id="infopanel-for-actionscrollpageup" role="dialog">
+   <span id="infopaneltitle-for-actionscrollpageup" style="display:none">Info about the 'actionScrollPageUp' definition.</span><b><a href="#actionscrollpageup">#actionscrollpageup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actionscrollpageup">3.2.4. actionScrollPageUp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actionscrollpagedown">
-   <b><a href="#actionscrollpagedown">#actionscrollpagedown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actionscrollpagedown" class="dfn-panel" data-for="actionscrollpagedown" id="infopanel-for-actionscrollpagedown" role="dialog">
+   <span id="infopaneltitle-for-actionscrollpagedown" style="display:none">Info about the 'actionScrollPageDown' definition.</span><b><a href="#actionscrollpagedown">#actionscrollpagedown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actionscrollpagedown">3.2.5. actionScrollPageDown</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/app-history/spec.html
+++ b/tests/github/WICG/app-history/spec.html
@@ -1530,8 +1530,8 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><a href="#event-user-navigation-involvement">dfn for Event</a><span>, in § 4.2</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">1. The AppHistory class</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a>
     <li><a href="#ref-for-document③">2. The navigate event</a> <a href="#ref-for-document④">(2)</a>
@@ -1540,319 +1540,319 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-document⑦">5.4. Updating the AppHistory object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">2. The navigate event</a>
     <li><a href="#ref-for-event①">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">1. The AppHistory class</a>
     <li><a href="#ref-for-eventtarget①">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget-activation-behavior">
-   <a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">https://dom.spec.whatwg.org/#eventtarget-activation-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget-activation-behavior" class="dfn-panel" data-for="term-for-eventtarget-activation-behavior" id="infopanel-for-term-for-eventtarget-activation-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget-activation-behavior" style="display:none">Info about the 'activation behavior' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">https://dom.spec.whatwg.org/#eventtarget-activation-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-activation-behavior">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-eventtarget-activation-behavior①">(2)</a> <a href="#ref-for-eventtarget-activation-behavior②">(3)</a> <a href="#ref-for-eventtarget-activation-behavior③">(4)</a> <a href="#ref-for-eventtarget-activation-behavior④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">2. The navigate event</a> <a href="#ref-for-canceled-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2. The navigate event</a> <a href="#ref-for-concept-event-fire①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">2. The navigate event</a> <a href="#ref-for-dom-event-istrusted①">(2)</a>
     <li><a href="#ref-for-dom-event-istrusted②">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">4.3. Navigation algorithm updates</a> <a href="#ref-for-concept-document-origin①">(2)</a>
     <li><a href="#ref-for-concept-document-origin②">5.3. Tracking the origin member</a> <a href="#ref-for-concept-document-origin③">(2)</a> <a href="#ref-for-concept-document-origin④">(3)</a> <a href="#ref-for-concept-document-origin⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">2. The navigate event</a> <a href="#ref-for-concept-document-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-headerdef-sec-fetch-site">
-   <a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-headerdef-sec-fetch-site" class="dfn-panel" data-for="term-for-http-headerdef-sec-fetch-site" id="infopanel-for-term-for-http-headerdef-sec-fetch-site" role="menu">
+   <span id="infopaneltitle-for-term-for-http-headerdef-sec-fetch-site" style="display:none">Info about the 'sec-fetch-site' external reference.</span><a href="https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site">https://w3c.github.io/webappsec-fetch-metadata/#http-headerdef-sec-fetch-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-fetch-site">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-errorevent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-errorevent" class="dfn-panel" data-for="term-for-errorevent" id="infopanel-for-term-for-errorevent" role="menu">
+   <span id="infopaneltitle-for-term-for-errorevent" style="display:none">Info about the 'ErrorEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-errorevent">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">1. The AppHistory class</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">1. The AppHistory class</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a> <a href="#ref-for-window③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">2. The navigate event</a>
     <li><a href="#ref-for-the-a-element①">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-the-a-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-area-element">
-   <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-area-element" class="dfn-panel" data-for="term-for-the-area-element" id="infopanel-for-term-for-the-area-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-area-element" style="display:none">Info about the 'area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-area-element">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-the-area-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">1. The AppHistory class</a> <a href="#ref-for-concept-document-window①">(2)</a> <a href="#ref-for-concept-document-window②">(3)</a> <a href="#ref-for-concept-document-window③">(4)</a> <a href="#ref-for-concept-document-window④">(5)</a>
     <li><a href="#ref-for-concept-document-window⑤">2. The navigate event</a> <a href="#ref-for-concept-document-window⑥">(2)</a>
     <li><a href="#ref-for-concept-document-window⑦">3. App history entries</a> <a href="#ref-for-concept-document-window⑧">(2)</a> <a href="#ref-for-concept-document-window⑨">(3)</a> <a href="#ref-for-concept-document-window①⓪">(4)</a> <a href="#ref-for-concept-document-window①①">(5)</a> <a href="#ref-for-concept-document-window①②">(6)</a> <a href="#ref-for-concept-document-window①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">2. The navigate event</a> <a href="#ref-for-window-bc①">(2)</a> <a href="#ref-for-window-bc②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-button-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-button-element" class="dfn-panel" data-for="term-for-the-button-element" id="infopanel-for-term-for-the-button-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-button-element" style="display:none">Info about the 'button' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-button-element">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-errorevent-colno">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-errorevent-colno" class="dfn-panel" data-for="term-for-dom-errorevent-colno" id="infopanel-for-term-for-dom-errorevent-colno" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-errorevent-colno" style="display:none">Info about the 'colno' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-colno</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-errorevent-colno">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-entry">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#current-entry">https://html.spec.whatwg.org/multipage/history.html#current-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-entry" class="dfn-panel" data-for="term-for-current-entry" id="infopanel-for-term-for-current-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-current-entry" style="display:none">Info about the 'current entry' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#current-entry">https://html.spec.whatwg.org/multipage/history.html#current-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-entry">1. The AppHistory class</a>
     <li><a href="#ref-for-current-entry①">5.2. Carrying over the app history key</a> <a href="#ref-for-current-entry②">(2)</a>
     <li><a href="#ref-for-current-entry③">5.3. Tracking the origin member</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hh-default">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-default">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hh-default" class="dfn-panel" data-for="term-for-hh-default" id="infopanel-for-term-for-hh-default" role="menu">
+   <span id="infopaneltitle-for-term-for-hh-default" style="display:none">Info about the 'default' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-default">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hh-default">4.3. Navigation algorithm updates</a> <a href="#ref-for-hh-default①">(2)</a>
     <li><a href="#ref-for-hh-default②">5.3. Tracking the origin member</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-2">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-2" class="dfn-panel" data-for="term-for-dom-document-2" id="infopanel-for-term-for-dom-document-2" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-2" style="display:none">Info about the 'document (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-2">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-she-document">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#she-document">https://html.spec.whatwg.org/multipage/history.html#she-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-she-document" class="dfn-panel" data-for="term-for-she-document" id="infopanel-for-term-for-she-document" role="menu">
+   <span id="infopaneltitle-for-term-for-she-document" style="display:none">Info about the 'document (for session history entry)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#she-document">https://html.spec.whatwg.org/multipage/history.html#she-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-she-document">3. App history entries</a>
     <li><a href="#ref-for-she-document①">4.3. Navigation algorithm updates</a> <a href="#ref-for-she-document②">(2)</a>
     <li><a href="#ref-for-she-document③">5.3. Tracking the origin member</a> <a href="#ref-for-she-document④">(2)</a> <a href="#ref-for-she-document⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hh-entry-update">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-entry-update">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-entry-update</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hh-entry-update" class="dfn-panel" data-for="term-for-hh-entry-update" id="infopanel-for-term-for-hh-entry-update" role="menu">
+   <span id="infopaneltitle-for-term-for-hh-entry-update" style="display:none">Info about the 'entry update' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-entry-update">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-entry-update</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hh-entry-update">4.3. Navigation algorithm updates</a> <a href="#ref-for-hh-entry-update①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-errorevent-error">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-errorevent-error" class="dfn-panel" data-for="term-for-dom-errorevent-error" id="infopanel-for-term-for-dom-errorevent-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-errorevent-error" style="display:none">Info about the 'error' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-errorevent-error">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">1. The AppHistory class</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">1. The AppHistory class</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-errorevent-filename">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-errorevent-filename" class="dfn-panel" data-for="term-for-dom-errorevent-filename" id="infopanel-for-term-for-dom-errorevent-filename" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-errorevent-filename" style="display:none">Info about the 'filename' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-errorevent-filename">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-following-hyperlinks-2">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2">https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-following-hyperlinks-2" class="dfn-panel" data-for="term-for-following-hyperlinks-2" id="infopanel-for-term-for-following-hyperlinks-2" role="menu">
+   <span id="infopaneltitle-for-term-for-following-hyperlinks-2" style="display:none">Info about the 'follow the hyperlink' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2">https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-following-hyperlinks-2">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-following-hyperlinks-2①">(2)</a> <a href="#ref-for-following-hyperlinks-2②">(3)</a> <a href="#ref-for-following-hyperlinks-2③">(4)</a> <a href="#ref-for-following-hyperlinks-2④">(5)</a> <a href="#ref-for-following-hyperlinks-2⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">2. The navigate event</a>
     <li><a href="#ref-for-the-form-element①">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">1. The AppHistory class</a> <a href="#ref-for-fully-active①">(2)</a> <a href="#ref-for-fully-active②">(3)</a> <a href="#ref-for-fully-active③">(4)</a>
     <li><a href="#ref-for-fully-active④">3. App history entries</a> <a href="#ref-for-fully-active⑤">(2)</a> <a href="#ref-for-fully-active⑥">(3)</a> <a href="#ref-for-fully-active⑦">(4)</a> <a href="#ref-for-fully-active⑧">(5)</a> <a href="#ref-for-fully-active⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-hh">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-hh">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-hh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-hh" class="dfn-panel" data-for="term-for-navigation-hh" id="infopanel-for-term-for-navigation-hh" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-hh" style="display:none">Info about the 'historyhandling' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-hh">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-hh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-hh">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. Form submission patches</a>
     <li><a href="#ref-for-in-parallel①">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-input-activation-behavior">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#input-activation-behavior">https://html.spec.whatwg.org/multipage/input.html#input-activation-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-input-activation-behavior" class="dfn-panel" data-for="term-for-input-activation-behavior" id="infopanel-for-term-for-input-activation-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-input-activation-behavior" style="display:none">Info about the 'input activation behavior' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#input-activation-behavior">https://html.spec.whatwg.org/multipage/input.html#input-activation-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-activation-behavior">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-input-activation-behavior①">(2)</a> <a href="#ref-for-input-activation-behavior②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uhus-ispush">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#uhus-ispush">https://html.spec.whatwg.org/multipage/history.html#uhus-ispush</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uhus-ispush" class="dfn-panel" data-for="term-for-uhus-ispush" id="infopanel-for-term-for-uhus-ispush" role="menu">
+   <span id="infopaneltitle-for-term-for-uhus-ispush" style="display:none">Info about the 'ispush' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#uhus-ispush">https://html.spec.whatwg.org/multipage/history.html#uhus-ispush</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uhus-ispush">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-errorevent-lineno">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-errorevent-lineno" class="dfn-panel" data-for="term-for-dom-errorevent-lineno" id="infopanel-for-term-for-dom-errorevent-lineno" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-errorevent-lineno" style="display:none">Info about the 'lineno' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-lineno</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-errorevent-lineno">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-errorevent-message">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-errorevent-message" class="dfn-panel" data-for="term-for-dom-errorevent-message" id="infopanel-for-term-for-dom-errorevent-message" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-errorevent-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message">https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-errorevent-message">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">4.1. Form submission patches</a> <a href="#ref-for-navigate①">(2)</a> <a href="#ref-for-navigate②">(3)</a>
     <li><a href="#ref-for-navigate③">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-navigate④">(2)</a> <a href="#ref-for-navigate⑤">(3)</a> <a href="#ref-for-navigate⑥">(4)</a> <a href="#ref-for-navigate⑦">(5)</a> <a href="#ref-for-navigate⑧">(6)</a>
     <li><a href="#ref-for-navigate⑨">4.3. Navigation algorithm updates</a> <a href="#ref-for-navigate①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate-fragid">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate-fragid" class="dfn-panel" data-for="term-for-navigate-fragid" id="infopanel-for-term-for-navigate-fragid" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate-fragid" style="display:none">Info about the 'navigate to a fragment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-fragid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate-fragid">2. The navigate event</a>
     <li><a href="#ref-for-navigate-fragid①">4.2. Browser UI/user-initiated patches</a>
@@ -1860,33 +1860,33 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-navigate-fragid⑤">5.3. Tracking the origin member</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-navigationtype">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-navigationtype">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-navigationtype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-navigationtype" class="dfn-panel" data-for="term-for-navigation-navigationtype" id="infopanel-for-term-for-navigation-navigationtype" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-navigationtype" style="display:none">Info about the 'navigationtype' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-navigationtype">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-navigationtype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-navigationtype">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-open">
-   <a href="https://html.spec.whatwg.org/multipage/multipage/dynamic-markup-insertion.html#dom-document-open">https://html.spec.whatwg.org/multipage/multipage/dynamic-markup-insertion.html#dom-document-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-open" class="dfn-panel" data-for="term-for-dom-document-open" id="infopanel-for-term-for-dom-document-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-open" style="display:none">Info about the 'open(unused1, unused2)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/multipage/dynamic-markup-insertion.html#dom-document-open">https://html.spec.whatwg.org/multipage/multipage/dynamic-markup-insertion.html#dom-document-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-open">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">5.1. New session history entry items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-plan-to-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#plan-to-navigate">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#plan-to-navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-plan-to-navigate" class="dfn-panel" data-for="term-for-plan-to-navigate" id="infopanel-for-term-for-plan-to-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-plan-to-navigate" style="display:none">Info about the 'plan to navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#plan-to-navigate">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#plan-to-navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plan-to-navigate">4.1. Form submission patches</a> <a href="#ref-for-plan-to-navigate①">(2)</a>
     <li><a href="#ref-for-plan-to-navigate②">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-plan-to-navigate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">1. The AppHistory class</a> <a href="#ref-for-concept-relevant-global①">(2)</a> <a href="#ref-for-concept-relevant-global②">(3)</a> <a href="#ref-for-concept-relevant-global③">(4)</a> <a href="#ref-for-concept-relevant-global④">(5)</a>
     <li><a href="#ref-for-concept-relevant-global⑤">2. The navigate event</a> <a href="#ref-for-concept-relevant-global⑥">(2)</a> <a href="#ref-for-concept-relevant-global⑦">(3)</a> <a href="#ref-for-concept-relevant-global⑧">(4)</a> <a href="#ref-for-concept-relevant-global⑨">(5)</a> <a href="#ref-for-concept-relevant-global①⓪">(6)</a>
@@ -1895,62 +1895,62 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-concept-relevant-global②⓪">5.4. Updating the AppHistory object</a> <a href="#ref-for-concept-relevant-global②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">1. The AppHistory class</a>
     <li><a href="#ref-for-concept-relevant-realm①">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hh-replace">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-replace">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-replace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hh-replace" class="dfn-panel" data-for="term-for-hh-replace" id="infopanel-for-term-for-hh-replace" role="menu">
+   <span id="infopaneltitle-for-term-for-hh-replace" style="display:none">Info about the 'replace' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-replace">https://html.spec.whatwg.org/multipage/browsing-the-web.html#hh-replace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hh-replace">5.2. Carrying over the app history key</a>
     <li><a href="#ref-for-hh-replace①">5.3. Tracking the origin member</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report an exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">1. The AppHistory class</a> <a href="#ref-for-same-origin①">(2)</a> <a href="#ref-for-same-origin②">(3)</a>
     <li><a href="#ref-for-same-origin③">2. The navigate event</a> <a href="#ref-for-same-origin④">(2)</a>
     <li><a href="#ref-for-same-origin⑤">5.2. Carrying over the app history key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">4.3. Navigation algorithm updates</a> <a href="#ref-for-same-origin-domain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialized-state">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#serialized-state">https://html.spec.whatwg.org/multipage/history.html#serialized-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialized-state" class="dfn-panel" data-for="term-for-serialized-state" id="infopanel-for-term-for-serialized-state" role="menu">
+   <span id="infopaneltitle-for-term-for-serialized-state" style="display:none">Info about the 'serialized state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#serialized-state">https://html.spec.whatwg.org/multipage/history.html#serialized-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-state">2. The navigate event</a> <a href="#ref-for-serialized-state①">(2)</a>
     <li><a href="#ref-for-serialized-state②">5.1. New session history entry items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uhus-serializeddata">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#uhus-serializeddata">https://html.spec.whatwg.org/multipage/history.html#uhus-serializeddata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uhus-serializeddata" class="dfn-panel" data-for="term-for-uhus-serializeddata" id="infopanel-for-term-for-uhus-serializeddata" role="menu">
+   <span id="infopaneltitle-for-term-for-uhus-serializeddata" style="display:none">Info about the 'serializeddata' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#uhus-serializeddata">https://html.spec.whatwg.org/multipage/history.html#uhus-serializeddata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uhus-serializeddata">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session-history">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session-history" class="dfn-panel" data-for="term-for-session-history" id="infopanel-for-term-for-session-history" role="menu">
+   <span id="infopaneltitle-for-term-for-session-history" style="display:none">Info about the 'session history' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history">1. The AppHistory class</a>
     <li><a href="#ref-for-session-history①">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session-history-entry">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#session-history-entry">https://html.spec.whatwg.org/multipage/history.html#session-history-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session-history-entry" class="dfn-panel" data-for="term-for-session-history-entry" id="infopanel-for-term-for-session-history-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-session-history-entry" style="display:none">Info about the 'session history entry' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#session-history-entry">https://html.spec.whatwg.org/multipage/history.html#session-history-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry">2. The navigate event</a> <a href="#ref-for-session-history-entry①">(2)</a>
     <li><a href="#ref-for-session-history-entry②">3. App history entries</a>
@@ -1959,52 +1959,52 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-session-history-entry⑥">5.3. Tracking the origin member</a> <a href="#ref-for-session-history-entry⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-history-push/replace-state-steps">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-state-steps">https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-state-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-history-push/replace-state-steps" class="dfn-panel" data-for="term-for-shared-history-push/replace-state-steps" id="infopanel-for-term-for-shared-history-push/replace-state-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-history-push/replace-state-steps" style="display:none">Info about the 'shared history push/replace state steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-state-steps">https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-state-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-history-push/replace-state-steps">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-history-state">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-history-state" class="dfn-panel" data-for="term-for-dom-history-state" id="infopanel-for-term-for-dom-history-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-history-state" style="display:none">Info about the 'state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-history-state">3. App history entries</a> <a href="#ref-for-dom-history-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-submit-body">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-body">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-submit-body" class="dfn-panel" data-for="term-for-submit-body" id="infopanel-for-term-for-submit-body" role="menu">
+   <span id="infopaneltitle-for-term-for-submit-body" style="display:none">Info about the 'submit as entity body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-body">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-submit-body">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-button-type-submit-state">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit-state">https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-button-type-submit-state" class="dfn-panel" data-for="term-for-attr-button-type-submit-state" id="infopanel-for-term-for-attr-button-type-submit-state" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-button-type-submit-state" style="display:none">Info about the 'submit button' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit-state">https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type-submit-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-button-type-submit-state">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-form-submit">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-form-submit" class="dfn-panel" data-for="term-for-concept-form-submit" id="infopanel-for-term-for-concept-form-submit" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-form-submit" style="display:none">Info about the 'submitted' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-submit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-form-submit">2. The navigate event</a>
     <li><a href="#ref-for-concept-form-submit①">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-concept-form-submit②">(2)</a> <a href="#ref-for-concept-form-submit③">(3)</a> <a href="#ref-for-concept-form-submit④">(4)</a> <a href="#ref-for-concept-form-submit⑤">(5)</a> <a href="#ref-for-concept-form-submit⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-traverse-the-history-by-a-delta">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta">https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-traverse-the-history-by-a-delta" class="dfn-panel" data-for="term-for-traverse-the-history-by-a-delta" id="infopanel-for-term-for-traverse-the-history-by-a-delta" role="menu">
+   <span id="infopaneltitle-for-term-for-traverse-the-history-by-a-delta" style="display:none">Info about the 'traverse the history by a delta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta">https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history-by-a-delta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-traverse-the-history-by-a-delta">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-traverse-the-history-by-a-delta①">(2)</a>
     <li><a href="#ref-for-traverse-the-history-by-a-delta②">4.3. Navigation algorithm updates</a> <a href="#ref-for-traverse-the-history-by-a-delta③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-she-url">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#she-url">https://html.spec.whatwg.org/multipage/history.html#she-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-she-url" class="dfn-panel" data-for="term-for-she-url" id="infopanel-for-term-for-she-url" role="menu">
+   <span id="infopaneltitle-for-term-for-she-url" style="display:none">Info about the 'url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#she-url">https://html.spec.whatwg.org/multipage/history.html#she-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-she-url">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-and-history-update-steps">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps">https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-and-history-update-steps" class="dfn-panel" data-for="term-for-url-and-history-update-steps" id="infopanel-for-term-for-url-and-history-update-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-url-and-history-update-steps" style="display:none">Info about the 'url and history update steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps">https://html.spec.whatwg.org/multipage/browsing-the-web.html#url-and-history-update-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-and-history-update-steps">1. The AppHistory class</a>
     <li><a href="#ref-for-url-and-history-update-steps①">2. The navigate event</a>
@@ -2013,248 +2013,248 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-url-and-history-update-steps④">5.4. Updating the AppHistory object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">1. The AppHistory class</a> <a href="#ref-for-list-append①">(2)</a> <a href="#ref-for-list-append②">(3)</a> <a href="#ref-for-list-append③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">1. The AppHistory class</a>
     <li><a href="#ref-for-assert①">2. The navigate event</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">1. The AppHistory class</a> <a href="#ref-for-iteration-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">1. The AppHistory class</a> <a href="#ref-for-list-iterate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'is' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">5.1. New session history entry items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">1. The AppHistory class</a>
     <li><a href="#ref-for-list①">2. The navigate event</a>
     <li><a href="#ref-for-list②">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">1. The AppHistory class</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-agent">
-   <a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-agent" class="dfn-panel" data-for="term-for-user-agent" id="infopanel-for-term-for-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-user-agent" style="display:none">Info about the 'user agent' external reference.</span><a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">3. App history entries</a> <a href="#ref-for-user-agent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-equals-exclude-fragments">
-   <a href="https://url.spec.whatwg.org/#url-equals-exclude-fragments">https://url.spec.whatwg.org/#url-equals-exclude-fragments</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-equals-exclude-fragments" class="dfn-panel" data-for="term-for-url-equals-exclude-fragments" id="infopanel-for-term-for-url-equals-exclude-fragments" role="menu">
+   <span id="infopaneltitle-for-term-for-url-equals-exclude-fragments" style="display:none">Info about the 'exclude fragments' external reference.</span><a href="https://url.spec.whatwg.org/#url-equals-exclude-fragments">https://url.spec.whatwg.org/#url-equals-exclude-fragments</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-equals-exclude-fragments">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">2. The navigate event</a> <a href="#ref-for-concept-url-fragment①">(2)</a> <a href="#ref-for-concept-url-fragment②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">2. The navigate event</a> <a href="#ref-for-concept-url①">(2)</a> <a href="#ref-for-concept-url②">(3)</a> <a href="#ref-for-concept-url③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-generate-a-random-uuid">
-   <a href="https://wicg.github.io/uuid/#dfn-generate-a-random-uuid">https://wicg.github.io/uuid/#dfn-generate-a-random-uuid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-generate-a-random-uuid" class="dfn-panel" data-for="term-for-dfn-generate-a-random-uuid" id="infopanel-for-term-for-dfn-generate-a-random-uuid" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-generate-a-random-uuid" style="display:none">Info about the 'generate a random uuid' external reference.</span><a href="https://wicg.github.io/uuid/#dfn-generate-a-random-uuid">https://wicg.github.io/uuid/#dfn-generate-a-random-uuid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-generate-a-random-uuid">5.1. New session history entry items</a> <a href="#ref-for-dfn-generate-a-random-uuid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2. The navigate event</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a> <a href="#ref-for-idl-DOMException⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. The navigate event</a>
     <li><a href="#ref-for-idl-DOMString①">3. App history entries</a> <a href="#ref-for-idl-DOMString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">1. The AppHistory class</a>
     <li><a href="#ref-for-Exposed①">2. The navigate event</a>
     <li><a href="#ref-for-Exposed②">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2. The navigate event</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2. The navigate event</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2. The navigate event</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2. The navigate event</a> <a href="#ref-for-idl-any①">(2)</a>
     <li><a href="#ref-for-idl-any②">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">1. The AppHistory class</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">2. The navigate event</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a> <a href="#ref-for-idl-boolean⑤">(4)</a> <a href="#ref-for-idl-boolean⑥">(5)</a> <a href="#ref-for-idl-boolean⑦">(6)</a>
     <li><a href="#ref-for-idl-boolean⑧">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long-long" class="dfn-panel" data-for="term-for-idl-long-long" id="infopanel-for-term-for-idl-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long-long" style="display:none">Info about the 'long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">1. The AppHistory class</a>
     <li><a href="#ref-for-new①">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'react' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">1. The AppHistory class</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a> <a href="#ref-for-this⑧">(9)</a> <a href="#ref-for-this⑨">(10)</a> <a href="#ref-for-this①⓪">(11)</a> <a href="#ref-for-this①①">(12)</a> <a href="#ref-for-this①②">(13)</a> <a href="#ref-for-this①③">(14)</a>
     <li><a href="#ref-for-this①④">2. The navigate event</a> <a href="#ref-for-this①⑤">(2)</a> <a href="#ref-for-this①⑥">(3)</a> <a href="#ref-for-this①⑦">(4)</a> <a href="#ref-for-this①⑧">(5)</a> <a href="#ref-for-this①⑨">(6)</a> <a href="#ref-for-this②⓪">(7)</a> <a href="#ref-for-this②①">(8)</a> <a href="#ref-for-this②②">(9)</a> <a href="#ref-for-this②③">(10)</a> <a href="#ref-for-this②④">(11)</a> <a href="#ref-for-this②⑤">(12)</a> <a href="#ref-for-this②⑥">(13)</a> <a href="#ref-for-this②⑦">(14)</a> <a href="#ref-for-this②⑧">(15)</a>
     <li><a href="#ref-for-this②⑨">3. App history entries</a> <a href="#ref-for-this③⓪">(2)</a> <a href="#ref-for-this③①">(3)</a> <a href="#ref-for-this③②">(4)</a> <a href="#ref-for-this③③">(5)</a> <a href="#ref-for-this③④">(6)</a> <a href="#ref-for-this③⑤">(7)</a> <a href="#ref-for-this③⑥">(8)</a> <a href="#ref-for-this③⑦">(9)</a> <a href="#ref-for-this③⑧">(10)</a> <a href="#ref-for-this③⑨">(11)</a> <a href="#ref-for-this④⓪">(12)</a> <a href="#ref-for-this④①">(13)</a> <a href="#ref-for-this④②">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2. The navigate event</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formdata">
-   <a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formdata" class="dfn-panel" data-for="term-for-formdata" id="infopanel-for-term-for-formdata" role="menu">
+   <span id="infopaneltitle-for-term-for-formdata" style="display:none">Info about the 'FormData' external reference.</span><a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formdata">2. The navigate event</a> <a href="#ref-for-formdata①">(2)</a> <a href="#ref-for-formdata②">(3)</a> <a href="#ref-for-formdata③">(4)</a> <a href="#ref-for-formdata④">(5)</a>
    </ul>
@@ -2494,22 +2494,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="window-app-history">
-   <b><a href="#window-app-history">#window-app-history</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-app-history" class="dfn-panel" data-for="window-app-history" id="infopanel-for-window-app-history" role="dialog">
+   <span id="infopaneltitle-for-window-app-history" style="display:none">Info about the 'app history' definition.</span><b><a href="#window-app-history">#window-app-history</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-app-history">1. The AppHistory class</a>
     <li><a href="#ref-for-window-app-history①">4.3. Navigation algorithm updates</a> <a href="#ref-for-window-app-history②">(2)</a> <a href="#ref-for-window-app-history③">(3)</a> <a href="#ref-for-window-app-history④">(4)</a>
     <li><a href="#ref-for-window-app-history⑤">5.4. Updating the AppHistory object</a> <a href="#ref-for-window-app-history⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-apphistory">
-   <b><a href="#dom-window-apphistory">#dom-window-apphistory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-apphistory" class="dfn-panel" data-for="dom-window-apphistory" id="infopanel-for-dom-window-apphistory" role="dialog">
+   <span id="infopaneltitle-for-dom-window-apphistory" style="display:none">Info about the 'appHistory' definition.</span><b><a href="#dom-window-apphistory">#dom-window-apphistory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-apphistory">1. The AppHistory class</a> <a href="#ref-for-dom-window-apphistory①">(2)</a> <a href="#ref-for-dom-window-apphistory②">(3)</a> <a href="#ref-for-dom-window-apphistory③">(4)</a> <a href="#ref-for-dom-window-apphistory④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistory">
-   <b><a href="#apphistory">#apphistory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistory" class="dfn-panel" data-for="apphistory" id="infopanel-for-apphistory" role="dialog">
+   <span id="infopaneltitle-for-apphistory" style="display:none">Info about the 'AppHistory' definition.</span><b><a href="#apphistory">#apphistory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistory">1. The AppHistory class</a> <a href="#ref-for-apphistory①">(2)</a> <a href="#ref-for-apphistory②">(3)</a> <a href="#ref-for-apphistory③">(4)</a> <a href="#ref-for-apphistory④">(5)</a> <a href="#ref-for-apphistory⑤">(6)</a> <a href="#ref-for-apphistory⑥">(7)</a>
     <li><a href="#ref-for-apphistory⑦">2. The navigate event</a>
@@ -2517,442 +2517,498 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-apphistory⑨">5.4. Updating the AppHistory object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistory-entry-list">
-   <b><a href="#apphistory-entry-list">#apphistory-entry-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistory-entry-list" class="dfn-panel" data-for="apphistory-entry-list" id="infopanel-for-apphistory-entry-list" role="dialog">
+   <span id="infopaneltitle-for-apphistory-entry-list" style="display:none">Info about the 'entry list' definition.</span><b><a href="#apphistory-entry-list">#apphistory-entry-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistory-entry-list">1. The AppHistory class</a> <a href="#ref-for-apphistory-entry-list①">(2)</a> <a href="#ref-for-apphistory-entry-list②">(3)</a> <a href="#ref-for-apphistory-entry-list③">(4)</a> <a href="#ref-for-apphistory-entry-list④">(5)</a> <a href="#ref-for-apphistory-entry-list⑤">(6)</a> <a href="#ref-for-apphistory-entry-list⑥">(7)</a> <a href="#ref-for-apphistory-entry-list⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistory-current-index">
-   <b><a href="#apphistory-current-index">#apphistory-current-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistory-current-index" class="dfn-panel" data-for="apphistory-current-index" id="infopanel-for-apphistory-current-index" role="dialog">
+   <span id="infopaneltitle-for-apphistory-current-index" style="display:none">Info about the 'current index' definition.</span><b><a href="#apphistory-current-index">#apphistory-current-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistory-current-index">1. The AppHistory class</a> <a href="#ref-for-apphistory-current-index①">(2)</a> <a href="#ref-for-apphistory-current-index②">(3)</a> <a href="#ref-for-apphistory-current-index③">(4)</a> <a href="#ref-for-apphistory-current-index④">(5)</a> <a href="#ref-for-apphistory-current-index⑤">(6)</a> <a href="#ref-for-apphistory-current-index⑥">(7)</a> <a href="#ref-for-apphistory-current-index⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-current">
-   <b><a href="#dom-apphistory-current">#dom-apphistory-current</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-current" class="dfn-panel" data-for="dom-apphistory-current" id="infopanel-for-dom-apphistory-current" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-current" style="display:none">Info about the 'current' definition.</span><b><a href="#dom-apphistory-current">#dom-apphistory-current</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-current">1. The AppHistory class</a> <a href="#ref-for-dom-apphistory-current①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-entries">
-   <b><a href="#dom-apphistory-entries">#dom-apphistory-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-entries" class="dfn-panel" data-for="dom-apphistory-entries" id="infopanel-for-dom-apphistory-entries" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-entries" style="display:none">Info about the 'entries()' definition.</span><b><a href="#dom-apphistory-entries">#dom-apphistory-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-entries">1. The AppHistory class</a> <a href="#ref-for-dom-apphistory-entries①">(2)</a>
     <li><a href="#ref-for-dom-apphistory-entries②">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-cangoback">
-   <b><a href="#dom-apphistory-cangoback">#dom-apphistory-cangoback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-cangoback" class="dfn-panel" data-for="dom-apphistory-cangoback" id="infopanel-for-dom-apphistory-cangoback" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-cangoback" style="display:none">Info about the 'canGoBack' definition.</span><b><a href="#dom-apphistory-cangoback">#dom-apphistory-cangoback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-cangoback">1. The AppHistory class</a> <a href="#ref-for-dom-apphistory-cangoback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-cangoforward">
-   <b><a href="#dom-apphistory-cangoforward">#dom-apphistory-cangoforward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-cangoforward" class="dfn-panel" data-for="dom-apphistory-cangoforward" id="infopanel-for-dom-apphistory-cangoforward" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-cangoforward" style="display:none">Info about the 'canGoForward' definition.</span><b><a href="#dom-apphistory-cangoforward">#dom-apphistory-cangoforward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-cangoforward">1. The AppHistory class</a> <a href="#ref-for-dom-apphistory-cangoforward①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-onnavigate">
-   <b><a href="#dom-apphistory-onnavigate">#dom-apphistory-onnavigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-onnavigate" class="dfn-panel" data-for="dom-apphistory-onnavigate" id="infopanel-for-dom-apphistory-onnavigate" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-onnavigate" style="display:none">Info about the 'onnavigate' definition.</span><b><a href="#dom-apphistory-onnavigate">#dom-apphistory-onnavigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-onnavigate">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-apphistory-navigate">
-   <b><a href="#eventdef-apphistory-navigate">#eventdef-apphistory-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-apphistory-navigate" class="dfn-panel" data-for="eventdef-apphistory-navigate" id="infopanel-for-eventdef-apphistory-navigate" role="dialog">
+   <span id="infopaneltitle-for-eventdef-apphistory-navigate" style="display:none">Info about the 'navigate' definition.</span><b><a href="#eventdef-apphistory-navigate">#eventdef-apphistory-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-apphistory-navigate">2. The navigate event</a> <a href="#ref-for-eventdef-apphistory-navigate①">(2)</a>
     <li><a href="#ref-for-eventdef-apphistory-navigate②">4. Patches to fire the navigate event</a> <a href="#ref-for-eventdef-apphistory-navigate③">(2)</a>
     <li><a href="#ref-for-eventdef-apphistory-navigate④">4.3. Navigation algorithm updates</a> <a href="#ref-for-eventdef-apphistory-navigate⑤">(2)</a> <a href="#ref-for-eventdef-apphistory-navigate⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-onnavigatesuccess">
-   <b><a href="#dom-apphistory-onnavigatesuccess">#dom-apphistory-onnavigatesuccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-onnavigatesuccess" class="dfn-panel" data-for="dom-apphistory-onnavigatesuccess" id="infopanel-for-dom-apphistory-onnavigatesuccess" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-onnavigatesuccess" style="display:none">Info about the 'onnavigatesuccess' definition.</span><b><a href="#dom-apphistory-onnavigatesuccess">#dom-apphistory-onnavigatesuccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-onnavigatesuccess">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-apphistory-navigatesuccess">
-   <b><a href="#eventdef-apphistory-navigatesuccess">#eventdef-apphistory-navigatesuccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-apphistory-navigatesuccess" class="dfn-panel" data-for="eventdef-apphistory-navigatesuccess" id="infopanel-for-eventdef-apphistory-navigatesuccess" role="dialog">
+   <span id="infopaneltitle-for-eventdef-apphistory-navigatesuccess" style="display:none">Info about the 'navigatesuccess' definition.</span><b><a href="#eventdef-apphistory-navigatesuccess">#eventdef-apphistory-navigatesuccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-apphistory-navigatesuccess">2. The navigate event</a> <a href="#ref-for-eventdef-apphistory-navigatesuccess①">(2)</a> <a href="#ref-for-eventdef-apphistory-navigatesuccess②">(3)</a> <a href="#ref-for-eventdef-apphistory-navigatesuccess③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistory-onnavigateerror">
-   <b><a href="#dom-apphistory-onnavigateerror">#dom-apphistory-onnavigateerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistory-onnavigateerror" class="dfn-panel" data-for="dom-apphistory-onnavigateerror" id="infopanel-for-dom-apphistory-onnavigateerror" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistory-onnavigateerror" style="display:none">Info about the 'onnavigateerror' definition.</span><b><a href="#dom-apphistory-onnavigateerror">#dom-apphistory-onnavigateerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistory-onnavigateerror">1. The AppHistory class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-apphistory-navigateerror">
-   <b><a href="#eventdef-apphistory-navigateerror">#eventdef-apphistory-navigateerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-apphistory-navigateerror" class="dfn-panel" data-for="eventdef-apphistory-navigateerror" id="infopanel-for-eventdef-apphistory-navigateerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-apphistory-navigateerror" style="display:none">Info about the 'navigateerror' definition.</span><b><a href="#eventdef-apphistory-navigateerror">#eventdef-apphistory-navigateerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-apphistory-navigateerror">2. The navigate event</a> <a href="#ref-for-eventdef-apphistory-navigateerror①">(2)</a> <a href="#ref-for-eventdef-apphistory-navigateerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistory-update-the-entries">
-   <b><a href="#apphistory-update-the-entries">#apphistory-update-the-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistory-update-the-entries" class="dfn-panel" data-for="apphistory-update-the-entries" id="infopanel-for-apphistory-update-the-entries" role="dialog">
+   <span id="infopaneltitle-for-apphistory-update-the-entries" style="display:none">Info about the 'update the entries' definition.</span><b><a href="#apphistory-update-the-entries">#apphistory-update-the-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistory-update-the-entries">1. The AppHistory class</a>
     <li><a href="#ref-for-apphistory-update-the-entries①">5.4. Updating the AppHistory object</a> <a href="#ref-for-apphistory-update-the-entries②">(2)</a> <a href="#ref-for-apphistory-update-the-entries③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistorynavigateevent">
-   <b><a href="#apphistorynavigateevent">#apphistorynavigateevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistorynavigateevent" class="dfn-panel" data-for="apphistorynavigateevent" id="infopanel-for-apphistorynavigateevent" role="dialog">
+   <span id="infopaneltitle-for-apphistorynavigateevent" style="display:none">Info about the 'AppHistoryNavigateEvent' definition.</span><b><a href="#apphistorynavigateevent">#apphistorynavigateevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistorynavigateevent">2. The navigate event</a> <a href="#ref-for-apphistorynavigateevent①">(2)</a> <a href="#ref-for-apphistorynavigateevent②">(3)</a>
     <li><a href="#ref-for-apphistorynavigateevent③">4.1. Form submission patches</a>
     <li><a href="#ref-for-apphistorynavigateevent④">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-apphistorynavigateeventinit">
-   <b><a href="#dictdef-apphistorynavigateeventinit">#dictdef-apphistorynavigateeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-apphistorynavigateeventinit" class="dfn-panel" data-for="dictdef-apphistorynavigateeventinit" id="infopanel-for-dictdef-apphistorynavigateeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-apphistorynavigateeventinit" style="display:none">Info about the 'AppHistoryNavigateEventInit' definition.</span><b><a href="#dictdef-apphistorynavigateeventinit">#dictdef-apphistorynavigateeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-apphistorynavigateeventinit">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-apphistorynavigationtype">
-   <b><a href="#enumdef-apphistorynavigationtype">#enumdef-apphistorynavigationtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-apphistorynavigationtype" class="dfn-panel" data-for="enumdef-apphistorynavigationtype" id="infopanel-for-enumdef-apphistorynavigationtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-apphistorynavigationtype" style="display:none">Info about the 'AppHistoryNavigationType' definition.</span><b><a href="#enumdef-apphistorynavigationtype">#enumdef-apphistorynavigationtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-apphistorynavigationtype">2. The navigate event</a> <a href="#ref-for-enumdef-apphistorynavigationtype①">(2)</a> <a href="#ref-for-enumdef-apphistorynavigationtype②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigationtype-push">
-   <b><a href="#dom-apphistorynavigationtype-push">#dom-apphistorynavigationtype-push</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigationtype-push" class="dfn-panel" data-for="dom-apphistorynavigationtype-push" id="infopanel-for-dom-apphistorynavigationtype-push" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigationtype-push" style="display:none">Info about the '"push"' definition.</span><b><a href="#dom-apphistorynavigationtype-push">#dom-apphistorynavigationtype-push</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigationtype-push">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigationtype-push①">(2)</a> <a href="#ref-for-dom-apphistorynavigationtype-push②">(3)</a> <a href="#ref-for-dom-apphistorynavigationtype-push③">(4)</a> <a href="#ref-for-dom-apphistorynavigationtype-push④">(5)</a>
     <li><a href="#ref-for-dom-apphistorynavigationtype-push⑤">4.3. Navigation algorithm updates</a> <a href="#ref-for-dom-apphistorynavigationtype-push⑥">(2)</a> <a href="#ref-for-dom-apphistorynavigationtype-push⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigationtype-replace">
-   <b><a href="#dom-apphistorynavigationtype-replace">#dom-apphistorynavigationtype-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigationtype-replace" class="dfn-panel" data-for="dom-apphistorynavigationtype-replace" id="infopanel-for-dom-apphistorynavigationtype-replace" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigationtype-replace" style="display:none">Info about the '"replace"' definition.</span><b><a href="#dom-apphistorynavigationtype-replace">#dom-apphistorynavigationtype-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigationtype-replace">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigationtype-replace①">(2)</a> <a href="#ref-for-dom-apphistorynavigationtype-replace②">(3)</a> <a href="#ref-for-dom-apphistorynavigationtype-replace③">(4)</a>
     <li><a href="#ref-for-dom-apphistorynavigationtype-replace④">4.3. Navigation algorithm updates</a> <a href="#ref-for-dom-apphistorynavigationtype-replace⑤">(2)</a> <a href="#ref-for-dom-apphistorynavigationtype-replace⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigationtype-traverse">
-   <b><a href="#dom-apphistorynavigationtype-traverse">#dom-apphistorynavigationtype-traverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigationtype-traverse" class="dfn-panel" data-for="dom-apphistorynavigationtype-traverse" id="infopanel-for-dom-apphistorynavigationtype-traverse" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigationtype-traverse" style="display:none">Info about the '"traverse"' definition.</span><b><a href="#dom-apphistorynavigationtype-traverse">#dom-apphistorynavigationtype-traverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigationtype-traverse">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigationtype-traverse①">(2)</a> <a href="#ref-for-dom-apphistorynavigationtype-traverse②">(3)</a> <a href="#ref-for-dom-apphistorynavigationtype-traverse③">(4)</a>
     <li><a href="#ref-for-dom-apphistorynavigationtype-traverse④">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-navigationtype">
-   <b><a href="#dom-apphistorynavigateevent-navigationtype">#dom-apphistorynavigateevent-navigationtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-navigationtype" class="dfn-panel" data-for="dom-apphistorynavigateevent-navigationtype" id="infopanel-for-dom-apphistorynavigateevent-navigationtype" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-navigationtype" style="display:none">Info about the 'navigationType' definition.</span><b><a href="#dom-apphistorynavigateevent-navigationtype">#dom-apphistorynavigateevent-navigationtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-navigationtype">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype②">(3)</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype③">(4)</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype④">(5)</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype⑤">(6)</a> <a href="#ref-for-dom-apphistorynavigateevent-navigationtype⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-canrespond">
-   <b><a href="#dom-apphistorynavigateevent-canrespond">#dom-apphistorynavigateevent-canrespond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-canrespond" class="dfn-panel" data-for="dom-apphistorynavigateevent-canrespond" id="infopanel-for-dom-apphistorynavigateevent-canrespond" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-canrespond" style="display:none">Info about the 'canRespond' definition.</span><b><a href="#dom-apphistorynavigateevent-canrespond">#dom-apphistorynavigateevent-canrespond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-canrespond">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-canrespond①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-canrespond②">(3)</a> <a href="#ref-for-dom-apphistorynavigateevent-canrespond③">(4)</a> <a href="#ref-for-dom-apphistorynavigateevent-canrespond④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-userinitiated">
-   <b><a href="#dom-apphistorynavigateevent-userinitiated">#dom-apphistorynavigateevent-userinitiated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-userinitiated" class="dfn-panel" data-for="dom-apphistorynavigateevent-userinitiated" id="infopanel-for-dom-apphistorynavigateevent-userinitiated" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-userinitiated" style="display:none">Info about the 'userInitiated' definition.</span><b><a href="#dom-apphistorynavigateevent-userinitiated">#dom-apphistorynavigateevent-userinitiated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-userinitiated">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-userinitiated①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-userinitiated②">(3)</a>
     <li><a href="#ref-for-dom-apphistorynavigateevent-userinitiated③">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-hashchange">
-   <b><a href="#dom-apphistorynavigateevent-hashchange">#dom-apphistorynavigateevent-hashchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-hashchange" class="dfn-panel" data-for="dom-apphistorynavigateevent-hashchange" id="infopanel-for-dom-apphistorynavigateevent-hashchange" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-hashchange" style="display:none">Info about the 'hashChange' definition.</span><b><a href="#dom-apphistorynavigateevent-hashchange">#dom-apphistorynavigateevent-hashchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-hashchange">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-hashchange①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-hashchange②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-formdata">
-   <b><a href="#dom-apphistorynavigateevent-formdata">#dom-apphistorynavigateevent-formdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-formdata" class="dfn-panel" data-for="dom-apphistorynavigateevent-formdata" id="infopanel-for-dom-apphistorynavigateevent-formdata" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-formdata" style="display:none">Info about the 'formData' definition.</span><b><a href="#dom-apphistorynavigateevent-formdata">#dom-apphistorynavigateevent-formdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-formdata">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-formdata①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-formdata②">(3)</a>
     <li><a href="#ref-for-dom-apphistorynavigateevent-formdata③">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-info">
-   <b><a href="#dom-apphistorynavigateevent-info">#dom-apphistorynavigateevent-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-info" class="dfn-panel" data-for="dom-apphistorynavigateevent-info" id="infopanel-for-dom-apphistorynavigateevent-info" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-info" style="display:none">Info about the 'info' definition.</span><b><a href="#dom-apphistorynavigateevent-info">#dom-apphistorynavigateevent-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-info">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-info①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-info②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistorynavigateevent-destination-url">
-   <b><a href="#apphistorynavigateevent-destination-url">#apphistorynavigateevent-destination-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistorynavigateevent-destination-url" class="dfn-panel" data-for="apphistorynavigateevent-destination-url" id="infopanel-for-apphistorynavigateevent-destination-url" role="dialog">
+   <span id="infopaneltitle-for-apphistorynavigateevent-destination-url" style="display:none">Info about the 'destination URL' definition.</span><b><a href="#apphistorynavigateevent-destination-url">#apphistorynavigateevent-destination-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistorynavigateevent-destination-url">2. The navigate event</a> <a href="#ref-for-apphistorynavigateevent-destination-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistorynavigateevent-classic-history-api-serialized-data">
-   <b><a href="#apphistorynavigateevent-classic-history-api-serialized-data">#apphistorynavigateevent-classic-history-api-serialized-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistorynavigateevent-classic-history-api-serialized-data" class="dfn-panel" data-for="apphistorynavigateevent-classic-history-api-serialized-data" id="infopanel-for-apphistorynavigateevent-classic-history-api-serialized-data" role="dialog">
+   <span id="infopaneltitle-for-apphistorynavigateevent-classic-history-api-serialized-data" style="display:none">Info about the 'classic history API serialized data' definition.</span><b><a href="#apphistorynavigateevent-classic-history-api-serialized-data">#apphistorynavigateevent-classic-history-api-serialized-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistorynavigateevent-classic-history-api-serialized-data">2. The navigate event</a> <a href="#ref-for-apphistorynavigateevent-classic-history-api-serialized-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistorynavigateevent-destination-entry">
-   <b><a href="#apphistorynavigateevent-destination-entry">#apphistorynavigateevent-destination-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistorynavigateevent-destination-entry" class="dfn-panel" data-for="apphistorynavigateevent-destination-entry" id="infopanel-for-apphistorynavigateevent-destination-entry" role="dialog">
+   <span id="infopaneltitle-for-apphistorynavigateevent-destination-entry" style="display:none">Info about the 'destination entry' definition.</span><b><a href="#apphistorynavigateevent-destination-entry">#apphistorynavigateevent-destination-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistorynavigateevent-destination-entry">2. The navigate event</a> <a href="#ref-for-apphistorynavigateevent-destination-entry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistorynavigateevent-navigation-action-promise">
-   <b><a href="#apphistorynavigateevent-navigation-action-promise">#apphistorynavigateevent-navigation-action-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistorynavigateevent-navigation-action-promise" class="dfn-panel" data-for="apphistorynavigateevent-navigation-action-promise" id="infopanel-for-apphistorynavigateevent-navigation-action-promise" role="dialog">
+   <span id="infopaneltitle-for-apphistorynavigateevent-navigation-action-promise" style="display:none">Info about the 'navigation action promise' definition.</span><b><a href="#apphistorynavigateevent-navigation-action-promise">#apphistorynavigateevent-navigation-action-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistorynavigateevent-navigation-action-promise">2. The navigate event</a> <a href="#ref-for-apphistorynavigateevent-navigation-action-promise①">(2)</a> <a href="#ref-for-apphistorynavigateevent-navigation-action-promise②">(3)</a> <a href="#ref-for-apphistorynavigateevent-navigation-action-promise③">(4)</a> <a href="#ref-for-apphistorynavigateevent-navigation-action-promise④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistorynavigateevent-respondwith">
-   <b><a href="#dom-apphistorynavigateevent-respondwith">#dom-apphistorynavigateevent-respondwith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistorynavigateevent-respondwith" class="dfn-panel" data-for="dom-apphistorynavigateevent-respondwith" id="infopanel-for-dom-apphistorynavigateevent-respondwith" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistorynavigateevent-respondwith" style="display:none">Info about the 'respondWith(newNavigationAction)' definition.</span><b><a href="#dom-apphistorynavigateevent-respondwith">#dom-apphistorynavigateevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistorynavigateevent-respondwith">2. The navigate event</a> <a href="#ref-for-dom-apphistorynavigateevent-respondwith①">(2)</a> <a href="#ref-for-dom-apphistorynavigateevent-respondwith②">(3)</a> <a href="#ref-for-dom-apphistorynavigateevent-respondwith③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event">
-   <b><a href="#fire-a-navigate-event">#fire-a-navigate-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event" class="dfn-panel" data-for="fire-a-navigate-event" id="infopanel-for-fire-a-navigate-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event" style="display:none">Info about the 'fire a navigate event' definition.</span><b><a href="#fire-a-navigate-event">#fire-a-navigate-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event">2. The navigate event</a>
     <li><a href="#ref-for-fire-a-navigate-event①">4.3. Navigation algorithm updates</a> <a href="#ref-for-fire-a-navigate-event②">(2)</a> <a href="#ref-for-fire-a-navigate-event③">(3)</a> <a href="#ref-for-fire-a-navigate-event④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-navigationtype">
-   <b><a href="#fire-a-navigate-event-navigationtype">#fire-a-navigate-event-navigationtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-navigationtype" class="dfn-panel" data-for="fire-a-navigate-event-navigationtype" id="infopanel-for-fire-a-navigate-event-navigationtype" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-navigationtype" style="display:none">Info about the 'navigationType' definition.</span><b><a href="#fire-a-navigate-event-navigationtype">#fire-a-navigate-event-navigationtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-navigationtype">4.3. Navigation algorithm updates</a> <a href="#ref-for-fire-a-navigate-event-navigationtype①">(2)</a> <a href="#ref-for-fire-a-navigate-event-navigationtype②">(3)</a> <a href="#ref-for-fire-a-navigate-event-navigationtype③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-issamedocument">
-   <b><a href="#fire-a-navigate-event-issamedocument">#fire-a-navigate-event-issamedocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-issamedocument" class="dfn-panel" data-for="fire-a-navigate-event-issamedocument" id="infopanel-for-fire-a-navigate-event-issamedocument" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-issamedocument" style="display:none">Info about the 'isSameDocument' definition.</span><b><a href="#fire-a-navigate-event-issamedocument">#fire-a-navigate-event-issamedocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-issamedocument">4.3. Navigation algorithm updates</a> <a href="#ref-for-fire-a-navigate-event-issamedocument①">(2)</a> <a href="#ref-for-fire-a-navigate-event-issamedocument②">(3)</a> <a href="#ref-for-fire-a-navigate-event-issamedocument③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-userinvolvement">
-   <b><a href="#fire-a-navigate-event-userinvolvement">#fire-a-navigate-event-userinvolvement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-userinvolvement" class="dfn-panel" data-for="fire-a-navigate-event-userinvolvement" id="infopanel-for-fire-a-navigate-event-userinvolvement" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-userinvolvement" style="display:none">Info about the 'userInvolvement' definition.</span><b><a href="#fire-a-navigate-event-userinvolvement">#fire-a-navigate-event-userinvolvement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-userinvolvement">4.3. Navigation algorithm updates</a> <a href="#ref-for-fire-a-navigate-event-userinvolvement①">(2)</a> <a href="#ref-for-fire-a-navigate-event-userinvolvement②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-formdataentrylist">
-   <b><a href="#fire-a-navigate-event-formdataentrylist">#fire-a-navigate-event-formdataentrylist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-formdataentrylist" class="dfn-panel" data-for="fire-a-navigate-event-formdataentrylist" id="infopanel-for-fire-a-navigate-event-formdataentrylist" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-formdataentrylist" style="display:none">Info about the 'formDataEntryList' definition.</span><b><a href="#fire-a-navigate-event-formdataentrylist">#fire-a-navigate-event-formdataentrylist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-formdataentrylist">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-destinationurl">
-   <b><a href="#fire-a-navigate-event-destinationurl">#fire-a-navigate-event-destinationurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-destinationurl" class="dfn-panel" data-for="fire-a-navigate-event-destinationurl" id="infopanel-for-fire-a-navigate-event-destinationurl" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-destinationurl" style="display:none">Info about the 'destinationURL' definition.</span><b><a href="#fire-a-navigate-event-destinationurl">#fire-a-navigate-event-destinationurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-destinationurl">4.3. Navigation algorithm updates</a> <a href="#ref-for-fire-a-navigate-event-destinationurl①">(2)</a> <a href="#ref-for-fire-a-navigate-event-destinationurl②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-classichistoryapiserializeddata">
-   <b><a href="#fire-a-navigate-event-classichistoryapiserializeddata">#fire-a-navigate-event-classichistoryapiserializeddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-classichistoryapiserializeddata" class="dfn-panel" data-for="fire-a-navigate-event-classichistoryapiserializeddata" id="infopanel-for-fire-a-navigate-event-classichistoryapiserializeddata" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-classichistoryapiserializeddata" style="display:none">Info about the 'classicHistoryAPISerializedData' definition.</span><b><a href="#fire-a-navigate-event-classichistoryapiserializeddata">#fire-a-navigate-event-classichistoryapiserializeddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-classichistoryapiserializeddata">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-navigate-event-destinationentry">
-   <b><a href="#fire-a-navigate-event-destinationentry">#fire-a-navigate-event-destinationentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-navigate-event-destinationentry" class="dfn-panel" data-for="fire-a-navigate-event-destinationentry" id="infopanel-for-fire-a-navigate-event-destinationentry" role="dialog">
+   <span id="infopaneltitle-for-fire-a-navigate-event-destinationentry" style="display:none">Info about the 'destinationEntry' definition.</span><b><a href="#fire-a-navigate-event-destinationentry">#fire-a-navigate-event-destinationentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-navigate-event-destinationentry">4.3. Navigation algorithm updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rewritable">
-   <b><a href="#rewritable">#rewritable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rewritable" class="dfn-panel" data-for="rewritable" id="infopanel-for-rewritable" role="dialog">
+   <span id="infopaneltitle-for-rewritable" style="display:none">Info about the 'rewritable' definition.</span><b><a href="#rewritable">#rewritable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rewritable">2. The navigate event</a> <a href="#ref-for-rewritable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistoryentry">
-   <b><a href="#apphistoryentry">#apphistoryentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistoryentry" class="dfn-panel" data-for="apphistoryentry" id="infopanel-for-apphistoryentry" role="dialog">
+   <span id="infopaneltitle-for-apphistoryentry" style="display:none">Info about the 'AppHistoryEntry' definition.</span><b><a href="#apphistoryentry">#apphistoryentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistoryentry">1. The AppHistory class</a> <a href="#ref-for-apphistoryentry①">(2)</a> <a href="#ref-for-apphistoryentry②">(3)</a> <a href="#ref-for-apphistoryentry③">(4)</a> <a href="#ref-for-apphistoryentry④">(5)</a> <a href="#ref-for-apphistoryentry⑤">(6)</a> <a href="#ref-for-apphistoryentry⑥">(7)</a> <a href="#ref-for-apphistoryentry⑦">(8)</a> <a href="#ref-for-apphistoryentry⑧">(9)</a> <a href="#ref-for-apphistoryentry⑨">(10)</a>
     <li><a href="#ref-for-apphistoryentry①⓪">3. App history entries</a> <a href="#ref-for-apphistoryentry①①">(2)</a> <a href="#ref-for-apphistoryentry①②">(3)</a> <a href="#ref-for-apphistoryentry①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistoryentry-session-history-entry">
-   <b><a href="#apphistoryentry-session-history-entry">#apphistoryentry-session-history-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistoryentry-session-history-entry" class="dfn-panel" data-for="apphistoryentry-session-history-entry" id="infopanel-for-apphistoryentry-session-history-entry" role="dialog">
+   <span id="infopaneltitle-for-apphistoryentry-session-history-entry" style="display:none">Info about the 'session history entry' definition.</span><b><a href="#apphistoryentry-session-history-entry">#apphistoryentry-session-history-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistoryentry-session-history-entry">1. The AppHistory class</a> <a href="#ref-for-apphistoryentry-session-history-entry①">(2)</a>
     <li><a href="#ref-for-apphistoryentry-session-history-entry②">3. App history entries</a> <a href="#ref-for-apphistoryentry-session-history-entry③">(2)</a> <a href="#ref-for-apphistoryentry-session-history-entry④">(3)</a> <a href="#ref-for-apphistoryentry-session-history-entry⑤">(4)</a> <a href="#ref-for-apphistoryentry-session-history-entry⑥">(5)</a> <a href="#ref-for-apphistoryentry-session-history-entry⑦">(6)</a> <a href="#ref-for-apphistoryentry-session-history-entry⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apphistoryentry-index">
-   <b><a href="#apphistoryentry-index">#apphistoryentry-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apphistoryentry-index" class="dfn-panel" data-for="apphistoryentry-index" id="infopanel-for-apphistoryentry-index" role="dialog">
+   <span id="infopaneltitle-for-apphistoryentry-index" style="display:none">Info about the 'index' definition.</span><b><a href="#apphistoryentry-index">#apphistoryentry-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apphistoryentry-index">1. The AppHistory class</a> <a href="#ref-for-apphistoryentry-index①">(2)</a> <a href="#ref-for-apphistoryentry-index②">(3)</a>
     <li><a href="#ref-for-apphistoryentry-index③">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-key">
-   <b><a href="#dom-apphistoryentry-key">#dom-apphistoryentry-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-key" class="dfn-panel" data-for="dom-apphistoryentry-key" id="infopanel-for-dom-apphistoryentry-key" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-key" style="display:none">Info about the 'key' definition.</span><b><a href="#dom-apphistoryentry-key">#dom-apphistoryentry-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-key">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-key①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-id">
-   <b><a href="#dom-apphistoryentry-id">#dom-apphistoryentry-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-id" class="dfn-panel" data-for="dom-apphistoryentry-id" id="infopanel-for-dom-apphistoryentry-id" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-apphistoryentry-id">#dom-apphistoryentry-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-id">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-id①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-url">
-   <b><a href="#dom-apphistoryentry-url">#dom-apphistoryentry-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-url" class="dfn-panel" data-for="dom-apphistoryentry-url" id="infopanel-for-dom-apphistoryentry-url" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-apphistoryentry-url">#dom-apphistoryentry-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-url">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-index">
-   <b><a href="#dom-apphistoryentry-index">#dom-apphistoryentry-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-index" class="dfn-panel" data-for="dom-apphistoryentry-index" id="infopanel-for-dom-apphistoryentry-index" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-index" style="display:none">Info about the 'index' definition.</span><b><a href="#dom-apphistoryentry-index">#dom-apphistoryentry-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-index">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-index①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-samedocument">
-   <b><a href="#dom-apphistoryentry-samedocument">#dom-apphistoryentry-samedocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-samedocument" class="dfn-panel" data-for="dom-apphistoryentry-samedocument" id="infopanel-for-dom-apphistoryentry-samedocument" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-samedocument" style="display:none">Info about the 'sameDocument' definition.</span><b><a href="#dom-apphistoryentry-samedocument">#dom-apphistoryentry-samedocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-samedocument">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-samedocument①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-apphistoryentry-getstate">
-   <b><a href="#dom-apphistoryentry-getstate">#dom-apphistoryentry-getstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-apphistoryentry-getstate" class="dfn-panel" data-for="dom-apphistoryentry-getstate" id="infopanel-for-dom-apphistoryentry-getstate" role="dialog">
+   <span id="infopaneltitle-for-dom-apphistoryentry-getstate" style="display:none">Info about the 'getState()' definition.</span><b><a href="#dom-apphistoryentry-getstate">#dom-apphistoryentry-getstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-apphistoryentry-getstate">3. App history entries</a> <a href="#ref-for-dom-apphistoryentry-getstate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigate-entrylist">
-   <b><a href="#navigate-entrylist">#navigate-entrylist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigate-entrylist" class="dfn-panel" data-for="navigate-entrylist" id="infopanel-for-navigate-entrylist" role="dialog">
+   <span id="infopaneltitle-for-navigate-entrylist" style="display:none">Info about the 'entryList' definition.</span><b><a href="#navigate-entrylist">#navigate-entrylist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate-entrylist">4.1. Form submission patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-navigation-involvement">
-   <b><a href="#user-navigation-involvement">#user-navigation-involvement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-navigation-involvement" class="dfn-panel" data-for="user-navigation-involvement" id="infopanel-for-user-navigation-involvement" role="dialog">
+   <span id="infopaneltitle-for-user-navigation-involvement" style="display:none">Info about the 'user navigation involvement' definition.</span><b><a href="#user-navigation-involvement">#user-navigation-involvement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-navigation-involvement">2. The navigate event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-navigation-involvement-browser-ui">
-   <b><a href="#user-navigation-involvement-browser-ui">#user-navigation-involvement-browser-ui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-navigation-involvement-browser-ui" class="dfn-panel" data-for="user-navigation-involvement-browser-ui" id="infopanel-for-user-navigation-involvement-browser-ui" role="dialog">
+   <span id="infopaneltitle-for-user-navigation-involvement-browser-ui" style="display:none">Info about the 'browser UI' definition.</span><b><a href="#user-navigation-involvement-browser-ui">#user-navigation-involvement-browser-ui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-navigation-involvement-browser-ui">2. The navigate event</a>
     <li><a href="#ref-for-user-navigation-involvement-browser-ui①">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-user-navigation-involvement-browser-ui②">(2)</a> <a href="#ref-for-user-navigation-involvement-browser-ui③">(3)</a>
     <li><a href="#ref-for-user-navigation-involvement-browser-ui④">4.3. Navigation algorithm updates</a> <a href="#ref-for-user-navigation-involvement-browser-ui⑤">(2)</a> <a href="#ref-for-user-navigation-involvement-browser-ui⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-navigation-involvement-activation">
-   <b><a href="#user-navigation-involvement-activation">#user-navigation-involvement-activation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-navigation-involvement-activation" class="dfn-panel" data-for="user-navigation-involvement-activation" id="infopanel-for-user-navigation-involvement-activation" role="dialog">
+   <span id="infopaneltitle-for-user-navigation-involvement-activation" style="display:none">Info about the 'activation' definition.</span><b><a href="#user-navigation-involvement-activation">#user-navigation-involvement-activation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-navigation-involvement-activation">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-user-navigation-involvement-activation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-navigation-involvement-none">
-   <b><a href="#user-navigation-involvement-none">#user-navigation-involvement-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-navigation-involvement-none" class="dfn-panel" data-for="user-navigation-involvement-none" id="infopanel-for-user-navigation-involvement-none" role="dialog">
+   <span id="infopaneltitle-for-user-navigation-involvement-none" style="display:none">Info about the 'none' definition.</span><b><a href="#user-navigation-involvement-none">#user-navigation-involvement-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-navigation-involvement-none">2. The navigate event</a> <a href="#ref-for-user-navigation-involvement-none①">(2)</a>
     <li><a href="#ref-for-user-navigation-involvement-none②">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-user-navigation-involvement-none③">(2)</a> <a href="#ref-for-user-navigation-involvement-none④">(3)</a> <a href="#ref-for-user-navigation-involvement-none⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-user-navigation-involvement">
-   <b><a href="#event-user-navigation-involvement">#event-user-navigation-involvement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-user-navigation-involvement" class="dfn-panel" data-for="event-user-navigation-involvement" id="infopanel-for-event-user-navigation-involvement" role="dialog">
+   <span id="infopaneltitle-for-event-user-navigation-involvement" style="display:none">Info about the 'user navigation involvement' definition.</span><b><a href="#event-user-navigation-involvement">#event-user-navigation-involvement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-user-navigation-involvement">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-event-user-navigation-involvement①">(2)</a> <a href="#ref-for-event-user-navigation-involvement②">(3)</a> <a href="#ref-for-event-user-navigation-involvement③">(4)</a> <a href="#ref-for-event-user-navigation-involvement④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigate-userinvolvement">
-   <b><a href="#navigate-userinvolvement">#navigate-userinvolvement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigate-userinvolvement" class="dfn-panel" data-for="navigate-userinvolvement" id="infopanel-for-navigate-userinvolvement" role="dialog">
+   <span id="infopaneltitle-for-navigate-userinvolvement" style="display:none">Info about the 'userInvolvement' definition.</span><b><a href="#navigate-userinvolvement">#navigate-userinvolvement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate-userinvolvement">4.2. Browser UI/user-initiated patches</a> <a href="#ref-for-navigate-userinvolvement①">(2)</a> <a href="#ref-for-navigate-userinvolvement②">(3)</a> <a href="#ref-for-navigate-userinvolvement③">(4)</a> <a href="#ref-for-navigate-userinvolvement④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="traverse-the-history-by-a-delta-userinvolvement">
-   <b><a href="#traverse-the-history-by-a-delta-userinvolvement">#traverse-the-history-by-a-delta-userinvolvement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-traverse-the-history-by-a-delta-userinvolvement" class="dfn-panel" data-for="traverse-the-history-by-a-delta-userinvolvement" id="infopanel-for-traverse-the-history-by-a-delta-userinvolvement" role="dialog">
+   <span id="infopaneltitle-for-traverse-the-history-by-a-delta-userinvolvement" style="display:none">Info about the 'userInvolvement' definition.</span><b><a href="#traverse-the-history-by-a-delta-userinvolvement">#traverse-the-history-by-a-delta-userinvolvement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-traverse-the-history-by-a-delta-userinvolvement">4.2. Browser UI/user-initiated patches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-history-entry-origin">
-   <b><a href="#session-history-entry-origin">#session-history-entry-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-history-entry-origin" class="dfn-panel" data-for="session-history-entry-origin" id="infopanel-for-session-history-entry-origin" role="dialog">
+   <span id="infopaneltitle-for-session-history-entry-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#session-history-entry-origin">#session-history-entry-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry-origin">1. The AppHistory class</a> <a href="#ref-for-session-history-entry-origin①">(2)</a> <a href="#ref-for-session-history-entry-origin②">(3)</a> <a href="#ref-for-session-history-entry-origin③">(4)</a>
     <li><a href="#ref-for-session-history-entry-origin④">5.2. Carrying over the app history key</a> <a href="#ref-for-session-history-entry-origin⑤">(2)</a>
     <li><a href="#ref-for-session-history-entry-origin⑥">5.3. Tracking the origin member</a> <a href="#ref-for-session-history-entry-origin⑦">(2)</a> <a href="#ref-for-session-history-entry-origin⑧">(3)</a> <a href="#ref-for-session-history-entry-origin⑨">(4)</a> <a href="#ref-for-session-history-entry-origin①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-history-entry-app-history-key">
-   <b><a href="#session-history-entry-app-history-key">#session-history-entry-app-history-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-history-entry-app-history-key" class="dfn-panel" data-for="session-history-entry-app-history-key" id="infopanel-for-session-history-entry-app-history-key" role="dialog">
+   <span id="infopaneltitle-for-session-history-entry-app-history-key" style="display:none">Info about the 'app history key' definition.</span><b><a href="#session-history-entry-app-history-key">#session-history-entry-app-history-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry-app-history-key">3. App history entries</a>
     <li><a href="#ref-for-session-history-entry-app-history-key①">5.2. Carrying over the app history key</a> <a href="#ref-for-session-history-entry-app-history-key②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-history-entry-app-history-id">
-   <b><a href="#session-history-entry-app-history-id">#session-history-entry-app-history-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-history-entry-app-history-id" class="dfn-panel" data-for="session-history-entry-app-history-id" id="infopanel-for-session-history-entry-app-history-id" role="dialog">
+   <span id="infopaneltitle-for-session-history-entry-app-history-id" style="display:none">Info about the 'app history id' definition.</span><b><a href="#session-history-entry-app-history-id">#session-history-entry-app-history-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry-app-history-id">3. App history entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-history-entry-app-history-state">
-   <b><a href="#session-history-entry-app-history-state">#session-history-entry-app-history-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-history-entry-app-history-state" class="dfn-panel" data-for="session-history-entry-app-history-state" id="infopanel-for-session-history-entry-app-history-state" role="dialog">
+   <span id="infopaneltitle-for-session-history-entry-app-history-state" style="display:none">Info about the 'app history state' definition.</span><b><a href="#session-history-entry-app-history-state">#session-history-entry-app-history-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry-app-history-state">3. App history entries</a> <a href="#ref-for-session-history-entry-app-history-state①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/background-fetch/index.html
+++ b/tests/github/WICG/background-fetch/index.html
@@ -3017,238 +3017,238 @@ complete-length = ( 1*DIGIT / "*" )</pre>
    <li><a href="#dom-backgroundfetchregistration-uploadtotal">uploadTotal</a><span>, in § 6.4</span>
    <li><a href="#validate-a-partial-response">validate a partial response</a><span>, in § 4.6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-section-7">
-   <a href="https://tools.ietf.org/html/rfc7230#section-7">https://tools.ietf.org/html/rfc7230#section-7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7" class="dfn-panel" data-for="term-for-section-7" id="infopanel-for-term-for-section-7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7" style="display:none">Info about the 'http abnf' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-7">https://tools.ietf.org/html/rfc7230#section-7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7">5. Header syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">6.4.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">4.3. Update background fetch instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">4.5. Get a BackgroundFetchRegistration instance</a>
     <li><a href="#ref-for-realm①">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">4.8. Create record objects</a> <a href="#ref-for-headers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">4.8. Create record objects</a> <a href="#ref-for-request①">(2)</a>
     <li><a href="#ref-for-request②">6.3.1. fetch()</a>
     <li><a href="#ref-for-request③">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-requestinfo">
-   <a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-requestinfo" class="dfn-panel" data-for="term-for-requestinfo" id="infopanel-for-term-for-requestinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-requestinfo" style="display:none">Info about the 'RequestInfo' external reference.</span><a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">6.3. BackgroundFetchManager</a> <a href="#ref-for-requestinfo①">(2)</a>
     <li><a href="#ref-for-requestinfo②">6.3.1. fetch()</a>
     <li><a href="#ref-for-requestinfo③">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-requestinfo④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.8. Create record objects</a> <a href="#ref-for-response①">(2)</a>
     <li><a href="#ref-for-response②">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-aborted-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-aborted-network-error">https://fetch.spec.whatwg.org/#concept-aborted-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-aborted-network-error" class="dfn-panel" data-for="term-for-concept-aborted-network-error" id="infopanel-for-term-for-concept-aborted-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-aborted-network-error" style="display:none">Info about the 'aborted network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-aborted-network-error">https://fetch.spec.whatwg.org/#concept-aborted-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-aborted-network-error">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-add-range-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-add-range-header">https://fetch.spec.whatwg.org/#concept-request-add-range-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-add-range-header" class="dfn-panel" data-for="term-for-concept-request-add-range-header" id="infopanel-for-term-for-concept-request-add-range-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-add-range-header" style="display:none">Info about the 'add a range header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-add-range-header">https://fetch.spec.whatwg.org/#concept-request-add-range-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-add-range-header">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body" class="dfn-panel" data-for="term-for-concept-body" id="infopanel-for-term-for-concept-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">4.2. Complete a record</a>
     <li><a href="#ref-for-concept-request-body①">4.8. Create record objects</a>
     <li><a href="#ref-for-concept-request-body②">6.3.1. fetch()</a> <a href="#ref-for-concept-request-body③">(2)</a> <a href="#ref-for-concept-request-body④">(3)</a> <a href="#ref-for-concept-request-body⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">4.2. Complete a record</a> <a href="#ref-for-concept-response-body①">(2)</a>
     <li><a href="#ref-for-concept-response-body②">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">3.2.1. Display</a>
     <li><a href="#ref-for-concept-request-client①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-combine">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-combine" class="dfn-panel" data-for="term-for-concept-header-list-combine" id="infopanel-for-term-for-concept-header-list-combine" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-combine" style="display:none">Info about the 'combine' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-combine">4.6. Validate a partial response</a> <a href="#ref-for-concept-header-list-combine①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">4.6. Validate a partial response</a>
     <li><a href="#ref-for-header-list-contains①">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-delete">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-delete">https://fetch.spec.whatwg.org/#concept-header-list-delete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-delete" class="dfn-panel" data-for="term-for-concept-header-list-delete" id="infopanel-for-term-for-concept-header-list-delete" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-delete" style="display:none">Info about the 'delete' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-delete">https://fetch.spec.whatwg.org/#concept-header-list-delete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-delete">4.8. Create record objects</a> <a href="#ref-for-concept-header-list-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">3.2.1. Display</a>
     <li><a href="#ref-for-concept-fetch①">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">4.6. Validate a partial response</a> <a href="#ref-for-concept-response-header-list①">(2)</a> <a href="#ref-for-concept-response-header-list②">(3)</a>
     <li><a href="#ref-for-concept-response-header-list③">4.7. Extract content-range values</a> <a href="#ref-for-concept-response-header-list④">(2)</a>
     <li><a href="#ref-for-concept-response-header-list⑤">4.8. Create record objects</a> <a href="#ref-for-concept-response-header-list⑥">(2)</a> <a href="#ref-for-concept-response-header-list⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-headers">
-   <a href="https://fetch.spec.whatwg.org/#request-headers">https://fetch.spec.whatwg.org/#request-headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-headers" class="dfn-panel" data-for="term-for-request-headers" id="infopanel-for-term-for-request-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-request-headers" style="display:none">Info about the 'headers (for Request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-headers">https://fetch.spec.whatwg.org/#request-headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-headers">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response-headers">
-   <a href="https://fetch.spec.whatwg.org/#response-headers">https://fetch.spec.whatwg.org/#response-headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response-headers" class="dfn-panel" data-for="term-for-response-headers" id="infopanel-for-term-for-response-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-response-headers" style="display:none">Info about the 'headers (for Response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#response-headers">https://fetch.spec.whatwg.org/#response-headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-headers">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">3.2.1. Display</a> <a href="#ref-for-concept-request-method①">(2)</a>
     <li><a href="#ref-for-concept-request-method②">4.2. Complete a record</a> <a href="#ref-for-concept-request-method③">(2)</a> <a href="#ref-for-concept-request-method④">(3)</a> <a href="#ref-for-concept-request-method⑤">(4)</a>
     <li><a href="#ref-for-concept-request-method⑥">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">3.2.1. Display</a>
     <li><a href="#ref-for-concept-request-mode①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.2.1. Display</a>
     <li><a href="#ref-for-concept-request①">3.3. Background fetch record</a>
     <li><a href="#ref-for-concept-request②">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request (for Request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">4.8. Create record objects</a> <a href="#ref-for-concept-request-request①">(2)</a>
     <li><a href="#ref-for-concept-request-request②">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">3.4. Background fetch response</a>
     <li><a href="#ref-for-concept-response①">4.6. Validate a partial response</a> <a href="#ref-for-concept-response②">(2)</a>
@@ -3257,62 +3257,62 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-concept-response⑤">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response (for Response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">4.8. Create record objects</a> <a href="#ref-for-concept-response-response①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">3.2.1. Display</a>
     <li><a href="#ref-for-request-service-workers-mode①">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">4.2. Complete a record</a> <a href="#ref-for-concept-response-status①">(2)</a> <a href="#ref-for-concept-response-status②">(3)</a> <a href="#ref-for-concept-response-status③">(4)</a>
     <li><a href="#ref-for-concept-response-status④">4.6. Validate a partial response</a> <a href="#ref-for-concept-response-status⑤">(2)</a>
     <li><a href="#ref-for-concept-response-status⑥">7.1. Click</a> <a href="#ref-for-concept-response-status⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">4.2. Complete a record</a>
     <li><a href="#ref-for-concept-body-stream①">4.8. Create record objects</a>
     <li><a href="#ref-for-concept-body-stream②">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">6.1. Extensions to ServiceWorkerGlobalScope</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
     <li><a href="#ref-for-eventhandler④">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">4.3. Update background fetch instances</a>
@@ -3321,41 +3321,41 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-enqueue-the-following-steps④">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.2.1. Display</a>
     <li><a href="#ref-for-environment-settings-object①">4.3. Update background fetch instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">6.1.1. Events</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">6.4.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">6.1.1. Events</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">6.4.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">3. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. Perform a background fetch</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">4.8. Create record objects</a> <a href="#ref-for-in-parallel③">(2)</a>
@@ -3367,34 +3367,34 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-in-parallel①①">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networking-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networking-task-source" class="dfn-panel" data-for="term-for-networking-task-source" id="infopanel-for-term-for-networking-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-networking-task-source" style="display:none">Info about the 'networking task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networking-task-source">4.8. Create record objects</a> <a href="#ref-for-networking-task-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.3. Update background fetch instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parallel-queue" class="dfn-panel" data-for="term-for-parallel-queue" id="infopanel-for-term-for-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-parallel-queue" style="display:none">Info about the 'parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parallel-queue">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-parallel-queue①">3.2. Background fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3. Infrastructure</a>
     <li><a href="#ref-for-queue-a-task①">4.8. Create record objects</a> <a href="#ref-for-queue-a-task②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">2. Realms</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.1. Perform a background fetch</a>
@@ -3405,109 +3405,109 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-concept-relevant-realm⑥">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3. Infrastructure</a>
     <li><a href="#ref-for-relevant-settings-object①">4.8. Create record objects</a> <a href="#ref-for-relevant-settings-object②">(2)</a>
     <li><a href="#ref-for-relevant-settings-object③">6.3.1. fetch()</a> <a href="#ref-for-relevant-settings-object④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">3. Infrastructure</a>
     <li><a href="#ref-for-responsible-event-loop①">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-responsible-event-loop②">4.8. Create record objects</a> <a href="#ref-for-responsible-event-loop③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-starting-a-new-parallel-queue①">3.2. Background fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">3. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-imageresource">
-   <a href="https://w3c.github.io/image-resource/#dom-imageresource">https://w3c.github.io/image-resource/#dom-imageresource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-imageresource" class="dfn-panel" data-for="term-for-dom-imageresource" id="infopanel-for-term-for-dom-imageresource" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-imageresource" style="display:none">Info about the 'ImageResource' external reference.</span><a href="https://w3c.github.io/image-resource/#dom-imageresource">https://w3c.github.io/image-resource/#dom-imageresource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imageresource">3.2. Background fetch</a>
     <li><a href="#ref-for-dom-imageresource①">6.3. BackgroundFetchManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-image-resource">
-   <a href="https://w3c.github.io/image-resource/#image-resource">https://w3c.github.io/image-resource/#image-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-image-resource" class="dfn-panel" data-for="term-for-image-resource" id="infopanel-for-term-for-image-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-image-resource" style="display:none">Info about the 'image resource' external reference.</span><a href="https://w3c.github.io/image-resource/#image-resource">https://w3c.github.io/image-resource/#image-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-resource">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-processing-an-imageresource-from-an-api">
-   <a href="https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api">https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-processing-an-imageresource-from-an-api" class="dfn-panel" data-for="term-for-processing-an-imageresource-from-an-api" id="infopanel-for-term-for-processing-an-imageresource-from-an-api" role="menu">
+   <span id="infopaneltitle-for-term-for-processing-an-imageresource-from-an-api" style="display:none">Info about the 'processing' external reference.</span><a href="https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api">https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processing-an-imageresource-from-an-api">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-src">
-   <a href="https://w3c.github.io/image-resource/#dfn-src">https://w3c.github.io/image-resource/#dfn-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-src" class="dfn-panel" data-for="term-for-dfn-src" id="infopanel-for-term-for-dfn-src" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-src" style="display:none">Info about the 'src' external reference.</span><a href="https://w3c.github.io/image-resource/#dfn-src">https://w3c.github.io/image-resource/#dfn-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-src">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abort-when">
-   <a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abort-when" class="dfn-panel" data-for="term-for-abort-when" id="infopanel-for-term-for-abort-when" role="menu">
+   <span id="infopaneltitle-for-term-for-abort-when" style="display:none">Info about the 'abort when' external reference.</span><a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-when">4.2. Complete a record</a>
     <li><a href="#ref-for-abort-when①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.8. Create record objects</a>
     <li><a href="#ref-for-list-append①">6.3.1. fetch()</a>
     <li><a href="#ref-for-list-append②">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3.4. Background fetch response</a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#byte-case-insensitive">https://infra.spec.whatwg.org/#byte-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-case-insensitive" class="dfn-panel" data-for="term-for-byte-case-insensitive" id="infopanel-for-term-for-byte-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-case-insensitive" style="display:none">Info about the 'byte-case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-case-insensitive">https://infra.spec.whatwg.org/#byte-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-case-insensitive">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.5. Get a BackgroundFetchRegistration instance</a>
     <li><a href="#ref-for-map-exists①">4.9. Contains background fetch</a>
     <li><a href="#ref-for-map-exists②">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.2. Background fetch</a>
     <li><a href="#ref-for-list-iterate①">4.1. Perform a background fetch</a>
@@ -3515,29 +3515,29 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-list-iterate③">6.3.1. fetch()</a> <a href="#ref-for-list-iterate④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'getting the keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">6.3.3. getIds()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-if-aborted">
-   <a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-if-aborted" class="dfn-panel" data-for="term-for-if-aborted" id="infopanel-for-term-for-if-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-if-aborted" style="display:none">Info about the 'if aborted' external reference.</span><a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-if-aborted">4.2. Complete a record</a>
     <li><a href="#ref-for-if-aborted①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">3.2. Background fetch</a>
     <li><a href="#ref-for-byte-sequence-length①">4.2. Complete a record</a> <a href="#ref-for-byte-sequence-length②">(2)</a>
     <li><a href="#ref-for-byte-sequence-length③">4.8. Create record objects</a> <a href="#ref-for-byte-sequence-length④">(2)</a> <a href="#ref-for-byte-sequence-length⑤">(3)</a> <a href="#ref-for-byte-sequence-length⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.2. Background fetch</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">4.8. Create record objects</a> <a href="#ref-for-list③">(2)</a>
@@ -3545,131 +3545,131 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-list⑥">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. Extensions to service worker registration</a> <a href="#ref-for-ordered-map①">(2)</a>
     <li><a href="#ref-for-ordered-map②">4.9. Contains background fetch</a> <a href="#ref-for-ordered-map③">(2)</a>
     <li><a href="#ref-for-ordered-map④">6.3. BackgroundFetchManager</a> <a href="#ref-for-ordered-map⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-list-size①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">3.2.1. Display</a>
     <li><a href="#ref-for-dom-permissiondescriptor①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">3.2.1. Display</a>
     <li><a href="#ref-for-dom-permissiondescriptor-name①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-new-information-about-the-user-s-intent">
-   <a href="https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent">https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-new-information-about-the-user-s-intent" class="dfn-panel" data-for="term-for-dfn-new-information-about-the-user-s-intent" id="infopanel-for-term-for-dfn-new-information-about-the-user-s-intent" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-new-information-about-the-user-s-intent" style="display:none">Info about the 'new information about the user's intent' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent">https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-new-information-about-the-user-s-intent">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">3.2.1. Display</a>
     <li><a href="#ref-for-dfn-permission-state①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-cachequeryoptions">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions">https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-cachequeryoptions" class="dfn-panel" data-for="term-for-dictdef-cachequeryoptions" id="infopanel-for-term-for-dictdef-cachequeryoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-cachequeryoptions" style="display:none">Info about the 'CacheQueryOptions' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions">https://w3c.github.io/ServiceWorker/#dictdef-cachequeryoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cachequeryoptions">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-dictdef-cachequeryoptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">6.6. BackgroundFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">6.6. BackgroundFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworker">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworker" class="dfn-panel" data-for="term-for-serviceworker" id="infopanel-for-term-for-serviceworker" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworker" style="display:none">Info about the 'ServiceWorker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">6.1. Extensions to ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">6.2. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent-active">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent-active">https://w3c.github.io/ServiceWorker/#extendableevent-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent-active" class="dfn-panel" data-for="term-for-extendableevent-active" id="infopanel-for-term-for-extendableevent-active" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent-active" style="display:none">Info about the 'active' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent-active">https://w3c.github.io/ServiceWorker/#extendableevent-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-active">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-extendableevent-active①">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire a functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-fire-functional-event①">4.4. Fire a background fetch click event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#match-service-worker-registration">https://w3c.github.io/ServiceWorker/#match-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-service-worker-registration" class="dfn-panel" data-for="term-for-match-service-worker-registration" id="infopanel-for-term-for-match-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-match-service-worker-registration" style="display:none">Info about the 'match service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#match-service-worker-registration">https://w3c.github.io/ServiceWorker/#match-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-service-worker-registration">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-matches-cached-item">
-   <a href="https://w3c.github.io/ServiceWorker/#request-matches-cached-item">https://w3c.github.io/ServiceWorker/#request-matches-cached-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-matches-cached-item" class="dfn-panel" data-for="term-for-request-matches-cached-item" id="infopanel-for-term-for-request-matches-cached-item" role="menu">
+   <span id="infopaneltitle-for-term-for-request-matches-cached-item" style="display:none">Info about the 'request matches cached item' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#request-matches-cached-item">https://w3c.github.io/ServiceWorker/#request-matches-cached-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-matches-cached-item">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-scope-url">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-scope-url" class="dfn-panel" data-for="term-for-dfn-scope-url" id="infopanel-for-term-for-dfn-scope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-scope-url" style="display:none">Info about the 'scope url' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">3.2.1. Display</a>
     <li><a href="#ref-for-dfn-scope-url①">4.3. Update background fetch instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker" class="dfn-panel" data-for="term-for-dfn-service-worker" id="infopanel-for-term-for-dfn-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1. Introduction</a> <a href="#ref-for-dfn-service-worker①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration" class="dfn-panel" data-for="term-for-dfn-service-worker-registration" id="infopanel-for-term-for-dfn-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">3.2. Background fetch</a>
@@ -3678,134 +3678,134 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-dfn-service-worker-registration④">8. Privacy and bandwidth usage</a> <a href="#ref-for-dfn-service-worker-registration⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-extendableevent-waituntil">
-   <a href="https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil">https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-extendableevent-waituntil" class="dfn-panel" data-for="term-for-dom-extendableevent-waituntil" id="infopanel-for-term-for-dom-extendableevent-waituntil" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-extendableevent-waituntil" style="display:none">Info about the 'waitUntil(f)' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil">https://w3c.github.io/ServiceWorker/#dom-extendableevent-waituntil</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendableevent-waituntil">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-cancel" class="dfn-panel" data-for="term-for-readablestream-cancel" id="infopanel-for-term-for-readablestream-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-cancel" style="display:none">Info about the 'cancel' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-cancel">4.2. Complete a record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-close">
-   <a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-close" class="dfn-panel" data-for="term-for-readablestream-close" id="infopanel-for-term-for-readablestream-close" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-close" style="display:none">Info about the 'close' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-close">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-error">
-   <a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-error" class="dfn-panel" data-for="term-for-readablestream-error" id="infopanel-for-term-for-readablestream-error" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-error" style="display:none">Info about the 'error' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-error">4.8. Create record objects</a> <a href="#ref-for-readablestream-error①">(2)</a>
     <li><a href="#ref-for-readablestream-error②">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-errored">
-   <a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-errored" class="dfn-panel" data-for="term-for-readablestream-errored" id="infopanel-for-term-for-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-errored">4.2. Complete a record</a>
     <li><a href="#ref-for-readablestream-errored①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-readable">
-   <a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-readable" class="dfn-panel" data-for="term-for-readablestream-readable" id="infopanel-for-term-for-readablestream-readable" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-readable" style="display:none">Info about the 'readable' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-readable">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">3.2.1. Display</a>
     <li><a href="#ref-for-concept-url-origin①">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-concept-url-origin②">8. Privacy and bandwidth usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-top-level-browsing-context">
-   <a href="https://w3c.github.io/webdriver/#dfn-current-top-level-browsing-context">https://w3c.github.io/webdriver/#dfn-current-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-top-level-browsing-context" class="dfn-panel" data-for="term-for-dfn-current-top-level-browsing-context" id="infopanel-for-term-for-dfn-current-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-top-level-browsing-context" style="display:none">Info about the 'current top-level browsing context' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-current-top-level-browsing-context">https://w3c.github.io/webdriver/#dfn-current-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-top-level-browsing-context">7.1. Click</a> <a href="#ref-for-dfn-current-top-level-browsing-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command" class="dfn-panel" data-for="term-for-dfn-extension-command" id="infopanel-for-term-for-dfn-extension-command" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command" style="display:none">Info about the 'extension command' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command">7. Automation</a>
     <li><a href="#ref-for-dfn-extension-command①">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command-uri-template" class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template" id="infopanel-for-term-for-dfn-extension-command-uri-template" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command-uri-template" style="display:none">Info about the 'extension command uri template' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command-uri-template">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-no-longer-open">
-   <a href="https://w3c.github.io/webdriver/#dfn-no-longer-open">https://w3c.github.io/webdriver/#dfn-no-longer-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-no-longer-open" class="dfn-panel" data-for="term-for-dfn-no-longer-open" id="infopanel-for-term-for-dfn-no-longer-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-no-longer-open" style="display:none">Info about the 'no longer open' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-no-longer-open">https://w3c.github.io/webdriver/#dfn-no-longer-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-no-longer-open">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-no-such-window">
-   <a href="https://w3c.github.io/webdriver/#dfn-no-such-window">https://w3c.github.io/webdriver/#dfn-no-such-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-no-such-window" class="dfn-panel" data-for="term-for-dfn-no-such-window" id="infopanel-for-term-for-dfn-no-such-window" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-no-such-window" style="display:none">Info about the 'no such window' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-no-such-window">https://w3c.github.io/webdriver/#dfn-no-such-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-no-such-window">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-url-variables">
-   <a href="https://w3c.github.io/webdriver/#dfn-url-variables">https://w3c.github.io/webdriver/#dfn-url-variables</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-url-variables" class="dfn-panel" data-for="term-for-dfn-url-variables" id="infopanel-for-term-for-dfn-url-variables" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-url-variables" style="display:none">Info about the 'url variable' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-url-variables">https://w3c.github.io/webdriver/#dfn-url-variables</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-url-variables">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-errors">
-   <a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-errors" class="dfn-panel" data-for="term-for-dfn-errors" id="infopanel-for-term-for-dfn-errors" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-errors" style="display:none">Info about the 'webdriver error' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-errors">7.1. Click</a> <a href="#ref-for-dfn-errors①">(2)</a> <a href="#ref-for-dfn-errors②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'webdriver error code' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'webdriver success' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">4.8. Create record objects</a> <a href="#ref-for-aborterror①">(2)</a>
     <li><a href="#ref-for-aborterror②">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.8. Create record objects</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">6.3.1. fetch()</a> <a href="#ref-for-idl-DOMException③">(2)</a> <a href="#ref-for-idl-DOMException④">(3)</a>
@@ -3813,8 +3813,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-idl-DOMException⑥">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">6.3. BackgroundFetchManager</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
     <li><a href="#ref-for-idl-DOMString④">6.4. BackgroundFetchRegistration</a>
@@ -3822,8 +3822,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-idl-DOMString⑥">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-Exposed①">6.4. BackgroundFetchRegistration</a>
@@ -3832,21 +3832,21 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-Exposed④">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6.4.4. matchAll()</a>
     <li><a href="#ref-for-invalidstateerror①">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">6.3. BackgroundFetchManager</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
     <li><a href="#ref-for-idl-promise③">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-idl-promise④">(2)</a> <a href="#ref-for-idl-promise⑤">(3)</a>
@@ -3854,27 +3854,27 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-idl-promise⑧">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">4.8. Create record objects</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">6.3.1. fetch()</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a> <a href="#ref-for-exceptiondef-typeerror④">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(4)</a> <a href="#ref-for-exceptiondef-typeerror⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">4.8. Create record objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.8. Create record objects</a> <a href="#ref-for-a-new-promise①">(2)</a>
     <li><a href="#ref-for-a-new-promise②">6.3.1. fetch()</a>
@@ -3885,34 +3885,34 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-a-new-promise⑦">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">6.3.1. fetch()</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a>
     <li><a href="#ref-for-a-promise-rejected-with③">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'reacting' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">6.4.3. match()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.8. Create record objects</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">6.3.1. fetch()</a> <a href="#ref-for-reject③">(2)</a> <a href="#ref-for-reject④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.8. Create record objects</a> <a href="#ref-for-resolve①">(2)</a>
     <li><a href="#ref-for-resolve②">6.3.1. fetch()</a>
@@ -3923,15 +3923,15 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-resolve⑨">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">6.3. BackgroundFetchManager</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
     <li><a href="#ref-for-idl-sequence③">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-idl-unsigned-long-long①">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-idl-unsigned-long-long②">(2)</a> <a href="#ref-for-idl-unsigned-long-long③">(3)</a> <a href="#ref-for-idl-unsigned-long-long④">(4)</a>
@@ -4251,20 +4251,20 @@ complete-length = ( 1*DIGIT / "*" )</pre>
    <div class="issue"> Parsing as an integer <a href="https://github.com/whatwg/infra/issues/189">infra/189</a>. <a class="issue-return" href="#issue-cddfe468" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/ServiceWorker/pull/1348">ServiceWorker/1348</a>. <a class="issue-return" href="#issue-b420dc4f①" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="temporarily-unavailable">
-   <b><a href="#temporarily-unavailable">#temporarily-unavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-temporarily-unavailable" class="dfn-panel" data-for="temporarily-unavailable" id="infopanel-for-temporarily-unavailable" role="dialog">
+   <span id="infopaneltitle-for-temporarily-unavailable" style="display:none">Info about the 'temporarily unavailable' definition.</span><b><a href="#temporarily-unavailable">#temporarily-unavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-temporarily-unavailable">4.2. Complete a record</a> <a href="#ref-for-temporarily-unavailable①">(2)</a> <a href="#ref-for-temporarily-unavailable②">(3)</a> <a href="#ref-for-temporarily-unavailable③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-task-source">
-   <b><a href="#background-fetch-task-source">#background-fetch-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-task-source" class="dfn-panel" data-for="background-fetch-task-source" id="infopanel-for-background-fetch-task-source" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-task-source" style="display:none">Info about the 'background fetch task source' definition.</span><b><a href="#background-fetch-task-source">#background-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-task-source">3. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-bgfetch-task">
-   <b><a href="#queue-a-bgfetch-task">#queue-a-bgfetch-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-bgfetch-task" class="dfn-panel" data-for="queue-a-bgfetch-task" id="infopanel-for-queue-a-bgfetch-task" role="dialog">
+   <span id="infopaneltitle-for-queue-a-bgfetch-task" style="display:none">Info about the 'queue a bgfetch task' definition.</span><b><a href="#queue-a-bgfetch-task">#queue-a-bgfetch-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-bgfetch-task">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-queue-a-bgfetch-task①">6.3.1. fetch()</a>
@@ -4272,8 +4272,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-queue-a-bgfetch-task③">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-active-background-fetches">
-   <b><a href="#service-worker-registration-active-background-fetches">#service-worker-registration-active-background-fetches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-active-background-fetches" class="dfn-panel" data-for="service-worker-registration-active-background-fetches" id="infopanel-for-service-worker-registration-active-background-fetches" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-active-background-fetches" style="display:none">Info about the 'Active background fetches' definition.</span><b><a href="#service-worker-registration-active-background-fetches">#service-worker-registration-active-background-fetches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches①">6.3.1. fetch()</a>
@@ -4282,16 +4282,16 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches④">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-active-background-fetches-edit-queue">
-   <b><a href="#service-worker-registration-active-background-fetches-edit-queue">#service-worker-registration-active-background-fetches-edit-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-active-background-fetches-edit-queue" class="dfn-panel" data-for="service-worker-registration-active-background-fetches-edit-queue" id="infopanel-for-service-worker-registration-active-background-fetches-edit-queue" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-active-background-fetches-edit-queue" style="display:none">Info about the 'active background fetches edit queue' definition.</span><b><a href="#service-worker-registration-active-background-fetches-edit-queue">#service-worker-registration-active-background-fetches-edit-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches-edit-queue">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches-edit-queue①">6.3.1. fetch()</a>
     <li><a href="#ref-for-service-worker-registration-active-background-fetches-edit-queue②">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch">
-   <b><a href="#background-fetch">#background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch" class="dfn-panel" data-for="background-fetch" id="infopanel-for-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-background-fetch" style="display:none">Info about the 'background fetch' definition.</span><b><a href="#background-fetch">#background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-background-fetch①">3.2. Background fetch</a> <a href="#ref-for-background-fetch②">(2)</a>
@@ -4310,8 +4310,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch②⓪">8. Privacy and bandwidth usage</a> <a href="#ref-for-background-fetch②①">(2)</a> <a href="#ref-for-background-fetch②②">(3)</a> <a href="#ref-for-background-fetch②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-id">
-   <b><a href="#background-fetch-id">#background-fetch-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-id" class="dfn-panel" data-for="background-fetch-id" id="infopanel-for-background-fetch-id" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-id" style="display:none">Info about the 'id' definition.</span><b><a href="#background-fetch-id">#background-fetch-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-id">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-background-fetch-id①">4.9. Contains background fetch</a>
@@ -4321,8 +4321,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-id⑤">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-records">
-   <b><a href="#background-fetch-records">#background-fetch-records</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-records" class="dfn-panel" data-for="background-fetch-records" id="infopanel-for-background-fetch-records" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-records" style="display:none">Info about the 'Records' definition.</span><b><a href="#background-fetch-records">#background-fetch-records</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-records">3.2. Background fetch</a>
     <li><a href="#ref-for-background-fetch-records①">3.2.1. Display</a>
@@ -4331,16 +4331,16 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-records⑤">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-title">
-   <b><a href="#background-fetch-title">#background-fetch-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-title" class="dfn-panel" data-for="background-fetch-title" id="infopanel-for-background-fetch-title" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-title" style="display:none">Info about the 'title' definition.</span><b><a href="#background-fetch-title">#background-fetch-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-title">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-title①">6.3.1. fetch()</a>
     <li><a href="#ref-for-background-fetch-title②">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-download-total">
-   <b><a href="#background-fetch-download-total">#background-fetch-download-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-download-total" class="dfn-panel" data-for="background-fetch-download-total" id="infopanel-for-background-fetch-download-total" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-download-total" style="display:none">Info about the 'download total' definition.</span><b><a href="#background-fetch-download-total">#background-fetch-download-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-download-total">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-download-total①">4.2. Complete a record</a>
@@ -4348,16 +4348,16 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-download-total③">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-upload-total">
-   <b><a href="#background-fetch-upload-total">#background-fetch-upload-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-upload-total" class="dfn-panel" data-for="background-fetch-upload-total" id="infopanel-for-background-fetch-upload-total" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-upload-total" style="display:none">Info about the 'upload total' definition.</span><b><a href="#background-fetch-upload-total">#background-fetch-upload-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-upload-total">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-upload-total①">6.3.1. fetch()</a>
     <li><a href="#ref-for-background-fetch-upload-total②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-uploaded">
-   <b><a href="#background-fetch-uploaded">#background-fetch-uploaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-uploaded" class="dfn-panel" data-for="background-fetch-uploaded" id="infopanel-for-background-fetch-uploaded" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-uploaded" style="display:none">Info about the 'uploaded' definition.</span><b><a href="#background-fetch-uploaded">#background-fetch-uploaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-uploaded">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-uploaded①">4.2. Complete a record</a>
@@ -4365,8 +4365,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-uploaded③">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-result">
-   <b><a href="#background-fetch-result">#background-fetch-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-result" class="dfn-panel" data-for="background-fetch-result" id="infopanel-for-background-fetch-result" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-result" style="display:none">Info about the 'result' definition.</span><b><a href="#background-fetch-result">#background-fetch-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-result">3.2.1. Display</a> <a href="#ref-for-background-fetch-result①">(2)</a> <a href="#ref-for-background-fetch-result②">(3)</a>
     <li><a href="#ref-for-background-fetch-result③">4.1. Perform a background fetch</a> <a href="#ref-for-background-fetch-result④">(2)</a>
@@ -4374,32 +4374,32 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-result⑥">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-failure-reason">
-   <b><a href="#background-fetch-failure-reason">#background-fetch-failure-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-failure-reason" class="dfn-panel" data-for="background-fetch-failure-reason" id="infopanel-for-background-fetch-failure-reason" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-failure-reason" style="display:none">Info about the 'failure reason' definition.</span><b><a href="#background-fetch-failure-reason">#background-fetch-failure-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-failure-reason">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-background-fetch-failure-reason①">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-background-fetch-failure-reason②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-records-available-flag">
-   <b><a href="#background-fetch-records-available-flag">#background-fetch-records-available-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-records-available-flag" class="dfn-panel" data-for="background-fetch-records-available-flag" id="infopanel-for-background-fetch-records-available-flag" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-records-available-flag" style="display:none">Info about the 'records available flag' definition.</span><b><a href="#background-fetch-records-available-flag">#background-fetch-records-available-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-records-available-flag">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-background-fetch-records-available-flag①">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-background-fetch-records-available-flag②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-icons">
-   <b><a href="#background-fetch-icons">#background-fetch-icons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-icons" class="dfn-panel" data-for="background-fetch-icons" id="infopanel-for-background-fetch-icons" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-icons" style="display:none">Info about the 'Icons' definition.</span><b><a href="#background-fetch-icons">#background-fetch-icons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-icons">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-icons①">6.3.1. fetch()</a>
     <li><a href="#ref-for-background-fetch-icons②">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-service-worker-registration">
-   <b><a href="#background-fetch-service-worker-registration">#background-fetch-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-service-worker-registration" class="dfn-panel" data-for="background-fetch-service-worker-registration" id="infopanel-for-background-fetch-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#background-fetch-service-worker-registration">#background-fetch-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-service-worker-registration">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-service-worker-registration①">4.1. Perform a background fetch</a>
@@ -4410,22 +4410,22 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-service-worker-registration⑥">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-update-handling-queue">
-   <b><a href="#background-fetch-update-handling-queue">#background-fetch-update-handling-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-update-handling-queue" class="dfn-panel" data-for="background-fetch-update-handling-queue" id="infopanel-for-background-fetch-update-handling-queue" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-update-handling-queue" style="display:none">Info about the 'update handling queue' definition.</span><b><a href="#background-fetch-update-handling-queue">#background-fetch-update-handling-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-update-handling-queue">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-background-fetch-update-handling-queue①">6.3.2. get()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-paused-flag">
-   <b><a href="#background-fetch-paused-flag">#background-fetch-paused-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-paused-flag" class="dfn-panel" data-for="background-fetch-paused-flag" id="infopanel-for-background-fetch-paused-flag" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-paused-flag" style="display:none">Info about the 'paused flag' definition.</span><b><a href="#background-fetch-paused-flag">#background-fetch-paused-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-paused-flag">3.2.1. Display</a> <a href="#ref-for-background-fetch-paused-flag①">(2)</a> <a href="#ref-for-background-fetch-paused-flag②">(3)</a> <a href="#ref-for-background-fetch-paused-flag③">(4)</a> <a href="#ref-for-background-fetch-paused-flag④">(5)</a> <a href="#ref-for-background-fetch-paused-flag⑤">(6)</a>
     <li><a href="#ref-for-background-fetch-paused-flag⑥">4.2. Complete a record</a> <a href="#ref-for-background-fetch-paused-flag⑦">(2)</a> <a href="#ref-for-background-fetch-paused-flag⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-abort-all-flag">
-   <b><a href="#background-fetch-abort-all-flag">#background-fetch-abort-all-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-abort-all-flag" class="dfn-panel" data-for="background-fetch-abort-all-flag" id="infopanel-for-background-fetch-abort-all-flag" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-abort-all-flag" style="display:none">Info about the 'abort all flag' definition.</span><b><a href="#background-fetch-abort-all-flag">#background-fetch-abort-all-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-abort-all-flag">3.2.1. Display</a> <a href="#ref-for-background-fetch-abort-all-flag①">(2)</a>
     <li><a href="#ref-for-background-fetch-abort-all-flag②">4.1. Perform a background fetch</a>
@@ -4433,8 +4433,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-abort-all-flag⑤">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-stored-body-bytes-total">
-   <b><a href="#background-fetch-stored-body-bytes-total">#background-fetch-stored-body-bytes-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-stored-body-bytes-total" class="dfn-panel" data-for="background-fetch-stored-body-bytes-total" id="infopanel-for-background-fetch-stored-body-bytes-total" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-stored-body-bytes-total" style="display:none">Info about the 'stored body bytes total' definition.</span><b><a href="#background-fetch-stored-body-bytes-total">#background-fetch-stored-body-bytes-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-stored-body-bytes-total">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-stored-body-bytes-total①">4.2. Complete a record</a>
@@ -4442,8 +4442,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-stored-body-bytes-total③">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-display">
-   <b><a href="#background-fetch-display">#background-fetch-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-display" class="dfn-panel" data-for="background-fetch-display" id="infopanel-for-background-fetch-display" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-display" style="display:none">Info about the 'display' definition.</span><b><a href="#background-fetch-display">#background-fetch-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-display">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-display①">6.3.1. fetch()</a>
@@ -4451,8 +4451,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-display③">8. Privacy and bandwidth usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-record">
-   <b><a href="#background-fetch-record">#background-fetch-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-record" class="dfn-panel" data-for="background-fetch-record" id="infopanel-for-background-fetch-record" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-record" style="display:none">Info about the 'background fetch record' definition.</span><b><a href="#background-fetch-record">#background-fetch-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-record">3.2. Background fetch</a>
     <li><a href="#ref-for-background-fetch-record①">4.2. Complete a record</a> <a href="#ref-for-background-fetch-record②">(2)</a> <a href="#ref-for-background-fetch-record③">(3)</a>
@@ -4460,8 +4460,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-record⑥">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-record-request">
-   <b><a href="#background-fetch-record-request">#background-fetch-record-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-record-request" class="dfn-panel" data-for="background-fetch-record-request" id="infopanel-for-background-fetch-record-request" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-record-request" style="display:none">Info about the 'request' definition.</span><b><a href="#background-fetch-record-request">#background-fetch-record-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-record-request">3.2.1. Display</a>
     <li><a href="#ref-for-background-fetch-record-request①">4.2. Complete a record</a>
@@ -4470,8 +4470,8 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-record-request④">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-record-response-data">
-   <b><a href="#background-fetch-record-response-data">#background-fetch-record-response-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-record-response-data" class="dfn-panel" data-for="background-fetch-record-response-data" id="infopanel-for-background-fetch-record-response-data" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-record-response-data" style="display:none">Info about the 'response data' definition.</span><b><a href="#background-fetch-record-response-data">#background-fetch-record-response-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-record-response-data">3.2. Background fetch</a>
     <li><a href="#ref-for-background-fetch-record-response-data①">4.1. Perform a background fetch</a>
@@ -4480,15 +4480,15 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-record-response-data⑤">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-response">
-   <b><a href="#background-fetch-response">#background-fetch-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-response" class="dfn-panel" data-for="background-fetch-response" id="infopanel-for-background-fetch-response" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-response" style="display:none">Info about the 'Background fetch response' definition.</span><b><a href="#background-fetch-response">#background-fetch-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-response">3.3. Background fetch record</a> <a href="#ref-for-background-fetch-response①">(2)</a>
     <li><a href="#ref-for-background-fetch-response②">4.2. Complete a record</a> <a href="#ref-for-background-fetch-response③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-response-response">
-   <b><a href="#background-fetch-response-response">#background-fetch-response-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-response-response" class="dfn-panel" data-for="background-fetch-response-response" id="infopanel-for-background-fetch-response-response" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-response-response" style="display:none">Info about the 'response' definition.</span><b><a href="#background-fetch-response-response">#background-fetch-response-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-response-response">3.4. Background fetch response</a>
     <li><a href="#ref-for-background-fetch-response-response①">4.2. Complete a record</a> <a href="#ref-for-background-fetch-response-response②">(2)</a>
@@ -4496,16 +4496,16 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-response-response⑤">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-response-bytes">
-   <b><a href="#background-fetch-response-bytes">#background-fetch-response-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-response-bytes" class="dfn-panel" data-for="background-fetch-response-bytes" id="infopanel-for-background-fetch-response-bytes" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-response-bytes" style="display:none">Info about the 'Bytes' definition.</span><b><a href="#background-fetch-response-bytes">#background-fetch-response-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-response-bytes">3.2. Background fetch</a>
     <li><a href="#ref-for-background-fetch-response-bytes①">4.2. Complete a record</a> <a href="#ref-for-background-fetch-response-bytes②">(2)</a> <a href="#ref-for-background-fetch-response-bytes③">(3)</a>
     <li><a href="#ref-for-background-fetch-response-bytes④">4.8. Create record objects</a> <a href="#ref-for-background-fetch-response-bytes⑤">(2)</a> <a href="#ref-for-background-fetch-response-bytes⑥">(3)</a> <a href="#ref-for-background-fetch-response-bytes⑦">(4)</a> <a href="#ref-for-background-fetch-response-bytes⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-response-result">
-   <b><a href="#background-fetch-response-result">#background-fetch-response-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-response-result" class="dfn-panel" data-for="background-fetch-response-result" id="infopanel-for-background-fetch-response-result" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-response-result" style="display:none">Info about the 'result' definition.</span><b><a href="#background-fetch-response-result">#background-fetch-response-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-response-result">3.4. Background fetch response</a>
     <li><a href="#ref-for-background-fetch-response-result①">4.1. Perform a background fetch</a>
@@ -4513,44 +4513,44 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-background-fetch-response-result①④">4.8. Create record objects</a> <a href="#ref-for-background-fetch-response-result①⑤">(2)</a> <a href="#ref-for-background-fetch-response-result①⑥">(3)</a> <a href="#ref-for-background-fetch-response-result①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-response-exposed">
-   <b><a href="#background-fetch-response-exposed">#background-fetch-response-exposed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-response-exposed" class="dfn-panel" data-for="background-fetch-response-exposed" id="infopanel-for-background-fetch-response-exposed" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-response-exposed" style="display:none">Info about the 'exposed' definition.</span><b><a href="#background-fetch-response-exposed">#background-fetch-response-exposed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-response-exposed">4.8. Create record objects</a> <a href="#ref-for-background-fetch-response-exposed①">(2)</a> <a href="#ref-for-background-fetch-response-exposed②">(3)</a> <a href="#ref-for-background-fetch-response-exposed③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="perform-a-background-fetch">
-   <b><a href="#perform-a-background-fetch">#perform-a-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-perform-a-background-fetch" class="dfn-panel" data-for="perform-a-background-fetch" id="infopanel-for-perform-a-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-perform-a-background-fetch" style="display:none">Info about the 'perform a background fetch' definition.</span><b><a href="#perform-a-background-fetch">#perform-a-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-background-fetch">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-perform-a-background-fetch①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complete-a-record">
-   <b><a href="#complete-a-record">#complete-a-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complete-a-record" class="dfn-panel" data-for="complete-a-record" id="infopanel-for-complete-a-record" role="dialog">
+   <span id="infopaneltitle-for-complete-a-record" style="display:none">Info about the 'complete a record' definition.</span><b><a href="#complete-a-record">#complete-a-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complete-a-record">4.1. Perform a background fetch</a> <a href="#ref-for-complete-a-record①">(2)</a>
     <li><a href="#ref-for-complete-a-record②">4.2. Complete a record</a> <a href="#ref-for-complete-a-record③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-background-fetch-instances">
-   <b><a href="#update-background-fetch-instances">#update-background-fetch-instances</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-background-fetch-instances" class="dfn-panel" data-for="update-background-fetch-instances" id="infopanel-for-update-background-fetch-instances" role="dialog">
+   <span id="infopaneltitle-for-update-background-fetch-instances" style="display:none">Info about the 'update background fetch instances' definition.</span><b><a href="#update-background-fetch-instances">#update-background-fetch-instances</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-background-fetch-instances">4.1. Perform a background fetch</a> <a href="#ref-for-update-background-fetch-instances①">(2)</a>
     <li><a href="#ref-for-update-background-fetch-instances②">4.2. Complete a record</a> <a href="#ref-for-update-background-fetch-instances③">(2)</a> <a href="#ref-for-update-background-fetch-instances④">(3)</a>
     <li><a href="#ref-for-update-background-fetch-instances⑤">4.3. Update background fetch instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-background-fetch-click-event">
-   <b><a href="#fire-a-background-fetch-click-event">#fire-a-background-fetch-click-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-background-fetch-click-event" class="dfn-panel" data-for="fire-a-background-fetch-click-event" id="infopanel-for-fire-a-background-fetch-click-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-background-fetch-click-event" style="display:none">Info about the 'fire a background fetch click event' definition.</span><b><a href="#fire-a-background-fetch-click-event">#fire-a-background-fetch-click-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-background-fetch-click-event">3.2.1. Display</a>
     <li><a href="#ref-for-fire-a-background-fetch-click-event①">4.4. Fire a background fetch click event</a>
     <li><a href="#ref-for-fire-a-background-fetch-click-event②">7.1. Click</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-backgroundfetchregistration-instance">
-   <b><a href="#get-a-backgroundfetchregistration-instance">#get-a-backgroundfetchregistration-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-backgroundfetchregistration-instance" class="dfn-panel" data-for="get-a-backgroundfetchregistration-instance" id="infopanel-for-get-a-backgroundfetchregistration-instance" role="dialog">
+   <span id="infopaneltitle-for-get-a-backgroundfetchregistration-instance" style="display:none">Info about the 'get a BackgroundFetchRegistration instance' definition.</span><b><a href="#get-a-backgroundfetchregistration-instance">#get-a-backgroundfetchregistration-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-backgroundfetchregistration-instance">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-get-a-backgroundfetchregistration-instance①">4.3. Update background fetch instances</a>
@@ -4560,125 +4560,125 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-get-a-backgroundfetchregistration-instance⑤">6.3.2. get()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-a-partial-response">
-   <b><a href="#validate-a-partial-response">#validate-a-partial-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-a-partial-response" class="dfn-panel" data-for="validate-a-partial-response" id="infopanel-for-validate-a-partial-response" role="dialog">
+   <span id="infopaneltitle-for-validate-a-partial-response" style="display:none">Info about the 'validate a partial response' definition.</span><b><a href="#validate-a-partial-response">#validate-a-partial-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-a-partial-response">4.2. Complete a record</a>
     <li><a href="#ref-for-validate-a-partial-response①">4.6. Validate a partial response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-content-range-values">
-   <b><a href="#extract-content-range-values">#extract-content-range-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-content-range-values" class="dfn-panel" data-for="extract-content-range-values" id="infopanel-for-extract-content-range-values" role="dialog">
+   <span id="infopaneltitle-for-extract-content-range-values" style="display:none">Info about the 'extract content-range values' definition.</span><b><a href="#extract-content-range-values">#extract-content-range-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-content-range-values">4.2. Complete a record</a>
     <li><a href="#ref-for-extract-content-range-values①">4.6. Validate a partial response</a> <a href="#ref-for-extract-content-range-values②">(2)</a>
     <li><a href="#ref-for-extract-content-range-values③">4.7. Extract content-range values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-record-objects">
-   <b><a href="#create-record-objects">#create-record-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-record-objects" class="dfn-panel" data-for="create-record-objects" id="infopanel-for-create-record-objects" role="dialog">
+   <span id="infopaneltitle-for-create-record-objects" style="display:none">Info about the 'create record objects' definition.</span><b><a href="#create-record-objects">#create-record-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-record-objects">4.2. Complete a record</a>
     <li><a href="#ref-for-create-record-objects①">4.8. Create record objects</a>
     <li><a href="#ref-for-create-record-objects②">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contains-background-fetch">
-   <b><a href="#contains-background-fetch">#contains-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contains-background-fetch" class="dfn-panel" data-for="contains-background-fetch" id="infopanel-for-contains-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-contains-background-fetch" style="display:none">Info about the 'contains background fetch' definition.</span><b><a href="#contains-background-fetch">#contains-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contains-background-fetch">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-contains-background-fetch①">4.9. Contains background fetch</a> <a href="#ref-for-contains-background-fetch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="does-not-contain-background-fetch">
-   <b><a href="#does-not-contain-background-fetch">#does-not-contain-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-does-not-contain-background-fetch" class="dfn-panel" data-for="does-not-contain-background-fetch" id="infopanel-for-does-not-contain-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-does-not-contain-background-fetch" style="display:none">Info about the 'does not contain background fetch' definition.</span><b><a href="#does-not-contain-background-fetch">#does-not-contain-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-does-not-contain-background-fetch">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-byte-content-range">
-   <b><a href="#single-byte-content-range">#single-byte-content-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-byte-content-range" class="dfn-panel" data-for="single-byte-content-range" id="infopanel-for-single-byte-content-range" role="dialog">
+   <span id="infopaneltitle-for-single-byte-content-range" style="display:none">Info about the 'single byte content-range' definition.</span><b><a href="#single-byte-content-range">#single-byte-content-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-byte-content-range">4.7. Extract content-range values</a> <a href="#ref-for-single-byte-content-range①">(2)</a> <a href="#ref-for-single-byte-content-range②">(3)</a> <a href="#ref-for-single-byte-content-range③">(4)</a> <a href="#ref-for-single-byte-content-range④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchsuccess">
-   <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchsuccess">#dom-serviceworkerglobalscope-onbackgroundfetchsuccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchsuccess" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchsuccess" id="infopanel-for-dom-serviceworkerglobalscope-onbackgroundfetchsuccess" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchsuccess" style="display:none">Info about the 'onbackgroundfetchsuccess' definition.</span><b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchsuccess">#dom-serviceworkerglobalscope-onbackgroundfetchsuccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchsuccess">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchfail">
-   <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchfail">#dom-serviceworkerglobalscope-onbackgroundfetchfail</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchfail" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchfail" id="infopanel-for-dom-serviceworkerglobalscope-onbackgroundfetchfail" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchfail" style="display:none">Info about the 'onbackgroundfetchfail' definition.</span><b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchfail">#dom-serviceworkerglobalscope-onbackgroundfetchfail</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchfail">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchabort">
-   <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchabort">#dom-serviceworkerglobalscope-onbackgroundfetchabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchabort" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchabort" id="infopanel-for-dom-serviceworkerglobalscope-onbackgroundfetchabort" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchabort" style="display:none">Info about the 'onbackgroundfetchabort' definition.</span><b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchabort">#dom-serviceworkerglobalscope-onbackgroundfetchabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchabort">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchclick">
-   <b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchclick">#dom-serviceworkerglobalscope-onbackgroundfetchclick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchclick" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onbackgroundfetchclick" id="infopanel-for-dom-serviceworkerglobalscope-onbackgroundfetchclick" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onbackgroundfetchclick" style="display:none">Info about the 'onbackgroundfetchclick' definition.</span><b><a href="#dom-serviceworkerglobalscope-onbackgroundfetchclick">#dom-serviceworkerglobalscope-onbackgroundfetchclick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onbackgroundfetchclick">6.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-background-fetch-manager">
-   <b><a href="#serviceworkerregistration-background-fetch-manager">#serviceworkerregistration-background-fetch-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-background-fetch-manager" class="dfn-panel" data-for="serviceworkerregistration-background-fetch-manager" id="infopanel-for-serviceworkerregistration-background-fetch-manager" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-background-fetch-manager" style="display:none">Info about the 'background fetch manager' definition.</span><b><a href="#serviceworkerregistration-background-fetch-manager">#serviceworkerregistration-background-fetch-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-background-fetch-manager">6.2. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-backgroundfetch">
-   <b><a href="#dom-serviceworkerregistration-backgroundfetch">#dom-serviceworkerregistration-backgroundfetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-backgroundfetch" class="dfn-panel" data-for="dom-serviceworkerregistration-backgroundfetch" id="infopanel-for-dom-serviceworkerregistration-backgroundfetch" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-backgroundfetch" style="display:none">Info about the 'backgroundFetch' definition.</span><b><a href="#dom-serviceworkerregistration-backgroundfetch">#dom-serviceworkerregistration-backgroundfetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-backgroundfetch">6.2. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchmanager">
-   <b><a href="#backgroundfetchmanager">#backgroundfetchmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchmanager" class="dfn-panel" data-for="backgroundfetchmanager" id="infopanel-for-backgroundfetchmanager" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchmanager" style="display:none">Info about the 'BackgroundFetchManager' definition.</span><b><a href="#backgroundfetchmanager">#backgroundfetchmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchmanager">4.5. Get a BackgroundFetchRegistration instance</a> <a href="#ref-for-backgroundfetchmanager①">(2)</a>
     <li><a href="#ref-for-backgroundfetchmanager②">6.2. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-backgroundfetchmanager③">(2)</a> <a href="#ref-for-backgroundfetchmanager④">(3)</a>
     <li><a href="#ref-for-backgroundfetchmanager⑤">6.3. BackgroundFetchManager</a> <a href="#ref-for-backgroundfetchmanager⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-backgroundfetchuioptions">
-   <b><a href="#dictdef-backgroundfetchuioptions">#dictdef-backgroundfetchuioptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-backgroundfetchuioptions" class="dfn-panel" data-for="dictdef-backgroundfetchuioptions" id="infopanel-for-dictdef-backgroundfetchuioptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-backgroundfetchuioptions" style="display:none">Info about the 'BackgroundFetchUIOptions' definition.</span><b><a href="#dictdef-backgroundfetchuioptions">#dictdef-backgroundfetchuioptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundfetchuioptions">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-dictdef-backgroundfetchuioptions①">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchuioptions-icons">
-   <b><a href="#dom-backgroundfetchuioptions-icons">#dom-backgroundfetchuioptions-icons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchuioptions-icons" class="dfn-panel" data-for="dom-backgroundfetchuioptions-icons" id="infopanel-for-dom-backgroundfetchuioptions-icons" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchuioptions-icons" style="display:none">Info about the 'icons' definition.</span><b><a href="#dom-backgroundfetchuioptions-icons">#dom-backgroundfetchuioptions-icons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchuioptions-icons">6.7.1. updateUI()</a> <a href="#ref-for-dom-backgroundfetchuioptions-icons①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchuioptions-title">
-   <b><a href="#dom-backgroundfetchuioptions-title">#dom-backgroundfetchuioptions-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchuioptions-title" class="dfn-panel" data-for="dom-backgroundfetchuioptions-title" id="infopanel-for-dom-backgroundfetchuioptions-title" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchuioptions-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-backgroundfetchuioptions-title">#dom-backgroundfetchuioptions-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchuioptions-title">6.7.1. updateUI()</a> <a href="#ref-for-dom-backgroundfetchuioptions-title①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-backgroundfetchoptions">
-   <b><a href="#dictdef-backgroundfetchoptions">#dictdef-backgroundfetchoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-backgroundfetchoptions" class="dfn-panel" data-for="dictdef-backgroundfetchoptions" id="infopanel-for-dictdef-backgroundfetchoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-backgroundfetchoptions" style="display:none">Info about the 'BackgroundFetchOptions' definition.</span><b><a href="#dictdef-backgroundfetchoptions">#dictdef-backgroundfetchoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundfetchoptions">6.3. BackgroundFetchManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchmanager-backgroundfetchregistration-instances">
-   <b><a href="#backgroundfetchmanager-backgroundfetchregistration-instances">#backgroundfetchmanager-backgroundfetchregistration-instances</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchmanager-backgroundfetchregistration-instances" class="dfn-panel" data-for="backgroundfetchmanager-backgroundfetchregistration-instances" id="infopanel-for-backgroundfetchmanager-backgroundfetchregistration-instances" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchmanager-backgroundfetchregistration-instances" style="display:none">Info about the 'BackgroundFetchRegistration instances' definition.</span><b><a href="#backgroundfetchmanager-backgroundfetchregistration-instances">#backgroundfetchmanager-backgroundfetchregistration-instances</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchmanager-backgroundfetchregistration-instances">4.5. Get a BackgroundFetchRegistration instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchmanager-service-worker-registration">
-   <b><a href="#backgroundfetchmanager-service-worker-registration">#backgroundfetchmanager-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchmanager-service-worker-registration" class="dfn-panel" data-for="backgroundfetchmanager-service-worker-registration" id="infopanel-for-backgroundfetchmanager-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchmanager-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#backgroundfetchmanager-service-worker-registration">#backgroundfetchmanager-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchmanager-service-worker-registration">6.2. Extensions to ServiceWorkerRegistration</a>
     <li><a href="#ref-for-backgroundfetchmanager-service-worker-registration①">6.3.1. fetch()</a>
@@ -4686,29 +4686,29 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-backgroundfetchmanager-service-worker-registration③">6.3.3. getIds()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-fetch">
-   <b><a href="#dom-backgroundfetchmanager-fetch">#dom-backgroundfetchmanager-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchmanager-fetch" class="dfn-panel" data-for="dom-backgroundfetchmanager-fetch" id="infopanel-for-dom-backgroundfetchmanager-fetch" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchmanager-fetch" style="display:none">Info about the 'fetch(id, requests, options)' definition.</span><b><a href="#dom-backgroundfetchmanager-fetch">#dom-backgroundfetchmanager-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch①">6.3.1. fetch()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-get">
-   <b><a href="#dom-backgroundfetchmanager-get">#dom-backgroundfetchmanager-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchmanager-get" class="dfn-panel" data-for="dom-backgroundfetchmanager-get" id="infopanel-for-dom-backgroundfetchmanager-get" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchmanager-get" style="display:none">Info about the 'get(id)' definition.</span><b><a href="#dom-backgroundfetchmanager-get">#dom-backgroundfetchmanager-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchmanager-get">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-dom-backgroundfetchmanager-get①">6.3.2. get()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchmanager-getids">
-   <b><a href="#dom-backgroundfetchmanager-getids">#dom-backgroundfetchmanager-getids</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchmanager-getids" class="dfn-panel" data-for="dom-backgroundfetchmanager-getids" id="infopanel-for-dom-backgroundfetchmanager-getids" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchmanager-getids" style="display:none">Info about the 'getIds()' definition.</span><b><a href="#dom-backgroundfetchmanager-getids">#dom-backgroundfetchmanager-getids</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchmanager-getids">6.3. BackgroundFetchManager</a>
     <li><a href="#ref-for-dom-backgroundfetchmanager-getids①">6.3.3. getIds()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration">
-   <b><a href="#backgroundfetchregistration">#backgroundfetchregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration" class="dfn-panel" data-for="backgroundfetchregistration" id="infopanel-for-backgroundfetchregistration" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration" style="display:none">Info about the 'BackgroundFetchRegistration' definition.</span><b><a href="#backgroundfetchregistration">#backgroundfetchregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-backgroundfetchregistration①">4.5. Get a BackgroundFetchRegistration instance</a> <a href="#ref-for-backgroundfetchregistration②">(2)</a>
@@ -4718,23 +4718,23 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-backgroundfetchregistration⑨">6.6. BackgroundFetchEvent</a> <a href="#ref-for-backgroundfetchregistration①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-backgroundfetchresult">
-   <b><a href="#enumdef-backgroundfetchresult">#enumdef-backgroundfetchresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-backgroundfetchresult" class="dfn-panel" data-for="enumdef-backgroundfetchresult" id="infopanel-for-enumdef-backgroundfetchresult" role="dialog">
+   <span id="infopaneltitle-for-enumdef-backgroundfetchresult" style="display:none">Info about the 'BackgroundFetchResult' definition.</span><b><a href="#enumdef-backgroundfetchresult">#enumdef-backgroundfetchresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-backgroundfetchresult">3.2. Background fetch</a>
     <li><a href="#ref-for-enumdef-backgroundfetchresult①">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-enumdef-backgroundfetchresult②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-backgroundfetchfailurereason">
-   <b><a href="#enumdef-backgroundfetchfailurereason">#enumdef-backgroundfetchfailurereason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-backgroundfetchfailurereason" class="dfn-panel" data-for="enumdef-backgroundfetchfailurereason" id="infopanel-for-enumdef-backgroundfetchfailurereason" role="dialog">
+   <span id="infopaneltitle-for-enumdef-backgroundfetchfailurereason" style="display:none">Info about the 'BackgroundFetchFailureReason' definition.</span><b><a href="#enumdef-backgroundfetchfailurereason">#enumdef-backgroundfetchfailurereason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-backgroundfetchfailurereason">3.2. Background fetch</a>
     <li><a href="#ref-for-enumdef-backgroundfetchfailurereason①">3.4. Background fetch response</a>
     <li><a href="#ref-for-enumdef-backgroundfetchfailurereason②">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-enumdef-backgroundfetchfailurereason③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-background-fetch">
-   <b><a href="#backgroundfetchregistration-background-fetch">#backgroundfetchregistration-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-background-fetch" class="dfn-panel" data-for="backgroundfetchregistration-background-fetch" id="infopanel-for-backgroundfetchregistration-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-background-fetch" style="display:none">Info about the 'background fetch' definition.</span><b><a href="#backgroundfetchregistration-background-fetch">#backgroundfetchregistration-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-background-fetch">4.3. Update background fetch instances</a>
     <li><a href="#ref-for-backgroundfetchregistration-background-fetch①">4.5. Get a BackgroundFetchRegistration instance</a>
@@ -4744,180 +4744,180 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-backgroundfetchregistration-background-fetch①②">6.6. BackgroundFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-downloaded">
-   <b><a href="#backgroundfetchregistration-downloaded">#backgroundfetchregistration-downloaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-downloaded" class="dfn-panel" data-for="backgroundfetchregistration-downloaded" id="infopanel-for-backgroundfetchregistration-downloaded" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-downloaded" style="display:none">Info about the 'downloaded' definition.</span><b><a href="#backgroundfetchregistration-downloaded">#backgroundfetchregistration-downloaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-downloaded">4.3. Update background fetch instances</a> <a href="#ref-for-backgroundfetchregistration-downloaded①">(2)</a>
     <li><a href="#ref-for-backgroundfetchregistration-downloaded②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-uploaded">
-   <b><a href="#backgroundfetchregistration-uploaded">#backgroundfetchregistration-uploaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-uploaded" class="dfn-panel" data-for="backgroundfetchregistration-uploaded" id="infopanel-for-backgroundfetchregistration-uploaded" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-uploaded" style="display:none">Info about the 'uploaded' definition.</span><b><a href="#backgroundfetchregistration-uploaded">#backgroundfetchregistration-uploaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-uploaded">4.3. Update background fetch instances</a> <a href="#ref-for-backgroundfetchregistration-uploaded①">(2)</a>
     <li><a href="#ref-for-backgroundfetchregistration-uploaded②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-result">
-   <b><a href="#backgroundfetchregistration-result">#backgroundfetchregistration-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-result" class="dfn-panel" data-for="backgroundfetchregistration-result" id="infopanel-for-backgroundfetchregistration-result" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-result" style="display:none">Info about the 'result' definition.</span><b><a href="#backgroundfetchregistration-result">#backgroundfetchregistration-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-result">4.3. Update background fetch instances</a> <a href="#ref-for-backgroundfetchregistration-result①">(2)</a> <a href="#ref-for-backgroundfetchregistration-result②">(3)</a>
     <li><a href="#ref-for-backgroundfetchregistration-result③">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-failure-reason">
-   <b><a href="#backgroundfetchregistration-failure-reason">#backgroundfetchregistration-failure-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-failure-reason" class="dfn-panel" data-for="backgroundfetchregistration-failure-reason" id="infopanel-for-backgroundfetchregistration-failure-reason" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-failure-reason" style="display:none">Info about the 'failure reason' definition.</span><b><a href="#backgroundfetchregistration-failure-reason">#backgroundfetchregistration-failure-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-failure-reason">4.3. Update background fetch instances</a> <a href="#ref-for-backgroundfetchregistration-failure-reason①">(2)</a>
     <li><a href="#ref-for-backgroundfetchregistration-failure-reason②">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-id">
-   <b><a href="#backgroundfetchregistration-id">#backgroundfetchregistration-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-id" class="dfn-panel" data-for="backgroundfetchregistration-id" id="infopanel-for-backgroundfetchregistration-id" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-id" style="display:none">Info about the 'id' definition.</span><b><a href="#backgroundfetchregistration-id">#backgroundfetchregistration-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-id">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-upload-total">
-   <b><a href="#backgroundfetchregistration-upload-total">#backgroundfetchregistration-upload-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-upload-total" class="dfn-panel" data-for="backgroundfetchregistration-upload-total" id="infopanel-for-backgroundfetchregistration-upload-total" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-upload-total" style="display:none">Info about the 'upload total' definition.</span><b><a href="#backgroundfetchregistration-upload-total">#backgroundfetchregistration-upload-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-upload-total">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-download-total">
-   <b><a href="#backgroundfetchregistration-download-total">#backgroundfetchregistration-download-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-download-total" class="dfn-panel" data-for="backgroundfetchregistration-download-total" id="infopanel-for-backgroundfetchregistration-download-total" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-download-total" style="display:none">Info about the 'download total' definition.</span><b><a href="#backgroundfetchregistration-download-total">#backgroundfetchregistration-download-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-download-total">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchregistration-records-available-flag">
-   <b><a href="#backgroundfetchregistration-records-available-flag">#backgroundfetchregistration-records-available-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchregistration-records-available-flag" class="dfn-panel" data-for="backgroundfetchregistration-records-available-flag" id="infopanel-for-backgroundfetchregistration-records-available-flag" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchregistration-records-available-flag" style="display:none">Info about the 'records available flag' definition.</span><b><a href="#backgroundfetchregistration-records-available-flag">#backgroundfetchregistration-records-available-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchregistration-records-available-flag">4.3. Update background fetch instances</a> <a href="#ref-for-backgroundfetchregistration-records-available-flag①">(2)</a>
     <li><a href="#ref-for-backgroundfetchregistration-records-available-flag②">6.4. BackgroundFetchRegistration</a>
     <li><a href="#ref-for-backgroundfetchregistration-records-available-flag③">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-id">
-   <b><a href="#dom-backgroundfetchregistration-id">#dom-backgroundfetchregistration-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-id" class="dfn-panel" data-for="dom-backgroundfetchregistration-id" id="infopanel-for-dom-backgroundfetchregistration-id" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-backgroundfetchregistration-id">#dom-backgroundfetchregistration-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-id">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-uploadtotal">
-   <b><a href="#dom-backgroundfetchregistration-uploadtotal">#dom-backgroundfetchregistration-uploadtotal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-uploadtotal" class="dfn-panel" data-for="dom-backgroundfetchregistration-uploadtotal" id="infopanel-for-dom-backgroundfetchregistration-uploadtotal" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-uploadtotal" style="display:none">Info about the 'uploadTotal' definition.</span><b><a href="#dom-backgroundfetchregistration-uploadtotal">#dom-backgroundfetchregistration-uploadtotal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-uploadtotal">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-downloadtotal">
-   <b><a href="#dom-backgroundfetchregistration-downloadtotal">#dom-backgroundfetchregistration-downloadtotal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-downloadtotal" class="dfn-panel" data-for="dom-backgroundfetchregistration-downloadtotal" id="infopanel-for-dom-backgroundfetchregistration-downloadtotal" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-downloadtotal" style="display:none">Info about the 'downloadTotal' definition.</span><b><a href="#dom-backgroundfetchregistration-downloadtotal">#dom-backgroundfetchregistration-downloadtotal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-downloadtotal">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-uploaded">
-   <b><a href="#dom-backgroundfetchregistration-uploaded">#dom-backgroundfetchregistration-uploaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-uploaded" class="dfn-panel" data-for="dom-backgroundfetchregistration-uploaded" id="infopanel-for-dom-backgroundfetchregistration-uploaded" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-uploaded" style="display:none">Info about the 'uploaded' definition.</span><b><a href="#dom-backgroundfetchregistration-uploaded">#dom-backgroundfetchregistration-uploaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-uploaded">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-downloaded">
-   <b><a href="#dom-backgroundfetchregistration-downloaded">#dom-backgroundfetchregistration-downloaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-downloaded" class="dfn-panel" data-for="dom-backgroundfetchregistration-downloaded" id="infopanel-for-dom-backgroundfetchregistration-downloaded" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-downloaded" style="display:none">Info about the 'downloaded' definition.</span><b><a href="#dom-backgroundfetchregistration-downloaded">#dom-backgroundfetchregistration-downloaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-downloaded">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-result">
-   <b><a href="#dom-backgroundfetchregistration-result">#dom-backgroundfetchregistration-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-result" class="dfn-panel" data-for="dom-backgroundfetchregistration-result" id="infopanel-for-dom-backgroundfetchregistration-result" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-result" style="display:none">Info about the 'result' definition.</span><b><a href="#dom-backgroundfetchregistration-result">#dom-backgroundfetchregistration-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-result">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-failurereason">
-   <b><a href="#dom-backgroundfetchregistration-failurereason">#dom-backgroundfetchregistration-failurereason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-failurereason" class="dfn-panel" data-for="dom-backgroundfetchregistration-failurereason" id="infopanel-for-dom-backgroundfetchregistration-failurereason" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-failurereason" style="display:none">Info about the 'failureReason' definition.</span><b><a href="#dom-backgroundfetchregistration-failurereason">#dom-backgroundfetchregistration-failurereason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-failurereason">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-recordsavailable">
-   <b><a href="#dom-backgroundfetchregistration-recordsavailable">#dom-backgroundfetchregistration-recordsavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-recordsavailable" class="dfn-panel" data-for="dom-backgroundfetchregistration-recordsavailable" id="infopanel-for-dom-backgroundfetchregistration-recordsavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-recordsavailable" style="display:none">Info about the 'recordsAvailable' definition.</span><b><a href="#dom-backgroundfetchregistration-recordsavailable">#dom-backgroundfetchregistration-recordsavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-recordsavailable">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-onprogress">
-   <b><a href="#dom-backgroundfetchregistration-onprogress">#dom-backgroundfetchregistration-onprogress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-onprogress" class="dfn-panel" data-for="dom-backgroundfetchregistration-onprogress" id="infopanel-for-dom-backgroundfetchregistration-onprogress" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-onprogress" style="display:none">Info about the 'onprogress' definition.</span><b><a href="#dom-backgroundfetchregistration-onprogress">#dom-backgroundfetchregistration-onprogress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-onprogress">6.4. BackgroundFetchRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-backgroundfetchregistration-progress">
-   <b><a href="#eventdef-backgroundfetchregistration-progress">#eventdef-backgroundfetchregistration-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-backgroundfetchregistration-progress" class="dfn-panel" data-for="eventdef-backgroundfetchregistration-progress" id="infopanel-for-eventdef-backgroundfetchregistration-progress" role="dialog">
+   <span id="infopaneltitle-for-eventdef-backgroundfetchregistration-progress" style="display:none">Info about the 'progress' definition.</span><b><a href="#eventdef-backgroundfetchregistration-progress">#eventdef-backgroundfetchregistration-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-backgroundfetchregistration-progress">6.3.2. get()</a>
     <li><a href="#ref-for-eventdef-backgroundfetchregistration-progress①">6.4.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-abort">
-   <b><a href="#dom-backgroundfetchregistration-abort">#dom-backgroundfetchregistration-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-abort" class="dfn-panel" data-for="dom-backgroundfetchregistration-abort" id="infopanel-for-dom-backgroundfetchregistration-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-backgroundfetchregistration-abort">#dom-backgroundfetchregistration-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-abort">4.1. Perform a background fetch</a> <a href="#ref-for-dom-backgroundfetchregistration-abort①">(2)</a>
     <li><a href="#ref-for-dom-backgroundfetchregistration-abort②">6.4. BackgroundFetchRegistration</a>
     <li><a href="#ref-for-dom-backgroundfetchregistration-abort③">6.4.2. abort()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-match">
-   <b><a href="#dom-backgroundfetchregistration-match">#dom-backgroundfetchregistration-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-match" class="dfn-panel" data-for="dom-backgroundfetchregistration-match" id="infopanel-for-dom-backgroundfetchregistration-match" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-match" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#dom-backgroundfetchregistration-match">#dom-backgroundfetchregistration-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-match">6.4. BackgroundFetchRegistration</a>
     <li><a href="#ref-for-dom-backgroundfetchregistration-match①">6.4.3. match()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchregistration-matchall">
-   <b><a href="#dom-backgroundfetchregistration-matchall">#dom-backgroundfetchregistration-matchall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchregistration-matchall" class="dfn-panel" data-for="dom-backgroundfetchregistration-matchall" id="infopanel-for-dom-backgroundfetchregistration-matchall" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchregistration-matchall" style="display:none">Info about the 'matchAll(request, options)' definition.</span><b><a href="#dom-backgroundfetchregistration-matchall">#dom-backgroundfetchregistration-matchall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchregistration-matchall">6.4. BackgroundFetchRegistration</a>
     <li><a href="#ref-for-dom-backgroundfetchregistration-matchall①">6.4.3. match()</a> <a href="#ref-for-dom-backgroundfetchregistration-matchall②">(2)</a>
     <li><a href="#ref-for-dom-backgroundfetchregistration-matchall③">6.4.4. matchAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchrecord">
-   <b><a href="#backgroundfetchrecord">#backgroundfetchrecord</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchrecord" class="dfn-panel" data-for="backgroundfetchrecord" id="infopanel-for-backgroundfetchrecord" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchrecord" style="display:none">Info about the 'BackgroundFetchRecord' definition.</span><b><a href="#backgroundfetchrecord">#backgroundfetchrecord</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchrecord">4.8. Create record objects</a>
     <li><a href="#ref-for-backgroundfetchrecord①">6.4. BackgroundFetchRegistration</a> <a href="#ref-for-backgroundfetchrecord②">(2)</a>
     <li><a href="#ref-for-backgroundfetchrecord③">6.5. BackgroundFetchRecord</a> <a href="#ref-for-backgroundfetchrecord④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchrecord-request">
-   <b><a href="#backgroundfetchrecord-request">#backgroundfetchrecord-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchrecord-request" class="dfn-panel" data-for="backgroundfetchrecord-request" id="infopanel-for-backgroundfetchrecord-request" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchrecord-request" style="display:none">Info about the 'request' definition.</span><b><a href="#backgroundfetchrecord-request">#backgroundfetchrecord-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchrecord-request">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchrecord-response-promise">
-   <b><a href="#backgroundfetchrecord-response-promise">#backgroundfetchrecord-response-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchrecord-response-promise" class="dfn-panel" data-for="backgroundfetchrecord-response-promise" id="infopanel-for-backgroundfetchrecord-response-promise" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchrecord-response-promise" style="display:none">Info about the 'response promise' definition.</span><b><a href="#backgroundfetchrecord-response-promise">#backgroundfetchrecord-response-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchrecord-response-promise">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchrecord-request">
-   <b><a href="#dom-backgroundfetchrecord-request">#dom-backgroundfetchrecord-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchrecord-request" class="dfn-panel" data-for="dom-backgroundfetchrecord-request" id="infopanel-for-dom-backgroundfetchrecord-request" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchrecord-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-backgroundfetchrecord-request">#dom-backgroundfetchrecord-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchrecord-request">4.8. Create record objects</a>
     <li><a href="#ref-for-dom-backgroundfetchrecord-request①">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchrecord-responseready">
-   <b><a href="#dom-backgroundfetchrecord-responseready">#dom-backgroundfetchrecord-responseready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchrecord-responseready" class="dfn-panel" data-for="dom-backgroundfetchrecord-responseready" id="infopanel-for-dom-backgroundfetchrecord-responseready" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchrecord-responseready" style="display:none">Info about the 'responseReady' definition.</span><b><a href="#dom-backgroundfetchrecord-responseready">#dom-backgroundfetchrecord-responseready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchrecord-responseready">4.8. Create record objects</a> <a href="#ref-for-dom-backgroundfetchrecord-responseready①">(2)</a> <a href="#ref-for-dom-backgroundfetchrecord-responseready②">(3)</a> <a href="#ref-for-dom-backgroundfetchrecord-responseready③">(4)</a>
     <li><a href="#ref-for-dom-backgroundfetchrecord-responseready④">6.5. BackgroundFetchRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchevent">
-   <b><a href="#backgroundfetchevent">#backgroundfetchevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchevent" class="dfn-panel" data-for="backgroundfetchevent" id="infopanel-for-backgroundfetchevent" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchevent" style="display:none">Info about the 'BackgroundFetchEvent' definition.</span><b><a href="#backgroundfetchevent">#backgroundfetchevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchevent">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-backgroundfetchevent①">4.4. Fire a background fetch click event</a>
@@ -4926,109 +4926,165 @@ complete-length = ( 1*DIGIT / "*" )</pre>
     <li><a href="#ref-for-backgroundfetchevent⑥">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-backgroundfetcheventinit">
-   <b><a href="#dictdef-backgroundfetcheventinit">#dictdef-backgroundfetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-backgroundfetcheventinit" class="dfn-panel" data-for="dictdef-backgroundfetcheventinit" id="infopanel-for-dictdef-backgroundfetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-backgroundfetcheventinit" style="display:none">Info about the 'BackgroundFetchEventInit' definition.</span><b><a href="#dictdef-backgroundfetcheventinit">#dictdef-backgroundfetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundfetcheventinit">6.6. BackgroundFetchEvent</a>
     <li><a href="#ref-for-dictdef-backgroundfetcheventinit①">6.7. BackgroundFetchUpdateUIEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchevent-background-fetch">
-   <b><a href="#backgroundfetchevent-background-fetch">#backgroundfetchevent-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchevent-background-fetch" class="dfn-panel" data-for="backgroundfetchevent-background-fetch" id="infopanel-for-backgroundfetchevent-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchevent-background-fetch" style="display:none">Info about the 'background fetch' definition.</span><b><a href="#backgroundfetchevent-background-fetch">#backgroundfetchevent-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchevent-background-fetch">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchevent-registration">
-   <b><a href="#dom-backgroundfetchevent-registration">#dom-backgroundfetchevent-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchevent-registration" class="dfn-panel" data-for="dom-backgroundfetchevent-registration" id="infopanel-for-dom-backgroundfetchevent-registration" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchevent-registration" style="display:none">Info about the 'registration' definition.</span><b><a href="#dom-backgroundfetchevent-registration">#dom-backgroundfetchevent-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchevent-registration">4.1. Perform a background fetch</a>
     <li><a href="#ref-for-dom-backgroundfetchevent-registration①">4.4. Fire a background fetch click event</a>
     <li><a href="#ref-for-dom-backgroundfetchevent-registration②">6.6. BackgroundFetchEvent</a> <a href="#ref-for-dom-backgroundfetchevent-registration③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchupdateuievent">
-   <b><a href="#backgroundfetchupdateuievent">#backgroundfetchupdateuievent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchupdateuievent" class="dfn-panel" data-for="backgroundfetchupdateuievent" id="infopanel-for-backgroundfetchupdateuievent" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchupdateuievent" style="display:none">Info about the 'BackgroundFetchUpdateUIEvent' definition.</span><b><a href="#backgroundfetchupdateuievent">#backgroundfetchupdateuievent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchupdateuievent">4.1. Perform a background fetch</a> <a href="#ref-for-backgroundfetchupdateuievent①">(2)</a>
     <li><a href="#ref-for-backgroundfetchupdateuievent②">6.1.1. Events</a> <a href="#ref-for-backgroundfetchupdateuievent③">(2)</a>
     <li><a href="#ref-for-backgroundfetchupdateuievent④">6.7. BackgroundFetchUpdateUIEvent</a> <a href="#ref-for-backgroundfetchupdateuievent⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backgroundfetchupdateuievent-ui-updated-flag">
-   <b><a href="#backgroundfetchupdateuievent-ui-updated-flag">#backgroundfetchupdateuievent-ui-updated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backgroundfetchupdateuievent-ui-updated-flag" class="dfn-panel" data-for="backgroundfetchupdateuievent-ui-updated-flag" id="infopanel-for-backgroundfetchupdateuievent-ui-updated-flag" role="dialog">
+   <span id="infopaneltitle-for-backgroundfetchupdateuievent-ui-updated-flag" style="display:none">Info about the 'UI updated flag' definition.</span><b><a href="#backgroundfetchupdateuievent-ui-updated-flag">#backgroundfetchupdateuievent-ui-updated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchupdateuievent-ui-updated-flag">6.7.1. updateUI()</a> <a href="#ref-for-backgroundfetchupdateuievent-ui-updated-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundfetchupdateuievent-updateui">
-   <b><a href="#dom-backgroundfetchupdateuievent-updateui">#dom-backgroundfetchupdateuievent-updateui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundfetchupdateuievent-updateui" class="dfn-panel" data-for="dom-backgroundfetchupdateuievent-updateui" id="infopanel-for-dom-backgroundfetchupdateuievent-updateui" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundfetchupdateuievent-updateui" style="display:none">Info about the 'updateUI(options)' definition.</span><b><a href="#dom-backgroundfetchupdateuievent-updateui">#dom-backgroundfetchupdateuievent-updateui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchupdateuievent-updateui">6.7. BackgroundFetchUpdateUIEvent</a>
     <li><a href="#ref-for-dom-backgroundfetchupdateuievent-updateui①">6.7.1. updateUI()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-fetch-click">
-   <b><a href="#background-fetch-click">#background-fetch-click</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-fetch-click" class="dfn-panel" data-for="background-fetch-click" id="infopanel-for-background-fetch-click" role="dialog">
+   <span id="infopaneltitle-for-background-fetch-click" style="display:none">Info about the 'background fetch click' definition.</span><b><a href="#background-fetch-click">#background-fetch-click</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch-click">7.1. Click</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/background-sync/spec/PeriodicBackgroundSync-index.html
+++ b/tests/github/WICG/background-sync/spec/PeriodicBackgroundSync-index.html
@@ -1537,174 +1537,174 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
    <li><a href="#periodic-sync-scheduler-time-of-last-fire">time of last fire</a><span>, in § 4.2</span>
    <li><a href="#dom-periodicsyncmanager-unregister">unregister(tag)</a><span>, in § 9.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-backgroundfetchmanager">
-   <a href="https://wicg.github.io/background-fetch/#backgroundfetchmanager">https://wicg.github.io/background-fetch/#backgroundfetchmanager</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-backgroundfetchmanager" class="dfn-panel" data-for="term-for-backgroundfetchmanager" id="infopanel-for-term-for-backgroundfetchmanager" role="menu">
+   <span id="infopaneltitle-for-term-for-backgroundfetchmanager" style="display:none">Info about the 'BackgroundFetchManager' external reference.</span><a href="https://wicg.github.io/background-fetch/#backgroundfetchmanager">https://wicg.github.io/background-fetch/#backgroundfetchmanager</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchmanager">7. Resource Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-fetch">
-   <a href="https://wicg.github.io/background-fetch/#background-fetch">https://wicg.github.io/background-fetch/#background-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-fetch" class="dfn-panel" data-for="term-for-background-fetch" id="infopanel-for-term-for-background-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-background-fetch" style="display:none">Info about the 'background fetch' external reference.</span><a href="https://wicg.github.io/background-fetch/#background-fetch">https://wicg.github.io/background-fetch/#background-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch">7. Resource Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">9.1. Extensions to the ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">8.2. Respond to permission revocation</a>
     <li><a href="#ref-for-enqueue-the-following-steps②">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-enqueue-the-following-steps③">(2)</a> <a href="#ref-for-enqueue-the-following-steps④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-in-parallel①">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">3. Extensions to service worker registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">8.1. Process periodic sync registrations</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-ordered-map①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-ordered-map②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissiondescriptor①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate" class="dfn-panel" data-for="term-for-dom-permissionstate" id="infopanel-for-term-for-dom-permissionstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate" style="display:none">Info about the 'PermissionState' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissionstate①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissionstate-granted①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cache">
-   <a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cache" class="dfn-panel" data-for="term-for-cache" id="infopanel-for-term-for-cache" role="menu">
+   <span id="infopaneltitle-for-term-for-cache" style="display:none">Info about the 'Cache' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">6. Security Considerations</a>
     <li><a href="#ref-for-extendableevent①">9.4. The periodicsync event</a>
     <li><a href="#ref-for-extendableevent②">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">9.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">9.1. Extensions to the ServiceWorkerGlobalScope interface</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">9.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent-extend-lifetime-promises">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises">https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent-extend-lifetime-promises" class="dfn-panel" data-for="term-for-extendableevent-extend-lifetime-promises" id="infopanel-for-term-for-extendableevent-extend-lifetime-promises" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises">https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type" id="infopanel-for-term-for-dfn-service-worker-client-frame-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-client-origin">
-   <a href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin">https://w3c.github.io/ServiceWorker/#service-worker-client-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-client-origin" class="dfn-panel" data-for="term-for-service-worker-client-origin" id="infopanel-for-term-for-service-worker-client-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-client-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin">https://w3c.github.io/ServiceWorker/#service-worker-client-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-origin">2. Concepts</a>
     <li><a href="#ref-for-service-worker-client-origin①">4.1. Periodic sync registration</a>
@@ -1719,22 +1719,22 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-service-worker-client-origin②⑧">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker" class="dfn-panel" data-for="term-for-dfn-service-worker" id="infopanel-for-term-for-dfn-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1.1. Example</a>
     <li><a href="#ref-for-dfn-service-worker①">6. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client" class="dfn-panel" data-for="term-for-dfn-service-worker-client" id="infopanel-for-term-for-dfn-service-worker-client" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration" class="dfn-panel" data-for="term-for-dfn-service-worker-registration" id="infopanel-for-term-for-dfn-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">4.1. Periodic sync registration</a>
@@ -1743,20 +1743,20 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-dfn-service-worker-registration④">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent-timed-out-flag">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent-timed-out-flag">https://w3c.github.io/ServiceWorker/#extendableevent-timed-out-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent-timed-out-flag" class="dfn-panel" data-for="term-for-extendableevent-timed-out-flag" id="infopanel-for-term-for-extendableevent-timed-out-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent-timed-out-flag" style="display:none">Info about the 'timed out flag' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent-timed-out-flag">https://w3c.github.io/ServiceWorker/#extendableevent-timed-out-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-timed-out-flag">6. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration-unregistered">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration-unregistered" class="dfn-panel" data-for="term-for-dfn-service-worker-registration-unregistered" id="infopanel-for-term-for-dfn-service-worker-registration-unregistered" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration-unregistered" style="display:none">Info about the 'unregistered' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered">8.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-idl-DOMString①">4.1. Periodic sync registration</a>
@@ -1764,88 +1764,88 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-idl-DOMString⑤">9.4. The periodicsync event</a> <a href="#ref-for-idl-DOMString⑥">(2)</a> <a href="#ref-for-idl-DOMString⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">9.2. Extensions to the ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-Exposed①">9.3. PeriodicSyncManager interface</a>
     <li><a href="#ref-for-Exposed②">9.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wait-for-all">
-   <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wait-for-all" class="dfn-panel" data-for="term-for-wait-for-all" id="infopanel-for-term-for-wait-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-wait-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">9.4.1. Fire a periodicsync event</a>
    </ul>
@@ -1974,16 +1974,16 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="periodicsync-event-in-the-background">
-   <b><a href="#periodicsync-event-in-the-background">#periodicsync-event-in-the-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsync-event-in-the-background" class="dfn-panel" data-for="periodicsync-event-in-the-background" id="infopanel-for-periodicsync-event-in-the-background" role="dialog">
+   <span id="infopaneltitle-for-periodicsync-event-in-the-background" style="display:none">Info about the 'in the background' definition.</span><b><a href="#periodicsync-event-in-the-background">#periodicsync-event-in-the-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsync-event-in-the-background">5.2. Location Tracking</a>
     <li><a href="#ref-for-periodicsync-event-in-the-background①">5.3. History Leaking</a>
     <li><a href="#ref-for-periodicsync-event-in-the-background②">6. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-periodic-sync-registrations">
-   <b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-periodic-sync-registrations" class="dfn-panel" data-for="active-periodic-sync-registrations" id="infopanel-for-active-periodic-sync-registrations" role="dialog">
+   <span id="infopaneltitle-for-active-periodic-sync-registrations" style="display:none">Info about the 'Active periodic sync registrations' definition.</span><b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-active-periodic-sync-registrations①">(2)</a>
     <li><a href="#ref-for-active-periodic-sync-registrations②">8.1. Process periodic sync registrations</a>
@@ -1992,16 +1992,16 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-active-periodic-sync-registrations①⓪">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-processing-queue">
-   <b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-processing-queue" class="dfn-panel" data-for="periodic-sync-processing-queue" id="infopanel-for-periodic-sync-processing-queue" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-processing-queue" style="display:none">Info about the 'Periodic sync processing queue' definition.</span><b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-processing-queue">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-processing-queue①">8.2. Respond to permission revocation</a>
     <li><a href="#ref-for-periodic-sync-processing-queue②">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-processing-queue③">(2)</a> <a href="#ref-for-periodic-sync-processing-queue④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration">
-   <b><a href="#periodic-sync-registration">#periodic-sync-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration" class="dfn-panel" data-for="periodic-sync-registration" id="infopanel-for-periodic-sync-registration" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration" style="display:none">Info about the 'periodic sync registration' definition.</span><b><a href="#periodic-sync-registration">#periodic-sync-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration">2. Concepts</a>
     <li><a href="#ref-for-periodic-sync-registration①">3. Extensions to service worker registration</a>
@@ -2016,8 +2016,8 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-periodic-sync-registration①④">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration">
-   <b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-service-worker-registration" class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration" id="infopanel-for-periodic-sync-registration-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration">2. Concepts</a>
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration①">4.2. Periodic Sync Scheduler</a>
@@ -2027,151 +2027,151 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑤">9.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-tag">
-   <b><a href="#periodic-sync-registration-tag">#periodic-sync-registration-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-tag" class="dfn-panel" data-for="periodic-sync-registration-tag" id="infopanel-for-periodic-sync-registration-tag" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#periodic-sync-registration-tag">#periodic-sync-registration-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-tag">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-tag①">(2)</a> <a href="#ref-for-periodic-sync-registration-tag②">(3)</a> <a href="#ref-for-periodic-sync-registration-tag③">(4)</a>
     <li><a href="#ref-for-periodic-sync-registration-tag④">9.4. The periodicsync event</a>
     <li><a href="#ref-for-periodic-sync-registration-tag⑤">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-minimum-interval">
-   <b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-minimum-interval" class="dfn-panel" data-for="periodic-sync-registration-minimum-interval" id="infopanel-for-periodic-sync-registration-minimum-interval" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-minimum-interval" style="display:none">Info about the 'minimum interval' definition.</span><b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval">4.1. Periodic sync registration</a>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval①">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval②">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-minimum-interval③">(2)</a> <a href="#ref-for-periodic-sync-registration-minimum-interval④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-anchor-time">
-   <b><a href="#periodic-sync-registration-anchor-time">#periodic-sync-registration-anchor-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-anchor-time" class="dfn-panel" data-for="periodic-sync-registration-anchor-time" id="infopanel-for-periodic-sync-registration-anchor-time" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-anchor-time" style="display:none">Info about the 'anchor time' definition.</span><b><a href="#periodic-sync-registration-anchor-time">#periodic-sync-registration-anchor-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time①">9.3. PeriodicSyncManager interface</a>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time②">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-state">
-   <b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-state" class="dfn-panel" data-for="periodic-sync-registration-state" id="infopanel-for-periodic-sync-registration-state" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-state" style="display:none">Info about the 'state' definition.</span><b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-state">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-state①">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-state②">(2)</a> <a href="#ref-for-periodic-sync-registration-state③">(3)</a>
     <li><a href="#ref-for-periodic-sync-registration-state④">9.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-state⑤">(2)</a> <a href="#ref-for-periodic-sync-registration-state⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-scheduler">
-   <b><a href="#periodic-sync-scheduler">#periodic-sync-scheduler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-scheduler" class="dfn-panel" data-for="periodic-sync-scheduler" id="infopanel-for-periodic-sync-scheduler" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-scheduler" style="display:none">Info about the 'Periodic Sync Scheduler' definition.</span><b><a href="#periodic-sync-scheduler">#periodic-sync-scheduler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-scheduler">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-periodic-sync-scheduler①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire">
-   <b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-scheduler-time-of-last-fire" class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire" id="infopanel-for-periodic-sync-scheduler-time-of-last-fire" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-scheduler-time-of-last-fire" style="display:none">Info about the 'time of last fire' definition.</span><b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire①">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-minimum-sync-interval-for-origin">
-   <b><a href="#effective-minimum-sync-interval-for-origin">#effective-minimum-sync-interval-for-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-minimum-sync-interval-for-origin" class="dfn-panel" data-for="effective-minimum-sync-interval-for-origin" id="infopanel-for-effective-minimum-sync-interval-for-origin" role="dialog">
+   <span id="infopaneltitle-for-effective-minimum-sync-interval-for-origin" style="display:none">Info about the 'effective minimum sync interval for origin' definition.</span><b><a href="#effective-minimum-sync-interval-for-origin">#effective-minimum-sync-interval-for-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-minimum-sync-interval-for-origin">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-effective-minimum-sync-interval-for-origin①">(2)</a>
     <li><a href="#ref-for-effective-minimum-sync-interval-for-origin②">6. Security Considerations</a>
     <li><a href="#ref-for-effective-minimum-sync-interval-for-origin③">8.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin">
-   <b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-periodic-sync-interval-for-any-origin" class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin" id="infopanel-for-minimum-periodic-sync-interval-for-any-origin" role="dialog">
+   <span id="infopaneltitle-for-minimum-periodic-sync-interval-for-any-origin" style="display:none">Info about the 'minimum periodic sync interval for any origin' definition.</span><b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin">4.2. Periodic Sync Scheduler</a>
     <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin①">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin②">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins">
-   <b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-periodic-sync-interval-across-origins" class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins" id="infopanel-for-minimum-periodic-sync-interval-across-origins" role="dialog">
+   <span id="infopaneltitle-for-minimum-periodic-sync-interval-across-origins" style="display:none">Info about the 'minimum periodic sync interval across origins' definition.</span><b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins①">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins②">(3)</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins③">(4)</a>
     <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins④">8.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-number-of-retries">
-   <b><a href="#maximum-number-of-retries">#maximum-number-of-retries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-number-of-retries" class="dfn-panel" data-for="maximum-number-of-retries" id="infopanel-for-maximum-number-of-retries" role="dialog">
+   <span id="infopaneltitle-for-maximum-number-of-retries" style="display:none">Info about the 'maximum number of retries' definition.</span><b><a href="#maximum-number-of-retries">#maximum-number-of-retries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-number-of-retries">4.3. Constants</a>
     <li><a href="#ref-for-maximum-number-of-retries①">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-periodic-sync-registrations">
-   <b><a href="#process-periodic-sync-registrations">#process-periodic-sync-registrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-periodic-sync-registrations" class="dfn-panel" data-for="process-periodic-sync-registrations" id="infopanel-for-process-periodic-sync-registrations" role="dialog">
+   <span id="infopaneltitle-for-process-periodic-sync-registrations" style="display:none">Info about the 'Process periodic sync registrations' definition.</span><b><a href="#process-periodic-sync-registrations">#process-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-to-permission-revocation">
-   <b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-to-permission-revocation" class="dfn-panel" data-for="respond-to-permission-revocation" id="infopanel-for-respond-to-permission-revocation" role="dialog">
+   <span id="infopaneltitle-for-respond-to-permission-revocation" style="display:none">Info about the 'Respond to permission revocation' definition.</span><b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-to-permission-revocation">8.2. Respond to permission revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager">
-   <b><a href="#serviceworkerregistration-periodic-sync-manager">#serviceworkerregistration-periodic-sync-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-periodic-sync-manager" class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager" id="infopanel-for-serviceworkerregistration-periodic-sync-manager" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-periodic-sync-manager" style="display:none">Info about the 'periodic sync manager' definition.</span><b><a href="#serviceworkerregistration-periodic-sync-manager">#serviceworkerregistration-periodic-sync-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-periodic-sync-manager">9.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-periodicsync">
-   <b><a href="#dom-serviceworkerregistration-periodicsync">#dom-serviceworkerregistration-periodicsync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-periodicsync" class="dfn-panel" data-for="dom-serviceworkerregistration-periodicsync" id="infopanel-for-dom-serviceworkerregistration-periodicsync" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-periodicsync" style="display:none">Info about the 'periodicSync' definition.</span><b><a href="#dom-serviceworkerregistration-periodicsync">#dom-serviceworkerregistration-periodicsync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-periodicsync">9.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncmanager">
-   <b><a href="#periodicsyncmanager">#periodicsyncmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncmanager" class="dfn-panel" data-for="periodicsyncmanager" id="infopanel-for-periodicsyncmanager" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncmanager" style="display:none">Info about the 'PeriodicSyncManager' definition.</span><b><a href="#periodicsyncmanager">#periodicsyncmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncmanager">9.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-periodicsyncmanager①">(2)</a> <a href="#ref-for-periodicsyncmanager②">(3)</a>
     <li><a href="#ref-for-periodicsyncmanager③">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager④">(2)</a> <a href="#ref-for-periodicsyncmanager⑤">(3)</a> <a href="#ref-for-periodicsyncmanager⑥">(4)</a> <a href="#ref-for-periodicsyncmanager⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-backgroundsyncoptions">
-   <b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-backgroundsyncoptions" class="dfn-panel" data-for="dictdef-backgroundsyncoptions" id="infopanel-for-dictdef-backgroundsyncoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-backgroundsyncoptions" style="display:none">Info about the 'BackgroundSyncOptions' definition.</span><b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundsyncoptions">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundsyncoptions-mininterval">
-   <b><a href="#dom-backgroundsyncoptions-mininterval">#dom-backgroundsyncoptions-mininterval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundsyncoptions-mininterval" class="dfn-panel" data-for="dom-backgroundsyncoptions-mininterval" id="infopanel-for-dom-backgroundsyncoptions-mininterval" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundsyncoptions-mininterval" style="display:none">Info about the 'minInterval' definition.</span><b><a href="#dom-backgroundsyncoptions-mininterval">#dom-backgroundsyncoptions-mininterval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundsyncoptions-mininterval">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval①">(2)</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration">
-   <b><a href="#periodicsyncmanager-service-worker-registration">#periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncmanager-service-worker-registration" class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration" id="infopanel-for-periodicsyncmanager-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncmanager-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#periodicsyncmanager-service-worker-registration">#periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncmanager-service-worker-registration">9.2. Extensions to the ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-periodicsyncmanager-service-worker-registration①">9.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration②">(2)</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-register">
-   <b><a href="#dom-periodicsyncmanager-register">#dom-periodicsyncmanager-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-register" class="dfn-panel" data-for="dom-periodicsyncmanager-register" id="infopanel-for-dom-periodicsyncmanager-register" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-register" style="display:none">Info about the 'register(tag, options)' definition.</span><b><a href="#dom-periodicsyncmanager-register">#dom-periodicsyncmanager-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-register">6. Security Considerations</a>
     <li><a href="#ref-for-dom-periodicsyncmanager-register①">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-gettags">
-   <b><a href="#dom-periodicsyncmanager-gettags">#dom-periodicsyncmanager-gettags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-gettags" class="dfn-panel" data-for="dom-periodicsyncmanager-gettags" id="infopanel-for-dom-periodicsyncmanager-gettags" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-gettags" style="display:none">Info about the 'getTags()' definition.</span><b><a href="#dom-periodicsyncmanager-gettags">#dom-periodicsyncmanager-gettags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-gettags">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-unregister">
-   <b><a href="#dom-periodicsyncmanager-unregister">#dom-periodicsyncmanager-unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-unregister" class="dfn-panel" data-for="dom-periodicsyncmanager-unregister" id="infopanel-for-dom-periodicsyncmanager-unregister" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-unregister" style="display:none">Info about the 'unregister(tag)' definition.</span><b><a href="#dom-periodicsyncmanager-unregister">#dom-periodicsyncmanager-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-unregister">9.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-event">
-   <b><a href="#periodicsync-event">#periodicsync-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsync-event" class="dfn-panel" data-for="periodicsync-event" id="infopanel-for-periodicsync-event" role="dialog">
+   <span id="infopaneltitle-for-periodicsync-event" style="display:none">Info about the 'periodicsync event' definition.</span><b><a href="#periodicsync-event">#periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsync-event">1.1. Example</a>
     <li><a href="#ref-for-periodicsync-event①">2. Concepts</a>
@@ -2186,34 +2186,34 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
     <li><a href="#ref-for-periodicsync-event②⑦">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-periodicsynceventinit">
-   <b><a href="#dictdef-periodicsynceventinit">#dictdef-periodicsynceventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-periodicsynceventinit" class="dfn-panel" data-for="dictdef-periodicsynceventinit" id="infopanel-for-dictdef-periodicsynceventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-periodicsynceventinit" style="display:none">Info about the 'PeriodicSyncEventInit' definition.</span><b><a href="#dictdef-periodicsynceventinit">#dictdef-periodicsynceventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-periodicsynceventinit">9.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncevent">
-   <b><a href="#periodicsyncevent">#periodicsyncevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncevent" class="dfn-panel" data-for="periodicsyncevent" id="infopanel-for-periodicsyncevent" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncevent" style="display:none">Info about the 'PeriodicSyncEvent' definition.</span><b><a href="#periodicsyncevent">#periodicsyncevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncevent">6. Security Considerations</a> <a href="#ref-for-periodicsyncevent①">(2)</a>
     <li><a href="#ref-for-periodicsyncevent②">9.4. The periodicsync event</a>
     <li><a href="#ref-for-periodicsyncevent③">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncevent-tag">
-   <b><a href="#periodicsyncevent-tag">#periodicsyncevent-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncevent-tag" class="dfn-panel" data-for="periodicsyncevent-tag" id="infopanel-for-periodicsyncevent-tag" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncevent-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#periodicsyncevent-tag">#periodicsyncevent-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncevent-tag">9.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncevent-tag">
-   <b><a href="#dom-periodicsyncevent-tag">#dom-periodicsyncevent-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncevent-tag" class="dfn-panel" data-for="dom-periodicsyncevent-tag" id="infopanel-for-dom-periodicsyncevent-tag" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncevent-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#dom-periodicsyncevent-tag">#dom-periodicsyncevent-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncevent-tag">9.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-periodicsync-event">
-   <b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-periodicsync-event" class="dfn-panel" data-for="fire-a-periodicsync-event" id="infopanel-for-fire-a-periodicsync-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-periodicsync-event" style="display:none">Info about the 'fire a periodicsync event' definition.</span><b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-periodicsync-event">8.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-fire-a-periodicsync-event①">9.4.1. Fire a periodicsync event</a>
@@ -2221,59 +2221,115 @@ Note: This can be used to mitigate concerns raised in <a href="#security">§ 6
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/background-sync/spec/index.html
+++ b/tests/github/WICG/background-sync/spec/index.html
@@ -1340,139 +1340,139 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#waiting">waiting</a><span>, in § 3</span>
    <li><a href="#will-retry">will retry</a><span>, in § 5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the 'assert' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">5.3. The sync event</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a> <a href="#ref-for-sec-algorithm-conventions②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/#browsing-context">https://html.spec.whatwg.org/#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#browsing-context">https://html.spec.whatwg.org/#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.2. SyncManager interface</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise">https://www.w3.org/2001/tag/doc/promises-guide#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">5.2. SyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject-promise">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">https://www.w3.org/2001/tag/doc/promises-guide#reject-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject-promise" class="dfn-panel" data-for="term-for-reject-promise" id="infopanel-for-term-for-reject-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-reject-promise" style="display:none">Info about the 'reject' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">https://www.w3.org/2001/tag/doc/promises-guide#reject-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject-promise">5.2. SyncManager interface</a> <a href="#ref-for-reject-promise①">(2)</a> <a href="#ref-for-reject-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve-promise">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve-promise" class="dfn-panel" data-for="term-for-resolve-promise" id="infopanel-for-term-for-resolve-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve-promise" style="display:none">Info about the 'resolve' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">https://www.w3.org/2001/tag/doc/promises-guide#resolve-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-promise">5.2. SyncManager interface</a> <a href="#ref-for-resolve-promise①">(2)</a> <a href="#ref-for-resolve-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment">https://www.w3.org/2001/tag/doc/promises-guide#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection">https://www.w3.org/2001/tag/doc/promises-guide#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all" class="dfn-panel" data-for="term-for-waiting-for-all" id="infopanel-for-term-for-waiting-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendable-event-interface">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendable-event-interface" class="dfn-panel" data-for="term-for-extendable-event-interface" id="infopanel-for-term-for-extendable-event-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-extendable-event-interface" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-interface">5.3. The sync event</a> <a href="#ref-for-extendable-event-interface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendable-event-init-dictionary">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendable-event-init-dictionary" class="dfn-panel" data-for="term-for-extendable-event-init-dictionary" id="infopanel-for-term-for-extendable-event-init-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-extendable-event-init-dictionary" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#extendable-event-init-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-init-dictionary">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-global-scope-interface">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-global-scope-interface" class="dfn-panel" data-for="term-for-service-worker-global-scope-interface" id="infopanel-for-term-for-service-worker-global-scope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-global-scope-interface" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-global-scope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-interface">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-registration-interface">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-registration-interface" class="dfn-panel" data-for="term-for-service-worker-registration-interface" id="infopanel-for-term-for-service-worker-registration-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-registration-interface" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-interface">5.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-service-worker-registration-interface①">(2)</a> <a href="#ref-for-service-worker-registration-interface②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extend-lifetime-promises">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extend-lifetime-promises" class="dfn-panel" data-for="term-for-dfn-extend-lifetime-promises" id="infopanel-for-term-for-dfn-extend-lifetime-promises" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extend-lifetime-promises" style="display:none">Info about the 'extended lifetime promises' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-extend-lifetime-promises</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extend-lifetime-promises">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type" id="infopanel-for-term-for-dfn-service-worker-client-frame-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type①">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-concept">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-concept" class="dfn-panel" data-for="term-for-service-worker-concept" id="infopanel-for-term-for-service-worker-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-concept" style="display:none">Info about the 'service worker' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-concept">1. Introduction</a> <a href="#ref-for-service-worker-concept①">(2)</a>
     <li><a href="#ref-for-service-worker-concept②">2. Concepts</a>
     <li><a href="#ref-for-service-worker-concept③">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client" class="dfn-panel" data-for="term-for-dfn-service-worker-client" id="infopanel-for-term-for-dfn-service-worker-client" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client①">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-registration-concept">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-registration-concept" class="dfn-panel" data-for="term-for-service-worker-registration-concept" id="infopanel-for-term-for-service-worker-registration-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-registration-concept" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#service-worker-registration-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-concept">3. Constructs</a> <a href="#ref-for-service-worker-registration-concept①">(2)</a>
     <li><a href="#ref-for-service-worker-registration-concept②">5.1. Extensions to the ServiceWorkerRegistration interface</a>
@@ -1480,64 +1480,64 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-service-worker-registration-concept⑥">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-service-worker-algorithm">
-   <a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-terminate-service-worker-algorithm" class="dfn-panel" data-for="term-for-terminate-service-worker-algorithm" id="infopanel-for-term-for-terminate-service-worker-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-terminate-service-worker-algorithm" style="display:none">Info about the 'termination' external reference.</span><a href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm">https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#terminate-service-worker-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-service-worker-algorithm">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5.2. SyncManager interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">5.3. The sync event</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.2. SyncManager interface</a>
     <li><a href="#ref-for-Exposed①">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.2. SyncManager interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5.3. The sync event</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://heycam.github.io/webidl/#idl-sequence">https://heycam.github.io/webidl/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://heycam.github.io/webidl/#idl-sequence">https://heycam.github.io/webidl/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence①">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.2. SyncManager interface</a>
    </ul>
@@ -1647,32 +1647,32 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="in-the-background">
-   <b><a href="#in-the-background">#in-the-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-the-background" class="dfn-panel" data-for="in-the-background" id="infopanel-for-in-the-background" role="dialog">
+   <span id="infopaneltitle-for-in-the-background" style="display:none">Info about the 'in the background' definition.</span><b><a href="#in-the-background">#in-the-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-the-background">1. Introduction</a>
     <li><a href="#ref-for-in-the-background①">4.2. Location Tracking</a>
     <li><a href="#ref-for-in-the-background②">4.3. History Leaking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="online">
-   <b><a href="#online">#online</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-online" class="dfn-panel" data-for="online" id="infopanel-for-online" role="dialog">
+   <span id="infopaneltitle-for-online" style="display:none">Info about the 'online' definition.</span><b><a href="#online">#online</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-online">2. Concepts</a>
     <li><a href="#ref-for-online①">5.2. SyncManager interface</a> <a href="#ref-for-online②">(2)</a>
     <li><a href="#ref-for-online③">5.3. The sync event</a> <a href="#ref-for-online④">(2)</a> <a href="#ref-for-online⑤">(3)</a> <a href="#ref-for-online⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-sync-registrations">
-   <b><a href="#list-of-sync-registrations">#list-of-sync-registrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-sync-registrations" class="dfn-panel" data-for="list-of-sync-registrations" id="infopanel-for-list-of-sync-registrations" role="dialog">
+   <span id="infopaneltitle-for-list-of-sync-registrations" style="display:none">Info about the 'list of sync registrations' definition.</span><b><a href="#list-of-sync-registrations">#list-of-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-sync-registrations">3. Constructs</a>
     <li><a href="#ref-for-list-of-sync-registrations①">5.2. SyncManager interface</a> <a href="#ref-for-list-of-sync-registrations②">(2)</a> <a href="#ref-for-list-of-sync-registrations③">(3)</a>
     <li><a href="#ref-for-list-of-sync-registrations④">5.3. The sync event</a> <a href="#ref-for-list-of-sync-registrations⑤">(2)</a> <a href="#ref-for-list-of-sync-registrations⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sync-registration">
-   <b><a href="#sync-registration">#sync-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sync-registration" class="dfn-panel" data-for="sync-registration" id="infopanel-for-sync-registration" role="dialog">
+   <span id="infopaneltitle-for-sync-registration" style="display:none">Info about the 'sync registration' definition.</span><b><a href="#sync-registration">#sync-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sync-registration">2. Concepts</a>
     <li><a href="#ref-for-sync-registration①">3. Constructs</a> <a href="#ref-for-sync-registration②">(2)</a> <a href="#ref-for-sync-registration③">(3)</a> <a href="#ref-for-sync-registration④">(4)</a> <a href="#ref-for-sync-registration⑤">(5)</a>
@@ -1680,162 +1680,218 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-sync-registration⑧">5.3. The sync event</a> <a href="#ref-for-sync-registration⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tag">
-   <b><a href="#tag">#tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tag" class="dfn-panel" data-for="tag" id="infopanel-for-tag" role="dialog">
+   <span id="infopaneltitle-for-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#tag">#tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tag">3. Constructs</a> <a href="#ref-for-tag①">(2)</a>
     <li><a href="#ref-for-tag②">5.2. SyncManager interface</a> <a href="#ref-for-tag③">(2)</a> <a href="#ref-for-tag④">(3)</a>
     <li><a href="#ref-for-tag⑤">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registration-state">
-   <b><a href="#registration-state">#registration-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registration-state" class="dfn-panel" data-for="registration-state" id="infopanel-for-registration-state" role="dialog">
+   <span id="infopaneltitle-for-registration-state" style="display:none">Info about the 'registration state' definition.</span><b><a href="#registration-state">#registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration-state">3. Constructs</a>
     <li><a href="#ref-for-registration-state①">5.2. SyncManager interface</a> <a href="#ref-for-registration-state②">(2)</a> <a href="#ref-for-registration-state③">(3)</a> <a href="#ref-for-registration-state④">(4)</a> <a href="#ref-for-registration-state⑤">(5)</a>
     <li><a href="#ref-for-registration-state⑥">5.3. The sync event</a> <a href="#ref-for-registration-state⑦">(2)</a> <a href="#ref-for-registration-state⑧">(3)</a> <a href="#ref-for-registration-state⑨">(4)</a> <a href="#ref-for-registration-state①⓪">(5)</a> <a href="#ref-for-registration-state①①">(6)</a> <a href="#ref-for-registration-state①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending">
-   <b><a href="#pending">#pending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending" class="dfn-panel" data-for="pending" id="infopanel-for-pending" role="dialog">
+   <span id="infopaneltitle-for-pending" style="display:none">Info about the 'pending' definition.</span><b><a href="#pending">#pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending">3. Constructs</a>
     <li><a href="#ref-for-pending①">5.2. SyncManager interface</a> <a href="#ref-for-pending②">(2)</a>
     <li><a href="#ref-for-pending③">5.3. The sync event</a> <a href="#ref-for-pending④">(2)</a> <a href="#ref-for-pending⑤">(3)</a> <a href="#ref-for-pending⑥">(4)</a> <a href="#ref-for-pending⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="waiting">
-   <b><a href="#waiting">#waiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-waiting" class="dfn-panel" data-for="waiting" id="infopanel-for-waiting" role="dialog">
+   <span id="infopaneltitle-for-waiting" style="display:none">Info about the 'waiting' definition.</span><b><a href="#waiting">#waiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting">5.2. SyncManager interface</a>
     <li><a href="#ref-for-waiting①">5.3. The sync event</a> <a href="#ref-for-waiting②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="firing">
-   <b><a href="#firing">#firing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-firing" class="dfn-panel" data-for="firing" id="infopanel-for-firing" role="dialog">
+   <span id="infopaneltitle-for-firing" style="display:none">Info about the 'firing' definition.</span><b><a href="#firing">#firing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-firing">5.2. SyncManager interface</a>
     <li><a href="#ref-for-firing①">5.3. The sync event</a> <a href="#ref-for-firing②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reregisteredwhilefiring">
-   <b><a href="#reregisteredwhilefiring">#reregisteredwhilefiring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reregisteredwhilefiring" class="dfn-panel" data-for="reregisteredwhilefiring" id="infopanel-for-reregisteredwhilefiring" role="dialog">
+   <span id="infopaneltitle-for-reregisteredwhilefiring" style="display:none">Info about the 'reregisteredWhileFiring' definition.</span><b><a href="#reregisteredwhilefiring">#reregisteredwhilefiring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reregisteredwhilefiring">5.2. SyncManager interface</a>
     <li><a href="#ref-for-reregisteredwhilefiring①">5.3. The sync event</a> <a href="#ref-for-reregisteredwhilefiring②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syncmanager">
-   <b><a href="#syncmanager">#syncmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syncmanager" class="dfn-panel" data-for="syncmanager" id="infopanel-for-syncmanager" role="dialog">
+   <span id="infopaneltitle-for-syncmanager" style="display:none">Info about the 'SyncManager' definition.</span><b><a href="#syncmanager">#syncmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syncmanager">5.1. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-syncmanager①">(2)</a>
     <li><a href="#ref-for-syncmanager②">5.2. SyncManager interface</a> <a href="#ref-for-syncmanager③">(2)</a> <a href="#ref-for-syncmanager④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-syncmanager-register">
-   <b><a href="#dom-syncmanager-register">#dom-syncmanager-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-syncmanager-register" class="dfn-panel" data-for="dom-syncmanager-register" id="infopanel-for-dom-syncmanager-register" role="dialog">
+   <span id="infopaneltitle-for-dom-syncmanager-register" style="display:none">Info about the 'register(tag)' definition.</span><b><a href="#dom-syncmanager-register">#dom-syncmanager-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-syncmanager-register">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-syncmanager-gettags">
-   <b><a href="#dom-syncmanager-gettags">#dom-syncmanager-gettags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-syncmanager-gettags" class="dfn-panel" data-for="dom-syncmanager-gettags" id="infopanel-for-dom-syncmanager-gettags" role="dialog">
+   <span id="infopaneltitle-for-dom-syncmanager-gettags" style="display:none">Info about the 'getTags()' definition.</span><b><a href="#dom-syncmanager-gettags">#dom-syncmanager-gettags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-syncmanager-gettags">5.2. SyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syncevent">
-   <b><a href="#syncevent">#syncevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syncevent" class="dfn-panel" data-for="syncevent" id="infopanel-for-syncevent" role="dialog">
+   <span id="infopaneltitle-for-syncevent" style="display:none">Info about the 'SyncEvent' definition.</span><b><a href="#syncevent">#syncevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syncevent">5.3. The sync event</a> <a href="#ref-for-syncevent①">(2)</a> <a href="#ref-for-syncevent②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-syncevent-tag">
-   <b><a href="#dom-syncevent-tag">#dom-syncevent-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-syncevent-tag" class="dfn-panel" data-for="dom-syncevent-tag" id="infopanel-for-dom-syncevent-tag" role="dialog">
+   <span id="infopaneltitle-for-dom-syncevent-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#dom-syncevent-tag">#dom-syncevent-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-syncevent-tag">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-syncevent-lastchance">
-   <b><a href="#dom-syncevent-lastchance">#dom-syncevent-lastchance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-syncevent-lastchance" class="dfn-panel" data-for="dom-syncevent-lastchance" id="infopanel-for-dom-syncevent-lastchance" role="dialog">
+   <span id="infopaneltitle-for-dom-syncevent-lastchance" style="display:none">Info about the 'lastChance' definition.</span><b><a href="#dom-syncevent-lastchance">#dom-syncevent-lastchance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-syncevent-lastchance">5.3. The sync event</a> <a href="#ref-for-dom-syncevent-lastchance①">(2)</a> <a href="#ref-for-dom-syncevent-lastchance②">(3)</a> <a href="#ref-for-dom-syncevent-lastchance③">(4)</a> <a href="#ref-for-dom-syncevent-lastchance④">(5)</a> <a href="#ref-for-dom-syncevent-lastchance⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-synceventinit">
-   <b><a href="#dictdef-synceventinit">#dictdef-synceventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-synceventinit" class="dfn-panel" data-for="dictdef-synceventinit" id="infopanel-for-dictdef-synceventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-synceventinit" style="display:none">Info about the 'SyncEventInit' definition.</span><b><a href="#dictdef-synceventinit">#dictdef-synceventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-synceventinit">5.3. The sync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-sync-event">
-   <b><a href="#fire-a-sync-event">#fire-a-sync-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-sync-event" class="dfn-panel" data-for="fire-a-sync-event" id="infopanel-for-fire-a-sync-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-sync-event" style="display:none">Info about the 'fire a sync event' definition.</span><b><a href="#fire-a-sync-event">#fire-a-sync-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-sync-event">5.2. SyncManager interface</a> <a href="#ref-for-fire-a-sync-event①">(2)</a>
     <li><a href="#ref-for-fire-a-sync-event②">5.3. The sync event</a> <a href="#ref-for-fire-a-sync-event③">(2)</a> <a href="#ref-for-fire-a-sync-event④">(3)</a> <a href="#ref-for-fire-a-sync-event⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="will-retry">
-   <b><a href="#will-retry">#will-retry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-will-retry" class="dfn-panel" data-for="will-retry" id="infopanel-for-will-retry" role="dialog">
+   <span id="infopaneltitle-for-will-retry" style="display:none">Info about the 'will retry' definition.</span><b><a href="#will-retry">#will-retry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-will-retry">5.3. The sync event</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/client-hints-infrastructure/index.html
+++ b/tests/github/WICG/client-hints-infrastructure/index.html
@@ -952,219 +952,219 @@ the following <a data-link-type="dfn" href="https://w3c.github.io/webappsec-perm
    <li><a href="#abstract-opdef-remove-client-hints-from-redirect-if-needed">remove client hints from redirect if needed</a><span>, in § 5</span>
    <li><a href="#retrieve-the-client-hints-set">retrieve the client hints set</a><span>, in § 3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-append">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-append" class="dfn-panel" data-for="term-for-concept-header-list-append" id="infopanel-for-term-for-concept-header-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-append">5. Request processing</a> <a href="#ref-for-concept-header-list-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">4.5. Extending environment settings object</a>
     <li><a href="#ref-for-concept-request-client①">5. Request processing</a> <a href="#ref-for-concept-request-client②">(2)</a> <a href="#ref-for-concept-request-client③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">5. Request processing</a> <a href="#ref-for-header-list-contains①">(2)</a> <a href="#ref-for-header-list-contains②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains①" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains①" style="display:none">Info about the 'does not contain' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">5. Request processing</a> <a href="#ref-for-header-list-contains①">(2)</a> <a href="#ref-for-header-list-contains②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">4.5. Extending environment settings object</a>
     <li><a href="#ref-for-concept-fetch①">6. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">5. Request processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">5. Request processing</a> <a href="#ref-for-concept-request-header-list①">(2)</a> <a href="#ref-for-concept-request-header-list②">(3)</a> <a href="#ref-for-concept-request-header-list③">(4)</a> <a href="#ref-for-concept-request-header-list④">(5)</a> <a href="#ref-for-concept-request-header-list⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-redirect-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-redirect-fetch">https://fetch.spec.whatwg.org/#concept-http-redirect-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-redirect-fetch" class="dfn-panel" data-for="term-for-concept-http-redirect-fetch" id="infopanel-for-term-for-concept-http-redirect-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-redirect-fetch" style="display:none">Info about the 'http-redirect fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-redirect-fetch">https://fetch.spec.whatwg.org/#concept-http-redirect-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-redirect-fetch">6. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">5. Request processing</a>
     <li><a href="#ref-for-concept-header-name①">7.3. Low entropy hint table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">4.5. Extending environment settings object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subresource-request" class="dfn-panel" data-for="term-for-subresource-request" id="infopanel-for-term-for-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-subresource-request" style="display:none">Info about the 'subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">5. Request processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">7.3. Low entropy hint table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">3.3. Initialize Client Hints set</a>
     <li><a href="#ref-for-window-bc①">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-content">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-content" class="dfn-panel" data-for="term-for-attr-meta-content" id="infopanel-for-term-for-attr-meta-content" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-content" style="display:none">Info about the 'content' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-content">3.4. Accept-CH state (http-equiv="accept-ch")</a> <a href="#ref-for-attr-meta-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.4. Accept-CH state (http-equiv="accept-ch")</a>
     <li><a href="#ref-for-environment-settings-object①">4.5. Extending environment settings object</a> <a href="#ref-for-environment-settings-object②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">3.3. Initialize Client Hints set</a>
     <li><a href="#ref-for-concept-settings-object-global①">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-head-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">https://html.spec.whatwg.org/multipage/semantics.html#the-head-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-head-element" class="dfn-panel" data-for="term-for-the-head-element" id="infopanel-for-term-for-the-head-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-head-element" style="display:none">Info about the 'head' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">https://html.spec.whatwg.org/multipage/semantics.html#the-head-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-head-element">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-meta" class="dfn-panel" data-for="term-for-meta" id="infopanel-for-term-for-meta" role="menu">
+   <span id="infopaneltitle-for-term-for-meta" style="display:none">Info about the 'meta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">3.4. Accept-CH state (http-equiv="accept-ch")</a> <a href="#ref-for-meta①">(2)</a> <a href="#ref-for-meta②">(3)</a> <a href="#ref-for-meta③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3.2. Accept-CH cache</a>
     <li><a href="#ref-for-concept-origin①">3.3. Initialize Client Hints set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">3.3. Initialize Client Hints set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.4. Accept-CH state (http-equiv="accept-ch")</a>
     <li><a href="#ref-for-relevant-settings-object①">4.1. Document object initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3.3. Initialize Client Hints set</a>
     <li><a href="#ref-for-top-level-browsing-context①">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3.2. Accept-CH cache</a>
     <li><a href="#ref-for-set-append①">3.3. Initialize Client Hints set</a>
     <li><a href="#ref-for-set-append②">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-lowercase">
-   <a href="https://infra.spec.whatwg.org/#byte-lowercase">https://infra.spec.whatwg.org/#byte-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-lowercase" class="dfn-panel" data-for="term-for-byte-lowercase" id="infopanel-for-term-for-byte-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-lowercase" style="display:none">Info about the 'byte-lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-lowercase">https://infra.spec.whatwg.org/#byte-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-lowercase">7.1. Client hints token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-clone">
-   <a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-clone" class="dfn-panel" data-for="term-for-list-clone" id="infopanel-for-term-for-list-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-list-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">4.2. Worker initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5. Request processing</a> <a href="#ref-for-list-iterate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">3.1. Client hints set</a>
     <li><a href="#ref-for-ordered-set①">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set①" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">3.1. Client hints set</a>
     <li><a href="#ref-for-ordered-set①">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">7.2. Policy-controlled features</a> <a href="#ref-for-default-allowlist①">(2)</a> <a href="#ref-for-default-allowlist②">(3)</a> <a href="#ref-for-default-allowlist③">(4)</a> <a href="#ref-for-default-allowlist④">(5)</a> <a href="#ref-for-default-allowlist⑤">(6)</a> <a href="#ref-for-default-allowlist⑥">(7)</a> <a href="#ref-for-default-allowlist⑦">(8)</a> <a href="#ref-for-default-allowlist⑧">(9)</a> <a href="#ref-for-default-allowlist⑨">(10)</a> <a href="#ref-for-default-allowlist①⓪">(11)</a> <a href="#ref-for-default-allowlist①①">(12)</a> <a href="#ref-for-default-allowlist①②">(13)</a> <a href="#ref-for-default-allowlist①③">(14)</a> <a href="#ref-for-default-allowlist①④">(15)</a> <a href="#ref-for-default-allowlist①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">7.2. Policy-controlled features</a>
    </ul>
@@ -1245,64 +1245,64 @@ the following <a data-link-type="dfn" href="https://w3c.github.io/webappsec-perm
    <div class="issue"> Should we tie low-entropy-ness to allowlists, generally? <a class="issue-return" href="#issue-0277eb34" title="Jump to section">↵</a></div>
    <div class="issue"> Links for image features are broken, need to actually define that and link to them. <a class="issue-return" href="#issue-707decdc" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="client-hints-set">
-   <b><a href="#client-hints-set">#client-hints-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-hints-set" class="dfn-panel" data-for="client-hints-set" id="infopanel-for-client-hints-set" role="dialog">
+   <span id="infopaneltitle-for-client-hints-set" style="display:none">Info about the 'client hints set' definition.</span><b><a href="#client-hints-set">#client-hints-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-hints-set">3.2. Accept-CH cache</a> <a href="#ref-for-client-hints-set①">(2)</a>
     <li><a href="#ref-for-client-hints-set②">4.5. Extending environment settings object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accept-ch-cache">
-   <b><a href="#accept-ch-cache">#accept-ch-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accept-ch-cache" class="dfn-panel" data-for="accept-ch-cache" id="infopanel-for-accept-ch-cache" role="dialog">
+   <span id="infopaneltitle-for-accept-ch-cache" style="display:none">Info about the 'Accept-CH cache' definition.</span><b><a href="#accept-ch-cache">#accept-ch-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accept-ch-cache">3.2. Accept-CH cache</a> <a href="#ref-for-accept-ch-cache①">(2)</a> <a href="#ref-for-accept-ch-cache②">(3)</a>
     <li><a href="#ref-for-accept-ch-cache③">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accept-ch-cache-origin">
-   <b><a href="#accept-ch-cache-origin">#accept-ch-cache-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accept-ch-cache-origin" class="dfn-panel" data-for="accept-ch-cache-origin" id="infopanel-for-accept-ch-cache-origin" role="dialog">
+   <span id="infopaneltitle-for-accept-ch-cache-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#accept-ch-cache-origin">#accept-ch-cache-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accept-ch-cache-origin">3.2. Accept-CH cache</a> <a href="#ref-for-accept-ch-cache-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accept-ch-cache-client-hints-set">
-   <b><a href="#accept-ch-cache-client-hints-set">#accept-ch-cache-client-hints-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accept-ch-cache-client-hints-set" class="dfn-panel" data-for="accept-ch-cache-client-hints-set" id="infopanel-for-accept-ch-cache-client-hints-set" role="dialog">
+   <span id="infopaneltitle-for-accept-ch-cache-client-hints-set" style="display:none">Info about the 'client hints set' definition.</span><b><a href="#accept-ch-cache-client-hints-set">#accept-ch-cache-client-hints-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accept-ch-cache-client-hints-set">3.2. Accept-CH cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-a-new-accept-ch-cache-entry">
-   <b><a href="#add-a-new-accept-ch-cache-entry">#add-a-new-accept-ch-cache-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-a-new-accept-ch-cache-entry" class="dfn-panel" data-for="add-a-new-accept-ch-cache-entry" id="infopanel-for-add-a-new-accept-ch-cache-entry" role="dialog">
+   <span id="infopaneltitle-for-add-a-new-accept-ch-cache-entry" style="display:none">Info about the 'add a new Accept-CH cache entry' definition.</span><b><a href="#add-a-new-accept-ch-cache-entry">#add-a-new-accept-ch-cache-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-a-new-accept-ch-cache-entry">3.3. Initialize Client Hints set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-the-client-hints-set">
-   <b><a href="#retrieve-the-client-hints-set">#retrieve-the-client-hints-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-the-client-hints-set" class="dfn-panel" data-for="retrieve-the-client-hints-set" id="infopanel-for-retrieve-the-client-hints-set" role="dialog">
+   <span id="infopaneltitle-for-retrieve-the-client-hints-set" style="display:none">Info about the 'retrieve the client hints set' definition.</span><b><a href="#retrieve-the-client-hints-set">#retrieve-the-client-hints-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-the-client-hints-set">3.3. Initialize Client Hints set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-initialize-the-client-hints-set">
-   <b><a href="#abstract-opdef-initialize-the-client-hints-set">#abstract-opdef-initialize-the-client-hints-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-initialize-the-client-hints-set" class="dfn-panel" data-for="abstract-opdef-initialize-the-client-hints-set" id="infopanel-for-abstract-opdef-initialize-the-client-hints-set" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-initialize-the-client-hints-set" style="display:none">Info about the 'initialize the Client Hints set' definition.</span><b><a href="#abstract-opdef-initialize-the-client-hints-set">#abstract-opdef-initialize-the-client-hints-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-initialize-the-client-hints-set">4.1. Document object initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accept-ch-state">
-   <b><a href="#accept-ch-state">#accept-ch-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accept-ch-state" class="dfn-panel" data-for="accept-ch-state" id="infopanel-for-accept-ch-state" role="dialog">
+   <span id="infopaneltitle-for-accept-ch-state" style="display:none">Info about the 'Accept-CH state' definition.</span><b><a href="#accept-ch-state">#accept-ch-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accept-ch-state">4.4. Pragma directives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accept-ch">
-   <b><a href="#accept-ch">#accept-ch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accept-ch" class="dfn-panel" data-for="accept-ch" id="infopanel-for-accept-ch" role="dialog">
+   <span id="infopaneltitle-for-accept-ch" style="display:none">Info about the 'accept-ch' definition.</span><b><a href="#accept-ch">#accept-ch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accept-ch">3.4. Accept-CH state (http-equiv="accept-ch")</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-client-hints-set">
-   <b><a href="#environment-settings-object-client-hints-set">#environment-settings-object-client-hints-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-client-hints-set" class="dfn-panel" data-for="environment-settings-object-client-hints-set" id="infopanel-for-environment-settings-object-client-hints-set" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-client-hints-set" style="display:none">Info about the 'client hints set' definition.</span><b><a href="#environment-settings-object-client-hints-set">#environment-settings-object-client-hints-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-client-hints-set">3.3. Initialize Client Hints set</a> <a href="#ref-for-environment-settings-object-client-hints-set①">(2)</a> <a href="#ref-for-environment-settings-object-client-hints-set②">(3)</a>
     <li><a href="#ref-for-environment-settings-object-client-hints-set③">3.4. Accept-CH state (http-equiv="accept-ch")</a> <a href="#ref-for-environment-settings-object-client-hints-set④">(2)</a>
@@ -1310,20 +1310,20 @@ the following <a data-link-type="dfn" href="https://w3c.github.io/webappsec-perm
     <li><a href="#ref-for-environment-settings-object-client-hints-set⑦">5. Request processing</a> <a href="#ref-for-environment-settings-object-client-hints-set⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-append-client-hints-to-request">
-   <b><a href="#abstract-opdef-append-client-hints-to-request">#abstract-opdef-append-client-hints-to-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-append-client-hints-to-request" class="dfn-panel" data-for="abstract-opdef-append-client-hints-to-request" id="infopanel-for-abstract-opdef-append-client-hints-to-request" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-append-client-hints-to-request" style="display:none">Info about the 'append client hints to request' definition.</span><b><a href="#abstract-opdef-append-client-hints-to-request">#abstract-opdef-append-client-hints-to-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-append-client-hints-to-request">6. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-remove-client-hints-from-redirect-if-needed">
-   <b><a href="#abstract-opdef-remove-client-hints-from-redirect-if-needed">#abstract-opdef-remove-client-hints-from-redirect-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-remove-client-hints-from-redirect-if-needed" class="dfn-panel" data-for="abstract-opdef-remove-client-hints-from-redirect-if-needed" id="infopanel-for-abstract-opdef-remove-client-hints-from-redirect-if-needed" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-remove-client-hints-from-redirect-if-needed" style="display:none">Info about the 'remove client hints from redirect if needed' definition.</span><b><a href="#abstract-opdef-remove-client-hints-from-redirect-if-needed">#abstract-opdef-remove-client-hints-from-redirect-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-remove-client-hints-from-redirect-if-needed">6. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-hints-token">
-   <b><a href="#client-hints-token">#client-hints-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-hints-token" class="dfn-panel" data-for="client-hints-token" id="infopanel-for-client-hints-token" role="dialog">
+   <span id="infopaneltitle-for-client-hints-token" style="display:none">Info about the 'client hints token' definition.</span><b><a href="#client-hints-token">#client-hints-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-hints-token">3.1. Client hints set</a>
     <li><a href="#ref-for-client-hints-token①">3.3. Initialize Client Hints set</a>
@@ -1331,20 +1331,20 @@ the following <a data-link-type="dfn" href="https://w3c.github.io/webappsec-perm
     <li><a href="#ref-for-client-hints-token④">5. Request processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="low-entropy-hint-table">
-   <b><a href="#low-entropy-hint-table">#low-entropy-hint-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-low-entropy-hint-table" class="dfn-panel" data-for="low-entropy-hint-table" id="infopanel-for-low-entropy-hint-table" role="dialog">
+   <span id="infopaneltitle-for-low-entropy-hint-table" style="display:none">Info about the 'low entropy hint table' definition.</span><b><a href="#low-entropy-hint-table">#low-entropy-hint-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-entropy-hint-table">5. Request processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-client-hint-value">
-   <b><a href="#find-client-hint-value">#find-client-hint-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-client-hint-value" class="dfn-panel" data-for="find-client-hint-value" id="infopanel-for-find-client-hint-value" role="dialog">
+   <span id="infopaneltitle-for-find-client-hint-value" style="display:none">Info about the 'find client hint value' definition.</span><b><a href="#find-client-hint-value">#find-client-hint-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-client-hint-value">5. Request processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="field-name">
-   <b><a href="#field-name">#field-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-field-name" class="dfn-panel" data-for="field-name" id="infopanel-for-field-name" role="dialog">
+   <span id="infopaneltitle-for-field-name" style="display:none">Info about the 'field-name' definition.</span><b><a href="#field-name">#field-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-field-name">3.3. Initialize Client Hints set</a>
     <li><a href="#ref-for-field-name①">3.4. Accept-CH state (http-equiv="accept-ch")</a>
@@ -1352,57 +1352,113 @@ the following <a data-link-type="dfn" href="https://w3c.github.io/webappsec-perm
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/compression/index.html
+++ b/tests/github/WICG/compression/index.html
@@ -1191,114 +1191,114 @@ specification uses that specification and terminology.</p>
      <li><a href="#decompressionstream-format">dfn for DecompressionStream</a><span>, in § 6</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">3. Terminology</a>
     <li><a href="#ref-for-BufferSource①">5. Interface CompressionStream</a>
     <li><a href="#ref-for-BufferSource②">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5. Interface CompressionStream</a>
     <li><a href="#ref-for-idl-DOMString①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5. Interface CompressionStream</a>
     <li><a href="#ref-for-Exposed①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5. Interface CompressionStream</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">6. Interface DecompressionStream</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a> <a href="#ref-for-exceptiondef-typeerror④">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">5. Interface CompressionStream</a> <a href="#ref-for-idl-Uint8Array①">(2)</a> <a href="#ref-for-idl-Uint8Array②">(3)</a> <a href="#ref-for-idl-Uint8Array③">(4)</a>
     <li><a href="#ref-for-idl-Uint8Array④">6. Interface DecompressionStream</a> <a href="#ref-for-idl-Uint8Array⑤">(2)</a> <a href="#ref-for-idl-Uint8Array⑥">(3)</a> <a href="#ref-for-idl-Uint8Array⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">5. Interface CompressionStream</a>
     <li><a href="#ref-for-new①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">5. Interface CompressionStream</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a>
     <li><a href="#ref-for-this⑤">6. Interface DecompressionStream</a> <a href="#ref-for-this⑥">(2)</a> <a href="#ref-for-this⑦">(3)</a> <a href="#ref-for-this⑧">(4)</a> <a href="#ref-for-this⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generictransformstream">
-   <a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generictransformstream" class="dfn-panel" data-for="term-for-generictransformstream" id="infopanel-for-term-for-generictransformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-generictransformstream" style="display:none">Info about the 'GenericTransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream">5. Interface CompressionStream</a>
     <li><a href="#ref-for-generictransformstream①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">3. Terminology</a>
     <li><a href="#ref-for-readablestream①">5. Interface CompressionStream</a>
     <li><a href="#ref-for-readablestream②">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream">
-   <a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream" class="dfn-panel" data-for="term-for-transformstream" id="infopanel-for-term-for-transformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream" style="display:none">Info about the 'TransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream">5. Interface CompressionStream</a>
     <li><a href="#ref-for-transformstream①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream">
-   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream" class="dfn-panel" data-for="term-for-writablestream" id="infopanel-for-term-for-writablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream" style="display:none">Info about the 'WritableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#transformstream-enqueue">https://streams.spec.whatwg.org/#transformstream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-enqueue" class="dfn-panel" data-for="term-for-transformstream-enqueue" id="infopanel-for-term-for-transformstream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-enqueue">https://streams.spec.whatwg.org/#transformstream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-enqueue">5. Interface CompressionStream</a> <a href="#ref-for-transformstream-enqueue①">(2)</a>
     <li><a href="#ref-for-transformstream-enqueue②">6. Interface DecompressionStream</a> <a href="#ref-for-transformstream-enqueue③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-set-up-flushalgorithm">
-   <a href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-set-up-flushalgorithm" class="dfn-panel" data-for="term-for-transformstream-set-up-flushalgorithm" id="infopanel-for-term-for-transformstream-set-up-flushalgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-set-up-flushalgorithm" style="display:none">Info about the 'flushalgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-flushalgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up-flushalgorithm">5. Interface CompressionStream</a>
     <li><a href="#ref-for-transformstream-set-up-flushalgorithm①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-set-up">
-   <a href="https://streams.spec.whatwg.org/#transformstream-set-up">https://streams.spec.whatwg.org/#transformstream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-set-up" class="dfn-panel" data-for="term-for-transformstream-set-up" id="infopanel-for-term-for-transformstream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-set-up" style="display:none">Info about the 'set up' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-set-up">https://streams.spec.whatwg.org/#transformstream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up">5. Interface CompressionStream</a>
     <li><a href="#ref-for-transformstream-set-up①">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generictransformstream-transform">
-   <a href="https://streams.spec.whatwg.org/#generictransformstream-transform">https://streams.spec.whatwg.org/#generictransformstream-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generictransformstream-transform" class="dfn-panel" data-for="term-for-generictransformstream-transform" id="infopanel-for-term-for-generictransformstream-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-generictransformstream-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://streams.spec.whatwg.org/#generictransformstream-transform">https://streams.spec.whatwg.org/#generictransformstream-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream-transform">5. Interface CompressionStream</a> <a href="#ref-for-generictransformstream-transform①">(2)</a> <a href="#ref-for-generictransformstream-transform②">(3)</a> <a href="#ref-for-generictransformstream-transform③">(4)</a>
     <li><a href="#ref-for-generictransformstream-transform④">6. Interface DecompressionStream</a> <a href="#ref-for-generictransformstream-transform⑤">(2)</a> <a href="#ref-for-generictransformstream-transform⑥">(3)</a> <a href="#ref-for-generictransformstream-transform⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-set-up-transformalgorithm">
-   <a href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-set-up-transformalgorithm" class="dfn-panel" data-for="term-for-transformstream-set-up-transformalgorithm" id="infopanel-for-term-for-transformstream-set-up-transformalgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-set-up-transformalgorithm" style="display:none">Info about the 'transformalgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up-transformalgorithm">5. Interface CompressionStream</a>
     <li><a href="#ref-for-transformstream-set-up-transformalgorithm①">6. Interface DecompressionStream</a>
@@ -1364,141 +1364,197 @@ specification uses that specification and terminology.</p>
 <a data-link-type="idl-name" href="#decompressionstream"><c- n>DecompressionStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream"><c- n>GenericTransformStream</c-></a>;
 
 </pre>
-  <aside class="dfn-panel" data-for="compression-context">
-   <b><a href="#compression-context">#compression-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compression-context" class="dfn-panel" data-for="compression-context" id="infopanel-for-compression-context" role="dialog">
+   <span id="infopaneltitle-for-compression-context" style="display:none">Info about the 'compression context' definition.</span><b><a href="#compression-context">#compression-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compression-context">3. Terminology</a> <a href="#ref-for-compression-context①">(2)</a>
     <li><a href="#ref-for-compression-context②">5. Interface CompressionStream</a>
     <li><a href="#ref-for-compression-context③">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compressionstream">
-   <b><a href="#compressionstream">#compressionstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compressionstream" class="dfn-panel" data-for="compressionstream" id="infopanel-for-compressionstream" role="dialog">
+   <span id="infopaneltitle-for-compressionstream" style="display:none">Info about the 'CompressionStream' definition.</span><b><a href="#compressionstream">#compressionstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressionstream">5. Interface CompressionStream</a> <a href="#ref-for-compressionstream①">(2)</a> <a href="#ref-for-compressionstream②">(3)</a> <a href="#ref-for-compressionstream③">(4)</a> <a href="#ref-for-compressionstream④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compressionstream-format">
-   <b><a href="#compressionstream-format">#compressionstream-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compressionstream-format" class="dfn-panel" data-for="compressionstream-format" id="infopanel-for-compressionstream-format" role="dialog">
+   <span id="infopaneltitle-for-compressionstream-format" style="display:none">Info about the 'format' definition.</span><b><a href="#compressionstream-format">#compressionstream-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressionstream-format">5. Interface CompressionStream</a> <a href="#ref-for-compressionstream-format①">(2)</a> <a href="#ref-for-compressionstream-format②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compressionstream-context">
-   <b><a href="#compressionstream-context">#compressionstream-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compressionstream-context" class="dfn-panel" data-for="compressionstream-context" id="infopanel-for-compressionstream-context" role="dialog">
+   <span id="infopaneltitle-for-compressionstream-context" style="display:none">Info about the 'context' definition.</span><b><a href="#compressionstream-context">#compressionstream-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressionstream-context">5. Interface CompressionStream</a> <a href="#ref-for-compressionstream-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-compressionstream-compressionstream">
-   <b><a href="#dom-compressionstream-compressionstream">#dom-compressionstream-compressionstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-compressionstream-compressionstream" class="dfn-panel" data-for="dom-compressionstream-compressionstream" id="infopanel-for-dom-compressionstream-compressionstream" role="dialog">
+   <span id="infopaneltitle-for-dom-compressionstream-compressionstream" style="display:none">Info about the 'new CompressionStream(format)' definition.</span><b><a href="#dom-compressionstream-compressionstream">#dom-compressionstream-compressionstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-compressionstream-compressionstream">5. Interface CompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compress-and-enqueue-a-chunk">
-   <b><a href="#compress-and-enqueue-a-chunk">#compress-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compress-and-enqueue-a-chunk" class="dfn-panel" data-for="compress-and-enqueue-a-chunk" id="infopanel-for-compress-and-enqueue-a-chunk" role="dialog">
+   <span id="infopaneltitle-for-compress-and-enqueue-a-chunk" style="display:none">Info about the 'compress and enqueue a chunk' definition.</span><b><a href="#compress-and-enqueue-a-chunk">#compress-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compress-and-enqueue-a-chunk">5. Interface CompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compress-flush-and-enqueue">
-   <b><a href="#compress-flush-and-enqueue">#compress-flush-and-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compress-flush-and-enqueue" class="dfn-panel" data-for="compress-flush-and-enqueue" id="infopanel-for-compress-flush-and-enqueue" role="dialog">
+   <span id="infopaneltitle-for-compress-flush-and-enqueue" style="display:none">Info about the 'compress flush and enqueue' definition.</span><b><a href="#compress-flush-and-enqueue">#compress-flush-and-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compress-flush-and-enqueue">5. Interface CompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decompressionstream">
-   <b><a href="#decompressionstream">#decompressionstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decompressionstream" class="dfn-panel" data-for="decompressionstream" id="infopanel-for-decompressionstream" role="dialog">
+   <span id="infopaneltitle-for-decompressionstream" style="display:none">Info about the 'DecompressionStream' definition.</span><b><a href="#decompressionstream">#decompressionstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decompressionstream">6. Interface DecompressionStream</a> <a href="#ref-for-decompressionstream①">(2)</a> <a href="#ref-for-decompressionstream②">(3)</a> <a href="#ref-for-decompressionstream③">(4)</a> <a href="#ref-for-decompressionstream④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decompressionstream-format">
-   <b><a href="#decompressionstream-format">#decompressionstream-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decompressionstream-format" class="dfn-panel" data-for="decompressionstream-format" id="infopanel-for-decompressionstream-format" role="dialog">
+   <span id="infopaneltitle-for-decompressionstream-format" style="display:none">Info about the 'format' definition.</span><b><a href="#decompressionstream-format">#decompressionstream-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decompressionstream-format">6. Interface DecompressionStream</a> <a href="#ref-for-decompressionstream-format①">(2)</a> <a href="#ref-for-decompressionstream-format②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decompressionstream-context">
-   <b><a href="#decompressionstream-context">#decompressionstream-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decompressionstream-context" class="dfn-panel" data-for="decompressionstream-context" id="infopanel-for-decompressionstream-context" role="dialog">
+   <span id="infopaneltitle-for-decompressionstream-context" style="display:none">Info about the 'context' definition.</span><b><a href="#decompressionstream-context">#decompressionstream-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decompressionstream-context">6. Interface DecompressionStream</a> <a href="#ref-for-decompressionstream-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-decompressionstream-decompressionstream">
-   <b><a href="#dom-decompressionstream-decompressionstream">#dom-decompressionstream-decompressionstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-decompressionstream-decompressionstream" class="dfn-panel" data-for="dom-decompressionstream-decompressionstream" id="infopanel-for-dom-decompressionstream-decompressionstream" role="dialog">
+   <span id="infopaneltitle-for-dom-decompressionstream-decompressionstream" style="display:none">Info about the 'new DecompressionStream(format)' definition.</span><b><a href="#dom-decompressionstream-decompressionstream">#dom-decompressionstream-decompressionstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-decompressionstream-decompressionstream">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decompress-and-enqueue-a-chunk">
-   <b><a href="#decompress-and-enqueue-a-chunk">#decompress-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decompress-and-enqueue-a-chunk" class="dfn-panel" data-for="decompress-and-enqueue-a-chunk" id="infopanel-for-decompress-and-enqueue-a-chunk" role="dialog">
+   <span id="infopaneltitle-for-decompress-and-enqueue-a-chunk" style="display:none">Info about the 'decompress and enqueue a chunk' definition.</span><b><a href="#decompress-and-enqueue-a-chunk">#decompress-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decompress-and-enqueue-a-chunk">6. Interface DecompressionStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decompress-flush-and-enqueue">
-   <b><a href="#decompress-flush-and-enqueue">#decompress-flush-and-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decompress-flush-and-enqueue" class="dfn-panel" data-for="decompress-flush-and-enqueue" id="infopanel-for-decompress-flush-and-enqueue" role="dialog">
+   <span id="infopaneltitle-for-decompress-flush-and-enqueue" style="display:none">Info about the 'decompress flush and enqueue' definition.</span><b><a href="#decompress-flush-and-enqueue">#decompress-flush-and-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decompress-flush-and-enqueue">6. Interface DecompressionStream</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/construct-stylesheets/index.html
+++ b/tests/github/WICG/construct-stylesheets/index.html
@@ -2484,26 +2484,26 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
    <li><a href="#dom-cssstylesheet-replace">replace(text)</a><span>, in § 4</span>
    <li><a href="#dom-cssstylesheetinit-title">title</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-at-ruledef-import①">(2)</a> <a href="#ref-for-at-ruledef-import②">(3)</a> <a href="#ref-for-at-ruledef-import③">(4)</a> <a href="#ref-for-at-ruledef-import④">(5)</a> <a href="#ref-for-at-ruledef-import⑤">(6)</a> <a href="#ref-for-at-ruledef-import⑥">(7)</a> <a href="#ref-for-at-ruledef-import⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-list-of-rules">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-rules">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-rules</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-list-of-rules" class="dfn-panel" data-for="term-for-parse-a-list-of-rules" id="infopanel-for-term-for-parse-a-list-of-rules" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-list-of-rules" style="display:none">Info about the 'parse a list of rules' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-rules">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-rules</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-rules">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-parse-a-list-of-rules①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-rule">https://drafts.csswg.org/css-syntax-3/#parse-a-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-rule" class="dfn-panel" data-for="term-for-parse-a-rule" id="infopanel-for-term-for-parse-a-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-rule" style="display:none">Info about the 'parse a rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-rule">https://drafts.csswg.org/css-syntax-3/#parse-a-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-rule">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstylesheet">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstylesheet">https://drafts.csswg.org/cssom-1/#cssstylesheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylesheet" class="dfn-panel" data-for="term-for-cssstylesheet" id="infopanel-for-term-for-cssstylesheet" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylesheet" style="display:none">Info about the 'CSSStyleSheet' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstylesheet">https://drafts.csswg.org/cssom-1/#cssstylesheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylesheet">Unnumbered Section</a>
     <li><a href="#ref-for-cssstylesheet①">3. Constructing Stylesheets</a> <a href="#ref-for-cssstylesheet②">(2)</a> <a href="#ref-for-cssstylesheet③">(3)</a> <a href="#ref-for-cssstylesheet④">(4)</a>
@@ -2511,228 +2511,228 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
     <li><a href="#ref-for-cssstylesheet⑨">5. Using Constructed Stylesheets</a> <a href="#ref-for-cssstylesheet①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-medialist">
-   <a href="https://drafts.csswg.org/cssom-1/#medialist">https://drafts.csswg.org/cssom-1/#medialist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-medialist" class="dfn-panel" data-for="term-for-medialist" id="infopanel-for-term-for-medialist" role="menu">
+   <span id="infopaneltitle-for-term-for-medialist" style="display:none">Info about the 'MediaList' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#medialist">https://drafts.csswg.org/cssom-1/#medialist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-medialist">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-alternate-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-alternate-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-alternate-flag" id="infopanel-for-term-for-concept-css-style-sheet-alternate-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-alternate-flag" style="display:none">Info about the 'alternate flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-alternate-flag">3. Constructing Stylesheets</a> <a href="#ref-for-concept-css-style-sheet-alternate-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-medialist-object">
-   <a href="https://drafts.csswg.org/cssom-1/#create-a-medialist-object">https://drafts.csswg.org/cssom-1/#create-a-medialist-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-medialist-object" class="dfn-panel" data-for="term-for-create-a-medialist-object" id="infopanel-for-term-for-create-a-medialist-object" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-medialist-object" style="display:none">Info about the 'create a medialist object' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#create-a-medialist-object">https://drafts.csswg.org/cssom-1/#create-a-medialist-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-medialist-object">3. Constructing Stylesheets</a> <a href="#ref-for-create-a-medialist-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#css-rule">https://drafts.csswg.org/cssom-1/#css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-rule" class="dfn-panel" data-for="term-for-css-rule" id="infopanel-for-term-for-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-css-rule" style="display:none">Info about the 'css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#css-rule">https://drafts.csswg.org/cssom-1/#css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-rule">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-css-rule①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-disabled-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-disabled-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-disabled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-disabled-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-disabled-flag" id="infopanel-for-term-for-concept-css-style-sheet-disabled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-disabled-flag" style="display:none">Info about the 'disabled flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-disabled-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-disabled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-disabled-flag">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">
-   <a href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets">https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" class="dfn-panel" data-for="term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" id="infopanel-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" style="display:none">Info about the 'document or shadow root css style sheets' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets">https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-location">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-location" class="dfn-panel" data-for="term-for-concept-css-style-sheet-location" id="infopanel-for-term-for-concept-css-style-sheet-location" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-location" style="display:none">Info about the 'location' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-location">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-media">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-media" class="dfn-panel" data-for="term-for-concept-css-style-sheet-media" id="infopanel-for-term-for-concept-css-style-sheet-media" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-media" style="display:none">Info about the 'media' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-media">3. Constructing Stylesheets</a> <a href="#ref-for-concept-css-style-sheet-media①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag" id="infopanel-for-term-for-concept-css-style-sheet-origin-clean-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" style="display:none">Info about the 'origin-clean flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-owner-css-rule" class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-css-rule" id="infopanel-for-term-for-concept-css-style-sheet-owner-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-owner-css-rule" style="display:none">Info about the 'owner css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-css-rule">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-node">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-owner-node" class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-node" id="infopanel-for-term-for-concept-css-style-sheet-owner-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-owner-node" style="display:none">Info about the 'owner node' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-node">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-parent-css-style-sheet">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-parent-css-style-sheet" class="dfn-panel" data-for="term-for-concept-css-style-sheet-parent-css-style-sheet" id="infopanel-for-term-for-concept-css-style-sheet-parent-css-style-sheet" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-parent-css-style-sheet" style="display:none">Info about the 'parent css style sheet' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet">3. Constructing Stylesheets</a>
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet①">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-media-query-list">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-media-query-list">https://drafts.csswg.org/cssom-1/#serialize-a-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-media-query-list" class="dfn-panel" data-for="term-for-serialize-a-media-query-list" id="infopanel-for-term-for-serialize-a-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-media-query-list" style="display:none">Info about the 'serialize a media query list' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-media-query-list">https://drafts.csswg.org/cssom-1/#serialize-a-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-media-query-list">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-documentorshadowroot-stylesheets">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets">https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-documentorshadowroot-stylesheets" class="dfn-panel" data-for="term-for-dom-documentorshadowroot-stylesheets" id="infopanel-for-term-for-dom-documentorshadowroot-stylesheets" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-documentorshadowroot-stylesheets" style="display:none">Info about the 'styleSheets' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets">https://drafts.csswg.org/cssom-1/#dom-documentorshadowroot-stylesheets</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentorshadowroot-stylesheets">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-title">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-title" class="dfn-panel" data-for="term-for-concept-css-style-sheet-title" id="infopanel-for-term-for-concept-css-style-sheet-title" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-title" style="display:none">Info about the 'title' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-title">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">Unnumbered Section</a>
     <li><a href="#ref-for-documentorshadowroot①">5. Using Constructed Stylesheets</a> <a href="#ref-for-documentorshadowroot②">(2)</a> <a href="#ref-for-documentorshadowroot③">(3)</a> <a href="#ref-for-documentorshadowroot④">(4)</a> <a href="#ref-for-documentorshadowroot⑤">(5)</a> <a href="#ref-for-documentorshadowroot⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadowroot">
-   <a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadowroot" class="dfn-panel" data-for="term-for-shadowroot" id="infopanel-for-term-for-shadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-shadowroot" style="display:none">Info about the 'ShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-adopt-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-node-adopt-ext">https://dom.spec.whatwg.org/#concept-node-adopt-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-adopt-ext" class="dfn-panel" data-for="term-for-concept-node-adopt-ext" id="infopanel-for-term-for-concept-node-adopt-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-adopt-ext" style="display:none">Info about the 'adopting steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-adopt-ext">https://dom.spec.whatwg.org/#concept-node-adopt-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-adopt-ext">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch-group">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch-group">https://fetch.spec.whatwg.org/#concept-fetch-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch-group" class="dfn-panel" data-for="term-for-concept-fetch-group" id="infopanel-for-term-for-concept-fetch-group" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch-group" style="display:none">Info about the 'fetch group' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch-group">https://fetch.spec.whatwg.org/#concept-fetch-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-group">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">3. Constructing Stylesheets</a> <a href="#ref-for-concept-document-window①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-link-options-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#link-options-base-url">https://html.spec.whatwg.org/multipage/semantics.html#link-options-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-link-options-base-url" class="dfn-panel" data-for="term-for-link-options-base-url" id="infopanel-for-term-for-link-options-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-link-options-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#link-options-base-url">https://html.spec.whatwg.org/multipage/semantics.html#link-options-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-options-base-url">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3. Constructing Stylesheets</a> <a href="#ref-for-current-global-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networking-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networking-task-source" class="dfn-panel" data-for="term-for-networking-task-source" id="infopanel-for-term-for-networking-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-networking-task-source" style="display:none">Info about the 'networking task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networking-task-source">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-networking-task-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-queue-a-task①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a> <a href="#ref-for-idl-DOMException⑥">(7)</a>
     <li><a href="#ref-for-idl-DOMException⑦">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Constructing Stylesheets</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networkerror">
-   <a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networkerror" class="dfn-panel" data-for="term-for-networkerror" id="infopanel-for-term-for-networkerror" role="menu">
+   <span id="infopaneltitle-for-term-for-networkerror" style="display:none">Info about the 'NetworkError' external reference.</span><a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-notallowederror①">(2)</a> <a href="#ref-for-notallowederror②">(3)</a> <a href="#ref-for-notallowederror③">(4)</a> <a href="#ref-for-notallowederror④">(5)</a> <a href="#ref-for-notallowederror⑤">(6)</a>
     <li><a href="#ref-for-notallowederror⑥">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. Constructing Stylesheets</a> <a href="#ref-for-idl-USVString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. Constructing Stylesheets</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. Constructing Stylesheets</a>
    </ul>
@@ -2851,155 +2851,211 @@ set <var>sheet</var>’s <a data-link-type="dfn" href="https://drafts.csswg.org/
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dictdef-cssstylesheetinit">
-   <b><a href="#dictdef-cssstylesheetinit">#dictdef-cssstylesheetinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cssstylesheetinit" class="dfn-panel" data-for="dictdef-cssstylesheetinit" id="infopanel-for-dictdef-cssstylesheetinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cssstylesheetinit" style="display:none">Info about the 'CSSStyleSheetInit' definition.</span><b><a href="#dictdef-cssstylesheetinit">#dictdef-cssstylesheetinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cssstylesheetinit">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheetinit-media">
-   <b><a href="#dom-cssstylesheetinit-media">#dom-cssstylesheetinit-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheetinit-media" class="dfn-panel" data-for="dom-cssstylesheetinit-media" id="infopanel-for-dom-cssstylesheetinit-media" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheetinit-media" style="display:none">Info about the 'media' definition.</span><b><a href="#dom-cssstylesheetinit-media">#dom-cssstylesheetinit-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheetinit-media">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheetinit-title">
-   <b><a href="#dom-cssstylesheetinit-title">#dom-cssstylesheetinit-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheetinit-title" class="dfn-panel" data-for="dom-cssstylesheetinit-title" id="infopanel-for-dom-cssstylesheetinit-title" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheetinit-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-cssstylesheetinit-title">#dom-cssstylesheetinit-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheetinit-title">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheetinit-alternate">
-   <b><a href="#dom-cssstylesheetinit-alternate">#dom-cssstylesheetinit-alternate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheetinit-alternate" class="dfn-panel" data-for="dom-cssstylesheetinit-alternate" id="infopanel-for-dom-cssstylesheetinit-alternate" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheetinit-alternate" style="display:none">Info about the 'alternate' definition.</span><b><a href="#dom-cssstylesheetinit-alternate">#dom-cssstylesheetinit-alternate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheetinit-alternate">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheetinit-disabled">
-   <b><a href="#dom-cssstylesheetinit-disabled">#dom-cssstylesheetinit-disabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheetinit-disabled" class="dfn-panel" data-for="dom-cssstylesheetinit-disabled" id="infopanel-for-dom-cssstylesheetinit-disabled" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheetinit-disabled" style="display:none">Info about the 'disabled' definition.</span><b><a href="#dom-cssstylesheetinit-disabled">#dom-cssstylesheetinit-disabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheetinit-disabled">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-cssstylesheet">
-   <b><a href="#dom-cssstylesheet-cssstylesheet">#dom-cssstylesheet-cssstylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-cssstylesheet" class="dfn-panel" data-for="dom-cssstylesheet-cssstylesheet" id="infopanel-for-dom-cssstylesheet-cssstylesheet" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-cssstylesheet" style="display:none">Info about the 'CSSStyleSheet(options)' definition.</span><b><a href="#dom-cssstylesheet-cssstylesheet">#dom-cssstylesheet-cssstylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-cssstylesheet">3. Constructing Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylesheet-constructed-flag">
-   <b><a href="#cssstylesheet-constructed-flag">#cssstylesheet-constructed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylesheet-constructed-flag" class="dfn-panel" data-for="cssstylesheet-constructed-flag" id="infopanel-for-cssstylesheet-constructed-flag" role="dialog">
+   <span id="infopaneltitle-for-cssstylesheet-constructed-flag" style="display:none">Info about the 'constructed flag' definition.</span><b><a href="#cssstylesheet-constructed-flag">#cssstylesheet-constructed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylesheet-constructed-flag">3. Constructing Stylesheets</a> <a href="#ref-for-cssstylesheet-constructed-flag①">(2)</a>
     <li><a href="#ref-for-cssstylesheet-constructed-flag②">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-cssstylesheet-constructed-flag③">(2)</a> <a href="#ref-for-cssstylesheet-constructed-flag④">(3)</a> <a href="#ref-for-cssstylesheet-constructed-flag⑤">(4)</a> <a href="#ref-for-cssstylesheet-constructed-flag⑥">(5)</a> <a href="#ref-for-cssstylesheet-constructed-flag⑦">(6)</a>
     <li><a href="#ref-for-cssstylesheet-constructed-flag⑧">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylesheet-disallow-modification-flag">
-   <b><a href="#cssstylesheet-disallow-modification-flag">#cssstylesheet-disallow-modification-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylesheet-disallow-modification-flag" class="dfn-panel" data-for="cssstylesheet-disallow-modification-flag" id="infopanel-for-cssstylesheet-disallow-modification-flag" role="dialog">
+   <span id="infopaneltitle-for-cssstylesheet-disallow-modification-flag" style="display:none">Info about the 'disallow modification flag' definition.</span><b><a href="#cssstylesheet-disallow-modification-flag">#cssstylesheet-disallow-modification-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylesheet-disallow-modification-flag">4. Modifying Constructed Stylesheets</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag①">(2)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag②">(3)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag③">(4)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag④">(5)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag⑤">(6)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag⑥">(7)</a> <a href="#ref-for-cssstylesheet-disallow-modification-flag⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylesheet-constructor-document">
-   <b><a href="#cssstylesheet-constructor-document">#cssstylesheet-constructor-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylesheet-constructor-document" class="dfn-panel" data-for="cssstylesheet-constructor-document" id="infopanel-for-cssstylesheet-constructor-document" role="dialog">
+   <span id="infopaneltitle-for-cssstylesheet-constructor-document" style="display:none">Info about the 'constructor document' definition.</span><b><a href="#cssstylesheet-constructor-document">#cssstylesheet-constructor-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylesheet-constructor-document">3. Constructing Stylesheets</a>
     <li><a href="#ref-for-cssstylesheet-constructor-document①">4. Modifying Constructed Stylesheets</a>
     <li><a href="#ref-for-cssstylesheet-constructor-document②">5. Using Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-insertrule">
-   <b><a href="#dom-cssstylesheet-insertrule">#dom-cssstylesheet-insertrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-insertrule" class="dfn-panel" data-for="dom-cssstylesheet-insertrule" id="infopanel-for-dom-cssstylesheet-insertrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-insertrule" style="display:none">Info about the 'insertRule(rule, index)' definition.</span><b><a href="#dom-cssstylesheet-insertrule">#dom-cssstylesheet-insertrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-insertrule">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-deleterule">
-   <b><a href="#dom-cssstylesheet-deleterule">#dom-cssstylesheet-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-deleterule" class="dfn-panel" data-for="dom-cssstylesheet-deleterule" id="infopanel-for-dom-cssstylesheet-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-deleterule" style="display:none">Info about the 'deleteRule(index)' definition.</span><b><a href="#dom-cssstylesheet-deleterule">#dom-cssstylesheet-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-deleterule">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-replace">
-   <b><a href="#dom-cssstylesheet-replace">#dom-cssstylesheet-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-replace" class="dfn-panel" data-for="dom-cssstylesheet-replace" id="infopanel-for-dom-cssstylesheet-replace" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-replace" style="display:none">Info about the 'replace(text)' definition.</span><b><a href="#dom-cssstylesheet-replace">#dom-cssstylesheet-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-replace">3. Constructing Stylesheets</a>
     <li><a href="#ref-for-dom-cssstylesheet-replace①">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-replacesync">
-   <b><a href="#dom-cssstylesheet-replacesync">#dom-cssstylesheet-replacesync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-replacesync" class="dfn-panel" data-for="dom-cssstylesheet-replacesync" id="infopanel-for-dom-cssstylesheet-replacesync" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-replacesync" style="display:none">Info about the 'replaceSync(text)' definition.</span><b><a href="#dom-cssstylesheet-replacesync">#dom-cssstylesheet-replacesync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-replacesync">3. Constructing Stylesheets</a>
     <li><a href="#ref-for-dom-cssstylesheet-replacesync①">4. Modifying Constructed Stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documentorshadowroot-adoptedstylesheets">
-   <b><a href="#dom-documentorshadowroot-adoptedstylesheets">#dom-documentorshadowroot-adoptedstylesheets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documentorshadowroot-adoptedstylesheets" class="dfn-panel" data-for="dom-documentorshadowroot-adoptedstylesheets" id="infopanel-for-dom-documentorshadowroot-adoptedstylesheets" role="dialog">
+   <span id="infopaneltitle-for-dom-documentorshadowroot-adoptedstylesheets" style="display:none">Info about the 'adoptedStyleSheets' definition.</span><b><a href="#dom-documentorshadowroot-adoptedstylesheets">#dom-documentorshadowroot-adoptedstylesheets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets①">(2)</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets②">(3)</a> <a href="#ref-for-dom-documentorshadowroot-adoptedstylesheets③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="adopted-stylesheets">
-   <b><a href="#adopted-stylesheets">#adopted-stylesheets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-adopted-stylesheets" class="dfn-panel" data-for="adopted-stylesheets" id="infopanel-for-adopted-stylesheets" role="dialog">
+   <span id="infopaneltitle-for-adopted-stylesheets" style="display:none">Info about the 'adopted stylesheets' definition.</span><b><a href="#adopted-stylesheets">#adopted-stylesheets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-adopted-stylesheets">5. Using Constructed Stylesheets</a> <a href="#ref-for-adopted-stylesheets①">(2)</a> <a href="#ref-for-adopted-stylesheets②">(3)</a> <a href="#ref-for-adopted-stylesheets③">(4)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/contact-api/spec/index.html
+++ b/tests/github/WICG/contact-api/spec/index.html
@@ -1088,145 +1088,145 @@ remove the UI and return a <a data-link-type="dfn" href="https://infra.spec.what
    <li><a href="#dom-contactinfo-tel">tel</a><span>, in § 5.3</span>
    <li><a href="#user-contact">user contact</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">4.1. User contact</a> <a href="#ref-for-dfn-Blob①">(2)</a>
     <li><a href="#ref-for-dfn-Blob②">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">4.1. User contact</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlbuttonelement">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlbuttonelement" class="dfn-panel" data-for="term-for-htmlbuttonelement" id="infopanel-for-term-for-htmlbuttonelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlbuttonelement" style="display:none">Info about the 'HTMLButtonElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlbuttonelement">1.1. Examples</a> <a href="#ref-for-htmlbuttonelement①">(2)</a> <a href="#ref-for-htmlbuttonelement②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">1.1. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">5.1. Extensions to Navigator</a> <a href="#ref-for-navigator①">(2)</a> <a href="#ref-for-navigator②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">5.1. Extensions to Navigator</a>
     <li><a href="#ref-for-browsing-context①">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">4. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.3.1. getProperties()</a>
     <li><a href="#ref-for-in-parallel①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3. Realms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4. Infrastructure</a>
     <li><a href="#ref-for-relevant-settings-object①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">4. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">4. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2. Privacy Considerations</a>
     <li><a href="#ref-for-top-level-browsing-context①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boolean">
-   <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boolean" class="dfn-panel" data-for="term-for-boolean" id="infopanel-for-term-for-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">5.3.2. select()</a> <a href="#ref-for-list-contain①">(2)</a> <a href="#ref-for-list-contain②">(3)</a> <a href="#ref-for-list-contain③">(4)</a> <a href="#ref-for-list-contain④">(5)</a> <a href="#ref-for-list-contain⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.3.2. select()</a> <a href="#ref-for-list-iterate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.1. User contact</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a> <a href="#ref-for-list-item③">(4)</a> <a href="#ref-for-list-item④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">4.1. User contact</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a> <a href="#ref-for-list③">(4)</a> <a href="#ref-for-list④">(5)</a>
     <li><a href="#ref-for-list⑤">4.2. Contacts source</a> <a href="#ref-for-list⑥">(2)</a>
@@ -1234,102 +1234,102 @@ remove the UI and return a <a data-link-type="dfn" href="https://infra.spec.what
     <li><a href="#ref-for-list⑧">6. Contact Picker</a> <a href="#ref-for-list⑨">(2)</a> <a href="#ref-for-list①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-image-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#image-mime-type">https://mimesniff.spec.whatwg.org/#image-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-image-mime-type" class="dfn-panel" data-for="term-for-image-mime-type" id="infopanel-for-term-for-image-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-image-mime-type" style="display:none">Info about the 'image mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#image-mime-type">https://mimesniff.spec.whatwg.org/#image-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-mime-type">4.1. User contact</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-paymentaddress">
-   <a href="https://www.w3.org/TR/payment-request/#dom-paymentaddress">https://www.w3.org/TR/payment-request/#dom-paymentaddress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-paymentaddress" class="dfn-panel" data-for="term-for-dom-paymentaddress" id="infopanel-for-term-for-dom-paymentaddress" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-paymentaddress" style="display:none">Info about the 'PaymentAddress' external reference.</span><a href="https://www.w3.org/TR/payment-request/#dom-paymentaddress">https://www.w3.org/TR/payment-request/#dom-paymentaddress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paymentaddress">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-addresses">
-   <a href="https://www.w3.org/TR/payment-request/#physical-addresses">https://www.w3.org/TR/payment-request/#physical-addresses</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-addresses" class="dfn-panel" data-for="term-for-physical-addresses" id="infopanel-for-term-for-physical-addresses" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-addresses" style="display:none">Info about the 'physical addresses' external reference.</span><a href="https://www.w3.org/TR/payment-request/#physical-addresses">https://www.w3.org/TR/payment-request/#physical-addresses</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-addresses">4.1. User contact</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">5.3.2. select()</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.1. User contact</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">5.3. ContactsManager</a> <a href="#ref-for-idl-DOMString④">(2)</a> <a href="#ref-for-idl-DOMString⑤">(3)</a>
     <li><a href="#ref-for-idl-DOMString⑥">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. Extensions to Navigator</a>
     <li><a href="#ref-for-Exposed①">5.3. ContactsManager</a> <a href="#ref-for-Exposed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">5.3.2. select()</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.3. ContactsManager</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.1. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5.3.2. select()</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">5.3.1. getProperties()</a>
     <li><a href="#ref-for-a-new-promise①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">5.3.2. select()</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a> <a href="#ref-for-a-promise-rejected-with③">(4)</a> <a href="#ref-for-a-promise-rejected-with④">(5)</a> <a href="#ref-for-a-promise-rejected-with⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.3. ContactsManager</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a> <a href="#ref-for-idl-sequence④">(5)</a> <a href="#ref-for-idl-sequence⑤">(6)</a> <a href="#ref-for-idl-sequence⑥">(7)</a> <a href="#ref-for-idl-sequence⑦">(8)</a>
    </ul>
@@ -1451,20 +1451,20 @@ remove the UI and return a <a data-link-type="dfn" href="https://infra.spec.what
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="contact-picker-task-source">
-   <b><a href="#contact-picker-task-source">#contact-picker-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contact-picker-task-source" class="dfn-panel" data-for="contact-picker-task-source" id="infopanel-for-contact-picker-task-source" role="dialog">
+   <span id="infopaneltitle-for-contact-picker-task-source" style="display:none">Info about the 'contact picker task source' definition.</span><b><a href="#contact-picker-task-source">#contact-picker-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contact-picker-task-source">4. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-contact-picker-task">
-   <b><a href="#queue-a-contact-picker-task">#queue-a-contact-picker-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-contact-picker-task" class="dfn-panel" data-for="queue-a-contact-picker-task" id="infopanel-for-queue-a-contact-picker-task" role="dialog">
+   <span id="infopaneltitle-for-queue-a-contact-picker-task" style="display:none">Info about the 'queue a contact picker task' definition.</span><b><a href="#queue-a-contact-picker-task">#queue-a-contact-picker-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-contact-picker-task">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact">
-   <b><a href="#user-contact">#user-contact</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact" class="dfn-panel" data-for="user-contact" id="infopanel-for-user-contact" role="dialog">
+   <span id="infopaneltitle-for-user-contact" style="display:none">Info about the 'user contact' definition.</span><b><a href="#user-contact">#user-contact</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact">4.1. User contact</a>
     <li><a href="#ref-for-user-contact①">4.2. Contacts source</a>
@@ -1472,43 +1472,43 @@ remove the UI and return a <a data-link-type="dfn" href="https://infra.spec.what
     <li><a href="#ref-for-user-contact⑧">6. Contact Picker</a> <a href="#ref-for-user-contact⑨">(2)</a> <a href="#ref-for-user-contact①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-names">
-   <b><a href="#user-contact-names">#user-contact-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-names" class="dfn-panel" data-for="user-contact-names" id="infopanel-for-user-contact-names" role="dialog">
+   <span id="infopaneltitle-for-user-contact-names" style="display:none">Info about the 'names' definition.</span><b><a href="#user-contact-names">#user-contact-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-names">5.2. ContactProperty</a>
     <li><a href="#ref-for-user-contact-names①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-emails">
-   <b><a href="#user-contact-emails">#user-contact-emails</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-emails" class="dfn-panel" data-for="user-contact-emails" id="infopanel-for-user-contact-emails" role="dialog">
+   <span id="infopaneltitle-for-user-contact-emails" style="display:none">Info about the 'emails' definition.</span><b><a href="#user-contact-emails">#user-contact-emails</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-emails">5.2. ContactProperty</a>
     <li><a href="#ref-for-user-contact-emails①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-numbers">
-   <b><a href="#user-contact-numbers">#user-contact-numbers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-numbers" class="dfn-panel" data-for="user-contact-numbers" id="infopanel-for-user-contact-numbers" role="dialog">
+   <span id="infopaneltitle-for-user-contact-numbers" style="display:none">Info about the 'numbers' definition.</span><b><a href="#user-contact-numbers">#user-contact-numbers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-numbers">5.2. ContactProperty</a>
     <li><a href="#ref-for-user-contact-numbers①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-addresses">
-   <b><a href="#user-contact-addresses">#user-contact-addresses</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-addresses" class="dfn-panel" data-for="user-contact-addresses" id="infopanel-for-user-contact-addresses" role="dialog">
+   <span id="infopaneltitle-for-user-contact-addresses" style="display:none">Info about the 'addresses' definition.</span><b><a href="#user-contact-addresses">#user-contact-addresses</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-addresses">5.2. ContactProperty</a>
     <li><a href="#ref-for-user-contact-addresses①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-icons">
-   <b><a href="#user-contact-icons">#user-contact-icons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-icons" class="dfn-panel" data-for="user-contact-icons" id="infopanel-for-user-contact-icons" role="dialog">
+   <span id="infopaneltitle-for-user-contact-icons" style="display:none">Info about the 'icons' definition.</span><b><a href="#user-contact-icons">#user-contact-icons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-icons">5.2. ContactProperty</a>
     <li><a href="#ref-for-user-contact-icons①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-contact-contacts-source">
-   <b><a href="#user-contact-contacts-source">#user-contact-contacts-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-contact-contacts-source" class="dfn-panel" data-for="user-contact-contacts-source" id="infopanel-for-user-contact-contacts-source" role="dialog">
+   <span id="infopaneltitle-for-user-contact-contacts-source" style="display:none">Info about the 'contacts source' definition.</span><b><a href="#user-contact-contacts-source">#user-contact-contacts-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-contact-contacts-source">4.2. Contacts source</a> <a href="#ref-for-user-contact-contacts-source①">(2)</a>
     <li><a href="#ref-for-user-contact-contacts-source②">5.3.1. getProperties()</a>
@@ -1516,183 +1516,239 @@ remove the UI and return a <a data-link-type="dfn" href="https://infra.spec.what
     <li><a href="#ref-for-user-contact-contacts-source④">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contacts-source-available-contacts">
-   <b><a href="#contacts-source-available-contacts">#contacts-source-available-contacts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contacts-source-available-contacts" class="dfn-panel" data-for="contacts-source-available-contacts" id="infopanel-for-contacts-source-available-contacts" role="dialog">
+   <span id="infopaneltitle-for-contacts-source-available-contacts" style="display:none">Info about the 'available contacts' definition.</span><b><a href="#contacts-source-available-contacts">#contacts-source-available-contacts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contacts-source-available-contacts">6. Contact Picker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contacts-source-supported-properties">
-   <b><a href="#contacts-source-supported-properties">#contacts-source-supported-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contacts-source-supported-properties" class="dfn-panel" data-for="contacts-source-supported-properties" id="infopanel-for-contacts-source-supported-properties" role="dialog">
+   <span id="infopaneltitle-for-contacts-source-supported-properties" style="display:none">Info about the 'supported properties' definition.</span><b><a href="#contacts-source-supported-properties">#contacts-source-supported-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contacts-source-supported-properties">5.3.1. getProperties()</a>
     <li><a href="#ref-for-contacts-source-supported-properties①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-contacts-manager">
-   <b><a href="#navigator-contacts-manager">#navigator-contacts-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-contacts-manager" class="dfn-panel" data-for="navigator-contacts-manager" id="infopanel-for-navigator-contacts-manager" role="dialog">
+   <span id="infopaneltitle-for-navigator-contacts-manager" style="display:none">Info about the 'contacts manager' definition.</span><b><a href="#navigator-contacts-manager">#navigator-contacts-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-contacts-manager">5.1. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-contacts">
-   <b><a href="#dom-navigator-contacts">#dom-navigator-contacts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-contacts" class="dfn-panel" data-for="dom-navigator-contacts" id="infopanel-for-dom-navigator-contacts" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-contacts" style="display:none">Info about the 'contacts' definition.</span><b><a href="#dom-navigator-contacts">#dom-navigator-contacts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-contacts">5.1. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contact-picker-is-showing-flag">
-   <b><a href="#contact-picker-is-showing-flag">#contact-picker-is-showing-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contact-picker-is-showing-flag" class="dfn-panel" data-for="contact-picker-is-showing-flag" id="infopanel-for-contact-picker-is-showing-flag" role="dialog">
+   <span id="infopaneltitle-for-contact-picker-is-showing-flag" style="display:none">Info about the 'contact picker is showing flag' definition.</span><b><a href="#contact-picker-is-showing-flag">#contact-picker-is-showing-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contact-picker-is-showing-flag">5.3.2. select()</a> <a href="#ref-for-contact-picker-is-showing-flag①">(2)</a> <a href="#ref-for-contact-picker-is-showing-flag②">(3)</a> <a href="#ref-for-contact-picker-is-showing-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-contactproperty">
-   <b><a href="#enumdef-contactproperty">#enumdef-contactproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-contactproperty" class="dfn-panel" data-for="enumdef-contactproperty" id="infopanel-for-enumdef-contactproperty" role="dialog">
+   <span id="infopaneltitle-for-enumdef-contactproperty" style="display:none">Info about the 'ContactProperty' definition.</span><b><a href="#enumdef-contactproperty">#enumdef-contactproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-contactproperty">4.2. Contacts source</a>
     <li><a href="#ref-for-enumdef-contactproperty①">5.2. ContactProperty</a> <a href="#ref-for-enumdef-contactproperty②">(2)</a>
     <li><a href="#ref-for-enumdef-contactproperty③">5.3. ContactsManager</a> <a href="#ref-for-enumdef-contactproperty④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available">
-   <b><a href="#available">#available</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available" class="dfn-panel" data-for="available" id="infopanel-for-available" role="dialog">
+   <span id="infopaneltitle-for-available" style="display:none">Info about the 'available' definition.</span><b><a href="#available">#available</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">4.2. Contacts source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contactaddress">
-   <b><a href="#contactaddress">#contactaddress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contactaddress" class="dfn-panel" data-for="contactaddress" id="infopanel-for-contactaddress" role="dialog">
+   <span id="infopaneltitle-for-contactaddress" style="display:none">Info about the 'ContactAddress' definition.</span><b><a href="#contactaddress">#contactaddress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contactaddress">4.1. User contact</a>
     <li><a href="#ref-for-contactaddress①">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-contactinfo">
-   <b><a href="#dictdef-contactinfo">#dictdef-contactinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-contactinfo" class="dfn-panel" data-for="dictdef-contactinfo" id="infopanel-for-dictdef-contactinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-contactinfo" style="display:none">Info about the 'ContactInfo' definition.</span><b><a href="#dictdef-contactinfo">#dictdef-contactinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-contactinfo">5.3. ContactsManager</a>
     <li><a href="#ref-for-dictdef-contactinfo①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactinfo-address">
-   <b><a href="#dom-contactinfo-address">#dom-contactinfo-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactinfo-address" class="dfn-panel" data-for="dom-contactinfo-address" id="infopanel-for-dom-contactinfo-address" role="dialog">
+   <span id="infopaneltitle-for-dom-contactinfo-address" style="display:none">Info about the 'address' definition.</span><b><a href="#dom-contactinfo-address">#dom-contactinfo-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactinfo-address">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactinfo-email">
-   <b><a href="#dom-contactinfo-email">#dom-contactinfo-email</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactinfo-email" class="dfn-panel" data-for="dom-contactinfo-email" id="infopanel-for-dom-contactinfo-email" role="dialog">
+   <span id="infopaneltitle-for-dom-contactinfo-email" style="display:none">Info about the 'email' definition.</span><b><a href="#dom-contactinfo-email">#dom-contactinfo-email</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactinfo-email">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactinfo-icon">
-   <b><a href="#dom-contactinfo-icon">#dom-contactinfo-icon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactinfo-icon" class="dfn-panel" data-for="dom-contactinfo-icon" id="infopanel-for-dom-contactinfo-icon" role="dialog">
+   <span id="infopaneltitle-for-dom-contactinfo-icon" style="display:none">Info about the 'icon' definition.</span><b><a href="#dom-contactinfo-icon">#dom-contactinfo-icon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactinfo-icon">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactinfo-name">
-   <b><a href="#dom-contactinfo-name">#dom-contactinfo-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactinfo-name" class="dfn-panel" data-for="dom-contactinfo-name" id="infopanel-for-dom-contactinfo-name" role="dialog">
+   <span id="infopaneltitle-for-dom-contactinfo-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-contactinfo-name">#dom-contactinfo-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactinfo-name">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactinfo-tel">
-   <b><a href="#dom-contactinfo-tel">#dom-contactinfo-tel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactinfo-tel" class="dfn-panel" data-for="dom-contactinfo-tel" id="infopanel-for-dom-contactinfo-tel" role="dialog">
+   <span id="infopaneltitle-for-dom-contactinfo-tel" style="display:none">Info about the 'tel' definition.</span><b><a href="#dom-contactinfo-tel">#dom-contactinfo-tel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactinfo-tel">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-contactsselectoptions">
-   <b><a href="#dictdef-contactsselectoptions">#dictdef-contactsselectoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-contactsselectoptions" class="dfn-panel" data-for="dictdef-contactsselectoptions" id="infopanel-for-dictdef-contactsselectoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-contactsselectoptions" style="display:none">Info about the 'ContactsSelectOptions' definition.</span><b><a href="#dictdef-contactsselectoptions">#dictdef-contactsselectoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-contactsselectoptions">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contactsmanager">
-   <b><a href="#contactsmanager">#contactsmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contactsmanager" class="dfn-panel" data-for="contactsmanager" id="infopanel-for-contactsmanager" role="dialog">
+   <span id="infopaneltitle-for-contactsmanager" style="display:none">Info about the 'ContactsManager' definition.</span><b><a href="#contactsmanager">#contactsmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contactsmanager">5.1. Extensions to Navigator</a> <a href="#ref-for-contactsmanager①">(2)</a> <a href="#ref-for-contactsmanager②">(3)</a>
     <li><a href="#ref-for-contactsmanager③">5.3. ContactsManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactsmanager-getproperties">
-   <b><a href="#dom-contactsmanager-getproperties">#dom-contactsmanager-getproperties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactsmanager-getproperties" class="dfn-panel" data-for="dom-contactsmanager-getproperties" id="infopanel-for-dom-contactsmanager-getproperties" role="dialog">
+   <span id="infopaneltitle-for-dom-contactsmanager-getproperties" style="display:none">Info about the 'getProperties()' definition.</span><b><a href="#dom-contactsmanager-getproperties">#dom-contactsmanager-getproperties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactsmanager-getproperties">5.3. ContactsManager</a>
     <li><a href="#ref-for-dom-contactsmanager-getproperties①">5.3.1. getProperties()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contactsmanager-select">
-   <b><a href="#dom-contactsmanager-select">#dom-contactsmanager-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contactsmanager-select" class="dfn-panel" data-for="dom-contactsmanager-select" id="infopanel-for-dom-contactsmanager-select" role="dialog">
+   <span id="infopaneltitle-for-dom-contactsmanager-select" style="display:none">Info about the 'select(properties, options)' definition.</span><b><a href="#dom-contactsmanager-select">#dom-contactsmanager-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contactsmanager-select">5.3. ContactsManager</a>
     <li><a href="#ref-for-dom-contactsmanager-select①">5.3.2. select()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contactsmanager-launching-a-contact-picker">
-   <b><a href="#contactsmanager-launching-a-contact-picker">#contactsmanager-launching-a-contact-picker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contactsmanager-launching-a-contact-picker" class="dfn-panel" data-for="contactsmanager-launching-a-contact-picker" id="infopanel-for-contactsmanager-launching-a-contact-picker" role="dialog">
+   <span id="infopaneltitle-for-contactsmanager-launching-a-contact-picker" style="display:none">Info about the 'launch' definition.</span><b><a href="#contactsmanager-launching-a-contact-picker">#contactsmanager-launching-a-contact-picker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contactsmanager-launching-a-contact-picker">5.3.2. select()</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/content-index/spec/index.html
+++ b/tests/github/WICG/content-index/spec/index.html
@@ -1594,110 +1594,110 @@ steps.</p>
    <li><a href="#dom-contentdescription-url">url</a><span>, in § 5.3</span>
    <li><a href="#dom-contentcategory-video">"video"</a><span>, in § 5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">3.2. Content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">5.1. Extensions to ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.2. Activate a content index entry</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">4.2. Activate a content index entry</a> <a href="#ref-for-nav-document①">(2)</a> <a href="#ref-for-nav-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list" id="infopanel-for-term-for-concept-location-ancestor-origins-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" style="display:none">Info about the 'ancestor origins list' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-location-ancestor-origins-list">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-creation-url" class="dfn-panel" data-for="term-for-concept-environment-creation-url" id="infopanel-for-term-for-concept-environment-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-creation-url">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">5.3.1. add()</a>
@@ -1705,291 +1705,291 @@ steps.</p>
     <li><a href="#ref-for-enqueue-the-following-steps③">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">4.2. Activate a content index entry</a> <a href="#ref-for-environment-settings-object①">(2)</a> <a href="#ref-for-environment-settings-object②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">5.1.1. Events</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">5.1.1. Events</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">5.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-focus-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-focus-steps" class="dfn-panel" data-for="term-for-has-focus-steps" id="infopanel-for-term-for-has-focus-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-has-focus-steps" style="display:none">Info about the 'has focus steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-focus-steps">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.3.1. add()</a>
     <li><a href="#ref-for-in-parallel①">5.3.2. delete()</a>
     <li><a href="#ref-for-in-parallel②">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.2. Activate a content index entry</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parallel-queue" class="dfn-panel" data-for="term-for-parallel-queue" id="infopanel-for-term-for-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-parallel-queue" style="display:none">Info about the 'parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parallel-queue">3.1. Extensions to service worker registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4.2. Activate a content index entry</a> <a href="#ref-for-queue-a-task①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.3.1. add()</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">3.1. Extensions to service worker registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-interaction-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-interaction-task-source" class="dfn-panel" data-for="term-for-user-interaction-task-source" id="infopanel-for-term-for-user-interaction-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-user-interaction-task-source" style="display:none">Info about the 'user interaction task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-interaction-task-source">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-imageresource">
-   <a href="https://w3c.github.io/image-resource/#dom-imageresource">https://w3c.github.io/image-resource/#dom-imageresource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-imageresource" class="dfn-panel" data-for="term-for-dom-imageresource" id="infopanel-for-term-for-dom-imageresource" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-imageresource" style="display:none">Info about the 'ImageResource' external reference.</span><a href="https://w3c.github.io/image-resource/#dom-imageresource">https://w3c.github.io/image-resource/#dom-imageresource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imageresource">5.3. ContentIndex</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-image-resource">
-   <a href="https://w3c.github.io/image-resource/#image-resource">https://w3c.github.io/image-resource/#image-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-image-resource" class="dfn-panel" data-for="term-for-image-resource" id="infopanel-for-term-for-image-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-image-resource" style="display:none">Info about the 'image resource' external reference.</span><a href="https://w3c.github.io/image-resource/#image-resource">https://w3c.github.io/image-resource/#image-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-resource">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-processing-an-imageresource-from-an-api">
-   <a href="https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api">https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-processing-an-imageresource-from-an-api" class="dfn-panel" data-for="term-for-processing-an-imageresource-from-an-api" id="infopanel-for-term-for-processing-an-imageresource-from-an-api" role="menu">
+   <span id="infopaneltitle-for-term-for-processing-an-imageresource-from-an-api" style="display:none">Info about the 'parsing' external reference.</span><a href="https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api">https://w3c.github.io/image-resource/#processing-an-imageresource-from-an-api</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processing-an-imageresource-from-an-api">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-src">
-   <a href="https://w3c.github.io/image-resource/#dfn-src">https://w3c.github.io/image-resource/#dfn-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-src" class="dfn-panel" data-for="term-for-dfn-src" id="infopanel-for-term-for-dfn-src" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-src" style="display:none">Info about the 'src' external reference.</span><a href="https://w3c.github.io/image-resource/#dfn-src">https://w3c.github.io/image-resource/#dfn-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-src">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.3.1. add()</a>
     <li><a href="#ref-for-list-append①">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.2. Content index entry</a>
     <li><a href="#ref-for-list①">5.3.1. add()</a>
     <li><a href="#ref-for-list②">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. Extensions to service worker registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-map-remove①">5.3.2. delete()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-visibilitystate" class="dfn-panel" data-for="term-for-dom-document-visibilitystate" id="infopanel-for-term-for-dom-document-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-visibilitystate">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">5.4. ContentIndexEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">5.4. ContentIndexEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetchevent">
-   <a href="https://w3c.github.io/ServiceWorker/#fetchevent">https://w3c.github.io/ServiceWorker/#fetchevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetchevent" class="dfn-panel" data-for="term-for-fetchevent" id="infopanel-for-term-for-fetchevent" role="menu">
+   <span id="infopaneltitle-for-term-for-fetchevent" style="display:none">Info about the 'FetchEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fetchevent">https://w3c.github.io/ServiceWorker/#fetchevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworker">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworker" class="dfn-panel" data-for="term-for-serviceworker" id="infopanel-for-term-for-serviceworker" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworker" style="display:none">Info about the 'ServiceWorker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">5.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">5.1. Extensions to ServiceWorkerGlobalScope</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">5.2. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">4.2. Activate a content index entry</a>
     <li><a href="#ref-for-dfn-active-worker①">5.3.1. add()</a> <a href="#ref-for-dfn-active-worker②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-windowclient-algorithm">
-   <a href="https://www.w3.org/TR/service-workers/#create-windowclient-algorithm">https://www.w3.org/TR/service-workers/#create-windowclient-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-windowclient-algorithm" class="dfn-panel" data-for="term-for-create-windowclient-algorithm" id="infopanel-for-term-for-create-windowclient-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-create-windowclient-algorithm" style="display:none">Info about the 'create window client' external reference.</span><a href="https://www.w3.org/TR/service-workers/#create-windowclient-algorithm">https://www.w3.org/TR/service-workers/#create-windowclient-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-windowclient-algorithm">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire a functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">4.3. Fire a content delete event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-global-object">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-global-object">https://w3c.github.io/ServiceWorker/#dfn-service-worker-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-global-object" class="dfn-panel" data-for="term-for-dfn-service-worker-global-object" id="infopanel-for-term-for-dfn-service-worker-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-global-object">https://w3c.github.io/ServiceWorker/#dfn-service-worker-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-global-object">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#match-service-worker-registration">https://w3c.github.io/ServiceWorker/#match-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-service-worker-registration" class="dfn-panel" data-for="term-for-match-service-worker-registration" id="infopanel-for-term-for-match-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-match-service-worker-registration" style="display:none">Info about the 'match service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#match-service-worker-registration">https://w3c.github.io/ServiceWorker/#match-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-service-worker-registration">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-scope-url">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-scope-url" class="dfn-panel" data-for="term-for-dfn-scope-url" id="infopanel-for-term-for-dfn-scope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-scope-url" style="display:none">Info about the 'scope url' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker" class="dfn-panel" data-for="term-for-dfn-service-worker" id="infopanel-for-term-for-dfn-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration" class="dfn-panel" data-for="term-for-dfn-service-worker-registration" id="infopanel-for-term-for-dfn-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">3.2. Content index entry</a>
@@ -1999,96 +1999,96 @@ steps.</p>
     <li><a href="#ref-for-dfn-service-worker-registration⑤">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-of-extended-events">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-set-of-extended-events">https://w3c.github.io/ServiceWorker/#dfn-set-of-extended-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-of-extended-events" class="dfn-panel" data-for="term-for-dfn-set-of-extended-events" id="infopanel-for-term-for-dfn-set-of-extended-events" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-of-extended-events" style="display:none">Info about the 'set of extended events' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-set-of-extended-events">https://w3c.github.io/ServiceWorker/#dfn-set-of-extended-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-extended-events">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3.2. Content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5.3. ContentIndex</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
     <li><a href="#ref-for-idl-DOMString④">5.4. ContentIndexEvent</a> <a href="#ref-for-idl-DOMString⑤">(2)</a> <a href="#ref-for-idl-DOMString⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.3. ContentIndex</a>
     <li><a href="#ref-for-Exposed①">5.4. ContentIndexEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.3. ContentIndex</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.2. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5.3.1. add()</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a> <a href="#ref-for-exceptiondef-typeerror③">(4)</a> <a href="#ref-for-exceptiondef-typeerror④">(5)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">5.3. ContentIndex</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">5.3.1. add()</a>
     <li><a href="#ref-for-a-new-promise①">5.3.2. delete()</a>
     <li><a href="#ref-for-a-new-promise②">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">5.3.1. add()</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a> <a href="#ref-for-reject④">(5)</a> <a href="#ref-for-reject⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.3. ContentIndex</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.3. ContentIndex</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
@@ -2279,8 +2279,8 @@ steps.</p>
    <div class="issue"> Is creating a new Browsing Context the right thing to do here?
     (<a href="https://github.com/wicg/content-index/issues/15">issue</a>) <a class="issue-return" href="#issue-ef5b12db" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="service-worker-registration-content-index-entries">
-   <b><a href="#service-worker-registration-content-index-entries">#service-worker-registration-content-index-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-content-index-entries" class="dfn-panel" data-for="service-worker-registration-content-index-entries" id="infopanel-for-service-worker-registration-content-index-entries" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-content-index-entries" style="display:none">Info about the 'Content index entries' definition.</span><b><a href="#service-worker-registration-content-index-entries">#service-worker-registration-content-index-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-content-index-entries">3.2.1. Display</a>
     <li><a href="#ref-for-service-worker-registration-content-index-entries①">4.1. Delete a content index entry</a>
@@ -2289,8 +2289,8 @@ steps.</p>
     <li><a href="#ref-for-service-worker-registration-content-index-entries④">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-entry-edit-queue">
-   <b><a href="#service-worker-registration-entry-edit-queue">#service-worker-registration-entry-edit-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-entry-edit-queue" class="dfn-panel" data-for="service-worker-registration-entry-edit-queue" id="infopanel-for-service-worker-registration-entry-edit-queue" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-entry-edit-queue" style="display:none">Info about the 'entry edit queue' definition.</span><b><a href="#service-worker-registration-entry-edit-queue">#service-worker-registration-entry-edit-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-entry-edit-queue">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-service-worker-registration-entry-edit-queue①">5.3.1. add()</a>
@@ -2298,8 +2298,8 @@ steps.</p>
     <li><a href="#ref-for-service-worker-registration-entry-edit-queue③">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-index-entry">
-   <b><a href="#content-index-entry">#content-index-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-index-entry" class="dfn-panel" data-for="content-index-entry" id="infopanel-for-content-index-entry" role="dialog">
+   <span id="infopaneltitle-for-content-index-entry" style="display:none">Info about the 'content index entry' definition.</span><b><a href="#content-index-entry">#content-index-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-index-entry">3.1. Extensions to service worker registration</a>
     <li><a href="#ref-for-content-index-entry①">3.2.1. Display</a> <a href="#ref-for-content-index-entry②">(2)</a>
@@ -2310,8 +2310,8 @@ steps.</p>
     <li><a href="#ref-for-content-index-entry⑦">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-index-entry-description">
-   <b><a href="#content-index-entry-description">#content-index-entry-description</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-index-entry-description" class="dfn-panel" data-for="content-index-entry-description" id="infopanel-for-content-index-entry-description" role="dialog">
+   <span id="infopaneltitle-for-content-index-entry-description" style="display:none">Info about the 'description' definition.</span><b><a href="#content-index-entry-description">#content-index-entry-description</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-index-entry-description">3.2.1. Display</a> <a href="#ref-for-content-index-entry-description①">(2)</a> <a href="#ref-for-content-index-entry-description②">(3)</a>
     <li><a href="#ref-for-content-index-entry-description③">4.1. Delete a content index entry</a>
@@ -2320,15 +2320,15 @@ steps.</p>
     <li><a href="#ref-for-content-index-entry-description⑥">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-index-entry-launch-url">
-   <b><a href="#content-index-entry-launch-url">#content-index-entry-launch-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-index-entry-launch-url" class="dfn-panel" data-for="content-index-entry-launch-url" id="infopanel-for-content-index-entry-launch-url" role="dialog">
+   <span id="infopaneltitle-for-content-index-entry-launch-url" style="display:none">Info about the 'launch url' definition.</span><b><a href="#content-index-entry-launch-url">#content-index-entry-launch-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-index-entry-launch-url">4.2. Activate a content index entry</a>
     <li><a href="#ref-for-content-index-entry-launch-url①">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-index-entry-service-worker-registration">
-   <b><a href="#content-index-entry-service-worker-registration">#content-index-entry-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-index-entry-service-worker-registration" class="dfn-panel" data-for="content-index-entry-service-worker-registration" id="infopanel-for-content-index-entry-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-content-index-entry-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#content-index-entry-service-worker-registration">#content-index-entry-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-index-entry-service-worker-registration">3.2.1. Display</a>
     <li><a href="#ref-for-content-index-entry-service-worker-registration①">4.1. Delete a content index entry</a> <a href="#ref-for-content-index-entry-service-worker-registration②">(2)</a>
@@ -2337,15 +2337,15 @@ steps.</p>
     <li><a href="#ref-for-content-index-entry-service-worker-registration⑤">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-index-entry-icons">
-   <b><a href="#content-index-entry-icons">#content-index-entry-icons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-index-entry-icons" class="dfn-panel" data-for="content-index-entry-icons" id="infopanel-for-content-index-entry-icons" role="dialog">
+   <span id="infopaneltitle-for-content-index-entry-icons" style="display:none">Info about the 'icons' definition.</span><b><a href="#content-index-entry-icons">#content-index-entry-icons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-index-entry-icons">3.2.1. Display</a>
     <li><a href="#ref-for-content-index-entry-icons①">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="display">
-   <b><a href="#display">#display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-display" class="dfn-panel" data-for="display" id="infopanel-for-display" role="dialog">
+   <span id="infopaneltitle-for-display" style="display:none">Info about the 'display' definition.</span><b><a href="#display">#display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display">2. Privacy Considerations</a> <a href="#ref-for-display①">(2)</a>
     <li><a href="#ref-for-display②">3.2.1. Display</a> <a href="#ref-for-display③">(2)</a>
@@ -2353,115 +2353,115 @@ steps.</p>
     <li><a href="#ref-for-display⑤">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="undisplay">
-   <b><a href="#undisplay">#undisplay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-undisplay" class="dfn-panel" data-for="undisplay" id="infopanel-for-undisplay" role="dialog">
+   <span id="infopaneltitle-for-undisplay" style="display:none">Info about the 'undisplay' definition.</span><b><a href="#undisplay">#undisplay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-undisplay">3.2.2. Undisplay</a>
     <li><a href="#ref-for-undisplay①">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-undisplay②">5.3.2. delete()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delete-a-content-index-entry">
-   <b><a href="#delete-a-content-index-entry">#delete-a-content-index-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delete-a-content-index-entry" class="dfn-panel" data-for="delete-a-content-index-entry" id="infopanel-for-delete-a-content-index-entry" role="dialog">
+   <span id="infopaneltitle-for-delete-a-content-index-entry" style="display:none">Info about the 'delete a content index entry' definition.</span><b><a href="#delete-a-content-index-entry">#delete-a-content-index-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delete-a-content-index-entry">3.2.1. Display</a>
     <li><a href="#ref-for-delete-a-content-index-entry①">4.1. Delete a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activate-a-content-index-entry">
-   <b><a href="#activate-a-content-index-entry">#activate-a-content-index-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activate-a-content-index-entry" class="dfn-panel" data-for="activate-a-content-index-entry" id="infopanel-for-activate-a-content-index-entry" role="dialog">
+   <span id="infopaneltitle-for-activate-a-content-index-entry" style="display:none">Info about the 'activate a content index entry' definition.</span><b><a href="#activate-a-content-index-entry">#activate-a-content-index-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activate-a-content-index-entry">3.2.1. Display</a>
     <li><a href="#ref-for-activate-a-content-index-entry①">4.2. Activate a content index entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-content-delete-event">
-   <b><a href="#fire-a-content-delete-event">#fire-a-content-delete-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-content-delete-event" class="dfn-panel" data-for="fire-a-content-delete-event" id="infopanel-for-fire-a-content-delete-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-content-delete-event" style="display:none">Info about the 'fire a content delete event' definition.</span><b><a href="#fire-a-content-delete-event">#fire-a-content-delete-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-content-delete-event">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-fire-a-content-delete-event①">4.3. Fire a content delete event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-oncontentdelete">
-   <b><a href="#dom-serviceworkerglobalscope-oncontentdelete">#dom-serviceworkerglobalscope-oncontentdelete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-oncontentdelete" class="dfn-panel" data-for="dom-serviceworkerglobalscope-oncontentdelete" id="infopanel-for-dom-serviceworkerglobalscope-oncontentdelete" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-oncontentdelete" style="display:none">Info about the 'oncontentdelete' definition.</span><b><a href="#dom-serviceworkerglobalscope-oncontentdelete">#dom-serviceworkerglobalscope-oncontentdelete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-oncontentdelete">5.1.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-content-index">
-   <b><a href="#serviceworkerregistration-content-index">#serviceworkerregistration-content-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-content-index" class="dfn-panel" data-for="serviceworkerregistration-content-index" id="infopanel-for-serviceworkerregistration-content-index" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-content-index" style="display:none">Info about the 'content index' definition.</span><b><a href="#serviceworkerregistration-content-index">#serviceworkerregistration-content-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-content-index">5.2. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-index">
-   <b><a href="#dom-serviceworkerregistration-index">#dom-serviceworkerregistration-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-index" class="dfn-panel" data-for="dom-serviceworkerregistration-index" id="infopanel-for-dom-serviceworkerregistration-index" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-index" style="display:none">Info about the 'index' definition.</span><b><a href="#dom-serviceworkerregistration-index">#dom-serviceworkerregistration-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-index">5.2. Extensions to ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-contentcategory">
-   <b><a href="#enumdef-contentcategory">#enumdef-contentcategory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-contentcategory" class="dfn-panel" data-for="enumdef-contentcategory" id="infopanel-for-enumdef-contentcategory" role="dialog">
+   <span id="infopaneltitle-for-enumdef-contentcategory" style="display:none">Info about the 'ContentCategory' definition.</span><b><a href="#enumdef-contentcategory">#enumdef-contentcategory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-contentcategory">5.3. ContentIndex</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-contentdescription">
-   <b><a href="#dictdef-contentdescription">#dictdef-contentdescription</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-contentdescription" class="dfn-panel" data-for="dictdef-contentdescription" id="infopanel-for-dictdef-contentdescription" role="dialog">
+   <span id="infopaneltitle-for-dictdef-contentdescription" style="display:none">Info about the 'ContentDescription' definition.</span><b><a href="#dictdef-contentdescription">#dictdef-contentdescription</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-contentdescription">3.2. Content index entry</a>
     <li><a href="#ref-for-dictdef-contentdescription①">5.3. ContentIndex</a> <a href="#ref-for-dictdef-contentdescription②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-id">
-   <b><a href="#dom-contentdescription-id">#dom-contentdescription-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-id" class="dfn-panel" data-for="dom-contentdescription-id" id="infopanel-for-dom-contentdescription-id" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-contentdescription-id">#dom-contentdescription-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-id">4.1. Delete a content index entry</a>
     <li><a href="#ref-for-dom-contentdescription-id①">4.3. Fire a content delete event</a>
     <li><a href="#ref-for-dom-contentdescription-id②">5.3.1. add()</a> <a href="#ref-for-dom-contentdescription-id③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-title">
-   <b><a href="#dom-contentdescription-title">#dom-contentdescription-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-title" class="dfn-panel" data-for="dom-contentdescription-title" id="infopanel-for-dom-contentdescription-title" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-contentdescription-title">#dom-contentdescription-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-title">3.2.1. Display</a>
     <li><a href="#ref-for-dom-contentdescription-title①">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-description">
-   <b><a href="#dom-contentdescription-description">#dom-contentdescription-description</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-description" class="dfn-panel" data-for="dom-contentdescription-description" id="infopanel-for-dom-contentdescription-description" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-description" style="display:none">Info about the 'description' definition.</span><b><a href="#dom-contentdescription-description">#dom-contentdescription-description</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-description">3.2.1. Display</a>
     <li><a href="#ref-for-dom-contentdescription-description①">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-category">
-   <b><a href="#dom-contentdescription-category">#dom-contentdescription-category</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-category" class="dfn-panel" data-for="dom-contentdescription-category" id="infopanel-for-dom-contentdescription-category" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-category" style="display:none">Info about the 'category' definition.</span><b><a href="#dom-contentdescription-category">#dom-contentdescription-category</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-category">3.2.1. Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-icons">
-   <b><a href="#dom-contentdescription-icons">#dom-contentdescription-icons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-icons" class="dfn-panel" data-for="dom-contentdescription-icons" id="infopanel-for-dom-contentdescription-icons" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-icons" style="display:none">Info about the 'icons' definition.</span><b><a href="#dom-contentdescription-icons">#dom-contentdescription-icons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-icons">5.3.1. add()</a> <a href="#ref-for-dom-contentdescription-icons①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentdescription-url">
-   <b><a href="#dom-contentdescription-url">#dom-contentdescription-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentdescription-url" class="dfn-panel" data-for="dom-contentdescription-url" id="infopanel-for-dom-contentdescription-url" role="dialog">
+   <span id="infopaneltitle-for-dom-contentdescription-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-contentdescription-url">#dom-contentdescription-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentdescription-url">5.3.1. add()</a> <a href="#ref-for-dom-contentdescription-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contentindex">
-   <b><a href="#contentindex">#contentindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contentindex" class="dfn-panel" data-for="contentindex" id="infopanel-for-contentindex" role="dialog">
+   <span id="infopaneltitle-for-contentindex" style="display:none">Info about the 'ContentIndex' definition.</span><b><a href="#contentindex">#contentindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contentindex">5.2. Extensions to ServiceWorkerRegistration</a> <a href="#ref-for-contentindex①">(2)</a> <a href="#ref-for-contentindex②">(3)</a>
     <li><a href="#ref-for-contentindex③">5.3. ContentIndex</a> <a href="#ref-for-contentindex④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contentindex-service-worker-registration">
-   <b><a href="#contentindex-service-worker-registration">#contentindex-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contentindex-service-worker-registration" class="dfn-panel" data-for="contentindex-service-worker-registration" id="infopanel-for-contentindex-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-contentindex-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#contentindex-service-worker-registration">#contentindex-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contentindex-service-worker-registration">5.2. Extensions to ServiceWorkerRegistration</a>
     <li><a href="#ref-for-contentindex-service-worker-registration①">5.3.1. add()</a>
@@ -2469,102 +2469,158 @@ steps.</p>
     <li><a href="#ref-for-contentindex-service-worker-registration③">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentindex-add">
-   <b><a href="#dom-contentindex-add">#dom-contentindex-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentindex-add" class="dfn-panel" data-for="dom-contentindex-add" id="infopanel-for-dom-contentindex-add" role="dialog">
+   <span id="infopaneltitle-for-dom-contentindex-add" style="display:none">Info about the 'add(description)' definition.</span><b><a href="#dom-contentindex-add">#dom-contentindex-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentindex-add">5.3. ContentIndex</a>
     <li><a href="#ref-for-dom-contentindex-add①">5.3.1. add()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentindex-delete">
-   <b><a href="#dom-contentindex-delete">#dom-contentindex-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentindex-delete" class="dfn-panel" data-for="dom-contentindex-delete" id="infopanel-for-dom-contentindex-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-contentindex-delete" style="display:none">Info about the 'delete(id)' definition.</span><b><a href="#dom-contentindex-delete">#dom-contentindex-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentindex-delete">5.3. ContentIndex</a>
     <li><a href="#ref-for-dom-contentindex-delete①">5.3.2. delete()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentindex-getall">
-   <b><a href="#dom-contentindex-getall">#dom-contentindex-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentindex-getall" class="dfn-panel" data-for="dom-contentindex-getall" id="infopanel-for-dom-contentindex-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-contentindex-getall" style="display:none">Info about the 'getAll()' definition.</span><b><a href="#dom-contentindex-getall">#dom-contentindex-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentindex-getall">5.3. ContentIndex</a>
     <li><a href="#ref-for-dom-contentindex-getall①">5.3.3. getAll()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-contentindexeventinit">
-   <b><a href="#dictdef-contentindexeventinit">#dictdef-contentindexeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-contentindexeventinit" class="dfn-panel" data-for="dictdef-contentindexeventinit" id="infopanel-for-dictdef-contentindexeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-contentindexeventinit" style="display:none">Info about the 'ContentIndexEventInit' definition.</span><b><a href="#dictdef-contentindexeventinit">#dictdef-contentindexeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-contentindexeventinit">5.4. ContentIndexEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contentindexevent">
-   <b><a href="#contentindexevent">#contentindexevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contentindexevent" class="dfn-panel" data-for="contentindexevent" id="infopanel-for-contentindexevent" role="dialog">
+   <span id="infopaneltitle-for-contentindexevent" style="display:none">Info about the 'ContentIndexEvent' definition.</span><b><a href="#contentindexevent">#contentindexevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contentindexevent">4.3. Fire a content delete event</a>
     <li><a href="#ref-for-contentindexevent①">5.1.1. Events</a>
     <li><a href="#ref-for-contentindexevent②">5.4. ContentIndexEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-contentindexevent-id">
-   <b><a href="#dom-contentindexevent-id">#dom-contentindexevent-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-contentindexevent-id" class="dfn-panel" data-for="dom-contentindexevent-id" id="infopanel-for-dom-contentindexevent-id" role="dialog">
+   <span id="infopaneltitle-for-dom-contentindexevent-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-contentindexevent-id">#dom-contentindexevent-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-contentindexevent-id">4.3. Fire a content delete event</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/conversion-measurement-api/index.html
+++ b/tests/github/WICG/conversion-measurement-api/index.html
@@ -996,88 +996,88 @@ impression.</p>
      <li><a href="#element-attrdef-a-reportingorigin">element-attr for a</a><span>, in § 3</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-current-url" class="dfn-panel" data-for="term-for-concept-request-current-url" id="infopanel-for-term-for-concept-request-current-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-current-url" style="display:none">Info about the 'current url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">5.4. Register a conversion</a> <a href="#ref-for-concept-request-current-url①">(2)</a> <a href="#ref-for-concept-request-current-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-count">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-count" class="dfn-panel" data-for="term-for-concept-request-redirect-count" id="infopanel-for-term-for-concept-request-redirect-count" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-count" style="display:none">Info about the 'redirect count' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-count">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url-list">https://fetch.spec.whatwg.org/#concept-request-url-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url-list" class="dfn-panel" data-for="term-for-concept-request-url-list" id="infopanel-for-term-for-concept-request-url-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url-list" style="display:none">Info about the 'url list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url-list">https://fetch.spec.whatwg.org/#concept-request-url-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url-list">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">3. HTML monkeypatches</a> <a href="#ref-for-cereactions①">(2)</a> <a href="#ref-for-cereactions②">(3)</a> <a href="#ref-for-cereactions③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlanchorelement">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement">https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlanchorelement" class="dfn-panel" data-for="term-for-htmlanchorelement" id="infopanel-for-term-for-htmlanchorelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlanchorelement" style="display:none">Info about the 'HTMLAnchorElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement">https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlanchorelement">3. HTML monkeypatches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">5.1. Parsing a conversion destination</a>
     <li><a href="#ref-for-the-a-element①">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">5.3. Creating a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-site" class="dfn-panel" data-for="term-for-obtain-a-site" id="infopanel-for-term-for-obtain-a-site" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-site" style="display:none">Info about the 'obtain a site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-site">5.1. Parsing a conversion destination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3. HTML monkeypatches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">5.2. Activating an impression</a>
     <li><a href="#ref-for-concept-environment-top-level-origin①">5.3. Creating a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.1. Impression</a>
     <li><a href="#ref-for-string①">4.2. Conversion</a>
@@ -1085,16 +1085,16 @@ impression.</p>
     <li><a href="#ref-for-string④">5.5. Parsing data fields</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">4.1. Impression</a>
     <li><a href="#ref-for-struct①">4.2. Conversion</a>
     <li><a href="#ref-for-struct②">4.3. Conversion report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">4.1. Impression</a> <a href="#ref-for-concept-url-origin①">(2)</a> <a href="#ref-for-concept-url-origin②">(3)</a>
     <li><a href="#ref-for-concept-url-origin③">4.2. Conversion</a>
@@ -1103,40 +1103,40 @@ impression.</p>
     <li><a href="#ref-for-concept-url-origin⑥">5.4. Register a conversion</a> <a href="#ref-for-concept-url-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">5.3. Creating a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">5.3. Creating a conversion</a>
     <li><a href="#ref-for-concept-url①">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">5.1. Parsing a conversion destination</a>
     <li><a href="#ref-for-concept-url-parser①">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. HTML monkeypatches</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">3. HTML monkeypatches</a>
    </ul>
@@ -1221,126 +1221,126 @@ for validating the resulting document matches the conversiondestination. <a clas
    <div class="issue"> Formalize how to parse the query similar to URLSearchParams. <a class="issue-return" href="#issue-9d1372db" title="Jump to section">↵</a></div>
    <div class="issue"> Need to spec how to store the conversion. <a class="issue-return" href="#issue-e139b412" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="element-attrdef-a-conversiondestination">
-   <b><a href="#element-attrdef-a-conversiondestination">#element-attrdef-a-conversiondestination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-a-conversiondestination" class="dfn-panel" data-for="element-attrdef-a-conversiondestination" id="infopanel-for-element-attrdef-a-conversiondestination" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-a-conversiondestination" style="display:none">Info about the 'conversiondestination' definition.</span><b><a href="#element-attrdef-a-conversiondestination">#element-attrdef-a-conversiondestination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-a-conversiondestination">1.1. Overview</a> <a href="#ref-for-element-attrdef-a-conversiondestination①">(2)</a> <a href="#ref-for-element-attrdef-a-conversiondestination②">(3)</a>
     <li><a href="#ref-for-element-attrdef-a-conversiondestination③">5.1. Parsing a conversion destination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-a-impressiondata">
-   <b><a href="#element-attrdef-a-impressiondata">#element-attrdef-a-impressiondata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-a-impressiondata" class="dfn-panel" data-for="element-attrdef-a-impressiondata" id="infopanel-for-element-attrdef-a-impressiondata" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-a-impressiondata" style="display:none">Info about the 'impressiondata' definition.</span><b><a href="#element-attrdef-a-impressiondata">#element-attrdef-a-impressiondata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-a-impressiondata">1.1. Overview</a>
     <li><a href="#ref-for-element-attrdef-a-impressiondata①">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-a-reportingorigin">
-   <b><a href="#element-attrdef-a-reportingorigin">#element-attrdef-a-reportingorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-a-reportingorigin" class="dfn-panel" data-for="element-attrdef-a-reportingorigin" id="infopanel-for-element-attrdef-a-reportingorigin" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-a-reportingorigin" style="display:none">Info about the 'reportingorigin' definition.</span><b><a href="#element-attrdef-a-reportingorigin">#element-attrdef-a-reportingorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-a-reportingorigin">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-a-impressionexpiry">
-   <b><a href="#element-attrdef-a-impressionexpiry">#element-attrdef-a-impressionexpiry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-a-impressionexpiry" class="dfn-panel" data-for="element-attrdef-a-impressionexpiry" id="infopanel-for-element-attrdef-a-impressionexpiry" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-a-impressionexpiry" style="display:none">Info about the 'impressionexpiry' definition.</span><b><a href="#element-attrdef-a-impressionexpiry">#element-attrdef-a-impressionexpiry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-a-impressionexpiry">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression">
-   <b><a href="#impression">#impression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression" class="dfn-panel" data-for="impression" id="infopanel-for-impression" role="dialog">
+   <span id="infopaneltitle-for-impression" style="display:none">Info about the '4.1. Impression' definition.</span><b><a href="#impression">#impression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression">4.1. Impression</a>
     <li><a href="#ref-for-impression">5.2. Activating an impression</a>
     <li><a href="#ref-for-impression①">5.6. Establishing report delivery time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-impression-source">
-   <b><a href="#impression-impression-source">#impression-impression-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-impression-source" class="dfn-panel" data-for="impression-impression-source" id="infopanel-for-impression-impression-source" role="dialog">
+   <span id="infopaneltitle-for-impression-impression-source" style="display:none">Info about the 'impression source' definition.</span><b><a href="#impression-impression-source">#impression-impression-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-impression-source">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-impression-data">
-   <b><a href="#impression-impression-data">#impression-impression-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-impression-data" class="dfn-panel" data-for="impression-impression-data" id="infopanel-for-impression-impression-data" role="dialog">
+   <span id="infopaneltitle-for-impression-impression-data" style="display:none">Info about the 'impression data' definition.</span><b><a href="#impression-impression-data">#impression-impression-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-impression-data">5.2. Activating an impression</a>
     <li><a href="#ref-for-impression-impression-data①">5.5. Parsing data fields</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-conversion-destination">
-   <b><a href="#impression-conversion-destination">#impression-conversion-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-conversion-destination" class="dfn-panel" data-for="impression-conversion-destination" id="infopanel-for-impression-conversion-destination" role="dialog">
+   <span id="infopaneltitle-for-impression-conversion-destination" style="display:none">Info about the 'conversion destination' definition.</span><b><a href="#impression-conversion-destination">#impression-conversion-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-conversion-destination">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-reporting-endpoint">
-   <b><a href="#impression-reporting-endpoint">#impression-reporting-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-reporting-endpoint" class="dfn-panel" data-for="impression-reporting-endpoint" id="infopanel-for-impression-reporting-endpoint" role="dialog">
+   <span id="infopaneltitle-for-impression-reporting-endpoint" style="display:none">Info about the 'reporting endpoint' definition.</span><b><a href="#impression-reporting-endpoint">#impression-reporting-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-reporting-endpoint">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-expiry">
-   <b><a href="#impression-expiry">#impression-expiry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-expiry" class="dfn-panel" data-for="impression-expiry" id="infopanel-for-impression-expiry" role="dialog">
+   <span id="infopaneltitle-for-impression-expiry" style="display:none">Info about the 'expiry' definition.</span><b><a href="#impression-expiry">#impression-expiry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-expiry">5.2. Activating an impression</a>
     <li><a href="#ref-for-impression-expiry①">5.6. Establishing report delivery time</a> <a href="#ref-for-impression-expiry②">(2)</a> <a href="#ref-for-impression-expiry③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impression-impression-time">
-   <b><a href="#impression-impression-time">#impression-impression-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impression-impression-time" class="dfn-panel" data-for="impression-impression-time" id="infopanel-for-impression-impression-time" role="dialog">
+   <span id="infopaneltitle-for-impression-impression-time" style="display:none">Info about the 'impression time' definition.</span><b><a href="#impression-impression-time">#impression-impression-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impression-impression-time">5.2. Activating an impression</a>
     <li><a href="#ref-for-impression-impression-time①">5.6. Establishing report delivery time</a> <a href="#ref-for-impression-impression-time②">(2)</a> <a href="#ref-for-impression-impression-time③">(3)</a> <a href="#ref-for-impression-impression-time④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion">
-   <b><a href="#conversion">#conversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion" class="dfn-panel" data-for="conversion" id="infopanel-for-conversion" role="dialog">
+   <span id="infopaneltitle-for-conversion" style="display:none">Info about the '4.2. Conversion' definition.</span><b><a href="#conversion">#conversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion">4.2. Conversion</a>
     <li><a href="#ref-for-conversion">5.3. Creating a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion-conversion-source">
-   <b><a href="#conversion-conversion-source">#conversion-conversion-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion-conversion-source" class="dfn-panel" data-for="conversion-conversion-source" id="infopanel-for-conversion-conversion-source" role="dialog">
+   <span id="infopaneltitle-for-conversion-conversion-source" style="display:none">Info about the 'conversion source' definition.</span><b><a href="#conversion-conversion-source">#conversion-conversion-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion-conversion-source">5.3. Creating a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion-conversion-data">
-   <b><a href="#conversion-conversion-data">#conversion-conversion-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion-conversion-data" class="dfn-panel" data-for="conversion-conversion-data" id="infopanel-for-conversion-conversion-data" role="dialog">
+   <span id="infopaneltitle-for-conversion-conversion-data" style="display:none">Info about the 'conversion data' definition.</span><b><a href="#conversion-conversion-data">#conversion-conversion-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion-conversion-data">5.3. Creating a conversion</a>
     <li><a href="#ref-for-conversion-conversion-data①">5.5. Parsing data fields</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion-conversion-time">
-   <b><a href="#conversion-conversion-time">#conversion-conversion-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion-conversion-time" class="dfn-panel" data-for="conversion-conversion-time" id="infopanel-for-conversion-conversion-time" role="dialog">
+   <span id="infopaneltitle-for-conversion-conversion-time" style="display:none">Info about the 'conversion time' definition.</span><b><a href="#conversion-conversion-time">#conversion-conversion-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion-conversion-time">5.3. Creating a conversion</a>
     <li><a href="#ref-for-conversion-conversion-time①">5.6. Establishing report delivery time</a> <a href="#ref-for-conversion-conversion-time②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion-report">
-   <b><a href="#conversion-report">#conversion-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion-report" class="dfn-panel" data-for="conversion-report" id="infopanel-for-conversion-report" role="dialog">
+   <span id="infopaneltitle-for-conversion-report" style="display:none">Info about the '4.3. Conversion report' definition.</span><b><a href="#conversion-report">#conversion-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion-report">4.3. Conversion report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-conversion-destination">
-   <b><a href="#parse-a-conversion-destination">#parse-a-conversion-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-conversion-destination" class="dfn-panel" data-for="parse-a-conversion-destination" id="infopanel-for-parse-a-conversion-destination" role="dialog">
+   <span id="infopaneltitle-for-parse-a-conversion-destination" style="display:none">Info about the 'parse a conversion destination' definition.</span><b><a href="#parse-a-conversion-destination">#parse-a-conversion-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-conversion-destination">5.2. Activating an impression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-conversion">
-   <b><a href="#create-a-conversion">#create-a-conversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-conversion" class="dfn-panel" data-for="create-a-conversion" id="infopanel-for-create-a-conversion" role="dialog">
+   <span id="infopaneltitle-for-create-a-conversion" style="display:none">Info about the 'create a conversion' definition.</span><b><a href="#create-a-conversion">#create-a-conversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-conversion">5.4. Register a conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-conversion-data">
-   <b><a href="#parsing-conversion-data">#parsing-conversion-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-conversion-data" class="dfn-panel" data-for="parsing-conversion-data" id="infopanel-for-parsing-conversion-data" role="dialog">
+   <span id="infopaneltitle-for-parsing-conversion-data" style="display:none">Info about the 'Parsing conversion data' definition.</span><b><a href="#parsing-conversion-data">#parsing-conversion-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-conversion-data">5.2. Activating an impression</a>
     <li><a href="#ref-for-parsing-conversion-data①">5.3. Creating a conversion</a>
@@ -1348,59 +1348,115 @@ for validating the resulting document matches the conversiondestination. <a clas
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/cookie-store/index.html
+++ b/tests/github/WICG/cookie-store/index.html
@@ -2136,109 +2136,109 @@ authoring advice.</p>
      <li><a href="#dom-cookielistitem-value">dict-member for CookieListItem</a><span>, in § 3</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'window' external reference.</span><a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">1.5. Monitoring Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.1. The CookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">5.1. The CookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. The CookieStore Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">5.1. The CookieChangeEvent interface</a>
     <li><a href="#ref-for-concept-event-dispatch①">5.2. The ExtendableCookieChangeEvent interface</a>
     <li><a href="#ref-for-concept-event-dispatch②">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">1.3. Querying Cookies</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a>
     <li><a href="#ref-for-concept-document③">1.4. Modifying Cookies</a>
     <li><a href="#ref-for-concept-document④">1.5. Monitoring Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">1.3. Querying Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-time-values-and-time-range">
-   <a href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">https://tc39.github.io/ecma262/#sec-time-values-and-time-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-time-values-and-time-range" class="dfn-panel" data-for="term-for-sec-time-values-and-time-range" id="infopanel-for-term-for-sec-time-values-and-time-range" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-time-values-and-time-range" style="display:none">Info about the 'time values' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-time-values-and-time-range">https://tc39.github.io/ecma262/#sec-time-values-and-time-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-time-values-and-time-range">7. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom" id="infopanel-for-term-for-utf-8-decode-without-bom" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom" style="display:none">Info about the 'utf-8 decode without bom' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom">7. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">7. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">1.3. Querying Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. The CookieStore Interface</a>
     <li><a href="#ref-for-eventhandler①">6.2. The ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window①" role="menu">
+   <span id="infopaneltitle-for-term-for-window①" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window①">3.1. The get() method</a>
     <li><a href="#ref-for-window②">3.2. The getAll() method</a>
@@ -2248,8 +2248,8 @@ authoring advice.</p>
     <li><a href="#ref-for-window⑧">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.1. The get() method</a>
     <li><a href="#ref-for-api-base-url①">3.2. The getAll() method</a>
@@ -2257,16 +2257,16 @@ authoring advice.</p>
     <li><a href="#ref-for-api-base-url③">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-cookie">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie">https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-cookie" class="dfn-panel" data-for="term-for-dom-document-cookie" id="infopanel-for-term-for-dom-document-cookie" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-cookie" style="display:none">Info about the 'cookie' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie">https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-cookie">1. Introduction</a> <a href="#ref-for-dom-document-cookie①">(2)</a>
     <li><a href="#ref-for-dom-document-cookie②">1.3. Querying Cookies</a>
     <li><a href="#ref-for-dom-document-cookie③">8.7. Cookie aversion</a> <a href="#ref-for-dom-document-cookie④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-creation-url" class="dfn-panel" data-for="term-for-concept-environment-creation-url" id="infopanel-for-term-for-concept-environment-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-creation-url">3.1. The get() method</a> <a href="#ref-for-concept-environment-creation-url①">(2)</a>
     <li><a href="#ref-for-concept-environment-creation-url②">3.2. The getAll() method</a> <a href="#ref-for-concept-environment-creation-url③">(2)</a>
@@ -2275,15 +2275,15 @@ authoring advice.</p>
     <li><a href="#ref-for-concept-environment-creation-url⑧">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3.1. The get() method</a>
     <li><a href="#ref-for-current-global-object①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">3.1. The get() method</a> <a href="#ref-for-current-settings-object①">(2)</a> <a href="#ref-for-current-settings-object②">(3)</a> <a href="#ref-for-current-settings-object③">(4)</a>
     <li><a href="#ref-for-current-settings-object④">3.2. The getAll() method</a> <a href="#ref-for-current-settings-object⑤">(2)</a> <a href="#ref-for-current-settings-object⑥">(3)</a> <a href="#ref-for-current-settings-object⑦">(4)</a>
@@ -2291,21 +2291,21 @@ authoring advice.</p>
     <li><a href="#ref-for-current-settings-object①②">3.4. The delete() method</a> <a href="#ref-for-current-settings-object①③">(2)</a> <a href="#ref-for-current-settings-object①④">(3)</a> <a href="#ref-for-current-settings-object①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-domain" class="dfn-panel" data-for="term-for-dom-document-domain" id="infopanel-for-term-for-dom-document-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-domain">3.1. The get() method</a>
     <li><a href="#ref-for-dom-document-domain①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.1. The get() method</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">3.2. The getAll() method</a> <a href="#ref-for-in-parallel③">(2)</a>
@@ -2316,8 +2316,8 @@ authoring advice.</p>
     <li><a href="#ref-for-in-parallel①⓪">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">3.1. The get() method</a> <a href="#ref-for-concept-origin-opaque①">(2)</a>
     <li><a href="#ref-for-concept-origin-opaque②">3.2. The getAll() method</a> <a href="#ref-for-concept-origin-opaque③">(2)</a>
@@ -2325,8 +2325,8 @@ authoring advice.</p>
     <li><a href="#ref-for-concept-origin-opaque⑥">3.4. The delete() method</a> <a href="#ref-for-concept-origin-opaque⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3.1. The get() method</a> <a href="#ref-for-concept-origin①">(2)</a>
     <li><a href="#ref-for-concept-origin②">3.2. The getAll() method</a> <a href="#ref-for-concept-origin③">(2)</a>
@@ -2334,14 +2334,14 @@ authoring advice.</p>
     <li><a href="#ref-for-concept-origin⑥">3.4. The delete() method</a> <a href="#ref-for-concept-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.1. The get() method</a>
     <li><a href="#ref-for-relevant-settings-object①">3.2. The getAll() method</a>
@@ -2349,22 +2349,22 @@ authoring advice.</p>
     <li><a href="#ref-for-relevant-settings-object③">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-history-replacestate">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-replacestate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-replacestate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-history-replacestate" class="dfn-panel" data-for="term-for-dom-history-replacestate" id="infopanel-for-term-for-dom-history-replacestate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-history-replacestate" style="display:none">Info about the 'replaceState(data, unused, url)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-replacestate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-replacestate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-history-replacestate">3.1. The get() method</a>
     <li><a href="#ref-for-dom-history-replacestate①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.1. The get() method</a>
     <li><a href="#ref-for-same-origin①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.1. The subscribe() method</a>
     <li><a href="#ref-for-list-append①">4.2. The getSubscriptions() method</a>
@@ -2373,40 +2373,40 @@ authoring advice.</p>
     <li><a href="#ref-for-list-append①⓪">7.4. Process Changes</a> <a href="#ref-for-list-append①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">7. Algorithms</a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.1. The subscribe() method</a>
     <li><a href="#ref-for-list-contain①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">7.1. Query Cookies</a>
     <li><a href="#ref-for-iteration-continue①">7.4. Process Changes</a> <a href="#ref-for-iteration-continue②">(2)</a> <a href="#ref-for-iteration-continue③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.1. The subscribe() method</a>
     <li><a href="#ref-for-list-iterate①">4.2. The getSubscriptions() method</a>
@@ -2415,27 +2415,27 @@ authoring advice.</p>
     <li><a href="#ref-for-list-iterate④">7.4. Process Changes</a> <a href="#ref-for-list-iterate⑤">(2)</a> <a href="#ref-for-list-iterate⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">3.1. The get() method</a> <a href="#ref-for-list-is-empty①">(2)</a>
     <li><a href="#ref-for-list-is-empty②">7.4. Process Changes</a> <a href="#ref-for-list-is-empty③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">7.2. Set a Cookie</a> <a href="#ref-for-string-length①">(2)</a> <a href="#ref-for-string-length②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.3. Extensions to Service Worker</a>
     <li><a href="#ref-for-list①">4.2. The getSubscriptions() method</a>
@@ -2444,58 +2444,58 @@ authoring advice.</p>
     <li><a href="#ref-for-list④">7.4. Process Changes</a> <a href="#ref-for-list⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">7.4. Process Changes</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">2.3. Extensions to Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">5.2. The ExtendableCookieChangeEvent interface</a> <a href="#ref-for-extendableevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">5.2. The ExtendableCookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">5.2. The ExtendableCookieChangeEvent interface</a>
     <li><a href="#ref-for-serviceworkerglobalscope①">6. Global Interfaces</a>
     <li><a href="#ref-for-serviceworkerglobalscope②">6.2. The ServiceWorkerGlobalScope interface</a> <a href="#ref-for-serviceworkerglobalscope③">(2)</a> <a href="#ref-for-serviceworkerglobalscope④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">4.4. The ServiceWorkerRegistration interface</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a> <a href="#ref-for-serviceworkerregistration③">(4)</a> <a href="#ref-for-serviceworkerregistration④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire a functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-scope-url">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-scope-url" class="dfn-panel" data-for="term-for-dfn-scope-url" id="infopanel-for-term-for-dfn-scope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-scope-url" style="display:none">Info about the 'scope url' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-scope-url">https://w3c.github.io/ServiceWorker/#dfn-scope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">1.3. Querying Cookies</a>
     <li><a href="#ref-for-dfn-scope-url①">4.1. The subscribe() method</a>
@@ -2503,8 +2503,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dfn-scope-url③">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker" class="dfn-panel" data-for="term-for-dfn-service-worker" id="infopanel-for-term-for-dfn-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1.3. Querying Cookies</a> <a href="#ref-for-dfn-service-worker①">(2)</a> <a href="#ref-for-dfn-service-worker②">(3)</a>
     <li><a href="#ref-for-dfn-service-worker③">1.4. Modifying Cookies</a>
@@ -2514,8 +2514,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dfn-service-worker①①">5.2. The ExtendableCookieChangeEvent interface</a> <a href="#ref-for-dfn-service-worker①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration" class="dfn-panel" data-for="term-for-dfn-service-worker-registration" id="infopanel-for-term-for-dfn-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">1.5. Monitoring Cookies</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">2.3. Extensions to Service Worker</a> <a href="#ref-for-dfn-service-worker-registration②">(2)</a>
@@ -2524,8 +2524,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dfn-service-worker-registration⑥">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-basic-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">https://url.spec.whatwg.org/#concept-basic-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-basic-url-parser" class="dfn-panel" data-for="term-for-concept-basic-url-parser" id="infopanel-for-term-for-concept-basic-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-basic-url-parser" style="display:none">Info about the 'basic url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-basic-url-parser">https://url.spec.whatwg.org/#concept-basic-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-basic-url-parser">3.1. The get() method</a>
     <li><a href="#ref-for-concept-basic-url-parser①">3.2. The getAll() method</a>
@@ -2533,28 +2533,28 @@ authoring advice.</p>
     <li><a href="#ref-for-concept-basic-url-parser③">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">3.1. The get() method</a>
     <li><a href="#ref-for-concept-url-equals①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">7.2. Set a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">3.1. The get() method</a> <a href="#ref-for-concept-url-origin①">(2)</a>
     <li><a href="#ref-for-concept-url-origin②">3.2. The getAll() method</a> <a href="#ref-for-concept-url-origin③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.1. The get() method</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">3.2. The getAll() method</a> <a href="#ref-for-idl-DOMException③">(2)</a>
@@ -2562,15 +2562,15 @@ authoring advice.</p>
     <li><a href="#ref-for-idl-DOMException⑥">3.4. The delete() method</a> <a href="#ref-for-idl-DOMException⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5.1. The CookieChangeEvent interface</a>
     <li><a href="#ref-for-idl-DOMString①">5.2. The ExtendableCookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. The CookieStore Interface</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">4. The CookieStoreManager Interface</a>
@@ -2579,22 +2579,22 @@ authoring advice.</p>
     <li><a href="#ref-for-Exposed⑤">5.2. The ExtendableCookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">5.1. The CookieChangeEvent interface</a> <a href="#ref-for-idl-frozen-array①">(2)</a>
     <li><a href="#ref-for-idl-frozen-array②">5.2. The ExtendableCookieChangeEvent interface</a> <a href="#ref-for-idl-frozen-array③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. The CookieStore Interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a> <a href="#ref-for-idl-promise④">(5)</a> <a href="#ref-for-idl-promise⑤">(6)</a> <a href="#ref-for-idl-promise⑥">(7)</a> <a href="#ref-for-idl-promise⑦">(8)</a>
     <li><a href="#ref-for-idl-promise⑧">4. The CookieStoreManager Interface</a> <a href="#ref-for-idl-promise⑨">(2)</a> <a href="#ref-for-idl-promise①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.4. The ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-SameObject①">5.1. The CookieChangeEvent interface</a> <a href="#ref-for-SameObject②">(2)</a>
@@ -2603,8 +2603,8 @@ authoring advice.</p>
     <li><a href="#ref-for-SameObject⑥">6.2. The ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3. The CookieStore Interface</a>
     <li><a href="#ref-for-SecureContext①">4. The CookieStoreManager Interface</a>
@@ -2612,8 +2612,8 @@ authoring advice.</p>
     <li><a href="#ref-for-SecureContext③">6.1. The Window interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.1. The get() method</a> <a href="#ref-for-securityerror①">(2)</a>
     <li><a href="#ref-for-securityerror②">3.2. The getAll() method</a> <a href="#ref-for-securityerror③">(2)</a>
@@ -2621,8 +2621,8 @@ authoring advice.</p>
     <li><a href="#ref-for-securityerror⑥">3.4. The delete() method</a> <a href="#ref-for-securityerror⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">3.1. The get() method</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a> <a href="#ref-for-exceptiondef-typeerror③">(4)</a> <a href="#ref-for-exceptiondef-typeerror④">(5)</a>
     <li><a href="#ref-for-exceptiondef-typeerror⑤">3.2. The getAll() method</a> <a href="#ref-for-exceptiondef-typeerror⑥">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑦">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑧">(4)</a>
@@ -2632,14 +2632,14 @@ authoring advice.</p>
     <li><a href="#ref-for-exceptiondef-typeerror①④">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. The CookieStore Interface</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a> <a href="#ref-for-idl-USVString④">(5)</a> <a href="#ref-for-idl-USVString⑤">(6)</a> <a href="#ref-for-idl-USVString⑥">(7)</a> <a href="#ref-for-idl-USVString⑦">(8)</a> <a href="#ref-for-idl-USVString⑧">(9)</a> <a href="#ref-for-idl-USVString⑨">(10)</a> <a href="#ref-for-idl-USVString①⓪">(11)</a> <a href="#ref-for-idl-USVString①①">(12)</a> <a href="#ref-for-idl-USVString①②">(13)</a> <a href="#ref-for-idl-USVString①③">(14)</a> <a href="#ref-for-idl-USVString①④">(15)</a> <a href="#ref-for-idl-USVString①⑤">(16)</a> <a href="#ref-for-idl-USVString①⑥">(17)</a> <a href="#ref-for-idl-USVString①⑦">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.1. The get() method</a> <a href="#ref-for-a-new-promise①">(2)</a>
     <li><a href="#ref-for-a-new-promise②">3.2. The getAll() method</a> <a href="#ref-for-a-new-promise③">(2)</a>
@@ -2650,8 +2650,8 @@ authoring advice.</p>
     <li><a href="#ref-for-a-new-promise①⓪">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.1. The get() method</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a> <a href="#ref-for-a-promise-rejected-with③">(4)</a> <a href="#ref-for-a-promise-rejected-with④">(5)</a>
     <li><a href="#ref-for-a-promise-rejected-with⑤">3.2. The getAll() method</a> <a href="#ref-for-a-promise-rejected-with⑥">(2)</a> <a href="#ref-for-a-promise-rejected-with⑦">(3)</a> <a href="#ref-for-a-promise-rejected-with⑧">(4)</a>
@@ -2659,14 +2659,14 @@ authoring advice.</p>
     <li><a href="#ref-for-a-promise-rejected-with①①">3.4. The delete() method</a> <a href="#ref-for-a-promise-rejected-with①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. The CookieStore Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.1. The get() method</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">3.2. The getAll() method</a> <a href="#ref-for-reject③">(2)</a>
@@ -2676,8 +2676,8 @@ authoring advice.</p>
     <li><a href="#ref-for-reject⑨">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.1. The get() method</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a>
     <li><a href="#ref-for-resolve④">3.2. The getAll() method</a> <a href="#ref-for-resolve⑤">(2)</a>
@@ -2688,15 +2688,15 @@ authoring advice.</p>
     <li><a href="#ref-for-resolve①②">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. The CookieStore Interface</a>
     <li><a href="#ref-for-idl-sequence①">4. The CookieStoreManager Interface</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-sequence③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. The get() method</a>
     <li><a href="#ref-for-this①">3.2. The getAll() method</a>
@@ -2708,8 +2708,8 @@ authoring advice.</p>
     <li><a href="#ref-for-this⑨">6.2. The ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. The CookieStore Interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
     <li><a href="#ref-for-idl-undefined④">4. The CookieStoreManager Interface</a> <a href="#ref-for-idl-undefined⑤">(2)</a>
@@ -2972,8 +2972,8 @@ authoring advice.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="cookie">
-   <b><a href="#cookie">#cookie</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie" class="dfn-panel" data-for="cookie" id="infopanel-for-cookie" role="dialog">
+   <span id="infopaneltitle-for-cookie" style="display:none">Info about the 'cookie' definition.</span><b><a href="#cookie">#cookie</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie">2.1. Cookie</a>
     <li><a href="#ref-for-cookie①">2.2. Cookie Store</a> <a href="#ref-for-cookie②">(2)</a> <a href="#ref-for-cookie③">(3)</a>
@@ -2981,85 +2981,85 @@ authoring advice.</p>
     <li><a href="#ref-for-cookie⑤">7.4. Process Changes</a> <a href="#ref-for-cookie⑥">(2)</a> <a href="#ref-for-cookie⑦">(3)</a> <a href="#ref-for-cookie⑧">(4)</a> <a href="#ref-for-cookie⑨">(5)</a> <a href="#ref-for-cookie①⓪">(6)</a> <a href="#ref-for-cookie①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-name">
-   <b><a href="#cookie-name">#cookie-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-name" class="dfn-panel" data-for="cookie-name" id="infopanel-for-cookie-name" role="dialog">
+   <span id="infopaneltitle-for-cookie-name" style="display:none">Info about the 'name' definition.</span><b><a href="#cookie-name">#cookie-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-name">1.3. Querying Cookies</a>
     <li><a href="#ref-for-cookie-name①">7.1. Query Cookies</a> <a href="#ref-for-cookie-name②">(2)</a>
     <li><a href="#ref-for-cookie-name③">7.4. Process Changes</a> <a href="#ref-for-cookie-name④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-value">
-   <b><a href="#cookie-value">#cookie-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-value" class="dfn-panel" data-for="cookie-value" id="infopanel-for-cookie-value" role="dialog">
+   <span id="infopaneltitle-for-cookie-value" style="display:none">Info about the 'value' definition.</span><b><a href="#cookie-value">#cookie-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-value">1.3. Querying Cookies</a>
     <li><a href="#ref-for-cookie-value①">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-expiry-time">
-   <b><a href="#cookie-expiry-time">#cookie-expiry-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-expiry-time" class="dfn-panel" data-for="cookie-expiry-time" id="infopanel-for-cookie-expiry-time" role="dialog">
+   <span id="infopaneltitle-for-cookie-expiry-time" style="display:none">Info about the 'expiry-time' definition.</span><b><a href="#cookie-expiry-time">#cookie-expiry-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-expiry-time">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-domain">
-   <b><a href="#cookie-domain">#cookie-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-domain" class="dfn-panel" data-for="cookie-domain" id="infopanel-for-cookie-domain" role="dialog">
+   <span id="infopaneltitle-for-cookie-domain" style="display:none">Info about the 'domain' definition.</span><b><a href="#cookie-domain">#cookie-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-domain">7.1. Query Cookies</a>
     <li><a href="#ref-for-cookie-domain①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-path">
-   <b><a href="#cookie-path">#cookie-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-path" class="dfn-panel" data-for="cookie-path" id="infopanel-for-cookie-path" role="dialog">
+   <span id="infopaneltitle-for-cookie-path" style="display:none">Info about the 'path' definition.</span><b><a href="#cookie-path">#cookie-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-path">7.1. Query Cookies</a>
     <li><a href="#ref-for-cookie-path①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-creation-time">
-   <b><a href="#cookie-creation-time">#cookie-creation-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-creation-time" class="dfn-panel" data-for="cookie-creation-time" id="infopanel-for-cookie-creation-time" role="dialog">
+   <span id="infopaneltitle-for-cookie-creation-time" style="display:none">Info about the 'creation-time' definition.</span><b><a href="#cookie-creation-time">#cookie-creation-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-creation-time">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-last-access-time">
-   <b><a href="#cookie-last-access-time">#cookie-last-access-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-last-access-time" class="dfn-panel" data-for="cookie-last-access-time" id="infopanel-for-cookie-last-access-time" role="dialog">
+   <span id="infopaneltitle-for-cookie-last-access-time" style="display:none">Info about the 'last-access-time' definition.</span><b><a href="#cookie-last-access-time">#cookie-last-access-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-last-access-time">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-persistent-flag">
-   <b><a href="#cookie-persistent-flag">#cookie-persistent-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-persistent-flag" class="dfn-panel" data-for="cookie-persistent-flag" id="infopanel-for-cookie-persistent-flag" role="dialog">
+   <span id="infopaneltitle-for-cookie-persistent-flag" style="display:none">Info about the 'persistent-flag' definition.</span><b><a href="#cookie-persistent-flag">#cookie-persistent-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-persistent-flag">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-host-only-flag">
-   <b><a href="#cookie-host-only-flag">#cookie-host-only-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-host-only-flag" class="dfn-panel" data-for="cookie-host-only-flag" id="infopanel-for-cookie-host-only-flag" role="dialog">
+   <span id="infopaneltitle-for-cookie-host-only-flag" style="display:none">Info about the 'host-only-flag' definition.</span><b><a href="#cookie-host-only-flag">#cookie-host-only-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-host-only-flag">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-secure-only-flag">
-   <b><a href="#cookie-secure-only-flag">#cookie-secure-only-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-secure-only-flag" class="dfn-panel" data-for="cookie-secure-only-flag" id="infopanel-for-cookie-secure-only-flag" role="dialog">
+   <span id="infopaneltitle-for-cookie-secure-only-flag" style="display:none">Info about the 'secure-only-flag' definition.</span><b><a href="#cookie-secure-only-flag">#cookie-secure-only-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-secure-only-flag">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-http-only-flag">
-   <b><a href="#cookie-http-only-flag">#cookie-http-only-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-http-only-flag" class="dfn-panel" data-for="cookie-http-only-flag" id="infopanel-for-cookie-http-only-flag" role="dialog">
+   <span id="infopaneltitle-for-cookie-http-only-flag" style="display:none">Info about the 'http-only-flag' definition.</span><b><a href="#cookie-http-only-flag">#cookie-http-only-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-http-only-flag">7.1. Query Cookies</a> <a href="#ref-for-cookie-http-only-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-same-site-flag">
-   <b><a href="#cookie-same-site-flag">#cookie-same-site-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-same-site-flag" class="dfn-panel" data-for="cookie-same-site-flag" id="infopanel-for-cookie-same-site-flag" role="dialog">
+   <span id="infopaneltitle-for-cookie-same-site-flag" style="display:none">Info about the 'same-site-flag' definition.</span><b><a href="#cookie-same-site-flag">#cookie-same-site-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-same-site-flag">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-visible">
-   <b><a href="#script-visible">#script-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-visible" class="dfn-panel" data-for="script-visible" id="infopanel-for-script-visible" role="dialog">
+   <span id="infopaneltitle-for-script-visible" style="display:none">Info about the 'script-visible' definition.</span><b><a href="#script-visible">#script-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-visible">1.2. Summary</a> <a href="#ref-for-script-visible①">(2)</a>
     <li><a href="#ref-for-script-visible②">3.1. The get() method</a>
@@ -3068,15 +3068,15 @@ authoring advice.</p>
     <li><a href="#ref-for-script-visible⑤">5.2. The ExtendableCookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-store">
-   <b><a href="#cookie-store">#cookie-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-store" class="dfn-panel" data-for="cookie-store" id="infopanel-for-cookie-store" role="dialog">
+   <span id="infopaneltitle-for-cookie-store" style="display:none">Info about the 'cookie store' definition.</span><b><a href="#cookie-store">#cookie-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-store">2.2. Cookie Store</a> <a href="#ref-for-cookie-store①">(2)</a> <a href="#ref-for-cookie-store②">(3)</a> <a href="#ref-for-cookie-store③">(4)</a>
     <li><a href="#ref-for-cookie-store④">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-change-subscription-list">
-   <b><a href="#cookie-change-subscription-list">#cookie-change-subscription-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-change-subscription-list" class="dfn-panel" data-for="cookie-change-subscription-list" id="infopanel-for-cookie-change-subscription-list" role="dialog">
+   <span id="infopaneltitle-for-cookie-change-subscription-list" style="display:none">Info about the 'cookie change subscription list' definition.</span><b><a href="#cookie-change-subscription-list">#cookie-change-subscription-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-change-subscription-list">4.1. The subscribe() method</a>
     <li><a href="#ref-for-cookie-change-subscription-list①">4.2. The getSubscriptions() method</a>
@@ -3085,30 +3085,30 @@ authoring advice.</p>
     <li><a href="#ref-for-cookie-change-subscription-list④">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-change-subscription">
-   <b><a href="#cookie-change-subscription">#cookie-change-subscription</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-change-subscription" class="dfn-panel" data-for="cookie-change-subscription" id="infopanel-for-cookie-change-subscription" role="dialog">
+   <span id="infopaneltitle-for-cookie-change-subscription" style="display:none">Info about the 'cookie change subscription' definition.</span><b><a href="#cookie-change-subscription">#cookie-change-subscription</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-change-subscription">2.3. Extensions to Service Worker</a>
     <li><a href="#ref-for-cookie-change-subscription①">4.1. The subscribe() method</a>
     <li><a href="#ref-for-cookie-change-subscription②">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-change-subscription-name">
-   <b><a href="#cookie-change-subscription-name">#cookie-change-subscription-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-change-subscription-name" class="dfn-panel" data-for="cookie-change-subscription-name" id="infopanel-for-cookie-change-subscription-name" role="dialog">
+   <span id="infopaneltitle-for-cookie-change-subscription-name" style="display:none">Info about the 'name' definition.</span><b><a href="#cookie-change-subscription-name">#cookie-change-subscription-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-change-subscription-name">4.2. The getSubscriptions() method</a>
     <li><a href="#ref-for-cookie-change-subscription-name①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-change-subscription-url">
-   <b><a href="#cookie-change-subscription-url">#cookie-change-subscription-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-change-subscription-url" class="dfn-panel" data-for="cookie-change-subscription-url" id="infopanel-for-cookie-change-subscription-url" role="dialog">
+   <span id="infopaneltitle-for-cookie-change-subscription-url" style="display:none">Info about the 'url' definition.</span><b><a href="#cookie-change-subscription-url">#cookie-change-subscription-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-change-subscription-url">4.2. The getSubscriptions() method</a>
     <li><a href="#ref-for-cookie-change-subscription-url①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookiestore">
-   <b><a href="#cookiestore">#cookiestore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookiestore" class="dfn-panel" data-for="cookiestore" id="infopanel-for-cookiestore" role="dialog">
+   <span id="infopaneltitle-for-cookiestore" style="display:none">Info about the 'CookieStore' definition.</span><b><a href="#cookiestore">#cookiestore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookiestore">1.3. Querying Cookies</a>
     <li><a href="#ref-for-cookiestore①">3. The CookieStore Interface</a>
@@ -3119,15 +3119,15 @@ authoring advice.</p>
     <li><a href="#ref-for-cookiestore⑧">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cookiestoregetoptions">
-   <b><a href="#dictdef-cookiestoregetoptions">#dictdef-cookiestoregetoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cookiestoregetoptions" class="dfn-panel" data-for="dictdef-cookiestoregetoptions" id="infopanel-for-dictdef-cookiestoregetoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cookiestoregetoptions" style="display:none">Info about the 'CookieStoreGetOptions' definition.</span><b><a href="#dictdef-cookiestoregetoptions">#dictdef-cookiestoregetoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cookiestoregetoptions">3. The CookieStore Interface</a> <a href="#ref-for-dictdef-cookiestoregetoptions①">(2)</a>
     <li><a href="#ref-for-dictdef-cookiestoregetoptions②">4. The CookieStoreManager Interface</a> <a href="#ref-for-dictdef-cookiestoregetoptions③">(2)</a> <a href="#ref-for-dictdef-cookiestoregetoptions④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoregetoptions-name">
-   <b><a href="#dom-cookiestoregetoptions-name">#dom-cookiestoregetoptions-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoregetoptions-name" class="dfn-panel" data-for="dom-cookiestoregetoptions-name" id="infopanel-for-dom-cookiestoregetoptions-name" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoregetoptions-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-cookiestoregetoptions-name">#dom-cookiestoregetoptions-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoregetoptions-name">3.1. The get() method</a>
     <li><a href="#ref-for-dom-cookiestoregetoptions-name①">3.2. The getAll() method</a>
@@ -3135,8 +3135,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestoregetoptions-name④">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoregetoptions-url">
-   <b><a href="#dom-cookiestoregetoptions-url">#dom-cookiestoregetoptions-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoregetoptions-url" class="dfn-panel" data-for="dom-cookiestoregetoptions-url" id="infopanel-for-dom-cookiestoregetoptions-url" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoregetoptions-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-cookiestoregetoptions-url">#dom-cookiestoregetoptions-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoregetoptions-url">1.3. Querying Cookies</a>
     <li><a href="#ref-for-dom-cookiestoregetoptions-url①">3.1. The get() method</a> <a href="#ref-for-dom-cookiestoregetoptions-url②">(2)</a>
@@ -3145,14 +3145,14 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestoregetoptions-url⑦">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-cookiesamesite">
-   <b><a href="#enumdef-cookiesamesite">#enumdef-cookiesamesite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-cookiesamesite" class="dfn-panel" data-for="enumdef-cookiesamesite" id="infopanel-for-enumdef-cookiesamesite" role="dialog">
+   <span id="infopaneltitle-for-enumdef-cookiesamesite" style="display:none">Info about the 'CookieSameSite' definition.</span><b><a href="#enumdef-cookiesamesite">#enumdef-cookiesamesite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-cookiesamesite">3. The CookieStore Interface</a> <a href="#ref-for-enumdef-cookiesamesite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiesamesite-strict">
-   <b><a href="#dom-cookiesamesite-strict">#dom-cookiesamesite-strict</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiesamesite-strict" class="dfn-panel" data-for="dom-cookiesamesite-strict" id="infopanel-for-dom-cookiesamesite-strict" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiesamesite-strict" style="display:none">Info about the '"strict"' definition.</span><b><a href="#dom-cookiesamesite-strict">#dom-cookiesamesite-strict</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiesamesite-strict">3.4. The delete() method</a>
     <li><a href="#ref-for-dom-cookiesamesite-strict①">7.1. Query Cookies</a>
@@ -3160,88 +3160,88 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiesamesite-strict③">7.3. Delete a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiesamesite-lax">
-   <b><a href="#dom-cookiesamesite-lax">#dom-cookiesamesite-lax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiesamesite-lax" class="dfn-panel" data-for="dom-cookiesamesite-lax" id="infopanel-for-dom-cookiesamesite-lax" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiesamesite-lax" style="display:none">Info about the '"lax"' definition.</span><b><a href="#dom-cookiesamesite-lax">#dom-cookiesamesite-lax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiesamesite-lax">7.1. Query Cookies</a>
     <li><a href="#ref-for-dom-cookiesamesite-lax①">7.2. Set a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiesamesite-none">
-   <b><a href="#dom-cookiesamesite-none">#dom-cookiesamesite-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiesamesite-none" class="dfn-panel" data-for="dom-cookiesamesite-none" id="infopanel-for-dom-cookiesamesite-none" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiesamesite-none" style="display:none">Info about the '"none"' definition.</span><b><a href="#dom-cookiesamesite-none">#dom-cookiesamesite-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiesamesite-none">7.1. Query Cookies</a>
     <li><a href="#ref-for-dom-cookiesamesite-none①">7.2. Set a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cookieinit">
-   <b><a href="#dictdef-cookieinit">#dictdef-cookieinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cookieinit" class="dfn-panel" data-for="dictdef-cookieinit" id="infopanel-for-dictdef-cookieinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cookieinit" style="display:none">Info about the 'CookieInit' definition.</span><b><a href="#dictdef-cookieinit">#dictdef-cookieinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cookieinit">3. The CookieStore Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-name">
-   <b><a href="#dom-cookieinit-name">#dom-cookieinit-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-name" class="dfn-panel" data-for="dom-cookieinit-name" id="infopanel-for-dom-cookieinit-name" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-cookieinit-name">#dom-cookieinit-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-name">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-value">
-   <b><a href="#dom-cookieinit-value">#dom-cookieinit-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-value" class="dfn-panel" data-for="dom-cookieinit-value" id="infopanel-for-dom-cookieinit-value" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-cookieinit-value">#dom-cookieinit-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-value">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-expires">
-   <b><a href="#dom-cookieinit-expires">#dom-cookieinit-expires</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-expires" class="dfn-panel" data-for="dom-cookieinit-expires" id="infopanel-for-dom-cookieinit-expires" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-expires" style="display:none">Info about the 'expires' definition.</span><b><a href="#dom-cookieinit-expires">#dom-cookieinit-expires</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-expires">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-domain">
-   <b><a href="#dom-cookieinit-domain">#dom-cookieinit-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-domain" class="dfn-panel" data-for="dom-cookieinit-domain" id="infopanel-for-dom-cookieinit-domain" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-domain" style="display:none">Info about the 'domain' definition.</span><b><a href="#dom-cookieinit-domain">#dom-cookieinit-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-domain">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-path">
-   <b><a href="#dom-cookieinit-path">#dom-cookieinit-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-path" class="dfn-panel" data-for="dom-cookieinit-path" id="infopanel-for-dom-cookieinit-path" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-path" style="display:none">Info about the 'path' definition.</span><b><a href="#dom-cookieinit-path">#dom-cookieinit-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-path">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookieinit-samesite">
-   <b><a href="#dom-cookieinit-samesite">#dom-cookieinit-samesite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookieinit-samesite" class="dfn-panel" data-for="dom-cookieinit-samesite" id="infopanel-for-dom-cookieinit-samesite" role="dialog">
+   <span id="infopaneltitle-for-dom-cookieinit-samesite" style="display:none">Info about the 'sameSite' definition.</span><b><a href="#dom-cookieinit-samesite">#dom-cookieinit-samesite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookieinit-samesite">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cookiestoredeleteoptions">
-   <b><a href="#dictdef-cookiestoredeleteoptions">#dictdef-cookiestoredeleteoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cookiestoredeleteoptions" class="dfn-panel" data-for="dictdef-cookiestoredeleteoptions" id="infopanel-for-dictdef-cookiestoredeleteoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cookiestoredeleteoptions" style="display:none">Info about the 'CookieStoreDeleteOptions' definition.</span><b><a href="#dictdef-cookiestoredeleteoptions">#dictdef-cookiestoredeleteoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cookiestoredeleteoptions">3. The CookieStore Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoredeleteoptions-name">
-   <b><a href="#dom-cookiestoredeleteoptions-name">#dom-cookiestoredeleteoptions-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoredeleteoptions-name" class="dfn-panel" data-for="dom-cookiestoredeleteoptions-name" id="infopanel-for-dom-cookiestoredeleteoptions-name" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoredeleteoptions-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-cookiestoredeleteoptions-name">#dom-cookiestoredeleteoptions-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoredeleteoptions-name">3.4. The delete() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoredeleteoptions-domain">
-   <b><a href="#dom-cookiestoredeleteoptions-domain">#dom-cookiestoredeleteoptions-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoredeleteoptions-domain" class="dfn-panel" data-for="dom-cookiestoredeleteoptions-domain" id="infopanel-for-dom-cookiestoredeleteoptions-domain" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoredeleteoptions-domain" style="display:none">Info about the 'domain' definition.</span><b><a href="#dom-cookiestoredeleteoptions-domain">#dom-cookiestoredeleteoptions-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoredeleteoptions-domain">3.4. The delete() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoredeleteoptions-path">
-   <b><a href="#dom-cookiestoredeleteoptions-path">#dom-cookiestoredeleteoptions-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoredeleteoptions-path" class="dfn-panel" data-for="dom-cookiestoredeleteoptions-path" id="infopanel-for-dom-cookiestoredeleteoptions-path" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoredeleteoptions-path" style="display:none">Info about the 'path' definition.</span><b><a href="#dom-cookiestoredeleteoptions-path">#dom-cookiestoredeleteoptions-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoredeleteoptions-path">3.4. The delete() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cookielistitem">
-   <b><a href="#dictdef-cookielistitem">#dictdef-cookielistitem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cookielistitem" class="dfn-panel" data-for="dictdef-cookielistitem" id="infopanel-for-dictdef-cookielistitem" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cookielistitem" style="display:none">Info about the 'CookieListItem' definition.</span><b><a href="#dictdef-cookielistitem">#dictdef-cookielistitem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cookielistitem">3. The CookieStore Interface</a> <a href="#ref-for-dictdef-cookielistitem①">(2)</a> <a href="#ref-for-dictdef-cookielistitem②">(3)</a>
     <li><a href="#ref-for-dictdef-cookielistitem③">5.1. The CookieChangeEvent interface</a> <a href="#ref-for-dictdef-cookielistitem④">(2)</a>
@@ -3249,29 +3249,29 @@ authoring advice.</p>
     <li><a href="#ref-for-dictdef-cookielistitem⑦">7.1. Query Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookielistitem-value">
-   <b><a href="#dom-cookielistitem-value">#dom-cookielistitem-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookielistitem-value" class="dfn-panel" data-for="dom-cookielistitem-value" id="infopanel-for-dom-cookielistitem-value" role="dialog">
+   <span id="infopaneltitle-for-dom-cookielistitem-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-cookielistitem-value">#dom-cookielistitem-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookielistitem-value">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-cookielist">
-   <b><a href="#typedefdef-cookielist">#typedefdef-cookielist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cookielist" class="dfn-panel" data-for="typedefdef-cookielist" id="infopanel-for-typedefdef-cookielist" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cookielist" style="display:none">Info about the 'CookieList' definition.</span><b><a href="#typedefdef-cookielist">#typedefdef-cookielist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cookielist">3. The CookieStore Interface</a> <a href="#ref-for-typedefdef-cookielist①">(2)</a>
     <li><a href="#ref-for-typedefdef-cookielist②">5.1. The CookieChangeEvent interface</a> <a href="#ref-for-typedefdef-cookielist③">(2)</a>
     <li><a href="#ref-for-typedefdef-cookielist④">5.2. The ExtendableCookieChangeEvent interface</a> <a href="#ref-for-typedefdef-cookielist⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-get">
-   <b><a href="#dom-cookiestore-get">#dom-cookiestore-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-get" class="dfn-panel" data-for="dom-cookiestore-get" id="infopanel-for-dom-cookiestore-get" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-get" style="display:none">Info about the 'get(name)' definition.</span><b><a href="#dom-cookiestore-get">#dom-cookiestore-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-get">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-get①">3.1. The get() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-get-options">
-   <b><a href="#dom-cookiestore-get-options">#dom-cookiestore-get-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-get-options" class="dfn-panel" data-for="dom-cookiestore-get-options" id="infopanel-for-dom-cookiestore-get-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-get-options" style="display:none">Info about the 'get(options)' definition.</span><b><a href="#dom-cookiestore-get-options">#dom-cookiestore-get-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-get-options">1.3. Querying Cookies</a> <a href="#ref-for-dom-cookiestore-get-options①">(2)</a> <a href="#ref-for-dom-cookiestore-get-options②">(3)</a>
     <li><a href="#ref-for-dom-cookiestore-get-options③">1.5. Monitoring Cookies</a>
@@ -3280,15 +3280,15 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestore-get-options⑦">4.1. The subscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-getall">
-   <b><a href="#dom-cookiestore-getall">#dom-cookiestore-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-getall" class="dfn-panel" data-for="dom-cookiestore-getall" id="infopanel-for-dom-cookiestore-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-getall" style="display:none">Info about the 'getAll(name)' definition.</span><b><a href="#dom-cookiestore-getall">#dom-cookiestore-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-getall">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-getall①">3.2. The getAll() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-getall-options">
-   <b><a href="#dom-cookiestore-getall-options">#dom-cookiestore-getall-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-getall-options" class="dfn-panel" data-for="dom-cookiestore-getall-options" id="infopanel-for-dom-cookiestore-getall-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-getall-options" style="display:none">Info about the 'getAll(options)' definition.</span><b><a href="#dom-cookiestore-getall-options">#dom-cookiestore-getall-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-getall-options">1.3. Querying Cookies</a> <a href="#ref-for-dom-cookiestore-getall-options①">(2)</a> <a href="#ref-for-dom-cookiestore-getall-options②">(3)</a> <a href="#ref-for-dom-cookiestore-getall-options③">(4)</a>
     <li><a href="#ref-for-dom-cookiestore-getall-options④">1.5. Monitoring Cookies</a>
@@ -3297,38 +3297,38 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestore-getall-options⑧">4.1. The subscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-set">
-   <b><a href="#dom-cookiestore-set">#dom-cookiestore-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-set" class="dfn-panel" data-for="dom-cookiestore-set" id="infopanel-for-dom-cookiestore-set" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-set" style="display:none">Info about the 'set(name, value)' definition.</span><b><a href="#dom-cookiestore-set">#dom-cookiestore-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-set">1.4. Modifying Cookies</a> <a href="#ref-for-dom-cookiestore-set①">(2)</a>
     <li><a href="#ref-for-dom-cookiestore-set②">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-set③">3.3. The set() method</a> <a href="#ref-for-dom-cookiestore-set④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-set-options">
-   <b><a href="#dom-cookiestore-set-options">#dom-cookiestore-set-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-set-options" class="dfn-panel" data-for="dom-cookiestore-set-options" id="infopanel-for-dom-cookiestore-set-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-set-options" style="display:none">Info about the 'set(options)' definition.</span><b><a href="#dom-cookiestore-set-options">#dom-cookiestore-set-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-set-options">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-set-options①">3.3. The set() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-delete">
-   <b><a href="#dom-cookiestore-delete">#dom-cookiestore-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-delete" class="dfn-panel" data-for="dom-cookiestore-delete" id="infopanel-for-dom-cookiestore-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-delete" style="display:none">Info about the 'delete(name)' definition.</span><b><a href="#dom-cookiestore-delete">#dom-cookiestore-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-delete">1.4. Modifying Cookies</a>
     <li><a href="#ref-for-dom-cookiestore-delete①">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-delete②">3.4. The delete() method</a> <a href="#ref-for-dom-cookiestore-delete③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestore-delete-options">
-   <b><a href="#dom-cookiestore-delete-options">#dom-cookiestore-delete-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestore-delete-options" class="dfn-panel" data-for="dom-cookiestore-delete-options" id="infopanel-for-dom-cookiestore-delete-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestore-delete-options" style="display:none">Info about the 'delete(options)' definition.</span><b><a href="#dom-cookiestore-delete-options">#dom-cookiestore-delete-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestore-delete-options">3. The CookieStore Interface</a>
     <li><a href="#ref-for-dom-cookiestore-delete-options①">3.4. The delete() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookiestoremanager-registration">
-   <b><a href="#cookiestoremanager-registration">#cookiestoremanager-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookiestoremanager-registration" class="dfn-panel" data-for="cookiestoremanager-registration" id="infopanel-for-cookiestoremanager-registration" role="dialog">
+   <span id="infopaneltitle-for-cookiestoremanager-registration" style="display:none">Info about the 'registration' definition.</span><b><a href="#cookiestoremanager-registration">#cookiestoremanager-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookiestoremanager-registration">4.1. The subscribe() method</a>
     <li><a href="#ref-for-cookiestoremanager-registration①">4.2. The getSubscriptions() method</a>
@@ -3336,15 +3336,15 @@ authoring advice.</p>
     <li><a href="#ref-for-cookiestoremanager-registration③">4.4. The ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookiestoremanager">
-   <b><a href="#cookiestoremanager">#cookiestoremanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookiestoremanager" class="dfn-panel" data-for="cookiestoremanager" id="infopanel-for-cookiestoremanager" role="dialog">
+   <span id="infopaneltitle-for-cookiestoremanager" style="display:none">Info about the 'CookieStoreManager' definition.</span><b><a href="#cookiestoremanager">#cookiestoremanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookiestoremanager">4. The CookieStoreManager Interface</a> <a href="#ref-for-cookiestoremanager①">(2)</a> <a href="#ref-for-cookiestoremanager②">(3)</a>
     <li><a href="#ref-for-cookiestoremanager③">4.4. The ServiceWorkerRegistration interface</a> <a href="#ref-for-cookiestoremanager④">(2)</a> <a href="#ref-for-cookiestoremanager⑤">(3)</a> <a href="#ref-for-cookiestoremanager⑥">(4)</a> <a href="#ref-for-cookiestoremanager⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoremanager-subscribe">
-   <b><a href="#dom-cookiestoremanager-subscribe">#dom-cookiestoremanager-subscribe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoremanager-subscribe" class="dfn-panel" data-for="dom-cookiestoremanager-subscribe" id="infopanel-for-dom-cookiestoremanager-subscribe" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoremanager-subscribe" style="display:none">Info about the 'subscribe(subscriptions)' definition.</span><b><a href="#dom-cookiestoremanager-subscribe">#dom-cookiestoremanager-subscribe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoremanager-subscribe">1.5. Monitoring Cookies</a>
     <li><a href="#ref-for-dom-cookiestoremanager-subscribe①">4. The CookieStoreManager Interface</a> <a href="#ref-for-dom-cookiestoremanager-subscribe②">(2)</a>
@@ -3352,8 +3352,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestoremanager-subscribe⑤">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoremanager-getsubscriptions">
-   <b><a href="#dom-cookiestoremanager-getsubscriptions">#dom-cookiestoremanager-getsubscriptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoremanager-getsubscriptions" class="dfn-panel" data-for="dom-cookiestoremanager-getsubscriptions" id="infopanel-for-dom-cookiestoremanager-getsubscriptions" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoremanager-getsubscriptions" style="display:none">Info about the 'getSubscriptions()' definition.</span><b><a href="#dom-cookiestoremanager-getsubscriptions">#dom-cookiestoremanager-getsubscriptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoremanager-getsubscriptions">1.5. Monitoring Cookies</a>
     <li><a href="#ref-for-dom-cookiestoremanager-getsubscriptions①">4. The CookieStoreManager Interface</a>
@@ -3361,237 +3361,293 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-cookiestoremanager-getsubscriptions④">4.3. The unsubscribe() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiestoremanager-unsubscribe">
-   <b><a href="#dom-cookiestoremanager-unsubscribe">#dom-cookiestoremanager-unsubscribe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiestoremanager-unsubscribe" class="dfn-panel" data-for="dom-cookiestoremanager-unsubscribe" id="infopanel-for-dom-cookiestoremanager-unsubscribe" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiestoremanager-unsubscribe" style="display:none">Info about the 'unsubscribe(subscriptions)' definition.</span><b><a href="#dom-cookiestoremanager-unsubscribe">#dom-cookiestoremanager-unsubscribe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiestoremanager-unsubscribe">4. The CookieStoreManager Interface</a>
     <li><a href="#ref-for-dom-cookiestoremanager-unsubscribe①">4.3. The unsubscribe() method</a> <a href="#ref-for-dom-cookiestoremanager-unsubscribe②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-cookies">
-   <b><a href="#dom-serviceworkerregistration-cookies">#dom-serviceworkerregistration-cookies</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-cookies" class="dfn-panel" data-for="dom-serviceworkerregistration-cookies" id="infopanel-for-dom-serviceworkerregistration-cookies" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-cookies" style="display:none">Info about the 'cookies' definition.</span><b><a href="#dom-serviceworkerregistration-cookies">#dom-serviceworkerregistration-cookies</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-cookies">4.4. The ServiceWorkerRegistration interface</a> <a href="#ref-for-dom-serviceworkerregistration-cookies①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookiechangeevent">
-   <b><a href="#cookiechangeevent">#cookiechangeevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookiechangeevent" class="dfn-panel" data-for="cookiechangeevent" id="infopanel-for-cookiechangeevent" role="dialog">
+   <span id="infopaneltitle-for-cookiechangeevent" style="display:none">Info about the 'CookieChangeEvent' definition.</span><b><a href="#cookiechangeevent">#cookiechangeevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookiechangeevent">5.1. The CookieChangeEvent interface</a> <a href="#ref-for-cookiechangeevent①">(2)</a>
     <li><a href="#ref-for-cookiechangeevent②">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiechangeevent-changed">
-   <b><a href="#dom-cookiechangeevent-changed">#dom-cookiechangeevent-changed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiechangeevent-changed" class="dfn-panel" data-for="dom-cookiechangeevent-changed" id="infopanel-for-dom-cookiechangeevent-changed" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiechangeevent-changed" style="display:none">Info about the 'changed' definition.</span><b><a href="#dom-cookiechangeevent-changed">#dom-cookiechangeevent-changed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiechangeevent-changed">5.1. The CookieChangeEvent interface</a>
     <li><a href="#ref-for-dom-cookiechangeevent-changed①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cookiechangeevent-deleted">
-   <b><a href="#dom-cookiechangeevent-deleted">#dom-cookiechangeevent-deleted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cookiechangeevent-deleted" class="dfn-panel" data-for="dom-cookiechangeevent-deleted" id="infopanel-for-dom-cookiechangeevent-deleted" role="dialog">
+   <span id="infopaneltitle-for-dom-cookiechangeevent-deleted" style="display:none">Info about the 'deleted' definition.</span><b><a href="#dom-cookiechangeevent-deleted">#dom-cookiechangeevent-deleted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cookiechangeevent-deleted">5.1. The CookieChangeEvent interface</a>
     <li><a href="#ref-for-dom-cookiechangeevent-deleted①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cookiechangeeventinit">
-   <b><a href="#dictdef-cookiechangeeventinit">#dictdef-cookiechangeeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cookiechangeeventinit" class="dfn-panel" data-for="dictdef-cookiechangeeventinit" id="infopanel-for-dictdef-cookiechangeeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cookiechangeeventinit" style="display:none">Info about the 'CookieChangeEventInit' definition.</span><b><a href="#dictdef-cookiechangeeventinit">#dictdef-cookiechangeeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cookiechangeeventinit">5.1. The CookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablecookiechangeevent">
-   <b><a href="#extendablecookiechangeevent">#extendablecookiechangeevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablecookiechangeevent" class="dfn-panel" data-for="extendablecookiechangeevent" id="infopanel-for-extendablecookiechangeevent" role="dialog">
+   <span id="infopaneltitle-for-extendablecookiechangeevent" style="display:none">Info about the 'ExtendableCookieChangeEvent' definition.</span><b><a href="#extendablecookiechangeevent">#extendablecookiechangeevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablecookiechangeevent">5.2. The ExtendableCookieChangeEvent interface</a> <a href="#ref-for-extendablecookiechangeevent①">(2)</a>
     <li><a href="#ref-for-extendablecookiechangeevent②">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablecookiechangeevent-changed">
-   <b><a href="#dom-extendablecookiechangeevent-changed">#dom-extendablecookiechangeevent-changed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablecookiechangeevent-changed" class="dfn-panel" data-for="dom-extendablecookiechangeevent-changed" id="infopanel-for-dom-extendablecookiechangeevent-changed" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablecookiechangeevent-changed" style="display:none">Info about the 'changed' definition.</span><b><a href="#dom-extendablecookiechangeevent-changed">#dom-extendablecookiechangeevent-changed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablecookiechangeevent-changed">5.2. The ExtendableCookieChangeEvent interface</a>
     <li><a href="#ref-for-dom-extendablecookiechangeevent-changed①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablecookiechangeevent-deleted">
-   <b><a href="#dom-extendablecookiechangeevent-deleted">#dom-extendablecookiechangeevent-deleted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablecookiechangeevent-deleted" class="dfn-panel" data-for="dom-extendablecookiechangeevent-deleted" id="infopanel-for-dom-extendablecookiechangeevent-deleted" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablecookiechangeevent-deleted" style="display:none">Info about the 'deleted' definition.</span><b><a href="#dom-extendablecookiechangeevent-deleted">#dom-extendablecookiechangeevent-deleted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablecookiechangeevent-deleted">5.2. The ExtendableCookieChangeEvent interface</a>
     <li><a href="#ref-for-dom-extendablecookiechangeevent-deleted①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendablecookiechangeeventinit">
-   <b><a href="#dictdef-extendablecookiechangeeventinit">#dictdef-extendablecookiechangeeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendablecookiechangeeventinit" class="dfn-panel" data-for="dictdef-extendablecookiechangeeventinit" id="infopanel-for-dictdef-extendablecookiechangeeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendablecookiechangeeventinit" style="display:none">Info about the 'ExtendableCookieChangeEventInit' definition.</span><b><a href="#dictdef-extendablecookiechangeeventinit">#dictdef-extendablecookiechangeeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendablecookiechangeeventinit">5.2. The ExtendableCookieChangeEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="window-associated-cookiestore">
-   <b><a href="#window-associated-cookiestore">#window-associated-cookiestore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-associated-cookiestore" class="dfn-panel" data-for="window-associated-cookiestore" id="infopanel-for-window-associated-cookiestore" role="dialog">
+   <span id="infopaneltitle-for-window-associated-cookiestore" style="display:none">Info about the 'associated CookieStore' definition.</span><b><a href="#window-associated-cookiestore">#window-associated-cookiestore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-associated-cookiestore">6.1. The Window interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-cookiestore">
-   <b><a href="#dom-window-cookiestore">#dom-window-cookiestore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-cookiestore" class="dfn-panel" data-for="dom-window-cookiestore" id="infopanel-for-dom-window-cookiestore" role="dialog">
+   <span id="infopaneltitle-for-dom-window-cookiestore" style="display:none">Info about the 'cookieStore' definition.</span><b><a href="#dom-window-cookiestore">#dom-window-cookiestore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-cookiestore">1.3. Querying Cookies</a>
     <li><a href="#ref-for-dom-window-cookiestore①">1.4. Modifying Cookies</a>
     <li><a href="#ref-for-dom-window-cookiestore②">6.1. The Window interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope-associated-cookiestore">
-   <b><a href="#serviceworkerglobalscope-associated-cookiestore">#serviceworkerglobalscope-associated-cookiestore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope-associated-cookiestore" class="dfn-panel" data-for="serviceworkerglobalscope-associated-cookiestore" id="infopanel-for-serviceworkerglobalscope-associated-cookiestore" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope-associated-cookiestore" style="display:none">Info about the 'associated CookieStore' definition.</span><b><a href="#serviceworkerglobalscope-associated-cookiestore">#serviceworkerglobalscope-associated-cookiestore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-associated-cookiestore">6.2. The ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-cookiestore">
-   <b><a href="#dom-serviceworkerglobalscope-cookiestore">#dom-serviceworkerglobalscope-cookiestore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-cookiestore" class="dfn-panel" data-for="dom-serviceworkerglobalscope-cookiestore" id="infopanel-for-dom-serviceworkerglobalscope-cookiestore" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-cookiestore" style="display:none">Info about the 'cookieStore' definition.</span><b><a href="#dom-serviceworkerglobalscope-cookiestore">#dom-serviceworkerglobalscope-cookiestore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-cookiestore">6.2. The ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encode">
-   <b><a href="#encode">#encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode" class="dfn-panel" data-for="encode" id="infopanel-for-encode" role="dialog">
+   <span id="infopaneltitle-for-encode" style="display:none">Info about the 'encode' definition.</span><b><a href="#encode">#encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode">7.2. Set a Cookie</a> <a href="#ref-for-encode①">(2)</a> <a href="#ref-for-encode②">(3)</a> <a href="#ref-for-encode③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decode">
-   <b><a href="#decode">#decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decode" class="dfn-panel" data-for="decode" id="infopanel-for-decode" role="dialog">
+   <span id="infopaneltitle-for-decode" style="display:none">Info about the 'decode' definition.</span><b><a href="#decode">#decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode">7.1. Query Cookies</a> <a href="#ref-for-decode①">(2)</a> <a href="#ref-for-decode②">(3)</a> <a href="#ref-for-decode③">(4)</a> <a href="#ref-for-decode④">(5)</a>
     <li><a href="#ref-for-decode⑤">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="as-a-timestamp">
-   <b><a href="#as-a-timestamp">#as-a-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-as-a-timestamp" class="dfn-panel" data-for="as-a-timestamp" id="infopanel-for-as-a-timestamp" role="dialog">
+   <span id="infopaneltitle-for-as-a-timestamp" style="display:none">Info about the 'as a timestamp' definition.</span><b><a href="#as-a-timestamp">#as-a-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-as-a-timestamp">7.1. Query Cookies</a>
     <li><a href="#ref-for-as-a-timestamp①">7.3. Delete a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="date-serialize">
-   <b><a href="#date-serialize">#date-serialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-date-serialize" class="dfn-panel" data-for="date-serialize" id="infopanel-for-date-serialize" role="dialog">
+   <span id="infopaneltitle-for-date-serialize" style="display:none">Info about the 'date serialize' definition.</span><b><a href="#date-serialize">#date-serialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-date-serialize">7.2. Set a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-cookies">
-   <b><a href="#query-cookies">#query-cookies</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-cookies" class="dfn-panel" data-for="query-cookies" id="infopanel-for-query-cookies" role="dialog">
+   <span id="infopaneltitle-for-query-cookies" style="display:none">Info about the 'query cookies' definition.</span><b><a href="#query-cookies">#query-cookies</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-cookies">3.1. The get() method</a> <a href="#ref-for-query-cookies①">(2)</a>
     <li><a href="#ref-for-query-cookies②">3.2. The getAll() method</a> <a href="#ref-for-query-cookies③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-cookielistitem">
-   <b><a href="#create-a-cookielistitem">#create-a-cookielistitem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-cookielistitem" class="dfn-panel" data-for="create-a-cookielistitem" id="infopanel-for-create-a-cookielistitem" role="dialog">
+   <span id="infopaneltitle-for-create-a-cookielistitem" style="display:none">Info about the 'create a CookieListItem' definition.</span><b><a href="#create-a-cookielistitem">#create-a-cookielistitem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cookielistitem">7.1. Query Cookies</a>
     <li><a href="#ref-for-create-a-cookielistitem①">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-a-cookie">
-   <b><a href="#set-a-cookie">#set-a-cookie</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-a-cookie" class="dfn-panel" data-for="set-a-cookie" id="infopanel-for-set-a-cookie" role="dialog">
+   <span id="infopaneltitle-for-set-a-cookie" style="display:none">Info about the 'set a cookie' definition.</span><b><a href="#set-a-cookie">#set-a-cookie</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-a-cookie">3.3. The set() method</a> <a href="#ref-for-set-a-cookie①">(2)</a>
     <li><a href="#ref-for-set-a-cookie②">7.3. Delete a Cookie</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delete-a-cookie">
-   <b><a href="#delete-a-cookie">#delete-a-cookie</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delete-a-cookie" class="dfn-panel" data-for="delete-a-cookie" id="infopanel-for-delete-a-cookie" role="dialog">
+   <span id="infopaneltitle-for-delete-a-cookie" style="display:none">Info about the 'delete a cookie' definition.</span><b><a href="#delete-a-cookie">#delete-a-cookie</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delete-a-cookie">3.4. The delete() method</a> <a href="#ref-for-delete-a-cookie①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-cookie-changes">
-   <b><a href="#process-cookie-changes">#process-cookie-changes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-cookie-changes" class="dfn-panel" data-for="process-cookie-changes" id="infopanel-for-process-cookie-changes" role="dialog">
+   <span id="infopaneltitle-for-process-cookie-changes" style="display:none">Info about the 'process cookie changes' definition.</span><b><a href="#process-cookie-changes">#process-cookie-changes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-cookie-changes">2.2. Cookie Store</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-changes">
-   <b><a href="#observable-changes">#observable-changes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-changes" class="dfn-panel" data-for="observable-changes" id="infopanel-for-observable-changes" role="dialog">
+   <span id="infopaneltitle-for-observable-changes" style="display:none">Info about the 'observable changes' definition.</span><b><a href="#observable-changes">#observable-changes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-changes">7.4. Process Changes</a> <a href="#ref-for-observable-changes①">(2)</a> <a href="#ref-for-observable-changes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cookie-change">
-   <b><a href="#cookie-change">#cookie-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-change" class="dfn-panel" data-for="cookie-change" id="infopanel-for-cookie-change" role="dialog">
+   <span id="infopaneltitle-for-cookie-change" style="display:none">Info about the 'cookie change' definition.</span><b><a href="#cookie-change">#cookie-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-change">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-change-event">
-   <b><a href="#fire-a-change-event">#fire-a-change-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-change-event" class="dfn-panel" data-for="fire-a-change-event" id="infopanel-for-fire-a-change-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-change-event" style="display:none">Info about the 'fire a change event' definition.</span><b><a href="#fire-a-change-event">#fire-a-change-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-change-event">7.4. Process Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="prepare-lists">
-   <b><a href="#prepare-lists">#prepare-lists</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-prepare-lists" class="dfn-panel" data-for="prepare-lists" id="infopanel-for-prepare-lists" role="dialog">
+   <span id="infopaneltitle-for-prepare-lists" style="display:none">Info about the 'prepare lists' definition.</span><b><a href="#prepare-lists">#prepare-lists</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prepare-lists">7.4. Process Changes</a> <a href="#ref-for-prepare-lists①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/crash-reporting/index.html
+++ b/tests/github/WICG/crash-reporting/index.html
@@ -1035,56 +1035,56 @@ Content-Type: application/reports+json
     </ul>
    <li><a href="#dom-crashreportbody-tojson">toJSON()</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-reportbody">
-   <a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reportbody" class="dfn-panel" data-for="term-for-reportbody" id="infopanel-for-term-for-reportbody" role="menu">
+   <span id="infopaneltitle-for-term-for-reportbody" style="display:none">Info about the 'ReportBody' external reference.</span><a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reportbody">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-body">
-   <a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-body" class="dfn-panel" data-for="term-for-report-body" id="infopanel-for-term-for-report-body" role="menu">
+   <span id="infopaneltitle-for-term-for-report-body" style="display:none">Info about the 'body' external reference.</span><a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-body">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-endpoint">
-   <a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-endpoint" class="dfn-panel" data-for="term-for-endpoint" id="infopanel-for-term-for-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-endpoint" style="display:none">Info about the 'endpoint' external reference.</span><a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report">
-   <a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report" class="dfn-panel" data-for="term-for-report" id="infopanel-for-term-for-report" role="menu">
+   <span id="infopaneltitle-for-term-for-report" style="display:none">Info about the 'report' external reference.</span><a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-type">
-   <a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-type" class="dfn-panel" data-for="term-for-report-type" id="infopanel-for-term-for-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-report-type" style="display:none">Info about the 'report type' external reference.</span><a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-type">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. Crash Reports</a>
    </ul>
@@ -1125,79 +1125,135 @@ Content-Type: application/reports+json
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="crash-reports">
-   <b><a href="#crash-reports">#crash-reports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-crash-reports" class="dfn-panel" data-for="crash-reports" id="infopanel-for-crash-reports" role="dialog">
+   <span id="infopaneltitle-for-crash-reports" style="display:none">Info about the 'Crash reports' definition.</span><b><a href="#crash-reports">#crash-reports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-crash-reports">3. Crash Reports</a> <a href="#ref-for-crash-reports①">(2)</a> <a href="#ref-for-crash-reports②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="crashreportbody">
-   <b><a href="#crashreportbody">#crashreportbody</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-crashreportbody" class="dfn-panel" data-for="crashreportbody" id="infopanel-for-crashreportbody" role="dialog">
+   <span id="infopaneltitle-for-crashreportbody" style="display:none">Info about the 'CrashReportBody' definition.</span><b><a href="#crashreportbody">#crashreportbody</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-crashreportbody">3. Crash Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="crashreportbody-reason">
-   <b><a href="#crashreportbody-reason">#crashreportbody-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-crashreportbody-reason" class="dfn-panel" data-for="crashreportbody-reason" id="infopanel-for-crashreportbody-reason" role="dialog">
+   <span id="infopaneltitle-for-crashreportbody-reason" style="display:none">Info about the 'reason' definition.</span><b><a href="#crashreportbody-reason">#crashreportbody-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-crashreportbody-reason">3. Crash Reports</a> <a href="#ref-for-crashreportbody-reason①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/css-parser-api/index.html
+++ b/tests/github/WICG/css-parser-api/index.html
@@ -954,63 +954,63 @@ Am I succeeding at this goal?</p>
      <li><a href="#CSSParserQualifiedRule-stringification-behavior">dfn for CSSParserQualifiedRule</a><span>, in § 3</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-cssstylevalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylevalue" class="dfn-panel" data-for="term-for-cssstylevalue" id="infopanel-for-term-for-cssstylevalue" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylevalue" style="display:none">Info about the 'CSSStyleValue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylevalue">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-sizes">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-sizes" class="dfn-panel" data-for="term-for-attr-img-sizes" id="infopanel-for-term-for-attr-img-sizes" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-sizes" style="display:none">Info about the 'sizes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-sizes">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Parsing API</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a>
     <li><a href="#ref-for-idl-DOMString⑥">3. Parser Values</a> <a href="#ref-for-idl-DOMString⑦">(2)</a> <a href="#ref-for-idl-DOMString⑧">(3)</a> <a href="#ref-for-idl-DOMString⑨">(4)</a> <a href="#ref-for-idl-DOMString①⓪">(5)</a> <a href="#ref-for-idl-DOMString①①">(6)</a> <a href="#ref-for-idl-DOMString①②">(7)</a> <a href="#ref-for-idl-DOMString①③">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Parser Values</a> <a href="#ref-for-Exposed①">(2)</a> <a href="#ref-for-Exposed②">(3)</a> <a href="#ref-for-Exposed③">(4)</a> <a href="#ref-for-Exposed④">(5)</a> <a href="#ref-for-Exposed⑤">(6)</a> <a href="#ref-for-Exposed⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. Parser Values</a> <a href="#ref-for-idl-frozen-array①">(2)</a> <a href="#ref-for-idl-frozen-array②">(3)</a> <a href="#ref-for-idl-frozen-array③">(4)</a> <a href="#ref-for-idl-frozen-array④">(5)</a> <a href="#ref-for-idl-frozen-array⑤">(6)</a> <a href="#ref-for-idl-frozen-array⑥">(7)</a> <a href="#ref-for-idl-frozen-array⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2. Parsing API</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2. Parsing API</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a> <a href="#ref-for-idl-sequence④">(5)</a> <a href="#ref-for-idl-sequence⑤">(6)</a>
     <li><a href="#ref-for-idl-sequence⑥">3. Parser Values</a> <a href="#ref-for-idl-sequence⑦">(2)</a> <a href="#ref-for-idl-sequence⑧">(3)</a> <a href="#ref-for-idl-sequence⑨">(4)</a> <a href="#ref-for-idl-sequence①⓪">(5)</a> <a href="#ref-for-idl-sequence①①">(6)</a> <a href="#ref-for-idl-sequence①②">(7)</a> <a href="#ref-for-idl-sequence①③">(8)</a>
@@ -1174,58 +1174,58 @@ without exposing so many details that we’re unable to change tokenization in t
 In particular, whitespace and delims all get parsed into DOMStrings.
 Am I succeeding at this goal? <a class="issue-return" href="#issue-296fa7f8" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedefdef-cssstringsource">
-   <b><a href="#typedefdef-cssstringsource">#typedefdef-cssstringsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cssstringsource" class="dfn-panel" data-for="typedefdef-cssstringsource" id="infopanel-for-typedefdef-cssstringsource" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cssstringsource" style="display:none">Info about the 'CSSStringSource' definition.</span><b><a href="#typedefdef-cssstringsource">#typedefdef-cssstringsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cssstringsource">2. Parsing API</a> <a href="#ref-for-typedefdef-cssstringsource①">(2)</a> <a href="#ref-for-typedefdef-cssstringsource②">(3)</a> <a href="#ref-for-typedefdef-cssstringsource③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-csstoken">
-   <b><a href="#typedefdef-csstoken">#typedefdef-csstoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-csstoken" class="dfn-panel" data-for="typedefdef-csstoken" id="infopanel-for-typedefdef-csstoken" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-csstoken" style="display:none">Info about the 'CSSToken' definition.</span><b><a href="#typedefdef-csstoken">#typedefdef-csstoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-csstoken">2. Parsing API</a> <a href="#ref-for-typedefdef-csstoken①">(2)</a> <a href="#ref-for-typedefdef-csstoken②">(3)</a>
     <li><a href="#ref-for-typedefdef-csstoken③">3. Parser Values</a> <a href="#ref-for-typedefdef-csstoken④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-parsevaluelist">
-   <b><a href="#dom-css-parsevaluelist">#dom-css-parsevaluelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-parsevaluelist" class="dfn-panel" data-for="dom-css-parsevaluelist" id="infopanel-for-dom-css-parsevaluelist" role="dialog">
+   <span id="infopaneltitle-for-dom-css-parsevaluelist" style="display:none">Info about the 'parseValueList' definition.</span><b><a href="#dom-css-parsevaluelist">#dom-css-parsevaluelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-parsevaluelist">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-parsecommavaluelist">
-   <b><a href="#dom-css-parsecommavaluelist">#dom-css-parsecommavaluelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-parsecommavaluelist" class="dfn-panel" data-for="dom-css-parsecommavaluelist" id="infopanel-for-dom-css-parsecommavaluelist" role="dialog">
+   <span id="infopaneltitle-for-dom-css-parsecommavaluelist" style="display:none">Info about the 'parseCommaValueList' definition.</span><b><a href="#dom-css-parsecommavaluelist">#dom-css-parsecommavaluelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-parsecommavaluelist">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cssparseroptions">
-   <b><a href="#dictdef-cssparseroptions">#dictdef-cssparseroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cssparseroptions" class="dfn-panel" data-for="dictdef-cssparseroptions" id="infopanel-for-dictdef-cssparseroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cssparseroptions" style="display:none">Info about the 'CSSParserOptions' definition.</span><b><a href="#dictdef-cssparseroptions">#dictdef-cssparseroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cssparseroptions">2. Parsing API</a> <a href="#ref-for-dictdef-cssparseroptions①">(2)</a> <a href="#ref-for-dictdef-cssparseroptions②">(3)</a> <a href="#ref-for-dictdef-cssparseroptions③">(4)</a> <a href="#ref-for-dictdef-cssparseroptions④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssparseroptions-atrules">
-   <b><a href="#dom-cssparseroptions-atrules">#dom-cssparseroptions-atrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssparseroptions-atrules" class="dfn-panel" data-for="dom-cssparseroptions-atrules" id="infopanel-for-dom-cssparseroptions-atrules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssparseroptions-atrules" style="display:none">Info about the 'atRules' definition.</span><b><a href="#dom-cssparseroptions-atrules">#dom-cssparseroptions-atrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssparseroptions-atrules">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssparserrule">
-   <b><a href="#cssparserrule">#cssparserrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssparserrule" class="dfn-panel" data-for="cssparserrule" id="infopanel-for-cssparserrule" role="dialog">
+   <span id="infopaneltitle-for-cssparserrule" style="display:none">Info about the 'CSSParserRule' definition.</span><b><a href="#cssparserrule">#cssparserrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssparserrule">2. Parsing API</a> <a href="#ref-for-cssparserrule①">(2)</a> <a href="#ref-for-cssparserrule②">(3)</a> <a href="#ref-for-cssparserrule③">(4)</a>
     <li><a href="#ref-for-cssparserrule④">3. Parser Values</a> <a href="#ref-for-cssparserrule⑤">(2)</a> <a href="#ref-for-cssparserrule⑥">(3)</a> <a href="#ref-for-cssparserrule⑦">(4)</a> <a href="#ref-for-cssparserrule⑧">(5)</a> <a href="#ref-for-cssparserrule⑨">(6)</a> <a href="#ref-for-cssparserrule①⓪">(7)</a> <a href="#ref-for-cssparserrule①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssparserdeclaration">
-   <b><a href="#cssparserdeclaration">#cssparserdeclaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssparserdeclaration" class="dfn-panel" data-for="cssparserdeclaration" id="infopanel-for-cssparserdeclaration" role="dialog">
+   <span id="infopaneltitle-for-cssparserdeclaration" style="display:none">Info about the 'CSSParserDeclaration' definition.</span><b><a href="#cssparserdeclaration">#cssparserdeclaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssparserdeclaration">2. Parsing API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssparservalue">
-   <b><a href="#cssparservalue">#cssparservalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssparservalue" class="dfn-panel" data-for="cssparservalue" id="infopanel-for-cssparservalue" role="dialog">
+   <span id="infopaneltitle-for-cssparservalue" style="display:none">Info about the 'CSSParserValue' definition.</span><b><a href="#cssparservalue">#cssparservalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssparservalue">2. Parsing API</a>
     <li><a href="#ref-for-cssparservalue①">3. Parser Values</a> <a href="#ref-for-cssparservalue②">(2)</a> <a href="#ref-for-cssparservalue③">(3)</a> <a href="#ref-for-cssparservalue④">(4)</a> <a href="#ref-for-cssparservalue⑤">(5)</a> <a href="#ref-for-cssparservalue⑥">(6)</a> <a href="#ref-for-cssparservalue⑦">(7)</a> <a href="#ref-for-cssparservalue⑧">(8)</a> <a href="#ref-for-cssparservalue⑨">(9)</a>
@@ -1233,57 +1233,113 @@ Am I succeeding at this goal? <a class="issue-return" href="#issue-296fa7f8" tit
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/custom-state-pseudo-class/index.html
+++ b/tests/github/WICG/custom-state-pseudo-class/index.html
@@ -836,92 +836,92 @@ element can expose multiple states. Authors can use <a data-link-type="dfn" href
    <li><a href="#dom-elementinternals-states">states</a><span>, in § 2</span>
    <li><a href="#states-set">states set</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-dashed-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dashed-ident" class="dfn-panel" data-for="term-for-typedef-dashed-ident" id="infopanel-for-term-for-typedef-dashed-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dashed-ident" style="display:none">Info about the '&lt;dashed-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dashed-ident">2. Exposing custom element states</a>
     <li><a href="#ref-for-typedef-dashed-ident①">3. Selecting a custom element with a specific state</a> <a href="#ref-for-typedef-dashed-ident②">(2)</a> <a href="#ref-for-typedef-dashed-ident③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementinternals">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals">https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementinternals" class="dfn-panel" data-for="term-for-elementinternals" id="infopanel-for-term-for-elementinternals" role="menu">
+   <span id="infopaneltitle-for-term-for-elementinternals" style="display:none">Info about the 'ElementInternals' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals">https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementinternals">1.2. Solution</a>
     <li><a href="#ref-for-elementinternals①">2. Exposing custom element states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-autonomous-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#autonomous-custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#autonomous-custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-autonomous-custom-element" class="dfn-panel" data-for="term-for-autonomous-custom-element" id="infopanel-for-term-for-autonomous-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-autonomous-custom-element" style="display:none">Info about the 'autonomous custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#autonomous-custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#autonomous-custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-autonomous-custom-element">2. Exposing custom element states</a>
     <li><a href="#ref-for-autonomous-custom-element①">3. Selecting a custom element with a specific state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">1.1. Motivation</a> <a href="#ref-for-custom-element①">(2)</a>
     <li><a href="#ref-for-custom-element②">1.2. Solution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3. Selecting a custom element with a specific state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2. Exposing custom element states</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#invalid-pseudo">https://drafts.csswg.org/selectors-4/#invalid-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-pseudo" class="dfn-panel" data-for="term-for-invalid-pseudo" id="infopanel-for-term-for-invalid-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-pseudo" style="display:none">Info about the ':invalid' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#invalid-pseudo">https://drafts.csswg.org/selectors-4/#invalid-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-pseudo">1.1. Motivation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-class" class="dfn-panel" data-for="term-for-pseudo-class" id="infopanel-for-term-for-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-class" style="display:none">Info about the 'pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">1.1. Motivation</a>
     <li><a href="#ref-for-pseudo-class①">1.2. Solution</a>
     <li><a href="#ref-for-pseudo-class②">3. Selecting a custom element with a specific state</a> <a href="#ref-for-pseudo-class③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2. Exposing custom element states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Exposing custom element states</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Exposing custom element states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">2. Exposing custom element states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">2. Exposing custom element states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2. Exposing custom element states</a>
    </ul>
@@ -996,34 +996,34 @@ element can expose multiple states. Authors can use <a data-link-type="dfn" href
    <div class="issue"> Support customized built-in elements. <a href="https://github.com/whatwg/html/issues/5166">[Issue #whatwg/html#5166]</a> <a class="issue-return" href="#issue-172e10b8" title="Jump to section">↵</a></div>
    <div class="issue"> Support non-boolean states. <a href="https://github.com/WICG/custom-state-pseudo-class/issues/4">[Issue #WICG/custom-state-pseudo-class#4]</a> <a class="issue-return" href="#issue-8463f5b0" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="states-set">
-   <b><a href="#states-set">#states-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-states-set" class="dfn-panel" data-for="states-set" id="infopanel-for-states-set" role="dialog">
+   <span id="infopaneltitle-for-states-set" style="display:none">Info about the 'states set' definition.</span><b><a href="#states-set">#states-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-states-set">2. Exposing custom element states</a> <a href="#ref-for-states-set①">(2)</a>
     <li><a href="#ref-for-states-set②">3. Selecting a custom element with a specific state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementinternals-states">
-   <b><a href="#dom-elementinternals-states">#dom-elementinternals-states</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementinternals-states" class="dfn-panel" data-for="dom-elementinternals-states" id="infopanel-for-dom-elementinternals-states" role="dialog">
+   <span id="infopaneltitle-for-dom-elementinternals-states" style="display:none">Info about the 'states' definition.</span><b><a href="#dom-elementinternals-states">#dom-elementinternals-states</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementinternals-states">1.2. Solution</a>
     <li><a href="#ref-for-dom-elementinternals-states①">2. Exposing custom element states</a> <a href="#ref-for-dom-elementinternals-states②">(2)</a> <a href="#ref-for-dom-elementinternals-states③">(3)</a> <a href="#ref-for-dom-elementinternals-states④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="customstateset">
-   <b><a href="#customstateset">#customstateset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-customstateset" class="dfn-panel" data-for="customstateset" id="infopanel-for-customstateset" role="dialog">
+   <span id="infopaneltitle-for-customstateset" style="display:none">Info about the 'CustomStateSet' definition.</span><b><a href="#customstateset">#customstateset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-customstateset">2. Exposing custom element states</a> <a href="#ref-for-customstateset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-customstateset-add">
-   <b><a href="#dom-customstateset-add">#dom-customstateset-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-customstateset-add" class="dfn-panel" data-for="dom-customstateset-add" id="infopanel-for-dom-customstateset-add" role="dialog">
+   <span id="infopaneltitle-for-dom-customstateset-add" style="display:none">Info about the 'add(value)' definition.</span><b><a href="#dom-customstateset-add">#dom-customstateset-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-customstateset-add">2. Exposing custom element states</a> <a href="#ref-for-dom-customstateset-add①">(2)</a> <a href="#ref-for-dom-customstateset-add②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-state-pseudo-class">
-   <b><a href="#custom-state-pseudo-class">#custom-state-pseudo-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-state-pseudo-class" class="dfn-panel" data-for="custom-state-pseudo-class" id="infopanel-for-custom-state-pseudo-class" role="dialog">
+   <span id="infopaneltitle-for-custom-state-pseudo-class" style="display:none">Info about the 'custom state pseudo class' definition.</span><b><a href="#custom-state-pseudo-class">#custom-state-pseudo-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-state-pseudo-class①">1.2. Solution</a>
     <li><a href="#ref-for-custom-state-pseudo-class②">3. Selecting a custom element with a specific state</a> <a href="#ref-for-custom-state-pseudo-class③">(2)</a> <a href="#ref-for-custom-state-pseudo-class④">(3)</a> <a href="#ref-for-custom-state-pseudo-class⑤">(4)</a>
@@ -1031,57 +1031,113 @@ element can expose multiple states. Authors can use <a data-link-type="dfn" href
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/datacue/index.html
+++ b/tests/github/WICG/datacue/index.html
@@ -768,38 +768,38 @@ allow being dealt with.</p>
    <li><a href="#dom-datacue-type">type</a><span>, in § 3.1</span>
    <li><a href="#dom-datacue-value">value</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-texttrackcue">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">https://html.spec.whatwg.org/multipage/media.html#texttrackcue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-texttrackcue" class="dfn-panel" data-for="term-for-texttrackcue" id="infopanel-for-term-for-texttrackcue" role="menu">
+   <span id="infopaneltitle-for-term-for-texttrackcue" style="display:none">Info about the 'TextTrackCue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">https://html.spec.whatwg.org/multipage/media.html#texttrackcue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-texttrackcue">3.1. The DataCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.1. The DataCue interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. The DataCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.1. The DataCue interface</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3.1. The DataCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">3.1. The DataCue interface</a>
    </ul>
@@ -845,65 +845,121 @@ allow being dealt with.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="datacue">
-   <b><a href="#datacue">#datacue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datacue" class="dfn-panel" data-for="datacue" id="infopanel-for-datacue" role="dialog">
+   <span id="infopaneltitle-for-datacue" style="display:none">Info about the 'DataCue' definition.</span><b><a href="#datacue">#datacue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacue">4. In-band event mappings</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/deprecation-reporting/index.html
+++ b/tests/github/WICG/deprecation-reporting/index.html
@@ -1132,68 +1132,68 @@ was first used, or null otherwise.</p>
     </ul>
    <li><a href="#dom-deprecationreportbody-tojson">toJSON()</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-date-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-date-objects" class="dfn-panel" data-for="term-for-sec-date-objects" id="infopanel-for-term-for-sec-date-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-date-objects" style="display:none">Info about the 'date object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-date-objects">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reportbody">
-   <a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reportbody" class="dfn-panel" data-for="term-for-reportbody" id="infopanel-for-term-for-reportbody" role="menu">
+   <span id="infopaneltitle-for-term-for-reportbody" style="display:none">Info about the 'ReportBody' external reference.</span><a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reportbody">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-body">
-   <a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-body" class="dfn-panel" data-for="term-for-report-body" id="infopanel-for-term-for-report-body" role="menu">
+   <span id="infopaneltitle-for-term-for-report-body" style="display:none">Info about the 'body' external reference.</span><a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-body">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-endpoint">
-   <a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-endpoint" class="dfn-panel" data-for="term-for-endpoint" id="infopanel-for-term-for-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-endpoint" style="display:none">Info about the 'endpoint' external reference.</span><a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report">
-   <a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report" class="dfn-panel" data-for="term-for-report" id="infopanel-for-term-for-report" role="menu">
+   <span id="infopaneltitle-for-term-for-report" style="display:none">Info about the 'report' external reference.</span><a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-type">
-   <a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-type" class="dfn-panel" data-for="term-for-report-type" id="infopanel-for-term-for-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-report-type" style="display:none">Info about the 'report type' external reference.</span><a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-type">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Deprecation Reports</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2. Deprecation Reports</a> <a href="#ref-for-idl-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2. Deprecation Reports</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
@@ -1247,85 +1247,141 @@ was first used, or null otherwise.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="deprecation-reports">
-   <b><a href="#deprecation-reports">#deprecation-reports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deprecation-reports" class="dfn-panel" data-for="deprecation-reports" id="infopanel-for-deprecation-reports" role="dialog">
+   <span id="infopaneltitle-for-deprecation-reports" style="display:none">Info about the 'Deprecation reports' definition.</span><b><a href="#deprecation-reports">#deprecation-reports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deprecation-reports">2. Deprecation Reports</a> <a href="#ref-for-deprecation-reports①">(2)</a> <a href="#ref-for-deprecation-reports②">(3)</a> <a href="#ref-for-deprecation-reports③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deprecationreportbody">
-   <b><a href="#deprecationreportbody">#deprecationreportbody</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deprecationreportbody" class="dfn-panel" data-for="deprecationreportbody" id="infopanel-for-deprecationreportbody" role="dialog">
+   <span id="infopaneltitle-for-deprecationreportbody" style="display:none">Info about the 'DeprecationReportBody' definition.</span><b><a href="#deprecationreportbody">#deprecationreportbody</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deprecationreportbody">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deprecationreportbody-id">
-   <b><a href="#deprecationreportbody-id">#deprecationreportbody-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deprecationreportbody-id" class="dfn-panel" data-for="deprecationreportbody-id" id="infopanel-for-deprecationreportbody-id" role="dialog">
+   <span id="infopaneltitle-for-deprecationreportbody-id" style="display:none">Info about the 'id' definition.</span><b><a href="#deprecationreportbody-id">#deprecationreportbody-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deprecationreportbody-id">2. Deprecation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deprecationreportbody-sourcefile">
-   <b><a href="#deprecationreportbody-sourcefile">#deprecationreportbody-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deprecationreportbody-sourcefile" class="dfn-panel" data-for="deprecationreportbody-sourcefile" id="infopanel-for-deprecationreportbody-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-deprecationreportbody-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#deprecationreportbody-sourcefile">#deprecationreportbody-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deprecationreportbody-sourcefile">2. Deprecation Reports</a> <a href="#ref-for-deprecationreportbody-sourcefile①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/document-policy/index.html
+++ b/tests/github/WICG/document-policy/index.html
@@ -1592,8 +1592,8 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
    <li><a href="#configuration-point-type">type</a><span>, in § 4.1</span>
    <li><a href="#policy-configuration-value">value</a><span>, in § 4.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">9.8. Get policy value for feature in document</a>
     <li><a href="#ref-for-document①">9.9. Determine compatibility of value with policy for feature</a>
@@ -1601,65 +1601,65 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     <li><a href="#ref-for-document③">9.11. Determine if value is compatible with policy for feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-content-type">
-   <a href="https://dom.spec.whatwg.org/#concept-document-content-type">https://dom.spec.whatwg.org/#concept-document-content-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-content-type" class="dfn-panel" data-for="term-for-concept-document-content-type" id="infopanel-for-term-for-concept-document-content-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-content-type" style="display:none">Info about the 'content type' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-content-type">https://dom.spec.whatwg.org/#concept-document-content-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-content-type">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4.2. Policies</a> <a href="#ref-for-concept-document①">(2)</a>
     <li><a href="#ref-for-concept-document②">8.1. Integration with HTML</a> <a href="#ref-for-concept-document③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-document">
-   <a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-document" class="dfn-panel" data-for="term-for-html-document" id="infopanel-for-term-for-html-document" role="menu">
+   <span id="infopaneltitle-for-term-for-html-document" style="display:none">Info about the 'html document' external reference.</span><a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-document">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">9.2. Process response policy</a> <a href="#ref-for-concept-header①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-headers-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-headers-header-list">https://fetch.spec.whatwg.org/#concept-headers-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-headers-header-list" class="dfn-panel" data-for="term-for-concept-headers-header-list" id="infopanel-for-term-for-concept-headers-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-headers-header-list" style="display:none">Info about the 'header list (for Headers)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-headers-header-list">https://fetch.spec.whatwg.org/#concept-headers-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-header-list">8.2. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">8.2. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">9.2. Process response policy</a> <a href="#ref-for-concept-response-header-list①">(2)</a>
     <li><a href="#ref-for-concept-response-header-list②">9.7. Should response to request be blocked due to document policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">8.2. Integration with Fetch</a>
     <li><a href="#ref-for-concept-request-request①">9.7. Should response to request be blocked due to document policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">7.2.1. Document-Policy</a>
     <li><a href="#ref-for-concept-response-response①">7.2.2. Document-Policy-Report-Only</a>
@@ -1668,65 +1668,65 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     <li><a href="#ref-for-concept-response-response④">9.7. Should response to request be blocked due to document policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-sandboxing-flag-set">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-sandboxing-flag-set" class="dfn-panel" data-for="term-for-active-sandboxing-flag-set" id="infopanel-for-term-for-active-sandboxing-flag-set" role="menu">
+   <span id="infopaneltitle-for-term-for-active-sandboxing-flag-set" style="display:none">Info about the 'active sandboxing flag set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-sandboxing-flag-set">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4.2. Policies</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a>
     <li><a href="#ref-for-browsing-context③">9.5. Create a required policy for a browsing context</a>
     <li><a href="#ref-for-browsing-context④">9.6. Create a document Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-creating-a-new-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-creating-a-new-browsing-context" class="dfn-panel" data-for="term-for-creating-a-new-browsing-context" id="infopanel-for-term-for-creating-a-new-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-creating-a-new-browsing-context" style="display:none">Info about the 'creating a new browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creating-a-new-browsing-context">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">9.10. Determine if value is compatible with policy for feature or report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">7.3. The policy attribute of the iframe element</a>
     <li><a href="#ref-for-the-iframe-element①">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialise-the-document-object" class="dfn-panel" data-for="term-for-initialise-the-document-object" id="infopanel-for-term-for-initialise-the-document-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialise-the-document-object" style="display:none">Info about the 'initialise the document object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialise-the-document-object">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opener-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#opener-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#opener-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opener-browsing-context" class="dfn-panel" data-for="term-for-opener-browsing-context" id="infopanel-for-term-for-opener-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-opener-browsing-context" style="display:none">Info about the 'opener browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#opener-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#opener-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opener-browsing-context">4.2. Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">11. Privacy and Security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-endpoint">
-   <a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-endpoint" class="dfn-panel" data-for="term-for-endpoint" id="infopanel-for-term-for-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-endpoint" style="display:none">Info about the 'endpoint' external reference.</span><a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint">6.1.1. The "report-to" parameter</a>
     <li><a href="#ref-for-endpoint①">6.1.2. Setting the default reporting endpoint</a> <a href="#ref-for-endpoint②">(2)</a>
@@ -1806,8 +1806,8 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     parameters? Perhaps parameters should be defined separately, with names,
     types, and ranges. <a class="issue-return" href="#issue-91264ad1" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="configuration-point">
-   <b><a href="#configuration-point">#configuration-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-point" class="dfn-panel" data-for="configuration-point" id="infopanel-for-configuration-point" role="dialog">
+   <span id="infopaneltitle-for-configuration-point" style="display:none">Info about the 'configuration point' definition.</span><b><a href="#configuration-point">#configuration-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-point">4.1. Configuration Points</a> <a href="#ref-for-configuration-point①">(2)</a> <a href="#ref-for-configuration-point②">(3)</a> <a href="#ref-for-configuration-point③">(4)</a>
     <li><a href="#ref-for-configuration-point④">4.2. Policies</a> <a href="#ref-for-configuration-point⑤">(2)</a>
@@ -1815,36 +1815,36 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     <li><a href="#ref-for-configuration-point⑧">7.1.1. Parameters</a> <a href="#ref-for-configuration-point⑨">(2)</a> <a href="#ref-for-configuration-point①⓪">(3)</a> <a href="#ref-for-configuration-point①①">(4)</a> <a href="#ref-for-configuration-point①②">(5)</a> <a href="#ref-for-configuration-point①③">(6)</a> <a href="#ref-for-configuration-point①④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-point-name">
-   <b><a href="#configuration-point-name">#configuration-point-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-point-name" class="dfn-panel" data-for="configuration-point-name" id="infopanel-for-configuration-point-name" role="dialog">
+   <span id="infopaneltitle-for-configuration-point-name" style="display:none">Info about the 'name' definition.</span><b><a href="#configuration-point-name">#configuration-point-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-point-name">7.1. Policies as Structured Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-point-type">
-   <b><a href="#configuration-point-type">#configuration-point-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-point-type" class="dfn-panel" data-for="configuration-point-type" id="infopanel-for-configuration-point-type" role="dialog">
+   <span id="infopaneltitle-for-configuration-point-type" style="display:none">Info about the 'type' definition.</span><b><a href="#configuration-point-type">#configuration-point-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-point-type">4.1. Configuration Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-point-range">
-   <b><a href="#configuration-point-range">#configuration-point-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-point-range" class="dfn-panel" data-for="configuration-point-range" id="infopanel-for-configuration-point-range" role="dialog">
+   <span id="infopaneltitle-for-configuration-point-range" style="display:none">Info about the 'range' definition.</span><b><a href="#configuration-point-range">#configuration-point-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-point-range">4.1. Configuration Points</a>
     <li><a href="#ref-for-configuration-point-range①">4.2. Policies</a>
     <li><a href="#ref-for-configuration-point-range②">7.1. Policies as Structured Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-point-default-value">
-   <b><a href="#configuration-point-default-value">#configuration-point-default-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-point-default-value" class="dfn-panel" data-for="configuration-point-default-value" id="infopanel-for-configuration-point-default-value" role="dialog">
+   <span id="infopaneltitle-for-configuration-point-default-value" style="display:none">Info about the 'default value' definition.</span><b><a href="#configuration-point-default-value">#configuration-point-default-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-point-default-value">4.1. Configuration Points</a>
     <li><a href="#ref-for-configuration-point-default-value①">9.8. Get policy value for feature in document</a>
     <li><a href="#ref-for-configuration-point-default-value②">9.9. Determine compatibility of value with policy for feature</a> <a href="#ref-for-configuration-point-default-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-policy">
-   <b><a href="#document-policy">#document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-policy" class="dfn-panel" data-for="document-policy" id="infopanel-for-document-policy" role="dialog">
+   <span id="infopaneltitle-for-document-policy" style="display:none">Info about the 'document policy' definition.</span><b><a href="#document-policy">#document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-policy">4.2. Policies</a> <a href="#ref-for-document-policy①">(2)</a> <a href="#ref-for-document-policy②">(3)</a> <a href="#ref-for-document-policy③">(4)</a>
     <li><a href="#ref-for-document-policy④">7.2.1. Document-Policy</a>
@@ -1861,29 +1861,29 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     <li><a href="#ref-for-document-policy①⑧">9.11. Determine if value is compatible with policy for feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-configuration">
-   <b><a href="#policy-configuration">#policy-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-configuration" class="dfn-panel" data-for="policy-configuration" id="infopanel-for-policy-configuration" role="dialog">
+   <span id="infopaneltitle-for-policy-configuration" style="display:none">Info about the 'policy configuration' definition.</span><b><a href="#policy-configuration">#policy-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-configuration">4.2. Policies</a>
     <li><a href="#ref-for-policy-configuration①">9.3. Parse document policy</a> <a href="#ref-for-policy-configuration②">(2)</a> <a href="#ref-for-policy-configuration③">(3)</a> <a href="#ref-for-policy-configuration④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-configuration-value">
-   <b><a href="#policy-configuration-value">#policy-configuration-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-configuration-value" class="dfn-panel" data-for="policy-configuration-value" id="infopanel-for-policy-configuration-value" role="dialog">
+   <span id="infopaneltitle-for-policy-configuration-value" style="display:none">Info about the 'value' definition.</span><b><a href="#policy-configuration-value">#policy-configuration-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-configuration-value">9.2. Process response policy</a>
     <li><a href="#ref-for-policy-configuration-value①">9.3. Parse document policy</a> <a href="#ref-for-policy-configuration-value②">(2)</a> <a href="#ref-for-policy-configuration-value③">(3)</a> <a href="#ref-for-policy-configuration-value④">(4)</a>
     <li><a href="#ref-for-policy-configuration-value⑤">9.8. Get policy value for feature in document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-configuration-reporting-endpoint">
-   <b><a href="#policy-configuration-reporting-endpoint">#policy-configuration-reporting-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-configuration-reporting-endpoint" class="dfn-panel" data-for="policy-configuration-reporting-endpoint" id="infopanel-for-policy-configuration-reporting-endpoint" role="dialog">
+   <span id="infopaneltitle-for-policy-configuration-reporting-endpoint" style="display:none">Info about the 'reporting endpoint' definition.</span><b><a href="#policy-configuration-reporting-endpoint">#policy-configuration-reporting-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-configuration-reporting-endpoint">9.3. Parse document policy</a> <a href="#ref-for-policy-configuration-reporting-endpoint①">(2)</a> <a href="#ref-for-policy-configuration-reporting-endpoint②">(3)</a> <a href="#ref-for-policy-configuration-reporting-endpoint③">(4)</a> <a href="#ref-for-policy-configuration-reporting-endpoint④">(5)</a> <a href="#ref-for-policy-configuration-reporting-endpoint⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="required-document-policy">
-   <b><a href="#required-document-policy">#required-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-required-document-policy" class="dfn-panel" data-for="required-document-policy" id="infopanel-for-required-document-policy" role="dialog">
+   <span id="infopaneltitle-for-required-document-policy" style="display:none">Info about the 'required document policy' definition.</span><b><a href="#required-document-policy">#required-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-required-document-policy">4.2. Policies</a>
     <li><a href="#ref-for-required-document-policy①">7.2.3. Require-Document-Policy</a>
@@ -1891,100 +1891,102 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
     <li><a href="#ref-for-required-document-policy⑦">9.1. Is policy compatible?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nested-context-required-document-policy">
-   <b><a href="#nested-context-required-document-policy">#nested-context-required-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nested-context-required-document-policy" class="dfn-panel" data-for="nested-context-required-document-policy" id="infopanel-for-nested-context-required-document-policy" role="dialog">
+   <span id="infopaneltitle-for-nested-context-required-document-policy" style="display:none">Info about the 'nested context required document
+    policy' definition.</span><b><a href="#nested-context-required-document-policy">#nested-context-required-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-context-required-document-policy">9.5. Create a required policy for a browsing context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-document-policy">
-   <b><a href="#declared-document-policy">#declared-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-document-policy" class="dfn-panel" data-for="declared-document-policy" id="infopanel-for-declared-document-policy" role="dialog">
+   <span id="infopaneltitle-for-declared-document-policy" style="display:none">Info about the 'declared document policy' definition.</span><b><a href="#declared-document-policy">#declared-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-document-policy">9.1. Is policy compatible?</a>
     <li><a href="#ref-for-declared-document-policy①">9.2. Process response policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-only-document-policy">
-   <b><a href="#report-only-document-policy">#report-only-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-only-document-policy" class="dfn-panel" data-for="report-only-document-policy" id="infopanel-for-report-only-document-policy" role="dialog">
+   <span id="infopaneltitle-for-report-only-document-policy" style="display:none">Info about the 'report-only document policy' definition.</span><b><a href="#report-only-document-policy">#report-only-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-only-document-policy">7.2.2. Document-Policy-Report-Only</a>
     <li><a href="#ref-for-report-only-document-policy①">9.9. Determine compatibility of value with policy for feature</a> <a href="#ref-for-report-only-document-policy②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-document-policy">
-   <b><a href="#serialized-document-policy">#serialized-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-document-policy" class="dfn-panel" data-for="serialized-document-policy" id="infopanel-for-serialized-document-policy" role="dialog">
+   <span id="infopaneltitle-for-serialized-document-policy" style="display:none">Info about the 'serialized' definition.</span><b><a href="#serialized-document-policy">#serialized-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-document-policy">7.1. Policies as Structured Headers</a>
     <li><a href="#ref-for-serialized-document-policy①">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-policy-directive">
-   <b><a href="#document-policy-directive">#document-policy-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-policy-directive" class="dfn-panel" data-for="document-policy-directive" id="infopanel-for-document-policy-directive" role="dialog">
+   <span id="infopaneltitle-for-document-policy-directive" style="display:none">Info about the 'document policy directive' definition.</span><b><a href="#document-policy-directive">#document-policy-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-policy-directive">7.1. Policies as Structured Headers</a>
     <li><a href="#ref-for-document-policy-directive①">7.1.1. Parameters</a> <a href="#ref-for-document-policy-directive②">(2)</a> <a href="#ref-for-document-policy-directive③">(3)</a> <a href="#ref-for-document-policy-directive④">(4)</a> <a href="#ref-for-document-policy-directive⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-name">
-   <b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-name" class="dfn-panel" data-for="directive-name" id="infopanel-for-directive-name" role="dialog">
+   <span id="infopaneltitle-for-directive-name" style="display:none">Info about the 'directive name' definition.</span><b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name">7.1. Policies as Structured Headers</a>
     <li><a href="#ref-for-directive-name①">7.1.1. Parameters</a> <a href="#ref-for-directive-name②">(2)</a> <a href="#ref-for-directive-name③">(3)</a> <a href="#ref-for-directive-name④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-required-document-policy">
-   <b><a href="#request-required-document-policy">#request-required-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-required-document-policy" class="dfn-panel" data-for="request-required-document-policy" id="infopanel-for-request-required-document-policy" role="dialog">
+   <span id="infopaneltitle-for-request-required-document-policy" style="display:none">Info about the 'required document
+policy' definition.</span><b><a href="#request-required-document-policy">#request-required-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-required-document-policy">8.2. Integration with Fetch</a> <a href="#ref-for-request-required-document-policy①">(2)</a>
     <li><a href="#ref-for-request-required-document-policy②">9.7. Should response to request be blocked due to document policy?</a> <a href="#ref-for-request-required-document-policy③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-policy-compatible">
-   <b><a href="#is-policy-compatible">#is-policy-compatible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-policy-compatible" class="dfn-panel" data-for="is-policy-compatible" id="infopanel-for-is-policy-compatible" role="dialog">
+   <span id="infopaneltitle-for-is-policy-compatible" style="display:none">Info about the 'Is policy compatible' definition.</span><b><a href="#is-policy-compatible">#is-policy-compatible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-policy-compatible">9.6. Create a document Policy for a browsing context from response</a>
     <li><a href="#ref-for-is-policy-compatible">9.7. Should response to request be blocked due to document policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-response-policy">
-   <b><a href="#process-response-policy">#process-response-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-response-policy" class="dfn-panel" data-for="process-response-policy" id="infopanel-for-process-response-policy" role="dialog">
+   <span id="infopaneltitle-for-process-response-policy" style="display:none">Info about the 'Process response policy' definition.</span><b><a href="#process-response-policy">#process-response-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response-policy">9.6. Create a document Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-document-policy">
-   <b><a href="#parse-document-policy">#parse-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-document-policy" class="dfn-panel" data-for="parse-document-policy" id="infopanel-for-parse-document-policy" role="dialog">
+   <span id="infopaneltitle-for-parse-document-policy" style="display:none">Info about the 'Parse document policy' definition.</span><b><a href="#parse-document-policy">#parse-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-document-policy">9.2. Process response policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-required-policy">
-   <b><a href="#serialize-required-policy">#serialize-required-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-required-policy" class="dfn-panel" data-for="serialize-required-policy" id="infopanel-for-serialize-required-policy" role="dialog">
+   <span id="infopaneltitle-for-serialize-required-policy" style="display:none">Info about the 'Serialize required policy' definition.</span><b><a href="#serialize-required-policy">#serialize-required-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-required-policy">8.2. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-for-browsingcontext">
-   <b><a href="#create-for-browsingcontext">#create-for-browsingcontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-for-browsingcontext" class="dfn-panel" data-for="create-for-browsingcontext" id="infopanel-for-create-for-browsingcontext" role="dialog">
+   <span id="infopaneltitle-for-create-for-browsingcontext" style="display:none">Info about the 'Create a required policy for a browsing context' definition.</span><b><a href="#create-for-browsingcontext">#create-for-browsingcontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-for-browsingcontext">8.1. Integration with HTML</a>
     <li><a href="#ref-for-create-for-browsingcontext①">9.6. Create a document Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-document-policy">
-   <b><a href="#create-document-policy">#create-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-document-policy" class="dfn-panel" data-for="create-document-policy" id="infopanel-for-create-document-policy" role="dialog">
+   <span id="infopaneltitle-for-create-document-policy" style="display:none">Info about the 'Create a document Policy for a browsing context from response' definition.</span><b><a href="#create-document-policy">#create-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-document-policy">8.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-document-policy">
-   <b><a href="#should-response-to-request-be-blocked-due-to-document-policy">#should-response-to-request-be-blocked-due-to-document-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-response-to-request-be-blocked-due-to-document-policy" class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-document-policy" id="infopanel-for-should-response-to-request-be-blocked-due-to-document-policy" role="dialog">
+   <span id="infopaneltitle-for-should-response-to-request-be-blocked-due-to-document-policy" style="display:none">Info about the 'Should response to request be blocked due to document policy' definition.</span><b><a href="#should-response-to-request-be-blocked-due-to-document-policy">#should-response-to-request-be-blocked-due-to-document-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-response-to-request-be-blocked-due-to-document-policy">8.2. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-compatibility">
-   <b><a href="#determine-compatibility">#determine-compatibility</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-compatibility" class="dfn-panel" data-for="determine-compatibility" id="infopanel-for-determine-compatibility" role="dialog">
+   <span id="infopaneltitle-for-determine-compatibility" style="display:none">Info about the 'Determine compatibility of value with policy for feature' definition.</span><b><a href="#determine-compatibility">#determine-compatibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-compatibility">9.10. Determine if value is compatible with policy for feature or report</a>
     <li><a href="#ref-for-determine-compatibility①">9.11. Determine if value is compatible with policy for feature</a>
@@ -1992,59 +1994,115 @@ calling <a data-link-type="dfn" href="#determine-compatibility" id="ref-for-dete
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/element-timing/index.html
+++ b/tests/github/WICG/element-timing/index.html
@@ -1500,33 +1500,33 @@ This would unintentionally leak some of the display timing of the image.</p>
    <li><a href="#dom-performanceelementtiming-tojson">toJSON()</a><span>, in § 2.1</span>
    <li><a href="#dom-performanceelementtiming-url">url</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-painting-order">
-   <a href="https://drafts.csswg.org/css2/zindex.html#painting-order">https://drafts.csswg.org/css2/zindex.html#painting-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-painting-order" class="dfn-panel" data-for="term-for-painting-order" id="infopanel-for-term-for-painting-order" role="menu">
+   <span id="infopaneltitle-for-term-for-painting-order" style="display:none">Info about the 'painting order' external reference.</span><a href="https://drafts.csswg.org/css2/zindex.html#painting-order">https://drafts.csswg.org/css2/zindex.html#painting-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-painting-order">3.2. Modifications to the CSS specification</a> <a href="#ref-for-painting-order①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">1.1. Elements exposed</a>
     <li><a href="#ref-for-propdef-background-image①">3.2. Modifications to the CSS specification</a> <a href="#ref-for-propdef-background-image②">(2)</a> <a href="#ref-for-propdef-background-image③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3.2. Modifications to the CSS specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-block-period">
-   <a href="https://drafts.csswg.org/css-fonts-4/#font-block-period">https://drafts.csswg.org/css-fonts-4/#font-block-period</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-block-period" class="dfn-panel" data-for="term-for-font-block-period" id="infopanel-for-term-for-font-block-period" role="menu">
+   <span id="infopaneltitle-for-term-for-font-block-period" style="display:none">Info about the 'font block period' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#font-block-period">https://drafts.csswg.org/css-fonts-4/#font-block-period</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-block-period">3.2. Modifications to the CSS specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-document①">3.1. Modifications to the DOM specification</a> <a href="#ref-for-document②">(2)</a>
@@ -1538,8 +1538,8 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-document⑨">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-element①">(2)</a>
     <li><a href="#ref-for-element③">3.1. Modifications to the DOM specification</a> <a href="#ref-for-element④">(2)</a> <a href="#ref-for-element⑤">(3)</a> <a href="#ref-for-element⑥">(4)</a> <a href="#ref-for-element⑦">(5)</a> <a href="#ref-for-element⑧">(6)</a> <a href="#ref-for-element⑨">(7)</a> <a href="#ref-for-element①⓪">(8)</a>
@@ -1550,295 +1550,295 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-element②③">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text">
-   <a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text" class="dfn-panel" data-for="term-for-text" id="infopanel-for-term-for-text" role="menu">
+   <span id="infopaneltitle-for-term-for-text" style="display:none">Info about the 'Text' external reference.</span><a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text">3.2. Modifications to the CSS specification</a>
     <li><a href="#ref-for-text①">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-concept-tree-descendant①">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
-   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boundary-point-node" class="dfn-panel" data-for="term-for-boundary-point-node" id="infopanel-for-term-for-boundary-point-node" role="menu">
+   <span id="infopaneltitle-for-term-for-boundary-point-node" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">3.4. Process image that finished loading</a>
     <li><a href="#ref-for-concept-tree-root①">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time#dom-domhighrestimestamp">https://w3c.github.io/hr-time#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time#dom-domhighrestimestamp">https://w3c.github.io/hr-time#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time">
-   <a href="https://w3c.github.io/hr-time#dfn-current-high-resolution-time">https://w3c.github.io/hr-time#dfn-current-high-resolution-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-high-resolution-time" class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time" id="infopanel-for-term-for-dfn-current-high-resolution-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-high-resolution-time" style="display:none">Info about the 'current high resolution time' external reference.</span><a href="https://w3c.github.io/hr-time#dfn-current-high-resolution-time">https://w3c.github.io/hr-time#dfn-current-high-resolution-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-high-resolution-time">3.4. Process image that finished loading</a>
     <li><a href="#ref-for-dfn-current-high-resolution-time①">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">3.1. Modifications to the DOM specification</a> <a href="#ref-for-htmlimageelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-img-all">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#img-all">https://html.spec.whatwg.org/multipage/images.html#img-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-img-all" class="dfn-panel" data-for="term-for-img-all" id="infopanel-for-term-for-img-all" role="menu">
+   <span id="infopaneltitle-for-term-for-img-all" style="display:none">Info about the 'completely available' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#img-all">https://html.spec.whatwg.org/multipage/images.html#img-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-img-all">3.1. Modifications to the DOM specification</a>
     <li><a href="#ref-for-img-all①">3.2. Modifications to the CSS specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">3.2. Modifications to the CSS specification</a> <a href="#ref-for-the-div-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">3.3. Modifications to the HTML specification</a>
     <li><a href="#ref-for-fully-active①">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-image-request">
-   <a href="https://html.spec.whatwg.org/multipage#image-request">https://html.spec.whatwg.org/multipage#image-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-image-request" class="dfn-panel" data-for="term-for-image-request" id="infopanel-for-term-for-image-request" role="menu">
+   <span id="infopaneltitle-for-term-for-image-request" style="display:none">Info about the 'image request' external reference.</span><a href="https://html.spec.whatwg.org/multipage#image-request">https://html.spec.whatwg.org/multipage#image-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-request">3.1. Modifications to the DOM specification</a> <a href="#ref-for-image-request①">(2)</a> <a href="#ref-for-image-request②">(3)</a>
     <li><a href="#ref-for-image-request③">3.2. Modifications to the CSS specification</a> <a href="#ref-for-image-request④">(2)</a> <a href="#ref-for-image-request⑤">(3)</a> <a href="#ref-for-image-request⑥">(4)</a> <a href="#ref-for-image-request⑦">(5)</a>
     <li><a href="#ref-for-image-request⑧">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1.1. Elements exposed</a>
     <li><a href="#ref-for-the-img-element①">3.5. Report image Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-available-images">
-   <a href="https://html.spec.whatwg.org/multipageimages.html#list-of-available-images">https://html.spec.whatwg.org/multipageimages.html#list-of-available-images</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-available-images" class="dfn-panel" data-for="term-for-list-of-available-images" id="infopanel-for-term-for-list-of-available-images" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-available-images" style="display:none">Info about the 'list of available images' external reference.</span><a href="https://html.spec.whatwg.org/multipageimages.html#list-of-available-images">https://html.spec.whatwg.org/multipageimages.html#list-of-available-images</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-available-images">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-naturalheight">
-   <a href="https://html.spec.whatwg.org/multipage#dom-img-naturalheight">https://html.spec.whatwg.org/multipage#dom-img-naturalheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-naturalheight" class="dfn-panel" data-for="term-for-dom-img-naturalheight" id="infopanel-for-term-for-dom-img-naturalheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-naturalheight" style="display:none">Info about the 'naturalHeight' external reference.</span><a href="https://html.spec.whatwg.org/multipage#dom-img-naturalheight">https://html.spec.whatwg.org/multipage#dom-img-naturalheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-naturalheight">3.5. Report image Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-naturalwidth">
-   <a href="https://html.spec.whatwg.org/multipage#dom-img-naturalwidth">https://html.spec.whatwg.org/multipage#dom-img-naturalwidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-naturalwidth" class="dfn-panel" data-for="term-for-dom-img-naturalwidth" id="infopanel-for-term-for-dom-img-naturalwidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-naturalwidth" style="display:none">Info about the 'naturalWidth' external reference.</span><a href="https://html.spec.whatwg.org/multipage#dom-img-naturalwidth">https://html.spec.whatwg.org/multipage#dom-img-naturalwidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-naturalwidth">3.5. Report image Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.4. Process image that finished loading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.8. Get an element algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve-a-url">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resolve-a-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resolve-a-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve-a-url" class="dfn-panel" data-for="term-for-resolve-a-url" id="infopanel-for-term-for-resolve-a-url" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve-a-url" style="display:none">Info about the 'resolved url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resolve-a-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resolve-a-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-url">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">3.3. Modifications to the HTML specification</a>
     <li><a href="#ref-for-update-the-rendering①">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">1.1. Elements exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3.2. Modifications to the CSS specification</a> <a href="#ref-for-set-append①">(2)</a>
     <li><a href="#ref-for-set-append②">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">3.1. Modifications to the DOM specification</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intersectionobserver">
-   <a href="https://w3c.github.io/IntersectionObserver#intersectionobserver">https://w3c.github.io/IntersectionObserver#intersectionobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intersectionobserver" class="dfn-panel" data-for="term-for-intersectionobserver" id="infopanel-for-term-for-intersectionobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-intersectionobserver" style="display:none">Info about the 'IntersectionObserver' external reference.</span><a href="https://w3c.github.io/IntersectionObserver#intersectionobserver">https://w3c.github.io/IntersectionObserver#intersectionobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver">4. Security &amp; privacy considerations</a> <a href="#ref-for-intersectionobserver①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calculate-intersection-rect-algo">
-   <a href="https://w3c.github.io/IntersectionObserver#calculate-intersection-rect-algo">https://w3c.github.io/IntersectionObserver#calculate-intersection-rect-algo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calculate-intersection-rect-algo" class="dfn-panel" data-for="term-for-calculate-intersection-rect-algo" id="infopanel-for-term-for-calculate-intersection-rect-algo" role="menu">
+   <span id="infopaneltitle-for-term-for-calculate-intersection-rect-algo" style="display:none">Info about the 'intersection rect algorithm' external reference.</span><a href="https://w3c.github.io/IntersectionObserver#calculate-intersection-rect-algo">https://w3c.github.io/IntersectionObserver#calculate-intersection-rect-algo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-intersection-rect-algo">3.5. Report image Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-add-a-largestcontentfulpaint-entry">
-   <a href="https://wicg.github.io/largest-contentful-paint/#potentially-add-a-largestcontentfulpaint-entry">https://wicg.github.io/largest-contentful-paint/#potentially-add-a-largestcontentfulpaint-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-add-a-largestcontentfulpaint-entry" class="dfn-panel" data-for="term-for-potentially-add-a-largestcontentfulpaint-entry" id="infopanel-for-term-for-potentially-add-a-largestcontentfulpaint-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-add-a-largestcontentfulpaint-entry" style="display:none">Info about the 'potentially add a largestcontentfulpaint entry' external reference.</span><a href="https://wicg.github.io/largest-contentful-paint/#potentially-add-a-largestcontentfulpaint-entry">https://wicg.github.io/largest-contentful-paint/#potentially-add-a-largestcontentfulpaint-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-add-a-largestcontentfulpaint-entry">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-potentially-add-a-largestcontentfulpaint-entry①">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceobserver-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceobserver-interface">https://w3c.github.io/performance-timeline/#the-performanceobserver-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceobserver-interface" class="dfn-panel" data-for="term-for-the-performanceobserver-interface" id="infopanel-for-term-for-the-performanceobserver-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceobserver-interface" style="display:none">Info about the 'PerformanceObserver' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceobserver-interface">https://w3c.github.io/performance-timeline/#the-performanceobserver-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceobserver-interface">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-name①">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dom-performanceentry-name②">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry">
-   <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry" id="infopanel-for-term-for-dfn-queue-a-performanceentry" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" style="display:none">Info about the 'queue the performanceentry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-queue-a-performanceentry">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dfn-queue-a-performanceentry①">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">3. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-timing-allow-check">
-   <a href="https://w3c.github.io/resource-timing#dfn-timing-allow-check">https://w3c.github.io/resource-timing#dfn-timing-allow-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-timing-allow-check" class="dfn-panel" data-for="term-for-dfn-timing-allow-check" id="infopanel-for-term-for-dfn-timing-allow-check" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-timing-allow-check" style="display:none">Info about the 'timing allow check' external reference.</span><a href="https://w3c.github.io/resource-timing#dfn-timing-allow-check">https://w3c.github.io/resource-timing#dfn-timing-allow-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-timing-allow-check">3.4. Process image that finished loading</a>
     <li><a href="#ref-for-dfn-timing-allow-check①">4. Security &amp; privacy considerations</a> <a href="#ref-for-dfn-timing-allow-check②">(2)</a> <a href="#ref-for-dfn-timing-allow-check③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGImageElement">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement">https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGImageElement" class="dfn-panel" data-for="term-for-InterfaceSVGImageElement" id="infopanel-for-term-for-InterfaceSVGImageElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGImageElement" style="display:none">Info about the 'SVGImageElement' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement">https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGImageElement">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-image">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-image" class="dfn-panel" data-for="term-for-elementdef-image" id="infopanel-for-term-for-elementdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-image" style="display:none">Info about the 'image' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-image">1.1. Elements exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">1.1. Elements exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-concept-url-scheme①">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
     <li><a href="#ref-for-idl-DOMString④">3.1. Modifications to the DOM specification</a>
@@ -1846,26 +1846,26 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-idl-DOMString⑥">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
@@ -2054,8 +2054,8 @@ This would unintentionally leak some of the display timing of the image.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="performanceelementtiming">
-   <b><a href="#performanceelementtiming">#performanceelementtiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performanceelementtiming" class="dfn-panel" data-for="performanceelementtiming" id="infopanel-for-performanceelementtiming" role="dialog">
+   <span id="infopaneltitle-for-performanceelementtiming" style="display:none">Info about the 'PerformanceElementTiming' definition.</span><b><a href="#performanceelementtiming">#performanceelementtiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performanceelementtiming">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-performanceelementtiming①">(2)</a> <a href="#ref-for-performanceelementtiming②">(3)</a> <a href="#ref-for-performanceelementtiming③">(4)</a>
     <li><a href="#ref-for-performanceelementtiming④">3.2. Modifications to the CSS specification</a>
@@ -2064,8 +2064,8 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-performanceelementtiming⑦">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-rendertime">
-   <b><a href="#dom-performanceelementtiming-rendertime">#dom-performanceelementtiming-rendertime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-rendertime" class="dfn-panel" data-for="dom-performanceelementtiming-rendertime" id="infopanel-for-dom-performanceelementtiming-rendertime" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-rendertime" style="display:none">Info about the 'renderTime' definition.</span><b><a href="#dom-performanceelementtiming-rendertime">#dom-performanceelementtiming-rendertime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-rendertime">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-dom-performanceelementtiming-rendertime①">(2)</a>
     <li><a href="#ref-for-dom-performanceelementtiming-rendertime②">3.5. Report image Element Timing</a>
@@ -2073,8 +2073,8 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-dom-performanceelementtiming-rendertime④">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-loadtime">
-   <b><a href="#dom-performanceelementtiming-loadtime">#dom-performanceelementtiming-loadtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-loadtime" class="dfn-panel" data-for="dom-performanceelementtiming-loadtime" id="infopanel-for-dom-performanceelementtiming-loadtime" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-loadtime" style="display:none">Info about the 'loadTime' definition.</span><b><a href="#dom-performanceelementtiming-loadtime">#dom-performanceelementtiming-loadtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-loadtime">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-dom-performanceelementtiming-loadtime①">(2)</a>
     <li><a href="#ref-for-dom-performanceelementtiming-loadtime②">3.5. Report image Element Timing</a>
@@ -2082,8 +2082,8 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-dom-performanceelementtiming-loadtime④">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-intersectionrect">
-   <b><a href="#dom-performanceelementtiming-intersectionrect">#dom-performanceelementtiming-intersectionrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-intersectionrect" class="dfn-panel" data-for="dom-performanceelementtiming-intersectionrect" id="infopanel-for-dom-performanceelementtiming-intersectionrect" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-intersectionrect" style="display:none">Info about the 'intersectionRect' definition.</span><b><a href="#dom-performanceelementtiming-intersectionrect">#dom-performanceelementtiming-intersectionrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-intersectionrect">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceelementtiming-intersectionrect①">3.5. Report image Element Timing</a>
@@ -2091,136 +2091,136 @@ This would unintentionally leak some of the display timing of the image.</p>
     <li><a href="#ref-for-dom-performanceelementtiming-intersectionrect③">4. Security &amp; privacy considerations</a> <a href="#ref-for-dom-performanceelementtiming-intersectionrect④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-identifier">
-   <b><a href="#dom-performanceelementtiming-identifier">#dom-performanceelementtiming-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-identifier" class="dfn-panel" data-for="dom-performanceelementtiming-identifier" id="infopanel-for-dom-performanceelementtiming-identifier" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#dom-performanceelementtiming-identifier">#dom-performanceelementtiming-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-identifier">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceelementtiming-identifier①">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dom-performanceelementtiming-identifier②">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-naturalwidth">
-   <b><a href="#dom-performanceelementtiming-naturalwidth">#dom-performanceelementtiming-naturalwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-naturalwidth" class="dfn-panel" data-for="dom-performanceelementtiming-naturalwidth" id="infopanel-for-dom-performanceelementtiming-naturalwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-naturalwidth" style="display:none">Info about the 'naturalWidth' definition.</span><b><a href="#dom-performanceelementtiming-naturalwidth">#dom-performanceelementtiming-naturalwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalwidth">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalwidth①">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalwidth②">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-naturalheight">
-   <b><a href="#dom-performanceelementtiming-naturalheight">#dom-performanceelementtiming-naturalheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-naturalheight" class="dfn-panel" data-for="dom-performanceelementtiming-naturalheight" id="infopanel-for-dom-performanceelementtiming-naturalheight" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-naturalheight" style="display:none">Info about the 'naturalHeight' definition.</span><b><a href="#dom-performanceelementtiming-naturalheight">#dom-performanceelementtiming-naturalheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalheight">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalheight①">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dom-performanceelementtiming-naturalheight②">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-id">
-   <b><a href="#dom-performanceelementtiming-id">#dom-performanceelementtiming-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-id" class="dfn-panel" data-for="dom-performanceelementtiming-id" id="infopanel-for-dom-performanceelementtiming-id" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-performanceelementtiming-id">#dom-performanceelementtiming-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-id">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-dom-performanceelementtiming-id①">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-dom-performanceelementtiming-id②">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-element">
-   <b><a href="#dom-performanceelementtiming-element">#dom-performanceelementtiming-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-element" class="dfn-panel" data-for="dom-performanceelementtiming-element" id="infopanel-for-dom-performanceelementtiming-element" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-element" style="display:none">Info about the 'element' definition.</span><b><a href="#dom-performanceelementtiming-element">#dom-performanceelementtiming-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-element">2.1. PerformanceElementTiming interface</a> <a href="#ref-for-dom-performanceelementtiming-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceelementtiming-url">
-   <b><a href="#dom-performanceelementtiming-url">#dom-performanceelementtiming-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceelementtiming-url" class="dfn-panel" data-for="dom-performanceelementtiming-url" id="infopanel-for-dom-performanceelementtiming-url" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceelementtiming-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-performanceelementtiming-url">#dom-performanceelementtiming-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceelementtiming-url">2.1. PerformanceElementTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request">
-   <b><a href="#request">#request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request" class="dfn-panel" data-for="request" id="infopanel-for-request" role="dialog">
+   <span id="infopaneltitle-for-request" style="display:none">Info about the 'request' definition.</span><b><a href="#request">#request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-request①">3.5. Report image Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element">
-   <b><a href="#element">#element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element" class="dfn-panel" data-for="element" id="infopanel-for-element" role="dialog">
+   <span id="infopaneltitle-for-element" style="display:none">Info about the 'element' definition.</span><b><a href="#element">#element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element②">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-element①⑨">3.5. Report image Element Timing</a>
     <li><a href="#ref-for-element②①">3.6. Report text Element Timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-elementtiming">
-   <b><a href="#dom-element-elementtiming">#dom-element-elementtiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-elementtiming" class="dfn-panel" data-for="dom-element-elementtiming" id="infopanel-for-dom-element-elementtiming" role="dialog">
+   <span id="infopaneltitle-for-dom-element-elementtiming" style="display:none">Info about the 'elementTiming' definition.</span><b><a href="#dom-element-elementtiming">#dom-element-elementtiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-elementtiming">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-image-request">
-   <b><a href="#associated-image-request">#associated-image-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-image-request" class="dfn-panel" data-for="associated-image-request" id="infopanel-for-associated-image-request" role="dialog">
+   <span id="infopaneltitle-for-associated-image-request" style="display:none">Info about the 'associated image request' definition.</span><b><a href="#associated-image-request">#associated-image-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-image-request">3.1. Modifications to the DOM specification</a> <a href="#ref-for-associated-image-request①">(2)</a> <a href="#ref-for-associated-image-request②">(3)</a> <a href="#ref-for-associated-image-request③">(4)</a>
     <li><a href="#ref-for-associated-image-request④">3.4. Process image that finished loading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-of-owned-text-nodes">
-   <b><a href="#set-of-owned-text-nodes">#set-of-owned-text-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-of-owned-text-nodes" class="dfn-panel" data-for="set-of-owned-text-nodes" id="infopanel-for-set-of-owned-text-nodes" role="dialog">
+   <span id="infopaneltitle-for-set-of-owned-text-nodes" style="display:none">Info about the 'set of owned text nodes' definition.</span><b><a href="#set-of-owned-text-nodes">#set-of-owned-text-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-of-owned-text-nodes">3.2. Modifications to the CSS specification</a> <a href="#ref-for-set-of-owned-text-nodes①">(2)</a> <a href="#ref-for-set-of-owned-text-nodes②">(3)</a> <a href="#ref-for-set-of-owned-text-nodes③">(4)</a>
     <li><a href="#ref-for-set-of-owned-text-nodes④">3.6. Report text Element Timing</a>
     <li><a href="#ref-for-set-of-owned-text-nodes⑤">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="images-pending-rendering">
-   <b><a href="#images-pending-rendering">#images-pending-rendering</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-images-pending-rendering" class="dfn-panel" data-for="images-pending-rendering" id="infopanel-for-images-pending-rendering" role="dialog">
+   <span id="infopaneltitle-for-images-pending-rendering" style="display:none">Info about the 'images pending rendering' definition.</span><b><a href="#images-pending-rendering">#images-pending-rendering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-images-pending-rendering">3.4. Process image that finished loading</a>
     <li><a href="#ref-for-images-pending-rendering①">3.7. Element Timing processing</a> <a href="#ref-for-images-pending-rendering②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-of-elements-with-rendered-text">
-   <b><a href="#set-of-elements-with-rendered-text">#set-of-elements-with-rendered-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-of-elements-with-rendered-text" class="dfn-panel" data-for="set-of-elements-with-rendered-text" id="infopanel-for-set-of-elements-with-rendered-text" role="dialog">
+   <span id="infopaneltitle-for-set-of-elements-with-rendered-text" style="display:none">Info about the 'set of elements with rendered text' definition.</span><b><a href="#set-of-elements-with-rendered-text">#set-of-elements-with-rendered-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-of-elements-with-rendered-text">3.7. Element Timing processing</a> <a href="#ref-for-set-of-elements-with-rendered-text①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-background-image-requests">
-   <b><a href="#associated-background-image-requests">#associated-background-image-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-background-image-requests" class="dfn-panel" data-for="associated-background-image-requests" id="infopanel-for-associated-background-image-requests" role="dialog">
+   <span id="infopaneltitle-for-associated-background-image-requests" style="display:none">Info about the 'associated background image requests' definition.</span><b><a href="#associated-background-image-requests">#associated-background-image-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-background-image-requests">3.2. Modifications to the CSS specification</a> <a href="#ref-for-associated-background-image-requests①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-an-image-that-finished-loading">
-   <b><a href="#process-an-image-that-finished-loading">#process-an-image-that-finished-loading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-an-image-that-finished-loading" class="dfn-panel" data-for="process-an-image-that-finished-loading" id="infopanel-for-process-an-image-that-finished-loading" role="dialog">
+   <span id="infopaneltitle-for-process-an-image-that-finished-loading" style="display:none">Info about the 'process an image that finished loading' definition.</span><b><a href="#process-an-image-that-finished-loading">#process-an-image-that-finished-loading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-an-image-that-finished-loading">3.1. Modifications to the DOM specification</a>
     <li><a href="#ref-for-process-an-image-that-finished-loading①">3.2. Modifications to the CSS specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-image-element-timing">
-   <b><a href="#report-image-element-timing">#report-image-element-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-image-element-timing" class="dfn-panel" data-for="report-image-element-timing" id="infopanel-for-report-image-element-timing" role="dialog">
+   <span id="infopaneltitle-for-report-image-element-timing" style="display:none">Info about the 'report image element timing' definition.</span><b><a href="#report-image-element-timing">#report-image-element-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-image-element-timing">1.1. Elements exposed</a>
     <li><a href="#ref-for-report-image-element-timing①">3.4. Process image that finished loading</a>
     <li><a href="#ref-for-report-image-element-timing②">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-text-element-timing">
-   <b><a href="#report-text-element-timing">#report-text-element-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-text-element-timing" class="dfn-panel" data-for="report-text-element-timing" id="infopanel-for-report-text-element-timing" role="dialog">
+   <span id="infopaneltitle-for-report-text-element-timing" style="display:none">Info about the 'report text element timing' definition.</span><b><a href="#report-text-element-timing">#report-text-element-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-text-element-timing">1.1. Elements exposed</a>
     <li><a href="#ref-for-report-text-element-timing①">3.7. Element Timing processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-timing-processing">
-   <b><a href="#element-timing-processing">#element-timing-processing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-timing-processing" class="dfn-panel" data-for="element-timing-processing" id="infopanel-for-element-timing-processing" role="dialog">
+   <span id="infopaneltitle-for-element-timing-processing" style="display:none">Info about the 'element timing processing' definition.</span><b><a href="#element-timing-processing">#element-timing-processing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-timing-processing">3.3. Modifications to the HTML specification</a>
     <li><a href="#ref-for-element-timing-processing①">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-an-element">
-   <b><a href="#get-an-element">#get-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-an-element" class="dfn-panel" data-for="get-an-element" id="infopanel-for-get-an-element" role="dialog">
+   <span id="infopaneltitle-for-get-an-element" style="display:none">Info about the 'get an element' definition.</span><b><a href="#get-an-element">#get-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-element">2.1. PerformanceElementTiming interface</a>
     <li><a href="#ref-for-get-an-element①">3.5. Report image Element Timing</a>
@@ -2229,59 +2229,115 @@ This would unintentionally leak some of the display timing of the image.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/encrypted-media-encryption-scheme/index.html
+++ b/tests/github/WICG/encrypted-media-encryption-scheme/index.html
@@ -930,22 +930,22 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
    <li><a href="#cenc">cenc</a><span>, in § 1</span>
    <li><a href="#dom-mediakeysystemmediacapability-encryptionscheme">encryptionScheme</a><span>, in § 1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-clear-key">
-   <a href="https://www.w3.org/TR/encrypted-media/#clear-key">https://www.w3.org/TR/encrypted-media/#clear-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clear-key" class="dfn-panel" data-for="term-for-clear-key" id="infopanel-for-term-for-clear-key" role="menu">
+   <span id="infopaneltitle-for-term-for-clear-key" style="display:none">Info about the 'Clear Key' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#clear-key">https://www.w3.org/TR/encrypted-media/#clear-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear-key">3. 
     Clear Key Requirements </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-supported-capabilities-for-audio-video-type">
-   <a href="https://www.w3.org/TR/encrypted-media/#get-supported-capabilities-for-audio-video-type">https://www.w3.org/TR/encrypted-media/#get-supported-capabilities-for-audio-video-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-supported-capabilities-for-audio-video-type" class="dfn-panel" data-for="term-for-get-supported-capabilities-for-audio-video-type" id="infopanel-for-term-for-get-supported-capabilities-for-audio-video-type" role="menu">
+   <span id="infopaneltitle-for-term-for-get-supported-capabilities-for-audio-video-type" style="display:none">Info about the 'Get Supported Capabilities...' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#get-supported-capabilities-for-audio-video-type">https://www.w3.org/TR/encrypted-media/#get-supported-capabilities-for-audio-video-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-supported-capabilities-for-audio-video-type">2. 
     Algorithm Extensions </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemaccess" class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess" id="infopanel-for-term-for-dom-mediakeysystemaccess" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemaccess" style="display:none">Info about the 'MediaKeySystemAccess' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemaccess">1. 
     MediaKeySystemMediaCapability dictionary extension </a>
@@ -953,8 +953,8 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
     Polyfills and Backward Compatibility </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability" class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability" id="infopanel-for-term-for-dom-mediakeysystemmediacapability" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability" style="display:none">Info about the 'MediaKeySystemMediaCapability' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemmediacapability①">1. 
     MediaKeySystemMediaCapability dictionary extension </a> <a href="#ref-for-dom-mediakeysystemmediacapability②">(2)</a>
@@ -962,8 +962,8 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
     Polyfills and Backward Compatibility </a> <a href="#ref-for-dom-mediakeysystemmediacapability④">(2)</a> <a href="#ref-for-dom-mediakeysystemmediacapability⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess-getconfiguration">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-getconfiguration">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-getconfiguration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemaccess-getconfiguration" class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess-getconfiguration" id="infopanel-for-term-for-dom-mediakeysystemaccess-getconfiguration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemaccess-getconfiguration" style="display:none">Info about the 'getConfiguration()' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-getconfiguration">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-getconfiguration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemaccess-getconfiguration">1. 
     MediaKeySystemMediaCapability dictionary extension </a>
@@ -973,8 +973,8 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
     Polyfills and Backward Compatibility </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()">
-   <a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()" id="infopanel-for-term-for-navigator-extension:-requestmediakeysystemaccess()" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" style="display:none">Info about the 'requestMediaKeySystemAccess()' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-extension:-requestmediakeysystemaccess()">5. 
     Polyfills and Backward Compatibility </a>
@@ -982,22 +982,22 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
         User Consent </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-data">
-   <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-data" class="dfn-panel" data-for="term-for-media-data" id="infopanel-for-term-for-media-data" role="menu">
+   <span id="infopaneltitle-for-term-for-media-data" style="display:none">Info about the 'media data' external reference.</span><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data">https://www.w3.org/TR/html51/semantics-embedded-content.html#media-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-data">2. 
     Algorithm Extensions </a> <a href="#ref-for-media-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">1. 
     MediaKeySystemMediaCapability dictionary extension </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-present">
-   <a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-present" class="dfn-panel" data-for="term-for-dfn-present" id="infopanel-for-term-for-dfn-present" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-present" style="display:none">Info about the 'present' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-present">1. 
     MediaKeySystemMediaCapability dictionary extension </a>
@@ -1052,8 +1052,8 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
     schemes. <a href="https://github.com/wicg/encrypted-media-encryption-scheme/issues/#9">[Issue ##9]</a> <a class="issue-return" href="#issue-7472f44c" title="Jump to section">↵</a></div>
    <div class="issue"> Publish and link to a polyfill for this feature. <a href="https://github.com/wicg/encrypted-media-encryption-scheme/issues/#13">[Issue ##13]</a> <a class="issue-return" href="#issue-74d893e8" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dom-mediakeysystemmediacapability-encryptionscheme">
-   <b><a href="#dom-mediakeysystemmediacapability-encryptionscheme">#dom-mediakeysystemmediacapability-encryptionscheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediakeysystemmediacapability-encryptionscheme" class="dfn-panel" data-for="dom-mediakeysystemmediacapability-encryptionscheme" id="infopanel-for-dom-mediakeysystemmediacapability-encryptionscheme" role="dialog">
+   <span id="infopaneltitle-for-dom-mediakeysystemmediacapability-encryptionscheme" style="display:none">Info about the 'encryptionScheme' definition.</span><b><a href="#dom-mediakeysystemmediacapability-encryptionscheme">#dom-mediakeysystemmediacapability-encryptionscheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme">1. 
     MediaKeySystemMediaCapability dictionary extension </a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme①">(2)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme②">(3)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme③">(4)</a>
@@ -1065,8 +1065,8 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
     Polyfills and Backward Compatibility </a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme⑦">(2)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme⑧">(3)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme⑨">(4)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme①⓪">(5)</a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme①①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cenc">
-   <b><a href="#cenc">#cenc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cenc" class="dfn-panel" data-for="cenc" id="infopanel-for-cenc" role="dialog">
+   <span id="infopaneltitle-for-cenc" style="display:none">Info about the 'cenc' definition.</span><b><a href="#cenc">#cenc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cenc">3. 
     Clear Key Requirements </a>
@@ -1074,57 +1074,113 @@ accumulated configuration</var> in combination with <var>restrictions</var>...</
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/entries-api/index.html
+++ b/tests/github/WICG/entries-api/index.html
@@ -2064,14 +2064,14 @@ for suggestions, reviews, and other feedback.</p>
    <li><a href="#dom-datatransferitem-webkitgetasentry">webkitGetAsEntry()</a><span>, in § 6</span>
    <li><a href="#dom-file-webkitrelativepath">webkitRelativePath</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-asynciterator-interface">
-   <a href="https://tc39.github.io/ecma262/#sec-asynciterator-interface">https://tc39.github.io/ecma262/#sec-asynciterator-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-asynciterator-interface" class="dfn-panel" data-for="term-for-sec-asynciterator-interface" id="infopanel-for-term-for-sec-asynciterator-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-asynciterator-interface" style="display:none">Info about the 'asynciterator' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-asynciterator-interface">https://tc39.github.io/ecma262/#sec-asynciterator-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-asynciterator-interface">7.3. The FileSystemDirectoryReader Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-sec-promise-objects①">7.2. The FileSystemDirectoryEntry Interface</a>
@@ -2079,8 +2079,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-sec-promise-objects③">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">4. The File Interface</a> <a href="#ref-for-dfn-file①">(2)</a>
     <li><a href="#ref-for-dfn-file②">5. HTML: Forms</a>
@@ -2088,82 +2088,82 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-dfn-file④">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-dfn-file⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-filereader">
-   <a href="https://w3c.github.io/FileAPI/#dfn-filereader">https://w3c.github.io/FileAPI/#dfn-filereader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-filereader" class="dfn-panel" data-for="term-for-dfn-filereader" id="infopanel-for-term-for-dfn-filereader" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-filereader" style="display:none">Info about the 'FileReader' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-filereader">https://w3c.github.io/FileAPI/#dfn-filereader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-filereader">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">5. HTML: Forms</a> <a href="#ref-for-dfn-name①">(2)</a> <a href="#ref-for-dfn-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransferitem">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransferitem" class="dfn-panel" data-for="term-for-datatransferitem" id="infopanel-for-term-for-datatransferitem" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransferitem" style="display:none">Info about the 'DataTransferItem' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransferitem">Unnumbered Section</a>
     <li><a href="#ref-for-datatransferitem①">6. HTML: Drag and drop</a> <a href="#ref-for-datatransferitem②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlinputelement">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlinputelement" class="dfn-panel" data-for="term-for-htmlinputelement" id="infopanel-for-term-for-htmlinputelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlinputelement" style="display:none">Info about the 'HTMLInputElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlinputelement">Unnumbered Section</a>
     <li><a href="#ref-for-htmlinputelement①">5. HTML: Forms</a> <a href="#ref-for-htmlinputelement②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-input-accept">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#dom-input-accept">https://html.spec.whatwg.org/multipage/input.html#dom-input-accept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-input-accept" class="dfn-panel" data-for="term-for-dom-input-accept" id="infopanel-for-term-for-dom-input-accept" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-input-accept" style="display:none">Info about the 'accept' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#dom-input-accept">https://html.spec.whatwg.org/multipage/input.html#dom-input-accept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-input-accept">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-drag-data-item-kind">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-kind">https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-drag-data-item-kind" class="dfn-panel" data-for="term-for-the-drag-data-item-kind" id="infopanel-for-term-for-the-drag-data-item-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-the-drag-data-item-kind" style="display:none">Info about the 'drag data item kind' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-kind">https://html.spec.whatwg.org/multipage/interaction.html#the-drag-data-item-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-drag-data-item-kind">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drag-data-store">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drag-data-store" class="dfn-panel" data-for="term-for-drag-data-store" id="infopanel-for-term-for-drag-data-store" role="menu">
+   <span id="infopaneltitle-for-term-for-drag-data-store" style="display:none">Info about the 'drag data store' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drag-data-store">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drag-data-store-item-list">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-item-list">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-item-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drag-data-store-item-list" class="dfn-panel" data-for="term-for-drag-data-store-item-list" id="infopanel-for-term-for-drag-data-store-item-list" role="menu">
+   <span id="infopaneltitle-for-term-for-drag-data-store-item-list" style="display:none">Info about the 'drag data store item list' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-item-list">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-item-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drag-data-store-item-list">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-file-upload-state-(type=file)">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#file-upload-state-(type=file)">https://html.spec.whatwg.org/multipage/forms.html#file-upload-state-(type=file)</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-file-upload-state-(type=file)" class="dfn-panel" data-for="term-for-file-upload-state-(type=file)" id="infopanel-for-term-for-file-upload-state-(type=file)" role="menu">
+   <span id="infopaneltitle-for-term-for-file-upload-state-(type=file)" style="display:none">Info about the 'file upload' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#file-upload-state-(type=file)">https://html.spec.whatwg.org/multipage/forms.html#file-upload-state-(type=file)</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-upload-state-(type=file)">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-input-files">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#dom-input-files">https://html.spec.whatwg.org/multipage/input.html#dom-input-files</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-input-files" class="dfn-panel" data-for="term-for-dom-input-files" id="infopanel-for-term-for-dom-input-files" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-input-files" style="display:none">Info about the 'files' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#dom-input-files">https://html.spec.whatwg.org/multipage/input.html#dom-input-files</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-input-files">5. HTML: Forms</a> <a href="#ref-for-dom-input-files①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransferitem-getasfile">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasfile">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasfile</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransferitem-getasfile" class="dfn-panel" data-for="term-for-dom-datatransferitem-getasfile" id="infopanel-for-term-for-dom-datatransferitem-getasfile" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransferitem-getasfile" style="display:none">Info about the 'getAsFile()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasfile">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasfile</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransferitem-getasfile">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">5. HTML: Forms</a> <a href="#ref-for-the-input-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-queue-a-task①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-queue-a-task②">(2)</a>
@@ -2171,38 +2171,38 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-queue-a-task⑦">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-ro">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-ro" class="dfn-panel" data-for="term-for-concept-dnd-ro" id="infopanel-for-term-for-concept-dnd-ro" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-ro" style="display:none">Info about the 'read-only mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-ro">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-rw">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-rw" class="dfn-panel" data-for="term-for-concept-dnd-rw" id="infopanel-for-term-for-concept-dnd-rw" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-rw" style="display:none">Info about the 'read/write mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-rw">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-input-type-file-selected">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#concept-input-type-file-selected">https://html.spec.whatwg.org/multipage/forms.html#concept-input-type-file-selected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-input-type-file-selected" class="dfn-panel" data-for="term-for-concept-input-type-file-selected" id="infopanel-for-term-for-concept-input-type-file-selected" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-input-type-file-selected" style="display:none">Info about the 'selected files' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#concept-input-type-file-selected">https://html.spec.whatwg.org/multipage/forms.html#concept-input-type-file-selected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-input-type-file-selected">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-type">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-type" class="dfn-panel" data-for="term-for-attr-input-type" id="infopanel-for-term-for-attr-input-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-type">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">3. Algorithms</a> <a href="#ref-for-strictly-split①">(2)</a> <a href="#ref-for-strictly-split②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">7. Files and Directories</a>
     <li><a href="#ref-for-idl-DOMException①">7.1. The FileSystemEntry Interface</a>
@@ -2211,8 +2211,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-idl-DOMException①③">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-idl-DOMException①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-Exposed①">7.2. The FileSystemDirectoryEntry Interface</a>
@@ -2221,20 +2221,20 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-Exposed④">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">7.3. The FileSystemDirectoryReader Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-notfounderror①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-notfounderror②">(2)</a>
@@ -2242,28 +2242,28 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-notfounderror④">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-securityerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">7. Files and Directories</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typemismatcherror">
-   <a href="https://webidl.spec.whatwg.org/#typemismatcherror">https://webidl.spec.whatwg.org/#typemismatcherror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typemismatcherror" class="dfn-panel" data-for="term-for-typemismatcherror" id="infopanel-for-term-for-typemismatcherror" role="menu">
+   <span id="infopaneltitle-for-term-for-typemismatcherror" style="display:none">Info about the 'TypeMismatchError' external reference.</span><a href="https://webidl.spec.whatwg.org/#typemismatcherror">https://webidl.spec.whatwg.org/#typemismatcherror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typemismatcherror">7. Files and Directories</a>
     <li><a href="#ref-for-typemismatcherror①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-typemismatcherror②">(2)</a> <a href="#ref-for-typemismatcherror③">(3)</a> <a href="#ref-for-typemismatcherror④">(4)</a>
     <li><a href="#ref-for-typemismatcherror⑤">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2.1. Names and Paths</a>
     <li><a href="#ref-for-idl-USVString①">2.2. Files and Directories</a>
@@ -2273,16 +2273,16 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-idl-USVString⑦">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5. HTML: Forms</a>
     <li><a href="#ref-for-idl-boolean①">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-idl-boolean②">(2)</a>
     <li><a href="#ref-for-idl-boolean③">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-idl-boolean④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-exception" class="dfn-panel" data-for="term-for-dfn-create-exception" id="infopanel-for-term-for-dfn-create-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-exception" style="display:none">Info about the 'created' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-dfn-create-exception①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-dfn-create-exception②">(2)</a> <a href="#ref-for-dfn-create-exception③">(3)</a> <a href="#ref-for-dfn-create-exception④">(4)</a> <a href="#ref-for-dfn-create-exception⑤">(5)</a> <a href="#ref-for-dfn-create-exception⑥">(6)</a> <a href="#ref-for-dfn-create-exception⑦">(7)</a> <a href="#ref-for-dfn-create-exception⑧">(8)</a>
@@ -2290,8 +2290,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-dfn-create-exception①①">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-dfn-create-exception①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-invoke-a-callback-function①">(2)</a>
     <li><a href="#ref-for-invoke-a-callback-function②">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-invoke-a-callback-function③">(2)</a> <a href="#ref-for-invoke-a-callback-function④">(3)</a> <a href="#ref-for-invoke-a-callback-function⑤">(4)</a> <a href="#ref-for-invoke-a-callback-function⑥">(5)</a> <a href="#ref-for-invoke-a-callback-function⑦">(6)</a> <a href="#ref-for-invoke-a-callback-function⑧">(7)</a> <a href="#ref-for-invoke-a-callback-function⑨">(8)</a> <a href="#ref-for-invoke-a-callback-function①⓪">(9)</a> <a href="#ref-for-invoke-a-callback-function①①">(10)</a>
@@ -2299,14 +2299,14 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-invoke-a-callback-function①⑧">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-invoke-a-callback-function①⑨">(2)</a> <a href="#ref-for-invoke-a-callback-function②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">7.3. The FileSystemDirectoryReader Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a>
     <li><a href="#ref-for-this⑦">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-this⑧">(2)</a> <a href="#ref-for-this⑨">(3)</a> <a href="#ref-for-this①⓪">(4)</a>
@@ -2315,8 +2315,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-this②③">7.5. The FileSystem Interface</a> <a href="#ref-for-this②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">7. Files and Directories</a>
     <li><a href="#ref-for-idl-undefined①">7.1. The FileSystemEntry Interface</a>
@@ -2499,8 +2499,8 @@ for suggestions, reviews, and other feedback.</p>
   specifications by <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">TypeError</a></code>, but the name differs. Is it
   compatible to switch here as well? <a class="issue-return" href="#issue-b91b245d" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="name">
-   <b><a href="#name">#name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-name" class="dfn-panel" data-for="name" id="infopanel-for-name" role="dialog">
+   <span id="infopaneltitle-for-name" style="display:none">Info about the 'name' definition.</span><b><a href="#name">#name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name">2.1. Names and Paths</a>
     <li><a href="#ref-for-name①">2.2. Files and Directories</a> <a href="#ref-for-name②">(2)</a> <a href="#ref-for-name③">(3)</a> <a href="#ref-for-name④">(4)</a>
@@ -2508,14 +2508,14 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-name⑥">3. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-segment">
-   <b><a href="#path-segment">#path-segment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-segment" class="dfn-panel" data-for="path-segment" id="infopanel-for-path-segment" role="dialog">
+   <span id="infopaneltitle-for-path-segment" style="display:none">Info about the 'path segment' definition.</span><b><a href="#path-segment">#path-segment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-segment">2.1. Names and Paths</a> <a href="#ref-for-path-segment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-path">
-   <b><a href="#relative-path">#relative-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-path" class="dfn-panel" data-for="relative-path" id="infopanel-for-relative-path" role="dialog">
+   <span id="infopaneltitle-for-relative-path" style="display:none">Info about the 'relative path' definition.</span><b><a href="#relative-path">#relative-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-path">2.1. Names and Paths</a>
     <li><a href="#ref-for-relative-path①">3. Algorithms</a>
@@ -2523,29 +2523,29 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-relative-path③">5. HTML: Forms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-path">
-   <b><a href="#absolute-path">#absolute-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-path" class="dfn-panel" data-for="absolute-path" id="infopanel-for-absolute-path" role="dialog">
+   <span id="infopaneltitle-for-absolute-path" style="display:none">Info about the 'absolute path' definition.</span><b><a href="#absolute-path">#absolute-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-path">2.1. Names and Paths</a>
     <li><a href="#ref-for-absolute-path①">2.3. Entries</a>
     <li><a href="#ref-for-absolute-path②">3. Algorithms</a> <a href="#ref-for-absolute-path③">(2)</a> <a href="#ref-for-absolute-path④">(3)</a> <a href="#ref-for-absolute-path⑤">(4)</a> <a href="#ref-for-absolute-path⑥">(5)</a> <a href="#ref-for-absolute-path⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path">
-   <b><a href="#path">#path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path" class="dfn-panel" data-for="path" id="infopanel-for-path" role="dialog">
+   <span id="infopaneltitle-for-path" style="display:none">Info about the 'path' definition.</span><b><a href="#path">#path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path">2.1. Names and Paths</a>
     <li><a href="#ref-for-path①">2.3. Entries</a> <a href="#ref-for-path②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-path">
-   <b><a href="#valid-path">#valid-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-path" class="dfn-panel" data-for="valid-path" id="infopanel-for-valid-path" role="dialog">
+   <span id="infopaneltitle-for-valid-path" style="display:none">Info about the 'valid path' definition.</span><b><a href="#valid-path">#valid-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-path">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-valid-path①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file">
-   <b><a href="#file">#file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file" class="dfn-panel" data-for="file" id="infopanel-for-file" role="dialog">
+   <span id="infopaneltitle-for-file" style="display:none">Info about the 'file' definition.</span><b><a href="#file">#file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file">2.2. Files and Directories</a> <a href="#ref-for-file①">(2)</a> <a href="#ref-for-file②">(3)</a>
     <li><a href="#ref-for-file③">3. Algorithms</a> <a href="#ref-for-file④">(2)</a>
@@ -2553,14 +2553,14 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-file⑥">7.2. The FileSystemDirectoryEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-name">
-   <b><a href="#file-name">#file-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-name" class="dfn-panel" data-for="file-name" id="infopanel-for-file-name" role="dialog">
+   <span id="infopaneltitle-for-file-name" style="display:none">Info about the 'name' definition.</span><b><a href="#file-name">#file-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-name">7.2. The FileSystemDirectoryEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory">
-   <b><a href="#directory">#directory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory" class="dfn-panel" data-for="directory" id="infopanel-for-directory" role="dialog">
+   <span id="infopaneltitle-for-directory" style="display:none">Info about the 'directory' definition.</span><b><a href="#directory">#directory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory">2.2. Files and Directories</a> <a href="#ref-for-directory①">(2)</a> <a href="#ref-for-directory②">(3)</a> <a href="#ref-for-directory③">(4)</a> <a href="#ref-for-directory④">(5)</a> <a href="#ref-for-directory⑤">(6)</a> <a href="#ref-for-directory⑥">(7)</a>
     <li><a href="#ref-for-directory⑦">2.4. Directory Reader</a>
@@ -2571,15 +2571,15 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-directory①⑥">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory-name">
-   <b><a href="#directory-name">#directory-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory-name" class="dfn-panel" data-for="directory-name" id="infopanel-for-directory-name" role="dialog">
+   <span id="infopaneltitle-for-directory-name" style="display:none">Info about the 'name' definition.</span><b><a href="#directory-name">#directory-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory-name">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-directory-name①">7.2. The FileSystemDirectoryEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root-directory">
-   <b><a href="#root-directory">#root-directory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-root-directory" class="dfn-panel" data-for="root-directory" id="infopanel-for-root-directory" role="dialog">
+   <span id="infopaneltitle-for-root-directory" style="display:none">Info about the 'root directory' definition.</span><b><a href="#root-directory">#root-directory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-directory">2.2. Files and Directories</a> <a href="#ref-for-root-directory①">(2)</a> <a href="#ref-for-root-directory②">(3)</a> <a href="#ref-for-root-directory③">(4)</a>
     <li><a href="#ref-for-root-directory④">2.3. Entries</a> <a href="#ref-for-root-directory⑤">(2)</a>
@@ -2587,36 +2587,36 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-root-directory⑦">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parent">
-   <b><a href="#parent">#parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parent" class="dfn-panel" data-for="parent" id="infopanel-for-parent" role="dialog">
+   <span id="infopaneltitle-for-parent" style="display:none">Info about the 'parent' definition.</span><b><a href="#parent">#parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent">2.2. Files and Directories</a>
     <li><a href="#ref-for-parent①">3. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-system">
-   <b><a href="#file-system">#file-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-system" class="dfn-panel" data-for="file-system" id="infopanel-for-file-system" role="dialog">
+   <span id="infopaneltitle-for-file-system" style="display:none">Info about the 'file system' definition.</span><b><a href="#file-system">#file-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-system">2.2. Files and Directories</a> <a href="#ref-for-file-system①">(2)</a> <a href="#ref-for-file-system②">(3)</a> <a href="#ref-for-file-system③">(4)</a>
     <li><a href="#ref-for-file-system④">2.3. Entries</a>
     <li><a href="#ref-for-file-system⑤">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-system-name">
-   <b><a href="#file-system-name">#file-system-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-system-name" class="dfn-panel" data-for="file-system-name" id="infopanel-for-file-system-name" role="dialog">
+   <span id="infopaneltitle-for-file-system-name" style="display:none">Info about the 'name' definition.</span><b><a href="#file-system-name">#file-system-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-system-name">2.2. Files and Directories</a> <a href="#ref-for-file-system-name①">(2)</a>
     <li><a href="#ref-for-file-system-name②">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-system-root">
-   <b><a href="#file-system-root">#file-system-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-system-root" class="dfn-panel" data-for="file-system-root" id="infopanel-for-file-system-root" role="dialog">
+   <span id="infopaneltitle-for-file-system-root" style="display:none">Info about the 'root' definition.</span><b><a href="#file-system-root">#file-system-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-system-root">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-concept">
-   <b><a href="#entry-concept">#entry-concept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-concept" class="dfn-panel" data-for="entry-concept" id="infopanel-for-entry-concept" role="dialog">
+   <span id="infopaneltitle-for-entry-concept" style="display:none">Info about the 'entry' definition.</span><b><a href="#entry-concept">#entry-concept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-concept">2.3. Entries</a> <a href="#ref-for-entry-concept①">(2)</a> <a href="#ref-for-entry-concept②">(3)</a> <a href="#ref-for-entry-concept③">(4)</a> <a href="#ref-for-entry-concept④">(5)</a> <a href="#ref-for-entry-concept⑤">(6)</a>
     <li><a href="#ref-for-entry-concept⑥">6. HTML: Drag and drop</a> <a href="#ref-for-entry-concept⑦">(2)</a> <a href="#ref-for-entry-concept⑧">(3)</a>
@@ -2625,31 +2625,31 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-entry-concept①①">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-entry">
-   <b><a href="#file-entry">#file-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-entry" class="dfn-panel" data-for="file-entry" id="infopanel-for-file-entry" role="dialog">
+   <span id="infopaneltitle-for-file-entry" style="display:none">Info about the 'file entry' definition.</span><b><a href="#file-entry">#file-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-entry">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-file-entry①">7.2. The FileSystemDirectoryEntry Interface</a>
     <li><a href="#ref-for-file-entry②">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory-entry">
-   <b><a href="#directory-entry">#directory-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory-entry" class="dfn-panel" data-for="directory-entry" id="infopanel-for-directory-entry" role="dialog">
+   <span id="infopaneltitle-for-directory-entry" style="display:none">Info about the 'directory entry' definition.</span><b><a href="#directory-entry">#directory-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory-entry">2.4. Directory Reader</a>
     <li><a href="#ref-for-directory-entry①">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-directory-entry②">(2)</a>
     <li><a href="#ref-for-directory-entry③">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-directory-entry④">(2)</a> <a href="#ref-for-directory-entry⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-name">
-   <b><a href="#entry-name">#entry-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-name" class="dfn-panel" data-for="entry-name" id="infopanel-for-entry-name" role="dialog">
+   <span id="infopaneltitle-for-entry-name" style="display:none">Info about the 'name' definition.</span><b><a href="#entry-name">#entry-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-name">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-entry-name①">(2)</a>
     <li><a href="#ref-for-entry-name②">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-entry-name③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="full-path">
-   <b><a href="#full-path">#full-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-full-path" class="dfn-panel" data-for="full-path" id="infopanel-for-full-path" role="dialog">
+   <span id="infopaneltitle-for-full-path" style="display:none">Info about the 'full path' definition.</span><b><a href="#full-path">#full-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-full-path">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-full-path①">(2)</a> <a href="#ref-for-full-path②">(3)</a>
     <li><a href="#ref-for-full-path③">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-full-path④">(2)</a> <a href="#ref-for-full-path⑤">(3)</a> <a href="#ref-for-full-path⑥">(4)</a>
@@ -2657,8 +2657,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-full-path⑧">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-root">
-   <b><a href="#entry-root">#entry-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-root" class="dfn-panel" data-for="entry-root" id="infopanel-for-entry-root" role="dialog">
+   <span id="infopaneltitle-for-entry-root" style="display:none">Info about the 'root' definition.</span><b><a href="#entry-root">#entry-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-root">2.3. Entries</a>
     <li><a href="#ref-for-entry-root①">7.1. The FileSystemEntry Interface</a>
@@ -2667,46 +2667,47 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-entry-root⑤">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-file-system">
-   <b><a href="#entry-file-system">#entry-file-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-file-system" class="dfn-panel" data-for="entry-file-system" id="infopanel-for-entry-file-system" role="dialog">
+   <span id="infopaneltitle-for-entry-file-system" style="display:none">Info about the 'file system' definition.</span><b><a href="#entry-file-system">#entry-file-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-file-system">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory-reader">
-   <b><a href="#directory-reader">#directory-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory-reader" class="dfn-panel" data-for="directory-reader" id="infopanel-for-directory-reader" role="dialog">
+   <span id="infopaneltitle-for-directory-reader" style="display:none">Info about the 'directory reader' definition.</span><b><a href="#directory-reader">#directory-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory-reader">7.2. The FileSystemDirectoryEntry Interface</a>
     <li><a href="#ref-for-directory-reader①">7.3. The FileSystemDirectoryReader Interface</a> <a href="#ref-for-directory-reader②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reading-flag">
-   <b><a href="#reading-flag">#reading-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reading-flag" class="dfn-panel" data-for="reading-flag" id="infopanel-for-reading-flag" role="dialog">
+   <span id="infopaneltitle-for-reading-flag" style="display:none">Info about the 'reading
+flag' definition.</span><b><a href="#reading-flag">#reading-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reading-flag">7.3. The FileSystemDirectoryReader Interface</a> <a href="#ref-for-reading-flag①">(2)</a> <a href="#ref-for-reading-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="done-flag">
-   <b><a href="#done-flag">#done-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-done-flag" class="dfn-panel" data-for="done-flag" id="infopanel-for-done-flag" role="dialog">
+   <span id="infopaneltitle-for-done-flag" style="display:none">Info about the 'done flag' definition.</span><b><a href="#done-flag">#done-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-done-flag">7.3. The FileSystemDirectoryReader Interface</a> <a href="#ref-for-done-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reader-error">
-   <b><a href="#reader-error">#reader-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reader-error" class="dfn-panel" data-for="reader-error" id="infopanel-for-reader-error" role="dialog">
+   <span id="infopaneltitle-for-reader-error" style="display:none">Info about the 'reader error' definition.</span><b><a href="#reader-error">#reader-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reader-error">7.3. The FileSystemDirectoryReader Interface</a> <a href="#ref-for-reader-error①">(2)</a> <a href="#ref-for-reader-error②">(3)</a> <a href="#ref-for-reader-error③">(4)</a> <a href="#ref-for-reader-error④">(5)</a> <a href="#ref-for-reader-error⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-a-relative-path">
-   <b><a href="#resolve-a-relative-path">#resolve-a-relative-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-a-relative-path" class="dfn-panel" data-for="resolve-a-relative-path" id="infopanel-for-resolve-a-relative-path" role="dialog">
+   <span id="infopaneltitle-for-resolve-a-relative-path" style="display:none">Info about the 'resolve a relative path' definition.</span><b><a href="#resolve-a-relative-path">#resolve-a-relative-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-relative-path">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-resolve-a-relative-path①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-resolve-a-relative-path②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="evaluate-a-path">
-   <b><a href="#evaluate-a-path">#evaluate-a-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-evaluate-a-path" class="dfn-panel" data-for="evaluate-a-path" id="infopanel-for-evaluate-a-path" role="dialog">
+   <span id="infopaneltitle-for-evaluate-a-path" style="display:none">Info about the 'evaluate a path' definition.</span><b><a href="#evaluate-a-path">#evaluate-a-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-evaluate-a-path">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-evaluate-a-path①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-evaluate-a-path②">(2)</a>
@@ -2714,33 +2715,33 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-evaluate-a-path④">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-file-webkitrelativepath">
-   <b><a href="#dom-file-webkitrelativepath">#dom-file-webkitrelativepath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-file-webkitrelativepath" class="dfn-panel" data-for="dom-file-webkitrelativepath" id="infopanel-for-dom-file-webkitrelativepath" role="dialog">
+   <span id="infopaneltitle-for-dom-file-webkitrelativepath" style="display:none">Info about the 'webkitRelativePath' definition.</span><b><a href="#dom-file-webkitrelativepath">#dom-file-webkitrelativepath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-file-webkitrelativepath">4. The File Interface</a>
     <li><a href="#ref-for-dom-file-webkitrelativepath①">5. HTML: Forms</a> <a href="#ref-for-dom-file-webkitrelativepath②">(2)</a> <a href="#ref-for-dom-file-webkitrelativepath③">(3)</a> <a href="#ref-for-dom-file-webkitrelativepath④">(4)</a> <a href="#ref-for-dom-file-webkitrelativepath⑤">(5)</a> <a href="#ref-for-dom-file-webkitrelativepath⑥">(6)</a> <a href="#ref-for-dom-file-webkitrelativepath⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlinputelement-webkitdirectory">
-   <b><a href="#dom-htmlinputelement-webkitdirectory">#dom-htmlinputelement-webkitdirectory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlinputelement-webkitdirectory" class="dfn-panel" data-for="dom-htmlinputelement-webkitdirectory" id="infopanel-for-dom-htmlinputelement-webkitdirectory" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlinputelement-webkitdirectory" style="display:none">Info about the 'webkitdirectory' definition.</span><b><a href="#dom-htmlinputelement-webkitdirectory">#dom-htmlinputelement-webkitdirectory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlinputelement-webkitdirectory">5. HTML: Forms</a> <a href="#ref-for-dom-htmlinputelement-webkitdirectory①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlinputelement-webkitentries">
-   <b><a href="#dom-htmlinputelement-webkitentries">#dom-htmlinputelement-webkitentries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlinputelement-webkitentries" class="dfn-panel" data-for="dom-htmlinputelement-webkitentries" id="infopanel-for-dom-htmlinputelement-webkitentries" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlinputelement-webkitentries" style="display:none">Info about the 'webkitEntries' definition.</span><b><a href="#dom-htmlinputelement-webkitentries">#dom-htmlinputelement-webkitentries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlinputelement-webkitentries">5. HTML: Forms</a> <a href="#ref-for-dom-htmlinputelement-webkitentries①">(2)</a> <a href="#ref-for-dom-htmlinputelement-webkitentries②">(3)</a> <a href="#ref-for-dom-htmlinputelement-webkitentries③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datatransferitem-webkitgetasentry">
-   <b><a href="#dom-datatransferitem-webkitgetasentry">#dom-datatransferitem-webkitgetasentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datatransferitem-webkitgetasentry" class="dfn-panel" data-for="dom-datatransferitem-webkitgetasentry" id="infopanel-for-dom-datatransferitem-webkitgetasentry" role="dialog">
+   <span id="infopaneltitle-for-dom-datatransferitem-webkitgetasentry" style="display:none">Info about the 'webkitGetAsEntry()' definition.</span><b><a href="#dom-datatransferitem-webkitgetasentry">#dom-datatransferitem-webkitgetasentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransferitem-webkitgetasentry">6. HTML: Drag and drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-errorcallback">
-   <b><a href="#callbackdef-errorcallback">#callbackdef-errorcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-errorcallback" class="dfn-panel" data-for="callbackdef-errorcallback" id="infopanel-for-callbackdef-errorcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-errorcallback" style="display:none">Info about the 'ErrorCallback' definition.</span><b><a href="#callbackdef-errorcallback">#callbackdef-errorcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-errorcallback">7. Files and Directories</a>
     <li><a href="#ref-for-callbackdef-errorcallback①">7.1. The FileSystemEntry Interface</a>
@@ -2749,8 +2750,8 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-callbackdef-errorcallback⑤">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystementry">
-   <b><a href="#filesystementry">#filesystementry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystementry" class="dfn-panel" data-for="filesystementry" id="infopanel-for-filesystementry" role="dialog">
+   <span id="infopaneltitle-for-filesystementry" style="display:none">Info about the 'FileSystemEntry' definition.</span><b><a href="#filesystementry">#filesystementry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystementry">5. HTML: Forms</a> <a href="#ref-for-filesystementry①">(2)</a>
     <li><a href="#ref-for-filesystementry②">6. HTML: Drag and drop</a> <a href="#ref-for-filesystementry③">(2)</a>
@@ -2761,199 +2762,255 @@ for suggestions, reviews, and other feedback.</p>
     <li><a href="#ref-for-filesystementry①①">8. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-isfile">
-   <b><a href="#dom-filesystementry-isfile">#dom-filesystementry-isfile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-isfile" class="dfn-panel" data-for="dom-filesystementry-isfile" id="infopanel-for-dom-filesystementry-isfile" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-isfile" style="display:none">Info about the 'isFile' definition.</span><b><a href="#dom-filesystementry-isfile">#dom-filesystementry-isfile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-isfile">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-isdirectory">
-   <b><a href="#dom-filesystementry-isdirectory">#dom-filesystementry-isdirectory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-isdirectory" class="dfn-panel" data-for="dom-filesystementry-isdirectory" id="infopanel-for-dom-filesystementry-isdirectory" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-isdirectory" style="display:none">Info about the 'isDirectory' definition.</span><b><a href="#dom-filesystementry-isdirectory">#dom-filesystementry-isdirectory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-isdirectory">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-name">
-   <b><a href="#dom-filesystementry-name">#dom-filesystementry-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-name" class="dfn-panel" data-for="dom-filesystementry-name" id="infopanel-for-dom-filesystementry-name" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-filesystementry-name">#dom-filesystementry-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-name">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-fullpath">
-   <b><a href="#dom-filesystementry-fullpath">#dom-filesystementry-fullpath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-fullpath" class="dfn-panel" data-for="dom-filesystementry-fullpath" id="infopanel-for-dom-filesystementry-fullpath" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-fullpath" style="display:none">Info about the 'fullPath' definition.</span><b><a href="#dom-filesystementry-fullpath">#dom-filesystementry-fullpath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-fullpath">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-filesystem">
-   <b><a href="#dom-filesystementry-filesystem">#dom-filesystementry-filesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-filesystem" class="dfn-panel" data-for="dom-filesystementry-filesystem" id="infopanel-for-dom-filesystementry-filesystem" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-filesystem" style="display:none">Info about the 'filesystem' definition.</span><b><a href="#dom-filesystementry-filesystem">#dom-filesystementry-filesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-filesystem">7.1. The FileSystemEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystementry-getparent">
-   <b><a href="#dom-filesystementry-getparent">#dom-filesystementry-getparent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystementry-getparent" class="dfn-panel" data-for="dom-filesystementry-getparent" id="infopanel-for-dom-filesystementry-getparent" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystementry-getparent" style="display:none">Info about the 'getParent(successCallback, errorCallback)' definition.</span><b><a href="#dom-filesystementry-getparent">#dom-filesystementry-getparent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystementry-getparent">7.1. The FileSystemEntry Interface</a> <a href="#ref-for-dom-filesystementry-getparent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemdirectoryentry">
-   <b><a href="#filesystemdirectoryentry">#filesystemdirectoryentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemdirectoryentry" class="dfn-panel" data-for="filesystemdirectoryentry" id="infopanel-for-filesystemdirectoryentry" role="dialog">
+   <span id="infopaneltitle-for-filesystemdirectoryentry" style="display:none">Info about the 'FileSystemDirectoryEntry' definition.</span><b><a href="#filesystemdirectoryentry">#filesystemdirectoryentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemdirectoryentry">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-filesystemdirectoryentry①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-filesystemdirectoryentry②">(2)</a> <a href="#ref-for-filesystemdirectoryentry③">(3)</a>
     <li><a href="#ref-for-filesystemdirectoryentry④">7.5. The FileSystem Interface</a> <a href="#ref-for-filesystemdirectoryentry⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemflags">
-   <b><a href="#dictdef-filesystemflags">#dictdef-filesystemflags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemflags" class="dfn-panel" data-for="dictdef-filesystemflags" id="infopanel-for-dictdef-filesystemflags" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemflags" style="display:none">Info about the 'FileSystemFlags' definition.</span><b><a href="#dictdef-filesystemflags">#dictdef-filesystemflags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemflags">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-dictdef-filesystemflags①">(2)</a> <a href="#ref-for-dictdef-filesystemflags②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemflags-create">
-   <b><a href="#dom-filesystemflags-create">#dom-filesystemflags-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemflags-create" class="dfn-panel" data-for="dom-filesystemflags-create" id="infopanel-for-dom-filesystemflags-create" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemflags-create" style="display:none">Info about the 'create' definition.</span><b><a href="#dom-filesystemflags-create">#dom-filesystemflags-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemflags-create">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-dom-filesystemflags-create①">(2)</a> <a href="#ref-for-dom-filesystemflags-create②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemflags-exclusive">
-   <b><a href="#dom-filesystemflags-exclusive">#dom-filesystemflags-exclusive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemflags-exclusive" class="dfn-panel" data-for="dom-filesystemflags-exclusive" id="infopanel-for-dom-filesystemflags-exclusive" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemflags-exclusive" style="display:none">Info about the 'exclusive' definition.</span><b><a href="#dom-filesystemflags-exclusive">#dom-filesystemflags-exclusive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemflags-exclusive">7.2. The FileSystemDirectoryEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-filesystementrycallback">
-   <b><a href="#callbackdef-filesystementrycallback">#callbackdef-filesystementrycallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-filesystementrycallback" class="dfn-panel" data-for="callbackdef-filesystementrycallback" id="infopanel-for-callbackdef-filesystementrycallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-filesystementrycallback" style="display:none">Info about the 'FileSystemEntryCallback' definition.</span><b><a href="#callbackdef-filesystementrycallback">#callbackdef-filesystementrycallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-filesystementrycallback">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-callbackdef-filesystementrycallback①">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-callbackdef-filesystementrycallback②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryentry-createreader">
-   <b><a href="#dom-filesystemdirectoryentry-createreader">#dom-filesystemdirectoryentry-createreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryentry-createreader" class="dfn-panel" data-for="dom-filesystemdirectoryentry-createreader" id="infopanel-for-dom-filesystemdirectoryentry-createreader" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryentry-createreader" style="display:none">Info about the 'createReader()' definition.</span><b><a href="#dom-filesystemdirectoryentry-createreader">#dom-filesystemdirectoryentry-createreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryentry-createreader">7.2. The FileSystemDirectoryEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryentry-getfile">
-   <b><a href="#dom-filesystemdirectoryentry-getfile">#dom-filesystemdirectoryentry-getfile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryentry-getfile" class="dfn-panel" data-for="dom-filesystemdirectoryentry-getfile" id="infopanel-for-dom-filesystemdirectoryentry-getfile" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryentry-getfile" style="display:none">Info about the 'getFile(path, options, successCallback, errorCallback)' definition.</span><b><a href="#dom-filesystemdirectoryentry-getfile">#dom-filesystemdirectoryentry-getfile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryentry-getfile">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-dom-filesystemdirectoryentry-getfile①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryentry-getdirectory">
-   <b><a href="#dom-filesystemdirectoryentry-getdirectory">#dom-filesystemdirectoryentry-getdirectory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryentry-getdirectory" class="dfn-panel" data-for="dom-filesystemdirectoryentry-getdirectory" id="infopanel-for-dom-filesystemdirectoryentry-getdirectory" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryentry-getdirectory" style="display:none">Info about the 'getDirectory(path, options, successCallback, errorCallback)' definition.</span><b><a href="#dom-filesystemdirectoryentry-getdirectory">#dom-filesystemdirectoryentry-getdirectory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryentry-getdirectory">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-dom-filesystemdirectoryentry-getdirectory①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemdirectoryreader">
-   <b><a href="#filesystemdirectoryreader">#filesystemdirectoryreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemdirectoryreader" class="dfn-panel" data-for="filesystemdirectoryreader" id="infopanel-for-filesystemdirectoryreader" role="dialog">
+   <span id="infopaneltitle-for-filesystemdirectoryreader" style="display:none">Info about the 'FileSystemDirectoryReader' definition.</span><b><a href="#filesystemdirectoryreader">#filesystemdirectoryreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemdirectoryreader">7.2. The FileSystemDirectoryEntry Interface</a> <a href="#ref-for-filesystemdirectoryreader①">(2)</a>
     <li><a href="#ref-for-filesystemdirectoryreader②">7.3. The FileSystemDirectoryReader Interface</a> <a href="#ref-for-filesystemdirectoryreader③">(2)</a> <a href="#ref-for-filesystemdirectoryreader④">(3)</a> <a href="#ref-for-filesystemdirectoryreader⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-filesystementriescallback">
-   <b><a href="#callbackdef-filesystementriescallback">#callbackdef-filesystementriescallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-filesystementriescallback" class="dfn-panel" data-for="callbackdef-filesystementriescallback" id="infopanel-for-callbackdef-filesystementriescallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-filesystementriescallback" style="display:none">Info about the 'FileSystemEntriesCallback' definition.</span><b><a href="#callbackdef-filesystementriescallback">#callbackdef-filesystementriescallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-filesystementriescallback">7.3. The FileSystemDirectoryReader Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemfileentry">
-   <b><a href="#filesystemfileentry">#filesystemfileentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemfileentry" class="dfn-panel" data-for="filesystemfileentry" id="infopanel-for-filesystemfileentry" role="dialog">
+   <span id="infopaneltitle-for-filesystemfileentry" style="display:none">Info about the 'FileSystemFileEntry' definition.</span><b><a href="#filesystemfileentry">#filesystemfileentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemfileentry">7.2. The FileSystemDirectoryEntry Interface</a>
     <li><a href="#ref-for-filesystemfileentry①">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-filesystemfileentry②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-filecallback">
-   <b><a href="#callbackdef-filecallback">#callbackdef-filecallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-filecallback" class="dfn-panel" data-for="callbackdef-filecallback" id="infopanel-for-callbackdef-filecallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-filecallback" style="display:none">Info about the 'FileCallback' definition.</span><b><a href="#callbackdef-filecallback">#callbackdef-filecallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-filecallback">7.4. The FileSystemFileEntry Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemfileentry-file">
-   <b><a href="#dom-filesystemfileentry-file">#dom-filesystemfileentry-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemfileentry-file" class="dfn-panel" data-for="dom-filesystemfileentry-file" id="infopanel-for-dom-filesystemfileentry-file" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemfileentry-file" style="display:none">Info about the 'file(successCallback, errorCallback)' definition.</span><b><a href="#dom-filesystemfileentry-file">#dom-filesystemfileentry-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemfileentry-file">7.4. The FileSystemFileEntry Interface</a> <a href="#ref-for-dom-filesystemfileentry-file①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystem">
-   <b><a href="#filesystem">#filesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystem" class="dfn-panel" data-for="filesystem" id="infopanel-for-filesystem" role="dialog">
+   <span id="infopaneltitle-for-filesystem" style="display:none">Info about the 'FileSystem' definition.</span><b><a href="#filesystem">#filesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystem">7.1. The FileSystemEntry Interface</a>
     <li><a href="#ref-for-filesystem①">7.5. The FileSystem Interface</a> <a href="#ref-for-filesystem②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystem-name">
-   <b><a href="#dom-filesystem-name">#dom-filesystem-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystem-name" class="dfn-panel" data-for="dom-filesystem-name" id="infopanel-for-dom-filesystem-name" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystem-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-filesystem-name">#dom-filesystem-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystem-name">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystem-root">
-   <b><a href="#dom-filesystem-root">#dom-filesystem-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystem-root" class="dfn-panel" data-for="dom-filesystem-root" id="infopanel-for-dom-filesystem-root" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystem-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-filesystem-root">#dom-filesystem-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystem-root">7.5. The FileSystem Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/event-timing/index.html
+++ b/tests/github/WICG/event-timing/index.html
@@ -1492,70 +1492,70 @@ Such events are not handled within 100ms and will likely negatively impact user 
     </ul>
    <li><a href="#dom-performanceeventtiming-tojson">toJSON()</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-document①">3.2. Modifications to the HTML specification</a> <a href="#ref-for-document②">(2)</a>
     <li><a href="#ref-for-document③">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">1.1. Events exposed</a> <a href="#ref-for-event①">(2)</a> <a href="#ref-for-event②">(3)</a> <a href="#ref-for-event③">(4)</a> <a href="#ref-for-event④">(5)</a> <a href="#ref-for-event⑤">(6)</a>
     <li><a href="#ref-for-event⑥">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-event⑦">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-node①">(2)</a>
     <li><a href="#ref-for-node②">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-dom-event-cancelable①">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'event dispatch algorithm' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">1.1. Events exposed</a>
     <li><a href="#ref-for-concept-event-dispatch①">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-concept-event-dispatch②">(2)</a>
     <li><a href="#ref-for-concept-event-dispatch③">3.1. Modifications to the DOM specification</a> <a href="#ref-for-concept-event-dispatch④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">1.1. Events exposed</a> <a href="#ref-for-dom-event-istrusted①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-retarget">
-   <a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-retarget" class="dfn-panel" data-for="term-for-retarget" id="infopanel-for-term-for-retarget" role="menu">
+   <span id="infopaneltitle-for-term-for-retarget" style="display:none">Info about the 'retargeting' external reference.</span><a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retarget">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-target" class="dfn-panel" data-for="term-for-dom-event-target" id="infopanel-for-term-for-dom-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">2.1. PerformanceEventTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-timestamp">
-   <a href="https://dom.spec.whatwg.org/#dom-event-timestamp">https://dom.spec.whatwg.org/#dom-event-timestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-timestamp" class="dfn-panel" data-for="term-for-dom-event-timestamp" id="infopanel-for-term-for-dom-event-timestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-timestamp" style="display:none">Info about the 'timeStamp' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-timestamp">https://dom.spec.whatwg.org/#dom-event-timestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-timestamp">1. Introduction</a>
     <li><a href="#ref-for-dom-event-timestamp①">1.1. Events exposed</a> <a href="#ref-for-dom-event-timestamp②">(2)</a>
@@ -1563,8 +1563,8 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-event-timestamp④">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">1.1. Events exposed</a> <a href="#ref-for-dom-event-type①">(2)</a>
     <li><a href="#ref-for-dom-event-type②">2.1. PerformanceEventTiming interface</a>
@@ -1573,49 +1573,49 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-event-type⑥">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-an-element">
-   <a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-an-element" class="dfn-panel" data-for="term-for-get-an-element" id="infopanel-for-term-for-get-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-get-an-element" style="display:none">Info about the 'get an element' external reference.</span><a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-element">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-get-an-element①">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp" id="infopanel-for-term-for-idl-def-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-domhighrestimestamp">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-idl-def-domhighrestimestamp①">(2)</a>
     <li><a href="#ref-for-idl-def-domhighrestimestamp②">3.3. Modifications to the Performance Timeline specification</a>
     <li><a href="#ref-for-idl-def-domhighrestimestamp③">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-performance">
-   <a href="https://w3c.github.io/hr-time/#dfn-performance">https://w3c.github.io/hr-time/#dfn-performance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-performance" class="dfn-panel" data-for="term-for-dfn-performance" id="infopanel-for-term-for-dfn-performance" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-performance" style="display:none">Info about the 'Performance' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-performance">https://w3c.github.io/hr-time/#dfn-performance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-performance">2.3. Extensions to the Performance interface</a> <a href="#ref-for-dfn-performance①">(2)</a> <a href="#ref-for-dfn-performance②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-high-resolution-time" class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time" id="infopanel-for-term-for-dfn-current-high-resolution-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-high-resolution-time" style="display:none">Info about the 'current high resolution time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-high-resolution-time">3.1. Modifications to the DOM specification</a> <a href="#ref-for-dfn-current-high-resolution-time①">(2)</a>
     <li><a href="#ref-for-dfn-current-high-resolution-time②">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performance-now">
-   <a href="https://w3c.github.io/hr-time/#dom-performance-now">https://w3c.github.io/hr-time/#dom-performance-now</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performance-now" class="dfn-panel" data-for="term-for-dom-performance-now" id="infopanel-for-term-for-dom-performance-now" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performance-now" style="display:none">Info about the 'now()' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-performance-now">https://w3c.github.io/hr-time/#dom-performance-now</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performance-now">1. Introduction</a>
     <li><a href="#ref-for-dom-performance-now①">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-performance">
-   <a href="https://w3c.github.io/hr-time/#dom-windoworworkerglobalscope-performance">https://w3c.github.io/hr-time/#dom-windoworworkerglobalscope-performance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-performance" class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-performance" id="infopanel-for-term-for-dom-windoworworkerglobalscope-performance" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-performance" style="display:none">Info about the 'performance' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-windoworworkerglobalscope-performance">https://w3c.github.io/hr-time/#dom-windoworworkerglobalscope-performance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-performance">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">1.1. Events exposed</a>
     <li><a href="#ref-for-window①">2.1. PerformanceEventTiming interface</a>
@@ -1624,69 +1624,69 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-window⑥">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">1.1. Events exposed</a>
     <li><a href="#ref-for-concept-document-window①">3.6. Finalize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-drag">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-drag">https://html.spec.whatwg.org/multipage/#event-dnd-drag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-drag" class="dfn-panel" data-for="term-for-event-dnd-drag" id="infopanel-for-term-for-event-dnd-drag" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-drag" style="display:none">Info about the 'drag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-drag">https://html.spec.whatwg.org/multipage/#event-dnd-drag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-drag">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragend">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragend">https://html.spec.whatwg.org/multipage/#event-dnd-dragend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragend" class="dfn-panel" data-for="term-for-event-dnd-dragend" id="infopanel-for-term-for-event-dnd-dragend" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragend" style="display:none">Info about the 'dragend' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragend">https://html.spec.whatwg.org/multipage/#event-dnd-dragend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragend">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragenter">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragenter">https://html.spec.whatwg.org/multipage/#event-dnd-dragenter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragenter" class="dfn-panel" data-for="term-for-event-dnd-dragenter" id="infopanel-for-term-for-event-dnd-dragenter" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragenter" style="display:none">Info about the 'dragenter' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragenter">https://html.spec.whatwg.org/multipage/#event-dnd-dragenter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragenter">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragexit">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragexit">https://html.spec.whatwg.org/multipage/#event-dnd-dragexit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragexit" class="dfn-panel" data-for="term-for-event-dnd-dragexit" id="infopanel-for-term-for-event-dnd-dragexit" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragexit" style="display:none">Info about the 'dragexit' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragexit">https://html.spec.whatwg.org/multipage/#event-dnd-dragexit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragexit">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragleave">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragleave">https://html.spec.whatwg.org/multipage/#event-dnd-dragleave</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragleave" class="dfn-panel" data-for="term-for-event-dnd-dragleave" id="infopanel-for-term-for-event-dnd-dragleave" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragleave" style="display:none">Info about the 'dragleave' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragleave">https://html.spec.whatwg.org/multipage/#event-dnd-dragleave</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragleave">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragover">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragover">https://html.spec.whatwg.org/multipage/#event-dnd-dragover</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragover" class="dfn-panel" data-for="term-for-event-dnd-dragover" id="infopanel-for-term-for-event-dnd-dragover" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragover" style="display:none">Info about the 'dragover' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragover">https://html.spec.whatwg.org/multipage/#event-dnd-dragover</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragover">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-dragstart">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragstart">https://html.spec.whatwg.org/multipage/#event-dnd-dragstart</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-dragstart" class="dfn-panel" data-for="term-for-event-dnd-dragstart" id="infopanel-for-term-for-event-dnd-dragstart" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-dragstart" style="display:none">Info about the 'dragstart' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-dragstart">https://html.spec.whatwg.org/multipage/#event-dnd-dragstart</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-dragstart">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-dnd-drop">
-   <a href="https://html.spec.whatwg.org/multipage/#event-dnd-drop">https://html.spec.whatwg.org/multipage/#event-dnd-drop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-dnd-drop" class="dfn-panel" data-for="term-for-event-dnd-drop" id="infopanel-for-term-for-event-dnd-drop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-dnd-drop" style="display:none">Info about the 'drop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-dnd-drop">https://html.spec.whatwg.org/multipage/#event-dnd-drop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-dnd-drop">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">3.2. Modifications to the HTML specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">1.1. Events exposed</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
     <li><a href="#ref-for-concept-relevant-global②">2.3. Extensions to the Performance interface</a>
@@ -1694,47 +1694,47 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-concept-relevant-global④">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-update-the-rendering①">3.2. Modifications to the HTML specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mark-paint-timing">
-   <a href="https://w3c.github.io/paint-timing/#mark-paint-timing">https://w3c.github.io/paint-timing/#mark-paint-timing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mark-paint-timing" class="dfn-panel" data-for="term-for-mark-paint-timing" id="infopanel-for-term-for-mark-paint-timing" role="menu">
+   <span id="infopaneltitle-for-term-for-mark-paint-timing" style="display:none">Info about the 'mark paint timing' external reference.</span><a href="https://w3c.github.io/paint-timing/#mark-paint-timing">https://w3c.github.io/paint-timing/#mark-paint-timing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mark-paint-timing">3.2. Modifications to the HTML specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-the-performanceentry-interface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceobserver-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceobserver-interface">https://w3c.github.io/performance-timeline/#the-performanceobserver-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceobserver-interface" class="dfn-panel" data-for="term-for-the-performanceobserver-interface" id="infopanel-for-term-for-the-performanceobserver-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceobserver-interface" style="display:none">Info about the 'PerformanceObserver' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceobserver-interface">https://w3c.github.io/performance-timeline/#the-performanceobserver-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceobserver-interface">1.1. Events exposed</a>
     <li><a href="#ref-for-the-performanceobserver-interface①">3.4. Should add PerformanceEventTiming</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-performanceobserverinit-dictionary">
-   <a href="https://w3c.github.io/performance-timeline/#performanceobserverinit-dictionary">https://w3c.github.io/performance-timeline/#performanceobserverinit-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-performanceobserverinit-dictionary" class="dfn-panel" data-for="term-for-performanceobserverinit-dictionary" id="infopanel-for-term-for-performanceobserverinit-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-performanceobserverinit-dictionary" style="display:none">Info about the 'PerformanceObserverInit' external reference.</span><a href="https://w3c.github.io/performance-timeline/#performanceobserverinit-dictionary">https://w3c.github.io/performance-timeline/#performanceobserverinit-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performanceobserverinit-dictionary">3.3. Modifications to the Performance Timeline specification</a> <a href="#ref-for-performanceobserverinit-dictionary①">(2)</a>
     <li><a href="#ref-for-performanceobserverinit-dictionary②">3.4. Should add PerformanceEventTiming</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">1.1. Events exposed</a> <a href="#ref-for-dom-performanceentry-duration①">(2)</a>
     <li><a href="#ref-for-dom-performanceentry-duration②">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceentry-duration③">(2)</a>
@@ -1743,8 +1743,8 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-performanceentry-duration⑦">4. Security &amp; privacy considerations</a> <a href="#ref-for-dom-performanceentry-duration⑧">(2)</a> <a href="#ref-for-dom-performanceentry-duration⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceentry-entrytype①">(2)</a>
     <li><a href="#ref-for-dom-performanceentry-entrytype②">3.4. Should add PerformanceEventTiming</a> <a href="#ref-for-dom-performanceentry-entrytype③">(2)</a>
@@ -1752,22 +1752,22 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-performanceentry-entrytype⑤">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-dom-performanceentry-entrytype⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceentry-name①">(2)</a>
     <li><a href="#ref-for-dom-performanceentry-name②">3.5. Initialize event timing</a>
     <li><a href="#ref-for-dom-performanceentry-name③">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry">
-   <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry" id="infopanel-for-term-for-dfn-queue-a-performanceentry" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" style="display:none">Info about the 'queue the entry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-queue-a-performanceentry">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-dfn-queue-a-performanceentry①">(2)</a> <a href="#ref-for-dfn-queue-a-performanceentry②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">1.1. Events exposed</a> <a href="#ref-for-dom-performanceentry-starttime①">(2)</a>
     <li><a href="#ref-for-dom-performanceentry-starttime②">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceentry-starttime③">(2)</a> <a href="#ref-for-dom-performanceentry-starttime④">(3)</a>
@@ -1775,268 +1775,268 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-performanceentry-starttime⑥">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">2.1. PerformanceEventTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-gotpointercapture-event">
-   <a href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">https://w3c.github.io/pointerevents/#the-gotpointercapture-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-gotpointercapture-event" class="dfn-panel" data-for="term-for-the-gotpointercapture-event" id="infopanel-for-term-for-the-gotpointercapture-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-gotpointercapture-event" style="display:none">Info about the 'gotpointercapture' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-gotpointercapture-event">https://w3c.github.io/pointerevents/#the-gotpointercapture-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-gotpointercapture-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-lostpointercapture-event">
-   <a href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">https://w3c.github.io/pointerevents/#the-lostpointercapture-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-lostpointercapture-event" class="dfn-panel" data-for="term-for-the-lostpointercapture-event" id="infopanel-for-term-for-the-lostpointercapture-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-lostpointercapture-event" style="display:none">Info about the 'lostpointercapture' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-lostpointercapture-event">https://w3c.github.io/pointerevents/#the-lostpointercapture-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-lostpointercapture-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointercancel-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointercancel-event">https://w3c.github.io/pointerevents/#the-pointercancel-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointercancel-event" class="dfn-panel" data-for="term-for-the-pointercancel-event" id="infopanel-for-term-for-the-pointercancel-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointercancel-event" style="display:none">Info about the 'pointercancel' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointercancel-event">https://w3c.github.io/pointerevents/#the-pointercancel-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointercancel-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerdown-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerdown-event">https://w3c.github.io/pointerevents/#the-pointerdown-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerdown-event" class="dfn-panel" data-for="term-for-the-pointerdown-event" id="infopanel-for-term-for-the-pointerdown-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerdown-event" style="display:none">Info about the 'pointerdown' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerdown-event">https://w3c.github.io/pointerevents/#the-pointerdown-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerdown-event">1.1. Events exposed</a> <a href="#ref-for-the-pointerdown-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerenter-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerenter-event">https://w3c.github.io/pointerevents/#the-pointerenter-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerenter-event" class="dfn-panel" data-for="term-for-the-pointerenter-event" id="infopanel-for-term-for-the-pointerenter-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerenter-event" style="display:none">Info about the 'pointerenter' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerenter-event">https://w3c.github.io/pointerevents/#the-pointerenter-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerenter-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerleave-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerleave-event">https://w3c.github.io/pointerevents/#the-pointerleave-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerleave-event" class="dfn-panel" data-for="term-for-the-pointerleave-event" id="infopanel-for-term-for-the-pointerleave-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerleave-event" style="display:none">Info about the 'pointerleave' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerleave-event">https://w3c.github.io/pointerevents/#the-pointerleave-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerleave-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointermove-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointermove-event">https://w3c.github.io/pointerevents/#the-pointermove-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointermove-event" class="dfn-panel" data-for="term-for-the-pointermove-event" id="infopanel-for-term-for-the-pointermove-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointermove-event" style="display:none">Info about the 'pointermove' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointermove-event">https://w3c.github.io/pointerevents/#the-pointermove-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointermove-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerout-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerout-event">https://w3c.github.io/pointerevents/#the-pointerout-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerout-event" class="dfn-panel" data-for="term-for-the-pointerout-event" id="infopanel-for-term-for-the-pointerout-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerout-event" style="display:none">Info about the 'pointerout' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerout-event">https://w3c.github.io/pointerevents/#the-pointerout-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerout-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerover-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerover-event">https://w3c.github.io/pointerevents/#the-pointerover-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerover-event" class="dfn-panel" data-for="term-for-the-pointerover-event" id="infopanel-for-term-for-the-pointerover-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerover-event" style="display:none">Info about the 'pointerover' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerover-event">https://w3c.github.io/pointerevents/#the-pointerover-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerover-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerrawupdate-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerrawupdate-event">https://w3c.github.io/pointerevents/#the-pointerrawupdate-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerrawupdate-event" class="dfn-panel" data-for="term-for-the-pointerrawupdate-event" id="infopanel-for-term-for-the-pointerrawupdate-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerrawupdate-event" style="display:none">Info about the 'pointerrawupdate' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerrawupdate-event">https://w3c.github.io/pointerevents/#the-pointerrawupdate-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerrawupdate-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pointerup-event">
-   <a href="https://w3c.github.io/pointerevents/#the-pointerup-event">https://w3c.github.io/pointerevents/#the-pointerup-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pointerup-event" class="dfn-panel" data-for="term-for-the-pointerup-event" id="infopanel-for-term-for-the-pointerup-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pointerup-event" style="display:none">Info about the 'pointerup' external reference.</span><a href="https://w3c.github.io/pointerevents/#the-pointerup-event">https://w3c.github.io/pointerevents/#the-pointerup-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pointerup-event">1.1. Events exposed</a> <a href="#ref-for-the-pointerup-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-touchcancel-event">
-   <a href="https://w3c.github.io/touch-events/#the-touchcancel-event">https://w3c.github.io/touch-events/#the-touchcancel-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-touchcancel-event" class="dfn-panel" data-for="term-for-the-touchcancel-event" id="infopanel-for-term-for-the-touchcancel-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-touchcancel-event" style="display:none">Info about the 'touchcancel' external reference.</span><a href="https://w3c.github.io/touch-events/#the-touchcancel-event">https://w3c.github.io/touch-events/#the-touchcancel-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-touchcancel-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-touchend-event">
-   <a href="https://w3c.github.io/touch-events/#the-touchend-event">https://w3c.github.io/touch-events/#the-touchend-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-touchend-event" class="dfn-panel" data-for="term-for-the-touchend-event" id="infopanel-for-term-for-the-touchend-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-touchend-event" style="display:none">Info about the 'touchend' external reference.</span><a href="https://w3c.github.io/touch-events/#the-touchend-event">https://w3c.github.io/touch-events/#the-touchend-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-touchend-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-touchmove-event">
-   <a href="https://w3c.github.io/touch-events/#the-touchmove-event">https://w3c.github.io/touch-events/#the-touchmove-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-touchmove-event" class="dfn-panel" data-for="term-for-the-touchmove-event" id="infopanel-for-term-for-the-touchmove-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-touchmove-event" style="display:none">Info about the 'touchmove' external reference.</span><a href="https://w3c.github.io/touch-events/#the-touchmove-event">https://w3c.github.io/touch-events/#the-touchmove-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-touchmove-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-touchstart-event">
-   <a href="https://w3c.github.io/touch-events/#the-touchstart-event">https://w3c.github.io/touch-events/#the-touchstart-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-touchstart-event" class="dfn-panel" data-for="term-for-the-touchstart-event" id="infopanel-for-term-for-the-touchstart-event" role="menu">
+   <span id="infopaneltitle-for-term-for-the-touchstart-event" style="display:none">Info about the 'touchstart' external reference.</span><a href="https://w3c.github.io/touch-events/#the-touchstart-event">https://w3c.github.io/touch-events/#the-touchstart-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-touchstart-event">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-auxclick">
-   <a href="https://w3c.github.io/uievents/#event-type-auxclick">https://w3c.github.io/uievents/#event-type-auxclick</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-auxclick" class="dfn-panel" data-for="term-for-event-type-auxclick" id="infopanel-for-term-for-event-type-auxclick" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-auxclick" style="display:none">Info about the 'auxclick' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-auxclick">https://w3c.github.io/uievents/#event-type-auxclick</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-auxclick">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-beforeinput">
-   <a href="https://w3c.github.io/uievents/#event-type-beforeinput">https://w3c.github.io/uievents/#event-type-beforeinput</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-beforeinput" class="dfn-panel" data-for="term-for-event-type-beforeinput" id="infopanel-for-term-for-event-type-beforeinput" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-beforeinput" style="display:none">Info about the 'beforeinput' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-beforeinput">https://w3c.github.io/uievents/#event-type-beforeinput</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-beforeinput">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-click">
-   <a href="https://w3c.github.io/uievents/#event-type-click">https://w3c.github.io/uievents/#event-type-click</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-click" class="dfn-panel" data-for="term-for-event-type-click" id="infopanel-for-term-for-event-type-click" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-click" style="display:none">Info about the 'click' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-click">https://w3c.github.io/uievents/#event-type-click</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-click">1.1. Events exposed</a> <a href="#ref-for-event-type-click①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-compositionend">
-   <a href="https://w3c.github.io/uievents/#event-type-compositionend">https://w3c.github.io/uievents/#event-type-compositionend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-compositionend" class="dfn-panel" data-for="term-for-event-type-compositionend" id="infopanel-for-term-for-event-type-compositionend" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-compositionend" style="display:none">Info about the 'compositionend' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-compositionend">https://w3c.github.io/uievents/#event-type-compositionend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-compositionend">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-compositionstart">
-   <a href="https://w3c.github.io/uievents/#event-type-compositionstart">https://w3c.github.io/uievents/#event-type-compositionstart</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-compositionstart" class="dfn-panel" data-for="term-for-event-type-compositionstart" id="infopanel-for-term-for-event-type-compositionstart" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-compositionstart" style="display:none">Info about the 'compositionstart' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-compositionstart">https://w3c.github.io/uievents/#event-type-compositionstart</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-compositionstart">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-compositionupdate">
-   <a href="https://w3c.github.io/uievents/#event-type-compositionupdate">https://w3c.github.io/uievents/#event-type-compositionupdate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-compositionupdate" class="dfn-panel" data-for="term-for-event-type-compositionupdate" id="infopanel-for-term-for-event-type-compositionupdate" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-compositionupdate" style="display:none">Info about the 'compositionupdate' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-compositionupdate">https://w3c.github.io/uievents/#event-type-compositionupdate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-compositionupdate">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-dblclick">
-   <a href="https://w3c.github.io/uievents/#event-type-dblclick">https://w3c.github.io/uievents/#event-type-dblclick</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-dblclick" class="dfn-panel" data-for="term-for-event-type-dblclick" id="infopanel-for-term-for-event-type-dblclick" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-dblclick" style="display:none">Info about the 'dblclick' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-dblclick">https://w3c.github.io/uievents/#event-type-dblclick</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-dblclick">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-input">
-   <a href="https://w3c.github.io/uievents/#event-type-input">https://w3c.github.io/uievents/#event-type-input</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-input" class="dfn-panel" data-for="term-for-event-type-input" id="infopanel-for-term-for-event-type-input" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-input" style="display:none">Info about the 'input' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-input">https://w3c.github.io/uievents/#event-type-input</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-input">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-keydown">
-   <a href="https://w3c.github.io/uievents/#event-type-keydown">https://w3c.github.io/uievents/#event-type-keydown</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-keydown" class="dfn-panel" data-for="term-for-event-type-keydown" id="infopanel-for-term-for-event-type-keydown" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-keydown" style="display:none">Info about the 'keydown' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-keydown">https://w3c.github.io/uievents/#event-type-keydown</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-keydown">1.1. Events exposed</a> <a href="#ref-for-event-type-keydown①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-keypress">
-   <a href="https://w3c.github.io/uievents/#event-type-keypress">https://w3c.github.io/uievents/#event-type-keypress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-keypress" class="dfn-panel" data-for="term-for-event-type-keypress" id="infopanel-for-term-for-event-type-keypress" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-keypress" style="display:none">Info about the 'keypress' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-keypress">https://w3c.github.io/uievents/#event-type-keypress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-keypress">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-keyup">
-   <a href="https://w3c.github.io/uievents/#event-type-keyup">https://w3c.github.io/uievents/#event-type-keyup</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-keyup" class="dfn-panel" data-for="term-for-event-type-keyup" id="infopanel-for-term-for-event-type-keyup" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-keyup" style="display:none">Info about the 'keyup' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-keyup">https://w3c.github.io/uievents/#event-type-keyup</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-keyup">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mousedown">
-   <a href="https://w3c.github.io/uievents/#event-type-mousedown">https://w3c.github.io/uievents/#event-type-mousedown</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mousedown" class="dfn-panel" data-for="term-for-event-type-mousedown" id="infopanel-for-term-for-event-type-mousedown" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mousedown" style="display:none">Info about the 'mousedown' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mousedown">https://w3c.github.io/uievents/#event-type-mousedown</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mousedown">1.1. Events exposed</a> <a href="#ref-for-event-type-mousedown①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mouseenter">
-   <a href="https://w3c.github.io/uievents/#event-type-mouseenter">https://w3c.github.io/uievents/#event-type-mouseenter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mouseenter" class="dfn-panel" data-for="term-for-event-type-mouseenter" id="infopanel-for-term-for-event-type-mouseenter" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mouseenter" style="display:none">Info about the 'mouseenter' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mouseenter">https://w3c.github.io/uievents/#event-type-mouseenter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mouseenter">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mouseleave">
-   <a href="https://w3c.github.io/uievents/#event-type-mouseleave">https://w3c.github.io/uievents/#event-type-mouseleave</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mouseleave" class="dfn-panel" data-for="term-for-event-type-mouseleave" id="infopanel-for-term-for-event-type-mouseleave" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mouseleave" style="display:none">Info about the 'mouseleave' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mouseleave">https://w3c.github.io/uievents/#event-type-mouseleave</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mouseleave">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mousemove">
-   <a href="https://w3c.github.io/uievents/#event-type-mousemove">https://w3c.github.io/uievents/#event-type-mousemove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mousemove" class="dfn-panel" data-for="term-for-event-type-mousemove" id="infopanel-for-term-for-event-type-mousemove" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mousemove" style="display:none">Info about the 'mousemove' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mousemove">https://w3c.github.io/uievents/#event-type-mousemove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mousemove">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mouseout">
-   <a href="https://w3c.github.io/uievents/#event-type-mouseout">https://w3c.github.io/uievents/#event-type-mouseout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mouseout" class="dfn-panel" data-for="term-for-event-type-mouseout" id="infopanel-for-term-for-event-type-mouseout" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mouseout" style="display:none">Info about the 'mouseout' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mouseout">https://w3c.github.io/uievents/#event-type-mouseout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mouseout">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mouseover">
-   <a href="https://w3c.github.io/uievents/#event-type-mouseover">https://w3c.github.io/uievents/#event-type-mouseover</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mouseover" class="dfn-panel" data-for="term-for-event-type-mouseover" id="infopanel-for-term-for-event-type-mouseover" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mouseover" style="display:none">Info about the 'mouseover' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mouseover">https://w3c.github.io/uievents/#event-type-mouseover</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mouseover">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-mouseup">
-   <a href="https://w3c.github.io/uievents/#event-type-mouseup">https://w3c.github.io/uievents/#event-type-mouseup</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-mouseup" class="dfn-panel" data-for="term-for-event-type-mouseup" id="infopanel-for-term-for-event-type-mouseup" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-mouseup" style="display:none">Info about the 'mouseup' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-mouseup">https://w3c.github.io/uievents/#event-type-mouseup</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-mouseup">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-wheel">
-   <a href="https://w3c.github.io/uievents/#event-type-wheel">https://w3c.github.io/uievents/#event-type-wheel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-wheel" class="dfn-panel" data-for="term-for-event-type-wheel" id="infopanel-for-term-for-event-type-wheel" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-wheel" style="display:none">Info about the 'wheel' external reference.</span><a href="https://w3c.github.io/uievents/#event-type-wheel">https://w3c.github.io/uievents/#event-type-wheel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-wheel">1.1. Events exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. EventCounts interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2.1. PerformanceEventTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-Exposed①">2.2. EventCounts interface</a>
     <li><a href="#ref-for-Exposed②">2.3. Extensions to the Performance interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.3. Extensions to the Performance interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.1. PerformanceEventTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implements">
-   <a href="https://webidl.spec.whatwg.org/#implements">https://webidl.spec.whatwg.org/#implements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implements" class="dfn-panel" data-for="term-for-implements" id="infopanel-for-term-for-implements" role="menu">
+   <span id="infopaneltitle-for-term-for-implements" style="display:none">Info about the 'implements' external reference.</span><a href="https://webidl.spec.whatwg.org/#implements">https://webidl.spec.whatwg.org/#implements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implements">3.6. Finalize event timing</a> <a href="#ref-for-implements①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-map-entries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-map-entries" class="dfn-panel" data-for="term-for-dfn-map-entries" id="infopanel-for-term-for-dfn-map-entries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-map-entries" style="display:none">Info about the 'map entries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-map-entries">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-dfn-map-entries①">(2)</a> <a href="#ref-for-dfn-map-entries②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2.1. PerformanceEventTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">2.2. EventCounts interface</a>
    </ul>
@@ -2224,14 +2224,14 @@ Such events are not handled within 100ms and will likely negatively impact user 
    <div class="issue"> it’s unclear whether <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/#event-dnd-dragexit">dragexit</a></code> should be on the list. It may be deprecated and removed. <a class="issue-return" href="#issue-d9fb8154" title="Jump to section">↵</a></div>
    <div class="issue"> Change the linking of the "get an element" algorithm once it is moved to the DOM spec. <a class="issue-return" href="#issue-3b91075f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="considered-for-event-timing">
-   <b><a href="#considered-for-event-timing">#considered-for-event-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-considered-for-event-timing" class="dfn-panel" data-for="considered-for-event-timing" id="infopanel-for-considered-for-event-timing" role="dialog">
+   <span id="infopaneltitle-for-considered-for-event-timing" style="display:none">Info about the 'considered for Event Timing' definition.</span><b><a href="#considered-for-event-timing">#considered-for-event-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-considered-for-event-timing">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performanceeventtiming">
-   <b><a href="#performanceeventtiming">#performanceeventtiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performanceeventtiming" class="dfn-panel" data-for="performanceeventtiming" id="infopanel-for-performanceeventtiming" role="dialog">
+   <span id="infopaneltitle-for-performanceeventtiming" style="display:none">Info about the 'PerformanceEventTiming' definition.</span><b><a href="#performanceeventtiming">#performanceeventtiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performanceeventtiming">1.1. Events exposed</a> <a href="#ref-for-performanceeventtiming①">(2)</a>
     <li><a href="#ref-for-performanceeventtiming②">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-performanceeventtiming③">(2)</a> <a href="#ref-for-performanceeventtiming④">(3)</a> <a href="#ref-for-performanceeventtiming⑤">(4)</a> <a href="#ref-for-performanceeventtiming⑥">(5)</a> <a href="#ref-for-performanceeventtiming⑦">(6)</a>
@@ -2241,27 +2241,27 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-performanceeventtiming①③">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceeventtiming-target">
-   <b><a href="#dom-performanceeventtiming-target">#dom-performanceeventtiming-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceeventtiming-target" class="dfn-panel" data-for="dom-performanceeventtiming-target" id="infopanel-for-dom-performanceeventtiming-target" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceeventtiming-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-performanceeventtiming-target">#dom-performanceeventtiming-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceeventtiming-target">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceeventtiming-target①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performanceeventtiming-eventtarget">
-   <b><a href="#performanceeventtiming-eventtarget">#performanceeventtiming-eventtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performanceeventtiming-eventtarget" class="dfn-panel" data-for="performanceeventtiming-eventtarget" id="infopanel-for-performanceeventtiming-eventtarget" role="dialog">
+   <span id="infopaneltitle-for-performanceeventtiming-eventtarget" style="display:none">Info about the 'eventTarget' definition.</span><b><a href="#performanceeventtiming-eventtarget">#performanceeventtiming-eventtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performanceeventtiming-eventtarget">2.1. PerformanceEventTiming interface</a>
     <li><a href="#ref-for-performanceeventtiming-eventtarget①">3.6. Finalize event timing</a> <a href="#ref-for-performanceeventtiming-eventtarget②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performanceeventtiming-associated-event">
-   <b><a href="#performanceeventtiming-associated-event">#performanceeventtiming-associated-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performanceeventtiming-associated-event" class="dfn-panel" data-for="performanceeventtiming-associated-event" id="infopanel-for-performanceeventtiming-associated-event" role="dialog">
+   <span id="infopaneltitle-for-performanceeventtiming-associated-event" style="display:none">Info about the 'associated Event' definition.</span><b><a href="#performanceeventtiming-associated-event">#performanceeventtiming-associated-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performanceeventtiming-associated-event">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-performanceeventtiming-associated-event①">(2)</a> <a href="#ref-for-performanceeventtiming-associated-event②">(3)</a> <a href="#ref-for-performanceeventtiming-associated-event③">(4)</a> <a href="#ref-for-performanceeventtiming-associated-event④">(5)</a> <a href="#ref-for-performanceeventtiming-associated-event⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceeventtiming-processingstart">
-   <b><a href="#dom-performanceeventtiming-processingstart">#dom-performanceeventtiming-processingstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceeventtiming-processingstart" class="dfn-panel" data-for="dom-performanceeventtiming-processingstart" id="infopanel-for-dom-performanceeventtiming-processingstart" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceeventtiming-processingstart" style="display:none">Info about the 'processingStart' definition.</span><b><a href="#dom-performanceeventtiming-processingstart">#dom-performanceeventtiming-processingstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceeventtiming-processingstart">1.1. Events exposed</a> <a href="#ref-for-dom-performanceeventtiming-processingstart①">(2)</a> <a href="#ref-for-dom-performanceeventtiming-processingstart②">(3)</a>
     <li><a href="#ref-for-dom-performanceeventtiming-processingstart③">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceeventtiming-processingstart④">(2)</a> <a href="#ref-for-dom-performanceeventtiming-processingstart⑤">(3)</a>
@@ -2270,8 +2270,8 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-performanceeventtiming-processingstart⑧">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceeventtiming-processingend">
-   <b><a href="#dom-performanceeventtiming-processingend">#dom-performanceeventtiming-processingend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceeventtiming-processingend" class="dfn-panel" data-for="dom-performanceeventtiming-processingend" id="infopanel-for-dom-performanceeventtiming-processingend" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceeventtiming-processingend" style="display:none">Info about the 'processingEnd' definition.</span><b><a href="#dom-performanceeventtiming-processingend">#dom-performanceeventtiming-processingend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceeventtiming-processingend">1.1. Events exposed</a> <a href="#ref-for-dom-performanceeventtiming-processingend①">(2)</a>
     <li><a href="#ref-for-dom-performanceeventtiming-processingend②">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceeventtiming-processingend③">(2)</a>
@@ -2280,125 +2280,181 @@ Such events are not handled within 100ms and will likely negatively impact user 
     <li><a href="#ref-for-dom-performanceeventtiming-processingend⑥">4. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceeventtiming-cancelable">
-   <b><a href="#dom-performanceeventtiming-cancelable">#dom-performanceeventtiming-cancelable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceeventtiming-cancelable" class="dfn-panel" data-for="dom-performanceeventtiming-cancelable" id="infopanel-for-dom-performanceeventtiming-cancelable" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceeventtiming-cancelable" style="display:none">Info about the 'cancelable' definition.</span><b><a href="#dom-performanceeventtiming-cancelable">#dom-performanceeventtiming-cancelable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceeventtiming-cancelable">2.1. PerformanceEventTiming interface</a> <a href="#ref-for-dom-performanceeventtiming-cancelable①">(2)</a>
     <li><a href="#ref-for-dom-performanceeventtiming-cancelable②">3.5. Initialize event timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventcounts">
-   <b><a href="#eventcounts">#eventcounts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventcounts" class="dfn-panel" data-for="eventcounts" id="infopanel-for-eventcounts" role="dialog">
+   <span id="infopaneltitle-for-eventcounts" style="display:none">Info about the 'EventCounts' definition.</span><b><a href="#eventcounts">#eventcounts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventcounts">2.2. EventCounts interface</a> <a href="#ref-for-eventcounts①">(2)</a>
     <li><a href="#ref-for-eventcounts②">2.3. Extensions to the Performance interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performance-eventcounts">
-   <b><a href="#dom-performance-eventcounts">#dom-performance-eventcounts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performance-eventcounts" class="dfn-panel" data-for="dom-performance-eventcounts" id="infopanel-for-dom-performance-eventcounts" role="dialog">
+   <span id="infopaneltitle-for-dom-performance-eventcounts" style="display:none">Info about the 'eventCounts' definition.</span><b><a href="#dom-performance-eventcounts">#dom-performance-eventcounts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performance-eventcounts">2.3. Extensions to the Performance interface</a> <a href="#ref-for-dom-performance-eventcounts①">(2)</a>
     <li><a href="#ref-for-dom-performance-eventcounts②">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-dom-performance-eventcounts③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-event-entries">
-   <b><a href="#pending-event-entries">#pending-event-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-event-entries" class="dfn-panel" data-for="pending-event-entries" id="infopanel-for-pending-event-entries" role="dialog">
+   <span id="infopaneltitle-for-pending-event-entries" style="display:none">Info about the 'pending event entries' definition.</span><b><a href="#pending-event-entries">#pending-event-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-event-entries">3.6. Finalize event timing</a>
     <li><a href="#ref-for-pending-event-entries①">3.7. Dispatch pending Event Timing entries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-pointer-down">
-   <b><a href="#pending-pointer-down">#pending-pointer-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-pointer-down" class="dfn-panel" data-for="pending-pointer-down" id="infopanel-for-pending-pointer-down" role="dialog">
+   <span id="infopaneltitle-for-pending-pointer-down" style="display:none">Info about the 'pending pointer down' definition.</span><b><a href="#pending-pointer-down">#pending-pointer-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-pointer-down">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-pending-pointer-down①">(2)</a> <a href="#ref-for-pending-pointer-down②">(3)</a> <a href="#ref-for-pending-pointer-down③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-dispatched-input-event">
-   <b><a href="#has-dispatched-input-event">#has-dispatched-input-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-dispatched-input-event" class="dfn-panel" data-for="has-dispatched-input-event" id="infopanel-for-has-dispatched-input-event" role="dialog">
+   <span id="infopaneltitle-for-has-dispatched-input-event" style="display:none">Info about the 'has dispatched input event' definition.</span><b><a href="#has-dispatched-input-event">#has-dispatched-input-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-dispatched-input-event">3.7. Dispatch pending Event Timing entries</a> <a href="#ref-for-has-dispatched-input-event①">(2)</a> <a href="#ref-for-has-dispatched-input-event②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performanceobserverinit-durationthreshold">
-   <b><a href="#dom-performanceobserverinit-durationthreshold">#dom-performanceobserverinit-durationthreshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performanceobserverinit-durationthreshold" class="dfn-panel" data-for="dom-performanceobserverinit-durationthreshold" id="infopanel-for-dom-performanceobserverinit-durationthreshold" role="dialog">
+   <span id="infopaneltitle-for-dom-performanceobserverinit-durationthreshold" style="display:none">Info about the 'durationThreshold' definition.</span><b><a href="#dom-performanceobserverinit-durationthreshold">#dom-performanceobserverinit-durationthreshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceobserverinit-durationthreshold">3.4. Should add PerformanceEventTiming</a> <a href="#ref-for-dom-performanceobserverinit-durationthreshold①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-event-timing">
-   <b><a href="#initialize-event-timing">#initialize-event-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-event-timing" class="dfn-panel" data-for="initialize-event-timing" id="infopanel-for-initialize-event-timing" role="dialog">
+   <span id="infopaneltitle-for-initialize-event-timing" style="display:none">Info about the 'initialize event timing' definition.</span><b><a href="#initialize-event-timing">#initialize-event-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-event-timing">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finalize-event-timing">
-   <b><a href="#finalize-event-timing">#finalize-event-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finalize-event-timing" class="dfn-panel" data-for="finalize-event-timing" id="infopanel-for-finalize-event-timing" role="dialog">
+   <span id="infopaneltitle-for-finalize-event-timing" style="display:none">Info about the 'finalize event timing' definition.</span><b><a href="#finalize-event-timing">#finalize-event-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finalize-event-timing">3.1. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dispatch-pending-event-timing-entries">
-   <b><a href="#dispatch-pending-event-timing-entries">#dispatch-pending-event-timing-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dispatch-pending-event-timing-entries" class="dfn-panel" data-for="dispatch-pending-event-timing-entries" id="infopanel-for-dispatch-pending-event-timing-entries" role="dialog">
+   <span id="infopaneltitle-for-dispatch-pending-event-timing-entries" style="display:none">Info about the 'dispatch pending Event Timing entries' definition.</span><b><a href="#dispatch-pending-event-timing-entries">#dispatch-pending-event-timing-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-pending-event-timing-entries">3.2. Modifications to the HTML specification</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/file-system-access/index.html
+++ b/tests/github/WICG/file-system-access/index.html
@@ -3111,120 +3111,120 @@ use this API to write to disk.</p>
    <li><a href="#dom-filesystemwritablefilestream-write">write(data)</a><span>, in § 2.6.1</span>
    <li><a href="#dictdef-writeparams">WriteParams</a><span>, in § 2.6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-Blob①">(2)</a> <a href="#ref-for-dfn-Blob②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-dfn-file①">2.4.1. The getFile() method</a> <a href="#ref-for-dfn-file②">(2)</a> <a href="#ref-for-dfn-file③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-lastModified">
-   <a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-lastModified" class="dfn-panel" data-for="term-for-dfn-lastModified" id="infopanel-for-term-for-dfn-lastModified" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-lastModified" style="display:none">Info about the 'lastModified' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lastModified">2.4.1. The getFile() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">2.4.1. The getFile() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readOperation">
-   <a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readOperation" class="dfn-panel" data-for="term-for-readOperation" id="infopanel-for-term-for-readOperation" role="menu">
+   <span id="infopaneltitle-for-term-for-readOperation" style="display:none">Info about the 'read operation' external reference.</span><a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readOperation">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-snapshot-state">
-   <a href="https://w3c.github.io/FileAPI/#snapshot-state">https://w3c.github.io/FileAPI/#snapshot-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-snapshot-state" class="dfn-panel" data-for="term-for-snapshot-state" id="infopanel-for-term-for-snapshot-state" role="menu">
+   <span id="infopaneltitle-for-term-for-snapshot-state" style="display:none">Info about the 'snapshot state' external reference.</span><a href="https://w3c.github.io/FileAPI/#snapshot-state">https://w3c.github.io/FileAPI/#snapshot-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-snapshot-state">2.4.1. The getFile() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">2.4.1. The getFile() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-UnixEpoch">
-   <a href="https://w3c.github.io/FileAPI/#UnixEpoch">https://w3c.github.io/FileAPI/#UnixEpoch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-UnixEpoch" class="dfn-panel" data-for="term-for-UnixEpoch" id="infopanel-for-term-for-UnixEpoch" role="menu">
+   <span id="infopaneltitle-for-term-for-UnixEpoch" style="display:none">Info about the 'unix epoch' external reference.</span><a href="https://w3c.github.io/FileAPI/#UnixEpoch">https://w3c.github.io/FileAPI/#UnixEpoch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-UnixEpoch">2.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransferitem">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransferitem" class="dfn-panel" data-for="term-for-datatransferitem" id="infopanel-for-term-for-datatransferitem" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransferitem" style="display:none">Info about the 'DataTransferItem' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransferitem">3.6. Drag and Drop</a> <a href="#ref-for-datatransferitem①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serializable">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serializable" class="dfn-panel" data-for="term-for-serializable" id="infopanel-for-term-for-serializable" role="menu">
+   <span id="infopaneltitle-for-term-for-serializable" style="display:none">Info about the 'Serializable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializable">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-serializable①">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-serializable②">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.2. Permissions</a>
     <li><a href="#ref-for-window①">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-activation-notification">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">https://html.spec.whatwg.org/multipage/interaction.html#activation-notification</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-activation-notification" class="dfn-panel" data-for="term-for-activation-notification" id="infopanel-for-term-for-activation-notification" role="menu">
+   <span id="infopaneltitle-for-term-for-activation-notification" style="display:none">Info about the 'activation notification' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">https://html.spec.whatwg.org/multipage/interaction.html#activation-notification</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activation-notification">3.2. The showOpenFilePicker() method</a>
     <li><a href="#ref-for-activation-notification①">3.3. The showSaveFilePicker() method</a>
     <li><a href="#ref-for-activation-notification②">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">3.2. The showOpenFilePicker() method</a>
     <li><a href="#ref-for-window-bc①">3.3. The showSaveFilePicker() method</a>
     <li><a href="#ref-for-window-bc②">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deserialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deserialization-steps" class="dfn-panel" data-for="term-for-deserialization-steps" id="infopanel-for-term-for-deserialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-deserialization-steps" style="display:none">Info about the 'deserialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deserialization-steps">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-deserialization-steps①">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-deserialization-steps②">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.2. Permissions</a>
     <li><a href="#ref-for-concept-settings-object-global①">3.1. Local File System Permissions</a>
@@ -3233,8 +3233,8 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-concept-settings-object-global④">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.1. Concepts</a>
     <li><a href="#ref-for-in-parallel①">2.3.1. The isSameEntry() method</a>
@@ -3252,47 +3252,47 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-in-parallel①⑦">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-messageerror">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror">https://html.spec.whatwg.org/multipage/indices.html#event-messageerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-messageerror" class="dfn-panel" data-for="term-for-event-messageerror" id="infopanel-for-term-for-event-messageerror" role="menu">
+   <span id="infopaneltitle-for-term-for-event-messageerror" style="display:none">Info about the 'messageerror' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror">https://html.spec.whatwg.org/multipage/indices.html#event-messageerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-messageerror">6.3. First-party vs third-party contexts.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.2. Permissions</a>
     <li><a href="#ref-for-concept-settings-object-origin①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-concept-settings-object-origin②">(2)</a>
     <li><a href="#ref-for-concept-settings-object-origin③">3.1. Local File System Permissions</a> <a href="#ref-for-concept-settings-object-origin④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-ro">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-ro" class="dfn-panel" data-for="term-for-concept-dnd-ro" id="infopanel-for-term-for-concept-dnd-ro" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-ro" style="display:none">Info about the 'read-only mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-ro</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-ro">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-rw">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-rw" class="dfn-panel" data-for="term-for-concept-dnd-rw" id="infopanel-for-term-for-concept-dnd-rw" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-rw" style="display:none">Info about the 'read/write mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-rw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-rw">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">2.3.1. The isSameEntry() method</a>
     <li><a href="#ref-for-concept-relevant-realm①">2.4.2. The createWritable() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2.2. Permissions</a>
     <li><a href="#ref-for-relevant-settings-object①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-relevant-settings-object②">(2)</a>
@@ -3301,71 +3301,71 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-relevant-settings-object⑤">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.2. Permissions</a>
     <li><a href="#ref-for-same-origin①">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-same-origin②">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialization-steps" class="dfn-panel" data-for="term-for-serialization-steps" id="infopanel-for-term-for-serialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-serialization-steps" style="display:none">Info about the 'serialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialization-steps">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-serialization-steps①">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-serialization-steps②">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-drag-data-item-kind">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind">https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-drag-data-item-kind" class="dfn-panel" data-for="term-for-the-drag-data-item-kind" id="infopanel-for-term-for-the-drag-data-item-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-the-drag-data-item-kind" style="display:none">Info about the 'the drag data item kind' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind">https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-item-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-drag-data-item-kind">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">2.2. Permissions</a>
     <li><a href="#ref-for-concept-environment-top-level-origin①">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">2.2. Permissions</a>
     <li><a href="#ref-for-transient-activation①">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.1. Concepts</a>
     <li><a href="#ref-for-list-append①">3.4. FilePickerOptions.types</a> <a href="#ref-for-list-append②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.5.1. Directory iteration</a>
     <li><a href="#ref-for-set-append①">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-set-append②">2.5.3. The getDirectoryHandle() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-alphanumeric">
-   <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-alphanumeric" class="dfn-panel" data-for="term-for-ascii-alphanumeric" id="infopanel-for-term-for-ascii-alphanumeric" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-alphanumeric" style="display:none">Info about the 'ascii alphanumeric' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alphanumeric">2.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.1. Concepts</a>
     <li><a href="#ref-for-byte-sequence①">2.5.2. The getFileHandle() method</a>
@@ -3373,39 +3373,39 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-byte-sequence⑨">3.3. The showSaveFilePicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">2.1. Concepts</a>
     <li><a href="#ref-for-code-point①">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.1. Concepts</a>
     <li><a href="#ref-for-list-iterate①">2.5.2. The getFileHandle() method</a>
@@ -3415,51 +3415,51 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-list-iterate⑤">3.4. FilePickerOptions.types</a> <a href="#ref-for-list-iterate⑥">(2)</a> <a href="#ref-for-list-iterate⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3.4. FilePickerOptions.types</a> <a href="#ref-for-map-iterate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length (for byte sequence)' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-byte-sequence-length①">(2)</a> <a href="#ref-for-byte-sequence-length②">(3)</a> <a href="#ref-for-byte-sequence-length③">(4)</a> <a href="#ref-for-byte-sequence-length④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length (for string)' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.2. The showOpenFilePicker() method</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">2.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.1. Concepts</a>
     <li><a href="#ref-for-ordered-set①">2.5.1. Directory iteration</a>
@@ -3467,81 +3467,81 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-ordered-set③">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-starts-with">
-   <a href="https://infra.spec.whatwg.org/#string-starts-with">https://infra.spec.whatwg.org/#string-starts-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-starts-with" class="dfn-panel" data-for="term-for-string-starts-with" id="infopanel-for-term-for-string-starts-with" role="menu">
+   <span id="infopaneltitle-for-term-for-string-starts-with" style="display:none">Info about the 'starts with' external reference.</span><a href="https://infra.spec.whatwg.org/#string-starts-with">https://infra.spec.whatwg.org/#string-starts-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-starts-with">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.1. Concepts</a> <a href="#ref-for-string①">(2)</a>
     <li><a href="#ref-for-string②">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type-essence">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type-essence" class="dfn-panel" data-for="term-for-mime-type-essence" id="infopanel-for-term-for-mime-type-essence" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type-essence" style="display:none">Info about the 'essence' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type-essence">3.4. FilePickerOptions.types</a> <a href="#ref-for-mime-type-essence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parameters">
-   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parameters" class="dfn-panel" data-for="term-for-parameters" id="infopanel-for-term-for-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-parameters" style="display:none">Info about the 'parameters' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-mime-type" class="dfn-panel" data-for="term-for-parse-a-mime-type" id="infopanel-for-term-for-parse-a-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-mime-type" style="display:none">Info about the 'parse a mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type">3.4. FilePickerOptions.types</a> <a href="#ref-for-parse-a-mime-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subtype">
-   <a href="https://mimesniff.spec.whatwg.org/#subtype">https://mimesniff.spec.whatwg.org/#subtype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subtype" class="dfn-panel" data-for="term-for-subtype" id="infopanel-for-term-for-subtype" role="menu">
+   <span id="infopaneltitle-for-term-for-subtype" style="display:none">Info about the 'subtype' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#subtype">https://mimesniff.spec.whatwg.org/#subtype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subtype">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type">
-   <a href="https://mimesniff.spec.whatwg.org/#type">https://mimesniff.spec.whatwg.org/#type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type" class="dfn-panel" data-for="term-for-type" id="infopanel-for-term-for-type" role="menu">
+   <span id="infopaneltitle-for-term-for-type" style="display:none">Info about the 'type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#type">https://mimesniff.spec.whatwg.org/#type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type">3.4. FilePickerOptions.types</a> <a href="#ref-for-type①">(2)</a> <a href="#ref-for-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate" class="dfn-panel" data-for="term-for-dom-permissionstate" id="infopanel-for-term-for-dom-permissionstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate" style="display:none">Info about the 'PermissionState' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-permissionstate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-a-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus">https://w3c.github.io/permissions/#dfn-create-a-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-a-permissionstatus" class="dfn-panel" data-for="term-for-dfn-create-a-permissionstatus" id="infopanel-for-term-for-dfn-create-a-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-a-permissionstatus" style="display:none">Info about the 'create a permissionstatus' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus">https://w3c.github.io/permissions/#dfn-create-a-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-a-permissionstatus">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">2.2. Permissions</a> <a href="#ref-for-dom-permissionstate-granted①">(2)</a>
     <li><a href="#ref-for-dom-permissionstate-granted②">2.4.1. The getFile() method</a>
@@ -3554,211 +3554,211 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-dom-permissionstate-granted①①">3.1. Local File System Permissions</a> <a href="#ref-for-dom-permissionstate-granted①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">2.2. Permissions</a> <a href="#ref-for-dom-permissiondescriptor-name①">(2)</a>
     <li><a href="#ref-for-dom-permissiondescriptor-name②">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissiondescriptor-name③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">2.2. Permissions</a> <a href="#ref-for-dfn-permission-state①">(2)</a> <a href="#ref-for-dfn-permission-state②">(3)</a> <a href="#ref-for-dfn-permission-state③">(4)</a> <a href="#ref-for-dfn-permission-state④">(5)</a> <a href="#ref-for-dfn-permission-state⑤">(6)</a> <a href="#ref-for-dfn-permission-state⑥">(7)</a>
     <li><a href="#ref-for-dfn-permission-state⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dfn-permission-state⑧">(2)</a>
     <li><a href="#ref-for-dfn-permission-state⑨">3.1. Local File System Permissions</a> <a href="#ref-for-dfn-permission-state①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state-constraints">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state-constraints">https://w3c.github.io/permissions/#dfn-permission-state-constraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state-constraints" class="dfn-panel" data-for="term-for-dfn-permission-state-constraints" id="infopanel-for-term-for-dfn-permission-state-constraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state-constraints" style="display:none">Info about the 'permission state constraints' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state-constraints">https://w3c.github.io/permissions/#dfn-permission-state-constraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state-constraints">2.2. Permissions</a> <a href="#ref-for-dfn-permission-state-constraints①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-permissions">
-   <a href="https://w3c.github.io/permissions/#dom-navigator-permissions">https://w3c.github.io/permissions/#dom-navigator-permissions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-permissions" class="dfn-panel" data-for="term-for-dom-navigator-permissions" id="infopanel-for-term-for-dom-navigator-permissions" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-permissions" style="display:none">Info about the 'permissions' external reference.</span><a href="https://w3c.github.io/permissions/#dom-navigator-permissions">https://w3c.github.io/permissions/#dom-navigator-permissions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-permissions">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-navigator-permissions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-prompt">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-prompt" class="dfn-panel" data-for="term-for-dom-permissionstate-prompt" id="infopanel-for-term-for-dom-permissionstate-prompt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-prompt" style="display:none">Info about the 'prompt' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-prompt">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions-query">
-   <a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions-query" class="dfn-panel" data-for="term-for-dom-permissions-query" id="infopanel-for-term-for-dom-permissions-query" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions-query" style="display:none">Info about the 'query()' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-query">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissions-query①">(2)</a> <a href="#ref-for-dom-permissions-query②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">2.2. Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus-state" class="dfn-panel" data-for="term-for-dom-permissionstatus-state" id="infopanel-for-term-for-dom-permissionstatus-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus-state" style="display:none">Info about the 'state' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">2.2. Permissions</a>
     <li><a href="#ref-for-dom-permissionstatus-state①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-permissionstatus-state②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
-   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-request-algorithm" class="dfn-panel" data-for="term-for-permission-request-algorithm" id="infopanel-for-term-for-permission-request-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-request-algorithm" style="display:none">Info about the 'permission request algorithm' external reference.</span><a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">2.2. Permissions</a> <a href="#ref-for-permission-request-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storagemanager">
-   <a href="https://storage.spec.whatwg.org/#storagemanager">https://storage.spec.whatwg.org/#storagemanager</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storagemanager" class="dfn-panel" data-for="term-for-storagemanager" id="infopanel-for-term-for-storagemanager" role="menu">
+   <span id="infopaneltitle-for-term-for-storagemanager" style="display:none">Info about the 'StorageManager' external reference.</span><a href="https://storage.spec.whatwg.org/#storagemanager">https://storage.spec.whatwg.org/#storagemanager</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storagemanager">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-endpoint-identifier">
-   <a href="https://storage.spec.whatwg.org/#storage-endpoint-identifier">https://storage.spec.whatwg.org/#storage-endpoint-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-endpoint-identifier" class="dfn-panel" data-for="term-for-storage-endpoint-identifier" id="infopanel-for-term-for-storage-endpoint-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-endpoint-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-endpoint-identifier">https://storage.spec.whatwg.org/#storage-endpoint-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-identifier">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-local-storage-bottle-map">
-   <a href="https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map">https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-local-storage-bottle-map" class="dfn-panel" data-for="term-for-obtain-a-local-storage-bottle-map" id="infopanel-for-term-for-obtain-a-local-storage-bottle-map" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-local-storage-bottle-map" style="display:none">Info about the 'obtain a local storage bottle map' external reference.</span><a href="https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map">https://storage.spec.whatwg.org/#obtain-a-local-storage-bottle-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-local-storage-bottle-map">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-endpoint-quota">
-   <a href="https://storage.spec.whatwg.org/#storage-endpoint-quota">https://storage.spec.whatwg.org/#storage-endpoint-quota</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-endpoint-quota" class="dfn-panel" data-for="term-for-storage-endpoint-quota" id="infopanel-for-term-for-storage-endpoint-quota" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-endpoint-quota" style="display:none">Info about the 'quota' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-endpoint-quota">https://storage.spec.whatwg.org/#storage-endpoint-quota</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-quota">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-site-storage">
-   <a href="https://storage.spec.whatwg.org/#site-storage">https://storage.spec.whatwg.org/#site-storage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-site-storage" class="dfn-panel" data-for="term-for-site-storage" id="infopanel-for-term-for-site-storage" role="menu">
+   <span id="infopaneltitle-for-term-for-site-storage" style="display:none">Info about the 'storage' external reference.</span><a href="https://storage.spec.whatwg.org/#site-storage">https://storage.spec.whatwg.org/#site-storage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-site-storage">6.1. Users giving access to more, or more sensitive files than they intended.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-endpoint">
-   <a href="https://storage.spec.whatwg.org/#storage-endpoint">https://storage.spec.whatwg.org/#storage-endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-endpoint" class="dfn-panel" data-for="term-for-storage-endpoint" id="infopanel-for-term-for-storage-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-endpoint" style="display:none">Info about the 'storage endpoint' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-endpoint">https://storage.spec.whatwg.org/#storage-endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-quota">
-   <a href="https://storage.spec.whatwg.org/#storage-quota">https://storage.spec.whatwg.org/#storage-quota</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-quota" class="dfn-panel" data-for="term-for-storage-quota" id="infopanel-for-term-for-storage-quota" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-quota" style="display:none">Info about the 'storage quota' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-quota">https://storage.spec.whatwg.org/#storage-quota</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-quota">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-storage-quota①">(2)</a> <a href="#ref-for-storage-quota②">(3)</a> <a href="#ref-for-storage-quota③">(4)</a>
     <li><a href="#ref-for-storage-quota④">7.3. Filling up a users disk</a> <a href="#ref-for-storage-quota⑤">(2)</a> <a href="#ref-for-storage-quota⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-endpoint-types">
-   <a href="https://storage.spec.whatwg.org/#storage-endpoint-types">https://storage.spec.whatwg.org/#storage-endpoint-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-endpoint-types" class="dfn-panel" data-for="term-for-storage-endpoint-types" id="infopanel-for-term-for-storage-endpoint-types" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-endpoint-types" style="display:none">Info about the 'types' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-endpoint-types">https://storage.spec.whatwg.org/#storage-endpoint-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-types">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream">
-   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream" class="dfn-panel" data-for="term-for-writablestream" id="infopanel-for-term-for-writablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream" style="display:none">Info about the 'WritableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-writablestream①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter">
-   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter">https://streams.spec.whatwg.org/#writablestreamdefaultwriter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestreamdefaultwriter" class="dfn-panel" data-for="term-for-writablestreamdefaultwriter" id="infopanel-for-term-for-writablestreamdefaultwriter" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestreamdefaultwriter" style="display:none">Info about the 'WritableStreamDefaultWriter' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter">https://streams.spec.whatwg.org/#writablestreamdefaultwriter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-closealgorithm">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up-closealgorithm" class="dfn-panel" data-for="term-for-writablestream-set-up-closealgorithm" id="infopanel-for-term-for-writablestream-set-up-closealgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up-closealgorithm" style="display:none">Info about the 'closealgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-closealgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up-closealgorithm">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ws-get-writer">
-   <a href="https://streams.spec.whatwg.org/#ws-get-writer">https://streams.spec.whatwg.org/#ws-get-writer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ws-get-writer" class="dfn-panel" data-for="term-for-ws-get-writer" id="infopanel-for-term-for-ws-get-writer" role="menu">
+   <span id="infopaneltitle-for-term-for-ws-get-writer" style="display:none">Info about the 'getWriter()' external reference.</span><a href="https://streams.spec.whatwg.org/#ws-get-writer">https://streams.spec.whatwg.org/#ws-get-writer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-get-writer">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-get-a-writer">
-   <a href="https://streams.spec.whatwg.org/#writablestream-get-a-writer">https://streams.spec.whatwg.org/#writablestream-get-a-writer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-get-a-writer" class="dfn-panel" data-for="term-for-writablestream-get-a-writer" id="infopanel-for-term-for-writablestream-get-a-writer" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-get-a-writer" style="display:none">Info about the 'getting a writer' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-get-a-writer">https://streams.spec.whatwg.org/#writablestream-get-a-writer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-get-a-writer">2.6.1. The write() method</a>
     <li><a href="#ref-for-writablestream-get-a-writer①">2.6.2. The seek() method</a>
     <li><a href="#ref-for-writablestream-get-a-writer②">2.6.3. The truncate() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-highwatermark">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark">https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up-highwatermark" class="dfn-panel" data-for="term-for-writablestream-set-up-highwatermark" id="infopanel-for-term-for-writablestream-set-up-highwatermark" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up-highwatermark" style="display:none">Info about the 'highwatermark' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark">https://streams.spec.whatwg.org/#writablestream-set-up-highwatermark</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up-highwatermark">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-release">
-   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestreamdefaultwriter-release" class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-release" id="infopanel-for-term-for-writablestreamdefaultwriter-release" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestreamdefaultwriter-release" style="display:none">Info about the 'release' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-release">2.6.1. The write() method</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-release①">2.6.2. The seek() method</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-release②">2.6.3. The truncate() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up">https://streams.spec.whatwg.org/#writablestream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up" class="dfn-panel" data-for="term-for-writablestream-set-up" id="infopanel-for-term-for-writablestream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up" style="display:none">Info about the 'set up' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up">https://streams.spec.whatwg.org/#writablestream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-sizealgorithm">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up-sizealgorithm" class="dfn-panel" data-for="term-for-writablestream-set-up-sizealgorithm" id="infopanel-for-term-for-writablestream-set-up-sizealgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up-sizealgorithm" style="display:none">Info about the 'sizealgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-sizealgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up-sizealgorithm">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-writer-write">
-   <a href="https://streams.spec.whatwg.org/#default-writer-write">https://streams.spec.whatwg.org/#default-writer-write</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-writer-write" class="dfn-panel" data-for="term-for-default-writer-write" id="infopanel-for-term-for-default-writer-write" role="menu">
+   <span id="infopaneltitle-for-term-for-default-writer-write" style="display:none">Info about the 'write()' external reference.</span><a href="https://streams.spec.whatwg.org/#default-writer-write">https://streams.spec.whatwg.org/#default-writer-write</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-default-writer-write①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-writealgorithm">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up-writealgorithm" class="dfn-panel" data-for="term-for-writablestream-set-up-writealgorithm" id="infopanel-for-term-for-writablestream-set-up-writealgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up-writealgorithm" style="display:none">Info about the 'writealgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up-writealgorithm">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-write-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestreamdefaultwriter-write-a-chunk" class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-write-a-chunk" id="infopanel-for-term-for-writablestreamdefaultwriter-write-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestreamdefaultwriter-write-a-chunk" style="display:none">Info about the 'writing a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-write-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk">2.6.1. The write() method</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk①">2.6.2. The seek() method</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-write-a-chunk②">2.6.3. The truncate() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-aborterror①">3.2. The showOpenFilePicker() method</a> <a href="#ref-for-aborterror②">(2)</a>
@@ -3766,20 +3766,20 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-aborterror⑤">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-aborterror⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-BufferSource①">(2)</a> <a href="#ref-for-BufferSource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datacloneerror">
-   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datacloneerror" class="dfn-panel" data-for="term-for-datacloneerror" id="infopanel-for-term-for-datacloneerror" role="menu">
+   <span id="infopaneltitle-for-term-for-datacloneerror" style="display:none">Info about the 'DataCloneError' external reference.</span><a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacloneerror">2.3. The FileSystemHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-Exposed①">2.4. The FileSystemFileHandle interface</a>
@@ -3787,14 +3787,14 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-Exposed③">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">2.4.1. The getFile() method</a>
     <li><a href="#ref-for-notallowederror①">2.4.2. The createWritable() method</a>
@@ -3805,16 +3805,16 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-notallowederror⑦">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-notallowederror⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-notfounderror①">2.5.3. The getDirectoryHandle() method</a>
     <li><a href="#ref-for-notfounderror②">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.3. The FileSystemHandle interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
     <li><a href="#ref-for-idl-promise③">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-idl-promise④">(2)</a>
@@ -3825,14 +3825,14 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-idl-promise①⑥">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-quotaexceedederror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-SecureContext①">2.4. The FileSystemFileHandle interface</a>
@@ -3842,16 +3842,16 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-SecureContext⑤">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.2. Permissions</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
     <li><a href="#ref-for-securityerror③">3.1. Local File System Permissions</a> <a href="#ref-for-securityerror④">(2)</a> <a href="#ref-for-securityerror⑤">(3)</a>
     <li><a href="#ref-for-securityerror⑥">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">2.5.3. The getDirectoryHandle() method</a>
@@ -3860,15 +3860,15 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-exceptiondef-typeerror⑥">3.4. FilePickerOptions.types</a> <a href="#ref-for-exceptiondef-typeerror⑦">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑧">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑨">(4)</a> <a href="#ref-for-exceptiondef-typeerror①⓪">(5)</a> <a href="#ref-for-exceptiondef-typeerror①①">(6)</a> <a href="#ref-for-exceptiondef-typeerror①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typemismatcherror">
-   <a href="https://webidl.spec.whatwg.org/#typemismatcherror">https://webidl.spec.whatwg.org/#typemismatcherror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typemismatcherror" class="dfn-panel" data-for="term-for-typemismatcherror" id="infopanel-for-term-for-typemismatcherror" role="menu">
+   <span id="infopaneltitle-for-term-for-typemismatcherror" style="display:none">Info about the 'TypeMismatchError' external reference.</span><a href="https://webidl.spec.whatwg.org/#typemismatcherror">https://webidl.spec.whatwg.org/#typemismatcherror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typemismatcherror">2.5.2. The getFileHandle() method</a>
     <li><a href="#ref-for-typemismatcherror①">2.5.3. The getDirectoryHandle() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-idl-USVString①">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-idl-USVString②">(2)</a> <a href="#ref-for-idl-USVString③">(3)</a> <a href="#ref-for-idl-USVString④">(4)</a> <a href="#ref-for-idl-USVString⑤">(5)</a>
@@ -3876,8 +3876,8 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-idl-USVString⑨">3. Accessing Local File System</a> <a href="#ref-for-idl-USVString①⓪">(2)</a> <a href="#ref-for-idl-USVString①①">(3)</a> <a href="#ref-for-idl-USVString①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">2.1. Concepts</a>
     <li><a href="#ref-for-a-new-promise①">2.3.1. The isSameEntry() method</a>
@@ -3896,29 +3896,29 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-a-new-promise①⑤">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-a-promise-rejected-with①">3.1. Local File System Permissions</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a>
     <li><a href="#ref-for-a-promise-rejected-with③">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">3.6. Drag and Drop</a> <a href="#ref-for-a-promise-resolved-with①">(2)</a>
     <li><a href="#ref-for-a-promise-resolved-with②">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps">
-   <a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps" id="infopanel-for-term-for-asynchronous-iterator-initialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" style="display:none">Info about the 'asynchronous iterator initialization steps' external reference.</span><a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-initialization-steps">2.5.1. Directory iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-idl-boolean①">2.4. The FileSystemFileHandle interface</a>
@@ -3926,32 +3926,32 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-idl-boolean⑤">3. Accessing Local File System</a> <a href="#ref-for-idl-boolean⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result" id="infopanel-for-term-for-dfn-get-the-next-iteration-result" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" style="display:none">Info about the 'get the next iteration result' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-the-next-iteration-result">2.5.1. Directory iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2.3.3. The requestPermission() method</a>
     <li><a href="#ref-for-reject①">2.4.2. The createWritable() method</a>
@@ -3964,8 +3964,8 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-reject②⑧">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-reject②⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">2.1. Concepts</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
     <li><a href="#ref-for-resolve③">2.3.1. The isSameEntry() method</a> <a href="#ref-for-resolve④">(2)</a>
@@ -3984,15 +3984,15 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-resolve②③">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-idl-sequence①">3. Accessing Local File System</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-sequence③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">2.3.1. The isSameEntry() method</a> <a href="#ref-for-this①">(2)</a>
     <li><a href="#ref-for-this②">2.3.2. The queryPermission() method</a>
@@ -4011,27 +4011,27 @@ use this API to write to disk.</p>
     <li><a href="#ref-for-this②③">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-idl-undefined①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-undefined②">(2)</a> <a href="#ref-for-idl-undefined③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">2.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wait-for-all">
-   <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wait-for-all" class="dfn-panel" data-for="term-for-wait-for-all" id="infopanel-for-term-for-wait-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-wait-for-all" style="display:none">Info about the 'wait for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">2.1. Concepts</a>
    </ul>
@@ -4399,8 +4399,8 @@ with the <a data-link-type="dfn" href="#local-file-system-handle-factories">loca
    <div class="issue"> Storage endpoints should be defined in <a data-link-type="biblio" href="#biblio-storage" title="Storage Standard">[storage]</a> itself, rather
 than being defined here. So merge this into the table there. <a class="issue-return" href="#issue-9c98e739" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="entry">
-   <b><a href="#entry">#entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry" class="dfn-panel" data-for="entry" id="infopanel-for-entry" role="dialog">
+   <span id="infopaneltitle-for-entry" style="display:none">Info about the 'entry' definition.</span><b><a href="#entry">#entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry">2.1. Concepts</a> <a href="#ref-for-entry①">(2)</a> <a href="#ref-for-entry②">(3)</a> <a href="#ref-for-entry③">(4)</a> <a href="#ref-for-entry④">(5)</a> <a href="#ref-for-entry⑤">(6)</a> <a href="#ref-for-entry⑥">(7)</a> <a href="#ref-for-entry⑦">(8)</a> <a href="#ref-for-entry⑧">(9)</a>
     <li><a href="#ref-for-entry⑨">2.2. Permissions</a>
@@ -4409,8 +4409,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-entry①④">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-name">
-   <b><a href="#entry-name">#entry-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-name" class="dfn-panel" data-for="entry-name" id="infopanel-for-entry-name" role="dialog">
+   <span id="infopaneltitle-for-entry-name" style="display:none">Info about the 'name' definition.</span><b><a href="#entry-name">#entry-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-name">2.1. Concepts</a>
     <li><a href="#ref-for-entry-name①">2.3. The FileSystemHandle interface</a> <a href="#ref-for-entry-name②">(2)</a>
@@ -4422,8 +4422,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-entry-name①③">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-file-name">
-   <b><a href="#valid-file-name">#valid-file-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-file-name" class="dfn-panel" data-for="valid-file-name" id="infopanel-for-valid-file-name" role="dialog">
+   <span id="infopaneltitle-for-valid-file-name" style="display:none">Info about the 'valid file name' definition.</span><b><a href="#valid-file-name">#valid-file-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-file-name">2.1. Concepts</a>
     <li><a href="#ref-for-valid-file-name①">2.5.2. The getFileHandle() method</a>
@@ -4431,14 +4431,14 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-valid-file-name③">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-suffix-code-point">
-   <b><a href="#valid-suffix-code-point">#valid-suffix-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-suffix-code-point" class="dfn-panel" data-for="valid-suffix-code-point" id="infopanel-for-valid-suffix-code-point" role="dialog">
+   <span id="infopaneltitle-for-valid-suffix-code-point" style="display:none">Info about the 'valid suffix code point' definition.</span><b><a href="#valid-suffix-code-point">#valid-suffix-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-suffix-code-point">3.4. FilePickerOptions.types</a> <a href="#ref-for-valid-suffix-code-point①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file">
-   <b><a href="#file">#file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file" class="dfn-panel" data-for="file" id="infopanel-for-file" role="dialog">
+   <span id="infopaneltitle-for-file" style="display:none">Info about the 'file entry' definition.</span><b><a href="#file">#file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file">2.1. Concepts</a> <a href="#ref-for-file①">(2)</a>
     <li><a href="#ref-for-file②">2.3. The FileSystemHandle interface</a>
@@ -4452,8 +4452,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-file①①">3.6. Drag and Drop</a> <a href="#ref-for-file①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-entry-binary-data">
-   <b><a href="#file-entry-binary-data">#file-entry-binary-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-entry-binary-data" class="dfn-panel" data-for="file-entry-binary-data" id="infopanel-for-file-entry-binary-data" role="dialog">
+   <span id="infopaneltitle-for-file-entry-binary-data" style="display:none">Info about the 'binary data' definition.</span><b><a href="#file-entry-binary-data">#file-entry-binary-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-entry-binary-data">2.1. Concepts</a>
     <li><a href="#ref-for-file-entry-binary-data①">2.4.1. The getFile() method</a>
@@ -4463,16 +4463,16 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-file-entry-binary-data⑤">3.3. The showSaveFilePicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-entry-modification-timestamp">
-   <b><a href="#file-entry-modification-timestamp">#file-entry-modification-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-entry-modification-timestamp" class="dfn-panel" data-for="file-entry-modification-timestamp" id="infopanel-for-file-entry-modification-timestamp" role="dialog">
+   <span id="infopaneltitle-for-file-entry-modification-timestamp" style="display:none">Info about the 'modification timestamp' definition.</span><b><a href="#file-entry-modification-timestamp">#file-entry-modification-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-entry-modification-timestamp">2.1. Concepts</a>
     <li><a href="#ref-for-file-entry-modification-timestamp①">2.4.1. The getFile() method</a>
     <li><a href="#ref-for-file-entry-modification-timestamp②">2.5.2. The getFileHandle() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory">
-   <b><a href="#directory">#directory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory" class="dfn-panel" data-for="directory" id="infopanel-for-directory" role="dialog">
+   <span id="infopaneltitle-for-directory" style="display:none">Info about the 'directory entry' definition.</span><b><a href="#directory">#directory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory">2.1. Concepts</a> <a href="#ref-for-directory①">(2)</a> <a href="#ref-for-directory②">(3)</a> <a href="#ref-for-directory③">(4)</a>
     <li><a href="#ref-for-directory④">2.5. The FileSystemDirectoryHandle interface</a>
@@ -4484,8 +4484,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-directory①①">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directory-entry-children">
-   <b><a href="#directory-entry-children">#directory-entry-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directory-entry-children" class="dfn-panel" data-for="directory-entry-children" id="infopanel-for-directory-entry-children" role="dialog">
+   <span id="infopaneltitle-for-directory-entry-children" style="display:none">Info about the 'children' definition.</span><b><a href="#directory-entry-children">#directory-entry-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directory-entry-children">2.1. Concepts</a> <a href="#ref-for-directory-entry-children①">(2)</a> <a href="#ref-for-directory-entry-children②">(3)</a>
     <li><a href="#ref-for-directory-entry-children③">2.5.1. Directory iteration</a>
@@ -4495,42 +4495,42 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-directory-entry-children①②">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-parent">
-   <b><a href="#entry-parent">#entry-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-parent" class="dfn-panel" data-for="entry-parent" id="infopanel-for-entry-parent" role="dialog">
+   <span id="infopaneltitle-for-entry-parent" style="display:none">Info about the 'parent' definition.</span><b><a href="#entry-parent">#entry-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-parent">2.1. Concepts</a>
     <li><a href="#ref-for-entry-parent①">2.2. Permissions</a> <a href="#ref-for-entry-parent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-the-same-as">
-   <b><a href="#entry-the-same-as">#entry-the-same-as</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-the-same-as" class="dfn-panel" data-for="entry-the-same-as" id="infopanel-for-entry-the-same-as" role="dialog">
+   <span id="infopaneltitle-for-entry-the-same-as" style="display:none">Info about the 'the same as' definition.</span><b><a href="#entry-the-same-as">#entry-the-same-as</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-the-same-as">2.1. Concepts</a>
     <li><a href="#ref-for-entry-the-same-as①">2.3.1. The isSameEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-resolve">
-   <b><a href="#entry-resolve">#entry-resolve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-resolve" class="dfn-panel" data-for="entry-resolve" id="infopanel-for-entry-resolve" role="dialog">
+   <span id="infopaneltitle-for-entry-resolve" style="display:none">Info about the 'resolve' definition.</span><b><a href="#entry-resolve">#entry-resolve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-resolve">2.1. Concepts</a>
     <li><a href="#ref-for-entry-resolve①">2.5.5. The resolve() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-file-system">
-   <b><a href="#dom-permissionname-file-system">#dom-permissionname-file-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-file-system" class="dfn-panel" data-for="dom-permissionname-file-system" id="infopanel-for-dom-permissionname-file-system" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-file-system" style="display:none">Info about the '"file-system"' definition.</span><b><a href="#dom-permissionname-file-system">#dom-permissionname-file-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-file-system">2.2. Permissions</a> <a href="#ref-for-dom-permissionname-file-system①">(2)</a> <a href="#ref-for-dom-permissionname-file-system②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-filesystempermissionmode">
-   <b><a href="#enumdef-filesystempermissionmode">#enumdef-filesystempermissionmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-filesystempermissionmode" class="dfn-panel" data-for="enumdef-filesystempermissionmode" id="infopanel-for-enumdef-filesystempermissionmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-filesystempermissionmode" style="display:none">Info about the 'FileSystemPermissionMode' definition.</span><b><a href="#enumdef-filesystempermissionmode">#enumdef-filesystempermissionmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-filesystempermissionmode">2.2. Permissions</a> <a href="#ref-for-enumdef-filesystempermissionmode①">(2)</a> <a href="#ref-for-enumdef-filesystempermissionmode②">(3)</a> <a href="#ref-for-enumdef-filesystempermissionmode③">(4)</a>
     <li><a href="#ref-for-enumdef-filesystempermissionmode④">2.3. The FileSystemHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystempermissionmode-read">
-   <b><a href="#dom-filesystempermissionmode-read">#dom-filesystempermissionmode-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystempermissionmode-read" class="dfn-panel" data-for="dom-filesystempermissionmode-read" id="infopanel-for-dom-filesystempermissionmode-read" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystempermissionmode-read" style="display:none">Info about the '"read"' definition.</span><b><a href="#dom-filesystempermissionmode-read">#dom-filesystempermissionmode-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystempermissionmode-read">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissionmode-read①">(2)</a>
     <li><a href="#ref-for-dom-filesystempermissionmode-read②">2.3.2. The queryPermission() method</a>
@@ -4542,8 +4542,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystempermissionmode-read⑨">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystempermissionmode-readwrite">
-   <b><a href="#dom-filesystempermissionmode-readwrite">#dom-filesystempermissionmode-readwrite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystempermissionmode-readwrite" class="dfn-panel" data-for="dom-filesystempermissionmode-readwrite" id="infopanel-for-dom-filesystempermissionmode-readwrite" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystempermissionmode-readwrite" style="display:none">Info about the '"readwrite"' definition.</span><b><a href="#dom-filesystempermissionmode-readwrite">#dom-filesystempermissionmode-readwrite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystempermissionmode-readwrite">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissionmode-readwrite①">(2)</a>
     <li><a href="#ref-for-dom-filesystempermissionmode-readwrite②">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystempermissionmode-readwrite③">(2)</a>
@@ -4556,15 +4556,15 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystempermissionmode-readwrite①①">3.1. Local File System Permissions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystempermissiondescriptor">
-   <b><a href="#dictdef-filesystempermissiondescriptor">#dictdef-filesystempermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystempermissiondescriptor" class="dfn-panel" data-for="dictdef-filesystempermissiondescriptor" id="infopanel-for-dictdef-filesystempermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystempermissiondescriptor" style="display:none">Info about the 'FileSystemPermissionDescriptor' definition.</span><b><a href="#dictdef-filesystempermissiondescriptor">#dictdef-filesystempermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystempermissiondescriptor">2.2. Permissions</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor①">(2)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor②">(3)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor③">(4)</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor④">(5)</a>
     <li><a href="#ref-for-dictdef-filesystempermissiondescriptor⑤">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dictdef-filesystempermissiondescriptor⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystempermissiondescriptor-handle">
-   <b><a href="#dom-filesystempermissiondescriptor-handle">#dom-filesystempermissiondescriptor-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystempermissiondescriptor-handle" class="dfn-panel" data-for="dom-filesystempermissiondescriptor-handle" id="infopanel-for-dom-filesystempermissiondescriptor-handle" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystempermissiondescriptor-handle" style="display:none">Info about the 'handle' definition.</span><b><a href="#dom-filesystempermissiondescriptor-handle">#dom-filesystempermissiondescriptor-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle①">(2)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle②">(3)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle③">(4)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle④">(5)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle⑤">(6)</a>
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle⑥">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle⑦">(2)</a>
@@ -4572,8 +4572,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-handle①⓪">3.1. Local File System Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-handle①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystempermissiondescriptor-mode">
-   <b><a href="#dom-filesystempermissiondescriptor-mode">#dom-filesystempermissiondescriptor-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystempermissiondescriptor-mode" class="dfn-panel" data-for="dom-filesystempermissiondescriptor-mode" id="infopanel-for-dom-filesystempermissiondescriptor-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystempermissiondescriptor-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-filesystempermissiondescriptor-mode">#dom-filesystempermissiondescriptor-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode">2.2. Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode①">(2)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode②">(3)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode③">(4)</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode④">(5)</a>
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode⑤">2.3.2. The queryPermission() method</a>
@@ -4581,8 +4581,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystempermissiondescriptor-mode⑧">3.1. Local File System Permissions</a> <a href="#ref-for-dom-filesystempermissiondescriptor-mode⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="querying-file-system-permission">
-   <b><a href="#querying-file-system-permission">#querying-file-system-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-querying-file-system-permission" class="dfn-panel" data-for="querying-file-system-permission" id="infopanel-for-querying-file-system-permission" role="dialog">
+   <span id="infopaneltitle-for-querying-file-system-permission" style="display:none">Info about the 'query file system permission' definition.</span><b><a href="#querying-file-system-permission">#querying-file-system-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-querying-file-system-permission">2.3.2. The queryPermission() method</a>
     <li><a href="#ref-for-querying-file-system-permission①">2.4.1. The getFile() method</a>
@@ -4591,8 +4591,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-querying-file-system-permission⑤">2.5.3. The getDirectoryHandle() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requesting-file-system-permission">
-   <b><a href="#requesting-file-system-permission">#requesting-file-system-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requesting-file-system-permission" class="dfn-panel" data-for="requesting-file-system-permission" id="infopanel-for-requesting-file-system-permission" role="dialog">
+   <span id="infopaneltitle-for-requesting-file-system-permission" style="display:none">Info about the 'request file system permission' definition.</span><b><a href="#requesting-file-system-permission">#requesting-file-system-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requesting-file-system-permission">2.3.3. The requestPermission() method</a>
     <li><a href="#ref-for-requesting-file-system-permission①">2.4.2. The createWritable() method</a>
@@ -4601,39 +4601,39 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-requesting-file-system-permission④">2.5.4. The removeEntry() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemhandlepermissiondescriptor">
-   <b><a href="#dictdef-filesystemhandlepermissiondescriptor">#dictdef-filesystemhandlepermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemhandlepermissiondescriptor" class="dfn-panel" data-for="dictdef-filesystemhandlepermissiondescriptor" id="infopanel-for-dictdef-filesystemhandlepermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemhandlepermissiondescriptor" style="display:none">Info about the 'FileSystemHandlePermissionDescriptor' definition.</span><b><a href="#dictdef-filesystemhandlepermissiondescriptor">#dictdef-filesystemhandlepermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemhandlepermissiondescriptor">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dictdef-filesystemhandlepermissiondescriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandlepermissiondescriptor-mode">
-   <b><a href="#dom-filesystemhandlepermissiondescriptor-mode">#dom-filesystemhandlepermissiondescriptor-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandlepermissiondescriptor-mode" class="dfn-panel" data-for="dom-filesystemhandlepermissiondescriptor-mode" id="infopanel-for-dom-filesystemhandlepermissiondescriptor-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandlepermissiondescriptor-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-filesystemhandlepermissiondescriptor-mode">#dom-filesystemhandlepermissiondescriptor-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode①">(2)</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode②">(3)</a>
     <li><a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode③">2.3.3. The requestPermission() method</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode④">(2)</a> <a href="#ref-for-dom-filesystemhandlepermissiondescriptor-mode⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-filesystemhandlekind">
-   <b><a href="#enumdef-filesystemhandlekind">#enumdef-filesystemhandlekind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-filesystemhandlekind" class="dfn-panel" data-for="enumdef-filesystemhandlekind" id="infopanel-for-enumdef-filesystemhandlekind" role="dialog">
+   <span id="infopaneltitle-for-enumdef-filesystemhandlekind" style="display:none">Info about the 'FileSystemHandleKind' definition.</span><b><a href="#enumdef-filesystemhandlekind">#enumdef-filesystemhandlekind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-filesystemhandlekind">2.3. The FileSystemHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandlekind-file">
-   <b><a href="#dom-filesystemhandlekind-file">#dom-filesystemhandlekind-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandlekind-file" class="dfn-panel" data-for="dom-filesystemhandlekind-file" id="infopanel-for-dom-filesystemhandlekind-file" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandlekind-file" style="display:none">Info about the '"file"' definition.</span><b><a href="#dom-filesystemhandlekind-file">#dom-filesystemhandlekind-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandlekind-file">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandlekind-file①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandlekind-directory">
-   <b><a href="#dom-filesystemhandlekind-directory">#dom-filesystemhandlekind-directory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandlekind-directory" class="dfn-panel" data-for="dom-filesystemhandlekind-directory" id="infopanel-for-dom-filesystemhandlekind-directory" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandlekind-directory" style="display:none">Info about the '"directory"' definition.</span><b><a href="#dom-filesystemhandlekind-directory">#dom-filesystemhandlekind-directory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandlekind-directory">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandlekind-directory①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemhandle">
-   <b><a href="#filesystemhandle">#filesystemhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemhandle" class="dfn-panel" data-for="filesystemhandle" id="infopanel-for-filesystemhandle" role="dialog">
+   <span id="infopaneltitle-for-filesystemhandle" style="display:none">Info about the 'FileSystemHandle' definition.</span><b><a href="#filesystemhandle">#filesystemhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemhandle">2.2. Permissions</a> <a href="#ref-for-filesystemhandle①">(2)</a> <a href="#ref-for-filesystemhandle②">(3)</a>
     <li><a href="#ref-for-filesystemhandle③">2.3. The FileSystemHandle interface</a> <a href="#ref-for-filesystemhandle④">(2)</a> <a href="#ref-for-filesystemhandle⑤">(3)</a> <a href="#ref-for-filesystemhandle⑥">(4)</a> <a href="#ref-for-filesystemhandle⑦">(5)</a> <a href="#ref-for-filesystemhandle⑧">(6)</a>
@@ -4642,8 +4642,8 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-filesystemhandle①⑤">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemhandle-entry">
-   <b><a href="#filesystemhandle-entry">#filesystemhandle-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemhandle-entry" class="dfn-panel" data-for="filesystemhandle-entry" id="infopanel-for-filesystemhandle-entry" role="dialog">
+   <span id="infopaneltitle-for-filesystemhandle-entry" style="display:none">Info about the 'entry' definition.</span><b><a href="#filesystemhandle-entry">#filesystemhandle-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemhandle-entry">2.1. Concepts</a>
     <li><a href="#ref-for-filesystemhandle-entry①">2.2. Permissions</a>
@@ -4661,34 +4661,34 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-filesystemhandle-entry②②">4. Accessing the Origin Private File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandle-kind">
-   <b><a href="#dom-filesystemhandle-kind">#dom-filesystemhandle-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandle-kind" class="dfn-panel" data-for="dom-filesystemhandle-kind" id="infopanel-for-dom-filesystemhandle-kind" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandle-kind" style="display:none">Info about the 'kind' definition.</span><b><a href="#dom-filesystemhandle-kind">#dom-filesystemhandle-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandle-kind">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandle-kind①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandle-name">
-   <b><a href="#dom-filesystemhandle-name">#dom-filesystemhandle-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandle-name" class="dfn-panel" data-for="dom-filesystemhandle-name" id="infopanel-for-dom-filesystemhandle-name" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandle-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-filesystemhandle-name">#dom-filesystemhandle-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandle-name">2.3. The FileSystemHandle interface</a> <a href="#ref-for-dom-filesystemhandle-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandle-issameentry">
-   <b><a href="#dom-filesystemhandle-issameentry">#dom-filesystemhandle-issameentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandle-issameentry" class="dfn-panel" data-for="dom-filesystemhandle-issameentry" id="infopanel-for-dom-filesystemhandle-issameentry" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandle-issameentry" style="display:none">Info about the 'isSameEntry(other)' definition.</span><b><a href="#dom-filesystemhandle-issameentry">#dom-filesystemhandle-issameentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandle-issameentry">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-dom-filesystemhandle-issameentry①">2.3.1. The isSameEntry() method</a> <a href="#ref-for-dom-filesystemhandle-issameentry②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandle-querypermission">
-   <b><a href="#dom-filesystemhandle-querypermission">#dom-filesystemhandle-querypermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandle-querypermission" class="dfn-panel" data-for="dom-filesystemhandle-querypermission" id="infopanel-for-dom-filesystemhandle-querypermission" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandle-querypermission" style="display:none">Info about the 'queryPermission(descriptor)' definition.</span><b><a href="#dom-filesystemhandle-querypermission">#dom-filesystemhandle-querypermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandle-querypermission">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-dom-filesystemhandle-querypermission①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandle-querypermission②">(2)</a> <a href="#ref-for-dom-filesystemhandle-querypermission③">(3)</a> <a href="#ref-for-dom-filesystemhandle-querypermission④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemhandle-requestpermission">
-   <b><a href="#dom-filesystemhandle-requestpermission">#dom-filesystemhandle-requestpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemhandle-requestpermission" class="dfn-panel" data-for="dom-filesystemhandle-requestpermission" id="infopanel-for-dom-filesystemhandle-requestpermission" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemhandle-requestpermission" style="display:none">Info about the 'requestPermission(descriptor)' definition.</span><b><a href="#dom-filesystemhandle-requestpermission">#dom-filesystemhandle-requestpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemhandle-requestpermission">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-dom-filesystemhandle-requestpermission①">2.3.2. The queryPermission() method</a> <a href="#ref-for-dom-filesystemhandle-requestpermission②">(2)</a>
@@ -4696,20 +4696,20 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-filesystemhandle-requestpermission⑦">6.3. First-party vs third-party contexts.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemcreatewritableoptions">
-   <b><a href="#dictdef-filesystemcreatewritableoptions">#dictdef-filesystemcreatewritableoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemcreatewritableoptions" class="dfn-panel" data-for="dictdef-filesystemcreatewritableoptions" id="infopanel-for-dictdef-filesystemcreatewritableoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemcreatewritableoptions" style="display:none">Info about the 'FileSystemCreateWritableOptions' definition.</span><b><a href="#dictdef-filesystemcreatewritableoptions">#dictdef-filesystemcreatewritableoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemcreatewritableoptions">2.4. The FileSystemFileHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemcreatewritableoptions-keepexistingdata">
-   <b><a href="#dom-filesystemcreatewritableoptions-keepexistingdata">#dom-filesystemcreatewritableoptions-keepexistingdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemcreatewritableoptions-keepexistingdata" class="dfn-panel" data-for="dom-filesystemcreatewritableoptions-keepexistingdata" id="infopanel-for-dom-filesystemcreatewritableoptions-keepexistingdata" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemcreatewritableoptions-keepexistingdata" style="display:none">Info about the 'keepExistingData' definition.</span><b><a href="#dom-filesystemcreatewritableoptions-keepexistingdata">#dom-filesystemcreatewritableoptions-keepexistingdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata">2.4.2. The createWritable() method</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata①">(2)</a> <a href="#ref-for-dom-filesystemcreatewritableoptions-keepexistingdata②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemfilehandle">
-   <b><a href="#filesystemfilehandle">#filesystemfilehandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemfilehandle" class="dfn-panel" data-for="filesystemfilehandle" id="infopanel-for-filesystemfilehandle" role="dialog">
+   <span id="infopaneltitle-for-filesystemfilehandle" style="display:none">Info about the 'FileSystemFileHandle' definition.</span><b><a href="#filesystemfilehandle">#filesystemfilehandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemfilehandle">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-filesystemfilehandle①">2.4. The FileSystemFileHandle interface</a> <a href="#ref-for-filesystemfilehandle②">(2)</a> <a href="#ref-for-filesystemfilehandle③">(3)</a>
@@ -4722,59 +4722,59 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-filesystemfilehandle①②">3.6. Drag and Drop</a> <a href="#ref-for-filesystemfilehandle①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemfilehandle-getfile">
-   <b><a href="#dom-filesystemfilehandle-getfile">#dom-filesystemfilehandle-getfile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemfilehandle-getfile" class="dfn-panel" data-for="dom-filesystemfilehandle-getfile" id="infopanel-for-dom-filesystemfilehandle-getfile" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemfilehandle-getfile" style="display:none">Info about the 'getFile()' definition.</span><b><a href="#dom-filesystemfilehandle-getfile">#dom-filesystemfilehandle-getfile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemfilehandle-getfile">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-dom-filesystemfilehandle-getfile①">2.4.1. The getFile() method</a> <a href="#ref-for-dom-filesystemfilehandle-getfile②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemfilehandle-createwritable">
-   <b><a href="#dom-filesystemfilehandle-createwritable">#dom-filesystemfilehandle-createwritable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemfilehandle-createwritable" class="dfn-panel" data-for="dom-filesystemfilehandle-createwritable" id="infopanel-for-dom-filesystemfilehandle-createwritable" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemfilehandle-createwritable" style="display:none">Info about the 'createWritable(options)' definition.</span><b><a href="#dom-filesystemfilehandle-createwritable">#dom-filesystemfilehandle-createwritable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemfilehandle-createwritable">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-dom-filesystemfilehandle-createwritable①">2.4.2. The createWritable() method</a> <a href="#ref-for-dom-filesystemfilehandle-createwritable②">(2)</a> <a href="#ref-for-dom-filesystemfilehandle-createwritable③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemgetfileoptions">
-   <b><a href="#dictdef-filesystemgetfileoptions">#dictdef-filesystemgetfileoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemgetfileoptions" class="dfn-panel" data-for="dictdef-filesystemgetfileoptions" id="infopanel-for-dictdef-filesystemgetfileoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemgetfileoptions" style="display:none">Info about the 'FileSystemGetFileOptions' definition.</span><b><a href="#dictdef-filesystemgetfileoptions">#dictdef-filesystemgetfileoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemgetfileoptions">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemgetfileoptions-create">
-   <b><a href="#dom-filesystemgetfileoptions-create">#dom-filesystemgetfileoptions-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemgetfileoptions-create" class="dfn-panel" data-for="dom-filesystemgetfileoptions-create" id="infopanel-for-dom-filesystemgetfileoptions-create" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemgetfileoptions-create" style="display:none">Info about the 'create' definition.</span><b><a href="#dom-filesystemgetfileoptions-create">#dom-filesystemgetfileoptions-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemgetfileoptions-create">2.5.2. The getFileHandle() method</a> <a href="#ref-for-dom-filesystemgetfileoptions-create①">(2)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create②">(3)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create③">(4)</a> <a href="#ref-for-dom-filesystemgetfileoptions-create④">(5)</a>
     <li><a href="#ref-for-dom-filesystemgetfileoptions-create⑤">2.5.3. The getDirectoryHandle() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemgetdirectoryoptions">
-   <b><a href="#dictdef-filesystemgetdirectoryoptions">#dictdef-filesystemgetdirectoryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemgetdirectoryoptions" class="dfn-panel" data-for="dictdef-filesystemgetdirectoryoptions" id="infopanel-for-dictdef-filesystemgetdirectoryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemgetdirectoryoptions" style="display:none">Info about the 'FileSystemGetDirectoryOptions' definition.</span><b><a href="#dictdef-filesystemgetdirectoryoptions">#dictdef-filesystemgetdirectoryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemgetdirectoryoptions">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemgetdirectoryoptions-create">
-   <b><a href="#dom-filesystemgetdirectoryoptions-create">#dom-filesystemgetdirectoryoptions-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemgetdirectoryoptions-create" class="dfn-panel" data-for="dom-filesystemgetdirectoryoptions-create" id="infopanel-for-dom-filesystemgetdirectoryoptions-create" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemgetdirectoryoptions-create" style="display:none">Info about the 'create' definition.</span><b><a href="#dom-filesystemgetdirectoryoptions-create">#dom-filesystemgetdirectoryoptions-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemgetdirectoryoptions-create">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create①">(2)</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create②">(3)</a> <a href="#ref-for-dom-filesystemgetdirectoryoptions-create③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filesystemremoveoptions">
-   <b><a href="#dictdef-filesystemremoveoptions">#dictdef-filesystemremoveoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filesystemremoveoptions" class="dfn-panel" data-for="dictdef-filesystemremoveoptions" id="infopanel-for-dictdef-filesystemremoveoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filesystemremoveoptions" style="display:none">Info about the 'FileSystemRemoveOptions' definition.</span><b><a href="#dictdef-filesystemremoveoptions">#dictdef-filesystemremoveoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filesystemremoveoptions">2.5. The FileSystemDirectoryHandle interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemremoveoptions-recursive">
-   <b><a href="#dom-filesystemremoveoptions-recursive">#dom-filesystemremoveoptions-recursive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemremoveoptions-recursive" class="dfn-panel" data-for="dom-filesystemremoveoptions-recursive" id="infopanel-for-dom-filesystemremoveoptions-recursive" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemremoveoptions-recursive" style="display:none">Info about the 'recursive' definition.</span><b><a href="#dom-filesystemremoveoptions-recursive">#dom-filesystemremoveoptions-recursive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemremoveoptions-recursive">2.5.4. The removeEntry() method</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive①">(2)</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive②">(3)</a> <a href="#ref-for-dom-filesystemremoveoptions-recursive③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemdirectoryhandle">
-   <b><a href="#filesystemdirectoryhandle">#filesystemdirectoryhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemdirectoryhandle" class="dfn-panel" data-for="filesystemdirectoryhandle" id="infopanel-for-filesystemdirectoryhandle" role="dialog">
+   <span id="infopaneltitle-for-filesystemdirectoryhandle" style="display:none">Info about the 'FileSystemDirectoryHandle' definition.</span><b><a href="#filesystemdirectoryhandle">#filesystemdirectoryhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemdirectoryhandle">2.3. The FileSystemHandle interface</a>
     <li><a href="#ref-for-filesystemdirectoryhandle①">2.5. The FileSystemDirectoryHandle interface</a> <a href="#ref-for-filesystemdirectoryhandle②">(2)</a> <a href="#ref-for-filesystemdirectoryhandle③">(3)</a> <a href="#ref-for-filesystemdirectoryhandle④">(4)</a>
@@ -4786,77 +4786,77 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-filesystemdirectoryhandle①④">4. Accessing the Origin Private File System</a> <a href="#ref-for-filesystemdirectoryhandle①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemdirectoryhandle-iterator-past-results">
-   <b><a href="#filesystemdirectoryhandle-iterator-past-results">#filesystemdirectoryhandle-iterator-past-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemdirectoryhandle-iterator-past-results" class="dfn-panel" data-for="filesystemdirectoryhandle-iterator-past-results" id="infopanel-for-filesystemdirectoryhandle-iterator-past-results" role="dialog">
+   <span id="infopaneltitle-for-filesystemdirectoryhandle-iterator-past-results" style="display:none">Info about the 'past results' definition.</span><b><a href="#filesystemdirectoryhandle-iterator-past-results">#filesystemdirectoryhandle-iterator-past-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemdirectoryhandle-iterator-past-results">2.5.1. Directory iteration</a> <a href="#ref-for-filesystemdirectoryhandle-iterator-past-results①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getfilehandle">
-   <b><a href="#dom-filesystemdirectoryhandle-getfilehandle">#dom-filesystemdirectoryhandle-getfilehandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryhandle-getfilehandle" class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getfilehandle" id="infopanel-for-dom-filesystemdirectoryhandle-getfilehandle" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryhandle-getfilehandle" style="display:none">Info about the 'getFileHandle(name, options)' definition.</span><b><a href="#dom-filesystemdirectoryhandle-getfilehandle">#dom-filesystemdirectoryhandle-getfilehandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle①">2.5.2. The getFileHandle() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getfilehandle④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getdirectoryhandle">
-   <b><a href="#dom-filesystemdirectoryhandle-getdirectoryhandle">#dom-filesystemdirectoryhandle-getdirectoryhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryhandle-getdirectoryhandle" class="dfn-panel" data-for="dom-filesystemdirectoryhandle-getdirectoryhandle" id="infopanel-for-dom-filesystemdirectoryhandle-getdirectoryhandle" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryhandle-getdirectoryhandle" style="display:none">Info about the 'getDirectoryHandle(name, options)' definition.</span><b><a href="#dom-filesystemdirectoryhandle-getdirectoryhandle">#dom-filesystemdirectoryhandle-getdirectoryhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle①">2.5.3. The getDirectoryHandle() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-getdirectoryhandle④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-removeentry">
-   <b><a href="#dom-filesystemdirectoryhandle-removeentry">#dom-filesystemdirectoryhandle-removeentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryhandle-removeentry" class="dfn-panel" data-for="dom-filesystemdirectoryhandle-removeentry" id="infopanel-for-dom-filesystemdirectoryhandle-removeentry" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryhandle-removeentry" style="display:none">Info about the 'removeEntry(name, options)' definition.</span><b><a href="#dom-filesystemdirectoryhandle-removeentry">#dom-filesystemdirectoryhandle-removeentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-removeentry">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-removeentry①">2.5.4. The removeEntry() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry②">(2)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry③">(3)</a> <a href="#ref-for-dom-filesystemdirectoryhandle-removeentry④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemdirectoryhandle-resolve">
-   <b><a href="#dom-filesystemdirectoryhandle-resolve">#dom-filesystemdirectoryhandle-resolve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemdirectoryhandle-resolve" class="dfn-panel" data-for="dom-filesystemdirectoryhandle-resolve" id="infopanel-for-dom-filesystemdirectoryhandle-resolve" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemdirectoryhandle-resolve" style="display:none">Info about the 'resolve(possibleDescendant)' definition.</span><b><a href="#dom-filesystemdirectoryhandle-resolve">#dom-filesystemdirectoryhandle-resolve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-resolve">2.5. The FileSystemDirectoryHandle interface</a>
     <li><a href="#ref-for-dom-filesystemdirectoryhandle-resolve①">2.5.5. The resolve() method</a> <a href="#ref-for-dom-filesystemdirectoryhandle-resolve②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-writecommandtype">
-   <b><a href="#enumdef-writecommandtype">#enumdef-writecommandtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-writecommandtype" class="dfn-panel" data-for="enumdef-writecommandtype" id="infopanel-for-enumdef-writecommandtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-writecommandtype" style="display:none">Info about the 'WriteCommandType' definition.</span><b><a href="#enumdef-writecommandtype">#enumdef-writecommandtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-writecommandtype">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writecommandtype-write">
-   <b><a href="#dom-writecommandtype-write">#dom-writecommandtype-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writecommandtype-write" class="dfn-panel" data-for="dom-writecommandtype-write" id="infopanel-for-dom-writecommandtype-write" role="dialog">
+   <span id="infopaneltitle-for-dom-writecommandtype-write" style="display:none">Info about the '"write"' definition.</span><b><a href="#dom-writecommandtype-write">#dom-writecommandtype-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writecommandtype-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writecommandtype-write①">(2)</a>
     <li><a href="#ref-for-dom-writecommandtype-write②">2.6.1. The write() method</a> <a href="#ref-for-dom-writecommandtype-write③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writecommandtype-seek">
-   <b><a href="#dom-writecommandtype-seek">#dom-writecommandtype-seek</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writecommandtype-seek" class="dfn-panel" data-for="dom-writecommandtype-seek" id="infopanel-for-dom-writecommandtype-seek" role="dialog">
+   <span id="infopaneltitle-for-dom-writecommandtype-seek" style="display:none">Info about the '"seek"' definition.</span><b><a href="#dom-writecommandtype-seek">#dom-writecommandtype-seek</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writecommandtype-seek">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-writecommandtype-seek①">2.6.1. The write() method</a>
     <li><a href="#ref-for-dom-writecommandtype-seek②">2.6.2. The seek() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writecommandtype-truncate">
-   <b><a href="#dom-writecommandtype-truncate">#dom-writecommandtype-truncate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writecommandtype-truncate" class="dfn-panel" data-for="dom-writecommandtype-truncate" id="infopanel-for-dom-writecommandtype-truncate" role="dialog">
+   <span id="infopaneltitle-for-dom-writecommandtype-truncate" style="display:none">Info about the '"truncate"' definition.</span><b><a href="#dom-writecommandtype-truncate">#dom-writecommandtype-truncate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writecommandtype-truncate">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-writecommandtype-truncate①">2.6.1. The write() method</a> <a href="#ref-for-dom-writecommandtype-truncate②">(2)</a>
     <li><a href="#ref-for-dom-writecommandtype-truncate③">2.6.3. The truncate() method</a> <a href="#ref-for-dom-writecommandtype-truncate④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-writeparams">
-   <b><a href="#dictdef-writeparams">#dictdef-writeparams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-writeparams" class="dfn-panel" data-for="dictdef-writeparams" id="infopanel-for-dictdef-writeparams" role="dialog">
+   <span id="infopaneltitle-for-dictdef-writeparams" style="display:none">Info about the 'WriteParams' definition.</span><b><a href="#dictdef-writeparams">#dictdef-writeparams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-writeparams">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dictdef-writeparams①">(2)</a> <a href="#ref-for-dictdef-writeparams②">(3)</a> <a href="#ref-for-dictdef-writeparams③">(4)</a> <a href="#ref-for-dictdef-writeparams④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writeparams-type">
-   <b><a href="#dom-writeparams-type">#dom-writeparams-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writeparams-type" class="dfn-panel" data-for="dom-writeparams-type" id="infopanel-for-dom-writeparams-type" role="dialog">
+   <span id="infopaneltitle-for-dom-writeparams-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-writeparams-type">#dom-writeparams-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writeparams-type">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-writeparams-type①">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-type②">(2)</a> <a href="#ref-for-dom-writeparams-type③">(3)</a> <a href="#ref-for-dom-writeparams-type④">(4)</a>
@@ -4864,159 +4864,159 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-writeparams-type⑥">2.6.3. The truncate() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writeparams-size">
-   <b><a href="#dom-writeparams-size">#dom-writeparams-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writeparams-size" class="dfn-panel" data-for="dom-writeparams-size" id="infopanel-for-dom-writeparams-size" role="dialog">
+   <span id="infopaneltitle-for-dom-writeparams-size" style="display:none">Info about the 'size' definition.</span><b><a href="#dom-writeparams-size">#dom-writeparams-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writeparams-size">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writeparams-size①">(2)</a>
     <li><a href="#ref-for-dom-writeparams-size②">2.6.1. The write() method</a>
     <li><a href="#ref-for-dom-writeparams-size③">2.6.3. The truncate() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writeparams-position">
-   <b><a href="#dom-writeparams-position">#dom-writeparams-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writeparams-position" class="dfn-panel" data-for="dom-writeparams-position" id="infopanel-for-dom-writeparams-position" role="dialog">
+   <span id="infopaneltitle-for-dom-writeparams-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-writeparams-position">#dom-writeparams-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writeparams-position">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-writeparams-position①">(2)</a> <a href="#ref-for-dom-writeparams-position②">(3)</a> <a href="#ref-for-dom-writeparams-position③">(4)</a>
     <li><a href="#ref-for-dom-writeparams-position④">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-position⑤">(2)</a>
     <li><a href="#ref-for-dom-writeparams-position⑥">2.6.2. The seek() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-writeparams-data">
-   <b><a href="#dom-writeparams-data">#dom-writeparams-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-writeparams-data" class="dfn-panel" data-for="dom-writeparams-data" id="infopanel-for-dom-writeparams-data" role="dialog">
+   <span id="infopaneltitle-for-dom-writeparams-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-writeparams-data">#dom-writeparams-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-writeparams-data">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-writeparams-data①">2.6.1. The write() method</a> <a href="#ref-for-dom-writeparams-data②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-filesystemwritechunktype">
-   <b><a href="#typedefdef-filesystemwritechunktype">#typedefdef-filesystemwritechunktype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-filesystemwritechunktype" class="dfn-panel" data-for="typedefdef-filesystemwritechunktype" id="infopanel-for-typedefdef-filesystemwritechunktype" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-filesystemwritechunktype" style="display:none">Info about the 'FileSystemWriteChunkType' definition.</span><b><a href="#typedefdef-filesystemwritechunktype">#typedefdef-filesystemwritechunktype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-filesystemwritechunktype">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-typedefdef-filesystemwritechunktype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemwritablefilestream">
-   <b><a href="#filesystemwritablefilestream">#filesystemwritablefilestream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemwritablefilestream" class="dfn-panel" data-for="filesystemwritablefilestream" id="infopanel-for-filesystemwritablefilestream" role="dialog">
+   <span id="infopaneltitle-for-filesystemwritablefilestream" style="display:none">Info about the 'FileSystemWritableFileStream' definition.</span><b><a href="#filesystemwritablefilestream">#filesystemwritablefilestream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemwritablefilestream">2.4. The FileSystemFileHandle interface</a>
     <li><a href="#ref-for-filesystemwritablefilestream①">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-filesystemwritablefilestream②">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream③">(2)</a> <a href="#ref-for-filesystemwritablefilestream④">(3)</a> <a href="#ref-for-filesystemwritablefilestream⑤">(4)</a> <a href="#ref-for-filesystemwritablefilestream⑥">(5)</a> <a href="#ref-for-filesystemwritablefilestream⑦">(6)</a> <a href="#ref-for-filesystemwritablefilestream⑧">(7)</a> <a href="#ref-for-filesystemwritablefilestream⑨">(8)</a> <a href="#ref-for-filesystemwritablefilestream①⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemwritablefilestream-file">
-   <b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemwritablefilestream-file" class="dfn-panel" data-for="filesystemwritablefilestream-file" id="infopanel-for-filesystemwritablefilestream-file" role="dialog">
+   <span id="infopaneltitle-for-filesystemwritablefilestream-file" style="display:none">Info about the '[[file]]' definition.</span><b><a href="#filesystemwritablefilestream-file">#filesystemwritablefilestream-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemwritablefilestream-file">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-file①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-file②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-file③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemwritablefilestream-buffer">
-   <b><a href="#filesystemwritablefilestream-buffer">#filesystemwritablefilestream-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemwritablefilestream-buffer" class="dfn-panel" data-for="filesystemwritablefilestream-buffer" id="infopanel-for-filesystemwritablefilestream-buffer" role="dialog">
+   <span id="infopaneltitle-for-filesystemwritablefilestream-buffer" style="display:none">Info about the '[[buffer]]' definition.</span><b><a href="#filesystemwritablefilestream-buffer">#filesystemwritablefilestream-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemwritablefilestream-buffer">2.4.2. The createWritable() method</a>
     <li><a href="#ref-for-filesystemwritablefilestream-buffer①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-buffer②">(2)</a> <a href="#ref-for-filesystemwritablefilestream-buffer③">(3)</a> <a href="#ref-for-filesystemwritablefilestream-buffer④">(4)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑤">(5)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑥">(6)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑦">(7)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑧">(8)</a> <a href="#ref-for-filesystemwritablefilestream-buffer⑨">(9)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①⓪">(10)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①①">(11)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①②">(12)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①③">(13)</a> <a href="#ref-for-filesystemwritablefilestream-buffer①④">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filesystemwritablefilestream-seekoffset">
-   <b><a href="#filesystemwritablefilestream-seekoffset">#filesystemwritablefilestream-seekoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filesystemwritablefilestream-seekoffset" class="dfn-panel" data-for="filesystemwritablefilestream-seekoffset" id="infopanel-for-filesystemwritablefilestream-seekoffset" role="dialog">
+   <span id="infopaneltitle-for-filesystemwritablefilestream-seekoffset" style="display:none">Info about the '[[seekOffset]]' definition.</span><b><a href="#filesystemwritablefilestream-seekoffset">#filesystemwritablefilestream-seekoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filesystemwritablefilestream-seekoffset">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset①">(2)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset②">(3)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset③">(4)</a> <a href="#ref-for-filesystemwritablefilestream-seekoffset④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-new-filesystemwritablefilestream">
-   <b><a href="#create-a-new-filesystemwritablefilestream">#create-a-new-filesystemwritablefilestream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-new-filesystemwritablefilestream" class="dfn-panel" data-for="create-a-new-filesystemwritablefilestream" id="infopanel-for-create-a-new-filesystemwritablefilestream" role="dialog">
+   <span id="infopaneltitle-for-create-a-new-filesystemwritablefilestream" style="display:none">Info about the 'create a new FileSystemWritableFileStream' definition.</span><b><a href="#create-a-new-filesystemwritablefilestream">#create-a-new-filesystemwritablefilestream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-new-filesystemwritablefilestream">2.4.2. The createWritable() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-a-chunk">
-   <b><a href="#write-a-chunk">#write-a-chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-a-chunk" class="dfn-panel" data-for="write-a-chunk" id="infopanel-for-write-a-chunk" role="dialog">
+   <span id="infopaneltitle-for-write-a-chunk" style="display:none">Info about the 'write a chunk' definition.</span><b><a href="#write-a-chunk">#write-a-chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-a-chunk">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-write">
-   <b><a href="#dom-filesystemwritablefilestream-write">#dom-filesystemwritablefilestream-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemwritablefilestream-write" class="dfn-panel" data-for="dom-filesystemwritablefilestream-write" id="infopanel-for-dom-filesystemwritablefilestream-write" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemwritablefilestream-write" style="display:none">Info about the 'write(data)' definition.</span><b><a href="#dom-filesystemwritablefilestream-write">#dom-filesystemwritablefilestream-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-write">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-dom-filesystemwritablefilestream-write①">(2)</a>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-write②">2.6.1. The write() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-write③">(2)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write④">(3)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑤">(4)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑥">(5)</a> <a href="#ref-for-dom-filesystemwritablefilestream-write⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-seek">
-   <b><a href="#dom-filesystemwritablefilestream-seek">#dom-filesystemwritablefilestream-seek</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemwritablefilestream-seek" class="dfn-panel" data-for="dom-filesystemwritablefilestream-seek" id="infopanel-for-dom-filesystemwritablefilestream-seek" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemwritablefilestream-seek" style="display:none">Info about the 'seek(position)' definition.</span><b><a href="#dom-filesystemwritablefilestream-seek">#dom-filesystemwritablefilestream-seek</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-seek">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-seek①">2.6.2. The seek() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-seek②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filesystemwritablefilestream-truncate">
-   <b><a href="#dom-filesystemwritablefilestream-truncate">#dom-filesystemwritablefilestream-truncate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filesystemwritablefilestream-truncate" class="dfn-panel" data-for="dom-filesystemwritablefilestream-truncate" id="infopanel-for-dom-filesystemwritablefilestream-truncate" role="dialog">
+   <span id="infopaneltitle-for-dom-filesystemwritablefilestream-truncate" style="display:none">Info about the 'truncate(size)' definition.</span><b><a href="#dom-filesystemwritablefilestream-truncate">#dom-filesystemwritablefilestream-truncate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate">2.6. The FileSystemWritableFileStream interface</a>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate①">2.6.3. The truncate() method</a> <a href="#ref-for-dom-filesystemwritablefilestream-truncate②">(2)</a>
     <li><a href="#ref-for-dom-filesystemwritablefilestream-truncate③">7.3. Filling up a users disk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filepickeraccepttype">
-   <b><a href="#dictdef-filepickeraccepttype">#dictdef-filepickeraccepttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filepickeraccepttype" class="dfn-panel" data-for="dictdef-filepickeraccepttype" id="infopanel-for-dictdef-filepickeraccepttype" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filepickeraccepttype" style="display:none">Info about the 'FilePickerAcceptType' definition.</span><b><a href="#dictdef-filepickeraccepttype">#dictdef-filepickeraccepttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filepickeraccepttype">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filepickeraccepttype-description">
-   <b><a href="#dom-filepickeraccepttype-description">#dom-filepickeraccepttype-description</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filepickeraccepttype-description" class="dfn-panel" data-for="dom-filepickeraccepttype-description" id="infopanel-for-dom-filepickeraccepttype-description" role="dialog">
+   <span id="infopaneltitle-for-dom-filepickeraccepttype-description" style="display:none">Info about the 'description' definition.</span><b><a href="#dom-filepickeraccepttype-description">#dom-filepickeraccepttype-description</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filepickeraccepttype-description">3.4. FilePickerOptions.types</a> <a href="#ref-for-dom-filepickeraccepttype-description①">(2)</a> <a href="#ref-for-dom-filepickeraccepttype-description②">(3)</a> <a href="#ref-for-dom-filepickeraccepttype-description③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filepickeraccepttype-accept">
-   <b><a href="#dom-filepickeraccepttype-accept">#dom-filepickeraccepttype-accept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filepickeraccepttype-accept" class="dfn-panel" data-for="dom-filepickeraccepttype-accept" id="infopanel-for-dom-filepickeraccepttype-accept" role="dialog">
+   <span id="infopaneltitle-for-dom-filepickeraccepttype-accept" style="display:none">Info about the 'accept' definition.</span><b><a href="#dom-filepickeraccepttype-accept">#dom-filepickeraccepttype-accept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filepickeraccepttype-accept">3.4. FilePickerOptions.types</a> <a href="#ref-for-dom-filepickeraccepttype-accept①">(2)</a> <a href="#ref-for-dom-filepickeraccepttype-accept②">(3)</a> <a href="#ref-for-dom-filepickeraccepttype-accept③">(4)</a> <a href="#ref-for-dom-filepickeraccepttype-accept④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-filepickeroptions">
-   <b><a href="#dictdef-filepickeroptions">#dictdef-filepickeroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-filepickeroptions" class="dfn-panel" data-for="dictdef-filepickeroptions" id="infopanel-for-dictdef-filepickeroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-filepickeroptions" style="display:none">Info about the 'FilePickerOptions' definition.</span><b><a href="#dictdef-filepickeroptions">#dictdef-filepickeroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-filepickeroptions">3. Accessing Local File System</a> <a href="#ref-for-dictdef-filepickeroptions①">(2)</a>
     <li><a href="#ref-for-dictdef-filepickeroptions②">3.4. FilePickerOptions.types</a> <a href="#ref-for-dictdef-filepickeroptions③">(2)</a> <a href="#ref-for-dictdef-filepickeroptions④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filepickeroptions-types">
-   <b><a href="#dom-filepickeroptions-types">#dom-filepickeroptions-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filepickeroptions-types" class="dfn-panel" data-for="dom-filepickeroptions-types" id="infopanel-for-dom-filepickeroptions-types" role="dialog">
+   <span id="infopaneltitle-for-dom-filepickeroptions-types" style="display:none">Info about the 'types' definition.</span><b><a href="#dom-filepickeroptions-types">#dom-filepickeroptions-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filepickeroptions-types">3.4. FilePickerOptions.types</a> <a href="#ref-for-dom-filepickeroptions-types①">(2)</a> <a href="#ref-for-dom-filepickeroptions-types②">(3)</a> <a href="#ref-for-dom-filepickeroptions-types③">(4)</a> <a href="#ref-for-dom-filepickeroptions-types④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filepickeroptions-excludeacceptalloption">
-   <b><a href="#dom-filepickeroptions-excludeacceptalloption">#dom-filepickeroptions-excludeacceptalloption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filepickeroptions-excludeacceptalloption" class="dfn-panel" data-for="dom-filepickeroptions-excludeacceptalloption" id="infopanel-for-dom-filepickeroptions-excludeacceptalloption" role="dialog">
+   <span id="infopaneltitle-for-dom-filepickeroptions-excludeacceptalloption" style="display:none">Info about the 'excludeAcceptAllOption' definition.</span><b><a href="#dom-filepickeroptions-excludeacceptalloption">#dom-filepickeroptions-excludeacceptalloption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filepickeroptions-excludeacceptalloption">3.4. FilePickerOptions.types</a> <a href="#ref-for-dom-filepickeroptions-excludeacceptalloption①">(2)</a> <a href="#ref-for-dom-filepickeroptions-excludeacceptalloption②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-openfilepickeroptions">
-   <b><a href="#dictdef-openfilepickeroptions">#dictdef-openfilepickeroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-openfilepickeroptions" class="dfn-panel" data-for="dictdef-openfilepickeroptions" id="infopanel-for-dictdef-openfilepickeroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-openfilepickeroptions" style="display:none">Info about the 'OpenFilePickerOptions' definition.</span><b><a href="#dictdef-openfilepickeroptions">#dictdef-openfilepickeroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-openfilepickeroptions">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-openfilepickeroptions-multiple">
-   <b><a href="#dom-openfilepickeroptions-multiple">#dom-openfilepickeroptions-multiple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-openfilepickeroptions-multiple" class="dfn-panel" data-for="dom-openfilepickeroptions-multiple" id="infopanel-for-dom-openfilepickeroptions-multiple" role="dialog">
+   <span id="infopaneltitle-for-dom-openfilepickeroptions-multiple" style="display:none">Info about the 'multiple' definition.</span><b><a href="#dom-openfilepickeroptions-multiple">#dom-openfilepickeroptions-multiple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-openfilepickeroptions-multiple">3.2. The showOpenFilePicker() method</a> <a href="#ref-for-dom-openfilepickeroptions-multiple①">(2)</a> <a href="#ref-for-dom-openfilepickeroptions-multiple②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-savefilepickeroptions">
-   <b><a href="#dictdef-savefilepickeroptions">#dictdef-savefilepickeroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-savefilepickeroptions" class="dfn-panel" data-for="dictdef-savefilepickeroptions" id="infopanel-for-dictdef-savefilepickeroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-savefilepickeroptions" style="display:none">Info about the 'SaveFilePickerOptions' definition.</span><b><a href="#dictdef-savefilepickeroptions">#dictdef-savefilepickeroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-savefilepickeroptions">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-directorypickeroptions">
-   <b><a href="#dictdef-directorypickeroptions">#dictdef-directorypickeroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-directorypickeroptions" class="dfn-panel" data-for="dictdef-directorypickeroptions" id="infopanel-for-dictdef-directorypickeroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-directorypickeroptions" style="display:none">Info about the 'DirectoryPickerOptions' definition.</span><b><a href="#dictdef-directorypickeroptions">#dictdef-directorypickeroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-directorypickeroptions">3. Accessing Local File System</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-file-system-handle-factories">
-   <b><a href="#local-file-system-handle-factories">#local-file-system-handle-factories</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-file-system-handle-factories" class="dfn-panel" data-for="local-file-system-handle-factories" id="infopanel-for-local-file-system-handle-factories" role="dialog">
+   <span id="infopaneltitle-for-local-file-system-handle-factories" style="display:none">Info about the 'local file system handle factories' definition.</span><b><a href="#local-file-system-handle-factories">#local-file-system-handle-factories</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-file-system-handle-factories">2.1. Concepts</a>
     <li><a href="#ref-for-local-file-system-handle-factories①">2.3.2. The queryPermission() method</a>
@@ -5025,24 +5025,24 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-local-file-system-handle-factories⑤">6.3. First-party vs third-party contexts.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-allowed-to-show-a-file-picker">
-   <b><a href="#is-allowed-to-show-a-file-picker">#is-allowed-to-show-a-file-picker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-allowed-to-show-a-file-picker" class="dfn-panel" data-for="is-allowed-to-show-a-file-picker" id="infopanel-for-is-allowed-to-show-a-file-picker" role="dialog">
+   <span id="infopaneltitle-for-is-allowed-to-show-a-file-picker" style="display:none">Info about the 'is allowed to show a file picker' definition.</span><b><a href="#is-allowed-to-show-a-file-picker">#is-allowed-to-show-a-file-picker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-allowed-to-show-a-file-picker">3.2. The showOpenFilePicker() method</a>
     <li><a href="#ref-for-is-allowed-to-show-a-file-picker①">3.3. The showSaveFilePicker() method</a>
     <li><a href="#ref-for-is-allowed-to-show-a-file-picker②">3.5. The showDirectoryPicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-showopenfilepicker">
-   <b><a href="#dom-window-showopenfilepicker">#dom-window-showopenfilepicker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-showopenfilepicker" class="dfn-panel" data-for="dom-window-showopenfilepicker" id="infopanel-for-dom-window-showopenfilepicker" role="dialog">
+   <span id="infopaneltitle-for-dom-window-showopenfilepicker" style="display:none">Info about the 'showOpenFilePicker(options)' definition.</span><b><a href="#dom-window-showopenfilepicker">#dom-window-showopenfilepicker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-showopenfilepicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showopenfilepicker①">(2)</a>
     <li><a href="#ref-for-dom-window-showopenfilepicker②">3.2. The showOpenFilePicker() method</a> <a href="#ref-for-dom-window-showopenfilepicker③">(2)</a> <a href="#ref-for-dom-window-showopenfilepicker④">(3)</a> <a href="#ref-for-dom-window-showopenfilepicker⑤">(4)</a> <a href="#ref-for-dom-window-showopenfilepicker⑥">(5)</a>
     <li><a href="#ref-for-dom-window-showopenfilepicker⑦">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-showsavefilepicker">
-   <b><a href="#dom-window-showsavefilepicker">#dom-window-showsavefilepicker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-showsavefilepicker" class="dfn-panel" data-for="dom-window-showsavefilepicker" id="infopanel-for-dom-window-showsavefilepicker" role="dialog">
+   <span id="infopaneltitle-for-dom-window-showsavefilepicker" style="display:none">Info about the 'showSaveFilePicker(options)' definition.</span><b><a href="#dom-window-showsavefilepicker">#dom-window-showsavefilepicker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-showsavefilepicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showsavefilepicker①">(2)</a>
     <li><a href="#ref-for-dom-window-showsavefilepicker②">3.1. Local File System Permissions</a>
@@ -5050,34 +5050,34 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-dom-window-showsavefilepicker⑥">3.4. FilePickerOptions.types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-accept-types">
-   <b><a href="#process-accept-types">#process-accept-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-accept-types" class="dfn-panel" data-for="process-accept-types" id="infopanel-for-process-accept-types" role="dialog">
+   <span id="infopaneltitle-for-process-accept-types" style="display:none">Info about the 'process accept types' definition.</span><b><a href="#process-accept-types">#process-accept-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-accept-types">3.2. The showOpenFilePicker() method</a>
     <li><a href="#ref-for-process-accept-types①">3.3. The showSaveFilePicker() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-a-suffix">
-   <b><a href="#validate-a-suffix">#validate-a-suffix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-a-suffix" class="dfn-panel" data-for="validate-a-suffix" id="infopanel-for-validate-a-suffix" role="dialog">
+   <span id="infopaneltitle-for-validate-a-suffix" style="display:none">Info about the 'validate a suffix' definition.</span><b><a href="#validate-a-suffix">#validate-a-suffix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-a-suffix">3.4. FilePickerOptions.types</a> <a href="#ref-for-validate-a-suffix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-showdirectorypicker">
-   <b><a href="#dom-window-showdirectorypicker">#dom-window-showdirectorypicker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-showdirectorypicker" class="dfn-panel" data-for="dom-window-showdirectorypicker" id="infopanel-for-dom-window-showdirectorypicker" role="dialog">
+   <span id="infopaneltitle-for-dom-window-showdirectorypicker" style="display:none">Info about the 'showDirectoryPicker(options)' definition.</span><b><a href="#dom-window-showdirectorypicker">#dom-window-showdirectorypicker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-showdirectorypicker">3. Accessing Local File System</a> <a href="#ref-for-dom-window-showdirectorypicker①">(2)</a>
     <li><a href="#ref-for-dom-window-showdirectorypicker②">3.5. The showDirectoryPicker() method</a> <a href="#ref-for-dom-window-showdirectorypicker③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datatransferitem-getasfilesystemhandle">
-   <b><a href="#dom-datatransferitem-getasfilesystemhandle">#dom-datatransferitem-getasfilesystemhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datatransferitem-getasfilesystemhandle" class="dfn-panel" data-for="dom-datatransferitem-getasfilesystemhandle" id="infopanel-for-dom-datatransferitem-getasfilesystemhandle" role="dialog">
+   <span id="infopaneltitle-for-dom-datatransferitem-getasfilesystemhandle" style="display:none">Info about the 'getAsFileSystemHandle()' definition.</span><b><a href="#dom-datatransferitem-getasfilesystemhandle">#dom-datatransferitem-getasfilesystemhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransferitem-getasfilesystemhandle">3.6. Drag and Drop</a> <a href="#ref-for-dom-datatransferitem-getasfilesystemhandle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-private-file-system">
-   <b><a href="#origin-private-file-system">#origin-private-file-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-private-file-system" class="dfn-panel" data-for="origin-private-file-system" id="infopanel-for-origin-private-file-system" role="dialog">
+   <span id="infopaneltitle-for-origin-private-file-system" style="display:none">Info about the 'origin private file system' definition.</span><b><a href="#origin-private-file-system">#origin-private-file-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-private-file-system">2.2. Permissions</a>
     <li><a href="#ref-for-origin-private-file-system①">2.6. The FileSystemWritableFileStream interface</a> <a href="#ref-for-origin-private-file-system②">(2)</a>
@@ -5085,16 +5085,16 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-origin-private-file-system⑤">7.3. Filling up a users disk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storagemanager-getdirectory">
-   <b><a href="#dom-storagemanager-getdirectory">#dom-storagemanager-getdirectory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storagemanager-getdirectory" class="dfn-panel" data-for="dom-storagemanager-getdirectory" id="infopanel-for-dom-storagemanager-getdirectory" role="dialog">
+   <span id="infopaneltitle-for-dom-storagemanager-getdirectory" style="display:none">Info about the 'getDirectory()' definition.</span><b><a href="#dom-storagemanager-getdirectory">#dom-storagemanager-getdirectory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storagemanager-getdirectory">1. Introduction</a>
     <li><a href="#ref-for-dom-storagemanager-getdirectory①">2.1. Concepts</a>
     <li><a href="#ref-for-dom-storagemanager-getdirectory②">4. Accessing the Origin Private File System</a> <a href="#ref-for-dom-storagemanager-getdirectory③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="too-sensitive-or-dangerous">
-   <b><a href="#too-sensitive-or-dangerous">#too-sensitive-or-dangerous</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-too-sensitive-or-dangerous" class="dfn-panel" data-for="too-sensitive-or-dangerous" id="infopanel-for-too-sensitive-or-dangerous" role="dialog">
+   <span id="infopaneltitle-for-too-sensitive-or-dangerous" style="display:none">Info about the 'too sensitive or dangerous' definition.</span><b><a href="#too-sensitive-or-dangerous">#too-sensitive-or-dangerous</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-too-sensitive-or-dangerous">3.2. The showOpenFilePicker() method</a>
     <li><a href="#ref-for-too-sensitive-or-dangerous①">3.3. The showSaveFilePicker() method</a>
@@ -5102,67 +5102,124 @@ than being defined here. So merge this into the table there. <a class="issue-ret
     <li><a href="#ref-for-too-sensitive-or-dangerous③">3.6. Drag and Drop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="malware-scans-and-safe-browsing-checks">
-   <b><a href="#malware-scans-and-safe-browsing-checks">#malware-scans-and-safe-browsing-checks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-malware-scans-and-safe-browsing-checks" class="dfn-panel" data-for="malware-scans-and-safe-browsing-checks" id="infopanel-for-malware-scans-and-safe-browsing-checks" role="dialog">
+   <span id="infopaneltitle-for-malware-scans-and-safe-browsing-checks" style="display:none">Info about the 'malware
+scans and safe browsing checks' definition.</span><b><a href="#malware-scans-and-safe-browsing-checks">#malware-scans-and-safe-browsing-checks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-malware-scans-and-safe-browsing-checks">2.6. The FileSystemWritableFileStream interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/floc/floc.html
+++ b/tests/github/WICG/floc/floc.html
@@ -869,108 +869,108 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
    <li><a href="#string-representation-of-the-interest-cohort-version">string representation of the interest cohort version</a><span>, in § 2</span>
    <li><a href="#dom-interestcohort-version">version</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. The API</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">7.1.4. Adoption phase</a>
     <li><a href="#ref-for-document③">7.3. Tracking people via their interest cohort</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">3. The API</a> <a href="#ref-for-queue-a-global-task①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3. The API</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">2. Interest cohort</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">6. Permissions policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">6. Permissions policy integration</a>
     <li><a href="#ref-for-policy-controlled-feature①">7.1.1. Eligibility for a page to be included in the interest cohort computation</a>
     <li><a href="#ref-for-policy-controlled-feature②">7.1.2. Permission to access the interest cohort</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Interest cohort</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3. The API</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
    </ul>
@@ -1042,8 +1042,8 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="interest-cohort">
-   <b><a href="#interest-cohort">#interest-cohort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interest-cohort" class="dfn-panel" data-for="interest-cohort" id="infopanel-for-interest-cohort" role="dialog">
+   <span id="infopaneltitle-for-interest-cohort" style="display:none">Info about the 'interest cohort' definition.</span><b><a href="#interest-cohort">#interest-cohort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interest-cohort">4. Interpretation</a>
     <li><a href="#ref-for-interest-cohort①">7.1.2. Permission to access the interest cohort</a>
@@ -1052,8 +1052,8 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
     <li><a href="#ref-for-interest-cohort⑦">7.4. Recovering the browsing history from cohorts</a> <a href="#ref-for-interest-cohort⑧">(2)</a> <a href="#ref-for-interest-cohort⑨">(3)</a> <a href="#ref-for-interest-cohort①⓪">(4)</a> <a href="#ref-for-interest-cohort①①">(5)</a> <a href="#ref-for-interest-cohort①②">(6)</a> <a href="#ref-for-interest-cohort①③">(7)</a> <a href="#ref-for-interest-cohort①④">(8)</a> <a href="#ref-for-interest-cohort①⑤">(9)</a> <a href="#ref-for-interest-cohort①⑥">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interest-cohort-id">
-   <b><a href="#interest-cohort-id">#interest-cohort-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interest-cohort-id" class="dfn-panel" data-for="interest-cohort-id" id="infopanel-for-interest-cohort-id" role="dialog">
+   <span id="infopaneltitle-for-interest-cohort-id" style="display:none">Info about the 'interest cohort id' definition.</span><b><a href="#interest-cohort-id">#interest-cohort-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interest-cohort-id">2. Interest cohort</a> <a href="#ref-for-interest-cohort-id①">(2)</a> <a href="#ref-for-interest-cohort-id②">(3)</a> <a href="#ref-for-interest-cohort-id③">(4)</a>
     <li><a href="#ref-for-interest-cohort-id④">3. The API</a>
@@ -1067,49 +1067,49 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
     <li><a href="#ref-for-interest-cohort-id①④">5.3.3. No sensitive cohorts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-representation-of-the-interest-cohort-id">
-   <b><a href="#string-representation-of-the-interest-cohort-id">#string-representation-of-the-interest-cohort-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-representation-of-the-interest-cohort-id" class="dfn-panel" data-for="string-representation-of-the-interest-cohort-id" id="infopanel-for-string-representation-of-the-interest-cohort-id" role="dialog">
+   <span id="infopaneltitle-for-string-representation-of-the-interest-cohort-id" style="display:none">Info about the 'string representation of the interest cohort id' definition.</span><b><a href="#string-representation-of-the-interest-cohort-id">#string-representation-of-the-interest-cohort-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-representation-of-the-interest-cohort-id">2. Interest cohort</a>
     <li><a href="#ref-for-string-representation-of-the-interest-cohort-id">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interest-cohort-version">
-   <b><a href="#interest-cohort-version">#interest-cohort-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interest-cohort-version" class="dfn-panel" data-for="interest-cohort-version" id="infopanel-for-interest-cohort-version" role="dialog">
+   <span id="infopaneltitle-for-interest-cohort-version" style="display:none">Info about the 'interest cohort version' definition.</span><b><a href="#interest-cohort-version">#interest-cohort-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interest-cohort-version">2. Interest cohort</a>
     <li><a href="#ref-for-interest-cohort-version①">3. The API</a>
     <li><a href="#ref-for-interest-cohort-version②">4. Interpretation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-representation-of-the-interest-cohort-version">
-   <b><a href="#string-representation-of-the-interest-cohort-version">#string-representation-of-the-interest-cohort-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-representation-of-the-interest-cohort-version" class="dfn-panel" data-for="string-representation-of-the-interest-cohort-version" id="infopanel-for-string-representation-of-the-interest-cohort-version" role="dialog">
+   <span id="infopaneltitle-for-string-representation-of-the-interest-cohort-version" style="display:none">Info about the 'string representation of the interest cohort version' definition.</span><b><a href="#string-representation-of-the-interest-cohort-version">#string-representation-of-the-interest-cohort-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-representation-of-the-interest-cohort-version">2. Interest cohort</a>
     <li><a href="#ref-for-string-representation-of-the-interest-cohort-version">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-interestcohort">
-   <b><a href="#dictdef-interestcohort">#dictdef-interestcohort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-interestcohort" class="dfn-panel" data-for="dictdef-interestcohort" id="infopanel-for-dictdef-interestcohort" role="dialog">
+   <span id="infopaneltitle-for-dictdef-interestcohort" style="display:none">Info about the 'InterestCohort' definition.</span><b><a href="#dictdef-interestcohort">#dictdef-interestcohort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-interestcohort">2. Interest cohort</a>
     <li><a href="#ref-for-dictdef-interestcohort①">3. The API</a> <a href="#ref-for-dictdef-interestcohort②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-interestcohort-id">
-   <b><a href="#dom-interestcohort-id">#dom-interestcohort-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-interestcohort-id" class="dfn-panel" data-for="dom-interestcohort-id" id="infopanel-for-dom-interestcohort-id" role="dialog">
+   <span id="infopaneltitle-for-dom-interestcohort-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-interestcohort-id">#dom-interestcohort-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-interestcohort-id">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-interestcohort-version">
-   <b><a href="#dom-interestcohort-version">#dom-interestcohort-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-interestcohort-version" class="dfn-panel" data-for="dom-interestcohort-version" id="infopanel-for-dom-interestcohort-version" role="dialog">
+   <span id="infopaneltitle-for-dom-interestcohort-version" style="display:none">Info about the 'version' definition.</span><b><a href="#dom-interestcohort-version">#dom-interestcohort-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-interestcohort-version">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-interestcohort">
-   <b><a href="#dom-document-interestcohort">#dom-document-interestcohort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-interestcohort" class="dfn-panel" data-for="dom-document-interestcohort" id="infopanel-for-dom-document-interestcohort" role="dialog">
+   <span id="infopaneltitle-for-dom-document-interestcohort" style="display:none">Info about the 'interestCohort()' definition.</span><b><a href="#dom-document-interestcohort">#dom-document-interestcohort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-interestcohort">3. The API</a>
     <li><a href="#ref-for-dom-document-interestcohort①">7.1.1. Eligibility for a page to be included in the interest cohort computation</a>
@@ -1117,14 +1117,14 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
     <li><a href="#ref-for-dom-document-interestcohort③">7.3. Tracking people via their interest cohort</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interest-cohort-task-source">
-   <b><a href="#interest-cohort-task-source">#interest-cohort-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interest-cohort-task-source" class="dfn-panel" data-for="interest-cohort-task-source" id="infopanel-for-interest-cohort-task-source" role="dialog">
+   <span id="infopaneltitle-for-interest-cohort-task-source" style="display:none">Info about the 'interest cohort task source' definition.</span><b><a href="#interest-cohort-task-source">#interest-cohort-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interest-cohort-task-source">3. The API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interest-cohort-policy-controlled-feature">
-   <b><a href="#interest-cohort-policy-controlled-feature">#interest-cohort-policy-controlled-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interest-cohort-policy-controlled-feature" class="dfn-panel" data-for="interest-cohort-policy-controlled-feature" id="infopanel-for-interest-cohort-policy-controlled-feature" role="dialog">
+   <span id="infopaneltitle-for-interest-cohort-policy-controlled-feature" style="display:none">Info about the 'interest-cohort' definition.</span><b><a href="#interest-cohort-policy-controlled-feature">#interest-cohort-policy-controlled-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interest-cohort-policy-controlled-feature">3. The API</a>
     <li><a href="#ref-for-interest-cohort-policy-controlled-feature">7.1.1. Eligibility for a page to be included in the interest cohort computation</a>
@@ -1133,57 +1133,113 @@ url<c- p>.</c->searchParams<c- p>.</c->append<c- p>(</c-><c- u>"cohort_version"<
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/get-installed-related-apps/spec/index.html
+++ b/tests/github/WICG/get-installed-related-apps/spec/index.html
@@ -906,136 +906,136 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li><a href="#dom-relatedapplication-version">dict-member for RelatedApplication</a><span>, in § 5.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource" class="dfn-panel" data-for="term-for-dom-externalapplicationresource" id="infopanel-for-term-for-dom-externalapplicationresource" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource" style="display:none">Info about the 'ExternalApplicationResource' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource">4.1. Match an installed app</a>
     <li><a href="#ref-for-dom-externalapplicationresource①">5.1. RelatedApplication</a>
     <li><a href="#ref-for-dom-externalapplicationresource②">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fingerprint">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-fingerprint">https://www.w3.org/TR/appmanifest/#dom-fingerprint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fingerprint" class="dfn-panel" data-for="term-for-dom-fingerprint" id="infopanel-for-term-for-dom-fingerprint" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fingerprint" style="display:none">Info about the 'Fingerprint' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-fingerprint">https://www.w3.org/TR/appmanifest/#dom-fingerprint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fingerprint">3.2. Installed App</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-webappmanifest">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-webappmanifest">https://www.w3.org/TR/appmanifest/#dom-webappmanifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-webappmanifest" class="dfn-panel" data-for="term-for-dom-webappmanifest" id="infopanel-for-term-for-dom-webappmanifest" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-webappmanifest" style="display:none">Info about the 'WebAppManifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-webappmanifest">https://www.w3.org/TR/appmanifest/#dom-webappmanifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webappmanifest">5.1. RelatedApplication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource-fingerprints">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-fingerprints">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-fingerprints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource-fingerprints" class="dfn-panel" data-for="term-for-dom-externalapplicationresource-fingerprints" id="infopanel-for-term-for-dom-externalapplicationresource-fingerprints" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource-fingerprints" style="display:none">Info about the 'fingerprints' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-fingerprints">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-fingerprints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource-fingerprints">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource-id">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-id">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource-id" class="dfn-panel" data-for="term-for-dom-externalapplicationresource-id" id="infopanel-for-term-for-dom-externalapplicationresource-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource-id" style="display:none">Info about the 'id' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-id">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource-id">4.1. Match an installed app</a>
     <li><a href="#ref-for-dom-externalapplicationresource-id①">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource-min_version">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-min_version">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-min_version</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource-min_version" class="dfn-panel" data-for="term-for-dom-externalapplicationresource-min_version" id="infopanel-for-term-for-dom-externalapplicationresource-min_version" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource-min_version" style="display:none">Info about the 'min_version' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-min_version">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-min_version</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource-min_version">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtaining">
-   <a href="https://www.w3.org/TR/appmanifest/#obtaining">https://www.w3.org/TR/appmanifest/#obtaining</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtaining" class="dfn-panel" data-for="term-for-obtaining" id="infopanel-for-term-for-obtaining" role="menu">
+   <span id="infopaneltitle-for-term-for-obtaining" style="display:none">Info about the 'obtaining the manifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#obtaining">https://www.w3.org/TR/appmanifest/#obtaining</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtaining">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-platform-member">
-   <a href="https://www.w3.org/TR/appmanifest/#platform-member">https://www.w3.org/TR/appmanifest/#platform-member</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-platform-member" class="dfn-panel" data-for="term-for-platform-member" id="infopanel-for-term-for-platform-member" role="menu">
+   <span id="infopaneltitle-for-term-for-platform-member" style="display:none">Info about the 'platform' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#platform-member">https://www.w3.org/TR/appmanifest/#platform-member</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-platform-member">3.1. Platform</a> <a href="#ref-for-platform-member①">(2)</a>
     <li><a href="#ref-for-platform-member②">3.2. Installed App</a> <a href="#ref-for-platform-member③">(2)</a> <a href="#ref-for-platform-member④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource-platform">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-platform">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-platform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource-platform" class="dfn-panel" data-for="term-for-dom-externalapplicationresource-platform" id="infopanel-for-term-for-dom-externalapplicationresource-platform" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource-platform" style="display:none">Info about the 'platform (for ExternalApplicationResource)' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-platform">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-platform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource-platform">4.1. Match an installed app</a>
     <li><a href="#ref-for-dom-externalapplicationresource-platform①">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-webappmanifest-related_applications">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-webappmanifest-related_applications">https://www.w3.org/TR/appmanifest/#dom-webappmanifest-related_applications</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-webappmanifest-related_applications" class="dfn-panel" data-for="term-for-dom-webappmanifest-related_applications" id="infopanel-for-term-for-dom-webappmanifest-related_applications" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-webappmanifest-related_applications" style="display:none">Info about the 'related_applications' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-webappmanifest-related_applications">https://www.w3.org/TR/appmanifest/#dom-webappmanifest-related_applications</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webappmanifest-related_applications">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-externalapplicationresource-url">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-url">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-externalapplicationresource-url" class="dfn-panel" data-for="term-for-dom-externalapplicationresource-url" id="infopanel-for-term-for-dom-externalapplicationresource-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-externalapplicationresource-url" style="display:none">Info about the 'url' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-url">https://www.w3.org/TR/appmanifest/#dom-externalapplicationresource-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-externalapplicationresource-url">4.1. Match an installed app</a>
     <li><a href="#ref-for-dom-externalapplicationresource-url①">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">5.2. Extensions to Navigator</a> <a href="#ref-for-navigator①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.1. Match an installed app</a> <a href="#ref-for-list-contain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">4.1. Match an installed app</a>
     <li><a href="#ref-for-iteration-continue①">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.1. Match an installed app</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.1. Platform</a>
     <li><a href="#ref-for-list①">3.2. Installed App</a>
@@ -1043,96 +1043,96 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-list③">5.2.1. getInstalledRelatedApps()</a> <a href="#ref-for-list④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. Platform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">3.2. Installed App</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">5.2.1. getInstalledRelatedApps()</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url">
-   <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url" class="dfn-panel" data-for="term-for-url" id="infopanel-for-term-for-url" role="menu">
+   <span id="infopaneltitle-for-term-for-url" style="display:none">Info about the 'URL' external reference.</span><a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">3.2. Installed App</a>
     <li><a href="#ref-for-url①">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-url-origin">
-   <a href="https://url.spec.whatwg.org/#dom-url-origin">https://url.spec.whatwg.org/#dom-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-url-origin" class="dfn-panel" data-for="term-for-dom-url-origin" id="infopanel-for-term-for-dom-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#dom-url-origin">https://url.spec.whatwg.org/#dom-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-origin">3.2. Installed App</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. Installed App</a>
     <li><a href="#ref-for-idl-DOMString①">5.1. RelatedApplication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.2. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.2. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.2. Extensions to Navigator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3.1. Platform</a>
     <li><a href="#ref-for-idl-USVString①">3.2. Installed App</a>
     <li><a href="#ref-for-idl-USVString②">5.1. RelatedApplication</a> <a href="#ref-for-idl-USVString③">(2)</a> <a href="#ref-for-idl-USVString④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.2. Extensions to Navigator</a>
    </ul>
@@ -1230,85 +1230,85 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   <div style="counter-reset:issue">
    <div class="issue"> Should this restriction be removed? (<a href="https://github.com/WICG/get-installed-related-apps/issues/11">#11</a>) <a class="issue-return" href="#issue-311e9dcb" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="installed-apps">
-   <b><a href="#installed-apps">#installed-apps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-apps" class="dfn-panel" data-for="installed-apps" id="infopanel-for-installed-apps" role="dialog">
+   <span id="infopaneltitle-for-installed-apps" style="display:none">Info about the 'installed apps' definition.</span><b><a href="#installed-apps">#installed-apps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-apps">4.1. Match an installed app</a> <a href="#ref-for-installed-apps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installed-app">
-   <b><a href="#installed-app">#installed-app</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-app" class="dfn-panel" data-for="installed-app" id="infopanel-for-installed-app" role="dialog">
+   <span id="infopaneltitle-for-installed-app" style="display:none">Info about the 'installed app' definition.</span><b><a href="#installed-app">#installed-app</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-app">3.1. Platform</a>
     <li><a href="#ref-for-installed-app①">3.2. Installed App</a> <a href="#ref-for-installed-app②">(2)</a>
     <li><a href="#ref-for-installed-app③">5.1. RelatedApplication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installed-app-id">
-   <b><a href="#installed-app-id">#installed-app-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-app-id" class="dfn-panel" data-for="installed-app-id" id="infopanel-for-installed-app-id" role="dialog">
+   <span id="infopaneltitle-for-installed-app-id" style="display:none">Info about the 'id' definition.</span><b><a href="#installed-app-id">#installed-app-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-app-id">4.1. Match an installed app</a> <a href="#ref-for-installed-app-id①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installed-app-version">
-   <b><a href="#installed-app-version">#installed-app-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-app-version" class="dfn-panel" data-for="installed-app-version" id="infopanel-for-installed-app-version" role="dialog">
+   <span id="infopaneltitle-for-installed-app-version" style="display:none">Info about the 'version' definition.</span><b><a href="#installed-app-version">#installed-app-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-app-version">4.1. Match an installed app</a>
     <li><a href="#ref-for-installed-app-version①">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installed-app-fingerprints">
-   <b><a href="#installed-app-fingerprints">#installed-app-fingerprints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-app-fingerprints" class="dfn-panel" data-for="installed-app-fingerprints" id="infopanel-for-installed-app-fingerprints" role="dialog">
+   <span id="infopaneltitle-for-installed-app-fingerprints" style="display:none">Info about the 'Fingerprints' definition.</span><b><a href="#installed-app-fingerprints">#installed-app-fingerprints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-app-fingerprints">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installed-app-relatedurls">
-   <b><a href="#installed-app-relatedurls">#installed-app-relatedurls</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installed-app-relatedurls" class="dfn-panel" data-for="installed-app-relatedurls" id="infopanel-for-installed-app-relatedurls" role="dialog">
+   <span id="infopaneltitle-for-installed-app-relatedurls" style="display:none">Info about the 'relatedURLs' definition.</span><b><a href="#installed-app-relatedurls">#installed-app-relatedurls</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installed-app-relatedurls">4.1. Match an installed app</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-an-installed-app">
-   <b><a href="#match-an-installed-app">#match-an-installed-app</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-an-installed-app" class="dfn-panel" data-for="match-an-installed-app" id="infopanel-for-match-an-installed-app" role="dialog">
+   <span id="infopaneltitle-for-match-an-installed-app" style="display:none">Info about the 'match an installed app' definition.</span><b><a href="#match-an-installed-app">#match-an-installed-app</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-an-installed-app">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-relatedapplication">
-   <b><a href="#dictdef-relatedapplication">#dictdef-relatedapplication</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-relatedapplication" class="dfn-panel" data-for="dictdef-relatedapplication" id="infopanel-for-dictdef-relatedapplication" role="dialog">
+   <span id="infopaneltitle-for-dictdef-relatedapplication" style="display:none">Info about the 'RelatedApplication' definition.</span><b><a href="#dictdef-relatedapplication">#dictdef-relatedapplication</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-relatedapplication">5.1. RelatedApplication</a>
     <li><a href="#ref-for-dictdef-relatedapplication①">5.2. Extensions to Navigator</a>
     <li><a href="#ref-for-dictdef-relatedapplication②">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-relatedapplication-platform">
-   <b><a href="#dom-relatedapplication-platform">#dom-relatedapplication-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-relatedapplication-platform" class="dfn-panel" data-for="dom-relatedapplication-platform" id="infopanel-for-dom-relatedapplication-platform" role="dialog">
+   <span id="infopaneltitle-for-dom-relatedapplication-platform" style="display:none">Info about the 'platform' definition.</span><b><a href="#dom-relatedapplication-platform">#dom-relatedapplication-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-relatedapplication-platform">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-relatedapplication-url">
-   <b><a href="#dom-relatedapplication-url">#dom-relatedapplication-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-relatedapplication-url" class="dfn-panel" data-for="dom-relatedapplication-url" id="infopanel-for-dom-relatedapplication-url" role="dialog">
+   <span id="infopaneltitle-for-dom-relatedapplication-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-relatedapplication-url">#dom-relatedapplication-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-relatedapplication-url">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-relatedapplication-id">
-   <b><a href="#dom-relatedapplication-id">#dom-relatedapplication-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-relatedapplication-id" class="dfn-panel" data-for="dom-relatedapplication-id" id="infopanel-for-dom-relatedapplication-id" role="dialog">
+   <span id="infopaneltitle-for-dom-relatedapplication-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-relatedapplication-id">#dom-relatedapplication-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-relatedapplication-id">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-relatedapplication-version">
-   <b><a href="#dom-relatedapplication-version">#dom-relatedapplication-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-relatedapplication-version" class="dfn-panel" data-for="dom-relatedapplication-version" id="infopanel-for-dom-relatedapplication-version" role="dialog">
+   <span id="infopaneltitle-for-dom-relatedapplication-version" style="display:none">Info about the 'version' definition.</span><b><a href="#dom-relatedapplication-version">#dom-relatedapplication-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-relatedapplication-version">5.2.1. getInstalledRelatedApps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-getinstalledrelatedapps">
-   <b><a href="#dom-navigator-getinstalledrelatedapps">#dom-navigator-getinstalledrelatedapps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-getinstalledrelatedapps" class="dfn-panel" data-for="dom-navigator-getinstalledrelatedapps" id="infopanel-for-dom-navigator-getinstalledrelatedapps" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-getinstalledrelatedapps" style="display:none">Info about the 'getInstalledRelatedApps()' definition.</span><b><a href="#dom-navigator-getinstalledrelatedapps">#dom-navigator-getinstalledrelatedapps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-getinstalledrelatedapps">5.2. Extensions to Navigator</a>
     <li><a href="#ref-for-dom-navigator-getinstalledrelatedapps①">5.2.1. getInstalledRelatedApps()</a>
@@ -1316,59 +1316,115 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/hdcp-detection/index.html
+++ b/tests/github/WICG/hdcp-detection/index.html
@@ -822,63 +822,63 @@ requesting a key.</p>
    <li><a href="#dom-mediakeyspolicy-minhdcpversion">minHdcpVersion</a><span>, in § 1.1</span>
    <li><a href="#policy-requirement">policy requirement</a><span>, in § 1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaKeyStatus.output-restricted">
-   <a href="https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.output-restricted">https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.output-restricted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaKeyStatus.output-restricted" class="dfn-panel" data-for="term-for-idl-def-MediaKeyStatus.output-restricted" id="infopanel-for-term-for-idl-def-MediaKeyStatus.output-restricted" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaKeyStatus.output-restricted" style="display:none">Info about the 'output-restricted' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.output-restricted">https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.output-restricted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaKeyStatus.output-restricted">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()">
-   <a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()" id="infopanel-for-term-for-navigator-extension:-requestmediakeysystemaccess()" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" style="display:none">Info about the 'requestMediaKeySystemAccess()' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-extension:-requestmediakeysystemaccess()">3.2. 
         User Consent </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaKeyStatus.usable">
-   <a href="https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.usable">https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.usable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaKeyStatus.usable" class="dfn-panel" data-for="term-for-idl-def-MediaKeyStatus.usable" id="infopanel-for-term-for-idl-def-MediaKeyStatus.usable" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaKeyStatus.usable" style="display:none">Info about the 'usable' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.usable">https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeyStatus.usable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaKeyStatus.usable">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary-member">
-   <a href="https://heycam.github.io/webidl/#dfn-dictionary-member">https://heycam.github.io/webidl/#dfn-dictionary-member</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary-member" class="dfn-panel" data-for="term-for-dfn-dictionary-member" id="infopanel-for-term-for-dfn-dictionary-member" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary-member" style="display:none">Info about the 'member' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-dictionary-member">https://heycam.github.io/webidl/#dfn-dictionary-member</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary-member">2. MediaKeys extension</a> <a href="#ref-for-dfn-dictionary-member①">(2)</a> <a href="#ref-for-dfn-dictionary-member②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-present">
-   <a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-present" class="dfn-panel" data-for="term-for-dfn-present" id="infopanel-for-term-for-dfn-present" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-present" style="display:none">Info about the 'present' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-present">2. MediaKeys extension</a>
    </ul>
@@ -949,23 +949,23 @@ requesting a key.</p>
       behaviour (TypeError) but may be based on a registry so the list can be
       updated without updating this document. <a class="issue-return" href="#issue-7faaf6c3" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dictdef-mediakeyspolicy">
-   <b><a href="#dictdef-mediakeyspolicy">#dictdef-mediakeyspolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediakeyspolicy" class="dfn-panel" data-for="dictdef-mediakeyspolicy" id="infopanel-for-dictdef-mediakeyspolicy" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediakeyspolicy" style="display:none">Info about the 'MediaKeysPolicy' definition.</span><b><a href="#dictdef-mediakeyspolicy">#dictdef-mediakeyspolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediakeyspolicy">1.1. 
       MediaKeysPolicy Dictionary </a>
     <li><a href="#ref-for-dictdef-mediakeyspolicy①">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediakeyspolicy-minhdcpversion">
-   <b><a href="#dom-mediakeyspolicy-minhdcpversion">#dom-mediakeyspolicy-minhdcpversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediakeyspolicy-minhdcpversion" class="dfn-panel" data-for="dom-mediakeyspolicy-minhdcpversion" id="infopanel-for-dom-mediakeyspolicy-minhdcpversion" role="dialog">
+   <span id="infopaneltitle-for-dom-mediakeyspolicy-minhdcpversion" style="display:none">Info about the 'minHdcpVersion' definition.</span><b><a href="#dom-mediakeyspolicy-minhdcpversion">#dom-mediakeyspolicy-minhdcpversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeyspolicy-minhdcpversion">1.2. 
       HDCP Policy </a> <a href="#ref-for-dom-mediakeyspolicy-minhdcpversion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-requirement">
-   <b><a href="#policy-requirement">#policy-requirement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-requirement" class="dfn-panel" data-for="policy-requirement" id="infopanel-for-policy-requirement" role="dialog">
+   <span id="infopaneltitle-for-policy-requirement" style="display:none">Info about the 'policy requirement' definition.</span><b><a href="#policy-requirement">#policy-requirement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-requirement">1.1. 
       MediaKeysPolicy Dictionary </a> <a href="#ref-for-policy-requirement①">(2)</a>
@@ -974,80 +974,136 @@ requesting a key.</p>
     <li><a href="#ref-for-policy-requirement③">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fulfilled">
-   <b><a href="#fulfilled">#fulfilled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fulfilled" class="dfn-panel" data-for="fulfilled" id="infopanel-for-fulfilled" role="dialog">
+   <span id="infopaneltitle-for-fulfilled" style="display:none">Info about the 'fulfilled' definition.</span><b><a href="#fulfilled">#fulfilled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fulfilled">1.2. 
       HDCP Policy </a>
     <li><a href="#ref-for-fulfilled①">2. MediaKeys extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-hdcpversion">
-   <b><a href="#enumdef-hdcpversion">#enumdef-hdcpversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-hdcpversion" class="dfn-panel" data-for="enumdef-hdcpversion" id="infopanel-for-enumdef-hdcpversion" role="dialog">
+   <span id="infopaneltitle-for-enumdef-hdcpversion" style="display:none">Info about the 'HDCPVersion' definition.</span><b><a href="#enumdef-hdcpversion">#enumdef-hdcpversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-hdcpversion">1.1. 
       MediaKeysPolicy Dictionary </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediakeys-getstatusforpolicy">
-   <b><a href="#dom-mediakeys-getstatusforpolicy">#dom-mediakeys-getstatusforpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediakeys-getstatusforpolicy" class="dfn-panel" data-for="dom-mediakeys-getstatusforpolicy" id="infopanel-for-dom-mediakeys-getstatusforpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-mediakeys-getstatusforpolicy" style="display:none">Info about the 'getStatusForPolicy' definition.</span><b><a href="#dom-mediakeys-getstatusforpolicy">#dom-mediakeys-getstatusforpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeys-getstatusforpolicy">2. MediaKeys extension</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/idle-detection/index.html
+++ b/tests/github/WICG/idle-detection/index.html
@@ -1711,264 +1711,264 @@ for their help in crafting this proposal.</p>
    <li><a href="#dom-idledetector-userstate-slot">[[userState]]</a><span>, in § 2.4</span>
    <li><a href="#dom-idledetector-userstate">userState</a><span>, in § 2.4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-abortsignal①">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2.4.6. Reacting to state changes</a> <a href="#ref-for-concept-event-fire①">(2)</a> <a href="#ref-for-concept-event-fire②">(3)</a> <a href="#ref-for-concept-event-fire③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">2.4. The IdleDetector interface</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-requestdestination-iframe">
-   <a href="https://fetch.spec.whatwg.org/#dom-requestdestination-iframe">https://fetch.spec.whatwg.org/#dom-requestdestination-iframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-requestdestination-iframe" class="dfn-panel" data-for="term-for-dom-requestdestination-iframe" id="infopanel-for-term-for-dom-requestdestination-iframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-requestdestination-iframe" style="display:none">Info about the '"iframe"' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-requestdestination-iframe">https://fetch.spec.whatwg.org/#dom-requestdestination-iframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdestination-iframe">2.3. Permissions policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-change">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-change">https://html.spec.whatwg.org/multipage/indices.html#event-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-change" class="dfn-panel" data-for="term-for-event-change" id="infopanel-for-term-for-event-change" role="menu">
+   <span id="infopaneltitle-for-term-for-event-change" style="display:none">Info about the 'change' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-change">https://html.spec.whatwg.org/multipage/indices.html#event-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-change">2.4.3. onchange attribute</a>
     <li><a href="#ref-for-event-change①">2.4.5. start() method</a>
     <li><a href="#ref-for-event-change②">2.4.6. Reacting to state changes</a> <a href="#ref-for-event-change③">(2)</a> <a href="#ref-for-event-change④">(3)</a> <a href="#ref-for-event-change⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">2.4.3. onchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.4.4. requestPermission() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handler-onkeypress">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#handler-onkeypress">https://html.spec.whatwg.org/multipage/webappapis.html#handler-onkeypress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handler-onkeypress" class="dfn-panel" data-for="term-for-handler-onkeypress" id="infopanel-for-term-for-handler-onkeypress" role="menu">
+   <span id="infopaneltitle-for-term-for-handler-onkeypress" style="display:none">Info about the 'onkeypress' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#handler-onkeypress">https://html.spec.whatwg.org/multipage/webappapis.html#handler-onkeypress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-onkeypress">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handler-onmousemove">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousemove">https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousemove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handler-onmousemove" class="dfn-panel" data-for="term-for-handler-onmousemove" id="infopanel-for-term-for-handler-onmousemove" role="menu">
+   <span id="infopaneltitle-for-term-for-handler-onmousemove" style="display:none">Info about the 'onmousemove' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousemove">https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousemove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-onmousemove">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-queue-a-global-task①">2.4.5. start() method</a>
     <li><a href="#ref-for-queue-a-global-task②">2.4.6. Reacting to state changes</a> <a href="#ref-for-queue-a-global-task③">(2)</a> <a href="#ref-for-queue-a-global-task④">(3)</a> <a href="#ref-for-queue-a-global-task⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">2.4.4. requestPermission() method</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
     <li><a href="#ref-for-concept-relevant-global②">2.4.5. start() method</a> <a href="#ref-for-concept-relevant-global③">(2)</a>
     <li><a href="#ref-for-concept-relevant-global④">2.4.6. Reacting to state changes</a> <a href="#ref-for-concept-relevant-global⑤">(2)</a> <a href="#ref-for-concept-relevant-global⑥">(3)</a> <a href="#ref-for-concept-relevant-global⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">2.4.4. requestPermission() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abort-when">
-   <a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abort-when" class="dfn-panel" data-for="term-for-abort-when" id="infopanel-for-term-for-abort-when" role="menu">
+   <span id="infopaneltitle-for-term-for-abort-when" style="display:none">Info about the 'abort when' external reference.</span><a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-when">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-agent">
-   <a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-agent" class="dfn-panel" data-for="term-for-user-agent" id="infopanel-for-term-for-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-user-agent" style="display:none">Info about the 'user agent' external reference.</span><a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">2.4.5. start() method</a>
     <li><a href="#ref-for-user-agent①">2.4.6. Reacting to state changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-hidden">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dom-document-hidden">https://www.w3.org/TR/page-visibility-2/#dom-document-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-hidden" class="dfn-panel" data-for="term-for-dom-document-hidden" id="infopanel-for-term-for-dom-document-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dom-document-hidden">https://www.w3.org/TR/page-visibility-2/#dom-document-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-hidden">1. Introduction</a> <a href="#ref-for-dom-document-hidden①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-onvisibilitychange">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dom-document-onvisibilitychange">https://www.w3.org/TR/page-visibility-2/#dom-document-onvisibilitychange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-onvisibilitychange" class="dfn-panel" data-for="term-for-dom-document-onvisibilitychange" id="infopanel-for-term-for-dom-document-onvisibilitychange" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-onvisibilitychange" style="display:none">Info about the 'onvisibilitychange' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dom-document-onvisibilitychange">https://www.w3.org/TR/page-visibility-2/#dom-document-onvisibilitychange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-onvisibilitychange">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate" class="dfn-panel" data-for="term-for-dom-permissionstate" id="infopanel-for-term-for-dom-permissionstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate" style="display:none">Info about the 'PermissionState' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">2.2. Permissions</a>
     <li><a href="#ref-for-dfn-powerful-feature①">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-dfn-powerful-feature②">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'requesting permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">2.4.4. requestPermission() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">2.3. Permissions policy</a> <a href="#ref-for-default-allowlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">2.3. Permissions policy</a>
     <li><a href="#ref-for-policy-controlled-feature①">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">2.4.5. start() method</a> <a href="#ref-for-aborterror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-idl-DOMException①">2.4.5. start() method</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a> <a href="#ref-for-idl-DOMException⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.4. The IdleDetector interface</a> <a href="#ref-for-Exposed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-notallowederror①">2.4.5. start() method</a> <a href="#ref-for-notallowederror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.4. The IdleDetector interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">2.4.4. requestPermission() method</a> <a href="#ref-for-a-new-promise①">(2)</a>
     <li><a href="#ref-for-a-new-promise②">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-reject①">2.4.5. start() method</a> <a href="#ref-for-reject②">(2)</a> <a href="#ref-for-reject③">(3)</a> <a href="#ref-for-reject④">(4)</a> <a href="#ref-for-reject⑤">(5)</a> <a href="#ref-for-reject⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">2.4.4. requestPermission() method</a>
     <li><a href="#ref-for-resolve①">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">2.4.1. userState attribute</a>
     <li><a href="#ref-for-this①">2.4.2. screenState attribute</a>
@@ -1976,14 +1976,14 @@ for their help in crafting this proposal.</p>
     <li><a href="#ref-for-this④">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">2.4. The IdleDetector interface</a>
    </ul>
@@ -2132,152 +2132,152 @@ for their help in crafting this proposal.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-useridlestate">
-   <b><a href="#enumdef-useridlestate">#enumdef-useridlestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-useridlestate" class="dfn-panel" data-for="enumdef-useridlestate" id="infopanel-for-enumdef-useridlestate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-useridlestate" style="display:none">Info about the 'UserIdleState' definition.</span><b><a href="#enumdef-useridlestate">#enumdef-useridlestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-useridlestate">2.1.1. The UserIdleState enum</a>
     <li><a href="#ref-for-enumdef-useridlestate①">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-useridlestate-active">
-   <b><a href="#dom-useridlestate-active">#dom-useridlestate-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-useridlestate-active" class="dfn-panel" data-for="dom-useridlestate-active" id="infopanel-for-dom-useridlestate-active" role="dialog">
+   <span id="infopaneltitle-for-dom-useridlestate-active" style="display:none">Info about the '"active"' definition.</span><b><a href="#dom-useridlestate-active">#dom-useridlestate-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-useridlestate-active">2.1.1. The UserIdleState enum</a>
     <li><a href="#ref-for-dom-useridlestate-active①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-useridlestate-active②">(2)</a>
     <li><a href="#ref-for-dom-useridlestate-active③">3.2. Behavior tracking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-useridlestate-idle">
-   <b><a href="#dom-useridlestate-idle">#dom-useridlestate-idle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-useridlestate-idle" class="dfn-panel" data-for="dom-useridlestate-idle" id="infopanel-for-dom-useridlestate-idle" role="dialog">
+   <span id="infopaneltitle-for-dom-useridlestate-idle" style="display:none">Info about the '"idle"' definition.</span><b><a href="#dom-useridlestate-idle">#dom-useridlestate-idle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-useridlestate-idle">2.1.1. The UserIdleState enum</a>
     <li><a href="#ref-for-dom-useridlestate-idle①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-useridlestate-idle②">(2)</a>
     <li><a href="#ref-for-dom-useridlestate-idle③">3.2. Behavior tracking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-screenidlestate">
-   <b><a href="#enumdef-screenidlestate">#enumdef-screenidlestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-screenidlestate" class="dfn-panel" data-for="enumdef-screenidlestate" id="infopanel-for-enumdef-screenidlestate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-screenidlestate" style="display:none">Info about the 'ScreenIdleState' definition.</span><b><a href="#enumdef-screenidlestate">#enumdef-screenidlestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-screenidlestate">2.1.2. The ScreenIdleState enum</a>
     <li><a href="#ref-for-enumdef-screenidlestate①">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screenidlestate-locked">
-   <b><a href="#dom-screenidlestate-locked">#dom-screenidlestate-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screenidlestate-locked" class="dfn-panel" data-for="dom-screenidlestate-locked" id="infopanel-for-dom-screenidlestate-locked" role="dialog">
+   <span id="infopaneltitle-for-dom-screenidlestate-locked" style="display:none">Info about the '"locked"' definition.</span><b><a href="#dom-screenidlestate-locked">#dom-screenidlestate-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screenidlestate-locked">2.1.2. The ScreenIdleState enum</a>
     <li><a href="#ref-for-dom-screenidlestate-locked①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-screenidlestate-locked②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screenidlestate-unlocked">
-   <b><a href="#dom-screenidlestate-unlocked">#dom-screenidlestate-unlocked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screenidlestate-unlocked" class="dfn-panel" data-for="dom-screenidlestate-unlocked" id="infopanel-for-dom-screenidlestate-unlocked" role="dialog">
+   <span id="infopaneltitle-for-dom-screenidlestate-unlocked" style="display:none">Info about the '"unlocked"' definition.</span><b><a href="#dom-screenidlestate-unlocked">#dom-screenidlestate-unlocked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screenidlestate-unlocked">2.1.2. The ScreenIdleState enum</a>
     <li><a href="#ref-for-dom-screenidlestate-unlocked①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-screenidlestate-unlocked②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-idle-detection">
-   <b><a href="#dom-permissionname-idle-detection">#dom-permissionname-idle-detection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-idle-detection" class="dfn-panel" data-for="dom-permissionname-idle-detection" id="infopanel-for-dom-permissionname-idle-detection" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-idle-detection" style="display:none">Info about the '"idle-detection"' definition.</span><b><a href="#dom-permissionname-idle-detection">#dom-permissionname-idle-detection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-idle-detection">2.4.5. start() method</a>
     <li><a href="#ref-for-dom-permissionname-idle-detection①">3.1. Cross-origin information leakage</a> <a href="#ref-for-dom-permissionname-idle-detection②">(2)</a>
     <li><a href="#ref-for-dom-permissionname-idle-detection③">3.3. User coercion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idleoptions">
-   <b><a href="#dictdef-idleoptions">#dictdef-idleoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idleoptions" class="dfn-panel" data-for="dictdef-idleoptions" id="infopanel-for-dictdef-idleoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idleoptions" style="display:none">Info about the 'IdleOptions' definition.</span><b><a href="#dictdef-idleoptions">#dictdef-idleoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idleoptions">2.4. The IdleDetector interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idleoptions-threshold">
-   <b><a href="#dom-idleoptions-threshold">#dom-idleoptions-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idleoptions-threshold" class="dfn-panel" data-for="dom-idleoptions-threshold" id="infopanel-for-dom-idleoptions-threshold" role="dialog">
+   <span id="infopaneltitle-for-dom-idleoptions-threshold" style="display:none">Info about the 'threshold' definition.</span><b><a href="#dom-idleoptions-threshold">#dom-idleoptions-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idleoptions-threshold">2.1.1. The UserIdleState enum</a> <a href="#ref-for-dom-idleoptions-threshold①">(2)</a>
     <li><a href="#ref-for-dom-idleoptions-threshold②">2.4.5. start() method</a> <a href="#ref-for-dom-idleoptions-threshold③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idleoptions-signal">
-   <b><a href="#dom-idleoptions-signal">#dom-idleoptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idleoptions-signal" class="dfn-panel" data-for="dom-idleoptions-signal" id="infopanel-for-dom-idleoptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-idleoptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-idleoptions-signal">#dom-idleoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idleoptions-signal">2.4.5. start() method</a> <a href="#ref-for-dom-idleoptions-signal①">(2)</a> <a href="#ref-for-dom-idleoptions-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idledetector">
-   <b><a href="#idledetector">#idledetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idledetector" class="dfn-panel" data-for="idledetector" id="infopanel-for-idledetector" role="dialog">
+   <span id="infopaneltitle-for-idledetector" style="display:none">Info about the 'IdleDetector' definition.</span><b><a href="#idledetector">#idledetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idledetector">2.4. The IdleDetector interface</a> <a href="#ref-for-idledetector①">(2)</a> <a href="#ref-for-idledetector②">(3)</a>
     <li><a href="#ref-for-idledetector③">2.4.5. start() method</a> <a href="#ref-for-idledetector④">(2)</a>
     <li><a href="#ref-for-idledetector⑤">2.4.6. Reacting to state changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-state-slot">
-   <b><a href="#dom-idledetector-state-slot">#dom-idledetector-state-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-state-slot" class="dfn-panel" data-for="dom-idledetector-state-slot" id="infopanel-for-dom-idledetector-state-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-state-slot" style="display:none">Info about the '[[state]]' definition.</span><b><a href="#dom-idledetector-state-slot">#dom-idledetector-state-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-state-slot">2.4.5. start() method</a> <a href="#ref-for-dom-idledetector-state-slot①">(2)</a> <a href="#ref-for-dom-idledetector-state-slot②">(3)</a> <a href="#ref-for-dom-idledetector-state-slot③">(4)</a> <a href="#ref-for-dom-idledetector-state-slot④">(5)</a> <a href="#ref-for-dom-idledetector-state-slot⑤">(6)</a>
     <li><a href="#ref-for-dom-idledetector-state-slot⑥">2.4.6. Reacting to state changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-threshold-slot">
-   <b><a href="#dom-idledetector-threshold-slot">#dom-idledetector-threshold-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-threshold-slot" class="dfn-panel" data-for="dom-idledetector-threshold-slot" id="infopanel-for-dom-idledetector-threshold-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-threshold-slot" style="display:none">Info about the '[[threshold]]' definition.</span><b><a href="#dom-idledetector-threshold-slot">#dom-idledetector-threshold-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-threshold-slot">2.4.5. start() method</a>
     <li><a href="#ref-for-dom-idledetector-threshold-slot①">2.4.6. Reacting to state changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-userstate-slot">
-   <b><a href="#dom-idledetector-userstate-slot">#dom-idledetector-userstate-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-userstate-slot" class="dfn-panel" data-for="dom-idledetector-userstate-slot" id="infopanel-for-dom-idledetector-userstate-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-userstate-slot" style="display:none">Info about the '[[userState]]' definition.</span><b><a href="#dom-idledetector-userstate-slot">#dom-idledetector-userstate-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-userstate-slot">2.4.1. userState attribute</a>
     <li><a href="#ref-for-dom-idledetector-userstate-slot①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-idledetector-userstate-slot②">(2)</a> <a href="#ref-for-dom-idledetector-userstate-slot③">(3)</a> <a href="#ref-for-dom-idledetector-userstate-slot④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-screenstate-slot">
-   <b><a href="#dom-idledetector-screenstate-slot">#dom-idledetector-screenstate-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-screenstate-slot" class="dfn-panel" data-for="dom-idledetector-screenstate-slot" id="infopanel-for-dom-idledetector-screenstate-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-screenstate-slot" style="display:none">Info about the '[[screenState]]' definition.</span><b><a href="#dom-idledetector-screenstate-slot">#dom-idledetector-screenstate-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-screenstate-slot">2.4.2. screenState attribute</a>
     <li><a href="#ref-for-dom-idledetector-screenstate-slot①">2.4.6. Reacting to state changes</a> <a href="#ref-for-dom-idledetector-screenstate-slot②">(2)</a> <a href="#ref-for-dom-idledetector-screenstate-slot③">(3)</a> <a href="#ref-for-dom-idledetector-screenstate-slot④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idle-detection-task-source">
-   <b><a href="#idle-detection-task-source">#idle-detection-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idle-detection-task-source" class="dfn-panel" data-for="idle-detection-task-source" id="infopanel-for-idle-detection-task-source" role="dialog">
+   <span id="infopaneltitle-for-idle-detection-task-source" style="display:none">Info about the 'idle detection task source' definition.</span><b><a href="#idle-detection-task-source">#idle-detection-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle-detection-task-source">2.4.5. start() method</a>
     <li><a href="#ref-for-idle-detection-task-source①">2.4.6. Reacting to state changes</a> <a href="#ref-for-idle-detection-task-source②">(2)</a> <a href="#ref-for-idle-detection-task-source③">(3)</a> <a href="#ref-for-idle-detection-task-source④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-userstate">
-   <b><a href="#dom-idledetector-userstate">#dom-idledetector-userstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-userstate" class="dfn-panel" data-for="dom-idledetector-userstate" id="infopanel-for-dom-idledetector-userstate" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-userstate" style="display:none">Info about the 'userState' definition.</span><b><a href="#dom-idledetector-userstate">#dom-idledetector-userstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-userstate">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-dom-idledetector-userstate①">2.4.1. userState attribute</a>
     <li><a href="#ref-for-dom-idledetector-userstate②">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-screenstate">
-   <b><a href="#dom-idledetector-screenstate">#dom-idledetector-screenstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-screenstate" class="dfn-panel" data-for="dom-idledetector-screenstate" id="infopanel-for-dom-idledetector-screenstate" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-screenstate" style="display:none">Info about the 'screenState' definition.</span><b><a href="#dom-idledetector-screenstate">#dom-idledetector-screenstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-screenstate">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-dom-idledetector-screenstate①">2.4.2. screenState attribute</a>
     <li><a href="#ref-for-dom-idledetector-screenstate②">2.4.5. start() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-onchange">
-   <b><a href="#dom-idledetector-onchange">#dom-idledetector-onchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-onchange" class="dfn-panel" data-for="dom-idledetector-onchange" id="infopanel-for-dom-idledetector-onchange" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-onchange" style="display:none">Info about the 'onchange' definition.</span><b><a href="#dom-idledetector-onchange">#dom-idledetector-onchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-onchange">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-dom-idledetector-onchange①">2.4.3. onchange attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-requestpermission">
-   <b><a href="#dom-idledetector-requestpermission">#dom-idledetector-requestpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-requestpermission" class="dfn-panel" data-for="dom-idledetector-requestpermission" id="infopanel-for-dom-idledetector-requestpermission" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-requestpermission" style="display:none">Info about the 'requestPermission()' definition.</span><b><a href="#dom-idledetector-requestpermission">#dom-idledetector-requestpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-requestpermission">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-dom-idledetector-requestpermission①">2.4.4. requestPermission() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idledetector-start">
-   <b><a href="#dom-idledetector-start">#dom-idledetector-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idledetector-start" class="dfn-panel" data-for="dom-idledetector-start" id="infopanel-for-dom-idledetector-start" role="dialog">
+   <span id="infopaneltitle-for-dom-idledetector-start" style="display:none">Info about the 'start(options)' definition.</span><b><a href="#dom-idledetector-start">#dom-idledetector-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idledetector-start">2.4. The IdleDetector interface</a>
     <li><a href="#ref-for-dom-idledetector-start①">2.4.5. start() method</a> <a href="#ref-for-dom-idledetector-start②">(2)</a> <a href="#ref-for-dom-idledetector-start③">(3)</a>
@@ -2285,59 +2285,115 @@ for their help in crafting this proposal.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/import-maps/spec.html
+++ b/tests/github/WICG/import-maps/spec.html
@@ -1286,271 +1286,271 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <li><a href="#the-scripts-result">the script’s result</a><span>, in § 2.2</span>
    <li><a href="#wait-for-import-maps">wait for import maps</a><span>, in § 2.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-report-a-warning-to-the-console">
-   <a href="https://console.spec.whatwg.org/#report-a-warning-to-the-console">https://console.spec.whatwg.org/#report-a-warning-to-the-console</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-a-warning-to-the-console" class="dfn-panel" data-for="term-for-report-a-warning-to-the-console" id="infopanel-for-term-for-report-a-warning-to-the-console" role="menu">
+   <span id="infopaneltitle-for-term-for-report-a-warning-to-the-console" style="display:none">Info about the 'report a warning to the console' external reference.</span><a href="https://console.spec.whatwg.org/#report-a-warning-to-the-console">https://console.spec.whatwg.org/#report-a-warning-to-the-console</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-a-warning-to-the-console">3. Parsing import maps</a> <a href="#ref-for-report-a-warning-to-the-console①">(2)</a> <a href="#ref-for-report-a-warning-to-the-console②">(3)</a> <a href="#ref-for-report-a-warning-to-the-console③">(4)</a> <a href="#ref-for-report-a-warning-to-the-console④">(5)</a> <a href="#ref-for-report-a-warning-to-the-console⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. New members of environment settings objects</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a>
     <li><a href="#ref-for-document③">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2.5. Registering an import map</a> <a href="#ref-for-concept-event-fire①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">2.3. Prepare a script</a> <a href="#ref-for-concept-node-document①">(2)</a> <a href="#ref-for-concept-node-document②">(3)</a> <a href="#ref-for-concept-node-document③">(4)</a>
     <li><a href="#ref-for-concept-node-document④">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">2.3. Prepare a script</a> <a href="#ref-for-concept-request-destination①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extracting a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer" class="dfn-panel" data-for="term-for-concept-request-referrer" id="infopanel-for-term-for-concept-request-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer" style="display:none">Info about the 'referrer' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlscriptelement" class="dfn-panel" data-for="term-for-htmlscriptelement" id="infopanel-for-term-for-htmlscriptelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlscriptelement" style="display:none">Info about the 'HTMLScriptElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlscriptelement">2.1. New members of environment settings objects</a>
     <li><a href="#ref-for-htmlscriptelement①">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">2.1. New members of environment settings objects</a> <a href="#ref-for-workerglobalscope①">(2)</a> <a href="#ref-for-workerglobalscope②">(3)</a>
     <li><a href="#ref-for-workerglobalscope③">2.4. Wait for import maps</a> <a href="#ref-for-workerglobalscope④">(2)</a> <a href="#ref-for-workerglobalscope⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">2.1. New members of environment settings objects</a>
     <li><a href="#ref-for-concept-document-window①">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script-base-url" class="dfn-panel" data-for="term-for-concept-script-base-url" id="infopanel-for-term-for-concept-script-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script-base-url">4.1. New "resolve a module specifier"</a>
     <li><a href="#ref-for-concept-script-base-url①">4.2. Updates to other algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-same-origin" class="dfn-panel" data-for="term-for-cors-same-origin" id="infopanel-for-term-for-cors-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-same-origin" style="display:none">Info about the 'cors-same-origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-same-origin">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.1. New members of environment settings objects</a>
     <li><a href="#ref-for-environment-settings-object①">2.2. Script type</a>
     <li><a href="#ref-for-environment-settings-object②">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree" id="infopanel-for-term-for-fetch-a-module-worker-script-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" style="display:none">Info about the 'fetch a module worker script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-module-worker-script-tree">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-modulepreload-module-script-graph">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-modulepreload-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-modulepreload-module-script-graph</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-modulepreload-module-script-graph" class="dfn-panel" data-for="term-for-fetch-a-modulepreload-module-script-graph" id="infopanel-for-term-for-fetch-a-modulepreload-module-script-graph" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-modulepreload-module-script-graph" style="display:none">Info about the 'fetch a modulepreload module script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-modulepreload-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-modulepreload-module-script-graph</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-modulepreload-module-script-graph">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-single-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-single-module-script" class="dfn-panel" data-for="term-for-fetch-a-single-module-script" id="infopanel-for-term-for-fetch-a-single-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-single-module-script" style="display:none">Info about the 'fetch a single module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-single-module-script">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-module-script-tree">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-module-script-tree" class="dfn-panel" data-for="term-for-fetch-a-module-script-tree" id="infopanel-for-term-for-fetch-a-module-script-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-module-script-tree" style="display:none">Info about the 'fetch an external module script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-script-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-module-script-tree">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-an-import()-module-script-graph">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-import()-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-import()-module-script-graph</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-an-import()-module-script-graph" class="dfn-panel" data-for="term-for-fetch-an-import()-module-script-graph" id="infopanel-for-term-for-fetch-an-import()-module-script-graph" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-an-import()-module-script-graph" style="display:none">Info about the 'fetch an import() module script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-import()-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-import()-module-script-graph</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-an-import()-module-script-graph">2.4. Wait for import maps</a>
     <li><a href="#ref-for-fetch-an-import()-module-script-graph①">4.2. Updates to other algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-an-inline-module-script-graph">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-an-inline-module-script-graph" class="dfn-panel" data-for="term-for-fetch-an-inline-module-script-graph" id="infopanel-for-term-for-fetch-an-inline-module-script-graph" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-an-inline-module-script-graph" style="display:none">Info about the 'fetch an inline module script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-an-inline-module-script-graph</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-an-inline-module-script-graph">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script-external">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#concept-script-external">https://html.spec.whatwg.org/multipage/scripting.html#concept-script-external</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script-external" class="dfn-panel" data-for="term-for-concept-script-external" id="infopanel-for-term-for-concept-script-external" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script-external" style="display:none">Info about the 'from an external file' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#concept-script-external">https://html.spec.whatwg.org/multipage/scripting.html#concept-script-external</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script-external">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.4. Wait for import maps</a> <a href="#ref-for-concept-settings-object-global①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#list-of-scripts-that-will-execute-in-order-as-soon-as-possible">https://html.spec.whatwg.org/multipage/scripting.html#list-of-scripts-that-will-execute-in-order-as-soon-as-possible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible" class="dfn-panel" data-for="term-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible" id="infopanel-for-term-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible" style="display:none">Info about the 'list of scripts that will execute in order as soon as possible' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#list-of-scripts-that-will-execute-in-order-as-soon-as-possible">https://html.spec.whatwg.org/multipage/scripting.html#list-of-scripts-that-will-execute-in-order-as-soon-as-possible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-scripts-that-will-execute-in-order-as-soon-as-possible">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve-a-module-specifier">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier">https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve-a-module-specifier" class="dfn-panel" data-for="term-for-resolve-a-module-specifier" id="infopanel-for-term-for-resolve-a-module-specifier" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve-a-module-specifier" style="display:none">Info about the 'resolve a module specifier' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier">https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-module-specifier③">4.1. New "resolve a module specifier"</a>
     <li><a href="#ref-for-resolve-a-module-specifier⑨">4.2. Updates to other algorithms</a>
     <li><a href="#ref-for-resolve-a-module-specifier①②">5.2. A note on import specifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script" class="dfn-panel" data-for="term-for-concept-script" id="infopanel-for-term-for-concept-script" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script">2.2. Script type</a> <a href="#ref-for-concept-script①">(2)</a>
     <li><a href="#ref-for-concept-script②">2.5. Registering an import map</a> <a href="#ref-for-concept-script③">(2)</a>
@@ -1558,162 +1558,162 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-concept-script⑤">4.2. Updates to other algorithms</a> <a href="#ref-for-concept-script⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-up-a-window-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#set-up-a-window-environment-settings-object">https://html.spec.whatwg.org/multipage/nav-history-apis.html#set-up-a-window-environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-up-a-window-environment-settings-object" class="dfn-panel" data-for="term-for-set-up-a-window-environment-settings-object" id="infopanel-for-term-for-set-up-a-window-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-set-up-a-window-environment-settings-object" style="display:none">Info about the 'set up a window environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#set-up-a-window-environment-settings-object">https://html.spec.whatwg.org/multipage/nav-history-apis.html#set-up-a-window-environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-a-window-environment-settings-object">2.1. New members of environment settings objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-up-a-worker-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#set-up-a-worker-environment-settings-object">https://html.spec.whatwg.org/multipage/workers.html#set-up-a-worker-environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-up-a-worker-environment-settings-object" class="dfn-panel" data-for="term-for-set-up-a-worker-environment-settings-object" id="infopanel-for-term-for-set-up-a-worker-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-set-up-a-worker-environment-settings-object" style="display:none">Info about the 'set up a worker environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#set-up-a-worker-environment-settings-object">https://html.spec.whatwg.org/multipage/workers.html#set-up-a-worker-environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-a-worker-environment-settings-object">2.1. New members of environment settings objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-up-the-module-script-request">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#set-up-the-module-script-request">https://html.spec.whatwg.org/multipage/webappapis.html#set-up-the-module-script-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-up-the-module-script-request" class="dfn-panel" data-for="term-for-set-up-the-module-script-request" id="infopanel-for-term-for-set-up-the-module-script-request" role="menu">
+   <span id="infopaneltitle-for-term-for-set-up-the-module-script-request" style="display:none">Info about the 'set up the module script request' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#set-up-the-module-script-request">https://html.spec.whatwg.org/multipage/webappapis.html#set-up-the-module-script-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-the-module-script-request">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-spin-the-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-spin-the-event-loop" class="dfn-panel" data-for="term-for-spin-the-event-loop" id="infopanel-for-term-for-spin-the-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-spin-the-event-loop" style="display:none">Info about the 'spin the event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spin-the-event-loop">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">2.3. Prepare a script</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit-less-than">
-   <a href="https://infra.spec.whatwg.org/#code-unit-less-than">https://infra.spec.whatwg.org/#code-unit-less-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit-less-than" class="dfn-panel" data-for="term-for-code-unit-less-than" id="infopanel-for-term-for-code-unit-less-than" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit-less-than" style="display:none">Info about the 'code unit less than' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit-less-than">https://infra.spec.whatwg.org/#code-unit-less-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit-less-than">3. Parsing import maps</a> <a href="#ref-for-code-unit-less-than①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3. Parsing import maps</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3. Parsing import maps</a> <a href="#ref-for-map-exists①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3. Parsing import maps</a> <a href="#ref-for-map-iterate①">(2)</a>
     <li><a href="#ref-for-map-iterate②">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'get the keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">1. Definitions</a>
     <li><a href="#ref-for-struct-item①">2.2. Script type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'javascript string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">1. Definitions</a>
     <li><a href="#ref-for-string①">3. Parsing import maps</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a> <a href="#ref-for-string⑤">(5)</a>
     <li><a href="#ref-for-string⑥">4.1. New "resolve a module specifier"</a> <a href="#ref-for-string⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">3. Parsing import maps</a> <a href="#ref-for-map-key①">(2)</a> <a href="#ref-for-map-key②">(3)</a> <a href="#ref-for-map-key③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1. Definitions</a> <a href="#ref-for-ordered-map①">(2)</a>
     <li><a href="#ref-for-ordered-map②">3. Parsing import maps</a> <a href="#ref-for-ordered-map③">(2)</a> <a href="#ref-for-ordered-map④">(3)</a> <a href="#ref-for-ordered-map⑤">(4)</a> <a href="#ref-for-ordered-map⑥">(5)</a> <a href="#ref-for-ordered-map⑦">(6)</a> <a href="#ref-for-ordered-map⑧">(7)</a> <a href="#ref-for-ordered-map⑨">(8)</a> <a href="#ref-for-ordered-map①⓪">(9)</a> <a href="#ref-for-ordered-map①①">(10)</a> <a href="#ref-for-ordered-map①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1. Definitions</a> <a href="#ref-for-ordered-map①">(2)</a>
     <li><a href="#ref-for-ordered-map②">3. Parsing import maps</a> <a href="#ref-for-ordered-map③">(2)</a> <a href="#ref-for-ordered-map④">(3)</a> <a href="#ref-for-ordered-map⑤">(4)</a> <a href="#ref-for-ordered-map⑥">(5)</a> <a href="#ref-for-ordered-map⑦">(6)</a> <a href="#ref-for-ordered-map⑧">(7)</a> <a href="#ref-for-ordered-map⑨">(8)</a> <a href="#ref-for-ordered-map①⓪">(9)</a> <a href="#ref-for-ordered-map①①">(10)</a> <a href="#ref-for-ordered-map①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value">
-   <a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value" id="infopanel-for-term-for-parse-a-json-string-to-an-infra-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" style="display:none">Info about the 'parse json into infra values' external reference.</span><a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-json-string-to-an-infra-value">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-sort-in-ascending-order">
-   <a href="https://infra.spec.whatwg.org/#map-sort-in-ascending-order">https://infra.spec.whatwg.org/#map-sort-in-ascending-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-sort-in-ascending-order" class="dfn-panel" data-for="term-for-map-sort-in-ascending-order" id="infopanel-for-term-for-map-sort-in-ascending-order" role="menu">
+   <span id="infopaneltitle-for-term-for-map-sort-in-ascending-order" style="display:none">Info about the 'sorting' external reference.</span><a href="https://infra.spec.whatwg.org/#map-sort-in-ascending-order">https://infra.spec.whatwg.org/#map-sort-in-ascending-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-sort-in-ascending-order">3. Parsing import maps</a> <a href="#ref-for-map-sort-in-ascending-order①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-starts-with">
-   <a href="https://infra.spec.whatwg.org/#string-starts-with">https://infra.spec.whatwg.org/#string-starts-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-starts-with" class="dfn-panel" data-for="term-for-string-starts-with" id="infopanel-for-term-for-string-starts-with" role="menu">
+   <span id="infopaneltitle-for-term-for-string-starts-with" style="display:none">Info about the 'starts with' external reference.</span><a href="https://infra.spec.whatwg.org/#string-starts-with">https://infra.spec.whatwg.org/#string-starts-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-starts-with">3. Parsing import maps</a> <a href="#ref-for-string-starts-with①">(2)</a>
     <li><a href="#ref-for-string-starts-with②">4.1. New "resolve a module specifier"</a> <a href="#ref-for-string-starts-with③">(2)</a> <a href="#ref-for-string-starts-with④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string①" role="menu">
+   <span id="infopaneltitle-for-term-for-string①" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">1. Definitions</a>
     <li><a href="#ref-for-string①">3. Parsing import maps</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a> <a href="#ref-for-string⑤">(5)</a>
     <li><a href="#ref-for-string⑥">4.1. New "resolve a module specifier"</a> <a href="#ref-for-string⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">1. Definitions</a>
     <li><a href="#ref-for-struct①">2.2. Script type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-special">
-   <a href="https://url.spec.whatwg.org/#is-special">https://url.spec.whatwg.org/#is-special</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-special" class="dfn-panel" data-for="term-for-is-special" id="infopanel-for-term-for-is-special" role="menu">
+   <span id="infopaneltitle-for-term-for-is-special" style="display:none">Info about the 'is special' external reference.</span><a href="https://url.spec.whatwg.org/#is-special">https://url.spec.whatwg.org/#is-special</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-special">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">1. Definitions</a> <a href="#ref-for-concept-url①">(2)</a>
     <li><a href="#ref-for-concept-url②">3. Parsing import maps</a> <a href="#ref-for-concept-url③">(2)</a> <a href="#ref-for-concept-url④">(3)</a> <a href="#ref-for-concept-url⑤">(4)</a> <a href="#ref-for-concept-url⑥">(5)</a> <a href="#ref-for-concept-url⑦">(6)</a>
@@ -1722,22 +1722,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-concept-url①④">5.2. A note on import specifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3. Parsing import maps</a> <a href="#ref-for-concept-url-parser①">(2)</a> <a href="#ref-for-concept-url-parser②">(3)</a>
     <li><a href="#ref-for-concept-url-parser③">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3. Parsing import maps</a> <a href="#ref-for-concept-url-serializer①">(2)</a> <a href="#ref-for-concept-url-serializer②">(3)</a>
     <li><a href="#ref-for-concept-url-serializer③">4.1. New "resolve a module specifier"</a> <a href="#ref-for-concept-url-serializer④">(2)</a> <a href="#ref-for-concept-url-serializer⑤">(3)</a> <a href="#ref-for-concept-url-serializer⑥">(4)</a> <a href="#ref-for-concept-url-serializer⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">3. Parsing import maps</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a> <a href="#ref-for-exceptiondef-typeerror③">(4)</a>
     <li><a href="#ref-for-exceptiondef-typeerror④">4.1. New "resolve a module specifier"</a> <a href="#ref-for-exceptiondef-typeerror⑤">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑥">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑦">(4)</a> <a href="#ref-for-exceptiondef-typeerror⑧">(5)</a>
@@ -1875,22 +1875,22 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
    <div class="issue"> Specify a way to set <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#workerglobalscope-import-map">import map</a>. We might want to inherit parent context’s import maps, or provide APIs on <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">WorkerGlobalScope</a></code>, but we are not sure. Currently it is always an <a data-link-type="dfn" href="#empty-import-map">empty import map</a>. See <a href="https://github.com/WICG/import-maps/issues/2">#2</a>. <a class="issue-return" href="#issue-53aae9a6" title="Jump to section">↵</a></div>
    <div class="issue">There are no relevant <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>, because <a data-link-type="dfn" href="#import-map-parse-result">import map parse result</a> isn’t a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">script</a>. This needs to wait for <a href="https://github.com/whatwg/html/issues/958">whatwg/html#958</a> before it is fixable. <a class="issue-return" href="#issue-3b40327d" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="resolution-result">
-   <b><a href="#resolution-result">#resolution-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolution-result" class="dfn-panel" data-for="resolution-result" id="infopanel-for-resolution-result" role="dialog">
+   <span id="infopaneltitle-for-resolution-result" style="display:none">Info about the 'resolution result' definition.</span><b><a href="#resolution-result">#resolution-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-result">1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specifier-map">
-   <b><a href="#specifier-map">#specifier-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specifier-map" class="dfn-panel" data-for="specifier-map" id="infopanel-for-specifier-map" role="dialog">
+   <span id="infopaneltitle-for-specifier-map" style="display:none">Info about the 'specifier map' definition.</span><b><a href="#specifier-map">#specifier-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specifier-map">1. Definitions</a> <a href="#ref-for-specifier-map①">(2)</a>
     <li><a href="#ref-for-specifier-map②">4. Resolving module specifiers</a>
     <li><a href="#ref-for-specifier-map③">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map">
-   <b><a href="#import-map">#import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map" class="dfn-panel" data-for="import-map" id="infopanel-for-import-map" role="dialog">
+   <span id="infopaneltitle-for-import-map" style="display:none">Info about the 'import map' definition.</span><b><a href="#import-map">#import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map">1. Definitions</a>
     <li><a href="#ref-for-import-map①">2.1. New members of environment settings objects</a> <a href="#ref-for-import-map②">(2)</a> <a href="#ref-for-import-map③">(3)</a>
@@ -1899,227 +1899,283 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li><a href="#ref-for-import-map⑥">3. Parsing import maps</a> <a href="#ref-for-import-map⑦">(2)</a> <a href="#ref-for-import-map⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-imports">
-   <b><a href="#import-map-imports">#import-map-imports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-imports" class="dfn-panel" data-for="import-map-imports" id="infopanel-for-import-map-imports" role="dialog">
+   <span id="infopaneltitle-for-import-map-imports" style="display:none">Info about the 'imports' definition.</span><b><a href="#import-map-imports">#import-map-imports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-imports">1. Definitions</a>
     <li><a href="#ref-for-import-map-imports①">3. Parsing import maps</a> <a href="#ref-for-import-map-imports②">(2)</a>
     <li><a href="#ref-for-import-map-imports③">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-scopes">
-   <b><a href="#import-map-scopes">#import-map-scopes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-scopes" class="dfn-panel" data-for="import-map-scopes" id="infopanel-for-import-map-scopes" role="dialog">
+   <span id="infopaneltitle-for-import-map-scopes" style="display:none">Info about the 'scopes' definition.</span><b><a href="#import-map-scopes">#import-map-scopes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-scopes">1. Definitions</a>
     <li><a href="#ref-for-import-map-scopes①">3. Parsing import maps</a> <a href="#ref-for-import-map-scopes②">(2)</a>
     <li><a href="#ref-for-import-map-scopes③">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-import-map">
-   <b><a href="#empty-import-map">#empty-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-import-map" class="dfn-panel" data-for="empty-import-map" id="infopanel-for-empty-import-map" role="dialog">
+   <span id="infopaneltitle-for-empty-import-map" style="display:none">Info about the 'empty import map' definition.</span><b><a href="#empty-import-map">#empty-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-import-map">2.1. New members of environment settings objects</a> <a href="#ref-for-empty-import-map①">(2)</a> <a href="#ref-for-empty-import-map②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-import-map">
-   <b><a href="#environment-settings-object-import-map">#environment-settings-object-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-import-map" class="dfn-panel" data-for="environment-settings-object-import-map" id="infopanel-for-environment-settings-object-import-map" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-import-map" style="display:none">Info about the 'import map' definition.</span><b><a href="#environment-settings-object-import-map">#environment-settings-object-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-import-map">2.1. New members of environment settings objects</a> <a href="#ref-for-environment-settings-object-import-map①">(2)</a>
     <li><a href="#ref-for-environment-settings-object-import-map②">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-import-map">
-   <b><a href="#document-import-map">#document-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-import-map" class="dfn-panel" data-for="document-import-map" id="infopanel-for-document-import-map" role="dialog">
+   <span id="infopaneltitle-for-document-import-map" style="display:none">Info about the 'import map' definition.</span><b><a href="#document-import-map">#document-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-import-map">2.1. New members of environment settings objects</a>
     <li><a href="#ref-for-document-import-map①">2.5. Registering an import map</a> <a href="#ref-for-document-import-map②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="workerglobalscope-import-map">
-   <b><a href="#workerglobalscope-import-map">#workerglobalscope-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-workerglobalscope-import-map" class="dfn-panel" data-for="workerglobalscope-import-map" id="infopanel-for-workerglobalscope-import-map" role="dialog">
+   <span id="infopaneltitle-for-workerglobalscope-import-map" style="display:none">Info about the 'import map' definition.</span><b><a href="#workerglobalscope-import-map">#workerglobalscope-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope-import-map">2.1. New members of environment settings objects</a> <a href="#ref-for-workerglobalscope-import-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-pending-import-map-script">
-   <b><a href="#document-pending-import-map-script">#document-pending-import-map-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-pending-import-map-script" class="dfn-panel" data-for="document-pending-import-map-script" id="infopanel-for-document-pending-import-map-script" role="dialog">
+   <span id="infopaneltitle-for-document-pending-import-map-script" style="display:none">Info about the 'pending import map script' definition.</span><b><a href="#document-pending-import-map-script">#document-pending-import-map-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-pending-import-map-script">2.3. Prepare a script</a> <a href="#ref-for-document-pending-import-map-script①">(2)</a> <a href="#ref-for-document-pending-import-map-script②">(3)</a> <a href="#ref-for-document-pending-import-map-script③">(4)</a>
     <li><a href="#ref-for-document-pending-import-map-script④">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-acquiring-import-maps">
-   <b><a href="#document-acquiring-import-maps">#document-acquiring-import-maps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-acquiring-import-maps" class="dfn-panel" data-for="document-acquiring-import-maps" id="infopanel-for-document-acquiring-import-maps" role="dialog">
+   <span id="infopaneltitle-for-document-acquiring-import-maps" style="display:none">Info about the 'acquiring import maps' definition.</span><b><a href="#document-acquiring-import-maps">#document-acquiring-import-maps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-acquiring-import-maps">2.3. Prepare a script</a> <a href="#ref-for-document-acquiring-import-maps①">(2)</a> <a href="#ref-for-document-acquiring-import-maps②">(3)</a>
     <li><a href="#ref-for-document-acquiring-import-maps③">2.4. Wait for import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-parse-result">
-   <b><a href="#import-map-parse-result">#import-map-parse-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-parse-result" class="dfn-panel" data-for="import-map-parse-result" id="infopanel-for-import-map-parse-result" role="dialog">
+   <span id="infopaneltitle-for-import-map-parse-result" style="display:none">Info about the 'import map parse result' definition.</span><b><a href="#import-map-parse-result">#import-map-parse-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-parse-result">2.2. Script type</a> <a href="#ref-for-import-map-parse-result①">(2)</a>
     <li><a href="#ref-for-import-map-parse-result②">2.5. Registering an import map</a> <a href="#ref-for-import-map-parse-result③">(2)</a>
     <li><a href="#ref-for-import-map-parse-result④">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-parse-result-settings-object">
-   <b><a href="#import-map-parse-result-settings-object">#import-map-parse-result-settings-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-parse-result-settings-object" class="dfn-panel" data-for="import-map-parse-result-settings-object" id="infopanel-for-import-map-parse-result-settings-object" role="dialog">
+   <span id="infopaneltitle-for-import-map-parse-result-settings-object" style="display:none">Info about the 'settings object' definition.</span><b><a href="#import-map-parse-result-settings-object">#import-map-parse-result-settings-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-parse-result-settings-object">2.5. Registering an import map</a>
     <li><a href="#ref-for-import-map-parse-result-settings-object①">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-parse-result-import-map">
-   <b><a href="#import-map-parse-result-import-map">#import-map-parse-result-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-parse-result-import-map" class="dfn-panel" data-for="import-map-parse-result-import-map" id="infopanel-for-import-map-parse-result-import-map" role="dialog">
+   <span id="infopaneltitle-for-import-map-parse-result-import-map" style="display:none">Info about the 'import map' definition.</span><b><a href="#import-map-parse-result-import-map">#import-map-parse-result-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-parse-result-import-map">2.5. Registering an import map</a>
     <li><a href="#ref-for-import-map-parse-result-import-map①">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-map-parse-result-error-to-rethrow">
-   <b><a href="#import-map-parse-result-error-to-rethrow">#import-map-parse-result-error-to-rethrow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-map-parse-result-error-to-rethrow" class="dfn-panel" data-for="import-map-parse-result-error-to-rethrow" id="infopanel-for-import-map-parse-result-error-to-rethrow" role="dialog">
+   <span id="infopaneltitle-for-import-map-parse-result-error-to-rethrow" style="display:none">Info about the 'error to rethrow' definition.</span><b><a href="#import-map-parse-result-error-to-rethrow">#import-map-parse-result-error-to-rethrow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-map-parse-result-error-to-rethrow">2.5. Registering an import map</a> <a href="#ref-for-import-map-parse-result-error-to-rethrow①">(2)</a>
     <li><a href="#ref-for-import-map-parse-result-error-to-rethrow②">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-scripts-result">
-   <b><a href="#the-scripts-result">#the-scripts-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-scripts-result" class="dfn-panel" data-for="the-scripts-result" id="infopanel-for-the-scripts-result" role="dialog">
+   <span id="infopaneltitle-for-the-scripts-result" style="display:none">Info about the 'the script’s result' definition.</span><b><a href="#the-scripts-result">#the-scripts-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-scripts-result">2.3. Prepare a script</a>
     <li><a href="#ref-for-the-scripts-result①">2.5. Registering an import map</a> <a href="#ref-for-the-scripts-result②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-an-import-map">
-   <b><a href="#fetch-an-import-map">#fetch-an-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-an-import-map" class="dfn-panel" data-for="fetch-an-import-map" id="infopanel-for-fetch-an-import-map" role="dialog">
+   <span id="infopaneltitle-for-fetch-an-import-map" style="display:none">Info about the 'fetch an import map' definition.</span><b><a href="#fetch-an-import-map">#fetch-an-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-an-import-map">2.3. Prepare a script</a> <a href="#ref-for-fetch-an-import-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wait-for-import-maps">
-   <b><a href="#wait-for-import-maps">#wait-for-import-maps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wait-for-import-maps" class="dfn-panel" data-for="wait-for-import-maps" id="infopanel-for-wait-for-import-maps" role="dialog">
+   <span id="infopaneltitle-for-wait-for-import-maps" style="display:none">Info about the 'wait for import maps' definition.</span><b><a href="#wait-for-import-maps">#wait-for-import-maps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-import-maps">2.3. Prepare a script</a>
     <li><a href="#ref-for-wait-for-import-maps①">2.4. Wait for import maps</a>
     <li><a href="#ref-for-wait-for-import-maps②">2.5. Registering an import map</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register-an-import-map">
-   <b><a href="#register-an-import-map">#register-an-import-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-register-an-import-map" class="dfn-panel" data-for="register-an-import-map" id="infopanel-for-register-an-import-map" role="dialog">
+   <span id="infopaneltitle-for-register-an-import-map" style="display:none">Info about the 'register an import map' definition.</span><b><a href="#register-an-import-map">#register-an-import-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-register-an-import-map">2.2. Script type</a>
     <li><a href="#ref-for-register-an-import-map①">2.3. Prepare a script</a>
     <li><a href="#ref-for-register-an-import-map②">2.5. Registering an import map</a> <a href="#ref-for-register-an-import-map③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-an-import-map-string">
-   <b><a href="#parse-an-import-map-string">#parse-an-import-map-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-an-import-map-string" class="dfn-panel" data-for="parse-an-import-map-string" id="infopanel-for-parse-an-import-map-string" role="dialog">
+   <span id="infopaneltitle-for-parse-an-import-map-string" style="display:none">Info about the 'parse an import map string' definition.</span><b><a href="#parse-an-import-map-string">#parse-an-import-map-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-an-import-map-string">3. Parsing import maps</a>
     <li><a href="#ref-for-parse-an-import-map-string①">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-import-map-parse-result">
-   <b><a href="#create-an-import-map-parse-result">#create-an-import-map-parse-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-import-map-parse-result" class="dfn-panel" data-for="create-an-import-map-parse-result" id="infopanel-for-create-an-import-map-parse-result" role="dialog">
+   <span id="infopaneltitle-for-create-an-import-map-parse-result" style="display:none">Info about the 'create an import map parse result' definition.</span><b><a href="#create-an-import-map-parse-result">#create-an-import-map-parse-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-import-map-parse-result">2.3. Prepare a script</a> <a href="#ref-for-create-an-import-map-parse-result①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sort-and-normalize-a-specifier-map">
-   <b><a href="#sort-and-normalize-a-specifier-map">#sort-and-normalize-a-specifier-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sort-and-normalize-a-specifier-map" class="dfn-panel" data-for="sort-and-normalize-a-specifier-map" id="infopanel-for-sort-and-normalize-a-specifier-map" role="dialog">
+   <span id="infopaneltitle-for-sort-and-normalize-a-specifier-map" style="display:none">Info about the 'sort and normalize a specifier map' definition.</span><b><a href="#sort-and-normalize-a-specifier-map">#sort-and-normalize-a-specifier-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sort-and-normalize-a-specifier-map">3. Parsing import maps</a> <a href="#ref-for-sort-and-normalize-a-specifier-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sort-and-normalize-scopes">
-   <b><a href="#sort-and-normalize-scopes">#sort-and-normalize-scopes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sort-and-normalize-scopes" class="dfn-panel" data-for="sort-and-normalize-scopes" id="infopanel-for-sort-and-normalize-scopes" role="dialog">
+   <span id="infopaneltitle-for-sort-and-normalize-scopes" style="display:none">Info about the 'sort and normalize scopes' definition.</span><b><a href="#sort-and-normalize-scopes">#sort-and-normalize-scopes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sort-and-normalize-scopes">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normalize-a-specifier-key">
-   <b><a href="#normalize-a-specifier-key">#normalize-a-specifier-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalize-a-specifier-key" class="dfn-panel" data-for="normalize-a-specifier-key" id="infopanel-for-normalize-a-specifier-key" role="dialog">
+   <span id="infopaneltitle-for-normalize-a-specifier-key" style="display:none">Info about the 'normalize a specifier key' definition.</span><b><a href="#normalize-a-specifier-key">#normalize-a-specifier-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize-a-specifier-key">3. Parsing import maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-url-like-import-specifier">
-   <b><a href="#parse-a-url-like-import-specifier">#parse-a-url-like-import-specifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-url-like-import-specifier" class="dfn-panel" data-for="parse-a-url-like-import-specifier" id="infopanel-for-parse-a-url-like-import-specifier" role="dialog">
+   <span id="infopaneltitle-for-parse-a-url-like-import-specifier" style="display:none">Info about the 'parse a URL-like import specifier' definition.</span><b><a href="#parse-a-url-like-import-specifier">#parse-a-url-like-import-specifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-url-like-import-specifier">3. Parsing import maps</a> <a href="#ref-for-parse-a-url-like-import-specifier①">(2)</a>
     <li><a href="#ref-for-parse-a-url-like-import-specifier②">4.1. New "resolve a module specifier"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-a-module-specifier">
-   <b><a href="#resolve-a-module-specifier">#resolve-a-module-specifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-a-module-specifier" class="dfn-panel" data-for="resolve-a-module-specifier" id="infopanel-for-resolve-a-module-specifier" role="dialog">
+   <span id="infopaneltitle-for-resolve-a-module-specifier" style="display:none">Info about the 'resolve a module specifier' definition.</span><b><a href="#resolve-a-module-specifier">#resolve-a-module-specifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-module-specifier">4. Resolving module specifiers</a> <a href="#ref-for-resolve-a-module-specifier①">(2)</a> <a href="#ref-for-resolve-a-module-specifier②">(3)</a>
     <li><a href="#ref-for-resolve-a-module-specifier④">4.1. New "resolve a module specifier"</a> <a href="#ref-for-resolve-a-module-specifier⑤">(2)</a> <a href="#ref-for-resolve-a-module-specifier⑥">(3)</a> <a href="#ref-for-resolve-a-module-specifier⑦">(4)</a> <a href="#ref-for-resolve-a-module-specifier⑧">(5)</a>
     <li><a href="#ref-for-resolve-a-module-specifier①⓪">4.2. Updates to other algorithms</a> <a href="#ref-for-resolve-a-module-specifier①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-an-imports-match">
-   <b><a href="#resolve-an-imports-match">#resolve-an-imports-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-an-imports-match" class="dfn-panel" data-for="resolve-an-imports-match" id="infopanel-for-resolve-an-imports-match" role="dialog">
+   <span id="infopaneltitle-for-resolve-an-imports-match" style="display:none">Info about the 'resolve an imports match' definition.</span><b><a href="#resolve-an-imports-match">#resolve-an-imports-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-an-imports-match">4.1. New "resolve a module specifier"</a> <a href="#ref-for-resolve-an-imports-match①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/intervention-reporting/index.html
+++ b/tests/github/WICG/intervention-reporting/index.html
@@ -1118,62 +1118,62 @@ behavior (which prompted the intervention), or null otherwise.</p>
     </ul>
    <li><a href="#dom-interventionreportbody-tojson">toJSON()</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-reportbody">
-   <a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reportbody" class="dfn-panel" data-for="term-for-reportbody" id="infopanel-for-term-for-reportbody" role="menu">
+   <span id="infopaneltitle-for-term-for-reportbody" style="display:none">Info about the 'ReportBody' external reference.</span><a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reportbody">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-body">
-   <a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-body" class="dfn-panel" data-for="term-for-report-body" id="infopanel-for-term-for-report-body" role="menu">
+   <span id="infopaneltitle-for-term-for-report-body" style="display:none">Info about the 'body' external reference.</span><a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-body">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-endpoint">
-   <a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-endpoint" class="dfn-panel" data-for="term-for-endpoint" id="infopanel-for-term-for-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-endpoint" style="display:none">Info about the 'endpoint' external reference.</span><a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report">
-   <a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report" class="dfn-panel" data-for="term-for-report" id="infopanel-for-term-for-report" role="menu">
+   <span id="infopaneltitle-for-term-for-report" style="display:none">Info about the 'report' external reference.</span><a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-type">
-   <a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-type" class="dfn-panel" data-for="term-for-report-type" id="infopanel-for-term-for-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-report-type" style="display:none">Info about the 'report type' external reference.</span><a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-type">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Intervention Reports</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3. Intervention Reports</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
@@ -1219,85 +1219,141 @@ behavior (which prompted the intervention), or null otherwise.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="intervention-reports">
-   <b><a href="#intervention-reports">#intervention-reports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intervention-reports" class="dfn-panel" data-for="intervention-reports" id="infopanel-for-intervention-reports" role="dialog">
+   <span id="infopaneltitle-for-intervention-reports" style="display:none">Info about the 'Intervention reports' definition.</span><b><a href="#intervention-reports">#intervention-reports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intervention-reports">3. Intervention Reports</a> <a href="#ref-for-intervention-reports①">(2)</a> <a href="#ref-for-intervention-reports②">(3)</a> <a href="#ref-for-intervention-reports③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interventionreportbody">
-   <b><a href="#interventionreportbody">#interventionreportbody</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interventionreportbody" class="dfn-panel" data-for="interventionreportbody" id="infopanel-for-interventionreportbody" role="dialog">
+   <span id="infopaneltitle-for-interventionreportbody" style="display:none">Info about the 'InterventionReportBody' definition.</span><b><a href="#interventionreportbody">#interventionreportbody</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interventionreportbody">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interventionreportbody-id">
-   <b><a href="#interventionreportbody-id">#interventionreportbody-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interventionreportbody-id" class="dfn-panel" data-for="interventionreportbody-id" id="infopanel-for-interventionreportbody-id" role="dialog">
+   <span id="infopaneltitle-for-interventionreportbody-id" style="display:none">Info about the 'id' definition.</span><b><a href="#interventionreportbody-id">#interventionreportbody-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interventionreportbody-id">3. Intervention Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interventionreportbody-sourcefile">
-   <b><a href="#interventionreportbody-sourcefile">#interventionreportbody-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interventionreportbody-sourcefile" class="dfn-panel" data-for="interventionreportbody-sourcefile" id="infopanel-for-interventionreportbody-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-interventionreportbody-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#interventionreportbody-sourcefile">#interventionreportbody-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interventionreportbody-sourcefile">3. Intervention Reports</a> <a href="#ref-for-interventionreportbody-sourcefile①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/keyboard-lock/index.html
+++ b/tests/github/WICG/keyboard-lock/index.html
@@ -1093,168 +1093,168 @@ navigator.keyboard.unlock();
     </ul>
    <li><a href="#unregister-the-system-key-press-handler">unregister the system key press handler</a><span>, in § 3.1.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fullscreen-element">
-   <a href="https://fullscreen.spec.whatwg.org/#fullscreen-element">https://fullscreen.spec.whatwg.org/#fullscreen-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fullscreen-element" class="dfn-panel" data-for="term-for-fullscreen-element" id="infopanel-for-term-for-fullscreen-element" role="menu">
+   <span id="infopaneltitle-for-term-for-fullscreen-element" style="display:none">Info about the 'fullscreen element' external reference.</span><a href="https://fullscreen.spec.whatwg.org/#fullscreen-element">https://fullscreen.spec.whatwg.org/#fullscreen-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-element">3.2. Handling Keyboard Events</a> <a href="#ref-for-fullscreen-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2.1. Navigator Interface</a>
     <li><a href="#ref-for-navigator①">2.1.1. keyboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context" id="infopanel-for-term-for-currently-focused-area-of-a-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" style="display:none">Info about the 'currently focused area of a top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context">3.2. Handling Keyboard Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">2.2.1. lock()</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">2.2.2. unlock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/#top-level-browsing-context">https://html.spec.whatwg.org/#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#top-level-browsing-context">https://html.spec.whatwg.org/#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyboardevent-code">
-   <a href="https://w3c.github.io/uievents/#dom-keyboardevent-code">https://w3c.github.io/uievents/#dom-keyboardevent-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyboardevent-code" class="dfn-panel" data-for="term-for-dom-keyboardevent-code" id="infopanel-for-term-for-dom-keyboardevent-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyboardevent-code" style="display:none">Info about the 'code' external reference.</span><a href="https://w3c.github.io/uievents/#dom-keyboardevent-code">https://w3c.github.io/uievents/#dom-keyboardevent-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboardevent-code">3.2. Handling Keyboard Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-delete">
-   <a href="http://www.w3.org/TR/uievents-code/#code-delete">http://www.w3.org/TR/uievents-code/#code-delete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-delete" class="dfn-panel" data-for="term-for-code-delete" id="infopanel-for-term-for-code-delete" role="menu">
+   <span id="infopaneltitle-for-term-for-code-delete" style="display:none">Info about the 'delete' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-delete">http://www.w3.org/TR/uievents-code/#code-delete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-delete">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-key-code-attribute-value">
-   <a href="http://www.w3.org/TR/uievents-code/#key-code-attribute-value">http://www.w3.org/TR/uievents-code/#key-code-attribute-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-key-code-attribute-value" class="dfn-panel" data-for="term-for-key-code-attribute-value" id="infopanel-for-term-for-key-code-attribute-value" role="menu">
+   <span id="infopaneltitle-for-term-for-key-code-attribute-value" style="display:none">Info about the 'key code attribute value' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#key-code-attribute-value">http://www.w3.org/TR/uievents-code/#key-code-attribute-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-code-attribute-value">2.2. Keyboard Interface</a>
     <li><a href="#ref-for-key-code-attribute-value①">2.2.1. lock()</a> <a href="#ref-for-key-code-attribute-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-keya">
-   <a href="http://www.w3.org/TR/uievents-code/#code-keya">http://www.w3.org/TR/uievents-code/#code-keya</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-keya" class="dfn-panel" data-for="term-for-code-keya" id="infopanel-for-term-for-code-keya" role="menu">
+   <span id="infopaneltitle-for-term-for-code-keya" style="display:none">Info about the 'keya' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-keya">http://www.w3.org/TR/uievents-code/#code-keya</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-keya">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-keyd">
-   <a href="http://www.w3.org/TR/uievents-code/#code-keyd">http://www.w3.org/TR/uievents-code/#code-keyd</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-keyd" class="dfn-panel" data-for="term-for-code-keyd" id="infopanel-for-term-for-code-keyd" role="menu">
+   <span id="infopaneltitle-for-term-for-code-keyd" style="display:none">Info about the 'keyd' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-keyd">http://www.w3.org/TR/uievents-code/#code-keyd</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-keyd">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-keys">
-   <a href="http://www.w3.org/TR/uievents-code/#code-keys">http://www.w3.org/TR/uievents-code/#code-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-keys" class="dfn-panel" data-for="term-for-code-keys" id="infopanel-for-term-for-code-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-code-keys" style="display:none">Info about the 'keys' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-keys">http://www.w3.org/TR/uievents-code/#code-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-keys">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-keyw">
-   <a href="http://www.w3.org/TR/uievents-code/#code-keyw">http://www.w3.org/TR/uievents-code/#code-keyw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-keyw" class="dfn-panel" data-for="term-for-code-keyw" id="infopanel-for-term-for-code-keyw" role="menu">
+   <span id="infopaneltitle-for-term-for-code-keyw" style="display:none">Info about the 'keyw' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-keyw">http://www.w3.org/TR/uievents-code/#code-keyw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-keyw">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">2.2.1. lock()</a> <a href="#ref-for-aborterror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.2.1. lock()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.2.1. lock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.1. Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.1. Navigator Interface</a>
     <li><a href="#ref-for-SecureContext①">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.2. Keyboard Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
@@ -1359,42 +1359,42 @@ navigator.keyboard.unlock();
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="navigator-keyboard">
-   <b><a href="#navigator-keyboard">#navigator-keyboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-keyboard" class="dfn-panel" data-for="navigator-keyboard" id="infopanel-for-navigator-keyboard" role="dialog">
+   <span id="infopaneltitle-for-navigator-keyboard" style="display:none">Info about the 'keyboard' definition.</span><b><a href="#navigator-keyboard">#navigator-keyboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-keyboard">2.1.1. keyboard</a>
     <li><a href="#ref-for-navigator-keyboard①">2.1. Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard">
-   <b><a href="#keyboard">#keyboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard" class="dfn-panel" data-for="keyboard" id="infopanel-for-keyboard" role="dialog">
+   <span id="infopaneltitle-for-keyboard" style="display:none">Info about the 'Keyboard' definition.</span><b><a href="#keyboard">#keyboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard">2.1. Navigator Interface</a>
     <li><a href="#ref-for-keyboard①">2.1.1. keyboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyboard-lock">
-   <b><a href="#dom-keyboard-lock">#dom-keyboard-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyboard-lock" class="dfn-panel" data-for="dom-keyboard-lock" id="infopanel-for-dom-keyboard-lock" role="dialog">
+   <span id="infopaneltitle-for-dom-keyboard-lock" style="display:none">Info about the 'lock' definition.</span><b><a href="#dom-keyboard-lock">#dom-keyboard-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboard-lock">2.2.1. lock()</a> <a href="#ref-for-dom-keyboard-lock①">(2)</a> <a href="#ref-for-dom-keyboard-lock②">(3)</a> <a href="#ref-for-dom-keyboard-lock③">(4)</a> <a href="#ref-for-dom-keyboard-lock④">(5)</a> <a href="#ref-for-dom-keyboard-lock⑤">(6)</a>
     <li><a href="#ref-for-dom-keyboard-lock⑥">4.1. Special Considerations with the Escape Key</a> <a href="#ref-for-dom-keyboard-lock⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyboard-lock-keycodes-keycodes">
-   <b><a href="#dom-keyboard-lock-keycodes-keycodes">#dom-keyboard-lock-keycodes-keycodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyboard-lock-keycodes-keycodes" class="dfn-panel" data-for="dom-keyboard-lock-keycodes-keycodes" id="infopanel-for-dom-keyboard-lock-keycodes-keycodes" role="dialog">
+   <span id="infopaneltitle-for-dom-keyboard-lock-keycodes-keycodes" style="display:none">Info about the 'keyCodes' definition.</span><b><a href="#dom-keyboard-lock-keycodes-keycodes">#dom-keyboard-lock-keycodes-keycodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboard-lock-keycodes-keycodes">2.2.1. lock()</a> <a href="#ref-for-dom-keyboard-lock-keycodes-keycodes①">(2)</a> <a href="#ref-for-dom-keyboard-lock-keycodes-keycodes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyboard-unlock">
-   <b><a href="#dom-keyboard-unlock">#dom-keyboard-unlock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyboard-unlock" class="dfn-panel" data-for="dom-keyboard-unlock" id="infopanel-for-dom-keyboard-unlock" role="dialog">
+   <span id="infopaneltitle-for-dom-keyboard-unlock" style="display:none">Info about the 'unlock' definition.</span><b><a href="#dom-keyboard-unlock">#dom-keyboard-unlock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboard-unlock">2.2.1. lock()</a>
     <li><a href="#ref-for-dom-keyboard-unlock①">2.2.2. unlock()</a> <a href="#ref-for-dom-keyboard-unlock②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard-enable-keyboard-lock">
-   <b><a href="#keyboard-enable-keyboard-lock">#keyboard-enable-keyboard-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard-enable-keyboard-lock" class="dfn-panel" data-for="keyboard-enable-keyboard-lock" id="infopanel-for-keyboard-enable-keyboard-lock" role="dialog">
+   <span id="infopaneltitle-for-keyboard-enable-keyboard-lock" style="display:none">Info about the 'enable keyboard lock' definition.</span><b><a href="#keyboard-enable-keyboard-lock">#keyboard-enable-keyboard-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard-enable-keyboard-lock">2.2. Keyboard Interface</a>
     <li><a href="#ref-for-keyboard-enable-keyboard-lock①">2.2.1. lock()</a> <a href="#ref-for-keyboard-enable-keyboard-lock②">(2)</a> <a href="#ref-for-keyboard-enable-keyboard-lock③">(3)</a> <a href="#ref-for-keyboard-enable-keyboard-lock④">(4)</a>
@@ -1402,97 +1402,153 @@ navigator.keyboard.unlock();
     <li><a href="#ref-for-keyboard-enable-keyboard-lock⑦">3.2. Handling Keyboard Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard-reserved-key-codes">
-   <b><a href="#keyboard-reserved-key-codes">#keyboard-reserved-key-codes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard-reserved-key-codes" class="dfn-panel" data-for="keyboard-reserved-key-codes" id="infopanel-for-keyboard-reserved-key-codes" role="dialog">
+   <span id="infopaneltitle-for-keyboard-reserved-key-codes" style="display:none">Info about the 'reserved key codes' definition.</span><b><a href="#keyboard-reserved-key-codes">#keyboard-reserved-key-codes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard-reserved-key-codes">2.2.1. lock()</a> <a href="#ref-for-keyboard-reserved-key-codes①">(2)</a>
     <li><a href="#ref-for-keyboard-reserved-key-codes②">2.2.2. unlock()</a>
     <li><a href="#ref-for-keyboard-reserved-key-codes③">3.2. Handling Keyboard Events</a> <a href="#ref-for-keyboard-reserved-key-codes④">(2)</a> <a href="#ref-for-keyboard-reserved-key-codes⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard-keyboard-lock-task-queue">
-   <b><a href="#keyboard-keyboard-lock-task-queue">#keyboard-keyboard-lock-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard-keyboard-lock-task-queue" class="dfn-panel" data-for="keyboard-keyboard-lock-task-queue" id="infopanel-for-keyboard-keyboard-lock-task-queue" role="dialog">
+   <span id="infopaneltitle-for-keyboard-keyboard-lock-task-queue" style="display:none">Info about the 'keyboard lock task queue' definition.</span><b><a href="#keyboard-keyboard-lock-task-queue">#keyboard-keyboard-lock-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard-keyboard-lock-task-queue">2.2.1. lock()</a> <a href="#ref-for-keyboard-keyboard-lock-task-queue①">(2)</a>
     <li><a href="#ref-for-keyboard-keyboard-lock-task-queue②">2.2.2. unlock()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="system-key-press-handler">
-   <b><a href="#system-key-press-handler">#system-key-press-handler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-system-key-press-handler" class="dfn-panel" data-for="system-key-press-handler" id="infopanel-for-system-key-press-handler" role="dialog">
+   <span id="infopaneltitle-for-system-key-press-handler" style="display:none">Info about the 'system key press handler' definition.</span><b><a href="#system-key-press-handler">#system-key-press-handler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-system-key-press-handler">3.1. System Key Press Handler</a>
     <li><a href="#ref-for-system-key-press-handler①">3.1.1. Registering</a>
     <li><a href="#ref-for-system-key-press-handler②">3.2. Handling Keyboard Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register-a-system-key-press-handler">
-   <b><a href="#register-a-system-key-press-handler">#register-a-system-key-press-handler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-register-a-system-key-press-handler" class="dfn-panel" data-for="register-a-system-key-press-handler" id="infopanel-for-register-a-system-key-press-handler" role="dialog">
+   <span id="infopaneltitle-for-register-a-system-key-press-handler" style="display:none">Info about the 'register a system key press handler' definition.</span><b><a href="#register-a-system-key-press-handler">#register-a-system-key-press-handler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-register-a-system-key-press-handler">2.2.1. lock()</a>
     <li><a href="#ref-for-register-a-system-key-press-handler①">3.2. Handling Keyboard Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unregister-the-system-key-press-handler">
-   <b><a href="#unregister-the-system-key-press-handler">#unregister-the-system-key-press-handler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unregister-the-system-key-press-handler" class="dfn-panel" data-for="unregister-the-system-key-press-handler" id="infopanel-for-unregister-the-system-key-press-handler" role="dialog">
+   <span id="infopaneltitle-for-unregister-the-system-key-press-handler" style="display:none">Info about the 'unregister the system key press handler' definition.</span><b><a href="#unregister-the-system-key-press-handler">#unregister-the-system-key-press-handler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unregister-the-system-key-press-handler">2.2.2. unlock()</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/keyboard-map/index.html
+++ b/tests/github/WICG/keyboard-map/index.html
@@ -1296,41 +1296,41 @@ See <a href="https://en.wikipedia.org/wiki/Scancode">https://en.wikipedia.org/wi
    <li><a href="#layoutchange">layoutchange</a><span>, in § 3.1</span>
    <li><a href="#scancode">scancode</a><span>, in § 8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2.1. Navigator Interface</a>
     <li><a href="#ref-for-navigator①">2.1.1. keyboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">6.1. Privacy Mitigations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2.3.1. getLayoutMap()</a>
     <li><a href="#ref-for-top-level-browsing-context①">6.1. Privacy Mitigations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyboardevent">
-   <a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyboardevent" class="dfn-panel" data-for="term-for-keyboardevent" id="infopanel-for-term-for-keyboardevent" role="menu">
+   <span id="infopaneltitle-for-term-for-keyboardevent" style="display:none">Info about the 'KeyboardEvent' external reference.</span><a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboardevent">1. Introduction</a> <a href="#ref-for-keyboardevent①">(2)</a>
     <li><a href="#ref-for-keyboardevent②">6. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyboardevent-code">
-   <a href="https://w3c.github.io/uievents/#dom-keyboardevent-code">https://w3c.github.io/uievents/#dom-keyboardevent-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyboardevent-code" class="dfn-panel" data-for="term-for-dom-keyboardevent-code" id="infopanel-for-term-for-dom-keyboardevent-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyboardevent-code" style="display:none">Info about the 'code' external reference.</span><a href="https://w3c.github.io/uievents/#dom-keyboardevent-code">https://w3c.github.io/uievents/#dom-keyboardevent-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboardevent-code">Unnumbered Section</a> <a href="#ref-for-dom-keyboardevent-code①">(2)</a>
     <li><a href="#ref-for-dom-keyboardevent-code②">1. Introduction</a> <a href="#ref-for-dom-keyboardevent-code③">(2)</a> <a href="#ref-for-dom-keyboardevent-code④">(3)</a>
@@ -1338,15 +1338,15 @@ See <a href="https://en.wikipedia.org/wiki/Scancode">https://en.wikipedia.org/wi
     <li><a href="#ref-for-dom-keyboardevent-code⑥">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dead-key">
-   <a href="http://www.w3.org/TR/uievents/#dead-key">http://www.w3.org/TR/uievents/#dead-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dead-key" class="dfn-panel" data-for="term-for-dead-key" id="infopanel-for-term-for-dead-key" role="menu">
+   <span id="infopaneltitle-for-term-for-dead-key" style="display:none">Info about the 'dead key' external reference.</span><a href="http://www.w3.org/TR/uievents/#dead-key">http://www.w3.org/TR/uievents/#dead-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dead-key">2.3.1. getLayoutMap()</a> <a href="#ref-for-dead-key①">(2)</a> <a href="#ref-for-dead-key②">(3)</a>
     <li><a href="#ref-for-dead-key③">2.4. Dead Keys and Combining Characters</a> <a href="#ref-for-dead-key④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyboardevent-key">
-   <a href="https://w3c.github.io/uievents/#dom-keyboardevent-key">https://w3c.github.io/uievents/#dom-keyboardevent-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyboardevent-key" class="dfn-panel" data-for="term-for-dom-keyboardevent-key" id="infopanel-for-term-for-dom-keyboardevent-key" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyboardevent-key" style="display:none">Info about the 'key' external reference.</span><a href="https://w3c.github.io/uievents/#dom-keyboardevent-key">https://w3c.github.io/uievents/#dom-keyboardevent-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboardevent-key">Unnumbered Section</a> <a href="#ref-for-dom-keyboardevent-key①">(2)</a>
     <li><a href="#ref-for-dom-keyboardevent-key②">1. Introduction</a> <a href="#ref-for-dom-keyboardevent-key③">(2)</a> <a href="#ref-for-dom-keyboardevent-key④">(3)</a> <a href="#ref-for-dom-keyboardevent-key⑤">(4)</a>
@@ -1354,66 +1354,66 @@ See <a href="https://en.wikipedia.org/wiki/Scancode">https://en.wikipedia.org/wi
     <li><a href="#ref-for-dom-keyboardevent-key⑦">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-quote">
-   <a href="http://www.w3.org/TR/uievents-code/#code-quote">http://www.w3.org/TR/uievents-code/#code-quote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-quote" class="dfn-panel" data-for="term-for-code-quote" id="infopanel-for-term-for-code-quote" role="menu">
+   <span id="infopaneltitle-for-term-for-code-quote" style="display:none">Info about the 'quote' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#code-quote">http://www.w3.org/TR/uievents-code/#code-quote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-quote">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-system-keys">
-   <a href="http://www.w3.org/TR/uievents-code/#writing-system-keys">http://www.w3.org/TR/uievents-code/#writing-system-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-system-keys" class="dfn-panel" data-for="term-for-writing-system-keys" id="infopanel-for-term-for-writing-system-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-system-keys" style="display:none">Info about the 'writing system keys' external reference.</span><a href="http://www.w3.org/TR/uievents-code/#writing-system-keys">http://www.w3.org/TR/uievents-code/#writing-system-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-system-keys">2.3.1. getLayoutMap()</a>
     <li><a href="#ref-for-writing-system-keys①">4. Mobile Device Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-key-attribute-value">
-   <a href="http://www.w3.org/TR/uievents-key/#key-attribute-value">http://www.w3.org/TR/uievents-key/#key-attribute-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-key-attribute-value" class="dfn-panel" data-for="term-for-key-attribute-value" id="infopanel-for-term-for-key-attribute-value" role="menu">
+   <span id="infopaneltitle-for-term-for-key-attribute-value" style="display:none">Info about the 'key attribute value' external reference.</span><a href="http://www.w3.org/TR/uievents-key/#key-attribute-value">http://www.w3.org/TR/uievents-key/#key-attribute-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-attribute-value">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. KeyboardLayoutMap Interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. Navigator Interface</a>
     <li><a href="#ref-for-Exposed①">2.2. KeyboardLayoutMap Interface</a>
     <li><a href="#ref-for-Exposed②">2.3. Keyboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.3. Keyboard Interface</a>
     <li><a href="#ref-for-idl-promise①">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.1. Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.1. Navigator Interface</a>
     <li><a href="#ref-for-SecureContext①">2.3. Keyboard Interface</a>
@@ -1492,114 +1492,170 @@ See <a href="https://en.wikipedia.org/wiki/Scancode">https://en.wikipedia.org/wi
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="navigator-keyboard">
-   <b><a href="#navigator-keyboard">#navigator-keyboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-keyboard" class="dfn-panel" data-for="navigator-keyboard" id="infopanel-for-navigator-keyboard" role="dialog">
+   <span id="infopaneltitle-for-navigator-keyboard" style="display:none">Info about the 'keyboard' definition.</span><b><a href="#navigator-keyboard">#navigator-keyboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-keyboard">2.1.1. keyboard</a>
     <li><a href="#ref-for-navigator-keyboard①">2.1. Navigator Interface</a>
     <li><a href="#ref-for-navigator-keyboard②">3.1. The layoutchange Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboardlayoutmap">
-   <b><a href="#keyboardlayoutmap">#keyboardlayoutmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboardlayoutmap" class="dfn-panel" data-for="keyboardlayoutmap" id="infopanel-for-keyboardlayoutmap" role="dialog">
+   <span id="infopaneltitle-for-keyboardlayoutmap" style="display:none">Info about the 'KeyboardLayoutMap' definition.</span><b><a href="#keyboardlayoutmap">#keyboardlayoutmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboardlayoutmap">2.2. KeyboardLayoutMap Interface</a>
     <li><a href="#ref-for-keyboardlayoutmap①">2.3. Keyboard Interface</a>
     <li><a href="#ref-for-keyboardlayoutmap②">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard">
-   <b><a href="#keyboard">#keyboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard" class="dfn-panel" data-for="keyboard" id="infopanel-for-keyboard" role="dialog">
+   <span id="infopaneltitle-for-keyboard" style="display:none">Info about the 'Keyboard' definition.</span><b><a href="#keyboard">#keyboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard">2.1. Navigator Interface</a>
     <li><a href="#ref-for-keyboard①">2.1.1. keyboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyboard-getlayoutmap">
-   <b><a href="#keyboard-getlayoutmap">#keyboard-getlayoutmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyboard-getlayoutmap" class="dfn-panel" data-for="keyboard-getlayoutmap" id="infopanel-for-keyboard-getlayoutmap" role="dialog">
+   <span id="infopaneltitle-for-keyboard-getlayoutmap" style="display:none">Info about the 'getLayoutMap()' definition.</span><b><a href="#keyboard-getlayoutmap">#keyboard-getlayoutmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboard-getlayoutmap">2.3.1. getLayoutMap()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-capable">
-   <b><a href="#ascii-capable">#ascii-capable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-capable" class="dfn-panel" data-for="ascii-capable" id="infopanel-for-ascii-capable" role="dialog">
+   <span id="infopaneltitle-for-ascii-capable" style="display:none">Info about the 'ASCII-capable' definition.</span><b><a href="#ascii-capable">#ascii-capable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-capable">2.3.1. getLayoutMap()</a> <a href="#ref-for-ascii-capable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="common-writing-system-keys">
-   <b><a href="#common-writing-system-keys">#common-writing-system-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-common-writing-system-keys" class="dfn-panel" data-for="common-writing-system-keys" id="infopanel-for-common-writing-system-keys" role="dialog">
+   <span id="infopaneltitle-for-common-writing-system-keys" style="display:none">Info about the 'common writing system keys' definition.</span><b><a href="#common-writing-system-keys">#common-writing-system-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-common-writing-system-keys">2.5. ASCII-Capable Keyboard Layouts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutchange">
-   <b><a href="#layoutchange">#layoutchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutchange" class="dfn-panel" data-for="layoutchange" id="infopanel-for-layoutchange" role="dialog">
+   <span id="infopaneltitle-for-layoutchange" style="display:none">Info about the 'layoutchange' definition.</span><b><a href="#layoutchange">#layoutchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutchange">3.1. The layoutchange Event</a> <a href="#ref-for-layoutchange①">(2)</a> <a href="#ref-for-layoutchange②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scancode">
-   <b><a href="#scancode">#scancode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scancode" class="dfn-panel" data-for="scancode" id="infopanel-for-scancode" role="dialog">
+   <span id="infopaneltitle-for-scancode" style="display:none">Info about the 'scancode' definition.</span><b><a href="#scancode">#scancode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scancode">1. Introduction</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/kv-storage/spec.html
+++ b/tests/github/WICG/kv-storage/spec.html
@@ -1348,141 +1348,141 @@ for their contributions to this specification.</p>
    <li><a href="#KVStorageArea-set">set(key, value)</a><span>, in § 3.1</span>
    <li><a href="#dom-kvstoragearea-values">values()</a><span>, in § 3.6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-callbackdef-eventlistener">
-   <a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-callbackdef-eventlistener" class="dfn-panel" data-for="term-for-callbackdef-eventlistener" id="infopanel-for-term-for-callbackdef-eventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-callbackdef-eventlistener" style="display:none">Info about the 'EventListener' external reference.</span><a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-eventlistener">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4. Supporting operations and concepts</a> <a href="#ref-for-eventtarget①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener">
-   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener" id="infopanel-for-term-for-dom-eventtarget-addeventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" style="display:none">Info about the 'addEventListener(type, callback)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object">
-   <a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object" id="infopanel-for-term-for-sec-properties-of-the-object-prototype-object" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" style="display:none">Info about the '%ObjectPrototype%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-properties-of-the-object-prototype-object">3.7. backingStore</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdataproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdataproperty" class="dfn-panel" data-for="term-for-sec-createdataproperty" id="infopanel-for-term-for-sec-createdataproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdataproperty" style="display:none">Info about the 'CreateDataProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdataproperty">3.7. backingStore</a> <a href="#ref-for-sec-createdataproperty①">(2)</a> <a href="#ref-for-sec-createdataproperty②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-date-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-date-objects" class="dfn-panel" data-for="term-for-sec-date-objects" id="infopanel-for-term-for-sec-date-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-date-objects" style="display:none">Info about the 'Date' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-date-objects">3.2. set(key, value)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isarray">
-   <a href="https://tc39.github.io/ecma262/#sec-isarray">https://tc39.github.io/ecma262/#sec-isarray</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isarray" class="dfn-panel" data-for="term-for-sec-isarray" id="infopanel-for-term-for-sec-isarray" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isarray" style="display:none">Info about the 'IsArray' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isarray">https://tc39.github.io/ecma262/#sec-isarray</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isarray">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-map-objects">https://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'Map' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-map-objects">https://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-objectcreate">
-   <a href="https://tc39.github.io/ecma262/#sec-objectcreate">https://tc39.github.io/ecma262/#sec-objectcreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-objectcreate" class="dfn-panel" data-for="term-for-sec-objectcreate" id="infopanel-for-term-for-sec-objectcreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-objectcreate" style="display:none">Info about the 'ObjectCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-objectcreate">https://tc39.github.io/ecma262/#sec-objectcreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-objectcreate">3.7. backingStore</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setintegritylevel">
-   <a href="https://tc39.github.io/ecma262/#sec-setintegritylevel">https://tc39.github.io/ecma262/#sec-setintegritylevel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setintegritylevel" class="dfn-panel" data-for="term-for-sec-setintegritylevel" id="infopanel-for-term-for-sec-setintegritylevel" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setintegritylevel" style="display:none">Info about the 'SetIntegrityLevel' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-setintegritylevel">https://tc39.github.io/ecma262/#sec-setintegritylevel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setintegritylevel">3.7. backingStore</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'Type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-record">
-   <a href="https://tc39.github.io/ecma262/#realm-record">https://tc39.github.io/ecma262/#realm-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-record" class="dfn-panel" data-for="term-for-realm-record" id="infopanel-for-term-for-realm-record" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-record" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm-record">https://tc39.github.io/ecma262/#realm-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-record">3.5. clear()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-typedarray-objects">https://tc39.github.io/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-objects" class="dfn-panel" data-for="term-for-sec-typedarray-objects" id="infopanel-for-term-for-sec-typedarray-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-objects" style="display:none">Info about the 'typed array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-typedarray-objects">https://tc39.github.io/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-objects">3.2. set(key, value)</a>
     <li><a href="#ref-for-sec-typedarray-objects①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-2">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#storage-2">https://html.spec.whatwg.org/multipage/webstorage.html#storage-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-2" class="dfn-panel" data-for="term-for-storage-2" id="infopanel-for-term-for-storage-2" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-2" style="display:none">Info about the 'Storage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#storage-2">https://html.spec.whatwg.org/multipage/webstorage.html#storage-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-2">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">3.3. get(key)</a>
     <li><a href="#ref-for-structureddeserialize①">3.6. Iteration</a> <a href="#ref-for-structureddeserialize②">(2)</a>
     <li><a href="#ref-for-structureddeserialize③">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializeforstorage">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializeforstorage" class="dfn-panel" data-for="term-for-structuredserializeforstorage" id="infopanel-for-term-for-structuredserializeforstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializeforstorage" style="display:none">Info about the 'StructuredSerializeForStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializeforstorage">3.2. set(key, value)</a>
     <li><a href="#ref-for-structuredserializeforstorage①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">2. The kvStorage global</a> <a href="#ref-for-windoworworkerglobalscope①">(2)</a>
     <li><a href="#ref-for-windoworworkerglobalscope②">4. Supporting operations and concepts</a> <a href="#ref-for-windoworworkerglobalscope③">(2)</a> <a href="#ref-for-windoworworkerglobalscope④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4. Supporting operations and concepts</a> <a href="#ref-for-current-global-object①">(2)</a> <a href="#ref-for-current-global-object②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-localstorage">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-localstorage" class="dfn-panel" data-for="term-for-dom-localstorage" id="infopanel-for-term-for-dom-localstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-localstorage" style="display:none">Info about the 'localStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-localstorage">Unnumbered Section</a>
     <li><a href="#ref-for-dom-localstorage①">1. Introduction</a> <a href="#ref-for-dom-localstorage②">(2)</a>
     <li><a href="#ref-for-dom-localstorage③">2. The kvStorage global</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.2. set(key, value)</a>
     <li><a href="#ref-for-concept-relevant-realm①">3.3. get(key)</a>
@@ -1492,44 +1492,44 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-concept-relevant-realm⑤">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2. The kvStorage global</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-greater-than">
-   <a href="https://w3c.github.io/IndexedDB/#greater-than">https://w3c.github.io/IndexedDB/#greater-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-greater-than" class="dfn-panel" data-for="term-for-greater-than" id="infopanel-for-term-for-greater-than" role="menu">
+   <span id="infopaneltitle-for-term-for-greater-than" style="display:none">Info about the 'ascending' external reference.</span><a href="https://w3c.github.io/IndexedDB/#greater-than">https://w3c.github.io/IndexedDB/#greater-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-greater-than">3.6. Iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-close-a-database-connection">
-   <a href="https://w3c.github.io/IndexedDB/#close-a-database-connection">https://w3c.github.io/IndexedDB/#close-a-database-connection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-close-a-database-connection" class="dfn-panel" data-for="term-for-close-a-database-connection" id="infopanel-for-term-for-close-a-database-connection" role="menu">
+   <span id="infopaneltitle-for-term-for-close-a-database-connection" style="display:none">Info about the 'close a database connection' external reference.</span><a href="https://w3c.github.io/IndexedDB/#close-a-database-connection">https://w3c.github.io/IndexedDB/#close-a-database-connection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-a-database-connection">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connection">
-   <a href="https://w3c.github.io/IndexedDB/#connection">https://w3c.github.io/IndexedDB/#connection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connection" class="dfn-panel" data-for="term-for-connection" id="infopanel-for-term-for-connection" role="menu">
+   <span id="infopaneltitle-for-term-for-connection" style="display:none">Info about the 'connection' external reference.</span><a href="https://w3c.github.io/IndexedDB/#connection">https://w3c.github.io/IndexedDB/#connection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-convert-a-key-to-a-value">
-   <a href="https://w3c.github.io/IndexedDB/#convert-a-key-to-a-value">https://w3c.github.io/IndexedDB/#convert-a-key-to-a-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-convert-a-key-to-a-value" class="dfn-panel" data-for="term-for-convert-a-key-to-a-value" id="infopanel-for-term-for-convert-a-key-to-a-value" role="menu">
+   <span id="infopaneltitle-for-term-for-convert-a-key-to-a-value" style="display:none">Info about the 'convert a key to a value' external reference.</span><a href="https://w3c.github.io/IndexedDB/#convert-a-key-to-a-value">https://w3c.github.io/IndexedDB/#convert-a-key-to-a-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-key-to-a-value">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-convert-a-value-to-a-key">
-   <a href="https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key">https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-convert-a-value-to-a-key" class="dfn-panel" data-for="term-for-convert-a-value-to-a-key" id="infopanel-for-term-for-convert-a-value-to-a-key" role="menu">
+   <span id="infopaneltitle-for-term-for-convert-a-value-to-a-key" style="display:none">Info about the 'convert a value to a key' external reference.</span><a href="https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key">https://w3c.github.io/IndexedDB/#convert-a-value-to-a-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-value-to-a-key">4. Supporting operations and concepts</a> <a href="#ref-for-convert-a-value-to-a-key①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-error">
-   <a href="https://w3c.github.io/IndexedDB/#request-error">https://w3c.github.io/IndexedDB/#request-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-error" class="dfn-panel" data-for="term-for-request-error" id="infopanel-for-term-for-request-error" role="menu">
+   <span id="infopaneltitle-for-term-for-request-error" style="display:none">Info about the 'error (for request)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#request-error">https://w3c.github.io/IndexedDB/#request-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-error">3.3. get(key)</a>
     <li><a href="#ref-for-request-error①">3.5. clear()</a>
@@ -1537,85 +1537,85 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-request-error④">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transaction-error">
-   <a href="https://w3c.github.io/IndexedDB/#transaction-error">https://w3c.github.io/IndexedDB/#transaction-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transaction-error" class="dfn-panel" data-for="term-for-transaction-error" id="infopanel-for-term-for-transaction-error" role="menu">
+   <span id="infopaneltitle-for-term-for-transaction-error" style="display:none">Info about the 'error (for transaction)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#transaction-error">https://w3c.github.io/IndexedDB/#transaction-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-error">3.2. set(key, value)</a> <a href="#ref-for-transaction-error①">(2)</a>
     <li><a href="#ref-for-transaction-error②">3.4. delete(key)</a> <a href="#ref-for-transaction-error③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-index-concept">
-   <a href="https://w3c.github.io/IndexedDB/#index-concept">https://w3c.github.io/IndexedDB/#index-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-index-concept" class="dfn-panel" data-for="term-for-index-concept" id="infopanel-for-term-for-index-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-index-concept" style="display:none">Info about the 'index' external reference.</span><a href="https://w3c.github.io/IndexedDB/#index-concept">https://w3c.github.io/IndexedDB/#index-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-concept">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-key-generator">
-   <a href="https://w3c.github.io/IndexedDB/#key-generator">https://w3c.github.io/IndexedDB/#key-generator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-key-generator" class="dfn-panel" data-for="term-for-key-generator" id="infopanel-for-term-for-key-generator" role="menu">
+   <span id="infopaneltitle-for-term-for-key-generator" style="display:none">Info about the 'key generator' external reference.</span><a href="https://w3c.github.io/IndexedDB/#key-generator">https://w3c.github.io/IndexedDB/#key-generator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-generator">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-store-key-path">
-   <a href="https://w3c.github.io/IndexedDB/#object-store-key-path">https://w3c.github.io/IndexedDB/#object-store-key-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-store-key-path" class="dfn-panel" data-for="term-for-object-store-key-path" id="infopanel-for-term-for-object-store-key-path" role="menu">
+   <span id="infopaneltitle-for-term-for-object-store-key-path" style="display:none">Info about the 'key path' external reference.</span><a href="https://w3c.github.io/IndexedDB/#object-store-key-path">https://w3c.github.io/IndexedDB/#object-store-key-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-key-path">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-store-name">
-   <a href="https://w3c.github.io/IndexedDB/#object-store-name">https://w3c.github.io/IndexedDB/#object-store-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-store-name" class="dfn-panel" data-for="term-for-object-store-name" id="infopanel-for-term-for-object-store-name" role="menu">
+   <span id="infopaneltitle-for-term-for-object-store-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/IndexedDB/#object-store-name">https://w3c.github.io/IndexedDB/#object-store-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-name">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connection-object-store-set">
-   <a href="https://w3c.github.io/IndexedDB/#connection-object-store-set">https://w3c.github.io/IndexedDB/#connection-object-store-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connection-object-store-set" class="dfn-panel" data-for="term-for-connection-object-store-set" id="infopanel-for-term-for-connection-object-store-set" role="menu">
+   <span id="infopaneltitle-for-term-for-connection-object-store-set" style="display:none">Info about the 'object store set' external reference.</span><a href="https://w3c.github.io/IndexedDB/#connection-object-store-set">https://w3c.github.io/IndexedDB/#connection-object-store-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-object-store-set">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-result">
-   <a href="https://w3c.github.io/IndexedDB/#request-result">https://w3c.github.io/IndexedDB/#request-result</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-result" class="dfn-panel" data-for="term-for-request-result" id="infopanel-for-term-for-request-result" role="menu">
+   <span id="infopaneltitle-for-term-for-request-result" style="display:none">Info about the 'result' external reference.</span><a href="https://w3c.github.io/IndexedDB/#request-result">https://w3c.github.io/IndexedDB/#request-result</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-result">3.3. get(key)</a>
     <li><a href="#ref-for-request-result①">3.6. Iteration</a> <a href="#ref-for-request-result②">(2)</a>
     <li><a href="#ref-for-request-result③">4. Supporting operations and concepts</a> <a href="#ref-for-request-result④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transaction-concept">
-   <a href="https://w3c.github.io/IndexedDB/#transaction-concept">https://w3c.github.io/IndexedDB/#transaction-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transaction-concept" class="dfn-panel" data-for="term-for-transaction-concept" id="infopanel-for-term-for-transaction-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-transaction-concept" style="display:none">Info about the 'transaction' external reference.</span><a href="https://w3c.github.io/IndexedDB/#transaction-concept">https://w3c.github.io/IndexedDB/#transaction-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-concept">3.7. backingStore</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unbounded-key-range">
-   <a href="https://w3c.github.io/IndexedDB/#unbounded-key-range">https://w3c.github.io/IndexedDB/#unbounded-key-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unbounded-key-range" class="dfn-panel" data-for="term-for-unbounded-key-range" id="infopanel-for-term-for-unbounded-key-range" role="menu">
+   <span id="infopaneltitle-for-term-for-unbounded-key-range" style="display:none">Info about the 'unbounded key range' external reference.</span><a href="https://w3c.github.io/IndexedDB/#unbounded-key-range">https://w3c.github.io/IndexedDB/#unbounded-key-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unbounded-key-range">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbdatabase">
-   <a href="https://w3c.github.io/IndexedDB/#idbdatabase">https://w3c.github.io/IndexedDB/#idbdatabase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbdatabase" class="dfn-panel" data-for="term-for-idbdatabase" id="infopanel-for-term-for-idbdatabase" role="menu">
+   <span id="infopaneltitle-for-term-for-idbdatabase" style="display:none">Info about the 'IDBDatabase' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbdatabase">https://w3c.github.io/IndexedDB/#idbdatabase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbdatabase">3. The KVStorageArea class</a>
     <li><a href="#ref-for-idbdatabase①">4. Supporting operations and concepts</a> <a href="#ref-for-idbdatabase②">(2)</a> <a href="#ref-for-idbdatabase③">(3)</a> <a href="#ref-for-idbdatabase④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbfactory">
-   <a href="https://w3c.github.io/IndexedDB/#idbfactory">https://w3c.github.io/IndexedDB/#idbfactory</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbfactory" class="dfn-panel" data-for="term-for-idbfactory" id="infopanel-for-term-for-idbfactory" role="menu">
+   <span id="infopaneltitle-for-term-for-idbfactory" style="display:none">Info about the 'IDBFactory' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbfactory">https://w3c.github.io/IndexedDB/#idbfactory</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbfactory">3.5. clear()</a>
     <li><a href="#ref-for-idbfactory①">4. Supporting operations and concepts</a> <a href="#ref-for-idbfactory②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbkeyrange">
-   <a href="https://w3c.github.io/IndexedDB/#idbkeyrange">https://w3c.github.io/IndexedDB/#idbkeyrange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbkeyrange" class="dfn-panel" data-for="term-for-idbkeyrange" id="infopanel-for-term-for-idbkeyrange" role="menu">
+   <span id="infopaneltitle-for-term-for-idbkeyrange" style="display:none">Info about the 'IDBKeyRange' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbkeyrange">https://w3c.github.io/IndexedDB/#idbkeyrange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbkeyrange">4. Supporting operations and concepts</a> <a href="#ref-for-idbkeyrange①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbobjectstore">
-   <a href="https://w3c.github.io/IndexedDB/#idbobjectstore">https://w3c.github.io/IndexedDB/#idbobjectstore</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbobjectstore" class="dfn-panel" data-for="term-for-idbobjectstore" id="infopanel-for-term-for-idbobjectstore" role="menu">
+   <span id="infopaneltitle-for-term-for-idbobjectstore" style="display:none">Info about the 'IDBObjectStore' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbobjectstore">https://w3c.github.io/IndexedDB/#idbobjectstore</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbobjectstore">3.2. set(key, value)</a> <a href="#ref-for-idbobjectstore①">(2)</a>
     <li><a href="#ref-for-idbobjectstore②">3.3. get(key)</a>
@@ -1624,113 +1624,113 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-idbobjectstore⑥">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbtransaction">
-   <a href="https://w3c.github.io/IndexedDB/#idbtransaction">https://w3c.github.io/IndexedDB/#idbtransaction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbtransaction" class="dfn-panel" data-for="term-for-idbtransaction" id="infopanel-for-term-for-idbtransaction" role="menu">
+   <span id="infopaneltitle-for-term-for-idbtransaction" style="display:none">Info about the 'IDBTransaction' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbtransaction">https://w3c.github.io/IndexedDB/#idbtransaction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbtransaction">4. Supporting operations and concepts</a> <a href="#ref-for-idbtransaction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbdatabase-close">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-close">https://w3c.github.io/IndexedDB/#dom-idbdatabase-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbdatabase-close" class="dfn-panel" data-for="term-for-dom-idbdatabase-close" id="infopanel-for-term-for-dom-idbdatabase-close" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbdatabase-close" style="display:none">Info about the 'close()' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-close">https://w3c.github.io/IndexedDB/#dom-idbdatabase-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-close">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbdatabase-createobjectstore">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore">https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbdatabase-createobjectstore" class="dfn-panel" data-for="term-for-dom-idbdatabase-createobjectstore" id="infopanel-for-term-for-dom-idbdatabase-createobjectstore" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbdatabase-createobjectstore" style="display:none">Info about the 'createObjectStore(name)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore">https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-createobjectstore">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbobjectstore-delete">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-delete">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-delete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbobjectstore-delete" class="dfn-panel" data-for="term-for-dom-idbobjectstore-delete" id="infopanel-for-term-for-dom-idbobjectstore-delete" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbobjectstore-delete" style="display:none">Info about the 'delete(query)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-delete">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-delete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-delete">3.2. set(key, value)</a>
     <li><a href="#ref-for-dom-idbobjectstore-delete①">3.4. delete(key)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbfactory-deletedatabase">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbfactory-deletedatabase">https://w3c.github.io/IndexedDB/#dom-idbfactory-deletedatabase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbfactory-deletedatabase" class="dfn-panel" data-for="term-for-dom-idbfactory-deletedatabase" id="infopanel-for-term-for-dom-idbfactory-deletedatabase" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbfactory-deletedatabase" style="display:none">Info about the 'deleteDatabase(name)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbfactory-deletedatabase">https://w3c.github.io/IndexedDB/#dom-idbfactory-deletedatabase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-deletedatabase">3.5. clear()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbobjectstore-get">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-get">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbobjectstore-get" class="dfn-panel" data-for="term-for-dom-idbobjectstore-get" id="infopanel-for-term-for-dom-idbobjectstore-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbobjectstore-get" style="display:none">Info about the 'get(query)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-get">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-get">3.3. get(key)</a>
     <li><a href="#ref-for-dom-idbobjectstore-get①">3.6. Iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbobjectstore-getkey">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getkey">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getkey</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbobjectstore-getkey" class="dfn-panel" data-for="term-for-dom-idbobjectstore-getkey" id="infopanel-for-term-for-dom-idbobjectstore-getkey" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbobjectstore-getkey" style="display:none">Info about the 'getKey(query)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getkey">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-getkey</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-getkey">3.6. Iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-indexeddb">
-   <a href="https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb">https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-indexeddb" class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-indexeddb" id="infopanel-for-term-for-dom-windoworworkerglobalscope-indexeddb" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-indexeddb" style="display:none">Info about the 'indexedDB' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb">https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-indexeddb">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbkeyrange-lowerbound">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound">https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbkeyrange-lowerbound" class="dfn-panel" data-for="term-for-dom-idbkeyrange-lowerbound" id="infopanel-for-term-for-dom-idbkeyrange-lowerbound" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbkeyrange-lowerbound" style="display:none">Info about the 'lowerBound(lower)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound">https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-lowerbound">4. Supporting operations and concepts</a> <a href="#ref-for-dom-idbkeyrange-lowerbound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbkeyrange-lowerbound">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound">https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbkeyrange-lowerbound" class="dfn-panel" data-for="term-for-dom-idbkeyrange-lowerbound" id="infopanel-for-term-for-dom-idbkeyrange-lowerbound①" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbkeyrange-lowerbound①" style="display:none">Info about the 'lowerBound(lower, open)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound">https://w3c.github.io/IndexedDB/#dom-idbkeyrange-lowerbound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-lowerbound">4. Supporting operations and concepts</a> <a href="#ref-for-dom-idbkeyrange-lowerbound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbtransaction-objectstore">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbtransaction-objectstore">https://w3c.github.io/IndexedDB/#dom-idbtransaction-objectstore</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbtransaction-objectstore" class="dfn-panel" data-for="term-for-dom-idbtransaction-objectstore" id="infopanel-for-term-for-dom-idbtransaction-objectstore" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbtransaction-objectstore" style="display:none">Info about the 'objectStore(name)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbtransaction-objectstore">https://w3c.github.io/IndexedDB/#dom-idbtransaction-objectstore</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-objectstore">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbfactory-open">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbfactory-open">https://w3c.github.io/IndexedDB/#dom-idbfactory-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbfactory-open" class="dfn-panel" data-for="term-for-dom-idbfactory-open" id="infopanel-for-term-for-dom-idbfactory-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbfactory-open" style="display:none">Info about the 'open(name)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbfactory-open">https://w3c.github.io/IndexedDB/#dom-idbfactory-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-open">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbobjectstore-put">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-put">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-put</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbobjectstore-put" class="dfn-panel" data-for="term-for-dom-idbobjectstore-put" id="infopanel-for-term-for-dom-idbobjectstore-put" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbobjectstore-put" style="display:none">Info about the 'put(value)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-put">https://w3c.github.io/IndexedDB/#dom-idbobjectstore-put</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-put">3.2. set(key, value)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbdatabase-transaction">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction">https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbdatabase-transaction" class="dfn-panel" data-for="term-for-dom-idbdatabase-transaction" id="infopanel-for-term-for-dom-idbdatabase-transaction" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbdatabase-transaction" style="display:none">Info about the 'transaction(storeNames)' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction">https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-transaction">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cache">
-   <a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cache" class="dfn-panel" data-for="term-for-cache" id="infopanel-for-term-for-cache" role="menu">
+   <span id="infopaneltitle-for-term-for-cache" style="display:none">Info about the 'Cache' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">3.2. set(key, value)</a>
     <li><a href="#ref-for-idl-ArrayBuffer①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2. set(key, value)</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a>
     <li><a href="#ref-for-idl-DOMException③">3.3. get(key)</a>
@@ -1738,72 +1738,72 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-idl-DOMException⑤">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. The KVStorageArea class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datacloneerror">
-   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datacloneerror" class="dfn-panel" data-for="term-for-datacloneerror" id="infopanel-for-term-for-datacloneerror" role="menu">
+   <span id="infopaneltitle-for-term-for-datacloneerror" style="display:none">Info about the 'DataCloneError' external reference.</span><a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacloneerror">3.2. set(key, value)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dataerror">
-   <a href="https://webidl.spec.whatwg.org/#dataerror">https://webidl.spec.whatwg.org/#dataerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dataerror" class="dfn-panel" data-for="term-for-dataerror" id="infopanel-for-term-for-dataerror" role="menu">
+   <span id="infopaneltitle-for-term-for-dataerror" style="display:none">Info about the 'DataError' external reference.</span><a href="https://webidl.spec.whatwg.org/#dataerror">https://webidl.spec.whatwg.org/#dataerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dataerror">3.2. set(key, value)</a> <a href="#ref-for-dataerror①">(2)</a>
     <li><a href="#ref-for-dataerror②">3.3. get(key)</a>
     <li><a href="#ref-for-dataerror③">3.4. delete(key)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DataView">
-   <a href="https://webidl.spec.whatwg.org/#idl-DataView">https://webidl.spec.whatwg.org/#idl-DataView</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DataView" class="dfn-panel" data-for="term-for-idl-DataView" id="infopanel-for-term-for-idl-DataView" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DataView" style="display:none">Info about the 'DataView' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DataView">https://webidl.spec.whatwg.org/#idl-DataView</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DataView">3.2. set(key, value)</a>
     <li><a href="#ref-for-idl-DataView①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. The KVStorageArea class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. The KVStorageArea class</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. The KVStorageArea class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2. The kvStorage global</a>
     <li><a href="#ref-for-SecureContext①">3. The KVStorageArea class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2. set(key, value)</a>
     <li><a href="#ref-for-a-new-promise①">3.3. get(key)</a>
@@ -1813,65 +1813,65 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-a-new-promise⑤">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2. set(key, value)</a>
     <li><a href="#ref-for-a-promise-rejected-with①">3.3. get(key)</a>
     <li><a href="#ref-for-a-promise-rejected-with②">3.4. delete(key)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3. The KVStorageArea class</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a> <a href="#ref-for-idl-any③">(4)</a> <a href="#ref-for-idl-any④">(5)</a> <a href="#ref-for-idl-any⑤">(6)</a> <a href="#ref-for-idl-any⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps">
-   <a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps" id="infopanel-for-term-for-asynchronous-iterator-initialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" style="display:none">Info about the 'asynchronous iterator initialization steps' external reference.</span><a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-initialization-steps">3.6. Iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result" id="infopanel-for-term-for-dfn-get-the-next-iteration-result" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" style="display:none">Info about the 'get the next iteration result' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-the-next-iteration-result">3.6. Iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include">
-   <a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include" class="dfn-panel" data-for="term-for-include" id="infopanel-for-term-for-include" role="menu">
+   <span id="infopaneltitle-for-term-for-include" style="display:none">Info about the 'include' external reference.</span><a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include">4. Supporting operations and concepts</a> <a href="#ref-for-include①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-named-properties">
-   <a href="https://webidl.spec.whatwg.org/#idl-named-properties">https://webidl.spec.whatwg.org/#idl-named-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-named-properties" class="dfn-panel" data-for="term-for-idl-named-properties" id="infopanel-for-term-for-idl-named-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-named-properties" style="display:none">Info about the 'named properties' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-named-properties">https://webidl.spec.whatwg.org/#idl-named-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-named-properties">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. The KVStorageArea class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'reacting' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">3.5. clear()</a>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2. set(key, value)</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">3.3. get(key)</a>
@@ -1881,8 +1881,8 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-reject⑨">4. Supporting operations and concepts</a> <a href="#ref-for-reject①⓪">(2)</a> <a href="#ref-for-reject①①">(3)</a> <a href="#ref-for-reject①②">(4)</a> <a href="#ref-for-reject①③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.2. set(key, value)</a>
     <li><a href="#ref-for-resolve①">3.3. get(key)</a>
@@ -1892,8 +1892,8 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-resolve⑥">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">2. The kvStorage global</a>
    </ul>
@@ -2065,20 +2065,20 @@ for their contributions to this specification.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="default-kv-storage-area">
-   <b><a href="#default-kv-storage-area">#default-kv-storage-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-kv-storage-area" class="dfn-panel" data-for="default-kv-storage-area" id="infopanel-for-default-kv-storage-area" role="dialog">
+   <span id="infopaneltitle-for-default-kv-storage-area" style="display:none">Info about the 'default KV Storage area' definition.</span><b><a href="#default-kv-storage-area">#default-kv-storage-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-kv-storage-area">2. The kvStorage global</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windoworworkerglobalscope-kvstorage">
-   <b><a href="#dom-windoworworkerglobalscope-kvstorage">#dom-windoworworkerglobalscope-kvstorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windoworworkerglobalscope-kvstorage" class="dfn-panel" data-for="dom-windoworworkerglobalscope-kvstorage" id="infopanel-for-dom-windoworworkerglobalscope-kvstorage" role="dialog">
+   <span id="infopaneltitle-for-dom-windoworworkerglobalscope-kvstorage" style="display:none">Info about the 'kvStorage' definition.</span><b><a href="#dom-windoworworkerglobalscope-kvstorage">#dom-windoworworkerglobalscope-kvstorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-kvstorage">2. The kvStorage global</a> <a href="#ref-for-dom-windoworworkerglobalscope-kvstorage①">(2)</a> <a href="#ref-for-dom-windoworworkerglobalscope-kvstorage②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea">
-   <b><a href="#KVStorageArea">#KVStorageArea</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea" class="dfn-panel" data-for="KVStorageArea" id="infopanel-for-KVStorageArea" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea" style="display:none">Info about the '3. The KVStorageArea class' definition.</span><b><a href="#KVStorageArea">#KVStorageArea</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea">2. The kvStorage global</a> <a href="#ref-for-KVStorageArea①">(2)</a> <a href="#ref-for-KVStorageArea②">(3)</a>
     <li><a href="#ref-for-KVStorageArea">3. The KVStorageArea class</a> <a href="#ref-for-KVStorageArea③">(2)</a> <a href="#ref-for-KVStorageArea④">(3)</a>
@@ -2088,8 +2088,8 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-KVStorageArea①⓪">4. Supporting operations and concepts</a> <a href="#ref-for-KVStorageArea①①">(2)</a> <a href="#ref-for-KVStorageArea①②">(3)</a> <a href="#ref-for-KVStorageArea①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="databasename">
-   <b><a href="#databasename">#databasename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-databasename" class="dfn-panel" data-for="databasename" id="infopanel-for-databasename" role="dialog">
+   <span id="infopaneltitle-for-databasename" style="display:none">Info about the '[[DatabaseName]]' definition.</span><b><a href="#databasename">#databasename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-databasename">2. The kvStorage global</a>
     <li><a href="#ref-for-databasename①">3. The KVStorageArea class</a>
@@ -2099,8 +2099,8 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-databasename⑥">4. Supporting operations and concepts</a> <a href="#ref-for-databasename⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="databasepromise">
-   <b><a href="#databasepromise">#databasepromise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-databasepromise" class="dfn-panel" data-for="databasepromise" id="infopanel-for-databasepromise" role="dialog">
+   <span id="infopaneltitle-for-databasepromise" style="display:none">Info about the '[[DatabasePromise]]' definition.</span><b><a href="#databasepromise">#databasepromise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-databasepromise">2. The kvStorage global</a>
     <li><a href="#ref-for-databasepromise①">3. The KVStorageArea class</a>
@@ -2109,8 +2109,8 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-databasepromise⑥">4. Supporting operations and concepts</a> <a href="#ref-for-databasepromise⑦">(2)</a> <a href="#ref-for-databasepromise⑧">(3)</a> <a href="#ref-for-databasepromise⑨">(4)</a> <a href="#ref-for-databasepromise①⓪">(5)</a> <a href="#ref-for-databasepromise①①">(6)</a> <a href="#ref-for-databasepromise①②">(7)</a> <a href="#ref-for-databasepromise①③">(8)</a> <a href="#ref-for-databasepromise①④">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backingstoreobject">
-   <b><a href="#backingstoreobject">#backingstoreobject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backingstoreobject" class="dfn-panel" data-for="backingstoreobject" id="infopanel-for-backingstoreobject" role="dialog">
+   <span id="infopaneltitle-for-backingstoreobject" style="display:none">Info about the '[[BackingStoreObject]]' definition.</span><b><a href="#backingstoreobject">#backingstoreobject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backingstoreobject">2. The kvStorage global</a>
     <li><a href="#ref-for-backingstoreobject①">3. The KVStorageArea class</a>
@@ -2118,77 +2118,77 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-backingstoreobject③">3.7. backingStore</a> <a href="#ref-for-backingstoreobject④">(2)</a> <a href="#ref-for-backingstoreobject⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-constructor">
-   <b><a href="#KVStorageArea-constructor">#KVStorageArea-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-constructor" class="dfn-panel" data-for="KVStorageArea-constructor" id="infopanel-for-KVStorageArea-constructor" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-constructor" style="display:none">Info about the '3.1. constructor(name)' definition.</span><b><a href="#KVStorageArea-constructor">#KVStorageArea-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-constructor">3. The KVStorageArea class</a>
     <li><a href="#ref-for-KVStorageArea-constructor">3.1. constructor(name)</a> <a href="#ref-for-KVStorageArea-constructor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-set">
-   <b><a href="#KVStorageArea-set">#KVStorageArea-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-set" class="dfn-panel" data-for="KVStorageArea-set" id="infopanel-for-KVStorageArea-set" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-set" style="display:none">Info about the '3.2. set(key, value)' definition.</span><b><a href="#KVStorageArea-set">#KVStorageArea-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-set">3. The KVStorageArea class</a>
     <li><a href="#ref-for-KVStorageArea-set">3.2. set(key, value)</a> <a href="#ref-for-KVStorageArea-set①">(2)</a>
     <li><a href="#ref-for-KVStorageArea-set②">3.4. delete(key)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-get">
-   <b><a href="#KVStorageArea-get">#KVStorageArea-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-get" class="dfn-panel" data-for="KVStorageArea-get" id="infopanel-for-KVStorageArea-get" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-get" style="display:none">Info about the '3.3. get(key)' definition.</span><b><a href="#KVStorageArea-get">#KVStorageArea-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-get">3. The KVStorageArea class</a>
     <li><a href="#ref-for-KVStorageArea-get">3.3. get(key)</a> <a href="#ref-for-KVStorageArea-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-delete">
-   <b><a href="#KVStorageArea-delete">#KVStorageArea-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-delete" class="dfn-panel" data-for="KVStorageArea-delete" id="infopanel-for-KVStorageArea-delete" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-delete" style="display:none">Info about the '3.4. delete(key)' definition.</span><b><a href="#KVStorageArea-delete">#KVStorageArea-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-delete">3. The KVStorageArea class</a>
     <li><a href="#ref-for-KVStorageArea-delete">3.4. delete(key)</a> <a href="#ref-for-KVStorageArea-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-clear">
-   <b><a href="#KVStorageArea-clear">#KVStorageArea-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-clear" class="dfn-panel" data-for="KVStorageArea-clear" id="infopanel-for-KVStorageArea-clear" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-clear" style="display:none">Info about the '3.5. clear()' definition.</span><b><a href="#KVStorageArea-clear">#KVStorageArea-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-clear">3. The KVStorageArea class</a>
     <li><a href="#ref-for-KVStorageArea-clear">3.5. clear()</a> <a href="#ref-for-KVStorageArea-clear①">(2)</a>
     <li><a href="#ref-for-KVStorageArea-clear②">4. Supporting operations and concepts</a> <a href="#ref-for-KVStorageArea-clear③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deleting-the-database">
-   <b><a href="#deleting-the-database">#deleting-the-database</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deleting-the-database" class="dfn-panel" data-for="deleting-the-database" id="infopanel-for-deleting-the-database" role="dialog">
+   <span id="infopaneltitle-for-deleting-the-database" style="display:none">Info about the 'delete the database' definition.</span><b><a href="#deleting-the-database">#deleting-the-database</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deleting-the-database">3.5. clear()</a> <a href="#ref-for-deleting-the-database①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-kvstoragearea-keys">
-   <b><a href="#dom-kvstoragearea-keys">#dom-kvstoragearea-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-kvstoragearea-keys" class="dfn-panel" data-for="dom-kvstoragearea-keys" id="infopanel-for-dom-kvstoragearea-keys" role="dialog">
+   <span id="infopaneltitle-for-dom-kvstoragearea-keys" style="display:none">Info about the 'keys()' definition.</span><b><a href="#dom-kvstoragearea-keys">#dom-kvstoragearea-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-kvstoragearea-keys">3.6. Iteration</a> <a href="#ref-for-dom-kvstoragearea-keys①">(2)</a> <a href="#ref-for-dom-kvstoragearea-keys②">(3)</a> <a href="#ref-for-dom-kvstoragearea-keys③">(4)</a>
     <li><a href="#ref-for-dom-kvstoragearea-keys④">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-kvstoragearea-entries">
-   <b><a href="#dom-kvstoragearea-entries">#dom-kvstoragearea-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-kvstoragearea-entries" class="dfn-panel" data-for="dom-kvstoragearea-entries" id="infopanel-for-dom-kvstoragearea-entries" role="dialog">
+   <span id="infopaneltitle-for-dom-kvstoragearea-entries" style="display:none">Info about the 'entries()' definition.</span><b><a href="#dom-kvstoragearea-entries">#dom-kvstoragearea-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-kvstoragearea-entries">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="kvstorageareaasynciterator-last-key">
-   <b><a href="#kvstorageareaasynciterator-last-key">#kvstorageareaasynciterator-last-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-kvstorageareaasynciterator-last-key" class="dfn-panel" data-for="kvstorageareaasynciterator-last-key" id="infopanel-for-kvstorageareaasynciterator-last-key" role="dialog">
+   <span id="infopaneltitle-for-kvstorageareaasynciterator-last-key" style="display:none">Info about the 'last key' definition.</span><b><a href="#kvstorageareaasynciterator-last-key">#kvstorageareaasynciterator-last-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kvstorageareaasynciterator-last-key">3.6. Iteration</a> <a href="#ref-for-kvstorageareaasynciterator-last-key①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="KVStorageArea-backingstore">
-   <b><a href="#KVStorageArea-backingstore">#KVStorageArea-backingstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-KVStorageArea-backingstore" class="dfn-panel" data-for="KVStorageArea-backingstore" id="infopanel-for-KVStorageArea-backingstore" role="dialog">
+   <span id="infopaneltitle-for-KVStorageArea-backingstore" style="display:none">Info about the '3.7. backingStore' definition.</span><b><a href="#KVStorageArea-backingstore">#KVStorageArea-backingstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-KVStorageArea-backingstore">3. The KVStorageArea class</a> <a href="#ref-for-KVStorageArea-backingstore①">(2)</a>
     <li><a href="#ref-for-KVStorageArea-backingstore">3.7. backingStore</a> <a href="#ref-for-KVStorageArea-backingstore②">(2)</a> <a href="#ref-for-KVStorageArea-backingstore③">(3)</a> <a href="#ref-for-KVStorageArea-backingstore④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-a-simple-event-listener">
-   <b><a href="#add-a-simple-event-listener">#add-a-simple-event-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-a-simple-event-listener" class="dfn-panel" data-for="add-a-simple-event-listener" id="infopanel-for-add-a-simple-event-listener" role="dialog">
+   <span id="infopaneltitle-for-add-a-simple-event-listener" style="display:none">Info about the 'add a simple event listener' definition.</span><b><a href="#add-a-simple-event-listener">#add-a-simple-event-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-a-simple-event-listener">3.2. set(key, value)</a> <a href="#ref-for-add-a-simple-event-listener①">(2)</a> <a href="#ref-for-add-a-simple-event-listener②">(3)</a>
     <li><a href="#ref-for-add-a-simple-event-listener③">3.3. get(key)</a> <a href="#ref-for-add-a-simple-event-listener④">(2)</a>
@@ -2198,15 +2198,15 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-add-a-simple-event-listener①③">4. Supporting operations and concepts</a> <a href="#ref-for-add-a-simple-event-listener①④">(2)</a> <a href="#ref-for-add-a-simple-event-listener①⑤">(3)</a> <a href="#ref-for-add-a-simple-event-listener①⑥">(4)</a> <a href="#ref-for-add-a-simple-event-listener①⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-idbfactory">
-   <b><a href="#current-idbfactory">#current-idbfactory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-idbfactory" class="dfn-panel" data-for="current-idbfactory" id="infopanel-for-current-idbfactory" role="dialog">
+   <span id="infopaneltitle-for-current-idbfactory" style="display:none">Info about the 'current IDBFactory' definition.</span><b><a href="#current-idbfactory">#current-idbfactory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-idbfactory">3.5. clear()</a>
     <li><a href="#ref-for-current-idbfactory①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performing-a-database-operation">
-   <b><a href="#performing-a-database-operation">#performing-a-database-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performing-a-database-operation" class="dfn-panel" data-for="performing-a-database-operation" id="infopanel-for-performing-a-database-operation" role="dialog">
+   <span id="infopaneltitle-for-performing-a-database-operation" style="display:none">Info about the 'perform a database operation' definition.</span><b><a href="#performing-a-database-operation">#performing-a-database-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performing-a-database-operation">3. The KVStorageArea class</a>
     <li><a href="#ref-for-performing-a-database-operation①">3.2. set(key, value)</a>
@@ -2216,20 +2216,20 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-performing-a-database-operation⑤">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-the-database-promise">
-   <b><a href="#initialize-the-database-promise">#initialize-the-database-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-the-database-promise" class="dfn-panel" data-for="initialize-the-database-promise" id="infopanel-for-initialize-the-database-promise" role="dialog">
+   <span id="infopaneltitle-for-initialize-the-database-promise" style="display:none">Info about the 'initialize the database promise' definition.</span><b><a href="#initialize-the-database-promise">#initialize-the-database-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-the-database-promise">4. Supporting operations and concepts</a> <a href="#ref-for-initialize-the-database-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-the-database-schema">
-   <b><a href="#check-the-database-schema">#check-the-database-schema</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-the-database-schema" class="dfn-panel" data-for="check-the-database-schema" id="infopanel-for-check-the-database-schema" role="dialog">
+   <span id="infopaneltitle-for-check-the-database-schema" style="display:none">Info about the 'check the database schema' definition.</span><b><a href="#check-the-database-schema">#check-the-database-schema</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-database-schema">4. Supporting operations and concepts</a> <a href="#ref-for-check-the-database-schema①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-as-a-key">
-   <b><a href="#allowed-as-a-key">#allowed-as-a-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-as-a-key" class="dfn-panel" data-for="allowed-as-a-key" id="infopanel-for-allowed-as-a-key" role="dialog">
+   <span id="infopaneltitle-for-allowed-as-a-key" style="display:none">Info about the 'allowed as a key' definition.</span><b><a href="#allowed-as-a-key">#allowed-as-a-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-as-a-key">3.2. set(key, value)</a>
     <li><a href="#ref-for-allowed-as-a-key①">3.3. get(key)</a>
@@ -2237,22 +2237,22 @@ for their contributions to this specification.</p>
     <li><a href="#ref-for-allowed-as-a-key③">4. Supporting operations and concepts</a> <a href="#ref-for-allowed-as-a-key④">(2)</a> <a href="#ref-for-allowed-as-a-key⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-round-trip">
-   <b><a href="#key-round-trip">#key-round-trip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-round-trip" class="dfn-panel" data-for="key-round-trip" id="infopanel-for-key-round-trip" role="dialog">
+   <span id="infopaneltitle-for-key-round-trip" style="display:none">Info about the 'Key round-tripping' definition.</span><b><a href="#key-round-trip">#key-round-trip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-round-trip">3.6. Iteration</a> <a href="#ref-for-key-round-trip①">(2)</a>
     <li><a href="#ref-for-key-round-trip②">4. Supporting operations and concepts</a> <a href="#ref-for-key-round-trip③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-range-for-a-key">
-   <b><a href="#get-the-range-for-a-key">#get-the-range-for-a-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-range-for-a-key" class="dfn-panel" data-for="get-the-range-for-a-key" id="infopanel-for-get-the-range-for-a-key" role="dialog">
+   <span id="infopaneltitle-for-get-the-range-for-a-key" style="display:none">Info about the 'get the range for a key' definition.</span><b><a href="#get-the-range-for-a-key">#get-the-range-for-a-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-range-for-a-key">3.6. Iteration</a>
     <li><a href="#ref-for-get-the-range-for-a-key①">4. Supporting operations and concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="not-yet-started">
-   <b><a href="#not-yet-started">#not-yet-started</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-not-yet-started" class="dfn-panel" data-for="not-yet-started" id="infopanel-for-not-yet-started" role="dialog">
+   <span id="infopaneltitle-for-not-yet-started" style="display:none">Info about the 'not yet started' definition.</span><b><a href="#not-yet-started">#not-yet-started</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-yet-started">3.6. Iteration</a>
     <li><a href="#ref-for-not-yet-started①">4. Supporting operations and concepts</a>
@@ -2260,59 +2260,115 @@ for their contributions to this specification.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/largest-contentful-paint/index.html
+++ b/tests/github/WICG/largest-contentful-paint/index.html
@@ -1305,260 +1305,260 @@ This allows developers to detect support for the API.</p>
      <li><a href="#url">definition of</a><span>, in § 2.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-eventdef-document-scroll">
-   <a href="https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll">https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-document-scroll" class="dfn-panel" data-for="term-for-eventdef-document-scroll" id="infopanel-for-term-for-eventdef-document-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-document-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll">https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-document-scroll">3.3. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element③">(3)</a> <a href="#ref-for-element④">(4)</a> <a href="#ref-for-element⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org#concept-document">https://dom.spec.whatwg.org#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org#concept-document">https://dom.spec.whatwg.org#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-id">
-   <a href="https://dom.spec.whatwg.org#dom-element-id">https://dom.spec.whatwg.org#dom-element-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-id" class="dfn-panel" data-for="term-for-dom-element-id" id="infopanel-for-term-for-dom-element-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-id" style="display:none">Info about the 'element id' external reference.</span><a href="https://dom.spec.whatwg.org#dom-element-id">https://dom.spec.whatwg.org#dom-element-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-id">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org#concept-event-dispatch">https://dom.spec.whatwg.org#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'event dispatch algorithm' external reference.</span><a href="https://dom.spec.whatwg.org#concept-event-dispatch">https://dom.spec.whatwg.org#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">3.3. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">3.3. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">3.3. Modifications to the DOM specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-elements-exposed">
-   <a href="https://wicg.github.io/element-timing/#sec-elements-exposed">https://wicg.github.io/element-timing/#sec-elements-exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-elements-exposed" class="dfn-panel" data-for="term-for-sec-elements-exposed" id="infopanel-for-term-for-sec-elements-exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-elements-exposed" style="display:none">Info about the 'exposed' external reference.</span><a href="https://wicg.github.io/element-timing/#sec-elements-exposed">https://wicg.github.io/element-timing/#sec-elements-exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-elements-exposed">1.1. Elements exposed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-an-element">
-   <a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-an-element" class="dfn-panel" data-for="term-for-get-an-element" id="infopanel-for-term-for-get-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-get-an-element" style="display:none">Info about the 'get an element' external reference.</span><a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-element">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-dispatched-input-event">
-   <a href="https://wicg.github.io/event-timing#has-dispatched-input-event">https://wicg.github.io/event-timing#has-dispatched-input-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-dispatched-input-event" class="dfn-panel" data-for="term-for-has-dispatched-input-event" id="infopanel-for-term-for-has-dispatched-input-event" role="menu">
+   <span id="infopaneltitle-for-term-for-has-dispatched-input-event" style="display:none">Info about the 'has dispatched input event' external reference.</span><a href="https://wicg.github.io/event-timing#has-dispatched-input-event">https://wicg.github.io/event-timing#has-dispatched-input-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-dispatched-input-event">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-request①">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-url">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-url">https://fetch.spec.whatwg.org/#dom-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-url" class="dfn-panel" data-for="term-for-dom-request-url" id="infopanel-for-term-for-dom-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-url" style="display:none">Info about the 'request url' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-url">https://fetch.spec.whatwg.org/#dom-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-url">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrectreadonly-height">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-height">https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrectreadonly-height" class="dfn-panel" data-for="term-for-dom-domrectreadonly-height" id="infopanel-for-term-for-dom-domrectreadonly-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrectreadonly-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-height">https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectreadonly-height">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrectreadonly-width">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-width">https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrectreadonly-width" class="dfn-panel" data-for="term-for-dom-domrectreadonly-width" id="infopanel-for-term-for-dom-domrectreadonly-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrectreadonly-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-width">https://drafts.fxtf.org/geometry-1/#dom-domrectreadonly-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectreadonly-width">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time#dom-domhighrestimestamp">https://w3c.github.io/hr-time#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time#dom-domhighrestimestamp">https://w3c.github.io/hr-time#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-window①">3.3. Modifications to the DOM specification</a>
     <li><a href="#ref-for-window②">3.4. Modifications to the HTML specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-height">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-height">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-height" class="dfn-panel" data-for="term-for-dom-img-height" id="infopanel-for-term-for-dom-img-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-height" style="display:none">Info about the 'height' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-height">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-height">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">3.1. Potentially add LargestContentfulPaint entry</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-naturalheight">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalheight">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-naturalheight" class="dfn-panel" data-for="term-for-dom-img-naturalheight" id="infopanel-for-term-for-dom-img-naturalheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-naturalheight" style="display:none">Info about the 'naturalHeight' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalheight">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-naturalheight">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-naturalwidth">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalwidth">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalwidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-naturalwidth" class="dfn-panel" data-for="term-for-dom-img-naturalwidth" id="infopanel-for-term-for-dom-img-naturalwidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-naturalwidth" style="display:none">Info about the 'naturalWidth' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalwidth">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-naturalwidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-naturalwidth">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-concept-relevant-global①">3.3. Modifications to the DOM specification</a> <a href="#ref-for-concept-relevant-global②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-width">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-width">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-width" class="dfn-panel" data-for="term-for-dom-img-width" id="infopanel-for-term-for-dom-img-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-width" style="display:none">Info about the 'width' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-width">https://html.spec.whatwg.org/multipage/webappapis.html#dom-img-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-width">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-ordered-map①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry">
-   <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry" id="infopanel-for-term-for-dfn-queue-a-performanceentry" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" style="display:none">Info about the 'queue the performanceentry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-queue-a-performanceentry">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2.1. LargestContentfulPaint interface</a>
    </ul>
@@ -1693,115 +1693,115 @@ This allows developers to detect support for the API.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="largestcontentfulpaint">
-   <b><a href="#largestcontentfulpaint">#largestcontentfulpaint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-largestcontentfulpaint" class="dfn-panel" data-for="largestcontentfulpaint" id="infopanel-for-largestcontentfulpaint" role="dialog">
+   <span id="infopaneltitle-for-largestcontentfulpaint" style="display:none">Info about the 'LargestContentfulPaint' definition.</span><b><a href="#largestcontentfulpaint">#largestcontentfulpaint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-largestcontentfulpaint">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-largestcontentfulpaint①">(2)</a>
     <li><a href="#ref-for-largestcontentfulpaint②">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-largestcontentfulpaint③">3.2. Create a LargestContentfulPaint entry</a> <a href="#ref-for-largestcontentfulpaint④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-rendertime">
-   <b><a href="#dom-largestcontentfulpaint-rendertime">#dom-largestcontentfulpaint-rendertime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-rendertime" class="dfn-panel" data-for="dom-largestcontentfulpaint-rendertime" id="infopanel-for-dom-largestcontentfulpaint-rendertime" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-rendertime" style="display:none">Info about the 'renderTime' definition.</span><b><a href="#dom-largestcontentfulpaint-rendertime">#dom-largestcontentfulpaint-rendertime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-rendertime">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-rendertime①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-loadtime">
-   <b><a href="#dom-largestcontentfulpaint-loadtime">#dom-largestcontentfulpaint-loadtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-loadtime" class="dfn-panel" data-for="dom-largestcontentfulpaint-loadtime" id="infopanel-for-dom-largestcontentfulpaint-loadtime" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-loadtime" style="display:none">Info about the 'loadTime' definition.</span><b><a href="#dom-largestcontentfulpaint-loadtime">#dom-largestcontentfulpaint-loadtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-loadtime">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-loadtime①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-size">
-   <b><a href="#dom-largestcontentfulpaint-size">#dom-largestcontentfulpaint-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-size" class="dfn-panel" data-for="dom-largestcontentfulpaint-size" id="infopanel-for-dom-largestcontentfulpaint-size" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-size" style="display:none">Info about the 'size' definition.</span><b><a href="#dom-largestcontentfulpaint-size">#dom-largestcontentfulpaint-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-size">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-size①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-id">
-   <b><a href="#dom-largestcontentfulpaint-id">#dom-largestcontentfulpaint-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-id" class="dfn-panel" data-for="dom-largestcontentfulpaint-id" id="infopanel-for-dom-largestcontentfulpaint-id" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-largestcontentfulpaint-id">#dom-largestcontentfulpaint-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-id">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-id①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-url">
-   <b><a href="#dom-largestcontentfulpaint-url">#dom-largestcontentfulpaint-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-url" class="dfn-panel" data-for="dom-largestcontentfulpaint-url" id="infopanel-for-dom-largestcontentfulpaint-url" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-largestcontentfulpaint-url">#dom-largestcontentfulpaint-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-url">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-url①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largestcontentfulpaint-element">
-   <b><a href="#dom-largestcontentfulpaint-element">#dom-largestcontentfulpaint-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largestcontentfulpaint-element" class="dfn-panel" data-for="dom-largestcontentfulpaint-element" id="infopanel-for-dom-largestcontentfulpaint-element" role="dialog">
+   <span id="infopaneltitle-for-dom-largestcontentfulpaint-element" style="display:none">Info about the 'element' definition.</span><b><a href="#dom-largestcontentfulpaint-element">#dom-largestcontentfulpaint-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largestcontentfulpaint-element">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-dom-largestcontentfulpaint-element①">(2)</a>
     <li><a href="#ref-for-dom-largestcontentfulpaint-element②">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rendertime">
-   <b><a href="#rendertime">#rendertime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rendertime" class="dfn-panel" data-for="rendertime" id="infopanel-for-rendertime" role="dialog">
+   <span id="infopaneltitle-for-rendertime" style="display:none">Info about the 'renderTime' definition.</span><b><a href="#rendertime">#rendertime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendertime">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-rendertime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size">
-   <b><a href="#size">#size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size" class="dfn-panel" data-for="size" id="infopanel-for-size" role="dialog">
+   <span id="infopaneltitle-for-size" style="display:none">Info about the 'size' definition.</span><b><a href="#size">#size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="loadtime">
-   <b><a href="#loadtime">#loadtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-loadtime" class="dfn-panel" data-for="loadtime" id="infopanel-for-loadtime" role="dialog">
+   <span id="infopaneltitle-for-loadtime" style="display:none">Info about the 'loadTime' definition.</span><b><a href="#loadtime">#loadtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-loadtime">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-loadtime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="id">
-   <b><a href="#id">#id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-id" class="dfn-panel" data-for="id" id="infopanel-for-id" role="dialog">
+   <span id="infopaneltitle-for-id" style="display:none">Info about the 'id' definition.</span><b><a href="#id">#id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-id">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url">
-   <b><a href="#url">#url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url" class="dfn-panel" data-for="url" id="infopanel-for-url" role="dialog">
+   <span id="infopaneltitle-for-url" style="display:none">Info about the 'url' definition.</span><b><a href="#url">#url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">2.1. LargestContentfulPaint interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element">
-   <b><a href="#element">#element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element" class="dfn-panel" data-for="element" id="infopanel-for-element" role="dialog">
+   <span id="infopaneltitle-for-element" style="display:none">Info about the 'element' definition.</span><b><a href="#element">#element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element②">2.1. LargestContentfulPaint interface</a>
     <li><a href="#ref-for-element⑥">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="largest-contentful-paint-size">
-   <b><a href="#largest-contentful-paint-size">#largest-contentful-paint-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-largest-contentful-paint-size" class="dfn-panel" data-for="largest-contentful-paint-size" id="infopanel-for-largest-contentful-paint-size" role="dialog">
+   <span id="infopaneltitle-for-largest-contentful-paint-size" style="display:none">Info about the 'largest contentful paint size' definition.</span><b><a href="#largest-contentful-paint-size">#largest-contentful-paint-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-largest-contentful-paint-size">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-largest-contentful-paint-size①">3.2. Create a LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-set">
-   <b><a href="#content-set">#content-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-set" class="dfn-panel" data-for="content-set" id="infopanel-for-content-set" role="dialog">
+   <span id="infopaneltitle-for-content-set" style="display:none">Info about the 'content set' definition.</span><b><a href="#content-set">#content-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-set">2.1. LargestContentfulPaint interface</a> <a href="#ref-for-content-set①">(2)</a>
     <li><a href="#ref-for-content-set②">3.1. Potentially add LargestContentfulPaint entry</a> <a href="#ref-for-content-set③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-largestcontentfulpaint-entry">
-   <b><a href="#create-a-largestcontentfulpaint-entry">#create-a-largestcontentfulpaint-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-largestcontentfulpaint-entry" class="dfn-panel" data-for="create-a-largestcontentfulpaint-entry" id="infopanel-for-create-a-largestcontentfulpaint-entry" role="dialog">
+   <span id="infopaneltitle-for-create-a-largestcontentfulpaint-entry" style="display:none">Info about the 'create a LargestContentfulPaint entry' definition.</span><b><a href="#create-a-largestcontentfulpaint-entry">#create-a-largestcontentfulpaint-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-largestcontentfulpaint-entry">3.1. Potentially add LargestContentfulPaint entry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-dispatched-scroll-event">
-   <b><a href="#has-dispatched-scroll-event">#has-dispatched-scroll-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-dispatched-scroll-event" class="dfn-panel" data-for="has-dispatched-scroll-event" id="infopanel-for-has-dispatched-scroll-event" role="dialog">
+   <span id="infopaneltitle-for-has-dispatched-scroll-event" style="display:none">Info about the 'has dispatched scroll event' definition.</span><b><a href="#has-dispatched-scroll-event">#has-dispatched-scroll-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-dispatched-scroll-event">3.1. Potentially add LargestContentfulPaint entry</a>
     <li><a href="#ref-for-has-dispatched-scroll-event①">3.3. Modifications to the DOM specification</a>
@@ -1809,59 +1809,115 @@ This allows developers to detect support for the API.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/layout-instability/index.html
+++ b/tests/github/WICG/layout-instability/index.html
@@ -1498,113 +1498,113 @@ to cooperate to share instability scores.</p>
    <li><a href="#viewport-base-distance">viewport base distance</a><span>, in § 2.3</span>
    <li><a href="#visual-representation">visual representation</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event-change">
-   <a href="https://html.spec.whatwg.org/multipage#event-change">https://html.spec.whatwg.org/multipage#event-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-change" class="dfn-panel" data-for="term-for-event-change" id="infopanel-for-term-for-event-change" role="menu">
+   <span id="infopaneltitle-for-term-for-event-change" style="display:none">Info about the 'change event' external reference.</span><a href="https://html.spec.whatwg.org/multipage#event-change">https://html.spec.whatwg.org/multipage#event-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-change">2.4. Input Exclusion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#fragment">https://drafts.csswg.org/css-break-4/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragment">https://drafts.csswg.org/css-break-4/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2.1. Basic Concepts</a> <a href="#ref-for-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2.2. Unstable Nodes</a> <a href="#ref-for-computed-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transparency">
-   <a href="https://www.w3.org/TR/css-color-3#transparency">https://www.w3.org/TR/css-color-3#transparency</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transparency" class="dfn-panel" data-for="term-for-transparency" id="infopanel-for-term-for-transparency" role="menu">
+   <span id="infopaneltitle-for-term-for-transparency" style="display:none">Info about the 'opacity' external reference.</span><a href="https://www.w3.org/TR/css-color-3#transparency">https://www.w3.org/TR/css-color-3#transparency</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transparency">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2.1. Basic Concepts</a> <a href="#ref-for-box①">(2)</a> <a href="#ref-for-box②">(3)</a>
     <li><a href="#ref-for-box③">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">2.1. Basic Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">2.1. Basic Concepts</a> <a href="#ref-for-text-nodes①">(2)</a>
     <li><a href="#ref-for-text-nodes②">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow region' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">2.2. Unstable Nodes</a> <a href="#ref-for-scrollable-overflow-region①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-breaking">
-   <a href="https://www.w3.org/TR/css-text-3/#line-breaking">https://www.w3.org/TR/css-text-3/#line-breaking</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-breaking" class="dfn-panel" data-for="term-for-line-breaking" id="infopanel-for-term-for-line-breaking" role="menu">
+   <span id="infopaneltitle-for-term-for-line-breaking" style="display:none">Info about the 'line box' external reference.</span><a href="https://www.w3.org/TR/css-text-3/#line-breaking">https://www.w3.org/TR/css-text-3/#line-breaking</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-breaking">2.1. Basic Concepts</a> <a href="#ref-for-line-breaking①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformation-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#transformation-matrix">https://drafts.csswg.org/css-transforms-1/#transformation-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformation-matrix" class="dfn-panel" data-for="term-for-transformation-matrix" id="infopanel-for-term-for-transformation-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-transformation-matrix" style="display:none">Info about the 'transformation matrix' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#transformation-matrix">https://drafts.csswg.org/css-transforms-1/#transformation-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformation-matrix">2.1. Basic Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformed-element">
-   <a href="https://drafts.csswg.org/css-transforms-1/#transformed-element">https://drafts.csswg.org/css-transforms-1/#transformed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformed-element" class="dfn-panel" data-for="term-for-transformed-element" id="infopanel-for-term-for-transformed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-transformed-element" style="display:none">Info about the 'transformed element' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#transformed-element">https://drafts.csswg.org/css-transforms-1/#transformed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-element">2.1. Basic Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pixel-unit">
-   <a href="https://www.w3.org/TR/css-values-4/#pixel-unit">https://www.w3.org/TR/css-values-4/#pixel-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pixel-unit" class="dfn-panel" data-for="term-for-pixel-unit" id="infopanel-for-term-for-pixel-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-pixel-unit" style="display:none">Info about the 'pixel units' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#pixel-unit">https://www.w3.org/TR/css-values-4/#pixel-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pixel-unit">2.1. Basic Concepts</a> <a href="#ref-for-pixel-unit①">(2)</a> <a href="#ref-for-pixel-unit②">(3)</a>
     <li><a href="#ref-for-pixel-unit③">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2.2. Unstable Nodes</a> <a href="#ref-for-block-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">2.1. Basic Concepts</a> <a href="#ref-for-flow-relative①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-details">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">https://www.w3.org/TR/CSS2/visudet.html#containing-block-details</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-details" class="dfn-panel" data-for="term-for-containing-block-details" id="infopanel-for-term-for-containing-block-details" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-details" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">https://www.w3.org/TR/CSS2/visudet.html#containing-block-details</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-details">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-visibility">
-   <a href="https://www.w3.org/TR/CSS2/visufx.html#visibility">https://www.w3.org/TR/CSS2/visufx.html#visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-visibility" class="dfn-panel" data-for="term-for-visibility" id="infopanel-for-term-for-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://www.w3.org/TR/CSS2/visufx.html#visibility">https://www.w3.org/TR/CSS2/visufx.html#visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visibility">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://www.w3.org/TR/cssom-view-1/#viewport">https://www.w3.org/TR/cssom-view-1/#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#viewport">https://www.w3.org/TR/cssom-view-1/#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">1.1. Cumulative Layout Shift (CLS)</a> <a href="#ref-for-viewport①">(2)</a>
     <li><a href="#ref-for-viewport②">2.1. Basic Concepts</a> <a href="#ref-for-viewport③">(2)</a> <a href="#ref-for-viewport④">(3)</a> <a href="#ref-for-viewport⑤">(4)</a>
@@ -1613,8 +1613,8 @@ to cooperate to share instability scores.</p>
     <li><a href="#ref-for-viewport①①">2.4. Input Exclusion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.2. Unstable Nodes</a>
     <li><a href="#ref-for-document①">2.3. Layout Shift Value</a> <a href="#ref-for-document②">(2)</a> <a href="#ref-for-document③">(3)</a> <a href="#ref-for-document④">(4)</a> <a href="#ref-for-document⑤">(5)</a>
@@ -1623,16 +1623,16 @@ to cooperate to share instability scores.</p>
     <li><a href="#ref-for-document⑨">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.1. Basic Concepts</a> <a href="#ref-for-element①">(2)</a>
     <li><a href="#ref-for-element②">2.2. Unstable Nodes</a> <a href="#ref-for-element③">(2)</a>
     <li><a href="#ref-for-element④">4. LayoutShiftAttribution interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">2.1. Basic Concepts</a> <a href="#ref-for-node①">(2)</a> <a href="#ref-for-node②">(3)</a> <a href="#ref-for-node③">(4)</a> <a href="#ref-for-node④">(5)</a> <a href="#ref-for-node⑤">(6)</a>
     <li><a href="#ref-for-node⑥">2.2. Unstable Nodes</a> <a href="#ref-for-node⑦">(2)</a> <a href="#ref-for-node⑧">(3)</a> <a href="#ref-for-node⑨">(4)</a>
@@ -1641,167 +1641,167 @@ to cooperate to share instability scores.</p>
     <li><a href="#ref-for-node①⑧">5.2. Report the layout shift sources</a> <a href="#ref-for-node①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">4. LayoutShiftAttribution interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-descendant" class="dfn-panel" data-for="term-for-concept-shadow-including-descendant" id="infopanel-for-term-for-concept-shadow-including-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-descendant" style="display:none">Info about the 'shadow-including descendants' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-descendant">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-an-element">
-   <a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-an-element" class="dfn-panel" data-for="term-for-get-an-element" id="infopanel-for-term-for-get-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-get-an-element" style="display:none">Info about the 'get an element' external reference.</span><a href="https://wicg.github.io/element-timing/#get-an-element">https://wicg.github.io/element-timing/#get-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-element">4. LayoutShiftAttribution interface</a> <a href="#ref-for-get-an-element①">(2)</a> <a href="#ref-for-get-an-element②">(3)</a> <a href="#ref-for-get-an-element③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">4. LayoutShiftAttribution interface</a> <a href="#ref-for-domrectreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rectangle">
-   <a href="https://www.w3.org/TR/geometry-1/#rectangle">https://www.w3.org/TR/geometry-1/#rectangle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rectangle" class="dfn-panel" data-for="term-for-rectangle" id="infopanel-for-term-for-rectangle" role="menu">
+   <span id="infopaneltitle-for-term-for-rectangle" style="display:none">Info about the 'rectangle' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#rectangle">https://www.w3.org/TR/geometry-1/#rectangle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle">5.2. Report the layout shift sources</a> <a href="#ref-for-rectangle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp" id="infopanel-for-term-for-idl-def-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-domhighrestimestamp">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-high-resolution-time" class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time" id="infopanel-for-term-for-dfn-current-high-resolution-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-high-resolution-time" style="display:none">Info about the 'current high resolution time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-high-resolution-time">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">5.1. Report the layout shift</a>
     <li><a href="#ref-for-concept-relevant-realm①">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">1.1. Cumulative Layout Shift (CLS)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">5. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mark-paint-timing">
-   <a href="https://w3c.github.io/paint-timing/#mark-paint-timing">https://w3c.github.io/paint-timing/#mark-paint-timing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mark-paint-timing" class="dfn-panel" data-for="term-for-mark-paint-timing" id="infopanel-for-term-for-mark-paint-timing" role="menu">
+   <span id="infopaneltitle-for-term-for-mark-paint-timing" style="display:none">Info about the 'mark paint timing' external reference.</span><a href="https://w3c.github.io/paint-timing/#mark-paint-timing">https://w3c.github.io/paint-timing/#mark-paint-timing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mark-paint-timing">5. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-privacy-security">
-   <a href="https://w3c.github.io/resource-timing/#sec-privacy-security">https://w3c.github.io/resource-timing/#sec-privacy-security</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-privacy-security" class="dfn-panel" data-for="term-for-sec-privacy-security" id="infopanel-for-term-for-sec-privacy-security" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-privacy-security" style="display:none">Info about the 'statistical fingerprinting' external reference.</span><a href="https://w3c.github.io/resource-timing/#sec-privacy-security">https://w3c.github.io/resource-timing/#sec-privacy-security</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-privacy-security">6. Security &amp; privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visualviewport-height">
-   <a href="https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-height">https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visualviewport-height" class="dfn-panel" data-for="term-for-dom-visualviewport-height" id="infopanel-for-term-for-dom-visualviewport-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visualviewport-height" style="display:none">Info about the 'visual viewport height' external reference.</span><a href="https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-height">https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visualviewport-height">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visualviewport-width">
-   <a href="https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-width">https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visualviewport-width" class="dfn-panel" data-for="term-for-dom-visualviewport-width" id="infopanel-for-term-for-dom-visualviewport-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visualviewport-width" style="display:none">Info about the 'visual viewport width' external reference.</span><a href="https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-width">https://wicg.github.io/visual-viewport/index.html#dom-visualviewport-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visualviewport-width">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. LayoutShift interface</a>
     <li><a href="#ref-for-Exposed①">4. LayoutShiftAttribution interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. LayoutShift interface</a>
     <li><a href="#ref-for-idl-frozen-array①">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. LayoutShift interface</a>
    </ul>
@@ -2017,29 +2017,29 @@ to cooperate to share instability scores.</p>
 Element Timing spec and into a place more suitable for reuse here. <a class="issue-return" href="#issue-fa232fd7" title="Jump to section">↵</a></div>
    <div class="issue"> The <a data-link-type="dfn" href="https://wicg.github.io/element-timing/#get-an-element">get an element</a> algorithm should be generalized to accept <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#node">Node</a></code> instead of <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#element">Element</a></code>. <a class="issue-return" href="#issue-96ebd277" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="subframe-weighting-factor">
-   <b><a href="#subframe-weighting-factor">#subframe-weighting-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subframe-weighting-factor" class="dfn-panel" data-for="subframe-weighting-factor" id="infopanel-for-subframe-weighting-factor" role="dialog">
+   <span id="infopaneltitle-for-subframe-weighting-factor" style="display:none">Info about the 'subframe weighting factor' definition.</span><b><a href="#subframe-weighting-factor">#subframe-weighting-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subframe-weighting-factor">1.1. Cumulative Layout Shift (CLS)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="starting-point">
-   <b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-starting-point" class="dfn-panel" data-for="starting-point" id="infopanel-for-starting-point" role="dialog">
+   <span id="infopaneltitle-for-starting-point" style="display:none">Info about the 'starting point' definition.</span><b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-point">2.1. Basic Concepts</a> <a href="#ref-for-starting-point①">(2)</a>
     <li><a href="#ref-for-starting-point②">2.2. Unstable Nodes</a>
     <li><a href="#ref-for-starting-point③">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-indifferent-starting-point">
-   <b><a href="#transform-indifferent-starting-point">#transform-indifferent-starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-indifferent-starting-point" class="dfn-panel" data-for="transform-indifferent-starting-point" id="infopanel-for-transform-indifferent-starting-point" role="dialog">
+   <span id="infopaneltitle-for-transform-indifferent-starting-point" style="display:none">Info about the 'transform-indifferent starting point' definition.</span><b><a href="#transform-indifferent-starting-point">#transform-indifferent-starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-indifferent-starting-point">2.1. Basic Concepts</a>
     <li><a href="#ref-for-transform-indifferent-starting-point①">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visual-representation">
-   <b><a href="#visual-representation">#visual-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visual-representation" class="dfn-panel" data-for="visual-representation" id="infopanel-for-visual-representation" role="dialog">
+   <span id="infopaneltitle-for-visual-representation" style="display:none">Info about the 'visual representation' definition.</span><b><a href="#visual-representation">#visual-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visual-representation">2.1. Basic Concepts</a>
     <li><a href="#ref-for-visual-representation①">2.2. Unstable Nodes</a>
@@ -2047,282 +2047,338 @@ Element Timing spec and into a place more suitable for reuse here. <a class="iss
     <li><a href="#ref-for-visual-representation③">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-the-previous-frame">
-   <b><a href="#in-the-previous-frame">#in-the-previous-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-the-previous-frame" class="dfn-panel" data-for="in-the-previous-frame" id="infopanel-for-in-the-previous-frame" role="dialog">
+   <span id="infopaneltitle-for-in-the-previous-frame" style="display:none">Info about the 'in the previous frame' definition.</span><b><a href="#in-the-previous-frame">#in-the-previous-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-the-previous-frame">2.1. Basic Concepts</a> <a href="#ref-for-in-the-previous-frame①">(2)</a> <a href="#ref-for-in-the-previous-frame②">(3)</a>
     <li><a href="#ref-for-in-the-previous-frame③">2.2. Unstable Nodes</a> <a href="#ref-for-in-the-previous-frame④">(2)</a> <a href="#ref-for-in-the-previous-frame⑤">(3)</a> <a href="#ref-for-in-the-previous-frame⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-frame-starting-point">
-   <b><a href="#previous-frame-starting-point">#previous-frame-starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-frame-starting-point" class="dfn-panel" data-for="previous-frame-starting-point" id="infopanel-for-previous-frame-starting-point" role="dialog">
+   <span id="infopaneltitle-for-previous-frame-starting-point" style="display:none">Info about the 'previous frame starting point' definition.</span><b><a href="#previous-frame-starting-point">#previous-frame-starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-frame-starting-point">2.2. Unstable Nodes</a>
     <li><a href="#ref-for-previous-frame-starting-point①">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-frame-transform-indifferent-starting-point">
-   <b><a href="#previous-frame-transform-indifferent-starting-point">#previous-frame-transform-indifferent-starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-frame-transform-indifferent-starting-point" class="dfn-panel" data-for="previous-frame-transform-indifferent-starting-point" id="infopanel-for-previous-frame-transform-indifferent-starting-point" role="dialog">
+   <span id="infopaneltitle-for-previous-frame-transform-indifferent-starting-point" style="display:none">Info about the 'previous frame transform-indifferent starting point' definition.</span><b><a href="#previous-frame-transform-indifferent-starting-point">#previous-frame-transform-indifferent-starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-frame-transform-indifferent-starting-point">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-frame-visual-representation">
-   <b><a href="#previous-frame-visual-representation">#previous-frame-visual-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-frame-visual-representation" class="dfn-panel" data-for="previous-frame-visual-representation" id="infopanel-for-previous-frame-visual-representation" role="dialog">
+   <span id="infopaneltitle-for-previous-frame-visual-representation" style="display:none">Info about the 'previous frame visual representation' definition.</span><b><a href="#previous-frame-visual-representation">#previous-frame-visual-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-frame-visual-representation">2.2. Unstable Nodes</a>
     <li><a href="#ref-for-previous-frame-visual-representation①">2.3. Layout Shift Value</a>
     <li><a href="#ref-for-previous-frame-visual-representation②">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="differs-significantly">
-   <b><a href="#differs-significantly">#differs-significantly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-differs-significantly" class="dfn-panel" data-for="differs-significantly" id="infopanel-for-differs-significantly" role="dialog">
+   <span id="infopaneltitle-for-differs-significantly" style="display:none">Info about the 'differs significantly' definition.</span><b><a href="#differs-significantly">#differs-significantly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-differs-significantly">2.2. Unstable Nodes</a> <a href="#ref-for-differs-significantly①">(2)</a> <a href="#ref-for-differs-significantly②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-shifted">
-   <b><a href="#has-shifted">#has-shifted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-shifted" class="dfn-panel" data-for="has-shifted" id="infopanel-for-has-shifted" role="dialog">
+   <span id="infopaneltitle-for-has-shifted" style="display:none">Info about the 'has shifted' definition.</span><b><a href="#has-shifted">#has-shifted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-shifted">2.2. Unstable Nodes</a> <a href="#ref-for-has-shifted①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-not-shifted">
-   <b><a href="#has-not-shifted">#has-not-shifted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-not-shifted" class="dfn-panel" data-for="has-not-shifted" id="infopanel-for-has-not-shifted" role="dialog">
+   <span id="infopaneltitle-for-has-not-shifted" style="display:none">Info about the 'has not shifted' definition.</span><b><a href="#has-not-shifted">#has-not-shifted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-not-shifted">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable-candidate">
-   <b><a href="#unstable-candidate">#unstable-candidate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable-candidate" class="dfn-panel" data-for="unstable-candidate" id="infopanel-for-unstable-candidate" role="dialog">
+   <span id="infopaneltitle-for-unstable-candidate" style="display:none">Info about the 'unstable-candidate' definition.</span><b><a href="#unstable-candidate">#unstable-candidate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable-candidate">2.2. Unstable Nodes</a> <a href="#ref-for-unstable-candidate①">(2)</a> <a href="#ref-for-unstable-candidate②">(3)</a> <a href="#ref-for-unstable-candidate③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable">
-   <b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable" class="dfn-panel" data-for="unstable" id="infopanel-for-unstable" role="dialog">
+   <span id="infopaneltitle-for-unstable" style="display:none">Info about the 'unstable' definition.</span><b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable">2.2. Unstable Nodes</a>
     <li><a href="#ref-for-unstable①">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-clip-crosser">
-   <b><a href="#inline-clip-crosser">#inline-clip-crosser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-clip-crosser" class="dfn-panel" data-for="inline-clip-crosser" id="infopanel-for-inline-clip-crosser" role="dialog">
+   <span id="infopaneltitle-for-inline-clip-crosser" style="display:none">Info about the 'inline clip crosser' definition.</span><b><a href="#inline-clip-crosser">#inline-clip-crosser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-clip-crosser">2.2. Unstable Nodes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable-node-set">
-   <b><a href="#unstable-node-set">#unstable-node-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable-node-set" class="dfn-panel" data-for="unstable-node-set" id="infopanel-for-unstable-node-set" role="dialog">
+   <span id="infopaneltitle-for-unstable-node-set" style="display:none">Info about the 'unstable node set' definition.</span><b><a href="#unstable-node-set">#unstable-node-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable-node-set">2.3. Layout Shift Value</a> <a href="#ref-for-unstable-node-set①">(2)</a> <a href="#ref-for-unstable-node-set②">(3)</a>
     <li><a href="#ref-for-unstable-node-set③">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="viewport-base-distance">
-   <b><a href="#viewport-base-distance">#viewport-base-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-viewport-base-distance" class="dfn-panel" data-for="viewport-base-distance" id="infopanel-for-viewport-base-distance" role="dialog">
+   <span id="infopaneltitle-for-viewport-base-distance" style="display:none">Info about the 'viewport base distance' definition.</span><b><a href="#viewport-base-distance">#viewport-base-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport-base-distance">2.3. Layout Shift Value</a> <a href="#ref-for-viewport-base-distance①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="move-vector">
-   <b><a href="#move-vector">#move-vector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-move-vector" class="dfn-panel" data-for="move-vector" id="infopanel-for-move-vector" role="dialog">
+   <span id="infopaneltitle-for-move-vector" style="display:none">Info about the 'move vector' definition.</span><b><a href="#move-vector">#move-vector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-move-vector">2.3. Layout Shift Value</a> <a href="#ref-for-move-vector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="move-distance">
-   <b><a href="#move-distance">#move-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-move-distance" class="dfn-panel" data-for="move-distance" id="infopanel-for-move-distance" role="dialog">
+   <span id="infopaneltitle-for-move-distance" style="display:none">Info about the 'move distance' definition.</span><b><a href="#move-distance">#move-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-move-distance">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-move-distance">
-   <b><a href="#maximum-move-distance">#maximum-move-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-move-distance" class="dfn-panel" data-for="maximum-move-distance" id="infopanel-for-maximum-move-distance" role="dialog">
+   <span id="infopaneltitle-for-maximum-move-distance" style="display:none">Info about the 'maximum move distance' definition.</span><b><a href="#maximum-move-distance">#maximum-move-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-move-distance">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distance-fraction">
-   <b><a href="#distance-fraction">#distance-fraction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distance-fraction" class="dfn-panel" data-for="distance-fraction" id="infopanel-for-distance-fraction" role="dialog">
+   <span id="infopaneltitle-for-distance-fraction" style="display:none">Info about the 'distance fraction' definition.</span><b><a href="#distance-fraction">#distance-fraction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distance-fraction">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="node-impact-region">
-   <b><a href="#node-impact-region">#node-impact-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-node-impact-region" class="dfn-panel" data-for="node-impact-region" id="infopanel-for-node-impact-region" role="dialog">
+   <span id="infopaneltitle-for-node-impact-region" style="display:none">Info about the 'node impact region' definition.</span><b><a href="#node-impact-region">#node-impact-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node-impact-region">2.3. Layout Shift Value</a>
     <li><a href="#ref-for-node-impact-region①">5.2. Report the layout shift sources</a> <a href="#ref-for-node-impact-region②">(2)</a> <a href="#ref-for-node-impact-region③">(3)</a> <a href="#ref-for-node-impact-region④">(4)</a> <a href="#ref-for-node-impact-region⑤">(5)</a> <a href="#ref-for-node-impact-region⑥">(6)</a> <a href="#ref-for-node-impact-region⑦">(7)</a> <a href="#ref-for-node-impact-region⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impact-region">
-   <b><a href="#impact-region">#impact-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impact-region" class="dfn-panel" data-for="impact-region" id="infopanel-for-impact-region" role="dialog">
+   <span id="infopaneltitle-for-impact-region" style="display:none">Info about the 'impact region' definition.</span><b><a href="#impact-region">#impact-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impact-region">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="impact-fraction">
-   <b><a href="#impact-fraction">#impact-fraction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-impact-fraction" class="dfn-panel" data-for="impact-fraction" id="infopanel-for-impact-fraction" role="dialog">
+   <span id="infopaneltitle-for-impact-fraction" style="display:none">Info about the 'impact fraction' definition.</span><b><a href="#impact-fraction">#impact-fraction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-impact-fraction">2.3. Layout Shift Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-shift-value">
-   <b><a href="#layout-shift-value">#layout-shift-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-shift-value" class="dfn-panel" data-for="layout-shift-value" id="infopanel-for-layout-shift-value" role="dialog">
+   <span id="infopaneltitle-for-layout-shift-value" style="display:none">Info about the 'layout shift value' definition.</span><b><a href="#layout-shift-value">#layout-shift-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-shift-value">1.1. Cumulative Layout Shift (CLS)</a> <a href="#ref-for-layout-shift-value①">(2)</a> <a href="#ref-for-layout-shift-value②">(3)</a> <a href="#ref-for-layout-shift-value③">(4)</a> <a href="#ref-for-layout-shift-value④">(5)</a>
     <li><a href="#ref-for-layout-shift-value⑤">5.1. Report the layout shift</a> <a href="#ref-for-layout-shift-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="excluding-input">
-   <b><a href="#excluding-input">#excluding-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-excluding-input" class="dfn-panel" data-for="excluding-input" id="infopanel-for-excluding-input" role="dialog">
+   <span id="infopaneltitle-for-excluding-input" style="display:none">Info about the 'excluding input' definition.</span><b><a href="#excluding-input">#excluding-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-excluding-input">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutshift">
-   <b><a href="#layoutshift">#layoutshift</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutshift" class="dfn-panel" data-for="layoutshift" id="infopanel-for-layoutshift" role="dialog">
+   <span id="infopaneltitle-for-layoutshift" style="display:none">Info about the 'LayoutShift' definition.</span><b><a href="#layoutshift">#layoutshift</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutshift">3. LayoutShift interface</a>
     <li><a href="#ref-for-layoutshift①">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutshiftattribution">
-   <b><a href="#layoutshiftattribution">#layoutshiftattribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutshiftattribution" class="dfn-panel" data-for="layoutshiftattribution" id="infopanel-for-layoutshiftattribution" role="dialog">
+   <span id="infopaneltitle-for-layoutshiftattribution" style="display:none">Info about the 'LayoutShiftAttribution' definition.</span><b><a href="#layoutshiftattribution">#layoutshiftattribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutshiftattribution">3. LayoutShift interface</a>
     <li><a href="#ref-for-layoutshiftattribution①">4. LayoutShiftAttribution interface</a> <a href="#ref-for-layoutshiftattribution②">(2)</a> <a href="#ref-for-layoutshiftattribution③">(3)</a>
     <li><a href="#ref-for-layoutshiftattribution④">5.2. Report the layout shift sources</a> <a href="#ref-for-layoutshiftattribution⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshiftattribution-node">
-   <b><a href="#dom-layoutshiftattribution-node">#dom-layoutshiftattribution-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshiftattribution-node" class="dfn-panel" data-for="dom-layoutshiftattribution-node" id="infopanel-for-dom-layoutshiftattribution-node" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshiftattribution-node" style="display:none">Info about the 'node' definition.</span><b><a href="#dom-layoutshiftattribution-node">#dom-layoutshiftattribution-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshiftattribution-node">4. LayoutShiftAttribution interface</a> <a href="#ref-for-dom-layoutshiftattribution-node">(2)</a> <a href="#ref-for-dom-layoutshiftattribution-node">(3)</a> <a href="#ref-for-dom-layoutshiftattribution-node">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-node">
-   <b><a href="#associated-node">#associated-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-node" class="dfn-panel" data-for="associated-node" id="infopanel-for-associated-node" role="dialog">
+   <span id="infopaneltitle-for-associated-node" style="display:none">Info about the 'associated node' definition.</span><b><a href="#associated-node">#associated-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-node">4. LayoutShiftAttribution interface</a> <a href="#ref-for-associated-node①">(2)</a>
     <li><a href="#ref-for-associated-node②">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-the-layout-shift">
-   <b><a href="#report-the-layout-shift">#report-the-layout-shift</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-the-layout-shift" class="dfn-panel" data-for="report-the-layout-shift" id="infopanel-for-report-the-layout-shift" role="dialog">
+   <span id="infopaneltitle-for-report-the-layout-shift" style="display:none">Info about the 'report the layout shift' definition.</span><b><a href="#report-the-layout-shift">#report-the-layout-shift</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-layout-shift">2.1. Basic Concepts</a>
     <li><a href="#ref-for-report-the-layout-shift①">3. LayoutShift interface</a>
     <li><a href="#ref-for-report-the-layout-shift②">5. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshift-value">
-   <b><a href="#dom-layoutshift-value">#dom-layoutshift-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshift-value" class="dfn-panel" data-for="dom-layoutshift-value" id="infopanel-for-dom-layoutshift-value" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshift-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-layoutshift-value">#dom-layoutshift-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshift-value">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshift-lastinputtime">
-   <b><a href="#dom-layoutshift-lastinputtime">#dom-layoutshift-lastinputtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshift-lastinputtime" class="dfn-panel" data-for="dom-layoutshift-lastinputtime" id="infopanel-for-dom-layoutshift-lastinputtime" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshift-lastinputtime" style="display:none">Info about the 'lastInputTime' definition.</span><b><a href="#dom-layoutshift-lastinputtime">#dom-layoutshift-lastinputtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshift-lastinputtime">3. LayoutShift interface</a>
     <li><a href="#ref-for-dom-layoutshift-lastinputtime①">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshift-hadrecentinput">
-   <b><a href="#dom-layoutshift-hadrecentinput">#dom-layoutshift-hadrecentinput</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshift-hadrecentinput" class="dfn-panel" data-for="dom-layoutshift-hadrecentinput" id="infopanel-for-dom-layoutshift-hadrecentinput" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshift-hadrecentinput" style="display:none">Info about the 'hadRecentInput' definition.</span><b><a href="#dom-layoutshift-hadrecentinput">#dom-layoutshift-hadrecentinput</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshift-hadrecentinput">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshift-sources">
-   <b><a href="#dom-layoutshift-sources">#dom-layoutshift-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshift-sources" class="dfn-panel" data-for="dom-layoutshift-sources" id="infopanel-for-dom-layoutshift-sources" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshift-sources" style="display:none">Info about the 'sources' definition.</span><b><a href="#dom-layoutshift-sources">#dom-layoutshift-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshift-sources">1.2. Source attribution</a>
     <li><a href="#ref-for-dom-layoutshift-sources">3. LayoutShift interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-the-layout-shift-sources">
-   <b><a href="#report-the-layout-shift-sources">#report-the-layout-shift-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-the-layout-shift-sources" class="dfn-panel" data-for="report-the-layout-shift-sources" id="infopanel-for-report-the-layout-shift-sources" role="dialog">
+   <span id="infopaneltitle-for-report-the-layout-shift-sources" style="display:none">Info about the 'report the layout shift sources' definition.</span><b><a href="#report-the-layout-shift-sources">#report-the-layout-shift-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-layout-shift-sources">5.1. Report the layout shift</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-the-attribution">
-   <b><a href="#create-the-attribution">#create-the-attribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-the-attribution" class="dfn-panel" data-for="create-the-attribution" id="infopanel-for-create-the-attribution" role="dialog">
+   <span id="infopaneltitle-for-create-the-attribution" style="display:none">Info about the 'create the attribution' definition.</span><b><a href="#create-the-attribution">#create-the-attribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-the-attribution">4. LayoutShiftAttribution interface</a>
     <li><a href="#ref-for-create-the-attribution①">5.2. Report the layout shift sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshiftattribution-previousrect">
-   <b><a href="#dom-layoutshiftattribution-previousrect">#dom-layoutshiftattribution-previousrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshiftattribution-previousrect" class="dfn-panel" data-for="dom-layoutshiftattribution-previousrect" id="infopanel-for-dom-layoutshiftattribution-previousrect" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshiftattribution-previousrect" style="display:none">Info about the 'previousRect' definition.</span><b><a href="#dom-layoutshiftattribution-previousrect">#dom-layoutshiftattribution-previousrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshiftattribution-previousrect">4. LayoutShiftAttribution interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutshiftattribution-currentrect">
-   <b><a href="#dom-layoutshiftattribution-currentrect">#dom-layoutshiftattribution-currentrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutshiftattribution-currentrect" class="dfn-panel" data-for="dom-layoutshiftattribution-currentrect" id="infopanel-for-dom-layoutshiftattribution-currentrect" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutshiftattribution-currentrect" style="display:none">Info about the 'currentRect' definition.</span><b><a href="#dom-layoutshiftattribution-currentrect">#dom-layoutshiftattribution-currentrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutshiftattribution-currentrect">4. LayoutShiftAttribution interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/local-font-access/index.html
+++ b/tests/github/WICG/local-font-access/index.html
@@ -1227,250 +1227,250 @@ Jake Archibald</p>
    <li><a href="#font-representation-table-list">table list</a><span>, in § 4.1</span>
    <li><a href="#font-table-tag">tag</a><span>, in § 4.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-fontface">
-   <a href="https://drafts.csswg.org/css-font-loading-3/#fontface">https://drafts.csswg.org/css-font-loading-3/#fontface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fontface" class="dfn-panel" data-for="term-for-fontface" id="infopanel-for-term-for-fontface" role="menu">
+   <span id="infopaneltitle-for-term-for-fontface" style="display:none">Info about the 'FontFace' external reference.</span><a href="https://drafts.csswg.org/css-font-loading-3/#fontface">https://drafts.csswg.org/css-font-loading-3/#fontface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontface">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fontface-family">
-   <a href="https://drafts.csswg.org/css-font-loading-3/#dom-fontface-family">https://drafts.csswg.org/css-font-loading-3/#dom-fontface-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fontface-family" class="dfn-panel" data-for="term-for-dom-fontface-family" id="infopanel-for-term-for-dom-fontface-family" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fontface-family" style="display:none">Info about the 'family' external reference.</span><a href="https://drafts.csswg.org/css-font-loading-3/#dom-fontface-family">https://drafts.csswg.org/css-font-loading-3/#dom-fontface-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-family">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">6.2. The FontMetadata interface</a> <a href="#ref-for-dfn-Blob①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigatorlanguage">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage">https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigatorlanguage" class="dfn-panel" data-for="term-for-navigatorlanguage" id="infopanel-for-term-for-navigatorlanguage" role="menu">
+   <span id="infopaneltitle-for-term-for-navigatorlanguage" style="display:none">Info about the 'NavigatorLanguage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage">https://html.spec.whatwg.org/multipage/system-state.html#navigatorlanguage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatorlanguage">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">6.1. Font manager</a>
     <li><a href="#ref-for-in-parallel①">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-language">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-language">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-language" class="dfn-panel" data-for="term-for-dom-navigator-language" id="infopanel-for-term-for-dom-navigator-language" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-language" style="display:none">Info about the 'language' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-language">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-language">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">6.1. Font manager</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">4.1. Font Representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">4.1. Font Representation</a>
     <li><a href="#ref-for-list①">6.1. Font manager</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4.3. Name Table</a> <a href="#ref-for-ordered-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-sort-in-ascending-order">
-   <a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-sort-in-ascending-order" class="dfn-panel" data-for="term-for-list-sort-in-ascending-order" id="infopanel-for-term-for-list-sort-in-ascending-order" role="menu">
+   <span id="infopaneltitle-for-term-for-list-sort-in-ascending-order" style="display:none">Info about the 'sort in ascending order' external reference.</span><a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-sort-in-ascending-order">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">5. Local font access permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'requesting permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">4.2. Font Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. Font manager</a>
     <li><a href="#ref-for-Exposed①">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">6.1. Font manager</a>
     <li><a href="#ref-for-idl-promise①">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">6.1. Font manager</a> <a href="#ref-for-SecureContext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">4.3. Name Table</a>
     <li><a href="#ref-for-idl-USVString①">6.2. The FontMetadata interface</a> <a href="#ref-for-idl-USVString②">(2)</a> <a href="#ref-for-idl-USVString③">(3)</a> <a href="#ref-for-idl-USVString④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">6.1. Font manager</a>
     <li><a href="#ref-for-a-new-promise①">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">6.1. Font manager</a> <a href="#ref-for-reject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">6.1. Font manager</a>
     <li><a href="#ref-for-resolve①">6.2. The FontMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">6.1. Font manager</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">6.1. Font manager</a> <a href="#ref-for-this①">(2)</a>
     <li><a href="#ref-for-this②">6.2. The FontMetadata interface</a> <a href="#ref-for-this③">(2)</a> <a href="#ref-for-this④">(3)</a> <a href="#ref-for-this⑤">(4)</a> <a href="#ref-for-this⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">4.3. Name Table</a>
    </ul>
@@ -1626,8 +1626,8 @@ Jake Archibald</p>
    <div class="issue"> The above does not match the spec/implementation. Resolve the ambiguity. <a class="issue-return" href="#issue-5dc0994a" title="Jump to section">↵</a></div>
    <div class="issue"> Should we define an option to the <code class="idl"><a data-link-type="idl" href="#dom-fontmanager-query">query()</a></code> method to specify the desired language for strings (e.g. <code>{lang: 'zh'}</code>), falling back to `<code>en</code>` if not present? <a class="issue-return" href="#issue-656971e2" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="font-representation">
-   <b><a href="#font-representation">#font-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-representation" class="dfn-panel" data-for="font-representation" id="infopanel-for-font-representation" role="dialog">
+   <span id="infopaneltitle-for-font-representation" style="display:none">Info about the 'font representation' definition.</span><b><a href="#font-representation">#font-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-representation">4.1. Font Representation</a>
     <li><a href="#ref-for-font-representation①">4.3. Name Table</a> <a href="#ref-for-font-representation②">(2)</a> <a href="#ref-for-font-representation③">(3)</a>
@@ -1635,211 +1635,267 @@ Jake Archibald</p>
     <li><a href="#ref-for-font-representation⑤">6.2. The FontMetadata interface</a> <a href="#ref-for-font-representation⑥">(2)</a> <a href="#ref-for-font-representation⑦">(3)</a> <a href="#ref-for-font-representation⑧">(4)</a> <a href="#ref-for-font-representation⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-representation-data-bytes">
-   <b><a href="#font-representation-data-bytes">#font-representation-data-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-representation-data-bytes" class="dfn-panel" data-for="font-representation-data-bytes" id="infopanel-for-font-representation-data-bytes" role="dialog">
+   <span id="infopaneltitle-for-font-representation-data-bytes" style="display:none">Info about the 'data bytes' definition.</span><b><a href="#font-representation-data-bytes">#font-representation-data-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-representation-data-bytes">6.2. The FontMetadata interface</a> <a href="#ref-for-font-representation-data-bytes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-representation-table-list">
-   <b><a href="#font-representation-table-list">#font-representation-table-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-representation-table-list" class="dfn-panel" data-for="font-representation-table-list" id="infopanel-for-font-representation-table-list" role="dialog">
+   <span id="infopaneltitle-for-font-representation-table-list" style="display:none">Info about the 'table list' definition.</span><b><a href="#font-representation-table-list">#font-representation-table-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-representation-table-list">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-table">
-   <b><a href="#font-table">#font-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-table" class="dfn-panel" data-for="font-table" id="infopanel-for-font-table" role="dialog">
+   <span id="infopaneltitle-for-font-table" style="display:none">Info about the 'font table' definition.</span><b><a href="#font-table">#font-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-table">4.1. Font Representation</a>
     <li><a href="#ref-for-font-table①">4.2. Font Table</a>
     <li><a href="#ref-for-font-table②">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-table-tag">
-   <b><a href="#font-table-tag">#font-table-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-table-tag" class="dfn-panel" data-for="font-table-tag" id="infopanel-for-font-table-tag" role="dialog">
+   <span id="infopaneltitle-for-font-table-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#font-table-tag">#font-table-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-table-tag">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-representation-name-table">
-   <b><a href="#font-representation-name-table">#font-representation-name-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-representation-name-table" class="dfn-panel" data-for="font-representation-name-table" id="infopanel-for-font-representation-name-table" role="dialog">
+   <span id="infopaneltitle-for-font-representation-name-table" style="display:none">Info about the 'name table' definition.</span><b><a href="#font-representation-name-table">#font-representation-name-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-representation-name-table">4.3. Name Table</a> <a href="#ref-for-font-representation-name-table①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="name-table-names">
-   <b><a href="#name-table-names">#name-table-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-name-table-names" class="dfn-panel" data-for="name-table-names" id="infopanel-for-name-table-names" role="dialog">
+   <span id="infopaneltitle-for-name-table-names" style="display:none">Info about the 'names' definition.</span><b><a href="#name-table-names">#name-table-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name-table-names">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="localized-string-table">
-   <b><a href="#localized-string-table">#localized-string-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-localized-string-table" class="dfn-panel" data-for="localized-string-table" id="infopanel-for-localized-string-table" role="dialog">
+   <span id="infopaneltitle-for-localized-string-table" style="display:none">Info about the 'localized string table' definition.</span><b><a href="#localized-string-table">#localized-string-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-localized-string-table">4.3. Name Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-representation-name-string">
-   <b><a href="#font-representation-name-string">#font-representation-name-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-representation-name-string" class="dfn-panel" data-for="font-representation-name-string" id="infopanel-for-font-representation-name-string" role="dialog">
+   <span id="infopaneltitle-for-font-representation-name-string" style="display:none">Info about the 'name string id for tag' definition.</span><b><a href="#font-representation-name-string">#font-representation-name-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-representation-name-string">6.1. Font manager</a>
     <li><a href="#ref-for-font-representation-name-string①">6.2. The FontMetadata interface</a> <a href="#ref-for-font-representation-name-string②">(2)</a> <a href="#ref-for-font-representation-name-string③">(3)</a> <a href="#ref-for-font-representation-name-string④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-language">
-   <b><a href="#current-language">#current-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-language" class="dfn-panel" data-for="current-language" id="infopanel-for-current-language" role="dialog">
+   <span id="infopaneltitle-for-current-language" style="display:none">Info about the 'current language' definition.</span><b><a href="#current-language">#current-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-language">6.2. The FontMetadata interface</a> <a href="#ref-for-current-language①">(2)</a> <a href="#ref-for-current-language②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-font-access">
-   <b><a href="#dom-permissionname-font-access">#dom-permissionname-font-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-font-access" class="dfn-panel" data-for="dom-permissionname-font-access" id="infopanel-for-dom-permissionname-font-access" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-font-access" style="display:none">Info about the '"font-access"' definition.</span><b><a href="#dom-permissionname-font-access">#dom-permissionname-font-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-font-access">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatorfonts">
-   <b><a href="#navigatorfonts">#navigatorfonts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatorfonts" class="dfn-panel" data-for="navigatorfonts" id="infopanel-for-navigatorfonts" role="dialog">
+   <span id="infopaneltitle-for-navigatorfonts" style="display:none">Info about the 'NavigatorFonts' definition.</span><b><a href="#navigatorfonts">#navigatorfonts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatorfonts">6.1. Font manager</a> <a href="#ref-for-navigatorfonts①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatorfonts-fonts">
-   <b><a href="#dom-navigatorfonts-fonts">#dom-navigatorfonts-fonts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatorfonts-fonts" class="dfn-panel" data-for="dom-navigatorfonts-fonts" id="infopanel-for-dom-navigatorfonts-fonts" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatorfonts-fonts" style="display:none">Info about the 'fonts' definition.</span><b><a href="#dom-navigatorfonts-fonts">#dom-navigatorfonts-fonts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatorfonts-fonts">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontmanager">
-   <b><a href="#fontmanager">#fontmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontmanager" class="dfn-panel" data-for="fontmanager" id="infopanel-for-fontmanager" role="dialog">
+   <span id="infopaneltitle-for-fontmanager" style="display:none">Info about the 'FontManager' definition.</span><b><a href="#fontmanager">#fontmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontmanager">6.1. Font manager</a> <a href="#ref-for-fontmanager①">(2)</a> <a href="#ref-for-fontmanager②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-queryoptions">
-   <b><a href="#dictdef-queryoptions">#dictdef-queryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-queryoptions" class="dfn-panel" data-for="dictdef-queryoptions" id="infopanel-for-dictdef-queryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-queryoptions" style="display:none">Info about the 'QueryOptions' definition.</span><b><a href="#dictdef-queryoptions">#dictdef-queryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-queryoptions">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-queryoptions-persistentaccess">
-   <b><a href="#dom-queryoptions-persistentaccess">#dom-queryoptions-persistentaccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-queryoptions-persistentaccess" class="dfn-panel" data-for="dom-queryoptions-persistentaccess" id="infopanel-for-dom-queryoptions-persistentaccess" role="dialog">
+   <span id="infopaneltitle-for-dom-queryoptions-persistentaccess" style="display:none">Info about the 'persistentAccess' definition.</span><b><a href="#dom-queryoptions-persistentaccess">#dom-queryoptions-persistentaccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-queryoptions-persistentaccess">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-queryoptions-select">
-   <b><a href="#dom-queryoptions-select">#dom-queryoptions-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-queryoptions-select" class="dfn-panel" data-for="dom-queryoptions-select" id="infopanel-for-dom-queryoptions-select" role="dialog">
+   <span id="infopaneltitle-for-dom-queryoptions-select" style="display:none">Info about the 'select' definition.</span><b><a href="#dom-queryoptions-select">#dom-queryoptions-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-queryoptions-select">3.3. Accessing font data</a>
     <li><a href="#ref-for-dom-queryoptions-select①">6.1. Font manager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmanager-query">
-   <b><a href="#dom-fontmanager-query">#dom-fontmanager-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmanager-query" class="dfn-panel" data-for="dom-fontmanager-query" id="infopanel-for-dom-fontmanager-query" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmanager-query" style="display:none">Info about the 'query(options)' definition.</span><b><a href="#dom-fontmanager-query">#dom-fontmanager-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmanager-query">6.1. Font manager</a> <a href="#ref-for-dom-fontmanager-query①">(2)</a>
     <li><a href="#ref-for-dom-fontmanager-query②">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontmetadata">
-   <b><a href="#fontmetadata">#fontmetadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontmetadata" class="dfn-panel" data-for="fontmetadata" id="infopanel-for-fontmetadata" role="dialog">
+   <span id="infopaneltitle-for-fontmetadata" style="display:none">Info about the 'FontMetadata' definition.</span><b><a href="#fontmetadata">#fontmetadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontmetadata">6.1. Font manager</a> <a href="#ref-for-fontmetadata①">(2)</a> <a href="#ref-for-fontmetadata②">(3)</a>
     <li><a href="#ref-for-fontmetadata③">6.2. The FontMetadata interface</a> <a href="#ref-for-fontmetadata④">(2)</a> <a href="#ref-for-fontmetadata⑤">(3)</a>
     <li><a href="#ref-for-fontmetadata⑥">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetadata-postscriptname">
-   <b><a href="#dom-fontmetadata-postscriptname">#dom-fontmetadata-postscriptname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetadata-postscriptname" class="dfn-panel" data-for="dom-fontmetadata-postscriptname" id="infopanel-for-dom-fontmetadata-postscriptname" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetadata-postscriptname" style="display:none">Info about the 'postscriptName' definition.</span><b><a href="#dom-fontmetadata-postscriptname">#dom-fontmetadata-postscriptname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetadata-postscriptname">6.1. Font manager</a>
     <li><a href="#ref-for-dom-fontmetadata-postscriptname①">6.2. The FontMetadata interface</a> <a href="#ref-for-dom-fontmetadata-postscriptname②">(2)</a>
     <li><a href="#ref-for-dom-fontmetadata-postscriptname③">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetadata-fullname">
-   <b><a href="#dom-fontmetadata-fullname">#dom-fontmetadata-fullname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetadata-fullname" class="dfn-panel" data-for="dom-fontmetadata-fullname" id="infopanel-for-dom-fontmetadata-fullname" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetadata-fullname" style="display:none">Info about the 'fullName' definition.</span><b><a href="#dom-fontmetadata-fullname">#dom-fontmetadata-fullname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetadata-fullname">6.2. The FontMetadata interface</a> <a href="#ref-for-dom-fontmetadata-fullname①">(2)</a>
     <li><a href="#ref-for-dom-fontmetadata-fullname②">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetadata-family">
-   <b><a href="#dom-fontmetadata-family">#dom-fontmetadata-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetadata-family" class="dfn-panel" data-for="dom-fontmetadata-family" id="infopanel-for-dom-fontmetadata-family" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetadata-family" style="display:none">Info about the 'family' definition.</span><b><a href="#dom-fontmetadata-family">#dom-fontmetadata-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetadata-family">6.2. The FontMetadata interface</a> <a href="#ref-for-dom-fontmetadata-family①">(2)</a>
     <li><a href="#ref-for-dom-fontmetadata-family②">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetadata-style">
-   <b><a href="#dom-fontmetadata-style">#dom-fontmetadata-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetadata-style" class="dfn-panel" data-for="dom-fontmetadata-style" id="infopanel-for-dom-fontmetadata-style" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetadata-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-fontmetadata-style">#dom-fontmetadata-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetadata-style">6.2. The FontMetadata interface</a> <a href="#ref-for-dom-fontmetadata-style①">(2)</a>
     <li><a href="#ref-for-dom-fontmetadata-style②">7.1. Font Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetadata-blob">
-   <b><a href="#dom-fontmetadata-blob">#dom-fontmetadata-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetadata-blob" class="dfn-panel" data-for="dom-fontmetadata-blob" id="infopanel-for-dom-fontmetadata-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetadata-blob" style="display:none">Info about the 'blob()' definition.</span><b><a href="#dom-fontmetadata-blob">#dom-fontmetadata-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetadata-blob">6.2. The FontMetadata interface</a> <a href="#ref-for-dom-fontmetadata-blob①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/page-lifecycle/spec.html
+++ b/tests/github/WICG/page-lifecycle/spec.html
@@ -1193,20 +1193,20 @@ for their technical input and suggestions that led to improvements to this speci
    <li><a href="#update-document-frozenness-steps">update document frozenness steps</a><span>, in § 4</span>
    <li><a href="#dom-document-wasdiscarded">wasDiscarded</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope-owner-document">
-   <a href="https://drafts.css-houdini.org/worklets#workletglobalscope-owner-document">https://drafts.css-houdini.org/worklets#workletglobalscope-owner-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope-owner-document" class="dfn-panel" data-for="term-for-workletglobalscope-owner-document" id="infopanel-for-term-for-workletglobalscope-owner-document" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope-owner-document" style="display:none">Info about the 'owning document' external reference.</span><a href="https://drafts.css-houdini.org/worklets#workletglobalscope-owner-document">https://drafts.css-houdini.org/worklets#workletglobalscope-owner-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope-owner-document">5.1. Modifications to worklet and worker behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#viewport">https://www.w3.org/TR/CSS2/visuren.html#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#viewport">https://www.w3.org/TR/CSS2/visuren.html#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">4. Feature Policies</a> <a href="#ref-for-viewport①">(2)</a> <a href="#ref-for-viewport②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Page Lifecycle States</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">3. API</a> <a href="#ref-for-document③">(2)</a> <a href="#ref-for-document④">(3)</a>
@@ -1218,300 +1218,300 @@ for their technical input and suggestions that led to improvements to this speci
     <li><a href="#ref-for-document①③">5.4.3. Discarding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">5.2.2. Event loop: definitions</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-concept-event-fire①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-descendant" class="dfn-panel" data-for="term-for-concept-shadow-including-descendant" id="infopanel-for-term-for-concept-shadow-including-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-descendant" style="display:none">Info about the 'shadow-including descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-descendant">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-concept-shadow-including-descendant①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-forward-progress">
-   <a href="https://tc39.github.io/ecma262/#sec-forward-progress">https://tc39.github.io/ecma262/#sec-forward-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-forward-progress" class="dfn-panel" data-for="term-for-sec-forward-progress" id="infopanel-for-term-for-sec-forward-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-forward-progress" style="display:none">Info about the 'blocked' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-forward-progress">https://tc39.github.io/ecma262/#sec-forward-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-forward-progress">5.1. Modifications to worklet and worker behavior</a> <a href="#ref-for-sec-forward-progress①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">5.1. Modifications to worklet and worker behavior</a> <a href="#ref-for-sec-code-realms①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">5.1. Modifications to worklet and worker behavior</a> <a href="#ref-for-dedicatedworkerglobalscope①">(2)</a> <a href="#ref-for-dedicatedworkerglobalscope②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. API</a> <a href="#ref-for-eventhandler①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlmediaelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlmediaelement" class="dfn-panel" data-for="term-for-htmlmediaelement" id="infopanel-for-term-for-htmlmediaelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlmediaelement" style="display:none">Info about the 'HTMLMediaElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlmediaelement">5.2.7. HTMLMediaElement</a> <a href="#ref-for-htmlmediaelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3. API</a> <a href="#ref-for-window①">(2)</a>
     <li><a href="#ref-for-window②">5.2.8. Posting messages</a> <a href="#ref-for-window③">(2)</a> <a href="#ref-for-window④">(3)</a>
     <li><a href="#ref-for-window⑤">5.3.1.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">4. Feature Policies</a> <a href="#ref-for-allowed-to-use①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">4. Feature Policies</a> <a href="#ref-for-being-rendered①">(2)</a> <a href="#ref-for-being-rendered②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc⑤">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">5.2.8. Posting messages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc①" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc①" style="display:none">Info about the 'browsing context (for document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">2. Page Lifecycle States</a> <a href="#ref-for-concept-document-bc①">(2)</a>
     <li><a href="#ref-for-concept-document-bc②">4. Feature Policies</a> <a href="#ref-for-concept-document-bc③">(2)</a> <a href="#ref-for-concept-document-bc④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-container">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context-container" class="dfn-panel" data-for="term-for-browsing-context-container" id="infopanel-for-term-for-browsing-context-container" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context-container" style="display:none">Info about the 'browsing context container' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-container">4. Feature Policies</a> <a href="#ref-for-browsing-context-container①">(2)</a> <a href="#ref-for-browsing-context-container②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicated-worker-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dedicated-worker-agent">https://html.spec.whatwg.org/multipage/webappapis.html#dedicated-worker-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicated-worker-agent" class="dfn-panel" data-for="term-for-dedicated-worker-agent" id="infopanel-for-term-for-dedicated-worker-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicated-worker-agent" style="display:none">Info about the 'dedicated worker agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dedicated-worker-agent">https://html.spec.whatwg.org/multipage/webappapis.html#dedicated-worker-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicated-worker-agent">5.1. Modifications to worklet and worker behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">5.3.1.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">5.2.2. Event loop: definitions</a> <a href="#ref-for-fully-active①">(2)</a>
     <li><a href="#ref-for-fully-active②">5.2.3. Event loop: processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">5.3.2.1. Get Client Lifecycle State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iframe-load-event-steps">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iframe-load-event-steps" class="dfn-panel" data-for="term-for-iframe-load-event-steps" id="infopanel-for-term-for-iframe-load-event-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-iframe-load-event-steps" style="display:none">Info about the 'iframe load event steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#iframe-load-event-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iframe-load-event-steps">4. Feature Policies</a>
     <li><a href="#ref-for-iframe-load-event-steps①">5.2.6. iframe load event steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts" id="infopanel-for-term-for-list-of-the-descendant-browsing-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" style="display:none">Info about the 'list of the descendant browsing contexts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-the-descendant-browsing-contexts">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element" class="dfn-panel" data-for="term-for-media-element" id="infopanel-for-term-for-media-element" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element" style="display:none">Info about the 'media elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-media-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-pause-steps">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#internal-pause-steps">https://html.spec.whatwg.org/multipage/media.html#internal-pause-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-pause-steps" class="dfn-panel" data-for="term-for-internal-pause-steps" id="infopanel-for-term-for-internal-pause-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-pause-steps" style="display:none">Info about the 'media pause' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#internal-pause-steps">https://html.spec.whatwg.org/multipage/media.html#internal-pause-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-pause-steps">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-play-steps">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#internal-play-steps">https://html.spec.whatwg.org/multipage/media.html#internal-play-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-play-steps" class="dfn-panel" data-for="term-for-internal-play-steps" id="infopanel-for-term-for-internal-play-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-play-steps" style="display:none">Info about the 'media play' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#internal-play-steps">https://html.spec.whatwg.org/multipage/media.html#internal-play-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-play-steps">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set" id="infopanel-for-term-for-concept-WorkerGlobalScope-owner-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" style="display:none">Info about the 'owner set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">5.1. Modifications to worklet and worker behavior</a> <a href="#ref-for-concept-WorkerGlobalScope-owner-set①">(2)</a> <a href="#ref-for-concept-WorkerGlobalScope-owner-set②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-paused">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-paused" class="dfn-panel" data-for="term-for-dom-media-paused" id="infopanel-for-term-for-dom-media-paused" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-paused" style="display:none">Info about the 'paused' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-paused">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-pagetransitionevent-persisted">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-pagetransitionevent-persisted">https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-pagetransitionevent-persisted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-pagetransitionevent-persisted" class="dfn-panel" data-for="term-for-dom-pagetransitionevent-persisted" id="infopanel-for-term-for-dom-pagetransitionevent-persisted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-pagetransitionevent-persisted" style="display:none">Info about the 'persisted' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-pagetransitionevent-persisted">https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-pagetransitionevent-persisted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pagetransitionevent-persisted">5.2.1. Unloading documents and history traversal</a> <a href="#ref-for-dom-pagetransitionevent-persisted①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-posted-message-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#posted-message-task-source">https://html.spec.whatwg.org/multipage/web-messaging.html#posted-message-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-posted-message-task-source" class="dfn-panel" data-for="term-for-posted-message-task-source" id="infopanel-for-term-for-posted-message-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-posted-message-task-source" style="display:none">Info about the 'posted message task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#posted-message-task-source">https://html.spec.whatwg.org/multipage/web-messaging.html#posted-message-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-posted-message-task-source">5.2.8. Posting messages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-document-readiness">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness">https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-document-readiness" class="dfn-panel" data-for="term-for-current-document-readiness" id="infopanel-for-term-for-current-document-readiness" role="menu">
+   <span id="infopaneltitle-for-term-for-current-document-readiness" style="display:none">Info about the 'readiness' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness">https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-document-readiness">4. Feature Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">5.2.2. Event loop: definitions</a> <a href="#ref-for-concept-task①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">5.4.2. Changing the frozenness of documents</a>
     <li><a href="#ref-for-top-level-browsing-context①">5.4.3. Discarding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-traverse-the-history">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history">https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-traverse-the-history" class="dfn-panel" data-for="term-for-traverse-the-history" id="infopanel-for-term-for-traverse-the-history" role="menu">
+   <span id="infopaneltitle-for-term-for-traverse-the-history" style="display:none">Info about the 'traverse the history' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history">https://html.spec.whatwg.org/multipage/browsing-the-web.html#traverse-the-history</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-traverse-the-history">5.2.1. Unloading documents and history traversal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">5.2.3. Event loop: processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#worklet-agent">https://html.spec.whatwg.org/multipage/webappapis.html#worklet-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-agent" class="dfn-panel" data-for="term-for-worklet-agent" id="infopanel-for-term-for-worklet-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-agent" style="display:none">Info about the 'worklet agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#worklet-agent">https://html.spec.whatwg.org/multipage/webappapis.html#worklet-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-agent">5.1. Modifications to worklet and worker behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.3.1.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.3.1.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.3.1.2. matchAll(options)</a> <a href="#ref-for-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calculate-intersection-rect-algo">
-   <a href="https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo">https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calculate-intersection-rect-algo" class="dfn-panel" data-for="term-for-calculate-intersection-rect-algo" id="infopanel-for-term-for-calculate-intersection-rect-algo" role="menu">
+   <span id="infopaneltitle-for-term-for-calculate-intersection-rect-algo" style="display:none">Info about the 'compute the intersection of a target element and the root' external reference.</span><a href="https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo">https://w3c.github.io/IntersectionObserver/#calculate-intersection-rect-algo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-intersection-rect-algo">4. Feature Policies</a> <a href="#ref-for-calculate-intersection-rect-algo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">4. Feature Policies</a> <a href="#ref-for-default-allowlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-client">
-   <a href="https://w3c.github.io/ServiceWorker/#client">https://w3c.github.io/ServiceWorker/#client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-client" class="dfn-panel" data-for="term-for-client" id="infopanel-for-term-for-client" role="menu">
+   <span id="infopaneltitle-for-term-for-client" style="display:none">Info about the 'Client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#client">https://w3c.github.io/ServiceWorker/#client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">5.3.1. Client</a> <a href="#ref-for-client①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client" class="dfn-panel" data-for="term-for-dfn-service-worker-client" id="infopanel-for-term-for-dfn-service-worker-client" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">5.3.1.3. openWindow(url)</a>
     <li><a href="#ref-for-dfn-service-worker-client①">5.3.2.1. Get Client Lifecycle State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-client-algorithm">
-   <a href="https://w3c.github.io/ServiceWorker/#create-client-algorithm">https://w3c.github.io/ServiceWorker/#create-client-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-client-algorithm" class="dfn-panel" data-for="term-for-create-client-algorithm" id="infopanel-for-term-for-create-client-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-create-client-algorithm" style="display:none">Info about the 'create client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#create-client-algorithm">https://w3c.github.io/ServiceWorker/#create-client-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-client-algorithm">5.3.1.2. matchAll(options)</a>
     <li><a href="#termref-for-create-client-algorithm">5.3.2.2. Create Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-windowclient-algorithm">
-   <a href="https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm">https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-windowclient-algorithm" class="dfn-panel" data-for="term-for-create-windowclient-algorithm" id="infopanel-for-term-for-create-windowclient-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-create-windowclient-algorithm" style="display:none">Info about the 'create window client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm">https://w3c.github.io/ServiceWorker/#create-windowclient-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-windowclient-algorithm">5.3.1.2. matchAll(options)</a>
     <li><a href="#ref-for-create-windowclient-algorithm①">5.3.1.3. openWindow(url)</a>
     <li><a href="#termref-for-create-windowclient-algorithm">5.3.2.3. Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. API</a>
    </ul>
@@ -1656,98 +1656,98 @@ for their technical input and suggestions that led to improvements to this speci
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-document-onfreeze">
-   <b><a href="#dom-document-onfreeze">#dom-document-onfreeze</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-onfreeze" class="dfn-panel" data-for="dom-document-onfreeze" id="infopanel-for-dom-document-onfreeze" role="dialog">
+   <span id="infopaneltitle-for-dom-document-onfreeze" style="display:none">Info about the 'onfreeze' definition.</span><b><a href="#dom-document-onfreeze">#dom-document-onfreeze</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-onfreeze">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-onresume">
-   <b><a href="#dom-document-onresume">#dom-document-onresume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-onresume" class="dfn-panel" data-for="dom-document-onresume" id="infopanel-for-dom-document-onresume" role="dialog">
+   <span id="infopaneltitle-for-dom-document-onresume" style="display:none">Info about the 'onresume' definition.</span><b><a href="#dom-document-onresume">#dom-document-onresume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-onresume">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-wasdiscarded">
-   <b><a href="#dom-document-wasdiscarded">#dom-document-wasdiscarded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-wasdiscarded" class="dfn-panel" data-for="dom-document-wasdiscarded" id="infopanel-for-dom-document-wasdiscarded" role="dialog">
+   <span id="infopaneltitle-for-dom-document-wasdiscarded" style="display:none">Info about the 'wasDiscarded' definition.</span><b><a href="#dom-document-wasdiscarded">#dom-document-wasdiscarded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-wasdiscarded">3. API</a>
     <li><a href="#ref-for-dom-document-wasdiscarded①">5.2.4. Discarding browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="execution-while-not-rendered">
-   <b><a href="#execution-while-not-rendered">#execution-while-not-rendered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-execution-while-not-rendered" class="dfn-panel" data-for="execution-while-not-rendered" id="infopanel-for-execution-while-not-rendered" role="dialog">
+   <span id="infopaneltitle-for-execution-while-not-rendered" style="display:none">Info about the 'execution-while-not-rendered' definition.</span><b><a href="#execution-while-not-rendered">#execution-while-not-rendered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-execution-while-not-rendered">4. Feature Policies</a> <a href="#ref-for-execution-while-not-rendered①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="execution-while-out-of-viewport">
-   <b><a href="#execution-while-out-of-viewport">#execution-while-out-of-viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-execution-while-out-of-viewport" class="dfn-panel" data-for="execution-while-out-of-viewport" id="infopanel-for-execution-while-out-of-viewport" role="dialog">
+   <span id="infopaneltitle-for-execution-while-out-of-viewport" style="display:none">Info about the 'execution-while-out-of-viewport' definition.</span><b><a href="#execution-while-out-of-viewport">#execution-while-out-of-viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-execution-while-out-of-viewport">4. Feature Policies</a> <a href="#ref-for-execution-while-out-of-viewport①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-document-frozenness-steps">
-   <b><a href="#update-document-frozenness-steps">#update-document-frozenness-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-document-frozenness-steps" class="dfn-panel" data-for="update-document-frozenness-steps" id="infopanel-for-update-document-frozenness-steps" role="dialog">
+   <span id="infopaneltitle-for-update-document-frozenness-steps" style="display:none">Info about the 'update document frozenness steps' definition.</span><b><a href="#update-document-frozenness-steps">#update-document-frozenness-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-document-frozenness-steps">5.2.3. Event loop: processing model</a>
     <li><a href="#ref-for-update-document-frozenness-steps①">5.2.6. iframe load event steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dedicatedworkerglobalscope-owning-document">
-   <b><a href="#dedicatedworkerglobalscope-owning-document">#dedicatedworkerglobalscope-owning-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dedicatedworkerglobalscope-owning-document" class="dfn-panel" data-for="dedicatedworkerglobalscope-owning-document" id="infopanel-for-dedicatedworkerglobalscope-owning-document" role="dialog">
+   <span id="infopaneltitle-for-dedicatedworkerglobalscope-owning-document" style="display:none">Info about the 'owning document' definition.</span><b><a href="#dedicatedworkerglobalscope-owning-document">#dedicatedworkerglobalscope-owning-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope-owning-document">5.1. Modifications to worklet and worker behavior</a> <a href="#ref-for-dedicatedworkerglobalscope-owning-document①">(2)</a>
     <li><a href="#ref-for-dedicatedworkerglobalscope-owning-document②">5.3.2.1. Get Client Lifecycle State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="htmlmediaelement-resume-frozen-flag">
-   <b><a href="#htmlmediaelement-resume-frozen-flag">#htmlmediaelement-resume-frozen-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-htmlmediaelement-resume-frozen-flag" class="dfn-panel" data-for="htmlmediaelement-resume-frozen-flag" id="infopanel-for-htmlmediaelement-resume-frozen-flag" role="dialog">
+   <span id="infopaneltitle-for-htmlmediaelement-resume-frozen-flag" style="display:none">Info about the 'resume frozen flag' definition.</span><b><a href="#htmlmediaelement-resume-frozen-flag">#htmlmediaelement-resume-frozen-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlmediaelement-resume-frozen-flag">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-htmlmediaelement-resume-frozen-flag①">(2)</a> <a href="#ref-for-htmlmediaelement-resume-frozen-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-clientlifecyclestate">
-   <b><a href="#enumdef-clientlifecyclestate">#enumdef-clientlifecyclestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-clientlifecyclestate" class="dfn-panel" data-for="enumdef-clientlifecyclestate" id="infopanel-for-enumdef-clientlifecyclestate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-clientlifecyclestate" style="display:none">Info about the 'ClientLifecycleState' definition.</span><b><a href="#enumdef-clientlifecyclestate">#enumdef-clientlifecyclestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-clientlifecyclestate">5.3.1. Client</a> <a href="#ref-for-enumdef-clientlifecyclestate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientlifecyclestate-active">
-   <b><a href="#dom-clientlifecyclestate-active">#dom-clientlifecyclestate-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientlifecyclestate-active" class="dfn-panel" data-for="dom-clientlifecyclestate-active" id="infopanel-for-dom-clientlifecyclestate-active" role="dialog">
+   <span id="infopaneltitle-for-dom-clientlifecyclestate-active" style="display:none">Info about the '"active"' definition.</span><b><a href="#dom-clientlifecyclestate-active">#dom-clientlifecyclestate-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientlifecyclestate-active">5.3.2.1. Get Client Lifecycle State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientlifecyclestate-frozen">
-   <b><a href="#dom-clientlifecyclestate-frozen">#dom-clientlifecyclestate-frozen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientlifecyclestate-frozen" class="dfn-panel" data-for="dom-clientlifecyclestate-frozen" id="infopanel-for-dom-clientlifecyclestate-frozen" role="dialog">
+   <span id="infopaneltitle-for-dom-clientlifecyclestate-frozen" style="display:none">Info about the '"frozen"' definition.</span><b><a href="#dom-clientlifecyclestate-frozen">#dom-clientlifecyclestate-frozen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientlifecyclestate-frozen">5.3.2.1. Get Client Lifecycle State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-lifecycle-state">
-   <b><a href="#dfn-service-worker-client-lifecycle-state">#dfn-service-worker-client-lifecycle-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-lifecycle-state" class="dfn-panel" data-for="dfn-service-worker-client-lifecycle-state" id="infopanel-for-dfn-service-worker-client-lifecycle-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-lifecycle-state" style="display:none">Info about the 'lifecycle state' definition.</span><b><a href="#dfn-service-worker-client-lifecycle-state">#dfn-service-worker-client-lifecycle-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-lifecycle-state">5.3.1.1. lifecycleState</a>
     <li><a href="#ref-for-dfn-service-worker-client-lifecycle-state①">5.3.2.2. Create Client</a>
     <li><a href="#ref-for-dfn-service-worker-client-lifecycle-state②">5.3.2.3. Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerclient-lifecyclestate">
-   <b><a href="#dom-serviceworkerclient-lifecyclestate">#dom-serviceworkerclient-lifecyclestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerclient-lifecyclestate" class="dfn-panel" data-for="dom-serviceworkerclient-lifecyclestate" id="infopanel-for-dom-serviceworkerclient-lifecyclestate" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerclient-lifecyclestate" style="display:none">Info about the 'lifecycleState' definition.</span><b><a href="#dom-serviceworkerclient-lifecyclestate">#dom-serviceworkerclient-lifecyclestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerclient-lifecyclestate">5.3.1.1. lifecycleState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-client-lifecycle-state">
-   <b><a href="#get-client-lifecycle-state">#get-client-lifecycle-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-client-lifecycle-state" class="dfn-panel" data-for="get-client-lifecycle-state" id="infopanel-for-get-client-lifecycle-state" role="dialog">
+   <span id="infopaneltitle-for-get-client-lifecycle-state" style="display:none">Info about the 'Get Client Lifecycle State' definition.</span><b><a href="#get-client-lifecycle-state">#get-client-lifecycle-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-client-lifecycle-state">5.3.1.2. matchAll(options)</a>
     <li><a href="#ref-for-get-client-lifecycle-state①">5.3.1.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-frozenness">
-   <b><a href="#document-frozenness">#document-frozenness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-frozenness" class="dfn-panel" data-for="document-frozenness" id="infopanel-for-document-frozenness" role="dialog">
+   <span id="infopaneltitle-for-document-frozenness" style="display:none">Info about the 'FROZENNESS' definition.</span><b><a href="#document-frozenness">#document-frozenness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-frozenness">4. Feature Policies</a>
     <li><a href="#ref-for-document-frozenness①">5.2.1. Unloading documents and history traversal</a>
@@ -1755,8 +1755,8 @@ for their technical input and suggestions that led to improvements to this speci
     <li><a href="#ref-for-document-frozenness④">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-document-frozenness⑤">(2)</a> <a href="#ref-for-document-frozenness⑥">(3)</a> <a href="#ref-for-document-frozenness⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frozen">
-   <b><a href="#frozen">#frozen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frozen" class="dfn-panel" data-for="frozen" id="infopanel-for-frozen" role="dialog">
+   <span id="infopaneltitle-for-frozen" style="display:none">Info about the 'frozen' definition.</span><b><a href="#frozen">#frozen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frozen">2. Page Lifecycle States</a> <a href="#ref-for-frozen①">(2)</a>
     <li><a href="#ref-for-frozen②">4. Feature Policies</a>
@@ -1766,51 +1766,51 @@ for their technical input and suggestions that led to improvements to this speci
     <li><a href="#ref-for-frozen⑦">5.4.1. FROZENNESS state</a> <a href="#ref-for-frozen⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unfrozen">
-   <b><a href="#unfrozen">#unfrozen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unfrozen" class="dfn-panel" data-for="unfrozen" id="infopanel-for-unfrozen" role="dialog">
+   <span id="infopaneltitle-for-unfrozen" style="display:none">Info about the 'unfrozen' definition.</span><b><a href="#unfrozen">#unfrozen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unfrozen">4. Feature Policies</a>
     <li><a href="#ref-for-unfrozen①">5.2.2. Event loop: definitions</a>
     <li><a href="#ref-for-unfrozen②">5.2.8. Posting messages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="change-the-frozenness-of-a-top-level-document">
-   <b><a href="#change-the-frozenness-of-a-top-level-document">#change-the-frozenness-of-a-top-level-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-change-the-frozenness-of-a-top-level-document" class="dfn-panel" data-for="change-the-frozenness-of-a-top-level-document" id="infopanel-for-change-the-frozenness-of-a-top-level-document" role="dialog">
+   <span id="infopaneltitle-for-change-the-frozenness-of-a-top-level-document" style="display:none">Info about the 'change the frozenness of a top-level document' definition.</span><b><a href="#change-the-frozenness-of-a-top-level-document">#change-the-frozenness-of-a-top-level-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-change-the-frozenness-of-a-top-level-document">5.4.1. FROZENNESS state</a> <a href="#ref-for-change-the-frozenness-of-a-top-level-document①">(2)</a> <a href="#ref-for-change-the-frozenness-of-a-top-level-document②">(3)</a> <a href="#ref-for-change-the-frozenness-of-a-top-level-document③">(4)</a> <a href="#ref-for-change-the-frozenness-of-a-top-level-document④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="change-the-frozenness-of-a-document">
-   <b><a href="#change-the-frozenness-of-a-document">#change-the-frozenness-of-a-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-change-the-frozenness-of-a-document" class="dfn-panel" data-for="change-the-frozenness-of-a-document" id="infopanel-for-change-the-frozenness-of-a-document" role="dialog">
+   <span id="infopaneltitle-for-change-the-frozenness-of-a-document" style="display:none">Info about the 'change the frozenness of a document' definition.</span><b><a href="#change-the-frozenness-of-a-document">#change-the-frozenness-of-a-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-change-the-frozenness-of-a-document">4. Feature Policies</a>
     <li><a href="#ref-for-change-the-frozenness-of-a-document①">5.2.1. Unloading documents and history traversal</a> <a href="#ref-for-change-the-frozenness-of-a-document②">(2)</a>
     <li><a href="#ref-for-change-the-frozenness-of-a-document③">5.4.2. Changing the frozenness of documents</a> <a href="#ref-for-change-the-frozenness-of-a-document④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="freeze-steps">
-   <b><a href="#freeze-steps">#freeze-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-freeze-steps" class="dfn-panel" data-for="freeze-steps" id="infopanel-for-freeze-steps" role="dialog">
+   <span id="infopaneltitle-for-freeze-steps" style="display:none">Info about the 'freeze steps' definition.</span><b><a href="#freeze-steps">#freeze-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-freeze-steps">2. Page Lifecycle States</a>
     <li><a href="#ref-for-freeze-steps①">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resume-steps">
-   <b><a href="#resume-steps">#resume-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resume-steps" class="dfn-panel" data-for="resume-steps" id="infopanel-for-resume-steps" role="dialog">
+   <span id="infopaneltitle-for-resume-steps" style="display:none">Info about the 'resume steps' definition.</span><b><a href="#resume-steps">#resume-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resume-steps">5.4.2. Changing the frozenness of documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-discarded">
-   <b><a href="#document-discarded">#document-discarded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-discarded" class="dfn-panel" data-for="document-discarded" id="infopanel-for-document-discarded" role="dialog">
+   <span id="infopaneltitle-for-document-discarded" style="display:none">Info about the 'discarded' definition.</span><b><a href="#document-discarded">#document-discarded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-discarded">3. API</a>
     <li><a href="#ref-for-document-discarded①">5.2.5. Initialize the document</a>
     <li><a href="#ref-for-document-discarded②">5.4.3. Discarding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discarded">
-   <b><a href="#discarded">#discarded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discarded" class="dfn-panel" data-for="discarded" id="infopanel-for-discarded" role="dialog">
+   <span id="infopaneltitle-for-discarded" style="display:none">Info about the 'discard' definition.</span><b><a href="#discarded">#discarded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discarded">2. Page Lifecycle States</a>
     <li><a href="#ref-for-discarded①">5.2.5. Initialize the document</a>
@@ -1821,59 +1821,115 @@ for their technical input and suggestions that led to improvements to this speci
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/periodic-background-sync/index.html
+++ b/tests/github/WICG/periodic-background-sync/index.html
@@ -1502,167 +1502,167 @@ The user agent should cap the duration and frequency of these events to limit re
    <li><a href="#periodic-sync-scheduler-time-of-last-fire">time of last fire</a><span>, in § 4.2</span>
    <li><a href="#dom-periodicsyncmanager-unregister">unregister(tag)</a><span>, in § 8.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-backgroundfetchmanager">
-   <a href="https://wicg.github.io/background-fetch/#backgroundfetchmanager">https://wicg.github.io/background-fetch/#backgroundfetchmanager</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-backgroundfetchmanager" class="dfn-panel" data-for="term-for-backgroundfetchmanager" id="infopanel-for-term-for-backgroundfetchmanager" role="menu">
+   <span id="infopaneltitle-for-term-for-backgroundfetchmanager" style="display:none">Info about the 'BackgroundFetchManager' external reference.</span><a href="https://wicg.github.io/background-fetch/#backgroundfetchmanager">https://wicg.github.io/background-fetch/#backgroundfetchmanager</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backgroundfetchmanager">6. Resource Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-fetch">
-   <a href="https://wicg.github.io/background-fetch/#background-fetch">https://wicg.github.io/background-fetch/#background-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-fetch" class="dfn-panel" data-for="term-for-background-fetch" id="infopanel-for-term-for-background-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-background-fetch" style="display:none">Info about the 'background fetch' external reference.</span><a href="https://wicg.github.io/background-fetch/#background-fetch">https://wicg.github.io/background-fetch/#background-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-fetch">6. Resource Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">8.1. Extensions to the ServiceWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">7.2. Respond to permission revocation</a>
     <li><a href="#ref-for-enqueue-the-following-steps②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-enqueue-the-following-steps③">(2)</a> <a href="#ref-for-enqueue-the-following-steps④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-in-parallel①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">3. Extensions to service worker registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">7.1. Process periodic sync registrations</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-ordered-map①">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-ordered-map②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissiondescriptor①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate" class="dfn-panel" data-for="term-for-dom-permissionstate" id="infopanel-for-term-for-dom-permissionstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate" style="display:none">Info about the 'PermissionState' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate">https://w3c.github.io/permissions/#dom-permissionstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissionstate①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">5.1. Permission</a>
     <li><a href="#ref-for-dom-permissionstate-granted①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cache">
-   <a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cache" class="dfn-panel" data-for="term-for-cache" id="infopanel-for-term-for-cache" role="menu">
+   <span id="infopaneltitle-for-term-for-cache" style="display:none">Info about the 'Cache' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#cache">https://w3c.github.io/ServiceWorker/#cache</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">8.4. The periodicsync event</a>
     <li><a href="#ref-for-extendableevent①">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-extendableevent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">8.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">8.1. Extensions to the ServiceWorkerGlobalScope interface</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">8.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-serviceworkerregistration①">(2)</a> <a href="#ref-for-serviceworkerregistration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent-extend-lifetime-promises">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises">https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent-extend-lifetime-promises" class="dfn-panel" data-for="term-for-extendableevent-extend-lifetime-promises" id="infopanel-for-term-for-extendableevent-extend-lifetime-promises" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises">https://w3c.github.io/ServiceWorker/#extendableevent-extend-lifetime-promises</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="term-for-dfn-service-worker-client-frame-type" id="infopanel-for-term-for-dfn-service-worker-client-frame-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client-frame-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-client-origin">
-   <a href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin">https://w3c.github.io/ServiceWorker/#service-worker-client-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-client-origin" class="dfn-panel" data-for="term-for-service-worker-client-origin" id="infopanel-for-term-for-service-worker-client-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-client-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#service-worker-client-origin">https://w3c.github.io/ServiceWorker/#service-worker-client-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-origin">2. Concepts</a>
     <li><a href="#ref-for-service-worker-client-origin①">4.1. Periodic sync registration</a>
@@ -1675,21 +1675,21 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-service-worker-client-origin①②">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker" class="dfn-panel" data-for="term-for-dfn-service-worker" id="infopanel-for-term-for-dfn-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker">https://w3c.github.io/ServiceWorker/#dfn-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1.1. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-client">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-client" class="dfn-panel" data-for="term-for-dfn-service-worker-client" id="infopanel-for-term-for-dfn-service-worker-client" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-client">https://w3c.github.io/ServiceWorker/#dfn-service-worker-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2. Concepts</a>
     <li><a href="#ref-for-dfn-service-worker-client①">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration" class="dfn-panel" data-for="term-for-dfn-service-worker-registration" id="infopanel-for-term-for-dfn-service-worker-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">4.1. Periodic sync registration</a>
@@ -1698,14 +1698,14 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-dfn-service-worker-registration④">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-registration-unregistered">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-registration-unregistered" class="dfn-panel" data-for="term-for-dfn-service-worker-registration-unregistered" id="infopanel-for-term-for-dfn-service-worker-registration-unregistered" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-registration-unregistered" style="display:none">Info about the 'unregistered' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered">https://w3c.github.io/ServiceWorker/#dfn-service-worker-registration-unregistered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Extensions to service worker registration</a>
     <li><a href="#ref-for-idl-DOMString①">4.1. Periodic sync registration</a>
@@ -1713,94 +1713,94 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-idl-DOMString⑤">8.4. The periodicsync event</a> <a href="#ref-for-idl-DOMString⑥">(2)</a> <a href="#ref-for-idl-DOMString⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">8.2. Extensions to the ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-Exposed①">8.3. PeriodicSyncManager interface</a>
     <li><a href="#ref-for-Exposed②">8.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-a-new-promise①">(2)</a> <a href="#ref-for-a-new-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wait-for-all">
-   <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wait-for-all" class="dfn-panel" data-for="term-for-wait-for-all" id="infopanel-for-term-for-wait-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-wait-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">8.4.1. Fire a periodicsync event</a>
    </ul>
@@ -1928,15 +1928,15 @@ The user agent should cap the duration and frequency of these events to limit re
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="periodicsync-event-in-the-background">
-   <b><a href="#periodicsync-event-in-the-background">#periodicsync-event-in-the-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsync-event-in-the-background" class="dfn-panel" data-for="periodicsync-event-in-the-background" id="infopanel-for-periodicsync-event-in-the-background" role="dialog">
+   <span id="infopaneltitle-for-periodicsync-event-in-the-background" style="display:none">Info about the 'in the background' definition.</span><b><a href="#periodicsync-event-in-the-background">#periodicsync-event-in-the-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsync-event-in-the-background">5.2. Location Tracking</a>
     <li><a href="#ref-for-periodicsync-event-in-the-background①">5.3. History Leaking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-periodic-sync-registrations">
-   <b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-periodic-sync-registrations" class="dfn-panel" data-for="active-periodic-sync-registrations" id="infopanel-for-active-periodic-sync-registrations" role="dialog">
+   <span id="infopaneltitle-for-active-periodic-sync-registrations" style="display:none">Info about the 'Active periodic sync registrations' definition.</span><b><a href="#active-periodic-sync-registrations">#active-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a> <a href="#ref-for-active-periodic-sync-registrations①">(2)</a>
     <li><a href="#ref-for-active-periodic-sync-registrations②">7.1. Process periodic sync registrations</a>
@@ -1945,16 +1945,16 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-active-periodic-sync-registrations①⓪">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-processing-queue">
-   <b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-processing-queue" class="dfn-panel" data-for="periodic-sync-processing-queue" id="infopanel-for-periodic-sync-processing-queue" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-processing-queue" style="display:none">Info about the 'Periodic sync processing queue' definition.</span><b><a href="#periodic-sync-processing-queue">#periodic-sync-processing-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-processing-queue">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-processing-queue①">7.2. Respond to permission revocation</a>
     <li><a href="#ref-for-periodic-sync-processing-queue②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-processing-queue③">(2)</a> <a href="#ref-for-periodic-sync-processing-queue④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration">
-   <b><a href="#periodic-sync-registration">#periodic-sync-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration" class="dfn-panel" data-for="periodic-sync-registration" id="infopanel-for-periodic-sync-registration" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration" style="display:none">Info about the 'periodic sync registration' definition.</span><b><a href="#periodic-sync-registration">#periodic-sync-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration">2. Concepts</a>
     <li><a href="#ref-for-periodic-sync-registration①">3. Extensions to service worker registration</a>
@@ -1968,8 +1968,8 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-periodic-sync-registration①③">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration">
-   <b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-service-worker-registration" class="dfn-panel" data-for="periodic-sync-registration-service-worker-registration" id="infopanel-for-periodic-sync-registration-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#periodic-sync-registration-service-worker-registration">#periodic-sync-registration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration">2. Concepts</a>
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration①">4.2. Periodic Sync Scheduler</a>
@@ -1979,149 +1979,149 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-periodic-sync-registration-service-worker-registration⑤">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-service-worker-registration⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-tag">
-   <b><a href="#periodic-sync-registration-tag">#periodic-sync-registration-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-tag" class="dfn-panel" data-for="periodic-sync-registration-tag" id="infopanel-for-periodic-sync-registration-tag" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#periodic-sync-registration-tag">#periodic-sync-registration-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-tag">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-tag①">(2)</a> <a href="#ref-for-periodic-sync-registration-tag②">(3)</a> <a href="#ref-for-periodic-sync-registration-tag③">(4)</a>
     <li><a href="#ref-for-periodic-sync-registration-tag④">8.4. The periodicsync event</a>
     <li><a href="#ref-for-periodic-sync-registration-tag⑤">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-minimum-interval">
-   <b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-minimum-interval" class="dfn-panel" data-for="periodic-sync-registration-minimum-interval" id="infopanel-for-periodic-sync-registration-minimum-interval" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-minimum-interval" style="display:none">Info about the 'minimum interval' definition.</span><b><a href="#periodic-sync-registration-minimum-interval">#periodic-sync-registration-minimum-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval">4.1. Periodic sync registration</a>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval①">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-minimum-interval②">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-minimum-interval③">(2)</a> <a href="#ref-for-periodic-sync-registration-minimum-interval④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-anchor-time">
-   <b><a href="#periodic-sync-registration-anchor-time">#periodic-sync-registration-anchor-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-anchor-time" class="dfn-panel" data-for="periodic-sync-registration-anchor-time" id="infopanel-for-periodic-sync-registration-anchor-time" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-anchor-time" style="display:none">Info about the 'anchor time' definition.</span><b><a href="#periodic-sync-registration-anchor-time">#periodic-sync-registration-anchor-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time①">8.3. PeriodicSyncManager interface</a>
     <li><a href="#ref-for-periodic-sync-registration-anchor-time②">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-registration-state">
-   <b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-registration-state" class="dfn-panel" data-for="periodic-sync-registration-state" id="infopanel-for-periodic-sync-registration-state" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-registration-state" style="display:none">Info about the 'state' definition.</span><b><a href="#periodic-sync-registration-state">#periodic-sync-registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-registration-state">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-registration-state①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodic-sync-registration-state②">(2)</a> <a href="#ref-for-periodic-sync-registration-state③">(3)</a>
     <li><a href="#ref-for-periodic-sync-registration-state④">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodic-sync-registration-state⑤">(2)</a> <a href="#ref-for-periodic-sync-registration-state⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-scheduler">
-   <b><a href="#periodic-sync-scheduler">#periodic-sync-scheduler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-scheduler" class="dfn-panel" data-for="periodic-sync-scheduler" id="infopanel-for-periodic-sync-scheduler" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-scheduler" style="display:none">Info about the 'Periodic Sync Scheduler' definition.</span><b><a href="#periodic-sync-scheduler">#periodic-sync-scheduler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-scheduler">4.2. Periodic Sync Scheduler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire">
-   <b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodic-sync-scheduler-time-of-last-fire" class="dfn-panel" data-for="periodic-sync-scheduler-time-of-last-fire" id="infopanel-for-periodic-sync-scheduler-time-of-last-fire" role="dialog">
+   <span id="infopaneltitle-for-periodic-sync-scheduler-time-of-last-fire" style="display:none">Info about the 'time of last fire' definition.</span><b><a href="#periodic-sync-scheduler-time-of-last-fire">#periodic-sync-scheduler-time-of-last-fire</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-periodic-sync-scheduler-time-of-last-fire①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-minimum-sync-interval-for-origin">
-   <b><a href="#effective-minimum-sync-interval-for-origin">#effective-minimum-sync-interval-for-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-minimum-sync-interval-for-origin" class="dfn-panel" data-for="effective-minimum-sync-interval-for-origin" id="infopanel-for-effective-minimum-sync-interval-for-origin" role="dialog">
+   <span id="infopaneltitle-for-effective-minimum-sync-interval-for-origin" style="display:none">Info about the 'effective minimum sync interval for origin' definition.</span><b><a href="#effective-minimum-sync-interval-for-origin">#effective-minimum-sync-interval-for-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-minimum-sync-interval-for-origin">4.2. Periodic Sync Scheduler</a>
     <li><a href="#ref-for-effective-minimum-sync-interval-for-origin①">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin">
-   <b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-periodic-sync-interval-for-any-origin" class="dfn-panel" data-for="minimum-periodic-sync-interval-for-any-origin" id="infopanel-for-minimum-periodic-sync-interval-for-any-origin" role="dialog">
+   <span id="infopaneltitle-for-minimum-periodic-sync-interval-for-any-origin" style="display:none">Info about the 'minimum periodic sync interval for any origin' definition.</span><b><a href="#minimum-periodic-sync-interval-for-any-origin">#minimum-periodic-sync-interval-for-any-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin">4.2. Periodic Sync Scheduler</a>
     <li><a href="#ref-for-minimum-periodic-sync-interval-for-any-origin①">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin②">(2)</a> <a href="#ref-for-minimum-periodic-sync-interval-for-any-origin③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins">
-   <b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-periodic-sync-interval-across-origins" class="dfn-panel" data-for="minimum-periodic-sync-interval-across-origins" id="infopanel-for-minimum-periodic-sync-interval-across-origins" role="dialog">
+   <span id="infopaneltitle-for-minimum-periodic-sync-interval-across-origins" style="display:none">Info about the 'minimum periodic sync interval across origins' definition.</span><b><a href="#minimum-periodic-sync-interval-across-origins">#minimum-periodic-sync-interval-across-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins">4.3. Constants</a> <a href="#ref-for-minimum-periodic-sync-interval-across-origins①">(2)</a>
     <li><a href="#ref-for-minimum-periodic-sync-interval-across-origins②">7.1. Process periodic sync registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-number-of-retries">
-   <b><a href="#maximum-number-of-retries">#maximum-number-of-retries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-number-of-retries" class="dfn-panel" data-for="maximum-number-of-retries" id="infopanel-for-maximum-number-of-retries" role="dialog">
+   <span id="infopaneltitle-for-maximum-number-of-retries" style="display:none">Info about the 'maximum number of retries' definition.</span><b><a href="#maximum-number-of-retries">#maximum-number-of-retries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-number-of-retries">4.3. Constants</a>
     <li><a href="#ref-for-maximum-number-of-retries①">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-periodic-sync-registrations">
-   <b><a href="#process-periodic-sync-registrations">#process-periodic-sync-registrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-periodic-sync-registrations" class="dfn-panel" data-for="process-periodic-sync-registrations" id="infopanel-for-process-periodic-sync-registrations" role="dialog">
+   <span id="infopaneltitle-for-process-periodic-sync-registrations" style="display:none">Info about the 'Process periodic sync registrations' definition.</span><b><a href="#process-periodic-sync-registrations">#process-periodic-sync-registrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-periodic-sync-registrations">4.2. Periodic Sync Scheduler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-to-permission-revocation">
-   <b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-to-permission-revocation" class="dfn-panel" data-for="respond-to-permission-revocation" id="infopanel-for-respond-to-permission-revocation" role="dialog">
+   <span id="infopaneltitle-for-respond-to-permission-revocation" style="display:none">Info about the 'Respond to permission revocation' definition.</span><b><a href="#respond-to-permission-revocation">#respond-to-permission-revocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-to-permission-revocation">7.2. Respond to permission revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager">
-   <b><a href="#serviceworkerregistration-periodic-sync-manager">#serviceworkerregistration-periodic-sync-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-periodic-sync-manager" class="dfn-panel" data-for="serviceworkerregistration-periodic-sync-manager" id="infopanel-for-serviceworkerregistration-periodic-sync-manager" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-periodic-sync-manager" style="display:none">Info about the 'periodic sync manager' definition.</span><b><a href="#serviceworkerregistration-periodic-sync-manager">#serviceworkerregistration-periodic-sync-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-periodic-sync-manager">8.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-periodicsync">
-   <b><a href="#dom-serviceworkerregistration-periodicsync">#dom-serviceworkerregistration-periodicsync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-periodicsync" class="dfn-panel" data-for="dom-serviceworkerregistration-periodicsync" id="infopanel-for-dom-serviceworkerregistration-periodicsync" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-periodicsync" style="display:none">Info about the 'periodicSync' definition.</span><b><a href="#dom-serviceworkerregistration-periodicsync">#dom-serviceworkerregistration-periodicsync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-periodicsync">8.2. Extensions to the ServiceWorkerRegistration interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncmanager">
-   <b><a href="#periodicsyncmanager">#periodicsyncmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncmanager" class="dfn-panel" data-for="periodicsyncmanager" id="infopanel-for-periodicsyncmanager" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncmanager" style="display:none">Info about the 'PeriodicSyncManager' definition.</span><b><a href="#periodicsyncmanager">#periodicsyncmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncmanager">8.2. Extensions to the ServiceWorkerRegistration interface</a> <a href="#ref-for-periodicsyncmanager①">(2)</a> <a href="#ref-for-periodicsyncmanager②">(3)</a>
     <li><a href="#ref-for-periodicsyncmanager③">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager④">(2)</a> <a href="#ref-for-periodicsyncmanager⑤">(3)</a> <a href="#ref-for-periodicsyncmanager⑥">(4)</a> <a href="#ref-for-periodicsyncmanager⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-backgroundsyncoptions">
-   <b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-backgroundsyncoptions" class="dfn-panel" data-for="dictdef-backgroundsyncoptions" id="infopanel-for-dictdef-backgroundsyncoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-backgroundsyncoptions" style="display:none">Info about the 'BackgroundSyncOptions' definition.</span><b><a href="#dictdef-backgroundsyncoptions">#dictdef-backgroundsyncoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-backgroundsyncoptions">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-backgroundsyncoptions-mininterval">
-   <b><a href="#dom-backgroundsyncoptions-mininterval">#dom-backgroundsyncoptions-mininterval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-backgroundsyncoptions-mininterval" class="dfn-panel" data-for="dom-backgroundsyncoptions-mininterval" id="infopanel-for-dom-backgroundsyncoptions-mininterval" role="dialog">
+   <span id="infopaneltitle-for-dom-backgroundsyncoptions-mininterval" style="display:none">Info about the 'minInterval' definition.</span><b><a href="#dom-backgroundsyncoptions-mininterval">#dom-backgroundsyncoptions-mininterval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundsyncoptions-mininterval">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval①">(2)</a> <a href="#ref-for-dom-backgroundsyncoptions-mininterval②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration">
-   <b><a href="#periodicsyncmanager-service-worker-registration">#periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncmanager-service-worker-registration" class="dfn-panel" data-for="periodicsyncmanager-service-worker-registration" id="infopanel-for-periodicsyncmanager-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncmanager-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#periodicsyncmanager-service-worker-registration">#periodicsyncmanager-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncmanager-service-worker-registration">8.2. Extensions to the ServiceWorkerRegistration interface</a>
     <li><a href="#ref-for-periodicsyncmanager-service-worker-registration①">8.3. PeriodicSyncManager interface</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration②">(2)</a> <a href="#ref-for-periodicsyncmanager-service-worker-registration③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-register">
-   <b><a href="#dom-periodicsyncmanager-register">#dom-periodicsyncmanager-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-register" class="dfn-panel" data-for="dom-periodicsyncmanager-register" id="infopanel-for-dom-periodicsyncmanager-register" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-register" style="display:none">Info about the 'register(tag, options)' definition.</span><b><a href="#dom-periodicsyncmanager-register">#dom-periodicsyncmanager-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-register">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-gettags">
-   <b><a href="#dom-periodicsyncmanager-gettags">#dom-periodicsyncmanager-gettags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-gettags" class="dfn-panel" data-for="dom-periodicsyncmanager-gettags" id="infopanel-for-dom-periodicsyncmanager-gettags" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-gettags" style="display:none">Info about the 'getTags()' definition.</span><b><a href="#dom-periodicsyncmanager-gettags">#dom-periodicsyncmanager-gettags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-gettags">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncmanager-unregister">
-   <b><a href="#dom-periodicsyncmanager-unregister">#dom-periodicsyncmanager-unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncmanager-unregister" class="dfn-panel" data-for="dom-periodicsyncmanager-unregister" id="infopanel-for-dom-periodicsyncmanager-unregister" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncmanager-unregister" style="display:none">Info about the 'unregister(tag)' definition.</span><b><a href="#dom-periodicsyncmanager-unregister">#dom-periodicsyncmanager-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncmanager-unregister">8.3. PeriodicSyncManager interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsync-event">
-   <b><a href="#periodicsync-event">#periodicsync-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsync-event" class="dfn-panel" data-for="periodicsync-event" id="infopanel-for-periodicsync-event" role="dialog">
+   <span id="infopaneltitle-for-periodicsync-event" style="display:none">Info about the 'periodicsync event' definition.</span><b><a href="#periodicsync-event">#periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsync-event">1.1. Example</a>
     <li><a href="#ref-for-periodicsync-event①">2. Concepts</a>
@@ -2135,33 +2135,33 @@ The user agent should cap the duration and frequency of these events to limit re
     <li><a href="#ref-for-periodicsync-event②⓪">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-periodicsynceventinit">
-   <b><a href="#dictdef-periodicsynceventinit">#dictdef-periodicsynceventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-periodicsynceventinit" class="dfn-panel" data-for="dictdef-periodicsynceventinit" id="infopanel-for-dictdef-periodicsynceventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-periodicsynceventinit" style="display:none">Info about the 'PeriodicSyncEventInit' definition.</span><b><a href="#dictdef-periodicsynceventinit">#dictdef-periodicsynceventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-periodicsynceventinit">8.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncevent">
-   <b><a href="#periodicsyncevent">#periodicsyncevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncevent" class="dfn-panel" data-for="periodicsyncevent" id="infopanel-for-periodicsyncevent" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncevent" style="display:none">Info about the 'PeriodicSyncEvent' definition.</span><b><a href="#periodicsyncevent">#periodicsyncevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncevent">8.4. The periodicsync event</a>
     <li><a href="#ref-for-periodicsyncevent①">8.4.1. Fire a periodicsync event</a> <a href="#ref-for-periodicsyncevent②">(2)</a> <a href="#ref-for-periodicsyncevent③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicsyncevent-tag">
-   <b><a href="#periodicsyncevent-tag">#periodicsyncevent-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicsyncevent-tag" class="dfn-panel" data-for="periodicsyncevent-tag" id="infopanel-for-periodicsyncevent-tag" role="dialog">
+   <span id="infopaneltitle-for-periodicsyncevent-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#periodicsyncevent-tag">#periodicsyncevent-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicsyncevent-tag">8.4.1. Fire a periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicsyncevent-tag">
-   <b><a href="#dom-periodicsyncevent-tag">#dom-periodicsyncevent-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicsyncevent-tag" class="dfn-panel" data-for="dom-periodicsyncevent-tag" id="infopanel-for-dom-periodicsyncevent-tag" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicsyncevent-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#dom-periodicsyncevent-tag">#dom-periodicsyncevent-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicsyncevent-tag">8.4. The periodicsync event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-periodicsync-event">
-   <b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-periodicsync-event" class="dfn-panel" data-for="fire-a-periodicsync-event" id="infopanel-for-fire-a-periodicsync-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-periodicsync-event" style="display:none">Info about the 'fire a periodicsync event' definition.</span><b><a href="#fire-a-periodicsync-event">#fire-a-periodicsync-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-periodicsync-event">7.1. Process periodic sync registrations</a>
     <li><a href="#ref-for-fire-a-periodicsync-event①">8.4.1. Fire a periodicsync event</a>
@@ -2169,59 +2169,115 @@ The user agent should cap the duration and frequency of these events to limit re
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/permissions-request/index.html
+++ b/tests/github/WICG/permissions-request/index.html
@@ -798,102 +798,102 @@ algorithm</a>.</p>
    <li><a href="#permission-request-algorithm">permission request algorithm</a><span>, in § 3</span>
    <li><a href="#dom-permissions-request">request(permissionDesc)</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.1. Default request algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">2. Request API</a>
     <li><a href="#ref-for-dom-permissiondescriptor①">3.1. Default request algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">2. Request API</a>
     <li><a href="#ref-for-dom-permissionstatus①">3.1. Default request algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions">
-   <a href="https://w3c.github.io/permissions/#dom-permissions">https://w3c.github.io/permissions/#dom-permissions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions" class="dfn-panel" data-for="term-for-dom-permissions" id="infopanel-for-term-for-dom-permissions" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions" style="display:none">Info about the 'Permissions' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissions">https://w3c.github.io/permissions/#dom-permissions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions">2. Request API</a>
     <li><a href="#ref-for-dom-permissions①">3. Additional fields in the Permission Registry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-a-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus">https://w3c.github.io/permissions/#dfn-create-a-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-a-permissionstatus" class="dfn-panel" data-for="term-for-dfn-create-a-permissionstatus" id="infopanel-for-term-for-dfn-create-a-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-a-permissionstatus" style="display:none">Info about the 'create a permissionstatus' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-create-a-permissionstatus">https://w3c.github.io/permissions/#dfn-create-a-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-a-permissionstatus">2. Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">2. Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">2. Request API</a>
     <li><a href="#ref-for-dfn-permission-descriptor-type①">3. Additional fields in the Permission Registry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-result-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-result-type" class="dfn-panel" data-for="term-for-dfn-permission-result-type" id="infopanel-for-term-for-dfn-permission-result-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-result-type" style="display:none">Info about the 'permission result type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-result-type">3. Additional fields in the Permission Registry</a> <a href="#ref-for-dfn-permission-result-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-prompt">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-prompt" class="dfn-panel" data-for="term-for-dom-permissionstate-prompt" id="infopanel-for-term-for-dom-permissionstate-prompt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-prompt" style="display:none">Info about the 'prompt' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-prompt">3.1. Default request algorithm</a> <a href="#ref-for-dom-permissionstate-prompt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">3.1. Default request algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2. Request API</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2. Request API</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">2. Request API</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2. Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2. Request API</a>
    </ul>
@@ -961,21 +961,22 @@ algorithm</a>.</p>
   permissions should use the <a data-link-type="dfn" href="#boolean-permission-request-algorithm">boolean permission request algorithm</a>,
   since it can never return an appropriate object-capability. <a class="issue-return" href="#issue-non-persistent-grants" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dom-permissions-request">
-   <b><a href="#dom-permissions-request">#dom-permissions-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissions-request" class="dfn-panel" data-for="dom-permissions-request" id="infopanel-for-dom-permissions-request" role="dialog">
+   <span id="infopaneltitle-for-dom-permissions-request" style="display:none">Info about the 'request(permissionDesc)' definition.</span><b><a href="#dom-permissions-request">#dom-permissions-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-request">2. Request API</a>
     <li><a href="#ref-for-dom-permissions-request①">3. Additional fields in the Permission Registry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-request-algorithm">
-   <b><a href="#permission-request-algorithm">#permission-request-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-request-algorithm" class="dfn-panel" data-for="permission-request-algorithm" id="infopanel-for-permission-request-algorithm" role="dialog">
+   <span id="infopaneltitle-for-permission-request-algorithm" style="display:none">Info about the 'permission request
+algorithm' definition.</span><b><a href="#permission-request-algorithm">#permission-request-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">2. Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean-permission-request-algorithm">
-   <b><a href="#boolean-permission-request-algorithm">#boolean-permission-request-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean-permission-request-algorithm" class="dfn-panel" data-for="boolean-permission-request-algorithm" id="infopanel-for-boolean-permission-request-algorithm" role="dialog">
+   <span id="infopaneltitle-for-boolean-permission-request-algorithm" style="display:none">Info about the 'boolean permission request algorithm' definition.</span><b><a href="#boolean-permission-request-algorithm">#boolean-permission-request-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean-permission-request-algorithm">3. Additional fields in the Permission Registry</a>
     <li><a href="#ref-for-boolean-permission-request-algorithm①">3.1. Default request algorithm</a>
@@ -983,57 +984,113 @@ algorithm</a>.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/permissions-revoke/index.html
+++ b/tests/github/WICG/permissions-revoke/index.html
@@ -731,92 +731,92 @@ parallel part of query().</p>
   <ul class="index">
    <li><a href="#dom-permissions-revoke">revoke(permissionDesc)</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-blob-url-resolve">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-resolve">https://w3c.github.io/FileAPI/#blob-url-resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-resolve" class="dfn-panel" data-for="term-for-blob-url-resolve" id="infopanel-for-term-for-blob-url-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-resolve">https://w3c.github.io/FileAPI/#blob-url-resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-resolve">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions">
-   <a href="https://w3c.github.io/permissions/#dom-permissions">https://w3c.github.io/permissions/#dom-permissions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions" class="dfn-panel" data-for="term-for-dom-permissions" id="infopanel-for-term-for-dom-permissions" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions" style="display:none">Info about the 'Permissions' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissions">https://w3c.github.io/permissions/#dom-permissions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-new-information-about-the-user-s-intent">
-   <a href="https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent">https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-new-information-about-the-user-s-intent" class="dfn-panel" data-for="term-for-dfn-new-information-about-the-user-s-intent" id="infopanel-for-term-for-dfn-new-information-about-the-user-s-intent" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-new-information-about-the-user-s-intent" style="display:none">Info about the 'new information about the user's intent' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent">https://w3c.github.io/permissions/#dfn-new-information-about-the-user-s-intent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-new-information-about-the-user-s-intent">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions-query">
-   <a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions-query" class="dfn-panel" data-for="term-for-dom-permissions-query" id="infopanel-for-term-for-dom-permissions-query" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions-query" style="display:none">Info about the 'query(permissionDesc)' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-query">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">2. Revoke API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2. Revoke API</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">2. Revoke API</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2. Revoke API</a>
    </ul>
@@ -880,65 +880,121 @@ parallel part of query().</p>
    <div class="issue"> This should pass <var>typedDescriptor</var> directly into the
 parallel part of query(). <a class="issue-return" href="#issue-0871c93c" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dom-permissions-revoke">
-   <b><a href="#dom-permissions-revoke">#dom-permissions-revoke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissions-revoke" class="dfn-panel" data-for="dom-permissions-revoke" id="infopanel-for-dom-permissions-revoke" role="dialog">
+   <span id="infopaneltitle-for-dom-permissions-revoke" style="display:none">Info about the 'revoke(permissionDesc)' definition.</span><b><a href="#dom-permissions-revoke">#dom-permissions-revoke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-revoke">2. Revoke API</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/portals/index.html
+++ b/tests/github/WICG/portals/index.html
@@ -2211,51 +2211,51 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     </ul>
    <li><a href="#portalactivateevent-successor-window">successor window</a><span>, in § 3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
-   <a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy">https://w3c.github.io/webappsec-csp/#header-content-security-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-content-security-policy" class="dfn-panel" data-for="term-for-header-content-security-policy" id="infopanel-for-term-for-header-content-security-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-header-content-security-policy" style="display:none">Info about the 'content-security-policy' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy">https://w3c.github.io/webappsec-csp/#header-content-security-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-content-security-policy">5.1.1. portal-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-post-request-check">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-post-request-check">https://w3c.github.io/webappsec-csp/#directive-post-request-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-post-request-check" class="dfn-panel" data-for="term-for-directive-post-request-check" id="infopanel-for-term-for-directive-post-request-check" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-post-request-check" style="display:none">Info about the 'post-request check' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-post-request-check">https://w3c.github.io/webappsec-csp/#directive-post-request-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-post-request-check">5.1.1.2. portal-src Post-request check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-pre-request-check">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-pre-request-check">https://w3c.github.io/webappsec-csp/#directive-pre-request-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-pre-request-check" class="dfn-panel" data-for="term-for-directive-pre-request-check" id="infopanel-for-term-for-directive-pre-request-check" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-pre-request-check" style="display:none">Info about the 'pre-request check' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-pre-request-check">https://w3c.github.io/webappsec-csp/#directive-pre-request-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-pre-request-check">5.1.1.1. portal-src Pre-request check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandbox">
-   <a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandbox" class="dfn-panel" data-for="term-for-sandbox" id="infopanel-for-term-for-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grammardef-serialized-source-list">
-   <a href="https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list">https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grammardef-serialized-source-list" class="dfn-panel" data-for="term-for-grammardef-serialized-source-list" id="infopanel-for-term-for-grammardef-serialized-source-list" role="menu">
+   <span id="infopaneltitle-for-term-for-grammardef-serialized-source-list" style="display:none">Info about the 'serialized-source-list' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list">https://w3c.github.io/webappsec-csp/#grammardef-serialized-source-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-serialized-source-list">5.1.1. portal-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-source-lists">
-   <a href="https://w3c.github.io/webappsec-csp/#source-lists">https://w3c.github.io/webappsec-csp/#source-lists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-source-lists" class="dfn-panel" data-for="term-for-source-lists" id="infopanel-for-term-for-source-lists" role="menu">
+   <span id="infopaneltitle-for-term-for-source-lists" style="display:none">Info about the 'source lists' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#source-lists">https://w3c.github.io/webappsec-csp/#source-lists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-lists">5.1.1. portal-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-value">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-value" class="dfn-panel" data-for="term-for-directive-value" id="infopanel-for-term-for-directive-value" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-value" style="display:none">Info about the 'value' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value">5.1.1.1. portal-src Pre-request check</a>
     <li><a href="#ref-for-directive-value①">5.1.1.2. portal-src Post-request check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Portal browsing contexts</a>
     <li><a href="#ref-for-document①">3. The portal element</a> <a href="#ref-for-document②">(2)</a>
@@ -2263,185 +2263,185 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-document④">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget-activation-behavior">
-   <a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">https://dom.spec.whatwg.org/#eventtarget-activation-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget-activation-behavior" class="dfn-panel" data-for="term-for-eventtarget-activation-behavior" id="infopanel-for-term-for-eventtarget-activation-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget-activation-behavior" style="display:none">Info about the 'activation behavior' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">https://dom.spec.whatwg.org/#eventtarget-activation-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-activation-behavior">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-adopt-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-node-adopt-ext">https://dom.spec.whatwg.org/#concept-node-adopt-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-adopt-ext" class="dfn-panel" data-for="term-for-concept-node-adopt-ext" id="infopanel-for-term-for-concept-node-adopt-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-adopt-ext" style="display:none">Info about the 'adopting steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-adopt-ext">https://dom.spec.whatwg.org/#concept-node-adopt-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-adopt-ext">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-create-element">
-   <a href="https://dom.spec.whatwg.org/#concept-create-element">https://dom.spec.whatwg.org/#concept-create-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-create-element" class="dfn-panel" data-for="term-for-concept-create-element" id="infopanel-for-term-for-concept-create-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-create-element" style="display:none">Info about the 'creating an element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-create-element">https://dom.spec.whatwg.org/#concept-create-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-create-element">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-constructor-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-event-constructor-ext">https://dom.spec.whatwg.org/#concept-event-constructor-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-constructor-ext" class="dfn-panel" data-for="term-for-concept-event-constructor-ext" id="infopanel-for-term-for-concept-event-constructor-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-constructor-ext" style="display:none">Info about the 'event constructing steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-constructor-ext">https://dom.spec.whatwg.org/#concept-event-constructor-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-constructor-ext">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3. The portal element</a> <a href="#ref-for-concept-event-fire①">(2)</a> <a href="#ref-for-concept-event-fire②">(3)</a>
     <li><a href="#ref-for-concept-event-fire③">3.1. Portal hosts</a> <a href="#ref-for-concept-event-fire④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">2. Portal browsing contexts</a>
     <li><a href="#ref-for-concept-node-document①">3. The portal element</a> <a href="#ref-for-concept-node-document②">(2)</a> <a href="#ref-for-concept-node-document③">(3)</a> <a href="#ref-for-concept-node-document④">(4)</a> <a href="#ref-for-concept-node-document⑤">(5)</a> <a href="#ref-for-concept-node-document⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">2. Portal browsing contexts</a>
     <li><a href="#ref-for-concept-document-origin①">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-agents">
-   <a href="http://tc39.github.io/ecma262/#sec-agents">http://tc39.github.io/ecma262/#sec-agents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-agents" class="dfn-panel" data-for="term-for-sec-agents" id="infopanel-for-term-for-sec-agents" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-agents" style="display:none">Info about the 'agent' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-agents">http://tc39.github.io/ecma262/#sec-agents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-agents">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. The portal element</a>
     <li><a href="#ref-for-sec-promise-objects①">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-current-url" class="dfn-panel" data-for="term-for-concept-request-current-url" id="infopanel-for-term-for-concept-request-current-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-current-url" style="display:none">Info about the 'current url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-scheme">
-   <a href="https://fetch.spec.whatwg.org/#http-scheme">https://fetch.spec.whatwg.org/#http-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-scheme" class="dfn-panel" data-for="term-for-http-scheme" id="infopanel-for-term-for-http-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-http-scheme" style="display:none">Info about the 'http(s) scheme' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-scheme">https://fetch.spec.whatwg.org/#http-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-scheme">3. The portal element</a> <a href="#ref-for-http-scheme①">(2)</a>
     <li><a href="#ref-for-http-scheme②">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer-policy">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer-policy" class="dfn-panel" data-for="term-for-concept-request-referrer-policy" id="infopanel-for-term-for-concept-request-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer-policy">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3. The portal element</a>
     <li><a href="#ref-for-concept-request①">5.1.1.1. portal-src Pre-request check</a>
     <li><a href="#ref-for-concept-request②">5.1.1.2. portal-src Post-request check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-reserved-client" class="dfn-panel" data-for="term-for-concept-request-reserved-client" id="infopanel-for-term-for-concept-request-reserved-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-reserved-client" style="display:none">Info about the 'reserved client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-reserved-client">5.2. Fetch Metadata Request Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">5.1.1.2. portal-src Post-request check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">3. The portal element</a> <a href="#ref-for-cereactions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. The portal element</a> <a href="#ref-for-eventhandler①">(2)</a>
     <li><a href="#ref-for-eventhandler②">3.1. Portal hosts</a> <a href="#ref-for-eventhandler③">(2)</a>
     <li><a href="#ref-for-eventhandler④">4.2. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlconstructor">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor">https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlconstructor" class="dfn-panel" data-for="term-for-htmlconstructor" id="infopanel-for-term-for-htmlconstructor" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlconstructor" style="display:none">Info about the 'HTMLConstructor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor">https://html.spec.whatwg.org/multipage/dom.html#htmlconstructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlconstructor">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlelement" class="dfn-panel" data-for="term-for-htmlelement" id="infopanel-for-term-for-htmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlelement" style="display:none">Info about the 'HTMLElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlelement">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageevent">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageevent" class="dfn-panel" data-for="term-for-messageevent" id="infopanel-for-term-for-messageevent" role="menu">
+   <span id="infopaneltitle-for-term-for-messageevent" style="display:none">Info about the 'MessageEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageevent">3. The portal element</a> <a href="#ref-for-messageevent①">(2)</a> <a href="#ref-for-messageevent②">(3)</a> <a href="#ref-for-messageevent③">(4)</a>
     <li><a href="#ref-for-messageevent④">3.1. Portal hosts</a> <a href="#ref-for-messageevent⑤">(2)</a> <a href="#ref-for-messageevent⑥">(3)</a> <a href="#ref-for-messageevent⑦">(4)</a>
@@ -2449,395 +2449,395 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-messageevent⑨">4.1. The MessageEvent interface</a> <a href="#ref-for-messageevent①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">3. The portal element</a>
     <li><a href="#ref-for-messageport①">3.1. Portal hosts</a>
     <li><a href="#ref-for-messageport②">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserializewithtransfer" class="dfn-panel" data-for="term-for-structureddeserializewithtransfer" id="infopanel-for-term-for-structureddeserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserializewithtransfer" style="display:none">Info about the 'StructuredDeserializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserializewithtransfer">2. Portal browsing contexts</a>
     <li><a href="#ref-for-structureddeserializewithtransfer①">3. The portal element</a>
     <li><a href="#ref-for-structureddeserializewithtransfer②">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">3. The portal element</a> <a href="#ref-for-structuredserializewithtransfer①">(2)</a>
     <li><a href="#ref-for-structuredserializewithtransfer②">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.1. Portal hosts</a> <a href="#ref-for-window①">(2)</a>
     <li><a href="#ref-for-window②">3.2. The PortalActivateEvent interface</a>
     <li><a href="#ref-for-window③">4.2. Event handlers</a> <a href="#ref-for-window④">(2)</a> <a href="#ref-for-window⑤">(3)</a> <a href="#ref-for-window⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoweventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoweventhandlers" class="dfn-panel" data-for="term-for-windoweventhandlers" id="infopanel-for-term-for-windoweventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-windoweventhandlers" style="display:none">Info about the 'WindowEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoweventhandlers">4.2. Event handlers</a> <a href="#ref-for-windoweventhandlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windowproxy">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windowproxy" class="dfn-panel" data-for="term-for-windowproxy" id="infopanel-for-term-for-windowproxy" role="menu">
+   <span id="infopaneltitle-for-term-for-windowproxy" style="display:none">Info about the 'WindowProxy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowproxy">2. Portal browsing contexts</a>
     <li><a href="#ref-for-windowproxy①">3. The portal element</a>
     <li><a href="#ref-for-windowproxy②">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-sandboxing-flag-set">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-sandboxing-flag-set" class="dfn-panel" data-for="term-for-active-sandboxing-flag-set" id="infopanel-for-term-for-active-sandboxing-flag-set" role="menu">
+   <span id="infopaneltitle-for-term-for-active-sandboxing-flag-set" style="display:none">Info about the 'active sandboxing flag set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-sandboxing-flag-set">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-download">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#allowed-to-download">https://html.spec.whatwg.org/multipage/links.html#allowed-to-download</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-download" class="dfn-panel" data-for="term-for-allowed-to-download" id="infopanel-for-term-for-allowed-to-download" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-download" style="display:none">Info about the 'allowed to download' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#allowed-to-download">https://html.spec.whatwg.org/multipage/links.html#allowed-to-download</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-download">4.5. Downloading resources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">3. The portal element</a>
     <li><a href="#ref-for-auxiliary-browsing-context①">4.3. APIs for creating and navigating browsing contexts by name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-becomes-browsing-context-connected">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-connected">https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-becomes-browsing-context-connected" class="dfn-panel" data-for="term-for-becomes-browsing-context-connected" id="infopanel-for-term-for-becomes-browsing-context-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-becomes-browsing-context-connected" style="display:none">Info about the 'become browsing-context connected' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-connected">https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-becomes-browsing-context-connected">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-becomes-browsing-context-disconnected">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-disconnected">https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-disconnected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-becomes-browsing-context-disconnected" class="dfn-panel" data-for="term-for-becomes-browsing-context-disconnected" id="infopanel-for-term-for-becomes-browsing-context-disconnected" role="menu">
+   <span id="infopaneltitle-for-term-for-becomes-browsing-context-disconnected" style="display:none">Info about the 'become browsing-context disconnected' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-disconnected">https://html.spec.whatwg.org/multipage/infrastructure.html#becomes-browsing-context-disconnected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-becomes-browsing-context-disconnected">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a>
     <li><a href="#ref-for-browsing-context③">3. The portal element</a> <a href="#ref-for-browsing-context④">(2)</a>
     <li><a href="#ref-for-browsing-context⑤">4.3. APIs for creating and navigating browsing contexts by name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">3. The portal element</a> <a href="#ref-for-concept-document-bc①">(2)</a> <a href="#ref-for-concept-document-bc②">(3)</a> <a href="#ref-for-concept-document-bc③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">3.1. Portal hosts</a> <a href="#ref-for-window-bc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-group">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context-group" class="dfn-panel" data-for="term-for-browsing-context-group" id="infopanel-for-term-for-browsing-context-group" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context-group" style="display:none">Info about the 'browsing context group' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-group">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-connected">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected">https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context-connected" class="dfn-panel" data-for="term-for-browsing-context-connected" id="infopanel-for-term-for-browsing-context-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context-connected" style="display:none">Info about the 'browsing-context connected' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected">https://html.spec.whatwg.org/multipage/infrastructure.html#browsing-context-connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-connected">2. Portal browsing contexts</a>
     <li><a href="#ref-for-browsing-context-connected①">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-close-a-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context">https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-close-a-browsing-context" class="dfn-panel" data-for="term-for-close-a-browsing-context" id="infopanel-for-term-for-close-a-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-close-a-browsing-context" style="display:none">Info about the 'close a browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context">https://html.spec.whatwg.org/multipage/window-object.html#close-a-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-a-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-close-a-browsing-context①">(2)</a> <a href="#ref-for-close-a-browsing-context②">(3)</a>
     <li><a href="#ref-for-close-a-browsing-context③">3. The portal element</a> <a href="#ref-for-close-a-browsing-context④">(2)</a> <a href="#ref-for-close-a-browsing-context⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-completely-loaded">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#completely-loaded">https://html.spec.whatwg.org/multipage/parsing.html#completely-loaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-completely-loaded" class="dfn-panel" data-for="term-for-completely-loaded" id="infopanel-for-term-for-completely-loaded" role="menu">
+   <span id="infopaneltitle-for-term-for-completely-loaded" style="display:none">Info about the 'completely loaded' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#completely-loaded">https://html.spec.whatwg.org/multipage/parsing.html#completely-loaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-completely-loaded">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-creating-a-new-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-creating-a-new-top-level-browsing-context" class="dfn-panel" data-for="term-for-creating-a-new-top-level-browsing-context" id="infopanel-for-term-for-creating-a-new-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-creating-a-new-top-level-browsing-context" style="display:none">Info about the 'create a new top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creating-a-new-top-level-browsing-context">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-data">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-data" class="dfn-panel" data-for="term-for-dom-messageevent-data" id="infopanel-for-term-for-dom-messageevent-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-data" style="display:none">Info about the 'data' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-data">3. The portal element</a>
     <li><a href="#ref-for-dom-messageevent-data①">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-browsing-context-is-discarded">
-   <a href="https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded">https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-browsing-context-is-discarded" class="dfn-panel" data-for="term-for-a-browsing-context-is-discarded" id="infopanel-for-term-for-a-browsing-context-is-discarded" role="menu">
+   <span id="infopaneltitle-for-term-for-a-browsing-context-is-discarded" style="display:none">Info about the 'discard a browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded">https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-browsing-context-is-discarded">2. Portal browsing contexts</a> <a href="#ref-for-a-browsing-context-is-discarded①">(2)</a> <a href="#ref-for-a-browsing-context-is-discarded②">(3)</a>
     <li><a href="#ref-for-a-browsing-context-is-discarded③">3. The portal element</a> <a href="#ref-for-a-browsing-context-is-discarded④">(2)</a> <a href="#ref-for-a-browsing-context-is-discarded⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-discarding-steps">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-discarding-steps" class="dfn-panel" data-for="term-for-environment-discarding-steps" id="infopanel-for-term-for-environment-discarding-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-discarding-steps" style="display:none">Info about the 'environment discarding steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-discarding-steps">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">4.2. Event handlers</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-content-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-content-attributes" class="dfn-panel" data-for="term-for-event-handler-content-attributes" id="infopanel-for-term-for-event-handler-content-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-content-attributes" style="display:none">Info about the 'event handler content attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-content-attributes">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.2. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">4.2. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">3.1. Portal hosts</a> <a href="#ref-for-event-loop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop (for agent)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">3. The portal element</a> <a href="#ref-for-the-iframe-element①">(2)</a> <a href="#ref-for-the-iframe-element②">(3)</a>
     <li><a href="#ref-for-the-iframe-element③">5.2. Fetch Metadata Request Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-limited-to-only-known-values">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-limited-to-only-known-values" class="dfn-panel" data-for="term-for-limited-to-only-known-values" id="infopanel-for-term-for-limited-to-only-known-values" role="menu">
+   <span id="infopaneltitle-for-term-for-limited-to-only-known-values" style="display:none">Info about the 'limited to only known values' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limited-to-only-known-values">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-load">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-load">https://html.spec.whatwg.org/multipage/indices.html#event-load</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-load" class="dfn-panel" data-for="term-for-event-load" id="infopanel-for-term-for-event-load" role="menu">
+   <span id="infopaneltitle-for-term-for-event-load" style="display:none">Info about the 'load' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-load">https://html.spec.whatwg.org/multipage/indices.html#event-load</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-load">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">3. The portal element</a> <a href="#ref-for-navigate①">(2)</a>
     <li><a href="#ref-for-navigate②">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2. Portal browsing contexts</a>
     <li><a href="#ref-for-concept-origin①">6.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-origin">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-origin" class="dfn-panel" data-for="term-for-dom-messageevent-origin" id="infopanel-for-term-for-dom-messageevent-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-origin" style="display:none">Info about the 'origin (for MessageEvent)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-origin">3. The portal element</a> <a href="#ref-for-dom-messageevent-origin①">(2)</a>
     <li><a href="#ref-for-dom-messageevent-origin②">3.1. Portal hosts</a> <a href="#ref-for-dom-messageevent-origin③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">3. The portal element</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a> <a href="#ref-for-concept-settings-object-origin②">(3)</a>
     <li><a href="#ref-for-concept-settings-object-origin③">3.1. Portal hosts</a> <a href="#ref-for-concept-settings-object-origin④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-url">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-url" class="dfn-panel" data-for="term-for-parse-a-url" id="infopanel-for-term-for-parse-a-url" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-url" style="display:none">Info about the 'parse a url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-url">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-ports">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-ports" class="dfn-panel" data-for="term-for-dom-messageevent-ports" id="infopanel-for-term-for-dom-messageevent-ports" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-ports" style="display:none">Info about the 'ports' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-ports">3. The portal element</a>
     <li><a href="#ref-for-dom-messageevent-ports①">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prompt-to-unload-a-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#prompt-to-unload-a-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#prompt-to-unload-a-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prompt-to-unload-a-document" class="dfn-panel" data-for="term-for-prompt-to-unload-a-document" id="infopanel-for-term-for-prompt-to-unload-a-document" role="menu">
+   <span id="infopaneltitle-for-term-for-prompt-to-unload-a-document" style="display:none">Info about the 'prompt to unload' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#prompt-to-unload-a-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#prompt-to-unload-a-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prompt-to-unload-a-document">2. Portal browsing contexts</a>
     <li><a href="#ref-for-prompt-to-unload-a-document①">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">2. Portal browsing contexts</a> <a href="#ref-for-queue-a-global-task①">(2)</a> <a href="#ref-for-queue-a-global-task②">(3)</a> <a href="#ref-for-queue-a-global-task③">(4)</a>
     <li><a href="#ref-for-queue-a-global-task④">3. The portal element</a>
     <li><a href="#ref-for-queue-a-global-task⑤">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-an-element-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-an-element-task" class="dfn-panel" data-for="term-for-queue-an-element-task" id="infopanel-for-term-for-queue-an-element-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-an-element-task" style="display:none">Info about the 'queue an element task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-an-element-task">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm" id="infopanel-for-term-for-environment-settings-object&apos;s-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" style="display:none">Info about the 'realm (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'realm (for global object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">2. Portal browsing contexts</a>
     <li><a href="#ref-for-concept-global-object-realm①">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy-attribute" class="dfn-panel" data-for="term-for-referrer-policy-attribute" id="infopanel-for-term-for-referrer-policy-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy-attribute" style="display:none">Info about the 'referrer policy attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy-attribute">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reflect">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reflect" class="dfn-panel" data-for="term-for-reflect" id="infopanel-for-term-for-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reflect">3. The portal element</a> <a href="#ref-for-reflect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3. The portal element</a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
     <li><a href="#ref-for-relevant-settings-object③">3.1. Portal hosts</a> <a href="#ref-for-relevant-settings-object④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-params-request">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-params-request" class="dfn-panel" data-for="term-for-navigation-params-request" id="infopanel-for-term-for-navigation-params-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-params-request" style="display:none">Info about the 'request' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-params-request">4.4. Navigation</a> <a href="#ref-for-navigation-params-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-params-reserved-environment">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-reserved-environment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-reserved-environment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-params-reserved-environment" class="dfn-panel" data-for="term-for-navigation-params-reserved-environment" id="infopanel-for-term-for-navigation-params-reserved-environment" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-params-reserved-environment" style="display:none">Info about the 'reserved environment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-reserved-environment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-reserved-environment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-params-reserved-environment">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resulting-url-record">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resulting-url-record">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resulting-url-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resulting-url-record" class="dfn-panel" data-for="term-for-resulting-url-record" id="infopanel-for-term-for-resulting-url-record" role="menu">
+   <span id="infopaneltitle-for-term-for-resulting-url-record" style="display:none">Info about the 'resulting url record' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resulting-url-record">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resulting-url-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resulting-url-record">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2. Portal browsing contexts</a>
     <li><a href="#ref-for-same-origin①">3. The portal element</a>
     <li><a href="#ref-for-same-origin②">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-closable">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#script-closable">https://html.spec.whatwg.org/multipage/nav-history-apis.html#script-closable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-closable" class="dfn-panel" data-for="term-for-script-closable" id="infopanel-for-term-for-script-closable" role="menu">
+   <span id="infopaneltitle-for-term-for-script-closable" style="display:none">Info about the 'script-closable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#script-closable">https://html.spec.whatwg.org/multipage/nav-history-apis.html#script-closable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-closable">4.3. APIs for creating and navigating browsing contexts by name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">3. The portal element</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session-history">
-   <a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session-history" class="dfn-panel" data-for="term-for-session-history" id="infopanel-for-term-for-session-history" role="menu">
+   <span id="infopaneltitle-for-term-for-session-history" style="display:none">Info about the 'session history' external reference.</span><a href="https://html.spec.whatwg.org/multipage/history.html#session-history">https://html.spec.whatwg.org/multipage/history.html#session-history</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history">2. Portal browsing contexts</a> <a href="#ref-for-session-history①">(2)</a>
     <li><a href="#ref-for-session-history②">4.3. APIs for creating and navigating browsing contexts by name</a>
     <li><a href="#ref-for-session-history③">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-source">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-source" class="dfn-panel" data-for="term-for-dom-messageevent-source" id="infopanel-for-term-for-dom-messageevent-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-source" style="display:none">Info about the 'source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-source">3. The portal element</a> <a href="#ref-for-dom-messageevent-source①">(2)</a>
     <li><a href="#ref-for-dom-messageevent-source②">3.1. Portal hosts</a> <a href="#ref-for-dom-messageevent-source③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">5.2. Fetch Metadata Request Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2. Portal browsing contexts</a> <a href="#ref-for-task-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">1. Introduction</a>
     <li><a href="#ref-for-top-level-browsing-context①">3. The portal element</a> <a href="#ref-for-top-level-browsing-context②">(2)</a>
@@ -2845,70 +2845,70 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-top-level-browsing-context④">4.3. APIs for creating and navigating browsing contexts by name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unload-a-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#unload-a-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#unload-a-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unload-a-document" class="dfn-panel" data-for="term-for-unload-a-document" id="infopanel-for-term-for-unload-a-document" role="menu">
+   <span id="infopaneltitle-for-term-for-unload-a-document" style="display:none">Info about the 'unload' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#unload-a-document">https://html.spec.whatwg.org/multipage/browsing-the-web.html#unload-a-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unload-a-document">2. Portal browsing contexts</a> <a href="#ref-for-unload-a-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-unload">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-unload">https://html.spec.whatwg.org/multipage/indices.html#event-unload</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-unload" class="dfn-panel" data-for="term-for-event-unload" id="infopanel-for-term-for-event-unload" role="menu">
+   <span id="infopaneltitle-for-term-for-event-unload" style="display:none">Info about the 'unload (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-unload">https://html.spec.whatwg.org/multipage/indices.html#event-unload</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-unload">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-non-empty-url-potentially-surrounded-by-spaces">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-non-empty-url-potentially-surrounded-by-spaces">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-non-empty-url-potentially-surrounded-by-spaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-non-empty-url-potentially-surrounded-by-spaces" class="dfn-panel" data-for="term-for-valid-non-empty-url-potentially-surrounded-by-spaces" id="infopanel-for-term-for-valid-non-empty-url-potentially-surrounded-by-spaces" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-non-empty-url-potentially-surrounded-by-spaces" style="display:none">Info about the 'valid non-empty url potentially surrounded by spaces' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-non-empty-url-potentially-surrounded-by-spaces">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#valid-non-empty-url-potentially-surrounded-by-spaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-non-empty-url-potentially-surrounded-by-spaces">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">2. Portal browsing contexts</a> <a href="#ref-for-assert①">(2)</a> <a href="#ref-for-assert②">(3)</a> <a href="#ref-for-assert③">(4)</a>
     <li><a href="#ref-for-assert④">3. The portal element</a> <a href="#ref-for-assert⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boolean">
-   <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boolean" class="dfn-panel" data-for="term-for-boolean" id="infopanel-for-term-for-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy" class="dfn-panel" data-for="term-for-referrer-policy" id="infopanel-for-term-for-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworker">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworker" class="dfn-panel" data-for="term-for-serviceworker" id="infopanel-for-term-for-serviceworker" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworker" style="display:none">Info about the 'ServiceWorker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworker">https://w3c.github.io/ServiceWorker/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">3. The portal element</a>
     <li><a href="#ref-for-concept-url-scheme①">4.4. Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2. Portal browsing contexts</a>
     <li><a href="#ref-for-idl-DOMException①">3. The portal element</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a>
@@ -2916,23 +2916,23 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-idl-DOMException⑥">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. The portal element</a>
     <li><a href="#ref-for-idl-DOMString①">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. The portal element</a>
     <li><a href="#ref-for-Exposed①">3.1. Portal hosts</a>
     <li><a href="#ref-for-Exposed②">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2. Portal browsing contexts</a>
     <li><a href="#ref-for-invalidstateerror①">3. The portal element</a> <a href="#ref-for-invalidstateerror②">(2)</a> <a href="#ref-for-invalidstateerror③">(3)</a> <a href="#ref-for-invalidstateerror④">(4)</a>
@@ -2940,55 +2940,55 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-invalidstateerror⑥">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3. The portal element</a> <a href="#ref-for-idl-any①">(2)</a>
     <li><a href="#ref-for-idl-any②">3.1. Portal hosts</a>
     <li><a href="#ref-for-idl-any③">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-idl-any④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">3. The portal element</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3. The portal element</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a>
     <li><a href="#ref-for-this⑤">3.1. Portal hosts</a> <a href="#ref-for-this⑥">(2)</a> <a href="#ref-for-this⑦">(3)</a> <a href="#ref-for-this⑧">(4)</a>
     <li><a href="#ref-for-this⑨">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-this①⓪">(2)</a> <a href="#ref-for-this①①">(3)</a> <a href="#ref-for-this①②">(4)</a> <a href="#ref-for-this①③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. The portal element</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">3.1. Portal hosts</a>
@@ -3252,8 +3252,8 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
    <div class="issue"> We should expand this section further. Much of what was formerly there is in <a href="#other-spec-updates">§ 5 Updates to other specifications</a> now. Once we have a more comprehensive view of all the security-related
     spec updates, we should summarize them in a non-normative fashion here. <a class="issue-return" href="#issue-8e856747" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="portal-state">
-   <b><a href="#portal-state">#portal-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portal-state" class="dfn-panel" data-for="portal-state" id="infopanel-for-portal-state" role="dialog">
+   <span id="infopaneltitle-for-portal-state" style="display:none">Info about the 'portal state' definition.</span><b><a href="#portal-state">#portal-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portal-state">2. Portal browsing contexts</a> <a href="#ref-for-portal-state①">(2)</a> <a href="#ref-for-portal-state②">(3)</a> <a href="#ref-for-portal-state③">(4)</a> <a href="#ref-for-portal-state④">(5)</a> <a href="#ref-for-portal-state⑤">(6)</a> <a href="#ref-for-portal-state⑥">(7)</a> <a href="#ref-for-portal-state⑦">(8)</a> <a href="#ref-for-portal-state⑧">(9)</a>
     <li><a href="#ref-for-portal-state⑨">3. The portal element</a> <a href="#ref-for-portal-state①⓪">(2)</a> <a href="#ref-for-portal-state①①">(3)</a>
@@ -3263,8 +3263,8 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-portal-state①⑦">4.5. Downloading resources</a> <a href="#ref-for-portal-state①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portal-browsing-context">
-   <b><a href="#portal-browsing-context">#portal-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portal-browsing-context" class="dfn-panel" data-for="portal-browsing-context" id="infopanel-for-portal-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-portal-browsing-context" style="display:none">Info about the 'portal browsing context' definition.</span><b><a href="#portal-browsing-context">#portal-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portal-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-portal-browsing-context①">(2)</a> <a href="#ref-for-portal-browsing-context②">(3)</a>
     <li><a href="#ref-for-portal-browsing-context③">3. The portal element</a> <a href="#ref-for-portal-browsing-context④">(2)</a> <a href="#ref-for-portal-browsing-context⑤">(3)</a> <a href="#ref-for-portal-browsing-context⑥">(4)</a> <a href="#ref-for-portal-browsing-context⑦">(5)</a> <a href="#ref-for-portal-browsing-context⑧">(6)</a> <a href="#ref-for-portal-browsing-context⑨">(7)</a>
@@ -3276,8 +3276,8 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-portal-browsing-context①⑧">6.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-element">
-   <b><a href="#host-element">#host-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-element" class="dfn-panel" data-for="host-element" id="infopanel-for-host-element" role="dialog">
+   <span id="infopaneltitle-for-host-element" style="display:none">Info about the 'host element' definition.</span><b><a href="#host-element">#host-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-element">2. Portal browsing contexts</a> <a href="#ref-for-host-element①">(2)</a> <a href="#ref-for-host-element②">(3)</a> <a href="#ref-for-host-element③">(4)</a> <a href="#ref-for-host-element④">(5)</a> <a href="#ref-for-host-element⑤">(6)</a>
     <li><a href="#ref-for-host-element⑥">3. The portal element</a> <a href="#ref-for-host-element⑦">(2)</a> <a href="#ref-for-host-element⑧">(3)</a>
@@ -3285,15 +3285,15 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-host-element①⓪">4.4. Navigation</a> <a href="#ref-for-host-element①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-browsing-context">
-   <b><a href="#host-browsing-context">#host-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-browsing-context" class="dfn-panel" data-for="host-browsing-context" id="infopanel-for-host-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-host-browsing-context" style="display:none">Info about the 'host browsing context' definition.</span><b><a href="#host-browsing-context">#host-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-host-browsing-context①">(2)</a>
     <li><a href="#ref-for-host-browsing-context②">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portal-task-source">
-   <b><a href="#portal-task-source">#portal-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portal-task-source" class="dfn-panel" data-for="portal-task-source" id="infopanel-for-portal-task-source" role="dialog">
+   <span id="infopaneltitle-for-portal-task-source" style="display:none">Info about the 'portal task source' definition.</span><b><a href="#portal-task-source">#portal-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portal-task-source">2. Portal browsing contexts</a> <a href="#ref-for-portal-task-source①">(2)</a> <a href="#ref-for-portal-task-source②">(3)</a> <a href="#ref-for-portal-task-source③">(4)</a>
     <li><a href="#ref-for-portal-task-source④">3. The portal element</a>
@@ -3301,59 +3301,61 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-portal-task-source⑥">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activate-a-portal-browsing-context">
-   <b><a href="#activate-a-portal-browsing-context">#activate-a-portal-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activate-a-portal-browsing-context" class="dfn-panel" data-for="activate-a-portal-browsing-context" id="infopanel-for-activate-a-portal-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-activate-a-portal-browsing-context" style="display:none">Info about the 'activate a portal browsing context' definition.</span><b><a href="#activate-a-portal-browsing-context">#activate-a-portal-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activate-a-portal-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-activate-a-portal-browsing-context①">(2)</a>
     <li><a href="#ref-for-activate-a-portal-browsing-context②">3. The portal element</a> <a href="#ref-for-activate-a-portal-browsing-context③">(2)</a>
     <li><a href="#ref-for-activate-a-portal-browsing-context④">3.1. Portal hosts</a> <a href="#ref-for-activate-a-portal-browsing-context⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="adopt-the-predecessor-browsing-context">
-   <b><a href="#adopt-the-predecessor-browsing-context">#adopt-the-predecessor-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-adopt-the-predecessor-browsing-context" class="dfn-panel" data-for="adopt-the-predecessor-browsing-context" id="infopanel-for-adopt-the-predecessor-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-adopt-the-predecessor-browsing-context" style="display:none">Info about the 'adopt the predecessor browsing context' definition.</span><b><a href="#adopt-the-predecessor-browsing-context">#adopt-the-predecessor-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-adopt-the-predecessor-browsing-context">2. Portal browsing contexts</a> <a href="#ref-for-adopt-the-predecessor-browsing-context①">(2)</a>
     <li><a href="#ref-for-adopt-the-predecessor-browsing-context②">3. The portal element</a> <a href="#ref-for-adopt-the-predecessor-browsing-context③">(2)</a>
     <li><a href="#ref-for-adopt-the-predecessor-browsing-context④">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-portal">
-   <b><a href="#elementdef-portal">#elementdef-portal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-portal" class="dfn-panel" data-for="elementdef-portal" id="infopanel-for-elementdef-portal" role="dialog">
+   <span id="infopaneltitle-for-elementdef-portal" style="display:none">Info about the 'portal' definition.</span><b><a href="#elementdef-portal">#elementdef-portal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-portal">2. Portal browsing contexts</a> <a href="#ref-for-elementdef-portal①">(2)</a> <a href="#ref-for-elementdef-portal②">(3)</a>
     <li><a href="#ref-for-elementdef-portal③">3. The portal element</a> <a href="#ref-for-elementdef-portal④">(2)</a> <a href="#ref-for-elementdef-portal⑤">(3)</a> <a href="#ref-for-elementdef-portal⑥">(4)</a> <a href="#ref-for-elementdef-portal⑦">(5)</a> <a href="#ref-for-elementdef-portal⑧">(6)</a> <a href="#ref-for-elementdef-portal⑨">(7)</a> <a href="#ref-for-elementdef-portal①⓪">(8)</a> <a href="#ref-for-elementdef-portal①①">(9)</a> <a href="#ref-for-elementdef-portal①②">(10)</a> <a href="#ref-for-elementdef-portal①③">(11)</a> <a href="#ref-for-elementdef-portal①④">(12)</a> <a href="#ref-for-elementdef-portal①⑤">(13)</a> <a href="#ref-for-elementdef-portal①⑥">(14)</a> <a href="#ref-for-elementdef-portal①⑦">(15)</a> <a href="#ref-for-elementdef-portal①⑧">(16)</a> <a href="#ref-for-elementdef-portal①⑨">(17)</a> <a href="#ref-for-elementdef-portal②⓪">(18)</a> <a href="#ref-for-elementdef-portal②①">(19)</a> <a href="#ref-for-elementdef-portal②②">(20)</a> <a href="#ref-for-elementdef-portal②③">(21)</a> <a href="#ref-for-elementdef-portal②④">(22)</a>
     <li><a href="#ref-for-elementdef-portal②⑤">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="htmlportalelement-guest-browsing-context">
-   <b><a href="#htmlportalelement-guest-browsing-context">#htmlportalelement-guest-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-htmlportalelement-guest-browsing-context" class="dfn-panel" data-for="htmlportalelement-guest-browsing-context" id="infopanel-for-htmlportalelement-guest-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-htmlportalelement-guest-browsing-context" style="display:none">Info about the 'guest
+  browsing context' definition.</span><b><a href="#htmlportalelement-guest-browsing-context">#htmlportalelement-guest-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlportalelement-guest-browsing-context">2. Portal browsing contexts</a>
     <li><a href="#ref-for-htmlportalelement-guest-browsing-context①">3. The portal element</a> <a href="#ref-for-htmlportalelement-guest-browsing-context②">(2)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context③">(3)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context④">(4)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context⑤">(5)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context⑥">(6)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context⑦">(7)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context⑧">(8)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context⑨">(9)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context①⓪">(10)</a> <a href="#ref-for-htmlportalelement-guest-browsing-context①①">(11)</a>
     <li><a href="#ref-for-htmlportalelement-guest-browsing-context①②">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="htmlportalelement-just-adopted-flag">
-   <b><a href="#htmlportalelement-just-adopted-flag">#htmlportalelement-just-adopted-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-htmlportalelement-just-adopted-flag" class="dfn-panel" data-for="htmlportalelement-just-adopted-flag" id="infopanel-for-htmlportalelement-just-adopted-flag" role="dialog">
+   <span id="infopaneltitle-for-htmlportalelement-just-adopted-flag" style="display:none">Info about the 'just-adopted
+  flag' definition.</span><b><a href="#htmlportalelement-just-adopted-flag">#htmlportalelement-just-adopted-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlportalelement-just-adopted-flag">2. Portal browsing contexts</a> <a href="#ref-for-htmlportalelement-just-adopted-flag①">(2)</a> <a href="#ref-for-htmlportalelement-just-adopted-flag②">(3)</a>
     <li><a href="#ref-for-htmlportalelement-just-adopted-flag③">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-portal-src">
-   <b><a href="#element-attrdef-portal-src">#element-attrdef-portal-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-portal-src" class="dfn-panel" data-for="element-attrdef-portal-src" id="infopanel-for-element-attrdef-portal-src" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-portal-src" style="display:none">Info about the 'src' definition.</span><b><a href="#element-attrdef-portal-src">#element-attrdef-portal-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-portal-src">3. The portal element</a> <a href="#ref-for-element-attrdef-portal-src①">(2)</a> <a href="#ref-for-element-attrdef-portal-src②">(3)</a> <a href="#ref-for-element-attrdef-portal-src③">(4)</a> <a href="#ref-for-element-attrdef-portal-src④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-portal-referrerpolicy">
-   <b><a href="#element-attrdef-portal-referrerpolicy">#element-attrdef-portal-referrerpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-portal-referrerpolicy" class="dfn-panel" data-for="element-attrdef-portal-referrerpolicy" id="infopanel-for-element-attrdef-portal-referrerpolicy" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-portal-referrerpolicy" style="display:none">Info about the 'referrerpolicy' definition.</span><b><a href="#element-attrdef-portal-referrerpolicy">#element-attrdef-portal-referrerpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-portal-referrerpolicy">3. The portal element</a> <a href="#ref-for-element-attrdef-portal-referrerpolicy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="htmlportalelement">
-   <b><a href="#htmlportalelement">#htmlportalelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-htmlportalelement" class="dfn-panel" data-for="htmlportalelement" id="infopanel-for-htmlportalelement" role="dialog">
+   <span id="infopaneltitle-for-htmlportalelement" style="display:none">Info about the 'HTMLPortalElement' definition.</span><b><a href="#htmlportalelement">#htmlportalelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlportalelement">2. Portal browsing contexts</a>
     <li><a href="#ref-for-htmlportalelement①">3. The portal element</a>
@@ -3361,190 +3363,190 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-htmlportalelement③">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-onmessage">
-   <b><a href="#dom-htmlportalelement-onmessage">#dom-htmlportalelement-onmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-onmessage" class="dfn-panel" data-for="dom-htmlportalelement-onmessage" id="infopanel-for-dom-htmlportalelement-onmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-onmessage" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#dom-htmlportalelement-onmessage">#dom-htmlportalelement-onmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-onmessage">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-onmessageerror">
-   <b><a href="#dom-htmlportalelement-onmessageerror">#dom-htmlportalelement-onmessageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-onmessageerror" class="dfn-panel" data-for="dom-htmlportalelement-onmessageerror" id="infopanel-for-dom-htmlportalelement-onmessageerror" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-onmessageerror" style="display:none">Info about the 'onmessageerror' definition.</span><b><a href="#dom-htmlportalelement-onmessageerror">#dom-htmlportalelement-onmessageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-onmessageerror">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-portalactivateoptions">
-   <b><a href="#dictdef-portalactivateoptions">#dictdef-portalactivateoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-portalactivateoptions" class="dfn-panel" data-for="dictdef-portalactivateoptions" id="infopanel-for-dictdef-portalactivateoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-portalactivateoptions" style="display:none">Info about the 'PortalActivateOptions' definition.</span><b><a href="#dictdef-portalactivateoptions">#dictdef-portalactivateoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-portalactivateoptions">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-portalactivateoptions-data">
-   <b><a href="#dom-portalactivateoptions-data">#dom-portalactivateoptions-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-portalactivateoptions-data" class="dfn-panel" data-for="dom-portalactivateoptions-data" id="infopanel-for-dom-portalactivateoptions-data" role="dialog">
+   <span id="infopaneltitle-for-dom-portalactivateoptions-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-portalactivateoptions-data">#dom-portalactivateoptions-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-portalactivateoptions-data">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-src">
-   <b><a href="#dom-htmlportalelement-src">#dom-htmlportalelement-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-src" class="dfn-panel" data-for="dom-htmlportalelement-src" id="infopanel-for-dom-htmlportalelement-src" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-src" style="display:none">Info about the 'src' definition.</span><b><a href="#dom-htmlportalelement-src">#dom-htmlportalelement-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-src">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-referrerpolicy">
-   <b><a href="#dom-htmlportalelement-referrerpolicy">#dom-htmlportalelement-referrerpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-referrerpolicy" class="dfn-panel" data-for="dom-htmlportalelement-referrerpolicy" id="infopanel-for-dom-htmlportalelement-referrerpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-referrerpolicy" style="display:none">Info about the 'referrerPolicy' definition.</span><b><a href="#dom-htmlportalelement-referrerpolicy">#dom-htmlportalelement-referrerpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-referrerpolicy">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-activate">
-   <b><a href="#dom-htmlportalelement-activate">#dom-htmlportalelement-activate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-activate" class="dfn-panel" data-for="dom-htmlportalelement-activate" id="infopanel-for-dom-htmlportalelement-activate" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-activate" style="display:none">Info about the 'activate(options)' definition.</span><b><a href="#dom-htmlportalelement-activate">#dom-htmlportalelement-activate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-activate">2. Portal browsing contexts</a> <a href="#ref-for-dom-htmlportalelement-activate①">(2)</a>
     <li><a href="#ref-for-dom-htmlportalelement-activate②">3. The portal element</a> <a href="#ref-for-dom-htmlportalelement-activate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlportalelement-postmessage">
-   <b><a href="#dom-htmlportalelement-postmessage">#dom-htmlportalelement-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlportalelement-postmessage" class="dfn-panel" data-for="dom-htmlportalelement-postmessage" id="infopanel-for-dom-htmlportalelement-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlportalelement-postmessage" style="display:none">Info about the 'postMessage(message, options)' definition.</span><b><a href="#dom-htmlportalelement-postmessage">#dom-htmlportalelement-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlportalelement-postmessage">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="may-have-a-guest-browsing-context">
-   <b><a href="#may-have-a-guest-browsing-context">#may-have-a-guest-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-may-have-a-guest-browsing-context" class="dfn-panel" data-for="may-have-a-guest-browsing-context" id="infopanel-for-may-have-a-guest-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-may-have-a-guest-browsing-context" style="display:none">Info about the 'may have a guest browsing context' definition.</span><b><a href="#may-have-a-guest-browsing-context">#may-have-a-guest-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-may-have-a-guest-browsing-context">2. Portal browsing contexts</a>
     <li><a href="#ref-for-may-have-a-guest-browsing-context①">3. The portal element</a> <a href="#ref-for-may-have-a-guest-browsing-context②">(2)</a> <a href="#ref-for-may-have-a-guest-browsing-context③">(3)</a> <a href="#ref-for-may-have-a-guest-browsing-context④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="close-a-portal-element">
-   <b><a href="#close-a-portal-element">#close-a-portal-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-close-a-portal-element" class="dfn-panel" data-for="close-a-portal-element" id="infopanel-for-close-a-portal-element" role="dialog">
+   <span id="infopaneltitle-for-close-a-portal-element" style="display:none">Info about the 'close a portal element' definition.</span><b><a href="#close-a-portal-element">#close-a-portal-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-a-portal-element">3. The portal element</a>
     <li><a href="#ref-for-close-a-portal-element①">4.4. Navigation</a> <a href="#ref-for-close-a-portal-element②">(2)</a>
     <li><a href="#ref-for-close-a-portal-element③">5.1.1. portal-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-source-url-of-a-portal-element">
-   <b><a href="#set-the-source-url-of-a-portal-element">#set-the-source-url-of-a-portal-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-source-url-of-a-portal-element" class="dfn-panel" data-for="set-the-source-url-of-a-portal-element" id="infopanel-for-set-the-source-url-of-a-portal-element" role="dialog">
+   <span id="infopaneltitle-for-set-the-source-url-of-a-portal-element" style="display:none">Info about the 'set the source URL of a portal element' definition.</span><b><a href="#set-the-source-url-of-a-portal-element">#set-the-source-url-of-a-portal-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-source-url-of-a-portal-element">3. The portal element</a> <a href="#ref-for-set-the-source-url-of-a-portal-element①">(2)</a> <a href="#ref-for-set-the-source-url-of-a-portal-element②">(3)</a> <a href="#ref-for-set-the-source-url-of-a-portal-element③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-htmlportalelement-message">
-   <b><a href="#eventdef-htmlportalelement-message">#eventdef-htmlportalelement-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-htmlportalelement-message" class="dfn-panel" data-for="eventdef-htmlportalelement-message" id="infopanel-for-eventdef-htmlportalelement-message" role="dialog">
+   <span id="infopaneltitle-for-eventdef-htmlportalelement-message" style="display:none">Info about the 'message' definition.</span><b><a href="#eventdef-htmlportalelement-message">#eventdef-htmlportalelement-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-htmlportalelement-message">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-htmlportalelement-messageerror">
-   <b><a href="#eventdef-htmlportalelement-messageerror">#eventdef-htmlportalelement-messageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-htmlportalelement-messageerror" class="dfn-panel" data-for="eventdef-htmlportalelement-messageerror" id="infopanel-for-eventdef-htmlportalelement-messageerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-htmlportalelement-messageerror" style="display:none">Info about the 'messageerror' definition.</span><b><a href="#eventdef-htmlportalelement-messageerror">#eventdef-htmlportalelement-messageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-htmlportalelement-messageerror">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portal-host-object">
-   <b><a href="#portal-host-object">#portal-host-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portal-host-object" class="dfn-panel" data-for="portal-host-object" id="infopanel-for-portal-host-object" role="dialog">
+   <span id="infopaneltitle-for-portal-host-object" style="display:none">Info about the 'portal host object' definition.</span><b><a href="#portal-host-object">#portal-host-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portal-host-object">3. The portal element</a>
     <li><a href="#ref-for-portal-host-object①">3.1. Portal hosts</a> <a href="#ref-for-portal-host-object②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-portalhost">
-   <b><a href="#dom-window-portalhost">#dom-window-portalhost</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-portalhost" class="dfn-panel" data-for="dom-window-portalhost" id="infopanel-for-dom-window-portalhost" role="dialog">
+   <span id="infopaneltitle-for-dom-window-portalhost" style="display:none">Info about the 'portalHost' definition.</span><b><a href="#dom-window-portalhost">#dom-window-portalhost</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-portalhost">3.1. Portal hosts</a> <a href="#ref-for-dom-window-portalhost①">(2)</a> <a href="#ref-for-dom-window-portalhost②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalhost">
-   <b><a href="#portalhost">#portalhost</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalhost" class="dfn-panel" data-for="portalhost" id="infopanel-for-portalhost" role="dialog">
+   <span id="infopaneltitle-for-portalhost" style="display:none">Info about the 'PortalHost' definition.</span><b><a href="#portalhost">#portalhost</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalhost">2. Portal browsing contexts</a>
     <li><a href="#ref-for-portalhost①">3.1. Portal hosts</a> <a href="#ref-for-portalhost②">(2)</a> <a href="#ref-for-portalhost③">(3)</a> <a href="#ref-for-portalhost④">(4)</a>
     <li><a href="#ref-for-portalhost⑤">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-portalhost-postmessage">
-   <b><a href="#dom-portalhost-postmessage">#dom-portalhost-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-portalhost-postmessage" class="dfn-panel" data-for="dom-portalhost-postmessage" id="infopanel-for-dom-portalhost-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-portalhost-postmessage" style="display:none">Info about the 'postMessage(message, options)' definition.</span><b><a href="#dom-portalhost-postmessage">#dom-portalhost-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-portalhost-postmessage">3.1. Portal hosts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-portalhost-message">
-   <b><a href="#eventdef-portalhost-message">#eventdef-portalhost-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-portalhost-message" class="dfn-panel" data-for="eventdef-portalhost-message" id="infopanel-for-eventdef-portalhost-message" role="dialog">
+   <span id="infopaneltitle-for-eventdef-portalhost-message" style="display:none">Info about the 'message' definition.</span><b><a href="#eventdef-portalhost-message">#eventdef-portalhost-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-portalhost-message">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-portalhost-messageerror">
-   <b><a href="#eventdef-portalhost-messageerror">#eventdef-portalhost-messageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-portalhost-messageerror" class="dfn-panel" data-for="eventdef-portalhost-messageerror" id="infopanel-for-eventdef-portalhost-messageerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-portalhost-messageerror" style="display:none">Info about the 'messageerror' definition.</span><b><a href="#eventdef-portalhost-messageerror">#eventdef-portalhost-messageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-portalhost-messageerror">3. The portal element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalactivateevent">
-   <b><a href="#portalactivateevent">#portalactivateevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalactivateevent" class="dfn-panel" data-for="portalactivateevent" id="infopanel-for-portalactivateevent" role="dialog">
+   <span id="infopaneltitle-for-portalactivateevent" style="display:none">Info about the 'PortalActivateEvent' definition.</span><b><a href="#portalactivateevent">#portalactivateevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalactivateevent">2. Portal browsing contexts</a>
     <li><a href="#ref-for-portalactivateevent①">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-portalactivateevent②">(2)</a> <a href="#ref-for-portalactivateevent③">(3)</a>
     <li><a href="#ref-for-portalactivateevent④">4.2. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-portalactivateevent-data">
-   <b><a href="#dom-portalactivateevent-data">#dom-portalactivateevent-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-portalactivateevent-data" class="dfn-panel" data-for="dom-portalactivateevent-data" id="infopanel-for-dom-portalactivateevent-data" role="dialog">
+   <span id="infopaneltitle-for-dom-portalactivateevent-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-portalactivateevent-data">#dom-portalactivateevent-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-portalactivateevent-data">2. Portal browsing contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-portalactivateeventinit">
-   <b><a href="#dictdef-portalactivateeventinit">#dictdef-portalactivateeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-portalactivateeventinit" class="dfn-panel" data-for="dictdef-portalactivateeventinit" id="infopanel-for-dictdef-portalactivateeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-portalactivateeventinit" style="display:none">Info about the 'PortalActivateEventInit' definition.</span><b><a href="#dictdef-portalactivateeventinit">#dictdef-portalactivateeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-portalactivateeventinit">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalactivateevent-predecessor-browsing-context">
-   <b><a href="#portalactivateevent-predecessor-browsing-context">#portalactivateevent-predecessor-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalactivateevent-predecessor-browsing-context" class="dfn-panel" data-for="portalactivateevent-predecessor-browsing-context" id="infopanel-for-portalactivateevent-predecessor-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-portalactivateevent-predecessor-browsing-context" style="display:none">Info about the 'predecessor browsing context' definition.</span><b><a href="#portalactivateevent-predecessor-browsing-context">#portalactivateevent-predecessor-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalactivateevent-predecessor-browsing-context">2. Portal browsing contexts</a>
     <li><a href="#ref-for-portalactivateevent-predecessor-browsing-context①">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-portalactivateevent-predecessor-browsing-context②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalactivateevent-successor-window">
-   <b><a href="#portalactivateevent-successor-window">#portalactivateevent-successor-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalactivateevent-successor-window" class="dfn-panel" data-for="portalactivateevent-successor-window" id="infopanel-for-portalactivateevent-successor-window" role="dialog">
+   <span id="infopaneltitle-for-portalactivateevent-successor-window" style="display:none">Info about the 'successor window' definition.</span><b><a href="#portalactivateevent-successor-window">#portalactivateevent-successor-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalactivateevent-successor-window">2. Portal browsing contexts</a>
     <li><a href="#ref-for-portalactivateevent-successor-window①">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-portalactivateevent-successor-window②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalactivateevent-activation-promise">
-   <b><a href="#portalactivateevent-activation-promise">#portalactivateevent-activation-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalactivateevent-activation-promise" class="dfn-panel" data-for="portalactivateevent-activation-promise" id="infopanel-for-portalactivateevent-activation-promise" role="dialog">
+   <span id="infopaneltitle-for-portalactivateevent-activation-promise" style="display:none">Info about the 'activation promise' definition.</span><b><a href="#portalactivateevent-activation-promise">#portalactivateevent-activation-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalactivateevent-activation-promise">2. Portal browsing contexts</a> <a href="#ref-for-portalactivateevent-activation-promise①">(2)</a>
     <li><a href="#ref-for-portalactivateevent-activation-promise②">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portalactivateevent-adopted-predecessor-element">
-   <b><a href="#portalactivateevent-adopted-predecessor-element">#portalactivateevent-adopted-predecessor-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portalactivateevent-adopted-predecessor-element" class="dfn-panel" data-for="portalactivateevent-adopted-predecessor-element" id="infopanel-for-portalactivateevent-adopted-predecessor-element" role="dialog">
+   <span id="infopaneltitle-for-portalactivateevent-adopted-predecessor-element" style="display:none">Info about the 'adopted predecessor element' definition.</span><b><a href="#portalactivateevent-adopted-predecessor-element">#portalactivateevent-adopted-predecessor-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portalactivateevent-adopted-predecessor-element">2. Portal browsing contexts</a>
     <li><a href="#ref-for-portalactivateevent-adopted-predecessor-element①">3.2. The PortalActivateEvent interface</a> <a href="#ref-for-portalactivateevent-adopted-predecessor-element②">(2)</a> <a href="#ref-for-portalactivateevent-adopted-predecessor-element③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-portalactivateevent-adoptpredecessor">
-   <b><a href="#dom-portalactivateevent-adoptpredecessor">#dom-portalactivateevent-adoptpredecessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-portalactivateevent-adoptpredecessor" class="dfn-panel" data-for="dom-portalactivateevent-adoptpredecessor" id="infopanel-for-dom-portalactivateevent-adoptpredecessor" role="dialog">
+   <span id="infopaneltitle-for-dom-portalactivateevent-adoptpredecessor" style="display:none">Info about the 'adoptPredecessor()' definition.</span><b><a href="#dom-portalactivateevent-adoptpredecessor">#dom-portalactivateevent-adoptpredecessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-portalactivateevent-adoptpredecessor">2. Portal browsing contexts</a> <a href="#ref-for-dom-portalactivateevent-adoptpredecessor①">(2)</a>
     <li><a href="#ref-for-dom-portalactivateevent-adoptpredecessor②">3.2. The PortalActivateEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-messageeventsource">
-   <b><a href="#typedefdef-messageeventsource">#typedefdef-messageeventsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-messageeventsource" class="dfn-panel" data-for="typedefdef-messageeventsource" id="infopanel-for-typedefdef-messageeventsource" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-messageeventsource" style="display:none">Info about the 'MessageEventSource' definition.</span><b><a href="#typedefdef-messageeventsource">#typedefdef-messageeventsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-messageeventsource">4.1. The MessageEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-window-portalactivate">
-   <b><a href="#eventdef-window-portalactivate">#eventdef-window-portalactivate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-window-portalactivate" class="dfn-panel" data-for="eventdef-window-portalactivate" id="infopanel-for-eventdef-window-portalactivate" role="dialog">
+   <span id="infopaneltitle-for-eventdef-window-portalactivate" style="display:none">Info about the 'portalactivate' definition.</span><b><a href="#eventdef-window-portalactivate">#eventdef-window-portalactivate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-window-portalactivate">2. Portal browsing contexts</a> <a href="#ref-for-eventdef-window-portalactivate①">(2)</a>
     <li><a href="#ref-for-eventdef-window-portalactivate②">3. The portal element</a>
@@ -3552,8 +3554,8 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
     <li><a href="#ref-for-eventdef-window-portalactivate④">4.2. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="portal-src">
-   <b><a href="#portal-src">#portal-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-portal-src" class="dfn-panel" data-for="portal-src" id="infopanel-for-portal-src" role="dialog">
+   <span id="infopaneltitle-for-portal-src" style="display:none">Info about the 'portal-src' definition.</span><b><a href="#portal-src">#portal-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-portal-src">5.1.1. portal-src</a>
     <li><a href="#ref-for-portal-src①">5.1.2. default-src</a>
@@ -3562,59 +3564,115 @@ browsing context</a> or a <a data-link-type="dfn" href="#portal-browsing-context
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/priority-hints/index.html
+++ b/tests/github/WICG/priority-hints/index.html
@@ -1009,28 +1009,28 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </div>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">1. Introduction</a>
     <li><a href="#ref-for-concept-request-destination①">3. Effects of Priority Hints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumerated-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumerated-attribute" class="dfn-panel" data-for="term-for-enumerated-attribute" id="infopanel-for-term-for-enumerated-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-enumerated-attribute" style="display:none">Info about the 'enumerated attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumerated-attribute">Unnumbered Section</a>
     <li><a href="#ref-for-enumerated-attribute①">2. Solution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-value-default">
-   <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#invalid-value-default">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#invalid-value-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-value-default" class="dfn-panel" data-for="term-for-invalid-value-default" id="infopanel-for-term-for-invalid-value-default" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-value-default" style="display:none">Info about the 'invalid value default' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#invalid-value-default">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#invalid-value-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-value-default">2. Solution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-missing-value-default">
-   <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-missing-value-default" class="dfn-panel" data-for="term-for-missing-value-default" id="infopanel-for-term-for-missing-value-default" role="menu">
+   <span id="infopaneltitle-for-term-for-missing-value-default" style="display:none">Info about the 'missing value default' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#missing-value-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-missing-value-default">2. Solution</a>
    </ul>
@@ -1069,57 +1069,113 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/responsive-image-client-hints/index.html
+++ b/tests/github/WICG/responsive-image-client-hints/index.html
@@ -896,51 +896,51 @@ PixelYDimensions: 600
    <li><a href="#http-headerdef-sec-ch-viewport-width">Sec-CH-Viewport-Width</a><span>, in § 2.2</span>
    <li><a href="#http-headerdef-sec-ch-width">Sec-CH-Width</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-abstract-opdef-append-client-hints-to-request">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request">https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-opdef-append-client-hints-to-request" class="dfn-panel" data-for="term-for-abstract-opdef-append-client-hints-to-request" id="infopanel-for-term-for-abstract-opdef-append-client-hints-to-request" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-opdef-append-client-hints-to-request" style="display:none">Info about the 'append client hints to request' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request">https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-append-client-hints-to-request">3.2. Delegation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#fetch">https://wicg.github.io/client-hints-infrastructure/#fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch" class="dfn-panel" data-for="term-for-fetch" id="infopanel-for-term-for-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch" style="display:none">Info about the 'integration with Fetch' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#fetch">https://wicg.github.io/client-hints-infrastructure/#fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch">2.5. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.1. The Sec-CH-Width Header Field</a> <a href="#ref-for-px①">(2)</a> <a href="#ref-for-px②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-clientwidth">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-clientwidth">https://drafts.csswg.org/cssom-view-1/#dom-element-clientwidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-clientwidth" class="dfn-panel" data-for="term-for-dom-element-clientwidth" id="infopanel-for-term-for-dom-element-clientwidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-clientwidth" style="display:none">Info about the 'clientWidth' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-clientwidth">https://drafts.csswg.org/cssom-view-1/#dom-element-clientwidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-clientwidth">2.1. The Sec-CH-Width Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-devicepixelratio">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio">https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-devicepixelratio" class="dfn-panel" data-for="term-for-dom-window-devicepixelratio" id="infopanel-for-term-for-dom-window-devicepixelratio" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-devicepixelratio" style="display:none">Info about the 'devicePixelRatio' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio">https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-devicepixelratio">2.1. The Sec-CH-Width Header Field</a> <a href="#ref-for-dom-window-devicepixelratio①">(2)</a> <a href="#ref-for-dom-window-devicepixelratio②">(3)</a>
     <li><a href="#ref-for-dom-window-devicepixelratio③">2.4. The Sec-CH-DPR Header Field</a> <a href="#ref-for-dom-window-devicepixelratio④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-innerheight">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-innerheight">https://drafts.csswg.org/cssom-view-1/#dom-window-innerheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-innerheight" class="dfn-panel" data-for="term-for-dom-window-innerheight" id="infopanel-for-term-for-dom-window-innerheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-innerheight" style="display:none">Info about the 'innerHeight' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-innerheight">https://drafts.csswg.org/cssom-view-1/#dom-window-innerheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-innerheight">2.3. The Sec-CH-Viewport-Height Header Field</a> <a href="#ref-for-dom-window-innerheight①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-innerwidth">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-innerwidth">https://drafts.csswg.org/cssom-view-1/#dom-window-innerwidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-innerwidth" class="dfn-panel" data-for="term-for-dom-window-innerwidth" id="infopanel-for-term-for-dom-window-innerwidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-innerwidth" style="display:none">Info about the 'innerWidth' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-innerwidth">https://drafts.csswg.org/cssom-view-1/#dom-window-innerwidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-innerwidth">2.2. The Sec-CH-Viewport-Width Header Field</a> <a href="#ref-for-dom-window-innerwidth①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.1. The Sec-CH-Width Header Field</a>
     <li><a href="#ref-for-concept-fetch①">2.2. The Sec-CH-Viewport-Width Header Field</a>
@@ -948,14 +948,14 @@ PixelYDimensions: 600
     <li><a href="#ref-for-concept-fetch③">2.4. The Sec-CH-DPR Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-passive-fingerprinting">
-   <a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-passive-fingerprinting">https://www.w3.org/TR/fingerprinting-guidance/#dfn-passive-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-passive-fingerprinting" class="dfn-panel" data-for="term-for-dfn-passive-fingerprinting" id="infopanel-for-term-for-dfn-passive-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-passive-fingerprinting" style="display:none">Info about the 'passive fingerprinting' external reference.</span><a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-passive-fingerprinting">https://www.w3.org/TR/fingerprinting-guidance/#dfn-passive-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-passive-fingerprinting">3.2. Delegation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.1. The Sec-CH-Width Header Field</a>
     <li><a href="#ref-for-window①">2.2. The Sec-CH-Viewport-Width Header Field</a>
@@ -963,60 +963,60 @@ PixelYDimensions: 600
     <li><a href="#ref-for-window③">2.4. The Sec-CH-DPR Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-density-corrected-intrinsic-width-and-height">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#density-corrected-intrinsic-width-and-height">https://html.spec.whatwg.org/multipage/images.html#density-corrected-intrinsic-width-and-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-density-corrected-intrinsic-width-and-height" class="dfn-panel" data-for="term-for-density-corrected-intrinsic-width-and-height" id="infopanel-for-term-for-density-corrected-intrinsic-width-and-height" role="menu">
+   <span id="infopaneltitle-for-term-for-density-corrected-intrinsic-width-and-height" style="display:none">Info about the 'density-corrected intrinsic width and height' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#density-corrected-intrinsic-width-and-height">https://html.spec.whatwg.org/multipage/images.html#density-corrected-intrinsic-width-and-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-density-corrected-intrinsic-width-and-height">1. Introduction</a>
     <li><a href="#ref-for-density-corrected-intrinsic-width-and-height①">2.4. The Sec-CH-DPR Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1. Introduction</a>
     <li><a href="#ref-for-the-img-element①">2.1. The Sec-CH-Width Header Field</a> <a href="#ref-for-the-img-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-picture-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-picture-element" class="dfn-panel" data-for="term-for-the-picture-element" id="infopanel-for-term-for-the-picture-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-picture-element" style="display:none">Info about the 'picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-picture-element">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-srcset">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-srcset" class="dfn-panel" data-for="term-for-attr-img-srcset" id="infopanel-for-term-for-attr-img-srcset" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-srcset" style="display:none">Info about the 'srcset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-srcset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-srcset">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#section-3.1">https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#section-3.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1" class="dfn-panel" data-for="term-for-section-3.1" id="infopanel-for-term-for-section-3.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1" style="display:none">Info about the 'accept-ch' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#section-3.1">https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#section-3.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#">https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'client hints' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#">https://tools.ietf.org/html/draft-ietf-httpbis-client-hints#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3.2">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.2">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3.2" class="dfn-panel" data-for="term-for-section-3.3.2" id="infopanel-for-term-for-section-3.3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3.2" style="display:none">Info about the 'decimal' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.2">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3.2">2.4. The Sec-CH-DPR Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3.1">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.1">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3.1" class="dfn-panel" data-for="term-for-section-3.3.1" id="infopanel-for-term-for-section-3.3.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3.1" style="display:none">Info about the 'integer' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.1">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.3.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3.1">2.1. The Sec-CH-Width Header Field</a>
     <li><a href="#ref-for-section-3.3.1①">2.2. The Sec-CH-Viewport-Width Header Field</a>
     <li><a href="#ref-for-section-3.3.1②">2.3. The Sec-CH-Viewport-Height Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-①" role="menu">
+   <span id="infopaneltitle-for-term-for-①" style="display:none">Info about the 'structured header' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.1. The Sec-CH-Width Header Field</a>
     <li><a href="#termref-for-">2.2. The Sec-CH-Viewport-Width Header Field</a>
@@ -1024,8 +1024,8 @@ PixelYDimensions: 600
     <li><a href="#termref-for-">2.4. The Sec-CH-DPR Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permissions-policy-header">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header">https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permissions-policy-header" class="dfn-panel" data-for="term-for-permissions-policy-header" id="infopanel-for-term-for-permissions-policy-header" role="menu">
+   <span id="infopaneltitle-for-term-for-permissions-policy-header" style="display:none">Info about the 'permissions-policy' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header">https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions-policy-header">1. Introduction</a>
    </ul>
@@ -1125,14 +1125,14 @@ PixelYDimensions: 600
    <div class="issue"> TODO!? Or do the "in web contexts" notes above, cover this? Do we need an IDL interface? Related - do I need ABNFs, or are the simple structured header types enough? <a class="issue-return" href="#issue-d481809c" title="Jump to section">↵</a></div>
    <div class="issue"> TODO (start with https://github.com/WICG/ua-client-hints/blob/master/index.bs#L282 or https://github.com/WICG/ua-client-hints/blob/master/index.bs#L554) <a class="issue-return" href="#issue-8e5d3dd1" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-ch-width">
-   <b><a href="#http-headerdef-sec-ch-width">#http-headerdef-sec-ch-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-ch-width" class="dfn-panel" data-for="http-headerdef-sec-ch-width" id="infopanel-for-http-headerdef-sec-ch-width" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-ch-width" style="display:none">Info about the 'Sec-CH-Width' definition.</span><b><a href="#http-headerdef-sec-ch-width">#http-headerdef-sec-ch-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-ch-width">2.1. The Sec-CH-Width Header Field</a> <a href="#ref-for-http-headerdef-sec-ch-width①">(2)</a> <a href="#ref-for-http-headerdef-sec-ch-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-ch-dpr">
-   <b><a href="#http-headerdef-sec-ch-dpr">#http-headerdef-sec-ch-dpr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-ch-dpr" class="dfn-panel" data-for="http-headerdef-sec-ch-dpr" id="infopanel-for-http-headerdef-sec-ch-dpr" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-ch-dpr" style="display:none">Info about the 'Sec-CH-DPR' definition.</span><b><a href="#http-headerdef-sec-ch-dpr">#http-headerdef-sec-ch-dpr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-ch-dpr">2.1. The Sec-CH-Width Header Field</a> <a href="#ref-for-http-headerdef-sec-ch-dpr①">(2)</a>
     <li><a href="#ref-for-http-headerdef-sec-ch-dpr②">2.4. The Sec-CH-DPR Header Field</a> <a href="#ref-for-http-headerdef-sec-ch-dpr③">(2)</a>
@@ -1140,57 +1140,113 @@ PixelYDimensions: 600
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/sanitizer-api/index.html
+++ b/tests/github/WICG/sanitizer-api/index.html
@@ -1285,156 +1285,156 @@ describes, as is Internet Explorer’s <code class="idl"><a data-link-type="idl"
    <li><a href="#dom-sanitizer-sanitizetostring">sanitizeToString(input)</a><span>, in § 2.1</span>
    <li><a href="#stricter-action">stricter action</a><span>, in § 2.4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-interface-Document">
-   <a href="https://dom.spec.whatwg.org/#interface-Document">https://dom.spec.whatwg.org/#interface-Document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-Document" class="dfn-panel" data-for="term-for-interface-Document" id="infopanel-for-term-for-interface-Document" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-Document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#interface-Document">https://dom.spec.whatwg.org/#interface-Document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-Document">2.2. Input Types</a>
     <li><a href="#ref-for-interface-Document①">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentfragment">
-   <a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentfragment" class="dfn-panel" data-for="term-for-documentfragment" id="infopanel-for-term-for-documentfragment" role="menu">
+   <span id="infopaneltitle-for-term-for-documentfragment" style="display:none">Info about the 'DocumentFragment' external reference.</span><a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentfragment">2.1. Sanitizer API</a>
     <li><a href="#ref-for-documentfragment①">2.2. Input Types</a> <a href="#ref-for-documentfragment②">(2)</a>
     <li><a href="#ref-for-documentfragment③">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-createdocumentfragment">
-   <a href="https://dom.spec.whatwg.org/#dom-document-createdocumentfragment">https://dom.spec.whatwg.org/#dom-document-createdocumentfragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-createdocumentfragment" class="dfn-panel" data-for="term-for-dom-document-createdocumentfragment" id="infopanel-for-term-for-dom-document-createdocumentfragment" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-createdocumentfragment" style="display:none">Info about the 'createDocumentFragment' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-createdocumentfragment">https://dom.spec.whatwg.org/#dom-document-createdocumentfragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createdocumentfragment">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx">https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'window.toStaticHTML()' external reference.</span><a href="https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx">https://msdn.microsoft.com/en-us/library/cc848922(v=vs.85).aspx</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-append">
-   <a href="https://dom.spec.whatwg.org/#concept-node-append">https://dom.spec.whatwg.org/#concept-node-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-append" class="dfn-panel" data-for="term-for-concept-node-append" id="infopanel-for-term-for-concept-node-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-append" style="display:none">Info about the 'append' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-append">https://dom.spec.whatwg.org/#concept-node-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-append">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attribute" class="dfn-panel" data-for="term-for-concept-element-attribute" id="infopanel-for-term-for-concept-element-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attribute" style="display:none">Info about the 'attribute list' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-clone">
-   <a href="https://dom.spec.whatwg.org/#concept-node-clone">https://dom.spec.whatwg.org/#concept-node-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-clone" class="dfn-panel" data-for="term-for-concept-node-clone" id="infopanel-for-term-for-concept-node-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-clone" style="display:none">Info about the 'clone a node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-clone">https://dom.spec.whatwg.org/#concept-node-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-clone">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-interface">
-   <a href="https://dom.spec.whatwg.org/#concept-element-interface">https://dom.spec.whatwg.org/#concept-element-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-interface" class="dfn-panel" data-for="term-for-concept-element-interface" id="infopanel-for-term-for-concept-element-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-interface" style="display:none">Info about the 'element interface' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-interface">https://dom.spec.whatwg.org/#concept-element-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-interface">2.4. Algorithms</a> <a href="#ref-for-concept-element-interface①">(2)</a> <a href="#ref-for-concept-element-interface②">(3)</a> <a href="#ref-for-concept-element-interface③">(4)</a>
     <li><a href="#ref-for-concept-element-interface④">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-inclusive-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant">https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-inclusive-descendant" class="dfn-panel" data-for="term-for-concept-tree-inclusive-descendant" id="infopanel-for-term-for-concept-tree-inclusive-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-inclusive-descendant" style="display:none">Info about the 'inclusive descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant">https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-inclusive-descendant">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-Element-innerHTML">
-   <a href="https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML">https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-Element-innerHTML" class="dfn-panel" data-for="term-for-widl-Element-innerHTML" id="infopanel-for-term-for-widl-Element-innerHTML" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-Element-innerHTML" style="display:none">Info about the 'innerHTML' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML">https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-Element-innerHTML">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type">
-   <a href="https://w3c.github.io/DOM-Parsing/#widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type">https://w3c.github.io/DOM-Parsing/#widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type" class="dfn-panel" data-for="term-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type" id="infopanel-for-term-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type" style="display:none">Info about the 'parseFromString' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type">https://w3c.github.io/DOM-Parsing/#widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type">2.4. Algorithms</a> <a href="#ref-for-widl-DOMParser-parseFromString-Document-DOMString-str-SupportedType-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlbuttonelement">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlbuttonelement" class="dfn-panel" data-for="term-for-htmlbuttonelement" id="infopanel-for-term-for-htmlbuttonelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlbuttonelement" style="display:none">Info about the 'HTMLButtonElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlbuttonelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlbuttonelement">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlformelement">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlformelement" class="dfn-panel" data-for="term-for-htmlformelement" id="infopanel-for-term-for-htmlformelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlformelement" style="display:none">Info about the 'HTMLFormElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlformelement">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhyperlinkelementutils">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlhyperlinkelementutils" class="dfn-panel" data-for="term-for-htmlhyperlinkelementutils" id="infopanel-for-term-for-htmlhyperlinkelementutils" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlhyperlinkelementutils" style="display:none">Info about the 'HTMLHyperlinkElementUtils' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlhyperlinkelementutils">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlinputelement">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlinputelement" class="dfn-panel" data-for="term-for-htmlinputelement" id="infopanel-for-term-for-htmlinputelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlinputelement" style="display:none">Info about the 'HTMLInputElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlinputelement">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmltemplateelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement">https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmltemplateelement" class="dfn-panel" data-for="term-for-htmltemplateelement" id="infopanel-for-term-for-htmltemplateelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmltemplateelement" style="display:none">Info about the 'HTMLTemplateElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement">https://html.spec.whatwg.org/multipage/scripting.html#htmltemplateelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmltemplateelement">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlunknownelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement">https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlunknownelement" class="dfn-panel" data-for="term-for-htmlunknownelement" id="infopanel-for-term-for-htmlunknownelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlunknownelement" style="display:none">Info about the 'HTMLUnknownElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement">https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlunknownelement">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">2.3. The Configuration Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-fragment-serialisation-algorithm">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm">https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-fragment-serialisation-algorithm" class="dfn-panel" data-for="term-for-html-fragment-serialisation-algorithm" id="infopanel-for-term-for-html-fragment-serialisation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-html-fragment-serialisation-algorithm" style="display:none">Info about the 'html fragment serialization algorithm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm">https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-serialisation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-fragment-serialisation-algorithm">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-parser">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#html-parser">https://html.spec.whatwg.org/multipage/parsing.html#html-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-parser" class="dfn-panel" data-for="term-for-html-parser" id="infopanel-for-term-for-html-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-html-parser" style="display:none">Info about the 'html parser' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#html-parser">https://html.spec.whatwg.org/multipage/parsing.html#html-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-parser">2.2. Input Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-custom-element-name">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name">https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-custom-element-name" class="dfn-panel" data-for="term-for-valid-custom-element-name" id="infopanel-for-term-for-valid-custom-element-name" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-custom-element-name" style="display:none">Info about the 'valid custom element name' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name">https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-custom-element-name">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'iterate' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.4. Algorithms</a> <a href="#ref-for-list-iterate①">(2)</a> <a href="#ref-for-list-iterate②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1. Sanitizer API</a>
     <li><a href="#ref-for-idl-DOMString①">2.2. Input Types</a>
@@ -1442,32 +1442,32 @@ describes, as is Internet Explorer’s <code class="idl"><a data-link-type="idl"
     <li><a href="#ref-for-idl-DOMString⑤">2.3.1. Attribute Match Lists</a> <a href="#ref-for-idl-DOMString⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.3. The Configuration Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">2.3.1. Attribute Match Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.3. The Configuration Dictionary</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
     <li><a href="#ref-for-idl-sequence③">2.3.1. Attribute Match Lists</a>
@@ -1588,206 +1588,207 @@ describes, as is Internet Explorer’s <code class="idl"><a data-link-type="idl"
     are still under discussion. The values below are for illustrative
     purposes only. <a class="issue-return" href="#issue-53c87d03" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dom-sanitizer-sanitizer">
-   <b><a href="#dom-sanitizer-sanitizer">#dom-sanitizer-sanitizer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sanitizer-sanitizer" class="dfn-panel" data-for="dom-sanitizer-sanitizer" id="infopanel-for-dom-sanitizer-sanitizer" role="dialog">
+   <span id="infopaneltitle-for-dom-sanitizer-sanitizer" style="display:none">Info about the '
+  new Sanitizer(config)' definition.</span><b><a href="#dom-sanitizer-sanitizer">#dom-sanitizer-sanitizer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sanitizer-sanitizer">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sanitizer-sanitize">
-   <b><a href="#dom-sanitizer-sanitize">#dom-sanitizer-sanitize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sanitizer-sanitize" class="dfn-panel" data-for="dom-sanitizer-sanitize" id="infopanel-for-dom-sanitizer-sanitize" role="dialog">
+   <span id="infopaneltitle-for-dom-sanitizer-sanitize" style="display:none">Info about the 'sanitize(input)' definition.</span><b><a href="#dom-sanitizer-sanitize">#dom-sanitizer-sanitize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sanitizer-sanitize">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sanitizer-sanitizetostring">
-   <b><a href="#dom-sanitizer-sanitizetostring">#dom-sanitizer-sanitizetostring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sanitizer-sanitizetostring" class="dfn-panel" data-for="dom-sanitizer-sanitizetostring" id="infopanel-for-dom-sanitizer-sanitizetostring" role="dialog">
+   <span id="infopaneltitle-for-dom-sanitizer-sanitizetostring" style="display:none">Info about the 'sanitizeToString(input)' definition.</span><b><a href="#dom-sanitizer-sanitizetostring">#dom-sanitizer-sanitizetostring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sanitizer-sanitizetostring">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-sanitizerinput">
-   <b><a href="#typedefdef-sanitizerinput">#typedefdef-sanitizerinput</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-sanitizerinput" class="dfn-panel" data-for="typedefdef-sanitizerinput" id="infopanel-for-typedefdef-sanitizerinput" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-sanitizerinput" style="display:none">Info about the 'SanitizerInput' definition.</span><b><a href="#typedefdef-sanitizerinput">#typedefdef-sanitizerinput</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-sanitizerinput">2.1. Sanitizer API</a> <a href="#ref-for-typedefdef-sanitizerinput①">(2)</a>
     <li><a href="#ref-for-typedefdef-sanitizerinput②">2.4. Algorithms</a> <a href="#ref-for-typedefdef-sanitizerinput③">(2)</a> <a href="#ref-for-typedefdef-sanitizerinput④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-object">
-   <b><a href="#configuration-object">#configuration-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-object" class="dfn-panel" data-for="configuration-object" id="infopanel-for-configuration-object" role="dialog">
+   <span id="infopaneltitle-for-configuration-object" style="display:none">Info about the 'configuration object' definition.</span><b><a href="#configuration-object">#configuration-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-object">2.1. Sanitizer API</a>
     <li><a href="#ref-for-configuration-object①">2.4.1. The Effective Configuration</a> <a href="#ref-for-configuration-object②">(2)</a> <a href="#ref-for-configuration-object③">(3)</a> <a href="#ref-for-configuration-object④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-sanitizerconfig">
-   <b><a href="#dictdef-sanitizerconfig">#dictdef-sanitizerconfig</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-sanitizerconfig" class="dfn-panel" data-for="dictdef-sanitizerconfig" id="infopanel-for-dictdef-sanitizerconfig" role="dialog">
+   <span id="infopaneltitle-for-dictdef-sanitizerconfig" style="display:none">Info about the 'SanitizerConfig' definition.</span><b><a href="#dictdef-sanitizerconfig">#dictdef-sanitizerconfig</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sanitizerconfig">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-allow-list">
-   <b><a href="#element-allow-list">#element-allow-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-allow-list" class="dfn-panel" data-for="element-allow-list" id="infopanel-for-element-allow-list" role="dialog">
+   <span id="infopaneltitle-for-element-allow-list" style="display:none">Info about the 'element allow list' definition.</span><b><a href="#element-allow-list">#element-allow-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-allow-list">2.4.1. The Effective Configuration</a> <a href="#ref-for-element-allow-list①">(2)</a> <a href="#ref-for-element-allow-list②">(3)</a> <a href="#ref-for-element-allow-list③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-block-list">
-   <b><a href="#element-block-list">#element-block-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-block-list" class="dfn-panel" data-for="element-block-list" id="infopanel-for-element-block-list" role="dialog">
+   <span id="infopaneltitle-for-element-block-list" style="display:none">Info about the 'element block list' definition.</span><b><a href="#element-block-list">#element-block-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-block-list">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-drop-list">
-   <b><a href="#element-drop-list">#element-drop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-drop-list" class="dfn-panel" data-for="element-drop-list" id="infopanel-for-element-drop-list" role="dialog">
+   <span id="infopaneltitle-for-element-drop-list" style="display:none">Info about the 'element drop list' definition.</span><b><a href="#element-drop-list">#element-drop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-drop-list">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-allow-list">
-   <b><a href="#attribute-allow-list">#attribute-allow-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-allow-list" class="dfn-panel" data-for="attribute-allow-list" id="infopanel-for-attribute-allow-list" role="dialog">
+   <span id="infopaneltitle-for-attribute-allow-list" style="display:none">Info about the 'attribute allow list' definition.</span><b><a href="#attribute-allow-list">#attribute-allow-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-allow-list">2.4.1. The Effective Configuration</a> <a href="#ref-for-attribute-allow-list①">(2)</a> <a href="#ref-for-attribute-allow-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-drop-list">
-   <b><a href="#attribute-drop-list">#attribute-drop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-drop-list" class="dfn-panel" data-for="attribute-drop-list" id="infopanel-for-attribute-drop-list" role="dialog">
+   <span id="infopaneltitle-for-attribute-drop-list" style="display:none">Info about the 'attribute drop list' definition.</span><b><a href="#attribute-drop-list">#attribute-drop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-drop-list">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allow-custom-elements-option">
-   <b><a href="#allow-custom-elements-option">#allow-custom-elements-option</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allow-custom-elements-option" class="dfn-panel" data-for="allow-custom-elements-option" id="infopanel-for-allow-custom-elements-option" role="dialog">
+   <span id="infopaneltitle-for-allow-custom-elements-option" style="display:none">Info about the 'allow custom elements option' definition.</span><b><a href="#allow-custom-elements-option">#allow-custom-elements-option</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allow-custom-elements-option">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-match-list">
-   <b><a href="#attribute-match-list">#attribute-match-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-match-list" class="dfn-panel" data-for="attribute-match-list" id="infopanel-for-attribute-match-list" role="dialog">
+   <span id="infopaneltitle-for-attribute-match-list" style="display:none">Info about the 'attribute match list' definition.</span><b><a href="#attribute-match-list">#attribute-match-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-match-list">2.3. The Configuration Dictionary</a> <a href="#ref-for-attribute-match-list①">(2)</a>
     <li><a href="#ref-for-attribute-match-list②">2.3.1. Attribute Match Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-attributematchlist">
-   <b><a href="#typedefdef-attributematchlist">#typedefdef-attributematchlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-attributematchlist" class="dfn-panel" data-for="typedefdef-attributematchlist" id="infopanel-for-typedefdef-attributematchlist" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-attributematchlist" style="display:none">Info about the 'AttributeMatchList' definition.</span><b><a href="#typedefdef-attributematchlist">#typedefdef-attributematchlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-attributematchlist">2.3. The Configuration Dictionary</a> <a href="#ref-for-typedefdef-attributematchlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sanitize">
-   <b><a href="#sanitize">#sanitize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sanitize" class="dfn-panel" data-for="sanitize" id="infopanel-for-sanitize" role="dialog">
+   <span id="infopaneltitle-for-sanitize" style="display:none">Info about the 'sanitize' definition.</span><b><a href="#sanitize">#sanitize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sanitize">2.1. Sanitizer API</a>
     <li><a href="#ref-for-sanitize①">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sanitizetostring">
-   <b><a href="#sanitizetostring">#sanitizetostring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sanitizetostring" class="dfn-panel" data-for="sanitizetostring" id="infopanel-for-sanitizetostring" role="dialog">
+   <span id="infopaneltitle-for-sanitizetostring" style="display:none">Info about the 'sanitizeToString' definition.</span><b><a href="#sanitizetostring">#sanitizetostring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sanitizetostring">2.1. Sanitizer API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-document-fragment">
-   <b><a href="#create-a-document-fragment">#create-a-document-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-document-fragment" class="dfn-panel" data-for="create-a-document-fragment" id="infopanel-for-create-a-document-fragment" role="dialog">
+   <span id="infopaneltitle-for-create-a-document-fragment" style="display:none">Info about the 'create a document fragment' definition.</span><b><a href="#create-a-document-fragment">#create-a-document-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-document-fragment">2.4. Algorithms</a> <a href="#ref-for-create-a-document-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sanitize-a-document-fragment">
-   <b><a href="#sanitize-a-document-fragment">#sanitize-a-document-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sanitize-a-document-fragment" class="dfn-panel" data-for="sanitize-a-document-fragment" id="infopanel-for-sanitize-a-document-fragment" role="dialog">
+   <span id="infopaneltitle-for-sanitize-a-document-fragment" style="display:none">Info about the 'sanitize a document fragment' definition.</span><b><a href="#sanitize-a-document-fragment">#sanitize-a-document-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sanitize-a-document-fragment">2.4. Algorithms</a> <a href="#ref-for-sanitize-a-document-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sanitize-a-node">
-   <b><a href="#sanitize-a-node">#sanitize-a-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sanitize-a-node" class="dfn-panel" data-for="sanitize-a-node" id="infopanel-for-sanitize-a-node" role="dialog">
+   <span id="infopaneltitle-for-sanitize-a-node" style="display:none">Info about the 'sanitize a node' definition.</span><b><a href="#sanitize-a-node">#sanitize-a-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sanitize-a-node">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-funky-elements">
-   <b><a href="#handle-funky-elements">#handle-funky-elements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-funky-elements" class="dfn-panel" data-for="handle-funky-elements" id="infopanel-for-handle-funky-elements" role="dialog">
+   <span id="infopaneltitle-for-handle-funky-elements" style="display:none">Info about the 'handle funky elements' definition.</span><b><a href="#handle-funky-elements">#handle-funky-elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-funky-elements">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sanitize-action">
-   <b><a href="#sanitize-action">#sanitize-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sanitize-action" class="dfn-panel" data-for="sanitize-action" id="infopanel-for-sanitize-action" role="dialog">
+   <span id="infopaneltitle-for-sanitize-action" style="display:none">Info about the 'sanitize action' definition.</span><b><a href="#sanitize-action">#sanitize-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sanitize-action">2.4. Algorithms</a>
     <li><a href="#ref-for-sanitize-action①">2.4.1. The Effective Configuration</a> <a href="#ref-for-sanitize-action②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stricter-action">
-   <b><a href="#stricter-action">#stricter-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stricter-action" class="dfn-panel" data-for="stricter-action" id="infopanel-for-stricter-action" role="dialog">
+   <span id="infopaneltitle-for-stricter-action" style="display:none">Info about the 'stricter action' definition.</span><b><a href="#stricter-action">#stricter-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stricter-action">2.4.1. The Effective Configuration</a> <a href="#ref-for-stricter-action①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-element-configuration">
-   <b><a href="#effective-element-configuration">#effective-element-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-element-configuration" class="dfn-panel" data-for="effective-element-configuration" id="infopanel-for-effective-element-configuration" role="dialog">
+   <span id="infopaneltitle-for-effective-element-configuration" style="display:none">Info about the 'effective element configuration' definition.</span><b><a href="#effective-element-configuration">#effective-element-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-element-configuration">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-attribute-configuration">
-   <b><a href="#effective-attribute-configuration">#effective-attribute-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-attribute-configuration" class="dfn-panel" data-for="effective-attribute-configuration" id="infopanel-for-effective-attribute-configuration" role="dialog">
+   <span id="infopaneltitle-for-effective-attribute-configuration" style="display:none">Info about the 'effective attribute configuration' definition.</span><b><a href="#effective-attribute-configuration">#effective-attribute-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-attribute-configuration">2.4. Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-kind">
-   <b><a href="#element-kind">#element-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-kind" class="dfn-panel" data-for="element-kind" id="infopanel-for-element-kind" role="dialog">
+   <span id="infopaneltitle-for-element-kind" style="display:none">Info about the 'element kind' definition.</span><b><a href="#element-kind">#element-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-kind">2.4.1. The Effective Configuration</a>
     <li><a href="#ref-for-element-kind①">2.4.2. Baseline and Defaults</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-kind">
-   <b><a href="#attribute-kind">#attribute-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-kind" class="dfn-panel" data-for="attribute-kind" id="infopanel-for-attribute-kind" role="dialog">
+   <span id="infopaneltitle-for-attribute-kind" style="display:none">Info about the 'attribute kind' definition.</span><b><a href="#attribute-kind">#attribute-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-kind">2.4.2. Baseline and Defaults</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-effective-configuration-for-an-element">
-   <b><a href="#determine-the-effective-configuration-for-an-element">#determine-the-effective-configuration-for-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-effective-configuration-for-an-element" class="dfn-panel" data-for="determine-the-effective-configuration-for-an-element" id="infopanel-for-determine-the-effective-configuration-for-an-element" role="dialog">
+   <span id="infopaneltitle-for-determine-the-effective-configuration-for-an-element" style="display:none">Info about the 'determine the effective configuration for an element' definition.</span><b><a href="#determine-the-effective-configuration-for-an-element">#determine-the-effective-configuration-for-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-effective-configuration-for-an-element">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-effective-configuration-for-an-attribute">
-   <b><a href="#determine-the-effective-configuration-for-an-attribute">#determine-the-effective-configuration-for-an-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-effective-configuration-for-an-attribute" class="dfn-panel" data-for="determine-the-effective-configuration-for-an-attribute" id="infopanel-for-determine-the-effective-configuration-for-an-attribute" role="dialog">
+   <span id="infopaneltitle-for-determine-the-effective-configuration-for-an-attribute" style="display:none">Info about the 'determine the effective configuration for an attribute' definition.</span><b><a href="#determine-the-effective-configuration-for-an-attribute">#determine-the-effective-configuration-for-an-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-effective-configuration-for-an-attribute">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-baseline-configuration-for-an-element">
-   <b><a href="#determine-the-baseline-configuration-for-an-element">#determine-the-baseline-configuration-for-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-baseline-configuration-for-an-element" class="dfn-panel" data-for="determine-the-baseline-configuration-for-an-element" id="infopanel-for-determine-the-baseline-configuration-for-an-element" role="dialog">
+   <span id="infopaneltitle-for-determine-the-baseline-configuration-for-an-element" style="display:none">Info about the 'determine the baseline configuration for an element' definition.</span><b><a href="#determine-the-baseline-configuration-for-an-element">#determine-the-baseline-configuration-for-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-baseline-configuration-for-an-element">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-baseline-configuration-for-an-attribute">
-   <b><a href="#determine-the-baseline-configuration-for-an-attribute">#determine-the-baseline-configuration-for-an-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-baseline-configuration-for-an-attribute" class="dfn-panel" data-for="determine-the-baseline-configuration-for-an-attribute" id="infopanel-for-determine-the-baseline-configuration-for-an-attribute" role="dialog">
+   <span id="infopaneltitle-for-determine-the-baseline-configuration-for-an-attribute" style="display:none">Info about the 'determine the baseline configuration for an attribute' definition.</span><b><a href="#determine-the-baseline-configuration-for-an-attribute">#determine-the-baseline-configuration-for-an-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-baseline-configuration-for-an-attribute">2.4.1. The Effective Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-element-allow-list①">
-   <b><a href="#baseline-element-allow-list①">#baseline-element-allow-list①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-element-allow-list①" class="dfn-panel" data-for="baseline-element-allow-list①" id="infopanel-for-baseline-element-allow-list①" role="dialog">
+   <span id="infopaneltitle-for-baseline-element-allow-list①" style="display:none">Info about the 'baseline element allow list' definition.</span><b><a href="#baseline-element-allow-list①">#baseline-element-allow-list①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-element-allow-list①">2.4.2. Baseline and Defaults</a> <a href="#ref-for-baseline-element-allow-list①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-attribute-allow-list①">
-   <b><a href="#baseline-attribute-allow-list①">#baseline-attribute-allow-list①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-attribute-allow-list①" class="dfn-panel" data-for="baseline-attribute-allow-list①" id="infopanel-for-baseline-attribute-allow-list①" role="dialog">
+   <span id="infopaneltitle-for-baseline-attribute-allow-list①" style="display:none">Info about the 'baseline attribute allow list' definition.</span><b><a href="#baseline-attribute-allow-list①">#baseline-attribute-allow-list①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-attribute-allow-list①">2.4.2. Baseline and Defaults</a> <a href="#ref-for-baseline-attribute-allow-list①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-configuration">
-   <b><a href="#default-configuration">#default-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-configuration" class="dfn-panel" data-for="default-configuration" id="infopanel-for-default-configuration" role="dialog">
+   <span id="infopaneltitle-for-default-configuration" style="display:none">Info about the 'default configuration' definition.</span><b><a href="#default-configuration">#default-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-configuration">2.3. The Configuration Dictionary</a>
     <li><a href="#ref-for-default-configuration①">2.4.1. The Effective Configuration</a> <a href="#ref-for-default-configuration②">(2)</a>
@@ -1796,59 +1797,115 @@ describes, as is Internet Explorer’s <code class="idl"><a data-link-type="idl"
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/scroll-to-text-fragment/index.html
+++ b/tests/github/WICG/scroll-to-text-fragment/index.html
@@ -2501,142 +2501,142 @@ match based on whether the element-id was scrolled.</p>
    <li><a href="#word-boundary">word boundary</a><span>, in § 3.5.3</span>
    <li><a href="#word-bounded">word bounded</a><span>, in § 3.5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-block" class="dfn-panel" data-for="term-for-valdef-display-block" id="infopanel-for-term-for-valdef-display-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flex">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flex" class="dfn-panel" data-for="term-for-valdef-display-flex" id="infopanel-for-term-for-valdef-display-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flow-root">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flow-root" class="dfn-panel" data-for="term-for-valdef-display-flow-root" id="infopanel-for-term-for-valdef-display-flow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flow-root" style="display:none">Info about the 'flow-root' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow-root">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-grid">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-grid">https://drafts.csswg.org/css-display-3/#valdef-display-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-grid" class="dfn-panel" data-for="term-for-valdef-display-grid" id="infopanel-for-term-for-valdef-display-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-grid" style="display:none">Info about the 'grid' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-grid">https://drafts.csswg.org/css-display-3/#valdef-display-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-grid">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-list-item">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-list-item" class="dfn-panel" data-for="term-for-valdef-display-list-item" id="infopanel-for-term-for-valdef-display-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-list-item" style="display:none">Info about the 'list-item' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-list-item">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-visible">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-visible" class="dfn-panel" data-for="term-for-valdef-visibility-visible" id="infopanel-for-term-for-valdef-visibility-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-visible">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-scrollintoviewoptions" class="dfn-panel" data-for="term-for-dictdef-scrollintoviewoptions" id="infopanel-for-term-for-dictdef-scrollintoviewoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-scrollintoviewoptions" style="display:none">Info about the 'ScrollIntoViewOptions' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions">https://drafts.csswg.org/cssom-view-1/#dictdef-scrollintoviewoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-scrollintoviewoptions">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect() (for Element)' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-range-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect" id="infopanel-for-term-for-dom-range-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-range-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect() (for Range)' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-getboundingclientrect">3.5.1. Scroll a DOMRect into view</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-an-element-into-view">
-   <a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-an-element-into-view" class="dfn-panel" data-for="term-for-scroll-an-element-into-view" id="infopanel-for-term-for-scroll-an-element-into-view" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-an-element-into-view" style="display:none">Info about the 'scroll an element into view' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view">https://www.w3.org/TR/cssom-view-1/#scroll-an-element-into-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-an-element-into-view">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-scroll-an-element-into-view①">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-an-element-into-view②">(2)</a> <a href="#ref-for-scroll-an-element-into-view③">(3)</a> <a href="#ref-for-scroll-an-element-into-view④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">3.8. Feature Detectability</a> <a href="#ref-for-document③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text">
-   <a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text" class="dfn-panel" data-for="term-for-text" id="infopanel-for-term-for-text" role="menu">
+   <span id="infopaneltitle-for-term-for-text" style="display:none">Info about the 'Text' external reference.</span><a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-text①">(2)</a> <a href="#ref-for-text②">(3)</a> <a href="#ref-for-text③">(4)</a> <a href="#ref-for-text④">(5)</a> <a href="#ref-for-text⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-bp-after">
-   <a href="https://dom.spec.whatwg.org/#concept-range-bp-after">https://dom.spec.whatwg.org/#concept-range-bp-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-bp-after" class="dfn-panel" data-for="term-for-concept-range-bp-after" id="infopanel-for-term-for-concept-range-bp-after" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-bp-after" style="display:none">Info about the 'after' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-bp-after">https://dom.spec.whatwg.org/#concept-range-bp-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-after">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp-after①">(2)</a> <a href="#ref-for-concept-range-bp-after②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-bp">
-   <a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-bp" class="dfn-panel" data-for="term-for-concept-range-bp" id="infopanel-for-term-for-concept-range-bp" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-bp" style="display:none">Info about the 'boundary point' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-bp①">(2)</a> <a href="#ref-for-concept-range-bp②">(3)</a> <a href="#ref-for-concept-range-bp③">(4)</a> <a href="#ref-for-concept-range-bp④">(5)</a> <a href="#ref-for-concept-range-bp⑤">(6)</a> <a href="#ref-for-concept-range-bp⑥">(7)</a> <a href="#ref-for-concept-range-bp⑦">(8)</a> <a href="#ref-for-concept-range-bp⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range-collapsed">
-   <a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range-collapsed" class="dfn-panel" data-for="term-for-range-collapsed" id="infopanel-for-term-for-range-collapsed" role="menu">
+   <span id="infopaneltitle-for-term-for-range-collapsed" style="display:none">Info about the 'collapsed' external reference.</span><a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range-collapsed">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-range-collapsed①">(2)</a> <a href="#ref-for-range-collapsed②">(3)</a> <a href="#ref-for-range-collapsed③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cd-data">
-   <a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cd-data" class="dfn-panel" data-for="term-for-concept-cd-data" id="infopanel-for-term-for-concept-cd-data" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cd-data" style="display:none">Info about the 'data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-data">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-data①">(2)</a> <a href="#ref-for-concept-cd-data②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-doctype">
-   <a href="https://dom.spec.whatwg.org/#concept-doctype">https://dom.spec.whatwg.org/#concept-doctype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-doctype" class="dfn-panel" data-for="term-for-concept-doctype" id="infopanel-for-term-for-concept-doctype" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-doctype" style="display:none">Info about the 'doctype' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-doctype">https://dom.spec.whatwg.org/#concept-doctype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-doctype">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-concept-document①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document②">(2)</a> <a href="#ref-for-concept-document③">(3)</a>
@@ -2646,446 +2646,446 @@ match based on whether the element-id was scrolled.</p>
     <li><a href="#ref-for-concept-document①⑤">3.7. Document Policy Integration</a> <a href="#ref-for-concept-document①⑥">(2)</a> <a href="#ref-for-concept-document①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-element">
-   <a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-element" class="dfn-panel" data-for="term-for-document-element" id="infopanel-for-term-for-document-element" role="menu">
+   <span id="infopaneltitle-for-term-for-document-element" style="display:none">Info about the 'document element' external reference.</span><a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-element">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-element①">(2)</a>
     <li><a href="#ref-for-concept-element②">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-element③">(2)</a> <a href="#ref-for-concept-element④">(3)</a>
     <li><a href="#ref-for-concept-element⑤">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-element⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-end">
-   <a href="https://dom.spec.whatwg.org/#concept-range-end">https://dom.spec.whatwg.org/#concept-range-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-end" class="dfn-panel" data-for="term-for-concept-range-end" id="infopanel-for-term-for-concept-range-end" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-end" style="display:none">Info about the 'end' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end">https://dom.spec.whatwg.org/#concept-range-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end①">(2)</a> <a href="#ref-for-concept-range-end②">(3)</a> <a href="#ref-for-concept-range-end③">(4)</a> <a href="#ref-for-concept-range-end④">(5)</a> <a href="#ref-for-concept-range-end⑤">(6)</a> <a href="#ref-for-concept-range-end⑥">(7)</a> <a href="#ref-for-concept-range-end⑦">(8)</a> <a href="#ref-for-concept-range-end⑧">(9)</a> <a href="#ref-for-concept-range-end⑨">(10)</a> <a href="#ref-for-concept-range-end①⓪">(11)</a> <a href="#ref-for-concept-range-end①①">(12)</a> <a href="#ref-for-concept-range-end①②">(13)</a> <a href="#ref-for-concept-range-end①③">(14)</a> <a href="#ref-for-concept-range-end①④">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-end-node">
-   <a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-end-node" class="dfn-panel" data-for="term-for-concept-range-end-node" id="infopanel-for-term-for-concept-range-end-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-end-node" style="display:none">Info about the 'end node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-node">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-concept-range-end-node①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-end-node②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-end-offset">
-   <a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-end-offset" class="dfn-panel" data-for="term-for-concept-range-end-offset" id="infopanel-for-term-for-concept-range-end-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-end-offset" style="display:none">Info about the 'end offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-offset">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-following">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-following" class="dfn-panel" data-for="term-for-concept-tree-following" id="infopanel-for-term-for-concept-tree-following" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-following" style="display:none">Info about the 'following' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-following">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-documentfragment-host">
-   <a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-documentfragment-host" class="dfn-panel" data-for="term-for-concept-documentfragment-host" id="infopanel-for-term-for-concept-documentfragment-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-documentfragment-host" style="display:none">Info about the 'host' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-length">
-   <a href="https://dom.spec.whatwg.org/#concept-node-length">https://dom.spec.whatwg.org/#concept-node-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-length" class="dfn-panel" data-for="term-for-concept-node-length" id="infopanel-for-term-for-concept-node-length" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-length" style="display:none">Info about the 'length' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-length">https://dom.spec.whatwg.org/#concept-node-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-length">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-node-length①">(2)</a> <a href="#ref-for-concept-node-length②">(3)</a> <a href="#ref-for-concept-node-length③">(4)</a> <a href="#ref-for-concept-node-length④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
-   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boundary-point-node" class="dfn-panel" data-for="term-for-boundary-point-node" id="infopanel-for-term-for-boundary-point-node" role="menu">
+   <span id="infopaneltitle-for-term-for-boundary-point-node" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-boundary-point-node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-parent">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-parent">https://dom.spec.whatwg.org/#concept-tree-parent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-parent" class="dfn-panel" data-for="term-for-concept-tree-parent" id="infopanel-for-term-for-concept-tree-parent" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-parent" style="display:none">Info about the 'parent' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-parent">https://dom.spec.whatwg.org/#concept-tree-parent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-parent">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-tree-parent①">(2)</a>
     <li><a href="#ref-for-concept-tree-parent②">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parent-element">
-   <a href="https://dom.spec.whatwg.org/#parent-element">https://dom.spec.whatwg.org/#parent-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parent-element" class="dfn-panel" data-for="term-for-parent-element" id="infopanel-for-term-for-parent-element" role="menu">
+   <span id="infopaneltitle-for-term-for-parent-element" style="display:none">Info about the 'parent element' external reference.</span><a href="https://dom.spec.whatwg.org/#parent-element">https://dom.spec.whatwg.org/#parent-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-element">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range">
-   <a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range" class="dfn-panel" data-for="term-for-concept-range" id="infopanel-for-term-for-concept-range" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range" style="display:none">Info about the 'range' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a>
     <li><a href="#ref-for-concept-range④">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-concept-range⑤">(2)</a>
     <li><a href="#ref-for-concept-range⑥">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range⑦">(2)</a> <a href="#ref-for-concept-range⑧">(3)</a> <a href="#ref-for-concept-range⑨">(4)</a> <a href="#ref-for-concept-range①⓪">(5)</a> <a href="#ref-for-concept-range①①">(6)</a> <a href="#ref-for-concept-range①②">(7)</a> <a href="#ref-for-concept-range①③">(8)</a> <a href="#ref-for-concept-range①④">(9)</a> <a href="#ref-for-concept-range①⑤">(10)</a> <a href="#ref-for-concept-range①⑥">(11)</a> <a href="#ref-for-concept-range①⑦">(12)</a> <a href="#ref-for-concept-range①⑧">(13)</a> <a href="#ref-for-concept-range①⑨">(14)</a> <a href="#ref-for-concept-range②⓪">(15)</a> <a href="#ref-for-concept-range②①">(16)</a> <a href="#ref-for-concept-range②②">(17)</a> <a href="#ref-for-concept-range②③">(18)</a> <a href="#ref-for-concept-range②④">(19)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-root" class="dfn-panel" data-for="term-for-concept-shadow-root" id="infopanel-for-term-for-concept-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-ancestor" class="dfn-panel" data-for="term-for-concept-shadow-including-ancestor" id="infopanel-for-term-for-concept-shadow-including-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-ancestor" style="display:none">Info about the 'shadow-including ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-ancestor">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-descendant" class="dfn-panel" data-for="term-for-concept-shadow-including-descendant" id="infopanel-for-term-for-concept-shadow-including-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-descendant" style="display:none">Info about the 'shadow-including descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-descendant">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-descendant①">(2)</a> <a href="#ref-for-concept-shadow-including-descendant②">(3)</a> <a href="#ref-for-concept-shadow-including-descendant③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-inclusive-ancestor" class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-ancestor" id="infopanel-for-term-for-concept-shadow-including-inclusive-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-inclusive-ancestor" style="display:none">Info about the 'shadow-including inclusive ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a> <a href="#ref-for-concept-shadow-including-tree-order②">(3)</a> <a href="#ref-for-concept-shadow-including-tree-order③">(4)</a> <a href="#ref-for-concept-shadow-including-tree-order④">(5)</a> <a href="#ref-for-concept-shadow-including-tree-order⑤">(6)</a> <a href="#ref-for-concept-shadow-including-tree-order⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start" class="dfn-panel" data-for="term-for-concept-range-start" id="infopanel-for-term-for-concept-range-start" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start" style="display:none">Info about the 'start' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start①">(2)</a> <a href="#ref-for-concept-range-start②">(3)</a> <a href="#ref-for-concept-range-start③">(4)</a> <a href="#ref-for-concept-range-start④">(5)</a> <a href="#ref-for-concept-range-start⑤">(6)</a> <a href="#ref-for-concept-range-start⑥">(7)</a> <a href="#ref-for-concept-range-start⑦">(8)</a> <a href="#ref-for-concept-range-start⑧">(9)</a> <a href="#ref-for-concept-range-start⑨">(10)</a> <a href="#ref-for-concept-range-start①⓪">(11)</a> <a href="#ref-for-concept-range-start①①">(12)</a> <a href="#ref-for-concept-range-start①②">(13)</a> <a href="#ref-for-concept-range-start①③">(14)</a> <a href="#ref-for-concept-range-start①④">(15)</a> <a href="#ref-for-concept-range-start①⑤">(16)</a> <a href="#ref-for-concept-range-start①⑥">(17)</a> <a href="#ref-for-concept-range-start①⑦">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start-node">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start-node" class="dfn-panel" data-for="term-for-concept-range-start-node" id="infopanel-for-term-for-concept-range-start-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start-node" style="display:none">Info about the 'start node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-node">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-concept-range-start-node①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-node②">(2)</a> <a href="#ref-for-concept-range-start-node③">(3)</a> <a href="#ref-for-concept-range-start-node④">(4)</a> <a href="#ref-for-concept-range-start-node⑤">(5)</a> <a href="#ref-for-concept-range-start-node⑥">(6)</a> <a href="#ref-for-concept-range-start-node⑦">(7)</a> <a href="#ref-for-concept-range-start-node⑧">(8)</a> <a href="#ref-for-concept-range-start-node⑨">(9)</a> <a href="#ref-for-concept-range-start-node①⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start-offset">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start-offset" class="dfn-panel" data-for="term-for-concept-range-start-offset" id="infopanel-for-term-for-concept-range-start-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start-offset" style="display:none">Info about the 'start offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-offset">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-range-start-offset①">(2)</a> <a href="#ref-for-concept-range-start-offset②">(3)</a> <a href="#ref-for-concept-range-start-offset③">(4)</a> <a href="#ref-for-concept-range-start-offset④">(5)</a> <a href="#ref-for-concept-range-start-offset⑤">(6)</a> <a href="#ref-for-concept-range-start-offset⑥">(7)</a> <a href="#ref-for-concept-range-start-offset⑦">(8)</a> <a href="#ref-for-concept-range-start-offset⑧">(9)</a> <a href="#ref-for-concept-range-start-offset⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cd-substring">
-   <a href="https://dom.spec.whatwg.org/#concept-cd-substring">https://dom.spec.whatwg.org/#concept-cd-substring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cd-substring" class="dfn-panel" data-for="term-for-concept-cd-substring" id="infopanel-for-term-for-concept-cd-substring" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cd-substring" style="display:none">Info about the 'substring data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-substring">https://dom.spec.whatwg.org/#concept-cd-substring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-substring">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-concept-cd-substring①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-concept-document-url①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-document-url②">(2)</a> <a href="#ref-for-concept-document-url③">(3)</a> <a href="#ref-for-concept-document-url④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrect">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrect" class="dfn-panel" data-for="term-for-domrect" id="infopanel-for-term-for-domrect" role="menu">
+   <span id="infopaneltitle-for-term-for-domrect" style="display:none">Info about the 'DOMRect' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-domrect①">(2)</a> <a href="#ref-for-domrect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlaudioelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement">https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlaudioelement" class="dfn-panel" data-for="term-for-htmlaudioelement" id="infopanel-for-term-for-htmlaudioelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlaudioelement" style="display:none">Info about the 'HTMLAudioElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement">https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlaudioelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmliframeelement" class="dfn-panel" data-for="term-for-htmliframeelement" id="infopanel-for-term-for-htmliframeelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmliframeelement" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmliframeelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlmeterelement">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlmeterelement" class="dfn-panel" data-for="term-for-htmlmeterelement" id="infopanel-for-term-for-htmlmeterelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlmeterelement" style="display:none">Info about the 'HTMLMeterElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlmeterelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlmeterelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlobjectelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlobjectelement" class="dfn-panel" data-for="term-for-htmlobjectelement" id="infopanel-for-term-for-htmlobjectelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlobjectelement" style="display:none">Info about the 'HTMLObjectElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlobjectelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlprogresselement">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlprogresselement" class="dfn-panel" data-for="term-for-htmlprogresselement" id="infopanel-for-term-for-htmlprogresselement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlprogresselement" style="display:none">Info about the 'HTMLProgressElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement">https://html.spec.whatwg.org/multipage/form-elements.html#htmlprogresselement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlprogresselement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlscriptelement" class="dfn-panel" data-for="term-for-htmlscriptelement" id="infopanel-for-term-for-htmlscriptelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlscriptelement" style="display:none">Info about the 'HTMLScriptElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlscriptelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlstyleelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlstyleelement" class="dfn-panel" data-for="term-for-htmlstyleelement" id="infopanel-for-term-for-htmlstyleelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlstyleelement" style="display:none">Info about the 'HTMLStyleElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlstyleelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlstyleelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">3.3.1. Processing the fragment directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">3.3.1. Processing the fragment directive</a>
     <li><a href="#ref-for-nav-document①">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-nav-document②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-concept-document-bc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-set">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context-set" class="dfn-panel" data-for="term-for-browsing-context-set" id="infopanel-for-term-for-browsing-context-set" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context-set" style="display:none">Info about the 'browsing context set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-set">3.4.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-language">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-language" class="dfn-panel" data-for="term-for-language" id="infopanel-for-term-for-language" role="menu">
+   <span id="infopaneltitle-for-term-for-language" style="display:none">Info about the 'language' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-language">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-language①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-entry">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-entry" class="dfn-panel" data-for="term-for-latest-entry" id="infopanel-for-term-for-latest-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-entry" style="display:none">Info about the 'latest entry' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry">https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-entry">3.4.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-select-multiple">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-select-multiple" class="dfn-panel" data-for="term-for-attr-select-multiple" id="infopanel-for-term-for-attr-select-multiple" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-select-multiple" style="display:none">Info about the 'multiple' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple">https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-multiple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-select-multiple">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-restore-persisted-state">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state">https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-restore-persisted-state" class="dfn-panel" data-for="term-for-restore-persisted-state" id="infopanel-for-term-for-restore-persisted-state" role="menu">
+   <span id="infopaneltitle-for-term-for-restore-persisted-state" style="display:none">Info about the 'restore persisted state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state">https://html.spec.whatwg.org/multipage/browsing-the-web.html#restore-persisted-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-restore-persisted-state">3.7. Document Policy Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-to-the-fragment-identifier" class="dfn-panel" data-for="term-for-scroll-to-the-fragment-identifier" id="infopanel-for-term-for-scroll-to-the-fragment-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-to-the-fragment-identifier" style="display:none">Info about the 'scroll to the fragment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier">https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-to-the-fragment-identifier">3.4.4. Restricting the Text Fragment</a>
     <li><a href="#ref-for-scroll-to-the-fragment-identifier①">3.5. Navigating to a Text Fragment</a> <a href="#ref-for-scroll-to-the-fragment-identifier②">(2)</a>
     <li><a href="#ref-for-scroll-to-the-fragment-identifier③">3.7. Document Policy Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-select-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-select-element" class="dfn-panel" data-for="term-for-the-select-element" id="infopanel-for-term-for-the-select-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-select-element" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-select-element">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serializes-as-void">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void">https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serializes-as-void" class="dfn-panel" data-for="term-for-serializes-as-void" id="infopanel-for-term-for-serializes-as-void" role="menu">
+   <span id="infopaneltitle-for-term-for-serializes-as-void" style="display:none">Info about the 'serializes as void' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void">https://html.spec.whatwg.org/multipage/parsing.html#serializes-as-void</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializes-as-void">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3.4.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">3.4.4. Restricting the Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-try-to-scroll-to-the-fragment">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-try-to-scroll-to-the-fragment" class="dfn-panel" data-for="term-for-try-to-scroll-to-the-fragment" id="infopanel-for-term-for-try-to-scroll-to-the-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-try-to-scroll-to-the-fragment" style="display:none">Info about the 'try to scroll to the fragment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment">https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-try-to-scroll-to-the-fragment">3.4.4. Restricting the Text Fragment</a>
     <li><a href="#ref-for-try-to-scroll-to-the-fragment①">3.6. Indicating The Text Match</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-ascii-string①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-ascii-string②">(2)</a> <a href="#ref-for-ascii-string③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-assert①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-assert②">(2)</a> <a href="#ref-for-assert③">(3)</a> <a href="#ref-for-assert④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-iteration-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenate' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a> <a href="#ref-for-iteration-continue⑤">(6)</a> <a href="#ref-for-iteration-continue⑥">(7)</a> <a href="#ref-for-iteration-continue⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-string-length①">(2)</a> <a href="#ref-for-string-length②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-list①">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-list②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a> <a href="#ref-for-list⑦">(6)</a> <a href="#ref-for-list⑧">(7)</a> <a href="#ref-for-list⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-commas">
-   <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-commas" class="dfn-panel" data-for="term-for-split-on-commas" id="infopanel-for-term-for-split-on-commas" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-commas" style="display:none">Info about the 'split on commas' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-commas">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split a string' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3.5.2. Finding Ranges in a Document</a>
     <li><a href="#ref-for-string①">3.5.3. Word Boundaries</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3.3.2. Parsing the fragment directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-concept-url-fragment①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url-fragment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-percent-decode">
-   <a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-percent-decode" class="dfn-panel" data-for="term-for-string-percent-decode" id="infopanel-for-term-for-string-percent-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-string-percent-decode" style="display:none">Info about the 'percent-decode' external reference.</span><a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-percent-decode">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-string-percent-decode①">(2)</a> <a href="#ref-for-string-percent-decode②">(3)</a> <a href="#ref-for-string-percent-decode③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3.3.1. Processing the fragment directive</a> <a href="#ref-for-concept-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-code-points">
-   <a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-code-points" class="dfn-panel" data-for="term-for-url-code-points" id="infopanel-for-term-for-url-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-url-code-points" style="display:none">Info about the 'url code point' external reference.</span><a href="https://url.spec.whatwg.org/#url-code-points">https://url.spec.whatwg.org/#url-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-code-points">3.3.3. Fragment directive grammar</a> <a href="#ref-for-url-code-points①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.8. Feature Detectability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.8. Feature Detectability</a>
    </ul>
@@ -3283,15 +3283,15 @@ correct here since that’s the text data as it exists in the DOM. This
 algorithm means to run over the text as rendered (and then convert back
 to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/issues/98">[Issue #WICG/scroll-to-text-fragment#98]</a> <a class="issue-return" href="#issue-96fe4755" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="fragment-directive-delimiter">
-   <b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment-directive-delimiter" class="dfn-panel" data-for="fragment-directive-delimiter" id="infopanel-for-fragment-directive-delimiter" role="dialog">
+   <span id="infopaneltitle-for-fragment-directive-delimiter" style="display:none">Info about the 'fragment directive delimiter' definition.</span><b><a href="#fragment-directive-delimiter">#fragment-directive-delimiter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive-delimiter">3.3. The Fragment Directive</a>
     <li><a href="#ref-for-fragment-directive-delimiter①">3.3.1. Processing the fragment directive</a> <a href="#ref-for-fragment-directive-delimiter②">(2)</a> <a href="#ref-for-fragment-directive-delimiter③">(3)</a> <a href="#ref-for-fragment-directive-delimiter④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-directive">
-   <b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment-directive" class="dfn-panel" data-for="fragment-directive" id="infopanel-for-fragment-directive" role="dialog">
+   <span id="infopaneltitle-for-fragment-directive" style="display:none">Info about the 'fragment directive' definition.</span><b><a href="#fragment-directive">#fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-directive">3.2. Syntax</a>
     <li><a href="#ref-for-fragment-directive①">3.3. The Fragment Directive</a> <a href="#ref-for-fragment-directive②">(2)</a> <a href="#ref-for-fragment-directive③">(3)</a> <a href="#ref-for-fragment-directive④">(4)</a>
@@ -3305,85 +3305,85 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-fragment-directive②①">3.6.1.3. Sharing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-and-consume-fragment-directive">
-   <b><a href="#process-and-consume-fragment-directive">#process-and-consume-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-and-consume-fragment-directive" class="dfn-panel" data-for="process-and-consume-fragment-directive" id="infopanel-for-process-and-consume-fragment-directive" role="dialog">
+   <span id="infopaneltitle-for-process-and-consume-fragment-directive" style="display:none">Info about the 'process and consume fragment directive' definition.</span><b><a href="#process-and-consume-fragment-directive">#process-and-consume-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-and-consume-fragment-directive">3.3.1. Processing the fragment directive</a> <a href="#ref-for-process-and-consume-fragment-directive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsedtextdirective">
-   <b><a href="#parsedtextdirective">#parsedtextdirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsedtextdirective" class="dfn-panel" data-for="parsedtextdirective" id="infopanel-for-parsedtextdirective" role="dialog">
+   <span id="infopaneltitle-for-parsedtextdirective" style="display:none">Info about the 'ParsedTextDirective' definition.</span><b><a href="#parsedtextdirective">#parsedtextdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective①">(2)</a>
     <li><a href="#ref-for-parsedtextdirective②">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsedtextdirective-textstart">
-   <b><a href="#parsedtextdirective-textstart">#parsedtextdirective-textstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsedtextdirective-textstart" class="dfn-panel" data-for="parsedtextdirective-textstart" id="infopanel-for-parsedtextdirective-textstart" role="dialog">
+   <span id="infopaneltitle-for-parsedtextdirective-textstart" style="display:none">Info about the 'textStart' definition.</span><b><a href="#parsedtextdirective-textstart">#parsedtextdirective-textstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective-textstart">3.3.2. Parsing the fragment directive</a> <a href="#ref-for-parsedtextdirective-textstart①">(2)</a>
     <li><a href="#ref-for-parsedtextdirective-textstart②">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textstart③">(2)</a> <a href="#ref-for-parsedtextdirective-textstart④">(3)</a> <a href="#ref-for-parsedtextdirective-textstart⑤">(4)</a> <a href="#ref-for-parsedtextdirective-textstart⑥">(5)</a> <a href="#ref-for-parsedtextdirective-textstart⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsedtextdirective-textend">
-   <b><a href="#parsedtextdirective-textend">#parsedtextdirective-textend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsedtextdirective-textend" class="dfn-panel" data-for="parsedtextdirective-textend" id="infopanel-for-parsedtextdirective-textend" role="dialog">
+   <span id="infopaneltitle-for-parsedtextdirective-textend" style="display:none">Info about the 'textEnd' definition.</span><b><a href="#parsedtextdirective-textend">#parsedtextdirective-textend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective-textend">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-textend①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-textend②">(2)</a> <a href="#ref-for-parsedtextdirective-textend③">(3)</a> <a href="#ref-for-parsedtextdirective-textend④">(4)</a> <a href="#ref-for-parsedtextdirective-textend⑤">(5)</a> <a href="#ref-for-parsedtextdirective-textend⑥">(6)</a> <a href="#ref-for-parsedtextdirective-textend⑦">(7)</a> <a href="#ref-for-parsedtextdirective-textend⑧">(8)</a> <a href="#ref-for-parsedtextdirective-textend⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsedtextdirective-prefix">
-   <b><a href="#parsedtextdirective-prefix">#parsedtextdirective-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsedtextdirective-prefix" class="dfn-panel" data-for="parsedtextdirective-prefix" id="infopanel-for-parsedtextdirective-prefix" role="dialog">
+   <span id="infopaneltitle-for-parsedtextdirective-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#parsedtextdirective-prefix">#parsedtextdirective-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective-prefix">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-prefix①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-prefix②">(2)</a> <a href="#ref-for-parsedtextdirective-prefix③">(3)</a> <a href="#ref-for-parsedtextdirective-prefix④">(4)</a> <a href="#ref-for-parsedtextdirective-prefix⑤">(5)</a> <a href="#ref-for-parsedtextdirective-prefix⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsedtextdirective-suffix">
-   <b><a href="#parsedtextdirective-suffix">#parsedtextdirective-suffix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsedtextdirective-suffix" class="dfn-panel" data-for="parsedtextdirective-suffix" id="infopanel-for-parsedtextdirective-suffix" role="dialog">
+   <span id="infopaneltitle-for-parsedtextdirective-suffix" style="display:none">Info about the 'suffix' definition.</span><b><a href="#parsedtextdirective-suffix">#parsedtextdirective-suffix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsedtextdirective-suffix">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-parsedtextdirective-suffix①">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-parsedtextdirective-suffix②">(2)</a> <a href="#ref-for-parsedtextdirective-suffix③">(3)</a> <a href="#ref-for-parsedtextdirective-suffix④">(4)</a> <a href="#ref-for-parsedtextdirective-suffix⑤">(5)</a> <a href="#ref-for-parsedtextdirective-suffix⑥">(6)</a> <a href="#ref-for-parsedtextdirective-suffix⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-text-directive">
-   <b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-text-directive" class="dfn-panel" data-for="parse-a-text-directive" id="infopanel-for-parse-a-text-directive" role="dialog">
+   <span id="infopaneltitle-for-parse-a-text-directive" style="display:none">Info about the 'parse a text directive' definition.</span><b><a href="#parse-a-text-directive">#parse-a-text-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-text-directive">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-fragment-directive">
-   <b><a href="#valid-fragment-directive">#valid-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-fragment-directive" class="dfn-panel" data-for="valid-fragment-directive" id="infopanel-for-valid-fragment-directive" role="dialog">
+   <span id="infopaneltitle-for-valid-fragment-directive" style="display:none">Info about the 'valid fragment directive' definition.</span><b><a href="#valid-fragment-directive">#valid-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-fragment-directive">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentdirectiveproduction">
-   <b><a href="#fragmentdirectiveproduction">#fragmentdirectiveproduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentdirectiveproduction" class="dfn-panel" data-for="fragmentdirectiveproduction" id="infopanel-for-fragmentdirectiveproduction" role="dialog">
+   <span id="infopaneltitle-for-fragmentdirectiveproduction" style="display:none">Info about the 'FragmentDirective' definition.</span><b><a href="#fragmentdirectiveproduction">#fragmentdirectiveproduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentdirectiveproduction">3.3.3. Fragment directive grammar</a> <a href="#ref-for-fragmentdirectiveproduction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unknowndirective">
-   <b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unknowndirective" class="dfn-panel" data-for="unknowndirective" id="infopanel-for-unknowndirective" role="dialog">
+   <span id="infopaneltitle-for-unknowndirective" style="display:none">Info about the 'UnknownDirective' definition.</span><b><a href="#unknowndirective">#unknowndirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknowndirective">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characterstring">
-   <b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characterstring" class="dfn-panel" data-for="characterstring" id="infopanel-for-characterstring" role="dialog">
+   <span id="infopaneltitle-for-characterstring" style="display:none">Info about the 'CharacterString' definition.</span><b><a href="#characterstring">#characterstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characterstring">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicitchar">
-   <b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicitchar" class="dfn-panel" data-for="explicitchar" id="infopanel-for-explicitchar" role="dialog">
+   <span id="infopaneltitle-for-explicitchar" style="display:none">Info about the 'ExplicitChar' definition.</span><b><a href="#explicitchar">#explicitchar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-explicitchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-fragment-directive">
-   <b><a href="#text-fragment-directive">#text-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-fragment-directive" class="dfn-panel" data-for="text-fragment-directive" id="infopanel-for-text-fragment-directive" role="dialog">
+   <span id="infopaneltitle-for-text-fragment-directive" style="display:none">Info about the 'text fragment directive' definition.</span><b><a href="#text-fragment-directive">#text-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-fragment-directive">3.2. Syntax</a>
     <li><a href="#ref-for-text-fragment-directive①">3.4.1. Motivation</a> <a href="#ref-for-text-fragment-directive②">(2)</a>
@@ -3394,248 +3394,305 @@ to Ranges in the DOM). <a href="https://github.com/WICG/scroll-to-text-fragment/
     <li><a href="#ref-for-text-fragment-directive⑨">4.3. Determine If Fragment Id Is Needed</a> <a href="#ref-for-text-fragment-directive①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirective">
-   <b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirective" class="dfn-panel" data-for="textdirective" id="infopanel-for-textdirective" role="dialog">
+   <span id="infopaneltitle-for-textdirective" style="display:none">Info about the 'TextDirective' definition.</span><b><a href="#textdirective">#textdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirective">3.3.2. Parsing the fragment directive</a>
     <li><a href="#ref-for-textdirective①">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirective②">(2)</a>
     <li><a href="#ref-for-textdirective③">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirectiveparameters">
-   <b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveparameters" class="dfn-panel" data-for="textdirectiveparameters" id="infopanel-for-textdirectiveparameters" role="dialog">
+   <span id="infopaneltitle-for-textdirectiveparameters" style="display:none">Info about the 'TextDirectiveParameters' definition.</span><b><a href="#textdirectiveparameters">#textdirectiveparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirectiveparameters">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirectiveprefix">
-   <b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveprefix" class="dfn-panel" data-for="textdirectiveprefix" id="infopanel-for-textdirectiveprefix" role="dialog">
+   <span id="infopaneltitle-for-textdirectiveprefix" style="display:none">Info about the 'TextDirectivePrefix' definition.</span><b><a href="#textdirectiveprefix">#textdirectiveprefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirectiveprefix">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirectivesuffix">
-   <b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirectivesuffix" class="dfn-panel" data-for="textdirectivesuffix" id="infopanel-for-textdirectivesuffix" role="dialog">
+   <span id="infopaneltitle-for-textdirectivesuffix" style="display:none">Info about the 'TextDirectiveSuffix' definition.</span><b><a href="#textdirectivesuffix">#textdirectivesuffix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirectivesuffix">3.3.3. Fragment directive grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirectivestring">
-   <b><a href="#textdirectivestring">#textdirectivestring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirectivestring" class="dfn-panel" data-for="textdirectivestring" id="infopanel-for-textdirectivestring" role="dialog">
+   <span id="infopaneltitle-for-textdirectivestring" style="display:none">Info about the 'TextDirectiveString' definition.</span><b><a href="#textdirectivestring">#textdirectivestring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirectivestring">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectivestring①">(2)</a> <a href="#ref-for-textdirectivestring②">(3)</a> <a href="#ref-for-textdirectivestring③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdirectiveexplicitchar">
-   <b><a href="#textdirectiveexplicitchar">#textdirectiveexplicitchar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdirectiveexplicitchar" class="dfn-panel" data-for="textdirectiveexplicitchar" id="infopanel-for-textdirectiveexplicitchar" role="dialog">
+   <span id="infopaneltitle-for-textdirectiveexplicitchar" style="display:none">Info about the 'TextDirectiveExplicitChar' definition.</span><b><a href="#textdirectiveexplicitchar">#textdirectiveexplicitchar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdirectiveexplicitchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-textdirectiveexplicitchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percentencodedchar">
-   <b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percentencodedchar" class="dfn-panel" data-for="percentencodedchar" id="infopanel-for-percentencodedchar" role="dialog">
+   <span id="infopaneltitle-for-percentencodedchar" style="display:none">Info about the 'PercentEncodedChar' definition.</span><b><a href="#percentencodedchar">#percentencodedchar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentencodedchar">3.3.3. Fragment directive grammar</a> <a href="#ref-for-percentencodedchar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-textfragmenttoken">
-   <b><a href="#request-textfragmenttoken">#request-textfragmenttoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-textfragmenttoken" class="dfn-panel" data-for="request-textfragmenttoken" id="infopanel-for-request-textfragmenttoken" role="dialog">
+   <span id="infopaneltitle-for-request-textfragmenttoken" style="display:none">Info about the 'textFragmentToken' definition.</span><b><a href="#request-textfragmenttoken">#request-textfragmenttoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-request-textfragmenttoken①">(2)</a> <a href="#ref-for-request-textfragmenttoken②">(3)</a> <a href="#ref-for-request-textfragmenttoken③">(4)</a> <a href="#ref-for-request-textfragmenttoken④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-textfragmenttoken">
-   <b><a href="#document-textfragmenttoken">#document-textfragmenttoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-textfragmenttoken" class="dfn-panel" data-for="document-textfragmenttoken" id="infopanel-for-document-textfragmenttoken" role="dialog">
+   <span id="infopaneltitle-for-document-textfragmenttoken" style="display:none">Info about the 'textFragmentToken' definition.</span><b><a href="#document-textfragmenttoken">#document-textfragmenttoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-textfragmenttoken">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-textfragmenttoken①">(2)</a> <a href="#ref-for-document-textfragmenttoken②">(3)</a> <a href="#ref-for-document-textfragmenttoken③">(4)</a> <a href="#ref-for-document-textfragmenttoken④">(5)</a> <a href="#ref-for-document-textfragmenttoken⑤">(6)</a> <a href="#ref-for-document-textfragmenttoken⑥">(7)</a> <a href="#ref-for-document-textfragmenttoken⑦">(8)</a> <a href="#ref-for-document-textfragmenttoken⑧">(9)</a> <a href="#ref-for-document-textfragmenttoken⑨">(10)</a> <a href="#ref-for-document-textfragmenttoken①⓪">(11)</a> <a href="#ref-for-document-textfragmenttoken①①">(12)</a> <a href="#ref-for-document-textfragmenttoken①②">(13)</a> <a href="#ref-for-document-textfragmenttoken①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-allowtextfragmentdirective">
-   <b><a href="#document-allowtextfragmentdirective">#document-allowtextfragmentdirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-allowtextfragmentdirective" class="dfn-panel" data-for="document-allowtextfragmentdirective" id="infopanel-for-document-allowtextfragmentdirective" role="dialog">
+   <span id="infopaneltitle-for-document-allowtextfragmentdirective" style="display:none">Info about the 'allowTextFragmentDirective' definition.</span><b><a href="#document-allowtextfragmentdirective">#document-allowtextfragmentdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-allowtextfragmentdirective">3.4.4. Restricting the Text Fragment</a> <a href="#ref-for-document-allowtextfragmentdirective①">(2)</a> <a href="#ref-for-document-allowtextfragmentdirective②">(3)</a> <a href="#ref-for-document-allowtextfragmentdirective③">(4)</a> <a href="#ref-for-document-allowtextfragmentdirective④">(5)</a> <a href="#ref-for-document-allowtextfragmentdirective⑤">(6)</a> <a href="#ref-for-document-allowtextfragmentdirective⑥">(7)</a> <a href="#ref-for-document-allowtextfragmentdirective⑦">(8)</a> <a href="#ref-for-document-allowtextfragmentdirective⑧">(9)</a> <a href="#ref-for-document-allowtextfragmentdirective⑨">(10)</a> <a href="#ref-for-document-allowtextfragmentdirective①⓪">(11)</a>
     <li><a href="#ref-for-document-allowtextfragmentdirective①①">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-common-ancestor">
-   <b><a href="#first-common-ancestor">#first-common-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-common-ancestor" class="dfn-panel" data-for="first-common-ancestor" id="infopanel-for-first-common-ancestor" role="dialog">
+   <span id="infopaneltitle-for-first-common-ancestor" style="display:none">Info about the 'first common ancestor' definition.</span><b><a href="#first-common-ancestor">#first-common-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-common-ancestor">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadow-including-parent">
-   <b><a href="#shadow-including-parent">#shadow-including-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadow-including-parent" class="dfn-panel" data-for="shadow-including-parent" id="infopanel-for-shadow-including-parent" role="dialog">
+   <span id="infopaneltitle-for-shadow-including-parent" style="display:none">Info about the 'shadow-including parent' definition.</span><b><a href="#shadow-including-parent">#shadow-including-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-including-parent">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-a-domrect-into-view">
-   <b><a href="#scroll-a-domrect-into-view">#scroll-a-domrect-into-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-a-domrect-into-view" class="dfn-panel" data-for="scroll-a-domrect-into-view" id="infopanel-for-scroll-a-domrect-into-view" role="dialog">
+   <span id="infopaneltitle-for-scroll-a-domrect-into-view" style="display:none">Info about the 'scroll a DOMRect into view' definition.</span><b><a href="#scroll-a-domrect-into-view">#scroll-a-domrect-into-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-a-domrect-into-view">3.5.1. Scroll a DOMRect into view</a> <a href="#ref-for-scroll-a-domrect-into-view①">(2)</a> <a href="#ref-for-scroll-a-domrect-into-view②">(3)</a> <a href="#ref-for-scroll-a-domrect-into-view③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-a-range-into-view">
-   <b><a href="#scroll-a-range-into-view">#scroll-a-range-into-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-a-range-into-view" class="dfn-panel" data-for="scroll-a-range-into-view" id="infopanel-for-scroll-a-range-into-view" role="dialog">
+   <span id="infopaneltitle-for-scroll-a-range-into-view" style="display:none">Info about the 'scroll a Range into view' definition.</span><b><a href="#scroll-a-range-into-view">#scroll-a-range-into-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-a-range-into-view">3.5. Navigating to a Text Fragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-a-fragment-directive">
-   <b><a href="#process-a-fragment-directive">#process-a-fragment-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-a-fragment-directive" class="dfn-panel" data-for="process-a-fragment-directive" id="infopanel-for-process-a-fragment-directive" role="dialog">
+   <span id="infopaneltitle-for-process-a-fragment-directive" style="display:none">Info about the 'process a fragment directive' definition.</span><b><a href="#process-a-fragment-directive">#process-a-fragment-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-a-fragment-directive">3.5. Navigating to a Text Fragment</a>
     <li><a href="#ref-for-process-a-fragment-directive①">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-a-range-from-a-text-directive">
-   <b><a href="#find-a-range-from-a-text-directive">#find-a-range-from-a-text-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-a-range-from-a-text-directive" class="dfn-panel" data-for="find-a-range-from-a-text-directive" id="infopanel-for-find-a-range-from-a-text-directive" role="dialog">
+   <span id="infopaneltitle-for-find-a-range-from-a-text-directive" style="display:none">Info about the 'find a range from a text directive' definition.</span><b><a href="#find-a-range-from-a-text-directive">#find-a-range-from-a-text-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-a-range-from-a-text-directive">3.4.3. Search Timing</a>
     <li><a href="#ref-for-find-a-range-from-a-text-directive①">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-non-whitespace-position">
-   <b><a href="#next-non-whitespace-position">#next-non-whitespace-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-non-whitespace-position" class="dfn-panel" data-for="next-non-whitespace-position" id="infopanel-for-next-non-whitespace-position" role="dialog">
+   <span id="infopaneltitle-for-next-non-whitespace-position" style="display:none">Info about the 'next
+non-whitespace position' definition.</span><b><a href="#next-non-whitespace-position">#next-non-whitespace-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-non-whitespace-position">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-next-non-whitespace-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-a-string-in-range">
-   <b><a href="#find-a-string-in-range">#find-a-string-in-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-a-string-in-range" class="dfn-panel" data-for="find-a-string-in-range" id="infopanel-for-find-a-string-in-range" role="dialog">
+   <span id="infopaneltitle-for-find-a-string-in-range" style="display:none">Info about the 'find a string in range' definition.</span><b><a href="#find-a-string-in-range">#find-a-string-in-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-a-string-in-range">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-find-a-string-in-range①">(2)</a> <a href="#ref-for-find-a-string-in-range②">(3)</a> <a href="#ref-for-find-a-string-in-range③">(4)</a> <a href="#ref-for-find-a-string-in-range④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="search-invisible">
-   <b><a href="#search-invisible">#search-invisible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-search-invisible" class="dfn-panel" data-for="search-invisible" id="infopanel-for-search-invisible" role="dialog">
+   <span id="infopaneltitle-for-search-invisible" style="display:none">Info about the 'search invisible' definition.</span><b><a href="#search-invisible">#search-invisible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-search-invisible">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-search-invisible①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-searchable-subtree">
-   <b><a href="#non-searchable-subtree">#non-searchable-subtree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-searchable-subtree" class="dfn-panel" data-for="non-searchable-subtree" id="infopanel-for-non-searchable-subtree" role="dialog">
+   <span id="infopaneltitle-for-non-searchable-subtree" style="display:none">Info about the 'non-searchable subtree' definition.</span><b><a href="#non-searchable-subtree">#non-searchable-subtree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-searchable-subtree">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-non-searchable-subtree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visible-text-node">
-   <b><a href="#visible-text-node">#visible-text-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visible-text-node" class="dfn-panel" data-for="visible-text-node" id="infopanel-for-visible-text-node" role="dialog">
+   <span id="infopaneltitle-for-visible-text-node" style="display:none">Info about the 'visible text node' definition.</span><b><a href="#visible-text-node">#visible-text-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-text-node">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-visible-text-node①">(2)</a> <a href="#ref-for-visible-text-node②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-block-level-display">
-   <b><a href="#has-block-level-display">#has-block-level-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-block-level-display" class="dfn-panel" data-for="has-block-level-display" id="infopanel-for-has-block-level-display" role="dialog">
+   <span id="infopaneltitle-for-has-block-level-display" style="display:none">Info about the 'has block-level display' definition.</span><b><a href="#has-block-level-display">#has-block-level-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-block-level-display">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-has-block-level-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nearest-block-ancestor">
-   <b><a href="#nearest-block-ancestor">#nearest-block-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nearest-block-ancestor" class="dfn-panel" data-for="nearest-block-ancestor" id="infopanel-for-nearest-block-ancestor" role="dialog">
+   <span id="infopaneltitle-for-nearest-block-ancestor" style="display:none">Info about the 'nearest block ancestor' definition.</span><b><a href="#nearest-block-ancestor">#nearest-block-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nearest-block-ancestor">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-a-range-from-a-node-list">
-   <b><a href="#find-a-range-from-a-node-list">#find-a-range-from-a-node-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-a-range-from-a-node-list" class="dfn-panel" data-for="find-a-range-from-a-node-list" id="infopanel-for-find-a-range-from-a-node-list" role="dialog">
+   <span id="infopaneltitle-for-find-a-range-from-a-node-list" style="display:none">Info about the 'find a range from a node list' definition.</span><b><a href="#find-a-range-from-a-node-list">#find-a-range-from-a-node-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-a-range-from-a-node-list">3.5.2. Finding Ranges in a Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-boundary-point-at-index">
-   <b><a href="#get-boundary-point-at-index">#get-boundary-point-at-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-boundary-point-at-index" class="dfn-panel" data-for="get-boundary-point-at-index" id="infopanel-for-get-boundary-point-at-index" role="dialog">
+   <span id="infopaneltitle-for-get-boundary-point-at-index" style="display:none">Info about the 'get boundary point at index' definition.</span><b><a href="#get-boundary-point-at-index">#get-boundary-point-at-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-boundary-point-at-index">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-get-boundary-point-at-index①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="word-boundary">
-   <b><a href="#word-boundary">#word-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-word-boundary" class="dfn-panel" data-for="word-boundary" id="infopanel-for-word-boundary" role="dialog">
+   <span id="infopaneltitle-for-word-boundary" style="display:none">Info about the 'word boundary' definition.</span><b><a href="#word-boundary">#word-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-word-boundary">3.5.2. Finding Ranges in a Document</a>
     <li><a href="#ref-for-word-boundary①">3.5.3. Word Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="locale">
-   <b><a href="#locale">#locale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-locale" class="dfn-panel" data-for="locale" id="infopanel-for-locale" role="dialog">
+   <span id="infopaneltitle-for-locale" style="display:none">Info about the 'locale' definition.</span><b><a href="#locale">#locale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-locale">3.5.3. Word Boundaries</a> <a href="#ref-for-locale①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="word-bounded">
-   <b><a href="#word-bounded">#word-bounded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-word-bounded" class="dfn-panel" data-for="word-bounded" id="infopanel-for-word-bounded" role="dialog">
+   <span id="infopaneltitle-for-word-bounded" style="display:none">Info about the 'word bounded' definition.</span><b><a href="#word-bounded">#word-bounded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-word-bounded">3.5.3. Word Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-at-a-word-boundary">
-   <b><a href="#is-at-a-word-boundary">#is-at-a-word-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-at-a-word-boundary" class="dfn-panel" data-for="is-at-a-word-boundary" id="infopanel-for-is-at-a-word-boundary" role="dialog">
+   <span id="infopaneltitle-for-is-at-a-word-boundary" style="display:none">Info about the 'is at a word boundary' definition.</span><b><a href="#is-at-a-word-boundary">#is-at-a-word-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-at-a-word-boundary">3.5.2. Finding Ranges in a Document</a> <a href="#ref-for-is-at-a-word-boundary①">(2)</a>
     <li><a href="#ref-for-is-at-a-word-boundary②">3.5.3. Word Boundaries</a> <a href="#ref-for-is-at-a-word-boundary③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentdirective">
-   <b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentdirective" class="dfn-panel" data-for="fragmentdirective" id="infopanel-for-fragmentdirective" role="dialog">
+   <span id="infopaneltitle-for-fragmentdirective" style="display:none">Info about the 'FragmentDirective' definition.</span><b><a href="#fragmentdirective">#fragmentdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentdirective">3.8. Feature Detectability</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/shape-detection-api/index-zh-cn.html
+++ b/tests/github/WICG/shape-detection-api/index-zh-cn.html
@@ -1216,45 +1216,45 @@ textDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
     </ul>
    <li><a href="#textdetector">TextDetector</a><span>, in § 2.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-Point2D">
-   <a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Point2D" class="dfn-panel" data-for="term-for-Point2D" id="infopanel-for-term-for-Point2D" role="menu">
+   <span id="infopaneltitle-for-term-for-Point2D" style="display:none">Info about the 'Point2D' external reference.</span><a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Point2D">2.3. 条形码识别API</a> <a href="#ref-for-Point2D①">(2)</a> <a href="#ref-for-Point2D②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrect">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrect" class="dfn-panel" data-for="term-for-domrect" id="infopanel-for-term-for-domrect" role="menu">
+   <span id="infopaneltitle-for-term-for-domrect" style="display:none">Info about the 'DOMRect' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">2.4. 文本识别API</a> <a href="#ref-for-domrect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.2. 人脸识别API</a> <a href="#ref-for-domrectreadonly①">(2)</a>
     <li><a href="#ref-for-domrectreadonly②">2.3. 条形码识别API</a> <a href="#ref-for-domrectreadonly③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlcanvaselement">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlcanvaselement" class="dfn-panel" data-for="term-for-htmlcanvaselement" id="infopanel-for-term-for-htmlcanvaselement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlcanvaselement" style="display:none">Info about the 'HTMLCanvasElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcanvaselement">2.1. 用于识别的图像源</a> <a href="#ref-for-htmlcanvaselement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">2.1. 用于识别的图像源</a> <a href="#ref-for-htmlimageelement①">(2)</a> <a href="#ref-for-htmlimageelement②">(3)</a> <a href="#ref-for-htmlimageelement③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">2.1. 用于识别的图像源</a> <a href="#ref-for-htmlvideoelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagebitmapsource">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagebitmapsource" class="dfn-panel" data-for="term-for-imagebitmapsource" id="infopanel-for-term-for-imagebitmapsource" role="menu">
+   <span id="infopaneltitle-for-term-for-imagebitmapsource" style="display:none">Info about the 'ImageBitmapSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagebitmapsource">2.1. 用于识别的图像源</a> <a href="#ref-for-imagebitmapsource①">(2)</a> <a href="#ref-for-imagebitmapsource②">(3)</a> <a href="#ref-for-imagebitmapsource③">(4)</a> <a href="#ref-for-imagebitmapsource④">(5)</a> <a href="#ref-for-imagebitmapsource⑤">(6)</a> <a href="#ref-for-imagebitmapsource⑥">(7)</a> <a href="#ref-for-imagebitmapsource⑦">(8)</a> <a href="#ref-for-imagebitmapsource⑧">(9)</a> <a href="#ref-for-imagebitmapsource⑨">(10)</a> <a href="#ref-for-imagebitmapsource①⓪">(11)</a> <a href="#ref-for-imagebitmapsource①①">(12)</a>
     <li><a href="#ref-for-imagebitmapsource①②">2.2. 人脸识别API</a> <a href="#ref-for-imagebitmapsource①③">(2)</a> <a href="#ref-for-imagebitmapsource①④">(3)</a>
@@ -1262,77 +1262,77 @@ textDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
     <li><a href="#ref-for-imagebitmapsource①⑧">2.4. 文本识别API</a> <a href="#ref-for-imagebitmapsource①⑨">(2)</a> <a href="#ref-for-imagebitmapsource②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.1. 用于识别的图像源</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.3. 条形码识别API</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">2.4. 文本识别API</a> <a href="#ref-for-idl-DOMString④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. 人脸识别API</a>
     <li><a href="#ref-for-Exposed①">2.3. 条形码识别API</a>
     <li><a href="#ref-for-Exposed②">2.4. 文本识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.3. 条形码识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.1. 用于识别的图像源</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.2. 人脸识别API</a>
     <li><a href="#ref-for-idl-promise①">2.3. 条形码识别API</a>
     <li><a href="#ref-for-idl-promise②">2.4. 文本识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.2. 人脸识别API</a>
     <li><a href="#ref-for-SameObject①">2.3. 条形码识别API</a> <a href="#ref-for-SameObject②">(2)</a> <a href="#ref-for-SameObject③">(3)</a>
     <li><a href="#ref-for-SameObject④">2.4. 文本识别API</a> <a href="#ref-for-SameObject⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.1. 用于识别的图像源</a> <a href="#ref-for-securityerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.2. 人脸识别API</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. 人脸识别API</a>
     <li><a href="#ref-for-idl-sequence①">2.3. 条形码识别API</a> <a href="#ref-for-idl-sequence②">(2)</a>
     <li><a href="#ref-for-idl-sequence③">2.4. 文本识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">2.2. 人脸识别API</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
    </ul>
@@ -1432,163 +1432,219 @@ textDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dictdef-facedetectoroptions">
-   <b><a href="#dictdef-facedetectoroptions">#dictdef-facedetectoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-facedetectoroptions" class="dfn-panel" data-for="dictdef-facedetectoroptions" id="infopanel-for-dictdef-facedetectoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-facedetectoroptions" style="display:none">Info about the 'FaceDetectorOptions' definition.</span><b><a href="#dictdef-facedetectoroptions">#dictdef-facedetectoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-facedetectoroptions">2.2. 人脸识别API</a> <a href="#ref-for-dictdef-facedetectoroptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetectoroptions-maxdetectedfaces">
-   <b><a href="#dom-facedetectoroptions-maxdetectedfaces">#dom-facedetectoroptions-maxdetectedfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetectoroptions-maxdetectedfaces" class="dfn-panel" data-for="dom-facedetectoroptions-maxdetectedfaces" id="infopanel-for-dom-facedetectoroptions-maxdetectedfaces" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetectoroptions-maxdetectedfaces" style="display:none">Info about the 'maxDetectedFaces' definition.</span><b><a href="#dom-facedetectoroptions-maxdetectedfaces">#dom-facedetectoroptions-maxdetectedfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetectoroptions-maxdetectedfaces">2.2. 人脸识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetectoroptions-fastmode">
-   <b><a href="#dom-facedetectoroptions-fastmode">#dom-facedetectoroptions-fastmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetectoroptions-fastmode" class="dfn-panel" data-for="dom-facedetectoroptions-fastmode" id="infopanel-for-dom-facedetectoroptions-fastmode" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetectoroptions-fastmode" style="display:none">Info about the 'fastMode' definition.</span><b><a href="#dom-facedetectoroptions-fastmode">#dom-facedetectoroptions-fastmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetectoroptions-fastmode">2.2. 人脸识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="facedetector">
-   <b><a href="#facedetector">#facedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-facedetector" class="dfn-panel" data-for="facedetector" id="infopanel-for-facedetector" role="dialog">
+   <span id="infopaneltitle-for-facedetector" style="display:none">Info about the 'FaceDetector' definition.</span><b><a href="#facedetector">#facedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-facedetector">2.2. 人脸识别API</a> <a href="#ref-for-facedetector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetector-detect">
-   <b><a href="#dom-facedetector-detect">#dom-facedetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetector-detect" class="dfn-panel" data-for="dom-facedetector-detect" id="infopanel-for-dom-facedetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetector-detect" style="display:none">Info about the 'detect' definition.</span><b><a href="#dom-facedetector-detect">#dom-facedetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetector-detect">2.2. 人脸识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="detectedface">
-   <b><a href="#detectedface">#detectedface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-detectedface" class="dfn-panel" data-for="detectedface" id="infopanel-for-detectedface" role="dialog">
+   <span id="infopaneltitle-for-detectedface" style="display:none">Info about the 'DetectedFace' definition.</span><b><a href="#detectedface">#detectedface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-detectedface">2.2. 人脸识别API</a> <a href="#ref-for-detectedface①">(2)</a> <a href="#ref-for-detectedface②">(3)</a> <a href="#ref-for-detectedface③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedface-boundingbox">
-   <b><a href="#dom-detectedface-boundingbox">#dom-detectedface-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedface-boundingbox" class="dfn-panel" data-for="dom-detectedface-boundingbox" id="infopanel-for-dom-detectedface-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedface-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedface-boundingbox">#dom-detectedface-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedface-boundingbox">2.2. 人脸识别API</a> <a href="#ref-for-dom-detectedface-boundingbox①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="barcodedetector">
-   <b><a href="#barcodedetector">#barcodedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-barcodedetector" class="dfn-panel" data-for="barcodedetector" id="infopanel-for-barcodedetector" role="dialog">
+   <span id="infopaneltitle-for-barcodedetector" style="display:none">Info about the 'BarcodeDetector' definition.</span><b><a href="#barcodedetector">#barcodedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-barcodedetector">2.3. 条形码识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodedetector-detect">
-   <b><a href="#dom-barcodedetector-detect">#dom-barcodedetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodedetector-detect" class="dfn-panel" data-for="dom-barcodedetector-detect" id="infopanel-for-dom-barcodedetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodedetector-detect" style="display:none">Info about the 'detect(ImageBitmapSource image)' definition.</span><b><a href="#dom-barcodedetector-detect">#dom-barcodedetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodedetector-detect">2.3. 条形码识别API</a> <a href="#ref-for-dom-barcodedetector-detect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="detectedbarcode">
-   <b><a href="#detectedbarcode">#detectedbarcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-detectedbarcode" class="dfn-panel" data-for="detectedbarcode" id="infopanel-for-detectedbarcode" role="dialog">
+   <span id="infopaneltitle-for-detectedbarcode" style="display:none">Info about the 'DetectedBarcode' definition.</span><b><a href="#detectedbarcode">#detectedbarcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-detectedbarcode">2.3. 条形码识别API</a> <a href="#ref-for-detectedbarcode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-boundingbox">
-   <b><a href="#dom-detectedbarcode-boundingbox">#dom-detectedbarcode-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-boundingbox" class="dfn-panel" data-for="dom-detectedbarcode-boundingbox" id="infopanel-for-dom-detectedbarcode-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedbarcode-boundingbox">#dom-detectedbarcode-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-boundingbox">2.3. 条形码识别API</a> <a href="#ref-for-dom-detectedbarcode-boundingbox①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-rawvalue">
-   <b><a href="#dom-detectedbarcode-rawvalue">#dom-detectedbarcode-rawvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-rawvalue" class="dfn-panel" data-for="dom-detectedbarcode-rawvalue" id="infopanel-for-dom-detectedbarcode-rawvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-rawvalue" style="display:none">Info about the 'rawValue' definition.</span><b><a href="#dom-detectedbarcode-rawvalue">#dom-detectedbarcode-rawvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-rawvalue">2.3. 条形码识别API</a> <a href="#ref-for-dom-detectedbarcode-rawvalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-cornerpoints">
-   <b><a href="#dom-detectedbarcode-cornerpoints">#dom-detectedbarcode-cornerpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-cornerpoints" class="dfn-panel" data-for="dom-detectedbarcode-cornerpoints" id="infopanel-for-dom-detectedbarcode-cornerpoints" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-cornerpoints" style="display:none">Info about the 'cornerPoints' definition.</span><b><a href="#dom-detectedbarcode-cornerpoints">#dom-detectedbarcode-cornerpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-cornerpoints">2.3. 条形码识别API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdetector-detect">
-   <b><a href="#dom-textdetector-detect">#dom-textdetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdetector-detect" class="dfn-panel" data-for="dom-textdetector-detect" id="infopanel-for-dom-textdetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-textdetector-detect" style="display:none">Info about the 'detect(ImageBitmapSource image)' definition.</span><b><a href="#dom-textdetector-detect">#dom-textdetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdetector-detect">2.4. 文本识别API</a> <a href="#ref-for-dom-textdetector-detect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="detectedtext">
-   <b><a href="#detectedtext">#detectedtext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-detectedtext" class="dfn-panel" data-for="detectedtext" id="infopanel-for-detectedtext" role="dialog">
+   <span id="infopaneltitle-for-detectedtext" style="display:none">Info about the 'DetectedText' definition.</span><b><a href="#detectedtext">#detectedtext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-detectedtext">2.4. 文本识别API</a> <a href="#ref-for-detectedtext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedtext-boundingbox">
-   <b><a href="#dom-detectedtext-boundingbox">#dom-detectedtext-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedtext-boundingbox" class="dfn-panel" data-for="dom-detectedtext-boundingbox" id="infopanel-for-dom-detectedtext-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedtext-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedtext-boundingbox">#dom-detectedtext-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedtext-boundingbox">2.4. 文本识别API</a> <a href="#ref-for-dom-detectedtext-boundingbox①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedtext-rawvalue">
-   <b><a href="#dom-detectedtext-rawvalue">#dom-detectedtext-rawvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedtext-rawvalue" class="dfn-panel" data-for="dom-detectedtext-rawvalue" id="infopanel-for-dom-detectedtext-rawvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedtext-rawvalue" style="display:none">Info about the 'rawValue' definition.</span><b><a href="#dom-detectedtext-rawvalue">#dom-detectedtext-rawvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedtext-rawvalue">2.4. 文本识别API</a> <a href="#ref-for-dom-detectedtext-rawvalue①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/shape-detection-api/index.html
+++ b/tests/github/WICG/shape-detection-api/index.html
@@ -1399,156 +1399,156 @@ barcodeDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
    <li><a href="#dom-barcodeformat-upc_e">"upc_e"</a><span>, in § 2.3.3</span>
    <li><a href="#dom-barcodeformat-upc_e">upc_e</a><span>, in § 2.3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-Point2D">
-   <a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Point2D" class="dfn-panel" data-for="term-for-Point2D" id="infopanel-for-term-for-Point2D" role="menu">
+   <span id="infopaneltitle-for-term-for-Point2D" style="display:none">Info about the 'Point2D' external reference.</span><a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Point2D">2.2.2. DetectedFace</a> <a href="#ref-for-Point2D①">(2)</a>
     <li><a href="#ref-for-Point2D②">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-Point2D③">2.3.2. DetectedBarcode</a> <a href="#ref-for-Point2D④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-objects" class="dfn-panel" data-for="term-for-sec-array-objects" id="infopanel-for-term-for-sec-array-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-objects" style="display:none">Info about the 'Array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-objects">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'Promise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">2.3. Barcode Detection API</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.2.2. DetectedFace</a> <a href="#ref-for-domrectreadonly①">(2)</a>
     <li><a href="#ref-for-domrectreadonly②">2.3.2. DetectedBarcode</a> <a href="#ref-for-domrectreadonly③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-have_metadata">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_metadata">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-have_metadata" class="dfn-panel" data-for="term-for-dom-media-have_metadata" id="infopanel-for-term-for-dom-media-have_metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-have_metadata" style="display:none">Info about the 'HAVE_METADATA' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_metadata">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-have_metadata">2.1. Image sources for detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-have_nothing">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-have_nothing" class="dfn-panel" data-for="term-for-dom-media-have_nothing" id="infopanel-for-term-for-dom-media-have_nothing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-have_nothing" style="display:none">Info about the 'HAVE_NOTHING' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-have_nothing">2.1. Image sources for detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlcanvaselement">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlcanvaselement" class="dfn-panel" data-for="term-for-htmlcanvaselement" id="infopanel-for-term-for-htmlcanvaselement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlcanvaselement" style="display:none">Info about the 'HTMLCanvasElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcanvaselement">2.1. Image sources for detection</a> <a href="#ref-for-htmlcanvaselement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">2.1. Image sources for detection</a> <a href="#ref-for-htmlimageelement①">(2)</a> <a href="#ref-for-htmlimageelement②">(3)</a> <a href="#ref-for-htmlimageelement③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">2.1. Image sources for detection</a> <a href="#ref-for-htmlvideoelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagebitmapsource">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagebitmapsource" class="dfn-panel" data-for="term-for-imagebitmapsource" id="infopanel-for-term-for-imagebitmapsource" role="menu">
+   <span id="infopaneltitle-for-term-for-imagebitmapsource" style="display:none">Info about the 'ImageBitmapSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagebitmapsource">2.1. Image sources for detection</a> <a href="#ref-for-imagebitmapsource①">(2)</a> <a href="#ref-for-imagebitmapsource②">(3)</a> <a href="#ref-for-imagebitmapsource③">(4)</a> <a href="#ref-for-imagebitmapsource④">(5)</a> <a href="#ref-for-imagebitmapsource⑤">(6)</a> <a href="#ref-for-imagebitmapsource⑥">(7)</a> <a href="#ref-for-imagebitmapsource⑦">(8)</a> <a href="#ref-for-imagebitmapsource⑧">(9)</a> <a href="#ref-for-imagebitmapsource⑨">(10)</a> <a href="#ref-for-imagebitmapsource①⓪">(11)</a> <a href="#ref-for-imagebitmapsource①①">(12)</a>
     <li><a href="#ref-for-imagebitmapsource①②">2.2. Face Detection API</a> <a href="#ref-for-imagebitmapsource①③">(2)</a> <a href="#ref-for-imagebitmapsource①④">(3)</a>
     <li><a href="#ref-for-imagebitmapsource①⑤">2.3. Barcode Detection API</a> <a href="#ref-for-imagebitmapsource①⑥">(2)</a> <a href="#ref-for-imagebitmapsource①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.1. Image sources for detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-readystate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-readystate" class="dfn-panel" data-for="term-for-dom-media-readystate" id="infopanel-for-term-for-dom-media-readystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-readystate" style="display:none">Info about the 'readyState' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-readystate">2.1. Image sources for detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.1. Image sources for detection</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-idl-DOMString①">2.3.2. DetectedBarcode</a> <a href="#ref-for-idl-DOMString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. Face Detection API</a>
     <li><a href="#ref-for-Exposed①">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.2.2. DetectedFace</a> <a href="#ref-for-idl-frozen-array①">(2)</a>
     <li><a href="#ref-for-idl-frozen-array②">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.1. Image sources for detection</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.2. Face Detection API</a>
     <li><a href="#ref-for-idl-promise①">2.3. Barcode Detection API</a> <a href="#ref-for-idl-promise②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.2. Face Detection API</a>
     <li><a href="#ref-for-SecureContext①">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.1. Image sources for detection</a> <a href="#ref-for-securityerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.2.1. FaceDetectorOptions</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. Face Detection API</a>
     <li><a href="#ref-for-idl-sequence①">2.2.2. DetectedFace</a>
@@ -1557,8 +1557,8 @@ barcodeDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
     <li><a href="#ref-for-idl-sequence⑤">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">2.2.1. FaceDetectorOptions</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
    </ul>
@@ -1717,179 +1717,179 @@ barcodeDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="facedetector">
-   <b><a href="#facedetector">#facedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-facedetector" class="dfn-panel" data-for="facedetector" id="infopanel-for-facedetector" role="dialog">
+   <span id="infopaneltitle-for-facedetector" style="display:none">Info about the 'FaceDetector' definition.</span><b><a href="#facedetector">#facedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-facedetector">2.2. Face Detection API</a> <a href="#ref-for-facedetector①">(2)</a> <a href="#ref-for-facedetector②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetector-facedetector">
-   <b><a href="#dom-facedetector-facedetector">#dom-facedetector-facedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetector-facedetector" class="dfn-panel" data-for="dom-facedetector-facedetector" id="infopanel-for-dom-facedetector-facedetector" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetector-facedetector" style="display:none">Info about the 'FaceDetector(optional FaceDetectorOptions faceDetectorOptions)' definition.</span><b><a href="#dom-facedetector-facedetector">#dom-facedetector-facedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetector-facedetector">2.2. Face Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetector-detect">
-   <b><a href="#dom-facedetector-detect">#dom-facedetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetector-detect" class="dfn-panel" data-for="dom-facedetector-detect" id="infopanel-for-dom-facedetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetector-detect" style="display:none">Info about the 'detect(ImageBitmapSource image)' definition.</span><b><a href="#dom-facedetector-detect">#dom-facedetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetector-detect">2.2. Face Detection API</a> <a href="#ref-for-dom-facedetector-detect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-facedetectoroptions">
-   <b><a href="#dictdef-facedetectoroptions">#dictdef-facedetectoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-facedetectoroptions" class="dfn-panel" data-for="dictdef-facedetectoroptions" id="infopanel-for-dictdef-facedetectoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-facedetectoroptions" style="display:none">Info about the 'FaceDetectorOptions' definition.</span><b><a href="#dictdef-facedetectoroptions">#dictdef-facedetectoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-facedetectoroptions">2.2. Face Detection API</a> <a href="#ref-for-dictdef-facedetectoroptions①">(2)</a>
     <li><a href="#ref-for-dictdef-facedetectoroptions②">2.2.1. FaceDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetectoroptions-maxdetectedfaces">
-   <b><a href="#dom-facedetectoroptions-maxdetectedfaces">#dom-facedetectoroptions-maxdetectedfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetectoroptions-maxdetectedfaces" class="dfn-panel" data-for="dom-facedetectoroptions-maxdetectedfaces" id="infopanel-for-dom-facedetectoroptions-maxdetectedfaces" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetectoroptions-maxdetectedfaces" style="display:none">Info about the 'maxDetectedFaces' definition.</span><b><a href="#dom-facedetectoroptions-maxdetectedfaces">#dom-facedetectoroptions-maxdetectedfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetectoroptions-maxdetectedfaces">2.2.1. FaceDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-facedetectoroptions-fastmode">
-   <b><a href="#dom-facedetectoroptions-fastmode">#dom-facedetectoroptions-fastmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-facedetectoroptions-fastmode" class="dfn-panel" data-for="dom-facedetectoroptions-fastmode" id="infopanel-for-dom-facedetectoroptions-fastmode" role="dialog">
+   <span id="infopaneltitle-for-dom-facedetectoroptions-fastmode" style="display:none">Info about the 'fastMode' definition.</span><b><a href="#dom-facedetectoroptions-fastmode">#dom-facedetectoroptions-fastmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-facedetectoroptions-fastmode">2.2.1. FaceDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-detectedface">
-   <b><a href="#dictdef-detectedface">#dictdef-detectedface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-detectedface" class="dfn-panel" data-for="dictdef-detectedface" id="infopanel-for-dictdef-detectedface" role="dialog">
+   <span id="infopaneltitle-for-dictdef-detectedface" style="display:none">Info about the 'DetectedFace' definition.</span><b><a href="#dictdef-detectedface">#dictdef-detectedface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-detectedface">2.2. Face Detection API</a> <a href="#ref-for-dictdef-detectedface①">(2)</a> <a href="#ref-for-dictdef-detectedface②">(3)</a>
     <li><a href="#ref-for-dictdef-detectedface③">2.2.2. DetectedFace</a> <a href="#ref-for-dictdef-detectedface④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedface-boundingbox">
-   <b><a href="#dom-detectedface-boundingbox">#dom-detectedface-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedface-boundingbox" class="dfn-panel" data-for="dom-detectedface-boundingbox" id="infopanel-for-dom-detectedface-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedface-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedface-boundingbox">#dom-detectedface-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedface-boundingbox">2.2. Face Detection API</a>
     <li><a href="#ref-for-dom-detectedface-boundingbox①">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedface-landmarks">
-   <b><a href="#dom-detectedface-landmarks">#dom-detectedface-landmarks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedface-landmarks" class="dfn-panel" data-for="dom-detectedface-landmarks" id="infopanel-for-dom-detectedface-landmarks" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedface-landmarks" style="display:none">Info about the 'landmarks' definition.</span><b><a href="#dom-detectedface-landmarks">#dom-detectedface-landmarks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedface-landmarks">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-landmark">
-   <b><a href="#dictdef-landmark">#dictdef-landmark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-landmark" class="dfn-panel" data-for="dictdef-landmark" id="infopanel-for-dictdef-landmark" role="dialog">
+   <span id="infopaneltitle-for-dictdef-landmark" style="display:none">Info about the 'Landmark' definition.</span><b><a href="#dictdef-landmark">#dictdef-landmark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-landmark">2.2.2. DetectedFace</a> <a href="#ref-for-dictdef-landmark①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-landmark-locations">
-   <b><a href="#dom-landmark-locations">#dom-landmark-locations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-landmark-locations" class="dfn-panel" data-for="dom-landmark-locations" id="infopanel-for-dom-landmark-locations" role="dialog">
+   <span id="infopaneltitle-for-dom-landmark-locations" style="display:none">Info about the 'locations' definition.</span><b><a href="#dom-landmark-locations">#dom-landmark-locations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-landmark-locations">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-landmark-type">
-   <b><a href="#dom-landmark-type">#dom-landmark-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-landmark-type" class="dfn-panel" data-for="dom-landmark-type" id="infopanel-for-dom-landmark-type" role="dialog">
+   <span id="infopaneltitle-for-dom-landmark-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-landmark-type">#dom-landmark-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-landmark-type">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-landmarktype">
-   <b><a href="#enumdef-landmarktype">#enumdef-landmarktype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-landmarktype" class="dfn-panel" data-for="enumdef-landmarktype" id="infopanel-for-enumdef-landmarktype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-landmarktype" style="display:none">Info about the 'LandmarkType' definition.</span><b><a href="#enumdef-landmarktype">#enumdef-landmarktype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-landmarktype">2.2.2. DetectedFace</a> <a href="#ref-for-enumdef-landmarktype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-landmarktype-mouth">
-   <b><a href="#dom-landmarktype-mouth">#dom-landmarktype-mouth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-landmarktype-mouth" class="dfn-panel" data-for="dom-landmarktype-mouth" id="infopanel-for-dom-landmarktype-mouth" role="dialog">
+   <span id="infopaneltitle-for-dom-landmarktype-mouth" style="display:none">Info about the 'mouth' definition.</span><b><a href="#dom-landmarktype-mouth">#dom-landmarktype-mouth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-landmarktype-mouth">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-landmarktype-eye">
-   <b><a href="#dom-landmarktype-eye">#dom-landmarktype-eye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-landmarktype-eye" class="dfn-panel" data-for="dom-landmarktype-eye" id="infopanel-for-dom-landmarktype-eye" role="dialog">
+   <span id="infopaneltitle-for-dom-landmarktype-eye" style="display:none">Info about the 'eye' definition.</span><b><a href="#dom-landmarktype-eye">#dom-landmarktype-eye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-landmarktype-eye">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-landmarktype-nose">
-   <b><a href="#dom-landmarktype-nose">#dom-landmarktype-nose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-landmarktype-nose" class="dfn-panel" data-for="dom-landmarktype-nose" id="infopanel-for-dom-landmarktype-nose" role="dialog">
+   <span id="infopaneltitle-for-dom-landmarktype-nose" style="display:none">Info about the 'nose' definition.</span><b><a href="#dom-landmarktype-nose">#dom-landmarktype-nose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-landmarktype-nose">2.2.2. DetectedFace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="barcodedetector">
-   <b><a href="#barcodedetector">#barcodedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-barcodedetector" class="dfn-panel" data-for="barcodedetector" id="infopanel-for-barcodedetector" role="dialog">
+   <span id="infopaneltitle-for-barcodedetector" style="display:none">Info about the 'BarcodeDetector' definition.</span><b><a href="#barcodedetector">#barcodedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-barcodedetector">2.3. Barcode Detection API</a> <a href="#ref-for-barcodedetector①">(2)</a> <a href="#ref-for-barcodedetector②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodedetector-barcodedetector">
-   <b><a href="#dom-barcodedetector-barcodedetector">#dom-barcodedetector-barcodedetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodedetector-barcodedetector" class="dfn-panel" data-for="dom-barcodedetector-barcodedetector" id="infopanel-for-dom-barcodedetector-barcodedetector" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodedetector-barcodedetector" style="display:none">Info about the 'BarcodeDetector(optional BarcodeDetectorOptions barcodeDetectorOptions)' definition.</span><b><a href="#dom-barcodedetector-barcodedetector">#dom-barcodedetector-barcodedetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodedetector-barcodedetector">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodedetector-getsupportedformats">
-   <b><a href="#dom-barcodedetector-getsupportedformats">#dom-barcodedetector-getsupportedformats</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodedetector-getsupportedformats" class="dfn-panel" data-for="dom-barcodedetector-getsupportedformats" id="infopanel-for-dom-barcodedetector-getsupportedformats" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodedetector-getsupportedformats" style="display:none">Info about the 'getSupportedFormats()' definition.</span><b><a href="#dom-barcodedetector-getsupportedformats">#dom-barcodedetector-getsupportedformats</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodedetector-getsupportedformats">2.3. Barcode Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodedetector-detect">
-   <b><a href="#dom-barcodedetector-detect">#dom-barcodedetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodedetector-detect" class="dfn-panel" data-for="dom-barcodedetector-detect" id="infopanel-for-dom-barcodedetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodedetector-detect" style="display:none">Info about the 'detect(ImageBitmapSource image)' definition.</span><b><a href="#dom-barcodedetector-detect">#dom-barcodedetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodedetector-detect">2.3. Barcode Detection API</a> <a href="#ref-for-dom-barcodedetector-detect①">(2)</a>
     <li><a href="#ref-for-dom-barcodedetector-detect②">2.3.1. BarcodeDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-barcodedetectoroptions">
-   <b><a href="#dictdef-barcodedetectoroptions">#dictdef-barcodedetectoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-barcodedetectoroptions" class="dfn-panel" data-for="dictdef-barcodedetectoroptions" id="infopanel-for-dictdef-barcodedetectoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-barcodedetectoroptions" style="display:none">Info about the 'BarcodeDetectorOptions' definition.</span><b><a href="#dictdef-barcodedetectoroptions">#dictdef-barcodedetectoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-barcodedetectoroptions">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-dictdef-barcodedetectoroptions①">2.3.1. BarcodeDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodedetectoroptions-formats">
-   <b><a href="#dom-barcodedetectoroptions-formats">#dom-barcodedetectoroptions-formats</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodedetectoroptions-formats" class="dfn-panel" data-for="dom-barcodedetectoroptions-formats" id="infopanel-for-dom-barcodedetectoroptions-formats" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodedetectoroptions-formats" style="display:none">Info about the 'formats' definition.</span><b><a href="#dom-barcodedetectoroptions-formats">#dom-barcodedetectoroptions-formats</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodedetectoroptions-formats">2.3. Barcode Detection API</a> <a href="#ref-for-dom-barcodedetectoroptions-formats①">(2)</a>
     <li><a href="#ref-for-dom-barcodedetectoroptions-formats②">2.3.1. BarcodeDetectorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-detectedbarcode">
-   <b><a href="#dictdef-detectedbarcode">#dictdef-detectedbarcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-detectedbarcode" class="dfn-panel" data-for="dictdef-detectedbarcode" id="infopanel-for-dictdef-detectedbarcode" role="dialog">
+   <span id="infopaneltitle-for-dictdef-detectedbarcode" style="display:none">Info about the 'DetectedBarcode' definition.</span><b><a href="#dictdef-detectedbarcode">#dictdef-detectedbarcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-detectedbarcode">2.3. Barcode Detection API</a> <a href="#ref-for-dictdef-detectedbarcode①">(2)</a>
     <li><a href="#ref-for-dictdef-detectedbarcode②">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-boundingbox">
-   <b><a href="#dom-detectedbarcode-boundingbox">#dom-detectedbarcode-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-boundingbox" class="dfn-panel" data-for="dom-detectedbarcode-boundingbox" id="infopanel-for-dom-detectedbarcode-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedbarcode-boundingbox">#dom-detectedbarcode-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-boundingbox">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-dom-detectedbarcode-boundingbox①">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-rawvalue">
-   <b><a href="#dom-detectedbarcode-rawvalue">#dom-detectedbarcode-rawvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-rawvalue" class="dfn-panel" data-for="dom-detectedbarcode-rawvalue" id="infopanel-for-dom-detectedbarcode-rawvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-rawvalue" style="display:none">Info about the 'rawValue' definition.</span><b><a href="#dom-detectedbarcode-rawvalue">#dom-detectedbarcode-rawvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-rawvalue">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-dom-detectedbarcode-rawvalue①">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-format">
-   <b><a href="#dom-detectedbarcode-format">#dom-detectedbarcode-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-format" class="dfn-panel" data-for="dom-detectedbarcode-format" id="infopanel-for-dom-detectedbarcode-format" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-format" style="display:none">Info about the 'format' definition.</span><b><a href="#dom-detectedbarcode-format">#dom-detectedbarcode-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-format">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedbarcode-cornerpoints">
-   <b><a href="#dom-detectedbarcode-cornerpoints">#dom-detectedbarcode-cornerpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedbarcode-cornerpoints" class="dfn-panel" data-for="dom-detectedbarcode-cornerpoints" id="infopanel-for-dom-detectedbarcode-cornerpoints" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedbarcode-cornerpoints" style="display:none">Info about the 'cornerPoints' definition.</span><b><a href="#dom-detectedbarcode-cornerpoints">#dom-detectedbarcode-cornerpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedbarcode-cornerpoints">2.3.2. DetectedBarcode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-barcodeformat">
-   <b><a href="#enumdef-barcodeformat">#enumdef-barcodeformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-barcodeformat" class="dfn-panel" data-for="enumdef-barcodeformat" id="infopanel-for-enumdef-barcodeformat" role="dialog">
+   <span id="infopaneltitle-for-enumdef-barcodeformat" style="display:none">Info about the 'BarcodeFormat' definition.</span><b><a href="#enumdef-barcodeformat">#enumdef-barcodeformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-barcodeformat">2.3. Barcode Detection API</a> <a href="#ref-for-enumdef-barcodeformat①">(2)</a> <a href="#ref-for-enumdef-barcodeformat②">(3)</a>
     <li><a href="#ref-for-enumdef-barcodeformat③">2.3.1. BarcodeDetectorOptions</a> <a href="#ref-for-enumdef-barcodeformat④">(2)</a> <a href="#ref-for-enumdef-barcodeformat⑤">(3)</a>
@@ -1897,170 +1897,226 @@ barcodeDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
     <li><a href="#ref-for-enumdef-barcodeformat⑨">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-aztec">
-   <b><a href="#dom-barcodeformat-aztec">#dom-barcodeformat-aztec</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-aztec" class="dfn-panel" data-for="dom-barcodeformat-aztec" id="infopanel-for-dom-barcodeformat-aztec" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-aztec" style="display:none">Info about the 'aztec' definition.</span><b><a href="#dom-barcodeformat-aztec">#dom-barcodeformat-aztec</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-aztec">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-code_128">
-   <b><a href="#dom-barcodeformat-code_128">#dom-barcodeformat-code_128</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-code_128" class="dfn-panel" data-for="dom-barcodeformat-code_128" id="infopanel-for-dom-barcodeformat-code_128" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-code_128" style="display:none">Info about the 'code_128' definition.</span><b><a href="#dom-barcodeformat-code_128">#dom-barcodeformat-code_128</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-code_128">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-128">
-   <b><a href="#code-128">#code-128</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-128" class="dfn-panel" data-for="code-128" id="infopanel-for-code-128" role="dialog">
+   <span id="infopaneltitle-for-code-128" style="display:none">Info about the 'Code 128' definition.</span><b><a href="#code-128">#code-128</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-128">2.3.3. BarcodeFormat</a> <a href="#ref-for-code-128①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-code_39">
-   <b><a href="#dom-barcodeformat-code_39">#dom-barcodeformat-code_39</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-code_39" class="dfn-panel" data-for="dom-barcodeformat-code_39" id="infopanel-for-dom-barcodeformat-code_39" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-code_39" style="display:none">Info about the 'code_39' definition.</span><b><a href="#dom-barcodeformat-code_39">#dom-barcodeformat-code_39</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-code_39">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-39">
-   <b><a href="#code-39">#code-39</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-39" class="dfn-panel" data-for="code-39" id="infopanel-for-code-39" role="dialog">
+   <span id="infopaneltitle-for-code-39" style="display:none">Info about the 'Code 39' definition.</span><b><a href="#code-39">#code-39</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-39">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-code_93">
-   <b><a href="#dom-barcodeformat-code_93">#dom-barcodeformat-code_93</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-code_93" class="dfn-panel" data-for="dom-barcodeformat-code_93" id="infopanel-for-dom-barcodeformat-code_93" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-code_93" style="display:none">Info about the 'code_93' definition.</span><b><a href="#dom-barcodeformat-code_93">#dom-barcodeformat-code_93</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-code_93">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-codabar">
-   <b><a href="#dom-barcodeformat-codabar">#dom-barcodeformat-codabar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-codabar" class="dfn-panel" data-for="dom-barcodeformat-codabar" id="infopanel-for-dom-barcodeformat-codabar" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-codabar" style="display:none">Info about the 'codabar' definition.</span><b><a href="#dom-barcodeformat-codabar">#dom-barcodeformat-codabar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-codabar">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-data_matrix">
-   <b><a href="#dom-barcodeformat-data_matrix">#dom-barcodeformat-data_matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-data_matrix" class="dfn-panel" data-for="dom-barcodeformat-data_matrix" id="infopanel-for-dom-barcodeformat-data_matrix" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-data_matrix" style="display:none">Info about the 'data_matrix' definition.</span><b><a href="#dom-barcodeformat-data_matrix">#dom-barcodeformat-data_matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-data_matrix">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-ean_13">
-   <b><a href="#dom-barcodeformat-ean_13">#dom-barcodeformat-ean_13</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-ean_13" class="dfn-panel" data-for="dom-barcodeformat-ean_13" id="infopanel-for-dom-barcodeformat-ean_13" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-ean_13" style="display:none">Info about the 'ean_13' definition.</span><b><a href="#dom-barcodeformat-ean_13">#dom-barcodeformat-ean_13</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-ean_13">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ean-13">
-   <b><a href="#ean-13">#ean-13</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ean-13" class="dfn-panel" data-for="ean-13" id="infopanel-for-ean-13" role="dialog">
+   <span id="infopaneltitle-for-ean-13" style="display:none">Info about the 'EAN-13' definition.</span><b><a href="#ean-13">#ean-13</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ean-13">2.3.3. BarcodeFormat</a> <a href="#ref-for-ean-13①">(2)</a> <a href="#ref-for-ean-13②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-ean_8">
-   <b><a href="#dom-barcodeformat-ean_8">#dom-barcodeformat-ean_8</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-ean_8" class="dfn-panel" data-for="dom-barcodeformat-ean_8" id="infopanel-for-dom-barcodeformat-ean_8" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-ean_8" style="display:none">Info about the 'ean_8' definition.</span><b><a href="#dom-barcodeformat-ean_8">#dom-barcodeformat-ean_8</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-ean_8">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-itf">
-   <b><a href="#dom-barcodeformat-itf">#dom-barcodeformat-itf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-itf" class="dfn-panel" data-for="dom-barcodeformat-itf" id="infopanel-for-dom-barcodeformat-itf" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-itf" style="display:none">Info about the 'itf' definition.</span><b><a href="#dom-barcodeformat-itf">#dom-barcodeformat-itf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-itf">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-pdf417">
-   <b><a href="#dom-barcodeformat-pdf417">#dom-barcodeformat-pdf417</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-pdf417" class="dfn-panel" data-for="dom-barcodeformat-pdf417" id="infopanel-for-dom-barcodeformat-pdf417" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-pdf417" style="display:none">Info about the 'pdf417' definition.</span><b><a href="#dom-barcodeformat-pdf417">#dom-barcodeformat-pdf417</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-pdf417">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-qr_code">
-   <b><a href="#dom-barcodeformat-qr_code">#dom-barcodeformat-qr_code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-qr_code" class="dfn-panel" data-for="dom-barcodeformat-qr_code" id="infopanel-for-dom-barcodeformat-qr_code" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-qr_code" style="display:none">Info about the 'qr_code' definition.</span><b><a href="#dom-barcodeformat-qr_code">#dom-barcodeformat-qr_code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-qr_code">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-unknown">
-   <b><a href="#dom-barcodeformat-unknown">#dom-barcodeformat-unknown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-unknown" class="dfn-panel" data-for="dom-barcodeformat-unknown" id="infopanel-for-dom-barcodeformat-unknown" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-unknown" style="display:none">Info about the 'unknown' definition.</span><b><a href="#dom-barcodeformat-unknown">#dom-barcodeformat-unknown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-unknown">2.3. Barcode Detection API</a>
     <li><a href="#ref-for-dom-barcodeformat-unknown①">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-upc_a">
-   <b><a href="#dom-barcodeformat-upc_a">#dom-barcodeformat-upc_a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-upc_a" class="dfn-panel" data-for="dom-barcodeformat-upc_a" id="infopanel-for-dom-barcodeformat-upc_a" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-upc_a" style="display:none">Info about the 'upc_a' definition.</span><b><a href="#dom-barcodeformat-upc_a">#dom-barcodeformat-upc_a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-upc_a">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upc-a">
-   <b><a href="#upc-a">#upc-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upc-a" class="dfn-panel" data-for="upc-a" id="infopanel-for-upc-a" role="dialog">
+   <span id="infopaneltitle-for-upc-a" style="display:none">Info about the 'UPC-A' definition.</span><b><a href="#upc-a">#upc-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upc-a">2.3.3. BarcodeFormat</a> <a href="#ref-for-upc-a①">(2)</a> <a href="#ref-for-upc-a②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-barcodeformat-upc_e">
-   <b><a href="#dom-barcodeformat-upc_e">#dom-barcodeformat-upc_e</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-barcodeformat-upc_e" class="dfn-panel" data-for="dom-barcodeformat-upc_e" id="infopanel-for-dom-barcodeformat-upc_e" role="dialog">
+   <span id="infopaneltitle-for-dom-barcodeformat-upc_e" style="display:none">Info about the 'upc_e' definition.</span><b><a href="#dom-barcodeformat-upc_e">#dom-barcodeformat-upc_e</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-barcodeformat-upc_e">2.3.3. BarcodeFormat</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/shape-detection-api/text.html
+++ b/tests/github/WICG/shape-detection-api/text.html
@@ -808,57 +808,57 @@ textDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
    <li><a href="#textdetector">TextDetector</a><span>, in § 2.2</span>
    <li><a href="#dom-textdetector-textdetector">TextDetector()</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-Point2D">
-   <a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Point2D" class="dfn-panel" data-for="term-for-Point2D" id="infopanel-for-term-for-Point2D" role="menu">
+   <span id="infopaneltitle-for-term-for-Point2D" style="display:none">Info about the 'Point2D' external reference.</span><a href="https://w3c.github.io/mediacapture-image/#Point2D">https://w3c.github.io/mediacapture-image/#Point2D</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Point2D">2.2. Text Detection API</a>
     <li><a href="#ref-for-Point2D①">2.2.1. DetectedText</a> <a href="#ref-for-Point2D②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.2.1. DetectedText</a> <a href="#ref-for-domrectreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagebitmapsource">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagebitmapsource" class="dfn-panel" data-for="term-for-imagebitmapsource" id="infopanel-for-term-for-imagebitmapsource" role="menu">
+   <span id="infopaneltitle-for-term-for-imagebitmapsource" style="display:none">Info about the 'ImageBitmapSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagebitmapsource">2.2. Text Detection API</a> <a href="#ref-for-imagebitmapsource①">(2)</a> <a href="#ref-for-imagebitmapsource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2.1. DetectedText</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. Text Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.2.1. DetectedText</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.2. Text Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.2. Text Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. Text Detection API</a>
     <li><a href="#ref-for-idl-sequence①">2.2.1. DetectedText</a>
@@ -927,104 +927,160 @@ textDetector<c- p>.</c->detect<c- p>(</c->theImage<c- p>)</c->
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="textdetector">
-   <b><a href="#textdetector">#textdetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdetector" class="dfn-panel" data-for="textdetector" id="infopanel-for-textdetector" role="dialog">
+   <span id="infopaneltitle-for-textdetector" style="display:none">Info about the 'TextDetector' definition.</span><b><a href="#textdetector">#textdetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdetector">2.2. Text Detection API</a> <a href="#ref-for-textdetector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdetector-textdetector">
-   <b><a href="#dom-textdetector-textdetector">#dom-textdetector-textdetector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdetector-textdetector" class="dfn-panel" data-for="dom-textdetector-textdetector" id="infopanel-for-dom-textdetector-textdetector" role="dialog">
+   <span id="infopaneltitle-for-dom-textdetector-textdetector" style="display:none">Info about the 'TextDetector()' definition.</span><b><a href="#dom-textdetector-textdetector">#dom-textdetector-textdetector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdetector-textdetector">2.2. Text Detection API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdetector-detect">
-   <b><a href="#dom-textdetector-detect">#dom-textdetector-detect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdetector-detect" class="dfn-panel" data-for="dom-textdetector-detect" id="infopanel-for-dom-textdetector-detect" role="dialog">
+   <span id="infopaneltitle-for-dom-textdetector-detect" style="display:none">Info about the 'detect(ImageBitmapSource image)' definition.</span><b><a href="#dom-textdetector-detect">#dom-textdetector-detect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdetector-detect">2.2. Text Detection API</a> <a href="#ref-for-dom-textdetector-detect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-detectedtext">
-   <b><a href="#dictdef-detectedtext">#dictdef-detectedtext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-detectedtext" class="dfn-panel" data-for="dictdef-detectedtext" id="infopanel-for-dictdef-detectedtext" role="dialog">
+   <span id="infopaneltitle-for-dictdef-detectedtext" style="display:none">Info about the 'DetectedText' definition.</span><b><a href="#dictdef-detectedtext">#dictdef-detectedtext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-detectedtext">2.2. Text Detection API</a> <a href="#ref-for-dictdef-detectedtext①">(2)</a>
     <li><a href="#ref-for-dictdef-detectedtext②">2.2.1. DetectedText</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedtext-boundingbox">
-   <b><a href="#dom-detectedtext-boundingbox">#dom-detectedtext-boundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedtext-boundingbox" class="dfn-panel" data-for="dom-detectedtext-boundingbox" id="infopanel-for-dom-detectedtext-boundingbox" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedtext-boundingbox" style="display:none">Info about the 'boundingBox' definition.</span><b><a href="#dom-detectedtext-boundingbox">#dom-detectedtext-boundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedtext-boundingbox">2.2. Text Detection API</a>
     <li><a href="#ref-for-dom-detectedtext-boundingbox①">2.2.1. DetectedText</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedtext-rawvalue">
-   <b><a href="#dom-detectedtext-rawvalue">#dom-detectedtext-rawvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedtext-rawvalue" class="dfn-panel" data-for="dom-detectedtext-rawvalue" id="infopanel-for-dom-detectedtext-rawvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedtext-rawvalue" style="display:none">Info about the 'rawValue' definition.</span><b><a href="#dom-detectedtext-rawvalue">#dom-detectedtext-rawvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedtext-rawvalue">2.2. Text Detection API</a>
     <li><a href="#ref-for-dom-detectedtext-rawvalue①">2.2.1. DetectedText</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-detectedtext-cornerpoints">
-   <b><a href="#dom-detectedtext-cornerpoints">#dom-detectedtext-cornerpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-detectedtext-cornerpoints" class="dfn-panel" data-for="dom-detectedtext-cornerpoints" id="infopanel-for-dom-detectedtext-cornerpoints" role="dialog">
+   <span id="infopaneltitle-for-dom-detectedtext-cornerpoints" style="display:none">Info about the 'cornerPoints' definition.</span><b><a href="#dom-detectedtext-cornerpoints">#dom-detectedtext-cornerpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-detectedtext-cornerpoints">2.2.1. DetectedText</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/sms-one-time-codes/index.html
+++ b/tests/github/WICG/sms-one-time-codes/index.html
@@ -783,112 +783,112 @@ for their valuable feedback on this proposal.</p>
    <li><a href="#parse-an-origin-bound-one-time-code-message">parse an origin-bound one-time code message</a><span>, in § 3.2</span>
    <li><a href="#origin-bound-one-time-code-message-top-level-host">top-level host</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">2.1. Usage</a> <a href="#ref-for-concept-document-origin①">(2)</a> <a href="#ref-for-concept-document-origin②">(3)</a> <a href="#ref-for-concept-document-origin③">(4)</a> <a href="#ref-for-concept-document-origin④">(5)</a> <a href="#ref-for-concept-document-origin⑤">(6)</a> <a href="#ref-for-concept-document-origin⑥">(7)</a> <a href="#ref-for-concept-document-origin⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">2.1. Usage</a> <a href="#ref-for-nav-document①">(2)</a> <a href="#ref-for-nav-document②">(3)</a> <a href="#ref-for-nav-document③">(4)</a> <a href="#ref-for-nav-document④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.1. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">2.1. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2. Origin-bound one-time codes</a> <a href="#ref-for-concept-origin①">(2)</a>
     <li><a href="#ref-for-concept-origin②">3.2. Parsing</a> <a href="#ref-for-concept-origin③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.1. Usage</a> <a href="#ref-for-same-origin①">(2)</a> <a href="#ref-for-same-origin②">(3)</a> <a href="#ref-for-same-origin③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-site-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-site-same-site" class="dfn-panel" data-for="term-for-concept-site-same-site" id="infopanel-for-term-for-concept-site-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-site-same-site" style="display:none">Info about the 'same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-site-same-site">2.1. Usage</a> <a href="#ref-for-concept-site-same-site①">(2)</a> <a href="#ref-for-concept-site-same-site②">(3)</a> <a href="#ref-for-concept-site-same-site③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2.1. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2.1. Usage</a> <a href="#ref-for-top-level-browsing-context①">(2)</a> <a href="#ref-for-top-level-browsing-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">3.2. Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">3.2. Parsing</a> <a href="#ref-for-code-point①">(2)</a> <a href="#ref-for-code-point②">(3)</a> <a href="#ref-for-code-point③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collecting a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">3.2. Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-normalize-newlines">
-   <a href="https://infra.spec.whatwg.org/#normalize-newlines">https://infra.spec.whatwg.org/#normalize-newlines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-normalize-newlines" class="dfn-panel" data-for="term-for-normalize-newlines" id="infopanel-for-term-for-normalize-newlines" role="menu">
+   <span id="infopaneltitle-for-term-for-normalize-newlines" style="display:none">Info about the 'normalize newlines' external reference.</span><a href="https://infra.spec.whatwg.org/#normalize-newlines">https://infra.spec.whatwg.org/#normalize-newlines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize-newlines">3.2. Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split a string' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">3.2. Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2. Origin-bound one-time codes</a>
     <li><a href="#ref-for-string①">3. Message format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">2. Origin-bound one-time codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">2.1. Usage</a>
    </ul>
@@ -951,8 +951,8 @@ for their valuable feedback on this proposal.</p>
    <dt id="biblio-webauthn">[WEBAUTHN]
    <dd>Dirk Balfanz; et al. <a href="https://w3c.github.io/webauthn/"><cite>Web Authentication:An API for accessing Public Key Credentials Level 1</cite></a>. URL: <a href="https://w3c.github.io/webauthn/">https://w3c.github.io/webauthn/</a>
   </dl>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code">
-   <b><a href="#origin-bound-one-time-code">#origin-bound-one-time-code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code" class="dfn-panel" data-for="origin-bound-one-time-code" id="infopanel-for-origin-bound-one-time-code" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code" style="display:none">Info about the 'origin-bound one-time code' definition.</span><b><a href="#origin-bound-one-time-code">#origin-bound-one-time-code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code">2. Origin-bound one-time codes</a> <a href="#ref-for-origin-bound-one-time-code①">(2)</a>
     <li><a href="#ref-for-origin-bound-one-time-code②">2.1. Usage</a> <a href="#ref-for-origin-bound-one-time-code③">(2)</a> <a href="#ref-for-origin-bound-one-time-code④">(3)</a> <a href="#ref-for-origin-bound-one-time-code⑤">(4)</a> <a href="#ref-for-origin-bound-one-time-code⑥">(5)</a> <a href="#ref-for-origin-bound-one-time-code⑦">(6)</a> <a href="#ref-for-origin-bound-one-time-code⑧">(7)</a>
@@ -961,108 +961,164 @@ for their valuable feedback on this proposal.</p>
     <li><a href="#ref-for-origin-bound-one-time-code①①">5. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code-message">
-   <b><a href="#origin-bound-one-time-code-message">#origin-bound-one-time-code-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code-message" class="dfn-panel" data-for="origin-bound-one-time-code-message" id="infopanel-for-origin-bound-one-time-code-message" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code-message" style="display:none">Info about the 'origin-bound one-time code message' definition.</span><b><a href="#origin-bound-one-time-code-message">#origin-bound-one-time-code-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message">3.1. Authoring</a> <a href="#ref-for-origin-bound-one-time-code-message①">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message②">(3)</a> <a href="#ref-for-origin-bound-one-time-code-message③">(4)</a> <a href="#ref-for-origin-bound-one-time-code-message④">(5)</a> <a href="#ref-for-origin-bound-one-time-code-message⑤">(6)</a> <a href="#ref-for-origin-bound-one-time-code-message⑥">(7)</a> <a href="#ref-for-origin-bound-one-time-code-message⑦">(8)</a>
     <li><a href="#ref-for-origin-bound-one-time-code-message⑧">5. Privacy considerations</a> <a href="#ref-for-origin-bound-one-time-code-message⑨">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code-message-explanatory-text">
-   <b><a href="#origin-bound-one-time-code-message-explanatory-text">#origin-bound-one-time-code-message-explanatory-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code-message-explanatory-text" class="dfn-panel" data-for="origin-bound-one-time-code-message-explanatory-text" id="infopanel-for-origin-bound-one-time-code-message-explanatory-text" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code-message-explanatory-text" style="display:none">Info about the 'explanatory text' definition.</span><b><a href="#origin-bound-one-time-code-message-explanatory-text">#origin-bound-one-time-code-message-explanatory-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message-explanatory-text">3.1. Authoring</a> <a href="#ref-for-origin-bound-one-time-code-message-explanatory-text①">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message-explanatory-text②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code-message-top-level-host">
-   <b><a href="#origin-bound-one-time-code-message-top-level-host">#origin-bound-one-time-code-message-top-level-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code-message-top-level-host" class="dfn-panel" data-for="origin-bound-one-time-code-message-top-level-host" id="infopanel-for-origin-bound-one-time-code-message-top-level-host" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code-message-top-level-host" style="display:none">Info about the 'top-level host' definition.</span><b><a href="#origin-bound-one-time-code-message-top-level-host">#origin-bound-one-time-code-message-top-level-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message-top-level-host">3.1. Authoring</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host①">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host②">(3)</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host③">(4)</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host④">(5)</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host⑤">(6)</a> <a href="#ref-for-origin-bound-one-time-code-message-top-level-host⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code-message-code">
-   <b><a href="#origin-bound-one-time-code-message-code">#origin-bound-one-time-code-message-code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code-message-code" class="dfn-panel" data-for="origin-bound-one-time-code-message-code" id="infopanel-for-origin-bound-one-time-code-message-code" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code-message-code" style="display:none">Info about the 'code' definition.</span><b><a href="#origin-bound-one-time-code-message-code">#origin-bound-one-time-code-message-code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message-code">3.1. Authoring</a> <a href="#ref-for-origin-bound-one-time-code-message-code①">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message-code②">(3)</a> <a href="#ref-for-origin-bound-one-time-code-message-code③">(4)</a> <a href="#ref-for-origin-bound-one-time-code-message-code④">(5)</a> <a href="#ref-for-origin-bound-one-time-code-message-code⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-bound-one-time-code-message-embedded-host">
-   <b><a href="#origin-bound-one-time-code-message-embedded-host">#origin-bound-one-time-code-message-embedded-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-bound-one-time-code-message-embedded-host" class="dfn-panel" data-for="origin-bound-one-time-code-message-embedded-host" id="infopanel-for-origin-bound-one-time-code-message-embedded-host" role="dialog">
+   <span id="infopaneltitle-for-origin-bound-one-time-code-message-embedded-host" style="display:none">Info about the 'embedded host' definition.</span><b><a href="#origin-bound-one-time-code-message-embedded-host">#origin-bound-one-time-code-message-embedded-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message-embedded-host">3.1. Authoring</a> <a href="#ref-for-origin-bound-one-time-code-message-embedded-host①">(2)</a> <a href="#ref-for-origin-bound-one-time-code-message-embedded-host②">(3)</a> <a href="#ref-for-origin-bound-one-time-code-message-embedded-host③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-an-origin-bound-one-time-code-message">
-   <b><a href="#parse-an-origin-bound-one-time-code-message">#parse-an-origin-bound-one-time-code-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-an-origin-bound-one-time-code-message" class="dfn-panel" data-for="parse-an-origin-bound-one-time-code-message" id="infopanel-for-parse-an-origin-bound-one-time-code-message" role="dialog">
+   <span id="infopaneltitle-for-parse-an-origin-bound-one-time-code-message" style="display:none">Info about the 'parse an origin-bound one-time code message' definition.</span><b><a href="#parse-an-origin-bound-one-time-code-message">#parse-an-origin-bound-one-time-code-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-an-origin-bound-one-time-code-message">3. Message format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-a-marked-token">
-   <b><a href="#extract-a-marked-token">#extract-a-marked-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-a-marked-token" class="dfn-panel" data-for="extract-a-marked-token" id="infopanel-for-extract-a-marked-token" role="dialog">
+   <span id="infopaneltitle-for-extract-a-marked-token" style="display:none">Info about the 'extract a marked token' definition.</span><b><a href="#extract-a-marked-token">#extract-a-marked-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-a-marked-token">3.2. Parsing</a> <a href="#ref-for-extract-a-marked-token①">(2)</a> <a href="#ref-for-extract-a-marked-token②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-line">
-   <b><a href="#last-line">#last-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-line" class="dfn-panel" data-for="last-line" id="infopanel-for-last-line" role="dialog">
+   <span id="infopaneltitle-for-last-line" style="display:none">Info about the 'last line' definition.</span><b><a href="#last-line">#last-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-line">3.2. Parsing</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/speech-api/index.html
+++ b/tests/github/WICG/speech-api/index.html
@@ -3653,55 +3653,55 @@ These events bubble up to SpeechSynthesis.</p>
    <li><a href="#dom-speechsynthesisutterance-volume">volume</a><span>, in § 4.2.4</span>
    <li><a href="#dom-speechgrammar-weight">weight</a><span>, in § 4.1.9</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-event①">(2)</a>
     <li><a href="#ref-for-event②">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-dictdef-eventinit①">(2)</a>
     <li><a href="#ref-for-dictdef-eventinit②">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.1. The SpeechRecognition Interface</a>
     <li><a href="#ref-for-eventtarget①">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-eventtarget②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a> <a href="#ref-for-eventhandler⑥">(7)</a> <a href="#ref-for-eventhandler⑦">(8)</a> <a href="#ref-for-eventhandler⑧">(9)</a> <a href="#ref-for-eventhandler⑨">(10)</a> <a href="#ref-for-eventhandler①⓪">(11)</a>
     <li><a href="#ref-for-eventhandler①①">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-eventhandler①②">(2)</a> <a href="#ref-for-eventhandler①③">(3)</a> <a href="#ref-for-eventhandler①④">(4)</a> <a href="#ref-for-eventhandler①⑤">(5)</a> <a href="#ref-for-eventhandler①⑥">(6)</a> <a href="#ref-for-eventhandler①⑦">(7)</a> <a href="#ref-for-eventhandler①⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-language">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-language" class="dfn-panel" data-for="term-for-language" id="infopanel-for-term-for-language" role="menu">
+   <span id="infopaneltitle-for-term-for-language" style="display:none">Info about the 'language' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-language">4.1.1. SpeechRecognition Attributes</a>
     <li><a href="#ref-for-language①">4.2.4. SpeechSynthesisUtterance Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.1.2. SpeechRecognition Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a> <a href="#ref-for-idl-DOMString⑥">(7)</a> <a href="#ref-for-idl-DOMString⑦">(8)</a> <a href="#ref-for-idl-DOMString⑧">(9)</a>
     <li><a href="#ref-for-idl-DOMString⑨">4.1.1. SpeechRecognition Attributes</a>
@@ -3714,27 +3714,27 @@ These events bubble up to SpeechSynthesis.</p>
     <li><a href="#ref-for-idl-DOMString②⑥">4.2.8. SpeechSynthesisVoice Attributes</a> <a href="#ref-for-idl-DOMString②⑦">(2)</a> <a href="#ref-for-idl-DOMString②⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-Exposed①">(2)</a> <a href="#ref-for-Exposed②">(3)</a> <a href="#ref-for-Exposed③">(4)</a> <a href="#ref-for-Exposed④">(5)</a> <a href="#ref-for-Exposed⑤">(6)</a> <a href="#ref-for-Exposed⑥">(7)</a> <a href="#ref-for-Exposed⑦">(8)</a>
     <li><a href="#ref-for-Exposed⑧">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-Exposed⑨">(2)</a> <a href="#ref-for-Exposed①⓪">(3)</a> <a href="#ref-for-Exposed①①">(4)</a> <a href="#ref-for-Exposed①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1.2. SpeechRecognition Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
     <li><a href="#ref-for-idl-boolean③">4.1.1. SpeechRecognition Attributes</a> <a href="#ref-for-idl-boolean④">(2)</a>
@@ -3744,8 +3744,8 @@ These events bubble up to SpeechSynthesis.</p>
     <li><a href="#ref-for-idl-boolean①④">4.2.8. SpeechSynthesisVoice Attributes</a> <a href="#ref-for-idl-boolean①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-idl-float①">(2)</a> <a href="#ref-for-idl-float②">(3)</a> <a href="#ref-for-idl-float③">(4)</a>
     <li><a href="#ref-for-idl-float④">4.1.5. SpeechRecognitionAlternative</a>
@@ -3755,21 +3755,21 @@ These events bubble up to SpeechSynthesis.</p>
     <li><a href="#ref-for-idl-float①④">4.2.6. SpeechSynthesisEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a>
     <li><a href="#ref-for-idl-undefined⑤">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-idl-undefined⑥">(2)</a> <a href="#ref-for-idl-undefined⑦">(3)</a> <a href="#ref-for-idl-undefined⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a> <a href="#ref-for-idl-unsigned-long⑥">(7)</a> <a href="#ref-for-idl-unsigned-long⑦">(8)</a> <a href="#ref-for-idl-unsigned-long⑧">(9)</a>
     <li><a href="#ref-for-idl-unsigned-long⑨">4.1.1. SpeechRecognition Attributes</a>
@@ -4039,680 +4039,736 @@ See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Sep/0072
    <div class="issue">The group has discussed options for which grammar formats should be supported, how builtin grammar types are specified, and default grammars when not specified.
 See <a href="https://lists.w3.org/Archives/Public/public-speech-api/2012Jun/0179.html">Default value of SpeechRecognition.grammars</a> thread on public-speech-api@w3.org. <a class="issue-return" href="#issue-29f5066f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="enumdef-speechrecognitionerrorcode">
-   <b><a href="#enumdef-speechrecognitionerrorcode">#enumdef-speechrecognitionerrorcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-speechrecognitionerrorcode" class="dfn-panel" data-for="enumdef-speechrecognitionerrorcode" id="infopanel-for-enumdef-speechrecognitionerrorcode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-speechrecognitionerrorcode" style="display:none">Info about the 'SpeechRecognitionErrorCode' definition.</span><b><a href="#enumdef-speechrecognitionerrorcode">#enumdef-speechrecognitionerrorcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-speechrecognitionerrorcode">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-enumdef-speechrecognitionerrorcode①">(2)</a>
     <li><a href="#ref-for-enumdef-speechrecognitionerrorcode②">4.1.4. SpeechRecognitionErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechrecognitionerrorevent">
-   <b><a href="#speechrecognitionerrorevent">#speechrecognitionerrorevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechrecognitionerrorevent" class="dfn-panel" data-for="speechrecognitionerrorevent" id="infopanel-for-speechrecognitionerrorevent" role="dialog">
+   <span id="infopaneltitle-for-speechrecognitionerrorevent" style="display:none">Info about the 'SpeechRecognitionErrorEvent' definition.</span><b><a href="#speechrecognitionerrorevent">#speechrecognitionerrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechrecognitionerrorevent">4.1.3. SpeechRecognition Events</a>
     <li><a href="#ref-for-speechrecognitionerrorevent①">4.1.4. SpeechRecognitionErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-speechrecognitionerroreventinit">
-   <b><a href="#dictdef-speechrecognitionerroreventinit">#dictdef-speechrecognitionerroreventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-speechrecognitionerroreventinit" class="dfn-panel" data-for="dictdef-speechrecognitionerroreventinit" id="infopanel-for-dictdef-speechrecognitionerroreventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-speechrecognitionerroreventinit" style="display:none">Info about the 'SpeechRecognitionErrorEventInit' definition.</span><b><a href="#dictdef-speechrecognitionerroreventinit">#dictdef-speechrecognitionerroreventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-speechrecognitionerroreventinit">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechrecognitionalternative">
-   <b><a href="#speechrecognitionalternative">#speechrecognitionalternative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechrecognitionalternative" class="dfn-panel" data-for="speechrecognitionalternative" id="infopanel-for-speechrecognitionalternative" role="dialog">
+   <span id="infopaneltitle-for-speechrecognitionalternative" style="display:none">Info about the 'SpeechRecognitionAlternative' definition.</span><b><a href="#speechrecognitionalternative">#speechrecognitionalternative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechrecognitionalternative">4.1. The SpeechRecognition Interface</a>
     <li><a href="#ref-for-speechrecognitionalternative①">4.1.1. SpeechRecognition Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechrecognitionresult">
-   <b><a href="#speechrecognitionresult">#speechrecognitionresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechrecognitionresult" class="dfn-panel" data-for="speechrecognitionresult" id="infopanel-for-speechrecognitionresult" role="dialog">
+   <span id="infopaneltitle-for-speechrecognitionresult" style="display:none">Info about the 'SpeechRecognitionResult' definition.</span><b><a href="#speechrecognitionresult">#speechrecognitionresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechrecognitionresult">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechrecognitionresultlist">
-   <b><a href="#speechrecognitionresultlist">#speechrecognitionresultlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechrecognitionresultlist" class="dfn-panel" data-for="speechrecognitionresultlist" id="infopanel-for-speechrecognitionresultlist" role="dialog">
+   <span id="infopaneltitle-for-speechrecognitionresultlist" style="display:none">Info about the 'SpeechRecognitionResultList' definition.</span><b><a href="#speechrecognitionresultlist">#speechrecognitionresultlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechrecognitionresultlist">4.1. The SpeechRecognition Interface</a> <a href="#ref-for-speechrecognitionresultlist①">(2)</a>
     <li><a href="#ref-for-speechrecognitionresultlist②">4.1.8. SpeechRecognitionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechrecognitionevent">
-   <b><a href="#speechrecognitionevent">#speechrecognitionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechrecognitionevent" class="dfn-panel" data-for="speechrecognitionevent" id="infopanel-for-speechrecognitionevent" role="dialog">
+   <span id="infopaneltitle-for-speechrecognitionevent" style="display:none">Info about the 'SpeechRecognitionEvent' definition.</span><b><a href="#speechrecognitionevent">#speechrecognitionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechrecognitionevent">4.1.3. SpeechRecognition Events</a> <a href="#ref-for-speechrecognitionevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-speechrecognitioneventinit">
-   <b><a href="#dictdef-speechrecognitioneventinit">#dictdef-speechrecognitioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-speechrecognitioneventinit" class="dfn-panel" data-for="dictdef-speechrecognitioneventinit" id="infopanel-for-dictdef-speechrecognitioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-speechrecognitioneventinit" style="display:none">Info about the 'SpeechRecognitionEventInit' definition.</span><b><a href="#dictdef-speechrecognitioneventinit">#dictdef-speechrecognitioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-speechrecognitioneventinit">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechgrammar">
-   <b><a href="#speechgrammar">#speechgrammar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechgrammar" class="dfn-panel" data-for="speechgrammar" id="infopanel-for-speechgrammar" role="dialog">
+   <span id="infopaneltitle-for-speechgrammar" style="display:none">Info about the 'SpeechGrammar' definition.</span><b><a href="#speechgrammar">#speechgrammar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechgrammar">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechgrammarlist">
-   <b><a href="#speechgrammarlist">#speechgrammarlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechgrammarlist" class="dfn-panel" data-for="speechgrammarlist" id="infopanel-for-speechgrammarlist" role="dialog">
+   <span id="infopaneltitle-for-speechgrammarlist" style="display:none">Info about the 'SpeechGrammarList' definition.</span><b><a href="#speechgrammarlist">#speechgrammarlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechgrammarlist">4.1. The SpeechRecognition Interface</a>
     <li><a href="#ref-for-speechgrammarlist①">4.1.1. SpeechRecognition Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-grammars">
-   <b><a href="#dom-speechrecognition-grammars">#dom-speechrecognition-grammars</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-grammars" class="dfn-panel" data-for="dom-speechrecognition-grammars" id="infopanel-for-dom-speechrecognition-grammars" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-grammars" style="display:none">Info about the 'grammars' definition.</span><b><a href="#dom-speechrecognition-grammars">#dom-speechrecognition-grammars</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-grammars">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-lang">
-   <b><a href="#dom-speechrecognition-lang">#dom-speechrecognition-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-lang" class="dfn-panel" data-for="dom-speechrecognition-lang" id="infopanel-for-dom-speechrecognition-lang" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-lang" style="display:none">Info about the 'lang' definition.</span><b><a href="#dom-speechrecognition-lang">#dom-speechrecognition-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-lang">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-continuous">
-   <b><a href="#dom-speechrecognition-continuous">#dom-speechrecognition-continuous</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-continuous" class="dfn-panel" data-for="dom-speechrecognition-continuous" id="infopanel-for-dom-speechrecognition-continuous" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-continuous" style="display:none">Info about the 'continuous' definition.</span><b><a href="#dom-speechrecognition-continuous">#dom-speechrecognition-continuous</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-continuous">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-interimresults">
-   <b><a href="#dom-speechrecognition-interimresults">#dom-speechrecognition-interimresults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-interimresults" class="dfn-panel" data-for="dom-speechrecognition-interimresults" id="infopanel-for-dom-speechrecognition-interimresults" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-interimresults" style="display:none">Info about the 'interimResults' definition.</span><b><a href="#dom-speechrecognition-interimresults">#dom-speechrecognition-interimresults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-interimresults">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-maxalternatives">
-   <b><a href="#dom-speechrecognition-maxalternatives">#dom-speechrecognition-maxalternatives</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-maxalternatives" class="dfn-panel" data-for="dom-speechrecognition-maxalternatives" id="infopanel-for-dom-speechrecognition-maxalternatives" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-maxalternatives" style="display:none">Info about the 'maxAlternatives' definition.</span><b><a href="#dom-speechrecognition-maxalternatives">#dom-speechrecognition-maxalternatives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-maxalternatives">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-start">
-   <b><a href="#dom-speechrecognition-start">#dom-speechrecognition-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-start" class="dfn-panel" data-for="dom-speechrecognition-start" id="infopanel-for-dom-speechrecognition-start" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-start" style="display:none">Info about the 'start()' definition.</span><b><a href="#dom-speechrecognition-start">#dom-speechrecognition-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-start">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-stop">
-   <b><a href="#dom-speechrecognition-stop">#dom-speechrecognition-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-stop" class="dfn-panel" data-for="dom-speechrecognition-stop" id="infopanel-for-dom-speechrecognition-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-stop" style="display:none">Info about the 'stop()' definition.</span><b><a href="#dom-speechrecognition-stop">#dom-speechrecognition-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-stop">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognition-abort">
-   <b><a href="#dom-speechrecognition-abort">#dom-speechrecognition-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognition-abort" class="dfn-panel" data-for="dom-speechrecognition-abort" id="infopanel-for-dom-speechrecognition-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognition-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-speechrecognition-abort">#dom-speechrecognition-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognition-abort">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-audiostart">
-   <b><a href="#eventdef-speechrecognition-audiostart">#eventdef-speechrecognition-audiostart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-audiostart" class="dfn-panel" data-for="eventdef-speechrecognition-audiostart" id="infopanel-for-eventdef-speechrecognition-audiostart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-audiostart" style="display:none">Info about the 'audiostart' definition.</span><b><a href="#eventdef-speechrecognition-audiostart">#eventdef-speechrecognition-audiostart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-audiostart">4.1.3. SpeechRecognition Events</a> <a href="#ref-for-eventdef-speechrecognition-audiostart①">(2)</a> <a href="#ref-for-eventdef-speechrecognition-audiostart②">(3)</a> <a href="#ref-for-eventdef-speechrecognition-audiostart③">(4)</a> <a href="#ref-for-eventdef-speechrecognition-audiostart④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-soundstart">
-   <b><a href="#eventdef-speechrecognition-soundstart">#eventdef-speechrecognition-soundstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-soundstart" class="dfn-panel" data-for="eventdef-speechrecognition-soundstart" id="infopanel-for-eventdef-speechrecognition-soundstart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-soundstart" style="display:none">Info about the 'soundstart' definition.</span><b><a href="#eventdef-speechrecognition-soundstart">#eventdef-speechrecognition-soundstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-soundstart">4.1.3. SpeechRecognition Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-speechstart">
-   <b><a href="#eventdef-speechrecognition-speechstart">#eventdef-speechrecognition-speechstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-speechstart" class="dfn-panel" data-for="eventdef-speechrecognition-speechstart" id="infopanel-for-eventdef-speechrecognition-speechstart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-speechstart" style="display:none">Info about the 'speechstart' definition.</span><b><a href="#eventdef-speechrecognition-speechstart">#eventdef-speechrecognition-speechstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-speechstart">4.1.3. SpeechRecognition Events</a> <a href="#ref-for-eventdef-speechrecognition-speechstart①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-speechend">
-   <b><a href="#eventdef-speechrecognition-speechend">#eventdef-speechrecognition-speechend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-speechend" class="dfn-panel" data-for="eventdef-speechrecognition-speechend" id="infopanel-for-eventdef-speechrecognition-speechend" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-speechend" style="display:none">Info about the 'speechend' definition.</span><b><a href="#eventdef-speechrecognition-speechend">#eventdef-speechrecognition-speechend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-speechend">4.1.3. SpeechRecognition Events</a> <a href="#ref-for-eventdef-speechrecognition-speechend①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-audioend">
-   <b><a href="#eventdef-speechrecognition-audioend">#eventdef-speechrecognition-audioend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-audioend" class="dfn-panel" data-for="eventdef-speechrecognition-audioend" id="infopanel-for-eventdef-speechrecognition-audioend" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-audioend" style="display:none">Info about the 'audioend' definition.</span><b><a href="#eventdef-speechrecognition-audioend">#eventdef-speechrecognition-audioend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-audioend">4.1.3. SpeechRecognition Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-error">
-   <b><a href="#eventdef-speechrecognition-error">#eventdef-speechrecognition-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-error" class="dfn-panel" data-for="eventdef-speechrecognition-error" id="infopanel-for-eventdef-speechrecognition-error" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-error" style="display:none">Info about the 'error' definition.</span><b><a href="#eventdef-speechrecognition-error">#eventdef-speechrecognition-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-error">4.1.2. SpeechRecognition Methods</a> <a href="#ref-for-eventdef-speechrecognition-error①">(2)</a> <a href="#ref-for-eventdef-speechrecognition-error②">(3)</a>
     <li><a href="#ref-for-eventdef-speechrecognition-error③">4.1.4. SpeechRecognitionErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechrecognition-end">
-   <b><a href="#eventdef-speechrecognition-end">#eventdef-speechrecognition-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechrecognition-end" class="dfn-panel" data-for="eventdef-speechrecognition-end" id="infopanel-for-eventdef-speechrecognition-end" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechrecognition-end" style="display:none">Info about the 'end' definition.</span><b><a href="#eventdef-speechrecognition-end">#eventdef-speechrecognition-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechrecognition-end">4.1.2. SpeechRecognition Methods</a> <a href="#ref-for-eventdef-speechrecognition-end①">(2)</a> <a href="#ref-for-eventdef-speechrecognition-end②">(3)</a> <a href="#ref-for-eventdef-speechrecognition-end③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorevent-error">
-   <b><a href="#dom-speechrecognitionerrorevent-error">#dom-speechrecognitionerrorevent-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorevent-error" class="dfn-panel" data-for="dom-speechrecognitionerrorevent-error" id="infopanel-for-dom-speechrecognitionerrorevent-error" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorevent-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-speechrecognitionerrorevent-error">#dom-speechrecognitionerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorevent-error">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-no-speech">
-   <b><a href="#dom-speechrecognitionerrorcode-no-speech">#dom-speechrecognitionerrorcode-no-speech</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-no-speech" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-no-speech" id="infopanel-for-dom-speechrecognitionerrorcode-no-speech" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-no-speech" style="display:none">Info about the '"no-speech"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-no-speech">#dom-speechrecognitionerrorcode-no-speech</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-no-speech">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-aborted">
-   <b><a href="#dom-speechrecognitionerrorcode-aborted">#dom-speechrecognitionerrorcode-aborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-aborted" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-aborted" id="infopanel-for-dom-speechrecognitionerrorcode-aborted" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-aborted" style="display:none">Info about the '"aborted"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-aborted">#dom-speechrecognitionerrorcode-aborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-aborted">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-audio-capture">
-   <b><a href="#dom-speechrecognitionerrorcode-audio-capture">#dom-speechrecognitionerrorcode-audio-capture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-audio-capture" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-audio-capture" id="infopanel-for-dom-speechrecognitionerrorcode-audio-capture" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-audio-capture" style="display:none">Info about the '"audio-capture"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-audio-capture">#dom-speechrecognitionerrorcode-audio-capture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-audio-capture">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-network">
-   <b><a href="#dom-speechrecognitionerrorcode-network">#dom-speechrecognitionerrorcode-network</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-network" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-network" id="infopanel-for-dom-speechrecognitionerrorcode-network" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-network" style="display:none">Info about the '"network"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-network">#dom-speechrecognitionerrorcode-network</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-network">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-not-allowed">
-   <b><a href="#dom-speechrecognitionerrorcode-not-allowed">#dom-speechrecognitionerrorcode-not-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-not-allowed" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-not-allowed" id="infopanel-for-dom-speechrecognitionerrorcode-not-allowed" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-not-allowed" style="display:none">Info about the '"not-allowed"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-not-allowed">#dom-speechrecognitionerrorcode-not-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-not-allowed">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-service-not-allowed">
-   <b><a href="#dom-speechrecognitionerrorcode-service-not-allowed">#dom-speechrecognitionerrorcode-service-not-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-service-not-allowed" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-service-not-allowed" id="infopanel-for-dom-speechrecognitionerrorcode-service-not-allowed" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-service-not-allowed" style="display:none">Info about the '"service-not-allowed"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-service-not-allowed">#dom-speechrecognitionerrorcode-service-not-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-service-not-allowed">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-bad-grammar">
-   <b><a href="#dom-speechrecognitionerrorcode-bad-grammar">#dom-speechrecognitionerrorcode-bad-grammar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-bad-grammar" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-bad-grammar" id="infopanel-for-dom-speechrecognitionerrorcode-bad-grammar" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-bad-grammar" style="display:none">Info about the '"bad-grammar"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-bad-grammar">#dom-speechrecognitionerrorcode-bad-grammar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-bad-grammar">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorcode-language-not-supported">
-   <b><a href="#dom-speechrecognitionerrorcode-language-not-supported">#dom-speechrecognitionerrorcode-language-not-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorcode-language-not-supported" class="dfn-panel" data-for="dom-speechrecognitionerrorcode-language-not-supported" id="infopanel-for-dom-speechrecognitionerrorcode-language-not-supported" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorcode-language-not-supported" style="display:none">Info about the '"language-not-supported"' definition.</span><b><a href="#dom-speechrecognitionerrorcode-language-not-supported">#dom-speechrecognitionerrorcode-language-not-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorcode-language-not-supported">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionerrorevent-message">
-   <b><a href="#dom-speechrecognitionerrorevent-message">#dom-speechrecognitionerrorevent-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionerrorevent-message" class="dfn-panel" data-for="dom-speechrecognitionerrorevent-message" id="infopanel-for-dom-speechrecognitionerrorevent-message" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionerrorevent-message" style="display:none">Info about the 'message' definition.</span><b><a href="#dom-speechrecognitionerrorevent-message">#dom-speechrecognitionerrorevent-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionerrorevent-message">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionalternative-transcript">
-   <b><a href="#dom-speechrecognitionalternative-transcript">#dom-speechrecognitionalternative-transcript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionalternative-transcript" class="dfn-panel" data-for="dom-speechrecognitionalternative-transcript" id="infopanel-for-dom-speechrecognitionalternative-transcript" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionalternative-transcript" style="display:none">Info about the 'transcript' definition.</span><b><a href="#dom-speechrecognitionalternative-transcript">#dom-speechrecognitionalternative-transcript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionalternative-transcript">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionalternative-confidence">
-   <b><a href="#dom-speechrecognitionalternative-confidence">#dom-speechrecognitionalternative-confidence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionalternative-confidence" class="dfn-panel" data-for="dom-speechrecognitionalternative-confidence" id="infopanel-for-dom-speechrecognitionalternative-confidence" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionalternative-confidence" style="display:none">Info about the 'confidence' definition.</span><b><a href="#dom-speechrecognitionalternative-confidence">#dom-speechrecognitionalternative-confidence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionalternative-confidence">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionresult-length">
-   <b><a href="#dom-speechrecognitionresult-length">#dom-speechrecognitionresult-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionresult-length" class="dfn-panel" data-for="dom-speechrecognitionresult-length" id="infopanel-for-dom-speechrecognitionresult-length" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionresult-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-speechrecognitionresult-length">#dom-speechrecognitionresult-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionresult-length">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionresult-item">
-   <b><a href="#dom-speechrecognitionresult-item">#dom-speechrecognitionresult-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionresult-item" class="dfn-panel" data-for="dom-speechrecognitionresult-item" id="infopanel-for-dom-speechrecognitionresult-item" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionresult-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-speechrecognitionresult-item">#dom-speechrecognitionresult-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionresult-item">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionresult-isfinal">
-   <b><a href="#dom-speechrecognitionresult-isfinal">#dom-speechrecognitionresult-isfinal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionresult-isfinal" class="dfn-panel" data-for="dom-speechrecognitionresult-isfinal" id="infopanel-for-dom-speechrecognitionresult-isfinal" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionresult-isfinal" style="display:none">Info about the 'isFinal' definition.</span><b><a href="#dom-speechrecognitionresult-isfinal">#dom-speechrecognitionresult-isfinal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionresult-isfinal">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionresultlist-length">
-   <b><a href="#dom-speechrecognitionresultlist-length">#dom-speechrecognitionresultlist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionresultlist-length" class="dfn-panel" data-for="dom-speechrecognitionresultlist-length" id="infopanel-for-dom-speechrecognitionresultlist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionresultlist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-speechrecognitionresultlist-length">#dom-speechrecognitionresultlist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionresultlist-length">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionresultlist-item">
-   <b><a href="#dom-speechrecognitionresultlist-item">#dom-speechrecognitionresultlist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionresultlist-item" class="dfn-panel" data-for="dom-speechrecognitionresultlist-item" id="infopanel-for-dom-speechrecognitionresultlist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionresultlist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-speechrecognitionresultlist-item">#dom-speechrecognitionresultlist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionresultlist-item">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionevent-resultindex">
-   <b><a href="#dom-speechrecognitionevent-resultindex">#dom-speechrecognitionevent-resultindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionevent-resultindex" class="dfn-panel" data-for="dom-speechrecognitionevent-resultindex" id="infopanel-for-dom-speechrecognitionevent-resultindex" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionevent-resultindex" style="display:none">Info about the 'resultIndex' definition.</span><b><a href="#dom-speechrecognitionevent-resultindex">#dom-speechrecognitionevent-resultindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionevent-resultindex">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechrecognitionevent-results">
-   <b><a href="#dom-speechrecognitionevent-results">#dom-speechrecognitionevent-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechrecognitionevent-results" class="dfn-panel" data-for="dom-speechrecognitionevent-results" id="infopanel-for-dom-speechrecognitionevent-results" role="dialog">
+   <span id="infopaneltitle-for-dom-speechrecognitionevent-results" style="display:none">Info about the 'results' definition.</span><b><a href="#dom-speechrecognitionevent-results">#dom-speechrecognitionevent-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechrecognitionevent-results">4.1. The SpeechRecognition Interface</a>
     <li><a href="#ref-for-dom-speechrecognitionevent-results①">4.1.3. SpeechRecognition Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammar-src">
-   <b><a href="#dom-speechgrammar-src">#dom-speechgrammar-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammar-src" class="dfn-panel" data-for="dom-speechgrammar-src" id="infopanel-for-dom-speechgrammar-src" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammar-src" style="display:none">Info about the 'src' definition.</span><b><a href="#dom-speechgrammar-src">#dom-speechgrammar-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammar-src">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammar-weight">
-   <b><a href="#dom-speechgrammar-weight">#dom-speechgrammar-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammar-weight" class="dfn-panel" data-for="dom-speechgrammar-weight" id="infopanel-for-dom-speechgrammar-weight" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammar-weight" style="display:none">Info about the 'weight' definition.</span><b><a href="#dom-speechgrammar-weight">#dom-speechgrammar-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammar-weight">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammarlist-length">
-   <b><a href="#dom-speechgrammarlist-length">#dom-speechgrammarlist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammarlist-length" class="dfn-panel" data-for="dom-speechgrammarlist-length" id="infopanel-for-dom-speechgrammarlist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammarlist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-speechgrammarlist-length">#dom-speechgrammarlist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammarlist-length">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammarlist-item">
-   <b><a href="#dom-speechgrammarlist-item">#dom-speechgrammarlist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammarlist-item" class="dfn-panel" data-for="dom-speechgrammarlist-item" id="infopanel-for-dom-speechgrammarlist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammarlist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-speechgrammarlist-item">#dom-speechgrammarlist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammarlist-item">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammarlist-addfromuri">
-   <b><a href="#dom-speechgrammarlist-addfromuri">#dom-speechgrammarlist-addfromuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammarlist-addfromuri" class="dfn-panel" data-for="dom-speechgrammarlist-addfromuri" id="infopanel-for-dom-speechgrammarlist-addfromuri" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammarlist-addfromuri" style="display:none">Info about the 'addFromURI(src, weight)' definition.</span><b><a href="#dom-speechgrammarlist-addfromuri">#dom-speechgrammarlist-addfromuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammarlist-addfromuri">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechgrammarlist-addfromstring">
-   <b><a href="#dom-speechgrammarlist-addfromstring">#dom-speechgrammarlist-addfromstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechgrammarlist-addfromstring" class="dfn-panel" data-for="dom-speechgrammarlist-addfromstring" id="infopanel-for-dom-speechgrammarlist-addfromstring" role="dialog">
+   <span id="infopaneltitle-for-dom-speechgrammarlist-addfromstring" style="display:none">Info about the 'addFromString(string, weight)' definition.</span><b><a href="#dom-speechgrammarlist-addfromstring">#dom-speechgrammarlist-addfromstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechgrammarlist-addfromstring">4.1. The SpeechRecognition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechsynthesis">
-   <b><a href="#speechsynthesis">#speechsynthesis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechsynthesis" class="dfn-panel" data-for="speechsynthesis" id="infopanel-for-speechsynthesis" role="dialog">
+   <span id="infopaneltitle-for-speechsynthesis" style="display:none">Info about the 'SpeechSynthesis' definition.</span><b><a href="#speechsynthesis">#speechsynthesis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechsynthesis">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechsynthesisutterance">
-   <b><a href="#speechsynthesisutterance">#speechsynthesisutterance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechsynthesisutterance" class="dfn-panel" data-for="speechsynthesisutterance" id="infopanel-for-speechsynthesisutterance" role="dialog">
+   <span id="infopaneltitle-for-speechsynthesisutterance" style="display:none">Info about the 'SpeechSynthesisUtterance' definition.</span><b><a href="#speechsynthesisutterance">#speechsynthesisutterance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechsynthesisutterance">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-speechsynthesisutterance①">(2)</a> <a href="#ref-for-speechsynthesisutterance②">(3)</a>
     <li><a href="#ref-for-speechsynthesisutterance③">4.2.4. SpeechSynthesisUtterance Attributes</a>
     <li><a href="#ref-for-speechsynthesisutterance④">4.2.6. SpeechSynthesisEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechsynthesisevent">
-   <b><a href="#speechsynthesisevent">#speechsynthesisevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechsynthesisevent" class="dfn-panel" data-for="speechsynthesisevent" id="infopanel-for-speechsynthesisevent" role="dialog">
+   <span id="infopaneltitle-for-speechsynthesisevent" style="display:none">Info about the 'SpeechSynthesisEvent' definition.</span><b><a href="#speechsynthesisevent">#speechsynthesisevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechsynthesisevent">4.2. The SpeechSynthesis Interface</a>
     <li><a href="#ref-for-speechsynthesisevent①">4.2.5. SpeechSynthesisUtterance Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-speechsynthesiseventinit">
-   <b><a href="#dictdef-speechsynthesiseventinit">#dictdef-speechsynthesiseventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-speechsynthesiseventinit" class="dfn-panel" data-for="dictdef-speechsynthesiseventinit" id="infopanel-for-dictdef-speechsynthesiseventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-speechsynthesiseventinit" style="display:none">Info about the 'SpeechSynthesisEventInit' definition.</span><b><a href="#dictdef-speechsynthesiseventinit">#dictdef-speechsynthesiseventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-speechsynthesiseventinit">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-dictdef-speechsynthesiseventinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-speechsynthesiserrorcode">
-   <b><a href="#enumdef-speechsynthesiserrorcode">#enumdef-speechsynthesiserrorcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-speechsynthesiserrorcode" class="dfn-panel" data-for="enumdef-speechsynthesiserrorcode" id="infopanel-for-enumdef-speechsynthesiserrorcode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-speechsynthesiserrorcode" style="display:none">Info about the 'SpeechSynthesisErrorCode' definition.</span><b><a href="#enumdef-speechsynthesiserrorcode">#enumdef-speechsynthesiserrorcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-speechsynthesiserrorcode">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-enumdef-speechsynthesiserrorcode①">(2)</a>
     <li><a href="#ref-for-enumdef-speechsynthesiserrorcode②">4.2.7. SpeechSynthesisErrorEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechsynthesiserrorevent">
-   <b><a href="#speechsynthesiserrorevent">#speechsynthesiserrorevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechsynthesiserrorevent" class="dfn-panel" data-for="speechsynthesiserrorevent" id="infopanel-for-speechsynthesiserrorevent" role="dialog">
+   <span id="infopaneltitle-for-speechsynthesiserrorevent" style="display:none">Info about the 'SpeechSynthesisErrorEvent' definition.</span><b><a href="#speechsynthesiserrorevent">#speechsynthesiserrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechsynthesiserrorevent">4.2.5. SpeechSynthesisUtterance Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-speechsynthesiserroreventinit">
-   <b><a href="#dictdef-speechsynthesiserroreventinit">#dictdef-speechsynthesiserroreventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-speechsynthesiserroreventinit" class="dfn-panel" data-for="dictdef-speechsynthesiserroreventinit" id="infopanel-for-dictdef-speechsynthesiserroreventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-speechsynthesiserroreventinit" style="display:none">Info about the 'SpeechSynthesisErrorEventInit' definition.</span><b><a href="#dictdef-speechsynthesiserroreventinit">#dictdef-speechsynthesiserroreventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-speechsynthesiserroreventinit">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="speechsynthesisvoice">
-   <b><a href="#speechsynthesisvoice">#speechsynthesisvoice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speechsynthesisvoice" class="dfn-panel" data-for="speechsynthesisvoice" id="infopanel-for-speechsynthesisvoice" role="dialog">
+   <span id="infopaneltitle-for-speechsynthesisvoice" style="display:none">Info about the 'SpeechSynthesisVoice' definition.</span><b><a href="#speechsynthesisvoice">#speechsynthesisvoice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speechsynthesisvoice">4.2. The SpeechSynthesis Interface</a> <a href="#ref-for-speechsynthesisvoice①">(2)</a>
     <li><a href="#ref-for-speechsynthesisvoice②">4.2.4. SpeechSynthesisUtterance Attributes</a> <a href="#ref-for-speechsynthesisvoice③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-pending">
-   <b><a href="#dom-speechsynthesis-pending">#dom-speechsynthesis-pending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-pending" class="dfn-panel" data-for="dom-speechsynthesis-pending" id="infopanel-for-dom-speechsynthesis-pending" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-pending" style="display:none">Info about the 'pending' definition.</span><b><a href="#dom-speechsynthesis-pending">#dom-speechsynthesis-pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-pending">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-speaking">
-   <b><a href="#dom-speechsynthesis-speaking">#dom-speechsynthesis-speaking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-speaking" class="dfn-panel" data-for="dom-speechsynthesis-speaking" id="infopanel-for-dom-speechsynthesis-speaking" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-speaking" style="display:none">Info about the 'speaking' definition.</span><b><a href="#dom-speechsynthesis-speaking">#dom-speechsynthesis-speaking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-speaking">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-paused">
-   <b><a href="#dom-speechsynthesis-paused">#dom-speechsynthesis-paused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-paused" class="dfn-panel" data-for="dom-speechsynthesis-paused" id="infopanel-for-dom-speechsynthesis-paused" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-paused" style="display:none">Info about the 'paused' definition.</span><b><a href="#dom-speechsynthesis-paused">#dom-speechsynthesis-paused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-paused">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-speak">
-   <b><a href="#dom-speechsynthesis-speak">#dom-speechsynthesis-speak</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-speak" class="dfn-panel" data-for="dom-speechsynthesis-speak" id="infopanel-for-dom-speechsynthesis-speak" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-speak" style="display:none">Info about the 'speak(utterance)' definition.</span><b><a href="#dom-speechsynthesis-speak">#dom-speechsynthesis-speak</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-speak">4.2. The SpeechSynthesis Interface</a>
     <li><a href="#ref-for-dom-speechsynthesis-speak①">4.2.4. SpeechSynthesisUtterance Attributes</a> <a href="#ref-for-dom-speechsynthesis-speak②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-cancel">
-   <b><a href="#dom-speechsynthesis-cancel">#dom-speechsynthesis-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-cancel" class="dfn-panel" data-for="dom-speechsynthesis-cancel" id="infopanel-for-dom-speechsynthesis-cancel" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-cancel" style="display:none">Info about the 'cancel()' definition.</span><b><a href="#dom-speechsynthesis-cancel">#dom-speechsynthesis-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-cancel">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-pause">
-   <b><a href="#dom-speechsynthesis-pause">#dom-speechsynthesis-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-pause" class="dfn-panel" data-for="dom-speechsynthesis-pause" id="infopanel-for-dom-speechsynthesis-pause" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-pause" style="display:none">Info about the 'pause()' definition.</span><b><a href="#dom-speechsynthesis-pause">#dom-speechsynthesis-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-pause">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-resume">
-   <b><a href="#dom-speechsynthesis-resume">#dom-speechsynthesis-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-resume" class="dfn-panel" data-for="dom-speechsynthesis-resume" id="infopanel-for-dom-speechsynthesis-resume" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-resume" style="display:none">Info about the 'resume()' definition.</span><b><a href="#dom-speechsynthesis-resume">#dom-speechsynthesis-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-resume">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesis-getvoices">
-   <b><a href="#dom-speechsynthesis-getvoices">#dom-speechsynthesis-getvoices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesis-getvoices" class="dfn-panel" data-for="dom-speechsynthesis-getvoices" id="infopanel-for-dom-speechsynthesis-getvoices" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesis-getvoices" style="display:none">Info about the 'getVoices()' definition.</span><b><a href="#dom-speechsynthesis-getvoices">#dom-speechsynthesis-getvoices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesis-getvoices">4.2. The SpeechSynthesis Interface</a>
     <li><a href="#ref-for-dom-speechsynthesis-getvoices①">4.2.4. SpeechSynthesisUtterance Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-text">
-   <b><a href="#dom-speechsynthesisutterance-text">#dom-speechsynthesisutterance-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-text" class="dfn-panel" data-for="dom-speechsynthesisutterance-text" id="infopanel-for-dom-speechsynthesisutterance-text" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-text" style="display:none">Info about the 'text' definition.</span><b><a href="#dom-speechsynthesisutterance-text">#dom-speechsynthesisutterance-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-text">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-lang">
-   <b><a href="#dom-speechsynthesisutterance-lang">#dom-speechsynthesisutterance-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-lang" class="dfn-panel" data-for="dom-speechsynthesisutterance-lang" id="infopanel-for-dom-speechsynthesisutterance-lang" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-lang" style="display:none">Info about the 'lang' definition.</span><b><a href="#dom-speechsynthesisutterance-lang">#dom-speechsynthesisutterance-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-lang">4.2. The SpeechSynthesis Interface</a>
     <li><a href="#ref-for-dom-speechsynthesisutterance-lang①">4.2.4. SpeechSynthesisUtterance Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-voice">
-   <b><a href="#dom-speechsynthesisutterance-voice">#dom-speechsynthesisutterance-voice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-voice" class="dfn-panel" data-for="dom-speechsynthesisutterance-voice" id="infopanel-for-dom-speechsynthesisutterance-voice" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-voice" style="display:none">Info about the 'voice' definition.</span><b><a href="#dom-speechsynthesisutterance-voice">#dom-speechsynthesisutterance-voice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-voice">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-volume">
-   <b><a href="#dom-speechsynthesisutterance-volume">#dom-speechsynthesisutterance-volume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-volume" class="dfn-panel" data-for="dom-speechsynthesisutterance-volume" id="infopanel-for-dom-speechsynthesisutterance-volume" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-volume" style="display:none">Info about the 'volume' definition.</span><b><a href="#dom-speechsynthesisutterance-volume">#dom-speechsynthesisutterance-volume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-volume">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-rate">
-   <b><a href="#dom-speechsynthesisutterance-rate">#dom-speechsynthesisutterance-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-rate" class="dfn-panel" data-for="dom-speechsynthesisutterance-rate" id="infopanel-for-dom-speechsynthesisutterance-rate" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-rate" style="display:none">Info about the 'rate' definition.</span><b><a href="#dom-speechsynthesisutterance-rate">#dom-speechsynthesisutterance-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-rate">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisutterance-pitch">
-   <b><a href="#dom-speechsynthesisutterance-pitch">#dom-speechsynthesisutterance-pitch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisutterance-pitch" class="dfn-panel" data-for="dom-speechsynthesisutterance-pitch" id="infopanel-for-dom-speechsynthesisutterance-pitch" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisutterance-pitch" style="display:none">Info about the 'pitch' definition.</span><b><a href="#dom-speechsynthesisutterance-pitch">#dom-speechsynthesisutterance-pitch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisutterance-pitch">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechsynthesisutterance-start">
-   <b><a href="#eventdef-speechsynthesisutterance-start">#eventdef-speechsynthesisutterance-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechsynthesisutterance-start" class="dfn-panel" data-for="eventdef-speechsynthesisutterance-start" id="infopanel-for-eventdef-speechsynthesisutterance-start" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechsynthesisutterance-start" style="display:none">Info about the 'start' definition.</span><b><a href="#eventdef-speechsynthesisutterance-start">#eventdef-speechsynthesisutterance-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-start">4.2.5. SpeechSynthesisUtterance Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechsynthesisutterance-end">
-   <b><a href="#eventdef-speechsynthesisutterance-end">#eventdef-speechsynthesisutterance-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechsynthesisutterance-end" class="dfn-panel" data-for="eventdef-speechsynthesisutterance-end" id="infopanel-for-eventdef-speechsynthesisutterance-end" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechsynthesisutterance-end" style="display:none">Info about the 'end' definition.</span><b><a href="#eventdef-speechsynthesisutterance-end">#eventdef-speechsynthesisutterance-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-end">4.2.2. SpeechSynthesis Methods</a>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-end①">4.2.5. SpeechSynthesisUtterance Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechsynthesisutterance-error">
-   <b><a href="#eventdef-speechsynthesisutterance-error">#eventdef-speechsynthesisutterance-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechsynthesisutterance-error" class="dfn-panel" data-for="eventdef-speechsynthesisutterance-error" id="infopanel-for-eventdef-speechsynthesisutterance-error" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechsynthesisutterance-error" style="display:none">Info about the 'error' definition.</span><b><a href="#eventdef-speechsynthesisutterance-error">#eventdef-speechsynthesisutterance-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-error">4.2.2. SpeechSynthesis Methods</a>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-error①">4.2.5. SpeechSynthesisUtterance Events</a>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-error②">4.2.7. SpeechSynthesisErrorEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechsynthesisutterance-mark">
-   <b><a href="#eventdef-speechsynthesisutterance-mark">#eventdef-speechsynthesisutterance-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechsynthesisutterance-mark" class="dfn-panel" data-for="eventdef-speechsynthesisutterance-mark" id="infopanel-for-eventdef-speechsynthesisutterance-mark" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechsynthesisutterance-mark" style="display:none">Info about the 'mark' definition.</span><b><a href="#eventdef-speechsynthesisutterance-mark">#eventdef-speechsynthesisutterance-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-mark">4.2.6. SpeechSynthesisEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-speechsynthesisutterance-boundary">
-   <b><a href="#eventdef-speechsynthesisutterance-boundary">#eventdef-speechsynthesisutterance-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-speechsynthesisutterance-boundary" class="dfn-panel" data-for="eventdef-speechsynthesisutterance-boundary" id="infopanel-for-eventdef-speechsynthesisutterance-boundary" role="dialog">
+   <span id="infopaneltitle-for-eventdef-speechsynthesisutterance-boundary" style="display:none">Info about the 'boundary' definition.</span><b><a href="#eventdef-speechsynthesisutterance-boundary">#eventdef-speechsynthesisutterance-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-speechsynthesisutterance-boundary">4.2.6. SpeechSynthesisEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisevent-utterance">
-   <b><a href="#dom-speechsynthesisevent-utterance">#dom-speechsynthesisevent-utterance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisevent-utterance" class="dfn-panel" data-for="dom-speechsynthesisevent-utterance" id="infopanel-for-dom-speechsynthesisevent-utterance" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisevent-utterance" style="display:none">Info about the 'utterance' definition.</span><b><a href="#dom-speechsynthesisevent-utterance">#dom-speechsynthesisevent-utterance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisevent-utterance">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisevent-charindex">
-   <b><a href="#dom-speechsynthesisevent-charindex">#dom-speechsynthesisevent-charindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisevent-charindex" class="dfn-panel" data-for="dom-speechsynthesisevent-charindex" id="infopanel-for-dom-speechsynthesisevent-charindex" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisevent-charindex" style="display:none">Info about the 'charIndex' definition.</span><b><a href="#dom-speechsynthesisevent-charindex">#dom-speechsynthesisevent-charindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisevent-charindex">4.2. The SpeechSynthesis Interface</a>
     <li><a href="#ref-for-dom-speechsynthesisevent-charindex①">4.2.6. SpeechSynthesisEvent Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisevent-charlength">
-   <b><a href="#dom-speechsynthesisevent-charlength">#dom-speechsynthesisevent-charlength</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisevent-charlength" class="dfn-panel" data-for="dom-speechsynthesisevent-charlength" id="infopanel-for-dom-speechsynthesisevent-charlength" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisevent-charlength" style="display:none">Info about the 'charLength' definition.</span><b><a href="#dom-speechsynthesisevent-charlength">#dom-speechsynthesisevent-charlength</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisevent-charlength">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisevent-elapsedtime">
-   <b><a href="#dom-speechsynthesisevent-elapsedtime">#dom-speechsynthesisevent-elapsedtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisevent-elapsedtime" class="dfn-panel" data-for="dom-speechsynthesisevent-elapsedtime" id="infopanel-for-dom-speechsynthesisevent-elapsedtime" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisevent-elapsedtime" style="display:none">Info about the 'elapsedTime' definition.</span><b><a href="#dom-speechsynthesisevent-elapsedtime">#dom-speechsynthesisevent-elapsedtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisevent-elapsedtime">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisevent-name">
-   <b><a href="#dom-speechsynthesisevent-name">#dom-speechsynthesisevent-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisevent-name" class="dfn-panel" data-for="dom-speechsynthesisevent-name" id="infopanel-for-dom-speechsynthesisevent-name" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisevent-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-speechsynthesisevent-name">#dom-speechsynthesisevent-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisevent-name">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorevent-error">
-   <b><a href="#dom-speechsynthesiserrorevent-error">#dom-speechsynthesiserrorevent-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorevent-error" class="dfn-panel" data-for="dom-speechsynthesiserrorevent-error" id="infopanel-for-dom-speechsynthesiserrorevent-error" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorevent-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-speechsynthesiserrorevent-error">#dom-speechsynthesiserrorevent-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorevent-error">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-canceled">
-   <b><a href="#dom-speechsynthesiserrorcode-canceled">#dom-speechsynthesiserrorcode-canceled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-canceled" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-canceled" id="infopanel-for-dom-speechsynthesiserrorcode-canceled" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-canceled" style="display:none">Info about the '"canceled"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-canceled">#dom-speechsynthesiserrorcode-canceled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-canceled">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-interrupted">
-   <b><a href="#dom-speechsynthesiserrorcode-interrupted">#dom-speechsynthesiserrorcode-interrupted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-interrupted" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-interrupted" id="infopanel-for-dom-speechsynthesiserrorcode-interrupted" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-interrupted" style="display:none">Info about the '"interrupted"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-interrupted">#dom-speechsynthesiserrorcode-interrupted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-interrupted">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-audio-busy">
-   <b><a href="#dom-speechsynthesiserrorcode-audio-busy">#dom-speechsynthesiserrorcode-audio-busy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-audio-busy" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-audio-busy" id="infopanel-for-dom-speechsynthesiserrorcode-audio-busy" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-audio-busy" style="display:none">Info about the '"audio-busy"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-audio-busy">#dom-speechsynthesiserrorcode-audio-busy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-audio-busy">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-audio-hardware">
-   <b><a href="#dom-speechsynthesiserrorcode-audio-hardware">#dom-speechsynthesiserrorcode-audio-hardware</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-audio-hardware" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-audio-hardware" id="infopanel-for-dom-speechsynthesiserrorcode-audio-hardware" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-audio-hardware" style="display:none">Info about the '"audio-hardware"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-audio-hardware">#dom-speechsynthesiserrorcode-audio-hardware</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-audio-hardware">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-network">
-   <b><a href="#dom-speechsynthesiserrorcode-network">#dom-speechsynthesiserrorcode-network</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-network" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-network" id="infopanel-for-dom-speechsynthesiserrorcode-network" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-network" style="display:none">Info about the '"network"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-network">#dom-speechsynthesiserrorcode-network</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-network">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-synthesis-unavailable">
-   <b><a href="#dom-speechsynthesiserrorcode-synthesis-unavailable">#dom-speechsynthesiserrorcode-synthesis-unavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-synthesis-unavailable" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-synthesis-unavailable" id="infopanel-for-dom-speechsynthesiserrorcode-synthesis-unavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-synthesis-unavailable" style="display:none">Info about the '"synthesis-unavailable"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-synthesis-unavailable">#dom-speechsynthesiserrorcode-synthesis-unavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-synthesis-unavailable">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-synthesis-failed">
-   <b><a href="#dom-speechsynthesiserrorcode-synthesis-failed">#dom-speechsynthesiserrorcode-synthesis-failed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-synthesis-failed" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-synthesis-failed" id="infopanel-for-dom-speechsynthesiserrorcode-synthesis-failed" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-synthesis-failed" style="display:none">Info about the '"synthesis-failed"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-synthesis-failed">#dom-speechsynthesiserrorcode-synthesis-failed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-synthesis-failed">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-language-unavailable">
-   <b><a href="#dom-speechsynthesiserrorcode-language-unavailable">#dom-speechsynthesiserrorcode-language-unavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-language-unavailable" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-language-unavailable" id="infopanel-for-dom-speechsynthesiserrorcode-language-unavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-language-unavailable" style="display:none">Info about the '"language-unavailable"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-language-unavailable">#dom-speechsynthesiserrorcode-language-unavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-language-unavailable">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-voice-unavailable">
-   <b><a href="#dom-speechsynthesiserrorcode-voice-unavailable">#dom-speechsynthesiserrorcode-voice-unavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-voice-unavailable" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-voice-unavailable" id="infopanel-for-dom-speechsynthesiserrorcode-voice-unavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-voice-unavailable" style="display:none">Info about the '"voice-unavailable"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-voice-unavailable">#dom-speechsynthesiserrorcode-voice-unavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-voice-unavailable">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-text-too-long">
-   <b><a href="#dom-speechsynthesiserrorcode-text-too-long">#dom-speechsynthesiserrorcode-text-too-long</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-text-too-long" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-text-too-long" id="infopanel-for-dom-speechsynthesiserrorcode-text-too-long" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-text-too-long" style="display:none">Info about the '"text-too-long"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-text-too-long">#dom-speechsynthesiserrorcode-text-too-long</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-text-too-long">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-invalid-argument">
-   <b><a href="#dom-speechsynthesiserrorcode-invalid-argument">#dom-speechsynthesiserrorcode-invalid-argument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-invalid-argument" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-invalid-argument" id="infopanel-for-dom-speechsynthesiserrorcode-invalid-argument" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-invalid-argument" style="display:none">Info about the '"invalid-argument"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-invalid-argument">#dom-speechsynthesiserrorcode-invalid-argument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-invalid-argument">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesiserrorcode-not-allowed">
-   <b><a href="#dom-speechsynthesiserrorcode-not-allowed">#dom-speechsynthesiserrorcode-not-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesiserrorcode-not-allowed" class="dfn-panel" data-for="dom-speechsynthesiserrorcode-not-allowed" id="infopanel-for-dom-speechsynthesiserrorcode-not-allowed" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesiserrorcode-not-allowed" style="display:none">Info about the '"not-allowed"' definition.</span><b><a href="#dom-speechsynthesiserrorcode-not-allowed">#dom-speechsynthesiserrorcode-not-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesiserrorcode-not-allowed">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisvoice-voiceuri">
-   <b><a href="#dom-speechsynthesisvoice-voiceuri">#dom-speechsynthesisvoice-voiceuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisvoice-voiceuri" class="dfn-panel" data-for="dom-speechsynthesisvoice-voiceuri" id="infopanel-for-dom-speechsynthesisvoice-voiceuri" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisvoice-voiceuri" style="display:none">Info about the 'voiceURI' definition.</span><b><a href="#dom-speechsynthesisvoice-voiceuri">#dom-speechsynthesisvoice-voiceuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisvoice-voiceuri">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisvoice-name">
-   <b><a href="#dom-speechsynthesisvoice-name">#dom-speechsynthesisvoice-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisvoice-name" class="dfn-panel" data-for="dom-speechsynthesisvoice-name" id="infopanel-for-dom-speechsynthesisvoice-name" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisvoice-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-speechsynthesisvoice-name">#dom-speechsynthesisvoice-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisvoice-name">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisvoice-lang">
-   <b><a href="#dom-speechsynthesisvoice-lang">#dom-speechsynthesisvoice-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisvoice-lang" class="dfn-panel" data-for="dom-speechsynthesisvoice-lang" id="infopanel-for-dom-speechsynthesisvoice-lang" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisvoice-lang" style="display:none">Info about the 'lang' definition.</span><b><a href="#dom-speechsynthesisvoice-lang">#dom-speechsynthesisvoice-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisvoice-lang">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisvoice-localservice">
-   <b><a href="#dom-speechsynthesisvoice-localservice">#dom-speechsynthesisvoice-localservice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisvoice-localservice" class="dfn-panel" data-for="dom-speechsynthesisvoice-localservice" id="infopanel-for-dom-speechsynthesisvoice-localservice" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisvoice-localservice" style="display:none">Info about the 'localService' definition.</span><b><a href="#dom-speechsynthesisvoice-localservice">#dom-speechsynthesisvoice-localservice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisvoice-localservice">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-speechsynthesisvoice-default">
-   <b><a href="#dom-speechsynthesisvoice-default">#dom-speechsynthesisvoice-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-speechsynthesisvoice-default" class="dfn-panel" data-for="dom-speechsynthesisvoice-default" id="infopanel-for-dom-speechsynthesisvoice-default" role="dialog">
+   <span id="infopaneltitle-for-dom-speechsynthesisvoice-default" style="display:none">Info about the 'default' definition.</span><b><a href="#dom-speechsynthesisvoice-default">#dom-speechsynthesisvoice-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-speechsynthesisvoice-default">4.2. The SpeechSynthesis Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/ua-client-hints/index.html
+++ b/tests/github/WICG/ua-client-hints/index.html
@@ -1660,46 +1660,46 @@ for valuable feedback and contributions to this specification.</p>
    <li><a href="#dom-navigatorua-useragentdata">userAgentData</a><span>, in § 4</span>
    <li><a href="#dom-navigatoruabrandversion-version">version</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-fingerprinting">
-   <a href="https://w3c.github.io/fingerprinting-guidance/#dfn-active-fingerprinting">https://w3c.github.io/fingerprinting-guidance/#dfn-active-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-fingerprinting" class="dfn-panel" data-for="term-for-dfn-active-fingerprinting" id="infopanel-for-term-for-dfn-active-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-fingerprinting" style="display:none">Info about the 'active fingerprinting' external reference.</span><a href="https://w3c.github.io/fingerprinting-guidance/#dfn-active-fingerprinting">https://w3c.github.io/fingerprinting-guidance/#dfn-active-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-fingerprinting">5.3. Fingerprinting</a> <a href="#ref-for-dfn-active-fingerprinting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstract-opdef-append-client-hints-to-request">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request">https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-opdef-append-client-hints-to-request" class="dfn-panel" data-for="term-for-abstract-opdef-append-client-hints-to-request" id="infopanel-for-term-for-abstract-opdef-append-client-hints-to-request" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-opdef-append-client-hints-to-request" style="display:none">Info about the 'append client hints to request' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request">https://wicg.github.io/client-hints-infrastructure/#abstract-opdef-append-client-hints-to-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-append-client-hints-to-request">5.2. Delegation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-avoid-passive-increases">
-   <a href="https://w3c.github.io/fingerprinting-guidance/#avoid-passive-increases">https://w3c.github.io/fingerprinting-guidance/#avoid-passive-increases</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-avoid-passive-increases" class="dfn-panel" data-for="term-for-avoid-passive-increases" id="infopanel-for-term-for-avoid-passive-increases" role="menu">
+   <span id="infopaneltitle-for-term-for-avoid-passive-increases" style="display:none">Info about the 'best practice 1' external reference.</span><a href="https://w3c.github.io/fingerprinting-guidance/#avoid-passive-increases">https://w3c.github.io/fingerprinting-guidance/#avoid-passive-increases</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-avoid-passive-increases">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-client-hints-token">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#client-hints-token">https://wicg.github.io/client-hints-infrastructure/#client-hints-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-client-hints-token" class="dfn-panel" data-for="term-for-client-hints-token" id="infopanel-for-term-for-client-hints-token" role="menu">
+   <span id="infopaneltitle-for-term-for-client-hints-token" style="display:none">Info about the 'client hints token' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#client-hints-token">https://wicg.github.io/client-hints-infrastructure/#client-hints-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-hints-token">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-low-entropy-hint-table">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#low-entropy-hint-table">https://wicg.github.io/client-hints-infrastructure/#low-entropy-hint-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-low-entropy-hint-table" class="dfn-panel" data-for="term-for-low-entropy-hint-table" id="infopanel-for-term-for-low-entropy-hint-table" role="menu">
+   <span id="infopaneltitle-for-term-for-low-entropy-hint-table" style="display:none">Info about the 'low entropy hint table' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#low-entropy-hint-table">https://wicg.github.io/client-hints-infrastructure/#low-entropy-hint-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-entropy-hint-table">3.1. The 'Sec-CH-UA' Header Field</a>
     <li><a href="#ref-for-low-entropy-hint-table①">3.5. The 'Sec-CH-UA-Mobile' Header Field</a>
     <li><a href="#ref-for-low-entropy-hint-table②">3.7. The 'Sec-CH-UA-Platform' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-passive-fingerprinting">
-   <a href="https://w3c.github.io/fingerprinting-guidance/#dfn-passive-fingerprinting">https://w3c.github.io/fingerprinting-guidance/#dfn-passive-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-passive-fingerprinting" class="dfn-panel" data-for="term-for-dfn-passive-fingerprinting" id="infopanel-for-term-for-dfn-passive-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-passive-fingerprinting" style="display:none">Info about the 'passive fingerprinting' external reference.</span><a href="https://w3c.github.io/fingerprinting-guidance/#dfn-passive-fingerprinting">https://w3c.github.io/fingerprinting-guidance/#dfn-passive-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-passive-fingerprinting">Unnumbered Section</a>
     <li><a href="#ref-for-dfn-passive-fingerprinting①">1. Introduction</a>
@@ -1707,96 +1707,96 @@ for valuable feedback and contributions to this specification.</p>
     <li><a href="#ref-for-dfn-passive-fingerprinting③">5.3. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-client-hints-features">
-   <a href="https://wicg.github.io/client-hints-infrastructure/#policy-controlled-client-hints-features">https://wicg.github.io/client-hints-infrastructure/#policy-controlled-client-hints-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-client-hints-features" class="dfn-panel" data-for="term-for-policy-controlled-client-hints-features" id="infopanel-for-term-for-policy-controlled-client-hints-features" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-client-hints-features" style="display:none">Info about the 'policy controlled client hints features' external reference.</span><a href="https://wicg.github.io/client-hints-infrastructure/#policy-controlled-client-hints-features">https://wicg.github.io/client-hints-infrastructure/#policy-controlled-client-hints-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-client-hints-features">3.1. The 'Sec-CH-UA' Header Field</a>
     <li><a href="#ref-for-policy-controlled-client-hints-features①">3.5. The 'Sec-CH-UA-Mobile' Header Field</a>
     <li><a href="#ref-for-policy-controlled-client-hints-features②">3.7. The 'Sec-CH-UA-Platform' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">4.1.1. WindowOrWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">4.1.4. Getters</a>
     <li><a href="#ref-for-concept-relevant-global①">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.1.2. Create brands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-alpha">
-   <a href="https://infra.spec.whatwg.org/#ascii-alpha">https://infra.spec.whatwg.org/#ascii-alpha</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-alpha" class="dfn-panel" data-for="term-for-ascii-alpha" id="infopanel-for-term-for-ascii-alpha" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-alpha" style="display:none">Info about the 'ascii alpha' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-alpha">https://infra.spec.whatwg.org/#ascii-alpha</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alpha">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-byte">
-   <a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-byte" class="dfn-panel" data-for="term-for-ascii-byte" id="infopanel-for-term-for-ascii-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-byte" style="display:none">Info about the 'ascii byte' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-byte">4.1.3. Create arbitrary brand and version values</a> <a href="#ref-for-ascii-byte①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenation' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.1.5. getHighEntropyValues method</a> <a href="#ref-for-list-contain①">(2)</a> <a href="#ref-for-list-contain②">(3)</a> <a href="#ref-for-list-contain③">(4)</a> <a href="#ref-for-list-contain④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.1.2. Create brands</a> <a href="#ref-for-list-item①">(2)</a>
     <li><a href="#ref-for-list-item②">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
     <li><a href="#ref-for-list①">4.1.1. WindowOrWorkerGlobalScope</a>
@@ -1804,44 +1804,44 @@ for valuable feedback and contributions to this specification.</p>
     <li><a href="#ref-for-list③">4.1.3. Create arbitrary brand and version values</a> <a href="#ref-for-list④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-pop">
-   <a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-pop" class="dfn-panel" data-for="term-for-stack-pop" id="infopanel-for-term-for-stack-pop" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-pop" style="display:none">Info about the 'pop' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-pop">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-push">
-   <a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-push" class="dfn-panel" data-for="term-for-stack-push" id="infopanel-for-term-for-stack-push" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-push" style="display:none">Info about the 'push' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-push">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-ascii-whitespace" class="dfn-panel" data-for="term-for-split-on-ascii-whitespace" id="infopanel-for-term-for-split-on-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-ascii-whitespace" style="display:none">Info about the 'split on ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-ascii-whitespace">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack">
-   <a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack" class="dfn-panel" data-for="term-for-stack" id="infopanel-for-term-for-stack" role="menu">
+   <span id="infopaneltitle-for-term-for-stack" style="display:none">Info about the 'stack' external reference.</span><a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.1.3. Create arbitrary brand and version values</a> <a href="#ref-for-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-agent">
-   <a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-agent" class="dfn-panel" data-for="term-for-user-agent" id="infopanel-for-term-for-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-user-agent" style="display:none">Info about the 'user agent' external reference.</span><a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">3. User Agent Hints</a> <a href="#ref-for-user-agent①">(2)</a> <a href="#ref-for-user-agent②">(3)</a> <a href="#ref-for-user-agent③">(4)</a> <a href="#ref-for-user-agent④">(5)</a> <a href="#ref-for-user-agent⑤">(6)</a> <a href="#ref-for-user-agent⑥">(7)</a> <a href="#ref-for-user-agent⑦">(8)</a> <a href="#ref-for-user-agent⑧">(9)</a> <a href="#ref-for-user-agent⑨">(10)</a> <a href="#ref-for-user-agent①⓪">(11)</a> <a href="#ref-for-user-agent①①">(12)</a> <a href="#ref-for-user-agent①②">(13)</a> <a href="#ref-for-user-agent①③">(14)</a> <a href="#ref-for-user-agent①④">(15)</a> <a href="#ref-for-user-agent①⑤">(16)</a> <a href="#ref-for-user-agent①⑥">(17)</a> <a href="#ref-for-user-agent①⑦">(18)</a>
     <li><a href="#ref-for-user-agent①⑧">3.1. The 'Sec-CH-UA' Header Field</a> <a href="#ref-for-user-agent①⑨">(2)</a> <a href="#ref-for-user-agent②⓪">(3)</a>
@@ -1865,26 +1865,26 @@ for valuable feedback and contributions to this specification.</p>
     <li><a href="#ref-for-user-agent⑤③">6.2. GREASE-like UA Brand Lists</a> <a href="#ref-for-user-agent⑤④">(2)</a> <a href="#ref-for-user-agent⑤⑤">(3)</a> <a href="#ref-for-user-agent⑤⑥">(4)</a> <a href="#ref-for-user-agent⑤⑦">(5)</a> <a href="#ref-for-user-agent⑤⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3.6">
-   <a href="https://tools.ietf.org/html/rfc8941#section-3.3.6">https://tools.ietf.org/html/rfc8941#section-3.3.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3.6" class="dfn-panel" data-for="term-for-section-3.3.6" id="infopanel-for-term-for-section-3.3.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3.6" style="display:none">Info about the 'boolean' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-3.3.6">https://tools.ietf.org/html/rfc8941#section-3.3.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3.6">3.5. The 'Sec-CH-UA-Mobile' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1">
-   <a href="https://tools.ietf.org/html/rfc8941#section-3.1">https://tools.ietf.org/html/rfc8941#section-3.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1" class="dfn-panel" data-for="term-for-section-3.1" id="infopanel-for-term-for-section-3.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1" style="display:none">Info about the 'list' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-3.1">https://tools.ietf.org/html/rfc8941#section-3.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1">3.1. The 'Sec-CH-UA' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1.1">
-   <a href="https://tools.ietf.org/html/rfc8941#section-4.1.1">https://tools.ietf.org/html/rfc8941#section-4.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1.1" class="dfn-panel" data-for="term-for-section-4.1.1" id="infopanel-for-term-for-section-4.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1.1" style="display:none">Info about the 'serializing a list' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-4.1.1">https://tools.ietf.org/html/rfc8941#section-4.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.1">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3.3">
-   <a href="https://tools.ietf.org/html/rfc8941#section-3.3.3">https://tools.ietf.org/html/rfc8941#section-3.3.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3.3" class="dfn-panel" data-for="term-for-section-3.3.3" id="infopanel-for-term-for-section-3.3.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3.3" style="display:none">Info about the 'string' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-3.3.3">https://tools.ietf.org/html/rfc8941#section-3.3.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3.3">3.1. The 'Sec-CH-UA' Header Field</a>
     <li><a href="#ref-for-section-3.3.3①">3.2. The 'Sec-CH-UA-Arch' Header Field</a>
@@ -1896,8 +1896,8 @@ for valuable feedback and contributions to this specification.</p>
     <li><a href="#ref-for-section-3.3.3⑦">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://tools.ietf.org/html/rfc8941#">https://tools.ietf.org/html/rfc8941#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'structured header' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#">https://tools.ietf.org/html/rfc8941#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">3.1. The 'Sec-CH-UA' Header Field</a>
     <li><a href="#termref-for-">3.2. The 'Sec-CH-UA-Arch' Header Field</a>
@@ -1910,87 +1910,87 @@ for valuable feedback and contributions to this specification.</p>
     <li><a href="#termref-for-">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4. Interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a> <a href="#ref-for-idl-DOMString⑥">(7)</a> <a href="#ref-for-idl-DOMString⑦">(8)</a> <a href="#ref-for-idl-DOMString⑧">(9)</a> <a href="#ref-for-idl-DOMString⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">4. Interface</a> <a href="#ref-for-idl-frozen-array①">(2)</a>
     <li><a href="#ref-for-idl-frozen-array②">4.1.1. WindowOrWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4. Interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4. Interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-frozen-array" class="dfn-panel" data-for="term-for-dfn-create-frozen-array" id="infopanel-for-term-for-dfn-create-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">4.1.1. WindowOrWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary">
-   <a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary" class="dfn-panel" data-for="term-for-dfn-dictionary" id="infopanel-for-term-for-dfn-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary" style="display:none">Info about the 'dictionary' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">4.1.4. Getters</a>
     <li><a href="#ref-for-this①">4.1.5. getHighEntropyValues method</a>
@@ -2139,273 +2139,329 @@ for valuable feedback and contributions to this specification.</p>
    <div class="issue"> Perhaps <code>Sec-CH-UA-Mobile</code> is enough, and we don’t need to expose the model? <a class="issue-return" href="#issue-1a9c4c0c" title="Jump to section">↵</a></div>
    <div class="issue"> We can improve upon when and why a UA decides to refuse a hint once <a href="https://github.com/WICG/ua-client-hints/issues/151">Issue #151</a> is resolved. <a class="issue-return" href="#issue-22962aa8" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="user-agent-brand">
-   <b><a href="#user-agent-brand">#user-agent-brand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-brand" class="dfn-panel" data-for="user-agent-brand" id="infopanel-for-user-agent-brand" role="dialog">
+   <span id="infopaneltitle-for-user-agent-brand" style="display:none">Info about the 'brand' definition.</span><b><a href="#user-agent-brand">#user-agent-brand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-brand">4.1.2. Create brands</a> <a href="#ref-for-user-agent-brand①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-significant-version">
-   <b><a href="#user-agent-significant-version">#user-agent-significant-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-significant-version" class="dfn-panel" data-for="user-agent-significant-version" id="infopanel-for-user-agent-significant-version" role="dialog">
+   <span id="infopaneltitle-for-user-agent-significant-version" style="display:none">Info about the 'significant version' definition.</span><b><a href="#user-agent-significant-version">#user-agent-significant-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-significant-version">4.1.2. Create brands</a> <a href="#ref-for-user-agent-significant-version①">(2)</a>
     <li><a href="#ref-for-user-agent-significant-version②">4.1.3. Create arbitrary brand and version values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-full-version">
-   <b><a href="#user-agent-full-version">#user-agent-full-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-full-version" class="dfn-panel" data-for="user-agent-full-version" id="infopanel-for-user-agent-full-version" role="dialog">
+   <span id="infopaneltitle-for-user-agent-full-version" style="display:none">Info about the 'full version' definition.</span><b><a href="#user-agent-full-version">#user-agent-full-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-full-version">3. User Agent Hints</a>
     <li><a href="#ref-for-user-agent-full-version①">3.4. The 'Sec-CH-UA-Full-Version' Header Field</a>
     <li><a href="#ref-for-user-agent-full-version②">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-platform-brand">
-   <b><a href="#user-agent-platform-brand">#user-agent-platform-brand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-platform-brand" class="dfn-panel" data-for="user-agent-platform-brand" id="infopanel-for-user-agent-platform-brand" role="dialog">
+   <span id="infopaneltitle-for-user-agent-platform-brand" style="display:none">Info about the 'platform brand' definition.</span><b><a href="#user-agent-platform-brand">#user-agent-platform-brand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-platform-brand">4.1.4. Getters</a>
     <li><a href="#ref-for-user-agent-platform-brand①">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-platform-version">
-   <b><a href="#user-agent-platform-version">#user-agent-platform-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-platform-version" class="dfn-panel" data-for="user-agent-platform-version" id="infopanel-for-user-agent-platform-version" role="dialog">
+   <span id="infopaneltitle-for-user-agent-platform-version" style="display:none">Info about the 'platform version' definition.</span><b><a href="#user-agent-platform-version">#user-agent-platform-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-platform-version">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-platform-architecture">
-   <b><a href="#user-agent-platform-architecture">#user-agent-platform-architecture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-platform-architecture" class="dfn-panel" data-for="user-agent-platform-architecture" id="infopanel-for-user-agent-platform-architecture" role="dialog">
+   <span id="infopaneltitle-for-user-agent-platform-architecture" style="display:none">Info about the 'platform architecture' definition.</span><b><a href="#user-agent-platform-architecture">#user-agent-platform-architecture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-platform-architecture">3. User Agent Hints</a> <a href="#ref-for-user-agent-platform-architecture①">(2)</a> <a href="#ref-for-user-agent-platform-architecture②">(3)</a>
     <li><a href="#ref-for-user-agent-platform-architecture③">4.1.5. getHighEntropyValues method</a>
     <li><a href="#ref-for-user-agent-platform-architecture④">5.4. Access Restrictions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-platform-bitness">
-   <b><a href="#user-agent-platform-bitness">#user-agent-platform-bitness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-platform-bitness" class="dfn-panel" data-for="user-agent-platform-bitness" id="infopanel-for-user-agent-platform-bitness" role="dialog">
+   <span id="infopaneltitle-for-user-agent-platform-bitness" style="display:none">Info about the 'platform bitness' definition.</span><b><a href="#user-agent-platform-bitness">#user-agent-platform-bitness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-platform-bitness">3. User Agent Hints</a> <a href="#ref-for-user-agent-platform-bitness①">(2)</a>
     <li><a href="#ref-for-user-agent-platform-bitness②">4.1.5. getHighEntropyValues method</a>
     <li><a href="#ref-for-user-agent-platform-bitness③">5.4. Access Restrictions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-model">
-   <b><a href="#user-agent-model">#user-agent-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-model" class="dfn-panel" data-for="user-agent-model" id="infopanel-for-user-agent-model" role="dialog">
+   <span id="infopaneltitle-for-user-agent-model" style="display:none">Info about the 'model' definition.</span><b><a href="#user-agent-model">#user-agent-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-model">3. User Agent Hints</a> <a href="#ref-for-user-agent-model①">(2)</a> <a href="#ref-for-user-agent-model②">(3)</a>
     <li><a href="#ref-for-user-agent-model③">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-mobileness">
-   <b><a href="#user-agent-mobileness">#user-agent-mobileness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-mobileness" class="dfn-panel" data-for="user-agent-mobileness" id="infopanel-for-user-agent-mobileness" role="dialog">
+   <span id="infopaneltitle-for-user-agent-mobileness" style="display:none">Info about the 'mobileness' definition.</span><b><a href="#user-agent-mobileness">#user-agent-mobileness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-mobileness">3. User Agent Hints</a> <a href="#ref-for-user-agent-mobileness①">(2)</a>
     <li><a href="#ref-for-user-agent-mobileness②">4.1.4. Getters</a>
     <li><a href="#ref-for-user-agent-mobileness③">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-navigatoruabrandversion">
-   <b><a href="#dictdef-navigatoruabrandversion">#dictdef-navigatoruabrandversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-navigatoruabrandversion" class="dfn-panel" data-for="dictdef-navigatoruabrandversion" id="infopanel-for-dictdef-navigatoruabrandversion" role="dialog">
+   <span id="infopaneltitle-for-dictdef-navigatoruabrandversion" style="display:none">Info about the 'NavigatorUABrandVersion' definition.</span><b><a href="#dictdef-navigatoruabrandversion">#dictdef-navigatoruabrandversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-navigatoruabrandversion">4. Interface</a> <a href="#ref-for-dictdef-navigatoruabrandversion①">(2)</a>
     <li><a href="#ref-for-dictdef-navigatoruabrandversion②">4.1.1. WindowOrWorkerGlobalScope</a>
     <li><a href="#ref-for-dictdef-navigatoruabrandversion③">4.1.2. Create brands</a> <a href="#ref-for-dictdef-navigatoruabrandversion④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatoruabrandversion-brand">
-   <b><a href="#dom-navigatoruabrandversion-brand">#dom-navigatoruabrandversion-brand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatoruabrandversion-brand" class="dfn-panel" data-for="dom-navigatoruabrandversion-brand" id="infopanel-for-dom-navigatoruabrandversion-brand" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatoruabrandversion-brand" style="display:none">Info about the 'brand' definition.</span><b><a href="#dom-navigatoruabrandversion-brand">#dom-navigatoruabrandversion-brand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatoruabrandversion-brand">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
     <li><a href="#ref-for-dom-navigatoruabrandversion-brand①">4.1.2. Create brands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatoruabrandversion-version">
-   <b><a href="#dom-navigatoruabrandversion-version">#dom-navigatoruabrandversion-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatoruabrandversion-version" class="dfn-panel" data-for="dom-navigatoruabrandversion-version" id="infopanel-for-dom-navigatoruabrandversion-version" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatoruabrandversion-version" style="display:none">Info about the 'version' definition.</span><b><a href="#dom-navigatoruabrandversion-version">#dom-navigatoruabrandversion-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatoruabrandversion-version">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
     <li><a href="#ref-for-dom-navigatoruabrandversion-version①">4.1.2. Create brands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-uadatavalues">
-   <b><a href="#dictdef-uadatavalues">#dictdef-uadatavalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-uadatavalues" class="dfn-panel" data-for="dictdef-uadatavalues" id="infopanel-for-dictdef-uadatavalues" role="dialog">
+   <span id="infopaneltitle-for-dictdef-uadatavalues" style="display:none">Info about the 'UADataValues' definition.</span><b><a href="#dictdef-uadatavalues">#dictdef-uadatavalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-uadatavalues">4. Interface</a>
     <li><a href="#ref-for-dictdef-uadatavalues①">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-brands">
-   <b><a href="#dom-uadatavalues-brands">#dom-uadatavalues-brands</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-brands" class="dfn-panel" data-for="dom-uadatavalues-brands" id="infopanel-for-dom-uadatavalues-brands" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-brands" style="display:none">Info about the 'brands' definition.</span><b><a href="#dom-uadatavalues-brands">#dom-uadatavalues-brands</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-brands">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-mobile">
-   <b><a href="#dom-uadatavalues-mobile">#dom-uadatavalues-mobile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-mobile" class="dfn-panel" data-for="dom-uadatavalues-mobile" id="infopanel-for-dom-uadatavalues-mobile" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-mobile" style="display:none">Info about the 'mobile' definition.</span><b><a href="#dom-uadatavalues-mobile">#dom-uadatavalues-mobile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-mobile">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-platform">
-   <b><a href="#dom-uadatavalues-platform">#dom-uadatavalues-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-platform" class="dfn-panel" data-for="dom-uadatavalues-platform" id="infopanel-for-dom-uadatavalues-platform" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-platform" style="display:none">Info about the 'platform' definition.</span><b><a href="#dom-uadatavalues-platform">#dom-uadatavalues-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-platform">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-architecture">
-   <b><a href="#dom-uadatavalues-architecture">#dom-uadatavalues-architecture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-architecture" class="dfn-panel" data-for="dom-uadatavalues-architecture" id="infopanel-for-dom-uadatavalues-architecture" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-architecture" style="display:none">Info about the 'architecture' definition.</span><b><a href="#dom-uadatavalues-architecture">#dom-uadatavalues-architecture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-architecture">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-bitness">
-   <b><a href="#dom-uadatavalues-bitness">#dom-uadatavalues-bitness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-bitness" class="dfn-panel" data-for="dom-uadatavalues-bitness" id="infopanel-for-dom-uadatavalues-bitness" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-bitness" style="display:none">Info about the 'bitness' definition.</span><b><a href="#dom-uadatavalues-bitness">#dom-uadatavalues-bitness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-bitness">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-model">
-   <b><a href="#dom-uadatavalues-model">#dom-uadatavalues-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-model" class="dfn-panel" data-for="dom-uadatavalues-model" id="infopanel-for-dom-uadatavalues-model" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-model" style="display:none">Info about the 'model' definition.</span><b><a href="#dom-uadatavalues-model">#dom-uadatavalues-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-model">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-platformversion">
-   <b><a href="#dom-uadatavalues-platformversion">#dom-uadatavalues-platformversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-platformversion" class="dfn-panel" data-for="dom-uadatavalues-platformversion" id="infopanel-for-dom-uadatavalues-platformversion" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-platformversion" style="display:none">Info about the 'platformVersion' definition.</span><b><a href="#dom-uadatavalues-platformversion">#dom-uadatavalues-platformversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-platformversion">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uadatavalues-uafullversion">
-   <b><a href="#dom-uadatavalues-uafullversion">#dom-uadatavalues-uafullversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uadatavalues-uafullversion" class="dfn-panel" data-for="dom-uadatavalues-uafullversion" id="infopanel-for-dom-uadatavalues-uafullversion" role="dialog">
+   <span id="infopaneltitle-for-dom-uadatavalues-uafullversion" style="display:none">Info about the 'uaFullVersion' definition.</span><b><a href="#dom-uadatavalues-uafullversion">#dom-uadatavalues-uafullversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uadatavalues-uafullversion">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatoruadata">
-   <b><a href="#navigatoruadata">#navigatoruadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatoruadata" class="dfn-panel" data-for="navigatoruadata" id="infopanel-for-navigatoruadata" role="dialog">
+   <span id="infopaneltitle-for-navigatoruadata" style="display:none">Info about the 'NavigatorUAData' definition.</span><b><a href="#navigatoruadata">#navigatoruadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatoruadata">4. Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatoruadata-brands">
-   <b><a href="#dom-navigatoruadata-brands">#dom-navigatoruadata-brands</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatoruadata-brands" class="dfn-panel" data-for="dom-navigatoruadata-brands" id="infopanel-for-dom-navigatoruadata-brands" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatoruadata-brands" style="display:none">Info about the 'brands' definition.</span><b><a href="#dom-navigatoruadata-brands">#dom-navigatoruadata-brands</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatoruadata-brands">4.1.4. Getters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatoruadata-mobile">
-   <b><a href="#dom-navigatoruadata-mobile">#dom-navigatoruadata-mobile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatoruadata-mobile" class="dfn-panel" data-for="dom-navigatoruadata-mobile" id="infopanel-for-dom-navigatoruadata-mobile" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatoruadata-mobile" style="display:none">Info about the 'mobile' definition.</span><b><a href="#dom-navigatoruadata-mobile">#dom-navigatoruadata-mobile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatoruadata-mobile">4.1.4. Getters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatoruadata-platform">
-   <b><a href="#dom-navigatoruadata-platform">#dom-navigatoruadata-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatoruadata-platform" class="dfn-panel" data-for="dom-navigatoruadata-platform" id="infopanel-for-dom-navigatoruadata-platform" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatoruadata-platform" style="display:none">Info about the 'platform' definition.</span><b><a href="#dom-navigatoruadata-platform">#dom-navigatoruadata-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatoruadata-platform">4.1.4. Getters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatorua">
-   <b><a href="#navigatorua">#navigatorua</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatorua" class="dfn-panel" data-for="navigatorua" id="infopanel-for-navigatorua" role="dialog">
+   <span id="infopaneltitle-for-navigatorua" style="display:none">Info about the 'NavigatorUA' definition.</span><b><a href="#navigatorua">#navigatorua</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatorua">4. Interface</a> <a href="#ref-for-navigatorua①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-brands">
-   <b><a href="#user-agent-brands">#user-agent-brands</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-brands" class="dfn-panel" data-for="user-agent-brands" id="infopanel-for-user-agent-brands" role="dialog">
+   <span id="infopaneltitle-for-user-agent-brands" style="display:none">Info about the 'brands' definition.</span><b><a href="#user-agent-brands">#user-agent-brands</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-brands">3.8. The 'Sec-CH-UA-Platform-Version' Header Field</a>
     <li><a href="#ref-for-user-agent-brands①">4.1.1. WindowOrWorkerGlobalScope</a>
     <li><a href="#ref-for-user-agent-brands②">6.2. GREASE-like UA Brand Lists</a> <a href="#ref-for-user-agent-brands③">(2)</a> <a href="#ref-for-user-agent-brands④">(3)</a> <a href="#ref-for-user-agent-brands⑤">(4)</a> <a href="#ref-for-user-agent-brands⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windoworworkerglobalscope-brands-frozen-array">
-   <b><a href="#windoworworkerglobalscope-brands-frozen-array">#windoworworkerglobalscope-brands-frozen-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windoworworkerglobalscope-brands-frozen-array" class="dfn-panel" data-for="windoworworkerglobalscope-brands-frozen-array" id="infopanel-for-windoworworkerglobalscope-brands-frozen-array" role="dialog">
+   <span id="infopaneltitle-for-windoworworkerglobalscope-brands-frozen-array" style="display:none">Info about the 'brands frozen array' definition.</span><b><a href="#windoworworkerglobalscope-brands-frozen-array">#windoworworkerglobalscope-brands-frozen-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope-brands-frozen-array">4.1.4. Getters</a>
     <li><a href="#ref-for-windoworworkerglobalscope-brands-frozen-array①">4.1.5. getHighEntropyValues method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-brands">
-   <b><a href="#create-brands">#create-brands</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-brands" class="dfn-panel" data-for="create-brands" id="infopanel-for-create-brands" role="dialog">
+   <span id="infopaneltitle-for-create-brands" style="display:none">Info about the 'create brands' definition.</span><b><a href="#create-brands">#create-brands</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-brands">4.1.1. WindowOrWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-equivalence-class">
-   <b><a href="#user-agent-equivalence-class">#user-agent-equivalence-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-equivalence-class" class="dfn-panel" data-for="user-agent-equivalence-class" id="infopanel-for-user-agent-equivalence-class" role="dialog">
+   <span id="infopaneltitle-for-user-agent-equivalence-class" style="display:none">Info about the 'equivalence class' definition.</span><b><a href="#user-agent-equivalence-class">#user-agent-equivalence-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-equivalence-class">4.1.2. Create brands</a> <a href="#ref-for-user-agent-equivalence-class①">(2)</a>
     <li><a href="#ref-for-user-agent-equivalence-class②">6.2. GREASE-like UA Brand Lists</a> <a href="#ref-for-user-agent-equivalence-class③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-arbitrary-brand">
-   <b><a href="#create-an-arbitrary-brand">#create-an-arbitrary-brand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-arbitrary-brand" class="dfn-panel" data-for="create-an-arbitrary-brand" id="infopanel-for-create-an-arbitrary-brand" role="dialog">
+   <span id="infopaneltitle-for-create-an-arbitrary-brand" style="display:none">Info about the 'create an arbitrary brand' definition.</span><b><a href="#create-an-arbitrary-brand">#create-an-arbitrary-brand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-arbitrary-brand">4.1.2. Create brands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-arbitrary-version">
-   <b><a href="#create-an-arbitrary-version">#create-an-arbitrary-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-arbitrary-version" class="dfn-panel" data-for="create-an-arbitrary-version" id="infopanel-for-create-an-arbitrary-version" role="dialog">
+   <span id="infopaneltitle-for-create-an-arbitrary-version" style="display:none">Info about the 'create an arbitrary version' definition.</span><b><a href="#create-an-arbitrary-version">#create-an-arbitrary-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-arbitrary-version">4.1.2. Create brands</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/video-rvfc/index.html
+++ b/tests/github/WICG/video-rvfc/index.html
@@ -1011,48 +1011,48 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
    <li><a href="#video-frame-request-callback-identifier">video frame request callback identifier</a><span>, in § 4.1</span>
    <li><a href="#dom-videoframemetadata-width">width</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values/#px">https://drafts.csswg.org/css-values/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'css pixels' external reference.</span><a href="https://drafts.csswg.org/css-values/#px">https://drafts.csswg.org/css-values/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2. Procedures</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a> <a href="#ref-for-document③">(4)</a> <a href="#ref-for-document④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-node-ownerdocument">
-   <a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">https://dom.spec.whatwg.org/#dom-node-ownerdocument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-node-ownerdocument" class="dfn-panel" data-for="term-for-dom-node-ownerdocument" id="infopanel-for-term-for-dom-node-ownerdocument" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-node-ownerdocument" style="display:none">Info about the 'ownerDocument' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">https://dom.spec.whatwg.org/#dom-node-ownerdocument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-ownerdocument">4.1. Methods</a> <a href="#ref-for-dom-node-ownerdocument①">(2)</a>
     <li><a href="#ref-for-dom-node-ownerdocument②">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">2. VideoFrameMetadata</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a> <a href="#ref-for-dom-domhighrestimestamp②">(3)</a> <a href="#ref-for-dom-domhighrestimestamp③">(4)</a>
     <li><a href="#ref-for-dom-domhighrestimestamp④">2.2. Attributes</a> <a href="#ref-for-dom-domhighrestimestamp⑤">(2)</a> <a href="#ref-for-dom-domhighrestimestamp⑥">(3)</a> <a href="#ref-for-dom-domhighrestimestamp⑦">(4)</a>
     <li><a href="#ref-for-dom-domhighrestimestamp⑧">3. VideoFrameRequestCallback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clock-resolution">
-   <a href="https://w3c.github.io/hr-time/#clock-resolution">https://w3c.github.io/hr-time/#clock-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clock-resolution" class="dfn-panel" data-for="term-for-clock-resolution" id="infopanel-for-term-for-clock-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-clock-resolution" style="display:none">Info about the 'clock resolution' external reference.</span><a href="https://w3c.github.io/hr-time/#clock-resolution">https://w3c.github.io/hr-time/#clock-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clock-resolution">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationframeprovider">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationframeprovider" class="dfn-panel" data-for="term-for-animationframeprovider" id="infopanel-for-term-for-animationframeprovider" role="menu">
+   <span id="infopaneltitle-for-term-for-animationframeprovider" style="display:none">Info about the 'AnimationFrameProvider' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animationframeprovider</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationframeprovider">1. Introduction</a>
     <li><a href="#ref-for-animationframeprovider①">6.1. Drawing frames at the video rate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">1. Introduction</a>
     <li><a href="#ref-for-htmlvideoelement①">4. HTMLVideoElement.requestVideoFrameCallback()</a>
@@ -1060,84 +1060,84 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
     <li><a href="#ref-for-htmlvideoelement⑤">4.2. Procedures</a> <a href="#ref-for-htmlvideoelement⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">1. Introduction</a>
     <li><a href="#ref-for-canvas①">6.1. Drawing frames at the video rate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-currenttime">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-currenttime" class="dfn-panel" data-for="term-for-dom-media-currenttime" id="infopanel-for-term-for-dom-media-currenttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-currenttime" style="display:none">Info about the 'currentTime' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-currenttime">2.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">4.2. Procedures</a> <a href="#ref-for-fully-active①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks" id="infopanel-for-term-for-run-the-animation-frame-callbacks" role="menu">
+   <span id="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" style="display:none">Info about the 'run the animation frame callbacks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-animation-frame-callbacks">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">1. Introduction</a>
     <li><a href="#ref-for-update-the-rendering①">4.2. Procedures</a> <a href="#ref-for-update-the-rendering②">(2)</a> <a href="#ref-for-update-the-rendering③">(3)</a> <a href="#ref-for-update-the-rendering④">(4)</a> <a href="#ref-for-update-the-rendering⑤">(5)</a> <a href="#ref-for-update-the-rendering⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videoheight" class="dfn-panel" data-for="term-for-dom-video-videoheight" id="infopanel-for-term-for-dom-video-videoheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videoheight" style="display:none">Info about the 'videoHeight' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videoheight">2.2. Attributes</a> <a href="#ref-for-dom-video-videoheight①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videowidth">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videowidth" class="dfn-panel" data-for="term-for-dom-video-videowidth" id="infopanel-for-term-for-dom-video-videowidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videowidth" style="display:none">Info about the 'videoWidth' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videowidth">2.2. Attributes</a> <a href="#ref-for-dom-video-videowidth①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-mediacapabilitiesinfo">
-   <a href="https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo">https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-mediacapabilitiesinfo" class="dfn-panel" data-for="term-for-dictdef-mediacapabilitiesinfo" id="infopanel-for-term-for-dictdef-mediacapabilitiesinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-mediacapabilitiesinfo" style="display:none">Info about the 'MediaCapabilitiesInfo' external reference.</span><a href="https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo">https://w3c.github.io/media-capabilities#dictdef-mediacapabilitiesinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediacapabilitiesinfo">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2. VideoFrameMetadata</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">2.2. Attributes</a> <a href="#ref-for-idl-double③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. VideoFrameRequestCallback</a>
     <li><a href="#ref-for-idl-undefined①">4. HTMLVideoElement.requestVideoFrameCallback()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2. VideoFrameMetadata</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a>
     <li><a href="#ref-for-idl-unsigned-long④">2.2. Attributes</a> <a href="#ref-for-idl-unsigned-long⑤">(2)</a> <a href="#ref-for-idl-unsigned-long⑥">(3)</a> <a href="#ref-for-idl-unsigned-long⑦">(4)</a>
@@ -1249,94 +1249,94 @@ can be done by using <code class="idl"><a data-link-type="idl" href="#dom-htmlvi
 video frame request callbacks</a> from the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">update the rendering</a> steps. This procedure describes
 where and how to invoke the algorithm in the meantime. <a class="issue-return" href="#issue-9a108000" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dictdef-videoframemetadata">
-   <b><a href="#dictdef-videoframemetadata">#dictdef-videoframemetadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-videoframemetadata" class="dfn-panel" data-for="dictdef-videoframemetadata" id="infopanel-for-dictdef-videoframemetadata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-videoframemetadata" style="display:none">Info about the 'VideoFrameMetadata' definition.</span><b><a href="#dictdef-videoframemetadata">#dictdef-videoframemetadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-videoframemetadata">1. Introduction</a>
     <li><a href="#ref-for-dictdef-videoframemetadata①">3. VideoFrameRequestCallback</a>
     <li><a href="#ref-for-dictdef-videoframemetadata②">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-pixels">
-   <b><a href="#media-pixels">#media-pixels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-pixels" class="dfn-panel" data-for="media-pixels" id="infopanel-for-media-pixels" role="dialog">
+   <span id="infopaneltitle-for-media-pixels" style="display:none">Info about the 'media pixels' definition.</span><b><a href="#media-pixels">#media-pixels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-pixels">2.2. Attributes</a> <a href="#ref-for-media-pixels①">(2)</a> <a href="#ref-for-media-pixels②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentationtime">
-   <b><a href="#dom-videoframemetadata-presentationtime">#dom-videoframemetadata-presentationtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-presentationtime" class="dfn-panel" data-for="dom-videoframemetadata-presentationtime" id="infopanel-for-dom-videoframemetadata-presentationtime" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-presentationtime" style="display:none">Info about the 'presentationTime' definition.</span><b><a href="#dom-videoframemetadata-presentationtime">#dom-videoframemetadata-presentationtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-presentationtime">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-presentationtime①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-expecteddisplaytime">
-   <b><a href="#dom-videoframemetadata-expecteddisplaytime">#dom-videoframemetadata-expecteddisplaytime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-expecteddisplaytime" class="dfn-panel" data-for="dom-videoframemetadata-expecteddisplaytime" id="infopanel-for-dom-videoframemetadata-expecteddisplaytime" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-expecteddisplaytime" style="display:none">Info about the 'expectedDisplayTime' definition.</span><b><a href="#dom-videoframemetadata-expecteddisplaytime">#dom-videoframemetadata-expecteddisplaytime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-expecteddisplaytime">1. Introduction</a>
     <li><a href="#ref-for-dom-videoframemetadata-expecteddisplaytime①">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-expecteddisplaytime②">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-width">
-   <b><a href="#dom-videoframemetadata-width">#dom-videoframemetadata-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-width" class="dfn-panel" data-for="dom-videoframemetadata-width" id="infopanel-for-dom-videoframemetadata-width" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-videoframemetadata-width">#dom-videoframemetadata-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-width">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-width①">2.2. Attributes</a> <a href="#ref-for-dom-videoframemetadata-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-height">
-   <b><a href="#dom-videoframemetadata-height">#dom-videoframemetadata-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-height" class="dfn-panel" data-for="dom-videoframemetadata-height" id="infopanel-for-dom-videoframemetadata-height" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-videoframemetadata-height">#dom-videoframemetadata-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-height">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-height①">2.2. Attributes</a> <a href="#ref-for-dom-videoframemetadata-height②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-mediatime">
-   <b><a href="#dom-videoframemetadata-mediatime">#dom-videoframemetadata-mediatime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-mediatime" class="dfn-panel" data-for="dom-videoframemetadata-mediatime" id="infopanel-for-dom-videoframemetadata-mediatime" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-mediatime" style="display:none">Info about the 'mediaTime' definition.</span><b><a href="#dom-videoframemetadata-mediatime">#dom-videoframemetadata-mediatime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-mediatime">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-mediatime①">2.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-presentedframes">
-   <b><a href="#dom-videoframemetadata-presentedframes">#dom-videoframemetadata-presentedframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-presentedframes" class="dfn-panel" data-for="dom-videoframemetadata-presentedframes" id="infopanel-for-dom-videoframemetadata-presentedframes" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-presentedframes" style="display:none">Info about the 'presentedFrames' definition.</span><b><a href="#dom-videoframemetadata-presentedframes">#dom-videoframemetadata-presentedframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes">1. Introduction</a>
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes①">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-presentedframes②">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-processingduration">
-   <b><a href="#dom-videoframemetadata-processingduration">#dom-videoframemetadata-processingduration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-processingduration" class="dfn-panel" data-for="dom-videoframemetadata-processingduration" id="infopanel-for-dom-videoframemetadata-processingduration" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-processingduration" style="display:none">Info about the 'processingDuration' definition.</span><b><a href="#dom-videoframemetadata-processingduration">#dom-videoframemetadata-processingduration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-processingduration">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-processingduration①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-capturetime">
-   <b><a href="#dom-videoframemetadata-capturetime">#dom-videoframemetadata-capturetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-capturetime" class="dfn-panel" data-for="dom-videoframemetadata-capturetime" id="infopanel-for-dom-videoframemetadata-capturetime" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-capturetime" style="display:none">Info about the 'captureTime' definition.</span><b><a href="#dom-videoframemetadata-capturetime">#dom-videoframemetadata-capturetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-capturetime">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-capturetime①">5. Security and Privacy Considerations</a> <a href="#ref-for-dom-videoframemetadata-capturetime②">(2)</a> <a href="#ref-for-dom-videoframemetadata-capturetime③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-receivetime">
-   <b><a href="#dom-videoframemetadata-receivetime">#dom-videoframemetadata-receivetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-receivetime" class="dfn-panel" data-for="dom-videoframemetadata-receivetime" id="infopanel-for-dom-videoframemetadata-receivetime" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-receivetime" style="display:none">Info about the 'receiveTime' definition.</span><b><a href="#dom-videoframemetadata-receivetime">#dom-videoframemetadata-receivetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-receivetime">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-receivetime①">5. Security and Privacy Considerations</a> <a href="#ref-for-dom-videoframemetadata-receivetime②">(2)</a> <a href="#ref-for-dom-videoframemetadata-receivetime③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoframemetadata-rtptimestamp">
-   <b><a href="#dom-videoframemetadata-rtptimestamp">#dom-videoframemetadata-rtptimestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoframemetadata-rtptimestamp" class="dfn-panel" data-for="dom-videoframemetadata-rtptimestamp" id="infopanel-for-dom-videoframemetadata-rtptimestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-videoframemetadata-rtptimestamp" style="display:none">Info about the 'rtpTimestamp' definition.</span><b><a href="#dom-videoframemetadata-rtptimestamp">#dom-videoframemetadata-rtptimestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoframemetadata-rtptimestamp">2. VideoFrameMetadata</a>
     <li><a href="#ref-for-dom-videoframemetadata-rtptimestamp①">5. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-videoframerequestcallback">
-   <b><a href="#callbackdef-videoframerequestcallback">#callbackdef-videoframerequestcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-videoframerequestcallback" class="dfn-panel" data-for="callbackdef-videoframerequestcallback" id="infopanel-for-callbackdef-videoframerequestcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-videoframerequestcallback" style="display:none">Info about the 'VideoFrameRequestCallback' definition.</span><b><a href="#callbackdef-videoframerequestcallback">#callbackdef-videoframerequestcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-videoframerequestcallback">1. Introduction</a> <a href="#ref-for-callbackdef-videoframerequestcallback①">(2)</a> <a href="#ref-for-callbackdef-videoframerequestcallback②">(3)</a> <a href="#ref-for-callbackdef-videoframerequestcallback③">(4)</a>
     <li><a href="#ref-for-callbackdef-videoframerequestcallback④">2.2. Attributes</a>
@@ -1345,113 +1345,170 @@ where and how to invoke the algorithm in the meantime. <a class="issue-return" h
     <li><a href="#ref-for-callbackdef-videoframerequestcallback⑦">4.2. Procedures</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑧">(2)</a> <a href="#ref-for-callbackdef-videoframerequestcallback⑨">(3)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①⓪">(4)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①①">(5)</a> <a href="#ref-for-callbackdef-videoframerequestcallback①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canceled">
-   <b><a href="#canceled">#canceled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canceled" class="dfn-panel" data-for="canceled" id="infopanel-for-canceled" role="dialog">
+   <span id="infopaneltitle-for-canceled" style="display:none">Info about the 'canceled' definition.</span><b><a href="#canceled">#canceled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled">4.1. Methods</a>
     <li><a href="#ref-for-canceled①">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-video-frame-request-callbacks">
-   <b><a href="#list-of-video-frame-request-callbacks">#list-of-video-frame-request-callbacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-video-frame-request-callbacks" class="dfn-panel" data-for="list-of-video-frame-request-callbacks" id="infopanel-for-list-of-video-frame-request-callbacks" role="dialog">
+   <span id="infopaneltitle-for-list-of-video-frame-request-callbacks" style="display:none">Info about the 'list of video frame request callbacks' definition.</span><b><a href="#list-of-video-frame-request-callbacks">#list-of-video-frame-request-callbacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-video-frame-request-callbacks">4.1. Methods</a> <a href="#ref-for-list-of-video-frame-request-callbacks①">(2)</a> <a href="#ref-for-list-of-video-frame-request-callbacks②">(3)</a>
     <li><a href="#ref-for-list-of-video-frame-request-callbacks③">4.2. Procedures</a> <a href="#ref-for-list-of-video-frame-request-callbacks④">(2)</a> <a href="#ref-for-list-of-video-frame-request-callbacks⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-presented-frame-indentifier">
-   <b><a href="#last-presented-frame-indentifier">#last-presented-frame-indentifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-presented-frame-indentifier" class="dfn-panel" data-for="last-presented-frame-indentifier" id="infopanel-for-last-presented-frame-indentifier" role="dialog">
+   <span id="infopaneltitle-for-last-presented-frame-indentifier" style="display:none">Info about the 'last presented frame indentifier' definition.</span><b><a href="#last-presented-frame-indentifier">#last-presented-frame-indentifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-presented-frame-indentifier">4.2. Procedures</a> <a href="#ref-for-last-presented-frame-indentifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="video-frame-request-callback-identifier">
-   <b><a href="#video-frame-request-callback-identifier">#video-frame-request-callback-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-video-frame-request-callback-identifier" class="dfn-panel" data-for="video-frame-request-callback-identifier" id="infopanel-for-video-frame-request-callback-identifier" role="dialog">
+   <span id="infopaneltitle-for-video-frame-request-callback-identifier" style="display:none">Info about the 'video frame request
+callback identifier' definition.</span><b><a href="#video-frame-request-callback-identifier">#video-frame-request-callback-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video-frame-request-callback-identifier">4.1. Methods</a> <a href="#ref-for-video-frame-request-callback-identifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlvideoelement-requestvideoframecallback">
-   <b><a href="#dom-htmlvideoelement-requestvideoframecallback">#dom-htmlvideoelement-requestvideoframecallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlvideoelement-requestvideoframecallback" class="dfn-panel" data-for="dom-htmlvideoelement-requestvideoframecallback" id="infopanel-for-dom-htmlvideoelement-requestvideoframecallback" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlvideoelement-requestvideoframecallback" style="display:none">Info about the 'requestVideoFrameCallback(callback)' definition.</span><b><a href="#dom-htmlvideoelement-requestvideoframecallback">#dom-htmlvideoelement-requestvideoframecallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlvideoelement-requestvideoframecallback">1. Introduction</a>
     <li><a href="#ref-for-dom-htmlvideoelement-requestvideoframecallback①">4. HTMLVideoElement.requestVideoFrameCallback()</a>
     <li><a href="#ref-for-dom-htmlvideoelement-requestvideoframecallback②">6.1. Drawing frames at the video rate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlvideoelement-cancelvideoframecallback">
-   <b><a href="#dom-htmlvideoelement-cancelvideoframecallback">#dom-htmlvideoelement-cancelvideoframecallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlvideoelement-cancelvideoframecallback" class="dfn-panel" data-for="dom-htmlvideoelement-cancelvideoframecallback" id="infopanel-for-dom-htmlvideoelement-cancelvideoframecallback" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlvideoelement-cancelvideoframecallback" style="display:none">Info about the 'cancelVideoFrameCallback(handle)' definition.</span><b><a href="#dom-htmlvideoelement-cancelvideoframecallback">#dom-htmlvideoelement-cancelvideoframecallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlvideoelement-cancelvideoframecallback">4. HTMLVideoElement.requestVideoFrameCallback()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-video-element">
-   <b><a href="#associated-video-element">#associated-video-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-video-element" class="dfn-panel" data-for="associated-video-element" id="infopanel-for-associated-video-element" role="dialog">
+   <span id="infopaneltitle-for-associated-video-element" style="display:none">Info about the 'associated video element' definition.</span><b><a href="#associated-video-element">#associated-video-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-video-element">4.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-the-video-frame-request-callbacks">
-   <b><a href="#run-the-video-frame-request-callbacks">#run-the-video-frame-request-callbacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-the-video-frame-request-callbacks" class="dfn-panel" data-for="run-the-video-frame-request-callbacks" id="infopanel-for-run-the-video-frame-request-callbacks" role="dialog">
+   <span id="infopaneltitle-for-run-the-video-frame-request-callbacks" style="display:none">Info about the 'run the video frame request callbacks' definition.</span><b><a href="#run-the-video-frame-request-callbacks">#run-the-video-frame-request-callbacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-video-frame-request-callbacks">4.2. Procedures</a> <a href="#ref-for-run-the-video-frame-request-callbacks①">(2)</a> <a href="#ref-for-run-the-video-frame-request-callbacks②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/web-locks/index.html
+++ b/tests/github/WICG/web-locks/index.html
@@ -1895,21 +1895,21 @@ authoring advice.</p>
    <li><a href="#lock-concept-waiting-promise">waiting promise</a><span>, in § 2.4</span>
    <li><a href="#web-locks-tasks-source">web locks tasks source</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">3.2. LockManager class</a>
     <li><a href="#ref-for-abortsignal①">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-agent">
-   <a href="https://tc39.github.io/ecma262/#agent">https://tc39.github.io/ecma262/#agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-agent" class="dfn-panel" data-for="term-for-agent" id="infopanel-for-term-for-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-agent" style="display:none">Info about the 'agent' external reference.</span><a href="https://tc39.github.io/ecma262/#agent">https://tc39.github.io/ecma262/#agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-agent">1. Introduction</a> <a href="#ref-for-agent①">(2)</a>
     <li><a href="#ref-for-agent②">2.2. Lock Managers</a>
@@ -1918,33 +1918,33 @@ authoring advice.</p>
     <li><a href="#ref-for-agent⑤">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.1. Navigator Mixins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3.1. Navigator Mixins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integration-with-the-javascript-agent-cluster-formalism">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-agent-cluster-formalism">https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-agent-cluster-formalism</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integration-with-the-javascript-agent-cluster-formalism" class="dfn-panel" data-for="term-for-integration-with-the-javascript-agent-cluster-formalism" id="infopanel-for-term-for-integration-with-the-javascript-agent-cluster-formalism" role="menu">
+   <span id="infopaneltitle-for-term-for-integration-with-the-javascript-agent-cluster-formalism" style="display:none">Info about the 'agent cluster' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-agent-cluster-formalism">https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-agent-cluster-formalism</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integration-with-the-javascript-agent-cluster-formalism">1. Introduction</a> <a href="#ref-for-integration-with-the-javascript-agent-cluster-formalism①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.1. Resources Names</a>
     <li><a href="#ref-for-browsing-context①">2.2. Lock Managers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">2. Concepts</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">2.4. Locks</a>
@@ -1955,8 +1955,8 @@ authoring advice.</p>
     <li><a href="#ref-for-enqueue-the-following-steps⑦">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps①" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps①" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">2. Concepts</a>
     <li><a href="#ref-for-enqueue-the-following-steps①">2.4. Locks</a>
@@ -1967,33 +1967,33 @@ authoring advice.</p>
     <li><a href="#ref-for-enqueue-the-following-steps⑦">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.1. Navigator Mixins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-id">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-id" class="dfn-panel" data-for="term-for-concept-environment-id" id="infopanel-for-term-for-concept-environment-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-id" style="display:none">Info about the 'id' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-id">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-localstorage">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-localstorage" class="dfn-panel" data-for="term-for-dom-localstorage" id="infopanel-for-term-for-dom-localstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-localstorage" style="display:none">Info about the 'localstorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-localstorage">2.2. Lock Managers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">3.2.1. The request() method</a>
     <li><a href="#ref-for-concept-origin-opaque①">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.1. Resources Names</a>
     <li><a href="#ref-for-concept-origin①">2.2. Lock Managers</a> <a href="#ref-for-concept-origin②">(2)</a>
@@ -2002,8 +2002,8 @@ authoring advice.</p>
     <li><a href="#ref-for-concept-origin⑤">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.1. Navigator Mixins</a>
     <li><a href="#ref-for-relevant-settings-object①">3.2.1. The request() method</a>
@@ -2012,39 +2012,39 @@ authoring advice.</p>
     <li><a href="#ref-for-relevant-settings-object④">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">4.1. Request a lock</a>
     <li><a href="#ref-for-responsible-event-loop①">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">2. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.5. Snapshot the lock state</a> <a href="#ref-for-list-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">4.2. Release a lock</a>
     <li><a href="#ref-for-assert①">4.3. Abort a request</a>
@@ -2052,64 +2052,64 @@ authoring advice.</p>
     <li><a href="#ref-for-assert③">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-enqueue">
-   <a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-enqueue" class="dfn-panel" data-for="term-for-queue-enqueue" id="infopanel-for-term-for-queue-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-enqueue">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.1. Request a lock</a>
     <li><a href="#ref-for-list-iterate①">4.4. Process a lock request queue for a given resource name</a>
     <li><a href="#ref-for-list-iterate②">4.5. Snapshot the lock state</a> <a href="#ref-for-list-iterate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">2.5. Lock Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'javascript string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.1. Resources Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">4.5. Snapshot the lock state</a> <a href="#ref-for-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.5. Lock Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue">
-   <a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue" class="dfn-panel" data-for="term-for-queue" id="infopanel-for-term-for-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue" style="display:none">Info about the 'queue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">2.5. Lock Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.1. Request a lock</a>
     <li><a href="#ref-for-list-remove①">4.2. Release a lock</a>
@@ -2117,147 +2117,147 @@ authoring advice.</p>
     <li><a href="#ref-for-list-remove③">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.4. Locks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">2.5. Lock Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-client">
-   <a href="https://w3c.github.io/ServiceWorker/#client">https://w3c.github.io/ServiceWorker/#client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-client" class="dfn-panel" data-for="term-for-client" id="infopanel-for-term-for-client" role="menu">
+   <span id="infopaneltitle-for-term-for-client" style="display:none">Info about the 'Client' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#client">https://w3c.github.io/ServiceWorker/#client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-client-id">
-   <a href="https://w3c.github.io/ServiceWorker/#dom-client-id">https://w3c.github.io/ServiceWorker/#dom-client-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-client-id" class="dfn-panel" data-for="term-for-dom-client-id" id="infopanel-for-term-for-dom-client-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-client-id" style="display:none">Info about the 'id' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dom-client-id">https://w3c.github.io/ServiceWorker/#dom-client-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-id">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-shelf">
-   <a href="https://storage.spec.whatwg.org/#storage-shelf">https://storage.spec.whatwg.org/#storage-shelf</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-shelf" class="dfn-panel" data-for="term-for-storage-shelf" id="infopanel-for-term-for-storage-shelf" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-shelf" style="display:none">Info about the 'storage shelf' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-shelf">https://storage.spec.whatwg.org/#storage-shelf</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-shelf">2.2. Lock Managers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">3.2.1. The request() method</a> <a href="#ref-for-aborterror①">(2)</a> <a href="#ref-for-aborterror②">(3)</a> <a href="#ref-for-aborterror③">(4)</a>
     <li><a href="#ref-for-aborterror④">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2.1. The request() method</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a>
     <li><a href="#ref-for-idl-DOMException⑥">3.2.2. The query() method</a>
     <li><a href="#ref-for-idl-DOMException⑦">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. LockManager class</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
     <li><a href="#ref-for-idl-DOMString④">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.2. LockManager class</a>
     <li><a href="#ref-for-Exposed①">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.2.1. The request() method</a> <a href="#ref-for-notsupportederror①">(2)</a> <a href="#ref-for-notsupportederror②">(3)</a> <a href="#ref-for-notsupportederror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. LockManager class</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. Navigator Mixins</a>
     <li><a href="#ref-for-SecureContext①">3.2. LockManager class</a>
     <li><a href="#ref-for-SecureContext②">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.2.1. The request() method</a>
     <li><a href="#ref-for-securityerror①">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2.1. The request() method</a>
     <li><a href="#ref-for-a-new-promise①">3.2.2. The query() method</a>
     <li><a href="#ref-for-a-new-promise②">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2.1. The request() method</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a> <a href="#ref-for-a-promise-rejected-with③">(4)</a> <a href="#ref-for-a-promise-rejected-with④">(5)</a> <a href="#ref-for-a-promise-rejected-with⑤">(6)</a>
     <li><a href="#ref-for-a-promise-rejected-with⑥">3.2.2. The query() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.2. LockManager class</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. LockManager class</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-function" class="dfn-panel" data-for="term-for-dfn-callback-function" id="infopanel-for-term-for-dfn-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-function" style="display:none">Info about the 'callback function' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.1. Request a lock</a>
     <li><a href="#ref-for-invoke-a-callback-function①">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2.1. The request() method</a>
     <li><a href="#ref-for-reject①">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">2.4. Locks</a>
     <li><a href="#ref-for-resolve①">4.1. Request a lock</a>
@@ -2265,14 +2265,14 @@ authoring advice.</p>
     <li><a href="#ref-for-resolve③">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.2. LockManager class</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. Navigator Mixins</a>
     <li><a href="#ref-for-this①">3.2.1. The request() method</a>
@@ -2441,8 +2441,8 @@ authoring advice.</p>
    <div class="issue"> Migrate this definition to <a data-link-type="biblio" href="#biblio-html" title="HTML Standard">[HTML]</a> or <a data-link-type="biblio" href="#biblio-storage" title="Storage Standard">[Storage]</a> so it can be referenced by other standards. <a class="issue-return" href="#issue-fb27f9c9" title="Jump to section">↵</a></div>
    <div class="issue"> Identify a normative reference for <i>terminates</i>. <a class="issue-return" href="#issue-77a47106" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="lock-task-queue">
-   <b><a href="#lock-task-queue">#lock-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-task-queue" class="dfn-panel" data-for="lock-task-queue" id="infopanel-for-lock-task-queue" role="dialog">
+   <span id="infopaneltitle-for-lock-task-queue" style="display:none">Info about the 'lock task queue' definition.</span><b><a href="#lock-task-queue">#lock-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-task-queue">2.4. Locks</a>
     <li><a href="#ref-for-lock-task-queue①">2.6. Agent Integration</a>
@@ -2455,8 +2455,8 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-task-queue⑧">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resource-name">
-   <b><a href="#resource-name">#resource-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resource-name" class="dfn-panel" data-for="resource-name" id="infopanel-for-resource-name" role="dialog">
+   <span id="infopaneltitle-for-resource-name" style="display:none">Info about the 'resource name' definition.</span><b><a href="#resource-name">#resource-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resource-name">1. Introduction</a> <a href="#ref-for-resource-name①">(2)</a>
     <li><a href="#ref-for-resource-name②">2.4. Locks</a>
@@ -2466,8 +2466,8 @@ authoring advice.</p>
     <li><a href="#ref-for-resource-name⑥">6.4. Checklist</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-manager">
-   <b><a href="#lock-manager">#lock-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-manager" class="dfn-panel" data-for="lock-manager" id="infopanel-for-lock-manager" role="dialog">
+   <span id="infopaneltitle-for-lock-manager" style="display:none">Info about the 'lock manager' definition.</span><b><a href="#lock-manager">#lock-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-manager">2.2. Lock Managers</a>
     <li><a href="#ref-for-lock-manager①">3.2. LockManager class</a>
@@ -2476,14 +2476,14 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-manager⑤">6.1. Lock Scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mode">
-   <b><a href="#mode">#mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mode" class="dfn-panel" data-for="mode" id="infopanel-for-mode" role="dialog">
+   <span id="infopaneltitle-for-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#mode">#mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mode">1. Introduction</a> <a href="#ref-for-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept">
-   <b><a href="#lock-concept">#lock-concept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept" class="dfn-panel" data-for="lock-concept" id="infopanel-for-lock-concept" role="dialog">
+   <span id="infopaneltitle-for-lock-concept" style="display:none">Info about the 'lock' definition.</span><b><a href="#lock-concept">#lock-concept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept">1. Introduction</a>
     <li><a href="#ref-for-lock-concept①">2.2. Lock Managers</a>
@@ -2496,29 +2496,29 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-concept②⓪">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-agent">
-   <b><a href="#lock-concept-agent">#lock-concept-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-agent" class="dfn-panel" data-for="lock-concept-agent" id="infopanel-for-lock-concept-agent" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-agent" style="display:none">Info about the 'agent' definition.</span><b><a href="#lock-concept-agent">#lock-concept-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-agent">2.6. Agent Integration</a>
     <li><a href="#ref-for-lock-concept-agent①">4.4. Process a lock request queue for a given resource name</a> <a href="#ref-for-lock-concept-agent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-clientid">
-   <b><a href="#lock-concept-clientid">#lock-concept-clientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-clientid" class="dfn-panel" data-for="lock-concept-clientid" id="infopanel-for-lock-concept-clientid" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-clientid" style="display:none">Info about the 'clientId' definition.</span><b><a href="#lock-concept-clientid">#lock-concept-clientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-clientid">4.4. Process a lock request queue for a given resource name</a>
     <li><a href="#ref-for-lock-concept-clientid①">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-origin">
-   <b><a href="#lock-concept-origin">#lock-concept-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-origin" class="dfn-panel" data-for="lock-concept-origin" id="infopanel-for-lock-concept-origin" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#lock-concept-origin">#lock-concept-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-origin">4.2. Release a lock</a>
     <li><a href="#ref-for-lock-concept-origin①">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-name">
-   <b><a href="#lock-concept-name">#lock-concept-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-name" class="dfn-panel" data-for="lock-concept-name" id="infopanel-for-lock-concept-name" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-name" style="display:none">Info about the 'name' definition.</span><b><a href="#lock-concept-name">#lock-concept-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-name">2.5. Lock Requests</a> <a href="#ref-for-lock-concept-name①">(2)</a>
     <li><a href="#ref-for-lock-concept-name②">3.3. Lock class</a>
@@ -2527,8 +2527,8 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-concept-name⑤">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-mode">
-   <b><a href="#lock-concept-mode">#lock-concept-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-mode" class="dfn-panel" data-for="lock-concept-mode" id="infopanel-for-lock-concept-mode" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#lock-concept-mode">#lock-concept-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-mode">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-concept-mode①">3.3. Lock class</a>
@@ -2536,15 +2536,15 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-concept-mode③">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-waiting-promise">
-   <b><a href="#lock-concept-waiting-promise">#lock-concept-waiting-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-waiting-promise" class="dfn-panel" data-for="lock-concept-waiting-promise" id="infopanel-for-lock-concept-waiting-promise" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-waiting-promise" style="display:none">Info about the 'waiting promise' definition.</span><b><a href="#lock-concept-waiting-promise">#lock-concept-waiting-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-waiting-promise">2.4. Locks</a> <a href="#ref-for-lock-concept-waiting-promise①">(2)</a> <a href="#ref-for-lock-concept-waiting-promise②">(3)</a> <a href="#ref-for-lock-concept-waiting-promise③">(4)</a> <a href="#ref-for-lock-concept-waiting-promise④">(5)</a>
     <li><a href="#ref-for-lock-concept-waiting-promise⑤">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-released-promise">
-   <b><a href="#lock-concept-released-promise">#lock-concept-released-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-released-promise" class="dfn-panel" data-for="lock-concept-released-promise" id="infopanel-for-lock-concept-released-promise" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-released-promise" style="display:none">Info about the 'released promise' definition.</span><b><a href="#lock-concept-released-promise">#lock-concept-released-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-released-promise">2.4. Locks</a> <a href="#ref-for-lock-concept-released-promise①">(2)</a> <a href="#ref-for-lock-concept-released-promise②">(3)</a> <a href="#ref-for-lock-concept-released-promise③">(4)</a>
     <li><a href="#ref-for-lock-concept-released-promise④">3.2.1. The request() method</a>
@@ -2552,8 +2552,8 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-concept-released-promise⑥">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-concept-held-lock-set">
-   <b><a href="#lock-concept-held-lock-set">#lock-concept-held-lock-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-concept-held-lock-set" class="dfn-panel" data-for="lock-concept-held-lock-set" id="infopanel-for-lock-concept-held-lock-set" role="dialog">
+   <span id="infopaneltitle-for-lock-concept-held-lock-set" style="display:none">Info about the 'held lock set' definition.</span><b><a href="#lock-concept-held-lock-set">#lock-concept-held-lock-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-concept-held-lock-set">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-concept-held-lock-set①">4.1. Request a lock</a>
@@ -2562,8 +2562,8 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-concept-held-lock-set④">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request">
-   <b><a href="#lock-request">#lock-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request" class="dfn-panel" data-for="lock-request" id="infopanel-for-lock-request" role="dialog">
+   <span id="infopaneltitle-for-lock-request" style="display:none">Info about the 'lock request' definition.</span><b><a href="#lock-request">#lock-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request">1. Introduction</a>
     <li><a href="#ref-for-lock-request①">2.2. Lock Managers</a>
@@ -2573,28 +2573,28 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-request⑨">4.1. Request a lock</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-agent">
-   <b><a href="#lock-request-agent">#lock-request-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-agent" class="dfn-panel" data-for="lock-request-agent" id="infopanel-for-lock-request-agent" role="dialog">
+   <span id="infopaneltitle-for-lock-request-agent" style="display:none">Info about the 'agent' definition.</span><b><a href="#lock-request-agent">#lock-request-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-agent">2.6. Agent Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-clientid">
-   <b><a href="#lock-request-clientid">#lock-request-clientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-clientid" class="dfn-panel" data-for="lock-request-clientid" id="infopanel-for-lock-request-clientid" role="dialog">
+   <span id="infopaneltitle-for-lock-request-clientid" style="display:none">Info about the 'clientId' definition.</span><b><a href="#lock-request-clientid">#lock-request-clientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-clientid">4.4. Process a lock request queue for a given resource name</a>
     <li><a href="#ref-for-lock-request-clientid①">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-origin">
-   <b><a href="#lock-request-origin">#lock-request-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-origin" class="dfn-panel" data-for="lock-request-origin" id="infopanel-for-lock-request-origin" role="dialog">
+   <span id="infopaneltitle-for-lock-request-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#lock-request-origin">#lock-request-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-origin">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-request-origin①">4.3. Abort a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-name">
-   <b><a href="#lock-request-name">#lock-request-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-name" class="dfn-panel" data-for="lock-request-name" id="infopanel-for-lock-request-name" role="dialog">
+   <span id="infopaneltitle-for-lock-request-name" style="display:none">Info about the 'name' definition.</span><b><a href="#lock-request-name">#lock-request-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-name">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-request-name①">4.3. Abort a request</a>
@@ -2602,28 +2602,28 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-request-name③">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-mode">
-   <b><a href="#lock-request-mode">#lock-request-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-mode" class="dfn-panel" data-for="lock-request-mode" id="infopanel-for-lock-request-mode" role="dialog">
+   <span id="infopaneltitle-for-lock-request-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#lock-request-mode">#lock-request-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-mode">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-request-mode①">4.4. Process a lock request queue for a given resource name</a>
     <li><a href="#ref-for-lock-request-mode②">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-promise">
-   <b><a href="#lock-request-promise">#lock-request-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-promise" class="dfn-panel" data-for="lock-request-promise" id="infopanel-for-lock-request-promise" role="dialog">
+   <span id="infopaneltitle-for-lock-request-promise" style="display:none">Info about the 'promise' definition.</span><b><a href="#lock-request-promise">#lock-request-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-promise">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-lock-request-queue">
-   <b><a href="#lock-request-lock-request-queue">#lock-request-lock-request-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-lock-request-queue" class="dfn-panel" data-for="lock-request-lock-request-queue" id="infopanel-for-lock-request-lock-request-queue" role="dialog">
+   <span id="infopaneltitle-for-lock-request-lock-request-queue" style="display:none">Info about the 'lock request queue' definition.</span><b><a href="#lock-request-lock-request-queue">#lock-request-lock-request-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-lock-request-queue">2.5. Lock Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-lock-request-queue-map">
-   <b><a href="#lock-request-lock-request-queue-map">#lock-request-lock-request-queue-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-lock-request-queue-map" class="dfn-panel" data-for="lock-request-lock-request-queue-map" id="infopanel-for-lock-request-lock-request-queue-map" role="dialog">
+   <span id="infopaneltitle-for-lock-request-lock-request-queue-map" style="display:none">Info about the 'lock request queue map' definition.</span><b><a href="#lock-request-lock-request-queue-map">#lock-request-lock-request-queue-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-lock-request-queue-map">2.5. Lock Requests</a>
     <li><a href="#ref-for-lock-request-lock-request-queue-map①">4.1. Request a lock</a>
@@ -2632,48 +2632,48 @@ authoring advice.</p>
     <li><a href="#ref-for-lock-request-lock-request-queue-map④">4.5. Snapshot the lock state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock-request-grantable">
-   <b><a href="#lock-request-grantable">#lock-request-grantable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock-request-grantable" class="dfn-panel" data-for="lock-request-grantable" id="infopanel-for-lock-request-grantable" role="dialog">
+   <span id="infopaneltitle-for-lock-request-grantable" style="display:none">Info about the 'grantable' definition.</span><b><a href="#lock-request-grantable">#lock-request-grantable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock-request-grantable">4.1. Request a lock</a>
     <li><a href="#ref-for-lock-request-grantable①">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatorlocks">
-   <b><a href="#navigatorlocks">#navigatorlocks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatorlocks" class="dfn-panel" data-for="navigatorlocks" id="infopanel-for-navigatorlocks" role="dialog">
+   <span id="infopaneltitle-for-navigatorlocks" style="display:none">Info about the 'NavigatorLocks' definition.</span><b><a href="#navigatorlocks">#navigatorlocks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatorlocks">3.1. Navigator Mixins</a> <a href="#ref-for-navigatorlocks①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatorlocks-locks">
-   <b><a href="#dom-navigatorlocks-locks">#dom-navigatorlocks-locks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatorlocks-locks" class="dfn-panel" data-for="dom-navigatorlocks-locks" id="infopanel-for-dom-navigatorlocks-locks" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatorlocks-locks" style="display:none">Info about the 'locks' definition.</span><b><a href="#dom-navigatorlocks-locks">#dom-navigatorlocks-locks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatorlocks-locks">3.1. Navigator Mixins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lockmanager">
-   <b><a href="#lockmanager">#lockmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lockmanager" class="dfn-panel" data-for="lockmanager" id="infopanel-for-lockmanager" role="dialog">
+   <span id="infopaneltitle-for-lockmanager" style="display:none">Info about the 'LockManager' definition.</span><b><a href="#lockmanager">#lockmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lockmanager">2.4. Locks</a>
     <li><a href="#ref-for-lockmanager①">3.1. Navigator Mixins</a> <a href="#ref-for-lockmanager②">(2)</a> <a href="#ref-for-lockmanager③">(3)</a>
     <li><a href="#ref-for-lockmanager④">3.2. LockManager class</a> <a href="#ref-for-lockmanager⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-lockgrantedcallback">
-   <b><a href="#callbackdef-lockgrantedcallback">#callbackdef-lockgrantedcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-lockgrantedcallback" class="dfn-panel" data-for="callbackdef-lockgrantedcallback" id="infopanel-for-callbackdef-lockgrantedcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-lockgrantedcallback" style="display:none">Info about the 'LockGrantedCallback' definition.</span><b><a href="#callbackdef-lockgrantedcallback">#callbackdef-lockgrantedcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-lockgrantedcallback">3.2. LockManager class</a> <a href="#ref-for-callbackdef-lockgrantedcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-lockmode">
-   <b><a href="#enumdef-lockmode">#enumdef-lockmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-lockmode" class="dfn-panel" data-for="enumdef-lockmode" id="infopanel-for-enumdef-lockmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-lockmode" style="display:none">Info about the 'LockMode' definition.</span><b><a href="#enumdef-lockmode">#enumdef-lockmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-lockmode">3.2. LockManager class</a> <a href="#ref-for-enumdef-lockmode①">(2)</a>
     <li><a href="#ref-for-enumdef-lockmode②">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockmode-shared">
-   <b><a href="#dom-lockmode-shared">#dom-lockmode-shared</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockmode-shared" class="dfn-panel" data-for="dom-lockmode-shared" id="infopanel-for-dom-lockmode-shared" role="dialog">
+   <span id="infopaneltitle-for-dom-lockmode-shared" style="display:none">Info about the '"shared"' definition.</span><b><a href="#dom-lockmode-shared">#dom-lockmode-shared</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockmode-shared">2.3. Modes and Scheduling</a> <a href="#ref-for-dom-lockmode-shared①">(2)</a> <a href="#ref-for-dom-lockmode-shared②">(3)</a>
     <li><a href="#ref-for-dom-lockmode-shared③">2.4. Locks</a>
@@ -2681,8 +2681,8 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-lockmode-shared⑤">3.2.1. The request() method</a> <a href="#ref-for-dom-lockmode-shared⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockmode-exclusive">
-   <b><a href="#dom-lockmode-exclusive">#dom-lockmode-exclusive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockmode-exclusive" class="dfn-panel" data-for="dom-lockmode-exclusive" id="infopanel-for-dom-lockmode-exclusive" role="dialog">
+   <span id="infopaneltitle-for-dom-lockmode-exclusive" style="display:none">Info about the '"exclusive"' definition.</span><b><a href="#dom-lockmode-exclusive">#dom-lockmode-exclusive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockmode-exclusive">2.3. Modes and Scheduling</a> <a href="#ref-for-dom-lockmode-exclusive①">(2)</a> <a href="#ref-for-dom-lockmode-exclusive②">(3)</a> <a href="#ref-for-dom-lockmode-exclusive③">(4)</a>
     <li><a href="#ref-for-dom-lockmode-exclusive④">2.4. Locks</a>
@@ -2690,73 +2690,73 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-lockmode-exclusive⑦">3.2.1. The request() method</a> <a href="#ref-for-dom-lockmode-exclusive⑧">(2)</a> <a href="#ref-for-dom-lockmode-exclusive⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-lockoptions">
-   <b><a href="#dictdef-lockoptions">#dictdef-lockoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-lockoptions" class="dfn-panel" data-for="dictdef-lockoptions" id="infopanel-for-dictdef-lockoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-lockoptions" style="display:none">Info about the 'LockOptions' definition.</span><b><a href="#dictdef-lockoptions">#dictdef-lockoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-lockoptions">3.2. LockManager class</a>
     <li><a href="#ref-for-dictdef-lockoptions①">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockoptions-mode">
-   <b><a href="#dom-lockoptions-mode">#dom-lockoptions-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockoptions-mode" class="dfn-panel" data-for="dom-lockoptions-mode" id="infopanel-for-dom-lockoptions-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-lockoptions-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-lockoptions-mode">#dom-lockoptions-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockoptions-mode">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockoptions-ifavailable">
-   <b><a href="#dom-lockoptions-ifavailable">#dom-lockoptions-ifavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockoptions-ifavailable" class="dfn-panel" data-for="dom-lockoptions-ifavailable" id="infopanel-for-dom-lockoptions-ifavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-lockoptions-ifavailable" style="display:none">Info about the 'ifAvailable' definition.</span><b><a href="#dom-lockoptions-ifavailable">#dom-lockoptions-ifavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockoptions-ifavailable">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockoptions-steal">
-   <b><a href="#dom-lockoptions-steal">#dom-lockoptions-steal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockoptions-steal" class="dfn-panel" data-for="dom-lockoptions-steal" id="infopanel-for-dom-lockoptions-steal" role="dialog">
+   <span id="infopaneltitle-for-dom-lockoptions-steal" style="display:none">Info about the 'steal' definition.</span><b><a href="#dom-lockoptions-steal">#dom-lockoptions-steal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockoptions-steal">3.2.1. The request() method</a> <a href="#ref-for-dom-lockoptions-steal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockoptions-signal">
-   <b><a href="#dom-lockoptions-signal">#dom-lockoptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockoptions-signal" class="dfn-panel" data-for="dom-lockoptions-signal" id="infopanel-for-dom-lockoptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-lockoptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-lockoptions-signal">#dom-lockoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockoptions-signal">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-lockmanagersnapshot">
-   <b><a href="#dictdef-lockmanagersnapshot">#dictdef-lockmanagersnapshot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-lockmanagersnapshot" class="dfn-panel" data-for="dictdef-lockmanagersnapshot" id="infopanel-for-dictdef-lockmanagersnapshot" role="dialog">
+   <span id="infopaneltitle-for-dictdef-lockmanagersnapshot" style="display:none">Info about the 'LockManagerSnapshot' definition.</span><b><a href="#dictdef-lockmanagersnapshot">#dictdef-lockmanagersnapshot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-lockmanagersnapshot">3.2. LockManager class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-lockinfo">
-   <b><a href="#dictdef-lockinfo">#dictdef-lockinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-lockinfo" class="dfn-panel" data-for="dictdef-lockinfo" id="infopanel-for-dictdef-lockinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-lockinfo" style="display:none">Info about the 'LockInfo' definition.</span><b><a href="#dictdef-lockinfo">#dictdef-lockinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-lockinfo">3.2. LockManager class</a> <a href="#ref-for-dictdef-lockinfo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockmanager-request">
-   <b><a href="#dom-lockmanager-request">#dom-lockmanager-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockmanager-request" class="dfn-panel" data-for="dom-lockmanager-request" id="infopanel-for-dom-lockmanager-request" role="dialog">
+   <span id="infopaneltitle-for-dom-lockmanager-request" style="display:none">Info about the 'request(name, callback)' definition.</span><b><a href="#dom-lockmanager-request">#dom-lockmanager-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockmanager-request">2.4. Locks</a>
     <li><a href="#ref-for-dom-lockmanager-request①">3.2. LockManager class</a>
     <li><a href="#ref-for-dom-lockmanager-request②">3.2.1. The request() method</a> <a href="#ref-for-dom-lockmanager-request③">(2)</a> <a href="#ref-for-dom-lockmanager-request④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockmanager-request-name-options-callback">
-   <b><a href="#dom-lockmanager-request-name-options-callback">#dom-lockmanager-request-name-options-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockmanager-request-name-options-callback" class="dfn-panel" data-for="dom-lockmanager-request-name-options-callback" id="infopanel-for-dom-lockmanager-request-name-options-callback" role="dialog">
+   <span id="infopaneltitle-for-dom-lockmanager-request-name-options-callback" style="display:none">Info about the 'request(name, options, callback)' definition.</span><b><a href="#dom-lockmanager-request-name-options-callback">#dom-lockmanager-request-name-options-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockmanager-request-name-options-callback">3.2. LockManager class</a>
     <li><a href="#ref-for-dom-lockmanager-request-name-options-callback①">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lockmanager-query">
-   <b><a href="#dom-lockmanager-query">#dom-lockmanager-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lockmanager-query" class="dfn-panel" data-for="dom-lockmanager-query" id="infopanel-for-dom-lockmanager-query" role="dialog">
+   <span id="infopaneltitle-for-dom-lockmanager-query" style="display:none">Info about the 'query()' definition.</span><b><a href="#dom-lockmanager-query">#dom-lockmanager-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lockmanager-query">3.2. LockManager class</a>
     <li><a href="#ref-for-dom-lockmanager-query①">3.2.2. The query() method</a> <a href="#ref-for-dom-lockmanager-query②">(2)</a> <a href="#ref-for-dom-lockmanager-query③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock">
-   <b><a href="#lock">#lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock" class="dfn-panel" data-for="lock" id="infopanel-for-lock" role="dialog">
+   <span id="infopaneltitle-for-lock" style="display:none">Info about the 'Lock' definition.</span><b><a href="#lock">#lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock">3.2. LockManager class</a>
     <li><a href="#ref-for-lock①">3.2.1. The request() method</a>
@@ -2764,107 +2764,163 @@ authoring advice.</p>
     <li><a href="#ref-for-lock④">4.4. Process a lock request queue for a given resource name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lock-name">
-   <b><a href="#dom-lock-name">#dom-lock-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lock-name" class="dfn-panel" data-for="dom-lock-name" id="infopanel-for-dom-lock-name" role="dialog">
+   <span id="infopaneltitle-for-dom-lock-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-lock-name">#dom-lock-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lock-name">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-lock-mode">
-   <b><a href="#dom-lock-mode">#dom-lock-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-lock-mode" class="dfn-panel" data-for="dom-lock-mode" id="infopanel-for-dom-lock-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-lock-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-lock-mode">#dom-lock-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-lock-mode">3.3. Lock class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-a-lock">
-   <b><a href="#request-a-lock">#request-a-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-a-lock" class="dfn-panel" data-for="request-a-lock" id="infopanel-for-request-a-lock" role="dialog">
+   <span id="infopaneltitle-for-request-a-lock" style="display:none">Info about the 'request a lock' definition.</span><b><a href="#request-a-lock">#request-a-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-a-lock">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="release-the-lock">
-   <b><a href="#release-the-lock">#release-the-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-release-the-lock" class="dfn-panel" data-for="release-the-lock" id="infopanel-for-release-the-lock" role="dialog">
+   <span id="infopaneltitle-for-release-the-lock" style="display:none">Info about the 'release the lock' definition.</span><b><a href="#release-the-lock">#release-the-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-release-the-lock">2.4. Locks</a>
     <li><a href="#ref-for-release-the-lock①">2.6. Agent Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-the-request">
-   <b><a href="#abort-the-request">#abort-the-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-the-request" class="dfn-panel" data-for="abort-the-request" id="infopanel-for-abort-the-request" role="dialog">
+   <span id="infopaneltitle-for-abort-the-request" style="display:none">Info about the 'abort the request' definition.</span><b><a href="#abort-the-request">#abort-the-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-the-request">2.6. Agent Integration</a>
     <li><a href="#ref-for-abort-the-request①">3.2.1. The request() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-the-lock-request-queue">
-   <b><a href="#process-the-lock-request-queue">#process-the-lock-request-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-the-lock-request-queue" class="dfn-panel" data-for="process-the-lock-request-queue" id="infopanel-for-process-the-lock-request-queue" role="dialog">
+   <span id="infopaneltitle-for-process-the-lock-request-queue" style="display:none">Info about the 'process the lock request queue' definition.</span><b><a href="#process-the-lock-request-queue">#process-the-lock-request-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-the-lock-request-queue">4.1. Request a lock</a>
     <li><a href="#ref-for-process-the-lock-request-queue①">4.2. Release a lock</a>
     <li><a href="#ref-for-process-the-lock-request-queue②">4.3. Abort a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="snapshot-the-lock-state">
-   <b><a href="#snapshot-the-lock-state">#snapshot-the-lock-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-snapshot-the-lock-state" class="dfn-panel" data-for="snapshot-the-lock-state" id="infopanel-for-snapshot-the-lock-state" role="dialog">
+   <span id="infopaneltitle-for-snapshot-the-lock-state" style="display:none">Info about the 'snapshot the lock state' definition.</span><b><a href="#snapshot-the-lock-state">#snapshot-the-lock-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-snapshot-the-lock-state">3.2.2. The query() method</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/web-otp/index.html
+++ b/tests/github/WICG/web-otp/index.html
@@ -1110,48 +1110,48 @@ authoring advice.</p>
    <li><a href="#dom-otpcredential-type-slot">[[type]]</a><span>, in § 2.1</span>
    <li><a href="#ui-redressing">UI Redressing</a><span>, in § 4.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-credential">
-   <a href="https://w3c.github.io/webappsec-credential-management/#credential">https://w3c.github.io/webappsec-credential-management/#credential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credential" class="dfn-panel" data-for="term-for-credential" id="infopanel-for-term-for-credential" role="menu">
+   <span id="infopaneltitle-for-term-for-credential" style="display:none">Info about the 'Credential' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#credential">https://w3c.github.io/webappsec-credential-management/#credential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential">2. Client Side API</a> <a href="#ref-for-credential①">(2)</a>
     <li><a href="#ref-for-credential②">2.1. The OTPCredential Interface</a> <a href="#ref-for-credential③">(2)</a> <a href="#ref-for-credential④">(3)</a> <a href="#ref-for-credential⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-credentialrequestoptions">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-credentialrequestoptions" class="dfn-panel" data-for="term-for-dictdef-credentialrequestoptions" id="infopanel-for-term-for-dictdef-credentialrequestoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-credentialrequestoptions" style="display:none">Info about the 'CredentialRequestOptions' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialrequestoptions">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dictdef-credentialrequestoptions①">2.2. CredentialRequestOptions</a> <a href="#ref-for-dictdef-credentialrequestoptions②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credentialscontainer">
-   <a href="https://w3c.github.io/webappsec-credential-management/#credentialscontainer">https://w3c.github.io/webappsec-credential-management/#credentialscontainer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credentialscontainer" class="dfn-panel" data-for="term-for-credentialscontainer" id="infopanel-for-term-for-credentialscontainer" role="menu">
+   <span id="infopaneltitle-for-term-for-credentialscontainer" style="display:none">Info about the 'CredentialsContainer' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#credentialscontainer">https://w3c.github.io/webappsec-credential-management/#credentialscontainer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialscontainer">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstract-opdef-request-a-credential">
-   <a href="https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential">https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-opdef-request-a-credential" class="dfn-panel" data-for="term-for-abstract-opdef-request-a-credential" id="infopanel-for-term-for-abstract-opdef-request-a-credential" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-opdef-request-a-credential" style="display:none">Info about the 'Request a Credential' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential">https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-request-a-credential">2. Client Side API</a>
     <li><a href="#ref-for-abstract-opdef-request-a-credential①">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" class="dfn-panel" data-for="term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" id="infopanel-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collectfromcredentialstore-origin-options-sameoriginwithancestors">2. Client Side API</a>
     <li><a href="#ref-for-collectfromcredentialstore-origin-options-sameoriginwithancestors①">2.1. The OTPCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-type-slot">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-type-slot" class="dfn-panel" data-for="term-for-dom-credential-type-slot" id="infopanel-for-term-for-dom-credential-type-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-type-slot" style="display:none">Info about the '[[type]]' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type-slot">2.1. The OTPCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialscontainer-get">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialscontainer-get" class="dfn-panel" data-for="term-for-dom-credentialscontainer-get" id="infopanel-for-term-for-dom-credentialscontainer-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialscontainer-get" style="display:none">Info about the 'get()' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-get">2. Client Side API</a> <a href="#ref-for-dom-credentialscontainer-get①">(2)</a>
     <li><a href="#ref-for-dom-credentialscontainer-get②">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialscontainer-get③">(2)</a> <a href="#ref-for-dom-credentialscontainer-get④">(3)</a>
@@ -1160,124 +1160,124 @@ authoring advice.</p>
     <li><a href="#ref-for-dom-credentialscontainer-get⑦">2.5. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-id">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-id" class="dfn-panel" data-for="term-for-dom-credential-id" id="infopanel-for-term-for-dom-credential-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-id" style="display:none">Info about the 'id' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-id">2.1. The OTPCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-with-its-ancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors">https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-with-its-ancestors" class="dfn-panel" data-for="term-for-same-origin-with-its-ancestors" id="infopanel-for-term-for-same-origin-with-its-ancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-with-its-ancestors" style="display:none">Info about the 'same-origin with its ancestors' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors">https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-with-its-ancestors">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialrequestoptions-signal">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialrequestoptions-signal" class="dfn-panel" data-for="term-for-dom-credentialrequestoptions-signal" id="infopanel-for-term-for-dom-credentialrequestoptions-signal" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialrequestoptions-signal" style="display:none">Info about the 'signal' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-signal">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-mediated">
-   <a href="https://w3c.github.io/webappsec-credential-management/#user-mediated">https://w3c.github.io/webappsec-credential-management/#user-mediated</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-mediated" class="dfn-panel" data-for="term-for-user-mediated" id="infopanel-for-term-for-user-mediated" role="menu">
+   <span id="infopaneltitle-for-term-for-user-mediated" style="display:none">Info about the 'user mediation' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#user-mediated">https://w3c.github.io/webappsec-credential-management/#user-mediated</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-mediated">2. Client Side API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.5. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-documentfragment-host">
-   <a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-documentfragment-host" class="dfn-panel" data-for="term-for-concept-documentfragment-host" id="infopanel-for-term-for-concept-documentfragment-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-documentfragment-host" style="display:none">Info about the 'host' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-documentfragment-host①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credentials">
-   <a href="https://fetch.spec.whatwg.org/#credentials">https://fetch.spec.whatwg.org/#credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credentials" class="dfn-panel" data-for="term-for-credentials" id="infopanel-for-term-for-credentials" role="menu">
+   <span id="infopaneltitle-for-term-for-credentials" style="display:none">Info about the 'credentials' external reference.</span><a href="https://fetch.spec.whatwg.org/#credentials">https://fetch.spec.whatwg.org/#credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentials">2. Client Side API</a> <a href="#ref-for-credentials①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-allow">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-allow" class="dfn-panel" data-for="term-for-attr-iframe-allow" id="infopanel-for-term-for-attr-iframe-allow" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-allow" style="display:none">Info about the 'allow' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-allow">2.6. Using WebOTP within iframe elements</a> <a href="#ref-for-attr-iframe-allow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">2.5. Permissions Policy integration</a> <a href="#ref-for-allowed-to-use①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-domain" class="dfn-panel" data-for="term-for-concept-origin-domain" id="infopanel-for-term-for-concept-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-domain">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-origin-domain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-effective-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-effective-domain" class="dfn-panel" data-for="term-for-concept-origin-effective-domain" id="infopanel-for-term-for-concept-origin-effective-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-effective-domain" style="display:none">Info about the 'effective domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-effective-domain">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-origin-effective-domain①">(2)</a> <a href="#ref-for-concept-origin-effective-domain②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.6. Using WebOTP within iframe elements</a> <a href="#ref-for-the-iframe-element①">(2)</a> <a href="#ref-for-the-iframe-element②">(3)</a>
     <li><a href="#ref-for-the-iframe-element③">4.4. Visibility Considerations for Embedded Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-permissions-policy">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-permissions-policy" class="dfn-panel" data-for="term-for-concept-document-permissions-policy" id="infopanel-for-term-for-concept-document-permissions-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-permissions-policy" style="display:none">Info about the 'permissions policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-permissions-policy">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-document-permissions-policy①">2.5. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">2.5. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">2.5. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-bound-one-time-code-message">
-   <a href="https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message">https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-bound-one-time-code-message" class="dfn-panel" data-for="term-for-origin-bound-one-time-code-message" id="infopanel-for-term-for-origin-bound-one-time-code-message" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-bound-one-time-code-message" style="display:none">Info about the 'origin-bound one-time code message' external reference.</span><a href="https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message">https://wicg.github.io/sms-one-time-codes/#origin-bound-one-time-code-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-bound-one-time-code-message">1.2. The server side API</a> <a href="#ref-for-origin-bound-one-time-code-message①">(2)</a>
     <li><a href="#ref-for-origin-bound-one-time-code-message②">3.1. SMS</a>
@@ -1286,86 +1286,86 @@ authoring advice.</p>
     <li><a href="#ref-for-origin-bound-one-time-code-message⑤">5. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-empty-host">
-   <a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-empty-host" class="dfn-panel" data-for="term-for-empty-host" id="infopanel-for-term-for-empty-host" role="menu">
+   <span id="infopaneltitle-for-term-for-empty-host" style="display:none">Info about the 'empty host' external reference.</span><a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-host">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv4">
-   <a href="https://url.spec.whatwg.org/#concept-ipv4">https://url.spec.whatwg.org/#concept-ipv4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv4" class="dfn-panel" data-for="term-for-concept-ipv4" id="infopanel-for-term-for-concept-ipv4" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv4" style="display:none">Info about the 'ipv4 address' external reference.</span><a href="https://url.spec.whatwg.org/#concept-ipv4">https://url.spec.whatwg.org/#concept-ipv4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv4">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv6">
-   <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv6" class="dfn-panel" data-for="term-for-concept-ipv6" id="infopanel-for-term-for-concept-ipv6" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv6" style="display:none">Info about the 'ipv6 address' external reference.</span><a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opaque-host">
-   <a href="https://url.spec.whatwg.org/#opaque-host">https://url.spec.whatwg.org/#opaque-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opaque-host" class="dfn-panel" data-for="term-for-opaque-host" id="infopanel-for-term-for-opaque-host" role="menu">
+   <span id="infopaneltitle-for-term-for-opaque-host" style="display:none">Info about the 'opaque host' external reference.</span><a href="https://url.spec.whatwg.org/#opaque-host">https://url.spec.whatwg.org/#opaque-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-host">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1. The OTPCredential Interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. The OTPCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.1. The OTPCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface-object" class="dfn-panel" data-for="term-for-dfn-interface-object" id="infopanel-for-term-for-dfn-interface-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface-object" style="display:none">Info about the 'interface object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-object">2.1. The OTPCredential Interface</a> <a href="#ref-for-dfn-interface-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.3. OTPCredentialRequestOptions</a>
    </ul>
@@ -1490,125 +1490,181 @@ authoring advice.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="otpcredential">
-   <b><a href="#otpcredential">#otpcredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-otpcredential" class="dfn-panel" data-for="otpcredential" id="infopanel-for-otpcredential" role="dialog">
+   <span id="infopaneltitle-for-otpcredential" style="display:none">Info about the 'OTPCredential' definition.</span><b><a href="#otpcredential">#otpcredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-otpcredential">2. Client Side API</a>
     <li><a href="#ref-for-otpcredential①">2.1. The OTPCredential Interface</a> <a href="#ref-for-otpcredential②">(2)</a> <a href="#ref-for-otpcredential③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-otpcredential-code">
-   <b><a href="#dom-otpcredential-code">#dom-otpcredential-code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-otpcredential-code" class="dfn-panel" data-for="dom-otpcredential-code" id="infopanel-for-dom-otpcredential-code" role="dialog">
+   <span id="infopaneltitle-for-dom-otpcredential-code" style="display:none">Info about the 'code' definition.</span><b><a href="#dom-otpcredential-code">#dom-otpcredential-code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-otpcredential-code">2.1. The OTPCredential Interface</a> <a href="#ref-for-dom-otpcredential-code①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-otpcredential-discoverfromexternalsource-slot">
-   <b><a href="#dom-otpcredential-discoverfromexternalsource-slot">#dom-otpcredential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-otpcredential-discoverfromexternalsource-slot" class="dfn-panel" data-for="dom-otpcredential-discoverfromexternalsource-slot" id="infopanel-for-dom-otpcredential-discoverfromexternalsource-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-otpcredential-discoverfromexternalsource-slot" style="display:none">Info about the '[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-otpcredential-discoverfromexternalsource-slot">#dom-otpcredential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-otpcredential-discoverfromexternalsource-slot">2. Client Side API</a> <a href="#ref-for-dom-otpcredential-discoverfromexternalsource-slot①">(2)</a>
     <li><a href="#ref-for-dom-otpcredential-discoverfromexternalsource-slot②">2.1. The OTPCredential Interface</a>
     <li><a href="#ref-for-dom-otpcredential-discoverfromexternalsource-slot③">2.6. Using WebOTP within iframe elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-otp">
-   <b><a href="#dom-credentialrequestoptions-otp">#dom-credentialrequestoptions-otp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-otp" class="dfn-panel" data-for="dom-credentialrequestoptions-otp" id="infopanel-for-dom-credentialrequestoptions-otp" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-otp" style="display:none">Info about the 'otp' definition.</span><b><a href="#dom-credentialrequestoptions-otp">#dom-credentialrequestoptions-otp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-otp">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialrequestoptions-otp①">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-otp②">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-otp③">(4)</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-otp④">2.2. CredentialRequestOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-otpcredentialrequestoptions">
-   <b><a href="#dictdef-otpcredentialrequestoptions">#dictdef-otpcredentialrequestoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-otpcredentialrequestoptions" class="dfn-panel" data-for="dictdef-otpcredentialrequestoptions" id="infopanel-for-dictdef-otpcredentialrequestoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-otpcredentialrequestoptions" style="display:none">Info about the 'OTPCredentialRequestOptions' definition.</span><b><a href="#dictdef-otpcredentialrequestoptions">#dictdef-otpcredentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-otpcredentialrequestoptions">2.1.1. The [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dictdef-otpcredentialrequestoptions①">2.2. CredentialRequestOptions</a> <a href="#ref-for-dictdef-otpcredentialrequestoptions②">(2)</a>
     <li><a href="#ref-for-dictdef-otpcredentialrequestoptions③">2.3. OTPCredentialRequestOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-otpcredentialrequestoptions-transport">
-   <b><a href="#dom-otpcredentialrequestoptions-transport">#dom-otpcredentialrequestoptions-transport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-otpcredentialrequestoptions-transport" class="dfn-panel" data-for="dom-otpcredentialrequestoptions-transport" id="infopanel-for-dom-otpcredentialrequestoptions-transport" role="dialog">
+   <span id="infopaneltitle-for-dom-otpcredentialrequestoptions-transport" style="display:none">Info about the 'transport' definition.</span><b><a href="#dom-otpcredentialrequestoptions-transport">#dom-otpcredentialrequestoptions-transport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-otpcredentialrequestoptions-transport">2.3. OTPCredentialRequestOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-otpcredentialtransporttype">
-   <b><a href="#enumdef-otpcredentialtransporttype">#enumdef-otpcredentialtransporttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-otpcredentialtransporttype" class="dfn-panel" data-for="enumdef-otpcredentialtransporttype" id="infopanel-for-enumdef-otpcredentialtransporttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-otpcredentialtransporttype" style="display:none">Info about the 'OTPCredentialTransportType' definition.</span><b><a href="#enumdef-otpcredentialtransporttype">#enumdef-otpcredentialtransporttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-otpcredentialtransporttype">2.3. OTPCredentialRequestOptions</a> <a href="#ref-for-enumdef-otpcredentialtransporttype①">(2)</a> <a href="#ref-for-enumdef-otpcredentialtransporttype②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-otpcredentialtransporttype-sms">
-   <b><a href="#dom-otpcredentialtransporttype-sms">#dom-otpcredentialtransporttype-sms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-otpcredentialtransporttype-sms" class="dfn-panel" data-for="dom-otpcredentialtransporttype-sms" id="infopanel-for-dom-otpcredentialtransporttype-sms" role="dialog">
+   <span id="infopaneltitle-for-dom-otpcredentialtransporttype-sms" style="display:none">Info about the 'sms' definition.</span><b><a href="#dom-otpcredentialtransporttype-sms">#dom-otpcredentialtransporttype-sms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-otpcredentialtransporttype-sms">2.4. OTPCredentialTransportType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="otp-credentials-feature">
-   <b><a href="#otp-credentials-feature">#otp-credentials-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-otp-credentials-feature" class="dfn-panel" data-for="otp-credentials-feature" id="infopanel-for-otp-credentials-feature" role="dialog">
+   <span id="infopaneltitle-for-otp-credentials-feature" style="display:none">Info about the 'otp-credentials' definition.</span><b><a href="#otp-credentials-feature">#otp-credentials-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-otp-credentials-feature">2.6. Using WebOTP within iframe elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ui-redressing">
-   <b><a href="#ui-redressing">#ui-redressing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ui-redressing" class="dfn-panel" data-for="ui-redressing" id="infopanel-for-ui-redressing" role="dialog">
+   <span id="infopaneltitle-for-ui-redressing" style="display:none">Info about the 'UI Redressing' definition.</span><b><a href="#ui-redressing">#ui-redressing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ui-redressing">2.6. Using WebOTP within iframe elements</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WICG/webpackage/loading.html
+++ b/tests/github/WICG/webpackage/loading.html
@@ -2633,158 +2633,158 @@ stop the UA from trusting it no more than 7 days later.</p>
     </ul>
    <li><a href="#wait-and-queue-a-report-for">wait and queue a report for</a><span>, in § 5.15</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6" style="display:none">Info about the 'quoted-string' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">3. Subresource substitution</a> <a href="#ref-for-section-3.2.6①">(2)</a> <a href="#ref-for-section-3.2.6②">(3)</a> <a href="#ref-for-section-3.2.6③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6①" style="display:none">Info about the 'token' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">3. Subresource substitution</a> <a href="#ref-for-section-3.2.6①">(2)</a> <a href="#ref-for-section-3.2.6②">(3)</a> <a href="#ref-for-section-3.2.6③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grammardef-hash-source">
-   <a href="https://w3c.github.io/webappsec-csp/#grammardef-hash-source">https://w3c.github.io/webappsec-csp/#grammardef-hash-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grammardef-hash-source" class="dfn-panel" data-for="term-for-grammardef-hash-source" id="infopanel-for-term-for-grammardef-hash-source" role="menu">
+   <span id="infopaneltitle-for-term-for-grammardef-hash-source" style="display:none">Info about the 'hash-source' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#grammardef-hash-source">https://w3c.github.io/webappsec-csp/#grammardef-hash-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">3. Subresource substitution</a>
     <li><a href="#ref-for-grammardef-hash-source①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://drafts.csswg.org/css2/#viewport">https://drafts.csswg.org/css2/#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://drafts.csswg.org/css2/#viewport">https://drafts.csswg.org/css2/#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-viewport①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.1. New Document fields</a> <a href="#ref-for-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-event-fire①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-node-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2" class="dfn-panel" data-for="term-for-section-4.2" id="infopanel-for-term-for-section-4.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2" style="display:none">Info about the 'parsing http1 header fields into structured headers' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-07#section-4.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2①">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-variant-key">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variant-key">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variant-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-variant-key" class="dfn-panel" data-for="term-for-variant-key" id="infopanel-for-term-for-variant-key" role="menu">
+   <span id="infopaneltitle-for-term-for-variant-key" style="display:none">Info about the 'variant-key' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variant-key">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variant-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-variant-key">3. Subresource substitution</a> <a href="#ref-for-variant-key①">(2)</a>
     <li><a href="#ref-for-variant-key②">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-variants">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variants">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variants</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-variants" class="dfn-panel" data-for="term-for-variants" id="infopanel-for-term-for-variants" role="menu">
+   <span id="infopaneltitle-for-term-for-variants" style="display:none">Info about the 'variants' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variants">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#variants</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-variants">3. Subresource substitution</a> <a href="#ref-for-variants①">(2)</a>
     <li><a href="#ref-for-variants②">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cache">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#cache">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#cache</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cache" class="dfn-panel" data-for="term-for-cache" id="infopanel-for-term-for-cache" role="menu">
+   <span id="infopaneltitle-for-term-for-cache" style="display:none">Info about the 'variants cache behavior' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#cache">https://httpwg.org/http-extensions/draft-ietf-httpbis-variants.html#cache</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">5.13. Request matching</a> <a href="#ref-for-cache①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2.2">
-   <a href="https://tools.ietf.org/html/draft-thomson-http-mice-03#section-2.2">https://tools.ietf.org/html/draft-thomson-http-mice-03#section-2.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2.2" class="dfn-panel" data-for="term-for-section-2.2" id="infopanel-for-term-for-section-2.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2.2" style="display:none">Info about the 'integrity proof for the first record' external reference.</span><a href="https://tools.ietf.org/html/draft-thomson-http-mice-03#section-2.2">https://tools.ietf.org/html/draft-thomson-http-mice-03#section-2.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2.2⑤">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-seccons-off-path">
-   <a href="https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#seccons-off-path">https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#seccons-off-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-seccons-off-path" class="dfn-panel" data-for="term-for-seccons-off-path" id="infopanel-for-term-for-seccons-off-path" role="menu">
+   <span id="infopaneltitle-for-term-for-seccons-off-path" style="display:none">Info about the 'off-path attackers' external reference.</span><a href="https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#seccons-off-path">https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#seccons-off-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-seccons-off-path">6.1. Certificate Transparency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uncached-headers">
-   <a href="https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#uncached-headers">https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#uncached-headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uncached-headers" class="dfn-panel" data-for="term-for-uncached-headers" id="infopanel-for-term-for-uncached-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-uncached-headers" style="display:none">Info about the 'uncached response header' external reference.</span><a href="https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#uncached-headers">https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#uncached-headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uncached-headers">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.4">
-   <a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.4">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.4" class="dfn-panel" data-for="term-for-section-3.4" id="infopanel-for-term-for-section-3.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.4" style="display:none">Info about the 'canonically-encoded cbor' external reference.</span><a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.4">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.4①">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2">
-   <a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-4.2">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-4.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2" class="dfn-panel" data-for="term-for-section-4.2" id="infopanel-for-term-for-section-4.2①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2①" style="display:none">Info about the 'cansignhttpexchanges' external reference.</span><a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-4.2">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-4.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2②">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3">
-   <a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.3">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3" class="dfn-panel" data-for="term-for-section-3.3" id="infopanel-for-term-for-section-3.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3" style="display:none">Info about the 'cert-chain cddl' external reference.</span><a href="https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.3">https://tools.ietf.org/html/draft-yasskin-httpbis-origin-signed-exchanges-impl-02#section-3.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3③">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-known-length">
-   <a href="https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#parse-known-length">https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#parse-known-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-known-length" class="dfn-panel" data-for="term-for-parse-known-length" id="infopanel-for-term-for-parse-known-length" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-known-length" style="display:none">Info about the 'parsing a cbor item' external reference.</span><a href="https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#parse-known-length">https://wicg.github.io/webpackage/draft-yasskin-wpack-bundled-exchanges.html#parse-known-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-known-length">5.10. Parsing b2 CBOR headers</a>
     <li><a href="#ref-for-parse-known-length①">5.11. Parsing b3 CBOR headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom-or-fail">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom-or-fail" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom-or-fail" id="infopanel-for-term-for-utf-8-decode-without-bom-or-fail" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom-or-fail" style="display:none">Info about the 'utf-8 decode without bom or fail' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom-or-fail">5.4. Parsing the invariant prefix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-requestcache-only-if-cached">
-   <a href="https://fetch.spec.whatwg.org/#dom-requestcache-only-if-cached">https://fetch.spec.whatwg.org/#dom-requestcache-only-if-cached</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-requestcache-only-if-cached" class="dfn-panel" data-for="term-for-dom-requestcache-only-if-cached" id="infopanel-for-term-for-dom-requestcache-only-if-cached" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-requestcache-only-if-cached" style="display:none">Info about the '"only-if-cached"' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-requestcache-only-if-cached">https://fetch.spec.whatwg.org/#dom-requestcache-only-if-cached</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestcache-only-if-cached">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-append">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-append" class="dfn-panel" data-for="term-for-concept-header-list-append" id="infopanel-for-term-for-concept-header-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-append">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body" class="dfn-panel" data-for="term-for-concept-body" id="infopanel-for-term-for-concept-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">2.2. Request clone</a> <a href="#ref-for-concept-request-body①">(2)</a> <a href="#ref-for-concept-request-body②">(3)</a> <a href="#ref-for-concept-request-body③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">5.2. Extracting the fallback URL</a>
     <li><a href="#ref-for-concept-response-body①">5.3. Parsing signed exchanges</a>
@@ -2793,20 +2793,20 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-view
     <li><a href="#ref-for-concept-response-body⑤">5.15. Wait and queue a report</a> <a href="#ref-for-concept-response-body⑥">(2)</a> <a href="#ref-for-concept-response-body⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-cache">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-cache">https://fetch.spec.whatwg.org/#dom-request-cache</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-cache" class="dfn-panel" data-for="term-for-dom-request-cache" id="infopanel-for-term-for-dom-request-cache" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-cache" style="display:none">Info about the 'cache' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-cache">https://fetch.spec.whatwg.org/#dom-request-cache</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-cache">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">2.6. Monkeypatch HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-concept-request-client①">3.5. 
@@ -2814,76 +2814,76 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-request-client②">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-clone">https://fetch.spec.whatwg.org/#concept-body-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-clone" class="dfn-panel" data-for="term-for-concept-body-clone" id="infopanel-for-term-for-concept-body-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-clone" style="display:none">Info about the 'clone (for body)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-clone">https://fetch.spec.whatwg.org/#concept-body-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-clone">2.2. Request clone</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-clone">https://fetch.spec.whatwg.org/#concept-request-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-clone" class="dfn-panel" data-for="term-for-concept-request-clone" id="infopanel-for-term-for-concept-request-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-clone" style="display:none">Info about the 'clone (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-clone">https://fetch.spec.whatwg.org/#concept-request-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-clone">2.2. Request clone</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-clone" class="dfn-panel" data-for="term-for-concept-response-clone" id="infopanel-for-term-for-concept-response-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-clone" style="display:none">Info about the 'clone (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-clone">2.2. Request clone</a>
     <li><a href="#ref-for-concept-response-clone①">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-concept-response-clone②">3.4. Monkeypatch process a navigate fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-clone">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-clone">https://fetch.spec.whatwg.org/#dom-request-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-clone" class="dfn-panel" data-for="term-for-dom-request-clone" id="infopanel-for-term-for-dom-request-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-clone" style="display:none">Info about the 'clone()' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-clone">https://fetch.spec.whatwg.org/#dom-request-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-clone">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">5.10. Parsing b2 CBOR headers</a>
     <li><a href="#ref-for-header-list-contains①">5.11.1. Converting a map to a header list</a>
     <li><a href="#ref-for-header-list-contains②">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-nonce-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">https://fetch.spec.whatwg.org/#concept-request-nonce-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-nonce-metadata" class="dfn-panel" data-for="term-for-concept-request-nonce-metadata" id="infopanel-for-term-for-concept-request-nonce-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-nonce-metadata" style="display:none">Info about the 'cryptographic nonce metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">https://fetch.spec.whatwg.org/#concept-request-nonce-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-determine-nosniff">
-   <a href="https://fetch.spec.whatwg.org/#determine-nosniff">https://fetch.spec.whatwg.org/#determine-nosniff</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-determine-nosniff" class="dfn-panel" data-for="term-for-determine-nosniff" id="infopanel-for-term-for-determine-nosniff" role="menu">
+   <span id="infopaneltitle-for-term-for-determine-nosniff" style="display:none">Info about the 'determine nosniff' external reference.</span><a href="https://fetch.spec.whatwg.org/#determine-nosniff">https://fetch.spec.whatwg.org/#determine-nosniff</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-nosniff">5.1. Identifying signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains①" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains①" style="display:none">Info about the 'does not contain' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">5.10. Parsing b2 CBOR headers</a>
     <li><a href="#ref-for-header-list-contains①">5.11.1. Converting a map to a header list</a>
     <li><a href="#ref-for-header-list-contains②">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extracting a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">5.1. Identifying signed exchanges</a>
     <li><a href="#ref-for-concept-header-extract-mime-type①">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extract-header-list-values" class="dfn-panel" data-for="term-for-extract-header-list-values" id="infopanel-for-term-for-extract-header-list-values" role="menu">
+   <span id="infopaneltitle-for-term-for-extract-header-list-values" style="display:none">Info about the 'extracting header list values' external reference.</span><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">2.4. Response date</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-concept-fetch①">3.5. 
@@ -2891,14 +2891,14 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-fetch②">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-get">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-get">https://fetch.spec.whatwg.org/#concept-header-list-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-get" class="dfn-panel" data-for="term-for-concept-header-list-get" id="infopanel-for-term-for-concept-header-list-get" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-get" style="display:none">Info about the 'get' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-get">https://fetch.spec.whatwg.org/#concept-header-list-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-header-list-get①">(2)</a>
     <li><a href="#ref-for-concept-header-list-get②">3.5. 
@@ -2906,33 +2906,33 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-header-list-get③">5.13. Request matching</a> <a href="#ref-for-concept-header-list-get④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-get-decode-split">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split">https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-get-decode-split" class="dfn-panel" data-for="term-for-concept-header-list-get-decode-split" id="infopanel-for-term-for-concept-header-list-get-decode-split" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-get-decode-split" style="display:none">Info about the 'getting, decoding, and splitting' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split">https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get-decode-split">5.12. Creating the response stream.</a> <a href="#ref-for-concept-header-list-get-decode-split①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handle-content-codings">
-   <a href="https://fetch.spec.whatwg.org/#handle-content-codings">https://fetch.spec.whatwg.org/#handle-content-codings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handle-content-codings" class="dfn-panel" data-for="term-for-handle-content-codings" id="infopanel-for-term-for-handle-content-codings" role="menu">
+   <span id="infopaneltitle-for-term-for-handle-content-codings" style="display:none">Info about the 'handle content codings' external reference.</span><a href="https://fetch.spec.whatwg.org/#handle-content-codings">https://fetch.spec.whatwg.org/#handle-content-codings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-content-codings">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list">https://fetch.spec.whatwg.org/#concept-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list" class="dfn-panel" data-for="term-for-concept-header-list" id="infopanel-for-term-for-concept-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list">https://fetch.spec.whatwg.org/#concept-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list">2.3. New response fields</a>
     <li><a href="#ref-for-concept-header-list①">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">2.3. New response fields</a>
     <li><a href="#ref-for-concept-response-header-list①">2.4. Response date</a>
@@ -2949,80 +2949,80 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-conc
     <li><a href="#ref-for-concept-response-header-list①⑦">5.13. Request matching</a> <a href="#ref-for-concept-response-header-list①⑧">(2)</a> <a href="#ref-for-concept-response-header-list①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">2.5. Monkeypatch HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-network-or-cache-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch">https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-network-or-cache-fetch" class="dfn-panel" data-for="term-for-concept-http-network-or-cache-fetch" id="infopanel-for-term-for-concept-http-network-or-cache-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-network-or-cache-fetch" style="display:none">Info about the 'http-network-or-cache fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch">https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-network-or-cache-fetch">2.6. Monkeypatch HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">2.6. Monkeypatch HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-integrity-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-integrity-metadata" class="dfn-panel" data-for="term-for-concept-request-integrity-metadata" id="infopanel-for-term-for-concept-request-integrity-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-integrity-metadata" style="display:none">Info about the 'integrity metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-integrity-metadata">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">2.5. Monkeypatch HTTP fetch</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">2.6. Monkeypatch HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-potential-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-potential-destination">https://fetch.spec.whatwg.org/#concept-potential-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-potential-destination" class="dfn-panel" data-for="term-for-concept-potential-destination" id="infopanel-for-term-for-concept-potential-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-potential-destination" style="display:none">Info about the 'potential destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-potential-destination">https://fetch.spec.whatwg.org/#concept-potential-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-potential-destination">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-concept-potential-destination①">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-concept-potential-destination②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-redirect-status">
-   <a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-redirect-status" class="dfn-panel" data-for="term-for-redirect-status" id="infopanel-for-term-for-redirect-status" role="menu">
+   <span id="infopaneltitle-for-term-for-redirect-status" style="display:none">Info about the 'redirect status' external reference.</span><a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-redirect-status">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-redirect-status①">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer-policy">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer-policy" class="dfn-panel" data-for="term-for-concept-request-referrer-policy" id="infopanel-for-term-for-concept-request-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer-policy">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2.1. A request’s stashed exchange</a>
     <li><a href="#ref-for-concept-request①">4.4. Signed Exchange report</a>
@@ -3030,8 +3030,8 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-request③">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. New response fields</a> <a href="#ref-for-concept-response①">(2)</a> <a href="#ref-for-concept-response②">(3)</a>
     <li><a href="#ref-for-concept-response③">2.4. Response date</a>
@@ -3048,14 +3048,14 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-response①④">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-set">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-set">https://fetch.spec.whatwg.org/#concept-header-list-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-set" class="dfn-panel" data-for="term-for-concept-header-list-set" id="infopanel-for-term-for-concept-header-list-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-set" style="display:none">Info about the 'set' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-set">https://fetch.spec.whatwg.org/#concept-header-list-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-set">2.5. Monkeypatch HTTP fetch</a> <a href="#ref-for-concept-header-list-set①">(2)</a>
     <li><a href="#ref-for-concept-header-list-set②">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-header-list-set③">(2)</a>
@@ -3064,14 +3064,14 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-conc
     <li><a href="#ref-for-concept-header-list-set⑥">5.10. Parsing b2 CBOR headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-status" class="dfn-panel" data-for="term-for-concept-status" id="infopanel-for-term-for-concept-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-status">https://fetch.spec.whatwg.org/#concept-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-status">2.5. Monkeypatch HTTP fetch</a> <a href="#ref-for-concept-status①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-concept-response-status①">5.3. Parsing signed exchanges</a>
@@ -3080,8 +3080,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-conc
     <li><a href="#ref-for-concept-response-status④">5.11. Parsing b3 CBOR headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">5.2. Extracting the fallback URL</a>
     <li><a href="#ref-for-concept-body-stream①">5.3. Parsing signed exchanges</a>
@@ -3090,22 +3090,22 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-conc
     <li><a href="#ref-for-concept-body-stream⑤">5.15. Wait and queue a report</a> <a href="#ref-for-concept-body-stream⑥">(2)</a> <a href="#ref-for-concept-body-stream⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-potential-destination-translate">
-   <a href="https://fetch.spec.whatwg.org/#concept-potential-destination-translate">https://fetch.spec.whatwg.org/#concept-potential-destination-translate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-potential-destination-translate" class="dfn-panel" data-for="term-for-concept-potential-destination-translate" id="infopanel-for-term-for-concept-potential-destination-translate" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-potential-destination-translate" style="display:none">Info about the 'translate' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-potential-destination-translate">https://fetch.spec.whatwg.org/#concept-potential-destination-translate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-potential-destination-translate">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-potential-destination-translate①">(2)</a>
     <li><a href="#ref-for-concept-potential-destination-translate②">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-concept-potential-destination-translate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-url">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-url">https://fetch.spec.whatwg.org/#dom-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-url" class="dfn-panel" data-for="term-for-dom-request-url" id="infopanel-for-term-for-dom-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-url" style="display:none">Info about the 'url (for Request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-url">https://fetch.spec.whatwg.org/#dom-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-url">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.4. Monkeypatch process a navigate fetch</a> <a href="#ref-for-concept-request-url①">(2)</a>
     <li><a href="#ref-for-concept-request-url②">5.5.1. Handling the certificate reference</a>
@@ -3113,8 +3113,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-conc
     <li><a href="#ref-for-concept-request-url④">5.16. Queuing signed exchange report</a> <a href="#ref-for-concept-request-url⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-concept-response-url①">(2)</a>
     <li><a href="#ref-for-concept-response-url②">3.5. 
@@ -3122,86 +3122,86 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-response-url③">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url-list">https://fetch.spec.whatwg.org/#concept-response-url-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url-list" class="dfn-panel" data-for="term-for-concept-response-url-list" id="infopanel-for-term-for-concept-response-url-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url-list" style="display:none">Info about the 'url list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url-list">https://fetch.spec.whatwg.org/#concept-response-url-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url-list">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rel-alternate">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#rel-alternate">https://html.spec.whatwg.org/multipage/links.html#rel-alternate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rel-alternate" class="dfn-panel" data-for="term-for-rel-alternate" id="infopanel-for-term-for-rel-alternate" role="menu">
+   <span id="infopaneltitle-for-term-for-rel-alternate" style="display:none">Info about the 'alternate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#rel-alternate">https://html.spec.whatwg.org/multipage/links.html#rel-alternate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rel-alternate">3. Subresource substitution</a>
     <li><a href="#ref-for-rel-alternate①">4.7. Alternate signed exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-settings-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-settings-attribute" class="dfn-panel" data-for="term-for-cors-settings-attribute" id="infopanel-for-term-for-cors-settings-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-settings-attribute" style="display:none">Info about the 'cors settings attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-settings-attribute">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-potential-cors-request">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-potential-cors-request" class="dfn-panel" data-for="term-for-create-a-potential-cors-request" id="infopanel-for-term-for-create-a-potential-cors-request" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-potential-cors-request" style="display:none">Info about the 'creating a potential-cors request' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-potential-cors-request">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-create-a-potential-cors-request①">(2)</a>
     <li><a href="#ref-for-create-a-potential-cors-request②">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-create-a-potential-cors-request③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-environment-settings-object①">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-environment-settings-object②">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-error">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-error">https://html.spec.whatwg.org/multipage/indices.html#event-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-error" class="dfn-panel" data-for="term-for-event-error" id="infopanel-for-term-for-event-error" role="menu">
+   <span id="infopaneltitle-for-term-for-event-error" style="display:none">Info about the 'error' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-error">https://html.spec.whatwg.org/multipage/indices.html#event-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-error">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-host">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-host" class="dfn-panel" data-for="term-for-concept-origin-host" id="infopanel-for-term-for-concept-origin-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-host" style="display:none">Info about the 'host' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-host">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-href">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-href" class="dfn-panel" data-for="term-for-attr-link-href" id="infopanel-for-term-for-attr-link-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-href" style="display:none">Info about the 'href' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-href">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-attr-link-href①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-imagesizes">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesizes">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesizes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-imagesizes" class="dfn-panel" data-for="term-for-attr-link-imagesizes" id="infopanel-for-term-for-attr-link-imagesizes" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-imagesizes" style="display:none">Info about the 'imagesizes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesizes">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesizes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-imagesizes">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-attr-link-imagesizes①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-imagesrcset">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-imagesrcset" class="dfn-panel" data-for="term-for-attr-link-imagesrcset" id="infopanel-for-term-for-attr-link-imagesrcset" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-imagesrcset" style="display:none">Info about the 'imagesrcset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-imagesrcset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-imagesrcset">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-attr-link-imagesrcset①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-in-parallel①">3.3. Monkeypatch Link type "prefetch"</a>
@@ -3218,63 +3218,63 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-in-p
     <li><a href="#ref-for-in-parallel①②">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-the-link-element①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-load">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-load">https://html.spec.whatwg.org/multipage/indices.html#event-load</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-load" class="dfn-panel" data-for="term-for-event-load" id="infopanel-for-term-for-event-load" role="menu">
+   <span id="infopaneltitle-for-term-for-event-load" style="display:none">Info about the 'load' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-load">https://html.spec.whatwg.org/multipage/indices.html#event-load</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-load">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-params">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-params" class="dfn-panel" data-for="term-for-navigation-params" id="infopanel-for-term-for-navigation-params" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-params" style="display:none">Info about the 'navigation params' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-params">3.2. New navigation params struct field</a>
     <li><a href="#ref-for-navigation-params①">3.4. Monkeypatch process a navigate fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networking-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networking-task-source" class="dfn-panel" data-for="term-for-networking-task-source" id="infopanel-for-term-for-networking-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-networking-task-source" style="display:none">Info about the 'networking task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networking-task-source">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-crossorigin-none">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-crossorigin-none">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-crossorigin-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-crossorigin-none" class="dfn-panel" data-for="term-for-attr-crossorigin-none" id="infopanel-for-term-for-attr-crossorigin-none" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-crossorigin-none" style="display:none">Info about the 'no cors' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-crossorigin-none">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-crossorigin-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-crossorigin-none">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-attr-crossorigin-none①">(2)</a>
     <li><a href="#ref-for-attr-crossorigin-none②">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-html">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html">https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-html" class="dfn-panel" data-for="term-for-read-html" id="infopanel-for-term-for-read-html" role="menu">
+   <span id="infopaneltitle-for-term-for-read-html" style="display:none">Info about the 'page load processing model for html files' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html">https://html.spec.whatwg.org/multipage/browsing-the-web.html#read-html</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-html">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-read-html①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-link-type-prefetch">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch">https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-link-type-prefetch" class="dfn-panel" data-for="term-for-link-type-prefetch" id="infopanel-for-term-for-link-type-prefetch" role="menu">
+   <span id="infopaneltitle-for-term-for-link-type-prefetch" style="display:none">Info about the 'prefetch' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch">https://html.spec.whatwg.org/multipage/links.html#link-type-prefetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-type-prefetch">3.1. New Document fields</a>
     <li><a href="#ref-for-link-type-prefetch①">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-link-type-prefetch②">(2)</a> <a href="#ref-for-link-type-prefetch③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-link-type-preload">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#link-type-preload">https://html.spec.whatwg.org/multipage/links.html#link-type-preload</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-link-type-preload" class="dfn-panel" data-for="term-for-link-type-preload" id="infopanel-for-term-for-link-type-preload" role="menu">
+   <span id="infopaneltitle-for-term-for-link-type-preload" style="display:none">Info about the 'preload' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#link-type-preload">https://html.spec.whatwg.org/multipage/links.html#link-type-preload</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-type-preload">3. Subresource substitution</a>
     <li><a href="#ref-for-link-type-preload①">3.3. Monkeypatch Link type "prefetch"</a>
@@ -3282,54 +3282,54 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-read
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-link-type-preload③">(2)</a> <a href="#ref-for-link-type-preload④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-the-linked-resource">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#process-the-linked-resource">https://html.spec.whatwg.org/multipage/semantics.html#process-the-linked-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-the-linked-resource" class="dfn-panel" data-for="term-for-process-the-linked-resource" id="infopanel-for-term-for-process-the-linked-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-process-the-linked-resource" style="display:none">Info about the 'process the linked resource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#process-the-linked-resource">https://html.spec.whatwg.org/multipage/semantics.html#process-the-linked-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-the-linked-resource">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy-attribute" class="dfn-panel" data-for="term-for-referrer-policy-attribute" id="infopanel-for-term-for-referrer-policy-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy-attribute" style="display:none">Info about the 'referrer policy attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#referrer-policy-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy-attribute">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-params-response">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-response">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-params-response" class="dfn-panel" data-for="term-for-navigation-params-response" id="infopanel-for-term-for-navigation-params-response" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-params-response" style="display:none">Info about the 'response' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-response">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-params-response">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-navigation-params-response①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-select-an-image-source">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#select-an-image-source">https://html.spec.whatwg.org/multipage/images.html#select-an-image-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-select-an-image-source" class="dfn-panel" data-for="term-for-select-an-image-source" id="infopanel-for-term-for-select-an-image-source" role="menu">
+   <span id="infopaneltitle-for-term-for-select-an-image-source" style="display:none">Info about the 'selecting an image source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#select-an-image-source">https://html.spec.whatwg.org/multipage/images.html#select-an-image-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-select-an-image-source">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-select-an-image-source①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-dig-alg-1">
-   <a href="https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml#http-dig-alg-1">https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml#http-dig-alg-1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-dig-alg-1" class="dfn-panel" data-for="term-for-http-dig-alg-1" id="infopanel-for-term-for-http-dig-alg-1" role="menu">
+   <span id="infopaneltitle-for-term-for-http-dig-alg-1" style="display:none">Info about the 'digest algorithm' external reference.</span><a href="https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml#http-dig-alg-1">https://www.iana.org/assignments/http-dig-alg/http-dig-alg.xhtml#http-dig-alg-1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-dig-alg-1">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
@@ -3338,45 +3338,45 @@ Monkeypatch Page load processing model for HTML files</a>
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-byte">
-   <a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-byte" class="dfn-panel" data-for="term-for-ascii-byte" id="infopanel-for-term-for-ascii-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-byte" style="display:none">Info about the 'ascii byte' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-byte">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-decode">
-   <a href="https://infra.spec.whatwg.org/#ascii-decode">https://infra.spec.whatwg.org/#ascii-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-decode" class="dfn-panel" data-for="term-for-ascii-decode" id="infopanel-for-term-for-ascii-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-decode" style="display:none">Info about the 'ascii decode' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-decode">https://infra.spec.whatwg.org/#ascii-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-decode">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-encode">
-   <a href="https://infra.spec.whatwg.org/#ascii-encode">https://infra.spec.whatwg.org/#ascii-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-encode" class="dfn-panel" data-for="term-for-ascii-encode" id="infopanel-for-term-for-ascii-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-encode" style="display:none">Info about the 'ascii encode' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-encode">https://infra.spec.whatwg.org/#ascii-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-encode">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-ascii-encode①">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">4.5. Exchange Signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-upper-alpha">
-   <a href="https://infra.spec.whatwg.org/#ascii-upper-alpha">https://infra.spec.whatwg.org/#ascii-upper-alpha</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-upper-alpha" class="dfn-panel" data-for="term-for-ascii-upper-alpha" id="infopanel-for-term-for-ascii-upper-alpha" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-upper-alpha" style="display:none">Info about the 'ascii upper alpha' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-upper-alpha">https://infra.spec.whatwg.org/#ascii-upper-alpha</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-upper-alpha">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.3. New response fields</a>
     <li><a href="#ref-for-byte-sequence①">4.2. Read buffer</a>
@@ -3391,52 +3391,52 @@ exchange link info</a>
     <li><a href="#ref-for-byte-sequence①⑦">5.17.2. Read up to bytes</a> <a href="#ref-for-byte-sequence①⑧">(2)</a> <a href="#ref-for-byte-sequence①⑨">(3)</a> <a href="#ref-for-byte-sequence②⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">5.20. Get alternate signed
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'contain (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.4. Monkeypatch process a navigate fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'identical to' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-string-is①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-intersection">
-   <a href="https://infra.spec.whatwg.org/#set-intersection">https://infra.spec.whatwg.org/#set-intersection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-intersection" class="dfn-panel" data-for="term-for-set-intersection" id="infopanel-for-term-for-set-intersection" role="menu">
+   <span id="infopaneltitle-for-term-for-set-intersection" style="display:none">Info about the 'intersection' external reference.</span><a href="https://infra.spec.whatwg.org/#set-intersection">https://infra.spec.whatwg.org/#set-intersection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-intersection">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-decode" class="dfn-panel" data-for="term-for-isomorphic-decode" id="infopanel-for-term-for-isomorphic-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">5.11.1. Converting a map to a header list</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.3. Augmented Certificate</a>
     <li><a href="#ref-for-list-item①">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
@@ -3448,33 +3448,33 @@ Monkeypatch Page load processing model for HTML files</a>
 exchange link info</a> <a href="#ref-for-list⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. New Document fields</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.6. Allowed signed exchange link info</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
     <li><a href="#ref-for-string③">4.7. Alternate signed exchange link info</a> <a href="#ref-for-string④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">4.1. Exchange</a>
     <li><a href="#ref-for-struct①">4.2. Read buffer</a>
@@ -3485,93 +3485,93 @@ exchange link info</a> <a href="#ref-for-list⑨">(2)</a>
     <li><a href="#ref-for-struct⑥">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type-essence">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type-essence" class="dfn-panel" data-for="term-for-mime-type-essence" id="infopanel-for-term-for-mime-type-essence" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type-essence" style="display:none">Info about the 'essence' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type-essence">5.1. Identifying signed exchanges</a>
     <li><a href="#ref-for-mime-type-essence①">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parameters">
-   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parameters" class="dfn-panel" data-for="term-for-parameters" id="infopanel-for-term-for-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-parameters" style="display:none">Info about the 'parameters' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">5.1. Identifying signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-nel-policies">
-   <a href="https://w3c.github.io/network-error-logging/#dfn-nel-policies">https://w3c.github.io/network-error-logging/#dfn-nel-policies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-nel-policies" class="dfn-panel" data-for="term-for-dfn-nel-policies" id="infopanel-for-term-for-dfn-nel-policies" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-nel-policies" style="display:none">Info about the 'nel policy' external reference.</span><a href="https://w3c.github.io/network-error-logging/#dfn-nel-policies">https://w3c.github.io/network-error-logging/#dfn-nel-policies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-nel-policies">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.3.2">
-   <a href="https://tools.ietf.org/html/rfc3230#section-4.3.2">https://tools.ietf.org/html/rfc3230#section-4.3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.3.2" class="dfn-panel" data-for="term-for-section-4.3.2" id="infopanel-for-term-for-section-4.3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.3.2" style="display:none">Info about the 'digest' external reference.</span><a href="https://tools.ietf.org/html/rfc3230#section-4.3.2">https://tools.ietf.org/html/rfc3230#section-4.3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.3.2">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1.1.2">
-   <a href="https://tools.ietf.org/html/rfc5280#section-4.1.1.2">https://tools.ietf.org/html/rfc5280#section-4.1.1.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1.1.2" class="dfn-panel" data-for="term-for-section-4.1.1.2" id="infopanel-for-term-for-section-4.1.1.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1.1.2" style="display:none">Info about the 'algorithmidentifier' external reference.</span><a href="https://tools.ietf.org/html/rfc5280#section-4.1.1.2">https://tools.ietf.org/html/rfc5280#section-4.1.1.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.1.2">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2">
-   <a href="https://tools.ietf.org/html/rfc5280#section-4.2">https://tools.ietf.org/html/rfc5280#section-4.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2" class="dfn-panel" data-for="term-for-section-4.2" id="infopanel-for-term-for-section-4.2②" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2②" style="display:none">Info about the 'certificate extensions' external reference.</span><a href="https://tools.ietf.org/html/rfc5280#section-4.2">https://tools.ietf.org/html/rfc5280#section-4.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1.2.7">
-   <a href="https://tools.ietf.org/html/rfc5280#section-4.1.2.7">https://tools.ietf.org/html/rfc5280#section-4.1.2.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1.2.7" class="dfn-panel" data-for="term-for-section-4.1.2.7" id="infopanel-for-term-for-section-4.1.2.7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1.2.7" style="display:none">Info about the 'subject public key info' external reference.</span><a href="https://tools.ietf.org/html/rfc5280#section-4.1.2.7">https://tools.ietf.org/html/rfc5280#section-4.1.2.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.2.7">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2.1.1">
-   <a href="https://tools.ietf.org/html/rfc5480#section-2.1.1">https://tools.ietf.org/html/rfc5480#section-2.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2.1.1" class="dfn-panel" data-for="term-for-section-2.1.1" id="infopanel-for-term-for-section-2.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2.1.1" style="display:none">Info about the 'id-ecpublickey' external reference.</span><a href="https://tools.ietf.org/html/rfc5480#section-2.1.1">https://tools.ietf.org/html/rfc5480#section-2.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2.1.1">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2.1.1.1">
-   <a href="https://tools.ietf.org/html/rfc5480#section-2.1.1.1">https://tools.ietf.org/html/rfc5480#section-2.1.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2.1.1.1" class="dfn-panel" data-for="term-for-section-2.1.1.1" id="infopanel-for-term-for-section-2.1.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2.1.1.1" style="display:none">Info about the 'secp256r1' external reference.</span><a href="https://tools.ietf.org/html/rfc5480#section-2.1.1.1">https://tools.ietf.org/html/rfc5480#section-2.1.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2.1.1.1">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2.1">
-   <a href="https://tools.ietf.org/html/rfc6960#section-4.2.1">https://tools.ietf.org/html/rfc6960#section-4.2.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2.1" class="dfn-panel" data-for="term-for-section-4.2.1" id="infopanel-for-term-for-section-4.2.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2.1" style="display:none">Info about the 'ocspresponse' external reference.</span><a href="https://tools.ietf.org/html/rfc6960#section-4.2.1">https://tools.ietf.org/html/rfc6960#section-4.2.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2.1">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3">
-   <a href="https://tools.ietf.org/html/rfc6962#section-3.3">https://tools.ietf.org/html/rfc6962#section-3.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3" class="dfn-panel" data-for="term-for-section-3.3" id="infopanel-for-term-for-section-3.3①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3①" style="display:none">Info about the 'signedcertificatetimestamplist' external reference.</span><a href="https://tools.ietf.org/html/rfc6962#section-3.3">https://tools.ietf.org/html/rfc6962#section-3.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3②">4.3. Augmented Certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.1.2">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.2">https://tools.ietf.org/html/rfc7231#section-7.1.1.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.1.2" class="dfn-panel" data-for="term-for-section-7.1.1.2" id="infopanel-for-term-for-section-7.1.1.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.1.2" style="display:none">Info about the 'date' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.2">https://tools.ietf.org/html/rfc7231#section-7.1.1.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.1.2">2.4. Response date</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc8288#section-3">https://tools.ietf.org/html/rfc8288#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'link' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-3">https://tools.ietf.org/html/rfc8288#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">3. Subresource substitution</a> <a href="#ref-for-section-3①">(2)</a> <a href="#ref-for-section-3②">(3)</a> <a href="#ref-for-section-3③">(4)</a> <a href="#ref-for-section-3④">(5)</a>
     <li><a href="#ref-for-section-3⑤">3.5. 
@@ -3579,8 +3579,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-sect
     <li><a href="#ref-for-section-3⑨">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc8288#section-3.2">https://tools.ietf.org/html/rfc8288#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'link context' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-3.2">https://tools.ietf.org/html/rfc8288#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">3. Subresource substitution</a> <a href="#ref-for-section-3.2①">(2)</a>
     <li><a href="#ref-for-section-3.2②">4.7. Alternate signed exchange link info</a>
@@ -3588,8 +3588,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-sect
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1">
-   <a href="https://tools.ietf.org/html/rfc8288#section-3.1">https://tools.ietf.org/html/rfc8288#section-3.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1" class="dfn-panel" data-for="term-for-section-3.1" id="infopanel-for-term-for-section-3.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1" style="display:none">Info about the 'link target' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-3.1">https://tools.ietf.org/html/rfc8288#section-3.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1">3. Subresource substitution</a> <a href="#ref-for-section-3.1①">(2)</a> <a href="#ref-for-section-3.1②">(3)</a>
     <li><a href="#ref-for-section-3.1③">3.3. Monkeypatch Link type "prefetch"</a>
@@ -3603,8 +3603,8 @@ Monkeypatch Page load processing model for HTML files</a>
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.2">
-   <a href="https://tools.ietf.org/html/rfc8288#appendix-B.2">https://tools.ietf.org/html/rfc8288#appendix-B.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.2" class="dfn-panel" data-for="term-for-appendix-B.2" id="infopanel-for-term-for-appendix-B.2" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.2" style="display:none">Info about the 'parsing a link field value' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#appendix-B.2">https://tools.ietf.org/html/rfc8288#appendix-B.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.2">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-appendix-B.2①">(2)</a>
     <li><a href="#ref-for-appendix-B.2②">3.5. 
@@ -3612,8 +3612,8 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-appendix-B.2③">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3">
-   <a href="https://tools.ietf.org/html/rfc8288#section-3.3">https://tools.ietf.org/html/rfc8288#section-3.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3" class="dfn-panel" data-for="term-for-section-3.3" id="infopanel-for-term-for-section-3.3②" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3②" style="display:none">Info about the 'relation type' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-3.3">https://tools.ietf.org/html/rfc8288#section-3.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-section-3.3①">3.5. 
@@ -3623,14 +3623,14 @@ Monkeypatch Page load processing model for HTML files</a>
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.4">
-   <a href="https://tools.ietf.org/html/rfc8288#section-3.4">https://tools.ietf.org/html/rfc8288#section-3.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.4" class="dfn-panel" data-for="term-for-section-3.4" id="infopanel-for-term-for-section-3.4①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.4①" style="display:none">Info about the 'serialisation-defined target attribute' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-3.4">https://tools.ietf.org/html/rfc8288#section-3.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.4">3. Subresource substitution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2.2">
-   <a href="https://tools.ietf.org/html/rfc8288#section-2.2">https://tools.ietf.org/html/rfc8288#section-2.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2.2" class="dfn-panel" data-for="term-for-section-2.2" id="infopanel-for-term-for-section-2.2①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2.2①" style="display:none">Info about the 'target attribute' external reference.</span><a href="https://tools.ietf.org/html/rfc8288#section-2.2">https://tools.ietf.org/html/rfc8288#section-2.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2.2">4.6. Allowed signed exchange link info</a> <a href="#ref-for-section-2.2①">(2)</a> <a href="#ref-for-section-2.2②">(3)</a>
     <li><a href="#ref-for-section-2.2③">4.7. Alternate signed exchange link info</a> <a href="#ref-for-section-2.2④">(2)</a>
@@ -3639,44 +3639,44 @@ exchange link info</a>
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2.3">
-   <a href="https://tools.ietf.org/html/draft-ietf-tls-tls13-28#section-4.2.3">https://tools.ietf.org/html/draft-ietf-tls-tls13-28#section-4.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2.3" class="dfn-panel" data-for="term-for-section-4.2.3" id="infopanel-for-term-for-section-4.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2.3" style="display:none">Info about the 'ecdsa_secp256r1_sha256' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-tls-tls13-28#section-4.2.3">https://tools.ietf.org/html/draft-ietf-tls-tls13-28#section-4.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2.3">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-origin">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-origin" class="dfn-panel" data-for="term-for-potentially-trustworthy-origin" id="infopanel-for-term-for-potentially-trustworthy-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-origin" style="display:none">Info about the 'potentially trustworthy origin' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-origin">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetchevent">
-   <a href="https://w3c.github.io/ServiceWorker/#fetchevent">https://w3c.github.io/ServiceWorker/#fetchevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetchevent" class="dfn-panel" data-for="term-for-fetchevent" id="infopanel-for-term-for-fetchevent" role="menu">
+   <span id="infopaneltitle-for-term-for-fetchevent" style="display:none">Info about the 'FetchEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fetchevent">https://w3c.github.io/ServiceWorker/#fetchevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-serviceworkerregistration-navigationpreload">
-   <a href="https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-navigationpreload">https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-navigationpreload</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-serviceworkerregistration-navigationpreload" class="dfn-panel" data-for="term-for-dom-serviceworkerregistration-navigationpreload" id="infopanel-for-term-for-dom-serviceworkerregistration-navigationpreload" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-serviceworkerregistration-navigationpreload" style="display:none">Info about the 'navigationPreload' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-navigationpreload">https://w3c.github.io/ServiceWorker/#dom-serviceworkerregistration-navigationpreload</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-navigationpreload">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fetchevent-preloadresponse">
-   <a href="https://w3c.github.io/ServiceWorker/#dom-fetchevent-preloadresponse">https://w3c.github.io/ServiceWorker/#dom-fetchevent-preloadresponse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fetchevent-preloadresponse" class="dfn-panel" data-for="term-for-dom-fetchevent-preloadresponse" id="infopanel-for-term-for-dom-fetchevent-preloadresponse" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fetchevent-preloadresponse" style="display:none">Info about the 'preloadResponse' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dom-fetchevent-preloadresponse">https://w3c.github.io/ServiceWorker/#dom-fetchevent-preloadresponse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-preloadresponse">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fetchevent-request">
-   <a href="https://w3c.github.io/ServiceWorker/#dom-fetchevent-request">https://w3c.github.io/ServiceWorker/#dom-fetchevent-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fetchevent-request" class="dfn-panel" data-for="term-for-dom-fetchevent-request" id="infopanel-for-term-for-dom-fetchevent-request" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fetchevent-request" style="display:none">Info about the 'request' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dom-fetchevent-request">https://w3c.github.io/ServiceWorker/#dom-fetchevent-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-request">1.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'sha-256' external reference.</span><a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3. New response fields</a>
     <li><a href="#termref-for-">4.5. Exchange Signature</a>
@@ -3684,8 +3684,8 @@ exchange link info</a>
     <li><a href="#termref-for-">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">4.2. Read buffer</a>
     <li><a href="#ref-for-readablestream①">5.12. Creating the response stream.</a>
@@ -3694,122 +3694,122 @@ exchange link info</a>
     <li><a href="#ref-for-readablestream④">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader">https://streams.spec.whatwg.org/#readablestreamdefaultreader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader" class="dfn-panel" data-for="term-for-readablestreamdefaultreader" id="infopanel-for-term-for-readablestreamdefaultreader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader" style="display:none">Info about the 'ReadableStreamDefaultReader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader">https://streams.spec.whatwg.org/#readablestreamdefaultreader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader">4.2. Read buffer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-cancel" class="dfn-panel" data-for="term-for-readablestream-cancel" id="infopanel-for-term-for-readablestream-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-cancel" style="display:none">Info about the 'cancel' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-cancel">5.12. Creating the response stream.</a>
     <li><a href="#ref-for-readablestream-cancel①">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-close">
-   <a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-close" class="dfn-panel" data-for="term-for-readablestream-close" id="infopanel-for-term-for-readablestream-close" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-close" style="display:none">Info about the 'close' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-close">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-closed">
-   <a href="https://streams.spec.whatwg.org/#readablestream-closed">https://streams.spec.whatwg.org/#readablestream-closed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-closed" class="dfn-panel" data-for="term-for-readablestream-closed" id="infopanel-for-term-for-readablestream-closed" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-closed" style="display:none">Info about the 'closed' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-closed">https://streams.spec.whatwg.org/#readablestream-closed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-closed">5.15. Wait and queue a report</a> <a href="#ref-for-readablestream-closed①">(2)</a>
     <li><a href="#ref-for-readablestream-closed②">5.17.4. Dump to another stream</a> <a href="#ref-for-readablestream-closed③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">5.17.4. Dump to another stream</a> <a href="#ref-for-readablestream-enqueue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-error">
-   <a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-error" class="dfn-panel" data-for="term-for-readablestream-error" id="infopanel-for-term-for-readablestream-error" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-error" style="display:none">Info about the 'error' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-error">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-errored">
-   <a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-errored" class="dfn-panel" data-for="term-for-readablestream-errored" id="infopanel-for-term-for-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-errored">5.15. Wait and queue a report</a> <a href="#ref-for-readablestream-errored①">(2)</a>
     <li><a href="#ref-for-readablestream-errored②">5.17.4. Dump to another stream</a> <a href="#ref-for-readablestream-errored③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">5.5.1. Handling the certificate reference</a>
     <li><a href="#ref-for-readablestream-get-a-reader①">5.17.1. Create a read buffer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader①" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader①" style="display:none">Info about the 'getting a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">5.5.1. Handling the certificate reference</a>
     <li><a href="#ref-for-readablestream-get-a-reader①">5.17.1. Create a read buffer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-need-more-data">
-   <a href="https://streams.spec.whatwg.org/#readablestream-need-more-data">https://streams.spec.whatwg.org/#readablestream-need-more-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-need-more-data" class="dfn-panel" data-for="term-for-readablestream-need-more-data" id="infopanel-for-term-for-readablestream-need-more-data" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-need-more-data" style="display:none">Info about the 'need more data' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-need-more-data">https://streams.spec.whatwg.org/#readablestream-need-more-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-need-more-data">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk" id="infopanel-for-term-for-readablestreamdefaultreader-read-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" style="display:none">Info about the 'read a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk">5.17.2. Read up to bytes</a>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk①">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-readable">
-   <a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-readable" class="dfn-panel" data-for="term-for-readablestream-readable" id="infopanel-for-term-for-readablestream-readable" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-readable" style="display:none">Info about the 'readable' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-readable">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes" id="infopanel-for-term-for-readablestreamdefaultreader-read-all-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" style="display:none">Info about the 'reading all bytes' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes">5.5.1. Handling the certificate reference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-concept-url-equals①">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">5.4. Parsing the invariant prefix</a>
     <li><a href="#ref-for-concept-url-fragment①">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-concept-url-fragment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-concept-url-origin①">5.8. Cross-origin trust</a> <a href="#ref-for-concept-url-origin②">(2)</a> <a href="#ref-for-concept-url-origin③">(3)</a>
     <li><a href="#ref-for-concept-url-origin④">5.16. Queuing signed exchange report</a> <a href="#ref-for-concept-url-origin⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">5.4. Parsing the invariant prefix</a>
     <li><a href="#ref-for-concept-url-scheme①">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-concept-url-scheme②">(2)</a>
     <li><a href="#ref-for-concept-url-scheme③">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3.1. New Document fields</a>
     <li><a href="#ref-for-concept-url①">4.1. Exchange</a>
@@ -3820,8 +3820,8 @@ exchange link info</a>
     <li><a href="#ref-for-concept-url⑧">5.4. Parsing the invariant prefix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-concept-url-parser①">3.5. 
@@ -3830,28 +3830,28 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-concept-url-parser③">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-concept-url-parser④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-concept-url-serializer①">5.16. Queuing signed exchange report</a> <a href="#ref-for-concept-url-serializer②">(2)</a> <a href="#ref-for-concept-url-serializer③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">5.17.4. Dump to another stream</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">5.17.2. Read up to bytes</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
     <li><a href="#ref-for-idl-Uint8Array②">5.17.4. Dump to another stream</a> <a href="#ref-for-idl-Uint8Array③">(2)</a> <a href="#ref-for-idl-Uint8Array④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sequence-type">
-   <a href="https://webidl.spec.whatwg.org/#sequence-type">https://webidl.spec.whatwg.org/#sequence-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sequence-type" class="dfn-panel" data-for="term-for-sequence-type" id="infopanel-for-term-for-sequence-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sequence-type" style="display:none">Info about the 'sequence type' external reference.</span><a href="https://webidl.spec.whatwg.org/#sequence-type">https://webidl.spec.whatwg.org/#sequence-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequence-type">5.16. Queuing signed exchange report</a>
    </ul>
@@ -4240,8 +4240,8 @@ Behavior</a> returning a list of lists. <a href="https://github.com/httpwg/http-
 ECMAScript objects like <code class="idl"><a data-link-type="idl" href="https://streams.spec.whatwg.org/#readablestream">ReadableStream</a></code> despite not having a Realm to attach
 them to. <a href="https://github.com/whatwg/fetch/issues/730">[Issue #whatwg/fetch#730]</a> <a class="issue-return" href="#issue-3ffca592" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="request-stashed-exchange">
-   <b><a href="#request-stashed-exchange">#request-stashed-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-stashed-exchange" class="dfn-panel" data-for="request-stashed-exchange" id="infopanel-for-request-stashed-exchange" role="dialog">
+   <span id="infopaneltitle-for-request-stashed-exchange" style="display:none">Info about the 'stashed exchange' definition.</span><b><a href="#request-stashed-exchange">#request-stashed-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-stashed-exchange">2.2. Request clone</a> <a href="#ref-for-request-stashed-exchange①">(2)</a> <a href="#ref-for-request-stashed-exchange②">(3)</a> <a href="#ref-for-request-stashed-exchange③">(4)</a> <a href="#ref-for-request-stashed-exchange④">(5)</a>
     <li><a href="#ref-for-request-stashed-exchange⑤">2.5. Monkeypatch HTTP fetch</a>
@@ -4251,23 +4251,25 @@ them to. <a href="https://github.com/whatwg/fetch/issues/730">[Issue #whatwg/fet
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-came-from-a-signed-exchange">
-   <b><a href="#response-came-from-a-signed-exchange">#response-came-from-a-signed-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-came-from-a-signed-exchange" class="dfn-panel" data-for="response-came-from-a-signed-exchange" id="infopanel-for-response-came-from-a-signed-exchange" role="dialog">
+   <span id="infopaneltitle-for-response-came-from-a-signed-exchange" style="display:none">Info about the 'came from a signed exchange' definition.</span><b><a href="#response-came-from-a-signed-exchange">#response-came-from-a-signed-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-came-from-a-signed-exchange">2.3. New response fields</a>
     <li><a href="#ref-for-response-came-from-a-signed-exchange①">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-response-came-from-a-signed-exchange②">(2)</a>
     <li><a href="#ref-for-response-came-from-a-signed-exchange③">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-signed-exchange-outer-header-list">
-   <b><a href="#response-signed-exchange-outer-header-list">#response-signed-exchange-outer-header-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-signed-exchange-outer-header-list" class="dfn-panel" data-for="response-signed-exchange-outer-header-list" id="infopanel-for-response-signed-exchange-outer-header-list" role="dialog">
+   <span id="infopaneltitle-for-response-signed-exchange-outer-header-list" style="display:none">Info about the 'signed exchange outer
+header list' definition.</span><b><a href="#response-signed-exchange-outer-header-list">#response-signed-exchange-outer-header-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-signed-exchange-outer-header-list">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-response-signed-exchange-outer-header-list①">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-header-integrity-value">
-   <b><a href="#response-header-integrity-value">#response-header-integrity-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-header-integrity-value" class="dfn-panel" data-for="response-header-integrity-value" id="infopanel-for-response-header-integrity-value" role="dialog">
+   <span id="infopaneltitle-for-response-header-integrity-value" style="display:none">Info about the 'header integrity
+value' definition.</span><b><a href="#response-header-integrity-value">#response-header-integrity-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-header-integrity-value">2.3. New response fields</a>
     <li><a href="#ref-for-response-header-integrity-value①">3. Subresource substitution</a>
@@ -4276,14 +4278,14 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-response-header-integrity-value③">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-date">
-   <b><a href="#response-date">#response-date</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-date" class="dfn-panel" data-for="response-date" id="infopanel-for-response-date" role="dialog">
+   <span id="infopaneltitle-for-response-date" style="display:none">Info about the 'date' definition.</span><b><a href="#response-date">#response-date</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-date">2.6. Monkeypatch HTTP-network-or-cache fetch</a> <a href="#ref-for-response-date①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr-valuedef-link-rel-allowed-alt-sxg">
-   <b><a href="#attr-valuedef-link-rel-allowed-alt-sxg">#attr-valuedef-link-rel-allowed-alt-sxg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr-valuedef-link-rel-allowed-alt-sxg" class="dfn-panel" data-for="attr-valuedef-link-rel-allowed-alt-sxg" id="infopanel-for-attr-valuedef-link-rel-allowed-alt-sxg" role="dialog">
+   <span id="infopaneltitle-for-attr-valuedef-link-rel-allowed-alt-sxg" style="display:none">Info about the 'allowed-alt-sxg' definition.</span><b><a href="#attr-valuedef-link-rel-allowed-alt-sxg">#attr-valuedef-link-rel-allowed-alt-sxg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-valuedef-link-rel-allowed-alt-sxg">3. Subresource substitution</a> <a href="#ref-for-attr-valuedef-link-rel-allowed-alt-sxg①">(2)</a> <a href="#ref-for-attr-valuedef-link-rel-allowed-alt-sxg②">(3)</a>
     <li><a href="#ref-for-attr-valuedef-link-rel-allowed-alt-sxg③">3.3. Monkeypatch Link type "prefetch"</a>
@@ -4292,63 +4294,65 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-attr
     <li><a href="#ref-for-attr-valuedef-link-rel-allowed-alt-sxg⑥">4.6. Allowed signed exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-link-header-integrity">
-   <b><a href="#element-attrdef-link-header-integrity">#element-attrdef-link-header-integrity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-link-header-integrity" class="dfn-panel" data-for="element-attrdef-link-header-integrity" id="infopanel-for-element-attrdef-link-header-integrity" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-link-header-integrity" style="display:none">Info about the 'header-integrity' definition.</span><b><a href="#element-attrdef-link-header-integrity">#element-attrdef-link-header-integrity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-link-header-integrity">3. Subresource substitution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link">
-   <b><a href="#alternate-signed-exchange-link">#alternate-signed-exchange-link</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link" class="dfn-panel" data-for="alternate-signed-exchange-link" id="infopanel-for-alternate-signed-exchange-link" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link" style="display:none">Info about the 'alternate signed exchange link' definition.</span><b><a href="#alternate-signed-exchange-link">#alternate-signed-exchange-link</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link">3. Subresource substitution</a> <a href="#ref-for-alternate-signed-exchange-link①">(2)</a> <a href="#ref-for-alternate-signed-exchange-link②">(3)</a> <a href="#ref-for-alternate-signed-exchange-link③">(4)</a>
     <li><a href="#ref-for-alternate-signed-exchange-link④">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange">
-   <b><a href="#alternate-signed-exchange">#alternate-signed-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange" class="dfn-panel" data-for="alternate-signed-exchange" id="infopanel-for-alternate-signed-exchange" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange" style="display:none">Info about the 'alternate signed exchange' definition.</span><b><a href="#alternate-signed-exchange">#alternate-signed-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange">3. Subresource substitution</a>
     <li><a href="#ref-for-alternate-signed-exchange①">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-alternate-signed-exchange②">(2)</a>
     <li><a href="#ref-for-alternate-signed-exchange③">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-link-variants">
-   <b><a href="#element-attrdef-link-variants">#element-attrdef-link-variants</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-link-variants" class="dfn-panel" data-for="element-attrdef-link-variants" id="infopanel-for-element-attrdef-link-variants" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-link-variants" style="display:none">Info about the 'variants' definition.</span><b><a href="#element-attrdef-link-variants">#element-attrdef-link-variants</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-link-variants">3. Subresource substitution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-link-variant-key">
-   <b><a href="#element-attrdef-link-variant-key">#element-attrdef-link-variant-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-link-variant-key" class="dfn-panel" data-for="element-attrdef-link-variant-key" id="infopanel-for-element-attrdef-link-variant-key" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-link-variant-key" style="display:none">Info about the 'variant-key' definition.</span><b><a href="#element-attrdef-link-variant-key">#element-attrdef-link-variant-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-link-variant-key">3. Subresource substitution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-prefetched-signed-exchanges-for-navigation">
-   <b><a href="#document-prefetched-signed-exchanges-for-navigation">#document-prefetched-signed-exchanges-for-navigation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-prefetched-signed-exchanges-for-navigation" class="dfn-panel" data-for="document-prefetched-signed-exchanges-for-navigation" id="infopanel-for-document-prefetched-signed-exchanges-for-navigation" role="dialog">
+   <span id="infopaneltitle-for-document-prefetched-signed-exchanges-for-navigation" style="display:none">Info about the 'prefetched signed exchanges for
+navigation' definition.</span><b><a href="#document-prefetched-signed-exchanges-for-navigation">#document-prefetched-signed-exchanges-for-navigation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-prefetched-signed-exchanges-for-navigation">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-document-prefetched-signed-exchanges-for-navigation①">3.4. Monkeypatch process a navigate fetch</a> <a href="#ref-for-document-prefetched-signed-exchanges-for-navigation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-prefetched-subresource-signed-exchanges">
-   <b><a href="#document-prefetched-subresource-signed-exchanges">#document-prefetched-subresource-signed-exchanges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-prefetched-subresource-signed-exchanges" class="dfn-panel" data-for="document-prefetched-subresource-signed-exchanges" id="infopanel-for-document-prefetched-subresource-signed-exchanges" role="dialog">
+   <span id="infopaneltitle-for-document-prefetched-subresource-signed-exchanges" style="display:none">Info about the 'prefetched
+subresource signed exchanges' definition.</span><b><a href="#document-prefetched-subresource-signed-exchanges">#document-prefetched-subresource-signed-exchanges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-prefetched-subresource-signed-exchanges">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-document-prefetched-subresource-signed-exchanges①">3.4. Monkeypatch process a navigate fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigation-params-prefetched-subresource-signed-exchanges">
-   <b><a href="#navigation-params-prefetched-subresource-signed-exchanges">#navigation-params-prefetched-subresource-signed-exchanges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigation-params-prefetched-subresource-signed-exchanges" class="dfn-panel" data-for="navigation-params-prefetched-subresource-signed-exchanges" id="infopanel-for-navigation-params-prefetched-subresource-signed-exchanges" role="dialog">
+   <span id="infopaneltitle-for-navigation-params-prefetched-subresource-signed-exchanges" style="display:none">Info about the 'prefetched subresource signed exchanges' definition.</span><b><a href="#navigation-params-prefetched-subresource-signed-exchanges">#navigation-params-prefetched-subresource-signed-exchanges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-params-prefetched-subresource-signed-exchanges">3.4. Monkeypatch process a navigate fetch</a>
     <li><a href="#ref-for-navigation-params-prefetched-subresource-signed-exchanges①">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-navigation-params-prefetched-subresource-signed-exchanges②">(2)</a> <a href="#ref-for-navigation-params-prefetched-subresource-signed-exchanges③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange">
-   <b><a href="#exchange">#exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange" class="dfn-panel" data-for="exchange" id="infopanel-for-exchange" role="dialog">
+   <span id="infopaneltitle-for-exchange" style="display:none">Info about the '4.1. Exchange' definition.</span><b><a href="#exchange">#exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange">2.1. A request’s stashed exchange</a>
     <li><a href="#ref-for-exchange①">2.5. Monkeypatch HTTP fetch</a>
@@ -4366,8 +4370,8 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-exchange①⑤">5.11. Parsing b3 CBOR headers</a> <a href="#ref-for-exchange①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-request-url">
-   <b><a href="#exchange-request-url">#exchange-request-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-request-url" class="dfn-panel" data-for="exchange-request-url" id="infopanel-for-exchange-request-url" role="dialog">
+   <span id="infopaneltitle-for-exchange-request-url" style="display:none">Info about the 'request URL' definition.</span><b><a href="#exchange-request-url">#exchange-request-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-request-url">2.2. Request clone</a> <a href="#ref-for-exchange-request-url①">(2)</a>
     <li><a href="#ref-for-exchange-request-url②">2.5. Monkeypatch HTTP fetch</a>
@@ -4377,8 +4381,8 @@ Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-exchange-request-url⑥">5.13. Request matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-response">
-   <b><a href="#exchange-response">#exchange-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-response" class="dfn-panel" data-for="exchange-response" id="infopanel-for-exchange-response" role="dialog">
+   <span id="infopaneltitle-for-exchange-response" style="display:none">Info about the 'response' definition.</span><b><a href="#exchange-response">#exchange-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-response">2.2. Request clone</a> <a href="#ref-for-exchange-response①">(2)</a>
     <li><a href="#ref-for-exchange-response②">2.3. New response fields</a>
@@ -4392,8 +4396,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-exchange-response①⑨">5.13. Request matching</a> <a href="#ref-for-exchange-response②⓪">(2)</a> <a href="#ref-for-exchange-response②①">(3)</a> <a href="#ref-for-exchange-response②②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer">
-   <b><a href="#read-buffer">#read-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer" class="dfn-panel" data-for="read-buffer" id="infopanel-for-read-buffer" role="dialog">
+   <span id="infopaneltitle-for-read-buffer" style="display:none">Info about the '4.2. Read buffer' definition.</span><b><a href="#read-buffer">#read-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer">4.2. Read buffer</a>
     <li><a href="#ref-for-read-buffer">5.4. Parsing the invariant prefix</a>
@@ -4404,8 +4408,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-read-buffer⑤">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-stream">
-   <b><a href="#read-buffer-stream">#read-buffer-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-stream" class="dfn-panel" data-for="read-buffer-stream" id="infopanel-for-read-buffer-stream" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-stream" style="display:none">Info about the 'stream' definition.</span><b><a href="#read-buffer-stream">#read-buffer-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-stream">4.2. Read buffer</a> <a href="#ref-for-read-buffer-stream①">(2)</a>
     <li><a href="#ref-for-read-buffer-stream②">5.12. Creating the response stream.</a>
@@ -4413,69 +4417,70 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-read-buffer-stream④">5.17.4. Dump to another stream</a> <a href="#ref-for-read-buffer-stream⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-reader">
-   <b><a href="#read-buffer-reader">#read-buffer-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-reader" class="dfn-panel" data-for="read-buffer-reader" id="infopanel-for-read-buffer-reader" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-reader" style="display:none">Info about the 'reader' definition.</span><b><a href="#read-buffer-reader">#read-buffer-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-reader">5.17.1. Create a read buffer</a>
     <li><a href="#ref-for-read-buffer-reader①">5.17.2. Read up to bytes</a>
     <li><a href="#ref-for-read-buffer-reader②">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-bytes">
-   <b><a href="#read-buffer-bytes">#read-buffer-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-bytes" class="dfn-panel" data-for="read-buffer-bytes" id="infopanel-for-read-buffer-bytes" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-bytes" style="display:none">Info about the 'bytes' definition.</span><b><a href="#read-buffer-bytes">#read-buffer-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-bytes">5.17.1. Create a read buffer</a>
     <li><a href="#ref-for-read-buffer-bytes①">5.17.2. Read up to bytes</a> <a href="#ref-for-read-buffer-bytes②">(2)</a> <a href="#ref-for-read-buffer-bytes③">(3)</a> <a href="#ref-for-read-buffer-bytes④">(4)</a> <a href="#ref-for-read-buffer-bytes⑤">(5)</a> <a href="#ref-for-read-buffer-bytes⑥">(6)</a>
     <li><a href="#ref-for-read-buffer-bytes⑦">5.17.4. Dump to another stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-certificate">
-   <b><a href="#augmented-certificate">#augmented-certificate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-certificate" class="dfn-panel" data-for="augmented-certificate" id="infopanel-for-augmented-certificate" role="dialog">
+   <span id="infopaneltitle-for-augmented-certificate" style="display:none">Info about the '4.3. Augmented Certificate' definition.</span><b><a href="#augmented-certificate">#augmented-certificate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-certificate">4.3. Augmented Certificate</a> <a href="#ref-for-augmented-certificate">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-certificate-certificate">
-   <b><a href="#augmented-certificate-certificate">#augmented-certificate-certificate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-certificate-certificate" class="dfn-panel" data-for="augmented-certificate-certificate" id="infopanel-for-augmented-certificate-certificate" role="dialog">
+   <span id="infopaneltitle-for-augmented-certificate-certificate" style="display:none">Info about the 'certificate' definition.</span><b><a href="#augmented-certificate-certificate">#augmented-certificate-certificate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-certificate-certificate">4.3. Augmented Certificate</a> <a href="#ref-for-augmented-certificate-certificate①">(2)</a> <a href="#ref-for-augmented-certificate-certificate②">(3)</a> <a href="#ref-for-augmented-certificate-certificate③">(4)</a>
     <li><a href="#ref-for-augmented-certificate-certificate④">5.5.1. Handling the certificate reference</a>
     <li><a href="#ref-for-augmented-certificate-certificate⑤">5.9. Establishing trust in a certificate</a> <a href="#ref-for-augmented-certificate-certificate⑥">(2)</a> <a href="#ref-for-augmented-certificate-certificate⑦">(3)</a> <a href="#ref-for-augmented-certificate-certificate⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-certificate-ocsp-response">
-   <b><a href="#augmented-certificate-ocsp-response">#augmented-certificate-ocsp-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-certificate-ocsp-response" class="dfn-panel" data-for="augmented-certificate-ocsp-response" id="infopanel-for-augmented-certificate-ocsp-response" role="dialog">
+   <span id="infopaneltitle-for-augmented-certificate-ocsp-response" style="display:none">Info about the 'OCSP response' definition.</span><b><a href="#augmented-certificate-ocsp-response">#augmented-certificate-ocsp-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-certificate-ocsp-response">5.9. Establishing trust in a certificate</a> <a href="#ref-for-augmented-certificate-ocsp-response①">(2)</a> <a href="#ref-for-augmented-certificate-ocsp-response②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-certificate-sct">
-   <b><a href="#augmented-certificate-sct">#augmented-certificate-sct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-certificate-sct" class="dfn-panel" data-for="augmented-certificate-sct" id="infopanel-for-augmented-certificate-sct" role="dialog">
+   <span id="infopaneltitle-for-augmented-certificate-sct" style="display:none">Info about the 'SCT' definition.</span><b><a href="#augmented-certificate-sct">#augmented-certificate-sct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-certificate-sct">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="certificate-public-key">
-   <b><a href="#certificate-public-key">#certificate-public-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-certificate-public-key" class="dfn-panel" data-for="certificate-public-key" id="infopanel-for-certificate-public-key" role="dialog">
+   <span id="infopaneltitle-for-certificate-public-key" style="display:none">Info about the 'public
+key' definition.</span><b><a href="#certificate-public-key">#certificate-public-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-certificate-public-key">4.5. Exchange Signature</a>
     <li><a href="#ref-for-certificate-public-key①">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-algorithm">
-   <b><a href="#public-key-algorithm">#public-key-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-algorithm" class="dfn-panel" data-for="public-key-algorithm" id="infopanel-for-public-key-algorithm" role="dialog">
+   <span id="infopaneltitle-for-public-key-algorithm" style="display:none">Info about the 'algorithm' definition.</span><b><a href="#public-key-algorithm">#public-key-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-algorithm">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="certificate-extensions">
-   <b><a href="#certificate-extensions">#certificate-extensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-certificate-extensions" class="dfn-panel" data-for="certificate-extensions" id="infopanel-for-certificate-extensions" role="dialog">
+   <span id="infopaneltitle-for-certificate-extensions" style="display:none">Info about the 'extensions' definition.</span><b><a href="#certificate-extensions">#certificate-extensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-certificate-extensions">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="certificate-chain">
-   <b><a href="#certificate-chain">#certificate-chain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-certificate-chain" class="dfn-panel" data-for="certificate-chain" id="infopanel-for-certificate-chain" role="dialog">
+   <span id="infopaneltitle-for-certificate-chain" style="display:none">Info about the 'certificate chain' definition.</span><b><a href="#certificate-chain">#certificate-chain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-certificate-chain">4.5. Exchange Signature</a>
     <li><a href="#ref-for-certificate-chain①">5.5. Parsing a Signature Header Field</a>
@@ -4483,8 +4488,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-certificate-chain④">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="certificate-chain-leaf">
-   <b><a href="#certificate-chain-leaf">#certificate-chain-leaf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-certificate-chain-leaf" class="dfn-panel" data-for="certificate-chain-leaf" id="infopanel-for-certificate-chain-leaf" role="dialog">
+   <span id="infopaneltitle-for-certificate-chain-leaf" style="display:none">Info about the 'leaf' definition.</span><b><a href="#certificate-chain-leaf">#certificate-chain-leaf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-certificate-chain-leaf">4.5. Exchange Signature</a> <a href="#ref-for-certificate-chain-leaf①">(2)</a> <a href="#ref-for-certificate-chain-leaf②">(3)</a>
     <li><a href="#ref-for-certificate-chain-leaf③">5.5.1. Handling the certificate reference</a>
@@ -4492,8 +4497,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-certificate-chain-leaf⑤">5.9. Establishing trust in a certificate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report">
-   <b><a href="#signed-exchange-report">#signed-exchange-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report" class="dfn-panel" data-for="signed-exchange-report" id="infopanel-for-signed-exchange-report" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report" style="display:none">Info about the '4.4. Signed Exchange report' definition.</span><b><a href="#signed-exchange-report">#signed-exchange-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report">4.4. Signed Exchange report</a>
     <li><a href="#ref-for-signed-exchange-report">5.3. Parsing signed exchanges</a>
@@ -4502,8 +4507,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-signed-exchange-report③">5.14. Create a new signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-result">
-   <b><a href="#signed-exchange-report-result">#signed-exchange-report-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-result" class="dfn-panel" data-for="signed-exchange-report-result" id="infopanel-for-signed-exchange-report-result" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-result" style="display:none">Info about the 'result' definition.</span><b><a href="#signed-exchange-report-result">#signed-exchange-report-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-result">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-signed-exchange-report-result①">5.5. Parsing a Signature Header Field</a>
@@ -4511,111 +4516,111 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-signed-exchange-report-result③">5.16. Queuing signed exchange report</a> <a href="#ref-for-signed-exchange-report-result④">(2)</a> <a href="#ref-for-signed-exchange-report-result⑤">(3)</a> <a href="#ref-for-signed-exchange-report-result⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-ok">
-   <b><a href="#signed-exchange-report-ok">#signed-exchange-report-ok</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-ok" class="dfn-panel" data-for="signed-exchange-report-ok" id="infopanel-for-signed-exchange-report-ok" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-ok" style="display:none">Info about the 'ok' definition.</span><b><a href="#signed-exchange-report-ok">#signed-exchange-report-ok</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-ok">5.15. Wait and queue a report</a>
     <li><a href="#ref-for-signed-exchange-report-ok①">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-mi_error">
-   <b><a href="#signed-exchange-report-mi_error">#signed-exchange-report-mi_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-mi_error" class="dfn-panel" data-for="signed-exchange-report-mi_error" id="infopanel-for-signed-exchange-report-mi_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-mi_error" style="display:none">Info about the 'mi_error' definition.</span><b><a href="#signed-exchange-report-mi_error">#signed-exchange-report-mi_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-mi_error">5.15. Wait and queue a report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-non_secure_distributor">
-   <b><a href="#signed-exchange-report-non_secure_distributor">#signed-exchange-report-non_secure_distributor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-non_secure_distributor" class="dfn-panel" data-for="signed-exchange-report-non_secure_distributor" id="infopanel-for-signed-exchange-report-non_secure_distributor" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-non_secure_distributor" style="display:none">Info about the 'non_secure_distributor' definition.</span><b><a href="#signed-exchange-report-non_secure_distributor">#signed-exchange-report-non_secure_distributor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-non_secure_distributor">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-parse_error">
-   <b><a href="#signed-exchange-report-parse_error">#signed-exchange-report-parse_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-parse_error" class="dfn-panel" data-for="signed-exchange-report-parse_error" id="infopanel-for-signed-exchange-report-parse_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-parse_error" style="display:none">Info about the 'parse_error' definition.</span><b><a href="#signed-exchange-report-parse_error">#signed-exchange-report-parse_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-parse_error">5.3. Parsing signed exchanges</a> <a href="#ref-for-signed-exchange-report-parse_error①">(2)</a> <a href="#ref-for-signed-exchange-report-parse_error②">(3)</a> <a href="#ref-for-signed-exchange-report-parse_error③">(4)</a> <a href="#ref-for-signed-exchange-report-parse_error④">(5)</a> <a href="#ref-for-signed-exchange-report-parse_error⑤">(6)</a> <a href="#ref-for-signed-exchange-report-parse_error⑥">(7)</a> <a href="#ref-for-signed-exchange-report-parse_error⑦">(8)</a>
     <li><a href="#ref-for-signed-exchange-report-parse_error⑧">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-signed-exchange-report-parse_error⑨">(2)</a> <a href="#ref-for-signed-exchange-report-parse_error①⓪">(3)</a> <a href="#ref-for-signed-exchange-report-parse_error①①">(4)</a> <a href="#ref-for-signed-exchange-report-parse_error①②">(5)</a> <a href="#ref-for-signed-exchange-report-parse_error①③">(6)</a> <a href="#ref-for-signed-exchange-report-parse_error①④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-invalid_integrity_header">
-   <b><a href="#signed-exchange-report-invalid_integrity_header">#signed-exchange-report-invalid_integrity_header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-invalid_integrity_header" class="dfn-panel" data-for="signed-exchange-report-invalid_integrity_header" id="infopanel-for-signed-exchange-report-invalid_integrity_header" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-invalid_integrity_header" style="display:none">Info about the 'invalid_integrity_header' definition.</span><b><a href="#signed-exchange-report-invalid_integrity_header">#signed-exchange-report-invalid_integrity_header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-invalid_integrity_header">5.12. Creating the response stream.</a> <a href="#ref-for-signed-exchange-report-invalid_integrity_header①">(2)</a> <a href="#ref-for-signed-exchange-report-invalid_integrity_header②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-signature_verification_error">
-   <b><a href="#signed-exchange-report-signature_verification_error">#signed-exchange-report-signature_verification_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-signature_verification_error" class="dfn-panel" data-for="signed-exchange-report-signature_verification_error" id="infopanel-for-signed-exchange-report-signature_verification_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-signature_verification_error" style="display:none">Info about the 'signature_verification_error' definition.</span><b><a href="#signed-exchange-report-signature_verification_error">#signed-exchange-report-signature_verification_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-signature_verification_error">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-signed-exchange-report-signature_verification_error①">5.5.1. Handling the certificate reference</a>
     <li><a href="#ref-for-signed-exchange-report-signature_verification_error②">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-cert_verification_error">
-   <b><a href="#signed-exchange-report-cert_verification_error">#signed-exchange-report-cert_verification_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-cert_verification_error" class="dfn-panel" data-for="signed-exchange-report-cert_verification_error" id="infopanel-for-signed-exchange-report-cert_verification_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-cert_verification_error" style="display:none">Info about the 'cert_verification_error' definition.</span><b><a href="#signed-exchange-report-cert_verification_error">#signed-exchange-report-cert_verification_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-cert_verification_error">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-signed-exchange-report-cert_verification_error①">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-cert_fetch_error">
-   <b><a href="#signed-exchange-report-cert_fetch_error">#signed-exchange-report-cert_fetch_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-cert_fetch_error" class="dfn-panel" data-for="signed-exchange-report-cert_fetch_error" id="infopanel-for-signed-exchange-report-cert_fetch_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-cert_fetch_error" style="display:none">Info about the 'cert_fetch_error' definition.</span><b><a href="#signed-exchange-report-cert_fetch_error">#signed-exchange-report-cert_fetch_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-cert_fetch_error">5.5.1. Handling the certificate reference</a> <a href="#ref-for-signed-exchange-report-cert_fetch_error①">(2)</a>
     <li><a href="#ref-for-signed-exchange-report-cert_fetch_error②">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-cert_parse_error">
-   <b><a href="#signed-exchange-report-cert_parse_error">#signed-exchange-report-cert_parse_error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-cert_parse_error" class="dfn-panel" data-for="signed-exchange-report-cert_parse_error" id="infopanel-for-signed-exchange-report-cert_parse_error" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-cert_parse_error" style="display:none">Info about the 'cert_parse_error' definition.</span><b><a href="#signed-exchange-report-cert_parse_error">#signed-exchange-report-cert_parse_error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-cert_parse_error">5.5.1. Handling the certificate reference</a> <a href="#ref-for-signed-exchange-report-cert_parse_error①">(2)</a> <a href="#ref-for-signed-exchange-report-cert_parse_error②">(3)</a>
     <li><a href="#ref-for-signed-exchange-report-cert_parse_error③">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-outer-request">
-   <b><a href="#signed-exchange-report-outer-request">#signed-exchange-report-outer-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-outer-request" class="dfn-panel" data-for="signed-exchange-report-outer-request" id="infopanel-for-signed-exchange-report-outer-request" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-outer-request" style="display:none">Info about the 'outer request' definition.</span><b><a href="#signed-exchange-report-outer-request">#signed-exchange-report-outer-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-outer-request">5.14. Create a new signed exchange report</a>
     <li><a href="#ref-for-signed-exchange-report-outer-request①">5.16. Queuing signed exchange report</a> <a href="#ref-for-signed-exchange-report-outer-request②">(2)</a> <a href="#ref-for-signed-exchange-report-outer-request③">(3)</a> <a href="#ref-for-signed-exchange-report-outer-request④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-outer-response">
-   <b><a href="#signed-exchange-report-outer-response">#signed-exchange-report-outer-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-outer-response" class="dfn-panel" data-for="signed-exchange-report-outer-response" id="infopanel-for-signed-exchange-report-outer-response" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-outer-response" style="display:none">Info about the 'outer response' definition.</span><b><a href="#signed-exchange-report-outer-response">#signed-exchange-report-outer-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-outer-response">5.14. Create a new signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-inner-url">
-   <b><a href="#signed-exchange-report-inner-url">#signed-exchange-report-inner-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-inner-url" class="dfn-panel" data-for="signed-exchange-report-inner-url" id="infopanel-for-signed-exchange-report-inner-url" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-inner-url" style="display:none">Info about the 'inner URL' definition.</span><b><a href="#signed-exchange-report-inner-url">#signed-exchange-report-inner-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-inner-url">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-signed-exchange-report-inner-url①">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-cert-url-list">
-   <b><a href="#signed-exchange-report-cert-url-list">#signed-exchange-report-cert-url-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-cert-url-list" class="dfn-panel" data-for="signed-exchange-report-cert-url-list" id="infopanel-for-signed-exchange-report-cert-url-list" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-cert-url-list" style="display:none">Info about the 'cert URL list' definition.</span><b><a href="#signed-exchange-report-cert-url-list">#signed-exchange-report-cert-url-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-cert-url-list">4.4. Signed Exchange report</a>
     <li><a href="#ref-for-signed-exchange-report-cert-url-list①">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-signed-exchange-report-cert-url-list②">5.16. Queuing signed exchange report</a> <a href="#ref-for-signed-exchange-report-cert-url-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-server-ip">
-   <b><a href="#signed-exchange-report-server-ip">#signed-exchange-report-server-ip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-server-ip" class="dfn-panel" data-for="signed-exchange-report-server-ip" id="infopanel-for-signed-exchange-report-server-ip" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-server-ip" style="display:none">Info about the 'server IP' definition.</span><b><a href="#signed-exchange-report-server-ip">#signed-exchange-report-server-ip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-server-ip">5.14. Create a new signed exchange report</a>
     <li><a href="#ref-for-signed-exchange-report-server-ip①">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-report-cert-server-ip-list">
-   <b><a href="#signed-exchange-report-cert-server-ip-list">#signed-exchange-report-cert-server-ip-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-report-cert-server-ip-list" class="dfn-panel" data-for="signed-exchange-report-cert-server-ip-list" id="infopanel-for-signed-exchange-report-cert-server-ip-list" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-report-cert-server-ip-list" style="display:none">Info about the 'cert server IP list' definition.</span><b><a href="#signed-exchange-report-cert-server-ip-list">#signed-exchange-report-cert-server-ip-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-report-cert-server-ip-list">5.5.1. Handling the certificate reference</a>
     <li><a href="#ref-for-signed-exchange-report-cert-server-ip-list①">5.16. Queuing signed exchange report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature">
-   <b><a href="#exchange-signature">#exchange-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature" class="dfn-panel" data-for="exchange-signature" id="infopanel-for-exchange-signature" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature" style="display:none">Info about the '4.5. Exchange Signature' definition.</span><b><a href="#exchange-signature">#exchange-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature">4.5. Exchange Signature</a>
     <li><a href="#ref-for-exchange-signature">5.3. Parsing signed exchanges</a>
@@ -4626,16 +4631,16 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-exchange-signature⑥">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-signature">
-   <b><a href="#exchange-signature-signature">#exchange-signature-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-signature" class="dfn-panel" data-for="exchange-signature-signature" id="infopanel-for-exchange-signature-signature" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-signature" style="display:none">Info about the 'signature' definition.</span><b><a href="#exchange-signature-signature">#exchange-signature-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-signature">4.5. Exchange Signature</a>
     <li><a href="#ref-for-exchange-signature-signature①">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-exchange-signature-signature②">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-certificate-chain">
-   <b><a href="#exchange-signature-certificate-chain">#exchange-signature-certificate-chain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-certificate-chain" class="dfn-panel" data-for="exchange-signature-certificate-chain" id="infopanel-for-exchange-signature-certificate-chain" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-certificate-chain" style="display:none">Info about the 'certificate chain' definition.</span><b><a href="#exchange-signature-certificate-chain">#exchange-signature-certificate-chain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-certificate-chain">4.5. Exchange Signature</a>
     <li><a href="#ref-for-exchange-signature-certificate-chain①">5.5. Parsing a Signature Header Field</a>
@@ -4643,37 +4648,37 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-exchange-signature-certificate-chain③">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-certsha256">
-   <b><a href="#exchange-signature-certsha256">#exchange-signature-certsha256</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-certsha256" class="dfn-panel" data-for="exchange-signature-certsha256" id="infopanel-for-exchange-signature-certsha256" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-certsha256" style="display:none">Info about the 'certSha256' definition.</span><b><a href="#exchange-signature-certsha256">#exchange-signature-certsha256</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-certsha256">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-exchange-signature-certsha256①">(2)</a>
     <li><a href="#ref-for-exchange-signature-certsha256②">5.6. The signed message</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-integrity-header">
-   <b><a href="#exchange-signature-integrity-header">#exchange-signature-integrity-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-integrity-header" class="dfn-panel" data-for="exchange-signature-integrity-header" id="infopanel-for-exchange-signature-integrity-header" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-integrity-header" style="display:none">Info about the 'integrity header' definition.</span><b><a href="#exchange-signature-integrity-header">#exchange-signature-integrity-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-integrity-header">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-exchange-signature-integrity-header①">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-validityurl">
-   <b><a href="#exchange-signature-validityurl">#exchange-signature-validityurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-validityurl" class="dfn-panel" data-for="exchange-signature-validityurl" id="infopanel-for-exchange-signature-validityurl" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-validityurl" style="display:none">Info about the 'validityUrl' definition.</span><b><a href="#exchange-signature-validityurl">#exchange-signature-validityurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-validityurl">4.5. Exchange Signature</a>
     <li><a href="#ref-for-exchange-signature-validityurl①">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-exchange-signature-validityurl②">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-validityurlbytes">
-   <b><a href="#exchange-signature-validityurlbytes">#exchange-signature-validityurlbytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-validityurlbytes" class="dfn-panel" data-for="exchange-signature-validityurlbytes" id="infopanel-for-exchange-signature-validityurlbytes" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-validityurlbytes" style="display:none">Info about the 'validityUrlBytes' definition.</span><b><a href="#exchange-signature-validityurlbytes">#exchange-signature-validityurlbytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-validityurlbytes">5.5. Parsing a Signature Header Field</a>
     <li><a href="#ref-for-exchange-signature-validityurlbytes①">5.6. The signed message</a> <a href="#ref-for-exchange-signature-validityurlbytes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-date">
-   <b><a href="#exchange-signature-date">#exchange-signature-date</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-date" class="dfn-panel" data-for="exchange-signature-date" id="infopanel-for-exchange-signature-date" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-date" style="display:none">Info about the 'date' definition.</span><b><a href="#exchange-signature-date">#exchange-signature-date</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-date">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-exchange-signature-date①">(2)</a> <a href="#ref-for-exchange-signature-date②">(3)</a>
     <li><a href="#ref-for-exchange-signature-date③">5.6. The signed message</a>
@@ -4681,8 +4686,8 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-exchange-signature-date⑥">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-expiration-time">
-   <b><a href="#exchange-signature-expiration-time">#exchange-signature-expiration-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-expiration-time" class="dfn-panel" data-for="exchange-signature-expiration-time" id="infopanel-for-exchange-signature-expiration-time" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-expiration-time" style="display:none">Info about the 'expiration time' definition.</span><b><a href="#exchange-signature-expiration-time">#exchange-signature-expiration-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-expiration-time">1.2. Other interesting details</a>
     <li><a href="#ref-for-exchange-signature-expiration-time①">5.5. Parsing a Signature Header Field</a> <a href="#ref-for-exchange-signature-expiration-time②">(2)</a> <a href="#ref-for-exchange-signature-expiration-time③">(3)</a>
@@ -4691,46 +4696,46 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-exch
     <li><a href="#ref-for-exchange-signature-expiration-time⑦">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-signed-exchange-link-info">
-   <b><a href="#allowed-signed-exchange-link-info">#allowed-signed-exchange-link-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-signed-exchange-link-info" class="dfn-panel" data-for="allowed-signed-exchange-link-info" id="infopanel-for-allowed-signed-exchange-link-info" role="dialog">
+   <span id="infopaneltitle-for-allowed-signed-exchange-link-info" style="display:none">Info about the '4.6. Allowed signed exchange link info' definition.</span><b><a href="#allowed-signed-exchange-link-info">#allowed-signed-exchange-link-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-signed-exchange-link-info">4.6. Allowed signed exchange link info</a>
     <li><a href="#ref-for-allowed-signed-exchange-link-info">5.19. Get allowed signed exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-signed-exchange-link-info-target">
-   <b><a href="#allowed-signed-exchange-link-info-target">#allowed-signed-exchange-link-info-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-signed-exchange-link-info-target" class="dfn-panel" data-for="allowed-signed-exchange-link-info-target" id="infopanel-for-allowed-signed-exchange-link-info-target" role="dialog">
+   <span id="infopaneltitle-for-allowed-signed-exchange-link-info-target" style="display:none">Info about the 'target' definition.</span><b><a href="#allowed-signed-exchange-link-info-target">#allowed-signed-exchange-link-info-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-target">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-target①">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-allowed-signed-exchange-link-info-target②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-signed-exchange-link-info-header-integrity">
-   <b><a href="#allowed-signed-exchange-link-info-header-integrity">#allowed-signed-exchange-link-info-header-integrity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-signed-exchange-link-info-header-integrity" class="dfn-panel" data-for="allowed-signed-exchange-link-info-header-integrity" id="infopanel-for-allowed-signed-exchange-link-info-header-integrity" role="dialog">
+   <span id="infopaneltitle-for-allowed-signed-exchange-link-info-header-integrity" style="display:none">Info about the 'header integrity' definition.</span><b><a href="#allowed-signed-exchange-link-info-header-integrity">#allowed-signed-exchange-link-info-header-integrity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-header-integrity">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-signed-exchange-link-info-variants">
-   <b><a href="#allowed-signed-exchange-link-info-variants">#allowed-signed-exchange-link-info-variants</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-signed-exchange-link-info-variants" class="dfn-panel" data-for="allowed-signed-exchange-link-info-variants" id="infopanel-for-allowed-signed-exchange-link-info-variants" role="dialog">
+   <span id="infopaneltitle-for-allowed-signed-exchange-link-info-variants" style="display:none">Info about the 'variants' definition.</span><b><a href="#allowed-signed-exchange-link-info-variants">#allowed-signed-exchange-link-info-variants</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-variants">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-allowed-signed-exchange-link-info-variants①">(2)</a> <a href="#ref-for-allowed-signed-exchange-link-info-variants②">(3)</a>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-variants③">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-allowed-signed-exchange-link-info-variants④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-signed-exchange-link-info-variant-key">
-   <b><a href="#allowed-signed-exchange-link-info-variant-key">#allowed-signed-exchange-link-info-variant-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-signed-exchange-link-info-variant-key" class="dfn-panel" data-for="allowed-signed-exchange-link-info-variant-key" id="infopanel-for-allowed-signed-exchange-link-info-variant-key" role="dialog">
+   <span id="infopaneltitle-for-allowed-signed-exchange-link-info-variant-key" style="display:none">Info about the 'variant key' definition.</span><b><a href="#allowed-signed-exchange-link-info-variant-key">#allowed-signed-exchange-link-info-variant-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-variant-key">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-allowed-signed-exchange-link-info-variant-key①">(2)</a> <a href="#ref-for-allowed-signed-exchange-link-info-variant-key②">(3)</a>
     <li><a href="#ref-for-allowed-signed-exchange-link-info-variant-key③">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-allowed-signed-exchange-link-info-variant-key④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link-info">
-   <b><a href="#alternate-signed-exchange-link-info">#alternate-signed-exchange-link-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link-info" class="dfn-panel" data-for="alternate-signed-exchange-link-info" id="infopanel-for-alternate-signed-exchange-link-info" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link-info" style="display:none">Info about the '4.7. Alternate signed exchange link info' definition.</span><b><a href="#alternate-signed-exchange-link-info">#alternate-signed-exchange-link-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link-info">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-alternate-signed-exchange-link-info">4.7. Alternate signed exchange link info</a>
@@ -4738,152 +4743,152 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-allo
 exchange link info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link-info-target">
-   <b><a href="#alternate-signed-exchange-link-info-target">#alternate-signed-exchange-link-info-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link-info-target" class="dfn-panel" data-for="alternate-signed-exchange-link-info-target" id="infopanel-for-alternate-signed-exchange-link-info-target" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link-info-target" style="display:none">Info about the 'target' definition.</span><b><a href="#alternate-signed-exchange-link-info-target">#alternate-signed-exchange-link-info-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link-info-target">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link-info-context">
-   <b><a href="#alternate-signed-exchange-link-info-context">#alternate-signed-exchange-link-info-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link-info-context" class="dfn-panel" data-for="alternate-signed-exchange-link-info-context" id="infopanel-for-alternate-signed-exchange-link-info-context" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link-info-context" style="display:none">Info about the 'context' definition.</span><b><a href="#alternate-signed-exchange-link-info-context">#alternate-signed-exchange-link-info-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link-info-context">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link-info-variants">
-   <b><a href="#alternate-signed-exchange-link-info-variants">#alternate-signed-exchange-link-info-variants</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link-info-variants" class="dfn-panel" data-for="alternate-signed-exchange-link-info-variants" id="infopanel-for-alternate-signed-exchange-link-info-variants" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link-info-variants" style="display:none">Info about the 'variants' definition.</span><b><a href="#alternate-signed-exchange-link-info-variants">#alternate-signed-exchange-link-info-variants</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link-info-variants">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-link-info-variant-key">
-   <b><a href="#alternate-signed-exchange-link-info-variant-key">#alternate-signed-exchange-link-info-variant-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-link-info-variant-key" class="dfn-panel" data-for="alternate-signed-exchange-link-info-variant-key" id="infopanel-for-alternate-signed-exchange-link-info-variant-key" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-link-info-variant-key" style="display:none">Info about the 'variant key' definition.</span><b><a href="#alternate-signed-exchange-link-info-variant-key">#alternate-signed-exchange-link-info-variant-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-link-info-variant-key">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-preload-info">
-   <b><a href="#alternate-signed-exchange-preload-info">#alternate-signed-exchange-preload-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-preload-info" class="dfn-panel" data-for="alternate-signed-exchange-preload-info" id="infopanel-for-alternate-signed-exchange-preload-info" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-preload-info" style="display:none">Info about the '4.8. Alternate signed exchange preload info' definition.</span><b><a href="#alternate-signed-exchange-preload-info">#alternate-signed-exchange-preload-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-preload-info-link">
-   <b><a href="#alternate-signed-exchange-preload-info-link">#alternate-signed-exchange-preload-info-link</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-preload-info-link" class="dfn-panel" data-for="alternate-signed-exchange-preload-info-link" id="infopanel-for-alternate-signed-exchange-preload-info-link" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-preload-info-link" style="display:none">Info about the 'link' definition.</span><b><a href="#alternate-signed-exchange-preload-info-link">#alternate-signed-exchange-preload-info-link</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info-link">3.5. 
 Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-alternate-signed-exchange-preload-info-link①">(2)</a> <a href="#ref-for-alternate-signed-exchange-preload-info-link②">(3)</a> <a href="#ref-for-alternate-signed-exchange-preload-info-link③">(4)</a> <a href="#ref-for-alternate-signed-exchange-preload-info-link④">(5)</a>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info-link⑤">4.8. Alternate signed exchange preload info</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-preload-info-target">
-   <b><a href="#alternate-signed-exchange-preload-info-target">#alternate-signed-exchange-preload-info-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-preload-info-target" class="dfn-panel" data-for="alternate-signed-exchange-preload-info-target" id="infopanel-for-alternate-signed-exchange-preload-info-target" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-preload-info-target" style="display:none">Info about the 'target' definition.</span><b><a href="#alternate-signed-exchange-preload-info-target">#alternate-signed-exchange-preload-info-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info-target">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alternate-signed-exchange-preload-info-prefetched-alternate-exchange">
-   <b><a href="#alternate-signed-exchange-preload-info-prefetched-alternate-exchange">#alternate-signed-exchange-preload-info-prefetched-alternate-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alternate-signed-exchange-preload-info-prefetched-alternate-exchange" class="dfn-panel" data-for="alternate-signed-exchange-preload-info-prefetched-alternate-exchange" id="infopanel-for-alternate-signed-exchange-preload-info-prefetched-alternate-exchange" role="dialog">
+   <span id="infopaneltitle-for-alternate-signed-exchange-preload-info-prefetched-alternate-exchange" style="display:none">Info about the 'prefetched alternate exchange' definition.</span><b><a href="#alternate-signed-exchange-preload-info-prefetched-alternate-exchange">#alternate-signed-exchange-preload-info-prefetched-alternate-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alternate-signed-exchange-preload-info-prefetched-alternate-exchange">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-exchange-version">
-   <b><a href="#signed-exchange-version">#signed-exchange-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-exchange-version" class="dfn-panel" data-for="signed-exchange-version" id="infopanel-for-signed-exchange-version" role="dialog">
+   <span id="infopaneltitle-for-signed-exchange-version" style="display:none">Info about the 'signed exchange version' definition.</span><b><a href="#signed-exchange-version">#signed-exchange-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-exchange-version">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-signed-exchange-version①">5.2. Extracting the fallback URL</a>
     <li><a href="#ref-for-signed-exchange-version②">5.3. Parsing signed exchanges</a> <a href="#ref-for-signed-exchange-version③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extracting-the-fallback-url">
-   <b><a href="#extracting-the-fallback-url">#extracting-the-fallback-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extracting-the-fallback-url" class="dfn-panel" data-for="extracting-the-fallback-url" id="infopanel-for-extracting-the-fallback-url" role="dialog">
+   <span id="infopaneltitle-for-extracting-the-fallback-url" style="display:none">Info about the 'Extracting the fallback URL' definition.</span><b><a href="#extracting-the-fallback-url">#extracting-the-fallback-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extracting-the-fallback-url">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-extracting-the-fallback-url①">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-a-signed-exchange">
-   <b><a href="#parsing-a-signed-exchange">#parsing-a-signed-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-a-signed-exchange" class="dfn-panel" data-for="parsing-a-signed-exchange" id="infopanel-for-parsing-a-signed-exchange" role="dialog">
+   <span id="infopaneltitle-for-parsing-a-signed-exchange" style="display:none">Info about the 'Parsing a signed exchange' definition.</span><b><a href="#parsing-a-signed-exchange">#parsing-a-signed-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-a-signed-exchange">2.5. Monkeypatch HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-the-invariant-prefix">
-   <b><a href="#parsing-the-invariant-prefix">#parsing-the-invariant-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-the-invariant-prefix" class="dfn-panel" data-for="parsing-the-invariant-prefix" id="infopanel-for-parsing-the-invariant-prefix" role="dialog">
+   <span id="infopaneltitle-for-parsing-the-invariant-prefix" style="display:none">Info about the 'Parsing the invariant prefix' definition.</span><b><a href="#parsing-the-invariant-prefix">#parsing-the-invariant-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-the-invariant-prefix">5.2. Extracting the fallback URL</a>
     <li><a href="#ref-for-parsing-the-invariant-prefix①">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-the-signature-header-field">
-   <b><a href="#parsing-the-signature-header-field">#parsing-the-signature-header-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-the-signature-header-field" class="dfn-panel" data-for="parsing-the-signature-header-field" id="infopanel-for-parsing-the-signature-header-field" role="dialog">
+   <span id="infopaneltitle-for-parsing-the-signature-header-field" style="display:none">Info about the 'Parsing the Signature header field' definition.</span><b><a href="#parsing-the-signature-header-field">#parsing-the-signature-header-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-the-signature-header-field">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handling-the-certificate-reference">
-   <b><a href="#handling-the-certificate-reference">#handling-the-certificate-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handling-the-certificate-reference" class="dfn-panel" data-for="handling-the-certificate-reference" id="infopanel-for-handling-the-certificate-reference" role="dialog">
+   <span id="infopaneltitle-for-handling-the-certificate-reference" style="display:none">Info about the 'Handling the certificate reference' definition.</span><b><a href="#handling-the-certificate-reference">#handling-the-certificate-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handling-the-certificate-reference">5.5. Parsing a Signature Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signed-message">
-   <b><a href="#signed-message">#signed-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signed-message" class="dfn-panel" data-for="signed-message" id="infopanel-for-signed-message" role="dialog">
+   <span id="infopaneltitle-for-signed-message" style="display:none">Info about the 'signed message' definition.</span><b><a href="#signed-message">#signed-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signed-message">5.7. Validating a signature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-is-valid">
-   <b><a href="#exchange-signature-is-valid">#exchange-signature-is-valid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-is-valid" class="dfn-panel" data-for="exchange-signature-is-valid" id="infopanel-for-exchange-signature-is-valid" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-is-valid" style="display:none">Info about the 'is valid' definition.</span><b><a href="#exchange-signature-is-valid">#exchange-signature-is-valid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-is-valid">5.3. Parsing signed exchanges</a>
     <li><a href="#ref-for-exchange-signature-is-valid①">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-signature-establishes-cross-origin-trust">
-   <b><a href="#exchange-signature-establishes-cross-origin-trust">#exchange-signature-establishes-cross-origin-trust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-signature-establishes-cross-origin-trust" class="dfn-panel" data-for="exchange-signature-establishes-cross-origin-trust" id="infopanel-for-exchange-signature-establishes-cross-origin-trust" role="dialog">
+   <span id="infopaneltitle-for-exchange-signature-establishes-cross-origin-trust" style="display:none">Info about the 'establishes cross-origin trust' definition.</span><b><a href="#exchange-signature-establishes-cross-origin-trust">#exchange-signature-establishes-cross-origin-trust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-signature-establishes-cross-origin-trust">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="certificate-chain-has-a-trusted-leaf">
-   <b><a href="#certificate-chain-has-a-trusted-leaf">#certificate-chain-has-a-trusted-leaf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-certificate-chain-has-a-trusted-leaf" class="dfn-panel" data-for="certificate-chain-has-a-trusted-leaf" id="infopanel-for-certificate-chain-has-a-trusted-leaf" role="dialog">
+   <span id="infopaneltitle-for-certificate-chain-has-a-trusted-leaf" style="display:none">Info about the 'has a trusted leaf' definition.</span><b><a href="#certificate-chain-has-a-trusted-leaf">#certificate-chain-has-a-trusted-leaf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-certificate-chain-has-a-trusted-leaf">5.8. Cross-origin trust</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-b2-cbor-headers">
-   <b><a href="#parsing-b2-cbor-headers">#parsing-b2-cbor-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-b2-cbor-headers" class="dfn-panel" data-for="parsing-b2-cbor-headers" id="infopanel-for-parsing-b2-cbor-headers" role="dialog">
+   <span id="infopaneltitle-for-parsing-b2-cbor-headers" style="display:none">Info about the 'Parsing b2 CBOR headers' definition.</span><b><a href="#parsing-b2-cbor-headers">#parsing-b2-cbor-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-b2-cbor-headers">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-b3-cbor-headers">
-   <b><a href="#parsing-b3-cbor-headers">#parsing-b3-cbor-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-b3-cbor-headers" class="dfn-panel" data-for="parsing-b3-cbor-headers" id="infopanel-for-parsing-b3-cbor-headers" role="dialog">
+   <span id="infopaneltitle-for-parsing-b3-cbor-headers" style="display:none">Info about the 'Parsing b3 CBOR headers' definition.</span><b><a href="#parsing-b3-cbor-headers">#parsing-b3-cbor-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-b3-cbor-headers">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="creating-a-header-list-from-the-cbor-map">
-   <b><a href="#creating-a-header-list-from-the-cbor-map">#creating-a-header-list-from-the-cbor-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-creating-a-header-list-from-the-cbor-map" class="dfn-panel" data-for="creating-a-header-list-from-the-cbor-map" id="infopanel-for-creating-a-header-list-from-the-cbor-map" role="dialog">
+   <span id="infopaneltitle-for-creating-a-header-list-from-the-cbor-map" style="display:none">Info about the 'creating a header list from the CBOR map' definition.</span><b><a href="#creating-a-header-list-from-the-cbor-map">#creating-a-header-list-from-the-cbor-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creating-a-header-list-from-the-cbor-map">5.10. Parsing b2 CBOR headers</a> <a href="#ref-for-creating-a-header-list-from-the-cbor-map①">(2)</a>
     <li><a href="#ref-for-creating-a-header-list-from-the-cbor-map②">5.11. Parsing b3 CBOR headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reading-a-body">
-   <b><a href="#reading-a-body">#reading-a-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reading-a-body" class="dfn-panel" data-for="reading-a-body" id="infopanel-for-reading-a-body" role="dialog">
+   <span id="infopaneltitle-for-reading-a-body" style="display:none">Info about the 'read a body' definition.</span><b><a href="#reading-a-body">#reading-a-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reading-a-body">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-the-stored-exchange">
-   <b><a href="#matches-the-stored-exchange">#matches-the-stored-exchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-the-stored-exchange" class="dfn-panel" data-for="matches-the-stored-exchange" id="infopanel-for-matches-the-stored-exchange" role="dialog">
+   <span id="infopaneltitle-for-matches-the-stored-exchange" style="display:none">Info about the 'matches the stored exchange' definition.</span><b><a href="#matches-the-stored-exchange">#matches-the-stored-exchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-the-stored-exchange">2.6. Monkeypatch HTTP-network-or-cache fetch</a>
     <li><a href="#ref-for-matches-the-stored-exchange①">3.3. Monkeypatch Link type "prefetch"</a>
@@ -4891,53 +4896,53 @@ Monkeypatch Page load processing model for HTML files</a>
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-new-signed-exchange-report">
-   <b><a href="#create-a-new-signed-exchange-report">#create-a-new-signed-exchange-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-new-signed-exchange-report" class="dfn-panel" data-for="create-a-new-signed-exchange-report" id="infopanel-for-create-a-new-signed-exchange-report" role="dialog">
+   <span id="infopaneltitle-for-create-a-new-signed-exchange-report" style="display:none">Info about the 'create a new signed exchange report' definition.</span><b><a href="#create-a-new-signed-exchange-report">#create-a-new-signed-exchange-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-new-signed-exchange-report">2.5. Monkeypatch HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wait-and-queue-a-report-for">
-   <b><a href="#wait-and-queue-a-report-for">#wait-and-queue-a-report-for</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wait-and-queue-a-report-for" class="dfn-panel" data-for="wait-and-queue-a-report-for" id="infopanel-for-wait-and-queue-a-report-for" role="dialog">
+   <span id="infopaneltitle-for-wait-and-queue-a-report-for" style="display:none">Info about the 'wait and queue a report for' definition.</span><b><a href="#wait-and-queue-a-report-for">#wait-and-queue-a-report-for</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-and-queue-a-report-for">2.5. Monkeypatch HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-signed-exchange-report">
-   <b><a href="#queue-a-signed-exchange-report">#queue-a-signed-exchange-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-signed-exchange-report" class="dfn-panel" data-for="queue-a-signed-exchange-report" id="infopanel-for-queue-a-signed-exchange-report" role="dialog">
+   <span id="infopaneltitle-for-queue-a-signed-exchange-report" style="display:none">Info about the 'queue a signed exchange report' definition.</span><b><a href="#queue-a-signed-exchange-report">#queue-a-signed-exchange-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-signed-exchange-report">2.5. Monkeypatch HTTP fetch</a>
     <li><a href="#ref-for-queue-a-signed-exchange-report①">5.15. Wait and queue a report</a> <a href="#ref-for-queue-a-signed-exchange-report②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="new-read-buffer">
-   <b><a href="#new-read-buffer">#new-read-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-new-read-buffer" class="dfn-panel" data-for="new-read-buffer" id="infopanel-for-new-read-buffer" role="dialog">
+   <span id="infopaneltitle-for-new-read-buffer" style="display:none">Info about the 'new read buffer' definition.</span><b><a href="#new-read-buffer">#new-read-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new-read-buffer">5.2. Extracting the fallback URL</a>
     <li><a href="#ref-for-new-read-buffer①">5.3. Parsing signed exchanges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-reading-up-to">
-   <b><a href="#read-buffer-reading-up-to">#read-buffer-reading-up-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-reading-up-to" class="dfn-panel" data-for="read-buffer-reading-up-to" id="infopanel-for-read-buffer-reading-up-to" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-reading-up-to" style="display:none">Info about the 'read up to' definition.</span><b><a href="#read-buffer-reading-up-to">#read-buffer-reading-up-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-reading-up-to">5.17.3. Read bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-read">
-   <b><a href="#read-buffer-read">#read-buffer-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-read" class="dfn-panel" data-for="read-buffer-read" id="infopanel-for-read-buffer-read" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-read" style="display:none">Info about the 'read' definition.</span><b><a href="#read-buffer-read">#read-buffer-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-read">5.3. Parsing signed exchanges</a> <a href="#ref-for-read-buffer-read①">(2)</a> <a href="#ref-for-read-buffer-read②">(3)</a> <a href="#ref-for-read-buffer-read③">(4)</a>
     <li><a href="#ref-for-read-buffer-read④">5.4. Parsing the invariant prefix</a> <a href="#ref-for-read-buffer-read⑤">(2)</a> <a href="#ref-for-read-buffer-read⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-buffer-dump">
-   <b><a href="#read-buffer-dump">#read-buffer-dump</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-buffer-dump" class="dfn-panel" data-for="read-buffer-dump" id="infopanel-for-read-buffer-dump" role="dialog">
+   <span id="infopaneltitle-for-read-buffer-dump" style="display:none">Info about the 'Dump' definition.</span><b><a href="#read-buffer-dump">#read-buffer-dump</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-buffer-dump">5.12. Creating the response stream.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-attribute-named">
-   <b><a href="#target-attribute-named">#target-attribute-named</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-attribute-named" class="dfn-panel" data-for="target-attribute-named" id="infopanel-for-target-attribute-named" role="dialog">
+   <span id="infopaneltitle-for-target-attribute-named" style="display:none">Info about the 'Target Attribute named' definition.</span><b><a href="#target-attribute-named">#target-attribute-named</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-attribute-named">3.3. Monkeypatch Link type "prefetch"</a> <a href="#ref-for-target-attribute-named①">(2)</a> <a href="#ref-for-target-attribute-named②">(3)</a>
     <li><a href="#ref-for-target-attribute-named③">3.5. 
@@ -4947,75 +4952,131 @@ Monkeypatch Page load processing model for HTML files</a> <a href="#ref-for-targ
 exchange link info</a> <a href="#ref-for-target-attribute-named①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="getting-allowed-signed-exchange-link-info">
-   <b><a href="#getting-allowed-signed-exchange-link-info">#getting-allowed-signed-exchange-link-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-getting-allowed-signed-exchange-link-info" class="dfn-panel" data-for="getting-allowed-signed-exchange-link-info" id="infopanel-for-getting-allowed-signed-exchange-link-info" role="dialog">
+   <span id="infopaneltitle-for-getting-allowed-signed-exchange-link-info" style="display:none">Info about the 'getting allowed signed exchange link info' definition.</span><b><a href="#getting-allowed-signed-exchange-link-info">#getting-allowed-signed-exchange-link-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-getting-allowed-signed-exchange-link-info">3.3. Monkeypatch Link type "prefetch"</a>
     <li><a href="#ref-for-getting-allowed-signed-exchange-link-info①">3.5. 
 Monkeypatch Page load processing model for HTML files</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="getting-alternate-signed-exchange-link-info">
-   <b><a href="#getting-alternate-signed-exchange-link-info">#getting-alternate-signed-exchange-link-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-getting-alternate-signed-exchange-link-info" class="dfn-panel" data-for="getting-alternate-signed-exchange-link-info" id="infopanel-for-getting-alternate-signed-exchange-link-info" role="dialog">
+   <span id="infopaneltitle-for-getting-alternate-signed-exchange-link-info" style="display:none">Info about the 'getting alternate signed exchange link info' definition.</span><b><a href="#getting-alternate-signed-exchange-link-info">#getting-alternate-signed-exchange-link-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-getting-alternate-signed-exchange-link-info">3.3. Monkeypatch Link type "prefetch"</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WICG/webusb/index.html
+++ b/tests/github/WICG/webusb/index.html
@@ -3602,182 +3602,182 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     </ul>
    <li><a href="#webusb-platform-capability-descriptor">WebUSB Platform Capability Descriptor</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-objects" class="dfn-panel" data-for="term-for-sec-array-objects" id="infopanel-for-term-for-sec-array-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-objects" style="display:none">Info about the 'Array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-objects">5. Device Enumeration</a>
     <li><a href="#ref-for-sec-array-objects①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'Promise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">5. Device Enumeration</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a>
     <li><a href="#ref-for-sec-promise-objects③">6. Device Usage</a> <a href="#ref-for-sec-promise-objects④">(2)</a> <a href="#ref-for-sec-promise-objects⑤">(3)</a> <a href="#ref-for-sec-promise-objects⑥">(4)</a> <a href="#ref-for-sec-promise-objects⑦">(5)</a> <a href="#ref-for-sec-promise-objects⑧">(6)</a> <a href="#ref-for-sec-promise-objects⑨">(7)</a> <a href="#ref-for-sec-promise-objects①⓪">(8)</a> <a href="#ref-for-sec-promise-objects①①">(9)</a> <a href="#ref-for-sec-promise-objects①②">(10)</a> <a href="#ref-for-sec-promise-objects①③">(11)</a> <a href="#ref-for-sec-promise-objects①④">(12)</a> <a href="#ref-for-sec-promise-objects①⑤">(13)</a> <a href="#ref-for-sec-promise-objects①⑥">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">5. Device Enumeration</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">5. Device Enumeration</a> <a href="#ref-for-eventhandler①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">5. Device Enumeration</a>
     <li><a href="#ref-for-navigator①">7.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5. Device Enumeration</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">6. Device Usage</a> <a href="#ref-for-in-parallel③">(2)</a> <a href="#ref-for-in-parallel④">(3)</a> <a href="#ref-for-in-parallel⑤">(4)</a> <a href="#ref-for-in-parallel⑥">(5)</a> <a href="#ref-for-in-parallel⑦">(6)</a> <a href="#ref-for-in-parallel⑧">(7)</a> <a href="#ref-for-in-parallel⑨">(8)</a> <a href="#ref-for-in-parallel①⓪">(9)</a> <a href="#ref-for-in-parallel①①">(10)</a> <a href="#ref-for-in-parallel①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">5. Device Enumeration</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">5. Device Enumeration</a> <a href="#ref-for-transient-activation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extra-permission-data-type">
-   <a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-type">https://w3c.github.io/permissions/#dfn-extra-permission-data-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extra-permission-data-type" class="dfn-panel" data-for="term-for-dfn-extra-permission-data-type" id="infopanel-for-term-for-dfn-extra-permission-data-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extra-permission-data-type" style="display:none">Info about the 'extra permission data type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-type">https://w3c.github.io/permissions/#dfn-extra-permission-data-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extra-permission-data-type">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-query-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm" id="infopanel-for-term-for-dfn-permission-query-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-query-algorithm" style="display:none">Info about the 'permission query algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-query-algorithm">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-result-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-result-type" class="dfn-panel" data-for="term-for-dfn-permission-result-type" id="infopanel-for-term-for-dfn-permission-result-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-result-type" style="display:none">Info about the 'permission result type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-result-type">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-prompt">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-prompt" class="dfn-panel" data-for="term-for-dom-permissionstate-prompt" id="infopanel-for-term-for-dom-permissionstate-prompt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-prompt" style="display:none">Info about the 'prompt' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-prompt">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus-state" class="dfn-panel" data-for="term-for-dom-permissionstatus-state" id="infopanel-for-term-for-dom-permissionstatus-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus-state" style="display:none">Info about the 'state' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">5. Device Enumeration</a>
     <li><a href="#ref-for-dom-permissionstatus-state①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">7.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">7.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
-   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-request-algorithm" class="dfn-panel" data-for="term-for-permission-request-algorithm" id="infopanel-for-term-for-permission-request-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-request-algorithm" style="display:none">Info about the 'permission request algorithm' external reference.</span><a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">6. Device Usage</a> <a href="#ref-for-aborterror①">(2)</a> <a href="#ref-for-aborterror②">(3)</a> <a href="#ref-for-aborterror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">6. Device Usage</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a> <a href="#ref-for-idl-ArrayBuffer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">6. Device Usage</a> <a href="#ref-for-BufferSource①">(2)</a> <a href="#ref-for-BufferSource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5. Device Enumeration</a>
     <li><a href="#ref-for-idl-DOMString①">5.1. Events</a>
@@ -3787,15 +3787,15 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-idl-DOMString⑦">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DataView">
-   <a href="https://webidl.spec.whatwg.org/#idl-DataView">https://webidl.spec.whatwg.org/#idl-DataView</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DataView" class="dfn-panel" data-for="term-for-idl-DataView" id="infopanel-for-term-for-idl-DataView" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DataView" style="display:none">Info about the 'DataView' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DataView">https://webidl.spec.whatwg.org/#idl-DataView</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DataView">6. Device Usage</a> <a href="#ref-for-idl-DataView①">(2)</a> <a href="#ref-for-idl-DataView②">(3)</a> <a href="#ref-for-idl-DataView③">(4)</a>
     <li><a href="#ref-for-idl-DataView④">6.1. Transfers</a> <a href="#ref-for-idl-DataView⑤">(2)</a> <a href="#ref-for-idl-DataView⑥">(3)</a> <a href="#ref-for-idl-DataView⑦">(4)</a> <a href="#ref-for-idl-DataView⑧">(5)</a> <a href="#ref-for-idl-DataView⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5. Device Enumeration</a> <a href="#ref-for-Exposed①">(2)</a> <a href="#ref-for-Exposed②">(3)</a> <a href="#ref-for-Exposed③">(4)</a>
     <li><a href="#ref-for-Exposed④">5.1. Events</a>
@@ -3807,8 +3807,8 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-Exposed①⑥">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">5. Device Enumeration</a> <a href="#ref-for-idl-frozen-array①">(2)</a>
     <li><a href="#ref-for-idl-frozen-array②">6. Device Usage</a>
@@ -3818,49 +3818,49 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-idl-frozen-array⑧">7.2. Permission API</a> <a href="#ref-for-idl-frozen-array⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">6. Device Usage</a> <a href="#ref-for-invalidaccesserror①">(2)</a> <a href="#ref-for-invalidaccesserror②">(3)</a> <a href="#ref-for-invalidaccesserror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6. Device Usage</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a> <a href="#ref-for-invalidstateerror④">(5)</a> <a href="#ref-for-invalidstateerror⑤">(6)</a> <a href="#ref-for-invalidstateerror⑥">(7)</a> <a href="#ref-for-invalidstateerror⑦">(8)</a> <a href="#ref-for-invalidstateerror⑧">(9)</a> <a href="#ref-for-invalidstateerror⑨">(10)</a> <a href="#ref-for-invalidstateerror①⓪">(11)</a> <a href="#ref-for-invalidstateerror①①">(12)</a>
     <li><a href="#ref-for-invalidstateerror①②">6.1. Transfers</a> <a href="#ref-for-invalidstateerror①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networkerror">
-   <a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networkerror" class="dfn-panel" data-for="term-for-networkerror" id="infopanel-for-term-for-networkerror" role="menu">
+   <span id="infopaneltitle-for-term-for-networkerror" style="display:none">Info about the 'NetworkError' external reference.</span><a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">6. Device Usage</a> <a href="#ref-for-networkerror①">(2)</a> <a href="#ref-for-networkerror②">(3)</a> <a href="#ref-for-networkerror③">(4)</a> <a href="#ref-for-networkerror④">(5)</a> <a href="#ref-for-networkerror⑤">(6)</a> <a href="#ref-for-networkerror⑥">(7)</a> <a href="#ref-for-networkerror⑦">(8)</a> <a href="#ref-for-networkerror⑧">(9)</a> <a href="#ref-for-networkerror⑨">(10)</a> <a href="#ref-for-networkerror①⓪">(11)</a> <a href="#ref-for-networkerror①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">5. Device Enumeration</a>
     <li><a href="#ref-for-notfounderror①">6. Device Usage</a> <a href="#ref-for-notfounderror②">(2)</a> <a href="#ref-for-notfounderror③">(3)</a> <a href="#ref-for-notfounderror④">(4)</a> <a href="#ref-for-notfounderror⑤">(5)</a> <a href="#ref-for-notfounderror⑥">(6)</a> <a href="#ref-for-notfounderror⑦">(7)</a> <a href="#ref-for-notfounderror⑧">(8)</a> <a href="#ref-for-notfounderror⑨">(9)</a> <a href="#ref-for-notfounderror①⓪">(10)</a> <a href="#ref-for-notfounderror①①">(11)</a> <a href="#ref-for-notfounderror①②">(12)</a> <a href="#ref-for-notfounderror①③">(13)</a> <a href="#ref-for-notfounderror①④">(14)</a> <a href="#ref-for-notfounderror①⑤">(15)</a> <a href="#ref-for-notfounderror①⑥">(16)</a> <a href="#ref-for-notfounderror①⑦">(17)</a> <a href="#ref-for-notfounderror①⑧">(18)</a> <a href="#ref-for-notfounderror①⑨">(19)</a> <a href="#ref-for-notfounderror②⓪">(20)</a> <a href="#ref-for-notfounderror②①">(21)</a> <a href="#ref-for-notfounderror②②">(22)</a>
     <li><a href="#ref-for-notfounderror②③">6.1. Transfers</a> <a href="#ref-for-notfounderror②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5. Device Enumeration</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">6. Device Usage</a> <a href="#ref-for-idl-promise③">(2)</a> <a href="#ref-for-idl-promise④">(3)</a> <a href="#ref-for-idl-promise⑤">(4)</a> <a href="#ref-for-idl-promise⑥">(5)</a> <a href="#ref-for-idl-promise⑦">(6)</a> <a href="#ref-for-idl-promise⑧">(7)</a> <a href="#ref-for-idl-promise⑨">(8)</a> <a href="#ref-for-idl-promise①⓪">(9)</a> <a href="#ref-for-idl-promise①①">(10)</a> <a href="#ref-for-idl-promise①②">(11)</a> <a href="#ref-for-idl-promise①③">(12)</a> <a href="#ref-for-idl-promise①④">(13)</a> <a href="#ref-for-idl-promise①⑤">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5. Device Enumeration</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject②">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5. Device Enumeration</a> <a href="#ref-for-SecureContext①">(2)</a> <a href="#ref-for-SecureContext②">(3)</a>
     <li><a href="#ref-for-SecureContext③">5.1. Events</a>
@@ -3871,21 +3871,21 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-SecureContext①④">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6. Device Usage</a>
     <li><a href="#ref-for-idl-boolean①">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-octet">
-   <a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-octet" class="dfn-panel" data-for="term-for-idl-octet" id="infopanel-for-term-for-idl-octet" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-octet" style="display:none">Info about the 'octet' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-octet">5. Device Enumeration</a> <a href="#ref-for-idl-octet①">(2)</a> <a href="#ref-for-idl-octet②">(3)</a>
     <li><a href="#ref-for-idl-octet③">6. Device Usage</a> <a href="#ref-for-idl-octet④">(2)</a> <a href="#ref-for-idl-octet⑤">(3)</a> <a href="#ref-for-idl-octet⑥">(4)</a> <a href="#ref-for-idl-octet⑦">(5)</a> <a href="#ref-for-idl-octet⑧">(6)</a> <a href="#ref-for-idl-octet⑨">(7)</a> <a href="#ref-for-idl-octet①⓪">(8)</a> <a href="#ref-for-idl-octet①①">(9)</a> <a href="#ref-for-idl-octet①②">(10)</a> <a href="#ref-for-idl-octet①③">(11)</a> <a href="#ref-for-idl-octet①④">(12)</a> <a href="#ref-for-idl-octet①⑤">(13)</a> <a href="#ref-for-idl-octet①⑥">(14)</a> <a href="#ref-for-idl-octet①⑦">(15)</a> <a href="#ref-for-idl-octet①⑧">(16)</a> <a href="#ref-for-idl-octet①⑨">(17)</a> <a href="#ref-for-idl-octet②⓪">(18)</a> <a href="#ref-for-idl-octet②①">(19)</a>
@@ -3896,23 +3896,23 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-idl-octet③④">7.2. Permission API</a> <a href="#ref-for-idl-octet③⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">5. Device Enumeration</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">6. Device Usage</a> <a href="#ref-for-reject③">(2)</a> <a href="#ref-for-reject④">(3)</a> <a href="#ref-for-reject⑤">(4)</a> <a href="#ref-for-reject⑥">(5)</a> <a href="#ref-for-reject⑦">(6)</a> <a href="#ref-for-reject⑧">(7)</a> <a href="#ref-for-reject⑨">(8)</a> <a href="#ref-for-reject①⓪">(9)</a> <a href="#ref-for-reject①①">(10)</a> <a href="#ref-for-reject①②">(11)</a> <a href="#ref-for-reject①③">(12)</a> <a href="#ref-for-reject①④">(13)</a> <a href="#ref-for-reject①⑤">(14)</a> <a href="#ref-for-reject①⑥">(15)</a> <a href="#ref-for-reject①⑦">(16)</a> <a href="#ref-for-reject①⑧">(17)</a> <a href="#ref-for-reject①⑨">(18)</a> <a href="#ref-for-reject②⓪">(19)</a> <a href="#ref-for-reject②①">(20)</a> <a href="#ref-for-reject②②">(21)</a> <a href="#ref-for-reject②③">(22)</a> <a href="#ref-for-reject②④">(23)</a> <a href="#ref-for-reject②⑤">(24)</a> <a href="#ref-for-reject②⑥">(25)</a> <a href="#ref-for-reject②⑦">(26)</a> <a href="#ref-for-reject②⑧">(27)</a> <a href="#ref-for-reject②⑨">(28)</a> <a href="#ref-for-reject③⓪">(29)</a> <a href="#ref-for-reject③①">(30)</a> <a href="#ref-for-reject③②">(31)</a> <a href="#ref-for-reject③③">(32)</a> <a href="#ref-for-reject③④">(33)</a> <a href="#ref-for-reject③⑤">(34)</a> <a href="#ref-for-reject③⑥">(35)</a> <a href="#ref-for-reject③⑦">(36)</a> <a href="#ref-for-reject③⑧">(37)</a> <a href="#ref-for-reject③⑨">(38)</a> <a href="#ref-for-reject④⓪">(39)</a> <a href="#ref-for-reject④①">(40)</a> <a href="#ref-for-reject④②">(41)</a> <a href="#ref-for-reject④③">(42)</a> <a href="#ref-for-reject④④">(43)</a> <a href="#ref-for-reject④⑤">(44)</a> <a href="#ref-for-reject④⑥">(45)</a> <a href="#ref-for-reject④⑦">(46)</a> <a href="#ref-for-reject④⑧">(47)</a> <a href="#ref-for-reject④⑨">(48)</a> <a href="#ref-for-reject⑤⓪">(49)</a> <a href="#ref-for-reject⑤①">(50)</a> <a href="#ref-for-reject⑤②">(51)</a> <a href="#ref-for-reject⑤③">(52)</a> <a href="#ref-for-reject⑤④">(53)</a> <a href="#ref-for-reject⑤⑤">(54)</a> <a href="#ref-for-reject⑤⑥">(55)</a>
     <li><a href="#ref-for-reject⑤⑦">6.1. Transfers</a> <a href="#ref-for-reject⑤⑧">(2)</a> <a href="#ref-for-reject⑤⑨">(3)</a> <a href="#ref-for-reject⑥⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">5. Device Enumeration</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a>
     <li><a href="#ref-for-resolve③">6. Device Usage</a> <a href="#ref-for-resolve④">(2)</a> <a href="#ref-for-resolve⑤">(3)</a> <a href="#ref-for-resolve⑥">(4)</a> <a href="#ref-for-resolve⑦">(5)</a> <a href="#ref-for-resolve⑧">(6)</a> <a href="#ref-for-resolve⑨">(7)</a> <a href="#ref-for-resolve①⓪">(8)</a> <a href="#ref-for-resolve①①">(9)</a> <a href="#ref-for-resolve①②">(10)</a> <a href="#ref-for-resolve①③">(11)</a> <a href="#ref-for-resolve①④">(12)</a> <a href="#ref-for-resolve①⑤">(13)</a> <a href="#ref-for-resolve①⑥">(14)</a> <a href="#ref-for-resolve①⑦">(15)</a> <a href="#ref-for-resolve①⑧">(16)</a> <a href="#ref-for-resolve①⑨">(17)</a> <a href="#ref-for-resolve②⓪">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5. Device Enumeration</a> <a href="#ref-for-idl-sequence①">(2)</a>
     <li><a href="#ref-for-idl-sequence②">6. Device Usage</a> <a href="#ref-for-idl-sequence③">(2)</a>
@@ -3920,30 +3920,30 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-idl-sequence⑥">7.2. Permission API</a> <a href="#ref-for-idl-sequence⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6. Device Usage</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a> <a href="#ref-for-idl-undefined⑤">(6)</a> <a href="#ref-for-idl-undefined⑥">(7)</a> <a href="#ref-for-idl-undefined⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">6. Device Usage</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
     <li><a href="#ref-for-idl-unsigned-long③">6.1. Transfers</a> <a href="#ref-for-idl-unsigned-long④">(2)</a> <a href="#ref-for-idl-unsigned-long⑤">(3)</a> <a href="#ref-for-idl-unsigned-long⑥">(4)</a>
     <li><a href="#ref-for-idl-unsigned-long⑦">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">5. Device Enumeration</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-short②">6. Device Usage</a> <a href="#ref-for-idl-unsigned-short③">(2)</a> <a href="#ref-for-idl-unsigned-short④">(3)</a>
     <li><a href="#ref-for-idl-unsigned-short⑤">6.1. Transfers</a> <a href="#ref-for-idl-unsigned-short⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">5. Device Enumeration</a>
    </ul>
@@ -4310,199 +4310,202 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
    <div class="issue"> What configuration is the device in after it resets? <a href="https://github.com/WICG/webusb/issues/36">[Issue #36]</a> <a class="issue-return" href="#issue-0de671a3" title="Jump to section">↵</a></div>
    <div class="issue"> Include some non-normative information about device configurations. <a href="https://github.com/WICG/webusb/issues/46">[Issue #46]</a> <a class="issue-return" href="#issue-7197531b" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="webusb-platform-capability-descriptor">
-   <b><a href="#webusb-platform-capability-descriptor">#webusb-platform-capability-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webusb-platform-capability-descriptor" class="dfn-panel" data-for="webusb-platform-capability-descriptor" id="infopanel-for-webusb-platform-capability-descriptor" role="dialog">
+   <span id="infopaneltitle-for-webusb-platform-capability-descriptor" style="display:none">Info about the '4.1. WebUSB Platform Capability Descriptor' definition.</span><b><a href="#webusb-platform-capability-descriptor">#webusb-platform-capability-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webusb-platform-capability-descriptor">4.1. WebUSB Platform Capability Descriptor</a>
     <li><a href="#ref-for-webusb-platform-capability-descriptor">4.2. WebUSB Device Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="landing-page">
-   <b><a href="#landing-page">#landing-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-landing-page" class="dfn-panel" data-for="landing-page" id="infopanel-for-landing-page" role="dialog">
+   <span id="infopaneltitle-for-landing-page" style="display:none">Info about the 'landing page' definition.</span><b><a href="#landing-page">#landing-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-landing-page">2.3. Devices Updates and Diagnostics</a>
     <li><a href="#ref-for-landing-page①">4.1. WebUSB Platform Capability Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-url">
-   <b><a href="#get-url">#get-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-url" class="dfn-panel" data-for="get-url" id="infopanel-for-get-url" role="dialog">
+   <span id="infopaneltitle-for-get-url" style="display:none">Info about the '4.2.1. Get URL' definition.</span><b><a href="#get-url">#get-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-url">4.2.1. Get URL</a>
     <li><a href="#ref-for-get-url">4.3.1. URL Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-descriptor">
-   <b><a href="#url-descriptor">#url-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-descriptor" class="dfn-panel" data-for="url-descriptor" id="infopanel-for-url-descriptor" role="dialog">
+   <span id="infopaneltitle-for-url-descriptor" style="display:none">Info about the '4.3.1. URL Descriptor' definition.</span><b><a href="#url-descriptor">#url-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-descriptor">4.2.1. Get URL</a>
     <li><a href="#ref-for-url-descriptor">4.3.1. URL Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbdevicefilter">
-   <b><a href="#dictdef-usbdevicefilter">#dictdef-usbdevicefilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbdevicefilter" class="dfn-panel" data-for="dictdef-usbdevicefilter" id="infopanel-for-dictdef-usbdevicefilter" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbdevicefilter" style="display:none">Info about the 'USBDeviceFilter' definition.</span><b><a href="#dictdef-usbdevicefilter">#dictdef-usbdevicefilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbdevicefilter">5. Device Enumeration</a> <a href="#ref-for-dictdef-usbdevicefilter①">(2)</a>
     <li><a href="#ref-for-dictdef-usbdevicefilter②">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-vendorid">
-   <b><a href="#dom-usbdevicefilter-vendorid">#dom-usbdevicefilter-vendorid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-vendorid" class="dfn-panel" data-for="dom-usbdevicefilter-vendorid" id="infopanel-for-dom-usbdevicefilter-vendorid" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-vendorid" style="display:none">Info about the 'vendorId' definition.</span><b><a href="#dom-usbdevicefilter-vendorid">#dom-usbdevicefilter-vendorid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-vendorid">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-vendorid①">(2)</a> <a href="#ref-for-dom-usbdevicefilter-vendorid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-productid">
-   <b><a href="#dom-usbdevicefilter-productid">#dom-usbdevicefilter-productid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-productid" class="dfn-panel" data-for="dom-usbdevicefilter-productid" id="infopanel-for-dom-usbdevicefilter-productid" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-productid" style="display:none">Info about the 'productId' definition.</span><b><a href="#dom-usbdevicefilter-productid">#dom-usbdevicefilter-productid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-productid">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-productid①">(2)</a> <a href="#ref-for-dom-usbdevicefilter-productid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-classcode">
-   <b><a href="#dom-usbdevicefilter-classcode">#dom-usbdevicefilter-classcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-classcode" class="dfn-panel" data-for="dom-usbdevicefilter-classcode" id="infopanel-for-dom-usbdevicefilter-classcode" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-classcode" style="display:none">Info about the 'classCode' definition.</span><b><a href="#dom-usbdevicefilter-classcode">#dom-usbdevicefilter-classcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-classcode">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-classcode①">(2)</a> <a href="#ref-for-dom-usbdevicefilter-classcode②">(3)</a> <a href="#ref-for-dom-usbdevicefilter-classcode③">(4)</a> <a href="#ref-for-dom-usbdevicefilter-classcode④">(5)</a> <a href="#ref-for-dom-usbdevicefilter-classcode⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-subclasscode">
-   <b><a href="#dom-usbdevicefilter-subclasscode">#dom-usbdevicefilter-subclasscode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-subclasscode" class="dfn-panel" data-for="dom-usbdevicefilter-subclasscode" id="infopanel-for-dom-usbdevicefilter-subclasscode" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-subclasscode" style="display:none">Info about the 'subclassCode' definition.</span><b><a href="#dom-usbdevicefilter-subclasscode">#dom-usbdevicefilter-subclasscode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-subclasscode">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-subclasscode①">(2)</a> <a href="#ref-for-dom-usbdevicefilter-subclasscode②">(3)</a> <a href="#ref-for-dom-usbdevicefilter-subclasscode③">(4)</a> <a href="#ref-for-dom-usbdevicefilter-subclasscode④">(5)</a> <a href="#ref-for-dom-usbdevicefilter-subclasscode⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-protocolcode">
-   <b><a href="#dom-usbdevicefilter-protocolcode">#dom-usbdevicefilter-protocolcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-protocolcode" class="dfn-panel" data-for="dom-usbdevicefilter-protocolcode" id="infopanel-for-dom-usbdevicefilter-protocolcode" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-protocolcode" style="display:none">Info about the 'protocolCode' definition.</span><b><a href="#dom-usbdevicefilter-protocolcode">#dom-usbdevicefilter-protocolcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-protocolcode">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-protocolcode①">(2)</a> <a href="#ref-for-dom-usbdevicefilter-protocolcode②">(3)</a> <a href="#ref-for-dom-usbdevicefilter-protocolcode③">(4)</a> <a href="#ref-for-dom-usbdevicefilter-protocolcode④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicefilter-serialnumber">
-   <b><a href="#dom-usbdevicefilter-serialnumber">#dom-usbdevicefilter-serialnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicefilter-serialnumber" class="dfn-panel" data-for="dom-usbdevicefilter-serialnumber" id="infopanel-for-dom-usbdevicefilter-serialnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicefilter-serialnumber" style="display:none">Info about the 'serialNumber' definition.</span><b><a href="#dom-usbdevicefilter-serialnumber">#dom-usbdevicefilter-serialnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicefilter-serialnumber">5. Device Enumeration</a> <a href="#ref-for-dom-usbdevicefilter-serialnumber①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbdevicerequestoptions">
-   <b><a href="#dictdef-usbdevicerequestoptions">#dictdef-usbdevicerequestoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbdevicerequestoptions" class="dfn-panel" data-for="dictdef-usbdevicerequestoptions" id="infopanel-for-dictdef-usbdevicerequestoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbdevicerequestoptions" style="display:none">Info about the 'USBDeviceRequestOptions' definition.</span><b><a href="#dictdef-usbdevicerequestoptions">#dictdef-usbdevicerequestoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbdevicerequestoptions">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicerequestoptions-filters">
-   <b><a href="#dom-usbdevicerequestoptions-filters">#dom-usbdevicerequestoptions-filters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicerequestoptions-filters" class="dfn-panel" data-for="dom-usbdevicerequestoptions-filters" id="infopanel-for-dom-usbdevicerequestoptions-filters" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicerequestoptions-filters" style="display:none">Info about the 'filters' definition.</span><b><a href="#dom-usbdevicerequestoptions-filters">#dom-usbdevicerequestoptions-filters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicerequestoptions-filters">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usb">
-   <b><a href="#usb">#usb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usb" class="dfn-panel" data-for="usb" id="infopanel-for-usb" role="dialog">
+   <span id="infopaneltitle-for-usb" style="display:none">Info about the 'USB' definition.</span><b><a href="#usb">#usb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usb">5. Device Enumeration</a> <a href="#ref-for-usb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usb-onconnect">
-   <b><a href="#dom-usb-onconnect">#dom-usb-onconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usb-onconnect" class="dfn-panel" data-for="dom-usb-onconnect" id="infopanel-for-dom-usb-onconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-usb-onconnect" style="display:none">Info about the 'onconnect' definition.</span><b><a href="#dom-usb-onconnect">#dom-usb-onconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usb-onconnect">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usb-ondisconnect">
-   <b><a href="#dom-usb-ondisconnect">#dom-usb-ondisconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usb-ondisconnect" class="dfn-panel" data-for="dom-usb-ondisconnect" id="infopanel-for-dom-usb-ondisconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-usb-ondisconnect" style="display:none">Info about the 'ondisconnect' definition.</span><b><a href="#dom-usb-ondisconnect">#dom-usb-ondisconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usb-ondisconnect">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usb-getdevices">
-   <b><a href="#dom-usb-getdevices">#dom-usb-getdevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usb-getdevices" class="dfn-panel" data-for="dom-usb-getdevices" id="infopanel-for-dom-usb-getdevices" role="dialog">
+   <span id="infopaneltitle-for-dom-usb-getdevices" style="display:none">Info about the 'getDevices' definition.</span><b><a href="#dom-usb-getdevices">#dom-usb-getdevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usb-getdevices">5. Device Enumeration</a> <a href="#ref-for-dom-usb-getdevices①">(2)</a> <a href="#ref-for-dom-usb-getdevices②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usb-requestdevice">
-   <b><a href="#dom-usb-requestdevice">#dom-usb-requestdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usb-requestdevice" class="dfn-panel" data-for="dom-usb-requestdevice" id="infopanel-for-dom-usb-requestdevice" role="dialog">
+   <span id="infopaneltitle-for-dom-usb-requestdevice" style="display:none">Info about the 'requestDevice' definition.</span><b><a href="#dom-usb-requestdevice">#dom-usb-requestdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usb-requestdevice">3.1. Abusing Access to a Device</a>
     <li><a href="#ref-for-dom-usb-requestdevice①">3.2. Attacking a Device</a>
     <li><a href="#ref-for-dom-usb-requestdevice②">5. Device Enumeration</a> <a href="#ref-for-dom-usb-requestdevice③">(2)</a> <a href="#ref-for-dom-usb-requestdevice④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-usb">
-   <b><a href="#dom-navigator-usb">#dom-navigator-usb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-usb" class="dfn-panel" data-for="dom-navigator-usb" id="infopanel-for-dom-navigator-usb" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-usb" style="display:none">Info about the 'usb' definition.</span><b><a href="#dom-navigator-usb">#dom-navigator-usb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-usb">5.1. Events</a> <a href="#ref-for-dom-navigator-usb①">(2)</a>
     <li><a href="#ref-for-dom-navigator-usb②">7.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-device-filter">
-   <b><a href="#match-a-device-filter">#match-a-device-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-device-filter" class="dfn-panel" data-for="match-a-device-filter" id="infopanel-for-match-a-device-filter" role="dialog">
+   <span id="infopaneltitle-for-match-a-device-filter" style="display:none">Info about the 'matches a device
+filter' definition.</span><b><a href="#match-a-device-filter">#match-a-device-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-device-filter">5. Device Enumeration</a>
     <li><a href="#ref-for-match-a-device-filter①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-the-interface-filter">
-   <b><a href="#matches-the-interface-filter">#matches-the-interface-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-the-interface-filter" class="dfn-panel" data-for="matches-the-interface-filter" id="infopanel-for-matches-the-interface-filter" role="dialog">
+   <span id="infopaneltitle-for-matches-the-interface-filter" style="display:none">Info about the 'matches
+an interface filter' definition.</span><b><a href="#matches-the-interface-filter">#matches-the-interface-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-the-interface-filter">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-not-a-valid-filter">
-   <b><a href="#is-not-a-valid-filter">#is-not-a-valid-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-not-a-valid-filter" class="dfn-panel" data-for="is-not-a-valid-filter" id="infopanel-for-is-not-a-valid-filter" role="dialog">
+   <span id="infopaneltitle-for-is-not-a-valid-filter" style="display:none">Info about the 'is valid' definition.</span><b><a href="#is-not-a-valid-filter">#is-not-a-valid-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-not-a-valid-filter">5. Device Enumeration</a>
     <li><a href="#ref-for-is-not-a-valid-filter①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumerate-all-devices-attached-to-the-system">
-   <b><a href="#enumerate-all-devices-attached-to-the-system">#enumerate-all-devices-attached-to-the-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumerate-all-devices-attached-to-the-system" class="dfn-panel" data-for="enumerate-all-devices-attached-to-the-system" id="infopanel-for-enumerate-all-devices-attached-to-the-system" role="dialog">
+   <span id="infopaneltitle-for-enumerate-all-devices-attached-to-the-system" style="display:none">Info about the 'enumerate all devices attached to the system' definition.</span><b><a href="#enumerate-all-devices-attached-to-the-system">#enumerate-all-devices-attached-to-the-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumerate-all-devices-attached-to-the-system">5. Device Enumeration</a> <a href="#ref-for-enumerate-all-devices-attached-to-the-system①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-the-usb-permission">
-   <b><a href="#request-the-usb-permission">#request-the-usb-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-the-usb-permission" class="dfn-panel" data-for="request-the-usb-permission" id="infopanel-for-request-the-usb-permission" role="dialog">
+   <span id="infopaneltitle-for-request-the-usb-permission" style="display:none">Info about the 'request the "usb" permission' definition.</span><b><a href="#request-the-usb-permission">#request-the-usb-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-the-usb-permission">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-device-to-storage">
-   <b><a href="#add-device-to-storage">#add-device-to-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-device-to-storage" class="dfn-panel" data-for="add-device-to-storage" id="infopanel-for-add-device-to-storage" role="dialog">
+   <span id="infopaneltitle-for-add-device-to-storage" style="display:none">Info about the 'add an allowed USB device' definition.</span><b><a href="#add-device-to-storage">#add-device-to-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-device-to-storage">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-permissions-for-device">
-   <b><a href="#check-permissions-for-device">#check-permissions-for-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-permissions-for-device" class="dfn-panel" data-for="check-permissions-for-device" id="infopanel-for-check-permissions-for-device" role="dialog">
+   <span id="infopaneltitle-for-check-permissions-for-device" style="display:none">Info about the 'check permissions for a new
+USB device' definition.</span><b><a href="#check-permissions-for-device">#check-permissions-for-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-permissions-for-device">5. Device Enumeration</a>
     <li><a href="#ref-for-check-permissions-for-device①">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbconnectioneventinit">
-   <b><a href="#dictdef-usbconnectioneventinit">#dictdef-usbconnectioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbconnectioneventinit" class="dfn-panel" data-for="dictdef-usbconnectioneventinit" id="infopanel-for-dictdef-usbconnectioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbconnectioneventinit" style="display:none">Info about the 'USBConnectionEventInit' definition.</span><b><a href="#dictdef-usbconnectioneventinit">#dictdef-usbconnectioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbconnectioneventinit">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbconnectionevent">
-   <b><a href="#usbconnectionevent">#usbconnectionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbconnectionevent" class="dfn-panel" data-for="usbconnectionevent" id="infopanel-for-usbconnectionevent" role="dialog">
+   <span id="infopaneltitle-for-usbconnectionevent" style="display:none">Info about the 'USBConnectionEvent' definition.</span><b><a href="#usbconnectionevent">#usbconnectionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbconnectionevent">5.1. Events</a> <a href="#ref-for-usbconnectionevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connect">
-   <b><a href="#connect">#connect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connect" class="dfn-panel" data-for="connect" id="infopanel-for-connect" role="dialog">
+   <span id="infopaneltitle-for-connect" style="display:none">Info about the 'connect' definition.</span><b><a href="#connect">#connect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect">5. Device Enumeration</a> <a href="#ref-for-connect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disconnect">
-   <b><a href="#disconnect">#disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disconnect" class="dfn-panel" data-for="disconnect" id="infopanel-for-disconnect" role="dialog">
+   <span id="infopaneltitle-for-disconnect" style="display:none">Info about the 'disconnect' definition.</span><b><a href="#disconnect">#disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disconnect">5. Device Enumeration</a> <a href="#ref-for-disconnect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbdevice">
-   <b><a href="#usbdevice">#usbdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbdevice" class="dfn-panel" data-for="usbdevice" id="infopanel-for-usbdevice" role="dialog">
+   <span id="infopaneltitle-for-usbdevice" style="display:none">Info about the 'USBDevice' definition.</span><b><a href="#usbdevice">#usbdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbdevice">5. Device Enumeration</a> <a href="#ref-for-usbdevice①">(2)</a> <a href="#ref-for-usbdevice②">(3)</a> <a href="#ref-for-usbdevice③">(4)</a>
     <li><a href="#ref-for-usbdevice④">5.1. Events</a> <a href="#ref-for-usbdevice⑤">(2)</a> <a href="#ref-for-usbdevice⑥">(3)</a> <a href="#ref-for-usbdevice⑦">(4)</a>
@@ -4511,398 +4514,398 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-usbdevice①⑧">7.2. Permission API</a> <a href="#ref-for-usbdevice①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-usbversionmajor">
-   <b><a href="#dom-usbdevice-usbversionmajor">#dom-usbdevice-usbversionmajor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-usbversionmajor" class="dfn-panel" data-for="dom-usbdevice-usbversionmajor" id="infopanel-for-dom-usbdevice-usbversionmajor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-usbversionmajor" style="display:none">Info about the 'usbVersionMajor' definition.</span><b><a href="#dom-usbdevice-usbversionmajor">#dom-usbdevice-usbversionmajor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-usbversionmajor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-usbversionminor">
-   <b><a href="#dom-usbdevice-usbversionminor">#dom-usbdevice-usbversionminor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-usbversionminor" class="dfn-panel" data-for="dom-usbdevice-usbversionminor" id="infopanel-for-dom-usbdevice-usbversionminor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-usbversionminor" style="display:none">Info about the 'usbVersionMinor' definition.</span><b><a href="#dom-usbdevice-usbversionminor">#dom-usbdevice-usbversionminor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-usbversionminor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-usbversionsubminor">
-   <b><a href="#dom-usbdevice-usbversionsubminor">#dom-usbdevice-usbversionsubminor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-usbversionsubminor" class="dfn-panel" data-for="dom-usbdevice-usbversionsubminor" id="infopanel-for-dom-usbdevice-usbversionsubminor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-usbversionsubminor" style="display:none">Info about the 'usbVersionSubminor' definition.</span><b><a href="#dom-usbdevice-usbversionsubminor">#dom-usbdevice-usbversionsubminor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-usbversionsubminor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-deviceclass">
-   <b><a href="#dom-usbdevice-deviceclass">#dom-usbdevice-deviceclass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-deviceclass" class="dfn-panel" data-for="dom-usbdevice-deviceclass" id="infopanel-for-dom-usbdevice-deviceclass" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-deviceclass" style="display:none">Info about the 'deviceClass' definition.</span><b><a href="#dom-usbdevice-deviceclass">#dom-usbdevice-deviceclass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-deviceclass">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-devicesubclass">
-   <b><a href="#dom-usbdevice-devicesubclass">#dom-usbdevice-devicesubclass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-devicesubclass" class="dfn-panel" data-for="dom-usbdevice-devicesubclass" id="infopanel-for-dom-usbdevice-devicesubclass" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-devicesubclass" style="display:none">Info about the 'deviceSubclass' definition.</span><b><a href="#dom-usbdevice-devicesubclass">#dom-usbdevice-devicesubclass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-devicesubclass">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-deviceprotocol">
-   <b><a href="#dom-usbdevice-deviceprotocol">#dom-usbdevice-deviceprotocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-deviceprotocol" class="dfn-panel" data-for="dom-usbdevice-deviceprotocol" id="infopanel-for-dom-usbdevice-deviceprotocol" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-deviceprotocol" style="display:none">Info about the 'deviceProtocol' definition.</span><b><a href="#dom-usbdevice-deviceprotocol">#dom-usbdevice-deviceprotocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-deviceprotocol">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-vendorid">
-   <b><a href="#dom-usbdevice-vendorid">#dom-usbdevice-vendorid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-vendorid" class="dfn-panel" data-for="dom-usbdevice-vendorid" id="infopanel-for-dom-usbdevice-vendorid" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-vendorid" style="display:none">Info about the 'vendorId' definition.</span><b><a href="#dom-usbdevice-vendorid">#dom-usbdevice-vendorid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-vendorid">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-productid">
-   <b><a href="#dom-usbdevice-productid">#dom-usbdevice-productid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-productid" class="dfn-panel" data-for="dom-usbdevice-productid" id="infopanel-for-dom-usbdevice-productid" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-productid" style="display:none">Info about the 'productId' definition.</span><b><a href="#dom-usbdevice-productid">#dom-usbdevice-productid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-productid">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-deviceversionmajor">
-   <b><a href="#dom-usbdevice-deviceversionmajor">#dom-usbdevice-deviceversionmajor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-deviceversionmajor" class="dfn-panel" data-for="dom-usbdevice-deviceversionmajor" id="infopanel-for-dom-usbdevice-deviceversionmajor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-deviceversionmajor" style="display:none">Info about the 'deviceVersionMajor' definition.</span><b><a href="#dom-usbdevice-deviceversionmajor">#dom-usbdevice-deviceversionmajor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-deviceversionmajor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-deviceversionminor">
-   <b><a href="#dom-usbdevice-deviceversionminor">#dom-usbdevice-deviceversionminor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-deviceversionminor" class="dfn-panel" data-for="dom-usbdevice-deviceversionminor" id="infopanel-for-dom-usbdevice-deviceversionminor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-deviceversionminor" style="display:none">Info about the 'deviceVersionMinor' definition.</span><b><a href="#dom-usbdevice-deviceversionminor">#dom-usbdevice-deviceversionminor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-deviceversionminor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-deviceversionsubminor">
-   <b><a href="#dom-usbdevice-deviceversionsubminor">#dom-usbdevice-deviceversionsubminor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-deviceversionsubminor" class="dfn-panel" data-for="dom-usbdevice-deviceversionsubminor" id="infopanel-for-dom-usbdevice-deviceversionsubminor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-deviceversionsubminor" style="display:none">Info about the 'deviceVersionSubminor' definition.</span><b><a href="#dom-usbdevice-deviceversionsubminor">#dom-usbdevice-deviceversionsubminor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-deviceversionsubminor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-manufacturername">
-   <b><a href="#dom-usbdevice-manufacturername">#dom-usbdevice-manufacturername</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-manufacturername" class="dfn-panel" data-for="dom-usbdevice-manufacturername" id="infopanel-for-dom-usbdevice-manufacturername" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-manufacturername" style="display:none">Info about the 'manufacturerName' definition.</span><b><a href="#dom-usbdevice-manufacturername">#dom-usbdevice-manufacturername</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-manufacturername">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-productname">
-   <b><a href="#dom-usbdevice-productname">#dom-usbdevice-productname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-productname" class="dfn-panel" data-for="dom-usbdevice-productname" id="infopanel-for-dom-usbdevice-productname" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-productname" style="display:none">Info about the 'productName' definition.</span><b><a href="#dom-usbdevice-productname">#dom-usbdevice-productname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-productname">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-serialnumber">
-   <b><a href="#dom-usbdevice-serialnumber">#dom-usbdevice-serialnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-serialnumber" class="dfn-panel" data-for="dom-usbdevice-serialnumber" id="infopanel-for-dom-usbdevice-serialnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-serialnumber" style="display:none">Info about the 'serialNumber' definition.</span><b><a href="#dom-usbdevice-serialnumber">#dom-usbdevice-serialnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-serialnumber">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-configuration">
-   <b><a href="#dom-usbdevice-configuration">#dom-usbdevice-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-configuration" class="dfn-panel" data-for="dom-usbdevice-configuration" id="infopanel-for-dom-usbdevice-configuration" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-configuration" style="display:none">Info about the 'configuration' definition.</span><b><a href="#dom-usbdevice-configuration">#dom-usbdevice-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-configuration">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-configuration①">(2)</a> <a href="#ref-for-dom-usbdevice-configuration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-configurations">
-   <b><a href="#dom-usbdevice-configurations">#dom-usbdevice-configurations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-configurations" class="dfn-panel" data-for="dom-usbdevice-configurations" id="infopanel-for-dom-usbdevice-configurations" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-configurations" style="display:none">Info about the 'configurations' definition.</span><b><a href="#dom-usbdevice-configurations">#dom-usbdevice-configurations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-configurations">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-configurations①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-opened">
-   <b><a href="#dom-usbdevice-opened">#dom-usbdevice-opened</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-opened" class="dfn-panel" data-for="dom-usbdevice-opened" id="infopanel-for-dom-usbdevice-opened" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-opened" style="display:none">Info about the 'opened' definition.</span><b><a href="#dom-usbdevice-opened">#dom-usbdevice-opened</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-opened">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-opened①">(2)</a> <a href="#ref-for-dom-usbdevice-opened②">(3)</a> <a href="#ref-for-dom-usbdevice-opened③">(4)</a> <a href="#ref-for-dom-usbdevice-opened④">(5)</a> <a href="#ref-for-dom-usbdevice-opened⑤">(6)</a> <a href="#ref-for-dom-usbdevice-opened⑥">(7)</a> <a href="#ref-for-dom-usbdevice-opened⑦">(8)</a> <a href="#ref-for-dom-usbdevice-opened⑧">(9)</a> <a href="#ref-for-dom-usbdevice-opened⑨">(10)</a> <a href="#ref-for-dom-usbdevice-opened①⓪">(11)</a> <a href="#ref-for-dom-usbdevice-opened①①">(12)</a> <a href="#ref-for-dom-usbdevice-opened①②">(13)</a> <a href="#ref-for-dom-usbdevice-opened①③">(14)</a> <a href="#ref-for-dom-usbdevice-opened①④">(15)</a> <a href="#ref-for-dom-usbdevice-opened①⑤">(16)</a> <a href="#ref-for-dom-usbdevice-opened①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-open">
-   <b><a href="#dom-usbdevice-open">#dom-usbdevice-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-open" class="dfn-panel" data-for="dom-usbdevice-open" id="infopanel-for-dom-usbdevice-open" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-open" style="display:none">Info about the 'open' definition.</span><b><a href="#dom-usbdevice-open">#dom-usbdevice-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-open">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-open①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-close">
-   <b><a href="#dom-usbdevice-close">#dom-usbdevice-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-close" class="dfn-panel" data-for="dom-usbdevice-close" id="infopanel-for-dom-usbdevice-close" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-close" style="display:none">Info about the 'close' definition.</span><b><a href="#dom-usbdevice-close">#dom-usbdevice-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-close">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-close①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-selectconfiguration">
-   <b><a href="#dom-usbdevice-selectconfiguration">#dom-usbdevice-selectconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-selectconfiguration" class="dfn-panel" data-for="dom-usbdevice-selectconfiguration" id="infopanel-for-dom-usbdevice-selectconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-selectconfiguration" style="display:none">Info about the 'selectConfiguration' definition.</span><b><a href="#dom-usbdevice-selectconfiguration">#dom-usbdevice-selectconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-selectconfiguration">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-selectconfiguration①">(2)</a> <a href="#ref-for-dom-usbdevice-selectconfiguration②">(3)</a>
     <li><a href="#ref-for-dom-usbdevice-selectconfiguration③">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-claiminterface">
-   <b><a href="#dom-usbdevice-claiminterface">#dom-usbdevice-claiminterface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-claiminterface" class="dfn-panel" data-for="dom-usbdevice-claiminterface" id="infopanel-for-dom-usbdevice-claiminterface" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-claiminterface" style="display:none">Info about the 'claimInterface' definition.</span><b><a href="#dom-usbdevice-claiminterface">#dom-usbdevice-claiminterface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-claiminterface">3.1. Abusing Access to a Device</a>
     <li><a href="#ref-for-dom-usbdevice-claiminterface①">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-claiminterface②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-releaseinterface">
-   <b><a href="#dom-usbdevice-releaseinterface">#dom-usbdevice-releaseinterface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-releaseinterface" class="dfn-panel" data-for="dom-usbdevice-releaseinterface" id="infopanel-for-dom-usbdevice-releaseinterface" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-releaseinterface" style="display:none">Info about the 'releaseInterface' definition.</span><b><a href="#dom-usbdevice-releaseinterface">#dom-usbdevice-releaseinterface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-releaseinterface">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-releaseinterface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-selectalternateinterface">
-   <b><a href="#dom-usbdevice-selectalternateinterface">#dom-usbdevice-selectalternateinterface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-selectalternateinterface" class="dfn-panel" data-for="dom-usbdevice-selectalternateinterface" id="infopanel-for-dom-usbdevice-selectalternateinterface" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-selectalternateinterface" style="display:none">Info about the 'selectAlternateInterface' definition.</span><b><a href="#dom-usbdevice-selectalternateinterface">#dom-usbdevice-selectalternateinterface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-selectalternateinterface">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbdevice-selectalternateinterface①">6.3. Interfaces</a> <a href="#ref-for-dom-usbdevice-selectalternateinterface②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-controltransferin">
-   <b><a href="#dom-usbdevice-controltransferin">#dom-usbdevice-controltransferin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-controltransferin" class="dfn-panel" data-for="dom-usbdevice-controltransferin" id="infopanel-for-dom-usbdevice-controltransferin" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-controltransferin" style="display:none">Info about the 'controlTransferIn' definition.</span><b><a href="#dom-usbdevice-controltransferin">#dom-usbdevice-controltransferin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-controltransferin">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-controltransferout">
-   <b><a href="#dom-usbdevice-controltransferout">#dom-usbdevice-controltransferout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-controltransferout" class="dfn-panel" data-for="dom-usbdevice-controltransferout" id="infopanel-for-dom-usbdevice-controltransferout" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-controltransferout" style="display:none">Info about the 'controlTransferOut' definition.</span><b><a href="#dom-usbdevice-controltransferout">#dom-usbdevice-controltransferout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-controltransferout">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-controltransferout①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-clearhalt">
-   <b><a href="#dom-usbdevice-clearhalt">#dom-usbdevice-clearhalt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-clearhalt" class="dfn-panel" data-for="dom-usbdevice-clearhalt" id="infopanel-for-dom-usbdevice-clearhalt" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-clearhalt" style="display:none">Info about the 'clearHalt' definition.</span><b><a href="#dom-usbdevice-clearhalt">#dom-usbdevice-clearhalt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-clearhalt">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-clearhalt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-transferin">
-   <b><a href="#dom-usbdevice-transferin">#dom-usbdevice-transferin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-transferin" class="dfn-panel" data-for="dom-usbdevice-transferin" id="infopanel-for-dom-usbdevice-transferin" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-transferin" style="display:none">Info about the 'transferIn' definition.</span><b><a href="#dom-usbdevice-transferin">#dom-usbdevice-transferin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-transferin">6. Device Usage</a> <a href="#ref-for-dom-usbdevice-transferin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-transferout">
-   <b><a href="#dom-usbdevice-transferout">#dom-usbdevice-transferout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-transferout" class="dfn-panel" data-for="dom-usbdevice-transferout" id="infopanel-for-dom-usbdevice-transferout" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-transferout" style="display:none">Info about the 'transferOut' definition.</span><b><a href="#dom-usbdevice-transferout">#dom-usbdevice-transferout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-transferout">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-isochronoustransferin">
-   <b><a href="#dom-usbdevice-isochronoustransferin">#dom-usbdevice-isochronoustransferin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-isochronoustransferin" class="dfn-panel" data-for="dom-usbdevice-isochronoustransferin" id="infopanel-for-dom-usbdevice-isochronoustransferin" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-isochronoustransferin" style="display:none">Info about the 'isochronousTransferIn' definition.</span><b><a href="#dom-usbdevice-isochronoustransferin">#dom-usbdevice-isochronoustransferin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-isochronoustransferin">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-isochronoustransferout">
-   <b><a href="#dom-usbdevice-isochronoustransferout">#dom-usbdevice-isochronoustransferout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-isochronoustransferout" class="dfn-panel" data-for="dom-usbdevice-isochronoustransferout" id="infopanel-for-dom-usbdevice-isochronoustransferout" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-isochronoustransferout" style="display:none">Info about the 'isochronousTransferOut' definition.</span><b><a href="#dom-usbdevice-isochronoustransferout">#dom-usbdevice-isochronoustransferout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-isochronoustransferout">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevice-reset">
-   <b><a href="#dom-usbdevice-reset">#dom-usbdevice-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevice-reset" class="dfn-panel" data-for="dom-usbdevice-reset" id="infopanel-for-dom-usbdevice-reset" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevice-reset" style="display:none">Info about the 'reset' definition.</span><b><a href="#dom-usbdevice-reset">#dom-usbdevice-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-reset">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-usbrequesttype">
-   <b><a href="#enumdef-usbrequesttype">#enumdef-usbrequesttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-usbrequesttype" class="dfn-panel" data-for="enumdef-usbrequesttype" id="infopanel-for-enumdef-usbrequesttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-usbrequesttype" style="display:none">Info about the 'USBRequestType' definition.</span><b><a href="#enumdef-usbrequesttype">#enumdef-usbrequesttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbrequesttype">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbrequesttype-vendor">
-   <b><a href="#dom-usbrequesttype-vendor">#dom-usbrequesttype-vendor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbrequesttype-vendor" class="dfn-panel" data-for="dom-usbrequesttype-vendor" id="infopanel-for-dom-usbrequesttype-vendor" role="dialog">
+   <span id="infopaneltitle-for-dom-usbrequesttype-vendor" style="display:none">Info about the '"vendor"' definition.</span><b><a href="#dom-usbrequesttype-vendor">#dom-usbrequesttype-vendor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbrequesttype-vendor">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-usbrecipient">
-   <b><a href="#enumdef-usbrecipient">#enumdef-usbrecipient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-usbrecipient" class="dfn-panel" data-for="enumdef-usbrecipient" id="infopanel-for-enumdef-usbrecipient" role="dialog">
+   <span id="infopaneltitle-for-enumdef-usbrecipient" style="display:none">Info about the 'USBRecipient' definition.</span><b><a href="#enumdef-usbrecipient">#enumdef-usbrecipient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbrecipient">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbrecipient-interface">
-   <b><a href="#dom-usbrecipient-interface">#dom-usbrecipient-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbrecipient-interface" class="dfn-panel" data-for="dom-usbrecipient-interface" id="infopanel-for-dom-usbrecipient-interface" role="dialog">
+   <span id="infopaneltitle-for-dom-usbrecipient-interface" style="display:none">Info about the '"interface"' definition.</span><b><a href="#dom-usbrecipient-interface">#dom-usbrecipient-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbrecipient-interface">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbrecipient-interface①">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbrecipient-endpoint">
-   <b><a href="#dom-usbrecipient-endpoint">#dom-usbrecipient-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbrecipient-endpoint" class="dfn-panel" data-for="dom-usbrecipient-endpoint" id="infopanel-for-dom-usbrecipient-endpoint" role="dialog">
+   <span id="infopaneltitle-for-dom-usbrecipient-endpoint" style="display:none">Info about the '"endpoint"' definition.</span><b><a href="#dom-usbrecipient-endpoint">#dom-usbrecipient-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbrecipient-endpoint">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-usbtransferstatus">
-   <b><a href="#enumdef-usbtransferstatus">#enumdef-usbtransferstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-usbtransferstatus" class="dfn-panel" data-for="enumdef-usbtransferstatus" id="infopanel-for-enumdef-usbtransferstatus" role="dialog">
+   <span id="infopaneltitle-for-enumdef-usbtransferstatus" style="display:none">Info about the 'USBTransferStatus' definition.</span><b><a href="#enumdef-usbtransferstatus">#enumdef-usbtransferstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbtransferstatus">6.1. Transfers</a> <a href="#ref-for-enumdef-usbtransferstatus①">(2)</a> <a href="#ref-for-enumdef-usbtransferstatus②">(3)</a> <a href="#ref-for-enumdef-usbtransferstatus③">(4)</a> <a href="#ref-for-enumdef-usbtransferstatus④">(5)</a> <a href="#ref-for-enumdef-usbtransferstatus⑤">(6)</a> <a href="#ref-for-enumdef-usbtransferstatus⑥">(7)</a> <a href="#ref-for-enumdef-usbtransferstatus⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtransferstatus-ok">
-   <b><a href="#dom-usbtransferstatus-ok">#dom-usbtransferstatus-ok</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtransferstatus-ok" class="dfn-panel" data-for="dom-usbtransferstatus-ok" id="infopanel-for-dom-usbtransferstatus-ok" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtransferstatus-ok" style="display:none">Info about the '"ok"' definition.</span><b><a href="#dom-usbtransferstatus-ok">#dom-usbtransferstatus-ok</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtransferstatus-ok">6. Device Usage</a> <a href="#ref-for-dom-usbtransferstatus-ok①">(2)</a> <a href="#ref-for-dom-usbtransferstatus-ok②">(3)</a> <a href="#ref-for-dom-usbtransferstatus-ok③">(4)</a> <a href="#ref-for-dom-usbtransferstatus-ok④">(5)</a> <a href="#ref-for-dom-usbtransferstatus-ok⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtransferstatus-stall">
-   <b><a href="#dom-usbtransferstatus-stall">#dom-usbtransferstatus-stall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtransferstatus-stall" class="dfn-panel" data-for="dom-usbtransferstatus-stall" id="infopanel-for-dom-usbtransferstatus-stall" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtransferstatus-stall" style="display:none">Info about the '"stall"' definition.</span><b><a href="#dom-usbtransferstatus-stall">#dom-usbtransferstatus-stall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtransferstatus-stall">6. Device Usage</a> <a href="#ref-for-dom-usbtransferstatus-stall①">(2)</a> <a href="#ref-for-dom-usbtransferstatus-stall②">(3)</a> <a href="#ref-for-dom-usbtransferstatus-stall③">(4)</a> <a href="#ref-for-dom-usbtransferstatus-stall④">(5)</a> <a href="#ref-for-dom-usbtransferstatus-stall⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtransferstatus-babble">
-   <b><a href="#dom-usbtransferstatus-babble">#dom-usbtransferstatus-babble</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtransferstatus-babble" class="dfn-panel" data-for="dom-usbtransferstatus-babble" id="infopanel-for-dom-usbtransferstatus-babble" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtransferstatus-babble" style="display:none">Info about the '"babble"' definition.</span><b><a href="#dom-usbtransferstatus-babble">#dom-usbtransferstatus-babble</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtransferstatus-babble">6. Device Usage</a> <a href="#ref-for-dom-usbtransferstatus-babble①">(2)</a> <a href="#ref-for-dom-usbtransferstatus-babble②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbcontroltransferparameters">
-   <b><a href="#dictdef-usbcontroltransferparameters">#dictdef-usbcontroltransferparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbcontroltransferparameters" class="dfn-panel" data-for="dictdef-usbcontroltransferparameters" id="infopanel-for-dictdef-usbcontroltransferparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbcontroltransferparameters" style="display:none">Info about the 'USBControlTransferParameters' definition.</span><b><a href="#dictdef-usbcontroltransferparameters">#dictdef-usbcontroltransferparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbcontroltransferparameters">6. Device Usage</a> <a href="#ref-for-dictdef-usbcontroltransferparameters①">(2)</a>
     <li><a href="#ref-for-dictdef-usbcontroltransferparameters②">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbcontroltransferparameters-requesttype">
-   <b><a href="#dom-usbcontroltransferparameters-requesttype">#dom-usbcontroltransferparameters-requesttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbcontroltransferparameters-requesttype" class="dfn-panel" data-for="dom-usbcontroltransferparameters-requesttype" id="infopanel-for-dom-usbcontroltransferparameters-requesttype" role="dialog">
+   <span id="infopaneltitle-for-dom-usbcontroltransferparameters-requesttype" style="display:none">Info about the 'requestType' definition.</span><b><a href="#dom-usbcontroltransferparameters-requesttype">#dom-usbcontroltransferparameters-requesttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-requesttype">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-requesttype①">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbcontroltransferparameters-recipient">
-   <b><a href="#dom-usbcontroltransferparameters-recipient">#dom-usbcontroltransferparameters-recipient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbcontroltransferparameters-recipient" class="dfn-panel" data-for="dom-usbcontroltransferparameters-recipient" id="infopanel-for-dom-usbcontroltransferparameters-recipient" role="dialog">
+   <span id="infopaneltitle-for-dom-usbcontroltransferparameters-recipient" style="display:none">Info about the 'recipient' definition.</span><b><a href="#dom-usbcontroltransferparameters-recipient">#dom-usbcontroltransferparameters-recipient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-recipient">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-recipient①">6.1. Transfers</a> <a href="#ref-for-dom-usbcontroltransferparameters-recipient②">(2)</a> <a href="#ref-for-dom-usbcontroltransferparameters-recipient③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbcontroltransferparameters-request">
-   <b><a href="#dom-usbcontroltransferparameters-request">#dom-usbcontroltransferparameters-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbcontroltransferparameters-request" class="dfn-panel" data-for="dom-usbcontroltransferparameters-request" id="infopanel-for-dom-usbcontroltransferparameters-request" role="dialog">
+   <span id="infopaneltitle-for-dom-usbcontroltransferparameters-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-usbcontroltransferparameters-request">#dom-usbcontroltransferparameters-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-request">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-request①">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbcontroltransferparameters-value">
-   <b><a href="#dom-usbcontroltransferparameters-value">#dom-usbcontroltransferparameters-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbcontroltransferparameters-value" class="dfn-panel" data-for="dom-usbcontroltransferparameters-value" id="infopanel-for-dom-usbcontroltransferparameters-value" role="dialog">
+   <span id="infopaneltitle-for-dom-usbcontroltransferparameters-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-usbcontroltransferparameters-value">#dom-usbcontroltransferparameters-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-value">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-value①">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbcontroltransferparameters-index">
-   <b><a href="#dom-usbcontroltransferparameters-index">#dom-usbcontroltransferparameters-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbcontroltransferparameters-index" class="dfn-panel" data-for="dom-usbcontroltransferparameters-index" id="infopanel-for-dom-usbcontroltransferparameters-index" role="dialog">
+   <span id="infopaneltitle-for-dom-usbcontroltransferparameters-index" style="display:none">Info about the 'index' definition.</span><b><a href="#dom-usbcontroltransferparameters-index">#dom-usbcontroltransferparameters-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-index">6. Device Usage</a>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-index①">6.1. Transfers</a> <a href="#ref-for-dom-usbcontroltransferparameters-index②">(2)</a> <a href="#ref-for-dom-usbcontroltransferparameters-index③">(3)</a> <a href="#ref-for-dom-usbcontroltransferparameters-index④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbintransferresult">
-   <b><a href="#usbintransferresult">#usbintransferresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbintransferresult" class="dfn-panel" data-for="usbintransferresult" id="infopanel-for-usbintransferresult" role="dialog">
+   <span id="infopaneltitle-for-usbintransferresult" style="display:none">Info about the 'USBInTransferResult' definition.</span><b><a href="#usbintransferresult">#usbintransferresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbintransferresult">6. Device Usage</a> <a href="#ref-for-usbintransferresult①">(2)</a> <a href="#ref-for-usbintransferresult②">(3)</a> <a href="#ref-for-usbintransferresult③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbintransferresult-data">
-   <b><a href="#dom-usbintransferresult-data">#dom-usbintransferresult-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbintransferresult-data" class="dfn-panel" data-for="dom-usbintransferresult-data" id="infopanel-for-dom-usbintransferresult-data" role="dialog">
+   <span id="infopaneltitle-for-dom-usbintransferresult-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-usbintransferresult-data">#dom-usbintransferresult-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbintransferresult-data">6. Device Usage</a> <a href="#ref-for-dom-usbintransferresult-data①">(2)</a> <a href="#ref-for-dom-usbintransferresult-data②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbintransferresult-status">
-   <b><a href="#dom-usbintransferresult-status">#dom-usbintransferresult-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbintransferresult-status" class="dfn-panel" data-for="dom-usbintransferresult-status" id="infopanel-for-dom-usbintransferresult-status" role="dialog">
+   <span id="infopaneltitle-for-dom-usbintransferresult-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-usbintransferresult-status">#dom-usbintransferresult-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbintransferresult-status">6. Device Usage</a> <a href="#ref-for-dom-usbintransferresult-status①">(2)</a> <a href="#ref-for-dom-usbintransferresult-status②">(3)</a> <a href="#ref-for-dom-usbintransferresult-status③">(4)</a> <a href="#ref-for-dom-usbintransferresult-status④">(5)</a> <a href="#ref-for-dom-usbintransferresult-status⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbouttransferresult">
-   <b><a href="#usbouttransferresult">#usbouttransferresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbouttransferresult" class="dfn-panel" data-for="usbouttransferresult" id="infopanel-for-usbouttransferresult" role="dialog">
+   <span id="infopaneltitle-for-usbouttransferresult" style="display:none">Info about the 'USBOutTransferResult' definition.</span><b><a href="#usbouttransferresult">#usbouttransferresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbouttransferresult">6. Device Usage</a> <a href="#ref-for-usbouttransferresult①">(2)</a> <a href="#ref-for-usbouttransferresult②">(3)</a> <a href="#ref-for-usbouttransferresult③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbouttransferresult-byteswritten">
-   <b><a href="#dom-usbouttransferresult-byteswritten">#dom-usbouttransferresult-byteswritten</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbouttransferresult-byteswritten" class="dfn-panel" data-for="dom-usbouttransferresult-byteswritten" id="infopanel-for-dom-usbouttransferresult-byteswritten" role="dialog">
+   <span id="infopaneltitle-for-dom-usbouttransferresult-byteswritten" style="display:none">Info about the 'bytesWritten' definition.</span><b><a href="#dom-usbouttransferresult-byteswritten">#dom-usbouttransferresult-byteswritten</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbouttransferresult-byteswritten">6. Device Usage</a> <a href="#ref-for-dom-usbouttransferresult-byteswritten①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbouttransferresult-status">
-   <b><a href="#dom-usbouttransferresult-status">#dom-usbouttransferresult-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbouttransferresult-status" class="dfn-panel" data-for="dom-usbouttransferresult-status" id="infopanel-for-dom-usbouttransferresult-status" role="dialog">
+   <span id="infopaneltitle-for-dom-usbouttransferresult-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-usbouttransferresult-status">#dom-usbouttransferresult-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbouttransferresult-status">6. Device Usage</a> <a href="#ref-for-dom-usbouttransferresult-status①">(2)</a> <a href="#ref-for-dom-usbouttransferresult-status②">(3)</a> <a href="#ref-for-dom-usbouttransferresult-status③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbisochronousintransferpacket">
-   <b><a href="#usbisochronousintransferpacket">#usbisochronousintransferpacket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbisochronousintransferpacket" class="dfn-panel" data-for="usbisochronousintransferpacket" id="infopanel-for-usbisochronousintransferpacket" role="dialog">
+   <span id="infopaneltitle-for-usbisochronousintransferpacket" style="display:none">Info about the 'USBIsochronousInTransferPacket' definition.</span><b><a href="#usbisochronousintransferpacket">#usbisochronousintransferpacket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbisochronousintransferpacket">6. Device Usage</a>
     <li><a href="#ref-for-usbisochronousintransferpacket①">6.1. Transfers</a> <a href="#ref-for-usbisochronousintransferpacket②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousintransferpacket-data">
-   <b><a href="#dom-usbisochronousintransferpacket-data">#dom-usbisochronousintransferpacket-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousintransferpacket-data" class="dfn-panel" data-for="dom-usbisochronousintransferpacket-data" id="infopanel-for-dom-usbisochronousintransferpacket-data" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousintransferpacket-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-usbisochronousintransferpacket-data">#dom-usbisochronousintransferpacket-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousintransferpacket-data">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousintransferpacket-status">
-   <b><a href="#dom-usbisochronousintransferpacket-status">#dom-usbisochronousintransferpacket-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousintransferpacket-status" class="dfn-panel" data-for="dom-usbisochronousintransferpacket-status" id="infopanel-for-dom-usbisochronousintransferpacket-status" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousintransferpacket-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-usbisochronousintransferpacket-status">#dom-usbisochronousintransferpacket-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousintransferpacket-status">6. Device Usage</a> <a href="#ref-for-dom-usbisochronousintransferpacket-status①">(2)</a> <a href="#ref-for-dom-usbisochronousintransferpacket-status②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbisochronousintransferresult">
-   <b><a href="#usbisochronousintransferresult">#usbisochronousintransferresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbisochronousintransferresult" class="dfn-panel" data-for="usbisochronousintransferresult" id="infopanel-for-usbisochronousintransferresult" role="dialog">
+   <span id="infopaneltitle-for-usbisochronousintransferresult" style="display:none">Info about the 'USBIsochronousInTransferResult' definition.</span><b><a href="#usbisochronousintransferresult">#usbisochronousintransferresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbisochronousintransferresult">6. Device Usage</a> <a href="#ref-for-usbisochronousintransferresult①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousintransferresult-data">
-   <b><a href="#dom-usbisochronousintransferresult-data">#dom-usbisochronousintransferresult-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousintransferresult-data" class="dfn-panel" data-for="dom-usbisochronousintransferresult-data" id="infopanel-for-dom-usbisochronousintransferresult-data" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousintransferresult-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-usbisochronousintransferresult-data">#dom-usbisochronousintransferresult-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousintransferresult-data">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousintransferresult-packets">
-   <b><a href="#dom-usbisochronousintransferresult-packets">#dom-usbisochronousintransferresult-packets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousintransferresult-packets" class="dfn-panel" data-for="dom-usbisochronousintransferresult-packets" id="infopanel-for-dom-usbisochronousintransferresult-packets" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousintransferresult-packets" style="display:none">Info about the 'packets' definition.</span><b><a href="#dom-usbisochronousintransferresult-packets">#dom-usbisochronousintransferresult-packets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousintransferresult-packets">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbisochronousouttransferpacket">
-   <b><a href="#usbisochronousouttransferpacket">#usbisochronousouttransferpacket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbisochronousouttransferpacket" class="dfn-panel" data-for="usbisochronousouttransferpacket" id="infopanel-for-usbisochronousouttransferpacket" role="dialog">
+   <span id="infopaneltitle-for-usbisochronousouttransferpacket" style="display:none">Info about the 'USBIsochronousOutTransferPacket' definition.</span><b><a href="#usbisochronousouttransferpacket">#usbisochronousouttransferpacket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbisochronousouttransferpacket">6. Device Usage</a>
     <li><a href="#ref-for-usbisochronousouttransferpacket①">6.1. Transfers</a> <a href="#ref-for-usbisochronousouttransferpacket②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousouttransferpacket-byteswritten">
-   <b><a href="#dom-usbisochronousouttransferpacket-byteswritten">#dom-usbisochronousouttransferpacket-byteswritten</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousouttransferpacket-byteswritten" class="dfn-panel" data-for="dom-usbisochronousouttransferpacket-byteswritten" id="infopanel-for-dom-usbisochronousouttransferpacket-byteswritten" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousouttransferpacket-byteswritten" style="display:none">Info about the 'bytesWritten' definition.</span><b><a href="#dom-usbisochronousouttransferpacket-byteswritten">#dom-usbisochronousouttransferpacket-byteswritten</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousouttransferpacket-byteswritten">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousouttransferpacket-status">
-   <b><a href="#dom-usbisochronousouttransferpacket-status">#dom-usbisochronousouttransferpacket-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousouttransferpacket-status" class="dfn-panel" data-for="dom-usbisochronousouttransferpacket-status" id="infopanel-for-dom-usbisochronousouttransferpacket-status" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousouttransferpacket-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-usbisochronousouttransferpacket-status">#dom-usbisochronousouttransferpacket-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousouttransferpacket-status">6. Device Usage</a> <a href="#ref-for-dom-usbisochronousouttransferpacket-status①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbisochronousouttransferresult">
-   <b><a href="#usbisochronousouttransferresult">#usbisochronousouttransferresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbisochronousouttransferresult" class="dfn-panel" data-for="usbisochronousouttransferresult" id="infopanel-for-usbisochronousouttransferresult" role="dialog">
+   <span id="infopaneltitle-for-usbisochronousouttransferresult" style="display:none">Info about the 'USBIsochronousOutTransferResult' definition.</span><b><a href="#usbisochronousouttransferresult">#usbisochronousouttransferresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbisochronousouttransferresult">6. Device Usage</a> <a href="#ref-for-usbisochronousouttransferresult①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbisochronousouttransferresult-packets">
-   <b><a href="#dom-usbisochronousouttransferresult-packets">#dom-usbisochronousouttransferresult-packets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbisochronousouttransferresult-packets" class="dfn-panel" data-for="dom-usbisochronousouttransferresult-packets" id="infopanel-for-dom-usbisochronousouttransferresult-packets" role="dialog">
+   <span id="infopaneltitle-for-dom-usbisochronousouttransferresult-packets" style="display:none">Info about the 'packets' definition.</span><b><a href="#dom-usbisochronousouttransferresult-packets">#dom-usbisochronousouttransferresult-packets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbisochronousouttransferresult-packets">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="control-transfer">
-   <b><a href="#control-transfer">#control-transfer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-control-transfer" class="dfn-panel" data-for="control-transfer" id="infopanel-for-control-transfer" role="dialog">
+   <span id="infopaneltitle-for-control-transfer" style="display:none">Info about the 'control transfer' definition.</span><b><a href="#control-transfer">#control-transfer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-control-transfer">4.2. WebUSB Device Requests</a> <a href="#ref-for-control-transfer①">(2)</a>
     <li><a href="#ref-for-control-transfer②">6. Device Usage</a> <a href="#ref-for-control-transfer③">(2)</a> <a href="#ref-for-control-transfer④">(3)</a> <a href="#ref-for-control-transfer⑤">(4)</a> <a href="#ref-for-control-transfer⑥">(5)</a> <a href="#ref-for-control-transfer⑦">(6)</a>
@@ -4910,289 +4913,289 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-control-transfer⑨">9.2. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="setup-stage">
-   <b><a href="#setup-stage">#setup-stage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-setup-stage" class="dfn-panel" data-for="setup-stage" id="infopanel-for-setup-stage" role="dialog">
+   <span id="infopaneltitle-for-setup-stage" style="display:none">Info about the 'setup stage' definition.</span><b><a href="#setup-stage">#setup-stage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-setup-stage">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="setup-packet">
-   <b><a href="#setup-packet">#setup-packet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-setup-packet" class="dfn-panel" data-for="setup-packet" id="infopanel-for-setup-packet" role="dialog">
+   <span id="infopaneltitle-for-setup-packet" style="display:none">Info about the 'setup packet' definition.</span><b><a href="#setup-packet">#setup-packet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-setup-packet">6. Device Usage</a>
     <li><a href="#ref-for-setup-packet①">6.1. Transfers</a> <a href="#ref-for-setup-packet②">(2)</a> <a href="#ref-for-setup-packet③">(3)</a> <a href="#ref-for-setup-packet④">(4)</a>
     <li><a href="#ref-for-setup-packet⑤">9.2. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-stage">
-   <b><a href="#data-stage">#data-stage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-stage" class="dfn-panel" data-for="data-stage" id="infopanel-for-data-stage" role="dialog">
+   <span id="infopaneltitle-for-data-stage" style="display:none">Info about the 'data stage' definition.</span><b><a href="#data-stage">#data-stage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-stage">6. Device Usage</a>
     <li><a href="#ref-for-data-stage①">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="status-stage">
-   <b><a href="#status-stage">#status-stage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-status-stage" class="dfn-panel" data-for="status-stage" id="infopanel-for-status-stage" role="dialog">
+   <span id="infopaneltitle-for-status-stage" style="display:none">Info about the 'status stage' definition.</span><b><a href="#status-stage">#status-stage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-status-stage">6.1. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-the-validity-of-the-control-transfer-parameters">
-   <b><a href="#check-the-validity-of-the-control-transfer-parameters">#check-the-validity-of-the-control-transfer-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-the-validity-of-the-control-transfer-parameters" class="dfn-panel" data-for="check-the-validity-of-the-control-transfer-parameters" id="infopanel-for-check-the-validity-of-the-control-transfer-parameters" role="dialog">
+   <span id="infopaneltitle-for-check-the-validity-of-the-control-transfer-parameters" style="display:none">Info about the 'check the validity of the control transfer parameters' definition.</span><b><a href="#check-the-validity-of-the-control-transfer-parameters">#check-the-validity-of-the-control-transfer-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-validity-of-the-control-transfer-parameters">6. Device Usage</a> <a href="#ref-for-check-the-validity-of-the-control-transfer-parameters①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbconfiguration">
-   <b><a href="#usbconfiguration">#usbconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbconfiguration" class="dfn-panel" data-for="usbconfiguration" id="infopanel-for-usbconfiguration" role="dialog">
+   <span id="infopaneltitle-for-usbconfiguration" style="display:none">Info about the 'USBConfiguration' definition.</span><b><a href="#usbconfiguration">#usbconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbconfiguration">6. Device Usage</a> <a href="#ref-for-usbconfiguration①">(2)</a>
     <li><a href="#ref-for-usbconfiguration②">6.3. Interfaces</a> <a href="#ref-for-usbconfiguration③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbconfiguration-configurationvalue">
-   <b><a href="#dom-usbconfiguration-configurationvalue">#dom-usbconfiguration-configurationvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbconfiguration-configurationvalue" class="dfn-panel" data-for="dom-usbconfiguration-configurationvalue" id="infopanel-for-dom-usbconfiguration-configurationvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-usbconfiguration-configurationvalue" style="display:none">Info about the 'configurationValue' definition.</span><b><a href="#dom-usbconfiguration-configurationvalue">#dom-usbconfiguration-configurationvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbconfiguration-configurationvalue">6.2. Configurations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbconfiguration-configurationname">
-   <b><a href="#dom-usbconfiguration-configurationname">#dom-usbconfiguration-configurationname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbconfiguration-configurationname" class="dfn-panel" data-for="dom-usbconfiguration-configurationname" id="infopanel-for-dom-usbconfiguration-configurationname" role="dialog">
+   <span id="infopaneltitle-for-dom-usbconfiguration-configurationname" style="display:none">Info about the 'configurationName' definition.</span><b><a href="#dom-usbconfiguration-configurationname">#dom-usbconfiguration-configurationname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbconfiguration-configurationname">6.2. Configurations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbconfiguration-interfaces">
-   <b><a href="#dom-usbconfiguration-interfaces">#dom-usbconfiguration-interfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbconfiguration-interfaces" class="dfn-panel" data-for="dom-usbconfiguration-interfaces" id="infopanel-for-dom-usbconfiguration-interfaces" role="dialog">
+   <span id="infopaneltitle-for-dom-usbconfiguration-interfaces" style="display:none">Info about the 'interfaces' definition.</span><b><a href="#dom-usbconfiguration-interfaces">#dom-usbconfiguration-interfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbconfiguration-interfaces">6.2. Configurations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbinterface">
-   <b><a href="#usbinterface">#usbinterface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbinterface" class="dfn-panel" data-for="usbinterface" id="infopanel-for-usbinterface" role="dialog">
+   <span id="infopaneltitle-for-usbinterface" style="display:none">Info about the 'USBInterface' definition.</span><b><a href="#usbinterface">#usbinterface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbinterface">6.2. Configurations</a>
     <li><a href="#ref-for-usbinterface①">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbinterface-interfacenumber">
-   <b><a href="#dom-usbinterface-interfacenumber">#dom-usbinterface-interfacenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbinterface-interfacenumber" class="dfn-panel" data-for="dom-usbinterface-interfacenumber" id="infopanel-for-dom-usbinterface-interfacenumber" role="dialog">
+   <span id="infopaneltitle-for-dom-usbinterface-interfacenumber" style="display:none">Info about the 'interfaceNumber' definition.</span><b><a href="#dom-usbinterface-interfacenumber">#dom-usbinterface-interfacenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbinterface-interfacenumber">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbinterface-alternate">
-   <b><a href="#dom-usbinterface-alternate">#dom-usbinterface-alternate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbinterface-alternate" class="dfn-panel" data-for="dom-usbinterface-alternate" id="infopanel-for-dom-usbinterface-alternate" role="dialog">
+   <span id="infopaneltitle-for-dom-usbinterface-alternate" style="display:none">Info about the 'alternate' definition.</span><b><a href="#dom-usbinterface-alternate">#dom-usbinterface-alternate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbinterface-alternate">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbinterface-alternates">
-   <b><a href="#dom-usbinterface-alternates">#dom-usbinterface-alternates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbinterface-alternates" class="dfn-panel" data-for="dom-usbinterface-alternates" id="infopanel-for-dom-usbinterface-alternates" role="dialog">
+   <span id="infopaneltitle-for-dom-usbinterface-alternates" style="display:none">Info about the 'alternates' definition.</span><b><a href="#dom-usbinterface-alternates">#dom-usbinterface-alternates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbinterface-alternates">6.3. Interfaces</a> <a href="#ref-for-dom-usbinterface-alternates①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbinterface-claimed">
-   <b><a href="#dom-usbinterface-claimed">#dom-usbinterface-claimed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbinterface-claimed" class="dfn-panel" data-for="dom-usbinterface-claimed" id="infopanel-for-dom-usbinterface-claimed" role="dialog">
+   <span id="infopaneltitle-for-dom-usbinterface-claimed" style="display:none">Info about the 'claimed' definition.</span><b><a href="#dom-usbinterface-claimed">#dom-usbinterface-claimed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbinterface-claimed">6. Device Usage</a> <a href="#ref-for-dom-usbinterface-claimed①">(2)</a> <a href="#ref-for-dom-usbinterface-claimed②">(3)</a> <a href="#ref-for-dom-usbinterface-claimed③">(4)</a> <a href="#ref-for-dom-usbinterface-claimed④">(5)</a> <a href="#ref-for-dom-usbinterface-claimed⑤">(6)</a> <a href="#ref-for-dom-usbinterface-claimed⑥">(7)</a> <a href="#ref-for-dom-usbinterface-claimed⑦">(8)</a> <a href="#ref-for-dom-usbinterface-claimed⑧">(9)</a> <a href="#ref-for-dom-usbinterface-claimed⑨">(10)</a>
     <li><a href="#ref-for-dom-usbinterface-claimed①⓪">6.1. Transfers</a> <a href="#ref-for-dom-usbinterface-claimed①①">(2)</a>
     <li><a href="#ref-for-dom-usbinterface-claimed①②">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbalternateinterface">
-   <b><a href="#usbalternateinterface">#usbalternateinterface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbalternateinterface" class="dfn-panel" data-for="usbalternateinterface" id="infopanel-for-usbalternateinterface" role="dialog">
+   <span id="infopaneltitle-for-usbalternateinterface" style="display:none">Info about the 'USBAlternateInterface' definition.</span><b><a href="#usbalternateinterface">#usbalternateinterface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbalternateinterface">6.3. Interfaces</a> <a href="#ref-for-usbalternateinterface①">(2)</a> <a href="#ref-for-usbalternateinterface②">(3)</a> <a href="#ref-for-usbalternateinterface③">(4)</a> <a href="#ref-for-usbalternateinterface④">(5)</a>
     <li><a href="#ref-for-usbalternateinterface⑤">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-alternatesetting">
-   <b><a href="#dom-usbalternateinterface-alternatesetting">#dom-usbalternateinterface-alternatesetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-alternatesetting" class="dfn-panel" data-for="dom-usbalternateinterface-alternatesetting" id="infopanel-for-dom-usbalternateinterface-alternatesetting" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-alternatesetting" style="display:none">Info about the 'alternateSetting' definition.</span><b><a href="#dom-usbalternateinterface-alternatesetting">#dom-usbalternateinterface-alternatesetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-alternatesetting">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-interfaceclass">
-   <b><a href="#dom-usbalternateinterface-interfaceclass">#dom-usbalternateinterface-interfaceclass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-interfaceclass" class="dfn-panel" data-for="dom-usbalternateinterface-interfaceclass" id="infopanel-for-dom-usbalternateinterface-interfaceclass" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-interfaceclass" style="display:none">Info about the 'interfaceClass' definition.</span><b><a href="#dom-usbalternateinterface-interfaceclass">#dom-usbalternateinterface-interfaceclass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-interfaceclass">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-interfacesubclass">
-   <b><a href="#dom-usbalternateinterface-interfacesubclass">#dom-usbalternateinterface-interfacesubclass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-interfacesubclass" class="dfn-panel" data-for="dom-usbalternateinterface-interfacesubclass" id="infopanel-for-dom-usbalternateinterface-interfacesubclass" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-interfacesubclass" style="display:none">Info about the 'interfaceSubclass' definition.</span><b><a href="#dom-usbalternateinterface-interfacesubclass">#dom-usbalternateinterface-interfacesubclass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-interfacesubclass">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-interfaceprotocol">
-   <b><a href="#dom-usbalternateinterface-interfaceprotocol">#dom-usbalternateinterface-interfaceprotocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-interfaceprotocol" class="dfn-panel" data-for="dom-usbalternateinterface-interfaceprotocol" id="infopanel-for-dom-usbalternateinterface-interfaceprotocol" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-interfaceprotocol" style="display:none">Info about the 'interfaceProtocol' definition.</span><b><a href="#dom-usbalternateinterface-interfaceprotocol">#dom-usbalternateinterface-interfaceprotocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-interfaceprotocol">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-interfacename">
-   <b><a href="#dom-usbalternateinterface-interfacename">#dom-usbalternateinterface-interfacename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-interfacename" class="dfn-panel" data-for="dom-usbalternateinterface-interfacename" id="infopanel-for-dom-usbalternateinterface-interfacename" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-interfacename" style="display:none">Info about the 'interfaceName' definition.</span><b><a href="#dom-usbalternateinterface-interfacename">#dom-usbalternateinterface-interfacename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-interfacename">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbalternateinterface-endpoints">
-   <b><a href="#dom-usbalternateinterface-endpoints">#dom-usbalternateinterface-endpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbalternateinterface-endpoints" class="dfn-panel" data-for="dom-usbalternateinterface-endpoints" id="infopanel-for-dom-usbalternateinterface-endpoints" role="dialog">
+   <span id="infopaneltitle-for-dom-usbalternateinterface-endpoints" style="display:none">Info about the 'endpoints' definition.</span><b><a href="#dom-usbalternateinterface-endpoints">#dom-usbalternateinterface-endpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-endpoints">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-configuration">
-   <b><a href="#active-configuration">#active-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-configuration" class="dfn-panel" data-for="active-configuration" id="infopanel-for-active-configuration" role="dialog">
+   <span id="infopaneltitle-for-active-configuration" style="display:none">Info about the 'active configuration' definition.</span><b><a href="#active-configuration">#active-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-configuration">6. Device Usage</a> <a href="#ref-for-active-configuration①">(2)</a> <a href="#ref-for-active-configuration②">(3)</a> <a href="#ref-for-active-configuration③">(4)</a> <a href="#ref-for-active-configuration④">(5)</a> <a href="#ref-for-active-configuration⑤">(6)</a> <a href="#ref-for-active-configuration⑥">(7)</a> <a href="#ref-for-active-configuration⑦">(8)</a> <a href="#ref-for-active-configuration⑧">(9)</a>
     <li><a href="#ref-for-active-configuration⑨">6.1. Transfers</a> <a href="#ref-for-active-configuration①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-usbdirection">
-   <b><a href="#enumdef-usbdirection">#enumdef-usbdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-usbdirection" class="dfn-panel" data-for="enumdef-usbdirection" id="infopanel-for-enumdef-usbdirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-usbdirection" style="display:none">Info about the 'USBDirection' definition.</span><b><a href="#enumdef-usbdirection">#enumdef-usbdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbdirection">6. Device Usage</a>
     <li><a href="#ref-for-enumdef-usbdirection①">6.4. Endpoints</a> <a href="#ref-for-enumdef-usbdirection②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdirection-in">
-   <b><a href="#dom-usbdirection-in">#dom-usbdirection-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdirection-in" class="dfn-panel" data-for="dom-usbdirection-in" id="infopanel-for-dom-usbdirection-in" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdirection-in" style="display:none">Info about the '"in"' definition.</span><b><a href="#dom-usbdirection-in">#dom-usbdirection-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdirection-in">6.1. Transfers</a>
     <li><a href="#ref-for-dom-usbdirection-in①">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdirection-out">
-   <b><a href="#dom-usbdirection-out">#dom-usbdirection-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdirection-out" class="dfn-panel" data-for="dom-usbdirection-out" id="infopanel-for-dom-usbdirection-out" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdirection-out" style="display:none">Info about the '"out"' definition.</span><b><a href="#dom-usbdirection-out">#dom-usbdirection-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdirection-out">6.1. Transfers</a>
     <li><a href="#ref-for-dom-usbdirection-out①">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-usbendpointtype">
-   <b><a href="#enumdef-usbendpointtype">#enumdef-usbendpointtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-usbendpointtype" class="dfn-panel" data-for="enumdef-usbendpointtype" id="infopanel-for-enumdef-usbendpointtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-usbendpointtype" style="display:none">Info about the 'USBEndpointType' definition.</span><b><a href="#enumdef-usbendpointtype">#enumdef-usbendpointtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbendpointtype">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbendpoint">
-   <b><a href="#usbendpoint">#usbendpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbendpoint" class="dfn-panel" data-for="usbendpoint" id="infopanel-for-usbendpoint" role="dialog">
+   <span id="infopaneltitle-for-usbendpoint" style="display:none">Info about the 'USBEndpoint' definition.</span><b><a href="#usbendpoint">#usbendpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbendpoint">6.3. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbendpoint-endpointnumber">
-   <b><a href="#dom-usbendpoint-endpointnumber">#dom-usbendpoint-endpointnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbendpoint-endpointnumber" class="dfn-panel" data-for="dom-usbendpoint-endpointnumber" id="infopanel-for-dom-usbendpoint-endpointnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-usbendpoint-endpointnumber" style="display:none">Info about the 'endpointNumber' definition.</span><b><a href="#dom-usbendpoint-endpointnumber">#dom-usbendpoint-endpointnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbendpoint-endpointnumber">6.4. Endpoints</a> <a href="#ref-for-dom-usbendpoint-endpointnumber①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbendpoint-direction">
-   <b><a href="#dom-usbendpoint-direction">#dom-usbendpoint-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbendpoint-direction" class="dfn-panel" data-for="dom-usbendpoint-direction" id="infopanel-for-dom-usbendpoint-direction" role="dialog">
+   <span id="infopaneltitle-for-dom-usbendpoint-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#dom-usbendpoint-direction">#dom-usbendpoint-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbendpoint-direction">6.4. Endpoints</a> <a href="#ref-for-dom-usbendpoint-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbendpoint-type">
-   <b><a href="#dom-usbendpoint-type">#dom-usbendpoint-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbendpoint-type" class="dfn-panel" data-for="dom-usbendpoint-type" id="infopanel-for-dom-usbendpoint-type" role="dialog">
+   <span id="infopaneltitle-for-dom-usbendpoint-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-usbendpoint-type">#dom-usbendpoint-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbendpoint-type">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbendpoint-packetsize">
-   <b><a href="#dom-usbendpoint-packetsize">#dom-usbendpoint-packetsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbendpoint-packetsize" class="dfn-panel" data-for="dom-usbendpoint-packetsize" id="infopanel-for-dom-usbendpoint-packetsize" role="dialog">
+   <span id="infopaneltitle-for-dom-usbendpoint-packetsize" style="display:none">Info about the 'packetSize' definition.</span><b><a href="#dom-usbendpoint-packetsize">#dom-usbendpoint-packetsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbendpoint-packetsize">6.4. Endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbpermissiondescriptor">
-   <b><a href="#dictdef-usbpermissiondescriptor">#dictdef-usbpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbpermissiondescriptor" class="dfn-panel" data-for="dictdef-usbpermissiondescriptor" id="infopanel-for-dictdef-usbpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbpermissiondescriptor" style="display:none">Info about the 'USBPermissionDescriptor' definition.</span><b><a href="#dictdef-usbpermissiondescriptor">#dictdef-usbpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbpermissiondescriptor">5. Device Enumeration</a>
     <li><a href="#ref-for-dictdef-usbpermissiondescriptor①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbpermissiondescriptor-filters">
-   <b><a href="#dom-usbpermissiondescriptor-filters">#dom-usbpermissiondescriptor-filters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbpermissiondescriptor-filters" class="dfn-panel" data-for="dom-usbpermissiondescriptor-filters" id="infopanel-for-dom-usbpermissiondescriptor-filters" role="dialog">
+   <span id="infopaneltitle-for-dom-usbpermissiondescriptor-filters" style="display:none">Info about the 'filters' definition.</span><b><a href="#dom-usbpermissiondescriptor-filters">#dom-usbpermissiondescriptor-filters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbpermissiondescriptor-filters">5. Device Enumeration</a> <a href="#ref-for-dom-usbpermissiondescriptor-filters①">(2)</a>
     <li><a href="#ref-for-dom-usbpermissiondescriptor-filters②">7.2. Permission API</a> <a href="#ref-for-dom-usbpermissiondescriptor-filters③">(2)</a> <a href="#ref-for-dom-usbpermissiondescriptor-filters④">(3)</a> <a href="#ref-for-dom-usbpermissiondescriptor-filters⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-allowedusbdevice">
-   <b><a href="#dictdef-allowedusbdevice">#dictdef-allowedusbdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-allowedusbdevice" class="dfn-panel" data-for="dictdef-allowedusbdevice" id="infopanel-for-dictdef-allowedusbdevice" role="dialog">
+   <span id="infopaneltitle-for-dictdef-allowedusbdevice" style="display:none">Info about the 'AllowedUSBDevice' definition.</span><b><a href="#dictdef-allowedusbdevice">#dictdef-allowedusbdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-allowedusbdevice">7.2. Permission API</a> <a href="#ref-for-dictdef-allowedusbdevice①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedusbdevice-vendorid">
-   <b><a href="#dom-allowedusbdevice-vendorid">#dom-allowedusbdevice-vendorid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedusbdevice-vendorid" class="dfn-panel" data-for="dom-allowedusbdevice-vendorid" id="infopanel-for-dom-allowedusbdevice-vendorid" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedusbdevice-vendorid" style="display:none">Info about the 'vendorId' definition.</span><b><a href="#dom-allowedusbdevice-vendorid">#dom-allowedusbdevice-vendorid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedusbdevice-vendorid">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedusbdevice-productid">
-   <b><a href="#dom-allowedusbdevice-productid">#dom-allowedusbdevice-productid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedusbdevice-productid" class="dfn-panel" data-for="dom-allowedusbdevice-productid" id="infopanel-for-dom-allowedusbdevice-productid" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedusbdevice-productid" style="display:none">Info about the 'productId' definition.</span><b><a href="#dom-allowedusbdevice-productid">#dom-allowedusbdevice-productid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedusbdevice-productid">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedusbdevice-serialnumber">
-   <b><a href="#dom-allowedusbdevice-serialnumber">#dom-allowedusbdevice-serialnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedusbdevice-serialnumber" class="dfn-panel" data-for="dom-allowedusbdevice-serialnumber" id="infopanel-for-dom-allowedusbdevice-serialnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedusbdevice-serialnumber" style="display:none">Info about the 'serialNumber' definition.</span><b><a href="#dom-allowedusbdevice-serialnumber">#dom-allowedusbdevice-serialnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedusbdevice-serialnumber">5. Device Enumeration</a>
     <li><a href="#ref-for-dom-allowedusbdevice-serialnumber①">5.1. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-usbpermissionstorage">
-   <b><a href="#dictdef-usbpermissionstorage">#dictdef-usbpermissionstorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-usbpermissionstorage" class="dfn-panel" data-for="dictdef-usbpermissionstorage" id="infopanel-for-dictdef-usbpermissionstorage" role="dialog">
+   <span id="infopaneltitle-for-dictdef-usbpermissionstorage" style="display:none">Info about the 'USBPermissionStorage' definition.</span><b><a href="#dictdef-usbpermissionstorage">#dictdef-usbpermissionstorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbpermissionstorage">5. Device Enumeration</a> <a href="#ref-for-dictdef-usbpermissionstorage①">(2)</a> <a href="#ref-for-dictdef-usbpermissionstorage②">(3)</a>
     <li><a href="#ref-for-dictdef-usbpermissionstorage③">5.1. Events</a> <a href="#ref-for-dictdef-usbpermissionstorage④">(2)</a>
     <li><a href="#ref-for-dictdef-usbpermissionstorage⑤">7.2. Permission API</a> <a href="#ref-for-dictdef-usbpermissionstorage⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbpermissionstorage-alloweddevices">
-   <b><a href="#dom-usbpermissionstorage-alloweddevices">#dom-usbpermissionstorage-alloweddevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbpermissionstorage-alloweddevices" class="dfn-panel" data-for="dom-usbpermissionstorage-alloweddevices" id="infopanel-for-dom-usbpermissionstorage-alloweddevices" role="dialog">
+   <span id="infopaneltitle-for-dom-usbpermissionstorage-alloweddevices" style="display:none">Info about the 'allowedDevices' definition.</span><b><a href="#dom-usbpermissionstorage-alloweddevices">#dom-usbpermissionstorage-alloweddevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbpermissionstorage-alloweddevices">5. Device Enumeration</a> <a href="#ref-for-dom-usbpermissionstorage-alloweddevices①">(2)</a> <a href="#ref-for-dom-usbpermissionstorage-alloweddevices②">(3)</a> <a href="#ref-for-dom-usbpermissionstorage-alloweddevices③">(4)</a>
     <li><a href="#ref-for-dom-usbpermissionstorage-alloweddevices④">5.1. Events</a> <a href="#ref-for-dom-usbpermissionstorage-alloweddevices⑤">(2)</a>
     <li><a href="#ref-for-dom-usbpermissionstorage-alloweddevices⑥">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedusbdevice-devices-slot">
-   <b><a href="#dom-allowedusbdevice-devices-slot">#dom-allowedusbdevice-devices-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedusbdevice-devices-slot" class="dfn-panel" data-for="dom-allowedusbdevice-devices-slot" id="infopanel-for-dom-allowedusbdevice-devices-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedusbdevice-devices-slot" style="display:none">Info about the '[[devices]]' definition.</span><b><a href="#dom-allowedusbdevice-devices-slot">#dom-allowedusbdevice-devices-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedusbdevice-devices-slot">5. Device Enumeration</a> <a href="#ref-for-dom-allowedusbdevice-devices-slot①">(2)</a> <a href="#ref-for-dom-allowedusbdevice-devices-slot②">(3)</a> <a href="#ref-for-dom-allowedusbdevice-devices-slot③">(4)</a>
     <li><a href="#ref-for-dom-allowedusbdevice-devices-slot④">5.1. Events</a> <a href="#ref-for-dom-allowedusbdevice-devices-slot⑤">(2)</a> <a href="#ref-for-dom-allowedusbdevice-devices-slot⑥">(3)</a>
     <li><a href="#ref-for-dom-allowedusbdevice-devices-slot⑦">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbpermissionresult">
-   <b><a href="#usbpermissionresult">#usbpermissionresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbpermissionresult" class="dfn-panel" data-for="usbpermissionresult" id="infopanel-for-usbpermissionresult" role="dialog">
+   <span id="infopaneltitle-for-usbpermissionresult" style="display:none">Info about the 'USBPermissionResult' definition.</span><b><a href="#usbpermissionresult">#usbpermissionresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbpermissionresult">5. Device Enumeration</a>
     <li><a href="#ref-for-usbpermissionresult①">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbpermissionresult-devices">
-   <b><a href="#dom-usbpermissionresult-devices">#dom-usbpermissionresult-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbpermissionresult-devices" class="dfn-panel" data-for="dom-usbpermissionresult-devices" id="infopanel-for-dom-usbpermissionresult-devices" role="dialog">
+   <span id="infopaneltitle-for-dom-usbpermissionresult-devices" style="display:none">Info about the 'devices' definition.</span><b><a href="#dom-usbpermissionresult-devices">#dom-usbpermissionresult-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbpermissionresult-devices">5. Device Enumeration</a> <a href="#ref-for-dom-usbpermissionresult-devices①">(2)</a> <a href="#ref-for-dom-usbpermissionresult-devices②">(3)</a> <a href="#ref-for-dom-usbpermissionresult-devices③">(4)</a>
     <li><a href="#ref-for-dom-usbpermissionresult-devices④">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descriptors">
-   <b><a href="#descriptors">#descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descriptors" class="dfn-panel" data-for="descriptors" id="infopanel-for-descriptors" role="dialog">
+   <span id="infopaneltitle-for-descriptors" style="display:none">Info about the 'Descriptors' definition.</span><b><a href="#descriptors">#descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descriptors">9.1. Descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="device-descriptor">
-   <b><a href="#device-descriptor">#device-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-device-descriptor" class="dfn-panel" data-for="device-descriptor" id="infopanel-for-device-descriptor" role="dialog">
+   <span id="infopaneltitle-for-device-descriptor" style="display:none">Info about the 'device descriptor' definition.</span><b><a href="#device-descriptor">#device-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-descriptor">5. Device Enumeration</a> <a href="#ref-for-device-descriptor①">(2)</a>
     <li><a href="#ref-for-device-descriptor②">6. Device Usage</a> <a href="#ref-for-device-descriptor③">(2)</a> <a href="#ref-for-device-descriptor④">(3)</a> <a href="#ref-for-device-descriptor⑤">(4)</a> <a href="#ref-for-device-descriptor⑥">(5)</a>
@@ -5200,31 +5203,31 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-device-descriptor①①">9.1. Descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="configuration-descriptor">
-   <b><a href="#configuration-descriptor">#configuration-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-configuration-descriptor" class="dfn-panel" data-for="configuration-descriptor" id="infopanel-for-configuration-descriptor" role="dialog">
+   <span id="infopaneltitle-for-configuration-descriptor" style="display:none">Info about the 'configuration descriptor' definition.</span><b><a href="#configuration-descriptor">#configuration-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-configuration-descriptor">6.2. Configurations</a> <a href="#ref-for-configuration-descriptor①">(2)</a> <a href="#ref-for-configuration-descriptor②">(3)</a>
     <li><a href="#ref-for-configuration-descriptor③">8. Terminology</a>
     <li><a href="#ref-for-configuration-descriptor④">9.1. Descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface-descriptor">
-   <b><a href="#interface-descriptor">#interface-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface-descriptor" class="dfn-panel" data-for="interface-descriptor" id="infopanel-for-interface-descriptor" role="dialog">
+   <span id="infopaneltitle-for-interface-descriptor" style="display:none">Info about the 'interface descriptor' definition.</span><b><a href="#interface-descriptor">#interface-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-descriptor">5. Device Enumeration</a> <a href="#ref-for-interface-descriptor①">(2)</a>
     <li><a href="#ref-for-interface-descriptor②">6.2. Configurations</a>
     <li><a href="#ref-for-interface-descriptor③">6.3. Interfaces</a> <a href="#ref-for-interface-descriptor④">(2)</a> <a href="#ref-for-interface-descriptor⑤">(3)</a> <a href="#ref-for-interface-descriptor⑥">(4)</a> <a href="#ref-for-interface-descriptor⑦">(5)</a> <a href="#ref-for-interface-descriptor⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="endpoint-descriptor">
-   <b><a href="#endpoint-descriptor">#endpoint-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-endpoint-descriptor" class="dfn-panel" data-for="endpoint-descriptor" id="infopanel-for-endpoint-descriptor" role="dialog">
+   <span id="infopaneltitle-for-endpoint-descriptor" style="display:none">Info about the 'endpoint descriptor' definition.</span><b><a href="#endpoint-descriptor">#endpoint-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint-descriptor">6.3. Interfaces</a>
     <li><a href="#ref-for-endpoint-descriptor①">6.4. Endpoints</a> <a href="#ref-for-endpoint-descriptor②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-descriptor">
-   <b><a href="#string-descriptor">#string-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-descriptor" class="dfn-panel" data-for="string-descriptor" id="infopanel-for-string-descriptor" role="dialog">
+   <span id="infopaneltitle-for-string-descriptor" style="display:none">Info about the 'string descriptor' definition.</span><b><a href="#string-descriptor">#string-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-descriptor">5. Device Enumeration</a>
     <li><a href="#ref-for-string-descriptor①">6. Device Usage</a>
@@ -5233,79 +5236,81 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
     <li><a href="#ref-for-string-descriptor④">8. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="binary-object-store">
-   <b><a href="#binary-object-store">#binary-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-binary-object-store" class="dfn-panel" data-for="binary-object-store" id="infopanel-for-binary-object-store" role="dialog">
+   <span id="infopaneltitle-for-binary-object-store" style="display:none">Info about the 'Binary Object Store' definition.</span><b><a href="#binary-object-store">#binary-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-binary-object-store">4.1. WebUSB Platform Capability Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="platform-descriptor">
-   <b><a href="#platform-descriptor">#platform-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-platform-descriptor" class="dfn-panel" data-for="platform-descriptor" id="infopanel-for-platform-descriptor" role="dialog">
+   <span id="infopaneltitle-for-platform-descriptor" style="display:none">Info about the 'Platform Descriptor' definition.</span><b><a href="#platform-descriptor">#platform-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-platform-descriptor">4.1. WebUSB Platform Capability Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usb-device">
-   <b><a href="#usb-device">#usb-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usb-device" class="dfn-panel" data-for="usb-device" id="infopanel-for-usb-device" role="dialog">
+   <span id="infopaneltitle-for-usb-device" style="display:none">Info about the 'USB device' definition.</span><b><a href="#usb-device">#usb-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usb-device">5. Device Enumeration</a> <a href="#ref-for-usb-device①">(2)</a>
     <li><a href="#ref-for-usb-device②">5.1. Events</a> <a href="#ref-for-usb-device③">(2)</a>
     <li><a href="#ref-for-usb-device④">7.2. Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vendor-id">
-   <b><a href="#vendor-id">#vendor-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vendor-id" class="dfn-panel" data-for="vendor-id" id="infopanel-for-vendor-id" role="dialog">
+   <span id="infopaneltitle-for-vendor-id" style="display:none">Info about the 'vendor ID' definition.</span><b><a href="#vendor-id">#vendor-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-id">5. Device Enumeration</a> <a href="#ref-for-vendor-id①">(2)</a>
     <li><a href="#ref-for-vendor-id②">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="product-id">
-   <b><a href="#product-id">#product-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-product-id" class="dfn-panel" data-for="product-id" id="infopanel-for-product-id" role="dialog">
+   <span id="infopaneltitle-for-product-id" style="display:none">Info about the 'product
+ID' definition.</span><b><a href="#product-id">#product-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-product-id">5. Device Enumeration</a> <a href="#ref-for-product-id①">(2)</a>
     <li><a href="#ref-for-product-id②">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serial-number">
-   <b><a href="#serial-number">#serial-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serial-number" class="dfn-panel" data-for="serial-number" id="infopanel-for-serial-number" role="dialog">
+   <span id="infopaneltitle-for-serial-number" style="display:none">Info about the 'serial
+number' definition.</span><b><a href="#serial-number">#serial-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serial-number">5. Device Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="out-transfers">
-   <b><a href="#out-transfers">#out-transfers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-out-transfers" class="dfn-panel" data-for="out-transfers" id="infopanel-for-out-transfers" role="dialog">
+   <span id="infopaneltitle-for-out-transfers" style="display:none">Info about the 'OUT transfers' definition.</span><b><a href="#out-transfers">#out-transfers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-transfers">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-transfers">
-   <b><a href="#in-transfers">#in-transfers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-transfers" class="dfn-panel" data-for="in-transfers" id="infopanel-for-in-transfers" role="dialog">
+   <span id="infopaneltitle-for-in-transfers" style="display:none">Info about the 'IN transfers' definition.</span><b><a href="#in-transfers">#in-transfers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-transfers">6. Device Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bulk-transfers">
-   <b><a href="#bulk-transfers">#bulk-transfers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bulk-transfers" class="dfn-panel" data-for="bulk-transfers" id="infopanel-for-bulk-transfers" role="dialog">
+   <span id="infopaneltitle-for-bulk-transfers" style="display:none">Info about the 'Bulk transfers' definition.</span><b><a href="#bulk-transfers">#bulk-transfers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bulk-transfers">6. Device Usage</a> <a href="#ref-for-bulk-transfers①">(2)</a>
     <li><a href="#ref-for-bulk-transfers②">9.2. Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interrupt-transfers">
-   <b><a href="#interrupt-transfers">#interrupt-transfers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interrupt-transfers" class="dfn-panel" data-for="interrupt-transfers" id="infopanel-for-interrupt-transfers" role="dialog">
+   <span id="infopaneltitle-for-interrupt-transfers" style="display:none">Info about the 'Interrupt transfers' definition.</span><b><a href="#interrupt-transfers">#interrupt-transfers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interrupt-transfers">6. Device Usage</a> <a href="#ref-for-interrupt-transfers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isochronous-transfers">
-   <b><a href="#isochronous-transfers">#isochronous-transfers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isochronous-transfers" class="dfn-panel" data-for="isochronous-transfers" id="infopanel-for-isochronous-transfers" role="dialog">
+   <span id="infopaneltitle-for-isochronous-transfers" style="display:none">Info about the 'Isochronous transfers' definition.</span><b><a href="#isochronous-transfers">#isochronous-transfers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isochronous-transfers">6. Device Usage</a> <a href="#ref-for-isochronous-transfers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-endpoint">
-   <b><a href="#default-endpoint">#default-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-endpoint" class="dfn-panel" data-for="default-endpoint" id="infopanel-for-default-endpoint" role="dialog">
+   <span id="infopaneltitle-for-default-endpoint" style="display:none">Info about the 'default endpoint' definition.</span><b><a href="#default-endpoint">#default-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-endpoint">6. Device Usage</a> <a href="#ref-for-default-endpoint①">(2)</a> <a href="#ref-for-default-endpoint②">(3)</a>
     <li><a href="#ref-for-default-endpoint③">6.1. Transfers</a>
@@ -5313,59 +5318,115 @@ parameters in addition to a larger data payload that can be either IN or OUT.</p
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WICG/webusb/test/index.html
+++ b/tests/github/WICG/webusb/test/index.html
@@ -1081,363 +1081,363 @@ operation are satisfied, behave as though the transfer succeeded in sending <var
    <li><a href="#dom-fakeusbdeviceinit-usbversionsubminor">usbVersionSubminor</a><span>, in § 4</span>
    <li><a href="#dom-fakeusbdeviceinit-vendorid">vendorId</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.1. USB Behavior</a>
     <li><a href="#ref-for-concept-event-fire①">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">3. Global Testing Interface</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. Global Testing Interface</a>
     <li><a href="#ref-for-eventhandler①">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmliframeelement" class="dfn-panel" data-for="term-for-htmliframeelement" id="infopanel-for-term-for-htmliframeelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmliframeelement" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmliframeelement">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">3. Global Testing Interface</a> <a href="#ref-for-global-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. Global Testing Interface</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a> <a href="#ref-for-in-parallel③">(4)</a>
     <li><a href="#ref-for-in-parallel④">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3. Global Testing Interface</a>
     <li><a href="#ref-for-queue-a-task①">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4. Fake Devices</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. Global Testing Interface</a>
     <li><a href="#ref-for-idl-frozen-array①">3.1. USB Behavior</a>
     <li><a href="#ref-for-idl-frozen-array②">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3. Global Testing Interface</a> <a href="#ref-for-invalidstateerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">1.1. Examples</a>
     <li><a href="#ref-for-idl-promise①">3. Global Testing Interface</a> <a href="#ref-for-idl-promise②">(2)</a> <a href="#ref-for-idl-promise③">(3)</a> <a href="#ref-for-idl-promise④">(4)</a> <a href="#ref-for-idl-promise⑤">(5)</a> <a href="#ref-for-idl-promise⑥">(6)</a> <a href="#ref-for-idl-promise⑦">(7)</a> <a href="#ref-for-idl-promise⑧">(8)</a>
     <li><a href="#ref-for-idl-promise⑨">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-octet">
-   <a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-octet" class="dfn-panel" data-for="term-for-idl-octet" id="infopanel-for-term-for-idl-octet" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-octet" style="display:none">Info about the 'octet' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-octet">4. Fake Devices</a> <a href="#ref-for-idl-octet①">(2)</a> <a href="#ref-for-idl-octet②">(3)</a> <a href="#ref-for-idl-octet③">(4)</a> <a href="#ref-for-idl-octet④">(5)</a> <a href="#ref-for-idl-octet⑤">(6)</a> <a href="#ref-for-idl-octet⑥">(7)</a> <a href="#ref-for-idl-octet⑦">(8)</a> <a href="#ref-for-idl-octet⑧">(9)</a> <a href="#ref-for-idl-octet⑨">(10)</a> <a href="#ref-for-idl-octet①⓪">(11)</a> <a href="#ref-for-idl-octet①①">(12)</a> <a href="#ref-for-idl-octet①②">(13)</a> <a href="#ref-for-idl-octet①③">(14)</a> <a href="#ref-for-idl-octet①④">(15)</a> <a href="#ref-for-idl-octet①⑤">(16)</a> <a href="#ref-for-idl-octet①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3. Global Testing Interface</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a> <a href="#ref-for-resolve④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. Fake Devices</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. Global Testing Interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
     <li><a href="#ref-for-idl-undefined④">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">4. Fake Devices</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usb">
-   <a href="https://wicg.github.io/webusb/#usb">https://wicg.github.io/webusb/#usb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usb" class="dfn-panel" data-for="term-for-usb" id="infopanel-for-term-for-usb" role="menu">
+   <span id="infopaneltitle-for-term-for-usb" style="display:none">Info about the 'USB' external reference.</span><a href="https://wicg.github.io/webusb/#usb">https://wicg.github.io/webusb/#usb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usb">3. Global Testing Interface</a> <a href="#ref-for-usb①">(2)</a> <a href="#ref-for-usb②">(3)</a>
     <li><a href="#ref-for-usb③">3.1. USB Behavior</a> <a href="#ref-for-usb④">(2)</a>
     <li><a href="#ref-for-usb⑤">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usbalternateinterface">
-   <a href="https://wicg.github.io/webusb/#usbalternateinterface">https://wicg.github.io/webusb/#usbalternateinterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usbalternateinterface" class="dfn-panel" data-for="term-for-usbalternateinterface" id="infopanel-for-term-for-usbalternateinterface" role="menu">
+   <span id="infopaneltitle-for-term-for-usbalternateinterface" style="display:none">Info about the 'USBAlternateInterface' external reference.</span><a href="https://wicg.github.io/webusb/#usbalternateinterface">https://wicg.github.io/webusb/#usbalternateinterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbalternateinterface">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usbconfiguration">
-   <a href="https://wicg.github.io/webusb/#usbconfiguration">https://wicg.github.io/webusb/#usbconfiguration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usbconfiguration" class="dfn-panel" data-for="term-for-usbconfiguration" id="infopanel-for-term-for-usbconfiguration" role="menu">
+   <span id="infopaneltitle-for-term-for-usbconfiguration" style="display:none">Info about the 'USBConfiguration' external reference.</span><a href="https://wicg.github.io/webusb/#usbconfiguration">https://wicg.github.io/webusb/#usbconfiguration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbconfiguration">4. Fake Devices</a> <a href="#ref-for-usbconfiguration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usbdevice">
-   <a href="https://wicg.github.io/webusb/#usbdevice">https://wicg.github.io/webusb/#usbdevice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usbdevice" class="dfn-panel" data-for="term-for-usbdevice" id="infopanel-for-term-for-usbdevice" role="menu">
+   <span id="infopaneltitle-for-term-for-usbdevice" style="display:none">Info about the 'USBDevice' external reference.</span><a href="https://wicg.github.io/webusb/#usbdevice">https://wicg.github.io/webusb/#usbdevice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbdevice">4. Fake Devices</a>
     <li><a href="#ref-for-usbdevice①">4.1. USBDevice Behavior</a> <a href="#ref-for-usbdevice②">(2)</a> <a href="#ref-for-usbdevice③">(3)</a> <a href="#ref-for-usbdevice④">(4)</a> <a href="#ref-for-usbdevice⑤">(5)</a> <a href="#ref-for-usbdevice⑥">(6)</a> <a href="#ref-for-usbdevice⑦">(7)</a> <a href="#ref-for-usbdevice⑧">(8)</a> <a href="#ref-for-usbdevice⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-usbdevicefilter">
-   <a href="https://wicg.github.io/webusb/#dictdef-usbdevicefilter">https://wicg.github.io/webusb/#dictdef-usbdevicefilter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-usbdevicefilter" class="dfn-panel" data-for="term-for-dictdef-usbdevicefilter" id="infopanel-for-term-for-dictdef-usbdevicefilter" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-usbdevicefilter" style="display:none">Info about the 'USBDeviceFilter' external reference.</span><a href="https://wicg.github.io/webusb/#dictdef-usbdevicefilter">https://wicg.github.io/webusb/#dictdef-usbdevicefilter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-usbdevicefilter">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-usbdirection">
-   <a href="https://wicg.github.io/webusb/#enumdef-usbdirection">https://wicg.github.io/webusb/#enumdef-usbdirection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-usbdirection" class="dfn-panel" data-for="term-for-enumdef-usbdirection" id="infopanel-for-term-for-enumdef-usbdirection" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-usbdirection" style="display:none">Info about the 'USBDirection' external reference.</span><a href="https://wicg.github.io/webusb/#enumdef-usbdirection">https://wicg.github.io/webusb/#enumdef-usbdirection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbdirection">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usbendpoint">
-   <a href="https://wicg.github.io/webusb/#usbendpoint">https://wicg.github.io/webusb/#usbendpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usbendpoint" class="dfn-panel" data-for="term-for-usbendpoint" id="infopanel-for-term-for-usbendpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-usbendpoint" style="display:none">Info about the 'USBEndpoint' external reference.</span><a href="https://wicg.github.io/webusb/#usbendpoint">https://wicg.github.io/webusb/#usbendpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbendpoint">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-usbendpointtype">
-   <a href="https://wicg.github.io/webusb/#enumdef-usbendpointtype">https://wicg.github.io/webusb/#enumdef-usbendpointtype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-usbendpointtype" class="dfn-panel" data-for="term-for-enumdef-usbendpointtype" id="infopanel-for-term-for-enumdef-usbendpointtype" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-usbendpointtype" style="display:none">Info about the 'USBEndpointType' external reference.</span><a href="https://wicg.github.io/webusb/#enumdef-usbendpointtype">https://wicg.github.io/webusb/#enumdef-usbendpointtype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-usbendpointtype">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usbinterface">
-   <a href="https://wicg.github.io/webusb/#usbinterface">https://wicg.github.io/webusb/#usbinterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usbinterface" class="dfn-panel" data-for="term-for-usbinterface" id="infopanel-for-term-for-usbinterface" role="menu">
+   <span id="infopaneltitle-for-term-for-usbinterface" style="display:none">Info about the 'USBInterface' external reference.</span><a href="https://wicg.github.io/webusb/#usbinterface">https://wicg.github.io/webusb/#usbinterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbinterface">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbinterface-alternates">
-   <a href="https://wicg.github.io/webusb/#dom-usbinterface-alternates">https://wicg.github.io/webusb/#dom-usbinterface-alternates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbinterface-alternates" class="dfn-panel" data-for="term-for-dom-usbinterface-alternates" id="infopanel-for-term-for-dom-usbinterface-alternates" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbinterface-alternates" style="display:none">Info about the 'alternates' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbinterface-alternates">https://wicg.github.io/webusb/#dom-usbinterface-alternates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbinterface-alternates">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-claiminterface">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-claiminterface">https://wicg.github.io/webusb/#dom-usbdevice-claiminterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-claiminterface" class="dfn-panel" data-for="term-for-dom-usbdevice-claiminterface" id="infopanel-for-term-for-dom-usbdevice-claiminterface" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-claiminterface" style="display:none">Info about the 'claimInterface(interfaceNumber)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-claiminterface">https://wicg.github.io/webusb/#dom-usbdevice-claiminterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-claiminterface">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-clearhalt">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-clearhalt">https://wicg.github.io/webusb/#dom-usbdevice-clearhalt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-clearhalt" class="dfn-panel" data-for="term-for-dom-usbdevice-clearhalt" id="infopanel-for-term-for-dom-usbdevice-clearhalt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-clearhalt" style="display:none">Info about the 'clearHalt(direction, endpointNumber)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-clearhalt">https://wicg.github.io/webusb/#dom-usbdevice-clearhalt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-clearhalt">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-close">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-close">https://wicg.github.io/webusb/#dom-usbdevice-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-close" class="dfn-panel" data-for="term-for-dom-usbdevice-close" id="infopanel-for-term-for-dom-usbdevice-close" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-close" style="display:none">Info about the 'close()' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-close">https://wicg.github.io/webusb/#dom-usbdevice-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-close">4.1. USBDevice Behavior</a> <a href="#ref-for-dom-usbdevice-close①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-configuration">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-configuration">https://wicg.github.io/webusb/#dom-usbdevice-configuration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-configuration" class="dfn-panel" data-for="term-for-dom-usbdevice-configuration" id="infopanel-for-term-for-dom-usbdevice-configuration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-configuration" style="display:none">Info about the 'configuration' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-configuration">https://wicg.github.io/webusb/#dom-usbdevice-configuration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-configuration">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbconfiguration-configurationvalue">
-   <a href="https://wicg.github.io/webusb/#dom-usbconfiguration-configurationvalue">https://wicg.github.io/webusb/#dom-usbconfiguration-configurationvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbconfiguration-configurationvalue" class="dfn-panel" data-for="term-for-dom-usbconfiguration-configurationvalue" id="infopanel-for-term-for-dom-usbconfiguration-configurationvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbconfiguration-configurationvalue" style="display:none">Info about the 'configurationValue' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbconfiguration-configurationvalue">https://wicg.github.io/webusb/#dom-usbconfiguration-configurationvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbconfiguration-configurationvalue">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-configurations">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-configurations">https://wicg.github.io/webusb/#dom-usbdevice-configurations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-configurations" class="dfn-panel" data-for="term-for-dom-usbdevice-configurations" id="infopanel-for-term-for-dom-usbdevice-configurations" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-configurations" style="display:none">Info about the 'configurations' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-configurations">https://wicg.github.io/webusb/#dom-usbdevice-configurations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-configurations">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-controltransferin">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-controltransferin">https://wicg.github.io/webusb/#dom-usbdevice-controltransferin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-controltransferin" class="dfn-panel" data-for="term-for-dom-usbdevice-controltransferin" id="infopanel-for-term-for-dom-usbdevice-controltransferin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-controltransferin" style="display:none">Info about the 'controlTransferIn(setup, length)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-controltransferin">https://wicg.github.io/webusb/#dom-usbdevice-controltransferin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-controltransferin">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-controltransferout">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-controltransferout">https://wicg.github.io/webusb/#dom-usbdevice-controltransferout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-controltransferout" class="dfn-panel" data-for="term-for-dom-usbdevice-controltransferout" id="infopanel-for-term-for-dom-usbdevice-controltransferout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-controltransferout" style="display:none">Info about the 'controlTransferOut(setup, data)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-controltransferout">https://wicg.github.io/webusb/#dom-usbdevice-controltransferout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-controltransferout">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbalternateinterface-endpoints">
-   <a href="https://wicg.github.io/webusb/#dom-usbalternateinterface-endpoints">https://wicg.github.io/webusb/#dom-usbalternateinterface-endpoints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbalternateinterface-endpoints" class="dfn-panel" data-for="term-for-dom-usbalternateinterface-endpoints" id="infopanel-for-term-for-dom-usbalternateinterface-endpoints" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbalternateinterface-endpoints" style="display:none">Info about the 'endpoints' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbalternateinterface-endpoints">https://wicg.github.io/webusb/#dom-usbalternateinterface-endpoints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbalternateinterface-endpoints">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevicerequestoptions-filters">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevicerequestoptions-filters">https://wicg.github.io/webusb/#dom-usbdevicerequestoptions-filters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevicerequestoptions-filters" class="dfn-panel" data-for="term-for-dom-usbdevicerequestoptions-filters" id="infopanel-for-term-for-dom-usbdevicerequestoptions-filters" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevicerequestoptions-filters" style="display:none">Info about the 'filters' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevicerequestoptions-filters">https://wicg.github.io/webusb/#dom-usbdevicerequestoptions-filters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicerequestoptions-filters">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-index">
-   <a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-index">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-index" class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-index" id="infopanel-for-term-for-dom-usbcontroltransferparameters-index" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-index" style="display:none">Info about the 'index' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-index">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-index">4.1. USBDevice Behavior</a> <a href="#ref-for-dom-usbcontroltransferparameters-index①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbconfiguration-interfaces">
-   <a href="https://wicg.github.io/webusb/#dom-usbconfiguration-interfaces">https://wicg.github.io/webusb/#dom-usbconfiguration-interfaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbconfiguration-interfaces" class="dfn-panel" data-for="term-for-dom-usbconfiguration-interfaces" id="infopanel-for-term-for-dom-usbconfiguration-interfaces" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbconfiguration-interfaces" style="display:none">Info about the 'interfaces' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbconfiguration-interfaces">https://wicg.github.io/webusb/#dom-usbconfiguration-interfaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbconfiguration-interfaces">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-isochronoustransferin">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferin">https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-isochronoustransferin" class="dfn-panel" data-for="term-for-dom-usbdevice-isochronoustransferin" id="infopanel-for-term-for-dom-usbdevice-isochronoustransferin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-isochronoustransferin" style="display:none">Info about the 'isochronousTransferIn(endpointNumber, packetLengths)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferin">https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-isochronoustransferin">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-isochronoustransferout">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferout">https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-isochronoustransferout" class="dfn-panel" data-for="term-for-dom-usbdevice-isochronoustransferout" id="infopanel-for-term-for-dom-usbdevice-isochronoustransferout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-isochronoustransferout" style="display:none">Info about the 'isochronousTransferOut(endpointNumber, data, packetLengths)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferout">https://wicg.github.io/webusb/#dom-usbdevice-isochronoustransferout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-isochronoustransferout">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-open">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-open">https://wicg.github.io/webusb/#dom-usbdevice-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-open" class="dfn-panel" data-for="term-for-dom-usbdevice-open" id="infopanel-for-term-for-dom-usbdevice-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-open" style="display:none">Info about the 'open()' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-open">https://wicg.github.io/webusb/#dom-usbdevice-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-open">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-releaseinterface">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-releaseinterface">https://wicg.github.io/webusb/#dom-usbdevice-releaseinterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-releaseinterface" class="dfn-panel" data-for="term-for-dom-usbdevice-releaseinterface" id="infopanel-for-term-for-dom-usbdevice-releaseinterface" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-releaseinterface" style="display:none">Info about the 'releaseInterface(interfaceNumber)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-releaseinterface">https://wicg.github.io/webusb/#dom-usbdevice-releaseinterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-releaseinterface">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-request">
-   <a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-request">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-request" class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-request" id="infopanel-for-term-for-dom-usbcontroltransferparameters-request" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-request" style="display:none">Info about the 'request' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-request">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-request">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usb-requestdevice">
-   <a href="https://wicg.github.io/webusb/#dom-usb-requestdevice">https://wicg.github.io/webusb/#dom-usb-requestdevice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usb-requestdevice" class="dfn-panel" data-for="term-for-dom-usb-requestdevice" id="infopanel-for-term-for-dom-usb-requestdevice" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usb-requestdevice" style="display:none">Info about the 'requestDevice(options)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usb-requestdevice">https://wicg.github.io/webusb/#dom-usb-requestdevice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usb-requestdevice">3.1. USB Behavior</a>
     <li><a href="#ref-for-dom-usb-requestdevice①">3.2. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-reset">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-reset">https://wicg.github.io/webusb/#dom-usbdevice-reset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-reset" class="dfn-panel" data-for="term-for-dom-usbdevice-reset" id="infopanel-for-term-for-dom-usbdevice-reset" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-reset" style="display:none">Info about the 'reset()' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-reset">https://wicg.github.io/webusb/#dom-usbdevice-reset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-reset">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-selectalternateinterface">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-selectalternateinterface">https://wicg.github.io/webusb/#dom-usbdevice-selectalternateinterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-selectalternateinterface" class="dfn-panel" data-for="term-for-dom-usbdevice-selectalternateinterface" id="infopanel-for-term-for-dom-usbdevice-selectalternateinterface" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-selectalternateinterface" style="display:none">Info about the 'selectAlternateInterface(interfaceNumber, alternateSetting)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-selectalternateinterface">https://wicg.github.io/webusb/#dom-usbdevice-selectalternateinterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-selectalternateinterface">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-selectconfiguration">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-selectconfiguration">https://wicg.github.io/webusb/#dom-usbdevice-selectconfiguration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-selectconfiguration" class="dfn-panel" data-for="term-for-dom-usbdevice-selectconfiguration" id="infopanel-for-term-for-dom-usbdevice-selectconfiguration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-selectconfiguration" style="display:none">Info about the 'selectConfiguration(configurationValue)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-selectconfiguration">https://wicg.github.io/webusb/#dom-usbdevice-selectconfiguration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-selectconfiguration">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-transferin">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-transferin">https://wicg.github.io/webusb/#dom-usbdevice-transferin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-transferin" class="dfn-panel" data-for="term-for-dom-usbdevice-transferin" id="infopanel-for-term-for-dom-usbdevice-transferin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-transferin" style="display:none">Info about the 'transferIn(endpointNumber, length)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-transferin">https://wicg.github.io/webusb/#dom-usbdevice-transferin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-transferin">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbdevice-transferout">
-   <a href="https://wicg.github.io/webusb/#dom-usbdevice-transferout">https://wicg.github.io/webusb/#dom-usbdevice-transferout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbdevice-transferout" class="dfn-panel" data-for="term-for-dom-usbdevice-transferout" id="infopanel-for-term-for-dom-usbdevice-transferout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbdevice-transferout" style="display:none">Info about the 'transferOut(endpointNumber, data)' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbdevice-transferout">https://wicg.github.io/webusb/#dom-usbdevice-transferout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevice-transferout">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-usb">
-   <a href="https://wicg.github.io/webusb/#dom-navigator-usb">https://wicg.github.io/webusb/#dom-navigator-usb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-usb" class="dfn-panel" data-for="term-for-dom-navigator-usb" id="infopanel-for-term-for-dom-navigator-usb" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-usb" style="display:none">Info about the 'usb' external reference.</span><a href="https://wicg.github.io/webusb/#dom-navigator-usb">https://wicg.github.io/webusb/#dom-navigator-usb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-usb">3. Global Testing Interface</a> <a href="#ref-for-dom-navigator-usb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-value">
-   <a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-value">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-value" class="dfn-panel" data-for="term-for-dom-usbcontroltransferparameters-value" id="infopanel-for-term-for-dom-usbcontroltransferparameters-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-usbcontroltransferparameters-value" style="display:none">Info about the 'value' external reference.</span><a href="https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-value">https://wicg.github.io/webusb/#dom-usbcontroltransferparameters-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbcontroltransferparameters-value">4.1. USBDevice Behavior</a> <a href="#ref-for-dom-usbcontroltransferparameters-value①">(2)</a>
    </ul>
@@ -1612,21 +1612,21 @@ operation are satisfied, behave as though the transfer succeeded in sending <var
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="usbdevicerequestevent">
-   <b><a href="#usbdevicerequestevent">#usbdevicerequestevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbdevicerequestevent" class="dfn-panel" data-for="usbdevicerequestevent" id="infopanel-for-usbdevicerequestevent" role="dialog">
+   <span id="infopaneltitle-for-usbdevicerequestevent" style="display:none">Info about the 'USBDeviceRequestEvent' definition.</span><b><a href="#usbdevicerequestevent">#usbdevicerequestevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbdevicerequestevent">3. Global Testing Interface</a> <a href="#ref-for-usbdevicerequestevent①">(2)</a>
     <li><a href="#ref-for-usbdevicerequestevent②">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicerequestevent-respondwith">
-   <b><a href="#dom-usbdevicerequestevent-respondwith">#dom-usbdevicerequestevent-respondwith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicerequestevent-respondwith" class="dfn-panel" data-for="dom-usbdevicerequestevent-respondwith" id="infopanel-for-dom-usbdevicerequestevent-respondwith" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicerequestevent-respondwith" style="display:none">Info about the 'respondWith' definition.</span><b><a href="#dom-usbdevicerequestevent-respondwith">#dom-usbdevicerequestevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicerequestevent-respondwith">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usbtest">
-   <b><a href="#usbtest">#usbtest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usbtest" class="dfn-panel" data-for="usbtest" id="infopanel-for-usbtest" role="dialog">
+   <span id="infopaneltitle-for-usbtest" style="display:none">Info about the 'USBTest' definition.</span><b><a href="#usbtest">#usbtest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usbtest">3. Global Testing Interface</a> <a href="#ref-for-usbtest①">(2)</a> <a href="#ref-for-usbtest②">(3)</a> <a href="#ref-for-usbtest③">(4)</a> <a href="#ref-for-usbtest④">(5)</a> <a href="#ref-for-usbtest⑤">(6)</a> <a href="#ref-for-usbtest⑥">(7)</a>
     <li><a href="#ref-for-usbtest⑦">3.1. USB Behavior</a>
@@ -1634,172 +1634,229 @@ operation are satisfied, behave as though the transfer succeeded in sending <var
     <li><a href="#ref-for-usbtest⑨">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtest-initialize">
-   <b><a href="#dom-usbtest-initialize">#dom-usbtest-initialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtest-initialize" class="dfn-panel" data-for="dom-usbtest-initialize" id="infopanel-for-dom-usbtest-initialize" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtest-initialize" style="display:none">Info about the 'initialize' definition.</span><b><a href="#dom-usbtest-initialize">#dom-usbtest-initialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtest-initialize">3. Global Testing Interface</a>
     <li><a href="#ref-for-dom-usbtest-initialize①">3.2. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtest-attachtocontext">
-   <b><a href="#dom-usbtest-attachtocontext">#dom-usbtest-attachtocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtest-attachtocontext" class="dfn-panel" data-for="dom-usbtest-attachtocontext" id="infopanel-for-dom-usbtest-attachtocontext" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtest-attachtocontext" style="display:none">Info about the 'attachToContext' definition.</span><b><a href="#dom-usbtest-attachtocontext">#dom-usbtest-attachtocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtest-attachtocontext">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtest-addfakedevice">
-   <b><a href="#dom-usbtest-addfakedevice">#dom-usbtest-addfakedevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtest-addfakedevice" class="dfn-panel" data-for="dom-usbtest-addfakedevice" id="infopanel-for-dom-usbtest-addfakedevice" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtest-addfakedevice" style="display:none">Info about the 'addFakeDevice' definition.</span><b><a href="#dom-usbtest-addfakedevice">#dom-usbtest-addfakedevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtest-addfakedevice">3. Global Testing Interface</a> <a href="#ref-for-dom-usbtest-addfakedevice①">(2)</a>
     <li><a href="#ref-for-dom-usbtest-addfakedevice②">4. Fake Devices</a> <a href="#ref-for-dom-usbtest-addfakedevice③">(2)</a> <a href="#ref-for-dom-usbtest-addfakedevice④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtest-reset">
-   <b><a href="#dom-usbtest-reset">#dom-usbtest-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtest-reset" class="dfn-panel" data-for="dom-usbtest-reset" id="infopanel-for-dom-usbtest-reset" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtest-reset" style="display:none">Info about the 'reset' definition.</span><b><a href="#dom-usbtest-reset">#dom-usbtest-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtest-reset">1.1. Examples</a>
     <li><a href="#ref-for-dom-usbtest-reset①">3. Global Testing Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="controlled-by">
-   <b><a href="#controlled-by">#controlled-by</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-controlled-by" class="dfn-panel" data-for="controlled-by" id="infopanel-for-controlled-by" role="dialog">
+   <span id="infopaneltitle-for-controlled-by" style="display:none">Info about the 'controlled
+by' definition.</span><b><a href="#controlled-by">#controlled-by</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-controlled-by">3. Global Testing Interface</a> <a href="#ref-for-controlled-by①">(2)</a> <a href="#ref-for-controlled-by②">(3)</a>
     <li><a href="#ref-for-controlled-by③">3.1. USB Behavior</a>
     <li><a href="#ref-for-controlled-by④">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbtest-initializationpromise-slot">
-   <b><a href="#dom-usbtest-initializationpromise-slot">#dom-usbtest-initializationpromise-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbtest-initializationpromise-slot" class="dfn-panel" data-for="dom-usbtest-initializationpromise-slot" id="infopanel-for-dom-usbtest-initializationpromise-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-usbtest-initializationpromise-slot" style="display:none">Info about the '[[initializationPromise]]' definition.</span><b><a href="#dom-usbtest-initializationpromise-slot">#dom-usbtest-initializationpromise-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbtest-initializationpromise-slot">3. Global Testing Interface</a> <a href="#ref-for-dom-usbtest-initializationpromise-slot①">(2)</a> <a href="#ref-for-dom-usbtest-initializationpromise-slot②">(3)</a> <a href="#ref-for-dom-usbtest-initializationpromise-slot③">(4)</a> <a href="#ref-for-dom-usbtest-initializationpromise-slot④">(5)</a> <a href="#ref-for-dom-usbtest-initializationpromise-slot⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-usbdevicerequestevent-promise-slot">
-   <b><a href="#dom-usbdevicerequestevent-promise-slot">#dom-usbdevicerequestevent-promise-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-usbdevicerequestevent-promise-slot" class="dfn-panel" data-for="dom-usbdevicerequestevent-promise-slot" id="infopanel-for-dom-usbdevicerequestevent-promise-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-usbdevicerequestevent-promise-slot" style="display:none">Info about the '[[promise]]' definition.</span><b><a href="#dom-usbdevicerequestevent-promise-slot">#dom-usbdevicerequestevent-promise-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-usbdevicerequestevent-promise-slot">3. Global Testing Interface</a> <a href="#ref-for-dom-usbdevicerequestevent-promise-slot①">(2)</a>
     <li><a href="#ref-for-dom-usbdevicerequestevent-promise-slot②">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestdevice">
-   <b><a href="#requestdevice">#requestdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestdevice" class="dfn-panel" data-for="requestdevice" id="infopanel-for-requestdevice" role="dialog">
+   <span id="infopaneltitle-for-requestdevice" style="display:none">Info about the 'requestdevice' definition.</span><b><a href="#requestdevice">#requestdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestdevice">3.1. USB Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakeusbdevice">
-   <b><a href="#fakeusbdevice">#fakeusbdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakeusbdevice" class="dfn-panel" data-for="fakeusbdevice" id="infopanel-for-fakeusbdevice" role="dialog">
+   <span id="infopaneltitle-for-fakeusbdevice" style="display:none">Info about the 'FakeUSBDevice' definition.</span><b><a href="#fakeusbdevice">#fakeusbdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakeusbdevice">3. Global Testing Interface</a> <a href="#ref-for-fakeusbdevice①">(2)</a> <a href="#ref-for-fakeusbdevice②">(3)</a> <a href="#ref-for-fakeusbdevice③">(4)</a> <a href="#ref-for-fakeusbdevice④">(5)</a>
     <li><a href="#ref-for-fakeusbdevice⑤">4. Fake Devices</a>
     <li><a href="#ref-for-fakeusbdevice⑥">4.1. USBDevice Behavior</a> <a href="#ref-for-fakeusbdevice⑦">(2)</a> <a href="#ref-for-fakeusbdevice⑧">(3)</a> <a href="#ref-for-fakeusbdevice⑨">(4)</a> <a href="#ref-for-fakeusbdevice①⓪">(5)</a> <a href="#ref-for-fakeusbdevice①①">(6)</a> <a href="#ref-for-fakeusbdevice①②">(7)</a> <a href="#ref-for-fakeusbdevice①③">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakeusbdevice-disconnect">
-   <b><a href="#dom-fakeusbdevice-disconnect">#dom-fakeusbdevice-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakeusbdevice-disconnect" class="dfn-panel" data-for="dom-fakeusbdevice-disconnect" id="infopanel-for-dom-fakeusbdevice-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-fakeusbdevice-disconnect" style="display:none">Info about the 'disconnect' definition.</span><b><a href="#dom-fakeusbdevice-disconnect">#dom-fakeusbdevice-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakeusbdevice-disconnect">3. Global Testing Interface</a>
     <li><a href="#ref-for-dom-fakeusbdevice-disconnect①">4. Fake Devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakeusbdeviceinit">
-   <b><a href="#dictdef-fakeusbdeviceinit">#dictdef-fakeusbdeviceinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakeusbdeviceinit" class="dfn-panel" data-for="dictdef-fakeusbdeviceinit" id="infopanel-for-dictdef-fakeusbdeviceinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakeusbdeviceinit" style="display:none">Info about the 'FakeUSBDeviceInit' definition.</span><b><a href="#dictdef-fakeusbdeviceinit">#dictdef-fakeusbdeviceinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakeusbdeviceinit">3. Global Testing Interface</a>
     <li><a href="#ref-for-dictdef-fakeusbdeviceinit①">4. Fake Devices</a> <a href="#ref-for-dictdef-fakeusbdeviceinit②">(2)</a>
     <li><a href="#ref-for-dictdef-fakeusbdeviceinit③">4.1. USBDevice Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakeusbdeviceinit-activeconfigurationvalue">
-   <b><a href="#dom-fakeusbdeviceinit-activeconfigurationvalue">#dom-fakeusbdeviceinit-activeconfigurationvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakeusbdeviceinit-activeconfigurationvalue" class="dfn-panel" data-for="dom-fakeusbdeviceinit-activeconfigurationvalue" id="infopanel-for-dom-fakeusbdeviceinit-activeconfigurationvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-fakeusbdeviceinit-activeconfigurationvalue" style="display:none">Info about the 'activeConfigurationValue' definition.</span><b><a href="#dom-fakeusbdeviceinit-activeconfigurationvalue">#dom-fakeusbdeviceinit-activeconfigurationvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakeusbdeviceinit-activeconfigurationvalue">4. Fake Devices</a> <a href="#ref-for-dom-fakeusbdeviceinit-activeconfigurationvalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakeusbconfigurationinit">
-   <b><a href="#dictdef-fakeusbconfigurationinit">#dictdef-fakeusbconfigurationinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakeusbconfigurationinit" class="dfn-panel" data-for="dictdef-fakeusbconfigurationinit" id="infopanel-for-dictdef-fakeusbconfigurationinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakeusbconfigurationinit" style="display:none">Info about the 'FakeUSBConfigurationInit' definition.</span><b><a href="#dictdef-fakeusbconfigurationinit">#dictdef-fakeusbconfigurationinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakeusbconfigurationinit">4. Fake Devices</a> <a href="#ref-for-dictdef-fakeusbconfigurationinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakeusbinterfaceinit">
-   <b><a href="#dictdef-fakeusbinterfaceinit">#dictdef-fakeusbinterfaceinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakeusbinterfaceinit" class="dfn-panel" data-for="dictdef-fakeusbinterfaceinit" id="infopanel-for-dictdef-fakeusbinterfaceinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakeusbinterfaceinit" style="display:none">Info about the 'FakeUSBInterfaceInit' definition.</span><b><a href="#dictdef-fakeusbinterfaceinit">#dictdef-fakeusbinterfaceinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakeusbinterfaceinit">4. Fake Devices</a> <a href="#ref-for-dictdef-fakeusbinterfaceinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakeusbalternateinterfaceinit">
-   <b><a href="#dictdef-fakeusbalternateinterfaceinit">#dictdef-fakeusbalternateinterfaceinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakeusbalternateinterfaceinit" class="dfn-panel" data-for="dictdef-fakeusbalternateinterfaceinit" id="infopanel-for-dictdef-fakeusbalternateinterfaceinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakeusbalternateinterfaceinit" style="display:none">Info about the 'FakeUSBAlternateInterfaceInit' definition.</span><b><a href="#dictdef-fakeusbalternateinterfaceinit">#dictdef-fakeusbalternateinterfaceinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakeusbalternateinterfaceinit">4. Fake Devices</a> <a href="#ref-for-dictdef-fakeusbalternateinterfaceinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakeusbendpointinit">
-   <b><a href="#dictdef-fakeusbendpointinit">#dictdef-fakeusbendpointinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakeusbendpointinit" class="dfn-panel" data-for="dictdef-fakeusbendpointinit" id="infopanel-for-dictdef-fakeusbendpointinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakeusbendpointinit" style="display:none">Info about the 'FakeUSBEndpointInit' definition.</span><b><a href="#dictdef-fakeusbendpointinit">#dictdef-fakeusbendpointinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakeusbendpointinit">4. Fake Devices</a> <a href="#ref-for-dictdef-fakeusbendpointinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="correspond-to">
-   <b><a href="#correspond-to">#correspond-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-correspond-to" class="dfn-panel" data-for="correspond-to" id="infopanel-for-correspond-to" role="dialog">
+   <span id="infopaneltitle-for-correspond-to" style="display:none">Info about the 'correspond to' definition.</span><b><a href="#correspond-to">#correspond-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-correspond-to">4.1. USBDevice Behavior</a> <a href="#ref-for-correspond-to①">(2)</a> <a href="#ref-for-correspond-to②">(3)</a> <a href="#ref-for-correspond-to③">(4)</a> <a href="#ref-for-correspond-to④">(5)</a> <a href="#ref-for-correspond-to⑤">(6)</a> <a href="#ref-for-correspond-to⑥">(7)</a> <a href="#ref-for-correspond-to⑦">(8)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/WebAudio/web-audio-api/index.html
+++ b/tests/github/WebAudio/web-audio-api/index.html
@@ -15827,8 +15827,8 @@ Zergaoui, Mohamed (INNOVIMAX)</p>
    <li><a href="#dictdef-waveshaperoptions">WaveShaperOptions</a><span>, in § 1.31.3</span>
    <li><a href="#WaveShaperOptions">waveshaperoptions</a><span>, in § 1.31.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia" id="infopanel-for-term-for-dom-mediadevices-getusermedia" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" style="display:none">Info about the 'getUserMedia()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadevices-getusermedia"> Features</a>
     <li><a href="#ref-for-dom-mediadevices-getusermedia①">1.23. 
@@ -15837,8 +15837,8 @@ The MediaStreamAudioDestinationNode Interface</a>
 Security and Privacy Considerations</a> <a href="#ref-for-dom-mediadevices-getusermedia③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">1.1.1. 
 Attributes</a>
@@ -15850,8 +15850,8 @@ Attributes</a>
 The AudioProcessingEvent Interface - DEPRECATED</a> <a href="#ref-for-event⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">1.3.5.2. 
 OfflineAudioCompletionEventInit</a>
@@ -15859,8 +15859,8 @@ OfflineAudioCompletionEventInit</a>
 AudioProcessingEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">1.1. 
 The BaseAudioContext Interface</a>
@@ -15870,8 +15870,8 @@ The AudioNode Interface</a>
 AudioNode Creation</a> <a href="#ref-for-eventtarget③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">1.2.1. 
 Constructors</a>
@@ -15887,15 +15887,15 @@ Attributes</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-data-blocks">
-   <a href="https://tc39.github.io/ecma262/#sec-data-blocks">https://tc39.github.io/ecma262/#sec-data-blocks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-data-blocks" class="dfn-panel" data-for="term-for-sec-data-blocks" id="infopanel-for-term-for-sec-data-blocks" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-data-blocks" style="display:none">Info about the 'data block' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-data-blocks">https://tc39.github.io/ecma262/#sec-data-blocks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-data-blocks">1.4. 
 The AudioBuffer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">1.2.5. 
 AudioTimestamp</a>
@@ -15903,15 +15903,15 @@ AudioTimestamp</a>
 Dictionary AudioTimestamp Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-errorevent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-errorevent" class="dfn-panel" data-for="term-for-errorevent" id="infopanel-for-term-for-errorevent" role="menu">
+   <span id="infopaneltitle-for-term-for-errorevent" style="display:none">Info about the 'ErrorEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-errorevent">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">1.1. 
 The BaseAudioContext Interface</a>
@@ -15935,8 +15935,8 @@ The AudioWorkletNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlmediaelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlmediaelement" class="dfn-panel" data-for="term-for-htmlmediaelement" id="infopanel-for-term-for-htmlmediaelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlmediaelement" style="display:none">Info about the 'HTMLMediaElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlmediaelement">1.2. 
 The AudioContext Interface</a>
@@ -15954,8 +15954,8 @@ Dictionary MediaElementAudioSourceOptions Members</a>
 Security with MediaElementAudioSourceNode and Cross-Origin Resources</a> <a href="#ref-for-htmlmediaelement①⑧">(2)</a> <a href="#ref-for-htmlmediaelement①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messagechannel">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messagechannel">https://html.spec.whatwg.org/multipage/web-messaging.html#messagechannel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messagechannel" class="dfn-panel" data-for="term-for-messagechannel" id="infopanel-for-term-for-messagechannel" role="menu">
+   <span id="infopaneltitle-for-term-for-messagechannel" style="display:none">Info about the 'MessageChannel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messagechannel">https://html.spec.whatwg.org/multipage/web-messaging.html#messagechannel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messagechannel">1.32.3.1. 
 Constructors</a>
@@ -15964,8 +15964,8 @@ Attributes</a>
     <li><a href="#ref-for-messagechannel②">1.32.4.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
@@ -15980,29 +15980,29 @@ The AudioWorkletProcessor Interface</a>
     <li><a href="#ref-for-messageport⑥">1.32.4.2. Attributes</a> <a href="#ref-for-messageport⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a> <a href="#ref-for-structureddeserialize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserialize" class="dfn-panel" data-for="term-for-structuredserialize" id="infopanel-for-term-for-structuredserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserialize" style="display:none">Info about the 'StructuredSerialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserialize">1.32.3.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">1.32.3.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet" class="dfn-panel" data-for="term-for-worklet" id="infopanel-for-term-for-worklet" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet" style="display:none">Info about the 'Worklet' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet">1.32. 
 The AudioWorklet Interface</a>
@@ -16010,15 +16010,15 @@ The AudioWorklet Interface</a>
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-worklet-addmodule">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule">https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-worklet-addmodule" class="dfn-panel" data-for="term-for-dom-worklet-addmodule" id="infopanel-for-term-for-dom-worklet-addmodule" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-worklet-addmodule" style="display:none">Info about the 'addModule(moduleURL, options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule">https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-worklet-addmodule">1.32.1. 
 Concepts</a> <a href="#ref-for-dom-worklet-addmodule①">(2)</a>
@@ -16026,8 +16026,8 @@ Concepts</a> <a href="#ref-for-dom-worklet-addmodule①">(2)</a>
 AudioWorklet Sequence of Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">1.1.2. 
 Methods</a>
@@ -16037,8 +16037,8 @@ Methods</a> <a href="#ref-for-concept-document-window②">(2)</a> <a href="#ref-
 Methods</a> <a href="#ref-for-concept-document-window⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audio">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audio" class="dfn-panel" data-for="term-for-audio" id="infopanel-for-term-for-audio" role="menu">
+   <span id="infopaneltitle-for-term-for-audio" style="display:none">Info about the 'audio' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio"> Introduction</a>
     <li><a href="#ref-for-audio①"> Features</a>
@@ -16051,37 +16051,37 @@ The AudioBuffer Interface</a>
 The MediaElementAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clean-up-after-running-a-callback">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clean-up-after-running-a-callback" class="dfn-panel" data-for="term-for-clean-up-after-running-a-callback" id="infopanel-for-term-for-clean-up-after-running-a-callback" role="menu">
+   <span id="infopaneltitle-for-term-for-clean-up-after-running-a-callback" style="display:none">Info about the 'clean up after running a callback' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clean-up-after-running-a-callback">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clean-up-after-running-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clean-up-after-running-script" class="dfn-panel" data-for="term-for-clean-up-after-running-script" id="infopanel-for-term-for-clean-up-after-running-script" role="menu">
+   <span id="infopaneltitle-for-term-for-clean-up-after-running-script" style="display:none">Info about the 'clean up after running script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clean-up-after-running-script">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageport-close">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageport-close" class="dfn-panel" data-for="term-for-dom-messageport-close" id="infopanel-for-term-for-dom-messageport-close" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageport-close" style="display:none">Info about the 'close()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageport-close">1.32.3.2. 
 Attributes</a>
     <li><a href="#ref-for-dom-messageport-close①">1.32.4.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-current-settings-object①">(2)</a> <a href="#ref-for-current-settings-object②">(3)</a> <a href="#ref-for-current-settings-object③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">1.1.2. 
 Methods</a>
@@ -16091,43 +16091,43 @@ Methods</a> <a href="#ref-for-fully-active②">(2)</a> <a href="#ref-for-fully-a
 Methods</a> <a href="#ref-for-fully-active⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messagechannel-port1">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port1">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messagechannel-port1" class="dfn-panel" data-for="term-for-dom-messagechannel-port1" id="infopanel-for-term-for-dom-messagechannel-port1" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messagechannel-port1" style="display:none">Info about the 'port1' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port1">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messagechannel-port1">1.32.3.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messagechannel-port2">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port2">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messagechannel-port2" class="dfn-panel" data-for="term-for-dom-messagechannel-port2" id="infopanel-for-term-for-dom-messagechannel-port2" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messagechannel-port2" style="display:none">Info about the 'port2' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port2">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel-port2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messagechannel-port2">1.32.3.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-to-run-a-callback">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prepare-to-run-a-callback" class="dfn-panel" data-for="term-for-prepare-to-run-a-callback" id="infopanel-for-term-for-prepare-to-run-a-callback" role="menu">
+   <span id="infopaneltitle-for-term-for-prepare-to-run-a-callback" style="display:none">Info about the 'prepare to run a callback' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prepare-to-run-a-callback">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-to-run-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prepare-to-run-script" class="dfn-panel" data-for="term-for-prepare-to-run-script" id="infopanel-for-term-for-prepare-to-run-script" role="menu">
+   <span id="infopaneltitle-for-term-for-prepare-to-run-script" style="display:none">Info about the 'prepare to run script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prepare-to-run-script">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -16135,8 +16135,8 @@ The instantiation of AudioWorkletProcessor</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">1.1.2. 
 Methods</a>
@@ -16148,22 +16148,22 @@ Methods</a> <a href="#ref-for-concept-relevant-global③">(2)</a> <a href="#ref-
 Methods</a> <a href="#ref-for-concept-relevant-global⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sticky-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation">https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sticky-activation" class="dfn-panel" data-for="term-for-sticky-activation" id="infopanel-for-term-for-sticky-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-sticky-activation" style="display:none">Info about the 'sticky activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation">https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sticky-activation">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-a-worklet-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#terminate-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#terminate-a-worklet-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-terminate-a-worklet-global-scope" class="dfn-panel" data-for="term-for-terminate-a-worklet-global-scope" id="infopanel-for-term-for-terminate-a-worklet-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-terminate-a-worklet-global-scope" style="display:none">Info about the 'terminate a worklet global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#terminate-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#terminate-a-worklet-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-a-worklet-global-scope">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video"> Features</a>
     <li><a href="#ref-for-video①"> API Overview</a>
@@ -16171,57 +16171,57 @@ The AudioWorkletGlobalScope Interface</a>
 The MediaElementAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-destination-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-destination-type" class="dfn-panel" data-for="term-for-worklet-destination-type" id="infopanel-for-term-for-worklet-destination-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-destination-type" style="display:none">Info about the 'worklet destination type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-destination-type">1.32.1. 
 Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-global-scope-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-global-scope-type" class="dfn-panel" data-for="term-for-worklet-global-scope-type" id="infopanel-for-term-for-worklet-global-scope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-global-scope-type" style="display:none">Info about the 'worklet global scope type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-global-scope-type">1.32.1. 
 Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit">
-   <a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit" class="dfn-panel" data-for="term-for-code-unit" id="infopanel-for-term-for-code-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit" style="display:none">Info about the 'code unit' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit">1.24.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1.32.4.3.1. 
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a> <a href="#ref-for-struct①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediadevices">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediadevices">https://w3c.github.io/mediacapture-main/#dom-mediadevices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediadevices" class="dfn-panel" data-for="term-for-dom-mediadevices" id="infopanel-for-term-for-dom-mediadevices" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediadevices" style="display:none">Info about the 'MediaDevices' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediadevices">https://w3c.github.io/mediacapture-main/#dom-mediadevices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadevices">8. 
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastream">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastream">https://w3c.github.io/mediacapture-main/#dom-mediastream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastream" class="dfn-panel" data-for="term-for-dom-mediastream" id="infopanel-for-term-for-dom-mediastream" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastream" style="display:none">Info about the 'MediaStream' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastream">https://w3c.github.io/mediacapture-main/#dom-mediastream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastream"> API Overview</a> <a href="#ref-for-dom-mediastream①">(2)</a>
     <li><a href="#ref-for-dom-mediastream②">1.2. 
@@ -16244,8 +16244,8 @@ MediaStreamAudioSourceOptions</a>
 Dictionary MediaStreamAudioSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack" class="dfn-panel" data-for="term-for-dom-mediastreamtrack" id="infopanel-for-term-for-dom-mediastreamtrack" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack" style="display:none">Info about the 'MediaStreamTrack' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack"> API Overview</a>
     <li><a href="#ref-for-dom-mediastreamtrack①">1.2. 
@@ -16269,8 +16269,8 @@ MediaStreamTrackAudioSourceOptions</a>
 Dictionary MediaStreamTrackAudioSourceOptions Members</a> <a href="#ref-for-dom-mediastreamtrack①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">1.1. 
 The BaseAudioContext Interface</a>
@@ -16282,8 +16282,8 @@ Methods</a> <a href="#ref-for-idl-ArrayBuffer⑥">(2)</a> <a href="#ref-for-idl-
 Audio Buffer Copying</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">1.1. 
 The BaseAudioContext Interface</a>
@@ -16297,8 +16297,8 @@ Methods</a> <a href="#ref-for-idl-DOMException④">(2)</a> <a href="#ref-for-idl
 Methods</a> <a href="#ref-for-idl-DOMException⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">1.3.5. 
 The OfflineAudioCompletionEvent Interface</a>
@@ -16324,22 +16324,22 @@ AudioParamDescriptor</a>
 Dictionary AudioParamDescriptor Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datacloneerror">
-   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datacloneerror" class="dfn-panel" data-for="term-for-datacloneerror" id="infopanel-for-term-for-datacloneerror" role="menu">
+   <span id="infopaneltitle-for-term-for-datacloneerror" style="display:none">Info about the 'DataCloneError' external reference.</span><a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacloneerror">1.1.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-encodingerror">
-   <a href="https://webidl.spec.whatwg.org/#encodingerror">https://webidl.spec.whatwg.org/#encodingerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-encodingerror" class="dfn-panel" data-for="term-for-encodingerror" id="infopanel-for-term-for-encodingerror" role="menu">
+   <span id="infopaneltitle-for-term-for-encodingerror" style="display:none">Info about the 'EncodingError' external reference.</span><a href="https://webidl.spec.whatwg.org/#encodingerror">https://webidl.spec.whatwg.org/#encodingerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encodingerror">1.1.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">1.1. 
 The BaseAudioContext Interface</a>
@@ -16415,8 +16415,8 @@ The AudioWorkletNode Interface</a> <a href="#ref-for-Exposed③⑤">(2)</a>
 The AudioWorkletProcessor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">1.4. 
 The AudioBuffer Interface</a> <a href="#ref-for-idl-Float32Array①">(2)</a> <a href="#ref-for-idl-Float32Array②">(3)</a>
@@ -16452,8 +16452,8 @@ Rendering an Audio Graph</a>
 Audio sample format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">1.32.4. 
 The AudioWorkletProcessor Interface</a> <a href="#ref-for-idl-frozen-array①">(2)</a> <a href="#ref-for-idl-frozen-array②">(3)</a> <a href="#ref-for-idl-frozen-array③">(4)</a>
@@ -16461,15 +16461,15 @@ The AudioWorkletProcessor Interface</a> <a href="#ref-for-idl-frozen-array①">(
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-idl-frozen-array⑤">(2)</a> <a href="#ref-for-idl-frozen-array⑥">(3)</a> <a href="#ref-for-idl-frozen-array⑦">(4)</a> <a href="#ref-for-idl-frozen-array⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indexsizeerror">
-   <a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indexsizeerror" class="dfn-panel" data-for="term-for-indexsizeerror" id="infopanel-for-term-for-indexsizeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-indexsizeerror" style="display:none">Info about the 'IndexSizeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indexsizeerror">1.1.2. 
 Methods</a> <a href="#ref-for-indexsizeerror①">(2)</a> <a href="#ref-for-indexsizeerror②">(3)</a> <a href="#ref-for-indexsizeerror③">(4)</a> <a href="#ref-for-indexsizeerror④">(5)</a> <a href="#ref-for-indexsizeerror⑤">(6)</a>
@@ -16489,8 +16489,8 @@ Constructors</a> <a href="#ref-for-indexsizeerror②④">(2)</a> <a href="#ref-f
 Configuring Channels with AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">1.5.5. 
 Methods</a> <a href="#ref-for-invalidaccesserror①">(2)</a> <a href="#ref-for-invalidaccesserror②">(3)</a> <a href="#ref-for-invalidaccesserror③">(4)</a> <a href="#ref-for-invalidaccesserror④">(5)</a> <a href="#ref-for-invalidaccesserror⑤">(6)</a> <a href="#ref-for-invalidaccesserror⑥">(7)</a>
@@ -16500,8 +16500,8 @@ Methods</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">1.1.2. 
 Methods</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
@@ -16543,8 +16543,8 @@ Constructors</a>
 The BitCrusher Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">1.1.2. 
 Methods</a> <a href="#ref-for-notsupportederror①">(2)</a> <a href="#ref-for-notsupportederror②">(3)</a> <a href="#ref-for-notsupportederror③">(4)</a> <a href="#ref-for-notsupportederror④">(5)</a> <a href="#ref-for-notsupportederror⑤">(6)</a>
@@ -16576,8 +16576,8 @@ Methods</a> <a href="#ref-for-notsupportederror③①">(2)</a> <a href="#ref-for
 Configuring Channels with AudioWorkletNodeOptions</a> <a href="#ref-for-notsupportederror③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">1.1. 
 The BaseAudioContext Interface</a>
@@ -16595,8 +16595,8 @@ Methods</a> <a href="#ref-for-idl-promise①②">(2)</a> <a href="#ref-for-idl-p
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">1.6.2. 
 Methods</a> <a href="#ref-for-exceptiondef-rangeerror①">(2)</a> <a href="#ref-for-exceptiondef-rangeerror②">(3)</a> <a href="#ref-for-exceptiondef-rangeerror③">(4)</a> <a href="#ref-for-exceptiondef-rangeerror④">(5)</a> <a href="#ref-for-exceptiondef-rangeerror⑤">(6)</a> <a href="#ref-for-exceptiondef-rangeerror⑥">(7)</a> <a href="#ref-for-exceptiondef-rangeerror⑦">(8)</a> <a href="#ref-for-exceptiondef-rangeerror⑧">(9)</a> <a href="#ref-for-exceptiondef-rangeerror⑨">(10)</a>
@@ -16608,8 +16608,8 @@ Methods</a> <a href="#ref-for-exceptiondef-rangeerror①③">(2)</a> <a href="#r
 Attributes</a> <a href="#ref-for-exceptiondef-rangeerror①⑥">(2)</a> <a href="#ref-for-exceptiondef-rangeerror①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">1.1. 
 The BaseAudioContext Interface</a>
@@ -16619,8 +16619,8 @@ The MediaElementAudioSourceNode Interface</a>
 The MediaStreamAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">1.1. 
 The BaseAudioContext Interface</a>
@@ -16630,8 +16630,8 @@ The AudioWorklet Interface</a>
 The AudioWorkletNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">1.32.2.2. 
 Methods</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
@@ -16639,8 +16639,8 @@ Methods</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">1.8. 
 The AnalyserNode Interface</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
@@ -16648,15 +16648,15 @@ The AnalyserNode Interface</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
 Methods</a> <a href="#ref-for-idl-Uint8Array③">(2)</a> <a href="#ref-for-idl-Uint8Array④">(3)</a> <a href="#ref-for-idl-Uint8Array⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">1.4.3. 
 Methods</a> <a href="#ref-for-unknownerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">1.1.2. 
 Methods</a>
@@ -16666,8 +16666,8 @@ Methods</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a> <a href="#ref-
 Methods</a> <a href="#ref-for-a-promise-rejected-with⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">1.9. 
 The AudioBufferSourceNode Interface</a>
@@ -16693,8 +16693,8 @@ Dictionary PeriodicWaveConstraints Members</a>
 The AudioWorkletProcessor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-conforming-implementation">
-   <a href="https://webidl.spec.whatwg.org/#dfn-conforming-implementation">https://webidl.spec.whatwg.org/#dfn-conforming-implementation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-conforming-implementation" class="dfn-panel" data-for="term-for-dfn-conforming-implementation" id="infopanel-for-term-for-dfn-conforming-implementation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-conforming-implementation" style="display:none">Info about the 'conforming implementation' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-conforming-implementation">https://webidl.spec.whatwg.org/#dfn-conforming-implementation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-conforming-implementation">1.13.5. 
 Filters Characteristics</a>
@@ -16702,15 +16702,15 @@ Filters Characteristics</a>
 The PeriodicWave Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-construct-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#construct-a-callback-function">https://webidl.spec.whatwg.org/#construct-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-construct-a-callback-function" class="dfn-panel" data-for="term-for-construct-a-callback-function" id="infopanel-for-term-for-construct-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-construct-a-callback-function" style="display:none">Info about the 'construct' external reference.</span><a href="https://webidl.spec.whatwg.org/#construct-a-callback-function">https://webidl.spec.whatwg.org/#construct-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-callback-function">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a>
@@ -16796,8 +16796,8 @@ AudioWorkletNodeOptions</a>
 Dictionary AudioWorkletNodeOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-idl-float①">(2)</a> <a href="#ref-for-idl-float②">(3)</a> <a href="#ref-for-idl-float③">(4)</a>
@@ -16893,15 +16893,15 @@ AudioParamDescriptor</a> <a href="#ref-for-idl-float①②③">(2)</a> <a href="
 Dictionary AudioParamDescriptor Members</a> <a href="#ref-for-idl-float①②⑥">(2)</a> <a href="#ref-for-idl-float①②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">1.4.3. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">1.29. 
 The ScriptProcessorNode Interface - DEPRECATED</a>
@@ -16909,8 +16909,8 @@ The ScriptProcessorNode Interface - DEPRECATED</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
@@ -16924,15 +16924,15 @@ The AudioWorkletProcessor Interface</a>
 Callback AudioWorkletProcessCallback Parameters </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">1.32.3.3. 
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a>
@@ -16952,8 +16952,8 @@ WaveShaperOptions</a>
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">1.1.2. 
 Methods</a>
@@ -16967,8 +16967,8 @@ Constructors</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
@@ -17030,8 +17030,8 @@ Methods</a> <a href="#ref-for-idl-undefined⑥②">(2)</a>
 Callback AudioWorkletProcessCallback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a> <a href="#ref-for-idl-unsigned-long⑥">(7)</a>
@@ -17093,8 +17093,8 @@ AudioWorkletNodeOptions</a> <a href="#ref-for-idl-unsigned-long⑦⑦">(2)</a> <
 Dictionary AudioWorkletNodeOptions Members</a> <a href="#ref-for-idl-unsigned-long⑧⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
@@ -17882,22 +17882,22 @@ Attributes</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="inputs">
-   <b><a href="#inputs">#inputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inputs" class="dfn-panel" data-for="inputs" id="infopanel-for-inputs" role="dialog">
+   <span id="infopaneltitle-for-inputs" style="display:none">Info about the 'inputs' definition.</span><b><a href="#inputs">#inputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inputs">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outputs">
-   <b><a href="#outputs">#outputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outputs" class="dfn-panel" data-for="outputs" id="infopanel-for-outputs" role="dialog">
+   <span id="infopaneltitle-for-outputs" style="display:none">Info about the 'outputs' definition.</span><b><a href="#outputs">#outputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outputs">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-node">
-   <b><a href="#source-node">#source-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-node" class="dfn-panel" data-for="source-node" id="infopanel-for-source-node" role="dialog">
+   <span id="infopaneltitle-for-source-node" style="display:none">Info about the 'source node' definition.</span><b><a href="#source-node">#source-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-node">1.5. 
 The AudioNode Interface</a>
@@ -17906,22 +17906,23 @@ The AudioNode Interface</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination-node">
-   <b><a href="#destination-node">#destination-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination-node" class="dfn-panel" data-for="destination-node" id="infopanel-for-destination-node" role="dialog">
+   <span id="infopaneltitle-for-destination-node" style="display:none">Info about the 'destination node' definition.</span><b><a href="#destination-node">#destination-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination-node">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="BaseAudioContext">
-   <b><a href="#BaseAudioContext">#BaseAudioContext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-BaseAudioContext" class="dfn-panel" data-for="BaseAudioContext" id="infopanel-for-BaseAudioContext" role="dialog">
+   <span id="infopaneltitle-for-BaseAudioContext" style="display:none">Info about the '1.1. 
+The BaseAudioContext Interface' definition.</span><b><a href="#BaseAudioContext">#BaseAudioContext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BaseAudioContext">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-pending-promises-slot">
-   <b><a href="#dom-baseaudiocontext-pending-promises-slot">#dom-baseaudiocontext-pending-promises-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-pending-promises-slot" class="dfn-panel" data-for="dom-baseaudiocontext-pending-promises-slot" id="infopanel-for-dom-baseaudiocontext-pending-promises-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-pending-promises-slot" style="display:none">Info about the '[[pending promises]]' definition.</span><b><a href="#dom-baseaudiocontext-pending-promises-slot">#dom-baseaudiocontext-pending-promises-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-pending-promises-slot">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-pending-promises-slot①">(2)</a> <a href="#ref-for-dom-baseaudiocontext-pending-promises-slot②">(3)</a>
@@ -17932,8 +17933,8 @@ Methods</a>
     <li><a href="#ref-for-dom-baseaudiocontext-pending-promises-slot⑧">2.5. Unloading a document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-rendering-thread-state-slot">
-   <b><a href="#dom-baseaudiocontext-rendering-thread-state-slot">#dom-baseaudiocontext-rendering-thread-state-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-rendering-thread-state-slot" class="dfn-panel" data-for="dom-baseaudiocontext-rendering-thread-state-slot" id="infopanel-for-dom-baseaudiocontext-rendering-thread-state-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-rendering-thread-state-slot" style="display:none">Info about the '[[rendering thread state]]' definition.</span><b><a href="#dom-baseaudiocontext-rendering-thread-state-slot">#dom-baseaudiocontext-rendering-thread-state-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-rendering-thread-state-slot">1.2.1. 
 Constructors</a> <a href="#ref-for-dom-baseaudiocontext-rendering-thread-state-slot①">(2)</a>
@@ -17947,8 +17948,8 @@ Methods</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-control-thread-state-slot">
-   <b><a href="#dom-baseaudiocontext-control-thread-state-slot">#dom-baseaudiocontext-control-thread-state-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-control-thread-state-slot" class="dfn-panel" data-for="dom-baseaudiocontext-control-thread-state-slot" id="infopanel-for-dom-baseaudiocontext-control-thread-state-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-control-thread-state-slot" style="display:none">Info about the '[[control thread state]]' definition.</span><b><a href="#dom-baseaudiocontext-control-thread-state-slot">#dom-baseaudiocontext-control-thread-state-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-control-thread-state-slot">1.1.1. 
 Attributes</a>
@@ -17966,8 +17967,8 @@ Methods</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-audiocontextstate">
-   <b><a href="#enumdef-audiocontextstate">#enumdef-audiocontextstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-audiocontextstate" class="dfn-panel" data-for="enumdef-audiocontextstate" id="infopanel-for-enumdef-audiocontextstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-audiocontextstate" style="display:none">Info about the 'AudioContextState' definition.</span><b><a href="#enumdef-audiocontextstate">#enumdef-audiocontextstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-audiocontextstate">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-enumdef-audiocontextstate①">(2)</a>
@@ -17975,8 +17976,8 @@ The BaseAudioContext Interface</a> <a href="#ref-for-enumdef-audiocontextstate�
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextstate-suspended">
-   <b><a href="#dom-audiocontextstate-suspended">#dom-audiocontextstate-suspended</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextstate-suspended" class="dfn-panel" data-for="dom-audiocontextstate-suspended" id="infopanel-for-dom-audiocontextstate-suspended" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextstate-suspended" style="display:none">Info about the 'suspended' definition.</span><b><a href="#dom-audiocontextstate-suspended">#dom-audiocontextstate-suspended</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextstate-suspended">1.1. 
 The BaseAudioContext Interface</a>
@@ -17990,8 +17991,8 @@ Methods</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextstate-running">
-   <b><a href="#dom-audiocontextstate-running">#dom-audiocontextstate-running</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextstate-running" class="dfn-panel" data-for="dom-audiocontextstate-running" id="infopanel-for-dom-audiocontextstate-running" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextstate-running" style="display:none">Info about the 'running' definition.</span><b><a href="#dom-audiocontextstate-running">#dom-audiocontextstate-running</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextstate-running">1.1. 
 The BaseAudioContext Interface</a>
@@ -18007,8 +18008,8 @@ Methods</a> <a href="#ref-for-dom-audiocontextstate-running⑤">(2)</a>
 Methods</a> <a href="#ref-for-dom-audiocontextstate-running⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextstate-closed">
-   <b><a href="#dom-audiocontextstate-closed">#dom-audiocontextstate-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextstate-closed" class="dfn-panel" data-for="dom-audiocontextstate-closed" id="infopanel-for-dom-audiocontextstate-closed" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextstate-closed" style="display:none">Info about the 'closed' definition.</span><b><a href="#dom-audiocontextstate-closed">#dom-audiocontextstate-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextstate-closed">1.1. 
 The BaseAudioContext Interface</a>
@@ -18016,22 +18017,22 @@ The BaseAudioContext Interface</a>
 Methods</a> <a href="#ref-for-dom-audiocontextstate-closed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-decodeerrorcallback-error">
-   <b><a href="#dom-decodeerrorcallback-error">#dom-decodeerrorcallback-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-decodeerrorcallback-error" class="dfn-panel" data-for="dom-decodeerrorcallback-error" id="infopanel-for-dom-decodeerrorcallback-error" role="dialog">
+   <span id="infopaneltitle-for-dom-decodeerrorcallback-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-decodeerrorcallback-error">#dom-decodeerrorcallback-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-decodeerrorcallback-error">1.1.4. 
 Callback DecodeErrorCallback() Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-decodesuccesscallback-decodeddata">
-   <b><a href="#dom-decodesuccesscallback-decodeddata">#dom-decodesuccesscallback-decodeddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-decodesuccesscallback-decodeddata" class="dfn-panel" data-for="dom-decodesuccesscallback-decodeddata" id="infopanel-for-dom-decodesuccesscallback-decodeddata" role="dialog">
+   <span id="infopaneltitle-for-dom-decodesuccesscallback-decodeddata" style="display:none">Info about the 'decodedData' definition.</span><b><a href="#dom-decodesuccesscallback-decodeddata">#dom-decodesuccesscallback-decodeddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-decodesuccesscallback-decodeddata">1.1.3. 
 Callback DecodeSuccessCallback() Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseaudiocontext">
-   <b><a href="#baseaudiocontext">#baseaudiocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseaudiocontext" class="dfn-panel" data-for="baseaudiocontext" id="infopanel-for-baseaudiocontext" role="dialog">
+   <span id="infopaneltitle-for-baseaudiocontext" style="display:none">Info about the 'BaseAudioContext' definition.</span><b><a href="#baseaudiocontext">#baseaudiocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseaudiocontext">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-baseaudiocontext①">(2)</a> <a href="#ref-for-baseaudiocontext②">(3)</a> <a href="#ref-for-baseaudiocontext③">(4)</a> <a href="#ref-for-baseaudiocontext④">(5)</a>
@@ -18152,15 +18153,15 @@ Rendering an Audio Graph</a> <a href="#ref-for-baseaudiocontext①⓪⑥">(2)</a
 Background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata">
-   <b><a href="#dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata">#dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata" class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata" id="infopanel-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata" style="display:none">Info about the 'audioData' definition.</span><b><a href="#dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata">#dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata①">(2)</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata②">(3)</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata③">(4)</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-audiodata-successcallback-errorcallback-audiodata④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-audioworklet">
-   <b><a href="#dom-baseaudiocontext-audioworklet">#dom-baseaudiocontext-audioworklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-audioworklet" class="dfn-panel" data-for="dom-baseaudiocontext-audioworklet" id="infopanel-for-dom-baseaudiocontext-audioworklet" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-audioworklet" style="display:none">Info about the 'audioWorklet' definition.</span><b><a href="#dom-baseaudiocontext-audioworklet">#dom-baseaudiocontext-audioworklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-audioworklet">1.1. 
 The BaseAudioContext Interface</a>
@@ -18168,8 +18169,8 @@ The BaseAudioContext Interface</a>
 Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-currenttime">
-   <b><a href="#dom-baseaudiocontext-currenttime">#dom-baseaudiocontext-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-currenttime" class="dfn-panel" data-for="dom-baseaudiocontext-currenttime" id="infopanel-for-dom-baseaudiocontext-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-baseaudiocontext-currenttime">#dom-baseaudiocontext-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-currenttime">1.1. 
 The BaseAudioContext Interface</a>
@@ -18197,8 +18198,8 @@ Attributes</a>
 Rendering an Audio Graph</a> <a href="#ref-for-dom-baseaudiocontext-currenttime④⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-destination">
-   <b><a href="#dom-baseaudiocontext-destination">#dom-baseaudiocontext-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-destination" class="dfn-panel" data-for="dom-baseaudiocontext-destination" id="infopanel-for-dom-baseaudiocontext-destination" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#dom-baseaudiocontext-destination">#dom-baseaudiocontext-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-destination">1.1. 
 The BaseAudioContext Interface</a>
@@ -18208,8 +18209,8 @@ Attributes</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-listener">
-   <b><a href="#dom-baseaudiocontext-listener">#dom-baseaudiocontext-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-listener" class="dfn-panel" data-for="dom-baseaudiocontext-listener" id="infopanel-for-dom-baseaudiocontext-listener" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-listener" style="display:none">Info about the 'listener' definition.</span><b><a href="#dom-baseaudiocontext-listener">#dom-baseaudiocontext-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-listener">1.1. 
 The BaseAudioContext Interface</a>
@@ -18221,15 +18222,15 @@ The PannerNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-onstatechange">
-   <b><a href="#dom-baseaudiocontext-onstatechange">#dom-baseaudiocontext-onstatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-onstatechange" class="dfn-panel" data-for="dom-baseaudiocontext-onstatechange" id="infopanel-for-dom-baseaudiocontext-onstatechange" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-onstatechange" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#dom-baseaudiocontext-onstatechange">#dom-baseaudiocontext-onstatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-onstatechange">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-samplerate">
-   <b><a href="#dom-baseaudiocontext-samplerate">#dom-baseaudiocontext-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-samplerate" class="dfn-panel" data-for="dom-baseaudiocontext-samplerate" id="infopanel-for-dom-baseaudiocontext-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-baseaudiocontext-samplerate">#dom-baseaudiocontext-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-samplerate">1.1. 
 The BaseAudioContext Interface</a>
@@ -18249,8 +18250,8 @@ Methods</a> <a href="#ref-for-dom-baseaudiocontext-samplerate⑧">(2)</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="--nyquist-frequency">
-   <b><a href="#--nyquist-frequency">#--nyquist-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for---nyquist-frequency" class="dfn-panel" data-for="--nyquist-frequency" id="infopanel-for---nyquist-frequency" role="dialog">
+   <span id="infopaneltitle-for---nyquist-frequency" style="display:none">Info about the 'Nyquist frequency' definition.</span><b><a href="#--nyquist-frequency">#--nyquist-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for---nyquist-frequency">1.13. 
 The BiquadFilterNode Interface</a>
@@ -18260,8 +18261,8 @@ The OscillatorNode Interface</a> <a href="#ref-for---nyquist-frequency②">(2)</
 Attributes</a> <a href="#ref-for---nyquist-frequency⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-state">
-   <b><a href="#dom-baseaudiocontext-state">#dom-baseaudiocontext-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-state" class="dfn-panel" data-for="dom-baseaudiocontext-state" id="infopanel-for-dom-baseaudiocontext-state" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-baseaudiocontext-state">#dom-baseaudiocontext-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-state">1.1. 
 The BaseAudioContext Interface</a>
@@ -18273,22 +18274,22 @@ Methods</a> <a href="#ref-for-dom-baseaudiocontext-state③">(2)</a> <a href="#r
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-state⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createanalyser">
-   <b><a href="#dom-baseaudiocontext-createanalyser">#dom-baseaudiocontext-createanalyser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createanalyser" class="dfn-panel" data-for="dom-baseaudiocontext-createanalyser" id="infopanel-for-dom-baseaudiocontext-createanalyser" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createanalyser" style="display:none">Info about the 'createAnalyser()' definition.</span><b><a href="#dom-baseaudiocontext-createanalyser">#dom-baseaudiocontext-createanalyser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createanalyser">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbiquadfilter">
-   <b><a href="#dom-baseaudiocontext-createbiquadfilter">#dom-baseaudiocontext-createbiquadfilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbiquadfilter" class="dfn-panel" data-for="dom-baseaudiocontext-createbiquadfilter" id="infopanel-for-dom-baseaudiocontext-createbiquadfilter" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbiquadfilter" style="display:none">Info about the 'createBiquadFilter()' definition.</span><b><a href="#dom-baseaudiocontext-createbiquadfilter">#dom-baseaudiocontext-createbiquadfilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbiquadfilter">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer">
-   <b><a href="#dom-baseaudiocontext-createbuffer">#dom-baseaudiocontext-createbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbuffer" class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer" id="infopanel-for-dom-baseaudiocontext-createbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbuffer" style="display:none">Info about the 'createBuffer(numberOfChannels, length, sampleRate)' definition.</span><b><a href="#dom-baseaudiocontext-createbuffer">#dom-baseaudiocontext-createbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbuffer">1.1. 
 The BaseAudioContext Interface</a>
@@ -18302,36 +18303,36 @@ Methods</a>
 Dictionary AudioBufferOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-numberofchannels">
-   <b><a href="#dom-baseaudiocontext-createbuffer-numberofchannels">#dom-baseaudiocontext-createbuffer-numberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbuffer-numberofchannels" class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-numberofchannels" id="infopanel-for-dom-baseaudiocontext-createbuffer-numberofchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbuffer-numberofchannels" style="display:none">Info about the 'numberOfChannels' definition.</span><b><a href="#dom-baseaudiocontext-createbuffer-numberofchannels">#dom-baseaudiocontext-createbuffer-numberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbuffer-numberofchannels">1.4.4.1. 
 Dictionary AudioBufferOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-length">
-   <b><a href="#dom-baseaudiocontext-createbuffer-length">#dom-baseaudiocontext-createbuffer-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbuffer-length" class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-length" id="infopanel-for-dom-baseaudiocontext-createbuffer-length" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbuffer-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-baseaudiocontext-createbuffer-length">#dom-baseaudiocontext-createbuffer-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbuffer-length">1.4.4.1. 
 Dictionary AudioBufferOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-samplerate">
-   <b><a href="#dom-baseaudiocontext-createbuffer-samplerate">#dom-baseaudiocontext-createbuffer-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbuffer-samplerate" class="dfn-panel" data-for="dom-baseaudiocontext-createbuffer-samplerate" id="infopanel-for-dom-baseaudiocontext-createbuffer-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbuffer-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-baseaudiocontext-createbuffer-samplerate">#dom-baseaudiocontext-createbuffer-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbuffer-samplerate">1.4.4.1. 
 Dictionary AudioBufferOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createbuffersource">
-   <b><a href="#dom-baseaudiocontext-createbuffersource">#dom-baseaudiocontext-createbuffersource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createbuffersource" class="dfn-panel" data-for="dom-baseaudiocontext-createbuffersource" id="infopanel-for-dom-baseaudiocontext-createbuffersource" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createbuffersource" style="display:none">Info about the 'createBufferSource()' definition.</span><b><a href="#dom-baseaudiocontext-createbuffersource">#dom-baseaudiocontext-createbuffersource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createbuffersource">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createchannelmerger">
-   <b><a href="#dom-baseaudiocontext-createchannelmerger">#dom-baseaudiocontext-createchannelmerger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createchannelmerger" class="dfn-panel" data-for="dom-baseaudiocontext-createchannelmerger" id="infopanel-for-dom-baseaudiocontext-createchannelmerger" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createchannelmerger" style="display:none">Info about the 'createChannelMerger(numberOfInputs)' definition.</span><b><a href="#dom-baseaudiocontext-createchannelmerger">#dom-baseaudiocontext-createchannelmerger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createchannelmerger">1.1. 
 The BaseAudioContext Interface</a>
@@ -18341,8 +18342,8 @@ Methods</a>
 Dictionary ChannelMergerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs">
-   <b><a href="#dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs">#dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs" class="dfn-panel" data-for="dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs" id="infopanel-for-dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs" style="display:none">Info about the 'numberOfInputs' definition.</span><b><a href="#dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs">#dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createchannelmerger-numberofinputs-numberofinputs">1.1. 
 The BaseAudioContext Interface</a>
@@ -18350,8 +18351,8 @@ The BaseAudioContext Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createchannelsplitter">
-   <b><a href="#dom-baseaudiocontext-createchannelsplitter">#dom-baseaudiocontext-createchannelsplitter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createchannelsplitter" class="dfn-panel" data-for="dom-baseaudiocontext-createchannelsplitter" id="infopanel-for-dom-baseaudiocontext-createchannelsplitter" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createchannelsplitter" style="display:none">Info about the 'createChannelSplitter(numberOfOutputs)' definition.</span><b><a href="#dom-baseaudiocontext-createchannelsplitter">#dom-baseaudiocontext-createchannelsplitter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createchannelsplitter">1.1. 
 The BaseAudioContext Interface</a>
@@ -18363,8 +18364,8 @@ The ChannelSplitterNode Interface</a>
 Dictionary ChannelSplitterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs">
-   <b><a href="#dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs">#dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs" class="dfn-panel" data-for="dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs" id="infopanel-for-dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs" style="display:none">Info about the 'numberOfOutputs' definition.</span><b><a href="#dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs">#dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createchannelsplitter-numberofoutputs-numberofoutputs">1.1. 
 The BaseAudioContext Interface</a>
@@ -18372,22 +18373,22 @@ The BaseAudioContext Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createconstantsource">
-   <b><a href="#dom-baseaudiocontext-createconstantsource">#dom-baseaudiocontext-createconstantsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createconstantsource" class="dfn-panel" data-for="dom-baseaudiocontext-createconstantsource" id="infopanel-for-dom-baseaudiocontext-createconstantsource" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createconstantsource" style="display:none">Info about the 'createConstantSource()' definition.</span><b><a href="#dom-baseaudiocontext-createconstantsource">#dom-baseaudiocontext-createconstantsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createconstantsource">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createconvolver">
-   <b><a href="#dom-baseaudiocontext-createconvolver">#dom-baseaudiocontext-createconvolver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createconvolver" class="dfn-panel" data-for="dom-baseaudiocontext-createconvolver" id="infopanel-for-dom-baseaudiocontext-createconvolver" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createconvolver" style="display:none">Info about the 'createConvolver()' definition.</span><b><a href="#dom-baseaudiocontext-createconvolver">#dom-baseaudiocontext-createconvolver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createconvolver">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createdelay">
-   <b><a href="#dom-baseaudiocontext-createdelay">#dom-baseaudiocontext-createdelay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createdelay" class="dfn-panel" data-for="dom-baseaudiocontext-createdelay" id="infopanel-for-dom-baseaudiocontext-createdelay" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createdelay" style="display:none">Info about the 'createDelay(maxDelayTime)' definition.</span><b><a href="#dom-baseaudiocontext-createdelay">#dom-baseaudiocontext-createdelay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createdelay">1.1. 
 The BaseAudioContext Interface</a>
@@ -18397,8 +18398,8 @@ Methods</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime">
-   <b><a href="#dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime">#dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime" class="dfn-panel" data-for="dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime" id="infopanel-for-dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime" style="display:none">Info about the 'maxDelayTime' definition.</span><b><a href="#dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime">#dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createdelay-maxdelaytime-maxdelaytime">1.1. 
 The BaseAudioContext Interface</a>
@@ -18408,22 +18409,22 @@ Attributes</a>
 Dictionary DelayOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createdynamicscompressor">
-   <b><a href="#dom-baseaudiocontext-createdynamicscompressor">#dom-baseaudiocontext-createdynamicscompressor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createdynamicscompressor" class="dfn-panel" data-for="dom-baseaudiocontext-createdynamicscompressor" id="infopanel-for-dom-baseaudiocontext-createdynamicscompressor" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createdynamicscompressor" style="display:none">Info about the 'createDynamicsCompressor()' definition.</span><b><a href="#dom-baseaudiocontext-createdynamicscompressor">#dom-baseaudiocontext-createdynamicscompressor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createdynamicscompressor">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-creategain">
-   <b><a href="#dom-baseaudiocontext-creategain">#dom-baseaudiocontext-creategain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-creategain" class="dfn-panel" data-for="dom-baseaudiocontext-creategain" id="infopanel-for-dom-baseaudiocontext-creategain" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-creategain" style="display:none">Info about the 'createGain()' definition.</span><b><a href="#dom-baseaudiocontext-creategain">#dom-baseaudiocontext-creategain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-creategain">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter">
-   <b><a href="#dom-baseaudiocontext-createiirfilter">#dom-baseaudiocontext-createiirfilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createiirfilter" class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter" id="infopanel-for-dom-baseaudiocontext-createiirfilter" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createiirfilter" style="display:none">Info about the 'createIIRFilter(feedforward, feedback)' definition.</span><b><a href="#dom-baseaudiocontext-createiirfilter">#dom-baseaudiocontext-createiirfilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createiirfilter">1.1. 
 The BaseAudioContext Interface</a>
@@ -18435,8 +18436,8 @@ Dictionary IIRFilterOptions Members</a> <a href="#ref-for-dom-baseaudiocontext-c
 Filter Definition</a> <a href="#ref-for-dom-baseaudiocontext-createiirfilter⑤">(2)</a> <a href="#ref-for-dom-baseaudiocontext-createiirfilter⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter-feedforward">
-   <b><a href="#dom-baseaudiocontext-createiirfilter-feedforward">#dom-baseaudiocontext-createiirfilter-feedforward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createiirfilter-feedforward" class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter-feedforward" id="infopanel-for-dom-baseaudiocontext-createiirfilter-feedforward" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createiirfilter-feedforward" style="display:none">Info about the 'feedforward' definition.</span><b><a href="#dom-baseaudiocontext-createiirfilter-feedforward">#dom-baseaudiocontext-createiirfilter-feedforward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createiirfilter-feedforward">1.21.3.1. 
 Dictionary IIRFilterOptions Members</a>
@@ -18444,8 +18445,8 @@ Dictionary IIRFilterOptions Members</a>
 Filter Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter-feedback">
-   <b><a href="#dom-baseaudiocontext-createiirfilter-feedback">#dom-baseaudiocontext-createiirfilter-feedback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createiirfilter-feedback" class="dfn-panel" data-for="dom-baseaudiocontext-createiirfilter-feedback" id="infopanel-for-dom-baseaudiocontext-createiirfilter-feedback" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createiirfilter-feedback" style="display:none">Info about the 'feedback' definition.</span><b><a href="#dom-baseaudiocontext-createiirfilter-feedback">#dom-baseaudiocontext-createiirfilter-feedback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createiirfilter-feedback">1.21.3.1. 
 Dictionary IIRFilterOptions Members</a>
@@ -18453,22 +18454,22 @@ Dictionary IIRFilterOptions Members</a>
 Filter Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createoscillator">
-   <b><a href="#dom-baseaudiocontext-createoscillator">#dom-baseaudiocontext-createoscillator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createoscillator" class="dfn-panel" data-for="dom-baseaudiocontext-createoscillator" id="infopanel-for-dom-baseaudiocontext-createoscillator" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createoscillator" style="display:none">Info about the 'createOscillator()' definition.</span><b><a href="#dom-baseaudiocontext-createoscillator">#dom-baseaudiocontext-createoscillator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createoscillator">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createpanner">
-   <b><a href="#dom-baseaudiocontext-createpanner">#dom-baseaudiocontext-createpanner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createpanner" class="dfn-panel" data-for="dom-baseaudiocontext-createpanner" id="infopanel-for-dom-baseaudiocontext-createpanner" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createpanner" style="display:none">Info about the 'createPanner()' definition.</span><b><a href="#dom-baseaudiocontext-createpanner">#dom-baseaudiocontext-createpanner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createpanner">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave">
-   <b><a href="#dom-baseaudiocontext-createperiodicwave">#dom-baseaudiocontext-createperiodicwave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave" class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave" id="infopanel-for-dom-baseaudiocontext-createperiodicwave" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave" style="display:none">Info about the 'createPeriodicWave(real, imag, constraints)' definition.</span><b><a href="#dom-baseaudiocontext-createperiodicwave">#dom-baseaudiocontext-createperiodicwave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createperiodicwave">1.1. 
 The BaseAudioContext Interface</a>
@@ -18480,22 +18481,22 @@ Waveform Generation</a>
 Oscillator Coefficients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave-real">
-   <b><a href="#dom-baseaudiocontext-createperiodicwave-real">#dom-baseaudiocontext-createperiodicwave-real</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave-real" class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave-real" id="infopanel-for-dom-baseaudiocontext-createperiodicwave-real" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave-real" style="display:none">Info about the 'real' definition.</span><b><a href="#dom-baseaudiocontext-createperiodicwave-real">#dom-baseaudiocontext-createperiodicwave-real</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createperiodicwave-real">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-createperiodicwave-real①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave-imag">
-   <b><a href="#dom-baseaudiocontext-createperiodicwave-imag">#dom-baseaudiocontext-createperiodicwave-imag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave-imag" class="dfn-panel" data-for="dom-baseaudiocontext-createperiodicwave-imag" id="infopanel-for-dom-baseaudiocontext-createperiodicwave-imag" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createperiodicwave-imag" style="display:none">Info about the 'imag' definition.</span><b><a href="#dom-baseaudiocontext-createperiodicwave-imag">#dom-baseaudiocontext-createperiodicwave-imag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createperiodicwave-imag">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-createperiodicwave-imag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor">
-   <b><a href="#dom-baseaudiocontext-createscriptprocessor">#dom-baseaudiocontext-createscriptprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor" class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor" id="infopanel-for-dom-baseaudiocontext-createscriptprocessor" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor" style="display:none">Info about the 'createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)' definition.</span><b><a href="#dom-baseaudiocontext-createscriptprocessor">#dom-baseaudiocontext-createscriptprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createscriptprocessor">1.1. 
 The BaseAudioContext Interface</a>
@@ -18505,8 +18506,8 @@ Methods</a>
 The ScriptProcessorNode Interface - DEPRECATED</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize">
-   <b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize" class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize" id="infopanel-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize" style="display:none">Info about the 'bufferSize' definition.</span><b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize">1.1. 
 The BaseAudioContext Interface</a>
@@ -18516,8 +18517,8 @@ Methods</a>
 The ScriptProcessorNode Interface - DEPRECATED</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels">
-   <b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels" class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels" id="infopanel-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels" style="display:none">Info about the 'numberOfInputChannels' definition.</span><b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels">1.1. 
 The BaseAudioContext Interface</a>
@@ -18527,8 +18528,8 @@ Methods</a> <a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffers
 The ScriptProcessorNode Interface - DEPRECATED</a> <a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofinputchannels④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels">
-   <b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels" class="dfn-panel" data-for="dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels" id="infopanel-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels" style="display:none">Info about the 'numberOfOutputChannels' definition.</span><b><a href="#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels">#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels">1.1. 
 The BaseAudioContext Interface</a>
@@ -18538,22 +18539,22 @@ Methods</a> <a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffers
 The ScriptProcessorNode Interface - DEPRECATED</a> <a href="#ref-for-dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-numberofoutputchannels④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createstereopanner">
-   <b><a href="#dom-baseaudiocontext-createstereopanner">#dom-baseaudiocontext-createstereopanner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createstereopanner" class="dfn-panel" data-for="dom-baseaudiocontext-createstereopanner" id="infopanel-for-dom-baseaudiocontext-createstereopanner" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createstereopanner" style="display:none">Info about the 'createStereoPanner()' definition.</span><b><a href="#dom-baseaudiocontext-createstereopanner">#dom-baseaudiocontext-createstereopanner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createstereopanner">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-createwaveshaper">
-   <b><a href="#dom-baseaudiocontext-createwaveshaper">#dom-baseaudiocontext-createwaveshaper</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-createwaveshaper" class="dfn-panel" data-for="dom-baseaudiocontext-createwaveshaper" id="infopanel-for-dom-baseaudiocontext-createwaveshaper" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-createwaveshaper" style="display:none">Info about the 'createWaveShaper()' definition.</span><b><a href="#dom-baseaudiocontext-createwaveshaper">#dom-baseaudiocontext-createwaveshaper</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-createwaveshaper">1.1. 
 The BaseAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata">
-   <b><a href="#dom-baseaudiocontext-decodeaudiodata">#dom-baseaudiocontext-decodeaudiodata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata" class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata" id="infopanel-for-dom-baseaudiocontext-decodeaudiodata" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata" style="display:none">Info about the 'decodeAudioData(audioData, successCallback, errorCallback)' definition.</span><b><a href="#dom-baseaudiocontext-decodeaudiodata">#dom-baseaudiocontext-decodeaudiodata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-decodeaudiodata">1.1. 
 The BaseAudioContext Interface</a>
@@ -18561,30 +18562,31 @@ The BaseAudioContext Interface</a>
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-decoding-thread">
-   <b><a href="#dom-baseaudiocontext-decoding-thread">#dom-baseaudiocontext-decoding-thread</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-decoding-thread" class="dfn-panel" data-for="dom-baseaudiocontext-decoding-thread" id="infopanel-for-dom-baseaudiocontext-decoding-thread" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-decoding-thread" style="display:none">Info about the 'decoding thread' definition.</span><b><a href="#dom-baseaudiocontext-decoding-thread">#dom-baseaudiocontext-decoding-thread</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-decoding-thread">1.1.2. 
 Methods</a>
     <li><a href="#ref-for-dom-baseaudiocontext-decoding-thread①">2.5. Unloading a document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-successcallback">
-   <b><a href="#dom-baseaudiocontext-decodeaudiodata-successcallback">#dom-baseaudiocontext-decodeaudiodata-successcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-successcallback" class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-successcallback" id="infopanel-for-dom-baseaudiocontext-decodeaudiodata-successcallback" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-successcallback" style="display:none">Info about the 'successCallback' definition.</span><b><a href="#dom-baseaudiocontext-decodeaudiodata-successcallback">#dom-baseaudiocontext-decodeaudiodata-successcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-successcallback">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-successcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-errorcallback">
-   <b><a href="#dom-baseaudiocontext-decodeaudiodata-errorcallback">#dom-baseaudiocontext-decodeaudiodata-errorcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-errorcallback" class="dfn-panel" data-for="dom-baseaudiocontext-decodeaudiodata-errorcallback" id="infopanel-for-dom-baseaudiocontext-decodeaudiodata-errorcallback" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-decodeaudiodata-errorcallback" style="display:none">Info about the 'errorCallback' definition.</span><b><a href="#dom-baseaudiocontext-decodeaudiodata-errorcallback">#dom-baseaudiocontext-decodeaudiodata-errorcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-errorcallback">1.1.2. 
 Methods</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-errorcallback①">(2)</a> <a href="#ref-for-dom-baseaudiocontext-decodeaudiodata-errorcallback②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callback-decodesuccesscallback-parameters">
-   <b><a href="#callback-decodesuccesscallback-parameters">#callback-decodesuccesscallback-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callback-decodesuccesscallback-parameters" class="dfn-panel" data-for="callback-decodesuccesscallback-parameters" id="infopanel-for-callback-decodesuccesscallback-parameters" role="dialog">
+   <span id="infopaneltitle-for-callback-decodesuccesscallback-parameters" style="display:none">Info about the '1.1.3. 
+Callback DecodeSuccessCallback() Parameters' definition.</span><b><a href="#callback-decodesuccesscallback-parameters">#callback-decodesuccesscallback-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callback-decodesuccesscallback-parameters">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-callback-decodesuccesscallback-parameters①">(2)</a>
@@ -18594,8 +18596,9 @@ Methods</a>
 Callback DecodeSuccessCallback() Parameters</a> <a href="#ref-for-callback-decodesuccesscallback-parameters">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callback-decodeerrorcallback-parameters">
-   <b><a href="#callback-decodeerrorcallback-parameters">#callback-decodeerrorcallback-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callback-decodeerrorcallback-parameters" class="dfn-panel" data-for="callback-decodeerrorcallback-parameters" id="infopanel-for-callback-decodeerrorcallback-parameters" role="dialog">
+   <span id="infopaneltitle-for-callback-decodeerrorcallback-parameters" style="display:none">Info about the '1.1.4. 
+Callback DecodeErrorCallback() Parameters' definition.</span><b><a href="#callback-decodeerrorcallback-parameters">#callback-decodeerrorcallback-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callback-decodeerrorcallback-parameters">1.1. 
 The BaseAudioContext Interface</a> <a href="#ref-for-callback-decodeerrorcallback-parameters①">(2)</a>
@@ -18605,8 +18608,8 @@ Methods</a>
 Callback DecodeErrorCallback() Parameters</a> <a href="#ref-for-callback-decodeerrorcallback-parameters">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acquiring">
-   <b><a href="#acquiring">#acquiring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acquiring" class="dfn-panel" data-for="acquiring" id="infopanel-for-acquiring" role="dialog">
+   <span id="infopaneltitle-for-acquiring" style="display:none">Info about the 'acquiring system resources' definition.</span><b><a href="#acquiring">#acquiring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acquiring">1.2.1. 
 Constructors</a>
@@ -18614,23 +18617,24 @@ Constructors</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="releasing">
-   <b><a href="#releasing">#releasing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-releasing" class="dfn-panel" data-for="releasing" id="infopanel-for-releasing" role="dialog">
+   <span id="infopaneltitle-for-releasing" style="display:none">Info about the 'release system resources' definition.</span><b><a href="#releasing">#releasing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-releasing">1.2.3. 
 Methods</a> <a href="#ref-for-releasing①">(2)</a> <a href="#ref-for-releasing②">(3)</a> <a href="#ref-for-releasing③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioContext">
-   <b><a href="#AudioContext">#AudioContext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioContext" class="dfn-panel" data-for="AudioContext" id="infopanel-for-AudioContext" role="dialog">
+   <span id="infopaneltitle-for-AudioContext" style="display:none">Info about the '1.2. 
+The AudioContext Interface' definition.</span><b><a href="#AudioContext">#AudioContext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioContext"> API Overview</a>
     <li><a href="#ref-for-AudioContext">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-audiocontextlatencycategory">
-   <b><a href="#enumdef-audiocontextlatencycategory">#enumdef-audiocontextlatencycategory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-audiocontextlatencycategory" class="dfn-panel" data-for="enumdef-audiocontextlatencycategory" id="infopanel-for-enumdef-audiocontextlatencycategory" role="dialog">
+   <span id="infopaneltitle-for-enumdef-audiocontextlatencycategory" style="display:none">Info about the 'AudioContextLatencyCategory' definition.</span><b><a href="#enumdef-audiocontextlatencycategory">#enumdef-audiocontextlatencycategory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-audiocontextlatencycategory">1.2.4. 
 AudioContextOptions</a>
@@ -18638,29 +18642,29 @@ AudioContextOptions</a>
 Dictionary AudioContextOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextlatencycategory-balanced">
-   <b><a href="#dom-audiocontextlatencycategory-balanced">#dom-audiocontextlatencycategory-balanced</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextlatencycategory-balanced" class="dfn-panel" data-for="dom-audiocontextlatencycategory-balanced" id="infopanel-for-dom-audiocontextlatencycategory-balanced" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextlatencycategory-balanced" style="display:none">Info about the 'balanced' definition.</span><b><a href="#dom-audiocontextlatencycategory-balanced">#dom-audiocontextlatencycategory-balanced</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextlatencycategory-balanced">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextlatencycategory-interactive">
-   <b><a href="#dom-audiocontextlatencycategory-interactive">#dom-audiocontextlatencycategory-interactive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextlatencycategory-interactive" class="dfn-panel" data-for="dom-audiocontextlatencycategory-interactive" id="infopanel-for-dom-audiocontextlatencycategory-interactive" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextlatencycategory-interactive" style="display:none">Info about the 'interactive' definition.</span><b><a href="#dom-audiocontextlatencycategory-interactive">#dom-audiocontextlatencycategory-interactive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextlatencycategory-interactive">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextlatencycategory-playback">
-   <b><a href="#dom-audiocontextlatencycategory-playback">#dom-audiocontextlatencycategory-playback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextlatencycategory-playback" class="dfn-panel" data-for="dom-audiocontextlatencycategory-playback" id="infopanel-for-dom-audiocontextlatencycategory-playback" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextlatencycategory-playback" style="display:none">Info about the 'playback' definition.</span><b><a href="#dom-audiocontextlatencycategory-playback">#dom-audiocontextlatencycategory-playback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextlatencycategory-playback">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiocontext">
-   <b><a href="#audiocontext">#audiocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiocontext" class="dfn-panel" data-for="audiocontext" id="infopanel-for-audiocontext" role="dialog">
+   <span id="infopaneltitle-for-audiocontext" style="display:none">Info about the 'AudioContext' definition.</span><b><a href="#audiocontext">#audiocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiocontext"> Modular Routing</a>
     <li><a href="#ref-for-audiocontext①"> API Overview</a>
@@ -18755,8 +18759,8 @@ Latency</a>
 Security and Privacy Considerations</a> <a href="#ref-for-audiocontext①③⑨">(2)</a> <a href="#ref-for-audiocontext①④⓪">(3)</a> <a href="#ref-for-audiocontext①④①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-to-start">
-   <b><a href="#allowed-to-start">#allowed-to-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-to-start" class="dfn-panel" data-for="allowed-to-start" id="infopanel-for-allowed-to-start" role="dialog">
+   <span id="infopaneltitle-for-allowed-to-start" style="display:none">Info about the 'allowed to start' definition.</span><b><a href="#allowed-to-start">#allowed-to-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-start">1.2.1. 
 Constructors</a>
@@ -18768,8 +18772,8 @@ Methods</a> <a href="#ref-for-allowed-to-start③">(2)</a>
 Methods</a> <a href="#ref-for-allowed-to-start⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-suspended-by-user-slot">
-   <b><a href="#dom-audiocontext-suspended-by-user-slot">#dom-audiocontext-suspended-by-user-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-suspended-by-user-slot" class="dfn-panel" data-for="dom-audiocontext-suspended-by-user-slot" id="infopanel-for-dom-audiocontext-suspended-by-user-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-suspended-by-user-slot" style="display:none">Info about the '[[suspended by user]]' definition.</span><b><a href="#dom-audiocontext-suspended-by-user-slot">#dom-audiocontext-suspended-by-user-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-suspended-by-user-slot">1.2.3. 
 Methods</a> <a href="#ref-for-dom-audiocontext-suspended-by-user-slot①">(2)</a>
@@ -18779,8 +18783,8 @@ Methods</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-audiocontext">
-   <b><a href="#dom-audiocontext-audiocontext">#dom-audiocontext-audiocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-audiocontext" class="dfn-panel" data-for="dom-audiocontext-audiocontext" id="infopanel-for-dom-audiocontext-audiocontext" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-audiocontext" style="display:none">Info about the 'AudioContext(contextOptions)' definition.</span><b><a href="#dom-audiocontext-audiocontext">#dom-audiocontext-audiocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-audiocontext">1.2. 
 The AudioContext Interface</a>
@@ -18788,22 +18792,22 @@ The AudioContext Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-pending-resume-promises-slot">
-   <b><a href="#dom-audiocontext-pending-resume-promises-slot">#dom-audiocontext-pending-resume-promises-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-pending-resume-promises-slot" class="dfn-panel" data-for="dom-audiocontext-pending-resume-promises-slot" id="infopanel-for-dom-audiocontext-pending-resume-promises-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-pending-resume-promises-slot" style="display:none">Info about the '[[pending resume promises]]' definition.</span><b><a href="#dom-audiocontext-pending-resume-promises-slot">#dom-audiocontext-pending-resume-promises-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-pending-resume-promises-slot">1.2.3. 
 Methods</a> <a href="#ref-for-dom-audiocontext-pending-resume-promises-slot①">(2)</a> <a href="#ref-for-dom-audiocontext-pending-resume-promises-slot②">(3)</a> <a href="#ref-for-dom-audiocontext-pending-resume-promises-slot③">(4)</a> <a href="#ref-for-dom-audiocontext-pending-resume-promises-slot④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-constructor-contextoptions-contextoptions">
-   <b><a href="#dom-audiocontext-constructor-contextoptions-contextoptions">#dom-audiocontext-constructor-contextoptions-contextoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-constructor-contextoptions-contextoptions" class="dfn-panel" data-for="dom-audiocontext-constructor-contextoptions-contextoptions" id="infopanel-for-dom-audiocontext-constructor-contextoptions-contextoptions" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-constructor-contextoptions-contextoptions" style="display:none">Info about the 'contextOptions' definition.</span><b><a href="#dom-audiocontext-constructor-contextoptions-contextoptions">#dom-audiocontext-constructor-contextoptions-contextoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-constructor-contextoptions-contextoptions">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-baselatency">
-   <b><a href="#dom-audiocontext-baselatency">#dom-audiocontext-baselatency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-baselatency" class="dfn-panel" data-for="dom-audiocontext-baselatency" id="infopanel-for-dom-audiocontext-baselatency" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-baselatency" style="display:none">Info about the 'baseLatency' definition.</span><b><a href="#dom-audiocontext-baselatency">#dom-audiocontext-baselatency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-baselatency">1.2. 
 The AudioContext Interface</a>
@@ -18813,8 +18817,8 @@ Dictionary AudioContextOptions Members</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-outputlatency">
-   <b><a href="#dom-audiocontext-outputlatency">#dom-audiocontext-outputlatency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-outputlatency" class="dfn-panel" data-for="dom-audiocontext-outputlatency" id="infopanel-for-dom-audiocontext-outputlatency" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-outputlatency" style="display:none">Info about the 'outputLatency' definition.</span><b><a href="#dom-audiocontext-outputlatency">#dom-audiocontext-outputlatency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-outputlatency">1.2. 
 The AudioContext Interface</a>
@@ -18826,8 +18830,8 @@ Methods</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-close">
-   <b><a href="#dom-audiocontext-close">#dom-audiocontext-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-close" class="dfn-panel" data-for="dom-audiocontext-close" id="infopanel-for-dom-audiocontext-close" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#dom-audiocontext-close">#dom-audiocontext-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-close">1.1.7. 
 System Resources Associated with BaseAudioContext Subclasses</a>
@@ -18836,8 +18840,8 @@ The AudioContext Interface</a>
     <li><a href="#ref-for-dom-audiocontext-close②">2.5. Unloading a document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-createmediaelementsource">
-   <b><a href="#dom-audiocontext-createmediaelementsource">#dom-audiocontext-createmediaelementsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-createmediaelementsource" class="dfn-panel" data-for="dom-audiocontext-createmediaelementsource" id="infopanel-for-dom-audiocontext-createmediaelementsource" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-createmediaelementsource" style="display:none">Info about the 'createMediaElementSource(mediaElement)' definition.</span><b><a href="#dom-audiocontext-createmediaelementsource">#dom-audiocontext-createmediaelementsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-createmediaelementsource">1.2. 
 The AudioContext Interface</a>
@@ -18847,15 +18851,15 @@ Methods</a>
 The MediaElementAudioSourceNode Interface</a> <a href="#ref-for-dom-audiocontext-createmediaelementsource③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-createmediastreamdestination">
-   <b><a href="#dom-audiocontext-createmediastreamdestination">#dom-audiocontext-createmediastreamdestination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-createmediastreamdestination" class="dfn-panel" data-for="dom-audiocontext-createmediastreamdestination" id="infopanel-for-dom-audiocontext-createmediastreamdestination" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-createmediastreamdestination" style="display:none">Info about the 'createMediaStreamDestination()' definition.</span><b><a href="#dom-audiocontext-createmediastreamdestination">#dom-audiocontext-createmediastreamdestination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-createmediastreamdestination">1.2. 
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-createmediastreamsource">
-   <b><a href="#dom-audiocontext-createmediastreamsource">#dom-audiocontext-createmediastreamsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-createmediastreamsource" class="dfn-panel" data-for="dom-audiocontext-createmediastreamsource" id="infopanel-for-dom-audiocontext-createmediastreamsource" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-createmediastreamsource" style="display:none">Info about the 'createMediaStreamSource(mediaStream)' definition.</span><b><a href="#dom-audiocontext-createmediastreamsource">#dom-audiocontext-createmediastreamsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-createmediastreamsource">1.2. 
 The AudioContext Interface</a>
@@ -18863,8 +18867,8 @@ The AudioContext Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-createmediastreamtracksource">
-   <b><a href="#dom-audiocontext-createmediastreamtracksource">#dom-audiocontext-createmediastreamtracksource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-createmediastreamtracksource" class="dfn-panel" data-for="dom-audiocontext-createmediastreamtracksource" id="infopanel-for-dom-audiocontext-createmediastreamtracksource" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-createmediastreamtracksource" style="display:none">Info about the 'createMediaStreamTrackSource(mediaStreamTrack)' definition.</span><b><a href="#dom-audiocontext-createmediastreamtracksource">#dom-audiocontext-createmediastreamtracksource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-createmediastreamtracksource">1.2. 
 The AudioContext Interface</a>
@@ -18872,8 +18876,8 @@ The AudioContext Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-getoutputtimestamp">
-   <b><a href="#dom-audiocontext-getoutputtimestamp">#dom-audiocontext-getoutputtimestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-getoutputtimestamp" class="dfn-panel" data-for="dom-audiocontext-getoutputtimestamp" id="infopanel-for-dom-audiocontext-getoutputtimestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-getoutputtimestamp" style="display:none">Info about the 'getOutputTimestamp()' definition.</span><b><a href="#dom-audiocontext-getoutputtimestamp">#dom-audiocontext-getoutputtimestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-getoutputtimestamp">1.2. 
 The AudioContext Interface</a>
@@ -18883,8 +18887,8 @@ Methods</a> <a href="#ref-for-dom-audiocontext-getoutputtimestamp②">(2)</a> <a
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-resume">
-   <b><a href="#dom-audiocontext-resume">#dom-audiocontext-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-resume" class="dfn-panel" data-for="dom-audiocontext-resume" id="infopanel-for-dom-audiocontext-resume" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-resume" style="display:none">Info about the 'resume()' definition.</span><b><a href="#dom-audiocontext-resume">#dom-audiocontext-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-resume">1.1.7. 
 System Resources Associated with BaseAudioContext Subclasses</a>
@@ -18892,8 +18896,8 @@ System Resources Associated with BaseAudioContext Subclasses</a>
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontext-suspend">
-   <b><a href="#dom-audiocontext-suspend">#dom-audiocontext-suspend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontext-suspend" class="dfn-panel" data-for="dom-audiocontext-suspend" id="infopanel-for-dom-audiocontext-suspend" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontext-suspend" style="display:none">Info about the 'suspend()' definition.</span><b><a href="#dom-audiocontext-suspend">#dom-audiocontext-suspend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontext-suspend">1.1.7. 
 System Resources Associated with BaseAudioContext Subclasses</a>
@@ -18901,15 +18905,16 @@ System Resources Associated with BaseAudioContext Subclasses</a>
 The AudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioContextOptions">
-   <b><a href="#AudioContextOptions">#AudioContextOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioContextOptions" class="dfn-panel" data-for="AudioContextOptions" id="infopanel-for-AudioContextOptions" role="dialog">
+   <span id="infopaneltitle-for-AudioContextOptions" style="display:none">Info about the '1.2.4. 
+AudioContextOptions' definition.</span><b><a href="#AudioContextOptions">#AudioContextOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioContextOptions">1.2.4. 
 AudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audiocontextoptions">
-   <b><a href="#dictdef-audiocontextoptions">#dictdef-audiocontextoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audiocontextoptions" class="dfn-panel" data-for="dictdef-audiocontextoptions" id="infopanel-for-dictdef-audiocontextoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audiocontextoptions" style="display:none">Info about the 'AudioContextOptions' definition.</span><b><a href="#dictdef-audiocontextoptions">#dictdef-audiocontextoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audiocontextoptions">1.2. 
 The AudioContext Interface</a>
@@ -18921,8 +18926,8 @@ AudioContextOptions</a> <a href="#ref-for-dictdef-audiocontextoptions③">(2)</a
 Dictionary AudioContextOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextoptions-latencyhint">
-   <b><a href="#dom-audiocontextoptions-latencyhint">#dom-audiocontextoptions-latencyhint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextoptions-latencyhint" class="dfn-panel" data-for="dom-audiocontextoptions-latencyhint" id="infopanel-for-dom-audiocontextoptions-latencyhint" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextoptions-latencyhint" style="display:none">Info about the 'latencyHint' definition.</span><b><a href="#dom-audiocontextoptions-latencyhint">#dom-audiocontextoptions-latencyhint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextoptions-latencyhint">1.2.1. 
 Constructors</a> <a href="#ref-for-dom-audiocontextoptions-latencyhint①">(2)</a>
@@ -18930,8 +18935,8 @@ Constructors</a> <a href="#ref-for-dom-audiocontextoptions-latencyhint①">(2)</
 AudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiocontextoptions-samplerate">
-   <b><a href="#dom-audiocontextoptions-samplerate">#dom-audiocontextoptions-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiocontextoptions-samplerate" class="dfn-panel" data-for="dom-audiocontextoptions-samplerate" id="infopanel-for-dom-audiocontextoptions-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-audiocontextoptions-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-audiocontextoptions-samplerate">#dom-audiocontextoptions-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiocontextoptions-samplerate">1.2.1. 
 Constructors</a>
@@ -18941,15 +18946,16 @@ AudioContextOptions</a>
 Dictionary AudioContextOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioTimestamp">
-   <b><a href="#AudioTimestamp">#AudioTimestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioTimestamp" class="dfn-panel" data-for="AudioTimestamp" id="infopanel-for-AudioTimestamp" role="dialog">
+   <span id="infopaneltitle-for-AudioTimestamp" style="display:none">Info about the '1.2.5. 
+AudioTimestamp' definition.</span><b><a href="#AudioTimestamp">#AudioTimestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioTimestamp">1.2.5. 
 AudioTimestamp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audiotimestamp">
-   <b><a href="#dictdef-audiotimestamp">#dictdef-audiotimestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audiotimestamp" class="dfn-panel" data-for="dictdef-audiotimestamp" id="infopanel-for-dictdef-audiotimestamp" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audiotimestamp" style="display:none">Info about the 'AudioTimestamp' definition.</span><b><a href="#dictdef-audiotimestamp">#dictdef-audiotimestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audiotimestamp">1.2. 
 The AudioContext Interface</a>
@@ -18961,8 +18967,8 @@ AudioTimestamp</a>
 Dictionary AudioTimestamp Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiotimestamp-contexttime">
-   <b><a href="#dom-audiotimestamp-contexttime">#dom-audiotimestamp-contexttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiotimestamp-contexttime" class="dfn-panel" data-for="dom-audiotimestamp-contexttime" id="infopanel-for-dom-audiotimestamp-contexttime" role="dialog">
+   <span id="infopaneltitle-for-dom-audiotimestamp-contexttime" style="display:none">Info about the 'contextTime' definition.</span><b><a href="#dom-audiotimestamp-contexttime">#dom-audiotimestamp-contexttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiotimestamp-contexttime">1.2.3. 
 Methods</a> <a href="#ref-for-dom-audiotimestamp-contexttime①">(2)</a> <a href="#ref-for-dom-audiotimestamp-contexttime②">(3)</a>
@@ -18970,8 +18976,8 @@ Methods</a> <a href="#ref-for-dom-audiotimestamp-contexttime①">(2)</a> <a href
 AudioTimestamp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiotimestamp-performancetime">
-   <b><a href="#dom-audiotimestamp-performancetime">#dom-audiotimestamp-performancetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiotimestamp-performancetime" class="dfn-panel" data-for="dom-audiotimestamp-performancetime" id="infopanel-for-dom-audiotimestamp-performancetime" role="dialog">
+   <span id="infopaneltitle-for-dom-audiotimestamp-performancetime" style="display:none">Info about the 'performanceTime' definition.</span><b><a href="#dom-audiotimestamp-performancetime">#dom-audiotimestamp-performancetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiotimestamp-performancetime">1.2.3. 
 Methods</a>
@@ -18979,15 +18985,16 @@ Methods</a>
 AudioTimestamp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OfflineAudioContext">
-   <b><a href="#OfflineAudioContext">#OfflineAudioContext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OfflineAudioContext" class="dfn-panel" data-for="OfflineAudioContext" id="infopanel-for-OfflineAudioContext" role="dialog">
+   <span id="infopaneltitle-for-OfflineAudioContext" style="display:none">Info about the '1.3. 
+The OfflineAudioContext Interface' definition.</span><b><a href="#OfflineAudioContext">#OfflineAudioContext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OfflineAudioContext">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offlineaudiocontext">
-   <b><a href="#offlineaudiocontext">#offlineaudiocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offlineaudiocontext" class="dfn-panel" data-for="offlineaudiocontext" id="infopanel-for-offlineaudiocontext" role="dialog">
+   <span id="infopaneltitle-for-offlineaudiocontext" style="display:none">Info about the 'OfflineAudioContext' definition.</span><b><a href="#offlineaudiocontext">#offlineaudiocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offlineaudiocontext">1.1. 
 The BaseAudioContext Interface</a>
@@ -19024,8 +19031,8 @@ Rendering an Audio Graph</a>
     <li><a href="#ref-for-offlineaudiocontext③⑦">2.5. Unloading a document</a> <a href="#ref-for-offlineaudiocontext③⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-offlineaudiocontext">
-   <b><a href="#dom-offlineaudiocontext-offlineaudiocontext">#dom-offlineaudiocontext-offlineaudiocontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-offlineaudiocontext" class="dfn-panel" data-for="dom-offlineaudiocontext-offlineaudiocontext" id="infopanel-for-dom-offlineaudiocontext-offlineaudiocontext" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-offlineaudiocontext" style="display:none">Info about the 'OfflineAudioContext(contextOptions)' definition.</span><b><a href="#dom-offlineaudiocontext-offlineaudiocontext">#dom-offlineaudiocontext-offlineaudiocontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-offlineaudiocontext">1.3. 
 The OfflineAudioContext Interface</a>
@@ -19033,15 +19040,15 @@ The OfflineAudioContext Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-contextoptions-contextoptions">
-   <b><a href="#dom-offlineaudiocontext-constructor-contextoptions-contextoptions">#dom-offlineaudiocontext-constructor-contextoptions-contextoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-constructor-contextoptions-contextoptions" class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-contextoptions-contextoptions" id="infopanel-for-dom-offlineaudiocontext-constructor-contextoptions-contextoptions" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-constructor-contextoptions-contextoptions" style="display:none">Info about the 'contextOptions' definition.</span><b><a href="#dom-offlineaudiocontext-constructor-contextoptions-contextoptions">#dom-offlineaudiocontext-constructor-contextoptions-contextoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-constructor-contextoptions-contextoptions">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">
-   <b><a href="#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate" class="dfn-panel" data-for="dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate" id="infopanel-for-dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate" style="display:none">Info about the 'OfflineAudioContext(numberOfChannels, length, sampleRate)' definition.</span><b><a href="#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">1.3. 
 The OfflineAudioContext Interface</a>
@@ -19049,36 +19056,36 @@ The OfflineAudioContext Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels">
-   <b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels" class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels" id="infopanel-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels" style="display:none">Info about the 'numberOfChannels' definition.</span><b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-numberofchannels">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length">
-   <b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length" class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length" id="infopanel-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-length">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate">
-   <b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate" class="dfn-panel" data-for="dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate" id="infopanel-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate">#dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-constructor-numberofchannels-length-samplerate-samplerate">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-length">
-   <b><a href="#dom-offlineaudiocontext-length">#dom-offlineaudiocontext-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-length" class="dfn-panel" data-for="dom-offlineaudiocontext-length" id="infopanel-for-dom-offlineaudiocontext-length" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-offlineaudiocontext-length">#dom-offlineaudiocontext-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-length">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-oncomplete">
-   <b><a href="#dom-offlineaudiocontext-oncomplete">#dom-offlineaudiocontext-oncomplete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-oncomplete" class="dfn-panel" data-for="dom-offlineaudiocontext-oncomplete" id="infopanel-for-dom-offlineaudiocontext-oncomplete" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-oncomplete" style="display:none">Info about the 'oncomplete' definition.</span><b><a href="#dom-offlineaudiocontext-oncomplete">#dom-offlineaudiocontext-oncomplete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-oncomplete">1.1.1. 
 Attributes</a>
@@ -19086,8 +19093,8 @@ Attributes</a>
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-startrendering">
-   <b><a href="#dom-offlineaudiocontext-startrendering">#dom-offlineaudiocontext-startrendering</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-startrendering" class="dfn-panel" data-for="dom-offlineaudiocontext-startrendering" id="infopanel-for-dom-offlineaudiocontext-startrendering" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-startrendering" style="display:none">Info about the 'startRendering()' definition.</span><b><a href="#dom-offlineaudiocontext-startrendering">#dom-offlineaudiocontext-startrendering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-startrendering">1.3. 
 The OfflineAudioContext Interface</a>
@@ -19095,36 +19102,36 @@ The OfflineAudioContext Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-rendering-started-slot">
-   <b><a href="#dom-offlineaudiocontext-rendering-started-slot">#dom-offlineaudiocontext-rendering-started-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-rendering-started-slot" class="dfn-panel" data-for="dom-offlineaudiocontext-rendering-started-slot" id="infopanel-for-dom-offlineaudiocontext-rendering-started-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-rendering-started-slot" style="display:none">Info about the '[[rendering started]]' definition.</span><b><a href="#dom-offlineaudiocontext-rendering-started-slot">#dom-offlineaudiocontext-rendering-started-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-rendering-started-slot">1.3.3. 
 Methods</a> <a href="#ref-for-dom-offlineaudiocontext-rendering-started-slot①">(2)</a> <a href="#ref-for-dom-offlineaudiocontext-rendering-started-slot②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-rendered-buffer-slot">
-   <b><a href="#dom-offlineaudiocontext-rendered-buffer-slot">#dom-offlineaudiocontext-rendered-buffer-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-rendered-buffer-slot" class="dfn-panel" data-for="dom-offlineaudiocontext-rendered-buffer-slot" id="infopanel-for-dom-offlineaudiocontext-rendered-buffer-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-rendered-buffer-slot" style="display:none">Info about the '[[rendered buffer]]' definition.</span><b><a href="#dom-offlineaudiocontext-rendered-buffer-slot">#dom-offlineaudiocontext-rendered-buffer-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-rendered-buffer-slot">1.3.3. 
 Methods</a> <a href="#ref-for-dom-offlineaudiocontext-rendered-buffer-slot①">(2)</a> <a href="#ref-for-dom-offlineaudiocontext-rendered-buffer-slot②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="begin-offline-rendering">
-   <b><a href="#begin-offline-rendering">#begin-offline-rendering</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-begin-offline-rendering" class="dfn-panel" data-for="begin-offline-rendering" id="infopanel-for-begin-offline-rendering" role="dialog">
+   <span id="infopaneltitle-for-begin-offline-rendering" style="display:none">Info about the 'begin offline rendering' definition.</span><b><a href="#begin-offline-rendering">#begin-offline-rendering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-begin-offline-rendering">1.3.3. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-resume">
-   <b><a href="#dom-offlineaudiocontext-resume">#dom-offlineaudiocontext-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-resume" class="dfn-panel" data-for="dom-offlineaudiocontext-resume" id="infopanel-for-dom-offlineaudiocontext-resume" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-resume" style="display:none">Info about the 'resume()' definition.</span><b><a href="#dom-offlineaudiocontext-resume">#dom-offlineaudiocontext-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-resume">1.3. 
 The OfflineAudioContext Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontext-suspend">
-   <b><a href="#dom-offlineaudiocontext-suspend">#dom-offlineaudiocontext-suspend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontext-suspend" class="dfn-panel" data-for="dom-offlineaudiocontext-suspend" id="infopanel-for-dom-offlineaudiocontext-suspend" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontext-suspend" style="display:none">Info about the 'suspend(suspendTime)' definition.</span><b><a href="#dom-offlineaudiocontext-suspend">#dom-offlineaudiocontext-suspend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontext-suspend">1.3. 
 The OfflineAudioContext Interface</a>
@@ -19132,15 +19139,16 @@ The OfflineAudioContext Interface</a>
 Methods</a> <a href="#ref-for-dom-offlineaudiocontext-suspend②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OfflineAudioContextOptions">
-   <b><a href="#OfflineAudioContextOptions">#OfflineAudioContextOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OfflineAudioContextOptions" class="dfn-panel" data-for="OfflineAudioContextOptions" id="infopanel-for-OfflineAudioContextOptions" role="dialog">
+   <span id="infopaneltitle-for-OfflineAudioContextOptions" style="display:none">Info about the '1.3.4. 
+OfflineAudioContextOptions' definition.</span><b><a href="#OfflineAudioContextOptions">#OfflineAudioContextOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OfflineAudioContextOptions">1.3.4. 
 OfflineAudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-offlineaudiocontextoptions">
-   <b><a href="#dictdef-offlineaudiocontextoptions">#dictdef-offlineaudiocontextoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-offlineaudiocontextoptions" class="dfn-panel" data-for="dictdef-offlineaudiocontextoptions" id="infopanel-for-dictdef-offlineaudiocontextoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-offlineaudiocontextoptions" style="display:none">Info about the 'OfflineAudioContextOptions' definition.</span><b><a href="#dictdef-offlineaudiocontextoptions">#dictdef-offlineaudiocontextoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-offlineaudiocontextoptions">1.3. 
 The OfflineAudioContext Interface</a>
@@ -19150,29 +19158,30 @@ OfflineAudioContextOptions</a>
 Dictionary OfflineAudioContextOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontextoptions-length">
-   <b><a href="#dom-offlineaudiocontextoptions-length">#dom-offlineaudiocontextoptions-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontextoptions-length" class="dfn-panel" data-for="dom-offlineaudiocontextoptions-length" id="infopanel-for-dom-offlineaudiocontextoptions-length" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontextoptions-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-offlineaudiocontextoptions-length">#dom-offlineaudiocontextoptions-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontextoptions-length">1.3.4. 
 OfflineAudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontextoptions-numberofchannels">
-   <b><a href="#dom-offlineaudiocontextoptions-numberofchannels">#dom-offlineaudiocontextoptions-numberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontextoptions-numberofchannels" class="dfn-panel" data-for="dom-offlineaudiocontextoptions-numberofchannels" id="infopanel-for-dom-offlineaudiocontextoptions-numberofchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontextoptions-numberofchannels" style="display:none">Info about the 'numberOfChannels' definition.</span><b><a href="#dom-offlineaudiocontextoptions-numberofchannels">#dom-offlineaudiocontextoptions-numberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontextoptions-numberofchannels">1.3.4. 
 OfflineAudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocontextoptions-samplerate">
-   <b><a href="#dom-offlineaudiocontextoptions-samplerate">#dom-offlineaudiocontextoptions-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocontextoptions-samplerate" class="dfn-panel" data-for="dom-offlineaudiocontextoptions-samplerate" id="infopanel-for-dom-offlineaudiocontextoptions-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocontextoptions-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-offlineaudiocontextoptions-samplerate">#dom-offlineaudiocontextoptions-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocontextoptions-samplerate">1.3.4. 
 OfflineAudioContextOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OfflineAudioCompletionEvent">
-   <b><a href="#OfflineAudioCompletionEvent">#OfflineAudioCompletionEvent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OfflineAudioCompletionEvent" class="dfn-panel" data-for="OfflineAudioCompletionEvent" id="infopanel-for-OfflineAudioCompletionEvent" role="dialog">
+   <span id="infopaneltitle-for-OfflineAudioCompletionEvent" style="display:none">Info about the '1.3.5. 
+The OfflineAudioCompletionEvent Interface' definition.</span><b><a href="#OfflineAudioCompletionEvent">#OfflineAudioCompletionEvent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OfflineAudioCompletionEvent">1.3.2. 
 Attributes</a>
@@ -19180,8 +19189,8 @@ Attributes</a>
 The OfflineAudioCompletionEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offlineaudiocompletionevent">
-   <b><a href="#offlineaudiocompletionevent">#offlineaudiocompletionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offlineaudiocompletionevent" class="dfn-panel" data-for="offlineaudiocompletionevent" id="infopanel-for-offlineaudiocompletionevent" role="dialog">
+   <span id="infopaneltitle-for-offlineaudiocompletionevent" style="display:none">Info about the 'OfflineAudioCompletionEvent' definition.</span><b><a href="#offlineaudiocompletionevent">#offlineaudiocompletionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offlineaudiocompletionevent">1.3.3. 
 Methods</a>
@@ -19189,8 +19198,8 @@ Methods</a>
 The OfflineAudioCompletionEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocompletionevent-renderedbuffer">
-   <b><a href="#dom-offlineaudiocompletionevent-renderedbuffer">#dom-offlineaudiocompletionevent-renderedbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocompletionevent-renderedbuffer" class="dfn-panel" data-for="dom-offlineaudiocompletionevent-renderedbuffer" id="infopanel-for-dom-offlineaudiocompletionevent-renderedbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocompletionevent-renderedbuffer" style="display:none">Info about the 'renderedBuffer' definition.</span><b><a href="#dom-offlineaudiocompletionevent-renderedbuffer">#dom-offlineaudiocompletionevent-renderedbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocompletionevent-renderedbuffer">1.3.5. 
 The OfflineAudioCompletionEvent Interface</a>
@@ -19198,15 +19207,16 @@ The OfflineAudioCompletionEvent Interface</a>
 Dictionary OfflineAudioCompletionEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OfflineAudioCompletionEventInit">
-   <b><a href="#OfflineAudioCompletionEventInit">#OfflineAudioCompletionEventInit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OfflineAudioCompletionEventInit" class="dfn-panel" data-for="OfflineAudioCompletionEventInit" id="infopanel-for-OfflineAudioCompletionEventInit" role="dialog">
+   <span id="infopaneltitle-for-OfflineAudioCompletionEventInit" style="display:none">Info about the '1.3.5.2. 
+OfflineAudioCompletionEventInit' definition.</span><b><a href="#OfflineAudioCompletionEventInit">#OfflineAudioCompletionEventInit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OfflineAudioCompletionEventInit">1.3.5.2. 
 OfflineAudioCompletionEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-offlineaudiocompletioneventinit">
-   <b><a href="#dictdef-offlineaudiocompletioneventinit">#dictdef-offlineaudiocompletioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-offlineaudiocompletioneventinit" class="dfn-panel" data-for="dictdef-offlineaudiocompletioneventinit" id="infopanel-for-dictdef-offlineaudiocompletioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-offlineaudiocompletioneventinit" style="display:none">Info about the 'OfflineAudioCompletionEventInit' definition.</span><b><a href="#dictdef-offlineaudiocompletioneventinit">#dictdef-offlineaudiocompletioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-offlineaudiocompletioneventinit">1.3.5. 
 The OfflineAudioCompletionEvent Interface</a>
@@ -19216,22 +19226,23 @@ OfflineAudioCompletionEventInit</a>
 Dictionary OfflineAudioCompletionEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-offlineaudiocompletioneventinit-renderedbuffer">
-   <b><a href="#dom-offlineaudiocompletioneventinit-renderedbuffer">#dom-offlineaudiocompletioneventinit-renderedbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-offlineaudiocompletioneventinit-renderedbuffer" class="dfn-panel" data-for="dom-offlineaudiocompletioneventinit-renderedbuffer" id="infopanel-for-dom-offlineaudiocompletioneventinit-renderedbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-offlineaudiocompletioneventinit-renderedbuffer" style="display:none">Info about the 'renderedBuffer' definition.</span><b><a href="#dom-offlineaudiocompletioneventinit-renderedbuffer">#dom-offlineaudiocompletioneventinit-renderedbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-offlineaudiocompletioneventinit-renderedbuffer">1.3.5.2. 
 OfflineAudioCompletionEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioBuffer">
-   <b><a href="#AudioBuffer">#AudioBuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioBuffer" class="dfn-panel" data-for="AudioBuffer" id="infopanel-for-AudioBuffer" role="dialog">
+   <span id="infopaneltitle-for-AudioBuffer" style="display:none">Info about the '1.4. 
+The AudioBuffer Interface' definition.</span><b><a href="#AudioBuffer">#AudioBuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioBuffer">1.4. 
 The AudioBuffer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-number-of-channels-slot">
-   <b><a href="#dom-audiobuffer-number-of-channels-slot">#dom-audiobuffer-number-of-channels-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-number-of-channels-slot" class="dfn-panel" data-for="dom-audiobuffer-number-of-channels-slot" id="infopanel-for-dom-audiobuffer-number-of-channels-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-number-of-channels-slot" style="display:none">Info about the '[[number of channels]]' definition.</span><b><a href="#dom-audiobuffer-number-of-channels-slot">#dom-audiobuffer-number-of-channels-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-number-of-channels-slot">1.4.1. 
 Constructors</a> <a href="#ref-for-dom-audiobuffer-number-of-channels-slot①">(2)</a>
@@ -19241,8 +19252,8 @@ Attributes</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-length-slot">
-   <b><a href="#dom-audiobuffer-length-slot">#dom-audiobuffer-length-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-length-slot" class="dfn-panel" data-for="dom-audiobuffer-length-slot" id="infopanel-for-dom-audiobuffer-length-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-length-slot" style="display:none">Info about the '[[length]]' definition.</span><b><a href="#dom-audiobuffer-length-slot">#dom-audiobuffer-length-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-length-slot">1.4.1. 
 Constructors</a> <a href="#ref-for-dom-audiobuffer-length-slot①">(2)</a>
@@ -19250,8 +19261,8 @@ Constructors</a> <a href="#ref-for-dom-audiobuffer-length-slot①">(2)</a>
 Attributes</a> <a href="#ref-for-dom-audiobuffer-length-slot③">(2)</a> <a href="#ref-for-dom-audiobuffer-length-slot④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-sample-rate-slot">
-   <b><a href="#dom-audiobuffer-sample-rate-slot">#dom-audiobuffer-sample-rate-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-sample-rate-slot" class="dfn-panel" data-for="dom-audiobuffer-sample-rate-slot" id="infopanel-for-dom-audiobuffer-sample-rate-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-sample-rate-slot" style="display:none">Info about the '[[sample rate]]' definition.</span><b><a href="#dom-audiobuffer-sample-rate-slot">#dom-audiobuffer-sample-rate-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-sample-rate-slot">1.4.1. 
 Constructors</a>
@@ -19259,8 +19270,8 @@ Constructors</a>
 Attributes</a> <a href="#ref-for-dom-audiobuffer-sample-rate-slot②">(2)</a> <a href="#ref-for-dom-audiobuffer-sample-rate-slot③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-internal-data-slot">
-   <b><a href="#dom-audiobuffer-internal-data-slot">#dom-audiobuffer-internal-data-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-internal-data-slot" class="dfn-panel" data-for="dom-audiobuffer-internal-data-slot" id="infopanel-for-dom-audiobuffer-internal-data-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-internal-data-slot" style="display:none">Info about the '[[internal data]]' definition.</span><b><a href="#dom-audiobuffer-internal-data-slot">#dom-audiobuffer-internal-data-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-internal-data-slot">1.4.1. 
 Constructors</a>
@@ -19268,8 +19279,8 @@ Constructors</a>
 Methods</a> <a href="#ref-for-dom-audiobuffer-internal-data-slot②">(2)</a> <a href="#ref-for-dom-audiobuffer-internal-data-slot③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiobuffer">
-   <b><a href="#audiobuffer">#audiobuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiobuffer" class="dfn-panel" data-for="audiobuffer" id="infopanel-for-audiobuffer" role="dialog">
+   <span id="infopaneltitle-for-audiobuffer" style="display:none">Info about the 'AudioBuffer' definition.</span><b><a href="#audiobuffer">#audiobuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiobuffer"> API Overview</a>
     <li><a href="#ref-for-audiobuffer①">1.1. 
@@ -19338,8 +19349,8 @@ Constructors</a>
 Audio Buffer Copying</a> <a href="#ref-for-audiobuffer⑦④">(2)</a> <a href="#ref-for-audiobuffer⑦⑤">(3)</a> <a href="#ref-for-audiobuffer⑦⑥">(4)</a> <a href="#ref-for-audiobuffer⑦⑦">(5)</a> <a href="#ref-for-audiobuffer⑦⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-audiobuffer">
-   <b><a href="#dom-audiobuffer-audiobuffer">#dom-audiobuffer-audiobuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-audiobuffer" class="dfn-panel" data-for="dom-audiobuffer-audiobuffer" id="infopanel-for-dom-audiobuffer-audiobuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-audiobuffer" style="display:none">Info about the 'AudioBuffer(options)' definition.</span><b><a href="#dom-audiobuffer-audiobuffer">#dom-audiobuffer-audiobuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-audiobuffer">1.4. 
 The AudioBuffer Interface</a>
@@ -19347,29 +19358,29 @@ The AudioBuffer Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-constructor-options">
-   <b><a href="#dom-audiobuffer-constructor-options">#dom-audiobuffer-constructor-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-constructor-options" class="dfn-panel" data-for="dom-audiobuffer-constructor-options" id="infopanel-for-dom-audiobuffer-constructor-options" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-constructor-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-audiobuffer-constructor-options">#dom-audiobuffer-constructor-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-constructor-options">1.4.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-duration">
-   <b><a href="#dom-audiobuffer-duration">#dom-audiobuffer-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-duration" class="dfn-panel" data-for="dom-audiobuffer-duration" id="infopanel-for-dom-audiobuffer-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#dom-audiobuffer-duration">#dom-audiobuffer-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-duration">1.4. 
 The AudioBuffer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-length">
-   <b><a href="#dom-audiobuffer-length">#dom-audiobuffer-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-length" class="dfn-panel" data-for="dom-audiobuffer-length" id="infopanel-for-dom-audiobuffer-length" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-audiobuffer-length">#dom-audiobuffer-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-length">1.4. 
 The AudioBuffer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-numberofchannels">
-   <b><a href="#dom-audiobuffer-numberofchannels">#dom-audiobuffer-numberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-numberofchannels" class="dfn-panel" data-for="dom-audiobuffer-numberofchannels" id="infopanel-for-dom-audiobuffer-numberofchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-numberofchannels" style="display:none">Info about the 'numberOfChannels' definition.</span><b><a href="#dom-audiobuffer-numberofchannels">#dom-audiobuffer-numberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-numberofchannels">1.4. 
 The AudioBuffer Interface</a>
@@ -19377,8 +19388,8 @@ The AudioBuffer Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-samplerate">
-   <b><a href="#dom-audiobuffer-samplerate">#dom-audiobuffer-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-samplerate" class="dfn-panel" data-for="dom-audiobuffer-samplerate" id="infopanel-for-dom-audiobuffer-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-audiobuffer-samplerate">#dom-audiobuffer-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-samplerate">1.4. 
 The AudioBuffer Interface</a>
@@ -19386,8 +19397,8 @@ The AudioBuffer Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel">
-   <b><a href="#dom-audiobuffer-copyfromchannel">#dom-audiobuffer-copyfromchannel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copyfromchannel" class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel" id="infopanel-for-dom-audiobuffer-copyfromchannel" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copyfromchannel" style="display:none">Info about the 'copyFromChannel(destination, channelNumber, bufferOffset)' definition.</span><b><a href="#dom-audiobuffer-copyfromchannel">#dom-audiobuffer-copyfromchannel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copyfromchannel">1.4. 
 The AudioBuffer Interface</a>
@@ -19395,22 +19406,22 @@ The AudioBuffer Interface</a>
 Methods</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel②">(2)</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel③">(3)</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel-destination">
-   <b><a href="#dom-audiobuffer-copyfromchannel-destination">#dom-audiobuffer-copyfromchannel-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copyfromchannel-destination" class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel-destination" id="infopanel-for-dom-audiobuffer-copyfromchannel-destination" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copyfromchannel-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#dom-audiobuffer-copyfromchannel-destination">#dom-audiobuffer-copyfromchannel-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copyfromchannel-destination">1.4.3. 
 Methods</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel-destination①">(2)</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel-destination②">(3)</a> <a href="#ref-for-dom-audiobuffer-copyfromchannel-destination③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel-bufferoffset">
-   <b><a href="#dom-audiobuffer-copyfromchannel-bufferoffset">#dom-audiobuffer-copyfromchannel-bufferoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copyfromchannel-bufferoffset" class="dfn-panel" data-for="dom-audiobuffer-copyfromchannel-bufferoffset" id="infopanel-for-dom-audiobuffer-copyfromchannel-bufferoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copyfromchannel-bufferoffset" style="display:none">Info about the 'bufferOffset' definition.</span><b><a href="#dom-audiobuffer-copyfromchannel-bufferoffset">#dom-audiobuffer-copyfromchannel-bufferoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copyfromchannel-bufferoffset">1.4.3. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copytochannel">
-   <b><a href="#dom-audiobuffer-copytochannel">#dom-audiobuffer-copytochannel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copytochannel" class="dfn-panel" data-for="dom-audiobuffer-copytochannel" id="infopanel-for-dom-audiobuffer-copytochannel" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copytochannel" style="display:none">Info about the 'copyToChannel(source, channelNumber, bufferOffset)' definition.</span><b><a href="#dom-audiobuffer-copytochannel">#dom-audiobuffer-copytochannel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copytochannel">1.4. 
 The AudioBuffer Interface</a>
@@ -19418,22 +19429,22 @@ The AudioBuffer Interface</a>
 Methods</a> <a href="#ref-for-dom-audiobuffer-copytochannel②">(2)</a> <a href="#ref-for-dom-audiobuffer-copytochannel③">(3)</a> <a href="#ref-for-dom-audiobuffer-copytochannel④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copytochannel-source">
-   <b><a href="#dom-audiobuffer-copytochannel-source">#dom-audiobuffer-copytochannel-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copytochannel-source" class="dfn-panel" data-for="dom-audiobuffer-copytochannel-source" id="infopanel-for-dom-audiobuffer-copytochannel-source" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copytochannel-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-audiobuffer-copytochannel-source">#dom-audiobuffer-copytochannel-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copytochannel-source">1.4.3. 
 Methods</a> <a href="#ref-for-dom-audiobuffer-copytochannel-source①">(2)</a> <a href="#ref-for-dom-audiobuffer-copytochannel-source②">(3)</a> <a href="#ref-for-dom-audiobuffer-copytochannel-source③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-copytochannel-bufferoffset">
-   <b><a href="#dom-audiobuffer-copytochannel-bufferoffset">#dom-audiobuffer-copytochannel-bufferoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-copytochannel-bufferoffset" class="dfn-panel" data-for="dom-audiobuffer-copytochannel-bufferoffset" id="infopanel-for-dom-audiobuffer-copytochannel-bufferoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-copytochannel-bufferoffset" style="display:none">Info about the 'bufferOffset' definition.</span><b><a href="#dom-audiobuffer-copytochannel-bufferoffset">#dom-audiobuffer-copytochannel-bufferoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-copytochannel-bufferoffset">1.4.3. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffer-getchanneldata">
-   <b><a href="#dom-audiobuffer-getchanneldata">#dom-audiobuffer-getchanneldata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffer-getchanneldata" class="dfn-panel" data-for="dom-audiobuffer-getchanneldata" id="infopanel-for-dom-audiobuffer-getchanneldata" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffer-getchanneldata" style="display:none">Info about the 'getChannelData(channel)' definition.</span><b><a href="#dom-audiobuffer-getchanneldata">#dom-audiobuffer-getchanneldata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffer-getchanneldata">1.4. 
 The AudioBuffer Interface</a>
@@ -19443,8 +19454,8 @@ Methods</a> <a href="#ref-for-dom-audiobuffer-getchanneldata②">(2)</a> <a href
 Audio Buffer Copying</a> <a href="#ref-for-dom-audiobuffer-getchanneldata⑥">(2)</a> <a href="#ref-for-dom-audiobuffer-getchanneldata⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acquire-the-content">
-   <b><a href="#acquire-the-content">#acquire-the-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acquire-the-content" class="dfn-panel" data-for="acquire-the-content" id="infopanel-for-acquire-the-content" role="dialog">
+   <span id="infopaneltitle-for-acquire-the-content" style="display:none">Info about the 'acquire the content' definition.</span><b><a href="#acquire-the-content">#acquire-the-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acquire-the-content">1.4.3. 
 Methods</a> <a href="#ref-for-acquire-the-content">(2)</a> <a href="#ref-for-acquire-the-content">(3)</a> <a href="#ref-for-acquire-the-content">(4)</a> <a href="#ref-for-acquire-the-content">(5)</a> <a href="#ref-for-acquire-the-content">(6)</a> <a href="#ref-for-acquire-the-content">(7)</a> <a href="#ref-for-acquire-the-content①">(8)</a>
@@ -19458,15 +19469,16 @@ Attributes</a>
 Audio Buffer Copying</a> <a href="#ref-for-acquire-the-content">(2)</a> <a href="#ref-for-acquire-the-content">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioBufferOptions">
-   <b><a href="#AudioBufferOptions">#AudioBufferOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioBufferOptions" class="dfn-panel" data-for="AudioBufferOptions" id="infopanel-for-AudioBufferOptions" role="dialog">
+   <span id="infopaneltitle-for-AudioBufferOptions" style="display:none">Info about the '1.4.4. 
+AudioBufferOptions' definition.</span><b><a href="#AudioBufferOptions">#AudioBufferOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioBufferOptions">1.4.4. 
 AudioBufferOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audiobufferoptions">
-   <b><a href="#dictdef-audiobufferoptions">#dictdef-audiobufferoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audiobufferoptions" class="dfn-panel" data-for="dictdef-audiobufferoptions" id="infopanel-for-dictdef-audiobufferoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audiobufferoptions" style="display:none">Info about the 'AudioBufferOptions' definition.</span><b><a href="#dictdef-audiobufferoptions">#dictdef-audiobufferoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audiobufferoptions">1.4. 
 The AudioBuffer Interface</a>
@@ -19478,8 +19490,8 @@ AudioBufferOptions</a>
 Dictionary AudioBufferOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobufferoptions-length">
-   <b><a href="#dom-audiobufferoptions-length">#dom-audiobufferoptions-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobufferoptions-length" class="dfn-panel" data-for="dom-audiobufferoptions-length" id="infopanel-for-dom-audiobufferoptions-length" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobufferoptions-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-audiobufferoptions-length">#dom-audiobufferoptions-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobufferoptions-length">1.4.1. 
 Constructors</a>
@@ -19487,8 +19499,8 @@ Constructors</a>
 AudioBufferOptions</a> <a href="#ref-for-dom-audiobufferoptions-length②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobufferoptions-numberofchannels">
-   <b><a href="#dom-audiobufferoptions-numberofchannels">#dom-audiobufferoptions-numberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobufferoptions-numberofchannels" class="dfn-panel" data-for="dom-audiobufferoptions-numberofchannels" id="infopanel-for-dom-audiobufferoptions-numberofchannels" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobufferoptions-numberofchannels" style="display:none">Info about the 'numberOfChannels' definition.</span><b><a href="#dom-audiobufferoptions-numberofchannels">#dom-audiobufferoptions-numberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobufferoptions-numberofchannels">1.4.1. 
 Constructors</a>
@@ -19496,8 +19508,8 @@ Constructors</a>
 AudioBufferOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobufferoptions-samplerate">
-   <b><a href="#dom-audiobufferoptions-samplerate">#dom-audiobufferoptions-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobufferoptions-samplerate" class="dfn-panel" data-for="dom-audiobufferoptions-samplerate" id="infopanel-for-dom-audiobufferoptions-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobufferoptions-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-audiobufferoptions-samplerate">#dom-audiobufferoptions-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobufferoptions-samplerate">1.4.1. 
 Constructors</a>
@@ -19505,29 +19517,30 @@ Constructors</a>
 AudioBufferOptions</a> <a href="#ref-for-dom-audiobufferoptions-samplerate②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioNode">
-   <b><a href="#AudioNode">#AudioNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioNode" class="dfn-panel" data-for="AudioNode" id="infopanel-for-AudioNode" role="dialog">
+   <span id="infopaneltitle-for-AudioNode" style="display:none">Info about the '1.5. 
+The AudioNode Interface' definition.</span><b><a href="#AudioNode">#AudioNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioNode">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection">
-   <b><a href="#connection">#connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection" class="dfn-panel" data-for="connection" id="infopanel-for-connection" role="dialog">
+   <span id="infopaneltitle-for-connection" style="display:none">Info about the 'connection' definition.</span><b><a href="#connection">#connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input">
-   <b><a href="#input">#input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input" class="dfn-panel" data-for="input" id="infopanel-for-input" role="dialog">
+   <span id="infopaneltitle-for-input" style="display:none">Info about the 'input' definition.</span><b><a href="#input">#input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audionode">
-   <b><a href="#audionode">#audionode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audionode" class="dfn-panel" data-for="audionode" id="infopanel-for-audionode" role="dialog">
+   <span id="infopaneltitle-for-audionode" style="display:none">Info about the 'AudioNode' definition.</span><b><a href="#audionode">#audionode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audionode①"> Modular Routing</a> <a href="#ref-for-audionode②">(2)</a> <a href="#ref-for-audionode③">(3)</a>
     <li><a href="#ref-for-audionode④"> API Overview</a> <a href="#ref-for-audionode⑤">(2)</a> <a href="#ref-for-audionode⑥">(3)</a> <a href="#ref-for-audionode⑦">(4)</a> <a href="#ref-for-audionode⑧">(5)</a> <a href="#ref-for-audionode⑨">(6)</a> <a href="#ref-for-audionode①⓪">(7)</a> <a href="#ref-for-audionode①①">(8)</a> <a href="#ref-for-audionode①②">(9)</a> <a href="#ref-for-audionode①③">(10)</a> <a href="#ref-for-audionode①④">(11)</a> <a href="#ref-for-audionode①⑤">(12)</a> <a href="#ref-for-audionode①⑥">(13)</a> <a href="#ref-for-audionode①⑦">(14)</a> <a href="#ref-for-audionode①⑧">(15)</a> <a href="#ref-for-audionode①⑨">(16)</a> <a href="#ref-for-audionode②⓪">(17)</a> <a href="#ref-for-audionode②①">(18)</a> <a href="#ref-for-audionode②②">(19)</a> <a href="#ref-for-audionode②③">(20)</a> <a href="#ref-for-audionode②④">(21)</a> <a href="#ref-for-audionode②⑤">(22)</a> <a href="#ref-for-audionode②⑥">(23)</a> <a href="#ref-for-audionode②⑦">(24)</a> <a href="#ref-for-audionode②⑧">(25)</a> <a href="#ref-for-audionode②⑨">(26)</a> <a href="#ref-for-audionode③⓪">(27)</a>
@@ -19630,8 +19643,8 @@ Latency</a>
 Security and Privacy Considerations</a> <a href="#ref-for-audionode②②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="factory-method">
-   <b><a href="#factory-method">#factory-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-factory-method" class="dfn-panel" data-for="factory-method" id="infopanel-for-factory-method" role="dialog">
+   <span id="infopaneltitle-for-factory-method" style="display:none">Info about the 'factory method' definition.</span><b><a href="#factory-method">#factory-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-factory-method">1.1.2. 
 Methods</a> <a href="#ref-for-factory-method①">(2)</a> <a href="#ref-for-factory-method②">(3)</a> <a href="#ref-for-factory-method③">(4)</a> <a href="#ref-for-factory-method④">(5)</a> <a href="#ref-for-factory-method⑤">(6)</a> <a href="#ref-for-factory-method⑥">(7)</a> <a href="#ref-for-factory-method⑦">(8)</a> <a href="#ref-for-factory-method⑧">(9)</a> <a href="#ref-for-factory-method⑨">(10)</a> <a href="#ref-for-factory-method①⓪">(11)</a> <a href="#ref-for-factory-method①①">(12)</a> <a href="#ref-for-factory-method①②">(13)</a> <a href="#ref-for-factory-method①③">(14)</a> <a href="#ref-for-factory-method①④">(15)</a> <a href="#ref-for-factory-method①⑤">(16)</a>
@@ -19639,8 +19652,8 @@ Methods</a> <a href="#ref-for-factory-method①">(2)</a> <a href="#ref-for-facto
 AudioNode Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated">
-   <b><a href="#associated">#associated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated" class="dfn-panel" data-for="associated" id="infopanel-for-associated" role="dialog">
+   <span id="infopaneltitle-for-associated" style="display:none">Info about the 'associated BaseAudioContext' definition.</span><b><a href="#associated">#associated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated">1.5.1. 
 AudioNode Creation</a>
@@ -19692,8 +19705,8 @@ Constructors</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audionode-constructor-init">
-   <b><a href="#audionode-constructor-init">#audionode-constructor-init</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audionode-constructor-init" class="dfn-panel" data-for="audionode-constructor-init" id="infopanel-for-audionode-constructor-init" role="dialog">
+   <span id="infopaneltitle-for-audionode-constructor-init" style="display:none">Info about the 'Initializing' definition.</span><b><a href="#audionode-constructor-init">#audionode-constructor-init</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audionode-constructor-init">1.17.1. 
 Constructors</a>
@@ -19709,22 +19722,22 @@ Constructors</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-interface">
-   <b><a href="#associated-interface">#associated-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-interface" class="dfn-panel" data-for="associated-interface" id="infopanel-for-associated-interface" role="dialog">
+   <span id="infopaneltitle-for-associated-interface" style="display:none">Info about the 'associated interface' definition.</span><b><a href="#associated-interface">#associated-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-interface">1.5.1. 
 AudioNode Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-option-object">
-   <b><a href="#associated-option-object">#associated-option-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-option-object" class="dfn-panel" data-for="associated-option-object" id="infopanel-for-associated-option-object" role="dialog">
+   <span id="infopaneltitle-for-associated-option-object" style="display:none">Info about the 'associated option object' definition.</span><b><a href="#associated-option-object">#associated-option-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-option-object">1.5.1. 
 AudioNode Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-channelcountmode">
-   <b><a href="#enumdef-channelcountmode">#enumdef-channelcountmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-channelcountmode" class="dfn-panel" data-for="enumdef-channelcountmode" id="infopanel-for-enumdef-channelcountmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-channelcountmode" style="display:none">Info about the 'ChannelCountMode' definition.</span><b><a href="#enumdef-channelcountmode">#enumdef-channelcountmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-channelcountmode">1.5. 
 The AudioNode Interface</a>
@@ -19738,8 +19751,8 @@ AudioNodeOptions</a>
 Dictionary AudioNodeOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computednumberofchannels">
-   <b><a href="#computednumberofchannels">#computednumberofchannels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computednumberofchannels" class="dfn-panel" data-for="computednumberofchannels" id="infopanel-for-computednumberofchannels" role="dialog">
+   <span id="infopaneltitle-for-computednumberofchannels" style="display:none">Info about the 'computedNumberOfChannels' definition.</span><b><a href="#computednumberofchannels">#computednumberofchannels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computednumberofchannels">1.5.1. 
 AudioNode Creation</a> <a href="#ref-for-computednumberofchannels①">(2)</a> <a href="#ref-for-computednumberofchannels②">(3)</a> <a href="#ref-for-computednumberofchannels③">(4)</a>
@@ -19751,8 +19764,8 @@ Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-computedn
 Channel Up-Mixing and Down-Mixing</a> <a href="#ref-for-computednumberofchannels⑧">(2)</a> <a href="#ref-for-computednumberofchannels⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelcountmode-max">
-   <b><a href="#dom-channelcountmode-max">#dom-channelcountmode-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelcountmode-max" class="dfn-panel" data-for="dom-channelcountmode-max" id="infopanel-for-dom-channelcountmode-max" role="dialog">
+   <span id="infopaneltitle-for-dom-channelcountmode-max" style="display:none">Info about the 'max' definition.</span><b><a href="#dom-channelcountmode-max">#dom-channelcountmode-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelcountmode-max">1.5.1. 
 AudioNode Creation</a> <a href="#ref-for-dom-channelcountmode-max①">(2)</a>
@@ -19762,15 +19775,15 @@ Attributes</a> <a href="#ref-for-dom-channelcountmode-max③">(2)</a> <a href="#
 Time-Domain Down-Mixing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelcountmode-clamped-max">
-   <b><a href="#dom-channelcountmode-clamped-max">#dom-channelcountmode-clamped-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelcountmode-clamped-max" class="dfn-panel" data-for="dom-channelcountmode-clamped-max" id="infopanel-for-dom-channelcountmode-clamped-max" role="dialog">
+   <span id="infopaneltitle-for-dom-channelcountmode-clamped-max" style="display:none">Info about the 'clamped-max' definition.</span><b><a href="#dom-channelcountmode-clamped-max">#dom-channelcountmode-clamped-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelcountmode-clamped-max">1.5.1. 
 AudioNode Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelcountmode-explicit">
-   <b><a href="#dom-channelcountmode-explicit">#dom-channelcountmode-explicit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelcountmode-explicit" class="dfn-panel" data-for="dom-channelcountmode-explicit" id="infopanel-for-dom-channelcountmode-explicit" role="dialog">
+   <span id="infopaneltitle-for-dom-channelcountmode-explicit" style="display:none">Info about the 'explicit' definition.</span><b><a href="#dom-channelcountmode-explicit">#dom-channelcountmode-explicit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelcountmode-explicit">1.5.1. 
 AudioNode Creation</a>
@@ -19780,8 +19793,8 @@ Attributes</a> <a href="#ref-for-dom-channelcountmode-explicit②">(2)</a> <a hr
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-channelinterpretation">
-   <b><a href="#enumdef-channelinterpretation">#enumdef-channelinterpretation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-channelinterpretation" class="dfn-panel" data-for="enumdef-channelinterpretation" id="infopanel-for-enumdef-channelinterpretation" role="dialog">
+   <span id="infopaneltitle-for-enumdef-channelinterpretation" style="display:none">Info about the 'ChannelInterpretation' definition.</span><b><a href="#enumdef-channelinterpretation">#enumdef-channelinterpretation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-channelinterpretation">1.5. 
 The AudioNode Interface</a>
@@ -19795,8 +19808,8 @@ Dictionary AudioNodeOptions Members</a>
 Channel Up-Mixing and Down-Mixing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelinterpretation-speakers">
-   <b><a href="#dom-channelinterpretation-speakers">#dom-channelinterpretation-speakers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelinterpretation-speakers" class="dfn-panel" data-for="dom-channelinterpretation-speakers" id="infopanel-for-dom-channelinterpretation-speakers" role="dialog">
+   <span id="infopaneltitle-for-dom-channelinterpretation-speakers" style="display:none">Info about the 'speakers' definition.</span><b><a href="#dom-channelinterpretation-speakers">#dom-channelinterpretation-speakers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelinterpretation-speakers">1.5.1. 
 AudioNode Creation</a>
@@ -19810,8 +19823,8 @@ Time-Domain Down-Mixing</a>
 Speaker Channel Layouts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelinterpretation-discrete">
-   <b><a href="#dom-channelinterpretation-discrete">#dom-channelinterpretation-discrete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelinterpretation-discrete" class="dfn-panel" data-for="dom-channelinterpretation-discrete" id="infopanel-for-dom-channelinterpretation-discrete" role="dialog">
+   <span id="infopaneltitle-for-dom-channelinterpretation-discrete" style="display:none">Info about the 'discrete' definition.</span><b><a href="#dom-channelinterpretation-discrete">#dom-channelinterpretation-discrete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelinterpretation-discrete">1.5.1. 
 AudioNode Creation</a> <a href="#ref-for-dom-channelinterpretation-discrete①">(2)</a>
@@ -19819,8 +19832,8 @@ AudioNode Creation</a> <a href="#ref-for-dom-channelinterpretation-discrete①">
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tail-time">
-   <b><a href="#tail-time">#tail-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tail-time" class="dfn-panel" data-for="tail-time" id="infopanel-for-tail-time" role="dialog">
+   <span id="infopaneltitle-for-tail-time" style="display:none">Info about the 'tail-time' definition.</span><b><a href="#tail-time">#tail-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tail-time">1.5.3. AudioNode Lifetime</a>
     <li><a href="#ref-for-tail-time①">1.32.4.3. 
@@ -19829,8 +19842,8 @@ Callback AudioWorkletProcessCallback</a>
 Implication of tail-time on input and output channel count</a> <a href="#ref-for-tail-time③">(2)</a> <a href="#ref-for-tail-time④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actively-processing">
-   <b><a href="#actively-processing">#actively-processing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actively-processing" class="dfn-panel" data-for="actively-processing" id="infopanel-for-actively-processing" role="dialog">
+   <span id="infopaneltitle-for-actively-processing" style="display:none">Info about the 'actively processing' definition.</span><b><a href="#actively-processing">#actively-processing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actively-processing">1.5.3. AudioNode Lifetime</a> <a href="#ref-for-actively-processing①">(2)</a> <a href="#ref-for-actively-processing②">(3)</a> <a href="#ref-for-actively-processing③">(4)</a> <a href="#ref-for-actively-processing④">(5)</a> <a href="#ref-for-actively-processing⑤">(6)</a> <a href="#ref-for-actively-processing⑥">(7)</a> <a href="#ref-for-actively-processing⑦">(8)</a> <a href="#ref-for-actively-processing⑧">(9)</a> <a href="#ref-for-actively-processing⑨">(10)</a> <a href="#ref-for-actively-processing①⓪">(11)</a> <a href="#ref-for-actively-processing①①">(12)</a>
     <li><a href="#ref-for-actively-processing①②">1.14. 
@@ -19845,8 +19858,8 @@ Callback AudioWorkletProcessCallback</a>
 Callback AudioWorkletProcessCallback Parameters </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-channelcount">
-   <b><a href="#dom-audionode-channelcount">#dom-audionode-channelcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-channelcount" class="dfn-panel" data-for="dom-audionode-channelcount" id="infopanel-for-dom-audionode-channelcount" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-channelcount" style="display:none">Info about the 'channelCount' definition.</span><b><a href="#dom-audionode-channelcount">#dom-audionode-channelcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-channelcount">1.3.1. 
 Constructors</a>
@@ -19868,15 +19881,16 @@ The AudioDestinationNode Interface</a> <a href="#ref-for-dom-audionode-channelco
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audionode-channelcount-constraints">
-   <b><a href="#audionode-channelcount-constraints">#audionode-channelcount-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audionode-channelcount-constraints" class="dfn-panel" data-for="audionode-channelcount-constraints" id="infopanel-for-audionode-channelcount-constraints" role="dialog">
+   <span id="infopaneltitle-for-audionode-channelcount-constraints" style="display:none">Info about the 'channelCount
+constraints' definition.</span><b><a href="#audionode-channelcount-constraints">#audionode-channelcount-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audionode-channelcount-constraints">1.17. 
 The ConvolverNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-channelcountmode">
-   <b><a href="#dom-audionode-channelcountmode">#dom-audionode-channelcountmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-channelcountmode" class="dfn-panel" data-for="dom-audionode-channelcountmode" id="infopanel-for-dom-audionode-channelcountmode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-channelcountmode" style="display:none">Info about the 'channelCountMode' definition.</span><b><a href="#dom-audionode-channelcountmode">#dom-audionode-channelcountmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-channelcountmode">1.5. 
 The AudioNode Interface</a>
@@ -19894,15 +19908,16 @@ Time-Domain Down-Mixing</a>
 Configuring Channels with AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audionode-channelcountmode-constraints">
-   <b><a href="#audionode-channelcountmode-constraints">#audionode-channelcountmode-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audionode-channelcountmode-constraints" class="dfn-panel" data-for="audionode-channelcountmode-constraints" id="infopanel-for-audionode-channelcountmode-constraints" role="dialog">
+   <span id="infopaneltitle-for-audionode-channelcountmode-constraints" style="display:none">Info about the 'channelCountMode
+constraints' definition.</span><b><a href="#audionode-channelcountmode-constraints">#audionode-channelcountmode-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audionode-channelcountmode-constraints">1.17. 
 The ConvolverNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-channelinterpretation">
-   <b><a href="#dom-audionode-channelinterpretation">#dom-audionode-channelinterpretation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-channelinterpretation" class="dfn-panel" data-for="dom-audionode-channelinterpretation" id="infopanel-for-dom-audionode-channelinterpretation" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-channelinterpretation" style="display:none">Info about the 'channelInterpretation' definition.</span><b><a href="#dom-audionode-channelinterpretation">#dom-audionode-channelinterpretation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-channelinterpretation">1.5. 
 The AudioNode Interface</a>
@@ -19922,15 +19937,15 @@ Channel Up-Mixing and Down-Mixing</a>
 Speaker Channel Layouts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-context">
-   <b><a href="#dom-audionode-context">#dom-audionode-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-context" class="dfn-panel" data-for="dom-audionode-context" id="infopanel-for-dom-audionode-context" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-context" style="display:none">Info about the 'context' definition.</span><b><a href="#dom-audionode-context">#dom-audionode-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-context">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-numberofinputs">
-   <b><a href="#dom-audionode-numberofinputs">#dom-audionode-numberofinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-numberofinputs" class="dfn-panel" data-for="dom-audionode-numberofinputs" id="infopanel-for-dom-audionode-numberofinputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-numberofinputs" style="display:none">Info about the 'numberOfInputs' definition.</span><b><a href="#dom-audionode-numberofinputs">#dom-audionode-numberofinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-numberofinputs">1.5. 
 The AudioNode Interface</a>
@@ -19940,15 +19955,15 @@ AudioNode Creation</a>
 Dictionary AudioWorkletNodeOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audionode-source-nodes">
-   <b><a href="#audionode-source-nodes">#audionode-source-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audionode-source-nodes" class="dfn-panel" data-for="audionode-source-nodes" id="infopanel-for-audionode-source-nodes" role="dialog">
+   <span id="infopaneltitle-for-audionode-source-nodes" style="display:none">Info about the 'source nodes' definition.</span><b><a href="#audionode-source-nodes">#audionode-source-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audionode-source-nodes">1.1.6. 
 Lack of Introspection or Serialization Primitives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-numberofoutputs">
-   <b><a href="#dom-audionode-numberofoutputs">#dom-audionode-numberofoutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-numberofoutputs" class="dfn-panel" data-for="dom-audionode-numberofoutputs" id="infopanel-for-dom-audionode-numberofoutputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-numberofoutputs" style="display:none">Info about the 'numberOfOutputs' definition.</span><b><a href="#dom-audionode-numberofoutputs">#dom-audionode-numberofoutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-numberofoutputs">1.5. 
 The AudioNode Interface</a>
@@ -19958,8 +19973,8 @@ AudioNode Creation</a>
 Dictionary AudioWorkletNodeOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect">
-   <b><a href="#dom-audionode-connect">#dom-audionode-connect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect" class="dfn-panel" data-for="dom-audionode-connect" id="infopanel-for-dom-audionode-connect" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect" style="display:none">Info about the 'connect(destinationNode, output, input)' definition.</span><b><a href="#dom-audionode-connect">#dom-audionode-connect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect">1.5. 
 The AudioNode Interface</a>
@@ -19967,36 +19982,36 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-destinationnode">
-   <b><a href="#dom-audionode-connect-destinationnode-output-input-destinationnode">#dom-audionode-connect-destinationnode-output-input-destinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-destinationnode" class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-destinationnode" id="infopanel-for-dom-audionode-connect-destinationnode-output-input-destinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-destinationnode" style="display:none">Info about the 'destinationNode' definition.</span><b><a href="#dom-audionode-connect-destinationnode-output-input-destinationnode">#dom-audionode-connect-destinationnode-output-input-destinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationnode-output-input-destinationnode">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-output">
-   <b><a href="#dom-audionode-connect-destinationnode-output-input-output">#dom-audionode-connect-destinationnode-output-input-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-output" class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-output" id="infopanel-for-dom-audionode-connect-destinationnode-output-input-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-connect-destinationnode-output-input-output">#dom-audionode-connect-destinationnode-output-input-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationnode-output-input-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-input">
-   <b><a href="#dom-audionode-connect-destinationnode-output-input-input">#dom-audionode-connect-destinationnode-output-input-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-input" class="dfn-panel" data-for="dom-audionode-connect-destinationnode-output-input-input" id="infopanel-for-dom-audionode-connect-destinationnode-output-input-input" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationnode-output-input-input" style="display:none">Info about the 'input' definition.</span><b><a href="#dom-audionode-connect-destinationnode-output-input-input">#dom-audionode-connect-destinationnode-output-input-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationnode-output-input-input">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cycle">
-   <b><a href="#cycle">#cycle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cycle" class="dfn-panel" data-for="cycle" id="infopanel-for-cycle" role="dialog">
+   <span id="infopaneltitle-for-cycle" style="display:none">Info about the 'cycle' definition.</span><b><a href="#cycle">#cycle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cycle">1.18.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output">
-   <b><a href="#dom-audionode-connect-destinationparam-output">#dom-audionode-connect-destinationparam-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationparam-output" class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output" id="infopanel-for-dom-audionode-connect-destinationparam-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationparam-output" style="display:none">Info about the 'connect(destinationParam, output)' definition.</span><b><a href="#dom-audionode-connect-destinationparam-output">#dom-audionode-connect-destinationparam-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationparam-output">1.5. 
 The AudioNode Interface</a>
@@ -20004,8 +20019,8 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output-destinationparam">
-   <b><a href="#dom-audionode-connect-destinationparam-output-destinationparam">#dom-audionode-connect-destinationparam-output-destinationparam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationparam-output-destinationparam" class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output-destinationparam" id="infopanel-for-dom-audionode-connect-destinationparam-output-destinationparam" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationparam-output-destinationparam" style="display:none">Info about the 'destinationParam' definition.</span><b><a href="#dom-audionode-connect-destinationparam-output-destinationparam">#dom-audionode-connect-destinationparam-output-destinationparam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationparam-output-destinationparam">1.5. 
 The AudioNode Interface</a>
@@ -20013,22 +20028,22 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output-output">
-   <b><a href="#dom-audionode-connect-destinationparam-output-output">#dom-audionode-connect-destinationparam-output-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-connect-destinationparam-output-output" class="dfn-panel" data-for="dom-audionode-connect-destinationparam-output-output" id="infopanel-for-dom-audionode-connect-destinationparam-output-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-connect-destinationparam-output-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-connect-destinationparam-output-output">#dom-audionode-connect-destinationparam-output-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-connect-destinationparam-output-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect">
-   <b><a href="#dom-audionode-disconnect">#dom-audionode-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect" class="dfn-panel" data-for="dom-audionode-disconnect" id="infopanel-for-dom-audionode-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-audionode-disconnect">#dom-audionode-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-output">
-   <b><a href="#dom-audionode-disconnect-output">#dom-audionode-disconnect-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-output" class="dfn-panel" data-for="dom-audionode-disconnect-output" id="infopanel-for-dom-audionode-disconnect-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-output" style="display:none">Info about the 'disconnect(output)' definition.</span><b><a href="#dom-audionode-disconnect-output">#dom-audionode-disconnect-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-output">1.5. 
 The AudioNode Interface</a>
@@ -20036,15 +20051,15 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-output-output">
-   <b><a href="#dom-audionode-disconnect-output-output">#dom-audionode-disconnect-output-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-output-output" class="dfn-panel" data-for="dom-audionode-disconnect-output-output" id="infopanel-for-dom-audionode-disconnect-output-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-output-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-disconnect-output-output">#dom-audionode-disconnect-output-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-output-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode">
-   <b><a href="#dom-audionode-disconnect-destinationnode">#dom-audionode-disconnect-destinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode" id="infopanel-for-dom-audionode-disconnect-destinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode" style="display:none">Info about the 'disconnect(destinationNode)' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode">#dom-audionode-disconnect-destinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode">1.5. 
 The AudioNode Interface</a>
@@ -20052,15 +20067,15 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-destinationnode">
-   <b><a href="#dom-audionode-disconnect-destinationnode-destinationnode">#dom-audionode-disconnect-destinationnode-destinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-destinationnode" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-destinationnode" id="infopanel-for-dom-audionode-disconnect-destinationnode-destinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-destinationnode" style="display:none">Info about the 'destinationNode' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-destinationnode">#dom-audionode-disconnect-destinationnode-destinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-destinationnode">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output">#dom-audionode-disconnect-destinationnode-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output" id="infopanel-for-dom-audionode-disconnect-destinationnode-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output" style="display:none">Info about the 'disconnect(destinationNode, output)' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output">#dom-audionode-disconnect-destinationnode-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output">1.5. 
 The AudioNode Interface</a>
@@ -20068,22 +20083,22 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-destinationnode">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-destinationnode">#dom-audionode-disconnect-destinationnode-output-destinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-destinationnode" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-destinationnode" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-destinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-destinationnode" style="display:none">Info about the 'destinationNode' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-destinationnode">#dom-audionode-disconnect-destinationnode-output-destinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-destinationnode">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-output">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-output">#dom-audionode-disconnect-destinationnode-output-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-output" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-output" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-output">#dom-audionode-disconnect-destinationnode-output-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-input">#dom-audionode-disconnect-destinationnode-output-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-input" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input" style="display:none">Info about the 'disconnect(destinationNode, output, input)' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-input">#dom-audionode-disconnect-destinationnode-output-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-input">1.5. 
 The AudioNode Interface</a>
@@ -20091,29 +20106,29 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-destinationnode">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-input-destinationnode">#dom-audionode-disconnect-destinationnode-output-input-destinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-destinationnode" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-destinationnode" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-input-destinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-destinationnode" style="display:none">Info about the 'destinationNode' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-input-destinationnode">#dom-audionode-disconnect-destinationnode-output-input-destinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-input-destinationnode">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-output">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-input-output">#dom-audionode-disconnect-destinationnode-output-input-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-output" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-output" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-input-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-input-output">#dom-audionode-disconnect-destinationnode-output-input-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-input-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-input">
-   <b><a href="#dom-audionode-disconnect-destinationnode-output-input-input">#dom-audionode-disconnect-destinationnode-output-input-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-input" class="dfn-panel" data-for="dom-audionode-disconnect-destinationnode-output-input-input" id="infopanel-for-dom-audionode-disconnect-destinationnode-output-input-input" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationnode-output-input-input" style="display:none">Info about the 'input' definition.</span><b><a href="#dom-audionode-disconnect-destinationnode-output-input-input">#dom-audionode-disconnect-destinationnode-output-input-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationnode-output-input-input">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam">
-   <b><a href="#dom-audionode-disconnect-destinationparam">#dom-audionode-disconnect-destinationparam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationparam" class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam" id="infopanel-for-dom-audionode-disconnect-destinationparam" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationparam" style="display:none">Info about the 'disconnect(destinationParam)' definition.</span><b><a href="#dom-audionode-disconnect-destinationparam">#dom-audionode-disconnect-destinationparam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationparam">1.5. 
 The AudioNode Interface</a>
@@ -20121,15 +20136,15 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-destinationparam">
-   <b><a href="#dom-audionode-disconnect-destinationparam-destinationparam">#dom-audionode-disconnect-destinationparam-destinationparam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationparam-destinationparam" class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-destinationparam" id="infopanel-for-dom-audionode-disconnect-destinationparam-destinationparam" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationparam-destinationparam" style="display:none">Info about the 'destinationParam' definition.</span><b><a href="#dom-audionode-disconnect-destinationparam-destinationparam">#dom-audionode-disconnect-destinationparam-destinationparam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationparam-destinationparam">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output">
-   <b><a href="#dom-audionode-disconnect-destinationparam-output">#dom-audionode-disconnect-destinationparam-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output" class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output" id="infopanel-for-dom-audionode-disconnect-destinationparam-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output" style="display:none">Info about the 'disconnect(destinationParam, output)' definition.</span><b><a href="#dom-audionode-disconnect-destinationparam-output">#dom-audionode-disconnect-destinationparam-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationparam-output">1.5. 
 The AudioNode Interface</a>
@@ -20137,29 +20152,30 @@ The AudioNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output-destinationparam">
-   <b><a href="#dom-audionode-disconnect-destinationparam-output-destinationparam">#dom-audionode-disconnect-destinationparam-output-destinationparam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output-destinationparam" class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output-destinationparam" id="infopanel-for-dom-audionode-disconnect-destinationparam-output-destinationparam" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output-destinationparam" style="display:none">Info about the 'destinationParam' definition.</span><b><a href="#dom-audionode-disconnect-destinationparam-output-destinationparam">#dom-audionode-disconnect-destinationparam-output-destinationparam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationparam-output-destinationparam">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output-output">
-   <b><a href="#dom-audionode-disconnect-destinationparam-output-output">#dom-audionode-disconnect-destinationparam-output-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output-output" class="dfn-panel" data-for="dom-audionode-disconnect-destinationparam-output-output" id="infopanel-for-dom-audionode-disconnect-destinationparam-output-output" role="dialog">
+   <span id="infopaneltitle-for-dom-audionode-disconnect-destinationparam-output-output" style="display:none">Info about the 'output' definition.</span><b><a href="#dom-audionode-disconnect-destinationparam-output-output">#dom-audionode-disconnect-destinationparam-output-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionode-disconnect-destinationparam-output-output">1.5. 
 The AudioNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioNodeOptions">
-   <b><a href="#AudioNodeOptions">#AudioNodeOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioNodeOptions" class="dfn-panel" data-for="AudioNodeOptions" id="infopanel-for-AudioNodeOptions" role="dialog">
+   <span id="infopaneltitle-for-AudioNodeOptions" style="display:none">Info about the '1.5.6. 
+AudioNodeOptions' definition.</span><b><a href="#AudioNodeOptions">#AudioNodeOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioNodeOptions">1.5.6. 
 AudioNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audionodeoptions">
-   <b><a href="#dictdef-audionodeoptions">#dictdef-audionodeoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audionodeoptions" class="dfn-panel" data-for="dictdef-audionodeoptions" id="infopanel-for-dictdef-audionodeoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audionodeoptions" style="display:none">Info about the 'AudioNodeOptions' definition.</span><b><a href="#dictdef-audionodeoptions">#dictdef-audionodeoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audionodeoptions">1.5.6. 
 AudioNodeOptions</a>
@@ -20201,8 +20217,8 @@ WaveShaperOptions</a>
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionodeoptions-channelcount">
-   <b><a href="#dom-audionodeoptions-channelcount">#dom-audionodeoptions-channelcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionodeoptions-channelcount" class="dfn-panel" data-for="dom-audionodeoptions-channelcount" id="infopanel-for-dom-audionodeoptions-channelcount" role="dialog">
+   <span id="infopaneltitle-for-dom-audionodeoptions-channelcount" style="display:none">Info about the 'channelCount' definition.</span><b><a href="#dom-audionodeoptions-channelcount">#dom-audionodeoptions-channelcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionodeoptions-channelcount">1.5.6. 
 AudioNodeOptions</a>
@@ -20210,8 +20226,8 @@ AudioNodeOptions</a>
 Constructors</a> <a href="#ref-for-dom-audionodeoptions-channelcount②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionodeoptions-channelcountmode">
-   <b><a href="#dom-audionodeoptions-channelcountmode">#dom-audionodeoptions-channelcountmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionodeoptions-channelcountmode" class="dfn-panel" data-for="dom-audionodeoptions-channelcountmode" id="infopanel-for-dom-audionodeoptions-channelcountmode" role="dialog">
+   <span id="infopaneltitle-for-dom-audionodeoptions-channelcountmode" style="display:none">Info about the 'channelCountMode' definition.</span><b><a href="#dom-audionodeoptions-channelcountmode">#dom-audionodeoptions-channelcountmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionodeoptions-channelcountmode">1.5.6. 
 AudioNodeOptions</a>
@@ -20219,8 +20235,8 @@ AudioNodeOptions</a>
 Constructors</a> <a href="#ref-for-dom-audionodeoptions-channelcountmode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audionodeoptions-channelinterpretation">
-   <b><a href="#dom-audionodeoptions-channelinterpretation">#dom-audionodeoptions-channelinterpretation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audionodeoptions-channelinterpretation" class="dfn-panel" data-for="dom-audionodeoptions-channelinterpretation" id="infopanel-for-dom-audionodeoptions-channelinterpretation" role="dialog">
+   <span id="infopaneltitle-for-dom-audionodeoptions-channelinterpretation" style="display:none">Info about the 'channelInterpretation' definition.</span><b><a href="#dom-audionodeoptions-channelinterpretation">#dom-audionodeoptions-channelinterpretation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audionodeoptions-channelinterpretation">1.5.6. 
 AudioNodeOptions</a>
@@ -20228,16 +20244,17 @@ AudioNodeOptions</a>
 Constructors</a> <a href="#ref-for-dom-audionodeoptions-channelinterpretation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioParam">
-   <b><a href="#AudioParam">#AudioParam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioParam" class="dfn-panel" data-for="AudioParam" id="infopanel-for-AudioParam" role="dialog">
+   <span id="infopaneltitle-for-AudioParam" style="display:none">Info about the '1.6. 
+The AudioParam Interface' definition.</span><b><a href="#AudioParam">#AudioParam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioParam"> Features</a>
     <li><a href="#ref-for-AudioParam">1.6. 
 The AudioParam Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="k-rate">
-   <b><a href="#k-rate">#k-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-k-rate" class="dfn-panel" data-for="k-rate" id="infopanel-for-k-rate" role="dialog">
+   <span id="infopaneltitle-for-k-rate" style="display:none">Info about the 'k-rate' definition.</span><b><a href="#k-rate">#k-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-k-rate">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-k-rate①">(2)</a>
@@ -20247,8 +20264,8 @@ Processing</a> <a href="#ref-for-k-rate③">(2)</a> <a href="#ref-for-k-rate④"
 The PannerNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="a-rate">
-   <b><a href="#a-rate">#a-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-a-rate" class="dfn-panel" data-for="a-rate" id="infopanel-for-a-rate" role="dialog">
+   <span id="infopaneltitle-for-a-rate" style="display:none">Info about the 'a-rate' definition.</span><b><a href="#a-rate">#a-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-rate">1.5.5. 
 Methods</a>
@@ -20268,15 +20285,15 @@ The BitCrusher Node</a>
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-nominal-range">
-   <b><a href="#simple-nominal-range">#simple-nominal-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-nominal-range" class="dfn-panel" data-for="simple-nominal-range" id="infopanel-for-simple-nominal-range" role="dialog">
+   <span id="infopaneltitle-for-simple-nominal-range" style="display:none">Info about the 'simple nominal range' definition.</span><b><a href="#simple-nominal-range">#simple-nominal-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-nominal-range">1.6.3. 
 Computation of Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="most-positive-single-float">
-   <b><a href="#most-positive-single-float">#most-positive-single-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-most-positive-single-float" class="dfn-panel" data-for="most-positive-single-float" id="infopanel-for-most-positive-single-float" role="dialog">
+   <span id="infopaneltitle-for-most-positive-single-float" style="display:none">Info about the 'most-positive-single-float' definition.</span><b><a href="#most-positive-single-float">#most-positive-single-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-most-positive-single-float">1.6. 
 The AudioParam Interface</a>
@@ -20284,15 +20301,15 @@ The AudioParam Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-automation-event">
-   <b><a href="#dfn-automation-event">#dfn-automation-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-automation-event" class="dfn-panel" data-for="dfn-automation-event" id="infopanel-for-dfn-automation-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-automation-event" style="display:none">Info about the 'automation events' definition.</span><b><a href="#dfn-automation-event">#dfn-automation-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-automation-event">1.6.3. 
 Computation of Value</a> <a href="#ref-for-dfn-automation-event">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="automation-event-time">
-   <b><a href="#automation-event-time">#automation-event-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-automation-event-time" class="dfn-panel" data-for="automation-event-time" id="infopanel-for-automation-event-time" role="dialog">
+   <span id="infopaneltitle-for-automation-event-time" style="display:none">Info about the 'automation event time' definition.</span><b><a href="#automation-event-time">#automation-event-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation-event-time">1.6. 
 The AudioParam Interface</a>
@@ -20300,15 +20317,15 @@ The AudioParam Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-automation-method">
-   <b><a href="#dfn-automation-method">#dfn-automation-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-automation-method" class="dfn-panel" data-for="dfn-automation-method" id="infopanel-for-dfn-automation-method" role="dialog">
+   <span id="infopaneltitle-for-dfn-automation-method" style="display:none">Info about the 'automation methods' definition.</span><b><a href="#dfn-automation-method">#dfn-automation-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-automation-method">1.6. 
 The AudioParam Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-automationrate">
-   <b><a href="#enumdef-automationrate">#enumdef-automationrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-automationrate" class="dfn-panel" data-for="enumdef-automationrate" id="infopanel-for-enumdef-automationrate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-automationrate" style="display:none">Info about the 'AutomationRate' definition.</span><b><a href="#enumdef-automationrate">#enumdef-automationrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-automationrate">1.6. 
 The AudioParam Interface</a>
@@ -20320,8 +20337,8 @@ AudioParamDescriptor</a>
 Dictionary AudioParamDescriptor Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-automationrate-a-rate">
-   <b><a href="#dom-automationrate-a-rate">#dom-automationrate-a-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-automationrate-a-rate" class="dfn-panel" data-for="dom-automationrate-a-rate" id="infopanel-for-dom-automationrate-a-rate" role="dialog">
+   <span id="infopaneltitle-for-dom-automationrate-a-rate" style="display:none">Info about the 'a-rate' definition.</span><b><a href="#dom-automationrate-a-rate">#dom-automationrate-a-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-automationrate-a-rate">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-automationrate-a-rate①">(2)</a>
@@ -20333,8 +20350,8 @@ Azimuth and Elevation</a>
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-automationrate-k-rate">
-   <b><a href="#dom-automationrate-k-rate">#dom-automationrate-k-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-automationrate-k-rate" class="dfn-panel" data-for="dom-automationrate-k-rate" id="infopanel-for-dom-automationrate-k-rate" role="dialog">
+   <span id="infopaneltitle-for-dom-automationrate-k-rate" style="display:none">Info about the 'k-rate' definition.</span><b><a href="#dom-automationrate-k-rate">#dom-automationrate-k-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-automationrate-k-rate">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-automationrate-k-rate①">(2)</a>
@@ -20346,8 +20363,8 @@ The PannerNode Interface</a>
 Azimuth and Elevation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-current-value-slot">
-   <b><a href="#dom-audioparam-current-value-slot">#dom-audioparam-current-value-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-current-value-slot" class="dfn-panel" data-for="dom-audioparam-current-value-slot" id="infopanel-for-dom-audioparam-current-value-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-current-value-slot" style="display:none">Info about the '[[current value]]' definition.</span><b><a href="#dom-audioparam-current-value-slot">#dom-audioparam-current-value-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-current-value-slot">1.6.1. 
 Attributes</a> <a href="#ref-for-dom-audioparam-current-value-slot①">(2)</a> <a href="#ref-for-dom-audioparam-current-value-slot②">(3)</a>
@@ -20361,8 +20378,8 @@ Methods</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioparam">
-   <b><a href="#audioparam">#audioparam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioparam" class="dfn-panel" data-for="audioparam" id="infopanel-for-audioparam" role="dialog">
+   <span id="infopaneltitle-for-audioparam" style="display:none">Info about the 'AudioParam' definition.</span><b><a href="#audioparam">#audioparam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioparam"> Modular Routing</a>
     <li><a href="#ref-for-audioparam①"> API Overview</a> <a href="#ref-for-audioparam②">(2)</a>
@@ -20460,8 +20477,8 @@ StereoPannerNode Panning</a>
 AudioParam Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-automationrate">
-   <b><a href="#dom-audioparam-automationrate">#dom-audioparam-automationrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-automationrate" class="dfn-panel" data-for="dom-audioparam-automationrate" id="infopanel-for-dom-audioparam-automationrate" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-automationrate" style="display:none">Info about the 'automationRate' definition.</span><b><a href="#dom-audioparam-automationrate">#dom-audioparam-automationrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-automationrate">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-automationrate①">(2)</a> <a href="#ref-for-dom-audioparam-automationrate②">(3)</a>
@@ -20473,8 +20490,8 @@ The PannerNode Interface</a> <a href="#ref-for-dom-audioparam-automationrate⑦"
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-defaultvalue">
-   <b><a href="#dom-audioparam-defaultvalue">#dom-audioparam-defaultvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-defaultvalue" class="dfn-panel" data-for="dom-audioparam-defaultvalue" id="infopanel-for-dom-audioparam-defaultvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-defaultvalue" style="display:none">Info about the 'defaultValue' definition.</span><b><a href="#dom-audioparam-defaultvalue">#dom-audioparam-defaultvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-defaultvalue">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-defaultvalue①">(2)</a>
@@ -20482,22 +20499,22 @@ The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-defaultvalue①">(
 Computation of Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-maxvalue">
-   <b><a href="#dom-audioparam-maxvalue">#dom-audioparam-maxvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-maxvalue" class="dfn-panel" data-for="dom-audioparam-maxvalue" id="infopanel-for-dom-audioparam-maxvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-maxvalue" style="display:none">Info about the 'maxValue' definition.</span><b><a href="#dom-audioparam-maxvalue">#dom-audioparam-maxvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-maxvalue">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-maxvalue①">(2)</a> <a href="#ref-for-dom-audioparam-maxvalue②">(3)</a> <a href="#ref-for-dom-audioparam-maxvalue③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-minvalue">
-   <b><a href="#dom-audioparam-minvalue">#dom-audioparam-minvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-minvalue" class="dfn-panel" data-for="dom-audioparam-minvalue" id="infopanel-for-dom-audioparam-minvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-minvalue" style="display:none">Info about the 'minValue' definition.</span><b><a href="#dom-audioparam-minvalue">#dom-audioparam-minvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-minvalue">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-minvalue①">(2)</a> <a href="#ref-for-dom-audioparam-minvalue②">(3)</a> <a href="#ref-for-dom-audioparam-minvalue③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-value">
-   <b><a href="#dom-audioparam-value">#dom-audioparam-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-value" class="dfn-panel" data-for="dom-audioparam-value" id="infopanel-for-dom-audioparam-value" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-audioparam-value">#dom-audioparam-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-value">1.5.1. 
 AudioNode Creation</a>
@@ -20517,8 +20534,8 @@ Dictionary AudioWorkletNodeOptions Members</a>
 AudioParam Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-cancelandholdattime">
-   <b><a href="#dom-audioparam-cancelandholdattime">#dom-audioparam-cancelandholdattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-cancelandholdattime" class="dfn-panel" data-for="dom-audioparam-cancelandholdattime" id="infopanel-for-dom-audioparam-cancelandholdattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-cancelandholdattime" style="display:none">Info about the 'cancelAndHoldAtTime(cancelTime)' definition.</span><b><a href="#dom-audioparam-cancelandholdattime">#dom-audioparam-cancelandholdattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-cancelandholdattime">1.6. 
 The AudioParam Interface</a>
@@ -20526,15 +20543,15 @@ The AudioParam Interface</a>
 Methods</a> <a href="#ref-for-dom-audioparam-cancelandholdattime②">(2)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime③">(3)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime④">(4)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime⑤">(5)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-cancelandholdattime-canceltime">
-   <b><a href="#dom-audioparam-cancelandholdattime-canceltime">#dom-audioparam-cancelandholdattime-canceltime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-cancelandholdattime-canceltime" class="dfn-panel" data-for="dom-audioparam-cancelandholdattime-canceltime" id="infopanel-for-dom-audioparam-cancelandholdattime-canceltime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-cancelandholdattime-canceltime" style="display:none">Info about the 'cancelTime' definition.</span><b><a href="#dom-audioparam-cancelandholdattime-canceltime">#dom-audioparam-cancelandholdattime-canceltime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-cancelandholdattime-canceltime">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-cancelandholdattime-canceltime①">(2)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime-canceltime②">(3)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime-canceltime③">(4)</a> <a href="#ref-for-dom-audioparam-cancelandholdattime-canceltime④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-cancelscheduledvalues">
-   <b><a href="#dom-audioparam-cancelscheduledvalues">#dom-audioparam-cancelscheduledvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-cancelscheduledvalues" class="dfn-panel" data-for="dom-audioparam-cancelscheduledvalues" id="infopanel-for-dom-audioparam-cancelscheduledvalues" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-cancelscheduledvalues" style="display:none">Info about the 'cancelScheduledValues(cancelTime)' definition.</span><b><a href="#dom-audioparam-cancelscheduledvalues">#dom-audioparam-cancelscheduledvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-cancelscheduledvalues">1.6. 
 The AudioParam Interface</a>
@@ -20542,15 +20559,15 @@ The AudioParam Interface</a>
 Methods</a> <a href="#ref-for-dom-audioparam-cancelscheduledvalues②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-cancelscheduledvalues-canceltime">
-   <b><a href="#dom-audioparam-cancelscheduledvalues-canceltime">#dom-audioparam-cancelscheduledvalues-canceltime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-cancelscheduledvalues-canceltime" class="dfn-panel" data-for="dom-audioparam-cancelscheduledvalues-canceltime" id="infopanel-for-dom-audioparam-cancelscheduledvalues-canceltime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-cancelscheduledvalues-canceltime" style="display:none">Info about the 'cancelTime' definition.</span><b><a href="#dom-audioparam-cancelscheduledvalues-canceltime">#dom-audioparam-cancelscheduledvalues-canceltime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-cancelscheduledvalues-canceltime">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-cancelscheduledvalues-canceltime①">(2)</a> <a href="#ref-for-dom-audioparam-cancelscheduledvalues-canceltime②">(3)</a> <a href="#ref-for-dom-audioparam-cancelscheduledvalues-canceltime③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime">
-   <b><a href="#dom-audioparam-exponentialramptovalueattime">#dom-audioparam-exponentialramptovalueattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime" class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime" id="infopanel-for-dom-audioparam-exponentialramptovalueattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime" style="display:none">Info about the 'exponentialRampToValueAtTime(value, endTime)' definition.</span><b><a href="#dom-audioparam-exponentialramptovalueattime">#dom-audioparam-exponentialramptovalueattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-exponentialramptovalueattime">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-exponentialramptovalueattime①">(2)</a>
@@ -20558,22 +20575,22 @@ The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-exponentialramptov
 Methods</a> <a href="#ref-for-dom-audioparam-exponentialramptovalueattime③">(2)</a> <a href="#ref-for-dom-audioparam-exponentialramptovalueattime④">(3)</a> <a href="#ref-for-dom-audioparam-exponentialramptovalueattime⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime-value">
-   <b><a href="#dom-audioparam-exponentialramptovalueattime-value">#dom-audioparam-exponentialramptovalueattime-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime-value" class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime-value" id="infopanel-for-dom-audioparam-exponentialramptovalueattime-value" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-audioparam-exponentialramptovalueattime-value">#dom-audioparam-exponentialramptovalueattime-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-exponentialramptovalueattime-value">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime-endtime">
-   <b><a href="#dom-audioparam-exponentialramptovalueattime-endtime">#dom-audioparam-exponentialramptovalueattime-endtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime-endtime" class="dfn-panel" data-for="dom-audioparam-exponentialramptovalueattime-endtime" id="infopanel-for-dom-audioparam-exponentialramptovalueattime-endtime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-exponentialramptovalueattime-endtime" style="display:none">Info about the 'endTime' definition.</span><b><a href="#dom-audioparam-exponentialramptovalueattime-endtime">#dom-audioparam-exponentialramptovalueattime-endtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-exponentialramptovalueattime-endtime">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime">
-   <b><a href="#dom-audioparam-linearramptovalueattime">#dom-audioparam-linearramptovalueattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-linearramptovalueattime" class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime" id="infopanel-for-dom-audioparam-linearramptovalueattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-linearramptovalueattime" style="display:none">Info about the 'linearRampToValueAtTime(value, endTime)' definition.</span><b><a href="#dom-audioparam-linearramptovalueattime">#dom-audioparam-linearramptovalueattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-linearramptovalueattime">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-linearramptovalueattime①">(2)</a>
@@ -20581,22 +20598,22 @@ The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-linearramptovaluea
 Methods</a> <a href="#ref-for-dom-audioparam-linearramptovalueattime③">(2)</a> <a href="#ref-for-dom-audioparam-linearramptovalueattime④">(3)</a> <a href="#ref-for-dom-audioparam-linearramptovalueattime⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime-value">
-   <b><a href="#dom-audioparam-linearramptovalueattime-value">#dom-audioparam-linearramptovalueattime-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-linearramptovalueattime-value" class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime-value" id="infopanel-for-dom-audioparam-linearramptovalueattime-value" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-linearramptovalueattime-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-audioparam-linearramptovalueattime-value">#dom-audioparam-linearramptovalueattime-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-linearramptovalueattime-value">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime-endtime">
-   <b><a href="#dom-audioparam-linearramptovalueattime-endtime">#dom-audioparam-linearramptovalueattime-endtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-linearramptovalueattime-endtime" class="dfn-panel" data-for="dom-audioparam-linearramptovalueattime-endtime" id="infopanel-for-dom-audioparam-linearramptovalueattime-endtime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-linearramptovalueattime-endtime" style="display:none">Info about the 'endTime' definition.</span><b><a href="#dom-audioparam-linearramptovalueattime-endtime">#dom-audioparam-linearramptovalueattime-endtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-linearramptovalueattime-endtime">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-settargetattime">
-   <b><a href="#dom-audioparam-settargetattime">#dom-audioparam-settargetattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-settargetattime" class="dfn-panel" data-for="dom-audioparam-settargetattime" id="infopanel-for-dom-audioparam-settargetattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-settargetattime" style="display:none">Info about the 'setTargetAtTime(target, startTime, timeConstant)' definition.</span><b><a href="#dom-audioparam-settargetattime">#dom-audioparam-settargetattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-settargetattime">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-settargetattime①">(2)</a>
@@ -20606,29 +20623,29 @@ Methods</a> <a href="#ref-for-dom-audioparam-settargetattime③">(2)</a>
 AudioParam Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-settargetattime-target">
-   <b><a href="#dom-audioparam-settargetattime-target">#dom-audioparam-settargetattime-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-settargetattime-target" class="dfn-panel" data-for="dom-audioparam-settargetattime-target" id="infopanel-for-dom-audioparam-settargetattime-target" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-settargetattime-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-audioparam-settargetattime-target">#dom-audioparam-settargetattime-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-settargetattime-target">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-settargetattime-starttime">
-   <b><a href="#dom-audioparam-settargetattime-starttime">#dom-audioparam-settargetattime-starttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-settargetattime-starttime" class="dfn-panel" data-for="dom-audioparam-settargetattime-starttime" id="infopanel-for-dom-audioparam-settargetattime-starttime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-settargetattime-starttime" style="display:none">Info about the 'startTime' definition.</span><b><a href="#dom-audioparam-settargetattime-starttime">#dom-audioparam-settargetattime-starttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-settargetattime-starttime">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-settargetattime-starttime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-settargetattime-timeconstant">
-   <b><a href="#dom-audioparam-settargetattime-timeconstant">#dom-audioparam-settargetattime-timeconstant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-settargetattime-timeconstant" class="dfn-panel" data-for="dom-audioparam-settargetattime-timeconstant" id="infopanel-for-dom-audioparam-settargetattime-timeconstant" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-settargetattime-timeconstant" style="display:none">Info about the 'timeConstant' definition.</span><b><a href="#dom-audioparam-settargetattime-timeconstant">#dom-audioparam-settargetattime-timeconstant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-settargetattime-timeconstant">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvalueattime">
-   <b><a href="#dom-audioparam-setvalueattime">#dom-audioparam-setvalueattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvalueattime" class="dfn-panel" data-for="dom-audioparam-setvalueattime" id="infopanel-for-dom-audioparam-setvalueattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvalueattime" style="display:none">Info about the 'setValueAtTime(value, startTime)' definition.</span><b><a href="#dom-audioparam-setvalueattime">#dom-audioparam-setvalueattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvalueattime">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-setvalueattime①">(2)</a>
@@ -20638,22 +20655,22 @@ Attributes</a>
 Methods</a> <a href="#ref-for-dom-audioparam-setvalueattime④">(2)</a> <a href="#ref-for-dom-audioparam-setvalueattime⑤">(3)</a> <a href="#ref-for-dom-audioparam-setvalueattime⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvalueattime-value">
-   <b><a href="#dom-audioparam-setvalueattime-value">#dom-audioparam-setvalueattime-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvalueattime-value" class="dfn-panel" data-for="dom-audioparam-setvalueattime-value" id="infopanel-for-dom-audioparam-setvalueattime-value" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvalueattime-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-audioparam-setvalueattime-value">#dom-audioparam-setvalueattime-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvalueattime-value">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvalueattime-starttime">
-   <b><a href="#dom-audioparam-setvalueattime-starttime">#dom-audioparam-setvalueattime-starttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvalueattime-starttime" class="dfn-panel" data-for="dom-audioparam-setvalueattime-starttime" id="infopanel-for-dom-audioparam-setvalueattime-starttime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvalueattime-starttime" style="display:none">Info about the 'startTime' definition.</span><b><a href="#dom-audioparam-setvalueattime-starttime">#dom-audioparam-setvalueattime-starttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvalueattime-starttime">1.6.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime">
-   <b><a href="#dom-audioparam-setvaluecurveattime">#dom-audioparam-setvaluecurveattime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvaluecurveattime" class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime" id="infopanel-for-dom-audioparam-setvaluecurveattime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvaluecurveattime" style="display:none">Info about the 'setValueCurveAtTime(values, startTime, duration)' definition.</span><b><a href="#dom-audioparam-setvaluecurveattime">#dom-audioparam-setvaluecurveattime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvaluecurveattime">1.6. 
 The AudioParam Interface</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime①">(2)</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime②">(3)</a>
@@ -20665,36 +20682,37 @@ Methods</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime⑦">(2)</a>
 Methods</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-values">
-   <b><a href="#dom-audioparam-setvaluecurveattime-values">#dom-audioparam-setvaluecurveattime-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvaluecurveattime-values" class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-values" id="infopanel-for-dom-audioparam-setvaluecurveattime-values" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvaluecurveattime-values" style="display:none">Info about the 'values' definition.</span><b><a href="#dom-audioparam-setvaluecurveattime-values">#dom-audioparam-setvaluecurveattime-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvaluecurveattime-values">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-starttime">
-   <b><a href="#dom-audioparam-setvaluecurveattime-starttime">#dom-audioparam-setvaluecurveattime-starttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvaluecurveattime-starttime" class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-starttime" id="infopanel-for-dom-audioparam-setvaluecurveattime-starttime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvaluecurveattime-starttime" style="display:none">Info about the 'startTime' definition.</span><b><a href="#dom-audioparam-setvaluecurveattime-starttime">#dom-audioparam-setvaluecurveattime-starttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvaluecurveattime-starttime">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime-starttime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-duration">
-   <b><a href="#dom-audioparam-setvaluecurveattime-duration">#dom-audioparam-setvaluecurveattime-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparam-setvaluecurveattime-duration" class="dfn-panel" data-for="dom-audioparam-setvaluecurveattime-duration" id="infopanel-for-dom-audioparam-setvaluecurveattime-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparam-setvaluecurveattime-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#dom-audioparam-setvaluecurveattime-duration">#dom-audioparam-setvaluecurveattime-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparam-setvaluecurveattime-duration">1.6.2. 
 Methods</a> <a href="#ref-for-dom-audioparam-setvaluecurveattime-duration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-parameter">
-   <b><a href="#simple-parameter">#simple-parameter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-parameter" class="dfn-panel" data-for="simple-parameter" id="infopanel-for-simple-parameter" role="dialog">
+   <span id="infopaneltitle-for-simple-parameter" style="display:none">Info about the 'Simple parameters' definition.</span><b><a href="#simple-parameter">#simple-parameter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-parameter">1.6.3. 
 Computation of Value</a> <a href="#ref-for-simple-parameter①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compound-parameter">
-   <b><a href="#compound-parameter">#compound-parameter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compound-parameter" class="dfn-panel" data-for="compound-parameter" id="infopanel-for-compound-parameter" role="dialog">
+   <span id="infopaneltitle-for-compound-parameter" style="display:none">Info about the 'Compound
+parameters' definition.</span><b><a href="#compound-parameter">#compound-parameter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound-parameter">1.6.3. 
 Computation of Value</a> <a href="#ref-for-compound-parameter①">(2)</a> <a href="#ref-for-compound-parameter②">(3)</a>
@@ -20712,8 +20730,8 @@ The OscillatorNode Interface</a>
 Attributes</a> <a href="#ref-for-compound-parameter①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computedvalue">
-   <b><a href="#computedvalue">#computedvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computedvalue" class="dfn-panel" data-for="computedvalue" id="infopanel-for-computedvalue" role="dialog">
+   <span id="infopaneltitle-for-computedvalue" style="display:none">Info about the 'computedValue' definition.</span><b><a href="#computedvalue">#computedvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computedvalue">1.6.3. 
 Computation of Value</a> <a href="#ref-for-computedvalue①">(2)</a> <a href="#ref-for-computedvalue②">(3)</a>
@@ -20727,8 +20745,8 @@ Callback AudioWorkletProcessCallback Parameters </a>
 StereoPannerNode Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nominal-range">
-   <b><a href="#nominal-range">#nominal-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nominal-range" class="dfn-panel" data-for="nominal-range" id="infopanel-for-nominal-range" role="dialog">
+   <span id="infopaneltitle-for-nominal-range" style="display:none">Info about the 'nominal range' definition.</span><b><a href="#nominal-range">#nominal-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nominal-range">1.6.1. 
 Attributes</a> <a href="#ref-for-nominal-range①">(2)</a>
@@ -20744,21 +20762,22 @@ The OscillatorNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioScheduledSourceNode">
-   <b><a href="#AudioScheduledSourceNode">#AudioScheduledSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioScheduledSourceNode" class="dfn-panel" data-for="AudioScheduledSourceNode" id="infopanel-for-AudioScheduledSourceNode" role="dialog">
+   <span id="infopaneltitle-for-AudioScheduledSourceNode" style="display:none">Info about the '1.7. 
+The AudioScheduledSourceNode Interface' definition.</span><b><a href="#AudioScheduledSourceNode">#AudioScheduledSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioScheduledSourceNode">1.7. 
 The AudioScheduledSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="playing">
-   <b><a href="#playing">#playing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-playing" class="dfn-panel" data-for="playing" id="infopanel-for-playing" role="dialog">
+   <span id="infopaneltitle-for-playing" style="display:none">Info about the 'playing' definition.</span><b><a href="#playing">#playing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playing">1.5.3. AudioNode Lifetime</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-source-started-slot">
-   <b><a href="#dom-audioscheduledsourcenode-source-started-slot">#dom-audioscheduledsourcenode-source-started-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-source-started-slot" class="dfn-panel" data-for="dom-audioscheduledsourcenode-source-started-slot" id="infopanel-for-dom-audioscheduledsourcenode-source-started-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-source-started-slot" style="display:none">Info about the '[[source started]]' definition.</span><b><a href="#dom-audioscheduledsourcenode-source-started-slot">#dom-audioscheduledsourcenode-source-started-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-source-started-slot">1.7.2. 
 Methods</a> <a href="#ref-for-dom-audioscheduledsourcenode-source-started-slot①">(2)</a> <a href="#ref-for-dom-audioscheduledsourcenode-source-started-slot②">(3)</a>
@@ -20766,8 +20785,8 @@ Methods</a> <a href="#ref-for-dom-audioscheduledsourcenode-source-started-slot�
 Methods</a> <a href="#ref-for-dom-audioscheduledsourcenode-source-started-slot④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioscheduledsourcenode">
-   <b><a href="#audioscheduledsourcenode">#audioscheduledsourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioscheduledsourcenode" class="dfn-panel" data-for="audioscheduledsourcenode" id="infopanel-for-audioscheduledsourcenode" role="dialog">
+   <span id="infopaneltitle-for-audioscheduledsourcenode" style="display:none">Info about the 'AudioScheduledSourceNode' definition.</span><b><a href="#audioscheduledsourcenode">#audioscheduledsourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioscheduledsourcenode">1.5.3. AudioNode Lifetime</a>
     <li><a href="#ref-for-audioscheduledsourcenode①">1.7. 
@@ -20784,15 +20803,15 @@ The ConstantSourceNode Interface</a>
 The OscillatorNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-onended">
-   <b><a href="#dom-audioscheduledsourcenode-onended">#dom-audioscheduledsourcenode-onended</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-onended" class="dfn-panel" data-for="dom-audioscheduledsourcenode-onended" id="infopanel-for-dom-audioscheduledsourcenode-onended" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-onended" style="display:none">Info about the 'onended' definition.</span><b><a href="#dom-audioscheduledsourcenode-onended">#dom-audioscheduledsourcenode-onended</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-onended">1.7. 
 The AudioScheduledSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-start">
-   <b><a href="#dom-audioscheduledsourcenode-start">#dom-audioscheduledsourcenode-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-start" class="dfn-panel" data-for="dom-audioscheduledsourcenode-start" id="infopanel-for-dom-audioscheduledsourcenode-start" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-start" style="display:none">Info about the 'start(when)' definition.</span><b><a href="#dom-audioscheduledsourcenode-start">#dom-audioscheduledsourcenode-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-start">1.7. 
 The AudioScheduledSourceNode Interface</a> <a href="#ref-for-dom-audioscheduledsourcenode-start①">(2)</a>
@@ -20804,8 +20823,8 @@ The AudioBufferSourceNode Interface</a> <a href="#ref-for-dom-audioscheduledsour
 The OscillatorNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-start-when-when">
-   <b><a href="#dom-audioscheduledsourcenode-start-when-when">#dom-audioscheduledsourcenode-start-when-when</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-start-when-when" class="dfn-panel" data-for="dom-audioscheduledsourcenode-start-when-when" id="infopanel-for-dom-audioscheduledsourcenode-start-when-when" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-start-when-when" style="display:none">Info about the 'when' definition.</span><b><a href="#dom-audioscheduledsourcenode-start-when-when">#dom-audioscheduledsourcenode-start-when-when</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-start-when-when">1.7. 
 The AudioScheduledSourceNode Interface</a>
@@ -20813,8 +20832,8 @@ The AudioScheduledSourceNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-stop">
-   <b><a href="#dom-audioscheduledsourcenode-stop">#dom-audioscheduledsourcenode-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-stop" class="dfn-panel" data-for="dom-audioscheduledsourcenode-stop" id="infopanel-for-dom-audioscheduledsourcenode-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-stop" style="display:none">Info about the 'stop(when)' definition.</span><b><a href="#dom-audioscheduledsourcenode-stop">#dom-audioscheduledsourcenode-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-stop">1.7. 
 The AudioScheduledSourceNode Interface</a> <a href="#ref-for-dom-audioscheduledsourcenode-stop①">(2)</a>
@@ -20828,8 +20847,8 @@ The AudioBufferSourceNode Interface</a> <a href="#ref-for-dom-audioscheduledsour
 Looping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioscheduledsourcenode-stop-when-when">
-   <b><a href="#dom-audioscheduledsourcenode-stop-when-when">#dom-audioscheduledsourcenode-stop-when-when</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioscheduledsourcenode-stop-when-when" class="dfn-panel" data-for="dom-audioscheduledsourcenode-stop-when-when" id="infopanel-for-dom-audioscheduledsourcenode-stop-when-when" role="dialog">
+   <span id="infopaneltitle-for-dom-audioscheduledsourcenode-stop-when-when" style="display:none">Info about the 'when' definition.</span><b><a href="#dom-audioscheduledsourcenode-stop-when-when">#dom-audioscheduledsourcenode-stop-when-when</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioscheduledsourcenode-stop-when-when">1.7. 
 The AudioScheduledSourceNode Interface</a>
@@ -20839,16 +20858,17 @@ Methods</a>
 The AudioBufferSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AnalyserNode">
-   <b><a href="#AnalyserNode">#AnalyserNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AnalyserNode" class="dfn-panel" data-for="AnalyserNode" id="infopanel-for-AnalyserNode" role="dialog">
+   <span id="infopaneltitle-for-AnalyserNode" style="display:none">Info about the '1.8. 
+The AnalyserNode Interface' definition.</span><b><a href="#AnalyserNode">#AnalyserNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AnalyserNode"> Features</a>
     <li><a href="#ref-for-AnalyserNode">1.8. 
 The AnalyserNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="analysernode">
-   <b><a href="#analysernode">#analysernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-analysernode" class="dfn-panel" data-for="analysernode" id="infopanel-for-analysernode" role="dialog">
+   <span id="infopaneltitle-for-analysernode" style="display:none">Info about the 'AnalyserNode' definition.</span><b><a href="#analysernode">#analysernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-analysernode"> API Overview</a>
     <li><a href="#ref-for-analysernode①">1.1. 
@@ -20873,8 +20893,8 @@ FFT Windowing and Smoothing over Time</a> <a href="#ref-for-analysernode①④">
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-analysernode">
-   <b><a href="#dom-analysernode-analysernode">#dom-analysernode-analysernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-analysernode" class="dfn-panel" data-for="dom-analysernode-analysernode" id="infopanel-for-dom-analysernode-analysernode" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-analysernode" style="display:none">Info about the 'AnalyserNode(context, options)' definition.</span><b><a href="#dom-analysernode-analysernode">#dom-analysernode-analysernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-analysernode">1.8. 
 The AnalyserNode Interface</a>
@@ -20882,8 +20902,8 @@ The AnalyserNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-fftsize">
-   <b><a href="#dom-analysernode-fftsize">#dom-analysernode-fftsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-fftsize" class="dfn-panel" data-for="dom-analysernode-fftsize" id="infopanel-for-dom-analysernode-fftsize" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-fftsize" style="display:none">Info about the 'fftSize' definition.</span><b><a href="#dom-analysernode-fftsize">#dom-analysernode-fftsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-fftsize">1.8. 
 The AnalyserNode Interface</a>
@@ -20897,8 +20917,8 @@ Time-Domain Down-Mixing</a>
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-frequencybincount">
-   <b><a href="#dom-analysernode-frequencybincount">#dom-analysernode-frequencybincount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-frequencybincount" class="dfn-panel" data-for="dom-analysernode-frequencybincount" id="infopanel-for-dom-analysernode-frequencybincount" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-frequencybincount" style="display:none">Info about the 'frequencyBinCount' definition.</span><b><a href="#dom-analysernode-frequencybincount">#dom-analysernode-frequencybincount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-frequencybincount">1.8. 
 The AnalyserNode Interface</a>
@@ -20906,8 +20926,8 @@ The AnalyserNode Interface</a>
 Methods</a> <a href="#ref-for-dom-analysernode-frequencybincount②">(2)</a> <a href="#ref-for-dom-analysernode-frequencybincount③">(3)</a> <a href="#ref-for-dom-analysernode-frequencybincount④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-maxdecibels">
-   <b><a href="#dom-analysernode-maxdecibels">#dom-analysernode-maxdecibels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-maxdecibels" class="dfn-panel" data-for="dom-analysernode-maxdecibels" id="infopanel-for-dom-analysernode-maxdecibels" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-maxdecibels" style="display:none">Info about the 'maxDecibels' definition.</span><b><a href="#dom-analysernode-maxdecibels">#dom-analysernode-maxdecibels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-maxdecibels">1.8. 
 The AnalyserNode Interface</a>
@@ -20919,8 +20939,8 @@ Methods</a>
 FFT Windowing and Smoothing over Time</a> <a href="#ref-for-dom-analysernode-maxdecibels⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-mindecibels">
-   <b><a href="#dom-analysernode-mindecibels">#dom-analysernode-mindecibels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-mindecibels" class="dfn-panel" data-for="dom-analysernode-mindecibels" id="infopanel-for-dom-analysernode-mindecibels" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-mindecibels" style="display:none">Info about the 'minDecibels' definition.</span><b><a href="#dom-analysernode-mindecibels">#dom-analysernode-mindecibels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-mindecibels">1.8. 
 The AnalyserNode Interface</a>
@@ -20932,8 +20952,8 @@ Methods</a>
 FFT Windowing and Smoothing over Time</a> <a href="#ref-for-dom-analysernode-mindecibels⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-smoothingtimeconstant">
-   <b><a href="#dom-analysernode-smoothingtimeconstant">#dom-analysernode-smoothingtimeconstant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-smoothingtimeconstant" class="dfn-panel" data-for="dom-analysernode-smoothingtimeconstant" id="infopanel-for-dom-analysernode-smoothingtimeconstant" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-smoothingtimeconstant" style="display:none">Info about the 'smoothingTimeConstant' definition.</span><b><a href="#dom-analysernode-smoothingtimeconstant">#dom-analysernode-smoothingtimeconstant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-smoothingtimeconstant">1.8. 
 The AnalyserNode Interface</a>
@@ -20941,8 +20961,8 @@ The AnalyserNode Interface</a>
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-getbytefrequencydata">
-   <b><a href="#dom-analysernode-getbytefrequencydata">#dom-analysernode-getbytefrequencydata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-getbytefrequencydata" class="dfn-panel" data-for="dom-analysernode-getbytefrequencydata" id="infopanel-for-dom-analysernode-getbytefrequencydata" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-getbytefrequencydata" style="display:none">Info about the 'getByteFrequencyData(array)' definition.</span><b><a href="#dom-analysernode-getbytefrequencydata">#dom-analysernode-getbytefrequencydata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-getbytefrequencydata">1.8. 
 The AnalyserNode Interface</a>
@@ -20954,8 +20974,8 @@ Methods</a> <a href="#ref-for-dom-analysernode-getbytefrequencydata③">(2)</a> 
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-getbytetimedomaindata">
-   <b><a href="#dom-analysernode-getbytetimedomaindata">#dom-analysernode-getbytetimedomaindata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-getbytetimedomaindata" class="dfn-panel" data-for="dom-analysernode-getbytetimedomaindata" id="infopanel-for-dom-analysernode-getbytetimedomaindata" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-getbytetimedomaindata" style="display:none">Info about the 'getByteTimeDomainData(array)' definition.</span><b><a href="#dom-analysernode-getbytetimedomaindata">#dom-analysernode-getbytetimedomaindata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-getbytetimedomaindata">1.8. 
 The AnalyserNode Interface</a>
@@ -20963,8 +20983,8 @@ The AnalyserNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-getfloatfrequencydata">
-   <b><a href="#dom-analysernode-getfloatfrequencydata">#dom-analysernode-getfloatfrequencydata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-getfloatfrequencydata" class="dfn-panel" data-for="dom-analysernode-getfloatfrequencydata" id="infopanel-for-dom-analysernode-getfloatfrequencydata" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-getfloatfrequencydata" style="display:none">Info about the 'getFloatFrequencyData(array)' definition.</span><b><a href="#dom-analysernode-getfloatfrequencydata">#dom-analysernode-getfloatfrequencydata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-getfloatfrequencydata">1.8. 
 The AnalyserNode Interface</a>
@@ -20976,8 +20996,8 @@ Methods</a> <a href="#ref-for-dom-analysernode-getfloatfrequencydata③">(2)</a>
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analysernode-getfloattimedomaindata">
-   <b><a href="#dom-analysernode-getfloattimedomaindata">#dom-analysernode-getfloattimedomaindata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analysernode-getfloattimedomaindata" class="dfn-panel" data-for="dom-analysernode-getfloattimedomaindata" id="infopanel-for-dom-analysernode-getfloattimedomaindata" role="dialog">
+   <span id="infopaneltitle-for-dom-analysernode-getfloattimedomaindata" style="display:none">Info about the 'getFloatTimeDomainData(array)' definition.</span><b><a href="#dom-analysernode-getfloattimedomaindata">#dom-analysernode-getfloattimedomaindata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analysernode-getfloattimedomaindata">1.8. 
 The AnalyserNode Interface</a>
@@ -20985,15 +21005,16 @@ The AnalyserNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AnalyserOptions">
-   <b><a href="#AnalyserOptions">#AnalyserOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AnalyserOptions" class="dfn-panel" data-for="AnalyserOptions" id="infopanel-for-AnalyserOptions" role="dialog">
+   <span id="infopaneltitle-for-AnalyserOptions" style="display:none">Info about the '1.8.4. 
+AnalyserOptions' definition.</span><b><a href="#AnalyserOptions">#AnalyserOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AnalyserOptions">1.8.4. 
 AnalyserOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-analyseroptions">
-   <b><a href="#dictdef-analyseroptions">#dictdef-analyseroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-analyseroptions" class="dfn-panel" data-for="dictdef-analyseroptions" id="infopanel-for-dictdef-analyseroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-analyseroptions" style="display:none">Info about the 'AnalyserOptions' definition.</span><b><a href="#dictdef-analyseroptions">#dictdef-analyseroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-analyseroptions">1.8. 
 The AnalyserNode Interface</a>
@@ -21005,36 +21026,36 @@ AnalyserOptions</a>
 Dictionary AnalyserOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analyseroptions-fftsize">
-   <b><a href="#dom-analyseroptions-fftsize">#dom-analyseroptions-fftsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analyseroptions-fftsize" class="dfn-panel" data-for="dom-analyseroptions-fftsize" id="infopanel-for-dom-analyseroptions-fftsize" role="dialog">
+   <span id="infopaneltitle-for-dom-analyseroptions-fftsize" style="display:none">Info about the 'fftSize' definition.</span><b><a href="#dom-analyseroptions-fftsize">#dom-analyseroptions-fftsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analyseroptions-fftsize">1.8.4. 
 AnalyserOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analyseroptions-maxdecibels">
-   <b><a href="#dom-analyseroptions-maxdecibels">#dom-analyseroptions-maxdecibels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analyseroptions-maxdecibels" class="dfn-panel" data-for="dom-analyseroptions-maxdecibels" id="infopanel-for-dom-analyseroptions-maxdecibels" role="dialog">
+   <span id="infopaneltitle-for-dom-analyseroptions-maxdecibels" style="display:none">Info about the 'maxDecibels' definition.</span><b><a href="#dom-analyseroptions-maxdecibels">#dom-analyseroptions-maxdecibels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analyseroptions-maxdecibels">1.8.4. 
 AnalyserOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analyseroptions-mindecibels">
-   <b><a href="#dom-analyseroptions-mindecibels">#dom-analyseroptions-mindecibels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analyseroptions-mindecibels" class="dfn-panel" data-for="dom-analyseroptions-mindecibels" id="infopanel-for-dom-analyseroptions-mindecibels" role="dialog">
+   <span id="infopaneltitle-for-dom-analyseroptions-mindecibels" style="display:none">Info about the 'minDecibels' definition.</span><b><a href="#dom-analyseroptions-mindecibels">#dom-analyseroptions-mindecibels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analyseroptions-mindecibels">1.8.4. 
 AnalyserOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-analyseroptions-smoothingtimeconstant">
-   <b><a href="#dom-analyseroptions-smoothingtimeconstant">#dom-analyseroptions-smoothingtimeconstant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-analyseroptions-smoothingtimeconstant" class="dfn-panel" data-for="dom-analyseroptions-smoothingtimeconstant" id="infopanel-for-dom-analyseroptions-smoothingtimeconstant" role="dialog">
+   <span id="infopaneltitle-for-dom-analyseroptions-smoothingtimeconstant" style="display:none">Info about the 'smoothingTimeConstant' definition.</span><b><a href="#dom-analyseroptions-smoothingtimeconstant">#dom-analyseroptions-smoothingtimeconstant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-analyseroptions-smoothingtimeconstant">1.8.4. 
 AnalyserOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-time-domain-data">
-   <b><a href="#current-time-domain-data">#current-time-domain-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-time-domain-data" class="dfn-panel" data-for="current-time-domain-data" id="infopanel-for-current-time-domain-data" role="dialog">
+   <span id="infopaneltitle-for-current-time-domain-data" style="display:none">Info about the 'current time-domain data' definition.</span><b><a href="#current-time-domain-data">#current-time-domain-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time-domain-data">1.8.2. 
 Attributes</a> <a href="#ref-for-current-time-domain-data①">(2)</a>
@@ -21044,29 +21065,30 @@ Methods</a> <a href="#ref-for-current-time-domain-data③">(2)</a>
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-frequency-data">
-   <b><a href="#current-frequency-data">#current-frequency-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-frequency-data" class="dfn-panel" data-for="current-frequency-data" id="infopanel-for-current-frequency-data" role="dialog">
+   <span id="infopaneltitle-for-current-frequency-data" style="display:none">Info about the 'current frequency
+data' definition.</span><b><a href="#current-frequency-data">#current-frequency-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-frequency-data">1.8.3. 
 Methods</a> <a href="#ref-for-current-frequency-data①">(2)</a> <a href="#ref-for-current-frequency-data②">(3)</a> <a href="#ref-for-current-frequency-data③">(4)</a> <a href="#ref-for-current-frequency-data④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blackman-window">
-   <b><a href="#blackman-window">#blackman-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blackman-window" class="dfn-panel" data-for="blackman-window" id="infopanel-for-blackman-window" role="dialog">
+   <span id="infopaneltitle-for-blackman-window" style="display:none">Info about the 'Applying a Blackman window' definition.</span><b><a href="#blackman-window">#blackman-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blackman-window">1.8.6. 
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fourier-transform">
-   <b><a href="#fourier-transform">#fourier-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fourier-transform" class="dfn-panel" data-for="fourier-transform" id="infopanel-for-fourier-transform" role="dialog">
+   <span id="infopaneltitle-for-fourier-transform" style="display:none">Info about the 'Applying a Fourier transform' definition.</span><b><a href="#fourier-transform">#fourier-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fourier-transform">1.8.6. 
 FFT Windowing and Smoothing over Time</a> <a href="#ref-for-fourier-transform">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="smoothing-over-time">
-   <b><a href="#smoothing-over-time">#smoothing-over-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-smoothing-over-time" class="dfn-panel" data-for="smoothing-over-time" id="infopanel-for-smoothing-over-time" role="dialog">
+   <span id="infopaneltitle-for-smoothing-over-time" style="display:none">Info about the 'Smoothing over time' definition.</span><b><a href="#smoothing-over-time">#smoothing-over-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-smoothing-over-time">1.8.2. 
 Attributes</a>
@@ -21074,8 +21096,8 @@ Attributes</a>
 FFT Windowing and Smoothing over Time</a> <a href="#ref-for-smoothing-over-time">(2)</a> <a href="#ref-for-smoothing-over-time">(3)</a> <a href="#ref-for-smoothing-over-time">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-block">
-   <b><a href="#previous-block">#previous-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-block" class="dfn-panel" data-for="previous-block" id="infopanel-for-previous-block" role="dialog">
+   <span id="infopaneltitle-for-previous-block" style="display:none">Info about the 'previous block' definition.</span><b><a href="#previous-block">#previous-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-block">1.8.2. 
 Attributes</a>
@@ -21083,22 +21105,23 @@ Attributes</a>
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conversion-to-db">
-   <b><a href="#conversion-to-db">#conversion-to-db</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conversion-to-db" class="dfn-panel" data-for="conversion-to-db" id="infopanel-for-conversion-to-db" role="dialog">
+   <span id="infopaneltitle-for-conversion-to-db" style="display:none">Info about the 'Conversion to dB' definition.</span><b><a href="#conversion-to-db">#conversion-to-db</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conversion-to-db">1.8.6. 
 FFT Windowing and Smoothing over Time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioBufferSourceNode">
-   <b><a href="#AudioBufferSourceNode">#AudioBufferSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioBufferSourceNode" class="dfn-panel" data-for="AudioBufferSourceNode" id="infopanel-for-AudioBufferSourceNode" role="dialog">
+   <span id="infopaneltitle-for-AudioBufferSourceNode" style="display:none">Info about the '1.9. 
+The AudioBufferSourceNode Interface' definition.</span><b><a href="#AudioBufferSourceNode">#AudioBufferSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioBufferSourceNode">1.9. 
 The AudioBufferSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="playhead-position">
-   <b><a href="#playhead-position">#playhead-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-playhead-position" class="dfn-panel" data-for="playhead-position" id="infopanel-for-playhead-position" role="dialog">
+   <span id="infopaneltitle-for-playhead-position" style="display:none">Info about the 'playhead position' definition.</span><b><a href="#playhead-position">#playhead-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playhead-position">1.9.2. 
 Attributes</a> <a href="#ref-for-playhead-position①">(2)</a>
@@ -21106,8 +21129,8 @@ Attributes</a> <a href="#ref-for-playhead-position①">(2)</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computedplaybackrate">
-   <b><a href="#computedplaybackrate">#computedplaybackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computedplaybackrate" class="dfn-panel" data-for="computedplaybackrate" id="infopanel-for-computedplaybackrate" role="dialog">
+   <span id="infopaneltitle-for-computedplaybackrate" style="display:none">Info about the 'computedPlaybackRate' definition.</span><b><a href="#computedplaybackrate">#computedplaybackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computedplaybackrate">1.9.2. 
 Attributes</a> <a href="#ref-for-computedplaybackrate①">(2)</a>
@@ -21115,15 +21138,15 @@ Attributes</a> <a href="#ref-for-computedplaybackrate①">(2)</a>
 Playback of AudioBuffer Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-buffer-set-slot">
-   <b><a href="#dom-audiobuffersourcenode-buffer-set-slot">#dom-audiobuffersourcenode-buffer-set-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-buffer-set-slot" class="dfn-panel" data-for="dom-audiobuffersourcenode-buffer-set-slot" id="infopanel-for-dom-audiobuffersourcenode-buffer-set-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-buffer-set-slot" style="display:none">Info about the '[[buffer set]]' definition.</span><b><a href="#dom-audiobuffersourcenode-buffer-set-slot">#dom-audiobuffersourcenode-buffer-set-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-buffer-set-slot">1.9.2. 
 Attributes</a> <a href="#ref-for-dom-audiobuffersourcenode-buffer-set-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiobuffersourcenode">
-   <b><a href="#audiobuffersourcenode">#audiobuffersourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiobuffersourcenode" class="dfn-panel" data-for="audiobuffersourcenode" id="infopanel-for-audiobuffersourcenode" role="dialog">
+   <span id="infopaneltitle-for-audiobuffersourcenode" style="display:none">Info about the 'AudioBufferSourceNode' definition.</span><b><a href="#audiobuffersourcenode">#audiobuffersourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiobuffersourcenode"> API Overview</a>
     <li><a href="#ref-for-audiobuffersourcenode①">1.1. 
@@ -21160,15 +21183,15 @@ Background</a> <a href="#ref-for-audiobuffersourcenode③⓪">(2)</a>
 Audio Buffer Copying</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-audiobuffersourcenode">
-   <b><a href="#dom-audiobuffersourcenode-audiobuffersourcenode">#dom-audiobuffersourcenode-audiobuffersourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-audiobuffersourcenode" class="dfn-panel" data-for="dom-audiobuffersourcenode-audiobuffersourcenode" id="infopanel-for-dom-audiobuffersourcenode-audiobuffersourcenode" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-audiobuffersourcenode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-audiobuffersourcenode-audiobuffersourcenode">#dom-audiobuffersourcenode-audiobuffersourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-audiobuffersourcenode">1.9.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-buffer">
-   <b><a href="#dom-audiobuffersourcenode-buffer">#dom-audiobuffersourcenode-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-buffer" class="dfn-panel" data-for="dom-audiobuffersourcenode-buffer" id="infopanel-for-dom-audiobuffersourcenode-buffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#dom-audiobuffersourcenode-buffer">#dom-audiobuffersourcenode-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-buffer">1.4.3. 
 Methods</a> <a href="#ref-for-dom-audiobuffersourcenode-buffer①">(2)</a>
@@ -21184,8 +21207,8 @@ Methods</a> <a href="#ref-for-dom-audiobuffersourcenode-buffer①②">(2)</a> <a
 Dictionary AudioBufferSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-detune">
-   <b><a href="#dom-audiobuffersourcenode-detune">#dom-audiobuffersourcenode-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-detune" class="dfn-panel" data-for="dom-audiobuffersourcenode-detune" id="infopanel-for-dom-audiobuffersourcenode-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-audiobuffersourcenode-detune">#dom-audiobuffersourcenode-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-detune">1.6.1. 
 Attributes</a>
@@ -21197,8 +21220,8 @@ Attributes</a>
 Dictionary AudioBufferSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-loop">
-   <b><a href="#dom-audiobuffersourcenode-loop">#dom-audiobuffersourcenode-loop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-loop" class="dfn-panel" data-for="dom-audiobuffersourcenode-loop" id="infopanel-for-dom-audiobuffersourcenode-loop" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-loop" style="display:none">Info about the 'loop' definition.</span><b><a href="#dom-audiobuffersourcenode-loop">#dom-audiobuffersourcenode-loop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-loop">1.9. 
 The AudioBufferSourceNode Interface</a> <a href="#ref-for-dom-audiobuffersourcenode-loop①">(2)</a>
@@ -21212,8 +21235,8 @@ Dictionary AudioBufferSourceOptions Members</a>
 Looping</a> <a href="#ref-for-dom-audiobuffersourcenode-loop⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-loopend">
-   <b><a href="#dom-audiobuffersourcenode-loopend">#dom-audiobuffersourcenode-loopend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-loopend" class="dfn-panel" data-for="dom-audiobuffersourcenode-loopend" id="infopanel-for-dom-audiobuffersourcenode-loopend" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-loopend" style="display:none">Info about the 'loopEnd' definition.</span><b><a href="#dom-audiobuffersourcenode-loopend">#dom-audiobuffersourcenode-loopend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-loopend">1.9. 
 The AudioBufferSourceNode Interface</a>
@@ -21227,8 +21250,8 @@ Dictionary AudioBufferSourceOptions Members</a>
 Looping</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend⑧">(2)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend⑨">(3)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend①⓪">(4)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend①①">(5)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend①②">(6)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopend①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-loopstart">
-   <b><a href="#dom-audiobuffersourcenode-loopstart">#dom-audiobuffersourcenode-loopstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-loopstart" class="dfn-panel" data-for="dom-audiobuffersourcenode-loopstart" id="infopanel-for-dom-audiobuffersourcenode-loopstart" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-loopstart" style="display:none">Info about the 'loopStart' definition.</span><b><a href="#dom-audiobuffersourcenode-loopstart">#dom-audiobuffersourcenode-loopstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-loopstart">1.9. 
 The AudioBufferSourceNode Interface</a>
@@ -21242,8 +21265,8 @@ Dictionary AudioBufferSourceOptions Members</a>
 Looping</a> <a href="#ref-for-dom-audiobuffersourcenode-loopstart⑧">(2)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopstart⑨">(3)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopstart①⓪">(4)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopstart①①">(5)</a> <a href="#ref-for-dom-audiobuffersourcenode-loopstart①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-playbackrate">
-   <b><a href="#dom-audiobuffersourcenode-playbackrate">#dom-audiobuffersourcenode-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-playbackrate" class="dfn-panel" data-for="dom-audiobuffersourcenode-playbackrate" id="infopanel-for-dom-audiobuffersourcenode-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-audiobuffersourcenode-playbackrate">#dom-audiobuffersourcenode-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-playbackrate">1.6.1. 
 Attributes</a>
@@ -21259,8 +21282,8 @@ Dictionary AudioBufferSourceOptions Members</a>
 Looping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-start">
-   <b><a href="#dom-audiobuffersourcenode-start">#dom-audiobuffersourcenode-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-start" class="dfn-panel" data-for="dom-audiobuffersourcenode-start" id="infopanel-for-dom-audiobuffersourcenode-start" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-start" style="display:none">Info about the 'start(when, offset, duration)' definition.</span><b><a href="#dom-audiobuffersourcenode-start">#dom-audiobuffersourcenode-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-start">1.4.3. 
 Methods</a> <a href="#ref-for-dom-audiobuffersourcenode-start①">(2)</a>
@@ -21276,22 +21299,22 @@ Looping</a> <a href="#ref-for-dom-audiobuffersourcenode-start⑦">(2)</a>
 Playback of AudioBuffer Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-when">
-   <b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-when">#dom-audiobuffersourcenode-start-when-offset-duration-when</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-when" class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-when" id="infopanel-for-dom-audiobuffersourcenode-start-when-offset-duration-when" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-when" style="display:none">Info about the 'when' definition.</span><b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-when">#dom-audiobuffersourcenode-start-when-offset-duration-when</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-start-when-offset-duration-when">1.9. 
 The AudioBufferSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-offset">
-   <b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-offset">#dom-audiobuffersourcenode-start-when-offset-duration-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-offset" class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-offset" id="infopanel-for-dom-audiobuffersourcenode-start-when-offset-duration-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-offset">#dom-audiobuffersourcenode-start-when-offset-duration-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-start-when-offset-duration-offset">1.9. 
 The AudioBufferSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-duration">
-   <b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-duration">#dom-audiobuffersourcenode-start-when-offset-duration-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-duration" class="dfn-panel" data-for="dom-audiobuffersourcenode-start-when-offset-duration-duration" id="infopanel-for-dom-audiobuffersourcenode-start-when-offset-duration-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourcenode-start-when-offset-duration-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#dom-audiobuffersourcenode-start-when-offset-duration-duration">#dom-audiobuffersourcenode-start-when-offset-duration-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourcenode-start-when-offset-duration-duration">1.7.1. 
 Attributes</a>
@@ -21301,15 +21324,16 @@ The AudioBufferSourceNode Interface</a> <a href="#ref-for-dom-audiobuffersourcen
 Methods</a> <a href="#ref-for-dom-audiobuffersourcenode-start-when-offset-duration-duration④">(2)</a> <a href="#ref-for-dom-audiobuffersourcenode-start-when-offset-duration-duration⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioBufferSourceOptions">
-   <b><a href="#AudioBufferSourceOptions">#AudioBufferSourceOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioBufferSourceOptions" class="dfn-panel" data-for="AudioBufferSourceOptions" id="infopanel-for-AudioBufferSourceOptions" role="dialog">
+   <span id="infopaneltitle-for-AudioBufferSourceOptions" style="display:none">Info about the '1.9.4. 
+AudioBufferSourceOptions' definition.</span><b><a href="#AudioBufferSourceOptions">#AudioBufferSourceOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioBufferSourceOptions">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audiobuffersourceoptions">
-   <b><a href="#dictdef-audiobuffersourceoptions">#dictdef-audiobuffersourceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audiobuffersourceoptions" class="dfn-panel" data-for="dictdef-audiobuffersourceoptions" id="infopanel-for-dictdef-audiobuffersourceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audiobuffersourceoptions" style="display:none">Info about the 'AudioBufferSourceOptions' definition.</span><b><a href="#dictdef-audiobuffersourceoptions">#dictdef-audiobuffersourceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audiobuffersourceoptions">1.9. 
 The AudioBufferSourceNode Interface</a>
@@ -21321,8 +21345,8 @@ AudioBufferSourceOptions</a>
 Dictionary AudioBufferSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-buffer">
-   <b><a href="#dom-audiobuffersourceoptions-buffer">#dom-audiobuffersourceoptions-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-buffer" class="dfn-panel" data-for="dom-audiobuffersourceoptions-buffer" id="infopanel-for-dom-audiobuffersourceoptions-buffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#dom-audiobuffersourceoptions-buffer">#dom-audiobuffersourceoptions-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-buffer">1.9.4. 
 AudioBufferSourceOptions</a>
@@ -21330,50 +21354,51 @@ AudioBufferSourceOptions</a>
 Dictionary AudioBufferSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-detune">
-   <b><a href="#dom-audiobuffersourceoptions-detune">#dom-audiobuffersourceoptions-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-detune" class="dfn-panel" data-for="dom-audiobuffersourceoptions-detune" id="infopanel-for-dom-audiobuffersourceoptions-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-audiobuffersourceoptions-detune">#dom-audiobuffersourceoptions-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-detune">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-loop">
-   <b><a href="#dom-audiobuffersourceoptions-loop">#dom-audiobuffersourceoptions-loop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-loop" class="dfn-panel" data-for="dom-audiobuffersourceoptions-loop" id="infopanel-for-dom-audiobuffersourceoptions-loop" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-loop" style="display:none">Info about the 'loop' definition.</span><b><a href="#dom-audiobuffersourceoptions-loop">#dom-audiobuffersourceoptions-loop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-loop">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-loopend">
-   <b><a href="#dom-audiobuffersourceoptions-loopend">#dom-audiobuffersourceoptions-loopend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-loopend" class="dfn-panel" data-for="dom-audiobuffersourceoptions-loopend" id="infopanel-for-dom-audiobuffersourceoptions-loopend" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-loopend" style="display:none">Info about the 'loopEnd' definition.</span><b><a href="#dom-audiobuffersourceoptions-loopend">#dom-audiobuffersourceoptions-loopend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-loopend">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-loopstart">
-   <b><a href="#dom-audiobuffersourceoptions-loopstart">#dom-audiobuffersourceoptions-loopstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-loopstart" class="dfn-panel" data-for="dom-audiobuffersourceoptions-loopstart" id="infopanel-for-dom-audiobuffersourceoptions-loopstart" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-loopstart" style="display:none">Info about the 'loopStart' definition.</span><b><a href="#dom-audiobuffersourceoptions-loopstart">#dom-audiobuffersourceoptions-loopstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-loopstart">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiobuffersourceoptions-playbackrate">
-   <b><a href="#dom-audiobuffersourceoptions-playbackrate">#dom-audiobuffersourceoptions-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiobuffersourceoptions-playbackrate" class="dfn-panel" data-for="dom-audiobuffersourceoptions-playbackrate" id="infopanel-for-dom-audiobuffersourceoptions-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-audiobuffersourceoptions-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-audiobuffersourceoptions-playbackrate">#dom-audiobuffersourceoptions-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiobuffersourceoptions-playbackrate">1.9.4. 
 AudioBufferSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioDestinationNode">
-   <b><a href="#AudioDestinationNode">#AudioDestinationNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioDestinationNode" class="dfn-panel" data-for="AudioDestinationNode" id="infopanel-for-AudioDestinationNode" role="dialog">
+   <span id="infopaneltitle-for-AudioDestinationNode" style="display:none">Info about the '1.10. 
+The AudioDestinationNode Interface' definition.</span><b><a href="#AudioDestinationNode">#AudioDestinationNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioDestinationNode">1.10. 
 The AudioDestinationNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiodestinationnode">
-   <b><a href="#audiodestinationnode">#audiodestinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiodestinationnode" class="dfn-panel" data-for="audiodestinationnode" id="infopanel-for-audiodestinationnode" role="dialog">
+   <span id="infopaneltitle-for-audiodestinationnode" style="display:none">Info about the 'AudioDestinationNode' definition.</span><b><a href="#audiodestinationnode">#audiodestinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiodestinationnode"> Modular Routing</a>
     <li><a href="#ref-for-audiodestinationnode①"> API Overview</a>
@@ -21397,8 +21422,8 @@ The AudioDestinationNode Interface</a> <a href="#ref-for-audiodestinationnode①
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiodestinationnode-maxchannelcount">
-   <b><a href="#dom-audiodestinationnode-maxchannelcount">#dom-audiodestinationnode-maxchannelcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiodestinationnode-maxchannelcount" class="dfn-panel" data-for="dom-audiodestinationnode-maxchannelcount" id="infopanel-for-dom-audiodestinationnode-maxchannelcount" role="dialog">
+   <span id="infopaneltitle-for-dom-audiodestinationnode-maxchannelcount" style="display:none">Info about the 'maxChannelCount' definition.</span><b><a href="#dom-audiodestinationnode-maxchannelcount">#dom-audiodestinationnode-maxchannelcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiodestinationnode-maxchannelcount">1.5.4. 
 Attributes</a>
@@ -21410,15 +21435,16 @@ Attributes</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioListener">
-   <b><a href="#AudioListener">#AudioListener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioListener" class="dfn-panel" data-for="AudioListener" id="infopanel-for-AudioListener" role="dialog">
+   <span id="infopaneltitle-for-AudioListener" style="display:none">Info about the '1.11. 
+The AudioListener Interface' definition.</span><b><a href="#AudioListener">#AudioListener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioListener">1.11. 
 The AudioListener Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiolistener">
-   <b><a href="#audiolistener">#audiolistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiolistener" class="dfn-panel" data-for="audiolistener" id="infopanel-for-audiolistener" role="dialog">
+   <span id="infopaneltitle-for-audiolistener" style="display:none">Info about the 'AudioListener' definition.</span><b><a href="#audiolistener">#audiolistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiolistener"> API Overview</a>
     <li><a href="#ref-for-audiolistener①">1.1. 
@@ -21443,8 +21469,8 @@ Background</a> <a href="#ref-for-audiolistener②⑤">(2)</a> <a href="#ref-for-
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-forwardx">
-   <b><a href="#dom-audiolistener-forwardx">#dom-audiolistener-forwardx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-forwardx" class="dfn-panel" data-for="dom-audiolistener-forwardx" id="infopanel-for-dom-audiolistener-forwardx" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-forwardx" style="display:none">Info about the 'forwardX' definition.</span><b><a href="#dom-audiolistener-forwardx">#dom-audiolistener-forwardx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-forwardx">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardx①">(2)</a>
@@ -21452,8 +21478,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardx①"
 Methods</a> <a href="#ref-for-dom-audiolistener-forwardx③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-forwardy">
-   <b><a href="#dom-audiolistener-forwardy">#dom-audiolistener-forwardy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-forwardy" class="dfn-panel" data-for="dom-audiolistener-forwardy" id="infopanel-for-dom-audiolistener-forwardy" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-forwardy" style="display:none">Info about the 'forwardY' definition.</span><b><a href="#dom-audiolistener-forwardy">#dom-audiolistener-forwardy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-forwardy">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardy①">(2)</a>
@@ -21461,8 +21487,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardy①"
 Methods</a> <a href="#ref-for-dom-audiolistener-forwardy③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-forwardz">
-   <b><a href="#dom-audiolistener-forwardz">#dom-audiolistener-forwardz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-forwardz" class="dfn-panel" data-for="dom-audiolistener-forwardz" id="infopanel-for-dom-audiolistener-forwardz" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-forwardz" style="display:none">Info about the 'forwardZ' definition.</span><b><a href="#dom-audiolistener-forwardz">#dom-audiolistener-forwardz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-forwardz">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardz①">(2)</a>
@@ -21470,8 +21496,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-forwardz①"
 Methods</a> <a href="#ref-for-dom-audiolistener-forwardz③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-positionx">
-   <b><a href="#dom-audiolistener-positionx">#dom-audiolistener-positionx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-positionx" class="dfn-panel" data-for="dom-audiolistener-positionx" id="infopanel-for-dom-audiolistener-positionx" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-positionx" style="display:none">Info about the 'positionX' definition.</span><b><a href="#dom-audiolistener-positionx">#dom-audiolistener-positionx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-positionx">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positionx①">(2)</a>
@@ -21479,8 +21505,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positionx①
 Methods</a> <a href="#ref-for-dom-audiolistener-positionx③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-positiony">
-   <b><a href="#dom-audiolistener-positiony">#dom-audiolistener-positiony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-positiony" class="dfn-panel" data-for="dom-audiolistener-positiony" id="infopanel-for-dom-audiolistener-positiony" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-positiony" style="display:none">Info about the 'positionY' definition.</span><b><a href="#dom-audiolistener-positiony">#dom-audiolistener-positiony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-positiony">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positiony①">(2)</a>
@@ -21488,8 +21514,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positiony①
 Methods</a> <a href="#ref-for-dom-audiolistener-positiony③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-positionz">
-   <b><a href="#dom-audiolistener-positionz">#dom-audiolistener-positionz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-positionz" class="dfn-panel" data-for="dom-audiolistener-positionz" id="infopanel-for-dom-audiolistener-positionz" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-positionz" style="display:none">Info about the 'positionZ' definition.</span><b><a href="#dom-audiolistener-positionz">#dom-audiolistener-positionz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-positionz">1.11. 
 The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positionz①">(2)</a>
@@ -21497,8 +21523,8 @@ The AudioListener Interface</a> <a href="#ref-for-dom-audiolistener-positionz①
 Methods</a> <a href="#ref-for-dom-audiolistener-positionz③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-upx">
-   <b><a href="#dom-audiolistener-upx">#dom-audiolistener-upx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-upx" class="dfn-panel" data-for="dom-audiolistener-upx" id="infopanel-for-dom-audiolistener-upx" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-upx" style="display:none">Info about the 'upX' definition.</span><b><a href="#dom-audiolistener-upx">#dom-audiolistener-upx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-upx">1.11. 
 The AudioListener Interface</a>
@@ -21506,8 +21532,8 @@ The AudioListener Interface</a>
 Methods</a> <a href="#ref-for-dom-audiolistener-upx②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-upy">
-   <b><a href="#dom-audiolistener-upy">#dom-audiolistener-upy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-upy" class="dfn-panel" data-for="dom-audiolistener-upy" id="infopanel-for-dom-audiolistener-upy" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-upy" style="display:none">Info about the 'upY' definition.</span><b><a href="#dom-audiolistener-upy">#dom-audiolistener-upy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-upy">1.11. 
 The AudioListener Interface</a>
@@ -21515,8 +21541,8 @@ The AudioListener Interface</a>
 Methods</a> <a href="#ref-for-dom-audiolistener-upy②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-upz">
-   <b><a href="#dom-audiolistener-upz">#dom-audiolistener-upz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-upz" class="dfn-panel" data-for="dom-audiolistener-upz" id="infopanel-for-dom-audiolistener-upz" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-upz" style="display:none">Info about the 'upZ' definition.</span><b><a href="#dom-audiolistener-upz">#dom-audiolistener-upz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-upz">1.11. 
 The AudioListener Interface</a>
@@ -21524,8 +21550,8 @@ The AudioListener Interface</a>
 Methods</a> <a href="#ref-for-dom-audiolistener-upz②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation">
-   <b><a href="#dom-audiolistener-setorientation">#dom-audiolistener-setorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation" class="dfn-panel" data-for="dom-audiolistener-setorientation" id="infopanel-for-dom-audiolistener-setorientation" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation" style="display:none">Info about the 'setOrientation(x, y, z, xUp, yUp, zUp)' definition.</span><b><a href="#dom-audiolistener-setorientation">#dom-audiolistener-setorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation">1.11. 
 The AudioListener Interface</a>
@@ -21533,8 +21559,8 @@ The AudioListener Interface</a>
 Methods</a> <a href="#ref-for-dom-audiolistener-setorientation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiolistener-forward">
-   <b><a href="#audiolistener-forward">#audiolistener-forward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiolistener-forward" class="dfn-panel" data-for="audiolistener-forward" id="infopanel-for-audiolistener-forward" role="dialog">
+   <span id="infopaneltitle-for-audiolistener-forward" style="display:none">Info about the 'forward' definition.</span><b><a href="#audiolistener-forward">#audiolistener-forward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiolistener-forward">1.11.2. 
 Methods</a> <a href="#ref-for-audiolistener-forward①">(2)</a>
@@ -21542,8 +21568,8 @@ Methods</a> <a href="#ref-for-audiolistener-forward①">(2)</a>
 Background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audiolistener-up">
-   <b><a href="#audiolistener-up">#audiolistener-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audiolistener-up" class="dfn-panel" data-for="audiolistener-up" id="infopanel-for-audiolistener-up" role="dialog">
+   <span id="infopaneltitle-for-audiolistener-up" style="display:none">Info about the 'up' definition.</span><b><a href="#audiolistener-up">#audiolistener-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audiolistener-up">1.11.2. 
 Methods</a> <a href="#ref-for-audiolistener-up①">(2)</a>
@@ -21551,50 +21577,50 @@ Methods</a> <a href="#ref-for-audiolistener-up①">(2)</a>
 Background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-x">
-   <b><a href="#dom-audiolistener-setorientation-x">#dom-audiolistener-setorientation-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-x" class="dfn-panel" data-for="dom-audiolistener-setorientation-x" id="infopanel-for-dom-audiolistener-setorientation-x" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-audiolistener-setorientation-x">#dom-audiolistener-setorientation-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-x">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-y">
-   <b><a href="#dom-audiolistener-setorientation-y">#dom-audiolistener-setorientation-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-y" class="dfn-panel" data-for="dom-audiolistener-setorientation-y" id="infopanel-for-dom-audiolistener-setorientation-y" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-audiolistener-setorientation-y">#dom-audiolistener-setorientation-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-y">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-z">
-   <b><a href="#dom-audiolistener-setorientation-z">#dom-audiolistener-setorientation-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-z" class="dfn-panel" data-for="dom-audiolistener-setorientation-z" id="infopanel-for-dom-audiolistener-setorientation-z" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-audiolistener-setorientation-z">#dom-audiolistener-setorientation-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-z">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-xup">
-   <b><a href="#dom-audiolistener-setorientation-xup">#dom-audiolistener-setorientation-xup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-xup" class="dfn-panel" data-for="dom-audiolistener-setorientation-xup" id="infopanel-for-dom-audiolistener-setorientation-xup" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-xup" style="display:none">Info about the 'xUp' definition.</span><b><a href="#dom-audiolistener-setorientation-xup">#dom-audiolistener-setorientation-xup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-xup">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-yup">
-   <b><a href="#dom-audiolistener-setorientation-yup">#dom-audiolistener-setorientation-yup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-yup" class="dfn-panel" data-for="dom-audiolistener-setorientation-yup" id="infopanel-for-dom-audiolistener-setorientation-yup" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-yup" style="display:none">Info about the 'yUp' definition.</span><b><a href="#dom-audiolistener-setorientation-yup">#dom-audiolistener-setorientation-yup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-yup">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setorientation-zup">
-   <b><a href="#dom-audiolistener-setorientation-zup">#dom-audiolistener-setorientation-zup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setorientation-zup" class="dfn-panel" data-for="dom-audiolistener-setorientation-zup" id="infopanel-for-dom-audiolistener-setorientation-zup" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setorientation-zup" style="display:none">Info about the 'zUp' definition.</span><b><a href="#dom-audiolistener-setorientation-zup">#dom-audiolistener-setorientation-zup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setorientation-zup">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setposition">
-   <b><a href="#dom-audiolistener-setposition">#dom-audiolistener-setposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setposition" class="dfn-panel" data-for="dom-audiolistener-setposition" id="infopanel-for-dom-audiolistener-setposition" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setposition" style="display:none">Info about the 'setPosition(x, y, z)' definition.</span><b><a href="#dom-audiolistener-setposition">#dom-audiolistener-setposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setposition">1.11. 
 The AudioListener Interface</a>
@@ -21602,36 +21628,37 @@ The AudioListener Interface</a>
 Methods</a> <a href="#ref-for-dom-audiolistener-setposition②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setposition-x">
-   <b><a href="#dom-audiolistener-setposition-x">#dom-audiolistener-setposition-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setposition-x" class="dfn-panel" data-for="dom-audiolistener-setposition-x" id="infopanel-for-dom-audiolistener-setposition-x" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setposition-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-audiolistener-setposition-x">#dom-audiolistener-setposition-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setposition-x">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setposition-y">
-   <b><a href="#dom-audiolistener-setposition-y">#dom-audiolistener-setposition-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setposition-y" class="dfn-panel" data-for="dom-audiolistener-setposition-y" id="infopanel-for-dom-audiolistener-setposition-y" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setposition-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-audiolistener-setposition-y">#dom-audiolistener-setposition-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setposition-y">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audiolistener-setposition-z">
-   <b><a href="#dom-audiolistener-setposition-z">#dom-audiolistener-setposition-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audiolistener-setposition-z" class="dfn-panel" data-for="dom-audiolistener-setposition-z" id="infopanel-for-dom-audiolistener-setposition-z" role="dialog">
+   <span id="infopaneltitle-for-dom-audiolistener-setposition-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-audiolistener-setposition-z">#dom-audiolistener-setposition-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audiolistener-setposition-z">1.11.2. 
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioProcessingEvent">
-   <b><a href="#AudioProcessingEvent">#AudioProcessingEvent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioProcessingEvent" class="dfn-panel" data-for="AudioProcessingEvent" id="infopanel-for-AudioProcessingEvent" role="dialog">
+   <span id="infopaneltitle-for-AudioProcessingEvent" style="display:none">Info about the '1.12. 
+The AudioProcessingEvent Interface - DEPRECATED' definition.</span><b><a href="#AudioProcessingEvent">#AudioProcessingEvent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioProcessingEvent">1.12. 
 The AudioProcessingEvent Interface - DEPRECATED</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioprocessingevent">
-   <b><a href="#audioprocessingevent">#audioprocessingevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioprocessingevent" class="dfn-panel" data-for="audioprocessingevent" id="infopanel-for-audioprocessingevent" role="dialog">
+   <span id="infopaneltitle-for-audioprocessingevent" style="display:none">Info about the 'AudioProcessingEvent' definition.</span><b><a href="#audioprocessingevent">#audioprocessingevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioprocessingevent"> API Overview</a>
     <li><a href="#ref-for-audioprocessingevent①">1.4.3. 
@@ -21644,8 +21671,8 @@ Attributes</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingevent-inputbuffer">
-   <b><a href="#dom-audioprocessingevent-inputbuffer">#dom-audioprocessingevent-inputbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingevent-inputbuffer" class="dfn-panel" data-for="dom-audioprocessingevent-inputbuffer" id="infopanel-for-dom-audioprocessingevent-inputbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingevent-inputbuffer" style="display:none">Info about the 'inputBuffer' definition.</span><b><a href="#dom-audioprocessingevent-inputbuffer">#dom-audioprocessingevent-inputbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingevent-inputbuffer">1.12. 
 The AudioProcessingEvent Interface - DEPRECATED</a>
@@ -21653,8 +21680,8 @@ The AudioProcessingEvent Interface - DEPRECATED</a>
 Dictionary AudioProcessingEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingevent-outputbuffer">
-   <b><a href="#dom-audioprocessingevent-outputbuffer">#dom-audioprocessingevent-outputbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingevent-outputbuffer" class="dfn-panel" data-for="dom-audioprocessingevent-outputbuffer" id="infopanel-for-dom-audioprocessingevent-outputbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingevent-outputbuffer" style="display:none">Info about the 'outputBuffer' definition.</span><b><a href="#dom-audioprocessingevent-outputbuffer">#dom-audioprocessingevent-outputbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingevent-outputbuffer">1.4.3. 
 Methods</a>
@@ -21664,8 +21691,8 @@ The AudioProcessingEvent Interface - DEPRECATED</a> <a href="#ref-for-dom-audiop
 Dictionary AudioProcessingEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingevent-playbacktime">
-   <b><a href="#dom-audioprocessingevent-playbacktime">#dom-audioprocessingevent-playbacktime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingevent-playbacktime" class="dfn-panel" data-for="dom-audioprocessingevent-playbacktime" id="infopanel-for-dom-audioprocessingevent-playbacktime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingevent-playbacktime" style="display:none">Info about the 'playbackTime' definition.</span><b><a href="#dom-audioprocessingevent-playbacktime">#dom-audioprocessingevent-playbacktime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingevent-playbacktime">1.12. 
 The AudioProcessingEvent Interface - DEPRECATED</a>
@@ -21673,15 +21700,16 @@ The AudioProcessingEvent Interface - DEPRECATED</a>
 Dictionary AudioProcessingEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioProcessingEventInit">
-   <b><a href="#AudioProcessingEventInit">#AudioProcessingEventInit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioProcessingEventInit" class="dfn-panel" data-for="AudioProcessingEventInit" id="infopanel-for-AudioProcessingEventInit" role="dialog">
+   <span id="infopaneltitle-for-AudioProcessingEventInit" style="display:none">Info about the '1.12.2. 
+AudioProcessingEventInit' definition.</span><b><a href="#AudioProcessingEventInit">#AudioProcessingEventInit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioProcessingEventInit">1.12.2. 
 AudioProcessingEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audioprocessingeventinit">
-   <b><a href="#dictdef-audioprocessingeventinit">#dictdef-audioprocessingeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audioprocessingeventinit" class="dfn-panel" data-for="dictdef-audioprocessingeventinit" id="infopanel-for-dictdef-audioprocessingeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audioprocessingeventinit" style="display:none">Info about the 'AudioProcessingEventInit' definition.</span><b><a href="#dictdef-audioprocessingeventinit">#dictdef-audioprocessingeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audioprocessingeventinit">1.12. 
 The AudioProcessingEvent Interface - DEPRECATED</a>
@@ -21691,36 +21719,37 @@ AudioProcessingEventInit</a>
 Dictionary AudioProcessingEventInit Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingeventinit-inputbuffer">
-   <b><a href="#dom-audioprocessingeventinit-inputbuffer">#dom-audioprocessingeventinit-inputbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingeventinit-inputbuffer" class="dfn-panel" data-for="dom-audioprocessingeventinit-inputbuffer" id="infopanel-for-dom-audioprocessingeventinit-inputbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingeventinit-inputbuffer" style="display:none">Info about the 'inputBuffer' definition.</span><b><a href="#dom-audioprocessingeventinit-inputbuffer">#dom-audioprocessingeventinit-inputbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingeventinit-inputbuffer">1.12.2. 
 AudioProcessingEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingeventinit-outputbuffer">
-   <b><a href="#dom-audioprocessingeventinit-outputbuffer">#dom-audioprocessingeventinit-outputbuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingeventinit-outputbuffer" class="dfn-panel" data-for="dom-audioprocessingeventinit-outputbuffer" id="infopanel-for-dom-audioprocessingeventinit-outputbuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingeventinit-outputbuffer" style="display:none">Info about the 'outputBuffer' definition.</span><b><a href="#dom-audioprocessingeventinit-outputbuffer">#dom-audioprocessingeventinit-outputbuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingeventinit-outputbuffer">1.12.2. 
 AudioProcessingEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioprocessingeventinit-playbacktime">
-   <b><a href="#dom-audioprocessingeventinit-playbacktime">#dom-audioprocessingeventinit-playbacktime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioprocessingeventinit-playbacktime" class="dfn-panel" data-for="dom-audioprocessingeventinit-playbacktime" id="infopanel-for-dom-audioprocessingeventinit-playbacktime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioprocessingeventinit-playbacktime" style="display:none">Info about the 'playbackTime' definition.</span><b><a href="#dom-audioprocessingeventinit-playbacktime">#dom-audioprocessingeventinit-playbacktime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioprocessingeventinit-playbacktime">1.12.2. 
 AudioProcessingEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="BiquadFilterNode">
-   <b><a href="#BiquadFilterNode">#BiquadFilterNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-BiquadFilterNode" class="dfn-panel" data-for="BiquadFilterNode" id="infopanel-for-BiquadFilterNode" role="dialog">
+   <span id="infopaneltitle-for-BiquadFilterNode" style="display:none">Info about the '1.13. 
+The BiquadFilterNode Interface' definition.</span><b><a href="#BiquadFilterNode">#BiquadFilterNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BiquadFilterNode">1.13. 
 The BiquadFilterNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computedfrequency">
-   <b><a href="#computedfrequency">#computedfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computedfrequency" class="dfn-panel" data-for="computedfrequency" id="infopanel-for-computedfrequency" role="dialog">
+   <span id="infopaneltitle-for-computedfrequency" style="display:none">Info about the 'computedFrequency' definition.</span><b><a href="#computedfrequency">#computedfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computedfrequency">1.13.2. 
 Attributes</a> <a href="#ref-for-computedfrequency①">(2)</a>
@@ -21728,8 +21757,8 @@ Attributes</a> <a href="#ref-for-computedfrequency①">(2)</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-biquadfiltertype">
-   <b><a href="#enumdef-biquadfiltertype">#enumdef-biquadfiltertype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-biquadfiltertype" class="dfn-panel" data-for="enumdef-biquadfiltertype" id="infopanel-for-enumdef-biquadfiltertype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-biquadfiltertype" style="display:none">Info about the 'BiquadFilterType' definition.</span><b><a href="#enumdef-biquadfiltertype">#enumdef-biquadfiltertype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-biquadfiltertype">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21741,8 +21770,8 @@ BiquadFilterOptions</a>
 Dictionary BiquadFilterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-lowpass">
-   <b><a href="#dom-biquadfiltertype-lowpass">#dom-biquadfiltertype-lowpass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-lowpass" class="dfn-panel" data-for="dom-biquadfiltertype-lowpass" id="infopanel-for-dom-biquadfiltertype-lowpass" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-lowpass" style="display:none">Info about the 'lowpass' definition.</span><b><a href="#dom-biquadfiltertype-lowpass">#dom-biquadfiltertype-lowpass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-lowpass">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21752,8 +21781,8 @@ Attributes</a> <a href="#ref-for-dom-biquadfiltertype-lowpass②">(2)</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-highpass">
-   <b><a href="#dom-biquadfiltertype-highpass">#dom-biquadfiltertype-highpass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-highpass" class="dfn-panel" data-for="dom-biquadfiltertype-highpass" id="infopanel-for-dom-biquadfiltertype-highpass" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-highpass" style="display:none">Info about the 'highpass' definition.</span><b><a href="#dom-biquadfiltertype-highpass">#dom-biquadfiltertype-highpass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-highpass">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21763,8 +21792,8 @@ Attributes</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-bandpass">
-   <b><a href="#dom-biquadfiltertype-bandpass">#dom-biquadfiltertype-bandpass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-bandpass" class="dfn-panel" data-for="dom-biquadfiltertype-bandpass" id="infopanel-for-dom-biquadfiltertype-bandpass" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-bandpass" style="display:none">Info about the 'bandpass' definition.</span><b><a href="#dom-biquadfiltertype-bandpass">#dom-biquadfiltertype-bandpass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-bandpass">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21774,8 +21803,8 @@ Attributes</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-lowshelf">
-   <b><a href="#dom-biquadfiltertype-lowshelf">#dom-biquadfiltertype-lowshelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-lowshelf" class="dfn-panel" data-for="dom-biquadfiltertype-lowshelf" id="infopanel-for-dom-biquadfiltertype-lowshelf" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-lowshelf" style="display:none">Info about the 'lowshelf' definition.</span><b><a href="#dom-biquadfiltertype-lowshelf">#dom-biquadfiltertype-lowshelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-lowshelf">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21785,8 +21814,8 @@ Attributes</a> <a href="#ref-for-dom-biquadfiltertype-lowshelf②">(2)</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-highshelf">
-   <b><a href="#dom-biquadfiltertype-highshelf">#dom-biquadfiltertype-highshelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-highshelf" class="dfn-panel" data-for="dom-biquadfiltertype-highshelf" id="infopanel-for-dom-biquadfiltertype-highshelf" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-highshelf" style="display:none">Info about the 'highshelf' definition.</span><b><a href="#dom-biquadfiltertype-highshelf">#dom-biquadfiltertype-highshelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-highshelf">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21796,8 +21825,8 @@ Attributes</a> <a href="#ref-for-dom-biquadfiltertype-highshelf②">(2)</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-peaking">
-   <b><a href="#dom-biquadfiltertype-peaking">#dom-biquadfiltertype-peaking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-peaking" class="dfn-panel" data-for="dom-biquadfiltertype-peaking" id="infopanel-for-dom-biquadfiltertype-peaking" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-peaking" style="display:none">Info about the 'peaking' definition.</span><b><a href="#dom-biquadfiltertype-peaking">#dom-biquadfiltertype-peaking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-peaking">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21807,8 +21836,8 @@ Attributes</a> <a href="#ref-for-dom-biquadfiltertype-peaking②">(2)</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-notch">
-   <b><a href="#dom-biquadfiltertype-notch">#dom-biquadfiltertype-notch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-notch" class="dfn-panel" data-for="dom-biquadfiltertype-notch" id="infopanel-for-dom-biquadfiltertype-notch" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-notch" style="display:none">Info about the 'notch' definition.</span><b><a href="#dom-biquadfiltertype-notch">#dom-biquadfiltertype-notch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-notch">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21818,8 +21847,8 @@ Attributes</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfiltertype-allpass">
-   <b><a href="#dom-biquadfiltertype-allpass">#dom-biquadfiltertype-allpass</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfiltertype-allpass" class="dfn-panel" data-for="dom-biquadfiltertype-allpass" id="infopanel-for-dom-biquadfiltertype-allpass" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfiltertype-allpass" style="display:none">Info about the 'allpass' definition.</span><b><a href="#dom-biquadfiltertype-allpass">#dom-biquadfiltertype-allpass</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfiltertype-allpass">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21829,8 +21858,8 @@ Attributes</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="biquadfilternode">
-   <b><a href="#biquadfilternode">#biquadfilternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-biquadfilternode" class="dfn-panel" data-for="biquadfilternode" id="infopanel-for-biquadfilternode" role="dialog">
+   <span id="infopaneltitle-for-biquadfilternode" style="display:none">Info about the 'BiquadFilterNode' definition.</span><b><a href="#biquadfilternode">#biquadfilternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-biquadfilternode"> API Overview</a>
     <li><a href="#ref-for-biquadfilternode①">1.1. 
@@ -21853,15 +21882,15 @@ The IIRFilterNode Interface</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-biquadfilternode">
-   <b><a href="#dom-biquadfilternode-biquadfilternode">#dom-biquadfilternode-biquadfilternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-biquadfilternode" class="dfn-panel" data-for="dom-biquadfilternode-biquadfilternode" id="infopanel-for-dom-biquadfilternode-biquadfilternode" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-biquadfilternode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-biquadfilternode-biquadfilternode">#dom-biquadfilternode-biquadfilternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-biquadfilternode">1.13.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-q">
-   <b><a href="#dom-biquadfilternode-q">#dom-biquadfilternode-q</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-q" class="dfn-panel" data-for="dom-biquadfilternode-q" id="infopanel-for-dom-biquadfilternode-q" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-q" style="display:none">Info about the 'Q' definition.</span><b><a href="#dom-biquadfilternode-q">#dom-biquadfilternode-q</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-q">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21873,8 +21902,8 @@ Dictionary BiquadFilterOptions Members</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-detune">
-   <b><a href="#dom-biquadfilternode-detune">#dom-biquadfilternode-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-detune" class="dfn-panel" data-for="dom-biquadfilternode-detune" id="infopanel-for-dom-biquadfilternode-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-biquadfilternode-detune">#dom-biquadfilternode-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-detune">1.13. 
 The BiquadFilterNode Interface</a> <a href="#ref-for-dom-biquadfilternode-detune①">(2)</a>
@@ -21884,8 +21913,8 @@ Attributes</a>
 Dictionary BiquadFilterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-frequency">
-   <b><a href="#dom-biquadfilternode-frequency">#dom-biquadfilternode-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-frequency" class="dfn-panel" data-for="dom-biquadfilternode-frequency" id="infopanel-for-dom-biquadfilternode-frequency" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-frequency" style="display:none">Info about the 'frequency' definition.</span><b><a href="#dom-biquadfilternode-frequency">#dom-biquadfilternode-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-frequency">1.13. 
 The BiquadFilterNode Interface</a> <a href="#ref-for-dom-biquadfilternode-frequency①">(2)</a> <a href="#ref-for-dom-biquadfilternode-frequency②">(3)</a>
@@ -21895,8 +21924,8 @@ Attributes</a>
 Dictionary BiquadFilterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-gain">
-   <b><a href="#dom-biquadfilternode-gain">#dom-biquadfilternode-gain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-gain" class="dfn-panel" data-for="dom-biquadfilternode-gain" id="infopanel-for-dom-biquadfilternode-gain" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-gain" style="display:none">Info about the 'gain' definition.</span><b><a href="#dom-biquadfilternode-gain">#dom-biquadfilternode-gain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-gain">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21906,8 +21935,8 @@ Dictionary BiquadFilterOptions Members</a>
 Filters Characteristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-type">
-   <b><a href="#dom-biquadfilternode-type">#dom-biquadfilternode-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-type" class="dfn-panel" data-for="dom-biquadfilternode-type" id="infopanel-for-dom-biquadfilternode-type" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-biquadfilternode-type">#dom-biquadfilternode-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-type">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21915,8 +21944,8 @@ The BiquadFilterNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilternode-getfrequencyresponse">
-   <b><a href="#dom-biquadfilternode-getfrequencyresponse">#dom-biquadfilternode-getfrequencyresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilternode-getfrequencyresponse" class="dfn-panel" data-for="dom-biquadfilternode-getfrequencyresponse" id="infopanel-for-dom-biquadfilternode-getfrequencyresponse" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilternode-getfrequencyresponse" style="display:none">Info about the 'getFrequencyResponse(frequencyHz, magResponse, phaseResponse)' definition.</span><b><a href="#dom-biquadfilternode-getfrequencyresponse">#dom-biquadfilternode-getfrequencyresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilternode-getfrequencyresponse">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21924,15 +21953,16 @@ The BiquadFilterNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="BiquadFilterOptions">
-   <b><a href="#BiquadFilterOptions">#BiquadFilterOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-BiquadFilterOptions" class="dfn-panel" data-for="BiquadFilterOptions" id="infopanel-for-BiquadFilterOptions" role="dialog">
+   <span id="infopaneltitle-for-BiquadFilterOptions" style="display:none">Info about the '1.13.4. 
+BiquadFilterOptions' definition.</span><b><a href="#BiquadFilterOptions">#BiquadFilterOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BiquadFilterOptions">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-biquadfilteroptions">
-   <b><a href="#dictdef-biquadfilteroptions">#dictdef-biquadfilteroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-biquadfilteroptions" class="dfn-panel" data-for="dictdef-biquadfilteroptions" id="infopanel-for-dictdef-biquadfilteroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-biquadfilteroptions" style="display:none">Info about the 'BiquadFilterOptions' definition.</span><b><a href="#dictdef-biquadfilteroptions">#dictdef-biquadfilteroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-biquadfilteroptions">1.13. 
 The BiquadFilterNode Interface</a>
@@ -21944,50 +21974,51 @@ BiquadFilterOptions</a>
 Dictionary BiquadFilterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilteroptions-q">
-   <b><a href="#dom-biquadfilteroptions-q">#dom-biquadfilteroptions-q</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilteroptions-q" class="dfn-panel" data-for="dom-biquadfilteroptions-q" id="infopanel-for-dom-biquadfilteroptions-q" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilteroptions-q" style="display:none">Info about the 'Q' definition.</span><b><a href="#dom-biquadfilteroptions-q">#dom-biquadfilteroptions-q</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilteroptions-q">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilteroptions-detune">
-   <b><a href="#dom-biquadfilteroptions-detune">#dom-biquadfilteroptions-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilteroptions-detune" class="dfn-panel" data-for="dom-biquadfilteroptions-detune" id="infopanel-for-dom-biquadfilteroptions-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilteroptions-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-biquadfilteroptions-detune">#dom-biquadfilteroptions-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilteroptions-detune">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilteroptions-frequency">
-   <b><a href="#dom-biquadfilteroptions-frequency">#dom-biquadfilteroptions-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilteroptions-frequency" class="dfn-panel" data-for="dom-biquadfilteroptions-frequency" id="infopanel-for-dom-biquadfilteroptions-frequency" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilteroptions-frequency" style="display:none">Info about the 'frequency' definition.</span><b><a href="#dom-biquadfilteroptions-frequency">#dom-biquadfilteroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilteroptions-frequency">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilteroptions-gain">
-   <b><a href="#dom-biquadfilteroptions-gain">#dom-biquadfilteroptions-gain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilteroptions-gain" class="dfn-panel" data-for="dom-biquadfilteroptions-gain" id="infopanel-for-dom-biquadfilteroptions-gain" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilteroptions-gain" style="display:none">Info about the 'gain' definition.</span><b><a href="#dom-biquadfilteroptions-gain">#dom-biquadfilteroptions-gain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilteroptions-gain">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-biquadfilteroptions-type">
-   <b><a href="#dom-biquadfilteroptions-type">#dom-biquadfilteroptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-biquadfilteroptions-type" class="dfn-panel" data-for="dom-biquadfilteroptions-type" id="infopanel-for-dom-biquadfilteroptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-biquadfilteroptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-biquadfilteroptions-type">#dom-biquadfilteroptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-biquadfilteroptions-type">1.13.4. 
 BiquadFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ChannelMergerNode">
-   <b><a href="#ChannelMergerNode">#ChannelMergerNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ChannelMergerNode" class="dfn-panel" data-for="ChannelMergerNode" id="infopanel-for-ChannelMergerNode" role="dialog">
+   <span id="infopaneltitle-for-ChannelMergerNode" style="display:none">Info about the '1.14. 
+The ChannelMergerNode Interface' definition.</span><b><a href="#ChannelMergerNode">#ChannelMergerNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ChannelMergerNode">1.14. 
 The ChannelMergerNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="channelmergernode">
-   <b><a href="#channelmergernode">#channelmergernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-channelmergernode" class="dfn-panel" data-for="channelmergernode" id="infopanel-for-channelmergernode" role="dialog">
+   <span id="infopaneltitle-for-channelmergernode" style="display:none">Info about the 'ChannelMergerNode' definition.</span><b><a href="#channelmergernode">#channelmergernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-channelmergernode"> API Overview</a>
     <li><a href="#ref-for-channelmergernode①">1.1. 
@@ -22010,22 +22041,23 @@ Channel Configurations for Input, Impulse Response and Output</a>
 Channel Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelmergernode-channelmergernode">
-   <b><a href="#dom-channelmergernode-channelmergernode">#dom-channelmergernode-channelmergernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelmergernode-channelmergernode" class="dfn-panel" data-for="dom-channelmergernode-channelmergernode" id="infopanel-for-dom-channelmergernode-channelmergernode" role="dialog">
+   <span id="infopaneltitle-for-dom-channelmergernode-channelmergernode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-channelmergernode-channelmergernode">#dom-channelmergernode-channelmergernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelmergernode-channelmergernode">1.14.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ChannelMergerOptions">
-   <b><a href="#ChannelMergerOptions">#ChannelMergerOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ChannelMergerOptions" class="dfn-panel" data-for="ChannelMergerOptions" id="infopanel-for-ChannelMergerOptions" role="dialog">
+   <span id="infopaneltitle-for-ChannelMergerOptions" style="display:none">Info about the '1.14.2. 
+ChannelMergerOptions' definition.</span><b><a href="#ChannelMergerOptions">#ChannelMergerOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ChannelMergerOptions">1.14.2. 
 ChannelMergerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-channelmergeroptions">
-   <b><a href="#dictdef-channelmergeroptions">#dictdef-channelmergeroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-channelmergeroptions" class="dfn-panel" data-for="dictdef-channelmergeroptions" id="infopanel-for-dictdef-channelmergeroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-channelmergeroptions" style="display:none">Info about the 'ChannelMergerOptions' definition.</span><b><a href="#dictdef-channelmergeroptions">#dictdef-channelmergeroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-channelmergeroptions">1.14. 
 The ChannelMergerNode Interface</a>
@@ -22037,22 +22069,23 @@ ChannelMergerOptions</a>
 Dictionary ChannelMergerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelmergeroptions-numberofinputs">
-   <b><a href="#dom-channelmergeroptions-numberofinputs">#dom-channelmergeroptions-numberofinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelmergeroptions-numberofinputs" class="dfn-panel" data-for="dom-channelmergeroptions-numberofinputs" id="infopanel-for-dom-channelmergeroptions-numberofinputs" role="dialog">
+   <span id="infopaneltitle-for-dom-channelmergeroptions-numberofinputs" style="display:none">Info about the 'numberOfInputs' definition.</span><b><a href="#dom-channelmergeroptions-numberofinputs">#dom-channelmergeroptions-numberofinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelmergeroptions-numberofinputs">1.14.2. 
 ChannelMergerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ChannelSplitterNode">
-   <b><a href="#ChannelSplitterNode">#ChannelSplitterNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ChannelSplitterNode" class="dfn-panel" data-for="ChannelSplitterNode" id="infopanel-for-ChannelSplitterNode" role="dialog">
+   <span id="infopaneltitle-for-ChannelSplitterNode" style="display:none">Info about the '1.15. 
+The ChannelSplitterNode Interface' definition.</span><b><a href="#ChannelSplitterNode">#ChannelSplitterNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ChannelSplitterNode">1.15. 
 The ChannelSplitterNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="channelsplitternode">
-   <b><a href="#channelsplitternode">#channelsplitternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-channelsplitternode" class="dfn-panel" data-for="channelsplitternode" id="infopanel-for-channelsplitternode" role="dialog">
+   <span id="infopaneltitle-for-channelsplitternode" style="display:none">Info about the 'ChannelSplitterNode' definition.</span><b><a href="#channelsplitternode">#channelsplitternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-channelsplitternode"> API Overview</a>
     <li><a href="#ref-for-channelsplitternode①">1.1. 
@@ -22075,22 +22108,23 @@ Channel Configurations for Input, Impulse Response and Output</a>
 Channel Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelsplitternode-channelsplitternode">
-   <b><a href="#dom-channelsplitternode-channelsplitternode">#dom-channelsplitternode-channelsplitternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelsplitternode-channelsplitternode" class="dfn-panel" data-for="dom-channelsplitternode-channelsplitternode" id="infopanel-for-dom-channelsplitternode-channelsplitternode" role="dialog">
+   <span id="infopaneltitle-for-dom-channelsplitternode-channelsplitternode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-channelsplitternode-channelsplitternode">#dom-channelsplitternode-channelsplitternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelsplitternode-channelsplitternode">1.15.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ChannelSplitterOptions">
-   <b><a href="#ChannelSplitterOptions">#ChannelSplitterOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ChannelSplitterOptions" class="dfn-panel" data-for="ChannelSplitterOptions" id="infopanel-for-ChannelSplitterOptions" role="dialog">
+   <span id="infopaneltitle-for-ChannelSplitterOptions" style="display:none">Info about the '1.15.2. 
+ChannelSplitterOptions' definition.</span><b><a href="#ChannelSplitterOptions">#ChannelSplitterOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ChannelSplitterOptions">1.15.2. 
 ChannelSplitterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-channelsplitteroptions">
-   <b><a href="#dictdef-channelsplitteroptions">#dictdef-channelsplitteroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-channelsplitteroptions" class="dfn-panel" data-for="dictdef-channelsplitteroptions" id="infopanel-for-dictdef-channelsplitteroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-channelsplitteroptions" style="display:none">Info about the 'ChannelSplitterOptions' definition.</span><b><a href="#dictdef-channelsplitteroptions">#dictdef-channelsplitteroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-channelsplitteroptions">1.15. 
 The ChannelSplitterNode Interface</a>
@@ -22102,22 +22136,23 @@ ChannelSplitterOptions</a>
 Dictionary ChannelSplitterOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-channelsplitteroptions-numberofoutputs">
-   <b><a href="#dom-channelsplitteroptions-numberofoutputs">#dom-channelsplitteroptions-numberofoutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-channelsplitteroptions-numberofoutputs" class="dfn-panel" data-for="dom-channelsplitteroptions-numberofoutputs" id="infopanel-for-dom-channelsplitteroptions-numberofoutputs" role="dialog">
+   <span id="infopaneltitle-for-dom-channelsplitteroptions-numberofoutputs" style="display:none">Info about the 'numberOfOutputs' definition.</span><b><a href="#dom-channelsplitteroptions-numberofoutputs">#dom-channelsplitteroptions-numberofoutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-channelsplitteroptions-numberofoutputs">1.15.2. 
 ChannelSplitterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ConstantSourceNode">
-   <b><a href="#ConstantSourceNode">#ConstantSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ConstantSourceNode" class="dfn-panel" data-for="ConstantSourceNode" id="infopanel-for-ConstantSourceNode" role="dialog">
+   <span id="infopaneltitle-for-ConstantSourceNode" style="display:none">Info about the '1.16. 
+The ConstantSourceNode Interface' definition.</span><b><a href="#ConstantSourceNode">#ConstantSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ConstantSourceNode">1.16. 
 The ConstantSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constantsourcenode">
-   <b><a href="#constantsourcenode">#constantsourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constantsourcenode" class="dfn-panel" data-for="constantsourcenode" id="infopanel-for-constantsourcenode" role="dialog">
+   <span id="infopaneltitle-for-constantsourcenode" style="display:none">Info about the 'ConstantSourceNode' definition.</span><b><a href="#constantsourcenode">#constantsourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constantsourcenode"> API Overview</a>
     <li><a href="#ref-for-constantsourcenode①">1.1. 
@@ -22134,15 +22169,15 @@ Constructors</a> <a href="#ref-for-constantsourcenode⑦">(2)</a>
 ConstantSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-constantsourcenode-constantsourcenode">
-   <b><a href="#dom-constantsourcenode-constantsourcenode">#dom-constantsourcenode-constantsourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-constantsourcenode-constantsourcenode" class="dfn-panel" data-for="dom-constantsourcenode-constantsourcenode" id="infopanel-for-dom-constantsourcenode-constantsourcenode" role="dialog">
+   <span id="infopaneltitle-for-dom-constantsourcenode-constantsourcenode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-constantsourcenode-constantsourcenode">#dom-constantsourcenode-constantsourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-constantsourcenode-constantsourcenode">1.16.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-constantsourcenode-offset">
-   <b><a href="#dom-constantsourcenode-offset">#dom-constantsourcenode-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-constantsourcenode-offset" class="dfn-panel" data-for="dom-constantsourcenode-offset" id="infopanel-for-dom-constantsourcenode-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-constantsourcenode-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-constantsourcenode-offset">#dom-constantsourcenode-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-constantsourcenode-offset">1.16. 
 The ConstantSourceNode Interface</a> <a href="#ref-for-dom-constantsourcenode-offset①">(2)</a>
@@ -22150,15 +22185,16 @@ The ConstantSourceNode Interface</a> <a href="#ref-for-dom-constantsourcenode-of
 Dictionary ConstantSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ConstantSourceOptions">
-   <b><a href="#ConstantSourceOptions">#ConstantSourceOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ConstantSourceOptions" class="dfn-panel" data-for="ConstantSourceOptions" id="infopanel-for-ConstantSourceOptions" role="dialog">
+   <span id="infopaneltitle-for-ConstantSourceOptions" style="display:none">Info about the '1.16.3. 
+ConstantSourceOptions' definition.</span><b><a href="#ConstantSourceOptions">#ConstantSourceOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ConstantSourceOptions">1.16.3. 
 ConstantSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-constantsourceoptions">
-   <b><a href="#dictdef-constantsourceoptions">#dictdef-constantsourceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-constantsourceoptions" class="dfn-panel" data-for="dictdef-constantsourceoptions" id="infopanel-for-dictdef-constantsourceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-constantsourceoptions" style="display:none">Info about the 'ConstantSourceOptions' definition.</span><b><a href="#dictdef-constantsourceoptions">#dictdef-constantsourceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-constantsourceoptions">1.16. 
 The ConstantSourceNode Interface</a>
@@ -22170,22 +22206,23 @@ ConstantSourceOptions</a>
 Dictionary ConstantSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-constantsourceoptions-offset">
-   <b><a href="#dom-constantsourceoptions-offset">#dom-constantsourceoptions-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-constantsourceoptions-offset" class="dfn-panel" data-for="dom-constantsourceoptions-offset" id="infopanel-for-dom-constantsourceoptions-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-constantsourceoptions-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-constantsourceoptions-offset">#dom-constantsourceoptions-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-constantsourceoptions-offset">1.16.3. 
 ConstantSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ConvolverNode">
-   <b><a href="#ConvolverNode">#ConvolverNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ConvolverNode" class="dfn-panel" data-for="ConvolverNode" id="infopanel-for-ConvolverNode" role="dialog">
+   <span id="infopaneltitle-for-ConvolverNode" style="display:none">Info about the '1.17. 
+The ConvolverNode Interface' definition.</span><b><a href="#ConvolverNode">#ConvolverNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ConvolverNode">1.17. 
 The ConvolverNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convolvernode">
-   <b><a href="#convolvernode">#convolvernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convolvernode" class="dfn-panel" data-for="convolvernode" id="infopanel-for-convolvernode" role="dialog">
+   <span id="infopaneltitle-for-convolvernode" style="display:none">Info about the 'ConvolverNode' definition.</span><b><a href="#convolvernode">#convolvernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convolvernode"> API Overview</a>
     <li><a href="#ref-for-convolvernode①">1.1. 
@@ -22214,15 +22251,15 @@ Implication of tail-time on input and output channel count</a> <a href="#ref-for
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-convolvernode-convolvernode">
-   <b><a href="#dom-convolvernode-convolvernode">#dom-convolvernode-convolvernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-convolvernode-convolvernode" class="dfn-panel" data-for="dom-convolvernode-convolvernode" id="infopanel-for-dom-convolvernode-convolvernode" role="dialog">
+   <span id="infopaneltitle-for-dom-convolvernode-convolvernode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-convolvernode-convolvernode">#dom-convolvernode-convolvernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-convolvernode-convolvernode">1.17.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-convolvernode-buffer">
-   <b><a href="#dom-convolvernode-buffer">#dom-convolvernode-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-convolvernode-buffer" class="dfn-panel" data-for="dom-convolvernode-buffer" id="infopanel-for-dom-convolvernode-buffer" role="dialog">
+   <span id="infopaneltitle-for-dom-convolvernode-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#dom-convolvernode-buffer">#dom-convolvernode-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-convolvernode-buffer">1.4.3. 
 Methods</a>
@@ -22236,8 +22273,8 @@ Attributes</a> <a href="#ref-for-dom-convolvernode-buffer⑤">(2)</a> <a href="#
 Channel Configurations for Input, Impulse Response and Output</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-convolvernode-normalize">
-   <b><a href="#dom-convolvernode-normalize">#dom-convolvernode-normalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-convolvernode-normalize" class="dfn-panel" data-for="dom-convolvernode-normalize" id="infopanel-for-dom-convolvernode-normalize" role="dialog">
+   <span id="infopaneltitle-for-dom-convolvernode-normalize" style="display:none">Info about the 'normalize' definition.</span><b><a href="#dom-convolvernode-normalize">#dom-convolvernode-normalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-convolvernode-normalize">1.17. 
 The ConvolverNode Interface</a>
@@ -22249,15 +22286,16 @@ Attributes</a> <a href="#ref-for-dom-convolvernode-normalize④">(2)</a> <a href
 Dictionary ConvolverOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ConvolverOptions">
-   <b><a href="#ConvolverOptions">#ConvolverOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ConvolverOptions" class="dfn-panel" data-for="ConvolverOptions" id="infopanel-for-ConvolverOptions" role="dialog">
+   <span id="infopaneltitle-for-ConvolverOptions" style="display:none">Info about the '1.17.3. 
+ConvolverOptions' definition.</span><b><a href="#ConvolverOptions">#ConvolverOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ConvolverOptions">1.17.3. 
 ConvolverOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-convolveroptions">
-   <b><a href="#dictdef-convolveroptions">#dictdef-convolveroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-convolveroptions" class="dfn-panel" data-for="dictdef-convolveroptions" id="infopanel-for-dictdef-convolveroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-convolveroptions" style="display:none">Info about the 'ConvolverOptions' definition.</span><b><a href="#dictdef-convolveroptions">#dictdef-convolveroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-convolveroptions">1.17. 
 The ConvolverNode Interface</a>
@@ -22269,15 +22307,15 @@ ConvolverOptions</a>
 Dictionary ConvolverOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-convolveroptions-buffer">
-   <b><a href="#dom-convolveroptions-buffer">#dom-convolveroptions-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-convolveroptions-buffer" class="dfn-panel" data-for="dom-convolveroptions-buffer" id="infopanel-for-dom-convolveroptions-buffer" role="dialog">
+   <span id="infopaneltitle-for-dom-convolveroptions-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#dom-convolveroptions-buffer">#dom-convolveroptions-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-convolveroptions-buffer">1.17.3. 
 ConvolverOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-convolveroptions-disablenormalization">
-   <b><a href="#dom-convolveroptions-disablenormalization">#dom-convolveroptions-disablenormalization</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-convolveroptions-disablenormalization" class="dfn-panel" data-for="dom-convolveroptions-disablenormalization" id="infopanel-for-dom-convolveroptions-disablenormalization" role="dialog">
+   <span id="infopaneltitle-for-dom-convolveroptions-disablenormalization" style="display:none">Info about the 'disableNormalization' definition.</span><b><a href="#dom-convolveroptions-disablenormalization">#dom-convolveroptions-disablenormalization</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-convolveroptions-disablenormalization">1.17.1. 
 Constructors</a>
@@ -22287,15 +22325,16 @@ ConvolverOptions</a>
 Dictionary ConvolverOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DelayNode">
-   <b><a href="#DelayNode">#DelayNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DelayNode" class="dfn-panel" data-for="DelayNode" id="infopanel-for-DelayNode" role="dialog">
+   <span id="infopaneltitle-for-DelayNode" style="display:none">Info about the '1.18. 
+The DelayNode Interface' definition.</span><b><a href="#DelayNode">#DelayNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DelayNode">1.18. 
 The DelayNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delaynode">
-   <b><a href="#delaynode">#delaynode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delaynode" class="dfn-panel" data-for="delaynode" id="infopanel-for-delaynode" role="dialog">
+   <span id="infopaneltitle-for-delaynode" style="display:none">Info about the 'DelayNode' definition.</span><b><a href="#delaynode">#delaynode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delaynode"> API Overview</a>
     <li><a href="#ref-for-delaynode①">1.1. 
@@ -22320,8 +22359,8 @@ Implication of tail-time on input and output channel count</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-delaynode-delaynode">
-   <b><a href="#dom-delaynode-delaynode">#dom-delaynode-delaynode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-delaynode-delaynode" class="dfn-panel" data-for="dom-delaynode-delaynode" id="infopanel-for-dom-delaynode-delaynode" role="dialog">
+   <span id="infopaneltitle-for-dom-delaynode-delaynode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-delaynode-delaynode">#dom-delaynode-delaynode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-delaynode-delaynode">1.18.1. 
 Constructors</a>
@@ -22329,8 +22368,8 @@ Constructors</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-delaynode-delaytime">
-   <b><a href="#dom-delaynode-delaytime">#dom-delaynode-delaytime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-delaynode-delaytime" class="dfn-panel" data-for="dom-delaynode-delaytime" id="infopanel-for-dom-delaynode-delaytime" role="dialog">
+   <span id="infopaneltitle-for-dom-delaynode-delaytime" style="display:none">Info about the 'delayTime' definition.</span><b><a href="#dom-delaynode-delaytime">#dom-delaynode-delaytime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-delaynode-delaytime">1.18. 
 The DelayNode Interface</a>
@@ -22338,15 +22377,16 @@ The DelayNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DelayOptions">
-   <b><a href="#DelayOptions">#DelayOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DelayOptions" class="dfn-panel" data-for="DelayOptions" id="infopanel-for-DelayOptions" role="dialog">
+   <span id="infopaneltitle-for-DelayOptions" style="display:none">Info about the '1.18.3. 
+DelayOptions' definition.</span><b><a href="#DelayOptions">#DelayOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DelayOptions">1.18.3. 
 DelayOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-delayoptions">
-   <b><a href="#dictdef-delayoptions">#dictdef-delayoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-delayoptions" class="dfn-panel" data-for="dictdef-delayoptions" id="infopanel-for-dictdef-delayoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-delayoptions" style="display:none">Info about the 'DelayOptions' definition.</span><b><a href="#dictdef-delayoptions">#dictdef-delayoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-delayoptions">1.18. 
 The DelayNode Interface</a>
@@ -22360,15 +22400,15 @@ DelayOptions</a>
 Dictionary DelayOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-delayoptions-delaytime">
-   <b><a href="#dom-delayoptions-delaytime">#dom-delayoptions-delaytime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-delayoptions-delaytime" class="dfn-panel" data-for="dom-delayoptions-delaytime" id="infopanel-for-dom-delayoptions-delaytime" role="dialog">
+   <span id="infopaneltitle-for-dom-delayoptions-delaytime" style="display:none">Info about the 'delayTime' definition.</span><b><a href="#dom-delayoptions-delaytime">#dom-delayoptions-delaytime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-delayoptions-delaytime">1.18.3. 
 DelayOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-delayoptions-maxdelaytime">
-   <b><a href="#dom-delayoptions-maxdelaytime">#dom-delayoptions-maxdelaytime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-delayoptions-maxdelaytime" class="dfn-panel" data-for="dom-delayoptions-maxdelaytime" id="infopanel-for-dom-delayoptions-maxdelaytime" role="dialog">
+   <span id="infopaneltitle-for-dom-delayoptions-maxdelaytime" style="display:none">Info about the 'maxDelayTime' definition.</span><b><a href="#dom-delayoptions-maxdelaytime">#dom-delayoptions-maxdelaytime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-delayoptions-maxdelaytime">1.18.2. 
 Attributes</a>
@@ -22376,31 +22416,32 @@ Attributes</a>
 DelayOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delaywriter">
-   <b><a href="#delaywriter">#delaywriter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delaywriter" class="dfn-panel" data-for="delaywriter" id="infopanel-for-delaywriter" role="dialog">
+   <span id="infopaneltitle-for-delaywriter" style="display:none">Info about the 'DelayWriter' definition.</span><b><a href="#delaywriter">#delaywriter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delaywriter">1.18.4. Processing</a> <a href="#ref-for-delaywriter①">(2)</a>
     <li><a href="#ref-for-delaywriter②">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delayreader">
-   <b><a href="#delayreader">#delayreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delayreader" class="dfn-panel" data-for="delayreader" id="infopanel-for-delayreader" role="dialog">
+   <span id="infopaneltitle-for-delayreader" style="display:none">Info about the 'DelayReader' definition.</span><b><a href="#delayreader">#delayreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delayreader">1.18.4. Processing</a> <a href="#ref-for-delayreader①">(2)</a>
     <li><a href="#ref-for-delayreader②">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DynamicsCompressorNode">
-   <b><a href="#DynamicsCompressorNode">#DynamicsCompressorNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DynamicsCompressorNode" class="dfn-panel" data-for="DynamicsCompressorNode" id="infopanel-for-DynamicsCompressorNode" role="dialog">
+   <span id="infopaneltitle-for-DynamicsCompressorNode" style="display:none">Info about the '1.19. 
+The DynamicsCompressorNode Interface' definition.</span><b><a href="#DynamicsCompressorNode">#DynamicsCompressorNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DynamicsCompressorNode">1.19. 
 The DynamicsCompressorNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dynamicscompressornode">
-   <b><a href="#dynamicscompressornode">#dynamicscompressornode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dynamicscompressornode" class="dfn-panel" data-for="dynamicscompressornode" id="infopanel-for-dynamicscompressornode" role="dialog">
+   <span id="infopaneltitle-for-dynamicscompressornode" style="display:none">Info about the 'DynamicsCompressorNode' definition.</span><b><a href="#dynamicscompressornode">#dynamicscompressornode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dynamicscompressornode"> API Overview</a>
     <li><a href="#ref-for-dynamicscompressornode①">1.1. 
@@ -22427,15 +22468,15 @@ Latency</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-dynamicscompressornode">
-   <b><a href="#dom-dynamicscompressornode-dynamicscompressornode">#dom-dynamicscompressornode-dynamicscompressornode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-dynamicscompressornode" class="dfn-panel" data-for="dom-dynamicscompressornode-dynamicscompressornode" id="infopanel-for-dom-dynamicscompressornode-dynamicscompressornode" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-dynamicscompressornode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-dynamicscompressornode-dynamicscompressornode">#dom-dynamicscompressornode-dynamicscompressornode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-dynamicscompressornode">1.19.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-internal-reduction-slot">
-   <b><a href="#dom-dynamicscompressornode-internal-reduction-slot">#dom-dynamicscompressornode-internal-reduction-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-internal-reduction-slot" class="dfn-panel" data-for="dom-dynamicscompressornode-internal-reduction-slot" id="infopanel-for-dom-dynamicscompressornode-internal-reduction-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-internal-reduction-slot" style="display:none">Info about the '[[internal reduction]]' definition.</span><b><a href="#dom-dynamicscompressornode-internal-reduction-slot">#dom-dynamicscompressornode-internal-reduction-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-internal-reduction-slot">1.19.1. 
 Constructors</a>
@@ -22445,8 +22486,8 @@ Attributes</a>
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-attack">
-   <b><a href="#dom-dynamicscompressornode-attack">#dom-dynamicscompressornode-attack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-attack" class="dfn-panel" data-for="dom-dynamicscompressornode-attack" id="infopanel-for-dom-dynamicscompressornode-attack" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-attack" style="display:none">Info about the 'attack' definition.</span><b><a href="#dom-dynamicscompressornode-attack">#dom-dynamicscompressornode-attack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-attack">1.6.1. 
 Attributes</a>
@@ -22458,8 +22499,8 @@ Dictionary DynamicsCompressorOptions Members</a>
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-attack④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-knee">
-   <b><a href="#dom-dynamicscompressornode-knee">#dom-dynamicscompressornode-knee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-knee" class="dfn-panel" data-for="dom-dynamicscompressornode-knee" id="infopanel-for-dom-dynamicscompressornode-knee" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-knee" style="display:none">Info about the 'knee' definition.</span><b><a href="#dom-dynamicscompressornode-knee">#dom-dynamicscompressornode-knee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-knee">1.6.1. 
 Attributes</a>
@@ -22471,8 +22512,8 @@ Dictionary DynamicsCompressorOptions Members</a>
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-knee④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-ratio">
-   <b><a href="#dom-dynamicscompressornode-ratio">#dom-dynamicscompressornode-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-ratio" class="dfn-panel" data-for="dom-dynamicscompressornode-ratio" id="infopanel-for-dom-dynamicscompressornode-ratio" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-ratio" style="display:none">Info about the 'ratio' definition.</span><b><a href="#dom-dynamicscompressornode-ratio">#dom-dynamicscompressornode-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-ratio">1.6.1. 
 Attributes</a>
@@ -22484,15 +22525,15 @@ Dictionary DynamicsCompressorOptions Members</a>
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-reduction">
-   <b><a href="#dom-dynamicscompressornode-reduction">#dom-dynamicscompressornode-reduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-reduction" class="dfn-panel" data-for="dom-dynamicscompressornode-reduction" id="infopanel-for-dom-dynamicscompressornode-reduction" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-reduction" style="display:none">Info about the 'reduction' definition.</span><b><a href="#dom-dynamicscompressornode-reduction">#dom-dynamicscompressornode-reduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-reduction">1.19. 
 The DynamicsCompressorNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-release">
-   <b><a href="#dom-dynamicscompressornode-release">#dom-dynamicscompressornode-release</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-release" class="dfn-panel" data-for="dom-dynamicscompressornode-release" id="infopanel-for-dom-dynamicscompressornode-release" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-release" style="display:none">Info about the 'release' definition.</span><b><a href="#dom-dynamicscompressornode-release">#dom-dynamicscompressornode-release</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-release">1.6.1. 
 Attributes</a>
@@ -22504,8 +22545,8 @@ Dictionary DynamicsCompressorOptions Members</a>
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-release④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-threshold">
-   <b><a href="#dom-dynamicscompressornode-threshold">#dom-dynamicscompressornode-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-threshold" class="dfn-panel" data-for="dom-dynamicscompressornode-threshold" id="infopanel-for-dom-dynamicscompressornode-threshold" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-threshold" style="display:none">Info about the 'threshold' definition.</span><b><a href="#dom-dynamicscompressornode-threshold">#dom-dynamicscompressornode-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-threshold">1.6.1. 
 Attributes</a>
@@ -22517,15 +22558,16 @@ Dictionary DynamicsCompressorOptions Members</a>
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-threshold④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DynamicsCompressorOptions">
-   <b><a href="#DynamicsCompressorOptions">#DynamicsCompressorOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DynamicsCompressorOptions" class="dfn-panel" data-for="DynamicsCompressorOptions" id="infopanel-for-DynamicsCompressorOptions" role="dialog">
+   <span id="infopaneltitle-for-DynamicsCompressorOptions" style="display:none">Info about the '1.19.3. 
+DynamicsCompressorOptions' definition.</span><b><a href="#DynamicsCompressorOptions">#DynamicsCompressorOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DynamicsCompressorOptions">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-dynamicscompressoroptions">
-   <b><a href="#dictdef-dynamicscompressoroptions">#dictdef-dynamicscompressoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dynamicscompressoroptions" class="dfn-panel" data-for="dictdef-dynamicscompressoroptions" id="infopanel-for-dictdef-dynamicscompressoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dynamicscompressoroptions" style="display:none">Info about the 'DynamicsCompressorOptions' definition.</span><b><a href="#dictdef-dynamicscompressoroptions">#dictdef-dynamicscompressoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dynamicscompressoroptions">1.19. 
 The DynamicsCompressorNode Interface</a>
@@ -22537,113 +22579,116 @@ DynamicsCompressorOptions</a>
 Dictionary DynamicsCompressorOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressoroptions-attack">
-   <b><a href="#dom-dynamicscompressoroptions-attack">#dom-dynamicscompressoroptions-attack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressoroptions-attack" class="dfn-panel" data-for="dom-dynamicscompressoroptions-attack" id="infopanel-for-dom-dynamicscompressoroptions-attack" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressoroptions-attack" style="display:none">Info about the 'attack' definition.</span><b><a href="#dom-dynamicscompressoroptions-attack">#dom-dynamicscompressoroptions-attack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressoroptions-attack">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressoroptions-knee">
-   <b><a href="#dom-dynamicscompressoroptions-knee">#dom-dynamicscompressoroptions-knee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressoroptions-knee" class="dfn-panel" data-for="dom-dynamicscompressoroptions-knee" id="infopanel-for-dom-dynamicscompressoroptions-knee" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressoroptions-knee" style="display:none">Info about the 'knee' definition.</span><b><a href="#dom-dynamicscompressoroptions-knee">#dom-dynamicscompressoroptions-knee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressoroptions-knee">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressoroptions-ratio">
-   <b><a href="#dom-dynamicscompressoroptions-ratio">#dom-dynamicscompressoroptions-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressoroptions-ratio" class="dfn-panel" data-for="dom-dynamicscompressoroptions-ratio" id="infopanel-for-dom-dynamicscompressoroptions-ratio" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressoroptions-ratio" style="display:none">Info about the 'ratio' definition.</span><b><a href="#dom-dynamicscompressoroptions-ratio">#dom-dynamicscompressoroptions-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressoroptions-ratio">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressoroptions-release">
-   <b><a href="#dom-dynamicscompressoroptions-release">#dom-dynamicscompressoroptions-release</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressoroptions-release" class="dfn-panel" data-for="dom-dynamicscompressoroptions-release" id="infopanel-for-dom-dynamicscompressoroptions-release" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressoroptions-release" style="display:none">Info about the 'release' definition.</span><b><a href="#dom-dynamicscompressoroptions-release">#dom-dynamicscompressoroptions-release</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressoroptions-release">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressoroptions-threshold">
-   <b><a href="#dom-dynamicscompressoroptions-threshold">#dom-dynamicscompressoroptions-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressoroptions-threshold" class="dfn-panel" data-for="dom-dynamicscompressoroptions-threshold" id="infopanel-for-dom-dynamicscompressoroptions-threshold" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressoroptions-threshold" style="display:none">Info about the 'threshold' definition.</span><b><a href="#dom-dynamicscompressoroptions-threshold">#dom-dynamicscompressoroptions-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressoroptions-threshold">1.19.3. 
 DynamicsCompressorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="envelopefollower">
-   <b><a href="#envelopefollower">#envelopefollower</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-envelopefollower" class="dfn-panel" data-for="envelopefollower" id="infopanel-for-envelopefollower" role="dialog">
+   <span id="infopaneltitle-for-envelopefollower" style="display:none">Info about the 'EnvelopeFollower' definition.</span><b><a href="#envelopefollower">#envelopefollower</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-envelopefollower">1.19.4. 
 Processing</a> <a href="#ref-for-envelopefollower①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-detector-average-slot">
-   <b><a href="#dom-dynamicscompressornode-detector-average-slot">#dom-dynamicscompressornode-detector-average-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-detector-average-slot" class="dfn-panel" data-for="dom-dynamicscompressornode-detector-average-slot" id="infopanel-for-dom-dynamicscompressornode-detector-average-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-detector-average-slot" style="display:none">Info about the '[[detector average]]' definition.</span><b><a href="#dom-dynamicscompressornode-detector-average-slot">#dom-dynamicscompressornode-detector-average-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-detector-average-slot">1.19.4. 
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-detector-average-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dynamicscompressornode-compressor-gain-slot">
-   <b><a href="#dom-dynamicscompressornode-compressor-gain-slot">#dom-dynamicscompressornode-compressor-gain-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dynamicscompressornode-compressor-gain-slot" class="dfn-panel" data-for="dom-dynamicscompressornode-compressor-gain-slot" id="infopanel-for-dom-dynamicscompressornode-compressor-gain-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-dynamicscompressornode-compressor-gain-slot" style="display:none">Info about the '[[compressor gain]]' definition.</span><b><a href="#dom-dynamicscompressornode-compressor-gain-slot">#dom-dynamicscompressornode-compressor-gain-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dynamicscompressornode-compressor-gain-slot">1.19.4. 
 Processing</a> <a href="#ref-for-dom-dynamicscompressornode-compressor-gain-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computing-the-makeup-gain">
-   <b><a href="#computing-the-makeup-gain">#computing-the-makeup-gain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computing-the-makeup-gain" class="dfn-panel" data-for="computing-the-makeup-gain" id="infopanel-for-computing-the-makeup-gain" role="dialog">
+   <span id="infopaneltitle-for-computing-the-makeup-gain" style="display:none">Info about the 'Computing the makeup gain' definition.</span><b><a href="#computing-the-makeup-gain">#computing-the-makeup-gain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computing-the-makeup-gain">1.19.4. 
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computing-the-envelope-rate">
-   <b><a href="#computing-the-envelope-rate">#computing-the-envelope-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computing-the-envelope-rate" class="dfn-panel" data-for="computing-the-envelope-rate" id="infopanel-for-computing-the-envelope-rate" role="dialog">
+   <span id="infopaneltitle-for-computing-the-envelope-rate" style="display:none">Info about the 'Computing the envelope rate' definition.</span><b><a href="#computing-the-envelope-rate">#computing-the-envelope-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computing-the-envelope-rate">1.19.4. 
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="detector-curve">
-   <b><a href="#detector-curve">#detector-curve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-detector-curve" class="dfn-panel" data-for="detector-curve" id="infopanel-for-detector-curve" role="dialog">
+   <span id="infopaneltitle-for-detector-curve" style="display:none">Info about the 'detector curve' definition.</span><b><a href="#detector-curve">#detector-curve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-detector-curve">1.19.4. 
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compression-curve">
-   <b><a href="#compression-curve">#compression-curve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compression-curve" class="dfn-panel" data-for="compression-curve" id="infopanel-for-compression-curve" role="dialog">
+   <span id="infopaneltitle-for-compression-curve" style="display:none">Info about the 'compression curve' definition.</span><b><a href="#compression-curve">#compression-curve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compression-curve">1.19.4. 
 Processing</a> <a href="#ref-for-compression-curve">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-to-decibel">
-   <b><a href="#linear-to-decibel">#linear-to-decibel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-to-decibel" class="dfn-panel" data-for="linear-to-decibel" id="infopanel-for-linear-to-decibel" role="dialog">
+   <span id="infopaneltitle-for-linear-to-decibel" style="display:none">Info about the 'linear gain
+	unit to decibel' definition.</span><b><a href="#linear-to-decibel">#linear-to-decibel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-to-decibel">1.19.4. 
 Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decibels-to-linear-gain-unit">
-   <b><a href="#decibels-to-linear-gain-unit">#decibels-to-linear-gain-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decibels-to-linear-gain-unit" class="dfn-panel" data-for="decibels-to-linear-gain-unit" id="infopanel-for-decibels-to-linear-gain-unit" role="dialog">
+   <span id="infopaneltitle-for-decibels-to-linear-gain-unit" style="display:none">Info about the 'decibels to
+	linear gain unit' definition.</span><b><a href="#decibels-to-linear-gain-unit">#decibels-to-linear-gain-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decibels-to-linear-gain-unit">1.19.4. 
 Processing</a> <a href="#ref-for-decibels-to-linear-gain-unit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="GainNode">
-   <b><a href="#GainNode">#GainNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-GainNode" class="dfn-panel" data-for="GainNode" id="infopanel-for-GainNode" role="dialog">
+   <span id="infopaneltitle-for-GainNode" style="display:none">Info about the '1.20. 
+The GainNode Interface' definition.</span><b><a href="#GainNode">#GainNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-GainNode">1.20. 
 The GainNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gainnode">
-   <b><a href="#gainnode">#gainnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gainnode" class="dfn-panel" data-for="gainnode" id="infopanel-for-gainnode" role="dialog">
+   <span id="infopaneltitle-for-gainnode" style="display:none">Info about the 'GainNode' definition.</span><b><a href="#gainnode">#gainnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gainnode"> API Overview</a>
     <li><a href="#ref-for-gainnode①">1.1. 
@@ -22660,15 +22705,15 @@ GainOptions</a>
 Channel Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gainnode-gainnode">
-   <b><a href="#dom-gainnode-gainnode">#dom-gainnode-gainnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gainnode-gainnode" class="dfn-panel" data-for="dom-gainnode-gainnode" id="infopanel-for-dom-gainnode-gainnode" role="dialog">
+   <span id="infopaneltitle-for-dom-gainnode-gainnode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-gainnode-gainnode">#dom-gainnode-gainnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gainnode-gainnode">1.20.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gainnode-gain">
-   <b><a href="#dom-gainnode-gain">#dom-gainnode-gain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gainnode-gain" class="dfn-panel" data-for="dom-gainnode-gain" id="infopanel-for-dom-gainnode-gain" role="dialog">
+   <span id="infopaneltitle-for-dom-gainnode-gain" style="display:none">Info about the 'gain' definition.</span><b><a href="#dom-gainnode-gain">#dom-gainnode-gain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gainnode-gain">1.20. 
 The GainNode Interface</a> <a href="#ref-for-dom-gainnode-gain①">(2)</a>
@@ -22676,15 +22721,16 @@ The GainNode Interface</a> <a href="#ref-for-dom-gainnode-gain①">(2)</a>
 Dictionary GainOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="GainOptions">
-   <b><a href="#GainOptions">#GainOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-GainOptions" class="dfn-panel" data-for="GainOptions" id="infopanel-for-GainOptions" role="dialog">
+   <span id="infopaneltitle-for-GainOptions" style="display:none">Info about the '1.20.3. 
+GainOptions' definition.</span><b><a href="#GainOptions">#GainOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-GainOptions">1.20.3. 
 GainOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-gainoptions">
-   <b><a href="#dictdef-gainoptions">#dictdef-gainoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-gainoptions" class="dfn-panel" data-for="dictdef-gainoptions" id="infopanel-for-dictdef-gainoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-gainoptions" style="display:none">Info about the 'GainOptions' definition.</span><b><a href="#dictdef-gainoptions">#dictdef-gainoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-gainoptions">1.20. 
 The GainNode Interface</a>
@@ -22696,22 +22742,23 @@ GainOptions</a>
 Dictionary GainOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gainoptions-gain">
-   <b><a href="#dom-gainoptions-gain">#dom-gainoptions-gain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gainoptions-gain" class="dfn-panel" data-for="dom-gainoptions-gain" id="infopanel-for-dom-gainoptions-gain" role="dialog">
+   <span id="infopaneltitle-for-dom-gainoptions-gain" style="display:none">Info about the 'gain' definition.</span><b><a href="#dom-gainoptions-gain">#dom-gainoptions-gain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gainoptions-gain">1.20.3. 
 GainOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="IIRFilterNode">
-   <b><a href="#IIRFilterNode">#IIRFilterNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-IIRFilterNode" class="dfn-panel" data-for="IIRFilterNode" id="infopanel-for-IIRFilterNode" role="dialog">
+   <span id="infopaneltitle-for-IIRFilterNode" style="display:none">Info about the '1.21. 
+The IIRFilterNode Interface' definition.</span><b><a href="#IIRFilterNode">#IIRFilterNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-IIRFilterNode">1.21. 
 The IIRFilterNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iirfilternode">
-   <b><a href="#iirfilternode">#iirfilternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iirfilternode" class="dfn-panel" data-for="iirfilternode" id="infopanel-for-iirfilternode" role="dialog">
+   <span id="infopaneltitle-for-iirfilternode" style="display:none">Info about the 'IIRFilterNode' definition.</span><b><a href="#iirfilternode">#iirfilternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iirfilternode"> API Overview</a>
     <li><a href="#ref-for-iirfilternode①">1.1. 
@@ -22730,8 +22777,8 @@ Dictionary IIRFilterOptions Members</a> <a href="#ref-for-iirfilternode⑨">(2)<
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-iirfilternode-iirfilternode">
-   <b><a href="#dom-iirfilternode-iirfilternode">#dom-iirfilternode-iirfilternode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-iirfilternode-iirfilternode" class="dfn-panel" data-for="dom-iirfilternode-iirfilternode" id="infopanel-for-dom-iirfilternode-iirfilternode" role="dialog">
+   <span id="infopaneltitle-for-dom-iirfilternode-iirfilternode" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-iirfilternode-iirfilternode">#dom-iirfilternode-iirfilternode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-iirfilternode-iirfilternode">1.21.1. 
 Constructors</a>
@@ -22739,8 +22786,8 @@ Constructors</a>
 Filter Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-iirfilternode-getfrequencyresponse">
-   <b><a href="#dom-iirfilternode-getfrequencyresponse">#dom-iirfilternode-getfrequencyresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-iirfilternode-getfrequencyresponse" class="dfn-panel" data-for="dom-iirfilternode-getfrequencyresponse" id="infopanel-for-dom-iirfilternode-getfrequencyresponse" role="dialog">
+   <span id="infopaneltitle-for-dom-iirfilternode-getfrequencyresponse" style="display:none">Info about the 'getFrequencyResponse(frequencyHz, magResponse, phaseResponse)' definition.</span><b><a href="#dom-iirfilternode-getfrequencyresponse">#dom-iirfilternode-getfrequencyresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-iirfilternode-getfrequencyresponse">1.21. 
 The IIRFilterNode Interface</a>
@@ -22748,15 +22795,16 @@ The IIRFilterNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="IIRFilterOptions">
-   <b><a href="#IIRFilterOptions">#IIRFilterOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-IIRFilterOptions" class="dfn-panel" data-for="IIRFilterOptions" id="infopanel-for-IIRFilterOptions" role="dialog">
+   <span id="infopaneltitle-for-IIRFilterOptions" style="display:none">Info about the '1.21.3. 
+IIRFilterOptions' definition.</span><b><a href="#IIRFilterOptions">#IIRFilterOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-IIRFilterOptions">1.21.3. 
 IIRFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-iirfilteroptions">
-   <b><a href="#dictdef-iirfilteroptions">#dictdef-iirfilteroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-iirfilteroptions" class="dfn-panel" data-for="dictdef-iirfilteroptions" id="infopanel-for-dictdef-iirfilteroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-iirfilteroptions" style="display:none">Info about the 'IIRFilterOptions' definition.</span><b><a href="#dictdef-iirfilteroptions">#dictdef-iirfilteroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-iirfilteroptions">1.21. 
 The IIRFilterNode Interface</a>
@@ -22770,29 +22818,30 @@ Dictionary IIRFilterOptions Members</a>
 Filter Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-iirfilteroptions-feedforward">
-   <b><a href="#dom-iirfilteroptions-feedforward">#dom-iirfilteroptions-feedforward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-iirfilteroptions-feedforward" class="dfn-panel" data-for="dom-iirfilteroptions-feedforward" id="infopanel-for-dom-iirfilteroptions-feedforward" role="dialog">
+   <span id="infopaneltitle-for-dom-iirfilteroptions-feedforward" style="display:none">Info about the 'feedforward' definition.</span><b><a href="#dom-iirfilteroptions-feedforward">#dom-iirfilteroptions-feedforward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-iirfilteroptions-feedforward">1.21.3. 
 IIRFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-iirfilteroptions-feedback">
-   <b><a href="#dom-iirfilteroptions-feedback">#dom-iirfilteroptions-feedback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-iirfilteroptions-feedback" class="dfn-panel" data-for="dom-iirfilteroptions-feedback" id="infopanel-for-dom-iirfilteroptions-feedback" role="dialog">
+   <span id="infopaneltitle-for-dom-iirfilteroptions-feedback" style="display:none">Info about the 'feedback' definition.</span><b><a href="#dom-iirfilteroptions-feedback">#dom-iirfilteroptions-feedback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-iirfilteroptions-feedback">1.21.3. 
 IIRFilterOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaElementAudioSourceNode">
-   <b><a href="#MediaElementAudioSourceNode">#MediaElementAudioSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaElementAudioSourceNode" class="dfn-panel" data-for="MediaElementAudioSourceNode" id="infopanel-for-MediaElementAudioSourceNode" role="dialog">
+   <span id="infopaneltitle-for-MediaElementAudioSourceNode" style="display:none">Info about the '1.22. 
+The MediaElementAudioSourceNode Interface' definition.</span><b><a href="#MediaElementAudioSourceNode">#MediaElementAudioSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaElementAudioSourceNode">1.22. 
 The MediaElementAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaelementaudiosourcenode">
-   <b><a href="#mediaelementaudiosourcenode">#mediaelementaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaelementaudiosourcenode" class="dfn-panel" data-for="mediaelementaudiosourcenode" id="infopanel-for-mediaelementaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-mediaelementaudiosourcenode" style="display:none">Info about the 'MediaElementAudioSourceNode' definition.</span><b><a href="#mediaelementaudiosourcenode">#mediaelementaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaelementaudiosourcenode"> Features</a>
     <li><a href="#ref-for-mediaelementaudiosourcenode①"> API Overview</a>
@@ -22815,8 +22864,8 @@ MediaElementAudioSourceOptions</a>
 Security with MediaElementAudioSourceNode and Cross-Origin Resources</a> <a href="#ref-for-mediaelementaudiosourcenode①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode">
-   <b><a href="#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode">#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode" class="dfn-panel" data-for="dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode" id="infopanel-for-dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode" style="display:none">Info about the 'MediaElementAudioSourceNode(context, options)' definition.</span><b><a href="#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode">#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode">1.22. 
 The MediaElementAudioSourceNode Interface</a> <a href="#ref-for-dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode①">(2)</a>
@@ -22824,23 +22873,24 @@ The MediaElementAudioSourceNode Interface</a> <a href="#ref-for-dom-mediaelement
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaelementaudiosourcenode-mediaelement">
-   <b><a href="#dom-mediaelementaudiosourcenode-mediaelement">#dom-mediaelementaudiosourcenode-mediaelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaelementaudiosourcenode-mediaelement" class="dfn-panel" data-for="dom-mediaelementaudiosourcenode-mediaelement" id="infopanel-for-dom-mediaelementaudiosourcenode-mediaelement" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaelementaudiosourcenode-mediaelement" style="display:none">Info about the 'mediaElement' definition.</span><b><a href="#dom-mediaelementaudiosourcenode-mediaelement">#dom-mediaelementaudiosourcenode-mediaelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaelementaudiosourcenode-mediaelement">1.5.3. AudioNode Lifetime</a>
     <li><a href="#ref-for-dom-mediaelementaudiosourcenode-mediaelement①">1.22. 
 The MediaElementAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaElementAudioSourceOptions">
-   <b><a href="#MediaElementAudioSourceOptions">#MediaElementAudioSourceOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaElementAudioSourceOptions" class="dfn-panel" data-for="MediaElementAudioSourceOptions" id="infopanel-for-MediaElementAudioSourceOptions" role="dialog">
+   <span id="infopaneltitle-for-MediaElementAudioSourceOptions" style="display:none">Info about the '1.22.3. 
+MediaElementAudioSourceOptions' definition.</span><b><a href="#MediaElementAudioSourceOptions">#MediaElementAudioSourceOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaElementAudioSourceOptions">1.22.3. 
 MediaElementAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediaelementaudiosourceoptions">
-   <b><a href="#dictdef-mediaelementaudiosourceoptions">#dictdef-mediaelementaudiosourceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediaelementaudiosourceoptions" class="dfn-panel" data-for="dictdef-mediaelementaudiosourceoptions" id="infopanel-for-dictdef-mediaelementaudiosourceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediaelementaudiosourceoptions" style="display:none">Info about the 'MediaElementAudioSourceOptions' definition.</span><b><a href="#dictdef-mediaelementaudiosourceoptions">#dictdef-mediaelementaudiosourceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediaelementaudiosourceoptions">1.22. 
 The MediaElementAudioSourceNode Interface</a> <a href="#ref-for-dictdef-mediaelementaudiosourceoptions①">(2)</a>
@@ -22852,8 +22902,8 @@ MediaElementAudioSourceOptions</a>
 Dictionary MediaElementAudioSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaelementaudiosourceoptions-mediaelement">
-   <b><a href="#dom-mediaelementaudiosourceoptions-mediaelement">#dom-mediaelementaudiosourceoptions-mediaelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaelementaudiosourceoptions-mediaelement" class="dfn-panel" data-for="dom-mediaelementaudiosourceoptions-mediaelement" id="infopanel-for-dom-mediaelementaudiosourceoptions-mediaelement" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaelementaudiosourceoptions-mediaelement" style="display:none">Info about the 'mediaElement' definition.</span><b><a href="#dom-mediaelementaudiosourceoptions-mediaelement">#dom-mediaelementaudiosourceoptions-mediaelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaelementaudiosourceoptions-mediaelement">1.22. 
 The MediaElementAudioSourceNode Interface</a>
@@ -22861,15 +22911,16 @@ The MediaElementAudioSourceNode Interface</a>
 MediaElementAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaStreamAudioDestinationNode">
-   <b><a href="#MediaStreamAudioDestinationNode">#MediaStreamAudioDestinationNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaStreamAudioDestinationNode" class="dfn-panel" data-for="MediaStreamAudioDestinationNode" id="infopanel-for-MediaStreamAudioDestinationNode" role="dialog">
+   <span id="infopaneltitle-for-MediaStreamAudioDestinationNode" style="display:none">Info about the '1.23. 
+The MediaStreamAudioDestinationNode Interface' definition.</span><b><a href="#MediaStreamAudioDestinationNode">#MediaStreamAudioDestinationNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaStreamAudioDestinationNode">1.23. 
 The MediaStreamAudioDestinationNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediastreamaudiodestinationnode">
-   <b><a href="#mediastreamaudiodestinationnode">#mediastreamaudiodestinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediastreamaudiodestinationnode" class="dfn-panel" data-for="mediastreamaudiodestinationnode" id="infopanel-for-mediastreamaudiodestinationnode" role="dialog">
+   <span id="infopaneltitle-for-mediastreamaudiodestinationnode" style="display:none">Info about the 'MediaStreamAudioDestinationNode' definition.</span><b><a href="#mediastreamaudiodestinationnode">#mediastreamaudiodestinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamaudiodestinationnode"> Features</a>
     <li><a href="#ref-for-mediastreamaudiodestinationnode①"> API Overview</a>
@@ -22887,8 +22938,8 @@ Constructors</a> <a href="#ref-for-mediastreamaudiodestinationnode⑧">(2)</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode">
-   <b><a href="#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode">#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode" class="dfn-panel" data-for="dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode" id="infopanel-for-dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode" style="display:none">Info about the 'MediaStreamAudioDestinationNode(context, options)' definition.</span><b><a href="#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode">#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode">1.23. 
 The MediaStreamAudioDestinationNode Interface</a>
@@ -22896,22 +22947,23 @@ The MediaStreamAudioDestinationNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiodestinationnode-stream">
-   <b><a href="#dom-mediastreamaudiodestinationnode-stream">#dom-mediastreamaudiodestinationnode-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiodestinationnode-stream" class="dfn-panel" data-for="dom-mediastreamaudiodestinationnode-stream" id="infopanel-for-dom-mediastreamaudiodestinationnode-stream" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiodestinationnode-stream" style="display:none">Info about the 'stream' definition.</span><b><a href="#dom-mediastreamaudiodestinationnode-stream">#dom-mediastreamaudiodestinationnode-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiodestinationnode-stream">1.23. 
 The MediaStreamAudioDestinationNode Interface</a> <a href="#ref-for-dom-mediastreamaudiodestinationnode-stream①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaStreamAudioSourceNode">
-   <b><a href="#MediaStreamAudioSourceNode">#MediaStreamAudioSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaStreamAudioSourceNode" class="dfn-panel" data-for="MediaStreamAudioSourceNode" id="infopanel-for-MediaStreamAudioSourceNode" role="dialog">
+   <span id="infopaneltitle-for-MediaStreamAudioSourceNode" style="display:none">Info about the '1.24. 
+The MediaStreamAudioSourceNode Interface' definition.</span><b><a href="#MediaStreamAudioSourceNode">#MediaStreamAudioSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaStreamAudioSourceNode">1.24. 
 The MediaStreamAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediastreamaudiosourcenode">
-   <b><a href="#mediastreamaudiosourcenode">#mediastreamaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediastreamaudiosourcenode" class="dfn-panel" data-for="mediastreamaudiosourcenode" id="infopanel-for-mediastreamaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-mediastreamaudiosourcenode" style="display:none">Info about the 'MediaStreamAudioSourceNode' definition.</span><b><a href="#mediastreamaudiosourcenode">#mediastreamaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamaudiosourcenode"> API Overview</a>
     <li><a href="#ref-for-mediastreamaudiosourcenode①">1.2. 
@@ -22931,15 +22983,15 @@ MediaStreamAudioSourceOptions</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options">
-   <b><a href="#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options">#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options" class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options" id="infopanel-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options">#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode-context-options-options">1.24.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode">
-   <b><a href="#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode">#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode" class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode" id="infopanel-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode" style="display:none">Info about the 'MediaStreamAudioSourceNode(context, options)' definition.</span><b><a href="#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode">#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode">1.24. 
 The MediaStreamAudioSourceNode Interface</a>
@@ -22947,29 +22999,30 @@ The MediaStreamAudioSourceNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-input-track-slot">
-   <b><a href="#dom-mediastreamaudiosourcenode-input-track-slot">#dom-mediastreamaudiosourcenode-input-track-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiosourcenode-input-track-slot" class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-input-track-slot" id="infopanel-for-dom-mediastreamaudiosourcenode-input-track-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiosourcenode-input-track-slot" style="display:none">Info about the '[[input track]]' definition.</span><b><a href="#dom-mediastreamaudiosourcenode-input-track-slot">#dom-mediastreamaudiosourcenode-input-track-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiosourcenode-input-track-slot">1.24.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastream">
-   <b><a href="#dom-mediastreamaudiosourcenode-mediastream">#dom-mediastreamaudiosourcenode-mediastream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastream" class="dfn-panel" data-for="dom-mediastreamaudiosourcenode-mediastream" id="infopanel-for-dom-mediastreamaudiosourcenode-mediastream" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiosourcenode-mediastream" style="display:none">Info about the 'mediaStream' definition.</span><b><a href="#dom-mediastreamaudiosourcenode-mediastream">#dom-mediastreamaudiosourcenode-mediastream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiosourcenode-mediastream">1.24. 
 The MediaStreamAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaStreamAudioSourceOptions">
-   <b><a href="#MediaStreamAudioSourceOptions">#MediaStreamAudioSourceOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaStreamAudioSourceOptions" class="dfn-panel" data-for="MediaStreamAudioSourceOptions" id="infopanel-for-MediaStreamAudioSourceOptions" role="dialog">
+   <span id="infopaneltitle-for-MediaStreamAudioSourceOptions" style="display:none">Info about the '1.24.3. 
+MediaStreamAudioSourceOptions' definition.</span><b><a href="#MediaStreamAudioSourceOptions">#MediaStreamAudioSourceOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaStreamAudioSourceOptions">1.24.3. 
 MediaStreamAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediastreamaudiosourceoptions">
-   <b><a href="#dictdef-mediastreamaudiosourceoptions">#dictdef-mediastreamaudiosourceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediastreamaudiosourceoptions" class="dfn-panel" data-for="dictdef-mediastreamaudiosourceoptions" id="infopanel-for-dictdef-mediastreamaudiosourceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediastreamaudiosourceoptions" style="display:none">Info about the 'MediaStreamAudioSourceOptions' definition.</span><b><a href="#dictdef-mediastreamaudiosourceoptions">#dictdef-mediastreamaudiosourceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediastreamaudiosourceoptions">1.24. 
 The MediaStreamAudioSourceNode Interface</a>
@@ -22981,8 +23034,8 @@ MediaStreamAudioSourceOptions</a>
 Dictionary MediaStreamAudioSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamaudiosourceoptions-mediastream">
-   <b><a href="#dom-mediastreamaudiosourceoptions-mediastream">#dom-mediastreamaudiosourceoptions-mediastream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamaudiosourceoptions-mediastream" class="dfn-panel" data-for="dom-mediastreamaudiosourceoptions-mediastream" id="infopanel-for-dom-mediastreamaudiosourceoptions-mediastream" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamaudiosourceoptions-mediastream" style="display:none">Info about the 'mediaStream' definition.</span><b><a href="#dom-mediastreamaudiosourceoptions-mediastream">#dom-mediastreamaudiosourceoptions-mediastream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamaudiosourceoptions-mediastream">1.24.1. 
 Constructors</a>
@@ -22990,15 +23043,16 @@ Constructors</a>
 MediaStreamAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaStreamTrackAudioSourceNode">
-   <b><a href="#MediaStreamTrackAudioSourceNode">#MediaStreamTrackAudioSourceNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaStreamTrackAudioSourceNode" class="dfn-panel" data-for="MediaStreamTrackAudioSourceNode" id="infopanel-for-MediaStreamTrackAudioSourceNode" role="dialog">
+   <span id="infopaneltitle-for-MediaStreamTrackAudioSourceNode" style="display:none">Info about the '1.25. 
+The MediaStreamTrackAudioSourceNode Interface' definition.</span><b><a href="#MediaStreamTrackAudioSourceNode">#MediaStreamTrackAudioSourceNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaStreamTrackAudioSourceNode">1.25. 
 The MediaStreamTrackAudioSourceNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediastreamtrackaudiosourcenode">
-   <b><a href="#mediastreamtrackaudiosourcenode">#mediastreamtrackaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediastreamtrackaudiosourcenode" class="dfn-panel" data-for="mediastreamtrackaudiosourcenode" id="infopanel-for-mediastreamtrackaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-mediastreamtrackaudiosourcenode" style="display:none">Info about the 'MediaStreamTrackAudioSourceNode' definition.</span><b><a href="#mediastreamtrackaudiosourcenode">#mediastreamtrackaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamtrackaudiosourcenode"> Features</a> <a href="#ref-for-mediastreamtrackaudiosourcenode①">(2)</a>
     <li><a href="#ref-for-mediastreamtrackaudiosourcenode②"> API Overview</a>
@@ -23019,8 +23073,8 @@ MediaStreamTrackAudioSourceOptions</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode">
-   <b><a href="#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode">#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode" class="dfn-panel" data-for="dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode" id="infopanel-for-dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode" style="display:none">Info about the 'MediaStreamTrackAudioSourceNode(context, options)' definition.</span><b><a href="#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode">#dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackaudiosourcenode-mediastreamtrackaudiosourcenode">1.25. 
 The MediaStreamTrackAudioSourceNode Interface</a>
@@ -23028,15 +23082,16 @@ The MediaStreamTrackAudioSourceNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MediaStreamTrackAudioSourceOptions">
-   <b><a href="#MediaStreamTrackAudioSourceOptions">#MediaStreamTrackAudioSourceOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MediaStreamTrackAudioSourceOptions" class="dfn-panel" data-for="MediaStreamTrackAudioSourceOptions" id="infopanel-for-MediaStreamTrackAudioSourceOptions" role="dialog">
+   <span id="infopaneltitle-for-MediaStreamTrackAudioSourceOptions" style="display:none">Info about the '1.25.2. 
+MediaStreamTrackAudioSourceOptions' definition.</span><b><a href="#MediaStreamTrackAudioSourceOptions">#MediaStreamTrackAudioSourceOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MediaStreamTrackAudioSourceOptions">1.25.2. 
 MediaStreamTrackAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediastreamtrackaudiosourceoptions">
-   <b><a href="#dictdef-mediastreamtrackaudiosourceoptions">#dictdef-mediastreamtrackaudiosourceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediastreamtrackaudiosourceoptions" class="dfn-panel" data-for="dictdef-mediastreamtrackaudiosourceoptions" id="infopanel-for-dictdef-mediastreamtrackaudiosourceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediastreamtrackaudiosourceoptions" style="display:none">Info about the 'MediaStreamTrackAudioSourceOptions' definition.</span><b><a href="#dictdef-mediastreamtrackaudiosourceoptions">#dictdef-mediastreamtrackaudiosourceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediastreamtrackaudiosourceoptions">1.25. 
 The MediaStreamTrackAudioSourceNode Interface</a>
@@ -23048,8 +23103,8 @@ MediaStreamTrackAudioSourceOptions</a>
 Dictionary MediaStreamTrackAudioSourceOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackaudiosourceoptions-mediastreamtrack">
-   <b><a href="#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack">#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackaudiosourceoptions-mediastreamtrack" class="dfn-panel" data-for="dom-mediastreamtrackaudiosourceoptions-mediastreamtrack" id="infopanel-for-dom-mediastreamtrackaudiosourceoptions-mediastreamtrack" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackaudiosourceoptions-mediastreamtrack" style="display:none">Info about the 'mediaStreamTrack' definition.</span><b><a href="#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack">#dom-mediastreamtrackaudiosourceoptions-mediastreamtrack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackaudiosourceoptions-mediastreamtrack">1.25.1. 
 Constructors</a>
@@ -23057,15 +23112,16 @@ Constructors</a>
 MediaStreamTrackAudioSourceOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OscillatorNode">
-   <b><a href="#OscillatorNode">#OscillatorNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OscillatorNode" class="dfn-panel" data-for="OscillatorNode" id="infopanel-for-OscillatorNode" role="dialog">
+   <span id="infopaneltitle-for-OscillatorNode" style="display:none">Info about the '1.26. 
+The OscillatorNode Interface' definition.</span><b><a href="#OscillatorNode">#OscillatorNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OscillatorNode">1.26. 
 The OscillatorNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computedoscfrequency">
-   <b><a href="#computedoscfrequency">#computedoscfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computedoscfrequency" class="dfn-panel" data-for="computedoscfrequency" id="infopanel-for-computedoscfrequency" role="dialog">
+   <span id="infopaneltitle-for-computedoscfrequency" style="display:none">Info about the 'computedOscFrequency' definition.</span><b><a href="#computedoscfrequency">#computedoscfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computedoscfrequency">1.26. 
 The OscillatorNode Interface</a>
@@ -23073,8 +23129,8 @@ The OscillatorNode Interface</a>
 Attributes</a> <a href="#ref-for-computedoscfrequency②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-oscillatortype">
-   <b><a href="#enumdef-oscillatortype">#enumdef-oscillatortype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-oscillatortype" class="dfn-panel" data-for="enumdef-oscillatortype" id="infopanel-for-enumdef-oscillatortype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-oscillatortype" style="display:none">Info about the 'OscillatorType' definition.</span><b><a href="#enumdef-oscillatortype">#enumdef-oscillatortype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-oscillatortype">1.26. 
 The OscillatorNode Interface</a>
@@ -23086,8 +23142,8 @@ OscillatorOptions</a>
 Dictionary OscillatorOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatortype-sine">
-   <b><a href="#dom-oscillatortype-sine">#dom-oscillatortype-sine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatortype-sine" class="dfn-panel" data-for="dom-oscillatortype-sine" id="infopanel-for-dom-oscillatortype-sine" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatortype-sine" style="display:none">Info about the 'sine' definition.</span><b><a href="#dom-oscillatortype-sine">#dom-oscillatortype-sine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatortype-sine">1.26. 
 The OscillatorNode Interface</a>
@@ -23103,8 +23159,8 @@ PeriodicWaveOptions</a>
 Oscillator Coefficients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatortype-square">
-   <b><a href="#dom-oscillatortype-square">#dom-oscillatortype-square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatortype-square" class="dfn-panel" data-for="dom-oscillatortype-square" id="infopanel-for-dom-oscillatortype-square" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatortype-square" style="display:none">Info about the 'square' definition.</span><b><a href="#dom-oscillatortype-square">#dom-oscillatortype-square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatortype-square">1.26. 
 The OscillatorNode Interface</a>
@@ -23114,8 +23170,8 @@ Basic Waveform Phase</a>
 Oscillator Coefficients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatortype-sawtooth">
-   <b><a href="#dom-oscillatortype-sawtooth">#dom-oscillatortype-sawtooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatortype-sawtooth" class="dfn-panel" data-for="dom-oscillatortype-sawtooth" id="infopanel-for-dom-oscillatortype-sawtooth" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatortype-sawtooth" style="display:none">Info about the 'sawtooth' definition.</span><b><a href="#dom-oscillatortype-sawtooth">#dom-oscillatortype-sawtooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatortype-sawtooth">1.26. 
 The OscillatorNode Interface</a>
@@ -23125,8 +23181,8 @@ Basic Waveform Phase</a>
 Oscillator Coefficients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatortype-triangle">
-   <b><a href="#dom-oscillatortype-triangle">#dom-oscillatortype-triangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatortype-triangle" class="dfn-panel" data-for="dom-oscillatortype-triangle" id="infopanel-for-dom-oscillatortype-triangle" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatortype-triangle" style="display:none">Info about the 'triangle' definition.</span><b><a href="#dom-oscillatortype-triangle">#dom-oscillatortype-triangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatortype-triangle">1.26. 
 The OscillatorNode Interface</a>
@@ -23136,8 +23192,8 @@ Basic Waveform Phase</a>
 Oscillator Coefficients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatortype-custom">
-   <b><a href="#dom-oscillatortype-custom">#dom-oscillatortype-custom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatortype-custom" class="dfn-panel" data-for="dom-oscillatortype-custom" id="infopanel-for-dom-oscillatortype-custom" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatortype-custom" style="display:none">Info about the 'custom' definition.</span><b><a href="#dom-oscillatortype-custom">#dom-oscillatortype-custom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatortype-custom">1.26. 
 The OscillatorNode Interface</a>
@@ -23147,8 +23203,8 @@ Attributes</a> <a href="#ref-for-dom-oscillatortype-custom②">(2)</a>
 Dictionary OscillatorOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="oscillatornode">
-   <b><a href="#oscillatornode">#oscillatornode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-oscillatornode" class="dfn-panel" data-for="oscillatornode" id="infopanel-for-oscillatornode" role="dialog">
+   <span id="infopaneltitle-for-oscillatornode" style="display:none">Info about the 'OscillatorNode' definition.</span><b><a href="#oscillatornode">#oscillatornode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-oscillatornode"> API Overview</a> <a href="#ref-for-oscillatornode①">(2)</a>
     <li><a href="#ref-for-oscillatornode②">1.1. 
@@ -23175,8 +23231,8 @@ PeriodicWaveOptions</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatornode-oscillatornode">
-   <b><a href="#dom-oscillatornode-oscillatornode">#dom-oscillatornode-oscillatornode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatornode-oscillatornode" class="dfn-panel" data-for="dom-oscillatornode-oscillatornode" id="infopanel-for-dom-oscillatornode-oscillatornode" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatornode-oscillatornode" style="display:none">Info about the 'OscillatorNode(context, options)' definition.</span><b><a href="#dom-oscillatornode-oscillatornode">#dom-oscillatornode-oscillatornode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatornode-oscillatornode">1.26. 
 The OscillatorNode Interface</a>
@@ -23184,8 +23240,8 @@ The OscillatorNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatornode-detune">
-   <b><a href="#dom-oscillatornode-detune">#dom-oscillatornode-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatornode-detune" class="dfn-panel" data-for="dom-oscillatornode-detune" id="infopanel-for-dom-oscillatornode-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatornode-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-oscillatornode-detune">#dom-oscillatornode-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatornode-detune">1.26. 
 The OscillatorNode Interface</a> <a href="#ref-for-dom-oscillatornode-detune①">(2)</a>
@@ -23193,8 +23249,8 @@ The OscillatorNode Interface</a> <a href="#ref-for-dom-oscillatornode-detune①"
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatornode-frequency">
-   <b><a href="#dom-oscillatornode-frequency">#dom-oscillatornode-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatornode-frequency" class="dfn-panel" data-for="dom-oscillatornode-frequency" id="infopanel-for-dom-oscillatornode-frequency" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatornode-frequency" style="display:none">Info about the 'frequency' definition.</span><b><a href="#dom-oscillatornode-frequency">#dom-oscillatornode-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatornode-frequency">1.26. 
 The OscillatorNode Interface</a> <a href="#ref-for-dom-oscillatornode-frequency①">(2)</a>
@@ -23202,8 +23258,8 @@ The OscillatorNode Interface</a> <a href="#ref-for-dom-oscillatornode-frequency�
 Attributes</a> <a href="#ref-for-dom-oscillatornode-frequency③">(2)</a> <a href="#ref-for-dom-oscillatornode-frequency④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatornode-type">
-   <b><a href="#dom-oscillatornode-type">#dom-oscillatornode-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatornode-type" class="dfn-panel" data-for="dom-oscillatornode-type" id="infopanel-for-dom-oscillatornode-type" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatornode-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-oscillatornode-type">#dom-oscillatornode-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatornode-type">1.26. 
 The OscillatorNode Interface</a>
@@ -23211,8 +23267,8 @@ The OscillatorNode Interface</a>
 PeriodicWaveOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatornode-setperiodicwave">
-   <b><a href="#dom-oscillatornode-setperiodicwave">#dom-oscillatornode-setperiodicwave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatornode-setperiodicwave" class="dfn-panel" data-for="dom-oscillatornode-setperiodicwave" id="infopanel-for-dom-oscillatornode-setperiodicwave" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatornode-setperiodicwave" style="display:none">Info about the 'setPeriodicWave(periodicWave)' definition.</span><b><a href="#dom-oscillatornode-setperiodicwave">#dom-oscillatornode-setperiodicwave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatornode-setperiodicwave">1.26. 
 The OscillatorNode Interface</a>
@@ -23222,15 +23278,16 @@ Attributes</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="OscillatorOptions">
-   <b><a href="#OscillatorOptions">#OscillatorOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-OscillatorOptions" class="dfn-panel" data-for="OscillatorOptions" id="infopanel-for-OscillatorOptions" role="dialog">
+   <span id="infopaneltitle-for-OscillatorOptions" style="display:none">Info about the '1.26.4. 
+OscillatorOptions' definition.</span><b><a href="#OscillatorOptions">#OscillatorOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-OscillatorOptions">1.26.4. 
 OscillatorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-oscillatoroptions">
-   <b><a href="#dictdef-oscillatoroptions">#dictdef-oscillatoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-oscillatoroptions" class="dfn-panel" data-for="dictdef-oscillatoroptions" id="infopanel-for-dictdef-oscillatoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-oscillatoroptions" style="display:none">Info about the 'OscillatorOptions' definition.</span><b><a href="#dictdef-oscillatoroptions">#dictdef-oscillatoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-oscillatoroptions">1.26. 
 The OscillatorNode Interface</a>
@@ -23242,22 +23299,22 @@ OscillatorOptions</a>
 Dictionary OscillatorOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatoroptions-detune">
-   <b><a href="#dom-oscillatoroptions-detune">#dom-oscillatoroptions-detune</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatoroptions-detune" class="dfn-panel" data-for="dom-oscillatoroptions-detune" id="infopanel-for-dom-oscillatoroptions-detune" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatoroptions-detune" style="display:none">Info about the 'detune' definition.</span><b><a href="#dom-oscillatoroptions-detune">#dom-oscillatoroptions-detune</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatoroptions-detune">1.26.4. 
 OscillatorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatoroptions-frequency">
-   <b><a href="#dom-oscillatoroptions-frequency">#dom-oscillatoroptions-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatoroptions-frequency" class="dfn-panel" data-for="dom-oscillatoroptions-frequency" id="infopanel-for-dom-oscillatoroptions-frequency" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatoroptions-frequency" style="display:none">Info about the 'frequency' definition.</span><b><a href="#dom-oscillatoroptions-frequency">#dom-oscillatoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatoroptions-frequency">1.26.4. 
 OscillatorOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatoroptions-periodicwave">
-   <b><a href="#dom-oscillatoroptions-periodicwave">#dom-oscillatoroptions-periodicwave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatoroptions-periodicwave" class="dfn-panel" data-for="dom-oscillatoroptions-periodicwave" id="infopanel-for-dom-oscillatoroptions-periodicwave" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatoroptions-periodicwave" style="display:none">Info about the 'periodicWave' definition.</span><b><a href="#dom-oscillatoroptions-periodicwave">#dom-oscillatoroptions-periodicwave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatoroptions-periodicwave">1.26.4. 
 OscillatorOptions</a>
@@ -23265,8 +23322,8 @@ OscillatorOptions</a>
 Dictionary OscillatorOptions Members</a> <a href="#ref-for-dom-oscillatoroptions-periodicwave②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oscillatoroptions-type">
-   <b><a href="#dom-oscillatoroptions-type">#dom-oscillatoroptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oscillatoroptions-type" class="dfn-panel" data-for="dom-oscillatoroptions-type" id="infopanel-for-dom-oscillatoroptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-oscillatoroptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-oscillatoroptions-type">#dom-oscillatoroptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oscillatoroptions-type">1.26.4. 
 OscillatorOptions</a>
@@ -23274,15 +23331,16 @@ OscillatorOptions</a>
 Dictionary OscillatorOptions Members</a> <a href="#ref-for-dom-oscillatoroptions-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PannerNode">
-   <b><a href="#PannerNode">#PannerNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PannerNode" class="dfn-panel" data-for="PannerNode" id="infopanel-for-PannerNode" role="dialog">
+   <span id="infopaneltitle-for-PannerNode" style="display:none">Info about the '1.27. 
+The PannerNode Interface' definition.</span><b><a href="#PannerNode">#PannerNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PannerNode">1.27. 
 The PannerNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-panningmodeltype">
-   <b><a href="#enumdef-panningmodeltype">#enumdef-panningmodeltype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-panningmodeltype" class="dfn-panel" data-for="enumdef-panningmodeltype" id="infopanel-for-enumdef-panningmodeltype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-panningmodeltype" style="display:none">Info about the 'PanningModelType' definition.</span><b><a href="#enumdef-panningmodeltype">#enumdef-panningmodeltype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-panningmodeltype">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-enumdef-panningmodeltype①">(2)</a>
@@ -23294,8 +23352,8 @@ PannerOptions</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panningmodeltype-equalpower">
-   <b><a href="#dom-panningmodeltype-equalpower">#dom-panningmodeltype-equalpower</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panningmodeltype-equalpower" class="dfn-panel" data-for="dom-panningmodeltype-equalpower" id="infopanel-for-dom-panningmodeltype-equalpower" role="dialog">
+   <span id="infopaneltitle-for-dom-panningmodeltype-equalpower" style="display:none">Info about the 'equalpower' definition.</span><b><a href="#dom-panningmodeltype-equalpower">#dom-panningmodeltype-equalpower</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panningmodeltype-equalpower">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-dom-panningmodeltype-equalpower①">(2)</a>
@@ -23305,8 +23363,8 @@ Attributes</a>
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panningmodeltype-hrtf">
-   <b><a href="#dom-panningmodeltype-hrtf">#dom-panningmodeltype-hrtf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panningmodeltype-hrtf" class="dfn-panel" data-for="dom-panningmodeltype-hrtf" id="infopanel-for-dom-panningmodeltype-hrtf" role="dialog">
+   <span id="infopaneltitle-for-dom-panningmodeltype-hrtf" style="display:none">Info about the 'HRTF' definition.</span><b><a href="#dom-panningmodeltype-hrtf">#dom-panningmodeltype-hrtf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panningmodeltype-hrtf">1.6.1. 
 Attributes</a>
@@ -23314,15 +23372,15 @@ Attributes</a>
 The PannerNode Interface</a> <a href="#ref-for-dom-panningmodeltype-hrtf②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-automation-rate">
-   <b><a href="#effective-automation-rate">#effective-automation-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-automation-rate" class="dfn-panel" data-for="effective-automation-rate" id="infopanel-for-effective-automation-rate" role="dialog">
+   <span id="infopaneltitle-for-effective-automation-rate" style="display:none">Info about the 'effective automation rate' definition.</span><b><a href="#effective-automation-rate">#effective-automation-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-automation-rate">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-effective-automation-rate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-distancemodeltype">
-   <b><a href="#enumdef-distancemodeltype">#enumdef-distancemodeltype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-distancemodeltype" class="dfn-panel" data-for="enumdef-distancemodeltype" id="infopanel-for-enumdef-distancemodeltype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-distancemodeltype" style="display:none">Info about the 'DistanceModelType' definition.</span><b><a href="#enumdef-distancemodeltype">#enumdef-distancemodeltype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-distancemodeltype">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-enumdef-distancemodeltype①">(2)</a>
@@ -23336,8 +23394,8 @@ Dictionary PannerOptions Members</a>
 Distance Effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-distancemodeltype-linear">
-   <b><a href="#dom-distancemodeltype-linear">#dom-distancemodeltype-linear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-distancemodeltype-linear" class="dfn-panel" data-for="dom-distancemodeltype-linear" id="infopanel-for-dom-distancemodeltype-linear" role="dialog">
+   <span id="infopaneltitle-for-dom-distancemodeltype-linear" style="display:none">Info about the 'linear' definition.</span><b><a href="#dom-distancemodeltype-linear">#dom-distancemodeltype-linear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-distancemodeltype-linear">1.27. 
 The PannerNode Interface</a>
@@ -23345,8 +23403,8 @@ The PannerNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-distancemodeltype-inverse">
-   <b><a href="#dom-distancemodeltype-inverse">#dom-distancemodeltype-inverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-distancemodeltype-inverse" class="dfn-panel" data-for="dom-distancemodeltype-inverse" id="infopanel-for-dom-distancemodeltype-inverse" role="dialog">
+   <span id="infopaneltitle-for-dom-distancemodeltype-inverse" style="display:none">Info about the 'inverse' definition.</span><b><a href="#dom-distancemodeltype-inverse">#dom-distancemodeltype-inverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-distancemodeltype-inverse">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-dom-distancemodeltype-inverse①">(2)</a>
@@ -23354,8 +23412,8 @@ The PannerNode Interface</a> <a href="#ref-for-dom-distancemodeltype-inverse①"
 Attributes</a> <a href="#ref-for-dom-distancemodeltype-inverse③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-distancemodeltype-exponential">
-   <b><a href="#dom-distancemodeltype-exponential">#dom-distancemodeltype-exponential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-distancemodeltype-exponential" class="dfn-panel" data-for="dom-distancemodeltype-exponential" id="infopanel-for-dom-distancemodeltype-exponential" role="dialog">
+   <span id="infopaneltitle-for-dom-distancemodeltype-exponential" style="display:none">Info about the 'exponential' definition.</span><b><a href="#dom-distancemodeltype-exponential">#dom-distancemodeltype-exponential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-distancemodeltype-exponential">1.27. 
 The PannerNode Interface</a>
@@ -23363,8 +23421,8 @@ The PannerNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pannernode">
-   <b><a href="#pannernode">#pannernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pannernode" class="dfn-panel" data-for="pannernode" id="infopanel-for-pannernode" role="dialog">
+   <span id="infopaneltitle-for-pannernode" style="display:none">Info about the 'PannerNode' definition.</span><b><a href="#pannernode">#pannernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pannernode"> API Overview</a> <a href="#ref-for-pannernode①">(2)</a>
     <li><a href="#ref-for-pannernode②">1.1. 
@@ -23403,8 +23461,8 @@ Distance Effects</a>
 Sound Cones</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-pannernode">
-   <b><a href="#dom-pannernode-pannernode">#dom-pannernode-pannernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-pannernode" class="dfn-panel" data-for="dom-pannernode-pannernode" id="infopanel-for-dom-pannernode-pannernode" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-pannernode" style="display:none">Info about the 'PannerNode(context, options)' definition.</span><b><a href="#dom-pannernode-pannernode">#dom-pannernode-pannernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-pannernode">1.27. 
 The PannerNode Interface</a>
@@ -23412,8 +23470,8 @@ The PannerNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-coneinnerangle">
-   <b><a href="#dom-pannernode-coneinnerangle">#dom-pannernode-coneinnerangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-coneinnerangle" class="dfn-panel" data-for="dom-pannernode-coneinnerangle" id="infopanel-for-dom-pannernode-coneinnerangle" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-coneinnerangle" style="display:none">Info about the 'coneInnerAngle' definition.</span><b><a href="#dom-pannernode-coneinnerangle">#dom-pannernode-coneinnerangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-coneinnerangle">1.27. 
 The PannerNode Interface</a>
@@ -23423,8 +23481,8 @@ Dictionary PannerOptions Members</a>
 Sound Cones</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-coneouterangle">
-   <b><a href="#dom-pannernode-coneouterangle">#dom-pannernode-coneouterangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-coneouterangle" class="dfn-panel" data-for="dom-pannernode-coneouterangle" id="infopanel-for-dom-pannernode-coneouterangle" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-coneouterangle" style="display:none">Info about the 'coneOuterAngle' definition.</span><b><a href="#dom-pannernode-coneouterangle">#dom-pannernode-coneouterangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-coneouterangle">1.27. 
 The PannerNode Interface</a>
@@ -23436,8 +23494,8 @@ Dictionary PannerOptions Members</a>
 Sound Cones</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-coneoutergain">
-   <b><a href="#dom-pannernode-coneoutergain">#dom-pannernode-coneoutergain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-coneoutergain" class="dfn-panel" data-for="dom-pannernode-coneoutergain" id="infopanel-for-dom-pannernode-coneoutergain" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-coneoutergain" style="display:none">Info about the 'coneOuterGain' definition.</span><b><a href="#dom-pannernode-coneoutergain">#dom-pannernode-coneoutergain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-coneoutergain">1.27. 
 The PannerNode Interface</a>
@@ -23447,8 +23505,8 @@ Attributes</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-distancemodel">
-   <b><a href="#dom-pannernode-distancemodel">#dom-pannernode-distancemodel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-distancemodel" class="dfn-panel" data-for="dom-pannernode-distancemodel" id="infopanel-for-dom-pannernode-distancemodel" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-distancemodel" style="display:none">Info about the 'distanceModel' definition.</span><b><a href="#dom-pannernode-distancemodel">#dom-pannernode-distancemodel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-distancemodel">1.27. 
 The PannerNode Interface</a>
@@ -23458,8 +23516,8 @@ Attributes</a>
 Distance Effects</a> <a href="#ref-for-dom-pannernode-distancemodel③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-maxdistance">
-   <b><a href="#dom-pannernode-maxdistance">#dom-pannernode-maxdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-maxdistance" class="dfn-panel" data-for="dom-pannernode-maxdistance" id="infopanel-for-dom-pannernode-maxdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-maxdistance" style="display:none">Info about the 'maxDistance' definition.</span><b><a href="#dom-pannernode-maxdistance">#dom-pannernode-maxdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-maxdistance">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-maxdistance①">(2)</a>
@@ -23467,8 +23525,8 @@ The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-maxdistance①">(2
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-orientationx">
-   <b><a href="#dom-pannernode-orientationx">#dom-pannernode-orientationx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-orientationx" class="dfn-panel" data-for="dom-pannernode-orientationx" id="infopanel-for-dom-pannernode-orientationx" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-orientationx" style="display:none">Info about the 'orientationX' definition.</span><b><a href="#dom-pannernode-orientationx">#dom-pannernode-orientationx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-orientationx">1.27. 
 The PannerNode Interface</a>
@@ -23478,8 +23536,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-orientationx②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-orientationy">
-   <b><a href="#dom-pannernode-orientationy">#dom-pannernode-orientationy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-orientationy" class="dfn-panel" data-for="dom-pannernode-orientationy" id="infopanel-for-dom-pannernode-orientationy" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-orientationy" style="display:none">Info about the 'orientationY' definition.</span><b><a href="#dom-pannernode-orientationy">#dom-pannernode-orientationy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-orientationy">1.27. 
 The PannerNode Interface</a>
@@ -23489,8 +23547,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-orientationy②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-orientationz">
-   <b><a href="#dom-pannernode-orientationz">#dom-pannernode-orientationz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-orientationz" class="dfn-panel" data-for="dom-pannernode-orientationz" id="infopanel-for-dom-pannernode-orientationz" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-orientationz" style="display:none">Info about the 'orientationZ' definition.</span><b><a href="#dom-pannernode-orientationz">#dom-pannernode-orientationz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-orientationz">1.27. 
 The PannerNode Interface</a>
@@ -23500,8 +23558,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-orientationz②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-panningmodel">
-   <b><a href="#dom-pannernode-panningmodel">#dom-pannernode-panningmodel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-panningmodel" class="dfn-panel" data-for="dom-pannernode-panningmodel" id="infopanel-for-dom-pannernode-panningmodel" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-panningmodel" style="display:none">Info about the 'panningModel' definition.</span><b><a href="#dom-pannernode-panningmodel">#dom-pannernode-panningmodel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-panningmodel">1.6.1. 
 Attributes</a>
@@ -23511,8 +23569,8 @@ The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-panningmodel②">(
 PannerNode "equalpower" Panning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-positionx">
-   <b><a href="#dom-pannernode-positionx">#dom-pannernode-positionx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-positionx" class="dfn-panel" data-for="dom-pannernode-positionx" id="infopanel-for-dom-pannernode-positionx" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-positionx" style="display:none">Info about the 'positionX' definition.</span><b><a href="#dom-pannernode-positionx">#dom-pannernode-positionx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-positionx">1.27. 
 The PannerNode Interface</a>
@@ -23522,8 +23580,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-positionx②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-positiony">
-   <b><a href="#dom-pannernode-positiony">#dom-pannernode-positiony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-positiony" class="dfn-panel" data-for="dom-pannernode-positiony" id="infopanel-for-dom-pannernode-positiony" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-positiony" style="display:none">Info about the 'positionY' definition.</span><b><a href="#dom-pannernode-positiony">#dom-pannernode-positiony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-positiony">1.27. 
 The PannerNode Interface</a>
@@ -23533,8 +23591,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-positiony②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-positionz">
-   <b><a href="#dom-pannernode-positionz">#dom-pannernode-positionz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-positionz" class="dfn-panel" data-for="dom-pannernode-positionz" id="infopanel-for-dom-pannernode-positionz" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-positionz" style="display:none">Info about the 'positionZ' definition.</span><b><a href="#dom-pannernode-positionz">#dom-pannernode-positionz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-positionz">1.27. 
 The PannerNode Interface</a>
@@ -23544,8 +23602,8 @@ Methods</a> <a href="#ref-for-dom-pannernode-positionz②">(2)</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-refdistance">
-   <b><a href="#dom-pannernode-refdistance">#dom-pannernode-refdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-refdistance" class="dfn-panel" data-for="dom-pannernode-refdistance" id="infopanel-for-dom-pannernode-refdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-refdistance" style="display:none">Info about the 'refDistance' definition.</span><b><a href="#dom-pannernode-refdistance">#dom-pannernode-refdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-refdistance">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-refdistance①">(2)</a>
@@ -23553,8 +23611,8 @@ The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-refdistance①">(2
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-rollofffactor">
-   <b><a href="#dom-pannernode-rollofffactor">#dom-pannernode-rollofffactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-rollofffactor" class="dfn-panel" data-for="dom-pannernode-rollofffactor" id="infopanel-for-dom-pannernode-rollofffactor" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-rollofffactor" style="display:none">Info about the 'rolloffFactor' definition.</span><b><a href="#dom-pannernode-rollofffactor">#dom-pannernode-rollofffactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-rollofffactor">1.27. 
 The PannerNode Interface</a> <a href="#ref-for-dom-pannernode-rollofffactor①">(2)</a>
@@ -23564,8 +23622,8 @@ Attributes</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-setorientation">
-   <b><a href="#dom-pannernode-setorientation">#dom-pannernode-setorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-setorientation" class="dfn-panel" data-for="dom-pannernode-setorientation" id="infopanel-for-dom-pannernode-setorientation" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-setorientation" style="display:none">Info about the 'setOrientation(x, y, z)' definition.</span><b><a href="#dom-pannernode-setorientation">#dom-pannernode-setorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-setorientation">1.27. 
 The PannerNode Interface</a>
@@ -23573,8 +23631,8 @@ The PannerNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pannernode-setposition">
-   <b><a href="#dom-pannernode-setposition">#dom-pannernode-setposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pannernode-setposition" class="dfn-panel" data-for="dom-pannernode-setposition" id="infopanel-for-dom-pannernode-setposition" role="dialog">
+   <span id="infopaneltitle-for-dom-pannernode-setposition" style="display:none">Info about the 'setPosition(x, y, z)' definition.</span><b><a href="#dom-pannernode-setposition">#dom-pannernode-setposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pannernode-setposition">1.27. 
 The PannerNode Interface</a>
@@ -23582,15 +23640,16 @@ The PannerNode Interface</a>
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PannerOptions">
-   <b><a href="#PannerOptions">#PannerOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PannerOptions" class="dfn-panel" data-for="PannerOptions" id="infopanel-for-PannerOptions" role="dialog">
+   <span id="infopaneltitle-for-PannerOptions" style="display:none">Info about the '1.27.4. 
+PannerOptions' definition.</span><b><a href="#PannerOptions">#PannerOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PannerOptions">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-panneroptions">
-   <b><a href="#dictdef-panneroptions">#dictdef-panneroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-panneroptions" class="dfn-panel" data-for="dictdef-panneroptions" id="infopanel-for-dictdef-panneroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-panneroptions" style="display:none">Info about the 'PannerOptions' definition.</span><b><a href="#dictdef-panneroptions">#dictdef-panneroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-panneroptions">1.27. 
 The PannerNode Interface</a>
@@ -23602,113 +23661,114 @@ PannerOptions</a>
 Dictionary PannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-coneinnerangle">
-   <b><a href="#dom-panneroptions-coneinnerangle">#dom-panneroptions-coneinnerangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-coneinnerangle" class="dfn-panel" data-for="dom-panneroptions-coneinnerangle" id="infopanel-for-dom-panneroptions-coneinnerangle" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-coneinnerangle" style="display:none">Info about the 'coneInnerAngle' definition.</span><b><a href="#dom-panneroptions-coneinnerangle">#dom-panneroptions-coneinnerangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-coneinnerangle">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-coneouterangle">
-   <b><a href="#dom-panneroptions-coneouterangle">#dom-panneroptions-coneouterangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-coneouterangle" class="dfn-panel" data-for="dom-panneroptions-coneouterangle" id="infopanel-for-dom-panneroptions-coneouterangle" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-coneouterangle" style="display:none">Info about the 'coneOuterAngle' definition.</span><b><a href="#dom-panneroptions-coneouterangle">#dom-panneroptions-coneouterangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-coneouterangle">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-coneoutergain">
-   <b><a href="#dom-panneroptions-coneoutergain">#dom-panneroptions-coneoutergain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-coneoutergain" class="dfn-panel" data-for="dom-panneroptions-coneoutergain" id="infopanel-for-dom-panneroptions-coneoutergain" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-coneoutergain" style="display:none">Info about the 'coneOuterGain' definition.</span><b><a href="#dom-panneroptions-coneoutergain">#dom-panneroptions-coneoutergain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-coneoutergain">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-distancemodel">
-   <b><a href="#dom-panneroptions-distancemodel">#dom-panneroptions-distancemodel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-distancemodel" class="dfn-panel" data-for="dom-panneroptions-distancemodel" id="infopanel-for-dom-panneroptions-distancemodel" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-distancemodel" style="display:none">Info about the 'distanceModel' definition.</span><b><a href="#dom-panneroptions-distancemodel">#dom-panneroptions-distancemodel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-distancemodel">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-maxdistance">
-   <b><a href="#dom-panneroptions-maxdistance">#dom-panneroptions-maxdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-maxdistance" class="dfn-panel" data-for="dom-panneroptions-maxdistance" id="infopanel-for-dom-panneroptions-maxdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-maxdistance" style="display:none">Info about the 'maxDistance' definition.</span><b><a href="#dom-panneroptions-maxdistance">#dom-panneroptions-maxdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-maxdistance">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-orientationx">
-   <b><a href="#dom-panneroptions-orientationx">#dom-panneroptions-orientationx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-orientationx" class="dfn-panel" data-for="dom-panneroptions-orientationx" id="infopanel-for-dom-panneroptions-orientationx" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-orientationx" style="display:none">Info about the 'orientationX' definition.</span><b><a href="#dom-panneroptions-orientationx">#dom-panneroptions-orientationx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-orientationx">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-orientationy">
-   <b><a href="#dom-panneroptions-orientationy">#dom-panneroptions-orientationy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-orientationy" class="dfn-panel" data-for="dom-panneroptions-orientationy" id="infopanel-for-dom-panneroptions-orientationy" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-orientationy" style="display:none">Info about the 'orientationY' definition.</span><b><a href="#dom-panneroptions-orientationy">#dom-panneroptions-orientationy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-orientationy">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-orientationz">
-   <b><a href="#dom-panneroptions-orientationz">#dom-panneroptions-orientationz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-orientationz" class="dfn-panel" data-for="dom-panneroptions-orientationz" id="infopanel-for-dom-panneroptions-orientationz" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-orientationz" style="display:none">Info about the 'orientationZ' definition.</span><b><a href="#dom-panneroptions-orientationz">#dom-panneroptions-orientationz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-orientationz">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-panningmodel">
-   <b><a href="#dom-panneroptions-panningmodel">#dom-panneroptions-panningmodel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-panningmodel" class="dfn-panel" data-for="dom-panneroptions-panningmodel" id="infopanel-for-dom-panneroptions-panningmodel" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-panningmodel" style="display:none">Info about the 'panningModel' definition.</span><b><a href="#dom-panneroptions-panningmodel">#dom-panneroptions-panningmodel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-panningmodel">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-positionx">
-   <b><a href="#dom-panneroptions-positionx">#dom-panneroptions-positionx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-positionx" class="dfn-panel" data-for="dom-panneroptions-positionx" id="infopanel-for-dom-panneroptions-positionx" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-positionx" style="display:none">Info about the 'positionX' definition.</span><b><a href="#dom-panneroptions-positionx">#dom-panneroptions-positionx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-positionx">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-positiony">
-   <b><a href="#dom-panneroptions-positiony">#dom-panneroptions-positiony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-positiony" class="dfn-panel" data-for="dom-panneroptions-positiony" id="infopanel-for-dom-panneroptions-positiony" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-positiony" style="display:none">Info about the 'positionY' definition.</span><b><a href="#dom-panneroptions-positiony">#dom-panneroptions-positiony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-positiony">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-positionz">
-   <b><a href="#dom-panneroptions-positionz">#dom-panneroptions-positionz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-positionz" class="dfn-panel" data-for="dom-panneroptions-positionz" id="infopanel-for-dom-panneroptions-positionz" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-positionz" style="display:none">Info about the 'positionZ' definition.</span><b><a href="#dom-panneroptions-positionz">#dom-panneroptions-positionz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-positionz">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-refdistance">
-   <b><a href="#dom-panneroptions-refdistance">#dom-panneroptions-refdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-refdistance" class="dfn-panel" data-for="dom-panneroptions-refdistance" id="infopanel-for-dom-panneroptions-refdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-refdistance" style="display:none">Info about the 'refDistance' definition.</span><b><a href="#dom-panneroptions-refdistance">#dom-panneroptions-refdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-refdistance">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-panneroptions-rollofffactor">
-   <b><a href="#dom-panneroptions-rollofffactor">#dom-panneroptions-rollofffactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-panneroptions-rollofffactor" class="dfn-panel" data-for="dom-panneroptions-rollofffactor" id="infopanel-for-dom-panneroptions-rollofffactor" role="dialog">
+   <span id="infopaneltitle-for-dom-panneroptions-rollofffactor" style="display:none">Info about the 'rolloffFactor' definition.</span><b><a href="#dom-panneroptions-rollofffactor">#dom-panneroptions-rollofffactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-panneroptions-rollofffactor">1.27.4. 
 PannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PeriodicWave">
-   <b><a href="#PeriodicWave">#PeriodicWave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PeriodicWave" class="dfn-panel" data-for="PeriodicWave" id="infopanel-for-PeriodicWave" role="dialog">
+   <span id="infopaneltitle-for-PeriodicWave" style="display:none">Info about the '1.28. 
+The PeriodicWave Interface' definition.</span><b><a href="#PeriodicWave">#PeriodicWave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PeriodicWave">1.28. 
 The PeriodicWave Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="periodicwave">
-   <b><a href="#periodicwave">#periodicwave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-periodicwave" class="dfn-panel" data-for="periodicwave" id="infopanel-for-periodicwave" role="dialog">
+   <span id="infopaneltitle-for-periodicwave" style="display:none">Info about the 'PeriodicWave' definition.</span><b><a href="#periodicwave">#periodicwave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-periodicwave"> API Overview</a>
     <li><a href="#ref-for-periodicwave①">1.1. 
@@ -23739,15 +23799,15 @@ Waveform Normalization</a>
 Oscillator Coefficients</a> <a href="#ref-for-periodicwave②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwave-periodicwave-context-options-options">
-   <b><a href="#dom-periodicwave-periodicwave-context-options-options">#dom-periodicwave-periodicwave-context-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwave-periodicwave-context-options-options" class="dfn-panel" data-for="dom-periodicwave-periodicwave-context-options-options" id="infopanel-for-dom-periodicwave-periodicwave-context-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwave-periodicwave-context-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-periodicwave-periodicwave-context-options-options">#dom-periodicwave-periodicwave-context-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwave-periodicwave-context-options-options">1.28.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwave-periodicwave">
-   <b><a href="#dom-periodicwave-periodicwave">#dom-periodicwave-periodicwave</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwave-periodicwave" class="dfn-panel" data-for="dom-periodicwave-periodicwave" id="infopanel-for-dom-periodicwave-periodicwave" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwave-periodicwave" style="display:none">Info about the 'PeriodicWave(context, options)' definition.</span><b><a href="#dom-periodicwave-periodicwave">#dom-periodicwave-periodicwave</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwave-periodicwave">1.28. 
 The PeriodicWave Interface</a>
@@ -23755,8 +23815,8 @@ The PeriodicWave Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwave-real-slot">
-   <b><a href="#dom-periodicwave-real-slot">#dom-periodicwave-real-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwave-real-slot" class="dfn-panel" data-for="dom-periodicwave-real-slot" id="infopanel-for-dom-periodicwave-real-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwave-real-slot" style="display:none">Info about the '[[real]]' definition.</span><b><a href="#dom-periodicwave-real-slot">#dom-periodicwave-real-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwave-real-slot">1.28.1. 
 Constructors</a> <a href="#ref-for-dom-periodicwave-real-slot①">(2)</a> <a href="#ref-for-dom-periodicwave-real-slot②">(3)</a> <a href="#ref-for-dom-periodicwave-real-slot③">(4)</a> <a href="#ref-for-dom-periodicwave-real-slot④">(5)</a> <a href="#ref-for-dom-periodicwave-real-slot⑤">(6)</a> <a href="#ref-for-dom-periodicwave-real-slot⑥">(7)</a> <a href="#ref-for-dom-periodicwave-real-slot⑦">(8)</a>
@@ -23764,8 +23824,8 @@ Constructors</a> <a href="#ref-for-dom-periodicwave-real-slot①">(2)</a> <a hre
 Waveform Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwave-imag-slot">
-   <b><a href="#dom-periodicwave-imag-slot">#dom-periodicwave-imag-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwave-imag-slot" class="dfn-panel" data-for="dom-periodicwave-imag-slot" id="infopanel-for-dom-periodicwave-imag-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwave-imag-slot" style="display:none">Info about the '[[imag]]' definition.</span><b><a href="#dom-periodicwave-imag-slot">#dom-periodicwave-imag-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwave-imag-slot">1.28.1. 
 Constructors</a> <a href="#ref-for-dom-periodicwave-imag-slot①">(2)</a> <a href="#ref-for-dom-periodicwave-imag-slot②">(3)</a> <a href="#ref-for-dom-periodicwave-imag-slot③">(4)</a> <a href="#ref-for-dom-periodicwave-imag-slot④">(5)</a> <a href="#ref-for-dom-periodicwave-imag-slot⑤">(6)</a> <a href="#ref-for-dom-periodicwave-imag-slot⑥">(7)</a> <a href="#ref-for-dom-periodicwave-imag-slot⑦">(8)</a> <a href="#ref-for-dom-periodicwave-imag-slot⑧">(9)</a>
@@ -23773,8 +23833,8 @@ Constructors</a> <a href="#ref-for-dom-periodicwave-imag-slot①">(2)</a> <a hre
 Waveform Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwave-normalize-slot">
-   <b><a href="#dom-periodicwave-normalize-slot">#dom-periodicwave-normalize-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwave-normalize-slot" class="dfn-panel" data-for="dom-periodicwave-normalize-slot" id="infopanel-for-dom-periodicwave-normalize-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwave-normalize-slot" style="display:none">Info about the '[[normalize]]' definition.</span><b><a href="#dom-periodicwave-normalize-slot">#dom-periodicwave-normalize-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwave-normalize-slot">1.28.1. 
 Constructors</a>
@@ -23782,15 +23842,16 @@ Constructors</a>
 Waveform Normalization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PeriodicWaveConstraints">
-   <b><a href="#PeriodicWaveConstraints">#PeriodicWaveConstraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PeriodicWaveConstraints" class="dfn-panel" data-for="PeriodicWaveConstraints" id="infopanel-for-PeriodicWaveConstraints" role="dialog">
+   <span id="infopaneltitle-for-PeriodicWaveConstraints" style="display:none">Info about the '1.28.2. 
+PeriodicWaveConstraints' definition.</span><b><a href="#PeriodicWaveConstraints">#PeriodicWaveConstraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PeriodicWaveConstraints">1.28.2. 
 PeriodicWaveConstraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-periodicwaveconstraints">
-   <b><a href="#dictdef-periodicwaveconstraints">#dictdef-periodicwaveconstraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-periodicwaveconstraints" class="dfn-panel" data-for="dictdef-periodicwaveconstraints" id="infopanel-for-dictdef-periodicwaveconstraints" role="dialog">
+   <span id="infopaneltitle-for-dictdef-periodicwaveconstraints" style="display:none">Info about the 'PeriodicWaveConstraints' definition.</span><b><a href="#dictdef-periodicwaveconstraints">#dictdef-periodicwaveconstraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-periodicwaveconstraints">1.1. 
 The BaseAudioContext Interface</a>
@@ -23806,8 +23867,8 @@ Dictionary PeriodicWaveConstraints Members</a>
 PeriodicWaveOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwaveconstraints-disablenormalization">
-   <b><a href="#dom-periodicwaveconstraints-disablenormalization">#dom-periodicwaveconstraints-disablenormalization</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwaveconstraints-disablenormalization" class="dfn-panel" data-for="dom-periodicwaveconstraints-disablenormalization" id="infopanel-for-dom-periodicwaveconstraints-disablenormalization" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwaveconstraints-disablenormalization" style="display:none">Info about the 'disableNormalization' definition.</span><b><a href="#dom-periodicwaveconstraints-disablenormalization">#dom-periodicwaveconstraints-disablenormalization</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwaveconstraints-disablenormalization">1.1.2. 
 Methods</a> <a href="#ref-for-dom-periodicwaveconstraints-disablenormalization①">(2)</a>
@@ -23819,15 +23880,16 @@ Constructors</a>
 PeriodicWaveConstraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PeriodicWaveOptions">
-   <b><a href="#PeriodicWaveOptions">#PeriodicWaveOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PeriodicWaveOptions" class="dfn-panel" data-for="PeriodicWaveOptions" id="infopanel-for-PeriodicWaveOptions" role="dialog">
+   <span id="infopaneltitle-for-PeriodicWaveOptions" style="display:none">Info about the '1.28.3. 
+PeriodicWaveOptions' definition.</span><b><a href="#PeriodicWaveOptions">#PeriodicWaveOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PeriodicWaveOptions">1.28.3. 
 PeriodicWaveOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-periodicwaveoptions">
-   <b><a href="#dictdef-periodicwaveoptions">#dictdef-periodicwaveoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-periodicwaveoptions" class="dfn-panel" data-for="dictdef-periodicwaveoptions" id="infopanel-for-dictdef-periodicwaveoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-periodicwaveoptions" style="display:none">Info about the 'PeriodicWaveOptions' definition.</span><b><a href="#dictdef-periodicwaveoptions">#dictdef-periodicwaveoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-periodicwaveoptions">1.1.2. 
 Methods</a>
@@ -23841,8 +23903,8 @@ PeriodicWaveOptions</a> <a href="#ref-for-dictdef-periodicwaveoptions⑤">(2)</a
 Dictionary PeriodicWaveOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwaveoptions-imag">
-   <b><a href="#dom-periodicwaveoptions-imag">#dom-periodicwaveoptions-imag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwaveoptions-imag" class="dfn-panel" data-for="dom-periodicwaveoptions-imag" id="infopanel-for-dom-periodicwaveoptions-imag" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwaveoptions-imag" style="display:none">Info about the 'imag' definition.</span><b><a href="#dom-periodicwaveoptions-imag">#dom-periodicwaveoptions-imag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwaveoptions-imag">1.1.2. 
 Methods</a>
@@ -23854,8 +23916,8 @@ PeriodicWaveOptions</a> <a href="#ref-for-dom-periodicwaveoptions-imag⑧">(2)</
 Dictionary PeriodicWaveOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-periodicwaveoptions-real">
-   <b><a href="#dom-periodicwaveoptions-real">#dom-periodicwaveoptions-real</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-periodicwaveoptions-real" class="dfn-panel" data-for="dom-periodicwaveoptions-real" id="infopanel-for-dom-periodicwaveoptions-real" role="dialog">
+   <span id="infopaneltitle-for-dom-periodicwaveoptions-real" style="display:none">Info about the 'real' definition.</span><b><a href="#dom-periodicwaveoptions-real">#dom-periodicwaveoptions-real</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-periodicwaveoptions-real">1.1.2. 
 Methods</a>
@@ -23867,15 +23929,16 @@ PeriodicWaveOptions</a> <a href="#ref-for-dom-periodicwaveoptions-real①①">(2
 Dictionary PeriodicWaveOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ScriptProcessorNode">
-   <b><a href="#ScriptProcessorNode">#ScriptProcessorNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ScriptProcessorNode" class="dfn-panel" data-for="ScriptProcessorNode" id="infopanel-for-ScriptProcessorNode" role="dialog">
+   <span id="infopaneltitle-for-ScriptProcessorNode" style="display:none">Info about the '1.29. 
+The ScriptProcessorNode Interface - DEPRECATED' definition.</span><b><a href="#ScriptProcessorNode">#ScriptProcessorNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ScriptProcessorNode">1.29. 
 The ScriptProcessorNode Interface - DEPRECATED</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scriptprocessornode">
-   <b><a href="#scriptprocessornode">#scriptprocessornode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scriptprocessornode" class="dfn-panel" data-for="scriptprocessornode" id="infopanel-for-scriptprocessornode" role="dialog">
+   <span id="infopaneltitle-for-scriptprocessornode" style="display:none">Info about the 'ScriptProcessorNode' definition.</span><b><a href="#scriptprocessornode">#scriptprocessornode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scriptprocessornode"> API Overview</a> <a href="#ref-for-scriptprocessornode①">(2)</a>
     <li><a href="#ref-for-scriptprocessornode②">1.1. 
@@ -23901,8 +23964,8 @@ Latency</a> <a href="#ref-for-scriptprocessornode①⑦">(2)</a>
 Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scriptprocessornode-buffersize">
-   <b><a href="#dom-scriptprocessornode-buffersize">#dom-scriptprocessornode-buffersize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scriptprocessornode-buffersize" class="dfn-panel" data-for="dom-scriptprocessornode-buffersize" id="infopanel-for-dom-scriptprocessornode-buffersize" role="dialog">
+   <span id="infopaneltitle-for-dom-scriptprocessornode-buffersize" style="display:none">Info about the 'bufferSize' definition.</span><b><a href="#dom-scriptprocessornode-buffersize">#dom-scriptprocessornode-buffersize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scriptprocessornode-buffersize">1.1.2. 
 Methods</a> <a href="#ref-for-dom-scriptprocessornode-buffersize①">(2)</a>
@@ -23910,8 +23973,8 @@ Methods</a> <a href="#ref-for-dom-scriptprocessornode-buffersize①">(2)</a>
 The ScriptProcessorNode Interface - DEPRECATED</a> <a href="#ref-for-dom-scriptprocessornode-buffersize③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scriptprocessornode-onaudioprocess">
-   <b><a href="#dom-scriptprocessornode-onaudioprocess">#dom-scriptprocessornode-onaudioprocess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scriptprocessornode-onaudioprocess" class="dfn-panel" data-for="dom-scriptprocessornode-onaudioprocess" id="infopanel-for-dom-scriptprocessornode-onaudioprocess" role="dialog">
+   <span id="infopaneltitle-for-dom-scriptprocessornode-onaudioprocess" style="display:none">Info about the 'onaudioprocess' definition.</span><b><a href="#dom-scriptprocessornode-onaudioprocess">#dom-scriptprocessornode-onaudioprocess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scriptprocessornode-onaudioprocess">1.1.2. 
 Methods</a>
@@ -23923,15 +23986,16 @@ The ScriptProcessorNode Interface - DEPRECATED</a> <a href="#ref-for-dom-scriptp
 Attributes</a> <a href="#ref-for-dom-scriptprocessornode-onaudioprocess⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="StereoPannerNode">
-   <b><a href="#StereoPannerNode">#StereoPannerNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-StereoPannerNode" class="dfn-panel" data-for="StereoPannerNode" id="infopanel-for-StereoPannerNode" role="dialog">
+   <span id="infopaneltitle-for-StereoPannerNode" style="display:none">Info about the '1.30. 
+The StereoPannerNode Interface' definition.</span><b><a href="#StereoPannerNode">#StereoPannerNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StereoPannerNode">1.30. 
 The StereoPannerNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stereopannernode">
-   <b><a href="#stereopannernode">#stereopannernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stereopannernode" class="dfn-panel" data-for="stereopannernode" id="infopanel-for-stereopannernode" role="dialog">
+   <span id="infopaneltitle-for-stereopannernode" style="display:none">Info about the 'StereoPannerNode' definition.</span><b><a href="#stereopannernode">#stereopannernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stereopannernode"> API Overview</a>
     <li><a href="#ref-for-stereopannernode①">1.1. 
@@ -23954,8 +24018,8 @@ Channel Limitations</a>
 StereoPannerNode Panning</a> <a href="#ref-for-stereopannernode①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stereopannernode-stereopannernode">
-   <b><a href="#dom-stereopannernode-stereopannernode">#dom-stereopannernode-stereopannernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stereopannernode-stereopannernode" class="dfn-panel" data-for="dom-stereopannernode-stereopannernode" id="infopanel-for-dom-stereopannernode-stereopannernode" role="dialog">
+   <span id="infopaneltitle-for-dom-stereopannernode-stereopannernode" style="display:none">Info about the 'StereoPannerNode(context, options)' definition.</span><b><a href="#dom-stereopannernode-stereopannernode">#dom-stereopannernode-stereopannernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stereopannernode-stereopannernode">1.30. 
 The StereoPannerNode Interface</a>
@@ -23963,8 +24027,8 @@ The StereoPannerNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stereopannernode-pan">
-   <b><a href="#dom-stereopannernode-pan">#dom-stereopannernode-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stereopannernode-pan" class="dfn-panel" data-for="dom-stereopannernode-pan" id="infopanel-for-dom-stereopannernode-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-stereopannernode-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-stereopannernode-pan">#dom-stereopannernode-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stereopannernode-pan">1.30. 
 The StereoPannerNode Interface</a>
@@ -23972,15 +24036,16 @@ The StereoPannerNode Interface</a>
 Dictionary StereoPannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="StereoPannerOptions">
-   <b><a href="#StereoPannerOptions">#StereoPannerOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-StereoPannerOptions" class="dfn-panel" data-for="StereoPannerOptions" id="infopanel-for-StereoPannerOptions" role="dialog">
+   <span id="infopaneltitle-for-StereoPannerOptions" style="display:none">Info about the '1.30.3. 
+StereoPannerOptions' definition.</span><b><a href="#StereoPannerOptions">#StereoPannerOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StereoPannerOptions">1.30.3. 
 StereoPannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-stereopanneroptions">
-   <b><a href="#dictdef-stereopanneroptions">#dictdef-stereopanneroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-stereopanneroptions" class="dfn-panel" data-for="dictdef-stereopanneroptions" id="infopanel-for-dictdef-stereopanneroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-stereopanneroptions" style="display:none">Info about the 'StereoPannerOptions' definition.</span><b><a href="#dictdef-stereopanneroptions">#dictdef-stereopanneroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-stereopanneroptions">1.30. 
 The StereoPannerNode Interface</a>
@@ -23992,22 +24057,23 @@ StereoPannerOptions</a>
 Dictionary StereoPannerOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stereopanneroptions-pan">
-   <b><a href="#dom-stereopanneroptions-pan">#dom-stereopanneroptions-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stereopanneroptions-pan" class="dfn-panel" data-for="dom-stereopanneroptions-pan" id="infopanel-for-dom-stereopanneroptions-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-stereopanneroptions-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-stereopanneroptions-pan">#dom-stereopanneroptions-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stereopanneroptions-pan">1.30.3. 
 StereoPannerOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="WaveShaperNode">
-   <b><a href="#WaveShaperNode">#WaveShaperNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-WaveShaperNode" class="dfn-panel" data-for="WaveShaperNode" id="infopanel-for-WaveShaperNode" role="dialog">
+   <span id="infopaneltitle-for-WaveShaperNode" style="display:none">Info about the '1.31. 
+The WaveShaperNode Interface' definition.</span><b><a href="#WaveShaperNode">#WaveShaperNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WaveShaperNode">1.31. 
 The WaveShaperNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-oversampletype">
-   <b><a href="#enumdef-oversampletype">#enumdef-oversampletype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-oversampletype" class="dfn-panel" data-for="enumdef-oversampletype" id="infopanel-for-enumdef-oversampletype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-oversampletype" style="display:none">Info about the 'OverSampleType' definition.</span><b><a href="#enumdef-oversampletype">#enumdef-oversampletype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-oversampletype">1.31. 
 The WaveShaperNode Interface</a>
@@ -24019,8 +24085,8 @@ WaveShaperOptions</a>
 Dictionary WaveShaperOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oversampletype-none">
-   <b><a href="#dom-oversampletype-none">#dom-oversampletype-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oversampletype-none" class="dfn-panel" data-for="dom-oversampletype-none" id="infopanel-for-dom-oversampletype-none" role="dialog">
+   <span id="infopaneltitle-for-dom-oversampletype-none" style="display:none">Info about the 'none' definition.</span><b><a href="#dom-oversampletype-none">#dom-oversampletype-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oversampletype-none">1.31. 
 The WaveShaperNode Interface</a>
@@ -24028,8 +24094,8 @@ The WaveShaperNode Interface</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oversampletype-2x">
-   <b><a href="#dom-oversampletype-2x">#dom-oversampletype-2x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oversampletype-2x" class="dfn-panel" data-for="dom-oversampletype-2x" id="infopanel-for-dom-oversampletype-2x" role="dialog">
+   <span id="infopaneltitle-for-dom-oversampletype-2x" style="display:none">Info about the '2x' definition.</span><b><a href="#dom-oversampletype-2x">#dom-oversampletype-2x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oversampletype-2x">1.31. 
 The WaveShaperNode Interface</a>
@@ -24037,8 +24103,8 @@ The WaveShaperNode Interface</a>
 Attributes</a> <a href="#ref-for-dom-oversampletype-2x②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-oversampletype-4x">
-   <b><a href="#dom-oversampletype-4x">#dom-oversampletype-4x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-oversampletype-4x" class="dfn-panel" data-for="dom-oversampletype-4x" id="infopanel-for-dom-oversampletype-4x" role="dialog">
+   <span id="infopaneltitle-for-dom-oversampletype-4x" style="display:none">Info about the '4x' definition.</span><b><a href="#dom-oversampletype-4x">#dom-oversampletype-4x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-oversampletype-4x">1.31. 
 The WaveShaperNode Interface</a>
@@ -24046,8 +24112,8 @@ The WaveShaperNode Interface</a>
 Attributes</a> <a href="#ref-for-dom-oversampletype-4x②">(2)</a> <a href="#ref-for-dom-oversampletype-4x③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="waveshapernode">
-   <b><a href="#waveshapernode">#waveshapernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-waveshapernode" class="dfn-panel" data-for="waveshapernode" id="infopanel-for-waveshapernode" role="dialog">
+   <span id="infopaneltitle-for-waveshapernode" style="display:none">Info about the 'WaveShaperNode' definition.</span><b><a href="#waveshapernode">#waveshapernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waveshapernode"> API Overview</a>
     <li><a href="#ref-for-waveshapernode①">1.1. 
@@ -24066,15 +24132,15 @@ WaveShaperOptions</a>
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshapernode-waveshapernode-context-options-options">
-   <b><a href="#dom-waveshapernode-waveshapernode-context-options-options">#dom-waveshapernode-waveshapernode-context-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshapernode-waveshapernode-context-options-options" class="dfn-panel" data-for="dom-waveshapernode-waveshapernode-context-options-options" id="infopanel-for-dom-waveshapernode-waveshapernode-context-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshapernode-waveshapernode-context-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-waveshapernode-waveshapernode-context-options-options">#dom-waveshapernode-waveshapernode-context-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshapernode-waveshapernode-context-options-options">1.31.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshapernode-waveshapernode">
-   <b><a href="#dom-waveshapernode-waveshapernode">#dom-waveshapernode-waveshapernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshapernode-waveshapernode" class="dfn-panel" data-for="dom-waveshapernode-waveshapernode" id="infopanel-for-dom-waveshapernode-waveshapernode" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshapernode-waveshapernode" style="display:none">Info about the 'WaveShaperNode(context, options)' definition.</span><b><a href="#dom-waveshapernode-waveshapernode">#dom-waveshapernode-waveshapernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshapernode-waveshapernode">1.31. 
 The WaveShaperNode Interface</a>
@@ -24082,8 +24148,8 @@ The WaveShaperNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshapernode-curve-set-slot">
-   <b><a href="#dom-waveshapernode-curve-set-slot">#dom-waveshapernode-curve-set-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshapernode-curve-set-slot" class="dfn-panel" data-for="dom-waveshapernode-curve-set-slot" id="infopanel-for-dom-waveshapernode-curve-set-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshapernode-curve-set-slot" style="display:none">Info about the '[[curve set]]' definition.</span><b><a href="#dom-waveshapernode-curve-set-slot">#dom-waveshapernode-curve-set-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshapernode-curve-set-slot">1.31.1. 
 Constructors</a>
@@ -24091,8 +24157,8 @@ Constructors</a>
 Attributes</a> <a href="#ref-for-dom-waveshapernode-curve-set-slot②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshapernode-curve">
-   <b><a href="#dom-waveshapernode-curve">#dom-waveshapernode-curve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshapernode-curve" class="dfn-panel" data-for="dom-waveshapernode-curve" id="infopanel-for-dom-waveshapernode-curve" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshapernode-curve" style="display:none">Info about the 'curve' definition.</span><b><a href="#dom-waveshapernode-curve">#dom-waveshapernode-curve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshapernode-curve">1.31. 
 The WaveShaperNode Interface</a>
@@ -24100,22 +24166,23 @@ The WaveShaperNode Interface</a>
 Attributes</a> <a href="#ref-for-dom-waveshapernode-curve②">(2)</a> <a href="#ref-for-dom-waveshapernode-curve③">(3)</a> <a href="#ref-for-dom-waveshapernode-curve④">(4)</a> <a href="#ref-for-dom-waveshapernode-curve⑤">(5)</a> <a href="#ref-for-dom-waveshapernode-curve⑥">(6)</a> <a href="#ref-for-dom-waveshapernode-curve⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshapernode-oversample">
-   <b><a href="#dom-waveshapernode-oversample">#dom-waveshapernode-oversample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshapernode-oversample" class="dfn-panel" data-for="dom-waveshapernode-oversample" id="infopanel-for-dom-waveshapernode-oversample" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshapernode-oversample" style="display:none">Info about the 'oversample' definition.</span><b><a href="#dom-waveshapernode-oversample">#dom-waveshapernode-oversample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshapernode-oversample">1.31. 
 The WaveShaperNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="WaveShaperOptions">
-   <b><a href="#WaveShaperOptions">#WaveShaperOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-WaveShaperOptions" class="dfn-panel" data-for="WaveShaperOptions" id="infopanel-for-WaveShaperOptions" role="dialog">
+   <span id="infopaneltitle-for-WaveShaperOptions" style="display:none">Info about the '1.31.3. 
+WaveShaperOptions' definition.</span><b><a href="#WaveShaperOptions">#WaveShaperOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WaveShaperOptions">1.31.3. 
 WaveShaperOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-waveshaperoptions">
-   <b><a href="#dictdef-waveshaperoptions">#dictdef-waveshaperoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-waveshaperoptions" class="dfn-panel" data-for="dictdef-waveshaperoptions" id="infopanel-for-dictdef-waveshaperoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-waveshaperoptions" style="display:none">Info about the 'WaveShaperOptions' definition.</span><b><a href="#dictdef-waveshaperoptions">#dictdef-waveshaperoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-waveshaperoptions">1.31. 
 The WaveShaperNode Interface</a>
@@ -24127,8 +24194,8 @@ WaveShaperOptions</a>
 Dictionary WaveShaperOptions Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshaperoptions-curve">
-   <b><a href="#dom-waveshaperoptions-curve">#dom-waveshaperoptions-curve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshaperoptions-curve" class="dfn-panel" data-for="dom-waveshaperoptions-curve" id="infopanel-for-dom-waveshaperoptions-curve" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshaperoptions-curve" style="display:none">Info about the 'curve' definition.</span><b><a href="#dom-waveshaperoptions-curve">#dom-waveshaperoptions-curve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshaperoptions-curve">1.31.1. 
 Constructors</a>
@@ -24136,23 +24203,24 @@ Constructors</a>
 WaveShaperOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-waveshaperoptions-oversample">
-   <b><a href="#dom-waveshaperoptions-oversample">#dom-waveshaperoptions-oversample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-waveshaperoptions-oversample" class="dfn-panel" data-for="dom-waveshaperoptions-oversample" id="infopanel-for-dom-waveshaperoptions-oversample" role="dialog">
+   <span id="infopaneltitle-for-dom-waveshaperoptions-oversample" style="display:none">Info about the 'oversample' definition.</span><b><a href="#dom-waveshaperoptions-oversample">#dom-waveshaperoptions-oversample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-waveshaperoptions-oversample">1.31.3. 
 WaveShaperOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioWorklet">
-   <b><a href="#AudioWorklet">#AudioWorklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioWorklet" class="dfn-panel" data-for="AudioWorklet" id="infopanel-for-AudioWorklet" role="dialog">
+   <span id="infopaneltitle-for-AudioWorklet" style="display:none">Info about the '1.32. 
+The AudioWorklet Interface' definition.</span><b><a href="#AudioWorklet">#AudioWorklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorklet"> Features</a>
     <li><a href="#ref-for-AudioWorklet">1.32. 
 The AudioWorklet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioworklet">
-   <b><a href="#audioworklet">#audioworklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioworklet" class="dfn-panel" data-for="audioworklet" id="infopanel-for-audioworklet" role="dialog">
+   <span id="infopaneltitle-for-audioworklet" style="display:none">Info about the 'AudioWorklet' definition.</span><b><a href="#audioworklet">#audioworklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioworklet"> API Overview</a>
     <li><a href="#ref-for-audioworklet①">1.1. 
@@ -24169,8 +24237,8 @@ The AudioWorkletGlobalScope Interface</a>
 AudioWorklet Sequence of Events</a> <a href="#ref-for-audioworklet①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="node-name-to-parameter-descriptor-map">
-   <b><a href="#node-name-to-parameter-descriptor-map">#node-name-to-parameter-descriptor-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-node-name-to-parameter-descriptor-map" class="dfn-panel" data-for="node-name-to-parameter-descriptor-map" id="infopanel-for-node-name-to-parameter-descriptor-map" role="dialog">
+   <span id="infopaneltitle-for-node-name-to-parameter-descriptor-map" style="display:none">Info about the 'node name to parameter descriptor map' definition.</span><b><a href="#node-name-to-parameter-descriptor-map">#node-name-to-parameter-descriptor-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node-name-to-parameter-descriptor-map">1.32.2.2. 
 Methods</a>
@@ -24178,15 +24246,16 @@ Methods</a>
 Constructors</a> <a href="#ref-for-node-name-to-parameter-descriptor-map②">(2)</a> <a href="#ref-for-node-name-to-parameter-descriptor-map③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioWorkletGlobalScope">
-   <b><a href="#AudioWorkletGlobalScope">#AudioWorkletGlobalScope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioWorkletGlobalScope" class="dfn-panel" data-for="AudioWorkletGlobalScope" id="infopanel-for-AudioWorkletGlobalScope" role="dialog">
+   <span id="infopaneltitle-for-AudioWorkletGlobalScope" style="display:none">Info about the '1.32.2. 
+The AudioWorkletGlobalScope Interface' definition.</span><b><a href="#AudioWorkletGlobalScope">#AudioWorkletGlobalScope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorkletGlobalScope">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="node-name-to-processor-constructor-map">
-   <b><a href="#node-name-to-processor-constructor-map">#node-name-to-processor-constructor-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-node-name-to-processor-constructor-map" class="dfn-panel" data-for="node-name-to-processor-constructor-map" id="infopanel-for-node-name-to-processor-constructor-map" role="dialog">
+   <span id="infopaneltitle-for-node-name-to-processor-constructor-map" style="display:none">Info about the 'node name to processor constructor map' definition.</span><b><a href="#node-name-to-processor-constructor-map">#node-name-to-processor-constructor-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node-name-to-processor-constructor-map">1.32.1. 
 Concepts</a>
@@ -24196,8 +24265,8 @@ Methods</a> <a href="#ref-for-node-name-to-processor-constructor-map②">(2)</a>
 The instantiation of AudioWorkletProcessor</a> <a href="#ref-for-node-name-to-processor-constructor-map④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-processor-construction-data">
-   <b><a href="#pending-processor-construction-data">#pending-processor-construction-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-processor-construction-data" class="dfn-panel" data-for="pending-processor-construction-data" id="infopanel-for-pending-processor-construction-data" role="dialog">
+   <span id="infopaneltitle-for-pending-processor-construction-data" style="display:none">Info about the 'pending processor construction data' definition.</span><b><a href="#pending-processor-construction-data">#pending-processor-construction-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-processor-construction-data">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
@@ -24207,8 +24276,8 @@ The instantiation of AudioWorkletProcessor</a> <a href="#ref-for-pending-process
 Constructors</a> <a href="#ref-for-pending-processor-construction-data④">(2)</a> <a href="#ref-for-pending-processor-construction-data⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-processor-construction-data-node-reference">
-   <b><a href="#pending-processor-construction-data-node-reference">#pending-processor-construction-data-node-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-processor-construction-data-node-reference" class="dfn-panel" data-for="pending-processor-construction-data-node-reference" id="infopanel-for-pending-processor-construction-data-node-reference" role="dialog">
+   <span id="infopaneltitle-for-pending-processor-construction-data-node-reference" style="display:none">Info about the 'node reference' definition.</span><b><a href="#pending-processor-construction-data-node-reference">#pending-processor-construction-data-node-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-processor-construction-data-node-reference">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24216,8 +24285,8 @@ The instantiation of AudioWorkletProcessor</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-processor-construction-data-transferred-port">
-   <b><a href="#pending-processor-construction-data-transferred-port">#pending-processor-construction-data-transferred-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-processor-construction-data-transferred-port" class="dfn-panel" data-for="pending-processor-construction-data-transferred-port" id="infopanel-for-pending-processor-construction-data-transferred-port" role="dialog">
+   <span id="infopaneltitle-for-pending-processor-construction-data-transferred-port" style="display:none">Info about the 'transferred port' definition.</span><b><a href="#pending-processor-construction-data-transferred-port">#pending-processor-construction-data-transferred-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-processor-construction-data-transferred-port">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24225,8 +24294,8 @@ The instantiation of AudioWorkletProcessor</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-audioworkletprocessorconstructor">
-   <b><a href="#callbackdef-audioworkletprocessorconstructor">#callbackdef-audioworkletprocessorconstructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-audioworkletprocessorconstructor" class="dfn-panel" data-for="callbackdef-audioworkletprocessorconstructor" id="infopanel-for-callbackdef-audioworkletprocessorconstructor" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-audioworkletprocessorconstructor" style="display:none">Info about the 'AudioWorkletProcessorConstructor' definition.</span><b><a href="#callbackdef-audioworkletprocessorconstructor">#callbackdef-audioworkletprocessorconstructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-audioworkletprocessorconstructor">1.32.2. 
 The AudioWorkletGlobalScope Interface</a> <a href="#ref-for-callbackdef-audioworkletprocessorconstructor①">(2)</a>
@@ -24234,8 +24303,8 @@ The AudioWorkletGlobalScope Interface</a> <a href="#ref-for-callbackdef-audiowor
 Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioworkletglobalscope">
-   <b><a href="#audioworkletglobalscope">#audioworkletglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioworkletglobalscope" class="dfn-panel" data-for="audioworkletglobalscope" id="infopanel-for-audioworkletglobalscope" role="dialog">
+   <span id="infopaneltitle-for-audioworkletglobalscope" style="display:none">Info about the 'AudioWorkletGlobalScope' definition.</span><b><a href="#audioworkletglobalscope">#audioworkletglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioworkletglobalscope"> API Overview</a>
     <li><a href="#ref-for-audioworkletglobalscope①">1.32.1. 
@@ -24256,15 +24325,15 @@ AudioWorklet Sequence of Events</a> <a href="#ref-for-audioworkletglobalscope①
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-currentframe">
-   <b><a href="#dom-audioworkletglobalscope-currentframe">#dom-audioworkletglobalscope-currentframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-currentframe" class="dfn-panel" data-for="dom-audioworkletglobalscope-currentframe" id="infopanel-for-dom-audioworkletglobalscope-currentframe" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-currentframe" style="display:none">Info about the 'currentFrame' definition.</span><b><a href="#dom-audioworkletglobalscope-currentframe">#dom-audioworkletglobalscope-currentframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-currentframe">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-currenttime">
-   <b><a href="#dom-audioworkletglobalscope-currenttime">#dom-audioworkletglobalscope-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-currenttime" class="dfn-panel" data-for="dom-audioworkletglobalscope-currenttime" id="infopanel-for-dom-audioworkletglobalscope-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-audioworkletglobalscope-currenttime">#dom-audioworkletglobalscope-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-currenttime">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
@@ -24272,15 +24341,15 @@ The AudioWorkletGlobalScope Interface</a>
 Callback AudioWorkletProcessCallback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-samplerate">
-   <b><a href="#dom-audioworkletglobalscope-samplerate">#dom-audioworkletglobalscope-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-samplerate" class="dfn-panel" data-for="dom-audioworkletglobalscope-samplerate" id="infopanel-for-dom-audioworkletglobalscope-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-samplerate" style="display:none">Info about the 'sampleRate' definition.</span><b><a href="#dom-audioworkletglobalscope-samplerate">#dom-audioworkletglobalscope-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-samplerate">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor">
-   <b><a href="#dom-audioworkletglobalscope-registerprocessor">#dom-audioworkletglobalscope-registerprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor" class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor" id="infopanel-for-dom-audioworkletglobalscope-registerprocessor" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor" style="display:none">Info about the 'registerProcessor(name, processorCtor)' definition.</span><b><a href="#dom-audioworkletglobalscope-registerprocessor">#dom-audioworkletglobalscope-registerprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-registerprocessor">1.32.1. 
 Concepts</a>
@@ -24290,22 +24359,22 @@ The AudioWorkletGlobalScope Interface</a> <a href="#ref-for-dom-audioworkletglob
 Methods</a> <a href="#ref-for-dom-audioworkletglobalscope-registerprocessor④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor-name-processorctor-name">
-   <b><a href="#dom-audioworkletglobalscope-registerprocessor-name-processorctor-name">#dom-audioworkletglobalscope-registerprocessor-name-processorctor-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-name" class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor-name-processorctor-name" id="infopanel-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-name" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-audioworkletglobalscope-registerprocessor-name-processorctor-name">#dom-audioworkletglobalscope-registerprocessor-name-processorctor-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-name">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor">
-   <b><a href="#dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor">#dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor" class="dfn-panel" data-for="dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor" id="infopanel-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor" style="display:none">Info about the 'processorCtor' definition.</span><b><a href="#dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor">#dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletglobalscope-registerprocessor-name-processorctor-processorctor">1.32.2. 
 The AudioWorkletGlobalScope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processor-construction-data">
-   <b><a href="#processor-construction-data">#processor-construction-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processor-construction-data" class="dfn-panel" data-for="processor-construction-data" id="infopanel-for-processor-construction-data" role="dialog">
+   <span id="infopaneltitle-for-processor-construction-data" style="display:none">Info about the 'processor construction data' definition.</span><b><a href="#processor-construction-data">#processor-construction-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processor-construction-data">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24313,51 +24382,52 @@ The instantiation of AudioWorkletProcessor</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processor-construction-data-name">
-   <b><a href="#processor-construction-data-name">#processor-construction-data-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processor-construction-data-name" class="dfn-panel" data-for="processor-construction-data-name" id="infopanel-for-processor-construction-data-name" role="dialog">
+   <span id="infopaneltitle-for-processor-construction-data-name" style="display:none">Info about the 'name' definition.</span><b><a href="#processor-construction-data-name">#processor-construction-data-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processor-construction-data-name">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processor-construction-data-node">
-   <b><a href="#processor-construction-data-node">#processor-construction-data-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processor-construction-data-node" class="dfn-panel" data-for="processor-construction-data-node" id="infopanel-for-processor-construction-data-node" role="dialog">
+   <span id="infopaneltitle-for-processor-construction-data-node" style="display:none">Info about the 'node' definition.</span><b><a href="#processor-construction-data-node">#processor-construction-data-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processor-construction-data-node">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processor-construction-data-options">
-   <b><a href="#processor-construction-data-options">#processor-construction-data-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processor-construction-data-options" class="dfn-panel" data-for="processor-construction-data-options" id="infopanel-for-processor-construction-data-options" role="dialog">
+   <span id="infopaneltitle-for-processor-construction-data-options" style="display:none">Info about the 'options' definition.</span><b><a href="#processor-construction-data-options">#processor-construction-data-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processor-construction-data-options">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processor-construction-data-port">
-   <b><a href="#processor-construction-data-port">#processor-construction-data-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processor-construction-data-port" class="dfn-panel" data-for="processor-construction-data-port" id="infopanel-for-processor-construction-data-port" role="dialog">
+   <span id="infopaneltitle-for-processor-construction-data-port" style="display:none">Info about the 'port' definition.</span><b><a href="#processor-construction-data-port">#processor-construction-data-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processor-construction-data-port">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioWorkletNode">
-   <b><a href="#AudioWorkletNode">#AudioWorkletNode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioWorkletNode" class="dfn-panel" data-for="AudioWorkletNode" id="infopanel-for-AudioWorkletNode" role="dialog">
+   <span id="infopaneltitle-for-AudioWorkletNode" style="display:none">Info about the '1.32.3. 
+The AudioWorkletNode Interface' definition.</span><b><a href="#AudioWorkletNode">#AudioWorkletNode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorkletNode">1.32.3. 
 The AudioWorkletNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-source">
-   <b><a href="#active-source">#active-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-source" class="dfn-panel" data-for="active-source" id="infopanel-for-active-source" role="dialog">
+   <span id="infopaneltitle-for-active-source" style="display:none">Info about the 'active source' definition.</span><b><a href="#active-source">#active-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-source">1.5.3. AudioNode Lifetime</a>
     <li><a href="#ref-for-active-source①">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-active-source②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioparammap">
-   <b><a href="#audioparammap">#audioparammap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioparammap" class="dfn-panel" data-for="audioparammap" id="infopanel-for-audioparammap" role="dialog">
+   <span id="infopaneltitle-for-audioparammap" style="display:none">Info about the 'AudioParamMap' definition.</span><b><a href="#audioparammap">#audioparammap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioparammap">1.32.3. 
 The AudioWorkletNode Interface</a>
@@ -24367,8 +24437,8 @@ Constructors</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioworkletnode">
-   <b><a href="#audioworkletnode">#audioworkletnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioworkletnode" class="dfn-panel" data-for="audioworkletnode" id="infopanel-for-audioworkletnode" role="dialog">
+   <span id="infopaneltitle-for-audioworkletnode" style="display:none">Info about the 'AudioWorkletNode' definition.</span><b><a href="#audioworkletnode">#audioworkletnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioworkletnode"> API Overview</a>
     <li><a href="#ref-for-audioworkletnode①">1.1.2. 
@@ -24425,8 +24495,8 @@ Rendering an Audio Graph</a> <a href="#ref-for-audioworkletnode⑤③">(2)</a> <
 Latency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnode-audioworkletnode">
-   <b><a href="#dom-audioworkletnode-audioworkletnode">#dom-audioworkletnode-audioworkletnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnode-audioworkletnode" class="dfn-panel" data-for="dom-audioworkletnode-audioworkletnode" id="infopanel-for-dom-audioworkletnode-audioworkletnode" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnode-audioworkletnode" style="display:none">Info about the 'AudioWorkletNode(context, name, options)' definition.</span><b><a href="#dom-audioworkletnode-audioworkletnode">#dom-audioworkletnode-audioworkletnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnode-audioworkletnode">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24436,15 +24506,15 @@ The AudioWorkletNode Interface</a>
 Constructors</a> <a href="#ref-for-dom-audioworkletnode-audioworkletnode③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnode-onprocessorerror">
-   <b><a href="#dom-audioworkletnode-onprocessorerror">#dom-audioworkletnode-onprocessorerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnode-onprocessorerror" class="dfn-panel" data-for="dom-audioworkletnode-onprocessorerror" id="infopanel-for-dom-audioworkletnode-onprocessorerror" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnode-onprocessorerror" style="display:none">Info about the 'onprocessorerror' definition.</span><b><a href="#dom-audioworkletnode-onprocessorerror">#dom-audioworkletnode-onprocessorerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnode-onprocessorerror">1.32.3. 
 The AudioWorkletNode Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnode-parameters">
-   <b><a href="#dom-audioworkletnode-parameters">#dom-audioworkletnode-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnode-parameters" class="dfn-panel" data-for="dom-audioworkletnode-parameters" id="infopanel-for-dom-audioworkletnode-parameters" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnode-parameters" style="display:none">Info about the 'parameters' definition.</span><b><a href="#dom-audioworkletnode-parameters">#dom-audioworkletnode-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnode-parameters">1.32.3. 
 The AudioWorkletNode Interface</a>
@@ -24452,8 +24522,8 @@ The AudioWorkletNode Interface</a>
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnode-port">
-   <b><a href="#dom-audioworkletnode-port">#dom-audioworkletnode-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnode-port" class="dfn-panel" data-for="dom-audioworkletnode-port" id="infopanel-for-dom-audioworkletnode-port" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnode-port" style="display:none">Info about the 'port' definition.</span><b><a href="#dom-audioworkletnode-port">#dom-audioworkletnode-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnode-port">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24465,15 +24535,16 @@ Constructors</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioWorkletNodeOptions">
-   <b><a href="#AudioWorkletNodeOptions">#AudioWorkletNodeOptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioWorkletNodeOptions" class="dfn-panel" data-for="AudioWorkletNodeOptions" id="infopanel-for-AudioWorkletNodeOptions" role="dialog">
+   <span id="infopaneltitle-for-AudioWorkletNodeOptions" style="display:none">Info about the '1.32.3.3. 
+AudioWorkletNodeOptions' definition.</span><b><a href="#AudioWorkletNodeOptions">#AudioWorkletNodeOptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorkletNodeOptions">1.32.3.3. 
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audioworkletnodeoptions">
-   <b><a href="#dictdef-audioworkletnodeoptions">#dictdef-audioworkletnodeoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audioworkletnodeoptions" class="dfn-panel" data-for="dictdef-audioworkletnodeoptions" id="infopanel-for-dictdef-audioworkletnodeoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audioworkletnodeoptions" style="display:none">Info about the 'AudioWorkletNodeOptions' definition.</span><b><a href="#dictdef-audioworkletnodeoptions">#dictdef-audioworkletnodeoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audioworkletnodeoptions">1.32.2.3. 
 The instantiation of AudioWorkletProcessor</a>
@@ -24489,8 +24560,8 @@ Dictionary AudioWorkletNodeOptions Members</a>
 Configuring Channels with AudioWorkletNodeOptions</a> <a href="#ref-for-dictdef-audioworkletnodeoptions⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnodeoptions-numberofinputs">
-   <b><a href="#dom-audioworkletnodeoptions-numberofinputs">#dom-audioworkletnodeoptions-numberofinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnodeoptions-numberofinputs" class="dfn-panel" data-for="dom-audioworkletnodeoptions-numberofinputs" id="infopanel-for-dom-audioworkletnodeoptions-numberofinputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnodeoptions-numberofinputs" style="display:none">Info about the 'numberOfInputs' definition.</span><b><a href="#dom-audioworkletnodeoptions-numberofinputs">#dom-audioworkletnodeoptions-numberofinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnodeoptions-numberofinputs">1.32.3.3. 
 AudioWorkletNodeOptions</a>
@@ -24498,8 +24569,8 @@ AudioWorkletNodeOptions</a>
 Configuring Channels with AudioWorkletNodeOptions</a> <a href="#ref-for-dom-audioworkletnodeoptions-numberofinputs②">(2)</a> <a href="#ref-for-dom-audioworkletnodeoptions-numberofinputs③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnodeoptions-numberofoutputs">
-   <b><a href="#dom-audioworkletnodeoptions-numberofoutputs">#dom-audioworkletnodeoptions-numberofoutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnodeoptions-numberofoutputs" class="dfn-panel" data-for="dom-audioworkletnodeoptions-numberofoutputs" id="infopanel-for-dom-audioworkletnodeoptions-numberofoutputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnodeoptions-numberofoutputs" style="display:none">Info about the 'numberOfOutputs' definition.</span><b><a href="#dom-audioworkletnodeoptions-numberofoutputs">#dom-audioworkletnodeoptions-numberofoutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnodeoptions-numberofoutputs">1.32.3.3. 
 AudioWorkletNodeOptions</a>
@@ -24507,8 +24578,8 @@ AudioWorkletNodeOptions</a>
 Configuring Channels with AudioWorkletNodeOptions</a> <a href="#ref-for-dom-audioworkletnodeoptions-numberofoutputs②">(2)</a> <a href="#ref-for-dom-audioworkletnodeoptions-numberofoutputs③">(3)</a> <a href="#ref-for-dom-audioworkletnodeoptions-numberofoutputs④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnodeoptions-outputchannelcount">
-   <b><a href="#dom-audioworkletnodeoptions-outputchannelcount">#dom-audioworkletnodeoptions-outputchannelcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnodeoptions-outputchannelcount" class="dfn-panel" data-for="dom-audioworkletnodeoptions-outputchannelcount" id="infopanel-for-dom-audioworkletnodeoptions-outputchannelcount" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnodeoptions-outputchannelcount" style="display:none">Info about the 'outputChannelCount' definition.</span><b><a href="#dom-audioworkletnodeoptions-outputchannelcount">#dom-audioworkletnodeoptions-outputchannelcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount">1.32.3.3. 
 AudioWorkletNodeOptions</a>
@@ -24516,8 +24587,8 @@ AudioWorkletNodeOptions</a>
 Configuring Channels with AudioWorkletNodeOptions</a> <a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount②">(2)</a> <a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount③">(3)</a> <a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount④">(4)</a> <a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount⑤">(5)</a> <a href="#ref-for-dom-audioworkletnodeoptions-outputchannelcount⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnodeoptions-parameterdata">
-   <b><a href="#dom-audioworkletnodeoptions-parameterdata">#dom-audioworkletnodeoptions-parameterdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnodeoptions-parameterdata" class="dfn-panel" data-for="dom-audioworkletnodeoptions-parameterdata" id="infopanel-for-dom-audioworkletnodeoptions-parameterdata" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnodeoptions-parameterdata" style="display:none">Info about the 'parameterData' definition.</span><b><a href="#dom-audioworkletnodeoptions-parameterdata">#dom-audioworkletnodeoptions-parameterdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnodeoptions-parameterdata">1.32.3.1. 
 Constructors</a> <a href="#ref-for-dom-audioworkletnodeoptions-parameterdata①">(2)</a>
@@ -24525,22 +24596,23 @@ Constructors</a> <a href="#ref-for-dom-audioworkletnodeoptions-parameterdata①"
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletnodeoptions-processoroptions">
-   <b><a href="#dom-audioworkletnodeoptions-processoroptions">#dom-audioworkletnodeoptions-processoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletnodeoptions-processoroptions" class="dfn-panel" data-for="dom-audioworkletnodeoptions-processoroptions" id="infopanel-for-dom-audioworkletnodeoptions-processoroptions" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletnodeoptions-processoroptions" style="display:none">Info about the 'processorOptions' definition.</span><b><a href="#dom-audioworkletnodeoptions-processoroptions">#dom-audioworkletnodeoptions-processoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletnodeoptions-processoroptions">1.32.3.3. 
 AudioWorkletNodeOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioWorkletProcessor">
-   <b><a href="#AudioWorkletProcessor">#AudioWorkletProcessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioWorkletProcessor" class="dfn-panel" data-for="AudioWorkletProcessor" id="infopanel-for-AudioWorkletProcessor" role="dialog">
+   <span id="infopaneltitle-for-AudioWorkletProcessor" style="display:none">Info about the '1.32.4. 
+The AudioWorkletProcessor Interface' definition.</span><b><a href="#AudioWorkletProcessor">#AudioWorkletProcessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorkletProcessor">1.32.4. 
 The AudioWorkletProcessor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioworkletprocessor">
-   <b><a href="#audioworkletprocessor">#audioworkletprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioworkletprocessor" class="dfn-panel" data-for="audioworkletprocessor" id="infopanel-for-audioworkletprocessor" role="dialog">
+   <span id="infopaneltitle-for-audioworkletprocessor" style="display:none">Info about the 'AudioWorkletProcessor' definition.</span><b><a href="#audioworkletprocessor">#audioworkletprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioworkletprocessor"> API Overview</a>
     <li><a href="#ref-for-audioworkletprocessor①">1.1.1. 
@@ -24579,8 +24651,8 @@ VU Meter Node</a>
 Rendering an Audio Graph</a> <a href="#ref-for-audioworkletprocessor④②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocesscallback-inputs">
-   <b><a href="#dom-audioworkletprocesscallback-inputs">#dom-audioworkletprocesscallback-inputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocesscallback-inputs" class="dfn-panel" data-for="dom-audioworkletprocesscallback-inputs" id="infopanel-for-dom-audioworkletprocesscallback-inputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocesscallback-inputs" style="display:none">Info about the 'inputs' definition.</span><b><a href="#dom-audioworkletprocesscallback-inputs">#dom-audioworkletprocesscallback-inputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocesscallback-inputs">1.32.4.3.1. 
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audioworkletprocesscallback-inputs①">(2)</a> <a href="#ref-for-dom-audioworkletprocesscallback-inputs②">(3)</a>
@@ -24588,8 +24660,8 @@ Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audio
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocesscallback-outputs">
-   <b><a href="#dom-audioworkletprocesscallback-outputs">#dom-audioworkletprocesscallback-outputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocesscallback-outputs" class="dfn-panel" data-for="dom-audioworkletprocesscallback-outputs" id="infopanel-for-dom-audioworkletprocesscallback-outputs" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocesscallback-outputs" style="display:none">Info about the 'outputs' definition.</span><b><a href="#dom-audioworkletprocesscallback-outputs">#dom-audioworkletprocesscallback-outputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocesscallback-outputs">1.32.4.3.1. 
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audioworkletprocesscallback-outputs①">(2)</a> <a href="#ref-for-dom-audioworkletprocesscallback-outputs②">(3)</a>
@@ -24597,8 +24669,8 @@ Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audio
 Rendering an Audio Graph</a> <a href="#ref-for-dom-audioworkletprocesscallback-outputs④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocesscallback-parameters">
-   <b><a href="#dom-audioworkletprocesscallback-parameters">#dom-audioworkletprocesscallback-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocesscallback-parameters" class="dfn-panel" data-for="dom-audioworkletprocesscallback-parameters" id="infopanel-for-dom-audioworkletprocesscallback-parameters" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocesscallback-parameters" style="display:none">Info about the 'parameters' definition.</span><b><a href="#dom-audioworkletprocesscallback-parameters">#dom-audioworkletprocesscallback-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocesscallback-parameters">1.32.4.3.1. 
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audioworkletprocesscallback-parameters①">(2)</a>
@@ -24606,15 +24678,15 @@ Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-dom-audio
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocessor-node-reference-slot">
-   <b><a href="#dom-audioworkletprocessor-node-reference-slot">#dom-audioworkletprocessor-node-reference-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocessor-node-reference-slot" class="dfn-panel" data-for="dom-audioworkletprocessor-node-reference-slot" id="infopanel-for-dom-audioworkletprocessor-node-reference-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocessor-node-reference-slot" style="display:none">Info about the '[[node reference]]' definition.</span><b><a href="#dom-audioworkletprocessor-node-reference-slot">#dom-audioworkletprocessor-node-reference-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocessor-node-reference-slot">1.32.4.1. 
 Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocessor-callable-process-slot">
-   <b><a href="#dom-audioworkletprocessor-callable-process-slot">#dom-audioworkletprocessor-callable-process-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocessor-callable-process-slot" class="dfn-panel" data-for="dom-audioworkletprocessor-callable-process-slot" id="infopanel-for-dom-audioworkletprocessor-callable-process-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocessor-callable-process-slot" style="display:none">Info about the '[[callable process]]' definition.</span><b><a href="#dom-audioworkletprocessor-callable-process-slot">#dom-audioworkletprocessor-callable-process-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocessor-callable-process-slot">1.5.3. AudioNode Lifetime</a>
     <li><a href="#ref-for-dom-audioworkletprocessor-callable-process-slot①">1.32.4.1. 
@@ -24623,8 +24695,8 @@ Constructors</a>
 Rendering an Audio Graph</a> <a href="#ref-for-dom-audioworkletprocessor-callable-process-slot③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocessor-audioworkletprocessor">
-   <b><a href="#dom-audioworkletprocessor-audioworkletprocessor">#dom-audioworkletprocessor-audioworkletprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocessor-audioworkletprocessor" class="dfn-panel" data-for="dom-audioworkletprocessor-audioworkletprocessor" id="infopanel-for-dom-audioworkletprocessor-audioworkletprocessor" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocessor-audioworkletprocessor" style="display:none">Info about the 'AudioWorkletProcessor()' definition.</span><b><a href="#dom-audioworkletprocessor-audioworkletprocessor">#dom-audioworkletprocessor-audioworkletprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocessor-audioworkletprocessor">1.32.3.1. 
 Constructors</a>
@@ -24632,8 +24704,8 @@ Constructors</a>
 The AudioWorkletProcessor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioworkletprocessor-port">
-   <b><a href="#dom-audioworkletprocessor-port">#dom-audioworkletprocessor-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioworkletprocessor-port" class="dfn-panel" data-for="dom-audioworkletprocessor-port" id="infopanel-for-dom-audioworkletprocessor-port" role="dialog">
+   <span id="infopaneltitle-for-dom-audioworkletprocessor-port" style="display:none">Info about the 'port' definition.</span><b><a href="#dom-audioworkletprocessor-port">#dom-audioworkletprocessor-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioworkletprocessor-port">1.32.4. 
 The AudioWorkletProcessor Interface</a>
@@ -24642,8 +24714,8 @@ Constructors</a>
     <li><a href="#ref-for-dom-audioworkletprocessor-port②">1.32.4.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process">
-   <b><a href="#process">#process</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process" class="dfn-panel" data-for="process" id="infopanel-for-process" role="dialog">
+   <span id="infopaneltitle-for-process" style="display:none">Info about the 'process()' definition.</span><b><a href="#process">#process</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process">1.32.4. 
 The AudioWorkletProcessor Interface</a>
@@ -24651,15 +24723,17 @@ The AudioWorkletProcessor Interface</a>
 Callback AudioWorkletProcessCallback</a> <a href="#ref-for-process②">(2)</a> <a href="#ref-for-process③">(3)</a> <a href="#ref-for-process④">(4)</a> <a href="#ref-for-process⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parameterdescriptors">
-   <b><a href="#parameterdescriptors">#parameterdescriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parameterdescriptors" class="dfn-panel" data-for="parameterdescriptors" id="infopanel-for-parameterdescriptors" role="dialog">
+   <span id="infopaneltitle-for-parameterdescriptors" style="display:none">Info about the 'parameterDescriptors' definition.</span><b><a href="#parameterdescriptors">#parameterdescriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameterdescriptors">1.32.1. 
 Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audioworkletprocess-callback-parameters">
-   <b><a href="#audioworkletprocess-callback-parameters">#audioworkletprocess-callback-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audioworkletprocess-callback-parameters" class="dfn-panel" data-for="audioworkletprocess-callback-parameters" id="infopanel-for-audioworkletprocess-callback-parameters" role="dialog">
+   <span id="infopaneltitle-for-audioworkletprocess-callback-parameters" style="display:none">Info about the '1.32.4.3.1. 
+Callback AudioWorkletProcessCallback Parameters
+' definition.</span><b><a href="#audioworkletprocess-callback-parameters">#audioworkletprocess-callback-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioworkletprocess-callback-parameters">1.32.4. 
 The AudioWorkletProcessor Interface</a>
@@ -24669,15 +24743,16 @@ Callback AudioWorkletProcessCallback</a> <a href="#ref-for-audioworkletprocess-c
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-audioworkletprocess-callback-parameters">(2)</a> <a href="#ref-for-audioworkletprocess-callback-parameters④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AudioParamDescriptor">
-   <b><a href="#AudioParamDescriptor">#AudioParamDescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AudioParamDescriptor" class="dfn-panel" data-for="AudioParamDescriptor" id="infopanel-for-AudioParamDescriptor" role="dialog">
+   <span id="infopaneltitle-for-AudioParamDescriptor" style="display:none">Info about the '1.32.4.4. 
+AudioParamDescriptor' definition.</span><b><a href="#AudioParamDescriptor">#AudioParamDescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioParamDescriptor">1.32.4.4. 
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audioparamdescriptor">
-   <b><a href="#dictdef-audioparamdescriptor">#dictdef-audioparamdescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audioparamdescriptor" class="dfn-panel" data-for="dictdef-audioparamdescriptor" id="infopanel-for-dictdef-audioparamdescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audioparamdescriptor" style="display:none">Info about the 'AudioParamDescriptor' definition.</span><b><a href="#dictdef-audioparamdescriptor">#dictdef-audioparamdescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audioparamdescriptor">1.32.3.2. 
 Attributes</a>
@@ -24689,8 +24764,8 @@ AudioParamDescriptor</a> <a href="#ref-for-dictdef-audioparamdescriptor③">(2)<
 Dictionary AudioParamDescriptor Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparamdescriptor-automationrate">
-   <b><a href="#dom-audioparamdescriptor-automationrate">#dom-audioparamdescriptor-automationrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparamdescriptor-automationrate" class="dfn-panel" data-for="dom-audioparamdescriptor-automationrate" id="infopanel-for-dom-audioparamdescriptor-automationrate" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparamdescriptor-automationrate" style="display:none">Info about the 'automationRate' definition.</span><b><a href="#dom-audioparamdescriptor-automationrate">#dom-audioparamdescriptor-automationrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparamdescriptor-automationrate">1.32.3.1. 
 Constructors</a>
@@ -24698,8 +24773,8 @@ Constructors</a>
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparamdescriptor-defaultvalue">
-   <b><a href="#dom-audioparamdescriptor-defaultvalue">#dom-audioparamdescriptor-defaultvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparamdescriptor-defaultvalue" class="dfn-panel" data-for="dom-audioparamdescriptor-defaultvalue" id="infopanel-for-dom-audioparamdescriptor-defaultvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparamdescriptor-defaultvalue" style="display:none">Info about the 'defaultValue' definition.</span><b><a href="#dom-audioparamdescriptor-defaultvalue">#dom-audioparamdescriptor-defaultvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparamdescriptor-defaultvalue">1.32.2.2. 
 Methods</a>
@@ -24709,8 +24784,8 @@ Constructors</a>
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparamdescriptor-maxvalue">
-   <b><a href="#dom-audioparamdescriptor-maxvalue">#dom-audioparamdescriptor-maxvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparamdescriptor-maxvalue" class="dfn-panel" data-for="dom-audioparamdescriptor-maxvalue" id="infopanel-for-dom-audioparamdescriptor-maxvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparamdescriptor-maxvalue" style="display:none">Info about the 'maxValue' definition.</span><b><a href="#dom-audioparamdescriptor-maxvalue">#dom-audioparamdescriptor-maxvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparamdescriptor-maxvalue">1.32.2.2. 
 Methods</a>
@@ -24720,8 +24795,8 @@ Constructors</a>
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparamdescriptor-minvalue">
-   <b><a href="#dom-audioparamdescriptor-minvalue">#dom-audioparamdescriptor-minvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparamdescriptor-minvalue" class="dfn-panel" data-for="dom-audioparamdescriptor-minvalue" id="infopanel-for-dom-audioparamdescriptor-minvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparamdescriptor-minvalue" style="display:none">Info about the 'minValue' definition.</span><b><a href="#dom-audioparamdescriptor-minvalue">#dom-audioparamdescriptor-minvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparamdescriptor-minvalue">1.32.2.2. 
 Methods</a>
@@ -24731,8 +24806,8 @@ Constructors</a>
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioparamdescriptor-name">
-   <b><a href="#dom-audioparamdescriptor-name">#dom-audioparamdescriptor-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioparamdescriptor-name" class="dfn-panel" data-for="dom-audioparamdescriptor-name" id="infopanel-for-dom-audioparamdescriptor-name" role="dialog">
+   <span id="infopaneltitle-for-dom-audioparamdescriptor-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-audioparamdescriptor-name">#dom-audioparamdescriptor-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioparamdescriptor-name">1.32.2.2. 
 Methods</a>
@@ -24742,8 +24817,8 @@ Constructors</a>
 AudioParamDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="control-thread">
-   <b><a href="#control-thread">#control-thread</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-control-thread" class="dfn-panel" data-for="control-thread" id="infopanel-for-control-thread" role="dialog">
+   <span id="infopaneltitle-for-control-thread" style="display:none">Info about the 'control thread' definition.</span><b><a href="#control-thread">#control-thread</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-control-thread">1.1.2. 
 Methods</a>
@@ -24763,8 +24838,8 @@ Asynchronous Operations</a> <a href="#ref-for-control-thread①①">(2)</a>
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rendering-thread">
-   <b><a href="#rendering-thread">#rendering-thread</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rendering-thread" class="dfn-panel" data-for="rendering-thread" id="infopanel-for-rendering-thread" role="dialog">
+   <span id="infopaneltitle-for-rendering-thread" style="display:none">Info about the 'rendering thread' definition.</span><b><a href="#rendering-thread">#rendering-thread</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendering-thread">1.1.2. 
 Methods</a>
@@ -24790,8 +24865,9 @@ Asynchronous Operations</a> <a href="#ref-for-rendering-thread①⑦">(2)</a> <a
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="control-message-queue">
-   <b><a href="#control-message-queue">#control-message-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-control-message-queue" class="dfn-panel" data-for="control-message-queue" id="infopanel-for-control-message-queue" role="dialog">
+   <span id="infopaneltitle-for-control-message-queue" style="display:none">Info about the 'control message
+queue' definition.</span><b><a href="#control-message-queue">#control-message-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-control-message-queue">2.2. 
 Control Thread and Rendering Thread</a> <a href="#ref-for-control-message-queue">(2)</a> <a href="#ref-for-control-message-queue①">(3)</a> <a href="#ref-for-control-message-queue②">(4)</a> <a href="#ref-for-control-message-queue③">(5)</a> <a href="#ref-for-control-message-queue④">(6)</a> <a href="#ref-for-control-message-queue⑤">(7)</a>
@@ -24801,8 +24877,9 @@ Asynchronous Operations</a>
 Rendering an Audio Graph</a> <a href="#ref-for-control-message-queue">(2)</a> <a href="#ref-for-control-message-queue⑦">(3)</a> <a href="#ref-for-control-message-queue⑧">(4)</a> <a href="#ref-for-control-message-queue⑨">(5)</a> <a href="#ref-for-control-message-queue①⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="control-message">
-   <b><a href="#control-message">#control-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-control-message" class="dfn-panel" data-for="control-message" id="infopanel-for-control-message" role="dialog">
+   <span id="infopaneltitle-for-control-message" style="display:none">Info about the 'control
+messages' definition.</span><b><a href="#control-message">#control-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-control-message">1.2.1. 
 Constructors</a> <a href="#ref-for-control-message①">(2)</a>
@@ -24820,8 +24897,8 @@ Control Thread and Rendering Thread</a> <a href="#ref-for-control-message①②"
 Asynchronous Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queuing">
-   <b><a href="#queuing">#queuing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queuing" class="dfn-panel" data-for="queuing" id="infopanel-for-queuing" role="dialog">
+   <span id="infopaneltitle-for-queuing" style="display:none">Info about the 'Queuing a control message' definition.</span><b><a href="#queuing">#queuing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queuing">1.2.3. 
 Methods</a> <a href="#ref-for-queuing①">(2)</a> <a href="#ref-for-queuing②">(3)</a>
@@ -24838,22 +24915,22 @@ Rendering an Audio Graph</a>
     <li><a href="#ref-for-queuing⑨">2.5. Unloading a document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="oldest-message">
-   <b><a href="#oldest-message">#oldest-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-oldest-message" class="dfn-panel" data-for="oldest-message" id="infopanel-for-oldest-message" role="dialog">
+   <span id="infopaneltitle-for-oldest-message" style="display:none">Info about the 'oldest message' definition.</span><b><a href="#oldest-message">#oldest-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-oldest-message">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-oldest-message①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="swap">
-   <b><a href="#swap">#swap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-swap" class="dfn-panel" data-for="swap" id="infopanel-for-swap" role="dialog">
+   <span id="infopaneltitle-for-swap" style="display:none">Info about the 'Swapping' definition.</span><b><a href="#swap">#swap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-swap">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="render-quantum">
-   <b><a href="#render-quantum">#render-quantum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-render-quantum" class="dfn-panel" data-for="render-quantum" id="infopanel-for-render-quantum" role="dialog">
+   <span id="infopaneltitle-for-render-quantum" style="display:none">Info about the 'render quantum' definition.</span><b><a href="#render-quantum">#render-quantum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-render-quantum">1.1.1. 
 Attributes</a>
@@ -24876,15 +24953,15 @@ Attributes</a>
 Callback AudioWorkletProcessCallback Parameters </a> <a href="#ref-for-render-quantum①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="render-quantum-size">
-   <b><a href="#render-quantum-size">#render-quantum-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-render-quantum-size" class="dfn-panel" data-for="render-quantum-size" id="infopanel-for-render-quantum-size" role="dialog">
+   <span id="infopaneltitle-for-render-quantum-size" style="display:none">Info about the 'render quantum size' definition.</span><b><a href="#render-quantum-size">#render-quantum-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-render-quantum-size">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="atomically">
-   <b><a href="#atomically">#atomically</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-atomically" class="dfn-panel" data-for="atomically" id="infopanel-for-atomically" role="dialog">
+   <span id="infopaneltitle-for-atomically" style="display:none">Info about the 'atomically' definition.</span><b><a href="#atomically">#atomically</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomically">1.1.1. 
 Attributes</a>
@@ -24894,15 +24971,15 @@ Processing</a>
 Rendering an Audio Graph</a> <a href="#ref-for-atomically③">(2)</a> <a href="#ref-for-atomically④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseaudiocontext-associated-task-queue">
-   <b><a href="#baseaudiocontext-associated-task-queue">#baseaudiocontext-associated-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseaudiocontext-associated-task-queue" class="dfn-panel" data-for="baseaudiocontext-associated-task-queue" id="infopanel-for-baseaudiocontext-associated-task-queue" role="dialog">
+   <span id="infopaneltitle-for-baseaudiocontext-associated-task-queue" style="display:none">Info about the 'associated task queue' definition.</span><b><a href="#baseaudiocontext-associated-task-queue">#baseaudiocontext-associated-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseaudiocontext-associated-task-queue">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-baseaudiocontext-associated-task-queue①">(2)</a> <a href="#ref-for-baseaudiocontext-associated-task-queue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseaudiocontext-current-frame-slot">
-   <b><a href="#dom-baseaudiocontext-current-frame-slot">#dom-baseaudiocontext-current-frame-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseaudiocontext-current-frame-slot" class="dfn-panel" data-for="dom-baseaudiocontext-current-frame-slot" id="infopanel-for-dom-baseaudiocontext-current-frame-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-baseaudiocontext-current-frame-slot" style="display:none">Info about the '[[current frame]]' definition.</span><b><a href="#dom-baseaudiocontext-current-frame-slot">#dom-baseaudiocontext-current-frame-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseaudiocontext-current-frame-slot">1.32.2.1. 
 Attributes</a>
@@ -24910,71 +24987,72 @@ Attributes</a>
 Rendering an Audio Graph</a> <a href="#ref-for-dom-baseaudiocontext-current-frame-slot②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visit">
-   <b><a href="#visit">#visit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visit" class="dfn-panel" data-for="visit" id="infopanel-for-visit" role="dialog">
+   <span id="infopaneltitle-for-visit" style="display:none">Info about the 'Visiting a node' definition.</span><b><a href="#visit">#visit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visit">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-visit①">(2)</a> <a href="#ref-for-visit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input-audioparam-buffer">
-   <b><a href="#input-audioparam-buffer">#input-audioparam-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input-audioparam-buffer" class="dfn-panel" data-for="input-audioparam-buffer" id="infopanel-for-input-audioparam-buffer" role="dialog">
+   <span id="infopaneltitle-for-input-audioparam-buffer" style="display:none">Info about the '
+input AudioParam buffer' definition.</span><b><a href="#input-audioparam-buffer">#input-audioparam-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-audioparam-buffer">1.6.3. 
 Computation of Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input-buffer">
-   <b><a href="#input-buffer">#input-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input-buffer" class="dfn-panel" data-for="input-buffer" id="infopanel-for-input-buffer" role="dialog">
+   <span id="infopaneltitle-for-input-buffer" style="display:none">Info about the 'input buffer' definition.</span><b><a href="#input-buffer">#input-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-buffer">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-input-buffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mute">
-   <b><a href="#mute">#mute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mute" class="dfn-panel" data-for="mute" id="infopanel-for-mute" role="dialog">
+   <span id="infopaneltitle-for-mute" style="display:none">Info about the 'Muting' definition.</span><b><a href="#mute">#mute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mute">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-for-reading">
-   <b><a href="#available-for-reading">#available-for-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-for-reading" class="dfn-panel" data-for="available-for-reading" id="infopanel-for-available-for-reading" role="dialog">
+   <span id="infopaneltitle-for-available-for-reading" style="display:none">Info about the 'Making a buffer available for reading' definition.</span><b><a href="#available-for-reading">#available-for-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-for-reading">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-available-for-reading①">(2)</a> <a href="#ref-for-available-for-reading②">(3)</a> <a href="#ref-for-available-for-reading③">(4)</a> <a href="#ref-for-available-for-reading④">(5)</a> <a href="#ref-for-available-for-reading⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="recording-the-input">
-   <b><a href="#recording-the-input">#recording-the-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-recording-the-input" class="dfn-panel" data-for="recording-the-input" id="infopanel-for-recording-the-input" role="dialog">
+   <span id="infopaneltitle-for-recording-the-input" style="display:none">Info about the 'Recording the input' definition.</span><b><a href="#recording-the-input">#recording-the-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-recording-the-input">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computing-a-block-of-audio">
-   <b><a href="#computing-a-block-of-audio">#computing-a-block-of-audio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computing-a-block-of-audio" class="dfn-panel" data-for="computing-a-block-of-audio" id="infopanel-for-computing-a-block-of-audio" role="dialog">
+   <span id="infopaneltitle-for-computing-a-block-of-audio" style="display:none">Info about the 'Computing a block of audio' definition.</span><b><a href="#computing-a-block-of-audio">#computing-a-block-of-audio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computing-a-block-of-audio">2.4. 
 Rendering an Audio Graph</a> <a href="#ref-for-computing-a-block-of-audio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processing-input-buffer">
-   <b><a href="#processing-input-buffer">#processing-input-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processing-input-buffer" class="dfn-panel" data-for="processing-input-buffer" id="infopanel-for-processing-input-buffer" role="dialog">
+   <span id="infopaneltitle-for-processing-input-buffer" style="display:none">Info about the 'Processing an input buffer' definition.</span><b><a href="#processing-input-buffer">#processing-input-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processing-input-buffer">2.4. 
 Rendering an Audio Graph</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mixing-rules">
-   <b><a href="#mixing-rules">#mixing-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mixing-rules" class="dfn-panel" data-for="mixing-rules" id="infopanel-for-mixing-rules" role="dialog">
+   <span id="infopaneltitle-for-mixing-rules" style="display:none">Info about the 'mixing rules' definition.</span><b><a href="#mixing-rules">#mixing-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mixing-rules">4. 
 Channel Up-Mixing and Down-Mixing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="up-mixing">
-   <b><a href="#up-mixing">#up-mixing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-up-mixing" class="dfn-panel" data-for="up-mixing" id="infopanel-for-up-mixing" role="dialog">
+   <span id="infopaneltitle-for-up-mixing" style="display:none">Info about the 'up-mixing' definition.</span><b><a href="#up-mixing">#up-mixing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-up-mixing">4. 
 Channel Up-Mixing and Down-Mixing</a> <a href="#ref-for-up-mixing①">(2)</a>
@@ -24982,8 +25060,8 @@ Channel Up-Mixing and Down-Mixing</a> <a href="#ref-for-up-mixing①">(2)</a>
 Speaker Channel Layouts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="down-mixing">
-   <b><a href="#down-mixing">#down-mixing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-down-mixing" class="dfn-panel" data-for="down-mixing" id="infopanel-for-down-mixing" role="dialog">
+   <span id="infopaneltitle-for-down-mixing" style="display:none">Info about the 'down-mixing' definition.</span><b><a href="#down-mixing">#down-mixing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-down-mixing">4. 
 Channel Up-Mixing and Down-Mixing</a> <a href="#ref-for-down-mixing①">(2)</a>
@@ -24991,8 +25069,8 @@ Channel Up-Mixing and Down-Mixing</a> <a href="#ref-for-down-mixing①">(2)</a>
 Speaker Channel Layouts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-pcm">
-   <b><a href="#linear-pcm">#linear-pcm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-pcm" class="dfn-panel" data-for="linear-pcm" id="infopanel-for-linear-pcm" role="dialog">
+   <span id="infopaneltitle-for-linear-pcm" style="display:none">Info about the 'Linear pulse code modulation' definition.</span><b><a href="#linear-pcm">#linear-pcm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-pcm">1.1.2. 
 Methods</a> <a href="#ref-for-linear-pcm①">(2)</a> <a href="#ref-for-linear-pcm②">(3)</a>
@@ -25004,59 +25082,115 @@ The AudioBuffer Interface</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WebBluetoothCG/web-bluetooth/index.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/index.html
@@ -6081,96 +6081,96 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
    <li><a href="#write-without-response">Write Without Response</a><span>, in § 9</span>
    <li><a href="#dom-bluetoothcharacteristicproperties-writewithoutresponse">writeWithoutResponse</a><span>, in § 5.4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'org.bluetooth.characteristic.body_sensor_location' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.body_sensor_location.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1.1. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-①" role="menu">
+   <span id="infopaneltitle-for-term-for-①" style="display:none">Info about the 'org.bluetooth.characteristic.gap.appearance' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.appearance.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_control_point.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_control_point.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-②" role="menu">
+   <span id="infopaneltitle-for-term-for-②" style="display:none">Info about the 'org.bluetooth.characteristic.heart_rate_control_point' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_control_point.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_control_point.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1.1. Examples</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-③" role="menu">
+   <span id="infopaneltitle-for-term-for-③" style="display:none">Info about the 'org.bluetooth.characteristic.heart_rate_measurement' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.heart_rate_measurement.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1.1. Examples</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-④" role="menu">
+   <span id="infopaneltitle-for-term-for-④" style="display:none">Info about the 'org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑤" role="menu">
+   <span id="infopaneltitle-for-term-for-⑤" style="display:none">Info about the 'org.bluetooth.descriptor.gatt.characteristic_presentation_format' external reference.</span><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_presentation_format.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑥" role="menu">
+   <span id="infopaneltitle-for-term-for-⑥" style="display:none">Info about the 'org.bluetooth.descriptor.gatt.client_characteristic_configuration' external reference.</span><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.client_characteristic_configuration.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.cycling_power.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.cycling_power.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑦" role="menu">
+   <span id="infopaneltitle-for-term-for-⑦" style="display:none">Info about the 'org.bluetooth.service.cycling_power' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.cycling_power.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.cycling_power.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑧" role="menu">
+   <span id="infopaneltitle-for-term-for-⑧" style="display:none">Info about the 'org.bluetooth.service.heart_rate' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1.1. Examples</a>
     <li><a href="#termref-for-">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#">https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑨" role="menu">
+   <span id="infopaneltitle-for-term-for-⑨" style="display:none">Info about the 'shortened local name' external reference.</span><a href="https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#">https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1. Global Bluetooth device properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortcontroller">
-   <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortcontroller" class="dfn-panel" data-for="term-for-abortcontroller" id="infopanel-for-term-for-abortcontroller" role="menu">
+   <span id="infopaneltitle-for-term-for-abortcontroller" style="display:none">Info about the 'AbortController' external reference.</span><a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">4.2. BluetoothDevice</a> <a href="#ref-for-abortsignal①">(2)</a> <a href="#ref-for-abortsignal②">(3)</a> <a href="#ref-for-abortsignal③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-event①">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-dictdef-eventinit①">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. Device Discovery</a>
     <li><a href="#ref-for-eventtarget①">4.2. BluetoothDevice</a>
@@ -6178,33 +6178,33 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-eventtarget③">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child" style="display:none">Info about the 'children' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">5.6.1. Bluetooth Tree</a> <a href="#ref-for-concept-tree-child①">(2)</a> <a href="#ref-for-concept-tree-child②">(3)</a> <a href="#ref-for-concept-tree-child③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4.2.1. Handling Visibility Change</a> <a href="#ref-for-concept-document①">(2)</a>
     <li><a href="#ref-for-concept-document②">4.2.2. Handling Document Loss of Full Activity</a> <a href="#ref-for-concept-document③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-concept-event-fire①">4.2.3. Responding to Advertising Events</a>
@@ -6214,34 +6214,34 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-concept-event-fire⑤">5.6.5. Responding to Service Changes</a> <a href="#ref-for-concept-event-fire⑥">(2)</a> <a href="#ref-for-concept-event-fire⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-participate">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-participate">https://dom.spec.whatwg.org/#concept-tree-participate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-participate" class="dfn-panel" data-for="term-for-concept-tree-participate" id="infopanel-for-term-for-concept-tree-participate" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-participate" style="display:none">Info about the 'participate in a tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-participate">https://dom.spec.whatwg.org/#concept-tree-participate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-participate">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-objects" class="dfn-panel" data-for="term-for-sec-array-objects" id="infopanel-for-term-for-sec-array-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-objects" style="display:none">Info about the 'Array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-objects">3. Device Discovery</a> <a href="#ref-for-sec-array-objects①">(2)</a>
     <li><a href="#ref-for-sec-array-objects②">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.map">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.map">https://tc39.github.io/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.map" class="dfn-panel" data-for="term-for-sec-array.prototype.map" id="infopanel-for-term-for-sec-array.prototype.map" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.map" style="display:none">Info about the 'Array.prototype.map' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.map">https://tc39.github.io/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.map">3. Device Discovery</a> <a href="#ref-for-sec-array.prototype.map①">(2)</a>
     <li><a href="#ref-for-sec-array.prototype.map②">9. Terminology and Conventions</a> <a href="#ref-for-sec-array.prototype.map③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-arraybuffer-constructor">https://tc39.github.io/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-constructor" class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor" id="infopanel-for-term-for-sec-arraybuffer-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-constructor" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-constructor">https://tc39.github.io/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-constructor">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-sec-arraybuffer-constructor①">(2)</a>
     <li><a href="#ref-for-sec-arraybuffer-constructor②">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-sec-arraybuffer-constructor③">(2)</a> <a href="#ref-for-sec-arraybuffer-constructor④">(3)</a>
@@ -6250,20 +6250,20 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-sec-arraybuffer-constructor⑨">9. Terminology and Conventions</a> <a href="#ref-for-sec-arraybuffer-constructor①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-canonicalnumericindexstring">
-   <a href="https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring">https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-canonicalnumericindexstring" class="dfn-panel" data-for="term-for-sec-canonicalnumericindexstring" id="infopanel-for-term-for-sec-canonicalnumericindexstring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-canonicalnumericindexstring" style="display:none">Info about the 'CanonicalNumericIndexString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring">https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-canonicalnumericindexstring">3. Device Discovery</a> <a href="#ref-for-sec-canonicalnumericindexstring①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdataproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdataproperty" class="dfn-panel" data-for="term-for-sec-createdataproperty" id="infopanel-for-term-for-sec-createdataproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdataproperty" style="display:none">Info about the 'CreateDataProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdataproperty">3. Device Discovery</a> <a href="#ref-for-sec-createdataproperty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-dataview-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-dataview-constructor">https://tc39.github.io/ecma262/#sec-dataview-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-dataview-constructor" class="dfn-panel" data-for="term-for-sec-dataview-constructor" id="infopanel-for-term-for-sec-dataview-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-dataview-constructor" style="display:none">Info about the 'DataView' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-dataview-constructor">https://tc39.github.io/ecma262/#sec-dataview-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-dataview-constructor">1.1. Examples</a>
     <li><a href="#ref-for-sec-dataview-constructor①">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-sec-dataview-constructor②">(2)</a> <a href="#ref-for-sec-dataview-constructor③">(3)</a> <a href="#ref-for-sec-dataview-constructor④">(4)</a>
@@ -6275,14 +6275,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-sec-dataview-constructor①⑥">9. Terminology and Conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isinteger">
-   <a href="https://tc39.github.io/ecma262/#sec-isinteger">https://tc39.github.io/ecma262/#sec-isinteger</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isinteger" class="dfn-panel" data-for="term-for-sec-isinteger" id="infopanel-for-term-for-sec-isinteger" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isinteger" style="display:none">Info about the 'IsInteger' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isinteger">https://tc39.github.io/ecma262/#sec-isinteger</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isinteger">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'Promise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise-objects">https://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">2.5. Exposing Bluetooth availability</a>
     <li><a href="#ref-for-sec-promise-objects①">3. Device Discovery</a> <a href="#ref-for-sec-promise-objects②">(2)</a> <a href="#ref-for-sec-promise-objects③">(3)</a> <a href="#ref-for-sec-promise-objects④">(4)</a>
@@ -6290,41 +6290,41 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-sec-promise-objects⑥">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-sec-promise-objects⑦">(2)</a> <a href="#ref-for-sec-promise-objects⑧">(3)</a> <a href="#ref-for-sec-promise-objects⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-set-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-set-objects">https://tc39.github.io/ecma262/#sec-set-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-set-objects" class="dfn-panel" data-for="term-for-sec-set-objects" id="infopanel-for-term-for-sec-set-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-set-objects" style="display:none">Info about the 'Set' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-set-objects">https://tc39.github.io/ecma262/#sec-set-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-set-objects">3. Device Discovery</a> <a href="#ref-for-sec-set-objects①">(2)</a>
     <li><a href="#ref-for-sec-set-objects②">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">3. Device Discovery</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">(3)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(4)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror④">(5)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑤">(6)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑥">(7)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑦">(8)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑧">(9)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑨">(10)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①⓪">(11)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①①">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①②">(2)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①③">6.1. Standardized UUIDs</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-constructors">
-   <a href="https://tc39.github.io/ecma262/#sec-typedarray-constructors">https://tc39.github.io/ecma262/#sec-typedarray-constructors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-constructors" class="dfn-panel" data-for="term-for-sec-typedarray-constructors" id="infopanel-for-term-for-sec-typedarray-constructors" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-constructors" style="display:none">Info about the 'TypedArray' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-typedarray-constructors">https://tc39.github.io/ecma262/#sec-typedarray-constructors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-constructors">9. Terminology and Conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" style="display:none">Info about the '[[OwnPropertyKeys]]' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">3. Device Discovery</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys①">(2)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys②">(3)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">3. Device Discovery</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots②">3.1. Permission API Integration</a>
@@ -6335,8 +6335,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots①①">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">3. Device Discovery</a>
     <li><a href="#ref-for-sec-code-realms①">3.1. Permission API Integration</a>
@@ -6346,47 +6346,47 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-sec-code-realms⑤">5.6.3. Responding to Disconnection</a> <a href="#ref-for-sec-code-realms⑥">(2)</a> <a href="#ref-for-sec-code-realms⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom" id="infopanel-for-term-for-utf-8-decode-without-bom" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom" style="display:none">Info about the 'utf-8 decode without bom' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom">4.1. Global Bluetooth device properties</a>
     <li><a href="#ref-for-utf-8-decode-without-bom①">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">3. Device Discovery</a> <a href="#ref-for-utf-8-encode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-fingerprinting-surface">
-   <a href="https://w3c.github.io/fingerprinting-guidance/#dfn-fingerprinting-surface">https://w3c.github.io/fingerprinting-guidance/#dfn-fingerprinting-surface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-fingerprinting-surface" class="dfn-panel" data-for="term-for-dfn-fingerprinting-surface" id="infopanel-for-term-for-dfn-fingerprinting-surface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-fingerprinting-surface" style="display:none">Info about the 'fingerprinting surface' external reference.</span><a href="https://w3c.github.io/fingerprinting-guidance/#dfn-fingerprinting-surface">https://w3c.github.io/fingerprinting-guidance/#dfn-fingerprinting-surface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fingerprinting-surface">2.5. Exposing Bluetooth availability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. Device Discovery</a>
     <li><a href="#ref-for-eventhandler①">5.6.6. IDL event handlers</a> <a href="#ref-for-eventhandler②">(2)</a> <a href="#ref-for-eventhandler③">(3)</a> <a href="#ref-for-eventhandler④">(4)</a> <a href="#ref-for-eventhandler⑤">(5)</a> <a href="#ref-for-eventhandler⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">8. Extensions to the Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3. Device Discovery</a>
     <li><a href="#ref-for-browsing-context①">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">3. Device Discovery</a>
     <li><a href="#ref-for-current-settings-object①">3.1. Permission API Integration</a> <a href="#ref-for-current-settings-object②">(2)</a>
@@ -6395,32 +6395,32 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-current-settings-object⑥">4.2.2. Handling Document Loss of Full Activity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">4.2. BluetoothDevice</a> <a href="#ref-for-enqueue-the-following-steps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">5.6.6. IDL event handlers</a> <a href="#ref-for-event-handler-idl-attributes①">(2)</a> <a href="#ref-for-event-handler-idl-attributes②">(3)</a> <a href="#ref-for-event-handler-idl-attributes③">(4)</a> <a href="#ref-for-event-handler-idl-attributes④">(5)</a> <a href="#ref-for-event-handler-idl-attributes⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">4.2.2. Handling Document Loss of Full Activity</a> <a href="#ref-for-fully-active①">(2)</a> <a href="#ref-for-fully-active②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-global-object①">4. Device Representation</a>
@@ -6428,14 +6428,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-global-object③">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. Device Discovery</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a>
     <li><a href="#ref-for-in-parallel③">3.2. Overall Bluetooth availability</a> <a href="#ref-for-in-parallel④">(2)</a>
@@ -6447,32 +6447,32 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-in-parallel①⑤">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-in-parallel①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialise-the-document-object" class="dfn-panel" data-for="term-for-initialise-the-document-object" id="infopanel-for-term-for-initialise-the-document-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialise-the-document-object" style="display:none">Info about the 'initializing the document object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialise-the-document-object">3. Device Discovery</a> <a href="#ref-for-initialise-the-document-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-secure-context" class="dfn-panel" data-for="term-for-non-secure-context" id="infopanel-for-term-for-non-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-non-secure-context" style="display:none">Info about the 'non-secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-secure-context">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.2. Overall Bluetooth availability</a> <a href="#ref-for-queue-a-task①">(2)</a> <a href="#ref-for-queue-a-task②">(3)</a> <a href="#ref-for-queue-a-task③">(4)</a>
     <li><a href="#ref-for-queue-a-task④">4.2. BluetoothDevice</a> <a href="#ref-for-queue-a-task⑤">(2)</a>
@@ -6485,16 +6485,16 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-queue-a-task①⑦">5.6.5. Responding to Service Changes</a> <a href="#ref-for-queue-a-task①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3. Device Discovery</a>
     <li><a href="#ref-for-concept-relevant-global①">3.1. Permission API Integration</a>
     <li><a href="#ref-for-concept-relevant-global②">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-relevant-settings-object①">4.2.3. Responding to Advertising Events</a>
@@ -6503,8 +6503,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-relevant-settings-object④">5.6.5. Responding to Service Changes</a> <a href="#ref-for-relevant-settings-object⑤">(2)</a> <a href="#ref-for-relevant-settings-object⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-responsible-event-loop①">4.2.3. Responding to Advertising Events</a>
@@ -6512,56 +6512,56 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-responsible-event-loop③">5.6.5. Responding to Service Changes</a> <a href="#ref-for-responsible-event-loop④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2.1. Device access is powerful</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abort-when">
-   <a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abort-when" class="dfn-panel" data-for="term-for-abort-when" id="infopanel-for-term-for-abort-when" role="menu">
+   <span id="infopaneltitle-for-term-for-abort-when" style="display:none">Info about the 'abort when' external reference.</span><a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-when">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-if-aborted">
-   <a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-if-aborted" class="dfn-panel" data-for="term-for-if-aborted" id="infopanel-for-term-for-if-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-if-aborted" style="display:none">Info about the 'if aborted' external reference.</span><a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-if-aborted">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visibilitystate" class="dfn-panel" data-for="term-for-dom-visibilitystate" id="infopanel-for-term-for-dom-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visibilitystate" style="display:none">Info about the 'document visibility state' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilitystate">4.2.1. Handling Visibility Change</a> <a href="#ref-for-dom-visibilitystate①">(2)</a> <a href="#ref-for-dom-visibilitystate②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extra-permission-data">
-   <a href="https://w3c.github.io/permissions/#dfn-extra-permission-data">https://w3c.github.io/permissions/#dfn-extra-permission-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extra-permission-data" class="dfn-panel" data-for="term-for-dfn-extra-permission-data" id="infopanel-for-term-for-dfn-extra-permission-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extra-permission-data" style="display:none">Info about the 'extra permission data' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-extra-permission-data">https://w3c.github.io/permissions/#dfn-extra-permission-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extra-permission-data">3. Device Discovery</a>
     <li><a href="#ref-for-dfn-extra-permission-data①">3.1. Permission API Integration</a> <a href="#ref-for-dfn-extra-permission-data②">(2)</a> <a href="#ref-for-dfn-extra-permission-data③">(3)</a>
@@ -6569,89 +6569,89 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-dfn-extra-permission-data⑥">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extra-permission-data-constraints">
-   <a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-constraints">https://w3c.github.io/permissions/#dfn-extra-permission-data-constraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extra-permission-data-constraints" class="dfn-panel" data-for="term-for-dfn-extra-permission-data-constraints" id="infopanel-for-term-for-dfn-extra-permission-data-constraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extra-permission-data-constraints" style="display:none">Info about the 'extra permission data constraints' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-constraints">https://w3c.github.io/permissions/#dfn-extra-permission-data-constraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extra-permission-data-constraints">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extra-permission-data-type">
-   <a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-type">https://w3c.github.io/permissions/#dfn-extra-permission-data-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extra-permission-data-type" class="dfn-panel" data-for="term-for-dfn-extra-permission-data-type" id="infopanel-for-term-for-dfn-extra-permission-data-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extra-permission-data-type" style="display:none">Info about the 'extra permission data type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-extra-permission-data-type">https://w3c.github.io/permissions/#dfn-extra-permission-data-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extra-permission-data-type">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-query-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm" id="infopanel-for-term-for-dfn-permission-query-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-query-algorithm" style="display:none">Info about the 'permission query algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-query-algorithm">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-result-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-result-type" class="dfn-panel" data-for="term-for-dfn-permission-result-type" id="infopanel-for-term-for-dfn-permission-result-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-result-type" style="display:none">Info about the 'permission result type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-result-type">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm" id="infopanel-for-term-for-dfn-permission-revocation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" style="display:none">Info about the 'permission revocation algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-revocation-algorithm">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">3. Device Discovery</a>
     <li><a href="#ref-for-dfn-permission-state①">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-prompt-the-user-to-choose">
-   <a href="https://w3c.github.io/permissions/#dfn-prompt-the-user-to-choose">https://w3c.github.io/permissions/#dfn-prompt-the-user-to-choose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-prompt-the-user-to-choose" class="dfn-panel" data-for="term-for-dfn-prompt-the-user-to-choose" id="infopanel-for-term-for-dfn-prompt-the-user-to-choose" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-prompt-the-user-to-choose" style="display:none">Info about the 'prompt the user to choose' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-prompt-the-user-to-choose">https://w3c.github.io/permissions/#dfn-prompt-the-user-to-choose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-prompt-the-user-to-choose">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions-query">
-   <a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions-query" class="dfn-panel" data-for="term-for-dom-permissions-query" id="infopanel-for-term-for-dom-permissions-query" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions-query" style="display:none">Info about the 'query()' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissions-query">https://w3c.github.io/permissions/#dom-permissions-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-query">3.1. Permission API Integration</a> <a href="#ref-for-dom-permissions-query①">(2)</a>
     <li><a href="#ref-for-dom-permissions-query②">3.2. Overall Bluetooth availability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus-state" class="dfn-panel" data-for="term-for-dom-permissionstatus-state" id="infopanel-for-term-for-dom-permissionstatus-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus-state" style="display:none">Info about the 'state' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">3.1. Permission API Integration</a> <a href="#ref-for-dom-permissionstatus-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">4.2. BluetoothDevice</a> <a href="#ref-for-aborterror①">(2)</a>
     <li><a href="#ref-for-aborterror②">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-aborterror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">3. Device Discovery</a> <a href="#ref-for-BufferSource①">(2)</a>
     <li><a href="#ref-for-BufferSource②">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-BufferSource③">(2)</a>
@@ -6659,14 +6659,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-BufferSource⑦">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Device Discovery</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">3.1. Permission API Integration</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a>
@@ -6677,14 +6677,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-idl-DOMString①③">6.1. Standardized UUIDs</a> <a href="#ref-for-idl-DOMString①④">(2)</a> <a href="#ref-for-idl-DOMString①⑤">(3)</a> <a href="#ref-for-idl-DOMString①⑥">(4)</a> <a href="#ref-for-idl-DOMString①⑦">(5)</a> <a href="#ref-for-idl-DOMString①⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Device Discovery</a>
     <li><a href="#ref-for-Exposed①">3.1. Permission API Integration</a>
@@ -6699,24 +6699,24 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-Exposed①②">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.1. Permission API Integration</a> <a href="#ref-for-idl-frozen-array①">(2)</a> <a href="#ref-for-idl-frozen-array②">(3)</a>
     <li><a href="#ref-for-idl-frozen-array③">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-idl-frozen-array④">(2)</a> <a href="#ref-for-idl-frozen-array⑤">(3)</a>
     <li><a href="#ref-for-idl-frozen-array⑥">9. Terminology and Conventions</a> <a href="#ref-for-idl-frozen-array⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">5.4. BluetoothRemoteGATTCharacteristic</a>
     <li><a href="#ref-for-invalidmodificationerror①">5.5. BluetoothRemoteGATTDescriptor</a>
     <li><a href="#ref-for-invalidmodificationerror②">5.7. Error handling</a> <a href="#ref-for-invalidmodificationerror③">(2)</a> <a href="#ref-for-invalidmodificationerror④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.2. BluetoothDevice</a> <a href="#ref-for-invalidstateerror①">(2)</a>
     <li><a href="#ref-for-invalidstateerror②">5.1.3. Navigating the Bluetooth Hierarchy</a>
@@ -6725,8 +6725,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-invalidstateerror⑨">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networkerror">
-   <a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networkerror" class="dfn-panel" data-for="term-for-networkerror" id="infopanel-for-term-for-networkerror" role="menu">
+   <span id="infopaneltitle-for-term-for-networkerror" style="display:none">Info about the 'NetworkError' external reference.</span><a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">5.1.3. Navigating the Bluetooth Hierarchy</a>
     <li><a href="#ref-for-networkerror①">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-networkerror②">(2)</a> <a href="#ref-for-networkerror③">(3)</a> <a href="#ref-for-networkerror④">(4)</a> <a href="#ref-for-networkerror⑤">(5)</a> <a href="#ref-for-networkerror⑥">(6)</a> <a href="#ref-for-networkerror⑦">(7)</a>
@@ -6735,24 +6735,24 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-networkerror②⑦">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">3. Device Discovery</a>
     <li><a href="#ref-for-notfounderror①">3.2. Overall Bluetooth availability</a>
     <li><a href="#ref-for-notfounderror②">5.1.3. Navigating the Bluetooth Hierarchy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-notsupportederror①">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-notsupportederror②">(2)</a>
     <li><a href="#ref-for-notsupportederror③">5.7. Error handling</a> <a href="#ref-for-notsupportederror④">(2)</a> <a href="#ref-for-notsupportederror⑤">(3)</a> <a href="#ref-for-notsupportederror⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. Device Discovery</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
     <li><a href="#ref-for-idl-promise③">4.2. BluetoothDevice</a>
@@ -6762,8 +6762,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-idl-promise①⑨">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-idl-promise②⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. Device Discovery</a>
     <li><a href="#ref-for-SameObject①">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-SameObject②">(2)</a> <a href="#ref-for-SameObject③">(3)</a>
@@ -6774,8 +6774,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-SameObject⑧">8. Extensions to the Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3. Device Discovery</a>
     <li><a href="#ref-for-SecureContext①">3.2. Overall Bluetooth availability</a>
@@ -6790,8 +6790,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-SecureContext①④">8. Extensions to the Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3. Device Discovery</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
     <li><a href="#ref-for-securityerror③">4.2. BluetoothDevice</a>
@@ -6802,14 +6802,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-securityerror①②">5.7. Error handling</a> <a href="#ref-for-securityerror①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">https://heycam.github.io/webidl/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'a copy of the bytes held' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">https://heycam.github.io/webidl/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">3. Device Discovery</a> <a href="#ref-for-dfn-get-buffer-source-copy①">(2)</a> <a href="#ref-for-dfn-get-buffer-source-copy②">(3)</a> <a href="#ref-for-dfn-get-buffer-source-copy③">(4)</a>
     <li><a href="#ref-for-dfn-get-buffer-source-copy④">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-dfn-get-buffer-source-copy⑤">(2)</a>
@@ -6817,8 +6817,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-dfn-get-buffer-source-copy⑦">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3. Device Discovery</a> <a href="#ref-for-a-new-promise①">(2)</a>
     <li><a href="#ref-for-a-new-promise②">3.2. Overall Bluetooth availability</a>
@@ -6831,8 +6831,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-a-new-promise①③">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-a-new-promise①④">(2)</a> <a href="#ref-for-a-new-promise①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">5.1.3. Navigating the Bluetooth Hierarchy</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a> <a href="#ref-for-a-promise-rejected-with③">(4)</a>
     <li><a href="#ref-for-a-promise-rejected-with④">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-a-promise-rejected-with⑤">(2)</a>
@@ -6841,14 +6841,14 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-a-promise-rejected-with②②">6. UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.2. Overall Bluetooth availability</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. Device Discovery</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">3.1. Permission API Integration</a> <a href="#ref-for-idl-boolean③">(2)</a>
@@ -6858,45 +6858,45 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-idl-boolean⑦">5.4.1. BluetoothCharacteristicProperties</a> <a href="#ref-for-idl-boolean⑧">(2)</a> <a href="#ref-for-idl-boolean⑨">(3)</a> <a href="#ref-for-idl-boolean①⓪">(4)</a> <a href="#ref-for-idl-boolean①①">(5)</a> <a href="#ref-for-idl-boolean①②">(6)</a> <a href="#ref-for-idl-boolean①③">(7)</a> <a href="#ref-for-idl-boolean①④">(8)</a> <a href="#ref-for-idl-boolean①⑤">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-byte">
-   <a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-byte" class="dfn-panel" data-for="term-for-idl-byte" id="infopanel-for-term-for-idl-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-byte">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-idl-byte①">(2)</a> <a href="#ref-for-idl-byte②">(3)</a> <a href="#ref-for-idl-byte③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-idl-to-ecmascript-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value">https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-idl-to-ecmascript-value" class="dfn-panel" data-for="term-for-dfn-convert-idl-to-ecmascript-value" id="infopanel-for-term-for-dfn-convert-idl-to-ecmascript-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-idl-to-ecmascript-value" style="display:none">Info about the 'converted to an ecmascript value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value">https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value">3. Device Discovery</a> <a href="#ref-for-dfn-convert-idl-to-ecmascript-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">3. Device Discovery</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-maplike">
-   <a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-maplike" class="dfn-panel" data-for="term-for-dfn-maplike" id="infopanel-for-term-for-dfn-maplike" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-maplike" style="display:none">Info about the 'maplike' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-maplike">4.2.3.1. BluetoothManufacturerDataMap</a>
     <li><a href="#ref-for-dfn-maplike①">4.2.3.2. BluetoothServiceDataMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3. Device Discovery</a> <a href="#ref-for-idl-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'react' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3. Device Discovery</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
     <li><a href="#ref-for-reject③">4.2. BluetoothDevice</a> <a href="#ref-for-reject④">(2)</a> <a href="#ref-for-reject⑤">(3)</a> <a href="#ref-for-reject⑥">(4)</a>
@@ -6908,8 +6908,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-reject②⑧">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-reject②⑨">(2)</a> <a href="#ref-for-reject③⓪">(3)</a> <a href="#ref-for-reject③①">(4)</a> <a href="#ref-for-reject③②">(5)</a> <a href="#ref-for-reject③③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3. Device Discovery</a> <a href="#ref-for-resolve①">(2)</a>
     <li><a href="#ref-for-resolve②">3.2. Overall Bluetooth availability</a> <a href="#ref-for-resolve③">(2)</a> <a href="#ref-for-resolve④">(3)</a> <a href="#ref-for-resolve⑤">(4)</a>
@@ -6922,8 +6922,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-resolve①⑨">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-resolve②⓪">(2)</a> <a href="#ref-for-resolve②①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. Device Discovery</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a> <a href="#ref-for-idl-sequence④">(5)</a>
     <li><a href="#ref-for-idl-sequence⑤">3.1. Permission API Integration</a> <a href="#ref-for-idl-sequence⑥">(2)</a> <a href="#ref-for-idl-sequence⑦">(3)</a> <a href="#ref-for-idl-sequence⑧">(4)</a> <a href="#ref-for-idl-sequence⑨">(5)</a> <a href="#ref-for-idl-sequence①⓪">(6)</a>
@@ -6933,8 +6933,8 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-idl-sequence①⑤">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-idl-undefined①">5.2. BluetoothRemoteGATTServer</a>
@@ -6942,29 +6942,29 @@ effect as trying to write to a <code class="idl"><a data-link-type="idl" href="h
     <li><a href="#ref-for-idl-undefined⑤">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.2.3. Responding to Advertising Events</a>
     <li><a href="#ref-for-idl-unsigned-long①">6.1. Standardized UUIDs</a> <a href="#ref-for-idl-unsigned-long②">(2)</a> <a href="#ref-for-idl-unsigned-long③">(3)</a> <a href="#ref-for-idl-unsigned-long④">(4)</a> <a href="#ref-for-idl-unsigned-long⑤">(5)</a> <a href="#ref-for-idl-unsigned-long⑥">(6)</a> <a href="#ref-for-idl-unsigned-long⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">3. Device Discovery</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-short②">3.1. Permission API Integration</a> <a href="#ref-for-idl-unsigned-short③">(2)</a>
     <li><a href="#ref-for-idl-unsigned-short④">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-idl-unsigned-short⑤">(2)</a> <a href="#ref-for-idl-unsigned-short⑥">(3)</a> <a href="#ref-for-idl-unsigned-short⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">5.1.3. Navigating the Bluetooth Hierarchy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wait-for-all">
-   <a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wait-for-all" class="dfn-panel" data-for="term-for-wait-for-all" id="infopanel-for-term-for-wait-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-wait-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#wait-for-all">https://webidl.spec.whatwg.org/#wait-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">5.1.2. The Bluetooth cache</a>
    </ul>
@@ -7449,39 +7449,39 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
 but for now sites need to serialize their use of this API
 and/or give the user a way to retry failed operations. <a href="https://github.com/WebBluetoothCG/web-bluetooth/issues/188">[Issue #188]</a> <a class="issue-return" href="#issue-f363405f⑤" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothdatafilterinit">
-   <b><a href="#dictdef-bluetoothdatafilterinit">#dictdef-bluetoothdatafilterinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothdatafilterinit" class="dfn-panel" data-for="dictdef-bluetoothdatafilterinit" id="infopanel-for-dictdef-bluetoothdatafilterinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothdatafilterinit" style="display:none">Info about the 'BluetoothDataFilterInit' definition.</span><b><a href="#dictdef-bluetoothdatafilterinit">#dictdef-bluetoothdatafilterinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothdatafilterinit">3. Device Discovery</a> <a href="#ref-for-dictdef-bluetoothdatafilterinit①">(2)</a> <a href="#ref-for-dictdef-bluetoothdatafilterinit②">(3)</a> <a href="#ref-for-dictdef-bluetoothdatafilterinit③">(4)</a> <a href="#ref-for-dictdef-bluetoothdatafilterinit④">(5)</a> <a href="#ref-for-dictdef-bluetoothdatafilterinit⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdatafilterinit-dataprefix">
-   <b><a href="#dom-bluetoothdatafilterinit-dataprefix">#dom-bluetoothdatafilterinit-dataprefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdatafilterinit-dataprefix" class="dfn-panel" data-for="dom-bluetoothdatafilterinit-dataprefix" id="infopanel-for-dom-bluetoothdatafilterinit-dataprefix" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdatafilterinit-dataprefix" style="display:none">Info about the 'dataPrefix' definition.</span><b><a href="#dom-bluetoothdatafilterinit-dataprefix">#dom-bluetoothdatafilterinit-dataprefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilterinit-dataprefix">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothdatafilterinit-dataprefix①">(2)</a> <a href="#ref-for-dom-bluetoothdatafilterinit-dataprefix②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdatafilterinit-mask">
-   <b><a href="#dom-bluetoothdatafilterinit-mask">#dom-bluetoothdatafilterinit-mask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdatafilterinit-mask" class="dfn-panel" data-for="dom-bluetoothdatafilterinit-mask" id="infopanel-for-dom-bluetoothdatafilterinit-mask" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdatafilterinit-mask" style="display:none">Info about the 'mask' definition.</span><b><a href="#dom-bluetoothdatafilterinit-mask">#dom-bluetoothdatafilterinit-mask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilterinit-mask">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothdatafilterinit-mask①">(2)</a> <a href="#ref-for-dom-bluetoothdatafilterinit-mask②">(3)</a> <a href="#ref-for-dom-bluetoothdatafilterinit-mask③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothlescanfilterinit">
-   <b><a href="#dictdef-bluetoothlescanfilterinit">#dictdef-bluetoothlescanfilterinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothlescanfilterinit" class="dfn-panel" data-for="dictdef-bluetoothlescanfilterinit" id="infopanel-for-dictdef-bluetoothlescanfilterinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothlescanfilterinit" style="display:none">Info about the 'BluetoothLEScanFilterInit' definition.</span><b><a href="#dictdef-bluetoothlescanfilterinit">#dictdef-bluetoothlescanfilterinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit">3. Device Discovery</a> <a href="#ref-for-dictdef-bluetoothlescanfilterinit①">(2)</a> <a href="#ref-for-dictdef-bluetoothlescanfilterinit②">(3)</a> <a href="#ref-for-dictdef-bluetoothlescanfilterinit③">(4)</a>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit④">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-requestdeviceoptions">
-   <b><a href="#dictdef-requestdeviceoptions">#dictdef-requestdeviceoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-requestdeviceoptions" class="dfn-panel" data-for="dictdef-requestdeviceoptions" id="infopanel-for-dictdef-requestdeviceoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-requestdeviceoptions" style="display:none">Info about the 'RequestDeviceOptions' definition.</span><b><a href="#dictdef-requestdeviceoptions">#dictdef-requestdeviceoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-requestdeviceoptions">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetooth">
-   <b><a href="#bluetooth">#bluetooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetooth" class="dfn-panel" data-for="bluetooth" id="infopanel-for-bluetooth" role="dialog">
+   <span id="infopaneltitle-for-bluetooth" style="display:none">Info about the 'Bluetooth' definition.</span><b><a href="#bluetooth">#bluetooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth">3. Device Discovery</a> <a href="#ref-for-bluetooth①">(2)</a> <a href="#ref-for-bluetooth②">(3)</a> <a href="#ref-for-bluetooth③">(4)</a> <a href="#ref-for-bluetooth④">(5)</a>
     <li><a href="#ref-for-bluetooth⑤">4.2. BluetoothDevice</a> <a href="#ref-for-bluetooth⑥">(2)</a> <a href="#ref-for-bluetooth⑦">(3)</a> <a href="#ref-for-bluetooth⑧">(4)</a>
@@ -7491,109 +7491,110 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetooth①②">8. Extensions to the Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestdeviceoptions-filters">
-   <b><a href="#dom-requestdeviceoptions-filters">#dom-requestdeviceoptions-filters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestdeviceoptions-filters" class="dfn-panel" data-for="dom-requestdeviceoptions-filters" id="infopanel-for-dom-requestdeviceoptions-filters" role="dialog">
+   <span id="infopaneltitle-for-dom-requestdeviceoptions-filters" style="display:none">Info about the 'filters' definition.</span><b><a href="#dom-requestdeviceoptions-filters">#dom-requestdeviceoptions-filters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdeviceoptions-filters">3. Device Discovery</a> <a href="#ref-for-dom-requestdeviceoptions-filters①">(2)</a> <a href="#ref-for-dom-requestdeviceoptions-filters②">(3)</a> <a href="#ref-for-dom-requestdeviceoptions-filters③">(4)</a> <a href="#ref-for-dom-requestdeviceoptions-filters④">(5)</a> <a href="#ref-for-dom-requestdeviceoptions-filters⑤">(6)</a> <a href="#ref-for-dom-requestdeviceoptions-filters⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-services">
-   <b><a href="#dom-bluetoothlescanfilterinit-services">#dom-bluetoothlescanfilterinit-services</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilterinit-services" class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-services" id="infopanel-for-dom-bluetoothlescanfilterinit-services" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilterinit-services" style="display:none">Info about the 'services' definition.</span><b><a href="#dom-bluetoothlescanfilterinit-services">#dom-bluetoothlescanfilterinit-services</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-services">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-services①">(2)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-services②">(3)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-services③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-name">
-   <b><a href="#dom-bluetoothlescanfilterinit-name">#dom-bluetoothlescanfilterinit-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilterinit-name" class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-name" id="infopanel-for-dom-bluetoothlescanfilterinit-name" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilterinit-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-bluetoothlescanfilterinit-name">#dom-bluetoothlescanfilterinit-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-name">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-name①">(2)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-nameprefix">
-   <b><a href="#dom-bluetoothlescanfilterinit-nameprefix">#dom-bluetoothlescanfilterinit-nameprefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilterinit-nameprefix" class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-nameprefix" id="infopanel-for-dom-bluetoothlescanfilterinit-nameprefix" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilterinit-nameprefix" style="display:none">Info about the 'namePrefix' definition.</span><b><a href="#dom-bluetoothlescanfilterinit-nameprefix">#dom-bluetoothlescanfilterinit-nameprefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-nameprefix">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-nameprefix①">(2)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-nameprefix②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-manufacturerdata">
-   <b><a href="#dom-bluetoothlescanfilterinit-manufacturerdata">#dom-bluetoothlescanfilterinit-manufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilterinit-manufacturerdata" class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-manufacturerdata" id="infopanel-for-dom-bluetoothlescanfilterinit-manufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilterinit-manufacturerdata" style="display:none">Info about the 'manufacturerData' definition.</span><b><a href="#dom-bluetoothlescanfilterinit-manufacturerdata">#dom-bluetoothlescanfilterinit-manufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata①">(2)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata②">(3)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata③">(4)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-servicedata">
-   <b><a href="#dom-bluetoothlescanfilterinit-servicedata">#dom-bluetoothlescanfilterinit-servicedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilterinit-servicedata" class="dfn-panel" data-for="dom-bluetoothlescanfilterinit-servicedata" id="infopanel-for-dom-bluetoothlescanfilterinit-servicedata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilterinit-servicedata" style="display:none">Info about the 'serviceData' definition.</span><b><a href="#dom-bluetoothlescanfilterinit-servicedata">#dom-bluetoothlescanfilterinit-servicedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata①">(2)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata②">(3)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata③">(4)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata④">(5)</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestdeviceoptions-acceptalldevices">
-   <b><a href="#dom-requestdeviceoptions-acceptalldevices">#dom-requestdeviceoptions-acceptalldevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestdeviceoptions-acceptalldevices" class="dfn-panel" data-for="dom-requestdeviceoptions-acceptalldevices" id="infopanel-for-dom-requestdeviceoptions-acceptalldevices" role="dialog">
+   <span id="infopaneltitle-for-dom-requestdeviceoptions-acceptalldevices" style="display:none">Info about the 'acceptAllDevices' definition.</span><b><a href="#dom-requestdeviceoptions-acceptalldevices">#dom-requestdeviceoptions-acceptalldevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdeviceoptions-acceptalldevices">3. Device Discovery</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices①">(2)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices②">(3)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices③">(4)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices④">(5)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices⑤">(6)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices⑥">(7)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices⑦">(8)</a> <a href="#ref-for-dom-requestdeviceoptions-acceptalldevices⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestdeviceoptions-optionalservices">
-   <b><a href="#dom-requestdeviceoptions-optionalservices">#dom-requestdeviceoptions-optionalservices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestdeviceoptions-optionalservices" class="dfn-panel" data-for="dom-requestdeviceoptions-optionalservices" id="infopanel-for-dom-requestdeviceoptions-optionalservices" role="dialog">
+   <span id="infopaneltitle-for-dom-requestdeviceoptions-optionalservices" style="display:none">Info about the 'optionalServices' definition.</span><b><a href="#dom-requestdeviceoptions-optionalservices">#dom-requestdeviceoptions-optionalservices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdeviceoptions-optionalservices">3. Device Discovery</a> <a href="#ref-for-dom-requestdeviceoptions-optionalservices①">(2)</a> <a href="#ref-for-dom-requestdeviceoptions-optionalservices②">(3)</a> <a href="#ref-for-dom-requestdeviceoptions-optionalservices③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestdeviceoptions-optionalmanufacturerdata">
-   <b><a href="#dom-requestdeviceoptions-optionalmanufacturerdata">#dom-requestdeviceoptions-optionalmanufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestdeviceoptions-optionalmanufacturerdata" class="dfn-panel" data-for="dom-requestdeviceoptions-optionalmanufacturerdata" id="infopanel-for-dom-requestdeviceoptions-optionalmanufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-requestdeviceoptions-optionalmanufacturerdata" style="display:none">Info about the 'optionalManufacturerData' definition.</span><b><a href="#dom-requestdeviceoptions-optionalmanufacturerdata">#dom-requestdeviceoptions-optionalmanufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdeviceoptions-optionalmanufacturerdata">3. Device Discovery</a> <a href="#ref-for-dom-requestdeviceoptions-optionalmanufacturerdata①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-deviceinstancemap-slot">
-   <b><a href="#dom-bluetooth-deviceinstancemap-slot">#dom-bluetooth-deviceinstancemap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-deviceinstancemap-slot" class="dfn-panel" data-for="dom-bluetooth-deviceinstancemap-slot" id="infopanel-for-dom-bluetooth-deviceinstancemap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-deviceinstancemap-slot" style="display:none">Info about the '[[deviceInstanceMap]]' definition.</span><b><a href="#dom-bluetooth-deviceinstancemap-slot">#dom-bluetooth-deviceinstancemap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-deviceinstancemap-slot">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetooth-deviceinstancemap-slot①">(2)</a> <a href="#ref-for-dom-bluetooth-deviceinstancemap-slot②">(3)</a> <a href="#ref-for-dom-bluetooth-deviceinstancemap-slot③">(4)</a>
     <li><a href="#ref-for-dom-bluetooth-deviceinstancemap-slot④">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-attributeinstancemap-slot">
-   <b><a href="#dom-bluetooth-attributeinstancemap-slot">#dom-bluetooth-attributeinstancemap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-attributeinstancemap-slot" class="dfn-panel" data-for="dom-bluetooth-attributeinstancemap-slot" id="infopanel-for-dom-bluetooth-attributeinstancemap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-attributeinstancemap-slot" style="display:none">Info about the '[[attributeInstanceMap]]' definition.</span><b><a href="#dom-bluetooth-attributeinstancemap-slot">#dom-bluetooth-attributeinstancemap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-attributeinstancemap-slot">5.1.2. The Bluetooth cache</a> <a href="#ref-for-dom-bluetooth-attributeinstancemap-slot①">(2)</a> <a href="#ref-for-dom-bluetooth-attributeinstancemap-slot②">(3)</a>
     <li><a href="#ref-for-dom-bluetooth-attributeinstancemap-slot③">5.6.3. Responding to Disconnection</a>
     <li><a href="#ref-for-dom-bluetooth-attributeinstancemap-slot④">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-referringdevice-slot">
-   <b><a href="#dom-bluetooth-referringdevice-slot">#dom-bluetooth-referringdevice-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-referringdevice-slot" class="dfn-panel" data-for="dom-bluetooth-referringdevice-slot" id="infopanel-for-dom-bluetooth-referringdevice-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-referringdevice-slot" style="display:none">Info about the '[[referringDevice]]' definition.</span><b><a href="#dom-bluetooth-referringdevice-slot">#dom-bluetooth-referringdevice-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-referringdevice-slot">3. Device Discovery</a> <a href="#ref-for-dom-bluetooth-referringdevice-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-referringdevice">
-   <b><a href="#dom-bluetooth-referringdevice">#dom-bluetooth-referringdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-referringdevice" class="dfn-panel" data-for="dom-bluetooth-referringdevice" id="infopanel-for-dom-bluetooth-referringdevice" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-referringdevice" style="display:none">Info about the 'referringDevice' definition.</span><b><a href="#dom-bluetooth-referringdevice">#dom-bluetooth-referringdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-referringdevice">3. Device Discovery</a> <a href="#ref-for-dom-bluetooth-referringdevice①">(2)</a> <a href="#ref-for-dom-bluetooth-referringdevice②">(3)</a>
     <li><a href="#ref-for-dom-bluetooth-referringdevice③">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-a-filter">
-   <b><a href="#matches-a-filter">#matches-a-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-a-filter" class="dfn-panel" data-for="matches-a-filter" id="infopanel-for-matches-a-filter" role="dialog">
+   <span id="infopaneltitle-for-matches-a-filter" style="display:none">Info about the 'matches a filter' definition.</span><b><a href="#matches-a-filter">#matches-a-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-a-filter">3. Device Discovery</a> <a href="#ref-for-matches-a-filter①">(2)</a> <a href="#ref-for-matches-a-filter②">(3)</a>
     <li><a href="#ref-for-matches-a-filter③">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothdatafilterinit-matches">
-   <b><a href="#bluetoothdatafilterinit-matches">#bluetoothdatafilterinit-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothdatafilterinit-matches" class="dfn-panel" data-for="bluetoothdatafilterinit-matches" id="infopanel-for-bluetoothdatafilterinit-matches" role="dialog">
+   <span id="infopaneltitle-for-bluetoothdatafilterinit-matches" style="display:none">Info about the 'matches' definition.</span><b><a href="#bluetoothdatafilterinit-matches">#bluetoothdatafilterinit-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdatafilterinit-matches">3. Device Discovery</a> <a href="#ref-for-bluetoothdatafilterinit-matches①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-getdevices">
-   <b><a href="#dom-bluetooth-getdevices">#dom-bluetooth-getdevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-getdevices" class="dfn-panel" data-for="dom-bluetooth-getdevices" id="infopanel-for-dom-bluetooth-getdevices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-getdevices" style="display:none">Info about the 'getDevices()' definition.</span><b><a href="#dom-bluetooth-getdevices">#dom-bluetooth-getdevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-getdevices">3. Device Discovery</a> <a href="#ref-for-dom-bluetooth-getdevices①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-requestdevice">
-   <b><a href="#dom-bluetooth-requestdevice">#dom-bluetooth-requestdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-requestdevice" class="dfn-panel" data-for="dom-bluetooth-requestdevice" id="infopanel-for-dom-bluetooth-requestdevice" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-requestdevice" style="display:none">Info about the 'requestDevice(options)
+' definition.</span><b><a href="#dom-bluetooth-requestdevice">#dom-bluetooth-requestdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-requestdevice">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetooth-requestdevice①">2.1. Device access is powerful</a>
@@ -7602,68 +7603,69 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetooth-requestdevice⑤">9. Terminology and Conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-bluetooth-devices">
-   <b><a href="#request-bluetooth-devices">#request-bluetooth-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-bluetooth-devices" class="dfn-panel" data-for="request-bluetooth-devices" id="infopanel-for-request-bluetooth-devices" role="dialog">
+   <span id="infopaneltitle-for-request-bluetooth-devices" style="display:none">Info about the 'request Bluetooth devices' definition.</span><b><a href="#request-bluetooth-devices">#request-bluetooth-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-bluetooth-devices">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescanfilterinit-canonicalizing">
-   <b><a href="#bluetoothlescanfilterinit-canonicalizing">#bluetoothlescanfilterinit-canonicalizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescanfilterinit-canonicalizing" class="dfn-panel" data-for="bluetoothlescanfilterinit-canonicalizing" id="infopanel-for-bluetoothlescanfilterinit-canonicalizing" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescanfilterinit-canonicalizing" style="display:none">Info about the 'canonicalizing' definition.</span><b><a href="#bluetoothlescanfilterinit-canonicalizing">#bluetoothlescanfilterinit-canonicalizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescanfilterinit-canonicalizing">3. Device Discovery</a>
     <li><a href="#ref-for-bluetoothlescanfilterinit-canonicalizing①">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothdatafilterinit-canonicalizing">
-   <b><a href="#bluetoothdatafilterinit-canonicalizing">#bluetoothdatafilterinit-canonicalizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothdatafilterinit-canonicalizing" class="dfn-panel" data-for="bluetoothdatafilterinit-canonicalizing" id="infopanel-for-bluetoothdatafilterinit-canonicalizing" role="dialog">
+   <span id="infopaneltitle-for-bluetoothdatafilterinit-canonicalizing" style="display:none">Info about the 'canonicalizing' definition.</span><b><a href="#bluetoothdatafilterinit-canonicalizing">#bluetoothdatafilterinit-canonicalizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdatafilterinit-canonicalizing">3. Device Discovery</a> <a href="#ref-for-bluetoothdatafilterinit-canonicalizing①">(2)</a> <a href="#ref-for-bluetoothdatafilterinit-canonicalizing②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scan-for-devices">
-   <b><a href="#scan-for-devices">#scan-for-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scan-for-devices" class="dfn-panel" data-for="scan-for-devices" id="infopanel-for-scan-for-devices" role="dialog">
+   <span id="infopaneltitle-for-scan-for-devices" style="display:none">Info about the 'scan for devices' definition.</span><b><a href="#scan-for-devices">#scan-for-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scan-for-devices">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-device-to-storage">
-   <b><a href="#add-device-to-storage">#add-device-to-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-device-to-storage" class="dfn-panel" data-for="add-device-to-storage" id="infopanel-for-add-device-to-storage" role="dialog">
+   <span id="infopaneltitle-for-add-device-to-storage" style="display:none">Info about the 'add an allowed
+Bluetooth device' definition.</span><b><a href="#add-device-to-storage">#add-device-to-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-device-to-storage">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothpermissiondescriptor">
-   <b><a href="#dictdef-bluetoothpermissiondescriptor">#dictdef-bluetoothpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothpermissiondescriptor" class="dfn-panel" data-for="dictdef-bluetoothpermissiondescriptor" id="infopanel-for-dictdef-bluetoothpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothpermissiondescriptor" style="display:none">Info about the 'BluetoothPermissionDescriptor' definition.</span><b><a href="#dictdef-bluetoothpermissiondescriptor">#dictdef-bluetoothpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothpermissiondescriptor">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-allowedbluetoothdevice">
-   <b><a href="#dictdef-allowedbluetoothdevice">#dictdef-allowedbluetoothdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-allowedbluetoothdevice" class="dfn-panel" data-for="dictdef-allowedbluetoothdevice" id="infopanel-for-dictdef-allowedbluetoothdevice" role="dialog">
+   <span id="infopaneltitle-for-dictdef-allowedbluetoothdevice" style="display:none">Info about the 'AllowedBluetoothDevice' definition.</span><b><a href="#dictdef-allowedbluetoothdevice">#dictdef-allowedbluetoothdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-allowedbluetoothdevice">3.1. Permission API Integration</a> <a href="#ref-for-dictdef-allowedbluetoothdevice①">(2)</a> <a href="#ref-for-dictdef-allowedbluetoothdevice②">(3)</a>
     <li><a href="#ref-for-dictdef-allowedbluetoothdevice③">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedbluetoothdevice-deviceid">
-   <b><a href="#dom-allowedbluetoothdevice-deviceid">#dom-allowedbluetoothdevice-deviceid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedbluetoothdevice-deviceid" class="dfn-panel" data-for="dom-allowedbluetoothdevice-deviceid" id="infopanel-for-dom-allowedbluetoothdevice-deviceid" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedbluetoothdevice-deviceid" style="display:none">Info about the 'deviceId' definition.</span><b><a href="#dom-allowedbluetoothdevice-deviceid">#dom-allowedbluetoothdevice-deviceid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-deviceid">3. Device Discovery</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-deviceid①">3.1. Permission API Integration</a> <a href="#ref-for-dom-allowedbluetoothdevice-deviceid②">(2)</a> <a href="#ref-for-dom-allowedbluetoothdevice-deviceid③">(3)</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-deviceid④">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedbluetoothdevice-mayusegatt">
-   <b><a href="#dom-allowedbluetoothdevice-mayusegatt">#dom-allowedbluetoothdevice-mayusegatt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedbluetoothdevice-mayusegatt" class="dfn-panel" data-for="dom-allowedbluetoothdevice-mayusegatt" id="infopanel-for-dom-allowedbluetoothdevice-mayusegatt" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedbluetoothdevice-mayusegatt" style="display:none">Info about the 'mayUseGATT' definition.</span><b><a href="#dom-allowedbluetoothdevice-mayusegatt">#dom-allowedbluetoothdevice-mayusegatt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-mayusegatt">3. Device Discovery</a> <a href="#ref-for-dom-allowedbluetoothdevice-mayusegatt①">(2)</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-mayusegatt②">3.1. Permission API Integration</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-mayusegatt③">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedbluetoothdevice-allowedservices">
-   <b><a href="#dom-allowedbluetoothdevice-allowedservices">#dom-allowedbluetoothdevice-allowedservices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedbluetoothdevice-allowedservices" class="dfn-panel" data-for="dom-allowedbluetoothdevice-allowedservices" id="infopanel-for-dom-allowedbluetoothdevice-allowedservices" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedbluetoothdevice-allowedservices" style="display:none">Info about the 'allowedServices' definition.</span><b><a href="#dom-allowedbluetoothdevice-allowedservices">#dom-allowedbluetoothdevice-allowedservices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedservices">3. Device Discovery</a> <a href="#ref-for-dom-allowedbluetoothdevice-allowedservices①">(2)</a> <a href="#ref-for-dom-allowedbluetoothdevice-allowedservices②">(3)</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedservices③">3.1. Permission API Integration</a> <a href="#ref-for-dom-allowedbluetoothdevice-allowedservices④">(2)</a>
@@ -7671,24 +7673,24 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedservices⑦">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedbluetoothdevice-allowedmanufacturerdata">
-   <b><a href="#dom-allowedbluetoothdevice-allowedmanufacturerdata">#dom-allowedbluetoothdevice-allowedmanufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedbluetoothdevice-allowedmanufacturerdata" class="dfn-panel" data-for="dom-allowedbluetoothdevice-allowedmanufacturerdata" id="infopanel-for-dom-allowedbluetoothdevice-allowedmanufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedbluetoothdevice-allowedmanufacturerdata" style="display:none">Info about the 'allowedManufacturerData' definition.</span><b><a href="#dom-allowedbluetoothdevice-allowedmanufacturerdata">#dom-allowedbluetoothdevice-allowedmanufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedmanufacturerdata">3. Device Discovery</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedmanufacturerdata①">3.1. Permission API Integration</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-allowedmanufacturerdata②">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothpermissionstorage">
-   <b><a href="#dictdef-bluetoothpermissionstorage">#dictdef-bluetoothpermissionstorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothpermissionstorage" class="dfn-panel" data-for="dictdef-bluetoothpermissionstorage" id="infopanel-for-dictdef-bluetoothpermissionstorage" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothpermissionstorage" style="display:none">Info about the 'BluetoothPermissionStorage' definition.</span><b><a href="#dictdef-bluetoothpermissionstorage">#dictdef-bluetoothpermissionstorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothpermissionstorage">3. Device Discovery</a> <a href="#ref-for-dictdef-bluetoothpermissionstorage①">(2)</a> <a href="#ref-for-dictdef-bluetoothpermissionstorage②">(3)</a>
     <li><a href="#ref-for-dictdef-bluetoothpermissionstorage③">3.1. Permission API Integration</a> <a href="#ref-for-dictdef-bluetoothpermissionstorage④">(2)</a> <a href="#ref-for-dictdef-bluetoothpermissionstorage⑤">(3)</a>
     <li><a href="#ref-for-dictdef-bluetoothpermissionstorage⑥">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothpermissionstorage-alloweddevices">
-   <b><a href="#dom-bluetoothpermissionstorage-alloweddevices">#dom-bluetoothpermissionstorage-alloweddevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothpermissionstorage-alloweddevices" class="dfn-panel" data-for="dom-bluetoothpermissionstorage-alloweddevices" id="infopanel-for-dom-bluetoothpermissionstorage-alloweddevices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothpermissionstorage-alloweddevices" style="display:none">Info about the 'allowedDevices' definition.</span><b><a href="#dom-bluetoothpermissionstorage-alloweddevices">#dom-bluetoothpermissionstorage-alloweddevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices①">(2)</a> <a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices②">(3)</a>
     <li><a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices③">3.1. Permission API Integration</a> <a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices④">(2)</a>
@@ -7696,61 +7698,61 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothpermissionstorage-alloweddevices⑦">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-allowedbluetoothdevice-device-slot">
-   <b><a href="#dom-allowedbluetoothdevice-device-slot">#dom-allowedbluetoothdevice-device-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-allowedbluetoothdevice-device-slot" class="dfn-panel" data-for="dom-allowedbluetoothdevice-device-slot" id="infopanel-for-dom-allowedbluetoothdevice-device-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-allowedbluetoothdevice-device-slot" style="display:none">Info about the '[[device]]' definition.</span><b><a href="#dom-allowedbluetoothdevice-device-slot">#dom-allowedbluetoothdevice-device-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-device-slot">3. Device Discovery</a> <a href="#ref-for-dom-allowedbluetoothdevice-device-slot①">(2)</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-device-slot②">3.1. Permission API Integration</a> <a href="#ref-for-dom-allowedbluetoothdevice-device-slot③">(2)</a> <a href="#ref-for-dom-allowedbluetoothdevice-device-slot④">(3)</a> <a href="#ref-for-dom-allowedbluetoothdevice-device-slot⑤">(4)</a>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-device-slot⑥">4.2. BluetoothDevice</a> <a href="#ref-for-dom-allowedbluetoothdevice-device-slot⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothpermissionresult">
-   <b><a href="#bluetoothpermissionresult">#bluetoothpermissionresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothpermissionresult" class="dfn-panel" data-for="bluetoothpermissionresult" id="infopanel-for-bluetoothpermissionresult" role="dialog">
+   <span id="infopaneltitle-for-bluetoothpermissionresult" style="display:none">Info about the 'BluetoothPermissionResult' definition.</span><b><a href="#bluetoothpermissionresult">#bluetoothpermissionresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothpermissionresult">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothpermissionresult-devices">
-   <b><a href="#dom-bluetoothpermissionresult-devices">#dom-bluetoothpermissionresult-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothpermissionresult-devices" class="dfn-panel" data-for="dom-bluetoothpermissionresult-devices" id="infopanel-for-dom-bluetoothpermissionresult-devices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothpermissionresult-devices" style="display:none">Info about the 'devices' definition.</span><b><a href="#dom-bluetoothpermissionresult-devices">#dom-bluetoothpermissionresult-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothpermissionresult-devices">3.1. Permission API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="revoke-bluetooth-access">
-   <b><a href="#revoke-bluetooth-access">#revoke-bluetooth-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-revoke-bluetooth-access" class="dfn-panel" data-for="revoke-bluetooth-access" id="infopanel-for-revoke-bluetooth-access" role="dialog">
+   <span id="infopaneltitle-for-revoke-bluetooth-access" style="display:none">Info about the 'revoke Bluetooth access' definition.</span><b><a href="#revoke-bluetooth-access">#revoke-bluetooth-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-revoke-bluetooth-access">2.1. Device access is powerful</a>
     <li><a href="#ref-for-revoke-bluetooth-access①">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-getavailability">
-   <b><a href="#dom-bluetooth-getavailability">#dom-bluetooth-getavailability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-getavailability" class="dfn-panel" data-for="dom-bluetooth-getavailability" id="infopanel-for-dom-bluetooth-getavailability" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-getavailability" style="display:none">Info about the 'getAvailability()' definition.</span><b><a href="#dom-bluetooth-getavailability">#dom-bluetooth-getavailability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-getavailability">2.5. Exposing Bluetooth availability</a>
     <li><a href="#ref-for-dom-bluetooth-getavailability①">3. Device Discovery</a> <a href="#ref-for-dom-bluetooth-getavailability②">(2)</a>
     <li><a href="#ref-for-dom-bluetooth-getavailability③">3.2. Overall Bluetooth availability</a> <a href="#ref-for-dom-bluetooth-getavailability④">(2)</a> <a href="#ref-for-dom-bluetooth-getavailability⑤">(3)</a> <a href="#ref-for-dom-bluetooth-getavailability⑥">(4)</a> <a href="#ref-for-dom-bluetooth-getavailability⑦">(5)</a> <a href="#ref-for-dom-bluetooth-getavailability⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valueevent">
-   <b><a href="#valueevent">#valueevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valueevent" class="dfn-panel" data-for="valueevent" id="infopanel-for-valueevent" role="dialog">
+   <span id="infopaneltitle-for-valueevent" style="display:none">Info about the 'ValueEvent' definition.</span><b><a href="#valueevent">#valueevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valueevent">3.2. Overall Bluetooth availability</a> <a href="#ref-for-valueevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-valueeventinit">
-   <b><a href="#dictdef-valueeventinit">#dictdef-valueeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-valueeventinit" class="dfn-panel" data-for="dictdef-valueeventinit" id="infopanel-for-dictdef-valueeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-valueeventinit" style="display:none">Info about the 'ValueEventInit' definition.</span><b><a href="#dictdef-valueeventinit">#dictdef-valueeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-valueeventinit">3.2. Overall Bluetooth availability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-valueevent-value">
-   <b><a href="#dom-valueevent-value">#dom-valueevent-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-valueevent-value" class="dfn-panel" data-for="dom-valueevent-value" id="infopanel-for-dom-valueevent-value" role="dialog">
+   <span id="infopaneltitle-for-dom-valueevent-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-valueevent-value">#dom-valueevent-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-valueevent-value">3.2. Overall Bluetooth availability</a> <a href="#ref-for-dom-valueevent-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetooth-device">
-   <b><a href="#bluetooth-device">#bluetooth-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetooth-device" class="dfn-panel" data-for="bluetooth-device" id="infopanel-for-bluetooth-device" role="dialog">
+   <span id="infopaneltitle-for-bluetooth-device" style="display:none">Info about the 'Bluetooth device' definition.</span><b><a href="#bluetooth-device">#bluetooth-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth-device">3. Device Discovery</a> <a href="#ref-for-bluetooth-device①">(2)</a> <a href="#ref-for-bluetooth-device②">(3)</a> <a href="#ref-for-bluetooth-device③">(4)</a> <a href="#ref-for-bluetooth-device④">(5)</a> <a href="#ref-for-bluetooth-device⑤">(6)</a> <a href="#ref-for-bluetooth-device⑥">(7)</a> <a href="#ref-for-bluetooth-device⑦">(8)</a> <a href="#ref-for-bluetooth-device⑧">(9)</a> <a href="#ref-for-bluetooth-device⑨">(10)</a>
     <li><a href="#ref-for-bluetooth-device①⓪">3.1. Permission API Integration</a>
@@ -7761,14 +7763,14 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetooth-device①⑦">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-physical-transports">
-   <b><a href="#supported-physical-transports">#supported-physical-transports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-physical-transports" class="dfn-panel" data-for="supported-physical-transports" id="infopanel-for-supported-physical-transports" role="dialog">
+   <span id="infopaneltitle-for-supported-physical-transports" style="display:none">Info about the 'supported physical transports' definition.</span><b><a href="#supported-physical-transports">#supported-physical-transports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-physical-transports">3. Device Discovery</a> <a href="#ref-for-supported-physical-transports①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-bluetooth-device">
-   <b><a href="#same-bluetooth-device">#same-bluetooth-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-bluetooth-device" class="dfn-panel" data-for="same-bluetooth-device" id="infopanel-for-same-bluetooth-device" role="dialog">
+   <span id="infopaneltitle-for-same-bluetooth-device" style="display:none">Info about the 'same Bluetooth device' definition.</span><b><a href="#same-bluetooth-device">#same-bluetooth-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-bluetooth-device">3.1. Permission API Integration</a>
     <li><a href="#ref-for-same-bluetooth-device①">4.2. BluetoothDevice</a> <a href="#ref-for-same-bluetooth-device②">(2)</a> <a href="#ref-for-same-bluetooth-device③">(3)</a> <a href="#ref-for-same-bluetooth-device④">(4)</a>
@@ -7778,8 +7780,8 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-same-bluetooth-device⑨">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothdevice">
-   <b><a href="#bluetoothdevice">#bluetoothdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothdevice" class="dfn-panel" data-for="bluetoothdevice" id="infopanel-for-bluetoothdevice" role="dialog">
+   <span id="infopaneltitle-for-bluetoothdevice" style="display:none">Info about the 'BluetoothDevice' definition.</span><b><a href="#bluetoothdevice">#bluetoothdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdevice">3. Device Discovery</a> <a href="#ref-for-bluetoothdevice①">(2)</a> <a href="#ref-for-bluetoothdevice②">(3)</a> <a href="#ref-for-bluetoothdevice③">(4)</a> <a href="#ref-for-bluetoothdevice④">(5)</a> <a href="#ref-for-bluetoothdevice⑤">(6)</a> <a href="#ref-for-bluetoothdevice⑥">(7)</a> <a href="#ref-for-bluetoothdevice⑦">(8)</a> <a href="#ref-for-bluetoothdevice⑧">(9)</a>
     <li><a href="#ref-for-bluetoothdevice⑨">3.1. Permission API Integration</a> <a href="#ref-for-bluetoothdevice①⓪">(2)</a> <a href="#ref-for-bluetoothdevice①①">(3)</a> <a href="#ref-for-bluetoothdevice①②">(4)</a>
@@ -7795,42 +7797,42 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetoothdevice④④">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-watchadvertisementsoptions">
-   <b><a href="#dictdef-watchadvertisementsoptions">#dictdef-watchadvertisementsoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-watchadvertisementsoptions" class="dfn-panel" data-for="dictdef-watchadvertisementsoptions" id="infopanel-for-dictdef-watchadvertisementsoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-watchadvertisementsoptions" style="display:none">Info about the 'WatchAdvertisementsOptions' definition.</span><b><a href="#dictdef-watchadvertisementsoptions">#dictdef-watchadvertisementsoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-watchadvertisementsoptions">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-id">
-   <b><a href="#dom-bluetoothdevice-id">#dom-bluetoothdevice-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-id" class="dfn-panel" data-for="dom-bluetoothdevice-id" id="infopanel-for-dom-bluetoothdevice-id" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-bluetoothdevice-id">#dom-bluetoothdevice-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-id">3.1. Permission API Integration</a>
     <li><a href="#ref-for-dom-bluetoothdevice-id①">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-name">
-   <b><a href="#dom-bluetoothdevice-name">#dom-bluetoothdevice-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-name" class="dfn-panel" data-for="dom-bluetoothdevice-name" id="infopanel-for-dom-bluetoothdevice-name" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-bluetoothdevice-name">#dom-bluetoothdevice-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-name">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-watchingadvertisements">
-   <b><a href="#dom-bluetoothdevice-watchingadvertisements">#dom-bluetoothdevice-watchingadvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-watchingadvertisements" class="dfn-panel" data-for="dom-bluetoothdevice-watchingadvertisements" id="infopanel-for-dom-bluetoothdevice-watchingadvertisements" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-watchingadvertisements" style="display:none">Info about the 'watchingAdvertisements' definition.</span><b><a href="#dom-bluetoothdevice-watchingadvertisements">#dom-bluetoothdevice-watchingadvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-watchingadvertisements">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetoothdevice-watchingadvertisements①">(2)</a> <a href="#ref-for-dom-bluetoothdevice-watchingadvertisements②">(3)</a> <a href="#ref-for-dom-bluetoothdevice-watchingadvertisements③">(4)</a> <a href="#ref-for-dom-bluetoothdevice-watchingadvertisements④">(5)</a>
     <li><a href="#ref-for-dom-bluetoothdevice-watchingadvertisements⑤">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-dom-bluetoothdevice-watchingadvertisements⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-context-slot">
-   <b><a href="#dom-bluetoothdevice-context-slot">#dom-bluetoothdevice-context-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-context-slot" class="dfn-panel" data-for="dom-bluetoothdevice-context-slot" id="infopanel-for-dom-bluetoothdevice-context-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-context-slot" style="display:none">Info about the '[[context]]' definition.</span><b><a href="#dom-bluetoothdevice-context-slot">#dom-bluetoothdevice-context-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-context-slot">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-dom-bluetoothdevice-context-slot①">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-dom-bluetoothdevice-context-slot②">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-representeddevice-slot">
-   <b><a href="#dom-bluetoothdevice-representeddevice-slot">#dom-bluetoothdevice-representeddevice-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-representeddevice-slot" class="dfn-panel" data-for="dom-bluetoothdevice-representeddevice-slot" id="infopanel-for-dom-bluetoothdevice-representeddevice-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-representeddevice-slot" style="display:none">Info about the '[[representedDevice]]' definition.</span><b><a href="#dom-bluetoothdevice-representeddevice-slot">#dom-bluetoothdevice-representeddevice-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-representeddevice-slot">3.1. Permission API Integration</a> <a href="#ref-for-dom-bluetoothdevice-representeddevice-slot①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothdevice-representeddevice-slot②">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetoothdevice-representeddevice-slot③">(2)</a>
@@ -7840,14 +7842,14 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothdevice-representeddevice-slot①③">5.6.3. Responding to Disconnection</a> <a href="#ref-for-dom-bluetoothdevice-representeddevice-slot①④">(2)</a> <a href="#ref-for-dom-bluetoothdevice-representeddevice-slot①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-gatt-slot">
-   <b><a href="#dom-bluetoothdevice-gatt-slot">#dom-bluetoothdevice-gatt-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-gatt-slot" class="dfn-panel" data-for="dom-bluetoothdevice-gatt-slot" id="infopanel-for-dom-bluetoothdevice-gatt-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-gatt-slot" style="display:none">Info about the '[[gatt]]' definition.</span><b><a href="#dom-bluetoothdevice-gatt-slot">#dom-bluetoothdevice-gatt-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-gatt-slot">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-allowedservices-slot">
-   <b><a href="#dom-bluetoothdevice-allowedservices-slot">#dom-bluetoothdevice-allowedservices-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-allowedservices-slot" class="dfn-panel" data-for="dom-bluetoothdevice-allowedservices-slot" id="infopanel-for-dom-bluetoothdevice-allowedservices-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-allowedservices-slot" style="display:none">Info about the '[[allowedServices]]' definition.</span><b><a href="#dom-bluetoothdevice-allowedservices-slot">#dom-bluetoothdevice-allowedservices-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-allowedservices-slot">3.1. Permission API Integration</a>
     <li><a href="#ref-for-dom-bluetoothdevice-allowedservices-slot①">4.2. BluetoothDevice</a>
@@ -7856,226 +7858,226 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothdevice-allowedservices-slot①⓪">5.6.5. Responding to Service Changes</a> <a href="#ref-for-dom-bluetoothdevice-allowedservices-slot①①">(2)</a> <a href="#ref-for-dom-bluetoothdevice-allowedservices-slot①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-allowedmanufacturerdata-slot">
-   <b><a href="#dom-bluetoothdevice-allowedmanufacturerdata-slot">#dom-bluetoothdevice-allowedmanufacturerdata-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-allowedmanufacturerdata-slot" class="dfn-panel" data-for="dom-bluetoothdevice-allowedmanufacturerdata-slot" id="infopanel-for-dom-bluetoothdevice-allowedmanufacturerdata-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-allowedmanufacturerdata-slot" style="display:none">Info about the '[[allowedManufacturerData]]' definition.</span><b><a href="#dom-bluetoothdevice-allowedmanufacturerdata-slot">#dom-bluetoothdevice-allowedmanufacturerdata-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-allowedmanufacturerdata-slot">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-watchadvertisementsstate-slot">
-   <b><a href="#dom-bluetoothdevice-watchadvertisementsstate-slot">#dom-bluetoothdevice-watchadvertisementsstate-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-watchadvertisementsstate-slot" class="dfn-panel" data-for="dom-bluetoothdevice-watchadvertisementsstate-slot" id="infopanel-for-dom-bluetoothdevice-watchadvertisementsstate-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-watchadvertisementsstate-slot" style="display:none">Info about the '[[watchAdvertisementsState]]' definition.</span><b><a href="#dom-bluetoothdevice-watchadvertisementsstate-slot">#dom-bluetoothdevice-watchadvertisementsstate-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot①">(2)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot②">(3)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot③">(4)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot④">(5)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot⑤">(6)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot⑥">(7)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisementsstate-slot⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-bluetoothdevice-representing">
-   <b><a href="#get-the-bluetoothdevice-representing">#get-the-bluetoothdevice-representing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-bluetoothdevice-representing" class="dfn-panel" data-for="get-the-bluetoothdevice-representing" id="infopanel-for-get-the-bluetoothdevice-representing" role="dialog">
+   <span id="infopaneltitle-for-get-the-bluetoothdevice-representing" style="display:none">Info about the 'get the BluetoothDevice representing' definition.</span><b><a href="#get-the-bluetoothdevice-representing">#get-the-bluetoothdevice-representing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-bluetoothdevice-representing">3. Device Discovery</a> <a href="#ref-for-get-the-bluetoothdevice-representing①">(2)</a>
     <li><a href="#ref-for-get-the-bluetoothdevice-representing②">3.1. Permission API Integration</a>
     <li><a href="#ref-for-get-the-bluetoothdevice-representing③">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-gatt">
-   <b><a href="#dom-bluetoothdevice-gatt">#dom-bluetoothdevice-gatt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-gatt" class="dfn-panel" data-for="dom-bluetoothdevice-gatt" id="infopanel-for-dom-bluetoothdevice-gatt" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-gatt" style="display:none">Info about the 'gatt' definition.</span><b><a href="#dom-bluetoothdevice-gatt">#dom-bluetoothdevice-gatt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-gatt">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetoothdevice-gatt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="watch-advertisements-manager">
-   <b><a href="#watch-advertisements-manager">#watch-advertisements-manager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-watch-advertisements-manager" class="dfn-panel" data-for="watch-advertisements-manager" id="infopanel-for-watch-advertisements-manager" role="dialog">
+   <span id="infopaneltitle-for-watch-advertisements-manager" style="display:none">Info about the 'watch advertisements manager' definition.</span><b><a href="#watch-advertisements-manager">#watch-advertisements-manager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-watch-advertisements-manager">4.2. BluetoothDevice</a> <a href="#ref-for-watch-advertisements-manager①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-watchadvertisements">
-   <b><a href="#dom-bluetoothdevice-watchadvertisements">#dom-bluetoothdevice-watchadvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-watchadvertisements" class="dfn-panel" data-for="dom-bluetoothdevice-watchadvertisements" id="infopanel-for-dom-bluetoothdevice-watchadvertisements" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-watchadvertisements" style="display:none">Info about the 'watchAdvertisements(options)' definition.</span><b><a href="#dom-bluetoothdevice-watchadvertisements">#dom-bluetoothdevice-watchadvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-watchadvertisements">3. Device Discovery</a>
     <li><a href="#ref-for-dom-bluetoothdevice-watchadvertisements①">4.2. BluetoothDevice</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisements②">(2)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisements③">(3)</a> <a href="#ref-for-dom-bluetoothdevice-watchadvertisements④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-watchadvertisements">
-   <b><a href="#abort-watchadvertisements">#abort-watchadvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-watchadvertisements" class="dfn-panel" data-for="abort-watchadvertisements" id="infopanel-for-abort-watchadvertisements" role="dialog">
+   <span id="infopaneltitle-for-abort-watchadvertisements" style="display:none">Info about the 'abort watchAdvertisements' definition.</span><b><a href="#abort-watchadvertisements">#abort-watchadvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-watchadvertisements">4.2. BluetoothDevice</a> <a href="#ref-for-abort-watchadvertisements①">(2)</a> <a href="#ref-for-abort-watchadvertisements②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-all-active-watchadvertisements">
-   <b><a href="#abort-all-active-watchadvertisements">#abort-all-active-watchadvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-all-active-watchadvertisements" class="dfn-panel" data-for="abort-all-active-watchadvertisements" id="infopanel-for-abort-all-active-watchadvertisements" role="dialog">
+   <span id="infopaneltitle-for-abort-all-active-watchadvertisements" style="display:none">Info about the 'abort all active watchAdvertisements' definition.</span><b><a href="#abort-all-active-watchadvertisements">#abort-all-active-watchadvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-all-active-watchadvertisements">4.2.1. Handling Visibility Change</a>
     <li><a href="#ref-for-abort-all-active-watchadvertisements①">4.2.2. Handling Document Loss of Full Activity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothadvertisingevent">
-   <b><a href="#bluetoothadvertisingevent">#bluetoothadvertisingevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothadvertisingevent" class="dfn-panel" data-for="bluetoothadvertisingevent" id="infopanel-for-bluetoothadvertisingevent" role="dialog">
+   <span id="infopaneltitle-for-bluetoothadvertisingevent" style="display:none">Info about the 'BluetoothAdvertisingEvent' definition.</span><b><a href="#bluetoothadvertisingevent">#bluetoothadvertisingevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothadvertisingevent">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-bluetoothadvertisingevent①">(2)</a> <a href="#ref-for-bluetoothadvertisingevent②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothadvertisingeventinit">
-   <b><a href="#dictdef-bluetoothadvertisingeventinit">#dictdef-bluetoothadvertisingeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothadvertisingeventinit" class="dfn-panel" data-for="dictdef-bluetoothadvertisingeventinit" id="infopanel-for-dictdef-bluetoothadvertisingeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothadvertisingeventinit" style="display:none">Info about the 'BluetoothAdvertisingEventInit' definition.</span><b><a href="#dictdef-bluetoothadvertisingeventinit">#dictdef-bluetoothadvertisingeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothadvertisingeventinit">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-uuids">
-   <b><a href="#dom-bluetoothadvertisingeventinit-uuids">#dom-bluetoothadvertisingeventinit-uuids</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingeventinit-uuids" class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-uuids" id="infopanel-for-dom-bluetoothadvertisingeventinit-uuids" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingeventinit-uuids" style="display:none">Info about the 'uuids' definition.</span><b><a href="#dom-bluetoothadvertisingeventinit-uuids">#dom-bluetoothadvertisingeventinit-uuids</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingeventinit-uuids">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-manufacturerdata">
-   <b><a href="#dom-bluetoothadvertisingeventinit-manufacturerdata">#dom-bluetoothadvertisingeventinit-manufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingeventinit-manufacturerdata" class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-manufacturerdata" id="infopanel-for-dom-bluetoothadvertisingeventinit-manufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingeventinit-manufacturerdata" style="display:none">Info about the 'manufacturerData' definition.</span><b><a href="#dom-bluetoothadvertisingeventinit-manufacturerdata">#dom-bluetoothadvertisingeventinit-manufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingeventinit-manufacturerdata">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-servicedata">
-   <b><a href="#dom-bluetoothadvertisingeventinit-servicedata">#dom-bluetoothadvertisingeventinit-servicedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingeventinit-servicedata" class="dfn-panel" data-for="dom-bluetoothadvertisingeventinit-servicedata" id="infopanel-for-dom-bluetoothadvertisingeventinit-servicedata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingeventinit-servicedata" style="display:none">Info about the 'serviceData' definition.</span><b><a href="#dom-bluetoothadvertisingeventinit-servicedata">#dom-bluetoothadvertisingeventinit-servicedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingeventinit-servicedata">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-device">
-   <b><a href="#dom-bluetoothadvertisingevent-device">#dom-bluetoothadvertisingevent-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-device" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-device" id="infopanel-for-dom-bluetoothadvertisingevent-device" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-device" style="display:none">Info about the 'device' definition.</span><b><a href="#dom-bluetoothadvertisingevent-device">#dom-bluetoothadvertisingevent-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-device">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-dom-bluetoothadvertisingevent-device①">(2)</a> <a href="#ref-for-dom-bluetoothadvertisingevent-device②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-uuids">
-   <b><a href="#dom-bluetoothadvertisingevent-uuids">#dom-bluetoothadvertisingevent-uuids</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-uuids" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-uuids" id="infopanel-for-dom-bluetoothadvertisingevent-uuids" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-uuids" style="display:none">Info about the 'uuids' definition.</span><b><a href="#dom-bluetoothadvertisingevent-uuids">#dom-bluetoothadvertisingevent-uuids</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-uuids">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-name">
-   <b><a href="#dom-bluetoothadvertisingevent-name">#dom-bluetoothadvertisingevent-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-name" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-name" id="infopanel-for-dom-bluetoothadvertisingevent-name" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-bluetoothadvertisingevent-name">#dom-bluetoothadvertisingevent-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-name">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-appearance">
-   <b><a href="#dom-bluetoothadvertisingevent-appearance">#dom-bluetoothadvertisingevent-appearance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-appearance" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-appearance" id="infopanel-for-dom-bluetoothadvertisingevent-appearance" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-appearance" style="display:none">Info about the 'appearance' definition.</span><b><a href="#dom-bluetoothadvertisingevent-appearance">#dom-bluetoothadvertisingevent-appearance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-appearance">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-txpower">
-   <b><a href="#dom-bluetoothadvertisingevent-txpower">#dom-bluetoothadvertisingevent-txpower</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-txpower" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-txpower" id="infopanel-for-dom-bluetoothadvertisingevent-txpower" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-txpower" style="display:none">Info about the 'txPower' definition.</span><b><a href="#dom-bluetoothadvertisingevent-txpower">#dom-bluetoothadvertisingevent-txpower</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-txpower">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-rssi">
-   <b><a href="#dom-bluetoothadvertisingevent-rssi">#dom-bluetoothadvertisingevent-rssi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-rssi" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-rssi" id="infopanel-for-dom-bluetoothadvertisingevent-rssi" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-rssi" style="display:none">Info about the 'rssi' definition.</span><b><a href="#dom-bluetoothadvertisingevent-rssi">#dom-bluetoothadvertisingevent-rssi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-rssi">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-manufacturerdata">
-   <b><a href="#dom-bluetoothadvertisingevent-manufacturerdata">#dom-bluetoothadvertisingevent-manufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-manufacturerdata" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-manufacturerdata" id="infopanel-for-dom-bluetoothadvertisingevent-manufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-manufacturerdata" style="display:none">Info about the 'manufacturerData' definition.</span><b><a href="#dom-bluetoothadvertisingevent-manufacturerdata">#dom-bluetoothadvertisingevent-manufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-manufacturerdata">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-servicedata">
-   <b><a href="#dom-bluetoothadvertisingevent-servicedata">#dom-bluetoothadvertisingevent-servicedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-servicedata" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-servicedata" id="infopanel-for-dom-bluetoothadvertisingevent-servicedata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-servicedata" style="display:none">Info about the 'serviceData' definition.</span><b><a href="#dom-bluetoothadvertisingevent-servicedata">#dom-bluetoothadvertisingevent-servicedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-servicedata">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-an-advertisementreceived-event">
-   <b><a href="#fire-an-advertisementreceived-event">#fire-an-advertisementreceived-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-an-advertisementreceived-event" class="dfn-panel" data-for="fire-an-advertisementreceived-event" id="infopanel-for-fire-an-advertisementreceived-event" role="dialog">
+   <span id="infopaneltitle-for-fire-an-advertisementreceived-event" style="display:none">Info about the 'fire an advertisementreceived event' definition.</span><b><a href="#fire-an-advertisementreceived-event">#fire-an-advertisementreceived-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-advertisementreceived-event">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothadvertisingevent-bluetoothadvertisingevent">
-   <b><a href="#dom-bluetoothadvertisingevent-bluetoothadvertisingevent">#dom-bluetoothadvertisingevent-bluetoothadvertisingevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothadvertisingevent-bluetoothadvertisingevent" class="dfn-panel" data-for="dom-bluetoothadvertisingevent-bluetoothadvertisingevent" id="infopanel-for-dom-bluetoothadvertisingevent-bluetoothadvertisingevent" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothadvertisingevent-bluetoothadvertisingevent" style="display:none">Info about the 'BluetoothAdvertisingEvent(type, init)' definition.</span><b><a href="#dom-bluetoothadvertisingevent-bluetoothadvertisingevent">#dom-bluetoothadvertisingevent-bluetoothadvertisingevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothadvertisingevent-bluetoothadvertisingevent">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothmanufacturerdatamap">
-   <b><a href="#bluetoothmanufacturerdatamap">#bluetoothmanufacturerdatamap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothmanufacturerdatamap" class="dfn-panel" data-for="bluetoothmanufacturerdatamap" id="infopanel-for-bluetoothmanufacturerdatamap" role="dialog">
+   <span id="infopaneltitle-for-bluetoothmanufacturerdatamap" style="display:none">Info about the '4.2.3.1. BluetoothManufacturerDataMap' definition.</span><b><a href="#bluetoothmanufacturerdatamap">#bluetoothmanufacturerdatamap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothmanufacturerdatamap">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-bluetoothmanufacturerdatamap①">(2)</a> <a href="#ref-for-bluetoothmanufacturerdatamap②">(3)</a>
     <li><a href="#ref-for-bluetoothmanufacturerdatamap">4.2.3.1. BluetoothManufacturerDataMap</a> <a href="#ref-for-bluetoothmanufacturerdatamap③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothmanufacturerdatamap-backingmap-slot">
-   <b><a href="#dom-bluetoothmanufacturerdatamap-backingmap-slot">#dom-bluetoothmanufacturerdatamap-backingmap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothmanufacturerdatamap-backingmap-slot" class="dfn-panel" data-for="dom-bluetoothmanufacturerdatamap-backingmap-slot" id="infopanel-for-dom-bluetoothmanufacturerdatamap-backingmap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothmanufacturerdatamap-backingmap-slot" style="display:none">Info about the '[[BackingMap]]' definition.</span><b><a href="#dom-bluetoothmanufacturerdatamap-backingmap-slot">#dom-bluetoothmanufacturerdatamap-backingmap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothmanufacturerdatamap-backingmap-slot">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothservicedatamap">
-   <b><a href="#bluetoothservicedatamap">#bluetoothservicedatamap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothservicedatamap" class="dfn-panel" data-for="bluetoothservicedatamap" id="infopanel-for-bluetoothservicedatamap" role="dialog">
+   <span id="infopaneltitle-for-bluetoothservicedatamap" style="display:none">Info about the '4.2.3.2. BluetoothServiceDataMap' definition.</span><b><a href="#bluetoothservicedatamap">#bluetoothservicedatamap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothservicedatamap">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-bluetoothservicedatamap①">(2)</a> <a href="#ref-for-bluetoothservicedatamap②">(3)</a>
     <li><a href="#ref-for-bluetoothservicedatamap">4.2.3.2. BluetoothServiceDataMap</a> <a href="#ref-for-bluetoothservicedatamap③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothservicedatamap-backingmap-slot">
-   <b><a href="#dom-bluetoothservicedatamap-backingmap-slot">#dom-bluetoothservicedatamap-backingmap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothservicedatamap-backingmap-slot" class="dfn-panel" data-for="dom-bluetoothservicedatamap-backingmap-slot" id="infopanel-for-dom-bluetoothservicedatamap-backingmap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothservicedatamap-backingmap-slot" style="display:none">Info about the '[[BackingMap]]' definition.</span><b><a href="#dom-bluetoothservicedatamap-backingmap-slot">#dom-bluetoothservicedatamap-backingmap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothservicedatamap-backingmap-slot">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute">
-   <b><a href="#attribute">#attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute" class="dfn-panel" data-for="attribute" id="infopanel-for-attribute" role="dialog">
+   <span id="infopaneltitle-for-attribute" style="display:none">Info about the 'Attribute' definition.</span><b><a href="#attribute">#attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute">4.1. Global Bluetooth device properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetooth-cache-bluetooth-cache">
-   <b><a href="#bluetooth-cache-bluetooth-cache">#bluetooth-cache-bluetooth-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetooth-cache-bluetooth-cache" class="dfn-panel" data-for="bluetooth-cache-bluetooth-cache" id="infopanel-for-bluetooth-cache-bluetooth-cache" role="dialog">
+   <span id="infopaneltitle-for-bluetooth-cache-bluetooth-cache" style="display:none">Info about the 'Bluetooth cache' definition.</span><b><a href="#bluetooth-cache-bluetooth-cache">#bluetooth-cache-bluetooth-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth-cache-bluetooth-cache">3. Device Discovery</a> <a href="#ref-for-bluetooth-cache-bluetooth-cache①">(2)</a>
     <li><a href="#ref-for-bluetooth-cache-bluetooth-cache②">5.1.2. The Bluetooth cache</a> <a href="#ref-for-bluetooth-cache-bluetooth-cache③">(2)</a>
     <li><a href="#ref-for-bluetooth-cache-bluetooth-cache④">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="populate-the-bluetooth-cache">
-   <b><a href="#populate-the-bluetooth-cache">#populate-the-bluetooth-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-populate-the-bluetooth-cache" class="dfn-panel" data-for="populate-the-bluetooth-cache" id="infopanel-for-populate-the-bluetooth-cache" role="dialog">
+   <span id="infopaneltitle-for-populate-the-bluetooth-cache" style="display:none">Info about the 'populate the Bluetooth cache' definition.</span><b><a href="#populate-the-bluetooth-cache">#populate-the-bluetooth-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-populate-the-bluetooth-cache">3. Device Discovery</a> <a href="#ref-for-populate-the-bluetooth-cache①">(2)</a>
     <li><a href="#ref-for-populate-the-bluetooth-cache②">5.1.2. The Bluetooth cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-the-bluetooth-cache">
-   <b><a href="#query-the-bluetooth-cache">#query-the-bluetooth-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-the-bluetooth-cache" class="dfn-panel" data-for="query-the-bluetooth-cache" id="infopanel-for-query-the-bluetooth-cache" role="dialog">
+   <span id="infopaneltitle-for-query-the-bluetooth-cache" style="display:none">Info about the 'query the Bluetooth cache' definition.</span><b><a href="#query-the-bluetooth-cache">#query-the-bluetooth-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-the-bluetooth-cache">5.1.3. Navigating the Bluetooth Hierarchy</a>
     <li><a href="#ref-for-query-the-bluetooth-cache①">5.1.4. Identifying Services, Characteristics, and Descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="represented">
-   <b><a href="#represented">#represented</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-represented" class="dfn-panel" data-for="represented" id="infopanel-for-represented" role="dialog">
+   <span id="infopaneltitle-for-represented" style="display:none">Info about the 'Represented' definition.</span><b><a href="#represented">#represented</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-represented">5.1.3. Navigating the Bluetooth Hierarchy</a> <a href="#ref-for-represented①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="getgattchildren">
-   <b><a href="#getgattchildren">#getgattchildren</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-getgattchildren" class="dfn-panel" data-for="getgattchildren" id="infopanel-for-getgattchildren" role="dialog">
+   <span id="infopaneltitle-for-getgattchildren" style="display:none">Info about the 'GetGATTChildren' definition.</span><b><a href="#getgattchildren">#getgattchildren</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-getgattchildren">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-getgattchildren①">(2)</a>
     <li><a href="#ref-for-getgattchildren②">5.3. BluetoothRemoteGATTService</a> <a href="#ref-for-getgattchildren③">(2)</a> <a href="#ref-for-getgattchildren④">(3)</a> <a href="#ref-for-getgattchildren⑤">(4)</a>
     <li><a href="#ref-for-getgattchildren⑥">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-getgattchildren⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-attribute">
-   <b><a href="#same-attribute">#same-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-attribute" class="dfn-panel" data-for="same-attribute" id="infopanel-for-same-attribute" role="dialog">
+   <span id="infopaneltitle-for-same-attribute" style="display:none">Info about the 'same attribute' definition.</span><b><a href="#same-attribute">#same-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-attribute">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-same-attribute①">5.1.4. Identifying Services, Characteristics, and Descriptors</a> <a href="#ref-for-same-attribute②">(2)</a> <a href="#ref-for-same-attribute③">(3)</a>
     <li><a href="#ref-for-same-attribute④">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothremotegattserver">
-   <b><a href="#bluetoothremotegattserver">#bluetoothremotegattserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothremotegattserver" class="dfn-panel" data-for="bluetoothremotegattserver" id="infopanel-for-bluetoothremotegattserver" role="dialog">
+   <span id="infopaneltitle-for-bluetoothremotegattserver" style="display:none">Info about the 'BluetoothRemoteGATTServer' definition.</span><b><a href="#bluetoothremotegattserver">#bluetoothremotegattserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothremotegattserver">4.2. BluetoothDevice</a> <a href="#ref-for-bluetoothremotegattserver①">(2)</a>
     <li><a href="#ref-for-bluetoothremotegattserver②">5.1. GATT Information Model</a> <a href="#ref-for-bluetoothremotegattserver③">(2)</a>
@@ -8083,15 +8085,15 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetoothremotegattserver①②">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-device">
-   <b><a href="#dom-bluetoothremotegattserver-device">#dom-bluetoothremotegattserver-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-device" class="dfn-panel" data-for="dom-bluetoothremotegattserver-device" id="infopanel-for-dom-bluetoothremotegattserver-device" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-device" style="display:none">Info about the 'device' definition.</span><b><a href="#dom-bluetoothremotegattserver-device">#dom-bluetoothremotegattserver-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-device">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-device①">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-connected">
-   <b><a href="#dom-bluetoothremotegattserver-connected">#dom-bluetoothremotegattserver-connected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-connected" class="dfn-panel" data-for="dom-bluetoothremotegattserver-connected" id="infopanel-for-dom-bluetoothremotegattserver-connected" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-connected" style="display:none">Info about the 'connected' definition.</span><b><a href="#dom-bluetoothremotegattserver-connected">#dom-bluetoothremotegattserver-connected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connected">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connected①">5.1.3. Navigating the Bluetooth Hierarchy</a>
@@ -8102,8 +8104,8 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connected①②">5.6.4. Responding to Notifications and Indications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-activealgorithms-slot">
-   <b><a href="#dom-bluetoothremotegattserver-activealgorithms-slot">#dom-bluetoothremotegattserver-activealgorithms-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-activealgorithms-slot" class="dfn-panel" data-for="dom-bluetoothremotegattserver-activealgorithms-slot" id="infopanel-for-dom-bluetoothremotegattserver-activealgorithms-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-activealgorithms-slot" style="display:none">Info about the '[[activeAlgorithms]]' definition.</span><b><a href="#dom-bluetoothremotegattserver-activealgorithms-slot">#dom-bluetoothremotegattserver-activealgorithms-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot①">(2)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot②">(3)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot③">(4)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot④">(5)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot⑤">(6)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot⑥">(7)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot⑦">(8)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot⑧">(9)</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot⑨">(10)</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot①⓪">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot①①">(2)</a>
@@ -8111,50 +8113,50 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothremotegattserver-activealgorithms-slot①④">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-connect">
-   <b><a href="#dom-bluetoothremotegattserver-connect">#dom-bluetoothremotegattserver-connect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-connect" class="dfn-panel" data-for="dom-bluetoothremotegattserver-connect" id="infopanel-for-dom-bluetoothremotegattserver-connect" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-connect" style="display:none">Info about the 'connect()' definition.</span><b><a href="#dom-bluetoothremotegattserver-connect">#dom-bluetoothremotegattserver-connect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connect">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connect①">3. Device Discovery</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-connect②">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-dom-bluetoothremotegattserver-connect③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-disconnect">
-   <b><a href="#dom-bluetoothremotegattserver-disconnect">#dom-bluetoothremotegattserver-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-disconnect" class="dfn-panel" data-for="dom-bluetoothremotegattserver-disconnect" id="infopanel-for-dom-bluetoothremotegattserver-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-bluetoothremotegattserver-disconnect">#dom-bluetoothremotegattserver-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-disconnect">3.1. Permission API Integration</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-disconnect①">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-dom-bluetoothremotegattserver-disconnect②">(2)</a> <a href="#ref-for-dom-bluetoothremotegattserver-disconnect③">(3)</a> <a href="#ref-for-dom-bluetoothremotegattserver-disconnect④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="garbage-collect-the-connection">
-   <b><a href="#garbage-collect-the-connection">#garbage-collect-the-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-garbage-collect-the-connection" class="dfn-panel" data-for="garbage-collect-the-connection" id="infopanel-for-garbage-collect-the-connection" role="dialog">
+   <span id="infopaneltitle-for-garbage-collect-the-connection" style="display:none">Info about the 'garbage-collect the connection' definition.</span><b><a href="#garbage-collect-the-connection">#garbage-collect-the-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-garbage-collect-the-connection">5.2. BluetoothRemoteGATTServer</a> <a href="#ref-for-garbage-collect-the-connection①">(2)</a> <a href="#ref-for-garbage-collect-the-connection②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-checking-wrapper">
-   <b><a href="#connection-checking-wrapper">#connection-checking-wrapper</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-checking-wrapper" class="dfn-panel" data-for="connection-checking-wrapper" id="infopanel-for-connection-checking-wrapper" role="dialog">
+   <span id="infopaneltitle-for-connection-checking-wrapper" style="display:none">Info about the 'connection-checking wrapper' definition.</span><b><a href="#connection-checking-wrapper">#connection-checking-wrapper</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-checking-wrapper">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-connection-checking-wrapper①">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-connection-checking-wrapper②">(2)</a>
     <li><a href="#ref-for-connection-checking-wrapper③">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-connection-checking-wrapper④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-getprimaryservice">
-   <b><a href="#dom-bluetoothremotegattserver-getprimaryservice">#dom-bluetoothremotegattserver-getprimaryservice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-getprimaryservice" class="dfn-panel" data-for="dom-bluetoothremotegattserver-getprimaryservice" id="infopanel-for-dom-bluetoothremotegattserver-getprimaryservice" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-getprimaryservice" style="display:none">Info about the 'getPrimaryService(service)' definition.</span><b><a href="#dom-bluetoothremotegattserver-getprimaryservice">#dom-bluetoothremotegattserver-getprimaryservice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-getprimaryservice">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-getprimaryservice①">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattserver-getprimaryservices">
-   <b><a href="#dom-bluetoothremotegattserver-getprimaryservices">#dom-bluetoothremotegattserver-getprimaryservices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattserver-getprimaryservices" class="dfn-panel" data-for="dom-bluetoothremotegattserver-getprimaryservices" id="infopanel-for-dom-bluetoothremotegattserver-getprimaryservices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattserver-getprimaryservices" style="display:none">Info about the 'getPrimaryServices(service)' definition.</span><b><a href="#dom-bluetoothremotegattserver-getprimaryservices">#dom-bluetoothremotegattserver-getprimaryservices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattserver-getprimaryservices">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothremotegattservice">
-   <b><a href="#bluetoothremotegattservice">#bluetoothremotegattservice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothremotegattservice" class="dfn-panel" data-for="bluetoothremotegattservice" id="infopanel-for-bluetoothremotegattservice" role="dialog">
+   <span id="infopaneltitle-for-bluetoothremotegattservice" style="display:none">Info about the 'BluetoothRemoteGATTService' definition.</span><b><a href="#bluetoothremotegattservice">#bluetoothremotegattservice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothremotegattservice">3. Device Discovery</a>
     <li><a href="#ref-for-bluetoothremotegattservice①">5.1. GATT Information Model</a>
@@ -8170,28 +8172,28 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetoothremotegattservice②⑤">5.6.5. Responding to Service Changes</a> <a href="#ref-for-bluetoothremotegattservice②⑥">(2)</a> <a href="#ref-for-bluetoothremotegattservice②⑦">(3)</a> <a href="#ref-for-bluetoothremotegattservice②⑧">(4)</a> <a href="#ref-for-bluetoothremotegattservice②⑨">(5)</a> <a href="#ref-for-bluetoothremotegattservice③⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-device">
-   <b><a href="#dom-bluetoothremotegattservice-device">#dom-bluetoothremotegattservice-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-device" class="dfn-panel" data-for="dom-bluetoothremotegattservice-device" id="infopanel-for-dom-bluetoothremotegattservice-device" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-device" style="display:none">Info about the 'device' definition.</span><b><a href="#dom-bluetoothremotegattservice-device">#dom-bluetoothremotegattservice-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-device">5.1.3. Navigating the Bluetooth Hierarchy</a> <a href="#ref-for-dom-bluetoothremotegattservice-device①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-device②">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-uuid">
-   <b><a href="#dom-bluetoothremotegattservice-uuid">#dom-bluetoothremotegattservice-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-uuid" class="dfn-panel" data-for="dom-bluetoothremotegattservice-uuid" id="infopanel-for-dom-bluetoothremotegattservice-uuid" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-uuid" style="display:none">Info about the 'uuid' definition.</span><b><a href="#dom-bluetoothremotegattservice-uuid">#dom-bluetoothremotegattservice-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-uuid">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-isprimary">
-   <b><a href="#dom-bluetoothremotegattservice-isprimary">#dom-bluetoothremotegattservice-isprimary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-isprimary" class="dfn-panel" data-for="dom-bluetoothremotegattservice-isprimary" id="infopanel-for-dom-bluetoothremotegattservice-isprimary" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-isprimary" style="display:none">Info about the 'isPrimary' definition.</span><b><a href="#dom-bluetoothremotegattservice-isprimary">#dom-bluetoothremotegattservice-isprimary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-isprimary">5.1. GATT Information Model</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-isprimary①">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-representedservice-slot">
-   <b><a href="#dom-bluetoothremotegattservice-representedservice-slot">#dom-bluetoothremotegattservice-representedservice-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-representedservice-slot" class="dfn-panel" data-for="dom-bluetoothremotegattservice-representedservice-slot" id="infopanel-for-dom-bluetoothremotegattservice-representedservice-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-representedservice-slot" style="display:none">Info about the '[[representedService]]' definition.</span><b><a href="#dom-bluetoothremotegattservice-representedservice-slot">#dom-bluetoothremotegattservice-representedservice-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-representedservice-slot">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-representedservice-slot①">5.3. BluetoothRemoteGATTService</a>
@@ -8199,41 +8201,45 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothremotegattservice-representedservice-slot③">5.6.5. Responding to Service Changes</a> <a href="#ref-for-dom-bluetoothremotegattservice-representedservice-slot④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-bluetoothremotegattservice-representing">
-   <b><a href="#create-a-bluetoothremotegattservice-representing">#create-a-bluetoothremotegattservice-representing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-bluetoothremotegattservice-representing" class="dfn-panel" data-for="create-a-bluetoothremotegattservice-representing" id="infopanel-for-create-a-bluetoothremotegattservice-representing" role="dialog">
+   <span id="infopaneltitle-for-create-a-bluetoothremotegattservice-representing" style="display:none">Info about the 'create a BluetoothRemoteGATTService representing' definition.</span><b><a href="#create-a-bluetoothremotegattservice-representing">#create-a-bluetoothremotegattservice-representing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-bluetoothremotegattservice-representing">5.1.2. The Bluetooth cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-getcharacteristic">
-   <b><a href="#dom-bluetoothremotegattservice-getcharacteristic">#dom-bluetoothremotegattservice-getcharacteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-getcharacteristic" class="dfn-panel" data-for="dom-bluetoothremotegattservice-getcharacteristic" id="infopanel-for-dom-bluetoothremotegattservice-getcharacteristic" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-getcharacteristic" style="display:none">Info about the '
+getCharacteristic(characteristic)' definition.</span><b><a href="#dom-bluetoothremotegattservice-getcharacteristic">#dom-bluetoothremotegattservice-getcharacteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristic">1.1. Examples</a> <a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristic①">(2)</a> <a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristic②">(3)</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristic③">5.1. GATT Information Model</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristic④">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-getcharacteristics">
-   <b><a href="#dom-bluetoothremotegattservice-getcharacteristics">#dom-bluetoothremotegattservice-getcharacteristics</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-getcharacteristics" class="dfn-panel" data-for="dom-bluetoothremotegattservice-getcharacteristics" id="infopanel-for-dom-bluetoothremotegattservice-getcharacteristics" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-getcharacteristics" style="display:none">Info about the '
+getCharacteristics(characteristic)' definition.</span><b><a href="#dom-bluetoothremotegattservice-getcharacteristics">#dom-bluetoothremotegattservice-getcharacteristics</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getcharacteristics">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-getincludedservice">
-   <b><a href="#dom-bluetoothremotegattservice-getincludedservice">#dom-bluetoothremotegattservice-getincludedservice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-getincludedservice" class="dfn-panel" data-for="dom-bluetoothremotegattservice-getincludedservice" id="infopanel-for-dom-bluetoothremotegattservice-getincludedservice" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-getincludedservice" style="display:none">Info about the '
+getIncludedService(service)' definition.</span><b><a href="#dom-bluetoothremotegattservice-getincludedservice">#dom-bluetoothremotegattservice-getincludedservice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getincludedservice">5.1. GATT Information Model</a>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getincludedservice①">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattservice-getincludedservices">
-   <b><a href="#dom-bluetoothremotegattservice-getincludedservices">#dom-bluetoothremotegattservice-getincludedservices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattservice-getincludedservices" class="dfn-panel" data-for="dom-bluetoothremotegattservice-getincludedservices" id="infopanel-for-dom-bluetoothremotegattservice-getincludedservices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattservice-getincludedservices" style="display:none">Info about the '
+getIncludedServices(service)' definition.</span><b><a href="#dom-bluetoothremotegattservice-getincludedservices">#dom-bluetoothremotegattservice-getincludedservices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattservice-getincludedservices">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothremotegattcharacteristic">
-   <b><a href="#bluetoothremotegattcharacteristic">#bluetoothremotegattcharacteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothremotegattcharacteristic" class="dfn-panel" data-for="bluetoothremotegattcharacteristic" id="infopanel-for-bluetoothremotegattcharacteristic" role="dialog">
+   <span id="infopaneltitle-for-bluetoothremotegattcharacteristic" style="display:none">Info about the 'BluetoothRemoteGATTCharacteristic' definition.</span><b><a href="#bluetoothremotegattcharacteristic">#bluetoothremotegattcharacteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothremotegattcharacteristic">1.1. Examples</a>
     <li><a href="#ref-for-bluetoothremotegattcharacteristic①">3. Device Discovery</a>
@@ -8252,34 +8258,34 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetoothremotegattcharacteristic②⑤">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-service">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-service">#dom-bluetoothremotegattcharacteristic-service</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-service" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-service" id="infopanel-for-dom-bluetoothremotegattcharacteristic-service" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-service" style="display:none">Info about the 'service' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-service">#dom-bluetoothremotegattcharacteristic-service</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-service">5.1.3. Navigating the Bluetooth Hierarchy</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-service①">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-uuid">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-uuid">#dom-bluetoothremotegattcharacteristic-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-uuid" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-uuid" id="infopanel-for-dom-bluetoothremotegattcharacteristic-uuid" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-uuid" style="display:none">Info about the 'uuid' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-uuid">#dom-bluetoothremotegattcharacteristic-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-uuid">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-properties">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-properties">#dom-bluetoothremotegattcharacteristic-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-properties" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-properties" id="infopanel-for-dom-bluetoothremotegattcharacteristic-properties" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-properties" style="display:none">Info about the 'properties' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-properties">#dom-bluetoothremotegattcharacteristic-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-properties">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-value">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-value">#dom-bluetoothremotegattcharacteristic-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-value" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-value" id="infopanel-for-dom-bluetoothremotegattcharacteristic-value" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-value">#dom-bluetoothremotegattcharacteristic-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-value">1.1. Examples</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-value①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-value②">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot">#dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot" id="infopanel-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot" style="display:none">Info about the '[[representedCharacteristic]]' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot">#dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot①">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot②">(2)</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot③">(3)</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot④">(4)</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot⑤">(5)</a>
@@ -8287,95 +8293,105 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot⑧">5.6.5. Responding to Service Changes</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-representedcharacteristic-slot⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-bluetoothremotegattcharacteristic-representing">
-   <b><a href="#create-a-bluetoothremotegattcharacteristic-representing">#create-a-bluetoothremotegattcharacteristic-representing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-bluetoothremotegattcharacteristic-representing" class="dfn-panel" data-for="create-a-bluetoothremotegattcharacteristic-representing" id="infopanel-for-create-a-bluetoothremotegattcharacteristic-representing" role="dialog">
+   <span id="infopaneltitle-for-create-a-bluetoothremotegattcharacteristic-representing" style="display:none">Info about the 'create a BluetoothRemoteGATTCharacteristic
+representing' definition.</span><b><a href="#create-a-bluetoothremotegattcharacteristic-representing">#create-a-bluetoothremotegattcharacteristic-representing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-bluetoothremotegattcharacteristic-representing">5.1.2. The Bluetooth cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-getdescriptor">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-getdescriptor">#dom-bluetoothremotegattcharacteristic-getdescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-getdescriptor" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-getdescriptor" id="infopanel-for-dom-bluetoothremotegattcharacteristic-getdescriptor" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-getdescriptor" style="display:none">Info about the '
+getDescriptor(descriptor)' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-getdescriptor">#dom-bluetoothremotegattcharacteristic-getdescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-getdescriptor">5.1. GATT Information Model</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-getdescriptor①">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-getdescriptors">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-getdescriptors">#dom-bluetoothremotegattcharacteristic-getdescriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-getdescriptors" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-getdescriptors" id="infopanel-for-dom-bluetoothremotegattcharacteristic-getdescriptors" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-getdescriptors" style="display:none">Info about the '
+getDescriptors(descriptor)' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-getdescriptors">#dom-bluetoothremotegattcharacteristic-getdescriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-getdescriptors">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-readvalue">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-readvalue">#dom-bluetoothremotegattcharacteristic-readvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-readvalue" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-readvalue" id="infopanel-for-dom-bluetoothremotegattcharacteristic-readvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-readvalue" style="display:none">Info about the 'readValue()' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-readvalue">#dom-bluetoothremotegattcharacteristic-readvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-readvalue">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-readvalue①">5.4. BluetoothRemoteGATTCharacteristic</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-readvalue②">5.6.2. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writecharacteristicvalue">
-   <b><a href="#writecharacteristicvalue">#writecharacteristicvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writecharacteristicvalue" class="dfn-panel" data-for="writecharacteristicvalue" id="infopanel-for-writecharacteristicvalue" role="dialog">
+   <span id="infopaneltitle-for-writecharacteristicvalue" style="display:none">Info about the 'WriteCharacteristicValue' definition.</span><b><a href="#writecharacteristicvalue">#writecharacteristicvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writecharacteristicvalue">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-writecharacteristicvalue①">(2)</a> <a href="#ref-for-writecharacteristicvalue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevalue">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-writevalue">#dom-bluetoothremotegattcharacteristic-writevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevalue" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevalue" id="infopanel-for-dom-bluetoothremotegattcharacteristic-writevalue" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevalue" style="display:none">Info about the '
+writeValue(value)' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-writevalue">#dom-bluetoothremotegattcharacteristic-writevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevalue">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevalue①">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevaluewithresponse">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-writevaluewithresponse">#dom-bluetoothremotegattcharacteristic-writevaluewithresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevaluewithresponse" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevaluewithresponse" id="infopanel-for-dom-bluetoothremotegattcharacteristic-writevaluewithresponse" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevaluewithresponse" style="display:none">Info about the '
+writeValueWithResponse(value)' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-writevaluewithresponse">#dom-bluetoothremotegattcharacteristic-writevaluewithresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevaluewithresponse">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevaluewithresponse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse">#dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse" id="infopanel-for-dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse" style="display:none">Info about the '
+writeValueWithoutResponse(value)' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse">#dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-writevaluewithoutresponse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-notification-context-set">
-   <b><a href="#active-notification-context-set">#active-notification-context-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-notification-context-set" class="dfn-panel" data-for="active-notification-context-set" id="infopanel-for-active-notification-context-set" role="dialog">
+   <span id="infopaneltitle-for-active-notification-context-set" style="display:none">Info about the 'active notification
+context set' definition.</span><b><a href="#active-notification-context-set">#active-notification-context-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-notification-context-set">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-active-notification-context-set①">(2)</a> <a href="#ref-for-active-notification-context-set②">(3)</a> <a href="#ref-for-active-notification-context-set③">(4)</a>
     <li><a href="#ref-for-active-notification-context-set④">5.6.3. Responding to Disconnection</a>
     <li><a href="#ref-for-active-notification-context-set⑤">5.6.4. Responding to Notifications and Indications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-startnotifications">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-startnotifications">#dom-bluetoothremotegattcharacteristic-startnotifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-startnotifications" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-startnotifications" id="infopanel-for-dom-bluetoothremotegattcharacteristic-startnotifications" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-startnotifications" style="display:none">Info about the '
+startNotifications()' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-startnotifications">#dom-bluetoothremotegattcharacteristic-startnotifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-startnotifications">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-startnotifications①">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-startnotifications②">(2)</a> <a href="#ref-for-dom-bluetoothremotegattcharacteristic-startnotifications③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-stopnotifications">
-   <b><a href="#dom-bluetoothremotegattcharacteristic-stopnotifications">#dom-bluetoothremotegattcharacteristic-stopnotifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-stopnotifications" class="dfn-panel" data-for="dom-bluetoothremotegattcharacteristic-stopnotifications" id="infopanel-for-dom-bluetoothremotegattcharacteristic-stopnotifications" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattcharacteristic-stopnotifications" style="display:none">Info about the '
+stopNotifications()' definition.</span><b><a href="#dom-bluetoothremotegattcharacteristic-stopnotifications">#dom-bluetoothremotegattcharacteristic-stopnotifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattcharacteristic-stopnotifications">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothcharacteristicproperties">
-   <b><a href="#bluetoothcharacteristicproperties">#bluetoothcharacteristicproperties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothcharacteristicproperties" class="dfn-panel" data-for="bluetoothcharacteristicproperties" id="infopanel-for-bluetoothcharacteristicproperties" role="dialog">
+   <span id="infopaneltitle-for-bluetoothcharacteristicproperties" style="display:none">Info about the 'BluetoothCharacteristicProperties' definition.</span><b><a href="#bluetoothcharacteristicproperties">#bluetoothcharacteristicproperties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothcharacteristicproperties">5.1. GATT Information Model</a>
     <li><a href="#ref-for-bluetoothcharacteristicproperties①">5.4. BluetoothRemoteGATTCharacteristic</a>
     <li><a href="#ref-for-bluetoothcharacteristicproperties②">5.4.1. BluetoothCharacteristicProperties</a> <a href="#ref-for-bluetoothcharacteristicproperties③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic">
-   <b><a href="#create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic">#create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic" class="dfn-panel" data-for="create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic" id="infopanel-for-create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic" role="dialog">
+   <span id="infopaneltitle-for-create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic" style="display:none">Info about the 'create a BluetoothCharacteristicProperties instance from
+the Characteristic' definition.</span><b><a href="#create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic">#create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-bluetoothcharacteristicproperties-instance-from-the-characteristic">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothremotegattdescriptor">
-   <b><a href="#bluetoothremotegattdescriptor">#bluetoothremotegattdescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothremotegattdescriptor" class="dfn-panel" data-for="bluetoothremotegattdescriptor" id="infopanel-for-bluetoothremotegattdescriptor" role="dialog">
+   <span id="infopaneltitle-for-bluetoothremotegattdescriptor" style="display:none">Info about the 'BluetoothRemoteGATTDescriptor' definition.</span><b><a href="#bluetoothremotegattdescriptor">#bluetoothremotegattdescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothremotegattdescriptor">3. Device Discovery</a>
     <li><a href="#ref-for-bluetoothremotegattdescriptor①">5.1. GATT Information Model</a>
@@ -8388,26 +8404,26 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetoothremotegattdescriptor①④">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-characteristic">
-   <b><a href="#dom-bluetoothremotegattdescriptor-characteristic">#dom-bluetoothremotegattdescriptor-characteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-characteristic" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-characteristic" id="infopanel-for-dom-bluetoothremotegattdescriptor-characteristic" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-characteristic" style="display:none">Info about the 'characteristic' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-characteristic">#dom-bluetoothremotegattdescriptor-characteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-characteristic">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-uuid">
-   <b><a href="#dom-bluetoothremotegattdescriptor-uuid">#dom-bluetoothremotegattdescriptor-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-uuid" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-uuid" id="infopanel-for-dom-bluetoothremotegattdescriptor-uuid" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-uuid" style="display:none">Info about the 'uuid' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-uuid">#dom-bluetoothremotegattdescriptor-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-uuid">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-value">
-   <b><a href="#dom-bluetoothremotegattdescriptor-value">#dom-bluetoothremotegattdescriptor-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-value" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-value" id="infopanel-for-dom-bluetoothremotegattdescriptor-value" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-value">#dom-bluetoothremotegattdescriptor-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-value">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-representeddescriptor-slot">
-   <b><a href="#dom-bluetoothremotegattdescriptor-representeddescriptor-slot">#dom-bluetoothremotegattdescriptor-representeddescriptor-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-representeddescriptor-slot" id="infopanel-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot" style="display:none">Info about the '[[representedDescriptor]]' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-representeddescriptor-slot">#dom-bluetoothremotegattdescriptor-representeddescriptor-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot①">5.5. BluetoothRemoteGATTDescriptor</a> <a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot②">(2)</a> <a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot③">(3)</a>
@@ -8415,49 +8431,53 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot⑤">5.6.5. Responding to Service Changes</a> <a href="#ref-for-dom-bluetoothremotegattdescriptor-representeddescriptor-slot⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-bluetoothremotegattdescriptor-representing">
-   <b><a href="#create-a-bluetoothremotegattdescriptor-representing">#create-a-bluetoothremotegattdescriptor-representing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-bluetoothremotegattdescriptor-representing" class="dfn-panel" data-for="create-a-bluetoothremotegattdescriptor-representing" id="infopanel-for-create-a-bluetoothremotegattdescriptor-representing" role="dialog">
+   <span id="infopaneltitle-for-create-a-bluetoothremotegattdescriptor-representing" style="display:none">Info about the 'create a BluetoothRemoteGATTDescriptor representing' definition.</span><b><a href="#create-a-bluetoothremotegattdescriptor-representing">#create-a-bluetoothremotegattdescriptor-representing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-bluetoothremotegattdescriptor-representing">5.1.2. The Bluetooth cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-readvalue">
-   <b><a href="#dom-bluetoothremotegattdescriptor-readvalue">#dom-bluetoothremotegattdescriptor-readvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-readvalue" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-readvalue" id="infopanel-for-dom-bluetoothremotegattdescriptor-readvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-readvalue" style="display:none">Info about the '
+readValue()' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-readvalue">#dom-bluetoothremotegattdescriptor-readvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-readvalue">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-writevalue">
-   <b><a href="#dom-bluetoothremotegattdescriptor-writevalue">#dom-bluetoothremotegattdescriptor-writevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothremotegattdescriptor-writevalue" class="dfn-panel" data-for="dom-bluetoothremotegattdescriptor-writevalue" id="infopanel-for-dom-bluetoothremotegattdescriptor-writevalue" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothremotegattdescriptor-writevalue" style="display:none">Info about the '
+writeValue(value)' definition.</span><b><a href="#dom-bluetoothremotegattdescriptor-writevalue">#dom-bluetoothremotegattdescriptor-writevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothremotegattdescriptor-writevalue">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetooth-tree-bluetooth-tree">
-   <b><a href="#bluetooth-tree-bluetooth-tree">#bluetooth-tree-bluetooth-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetooth-tree-bluetooth-tree" class="dfn-panel" data-for="bluetooth-tree-bluetooth-tree" id="infopanel-for-bluetooth-tree-bluetooth-tree" role="dialog">
+   <span id="infopaneltitle-for-bluetooth-tree-bluetooth-tree" style="display:none">Info about the 'Bluetooth tree' definition.</span><b><a href="#bluetooth-tree-bluetooth-tree">#bluetooth-tree-bluetooth-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth-tree-bluetooth-tree">5.6.2. Event types</a> <a href="#ref-for-bluetooth-tree-bluetooth-tree①">(2)</a>
     <li><a href="#ref-for-bluetooth-tree-bluetooth-tree②">5.6.4. Responding to Notifications and Indications</a>
     <li><a href="#ref-for-bluetooth-tree-bluetooth-tree③">5.6.5. Responding to Service Changes</a> <a href="#ref-for-bluetooth-tree-bluetooth-tree④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothdevice-advertisementreceived">
-   <b><a href="#eventdef-bluetoothdevice-advertisementreceived">#eventdef-bluetoothdevice-advertisementreceived</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothdevice-advertisementreceived" class="dfn-panel" data-for="eventdef-bluetoothdevice-advertisementreceived" id="infopanel-for-eventdef-bluetoothdevice-advertisementreceived" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothdevice-advertisementreceived" style="display:none">Info about the 'advertisementreceived' definition.</span><b><a href="#eventdef-bluetoothdevice-advertisementreceived">#eventdef-bluetoothdevice-advertisementreceived</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothdevice-advertisementreceived">3. Device Discovery</a>
     <li><a href="#ref-for-eventdef-bluetoothdevice-advertisementreceived①">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-eventdef-bluetoothdevice-advertisementreceived②">(2)</a> <a href="#ref-for-eventdef-bluetoothdevice-advertisementreceived③">(3)</a>
     <li><a href="#ref-for-eventdef-bluetoothdevice-advertisementreceived④">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetooth-availabilitychanged">
-   <b><a href="#eventdef-bluetooth-availabilitychanged">#eventdef-bluetooth-availabilitychanged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetooth-availabilitychanged" class="dfn-panel" data-for="eventdef-bluetooth-availabilitychanged" id="infopanel-for-eventdef-bluetooth-availabilitychanged" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetooth-availabilitychanged" style="display:none">Info about the 'availabilitychanged' definition.</span><b><a href="#eventdef-bluetooth-availabilitychanged">#eventdef-bluetooth-availabilitychanged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetooth-availabilitychanged">3. Device Discovery</a>
     <li><a href="#ref-for-eventdef-bluetooth-availabilitychanged①">3.2. Overall Bluetooth availability</a> <a href="#ref-for-eventdef-bluetooth-availabilitychanged②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged">
-   <b><a href="#eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged">#eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged" class="dfn-panel" data-for="eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged" id="infopanel-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged" style="display:none">Info about the '
+      characteristicvaluechanged
+    ' definition.</span><b><a href="#eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged">#eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged">1.1. Examples</a>
     <li><a href="#ref-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged①">5.4. BluetoothRemoteGATTCharacteristic</a>
@@ -8465,45 +8485,49 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-eventdef-bluetoothremotegattcharacteristic-characteristicvaluechanged③">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothdevice-gattserverdisconnected">
-   <b><a href="#eventdef-bluetoothdevice-gattserverdisconnected">#eventdef-bluetoothdevice-gattserverdisconnected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothdevice-gattserverdisconnected" class="dfn-panel" data-for="eventdef-bluetoothdevice-gattserverdisconnected" id="infopanel-for-eventdef-bluetoothdevice-gattserverdisconnected" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothdevice-gattserverdisconnected" style="display:none">Info about the 'gattserverdisconnected' definition.</span><b><a href="#eventdef-bluetoothdevice-gattserverdisconnected">#eventdef-bluetoothdevice-gattserverdisconnected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothdevice-gattserverdisconnected">3.1. Permission API Integration</a>
     <li><a href="#ref-for-eventdef-bluetoothdevice-gattserverdisconnected①">5.6.3. Responding to Disconnection</a>
     <li><a href="#ref-for-eventdef-bluetoothdevice-gattserverdisconnected②">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-serviceadded">
-   <b><a href="#eventdef-bluetoothremotegattservice-serviceadded">#eventdef-bluetoothremotegattservice-serviceadded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothremotegattservice-serviceadded" class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-serviceadded" id="infopanel-for-eventdef-bluetoothremotegattservice-serviceadded" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothremotegattservice-serviceadded" style="display:none">Info about the 'serviceadded' definition.</span><b><a href="#eventdef-bluetoothremotegattservice-serviceadded">#eventdef-bluetoothremotegattservice-serviceadded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-serviceadded">3. Device Discovery</a>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-serviceadded①">5.6.5. Responding to Service Changes</a> <a href="#ref-for-eventdef-bluetoothremotegattservice-serviceadded②">(2)</a>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-serviceadded③">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-servicechanged">
-   <b><a href="#eventdef-bluetoothremotegattservice-servicechanged">#eventdef-bluetoothremotegattservice-servicechanged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothremotegattservice-servicechanged" class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-servicechanged" id="infopanel-for-eventdef-bluetoothremotegattservice-servicechanged" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothremotegattservice-servicechanged" style="display:none">Info about the '
+      servicechanged
+    ' definition.</span><b><a href="#eventdef-bluetoothremotegattservice-servicechanged">#eventdef-bluetoothremotegattservice-servicechanged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-servicechanged">5.6.5. Responding to Service Changes</a> <a href="#ref-for-eventdef-bluetoothremotegattservice-servicechanged①">(2)</a> <a href="#ref-for-eventdef-bluetoothremotegattservice-servicechanged②">(3)</a>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-servicechanged③">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-serviceremoved">
-   <b><a href="#eventdef-bluetoothremotegattservice-serviceremoved">#eventdef-bluetoothremotegattservice-serviceremoved</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-bluetoothremotegattservice-serviceremoved" class="dfn-panel" data-for="eventdef-bluetoothremotegattservice-serviceremoved" id="infopanel-for-eventdef-bluetoothremotegattservice-serviceremoved" role="dialog">
+   <span id="infopaneltitle-for-eventdef-bluetoothremotegattservice-serviceremoved" style="display:none">Info about the '
+      serviceremoved
+    ' definition.</span><b><a href="#eventdef-bluetoothremotegattservice-serviceremoved">#eventdef-bluetoothremotegattservice-serviceremoved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-serviceremoved">5.6.5. Responding to Service Changes</a> <a href="#ref-for-eventdef-bluetoothremotegattservice-serviceremoved①">(2)</a>
     <li><a href="#ref-for-eventdef-bluetoothremotegattservice-serviceremoved②">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clean-up-the-disconnected-device">
-   <b><a href="#clean-up-the-disconnected-device">#clean-up-the-disconnected-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clean-up-the-disconnected-device" class="dfn-panel" data-for="clean-up-the-disconnected-device" id="infopanel-for-clean-up-the-disconnected-device" role="dialog">
+   <span id="infopaneltitle-for-clean-up-the-disconnected-device" style="display:none">Info about the 'clean up the disconnected device' definition.</span><b><a href="#clean-up-the-disconnected-device">#clean-up-the-disconnected-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clean-up-the-disconnected-device">5.2. BluetoothRemoteGATTServer</a>
     <li><a href="#ref-for-clean-up-the-disconnected-device①">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristiceventhandlers">
-   <b><a href="#characteristiceventhandlers">#characteristiceventhandlers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristiceventhandlers" class="dfn-panel" data-for="characteristiceventhandlers" id="infopanel-for-characteristiceventhandlers" role="dialog">
+   <span id="infopaneltitle-for-characteristiceventhandlers" style="display:none">Info about the 'CharacteristicEventHandlers' definition.</span><b><a href="#characteristiceventhandlers">#characteristiceventhandlers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristiceventhandlers">3. Device Discovery</a>
     <li><a href="#ref-for-characteristiceventhandlers①">4.2. BluetoothDevice</a>
@@ -8511,59 +8535,60 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-characteristiceventhandlers③">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characteristiceventhandlers-oncharacteristicvaluechanged">
-   <b><a href="#dom-characteristiceventhandlers-oncharacteristicvaluechanged">#dom-characteristiceventhandlers-oncharacteristicvaluechanged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characteristiceventhandlers-oncharacteristicvaluechanged" class="dfn-panel" data-for="dom-characteristiceventhandlers-oncharacteristicvaluechanged" id="infopanel-for-dom-characteristiceventhandlers-oncharacteristicvaluechanged" role="dialog">
+   <span id="infopaneltitle-for-dom-characteristiceventhandlers-oncharacteristicvaluechanged" style="display:none">Info about the '
+oncharacteristicvaluechanged' definition.</span><b><a href="#dom-characteristiceventhandlers-oncharacteristicvaluechanged">#dom-characteristiceventhandlers-oncharacteristicvaluechanged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characteristiceventhandlers-oncharacteristicvaluechanged">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothdeviceeventhandlers">
-   <b><a href="#bluetoothdeviceeventhandlers">#bluetoothdeviceeventhandlers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothdeviceeventhandlers" class="dfn-panel" data-for="bluetoothdeviceeventhandlers" id="infopanel-for-bluetoothdeviceeventhandlers" role="dialog">
+   <span id="infopaneltitle-for-bluetoothdeviceeventhandlers" style="display:none">Info about the 'BluetoothDeviceEventHandlers' definition.</span><b><a href="#bluetoothdeviceeventhandlers">#bluetoothdeviceeventhandlers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdeviceeventhandlers">3. Device Discovery</a>
     <li><a href="#ref-for-bluetoothdeviceeventhandlers①">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdeviceeventhandlers-onadvertisementreceived">
-   <b><a href="#dom-bluetoothdeviceeventhandlers-onadvertisementreceived">#dom-bluetoothdeviceeventhandlers-onadvertisementreceived</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdeviceeventhandlers-onadvertisementreceived" class="dfn-panel" data-for="dom-bluetoothdeviceeventhandlers-onadvertisementreceived" id="infopanel-for-dom-bluetoothdeviceeventhandlers-onadvertisementreceived" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdeviceeventhandlers-onadvertisementreceived" style="display:none">Info about the 'onadvertisementreceived' definition.</span><b><a href="#dom-bluetoothdeviceeventhandlers-onadvertisementreceived">#dom-bluetoothdeviceeventhandlers-onadvertisementreceived</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdeviceeventhandlers-onadvertisementreceived">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdeviceeventhandlers-ongattserverdisconnected">
-   <b><a href="#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected">#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdeviceeventhandlers-ongattserverdisconnected" class="dfn-panel" data-for="dom-bluetoothdeviceeventhandlers-ongattserverdisconnected" id="infopanel-for-dom-bluetoothdeviceeventhandlers-ongattserverdisconnected" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdeviceeventhandlers-ongattserverdisconnected" style="display:none">Info about the 'ongattserverdisconnected' definition.</span><b><a href="#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected">#dom-bluetoothdeviceeventhandlers-ongattserverdisconnected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdeviceeventhandlers-ongattserverdisconnected">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceeventhandlers">
-   <b><a href="#serviceeventhandlers">#serviceeventhandlers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceeventhandlers" class="dfn-panel" data-for="serviceeventhandlers" id="infopanel-for-serviceeventhandlers" role="dialog">
+   <span id="infopaneltitle-for-serviceeventhandlers" style="display:none">Info about the 'ServiceEventHandlers' definition.</span><b><a href="#serviceeventhandlers">#serviceeventhandlers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceeventhandlers">3. Device Discovery</a>
     <li><a href="#ref-for-serviceeventhandlers①">4.2. BluetoothDevice</a>
     <li><a href="#ref-for-serviceeventhandlers②">5.3. BluetoothRemoteGATTService</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceeventhandlers-onserviceadded">
-   <b><a href="#dom-serviceeventhandlers-onserviceadded">#dom-serviceeventhandlers-onserviceadded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceeventhandlers-onserviceadded" class="dfn-panel" data-for="dom-serviceeventhandlers-onserviceadded" id="infopanel-for-dom-serviceeventhandlers-onserviceadded" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceeventhandlers-onserviceadded" style="display:none">Info about the 'onserviceadded' definition.</span><b><a href="#dom-serviceeventhandlers-onserviceadded">#dom-serviceeventhandlers-onserviceadded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceeventhandlers-onserviceadded">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceeventhandlers-onservicechanged">
-   <b><a href="#dom-serviceeventhandlers-onservicechanged">#dom-serviceeventhandlers-onservicechanged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceeventhandlers-onservicechanged" class="dfn-panel" data-for="dom-serviceeventhandlers-onservicechanged" id="infopanel-for-dom-serviceeventhandlers-onservicechanged" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceeventhandlers-onservicechanged" style="display:none">Info about the 'onservicechanged' definition.</span><b><a href="#dom-serviceeventhandlers-onservicechanged">#dom-serviceeventhandlers-onservicechanged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceeventhandlers-onservicechanged">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceeventhandlers-onserviceremoved">
-   <b><a href="#dom-serviceeventhandlers-onserviceremoved">#dom-serviceeventhandlers-onserviceremoved</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceeventhandlers-onserviceremoved" class="dfn-panel" data-for="dom-serviceeventhandlers-onserviceremoved" id="infopanel-for-dom-serviceeventhandlers-onserviceremoved" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceeventhandlers-onserviceremoved" style="display:none">Info about the 'onserviceremoved' definition.</span><b><a href="#dom-serviceeventhandlers-onserviceremoved">#dom-serviceeventhandlers-onserviceremoved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceeventhandlers-onserviceremoved">5.6.6. IDL event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-uuid">
-   <b><a href="#typedefdef-uuid">#typedefdef-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-uuid" class="dfn-panel" data-for="typedefdef-uuid" id="infopanel-for-typedefdef-uuid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-uuid" style="display:none">Info about the 'UUID' definition.</span><b><a href="#typedefdef-uuid">#typedefdef-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-uuid">3.1. Permission API Integration</a>
     <li><a href="#ref-for-typedefdef-uuid①">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-typedefdef-uuid②">(2)</a> <a href="#ref-for-typedefdef-uuid③">(3)</a>
@@ -8573,23 +8598,25 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-typedefdef-uuid⑦">6.1. Standardized UUIDs</a> <a href="#ref-for-typedefdef-uuid⑧">(2)</a> <a href="#ref-for-typedefdef-uuid⑨">(3)</a> <a href="#ref-for-typedefdef-uuid①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-uuid">
-   <b><a href="#valid-uuid">#valid-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-uuid" class="dfn-panel" data-for="valid-uuid" id="infopanel-for-valid-uuid" role="dialog">
+   <span id="infopaneltitle-for-valid-uuid" style="display:none">Info about the 'valid
+UUID' definition.</span><b><a href="#valid-uuid">#valid-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-uuid">6. UUIDs</a> <a href="#ref-for-valid-uuid①">(2)</a> <a href="#ref-for-valid-uuid②">(3)</a>
     <li><a href="#ref-for-valid-uuid③">6.1. Standardized UUIDs</a> <a href="#ref-for-valid-uuid④">(2)</a> <a href="#ref-for-valid-uuid⑤">(3)</a> <a href="#ref-for-valid-uuid⑥">(4)</a>
     <li><a href="#ref-for-valid-uuid⑦">7. The GATT Blocklist</a> <a href="#ref-for-valid-uuid⑧">(2)</a> <a href="#ref-for-valid-uuid⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothuuid-canonicaluuid">
-   <b><a href="#dom-bluetoothuuid-canonicaluuid">#dom-bluetoothuuid-canonicaluuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothuuid-canonicaluuid" class="dfn-panel" data-for="dom-bluetoothuuid-canonicaluuid" id="infopanel-for-dom-bluetoothuuid-canonicaluuid" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothuuid-canonicaluuid" style="display:none">Info about the '
+canonicalUUID(alias)' definition.</span><b><a href="#dom-bluetoothuuid-canonicaluuid">#dom-bluetoothuuid-canonicaluuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothuuid-canonicaluuid">6. UUIDs</a>
     <li><a href="#ref-for-dom-bluetoothuuid-canonicaluuid①">6.1. Standardized UUIDs</a> <a href="#ref-for-dom-bluetoothuuid-canonicaluuid②">(2)</a> <a href="#ref-for-dom-bluetoothuuid-canonicaluuid③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-bluetoothserviceuuid">
-   <b><a href="#typedefdef-bluetoothserviceuuid">#typedefdef-bluetoothserviceuuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-bluetoothserviceuuid" class="dfn-panel" data-for="typedefdef-bluetoothserviceuuid" id="infopanel-for-typedefdef-bluetoothserviceuuid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-bluetoothserviceuuid" style="display:none">Info about the 'BluetoothServiceUUID' definition.</span><b><a href="#typedefdef-bluetoothserviceuuid">#typedefdef-bluetoothserviceuuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-bluetoothserviceuuid">3. Device Discovery</a> <a href="#ref-for-typedefdef-bluetoothserviceuuid①">(2)</a> <a href="#ref-for-typedefdef-bluetoothserviceuuid②">(3)</a>
     <li><a href="#ref-for-typedefdef-bluetoothserviceuuid③">3.1. Permission API Integration</a>
@@ -8598,28 +8625,29 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-typedefdef-bluetoothserviceuuid⑧">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-bluetoothcharacteristicuuid">
-   <b><a href="#typedefdef-bluetoothcharacteristicuuid">#typedefdef-bluetoothcharacteristicuuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-bluetoothcharacteristicuuid" class="dfn-panel" data-for="typedefdef-bluetoothcharacteristicuuid" id="infopanel-for-typedefdef-bluetoothcharacteristicuuid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-bluetoothcharacteristicuuid" style="display:none">Info about the 'BluetoothCharacteristicUUID' definition.</span><b><a href="#typedefdef-bluetoothcharacteristicuuid">#typedefdef-bluetoothcharacteristicuuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-bluetoothcharacteristicuuid">5.3. BluetoothRemoteGATTService</a> <a href="#ref-for-typedefdef-bluetoothcharacteristicuuid①">(2)</a>
     <li><a href="#ref-for-typedefdef-bluetoothcharacteristicuuid②">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-bluetoothdescriptoruuid">
-   <b><a href="#typedefdef-bluetoothdescriptoruuid">#typedefdef-bluetoothdescriptoruuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-bluetoothdescriptoruuid" class="dfn-panel" data-for="typedefdef-bluetoothdescriptoruuid" id="infopanel-for-typedefdef-bluetoothdescriptoruuid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-bluetoothdescriptoruuid" style="display:none">Info about the 'BluetoothDescriptorUUID' definition.</span><b><a href="#typedefdef-bluetoothdescriptoruuid">#typedefdef-bluetoothdescriptoruuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-bluetoothdescriptoruuid">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-typedefdef-bluetoothdescriptoruuid①">(2)</a>
     <li><a href="#ref-for-typedefdef-bluetoothdescriptoruuid②">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolveuuidname">
-   <b><a href="#resolveuuidname">#resolveuuidname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolveuuidname" class="dfn-panel" data-for="resolveuuidname" id="infopanel-for-resolveuuidname" role="dialog">
+   <span id="infopaneltitle-for-resolveuuidname" style="display:none">Info about the 'ResolveUUIDName' definition.</span><b><a href="#resolveuuidname">#resolveuuidname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolveuuidname">6.1. Standardized UUIDs</a> <a href="#ref-for-resolveuuidname①">(2)</a> <a href="#ref-for-resolveuuidname②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothuuid-getservice">
-   <b><a href="#dom-bluetoothuuid-getservice">#dom-bluetoothuuid-getservice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothuuid-getservice" class="dfn-panel" data-for="dom-bluetoothuuid-getservice" id="infopanel-for-dom-bluetoothuuid-getservice" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothuuid-getservice" style="display:none">Info about the '
+getService(name)' definition.</span><b><a href="#dom-bluetoothuuid-getservice">#dom-bluetoothuuid-getservice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothuuid-getservice">3. Device Discovery</a> <a href="#ref-for-dom-bluetoothuuid-getservice①">(2)</a> <a href="#ref-for-dom-bluetoothuuid-getservice②">(3)</a> <a href="#ref-for-dom-bluetoothuuid-getservice③">(4)</a> <a href="#ref-for-dom-bluetoothuuid-getservice④">(5)</a>
     <li><a href="#ref-for-dom-bluetoothuuid-getservice⑤">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-dom-bluetoothuuid-getservice⑥">(2)</a>
@@ -8629,100 +8657,104 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-dom-bluetoothuuid-getservice①⑥">9. Terminology and Conventions</a> <a href="#ref-for-dom-bluetoothuuid-getservice①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothuuid-getcharacteristic">
-   <b><a href="#dom-bluetoothuuid-getcharacteristic">#dom-bluetoothuuid-getcharacteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothuuid-getcharacteristic" class="dfn-panel" data-for="dom-bluetoothuuid-getcharacteristic" id="infopanel-for-dom-bluetoothuuid-getcharacteristic" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothuuid-getcharacteristic" style="display:none">Info about the '
+getCharacteristic(name)' definition.</span><b><a href="#dom-bluetoothuuid-getcharacteristic">#dom-bluetoothuuid-getcharacteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothuuid-getcharacteristic">5.3. BluetoothRemoteGATTService</a> <a href="#ref-for-dom-bluetoothuuid-getcharacteristic①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothuuid-getcharacteristic②">6.1. Standardized UUIDs</a> <a href="#ref-for-dom-bluetoothuuid-getcharacteristic③">(2)</a> <a href="#ref-for-dom-bluetoothuuid-getcharacteristic④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothuuid-getdescriptor">
-   <b><a href="#dom-bluetoothuuid-getdescriptor">#dom-bluetoothuuid-getdescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothuuid-getdescriptor" class="dfn-panel" data-for="dom-bluetoothuuid-getdescriptor" id="infopanel-for-dom-bluetoothuuid-getdescriptor" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothuuid-getdescriptor" style="display:none">Info about the '
+getDescriptor(name)' definition.</span><b><a href="#dom-bluetoothuuid-getdescriptor">#dom-bluetoothuuid-getdescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothuuid-getdescriptor">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-bluetoothuuid-getdescriptor①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothuuid-getdescriptor②">6.1. Standardized UUIDs</a> <a href="#ref-for-dom-bluetoothuuid-getdescriptor③">(2)</a> <a href="#ref-for-dom-bluetoothuuid-getdescriptor④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsing-the-blocklist">
-   <b><a href="#parsing-the-blocklist">#parsing-the-blocklist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsing-the-blocklist" class="dfn-panel" data-for="parsing-the-blocklist" id="infopanel-for-parsing-the-blocklist" role="dialog">
+   <span id="infopaneltitle-for-parsing-the-blocklist" style="display:none">Info about the 'parsing the blocklist' definition.</span><b><a href="#parsing-the-blocklist">#parsing-the-blocklist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsing-the-blocklist">7. The GATT Blocklist</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gatt-blocklist">
-   <b><a href="#gatt-blocklist">#gatt-blocklist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gatt-blocklist" class="dfn-panel" data-for="gatt-blocklist" id="infopanel-for-gatt-blocklist" role="dialog">
+   <span id="infopaneltitle-for-gatt-blocklist" style="display:none">Info about the 'GATT blocklist' definition.</span><b><a href="#gatt-blocklist">#gatt-blocklist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gatt-blocklist">2.3. Attacks on devices</a>
     <li><a href="#ref-for-gatt-blocklist①">7. The GATT Blocklist</a> <a href="#ref-for-gatt-blocklist②">(2)</a> <a href="#ref-for-gatt-blocklist③">(3)</a> <a href="#ref-for-gatt-blocklist④">(4)</a> <a href="#ref-for-gatt-blocklist⑤">(5)</a> <a href="#ref-for-gatt-blocklist⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blocklisted">
-   <b><a href="#blocklisted">#blocklisted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blocklisted" class="dfn-panel" data-for="blocklisted" id="infopanel-for-blocklisted" role="dialog">
+   <span id="infopaneltitle-for-blocklisted" style="display:none">Info about the 'blocklisted' definition.</span><b><a href="#blocklisted">#blocklisted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blocklisted">3. Device Discovery</a> <a href="#ref-for-blocklisted①">(2)</a> <a href="#ref-for-blocklisted②">(3)</a>
     <li><a href="#ref-for-blocklisted③">5.1.3. Navigating the Bluetooth Hierarchy</a> <a href="#ref-for-blocklisted④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blocklisted-for-reads">
-   <b><a href="#blocklisted-for-reads">#blocklisted-for-reads</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blocklisted-for-reads" class="dfn-panel" data-for="blocklisted-for-reads" id="infopanel-for-blocklisted-for-reads" role="dialog">
+   <span id="infopaneltitle-for-blocklisted-for-reads" style="display:none">Info about the 'blocklisted for reads' definition.</span><b><a href="#blocklisted-for-reads">#blocklisted-for-reads</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blocklisted-for-reads">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-blocklisted-for-reads①">(2)</a>
     <li><a href="#ref-for-blocklisted-for-reads②">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blocklisted-for-writes">
-   <b><a href="#blocklisted-for-writes">#blocklisted-for-writes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blocklisted-for-writes" class="dfn-panel" data-for="blocklisted-for-writes" id="infopanel-for-blocklisted-for-writes" role="dialog">
+   <span id="infopaneltitle-for-blocklisted-for-writes" style="display:none">Info about the 'blocklisted for writes' definition.</span><b><a href="#blocklisted-for-writes">#blocklisted-for-writes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blocklisted-for-writes">5.4. BluetoothRemoteGATTCharacteristic</a>
     <li><a href="#ref-for-blocklisted-for-writes①">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-bluetooth">
-   <b><a href="#dom-navigator-bluetooth">#dom-navigator-bluetooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-bluetooth" class="dfn-panel" data-for="dom-navigator-bluetooth" id="infopanel-for-dom-navigator-bluetooth" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-bluetooth" style="display:none">Info about the 'bluetooth' definition.</span><b><a href="#dom-navigator-bluetooth">#dom-navigator-bluetooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-bluetooth">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-dom-navigator-bluetooth①">(2)</a> <a href="#ref-for-dom-navigator-bluetooth②">(3)</a> <a href="#ref-for-dom-navigator-bluetooth③">(4)</a>
     <li><a href="#ref-for-dom-navigator-bluetooth④">5.6.1. Bluetooth Tree</a> <a href="#ref-for-dom-navigator-bluetooth⑤">(2)</a> <a href="#ref-for-dom-navigator-bluetooth⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-only-arraybuffer">
-   <b><a href="#read-only-arraybuffer">#read-only-arraybuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-only-arraybuffer" class="dfn-panel" data-for="read-only-arraybuffer" id="infopanel-for-read-only-arraybuffer" role="dialog">
+   <span id="infopaneltitle-for-read-only-arraybuffer" style="display:none">Info about the 'read only ArrayBuffer' definition.</span><b><a href="#read-only-arraybuffer">#read-only-arraybuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-only-arraybuffer">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-read-only-arraybuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advertising-event">
-   <b><a href="#advertising-event">#advertising-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advertising-event" class="dfn-panel" data-for="advertising-event" id="infopanel-for-advertising-event" role="dialog">
+   <span id="infopaneltitle-for-advertising-event" style="display:none">Info about the 'advertising events' definition.</span><b><a href="#advertising-event">#advertising-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advertising-event">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-advertising-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extended-inquiry-response">
-   <b><a href="#extended-inquiry-response">#extended-inquiry-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extended-inquiry-response" class="dfn-panel" data-for="extended-inquiry-response" id="infopanel-for-extended-inquiry-response" role="dialog">
+   <span id="infopaneltitle-for-extended-inquiry-response" style="display:none">Info about the 'Extended Inquiry Response' definition.</span><b><a href="#extended-inquiry-response">#extended-inquiry-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extended-inquiry-response">3. Device Discovery</a> <a href="#ref-for-extended-inquiry-response①">(2)</a>
     <li><a href="#ref-for-extended-inquiry-response②">4.1. Global Bluetooth device properties</a> <a href="#ref-for-extended-inquiry-response③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-bd_addr-command">
-   <b><a href="#read-bd_addr-command">#read-bd_addr-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-bd_addr-command" class="dfn-panel" data-for="read-bd_addr-command" id="infopanel-for-read-bd_addr-command" role="dialog">
+   <span id="infopaneltitle-for-read-bd_addr-command" style="display:none">Info about the 'Read BD_ADDR Command' definition.</span><b><a href="#read-bd_addr-command">#read-bd_addr-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-bd_addr-command">2.4. Bluetooth device identifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rssi">
-   <b><a href="#rssi">#rssi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rssi" class="dfn-panel" data-for="rssi" id="infopanel-for-rssi" role="dialog">
+   <span id="infopaneltitle-for-rssi" style="display:none">Info about the '
+                                  
+                                          RSSI' definition.</span><b><a href="#rssi">#rssi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rssi">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="searching-for-services">
-   <b><a href="#searching-for-services">#searching-for-services</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-searching-for-services" class="dfn-panel" data-for="searching-for-services" id="infopanel-for-searching-for-services" role="dialog">
+   <span id="infopaneltitle-for-searching-for-services" style="display:none">Info about the 'Searching for Services' definition.</span><b><a href="#searching-for-services">#searching-for-services</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-searching-for-services">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uuid">
-   <b><a href="#uuid">#uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uuid" class="dfn-panel" data-for="uuid" id="infopanel-for-uuid" role="dialog">
+   <span id="infopaneltitle-for-uuid" style="display:none">Info about the 'UUID' definition.</span><b><a href="#uuid">#uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uuid">3. Device Discovery</a>
     <li><a href="#ref-for-uuid①">4.2.3. Responding to Advertising Events</a>
@@ -8731,45 +8763,45 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-uuid⑦">7. The GATT Blocklist</a> <a href="#ref-for-uuid⑧">(2)</a> <a href="#ref-for-uuid⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uuid-alias">
-   <b><a href="#uuid-alias">#uuid-alias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uuid-alias" class="dfn-panel" data-for="uuid-alias" id="infopanel-for-uuid-alias" role="dialog">
+   <span id="infopaneltitle-for-uuid-alias" style="display:none">Info about the 'UUID alias' definition.</span><b><a href="#uuid-alias">#uuid-alias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uuid-alias">6. UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-128-bit-uuid-represented">
-   <b><a href="#the-128-bit-uuid-represented">#the-128-bit-uuid-represented</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-128-bit-uuid-represented" class="dfn-panel" data-for="the-128-bit-uuid-represented" id="infopanel-for-the-128-bit-uuid-represented" role="dialog">
+   <span id="infopaneltitle-for-the-128-bit-uuid-represented" style="display:none">Info about the 'the 128-bit UUID represented' definition.</span><b><a href="#the-128-bit-uuid-represented">#the-128-bit-uuid-represented</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-128-bit-uuid-represented">6.1. Standardized UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="broadcaster">
-   <b><a href="#broadcaster">#broadcaster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-broadcaster" class="dfn-panel" data-for="broadcaster" id="infopanel-for-broadcaster" role="dialog">
+   <span id="infopaneltitle-for-broadcaster" style="display:none">Info about the 'Broadcaster' definition.</span><b><a href="#broadcaster">#broadcaster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-broadcaster">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observer">
-   <b><a href="#observer">#observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observer" class="dfn-panel" data-for="observer" id="infopanel-for-observer" role="dialog">
+   <span id="infopaneltitle-for-observer" style="display:none">Info about the 'Observer' definition.</span><b><a href="#observer">#observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observer">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="peripheral">
-   <b><a href="#peripheral">#peripheral</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-peripheral" class="dfn-panel" data-for="peripheral" id="infopanel-for-peripheral" role="dialog">
+   <span id="infopaneltitle-for-peripheral" style="display:none">Info about the 'Peripheral' definition.</span><b><a href="#peripheral">#peripheral</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-peripheral">1. Introduction</a> <a href="#ref-for-peripheral①">(2)</a> <a href="#ref-for-peripheral②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="central">
-   <b><a href="#central">#central</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-central" class="dfn-panel" data-for="central" id="infopanel-for-central" role="dialog">
+   <span id="infopaneltitle-for-central" style="display:none">Info about the 'Central' definition.</span><b><a href="#central">#central</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-central">1. Introduction</a> <a href="#ref-for-central①">(2)</a> <a href="#ref-for-central②">(3)</a>
     <li><a href="#ref-for-central③">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetooth-device-name">
-   <b><a href="#bluetooth-device-name">#bluetooth-device-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetooth-device-name" class="dfn-panel" data-for="bluetooth-device-name" id="infopanel-for-bluetooth-device-name" role="dialog">
+   <span id="infopaneltitle-for-bluetooth-device-name" style="display:none">Info about the 'Bluetooth Device Name' definition.</span><b><a href="#bluetooth-device-name">#bluetooth-device-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth-device-name">2.4. Bluetooth device identifiers</a>
     <li><a href="#ref-for-bluetooth-device-name①">3. Device Discovery</a> <a href="#ref-for-bluetooth-device-name②">(2)</a> <a href="#ref-for-bluetooth-device-name③">(3)</a> <a href="#ref-for-bluetooth-device-name④">(4)</a> <a href="#ref-for-bluetooth-device-name⑤">(5)</a>
@@ -8777,141 +8809,141 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-bluetooth-device-name⑧">4.2. BluetoothDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="device-discovery-procedure">
-   <b><a href="#device-discovery-procedure">#device-discovery-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-device-discovery-procedure" class="dfn-panel" data-for="device-discovery-procedure" id="infopanel-for-device-discovery-procedure" role="dialog">
+   <span id="infopaneltitle-for-device-discovery-procedure" style="display:none">Info about the 'Device Discovery Procedure' definition.</span><b><a href="#device-discovery-procedure">#device-discovery-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-discovery-procedure">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="br-edr-bonding-procedure">
-   <b><a href="#br-edr-bonding-procedure">#br-edr-bonding-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-br-edr-bonding-procedure" class="dfn-panel" data-for="br-edr-bonding-procedure" id="infopanel-for-br-edr-bonding-procedure" role="dialog">
+   <span id="infopaneltitle-for-br-edr-bonding-procedure" style="display:none">Info about the 'BR/EDR Bonding Procedure' definition.</span><b><a href="#br-edr-bonding-procedure">#br-edr-bonding-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-br-edr-bonding-procedure">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observation-procedure">
-   <b><a href="#observation-procedure">#observation-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observation-procedure" class="dfn-panel" data-for="observation-procedure" id="infopanel-for-observation-procedure" role="dialog">
+   <span id="infopaneltitle-for-observation-procedure" style="display:none">Info about the 'Observation Procedure' definition.</span><b><a href="#observation-procedure">#observation-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observation-procedure">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="general-discovery-procedure">
-   <b><a href="#general-discovery-procedure">#general-discovery-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-general-discovery-procedure" class="dfn-panel" data-for="general-discovery-procedure" id="infopanel-for-general-discovery-procedure" role="dialog">
+   <span id="infopaneltitle-for-general-discovery-procedure" style="display:none">Info about the 'General Discovery Procedure' definition.</span><b><a href="#general-discovery-procedure">#general-discovery-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-general-discovery-procedure">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="name-discovery-procedure">
-   <b><a href="#name-discovery-procedure">#name-discovery-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-name-discovery-procedure" class="dfn-panel" data-for="name-discovery-procedure" id="infopanel-for-name-discovery-procedure" role="dialog">
+   <span id="infopaneltitle-for-name-discovery-procedure" style="display:none">Info about the 'Name Discovery Procedure' definition.</span><b><a href="#name-discovery-procedure">#name-discovery-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name-discovery-procedure">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="le-bonding-procedure">
-   <b><a href="#le-bonding-procedure">#le-bonding-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-le-bonding-procedure" class="dfn-panel" data-for="le-bonding-procedure" id="infopanel-for-le-bonding-procedure" role="dialog">
+   <span id="infopaneltitle-for-le-bonding-procedure" style="display:none">Info about the 'LE Bonding Procedure' definition.</span><b><a href="#le-bonding-procedure">#le-bonding-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-le-bonding-procedure">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="privacy-feature">
-   <b><a href="#privacy-feature">#privacy-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-privacy-feature" class="dfn-panel" data-for="privacy-feature" id="infopanel-for-privacy-feature" role="dialog">
+   <span id="infopaneltitle-for-privacy-feature" style="display:none">Info about the 'Privacy Feature' definition.</span><b><a href="#privacy-feature">#privacy-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-privacy-feature">2.4.2. The UA’s Bluetooth address</a> <a href="#ref-for-privacy-feature①">(2)</a> <a href="#ref-for-privacy-feature②">(3)</a>
     <li><a href="#ref-for-privacy-feature③">3. Device Discovery</a> <a href="#ref-for-privacy-feature④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="static-address">
-   <b><a href="#static-address">#static-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-static-address" class="dfn-panel" data-for="static-address" id="infopanel-for-static-address" role="dialog">
+   <span id="infopaneltitle-for-static-address" style="display:none">Info about the 'Static Address' definition.</span><b><a href="#static-address">#static-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-address">4.1. Global Bluetooth device properties</a> <a href="#ref-for-static-address①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="private-address">
-   <b><a href="#private-address">#private-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-private-address" class="dfn-panel" data-for="private-address" id="infopanel-for-private-address" role="dialog">
+   <span id="infopaneltitle-for-private-address" style="display:none">Info about the 'Private address' definition.</span><b><a href="#private-address">#private-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-private-address">2.4. Bluetooth device identifiers</a>
     <li><a href="#ref-for-private-address①">4.1. Global Bluetooth device properties</a> <a href="#ref-for-private-address②">(2)</a> <a href="#ref-for-private-address③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolvable-private-address-resolution-procedure">
-   <b><a href="#resolvable-private-address-resolution-procedure">#resolvable-private-address-resolution-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolvable-private-address-resolution-procedure" class="dfn-panel" data-for="resolvable-private-address-resolution-procedure" id="infopanel-for-resolvable-private-address-resolution-procedure" role="dialog">
+   <span id="infopaneltitle-for-resolvable-private-address-resolution-procedure" style="display:none">Info about the 'Resolvable Private Address Resolution Procedure' definition.</span><b><a href="#resolvable-private-address-resolution-procedure">#resolvable-private-address-resolution-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolvable-private-address-resolution-procedure">2.4. Bluetooth device identifiers</a>
     <li><a href="#ref-for-resolvable-private-address-resolution-procedure①">4.1. Global Bluetooth device properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advertising-data">
-   <b><a href="#advertising-data">#advertising-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advertising-data" class="dfn-panel" data-for="advertising-data" id="infopanel-for-advertising-data" role="dialog">
+   <span id="infopaneltitle-for-advertising-data" style="display:none">Info about the 'Advertising Data' definition.</span><b><a href="#advertising-data">#advertising-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advertising-data">4.1. Global Bluetooth device properties</a> <a href="#ref-for-advertising-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ad-structure">
-   <b><a href="#ad-structure">#ad-structure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ad-structure" class="dfn-panel" data-for="ad-structure" id="infopanel-for-ad-structure" role="dialog">
+   <span id="infopaneltitle-for-ad-structure" style="display:none">Info about the 'AD structure' definition.</span><b><a href="#ad-structure">#ad-structure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ad-structure">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bd_addr">
-   <b><a href="#bd_addr">#bd_addr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bd_addr" class="dfn-panel" data-for="bd_addr" id="infopanel-for-bd_addr" role="dialog">
+   <span id="infopaneltitle-for-bd_addr" style="display:none">Info about the 'BD_ADDR' definition.</span><b><a href="#bd_addr">#bd_addr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bd_addr">2.4. Bluetooth device identifiers</a> <a href="#ref-for-bd_addr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-bluetooth-address">
-   <b><a href="#public-bluetooth-address">#public-bluetooth-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-bluetooth-address" class="dfn-panel" data-for="public-bluetooth-address" id="infopanel-for-public-bluetooth-address" role="dialog">
+   <span id="infopaneltitle-for-public-bluetooth-address" style="display:none">Info about the 'Public Bluetooth Address' definition.</span><b><a href="#public-bluetooth-address">#public-bluetooth-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-bluetooth-address">4.1. Global Bluetooth device properties</a> <a href="#ref-for-public-bluetooth-address①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bond">
-   <b><a href="#bond">#bond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bond" class="dfn-panel" data-for="bond" id="infopanel-for-bond" role="dialog">
+   <span id="infopaneltitle-for-bond" style="display:none">Info about the 'bond' definition.</span><b><a href="#bond">#bond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bond">5.1.1. Persistence across connections</a> <a href="#ref-for-bond①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-type">
-   <b><a href="#attribute-type">#attribute-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-type" class="dfn-panel" data-for="attribute-type" id="infopanel-for-attribute-type" role="dialog">
+   <span id="infopaneltitle-for-attribute-type" style="display:none">Info about the 'Attribute Type' definition.</span><b><a href="#attribute-type">#attribute-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-type">6. UUIDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-handle">
-   <b><a href="#attribute-handle">#attribute-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-handle" class="dfn-panel" data-for="attribute-handle" id="infopanel-for-attribute-handle" role="dialog">
+   <span id="infopaneltitle-for-attribute-handle" style="display:none">Info about the 'Attribute Handle' definition.</span><b><a href="#attribute-handle">#attribute-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-handle">5.1. GATT Information Model</a> <a href="#ref-for-attribute-handle①">(2)</a> <a href="#ref-for-attribute-handle②">(3)</a>
     <li><a href="#ref-for-attribute-handle③">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-attribute-handle④">5.1.4. Identifying Services, Characteristics, and Descriptors</a> <a href="#ref-for-attribute-handle⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="long-attribute-values">
-   <b><a href="#long-attribute-values">#long-attribute-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-long-attribute-values" class="dfn-panel" data-for="long-attribute-values" id="infopanel-for-long-attribute-values" role="dialog">
+   <span id="infopaneltitle-for-long-attribute-values" style="display:none">Info about the 'Long Attribute Values' definition.</span><b><a href="#long-attribute-values">#long-attribute-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-long-attribute-values">5.4. BluetoothRemoteGATTCharacteristic</a>
     <li><a href="#ref-for-long-attribute-values①">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="error-response">
-   <b><a href="#error-response">#error-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-error-response" class="dfn-panel" data-for="error-response" id="infopanel-for-error-response" role="dialog">
+   <span id="infopaneltitle-for-error-response" style="display:none">Info about the 'Error Response' definition.</span><b><a href="#error-response">#error-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-error-response">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generic-attribute-profile">
-   <b><a href="#generic-attribute-profile">#generic-attribute-profile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generic-attribute-profile" class="dfn-panel" data-for="generic-attribute-profile" id="infopanel-for-generic-attribute-profile" role="dialog">
+   <span id="infopaneltitle-for-generic-attribute-profile" style="display:none">Info about the 'Generic Attribute Profile' definition.</span><b><a href="#generic-attribute-profile">#generic-attribute-profile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-attribute-profile">1. Introduction</a>
     <li><a href="#ref-for-generic-attribute-profile①">2.3. Attacks on devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gatt-client">
-   <b><a href="#gatt-client">#gatt-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gatt-client" class="dfn-panel" data-for="gatt-client" id="infopanel-for-gatt-client" role="dialog">
+   <span id="infopaneltitle-for-gatt-client" style="display:none">Info about the 'GATT Client' definition.</span><b><a href="#gatt-client">#gatt-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gatt-client">5.1. GATT Information Model</a> <a href="#ref-for-gatt-client①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gatt-server">
-   <b><a href="#gatt-server">#gatt-server</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gatt-server" class="dfn-panel" data-for="gatt-server" id="infopanel-for-gatt-server" role="dialog">
+   <span id="infopaneltitle-for-gatt-server" style="display:none">Info about the 'GATT Server' definition.</span><b><a href="#gatt-server">#gatt-server</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gatt-server">1. Introduction</a> <a href="#ref-for-gatt-server①">(2)</a>
     <li><a href="#ref-for-gatt-server②">5.1. GATT Information Model</a> <a href="#ref-for-gatt-server③">(2)</a>
@@ -8919,14 +8951,14 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-gatt-server⑤">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="profile-fundamentals">
-   <b><a href="#profile-fundamentals">#profile-fundamentals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-profile-fundamentals" class="dfn-panel" data-for="profile-fundamentals" id="infopanel-for-profile-fundamentals" role="dialog">
+   <span id="infopaneltitle-for-profile-fundamentals" style="display:none">Info about the 'Profile Fundamentals' definition.</span><b><a href="#profile-fundamentals">#profile-fundamentals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-profile-fundamentals">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="att-bearer">
-   <b><a href="#att-bearer">#att-bearer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-att-bearer" class="dfn-panel" data-for="att-bearer" id="infopanel-for-att-bearer" role="dialog">
+   <span id="infopaneltitle-for-att-bearer" style="display:none">Info about the 'ATT Bearer' definition.</span><b><a href="#att-bearer">#att-bearer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-att-bearer">3. Device Discovery</a>
     <li><a href="#ref-for-att-bearer①">4.1. Global Bluetooth device properties</a> <a href="#ref-for-att-bearer②">(2)</a>
@@ -8934,21 +8966,21 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-att-bearer⑦">5.6.3. Responding to Disconnection</a> <a href="#ref-for-att-bearer⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-caching">
-   <b><a href="#attribute-caching">#attribute-caching</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-caching" class="dfn-panel" data-for="attribute-caching" id="infopanel-for-attribute-caching" role="dialog">
+   <span id="infopaneltitle-for-attribute-caching" style="display:none">Info about the 'Attribute Caching' definition.</span><b><a href="#attribute-caching">#attribute-caching</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-caching">5.1.1. Persistence across connections</a>
     <li><a href="#ref-for-attribute-caching①">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gatt-profile-hierarchy">
-   <b><a href="#gatt-profile-hierarchy">#gatt-profile-hierarchy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gatt-profile-hierarchy" class="dfn-panel" data-for="gatt-profile-hierarchy" id="infopanel-for-gatt-profile-hierarchy" role="dialog">
+   <span id="infopaneltitle-for-gatt-profile-hierarchy" style="display:none">Info about the 'GATT Profile Hierarchy' definition.</span><b><a href="#gatt-profile-hierarchy">#gatt-profile-hierarchy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gatt-profile-hierarchy">5.1. GATT Information Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service">
-   <b><a href="#service">#service</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service" class="dfn-panel" data-for="service" id="infopanel-for-service" role="dialog">
+   <span id="infopaneltitle-for-service" style="display:none">Info about the 'Service' definition.</span><b><a href="#service">#service</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service">1. Introduction</a>
     <li><a href="#ref-for-service①">3. Device Discovery</a> <a href="#ref-for-service②">(2)</a> <a href="#ref-for-service③">(3)</a> <a href="#ref-for-service④">(4)</a> <a href="#ref-for-service⑤">(5)</a>
@@ -8958,15 +8990,15 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-service①⓪">5.6.5. Responding to Service Changes</a> <a href="#ref-for-service①①">(2)</a> <a href="#ref-for-service①②">(3)</a> <a href="#ref-for-service①③">(4)</a> <a href="#ref-for-service①④">(5)</a> <a href="#ref-for-service①⑤">(6)</a> <a href="#ref-for-service①⑥">(7)</a> <a href="#ref-for-service①⑦">(8)</a> <a href="#ref-for-service①⑧">(9)</a> <a href="#ref-for-service①⑨">(10)</a> <a href="#ref-for-service②⓪">(11)</a> <a href="#ref-for-service②①">(12)</a> <a href="#ref-for-service②②">(13)</a> <a href="#ref-for-service②③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="included-service">
-   <b><a href="#included-service">#included-service</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-included-service" class="dfn-panel" data-for="included-service" id="infopanel-for-included-service" role="dialog">
+   <span id="infopaneltitle-for-included-service" style="display:none">Info about the 'Included Service' definition.</span><b><a href="#included-service">#included-service</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-included-service">5.1. GATT Information Model</a>
     <li><a href="#ref-for-included-service①">5.3. BluetoothRemoteGATTService</a> <a href="#ref-for-included-service②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic">
-   <b><a href="#characteristic">#characteristic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic" class="dfn-panel" data-for="characteristic" id="infopanel-for-characteristic" role="dialog">
+   <span id="infopaneltitle-for-characteristic" style="display:none">Info about the 'Characteristic' definition.</span><b><a href="#characteristic">#characteristic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic">1. Introduction</a>
     <li><a href="#ref-for-characteristic①">2.3. Attacks on devices</a>
@@ -8978,27 +9010,27 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-characteristic①②">5.6.5. Responding to Service Changes</a> <a href="#ref-for-characteristic①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-interoperability-requirements">
-   <b><a href="#service-interoperability-requirements">#service-interoperability-requirements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-interoperability-requirements" class="dfn-panel" data-for="service-interoperability-requirements" id="infopanel-for-service-interoperability-requirements" role="dialog">
+   <span id="infopaneltitle-for-service-interoperability-requirements" style="display:none">Info about the 'Service Interoperability Requirements' definition.</span><b><a href="#service-interoperability-requirements">#service-interoperability-requirements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-interoperability-requirements">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-definition">
-   <b><a href="#service-definition">#service-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-definition" class="dfn-panel" data-for="service-definition" id="infopanel-for-service-definition" role="dialog">
+   <span id="infopaneltitle-for-service-definition" style="display:none">Info about the 'Service Definition' definition.</span><b><a href="#service-definition">#service-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-definition">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-properties">
-   <b><a href="#characteristic-properties">#characteristic-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-properties" class="dfn-panel" data-for="characteristic-properties" id="infopanel-for-characteristic-properties" role="dialog">
+   <span id="infopaneltitle-for-characteristic-properties" style="display:none">Info about the 'Characteristic Properties' definition.</span><b><a href="#characteristic-properties">#characteristic-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-properties">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-characteristic-properties①">(2)</a> <a href="#ref-for-characteristic-properties②">(3)</a>
     <li><a href="#ref-for-characteristic-properties③">5.4.1. BluetoothCharacteristicProperties</a> <a href="#ref-for-characteristic-properties④">(2)</a> <a href="#ref-for-characteristic-properties⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descriptor">
-   <b><a href="#descriptor">#descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descriptor" class="dfn-panel" data-for="descriptor" id="infopanel-for-descriptor" role="dialog">
+   <span id="infopaneltitle-for-descriptor" style="display:none">Info about the 'Descriptor' definition.</span><b><a href="#descriptor">#descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descriptor">1. Introduction</a>
     <li><a href="#ref-for-descriptor①">2.3. Attacks on devices</a>
@@ -9008,303 +9040,359 @@ and/or give the user a way to retry failed operations. <a href="https://github.c
     <li><a href="#ref-for-descriptor⑦">5.6.5. Responding to Service Changes</a> <a href="#ref-for-descriptor⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-extended-properties">
-   <b><a href="#characteristic-extended-properties">#characteristic-extended-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-extended-properties" class="dfn-panel" data-for="characteristic-extended-properties" id="infopanel-for-characteristic-extended-properties" role="dialog">
+   <span id="infopaneltitle-for-characteristic-extended-properties" style="display:none">Info about the 'Characteristic Extended Properties' definition.</span><b><a href="#characteristic-extended-properties">#characteristic-extended-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-extended-properties">5.4.1. BluetoothCharacteristicProperties</a> <a href="#ref-for-characteristic-extended-properties①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-characteristic-configuration">
-   <b><a href="#client-characteristic-configuration">#client-characteristic-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-characteristic-configuration" class="dfn-panel" data-for="client-characteristic-configuration" id="infopanel-for-client-characteristic-configuration" role="dialog">
+   <span id="infopaneltitle-for-client-characteristic-configuration" style="display:none">Info about the 'Client Characteristic Configuration' definition.</span><b><a href="#client-characteristic-configuration">#client-characteristic-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-characteristic-configuration">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-client-characteristic-configuration①">(2)</a> <a href="#ref-for-client-characteristic-configuration②">(3)</a> <a href="#ref-for-client-characteristic-configuration③">(4)</a> <a href="#ref-for-client-characteristic-configuration④">(5)</a>
     <li><a href="#ref-for-client-characteristic-configuration⑤">5.6.3. Responding to Disconnection</a> <a href="#ref-for-client-characteristic-configuration⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gatt-procedure">
-   <b><a href="#gatt-procedure">#gatt-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gatt-procedure" class="dfn-panel" data-for="gatt-procedure" id="infopanel-for-gatt-procedure" role="dialog">
+   <span id="infopaneltitle-for-gatt-procedure" style="display:none">Info about the 'GATT procedures' definition.</span><b><a href="#gatt-procedure">#gatt-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gatt-procedure">5.1. GATT Information Model</a>
     <li><a href="#ref-for-gatt-procedure①">5.1.2. The Bluetooth cache</a>
     <li><a href="#ref-for-gatt-procedure②">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exchange-mtu">
-   <b><a href="#exchange-mtu">#exchange-mtu</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exchange-mtu" class="dfn-panel" data-for="exchange-mtu" id="infopanel-for-exchange-mtu" role="dialog">
+   <span id="infopaneltitle-for-exchange-mtu" style="display:none">Info about the 'Exchange MTU' definition.</span><b><a href="#exchange-mtu">#exchange-mtu</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exchange-mtu">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-service-discovery">
-   <b><a href="#primary-service-discovery">#primary-service-discovery</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-service-discovery" class="dfn-panel" data-for="primary-service-discovery" id="infopanel-for-primary-service-discovery" role="dialog">
+   <span id="infopaneltitle-for-primary-service-discovery" style="display:none">Info about the 'Primary Service Discovery' definition.</span><b><a href="#primary-service-discovery">#primary-service-discovery</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-service-discovery">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discover-primary-service-by-service-uuid">
-   <b><a href="#discover-primary-service-by-service-uuid">#discover-primary-service-by-service-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discover-primary-service-by-service-uuid" class="dfn-panel" data-for="discover-primary-service-by-service-uuid" id="infopanel-for-discover-primary-service-by-service-uuid" role="dialog">
+   <span id="infopaneltitle-for-discover-primary-service-by-service-uuid" style="display:none">Info about the 'Discover Primary Service by Service UUID' definition.</span><b><a href="#discover-primary-service-by-service-uuid">#discover-primary-service-by-service-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discover-primary-service-by-service-uuid">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relationship-discovery">
-   <b><a href="#relationship-discovery">#relationship-discovery</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relationship-discovery" class="dfn-panel" data-for="relationship-discovery" id="infopanel-for-relationship-discovery" role="dialog">
+   <span id="infopaneltitle-for-relationship-discovery" style="display:none">Info about the 'Relationship Discovery' definition.</span><b><a href="#relationship-discovery">#relationship-discovery</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relationship-discovery">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-discovery">
-   <b><a href="#characteristic-discovery">#characteristic-discovery</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-discovery" class="dfn-panel" data-for="characteristic-discovery" id="infopanel-for-characteristic-discovery" role="dialog">
+   <span id="infopaneltitle-for-characteristic-discovery" style="display:none">Info about the 'Characteristic Discovery' definition.</span><b><a href="#characteristic-discovery">#characteristic-discovery</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-discovery">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discover-characteristics-by-uuid">
-   <b><a href="#discover-characteristics-by-uuid">#discover-characteristics-by-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discover-characteristics-by-uuid" class="dfn-panel" data-for="discover-characteristics-by-uuid" id="infopanel-for-discover-characteristics-by-uuid" role="dialog">
+   <span id="infopaneltitle-for-discover-characteristics-by-uuid" style="display:none">Info about the 'Discover Characteristics by UUID' definition.</span><b><a href="#discover-characteristics-by-uuid">#discover-characteristics-by-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discover-characteristics-by-uuid">5.1.2. The Bluetooth cache</a> <a href="#ref-for-discover-characteristics-by-uuid①">(2)</a>
     <li><a href="#ref-for-discover-characteristics-by-uuid②">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-descriptor-discovery">
-   <b><a href="#characteristic-descriptor-discovery">#characteristic-descriptor-discovery</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-descriptor-discovery" class="dfn-panel" data-for="characteristic-descriptor-discovery" id="infopanel-for-characteristic-descriptor-discovery" role="dialog">
+   <span id="infopaneltitle-for-characteristic-descriptor-discovery" style="display:none">Info about the 'Characteristic Descriptor Discovery' definition.</span><b><a href="#characteristic-descriptor-discovery">#characteristic-descriptor-discovery</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-descriptor-discovery">5.4.1. BluetoothCharacteristicProperties</a>
     <li><a href="#ref-for-characteristic-descriptor-discovery①">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discover-all-characteristic-descriptors">
-   <b><a href="#discover-all-characteristic-descriptors">#discover-all-characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discover-all-characteristic-descriptors" class="dfn-panel" data-for="discover-all-characteristic-descriptors" id="infopanel-for-discover-all-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-discover-all-characteristic-descriptors" style="display:none">Info about the 'Discover All Characteristic Descriptors' definition.</span><b><a href="#discover-all-characteristic-descriptors">#discover-all-characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discover-all-characteristic-descriptors">5.6.1. Bluetooth Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-value-read">
-   <b><a href="#characteristic-value-read">#characteristic-value-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-value-read" class="dfn-panel" data-for="characteristic-value-read" id="infopanel-for-characteristic-value-read" role="dialog">
+   <span id="infopaneltitle-for-characteristic-value-read" style="display:none">Info about the 'Characteristic Value Read' definition.</span><b><a href="#characteristic-value-read">#characteristic-value-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-value-read">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-value-write">
-   <b><a href="#characteristic-value-write">#characteristic-value-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-value-write" class="dfn-panel" data-for="characteristic-value-write" id="infopanel-for-characteristic-value-write" role="dialog">
+   <span id="infopaneltitle-for-characteristic-value-write" style="display:none">Info about the 'Characteristic Value Write' definition.</span><b><a href="#characteristic-value-write">#characteristic-value-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-value-write">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-without-response">
-   <b><a href="#write-without-response">#write-without-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-without-response" class="dfn-panel" data-for="write-without-response" id="infopanel-for-write-without-response" role="dialog">
+   <span id="infopaneltitle-for-write-without-response" style="display:none">Info about the 'Write Without Response' definition.</span><b><a href="#write-without-response">#write-without-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-without-response">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-characteristic-value">
-   <b><a href="#write-characteristic-value">#write-characteristic-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-characteristic-value" class="dfn-panel" data-for="write-characteristic-value" id="infopanel-for-write-characteristic-value" role="dialog">
+   <span id="infopaneltitle-for-write-characteristic-value" style="display:none">Info about the 'Write Characteristic Value' definition.</span><b><a href="#write-characteristic-value">#write-characteristic-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-characteristic-value">5.4. BluetoothRemoteGATTCharacteristic</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-value-notification">
-   <b><a href="#characteristic-value-notification">#characteristic-value-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-value-notification" class="dfn-panel" data-for="characteristic-value-notification" id="infopanel-for-characteristic-value-notification" role="dialog">
+   <span id="infopaneltitle-for-characteristic-value-notification" style="display:none">Info about the 'Characteristic Value Notification' definition.</span><b><a href="#characteristic-value-notification">#characteristic-value-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-value-notification">5.6.4. Responding to Notifications and Indications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-value-indications">
-   <b><a href="#characteristic-value-indications">#characteristic-value-indications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-value-indications" class="dfn-panel" data-for="characteristic-value-indications" id="infopanel-for-characteristic-value-indications" role="dialog">
+   <span id="infopaneltitle-for-characteristic-value-indications" style="display:none">Info about the 'Characteristic Value Indications' definition.</span><b><a href="#characteristic-value-indications">#characteristic-value-indications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-value-indications">5.6.4. Responding to Notifications and Indications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characteristic-descriptors">
-   <b><a href="#characteristic-descriptors">#characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characteristic-descriptors" class="dfn-panel" data-for="characteristic-descriptors" id="infopanel-for-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-characteristic-descriptors" style="display:none">Info about the 'Characteristic Descriptors' definition.</span><b><a href="#characteristic-descriptors">#characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characteristic-descriptors">5.4. BluetoothRemoteGATTCharacteristic</a> <a href="#ref-for-characteristic-descriptors①">(2)</a>
     <li><a href="#ref-for-characteristic-descriptors②">5.6.3. Responding to Disconnection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-characteristic-descriptors">
-   <b><a href="#read-characteristic-descriptors">#read-characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-characteristic-descriptors" class="dfn-panel" data-for="read-characteristic-descriptors" id="infopanel-for-read-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-read-characteristic-descriptors" style="display:none">Info about the 'Read Characteristic Descriptors' definition.</span><b><a href="#read-characteristic-descriptors">#read-characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-characteristic-descriptors">5.4.1. BluetoothCharacteristicProperties</a>
     <li><a href="#ref-for-read-characteristic-descriptors①">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-long-characteristic-descriptors">
-   <b><a href="#read-long-characteristic-descriptors">#read-long-characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-long-characteristic-descriptors" class="dfn-panel" data-for="read-long-characteristic-descriptors" id="infopanel-for-read-long-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-read-long-characteristic-descriptors" style="display:none">Info about the 'Read Long Characteristic Descriptors' definition.</span><b><a href="#read-long-characteristic-descriptors">#read-long-characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-long-characteristic-descriptors">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-characteristic-descriptors">
-   <b><a href="#write-characteristic-descriptors">#write-characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-characteristic-descriptors" class="dfn-panel" data-for="write-characteristic-descriptors" id="infopanel-for-write-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-write-characteristic-descriptors" style="display:none">Info about the 'Write Characteristic Descriptors' definition.</span><b><a href="#write-characteristic-descriptors">#write-characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-characteristic-descriptors">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-long-characteristic-descriptors">
-   <b><a href="#write-long-characteristic-descriptors">#write-long-characteristic-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-long-characteristic-descriptors" class="dfn-panel" data-for="write-long-characteristic-descriptors" id="infopanel-for-write-long-characteristic-descriptors" role="dialog">
+   <span id="infopaneltitle-for-write-long-characteristic-descriptors" style="display:none">Info about the 'Write Long Characteristic Descriptors' definition.</span><b><a href="#write-long-characteristic-descriptors">#write-long-characteristic-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-long-characteristic-descriptors">5.5. BluetoothRemoteGATTDescriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="procedure-timeouts">
-   <b><a href="#procedure-timeouts">#procedure-timeouts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-procedure-timeouts" class="dfn-panel" data-for="procedure-timeouts" id="infopanel-for-procedure-timeouts" role="dialog">
+   <span id="infopaneltitle-for-procedure-timeouts" style="display:none">Info about the 'Procedure Timeouts' definition.</span><b><a href="#procedure-timeouts">#procedure-timeouts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-procedure-timeouts">5.7. Error handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gap-interoperability-requirements">
-   <b><a href="#gap-interoperability-requirements">#gap-interoperability-requirements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gap-interoperability-requirements" class="dfn-panel" data-for="gap-interoperability-requirements" id="infopanel-for-gap-interoperability-requirements" role="dialog">
+   <span id="infopaneltitle-for-gap-interoperability-requirements" style="display:none">Info about the 'GAP Interoperability Requirements' definition.</span><b><a href="#gap-interoperability-requirements">#gap-interoperability-requirements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gap-interoperability-requirements">4.1. Global Bluetooth device properties</a>
     <li><a href="#ref-for-gap-interoperability-requirements①">5.2. BluetoothRemoteGATTServer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-changed">
-   <b><a href="#service-changed">#service-changed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-changed" class="dfn-panel" data-for="service-changed" id="infopanel-for-service-changed" role="dialog">
+   <span id="infopaneltitle-for-service-changed" style="display:none">Info about the 'Service Changed' definition.</span><b><a href="#service-changed">#service-changed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-changed">5.6.2. Event types</a>
     <li><a href="#ref-for-service-changed①">5.6.5. Responding to Service Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="definition-of-keys-and-values">
-   <b><a href="#definition-of-keys-and-values">#definition-of-keys-and-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-definition-of-keys-and-values" class="dfn-panel" data-for="definition-of-keys-and-values" id="infopanel-for-definition-of-keys-and-values" role="dialog">
+   <span id="infopaneltitle-for-definition-of-keys-and-values" style="display:none">Info about the 'Definition of Keys and Values' definition.</span><b><a href="#definition-of-keys-and-values">#definition-of-keys-and-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definition-of-keys-and-values">2.3. Attacks on devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identity-resolving-key">
-   <b><a href="#identity-resolving-key">#identity-resolving-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identity-resolving-key" class="dfn-panel" data-for="identity-resolving-key" id="infopanel-for-identity-resolving-key" role="dialog">
+   <span id="infopaneltitle-for-identity-resolving-key" style="display:none">Info about the 'Identity Resolving Key' definition.</span><b><a href="#identity-resolving-key">#identity-resolving-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-resolving-key">2.4. Bluetooth device identifiers</a> <a href="#ref-for-identity-resolving-key①">(2)</a>
     <li><a href="#ref-for-identity-resolving-key②">4.1. Global Bluetooth device properties</a> <a href="#ref-for-identity-resolving-key③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-device-address">
-   <b><a href="#public-device-address">#public-device-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-device-address" class="dfn-panel" data-for="public-device-address" id="infopanel-for-public-device-address" role="dialog">
+   <span id="infopaneltitle-for-public-device-address" style="display:none">Info about the 'Public Device Address' definition.</span><b><a href="#public-device-address">#public-device-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-device-address">2.4. Bluetooth device identifiers</a> <a href="#ref-for-public-device-address①">(2)</a> <a href="#ref-for-public-device-address②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="static-device-address">
-   <b><a href="#static-device-address">#static-device-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-static-device-address" class="dfn-panel" data-for="static-device-address" id="infopanel-for-static-device-address" role="dialog">
+   <span id="infopaneltitle-for-static-device-address" style="display:none">Info about the 'Static Device Address' definition.</span><b><a href="#static-device-address">#static-device-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-device-address">2.4. Bluetooth device identifiers</a> <a href="#ref-for-static-device-address①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="passive-scanning">
-   <b><a href="#passive-scanning">#passive-scanning</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-passive-scanning" class="dfn-panel" data-for="passive-scanning" id="infopanel-for-passive-scanning" role="dialog">
+   <span id="infopaneltitle-for-passive-scanning" style="display:none">Info about the 'Passive Scanning' definition.</span><b><a href="#passive-scanning">#passive-scanning</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-passive-scanning">3. Device Discovery</a> <a href="#ref-for-passive-scanning①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-uuid-data-type">
-   <b><a href="#service-uuid-data-type">#service-uuid-data-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-uuid-data-type" class="dfn-panel" data-for="service-uuid-data-type" id="infopanel-for-service-uuid-data-type" role="dialog">
+   <span id="infopaneltitle-for-service-uuid-data-type" style="display:none">Info about the 'Service UUID Data Type' definition.</span><b><a href="#service-uuid-data-type">#service-uuid-data-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-uuid-data-type">3. Device Discovery</a>
     <li><a href="#ref-for-service-uuid-data-type①">4.1. Global Bluetooth device properties</a>
     <li><a href="#ref-for-service-uuid-data-type②">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-service-uuid-data-type③">(2)</a> <a href="#ref-for-service-uuid-data-type④">(3)</a> <a href="#ref-for-service-uuid-data-type⑤">(4)</a> <a href="#ref-for-service-uuid-data-type⑥">(5)</a> <a href="#ref-for-service-uuid-data-type⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-name-data-type">
-   <b><a href="#local-name-data-type">#local-name-data-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-name-data-type" class="dfn-panel" data-for="local-name-data-type" id="infopanel-for-local-name-data-type" role="dialog">
+   <span id="infopaneltitle-for-local-name-data-type" style="display:none">Info about the 'Local Name Data Type' definition.</span><b><a href="#local-name-data-type">#local-name-data-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-name-data-type">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-local-name-data-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flags-data-type">
-   <b><a href="#flags-data-type">#flags-data-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flags-data-type" class="dfn-panel" data-for="flags-data-type" id="infopanel-for-flags-data-type" role="dialog">
+   <span id="infopaneltitle-for-flags-data-type" style="display:none">Info about the 'Flags Data Type' definition.</span><b><a href="#flags-data-type">#flags-data-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flags-data-type">4.1. Global Bluetooth device properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discoverable-mode">
-   <b><a href="#discoverable-mode">#discoverable-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discoverable-mode" class="dfn-panel" data-for="discoverable-mode" id="infopanel-for-discoverable-mode" role="dialog">
+   <span id="infopaneltitle-for-discoverable-mode" style="display:none">Info about the 'Discoverable Mode' definition.</span><b><a href="#discoverable-mode">#discoverable-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discoverable-mode">3. Device Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="manufacturer-specific-data">
-   <b><a href="#manufacturer-specific-data">#manufacturer-specific-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-manufacturer-specific-data" class="dfn-panel" data-for="manufacturer-specific-data" id="infopanel-for-manufacturer-specific-data" role="dialog">
+   <span id="infopaneltitle-for-manufacturer-specific-data" style="display:none">Info about the 'Manufacturer Specific Data' definition.</span><b><a href="#manufacturer-specific-data">#manufacturer-specific-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-manufacturer-specific-data">3. Device Discovery</a> <a href="#ref-for-manufacturer-specific-data①">(2)</a> <a href="#ref-for-manufacturer-specific-data②">(3)</a>
     <li><a href="#ref-for-manufacturer-specific-data③">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tx-power-level">
-   <b><a href="#tx-power-level">#tx-power-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tx-power-level" class="dfn-panel" data-for="tx-power-level" id="infopanel-for-tx-power-level" role="dialog">
+   <span id="infopaneltitle-for-tx-power-level" style="display:none">Info about the 'TX Power Level' definition.</span><b><a href="#tx-power-level">#tx-power-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tx-power-level">4.2.3. Responding to Advertising Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-data">
-   <b><a href="#service-data">#service-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-data" class="dfn-panel" data-for="service-data" id="infopanel-for-service-data" role="dialog">
+   <span id="infopaneltitle-for-service-data" style="display:none">Info about the 'Service Data' definition.</span><b><a href="#service-data">#service-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-data">3. Device Discovery</a> <a href="#ref-for-service-data①">(2)</a> <a href="#ref-for-service-data②">(3)</a>
     <li><a href="#ref-for-service-data③">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-service-data④">(2)</a> <a href="#ref-for-service-data⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="appearance">
-   <b><a href="#appearance">#appearance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-appearance" class="dfn-panel" data-for="appearance" id="infopanel-for-appearance" role="dialog">
+   <span id="infopaneltitle-for-appearance" style="display:none">Info about the 'Appearance' definition.</span><b><a href="#appearance">#appearance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appearance">4.2.3. Responding to Advertising Events</a> <a href="#ref-for-appearance①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/scanning.html
@@ -1403,402 +1403,402 @@ steps:</p>
    <li><a href="#shortened-local-name">Shortened Local Name</a><span>, in § 7</span>
    <li><a href="#dom-bluetoothlescan-stop">stop()</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4.2. Handling Document Loss of Full Activity</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.map">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.map">https://tc39.github.io/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.map" class="dfn-panel" data-for="term-for-sec-array.prototype.map" id="infopanel-for-term-for-sec-array.prototype.map" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.map" style="display:none">Info about the 'Array.prototype.map' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.map">https://tc39.github.io/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.map">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-sec-array.prototype.map①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-sec-array.prototype.map②">7. Terminology and conventions</a> <a href="#ref-for-sec-array.prototype.map③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">4. Scanning for BLE advertisements</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys" style="display:none">Info about the '[[OwnPropertyKeys]]' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys">4.1. Controlling a BLE scan</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys①">(2)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys②">(3)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">4.2. Handling Document Loss of Full Activity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">4.2. Handling Document Loss of Full Activity</a> <a href="#ref-for-fully-active①">(2)</a> <a href="#ref-for-fully-active②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">4. Scanning for BLE advertisements</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.2. Handling Document Loss of Full Activity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extra-permission-data">
-   <a href="https://w3c.github.io/permissions/#dfn-extra-permission-data">https://w3c.github.io/permissions/#dfn-extra-permission-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extra-permission-data" class="dfn-panel" data-for="term-for-dfn-extra-permission-data" id="infopanel-for-term-for-dfn-extra-permission-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extra-permission-data" style="display:none">Info about the 'extra permission data' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-extra-permission-data">https://w3c.github.io/permissions/#dfn-extra-permission-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extra-permission-data">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-query-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm" id="infopanel-for-term-for-dfn-permission-query-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-query-algorithm" style="display:none">Info about the 'permission query algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-query-algorithm">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-result-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-result-type" class="dfn-panel" data-for="term-for-dfn-permission-result-type" id="infopanel-for-term-for-dfn-permission-result-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-result-type" style="display:none">Info about the 'permission result type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-result-type">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm" id="infopanel-for-term-for-dfn-permission-revocation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" style="display:none">Info about the 'permission revocation algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-revocation-algorithm">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">4.3. Permission to scan</a> <a href="#ref-for-dfn-permission-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus-state" class="dfn-panel" data-for="term-for-dom-permissionstatus-state" id="infopanel-for-term-for-dom-permissionstatus-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus-state" style="display:none">Info about the 'state' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">4.3. Permission to scan</a> <a href="#ref-for-dom-permissionstatus-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetooth">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetooth">https://webbluetoothcg.github.io/web-bluetooth/#bluetooth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetooth" class="dfn-panel" data-for="term-for-bluetooth" id="infopanel-for-term-for-bluetooth" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetooth" style="display:none">Info about the 'Bluetooth' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetooth">https://webbluetoothcg.github.io/web-bluetooth/#bluetooth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-bluetooth①">5.1. Responding to advertising events</a>
     <li><a href="#ref-for-bluetooth②">6. Changes to existing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-bluetoothdatafilterinit">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothdatafilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothdatafilterinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-bluetoothdatafilterinit" class="dfn-panel" data-for="term-for-dictdef-bluetoothdatafilterinit" id="infopanel-for-term-for-dictdef-bluetoothdatafilterinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-bluetoothdatafilterinit" style="display:none">Info about the 'BluetoothDataFilterInit' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothdatafilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothdatafilterinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothdatafilterinit">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetoothdevice">
-   <a href="index.html#bluetoothdevice">index.html#bluetoothdevice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetoothdevice" class="dfn-panel" data-for="term-for-bluetoothdevice" id="infopanel-for-term-for-bluetoothdevice" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetoothdevice" style="display:none">Info about the 'BluetoothDevice' external reference.</span><a href="index.html#bluetoothdevice">index.html#bluetoothdevice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdevice">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-bluetoothdevice①">5.1. Responding to advertising events</a>
     <li><a href="#ref-for-bluetoothdevice②">6. Changes to existing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-bluetoothlescanfilterinit">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-bluetoothlescanfilterinit" class="dfn-panel" data-for="term-for-dictdef-bluetoothlescanfilterinit" id="infopanel-for-term-for-dictdef-bluetoothlescanfilterinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-bluetoothlescanfilterinit" style="display:none">Info about the 'BluetoothLEScanFilterInit' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit②">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedefdef-uuid">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-uuid">https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-uuid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedefdef-uuid" class="dfn-panel" data-for="term-for-typedefdef-uuid" id="infopanel-for-term-for-typedefdef-uuid" role="menu">
+   <span id="infopaneltitle-for-term-for-typedefdef-uuid" style="display:none">Info about the 'UUID' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-uuid">https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-uuid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-uuid">4.1. Controlling a BLE scan</a> <a href="#ref-for-typedefdef-uuid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetoothdeviceeventhandlers-advertisementreceived">https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetoothdeviceeventhandlers-advertisementreceived</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived" class="dfn-panel" data-for="term-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived" id="infopanel-for-term-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived" style="display:none">Info about the 'advertisementreceived' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetoothdeviceeventhandlers-advertisementreceived">https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetoothdeviceeventhandlers-advertisementreceived</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived">1.1. Examples</a>
     <li><a href="#ref-for-eventdef-bluetoothdeviceeventhandlers-advertisementreceived①">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetooth-device">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-device">https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetooth-device" class="dfn-panel" data-for="term-for-bluetooth-device" id="infopanel-for-term-for-bluetooth-device" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetooth-device" style="display:none">Info about the 'bluetooth device' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-device">https://webbluetoothcg.github.io/web-bluetooth/#bluetooth-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetooth-device">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetoothdatafilterinit-canonicalizing">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-canonicalizing">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-canonicalizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetoothdatafilterinit-canonicalizing" class="dfn-panel" data-for="term-for-bluetoothdatafilterinit-canonicalizing" id="infopanel-for-term-for-bluetoothdatafilterinit-canonicalizing" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetoothdatafilterinit-canonicalizing" style="display:none">Info about the 'canonicalizing (for BluetoothDataFilterInit)' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-canonicalizing">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-canonicalizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdatafilterinit-canonicalizing">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetoothlescanfilterinit-canonicalizing">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetoothlescanfilterinit-canonicalizing" class="dfn-panel" data-for="term-for-bluetoothlescanfilterinit-canonicalizing" id="infopanel-for-term-for-bluetoothlescanfilterinit-canonicalizing" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetoothlescanfilterinit-canonicalizing" style="display:none">Info about the 'canonicalizing (for BluetoothLEScanFilterInit)' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothlescanfilterinit-canonicalizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescanfilterinit-canonicalizing">4.1. Controlling a BLE scan</a> <a href="#ref-for-bluetoothlescanfilterinit-canonicalizing①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothdatafilterinit-dataprefix">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-dataprefix">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-dataprefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothdatafilterinit-dataprefix" class="dfn-panel" data-for="term-for-dom-bluetoothdatafilterinit-dataprefix" id="infopanel-for-term-for-dom-bluetoothdatafilterinit-dataprefix" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothdatafilterinit-dataprefix" style="display:none">Info about the 'dataPrefix' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-dataprefix">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-dataprefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilterinit-dataprefix">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-an-advertisementreceived-event">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#fire-an-advertisementreceived-event">https://webbluetoothcg.github.io/web-bluetooth/#fire-an-advertisementreceived-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-an-advertisementreceived-event" class="dfn-panel" data-for="term-for-fire-an-advertisementreceived-event" id="infopanel-for-term-for-fire-an-advertisementreceived-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-an-advertisementreceived-event" style="display:none">Info about the 'fire an advertisementreceived event' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#fire-an-advertisementreceived-event">https://webbluetoothcg.github.io/web-bluetooth/#fire-an-advertisementreceived-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-advertisementreceived-event">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-the-bluetoothdevice-representing">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing">https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-the-bluetoothdevice-representing" class="dfn-panel" data-for="term-for-get-the-bluetoothdevice-representing" id="infopanel-for-term-for-get-the-bluetoothdevice-representing" role="menu">
+   <span id="infopaneltitle-for-term-for-get-the-bluetoothdevice-representing" style="display:none">Info about the 'get the bluetoothdevice representing' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing">https://webbluetoothcg.github.io/web-bluetooth/#get-the-bluetoothdevice-representing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-bluetoothdevice-representing">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothuuid-getservice">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothuuid-getservice" class="dfn-panel" data-for="term-for-dom-bluetoothuuid-getservice" id="infopanel-for-term-for-dom-bluetoothuuid-getservice" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothuuid-getservice" style="display:none">Info about the 'getService(name)' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothuuid-getservice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothuuid-getservice">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-manufacturerdata">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-manufacturerdata">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-manufacturerdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-manufacturerdata" class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-manufacturerdata" id="infopanel-for-term-for-dom-bluetoothlescanfilterinit-manufacturerdata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-manufacturerdata" style="display:none">Info about the 'manufacturerData' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-manufacturerdata">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-manufacturerdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-manufacturerdata">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothdatafilterinit-mask">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-mask">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothdatafilterinit-mask" class="dfn-panel" data-for="term-for-dom-bluetoothdatafilterinit-mask" id="infopanel-for-term-for-dom-bluetoothdatafilterinit-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothdatafilterinit-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-mask">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdatafilterinit-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilterinit-mask">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bluetoothdatafilterinit-matches">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-matches">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-matches</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bluetoothdatafilterinit-matches" class="dfn-panel" data-for="term-for-bluetoothdatafilterinit-matches" id="infopanel-for-term-for-bluetoothdatafilterinit-matches" role="menu">
+   <span id="infopaneltitle-for-term-for-bluetoothdatafilterinit-matches" style="display:none">Info about the 'matches' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-matches">https://webbluetoothcg.github.io/web-bluetooth/#bluetoothdatafilterinit-matches</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdatafilterinit-matches">5.1. Responding to advertising events</a> <a href="#ref-for-bluetoothdatafilterinit-matches①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-allowedbluetoothdevice-mayusegatt">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-allowedbluetoothdevice-mayusegatt">https://webbluetoothcg.github.io/web-bluetooth/#dom-allowedbluetoothdevice-mayusegatt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-allowedbluetoothdevice-mayusegatt" class="dfn-panel" data-for="term-for-dom-allowedbluetoothdevice-mayusegatt" id="infopanel-for-term-for-dom-allowedbluetoothdevice-mayusegatt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-allowedbluetoothdevice-mayusegatt" style="display:none">Info about the 'mayUseGATT' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-allowedbluetoothdevice-mayusegatt">https://webbluetoothcg.github.io/web-bluetooth/#dom-allowedbluetoothdevice-mayusegatt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-allowedbluetoothdevice-mayusegatt">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-only-arraybuffer">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#read-only-arraybuffer">https://webbluetoothcg.github.io/web-bluetooth/#read-only-arraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-only-arraybuffer" class="dfn-panel" data-for="term-for-read-only-arraybuffer" id="infopanel-for-term-for-read-only-arraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-read-only-arraybuffer" style="display:none">Info about the 'read only arraybuffer' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#read-only-arraybuffer">https://webbluetoothcg.github.io/web-bluetooth/#read-only-arraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-only-arraybuffer">4.1. Controlling a BLE scan</a> <a href="#ref-for-read-only-arraybuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-bluetooth-device">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#same-bluetooth-device">https://webbluetoothcg.github.io/web-bluetooth/#same-bluetooth-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-bluetooth-device" class="dfn-panel" data-for="term-for-same-bluetooth-device" id="infopanel-for-term-for-same-bluetooth-device" role="menu">
+   <span id="infopaneltitle-for-term-for-same-bluetooth-device" style="display:none">Info about the 'same bluetooth device' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#same-bluetooth-device">https://webbluetoothcg.github.io/web-bluetooth/#same-bluetooth-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-bluetooth-device">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-servicedata">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-servicedata">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-servicedata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-servicedata" class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-servicedata" id="infopanel-for-term-for-dom-bluetoothlescanfilterinit-servicedata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-servicedata" style="display:none">Info about the 'serviceData' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-servicedata">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-servicedata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-servicedata">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-services">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-services">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-services</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-services" class="dfn-panel" data-for="term-for-dom-bluetoothlescanfilterinit-services" id="infopanel-for-term-for-dom-bluetoothlescanfilterinit-services" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothlescanfilterinit-services" style="display:none">Info about the 'services' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-services">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothlescanfilterinit-services</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilterinit-services">4.1. Controlling a BLE scan</a> <a href="#ref-for-dom-bluetoothlescanfilterinit-services①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">4.1. Controlling a BLE scan</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.1. Controlling a BLE scan</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-idl-frozen-array①">4.1. Controlling a BLE scan</a> <a href="#ref-for-idl-frozen-array②">(2)</a> <a href="#ref-for-idl-frozen-array③">(3)</a>
     <li><a href="#ref-for-idl-frozen-array④">4.3. Permission to scan</a> <a href="#ref-for-idl-frozen-array⑤">(2)</a> <a href="#ref-for-idl-frozen-array⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">https://heycam.github.io/webidl/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'a copy of the bytes held' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">https://heycam.github.io/webidl/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">4.1. Controlling a BLE scan</a> <a href="#ref-for-dfn-get-buffer-source-copy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4. Scanning for BLE advertisements</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">4.1. Controlling a BLE scan</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a>
     <li><a href="#ref-for-idl-boolean⑤">4.3. Permission to scan</a> <a href="#ref-for-idl-boolean⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-map-entries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-map-entries" class="dfn-panel" data-for="term-for-dfn-map-entries" id="infopanel-for-term-for-dfn-map-entries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-map-entries" style="display:none">Info about the 'map entries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-map-entries">4.1. Controlling a BLE scan</a> <a href="#ref-for-dfn-map-entries①">(2)</a> <a href="#ref-for-dfn-map-entries②">(3)</a> <a href="#ref-for-dfn-map-entries③">(4)</a>
     <li><a href="#ref-for-dfn-map-entries④">5.1. Responding to advertising events</a> <a href="#ref-for-dfn-map-entries⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">4.1. Controlling a BLE scan</a> <a href="#ref-for-idl-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4. Scanning for BLE advertisements</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-idl-sequence①">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">4.1. Controlling a BLE scan</a>
    </ul>
@@ -1993,98 +1993,98 @@ steps:</p>
    <div class="issue"> Consider filtering the result to active scans that
               match the fields of the descriptor. <a class="issue-return" href="#issue-should-query-filter" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothlescanoptions">
-   <b><a href="#dictdef-bluetoothlescanoptions">#dictdef-bluetoothlescanoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothlescanoptions" class="dfn-panel" data-for="dictdef-bluetoothlescanoptions" id="infopanel-for-dictdef-bluetoothlescanoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothlescanoptions" style="display:none">Info about the 'BluetoothLEScanOptions' definition.</span><b><a href="#dictdef-bluetoothlescanoptions">#dictdef-bluetoothlescanoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothlescanoptions">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanoptions-keeprepeateddevices">
-   <b><a href="#dom-bluetoothlescanoptions-keeprepeateddevices">#dom-bluetoothlescanoptions-keeprepeateddevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanoptions-keeprepeateddevices" class="dfn-panel" data-for="dom-bluetoothlescanoptions-keeprepeateddevices" id="infopanel-for-dom-bluetoothlescanoptions-keeprepeateddevices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanoptions-keeprepeateddevices" style="display:none">Info about the 'keepRepeatedDevices' definition.</span><b><a href="#dom-bluetoothlescanoptions-keeprepeateddevices">#dom-bluetoothlescanoptions-keeprepeateddevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanoptions-keeprepeateddevices">4. Scanning for BLE advertisements</a> <a href="#ref-for-dom-bluetoothlescanoptions-keeprepeateddevices①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothlescanoptions-keeprepeateddevices②">6. Changes to existing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanoptions-acceptalladvertisements">
-   <b><a href="#dom-bluetoothlescanoptions-acceptalladvertisements">#dom-bluetoothlescanoptions-acceptalladvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanoptions-acceptalladvertisements" class="dfn-panel" data-for="dom-bluetoothlescanoptions-acceptalladvertisements" id="infopanel-for-dom-bluetoothlescanoptions-acceptalladvertisements" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanoptions-acceptalladvertisements" style="display:none">Info about the 'acceptAllAdvertisements' definition.</span><b><a href="#dom-bluetoothlescanoptions-acceptalladvertisements">#dom-bluetoothlescanoptions-acceptalladvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanoptions-acceptalladvertisements">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dom-bluetoothlescanoptions-acceptalladvertisements①">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-requestlescan">
-   <b><a href="#dom-bluetooth-requestlescan">#dom-bluetooth-requestlescan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-requestlescan" class="dfn-panel" data-for="dom-bluetooth-requestlescan" id="infopanel-for-dom-bluetooth-requestlescan" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-requestlescan" style="display:none">Info about the 'requestLEScan(options)' definition.</span><b><a href="#dom-bluetooth-requestlescan">#dom-bluetooth-requestlescan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-requestlescan">1.1. Examples</a>
     <li><a href="#ref-for-dom-bluetooth-requestlescan①">4. Scanning for BLE advertisements</a> <a href="#ref-for-dom-bluetooth-requestlescan②">(2)</a> <a href="#ref-for-dom-bluetooth-requestlescan③">(3)</a> <a href="#ref-for-dom-bluetooth-requestlescan④">(4)</a>
     <li><a href="#ref-for-dom-bluetooth-requestlescan⑤">7. Terminology and conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothdatafilter">
-   <b><a href="#bluetoothdatafilter">#bluetoothdatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothdatafilter" class="dfn-panel" data-for="bluetoothdatafilter" id="infopanel-for-bluetoothdatafilter" role="dialog">
+   <span id="infopaneltitle-for-bluetoothdatafilter" style="display:none">Info about the 'BluetoothDataFilter' definition.</span><b><a href="#bluetoothdatafilter">#bluetoothdatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothdatafilter">4.1. Controlling a BLE scan</a> <a href="#ref-for-bluetoothdatafilter①">(2)</a> <a href="#ref-for-bluetoothdatafilter②">(3)</a> <a href="#ref-for-bluetoothdatafilter③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdatafilter-dataprefix">
-   <b><a href="#dom-bluetoothdatafilter-dataprefix">#dom-bluetoothdatafilter-dataprefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdatafilter-dataprefix" class="dfn-panel" data-for="dom-bluetoothdatafilter-dataprefix" id="infopanel-for-dom-bluetoothdatafilter-dataprefix" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdatafilter-dataprefix" style="display:none">Info about the 'dataPrefix' definition.</span><b><a href="#dom-bluetoothdatafilter-dataprefix">#dom-bluetoothdatafilter-dataprefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilter-dataprefix">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdatafilter-mask">
-   <b><a href="#dom-bluetoothdatafilter-mask">#dom-bluetoothdatafilter-mask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdatafilter-mask" class="dfn-panel" data-for="dom-bluetoothdatafilter-mask" id="infopanel-for-dom-bluetoothdatafilter-mask" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdatafilter-mask" style="display:none">Info about the 'mask' definition.</span><b><a href="#dom-bluetoothdatafilter-mask">#dom-bluetoothdatafilter-mask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilter-mask">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothmanufacturerdatafilter">
-   <b><a href="#bluetoothmanufacturerdatafilter">#bluetoothmanufacturerdatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothmanufacturerdatafilter" class="dfn-panel" data-for="bluetoothmanufacturerdatafilter" id="infopanel-for-bluetoothmanufacturerdatafilter" role="dialog">
+   <span id="infopaneltitle-for-bluetoothmanufacturerdatafilter" style="display:none">Info about the 'BluetoothManufacturerDataFilter' definition.</span><b><a href="#bluetoothmanufacturerdatafilter">#bluetoothmanufacturerdatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothmanufacturerdatafilter">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothservicedatafilter">
-   <b><a href="#bluetoothservicedatafilter">#bluetoothservicedatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothservicedatafilter" class="dfn-panel" data-for="bluetoothservicedatafilter" id="infopanel-for-bluetoothservicedatafilter" role="dialog">
+   <span id="infopaneltitle-for-bluetoothservicedatafilter" style="display:none">Info about the 'BluetoothServiceDataFilter' definition.</span><b><a href="#bluetoothservicedatafilter">#bluetoothservicedatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothservicedatafilter">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescanfilter">
-   <b><a href="#bluetoothlescanfilter">#bluetoothlescanfilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescanfilter" class="dfn-panel" data-for="bluetoothlescanfilter" id="infopanel-for-bluetoothlescanfilter" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescanfilter" style="display:none">Info about the 'BluetoothLEScanFilter' definition.</span><b><a href="#bluetoothlescanfilter">#bluetoothlescanfilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescanfilter">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-bluetoothlescanfilter①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-bluetoothlescanfilter②">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilter-name">
-   <b><a href="#dom-bluetoothlescanfilter-name">#dom-bluetoothlescanfilter-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilter-name" class="dfn-panel" data-for="dom-bluetoothlescanfilter-name" id="infopanel-for-dom-bluetoothlescanfilter-name" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilter-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-bluetoothlescanfilter-name">#dom-bluetoothlescanfilter-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-name">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilter-services">
-   <b><a href="#dom-bluetoothlescanfilter-services">#dom-bluetoothlescanfilter-services</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilter-services" class="dfn-panel" data-for="dom-bluetoothlescanfilter-services" id="infopanel-for-dom-bluetoothlescanfilter-services" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilter-services" style="display:none">Info about the 'services' definition.</span><b><a href="#dom-bluetoothlescanfilter-services">#dom-bluetoothlescanfilter-services</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-services">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilter-manufacturerdata">
-   <b><a href="#dom-bluetoothlescanfilter-manufacturerdata">#dom-bluetoothlescanfilter-manufacturerdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilter-manufacturerdata" class="dfn-panel" data-for="dom-bluetoothlescanfilter-manufacturerdata" id="infopanel-for-dom-bluetoothlescanfilter-manufacturerdata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilter-manufacturerdata" style="display:none">Info about the 'manufacturerData' definition.</span><b><a href="#dom-bluetoothlescanfilter-manufacturerdata">#dom-bluetoothlescanfilter-manufacturerdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-manufacturerdata">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilter-servicedata">
-   <b><a href="#dom-bluetoothlescanfilter-servicedata">#dom-bluetoothlescanfilter-servicedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilter-servicedata" class="dfn-panel" data-for="dom-bluetoothlescanfilter-servicedata" id="infopanel-for-dom-bluetoothlescanfilter-servicedata" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilter-servicedata" style="display:none">Info about the 'serviceData' definition.</span><b><a href="#dom-bluetoothlescanfilter-servicedata">#dom-bluetoothlescanfilter-servicedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-servicedata">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescan">
-   <b><a href="#bluetoothlescan">#bluetoothlescan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescan" class="dfn-panel" data-for="bluetoothlescan" id="infopanel-for-bluetoothlescan" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescan" style="display:none">Info about the 'BluetoothLEScan' definition.</span><b><a href="#bluetoothlescan">#bluetoothlescan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescan">4. Scanning for BLE advertisements</a> <a href="#ref-for-bluetoothlescan①">(2)</a> <a href="#ref-for-bluetoothlescan②">(3)</a>
     <li><a href="#ref-for-bluetoothlescan③">4.1. Controlling a BLE scan</a>
@@ -2093,109 +2093,109 @@ steps:</p>
     <li><a href="#ref-for-bluetoothlescan⑧">6. Changes to existing interfaces</a> <a href="#ref-for-bluetoothlescan⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescan-filters">
-   <b><a href="#dom-bluetoothlescan-filters">#dom-bluetoothlescan-filters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescan-filters" class="dfn-panel" data-for="dom-bluetoothlescan-filters" id="infopanel-for-dom-bluetoothlescan-filters" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescan-filters" style="display:none">Info about the 'filters' definition.</span><b><a href="#dom-bluetoothlescan-filters">#dom-bluetoothlescan-filters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescan-filters">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dom-bluetoothlescan-filters①">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescan-keeprepeateddevices">
-   <b><a href="#dom-bluetoothlescan-keeprepeateddevices">#dom-bluetoothlescan-keeprepeateddevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescan-keeprepeateddevices" class="dfn-panel" data-for="dom-bluetoothlescan-keeprepeateddevices" id="infopanel-for-dom-bluetoothlescan-keeprepeateddevices" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescan-keeprepeateddevices" style="display:none">Info about the 'keepRepeatedDevices' definition.</span><b><a href="#dom-bluetoothlescan-keeprepeateddevices">#dom-bluetoothlescan-keeprepeateddevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescan-keeprepeateddevices">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dom-bluetoothlescan-keeprepeateddevices①">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescan-acceptalladvertisements">
-   <b><a href="#dom-bluetoothlescan-acceptalladvertisements">#dom-bluetoothlescan-acceptalladvertisements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescan-acceptalladvertisements" class="dfn-panel" data-for="dom-bluetoothlescan-acceptalladvertisements" id="infopanel-for-dom-bluetoothlescan-acceptalladvertisements" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescan-acceptalladvertisements" style="display:none">Info about the 'acceptAllAdvertisements' definition.</span><b><a href="#dom-bluetoothlescan-acceptalladvertisements">#dom-bluetoothlescan-acceptalladvertisements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescan-acceptalladvertisements">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescan-active">
-   <b><a href="#dom-bluetoothlescan-active">#dom-bluetoothlescan-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescan-active" class="dfn-panel" data-for="dom-bluetoothlescan-active" id="infopanel-for-dom-bluetoothlescan-active" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescan-active" style="display:none">Info about the 'active' definition.</span><b><a href="#dom-bluetoothlescan-active">#dom-bluetoothlescan-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescan-active">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dom-bluetoothlescan-active①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-dom-bluetoothlescan-active②">6. Changes to existing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanfilter-bluetoothlescanfilter">
-   <b><a href="#dom-bluetoothlescanfilter-bluetoothlescanfilter">#dom-bluetoothlescanfilter-bluetoothlescanfilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanfilter-bluetoothlescanfilter" class="dfn-panel" data-for="dom-bluetoothlescanfilter-bluetoothlescanfilter" id="infopanel-for-dom-bluetoothlescanfilter-bluetoothlescanfilter" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanfilter-bluetoothlescanfilter" style="display:none">Info about the 'BluetoothLEScanFilter(init)' definition.</span><b><a href="#dom-bluetoothlescanfilter-bluetoothlescanfilter">#dom-bluetoothlescanfilter-bluetoothlescanfilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-bluetoothlescanfilter">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-bluetoothlescanfilter①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-dom-bluetoothlescanfilter-bluetoothlescanfilter②">7. Terminology and conventions</a> <a href="#ref-for-dom-bluetoothlescanfilter-bluetoothlescanfilter③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescan-stop">
-   <b><a href="#dom-bluetoothlescan-stop">#dom-bluetoothlescan-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescan-stop" class="dfn-panel" data-for="dom-bluetoothlescan-stop" id="infopanel-for-dom-bluetoothlescan-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescan-stop" style="display:none">Info about the 'stop()' definition.</span><b><a href="#dom-bluetoothlescan-stop">#dom-bluetoothlescan-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescan-stop">4.1. Controlling a BLE scan</a> <a href="#ref-for-dom-bluetoothlescan-stop①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothlescan-stop②">4.2. Handling Document Loss of Full Activity</a>
     <li><a href="#ref-for-dom-bluetoothlescan-stop③">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter">
-   <b><a href="#dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter">#dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter" class="dfn-panel" data-for="dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter" id="infopanel-for-dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter" style="display:none">Info about the 'BluetoothManufacturerDataFilter(init)' definition.</span><b><a href="#dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter">#dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothmanufacturerdatafilter-bluetoothmanufacturerdatafilter">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothservicedatafilter-bluetoothservicedatafilter">
-   <b><a href="#dom-bluetoothservicedatafilter-bluetoothservicedatafilter">#dom-bluetoothservicedatafilter-bluetoothservicedatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothservicedatafilter-bluetoothservicedatafilter" class="dfn-panel" data-for="dom-bluetoothservicedatafilter-bluetoothservicedatafilter" id="infopanel-for-dom-bluetoothservicedatafilter-bluetoothservicedatafilter" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothservicedatafilter-bluetoothservicedatafilter" style="display:none">Info about the 'BluetoothServiceDataFilter(init)' definition.</span><b><a href="#dom-bluetoothservicedatafilter-bluetoothservicedatafilter">#dom-bluetoothservicedatafilter-bluetoothservicedatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothservicedatafilter-bluetoothservicedatafilter">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdatafilter-bluetoothdatafilter">
-   <b><a href="#dom-bluetoothdatafilter-bluetoothdatafilter">#dom-bluetoothdatafilter-bluetoothdatafilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdatafilter-bluetoothdatafilter" class="dfn-panel" data-for="dom-bluetoothdatafilter-bluetoothdatafilter" id="infopanel-for-dom-bluetoothdatafilter-bluetoothdatafilter" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdatafilter-bluetoothdatafilter" style="display:none">Info about the 'BluetoothDataFilter(init)' definition.</span><b><a href="#dom-bluetoothdatafilter-bluetoothdatafilter">#dom-bluetoothdatafilter-bluetoothdatafilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdatafilter-bluetoothdatafilter">4.1. Controlling a BLE scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-bluetooth-le-scan">
-   <b><a href="#dom-permissionname-bluetooth-le-scan">#dom-permissionname-bluetooth-le-scan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-bluetooth-le-scan" class="dfn-panel" data-for="dom-permissionname-bluetooth-le-scan" id="infopanel-for-dom-permissionname-bluetooth-le-scan" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-bluetooth-le-scan" style="display:none">Info about the '"bluetooth-le-scan"' definition.</span><b><a href="#dom-permissionname-bluetooth-le-scan">#dom-permissionname-bluetooth-le-scan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-bluetooth-le-scan">4. Scanning for BLE advertisements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-bluetoothlescanpermissiondescriptor">
-   <b><a href="#dictdef-bluetoothlescanpermissiondescriptor">#dictdef-bluetoothlescanpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-bluetoothlescanpermissiondescriptor" class="dfn-panel" data-for="dictdef-bluetoothlescanpermissiondescriptor" id="infopanel-for-dictdef-bluetoothlescanpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-bluetoothlescanpermissiondescriptor" style="display:none">Info about the 'BluetoothLEScanPermissionDescriptor' definition.</span><b><a href="#dictdef-bluetoothlescanpermissiondescriptor">#dictdef-bluetoothlescanpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothlescanpermissiondescriptor">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescanpermissionresult">
-   <b><a href="#bluetoothlescanpermissionresult">#bluetoothlescanpermissionresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescanpermissionresult" class="dfn-panel" data-for="bluetoothlescanpermissionresult" id="infopanel-for-bluetoothlescanpermissionresult" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescanpermissionresult" style="display:none">Info about the 'BluetoothLEScanPermissionResult' definition.</span><b><a href="#bluetoothlescanpermissionresult">#bluetoothlescanpermissionresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescanpermissionresult">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothlescanpermissionresult-scans">
-   <b><a href="#dom-bluetoothlescanpermissionresult-scans">#dom-bluetoothlescanpermissionresult-scans</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothlescanpermissionresult-scans" class="dfn-panel" data-for="dom-bluetoothlescanpermissionresult-scans" id="infopanel-for-dom-bluetoothlescanpermissionresult-scans" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothlescanpermissionresult-scans" style="display:none">Info about the 'scans' definition.</span><b><a href="#dom-bluetoothlescanpermissionresult-scans">#dom-bluetoothlescanpermissionresult-scans</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothlescanpermissionresult-scans">4.3. Permission to scan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescan-match">
-   <b><a href="#bluetoothlescan-match">#bluetoothlescan-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescan-match" class="dfn-panel" data-for="bluetoothlescan-match" id="infopanel-for-bluetoothlescan-match" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescan-match" style="display:none">Info about the 'matches' definition.</span><b><a href="#bluetoothlescan-match">#bluetoothlescan-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescan-match">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-bluetoothlescan-match①">4.1. Controlling a BLE scan</a>
     <li><a href="#ref-for-bluetoothlescan-match②">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bluetoothlescanfilter-match">
-   <b><a href="#bluetoothlescanfilter-match">#bluetoothlescanfilter-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bluetoothlescanfilter-match" class="dfn-panel" data-for="bluetoothlescanfilter-match" id="infopanel-for-bluetoothlescanfilter-match" role="dialog">
+   <span id="infopaneltitle-for-bluetoothlescanfilter-match" style="display:none">Info about the 'matches' definition.</span><b><a href="#bluetoothlescanfilter-match">#bluetoothlescanfilter-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bluetoothlescanfilter-match">4. Scanning for BLE advertisements</a>
     <li><a href="#ref-for-bluetoothlescanfilter-match①">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetooth-activescans-slot">
-   <b><a href="#dom-bluetooth-activescans-slot">#dom-bluetooth-activescans-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetooth-activescans-slot" class="dfn-panel" data-for="dom-bluetooth-activescans-slot" id="infopanel-for-dom-bluetooth-activescans-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetooth-activescans-slot" style="display:none">Info about the '[[activeScans]]' definition.</span><b><a href="#dom-bluetooth-activescans-slot">#dom-bluetooth-activescans-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-activescans-slot">4. Scanning for BLE advertisements</a> <a href="#ref-for-dom-bluetooth-activescans-slot①">(2)</a> <a href="#ref-for-dom-bluetooth-activescans-slot②">(3)</a>
     <li><a href="#ref-for-dom-bluetooth-activescans-slot③">4.1. Controlling a BLE scan</a> <a href="#ref-for-dom-bluetooth-activescans-slot④">(2)</a>
@@ -2204,139 +2204,195 @@ steps:</p>
     <li><a href="#ref-for-dom-bluetooth-activescans-slot⑧">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bluetoothdevice-returnedfromscans-slot">
-   <b><a href="#dom-bluetoothdevice-returnedfromscans-slot">#dom-bluetoothdevice-returnedfromscans-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bluetoothdevice-returnedfromscans-slot" class="dfn-panel" data-for="dom-bluetoothdevice-returnedfromscans-slot" id="infopanel-for-dom-bluetoothdevice-returnedfromscans-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-bluetoothdevice-returnedfromscans-slot" style="display:none">Info about the '[[returnedFromScans]]' definition.</span><b><a href="#dom-bluetoothdevice-returnedfromscans-slot">#dom-bluetoothdevice-returnedfromscans-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-returnedfromscans-slot">5.1. Responding to advertising events</a> <a href="#ref-for-dom-bluetoothdevice-returnedfromscans-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advertising-event">
-   <b><a href="#advertising-event">#advertising-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advertising-event" class="dfn-panel" data-for="advertising-event" id="infopanel-for-advertising-event" role="dialog">
+   <span id="infopaneltitle-for-advertising-event" style="display:none">Info about the 'advertising events' definition.</span><b><a href="#advertising-event">#advertising-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advertising-event">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observer">
-   <b><a href="#observer">#observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observer" class="dfn-panel" data-for="observer" id="infopanel-for-observer" role="dialog">
+   <span id="infopaneltitle-for-observer" style="display:none">Info about the 'Observer' definition.</span><b><a href="#observer">#observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observer">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="privacy-feature">
-   <b><a href="#privacy-feature">#privacy-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-privacy-feature" class="dfn-panel" data-for="privacy-feature" id="infopanel-for-privacy-feature" role="dialog">
+   <span id="infopaneltitle-for-privacy-feature" style="display:none">Info about the 'Privacy Feature' definition.</span><b><a href="#privacy-feature">#privacy-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-privacy-feature">2. Privacy considerations</a> <a href="#ref-for-privacy-feature①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="privacy-feature-in-an-observer">
-   <b><a href="#privacy-feature-in-an-observer">#privacy-feature-in-an-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-privacy-feature-in-an-observer" class="dfn-panel" data-for="privacy-feature-in-an-observer" id="infopanel-for-privacy-feature-in-an-observer" role="dialog">
+   <span id="infopaneltitle-for-privacy-feature-in-an-observer" style="display:none">Info about the 'Privacy Feature in an Observer' definition.</span><b><a href="#privacy-feature-in-an-observer">#privacy-feature-in-an-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-privacy-feature-in-an-observer">2. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="device-address">
-   <b><a href="#device-address">#device-address</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-device-address" class="dfn-panel" data-for="device-address" id="infopanel-for-device-address" role="dialog">
+   <span id="infopaneltitle-for-device-address" style="display:none">Info about the 'Device Address' definition.</span><b><a href="#device-address">#device-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-address">2. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="passive-scanning">
-   <b><a href="#passive-scanning">#passive-scanning</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-passive-scanning" class="dfn-panel" data-for="passive-scanning" id="infopanel-for-passive-scanning" role="dialog">
+   <span id="infopaneltitle-for-passive-scanning" style="display:none">Info about the 'Passive Scanning' definition.</span><b><a href="#passive-scanning">#passive-scanning</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-passive-scanning">2. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-scanning">
-   <b><a href="#active-scanning">#active-scanning</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-scanning" class="dfn-panel" data-for="active-scanning" id="infopanel-for-active-scanning" role="dialog">
+   <span id="infopaneltitle-for-active-scanning" style="display:none">Info about the 'Active Scanning' definition.</span><b><a href="#active-scanning">#active-scanning</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-scanning">2. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-uuid">
-   <b><a href="#service-uuid">#service-uuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-uuid" class="dfn-panel" data-for="service-uuid" id="infopanel-for-service-uuid" role="dialog">
+   <span id="infopaneltitle-for-service-uuid" style="display:none">Info about the 'Service UUID' definition.</span><b><a href="#service-uuid">#service-uuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-uuid">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-name">
-   <b><a href="#local-name">#local-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-name" class="dfn-panel" data-for="local-name" id="infopanel-for-local-name" role="dialog">
+   <span id="infopaneltitle-for-local-name" style="display:none">Info about the 'Local Name' definition.</span><b><a href="#local-name">#local-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-name">5.1. Responding to advertising events</a> <a href="#ref-for-local-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shortened-local-name">
-   <b><a href="#shortened-local-name">#shortened-local-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shortened-local-name" class="dfn-panel" data-for="shortened-local-name" id="infopanel-for-shortened-local-name" role="dialog">
+   <span id="infopaneltitle-for-shortened-local-name" style="display:none">Info about the 'Shortened Local Name' definition.</span><b><a href="#shortened-local-name">#shortened-local-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shortened-local-name">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="manufacturer-specific-data">
-   <b><a href="#manufacturer-specific-data">#manufacturer-specific-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-manufacturer-specific-data" class="dfn-panel" data-for="manufacturer-specific-data" id="infopanel-for-manufacturer-specific-data" role="dialog">
+   <span id="infopaneltitle-for-manufacturer-specific-data" style="display:none">Info about the 'Manufacturer Specific Data' definition.</span><b><a href="#manufacturer-specific-data">#manufacturer-specific-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-manufacturer-specific-data">5.1. Responding to advertising events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-data">
-   <b><a href="#service-data">#service-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-data" class="dfn-panel" data-for="service-data" id="infopanel-for-service-data" role="dialog">
+   <span id="infopaneltitle-for-service-data" style="display:none">Info about the 'Service Data' definition.</span><b><a href="#service-data">#service-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-data">5.1. Responding to advertising events</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/WebBluetoothCG/web-bluetooth/tests.html
+++ b/tests/github/WebBluetoothCG/web-bluetooth/tests.html
@@ -926,124 +926,124 @@ action corresponding to the <code class="idl"><a data-link-type="idl" href="#dom
    <li><a href="#testrunner">TestRunner</a><span>, in § 4</span>
    <li><a href="#dom-window-testrunner">testRunner</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'org.bluetooth.characteristic.gap.device_name' external reference.</span><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1.6. MissingDescriptorGenericAccessDevice</a>
     <li><a href="#termref-for-">4.1.7. GenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-①" role="menu">
+   <span id="infopaneltitle-for-term-for-①" style="display:none">Info about the 'org.bluetooth.descriptor.gatt.characteristic_extended_properties' external reference.</span><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1.7. GenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-②" role="menu">
+   <span id="infopaneltitle-for-term-for-②" style="display:none">Info about the 'org.bluetooth.descriptor.gatt.characteristic_user_description' external reference.</span><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#">https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1.7. GenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-③" role="menu">
+   <span id="infopaneltitle-for-term-for-③" style="display:none">Info about the 'org.bluetooth.service.battery_service' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1. setBluetoothMockDataSet</a>
     <li><a href="#termref-for-">4.1.1. BatteryDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-④" role="menu">
+   <span id="infopaneltitle-for-term-for-④" style="display:none">Info about the 'org.bluetooth.service.generic_access' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1.5. MissingCharacteristicGenericAccessDevice</a>
     <li><a href="#termref-for-">4.1.6. MissingDescriptorGenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑤" role="menu">
+   <span id="infopaneltitle-for-term-for-⑤" style="display:none">Info about the 'org.bluetooth.service.glucose' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1. setBluetoothMockDataSet</a>
     <li><a href="#termref-for-">4.1.2. GlucoseDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-⑥" role="menu">
+   <span id="infopaneltitle-for-term-for-⑥" style="display:none">Info about the 'org.bluetooth.service.heart_rate' external reference.</span><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">4.1. setBluetoothMockDataSet</a>
     <li><a href="#termref-for-">4.1.3. HeartRateDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3. Testing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element-2">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element-2" class="dfn-panel" data-for="term-for-the-body-element-2" id="infopanel-for-term-for-the-body-element-2" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element-2" style="display:none">Info about the 'the body element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element-2">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-KeyboardEvent-key">
-   <a href="https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key">https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-KeyboardEvent-key" class="dfn-panel" data-for="term-for-widl-KeyboardEvent-key" id="infopanel-for-term-for-widl-KeyboardEvent-key" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-KeyboardEvent-key" style="display:none">Info about the 'key' external reference.</span><a href="https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key">https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-KeyboardEvent-key">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-type-keypress">
-   <a href="https://www.w3.org/TR/uievents/#event-type-keypress">https://www.w3.org/TR/uievents/#event-type-keypress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-type-keypress" class="dfn-panel" data-for="term-for-event-type-keypress" id="infopanel-for-term-for-event-type-keypress" role="menu">
+   <span id="infopaneltitle-for-term-for-event-type-keypress" style="display:none">Info about the 'keypress' external reference.</span><a href="https://www.w3.org/TR/uievents/#event-type-keypress">https://www.w3.org/TR/uievents/#event-type-keypress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-type-keypress">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothdevice-id">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothdevice-id" class="dfn-panel" data-for="term-for-dom-bluetoothdevice-id" id="infopanel-for-term-for-dom-bluetoothdevice-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothdevice-id" style="display:none">Info about the 'id' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-id">4.3. getBluetoothManualChooserEvents(callback)</a> <a href="#ref-for-dom-bluetoothdevice-id①">(2)</a>
     <li><a href="#ref-for-dom-bluetoothdevice-id②">4.4. sendBluetoothManualChooserEvent(event, argument)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetoothdevice-name">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetoothdevice-name" class="dfn-panel" data-for="term-for-dom-bluetoothdevice-name" id="infopanel-for-term-for-dom-bluetoothdevice-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetoothdevice-name" style="display:none">Info about the 'name' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetoothdevice-name">4.3. getBluetoothManualChooserEvents(callback)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-bluetooth-requestdevice">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-bluetooth-requestdevice" class="dfn-panel" data-for="term-for-dom-bluetooth-requestdevice" id="infopanel-for-term-for-dom-bluetooth-requestdevice" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-bluetooth-requestdevice" style="display:none">Info about the 'requestDevice()' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice">https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bluetooth-requestdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-dom-bluetooth-requestdevice①">4.2. setBluetoothManualChooser()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-uuid">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid">https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-uuid" class="dfn-panel" data-for="term-for-valid-uuid" id="infopanel-for-term-for-valid-uuid" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-uuid" style="display:none">Info about the 'valid uuid' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid">https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-uuid">4.1.8. FailingGATTOperationsDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4. testRunner</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
     <li><a href="#ref-for-idl-DOMString④">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. testRunner</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4. testRunner</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a>
     <li><a href="#ref-for-idl-undefined⑤">5. eventSender</a>
@@ -1141,208 +1141,264 @@ Chromium developers are interested
 in updating and collaborating on this document when the next tested
 implementation begins development. <a class="issue-return" href="#issue-4d7cfd5e" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="callbackdef-bluetoothmanualchoosereventscallback">
-   <b><a href="#callbackdef-bluetoothmanualchoosereventscallback">#callbackdef-bluetoothmanualchoosereventscallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-bluetoothmanualchoosereventscallback" class="dfn-panel" data-for="callbackdef-bluetoothmanualchoosereventscallback" id="infopanel-for-callbackdef-bluetoothmanualchoosereventscallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-bluetoothmanualchoosereventscallback" style="display:none">Info about the 'BluetoothManualChooserEventsCallback' definition.</span><b><a href="#callbackdef-bluetoothmanualchoosereventscallback">#callbackdef-bluetoothmanualchoosereventscallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-bluetoothmanualchoosereventscallback">4. testRunner</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="testrunner">
-   <b><a href="#testrunner">#testrunner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-testrunner" class="dfn-panel" data-for="testrunner" id="infopanel-for-testrunner" role="dialog">
+   <span id="infopaneltitle-for-testrunner" style="display:none">Info about the 'TestRunner' definition.</span><b><a href="#testrunner">#testrunner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-testrunner">3. Testing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">
-   <b><a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-setbluetoothmockdataset-datasetname-datasetname" class="dfn-panel" data-for="dom-testrunner-setbluetoothmockdataset-datasetname-datasetname" id="infopanel-for-dom-testrunner-setbluetoothmockdataset-datasetname-datasetname" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-setbluetoothmockdataset-datasetname-datasetname" style="display:none">Info about the 'dataSetName' definition.</span><b><a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">4.1. setBluetoothMockDataSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">
-   <b><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event" class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event" id="infopanel-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event" style="display:none">Info about the 'event' definition.</span><b><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">4.4. sendBluetoothManualChooserEvent(event, argument)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">
-   <b><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument" class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument" id="infopanel-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument" style="display:none">Info about the 'argument' definition.</span><b><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">4.4. sendBluetoothManualChooserEvent(event, argument)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-setbluetoothmockdataset">
-   <b><a href="#dom-testrunner-setbluetoothmockdataset">#dom-testrunner-setbluetoothmockdataset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-setbluetoothmockdataset" class="dfn-panel" data-for="dom-testrunner-setbluetoothmockdataset" id="infopanel-for-dom-testrunner-setbluetoothmockdataset" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-setbluetoothmockdataset" style="display:none">Info about the 'setBluetoothMockDataSet(dataSetName)' definition.</span><b><a href="#dom-testrunner-setbluetoothmockdataset">#dom-testrunner-setbluetoothmockdataset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-setbluetoothmockdataset">4. testRunner</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="batterydevice">
-   <b><a href="#batterydevice">#batterydevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-batterydevice" class="dfn-panel" data-for="batterydevice" id="infopanel-for-batterydevice" role="dialog">
+   <span id="infopaneltitle-for-batterydevice" style="display:none">Info about the '4.1.1. BatteryDevice' definition.</span><b><a href="#batterydevice">#batterydevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-batterydevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-batterydevice">4.1.1. BatteryDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="glucosedevice">
-   <b><a href="#glucosedevice">#glucosedevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-glucosedevice" class="dfn-panel" data-for="glucosedevice" id="infopanel-for-glucosedevice" role="dialog">
+   <span id="infopaneltitle-for-glucosedevice" style="display:none">Info about the '4.1.2. GlucoseDevice' definition.</span><b><a href="#glucosedevice">#glucosedevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-glucosedevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-glucosedevice">4.1.2. GlucoseDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="heartratedevice">
-   <b><a href="#heartratedevice">#heartratedevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-heartratedevice" class="dfn-panel" data-for="heartratedevice" id="infopanel-for-heartratedevice" role="dialog">
+   <span id="infopaneltitle-for-heartratedevice" style="display:none">Info about the '4.1.3. HeartRateDevice' definition.</span><b><a href="#heartratedevice">#heartratedevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-heartratedevice">4.1. setBluetoothMockDataSet</a> <a href="#ref-for-heartratedevice①">(2)</a>
     <li><a href="#ref-for-heartratedevice">4.1.3. HeartRateDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="missingservicegenericaccessdevice">
-   <b><a href="#missingservicegenericaccessdevice">#missingservicegenericaccessdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-missingservicegenericaccessdevice" class="dfn-panel" data-for="missingservicegenericaccessdevice" id="infopanel-for-missingservicegenericaccessdevice" role="dialog">
+   <span id="infopaneltitle-for-missingservicegenericaccessdevice" style="display:none">Info about the '4.1.4. MissingServiceGenericAccessDevice' definition.</span><b><a href="#missingservicegenericaccessdevice">#missingservicegenericaccessdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-missingservicegenericaccessdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-missingservicegenericaccessdevice">4.1.4. MissingServiceGenericAccessDevice</a>
     <li><a href="#ref-for-missingservicegenericaccessdevice①">4.1.5. MissingCharacteristicGenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="missingcharacteristicgenericaccessdevice">
-   <b><a href="#missingcharacteristicgenericaccessdevice">#missingcharacteristicgenericaccessdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-missingcharacteristicgenericaccessdevice" class="dfn-panel" data-for="missingcharacteristicgenericaccessdevice" id="infopanel-for-missingcharacteristicgenericaccessdevice" role="dialog">
+   <span id="infopaneltitle-for-missingcharacteristicgenericaccessdevice" style="display:none">Info about the '4.1.5. MissingCharacteristicGenericAccessDevice' definition.</span><b><a href="#missingcharacteristicgenericaccessdevice">#missingcharacteristicgenericaccessdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-missingcharacteristicgenericaccessdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-missingcharacteristicgenericaccessdevice">4.1.5. MissingCharacteristicGenericAccessDevice</a>
     <li><a href="#ref-for-missingcharacteristicgenericaccessdevice①">4.1.6. MissingDescriptorGenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="missingdescriptorgenericaccessdevice">
-   <b><a href="#missingdescriptorgenericaccessdevice">#missingdescriptorgenericaccessdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-missingdescriptorgenericaccessdevice" class="dfn-panel" data-for="missingdescriptorgenericaccessdevice" id="infopanel-for-missingdescriptorgenericaccessdevice" role="dialog">
+   <span id="infopaneltitle-for-missingdescriptorgenericaccessdevice" style="display:none">Info about the '4.1.6. MissingDescriptorGenericAccessDevice' definition.</span><b><a href="#missingdescriptorgenericaccessdevice">#missingdescriptorgenericaccessdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-missingdescriptorgenericaccessdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-missingdescriptorgenericaccessdevice">4.1.6. MissingDescriptorGenericAccessDevice</a>
     <li><a href="#ref-for-missingdescriptorgenericaccessdevice①">4.1.7. GenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="genericaccessdevice">
-   <b><a href="#genericaccessdevice">#genericaccessdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-genericaccessdevice" class="dfn-panel" data-for="genericaccessdevice" id="infopanel-for-genericaccessdevice" role="dialog">
+   <span id="infopaneltitle-for-genericaccessdevice" style="display:none">Info about the '4.1.7. GenericAccessDevice' definition.</span><b><a href="#genericaccessdevice">#genericaccessdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-genericaccessdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-genericaccessdevice">4.1.7. GenericAccessDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="failinggattoperationsdevice">
-   <b><a href="#failinggattoperationsdevice">#failinggattoperationsdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-failinggattoperationsdevice" class="dfn-panel" data-for="failinggattoperationsdevice" id="infopanel-for-failinggattoperationsdevice" role="dialog">
+   <span id="infopaneltitle-for-failinggattoperationsdevice" style="display:none">Info about the '4.1.8. FailingGATTOperationsDevice' definition.</span><b><a href="#failinggattoperationsdevice">#failinggattoperationsdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-failinggattoperationsdevice">4.1. setBluetoothMockDataSet</a>
     <li><a href="#ref-for-failinggattoperationsdevice">4.1.8. FailingGATTOperationsDevice</a> <a href="#ref-for-failinggattoperationsdevice①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-erroruuid">
-   <b><a href="#abstract-opdef-erroruuid">#abstract-opdef-erroruuid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-erroruuid" class="dfn-panel" data-for="abstract-opdef-erroruuid" id="infopanel-for-abstract-opdef-erroruuid" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-erroruuid" style="display:none">Info about the 'errorUUID' definition.</span><b><a href="#abstract-opdef-erroruuid">#abstract-opdef-erroruuid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-erroruuid">4.1.8. FailingGATTOperationsDevice</a> <a href="#ref-for-abstract-opdef-erroruuid①">(2)</a> <a href="#ref-for-abstract-opdef-erroruuid②">(3)</a> <a href="#ref-for-abstract-opdef-erroruuid③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-setbluetoothmanualchooser">
-   <b><a href="#dom-testrunner-setbluetoothmanualchooser">#dom-testrunner-setbluetoothmanualchooser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-setbluetoothmanualchooser" class="dfn-panel" data-for="dom-testrunner-setbluetoothmanualchooser" id="infopanel-for-dom-testrunner-setbluetoothmanualchooser" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-setbluetoothmanualchooser" style="display:none">Info about the '4.2. setBluetoothManualChooser()' definition.</span><b><a href="#dom-testrunner-setbluetoothmanualchooser">#dom-testrunner-setbluetoothmanualchooser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-setbluetoothmanualchooser">4. testRunner</a>
     <li><a href="#ref-for-dom-testrunner-setbluetoothmanualchooser">4.2. setBluetoothManualChooser()</a> <a href="#ref-for-dom-testrunner-setbluetoothmanualchooser①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="manual-chooser">
-   <b><a href="#manual-chooser">#manual-chooser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-manual-chooser" class="dfn-panel" data-for="manual-chooser" id="infopanel-for-manual-chooser" role="dialog">
+   <span id="infopaneltitle-for-manual-chooser" style="display:none">Info about the 'manual chooser' definition.</span><b><a href="#manual-chooser">#manual-chooser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-manual-chooser">4.3. getBluetoothManualChooserEvents(callback)</a>
     <li><a href="#ref-for-manual-chooser①">4.4. sendBluetoothManualChooserEvent(event, argument)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-getbluetoothmanualchooserevents">
-   <b><a href="#dom-testrunner-getbluetoothmanualchooserevents">#dom-testrunner-getbluetoothmanualchooserevents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-getbluetoothmanualchooserevents" class="dfn-panel" data-for="dom-testrunner-getbluetoothmanualchooserevents" id="infopanel-for-dom-testrunner-getbluetoothmanualchooserevents" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-getbluetoothmanualchooserevents" style="display:none">Info about the '4.3. getBluetoothManualChooserEvents(callback)' definition.</span><b><a href="#dom-testrunner-getbluetoothmanualchooserevents">#dom-testrunner-getbluetoothmanualchooserevents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-getbluetoothmanualchooserevents">4. testRunner</a>
     <li><a href="#ref-for-dom-testrunner-getbluetoothmanualchooserevents①">4.2. setBluetoothManualChooser()</a>
     <li><a href="#ref-for-dom-testrunner-getbluetoothmanualchooserevents">4.3. getBluetoothManualChooserEvents(callback)</a> <a href="#ref-for-dom-testrunner-getbluetoothmanualchooserevents②">(2)</a> <a href="#ref-for-dom-testrunner-getbluetoothmanualchooserevents③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent">
-   <b><a href="#dom-testrunner-sendbluetoothmanualchooserevent">#dom-testrunner-sendbluetoothmanualchooserevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent" class="dfn-panel" data-for="dom-testrunner-sendbluetoothmanualchooserevent" id="infopanel-for-dom-testrunner-sendbluetoothmanualchooserevent" role="dialog">
+   <span id="infopaneltitle-for-dom-testrunner-sendbluetoothmanualchooserevent" style="display:none">Info about the '4.4. sendBluetoothManualChooserEvent(event, argument)' definition.</span><b><a href="#dom-testrunner-sendbluetoothmanualchooserevent">#dom-testrunner-sendbluetoothmanualchooserevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent">4. testRunner</a>
     <li><a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent①">4.2. setBluetoothManualChooser()</a>
     <li><a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent">4.4. sendBluetoothManualChooserEvent(event, argument)</a> <a href="#ref-for-dom-testrunner-sendbluetoothmanualchooserevent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventsender">
-   <b><a href="#eventsender">#eventsender</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventsender" class="dfn-panel" data-for="eventsender" id="infopanel-for-eventsender" role="dialog">
+   <span id="infopaneltitle-for-eventsender" style="display:none">Info about the 'EventSender' definition.</span><b><a href="#eventsender">#eventsender</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventsender">3. Testing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventsender-keydown-code-code">
-   <b><a href="#dom-eventsender-keydown-code-code">#dom-eventsender-keydown-code-code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventsender-keydown-code-code" class="dfn-panel" data-for="dom-eventsender-keydown-code-code" id="infopanel-for-dom-eventsender-keydown-code-code" role="dialog">
+   <span id="infopaneltitle-for-dom-eventsender-keydown-code-code" style="display:none">Info about the 'code' definition.</span><b><a href="#dom-eventsender-keydown-code-code">#dom-eventsender-keydown-code-code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventsender-keydown-code-code">5. eventSender</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventsender-keydown">
-   <b><a href="#dom-eventsender-keydown">#dom-eventsender-keydown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventsender-keydown" class="dfn-panel" data-for="dom-eventsender-keydown" id="infopanel-for-dom-eventsender-keydown" role="dialog">
+   <span id="infopaneltitle-for-dom-eventsender-keydown" style="display:none">Info about the 'keyDown(code)' definition.</span><b><a href="#dom-eventsender-keydown">#dom-eventsender-keydown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventsender-keydown">5. eventSender</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/heycam/webidl/index.html
+++ b/tests/github/heycam/webidl/index.html
@@ -14385,64 +14385,64 @@ language binding.</p>
    <li><a href="#dom-domexception-wrong_document_err">WRONG_DOCUMENT_ERR</a><span>, in § 2.8.1</span>
    <li><a href="#wrongdocumenterror">WrongDocumentError</a><span>, in § 2.8.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-css-supports-conditiontext">
-   <a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports-conditiontext">https://drafts.csswg.org/css-conditional-3/#dom-css-supports-conditiontext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-css-supports-conditiontext" class="dfn-panel" data-for="term-for-dom-css-supports-conditiontext" id="infopanel-for-term-for-dom-css-supports-conditiontext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-css-supports-conditiontext" style="display:none">Info about the 'supports(conditionText)' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports-conditiontext">https://drafts.csswg.org/css-conditional-3/#dom-css-supports-conditiontext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-supports-conditiontext">2.5.7.1. Overloading vs. union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-css-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports">https://drafts.csswg.org/css-conditional-3/#dom-css-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-css-supports" class="dfn-panel" data-for="term-for-dom-css-supports" id="infopanel-for-term-for-dom-css-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-css-supports" style="display:none">Info about the 'supports(property, value)' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports">https://drafts.csswg.org/css-conditional-3/#dom-css-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-supports">2.5.7.1. Overloading vs. union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">2.5.7.1. Overloading vs. union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.3.8. [NewObject]</a>
     <li><a href="#ref-for-document①">3.3.11. [SameObject]</a> <a href="#ref-for-document②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-callbackdef-eventlistener">
-   <a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-callbackdef-eventlistener" class="dfn-panel" data-for="term-for-callbackdef-eventlistener" id="infopanel-for-term-for-callbackdef-eventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-callbackdef-eventlistener" style="display:none">Info about the 'EventListener' external reference.</span><a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-eventlistener">2.4. Callback interfaces</a>
     <li><a href="#ref-for-callbackdef-eventlistener①">2.12. Objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-createelement">
-   <a href="https://dom.spec.whatwg.org/#dom-document-createelement">https://dom.spec.whatwg.org/#dom-document-createelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-createelement" class="dfn-panel" data-for="term-for-dom-document-createelement" id="infopanel-for-term-for-dom-document-createelement" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-createelement" style="display:none">Info about the 'createElement(localName)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-createelement">https://dom.spec.whatwg.org/#dom-document-createelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createelement">3.3.8. [NewObject]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2.8.1. Error names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-implementation">
-   <a href="https://dom.spec.whatwg.org/#dom-document-implementation">https://dom.spec.whatwg.org/#dom-document-implementation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-implementation" class="dfn-panel" data-for="term-for-dom-document-implementation" id="infopanel-for-term-for-dom-document-implementation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-implementation" style="display:none">Info about the 'implementation' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-implementation">https://dom.spec.whatwg.org/#dom-document-implementation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-implementation">3.3.11. [SameObject]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-node-tree">https://dom.spec.whatwg.org/#concept-node-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-tree" class="dfn-panel" data-for="term-for-concept-node-tree" id="infopanel-for-term-for-concept-node-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-tree" style="display:none">Info about the 'node tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-tree">https://dom.spec.whatwg.org/#concept-node-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-tree">2.8.1. Error names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands">
-   <a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands" class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands" id="infopanel-for-term-for-sec-returnifabrupt-shorthands" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands" style="display:none">Info about the '!' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands">3.2.4.1. byte</a>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands①">3.2.4.2. octet</a>
@@ -14509,38 +14509,38 @@ language binding.</p>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands②③⑥">Document conventions</a> <a href="#ref-for-sec-returnifabrupt-shorthands②③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.entries">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.entries">https://tc39.github.io/ecma262/#sec-array.prototype.entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.entries" class="dfn-panel" data-for="term-for-sec-array.prototype.entries" id="infopanel-for-term-for-sec-array.prototype.entries" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.entries" style="display:none">Info about the '%Array.prototype.entries%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.entries">https://tc39.github.io/ecma262/#sec-array.prototype.entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.entries">3.7.9. Iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.foreach">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.foreach">https://tc39.github.io/ecma262/#sec-array.prototype.foreach</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.foreach" class="dfn-panel" data-for="term-for-sec-array.prototype.foreach" id="infopanel-for-term-for-sec-array.prototype.foreach" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.foreach" style="display:none">Info about the '%Array.prototype.forEach%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.foreach">https://tc39.github.io/ecma262/#sec-array.prototype.foreach</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.foreach">3.7.9. Iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.keys">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.keys">https://tc39.github.io/ecma262/#sec-array.prototype.keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.keys" class="dfn-panel" data-for="term-for-sec-array.prototype.keys" id="infopanel-for-term-for-sec-array.prototype.keys" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.keys" style="display:none">Info about the '%Array.prototype.keys%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.keys">https://tc39.github.io/ecma262/#sec-array.prototype.keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.keys">3.7.9. Iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.values">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.values">https://tc39.github.io/ecma262/#sec-array.prototype.values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.values" class="dfn-panel" data-for="term-for-sec-array.prototype.values" id="infopanel-for-term-for-sec-array.prototype.values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.values" style="display:none">Info about the '%Array.prototype.values%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.values">https://tc39.github.io/ecma262/#sec-array.prototype.values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.values">3.7.9. Iterable declarations</a> <a href="#ref-for-sec-array.prototype.values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise.prototype.then">
-   <a href="https://tc39.github.io/ecma262/#sec-promise.prototype.then">https://tc39.github.io/ecma262/#sec-promise.prototype.then</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise.prototype.then" class="dfn-panel" data-for="term-for-sec-promise.prototype.then" id="infopanel-for-term-for-sec-promise.prototype.then" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise.prototype.then" style="display:none">Info about the '%Promise.prototype.then%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise.prototype.then">https://tc39.github.io/ecma262/#sec-promise.prototype.then</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise.prototype.then">3.2.23.1. Creating and manipulating Promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise.reject">
-   <a href="https://tc39.github.io/ecma262/#sec-promise.reject">https://tc39.github.io/ecma262/#sec-promise.reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise.reject" class="dfn-panel" data-for="term-for-sec-promise.reject" id="infopanel-for-term-for-sec-promise.reject" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise.reject" style="display:none">Info about the '%Promise.reject%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise.reject">https://tc39.github.io/ecma262/#sec-promise.reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise.reject">3.7.6. Attributes</a>
     <li><a href="#ref-for-sec-promise.reject①">3.7.7. Operations</a>
@@ -14548,8 +14548,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-promise.reject③">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands">
-   <a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands" class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands" id="infopanel-for-term-for-sec-returnifabrupt-shorthands①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands①" style="display:none">Info about the '?' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands">3.2.4.1. byte</a>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands①">3.2.4.2. octet</a>
@@ -14616,22 +14616,22 @@ language binding.</p>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands②③⑥">Document conventions</a> <a href="#ref-for-sec-returnifabrupt-shorthands②③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">https://tc39.github.io/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-objects" class="dfn-panel" data-for="term-for-sec-arraybuffer-objects" id="infopanel-for-term-for-sec-arraybuffer-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-objects" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">https://tc39.github.io/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-objects">3.2.25. Buffer source types</a> <a href="#ref-for-sec-arraybuffer-objects①">(2)</a>
     <li><a href="#ref-for-sec-arraybuffer-objects②">3.3.1. [AllowShared]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraycreate">
-   <a href="https://tc39.github.io/ecma262/#sec-arraycreate">https://tc39.github.io/ecma262/#sec-arraycreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraycreate" class="dfn-panel" data-for="term-for-sec-arraycreate" id="infopanel-for-term-for-sec-arraycreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraycreate" style="display:none">Info about the 'ArrayCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraycreate">https://tc39.github.io/ecma262/#sec-arraycreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraycreate">3.7.9.2. Iterator prototype object</a>
     <li><a href="#ref-for-sec-arraycreate①">3.10. Observable array exotic objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-call">
-   <a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-call" class="dfn-panel" data-for="term-for-sec-call" id="infopanel-for-term-for-sec-call" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-call" style="display:none">Info about the 'Call' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-call">3.2.23. Promise types — Promise&lt;T></a>
     <li><a href="#ref-for-sec-call①">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-sec-call②">(2)</a> <a href="#ref-for-sec-call③">(3)</a> <a href="#ref-for-sec-call④">(4)</a>
@@ -14650,33 +14650,33 @@ language binding.</p>
     <li><a href="#ref-for-sec-call②④">3.12. Invoking callback functions</a> <a href="#ref-for-sec-call②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-canonicalnumericindexstring">
-   <a href="https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring">https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-canonicalnumericindexstring" class="dfn-panel" data-for="term-for-sec-canonicalnumericindexstring" id="infopanel-for-term-for-sec-canonicalnumericindexstring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-canonicalnumericindexstring" style="display:none">Info about the 'CanonicalNumericIndexString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring">https://tc39.github.io/ecma262/#sec-canonicalnumericindexstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-canonicalnumericindexstring">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion">
-   <a href="https://tc39.github.io/ecma262/#sec-completion">https://tc39.github.io/ecma262/#sec-completion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion" class="dfn-panel" data-for="term-for-sec-completion" id="infopanel-for-term-for-sec-completion" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion" style="display:none">Info about the 'Completion' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-completion">https://tc39.github.io/ecma262/#sec-completion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion">3.11. Callback interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-construct">
-   <a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-construct" class="dfn-panel" data-for="term-for-sec-construct" id="infopanel-for-term-for-sec-construct" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-construct" style="display:none">Info about the 'Construct' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-construct">3.12. Invoking callback functions</a>
     <li><a href="#ref-for-sec-construct①">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createarrayfromlist">
-   <a href="https://tc39.github.io/ecma262/#sec-createarrayfromlist">https://tc39.github.io/ecma262/#sec-createarrayfromlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createarrayfromlist" class="dfn-panel" data-for="term-for-sec-createarrayfromlist" id="infopanel-for-term-for-sec-createarrayfromlist" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createarrayfromlist" style="display:none">Info about the 'CreateArrayFromList' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createarrayfromlist">https://tc39.github.io/ecma262/#sec-createarrayfromlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createarrayfromlist">3.10.6. ownKeys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createbuiltinfunction">
-   <a href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">https://tc39.github.io/ecma262/#sec-createbuiltinfunction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createbuiltinfunction" class="dfn-panel" data-for="term-for-sec-createbuiltinfunction" id="infopanel-for-term-for-sec-createbuiltinfunction" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createbuiltinfunction" style="display:none">Info about the 'CreateBuiltinFunction' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createbuiltinfunction">https://tc39.github.io/ecma262/#sec-createbuiltinfunction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createbuiltinfunction">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-sec-createbuiltinfunction①">(2)</a> <a href="#ref-for-sec-createbuiltinfunction②">(3)</a> <a href="#ref-for-sec-createbuiltinfunction③">(4)</a>
     <li><a href="#ref-for-sec-createbuiltinfunction④">3.7.1. Interface object</a>
@@ -14690,8 +14690,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-createbuiltinfunction②⑨">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdataproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdataproperty" class="dfn-panel" data-for="term-for-sec-createdataproperty" id="infopanel-for-term-for-sec-createdataproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdataproperty" style="display:none">Info about the 'CreateDataProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdataproperty">3.2.17. Dictionary types</a>
     <li><a href="#ref-for-sec-createdataproperty①">3.2.21. Sequences — sequence&lt;T></a>
@@ -14705,21 +14705,21 @@ language binding.</p>
     <li><a href="#ref-for-sec-createdataproperty①⑨">3.10. Observable array exotic objects</a> <a href="#ref-for-sec-createdataproperty②⓪">(2)</a> <a href="#ref-for-sec-createdataproperty②①">(3)</a> <a href="#ref-for-sec-createdataproperty②②">(4)</a> <a href="#ref-for-sec-createdataproperty②③">(5)</a> <a href="#ref-for-sec-createdataproperty②④">(6)</a> <a href="#ref-for-sec-createdataproperty②⑤">(7)</a> <a href="#ref-for-sec-createdataproperty②⑥">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createiterresultobject">
-   <a href="https://tc39.github.io/ecma262/#sec-createiterresultobject">https://tc39.github.io/ecma262/#sec-createiterresultobject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createiterresultobject" class="dfn-panel" data-for="term-for-sec-createiterresultobject" id="infopanel-for-term-for-sec-createiterresultobject" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createiterresultobject" style="display:none">Info about the 'CreateIterResultObject' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createiterresultobject">https://tc39.github.io/ecma262/#sec-createiterresultobject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createiterresultobject">3.7.9.2. Iterator prototype object</a> <a href="#ref-for-sec-createiterresultobject①">(2)</a>
     <li><a href="#ref-for-sec-createiterresultobject②">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-sec-createiterresultobject③">(2)</a> <a href="#ref-for-sec-createiterresultobject④">(3)</a> <a href="#ref-for-sec-createiterresultobject⑤">(4)</a> <a href="#ref-for-sec-createiterresultobject⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createmapiterator">
-   <a href="https://tc39.github.io/ecma262/#sec-createmapiterator">https://tc39.github.io/ecma262/#sec-createmapiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createmapiterator" class="dfn-panel" data-for="term-for-sec-createmapiterator" id="infopanel-for-term-for-sec-createmapiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createmapiterator" style="display:none">Info about the 'CreateMapIterator' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createmapiterator">https://tc39.github.io/ecma262/#sec-createmapiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createmapiterator">3.7.8.1. @@iterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createmethodproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-createmethodproperty">https://tc39.github.io/ecma262/#sec-createmethodproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createmethodproperty" class="dfn-panel" data-for="term-for-sec-createmethodproperty" id="infopanel-for-term-for-sec-createmethodproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createmethodproperty" style="display:none">Info about the 'CreateMethodProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createmethodproperty">https://tc39.github.io/ecma262/#sec-createmethodproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createmethodproperty">3.7.9. Iterable declarations</a> <a href="#ref-for-sec-createmethodproperty①">(2)</a>
     <li><a href="#ref-for-sec-createmethodproperty②">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-sec-createmethodproperty③">(2)</a>
@@ -14727,21 +14727,21 @@ language binding.</p>
     <li><a href="#ref-for-sec-createmethodproperty⑨">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createsetiterator">
-   <a href="https://tc39.github.io/ecma262/#sec-createsetiterator">https://tc39.github.io/ecma262/#sec-createsetiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createsetiterator" class="dfn-panel" data-for="term-for-sec-createsetiterator" id="infopanel-for-term-for-sec-createsetiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createsetiterator" style="display:none">Info about the 'CreateSetIterator' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createsetiterator">https://tc39.github.io/ecma262/#sec-createsetiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createsetiterator">3.7.8.1. @@iterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-dataview-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-dataview-objects">https://tc39.github.io/ecma262/#sec-dataview-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-dataview-objects" class="dfn-panel" data-for="term-for-sec-dataview-objects" id="infopanel-for-term-for-sec-dataview-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-dataview-objects" style="display:none">Info about the 'DataView' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-dataview-objects">https://tc39.github.io/ecma262/#sec-dataview-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-dataview-objects">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-sec-dataview-objects①">3.3.1. [AllowShared]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-definepropertyorthrow">
-   <a href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">https://tc39.github.io/ecma262/#sec-definepropertyorthrow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-definepropertyorthrow" class="dfn-panel" data-for="term-for-sec-definepropertyorthrow" id="infopanel-for-term-for-sec-definepropertyorthrow" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-definepropertyorthrow" style="display:none">Info about the 'DefinePropertyOrThrow' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-definepropertyorthrow">https://tc39.github.io/ecma262/#sec-definepropertyorthrow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-definepropertyorthrow">3.7.1. Interface object</a>
     <li><a href="#ref-for-sec-definepropertyorthrow①">3.7.2. Legacy factory functions</a>
@@ -14752,27 +14752,27 @@ language binding.</p>
     <li><a href="#ref-for-sec-definepropertyorthrow⑦">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-detacharraybuffer">
-   <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">https://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-detacharraybuffer" class="dfn-panel" data-for="term-for-sec-detacharraybuffer" id="infopanel-for-term-for-sec-detacharraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-detacharraybuffer" style="display:none">Info about the 'DetachArrayBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">https://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-detacharraybuffer">3.2.25. Buffer source types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-error-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-error-objects" class="dfn-panel" data-for="term-for-sec-error-objects" id="infopanel-for-term-for-sec-error-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-error-objects" style="display:none">Info about the 'Error' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-error-objects">2.8. Exceptions</a> <a href="#ref-for-sec-error-objects①">(2)</a>
     <li><a href="#ref-for-sec-error-objects②">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-frompropertydescriptor">
-   <a href="https://tc39.github.io/ecma262/#sec-frompropertydescriptor">https://tc39.github.io/ecma262/#sec-frompropertydescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-frompropertydescriptor" class="dfn-panel" data-for="term-for-sec-frompropertydescriptor" id="infopanel-for-term-for-sec-frompropertydescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-frompropertydescriptor" style="display:none">Info about the 'FromPropertyDescriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-frompropertydescriptor">https://tc39.github.io/ecma262/#sec-frompropertydescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-frompropertydescriptor">3.10.4. getOwnPropertyDescriptor</a> <a href="#ref-for-sec-frompropertydescriptor①">(2)</a> <a href="#ref-for-sec-frompropertydescriptor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'Get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">3.2.17. Dictionary types</a>
     <li><a href="#ref-for-sec-get-o-p①">3.2.22. Records — record&lt;K, V></a>
@@ -14787,20 +14787,20 @@ language binding.</p>
     <li><a href="#ref-for-sec-get-o-p①⓪">3.11. Callback interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getfunctionrealm">
-   <a href="https://tc39.github.io/ecma262/#sec-getfunctionrealm">https://tc39.github.io/ecma262/#sec-getfunctionrealm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getfunctionrealm" class="dfn-panel" data-for="term-for-sec-getfunctionrealm" id="infopanel-for-term-for-sec-getfunctionrealm" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getfunctionrealm" style="display:none">Info about the 'GetFunctionRealm' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-getfunctionrealm">https://tc39.github.io/ecma262/#sec-getfunctionrealm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getfunctionrealm">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getiterator">
-   <a href="https://tc39.github.io/ecma262/#sec-getiterator">https://tc39.github.io/ecma262/#sec-getiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getiterator" class="dfn-panel" data-for="term-for-sec-getiterator" id="infopanel-for-term-for-sec-getiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getiterator" style="display:none">Info about the 'GetIterator' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-getiterator">https://tc39.github.io/ecma262/#sec-getiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getiterator">3.2.21.1. Creating a sequence from an iterable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getmethod">
-   <a href="https://tc39.github.io/ecma262/#sec-getmethod">https://tc39.github.io/ecma262/#sec-getmethod</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getmethod" class="dfn-panel" data-for="term-for-sec-getmethod" id="infopanel-for-term-for-sec-getmethod" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getmethod" style="display:none">Info about the 'GetMethod' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-getmethod">https://tc39.github.io/ecma262/#sec-getmethod</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getmethod">3.2.21. Sequences — sequence&lt;T></a>
     <li><a href="#ref-for-sec-getmethod①">3.2.24. Union types</a> <a href="#ref-for-sec-getmethod②">(2)</a>
@@ -14810,20 +14810,20 @@ language binding.</p>
     <li><a href="#ref-for-sec-getmethod⑥">3.7.12. Setlike declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ifabruptrejectpromise">
-   <a href="https://tc39.github.io/ecma262/#sec-ifabruptrejectpromise">https://tc39.github.io/ecma262/#sec-ifabruptrejectpromise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ifabruptrejectpromise" class="dfn-panel" data-for="term-for-sec-ifabruptrejectpromise" id="infopanel-for-term-for-sec-ifabruptrejectpromise" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ifabruptrejectpromise" style="display:none">Info about the 'IfAbruptRejectPromise' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ifabruptrejectpromise">https://tc39.github.io/ecma262/#sec-ifabruptrejectpromise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ifabruptrejectpromise">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-sec-ifabruptrejectpromise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isaccessordescriptor">
-   <a href="https://tc39.github.io/ecma262/#sec-isaccessordescriptor">https://tc39.github.io/ecma262/#sec-isaccessordescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isaccessordescriptor" class="dfn-panel" data-for="term-for-sec-isaccessordescriptor" id="infopanel-for-term-for-sec-isaccessordescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isaccessordescriptor" style="display:none">Info about the 'IsAccessorDescriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isaccessordescriptor">https://tc39.github.io/ecma262/#sec-isaccessordescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isaccessordescriptor">3.10.1. defineProperty</a> <a href="#ref-for-sec-isaccessordescriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iscallable">
-   <a href="https://tc39.github.io/ecma262/#sec-iscallable">https://tc39.github.io/ecma262/#sec-iscallable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iscallable" class="dfn-panel" data-for="term-for-sec-iscallable" id="infopanel-for-term-for-sec-iscallable" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iscallable" style="display:none">Info about the 'IsCallable' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-iscallable">https://tc39.github.io/ecma262/#sec-iscallable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iscallable">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-sec-iscallable①">3.2.19. Callback function types</a>
@@ -14836,64 +14836,64 @@ language binding.</p>
     <li><a href="#ref-for-sec-iscallable①①">3.12. Invoking callback functions</a> <a href="#ref-for-sec-iscallable①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isconstructor">
-   <a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isconstructor" class="dfn-panel" data-for="term-for-sec-isconstructor" id="infopanel-for-term-for-sec-isconstructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isconstructor" style="display:none">Info about the 'IsConstructor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isconstructor">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isdatadescriptor">
-   <a href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">https://tc39.github.io/ecma262/#sec-isdatadescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isdatadescriptor" class="dfn-panel" data-for="term-for-sec-isdatadescriptor" id="infopanel-for-term-for-sec-isdatadescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isdatadescriptor" style="display:none">Info about the 'IsDataDescriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isdatadescriptor">https://tc39.github.io/ecma262/#sec-isdatadescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isdatadescriptor">3.9.3. [[DefineOwnProperty]]</a> <a href="#ref-for-sec-isdatadescriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isdetachedbuffer">
-   <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isdetachedbuffer" class="dfn-panel" data-for="term-for-sec-isdetachedbuffer" id="infopanel-for-term-for-sec-isdetachedbuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isdetachedbuffer" style="display:none">Info about the 'IsDetachedBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isdetachedbuffer">3.2.25. Buffer source types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isinteger">
-   <a href="https://tc39.github.io/ecma262/#sec-isinteger">https://tc39.github.io/ecma262/#sec-isinteger</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isinteger" class="dfn-panel" data-for="term-for-sec-isinteger" id="infopanel-for-term-for-sec-isinteger" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isinteger" style="display:none">Info about the 'IsInteger' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isinteger">https://tc39.github.io/ecma262/#sec-isinteger</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isinteger">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-issharedarraybuffer">
-   <a href="https://tc39.github.io/ecma262/#sec-issharedarraybuffer">https://tc39.github.io/ecma262/#sec-issharedarraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-issharedarraybuffer" class="dfn-panel" data-for="term-for-sec-issharedarraybuffer" id="infopanel-for-term-for-sec-issharedarraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-issharedarraybuffer" style="display:none">Info about the 'IsSharedArrayBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-issharedarraybuffer">https://tc39.github.io/ecma262/#sec-issharedarraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-issharedarraybuffer">3.2.25. Buffer source types</a> <a href="#ref-for-sec-issharedarraybuffer①">(2)</a> <a href="#ref-for-sec-issharedarraybuffer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iteratorstep">
-   <a href="https://tc39.github.io/ecma262/#sec-iteratorstep">https://tc39.github.io/ecma262/#sec-iteratorstep</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iteratorstep" class="dfn-panel" data-for="term-for-sec-iteratorstep" id="infopanel-for-term-for-sec-iteratorstep" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iteratorstep" style="display:none">Info about the 'IteratorStep' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-iteratorstep">https://tc39.github.io/ecma262/#sec-iteratorstep</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iteratorstep">3.2.21.1. Creating a sequence from an iterable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iteratorvalue">
-   <a href="https://tc39.github.io/ecma262/#sec-iteratorvalue">https://tc39.github.io/ecma262/#sec-iteratorvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iteratorvalue" class="dfn-panel" data-for="term-for-sec-iteratorvalue" id="infopanel-for-term-for-sec-iteratorvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iteratorvalue" style="display:none">Info about the 'IteratorValue' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-iteratorvalue">https://tc39.github.io/ecma262/#sec-iteratorvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iteratorvalue">3.2.21.1. Creating a sequence from an iterable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-json.stringify">
-   <a href="https://tc39.github.io/ecma262/#sec-json.stringify">https://tc39.github.io/ecma262/#sec-json.stringify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-json.stringify" class="dfn-panel" data-for="term-for-sec-json.stringify" id="infopanel-for-term-for-sec-json.stringify" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-json.stringify" style="display:none">Info about the 'JSON.stringify()' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-json.stringify">https://tc39.github.io/ecma262/#sec-json.stringify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-json.stringify">2.5.3.1. toJSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-makebasicobject">
-   <a href="https://tc39.github.io/ecma262/#sec-makebasicobject">https://tc39.github.io/ecma262/#sec-makebasicobject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-makebasicobject" class="dfn-panel" data-for="term-for-sec-makebasicobject" id="infopanel-for-term-for-sec-makebasicobject" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-makebasicobject" style="display:none">Info about the 'MakeBasicObject' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-makebasicobject">https://tc39.github.io/ecma262/#sec-makebasicobject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-makebasicobject">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-sec-makebasicobject①">3.7.4. Named properties object</a>
     <li><a href="#ref-for-sec-makebasicobject②">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-map-objects">https://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'Map' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-map-objects">https://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">2.5.10. Maplike declarations</a>
     <li><a href="#ref-for-sec-map-objects①">3.7.11. Maplike declarations</a> <a href="#ref-for-sec-map-objects②">(2)</a> <a href="#ref-for-sec-map-objects③">(3)</a>
@@ -14904,16 +14904,16 @@ language binding.</p>
     <li><a href="#ref-for-sec-map-objects⑧">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-newpromisecapability">
-   <a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">https://tc39.github.io/ecma262/#sec-newpromisecapability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-newpromisecapability" class="dfn-panel" data-for="term-for-sec-newpromisecapability" id="infopanel-for-term-for-sec-newpromisecapability" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-newpromisecapability" style="display:none">Info about the 'NewPromiseCapability' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-newpromisecapability">https://tc39.github.io/ecma262/#sec-newpromisecapability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-newpromisecapability">3.2.23. Promise types — Promise&lt;T></a>
     <li><a href="#ref-for-sec-newpromisecapability①">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-sec-newpromisecapability②">(2)</a> <a href="#ref-for-sec-newpromisecapability③">(3)</a> <a href="#ref-for-sec-newpromisecapability④">(4)</a>
     <li><a href="#ref-for-sec-newpromisecapability⑤">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-sec-newpromisecapability⑥">(2)</a> <a href="#ref-for-sec-newpromisecapability⑦">(3)</a> <a href="#ref-for-sec-newpromisecapability⑧">(4)</a> <a href="#ref-for-sec-newpromisecapability⑨">(5)</a> <a href="#ref-for-sec-newpromisecapability①⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-built-in-function-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-built-in-function-objects" class="dfn-panel" data-for="term-for-sec-built-in-function-objects" id="infopanel-for-term-for-sec-built-in-function-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-built-in-function-objects" style="display:none">Info about the 'NewTarget' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-built-in-function-objects">2. Interface definition language</a>
     <li><a href="#ref-for-sec-built-in-function-objects①">2.3. Interface mixins</a> <a href="#ref-for-sec-built-in-function-objects②">(2)</a> <a href="#ref-for-sec-built-in-function-objects③">(3)</a>
@@ -14940,21 +14940,21 @@ language binding.</p>
     <li><a href="#ref-for-sec-built-in-function-objects②⑨">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinarydefineownproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinarydefineownproperty" class="dfn-panel" data-for="term-for-sec-ordinarydefineownproperty" id="infopanel-for-term-for-sec-ordinarydefineownproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinarydefineownproperty" style="display:none">Info about the 'OrdinaryDefineOwnProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty">https://tc39.github.io/ecma262/#sec-ordinarydefineownproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinarydefineownproperty">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinarygetownproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">https://tc39.github.io/ecma262/#sec-ordinarygetownproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinarygetownproperty" class="dfn-panel" data-for="term-for-sec-ordinarygetownproperty" id="infopanel-for-term-for-sec-ordinarygetownproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinarygetownproperty" style="display:none">Info about the 'OrdinaryGetOwnProperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinarygetownproperty">https://tc39.github.io/ecma262/#sec-ordinarygetownproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinarygetownproperty">3.7.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-sec-ordinarygetownproperty①">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate">https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate" id="infopanel-for-term-for-sec-ordinaryobjectcreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" style="display:none">Info about the 'OrdinaryObjectCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate">https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinaryobjectcreate">3.2.17. Dictionary types</a>
     <li><a href="#ref-for-sec-ordinaryobjectcreate①">3.2.22. Records — record&lt;K, V></a>
@@ -14965,33 +14965,33 @@ language binding.</p>
     <li><a href="#ref-for-sec-ordinaryobjectcreate⑦">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinarysetwithowndescriptor">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinarysetwithowndescriptor">https://tc39.github.io/ecma262/#sec-ordinarysetwithowndescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinarysetwithowndescriptor" class="dfn-panel" data-for="term-for-sec-ordinarysetwithowndescriptor" id="infopanel-for-term-for-sec-ordinarysetwithowndescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinarysetwithowndescriptor" style="display:none">Info about the 'OrdinarySetWithOwnDescriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinarysetwithowndescriptor">https://tc39.github.io/ecma262/#sec-ordinarysetwithowndescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinarysetwithowndescriptor">3.9.2. [[Set]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-performpromisethen">
-   <a href="https://tc39.github.io/ecma262/#sec-performpromisethen">https://tc39.github.io/ecma262/#sec-performpromisethen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-performpromisethen" class="dfn-panel" data-for="term-for-sec-performpromisethen" id="infopanel-for-term-for-sec-performpromisethen" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-performpromisethen" style="display:none">Info about the 'PerformPromiseThen' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-performpromisethen">https://tc39.github.io/ecma262/#sec-performpromisethen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-performpromisethen">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-sec-performpromisethen①">(2)</a>
     <li><a href="#ref-for-sec-performpromisethen②">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-sec-performpromisethen③">(2)</a> <a href="#ref-for-sec-performpromisethen④">(3)</a> <a href="#ref-for-sec-performpromisethen⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-proxycreate">
-   <a href="https://tc39.github.io/ecma262/#sec-proxycreate">https://tc39.github.io/ecma262/#sec-proxycreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-proxycreate" class="dfn-panel" data-for="term-for-sec-proxycreate" id="infopanel-for-term-for-sec-proxycreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-proxycreate" style="display:none">Info about the 'ProxyCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-proxycreate">https://tc39.github.io/ecma262/#sec-proxycreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-proxycreate">3.10. Observable array exotic objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-set-o-p-v-throw">
-   <a href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">https://tc39.github.io/ecma262/#sec-set-o-p-v-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-set-o-p-v-throw" class="dfn-panel" data-for="term-for-sec-set-o-p-v-throw" id="infopanel-for-term-for-sec-set-o-p-v-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-set-o-p-v-throw" style="display:none">Info about the 'Set' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-set-o-p-v-throw">https://tc39.github.io/ecma262/#sec-set-o-p-v-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-set-o-p-v-throw">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-set-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-set-objects">https://tc39.github.io/ecma262/#sec-set-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-set-objects" class="dfn-panel" data-for="term-for-sec-set-objects" id="infopanel-for-term-for-sec-set-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-set-objects" style="display:none">Info about the 'Set (for ECMAScript)' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-set-objects">https://tc39.github.io/ecma262/#sec-set-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-set-objects">2.5.11. Setlike declarations</a>
     <li><a href="#ref-for-sec-set-objects①">3.7.12. Setlike declarations</a> <a href="#ref-for-sec-set-objects②">(2)</a> <a href="#ref-for-sec-set-objects③">(3)</a>
@@ -15000,8 +15000,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-set-objects⑥">3.7.12.5. add and delete</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setfunctionlength">
-   <a href="https://tc39.github.io/ecma262/#sec-setfunctionlength">https://tc39.github.io/ecma262/#sec-setfunctionlength</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setfunctionlength" class="dfn-panel" data-for="term-for-sec-setfunctionlength" id="infopanel-for-term-for-sec-setfunctionlength" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setfunctionlength" style="display:none">Info about the 'SetFunctionLength' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-setfunctionlength">https://tc39.github.io/ecma262/#sec-setfunctionlength</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setfunctionlength">3.7.1. Interface object</a>
     <li><a href="#ref-for-sec-setfunctionlength①">3.7.2. Legacy factory functions</a>
@@ -15012,8 +15012,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-setfunctionlength①②">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setfunctionname">
-   <a href="https://tc39.github.io/ecma262/#sec-setfunctionname">https://tc39.github.io/ecma262/#sec-setfunctionname</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setfunctionname" class="dfn-panel" data-for="term-for-sec-setfunctionname" id="infopanel-for-term-for-sec-setfunctionname" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setfunctionname" style="display:none">Info about the 'SetFunctionName' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-setfunctionname">https://tc39.github.io/ecma262/#sec-setfunctionname</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setfunctionname">3.7.1. Interface object</a>
     <li><a href="#ref-for-sec-setfunctionname①">3.7.2. Legacy factory functions</a>
@@ -15024,54 +15024,54 @@ language binding.</p>
     <li><a href="#ref-for-sec-setfunctionname①②">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-set-immutable-prototype">
-   <a href="https://tc39.github.io/ecma262/#sec-set-immutable-prototype">https://tc39.github.io/ecma262/#sec-set-immutable-prototype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-set-immutable-prototype" class="dfn-panel" data-for="term-for-sec-set-immutable-prototype" id="infopanel-for-term-for-sec-set-immutable-prototype" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-set-immutable-prototype" style="display:none">Info about the 'SetImmutablePrototype' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-set-immutable-prototype">https://tc39.github.io/ecma262/#sec-set-immutable-prototype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-set-immutable-prototype">3.7.4.4. [[SetPrototypeOf]]</a>
     <li><a href="#ref-for-sec-set-immutable-prototype①">3.8.1. [[SetPrototypeOf]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setintegritylevel">
-   <a href="https://tc39.github.io/ecma262/#sec-setintegritylevel">https://tc39.github.io/ecma262/#sec-setintegritylevel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setintegritylevel" class="dfn-panel" data-for="term-for-sec-setintegritylevel" id="infopanel-for-term-for-sec-setintegritylevel" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setintegritylevel" style="display:none">Info about the 'SetIntegrityLevel' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-setintegritylevel">https://tc39.github.io/ecma262/#sec-setintegritylevel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setintegritylevel">3.2.26. Frozen arrays — FrozenArray&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-sharedarraybuffer-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects">https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-sharedarraybuffer-objects" class="dfn-panel" data-for="term-for-sec-sharedarraybuffer-objects" id="infopanel-for-term-for-sec-sharedarraybuffer-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-sharedarraybuffer-objects" style="display:none">Info about the 'SharedArrayBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects">https://tc39.github.io/ecma262/#sec-sharedarraybuffer-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-sharedarraybuffer-objects">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-sec-sharedarraybuffer-objects①">3.3.1. [AllowShared]</a> <a href="#ref-for-sec-sharedarraybuffer-objects②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-syntaxerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-syntaxerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-syntaxerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-syntaxerror">2.8. Exceptions</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-syntaxerror①">2.8.1. Error names</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-syntaxerror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tobigint">
-   <a href="https://tc39.github.io/ecma262/#sec-tobigint">https://tc39.github.io/ecma262/#sec-tobigint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tobigint" class="dfn-panel" data-for="term-for-sec-tobigint" id="infopanel-for-term-for-sec-tobigint" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tobigint" style="display:none">Info about the 'ToBigInt' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tobigint">https://tc39.github.io/ecma262/#sec-tobigint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tobigint">3.2.9. bigint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-toboolean">
-   <a href="https://tc39.github.io/ecma262/#sec-toboolean">https://tc39.github.io/ecma262/#sec-toboolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-toboolean" class="dfn-panel" data-for="term-for-sec-toboolean" id="infopanel-for-term-for-sec-toboolean" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-toboolean" style="display:none">Info about the 'ToBoolean' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-toboolean">https://tc39.github.io/ecma262/#sec-toboolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-toboolean">3.2.3. boolean</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-toint32">
-   <a href="https://tc39.github.io/ecma262/#sec-toint32">https://tc39.github.io/ecma262/#sec-toint32</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-toint32" class="dfn-panel" data-for="term-for-sec-toint32" id="infopanel-for-term-for-sec-toint32" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-toint32" style="display:none">Info about the 'ToInt32' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-toint32">https://tc39.github.io/ecma262/#sec-toint32</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-toint32">3.3.2. [Clamp]</a>
     <li><a href="#ref-for-sec-toint32①">3.3.5. [EnforceRange]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tonumber">
-   <a href="https://tc39.github.io/ecma262/#sec-tonumber">https://tc39.github.io/ecma262/#sec-tonumber</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tonumber" class="dfn-panel" data-for="term-for-sec-tonumber" id="infopanel-for-term-for-sec-tonumber" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tonumber" style="display:none">Info about the 'ToNumber' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tonumber">https://tc39.github.io/ecma262/#sec-tonumber</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tonumber">3.2.4.9. Abstract operations</a>
     <li><a href="#ref-for-sec-tonumber①">3.2.5. float</a>
@@ -15081,14 +15081,14 @@ language binding.</p>
     <li><a href="#ref-for-sec-tonumber⑤">3.10.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tonumeric">
-   <a href="https://tc39.github.io/ecma262/#sec-tonumeric">https://tc39.github.io/ecma262/#sec-tonumeric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tonumeric" class="dfn-panel" data-for="term-for-sec-tonumeric" id="infopanel-for-term-for-sec-tonumeric" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tonumeric" style="display:none">Info about the 'ToNumeric' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tonumeric">https://tc39.github.io/ecma262/#sec-tonumeric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tonumeric">3.2.9. bigint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-toobject">
-   <a href="https://tc39.github.io/ecma262/#sec-toobject">https://tc39.github.io/ecma262/#sec-toobject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-toobject" class="dfn-panel" data-for="term-for-sec-toobject" id="infopanel-for-term-for-sec-toobject" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-toobject" style="display:none">Info about the 'ToObject' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-toobject">https://tc39.github.io/ecma262/#sec-toobject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-toobject">3.7.7.2. Stringifiers</a>
     <li><a href="#ref-for-sec-toobject①">3.7.8.1. @@iterator</a>
@@ -15099,14 +15099,14 @@ language binding.</p>
     <li><a href="#ref-for-sec-toobject①①">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-sec-toobject①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-topropertydescriptor">
-   <a href="https://tc39.github.io/ecma262/#sec-topropertydescriptor">https://tc39.github.io/ecma262/#sec-topropertydescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-topropertydescriptor" class="dfn-panel" data-for="term-for-sec-topropertydescriptor" id="infopanel-for-term-for-sec-topropertydescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-topropertydescriptor" style="display:none">Info about the 'ToPropertyDescriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-topropertydescriptor">https://tc39.github.io/ecma262/#sec-topropertydescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-topropertydescriptor">3.10.1. defineProperty</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'ToString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">3. ECMAScript binding</a> <a href="#ref-for-sec-tostring①">(2)</a>
     <li><a href="#ref-for-sec-tostring②">3.2.10. DOMString</a>
@@ -15118,8 +15118,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-tostring⑧">3.10.6. ownKeys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-touint32">
-   <a href="https://tc39.github.io/ecma262/#sec-touint32">https://tc39.github.io/ecma262/#sec-touint32</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-touint32" class="dfn-panel" data-for="term-for-sec-touint32" id="infopanel-for-term-for-sec-touint32" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-touint32" style="display:none">Info about the 'ToUint32' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-touint32">https://tc39.github.io/ecma262/#sec-touint32</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-touint32">3.3.2. [Clamp]</a>
     <li><a href="#ref-for-sec-touint32①">3.3.5. [EnforceRange]</a>
@@ -15132,8 +15132,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-touint32⑨">3.10.9. Abstract operations</a> <a href="#ref-for-sec-touint32①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'Type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">3.2.1. any</a> <a href="#ref-for-sec-ecmascript-data-types-and-values①">(2)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values②">(3)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values③">(4)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values④">(5)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑤">(6)</a>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values⑥">3.2.9. bigint</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑦">(2)</a>
@@ -15155,8 +15155,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values④⓪">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">3.2.4.9. Abstract operations</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">3.2.5. float</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(2)</a>
@@ -15200,8 +15200,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑦⓪">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'abrupt completion' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">3.11. Callback interfaces</a> <a href="#ref-for-sec-completion-record-specification-type①">(2)</a> <a href="#ref-for-sec-completion-record-specification-type②">(3)</a>
     <li><a href="#ref-for-sec-completion-record-specification-type③">3.12. Invoking callback functions</a> <a href="#ref-for-sec-completion-record-specification-type④">(2)</a> <a href="#ref-for-sec-completion-record-specification-type⑤">(3)</a>
@@ -15209,40 +15209,40 @@ language binding.</p>
     <li><a href="#ref-for-sec-completion-record-specification-type⑦">Document conventions</a> <a href="#ref-for-sec-completion-record-specification-type⑧">(2)</a> <a href="#ref-for-sec-completion-record-specification-type⑨">(3)</a> <a href="#ref-for-sec-completion-record-specification-type①⓪">(4)</a> <a href="#ref-for-sec-completion-record-specification-type①①">(5)</a> <a href="#ref-for-sec-completion-record-specification-type①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eqn-abs">
-   <a href="https://tc39.github.io/ecma262/#eqn-abs">https://tc39.github.io/ecma262/#eqn-abs</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eqn-abs" class="dfn-panel" data-for="term-for-eqn-abs" id="infopanel-for-term-for-eqn-abs" role="menu">
+   <span id="infopaneltitle-for-term-for-eqn-abs" style="display:none">Info about the 'abs' external reference.</span><a href="https://tc39.github.io/ecma262/#eqn-abs">https://tc39.github.io/ecma262/#eqn-abs</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eqn-abs">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise.all">
-   <a href="https://tc39.github.io/ecma262/#sec-promise.all">https://tc39.github.io/ecma262/#sec-promise.all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise.all" class="dfn-panel" data-for="term-for-sec-promise.all" id="infopanel-for-term-for-sec-promise.all" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise.all" style="display:none">Info about the 'all()' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promise.all">https://tc39.github.io/ecma262/#sec-promise.all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise.all">3.2.23.1. Creating and manipulating Promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-array-index">
-   <a href="https://tc39.github.io/ecma262/#array-index">https://tc39.github.io/ecma262/#array-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-array-index" class="dfn-panel" data-for="term-for-array-index" id="infopanel-for-term-for-array-index" role="menu">
+   <span id="infopaneltitle-for-term-for-array-index" style="display:none">Info about the 'array index' external reference.</span><a href="https://tc39.github.io/ecma262/#array-index">https://tc39.github.io/ecma262/#array-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-array-index">3.9. Legacy platform objects</a>
     <li><a href="#ref-for-array-index①">3.9.7. Abstract operations</a>
     <li><a href="#ref-for-array-index②">3.10. Observable array exotic objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-iterator-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">https://tc39.github.io/ecma262/#sec-array-iterator-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-iterator-objects" class="dfn-panel" data-for="term-for-sec-array-iterator-objects" id="infopanel-for-term-for-sec-array-iterator-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-iterator-objects" style="display:none">Info about the 'array iterator object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array-iterator-objects">https://tc39.github.io/ecma262/#sec-array-iterator-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-iterator-objects">2.5.8. Iterable declarations</a> <a href="#ref-for-sec-array-iterator-objects①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-bigint-type">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-bigint-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-bigint-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-bigint-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-bigint-type" id="infopanel-for-term-for-sec-ecmascript-language-types-bigint-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-bigint-type" style="display:none">Info about the 'bigint' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-bigint-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-bigint-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-bigint-type">3.2.9. bigint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-built-in-function-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-built-in-function-objects" class="dfn-panel" data-for="term-for-sec-built-in-function-objects" id="infopanel-for-term-for-sec-built-in-function-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-built-in-function-objects①" style="display:none">Info about the 'built-in function object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-built-in-function-objects">2. Interface definition language</a>
     <li><a href="#ref-for-sec-built-in-function-objects①">2.3. Interface mixins</a> <a href="#ref-for-sec-built-in-function-objects②">(2)</a> <a href="#ref-for-sec-built-in-function-objects③">(3)</a>
@@ -15269,8 +15269,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-built-in-function-objects②⑨">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iscallable">
-   <a href="https://tc39.github.io/ecma262/#sec-iscallable">https://tc39.github.io/ecma262/#sec-iscallable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iscallable" class="dfn-panel" data-for="term-for-sec-iscallable" id="infopanel-for-term-for-sec-iscallable①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iscallable①" style="display:none">Info about the 'callable' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-iscallable">https://tc39.github.io/ecma262/#sec-iscallable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iscallable">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-sec-iscallable①">3.2.19. Callback function types</a>
@@ -15283,8 +15283,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-iscallable①①">3.12. Invoking callback functions</a> <a href="#ref-for-sec-iscallable①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type①" style="display:none">Info about the 'completion record' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">3.11. Callback interfaces</a> <a href="#ref-for-sec-completion-record-specification-type①">(2)</a> <a href="#ref-for-sec-completion-record-specification-type②">(3)</a>
     <li><a href="#ref-for-sec-completion-record-specification-type③">3.12. Invoking callback functions</a> <a href="#ref-for-sec-completion-record-specification-type④">(2)</a> <a href="#ref-for-sec-completion-record-specification-type⑤">(3)</a>
@@ -15292,8 +15292,8 @@ language binding.</p>
     <li><a href="#ref-for-sec-completion-record-specification-type⑦">Document conventions</a> <a href="#ref-for-sec-completion-record-specification-type⑧">(2)</a> <a href="#ref-for-sec-completion-record-specification-type⑨">(3)</a> <a href="#ref-for-sec-completion-record-specification-type①⓪">(4)</a> <a href="#ref-for-sec-completion-record-specification-type①①">(5)</a> <a href="#ref-for-sec-completion-record-specification-type①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constructor">
-   <a href="https://tc39.github.io/ecma262/#constructor">https://tc39.github.io/ecma262/#constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructor" class="dfn-panel" data-for="term-for-constructor" id="infopanel-for-term-for-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-constructor" style="display:none">Info about the 'constructor' external reference.</span><a href="https://tc39.github.io/ecma262/#constructor">https://tc39.github.io/ecma262/#constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructor">2. Interface definition language</a>
     <li><a href="#ref-for-constructor①">2.5.4. Constructor operations</a>
@@ -15304,31 +15304,31 @@ language binding.</p>
     <li><a href="#ref-for-constructor⑦">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the 'conventions' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">3. ECMAScript binding</a>
     <li><a href="#ref-for-sec-algorithm-conventions①">3.2.4. Integer types</a>
     <li><a href="#ref-for-sec-algorithm-conventions②">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">3. ECMAScript binding</a>
     <li><a href="#ref-for-current-realm①">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-current-realm②">(2)</a> <a href="#ref-for-current-realm③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions①" style="display:none">Info about the 'ecma-262 algorithm conventions' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">3. ECMAScript binding</a>
     <li><a href="#ref-for-sec-algorithm-conventions①">3.2.4. Integer types</a>
     <li><a href="#ref-for-sec-algorithm-conventions②">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-built-in-function-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-built-in-function-objects" class="dfn-panel" data-for="term-for-sec-built-in-function-objects" id="infopanel-for-term-for-sec-built-in-function-objects②" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-built-in-function-objects②" style="display:none">Info about the 'ecma-262 built-in function objects' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-built-in-function-objects">https://tc39.github.io/ecma262/#sec-built-in-function-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-built-in-function-objects">2. Interface definition language</a>
     <li><a href="#ref-for-sec-built-in-function-objects①">2.3. Interface mixins</a> <a href="#ref-for-sec-built-in-function-objects②">(2)</a> <a href="#ref-for-sec-built-in-function-objects③">(3)</a>
@@ -15355,32 +15355,32 @@ language binding.</p>
     <li><a href="#ref-for-sec-built-in-function-objects②⑨">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-immutable-prototype-exotic-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-immutable-prototype-exotic-objects" class="dfn-panel" data-for="term-for-sec-immutable-prototype-exotic-objects" id="infopanel-for-term-for-sec-immutable-prototype-exotic-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-immutable-prototype-exotic-objects" style="display:none">Info about the 'ecma-262 immutable prototype exotic objects' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-immutable-prototype-exotic-objects">3.7.3. Interface prototype object</a> <a href="#ref-for-sec-immutable-prototype-exotic-objects①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" style="display:none">Info about the 'ecma-262 ordinary object internal methods and internal slots' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots">3. ECMAScript binding</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-string-type">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-string-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-string-type" id="infopanel-for-term-for-sec-ecmascript-language-types-string-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-string-type" style="display:none">Info about the 'element' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-string-type">3.2.11. ByteString</a> <a href="#ref-for-sec-ecmascript-language-types-string-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-property-attributes">
-   <a href="https://tc39.github.io/ecma262/#sec-property-attributes">https://tc39.github.io/ecma262/#sec-property-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-property-attributes" class="dfn-panel" data-for="term-for-sec-property-attributes" id="infopanel-for-term-for-sec-property-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-property-attributes" style="display:none">Info about the 'enumerable' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-property-attributes">https://tc39.github.io/ecma262/#sec-property-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-property-attributes">3.2.22. Records — record&lt;K, V></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type" id="infopanel-for-term-for-sec-ecmascript-language-types-number-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" style="display:none">Info about the 'equally close values' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type">3.2.4.7. long long</a>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type①">3.2.4.8. unsigned long long</a>
@@ -15389,21 +15389,21 @@ language binding.</p>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type④">3.2.6. unrestricted float</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-error-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-error-objects" class="dfn-panel" data-for="term-for-sec-error-objects" id="infopanel-for-term-for-sec-error-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-error-objects①" style="display:none">Info about the 'error objects' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-error-objects">2.8. Exceptions</a> <a href="#ref-for-sec-error-objects①">(2)</a>
     <li><a href="#ref-for-sec-error-objects②">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eqn-floor">
-   <a href="https://tc39.github.io/ecma262/#eqn-floor">https://tc39.github.io/ecma262/#eqn-floor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eqn-floor" class="dfn-panel" data-for="term-for-eqn-floor" id="infopanel-for-term-for-eqn-floor" role="menu">
+   <span id="infopaneltitle-for-term-for-eqn-floor" style="display:none">Info about the 'floor' external reference.</span><a href="https://tc39.github.io/ecma262/#eqn-floor">https://tc39.github.io/ecma262/#eqn-floor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eqn-floor">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-function-object">
-   <a href="https://tc39.github.io/ecma262/#function-object">https://tc39.github.io/ecma262/#function-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-function-object" class="dfn-panel" data-for="term-for-function-object" id="infopanel-for-term-for-function-object" role="menu">
+   <span id="infopaneltitle-for-term-for-function-object" style="display:none">Info about the 'function object' external reference.</span><a href="https://tc39.github.io/ecma262/#function-object">https://tc39.github.io/ecma262/#function-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-function-object">2.4. Callback interfaces</a>
     <li><a href="#ref-for-function-object①">2.5.6. Static attributes and operations</a>
@@ -15436,14 +15436,14 @@ language binding.</p>
     <li><a href="#ref-for-function-object④⑥">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-function-object④⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-immutable-prototype-exotic-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-immutable-prototype-exotic-objects" class="dfn-panel" data-for="term-for-sec-immutable-prototype-exotic-objects" id="infopanel-for-term-for-sec-immutable-prototype-exotic-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-immutable-prototype-exotic-objects①" style="display:none">Info about the 'immutable prototype exotic object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects">https://tc39.github.io/ecma262/#sec-immutable-prototype-exotic-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-immutable-prototype-exotic-objects">3.7.3. Interface prototype object</a> <a href="#ref-for-sec-immutable-prototype-exotic-objects①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal method' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">3.2.24. Union types</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots②">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots③">(4)</a>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots④">3.2.25. Buffer source types</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑤">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑥">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑦">(4)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑧">(5)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑨">(6)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①⓪">(7)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①①">(8)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①②">(9)</a>
@@ -15468,14 +15468,14 @@ language binding.</p>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots③⑧">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots①" style="display:none">Info about the 'internal method (for ordinary object)' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots">3. ECMAScript binding</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots①" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">3.2.24. Union types</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots②">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots③">(4)</a>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots④">3.2.25. Buffer source types</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑤">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑥">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑦">(4)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑧">(5)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑨">(6)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①⓪">(7)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①①">(8)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①②">(9)</a>
@@ -15500,33 +15500,33 @@ language binding.</p>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots③⑧">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots②" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots②" style="display:none">Info about the 'internal slot (for ordinary object)' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots">3. ECMAScript binding</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eqn-max">
-   <a href="https://tc39.github.io/ecma262/#eqn-max">https://tc39.github.io/ecma262/#eqn-max</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eqn-max" class="dfn-panel" data-for="term-for-eqn-max" id="infopanel-for-term-for-eqn-max" role="menu">
+   <span id="infopaneltitle-for-term-for-eqn-max" style="display:none">Info about the 'max' external reference.</span><a href="https://tc39.github.io/ecma262/#eqn-max">https://tc39.github.io/ecma262/#eqn-max</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eqn-max">2.5.7. Overloading</a>
     <li><a href="#ref-for-eqn-max①">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eqn-min">
-   <a href="https://tc39.github.io/ecma262/#eqn-min">https://tc39.github.io/ecma262/#eqn-min</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eqn-min" class="dfn-panel" data-for="term-for-eqn-min" id="infopanel-for-term-for-eqn-min" role="menu">
+   <span id="infopaneltitle-for-term-for-eqn-min" style="display:none">Info about the 'min' external reference.</span><a href="https://tc39.github.io/ecma262/#eqn-min">https://tc39.github.io/ecma262/#eqn-min</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eqn-min">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eqn-modulo">
-   <a href="https://tc39.github.io/ecma262/#eqn-modulo">https://tc39.github.io/ecma262/#eqn-modulo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eqn-modulo" class="dfn-panel" data-for="term-for-eqn-modulo" id="infopanel-for-term-for-eqn-modulo" role="menu">
+   <span id="infopaneltitle-for-term-for-eqn-modulo" style="display:none">Info about the 'modulo' external reference.</span><a href="https://tc39.github.io/ecma262/#eqn-modulo">https://tc39.github.io/ecma262/#eqn-modulo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eqn-modulo">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type" id="infopanel-for-term-for-sec-ecmascript-language-types-number-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type①" style="display:none">Info about the 'number type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type">3.2.4.7. long long</a>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type①">3.2.4.8. unsigned long long</a>
@@ -15535,40 +15535,40 @@ language binding.</p>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type④">3.2.6. unrestricted float</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-literals-numeric-literals">
-   <a href="https://tc39.github.io/ecma262/#sec-literals-numeric-literals">https://tc39.github.io/ecma262/#sec-literals-numeric-literals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-literals-numeric-literals" class="dfn-panel" data-for="term-for-sec-literals-numeric-literals" id="infopanel-for-term-for-sec-literals-numeric-literals" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-literals-numeric-literals" style="display:none">Info about the 'numericliteral' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-literals-numeric-literals">https://tc39.github.io/ecma262/#sec-literals-numeric-literals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-literals-numeric-literals">2.5.1. Constants</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-own-property">
-   <a href="https://tc39.github.io/ecma262/#sec-own-property">https://tc39.github.io/ecma262/#sec-own-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-own-property" class="dfn-panel" data-for="term-for-sec-own-property" id="infopanel-for-term-for-sec-own-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-own-property" style="display:none">Info about the 'own property' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-own-property">https://tc39.github.io/ecma262/#sec-own-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-own-property">3.2.22. Records — record&lt;K, V></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promisecapability-records">
-   <a href="https://tc39.github.io/ecma262/#sec-promisecapability-records">https://tc39.github.io/ecma262/#sec-promisecapability-records</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promisecapability-records" class="dfn-panel" data-for="term-for-sec-promisecapability-records" id="infopanel-for-term-for-sec-promisecapability-records" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promisecapability-records" style="display:none">Info about the 'promisecapability' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-promisecapability-records">https://tc39.github.io/ecma262/#sec-promisecapability-records</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promisecapability-records">3.2.23. Promise types — Promise&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-property-descriptor-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-property-descriptor-specification-type" class="dfn-panel" data-for="term-for-sec-property-descriptor-specification-type" id="infopanel-for-term-for-sec-property-descriptor-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-property-descriptor-specification-type" style="display:none">Info about the 'property descriptor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type">https://tc39.github.io/ecma262/#sec-property-descriptor-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-property-descriptor-specification-type">3.7.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-sec-property-descriptor-specification-type①">3.9.3. [[DefineOwnProperty]]</a>
     <li><a href="#ref-for-sec-property-descriptor-specification-type②">3.9.7. Abstract operations</a> <a href="#ref-for-sec-property-descriptor-specification-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-proxy-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-proxy-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-proxy-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-proxy-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-proxy-object-internal-methods-and-internal-slots" style="display:none">Info about the 'proxy exotic object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-proxy-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-proxy-object-internal-methods-and-internal-slots">3.10. Observable array exotic objects</a> <a href="#ref-for-sec-proxy-object-internal-methods-and-internal-slots①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">2. Interface definition language</a>
     <li><a href="#ref-for-realm①">3.1. ECMAScript environment</a> <a href="#ref-for-realm②">(2)</a> <a href="#ref-for-realm③">(3)</a> <a href="#ref-for-realm④">(4)</a> <a href="#ref-for-realm⑤">(5)</a> <a href="#ref-for-realm⑥">(6)</a> <a href="#ref-for-realm⑦">(7)</a>
@@ -15593,50 +15593,50 @@ language binding.</p>
     <li><a href="#ref-for-realm④⑦">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-realm④⑧">(2)</a> <a href="#ref-for-realm④⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasdrawpath">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasdrawpath" class="dfn-panel" data-for="term-for-canvasdrawpath" id="infopanel-for-term-for-canvasdrawpath" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasdrawpath" style="display:none">Info about the 'CanvasDrawPath' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasdrawpath">2.5.7.1. Overloading vs. union types</a> <a href="#ref-for-canvasdrawpath①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlallcollection">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlallcollection">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlallcollection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlallcollection" class="dfn-panel" data-for="term-for-htmlallcollection" id="infopanel-for-term-for-htmlallcollection" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlallcollection" style="display:none">Info about the 'HTMLAllCollection' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlallcollection">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#htmlallcollection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlallcollection">3. ECMAScript binding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">3. ECMAScript binding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-path2d">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#path2d">https://html.spec.whatwg.org/multipage/canvas.html#path2d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-path2d" class="dfn-panel" data-for="term-for-path2d" id="infopanel-for-term-for-path2d" role="menu">
+   <span id="infopaneltitle-for-term-for-path2d" style="display:none">Info about the 'Path2D' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#path2d">https://html.spec.whatwg.org/multipage/canvas.html#path2d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path2d">2.5.7.1. Overloading vs. union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serializable">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serializable" class="dfn-panel" data-for="term-for-serializable" id="infopanel-for-term-for-serializable" role="menu">
+   <span id="infopaneltitle-for-term-for-serializable" style="display:none">Info about the 'Serializable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializable">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2. Interface definition language</a>
     <li><a href="#ref-for-window①">3.3.6. [Exposed]</a>
@@ -15646,124 +15646,124 @@ language binding.</p>
     <li><a href="#ref-for-window⑦">3.8.1. [[SetPrototypeOf]]</a> <a href="#ref-for-window⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">2.3.1. Using mixins and partials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windowproxy">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windowproxy" class="dfn-panel" data-for="term-for-windowproxy" id="infopanel-for-term-for-windowproxy" role="menu">
+   <span id="infopaneltitle-for-term-for-windowproxy" style="display:none">Info about the 'WindowProxy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowproxy">3.8.1. [[SetPrototypeOf]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet" class="dfn-panel" data-for="term-for-worklet" id="infopanel-for-term-for-worklet" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet" style="display:none">Info about the 'Worklet' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet">3.3.6. [Exposed]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clean-up-after-running-a-callback">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clean-up-after-running-a-callback" class="dfn-panel" data-for="term-for-clean-up-after-running-a-callback" id="infopanel-for-term-for-clean-up-after-running-a-callback" role="menu">
+   <span id="infopaneltitle-for-term-for-clean-up-after-running-a-callback" style="display:none">Info about the 'clean up after running a callback' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-a-callback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clean-up-after-running-a-callback">3.11. Callback interfaces</a>
     <li><a href="#ref-for-clean-up-after-running-a-callback①">3.12. Invoking callback functions</a> <a href="#ref-for-clean-up-after-running-a-callback②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clean-up-after-running-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clean-up-after-running-script" class="dfn-panel" data-for="term-for-clean-up-after-running-script" id="infopanel-for-term-for-clean-up-after-running-script" role="menu">
+   <span id="infopaneltitle-for-term-for-clean-up-after-running-script" style="display:none">Info about the 'clean up after running script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script">https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clean-up-after-running-script">3.11. Callback interfaces</a>
     <li><a href="#ref-for-clean-up-after-running-script①">3.12. Invoking callback functions</a> <a href="#ref-for-clean-up-after-running-script②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-cross-origin-isolated-capability">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-cross-origin-isolated-capability" class="dfn-panel" data-for="term-for-concept-settings-object-cross-origin-isolated-capability" id="infopanel-for-term-for-concept-settings-object-cross-origin-isolated-capability" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-cross-origin-isolated-capability" style="display:none">Info about the 'cross-origin isolated capability' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-cross-origin-isolated-capability">3.3.3. [CrossOriginIsolated]</a>
     <li><a href="#ref-for-concept-settings-object-cross-origin-isolated-capability①">3.3.6. [Exposed]</a> <a href="#ref-for-concept-settings-object-cross-origin-isolated-capability②">(2)</a>
     <li><a href="#ref-for-concept-settings-object-cross-origin-isolated-capability③">3.3.12. [SecureContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deserialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deserialization-steps" class="dfn-panel" data-for="term-for-deserialization-steps" id="infopanel-for-term-for-deserialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-deserialization-steps" style="display:none">Info about the 'deserialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deserialization-steps">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.2.23.2. Examples</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a> <a href="#ref-for-in-parallel③">(4)</a> <a href="#ref-for-in-parallel④">(5)</a> <a href="#ref-for-in-parallel⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-to-run-a-callback">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prepare-to-run-a-callback" class="dfn-panel" data-for="term-for-prepare-to-run-a-callback" id="infopanel-for-term-for-prepare-to-run-a-callback" role="menu">
+   <span id="infopaneltitle-for-term-for-prepare-to-run-a-callback" style="display:none">Info about the 'prepare to run a callback' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-a-callback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prepare-to-run-a-callback">3.11. Callback interfaces</a>
     <li><a href="#ref-for-prepare-to-run-a-callback①">3.12. Invoking callback functions</a> <a href="#ref-for-prepare-to-run-a-callback②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prepare-to-run-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prepare-to-run-script" class="dfn-panel" data-for="term-for-prepare-to-run-script" id="infopanel-for-term-for-prepare-to-run-script" role="menu">
+   <span id="infopaneltitle-for-term-for-prepare-to-run-script" style="display:none">Info about the 'prepare to run script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script">https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prepare-to-run-script">3.11. Callback interfaces</a>
     <li><a href="#ref-for-prepare-to-run-script①">3.12. Invoking callback functions</a> <a href="#ref-for-prepare-to-run-script②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">3.2.23.1. Creating and manipulating Promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.2.23.2. Examples</a> <a href="#ref-for-queue-a-task①">(2)</a> <a href="#ref-for-queue-a-task②">(3)</a> <a href="#ref-for-queue-a-task③">(4)</a> <a href="#ref-for-queue-a-task④">(5)</a> <a href="#ref-for-queue-a-task⑤">(6)</a> <a href="#ref-for-queue-a-task⑥">(7)</a> <a href="#ref-for-queue-a-task⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-concept-relevant-realm①">3.2.23.2. Examples</a> <a href="#ref-for-concept-relevant-realm②">(2)</a> <a href="#ref-for-concept-relevant-realm③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.3.6. [Exposed]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">3.3.6. [Exposed]</a> <a href="#ref-for-secure-context①">(2)</a>
     <li><a href="#ref-for-secure-context②">3.3.12. [SecureContext]</a> <a href="#ref-for-secure-context③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialization-steps" class="dfn-panel" data-for="term-for-serialization-steps" id="infopanel-for-term-for-serialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-serialization-steps" style="display:none">Info about the 'serialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialization-steps">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-context-2d-stroke">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroke">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroke</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-context-2d-stroke" class="dfn-panel" data-for="term-for-dom-context-2d-stroke" id="infopanel-for-term-for-dom-context-2d-stroke" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-context-2d-stroke" style="display:none">Info about the 'stroke()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroke">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-stroke</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-context-2d-stroke">2.5.7.1. Overloading vs. union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">3.2.23.2. Examples</a> <a href="#ref-for-task-source①">(2)</a> <a href="#ref-for-task-source②">(3)</a> <a href="#ref-for-task-source③">(4)</a> <a href="#ref-for-task-source④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.2. Interfaces</a>
     <li><a href="#ref-for-list-append①">2.5.7. Overloading</a> <a href="#ref-for-list-append②">(2)</a> <a href="#ref-for-list-append③">(3)</a> <a href="#ref-for-list-append④">(4)</a> <a href="#ref-for-list-append⑤">(5)</a> <a href="#ref-for-list-append⑥">(6)</a> <a href="#ref-for-list-append⑦">(7)</a> <a href="#ref-for-list-append⑧">(8)</a>
@@ -15775,67 +15775,67 @@ language binding.</p>
     <li><a href="#ref-for-list-append①⑥">3.11. Callback interfaces</a> <a href="#ref-for-list-append①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.5.7. Overloading</a> <a href="#ref-for-set-append①">(2)</a> <a href="#ref-for-set-append②">(3)</a>
     <li><a href="#ref-for-set-append③">2.13.32. Annotated types</a> <a href="#ref-for-set-append④">(2)</a> <a href="#ref-for-set-append⑤">(3)</a> <a href="#ref-for-set-append⑥">(4)</a> <a href="#ref-for-set-append⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">2.5.7. Overloading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenation' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">2.2. Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3.7.5. Constants</a>
     <li><a href="#ref-for-iteration-continue①">3.7.6. Attributes</a>
     <li><a href="#ref-for-iteration-continue②">3.7.7. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">3.2.12. USVString</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">2.7. Dictionaries</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a> <a href="#ref-for-map-entry③">(4)</a> <a href="#ref-for-map-entry④">(5)</a> <a href="#ref-for-map-entry⑤">(6)</a>
     <li><a href="#ref-for-map-entry⑥">2.13.29. Record types — record&lt;K, V></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">2.7. Dictionaries</a>
     <li><a href="#ref-for-map-exists①">3.2.17. Dictionary types</a> <a href="#ref-for-map-exists②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-extend">
-   <a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-extend" class="dfn-panel" data-for="term-for-list-extend" id="infopanel-for-term-for-list-extend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-extend" style="display:none">Info about the 'extend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-extend">3.10.6. ownKeys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-list-iterate①">2.5.7. Overloading</a> <a href="#ref-for-list-iterate②">(2)</a> <a href="#ref-for-list-iterate③">(3)</a> <a href="#ref-for-list-iterate④">(4)</a> <a href="#ref-for-list-iterate⑤">(5)</a> <a href="#ref-for-list-iterate⑥">(6)</a>
@@ -15850,50 +15850,50 @@ language binding.</p>
     <li><a href="#ref-for-list-iterate①⑤">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-list-iterate①⑥">(2)</a> <a href="#ref-for-list-iterate①⑦">(3)</a> <a href="#ref-for-list-iterate①⑧">(4)</a> <a href="#ref-for-list-iterate①⑨">(5)</a> <a href="#ref-for-list-iterate②⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3.2.22. Records — record&lt;K, V></a>
     <li><a href="#ref-for-map-iterate①">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-intersection">
-   <a href="https://infra.spec.whatwg.org/#set-intersection">https://infra.spec.whatwg.org/#set-intersection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-intersection" class="dfn-panel" data-for="term-for-set-intersection" id="infopanel-for-term-for-set-intersection" role="menu">
+   <span id="infopaneltitle-for-term-for-set-intersection" style="display:none">Info about the 'intersection' external reference.</span><a href="https://infra.spec.whatwg.org/#set-intersection">https://infra.spec.whatwg.org/#set-intersection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-intersection">3.3.6. [Exposed]</a> <a href="#ref-for-set-intersection①">(2)</a> <a href="#ref-for-set-intersection②">(3)</a> <a href="#ref-for-set-intersection③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.5.7. Overloading</a>
     <li><a href="#ref-for-list-is-empty①">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty①" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.5.7. Overloading</a>
     <li><a href="#ref-for-list-is-empty①">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.5.7. Overloading</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a> <a href="#ref-for-list-item③">(4)</a> <a href="#ref-for-list-item④">(5)</a>
     <li><a href="#ref-for-list-item⑤">2.13.28. Sequence types — sequence&lt;T></a>
     <li><a href="#ref-for-list-item⑥">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item (for struct)' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">2.5.7. Overloading</a>
     <li><a href="#ref-for-struct-item①">2.5.8. Iterable declarations</a> <a href="#ref-for-struct-item②">(2)</a> <a href="#ref-for-struct-item③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate①" style="display:none">Info about the 'iterate' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-list-iterate①">2.5.7. Overloading</a> <a href="#ref-for-list-iterate②">(2)</a> <a href="#ref-for-list-iterate③">(3)</a> <a href="#ref-for-list-iterate④">(4)</a> <a href="#ref-for-list-iterate⑤">(5)</a> <a href="#ref-for-list-iterate⑥">(6)</a>
@@ -15908,15 +15908,15 @@ language binding.</p>
     <li><a href="#ref-for-list-iterate①⑤">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-list-iterate①⑥">(2)</a> <a href="#ref-for-list-iterate①⑦">(3)</a> <a href="#ref-for-list-iterate①⑧">(4)</a> <a href="#ref-for-list-iterate①⑨">(5)</a> <a href="#ref-for-list-iterate②⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">2.7. Dictionaries</a> <a href="#ref-for-map-getting-the-keys①">(2)</a>
     <li><a href="#ref-for-map-getting-the-keys②">2.13.29. Record types — record&lt;K, V></a> <a href="#ref-for-map-getting-the-keys③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.2. Interfaces</a>
     <li><a href="#ref-for-list①">2.5.7. Overloading</a> <a href="#ref-for-list②">(2)</a> <a href="#ref-for-list③">(3)</a>
@@ -15935,8 +15935,8 @@ language binding.</p>
     <li><a href="#ref-for-list③④">3.11. Callback interfaces</a> <a href="#ref-for-list③⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-ordered-map①">2.7. Dictionaries</a> <a href="#ref-for-ordered-map②">(2)</a>
@@ -15946,14 +15946,14 @@ language binding.</p>
     <li><a href="#ref-for-ordered-map⑧">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-ordered-map⑨">(2)</a> <a href="#ref-for-ordered-map①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-name">
-   <a href="https://infra.spec.whatwg.org/#struct-name">https://infra.spec.whatwg.org/#struct-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-name" class="dfn-panel" data-for="term-for-struct-name" id="infopanel-for-term-for-struct-name" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-name" style="display:none">Info about the 'name' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-name">https://infra.spec.whatwg.org/#struct-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-name">2.5.8. Iterable declarations</a> <a href="#ref-for-struct-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-ordered-map①">2.7. Dictionaries</a> <a href="#ref-for-ordered-map②">(2)</a>
@@ -15963,27 +15963,27 @@ language binding.</p>
     <li><a href="#ref-for-ordered-map⑧">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-ordered-map⑨">(2)</a> <a href="#ref-for-ordered-map①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.5.7. Overloading</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">2.13.32. Annotated types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-pop">
-   <a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-pop" class="dfn-panel" data-for="term-for-stack-pop" id="infopanel-for-term-for-stack-pop" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-pop" style="display:none">Info about the 'pop' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-pop">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-push">
-   <a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-push" class="dfn-panel" data-for="term-for-stack-push" id="infopanel-for-term-for-stack-push" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-push" style="display:none">Info about the 'push' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-push">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-stack-push①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">3.7.6. Attributes</a>
     <li><a href="#ref-for-list-remove①">3.7.7. Operations</a>
@@ -15991,16 +15991,16 @@ language binding.</p>
     <li><a href="#ref-for-list-remove③">3.10.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.2.17. Dictionary types</a> <a href="#ref-for-map-set①">(2)</a>
     <li><a href="#ref-for-map-set②">3.2.22. Records — record&lt;K, V></a>
     <li><a href="#ref-for-map-set③">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">2.5.7. Overloading</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a>
     <li><a href="#ref-for-list-size③">3.2.23.1. Creating and manipulating Promises</a>
@@ -16020,46 +16020,46 @@ language binding.</p>
     <li><a href="#ref-for-list-size①⑧">3.11. Callback interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack">
-   <a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack" class="dfn-panel" data-for="term-for-stack" id="infopanel-for-term-for-stack" role="menu">
+   <span id="infopaneltitle-for-term-for-stack" style="display:none">Info about the 'stack' external reference.</span><a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-stack①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">2.5.8. Iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-range">
-   <a href="https://infra.spec.whatwg.org/#the-range">https://infra.spec.whatwg.org/#the-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-range" class="dfn-panel" data-for="term-for-the-range" id="infopanel-for-term-for-the-range" role="menu">
+   <span id="infopaneltitle-for-term-for-the-range" style="display:none">Info about the 'the range' external reference.</span><a href="https://infra.spec.whatwg.org/#the-range">https://infra.spec.whatwg.org/#the-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-range">2.5.7. Overloading</a> <a href="#ref-for-the-range①">(2)</a> <a href="#ref-for-the-range②">(3)</a> <a href="#ref-for-the-range③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">2.5.7. Overloading</a> <a href="#ref-for-tuple①">(2)</a> <a href="#ref-for-tuple②">(3)</a> <a href="#ref-for-tuple③">(4)</a> <a href="#ref-for-tuple④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-map-getting-the-values①">2.7. Dictionaries</a>
     <li><a href="#ref-for-map-getting-the-values②">2.13.29. Record types — record&lt;K, V></a> <a href="#ref-for-map-getting-the-values③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-while">
-   <a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-while" class="dfn-panel" data-for="term-for-iteration-while" id="infopanel-for-term-for-iteration-while" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-while" style="display:none">Info about the 'while' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">2.5.7. Overloading</a>
     <li><a href="#ref-for-iteration-while①">3.7.7.1.1. Default toJSON operation</a>
@@ -16067,8 +16067,8 @@ language binding.</p>
     <li><a href="#ref-for-iteration-while③">3.10.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unicode_scalar_value">
-   <a href="http://www.unicode.org/glossary/#unicode_scalar_value">http://www.unicode.org/glossary/#unicode_scalar_value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unicode_scalar_value" class="dfn-panel" data-for="term-for-unicode_scalar_value" id="infopanel-for-term-for-unicode_scalar_value" role="menu">
+   <span id="infopaneltitle-for-term-for-unicode_scalar_value" style="display:none">Info about the 'unicode scalar value' external reference.</span><a href="http://www.unicode.org/glossary/#unicode_scalar_value">http://www.unicode.org/glossary/#unicode_scalar_value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicode_scalar_value">2.5.3. Operations</a>
     <li><a href="#ref-for-unicode_scalar_value①">2.13.17. DOMString</a>
@@ -16076,8 +16076,8 @@ language binding.</p>
     <li><a href="#ref-for-unicode_scalar_value③">3.2.12. USVString</a> <a href="#ref-for-unicode_scalar_value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any①⑥">4.5. Function</a> <a href="#ref-for-idl-any①⑦">(2)</a>
    </ul>
@@ -16391,8 +16391,8 @@ language binding.</p>
 <c- b>callback</c-> <a class="idl-code" data-link-type="callback" href="#Function"><c- g>Function</c-></a> = <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a> (<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-any"><c- b>any</c-></a>... <a href="#dom-function-arguments"><code><c- g>arguments</c-></code></a>);
 <c- b>callback</c-> <a class="idl-code" data-link-type="callback" href="#VoidFunction"><c- g>VoidFunction</c-></a> = <a class="idl-code" data-link-type="interface" href="#idl-undefined"><c- b>undefined</c-></a> ();
 </pre>
-  <aside class="dfn-panel" data-for="dfn-idl-fragment">
-   <b><a href="#dfn-idl-fragment">#dfn-idl-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-idl-fragment" class="dfn-panel" data-for="dfn-idl-fragment" id="infopanel-for-dfn-idl-fragment" role="dialog">
+   <span id="infopaneltitle-for-dfn-idl-fragment" style="display:none">Info about the 'IDL fragments' definition.</span><b><a href="#dfn-idl-fragment">#dfn-idl-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-idl-fragment">2. Interface definition language</a> <a href="#ref-for-dfn-idl-fragment①">(2)</a> <a href="#ref-for-dfn-idl-fragment②">(3)</a> <a href="#ref-for-dfn-idl-fragment③">(4)</a>
     <li><a href="#ref-for-dfn-idl-fragment④">2.1. Names</a> <a href="#ref-for-dfn-idl-fragment⑤">(2)</a> <a href="#ref-for-dfn-idl-fragment⑥">(3)</a> <a href="#ref-for-dfn-idl-fragment⑦">(4)</a> <a href="#ref-for-dfn-idl-fragment⑧">(5)</a>
@@ -16435,8 +16435,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-idl-fragment⑤③">Conformance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-definition">
-   <b><a href="#dfn-definition">#dfn-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-definition" class="dfn-panel" data-for="dfn-definition" id="infopanel-for-dfn-definition" role="dialog">
+   <span id="infopaneltitle-for-dfn-definition" style="display:none">Info about the 'definitions' definition.</span><b><a href="#dfn-definition">#dfn-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-definition">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-definition①">2.1. Names</a>
@@ -16446,14 +16446,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-definition⑦">2.14. Extended attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-definition">
-   <b><a href="#dfn-named-definition">#dfn-named-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-definition" class="dfn-panel" data-for="dfn-named-definition" id="infopanel-for-dfn-named-definition" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-definition" style="display:none">Info about the 'named definitions' definition.</span><b><a href="#dfn-named-definition">#dfn-named-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-definition">2.1. Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-identifier">
-   <b><a href="#dfn-identifier">#dfn-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-identifier" class="dfn-panel" data-for="dfn-identifier" id="infopanel-for-dfn-identifier" role="dialog">
+   <span id="infopaneltitle-for-dfn-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#dfn-identifier">#dfn-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">2.1. Names</a> <a href="#ref-for-dfn-identifier①">(2)</a> <a href="#ref-for-dfn-identifier②">(3)</a> <a href="#ref-for-dfn-identifier③">(4)</a> <a href="#ref-for-dfn-identifier④">(5)</a> <a href="#ref-for-dfn-identifier⑤">(6)</a> <a href="#ref-for-dfn-identifier⑥">(7)</a> <a href="#ref-for-dfn-identifier⑦">(8)</a>
     <li><a href="#ref-for-dfn-identifier⑧">2.2. Interfaces</a> <a href="#ref-for-dfn-identifier⑨">(2)</a> <a href="#ref-for-dfn-identifier①⓪">(3)</a>
@@ -16508,16 +16508,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-identifier①⓪⑦">IDL grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-reserved-identifier">
-   <b><a href="#dfn-reserved-identifier">#dfn-reserved-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-reserved-identifier" class="dfn-panel" data-for="dfn-reserved-identifier" id="infopanel-for-dfn-reserved-identifier" role="dialog">
+   <span id="infopaneltitle-for-dfn-reserved-identifier" style="display:none">Info about the 'reserved identifiers' definition.</span><b><a href="#dfn-reserved-identifier">#dfn-reserved-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-reserved-identifier">2.1. Names</a>
     <li><a href="#ref-for-dfn-reserved-identifier①">3.4.1. [LegacyFactoryFunction]</a>
     <li><a href="#ref-for-dfn-reserved-identifier②">3.4.11. [LegacyWindowAlias]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-interface">
-   <b><a href="#dfn-interface">#dfn-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-interface" class="dfn-panel" data-for="dfn-interface" id="infopanel-for-dfn-interface" role="dialog">
+   <span id="infopaneltitle-for-dfn-interface" style="display:none">Info about the 'interface' definition.</span><b><a href="#dfn-interface">#dfn-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface">2. Interface definition language</a> <a href="#ref-for-dfn-interface①">(2)</a> <a href="#ref-for-dfn-interface②">(3)</a>
     <li><a href="#ref-for-dfn-interface③">2.1. Names</a> <a href="#ref-for-dfn-interface④">(2)</a> <a href="#ref-for-dfn-interface⑤">(3)</a> <a href="#ref-for-dfn-interface⑥">(4)</a>
@@ -16596,8 +16596,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface②④⑥">IDL grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-interface-member">
-   <b><a href="#dfn-interface-member">#dfn-interface-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-interface-member" class="dfn-panel" data-for="dfn-interface-member" id="infopanel-for-dfn-interface-member" role="dialog">
+   <span id="infopaneltitle-for-dfn-interface-member" style="display:none">Info about the 'interface members' definition.</span><b><a href="#dfn-interface-member">#dfn-interface-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-member">2.1. Names</a>
     <li><a href="#ref-for-dfn-interface-member①">2.5.1. Constants</a>
@@ -16616,8 +16616,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-member②⑨">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inherit">
-   <b><a href="#dfn-inherit">#dfn-inherit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inherit" class="dfn-panel" data-for="dfn-inherit" id="infopanel-for-dfn-inherit" role="dialog">
+   <span id="infopaneltitle-for-dfn-inherit" style="display:none">Info about the 'inherit' definition.</span><b><a href="#dfn-inherit">#dfn-inherit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherit">2.2. Interfaces</a> <a href="#ref-for-dfn-inherit①">(2)</a> <a href="#ref-for-dfn-inherit②">(3)</a> <a href="#ref-for-dfn-inherit③">(4)</a>
     <li><a href="#ref-for-dfn-inherit④">2.5. Members</a>
@@ -16630,8 +16630,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-inherit①②">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inherited-interfaces">
-   <b><a href="#dfn-inherited-interfaces">#dfn-inherited-interfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inherited-interfaces" class="dfn-panel" data-for="dfn-inherited-interfaces" id="infopanel-for-dfn-inherited-interfaces" role="dialog">
+   <span id="infopaneltitle-for-dfn-inherited-interfaces" style="display:none">Info about the 'inherited interfaces' definition.</span><b><a href="#dfn-inherited-interfaces">#dfn-inherited-interfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-interfaces">2.2. Interfaces</a> <a href="#ref-for-dfn-inherited-interfaces①">(2)</a>
     <li><a href="#ref-for-dfn-inherited-interfaces②">2.5.3.1. toJSON</a>
@@ -16645,14 +16645,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-inherited-interfaces②①">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-dfn-inherited-interfaces②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface-inclusive-inherited-interfaces">
-   <b><a href="#interface-inclusive-inherited-interfaces">#interface-inclusive-inherited-interfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface-inclusive-inherited-interfaces" class="dfn-panel" data-for="interface-inclusive-inherited-interfaces" id="infopanel-for-interface-inclusive-inherited-interfaces" role="dialog">
+   <span id="infopaneltitle-for-interface-inclusive-inherited-interfaces" style="display:none">Info about the 'inclusive inherited interfaces' definition.</span><b><a href="#interface-inclusive-inherited-interfaces">#interface-inclusive-inherited-interfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-inclusive-inherited-interfaces">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-interface-inclusive-inherited-interfaces①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-partial-interface">
-   <b><a href="#dfn-partial-interface">#dfn-partial-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-partial-interface" class="dfn-panel" data-for="dfn-partial-interface" id="infopanel-for-dfn-partial-interface" role="dialog">
+   <span id="infopaneltitle-for-dfn-partial-interface" style="display:none">Info about the 'partial interface' definition.</span><b><a href="#dfn-partial-interface">#dfn-partial-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-interface">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-partial-interface①">2.1. Names</a>
@@ -16667,14 +16667,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-partial-interface②②">3.4.7. [LegacyOverrideBuiltIns]</a> <a href="#ref-for-dfn-partial-interface②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="qualified-name">
-   <b><a href="#qualified-name">#qualified-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-qualified-name" class="dfn-panel" data-for="qualified-name" id="infopanel-for-qualified-name" role="dialog">
+   <span id="infopaneltitle-for-qualified-name" style="display:none">Info about the 'qualified name' definition.</span><b><a href="#qualified-name">#qualified-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-qualified-name">3.7.3. Interface prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface-mixin">
-   <b><a href="#interface-mixin">#interface-mixin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface-mixin" class="dfn-panel" data-for="interface-mixin" id="infopanel-for-interface-mixin" role="dialog">
+   <span id="infopaneltitle-for-interface-mixin" style="display:none">Info about the 'interface mixin' definition.</span><b><a href="#interface-mixin">#interface-mixin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-mixin">2. Interface definition language</a>
     <li><a href="#ref-for-interface-mixin①">2.2. Interfaces</a>
@@ -16689,8 +16689,8 @@ language binding.</p>
     <li><a href="#ref-for-interface-mixin⑤①">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-interface-mixin⑤②">(2)</a> <a href="#ref-for-interface-mixin⑤③">(3)</a> <a href="#ref-for-interface-mixin⑤④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface-mixin-member">
-   <b><a href="#interface-mixin-member">#interface-mixin-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface-mixin-member" class="dfn-panel" data-for="interface-mixin-member" id="infopanel-for-interface-mixin-member" role="dialog">
+   <span id="infopaneltitle-for-interface-mixin-member" style="display:none">Info about the 'interface mixin members' definition.</span><b><a href="#interface-mixin-member">#interface-mixin-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-mixin-member">2.2. Interfaces</a>
     <li><a href="#ref-for-interface-mixin-member①">2.3. Interface mixins</a> <a href="#ref-for-interface-mixin-member②">(2)</a> <a href="#ref-for-interface-mixin-member③">(3)</a> <a href="#ref-for-interface-mixin-member④">(4)</a> <a href="#ref-for-interface-mixin-member⑤">(5)</a> <a href="#ref-for-interface-mixin-member⑥">(6)</a> <a href="#ref-for-interface-mixin-member⑦">(7)</a>
@@ -16700,8 +16700,8 @@ language binding.</p>
     <li><a href="#ref-for-interface-mixin-member②⑤">3.3.12. [SecureContext]</a> <a href="#ref-for-interface-mixin-member②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partial-interface-mixin">
-   <b><a href="#partial-interface-mixin">#partial-interface-mixin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partial-interface-mixin" class="dfn-panel" data-for="partial-interface-mixin" id="infopanel-for-partial-interface-mixin" role="dialog">
+   <span id="infopaneltitle-for-partial-interface-mixin" style="display:none">Info about the 'partial interface mixin' definition.</span><b><a href="#partial-interface-mixin">#partial-interface-mixin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partial-interface-mixin">2. Interface definition language</a>
     <li><a href="#ref-for-partial-interface-mixin①">2.3. Interface mixins</a> <a href="#ref-for-partial-interface-mixin②">(2)</a> <a href="#ref-for-partial-interface-mixin③">(3)</a>
@@ -16712,16 +16712,16 @@ language binding.</p>
     <li><a href="#ref-for-partial-interface-mixin①⑧">3.3.12. [SecureContext]</a> <a href="#ref-for-partial-interface-mixin①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="includes-statement">
-   <b><a href="#includes-statement">#includes-statement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-includes-statement" class="dfn-panel" data-for="includes-statement" id="infopanel-for-includes-statement" role="dialog">
+   <span id="infopaneltitle-for-includes-statement" style="display:none">Info about the 'includes statement' definition.</span><b><a href="#includes-statement">#includes-statement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-includes-statement">2. Interface definition language</a>
     <li><a href="#ref-for-includes-statement①">2.2. Interfaces</a>
     <li><a href="#ref-for-includes-statement②">2.3. Interface mixins</a> <a href="#ref-for-includes-statement③">(2)</a> <a href="#ref-for-includes-statement④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="include">
-   <b><a href="#include">#include</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-include" class="dfn-panel" data-for="include" id="infopanel-for-include" role="dialog">
+   <span id="infopaneltitle-for-include" style="display:none">Info about the 'include' definition.</span><b><a href="#include">#include</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include">2.2. Interfaces</a>
     <li><a href="#ref-for-include①">2.3. Interface mixins</a> <a href="#ref-for-include②">(2)</a> <a href="#ref-for-include③">(3)</a> <a href="#ref-for-include④">(4)</a> <a href="#ref-for-include⑤">(5)</a> <a href="#ref-for-include⑥">(6)</a> <a href="#ref-for-include⑦">(7)</a>
@@ -16731,15 +16731,15 @@ language binding.</p>
     <li><a href="#ref-for-include①③">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-include①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-interfaces">
-   <b><a href="#host-interfaces">#host-interfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-interfaces" class="dfn-panel" data-for="host-interfaces" id="infopanel-for-host-interfaces" role="dialog">
+   <span id="infopaneltitle-for-host-interfaces" style="display:none">Info about the 'host interfaces' definition.</span><b><a href="#host-interfaces">#host-interfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-interfaces">2.3. Interface mixins</a>
     <li><a href="#ref-for-host-interfaces①">3.3.6. [Exposed]</a> <a href="#ref-for-host-interfaces②">(2)</a> <a href="#ref-for-host-interfaces③">(3)</a> <a href="#ref-for-host-interfaces④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-callback-interface">
-   <b><a href="#dfn-callback-interface">#dfn-callback-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-callback-interface" class="dfn-panel" data-for="dfn-callback-interface" id="infopanel-for-dfn-callback-interface" role="dialog">
+   <span id="infopaneltitle-for-dfn-callback-interface" style="display:none">Info about the 'callback interface' definition.</span><b><a href="#dfn-callback-interface">#dfn-callback-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-interface">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-callback-interface①">2.1. Names</a> <a href="#ref-for-dfn-callback-interface②">(2)</a> <a href="#ref-for-dfn-callback-interface③">(3)</a>
@@ -16764,16 +16764,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-interface④⑥">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callback-interface-member">
-   <b><a href="#callback-interface-member">#callback-interface-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callback-interface-member" class="dfn-panel" data-for="callback-interface-member" id="infopanel-for-callback-interface-member" role="dialog">
+   <span id="infopaneltitle-for-callback-interface-member" style="display:none">Info about the 'callback interface members' definition.</span><b><a href="#callback-interface-member">#callback-interface-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callback-interface-member">2.5.1. Constants</a>
     <li><a href="#ref-for-callback-interface-member①">2.5.3. Operations</a> <a href="#ref-for-callback-interface-member②">(2)</a>
     <li><a href="#ref-for-callback-interface-member③">2.14. Extended attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-member">
-   <b><a href="#dfn-member">#dfn-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-member" class="dfn-panel" data-for="dfn-member" id="infopanel-for-dfn-member" role="dialog">
+   <span id="infopaneltitle-for-dfn-member" style="display:none">Info about the 'members' definition.</span><b><a href="#dfn-member">#dfn-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-member">2.2. Interfaces</a>
     <li><a href="#ref-for-dfn-member①">2.3. Interface mixins</a> <a href="#ref-for-dfn-member②">(2)</a> <a href="#ref-for-dfn-member③">(3)</a> <a href="#ref-for-dfn-member④">(4)</a> <a href="#ref-for-dfn-member⑤">(5)</a>
@@ -16798,8 +16798,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-member③⑧">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="this">
-   <b><a href="#this">#this</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-this" class="dfn-panel" data-for="this" id="infopanel-for-this" role="dialog">
+   <span id="infopaneltitle-for-this" style="display:none">Info about the 'this' definition.</span><b><a href="#this">#this</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-this①">2.5.4. Constructor operations</a> <a href="#ref-for-this②">(2)</a>
@@ -16816,14 +16816,14 @@ language binding.</p>
     <li><a href="#ref-for-this②⑦">4.3. DOMException</a> <a href="#ref-for-this②⑧">(2)</a> <a href="#ref-for-this②⑨">(3)</a> <a href="#ref-for-this③⓪">(4)</a> <a href="#ref-for-this③①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-given-value">
-   <b><a href="#the-given-value">#the-given-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-given-value" class="dfn-panel" data-for="the-given-value" id="infopanel-for-the-given-value" role="dialog">
+   <span id="infopaneltitle-for-the-given-value" style="display:none">Info about the 'the given value' definition.</span><b><a href="#the-given-value">#the-given-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-given-value">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-constant">
-   <b><a href="#dfn-constant">#dfn-constant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-constant" class="dfn-panel" data-for="dfn-constant" id="infopanel-for-dfn-constant" role="dialog">
+   <span id="infopaneltitle-for-dfn-constant" style="display:none">Info about the 'constant' definition.</span><b><a href="#dfn-constant">#dfn-constant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-constant">2.1. Names</a> <a href="#ref-for-dfn-constant①">(2)</a>
     <li><a href="#ref-for-dfn-constant②">2.3. Interface mixins</a> <a href="#ref-for-dfn-constant③">(2)</a>
@@ -16846,8 +16846,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-constant③③">3.11.1. Legacy callback interface object</a> <a href="#ref-for-dfn-constant③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-attribute">
-   <b><a href="#dfn-attribute">#dfn-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-attribute" class="dfn-panel" data-for="dfn-attribute" id="infopanel-for-dfn-attribute" role="dialog">
+   <span id="infopaneltitle-for-dfn-attribute" style="display:none">Info about the 'attribute' definition.</span><b><a href="#dfn-attribute">#dfn-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-attribute①">2.1. Names</a> <a href="#ref-for-dfn-attribute②">(2)</a> <a href="#ref-for-dfn-attribute③">(3)</a>
@@ -16880,8 +16880,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute⑤⓪">3.7.7.2. Stringifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-regular-attribute">
-   <b><a href="#dfn-regular-attribute">#dfn-regular-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-regular-attribute" class="dfn-panel" data-for="dfn-regular-attribute" id="infopanel-for-dfn-regular-attribute" role="dialog">
+   <span id="infopaneltitle-for-dfn-regular-attribute" style="display:none">Info about the 'regular attribute' definition.</span><b><a href="#dfn-regular-attribute">#dfn-regular-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-regular-attribute">2.3. Interface mixins</a> <a href="#ref-for-dfn-regular-attribute①">(2)</a>
     <li><a href="#ref-for-dfn-regular-attribute②">2.5. Members</a>
@@ -16900,8 +16900,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-regular-attribute②⑧">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="getter-steps">
-   <b><a href="#getter-steps">#getter-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-getter-steps" class="dfn-panel" data-for="getter-steps" id="infopanel-for-getter-steps" role="dialog">
+   <span id="infopaneltitle-for-getter-steps" style="display:none">Info about the 'getter steps' definition.</span><b><a href="#getter-steps">#getter-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-getter-steps">2.5. Members</a>
     <li><a href="#ref-for-getter-steps①">2.5.3.1. toJSON</a>
@@ -16910,15 +16910,15 @@ language binding.</p>
     <li><a href="#ref-for-getter-steps④">3.7.7.2. Stringifiers</a> <a href="#ref-for-getter-steps⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="setter-steps">
-   <b><a href="#setter-steps">#setter-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-setter-steps" class="dfn-panel" data-for="setter-steps" id="infopanel-for-setter-steps" role="dialog">
+   <span id="infopaneltitle-for-setter-steps" style="display:none">Info about the 'setter steps' definition.</span><b><a href="#setter-steps">#setter-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-setter-steps">2.5. Members</a> <a href="#ref-for-setter-steps①">(2)</a>
     <li><a href="#ref-for-setter-steps②">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-read-only">
-   <b><a href="#dfn-read-only">#dfn-read-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-read-only" class="dfn-panel" data-for="dfn-read-only" id="infopanel-for-dfn-read-only" role="dialog">
+   <span id="infopaneltitle-for-dfn-read-only" style="display:none">Info about the 'read only' definition.</span><b><a href="#dfn-read-only">#dfn-read-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-read-only">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-read-only①">2.5. Members</a>
@@ -16933,15 +16933,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-read-only①⑦">3.7.6. Attributes</a> <a href="#ref-for-dfn-read-only①⑧">(2)</a> <a href="#ref-for-dfn-read-only①⑨">(3)</a> <a href="#ref-for-dfn-read-only②⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inherit-getter">
-   <b><a href="#dfn-inherit-getter">#dfn-inherit-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inherit-getter" class="dfn-panel" data-for="dfn-inherit-getter" id="infopanel-for-dfn-inherit-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-inherit-getter" style="display:none">Info about the 'inherit its getter' definition.</span><b><a href="#dfn-inherit-getter">#dfn-inherit-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherit-getter">2.5.2. Attributes</a>
     <li><a href="#ref-for-dfn-inherit-getter①">3.7.7.2. Stringifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-operation">
-   <b><a href="#dfn-operation">#dfn-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-operation" class="dfn-panel" data-for="dfn-operation" id="infopanel-for-dfn-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-operation" style="display:none">Info about the 'operation' definition.</span><b><a href="#dfn-operation">#dfn-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-operation">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-operation①">2.1. Names</a> <a href="#ref-for-dfn-operation②">(2)</a>
@@ -16979,8 +16979,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-operation⑥⑦">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-regular-operation">
-   <b><a href="#dfn-regular-operation">#dfn-regular-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-regular-operation" class="dfn-panel" data-for="dfn-regular-operation" id="infopanel-for-dfn-regular-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-regular-operation" style="display:none">Info about the 'regular operation' definition.</span><b><a href="#dfn-regular-operation">#dfn-regular-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-regular-operation">2.1. Names</a>
     <li><a href="#ref-for-dfn-regular-operation①">2.3. Interface mixins</a> <a href="#ref-for-dfn-regular-operation②">(2)</a> <a href="#ref-for-dfn-regular-operation③">(3)</a>
@@ -16998,8 +16998,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-regular-operation③②">3.7.7.1. Default operations</a> <a href="#ref-for-dfn-regular-operation③③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-return-type">
-   <b><a href="#dfn-return-type">#dfn-return-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-return-type" class="dfn-panel" data-for="dfn-return-type" id="infopanel-for-dfn-return-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-return-type" style="display:none">Info about the 'return type' definition.</span><b><a href="#dfn-return-type">#dfn-return-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-return-type">2.5.5.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-return-type①">2.5.7. Overloading</a> <a href="#ref-for-dfn-return-type②">(2)</a>
@@ -17013,16 +17013,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-return-type①⓪">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-variadic">
-   <b><a href="#dfn-variadic">#dfn-variadic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-variadic" class="dfn-panel" data-for="dfn-variadic" id="infopanel-for-dfn-variadic" role="dialog">
+   <span id="infopaneltitle-for-dfn-variadic" style="display:none">Info about the 'variadic' definition.</span><b><a href="#dfn-variadic">#dfn-variadic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-variadic">2.5.3. Operations</a> <a href="#ref-for-dfn-variadic①">(2)</a> <a href="#ref-for-dfn-variadic②">(3)</a> <a href="#ref-for-dfn-variadic③">(4)</a>
     <li><a href="#ref-for-dfn-variadic④">2.5.5. Special operations</a>
     <li><a href="#ref-for-dfn-variadic⑤">2.5.7. Overloading</a> <a href="#ref-for-dfn-variadic⑥">(2)</a> <a href="#ref-for-dfn-variadic⑦">(3)</a> <a href="#ref-for-dfn-variadic⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-optional-argument">
-   <b><a href="#dfn-optional-argument">#dfn-optional-argument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-optional-argument" class="dfn-panel" data-for="dfn-optional-argument" id="infopanel-for-dfn-optional-argument" role="dialog">
+   <span id="infopaneltitle-for-dfn-optional-argument" style="display:none">Info about the 'optional argument' definition.</span><b><a href="#dfn-optional-argument">#dfn-optional-argument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-optional-argument">2.5.3. Operations</a> <a href="#ref-for-dfn-optional-argument①">(2)</a>
     <li><a href="#ref-for-dfn-optional-argument②">2.5.5. Special operations</a>
@@ -17036,8 +17036,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-optional-argument②②">2.13.25. Enumeration types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-optional-argument-default-value">
-   <b><a href="#dfn-optional-argument-default-value">#dfn-optional-argument-default-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-optional-argument-default-value" class="dfn-panel" data-for="dfn-optional-argument-default-value" id="infopanel-for-dfn-optional-argument-default-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-optional-argument-default-value" style="display:none">Info about the 'default value' definition.</span><b><a href="#dfn-optional-argument-default-value">#dfn-optional-argument-default-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-optional-argument-default-value">2.5.1. Constants</a>
     <li><a href="#ref-for-dfn-optional-argument-default-value①">2.5.3. Operations</a> <a href="#ref-for-dfn-optional-argument-default-value②">(2)</a> <a href="#ref-for-dfn-optional-argument-default-value③">(3)</a> <a href="#ref-for-dfn-optional-argument-default-value④">(4)</a>
@@ -17050,8 +17050,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-optional-argument-default-value①⑤">3.7.10. Asynchronous iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-of-string-literal-tokens">
-   <b><a href="#value-of-string-literal-tokens">#value-of-string-literal-tokens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-of-string-literal-tokens" class="dfn-panel" data-for="value-of-string-literal-tokens" id="infopanel-for-value-of-string-literal-tokens" role="dialog">
+   <span id="infopaneltitle-for-value-of-string-literal-tokens" style="display:none">Info about the 'value' definition.</span><b><a href="#value-of-string-literal-tokens">#value-of-string-literal-tokens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-of-string-literal-tokens">2.13.17. DOMString</a>
     <li><a href="#ref-for-value-of-string-literal-tokens①">2.13.18. ByteString</a>
@@ -17059,8 +17059,8 @@ language binding.</p>
     <li><a href="#ref-for-value-of-string-literal-tokens③">2.13.25. Enumeration types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-code-unit">
-   <b><a href="#dfn-code-unit">#dfn-code-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-code-unit" class="dfn-panel" data-for="dfn-code-unit" id="infopanel-for-dfn-code-unit" role="dialog">
+   <span id="infopaneltitle-for-dfn-code-unit" style="display:none">Info about the 'code units' definition.</span><b><a href="#dfn-code-unit">#dfn-code-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-code-unit">2.13.17. DOMString</a> <a href="#ref-for-dfn-code-unit①">(2)</a>
     <li><a href="#ref-for-dfn-code-unit②">2.13.19. USVString</a>
@@ -17070,8 +17070,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-code-unit⑦">3.2.18. Enumeration types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="method-steps">
-   <b><a href="#method-steps">#method-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-method-steps" class="dfn-panel" data-for="method-steps" id="infopanel-for-method-steps" role="dialog">
+   <span id="infopaneltitle-for-method-steps" style="display:none">Info about the 'method steps' definition.</span><b><a href="#method-steps">#method-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-method-steps">2.5. Members</a>
     <li><a href="#ref-for-method-steps①">2.5.5. Special operations</a>
@@ -17082,16 +17082,16 @@ language binding.</p>
     <li><a href="#ref-for-method-steps⑧">3.9.7. Abstract operations</a> <a href="#ref-for-method-steps⑨">(2)</a> <a href="#ref-for-method-steps①⓪">(3)</a> <a href="#ref-for-method-steps①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-json-types">
-   <b><a href="#dfn-json-types">#dfn-json-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-json-types" class="dfn-panel" data-for="dfn-json-types" id="infopanel-for-dfn-json-types" role="dialog">
+   <span id="infopaneltitle-for-dfn-json-types" style="display:none">Info about the 'JSON types' definition.</span><b><a href="#dfn-json-types">#dfn-json-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-json-types">2.1. Names</a>
     <li><a href="#ref-for-dfn-json-types①">2.5.3.1. toJSON</a> <a href="#ref-for-dfn-json-types②">(2)</a> <a href="#ref-for-dfn-json-types③">(3)</a> <a href="#ref-for-dfn-json-types④">(4)</a> <a href="#ref-for-dfn-json-types⑤">(5)</a> <a href="#ref-for-dfn-json-types⑥">(6)</a> <a href="#ref-for-dfn-json-types⑦">(7)</a> <a href="#ref-for-dfn-json-types⑧">(8)</a> <a href="#ref-for-dfn-json-types⑨">(9)</a> <a href="#ref-for-dfn-json-types①⓪">(10)</a> <a href="#ref-for-dfn-json-types①①">(11)</a> <a href="#ref-for-dfn-json-types①②">(12)</a>
     <li><a href="#ref-for-dfn-json-types①③">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-constructors">
-   <b><a href="#idl-constructors">#idl-constructors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-constructors" class="dfn-panel" data-for="idl-constructors" id="infopanel-for-idl-constructors" role="dialog">
+   <span id="infopaneltitle-for-idl-constructors" style="display:none">Info about the '2.5.4. Constructor operations' definition.</span><b><a href="#idl-constructors">#idl-constructors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-constructors">2. Interface definition language</a>
     <li><a href="#ref-for-idl-constructors①">2.5.3. Operations</a>
@@ -17103,8 +17103,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-constructors①⑦">3.7.1. Interface object</a> <a href="#ref-for-idl-constructors①⑧">(2)</a> <a href="#ref-for-idl-constructors①⑨">(3)</a> <a href="#ref-for-idl-constructors②⓪">(4)</a> <a href="#ref-for-idl-constructors②①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constructor-steps">
-   <b><a href="#constructor-steps">#constructor-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constructor-steps" class="dfn-panel" data-for="constructor-steps" id="infopanel-for-constructor-steps" role="dialog">
+   <span id="infopaneltitle-for-constructor-steps" style="display:none">Info about the 'constructor steps' definition.</span><b><a href="#constructor-steps">#constructor-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructor-steps">2.5. Members</a>
     <li><a href="#ref-for-constructor-steps①">2.5.4. Constructor operations</a>
@@ -17112,8 +17112,8 @@ language binding.</p>
     <li><a href="#ref-for-constructor-steps③">3.7.2. Legacy factory functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-special-operation">
-   <b><a href="#dfn-special-operation">#dfn-special-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-special-operation" class="dfn-panel" data-for="dfn-special-operation" id="infopanel-for-dfn-special-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-special-operation" style="display:none">Info about the 'special operation' definition.</span><b><a href="#dfn-special-operation">#dfn-special-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-special-operation">2.1. Names</a>
     <li><a href="#ref-for-dfn-special-operation①">2.3. Interface mixins</a>
@@ -17121,27 +17121,27 @@ language binding.</p>
     <li><a href="#ref-for-dfn-special-operation③">2.5.3. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-special-keyword">
-   <b><a href="#dfn-special-keyword">#dfn-special-keyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-special-keyword" class="dfn-panel" data-for="dfn-special-keyword" id="infopanel-for-dfn-special-keyword" role="dialog">
+   <span id="infopaneltitle-for-dfn-special-keyword" style="display:none">Info about the 'special keyword' definition.</span><b><a href="#dfn-special-keyword">#dfn-special-keyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-special-keyword">2.5.3. Operations</a>
     <li><a href="#ref-for-dfn-special-keyword①">2.5.5. Special operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-getter">
-   <b><a href="#dfn-getter">#dfn-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-getter" class="dfn-panel" data-for="dfn-getter" id="infopanel-for-dfn-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-getter" style="display:none">Info about the 'Getters' definition.</span><b><a href="#dfn-getter">#dfn-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-getter">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-setter">
-   <b><a href="#dfn-setter">#dfn-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-setter" class="dfn-panel" data-for="dfn-setter" id="infopanel-for-dfn-setter" role="dialog">
+   <span id="infopaneltitle-for-dfn-setter" style="display:none">Info about the 'Setters' definition.</span><b><a href="#dfn-setter">#dfn-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-setter">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-stringifier">
-   <b><a href="#dfn-stringifier">#dfn-stringifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-stringifier" class="dfn-panel" data-for="dfn-stringifier" id="infopanel-for-dfn-stringifier" role="dialog">
+   <span id="infopaneltitle-for-dfn-stringifier" style="display:none">Info about the 'Stringifiers' definition.</span><b><a href="#dfn-stringifier">#dfn-stringifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-stringifier">2.3. Interface mixins</a> <a href="#ref-for-dfn-stringifier①">(2)</a> <a href="#ref-for-dfn-stringifier②">(3)</a>
     <li><a href="#ref-for-dfn-stringifier③">2.5. Members</a>
@@ -17150,8 +17150,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-stringifier⑥">3.7.7.2. Stringifiers</a> <a href="#ref-for-dfn-stringifier⑦">(2)</a> <a href="#ref-for-dfn-stringifier⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-property-getter">
-   <b><a href="#dfn-named-property-getter">#dfn-named-property-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-property-getter" class="dfn-panel" data-for="dfn-named-property-getter" id="infopanel-for-dfn-named-property-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-property-getter" style="display:none">Info about the 'named property getters' definition.</span><b><a href="#dfn-named-property-getter">#dfn-named-property-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-getter">2.5.5. Special operations</a>
     <li><a href="#ref-for-dfn-named-property-getter①">2.5.5.3. Named properties</a> <a href="#ref-for-dfn-named-property-getter②">(2)</a> <a href="#ref-for-dfn-named-property-getter③">(3)</a>
@@ -17160,8 +17160,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-property-getter⑧">3.4.9. [LegacyUnenumerableNamedProperties]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-property-setter">
-   <b><a href="#dfn-named-property-setter">#dfn-named-property-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-property-setter" class="dfn-panel" data-for="dfn-named-property-setter" id="infopanel-for-dfn-named-property-setter" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-property-setter" style="display:none">Info about the 'named property setters' definition.</span><b><a href="#dfn-named-property-setter">#dfn-named-property-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-setter">2.5.5.3. Named properties</a> <a href="#ref-for-dfn-named-property-setter①">(2)</a>
     <li><a href="#ref-for-dfn-named-property-setter②">3.3.7. [Global]</a>
@@ -17170,8 +17170,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-property-setter⑥">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-indexed-property-getter">
-   <b><a href="#dfn-indexed-property-getter">#dfn-indexed-property-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-indexed-property-getter" class="dfn-panel" data-for="dfn-indexed-property-getter" id="infopanel-for-dfn-indexed-property-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-indexed-property-getter" style="display:none">Info about the 'indexed property getters' definition.</span><b><a href="#dfn-indexed-property-getter">#dfn-indexed-property-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-getter">2.5.5.2. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-getter①">(2)</a> <a href="#ref-for-dfn-indexed-property-getter②">(3)</a>
     <li><a href="#ref-for-dfn-indexed-property-getter③">2.5.8. Iterable declarations</a>
@@ -17183,8 +17183,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-indexed-property-getter⑨">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-indexed-property-setter">
-   <b><a href="#dfn-indexed-property-setter">#dfn-indexed-property-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-indexed-property-setter" class="dfn-panel" data-for="dfn-indexed-property-setter" id="infopanel-for-dfn-indexed-property-setter" role="dialog">
+   <span id="infopaneltitle-for-dfn-indexed-property-setter" style="display:none">Info about the 'indexed property setters' definition.</span><b><a href="#dfn-indexed-property-setter">#dfn-indexed-property-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-setter">2.5.5.2. Indexed properties</a> <a href="#ref-for-dfn-indexed-property-setter①">(2)</a>
     <li><a href="#ref-for-dfn-indexed-property-setter②">3.3.7. [Global]</a>
@@ -17194,23 +17194,23 @@ language binding.</p>
     <li><a href="#ref-for-dfn-indexed-property-setter⑥">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-property-deleter">
-   <b><a href="#dfn-named-property-deleter">#dfn-named-property-deleter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-property-deleter" class="dfn-panel" data-for="dfn-named-property-deleter" id="infopanel-for-dfn-named-property-deleter" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-property-deleter" style="display:none">Info about the 'named property deleters' definition.</span><b><a href="#dfn-named-property-deleter">#dfn-named-property-deleter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-deleter">2.5.5. Special operations</a> <a href="#ref-for-dfn-named-property-deleter①">(2)</a>
     <li><a href="#ref-for-dfn-named-property-deleter②">2.5.5.3. Named properties</a> <a href="#ref-for-dfn-named-property-deleter③">(2)</a>
     <li><a href="#ref-for-dfn-named-property-deleter④">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-stringification-behavior">
-   <b><a href="#dfn-stringification-behavior">#dfn-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-stringification-behavior" class="dfn-panel" data-for="dfn-stringification-behavior" id="infopanel-for-dfn-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-dfn-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#dfn-stringification-behavior">#dfn-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-stringification-behavior">2.5.5.1. Stringifiers</a>
     <li><a href="#ref-for-dfn-stringification-behavior①">3.7.7.2. Stringifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-indexed-properties">
-   <b><a href="#idl-indexed-properties">#idl-indexed-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-indexed-properties" class="dfn-panel" data-for="idl-indexed-properties" id="infopanel-for-idl-indexed-properties" role="dialog">
+   <span id="infopaneltitle-for-idl-indexed-properties" style="display:none">Info about the '2.5.5.2. Indexed properties' definition.</span><b><a href="#idl-indexed-properties">#idl-indexed-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-indexed-properties">2.5.5. Special operations</a>
     <li><a href="#ref-for-idl-indexed-properties">2.5.5.2. Indexed properties</a>
@@ -17218,8 +17218,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-indexed-properties①">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-support-indexed-properties">
-   <b><a href="#dfn-support-indexed-properties">#dfn-support-indexed-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-support-indexed-properties" class="dfn-panel" data-for="dfn-support-indexed-properties" id="infopanel-for-dfn-support-indexed-properties" role="dialog">
+   <span id="infopaneltitle-for-dfn-support-indexed-properties" style="display:none">Info about the 'support indexed properties' definition.</span><b><a href="#dfn-support-indexed-properties">#dfn-support-indexed-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support-indexed-properties">2.5.5.2. Indexed properties</a> <a href="#ref-for-dfn-support-indexed-properties①">(2)</a> <a href="#ref-for-dfn-support-indexed-properties②">(3)</a>
     <li><a href="#ref-for-dfn-support-indexed-properties③">2.5.8. Iterable declarations</a> <a href="#ref-for-dfn-support-indexed-properties④">(2)</a> <a href="#ref-for-dfn-support-indexed-properties⑤">(3)</a> <a href="#ref-for-dfn-support-indexed-properties⑥">(4)</a> <a href="#ref-for-dfn-support-indexed-properties⑦">(5)</a>
@@ -17232,8 +17232,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-indexed-properties①④">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-supported-property-indices">
-   <b><a href="#dfn-supported-property-indices">#dfn-supported-property-indices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-supported-property-indices" class="dfn-panel" data-for="dfn-supported-property-indices" id="infopanel-for-dfn-supported-property-indices" role="dialog">
+   <span id="infopaneltitle-for-dfn-supported-property-indices" style="display:none">Info about the 'supported property indices' definition.</span><b><a href="#dfn-supported-property-indices">#dfn-supported-property-indices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices">2.5.5.2. Indexed properties</a> <a href="#ref-for-dfn-supported-property-indices①">(2)</a> <a href="#ref-for-dfn-supported-property-indices②">(3)</a>
     <li><a href="#ref-for-dfn-supported-property-indices③">3.9. Legacy platform objects</a>
@@ -17242,26 +17242,26 @@ language binding.</p>
     <li><a href="#ref-for-dfn-supported-property-indices⑥">3.9.7. Abstract operations</a> <a href="#ref-for-dfn-supported-property-indices⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-determine-the-value-of-an-indexed-property">
-   <b><a href="#dfn-determine-the-value-of-an-indexed-property">#dfn-determine-the-value-of-an-indexed-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-determine-the-value-of-an-indexed-property" class="dfn-panel" data-for="dfn-determine-the-value-of-an-indexed-property" id="infopanel-for-dfn-determine-the-value-of-an-indexed-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-determine-the-value-of-an-indexed-property" style="display:none">Info about the 'determine the value of an indexed property' definition.</span><b><a href="#dfn-determine-the-value-of-an-indexed-property">#dfn-determine-the-value-of-an-indexed-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-indexed-property">
-   <b><a href="#dfn-set-the-value-of-an-existing-indexed-property">#dfn-set-the-value-of-an-existing-indexed-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-the-value-of-an-existing-indexed-property" class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-indexed-property" id="infopanel-for-dfn-set-the-value-of-an-existing-indexed-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-the-value-of-an-existing-indexed-property" style="display:none">Info about the 'set the value of an existing indexed property' definition.</span><b><a href="#dfn-set-the-value-of-an-existing-indexed-property">#dfn-set-the-value-of-an-existing-indexed-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-indexed-property">
-   <b><a href="#dfn-set-the-value-of-a-new-indexed-property">#dfn-set-the-value-of-a-new-indexed-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-the-value-of-a-new-indexed-property" class="dfn-panel" data-for="dfn-set-the-value-of-a-new-indexed-property" id="infopanel-for-dfn-set-the-value-of-a-new-indexed-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-the-value-of-a-new-indexed-property" style="display:none">Info about the 'set the value of a new indexed property' definition.</span><b><a href="#dfn-set-the-value-of-a-new-indexed-property">#dfn-set-the-value-of-a-new-indexed-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-named-properties">
-   <b><a href="#idl-named-properties">#idl-named-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-named-properties" class="dfn-panel" data-for="idl-named-properties" id="infopanel-for-idl-named-properties" role="dialog">
+   <span id="infopaneltitle-for-idl-named-properties" style="display:none">Info about the '2.5.5.3. Named properties' definition.</span><b><a href="#idl-named-properties">#idl-named-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-named-properties">2.5.5. Special operations</a>
     <li><a href="#ref-for-idl-named-properties">2.5.5.3. Named properties</a>
@@ -17269,8 +17269,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-named-properties②">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-support-named-properties">
-   <b><a href="#dfn-support-named-properties">#dfn-support-named-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-support-named-properties" class="dfn-panel" data-for="dfn-support-named-properties" id="infopanel-for-dfn-support-named-properties" role="dialog">
+   <span id="infopaneltitle-for-dfn-support-named-properties" style="display:none">Info about the 'support named properties' definition.</span><b><a href="#dfn-support-named-properties">#dfn-support-named-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support-named-properties">2.5.5.3. Named properties</a> <a href="#ref-for-dfn-support-named-properties①">(2)</a>
     <li><a href="#ref-for-dfn-support-named-properties②">2.12. Objects implementing interfaces</a>
@@ -17284,8 +17284,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-support-named-properties①⓪">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-supported-property-names">
-   <b><a href="#dfn-supported-property-names">#dfn-supported-property-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-supported-property-names" class="dfn-panel" data-for="dfn-supported-property-names" id="infopanel-for-dfn-supported-property-names" role="dialog">
+   <span id="infopaneltitle-for-dfn-supported-property-names" style="display:none">Info about the 'supported property names' definition.</span><b><a href="#dfn-supported-property-names">#dfn-supported-property-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names">2.5.5.3. Named properties</a> <a href="#ref-for-dfn-supported-property-names①">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-names②">3.4.7. [LegacyOverrideBuiltIns]</a>
@@ -17294,33 +17294,33 @@ language binding.</p>
     <li><a href="#ref-for-dfn-supported-property-names⑤">3.9.7. Abstract operations</a> <a href="#ref-for-dfn-supported-property-names⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-determine-the-value-of-a-named-property">
-   <b><a href="#dfn-determine-the-value-of-a-named-property">#dfn-determine-the-value-of-a-named-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-determine-the-value-of-a-named-property" class="dfn-panel" data-for="dfn-determine-the-value-of-a-named-property" id="infopanel-for-dfn-determine-the-value-of-a-named-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-determine-the-value-of-a-named-property" style="display:none">Info about the 'determine the value of a named property' definition.</span><b><a href="#dfn-determine-the-value-of-a-named-property">#dfn-determine-the-value-of-a-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property">3.7.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-determine-the-value-of-a-named-property①">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-named-property">
-   <b><a href="#dfn-set-the-value-of-an-existing-named-property">#dfn-set-the-value-of-an-existing-named-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-the-value-of-an-existing-named-property" class="dfn-panel" data-for="dfn-set-the-value-of-an-existing-named-property" id="infopanel-for-dfn-set-the-value-of-an-existing-named-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-the-value-of-an-existing-named-property" style="display:none">Info about the 'set the value of an existing named property' definition.</span><b><a href="#dfn-set-the-value-of-an-existing-named-property">#dfn-set-the-value-of-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-an-existing-named-property">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-the-value-of-a-new-named-property">
-   <b><a href="#dfn-set-the-value-of-a-new-named-property">#dfn-set-the-value-of-a-new-named-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-the-value-of-a-new-named-property" class="dfn-panel" data-for="dfn-set-the-value-of-a-new-named-property" id="infopanel-for-dfn-set-the-value-of-a-new-named-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-the-value-of-a-new-named-property" style="display:none">Info about the 'set the value of a new named property' definition.</span><b><a href="#dfn-set-the-value-of-a-new-named-property">#dfn-set-the-value-of-a-new-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-a-new-named-property">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-delete-an-existing-named-property">
-   <b><a href="#dfn-delete-an-existing-named-property">#dfn-delete-an-existing-named-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-delete-an-existing-named-property" class="dfn-panel" data-for="dfn-delete-an-existing-named-property" id="infopanel-for-dfn-delete-an-existing-named-property" role="dialog">
+   <span id="infopaneltitle-for-dfn-delete-an-existing-named-property" style="display:none">Info about the 'delete an existing named property' definition.</span><b><a href="#dfn-delete-an-existing-named-property">#dfn-delete-an-existing-named-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-delete-an-existing-named-property">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-static-attribute">
-   <b><a href="#dfn-static-attribute">#dfn-static-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-static-attribute" class="dfn-panel" data-for="dfn-static-attribute" id="infopanel-for-dfn-static-attribute" role="dialog">
+   <span id="infopaneltitle-for-dfn-static-attribute" style="display:none">Info about the 'Static attributes' definition.</span><b><a href="#dfn-static-attribute">#dfn-static-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-static-attribute">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-static-attribute①">2.5. Members</a>
@@ -17332,8 +17332,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-static-attribute⑨">3.7.6. Attributes</a> <a href="#ref-for-dfn-static-attribute①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-static-operation">
-   <b><a href="#dfn-static-operation">#dfn-static-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-static-operation" class="dfn-panel" data-for="dfn-static-operation" id="infopanel-for-dfn-static-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-static-operation" style="display:none">Info about the 'static operations' definition.</span><b><a href="#dfn-static-operation">#dfn-static-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-static-operation">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-static-operation①">2.5. Members</a>
@@ -17346,8 +17346,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-static-operation①⑤">3.7.7. Operations</a> <a href="#ref-for-dfn-static-operation①⑥">(2)</a> <a href="#ref-for-dfn-static-operation①⑦">(3)</a> <a href="#ref-for-dfn-static-operation①⑧">(4)</a> <a href="#ref-for-dfn-static-operation①⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-overloaded">
-   <b><a href="#dfn-overloaded">#dfn-overloaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-overloaded" class="dfn-panel" data-for="dfn-overloaded" id="infopanel-for-dfn-overloaded" role="dialog">
+   <span id="infopaneltitle-for-dfn-overloaded" style="display:none">Info about the 'overloaded' definition.</span><b><a href="#dfn-overloaded">#dfn-overloaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-overloaded">2.5.3. Operations</a>
     <li><a href="#ref-for-dfn-overloaded①">2.5.7.1. Overloading vs. union types</a> <a href="#ref-for-dfn-overloaded②">(2)</a> <a href="#ref-for-dfn-overloaded③">(3)</a> <a href="#ref-for-dfn-overloaded④">(4)</a> <a href="#ref-for-dfn-overloaded⑤">(5)</a> <a href="#ref-for-dfn-overloaded⑥">(6)</a> <a href="#ref-for-dfn-overloaded⑦">(7)</a> <a href="#ref-for-dfn-overloaded⑧">(8)</a> <a href="#ref-for-dfn-overloaded⑨">(9)</a> <a href="#ref-for-dfn-overloaded①⓪">(10)</a>
@@ -17356,40 +17356,40 @@ language binding.</p>
     <li><a href="#ref-for-dfn-overloaded①③">3.3.12. [SecureContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-effective-overload-set">
-   <b><a href="#dfn-effective-overload-set">#dfn-effective-overload-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-effective-overload-set" class="dfn-panel" data-for="dfn-effective-overload-set" id="infopanel-for-dfn-effective-overload-set" role="dialog">
+   <span id="infopaneltitle-for-dfn-effective-overload-set" style="display:none">Info about the 'effective overload set' definition.</span><b><a href="#dfn-effective-overload-set">#dfn-effective-overload-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-effective-overload-set">2.5.7. Overloading</a> <a href="#ref-for-dfn-effective-overload-set①">(2)</a> <a href="#ref-for-dfn-effective-overload-set②">(3)</a> <a href="#ref-for-dfn-effective-overload-set③">(4)</a> <a href="#ref-for-dfn-effective-overload-set④">(5)</a> <a href="#ref-for-dfn-effective-overload-set⑤">(6)</a> <a href="#ref-for-dfn-effective-overload-set⑥">(7)</a> <a href="#ref-for-dfn-effective-overload-set⑦">(8)</a> <a href="#ref-for-dfn-effective-overload-set⑧">(9)</a> <a href="#ref-for-dfn-effective-overload-set⑨">(10)</a> <a href="#ref-for-dfn-effective-overload-set①⓪">(11)</a> <a href="#ref-for-dfn-effective-overload-set①①">(12)</a>
     <li><a href="#ref-for-dfn-effective-overload-set①②">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-overload-set-tuple-callable">
-   <b><a href="#effective-overload-set-tuple-callable">#effective-overload-set-tuple-callable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-overload-set-tuple-callable" class="dfn-panel" data-for="effective-overload-set-tuple-callable" id="infopanel-for-effective-overload-set-tuple-callable" role="dialog">
+   <span id="infopaneltitle-for-effective-overload-set-tuple-callable" style="display:none">Info about the 'callable' definition.</span><b><a href="#effective-overload-set-tuple-callable">#effective-overload-set-tuple-callable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-overload-set-tuple-callable">2.5.7. Overloading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="type-list">
-   <b><a href="#type-list">#type-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-type-list" class="dfn-panel" data-for="type-list" id="infopanel-for-type-list" role="dialog">
+   <span id="infopaneltitle-for-type-list" style="display:none">Info about the 'type list' definition.</span><b><a href="#type-list">#type-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-list">2.5.7. Overloading</a> <a href="#ref-for-type-list①">(2)</a> <a href="#ref-for-type-list②">(3)</a> <a href="#ref-for-type-list③">(4)</a> <a href="#ref-for-type-list④">(5)</a> <a href="#ref-for-type-list⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optionality-list">
-   <b><a href="#optionality-list">#optionality-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optionality-list" class="dfn-panel" data-for="optionality-list" id="infopanel-for-optionality-list" role="dialog">
+   <span id="infopaneltitle-for-optionality-list" style="display:none">Info about the 'optionality list' definition.</span><b><a href="#optionality-list">#optionality-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optionality-list">2.5.7. Overloading</a> <a href="#ref-for-optionality-list①">(2)</a> <a href="#ref-for-optionality-list②">(3)</a> <a href="#ref-for-optionality-list③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-optionality-value">
-   <b><a href="#dfn-optionality-value">#dfn-optionality-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-optionality-value" class="dfn-panel" data-for="dfn-optionality-value" id="infopanel-for-dfn-optionality-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-optionality-value" style="display:none">Info about the 'optionality values' definition.</span><b><a href="#dfn-optionality-value">#dfn-optionality-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-optionality-value">2.5.7. Overloading</a>
     <li><a href="#ref-for-dfn-optionality-value①">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-optionality-value②">(2)</a> <a href="#ref-for-dfn-optionality-value③">(3)</a> <a href="#ref-for-dfn-optionality-value④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-the-effective-overload-set">
-   <b><a href="#compute-the-effective-overload-set">#compute-the-effective-overload-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-the-effective-overload-set" class="dfn-panel" data-for="compute-the-effective-overload-set" id="infopanel-for-compute-the-effective-overload-set" role="dialog">
+   <span id="infopaneltitle-for-compute-the-effective-overload-set" style="display:none">Info about the 'compute the effective overload set' definition.</span><b><a href="#compute-the-effective-overload-set">#compute-the-effective-overload-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-the-effective-overload-set">2.5.7. Overloading</a>
     <li><a href="#ref-for-compute-the-effective-overload-set①">3.7.1. Interface object</a> <a href="#ref-for-compute-the-effective-overload-set②">(2)</a>
@@ -17397,22 +17397,22 @@ language binding.</p>
     <li><a href="#ref-for-compute-the-effective-overload-set⑤">3.7.7. Operations</a> <a href="#ref-for-compute-the-effective-overload-set⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-distinguishable">
-   <b><a href="#dfn-distinguishable">#dfn-distinguishable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-distinguishable" class="dfn-panel" data-for="dfn-distinguishable" id="infopanel-for-dfn-distinguishable" role="dialog">
+   <span id="infopaneltitle-for-dfn-distinguishable" style="display:none">Info about the 'distinguishable' definition.</span><b><a href="#dfn-distinguishable">#dfn-distinguishable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-distinguishable">2.5.7. Overloading</a> <a href="#ref-for-dfn-distinguishable①">(2)</a> <a href="#ref-for-dfn-distinguishable②">(3)</a>
     <li><a href="#ref-for-dfn-distinguishable③">2.13.31. Union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-distinguishing-argument-index">
-   <b><a href="#dfn-distinguishing-argument-index">#dfn-distinguishing-argument-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-distinguishing-argument-index" class="dfn-panel" data-for="dfn-distinguishing-argument-index" id="infopanel-for-dfn-distinguishing-argument-index" role="dialog">
+   <span id="infopaneltitle-for-dfn-distinguishing-argument-index" style="display:none">Info about the 'distinguishing argument index' definition.</span><b><a href="#dfn-distinguishing-argument-index">#dfn-distinguishing-argument-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-distinguishing-argument-index">2.5.7. Overloading</a> <a href="#ref-for-dfn-distinguishing-argument-index①">(2)</a> <a href="#ref-for-dfn-distinguishing-argument-index②">(3)</a> <a href="#ref-for-dfn-distinguishing-argument-index③">(4)</a> <a href="#ref-for-dfn-distinguishing-argument-index④">(5)</a>
     <li><a href="#ref-for-dfn-distinguishing-argument-index⑤">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-distinguishing-argument-index⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-iterable-declaration">
-   <b><a href="#dfn-iterable-declaration">#dfn-iterable-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-iterable-declaration" class="dfn-panel" data-for="dfn-iterable-declaration" id="infopanel-for-dfn-iterable-declaration" role="dialog">
+   <span id="infopaneltitle-for-dfn-iterable-declaration" style="display:none">Info about the 'iterable declaration' definition.</span><b><a href="#dfn-iterable-declaration">#dfn-iterable-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-iterable-declaration">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-iterable-declaration①">2.5. Members</a>
@@ -17424,16 +17424,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-iterable-declaration①①">3.7.10. Asynchronous iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-value-iterator">
-   <b><a href="#dfn-value-iterator">#dfn-value-iterator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-value-iterator" class="dfn-panel" data-for="dfn-value-iterator" id="infopanel-for-dfn-value-iterator" role="dialog">
+   <span id="infopaneltitle-for-dfn-value-iterator" style="display:none">Info about the 'value iterator' definition.</span><b><a href="#dfn-value-iterator">#dfn-value-iterator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-iterator">2.5.8. Iterable declarations</a> <a href="#ref-for-dfn-value-iterator①">(2)</a> <a href="#ref-for-dfn-value-iterator②">(3)</a> <a href="#ref-for-dfn-value-iterator③">(4)</a> <a href="#ref-for-dfn-value-iterator④">(5)</a> <a href="#ref-for-dfn-value-iterator⑤">(6)</a>
     <li><a href="#ref-for-dfn-value-iterator⑥">3.7.9. Iterable declarations</a>
     <li><a href="#ref-for-dfn-value-iterator⑦">3.7.9.1. Default iterator objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-pair-iterator">
-   <b><a href="#dfn-pair-iterator">#dfn-pair-iterator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-pair-iterator" class="dfn-panel" data-for="dfn-pair-iterator" id="infopanel-for-dfn-pair-iterator" role="dialog">
+   <span id="infopaneltitle-for-dfn-pair-iterator" style="display:none">Info about the 'pair iterator' definition.</span><b><a href="#dfn-pair-iterator">#dfn-pair-iterator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-pair-iterator">2.5.8. Iterable declarations</a> <a href="#ref-for-dfn-pair-iterator①">(2)</a> <a href="#ref-for-dfn-pair-iterator②">(3)</a>
     <li><a href="#ref-for-dfn-pair-iterator③">3.7.9. Iterable declarations</a>
@@ -17441,8 +17441,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-pair-iterator⑤">3.7.9.2. Iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-pair">
-   <b><a href="#value-pair">#value-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-pair" class="dfn-panel" data-for="value-pair" id="infopanel-for-value-pair" role="dialog">
+   <span id="infopaneltitle-for-value-pair" style="display:none">Info about the 'value pair' definition.</span><b><a href="#value-pair">#value-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-pair">2.5.8. Iterable declarations</a> <a href="#ref-for-value-pair①">(2)</a> <a href="#ref-for-value-pair②">(3)</a> <a href="#ref-for-value-pair③">(4)</a> <a href="#ref-for-value-pair④">(5)</a>
     <li><a href="#ref-for-value-pair⑤">2.5.9. Asynchronously iterable declarations</a>
@@ -17450,32 +17450,32 @@ language binding.</p>
     <li><a href="#ref-for-value-pair⑦">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-pair-key">
-   <b><a href="#value-pair-key">#value-pair-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-pair-key" class="dfn-panel" data-for="value-pair-key" id="infopanel-for-value-pair-key" role="dialog">
+   <span id="infopaneltitle-for-value-pair-key" style="display:none">Info about the 'key' definition.</span><b><a href="#value-pair-key">#value-pair-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-pair-key">2.5.8. Iterable declarations</a>
     <li><a href="#ref-for-value-pair-key①">3.7.9. Iterable declarations</a>
     <li><a href="#ref-for-value-pair-key②">3.7.9.2. Iterator prototype object</a> <a href="#ref-for-value-pair-key③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-pair-value">
-   <b><a href="#value-pair-value">#value-pair-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-pair-value" class="dfn-panel" data-for="value-pair-value" id="infopanel-for-value-pair-value" role="dialog">
+   <span id="infopaneltitle-for-value-pair-value" style="display:none">Info about the 'value' definition.</span><b><a href="#value-pair-value">#value-pair-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-pair-value">2.5.8. Iterable declarations</a>
     <li><a href="#ref-for-value-pair-value①">3.7.9. Iterable declarations</a>
     <li><a href="#ref-for-value-pair-value②">3.7.9.2. Iterator prototype object</a> <a href="#ref-for-value-pair-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-value-pairs-to-iterate-over">
-   <b><a href="#dfn-value-pairs-to-iterate-over">#dfn-value-pairs-to-iterate-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="dfn-value-pairs-to-iterate-over" id="infopanel-for-dfn-value-pairs-to-iterate-over" role="dialog">
+   <span id="infopaneltitle-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' definition.</span><b><a href="#dfn-value-pairs-to-iterate-over">#dfn-value-pairs-to-iterate-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">2.5.8. Iterable declarations</a>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over①">3.7.9. Iterable declarations</a> <a href="#ref-for-dfn-value-pairs-to-iterate-over②">(2)</a>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over③">3.7.9.2. Iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-async-iterable-declaration">
-   <b><a href="#dfn-async-iterable-declaration">#dfn-async-iterable-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-async-iterable-declaration" class="dfn-panel" data-for="dfn-async-iterable-declaration" id="infopanel-for-dfn-async-iterable-declaration" role="dialog">
+   <span id="infopaneltitle-for-dfn-async-iterable-declaration" style="display:none">Info about the 'asynchronously iterable declaration' definition.</span><b><a href="#dfn-async-iterable-declaration">#dfn-async-iterable-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-async-iterable-declaration">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-async-iterable-declaration①">2.5. Members</a>
@@ -17488,63 +17488,64 @@ language binding.</p>
     <li><a href="#ref-for-dfn-async-iterable-declaration②①">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-asynchronously-iterable-declaration">
-   <b><a href="#value-asynchronously-iterable-declaration">#value-asynchronously-iterable-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-asynchronously-iterable-declaration" class="dfn-panel" data-for="value-asynchronously-iterable-declaration" id="infopanel-for-value-asynchronously-iterable-declaration" role="dialog">
+   <span id="infopaneltitle-for-value-asynchronously-iterable-declaration" style="display:none">Info about the 'value asynchronously iterable declaration' definition.</span><b><a href="#value-asynchronously-iterable-declaration">#value-asynchronously-iterable-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-asynchronously-iterable-declaration">2.5.9. Asynchronously iterable declarations</a>
     <li><a href="#ref-for-value-asynchronously-iterable-declaration①">3.7.10. Asynchronous iterable declarations</a>
     <li><a href="#ref-for-value-asynchronously-iterable-declaration②">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pair-asynchronously-iterable-declaration">
-   <b><a href="#pair-asynchronously-iterable-declaration">#pair-asynchronously-iterable-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pair-asynchronously-iterable-declaration" class="dfn-panel" data-for="pair-asynchronously-iterable-declaration" id="infopanel-for-pair-asynchronously-iterable-declaration" role="dialog">
+   <span id="infopaneltitle-for-pair-asynchronously-iterable-declaration" style="display:none">Info about the 'pair asynchronously iterable declaration' definition.</span><b><a href="#pair-asynchronously-iterable-declaration">#pair-asynchronously-iterable-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pair-asynchronously-iterable-declaration">2.5.9. Asynchronously iterable declarations</a> <a href="#ref-for-pair-asynchronously-iterable-declaration①">(2)</a>
     <li><a href="#ref-for-pair-asynchronously-iterable-declaration②">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-pair-asynchronously-iterable-declaration③">(2)</a>
     <li><a href="#ref-for-pair-asynchronously-iterable-declaration④">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-get-the-next-iteration-result">
-   <b><a href="#dfn-get-the-next-iteration-result">#dfn-get-the-next-iteration-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-get-the-next-iteration-result" class="dfn-panel" data-for="dfn-get-the-next-iteration-result" id="infopanel-for-dfn-get-the-next-iteration-result" role="dialog">
+   <span id="infopaneltitle-for-dfn-get-the-next-iteration-result" style="display:none">Info about the 'get the next iteration result' definition.</span><b><a href="#dfn-get-the-next-iteration-result">#dfn-get-the-next-iteration-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-the-next-iteration-result">2.5.9. Asynchronously iterable declarations</a>
     <li><a href="#ref-for-dfn-get-the-next-iteration-result①">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-of-iteration">
-   <b><a href="#end-of-iteration">#end-of-iteration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-of-iteration" class="dfn-panel" data-for="end-of-iteration" id="infopanel-for-end-of-iteration" role="dialog">
+   <span id="infopaneltitle-for-end-of-iteration" style="display:none">Info about the 'end of
+iteration' definition.</span><b><a href="#end-of-iteration">#end-of-iteration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-of-iteration">2.5.9. Asynchronously iterable declarations</a>
     <li><a href="#ref-for-end-of-iteration①">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="asynchronous-iterator-return">
-   <b><a href="#asynchronous-iterator-return">#asynchronous-iterator-return</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-asynchronous-iterator-return" class="dfn-panel" data-for="asynchronous-iterator-return" id="infopanel-for-asynchronous-iterator-return" role="dialog">
+   <span id="infopaneltitle-for-asynchronous-iterator-return" style="display:none">Info about the 'asynchronous iterator return' definition.</span><b><a href="#asynchronous-iterator-return">#asynchronous-iterator-return</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-return">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-asynchronous-iterator-return①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="asynchronous-iterator-initialization-steps">
-   <b><a href="#asynchronous-iterator-initialization-steps">#asynchronous-iterator-initialization-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-asynchronous-iterator-initialization-steps" class="dfn-panel" data-for="asynchronous-iterator-initialization-steps" id="infopanel-for-asynchronous-iterator-initialization-steps" role="dialog">
+   <span id="infopaneltitle-for-asynchronous-iterator-initialization-steps" style="display:none">Info about the 'asynchronous iterator initialization steps' definition.</span><b><a href="#asynchronous-iterator-initialization-steps">#asynchronous-iterator-initialization-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-initialization-steps">2.5.9. Asynchronously iterable declarations</a> <a href="#ref-for-asynchronous-iterator-initialization-steps①">(2)</a>
     <li><a href="#ref-for-asynchronous-iterator-initialization-steps②">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-asynchronous-iterator-initialization-steps③">(2)</a> <a href="#ref-for-asynchronous-iterator-initialization-steps④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sessionmanager-async-iterator-current-state">
-   <b><a href="#sessionmanager-async-iterator-current-state">#sessionmanager-async-iterator-current-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sessionmanager-async-iterator-current-state" class="dfn-panel" data-for="sessionmanager-async-iterator-current-state" id="infopanel-for-sessionmanager-async-iterator-current-state" role="dialog">
+   <span id="infopaneltitle-for-sessionmanager-async-iterator-current-state" style="display:none">Info about the 'current state' definition.</span><b><a href="#sessionmanager-async-iterator-current-state">#sessionmanager-async-iterator-current-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sessionmanager-async-iterator-current-state">2.5.9. Asynchronously iterable declarations</a> <a href="#ref-for-sessionmanager-async-iterator-current-state①">(2)</a> <a href="#ref-for-sessionmanager-async-iterator-current-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-maplike">
-   <b><a href="#dfn-maplike">#dfn-maplike</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-maplike" class="dfn-panel" data-for="dfn-maplike" id="infopanel-for-dfn-maplike" role="dialog">
+   <span id="infopaneltitle-for-dfn-maplike" style="display:none">Info about the 'maplike' definition.</span><b><a href="#dfn-maplike">#dfn-maplike</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-maplike">2.5.10. Maplike declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-maplike-declaration">
-   <b><a href="#dfn-maplike-declaration">#dfn-maplike-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-maplike-declaration" class="dfn-panel" data-for="dfn-maplike-declaration" id="infopanel-for-dfn-maplike-declaration" role="dialog">
+   <span id="infopaneltitle-for-dfn-maplike-declaration" style="display:none">Info about the 'maplike declaration' definition.</span><b><a href="#dfn-maplike-declaration">#dfn-maplike-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-maplike-declaration">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-maplike-declaration①">2.5. Members</a>
@@ -17561,21 +17562,21 @@ language binding.</p>
     <li><a href="#ref-for-dfn-maplike-declaration②②">3.7.11.7. set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-map-entries">
-   <b><a href="#dfn-map-entries">#dfn-map-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-map-entries" class="dfn-panel" data-for="dfn-map-entries" id="infopanel-for-dfn-map-entries" role="dialog">
+   <span id="infopaneltitle-for-dfn-map-entries" style="display:none">Info about the 'map entries' definition.</span><b><a href="#dfn-map-entries">#dfn-map-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-map-entries">2.5.10. Maplike declarations</a> <a href="#ref-for-dfn-map-entries①">(2)</a>
     <li><a href="#ref-for-dfn-map-entries②">3.7.11. Maplike declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-setlike">
-   <b><a href="#dfn-setlike">#dfn-setlike</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-setlike" class="dfn-panel" data-for="dfn-setlike" id="infopanel-for-dfn-setlike" role="dialog">
+   <span id="infopaneltitle-for-dfn-setlike" style="display:none">Info about the 'setlike' definition.</span><b><a href="#dfn-setlike">#dfn-setlike</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-setlike">2.5.11. Setlike declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-setlike-declaration">
-   <b><a href="#dfn-setlike-declaration">#dfn-setlike-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-setlike-declaration" class="dfn-panel" data-for="dfn-setlike-declaration" id="infopanel-for-dfn-setlike-declaration" role="dialog">
+   <span id="infopaneltitle-for-dfn-setlike-declaration" style="display:none">Info about the 'setlike declaration' definition.</span><b><a href="#dfn-setlike-declaration">#dfn-setlike-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-setlike-declaration">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-setlike-declaration①">2.5. Members</a>
@@ -17591,15 +17592,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-setlike-declaration①⑨">3.7.12.5. add and delete</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-entries">
-   <b><a href="#dfn-set-entries">#dfn-set-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-entries" class="dfn-panel" data-for="dfn-set-entries" id="infopanel-for-dfn-set-entries" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-entries" style="display:none">Info about the 'set entries' definition.</span><b><a href="#dfn-set-entries">#dfn-set-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-entries">2.5.11. Setlike declarations</a> <a href="#ref-for-dfn-set-entries①">(2)</a>
     <li><a href="#ref-for-dfn-set-entries②">3.7.12. Setlike declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-namespace">
-   <b><a href="#dfn-namespace">#dfn-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-namespace" class="dfn-panel" data-for="dfn-namespace" id="infopanel-for-dfn-namespace" role="dialog">
+   <span id="infopaneltitle-for-dfn-namespace" style="display:none">Info about the 'namespace' definition.</span><b><a href="#dfn-namespace">#dfn-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-namespace">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-namespace①">2.1. Names</a> <a href="#ref-for-dfn-namespace②">(2)</a> <a href="#ref-for-dfn-namespace③">(3)</a>
@@ -17623,8 +17624,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-namespace⑤①">3.13.1. Namespace object</a> <a href="#ref-for-dfn-namespace⑤②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-namespace-member">
-   <b><a href="#dfn-namespace-member">#dfn-namespace-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-namespace-member" class="dfn-panel" data-for="dfn-namespace-member" id="infopanel-for-dfn-namespace-member" role="dialog">
+   <span id="infopaneltitle-for-dfn-namespace-member" style="display:none">Info about the 'namespace members' definition.</span><b><a href="#dfn-namespace-member">#dfn-namespace-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-namespace-member">2.5.2. Attributes</a> <a href="#ref-for-dfn-namespace-member①">(2)</a>
     <li><a href="#ref-for-dfn-namespace-member②">2.5.3. Operations</a> <a href="#ref-for-dfn-namespace-member③">(2)</a>
@@ -17634,8 +17635,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-namespace-member①⑤">3.3.12. [SecureContext]</a> <a href="#ref-for-dfn-namespace-member①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-partial-namespace">
-   <b><a href="#dfn-partial-namespace">#dfn-partial-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-partial-namespace" class="dfn-panel" data-for="dfn-partial-namespace" id="infopanel-for-dfn-partial-namespace" role="dialog">
+   <span id="infopaneltitle-for-dfn-partial-namespace" style="display:none">Info about the 'partial namespace' definition.</span><b><a href="#dfn-partial-namespace">#dfn-partial-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-namespace">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-partial-namespace①">2.1. Names</a>
@@ -17644,8 +17645,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-partial-namespace①②">3.3.12. [SecureContext]</a> <a href="#ref-for-dfn-partial-namespace①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dictionary">
-   <b><a href="#dfn-dictionary">#dfn-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dictionary" class="dfn-panel" data-for="dfn-dictionary" id="infopanel-for-dfn-dictionary" role="dialog">
+   <span id="infopaneltitle-for-dfn-dictionary" style="display:none">Info about the 'dictionary' definition.</span><b><a href="#dfn-dictionary">#dfn-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-dictionary①">2.1. Names</a> <a href="#ref-for-dfn-dictionary②">(2)</a> <a href="#ref-for-dfn-dictionary③">(3)</a>
@@ -17657,8 +17658,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary①⓪">3.2.17. Dictionary types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dictionary-member">
-   <b><a href="#dfn-dictionary-member">#dfn-dictionary-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dictionary-member" class="dfn-panel" data-for="dfn-dictionary-member" id="infopanel-for-dfn-dictionary-member" role="dialog">
+   <span id="infopaneltitle-for-dfn-dictionary-member" style="display:none">Info about the 'dictionary members' definition.</span><b><a href="#dfn-dictionary-member">#dfn-dictionary-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary-member">2.1. Names</a> <a href="#ref-for-dfn-dictionary-member①">(2)</a>
     <li><a href="#ref-for-dfn-dictionary-member②">2.5.3. Operations</a>
@@ -17673,22 +17674,22 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary-member②③">3.2.17. Dictionary types</a> <a href="#ref-for-dfn-dictionary-member②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inherit-dictionary">
-   <b><a href="#dfn-inherit-dictionary">#dfn-inherit-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inherit-dictionary" class="dfn-panel" data-for="dfn-inherit-dictionary" id="infopanel-for-dfn-inherit-dictionary" role="dialog">
+   <span id="infopaneltitle-for-dfn-inherit-dictionary" style="display:none">Info about the 'inherit' definition.</span><b><a href="#dfn-inherit-dictionary">#dfn-inherit-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherit-dictionary">2.7. Dictionaries</a> <a href="#ref-for-dfn-inherit-dictionary①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inherited-dictionaries">
-   <b><a href="#dfn-inherited-dictionaries">#dfn-inherited-dictionaries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inherited-dictionaries" class="dfn-panel" data-for="dfn-inherited-dictionaries" id="infopanel-for-dfn-inherited-dictionaries" role="dialog">
+   <span id="infopaneltitle-for-dfn-inherited-dictionaries" style="display:none">Info about the 'inherited dictionaries' definition.</span><b><a href="#dfn-inherited-dictionaries">#dfn-inherited-dictionaries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-dictionaries">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-dfn-inherited-dictionaries①">2.7. Dictionaries</a> <a href="#ref-for-dfn-inherited-dictionaries②">(2)</a> <a href="#ref-for-dfn-inherited-dictionaries③">(3)</a>
     <li><a href="#ref-for-dfn-inherited-dictionaries④">3.2.17. Dictionary types</a> <a href="#ref-for-dfn-inherited-dictionaries⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="required-dictionary-member">
-   <b><a href="#required-dictionary-member">#required-dictionary-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-required-dictionary-member" class="dfn-panel" data-for="required-dictionary-member" id="infopanel-for-required-dictionary-member" role="dialog">
+   <span id="infopaneltitle-for-required-dictionary-member" style="display:none">Info about the 'required' definition.</span><b><a href="#required-dictionary-member">#required-dictionary-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-required-dictionary-member">2.5.3. Operations</a>
     <li><a href="#ref-for-required-dictionary-member①">2.7. Dictionaries</a> <a href="#ref-for-required-dictionary-member②">(2)</a> <a href="#ref-for-required-dictionary-member③">(3)</a> <a href="#ref-for-required-dictionary-member④">(4)</a> <a href="#ref-for-required-dictionary-member⑤">(5)</a> <a href="#ref-for-required-dictionary-member⑥">(6)</a>
@@ -17696,14 +17697,14 @@ language binding.</p>
     <li><a href="#ref-for-required-dictionary-member⑧">3.2.17. Dictionary types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictionary-member-optional">
-   <b><a href="#dictionary-member-optional">#dictionary-member-optional</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictionary-member-optional" class="dfn-panel" data-for="dictionary-member-optional" id="infopanel-for-dictionary-member-optional" role="dialog">
+   <span id="infopaneltitle-for-dictionary-member-optional" style="display:none">Info about the 'optional' definition.</span><b><a href="#dictionary-member-optional">#dictionary-member-optional</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictionary-member-optional">2.7. Dictionaries</a> <a href="#ref-for-dictionary-member-optional①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dictionary-member-default-value">
-   <b><a href="#dfn-dictionary-member-default-value">#dfn-dictionary-member-default-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dictionary-member-default-value" class="dfn-panel" data-for="dfn-dictionary-member-default-value" id="infopanel-for-dfn-dictionary-member-default-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-dictionary-member-default-value" style="display:none">Info about the 'default value' definition.</span><b><a href="#dfn-dictionary-member-default-value">#dfn-dictionary-member-default-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary-member-default-value">2.5.1. Constants</a>
     <li><a href="#ref-for-dfn-dictionary-member-default-value①">2.7. Dictionaries</a> <a href="#ref-for-dfn-dictionary-member-default-value②">(2)</a> <a href="#ref-for-dfn-dictionary-member-default-value③">(3)</a> <a href="#ref-for-dfn-dictionary-member-default-value④">(4)</a> <a href="#ref-for-dfn-dictionary-member-default-value⑤">(5)</a> <a href="#ref-for-dfn-dictionary-member-default-value⑥">(6)</a> <a href="#ref-for-dfn-dictionary-member-default-value⑦">(7)</a> <a href="#ref-for-dfn-dictionary-member-default-value⑧">(8)</a>
@@ -17714,44 +17715,44 @@ language binding.</p>
     <li><a href="#ref-for-dfn-dictionary-member-default-value①③">3.2.17. Dictionary types</a> <a href="#ref-for-dfn-dictionary-member-default-value①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-partial-dictionary">
-   <b><a href="#dfn-partial-dictionary">#dfn-partial-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-partial-dictionary" class="dfn-panel" data-for="dfn-partial-dictionary" id="infopanel-for-dfn-partial-dictionary" role="dialog">
+   <span id="infopaneltitle-for-dfn-partial-dictionary" style="display:none">Info about the 'partial dictionary' definition.</span><b><a href="#dfn-partial-dictionary">#dfn-partial-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-dictionary">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-partial-dictionary①">2.1. Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-exception">
-   <b><a href="#dfn-exception">#dfn-exception</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-exception" class="dfn-panel" data-for="dfn-exception" id="infopanel-for-dfn-exception" role="dialog">
+   <span id="infopaneltitle-for-dfn-exception" style="display:none">Info about the 'exception' definition.</span><b><a href="#dfn-exception">#dfn-exception</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">3.14.4. Handling exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-exception-error-name">
-   <b><a href="#dfn-exception-error-name">#dfn-exception-error-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-exception-error-name" class="dfn-panel" data-for="dfn-exception-error-name" id="infopanel-for-dfn-exception-error-name" role="dialog">
+   <span id="infopaneltitle-for-dfn-exception-error-name" style="display:none">Info about the 'error name' definition.</span><b><a href="#dfn-exception-error-name">#dfn-exception-error-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception-error-name">2.8. Exceptions</a> <a href="#ref-for-dfn-exception-error-name①">(2)</a> <a href="#ref-for-dfn-exception-error-name②">(3)</a> <a href="#ref-for-dfn-exception-error-name③">(4)</a> <a href="#ref-for-dfn-exception-error-name④">(5)</a> <a href="#ref-for-dfn-exception-error-name⑤">(6)</a>
     <li><a href="#ref-for-dfn-exception-error-name⑥">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-dfn-exception-error-name⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-simple-exception">
-   <b><a href="#dfn-simple-exception">#dfn-simple-exception</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-simple-exception" class="dfn-panel" data-for="dfn-simple-exception" id="infopanel-for-dfn-simple-exception" role="dialog">
+   <span id="infopaneltitle-for-dfn-simple-exception" style="display:none">Info about the 'simple exception' definition.</span><b><a href="#dfn-simple-exception">#dfn-simple-exception</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-simple-exception">2.8. Exceptions</a> <a href="#ref-for-dfn-simple-exception①">(2)</a> <a href="#ref-for-dfn-simple-exception②">(3)</a> <a href="#ref-for-dfn-simple-exception③">(4)</a>
     <li><a href="#ref-for-dfn-simple-exception④">3.14.2. Exception objects</a>
     <li><a href="#ref-for-dfn-simple-exception⑤">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-dfn-simple-exception⑥">(2)</a> <a href="#ref-for-dfn-simple-exception⑦">(3)</a> <a href="#ref-for-dfn-simple-exception⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exceptiondef-rangeerror">
-   <b><a href="#exceptiondef-rangeerror">#exceptiondef-rangeerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exceptiondef-rangeerror" class="dfn-panel" data-for="exceptiondef-rangeerror" id="infopanel-for-exceptiondef-rangeerror" role="dialog">
+   <span id="infopaneltitle-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' definition.</span><b><a href="#exceptiondef-rangeerror">#exceptiondef-rangeerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">2.8.1. Error names</a>
     <li><a href="#ref-for-exceptiondef-rangeerror①">3.2.23.2. Examples</a>
     <li><a href="#ref-for-exceptiondef-rangeerror②">3.10.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exceptiondef-typeerror">
-   <b><a href="#exceptiondef-typeerror">#exceptiondef-typeerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exceptiondef-typeerror" class="dfn-panel" data-for="exceptiondef-typeerror" id="infopanel-for-exceptiondef-typeerror" role="dialog">
+   <span id="infopaneltitle-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' definition.</span><b><a href="#exceptiondef-typeerror">#exceptiondef-typeerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2.5.4. Constructor operations</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">2.5.7.1. Overloading vs. union types</a>
@@ -17760,208 +17761,208 @@ language binding.</p>
     <li><a href="#ref-for-exceptiondef-typeerror⑥">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-create-exception">
-   <b><a href="#dfn-create-exception">#dfn-create-exception</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-create-exception" class="dfn-panel" data-for="dfn-create-exception" id="infopanel-for-dfn-create-exception" role="dialog">
+   <span id="infopaneltitle-for-dfn-create-exception" style="display:none">Info about the 'created' definition.</span><b><a href="#dfn-create-exception">#dfn-create-exception</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">2.8. Exceptions</a> <a href="#ref-for-dfn-create-exception①">(2)</a> <a href="#ref-for-dfn-create-exception②">(3)</a>
     <li><a href="#ref-for-dfn-create-exception③">3.14.3. Creating and throwing exceptions</a> <a href="#ref-for-dfn-create-exception④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-throw">
-   <b><a href="#dfn-throw">#dfn-throw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-throw" class="dfn-panel" data-for="dfn-throw" id="infopanel-for-dfn-throw" role="dialog">
+   <span id="infopaneltitle-for-dfn-throw" style="display:none">Info about the 'thrown' definition.</span><b><a href="#dfn-throw">#dfn-throw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">2.8. Exceptions</a> <a href="#ref-for-dfn-throw①">(2)</a>
     <li><a href="#ref-for-dfn-throw②">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-error-names-table">
-   <b><a href="#dfn-error-names-table">#dfn-error-names-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-error-names-table" class="dfn-panel" data-for="dfn-error-names-table" id="infopanel-for-dfn-error-names-table" role="dialog">
+   <span id="infopaneltitle-for-dfn-error-names-table" style="display:none">Info about the 'error names table' definition.</span><b><a href="#dfn-error-names-table">#dfn-error-names-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-names-table">2.8. Exceptions</a>
     <li><a href="#ref-for-dfn-error-names-table①">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-index_size_err">
-   <b><a href="#dom-domexception-index_size_err">#dom-domexception-index_size_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-index_size_err" class="dfn-panel" data-for="dom-domexception-index_size_err" id="infopanel-for-dom-domexception-index_size_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-index_size_err" style="display:none">Info about the 'INDEX_SIZE_ERR' definition.</span><b><a href="#dom-domexception-index_size_err">#dom-domexception-index_size_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-index_size_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-hierarchy_request_err">
-   <b><a href="#dom-domexception-hierarchy_request_err">#dom-domexception-hierarchy_request_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-hierarchy_request_err" class="dfn-panel" data-for="dom-domexception-hierarchy_request_err" id="infopanel-for-dom-domexception-hierarchy_request_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-hierarchy_request_err" style="display:none">Info about the 'HIERARCHY_REQUEST_ERR' definition.</span><b><a href="#dom-domexception-hierarchy_request_err">#dom-domexception-hierarchy_request_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-hierarchy_request_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-wrong_document_err">
-   <b><a href="#dom-domexception-wrong_document_err">#dom-domexception-wrong_document_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-wrong_document_err" class="dfn-panel" data-for="dom-domexception-wrong_document_err" id="infopanel-for-dom-domexception-wrong_document_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-wrong_document_err" style="display:none">Info about the 'WRONG_DOCUMENT_ERR' definition.</span><b><a href="#dom-domexception-wrong_document_err">#dom-domexception-wrong_document_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-wrong_document_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-invalid_character_err">
-   <b><a href="#dom-domexception-invalid_character_err">#dom-domexception-invalid_character_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-invalid_character_err" class="dfn-panel" data-for="dom-domexception-invalid_character_err" id="infopanel-for-dom-domexception-invalid_character_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-invalid_character_err" style="display:none">Info about the 'INVALID_CHARACTER_ERR' definition.</span><b><a href="#dom-domexception-invalid_character_err">#dom-domexception-invalid_character_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-invalid_character_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-no_modification_allowed_err">
-   <b><a href="#dom-domexception-no_modification_allowed_err">#dom-domexception-no_modification_allowed_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-no_modification_allowed_err" class="dfn-panel" data-for="dom-domexception-no_modification_allowed_err" id="infopanel-for-dom-domexception-no_modification_allowed_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-no_modification_allowed_err" style="display:none">Info about the 'NO_MODIFICATION_ALLOWED_ERR' definition.</span><b><a href="#dom-domexception-no_modification_allowed_err">#dom-domexception-no_modification_allowed_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-no_modification_allowed_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-not_found_err">
-   <b><a href="#dom-domexception-not_found_err">#dom-domexception-not_found_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-not_found_err" class="dfn-panel" data-for="dom-domexception-not_found_err" id="infopanel-for-dom-domexception-not_found_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-not_found_err" style="display:none">Info about the 'NOT_FOUND_ERR' definition.</span><b><a href="#dom-domexception-not_found_err">#dom-domexception-not_found_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-not_found_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notsupportederror">
-   <b><a href="#notsupportederror">#notsupportederror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notsupportederror" class="dfn-panel" data-for="notsupportederror" id="infopanel-for-notsupportederror" role="dialog">
+   <span id="infopaneltitle-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' definition.</span><b><a href="#notsupportederror">#notsupportederror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">2.8.1. Error names</a>
     <li><a href="#ref-for-notsupportederror①">3.2.23.2. Examples</a>
     <li><a href="#ref-for-notsupportederror">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-not_supported_err">
-   <b><a href="#dom-domexception-not_supported_err">#dom-domexception-not_supported_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-not_supported_err" class="dfn-panel" data-for="dom-domexception-not_supported_err" id="infopanel-for-dom-domexception-not_supported_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-not_supported_err" style="display:none">Info about the 'NOT_SUPPORTED_ERR' definition.</span><b><a href="#dom-domexception-not_supported_err">#dom-domexception-not_supported_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-not_supported_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-inuse_attribute_err">
-   <b><a href="#dom-domexception-inuse_attribute_err">#dom-domexception-inuse_attribute_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-inuse_attribute_err" class="dfn-panel" data-for="dom-domexception-inuse_attribute_err" id="infopanel-for-dom-domexception-inuse_attribute_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-inuse_attribute_err" style="display:none">Info about the 'INUSE_ATTRIBUTE_ERR' definition.</span><b><a href="#dom-domexception-inuse_attribute_err">#dom-domexception-inuse_attribute_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-inuse_attribute_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-invalid_state_err">
-   <b><a href="#dom-domexception-invalid_state_err">#dom-domexception-invalid_state_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-invalid_state_err" class="dfn-panel" data-for="dom-domexception-invalid_state_err" id="infopanel-for-dom-domexception-invalid_state_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-invalid_state_err" style="display:none">Info about the 'INVALID_STATE_ERR' definition.</span><b><a href="#dom-domexception-invalid_state_err">#dom-domexception-invalid_state_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-invalid_state_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syntaxerror">
-   <b><a href="#syntaxerror">#syntaxerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syntaxerror" class="dfn-panel" data-for="syntaxerror" id="infopanel-for-syntaxerror" role="dialog">
+   <span id="infopaneltitle-for-syntaxerror" style="display:none">Info about the 'SyntaxError' definition.</span><b><a href="#syntaxerror">#syntaxerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">2.8. Exceptions</a> <a href="#ref-for-syntaxerror①">(2)</a>
     <li><a href="#ref-for-syntaxerror②">2.8.1. Error names</a> <a href="#ref-for-syntaxerror③">(2)</a> <a href="#ref-for-syntaxerror④">(3)</a> <a href="#ref-for-syntaxerror⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-syntax_err">
-   <b><a href="#dom-domexception-syntax_err">#dom-domexception-syntax_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-syntax_err" class="dfn-panel" data-for="dom-domexception-syntax_err" id="infopanel-for-dom-domexception-syntax_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-syntax_err" style="display:none">Info about the 'SYNTAX_ERR' definition.</span><b><a href="#dom-domexception-syntax_err">#dom-domexception-syntax_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-syntax_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-invalid_modification_err">
-   <b><a href="#dom-domexception-invalid_modification_err">#dom-domexception-invalid_modification_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-invalid_modification_err" class="dfn-panel" data-for="dom-domexception-invalid_modification_err" id="infopanel-for-dom-domexception-invalid_modification_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-invalid_modification_err" style="display:none">Info about the 'INVALID_MODIFICATION_ERR' definition.</span><b><a href="#dom-domexception-invalid_modification_err">#dom-domexception-invalid_modification_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-invalid_modification_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-namespace_err">
-   <b><a href="#dom-domexception-namespace_err">#dom-domexception-namespace_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-namespace_err" class="dfn-panel" data-for="dom-domexception-namespace_err" id="infopanel-for-dom-domexception-namespace_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-namespace_err" style="display:none">Info about the 'NAMESPACE_ERR' definition.</span><b><a href="#dom-domexception-namespace_err">#dom-domexception-namespace_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-namespace_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-invalid_access_err">
-   <b><a href="#dom-domexception-invalid_access_err">#dom-domexception-invalid_access_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-invalid_access_err" class="dfn-panel" data-for="dom-domexception-invalid_access_err" id="infopanel-for-dom-domexception-invalid_access_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-invalid_access_err" style="display:none">Info about the 'INVALID_ACCESS_ERR' definition.</span><b><a href="#dom-domexception-invalid_access_err">#dom-domexception-invalid_access_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-invalid_access_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-type_mismatch_err">
-   <b><a href="#dom-domexception-type_mismatch_err">#dom-domexception-type_mismatch_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-type_mismatch_err" class="dfn-panel" data-for="dom-domexception-type_mismatch_err" id="infopanel-for-dom-domexception-type_mismatch_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-type_mismatch_err" style="display:none">Info about the 'TYPE_MISMATCH_ERR' definition.</span><b><a href="#dom-domexception-type_mismatch_err">#dom-domexception-type_mismatch_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-type_mismatch_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="securityerror">
-   <b><a href="#securityerror">#securityerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-securityerror" class="dfn-panel" data-for="securityerror" id="infopanel-for-securityerror" role="dialog">
+   <span id="infopaneltitle-for-securityerror" style="display:none">Info about the 'SecurityError' definition.</span><b><a href="#securityerror">#securityerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-security_err">
-   <b><a href="#dom-domexception-security_err">#dom-domexception-security_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-security_err" class="dfn-panel" data-for="dom-domexception-security_err" id="infopanel-for-dom-domexception-security_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-security_err" style="display:none">Info about the 'SECURITY_ERR' definition.</span><b><a href="#dom-domexception-security_err">#dom-domexception-security_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-security_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="networkerror">
-   <b><a href="#networkerror">#networkerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-networkerror" class="dfn-panel" data-for="networkerror" id="infopanel-for-networkerror" role="dialog">
+   <span id="infopaneltitle-for-networkerror" style="display:none">Info about the 'NetworkError' definition.</span><b><a href="#networkerror">#networkerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-network_err">
-   <b><a href="#dom-domexception-network_err">#dom-domexception-network_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-network_err" class="dfn-panel" data-for="dom-domexception-network_err" id="infopanel-for-dom-domexception-network_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-network_err" style="display:none">Info about the 'NETWORK_ERR' definition.</span><b><a href="#dom-domexception-network_err">#dom-domexception-network_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-network_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="aborterror">
-   <b><a href="#aborterror">#aborterror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aborterror" class="dfn-panel" data-for="aborterror" id="infopanel-for-aborterror" role="dialog">
+   <span id="infopaneltitle-for-aborterror" style="display:none">Info about the 'AbortError' definition.</span><b><a href="#aborterror">#aborterror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-abort_err">
-   <b><a href="#dom-domexception-abort_err">#dom-domexception-abort_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-abort_err" class="dfn-panel" data-for="dom-domexception-abort_err" id="infopanel-for-dom-domexception-abort_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-abort_err" style="display:none">Info about the 'ABORT_ERR' definition.</span><b><a href="#dom-domexception-abort_err">#dom-domexception-abort_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-abort_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-url_mismatch_err">
-   <b><a href="#dom-domexception-url_mismatch_err">#dom-domexception-url_mismatch_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-url_mismatch_err" class="dfn-panel" data-for="dom-domexception-url_mismatch_err" id="infopanel-for-dom-domexception-url_mismatch_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-url_mismatch_err" style="display:none">Info about the 'URL_MISMATCH_ERR' definition.</span><b><a href="#dom-domexception-url_mismatch_err">#dom-domexception-url_mismatch_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-url_mismatch_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quotaexceedederror">
-   <b><a href="#quotaexceedederror">#quotaexceedederror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quotaexceedederror" class="dfn-panel" data-for="quotaexceedederror" id="infopanel-for-quotaexceedederror" role="dialog">
+   <span id="infopaneltitle-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' definition.</span><b><a href="#quotaexceedederror">#quotaexceedederror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">2.13.35. Observable array types — ObservableArray&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-quota_exceeded_err">
-   <b><a href="#dom-domexception-quota_exceeded_err">#dom-domexception-quota_exceeded_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-quota_exceeded_err" class="dfn-panel" data-for="dom-domexception-quota_exceeded_err" id="infopanel-for-dom-domexception-quota_exceeded_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-quota_exceeded_err" style="display:none">Info about the 'QUOTA_EXCEEDED_ERR' definition.</span><b><a href="#dom-domexception-quota_exceeded_err">#dom-domexception-quota_exceeded_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-quota_exceeded_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-timeout_err">
-   <b><a href="#dom-domexception-timeout_err">#dom-domexception-timeout_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-timeout_err" class="dfn-panel" data-for="dom-domexception-timeout_err" id="infopanel-for-dom-domexception-timeout_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-timeout_err" style="display:none">Info about the 'TIMEOUT_ERR' definition.</span><b><a href="#dom-domexception-timeout_err">#dom-domexception-timeout_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-timeout_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-invalid_node_type_err">
-   <b><a href="#dom-domexception-invalid_node_type_err">#dom-domexception-invalid_node_type_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-invalid_node_type_err" class="dfn-panel" data-for="dom-domexception-invalid_node_type_err" id="infopanel-for-dom-domexception-invalid_node_type_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-invalid_node_type_err" style="display:none">Info about the 'INVALID_NODE_TYPE_ERR' definition.</span><b><a href="#dom-domexception-invalid_node_type_err">#dom-domexception-invalid_node_type_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-invalid_node_type_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-data_clone_err">
-   <b><a href="#dom-domexception-data_clone_err">#dom-domexception-data_clone_err</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-data_clone_err" class="dfn-panel" data-for="dom-domexception-data_clone_err" id="infopanel-for-dom-domexception-data_clone_err" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-data_clone_err" style="display:none">Info about the 'DATA_CLONE_ERR' definition.</span><b><a href="#dom-domexception-data_clone_err">#dom-domexception-data_clone_err</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-data_clone_err">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notallowederror">
-   <b><a href="#notallowederror">#notallowederror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notallowederror" class="dfn-panel" data-for="notallowederror" id="infopanel-for-notallowederror" role="dialog">
+   <span id="infopaneltitle-for-notallowederror" style="display:none">Info about the 'NotAllowedError' definition.</span><b><a href="#notallowederror">#notallowederror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">2.8. Exceptions</a> <a href="#ref-for-notallowederror①">(2)</a>
     <li><a href="#ref-for-notallowederror②">2.8.1. Error names</a>
     <li><a href="#ref-for-notallowederror③">2.13.35. Observable array types — ObservableArray&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-enumeration">
-   <b><a href="#dfn-enumeration">#dfn-enumeration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-enumeration" class="dfn-panel" data-for="dfn-enumeration" id="infopanel-for-dfn-enumeration" role="dialog">
+   <span id="infopaneltitle-for-dfn-enumeration" style="display:none">Info about the 'enumeration' definition.</span><b><a href="#dfn-enumeration">#dfn-enumeration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-enumeration">2.1. Names</a> <a href="#ref-for-dfn-enumeration①">(2)</a> <a href="#ref-for-dfn-enumeration②">(3)</a>
     <li><a href="#ref-for-dfn-enumeration③">2.5.2. Attributes</a>
@@ -17973,8 +17974,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-enumeration①⑧">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-enumeration-value">
-   <b><a href="#dfn-enumeration-value">#dfn-enumeration-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-enumeration-value" class="dfn-panel" data-for="dfn-enumeration-value" id="infopanel-for-dfn-enumeration-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-enumeration-value" style="display:none">Info about the 'enumeration values' definition.</span><b><a href="#dfn-enumeration-value">#dfn-enumeration-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-enumeration-value">2.5.3. Operations</a>
     <li><a href="#ref-for-dfn-enumeration-value①">2.7. Dictionaries</a>
@@ -17984,8 +17985,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-enumeration-value⑥">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-callback-function">
-   <b><a href="#dfn-callback-function">#dfn-callback-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-callback-function" class="dfn-panel" data-for="dfn-callback-function" id="infopanel-for-dfn-callback-function" role="dialog">
+   <span id="infopaneltitle-for-dfn-callback-function" style="display:none">Info about the 'callback function' definition.</span><b><a href="#dfn-callback-function">#dfn-callback-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-callback-function①">2.1. Names</a> <a href="#ref-for-dfn-callback-function②">(2)</a> <a href="#ref-for-dfn-callback-function③">(3)</a>
@@ -18007,8 +18008,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-function③②">4.6. VoidFunction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-typedef">
-   <b><a href="#dfn-typedef">#dfn-typedef</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-typedef" class="dfn-panel" data-for="dfn-typedef" id="infopanel-for-dfn-typedef" role="dialog">
+   <span id="infopaneltitle-for-dfn-typedef" style="display:none">Info about the 'typedef' definition.</span><b><a href="#dfn-typedef">#dfn-typedef</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-typedef">2. Interface definition language</a>
     <li><a href="#ref-for-dfn-typedef①">2.1. Names</a> <a href="#ref-for-dfn-typedef②">(2)</a> <a href="#ref-for-dfn-typedef③">(3)</a> <a href="#ref-for-dfn-typedef④">(4)</a>
@@ -18022,15 +18023,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-typedef①⑤">2.13.32. Annotated types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="type-being-given-a-new-name">
-   <b><a href="#type-being-given-a-new-name">#type-being-given-a-new-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-type-being-given-a-new-name" class="dfn-panel" data-for="type-being-given-a-new-name" id="infopanel-for-type-being-given-a-new-name" role="dialog">
+   <span id="infopaneltitle-for-type-being-given-a-new-name" style="display:none">Info about the 'type being given a new name' definition.</span><b><a href="#type-being-given-a-new-name">#type-being-given-a-new-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-being-given-a-new-name">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-type-being-given-a-new-name①">2.13.32. Annotated types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-platform-object">
-   <b><a href="#dfn-platform-object">#dfn-platform-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-platform-object" class="dfn-panel" data-for="dfn-platform-object" id="infopanel-for-dfn-platform-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-platform-object" style="display:none">Info about the 'Platform objects' definition.</span><b><a href="#dfn-platform-object">#dfn-platform-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object">2.5.5.2. Indexed properties</a>
     <li><a href="#ref-for-dfn-platform-object①">2.5.5.3. Named properties</a>
@@ -18052,8 +18053,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-platform-object③②">3.14.2. Exception objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-legacy-platform-object">
-   <b><a href="#dfn-legacy-platform-object">#dfn-legacy-platform-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-legacy-platform-object" class="dfn-panel" data-for="dfn-legacy-platform-object" id="infopanel-for-dfn-legacy-platform-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-legacy-platform-object" style="display:none">Info about the 'Legacy platform objects' definition.</span><b><a href="#dfn-legacy-platform-object">#dfn-legacy-platform-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-legacy-platform-object">2.5.5.2. Indexed properties</a>
     <li><a href="#ref-for-dfn-legacy-platform-object①">3.4.7. [LegacyOverrideBuiltIns]</a>
@@ -18066,8 +18067,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-legacy-platform-object①⓪">3.9.6. [[OwnPropertyKeys]]</a> <a href="#ref-for-dfn-legacy-platform-object①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-integer-type">
-   <b><a href="#dfn-integer-type">#dfn-integer-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-integer-type" class="dfn-panel" data-for="dfn-integer-type" id="infopanel-for-dfn-integer-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-integer-type" style="display:none">Info about the 'integer types' definition.</span><b><a href="#dfn-integer-type">#dfn-integer-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-integer-type">2.5.5.2. Indexed properties</a>
     <li><a href="#ref-for-dfn-integer-type①">2.13. Types</a>
@@ -18075,8 +18076,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-integer-type④">3.3.5. [EnforceRange]</a> <a href="#ref-for-dfn-integer-type⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-numeric-type">
-   <b><a href="#dfn-numeric-type">#dfn-numeric-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-numeric-type" class="dfn-panel" data-for="dfn-numeric-type" id="infopanel-for-dfn-numeric-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-numeric-type" style="display:none">Info about the 'numeric types' definition.</span><b><a href="#dfn-numeric-type">#dfn-numeric-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-numeric-type">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-dfn-numeric-type①">2.5.7. Overloading</a> <a href="#ref-for-dfn-numeric-type②">(2)</a> <a href="#ref-for-dfn-numeric-type③">(3)</a> <a href="#ref-for-dfn-numeric-type④">(4)</a> <a href="#ref-for-dfn-numeric-type⑤">(5)</a>
@@ -18087,14 +18088,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-numeric-type①⑥">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-numeric-type①⑦">(2)</a> <a href="#ref-for-dfn-numeric-type①⑧">(3)</a> <a href="#ref-for-dfn-numeric-type①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-primitive-type">
-   <b><a href="#dfn-primitive-type">#dfn-primitive-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-primitive-type" class="dfn-panel" data-for="dfn-primitive-type" id="infopanel-for-dfn-primitive-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-primitive-type" style="display:none">Info about the 'primitive types' definition.</span><b><a href="#dfn-primitive-type">#dfn-primitive-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-primitive-type">2.5.1. Constants</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-string-type">
-   <b><a href="#dfn-string-type">#dfn-string-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-string-type" class="dfn-panel" data-for="dfn-string-type" id="infopanel-for-dfn-string-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-string-type" style="display:none">Info about the 'string types' definition.</span><b><a href="#dfn-string-type">#dfn-string-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-string-type">2.5.3. Operations</a>
     <li><a href="#ref-for-dfn-string-type①">2.5.3.1. toJSON</a>
@@ -18103,16 +18104,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-string-type④">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-typed-array-type">
-   <b><a href="#dfn-typed-array-type">#dfn-typed-array-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-typed-array-type" class="dfn-panel" data-for="dfn-typed-array-type" id="infopanel-for-dfn-typed-array-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-typed-array-type" style="display:none">Info about the 'typed array types' definition.</span><b><a href="#dfn-typed-array-type">#dfn-typed-array-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-typed-array-type">2.13. Types</a>
     <li><a href="#ref-for-dfn-typed-array-type①">3.2.24. Union types</a>
     <li><a href="#ref-for-dfn-typed-array-type②">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-buffer-source-type">
-   <b><a href="#dfn-buffer-source-type">#dfn-buffer-source-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-buffer-source-type" class="dfn-panel" data-for="dfn-buffer-source-type" id="infopanel-for-dfn-buffer-source-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-buffer-source-type" style="display:none">Info about the 'buffer source types' definition.</span><b><a href="#dfn-buffer-source-type">#dfn-buffer-source-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-buffer-source-type">2.5.7. Overloading</a>
     <li><a href="#ref-for-dfn-buffer-source-type①">2.13.33. Buffer source types</a>
@@ -18120,8 +18121,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-buffer-source-type④">3.3.1. [AllowShared]</a> <a href="#ref-for-dfn-buffer-source-type⑤">(2)</a> <a href="#ref-for-dfn-buffer-source-type⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type-name">
-   <b><a href="#dfn-type-name">#dfn-type-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type-name" class="dfn-panel" data-for="dfn-type-name" id="infopanel-for-dfn-type-name" role="dialog">
+   <span id="infopaneltitle-for-dfn-type-name" style="display:none">Info about the 'type name' definition.</span><b><a href="#dfn-type-name">#dfn-type-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type-name">2.13.1. any</a>
     <li><a href="#ref-for-dfn-type-name①">2.13.2. undefined</a>
@@ -18161,8 +18162,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-type-name③⑥">3.2.25. Buffer source types</a> <a href="#ref-for-dfn-type-name③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-any">
-   <b><a href="#idl-any">#idl-any</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-any" class="dfn-panel" data-for="idl-any" id="infopanel-for-idl-any" role="dialog">
+   <span id="infopaneltitle-for-idl-any" style="display:none">Info about the '2.13.1. any' definition.</span><b><a href="#idl-any">#idl-any</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2.5.9. Asynchronously iterable declarations</a>
     <li><a href="#ref-for-idl-any">2.13.1. any</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a> <a href="#ref-for-idl-any③">(4)</a> <a href="#ref-for-idl-any④">(5)</a> <a href="#ref-for-idl-any⑤">(6)</a>
@@ -18174,8 +18175,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-any①⑧">8. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-specific-type">
-   <b><a href="#dfn-specific-type">#dfn-specific-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-specific-type" class="dfn-panel" data-for="dfn-specific-type" id="infopanel-for-dfn-specific-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-specific-type" style="display:none">Info about the 'specific type' definition.</span><b><a href="#dfn-specific-type">#dfn-specific-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-specific-type">2.13.1. any</a>
     <li><a href="#ref-for-dfn-specific-type①">2.13.31. Union types</a>
@@ -18183,8 +18184,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-specific-type③">3.2.24. Union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-undefined">
-   <b><a href="#idl-undefined">#idl-undefined</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-undefined" class="dfn-panel" data-for="idl-undefined" id="infopanel-for-idl-undefined" role="dialog">
+   <span id="infopaneltitle-for-idl-undefined" style="display:none">Info about the '2.13.2. undefined' definition.</span><b><a href="#idl-undefined">#idl-undefined</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.13.2. undefined</a> <a href="#ref-for-idl-undefined">(2)</a> <a href="#ref-for-idl-undefined①">(3)</a> <a href="#ref-for-idl-undefined②">(4)</a> <a href="#ref-for-idl-undefined③">(5)</a>
     <li><a href="#ref-for-idl-undefined④">3.2.2. undefined</a> <a href="#ref-for-idl-undefined⑤">(2)</a> <a href="#ref-for-idl-undefined⑥">(3)</a>
@@ -18193,8 +18194,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-undefined①①">4.6. VoidFunction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-boolean">
-   <b><a href="#idl-boolean">#idl-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-boolean" class="dfn-panel" data-for="idl-boolean" id="infopanel-for-idl-boolean" role="dialog">
+   <span id="infopaneltitle-for-idl-boolean" style="display:none">Info about the '2.13.3. boolean' definition.</span><b><a href="#idl-boolean">#idl-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.5.1. Constants</a>
     <li><a href="#ref-for-idl-boolean①">2.5.3. Operations</a>
@@ -18209,8 +18210,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-boolean②①">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-byte">
-   <b><a href="#idl-byte">#idl-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-byte" class="dfn-panel" data-for="idl-byte" id="infopanel-for-idl-byte" role="dialog">
+   <span id="infopaneltitle-for-idl-byte" style="display:none">Info about the '2.13.4. byte' definition.</span><b><a href="#idl-byte">#idl-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-byte">2.13. Types</a>
     <li><a href="#ref-for-idl-byte">2.13.4. byte</a> <a href="#ref-for-idl-byte①">(2)</a> <a href="#ref-for-idl-byte②">(3)</a> <a href="#ref-for-idl-byte③">(4)</a>
@@ -18218,8 +18219,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-byte⑤">3.2.4.1. byte</a> <a href="#ref-for-idl-byte⑥">(2)</a> <a href="#ref-for-idl-byte⑦">(3)</a> <a href="#ref-for-idl-byte⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-octet">
-   <b><a href="#idl-octet">#idl-octet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-octet" class="dfn-panel" data-for="idl-octet" id="infopanel-for-idl-octet" role="dialog">
+   <span id="infopaneltitle-for-idl-octet" style="display:none">Info about the '2.13.5. octet' definition.</span><b><a href="#idl-octet">#idl-octet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-octet">2.13. Types</a>
     <li><a href="#ref-for-idl-octet">2.13.5. octet</a> <a href="#ref-for-idl-octet①">(2)</a> <a href="#ref-for-idl-octet②">(3)</a> <a href="#ref-for-idl-octet③">(4)</a>
@@ -18229,16 +18230,16 @@ language binding.</p>
     <li><a href="#ref-for-idl-octet①①">3.3.5. [EnforceRange]</a> <a href="#ref-for-idl-octet①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-short">
-   <b><a href="#idl-short">#idl-short</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-short" class="dfn-panel" data-for="idl-short" id="infopanel-for-idl-short" role="dialog">
+   <span id="infopaneltitle-for-idl-short" style="display:none">Info about the '2.13.6. short' definition.</span><b><a href="#idl-short">#idl-short</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">2.13. Types</a>
     <li><a href="#ref-for-idl-short">2.13.6. short</a> <a href="#ref-for-idl-short①">(2)</a> <a href="#ref-for-idl-short②">(3)</a> <a href="#ref-for-idl-short③">(4)</a>
     <li><a href="#ref-for-idl-short④">3.2.4.3. short</a> <a href="#ref-for-idl-short⑤">(2)</a> <a href="#ref-for-idl-short⑥">(3)</a> <a href="#ref-for-idl-short⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-unsigned-short">
-   <b><a href="#idl-unsigned-short">#idl-unsigned-short</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-unsigned-short" class="dfn-panel" data-for="idl-unsigned-short" id="infopanel-for-idl-unsigned-short" role="dialog">
+   <span id="infopaneltitle-for-idl-unsigned-short" style="display:none">Info about the '2.13.7. unsigned short' definition.</span><b><a href="#idl-unsigned-short">#idl-unsigned-short</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">2.13. Types</a>
     <li><a href="#ref-for-idl-unsigned-short">2.13.7. unsigned short</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a> <a href="#ref-for-idl-unsigned-short③">(4)</a>
@@ -18247,8 +18248,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-unsigned-short⑨">4.3. DOMException</a> <a href="#ref-for-idl-unsigned-short①⓪">(2)</a> <a href="#ref-for-idl-unsigned-short①①">(3)</a> <a href="#ref-for-idl-unsigned-short①②">(4)</a> <a href="#ref-for-idl-unsigned-short①③">(5)</a> <a href="#ref-for-idl-unsigned-short①④">(6)</a> <a href="#ref-for-idl-unsigned-short①⑤">(7)</a> <a href="#ref-for-idl-unsigned-short①⑥">(8)</a> <a href="#ref-for-idl-unsigned-short①⑦">(9)</a> <a href="#ref-for-idl-unsigned-short①⑧">(10)</a> <a href="#ref-for-idl-unsigned-short①⑨">(11)</a> <a href="#ref-for-idl-unsigned-short②⓪">(12)</a> <a href="#ref-for-idl-unsigned-short②①">(13)</a> <a href="#ref-for-idl-unsigned-short②②">(14)</a> <a href="#ref-for-idl-unsigned-short②③">(15)</a> <a href="#ref-for-idl-unsigned-short②④">(16)</a> <a href="#ref-for-idl-unsigned-short②⑤">(17)</a> <a href="#ref-for-idl-unsigned-short②⑥">(18)</a> <a href="#ref-for-idl-unsigned-short②⑦">(19)</a> <a href="#ref-for-idl-unsigned-short②⑧">(20)</a> <a href="#ref-for-idl-unsigned-short②⑨">(21)</a> <a href="#ref-for-idl-unsigned-short③⓪">(22)</a> <a href="#ref-for-idl-unsigned-short③①">(23)</a> <a href="#ref-for-idl-unsigned-short③②">(24)</a> <a href="#ref-for-idl-unsigned-short③③">(25)</a> <a href="#ref-for-idl-unsigned-short③④">(26)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-long">
-   <b><a href="#idl-long">#idl-long</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-long" class="dfn-panel" data-for="idl-long" id="infopanel-for-idl-long" role="dialog">
+   <span id="infopaneltitle-for-idl-long" style="display:none">Info about the '2.13.8. long' definition.</span><b><a href="#idl-long">#idl-long</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">2.5.7. Overloading</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a> <a href="#ref-for-idl-long④">(5)</a> <a href="#ref-for-idl-long⑤">(6)</a>
     <li><a href="#ref-for-idl-long⑥">2.5.7.1. Overloading vs. union types</a>
@@ -18259,8 +18260,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-long①③">3.2.4.5. long</a> <a href="#ref-for-idl-long①④">(2)</a> <a href="#ref-for-idl-long①⑤">(3)</a> <a href="#ref-for-idl-long①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-unsigned-long">
-   <b><a href="#idl-unsigned-long">#idl-unsigned-long</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-unsigned-long" class="dfn-panel" data-for="idl-unsigned-long" id="infopanel-for-idl-unsigned-long" role="dialog">
+   <span id="infopaneltitle-for-idl-unsigned-long" style="display:none">Info about the '2.13.9. unsigned long' definition.</span><b><a href="#idl-unsigned-long">#idl-unsigned-long</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">1. Introduction</a>
     <li><a href="#ref-for-idl-unsigned-long①">2.5.5. Special operations</a>
@@ -18272,8 +18273,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-unsigned-long①③">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-long-long">
-   <b><a href="#idl-long-long">#idl-long-long</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-long-long" class="dfn-panel" data-for="idl-long-long" id="infopanel-for-idl-long-long" role="dialog">
+   <span id="infopaneltitle-for-idl-long-long" style="display:none">Info about the '2.13.10. long long' definition.</span><b><a href="#idl-long-long">#idl-long-long</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">2.13. Types</a>
     <li><a href="#ref-for-idl-long-long">2.13.10. long long</a> <a href="#ref-for-idl-long-long①">(2)</a> <a href="#ref-for-idl-long-long②">(3)</a> <a href="#ref-for-idl-long-long③">(4)</a>
@@ -18281,8 +18282,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-long-long①⓪">3.2.4.9. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-unsigned-long-long">
-   <b><a href="#idl-unsigned-long-long">#idl-unsigned-long-long</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-unsigned-long-long" class="dfn-panel" data-for="idl-unsigned-long-long" id="infopanel-for-idl-unsigned-long-long" role="dialog">
+   <span id="infopaneltitle-for-idl-unsigned-long-long" style="display:none">Info about the '2.13.11. unsigned long long' definition.</span><b><a href="#idl-unsigned-long-long">#idl-unsigned-long-long</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">2.13. Types</a>
     <li><a href="#ref-for-idl-unsigned-long-long">2.13.11. unsigned long long</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a>
@@ -18290,8 +18291,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-unsigned-long-long①⓪">4.4. DOMTimeStamp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-float">
-   <b><a href="#idl-float">#idl-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-float" class="dfn-panel" data-for="idl-float" id="infopanel-for-idl-float" role="dialog">
+   <span id="infopaneltitle-for-idl-float" style="display:none">Info about the '2.13.12. float' definition.</span><b><a href="#idl-float">#idl-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">2.5.1. Constants</a> <a href="#ref-for-idl-float①">(2)</a>
     <li><a href="#ref-for-idl-float②">2.13. Types</a>
@@ -18299,8 +18300,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-float⑦">3.2.5. float</a> <a href="#ref-for-idl-float⑧">(2)</a> <a href="#ref-for-idl-float⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-unrestricted-float">
-   <b><a href="#idl-unrestricted-float">#idl-unrestricted-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-unrestricted-float" class="dfn-panel" data-for="idl-unrestricted-float" id="infopanel-for-idl-unrestricted-float" role="dialog">
+   <span id="infopaneltitle-for-idl-unrestricted-float" style="display:none">Info about the '2.13.13. unrestricted float' definition.</span><b><a href="#idl-unrestricted-float">#idl-unrestricted-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-float">2.5.1. Constants</a> <a href="#ref-for-idl-unrestricted-float①">(2)</a> <a href="#ref-for-idl-unrestricted-float②">(3)</a> <a href="#ref-for-idl-unrestricted-float③">(4)</a>
     <li><a href="#ref-for-idl-unrestricted-float④">2.13. Types</a>
@@ -18308,8 +18309,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-unrestricted-float⑧">3.2.6. unrestricted float</a> <a href="#ref-for-idl-unrestricted-float⑨">(2)</a> <a href="#ref-for-idl-unrestricted-float①⓪">(3)</a> <a href="#ref-for-idl-unrestricted-float①①">(4)</a> <a href="#ref-for-idl-unrestricted-float①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-double">
-   <b><a href="#idl-double">#idl-double</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-double" class="dfn-panel" data-for="idl-double" id="infopanel-for-idl-double" role="dialog">
+   <span id="infopaneltitle-for-idl-double" style="display:none">Info about the '2.13.14. double' definition.</span><b><a href="#idl-double">#idl-double</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.5.1. Constants</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">2.5.7. Overloading</a> <a href="#ref-for-idl-double③">(2)</a> <a href="#ref-for-idl-double④">(3)</a>
@@ -18319,8 +18320,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-double①①">3.2.7. double</a> <a href="#ref-for-idl-double①②">(2)</a> <a href="#ref-for-idl-double①③">(3)</a> <a href="#ref-for-idl-double①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-unrestricted-double">
-   <b><a href="#idl-unrestricted-double">#idl-unrestricted-double</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-unrestricted-double" class="dfn-panel" data-for="idl-unrestricted-double" id="infopanel-for-idl-unrestricted-double" role="dialog">
+   <span id="infopaneltitle-for-idl-unrestricted-double" style="display:none">Info about the '2.13.15. unrestricted double' definition.</span><b><a href="#idl-unrestricted-double">#idl-unrestricted-double</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">2.5.1. Constants</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a> <a href="#ref-for-idl-unrestricted-double②">(3)</a> <a href="#ref-for-idl-unrestricted-double③">(4)</a>
     <li><a href="#ref-for-idl-unrestricted-double④">2.13. Types</a>
@@ -18329,8 +18330,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-unrestricted-double⑨">3.2.8. unrestricted double</a> <a href="#ref-for-idl-unrestricted-double①⓪">(2)</a> <a href="#ref-for-idl-unrestricted-double①①">(3)</a> <a href="#ref-for-idl-unrestricted-double①②">(4)</a> <a href="#ref-for-idl-unrestricted-double①③">(5)</a> <a href="#ref-for-idl-unrestricted-double①④">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-bigint">
-   <b><a href="#idl-bigint">#idl-bigint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-bigint" class="dfn-panel" data-for="idl-bigint" id="infopanel-for-idl-bigint" role="dialog">
+   <span id="infopaneltitle-for-idl-bigint" style="display:none">Info about the '2.13.16. bigint' definition.</span><b><a href="#idl-bigint">#idl-bigint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-bigint">2.5.7. Overloading</a>
     <li><a href="#ref-for-idl-bigint①">2.13. Types</a>
@@ -18342,8 +18343,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-bigint②⓪">3.6. Overload resolution algorithm</a> <a href="#ref-for-idl-bigint②①">(2)</a> <a href="#ref-for-idl-bigint②②">(3)</a> <a href="#ref-for-idl-bigint②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-DOMString">
-   <b><a href="#idl-DOMString">#idl-DOMString</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-DOMString" class="dfn-panel" data-for="idl-DOMString" id="infopanel-for-idl-DOMString" role="dialog">
+   <span id="infopaneltitle-for-idl-DOMString" style="display:none">Info about the '2.13.17. DOMString' definition.</span><b><a href="#idl-DOMString">#idl-DOMString</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.5.3. Operations</a>
     <li><a href="#ref-for-idl-DOMString①">2.5.5. Special operations</a> <a href="#ref-for-idl-DOMString②">(2)</a>
@@ -18367,8 +18368,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-DOMString④⑤">4.3. DOMException</a> <a href="#ref-for-idl-DOMString④⑥">(2)</a> <a href="#ref-for-idl-DOMString④⑦">(3)</a> <a href="#ref-for-idl-DOMString④⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-ByteString">
-   <b><a href="#idl-ByteString">#idl-ByteString</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-ByteString" class="dfn-panel" data-for="idl-ByteString" id="infopanel-for-idl-ByteString" role="dialog">
+   <span id="infopaneltitle-for-idl-ByteString" style="display:none">Info about the '2.13.18. ByteString' definition.</span><b><a href="#idl-ByteString">#idl-ByteString</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">2.5.3. Operations</a>
     <li><a href="#ref-for-idl-ByteString①">2.13. Types</a>
@@ -18377,8 +18378,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-ByteString⑨">3.2.11. ByteString</a> <a href="#ref-for-idl-ByteString①⓪">(2)</a> <a href="#ref-for-idl-ByteString①①">(3)</a> <a href="#ref-for-idl-ByteString①②">(4)</a> <a href="#ref-for-idl-ByteString①③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-USVString">
-   <b><a href="#idl-USVString">#idl-USVString</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-USVString" class="dfn-panel" data-for="idl-USVString" id="infopanel-for-idl-USVString" role="dialog">
+   <span id="infopaneltitle-for-idl-USVString" style="display:none">Info about the '2.13.19. USVString' definition.</span><b><a href="#idl-USVString">#idl-USVString</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2.5.3. Operations</a>
     <li><a href="#ref-for-idl-USVString①">2.5.5.1. Stringifiers</a>
@@ -18391,8 +18392,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-USVString①⑤">3.4.6. [LegacyNullToEmptyString]</a> <a href="#ref-for-idl-USVString①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-object">
-   <b><a href="#idl-object">#idl-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-object" class="dfn-panel" data-for="idl-object" id="infopanel-for-idl-object" role="dialog">
+   <span id="infopaneltitle-for-idl-object" style="display:none">Info about the '2.13.20. object' definition.</span><b><a href="#idl-object">#idl-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-idl-object①">2.13. Types</a>
@@ -18407,16 +18408,16 @@ language binding.</p>
     <li><a href="#ref-for-idl-object③⓪">8. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-symbol">
-   <b><a href="#idl-symbol">#idl-symbol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-symbol" class="dfn-panel" data-for="idl-symbol" id="infopanel-for-idl-symbol" role="dialog">
+   <span id="infopaneltitle-for-idl-symbol" style="display:none">Info about the '2.13.21. symbol' definition.</span><b><a href="#idl-symbol">#idl-symbol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-symbol">2.13.21. symbol</a> <a href="#ref-for-idl-symbol">(2)</a> <a href="#ref-for-idl-symbol①">(3)</a> <a href="#ref-for-idl-symbol②">(4)</a>
     <li><a href="#ref-for-idl-symbol③">3.2.1. any</a>
     <li><a href="#ref-for-idl-symbol④">3.2.14. symbol</a> <a href="#ref-for-idl-symbol⑤">(2)</a> <a href="#ref-for-idl-symbol⑥">(3)</a> <a href="#ref-for-idl-symbol⑦">(4)</a> <a href="#ref-for-idl-symbol⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-interface">
-   <b><a href="#idl-interface">#idl-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-interface" class="dfn-panel" data-for="idl-interface" id="infopanel-for-idl-interface" role="dialog">
+   <span id="infopaneltitle-for-idl-interface" style="display:none">Info about the '2.13.22. Interface types' definition.</span><b><a href="#idl-interface">#idl-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-interface">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-idl-interface①">2.5.7. Overloading</a>
@@ -18437,8 +18438,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-interface②③">4.3. DOMException</a> <a href="#ref-for-idl-interface②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-callback-interface">
-   <b><a href="#idl-callback-interface">#idl-callback-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-callback-interface" class="dfn-panel" data-for="idl-callback-interface" id="infopanel-for-idl-callback-interface" role="dialog">
+   <span id="infopaneltitle-for-idl-callback-interface" style="display:none">Info about the '2.13.23. Callback interface types' definition.</span><b><a href="#idl-callback-interface">#idl-callback-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-callback-interface">2.5.7. Overloading</a>
     <li><a href="#ref-for-idl-callback-interface①">2.13. Types</a>
@@ -18450,8 +18451,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-callback-interface①②">3.11. Callback interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-callback-context">
-   <b><a href="#dfn-callback-context">#dfn-callback-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-callback-context" class="dfn-panel" data-for="dfn-callback-context" id="infopanel-for-dfn-callback-context" role="dialog">
+   <span id="infopaneltitle-for-dfn-callback-context" style="display:none">Info about the 'callback context' definition.</span><b><a href="#dfn-callback-context">#dfn-callback-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-context">2.13.23. Callback interface types</a> <a href="#ref-for-dfn-callback-context①">(2)</a>
     <li><a href="#ref-for-dfn-callback-context②">2.13.26. Callback function types</a> <a href="#ref-for-dfn-callback-context③">(2)</a>
@@ -18461,8 +18462,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-callback-context⑦">3.12. Invoking callback functions</a> <a href="#ref-for-dfn-callback-context⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-dictionary">
-   <b><a href="#idl-dictionary">#idl-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-dictionary" class="dfn-panel" data-for="idl-dictionary" id="infopanel-for-idl-dictionary" role="dialog">
+   <span id="infopaneltitle-for-idl-dictionary" style="display:none">Info about the '2.13.24. Dictionary types' definition.</span><b><a href="#idl-dictionary">#idl-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-dictionary">2.5.2. Attributes</a>
     <li><a href="#ref-for-idl-dictionary①">2.5.3. Operations</a> <a href="#ref-for-idl-dictionary②">(2)</a> <a href="#ref-for-idl-dictionary③">(3)</a> <a href="#ref-for-idl-dictionary④">(4)</a> <a href="#ref-for-idl-dictionary⑤">(5)</a>
@@ -18477,24 +18478,24 @@ language binding.</p>
     <li><a href="#ref-for-idl-dictionary①⑧">3.6. Overload resolution algorithm</a> <a href="#ref-for-idl-dictionary①⑨">(2)</a> <a href="#ref-for-idl-dictionary②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-enumeration">
-   <b><a href="#idl-enumeration">#idl-enumeration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-enumeration" class="dfn-panel" data-for="idl-enumeration" id="infopanel-for-idl-enumeration" role="dialog">
+   <span id="infopaneltitle-for-idl-enumeration" style="display:none">Info about the '2.13.25. Enumeration types' definition.</span><b><a href="#idl-enumeration">#idl-enumeration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-enumeration">2.13. Types</a>
     <li><a href="#ref-for-idl-enumeration">2.13.25. Enumeration types</a>
     <li><a href="#ref-for-idl-enumeration①">3.2.18. Enumeration types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-callback-function">
-   <b><a href="#idl-callback-function">#idl-callback-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-callback-function" class="dfn-panel" data-for="idl-callback-function" id="infopanel-for-idl-callback-function" role="dialog">
+   <span id="infopaneltitle-for-idl-callback-function" style="display:none">Info about the '2.13.26. Callback function types' definition.</span><b><a href="#idl-callback-function">#idl-callback-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-callback-function">2.13.26. Callback function types</a>
     <li><a href="#ref-for-idl-callback-function">3.2.19. Callback function types</a> <a href="#ref-for-idl-callback-function①">(2)</a> <a href="#ref-for-idl-callback-function②">(3)</a> <a href="#ref-for-idl-callback-function③">(4)</a> <a href="#ref-for-idl-callback-function④">(5)</a>
     <li><a href="#ref-for-idl-callback-function⑤">3.12. Invoking callback functions</a> <a href="#ref-for-idl-callback-function⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-nullable-type">
-   <b><a href="#dfn-nullable-type">#dfn-nullable-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-nullable-type" class="dfn-panel" data-for="dfn-nullable-type" id="infopanel-for-dfn-nullable-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-nullable-type" style="display:none">Info about the 'nullable type' definition.</span><b><a href="#dfn-nullable-type">#dfn-nullable-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-nullable-type">2.5.1. Constants</a> <a href="#ref-for-dfn-nullable-type①">(2)</a>
     <li><a href="#ref-for-dfn-nullable-type②">2.5.2. Attributes</a>
@@ -18514,8 +18515,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-nullable-type②⑨">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-nullable-type③⓪">(2)</a> <a href="#ref-for-dfn-nullable-type③①">(3)</a> <a href="#ref-for-dfn-nullable-type③②">(4)</a> <a href="#ref-for-dfn-nullable-type③③">(5)</a> <a href="#ref-for-dfn-nullable-type③④">(6)</a> <a href="#ref-for-dfn-nullable-type③⑤">(7)</a> <a href="#ref-for-dfn-nullable-type③⑥">(8)</a> <a href="#ref-for-dfn-nullable-type③⑦">(9)</a> <a href="#ref-for-dfn-nullable-type③⑧">(10)</a> <a href="#ref-for-dfn-nullable-type③⑨">(11)</a> <a href="#ref-for-dfn-nullable-type④⓪">(12)</a> <a href="#ref-for-dfn-nullable-type④①">(13)</a> <a href="#ref-for-dfn-nullable-type④②">(14)</a> <a href="#ref-for-dfn-nullable-type④③">(15)</a> <a href="#ref-for-dfn-nullable-type④④">(16)</a> <a href="#ref-for-dfn-nullable-type④⑤">(17)</a> <a href="#ref-for-dfn-nullable-type④⑥">(18)</a> <a href="#ref-for-dfn-nullable-type④⑦">(19)</a> <a href="#ref-for-dfn-nullable-type④⑧">(20)</a> <a href="#ref-for-dfn-nullable-type④⑨">(21)</a> <a href="#ref-for-dfn-nullable-type⑤⓪">(22)</a> <a href="#ref-for-dfn-nullable-type⑤①">(23)</a> <a href="#ref-for-dfn-nullable-type⑤②">(24)</a> <a href="#ref-for-dfn-nullable-type⑤③">(25)</a> <a href="#ref-for-dfn-nullable-type⑤④">(26)</a> <a href="#ref-for-dfn-nullable-type⑤⑤">(27)</a> <a href="#ref-for-dfn-nullable-type⑤⑥">(28)</a> <a href="#ref-for-dfn-nullable-type⑤⑦">(29)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-inner-type">
-   <b><a href="#dfn-inner-type">#dfn-inner-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-inner-type" class="dfn-panel" data-for="dfn-inner-type" id="infopanel-for-dfn-inner-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-inner-type" style="display:none">Info about the 'inner type' definition.</span><b><a href="#dfn-inner-type">#dfn-inner-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inner-type">2.5.1. Constants</a>
     <li><a href="#ref-for-dfn-inner-type①">2.5.3. Operations</a> <a href="#ref-for-dfn-inner-type②">(2)</a>
@@ -18527,15 +18528,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-inner-type①②">3.2.20. Nullable types — T?</a> <a href="#ref-for-dfn-inner-type①③">(2)</a> <a href="#ref-for-dfn-inner-type①④">(3)</a> <a href="#ref-for-dfn-inner-type①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-sequence">
-   <b><a href="#idl-sequence">#idl-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-sequence" class="dfn-panel" data-for="idl-sequence" id="infopanel-for-idl-sequence" role="dialog">
+   <span id="infopaneltitle-for-idl-sequence" style="display:none">Info about the '2.13.28. Sequence types — sequence&lt;T>' definition.</span><b><a href="#idl-sequence">#idl-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.13.28. Sequence types — sequence&lt;T></a>
     <li><a href="#ref-for-idl-sequence">3.2.23.2. Examples</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sequence-type">
-   <b><a href="#sequence-type">#sequence-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sequence-type" class="dfn-panel" data-for="sequence-type" id="infopanel-for-sequence-type" role="dialog">
+   <span id="infopaneltitle-for-sequence-type" style="display:none">Info about the 'sequence&lt;T>' definition.</span><b><a href="#sequence-type">#sequence-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequence-type">2.5.2. Attributes</a>
     <li><a href="#ref-for-sequence-type①">2.5.3. Operations</a> <a href="#ref-for-sequence-type②">(2)</a> <a href="#ref-for-sequence-type③">(3)</a>
@@ -18558,8 +18559,8 @@ language binding.</p>
     <li><a href="#ref-for-sequence-type②⑥">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-record">
-   <b><a href="#idl-record">#idl-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-record" class="dfn-panel" data-for="idl-record" id="infopanel-for-idl-record" role="dialog">
+   <span id="infopaneltitle-for-idl-record" style="display:none">Info about the '2.13.29. Record types — record&lt;K, V>' definition.</span><b><a href="#idl-record">#idl-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-idl-record①">2.7. Dictionaries</a>
@@ -18567,8 +18568,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-record②">3.2.22. Records — record&lt;K, V></a> <a href="#ref-for-idl-record③">(2)</a> <a href="#ref-for-idl-record④">(3)</a> <a href="#ref-for-idl-record⑤">(4)</a> <a href="#ref-for-idl-record⑥">(5)</a> <a href="#ref-for-idl-record⑦">(6)</a> <a href="#ref-for-idl-record⑧">(7)</a> <a href="#ref-for-idl-record⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="record-type">
-   <b><a href="#record-type">#record-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-record-type" class="dfn-panel" data-for="record-type" id="infopanel-for-record-type" role="dialog">
+   <span id="infopaneltitle-for-record-type" style="display:none">Info about the 'record type' definition.</span><b><a href="#record-type">#record-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-record-type">2.5.2. Attributes</a>
     <li><a href="#ref-for-record-type①">2.5.7. Overloading</a>
@@ -18577,8 +18578,8 @@ language binding.</p>
     <li><a href="#ref-for-record-type④">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-promise">
-   <b><a href="#idl-promise">#idl-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-promise" class="dfn-panel" data-for="idl-promise" id="infopanel-for-idl-promise" role="dialog">
+   <span id="infopaneltitle-for-idl-promise" style="display:none">Info about the '2.13.30. Promise types — Promise&lt;T>' definition.</span><b><a href="#idl-promise">#idl-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.5.9. Asynchronously iterable declarations</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise">2.13.30. Promise types — Promise&lt;T></a>
@@ -18588,8 +18589,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-promise①⑧">3.7.10.1. Default asynchronous iterator objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-promise-type">
-   <b><a href="#dfn-promise-type">#dfn-promise-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-promise-type" class="dfn-panel" data-for="dfn-promise-type" id="infopanel-for-dfn-promise-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-promise-type" style="display:none">Info about the 'promise type' definition.</span><b><a href="#dfn-promise-type">#dfn-promise-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-promise-type">2.5.2. Attributes</a>
     <li><a href="#ref-for-dfn-promise-type①">2.5.7. Overloading</a> <a href="#ref-for-dfn-promise-type②">(2)</a> <a href="#ref-for-dfn-promise-type③">(3)</a>
@@ -18602,8 +18603,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-promise-type①③">3.12. Invoking callback functions</a> <a href="#ref-for-dfn-promise-type①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-union-type">
-   <b><a href="#dfn-union-type">#dfn-union-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-union-type" class="dfn-panel" data-for="dfn-union-type" id="infopanel-for-dfn-union-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-union-type" style="display:none">Info about the 'union type' definition.</span><b><a href="#dfn-union-type">#dfn-union-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-union-type">2.5.2. Attributes</a>
     <li><a href="#ref-for-dfn-union-type①">2.5.3. Operations</a> <a href="#ref-for-dfn-union-type②">(2)</a> <a href="#ref-for-dfn-union-type③">(3)</a> <a href="#ref-for-dfn-union-type④">(4)</a>
@@ -18619,8 +18620,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-union-type③⑨">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-union-type④⓪">(2)</a> <a href="#ref-for-dfn-union-type④①">(3)</a> <a href="#ref-for-dfn-union-type④②">(4)</a> <a href="#ref-for-dfn-union-type④③">(5)</a> <a href="#ref-for-dfn-union-type④④">(6)</a> <a href="#ref-for-dfn-union-type④⑤">(7)</a> <a href="#ref-for-dfn-union-type④⑥">(8)</a> <a href="#ref-for-dfn-union-type④⑦">(9)</a> <a href="#ref-for-dfn-union-type④⑧">(10)</a> <a href="#ref-for-dfn-union-type④⑨">(11)</a> <a href="#ref-for-dfn-union-type⑤⓪">(12)</a> <a href="#ref-for-dfn-union-type⑤①">(13)</a> <a href="#ref-for-dfn-union-type⑤②">(14)</a> <a href="#ref-for-dfn-union-type⑤③">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-union-member-type">
-   <b><a href="#dfn-union-member-type">#dfn-union-member-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-union-member-type" class="dfn-panel" data-for="dfn-union-member-type" id="infopanel-for-dfn-union-member-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-union-member-type" style="display:none">Info about the 'member types' definition.</span><b><a href="#dfn-union-member-type">#dfn-union-member-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-union-member-type">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-dfn-union-member-type①">2.5.7. Overloading</a>
@@ -18630,8 +18631,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-union-member-type①⓪">3.2.24. Union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-flattened-union-member-types">
-   <b><a href="#dfn-flattened-union-member-types">#dfn-flattened-union-member-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-flattened-union-member-types" class="dfn-panel" data-for="dfn-flattened-union-member-types" id="infopanel-for-dfn-flattened-union-member-types" role="dialog">
+   <span id="infopaneltitle-for-dfn-flattened-union-member-types" style="display:none">Info about the 'flattened member types' definition.</span><b><a href="#dfn-flattened-union-member-types">#dfn-flattened-union-member-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-flattened-union-member-types">2.5.2. Attributes</a>
     <li><a href="#ref-for-dfn-flattened-union-member-types①">2.5.3. Operations</a> <a href="#ref-for-dfn-flattened-union-member-types②">(2)</a> <a href="#ref-for-dfn-flattened-union-member-types③">(3)</a> <a href="#ref-for-dfn-flattened-union-member-types④">(4)</a>
@@ -18642,14 +18643,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-flattened-union-member-types①②">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-flattened-union-member-types①③">(2)</a> <a href="#ref-for-dfn-flattened-union-member-types①④">(3)</a> <a href="#ref-for-dfn-flattened-union-member-types①⑤">(4)</a> <a href="#ref-for-dfn-flattened-union-member-types①⑥">(5)</a> <a href="#ref-for-dfn-flattened-union-member-types①⑦">(6)</a> <a href="#ref-for-dfn-flattened-union-member-types①⑧">(7)</a> <a href="#ref-for-dfn-flattened-union-member-types①⑨">(8)</a> <a href="#ref-for-dfn-flattened-union-member-types②⓪">(9)</a> <a href="#ref-for-dfn-flattened-union-member-types②①">(10)</a> <a href="#ref-for-dfn-flattened-union-member-types②②">(11)</a> <a href="#ref-for-dfn-flattened-union-member-types②③">(12)</a> <a href="#ref-for-dfn-flattened-union-member-types②④">(13)</a> <a href="#ref-for-dfn-flattened-union-member-types②⑤">(14)</a> <a href="#ref-for-dfn-flattened-union-member-types②⑥">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-number-of-nullable-member-types">
-   <b><a href="#dfn-number-of-nullable-member-types">#dfn-number-of-nullable-member-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-number-of-nullable-member-types" class="dfn-panel" data-for="dfn-number-of-nullable-member-types" id="infopanel-for-dfn-number-of-nullable-member-types" role="dialog">
+   <span id="infopaneltitle-for-dfn-number-of-nullable-member-types" style="display:none">Info about the 'number of nullable member types' definition.</span><b><a href="#dfn-number-of-nullable-member-types">#dfn-number-of-nullable-member-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-number-of-nullable-member-types">2.13.31. Union types</a> <a href="#ref-for-dfn-number-of-nullable-member-types①">(2)</a> <a href="#ref-for-dfn-number-of-nullable-member-types②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-includes-a-nullable-type">
-   <b><a href="#dfn-includes-a-nullable-type">#dfn-includes-a-nullable-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-includes-a-nullable-type" class="dfn-panel" data-for="dfn-includes-a-nullable-type" id="infopanel-for-dfn-includes-a-nullable-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-includes-a-nullable-type" style="display:none">Info about the 'includes a nullable type' definition.</span><b><a href="#dfn-includes-a-nullable-type">#dfn-includes-a-nullable-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-includes-a-nullable-type">2.5.7. Overloading</a> <a href="#ref-for-dfn-includes-a-nullable-type①">(2)</a>
     <li><a href="#ref-for-dfn-includes-a-nullable-type②">2.13.27. Nullable types — T?</a>
@@ -18657,8 +18658,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-includes-a-nullable-type④">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="annotated-types">
-   <b><a href="#annotated-types">#annotated-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-annotated-types" class="dfn-panel" data-for="annotated-types" id="infopanel-for-annotated-types" role="dialog">
+   <span id="infopaneltitle-for-annotated-types" style="display:none">Info about the 'annotated types' definition.</span><b><a href="#annotated-types">#annotated-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-annotated-types">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-annotated-types①">2.5.7. Overloading</a>
@@ -18670,8 +18671,8 @@ language binding.</p>
     <li><a href="#ref-for-annotated-types⑨">3.6. Overload resolution algorithm</a> <a href="#ref-for-annotated-types①⓪">(2)</a> <a href="#ref-for-annotated-types①①">(3)</a> <a href="#ref-for-annotated-types①②">(4)</a> <a href="#ref-for-annotated-types①③">(5)</a> <a href="#ref-for-annotated-types①④">(6)</a> <a href="#ref-for-annotated-types①⑤">(7)</a> <a href="#ref-for-annotated-types①⑥">(8)</a> <a href="#ref-for-annotated-types①⑦">(9)</a> <a href="#ref-for-annotated-types①⑧">(10)</a> <a href="#ref-for-annotated-types①⑨">(11)</a> <a href="#ref-for-annotated-types②⓪">(12)</a> <a href="#ref-for-annotated-types②①">(13)</a> <a href="#ref-for-annotated-types②②">(14)</a> <a href="#ref-for-annotated-types②③">(15)</a> <a href="#ref-for-annotated-types②④">(16)</a> <a href="#ref-for-annotated-types②⑤">(17)</a> <a href="#ref-for-annotated-types②⑥">(18)</a> <a href="#ref-for-annotated-types②⑦">(19)</a> <a href="#ref-for-annotated-types②⑧">(20)</a> <a href="#ref-for-annotated-types②⑨">(21)</a> <a href="#ref-for-annotated-types③⓪">(22)</a> <a href="#ref-for-annotated-types③①">(23)</a> <a href="#ref-for-annotated-types③②">(24)</a> <a href="#ref-for-annotated-types③③">(25)</a> <a href="#ref-for-annotated-types③④">(26)</a> <a href="#ref-for-annotated-types③⑤">(27)</a> <a href="#ref-for-annotated-types③⑥">(28)</a> <a href="#ref-for-annotated-types③⑦">(29)</a> <a href="#ref-for-annotated-types③⑧">(30)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="annotated-types-inner-type">
-   <b><a href="#annotated-types-inner-type">#annotated-types-inner-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-annotated-types-inner-type" class="dfn-panel" data-for="annotated-types-inner-type" id="infopanel-for-annotated-types-inner-type" role="dialog">
+   <span id="infopaneltitle-for-annotated-types-inner-type" style="display:none">Info about the 'inner types' definition.</span><b><a href="#annotated-types-inner-type">#annotated-types-inner-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-annotated-types-inner-type">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-annotated-types-inner-type①">2.5.7. Overloading</a>
@@ -18681,14 +18682,14 @@ language binding.</p>
     <li><a href="#ref-for-annotated-types-inner-type⑥">3.6. Overload resolution algorithm</a> <a href="#ref-for-annotated-types-inner-type⑦">(2)</a> <a href="#ref-for-annotated-types-inner-type⑧">(3)</a> <a href="#ref-for-annotated-types-inner-type⑨">(4)</a> <a href="#ref-for-annotated-types-inner-type①⓪">(5)</a> <a href="#ref-for-annotated-types-inner-type①①">(6)</a> <a href="#ref-for-annotated-types-inner-type①②">(7)</a> <a href="#ref-for-annotated-types-inner-type①③">(8)</a> <a href="#ref-for-annotated-types-inner-type①④">(9)</a> <a href="#ref-for-annotated-types-inner-type①⑤">(10)</a> <a href="#ref-for-annotated-types-inner-type①⑥">(11)</a> <a href="#ref-for-annotated-types-inner-type①⑦">(12)</a> <a href="#ref-for-annotated-types-inner-type①⑧">(13)</a> <a href="#ref-for-annotated-types-inner-type①⑨">(14)</a> <a href="#ref-for-annotated-types-inner-type②⓪">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extended-attributes-applicable-to-types">
-   <b><a href="#extended-attributes-applicable-to-types">#extended-attributes-applicable-to-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extended-attributes-applicable-to-types" class="dfn-panel" data-for="extended-attributes-applicable-to-types" id="infopanel-for-extended-attributes-applicable-to-types" role="dialog">
+   <span id="infopaneltitle-for-extended-attributes-applicable-to-types" style="display:none">Info about the 'applicable to types' definition.</span><b><a href="#extended-attributes-applicable-to-types">#extended-attributes-applicable-to-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extended-attributes-applicable-to-types">2.13.32. Annotated types</a> <a href="#ref-for-extended-attributes-applicable-to-types①">(2)</a> <a href="#ref-for-extended-attributes-applicable-to-types②">(3)</a> <a href="#ref-for-extended-attributes-applicable-to-types③">(4)</a> <a href="#ref-for-extended-attributes-applicable-to-types④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-type-extended-attribute-associated-with">
-   <b><a href="#idl-type-extended-attribute-associated-with">#idl-type-extended-attribute-associated-with</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-type-extended-attribute-associated-with" class="dfn-panel" data-for="idl-type-extended-attribute-associated-with" id="infopanel-for-idl-type-extended-attribute-associated-with" role="dialog">
+   <span id="infopaneltitle-for-idl-type-extended-attribute-associated-with" style="display:none">Info about the 'extended attributes associated with' definition.</span><b><a href="#idl-type-extended-attribute-associated-with">#idl-type-extended-attribute-associated-with</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-type-extended-attribute-associated-with">2.13.32. Annotated types</a> <a href="#ref-for-idl-type-extended-attribute-associated-with①">(2)</a> <a href="#ref-for-idl-type-extended-attribute-associated-with②">(3)</a> <a href="#ref-for-idl-type-extended-attribute-associated-with③">(4)</a>
     <li><a href="#ref-for-idl-type-extended-attribute-associated-with④">3.2.4.9. Abstract operations</a> <a href="#ref-for-idl-type-extended-attribute-associated-with⑤">(2)</a> <a href="#ref-for-idl-type-extended-attribute-associated-with⑥">(3)</a>
@@ -18700,8 +18701,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-type-extended-attribute-associated-with①⑦">3.4.6. [LegacyNullToEmptyString]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-ArrayBuffer">
-   <b><a href="#idl-ArrayBuffer">#idl-ArrayBuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-ArrayBuffer" class="dfn-panel" data-for="idl-ArrayBuffer" id="infopanel-for-idl-ArrayBuffer" role="dialog">
+   <span id="infopaneltitle-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' definition.</span><b><a href="#idl-ArrayBuffer">#idl-ArrayBuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">2.13. Types</a>
     <li><a href="#ref-for-idl-ArrayBuffer①">2.13.33. Buffer source types</a> <a href="#ref-for-idl-ArrayBuffer②">(2)</a> <a href="#ref-for-idl-ArrayBuffer③">(3)</a> <a href="#ref-for-idl-ArrayBuffer④">(4)</a> <a href="#ref-for-idl-ArrayBuffer⑤">(5)</a> <a href="#ref-for-idl-ArrayBuffer⑥">(6)</a> <a href="#ref-for-idl-ArrayBuffer⑦">(7)</a> <a href="#ref-for-idl-ArrayBuffer⑧">(8)</a>
@@ -18712,8 +18713,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-ArrayBuffer①⑦">4.2. BufferSource</a> <a href="#ref-for-idl-ArrayBuffer①⑧">(2)</a> <a href="#ref-for-idl-ArrayBuffer①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-DataView">
-   <b><a href="#idl-DataView">#idl-DataView</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-DataView" class="dfn-panel" data-for="idl-DataView" id="infopanel-for-idl-DataView" role="dialog">
+   <span id="infopaneltitle-for-idl-DataView" style="display:none">Info about the 'DataView' definition.</span><b><a href="#idl-DataView">#idl-DataView</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DataView">2.13. Types</a>
     <li><a href="#ref-for-idl-DataView①">3.2.24. Union types</a> <a href="#ref-for-idl-DataView②">(2)</a>
@@ -18722,8 +18723,8 @@ language binding.</p>
     <li><a href="#ref-for-idl-DataView⑥">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Int8Array">
-   <b><a href="#idl-Int8Array">#idl-Int8Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Int8Array" class="dfn-panel" data-for="idl-Int8Array" id="infopanel-for-idl-Int8Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Int8Array" style="display:none">Info about the 'Int8Array' definition.</span><b><a href="#idl-Int8Array">#idl-Int8Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Int8Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Int8Array①">2.13.18. ByteString</a>
@@ -18731,24 +18732,24 @@ language binding.</p>
     <li><a href="#ref-for-idl-Int8Array③">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Int16Array">
-   <b><a href="#idl-Int16Array">#idl-Int16Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Int16Array" class="dfn-panel" data-for="idl-Int16Array" id="infopanel-for-idl-Int16Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Int16Array" style="display:none">Info about the 'Int16Array' definition.</span><b><a href="#idl-Int16Array">#idl-Int16Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Int16Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Int16Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Int16Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Int32Array">
-   <b><a href="#idl-Int32Array">#idl-Int32Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Int32Array" class="dfn-panel" data-for="idl-Int32Array" id="infopanel-for-idl-Int32Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Int32Array" style="display:none">Info about the 'Int32Array' definition.</span><b><a href="#idl-Int32Array">#idl-Int32Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Int32Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Int32Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Int32Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Uint8Array">
-   <b><a href="#idl-Uint8Array">#idl-Uint8Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Uint8Array" class="dfn-panel" data-for="idl-Uint8Array" id="infopanel-for-idl-Uint8Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' definition.</span><b><a href="#idl-Uint8Array">#idl-Uint8Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Uint8Array①">2.13.18. ByteString</a>
@@ -18757,70 +18758,70 @@ language binding.</p>
     <li><a href="#ref-for-idl-Uint8Array④">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Uint16Array">
-   <b><a href="#idl-Uint16Array">#idl-Uint16Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Uint16Array" class="dfn-panel" data-for="idl-Uint16Array" id="infopanel-for-idl-Uint16Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Uint16Array" style="display:none">Info about the 'Uint16Array' definition.</span><b><a href="#idl-Uint16Array">#idl-Uint16Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint16Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Uint16Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Uint16Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Uint32Array">
-   <b><a href="#idl-Uint32Array">#idl-Uint32Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Uint32Array" class="dfn-panel" data-for="idl-Uint32Array" id="infopanel-for-idl-Uint32Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Uint32Array" style="display:none">Info about the 'Uint32Array' definition.</span><b><a href="#idl-Uint32Array">#idl-Uint32Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint32Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Uint32Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Uint32Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Uint8ClampedArray">
-   <b><a href="#idl-Uint8ClampedArray">#idl-Uint8ClampedArray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Uint8ClampedArray" class="dfn-panel" data-for="idl-Uint8ClampedArray" id="infopanel-for-idl-Uint8ClampedArray" role="dialog">
+   <span id="infopaneltitle-for-idl-Uint8ClampedArray" style="display:none">Info about the 'Uint8ClampedArray' definition.</span><b><a href="#idl-Uint8ClampedArray">#idl-Uint8ClampedArray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8ClampedArray">2.13. Types</a>
     <li><a href="#ref-for-idl-Uint8ClampedArray①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Uint8ClampedArray②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Float32Array">
-   <b><a href="#idl-Float32Array">#idl-Float32Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Float32Array" class="dfn-panel" data-for="idl-Float32Array" id="infopanel-for-idl-Float32Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' definition.</span><b><a href="#idl-Float32Array">#idl-Float32Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Float32Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Float32Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-Float64Array">
-   <b><a href="#idl-Float64Array">#idl-Float64Array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-Float64Array" class="dfn-panel" data-for="idl-Float64Array" id="infopanel-for-idl-Float64Array" role="dialog">
+   <span id="infopaneltitle-for-idl-Float64Array" style="display:none">Info about the 'Float64Array' definition.</span><b><a href="#idl-Float64Array">#idl-Float64Array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float64Array">2.13. Types</a>
     <li><a href="#ref-for-idl-Float64Array①">3.2.25. Buffer source types</a>
     <li><a href="#ref-for-idl-Float64Array②">4.1. ArrayBufferView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-get-buffer-source-reference">
-   <b><a href="#dfn-get-buffer-source-reference">#dfn-get-buffer-source-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-get-buffer-source-reference" class="dfn-panel" data-for="dfn-get-buffer-source-reference" id="infopanel-for-dfn-get-buffer-source-reference" role="dialog">
+   <span id="infopaneltitle-for-dfn-get-buffer-source-reference" style="display:none">Info about the 'get a reference to the bytes held by the buffer source' definition.</span><b><a href="#dfn-get-buffer-source-reference">#dfn-get-buffer-source-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-reference">2.13.33. Buffer source types</a>
     <li><a href="#ref-for-dfn-get-buffer-source-reference①">3.2.25. Buffer source types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-get-buffer-source-copy">
-   <b><a href="#dfn-get-buffer-source-copy">#dfn-get-buffer-source-copy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="dfn-get-buffer-source-copy" id="infopanel-for-dfn-get-buffer-source-copy" role="dialog">
+   <span id="infopaneltitle-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the bytes held by the buffer source' definition.</span><b><a href="#dfn-get-buffer-source-copy">#dfn-get-buffer-source-copy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">2.13.33. Buffer source types</a>
     <li><a href="#ref-for-dfn-get-buffer-source-copy①">3.2.25. Buffer source types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-frozen-array">
-   <b><a href="#idl-frozen-array">#idl-frozen-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-frozen-array" class="dfn-panel" data-for="idl-frozen-array" id="infopanel-for-idl-frozen-array" role="dialog">
+   <span id="infopaneltitle-for-idl-frozen-array" style="display:none">Info about the '2.13.34. Frozen array types — FrozenArray&lt;T>' definition.</span><b><a href="#idl-frozen-array">#idl-frozen-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.13.34. Frozen array types — FrozenArray&lt;T></a> <a href="#ref-for-idl-frozen-array">(2)</a>
     <li><a href="#ref-for-idl-frozen-array①">3.2.26. Frozen arrays — FrozenArray&lt;T></a> <a href="#ref-for-idl-frozen-array②">(2)</a> <a href="#ref-for-idl-frozen-array③">(3)</a>
     <li><a href="#ref-for-idl-frozen-array④">3.2.26.1. Creating a frozen array from an iterable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-frozen-array-type">
-   <b><a href="#dfn-frozen-array-type">#dfn-frozen-array-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-frozen-array-type" class="dfn-panel" data-for="dfn-frozen-array-type" id="infopanel-for-dfn-frozen-array-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' definition.</span><b><a href="#dfn-frozen-array-type">#dfn-frozen-array-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">2.5.7. Overloading</a>
@@ -18831,14 +18832,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-frozen-array-type⑥">3.6. Overload resolution algorithm</a> <a href="#ref-for-dfn-frozen-array-type⑦">(2)</a> <a href="#ref-for-dfn-frozen-array-type⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-observable-array">
-   <b><a href="#idl-observable-array">#idl-observable-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-observable-array" class="dfn-panel" data-for="idl-observable-array" id="infopanel-for-idl-observable-array" role="dialog">
+   <span id="infopaneltitle-for-idl-observable-array" style="display:none">Info about the '2.13.35. Observable array types — ObservableArray&lt;T>' definition.</span><b><a href="#idl-observable-array">#idl-observable-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-observable-array">2.13.35. Observable array types — ObservableArray&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-observable-array-type">
-   <b><a href="#dfn-observable-array-type">#dfn-observable-array-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-observable-array-type" class="dfn-panel" data-for="dfn-observable-array-type" id="infopanel-for-dfn-observable-array-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-observable-array-type" style="display:none">Info about the 'observable array type' definition.</span><b><a href="#dfn-observable-array-type">#dfn-observable-array-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-observable-array-type">2.13.35. Observable array types — ObservableArray&lt;T></a>
     <li><a href="#ref-for-dfn-observable-array-type①">3.2.27. Observable arrays — ObservableArray&lt;T></a>
@@ -18846,28 +18847,28 @@ language binding.</p>
     <li><a href="#ref-for-dfn-observable-array-type⑤">3.10. Observable array exotic objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-attribute-set-an-indexed-value">
-   <b><a href="#observable-array-attribute-set-an-indexed-value">#observable-array-attribute-set-an-indexed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-attribute-set-an-indexed-value" class="dfn-panel" data-for="observable-array-attribute-set-an-indexed-value" id="infopanel-for-observable-array-attribute-set-an-indexed-value" role="dialog">
+   <span id="infopaneltitle-for-observable-array-attribute-set-an-indexed-value" style="display:none">Info about the 'set an indexed value' definition.</span><b><a href="#observable-array-attribute-set-an-indexed-value">#observable-array-attribute-set-an-indexed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-attribute-set-an-indexed-value">2.13.35. Observable array types — ObservableArray&lt;T></a> <a href="#ref-for-observable-array-attribute-set-an-indexed-value①">(2)</a> <a href="#ref-for-observable-array-attribute-set-an-indexed-value②">(3)</a> <a href="#ref-for-observable-array-attribute-set-an-indexed-value③">(4)</a>
     <li><a href="#ref-for-observable-array-attribute-set-an-indexed-value④">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-attribute-delete-an-indexed-value">
-   <b><a href="#observable-array-attribute-delete-an-indexed-value">#observable-array-attribute-delete-an-indexed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-attribute-delete-an-indexed-value" class="dfn-panel" data-for="observable-array-attribute-delete-an-indexed-value" id="infopanel-for-observable-array-attribute-delete-an-indexed-value" role="dialog">
+   <span id="infopaneltitle-for-observable-array-attribute-delete-an-indexed-value" style="display:none">Info about the 'delete an indexed value' definition.</span><b><a href="#observable-array-attribute-delete-an-indexed-value">#observable-array-attribute-delete-an-indexed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-attribute-delete-an-indexed-value">2.13.35. Observable array types — ObservableArray&lt;T></a> <a href="#ref-for-observable-array-attribute-delete-an-indexed-value①">(2)</a> <a href="#ref-for-observable-array-attribute-delete-an-indexed-value②">(3)</a> <a href="#ref-for-observable-array-attribute-delete-an-indexed-value③">(4)</a>
     <li><a href="#ref-for-observable-array-attribute-delete-an-indexed-value④">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-attribute-backing-list">
-   <b><a href="#observable-array-attribute-backing-list">#observable-array-attribute-backing-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-attribute-backing-list" class="dfn-panel" data-for="observable-array-attribute-backing-list" id="infopanel-for-observable-array-attribute-backing-list" role="dialog">
+   <span id="infopaneltitle-for-observable-array-attribute-backing-list" style="display:none">Info about the 'backing list' definition.</span><b><a href="#observable-array-attribute-backing-list">#observable-array-attribute-backing-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-attribute-backing-list">3.2.27. Observable arrays — ObservableArray&lt;T></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-extended-attribute">
-   <b><a href="#dfn-extended-attribute">#dfn-extended-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-extended-attribute" class="dfn-panel" data-for="dfn-extended-attribute" id="infopanel-for-dfn-extended-attribute" role="dialog">
+   <span id="infopaneltitle-for-dfn-extended-attribute" style="display:none">Info about the 'extended attribute' definition.</span><b><a href="#dfn-extended-attribute">#dfn-extended-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extended-attribute">2. Interface definition language</a> <a href="#ref-for-dfn-extended-attribute①">(2)</a>
     <li><a href="#ref-for-dfn-extended-attribute②">2.2. Interfaces</a> <a href="#ref-for-dfn-extended-attribute③">(2)</a> <a href="#ref-for-dfn-extended-attribute④">(3)</a> <a href="#ref-for-dfn-extended-attribute⑤">(4)</a>
@@ -18939,8 +18940,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-extended-attribute①④③">IDL grammar</a> <a href="#ref-for-dfn-extended-attribute①④④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-xattr-no-arguments">
-   <b><a href="#dfn-xattr-no-arguments">#dfn-xattr-no-arguments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-xattr-no-arguments" class="dfn-panel" data-for="dfn-xattr-no-arguments" id="infopanel-for-dfn-xattr-no-arguments" role="dialog">
+   <span id="infopaneltitle-for-dfn-xattr-no-arguments" style="display:none">Info about the 'takes no arguments' definition.</span><b><a href="#dfn-xattr-no-arguments">#dfn-xattr-no-arguments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-no-arguments">3.3.1. [AllowShared]</a>
     <li><a href="#ref-for-dfn-xattr-no-arguments①">3.3.2. [Clamp]</a>
@@ -18960,21 +18961,21 @@ language binding.</p>
     <li><a href="#ref-for-dfn-xattr-no-arguments①⑤">3.4.10. [LegacyUnforgeable]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-xattr-argument-list">
-   <b><a href="#dfn-xattr-argument-list">#dfn-xattr-argument-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-xattr-argument-list" class="dfn-panel" data-for="dfn-xattr-argument-list" id="infopanel-for-dfn-xattr-argument-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-xattr-argument-list" style="display:none">Info about the 'takes an argument list' definition.</span><b><a href="#dfn-xattr-argument-list">#dfn-xattr-argument-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-argument-list">2.5.3. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-xattr-named-argument-list">
-   <b><a href="#dfn-xattr-named-argument-list">#dfn-xattr-named-argument-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-xattr-named-argument-list" class="dfn-panel" data-for="dfn-xattr-named-argument-list" id="infopanel-for-dfn-xattr-named-argument-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-xattr-named-argument-list" style="display:none">Info about the 'takes a named argument list' definition.</span><b><a href="#dfn-xattr-named-argument-list">#dfn-xattr-named-argument-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-named-argument-list">2.5.7. Overloading</a> <a href="#ref-for-dfn-xattr-named-argument-list①">(2)</a>
     <li><a href="#ref-for-dfn-xattr-named-argument-list②">3.4.1. [LegacyFactoryFunction]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-xattr-identifier">
-   <b><a href="#dfn-xattr-identifier">#dfn-xattr-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-xattr-identifier" class="dfn-panel" data-for="dfn-xattr-identifier" id="infopanel-for-dfn-xattr-identifier" role="dialog">
+   <span id="infopaneltitle-for-dfn-xattr-identifier" style="display:none">Info about the 'takes an identifier' definition.</span><b><a href="#dfn-xattr-identifier">#dfn-xattr-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-identifier">3.3.6. [Exposed]</a>
     <li><a href="#ref-for-dfn-xattr-identifier①">3.3.7. [Global]</a>
@@ -18983,16 +18984,16 @@ language binding.</p>
     <li><a href="#ref-for-dfn-xattr-identifier④">3.4.11. [LegacyWindowAlias]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-xattr-identifier-list">
-   <b><a href="#dfn-xattr-identifier-list">#dfn-xattr-identifier-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-xattr-identifier-list" class="dfn-panel" data-for="dfn-xattr-identifier-list" id="infopanel-for-dfn-xattr-identifier-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-xattr-identifier-list" style="display:none">Info about the 'takes an identifier list' definition.</span><b><a href="#dfn-xattr-identifier-list">#dfn-xattr-identifier-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-identifier-list">3.3.6. [Exposed]</a>
     <li><a href="#ref-for-dfn-xattr-identifier-list①">3.3.7. [Global]</a>
     <li><a href="#ref-for-dfn-xattr-identifier-list②">3.4.11. [LegacyWindowAlias]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-class-string">
-   <b><a href="#dfn-class-string">#dfn-class-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-class-string" class="dfn-panel" data-for="dfn-class-string" id="infopanel-for-dfn-class-string" role="dialog">
+   <span id="infopaneltitle-for-dfn-class-string" style="display:none">Info about the 'class string' definition.</span><b><a href="#dfn-class-string">#dfn-class-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-class-string">3. ECMAScript binding</a>
     <li><a href="#ref-for-dfn-class-string①">3.7.3. Interface prototype object</a>
@@ -19004,8 +19005,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-class-string⑨">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ecmascript-throw">
-   <b><a href="#ecmascript-throw">#ecmascript-throw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ecmascript-throw" class="dfn-panel" data-for="ecmascript-throw" id="infopanel-for-ecmascript-throw" role="dialog">
+   <span id="infopaneltitle-for-ecmascript-throw" style="display:none">Info about the 'throw' definition.</span><b><a href="#ecmascript-throw">#ecmascript-throw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ecmascript-throw">3.2.4.9. Abstract operations</a> <a href="#ref-for-ecmascript-throw①">(2)</a>
     <li><a href="#ref-for-ecmascript-throw②">3.2.5. float</a> <a href="#ref-for-ecmascript-throw③">(2)</a>
@@ -19046,23 +19047,23 @@ language binding.</p>
     <li><a href="#ref-for-ecmascript-throw⑤⑧">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-initial-object">
-   <b><a href="#dfn-initial-object">#dfn-initial-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-initial-object" class="dfn-panel" data-for="dfn-initial-object" id="infopanel-for-dfn-initial-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-initial-object" style="display:none">Info about the 'initial objects' definition.</span><b><a href="#dfn-initial-object">#dfn-initial-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-initial-object">3.1. ECMAScript environment</a> <a href="#ref-for-dfn-initial-object①">(2)</a>
     <li><a href="#ref-for-dfn-initial-object②">3.3.6. [Exposed]</a>
     <li><a href="#ref-for-dfn-initial-object③">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-associated-realm">
-   <b><a href="#dfn-associated-realm">#dfn-associated-realm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-associated-realm" class="dfn-panel" data-for="dfn-associated-realm" id="infopanel-for-dfn-associated-realm" role="dialog">
+   <span id="infopaneltitle-for-dfn-associated-realm" style="display:none">Info about the 'associated Realm' definition.</span><b><a href="#dfn-associated-realm">#dfn-associated-realm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-associated-realm">3.11. Callback interfaces</a>
     <li><a href="#ref-for-dfn-associated-realm①">3.12. Invoking callback functions</a> <a href="#ref-for-dfn-associated-realm②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-convert-ecmascript-to-idl-value">
-   <b><a href="#dfn-convert-ecmascript-to-idl-value">#dfn-convert-ecmascript-to-idl-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="dfn-convert-ecmascript-to-idl-value" id="infopanel-for-dfn-convert-ecmascript-to-idl-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an IDL value' definition.</span><b><a href="#dfn-convert-ecmascript-to-idl-value">#dfn-convert-ecmascript-to-idl-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">3.2.1. any</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">3.2.2. undefined</a>
@@ -19114,8 +19115,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value⑦⑥">3.12. Invoking callback functions</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value⑦⑦">(2)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value⑦⑧">(3)</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value⑦⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-convert-idl-to-ecmascript-value">
-   <b><a href="#dfn-convert-idl-to-ecmascript-value">#dfn-convert-idl-to-ecmascript-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-convert-idl-to-ecmascript-value" class="dfn-panel" data-for="dfn-convert-idl-to-ecmascript-value" id="infopanel-for-dfn-convert-idl-to-ecmascript-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-convert-idl-to-ecmascript-value" style="display:none">Info about the 'converted to ECMAScript values' definition.</span><b><a href="#dfn-convert-idl-to-ecmascript-value">#dfn-convert-idl-to-ecmascript-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value">3.2.1. any</a>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value①">3.2.2. undefined</a>
@@ -19172,14 +19173,14 @@ language binding.</p>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value⑥⑧">3.11. Callback interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-integerpart">
-   <b><a href="#abstract-opdef-integerpart">#abstract-opdef-integerpart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-integerpart" class="dfn-panel" data-for="abstract-opdef-integerpart" id="infopanel-for-abstract-opdef-integerpart" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-integerpart" style="display:none">Info about the 'IntegerPart(n)' definition.</span><b><a href="#abstract-opdef-integerpart">#abstract-opdef-integerpart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-integerpart">3.2.4.9. Abstract operations</a> <a href="#ref-for-abstract-opdef-integerpart①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-converttoint">
-   <b><a href="#abstract-opdef-converttoint">#abstract-opdef-converttoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-converttoint" class="dfn-panel" data-for="abstract-opdef-converttoint" id="infopanel-for-abstract-opdef-converttoint" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-converttoint" style="display:none">Info about the 'ConvertToInt(V, bitLength, signedness)' definition.</span><b><a href="#abstract-opdef-converttoint">#abstract-opdef-converttoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-converttoint">3.2.4.1. byte</a>
     <li><a href="#ref-for-abstract-opdef-converttoint①">3.2.4.2. octet</a>
@@ -19191,14 +19192,14 @@ language binding.</p>
     <li><a href="#ref-for-abstract-opdef-converttoint⑦">3.2.4.8. unsigned long long</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="converted-to-a-numeric-type-or-bigint">
-   <b><a href="#converted-to-a-numeric-type-or-bigint">#converted-to-a-numeric-type-or-bigint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-converted-to-a-numeric-type-or-bigint" class="dfn-panel" data-for="converted-to-a-numeric-type-or-bigint" id="infopanel-for-converted-to-a-numeric-type-or-bigint" role="dialog">
+   <span id="infopaneltitle-for-converted-to-a-numeric-type-or-bigint" style="display:none">Info about the 'converted' definition.</span><b><a href="#converted-to-a-numeric-type-or-bigint">#converted-to-a-numeric-type-or-bigint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-converted-to-a-numeric-type-or-bigint">3.2.24. Union types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-sequence-from-iterable">
-   <b><a href="#create-sequence-from-iterable">#create-sequence-from-iterable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-sequence-from-iterable" class="dfn-panel" data-for="create-sequence-from-iterable" id="infopanel-for-create-sequence-from-iterable" role="dialog">
+   <span id="infopaneltitle-for-create-sequence-from-iterable" style="display:none">Info about the '3.2.21.1. Creating a sequence from an iterable' definition.</span><b><a href="#create-sequence-from-iterable">#create-sequence-from-iterable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-sequence-from-iterable">3.2.21. Sequences — sequence&lt;T></a>
     <li><a href="#ref-for-create-sequence-from-iterable">3.2.21.1. Creating a sequence from an iterable</a>
@@ -19207,97 +19208,97 @@ language binding.</p>
     <li><a href="#ref-for-create-sequence-from-iterable③">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="a-new-promise">
-   <b><a href="#a-new-promise">#a-new-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-a-new-promise" class="dfn-panel" data-for="a-new-promise" id="infopanel-for-a-new-promise" role="dialog">
+   <span id="infopaneltitle-for-a-new-promise" style="display:none">Info about the 'create' definition.</span><b><a href="#a-new-promise">#a-new-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2.23.1. Creating and manipulating Promises</a>
     <li><a href="#ref-for-a-new-promise①">3.2.23.2. Examples</a> <a href="#ref-for-a-new-promise②">(2)</a> <a href="#ref-for-a-new-promise③">(3)</a> <a href="#ref-for-a-new-promise④">(4)</a> <a href="#ref-for-a-new-promise⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="a-promise-rejected-with">
-   <b><a href="#a-promise-rejected-with">#a-promise-rejected-with</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-a-promise-rejected-with" class="dfn-panel" data-for="a-promise-rejected-with" id="infopanel-for-a-promise-rejected-with" role="dialog">
+   <span id="infopaneltitle-for-a-promise-rejected-with" style="display:none">Info about the 'rejected promise' definition.</span><b><a href="#a-promise-rejected-with">#a-promise-rejected-with</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2.23.1. Creating and manipulating Promises</a>
     <li><a href="#ref-for-a-promise-rejected-with①">3.2.23.2. Examples</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a> <a href="#ref-for-a-promise-rejected-with③">(3)</a> <a href="#ref-for-a-promise-rejected-with④">(4)</a> <a href="#ref-for-a-promise-rejected-with⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve">
-   <b><a href="#resolve">#resolve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve" class="dfn-panel" data-for="resolve" id="infopanel-for-resolve" role="dialog">
+   <span id="infopaneltitle-for-resolve" style="display:none">Info about the 'resolve' definition.</span><b><a href="#resolve">#resolve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-resolve①">(2)</a>
     <li><a href="#ref-for-resolve②">3.2.23.2. Examples</a> <a href="#ref-for-resolve③">(2)</a> <a href="#ref-for-resolve④">(3)</a> <a href="#ref-for-resolve⑤">(4)</a> <a href="#ref-for-resolve⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reject">
-   <b><a href="#reject">#reject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reject" class="dfn-panel" data-for="reject" id="infopanel-for-reject" role="dialog">
+   <span id="infopaneltitle-for-reject" style="display:none">Info about the 'reject' definition.</span><b><a href="#reject">#reject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2.23.1. Creating and manipulating Promises</a>
     <li><a href="#ref-for-reject①">3.2.23.2. Examples</a> <a href="#ref-for-reject②">(2)</a> <a href="#ref-for-reject③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-perform-steps-once-promise-is-settled">
-   <b><a href="#dfn-perform-steps-once-promise-is-settled">#dfn-perform-steps-once-promise-is-settled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="dfn-perform-steps-once-promise-is-settled" id="infopanel-for-dfn-perform-steps-once-promise-is-settled" role="dialog">
+   <span id="infopaneltitle-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'react' definition.</span><b><a href="#dfn-perform-steps-once-promise-is-settled">#dfn-perform-steps-once-promise-is-settled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">3.2.23.1. Creating and manipulating Promises</a> <a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">(2)</a>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled②">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wait-for-all">
-   <b><a href="#wait-for-all">#wait-for-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wait-for-all" class="dfn-panel" data-for="wait-for-all" id="infopanel-for-wait-for-all" role="dialog">
+   <span id="infopaneltitle-for-wait-for-all" style="display:none">Info about the 'wait for all' definition.</span><b><a href="#wait-for-all">#wait-for-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-for-all">3.2.23.1. Creating and manipulating Promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="waiting-for-all-promise">
-   <b><a href="#waiting-for-all-promise">#waiting-for-all-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-waiting-for-all-promise" class="dfn-panel" data-for="waiting-for-all-promise" id="infopanel-for-waiting-for-all-promise" role="dialog">
+   <span id="infopaneltitle-for-waiting-for-all-promise" style="display:none">Info about the 'get a promise for waiting for all' definition.</span><b><a href="#waiting-for-all-promise">#waiting-for-all-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all-promise">3.2.23.2. Examples</a> <a href="#ref-for-waiting-for-all-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-ready-promise">
-   <b><a href="#environment-ready-promise">#environment-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-ready-promise" class="dfn-panel" data-for="environment-ready-promise" id="infopanel-for-environment-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-environment-ready-promise" style="display:none">Info about the 'ready promise' definition.</span><b><a href="#environment-ready-promise">#environment-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-ready-promise">3.2.23.2. Examples</a> <a href="#ref-for-environment-ready-promise①">(2)</a> <a href="#ref-for-environment-ready-promise②">(3)</a> <a href="#ref-for-environment-ready-promise③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-detach">
-   <b><a href="#dfn-detach">#dfn-detach</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-detach" class="dfn-panel" data-for="dfn-detach" id="infopanel-for-dfn-detach" role="dialog">
+   <span id="infopaneltitle-for-dfn-detach" style="display:none">Info about the 'detach' definition.</span><b><a href="#dfn-detach">#dfn-detach</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-detach">2.13.33. Buffer source types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-create-frozen-array">
-   <b><a href="#dfn-create-frozen-array">#dfn-create-frozen-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-create-frozen-array" class="dfn-panel" data-for="dfn-create-frozen-array" id="infopanel-for-dfn-create-frozen-array" role="dialog">
+   <span id="infopaneltitle-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' definition.</span><b><a href="#dfn-create-frozen-array">#dfn-create-frozen-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">3.2.26. Frozen arrays — FrozenArray&lt;T></a>
     <li><a href="#ref-for-dfn-create-frozen-array①">3.2.26.1. Creating a frozen array from an iterable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-frozen-array-from-iterable">
-   <b><a href="#create-frozen-array-from-iterable">#create-frozen-array-from-iterable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-frozen-array-from-iterable" class="dfn-panel" data-for="create-frozen-array-from-iterable" id="infopanel-for-create-frozen-array-from-iterable" role="dialog">
+   <span id="infopaneltitle-for-create-frozen-array-from-iterable" style="display:none">Info about the '3.2.26.1. Creating a frozen array from an iterable' definition.</span><b><a href="#create-frozen-array-from-iterable">#create-frozen-array-from-iterable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-frozen-array-from-iterable">3.2.24. Union types</a>
     <li><a href="#ref-for-create-frozen-array-from-iterable">3.2.26.1. Creating a frozen array from an iterable</a>
     <li><a href="#ref-for-create-frozen-array-from-iterable①">3.6. Overload resolution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backing-observable-array-exotic-object">
-   <b><a href="#backing-observable-array-exotic-object">#backing-observable-array-exotic-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backing-observable-array-exotic-object" class="dfn-panel" data-for="backing-observable-array-exotic-object" id="infopanel-for-backing-observable-array-exotic-object" role="dialog">
+   <span id="infopaneltitle-for-backing-observable-array-exotic-object" style="display:none">Info about the 'backing observable array exotic object' definition.</span><b><a href="#backing-observable-array-exotic-object">#backing-observable-array-exotic-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backing-observable-array-exotic-object">3.2.27. Observable arrays — ObservableArray&lt;T></a>
     <li><a href="#ref-for-backing-observable-array-exotic-object①">3.7.6. Attributes</a> <a href="#ref-for-backing-observable-array-exotic-object②">(2)</a> <a href="#ref-for-backing-observable-array-exotic-object③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="AllowShared">
-   <b><a href="#AllowShared">#AllowShared</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-AllowShared" class="dfn-panel" data-for="AllowShared" id="infopanel-for-AllowShared" role="dialog">
+   <span id="infopaneltitle-for-AllowShared" style="display:none">Info about the '3.3.1. [AllowShared]' definition.</span><b><a href="#AllowShared">#AllowShared</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AllowShared">2.13.32. Annotated types</a>
     <li><a href="#ref-for-AllowShared①">3.2.25. Buffer source types</a> <a href="#ref-for-AllowShared②">(2)</a> <a href="#ref-for-AllowShared③">(3)</a> <a href="#ref-for-AllowShared④">(4)</a>
     <li><a href="#ref-for-AllowShared">3.3.1. [AllowShared]</a> <a href="#ref-for-AllowShared⑤">(2)</a> <a href="#ref-for-AllowShared⑥">(3)</a> <a href="#ref-for-AllowShared⑦">(4)</a> <a href="#ref-for-AllowShared⑧">(5)</a> <a href="#ref-for-AllowShared⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Clamp">
-   <b><a href="#Clamp">#Clamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Clamp" class="dfn-panel" data-for="Clamp" id="infopanel-for-Clamp" role="dialog">
+   <span id="infopaneltitle-for-Clamp" style="display:none">Info about the '3.3.2. [Clamp]' definition.</span><b><a href="#Clamp">#Clamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Clamp">2.13.32. Annotated types</a> <a href="#ref-for-Clamp①">(2)</a>
     <li><a href="#ref-for-Clamp②">3.2.4.9. Abstract operations</a> <a href="#ref-for-Clamp③">(2)</a>
@@ -19305,8 +19306,8 @@ language binding.</p>
     <li><a href="#ref-for-Clamp①①">3.3.5. [EnforceRange]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="CrossOriginIsolated">
-   <b><a href="#CrossOriginIsolated">#CrossOriginIsolated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-CrossOriginIsolated" class="dfn-panel" data-for="CrossOriginIsolated" id="infopanel-for-CrossOriginIsolated" role="dialog">
+   <span id="infopaneltitle-for-CrossOriginIsolated" style="display:none">Info about the '3.3.3. [CrossOriginIsolated]' definition.</span><b><a href="#CrossOriginIsolated">#CrossOriginIsolated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CrossOriginIsolated">2.2. Interfaces</a> <a href="#ref-for-CrossOriginIsolated①">(2)</a>
     <li><a href="#ref-for-CrossOriginIsolated②">2.3. Interface mixins</a>
@@ -19321,8 +19322,8 @@ language binding.</p>
     <li><a href="#ref-for-CrossOriginIsolated①⑨">3.3.12. [SecureContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Default">
-   <b><a href="#Default">#Default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Default" class="dfn-panel" data-for="Default" id="infopanel-for-Default" role="dialog">
+   <span id="infopaneltitle-for-Default" style="display:none">Info about the '3.3.4. [Default]' definition.</span><b><a href="#Default">#Default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2.5.3. Operations</a>
     <li><a href="#ref-for-Default①">2.5.3.1. toJSON</a>
@@ -19332,8 +19333,8 @@ language binding.</p>
     <li><a href="#ref-for-Default⑧">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-Default⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="EnforceRange">
-   <b><a href="#EnforceRange">#EnforceRange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-EnforceRange" class="dfn-panel" data-for="EnforceRange" id="infopanel-for-EnforceRange" role="dialog">
+   <span id="infopaneltitle-for-EnforceRange" style="display:none">Info about the '3.3.5. [EnforceRange]' definition.</span><b><a href="#EnforceRange">#EnforceRange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">2.13.32. Annotated types</a>
     <li><a href="#ref-for-EnforceRange①">3.2.4.9. Abstract operations</a> <a href="#ref-for-EnforceRange②">(2)</a>
@@ -19341,8 +19342,8 @@ language binding.</p>
     <li><a href="#ref-for-EnforceRange">3.3.5. [EnforceRange]</a> <a href="#ref-for-EnforceRange④">(2)</a> <a href="#ref-for-EnforceRange⑤">(3)</a> <a href="#ref-for-EnforceRange⑥">(4)</a> <a href="#ref-for-EnforceRange⑦">(5)</a> <a href="#ref-for-EnforceRange⑧">(6)</a> <a href="#ref-for-EnforceRange⑨">(7)</a> <a href="#ref-for-EnforceRange①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Exposed">
-   <b><a href="#Exposed">#Exposed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Exposed" class="dfn-panel" data-for="Exposed" id="infopanel-for-Exposed" role="dialog">
+   <span id="infopaneltitle-for-Exposed" style="display:none">Info about the '3.3.6. [Exposed]' definition.</span><b><a href="#Exposed">#Exposed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Interface definition language</a>
     <li><a href="#ref-for-Exposed①">2.2. Interfaces</a> <a href="#ref-for-Exposed②">(2)</a> <a href="#ref-for-Exposed③">(3)</a>
@@ -19359,21 +19360,21 @@ language binding.</p>
     <li><a href="#ref-for-Exposed③①">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="own-exposure-set">
-   <b><a href="#own-exposure-set">#own-exposure-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-own-exposure-set" class="dfn-panel" data-for="own-exposure-set" id="infopanel-for-own-exposure-set" role="dialog">
+   <span id="infopaneltitle-for-own-exposure-set" style="display:none">Info about the 'own exposure set' definition.</span><b><a href="#own-exposure-set">#own-exposure-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-own-exposure-set">3.3.6. [Exposed]</a> <a href="#ref-for-own-exposure-set①">(2)</a> <a href="#ref-for-own-exposure-set②">(3)</a> <a href="#ref-for-own-exposure-set③">(4)</a> <a href="#ref-for-own-exposure-set④">(5)</a> <a href="#ref-for-own-exposure-set⑤">(6)</a> <a href="#ref-for-own-exposure-set⑥">(7)</a> <a href="#ref-for-own-exposure-set⑦">(8)</a> <a href="#ref-for-own-exposure-set⑧">(9)</a> <a href="#ref-for-own-exposure-set⑨">(10)</a> <a href="#ref-for-own-exposure-set①⓪">(11)</a> <a href="#ref-for-own-exposure-set①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-exposure-set">
-   <b><a href="#dfn-exposure-set">#dfn-exposure-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-exposure-set" class="dfn-panel" data-for="dfn-exposure-set" id="infopanel-for-dfn-exposure-set" role="dialog">
+   <span id="infopaneltitle-for-dfn-exposure-set" style="display:none">Info about the 'exposure set' definition.</span><b><a href="#dfn-exposure-set">#dfn-exposure-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exposure-set">3.3.6. [Exposed]</a> <a href="#ref-for-dfn-exposure-set①">(2)</a> <a href="#ref-for-dfn-exposure-set②">(3)</a> <a href="#ref-for-dfn-exposure-set③">(4)</a> <a href="#ref-for-dfn-exposure-set④">(5)</a> <a href="#ref-for-dfn-exposure-set⑤">(6)</a> <a href="#ref-for-dfn-exposure-set⑥">(7)</a> <a href="#ref-for-dfn-exposure-set⑦">(8)</a> <a href="#ref-for-dfn-exposure-set⑧">(9)</a> <a href="#ref-for-dfn-exposure-set⑨">(10)</a> <a href="#ref-for-dfn-exposure-set①⓪">(11)</a> <a href="#ref-for-dfn-exposure-set①①">(12)</a> <a href="#ref-for-dfn-exposure-set①②">(13)</a>
     <li><a href="#ref-for-dfn-exposure-set①③">3.4.11. [LegacyWindowAlias]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-exposed">
-   <b><a href="#dfn-exposed">#dfn-exposed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-exposed" class="dfn-panel" data-for="dfn-exposed" id="infopanel-for-dfn-exposed" role="dialog">
+   <span id="infopaneltitle-for-dfn-exposed" style="display:none">Info about the 'exposed' definition.</span><b><a href="#dfn-exposed">#dfn-exposed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exposed">2.3.1. Using mixins and partials</a>
     <li><a href="#ref-for-dfn-exposed①">3.1. ECMAScript environment</a> <a href="#ref-for-dfn-exposed②">(2)</a>
@@ -19392,15 +19393,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-exposed②①">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-conditionally-exposed">
-   <b><a href="#dfn-conditionally-exposed">#dfn-conditionally-exposed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-conditionally-exposed" class="dfn-panel" data-for="dfn-conditionally-exposed" id="infopanel-for-dfn-conditionally-exposed" role="dialog">
+   <span id="infopaneltitle-for-dfn-conditionally-exposed" style="display:none">Info about the 'conditionally exposed' definition.</span><b><a href="#dfn-conditionally-exposed">#dfn-conditionally-exposed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-conditionally-exposed">3.3.6. [Exposed]</a> <a href="#ref-for-dfn-conditionally-exposed①">(2)</a>
     <li><a href="#ref-for-dfn-conditionally-exposed②">3.3.12. [SecureContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Global">
-   <b><a href="#Global">#Global</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Global" class="dfn-panel" data-for="Global" id="infopanel-for-Global" role="dialog">
+   <span id="infopaneltitle-for-Global" style="display:none">Info about the '3.3.7. [Global]' definition.</span><b><a href="#Global">#Global</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">2.2. Interfaces</a>
     <li><a href="#ref-for-Global①">2.12. Objects implementing interfaces</a>
@@ -19421,22 +19422,22 @@ language binding.</p>
     <li><a href="#ref-for-Global③①">3.9.4. [[Delete]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-global-name">
-   <b><a href="#dfn-global-name">#dfn-global-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-global-name" class="dfn-panel" data-for="dfn-global-name" id="infopanel-for-dfn-global-name" role="dialog">
+   <span id="infopaneltitle-for-dfn-global-name" style="display:none">Info about the 'global names' definition.</span><b><a href="#dfn-global-name">#dfn-global-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-global-name">3.3.6. [Exposed]</a>
     <li><a href="#ref-for-dfn-global-name①">3.3.7. [Global]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="NewObject">
-   <b><a href="#NewObject">#NewObject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-NewObject" class="dfn-panel" data-for="NewObject" id="infopanel-for-NewObject" role="dialog">
+   <span id="infopaneltitle-for-NewObject" style="display:none">Info about the '3.3.8. [NewObject]' definition.</span><b><a href="#NewObject">#NewObject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">2.5.3. Operations</a>
     <li><a href="#ref-for-NewObject">3.3.8. [NewObject]</a> <a href="#ref-for-NewObject①">(2)</a> <a href="#ref-for-NewObject②">(3)</a> <a href="#ref-for-NewObject③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="PutForwards">
-   <b><a href="#PutForwards">#PutForwards</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-PutForwards" class="dfn-panel" data-for="PutForwards" id="infopanel-for-PutForwards" role="dialog">
+   <span id="infopaneltitle-for-PutForwards" style="display:none">Info about the '3.3.9. [PutForwards]' definition.</span><b><a href="#PutForwards">#PutForwards</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">2.5.2. Attributes</a> <a href="#ref-for-PutForwards①">(2)</a>
     <li><a href="#ref-for-PutForwards">3.3.9. [PutForwards]</a> <a href="#ref-for-PutForwards②">(2)</a> <a href="#ref-for-PutForwards③">(3)</a> <a href="#ref-for-PutForwards④">(4)</a> <a href="#ref-for-PutForwards⑤">(5)</a> <a href="#ref-for-PutForwards⑥">(6)</a> <a href="#ref-for-PutForwards⑦">(7)</a> <a href="#ref-for-PutForwards⑧">(8)</a> <a href="#ref-for-PutForwards⑨">(9)</a> <a href="#ref-for-PutForwards①⓪">(10)</a> <a href="#ref-for-PutForwards①①">(11)</a> <a href="#ref-for-PutForwards①②">(12)</a>
@@ -19445,8 +19446,8 @@ language binding.</p>
     <li><a href="#ref-for-PutForwards①⑤">3.7.6. Attributes</a> <a href="#ref-for-PutForwards①⑥">(2)</a> <a href="#ref-for-PutForwards①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Replaceable">
-   <b><a href="#Replaceable">#Replaceable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Replaceable" class="dfn-panel" data-for="Replaceable" id="infopanel-for-Replaceable" role="dialog">
+   <span id="infopaneltitle-for-Replaceable" style="display:none">Info about the '3.3.10. [Replaceable]' definition.</span><b><a href="#Replaceable">#Replaceable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Replaceable">2.5.2. Attributes</a> <a href="#ref-for-Replaceable①">(2)</a>
     <li><a href="#ref-for-Replaceable②">3.3.9. [PutForwards]</a>
@@ -19455,15 +19456,15 @@ language binding.</p>
     <li><a href="#ref-for-Replaceable①①">3.7.6. Attributes</a> <a href="#ref-for-Replaceable①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="SameObject">
-   <b><a href="#SameObject">#SameObject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-SameObject" class="dfn-panel" data-for="SameObject" id="infopanel-for-SameObject" role="dialog">
+   <span id="infopaneltitle-for-SameObject" style="display:none">Info about the '3.3.11. [SameObject]' definition.</span><b><a href="#SameObject">#SameObject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.5.2. Attributes</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject">3.3.11. [SameObject]</a> <a href="#ref-for-SameObject②">(2)</a> <a href="#ref-for-SameObject③">(3)</a> <a href="#ref-for-SameObject④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="SecureContext">
-   <b><a href="#SecureContext">#SecureContext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-SecureContext" class="dfn-panel" data-for="SecureContext" id="infopanel-for-SecureContext" role="dialog">
+   <span id="infopaneltitle-for-SecureContext" style="display:none">Info about the '3.3.12. [SecureContext]' definition.</span><b><a href="#SecureContext">#SecureContext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.2. Interfaces</a> <a href="#ref-for-SecureContext①">(2)</a>
     <li><a href="#ref-for-SecureContext②">2.3. Interface mixins</a>
@@ -19477,15 +19478,15 @@ language binding.</p>
     <li><a href="#ref-for-SecureContext">3.3.12. [SecureContext]</a> <a href="#ref-for-SecureContext①⓪">(2)</a> <a href="#ref-for-SecureContext①①">(3)</a> <a href="#ref-for-SecureContext①②">(4)</a> <a href="#ref-for-SecureContext①③">(5)</a> <a href="#ref-for-SecureContext①④">(6)</a> <a href="#ref-for-SecureContext①⑤">(7)</a> <a href="#ref-for-SecureContext①⑥">(8)</a> <a href="#ref-for-SecureContext①⑦">(9)</a> <a href="#ref-for-SecureContext①⑧">(10)</a> <a href="#ref-for-SecureContext①⑨">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Unscopable">
-   <b><a href="#Unscopable">#Unscopable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Unscopable" class="dfn-panel" data-for="Unscopable" id="infopanel-for-Unscopable" role="dialog">
+   <span id="infopaneltitle-for-Unscopable" style="display:none">Info about the '3.3.13. [Unscopable]' definition.</span><b><a href="#Unscopable">#Unscopable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Unscopable">3.3.13. [Unscopable]</a> <a href="#ref-for-Unscopable">(2)</a> <a href="#ref-for-Unscopable①">(3)</a> <a href="#ref-for-Unscopable②">(4)</a> <a href="#ref-for-Unscopable③">(5)</a> <a href="#ref-for-Unscopable④">(6)</a>
     <li><a href="#ref-for-Unscopable⑤">3.7.3. Interface prototype object</a> <a href="#ref-for-Unscopable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyFactoryFunction">
-   <b><a href="#LegacyFactoryFunction">#LegacyFactoryFunction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyFactoryFunction" class="dfn-panel" data-for="LegacyFactoryFunction" id="infopanel-for-LegacyFactoryFunction" role="dialog">
+   <span id="infopaneltitle-for-LegacyFactoryFunction" style="display:none">Info about the '3.4.1. [LegacyFactoryFunction]' definition.</span><b><a href="#LegacyFactoryFunction">#LegacyFactoryFunction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyFactoryFunction">2.2. Interfaces</a>
     <li><a href="#ref-for-LegacyFactoryFunction①">2.5.3. Operations</a>
@@ -19498,8 +19499,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyFactoryFunction②①">IDL grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacyfactoryfunction-identifier">
-   <b><a href="#legacyfactoryfunction-identifier">#legacyfactoryfunction-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacyfactoryfunction-identifier" class="dfn-panel" data-for="legacyfactoryfunction-identifier" id="infopanel-for-legacyfactoryfunction-identifier" role="dialog">
+   <span id="infopaneltitle-for-legacyfactoryfunction-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#legacyfactoryfunction-identifier">#legacyfactoryfunction-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacyfactoryfunction-identifier">3.4.1. [LegacyFactoryFunction]</a>
     <li><a href="#ref-for-legacyfactoryfunction-identifier①">3.4.11. [LegacyWindowAlias]</a>
@@ -19508,8 +19509,8 @@ language binding.</p>
     <li><a href="#ref-for-legacyfactoryfunction-identifier⑤">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-legacyfactoryfunction-identifier⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyLenientSetter">
-   <b><a href="#LegacyLenientSetter">#LegacyLenientSetter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyLenientSetter" class="dfn-panel" data-for="LegacyLenientSetter" id="infopanel-for-LegacyLenientSetter" role="dialog">
+   <span id="infopaneltitle-for-LegacyLenientSetter" style="display:none">Info about the '3.4.2. [LegacyLenientSetter]' definition.</span><b><a href="#LegacyLenientSetter">#LegacyLenientSetter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyLenientSetter">2.5.2. Attributes</a> <a href="#ref-for-LegacyLenientSetter①">(2)</a>
     <li><a href="#ref-for-LegacyLenientSetter②">3.3.9. [PutForwards]</a>
@@ -19518,8 +19519,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyLenientSetter①①">3.7.6. Attributes</a> <a href="#ref-for-LegacyLenientSetter①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyLenientThis">
-   <b><a href="#LegacyLenientThis">#LegacyLenientThis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyLenientThis" class="dfn-panel" data-for="LegacyLenientThis" id="infopanel-for-LegacyLenientThis" role="dialog">
+   <span id="infopaneltitle-for-LegacyLenientThis" style="display:none">Info about the '3.4.3. [LegacyLenientThis]' definition.</span><b><a href="#LegacyLenientThis">#LegacyLenientThis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyLenientThis">2.5.2. Attributes</a>
     <li><a href="#ref-for-LegacyLenientThis">3.4.3. [LegacyLenientThis]</a> <a href="#ref-for-LegacyLenientThis①">(2)</a> <a href="#ref-for-LegacyLenientThis②">(3)</a> <a href="#ref-for-LegacyLenientThis③">(4)</a> <a href="#ref-for-LegacyLenientThis④">(5)</a> <a href="#ref-for-LegacyLenientThis⑤">(6)</a>
@@ -19527,8 +19528,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyLenientThis①⓪">3.7.7. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyNamespace">
-   <b><a href="#LegacyNamespace">#LegacyNamespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyNamespace" class="dfn-panel" data-for="LegacyNamespace" id="infopanel-for-LegacyNamespace" role="dialog">
+   <span id="infopaneltitle-for-LegacyNamespace" style="display:none">Info about the '3.4.4. [LegacyNamespace]' definition.</span><b><a href="#LegacyNamespace">#LegacyNamespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNamespace">2.2. Interfaces</a> <a href="#ref-for-LegacyNamespace①">(2)</a>
     <li><a href="#ref-for-LegacyNamespace">3.4.4. [LegacyNamespace]</a> <a href="#ref-for-LegacyNamespace②">(2)</a> <a href="#ref-for-LegacyNamespace③">(3)</a> <a href="#ref-for-LegacyNamespace④">(4)</a> <a href="#ref-for-LegacyNamespace⑤">(5)</a>
@@ -19538,8 +19539,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyNamespace⑨">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyNoInterfaceObject">
-   <b><a href="#LegacyNoInterfaceObject">#LegacyNoInterfaceObject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyNoInterfaceObject" class="dfn-panel" data-for="LegacyNoInterfaceObject" id="infopanel-for-LegacyNoInterfaceObject" role="dialog">
+   <span id="infopaneltitle-for-LegacyNoInterfaceObject" style="display:none">Info about the '3.4.5. [LegacyNoInterfaceObject]' definition.</span><b><a href="#LegacyNoInterfaceObject">#LegacyNoInterfaceObject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNoInterfaceObject">2.2. Interfaces</a>
     <li><a href="#ref-for-LegacyNoInterfaceObject①">3.4.4. [LegacyNamespace]</a>
@@ -19550,16 +19551,16 @@ language binding.</p>
     <li><a href="#ref-for-LegacyNoInterfaceObject①③">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyNullToEmptyString">
-   <b><a href="#LegacyNullToEmptyString">#LegacyNullToEmptyString</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyNullToEmptyString" class="dfn-panel" data-for="LegacyNullToEmptyString" id="infopanel-for-LegacyNullToEmptyString" role="dialog">
+   <span id="infopaneltitle-for-LegacyNullToEmptyString" style="display:none">Info about the '3.4.6. [LegacyNullToEmptyString]' definition.</span><b><a href="#LegacyNullToEmptyString">#LegacyNullToEmptyString</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNullToEmptyString">2.13.32. Annotated types</a>
     <li><a href="#ref-for-LegacyNullToEmptyString①">3.2.10. DOMString</a>
     <li><a href="#ref-for-LegacyNullToEmptyString">3.4.6. [LegacyNullToEmptyString]</a> <a href="#ref-for-LegacyNullToEmptyString②">(2)</a> <a href="#ref-for-LegacyNullToEmptyString③">(3)</a> <a href="#ref-for-LegacyNullToEmptyString④">(4)</a> <a href="#ref-for-LegacyNullToEmptyString⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyOverrideBuiltIns">
-   <b><a href="#LegacyOverrideBuiltIns">#LegacyOverrideBuiltIns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyOverrideBuiltIns" class="dfn-panel" data-for="LegacyOverrideBuiltIns" id="infopanel-for-LegacyOverrideBuiltIns" role="dialog">
+   <span id="infopaneltitle-for-LegacyOverrideBuiltIns" style="display:none">Info about the '3.4.7. [LegacyOverrideBuiltIns]' definition.</span><b><a href="#LegacyOverrideBuiltIns">#LegacyOverrideBuiltIns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyOverrideBuiltIns">2.2. Interfaces</a> <a href="#ref-for-LegacyOverrideBuiltIns①">(2)</a>
     <li><a href="#ref-for-LegacyOverrideBuiltIns②">3.3.7. [Global]</a> <a href="#ref-for-LegacyOverrideBuiltIns③">(2)</a>
@@ -19568,8 +19569,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyOverrideBuiltIns⑨">3.9.7. Abstract operations</a> <a href="#ref-for-LegacyOverrideBuiltIns①⓪">(2)</a> <a href="#ref-for-LegacyOverrideBuiltIns①①">(3)</a> <a href="#ref-for-LegacyOverrideBuiltIns①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyTreatNonObjectAsNull">
-   <b><a href="#LegacyTreatNonObjectAsNull">#LegacyTreatNonObjectAsNull</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyTreatNonObjectAsNull" class="dfn-panel" data-for="LegacyTreatNonObjectAsNull" id="infopanel-for-LegacyTreatNonObjectAsNull" role="dialog">
+   <span id="infopaneltitle-for-LegacyTreatNonObjectAsNull" style="display:none">Info about the '3.4.8. [LegacyTreatNonObjectAsNull]' definition.</span><b><a href="#LegacyTreatNonObjectAsNull">#LegacyTreatNonObjectAsNull</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyTreatNonObjectAsNull">2.10. Callback functions</a>
     <li><a href="#ref-for-LegacyTreatNonObjectAsNull①">2.13.26. Callback function types</a>
@@ -19579,24 +19580,24 @@ language binding.</p>
     <li><a href="#ref-for-LegacyTreatNonObjectAsNull⑧">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyUnenumerableNamedProperties">
-   <b><a href="#LegacyUnenumerableNamedProperties">#LegacyUnenumerableNamedProperties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyUnenumerableNamedProperties" class="dfn-panel" data-for="LegacyUnenumerableNamedProperties" id="infopanel-for-LegacyUnenumerableNamedProperties" role="dialog">
+   <span id="infopaneltitle-for-LegacyUnenumerableNamedProperties" style="display:none">Info about the '3.4.9. [LegacyUnenumerableNamedProperties]' definition.</span><b><a href="#LegacyUnenumerableNamedProperties">#LegacyUnenumerableNamedProperties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties">3.4.9. [LegacyUnenumerableNamedProperties]</a> <a href="#ref-for-LegacyUnenumerableNamedProperties">(2)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties①">(3)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties②">(4)</a> <a href="#ref-for-LegacyUnenumerableNamedProperties③">(5)</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties④">3.7.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties⑤">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyUnforgeable">
-   <b><a href="#LegacyUnforgeable">#LegacyUnforgeable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyUnforgeable" class="dfn-panel" data-for="LegacyUnforgeable" id="infopanel-for-LegacyUnforgeable" role="dialog">
+   <span id="infopaneltitle-for-LegacyUnforgeable" style="display:none">Info about the '3.4.10. [LegacyUnforgeable]' definition.</span><b><a href="#LegacyUnforgeable">#LegacyUnforgeable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyUnforgeable">2.5.2. Attributes</a>
     <li><a href="#ref-for-LegacyUnforgeable①">2.5.3. Operations</a>
     <li><a href="#ref-for-LegacyUnforgeable">3.4.10. [LegacyUnforgeable]</a> <a href="#ref-for-LegacyUnforgeable②">(2)</a> <a href="#ref-for-LegacyUnforgeable③">(3)</a> <a href="#ref-for-LegacyUnforgeable④">(4)</a> <a href="#ref-for-LegacyUnforgeable⑤">(5)</a> <a href="#ref-for-LegacyUnforgeable⑥">(6)</a> <a href="#ref-for-LegacyUnforgeable⑦">(7)</a> <a href="#ref-for-LegacyUnforgeable⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-unforgeable-on-an-interface">
-   <b><a href="#dfn-unforgeable-on-an-interface">#dfn-unforgeable-on-an-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-unforgeable-on-an-interface" class="dfn-panel" data-for="dfn-unforgeable-on-an-interface" id="infopanel-for-dfn-unforgeable-on-an-interface" role="dialog">
+   <span id="infopaneltitle-for-dfn-unforgeable-on-an-interface" style="display:none">Info about the 'unforgeable' definition.</span><b><a href="#dfn-unforgeable-on-an-interface">#dfn-unforgeable-on-an-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface">3.4.10. [LegacyUnforgeable]</a>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface①">3.7.6. Attributes</a> <a href="#ref-for-dfn-unforgeable-on-an-interface②">(2)</a> <a href="#ref-for-dfn-unforgeable-on-an-interface③">(3)</a> <a href="#ref-for-dfn-unforgeable-on-an-interface④">(4)</a>
@@ -19605,8 +19606,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-unforgeable-on-an-interface①①">3.9. Legacy platform objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyWindowAlias">
-   <b><a href="#LegacyWindowAlias">#LegacyWindowAlias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyWindowAlias" class="dfn-panel" data-for="LegacyWindowAlias" id="infopanel-for-LegacyWindowAlias" role="dialog">
+   <span id="infopaneltitle-for-LegacyWindowAlias" style="display:none">Info about the '3.4.11. [LegacyWindowAlias]' definition.</span><b><a href="#LegacyWindowAlias">#LegacyWindowAlias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyWindowAlias">2.2. Interfaces</a>
     <li><a href="#ref-for-LegacyWindowAlias①">3.4.1. [LegacyFactoryFunction]</a>
@@ -19615,8 +19616,8 @@ language binding.</p>
     <li><a href="#ref-for-LegacyWindowAlias①④">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-LegacyWindowAlias①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacywindowalias-identifier">
-   <b><a href="#legacywindowalias-identifier">#legacywindowalias-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacywindowalias-identifier" class="dfn-panel" data-for="legacywindowalias-identifier" id="infopanel-for-legacywindowalias-identifier" role="dialog">
+   <span id="infopaneltitle-for-legacywindowalias-identifier" style="display:none">Info about the 'identifiers' definition.</span><b><a href="#legacywindowalias-identifier">#legacywindowalias-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacywindowalias-identifier">3.4.1. [LegacyFactoryFunction]</a>
     <li><a href="#ref-for-legacywindowalias-identifier①">3.4.11. [LegacyWindowAlias]</a>
@@ -19624,8 +19625,8 @@ language binding.</p>
     <li><a href="#ref-for-legacywindowalias-identifier⑤">3.8. Platform objects implementing interfaces</a> <a href="#ref-for-legacywindowalias-identifier⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-perform-a-security-check">
-   <b><a href="#dfn-perform-a-security-check">#dfn-perform-a-security-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-perform-a-security-check" class="dfn-panel" data-for="dfn-perform-a-security-check" id="infopanel-for-dfn-perform-a-security-check" role="dialog">
+   <span id="infopaneltitle-for-dfn-perform-a-security-check" style="display:none">Info about the 'perform a security check' definition.</span><b><a href="#dfn-perform-a-security-check">#dfn-perform-a-security-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-a-security-check">3.7.6. Attributes</a> <a href="#ref-for-dfn-perform-a-security-check①">(2)</a>
     <li><a href="#ref-for-dfn-perform-a-security-check②">3.7.7. Operations</a>
@@ -19647,8 +19648,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-perform-a-security-check②④">3.7.12.5. add and delete</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-overload-resolution-algorithm">
-   <b><a href="#dfn-overload-resolution-algorithm">#dfn-overload-resolution-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-overload-resolution-algorithm" class="dfn-panel" data-for="dfn-overload-resolution-algorithm" id="infopanel-for-dfn-overload-resolution-algorithm" role="dialog">
+   <span id="infopaneltitle-for-dfn-overload-resolution-algorithm" style="display:none">Info about the 'overload resolution algorithm' definition.</span><b><a href="#dfn-overload-resolution-algorithm">#dfn-overload-resolution-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm">2.5.7.1. Overloading vs. union types</a> <a href="#ref-for-dfn-overload-resolution-algorithm①">(2)</a> <a href="#ref-for-dfn-overload-resolution-algorithm②">(3)</a>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm③">3.7.1. Interface object</a>
@@ -19657,8 +19658,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-overload-resolution-algorithm⑥">3.7.10. Asynchronous iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-interface-object">
-   <b><a href="#dfn-interface-object">#dfn-interface-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-interface-object" class="dfn-panel" data-for="dfn-interface-object" id="infopanel-for-dfn-interface-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-interface-object" style="display:none">Info about the 'interface object' definition.</span><b><a href="#dfn-interface-object">#dfn-interface-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-object">2.5.1. Constants</a>
     <li><a href="#ref-for-dfn-interface-object①">2.5.6. Static attributes and operations</a>
@@ -19677,35 +19678,35 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-object②④">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-legacy-factory-function">
-   <b><a href="#dfn-legacy-factory-function">#dfn-legacy-factory-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-legacy-factory-function" class="dfn-panel" data-for="dfn-legacy-factory-function" id="infopanel-for-dfn-legacy-factory-function" role="dialog">
+   <span id="infopaneltitle-for-dfn-legacy-factory-function" style="display:none">Info about the 'legacy factory function' definition.</span><b><a href="#dfn-legacy-factory-function">#dfn-legacy-factory-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-legacy-factory-function">2.5.7. Overloading</a>
     <li><a href="#ref-for-dfn-legacy-factory-function①">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-legacy-factory-function②">3.7.2. Legacy factory functions</a> <a href="#ref-for-dfn-legacy-factory-function③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overridden-constructor-steps">
-   <b><a href="#overridden-constructor-steps">#overridden-constructor-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overridden-constructor-steps" class="dfn-panel" data-for="overridden-constructor-steps" id="infopanel-for-overridden-constructor-steps" role="dialog">
+   <span id="infopaneltitle-for-overridden-constructor-steps" style="display:none">Info about the 'overridden constructor steps' definition.</span><b><a href="#overridden-constructor-steps">#overridden-constructor-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overridden-constructor-steps">3.7.1. Interface object</a> <a href="#ref-for-overridden-constructor-steps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-interface-object">
-   <b><a href="#create-an-interface-object">#create-an-interface-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-interface-object" class="dfn-panel" data-for="create-an-interface-object" id="infopanel-for-create-an-interface-object" role="dialog">
+   <span id="infopaneltitle-for-create-an-interface-object" style="display:none">Info about the 'created' definition.</span><b><a href="#create-an-interface-object">#create-an-interface-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-interface-object">3.8. Platform objects implementing interfaces</a>
     <li><a href="#ref-for-create-an-interface-object①">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-legacy-factory-function">
-   <b><a href="#create-a-legacy-factory-function">#create-a-legacy-factory-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-legacy-factory-function" class="dfn-panel" data-for="create-a-legacy-factory-function" id="infopanel-for-create-a-legacy-factory-function" role="dialog">
+   <span id="infopaneltitle-for-create-a-legacy-factory-function" style="display:none">Info about the 'created' definition.</span><b><a href="#create-a-legacy-factory-function">#create-a-legacy-factory-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-legacy-factory-function">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-interface-prototype-object">
-   <b><a href="#dfn-interface-prototype-object">#dfn-interface-prototype-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-interface-prototype-object" class="dfn-panel" data-for="dfn-interface-prototype-object" id="infopanel-for-dfn-interface-prototype-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-interface-prototype-object" style="display:none">Info about the 'interface prototype object' definition.</span><b><a href="#dfn-interface-prototype-object">#dfn-interface-prototype-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-prototype-object">2.3. Interface mixins</a>
     <li><a href="#ref-for-dfn-interface-prototype-object①">2.5.8. Iterable declarations</a> <a href="#ref-for-dfn-interface-prototype-object②">(2)</a>
@@ -19743,15 +19744,15 @@ language binding.</p>
     <li><a href="#ref-for-dfn-interface-prototype-object④①">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-interface-prototype-object">
-   <b><a href="#create-an-interface-prototype-object">#create-an-interface-prototype-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-interface-prototype-object" class="dfn-panel" data-for="create-an-interface-prototype-object" id="infopanel-for-create-an-interface-prototype-object" role="dialog">
+   <span id="infopaneltitle-for-create-an-interface-prototype-object" style="display:none">Info about the 'created' definition.</span><b><a href="#create-an-interface-prototype-object">#create-an-interface-prototype-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-interface-prototype-object">3.7.1. Interface object</a>
     <li><a href="#ref-for-create-an-interface-prototype-object①">3.14.1. DOMException custom bindings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-properties-object">
-   <b><a href="#dfn-named-properties-object">#dfn-named-properties-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-properties-object" class="dfn-panel" data-for="dfn-named-properties-object" id="infopanel-for-dfn-named-properties-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-properties-object" style="display:none">Info about the 'named properties object' definition.</span><b><a href="#dfn-named-properties-object">#dfn-named-properties-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-properties-object">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-named-properties-object①">3.3.7. [Global]</a> <a href="#ref-for-dfn-named-properties-object②">(2)</a>
@@ -19764,49 +19765,49 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-properties-object①②">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-named-properties-object">
-   <b><a href="#create-a-named-properties-object">#create-a-named-properties-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-named-properties-object" class="dfn-panel" data-for="create-a-named-properties-object" id="infopanel-for-create-a-named-properties-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-named-properties-object" style="display:none">Info about the 'created' definition.</span><b><a href="#create-a-named-properties-object">#create-a-named-properties-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-named-properties-object">3.7.3. Interface prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-constants">
-   <b><a href="#define-the-constants">#define-the-constants</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-constants" class="dfn-panel" data-for="define-the-constants" id="infopanel-for-define-the-constants" role="dialog">
+   <span id="infopaneltitle-for-define-the-constants" style="display:none">Info about the 'define the constants' definition.</span><b><a href="#define-the-constants">#define-the-constants</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-constants">3.7.1. Interface object</a>
     <li><a href="#ref-for-define-the-constants①">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-define-the-constants②">3.11.1. Legacy callback interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-regular-attributes">
-   <b><a href="#define-the-regular-attributes">#define-the-regular-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-regular-attributes" class="dfn-panel" data-for="define-the-regular-attributes" id="infopanel-for-define-the-regular-attributes" role="dialog">
+   <span id="infopaneltitle-for-define-the-regular-attributes" style="display:none">Info about the 'define the regular attributes' definition.</span><b><a href="#define-the-regular-attributes">#define-the-regular-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-regular-attributes">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-define-the-regular-attributes①">3.8. Platform objects implementing interfaces</a>
     <li><a href="#ref-for-define-the-regular-attributes②">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-static-attributes">
-   <b><a href="#define-the-static-attributes">#define-the-static-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-static-attributes" class="dfn-panel" data-for="define-the-static-attributes" id="infopanel-for-define-the-static-attributes" role="dialog">
+   <span id="infopaneltitle-for-define-the-static-attributes" style="display:none">Info about the 'define the static attributes' definition.</span><b><a href="#define-the-static-attributes">#define-the-static-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-static-attributes">3.7.1. Interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-unforgeable-regular-attributes">
-   <b><a href="#define-the-unforgeable-regular-attributes">#define-the-unforgeable-regular-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-unforgeable-regular-attributes" class="dfn-panel" data-for="define-the-unforgeable-regular-attributes" id="infopanel-for-define-the-unforgeable-regular-attributes" role="dialog">
+   <span id="infopaneltitle-for-define-the-unforgeable-regular-attributes" style="display:none">Info about the 'define the unforgeable regular attributes' definition.</span><b><a href="#define-the-unforgeable-regular-attributes">#define-the-unforgeable-regular-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-unforgeable-regular-attributes">3.7.1. Interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-attributes">
-   <b><a href="#define-the-attributes">#define-the-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-attributes" class="dfn-panel" data-for="define-the-attributes" id="infopanel-for-define-the-attributes" role="dialog">
+   <span id="infopaneltitle-for-define-the-attributes" style="display:none">Info about the 'define the attributes' definition.</span><b><a href="#define-the-attributes">#define-the-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-attributes">3.2.27. Observable arrays — ObservableArray&lt;T></a>
     <li><a href="#ref-for-define-the-attributes①">3.7.6. Attributes</a> <a href="#ref-for-define-the-attributes②">(2)</a> <a href="#ref-for-define-the-attributes③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-attribute-getter">
-   <b><a href="#dfn-attribute-getter">#dfn-attribute-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-attribute-getter" class="dfn-panel" data-for="dfn-attribute-getter" id="infopanel-for-dfn-attribute-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-attribute-getter" style="display:none">Info about the 'attribute getter' definition.</span><b><a href="#dfn-attribute-getter">#dfn-attribute-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute-getter">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-attribute-getter①">3.2.27. Observable arrays — ObservableArray&lt;T></a>
@@ -19814,8 +19815,8 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-getter③">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-attribute-setter">
-   <b><a href="#dfn-attribute-setter">#dfn-attribute-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-attribute-setter" class="dfn-panel" data-for="dfn-attribute-setter" id="infopanel-for-dfn-attribute-setter" role="dialog">
+   <span id="infopaneltitle-for-dfn-attribute-setter" style="display:none">Info about the 'attribute setter' definition.</span><b><a href="#dfn-attribute-setter">#dfn-attribute-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute-setter">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-attribute-setter①">3.2.27. Observable arrays — ObservableArray&lt;T></a>
@@ -19823,216 +19824,217 @@ language binding.</p>
     <li><a href="#ref-for-dfn-attribute-setter③">3.7.6. Attributes</a> <a href="#ref-for-dfn-attribute-setter④">(2)</a> <a href="#ref-for-dfn-attribute-setter⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-regular-operations">
-   <b><a href="#define-the-regular-operations">#define-the-regular-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-regular-operations" class="dfn-panel" data-for="define-the-regular-operations" id="infopanel-for-define-the-regular-operations" role="dialog">
+   <span id="infopaneltitle-for-define-the-regular-operations" style="display:none">Info about the 'define the regular operations' definition.</span><b><a href="#define-the-regular-operations">#define-the-regular-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-regular-operations">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-define-the-regular-operations①">3.8. Platform objects implementing interfaces</a>
     <li><a href="#ref-for-define-the-regular-operations②">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-static-operations">
-   <b><a href="#define-the-static-operations">#define-the-static-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-static-operations" class="dfn-panel" data-for="define-the-static-operations" id="infopanel-for-define-the-static-operations" role="dialog">
+   <span id="infopaneltitle-for-define-the-static-operations" style="display:none">Info about the 'define the static operations' definition.</span><b><a href="#define-the-static-operations">#define-the-static-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-static-operations">3.7.1. Interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-unforgeable-regular-operations">
-   <b><a href="#define-the-unforgeable-regular-operations">#define-the-unforgeable-regular-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-unforgeable-regular-operations" class="dfn-panel" data-for="define-the-unforgeable-regular-operations" id="infopanel-for-define-the-unforgeable-regular-operations" role="dialog">
+   <span id="infopaneltitle-for-define-the-unforgeable-regular-operations" style="display:none">Info about the 'define the unforgeable regular operations' definition.</span><b><a href="#define-the-unforgeable-regular-operations">#define-the-unforgeable-regular-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-unforgeable-regular-operations">3.7.1. Interface object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-operations">
-   <b><a href="#define-the-operations">#define-the-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-operations" class="dfn-panel" data-for="define-the-operations" id="infopanel-for-define-the-operations" role="dialog">
+   <span id="infopaneltitle-for-define-the-operations" style="display:none">Info about the 'define the operations' definition.</span><b><a href="#define-the-operations">#define-the-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-operations">3.7.7. Operations</a> <a href="#ref-for-define-the-operations①">(2)</a> <a href="#ref-for-define-the-operations②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-create-operation-function">
-   <b><a href="#dfn-create-operation-function">#dfn-create-operation-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-create-operation-function" class="dfn-panel" data-for="dfn-create-operation-function" id="infopanel-for-dfn-create-operation-function" role="dialog">
+   <span id="infopaneltitle-for-dfn-create-operation-function" style="display:none">Info about the 'create an operation function' definition.</span><b><a href="#dfn-create-operation-function">#dfn-create-operation-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-operation-function">3.7.1. Interface object</a>
     <li><a href="#ref-for-dfn-create-operation-function①">3.7.7. Operations</a>
     <li><a href="#ref-for-dfn-create-operation-function②">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-default-method-steps">
-   <b><a href="#has-default-method-steps">#has-default-method-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-default-method-steps" class="dfn-panel" data-for="has-default-method-steps" id="infopanel-for-has-default-method-steps" role="dialog">
+   <span id="infopaneltitle-for-has-default-method-steps" style="display:none">Info about the 'has default method steps' definition.</span><b><a href="#has-default-method-steps">#has-default-method-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-default-method-steps">3.3.4. [Default]</a>
     <li><a href="#ref-for-has-default-method-steps①">3.7.7. Operations</a>
     <li><a href="#ref-for-has-default-method-steps②">3.7.7.1. Default operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-method-steps">
-   <b><a href="#default-method-steps">#default-method-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-method-steps" class="dfn-panel" data-for="default-method-steps" id="infopanel-for-default-method-steps" role="dialog">
+   <span id="infopaneltitle-for-default-method-steps" style="display:none">Info about the 'default method steps' definition.</span><b><a href="#default-method-steps">#default-method-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-method-steps">3.3.4. [Default]</a>
     <li><a href="#ref-for-default-method-steps①">3.7.7. Operations</a>
     <li><a href="#ref-for-default-method-steps②">3.7.7.1. Default operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-tojson-steps">
-   <b><a href="#default-tojson-steps">#default-tojson-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-tojson-steps" class="dfn-panel" data-for="default-tojson-steps" id="infopanel-for-default-tojson-steps" role="dialog">
+   <span id="infopaneltitle-for-default-tojson-steps" style="display:none">Info about the 'default toJSON steps' definition.</span><b><a href="#default-tojson-steps">#default-tojson-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-tojson-steps">2.5.3.1. toJSON</a>
     <li><a href="#ref-for-default-tojson-steps①">3.7.7.1. Default operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-attribute-values-of-an-inheritance-stack">
-   <b><a href="#collect-attribute-values-of-an-inheritance-stack">#collect-attribute-values-of-an-inheritance-stack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-attribute-values-of-an-inheritance-stack" class="dfn-panel" data-for="collect-attribute-values-of-an-inheritance-stack" id="infopanel-for-collect-attribute-values-of-an-inheritance-stack" role="dialog">
+   <span id="infopaneltitle-for-collect-attribute-values-of-an-inheritance-stack" style="display:none">Info about the 'collect attribute values of an inheritance stack' definition.</span><b><a href="#collect-attribute-values-of-an-inheritance-stack">#collect-attribute-values-of-an-inheritance-stack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-attribute-values-of-an-inheritance-stack">3.7.7.1.1. Default toJSON operation</a> <a href="#ref-for-collect-attribute-values-of-an-inheritance-stack①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-attribute-values">
-   <b><a href="#collect-attribute-values">#collect-attribute-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-attribute-values" class="dfn-panel" data-for="collect-attribute-values" id="infopanel-for-collect-attribute-values" role="dialog">
+   <span id="infopaneltitle-for-collect-attribute-values" style="display:none">Info about the 'collect attribute values' definition.</span><b><a href="#collect-attribute-values">#collect-attribute-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-attribute-values">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-inheritance-stack">
-   <b><a href="#create-an-inheritance-stack">#create-an-inheritance-stack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-inheritance-stack" class="dfn-panel" data-for="create-an-inheritance-stack" id="infopanel-for-create-an-inheritance-stack" role="dialog">
+   <span id="infopaneltitle-for-create-an-inheritance-stack" style="display:none">Info about the 'create an inheritance stack' definition.</span><b><a href="#create-an-inheritance-stack">#create-an-inheritance-stack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-inheritance-stack">3.7.7.1.1. Default toJSON operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-iteration-methods">
-   <b><a href="#define-the-iteration-methods">#define-the-iteration-methods</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-iteration-methods" class="dfn-panel" data-for="define-the-iteration-methods" id="infopanel-for-define-the-iteration-methods" role="dialog">
+   <span id="infopaneltitle-for-define-the-iteration-methods" style="display:none">Info about the 'define the iteration methods' definition.</span><b><a href="#define-the-iteration-methods">#define-the-iteration-methods</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-iteration-methods">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-define-the-iteration-methods①">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-default-iterator-object">
-   <b><a href="#dfn-default-iterator-object">#dfn-default-iterator-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-default-iterator-object" class="dfn-panel" data-for="dfn-default-iterator-object" id="infopanel-for-dfn-default-iterator-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-default-iterator-object" style="display:none">Info about the 'default iterator object' definition.</span><b><a href="#dfn-default-iterator-object">#dfn-default-iterator-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-default-iterator-object">3.7.9. Iterable declarations</a> <a href="#ref-for-dfn-default-iterator-object①">(2)</a> <a href="#ref-for-dfn-default-iterator-object②">(3)</a>
     <li><a href="#ref-for-dfn-default-iterator-object③">3.7.9.1. Default iterator objects</a> <a href="#ref-for-dfn-default-iterator-object④">(2)</a> <a href="#ref-for-dfn-default-iterator-object⑤">(3)</a>
     <li><a href="#ref-for-dfn-default-iterator-object⑥">3.7.9.2. Iterator prototype object</a> <a href="#ref-for-dfn-default-iterator-object⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-iterator-object-target">
-   <b><a href="#default-iterator-object-target">#default-iterator-object-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-iterator-object-target" class="dfn-panel" data-for="default-iterator-object-target" id="infopanel-for-default-iterator-object-target" role="dialog">
+   <span id="infopaneltitle-for-default-iterator-object-target" style="display:none">Info about the 'target' definition.</span><b><a href="#default-iterator-object-target">#default-iterator-object-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-iterator-object-target">3.7.9. Iterable declarations</a> <a href="#ref-for-default-iterator-object-target①">(2)</a> <a href="#ref-for-default-iterator-object-target②">(3)</a>
     <li><a href="#ref-for-default-iterator-object-target③">3.7.9.2. Iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-iterator-object-kind">
-   <b><a href="#default-iterator-object-kind">#default-iterator-object-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-iterator-object-kind" class="dfn-panel" data-for="default-iterator-object-kind" id="infopanel-for-default-iterator-object-kind" role="dialog">
+   <span id="infopaneltitle-for-default-iterator-object-kind" style="display:none">Info about the 'kind' definition.</span><b><a href="#default-iterator-object-kind">#default-iterator-object-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-iterator-object-kind">3.7.9. Iterable declarations</a> <a href="#ref-for-default-iterator-object-kind①">(2)</a> <a href="#ref-for-default-iterator-object-kind②">(3)</a>
     <li><a href="#ref-for-default-iterator-object-kind③">3.7.9.2. Iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-iterator-object-index">
-   <b><a href="#default-iterator-object-index">#default-iterator-object-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-iterator-object-index" class="dfn-panel" data-for="default-iterator-object-index" id="infopanel-for-default-iterator-object-index" role="dialog">
+   <span id="infopaneltitle-for-default-iterator-object-index" style="display:none">Info about the 'index' definition.</span><b><a href="#default-iterator-object-index">#default-iterator-object-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-iterator-object-index">3.7.9. Iterable declarations</a> <a href="#ref-for-default-iterator-object-index①">(2)</a> <a href="#ref-for-default-iterator-object-index②">(3)</a>
     <li><a href="#ref-for-default-iterator-object-index③">3.7.9.2. Iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-iterator-prototype-object">
-   <b><a href="#dfn-iterator-prototype-object">#dfn-iterator-prototype-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-iterator-prototype-object" class="dfn-panel" data-for="dfn-iterator-prototype-object" id="infopanel-for-dfn-iterator-prototype-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-iterator-prototype-object" style="display:none">Info about the 'iterator prototype object' definition.</span><b><a href="#dfn-iterator-prototype-object">#dfn-iterator-prototype-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-iterator-prototype-object">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-iterator-prototype-object①">3.7.9.1. Default iterator objects</a> <a href="#ref-for-dfn-iterator-prototype-object②">(2)</a>
     <li><a href="#ref-for-dfn-iterator-prototype-object③">3.7.9.2. Iterator prototype object</a> <a href="#ref-for-dfn-iterator-prototype-object④">(2)</a> <a href="#ref-for-dfn-iterator-prototype-object⑤">(3)</a> <a href="#ref-for-dfn-iterator-prototype-object⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iterator-result">
-   <b><a href="#iterator-result">#iterator-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iterator-result" class="dfn-panel" data-for="iterator-result" id="infopanel-for-iterator-result" role="dialog">
+   <span id="infopaneltitle-for-iterator-result" style="display:none">Info about the 'iterator result' definition.</span><b><a href="#iterator-result">#iterator-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iterator-result">3.7.9.2. Iterator prototype object</a>
     <li><a href="#ref-for-iterator-result①">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-asynchronous-iteration-methods">
-   <b><a href="#define-the-asynchronous-iteration-methods">#define-the-asynchronous-iteration-methods</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-asynchronous-iteration-methods" class="dfn-panel" data-for="define-the-asynchronous-iteration-methods" id="infopanel-for-define-the-asynchronous-iteration-methods" role="dialog">
+   <span id="infopaneltitle-for-define-the-asynchronous-iteration-methods" style="display:none">Info about the 'define the asynchronous iteration methods' definition.</span><b><a href="#define-the-asynchronous-iteration-methods">#define-the-asynchronous-iteration-methods</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-asynchronous-iteration-methods">3.7.3. Interface prototype object</a>
     <li><a href="#ref-for-define-the-asynchronous-iteration-methods①">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="converting-arguments-for-an-asynchronous-iterator-method">
-   <b><a href="#converting-arguments-for-an-asynchronous-iterator-method">#converting-arguments-for-an-asynchronous-iterator-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-converting-arguments-for-an-asynchronous-iterator-method" class="dfn-panel" data-for="converting-arguments-for-an-asynchronous-iterator-method" id="infopanel-for-converting-arguments-for-an-asynchronous-iterator-method" role="dialog">
+   <span id="infopaneltitle-for-converting-arguments-for-an-asynchronous-iterator-method" style="display:none">Info about the 'convert arguments for an asynchronous iterator method' definition.</span><b><a href="#converting-arguments-for-an-asynchronous-iterator-method">#converting-arguments-for-an-asynchronous-iterator-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-converting-arguments-for-an-asynchronous-iterator-method">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-converting-arguments-for-an-asynchronous-iterator-method①">(2)</a> <a href="#ref-for-converting-arguments-for-an-asynchronous-iterator-method②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-default-asynchronous-iterator-object">
-   <b><a href="#dfn-default-asynchronous-iterator-object">#dfn-default-asynchronous-iterator-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-default-asynchronous-iterator-object" class="dfn-panel" data-for="dfn-default-asynchronous-iterator-object" id="infopanel-for-dfn-default-asynchronous-iterator-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-default-asynchronous-iterator-object" style="display:none">Info about the 'default asynchronous iterator
+object' definition.</span><b><a href="#dfn-default-asynchronous-iterator-object">#dfn-default-asynchronous-iterator-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-default-asynchronous-iterator-object">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object①">(2)</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object②">(3)</a>
     <li><a href="#ref-for-dfn-default-asynchronous-iterator-object③">3.7.10.1. Default asynchronous iterator objects</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object④">(2)</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object⑤">(3)</a>
     <li><a href="#ref-for-dfn-default-asynchronous-iterator-object⑥">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object⑦">(2)</a> <a href="#ref-for-dfn-default-asynchronous-iterator-object⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-asynchronous-iterator-object-target">
-   <b><a href="#default-asynchronous-iterator-object-target">#default-asynchronous-iterator-object-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-asynchronous-iterator-object-target" class="dfn-panel" data-for="default-asynchronous-iterator-object-target" id="infopanel-for-default-asynchronous-iterator-object-target" role="dialog">
+   <span id="infopaneltitle-for-default-asynchronous-iterator-object-target" style="display:none">Info about the 'target' definition.</span><b><a href="#default-asynchronous-iterator-object-target">#default-asynchronous-iterator-object-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-asynchronous-iterator-object-target">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-default-asynchronous-iterator-object-target①">(2)</a> <a href="#ref-for-default-asynchronous-iterator-object-target②">(3)</a>
     <li><a href="#ref-for-default-asynchronous-iterator-object-target③">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-default-asynchronous-iterator-object-target④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-asynchronous-iterator-object-kind">
-   <b><a href="#default-asynchronous-iterator-object-kind">#default-asynchronous-iterator-object-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-asynchronous-iterator-object-kind" class="dfn-panel" data-for="default-asynchronous-iterator-object-kind" id="infopanel-for-default-asynchronous-iterator-object-kind" role="dialog">
+   <span id="infopaneltitle-for-default-asynchronous-iterator-object-kind" style="display:none">Info about the 'kind' definition.</span><b><a href="#default-asynchronous-iterator-object-kind">#default-asynchronous-iterator-object-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-asynchronous-iterator-object-kind">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-default-asynchronous-iterator-object-kind①">(2)</a> <a href="#ref-for-default-asynchronous-iterator-object-kind②">(3)</a>
     <li><a href="#ref-for-default-asynchronous-iterator-object-kind③">3.7.10.2. Asynchronous iterator prototype object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-asynchronous-iterator-object-ongoing-promise">
-   <b><a href="#default-asynchronous-iterator-object-ongoing-promise">#default-asynchronous-iterator-object-ongoing-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-asynchronous-iterator-object-ongoing-promise" class="dfn-panel" data-for="default-asynchronous-iterator-object-ongoing-promise" id="infopanel-for-default-asynchronous-iterator-object-ongoing-promise" role="dialog">
+   <span id="infopaneltitle-for-default-asynchronous-iterator-object-ongoing-promise" style="display:none">Info about the 'ongoing promise' definition.</span><b><a href="#default-asynchronous-iterator-object-ongoing-promise">#default-asynchronous-iterator-object-ongoing-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise①">(2)</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise②">(3)</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise③">(4)</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise④">(5)</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise⑤">(6)</a> <a href="#ref-for-default-asynchronous-iterator-object-ongoing-promise⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-asynchronous-iterator-object-is-finished">
-   <b><a href="#default-asynchronous-iterator-object-is-finished">#default-asynchronous-iterator-object-is-finished</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-asynchronous-iterator-object-is-finished" class="dfn-panel" data-for="default-asynchronous-iterator-object-is-finished" id="infopanel-for-default-asynchronous-iterator-object-is-finished" role="dialog">
+   <span id="infopaneltitle-for-default-asynchronous-iterator-object-is-finished" style="display:none">Info about the 'is finished' definition.</span><b><a href="#default-asynchronous-iterator-object-is-finished">#default-asynchronous-iterator-object-is-finished</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-asynchronous-iterator-object-is-finished">3.7.10. Asynchronous iterable declarations</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished①">(2)</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished②">(3)</a>
     <li><a href="#ref-for-default-asynchronous-iterator-object-is-finished③">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished④">(2)</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished⑤">(3)</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished⑥">(4)</a> <a href="#ref-for-default-asynchronous-iterator-object-is-finished⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-asynchronous-iterator-prototype-object">
-   <b><a href="#dfn-asynchronous-iterator-prototype-object">#dfn-asynchronous-iterator-prototype-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-asynchronous-iterator-prototype-object" class="dfn-panel" data-for="dfn-asynchronous-iterator-prototype-object" id="infopanel-for-dfn-asynchronous-iterator-prototype-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-asynchronous-iterator-prototype-object" style="display:none">Info about the 'asynchronous iterator prototype object' definition.</span><b><a href="#dfn-asynchronous-iterator-prototype-object">#dfn-asynchronous-iterator-prototype-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-asynchronous-iterator-prototype-object">3.7.10.1. Default asynchronous iterator objects</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object①">(2)</a>
     <li><a href="#ref-for-dfn-asynchronous-iterator-prototype-object②">3.7.10.2. Asynchronous iterator prototype object</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object③">(2)</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object④">(3)</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object⑤">(4)</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object⑥">(5)</a> <a href="#ref-for-dfn-asynchronous-iterator-prototype-object⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-forwards-to-the-internal-map-object">
-   <b><a href="#dfn-forwards-to-the-internal-map-object">#dfn-forwards-to-the-internal-map-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-forwards-to-the-internal-map-object" class="dfn-panel" data-for="dfn-forwards-to-the-internal-map-object" id="infopanel-for-dfn-forwards-to-the-internal-map-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-forwards-to-the-internal-map-object" style="display:none">Info about the 'forwards to the internal map object' definition.</span><b><a href="#dfn-forwards-to-the-internal-map-object">#dfn-forwards-to-the-internal-map-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-forwards-to-the-internal-map-object">3.7.11.3. keys and values</a>
     <li><a href="#ref-for-dfn-forwards-to-the-internal-map-object①">3.7.11.5. clear</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-map-size-getter">
-   <b><a href="#dfn-map-size-getter">#dfn-map-size-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-map-size-getter" class="dfn-panel" data-for="dfn-map-size-getter" id="infopanel-for-dfn-map-size-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-map-size-getter" style="display:none">Info about the 'map size getter' definition.</span><b><a href="#dfn-map-size-getter">#dfn-map-size-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-map-size-getter">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-map-size-getter①">3.7.11.1. size</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-forwards-to-the-internal-set-object">
-   <b><a href="#dfn-forwards-to-the-internal-set-object">#dfn-forwards-to-the-internal-set-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-forwards-to-the-internal-set-object" class="dfn-panel" data-for="dfn-forwards-to-the-internal-set-object" id="infopanel-for-dfn-forwards-to-the-internal-set-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-forwards-to-the-internal-set-object" style="display:none">Info about the 'forwards to the internal set object' definition.</span><b><a href="#dfn-forwards-to-the-internal-set-object">#dfn-forwards-to-the-internal-set-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-forwards-to-the-internal-set-object">3.7.12.3. entries and keys</a>
     <li><a href="#ref-for-dfn-forwards-to-the-internal-set-object①">3.7.12.6. clear</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-size-getter">
-   <b><a href="#dfn-set-size-getter">#dfn-set-size-getter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-size-getter" class="dfn-panel" data-for="dfn-set-size-getter" id="infopanel-for-dfn-set-size-getter" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-size-getter" style="display:none">Info about the 'set size getter' definition.</span><b><a href="#dfn-set-size-getter">#dfn-set-size-getter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-size-getter">3.7.12.1. size</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-a-platform-object">
-   <b><a href="#is-a-platform-object">#is-a-platform-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-a-platform-object" class="dfn-panel" data-for="is-a-platform-object" id="infopanel-for-is-a-platform-object" role="dialog">
+   <span id="infopaneltitle-for-is-a-platform-object" style="display:none">Info about the 'is a platform object' definition.</span><b><a href="#is-a-platform-object">#is-a-platform-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-a-platform-object">3.2.24. Union types</a>
     <li><a href="#ref-for-is-a-platform-object①">3.6. Overload resolution algorithm</a>
@@ -20057,8 +20059,8 @@ language binding.</p>
     <li><a href="#ref-for-is-a-platform-object②⑦">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implements">
-   <b><a href="#implements">#implements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implements" class="dfn-panel" data-for="implements" id="infopanel-for-implements" role="dialog">
+   <span id="infopaneltitle-for-implements" style="display:none">Info about the 'implements' definition.</span><b><a href="#implements">#implements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implements">2.5.4. Constructor operations</a> <a href="#ref-for-implements①">(2)</a>
     <li><a href="#ref-for-implements②">2.5.9. Asynchronously iterable declarations</a>
@@ -20096,40 +20098,40 @@ language binding.</p>
     <li><a href="#ref-for-implements⑤④">3.9.7. Abstract operations</a> <a href="#ref-for-implements⑤⑤">(2)</a> <a href="#ref-for-implements⑤⑥">(3)</a> <a href="#ref-for-implements⑤⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="new">
-   <b><a href="#new">#new</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-new" class="dfn-panel" data-for="new" id="infopanel-for-new" role="dialog">
+   <span id="infopaneltitle-for-new" style="display:none">Info about the 'create a new object implementing the interface' definition.</span><b><a href="#new">#new</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">3.2.23.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="internally-create-a-new-object-implementing-the-interface">
-   <b><a href="#internally-create-a-new-object-implementing-the-interface">#internally-create-a-new-object-implementing-the-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-internally-create-a-new-object-implementing-the-interface" class="dfn-panel" data-for="internally-create-a-new-object-implementing-the-interface" id="infopanel-for-internally-create-a-new-object-implementing-the-interface" role="dialog">
+   <span id="infopaneltitle-for-internally-create-a-new-object-implementing-the-interface" style="display:none">Info about the 'internally create a new object implementing the interface' definition.</span><b><a href="#internally-create-a-new-object-implementing-the-interface">#internally-create-a-new-object-implementing-the-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internally-create-a-new-object-implementing-the-interface">3.7.1. Interface object</a>
     <li><a href="#ref-for-internally-create-a-new-object-implementing-the-interface①">3.7.2. Legacy factory functions</a>
     <li><a href="#ref-for-internally-create-a-new-object-implementing-the-interface②">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-the-global-property-references">
-   <b><a href="#define-the-global-property-references">#define-the-global-property-references</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-the-global-property-references" class="dfn-panel" data-for="define-the-global-property-references" id="infopanel-for-define-the-global-property-references" role="dialog">
+   <span id="infopaneltitle-for-define-the-global-property-references" style="display:none">Info about the 'define the global property references' definition.</span><b><a href="#define-the-global-property-references">#define-the-global-property-references</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-the-global-property-references">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-primary-interface">
-   <b><a href="#dfn-primary-interface">#dfn-primary-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-primary-interface" class="dfn-panel" data-for="dfn-primary-interface" id="infopanel-for-dfn-primary-interface" role="dialog">
+   <span id="infopaneltitle-for-dfn-primary-interface" style="display:none">Info about the 'primary interface' definition.</span><b><a href="#dfn-primary-interface">#dfn-primary-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-primary-interface">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-unforgeable-property-name">
-   <b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-unforgeable-property-name" class="dfn-panel" data-for="dfn-unforgeable-property-name" id="infopanel-for-dfn-unforgeable-property-name" role="dialog">
+   <span id="infopaneltitle-for-dfn-unforgeable-property-name" style="display:none">Info about the 'unforgeable property name' definition.</span><b><a href="#dfn-unforgeable-property-name">#dfn-unforgeable-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unforgeable-property-name">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-platform-object-getownproperty">
-   <b><a href="#legacy-platform-object-getownproperty">#legacy-platform-object-getownproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-platform-object-getownproperty" class="dfn-panel" data-for="legacy-platform-object-getownproperty" id="infopanel-for-legacy-platform-object-getownproperty" role="dialog">
+   <span id="infopaneltitle-for-legacy-platform-object-getownproperty" style="display:none">Info about the '3.9.1. [[GetOwnProperty]]' definition.</span><b><a href="#legacy-platform-object-getownproperty">#legacy-platform-object-getownproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-platform-object-getownproperty">3.4.9. [LegacyUnenumerableNamedProperties]</a>
     <li><a href="#ref-for-legacy-platform-object-getownproperty">3.8. Platform objects implementing interfaces</a>
@@ -20137,8 +20139,8 @@ language binding.</p>
     <li><a href="#ref-for-legacy-platform-object-getownproperty">3.9.1. [[GetOwnProperty]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-an-array-index">
-   <b><a href="#is-an-array-index">#is-an-array-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-an-array-index" class="dfn-panel" data-for="is-an-array-index" id="infopanel-for-is-an-array-index" role="dialog">
+   <span id="infopaneltitle-for-is-an-array-index" style="display:none">Info about the 'is an array index' definition.</span><b><a href="#is-an-array-index">#is-an-array-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-an-array-index">3.9.2. [[Set]]</a>
     <li><a href="#ref-for-is-an-array-index①">3.9.3. [[DefineOwnProperty]]</a>
@@ -20152,8 +20154,8 @@ language binding.</p>
     <li><a href="#ref-for-is-an-array-index⑨">3.10.8. set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-named-property-visibility">
-   <b><a href="#dfn-named-property-visibility">#dfn-named-property-visibility</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-named-property-visibility" class="dfn-panel" data-for="dfn-named-property-visibility" id="infopanel-for-dfn-named-property-visibility" role="dialog">
+   <span id="infopaneltitle-for-dfn-named-property-visibility" style="display:none">Info about the 'named property visibility algorithm' definition.</span><b><a href="#dfn-named-property-visibility">#dfn-named-property-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-named-property-visibility">3.7.4.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-dfn-named-property-visibility①">3.9.4. [[Delete]]</a>
@@ -20161,29 +20163,29 @@ language binding.</p>
     <li><a href="#ref-for-dfn-named-property-visibility③">3.9.7. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-indexed-setter">
-   <b><a href="#invoke-indexed-setter">#invoke-indexed-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-indexed-setter" class="dfn-panel" data-for="invoke-indexed-setter" id="infopanel-for-invoke-indexed-setter" role="dialog">
+   <span id="infopaneltitle-for-invoke-indexed-setter" style="display:none">Info about the 'invoke an indexed property setter' definition.</span><b><a href="#invoke-indexed-setter">#invoke-indexed-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-indexed-setter">3.9.2. [[Set]]</a>
     <li><a href="#ref-for-invoke-indexed-setter①">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-named-setter">
-   <b><a href="#invoke-named-setter">#invoke-named-setter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-named-setter" class="dfn-panel" data-for="invoke-named-setter" id="infopanel-for-invoke-named-setter" role="dialog">
+   <span id="infopaneltitle-for-invoke-named-setter" style="display:none">Info about the 'invoke a named property setter' definition.</span><b><a href="#invoke-named-setter">#invoke-named-setter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-named-setter">3.9.2. [[Set]]</a>
     <li><a href="#ref-for-invoke-named-setter①">3.9.3. [[DefineOwnProperty]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="LegacyPlatformObjectGetOwnProperty">
-   <b><a href="#LegacyPlatformObjectGetOwnProperty">#LegacyPlatformObjectGetOwnProperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-LegacyPlatformObjectGetOwnProperty" class="dfn-panel" data-for="LegacyPlatformObjectGetOwnProperty" id="infopanel-for-LegacyPlatformObjectGetOwnProperty" role="dialog">
+   <span id="infopaneltitle-for-LegacyPlatformObjectGetOwnProperty" style="display:none">Info about the 'LegacyPlatformObjectGetOwnProperty' definition.</span><b><a href="#LegacyPlatformObjectGetOwnProperty">#LegacyPlatformObjectGetOwnProperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyPlatformObjectGetOwnProperty">3.9.1. [[GetOwnProperty]]</a>
     <li><a href="#ref-for-LegacyPlatformObjectGetOwnProperty①">3.9.2. [[Set]]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-exotic-object">
-   <b><a href="#observable-array-exotic-object">#observable-array-exotic-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-exotic-object" class="dfn-panel" data-for="observable-array-exotic-object" id="infopanel-for-observable-array-exotic-object" role="dialog">
+   <span id="infopaneltitle-for-observable-array-exotic-object" style="display:none">Info about the 'observable array exotic object' definition.</span><b><a href="#observable-array-exotic-object">#observable-array-exotic-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-exotic-object">3.2.27. Observable arrays — ObservableArray&lt;T></a>
     <li><a href="#ref-for-observable-array-exotic-object①">3.10.1. defineProperty</a>
@@ -20196,112 +20198,113 @@ language binding.</p>
     <li><a href="#ref-for-observable-array-exotic-object⑧">3.10.8. set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="creating-an-observable-array-exotic-object">
-   <b><a href="#creating-an-observable-array-exotic-object">#creating-an-observable-array-exotic-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-creating-an-observable-array-exotic-object" class="dfn-panel" data-for="creating-an-observable-array-exotic-object" id="infopanel-for-creating-an-observable-array-exotic-object" role="dialog">
+   <span id="infopaneltitle-for-creating-an-observable-array-exotic-object" style="display:none">Info about the 'create an observable array exotic object' definition.</span><b><a href="#creating-an-observable-array-exotic-object">#creating-an-observable-array-exotic-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creating-an-observable-array-exotic-object">3.7.6. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-exotic-object-set-the-length">
-   <b><a href="#observable-array-exotic-object-set-the-length">#observable-array-exotic-object-set-the-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-exotic-object-set-the-length" class="dfn-panel" data-for="observable-array-exotic-object-set-the-length" id="infopanel-for-observable-array-exotic-object-set-the-length" role="dialog">
+   <span id="infopaneltitle-for-observable-array-exotic-object-set-the-length" style="display:none">Info about the 'set the length' definition.</span><b><a href="#observable-array-exotic-object-set-the-length">#observable-array-exotic-object-set-the-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-exotic-object-set-the-length">3.7.6. Attributes</a>
     <li><a href="#ref-for-observable-array-exotic-object-set-the-length①">3.10.1. defineProperty</a>
     <li><a href="#ref-for-observable-array-exotic-object-set-the-length②">3.10.8. set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-array-exotic-object-set-the-indexed-value">
-   <b><a href="#observable-array-exotic-object-set-the-indexed-value">#observable-array-exotic-object-set-the-indexed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-array-exotic-object-set-the-indexed-value" class="dfn-panel" data-for="observable-array-exotic-object-set-the-indexed-value" id="infopanel-for-observable-array-exotic-object-set-the-indexed-value" role="dialog">
+   <span id="infopaneltitle-for-observable-array-exotic-object-set-the-indexed-value" style="display:none">Info about the 'set the indexed value' definition.</span><b><a href="#observable-array-exotic-object-set-the-indexed-value">#observable-array-exotic-object-set-the-indexed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-array-exotic-object-set-the-indexed-value">3.10.1. defineProperty</a>
     <li><a href="#ref-for-observable-array-exotic-object-set-the-indexed-value①">3.10.8. set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-idl-arguments-list">
-   <b><a href="#web-idl-arguments-list">#web-idl-arguments-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-idl-arguments-list" class="dfn-panel" data-for="web-idl-arguments-list" id="infopanel-for-web-idl-arguments-list" role="dialog">
+   <span id="infopaneltitle-for-web-idl-arguments-list" style="display:none">Info about the 'Web IDL arguments list' definition.</span><b><a href="#web-idl-arguments-list">#web-idl-arguments-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-idl-arguments-list">3.11. Callback interfaces</a> <a href="#ref-for-web-idl-arguments-list①">(2)</a>
     <li><a href="#ref-for-web-idl-arguments-list②">3.12. Invoking callback functions</a> <a href="#ref-for-web-idl-arguments-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-idl-arguments-list-converting">
-   <b><a href="#web-idl-arguments-list-converting">#web-idl-arguments-list-converting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-idl-arguments-list-converting" class="dfn-panel" data-for="web-idl-arguments-list-converting" id="infopanel-for-web-idl-arguments-list-converting" role="dialog">
+   <span id="infopaneltitle-for-web-idl-arguments-list-converting" style="display:none">Info about the 'convert a Web IDL arguments list to an
+    ECMAScript arguments list' definition.</span><b><a href="#web-idl-arguments-list-converting">#web-idl-arguments-list-converting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-idl-arguments-list-converting">3.11. Callback interfaces</a>
     <li><a href="#ref-for-web-idl-arguments-list-converting①">3.12. Invoking callback functions</a> <a href="#ref-for-web-idl-arguments-list-converting②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-callback-this-value">
-   <b><a href="#dfn-callback-this-value">#dfn-callback-this-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-callback-this-value" class="dfn-panel" data-for="dfn-callback-this-value" id="infopanel-for-dfn-callback-this-value" role="dialog">
+   <span id="infopaneltitle-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' definition.</span><b><a href="#dfn-callback-this-value">#dfn-callback-this-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">3.7.9. Iterable declarations</a>
     <li><a href="#ref-for-dfn-callback-this-value①">3.12. Invoking callback functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-legacy-callback-interface-object">
-   <b><a href="#dfn-legacy-callback-interface-object">#dfn-legacy-callback-interface-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-legacy-callback-interface-object" class="dfn-panel" data-for="dfn-legacy-callback-interface-object" id="infopanel-for-dfn-legacy-callback-interface-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-legacy-callback-interface-object" style="display:none">Info about the 'legacy callback interface object' definition.</span><b><a href="#dfn-legacy-callback-interface-object">#dfn-legacy-callback-interface-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-legacy-callback-interface-object">3.1. ECMAScript environment</a>
     <li><a href="#ref-for-dfn-legacy-callback-interface-object①">3.7.5. Constants</a>
     <li><a href="#ref-for-dfn-legacy-callback-interface-object②">3.11.1. Legacy callback interface object</a> <a href="#ref-for-dfn-legacy-callback-interface-object③">(2)</a> <a href="#ref-for-dfn-legacy-callback-interface-object④">(3)</a> <a href="#ref-for-dfn-legacy-callback-interface-object⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-legacy-callback-interface-object">
-   <b><a href="#create-a-legacy-callback-interface-object">#create-a-legacy-callback-interface-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-legacy-callback-interface-object" class="dfn-panel" data-for="create-a-legacy-callback-interface-object" id="infopanel-for-create-a-legacy-callback-interface-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-legacy-callback-interface-object" style="display:none">Info about the 'created' definition.</span><b><a href="#create-a-legacy-callback-interface-object">#create-a-legacy-callback-interface-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-legacy-callback-interface-object">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-a-callback-function">
-   <b><a href="#invoke-a-callback-function">#invoke-a-callback-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-a-callback-function" class="dfn-panel" data-for="invoke-a-callback-function" id="infopanel-for-invoke-a-callback-function" role="dialog">
+   <span id="infopaneltitle-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' definition.</span><b><a href="#invoke-a-callback-function">#invoke-a-callback-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">3.7.9. Iterable declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-namespace-object">
-   <b><a href="#dfn-namespace-object">#dfn-namespace-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-namespace-object" class="dfn-panel" data-for="dfn-namespace-object" id="infopanel-for-dfn-namespace-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-namespace-object" style="display:none">Info about the 'namespace object' definition.</span><b><a href="#dfn-namespace-object">#dfn-namespace-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-namespace-object">3.13.1. Namespace object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-namespace-object">
-   <b><a href="#create-a-namespace-object">#create-a-namespace-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-namespace-object" class="dfn-panel" data-for="create-a-namespace-object" id="infopanel-for-create-a-namespace-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-namespace-object" style="display:none">Info about the 'created' definition.</span><b><a href="#create-a-namespace-object">#create-a-namespace-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-namespace-object">3.8. Platform objects implementing interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="es-exception-objects">
-   <b><a href="#es-exception-objects">#es-exception-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-es-exception-objects" class="dfn-panel" data-for="es-exception-objects" id="infopanel-for-es-exception-objects" role="dialog">
+   <span id="infopaneltitle-for-es-exception-objects" style="display:none">Info about the '3.14.2. Exception objects' definition.</span><b><a href="#es-exception-objects">#es-exception-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-es-exception-objects">3.9.6. [[OwnPropertyKeys]]</a>
     <li><a href="#ref-for-es-exception-objects">3.14.2. Exception objects</a>
     <li><a href="#ref-for-es-exception-objects">3.14.3. Creating and throwing exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="an-exception-was-thrown">
-   <b><a href="#an-exception-was-thrown">#an-exception-was-thrown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-an-exception-was-thrown" class="dfn-panel" data-for="an-exception-was-thrown" id="infopanel-for-an-exception-was-thrown" role="dialog">
+   <span id="infopaneltitle-for-an-exception-was-thrown" style="display:none">Info about the 'an exception was thrown' definition.</span><b><a href="#an-exception-was-thrown">#an-exception-was-thrown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-an-exception-was-thrown">3.7.6. Attributes</a>
     <li><a href="#ref-for-an-exception-was-thrown①">3.7.7. Operations</a>
     <li><a href="#ref-for-an-exception-was-thrown②">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ArrayBufferView">
-   <b><a href="#ArrayBufferView">#ArrayBufferView</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ArrayBufferView" class="dfn-panel" data-for="ArrayBufferView" id="infopanel-for-ArrayBufferView" role="dialog">
+   <span id="infopaneltitle-for-ArrayBufferView" style="display:none">Info about the '4.1. ArrayBufferView' definition.</span><b><a href="#ArrayBufferView">#ArrayBufferView</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ArrayBufferView">4.1. ArrayBufferView</a> <a href="#ref-for-ArrayBufferView">(2)</a> <a href="#ref-for-ArrayBufferView①">(3)</a>
     <li><a href="#ref-for-ArrayBufferView②">4.2. BufferSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="BufferSource">
-   <b><a href="#BufferSource">#BufferSource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-BufferSource" class="dfn-panel" data-for="BufferSource" id="infopanel-for-BufferSource" role="dialog">
+   <span id="infopaneltitle-for-BufferSource" style="display:none">Info about the '4.2. BufferSource' definition.</span><b><a href="#BufferSource">#BufferSource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">2.13.33. Buffer source types</a>
     <li><a href="#ref-for-BufferSource">4.2. BufferSource</a> <a href="#ref-for-BufferSource①">(2)</a> <a href="#ref-for-BufferSource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-DOMException">
-   <b><a href="#idl-DOMException">#idl-DOMException</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-DOMException" class="dfn-panel" data-for="idl-DOMException" id="infopanel-for-idl-DOMException" role="dialog">
+   <span id="infopaneltitle-for-idl-DOMException" style="display:none">Info about the '4.3. DOMException' definition.</span><b><a href="#idl-DOMException">#idl-DOMException</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.8. Exceptions</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a> <a href="#ref-for-idl-DOMException⑥">(7)</a> <a href="#ref-for-idl-DOMException⑦">(8)</a> <a href="#ref-for-idl-DOMException⑧">(9)</a> <a href="#ref-for-idl-DOMException⑨">(10)</a> <a href="#ref-for-idl-DOMException①⓪">(11)</a>
     <li><a href="#ref-for-idl-DOMException①①">2.8.1. Error names</a> <a href="#ref-for-idl-DOMException①②">(2)</a> <a href="#ref-for-idl-DOMException①③">(3)</a> <a href="#ref-for-idl-DOMException①④">(4)</a> <a href="#ref-for-idl-DOMException①⑤">(5)</a> <a href="#ref-for-idl-DOMException①⑥">(6)</a> <a href="#ref-for-idl-DOMException①⑦">(7)</a> <a href="#ref-for-idl-DOMException①⑧">(8)</a>
@@ -20314,142 +20317,198 @@ language binding.</p>
     <li><a href="#ref-for-idl-DOMException">4.3. DOMException</a> <a href="#ref-for-idl-DOMException③⑧">(2)</a> <a href="#ref-for-idl-DOMException③⑨">(3)</a> <a href="#ref-for-idl-DOMException④⓪">(4)</a> <a href="#ref-for-idl-DOMException④①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domexception-name">
-   <b><a href="#domexception-name">#domexception-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domexception-name" class="dfn-panel" data-for="domexception-name" id="infopanel-for-domexception-name" role="dialog">
+   <span id="infopaneltitle-for-domexception-name" style="display:none">Info about the 'name' definition.</span><b><a href="#domexception-name">#domexception-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domexception-name">4.3. DOMException</a> <a href="#ref-for-domexception-name①">(2)</a> <a href="#ref-for-domexception-name②">(3)</a> <a href="#ref-for-domexception-name③">(4)</a> <a href="#ref-for-domexception-name④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domexception-message">
-   <b><a href="#domexception-message">#domexception-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domexception-message" class="dfn-panel" data-for="domexception-message" id="infopanel-for-domexception-message" role="dialog">
+   <span id="infopaneltitle-for-domexception-message" style="display:none">Info about the 'message' definition.</span><b><a href="#domexception-message">#domexception-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domexception-message">4.3. DOMException</a> <a href="#ref-for-domexception-message①">(2)</a> <a href="#ref-for-domexception-message②">(3)</a> <a href="#ref-for-domexception-message③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-domexception">
-   <b><a href="#dom-domexception-domexception">#dom-domexception-domexception</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-domexception" class="dfn-panel" data-for="dom-domexception-domexception" id="infopanel-for-dom-domexception-domexception" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-domexception" style="display:none">Info about the 'new DOMException(message, name)' definition.</span><b><a href="#dom-domexception-domexception">#dom-domexception-domexception</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-domexception">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-name">
-   <b><a href="#dom-domexception-name">#dom-domexception-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-name" class="dfn-panel" data-for="dom-domexception-name" id="infopanel-for-dom-domexception-name" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-domexception-name">#dom-domexception-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-name">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-message">
-   <b><a href="#dom-domexception-message">#dom-domexception-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-message" class="dfn-panel" data-for="dom-domexception-message" id="infopanel-for-dom-domexception-message" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-message" style="display:none">Info about the 'message' definition.</span><b><a href="#dom-domexception-message">#dom-domexception-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-message">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domexception-code">
-   <b><a href="#dom-domexception-code">#dom-domexception-code</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domexception-code" class="dfn-panel" data-for="dom-domexception-code" id="infopanel-for-dom-domexception-code" role="dialog">
+   <span id="infopaneltitle-for-dom-domexception-code" style="display:none">Info about the 'code' definition.</span><b><a href="#dom-domexception-code">#dom-domexception-code</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domexception-code">4.3. DOMException</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DOMTimeStamp">
-   <b><a href="#DOMTimeStamp">#DOMTimeStamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DOMTimeStamp" class="dfn-panel" data-for="DOMTimeStamp" id="infopanel-for-DOMTimeStamp" role="dialog">
+   <span id="infopaneltitle-for-DOMTimeStamp" style="display:none">Info about the '4.4. DOMTimeStamp' definition.</span><b><a href="#DOMTimeStamp">#DOMTimeStamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DOMTimeStamp">4.4. DOMTimeStamp</a> <a href="#ref-for-DOMTimeStamp">(2)</a> <a href="#ref-for-DOMTimeStamp①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Function">
-   <b><a href="#Function">#Function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Function" class="dfn-panel" data-for="Function" id="infopanel-for-Function" role="dialog">
+   <span id="infopaneltitle-for-Function" style="display:none">Info about the '4.5. Function' definition.</span><b><a href="#Function">#Function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Function">3.7.9. Iterable declarations</a>
     <li><a href="#ref-for-Function">4.5. Function</a> <a href="#ref-for-Function①">(2)</a> <a href="#ref-for-Function②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="VoidFunction">
-   <b><a href="#VoidFunction">#VoidFunction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-VoidFunction" class="dfn-panel" data-for="VoidFunction" id="infopanel-for-VoidFunction" role="dialog">
+   <span id="infopaneltitle-for-VoidFunction" style="display:none">Info about the '4.6. VoidFunction' definition.</span><b><a href="#VoidFunction">#VoidFunction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VoidFunction">4.6. VoidFunction</a> <a href="#ref-for-VoidFunction">(2)</a> <a href="#ref-for-VoidFunction①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-example-term">
-   <b><a href="#dfn-example-term">#dfn-example-term</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-example-term" class="dfn-panel" data-for="dfn-example-term" id="infopanel-for-dfn-example-term" role="dialog">
+   <span id="infopaneltitle-for-dfn-example-term" style="display:none">Info about the 'example term' definition.</span><b><a href="#dfn-example-term">#dfn-example-term</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-example-term">Document conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-conforming-set-of-idl-fragments">
-   <b><a href="#dfn-conforming-set-of-idl-fragments">#dfn-conforming-set-of-idl-fragments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-conforming-set-of-idl-fragments" class="dfn-panel" data-for="dfn-conforming-set-of-idl-fragments" id="infopanel-for-dfn-conforming-set-of-idl-fragments" role="dialog">
+   <span id="infopaneltitle-for-dfn-conforming-set-of-idl-fragments" style="display:none">Info about the 'conforming set of IDL fragments' definition.</span><b><a href="#dfn-conforming-set-of-idl-fragments">#dfn-conforming-set-of-idl-fragments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-conforming-set-of-idl-fragments">Conformance</a> <a href="#ref-for-dfn-conforming-set-of-idl-fragments①">(2)</a> <a href="#ref-for-dfn-conforming-set-of-idl-fragments②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-conforming-implementation">
-   <b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-conforming-implementation" class="dfn-panel" data-for="dfn-conforming-implementation" id="infopanel-for-dfn-conforming-implementation" role="dialog">
+   <span id="infopaneltitle-for-dfn-conforming-implementation" style="display:none">Info about the 'conforming implementation' definition.</span><b><a href="#dfn-conforming-implementation">#dfn-conforming-implementation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-conforming-implementation">4. Common definitions</a>
     <li><a href="#ref-for-dfn-conforming-implementation①">7. Referencing this specification</a>
     <li><a href="#ref-for-dfn-conforming-implementation②">Conformance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-conforming-ecmascript-implementation">
-   <b><a href="#dfn-conforming-ecmascript-implementation">#dfn-conforming-ecmascript-implementation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-conforming-ecmascript-implementation" class="dfn-panel" data-for="dfn-conforming-ecmascript-implementation" id="infopanel-for-dfn-conforming-ecmascript-implementation" role="dialog">
+   <span id="infopaneltitle-for-dfn-conforming-ecmascript-implementation" style="display:none">Info about the 'conforming ECMAScript implementation' definition.</span><b><a href="#dfn-conforming-ecmascript-implementation">#dfn-conforming-ecmascript-implementation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-conforming-ecmascript-implementation">Conformance</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/anchors/index.html
+++ b/tests/github/immersive-web/anchors/index.html
@@ -1015,207 +1015,207 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#xranchor">XRAnchor</a><span>, in § 3.1</span>
    <li><a href="#xranchorset">XRAnchorSet</a><span>, in § 5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. XRAnchor</a>
     <li><a href="#ref-for-Exposed①">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.1. XRAnchor</a>
     <li><a href="#ref-for-invalidstateerror①">4. Anchor creation</a> <a href="#ref-for-invalidstateerror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4. Anchor creation</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. XRAnchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4. Anchor creation</a> <a href="#ref-for-a-new-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4. Anchor creation</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3.1. XRAnchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr" id="infopanel-for-term-for-dom-xrsessionmode-immersive-vr" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" style="display:none">Info about the '"immersive-vr"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">4. Anchor creation</a> <a href="#ref-for-xrframe①">(2)</a> <a href="#ref-for-xrframe②">(3)</a>
     <li><a href="#ref-for-xrframe③">5. Anchor updates</a> <a href="#ref-for-xrframe④">(2)</a> <a href="#ref-for-xrframe⑤">(3)</a>
     <li><a href="#ref-for-xrframe⑥">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform" class="dfn-panel" data-for="term-for-xrrigidtransform" id="infopanel-for-term-for-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">4. Anchor creation</a> <a href="#ref-for-xrsession①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">3.1. XRAnchor</a> <a href="#ref-for-xrspace①">(2)</a> <a href="#ref-for-xrspace②">(3)</a>
     <li><a href="#ref-for-xrspace③">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">4. Anchor creation</a> <a href="#ref-for-xrframe-active①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-capable-of-supporting">
-   <a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-capable-of-supporting" class="dfn-panel" data-for="term-for-capable-of-supporting" id="infopanel-for-term-for-capable-of-supporting" role="menu">
+   <span id="infopaneltitle-for-term-for-capable-of-supporting" style="display:none">Info about the 'capable of supporting' external reference.</span><a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capable-of-supporting">2.1. Feature descriptor</a> <a href="#ref-for-capable-of-supporting①">(2)</a>
     <li><a href="#ref-for-capable-of-supporting②">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-effective-origin">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-effective-origin">https://www.w3.org/TR/webxr/#xrspace-effective-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-effective-origin" class="dfn-panel" data-for="term-for-xrspace-effective-origin" id="infopanel-for-term-for-xrspace-effective-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-effective-origin" style="display:none">Info about the 'effective origin' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-effective-origin">https://www.w3.org/TR/webxr/#xrspace-effective-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-effective-origin">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-descriptor">
-   <a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-descriptor" class="dfn-panel" data-for="term-for-feature-descriptor" id="infopanel-for-term-for-feature-descriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-xr-device" class="dfn-panel" data-for="term-for-inline-xr-device" id="infopanel-for-term-for-inline-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-xr-device" style="display:none">Info about the 'inline xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-xr-device">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates" id="infopanel-for-term-for-xrsession-list-of-frame-updates" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" style="display:none">Info about the 'list of frame updates' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-frame-updates">4. Anchor creation</a> <a href="#ref-for-xrsession-list-of-frame-updates①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-mode">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-mode">https://www.w3.org/TR/webxr/#xrsession-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-mode" class="dfn-panel" data-for="term-for-xrsession-mode" id="infopanel-for-term-for-xrsession-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-mode">https://www.w3.org/TR/webxr/#xrsession-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-mode">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-native-origin">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-native-origin" class="dfn-panel" data-for="term-for-xrspace-native-origin" id="infopanel-for-term-for-xrspace-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-native-origin">3.1. XRAnchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://www.w3.org/TR/webxr/#dom-xrframe-session">https://www.w3.org/TR/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session (for XRFrame)' external reference.</span><a href="https://www.w3.org/TR/webxr/#dom-xrframe-session">https://www.w3.org/TR/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">4. Anchor creation</a> <a href="#ref-for-dom-xrframe-session①">(2)</a>
     <li><a href="#ref-for-dom-xrframe-session②">5. Anchor updates</a>
     <li><a href="#ref-for-dom-xrframe-session③">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-session">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-session">https://www.w3.org/TR/webxr/#xrspace-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-session" class="dfn-panel" data-for="term-for-xrspace-session" id="infopanel-for-term-for-xrspace-session" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-session" style="display:none">Info about the 'session (for XRSpace)' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-session">https://www.w3.org/TR/webxr/#xrspace-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-session">3.1. XRAnchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-time">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-time" class="dfn-panel" data-for="term-for-xrframe-time" id="infopanel-for-term-for-xrframe-time" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-time" style="display:none">Info about the 'time' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-time">4. Anchor creation</a> <a href="#ref-for-xrframe-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xr-device">https://www.w3.org/TR/webxr/#xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-device" class="dfn-panel" data-for="term-for-xr-device" id="infopanel-for-term-for-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-device">https://www.w3.org/TR/webxr/#xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device">4. Anchor creation</a>
     <li><a href="#ref-for-xr-device①">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-xr-device" class="dfn-panel" data-for="term-for-xrsession-xr-device" id="infopanel-for-term-for-xrsession-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-xr-device" style="display:none">Info about the 'xr device (for XRSession)' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">4. Anchor creation</a> <a href="#ref-for-xrsession-xr-device①">(2)</a>
     <li><a href="#ref-for-xrsession-xr-device②">5. Anchor updates</a>
     <li><a href="#ref-for-xrsession-xr-device③">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrhittestresult">
-   <a href="https://immersive-web.github.io/hit-test/#xrhittestresult">https://immersive-web.github.io/hit-test/#xrhittestresult</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrhittestresult" class="dfn-panel" data-for="term-for-xrhittestresult" id="infopanel-for-term-for-xrhittestresult" role="menu">
+   <span id="infopaneltitle-for-term-for-xrhittestresult" style="display:none">Info about the 'XRHitTestResult' external reference.</span><a href="https://immersive-web.github.io/hit-test/#xrhittestresult">https://immersive-web.github.io/hit-test/#xrhittestresult</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult">4. Anchor creation</a> <a href="#ref-for-xrhittestresult①">(2)</a> <a href="#ref-for-xrhittestresult②">(3)</a> <a href="#ref-for-xrhittestresult③">(4)</a>
     <li><a href="#ref-for-xrhittestresult④">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrhittestresult-frame">
-   <a href="https://immersive-web.github.io/hit-test/#xrhittestresult-frame">https://immersive-web.github.io/hit-test/#xrhittestresult-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrhittestresult-frame" class="dfn-panel" data-for="term-for-xrhittestresult-frame" id="infopanel-for-term-for-xrhittestresult-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-xrhittestresult-frame" style="display:none">Info about the 'frame' external reference.</span><a href="https://immersive-web.github.io/hit-test/#xrhittestresult-frame">https://immersive-web.github.io/hit-test/#xrhittestresult-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult-frame">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hit-test">
-   <a href="https://immersive-web.github.io/hit-test/#hit-test">https://immersive-web.github.io/hit-test/#hit-test</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hit-test" class="dfn-panel" data-for="term-for-hit-test" id="infopanel-for-term-for-hit-test" role="menu">
+   <span id="infopaneltitle-for-term-for-hit-test" style="display:none">Info about the 'hit-test' external reference.</span><a href="https://immersive-web.github.io/hit-test/#hit-test">https://immersive-web.github.io/hit-test/#hit-test</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hit-test">8. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrhittestresult-native-origin">
-   <a href="https://immersive-web.github.io/hit-test/#xrhittestresult-native-origin">https://immersive-web.github.io/hit-test/#xrhittestresult-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrhittestresult-native-origin" class="dfn-panel" data-for="term-for-xrhittestresult-native-origin" id="infopanel-for-term-for-xrhittestresult-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrhittestresult-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://immersive-web.github.io/hit-test/#xrhittestresult-native-origin">https://immersive-web.github.io/hit-test/#xrhittestresult-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult-native-origin">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar">
-   <a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar" id="infopanel-for-term-for-dom-xrsessionmode-immersive-ar" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the '"immersive-ar"' external reference.</span><a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">2.1. Feature descriptor</a>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar①">7.1. Native anchor</a>
@@ -1319,14 +1319,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <div class="issue"> Session’s "list of frame updates" might need to have a way of specifying ordering - some algorithms may depend on others. <a class="issue-return" href="#issue-02fc6c42" title="Jump to section">↵</a></div>
    <div class="issue"> I’m not aware of devices that support tracking general objects that move - should they be considered by the spec at all? Are there any examples of such devices? <a class="issue-return" href="#issue-8bf9de01" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="anchors">
-   <b><a href="#anchors">#anchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchors" class="dfn-panel" data-for="anchors" id="infopanel-for-anchors" role="dialog">
+   <span id="infopaneltitle-for-anchors" style="display:none">Info about the 'anchors' definition.</span><b><a href="#anchors">#anchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchors">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xranchor">
-   <b><a href="#xranchor">#xranchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xranchor" class="dfn-panel" data-for="xranchor" id="infopanel-for-xranchor" role="dialog">
+   <span id="infopaneltitle-for-xranchor" style="display:none">Info about the 'XRAnchor' definition.</span><b><a href="#xranchor">#xranchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchor">3.1. XRAnchor</a> <a href="#ref-for-xranchor①">(2)</a> <a href="#ref-for-xranchor②">(3)</a> <a href="#ref-for-xranchor③">(4)</a> <a href="#ref-for-xranchor④">(5)</a>
     <li><a href="#ref-for-xranchor⑤">4. Anchor creation</a> <a href="#ref-for-xranchor⑥">(2)</a> <a href="#ref-for-xranchor⑦">(3)</a> <a href="#ref-for-xranchor⑧">(4)</a>
@@ -1334,28 +1334,28 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xranchor①⓪">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xranchor-anchorspace">
-   <b><a href="#dom-xranchor-anchorspace">#dom-xranchor-anchorspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xranchor-anchorspace" class="dfn-panel" data-for="dom-xranchor-anchorspace" id="infopanel-for-dom-xranchor-anchorspace" role="dialog">
+   <span id="infopaneltitle-for-dom-xranchor-anchorspace" style="display:none">Info about the 'anchorSpace' definition.</span><b><a href="#dom-xranchor-anchorspace">#dom-xranchor-anchorspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xranchor-anchorspace">3.1. XRAnchor</a> <a href="#ref-for-dom-xranchor-anchorspace①">(2)</a>
     <li><a href="#ref-for-dom-xranchor-anchorspace②">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xranchor-delete">
-   <b><a href="#dom-xranchor-delete">#dom-xranchor-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xranchor-delete" class="dfn-panel" data-for="dom-xranchor-delete" id="infopanel-for-dom-xranchor-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-xranchor-delete" style="display:none">Info about the 'delete' definition.</span><b><a href="#dom-xranchor-delete">#dom-xranchor-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xranchor-delete">6. Anchor removal</a> <a href="#ref-for-dom-xranchor-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xranchor-deleted">
-   <b><a href="#xranchor-deleted">#xranchor-deleted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xranchor-deleted" class="dfn-panel" data-for="xranchor-deleted" id="infopanel-for-xranchor-deleted" role="dialog">
+   <span id="infopaneltitle-for-xranchor-deleted" style="display:none">Info about the 'deleted' definition.</span><b><a href="#xranchor-deleted">#xranchor-deleted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchor-deleted">3.1. XRAnchor</a> <a href="#ref-for-xranchor-deleted①">(2)</a>
     <li><a href="#ref-for-xranchor-deleted②">6. Anchor removal</a> <a href="#ref-for-xranchor-deleted③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xranchor-native-origin">
-   <b><a href="#xranchor-native-origin">#xranchor-native-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xranchor-native-origin" class="dfn-panel" data-for="xranchor-native-origin" id="infopanel-for-xranchor-native-origin" role="dialog">
+   <span id="infopaneltitle-for-xranchor-native-origin" style="display:none">Info about the 'native origin' definition.</span><b><a href="#xranchor-native-origin">#xranchor-native-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchor-native-origin">3.1. XRAnchor</a> <a href="#ref-for-xranchor-native-origin①">(2)</a>
     <li><a href="#ref-for-xranchor-native-origin②">5. Anchor updates</a>
@@ -1363,163 +1363,219 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xranchor-native-origin④">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xranchor-session">
-   <b><a href="#xranchor-session">#xranchor-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xranchor-session" class="dfn-panel" data-for="xranchor-session" id="infopanel-for-xranchor-session" role="dialog">
+   <span id="infopaneltitle-for-xranchor-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xranchor-session">#xranchor-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchor-session">3.1. XRAnchor</a> <a href="#ref-for-xranchor-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-new-anchor-object">
-   <b><a href="#create-new-anchor-object">#create-new-anchor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-new-anchor-object" class="dfn-panel" data-for="create-new-anchor-object" id="infopanel-for-create-new-anchor-object" role="dialog">
+   <span id="infopaneltitle-for-create-new-anchor-object" style="display:none">Info about the 'create new anchor object' definition.</span><b><a href="#create-new-anchor-object">#create-new-anchor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-new-anchor-object">4. Anchor creation</a> <a href="#ref-for-create-new-anchor-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-set-of-tracked-anchors">
-   <b><a href="#xrsession-set-of-tracked-anchors">#xrsession-set-of-tracked-anchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-set-of-tracked-anchors" class="dfn-panel" data-for="xrsession-set-of-tracked-anchors" id="infopanel-for-xrsession-set-of-tracked-anchors" role="dialog">
+   <span id="infopaneltitle-for-xrsession-set-of-tracked-anchors" style="display:none">Info about the 'set of tracked anchors' definition.</span><b><a href="#xrsession-set-of-tracked-anchors">#xrsession-set-of-tracked-anchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-set-of-tracked-anchors">4. Anchor creation</a> <a href="#ref-for-xrsession-set-of-tracked-anchors①">(2)</a>
     <li><a href="#ref-for-xrsession-set-of-tracked-anchors②">5. Anchor updates</a> <a href="#ref-for-xrsession-set-of-tracked-anchors③">(2)</a> <a href="#ref-for-xrsession-set-of-tracked-anchors④">(3)</a>
     <li><a href="#ref-for-xrsession-set-of-tracked-anchors⑤">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-map-of-new-anchors">
-   <b><a href="#xrsession-map-of-new-anchors">#xrsession-map-of-new-anchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-map-of-new-anchors" class="dfn-panel" data-for="xrsession-map-of-new-anchors" id="infopanel-for-xrsession-map-of-new-anchors" role="dialog">
+   <span id="infopaneltitle-for-xrsession-map-of-new-anchors" style="display:none">Info about the 'map of new anchors' definition.</span><b><a href="#xrsession-map-of-new-anchors">#xrsession-map-of-new-anchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-map-of-new-anchors">4. Anchor creation</a> <a href="#ref-for-xrsession-map-of-new-anchors①">(2)</a>
     <li><a href="#ref-for-xrsession-map-of-new-anchors②">5. Anchor updates</a> <a href="#ref-for-xrsession-map-of-new-anchors③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-createanchor">
-   <b><a href="#dom-xrframe-createanchor">#dom-xrframe-createanchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-createanchor" class="dfn-panel" data-for="dom-xrframe-createanchor" id="infopanel-for-dom-xrframe-createanchor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-createanchor" style="display:none">Info about the 'createAnchor' definition.</span><b><a href="#dom-xrframe-createanchor">#dom-xrframe-createanchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-createanchor">4. Anchor creation</a> <a href="#ref-for-dom-xrframe-createanchor①">(2)</a> <a href="#ref-for-dom-xrframe-createanchor②">(3)</a> <a href="#ref-for-dom-xrframe-createanchor③">(4)</a>
     <li><a href="#ref-for-dom-xrframe-createanchor④">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestresult-createanchor">
-   <b><a href="#dom-xrhittestresult-createanchor">#dom-xrhittestresult-createanchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestresult-createanchor" class="dfn-panel" data-for="dom-xrhittestresult-createanchor" id="infopanel-for-dom-xrhittestresult-createanchor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestresult-createanchor" style="display:none">Info about the 'createAnchor' definition.</span><b><a href="#dom-xrhittestresult-createanchor">#dom-xrhittestresult-createanchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestresult-createanchor">4. Anchor creation</a> <a href="#ref-for-dom-xrhittestresult-createanchor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestresult-native-entity">
-   <b><a href="#xrhittestresult-native-entity">#xrhittestresult-native-entity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestresult-native-entity" class="dfn-panel" data-for="xrhittestresult-native-entity" id="infopanel-for-xrhittestresult-native-entity" role="dialog">
+   <span id="infopaneltitle-for-xrhittestresult-native-entity" style="display:none">Info about the 'native entity' definition.</span><b><a href="#xrhittestresult-native-entity">#xrhittestresult-native-entity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult-native-entity">4. Anchor creation</a> <a href="#ref-for-xrhittestresult-native-entity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-anchor-from-frame">
-   <b><a href="#create-an-anchor-from-frame">#create-an-anchor-from-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-anchor-from-frame" class="dfn-panel" data-for="create-an-anchor-from-frame" id="infopanel-for-create-an-anchor-from-frame" role="dialog">
+   <span id="infopaneltitle-for-create-an-anchor-from-frame" style="display:none">Info about the 'create an anchor from frame' definition.</span><b><a href="#create-an-anchor-from-frame">#create-an-anchor-from-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-anchor-from-frame">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-anchor-from-hit-test-result">
-   <b><a href="#create-an-anchor-from-hit-test-result">#create-an-anchor-from-hit-test-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-anchor-from-hit-test-result" class="dfn-panel" data-for="create-an-anchor-from-hit-test-result" id="infopanel-for-create-an-anchor-from-hit-test-result" role="dialog">
+   <span id="infopaneltitle-for-create-an-anchor-from-hit-test-result" style="display:none">Info about the 'create an anchor from hit test result' definition.</span><b><a href="#create-an-anchor-from-hit-test-result">#create-an-anchor-from-hit-test-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-anchor-from-hit-test-result">4. Anchor creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xranchorset">
-   <b><a href="#xranchorset">#xranchorset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xranchorset" class="dfn-panel" data-for="xranchorset" id="infopanel-for-xranchorset" role="dialog">
+   <span id="infopaneltitle-for-xranchorset" style="display:none">Info about the 'XRAnchorSet' definition.</span><b><a href="#xranchorset">#xranchorset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchorset">5. Anchor updates</a> <a href="#ref-for-xranchorset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-trackedanchors">
-   <b><a href="#dom-xrframe-trackedanchors">#dom-xrframe-trackedanchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-trackedanchors" class="dfn-panel" data-for="dom-xrframe-trackedanchors" id="infopanel-for-dom-xrframe-trackedanchors" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-trackedanchors" style="display:none">Info about the 'trackedAnchors' definition.</span><b><a href="#dom-xrframe-trackedanchors">#dom-xrframe-trackedanchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-trackedanchors">5. Anchor updates</a> <a href="#ref-for-dom-xrframe-trackedanchors①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-anchors">
-   <b><a href="#update-anchors">#update-anchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-anchors" class="dfn-panel" data-for="update-anchors" id="infopanel-for-update-anchors" role="dialog">
+   <span id="infopaneltitle-for-update-anchors" style="display:none">Info about the 'update anchors' definition.</span><b><a href="#update-anchors">#update-anchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-anchors">4. Anchor creation</a> <a href="#ref-for-update-anchors①">(2)</a>
     <li><a href="#ref-for-update-anchors②">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delete-an-anchor">
-   <b><a href="#delete-an-anchor">#delete-an-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delete-an-anchor" class="dfn-panel" data-for="delete-an-anchor" id="infopanel-for-delete-an-anchor" role="dialog">
+   <span id="infopaneltitle-for-delete-an-anchor" style="display:none">Info about the 'delete an anchor' definition.</span><b><a href="#delete-an-anchor">#delete-an-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delete-an-anchor">6. Anchor removal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tracked">
-   <b><a href="#tracked">#tracked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tracked" class="dfn-panel" data-for="tracked" id="infopanel-for-tracked" role="dialog">
+   <span id="infopaneltitle-for-tracked" style="display:none">Info about the 'tracked' definition.</span><b><a href="#tracked">#tracked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tracked">5. Anchor updates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attached">
-   <b><a href="#attached">#attached</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attached" class="dfn-panel" data-for="attached" id="infopanel-for-attached" role="dialog">
+   <span id="infopaneltitle-for-attached" style="display:none">Info about the 'attached' definition.</span><b><a href="#attached">#attached</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attached">4. Anchor creation</a>
     <li><a href="#ref-for-attached①">7.1. Native anchor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="emulated-native-anchors">
-   <b><a href="#emulated-native-anchors">#emulated-native-anchors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-emulated-native-anchors" class="dfn-panel" data-for="emulated-native-anchors" id="infopanel-for-emulated-native-anchors" role="dialog">
+   <span id="infopaneltitle-for-emulated-native-anchors" style="display:none">Info about the 'emulated native anchors' definition.</span><b><a href="#emulated-native-anchors">#emulated-native-anchors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-emulated-native-anchors">7.1. Native anchor</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/depth-sensing/index.html
+++ b/tests/github/immersive-web/depth-sensing/index.html
@@ -1282,59 +1282,59 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#enumdef-xrdepthusage">XRDepthUsage</a><span>, in § 2.2</span>
    <li><a href="#xrwebgldepthinformation">XRWebGLDepthInformation</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-list-contain①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-3.7">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-3.7" class="dfn-panel" data-for="term-for-3.7" id="infopanel-for-term-for-3.7" role="menu">
+   <span id="infopaneltitle-for-term-for-3.7" style="display:none">Info about the 'r32f' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3.7">2.2. Intended data usage and data formats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.1">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.1" class="dfn-panel" data-for="term-for-5.1" id="infopanel-for-term-for-5.1" role="menu">
+   <span id="infopaneltitle-for-term-for-5.1" style="display:none">Info about the 'GLenum' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.1">2.2. Intended data usage and data formats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.9">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.9">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.9</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.9" class="dfn-panel" data-for="term-for-5.9" id="infopanel-for-term-for-5.9" role="menu">
+   <span id="infopaneltitle-for-term-for-5.9" style="display:none">Info about the 'WebGLTexture' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.9">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.9">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14" style="display:none">Info about the 'luminance_alpha' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14">2.2. Intended data usage and data formats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">3.2. XRCPUDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-Exposed①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-Exposed②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">2.2. Intended data usage and data formats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.3. Session configuration</a> <a href="#ref-for-invalidstateerror①">(2)</a>
     <li><a href="#ref-for-invalidstateerror②">3.1. XRDepthInformation</a> <a href="#ref-for-invalidstateerror③">(2)</a>
@@ -1342,219 +1342,219 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-invalidstateerror⑧">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-invalidstateerror⑨">(2)</a> <a href="#ref-for-invalidstateerror①⓪">(3)</a> <a href="#ref-for-invalidstateerror①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">2.3. Session configuration</a> <a href="#ref-for-notsupportederror①">(2)</a>
     <li><a href="#ref-for-notsupportederror②">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-notsupportederror③">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">3.2. XRCPUDepthInformation</a> <a href="#ref-for-exceptiondef-rangeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-SameObject①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-SameObject②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. XRDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint16Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint16Array">https://webidl.spec.whatwg.org/#idl-Uint16Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint16Array" class="dfn-panel" data-for="term-for-idl-Uint16Array" id="infopanel-for-term-for-idl-Uint16Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint16Array" style="display:none">Info about the 'Uint16Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint16Array">https://webidl.spec.whatwg.org/#idl-Uint16Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint16Array">2.2. Intended data usage and data formats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-idl-float①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-idl-float②">(2)</a> <a href="#ref-for-idl-float③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.3. Session configuration</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a>
     <li><a href="#ref-for-dfn-throw④">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3.1. XRDepthInformation</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-callbackdef-xrframerequestcallback">
-   <a href="https://immersive-web.github.io/webxr/#callbackdef-xrframerequestcallback">https://immersive-web.github.io/webxr/#callbackdef-xrframerequestcallback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-callbackdef-xrframerequestcallback" class="dfn-panel" data-for="term-for-callbackdef-xrframerequestcallback" id="infopanel-for-term-for-callbackdef-xrframerequestcallback" role="menu">
+   <span id="infopaneltitle-for-term-for-callbackdef-xrframerequestcallback" style="display:none">Info about the 'XRFrameRequestCallback' external reference.</span><a href="https://immersive-web.github.io/webxr/#callbackdef-xrframerequestcallback">https://immersive-web.github.io/webxr/#callbackdef-xrframerequestcallback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-xrframerequestcallback">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-callbackdef-xrframerequestcallback①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform" class="dfn-panel" data-for="term-for-xrrigidtransform" id="infopanel-for-term-for-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">3.1. XRDepthInformation</a> <a href="#ref-for-xrrigidtransform①">(2)</a>
     <li><a href="#ref-for-xrrigidtransform②">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrrigidtransform③">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-xrsessioninit">
-   <a href="https://immersive-web.github.io/webxr/#dictdef-xrsessioninit">https://immersive-web.github.io/webxr/#dictdef-xrsessioninit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-xrsessioninit" class="dfn-panel" data-for="term-for-dictdef-xrsessioninit" id="infopanel-for-term-for-dictdef-xrsessioninit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-xrsessioninit" style="display:none">Info about the 'XRSessionInit' external reference.</span><a href="https://immersive-web.github.io/webxr/#dictdef-xrsessioninit">https://immersive-web.github.io/webxr/#dictdef-xrsessioninit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrsessioninit">2.3. Session configuration</a> <a href="#ref-for-dictdef-xrsessioninit①">(2)</a> <a href="#ref-for-dictdef-xrsessioninit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrview">
-   <a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrview" class="dfn-panel" data-for="term-for-xrview" id="infopanel-for-term-for-xrview" role="menu">
+   <span id="infopaneltitle-for-term-for-xrview" style="display:none">Info about the 'XRView' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-xrview①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrview②">(2)</a> <a href="#ref-for-xrview③">(3)</a>
     <li><a href="#ref-for-xrview④">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-xrview⑤">(2)</a> <a href="#ref-for-xrview⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessioninit-optionalfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessioninit-optionalfeatures" class="dfn-panel" data-for="term-for-dom-xrsessioninit-optionalfeatures" id="infopanel-for-term-for-dom-xrsessioninit-optionalfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessioninit-optionalfeatures" style="display:none">Info about the 'optionalFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-optionalfeatures">2.3. Session configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsystem-requestsession" class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession" id="infopanel-for-term-for-dom-xrsystem-requestsession" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsystem-requestsession" style="display:none">Info about the 'requestSession(mode, options)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-requestsession">2.3. Session configuration</a> <a href="#ref-for-dom-xrsystem-requestsession①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessioninit-requiredfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessioninit-requiredfeatures" class="dfn-panel" data-for="term-for-dom-xrsessioninit-requiredfeatures" id="infopanel-for-term-for-dom-xrsessioninit-requiredfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessioninit-requiredfeatures" style="display:none">Info about the 'requiredFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-requiredfeatures">2.3. Session configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrframe-session①">(2)</a> <a href="#ref-for-dom-xrframe-session②">(3)</a>
     <li><a href="#ref-for-dom-xrframe-session③">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-dom-xrframe-session④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-interface" class="dfn-panel" data-for="term-for-xrframe-interface" id="infopanel-for-term-for-xrframe-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-interface" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-interface">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrframe-interface①">(2)</a> <a href="#ref-for-xrframe-interface②">(3)</a> <a href="#ref-for-xrframe-interface③">(4)</a>
     <li><a href="#ref-for-xrframe-interface④">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-interface" class="dfn-panel" data-for="term-for-xrsession-interface" id="infopanel-for-term-for-xrsession-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-interface" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-interface">1. Introduction</a>
     <li><a href="#ref-for-xrsession-interface①">2.3. Session configuration</a> <a href="#ref-for-xrsession-interface②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-xrframe-active①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrframe-active②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-animationframe">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-animationframe">https://www.w3.org/TR/webxr/#xrframe-animationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-animationframe" class="dfn-panel" data-for="term-for-xrframe-animationframe" id="infopanel-for-term-for-xrframe-animationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-animationframe" style="display:none">Info about the 'animationframe' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-animationframe">https://www.w3.org/TR/webxr/#xrframe-animationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-animationframe">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-xrframe-animationframe①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrframe-animationframe②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-capable-of-supporting">
-   <a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-capable-of-supporting" class="dfn-panel" data-for="term-for-capable-of-supporting" id="infopanel-for-term-for-capable-of-supporting" role="menu">
+   <span id="infopaneltitle-for-term-for-capable-of-supporting" style="display:none">Info about the 'capable of supporting' external reference.</span><a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capable-of-supporting">2.1. Feature descriptor</a> <a href="#ref-for-capable-of-supporting①">(2)</a>
     <li><a href="#ref-for-capable-of-supporting②">2.3. Session configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-descriptor">
-   <a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-descriptor" class="dfn-panel" data-for="term-for-feature-descriptor" id="infopanel-for-term-for-feature-descriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-policy">
-   <a href="https://www.w3.org/TR/webxr/#feature-policy">https://www.w3.org/TR/webxr/#feature-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-policy" class="dfn-panel" data-for="term-for-feature-policy" id="infopanel-for-term-for-feature-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-policy" style="display:none">Info about the 'feature policy' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-policy">https://www.w3.org/TR/webxr/#feature-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-policy">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrview-frame">
-   <a href="https://www.w3.org/TR/webxr/#xrview-frame">https://www.w3.org/TR/webxr/#xrview-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrview-frame" class="dfn-panel" data-for="term-for-xrview-frame" id="infopanel-for-term-for-xrview-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-xrview-frame" style="display:none">Info about the 'frame' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrview-frame">https://www.w3.org/TR/webxr/#xrview-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-frame">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-xrview-frame①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrview-frame②">(2)</a>
     <li><a href="#ref-for-xrview-frame③">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-xr-device" class="dfn-panel" data-for="term-for-inline-xr-device" id="infopanel-for-term-for-inline-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-xr-device" style="display:none">Info about the 'inline xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-xr-device">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-device-list-of-enabled-features">
-   <a href="https://www.w3.org/TR/webxr/#xr-device-list-of-enabled-features">https://www.w3.org/TR/webxr/#xr-device-list-of-enabled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-device-list-of-enabled-features" class="dfn-panel" data-for="term-for-xr-device-list-of-enabled-features" id="infopanel-for-term-for-xr-device-list-of-enabled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-device-list-of-enabled-features" style="display:none">Info about the 'list of enabled features' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-device-list-of-enabled-features">https://www.w3.org/TR/webxr/#xr-device-list-of-enabled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device-list-of-enabled-features">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xr-device-list-of-enabled-features①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-mode">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-mode">https://www.w3.org/TR/webxr/#xrsession-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-mode" class="dfn-panel" data-for="term-for-xrsession-mode" id="infopanel-for-term-for-xrsession-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-mode">https://www.w3.org/TR/webxr/#xrsession-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-mode">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrsession-mode①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-time">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-time" class="dfn-panel" data-for="term-for-xrframe-time" id="infopanel-for-term-for-xrframe-time" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-time" style="display:none">Info about the 'time' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-time">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrframe-time①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-xr-device" class="dfn-panel" data-for="term-for-xrsession-xr-device" id="infopanel-for-term-for-xrsession-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrsession-xr-device①">(2)</a>
     <li><a href="#ref-for-xrsession-xr-device②">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-xrsession-xr-device③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opaque-texture">
-   <a href="https://immersive-web.github.io/layers/#opaque-texture">https://immersive-web.github.io/layers/#opaque-texture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opaque-texture" class="dfn-panel" data-for="term-for-opaque-texture" id="infopanel-for-term-for-opaque-texture" role="menu">
+   <span id="infopaneltitle-for-term-for-opaque-texture" style="display:none">Info about the 'opaque texture' external reference.</span><a href="https://immersive-web.github.io/layers/#opaque-texture">https://immersive-web.github.io/layers/#opaque-texture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-texture">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-opaque-texture①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebglbinding">
-   <a href="https://immersive-web.github.io/layers/#xrwebglbinding">https://immersive-web.github.io/layers/#xrwebglbinding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebglbinding" class="dfn-panel" data-for="term-for-xrwebglbinding" id="infopanel-for-term-for-xrwebglbinding" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebglbinding" style="display:none">Info about the 'XRWebGLBinding' external reference.</span><a href="https://immersive-web.github.io/layers/#xrwebglbinding">https://immersive-web.github.io/layers/#xrwebglbinding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-xrwebglbinding①">(2)</a> <a href="#ref-for-xrwebglbinding②">(3)</a>
    </ul>
@@ -1711,153 +1711,153 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="normalized-view-coordinates">
-   <b><a href="#normalized-view-coordinates">#normalized-view-coordinates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalized-view-coordinates" class="dfn-panel" data-for="normalized-view-coordinates" id="infopanel-for-normalized-view-coordinates" role="dialog">
+   <span id="infopaneltitle-for-normalized-view-coordinates" style="display:none">Info about the 'normalized view coordinates' definition.</span><b><a href="#normalized-view-coordinates">#normalized-view-coordinates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalized-view-coordinates">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-normalized-view-coordinates①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-normalized-view-coordinates②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="depth-sensing">
-   <b><a href="#depth-sensing">#depth-sensing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-depth-sensing" class="dfn-panel" data-for="depth-sensing" id="infopanel-for-depth-sensing" role="dialog">
+   <span id="infopaneltitle-for-depth-sensing" style="display:none">Info about the 'depth-sensing' definition.</span><b><a href="#depth-sensing">#depth-sensing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depth-sensing">2.3. Session configuration</a>
     <li><a href="#ref-for-depth-sensing①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-depth-sensing②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrdepthusage">
-   <b><a href="#enumdef-xrdepthusage">#enumdef-xrdepthusage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrdepthusage" class="dfn-panel" data-for="enumdef-xrdepthusage" id="infopanel-for-enumdef-xrdepthusage" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrdepthusage" style="display:none">Info about the 'XRDepthUsage' definition.</span><b><a href="#enumdef-xrdepthusage">#enumdef-xrdepthusage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrdepthusage">2.3. Session configuration</a> <a href="#ref-for-enumdef-xrdepthusage①">(2)</a> <a href="#ref-for-enumdef-xrdepthusage②">(3)</a> <a href="#ref-for-enumdef-xrdepthusage③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthusage-cpu-optimized">
-   <b><a href="#dom-xrdepthusage-cpu-optimized">#dom-xrdepthusage-cpu-optimized</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthusage-cpu-optimized" class="dfn-panel" data-for="dom-xrdepthusage-cpu-optimized" id="infopanel-for-dom-xrdepthusage-cpu-optimized" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthusage-cpu-optimized" style="display:none">Info about the '"cpu-optimized"' definition.</span><b><a href="#dom-xrdepthusage-cpu-optimized">#dom-xrdepthusage-cpu-optimized</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthusage-cpu-optimized">2.2. Intended data usage and data formats</a>
     <li><a href="#ref-for-dom-xrdepthusage-cpu-optimized①">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-dom-xrdepthusage-cpu-optimized②">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthusage-gpu-optimized">
-   <b><a href="#dom-xrdepthusage-gpu-optimized">#dom-xrdepthusage-gpu-optimized</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthusage-gpu-optimized" class="dfn-panel" data-for="dom-xrdepthusage-gpu-optimized" id="infopanel-for-dom-xrdepthusage-gpu-optimized" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthusage-gpu-optimized" style="display:none">Info about the '"gpu-optimized"' definition.</span><b><a href="#dom-xrdepthusage-gpu-optimized">#dom-xrdepthusage-gpu-optimized</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthusage-gpu-optimized">2.2. Intended data usage and data formats</a>
     <li><a href="#ref-for-dom-xrdepthusage-gpu-optimized①">3.3. XRWebGLDepthInformation</a>
     <li><a href="#ref-for-dom-xrdepthusage-gpu-optimized②">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrdepthdataformat">
-   <b><a href="#enumdef-xrdepthdataformat">#enumdef-xrdepthdataformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrdepthdataformat" class="dfn-panel" data-for="enumdef-xrdepthdataformat" id="infopanel-for-enumdef-xrdepthdataformat" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrdepthdataformat" style="display:none">Info about the 'XRDepthDataFormat' definition.</span><b><a href="#enumdef-xrdepthdataformat">#enumdef-xrdepthdataformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrdepthdataformat">2.3. Session configuration</a> <a href="#ref-for-enumdef-xrdepthdataformat①">(2)</a> <a href="#ref-for-enumdef-xrdepthdataformat②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthdataformat-luminance-alpha">
-   <b><a href="#dom-xrdepthdataformat-luminance-alpha">#dom-xrdepthdataformat-luminance-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthdataformat-luminance-alpha" class="dfn-panel" data-for="dom-xrdepthdataformat-luminance-alpha" id="infopanel-for-dom-xrdepthdataformat-luminance-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthdataformat-luminance-alpha" style="display:none">Info about the '"luminance-alpha"' definition.</span><b><a href="#dom-xrdepthdataformat-luminance-alpha">#dom-xrdepthdataformat-luminance-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthdataformat-luminance-alpha">2.2. Intended data usage and data formats</a> <a href="#ref-for-dom-xrdepthdataformat-luminance-alpha①">(2)</a>
     <li><a href="#ref-for-dom-xrdepthdataformat-luminance-alpha②">2.3. Session configuration</a>
     <li><a href="#ref-for-dom-xrdepthdataformat-luminance-alpha③">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthdataformat-float32">
-   <b><a href="#dom-xrdepthdataformat-float32">#dom-xrdepthdataformat-float32</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthdataformat-float32" class="dfn-panel" data-for="dom-xrdepthdataformat-float32" id="infopanel-for-dom-xrdepthdataformat-float32" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthdataformat-float32" style="display:none">Info about the '"float32"' definition.</span><b><a href="#dom-xrdepthdataformat-float32">#dom-xrdepthdataformat-float32</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthdataformat-float32">2.2. Intended data usage and data formats</a> <a href="#ref-for-dom-xrdepthdataformat-float32①">(2)</a>
     <li><a href="#ref-for-dom-xrdepthdataformat-float32②">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrdepthstateinit">
-   <b><a href="#dictdef-xrdepthstateinit">#dictdef-xrdepthstateinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrdepthstateinit" class="dfn-panel" data-for="dictdef-xrdepthstateinit" id="infopanel-for-dictdef-xrdepthstateinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrdepthstateinit" style="display:none">Info about the 'XRDepthStateInit' definition.</span><b><a href="#dictdef-xrdepthstateinit">#dictdef-xrdepthstateinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrdepthstateinit">2.3. Session configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthstateinit-usagepreference">
-   <b><a href="#dom-xrdepthstateinit-usagepreference">#dom-xrdepthstateinit-usagepreference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthstateinit-usagepreference" class="dfn-panel" data-for="dom-xrdepthstateinit-usagepreference" id="infopanel-for-dom-xrdepthstateinit-usagepreference" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthstateinit-usagepreference" style="display:none">Info about the 'usagePreference' definition.</span><b><a href="#dom-xrdepthstateinit-usagepreference">#dom-xrdepthstateinit-usagepreference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthstateinit-usagepreference">2.3. Session configuration</a> <a href="#ref-for-dom-xrdepthstateinit-usagepreference①">(2)</a> <a href="#ref-for-dom-xrdepthstateinit-usagepreference②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthstateinit-dataformatpreference">
-   <b><a href="#dom-xrdepthstateinit-dataformatpreference">#dom-xrdepthstateinit-dataformatpreference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthstateinit-dataformatpreference" class="dfn-panel" data-for="dom-xrdepthstateinit-dataformatpreference" id="infopanel-for-dom-xrdepthstateinit-dataformatpreference" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthstateinit-dataformatpreference" style="display:none">Info about the 'dataFormatPreference' definition.</span><b><a href="#dom-xrdepthstateinit-dataformatpreference">#dom-xrdepthstateinit-dataformatpreference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthstateinit-dataformatpreference">2.3. Session configuration</a> <a href="#ref-for-dom-xrdepthstateinit-dataformatpreference①">(2)</a> <a href="#ref-for-dom-xrdepthstateinit-dataformatpreference②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessioninit-depthsensing">
-   <b><a href="#dom-xrsessioninit-depthsensing">#dom-xrsessioninit-depthsensing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessioninit-depthsensing" class="dfn-panel" data-for="dom-xrsessioninit-depthsensing" id="infopanel-for-dom-xrsessioninit-depthsensing" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessioninit-depthsensing" style="display:none">Info about the 'depthSensing' definition.</span><b><a href="#dom-xrsessioninit-depthsensing">#dom-xrsessioninit-depthsensing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-depthsensing">2.3. Session configuration</a> <a href="#ref-for-dom-xrsessioninit-depthsensing①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-supported-configuration-combination">
-   <b><a href="#find-supported-configuration-combination">#find-supported-configuration-combination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-supported-configuration-combination" class="dfn-panel" data-for="find-supported-configuration-combination" id="infopanel-for-find-supported-configuration-combination" role="dialog">
+   <span id="infopaneltitle-for-find-supported-configuration-combination" style="display:none">Info about the 'find supported configuration combination' definition.</span><b><a href="#find-supported-configuration-combination">#find-supported-configuration-combination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-supported-configuration-combination">2.3. Session configuration</a> <a href="#ref-for-find-supported-configuration-combination①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-depthusage">
-   <b><a href="#dom-xrsession-depthusage">#dom-xrsession-depthusage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-depthusage" class="dfn-panel" data-for="dom-xrsession-depthusage" id="infopanel-for-dom-xrsession-depthusage" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-depthusage" style="display:none">Info about the 'depthUsage' definition.</span><b><a href="#dom-xrsession-depthusage">#dom-xrsession-depthusage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-depthusage">2.3. Session configuration</a> <a href="#ref-for-dom-xrsession-depthusage①">(2)</a>
     <li><a href="#ref-for-dom-xrsession-depthusage②">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrsession-depthusage③">(2)</a>
     <li><a href="#ref-for-dom-xrsession-depthusage④">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-dom-xrsession-depthusage⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-depthdataformat">
-   <b><a href="#dom-xrsession-depthdataformat">#dom-xrsession-depthdataformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-depthdataformat" class="dfn-panel" data-for="dom-xrsession-depthdataformat" id="infopanel-for-dom-xrsession-depthdataformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-depthdataformat" style="display:none">Info about the 'depthDataFormat' definition.</span><b><a href="#dom-xrsession-depthdataformat">#dom-xrsession-depthdataformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-depthdataformat">2.3. Session configuration</a> <a href="#ref-for-dom-xrsession-depthdataformat①">(2)</a>
     <li><a href="#ref-for-dom-xrsession-depthdataformat②">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrsession-depthdataformat③">(2)</a> <a href="#ref-for-dom-xrsession-depthdataformat④">(3)</a>
     <li><a href="#ref-for-dom-xrsession-depthdataformat⑤">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-dom-xrsession-depthdataformat⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrdepthinformation">
-   <b><a href="#xrdepthinformation">#xrdepthinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrdepthinformation" class="dfn-panel" data-for="xrdepthinformation" id="infopanel-for-xrdepthinformation" role="dialog">
+   <span id="infopaneltitle-for-xrdepthinformation" style="display:none">Info about the 'XRDepthInformation' definition.</span><b><a href="#xrdepthinformation">#xrdepthinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrdepthinformation">3.1. XRDepthInformation</a> <a href="#ref-for-xrdepthinformation①">(2)</a> <a href="#ref-for-xrdepthinformation②">(3)</a> <a href="#ref-for-xrdepthinformation③">(4)</a>
     <li><a href="#ref-for-xrdepthinformation④">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-xrdepthinformation⑤">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-xrdepthinformation⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthinformation-width">
-   <b><a href="#dom-xrdepthinformation-width">#dom-xrdepthinformation-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthinformation-width" class="dfn-panel" data-for="dom-xrdepthinformation-width" id="infopanel-for-dom-xrdepthinformation-width" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthinformation-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-xrdepthinformation-width">#dom-xrdepthinformation-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthinformation-width">3.1. XRDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-width①">(2)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-width②">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-width③">(2)</a> <a href="#ref-for-dom-xrdepthinformation-width④">(3)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-width⑤">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthinformation-height">
-   <b><a href="#dom-xrdepthinformation-height">#dom-xrdepthinformation-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthinformation-height" class="dfn-panel" data-for="dom-xrdepthinformation-height" id="infopanel-for-dom-xrdepthinformation-height" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthinformation-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-xrdepthinformation-height">#dom-xrdepthinformation-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthinformation-height">3.1. XRDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-height①">(2)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-height②">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-height③">(2)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-height④">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthinformation-normdepthbufferfromnormview">
-   <b><a href="#dom-xrdepthinformation-normdepthbufferfromnormview">#dom-xrdepthinformation-normdepthbufferfromnormview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthinformation-normdepthbufferfromnormview" class="dfn-panel" data-for="dom-xrdepthinformation-normdepthbufferfromnormview" id="infopanel-for-dom-xrdepthinformation-normdepthbufferfromnormview" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthinformation-normdepthbufferfromnormview" style="display:none">Info about the 'normDepthBufferFromNormView' definition.</span><b><a href="#dom-xrdepthinformation-normdepthbufferfromnormview">#dom-xrdepthinformation-normdepthbufferfromnormview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview②">(2)</a> <a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview③">(3)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview④">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-normdepthbufferfromnormview⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdepthinformation-rawvaluetometers">
-   <b><a href="#dom-xrdepthinformation-rawvaluetometers">#dom-xrdepthinformation-rawvaluetometers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdepthinformation-rawvaluetometers" class="dfn-panel" data-for="dom-xrdepthinformation-rawvaluetometers" id="infopanel-for-dom-xrdepthinformation-rawvaluetometers" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdepthinformation-rawvaluetometers" style="display:none">Info about the 'rawValueToMeters' definition.</span><b><a href="#dom-xrdepthinformation-rawvaluetometers">#dom-xrdepthinformation-rawvaluetometers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdepthinformation-rawvaluetometers">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-dom-xrdepthinformation-rawvaluetometers①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrdepthinformation-rawvaluetometers②">(2)</a>
     <li><a href="#ref-for-dom-xrdepthinformation-rawvaluetometers③">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrdepthinformation-view">
-   <b><a href="#xrdepthinformation-view">#xrdepthinformation-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrdepthinformation-view" class="dfn-panel" data-for="xrdepthinformation-view" id="infopanel-for-xrdepthinformation-view" role="dialog">
+   <span id="infopaneltitle-for-xrdepthinformation-view" style="display:none">Info about the 'view' definition.</span><b><a href="#xrdepthinformation-view">#xrdepthinformation-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrdepthinformation-view">3.1. XRDepthInformation</a>
     <li><a href="#ref-for-xrdepthinformation-view①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrdepthinformation-view②">(2)</a> <a href="#ref-for-xrdepthinformation-view③">(3)</a>
@@ -1865,28 +1865,28 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xrdepthinformation-view⑥">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrdepthinformation-depth-buffer">
-   <b><a href="#xrdepthinformation-depth-buffer">#xrdepthinformation-depth-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrdepthinformation-depth-buffer" class="dfn-panel" data-for="xrdepthinformation-depth-buffer" id="infopanel-for-xrdepthinformation-depth-buffer" role="dialog">
+   <span id="infopaneltitle-for-xrdepthinformation-depth-buffer" style="display:none">Info about the 'depth buffer' definition.</span><b><a href="#xrdepthinformation-depth-buffer">#xrdepthinformation-depth-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrdepthinformation-depth-buffer">3.1. XRDepthInformation</a> <a href="#ref-for-xrdepthinformation-depth-buffer①">(2)</a> <a href="#ref-for-xrdepthinformation-depth-buffer②">(3)</a> <a href="#ref-for-xrdepthinformation-depth-buffer③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attempting-to-access-the-depth-buffer">
-   <b><a href="#attempting-to-access-the-depth-buffer">#attempting-to-access-the-depth-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attempting-to-access-the-depth-buffer" class="dfn-panel" data-for="attempting-to-access-the-depth-buffer" id="infopanel-for-attempting-to-access-the-depth-buffer" role="dialog">
+   <span id="infopaneltitle-for-attempting-to-access-the-depth-buffer" style="display:none">Info about the 'attempting to access the depth buffer' definition.</span><b><a href="#attempting-to-access-the-depth-buffer">#attempting-to-access-the-depth-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attempting-to-access-the-depth-buffer">3.2. XRCPUDepthInformation</a> <a href="#ref-for-attempting-to-access-the-depth-buffer①">(2)</a>
     <li><a href="#ref-for-attempting-to-access-the-depth-buffer②">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcpudepthinformation">
-   <b><a href="#xrcpudepthinformation">#xrcpudepthinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcpudepthinformation" class="dfn-panel" data-for="xrcpudepthinformation" id="infopanel-for-xrcpudepthinformation" role="dialog">
+   <span id="infopaneltitle-for-xrcpudepthinformation" style="display:none">Info about the 'XRCPUDepthInformation' definition.</span><b><a href="#xrcpudepthinformation">#xrcpudepthinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcpudepthinformation">2.2. Intended data usage and data formats</a>
     <li><a href="#ref-for-xrcpudepthinformation①">3.2. XRCPUDepthInformation</a> <a href="#ref-for-xrcpudepthinformation②">(2)</a> <a href="#ref-for-xrcpudepthinformation③">(3)</a> <a href="#ref-for-xrcpudepthinformation④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcpudepthinformation-data">
-   <b><a href="#dom-xrcpudepthinformation-data">#dom-xrcpudepthinformation-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcpudepthinformation-data" class="dfn-panel" data-for="dom-xrcpudepthinformation-data" id="infopanel-for-dom-xrcpudepthinformation-data" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcpudepthinformation-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-xrcpudepthinformation-data">#dom-xrcpudepthinformation-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcpudepthinformation-data">1.1. Terminology</a>
     <li><a href="#ref-for-dom-xrcpudepthinformation-data①">2.2. Intended data usage and data formats</a> <a href="#ref-for-dom-xrcpudepthinformation-data②">(2)</a>
@@ -1894,112 +1894,112 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-dom-xrcpudepthinformation-data⑦">4. Interpreting the results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcpudepthinformation-getdepthinmeters">
-   <b><a href="#dom-xrcpudepthinformation-getdepthinmeters">#dom-xrcpudepthinformation-getdepthinmeters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcpudepthinformation-getdepthinmeters" class="dfn-panel" data-for="dom-xrcpudepthinformation-getdepthinmeters" id="infopanel-for-dom-xrcpudepthinformation-getdepthinmeters" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcpudepthinformation-getdepthinmeters" style="display:none">Info about the 'getDepthInMeters' definition.</span><b><a href="#dom-xrcpudepthinformation-getdepthinmeters">#dom-xrcpudepthinformation-getdepthinmeters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcpudepthinformation-getdepthinmeters">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrcpudepthinformation-getdepthinmeters①">(2)</a> <a href="#ref-for-dom-xrcpudepthinformation-getdepthinmeters②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-depth-at-coordinates">
-   <b><a href="#obtain-depth-at-coordinates">#obtain-depth-at-coordinates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-depth-at-coordinates" class="dfn-panel" data-for="obtain-depth-at-coordinates" id="infopanel-for-obtain-depth-at-coordinates" role="dialog">
+   <span id="infopaneltitle-for-obtain-depth-at-coordinates" style="display:none">Info about the 'obtain depth at coordinates' definition.</span><b><a href="#obtain-depth-at-coordinates">#obtain-depth-at-coordinates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-depth-at-coordinates">3.2. XRCPUDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-getdepthinformation">
-   <b><a href="#dom-xrframe-getdepthinformation">#dom-xrframe-getdepthinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-getdepthinformation" class="dfn-panel" data-for="dom-xrframe-getdepthinformation" id="infopanel-for-dom-xrframe-getdepthinformation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-getdepthinformation" style="display:none">Info about the 'getDepthInformation(view)' definition.</span><b><a href="#dom-xrframe-getdepthinformation">#dom-xrframe-getdepthinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getdepthinformation">3.2. XRCPUDepthInformation</a> <a href="#ref-for-dom-xrframe-getdepthinformation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-cpu-depth-information">
-   <b><a href="#obtain-cpu-depth-information">#obtain-cpu-depth-information</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-cpu-depth-information" class="dfn-panel" data-for="obtain-cpu-depth-information" id="infopanel-for-obtain-cpu-depth-information" role="dialog">
+   <span id="infopaneltitle-for-obtain-cpu-depth-information" style="display:none">Info about the 'obtain CPU depth information' definition.</span><b><a href="#obtain-cpu-depth-information">#obtain-cpu-depth-information</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-cpu-depth-information">3.2. XRCPUDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-cpu-depth-information-instance">
-   <b><a href="#create-a-cpu-depth-information-instance">#create-a-cpu-depth-information-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-cpu-depth-information-instance" class="dfn-panel" data-for="create-a-cpu-depth-information-instance" id="infopanel-for-create-a-cpu-depth-information-instance" role="dialog">
+   <span id="infopaneltitle-for-create-a-cpu-depth-information-instance" style="display:none">Info about the 'create a CPU depth information instance' definition.</span><b><a href="#create-a-cpu-depth-information-instance">#create-a-cpu-depth-information-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cpu-depth-information-instance">3.2. XRCPUDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgldepthinformation">
-   <b><a href="#xrwebgldepthinformation">#xrwebgldepthinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgldepthinformation" class="dfn-panel" data-for="xrwebgldepthinformation" id="infopanel-for-xrwebgldepthinformation" role="dialog">
+   <span id="infopaneltitle-for-xrwebgldepthinformation" style="display:none">Info about the 'XRWebGLDepthInformation' definition.</span><b><a href="#xrwebgldepthinformation">#xrwebgldepthinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgldepthinformation">2.2. Intended data usage and data formats</a>
     <li><a href="#ref-for-xrwebgldepthinformation①">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-xrwebgldepthinformation②">(2)</a> <a href="#ref-for-xrwebgldepthinformation③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgldepthinformation-texture">
-   <b><a href="#dom-xrwebgldepthinformation-texture">#dom-xrwebgldepthinformation-texture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgldepthinformation-texture" class="dfn-panel" data-for="dom-xrwebgldepthinformation-texture" id="infopanel-for-dom-xrwebgldepthinformation-texture" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgldepthinformation-texture" style="display:none">Info about the 'texture' definition.</span><b><a href="#dom-xrwebgldepthinformation-texture">#dom-xrwebgldepthinformation-texture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgldepthinformation-texture">1.1. Terminology</a>
     <li><a href="#ref-for-dom-xrwebgldepthinformation-texture①">3.3. XRWebGLDepthInformation</a> <a href="#ref-for-dom-xrwebgldepthinformation-texture②">(2)</a>
     <li><a href="#ref-for-dom-xrwebgldepthinformation-texture③">4. Interpreting the results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-getdepthinformation">
-   <b><a href="#dom-xrwebglbinding-getdepthinformation">#dom-xrwebglbinding-getdepthinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-getdepthinformation" class="dfn-panel" data-for="dom-xrwebglbinding-getdepthinformation" id="infopanel-for-dom-xrwebglbinding-getdepthinformation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-getdepthinformation" style="display:none">Info about the 'getDepthInformation' definition.</span><b><a href="#dom-xrwebglbinding-getdepthinformation">#dom-xrwebglbinding-getdepthinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-getdepthinformation">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-webgl-depth-information">
-   <b><a href="#obtain-webgl-depth-information">#obtain-webgl-depth-information</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-webgl-depth-information" class="dfn-panel" data-for="obtain-webgl-depth-information" id="infopanel-for-obtain-webgl-depth-information" role="dialog">
+   <span id="infopaneltitle-for-obtain-webgl-depth-information" style="display:none">Info about the 'obtain WebGL depth information' definition.</span><b><a href="#obtain-webgl-depth-information">#obtain-webgl-depth-information</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-webgl-depth-information">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-webgl-depth-information-instance">
-   <b><a href="#create-a-webgl-depth-information-instance">#create-a-webgl-depth-information-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-webgl-depth-information-instance" class="dfn-panel" data-for="create-a-webgl-depth-information-instance" id="infopanel-for-create-a-webgl-depth-information-instance" role="dialog">
+   <span id="infopaneltitle-for-create-a-webgl-depth-information-instance" style="display:none">Info about the 'create a WebGL depth information instance' definition.</span><b><a href="#create-a-webgl-depth-information-instance">#create-a-webgl-depth-information-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-webgl-depth-information-instance">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-depth-sensing">
-   <b><a href="#native-depth-sensing">#native-depth-sensing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-depth-sensing" class="dfn-panel" data-for="native-depth-sensing" id="infopanel-for-native-depth-sensing" role="dialog">
+   <span id="infopaneltitle-for-native-depth-sensing" style="display:none">Info about the 'native depth sensing' definition.</span><b><a href="#native-depth-sensing">#native-depth-sensing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-depth-sensing">2.1. Feature descriptor</a>
     <li><a href="#ref-for-native-depth-sensing①">2.3. Session configuration</a> <a href="#ref-for-native-depth-sensing②">(2)</a>
     <li><a href="#ref-for-native-depth-sensing③">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="depth-coordinates-transformation-matrix">
-   <b><a href="#depth-coordinates-transformation-matrix">#depth-coordinates-transformation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-depth-coordinates-transformation-matrix" class="dfn-panel" data-for="depth-coordinates-transformation-matrix" id="infopanel-for-depth-coordinates-transformation-matrix" role="dialog">
+   <span id="infopaneltitle-for-depth-coordinates-transformation-matrix" style="display:none">Info about the 'depth coordinates transformation matrix' definition.</span><b><a href="#depth-coordinates-transformation-matrix">#depth-coordinates-transformation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depth-coordinates-transformation-matrix">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-depth-coordinates-transformation-matrix①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="support-depth-sensing-usage">
-   <b><a href="#support-depth-sensing-usage">#support-depth-sensing-usage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-support-depth-sensing-usage" class="dfn-panel" data-for="support-depth-sensing-usage" id="infopanel-for-support-depth-sensing-usage" role="dialog">
+   <span id="infopaneltitle-for-support-depth-sensing-usage" style="display:none">Info about the 'support depth sensing usage' definition.</span><b><a href="#support-depth-sensing-usage">#support-depth-sensing-usage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-support-depth-sensing-usage">2.3. Session configuration</a>
     <li><a href="#ref-for-support-depth-sensing-usage①">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="support-depth-sensing-data-format">
-   <b><a href="#support-depth-sensing-data-format">#support-depth-sensing-data-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-support-depth-sensing-data-format" class="dfn-panel" data-for="support-depth-sensing-data-format" id="infopanel-for-support-depth-sensing-data-format" role="dialog">
+   <span id="infopaneltitle-for-support-depth-sensing-data-format" style="display:none">Info about the 'support depth sensing data format' definition.</span><b><a href="#support-depth-sensing-data-format">#support-depth-sensing-data-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-support-depth-sensing-data-format">5.1. Native depth sensing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="support-depth-sensing-usage-and-data-format-combination">
-   <b><a href="#support-depth-sensing-usage-and-data-format-combination">#support-depth-sensing-usage-and-data-format-combination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-support-depth-sensing-usage-and-data-format-combination" class="dfn-panel" data-for="support-depth-sensing-usage-and-data-format-combination" id="infopanel-for-support-depth-sensing-usage-and-data-format-combination" role="dialog">
+   <span id="infopaneltitle-for-support-depth-sensing-usage-and-data-format-combination" style="display:none">Info about the 'support depth sensing usage and data format combination' definition.</span><b><a href="#support-depth-sensing-usage-and-data-format-combination">#support-depth-sensing-usage-and-data-format-combination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-support-depth-sensing-usage-and-data-format-combination">2.3. Session configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="limit-the-amount-of-information">
-   <b><a href="#limit-the-amount-of-information">#limit-the-amount-of-information</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limit-the-amount-of-information" class="dfn-panel" data-for="limit-the-amount-of-information" id="infopanel-for-limit-the-amount-of-information" role="dialog">
+   <span id="infopaneltitle-for-limit-the-amount-of-information" style="display:none">Info about the 'limiting the amount of information' definition.</span><b><a href="#limit-the-amount-of-information">#limit-the-amount-of-information</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limit-the-amount-of-information">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-limit-the-amount-of-information①">3.3. XRWebGLDepthInformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-access">
-   <b><a href="#block-access">#block-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-access" class="dfn-panel" data-for="block-access" id="infopanel-for-block-access" role="dialog">
+   <span id="infopaneltitle-for-block-access" style="display:none">Info about the 'blocking access' definition.</span><b><a href="#block-access">#block-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-access">3.2. XRCPUDepthInformation</a>
     <li><a href="#ref-for-block-access①">3.3. XRWebGLDepthInformation</a>
@@ -2007,59 +2007,115 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/dom-overlays/index.html
+++ b/tests/github/immersive-web/dom-overlays/index.html
@@ -1265,167 +1265,167 @@ all.</p>
    <li><a href="#enumdef-xrdomoverlaytype">XRDOMOverlayType</a><span>, in § 4</span>
    <li><a href="#xr-overlay">:xr-overlay</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-root-element">
-   <a href="https://drafts.csswg.org/css-display-3/#root-element">https://drafts.csswg.org/css-display-3/#root-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-element" class="dfn-panel" data-for="term-for-root-element" id="infopanel-for-term-for-root-element" role="menu">
+   <span id="infopaneltitle-for-term-for-root-element" style="display:none">Info about the 'root element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#root-element">https://drafts.csswg.org/css-display-3/#root-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-element">2.4. Fullscreen API integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
-   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-preventdefault" class="dfn-panel" data-for="term-for-dom-event-preventdefault" id="infopanel-for-term-for-dom-event-preventdefault" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-preventdefault" style="display:none">Info about the 'preventDefault()' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">2.1. onbeforexrselect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-target" class="dfn-panel" data-for="term-for-dom-event-target" id="infopanel-for-term-for-dom-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">2.1. onbeforexrselect</a>
     <li><a href="#ref-for-dom-event-target①">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-backdrop-root">
-   <a href="https://drafts.fxtf.org/filter-effects-2/#backdrop-root">https://drafts.fxtf.org/filter-effects-2/#backdrop-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-backdrop-root" class="dfn-panel" data-for="term-for-backdrop-root" id="infopanel-for-term-for-backdrop-root" role="menu">
+   <span id="infopaneltitle-for-term-for-backdrop-root" style="display:none">Info about the 'backdrop root' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-2/#backdrop-root">https://drafts.fxtf.org/filter-effects-2/#backdrop-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backdrop-root">2.2. CSS pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-requestfullscreen">
-   <a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-requestfullscreen" class="dfn-panel" data-for="term-for-dom-element-requestfullscreen" id="infopanel-for-term-for-dom-element-requestfullscreen" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-requestfullscreen" style="display:none">Info about the 'requestFullscreen()' external reference.</span><a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-requestfullscreen">2.4. Fullscreen API integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-layer">
-   <a href="https://fullscreen.spec.whatwg.org/#top-layer">https://fullscreen.spec.whatwg.org/#top-layer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-layer" class="dfn-panel" data-for="term-for-top-layer" id="infopanel-for-term-for-top-layer" role="menu">
+   <span id="infopaneltitle-for-term-for-top-layer" style="display:none">Info about the 'top layer' external reference.</span><a href="https://fullscreen.spec.whatwg.org/#top-layer">https://fullscreen.spec.whatwg.org/#top-layer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-layer">2.4. Fullscreen API integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">2.1. onbeforexrselect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-globaleventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-globaleventhandlers" class="dfn-panel" data-for="term-for-globaleventhandlers" id="infopanel-for-term-for-globaleventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-globaleventhandlers" style="display:none">Info about the 'GlobalEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-globaleventhandlers">2. HTML API Integration</a>
     <li><a href="#ref-for-globaleventhandlers①">2.1. onbeforexrselect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmliframeelement" class="dfn-panel" data-for="term-for-htmliframeelement" id="infopanel-for-term-for-htmliframeelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmliframeelement" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmliframeelement">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rendering-opportunity">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rendering-opportunity" class="dfn-panel" data-for="term-for-rendering-opportunity" id="infopanel-for-term-for-rendering-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-rendering-opportunity" style="display:none">Info about the 'rendering opportunity' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendering-opportunity">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe" id="infopanel-for-term-for-dom-animationframeprovider-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationframeprovider-requestanimationframe">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-class" class="dfn-panel" data-for="term-for-pseudo-class" id="infopanel-for-term-for-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-class" style="display:none">Info about the 'pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">2.2. CSS pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">2.2. CSS pseudo-class</a>
     <li><a href="#ref-for-TermStackingContext①">2.4. Fullscreen API integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-topmost-event-target">
-   <a href="https://w3c.github.io/uievents/#topmost-event-target">https://w3c.github.io/uievents/#topmost-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-topmost-event-target" class="dfn-panel" data-for="term-for-topmost-event-target" id="infopanel-for-term-for-topmost-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-topmost-event-target" style="display:none">Info about the 'topmost event target' external reference.</span><a href="https://w3c.github.io/uievents/#topmost-event-target">https://w3c.github.io/uievents/#topmost-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-topmost-event-target">2.1. onbeforexrselect</a>
     <li><a href="#ref-for-topmost-event-target①">3.3. XRInputSource</a>
     <li><a href="#ref-for-topmost-event-target②">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.1. XRSessionInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource">
-   <a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource" class="dfn-panel" data-for="term-for-xrinputsource" id="infopanel-for-term-for-xrinputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource" style="display:none">Info about the 'XRInputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">3. WebXR Device API Integration</a>
     <li><a href="#ref-for-xrinputsource①">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">3. WebXR Device API Integration</a>
     <li><a href="#ref-for-xrsession①">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsessionevent">
-   <a href="https://immersive-web.github.io/webxr/#xrsessionevent">https://immersive-web.github.io/webxr/#xrsessionevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsessionevent" class="dfn-panel" data-for="term-for-xrsessionevent" id="infopanel-for-term-for-xrsessionevent" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsessionevent" style="display:none">Info about the 'XRSessionEvent' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsessionevent">https://immersive-web.github.io/webxr/#xrsessionevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsessionevent">2.1. onbeforexrselect</a> <a href="#ref-for-xrsessionevent①">(2)</a>
     <li><a href="#ref-for-xrsessionevent②">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-xrsessioninit">
-   <a href="https://immersive-web.github.io/webxr/#dictdef-xrsessioninit">https://immersive-web.github.io/webxr/#dictdef-xrsessioninit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-xrsessioninit" class="dfn-panel" data-for="term-for-dictdef-xrsessioninit" id="infopanel-for-term-for-dictdef-xrsessioninit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-xrsessioninit" style="display:none">Info about the 'XRSessionInit' external reference.</span><a href="https://immersive-web.github.io/webxr/#dictdef-xrsessioninit">https://immersive-web.github.io/webxr/#dictdef-xrsessioninit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrsessioninit">3. WebXR Device API Integration</a>
     <li><a href="#ref-for-dictdef-xrsessioninit①">3.1. XRSessionInit</a> <a href="#ref-for-dictdef-xrsessioninit②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrviewport">
-   <a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrviewport" class="dfn-panel" data-for="term-for-xrviewport" id="infopanel-for-term-for-xrviewport" role="menu">
+   <span id="infopaneltitle-for-term-for-xrviewport" style="display:none">Info about the 'XRViewport' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrviewport">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebgllayer">
-   <a href="https://immersive-web.github.io/webxr/#xrwebgllayer">https://immersive-web.github.io/webxr/#xrwebgllayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebgllayer" class="dfn-panel" data-for="term-for-xrwebgllayer" id="infopanel-for-term-for-xrwebgllayer" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebgllayer" style="display:none">Info about the 'XRWebGLLayer' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrwebgllayer">https://immersive-web.github.io/webxr/#xrwebgllayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer">2.2. CSS pseudo-class</a>
     <li><a href="#ref-for-xrwebgllayer①">3.1. XRSessionInit</a>
@@ -1433,47 +1433,47 @@ all.</p>
     <li><a href="#ref-for-xrwebgllayer③">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-xrsession-inputsourceschange">
-   <a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange">https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-xrsession-inputsourceschange" class="dfn-panel" data-for="term-for-eventdef-xrsession-inputsourceschange" id="infopanel-for-term-for-eventdef-xrsession-inputsourceschange" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-xrsession-inputsourceschange" style="display:none">Info about the 'inputsourceschange' external reference.</span><a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange">https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-inputsourceschange">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessioninit-optionalfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessioninit-optionalfeatures" class="dfn-panel" data-for="term-for-dom-xrsessioninit-optionalfeatures" id="infopanel-for-term-for-dom-xrsessioninit-optionalfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessioninit-optionalfeatures" style="display:none">Info about the 'optionalFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-optionalfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-optionalfeatures">3.1. XRSessionInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe" id="infopanel-for-term-for-dom-xrsession-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessioninit-requiredfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessioninit-requiredfeatures" class="dfn-panel" data-for="term-for-dom-xrsessioninit-requiredfeatures" id="infopanel-for-term-for-dom-xrsessioninit-requiredfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessioninit-requiredfeatures" style="display:none">Info about the 'requiredFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrsessioninit-requiredfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-requiredfeatures">3.1. XRSessionInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-xrsession-selectend">
-   <a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend">https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-xrsession-selectend" class="dfn-panel" data-for="term-for-eventdef-xrsession-selectend" id="infopanel-for-term-for-eventdef-xrsession-selectend" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-xrsession-selectend" style="display:none">Info about the 'selectend' external reference.</span><a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend">https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-selectend">2.1. onbeforexrselect</a>
     <li><a href="#ref-for-eventdef-xrsession-selectend①">3.3. XRInputSource</a>
     <li><a href="#ref-for-eventdef-xrsession-selectend②">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-xrsession-selectstart">
-   <a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-selectstart">https://immersive-web.github.io/webxr/#eventdef-xrsession-selectstart</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-xrsession-selectstart" class="dfn-panel" data-for="term-for-eventdef-xrsession-selectstart" id="infopanel-for-term-for-eventdef-xrsession-selectstart" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-xrsession-selectstart" style="display:none">Info about the 'selectstart' external reference.</span><a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-selectstart">https://immersive-web.github.io/webxr/#eventdef-xrsession-selectstart</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-selectstart">2.1. onbeforexrselect</a> <a href="#ref-for-eventdef-xrsession-selectstart①">(2)</a>
     <li><a href="#ref-for-eventdef-xrsession-selectstart②">3.3. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace" id="infopanel-for-term-for-dom-xrinputsource-targetrayspace" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" style="display:none">Info about the 'targetRaySpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace">2.1. onbeforexrselect</a> <a href="#ref-for-dom-xrinputsource-targetrayspace①">(2)</a>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace②">3.3. XRInputSource</a> <a href="#ref-for-dom-xrinputsource-targetrayspace③">(2)</a>
@@ -1612,8 +1612,8 @@ all.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="beforexrselect">
-   <b><a href="#beforexrselect">#beforexrselect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-beforexrselect" class="dfn-panel" data-for="beforexrselect" id="infopanel-for-beforexrselect" role="dialog">
+   <span id="infopaneltitle-for-beforexrselect" style="display:none">Info about the 'beforexrselect' definition.</span><b><a href="#beforexrselect">#beforexrselect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-beforexrselect">1.1. Overview</a>
     <li><a href="#ref-for-beforexrselect①">2.1. onbeforexrselect</a> <a href="#ref-for-beforexrselect②">(2)</a> <a href="#ref-for-beforexrselect③">(3)</a>
@@ -1621,146 +1621,202 @@ all.</p>
     <li><a href="#ref-for-beforexrselect⑦">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-overlay">
-   <b><a href="#xr-overlay">#xr-overlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-overlay" class="dfn-panel" data-for="xr-overlay" id="infopanel-for-xr-overlay" role="dialog">
+   <span id="infopaneltitle-for-xr-overlay" style="display:none">Info about the ':xr-overlay' definition.</span><b><a href="#xr-overlay">#xr-overlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-overlay">2.3. User-agent level style sheet defaults</a> <a href="#ref-for-xr-overlay①">(2)</a>
     <li><a href="#ref-for-xr-overlay②">2.4. Fullscreen API integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-descriptor-dom-overlay">
-   <b><a href="#feature-descriptor-dom-overlay">#feature-descriptor-dom-overlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-descriptor-dom-overlay" class="dfn-panel" data-for="feature-descriptor-dom-overlay" id="infopanel-for-feature-descriptor-dom-overlay" role="dialog">
+   <span id="infopaneltitle-for-feature-descriptor-dom-overlay" style="display:none">Info about the 'dom-overlay' definition.</span><b><a href="#feature-descriptor-dom-overlay">#feature-descriptor-dom-overlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor-dom-overlay">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessioninit-domoverlay">
-   <b><a href="#dom-xrsessioninit-domoverlay">#dom-xrsessioninit-domoverlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessioninit-domoverlay" class="dfn-panel" data-for="dom-xrsessioninit-domoverlay" id="infopanel-for-dom-xrsessioninit-domoverlay" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessioninit-domoverlay" style="display:none">Info about the 'domOverlay' definition.</span><b><a href="#dom-xrsessioninit-domoverlay">#dom-xrsessioninit-domoverlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-domoverlay">3.1. XRSessionInit</a> <a href="#ref-for-dom-xrsessioninit-domoverlay①">(2)</a>
     <li><a href="#ref-for-dom-xrsessioninit-domoverlay②">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-domoverlaystate">
-   <b><a href="#dom-xrsession-domoverlaystate">#dom-xrsession-domoverlaystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-domoverlaystate" class="dfn-panel" data-for="dom-xrsession-domoverlaystate" id="infopanel-for-dom-xrsession-domoverlaystate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-domoverlaystate" style="display:none">Info about the 'domOverlayState' definition.</span><b><a href="#dom-xrsession-domoverlaystate">#dom-xrsession-domoverlaystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-domoverlaystate">3.2. XRSession</a> <a href="#ref-for-dom-xrsession-domoverlaystate①">(2)</a> <a href="#ref-for-dom-xrsession-domoverlaystate②">(3)</a>
     <li><a href="#ref-for-dom-xrsession-domoverlaystate③">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrdomoverlayinit">
-   <b><a href="#dictdef-xrdomoverlayinit">#dictdef-xrdomoverlayinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrdomoverlayinit" class="dfn-panel" data-for="dictdef-xrdomoverlayinit" id="infopanel-for-dictdef-xrdomoverlayinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrdomoverlayinit" style="display:none">Info about the 'XRDOMOverlayInit' definition.</span><b><a href="#dictdef-xrdomoverlayinit">#dictdef-xrdomoverlayinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrdomoverlayinit">3.1. XRSessionInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdomoverlayinit-root">
-   <b><a href="#dom-xrdomoverlayinit-root">#dom-xrdomoverlayinit-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdomoverlayinit-root" class="dfn-panel" data-for="dom-xrdomoverlayinit-root" id="infopanel-for-dom-xrdomoverlayinit-root" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdomoverlayinit-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-xrdomoverlayinit-root">#dom-xrdomoverlayinit-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdomoverlayinit-root">3.3. XRInputSource</a>
     <li><a href="#ref-for-dom-xrdomoverlayinit-root①">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overlay-element">
-   <b><a href="#overlay-element">#overlay-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overlay-element" class="dfn-panel" data-for="overlay-element" id="infopanel-for-overlay-element" role="dialog">
+   <span id="infopaneltitle-for-overlay-element" style="display:none">Info about the 'overlay element' definition.</span><b><a href="#overlay-element">#overlay-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overlay-element">2.2. CSS pseudo-class</a> <a href="#ref-for-overlay-element①">(2)</a> <a href="#ref-for-overlay-element②">(3)</a>
     <li><a href="#ref-for-overlay-element③">2.3. User-agent level style sheet defaults</a>
     <li><a href="#ref-for-overlay-element④">2.4. Fullscreen API integration</a> <a href="#ref-for-overlay-element⑤">(2)</a> <a href="#ref-for-overlay-element⑥">(3)</a> <a href="#ref-for-overlay-element⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrdomoverlaytype">
-   <b><a href="#enumdef-xrdomoverlaytype">#enumdef-xrdomoverlaytype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrdomoverlaytype" class="dfn-panel" data-for="enumdef-xrdomoverlaytype" id="infopanel-for-enumdef-xrdomoverlaytype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrdomoverlaytype" style="display:none">Info about the 'XRDOMOverlayType' definition.</span><b><a href="#enumdef-xrdomoverlaytype">#enumdef-xrdomoverlaytype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrdomoverlaytype">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrdomoverlaystate">
-   <b><a href="#dictdef-xrdomoverlaystate">#dictdef-xrdomoverlaystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrdomoverlaystate" class="dfn-panel" data-for="dictdef-xrdomoverlaystate" id="infopanel-for-dictdef-xrdomoverlaystate" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrdomoverlaystate" style="display:none">Info about the 'XRDOMOverlayState' definition.</span><b><a href="#dictdef-xrdomoverlaystate">#dictdef-xrdomoverlaystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrdomoverlaystate">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdomoverlaystate-type">
-   <b><a href="#dom-xrdomoverlaystate-type">#dom-xrdomoverlaystate-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdomoverlaystate-type" class="dfn-panel" data-for="dom-xrdomoverlaystate-type" id="infopanel-for-dom-xrdomoverlaystate-type" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdomoverlaystate-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-xrdomoverlaystate-type">#dom-xrdomoverlaystate-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdomoverlaystate-type">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdomoverlaytype-screen">
-   <b><a href="#dom-xrdomoverlaytype-screen">#dom-xrdomoverlaytype-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdomoverlaytype-screen" class="dfn-panel" data-for="dom-xrdomoverlaytype-screen" id="infopanel-for-dom-xrdomoverlaytype-screen" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdomoverlaytype-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#dom-xrdomoverlaytype-screen">#dom-xrdomoverlaytype-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdomoverlaytype-screen">4. Initialization</a>
     <li><a href="#ref-for-dom-xrdomoverlaytype-screen①">5. Event handling for cross-origin content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdomoverlaytype-floating">
-   <b><a href="#dom-xrdomoverlaytype-floating">#dom-xrdomoverlaytype-floating</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdomoverlaytype-floating" class="dfn-panel" data-for="dom-xrdomoverlaytype-floating" id="infopanel-for-dom-xrdomoverlaytype-floating" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdomoverlaytype-floating" style="display:none">Info about the 'floating' definition.</span><b><a href="#dom-xrdomoverlaytype-floating">#dom-xrdomoverlaytype-floating</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdomoverlaytype-floating">4. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrdomoverlaytype-head-locked">
-   <b><a href="#dom-xrdomoverlaytype-head-locked">#dom-xrdomoverlaytype-head-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrdomoverlaytype-head-locked" class="dfn-panel" data-for="dom-xrdomoverlaytype-head-locked" id="infopanel-for-dom-xrdomoverlaytype-head-locked" role="dialog">
+   <span id="infopaneltitle-for-dom-xrdomoverlaytype-head-locked" style="display:none">Info about the 'head-locked' definition.</span><b><a href="#dom-xrdomoverlaytype-head-locked">#dom-xrdomoverlaytype-head-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrdomoverlaytype-head-locked">4. Initialization</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/immersive-web/hit-test/index.html
+++ b/tests/github/immersive-web/hit-test/index.html
@@ -2029,92 +2029,92 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
    <li><a href="#dom-xrraydirectioninit-y">y</a><span>, in § 9.1</span>
    <li><a href="#dom-xrraydirectioninit-z">z</a><span>, in § 9.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-isdetachedbuffer">
-   <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isdetachedbuffer" class="dfn-panel" data-for="term-for-sec-isdetachedbuffer" id="infopanel-for-term-for-sec-isdetachedbuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isdetachedbuffer" style="display:none">Info about the 'IsDetachedBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isdetachedbuffer">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-dompointinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-dompointinit" class="dfn-panel" data-for="term-for-dictdef-dompointinit" id="infopanel-for-term-for-dictdef-dompointinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">9.2. XRRay</a> <a href="#ref-for-dompointreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-w">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-w" class="dfn-panel" data-for="term-for-dom-dompointinit-w" id="infopanel-for-term-for-dom-dompointinit-w" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-w" style="display:none">Info about the 'w (for DOMPointInit)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-w">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-w">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-w" class="dfn-panel" data-for="term-for-dom-dompointreadonly-w" id="infopanel-for-term-for-dom-dompointreadonly-w" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-w" style="display:none">Info about the 'w (for DOMPointReadOnly)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-w">9.2. XRRay</a> <a href="#ref-for-dom-dompointreadonly-w①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-x" class="dfn-panel" data-for="term-for-dom-dompointinit-x" id="infopanel-for-term-for-dom-dompointinit-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-x" style="display:none">Info about the 'x (for DOMPointInit)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-x">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-x" class="dfn-panel" data-for="term-for-dom-dompointreadonly-x" id="infopanel-for-term-for-dom-dompointreadonly-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-x" style="display:none">Info about the 'x (for DOMPointReadOnly)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-x">9.2. XRRay</a> <a href="#ref-for-dom-dompointreadonly-x①">(2)</a> <a href="#ref-for-dom-dompointreadonly-x②">(3)</a> <a href="#ref-for-dom-dompointreadonly-x③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-y" class="dfn-panel" data-for="term-for-dom-dompointinit-y" id="infopanel-for-term-for-dom-dompointinit-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-y" style="display:none">Info about the 'y (for DOMPointInit)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-y">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-y" class="dfn-panel" data-for="term-for-dom-dompointreadonly-y" id="infopanel-for-term-for-dom-dompointreadonly-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-y" style="display:none">Info about the 'y (for DOMPointReadOnly)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-y">9.2. XRRay</a> <a href="#ref-for-dom-dompointreadonly-y①">(2)</a> <a href="#ref-for-dom-dompointreadonly-y②">(3)</a> <a href="#ref-for-dom-dompointreadonly-y③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-z">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-z" class="dfn-panel" data-for="term-for-dom-dompointinit-z" id="infopanel-for-term-for-dom-dompointinit-z" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-z" style="display:none">Info about the 'z (for DOMPointInit)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-z">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-z">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-z" class="dfn-panel" data-for="term-for-dom-dompointreadonly-z" id="infopanel-for-term-for-dom-dompointreadonly-z" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-z" style="display:none">Info about the 'z (for DOMPointReadOnly)' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-z">9.2. XRRay</a> <a href="#ref-for-dom-dompointreadonly-z①">(2)</a> <a href="#ref-for-dom-dompointreadonly-z②">(3)</a> <a href="#ref-for-dom-dompointreadonly-z③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">6. Requesting hit test</a> <a href="#ref-for-list-contain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.3. XRTransientInputHitTestOptionsInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-Exposed①">4.2. XRTransientInputHitTestSource</a>
@@ -2123,14 +2123,14 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-Exposed④">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.2. XRHitTestOptionsInit</a>
     <li><a href="#ref-for-idl-frozen-array①">3.3. XRTransientInputHitTestOptionsInit</a>
@@ -2138,8 +2138,8 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-idl-frozen-array③">8. Obtaining hit test results</a> <a href="#ref-for-idl-frozen-array④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-invalidstateerror①">4.2. XRTransientInputHitTestSource</a>
@@ -2148,39 +2148,39 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-invalidstateerror⑤">8. Obtaining hit test results</a> <a href="#ref-for-invalidstateerror⑥">(2)</a> <a href="#ref-for-invalidstateerror⑦">(3)</a> <a href="#ref-for-invalidstateerror⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">6. Requesting hit test</a> <a href="#ref-for-notallowederror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">6. Requesting hit test</a> <a href="#ref-for-notsupportederror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-operationerror">
-   <a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-operationerror" class="dfn-panel" data-for="term-for-operationerror" id="infopanel-for-term-for-operationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-operationerror" style="display:none">Info about the 'OperationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operationerror">6. Requesting hit test</a> <a href="#ref-for-operationerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">6. Requesting hit test</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.2. XRTransientInputHitTestResult</a>
     <li><a href="#ref-for-SameObject①">9.2. XRRay</a> <a href="#ref-for-SameObject②">(2)</a> <a href="#ref-for-SameObject③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-SecureContext①">4.2. XRTransientInputHitTestSource</a>
@@ -2189,84 +2189,84 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-SecureContext④">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">9.2. XRRay</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">6. Requesting hit test</a> <a href="#ref-for-a-new-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">9.1. XRRayDirectionInit</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">6. Requesting hit test</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a> <a href="#ref-for-reject④">(5)</a> <a href="#ref-for-reject⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">6. Requesting hit test</a> <a href="#ref-for-resolve①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-idl-undefined①">4.2. XRTransientInputHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource">
-   <a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource" class="dfn-panel" data-for="term-for-xrinputsource" id="infopanel-for-term-for-xrinputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource" style="display:none">Info about the 'XRInputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">3.3. XRTransientInputHitTestOptionsInit</a>
     <li><a href="#ref-for-xrinputsource①">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-xrinputsource②">(2)</a> <a href="#ref-for-xrinputsource③">(3)</a> <a href="#ref-for-xrinputsource④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrpose">
-   <a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrpose" class="dfn-panel" data-for="term-for-xrpose" id="infopanel-for-term-for-xrpose" role="menu">
+   <span id="infopaneltitle-for-term-for-xrpose" style="display:none">Info about the 'XRPose' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpose">5.1. XRHitTestResult</a> <a href="#ref-for-xrpose①">(2)</a> <a href="#ref-for-xrpose②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-xrspace①">(2)</a>
     <li><a href="#ref-for-xrspace②">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-xrspace③">5.1. XRHitTestResult</a> <a href="#ref-for-xrspace④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-profiles" class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles" id="infopanel-for-term-for-dom-xrinputsource-profiles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-profiles" style="display:none">Info about the 'profiles' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-profiles">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session①">7. Computing hit test results</a> <a href="#ref-for-dom-xrframe-session②">(2)</a> <a href="#ref-for-dom-xrframe-session③">(3)</a> <a href="#ref-for-dom-xrframe-session④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace" id="infopanel-for-term-for-dom-xrinputsource-targetrayspace" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" style="display:none">Info about the 'targetRaySpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-interface" class="dfn-panel" data-for="term-for-xrframe-interface" id="infopanel-for-term-for-xrframe-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-interface" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-interface">5.1. XRHitTestResult</a> <a href="#ref-for-xrframe-interface①">(2)</a>
     <li><a href="#ref-for-xrframe-interface②">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-xrframe-interface③">(2)</a>
@@ -2274,147 +2274,147 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-xrframe-interface⑦">8. Obtaining hit test results</a> <a href="#ref-for-xrframe-interface⑧">(2)</a> <a href="#ref-for-xrframe-interface⑨">(3)</a> <a href="#ref-for-xrframe-interface①⓪">(4)</a> <a href="#ref-for-xrframe-interface①①">(5)</a> <a href="#ref-for-xrframe-interface①②">(6)</a> <a href="#ref-for-xrframe-interface①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrrigidtransform-interface">https://www.w3.org/TR/webxr/#xrrigidtransform-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform-interface" class="dfn-panel" data-for="term-for-xrrigidtransform-interface" id="infopanel-for-term-for-xrrigidtransform-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform-interface" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrrigidtransform-interface">https://www.w3.org/TR/webxr/#xrrigidtransform-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform-interface">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-interface" class="dfn-panel" data-for="term-for-xrsession-interface" id="infopanel-for-term-for-xrsession-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-interface" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-interface">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-xrsession-interface①">4.2. XRTransientInputHitTestSource</a>
     <li><a href="#ref-for-xrsession-interface②">6. Requesting hit test</a> <a href="#ref-for-xrsession-interface③">(2)</a> <a href="#ref-for-xrsession-interface④">(3)</a> <a href="#ref-for-xrsession-interface⑤">(4)</a> <a href="#ref-for-xrsession-interface⑥">(5)</a> <a href="#ref-for-xrsession-interface⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">5.1. XRHitTestResult</a>
     <li><a href="#ref-for-xrframe-active①">8. Obtaining hit test results</a> <a href="#ref-for-xrframe-active②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-capable-of-supporting">
-   <a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-capable-of-supporting" class="dfn-panel" data-for="term-for-capable-of-supporting" id="infopanel-for-term-for-capable-of-supporting" role="menu">
+   <span id="infopaneltitle-for-term-for-capable-of-supporting" style="display:none">Info about the 'capable of supporting' external reference.</span><a href="https://www.w3.org/TR/webxr/#capable-of-supporting">https://www.w3.org/TR/webxr/#capable-of-supporting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capable-of-supporting">2.1. Feature descriptor</a> <a href="#ref-for-capable-of-supporting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-effective-origin">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-effective-origin">https://www.w3.org/TR/webxr/#xrspace-effective-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-effective-origin" class="dfn-panel" data-for="term-for-xrspace-effective-origin" id="infopanel-for-term-for-xrspace-effective-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-effective-origin" style="display:none">Info about the 'effective origin' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-effective-origin">https://www.w3.org/TR/webxr/#xrspace-effective-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-effective-origin">4.1. XRHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ended">
-   <a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ended" class="dfn-panel" data-for="term-for-ended" id="infopanel-for-term-for-ended" role="menu">
+   <span id="infopaneltitle-for-term-for-ended" style="display:none">Info about the 'ended' external reference.</span><a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ended">6. Requesting hit test</a> <a href="#ref-for-ended①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-descriptor">
-   <a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-descriptor" class="dfn-panel" data-for="term-for-feature-descriptor" id="infopanel-for-term-for-feature-descriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2.1. Feature descriptor</a>
     <li><a href="#ref-for-feature-descriptor①">11. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-policy">
-   <a href="https://www.w3.org/TR/webxr/#feature-policy">https://www.w3.org/TR/webxr/#feature-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-policy" class="dfn-panel" data-for="term-for-feature-policy" id="infopanel-for-term-for-feature-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-policy" style="display:none">Info about the 'feature policy' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-policy">https://www.w3.org/TR/webxr/#feature-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-policy">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identity-transform">
-   <a href="https://www.w3.org/TR/webxr/#identity-transform">https://www.w3.org/TR/webxr/#identity-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identity-transform" class="dfn-panel" data-for="term-for-identity-transform" id="infopanel-for-term-for-identity-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-identity-transform" style="display:none">Info about the 'identity transform' external reference.</span><a href="https://www.w3.org/TR/webxr/#identity-transform">https://www.w3.org/TR/webxr/#identity-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-xr-device" class="dfn-panel" data-for="term-for-inline-xr-device" id="infopanel-for-term-for-inline-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-xr-device" style="display:none">Info about the 'inline xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#inline-xr-device">https://www.w3.org/TR/webxr/#inline-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-xr-device">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource-input-profile-name">
-   <a href="https://www.w3.org/TR/webxr/#xrinputsource-input-profile-name">https://www.w3.org/TR/webxr/#xrinputsource-input-profile-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource-input-profile-name" class="dfn-panel" data-for="term-for-xrinputsource-input-profile-name" id="infopanel-for-term-for-xrinputsource-input-profile-name" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource-input-profile-name" style="display:none">Info about the 'input profile name' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrinputsource-input-profile-name">https://www.w3.org/TR/webxr/#xrinputsource-input-profile-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource-input-profile-name">3.3. XRTransientInputHitTestOptionsInit</a>
     <li><a href="#ref-for-xrinputsource-input-profile-name①">4.2. XRTransientInputHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-active-xr-input-sources">
-   <a href="https://www.w3.org/TR/webxr/#list-of-active-xr-input-sources">https://www.w3.org/TR/webxr/#list-of-active-xr-input-sources</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-active-xr-input-sources" class="dfn-panel" data-for="term-for-list-of-active-xr-input-sources" id="infopanel-for-term-for-list-of-active-xr-input-sources" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-active-xr-input-sources" style="display:none">Info about the 'list of active xr input sources' external reference.</span><a href="https://www.w3.org/TR/webxr/#list-of-active-xr-input-sources">https://www.w3.org/TR/webxr/#list-of-active-xr-input-sources</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-active-xr-input-sources">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-enabled-features">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features">https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-enabled-features" class="dfn-panel" data-for="term-for-xrsession-list-of-enabled-features" id="infopanel-for-term-for-xrsession-list-of-enabled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-enabled-features" style="display:none">Info about the 'list of enabled features' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features">https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-enabled-features">6. Requesting hit test</a> <a href="#ref-for-xrsession-list-of-enabled-features①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates" id="infopanel-for-term-for-xrsession-list-of-frame-updates" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" style="display:none">Info about the 'list of frame updates' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-frame-updates">6. Requesting hit test</a> <a href="#ref-for-xrsession-list-of-frame-updates①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-matrix">
-   <a href="https://www.w3.org/TR/webxr/#matrix">https://www.w3.org/TR/webxr/#matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-matrix" class="dfn-panel" data-for="term-for-matrix" id="infopanel-for-term-for-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-matrix" style="display:none">Info about the 'matrix' external reference.</span><a href="https://www.w3.org/TR/webxr/#matrix">https://www.w3.org/TR/webxr/#matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix">9.2. XRRay</a> <a href="#ref-for-matrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-matrix">
-   <a href="https://www.w3.org/TR/webxr/#dom-xrrigidtransform-matrix">https://www.w3.org/TR/webxr/#dom-xrrigidtransform-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-matrix" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-matrix" id="infopanel-for-term-for-dom-xrrigidtransform-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-matrix" style="display:none">Info about the 'matrix (for XRRigidTransform)' external reference.</span><a href="https://www.w3.org/TR/webxr/#dom-xrrigidtransform-matrix">https://www.w3.org/TR/webxr/#dom-xrrigidtransform-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-matrix">9.2. XRRay</a> <a href="#ref-for-dom-xrrigidtransform-matrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-native-origin">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-native-origin" class="dfn-panel" data-for="term-for-xrspace-native-origin" id="infopanel-for-term-for-xrspace-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-native-origin">4.1. XRHitTestSource</a> <a href="#ref-for-xrspace-native-origin①">(2)</a> <a href="#ref-for-xrspace-native-origin②">(3)</a>
     <li><a href="#ref-for-xrspace-native-origin③">5.1. XRHitTestResult</a>
     <li><a href="#ref-for-xrspace-native-origin④">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-normalize">
-   <a href="https://www.w3.org/TR/webxr/#normalize">https://www.w3.org/TR/webxr/#normalize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-normalize" class="dfn-panel" data-for="term-for-normalize" id="infopanel-for-term-for-normalize" role="menu">
+   <span id="infopaneltitle-for-term-for-normalize" style="display:none">Info about the 'normalize' external reference.</span><a href="https://www.w3.org/TR/webxr/#normalize">https://www.w3.org/TR/webxr/#normalize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize">9.2. XRRay</a> <a href="#ref-for-normalize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-origin-offset">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-origin-offset">https://www.w3.org/TR/webxr/#xrspace-origin-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-origin-offset" class="dfn-panel" data-for="term-for-xrspace-origin-offset" id="infopanel-for-term-for-xrspace-origin-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-origin-offset" style="display:none">Info about the 'origin offset' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-origin-offset">https://www.w3.org/TR/webxr/#xrspace-origin-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-origin-offset">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-populate-the-pose">
-   <a href="https://www.w3.org/TR/webxr/#populate-the-pose">https://www.w3.org/TR/webxr/#populate-the-pose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-populate-the-pose" class="dfn-panel" data-for="term-for-populate-the-pose" id="infopanel-for-term-for-populate-the-pose" role="menu">
+   <span id="infopaneltitle-for-term-for-populate-the-pose" style="display:none">Info about the 'populate the pose' external reference.</span><a href="https://www.w3.org/TR/webxr/#populate-the-pose">https://www.w3.org/TR/webxr/#populate-the-pose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-populate-the-pose">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://www.w3.org/TR/webxr/#dom-xrframe-session">https://www.w3.org/TR/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session①" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session①" style="display:none">Info about the 'session (for XRFrame)' external reference.</span><a href="https://www.w3.org/TR/webxr/#dom-xrframe-session">https://www.w3.org/TR/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-session">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-session">https://www.w3.org/TR/webxr/#xrspace-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-session" class="dfn-panel" data-for="term-for-xrspace-session" id="infopanel-for-term-for-xrspace-session" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-session" style="display:none">Info about the 'session (for XRSpace)' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-session">https://www.w3.org/TR/webxr/#xrspace-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-session">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xr-device">https://www.w3.org/TR/webxr/#xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-device" class="dfn-panel" data-for="term-for-xr-device" id="infopanel-for-term-for-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-device">https://www.w3.org/TR/webxr/#xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device">5.1. XRHitTestResult</a>
     <li><a href="#ref-for-xr-device①">9.2. XRRay</a>
@@ -2422,8 +2422,8 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-xr-device③">10.2. Native entity type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-xr-device" class="dfn-panel" data-for="term-for-xrsession-xr-device" id="infopanel-for-term-for-xrsession-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-xr-device" style="display:none">Info about the 'xr device (for XRSession)' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">5.1. XRHitTestResult</a>
     <li><a href="#ref-for-xrsession-xr-device①">7. Computing hit test results</a> <a href="#ref-for-xrsession-xr-device②">(2)</a>
@@ -2604,14 +2604,14 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
   <div style="counter-reset:issue">
    <div class="issue"> Decide if we need to specify other axes of the coordinate system defined by hit test result’s native origin to maintain compatibility between different implementations &amp; differrent AR frameworks. <a class="issue-return" href="#issue-4d2e55aa" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="hit-test">
-   <b><a href="#hit-test">#hit-test</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hit-test" class="dfn-panel" data-for="hit-test" id="infopanel-for-hit-test" role="dialog">
+   <span id="infopaneltitle-for-hit-test" style="display:none">Info about the 'hit-test' definition.</span><b><a href="#hit-test">#hit-test</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hit-test">6. Requesting hit test</a> <a href="#ref-for-hit-test①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrhittesttrackabletype">
-   <b><a href="#enumdef-xrhittesttrackabletype">#enumdef-xrhittesttrackabletype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrhittesttrackabletype" class="dfn-panel" data-for="enumdef-xrhittesttrackabletype" id="infopanel-for-enumdef-xrhittesttrackabletype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrhittesttrackabletype" style="display:none">Info about the 'XRHitTestTrackableType' definition.</span><b><a href="#enumdef-xrhittesttrackabletype">#enumdef-xrhittesttrackabletype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrhittesttrackabletype">3.1. XRHitTestTrackableType</a>
     <li><a href="#ref-for-enumdef-xrhittesttrackabletype①">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-enumdef-xrhittesttrackabletype②">(2)</a>
@@ -2623,15 +2623,15 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-enumdef-xrhittesttrackabletype⑨">10.2. Native entity type</a> <a href="#ref-for-enumdef-xrhittesttrackabletype①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittesttrackabletype-point">
-   <b><a href="#dom-xrhittesttrackabletype-point">#dom-xrhittesttrackabletype-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittesttrackabletype-point" class="dfn-panel" data-for="dom-xrhittesttrackabletype-point" id="infopanel-for-dom-xrhittesttrackabletype-point" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittesttrackabletype-point" style="display:none">Info about the '"point"' definition.</span><b><a href="#dom-xrhittesttrackabletype-point">#dom-xrhittesttrackabletype-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-point">3.1. XRHitTestTrackableType</a>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-point①">10.2. Native entity type</a> <a href="#ref-for-dom-xrhittesttrackabletype-point②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittesttrackabletype-plane">
-   <b><a href="#dom-xrhittesttrackabletype-plane">#dom-xrhittesttrackabletype-plane</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittesttrackabletype-plane" class="dfn-panel" data-for="dom-xrhittesttrackabletype-plane" id="infopanel-for-dom-xrhittesttrackabletype-plane" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittesttrackabletype-plane" style="display:none">Info about the '"plane"' definition.</span><b><a href="#dom-xrhittesttrackabletype-plane">#dom-xrhittesttrackabletype-plane</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-plane">3.1. XRHitTestTrackableType</a>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-plane①">3.2. XRHitTestOptionsInit</a>
@@ -2639,398 +2639,398 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-dom-xrhittesttrackabletype-plane③">10.2. Native entity type</a> <a href="#ref-for-dom-xrhittesttrackabletype-plane④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittesttrackabletype-mesh">
-   <b><a href="#dom-xrhittesttrackabletype-mesh">#dom-xrhittesttrackabletype-mesh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittesttrackabletype-mesh" class="dfn-panel" data-for="dom-xrhittesttrackabletype-mesh" id="infopanel-for-dom-xrhittesttrackabletype-mesh" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittesttrackabletype-mesh" style="display:none">Info about the '"mesh"' definition.</span><b><a href="#dom-xrhittesttrackabletype-mesh">#dom-xrhittesttrackabletype-mesh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-mesh">3.1. XRHitTestTrackableType</a>
     <li><a href="#ref-for-dom-xrhittesttrackabletype-mesh①">10.2. Native entity type</a> <a href="#ref-for-dom-xrhittesttrackabletype-mesh②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrhittestoptionsinit">
-   <b><a href="#dictdef-xrhittestoptionsinit">#dictdef-xrhittestoptionsinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrhittestoptionsinit" class="dfn-panel" data-for="dictdef-xrhittestoptionsinit" id="infopanel-for-dictdef-xrhittestoptionsinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrhittestoptionsinit" style="display:none">Info about the 'XRHitTestOptionsInit' definition.</span><b><a href="#dictdef-xrhittestoptionsinit">#dictdef-xrhittestoptionsinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrhittestoptionsinit">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-dictdef-xrhittestoptionsinit①">(2)</a> <a href="#ref-for-dictdef-xrhittestoptionsinit②">(3)</a>
     <li><a href="#ref-for-dictdef-xrhittestoptionsinit③">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestoptionsinit-space">
-   <b><a href="#dom-xrhittestoptionsinit-space">#dom-xrhittestoptionsinit-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestoptionsinit-space" class="dfn-panel" data-for="dom-xrhittestoptionsinit-space" id="infopanel-for-dom-xrhittestoptionsinit-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestoptionsinit-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrhittestoptionsinit-space">#dom-xrhittestoptionsinit-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestoptionsinit-space">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-dom-xrhittestoptionsinit-space①">(2)</a>
     <li><a href="#ref-for-dom-xrhittestoptionsinit-space②">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestoptionsinit-entitytypes">
-   <b><a href="#dom-xrhittestoptionsinit-entitytypes">#dom-xrhittestoptionsinit-entitytypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestoptionsinit-entitytypes" class="dfn-panel" data-for="dom-xrhittestoptionsinit-entitytypes" id="infopanel-for-dom-xrhittestoptionsinit-entitytypes" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestoptionsinit-entitytypes" style="display:none">Info about the 'entityTypes' definition.</span><b><a href="#dom-xrhittestoptionsinit-entitytypes">#dom-xrhittestoptionsinit-entitytypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestoptionsinit-entitytypes">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-dom-xrhittestoptionsinit-entitytypes①">(2)</a> <a href="#ref-for-dom-xrhittestoptionsinit-entitytypes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestoptionsinit-offsetray">
-   <b><a href="#dom-xrhittestoptionsinit-offsetray">#dom-xrhittestoptionsinit-offsetray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestoptionsinit-offsetray" class="dfn-panel" data-for="dom-xrhittestoptionsinit-offsetray" id="infopanel-for-dom-xrhittestoptionsinit-offsetray" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestoptionsinit-offsetray" style="display:none">Info about the 'offsetRay' definition.</span><b><a href="#dom-xrhittestoptionsinit-offsetray">#dom-xrhittestoptionsinit-offsetray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestoptionsinit-offsetray">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-dom-xrhittestoptionsinit-offsetray①">(2)</a> <a href="#ref-for-dom-xrhittestoptionsinit-offsetray②">(3)</a> <a href="#ref-for-dom-xrhittestoptionsinit-offsetray③">(4)</a> <a href="#ref-for-dom-xrhittestoptionsinit-offsetray④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestoptionsinit-effective-entitytypes">
-   <b><a href="#xrhittestoptionsinit-effective-entitytypes">#xrhittestoptionsinit-effective-entitytypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestoptionsinit-effective-entitytypes" class="dfn-panel" data-for="xrhittestoptionsinit-effective-entitytypes" id="infopanel-for-xrhittestoptionsinit-effective-entitytypes" role="dialog">
+   <span id="infopaneltitle-for-xrhittestoptionsinit-effective-entitytypes" style="display:none">Info about the 'effective entityTypes' definition.</span><b><a href="#xrhittestoptionsinit-effective-entitytypes">#xrhittestoptionsinit-effective-entitytypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestoptionsinit-effective-entitytypes">3.2. XRHitTestOptionsInit</a>
     <li><a href="#ref-for-xrhittestoptionsinit-effective-entitytypes①">6. Requesting hit test</a> <a href="#ref-for-xrhittestoptionsinit-effective-entitytypes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestoptionsinit-effective-offsetray">
-   <b><a href="#xrhittestoptionsinit-effective-offsetray">#xrhittestoptionsinit-effective-offsetray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestoptionsinit-effective-offsetray" class="dfn-panel" data-for="xrhittestoptionsinit-effective-offsetray" id="infopanel-for-xrhittestoptionsinit-effective-offsetray" role="dialog">
+   <span id="infopaneltitle-for-xrhittestoptionsinit-effective-offsetray" style="display:none">Info about the 'effective offsetRay' definition.</span><b><a href="#xrhittestoptionsinit-effective-offsetray">#xrhittestoptionsinit-effective-offsetray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestoptionsinit-effective-offsetray">3.2. XRHitTestOptionsInit</a>
     <li><a href="#ref-for-xrhittestoptionsinit-effective-offsetray①">6. Requesting hit test</a> <a href="#ref-for-xrhittestoptionsinit-effective-offsetray②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrtransientinputhittestoptionsinit">
-   <b><a href="#dictdef-xrtransientinputhittestoptionsinit">#dictdef-xrtransientinputhittestoptionsinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrtransientinputhittestoptionsinit" class="dfn-panel" data-for="dictdef-xrtransientinputhittestoptionsinit" id="infopanel-for-dictdef-xrtransientinputhittestoptionsinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrtransientinputhittestoptionsinit" style="display:none">Info about the 'XRTransientInputHitTestOptionsInit' definition.</span><b><a href="#dictdef-xrtransientinputhittestoptionsinit">#dictdef-xrtransientinputhittestoptionsinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrtransientinputhittestoptionsinit">3.3. XRTransientInputHitTestOptionsInit</a> <a href="#ref-for-dictdef-xrtransientinputhittestoptionsinit①">(2)</a> <a href="#ref-for-dictdef-xrtransientinputhittestoptionsinit②">(3)</a>
     <li><a href="#ref-for-dictdef-xrtransientinputhittestoptionsinit③">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-profile">
-   <b><a href="#dom-xrtransientinputhittestoptionsinit-profile">#dom-xrtransientinputhittestoptionsinit-profile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-profile" class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-profile" id="infopanel-for-dom-xrtransientinputhittestoptionsinit-profile" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-profile" style="display:none">Info about the 'profile' definition.</span><b><a href="#dom-xrtransientinputhittestoptionsinit-profile">#dom-xrtransientinputhittestoptionsinit-profile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestoptionsinit-profile">3.3. XRTransientInputHitTestOptionsInit</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-profile①">(2)</a>
     <li><a href="#ref-for-dom-xrtransientinputhittestoptionsinit-profile②">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-entitytypes">
-   <b><a href="#dom-xrtransientinputhittestoptionsinit-entitytypes">#dom-xrtransientinputhittestoptionsinit-entitytypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-entitytypes" class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-entitytypes" id="infopanel-for-dom-xrtransientinputhittestoptionsinit-entitytypes" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-entitytypes" style="display:none">Info about the 'entityTypes' definition.</span><b><a href="#dom-xrtransientinputhittestoptionsinit-entitytypes">#dom-xrtransientinputhittestoptionsinit-entitytypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestoptionsinit-entitytypes">3.3. XRTransientInputHitTestOptionsInit</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-entitytypes①">(2)</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-entitytypes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-offsetray">
-   <b><a href="#dom-xrtransientinputhittestoptionsinit-offsetray">#dom-xrtransientinputhittestoptionsinit-offsetray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-offsetray" class="dfn-panel" data-for="dom-xrtransientinputhittestoptionsinit-offsetray" id="infopanel-for-dom-xrtransientinputhittestoptionsinit-offsetray" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestoptionsinit-offsetray" style="display:none">Info about the 'offsetRay' definition.</span><b><a href="#dom-xrtransientinputhittestoptionsinit-offsetray">#dom-xrtransientinputhittestoptionsinit-offsetray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestoptionsinit-offsetray">3.3. XRTransientInputHitTestOptionsInit</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-offsetray①">(2)</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-offsetray②">(3)</a> <a href="#ref-for-dom-xrtransientinputhittestoptionsinit-offsetray③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestoptionsinit-effective-entitytypes">
-   <b><a href="#xrtransientinputhittestoptionsinit-effective-entitytypes">#xrtransientinputhittestoptionsinit-effective-entitytypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestoptionsinit-effective-entitytypes" class="dfn-panel" data-for="xrtransientinputhittestoptionsinit-effective-entitytypes" id="infopanel-for-xrtransientinputhittestoptionsinit-effective-entitytypes" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestoptionsinit-effective-entitytypes" style="display:none">Info about the 'effective entityTypes' definition.</span><b><a href="#xrtransientinputhittestoptionsinit-effective-entitytypes">#xrtransientinputhittestoptionsinit-effective-entitytypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestoptionsinit-effective-entitytypes">3.3. XRTransientInputHitTestOptionsInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestoptionsinit-effective-offsetray">
-   <b><a href="#xrtransientinputhittestoptionsinit-effective-offsetray">#xrtransientinputhittestoptionsinit-effective-offsetray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestoptionsinit-effective-offsetray" class="dfn-panel" data-for="xrtransientinputhittestoptionsinit-effective-offsetray" id="infopanel-for-xrtransientinputhittestoptionsinit-effective-offsetray" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestoptionsinit-effective-offsetray" style="display:none">Info about the 'effective offsetRay' definition.</span><b><a href="#xrtransientinputhittestoptionsinit-effective-offsetray">#xrtransientinputhittestoptionsinit-effective-offsetray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestoptionsinit-effective-offsetray">3.3. XRTransientInputHitTestOptionsInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource">
-   <b><a href="#xrhittestsource">#xrhittestsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource" class="dfn-panel" data-for="xrhittestsource" id="infopanel-for-xrhittestsource" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource" style="display:none">Info about the 'XRHitTestSource' definition.</span><b><a href="#xrhittestsource">#xrhittestsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource">4.1. XRHitTestSource</a> <a href="#ref-for-xrhittestsource①">(2)</a> <a href="#ref-for-xrhittestsource②">(3)</a> <a href="#ref-for-xrhittestsource③">(4)</a> <a href="#ref-for-xrhittestsource④">(5)</a> <a href="#ref-for-xrhittestsource⑤">(6)</a> <a href="#ref-for-xrhittestsource⑥">(7)</a> <a href="#ref-for-xrhittestsource⑦">(8)</a> <a href="#ref-for-xrhittestsource⑧">(9)</a>
     <li><a href="#ref-for-xrhittestsource⑨">6. Requesting hit test</a>
     <li><a href="#ref-for-xrhittestsource①⓪">8. Obtaining hit test results</a> <a href="#ref-for-xrhittestsource①①">(2)</a> <a href="#ref-for-xrhittestsource①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource-session">
-   <b><a href="#xrhittestsource-session">#xrhittestsource-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource-session" class="dfn-panel" data-for="xrhittestsource-session" id="infopanel-for-xrhittestsource-session" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrhittestsource-session">#xrhittestsource-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource-session">4.1. XRHitTestSource</a> <a href="#ref-for-xrhittestsource-session①">(2)</a> <a href="#ref-for-xrhittestsource-session②">(3)</a>
     <li><a href="#ref-for-xrhittestsource-session③">4.2. XRTransientInputHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource-native-origin">
-   <b><a href="#xrhittestsource-native-origin">#xrhittestsource-native-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource-native-origin" class="dfn-panel" data-for="xrhittestsource-native-origin" id="infopanel-for-xrhittestsource-native-origin" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource-native-origin" style="display:none">Info about the 'native origin' definition.</span><b><a href="#xrhittestsource-native-origin">#xrhittestsource-native-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource-native-origin">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-xrhittestsource-native-origin①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource-entity-types">
-   <b><a href="#xrhittestsource-entity-types">#xrhittestsource-entity-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource-entity-types" class="dfn-panel" data-for="xrhittestsource-entity-types" id="infopanel-for-xrhittestsource-entity-types" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource-entity-types" style="display:none">Info about the 'entity types' definition.</span><b><a href="#xrhittestsource-entity-types">#xrhittestsource-entity-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource-entity-types">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-xrhittestsource-entity-types①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource-offset-ray">
-   <b><a href="#xrhittestsource-offset-ray">#xrhittestsource-offset-ray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource-offset-ray" class="dfn-panel" data-for="xrhittestsource-offset-ray" id="infopanel-for-xrhittestsource-offset-ray" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource-offset-ray" style="display:none">Info about the 'offset ray' definition.</span><b><a href="#xrhittestsource-offset-ray">#xrhittestsource-offset-ray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource-offset-ray">4.1. XRHitTestSource</a>
     <li><a href="#ref-for-xrhittestsource-offset-ray①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestsource-active">
-   <b><a href="#xrhittestsource-active">#xrhittestsource-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestsource-active" class="dfn-panel" data-for="xrhittestsource-active" id="infopanel-for-xrhittestsource-active" role="dialog">
+   <span id="infopaneltitle-for-xrhittestsource-active" style="display:none">Info about the 'active' definition.</span><b><a href="#xrhittestsource-active">#xrhittestsource-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestsource-active">4.1. XRHitTestSource</a> <a href="#ref-for-xrhittestsource-active①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-hit-test-source">
-   <b><a href="#create-a-hit-test-source">#create-a-hit-test-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-hit-test-source" class="dfn-panel" data-for="create-a-hit-test-source" id="infopanel-for-create-a-hit-test-source" role="dialog">
+   <span id="infopaneltitle-for-create-a-hit-test-source" style="display:none">Info about the 'create a hit test source' definition.</span><b><a href="#create-a-hit-test-source">#create-a-hit-test-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-hit-test-source">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestsource-cancel">
-   <b><a href="#dom-xrhittestsource-cancel">#dom-xrhittestsource-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestsource-cancel" class="dfn-panel" data-for="dom-xrhittestsource-cancel" id="infopanel-for-dom-xrhittestsource-cancel" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestsource-cancel" style="display:none">Info about the 'cancel()' definition.</span><b><a href="#dom-xrhittestsource-cancel">#dom-xrhittestsource-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestsource-cancel">4.1. XRHitTestSource</a> <a href="#ref-for-dom-xrhittestsource-cancel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cancel-a-hit-test-source">
-   <b><a href="#cancel-a-hit-test-source">#cancel-a-hit-test-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cancel-a-hit-test-source" class="dfn-panel" data-for="cancel-a-hit-test-source" id="infopanel-for-cancel-a-hit-test-source" role="dialog">
+   <span id="infopaneltitle-for-cancel-a-hit-test-source" style="display:none">Info about the 'cancel a hit test source' definition.</span><b><a href="#cancel-a-hit-test-source">#cancel-a-hit-test-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-a-hit-test-source">4.1. XRHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource">
-   <b><a href="#xrtransientinputhittestsource">#xrtransientinputhittestsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource" class="dfn-panel" data-for="xrtransientinputhittestsource" id="infopanel-for-xrtransientinputhittestsource" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource" style="display:none">Info about the 'XRTransientInputHitTestSource' definition.</span><b><a href="#xrtransientinputhittestsource">#xrtransientinputhittestsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource">4.2. XRTransientInputHitTestSource</a> <a href="#ref-for-xrtransientinputhittestsource①">(2)</a> <a href="#ref-for-xrtransientinputhittestsource②">(3)</a> <a href="#ref-for-xrtransientinputhittestsource③">(4)</a> <a href="#ref-for-xrtransientinputhittestsource④">(5)</a> <a href="#ref-for-xrtransientinputhittestsource⑤">(6)</a> <a href="#ref-for-xrtransientinputhittestsource⑥">(7)</a> <a href="#ref-for-xrtransientinputhittestsource⑦">(8)</a> <a href="#ref-for-xrtransientinputhittestsource⑧">(9)</a>
     <li><a href="#ref-for-xrtransientinputhittestsource⑨">6. Requesting hit test</a>
     <li><a href="#ref-for-xrtransientinputhittestsource①⓪">8. Obtaining hit test results</a> <a href="#ref-for-xrtransientinputhittestsource①①">(2)</a> <a href="#ref-for-xrtransientinputhittestsource①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource-session">
-   <b><a href="#xrtransientinputhittestsource-session">#xrtransientinputhittestsource-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource-session" class="dfn-panel" data-for="xrtransientinputhittestsource-session" id="infopanel-for-xrtransientinputhittestsource-session" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrtransientinputhittestsource-session">#xrtransientinputhittestsource-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource-session">4.2. XRTransientInputHitTestSource</a> <a href="#ref-for-xrtransientinputhittestsource-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource-profile">
-   <b><a href="#xrtransientinputhittestsource-profile">#xrtransientinputhittestsource-profile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource-profile" class="dfn-panel" data-for="xrtransientinputhittestsource-profile" id="infopanel-for-xrtransientinputhittestsource-profile" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource-profile" style="display:none">Info about the 'profile' definition.</span><b><a href="#xrtransientinputhittestsource-profile">#xrtransientinputhittestsource-profile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource-profile">4.2. XRTransientInputHitTestSource</a>
     <li><a href="#ref-for-xrtransientinputhittestsource-profile①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource-entity-types">
-   <b><a href="#xrtransientinputhittestsource-entity-types">#xrtransientinputhittestsource-entity-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource-entity-types" class="dfn-panel" data-for="xrtransientinputhittestsource-entity-types" id="infopanel-for-xrtransientinputhittestsource-entity-types" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource-entity-types" style="display:none">Info about the 'entity types' definition.</span><b><a href="#xrtransientinputhittestsource-entity-types">#xrtransientinputhittestsource-entity-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource-entity-types">4.2. XRTransientInputHitTestSource</a>
     <li><a href="#ref-for-xrtransientinputhittestsource-entity-types①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource-offset-ray">
-   <b><a href="#xrtransientinputhittestsource-offset-ray">#xrtransientinputhittestsource-offset-ray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource-offset-ray" class="dfn-panel" data-for="xrtransientinputhittestsource-offset-ray" id="infopanel-for-xrtransientinputhittestsource-offset-ray" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource-offset-ray" style="display:none">Info about the 'offset ray' definition.</span><b><a href="#xrtransientinputhittestsource-offset-ray">#xrtransientinputhittestsource-offset-ray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource-offset-ray">4.2. XRTransientInputHitTestSource</a>
     <li><a href="#ref-for-xrtransientinputhittestsource-offset-ray①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestsource-active">
-   <b><a href="#xrtransientinputhittestsource-active">#xrtransientinputhittestsource-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestsource-active" class="dfn-panel" data-for="xrtransientinputhittestsource-active" id="infopanel-for-xrtransientinputhittestsource-active" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestsource-active" style="display:none">Info about the 'active' definition.</span><b><a href="#xrtransientinputhittestsource-active">#xrtransientinputhittestsource-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestsource-active">4.2. XRTransientInputHitTestSource</a> <a href="#ref-for-xrtransientinputhittestsource-active①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-hit-test-source-for-transient-input">
-   <b><a href="#create-a-hit-test-source-for-transient-input">#create-a-hit-test-source-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-hit-test-source-for-transient-input" class="dfn-panel" data-for="create-a-hit-test-source-for-transient-input" id="infopanel-for-create-a-hit-test-source-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-create-a-hit-test-source-for-transient-input" style="display:none">Info about the 'create a hit test source for transient input' definition.</span><b><a href="#create-a-hit-test-source-for-transient-input">#create-a-hit-test-source-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-hit-test-source-for-transient-input">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestsource-cancel">
-   <b><a href="#dom-xrtransientinputhittestsource-cancel">#dom-xrtransientinputhittestsource-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestsource-cancel" class="dfn-panel" data-for="dom-xrtransientinputhittestsource-cancel" id="infopanel-for-dom-xrtransientinputhittestsource-cancel" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestsource-cancel" style="display:none">Info about the 'cancel()' definition.</span><b><a href="#dom-xrtransientinputhittestsource-cancel">#dom-xrtransientinputhittestsource-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestsource-cancel">4.2. XRTransientInputHitTestSource</a> <a href="#ref-for-dom-xrtransientinputhittestsource-cancel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cancel-a-hit-test-source-for-transient-input">
-   <b><a href="#cancel-a-hit-test-source-for-transient-input">#cancel-a-hit-test-source-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cancel-a-hit-test-source-for-transient-input" class="dfn-panel" data-for="cancel-a-hit-test-source-for-transient-input" id="infopanel-for-cancel-a-hit-test-source-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-cancel-a-hit-test-source-for-transient-input" style="display:none">Info about the 'cancel a hit test source for transient input' definition.</span><b><a href="#cancel-a-hit-test-source-for-transient-input">#cancel-a-hit-test-source-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-a-hit-test-source-for-transient-input">4.2. XRTransientInputHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestresult">
-   <b><a href="#xrhittestresult">#xrhittestresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestresult" class="dfn-panel" data-for="xrhittestresult" id="infopanel-for-xrhittestresult" role="dialog">
+   <span id="infopaneltitle-for-xrhittestresult" style="display:none">Info about the 'XRHitTestResult' definition.</span><b><a href="#xrhittestresult">#xrhittestresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult">5.1. XRHitTestResult</a> <a href="#ref-for-xrhittestresult①">(2)</a> <a href="#ref-for-xrhittestresult②">(3)</a> <a href="#ref-for-xrhittestresult③">(4)</a> <a href="#ref-for-xrhittestresult④">(5)</a>
     <li><a href="#ref-for-xrhittestresult⑤">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-xrhittestresult⑥">(2)</a> <a href="#ref-for-xrhittestresult⑦">(3)</a>
     <li><a href="#ref-for-xrhittestresult⑧">8. Obtaining hit test results</a> <a href="#ref-for-xrhittestresult⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestresult-frame">
-   <b><a href="#xrhittestresult-frame">#xrhittestresult-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestresult-frame" class="dfn-panel" data-for="xrhittestresult-frame" id="infopanel-for-xrhittestresult-frame" role="dialog">
+   <span id="infopaneltitle-for-xrhittestresult-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#xrhittestresult-frame">#xrhittestresult-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult-frame">5.1. XRHitTestResult</a> <a href="#ref-for-xrhittestresult-frame①">(2)</a> <a href="#ref-for-xrhittestresult-frame②">(3)</a> <a href="#ref-for-xrhittestresult-frame③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhittestresult-native-origin">
-   <b><a href="#xrhittestresult-native-origin">#xrhittestresult-native-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhittestresult-native-origin" class="dfn-panel" data-for="xrhittestresult-native-origin" id="infopanel-for-xrhittestresult-native-origin" role="dialog">
+   <span id="infopaneltitle-for-xrhittestresult-native-origin" style="display:none">Info about the 'native origin' definition.</span><b><a href="#xrhittestresult-native-origin">#xrhittestresult-native-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhittestresult-native-origin">5.1. XRHitTestResult</a> <a href="#ref-for-xrhittestresult-native-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-hit-test-result">
-   <b><a href="#create-a-hit-test-result">#create-a-hit-test-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-hit-test-result" class="dfn-panel" data-for="create-a-hit-test-result" id="infopanel-for-create-a-hit-test-result" role="dialog">
+   <span id="infopaneltitle-for-create-a-hit-test-result" style="display:none">Info about the 'create a hit test result' definition.</span><b><a href="#create-a-hit-test-result">#create-a-hit-test-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-hit-test-result">5.2. XRTransientInputHitTestResult</a>
     <li><a href="#ref-for-create-a-hit-test-result①">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhittestresult-getpose">
-   <b><a href="#dom-xrhittestresult-getpose">#dom-xrhittestresult-getpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhittestresult-getpose" class="dfn-panel" data-for="dom-xrhittestresult-getpose" id="infopanel-for-dom-xrhittestresult-getpose" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhittestresult-getpose" style="display:none">Info about the 'getPose(baseSpace)' definition.</span><b><a href="#dom-xrhittestresult-getpose">#dom-xrhittestresult-getpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhittestresult-getpose">5.1. XRHitTestResult</a> <a href="#ref-for-dom-xrhittestresult-getpose①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestresult">
-   <b><a href="#xrtransientinputhittestresult">#xrtransientinputhittestresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestresult" class="dfn-panel" data-for="xrtransientinputhittestresult" id="infopanel-for-xrtransientinputhittestresult" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestresult" style="display:none">Info about the 'XRTransientInputHitTestResult' definition.</span><b><a href="#xrtransientinputhittestresult">#xrtransientinputhittestresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestresult">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-xrtransientinputhittestresult①">(2)</a> <a href="#ref-for-xrtransientinputhittestresult②">(3)</a>
     <li><a href="#ref-for-xrtransientinputhittestresult③">8. Obtaining hit test results</a> <a href="#ref-for-xrtransientinputhittestresult④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestresult-inputsource">
-   <b><a href="#dom-xrtransientinputhittestresult-inputsource">#dom-xrtransientinputhittestresult-inputsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestresult-inputsource" class="dfn-panel" data-for="dom-xrtransientinputhittestresult-inputsource" id="infopanel-for-dom-xrtransientinputhittestresult-inputsource" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestresult-inputsource" style="display:none">Info about the 'inputSource' definition.</span><b><a href="#dom-xrtransientinputhittestresult-inputsource">#dom-xrtransientinputhittestresult-inputsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestresult-inputsource">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-dom-xrtransientinputhittestresult-inputsource①">(2)</a> <a href="#ref-for-dom-xrtransientinputhittestresult-inputsource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtransientinputhittestresult-results">
-   <b><a href="#dom-xrtransientinputhittestresult-results">#dom-xrtransientinputhittestresult-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtransientinputhittestresult-results" class="dfn-panel" data-for="dom-xrtransientinputhittestresult-results" id="infopanel-for-dom-xrtransientinputhittestresult-results" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtransientinputhittestresult-results" style="display:none">Info about the 'results' definition.</span><b><a href="#dom-xrtransientinputhittestresult-results">#dom-xrtransientinputhittestresult-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtransientinputhittestresult-results">5.2. XRTransientInputHitTestResult</a> <a href="#ref-for-dom-xrtransientinputhittestresult-results①">(2)</a> <a href="#ref-for-dom-xrtransientinputhittestresult-results②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtransientinputhittestresult-frame">
-   <b><a href="#xrtransientinputhittestresult-frame">#xrtransientinputhittestresult-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtransientinputhittestresult-frame" class="dfn-panel" data-for="xrtransientinputhittestresult-frame" id="infopanel-for-xrtransientinputhittestresult-frame" role="dialog">
+   <span id="infopaneltitle-for-xrtransientinputhittestresult-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#xrtransientinputhittestresult-frame">#xrtransientinputhittestresult-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtransientinputhittestresult-frame">5.2. XRTransientInputHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-hit-test-result-for-transient-input">
-   <b><a href="#create-a-hit-test-result-for-transient-input">#create-a-hit-test-result-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-hit-test-result-for-transient-input" class="dfn-panel" data-for="create-a-hit-test-result-for-transient-input" id="infopanel-for-create-a-hit-test-result-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-create-a-hit-test-result-for-transient-input" style="display:none">Info about the 'create a hit test result for transient input' definition.</span><b><a href="#create-a-hit-test-result-for-transient-input">#create-a-hit-test-result-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-hit-test-result-for-transient-input">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-set-of-active-hit-test-sources">
-   <b><a href="#xrsession-set-of-active-hit-test-sources">#xrsession-set-of-active-hit-test-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-set-of-active-hit-test-sources" class="dfn-panel" data-for="xrsession-set-of-active-hit-test-sources" id="infopanel-for-xrsession-set-of-active-hit-test-sources" role="dialog">
+   <span id="infopaneltitle-for-xrsession-set-of-active-hit-test-sources" style="display:none">Info about the 'set of active hit test sources' definition.</span><b><a href="#xrsession-set-of-active-hit-test-sources">#xrsession-set-of-active-hit-test-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources">4.1. XRHitTestSource</a> <a href="#ref-for-xrsession-set-of-active-hit-test-sources①">(2)</a>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources②">6. Requesting hit test</a>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources③">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-set-of-active-hit-test-sources-for-transient-input">
-   <b><a href="#xrsession-set-of-active-hit-test-sources-for-transient-input">#xrsession-set-of-active-hit-test-sources-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-set-of-active-hit-test-sources-for-transient-input" class="dfn-panel" data-for="xrsession-set-of-active-hit-test-sources-for-transient-input" id="infopanel-for-xrsession-set-of-active-hit-test-sources-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-xrsession-set-of-active-hit-test-sources-for-transient-input" style="display:none">Info about the 'set of active hit test sources for transient input' definition.</span><b><a href="#xrsession-set-of-active-hit-test-sources-for-transient-input">#xrsession-set-of-active-hit-test-sources-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources-for-transient-input">4.2. XRTransientInputHitTestSource</a> <a href="#ref-for-xrsession-set-of-active-hit-test-sources-for-transient-input①">(2)</a>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources-for-transient-input②">6. Requesting hit test</a>
     <li><a href="#ref-for-xrsession-set-of-active-hit-test-sources-for-transient-input③">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unreasonable-number-of-requests">
-   <b><a href="#unreasonable-number-of-requests">#unreasonable-number-of-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unreasonable-number-of-requests" class="dfn-panel" data-for="unreasonable-number-of-requests" id="infopanel-for-unreasonable-number-of-requests" role="dialog">
+   <span id="infopaneltitle-for-unreasonable-number-of-requests" style="display:none">Info about the 'unreasonable number of requests' definition.</span><b><a href="#unreasonable-number-of-requests">#unreasonable-number-of-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unreasonable-number-of-requests">6. Requesting hit test</a> <a href="#ref-for-unreasonable-number-of-requests①">(2)</a>
     <li><a href="#ref-for-unreasonable-number-of-requests②">11. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-hit-test">
-   <b><a href="#request-hit-test">#request-hit-test</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-hit-test" class="dfn-panel" data-for="request-hit-test" id="infopanel-for-request-hit-test" role="dialog">
+   <span id="infopaneltitle-for-request-hit-test" style="display:none">Info about the 'request hit test' definition.</span><b><a href="#request-hit-test">#request-hit-test</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-hit-test">4.1. XRHitTestSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-requesthittestsource">
-   <b><a href="#dom-xrsession-requesthittestsource">#dom-xrsession-requesthittestsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-requesthittestsource" class="dfn-panel" data-for="dom-xrsession-requesthittestsource" id="infopanel-for-dom-xrsession-requesthittestsource" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-requesthittestsource" style="display:none">Info about the 'requestHitTestSource(options)' definition.</span><b><a href="#dom-xrsession-requesthittestsource">#dom-xrsession-requesthittestsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requesthittestsource">6. Requesting hit test</a> <a href="#ref-for-dom-xrsession-requesthittestsource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-requesthittestsourcefortransientinput">
-   <b><a href="#dom-xrsession-requesthittestsourcefortransientinput">#dom-xrsession-requesthittestsourcefortransientinput</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-requesthittestsourcefortransientinput" class="dfn-panel" data-for="dom-xrsession-requesthittestsourcefortransientinput" id="infopanel-for-dom-xrsession-requesthittestsourcefortransientinput" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-requesthittestsourcefortransientinput" style="display:none">Info about the 'requestHitTestSourceForTransientInput(options)' definition.</span><b><a href="#dom-xrsession-requesthittestsourcefortransientinput">#dom-xrsession-requesthittestsourcefortransientinput</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requesthittestsourcefortransientinput">6. Requesting hit test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-all-hit-test-results">
-   <b><a href="#compute-all-hit-test-results">#compute-all-hit-test-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-all-hit-test-results" class="dfn-panel" data-for="compute-all-hit-test-results" id="infopanel-for-compute-all-hit-test-results" role="dialog">
+   <span id="infopaneltitle-for-compute-all-hit-test-results" style="display:none">Info about the 'compute all hit test results' definition.</span><b><a href="#compute-all-hit-test-results">#compute-all-hit-test-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-all-hit-test-results">6. Requesting hit test</a> <a href="#ref-for-compute-all-hit-test-results①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-hit-test-results">
-   <b><a href="#compute-hit-test-results">#compute-hit-test-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-hit-test-results" class="dfn-panel" data-for="compute-hit-test-results" id="infopanel-for-compute-hit-test-results" role="dialog">
+   <span id="infopaneltitle-for-compute-hit-test-results" style="display:none">Info about the 'compute hit test results' definition.</span><b><a href="#compute-hit-test-results">#compute-hit-test-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-hit-test-results">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-hit-test-results-for-transient-input">
-   <b><a href="#compute-hit-test-results-for-transient-input">#compute-hit-test-results-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-hit-test-results-for-transient-input" class="dfn-panel" data-for="compute-hit-test-results-for-transient-input" id="infopanel-for-compute-hit-test-results-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-compute-hit-test-results-for-transient-input" style="display:none">Info about the 'compute hit test results for transient input' definition.</span><b><a href="#compute-hit-test-results-for-transient-input">#compute-hit-test-results-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-hit-test-results-for-transient-input">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-map-of-hit-test-sources-to-hit-test-results">
-   <b><a href="#xrframe-map-of-hit-test-sources-to-hit-test-results">#xrframe-map-of-hit-test-sources-to-hit-test-results</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-map-of-hit-test-sources-to-hit-test-results" class="dfn-panel" data-for="xrframe-map-of-hit-test-sources-to-hit-test-results" id="infopanel-for-xrframe-map-of-hit-test-sources-to-hit-test-results" role="dialog">
+   <span id="infopaneltitle-for-xrframe-map-of-hit-test-sources-to-hit-test-results" style="display:none">Info about the 'map of hit test sources to hit test results' definition.</span><b><a href="#xrframe-map-of-hit-test-sources-to-hit-test-results">#xrframe-map-of-hit-test-sources-to-hit-test-results</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results">7. Computing hit test results</a>
     <li><a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results①">8. Obtaining hit test results</a> <a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input">
-   <b><a href="#xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input">#xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input" class="dfn-panel" data-for="xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input" id="infopanel-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input" role="dialog">
+   <span id="infopaneltitle-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input" style="display:none">Info about the 'map of hit test sources to hit test results for transient input' definition.</span><b><a href="#xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input">#xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input">7. Computing hit test results</a>
     <li><a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input①">8. Obtaining hit test results</a> <a href="#ref-for-xrframe-map-of-hit-test-sources-to-hit-test-results-for-transient-input②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-gethittestresults">
-   <b><a href="#dom-xrframe-gethittestresults">#dom-xrframe-gethittestresults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-gethittestresults" class="dfn-panel" data-for="dom-xrframe-gethittestresults" id="infopanel-for-dom-xrframe-gethittestresults" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-gethittestresults" style="display:none">Info about the 'getHitTestResults(hitTestSource)' definition.</span><b><a href="#dom-xrframe-gethittestresults">#dom-xrframe-gethittestresults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-gethittestresults">8. Obtaining hit test results</a> <a href="#ref-for-dom-xrframe-gethittestresults①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-gethittestresultsfortransientinput">
-   <b><a href="#dom-xrframe-gethittestresultsfortransientinput">#dom-xrframe-gethittestresultsfortransientinput</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-gethittestresultsfortransientinput" class="dfn-panel" data-for="dom-xrframe-gethittestresultsfortransientinput" id="infopanel-for-dom-xrframe-gethittestresultsfortransientinput" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-gethittestresultsfortransientinput" style="display:none">Info about the 'getHitTestResultsForTransientInput(hitTestSource)' definition.</span><b><a href="#dom-xrframe-gethittestresultsfortransientinput">#dom-xrframe-gethittestresultsfortransientinput</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-gethittestresultsfortransientinput">8. Obtaining hit test results</a> <a href="#ref-for-dom-xrframe-gethittestresultsfortransientinput①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrraydirectioninit">
-   <b><a href="#dictdef-xrraydirectioninit">#dictdef-xrraydirectioninit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrraydirectioninit" class="dfn-panel" data-for="dictdef-xrraydirectioninit" id="infopanel-for-dictdef-xrraydirectioninit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrraydirectioninit" style="display:none">Info about the 'XRRayDirectionInit' definition.</span><b><a href="#dictdef-xrraydirectioninit">#dictdef-xrraydirectioninit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrraydirectioninit">9.1. XRRayDirectionInit</a>
     <li><a href="#ref-for-dictdef-xrraydirectioninit①">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrraydirectioninit-x">
-   <b><a href="#dom-xrraydirectioninit-x">#dom-xrraydirectioninit-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrraydirectioninit-x" class="dfn-panel" data-for="dom-xrraydirectioninit-x" id="infopanel-for-dom-xrraydirectioninit-x" role="dialog">
+   <span id="infopaneltitle-for-dom-xrraydirectioninit-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-xrraydirectioninit-x">#dom-xrraydirectioninit-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrraydirectioninit-x">9.2. XRRay</a> <a href="#ref-for-dom-xrraydirectioninit-x①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrraydirectioninit-y">
-   <b><a href="#dom-xrraydirectioninit-y">#dom-xrraydirectioninit-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrraydirectioninit-y" class="dfn-panel" data-for="dom-xrraydirectioninit-y" id="infopanel-for-dom-xrraydirectioninit-y" role="dialog">
+   <span id="infopaneltitle-for-dom-xrraydirectioninit-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-xrraydirectioninit-y">#dom-xrraydirectioninit-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrraydirectioninit-y">9.2. XRRay</a> <a href="#ref-for-dom-xrraydirectioninit-y①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrraydirectioninit-z">
-   <b><a href="#dom-xrraydirectioninit-z">#dom-xrraydirectioninit-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrraydirectioninit-z" class="dfn-panel" data-for="dom-xrraydirectioninit-z" id="infopanel-for-dom-xrraydirectioninit-z" role="dialog">
+   <span id="infopaneltitle-for-dom-xrraydirectioninit-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-xrraydirectioninit-z">#dom-xrraydirectioninit-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrraydirectioninit-z">9.2. XRRay</a> <a href="#ref-for-dom-xrraydirectioninit-z①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrraydirectioninit-w">
-   <b><a href="#dom-xrraydirectioninit-w">#dom-xrraydirectioninit-w</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrraydirectioninit-w" class="dfn-panel" data-for="dom-xrraydirectioninit-w" id="infopanel-for-dom-xrraydirectioninit-w" role="dialog">
+   <span id="infopaneltitle-for-dom-xrraydirectioninit-w" style="display:none">Info about the 'w' definition.</span><b><a href="#dom-xrraydirectioninit-w">#dom-xrraydirectioninit-w</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrraydirectioninit-w">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrray-matrix">
-   <b><a href="#xrray-matrix">#xrray-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrray-matrix" class="dfn-panel" data-for="xrray-matrix" id="infopanel-for-xrray-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrray-matrix" style="display:none">Info about the 'matrix' definition.</span><b><a href="#xrray-matrix">#xrray-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrray-matrix">9.2. XRRay</a> <a href="#ref-for-xrray-matrix①">(2)</a> <a href="#ref-for-xrray-matrix②">(3)</a> <a href="#ref-for-xrray-matrix③">(4)</a> <a href="#ref-for-xrray-matrix④">(5)</a> <a href="#ref-for-xrray-matrix⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrray">
-   <b><a href="#xrray">#xrray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrray" class="dfn-panel" data-for="xrray" id="infopanel-for-xrray" role="dialog">
+   <span id="infopaneltitle-for-xrray" style="display:none">Info about the 'XRRay' definition.</span><b><a href="#xrray">#xrray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrray">3.2. XRHitTestOptionsInit</a> <a href="#ref-for-xrray①">(2)</a> <a href="#ref-for-xrray②">(3)</a>
     <li><a href="#ref-for-xrray③">3.3. XRTransientInputHitTestOptionsInit</a> <a href="#ref-for-xrray④">(2)</a> <a href="#ref-for-xrray⑤">(3)</a>
@@ -3039,8 +3039,8 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-xrray⑧">9.2. XRRay</a> <a href="#ref-for-xrray⑨">(2)</a> <a href="#ref-for-xrray①⓪">(3)</a> <a href="#ref-for-xrray①①">(4)</a> <a href="#ref-for-xrray①②">(5)</a> <a href="#ref-for-xrray①③">(6)</a> <a href="#ref-for-xrray①④">(7)</a> <a href="#ref-for-xrray①⑤">(8)</a> <a href="#ref-for-xrray①⑥">(9)</a> <a href="#ref-for-xrray①⑦">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrray-xrray">
-   <b><a href="#dom-xrray-xrray">#dom-xrray-xrray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrray-xrray" class="dfn-panel" data-for="dom-xrray-xrray" id="infopanel-for-dom-xrray-xrray" role="dialog">
+   <span id="infopaneltitle-for-dom-xrray-xrray" style="display:none">Info about the 'XRRay(origin, direction)' definition.</span><b><a href="#dom-xrray-xrray">#dom-xrray-xrray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrray-xrray">3.2. XRHitTestOptionsInit</a>
     <li><a href="#ref-for-dom-xrray-xrray①">3.3. XRTransientInputHitTestOptionsInit</a>
@@ -3048,63 +3048,63 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
     <li><a href="#ref-for-dom-xrray-xrray③">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrray-xrray-transform">
-   <b><a href="#dom-xrray-xrray-transform">#dom-xrray-xrray-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrray-xrray-transform" class="dfn-panel" data-for="dom-xrray-xrray-transform" id="infopanel-for-dom-xrray-xrray-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrray-xrray-transform" style="display:none">Info about the 'XRRay(transform)' definition.</span><b><a href="#dom-xrray-xrray-transform">#dom-xrray-xrray-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrray-xrray-transform">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrray-origin">
-   <b><a href="#dom-xrray-origin">#dom-xrray-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrray-origin" class="dfn-panel" data-for="dom-xrray-origin" id="infopanel-for-dom-xrray-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-xrray-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-xrray-origin">#dom-xrray-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrray-origin">9.2. XRRay</a> <a href="#ref-for-dom-xrray-origin①">(2)</a> <a href="#ref-for-dom-xrray-origin②">(3)</a> <a href="#ref-for-dom-xrray-origin③">(4)</a> <a href="#ref-for-dom-xrray-origin④">(5)</a> <a href="#ref-for-dom-xrray-origin⑤">(6)</a> <a href="#ref-for-dom-xrray-origin⑥">(7)</a> <a href="#ref-for-dom-xrray-origin⑦">(8)</a> <a href="#ref-for-dom-xrray-origin⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrray-direction">
-   <b><a href="#dom-xrray-direction">#dom-xrray-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrray-direction" class="dfn-panel" data-for="dom-xrray-direction" id="infopanel-for-dom-xrray-direction" role="dialog">
+   <span id="infopaneltitle-for-dom-xrray-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#dom-xrray-direction">#dom-xrray-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrray-direction">9.2. XRRay</a> <a href="#ref-for-dom-xrray-direction①">(2)</a> <a href="#ref-for-dom-xrray-direction②">(3)</a> <a href="#ref-for-dom-xrray-direction③">(4)</a> <a href="#ref-for-dom-xrray-direction④">(5)</a> <a href="#ref-for-dom-xrray-direction⑤">(6)</a> <a href="#ref-for-dom-xrray-direction⑥">(7)</a> <a href="#ref-for-dom-xrray-direction⑦">(8)</a> <a href="#ref-for-dom-xrray-direction⑧">(9)</a> <a href="#ref-for-dom-xrray-direction⑨">(10)</a> <a href="#ref-for-dom-xrray-direction①⓪">(11)</a> <a href="#ref-for-dom-xrray-direction①①">(12)</a> <a href="#ref-for-dom-xrray-direction①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrray-matrix">
-   <b><a href="#dom-xrray-matrix">#dom-xrray-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrray-matrix" class="dfn-panel" data-for="dom-xrray-matrix" id="infopanel-for-dom-xrray-matrix" role="dialog">
+   <span id="infopaneltitle-for-dom-xrray-matrix" style="display:none">Info about the 'matrix' definition.</span><b><a href="#dom-xrray-matrix">#dom-xrray-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrray-matrix">9.2. XRRay</a> <a href="#ref-for-dom-xrray-matrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrray-obtain-the-matrix">
-   <b><a href="#xrray-obtain-the-matrix">#xrray-obtain-the-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrray-obtain-the-matrix" class="dfn-panel" data-for="xrray-obtain-the-matrix" id="infopanel-for-xrray-obtain-the-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrray-obtain-the-matrix" style="display:none">Info about the 'obtain the matrix' definition.</span><b><a href="#xrray-obtain-the-matrix">#xrray-obtain-the-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrray-obtain-the-matrix">9.2. XRRay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distance-along-the-ray">
-   <b><a href="#distance-along-the-ray">#distance-along-the-ray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distance-along-the-ray" class="dfn-panel" data-for="distance-along-the-ray" id="infopanel-for-distance-along-the-ray" role="dialog">
+   <span id="infopaneltitle-for-distance-along-the-ray" style="display:none">Info about the 'distance along the ray' definition.</span><b><a href="#distance-along-the-ray">#distance-along-the-ray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distance-along-the-ray">7. Computing hit test results</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-hit-test">
-   <b><a href="#native-hit-test">#native-hit-test</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-hit-test" class="dfn-panel" data-for="native-hit-test" id="infopanel-for-native-hit-test" role="dialog">
+   <span id="infopaneltitle-for-native-hit-test" style="display:none">Info about the 'native hit test' definition.</span><b><a href="#native-hit-test">#native-hit-test</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-hit-test">2.1. Feature descriptor</a>
     <li><a href="#ref-for-native-hit-test①">7. Computing hit test results</a> <a href="#ref-for-native-hit-test②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-entity-type">
-   <b><a href="#native-entity-type">#native-entity-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-entity-type" class="dfn-panel" data-for="native-entity-type" id="infopanel-for-native-entity-type" role="dialog">
+   <span id="infopaneltitle-for-native-entity-type" style="display:none">Info about the 'type of the entity' definition.</span><b><a href="#native-entity-type">#native-entity-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-entity-type">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-from-native-entity-type">
-   <b><a href="#convert-from-native-entity-type">#convert-from-native-entity-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-from-native-entity-type" class="dfn-panel" data-for="convert-from-native-entity-type" id="infopanel-for-convert-from-native-entity-type" role="dialog">
+   <span id="infopaneltitle-for-convert-from-native-entity-type" style="display:none">Info about the 'convert from native entity type' definition.</span><b><a href="#convert-from-native-entity-type">#convert-from-native-entity-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-from-native-entity-type">5.1. XRHitTestResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-hit-test-result">
-   <b><a href="#native-hit-test-result">#native-hit-test-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-hit-test-result" class="dfn-panel" data-for="native-hit-test-result" id="infopanel-for-native-hit-test-result" role="dialog">
+   <span id="infopaneltitle-for-native-hit-test-result" style="display:none">Info about the 'Native hit test results' definition.</span><b><a href="#native-hit-test-result">#native-hit-test-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-hit-test-result">5.1. XRHitTestResult</a>
     <li><a href="#ref-for-native-hit-test-result①">5.2. XRTransientInputHitTestResult</a>
@@ -3115,59 +3115,115 @@ number of requests</a> have been made for a genuine non-privacy invasive usage.<
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/immersive-web/layers/webxrlayers-1.html
+++ b/tests/github/immersive-web/layers/webxrlayers-1.html
@@ -2947,144 +2947,144 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
    <li><a href="#dom-xrwebglbinding-xrwebglbinding">XRWebGLBinding(session, context)</a><span>, in § 6.9</span>
    <li><a href="#xrwebglsubimage">XRWebGLSubImage</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-compressed_rgb8_etc2">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_etc2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_rgb8_etc2" class="dfn-panel" data-for="term-for-compressed_rgb8_etc2" id="infopanel-for-term-for-compressed_rgb8_etc2" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_rgb8_etc2" style="display:none">Info about the 'COMPRESSED_RGB8_ETC2' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_etc2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_rgb8_etc2">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressed_rgb8_punchthrough_alpha1_etc2">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_punchthrough_alpha1_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_punchthrough_alpha1_etc2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_rgb8_punchthrough_alpha1_etc2" class="dfn-panel" data-for="term-for-compressed_rgb8_punchthrough_alpha1_etc2" id="infopanel-for-term-for-compressed_rgb8_punchthrough_alpha1_etc2" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_rgb8_punchthrough_alpha1_etc2" style="display:none">Info about the 'COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_punchthrough_alpha1_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgb8_punchthrough_alpha1_etc2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_rgb8_punchthrough_alpha1_etc2">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressed_rgba8_etc2_eac">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgba8_etc2_eac">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgba8_etc2_eac</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_rgba8_etc2_eac" class="dfn-panel" data-for="term-for-compressed_rgba8_etc2_eac" id="infopanel-for-term-for-compressed_rgba8_etc2_eac" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_rgba8_etc2_eac" style="display:none">Info about the 'COMPRESSED_RGBA8_ETC2_EAC' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgba8_etc2_eac">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_rgba8_etc2_eac</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_rgba8_etc2_eac">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressed_srgb8_alpha8_etc2_eac">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_alpha8_etc2_eac">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_alpha8_etc2_eac</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_srgb8_alpha8_etc2_eac" class="dfn-panel" data-for="term-for-compressed_srgb8_alpha8_etc2_eac" id="infopanel-for-term-for-compressed_srgb8_alpha8_etc2_eac" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_srgb8_alpha8_etc2_eac" style="display:none">Info about the 'COMPRESSED_SRGB8_ALPHA8_ETC2_EAC' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_alpha8_etc2_eac">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_alpha8_etc2_eac</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_srgb8_alpha8_etc2_eac">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressed_srgb8_etc2">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_etc2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_srgb8_etc2" class="dfn-panel" data-for="term-for-compressed_srgb8_etc2" id="infopanel-for-term-for-compressed_srgb8_etc2" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_srgb8_etc2" style="display:none">Info about the 'COMPRESSED_SRGB8_ETC2' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_etc2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_srgb8_etc2">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressed_srgb8_punchthrough_alpha1_etc2">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_punchthrough_alpha1_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_punchthrough_alpha1_etc2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressed_srgb8_punchthrough_alpha1_etc2" class="dfn-panel" data-for="term-for-compressed_srgb8_punchthrough_alpha1_etc2" id="infopanel-for-term-for-compressed_srgb8_punchthrough_alpha1_etc2" role="menu">
+   <span id="infopaneltitle-for-term-for-compressed_srgb8_punchthrough_alpha1_etc2" style="display:none">Info about the 'COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_punchthrough_alpha1_etc2">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#compressed_srgb8_punchthrough_alpha1_etc2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressed_srgb8_punchthrough_alpha1_etc2">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-depth_component">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_component">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_component</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-depth_component" class="dfn-panel" data-for="term-for-depth_component" id="infopanel-for-term-for-depth_component" role="menu">
+   <span id="infopaneltitle-for-term-for-depth_component" style="display:none">Info about the 'DEPTH_COMPONENT' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_component">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_component</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depth_component">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-depth_component①">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-depth_stencil">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_stencil">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_stencil</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-depth_stencil" class="dfn-panel" data-for="term-for-depth_stencil" id="infopanel-for-term-for-depth_stencil" role="menu">
+   <span id="infopaneltitle-for-term-for-depth_stencil" style="display:none">Info about the 'DEPTH_STENCIL' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_stencil">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#depth_stencil</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depth_stencil">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-depth_stencil①">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ext_srgb">
-   <a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#ext_srgb">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#ext_srgb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ext_srgb" class="dfn-panel" data-for="term-for-ext_srgb" id="infopanel-for-term-for-ext_srgb" role="menu">
+   <span id="infopaneltitle-for-term-for-ext_srgb" style="display:none">Info about the 'EXT_sRGB' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#ext_srgb">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#ext_srgb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ext_srgb">6.3. XRProjectionLayerInit</a> <a href="#ref-for-ext_srgb①">(2)</a>
     <li><a href="#ref-for-ext_srgb②">6.4. XRLayerInit</a> <a href="#ref-for-ext_srgb③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-srgb_alpha_ext">
-   <a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_alpha_ext">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_alpha_ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-srgb_alpha_ext" class="dfn-panel" data-for="term-for-srgb_alpha_ext" id="infopanel-for-term-for-srgb_alpha_ext" role="menu">
+   <span id="infopaneltitle-for-term-for-srgb_alpha_ext" style="display:none">Info about the 'SRGB_ALPHA_EXT' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_alpha_ext">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_alpha_ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-srgb_alpha_ext">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-srgb_alpha_ext①">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-srgb_ext">
-   <a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_ext">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-srgb_ext" class="dfn-panel" data-for="term-for-srgb_ext" id="infopanel-for-term-for-srgb_ext" role="menu">
+   <span id="infopaneltitle-for-term-for-srgb_ext" style="display:none">Info about the 'SRGB_EXT' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_ext">https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/#srgb_ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-srgb_ext">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-srgb_ext①">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl_compressed_texture_astc">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/#webgl_compressed_texture_astc">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/#webgl_compressed_texture_astc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl_compressed_texture_astc" class="dfn-panel" data-for="term-for-webgl_compressed_texture_astc" id="infopanel-for-term-for-webgl_compressed_texture_astc" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl_compressed_texture_astc" style="display:none">Info about the 'WEBGL_compressed_texture_astc' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/#webgl_compressed_texture_astc">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/#webgl_compressed_texture_astc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl_compressed_texture_astc">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl_compressed_texture_etc">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#webgl_compressed_texture_etc">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#webgl_compressed_texture_etc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl_compressed_texture_etc" class="dfn-panel" data-for="term-for-webgl_compressed_texture_etc" id="infopanel-for-term-for-webgl_compressed_texture_etc" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl_compressed_texture_etc" style="display:none">Info about the 'WEBGL_compressed_texture_etc' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#webgl_compressed_texture_etc">https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/#webgl_compressed_texture_etc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl_compressed_texture_etc">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl_depth_texture">
-   <a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#webgl_depth_texture">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#webgl_depth_texture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl_depth_texture" class="dfn-panel" data-for="term-for-webgl_depth_texture" id="infopanel-for-term-for-webgl_depth_texture" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl_depth_texture" style="display:none">Info about the 'WEBGL_depth_texture' external reference.</span><a href="https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#webgl_depth_texture">https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/#webgl_depth_texture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl_depth_texture">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-webgl_depth_texture①">6.4. XRLayerInit</a>
     <li><a href="#ref-for-webgl_depth_texture②">6.9. XRWebGLBinding</a> <a href="#ref-for-webgl_depth_texture③">(2)</a> <a href="#ref-for-webgl_depth_texture④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-porterduffcompositingoperators_srcover">
-   <a href="https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-porterduffcompositingoperators_srcover" class="dfn-panel" data-for="term-for-porterduffcompositingoperators_srcover" id="infopanel-for-term-for-porterduffcompositingoperators_srcover" role="menu">
+   <span id="infopaneltitle-for-term-for-porterduffcompositingoperators_srcover" style="display:none">Info about the 'source-over' external reference.</span><a href="https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-porterduffcompositingoperators_srcover">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.3. XRCompositionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-dompointinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-dompointinit" class="dfn-panel" data-for="term-for-dictdef-dompointinit" id="infopanel-for-term-for-dictdef-dompointinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dictdef-dompointinit①">3.6. XRCylinderLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">3.8. XRCubeLayer</a>
     <li><a href="#ref-for-dompointreadonly①">6.8. XRCubeLayerInit</a>
     <li><a href="#ref-for-dompointreadonly②">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-frompoint">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-frompoint">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-frompoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-frompoint" class="dfn-panel" data-for="term-for-dom-dompointreadonly-frompoint" id="infopanel-for-term-for-dom-dompointreadonly-frompoint" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-frompoint" style="display:none">Info about the 'fromPoint()' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-frompoint">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-frompoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-frompoint">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-eventhandler①">3.6. XRCylinderLayer</a>
@@ -3092,28 +3092,28 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-eventhandler③">3.8. XRCubeLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-htmlvideoelement①">7.5. XRMediaBinding</a> <a href="#ref-for-htmlvideoelement②">(2)</a> <a href="#ref-for-htmlvideoelement③">(3)</a> <a href="#ref-for-htmlvideoelement④">(4)</a> <a href="#ref-for-htmlvideoelement⑤">(5)</a> <a href="#ref-for-htmlvideoelement⑥">(6)</a> <a href="#ref-for-htmlvideoelement⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-the-usability-of-the-image-argument">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument">https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-the-usability-of-the-image-argument" class="dfn-panel" data-for="term-for-check-the-usability-of-the-image-argument" id="infopanel-for-term-for-check-the-usability-of-the-image-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-check-the-usability-of-the-image-argument" style="display:none">Info about the 'check the usability of the image argument' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument">https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-usability-of-the-image-argument">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-queue-a-task①">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.5. XRQuadLayer</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
     <li><a href="#ref-for-concept-relevant-realm②">3.6. XRCylinderLayer</a> <a href="#ref-for-concept-relevant-realm③">(2)</a>
@@ -3123,75 +3123,75 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-concept-relevant-realm⑤⑦">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videoheight" class="dfn-panel" data-for="term-for-dom-video-videoheight" id="infopanel-for-term-for-dom-video-videoheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videoheight" style="display:none">Info about the 'videoHeight' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videoheight">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videowidth">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videowidth" class="dfn-panel" data-for="term-for-dom-video-videowidth" id="infopanel-for-term-for-dom-video-videowidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videowidth" style="display:none">Info about the 'videoWidth' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videowidth">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissions-request">
-   <a href="https://wicg.github.io/permissions-request/#dom-permissions-request">https://wicg.github.io/permissions-request/#dom-permissions-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissions-request" class="dfn-panel" data-for="term-for-dom-permissions-request" id="infopanel-for-term-for-dom-permissions-request" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissions-request" style="display:none">Info about the 'request(permissionDesc)' external reference.</span><a href="https://wicg.github.io/permissions-request/#dom-permissions-request">https://wicg.github.io/permissions-request/#dom-permissions-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-request">2. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14" style="display:none">Info about the 'DEPTH24_STENCIL8' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14①" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14①" style="display:none">Info about the 'DEPTH_COMPONENT24' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14②" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14②" style="display:none">Info about the 'RGB8' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14③" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14③" style="display:none">Info about the 'RGBA8' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14④" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14④" style="display:none">Info about the 'SRGB8' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14⑤" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14⑤" style="display:none">Info about the 'SRGB8_ALPHA8' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14③">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14④">(2)</a> <a href="#ref-for-5.14⑤">(3)</a> <a href="#ref-for-5.14⑥">(4)</a> <a href="#ref-for-5.14⑦">(5)</a> <a href="#ref-for-5.14⑧">(6)</a>
     <li><a href="#ref-for-5.14①①">6.4. XRLayerInit</a> <a href="#ref-for-5.14①②">(2)</a> <a href="#ref-for-5.14①③">(3)</a> <a href="#ref-for-5.14①④">(4)</a> <a href="#ref-for-5.14①⑤">(5)</a> <a href="#ref-for-5.14①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-3.7">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-3.7" class="dfn-panel" data-for="term-for-3.7" id="infopanel-for-term-for-3.7" role="menu">
+   <span id="infopaneltitle-for-term-for-3.7" style="display:none">Info about the 'TEXTURE_2D_ARRAY' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3.7">5.3. XRTextureType</a>
     <li><a href="#ref-for-3.7①">6.9. XRWebGLBinding</a> <a href="#ref-for-3.7②">(2)</a> <a href="#ref-for-3.7③">(3)</a> <a href="#ref-for-3.7④">(4)</a> <a href="#ref-for-3.7⑤">(5)</a> <a href="#ref-for-3.7⑥">(6)</a> <a href="#ref-for-3.7⑦">(7)</a> <a href="#ref-for-3.7⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGL2RenderingContext">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext">https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGL2RenderingContext" class="dfn-panel" data-for="term-for-WebGL2RenderingContext" id="infopanel-for-term-for-WebGL2RenderingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGL2RenderingContext" style="display:none">Info about the 'WebGL2RenderingContext' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext">https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGL2RenderingContext">3.3. XRCompositionLayer</a> <a href="#ref-for-WebGL2RenderingContext①">(2)</a>
     <li><a href="#ref-for-WebGL2RenderingContext②">6.3. XRProjectionLayerInit</a>
@@ -3199,34 +3199,34 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-WebGL2RenderingContext④">6.9. XRWebGLBinding</a> <a href="#ref-for-WebGL2RenderingContext⑤">(2)</a> <a href="#ref-for-WebGL2RenderingContext⑥">(3)</a> <a href="#ref-for-WebGL2RenderingContext⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-3.7.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-3.7.6" class="dfn-panel" data-for="term-for-3.7.6" id="infopanel-for-term-for-3.7.6" role="menu">
+   <span id="infopaneltitle-for-term-for-3.7.6" style="display:none">Info about the 'texstorage2d' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3.7.6">6.2. Opaque textures</a> <a href="#ref-for-3.7.6①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-3.7.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-3.7.6" class="dfn-panel" data-for="term-for-3.7.6" id="infopanel-for-term-for-3.7.6①" role="menu">
+   <span id="infopaneltitle-for-term-for-3.7.6①" style="display:none">Info about the 'texstorage3d' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6">https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3.7.6">6.2. Opaque textures</a> <a href="#ref-for-3.7.6①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.1">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.1" class="dfn-panel" data-for="term-for-5.1" id="infopanel-for-term-for-5.1" role="menu">
+   <span id="infopaneltitle-for-term-for-5.1" style="display:none">Info about the 'GLenum' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.1">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.1①">(2)</a>
     <li><a href="#ref-for-5.1②">6.4. XRLayerInit</a> <a href="#ref-for-5.1③">(2)</a>
     <li><a href="#ref-for-5.1④">6.9. XRWebGLBinding</a> <a href="#ref-for-5.1⑤">(2)</a> <a href="#ref-for-5.1⑥">(3)</a> <a href="#ref-for-5.1⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContextBase">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContextBase" class="dfn-panel" data-for="term-for-WebGLRenderingContextBase" id="infopanel-for-term-for-WebGLRenderingContextBase" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContextBase" style="display:none">Info about the 'INVALID_OPERATION' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContextBase">6.2. Opaque textures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14⑥" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14⑥" style="display:none">Info about the 'RGB' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14">5.3. XRTextureType</a>
     <li><a href="#ref-for-5.14①">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14②">(2)</a>
@@ -3234,8 +3234,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-5.14①⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14①⑧">(2)</a> <a href="#ref-for-5.14①⑨">(3)</a> <a href="#ref-for-5.14②⓪">(4)</a> <a href="#ref-for-5.14②①">(5)</a> <a href="#ref-for-5.14②②">(6)</a> <a href="#ref-for-5.14②③">(7)</a> <a href="#ref-for-5.14②④">(8)</a> <a href="#ref-for-5.14②⑤">(9)</a> <a href="#ref-for-5.14②⑥">(10)</a> <a href="#ref-for-5.14②⑦">(11)</a> <a href="#ref-for-5.14②⑧">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14⑦" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14⑦" style="display:none">Info about the 'RGBA' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14">5.3. XRTextureType</a>
     <li><a href="#ref-for-5.14①">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14②">(2)</a>
@@ -3243,8 +3243,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-5.14①⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14①⑧">(2)</a> <a href="#ref-for-5.14①⑨">(3)</a> <a href="#ref-for-5.14②⓪">(4)</a> <a href="#ref-for-5.14②①">(5)</a> <a href="#ref-for-5.14②②">(6)</a> <a href="#ref-for-5.14②③">(7)</a> <a href="#ref-for-5.14②④">(8)</a> <a href="#ref-for-5.14②⑤">(9)</a> <a href="#ref-for-5.14②⑥">(10)</a> <a href="#ref-for-5.14②⑦">(11)</a> <a href="#ref-for-5.14②⑧">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14⑧" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14⑧" style="display:none">Info about the 'TEXTURE_2D' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14">5.3. XRTextureType</a>
     <li><a href="#ref-for-5.14①">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14②">(2)</a>
@@ -3252,8 +3252,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-5.14①⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14①⑧">(2)</a> <a href="#ref-for-5.14①⑨">(3)</a> <a href="#ref-for-5.14②⓪">(4)</a> <a href="#ref-for-5.14②①">(5)</a> <a href="#ref-for-5.14②②">(6)</a> <a href="#ref-for-5.14②③">(7)</a> <a href="#ref-for-5.14②④">(8)</a> <a href="#ref-for-5.14②⑤">(9)</a> <a href="#ref-for-5.14②⑥">(10)</a> <a href="#ref-for-5.14②⑦">(11)</a> <a href="#ref-for-5.14②⑧">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14" class="dfn-panel" data-for="term-for-5.14" id="infopanel-for-term-for-5.14⑨" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14⑨" style="display:none">Info about the 'TEXTURE_CUBE_MAP' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14">5.3. XRTextureType</a>
     <li><a href="#ref-for-5.14①">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14②">(2)</a>
@@ -3261,8 +3261,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-5.14①⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14①⑧">(2)</a> <a href="#ref-for-5.14①⑨">(3)</a> <a href="#ref-for-5.14②⓪">(4)</a> <a href="#ref-for-5.14②①">(5)</a> <a href="#ref-for-5.14②②">(6)</a> <a href="#ref-for-5.14②③">(7)</a> <a href="#ref-for-5.14②④">(8)</a> <a href="#ref-for-5.14②⑤">(9)</a> <a href="#ref-for-5.14②⑥">(10)</a> <a href="#ref-for-5.14②⑦">(11)</a> <a href="#ref-for-5.14②⑧">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContext">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContext" class="dfn-panel" data-for="term-for-WebGLRenderingContext" id="infopanel-for-term-for-WebGLRenderingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContext" style="display:none">Info about the 'WebGLRenderingContext' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContext">3.3. XRCompositionLayer</a> <a href="#ref-for-WebGLRenderingContext①">(2)</a>
     <li><a href="#ref-for-WebGLRenderingContext②">6.1. Overview</a>
@@ -3271,60 +3271,60 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-WebGLRenderingContext⑤">6.9. XRWebGLBinding</a> <a href="#ref-for-WebGLRenderingContext⑥">(2)</a> <a href="#ref-for-WebGLRenderingContext⑦">(3)</a> <a href="#ref-for-WebGLRenderingContext⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.8">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.8" class="dfn-panel" data-for="term-for-5.8" id="infopanel-for-term-for-5.8" role="menu">
+   <span id="infopaneltitle-for-term-for-5.8" style="display:none">Info about the 'WebGLShader' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.8">6.2. Opaque textures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLTexture">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLTexture" class="dfn-panel" data-for="term-for-WebGLTexture" id="infopanel-for-term-for-WebGLTexture" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLTexture" style="display:none">Info about the 'WebGLTexture' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLTexture">5.2. XRWebGLSubImage</a> <a href="#ref-for-WebGLTexture①">(2)</a>
     <li><a href="#ref-for-WebGLTexture②">6.2. Opaque textures</a>
     <li><a href="#ref-for-WebGLTexture③">6.9. XRWebGLBinding</a> <a href="#ref-for-WebGLTexture④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11" style="display:none">Info about the 'clear' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.8">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.8" class="dfn-panel" data-for="term-for-5.14.8" id="infopanel-for-term-for-5.14.8" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.8" style="display:none">Info about the 'deleteTexture' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.8">6.2. Opaque textures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11①" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11①" style="display:none">Info about the 'drawArrays' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11②" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11②" style="display:none">Info about the 'drawElements' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.14">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.14" class="dfn-panel" data-for="term-for-5.14.14" id="infopanel-for-term-for-5.14.14" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.14" style="display:none">Info about the 'extension' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.14">6.3. XRProjectionLayerInit</a> <a href="#ref-for-5.14.14①">(2)</a> <a href="#ref-for-5.14.14②">(3)</a>
     <li><a href="#ref-for-5.14.14③">6.4. XRLayerInit</a> <a href="#ref-for-5.14.14④">(2)</a> <a href="#ref-for-5.14.14⑤">(3)</a> <a href="#ref-for-5.14.14⑥">(4)</a> <a href="#ref-for-5.14.14⑦">(5)</a> <a href="#ref-for-5.14.14⑧">(6)</a>
     <li><a href="#ref-for-5.14.14⑨">6.9. XRWebGLBinding</a> <a href="#ref-for-5.14.14①⓪">(2)</a> <a href="#ref-for-5.14.14①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-Exposed①">3.4. XRProjectionLayer</a>
@@ -3340,51 +3340,51 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-Exposed①①">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6.9. XRWebGLBinding</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a> <a href="#ref-for-invalidstateerror④">(5)</a> <a href="#ref-for-invalidstateerror⑤">(6)</a> <a href="#ref-for-invalidstateerror⑥">(7)</a> <a href="#ref-for-invalidstateerror⑦">(8)</a> <a href="#ref-for-invalidstateerror⑧">(9)</a> <a href="#ref-for-invalidstateerror⑨">(10)</a> <a href="#ref-for-invalidstateerror①⓪">(11)</a> <a href="#ref-for-invalidstateerror①①">(12)</a> <a href="#ref-for-invalidstateerror①②">(13)</a> <a href="#ref-for-invalidstateerror①③">(14)</a> <a href="#ref-for-invalidstateerror①④">(15)</a> <a href="#ref-for-invalidstateerror①⑤">(16)</a> <a href="#ref-for-invalidstateerror①⑥">(17)</a> <a href="#ref-for-invalidstateerror①⑦">(18)</a> <a href="#ref-for-invalidstateerror①⑧">(19)</a> <a href="#ref-for-invalidstateerror①⑨">(20)</a> <a href="#ref-for-invalidstateerror②⓪">(21)</a> <a href="#ref-for-invalidstateerror②①">(22)</a>
     <li><a href="#ref-for-invalidstateerror②②">7.5. XRMediaBinding</a> <a href="#ref-for-invalidstateerror②③">(2)</a> <a href="#ref-for-invalidstateerror②④">(3)</a> <a href="#ref-for-invalidstateerror②⑤">(4)</a> <a href="#ref-for-invalidstateerror②⑥">(5)</a> <a href="#ref-for-invalidstateerror②⑦">(6)</a> <a href="#ref-for-invalidstateerror②⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">6.9. XRWebGLBinding</a> <a href="#ref-for-notsupportederror①">(2)</a> <a href="#ref-for-notsupportederror②">(3)</a> <a href="#ref-for-notsupportederror③">(4)</a> <a href="#ref-for-notsupportederror④">(5)</a> <a href="#ref-for-notsupportederror⑤">(6)</a> <a href="#ref-for-notsupportederror⑥">(7)</a> <a href="#ref-for-notsupportederror⑦">(8)</a> <a href="#ref-for-notsupportederror⑧">(9)</a> <a href="#ref-for-notsupportederror⑨">(10)</a> <a href="#ref-for-notsupportederror①⓪">(11)</a> <a href="#ref-for-notsupportederror①①">(12)</a> <a href="#ref-for-notsupportederror①②">(13)</a> <a href="#ref-for-notsupportederror①③">(14)</a>
     <li><a href="#ref-for-notsupportederror①④">7.5. XRMediaBinding</a> <a href="#ref-for-notsupportederror①⑤">(2)</a> <a href="#ref-for-notsupportederror①⑥">(3)</a>
     <li><a href="#ref-for-notsupportederror①⑦">9.2. updateRenderState changes</a> <a href="#ref-for-notsupportederror①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-operationerror">
-   <a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-operationerror" class="dfn-panel" data-for="term-for-operationerror" id="infopanel-for-term-for-operationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-operationerror" style="display:none">Info about the 'OperationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operationerror">6.9. XRWebGLBinding</a> <a href="#ref-for-operationerror①">(2)</a> <a href="#ref-for-operationerror②">(3)</a> <a href="#ref-for-operationerror③">(4)</a> <a href="#ref-for-operationerror④">(5)</a>
     <li><a href="#ref-for-operationerror⑤">7.5. XRMediaBinding</a> <a href="#ref-for-operationerror⑥">(2)</a> <a href="#ref-for-operationerror⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.1. XRSubImage</a>
     <li><a href="#ref-for-SameObject①">5.2. XRWebGLSubImage</a> <a href="#ref-for-SameObject②">(2)</a>
     <li><a href="#ref-for-SameObject③">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">8.1. XRLayerEvent</a>
     <li><a href="#ref-for-SecureContext①">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">3.3. XRCompositionLayer</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">3.7. XREquirectLayer</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a>
@@ -3394,8 +3394,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-exceptiondef-typeerror②④">9.2. updateRenderState changes</a> <a href="#ref-for-exceptiondef-typeerror②⑤">(2)</a> <a href="#ref-for-exceptiondef-typeerror②⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.3. XRCompositionLayer</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
     <li><a href="#ref-for-idl-boolean③">3.4. XRProjectionLayer</a>
@@ -3403,15 +3403,15 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-idl-boolean⑤">7.1. XRMediaLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-idl-double①">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">3.4. XRProjectionLayer</a>
     <li><a href="#ref-for-idl-float①">3.5. XRQuadLayer</a> <a href="#ref-for-idl-float②">(2)</a>
@@ -3425,8 +3425,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-idl-float②④">7.4. XRMediaEquirectLayerInit</a> <a href="#ref-for-idl-float②⑤">(2)</a> <a href="#ref-for-idl-float②⑥">(3)</a> <a href="#ref-for-idl-float②⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">3.5. XRQuadLayer</a> <a href="#ref-for-new①">(2)</a>
     <li><a href="#ref-for-new②">3.6. XRCylinderLayer</a> <a href="#ref-for-new③">(2)</a>
@@ -3436,22 +3436,22 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-new⑤⑦">9.1. XRRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.3. XRCompositionLayer</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a>
     <li><a href="#ref-for-this⑧">6.9. XRWebGLBinding</a> <a href="#ref-for-this⑨">(2)</a> <a href="#ref-for-this①⓪">(3)</a> <a href="#ref-for-this①①">(4)</a> <a href="#ref-for-this①②">(5)</a> <a href="#ref-for-this①③">(6)</a> <a href="#ref-for-this①④">(7)</a> <a href="#ref-for-this①⑤">(8)</a> <a href="#ref-for-this①⑥">(9)</a> <a href="#ref-for-this①⑦">(10)</a> <a href="#ref-for-this①⑧">(11)</a> <a href="#ref-for-this①⑨">(12)</a> <a href="#ref-for-this②⓪">(13)</a> <a href="#ref-for-this②①">(14)</a> <a href="#ref-for-this②②">(15)</a> <a href="#ref-for-this②③">(16)</a> <a href="#ref-for-this②④">(17)</a> <a href="#ref-for-this②⑤">(18)</a> <a href="#ref-for-this②⑥">(19)</a> <a href="#ref-for-this②⑦">(20)</a> <a href="#ref-for-this②⑧">(21)</a> <a href="#ref-for-this②⑨">(22)</a>
     <li><a href="#ref-for-this③⓪">7.5. XRMediaBinding</a> <a href="#ref-for-this③①">(2)</a> <a href="#ref-for-this③②">(3)</a> <a href="#ref-for-this③③">(4)</a> <a href="#ref-for-this③④">(5)</a> <a href="#ref-for-this③⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3.3. XRCompositionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-idl-unsigned-long①">3.4. XRProjectionLayer</a> <a href="#ref-for-idl-unsigned-long②">(2)</a> <a href="#ref-for-idl-unsigned-long③">(3)</a>
@@ -3459,63 +3459,63 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-idl-unsigned-long⑦">6.4. XRLayerInit</a> <a href="#ref-for-idl-unsigned-long⑧">(2)</a> <a href="#ref-for-idl-unsigned-long⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-bounded-floor">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-bounded-floor">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-bounded-floor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-bounded-floor" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-bounded-floor" id="infopanel-for-term-for-dom-xrreferencespacetype-bounded-floor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-bounded-floor" style="display:none">Info about the '"bounded-floor"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-bounded-floor">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-bounded-floor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-bounded-floor">4. Spaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr" id="infopanel-for-term-for-dom-xrsessionmode-immersive-vr" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" style="display:none">Info about the '"immersive-vr"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr">2. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-inline">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline">https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-inline" class="dfn-panel" data-for="term-for-dom-xrsessionmode-inline" id="infopanel-for-term-for-dom-xrsessionmode-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-inline" style="display:none">Info about the '"inline"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline">https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-inline">2. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xreye-left">
-   <a href="https://immersive-web.github.io/webxr/#dom-xreye-left">https://immersive-web.github.io/webxr/#dom-xreye-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xreye-left" class="dfn-panel" data-for="term-for-dom-xreye-left" id="infopanel-for-term-for-dom-xreye-left" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xreye-left" style="display:none">Info about the '"left"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xreye-left">https://immersive-web.github.io/webxr/#dom-xreye-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xreye-left">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-local" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local" id="infopanel-for-term-for-dom-xrreferencespacetype-local" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-local" style="display:none">Info about the '"local"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-local">4. Spaces</a> <a href="#ref-for-dom-xrreferencespacetype-local①">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local-floor">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-local-floor" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local-floor" id="infopanel-for-term-for-dom-xrreferencespacetype-local-floor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-local-floor" style="display:none">Info about the '"local-floor"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-local-floor">4. Spaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xreye-none">
-   <a href="https://immersive-web.github.io/webxr/#dom-xreye-none">https://immersive-web.github.io/webxr/#dom-xreye-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xreye-none" class="dfn-panel" data-for="term-for-dom-xreye-none" id="infopanel-for-term-for-dom-xreye-none" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xreye-none" style="display:none">Info about the '"none"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xreye-none">https://immersive-web.github.io/webxr/#dom-xreye-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xreye-none">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xreye-none①">(2)</a>
     <li><a href="#ref-for-dom-xreye-none②">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xreye-right">
-   <a href="https://immersive-web.github.io/webxr/#dom-xreye-right">https://immersive-web.github.io/webxr/#dom-xreye-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xreye-right" class="dfn-panel" data-for="term-for-dom-xreye-right" id="infopanel-for-term-for-dom-xreye-right" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xreye-right" style="display:none">Info about the '"right"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xreye-right">https://immersive-web.github.io/webxr/#dom-xreye-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xreye-right">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-unbounded">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-unbounded">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-unbounded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-unbounded" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-unbounded" id="infopanel-for-term-for-dom-xrreferencespacetype-unbounded" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-unbounded" style="display:none">Info about the '"unbounded"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-unbounded">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-unbounded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-unbounded">4. Spaces</a> <a href="#ref-for-dom-xrreferencespacetype-unbounded①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-viewer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-viewer" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-viewer" id="infopanel-for-term-for-dom-xrreferencespacetype-viewer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-viewer" style="display:none">Info about the '"viewer"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer①">3.8. XRCubeLayer</a>
@@ -3524,23 +3524,23 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer⑦">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xreye">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xreye">https://immersive-web.github.io/webxr/#enumdef-xreye</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xreye" class="dfn-panel" data-for="term-for-enumdef-xreye" id="infopanel-for-term-for-enumdef-xreye" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xreye" style="display:none">Info about the 'XREye' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xreye">https://immersive-web.github.io/webxr/#enumdef-xreye</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xreye">6.9. XRWebGLBinding</a>
     <li><a href="#ref-for-enumdef-xreye①">9.3. XRCompositor changes</a> <a href="#ref-for-enumdef-xreye②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">3.3. XRCompositionLayer</a> <a href="#ref-for-xrframe①">(2)</a> <a href="#ref-for-xrframe②">(3)</a> <a href="#ref-for-xrframe③">(4)</a>
     <li><a href="#ref-for-xrframe④">3.4. XRProjectionLayer</a>
     <li><a href="#ref-for-xrframe⑤">6.9. XRWebGLBinding</a> <a href="#ref-for-xrframe⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrlayer">
-   <a href="https://immersive-web.github.io/webxr/#xrlayer">https://immersive-web.github.io/webxr/#xrlayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrlayer" class="dfn-panel" data-for="term-for-xrlayer" id="infopanel-for-term-for-xrlayer" role="menu">
+   <span id="infopaneltitle-for-term-for-xrlayer" style="display:none">Info about the 'XRLayer' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrlayer">https://immersive-web.github.io/webxr/#xrlayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlayer">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-xrlayer①">6.9. XRWebGLBinding</a> <a href="#ref-for-xrlayer②">(2)</a> <a href="#ref-for-xrlayer③">(3)</a> <a href="#ref-for-xrlayer④">(4)</a>
@@ -3550,8 +3550,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrlayer①③">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrreferencespace">
-   <a href="https://immersive-web.github.io/webxr/#xrreferencespace">https://immersive-web.github.io/webxr/#xrreferencespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrreferencespace" class="dfn-panel" data-for="term-for-xrreferencespace" id="infopanel-for-term-for-xrreferencespace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrreferencespace" style="display:none">Info about the 'XRReferenceSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrreferencespace">https://immersive-web.github.io/webxr/#xrreferencespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrreferencespace">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-xrreferencespace①">3.8. XRCubeLayer</a>
@@ -3560,22 +3560,22 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrreferencespace⑤">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrenderstate">
-   <a href="https://immersive-web.github.io/webxr/#xrrenderstate">https://immersive-web.github.io/webxr/#xrrenderstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrenderstate" class="dfn-panel" data-for="term-for-xrrenderstate" id="infopanel-for-term-for-xrrenderstate" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrenderstate" style="display:none">Info about the 'XRRenderState' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrenderstate">https://immersive-web.github.io/webxr/#xrrenderstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrenderstate">9.1. XRRenderState changes</a> <a href="#ref-for-xrrenderstate①">(2)</a> <a href="#ref-for-xrrenderstate②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-xrrenderstateinit">
-   <a href="https://immersive-web.github.io/webxr/#dictdef-xrrenderstateinit">https://immersive-web.github.io/webxr/#dictdef-xrrenderstateinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-xrrenderstateinit" class="dfn-panel" data-for="term-for-dictdef-xrrenderstateinit" id="infopanel-for-term-for-dictdef-xrrenderstateinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-xrrenderstateinit" style="display:none">Info about the 'XRRenderStateInit' external reference.</span><a href="https://immersive-web.github.io/webxr/#dictdef-xrrenderstateinit">https://immersive-web.github.io/webxr/#dictdef-xrrenderstateinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrrenderstateinit">1.2. Application flow</a>
     <li><a href="#ref-for-dictdef-xrrenderstateinit①">9.1. XRRenderState changes</a>
     <li><a href="#ref-for-dictdef-xrrenderstateinit②">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform" class="dfn-panel" data-for="term-for-xrrigidtransform" id="infopanel-for-term-for-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">3.5. XRQuadLayer</a> <a href="#ref-for-xrrigidtransform①">(2)</a> <a href="#ref-for-xrrigidtransform②">(3)</a>
     <li><a href="#ref-for-xrrigidtransform③">3.6. XRCylinderLayer</a> <a href="#ref-for-xrrigidtransform④">(2)</a> <a href="#ref-for-xrrigidtransform⑤">(3)</a>
@@ -3588,8 +3588,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrrigidtransform①④">7.4. XRMediaEquirectLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">3.3. XRCompositionLayer</a> <a href="#ref-for-xrsession①">(2)</a>
     <li><a href="#ref-for-xrsession②">6.1. Overview</a> <a href="#ref-for-xrsession③">(2)</a> <a href="#ref-for-xrsession④">(3)</a>
@@ -3599,8 +3599,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrsession①①">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-xrspace①">3.5. XRQuadLayer</a>
@@ -3612,241 +3612,241 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrspace①②">7.1. XRMediaLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrview">
-   <a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrview" class="dfn-panel" data-for="term-for-xrview" id="infopanel-for-term-for-xrview" role="menu">
+   <span id="infopaneltitle-for-term-for-xrview" style="display:none">Info about the 'XRView' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrviewport">
-   <a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrviewport" class="dfn-panel" data-for="term-for-xrviewport" id="infopanel-for-term-for-xrviewport" role="menu">
+   <span id="infopaneltitle-for-term-for-xrviewport" style="display:none">Info about the 'XRViewport' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrviewport">5.1. XRSubImage</a> <a href="#ref-for-xrviewport①">(2)</a>
     <li><a href="#ref-for-xrviewport②">6.9. XRWebGLBinding</a> <a href="#ref-for-xrviewport③">(2)</a> <a href="#ref-for-xrviewport④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebgllayer">
-   <a href="https://immersive-web.github.io/webxr/#xrwebgllayer">https://immersive-web.github.io/webxr/#xrwebgllayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebgllayer" class="dfn-panel" data-for="term-for-xrwebgllayer" id="infopanel-for-term-for-xrwebgllayer" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebgllayer" style="display:none">Info about the 'XRWebGLLayer' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrwebgllayer">https://immersive-web.github.io/webxr/#xrwebgllayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer">4. Spaces</a>
     <li><a href="#ref-for-xrwebgllayer①">6.9. XRWebGLBinding</a> <a href="#ref-for-xrwebgllayer②">(2)</a>
     <li><a href="#ref-for-xrwebgllayer③">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedefdef-xrwebglrenderingcontext">
-   <a href="https://immersive-web.github.io/webxr/#typedefdef-xrwebglrenderingcontext">https://immersive-web.github.io/webxr/#typedefdef-xrwebglrenderingcontext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedefdef-xrwebglrenderingcontext" class="dfn-panel" data-for="term-for-typedefdef-xrwebglrenderingcontext" id="infopanel-for-term-for-typedefdef-xrwebglrenderingcontext" role="menu">
+   <span id="infopaneltitle-for-term-for-typedefdef-xrwebglrenderingcontext" style="display:none">Info about the 'XRWebGLRenderingContext' external reference.</span><a href="https://immersive-web.github.io/webxr/#typedefdef-xrwebglrenderingcontext">https://immersive-web.github.io/webxr/#typedefdef-xrwebglrenderingcontext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-xrwebglrenderingcontext">6.9. XRWebGLBinding</a> <a href="#ref-for-typedefdef-xrwebglrenderingcontext①">(2)</a> <a href="#ref-for-typedefdef-xrwebglrenderingcontext②">(3)</a> <a href="#ref-for-typedefdef-xrwebglrenderingcontext③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://immersive-web.github.io/webxr/#xrframe-active">https://immersive-web.github.io/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active (for XRFrame)' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe-active">https://immersive-web.github.io/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-view-active">
-   <a href="https://immersive-web.github.io/webxr/#view-active">https://immersive-web.github.io/webxr/#view-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-view-active" class="dfn-panel" data-for="term-for-view-active" id="infopanel-for-term-for-view-active" role="menu">
+   <span id="infopaneltitle-for-term-for-view-active" style="display:none">Info about the 'active (for view)' external reference.</span><a href="https://immersive-web.github.io/webxr/#view-active">https://immersive-web.github.io/webxr/#view-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-active">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-immersive-session">
-   <a href="https://immersive-web.github.io/webxr/#active-immersive-session">https://immersive-web.github.io/webxr/#active-immersive-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-immersive-session" class="dfn-panel" data-for="term-for-active-immersive-session" id="infopanel-for-term-for-active-immersive-session" role="menu">
+   <span id="infopaneltitle-for-term-for-active-immersive-session" style="display:none">Info about the 'active immersive session' external reference.</span><a href="https://immersive-web.github.io/webxr/#active-immersive-session">https://immersive-web.github.io/webxr/#active-immersive-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-immersive-session">2. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-render-state">
-   <a href="https://immersive-web.github.io/webxr/#active-render-state">https://immersive-web.github.io/webxr/#active-render-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-render-state" class="dfn-panel" data-for="term-for-active-render-state" id="infopanel-for-term-for-active-render-state" role="menu">
+   <span id="infopaneltitle-for-term-for-active-render-state" style="display:none">Info about the 'active render state' external reference.</span><a href="https://immersive-web.github.io/webxr/#active-render-state">https://immersive-web.github.io/webxr/#active-render-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-render-state">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationframe">
-   <a href="https://www.w3.org/TR/webxr/#animationframe">https://www.w3.org/TR/webxr/#animationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationframe" class="dfn-panel" data-for="term-for-animationframe" id="infopanel-for-term-for-animationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-animationframe" style="display:none">Info about the 'animationframe' external reference.</span><a href="https://www.w3.org/TR/webxr/#animationframe">https://www.w3.org/TR/webxr/#animationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationframe">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstate-baselayer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstate-baselayer" class="dfn-panel" data-for="term-for-dom-xrrenderstate-baselayer" id="infopanel-for-term-for-dom-xrrenderstate-baselayer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstate-baselayer" style="display:none">Info about the 'baseLayer (for XRRenderState)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-baselayer">9.2. updateRenderState changes</a>
     <li><a href="#ref-for-dom-xrrenderstate-baselayer①">9.5. Animation frames changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstateinit-baselayer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-baselayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstateinit-baselayer" class="dfn-panel" data-for="term-for-dom-xrrenderstateinit-baselayer" id="infopanel-for-term-for-dom-xrrenderstateinit-baselayer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstateinit-baselayer" style="display:none">Info about the 'baseLayer (for XRRenderStateInit)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-baselayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-baselayer">9.2. updateRenderState changes</a> <a href="#ref-for-dom-xrrenderstateinit-baselayer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ended">
-   <a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ended" class="dfn-panel" data-for="term-for-ended" id="infopanel-for-term-for-ended" role="menu">
+   <span id="infopaneltitle-for-term-for-ended" style="display:none">Info about the 'ended' external reference.</span><a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ended">6.9. XRWebGLBinding</a> <a href="#ref-for-ended①">(2)</a> <a href="#ref-for-ended②">(3)</a> <a href="#ref-for-ended③">(4)</a> <a href="#ref-for-ended④">(5)</a> <a href="#ref-for-ended⑤">(6)</a>
     <li><a href="#ref-for-ended⑥">7.5. XRMediaBinding</a> <a href="#ref-for-ended⑦">(2)</a> <a href="#ref-for-ended⑧">(3)</a> <a href="#ref-for-ended⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-descriptor">
-   <a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-descriptor" class="dfn-panel" data-for="term-for-feature-descriptor" id="infopanel-for-term-for-feature-descriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' external reference.</span><a href="https://www.w3.org/TR/webxr/#feature-descriptor">https://www.w3.org/TR/webxr/#feature-descriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2. Initialization</a> <a href="#ref-for-feature-descriptor①">(2)</a> <a href="#ref-for-feature-descriptor②">(3)</a> <a href="#ref-for-feature-descriptor③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-requirements">
-   <a href="https://immersive-web.github.io/webxr/#feature-requirements">https://immersive-web.github.io/webxr/#feature-requirements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-requirements" class="dfn-panel" data-for="term-for-feature-requirements" id="infopanel-for-term-for-feature-requirements" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-requirements" style="display:none">Info about the 'feature requirements' external reference.</span><a href="https://immersive-web.github.io/webxr/#feature-requirements">https://immersive-web.github.io/webxr/#feature-requirements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-requirements">2. Initialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrviewport-height">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrviewport-height">https://immersive-web.github.io/webxr/#dom-xrviewport-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrviewport-height" class="dfn-panel" data-for="term-for-dom-xrviewport-height" id="infopanel-for-term-for-dom-xrviewport-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrviewport-height" style="display:none">Info about the 'height' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrviewport-height">https://immersive-web.github.io/webxr/#dom-xrviewport-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-height">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrviewport-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-immersive-session">
-   <a href="https://www.w3.org/TR/webxr/#immersive-session">https://www.w3.org/TR/webxr/#immersive-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-immersive-session" class="dfn-panel" data-for="term-for-immersive-session" id="infopanel-for-term-for-immersive-session" role="menu">
+   <span id="infopaneltitle-for-term-for-immersive-session" style="display:none">Info about the 'immersive session' external reference.</span><a href="https://www.w3.org/TR/webxr/#immersive-session">https://www.w3.org/TR/webxr/#immersive-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immersive-session">6.9. XRWebGLBinding</a>
     <li><a href="#ref-for-immersive-session①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-immersive-xr-device">
-   <a href="https://immersive-web.github.io/webxr/#immersive-xr-device">https://immersive-web.github.io/webxr/#immersive-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-immersive-xr-device" class="dfn-panel" data-for="term-for-immersive-xr-device" id="infopanel-for-term-for-immersive-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-immersive-xr-device" style="display:none">Info about the 'immersive xr device' external reference.</span><a href="https://immersive-web.github.io/webxr/#immersive-xr-device">https://immersive-web.github.io/webxr/#immersive-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immersive-xr-device">6.9. XRWebGLBinding</a> <a href="#ref-for-immersive-xr-device①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstateinit-layers">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-layers">https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-layers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstateinit-layers" class="dfn-panel" data-for="term-for-dom-xrrenderstateinit-layers" id="infopanel-for-term-for-dom-xrrenderstateinit-layers" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstateinit-layers" style="display:none">Info about the 'layers' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-layers">https://immersive-web.github.io/webxr/#dom-xrrenderstateinit-layers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-layers">9.1. XRRenderState changes</a> <a href="#ref-for-dom-xrrenderstateinit-layers①">(2)</a>
     <li><a href="#ref-for-dom-xrrenderstateinit-layers②">9.2. updateRenderState changes</a> <a href="#ref-for-dom-xrrenderstateinit-layers③">(2)</a> <a href="#ref-for-dom-xrrenderstateinit-layers④">(3)</a> <a href="#ref-for-dom-xrrenderstateinit-layers⑤">(4)</a> <a href="#ref-for-dom-xrrenderstateinit-layers⑥">(5)</a> <a href="#ref-for-dom-xrrenderstateinit-layers⑦">(6)</a>
     <li><a href="#ref-for-dom-xrrenderstateinit-layers⑧">9.5. Animation frames changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-views">
-   <a href="https://immersive-web.github.io/webxr/#xrsession-list-of-views">https://immersive-web.github.io/webxr/#xrsession-list-of-views</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-views" class="dfn-panel" data-for="term-for-xrsession-list-of-views" id="infopanel-for-term-for-xrsession-list-of-views" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-views" style="display:none">Info about the 'list of views' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession-list-of-views">https://immersive-web.github.io/webxr/#xrsession-list-of-views</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-views">3.2. XRLayerLayout</a>
     <li><a href="#ref-for-xrsession-list-of-views①">6.9. XRWebGLBinding</a> <a href="#ref-for-xrsession-list-of-views②">(2)</a> <a href="#ref-for-xrsession-list-of-views③">(3)</a> <a href="#ref-for-xrsession-list-of-views④">(4)</a> <a href="#ref-for-xrsession-list-of-views⑤">(5)</a> <a href="#ref-for-xrsession-list-of-views⑥">(6)</a> <a href="#ref-for-xrsession-list-of-views⑦">(7)</a> <a href="#ref-for-xrsession-list-of-views⑧">(8)</a> <a href="#ref-for-xrsession-list-of-views⑨">(9)</a> <a href="#ref-for-xrsession-list-of-views①⓪">(10)</a> <a href="#ref-for-xrsession-list-of-views①①">(11)</a> <a href="#ref-for-xrsession-list-of-views①②">(12)</a> <a href="#ref-for-xrsession-list-of-views①③">(13)</a> <a href="#ref-for-xrsession-list-of-views①④">(14)</a> <a href="#ref-for-xrsession-list-of-views①⑤">(15)</a> <a href="#ref-for-xrsession-list-of-views①⑥">(16)</a> <a href="#ref-for-xrsession-list-of-views①⑦">(17)</a> <a href="#ref-for-xrsession-list-of-views①⑧">(18)</a> <a href="#ref-for-xrsession-list-of-views①⑨">(19)</a> <a href="#ref-for-xrsession-list-of-views②⓪">(20)</a> <a href="#ref-for-xrsession-list-of-views②①">(21)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-native-webgl-framebuffer-resolution">
-   <a href="https://www.w3.org/TR/webxr/#native-webgl-framebuffer-resolution">https://www.w3.org/TR/webxr/#native-webgl-framebuffer-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-native-webgl-framebuffer-resolution" class="dfn-panel" data-for="term-for-native-webgl-framebuffer-resolution" id="infopanel-for-term-for-native-webgl-framebuffer-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-native-webgl-framebuffer-resolution" style="display:none">Info about the 'native webgl framebuffer resolution' external reference.</span><a href="https://www.w3.org/TR/webxr/#native-webgl-framebuffer-resolution">https://www.w3.org/TR/webxr/#native-webgl-framebuffer-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-webgl-framebuffer-resolution">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opaque-framebuffer">
-   <a href="https://immersive-web.github.io/webxr/#opaque-framebuffer">https://immersive-web.github.io/webxr/#opaque-framebuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opaque-framebuffer" class="dfn-panel" data-for="term-for-opaque-framebuffer" id="infopanel-for-term-for-opaque-framebuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-opaque-framebuffer" style="display:none">Info about the 'opaque framebuffer' external reference.</span><a href="https://immersive-web.github.io/webxr/#opaque-framebuffer">https://immersive-web.github.io/webxr/#opaque-framebuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-framebuffer">6.9. XRWebGLBinding</a> <a href="#ref-for-opaque-framebuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrpermissiondescriptor-optionalfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-optionalfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrpermissiondescriptor-optionalfeatures" class="dfn-panel" data-for="term-for-dom-xrpermissiondescriptor-optionalfeatures" id="infopanel-for-term-for-dom-xrpermissiondescriptor-optionalfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrpermissiondescriptor-optionalfeatures" style="display:none">Info about the 'optionalFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-optionalfeatures">https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-optionalfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissiondescriptor-optionalfeatures">1.2. Application flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-orientation">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-orientation" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-orientation" id="infopanel-for-term-for-dom-xrrigidtransform-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-orientation" style="display:none">Info about the 'orientation' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation①">3.6. XRCylinderLayer</a>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation②">3.7. XREquirectLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pending-render-state">
-   <a href="https://immersive-web.github.io/webxr/#pending-render-state">https://immersive-web.github.io/webxr/#pending-render-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pending-render-state" class="dfn-panel" data-for="term-for-pending-render-state" id="infopanel-for-term-for-pending-render-state" role="menu">
+   <span id="infopaneltitle-for-term-for-pending-render-state" style="display:none">Info about the 'pending render state' external reference.</span><a href="https://immersive-web.github.io/webxr/#pending-render-state">https://immersive-web.github.io/webxr/#pending-render-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-render-state">9.2. updateRenderState changes</a> <a href="#ref-for-pending-render-state①">(2)</a> <a href="#ref-for-pending-render-state②">(3)</a> <a href="#ref-for-pending-render-state③">(4)</a> <a href="#ref-for-pending-render-state④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-position">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-position" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-position" id="infopanel-for-term-for-dom-xrrigidtransform-position" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-position" style="display:none">Info about the 'position' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-position">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dom-xrrigidtransform-position①">3.6. XRCylinderLayer</a>
     <li><a href="#ref-for-dom-xrrigidtransform-position②">3.7. XREquirectLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-primary-view">
-   <a href="https://immersive-web.github.io/webxr/#primary-view">https://immersive-web.github.io/webxr/#primary-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-primary-view" class="dfn-panel" data-for="term-for-primary-view" id="infopanel-for-term-for-primary-view" role="menu">
+   <span id="infopaneltitle-for-term-for-primary-view" style="display:none">Info about the 'primary view' external reference.</span><a href="https://immersive-web.github.io/webxr/#primary-view">https://immersive-web.github.io/webxr/#primary-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-view">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-recommended-webgl-framebuffer-resolution">
-   <a href="https://www.w3.org/TR/webxr/#recommended-webgl-framebuffer-resolution">https://www.w3.org/TR/webxr/#recommended-webgl-framebuffer-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-recommended-webgl-framebuffer-resolution" class="dfn-panel" data-for="term-for-recommended-webgl-framebuffer-resolution" id="infopanel-for-term-for-recommended-webgl-framebuffer-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-recommended-webgl-framebuffer-resolution" style="display:none">Info about the 'recommended webgl framebuffer resolution' external reference.</span><a href="https://www.w3.org/TR/webxr/#recommended-webgl-framebuffer-resolution">https://www.w3.org/TR/webxr/#recommended-webgl-framebuffer-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-recommended-webgl-framebuffer-resolution">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-recommended-webgl-framebuffer-resolution①">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-renderstate">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-renderstate">https://immersive-web.github.io/webxr/#dom-xrsession-renderstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-renderstate" class="dfn-panel" data-for="term-for-dom-xrsession-renderstate" id="infopanel-for-term-for-dom-xrsession-renderstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-renderstate" style="display:none">Info about the 'renderState' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-renderstate">https://immersive-web.github.io/webxr/#dom-xrsession-renderstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-renderstate">7.5. XRMediaBinding</a>
     <li><a href="#ref-for-dom-xrsession-renderstate①">9.5. Animation frames changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe" id="infopanel-for-term-for-dom-xrsession-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe">1.2. Application flow</a>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe①">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrsession-requestanimationframe②">(2)</a>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe③">6.2. Opaque textures</a> <a href="#ref-for-dom-xrsession-requestanimationframe④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsystem-requestsession" class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession" id="infopanel-for-term-for-dom-xrsystem-requestsession" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsystem-requestsession" style="display:none">Info about the 'requestSession(mode)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-requestsession">1.2. Application flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrpermissiondescriptor-requiredfeatures">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-requiredfeatures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrpermissiondescriptor-requiredfeatures" class="dfn-panel" data-for="term-for-dom-xrpermissiondescriptor-requiredfeatures" id="infopanel-for-term-for-dom-xrpermissiondescriptor-requiredfeatures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrpermissiondescriptor-requiredfeatures" style="display:none">Info about the 'requiredFeatures' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-requiredfeatures">https://immersive-web.github.io/webxr/#dom-xrpermissiondescriptor-requiredfeatures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissiondescriptor-requiredfeatures">1.2. Application flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secondary-view">
-   <a href="https://immersive-web.github.io/webxr/#secondary-view">https://immersive-web.github.io/webxr/#secondary-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secondary-view" class="dfn-panel" data-for="term-for-secondary-view" id="infopanel-for-term-for-secondary-view" role="menu">
+   <span id="infopaneltitle-for-term-for-secondary-view" style="display:none">Info about the 'secondary view' external reference.</span><a href="https://immersive-web.github.io/webxr/#secondary-view">https://immersive-web.github.io/webxr/#secondary-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secondary-view">6.9. XRWebGLBinding</a> <a href="#ref-for-secondary-view①">(2)</a> <a href="#ref-for-secondary-view②">(3)</a> <a href="#ref-for-secondary-view③">(4)</a> <a href="#ref-for-secondary-view④">(5)</a> <a href="#ref-for-secondary-view⑤">(6)</a> <a href="#ref-for-secondary-view⑥">(7)</a> <a href="#ref-for-secondary-view⑦">(8)</a> <a href="#ref-for-secondary-view⑧">(9)</a> <a href="#ref-for-secondary-view⑨">(10)</a> <a href="#ref-for-secondary-view①⓪">(11)</a> <a href="#ref-for-secondary-view①①">(12)</a> <a href="#ref-for-secondary-view①②">(13)</a> <a href="#ref-for-secondary-view①③">(14)</a> <a href="#ref-for-secondary-view①④">(15)</a> <a href="#ref-for-secondary-view①⑤">(16)</a> <a href="#ref-for-secondary-view①⑥">(17)</a> <a href="#ref-for-secondary-view①⑦">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secondary-view-secondary-views">
-   <a href="https://immersive-web.github.io/webxr/#secondary-view-secondary-views">https://immersive-web.github.io/webxr/#secondary-view-secondary-views</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secondary-view-secondary-views" class="dfn-panel" data-for="term-for-secondary-view-secondary-views" id="infopanel-for-term-for-secondary-view-secondary-views" role="menu">
+   <span id="infopaneltitle-for-term-for-secondary-view-secondary-views" style="display:none">Info about the 'secondary-views' external reference.</span><a href="https://immersive-web.github.io/webxr/#secondary-view-secondary-views">https://immersive-web.github.io/webxr/#secondary-view-secondary-views</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secondary-view-secondary-views">6.9. XRWebGLBinding</a> <a href="#ref-for-secondary-view-secondary-views①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session (for XRFrame)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-session">
-   <a href="https://immersive-web.github.io/webxr/#xrspace-session">https://immersive-web.github.io/webxr/#xrspace-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-session" class="dfn-panel" data-for="term-for-xrspace-session" id="infopanel-for-term-for-xrspace-session" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-session" style="display:none">Info about the 'session (for XRSpace)' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace-session">https://immersive-web.github.io/webxr/#xrspace-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-session">3.3. XRCompositionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebgllayer-session">
-   <a href="https://immersive-web.github.io/webxr/#xrwebgllayer-session">https://immersive-web.github.io/webxr/#xrwebgllayer-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebgllayer-session" class="dfn-panel" data-for="term-for-xrwebgllayer-session" id="infopanel-for-term-for-xrwebgllayer-session" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebgllayer-session" style="display:none">Info about the 'session (for XRWebGLLayer)' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrwebgllayer-session">https://immersive-web.github.io/webxr/#xrwebgllayer-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer-session">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrreferencespace-type">
-   <a href="https://immersive-web.github.io/webxr/#xrreferencespace-type">https://immersive-web.github.io/webxr/#xrreferencespace-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrreferencespace-type" class="dfn-panel" data-for="term-for-xrreferencespace-type" id="infopanel-for-term-for-xrreferencespace-type" role="menu">
+   <span id="infopaneltitle-for-term-for-xrreferencespace-type" style="display:none">Info about the 'type' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrreferencespace-type">https://immersive-web.github.io/webxr/#xrreferencespace-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrreferencespace-type">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-xrreferencespace-type①">3.8. XRCubeLayer</a>
@@ -3854,34 +3854,34 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrreferencespace-type④">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-updaterenderstate">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate">https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-updaterenderstate" class="dfn-panel" data-for="term-for-dom-xrsession-updaterenderstate" id="infopanel-for-term-for-dom-xrsession-updaterenderstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-updaterenderstate" style="display:none">Info about the 'updateRenderState()' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate">https://immersive-web.github.io/webxr/#dom-xrsession-updaterenderstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-updaterenderstate">1.2. Application flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-view">
-   <a href="https://immersive-web.github.io/webxr/#view">https://immersive-web.github.io/webxr/#view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-view" class="dfn-panel" data-for="term-for-view" id="infopanel-for-term-for-view" role="menu">
+   <span id="infopaneltitle-for-term-for-view" style="display:none">Info about the 'view' external reference.</span><a href="https://immersive-web.github.io/webxr/#view">https://immersive-web.github.io/webxr/#view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view">6.9. XRWebGLBinding</a> <a href="#ref-for-view①">(2)</a> <a href="#ref-for-view②">(3)</a> <a href="#ref-for-view③">(4)</a> <a href="#ref-for-view④">(5)</a> <a href="#ref-for-view⑤">(6)</a>
     <li><a href="#ref-for-view⑥">9.3. XRCompositor changes</a> <a href="#ref-for-view⑦">(2)</a>
     <li><a href="#ref-for-view⑧">9.4. XRView changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrviewport-width">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrviewport-width">https://immersive-web.github.io/webxr/#dom-xrviewport-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrviewport-width" class="dfn-panel" data-for="term-for-dom-xrviewport-width" id="infopanel-for-term-for-dom-xrviewport-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrviewport-width" style="display:none">Info about the 'width' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrviewport-width">https://immersive-web.github.io/webxr/#dom-xrviewport-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-width">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrviewport-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrviewport-x">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrviewport-x">https://immersive-web.github.io/webxr/#dom-xrviewport-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrviewport-x" class="dfn-panel" data-for="term-for-dom-xrviewport-x" id="infopanel-for-term-for-dom-xrviewport-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrviewport-x" style="display:none">Info about the 'x' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrviewport-x">https://immersive-web.github.io/webxr/#dom-xrviewport-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-x">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrviewport-x①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-animation-frame">
-   <a href="https://immersive-web.github.io/webxr/#xr-animation-frame">https://immersive-web.github.io/webxr/#xr-animation-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-animation-frame" class="dfn-panel" data-for="term-for-xr-animation-frame" id="infopanel-for-term-for-xr-animation-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-animation-frame" style="display:none">Info about the 'xr animation frame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xr-animation-frame">https://immersive-web.github.io/webxr/#xr-animation-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-animation-frame">3.3. XRCompositionLayer</a> <a href="#ref-for-xr-animation-frame①">(2)</a>
     <li><a href="#ref-for-xr-animation-frame②">6.2. Opaque textures</a>
@@ -3889,14 +3889,14 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xr-animation-frame⑥">8.2. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-compatible">
-   <a href="https://www.w3.org/TR/webxr/#xr-compatible">https://www.w3.org/TR/webxr/#xr-compatible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-compatible" class="dfn-panel" data-for="term-for-xr-compatible" id="infopanel-for-term-for-xr-compatible" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-compatible" style="display:none">Info about the 'xr compatible' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-compatible">https://www.w3.org/TR/webxr/#xr-compatible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-compatible">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-compositor">
-   <a href="https://www.w3.org/TR/webxr/#xr-compositor">https://www.w3.org/TR/webxr/#xr-compositor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-compositor" class="dfn-panel" data-for="term-for-xr-compositor" id="infopanel-for-term-for-xr-compositor" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-compositor" style="display:none">Info about the 'xr compositor' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-compositor">https://www.w3.org/TR/webxr/#xr-compositor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-compositor">3.1. Mono and stereo layers</a>
     <li><a href="#ref-for-xr-compositor①">3.3. XRCompositionLayer</a> <a href="#ref-for-xr-compositor②">(2)</a> <a href="#ref-for-xr-compositor③">(3)</a> <a href="#ref-for-xr-compositor④">(4)</a> <a href="#ref-for-xr-compositor⑤">(5)</a> <a href="#ref-for-xr-compositor⑥">(6)</a>
@@ -3915,20 +3915,20 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xr-compositor③③">9.3. XRCompositor changes</a> <a href="#ref-for-xr-compositor③④">(2)</a> <a href="#ref-for-xr-compositor③⑤">(3)</a> <a href="#ref-for-xr-compositor③⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-device">
-   <a href="https://immersive-web.github.io/webxr/#xr-device">https://immersive-web.github.io/webxr/#xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-device" class="dfn-panel" data-for="term-for-xr-device" id="infopanel-for-term-for-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://immersive-web.github.io/webxr/#xr-device">https://immersive-web.github.io/webxr/#xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrviewport-y">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrviewport-y">https://immersive-web.github.io/webxr/#dom-xrviewport-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrviewport-y" class="dfn-panel" data-for="term-for-dom-xrviewport-y" id="infopanel-for-term-for-dom-xrviewport-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrviewport-y" style="display:none">Info about the 'y' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrviewport-y">https://immersive-web.github.io/webxr/#dom-xrviewport-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-y">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrviewport-y①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar">
-   <a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar" id="infopanel-for-term-for-dom-xrsessionmode-immersive-ar" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the '"immersive-ar"' external reference.</span><a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">2. Initialization</a>
    </ul>
@@ -4359,8 +4359,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
    <div class="issue"> add a better algorithm to describe the drawing. <a class="issue-return" href="#issue-da8fb26d" title="Jump to section">↵</a></div>
    <div class="issue"> define how the <code class="idl"><a data-link-type="idl" href="#xrequirectlayer">XREquirectLayer</a></code>'s parameters affect the video display. <a class="issue-return" href="#issue-d024c1a8" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="feature-descriptor-layers">
-   <b><a href="#feature-descriptor-layers">#feature-descriptor-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-descriptor-layers" class="dfn-panel" data-for="feature-descriptor-layers" id="infopanel-for-feature-descriptor-layers" role="dialog">
+   <span id="infopaneltitle-for-feature-descriptor-layers" style="display:none">Info about the 'layers' definition.</span><b><a href="#feature-descriptor-layers">#feature-descriptor-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor-layers">2. Initialization</a> <a href="#ref-for-feature-descriptor-layers①">(2)</a>
     <li><a href="#ref-for-feature-descriptor-layers②">6.9. XRWebGLBinding</a> <a href="#ref-for-feature-descriptor-layers③">(2)</a> <a href="#ref-for-feature-descriptor-layers④">(3)</a> <a href="#ref-for-feature-descriptor-layers⑤">(4)</a>
@@ -4368,8 +4368,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-feature-descriptor-layers⑨">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrlayerlayout">
-   <b><a href="#enumdef-xrlayerlayout">#enumdef-xrlayerlayout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrlayerlayout" class="dfn-panel" data-for="enumdef-xrlayerlayout" id="infopanel-for-enumdef-xrlayerlayout" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrlayerlayout" style="display:none">Info about the 'XRLayerLayout' definition.</span><b><a href="#enumdef-xrlayerlayout">#enumdef-xrlayerlayout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrlayerlayout">3.2. XRLayerLayout</a> <a href="#ref-for-enumdef-xrlayerlayout①">(2)</a>
     <li><a href="#ref-for-enumdef-xrlayerlayout②">3.3. XRCompositionLayer</a>
@@ -4379,47 +4379,47 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-enumdef-xrlayerlayout⑧">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerlayout-default">
-   <b><a href="#dom-xrlayerlayout-default">#dom-xrlayerlayout-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerlayout-default" class="dfn-panel" data-for="dom-xrlayerlayout-default" id="infopanel-for-dom-xrlayerlayout-default" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerlayout-default" style="display:none">Info about the 'default' definition.</span><b><a href="#dom-xrlayerlayout-default">#dom-xrlayerlayout-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerlayout-default">3.2. XRLayerLayout</a> <a href="#ref-for-dom-xrlayerlayout-default①">(2)</a> <a href="#ref-for-dom-xrlayerlayout-default②">(3)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-default③">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerlayout-default④">(2)</a> <a href="#ref-for-dom-xrlayerlayout-default⑤">(3)</a> <a href="#ref-for-dom-xrlayerlayout-default⑥">(4)</a> <a href="#ref-for-dom-xrlayerlayout-default⑦">(5)</a> <a href="#ref-for-dom-xrlayerlayout-default⑧">(6)</a> <a href="#ref-for-dom-xrlayerlayout-default⑨">(7)</a> <a href="#ref-for-dom-xrlayerlayout-default①⓪">(8)</a> <a href="#ref-for-dom-xrlayerlayout-default①①">(9)</a> <a href="#ref-for-dom-xrlayerlayout-default①②">(10)</a> <a href="#ref-for-dom-xrlayerlayout-default①③">(11)</a> <a href="#ref-for-dom-xrlayerlayout-default①④">(12)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-default①⑤">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrlayerlayout-default①⑥">(2)</a> <a href="#ref-for-dom-xrlayerlayout-default①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerlayout-mono">
-   <b><a href="#dom-xrlayerlayout-mono">#dom-xrlayerlayout-mono</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerlayout-mono" class="dfn-panel" data-for="dom-xrlayerlayout-mono" id="infopanel-for-dom-xrlayerlayout-mono" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerlayout-mono" style="display:none">Info about the 'mono' definition.</span><b><a href="#dom-xrlayerlayout-mono">#dom-xrlayerlayout-mono</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerlayout-mono">3.2. XRLayerLayout</a>
     <li><a href="#ref-for-dom-xrlayerlayout-mono①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerlayout-mono②">(2)</a> <a href="#ref-for-dom-xrlayerlayout-mono③">(3)</a> <a href="#ref-for-dom-xrlayerlayout-mono④">(4)</a> <a href="#ref-for-dom-xrlayerlayout-mono⑤">(5)</a> <a href="#ref-for-dom-xrlayerlayout-mono⑥">(6)</a> <a href="#ref-for-dom-xrlayerlayout-mono⑦">(7)</a> <a href="#ref-for-dom-xrlayerlayout-mono⑧">(8)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-mono⑨">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerlayout-stereo">
-   <b><a href="#dom-xrlayerlayout-stereo">#dom-xrlayerlayout-stereo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerlayout-stereo" class="dfn-panel" data-for="dom-xrlayerlayout-stereo" id="infopanel-for-dom-xrlayerlayout-stereo" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerlayout-stereo" style="display:none">Info about the 'stereo' definition.</span><b><a href="#dom-xrlayerlayout-stereo">#dom-xrlayerlayout-stereo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo">3.2. XRLayerLayout</a> <a href="#ref-for-dom-xrlayerlayout-stereo①">(2)</a> <a href="#ref-for-dom-xrlayerlayout-stereo②">(3)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo③">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerlayout-stereo④">(2)</a> <a href="#ref-for-dom-xrlayerlayout-stereo⑤">(3)</a> <a href="#ref-for-dom-xrlayerlayout-stereo⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerlayout-stereo-left-right">
-   <b><a href="#dom-xrlayerlayout-stereo-left-right">#dom-xrlayerlayout-stereo-left-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerlayout-stereo-left-right" class="dfn-panel" data-for="dom-xrlayerlayout-stereo-left-right" id="infopanel-for-dom-xrlayerlayout-stereo-left-right" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerlayout-stereo-left-right" style="display:none">Info about the 'stereo-left-right' definition.</span><b><a href="#dom-xrlayerlayout-stereo-left-right">#dom-xrlayerlayout-stereo-left-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-left-right">3.2. XRLayerLayout</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right①">(2)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-left-right②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right③">(2)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right④">(3)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right⑤">(4)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right⑥">(5)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right⑦">(6)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right⑧">(7)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right⑨">(8)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right①⓪">(9)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right①①">(10)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-left-right①②">(11)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-left-right①③">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerlayout-stereo-top-bottom">
-   <b><a href="#dom-xrlayerlayout-stereo-top-bottom">#dom-xrlayerlayout-stereo-top-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerlayout-stereo-top-bottom" class="dfn-panel" data-for="dom-xrlayerlayout-stereo-top-bottom" id="infopanel-for-dom-xrlayerlayout-stereo-top-bottom" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerlayout-stereo-top-bottom" style="display:none">Info about the 'stereo-top-bottom' definition.</span><b><a href="#dom-xrlayerlayout-stereo-top-bottom">#dom-xrlayerlayout-stereo-top-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom">3.2. XRLayerLayout</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom①">(2)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom③">(2)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom④">(3)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom⑤">(4)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom⑥">(5)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom⑦">(6)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom⑧">(7)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom⑨">(8)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom①⓪">(9)</a> <a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom①①">(10)</a>
     <li><a href="#ref-for-dom-xrlayerlayout-stereo-top-bottom①②">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcompositionlayer">
-   <b><a href="#xrcompositionlayer">#xrcompositionlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcompositionlayer" class="dfn-panel" data-for="xrcompositionlayer" id="infopanel-for-xrcompositionlayer" role="dialog">
+   <span id="infopaneltitle-for-xrcompositionlayer" style="display:none">Info about the 'XRCompositionLayer' definition.</span><b><a href="#xrcompositionlayer">#xrcompositionlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcompositionlayer">3.2. XRLayerLayout</a>
     <li><a href="#ref-for-xrcompositionlayer①">3.3. XRCompositionLayer</a> <a href="#ref-for-xrcompositionlayer②">(2)</a> <a href="#ref-for-xrcompositionlayer③">(3)</a> <a href="#ref-for-xrcompositionlayer④">(4)</a> <a href="#ref-for-xrcompositionlayer⑤">(5)</a> <a href="#ref-for-xrcompositionlayer⑥">(6)</a> <a href="#ref-for-xrcompositionlayer⑦">(7)</a> <a href="#ref-for-xrcompositionlayer⑧">(8)</a>
@@ -4438,84 +4438,84 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrcompositionlayer②⑧">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-destroy">
-   <b><a href="#dom-xrcompositionlayer-destroy">#dom-xrcompositionlayer-destroy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-destroy" class="dfn-panel" data-for="dom-xrcompositionlayer-destroy" id="infopanel-for-dom-xrcompositionlayer-destroy" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-destroy" style="display:none">Info about the 'destroy' definition.</span><b><a href="#dom-xrcompositionlayer-destroy">#dom-xrcompositionlayer-destroy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-destroy">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrcompositionlayer-destroy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-layout">
-   <b><a href="#dom-xrcompositionlayer-layout">#dom-xrcompositionlayer-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-layout" class="dfn-panel" data-for="dom-xrcompositionlayer-layout" id="infopanel-for-dom-xrcompositionlayer-layout" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-layout" style="display:none">Info about the 'layout' definition.</span><b><a href="#dom-xrcompositionlayer-layout">#dom-xrcompositionlayer-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-layout">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-dom-xrcompositionlayer-layout①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrcompositionlayer-layout②">(2)</a> <a href="#ref-for-dom-xrcompositionlayer-layout③">(3)</a> <a href="#ref-for-dom-xrcompositionlayer-layout④">(4)</a> <a href="#ref-for-dom-xrcompositionlayer-layout⑤">(5)</a> <a href="#ref-for-dom-xrcompositionlayer-layout⑥">(6)</a> <a href="#ref-for-dom-xrcompositionlayer-layout⑦">(7)</a> <a href="#ref-for-dom-xrcompositionlayer-layout⑧">(8)</a> <a href="#ref-for-dom-xrcompositionlayer-layout⑨">(9)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⓪">(10)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①①">(11)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①②">(12)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①③">(13)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①④">(14)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⑤">(15)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⑥">(16)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⑦">(17)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⑧">(18)</a> <a href="#ref-for-dom-xrcompositionlayer-layout①⑨">(19)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②⓪">(20)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②①">(21)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②②">(22)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②③">(23)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②④">(24)</a> <a href="#ref-for-dom-xrcompositionlayer-layout②⑤">(25)</a>
     <li><a href="#ref-for-dom-xrcompositionlayer-layout②⑥">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-blendtexturesourcealpha">
-   <b><a href="#dom-xrcompositionlayer-blendtexturesourcealpha">#dom-xrcompositionlayer-blendtexturesourcealpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-blendtexturesourcealpha" class="dfn-panel" data-for="dom-xrcompositionlayer-blendtexturesourcealpha" id="infopanel-for-dom-xrcompositionlayer-blendtexturesourcealpha" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-blendtexturesourcealpha" style="display:none">Info about the 'blendTextureSourceAlpha' definition.</span><b><a href="#dom-xrcompositionlayer-blendtexturesourcealpha">#dom-xrcompositionlayer-blendtexturesourcealpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-blendtexturesourcealpha">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrcompositionlayer-blendtexturesourcealpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-chromaticaberrationcorrection">
-   <b><a href="#dom-xrcompositionlayer-chromaticaberrationcorrection">#dom-xrcompositionlayer-chromaticaberrationcorrection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-chromaticaberrationcorrection" class="dfn-panel" data-for="dom-xrcompositionlayer-chromaticaberrationcorrection" id="infopanel-for-dom-xrcompositionlayer-chromaticaberrationcorrection" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-chromaticaberrationcorrection" style="display:none">Info about the 'chromaticAberrationCorrection' definition.</span><b><a href="#dom-xrcompositionlayer-chromaticaberrationcorrection">#dom-xrcompositionlayer-chromaticaberrationcorrection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-chromaticaberrationcorrection">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrcompositionlayer-chromaticaberrationcorrection①">(2)</a> <a href="#ref-for-dom-xrcompositionlayer-chromaticaberrationcorrection②">(3)</a> <a href="#ref-for-dom-xrcompositionlayer-chromaticaberrationcorrection③">(4)</a> <a href="#ref-for-dom-xrcompositionlayer-chromaticaberrationcorrection④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-needsredraw">
-   <b><a href="#dom-xrcompositionlayer-needsredraw">#dom-xrcompositionlayer-needsredraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-needsredraw" class="dfn-panel" data-for="dom-xrcompositionlayer-needsredraw" id="infopanel-for-dom-xrcompositionlayer-needsredraw" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-needsredraw" style="display:none">Info about the 'needsRedraw' definition.</span><b><a href="#dom-xrcompositionlayer-needsredraw">#dom-xrcompositionlayer-needsredraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-needsredraw">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw①">(2)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw②">(3)</a>
     <li><a href="#ref-for-dom-xrcompositionlayer-needsredraw③">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw④">(2)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw⑤">(3)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw⑥">(4)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw⑦">(5)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw⑧">(6)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw⑨">(7)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw①⓪">(8)</a>
     <li><a href="#ref-for-dom-xrcompositionlayer-needsredraw①①">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw①②">(2)</a> <a href="#ref-for-dom-xrcompositionlayer-needsredraw①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcompositionlayer-miplevels">
-   <b><a href="#dom-xrcompositionlayer-miplevels">#dom-xrcompositionlayer-miplevels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcompositionlayer-miplevels" class="dfn-panel" data-for="dom-xrcompositionlayer-miplevels" id="infopanel-for-dom-xrcompositionlayer-miplevels" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcompositionlayer-miplevels" style="display:none">Info about the 'mipLevels' definition.</span><b><a href="#dom-xrcompositionlayer-miplevels">#dom-xrcompositionlayer-miplevels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcompositionlayer-miplevels">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrcompositionlayer-miplevels①">(2)</a>
     <li><a href="#ref-for-dom-xrcompositionlayer-miplevels②">6.4. XRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-underlying-resources-of-a-layer-are-lost">
-   <b><a href="#the-underlying-resources-of-a-layer-are-lost">#the-underlying-resources-of-a-layer-are-lost</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-underlying-resources-of-a-layer-are-lost" class="dfn-panel" data-for="the-underlying-resources-of-a-layer-are-lost" id="infopanel-for-the-underlying-resources-of-a-layer-are-lost" role="dialog">
+   <span id="infopaneltitle-for-the-underlying-resources-of-a-layer-are-lost" style="display:none">Info about the 'the underlying resources of a layer are lost' definition.</span><b><a href="#the-underlying-resources-of-a-layer-are-lost">#the-underlying-resources-of-a-layer-are-lost</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-underlying-resources-of-a-layer-are-lost">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-the-underlying-resources-of-a-layer-are-lost①">8.2. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intialize-a-composition-layer">
-   <b><a href="#intialize-a-composition-layer">#intialize-a-composition-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intialize-a-composition-layer" class="dfn-panel" data-for="intialize-a-composition-layer" id="infopanel-for-intialize-a-composition-layer" role="dialog">
+   <span id="infopaneltitle-for-intialize-a-composition-layer" style="display:none">Info about the 'intialize a composition layer' definition.</span><b><a href="#intialize-a-composition-layer">#intialize-a-composition-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intialize-a-composition-layer">6.9. XRWebGLBinding</a> <a href="#ref-for-intialize-a-composition-layer①">(2)</a> <a href="#ref-for-intialize-a-composition-layer②">(3)</a> <a href="#ref-for-intialize-a-composition-layer③">(4)</a> <a href="#ref-for-intialize-a-composition-layer④">(5)</a>
     <li><a href="#ref-for-intialize-a-composition-layer⑤">7.5. XRMediaBinding</a> <a href="#ref-for-intialize-a-composition-layer⑥">(2)</a> <a href="#ref-for-intialize-a-composition-layer⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcompositionlayer-context">
-   <b><a href="#xrcompositionlayer-context">#xrcompositionlayer-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcompositionlayer-context" class="dfn-panel" data-for="xrcompositionlayer-context" id="infopanel-for-xrcompositionlayer-context" role="dialog">
+   <span id="infopaneltitle-for-xrcompositionlayer-context" style="display:none">Info about the 'context' definition.</span><b><a href="#xrcompositionlayer-context">#xrcompositionlayer-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcompositionlayer-context">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-xrcompositionlayer-context①">6.9. XRWebGLBinding</a> <a href="#ref-for-xrcompositionlayer-context②">(2)</a> <a href="#ref-for-xrcompositionlayer-context③">(3)</a> <a href="#ref-for-xrcompositionlayer-context④">(4)</a> <a href="#ref-for-xrcompositionlayer-context⑤">(5)</a> <a href="#ref-for-xrcompositionlayer-context⑥">(6)</a> <a href="#ref-for-xrcompositionlayer-context⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcompositionlayer-media">
-   <b><a href="#xrcompositionlayer-media">#xrcompositionlayer-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcompositionlayer-media" class="dfn-panel" data-for="xrcompositionlayer-media" id="infopanel-for-xrcompositionlayer-media" role="dialog">
+   <span id="infopaneltitle-for-xrcompositionlayer-media" style="display:none">Info about the 'media' definition.</span><b><a href="#xrcompositionlayer-media">#xrcompositionlayer-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcompositionlayer-media">7.5. XRMediaBinding</a> <a href="#ref-for-xrcompositionlayer-media①">(2)</a> <a href="#ref-for-xrcompositionlayer-media②">(3)</a> <a href="#ref-for-xrcompositionlayer-media③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcompositionlayer-session">
-   <b><a href="#xrcompositionlayer-session">#xrcompositionlayer-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcompositionlayer-session" class="dfn-panel" data-for="xrcompositionlayer-session" id="infopanel-for-xrcompositionlayer-session" role="dialog">
+   <span id="infopaneltitle-for-xrcompositionlayer-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrcompositionlayer-session">#xrcompositionlayer-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcompositionlayer-session">3.3. XRCompositionLayer</a> <a href="#ref-for-xrcompositionlayer-session①">(2)</a>
     <li><a href="#ref-for-xrcompositionlayer-session②">6.9. XRWebGLBinding</a> <a href="#ref-for-xrcompositionlayer-session③">(2)</a> <a href="#ref-for-xrcompositionlayer-session④">(3)</a> <a href="#ref-for-xrcompositionlayer-session⑤">(4)</a> <a href="#ref-for-xrcompositionlayer-session⑥">(5)</a> <a href="#ref-for-xrcompositionlayer-session⑦">(6)</a>
     <li><a href="#ref-for-xrcompositionlayer-session⑧">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="setting-the-space-on-a-layer">
-   <b><a href="#setting-the-space-on-a-layer">#setting-the-space-on-a-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-setting-the-space-on-a-layer" class="dfn-panel" data-for="setting-the-space-on-a-layer" id="infopanel-for-setting-the-space-on-a-layer" role="dialog">
+   <span id="infopaneltitle-for-setting-the-space-on-a-layer" style="display:none">Info about the 'setting the space on a layer' definition.</span><b><a href="#setting-the-space-on-a-layer">#setting-the-space-on-a-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-setting-the-space-on-a-layer">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-setting-the-space-on-a-layer①">3.6. XRCylinderLayer</a>
@@ -4523,8 +4523,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-setting-the-space-on-a-layer③">3.8. XRCubeLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcompositionlayer-isstatic">
-   <b><a href="#xrcompositionlayer-isstatic">#xrcompositionlayer-isstatic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcompositionlayer-isstatic" class="dfn-panel" data-for="xrcompositionlayer-isstatic" id="infopanel-for-xrcompositionlayer-isstatic" role="dialog">
+   <span id="infopaneltitle-for-xrcompositionlayer-isstatic" style="display:none">Info about the 'isStatic' definition.</span><b><a href="#xrcompositionlayer-isstatic">#xrcompositionlayer-isstatic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcompositionlayer-isstatic">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-xrcompositionlayer-isstatic①">3.5. XRQuadLayer</a>
@@ -4533,8 +4533,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrcompositionlayer-isstatic④">6.9. XRWebGLBinding</a> <a href="#ref-for-xrcompositionlayer-isstatic⑤">(2)</a> <a href="#ref-for-xrcompositionlayer-isstatic⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrprojectionlayer">
-   <b><a href="#xrprojectionlayer">#xrprojectionlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrprojectionlayer" class="dfn-panel" data-for="xrprojectionlayer" id="infopanel-for-xrprojectionlayer" role="dialog">
+   <span id="infopaneltitle-for-xrprojectionlayer" style="display:none">Info about the 'XRProjectionLayer' definition.</span><b><a href="#xrprojectionlayer">#xrprojectionlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrprojectionlayer">1.2. Application flow</a>
     <li><a href="#ref-for-xrprojectionlayer①">2. Initialization</a> <a href="#ref-for-xrprojectionlayer②">(2)</a>
@@ -4547,40 +4547,40 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrprojectionlayer①⑨">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayer-texturewidth">
-   <b><a href="#dom-xrprojectionlayer-texturewidth">#dom-xrprojectionlayer-texturewidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayer-texturewidth" class="dfn-panel" data-for="dom-xrprojectionlayer-texturewidth" id="infopanel-for-dom-xrprojectionlayer-texturewidth" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayer-texturewidth" style="display:none">Info about the 'textureWidth' definition.</span><b><a href="#dom-xrprojectionlayer-texturewidth">#dom-xrprojectionlayer-texturewidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayer-texturewidth">3.4. XRProjectionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayer-textureheight">
-   <b><a href="#dom-xrprojectionlayer-textureheight">#dom-xrprojectionlayer-textureheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayer-textureheight" class="dfn-panel" data-for="dom-xrprojectionlayer-textureheight" id="infopanel-for-dom-xrprojectionlayer-textureheight" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayer-textureheight" style="display:none">Info about the 'textureHeight' definition.</span><b><a href="#dom-xrprojectionlayer-textureheight">#dom-xrprojectionlayer-textureheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayer-textureheight">3.4. XRProjectionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayer-texturearraylength">
-   <b><a href="#dom-xrprojectionlayer-texturearraylength">#dom-xrprojectionlayer-texturearraylength</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayer-texturearraylength" class="dfn-panel" data-for="dom-xrprojectionlayer-texturearraylength" id="infopanel-for-dom-xrprojectionlayer-texturearraylength" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayer-texturearraylength" style="display:none">Info about the 'textureArrayLength' definition.</span><b><a href="#dom-xrprojectionlayer-texturearraylength">#dom-xrprojectionlayer-texturearraylength</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayer-texturearraylength">3.4. XRProjectionLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayer-fixedfoveation">
-   <b><a href="#dom-xrprojectionlayer-fixedfoveation">#dom-xrprojectionlayer-fixedfoveation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayer-fixedfoveation" class="dfn-panel" data-for="dom-xrprojectionlayer-fixedfoveation" id="infopanel-for-dom-xrprojectionlayer-fixedfoveation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayer-fixedfoveation" style="display:none">Info about the 'fixedFoveation' definition.</span><b><a href="#dom-xrprojectionlayer-fixedfoveation">#dom-xrprojectionlayer-fixedfoveation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayer-fixedfoveation">3.4. XRProjectionLayer</a> <a href="#ref-for-dom-xrprojectionlayer-fixedfoveation①">(2)</a> <a href="#ref-for-dom-xrprojectionlayer-fixedfoveation②">(3)</a>
     <li><a href="#ref-for-dom-xrprojectionlayer-fixedfoveation③">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayer-ignoredepthvalues">
-   <b><a href="#dom-xrprojectionlayer-ignoredepthvalues">#dom-xrprojectionlayer-ignoredepthvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayer-ignoredepthvalues" class="dfn-panel" data-for="dom-xrprojectionlayer-ignoredepthvalues" id="infopanel-for-dom-xrprojectionlayer-ignoredepthvalues" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayer-ignoredepthvalues" style="display:none">Info about the 'ignoreDepthValues' definition.</span><b><a href="#dom-xrprojectionlayer-ignoredepthvalues">#dom-xrprojectionlayer-ignoredepthvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayer-ignoredepthvalues">3.4. XRProjectionLayer</a>
     <li><a href="#ref-for-dom-xrprojectionlayer-ignoredepthvalues①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrprojectionlayer-ignoredepthvalues②">(2)</a> <a href="#ref-for-dom-xrprojectionlayer-ignoredepthvalues③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrquadlayer">
-   <b><a href="#xrquadlayer">#xrquadlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrquadlayer" class="dfn-panel" data-for="xrquadlayer" id="infopanel-for-xrquadlayer" role="dialog">
+   <span id="infopaneltitle-for-xrquadlayer" style="display:none">Info about the 'XRQuadLayer' definition.</span><b><a href="#xrquadlayer">#xrquadlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrquadlayer">3.5. XRQuadLayer</a> <a href="#ref-for-xrquadlayer①">(2)</a>
     <li><a href="#ref-for-xrquadlayer②">4. Spaces</a> <a href="#ref-for-xrquadlayer③">(2)</a> <a href="#ref-for-xrquadlayer④">(3)</a> <a href="#ref-for-xrquadlayer⑤">(4)</a>
@@ -4591,45 +4591,45 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrquadlayer①②">7.5. XRMediaBinding</a> <a href="#ref-for-xrquadlayer①③">(2)</a> <a href="#ref-for-xrquadlayer①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayer-transform">
-   <b><a href="#dom-xrquadlayer-transform">#dom-xrquadlayer-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayer-transform" class="dfn-panel" data-for="dom-xrquadlayer-transform" id="infopanel-for-dom-xrquadlayer-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayer-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrquadlayer-transform">#dom-xrquadlayer-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayer-transform">3.5. XRQuadLayer</a> <a href="#ref-for-dom-xrquadlayer-transform①">(2)</a> <a href="#ref-for-dom-xrquadlayer-transform②">(3)</a> <a href="#ref-for-dom-xrquadlayer-transform③">(4)</a> <a href="#ref-for-dom-xrquadlayer-transform④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayer-space">
-   <b><a href="#dom-xrquadlayer-space">#dom-xrquadlayer-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayer-space" class="dfn-panel" data-for="dom-xrquadlayer-space" id="infopanel-for-dom-xrquadlayer-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayer-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrquadlayer-space">#dom-xrquadlayer-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayer-space">3.5. XRQuadLayer</a> <a href="#ref-for-dom-xrquadlayer-space①">(2)</a> <a href="#ref-for-dom-xrquadlayer-space②">(3)</a> <a href="#ref-for-dom-xrquadlayer-space③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayer-width">
-   <b><a href="#dom-xrquadlayer-width">#dom-xrquadlayer-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayer-width" class="dfn-panel" data-for="dom-xrquadlayer-width" id="infopanel-for-dom-xrquadlayer-width" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayer-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-xrquadlayer-width">#dom-xrquadlayer-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayer-width">3.5. XRQuadLayer</a> <a href="#ref-for-dom-xrquadlayer-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayer-height">
-   <b><a href="#dom-xrquadlayer-height">#dom-xrquadlayer-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayer-height" class="dfn-panel" data-for="dom-xrquadlayer-height" id="infopanel-for-dom-xrquadlayer-height" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayer-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-xrquadlayer-height">#dom-xrquadlayer-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayer-height">3.5. XRQuadLayer</a> <a href="#ref-for-dom-xrquadlayer-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-a-quad-layer">
-   <b><a href="#initialize-a-quad-layer">#initialize-a-quad-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-a-quad-layer" class="dfn-panel" data-for="initialize-a-quad-layer" id="infopanel-for-initialize-a-quad-layer" role="dialog">
+   <span id="infopaneltitle-for-initialize-a-quad-layer" style="display:none">Info about the 'initializing an XRQuadLayer layer with an XRQuadLayerInit init' definition.</span><b><a href="#initialize-a-quad-layer">#initialize-a-quad-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-quad-layer">6.9. XRWebGLBinding</a>
     <li><a href="#ref-for-initialize-a-quad-layer①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayer-onredraw">
-   <b><a href="#dom-xrquadlayer-onredraw">#dom-xrquadlayer-onredraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayer-onredraw" class="dfn-panel" data-for="dom-xrquadlayer-onredraw" id="infopanel-for-dom-xrquadlayer-onredraw" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayer-onredraw" style="display:none">Info about the 'onredraw' definition.</span><b><a href="#dom-xrquadlayer-onredraw">#dom-xrquadlayer-onredraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayer-onredraw">3.5. XRQuadLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcylinderlayer">
-   <b><a href="#xrcylinderlayer">#xrcylinderlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcylinderlayer" class="dfn-panel" data-for="xrcylinderlayer" id="infopanel-for-xrcylinderlayer" role="dialog">
+   <span id="infopaneltitle-for-xrcylinderlayer" style="display:none">Info about the 'XRCylinderLayer' definition.</span><b><a href="#xrcylinderlayer">#xrcylinderlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcylinderlayer">3.6. XRCylinderLayer</a> <a href="#ref-for-xrcylinderlayer①">(2)</a>
     <li><a href="#ref-for-xrcylinderlayer②">4. Spaces</a> <a href="#ref-for-xrcylinderlayer③">(2)</a> <a href="#ref-for-xrcylinderlayer④">(3)</a>
@@ -4640,51 +4640,51 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrcylinderlayer①①">7.5. XRMediaBinding</a> <a href="#ref-for-xrcylinderlayer①②">(2)</a> <a href="#ref-for-xrcylinderlayer①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-transform">
-   <b><a href="#dom-xrcylinderlayer-transform">#dom-xrcylinderlayer-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-transform" class="dfn-panel" data-for="dom-xrcylinderlayer-transform" id="infopanel-for-dom-xrcylinderlayer-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrcylinderlayer-transform">#dom-xrcylinderlayer-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-transform">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayer-transform①">(2)</a> <a href="#ref-for-dom-xrcylinderlayer-transform②">(3)</a> <a href="#ref-for-dom-xrcylinderlayer-transform③">(4)</a> <a href="#ref-for-dom-xrcylinderlayer-transform④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-space">
-   <b><a href="#dom-xrcylinderlayer-space">#dom-xrcylinderlayer-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-space" class="dfn-panel" data-for="dom-xrcylinderlayer-space" id="infopanel-for-dom-xrcylinderlayer-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrcylinderlayer-space">#dom-xrcylinderlayer-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-space">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayer-space①">(2)</a> <a href="#ref-for-dom-xrcylinderlayer-space②">(3)</a> <a href="#ref-for-dom-xrcylinderlayer-space③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-radius">
-   <b><a href="#dom-xrcylinderlayer-radius">#dom-xrcylinderlayer-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-radius" class="dfn-panel" data-for="dom-xrcylinderlayer-radius" id="infopanel-for-dom-xrcylinderlayer-radius" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#dom-xrcylinderlayer-radius">#dom-xrcylinderlayer-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-radius">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayer-radius①">(2)</a> <a href="#ref-for-dom-xrcylinderlayer-radius②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-centralangle">
-   <b><a href="#dom-xrcylinderlayer-centralangle">#dom-xrcylinderlayer-centralangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-centralangle" class="dfn-panel" data-for="dom-xrcylinderlayer-centralangle" id="infopanel-for-dom-xrcylinderlayer-centralangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-centralangle" style="display:none">Info about the 'centralAngle' definition.</span><b><a href="#dom-xrcylinderlayer-centralangle">#dom-xrcylinderlayer-centralangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-centralangle">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayer-centralangle①">(2)</a> <a href="#ref-for-dom-xrcylinderlayer-centralangle②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-aspectratio">
-   <b><a href="#dom-xrcylinderlayer-aspectratio">#dom-xrcylinderlayer-aspectratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-aspectratio" class="dfn-panel" data-for="dom-xrcylinderlayer-aspectratio" id="infopanel-for-dom-xrcylinderlayer-aspectratio" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-aspectratio" style="display:none">Info about the 'aspectRatio' definition.</span><b><a href="#dom-xrcylinderlayer-aspectratio">#dom-xrcylinderlayer-aspectratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-aspectratio">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayer-aspectratio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-a-cylinder-layer">
-   <b><a href="#initialize-a-cylinder-layer">#initialize-a-cylinder-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-a-cylinder-layer" class="dfn-panel" data-for="initialize-a-cylinder-layer" id="infopanel-for-initialize-a-cylinder-layer" role="dialog">
+   <span id="infopaneltitle-for-initialize-a-cylinder-layer" style="display:none">Info about the 'initializing an XRCylinderLayer layer with an XRCylinderLayerInit init' definition.</span><b><a href="#initialize-a-cylinder-layer">#initialize-a-cylinder-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-cylinder-layer">6.9. XRWebGLBinding</a>
     <li><a href="#ref-for-initialize-a-cylinder-layer①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayer-onredraw">
-   <b><a href="#dom-xrcylinderlayer-onredraw">#dom-xrcylinderlayer-onredraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayer-onredraw" class="dfn-panel" data-for="dom-xrcylinderlayer-onredraw" id="infopanel-for-dom-xrcylinderlayer-onredraw" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayer-onredraw" style="display:none">Info about the 'onredraw' definition.</span><b><a href="#dom-xrcylinderlayer-onredraw">#dom-xrcylinderlayer-onredraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayer-onredraw">3.6. XRCylinderLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrequirectlayer">
-   <b><a href="#xrequirectlayer">#xrequirectlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrequirectlayer" class="dfn-panel" data-for="xrequirectlayer" id="infopanel-for-xrequirectlayer" role="dialog">
+   <span id="infopaneltitle-for-xrequirectlayer" style="display:none">Info about the 'XREquirectLayer' definition.</span><b><a href="#xrequirectlayer">#xrequirectlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrequirectlayer">3.7. XREquirectLayer</a> <a href="#ref-for-xrequirectlayer①">(2)</a> <a href="#ref-for-xrequirectlayer②">(3)</a>
     <li><a href="#ref-for-xrequirectlayer③">4. Spaces</a> <a href="#ref-for-xrequirectlayer④">(2)</a>
@@ -4695,57 +4695,57 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrequirectlayer①①">7.5. XRMediaBinding</a> <a href="#ref-for-xrequirectlayer①②">(2)</a> <a href="#ref-for-xrequirectlayer①③">(3)</a> <a href="#ref-for-xrequirectlayer①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-space">
-   <b><a href="#dom-xrequirectlayer-space">#dom-xrequirectlayer-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-space" class="dfn-panel" data-for="dom-xrequirectlayer-space" id="infopanel-for-dom-xrequirectlayer-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrequirectlayer-space">#dom-xrequirectlayer-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-space">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-space①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-space②">(3)</a> <a href="#ref-for-dom-xrequirectlayer-space③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-transform">
-   <b><a href="#dom-xrequirectlayer-transform">#dom-xrequirectlayer-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-transform" class="dfn-panel" data-for="dom-xrequirectlayer-transform" id="infopanel-for-dom-xrequirectlayer-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrequirectlayer-transform">#dom-xrequirectlayer-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-transform">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-transform①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-transform②">(3)</a> <a href="#ref-for-dom-xrequirectlayer-transform③">(4)</a> <a href="#ref-for-dom-xrequirectlayer-transform④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-radius">
-   <b><a href="#dom-xrequirectlayer-radius">#dom-xrequirectlayer-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-radius" class="dfn-panel" data-for="dom-xrequirectlayer-radius" id="infopanel-for-dom-xrequirectlayer-radius" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#dom-xrequirectlayer-radius">#dom-xrequirectlayer-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-radius">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-radius①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-radius②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-centralhorizontalangle">
-   <b><a href="#dom-xrequirectlayer-centralhorizontalangle">#dom-xrequirectlayer-centralhorizontalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-centralhorizontalangle" class="dfn-panel" data-for="dom-xrequirectlayer-centralhorizontalangle" id="infopanel-for-dom-xrequirectlayer-centralhorizontalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-centralhorizontalangle" style="display:none">Info about the 'centralHorizontalAngle' definition.</span><b><a href="#dom-xrequirectlayer-centralhorizontalangle">#dom-xrequirectlayer-centralhorizontalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-centralhorizontalangle">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-centralhorizontalangle①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-centralhorizontalangle②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-upperverticalangle">
-   <b><a href="#dom-xrequirectlayer-upperverticalangle">#dom-xrequirectlayer-upperverticalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-upperverticalangle" class="dfn-panel" data-for="dom-xrequirectlayer-upperverticalangle" id="infopanel-for-dom-xrequirectlayer-upperverticalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-upperverticalangle" style="display:none">Info about the 'upperVerticalAngle' definition.</span><b><a href="#dom-xrequirectlayer-upperverticalangle">#dom-xrequirectlayer-upperverticalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-upperverticalangle">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-upperverticalangle①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-upperverticalangle②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-lowerverticalangle">
-   <b><a href="#dom-xrequirectlayer-lowerverticalangle">#dom-xrequirectlayer-lowerverticalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-lowerverticalangle" class="dfn-panel" data-for="dom-xrequirectlayer-lowerverticalangle" id="infopanel-for-dom-xrequirectlayer-lowerverticalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-lowerverticalangle" style="display:none">Info about the 'lowerVerticalAngle' definition.</span><b><a href="#dom-xrequirectlayer-lowerverticalangle">#dom-xrequirectlayer-lowerverticalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-lowerverticalangle">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayer-lowerverticalangle①">(2)</a> <a href="#ref-for-dom-xrequirectlayer-lowerverticalangle②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-a-equirect-layer">
-   <b><a href="#initialize-a-equirect-layer">#initialize-a-equirect-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-a-equirect-layer" class="dfn-panel" data-for="initialize-a-equirect-layer" id="infopanel-for-initialize-a-equirect-layer" role="dialog">
+   <span id="infopaneltitle-for-initialize-a-equirect-layer" style="display:none">Info about the 'initializing an XREquirectLayer layer with an XREquirectLayerInit init' definition.</span><b><a href="#initialize-a-equirect-layer">#initialize-a-equirect-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-equirect-layer">6.9. XRWebGLBinding</a>
     <li><a href="#ref-for-initialize-a-equirect-layer①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayer-onredraw">
-   <b><a href="#dom-xrequirectlayer-onredraw">#dom-xrequirectlayer-onredraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayer-onredraw" class="dfn-panel" data-for="dom-xrequirectlayer-onredraw" id="infopanel-for-dom-xrequirectlayer-onredraw" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayer-onredraw" style="display:none">Info about the 'onredraw' definition.</span><b><a href="#dom-xrequirectlayer-onredraw">#dom-xrequirectlayer-onredraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayer-onredraw">3.7. XREquirectLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrcubelayer">
-   <b><a href="#xrcubelayer">#xrcubelayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrcubelayer" class="dfn-panel" data-for="xrcubelayer" id="infopanel-for-xrcubelayer" role="dialog">
+   <span id="infopaneltitle-for-xrcubelayer" style="display:none">Info about the 'XRCubeLayer' definition.</span><b><a href="#xrcubelayer">#xrcubelayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrcubelayer">3.8. XRCubeLayer</a> <a href="#ref-for-xrcubelayer①">(2)</a> <a href="#ref-for-xrcubelayer②">(3)</a>
     <li><a href="#ref-for-xrcubelayer③">4. Spaces</a> <a href="#ref-for-xrcubelayer④">(2)</a>
@@ -4754,87 +4754,87 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrcubelayer⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-xrcubelayer⑧">(2)</a> <a href="#ref-for-xrcubelayer⑨">(3)</a> <a href="#ref-for-xrcubelayer①⓪">(4)</a> <a href="#ref-for-xrcubelayer①①">(5)</a> <a href="#ref-for-xrcubelayer①②">(6)</a> <a href="#ref-for-xrcubelayer①③">(7)</a> <a href="#ref-for-xrcubelayer①④">(8)</a> <a href="#ref-for-xrcubelayer①⑤">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcubelayer-orientation">
-   <b><a href="#dom-xrcubelayer-orientation">#dom-xrcubelayer-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcubelayer-orientation" class="dfn-panel" data-for="dom-xrcubelayer-orientation" id="infopanel-for-dom-xrcubelayer-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcubelayer-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-xrcubelayer-orientation">#dom-xrcubelayer-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcubelayer-orientation">3.8. XRCubeLayer</a> <a href="#ref-for-dom-xrcubelayer-orientation①">(2)</a>
     <li><a href="#ref-for-dom-xrcubelayer-orientation②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrcubelayer-orientation③">(2)</a> <a href="#ref-for-dom-xrcubelayer-orientation④">(3)</a> <a href="#ref-for-dom-xrcubelayer-orientation⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcubelayer-space">
-   <b><a href="#dom-xrcubelayer-space">#dom-xrcubelayer-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcubelayer-space" class="dfn-panel" data-for="dom-xrcubelayer-space" id="infopanel-for-dom-xrcubelayer-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcubelayer-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrcubelayer-space">#dom-xrcubelayer-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcubelayer-space">3.8. XRCubeLayer</a> <a href="#ref-for-dom-xrcubelayer-space①">(2)</a> <a href="#ref-for-dom-xrcubelayer-space②">(3)</a> <a href="#ref-for-dom-xrcubelayer-space③">(4)</a>
     <li><a href="#ref-for-dom-xrcubelayer-space④">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcubelayer-onredraw">
-   <b><a href="#dom-xrcubelayer-onredraw">#dom-xrcubelayer-onredraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcubelayer-onredraw" class="dfn-panel" data-for="dom-xrcubelayer-onredraw" id="infopanel-for-dom-xrcubelayer-onredraw" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcubelayer-onredraw" style="display:none">Info about the 'onredraw' definition.</span><b><a href="#dom-xrcubelayer-onredraw">#dom-xrcubelayer-onredraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcubelayer-onredraw">3.8. XRCubeLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsubimage">
-   <b><a href="#xrsubimage">#xrsubimage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsubimage" class="dfn-panel" data-for="xrsubimage" id="infopanel-for-xrsubimage" role="dialog">
+   <span id="infopaneltitle-for-xrsubimage" style="display:none">Info about the 'XRSubImage' definition.</span><b><a href="#xrsubimage">#xrsubimage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsubimage">3.1. Mono and stereo layers</a> <a href="#ref-for-xrsubimage①">(2)</a>
     <li><a href="#ref-for-xrsubimage②">5.1. XRSubImage</a>
     <li><a href="#ref-for-xrsubimage③">5.2. XRWebGLSubImage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsubimage-viewport">
-   <b><a href="#dom-xrsubimage-viewport">#dom-xrsubimage-viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsubimage-viewport" class="dfn-panel" data-for="dom-xrsubimage-viewport" id="infopanel-for-dom-xrsubimage-viewport" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsubimage-viewport" style="display:none">Info about the 'viewport' definition.</span><b><a href="#dom-xrsubimage-viewport">#dom-xrsubimage-viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsubimage-viewport">5.1. XRSubImage</a>
     <li><a href="#ref-for-dom-xrsubimage-viewport①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrsubimage-viewport②">(2)</a> <a href="#ref-for-dom-xrsubimage-viewport③">(3)</a> <a href="#ref-for-dom-xrsubimage-viewport④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebglsubimage">
-   <b><a href="#xrwebglsubimage">#xrwebglsubimage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebglsubimage" class="dfn-panel" data-for="xrwebglsubimage" id="infopanel-for-xrwebglsubimage" role="dialog">
+   <span id="infopaneltitle-for-xrwebglsubimage" style="display:none">Info about the 'XRWebGLSubImage' definition.</span><b><a href="#xrwebglsubimage">#xrwebglsubimage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglsubimage">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-xrwebglsubimage①">5.3. XRTextureType</a> <a href="#ref-for-xrwebglsubimage②">(2)</a>
     <li><a href="#ref-for-xrwebglsubimage③">6.9. XRWebGLBinding</a> <a href="#ref-for-xrwebglsubimage④">(2)</a> <a href="#ref-for-xrwebglsubimage⑤">(3)</a> <a href="#ref-for-xrwebglsubimage⑥">(4)</a> <a href="#ref-for-xrwebglsubimage⑦">(5)</a> <a href="#ref-for-xrwebglsubimage⑧">(6)</a> <a href="#ref-for-xrwebglsubimage⑨">(7)</a> <a href="#ref-for-xrwebglsubimage①⓪">(8)</a> <a href="#ref-for-xrwebglsubimage①①">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglsubimage-colortexture">
-   <b><a href="#dom-xrwebglsubimage-colortexture">#dom-xrwebglsubimage-colortexture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglsubimage-colortexture" class="dfn-panel" data-for="dom-xrwebglsubimage-colortexture" id="infopanel-for-dom-xrwebglsubimage-colortexture" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglsubimage-colortexture" style="display:none">Info about the 'colorTexture' definition.</span><b><a href="#dom-xrwebglsubimage-colortexture">#dom-xrwebglsubimage-colortexture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglsubimage-colortexture">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-colortexture①">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-colortexture②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture③">(2)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture④">(3)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture⑤">(4)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture⑥">(5)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture⑦">(6)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture⑧">(7)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture⑨">(8)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①⓪">(9)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①①">(10)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①②">(11)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①③">(12)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①④">(13)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①⑤">(14)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①⑥">(15)</a> <a href="#ref-for-dom-xrwebglsubimage-colortexture①⑦">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglsubimage-depthstenciltexture">
-   <b><a href="#dom-xrwebglsubimage-depthstenciltexture">#dom-xrwebglsubimage-depthstenciltexture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglsubimage-depthstenciltexture" class="dfn-panel" data-for="dom-xrwebglsubimage-depthstenciltexture" id="infopanel-for-dom-xrwebglsubimage-depthstenciltexture" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglsubimage-depthstenciltexture" style="display:none">Info about the 'depthStencilTexture' definition.</span><b><a href="#dom-xrwebglsubimage-depthstenciltexture">#dom-xrwebglsubimage-depthstenciltexture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture②">(2)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture③">(3)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture④">(4)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture⑤">(5)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture⑥">(6)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture⑦">(7)</a> <a href="#ref-for-dom-xrwebglsubimage-depthstenciltexture⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglsubimage-imageindex">
-   <b><a href="#dom-xrwebglsubimage-imageindex">#dom-xrwebglsubimage-imageindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglsubimage-imageindex" class="dfn-panel" data-for="dom-xrwebglsubimage-imageindex" id="infopanel-for-dom-xrwebglsubimage-imageindex" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglsubimage-imageindex" style="display:none">Info about the 'imageIndex' definition.</span><b><a href="#dom-xrwebglsubimage-imageindex">#dom-xrwebglsubimage-imageindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglsubimage-imageindex">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-imageindex①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglsubimage-imageindex②">(2)</a> <a href="#ref-for-dom-xrwebglsubimage-imageindex③">(3)</a> <a href="#ref-for-dom-xrwebglsubimage-imageindex④">(4)</a> <a href="#ref-for-dom-xrwebglsubimage-imageindex⑤">(5)</a> <a href="#ref-for-dom-xrwebglsubimage-imageindex⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglsubimage-texturewidth">
-   <b><a href="#dom-xrwebglsubimage-texturewidth">#dom-xrwebglsubimage-texturewidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglsubimage-texturewidth" class="dfn-panel" data-for="dom-xrwebglsubimage-texturewidth" id="infopanel-for-dom-xrwebglsubimage-texturewidth" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglsubimage-texturewidth" style="display:none">Info about the 'textureWidth' definition.</span><b><a href="#dom-xrwebglsubimage-texturewidth">#dom-xrwebglsubimage-texturewidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglsubimage-texturewidth">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-texturewidth①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglsubimage-texturewidth②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglsubimage-textureheight">
-   <b><a href="#dom-xrwebglsubimage-textureheight">#dom-xrwebglsubimage-textureheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglsubimage-textureheight" class="dfn-panel" data-for="dom-xrwebglsubimage-textureheight" id="infopanel-for-dom-xrwebglsubimage-textureheight" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglsubimage-textureheight" style="display:none">Info about the 'textureHeight' definition.</span><b><a href="#dom-xrwebglsubimage-textureheight">#dom-xrwebglsubimage-textureheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglsubimage-textureheight">5.2. XRWebGLSubImage</a>
     <li><a href="#ref-for-dom-xrwebglsubimage-textureheight①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglsubimage-textureheight②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrtexturetype">
-   <b><a href="#enumdef-xrtexturetype">#enumdef-xrtexturetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrtexturetype" class="dfn-panel" data-for="enumdef-xrtexturetype" id="infopanel-for-enumdef-xrtexturetype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrtexturetype" style="display:none">Info about the 'XRTextureType' definition.</span><b><a href="#enumdef-xrtexturetype">#enumdef-xrtexturetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrtexturetype">5.3. XRTextureType</a>
     <li><a href="#ref-for-enumdef-xrtexturetype①">6.3. XRProjectionLayerInit</a>
@@ -4844,15 +4844,15 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-enumdef-xrtexturetype⑤">6.9. XRWebGLBinding</a> <a href="#ref-for-enumdef-xrtexturetype⑥">(2)</a> <a href="#ref-for-enumdef-xrtexturetype⑦">(3)</a> <a href="#ref-for-enumdef-xrtexturetype⑧">(4)</a> <a href="#ref-for-enumdef-xrtexturetype⑨">(5)</a> <a href="#ref-for-enumdef-xrtexturetype①⓪">(6)</a> <a href="#ref-for-enumdef-xrtexturetype①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtexturetype-texture">
-   <b><a href="#dom-xrtexturetype-texture">#dom-xrtexturetype-texture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtexturetype-texture" class="dfn-panel" data-for="dom-xrtexturetype-texture" id="infopanel-for-dom-xrtexturetype-texture" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtexturetype-texture" style="display:none">Info about the 'texture' definition.</span><b><a href="#dom-xrtexturetype-texture">#dom-xrtexturetype-texture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtexturetype-texture">5.3. XRTextureType</a>
     <li><a href="#ref-for-dom-xrtexturetype-texture①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrtexturetype-texture②">(2)</a> <a href="#ref-for-dom-xrtexturetype-texture③">(3)</a> <a href="#ref-for-dom-xrtexturetype-texture④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtexturetype-texture-array">
-   <b><a href="#dom-xrtexturetype-texture-array">#dom-xrtexturetype-texture-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtexturetype-texture-array" class="dfn-panel" data-for="dom-xrtexturetype-texture-array" id="infopanel-for-dom-xrtexturetype-texture-array" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtexturetype-texture-array" style="display:none">Info about the 'texture-array' definition.</span><b><a href="#dom-xrtexturetype-texture-array">#dom-xrtexturetype-texture-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtexturetype-texture-array">3.2. XRLayerLayout</a>
     <li><a href="#ref-for-dom-xrtexturetype-texture-array①">3.4. XRProjectionLayer</a>
@@ -4861,64 +4861,64 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrtexturetype-texture-array④">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrtexturetype-texture-array⑤">(2)</a> <a href="#ref-for-dom-xrtexturetype-texture-array⑥">(3)</a> <a href="#ref-for-dom-xrtexturetype-texture-array⑦">(4)</a> <a href="#ref-for-dom-xrtexturetype-texture-array⑧">(5)</a> <a href="#ref-for-dom-xrtexturetype-texture-array⑨">(6)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①⓪">(7)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①①">(8)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①②">(9)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①③">(10)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①④">(11)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①⑤">(12)</a> <a href="#ref-for-dom-xrtexturetype-texture-array①⑥">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-texture">
-   <b><a href="#opaque-texture">#opaque-texture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-texture" class="dfn-panel" data-for="opaque-texture" id="infopanel-for-opaque-texture" role="dialog">
+   <span id="infopaneltitle-for-opaque-texture" style="display:none">Info about the 'opaque texture' definition.</span><b><a href="#opaque-texture">#opaque-texture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-texture">5.2. XRWebGLSubImage</a> <a href="#ref-for-opaque-texture①">(2)</a>
     <li><a href="#ref-for-opaque-texture②">6.2. Opaque textures</a> <a href="#ref-for-opaque-texture③">(2)</a> <a href="#ref-for-opaque-texture④">(3)</a> <a href="#ref-for-opaque-texture⑤">(4)</a> <a href="#ref-for-opaque-texture⑥">(5)</a> <a href="#ref-for-opaque-texture⑦">(6)</a> <a href="#ref-for-opaque-texture⑧">(7)</a> <a href="#ref-for-opaque-texture⑨">(8)</a> <a href="#ref-for-opaque-texture①⓪">(9)</a> <a href="#ref-for-opaque-texture①①">(10)</a>
     <li><a href="#ref-for-opaque-texture①②">6.9. XRWebGLBinding</a> <a href="#ref-for-opaque-texture①③">(2)</a> <a href="#ref-for-opaque-texture①④">(3)</a> <a href="#ref-for-opaque-texture①⑤">(4)</a> <a href="#ref-for-opaque-texture①⑥">(5)</a> <a href="#ref-for-opaque-texture①⑦">(6)</a> <a href="#ref-for-opaque-texture①⑧">(7)</a> <a href="#ref-for-opaque-texture①⑨">(8)</a> <a href="#ref-for-opaque-texture②⓪">(9)</a> <a href="#ref-for-opaque-texture②①">(10)</a> <a href="#ref-for-opaque-texture②②">(11)</a> <a href="#ref-for-opaque-texture②③">(12)</a> <a href="#ref-for-opaque-texture②④">(13)</a> <a href="#ref-for-opaque-texture②⑤">(14)</a> <a href="#ref-for-opaque-texture②⑥">(15)</a> <a href="#ref-for-opaque-texture②⑦">(16)</a> <a href="#ref-for-opaque-texture②⑧">(17)</a> <a href="#ref-for-opaque-texture②⑨">(18)</a> <a href="#ref-for-opaque-texture③⓪">(19)</a> <a href="#ref-for-opaque-texture③①">(20)</a> <a href="#ref-for-opaque-texture③②">(21)</a> <a href="#ref-for-opaque-texture③③">(22)</a> <a href="#ref-for-opaque-texture③④">(23)</a> <a href="#ref-for-opaque-texture③⑤">(24)</a> <a href="#ref-for-opaque-texture③⑥">(25)</a> <a href="#ref-for-opaque-texture③⑦">(26)</a> <a href="#ref-for-opaque-texture③⑧">(27)</a> <a href="#ref-for-opaque-texture③⑨">(28)</a> <a href="#ref-for-opaque-texture④⓪">(29)</a> <a href="#ref-for-opaque-texture④①">(30)</a> <a href="#ref-for-opaque-texture④②">(31)</a> <a href="#ref-for-opaque-texture④③">(32)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrprojectionlayerinit">
-   <b><a href="#dictdef-xrprojectionlayerinit">#dictdef-xrprojectionlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrprojectionlayerinit" class="dfn-panel" data-for="dictdef-xrprojectionlayerinit" id="infopanel-for-dictdef-xrprojectionlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrprojectionlayerinit" style="display:none">Info about the 'XRProjectionLayerInit' definition.</span><b><a href="#dictdef-xrprojectionlayerinit">#dictdef-xrprojectionlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrprojectionlayerinit">6.3. XRProjectionLayerInit</a> <a href="#ref-for-dictdef-xrprojectionlayerinit①">(2)</a>
     <li><a href="#ref-for-dictdef-xrprojectionlayerinit②">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayerinit-texturetype">
-   <b><a href="#dom-xrprojectionlayerinit-texturetype">#dom-xrprojectionlayerinit-texturetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayerinit-texturetype" class="dfn-panel" data-for="dom-xrprojectionlayerinit-texturetype" id="infopanel-for-dom-xrprojectionlayerinit-texturetype" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayerinit-texturetype" style="display:none">Info about the 'textureType' definition.</span><b><a href="#dom-xrprojectionlayerinit-texturetype">#dom-xrprojectionlayerinit-texturetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-texturetype">3.4. XRProjectionLayer</a>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-texturetype①">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-texturetype②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrprojectionlayerinit-texturetype③">(2)</a> <a href="#ref-for-dom-xrprojectionlayerinit-texturetype④">(3)</a> <a href="#ref-for-dom-xrprojectionlayerinit-texturetype⑤">(4)</a> <a href="#ref-for-dom-xrprojectionlayerinit-texturetype⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayerinit-colorformat">
-   <b><a href="#dom-xrprojectionlayerinit-colorformat">#dom-xrprojectionlayerinit-colorformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayerinit-colorformat" class="dfn-panel" data-for="dom-xrprojectionlayerinit-colorformat" id="infopanel-for-dom-xrprojectionlayerinit-colorformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayerinit-colorformat" style="display:none">Info about the 'colorFormat' definition.</span><b><a href="#dom-xrprojectionlayerinit-colorformat">#dom-xrprojectionlayerinit-colorformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-colorformat">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-colorformat①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrprojectionlayerinit-colorformat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-color-formats-for-projection-layers">
-   <b><a href="#list-of-color-formats-for-projection-layers">#list-of-color-formats-for-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-color-formats-for-projection-layers" class="dfn-panel" data-for="list-of-color-formats-for-projection-layers" id="infopanel-for-list-of-color-formats-for-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-list-of-color-formats-for-projection-layers" style="display:none">Info about the 'list of color formats for projection layers' definition.</span><b><a href="#list-of-color-formats-for-projection-layers">#list-of-color-formats-for-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-color-formats-for-projection-layers">6.9. XRWebGLBinding</a> <a href="#ref-for-list-of-color-formats-for-projection-layers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayerinit-depthformat">
-   <b><a href="#dom-xrprojectionlayerinit-depthformat">#dom-xrprojectionlayerinit-depthformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayerinit-depthformat" class="dfn-panel" data-for="dom-xrprojectionlayerinit-depthformat" id="infopanel-for-dom-xrprojectionlayerinit-depthformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayerinit-depthformat" style="display:none">Info about the 'depthFormat' definition.</span><b><a href="#dom-xrprojectionlayerinit-depthformat">#dom-xrprojectionlayerinit-depthformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-depthformat">6.3. XRProjectionLayerInit</a> <a href="#ref-for-dom-xrprojectionlayerinit-depthformat①">(2)</a>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-depthformat②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrprojectionlayerinit-depthformat③">(2)</a> <a href="#ref-for-dom-xrprojectionlayerinit-depthformat④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-depth-formats-for-projection-layers">
-   <b><a href="#list-of-depth-formats-for-projection-layers">#list-of-depth-formats-for-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-depth-formats-for-projection-layers" class="dfn-panel" data-for="list-of-depth-formats-for-projection-layers" id="infopanel-for-list-of-depth-formats-for-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-list-of-depth-formats-for-projection-layers" style="display:none">Info about the 'list of depth formats for projection layers' definition.</span><b><a href="#list-of-depth-formats-for-projection-layers">#list-of-depth-formats-for-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-depth-formats-for-projection-layers">6.9. XRWebGLBinding</a> <a href="#ref-for-list-of-depth-formats-for-projection-layers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrprojectionlayerinit-scalefactor">
-   <b><a href="#dom-xrprojectionlayerinit-scalefactor">#dom-xrprojectionlayerinit-scalefactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrprojectionlayerinit-scalefactor" class="dfn-panel" data-for="dom-xrprojectionlayerinit-scalefactor" id="infopanel-for-dom-xrprojectionlayerinit-scalefactor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrprojectionlayerinit-scalefactor" style="display:none">Info about the 'scaleFactor' definition.</span><b><a href="#dom-xrprojectionlayerinit-scalefactor">#dom-xrprojectionlayerinit-scalefactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-scalefactor">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-dom-xrprojectionlayerinit-scalefactor①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrprojectionlayerinit-scalefactor②">(2)</a> <a href="#ref-for-dom-xrprojectionlayerinit-scalefactor③">(3)</a> <a href="#ref-for-dom-xrprojectionlayerinit-scalefactor④">(4)</a> <a href="#ref-for-dom-xrprojectionlayerinit-scalefactor⑤">(5)</a> <a href="#ref-for-dom-xrprojectionlayerinit-scalefactor⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrlayerinit">
-   <b><a href="#dictdef-xrlayerinit">#dictdef-xrlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrlayerinit" class="dfn-panel" data-for="dictdef-xrlayerinit" id="infopanel-for-dictdef-xrlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrlayerinit" style="display:none">Info about the 'XRLayerInit' definition.</span><b><a href="#dictdef-xrlayerinit">#dictdef-xrlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrlayerinit">6.3. XRProjectionLayerInit</a>
     <li><a href="#ref-for-dictdef-xrlayerinit①">6.4. XRLayerInit</a>
@@ -4929,8 +4929,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dictdef-xrlayerinit⑥">6.9. XRWebGLBinding</a> <a href="#ref-for-dictdef-xrlayerinit⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-isstatic">
-   <b><a href="#dom-xrlayerinit-isstatic">#dom-xrlayerinit-isstatic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-isstatic" class="dfn-panel" data-for="dom-xrlayerinit-isstatic" id="infopanel-for-dom-xrlayerinit-isstatic" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-isstatic" style="display:none">Info about the 'isStatic' definition.</span><b><a href="#dom-xrlayerinit-isstatic">#dom-xrlayerinit-isstatic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-isstatic">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dom-xrlayerinit-isstatic①">3.6. XRCylinderLayer</a>
@@ -4938,8 +4938,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrlayerinit-isstatic③">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-space">
-   <b><a href="#dom-xrlayerinit-space">#dom-xrlayerinit-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-space" class="dfn-panel" data-for="dom-xrlayerinit-space" id="infopanel-for-dom-xrlayerinit-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrlayerinit-space">#dom-xrlayerinit-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-space">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dom-xrlayerinit-space①">3.6. XRCylinderLayer</a>
@@ -4950,34 +4950,34 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrlayerinit-space①③">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrlayerinit-space①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-colorformat">
-   <b><a href="#dom-xrlayerinit-colorformat">#dom-xrlayerinit-colorformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-colorformat" class="dfn-panel" data-for="dom-xrlayerinit-colorformat" id="infopanel-for-dom-xrlayerinit-colorformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-colorformat" style="display:none">Info about the 'colorFormat' definition.</span><b><a href="#dom-xrlayerinit-colorformat">#dom-xrlayerinit-colorformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-colorformat">6.4. XRLayerInit</a>
     <li><a href="#ref-for-dom-xrlayerinit-colorformat①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-colorformat②">(2)</a> <a href="#ref-for-dom-xrlayerinit-colorformat③">(3)</a> <a href="#ref-for-dom-xrlayerinit-colorformat④">(4)</a> <a href="#ref-for-dom-xrlayerinit-colorformat⑤">(5)</a> <a href="#ref-for-dom-xrlayerinit-colorformat⑥">(6)</a> <a href="#ref-for-dom-xrlayerinit-colorformat⑦">(7)</a> <a href="#ref-for-dom-xrlayerinit-colorformat⑧">(8)</a> <a href="#ref-for-dom-xrlayerinit-colorformat⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-color-formats-for-non-projection-layers">
-   <b><a href="#list-of-color-formats-for-non-projection-layers">#list-of-color-formats-for-non-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-color-formats-for-non-projection-layers" class="dfn-panel" data-for="list-of-color-formats-for-non-projection-layers" id="infopanel-for-list-of-color-formats-for-non-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-list-of-color-formats-for-non-projection-layers" style="display:none">Info about the 'list of color formats for non-projection layers' definition.</span><b><a href="#list-of-color-formats-for-non-projection-layers">#list-of-color-formats-for-non-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-color-formats-for-non-projection-layers">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-depthformat">
-   <b><a href="#dom-xrlayerinit-depthformat">#dom-xrlayerinit-depthformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-depthformat" class="dfn-panel" data-for="dom-xrlayerinit-depthformat" id="infopanel-for-dom-xrlayerinit-depthformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-depthformat" style="display:none">Info about the 'depthFormat' definition.</span><b><a href="#dom-xrlayerinit-depthformat">#dom-xrlayerinit-depthformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-depthformat">6.4. XRLayerInit</a> <a href="#ref-for-dom-xrlayerinit-depthformat①">(2)</a>
     <li><a href="#ref-for-dom-xrlayerinit-depthformat②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-depthformat③">(2)</a> <a href="#ref-for-dom-xrlayerinit-depthformat④">(3)</a> <a href="#ref-for-dom-xrlayerinit-depthformat⑤">(4)</a> <a href="#ref-for-dom-xrlayerinit-depthformat⑥">(5)</a> <a href="#ref-for-dom-xrlayerinit-depthformat⑦">(6)</a> <a href="#ref-for-dom-xrlayerinit-depthformat⑧">(7)</a> <a href="#ref-for-dom-xrlayerinit-depthformat⑨">(8)</a> <a href="#ref-for-dom-xrlayerinit-depthformat①⓪">(9)</a> <a href="#ref-for-dom-xrlayerinit-depthformat①①">(10)</a> <a href="#ref-for-dom-xrlayerinit-depthformat①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-depth-formats-for-non-projection-layers">
-   <b><a href="#list-of-depth-formats-for-non-projection-layers">#list-of-depth-formats-for-non-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-depth-formats-for-non-projection-layers" class="dfn-panel" data-for="list-of-depth-formats-for-non-projection-layers" id="infopanel-for-list-of-depth-formats-for-non-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-list-of-depth-formats-for-non-projection-layers" style="display:none">Info about the 'list of depth formats for non-projection layers' definition.</span><b><a href="#list-of-depth-formats-for-non-projection-layers">#list-of-depth-formats-for-non-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-depth-formats-for-non-projection-layers">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-miplevels">
-   <b><a href="#dom-xrlayerinit-miplevels">#dom-xrlayerinit-miplevels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-miplevels" class="dfn-panel" data-for="dom-xrlayerinit-miplevels" id="infopanel-for-dom-xrlayerinit-miplevels" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-miplevels" style="display:none">Info about the 'mipLevels' definition.</span><b><a href="#dom-xrlayerinit-miplevels">#dom-xrlayerinit-miplevels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-miplevels">3.3. XRCompositionLayer</a> <a href="#ref-for-dom-xrlayerinit-miplevels①">(2)</a>
     <li><a href="#ref-for-dom-xrlayerinit-miplevels②">6.2. Opaque textures</a>
@@ -4986,154 +4986,154 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrlayerinit-miplevels⑤">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-miplevels⑥">(2)</a> <a href="#ref-for-dom-xrlayerinit-miplevels⑦">(3)</a> <a href="#ref-for-dom-xrlayerinit-miplevels⑧">(4)</a> <a href="#ref-for-dom-xrlayerinit-miplevels⑨">(5)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⓪">(6)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①①">(7)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①②">(8)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①③">(9)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①④">(10)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⑤">(11)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⑥">(12)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⑦">(13)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⑧">(14)</a> <a href="#ref-for-dom-xrlayerinit-miplevels①⑨">(15)</a> <a href="#ref-for-dom-xrlayerinit-miplevels②⓪">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-viewpixelwidth">
-   <b><a href="#dom-xrlayerinit-viewpixelwidth">#dom-xrlayerinit-viewpixelwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-viewpixelwidth" class="dfn-panel" data-for="dom-xrlayerinit-viewpixelwidth" id="infopanel-for-dom-xrlayerinit-viewpixelwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-viewpixelwidth" style="display:none">Info about the 'viewPixelWidth' definition.</span><b><a href="#dom-xrlayerinit-viewpixelwidth">#dom-xrlayerinit-viewpixelwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-viewpixelwidth">6.4. XRLayerInit</a>
     <li><a href="#ref-for-dom-xrlayerinit-viewpixelwidth①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth②">(2)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth③">(3)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth④">(4)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth⑤">(5)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth⑥">(6)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth⑦">(7)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth⑧">(8)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth⑨">(9)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①⓪">(10)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①①">(11)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①②">(12)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①③">(13)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①④">(14)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①⑤">(15)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①⑥">(16)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①⑦">(17)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelwidth①⑧">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-viewpixelheight">
-   <b><a href="#dom-xrlayerinit-viewpixelheight">#dom-xrlayerinit-viewpixelheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-viewpixelheight" class="dfn-panel" data-for="dom-xrlayerinit-viewpixelheight" id="infopanel-for-dom-xrlayerinit-viewpixelheight" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-viewpixelheight" style="display:none">Info about the 'viewPixelHeight' definition.</span><b><a href="#dom-xrlayerinit-viewpixelheight">#dom-xrlayerinit-viewpixelheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-viewpixelheight">6.4. XRLayerInit</a>
     <li><a href="#ref-for-dom-xrlayerinit-viewpixelheight①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight②">(2)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight③">(3)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight④">(4)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight⑤">(5)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight⑥">(6)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight⑦">(7)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight⑧">(8)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight⑨">(9)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①⓪">(10)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①①">(11)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①②">(12)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①③">(13)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①④">(14)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①⑤">(15)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①⑥">(16)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①⑦">(17)</a> <a href="#ref-for-dom-xrlayerinit-viewpixelheight①⑧">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerinit-layout">
-   <b><a href="#dom-xrlayerinit-layout">#dom-xrlayerinit-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerinit-layout" class="dfn-panel" data-for="dom-xrlayerinit-layout" id="infopanel-for-dom-xrlayerinit-layout" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerinit-layout" style="display:none">Info about the 'layout' definition.</span><b><a href="#dom-xrlayerinit-layout">#dom-xrlayerinit-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerinit-layout">6.4. XRLayerInit</a>
     <li><a href="#ref-for-dom-xrlayerinit-layout①">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrlayerinit-layout②">(2)</a> <a href="#ref-for-dom-xrlayerinit-layout③">(3)</a> <a href="#ref-for-dom-xrlayerinit-layout④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrquadlayerinit">
-   <b><a href="#dictdef-xrquadlayerinit">#dictdef-xrquadlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrquadlayerinit" class="dfn-panel" data-for="dictdef-xrquadlayerinit" id="infopanel-for-dictdef-xrquadlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrquadlayerinit" style="display:none">Info about the 'XRQuadLayerInit' definition.</span><b><a href="#dictdef-xrquadlayerinit">#dictdef-xrquadlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrquadlayerinit">3.5. XRQuadLayer</a>
     <li><a href="#ref-for-dictdef-xrquadlayerinit①">6.5. XRQuadLayerInit</a>
     <li><a href="#ref-for-dictdef-xrquadlayerinit②">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayerinit-texturetype">
-   <b><a href="#dom-xrquadlayerinit-texturetype">#dom-xrquadlayerinit-texturetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayerinit-texturetype" class="dfn-panel" data-for="dom-xrquadlayerinit-texturetype" id="infopanel-for-dom-xrquadlayerinit-texturetype" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayerinit-texturetype" style="display:none">Info about the 'textureType' definition.</span><b><a href="#dom-xrquadlayerinit-texturetype">#dom-xrquadlayerinit-texturetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayerinit-texturetype">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrquadlayerinit-texturetype①">(2)</a> <a href="#ref-for-dom-xrquadlayerinit-texturetype②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayerinit-transform">
-   <b><a href="#dom-xrquadlayerinit-transform">#dom-xrquadlayerinit-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayerinit-transform" class="dfn-panel" data-for="dom-xrquadlayerinit-transform" id="infopanel-for-dom-xrquadlayerinit-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayerinit-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrquadlayerinit-transform">#dom-xrquadlayerinit-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayerinit-transform">3.5. XRQuadLayer</a> <a href="#ref-for-dom-xrquadlayerinit-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayerinit-width">
-   <b><a href="#dom-xrquadlayerinit-width">#dom-xrquadlayerinit-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayerinit-width" class="dfn-panel" data-for="dom-xrquadlayerinit-width" id="infopanel-for-dom-xrquadlayerinit-width" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayerinit-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-xrquadlayerinit-width">#dom-xrquadlayerinit-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayerinit-width">3.5. XRQuadLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrquadlayerinit-height">
-   <b><a href="#dom-xrquadlayerinit-height">#dom-xrquadlayerinit-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrquadlayerinit-height" class="dfn-panel" data-for="dom-xrquadlayerinit-height" id="infopanel-for-dom-xrquadlayerinit-height" role="dialog">
+   <span id="infopaneltitle-for-dom-xrquadlayerinit-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-xrquadlayerinit-height">#dom-xrquadlayerinit-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrquadlayerinit-height">3.5. XRQuadLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrcylinderlayerinit">
-   <b><a href="#dictdef-xrcylinderlayerinit">#dictdef-xrcylinderlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrcylinderlayerinit" class="dfn-panel" data-for="dictdef-xrcylinderlayerinit" id="infopanel-for-dictdef-xrcylinderlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrcylinderlayerinit" style="display:none">Info about the 'XRCylinderLayerInit' definition.</span><b><a href="#dictdef-xrcylinderlayerinit">#dictdef-xrcylinderlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrcylinderlayerinit">3.6. XRCylinderLayer</a>
     <li><a href="#ref-for-dictdef-xrcylinderlayerinit①">6.6. XRCylinderLayerInit</a>
     <li><a href="#ref-for-dictdef-xrcylinderlayerinit②">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayerinit-texturetype">
-   <b><a href="#dom-xrcylinderlayerinit-texturetype">#dom-xrcylinderlayerinit-texturetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayerinit-texturetype" class="dfn-panel" data-for="dom-xrcylinderlayerinit-texturetype" id="infopanel-for-dom-xrcylinderlayerinit-texturetype" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayerinit-texturetype" style="display:none">Info about the 'textureType' definition.</span><b><a href="#dom-xrcylinderlayerinit-texturetype">#dom-xrcylinderlayerinit-texturetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-texturetype">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrcylinderlayerinit-texturetype①">(2)</a> <a href="#ref-for-dom-xrcylinderlayerinit-texturetype②">(3)</a> <a href="#ref-for-dom-xrcylinderlayerinit-texturetype③">(4)</a> <a href="#ref-for-dom-xrcylinderlayerinit-texturetype④">(5)</a> <a href="#ref-for-dom-xrcylinderlayerinit-texturetype⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayerinit-transform">
-   <b><a href="#dom-xrcylinderlayerinit-transform">#dom-xrcylinderlayerinit-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayerinit-transform" class="dfn-panel" data-for="dom-xrcylinderlayerinit-transform" id="infopanel-for-dom-xrcylinderlayerinit-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayerinit-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrcylinderlayerinit-transform">#dom-xrcylinderlayerinit-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-transform">3.6. XRCylinderLayer</a> <a href="#ref-for-dom-xrcylinderlayerinit-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayerinit-radius">
-   <b><a href="#dom-xrcylinderlayerinit-radius">#dom-xrcylinderlayerinit-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayerinit-radius" class="dfn-panel" data-for="dom-xrcylinderlayerinit-radius" id="infopanel-for-dom-xrcylinderlayerinit-radius" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayerinit-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#dom-xrcylinderlayerinit-radius">#dom-xrcylinderlayerinit-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-radius">3.6. XRCylinderLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayerinit-centralangle">
-   <b><a href="#dom-xrcylinderlayerinit-centralangle">#dom-xrcylinderlayerinit-centralangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayerinit-centralangle" class="dfn-panel" data-for="dom-xrcylinderlayerinit-centralangle" id="infopanel-for-dom-xrcylinderlayerinit-centralangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayerinit-centralangle" style="display:none">Info about the 'centralAngle' definition.</span><b><a href="#dom-xrcylinderlayerinit-centralangle">#dom-xrcylinderlayerinit-centralangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-centralangle">3.6. XRCylinderLayer</a>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-centralangle①">6.6. XRCylinderLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcylinderlayerinit-aspectratio">
-   <b><a href="#dom-xrcylinderlayerinit-aspectratio">#dom-xrcylinderlayerinit-aspectratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcylinderlayerinit-aspectratio" class="dfn-panel" data-for="dom-xrcylinderlayerinit-aspectratio" id="infopanel-for-dom-xrcylinderlayerinit-aspectratio" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcylinderlayerinit-aspectratio" style="display:none">Info about the 'aspectRatio' definition.</span><b><a href="#dom-xrcylinderlayerinit-aspectratio">#dom-xrcylinderlayerinit-aspectratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcylinderlayerinit-aspectratio">3.6. XRCylinderLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrequirectlayerinit">
-   <b><a href="#dictdef-xrequirectlayerinit">#dictdef-xrequirectlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrequirectlayerinit" class="dfn-panel" data-for="dictdef-xrequirectlayerinit" id="infopanel-for-dictdef-xrequirectlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrequirectlayerinit" style="display:none">Info about the 'XREquirectLayerInit' definition.</span><b><a href="#dictdef-xrequirectlayerinit">#dictdef-xrequirectlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrequirectlayerinit">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-dictdef-xrequirectlayerinit①">6.7. XREquirectLayerInit</a>
     <li><a href="#ref-for-dictdef-xrequirectlayerinit②">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayerinit-transform">
-   <b><a href="#dom-xrequirectlayerinit-transform">#dom-xrequirectlayerinit-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayerinit-transform" class="dfn-panel" data-for="dom-xrequirectlayerinit-transform" id="infopanel-for-dom-xrequirectlayerinit-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayerinit-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrequirectlayerinit-transform">#dom-xrequirectlayerinit-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayerinit-transform">3.7. XREquirectLayer</a> <a href="#ref-for-dom-xrequirectlayerinit-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayerinit-radius">
-   <b><a href="#dom-xrequirectlayerinit-radius">#dom-xrequirectlayerinit-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayerinit-radius" class="dfn-panel" data-for="dom-xrequirectlayerinit-radius" id="infopanel-for-dom-xrequirectlayerinit-radius" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayerinit-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#dom-xrequirectlayerinit-radius">#dom-xrequirectlayerinit-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayerinit-radius">3.7. XREquirectLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayerinit-centralhorizontalangle">
-   <b><a href="#dom-xrequirectlayerinit-centralhorizontalangle">#dom-xrequirectlayerinit-centralhorizontalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayerinit-centralhorizontalangle" class="dfn-panel" data-for="dom-xrequirectlayerinit-centralhorizontalangle" id="infopanel-for-dom-xrequirectlayerinit-centralhorizontalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayerinit-centralhorizontalangle" style="display:none">Info about the 'centralHorizontalAngle' definition.</span><b><a href="#dom-xrequirectlayerinit-centralhorizontalangle">#dom-xrequirectlayerinit-centralhorizontalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayerinit-centralhorizontalangle">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-dom-xrequirectlayerinit-centralhorizontalangle①">6.7. XREquirectLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayerinit-upperverticalangle">
-   <b><a href="#dom-xrequirectlayerinit-upperverticalangle">#dom-xrequirectlayerinit-upperverticalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayerinit-upperverticalangle" class="dfn-panel" data-for="dom-xrequirectlayerinit-upperverticalangle" id="infopanel-for-dom-xrequirectlayerinit-upperverticalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayerinit-upperverticalangle" style="display:none">Info about the 'upperVerticalAngle' definition.</span><b><a href="#dom-xrequirectlayerinit-upperverticalangle">#dom-xrequirectlayerinit-upperverticalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayerinit-upperverticalangle">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-dom-xrequirectlayerinit-upperverticalangle①">6.7. XREquirectLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrequirectlayerinit-lowerverticalangle">
-   <b><a href="#dom-xrequirectlayerinit-lowerverticalangle">#dom-xrequirectlayerinit-lowerverticalangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrequirectlayerinit-lowerverticalangle" class="dfn-panel" data-for="dom-xrequirectlayerinit-lowerverticalangle" id="infopanel-for-dom-xrequirectlayerinit-lowerverticalangle" role="dialog">
+   <span id="infopaneltitle-for-dom-xrequirectlayerinit-lowerverticalangle" style="display:none">Info about the 'lowerVerticalAngle' definition.</span><b><a href="#dom-xrequirectlayerinit-lowerverticalangle">#dom-xrequirectlayerinit-lowerverticalangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrequirectlayerinit-lowerverticalangle">3.7. XREquirectLayer</a>
     <li><a href="#ref-for-dom-xrequirectlayerinit-lowerverticalangle①">6.7. XREquirectLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrcubelayerinit">
-   <b><a href="#dictdef-xrcubelayerinit">#dictdef-xrcubelayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrcubelayerinit" class="dfn-panel" data-for="dictdef-xrcubelayerinit" id="infopanel-for-dictdef-xrcubelayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrcubelayerinit" style="display:none">Info about the 'XRCubeLayerInit' definition.</span><b><a href="#dictdef-xrcubelayerinit">#dictdef-xrcubelayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrcubelayerinit">6.8. XRCubeLayerInit</a>
     <li><a href="#ref-for-dictdef-xrcubelayerinit①">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrcubelayerinit-orientation">
-   <b><a href="#dom-xrcubelayerinit-orientation">#dom-xrcubelayerinit-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrcubelayerinit-orientation" class="dfn-panel" data-for="dom-xrcubelayerinit-orientation" id="infopanel-for-dom-xrcubelayerinit-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrcubelayerinit-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-xrcubelayerinit-orientation">#dom-xrcubelayerinit-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrcubelayerinit-orientation">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrcubelayerinit-orientation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebglbinding">
-   <b><a href="#xrwebglbinding">#xrwebglbinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebglbinding" class="dfn-panel" data-for="xrwebglbinding" id="infopanel-for-xrwebglbinding" role="dialog">
+   <span id="infopaneltitle-for-xrwebglbinding" style="display:none">Info about the 'XRWebGLBinding' definition.</span><b><a href="#xrwebglbinding">#xrwebglbinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding">1.2. Application flow</a>
     <li><a href="#ref-for-xrwebglbinding①">6.1. Overview</a> <a href="#ref-for-xrwebglbinding②">(2)</a> <a href="#ref-for-xrwebglbinding③">(3)</a> <a href="#ref-for-xrwebglbinding④">(4)</a> <a href="#ref-for-xrwebglbinding⑤">(5)</a>
@@ -5141,171 +5141,171 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-xrwebglbinding⑦">6.9. XRWebGLBinding</a> <a href="#ref-for-xrwebglbinding⑧">(2)</a> <a href="#ref-for-xrwebglbinding⑨">(3)</a> <a href="#ref-for-xrwebglbinding①⓪">(4)</a> <a href="#ref-for-xrwebglbinding①①">(5)</a> <a href="#ref-for-xrwebglbinding①②">(6)</a> <a href="#ref-for-xrwebglbinding①③">(7)</a> <a href="#ref-for-xrwebglbinding①④">(8)</a> <a href="#ref-for-xrwebglbinding①⑤">(9)</a> <a href="#ref-for-xrwebglbinding①⑥">(10)</a> <a href="#ref-for-xrwebglbinding①⑦">(11)</a> <a href="#ref-for-xrwebglbinding①⑧">(12)</a> <a href="#ref-for-xrwebglbinding①⑨">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-nativeprojectionscalefactor">
-   <b><a href="#dom-xrwebglbinding-nativeprojectionscalefactor">#dom-xrwebglbinding-nativeprojectionscalefactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-nativeprojectionscalefactor" class="dfn-panel" data-for="dom-xrwebglbinding-nativeprojectionscalefactor" id="infopanel-for-dom-xrwebglbinding-nativeprojectionscalefactor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-nativeprojectionscalefactor" style="display:none">Info about the 'nativeProjectionScaleFactor' definition.</span><b><a href="#dom-xrwebglbinding-nativeprojectionscalefactor">#dom-xrwebglbinding-nativeprojectionscalefactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-nativeprojectionscalefactor">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-getsubimage-layer-frame-eye-frame">
-   <b><a href="#dom-xrwebglbinding-getsubimage-layer-frame-eye-frame">#dom-xrwebglbinding-getsubimage-layer-frame-eye-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-getsubimage-layer-frame-eye-frame" class="dfn-panel" data-for="dom-xrwebglbinding-getsubimage-layer-frame-eye-frame" id="infopanel-for-dom-xrwebglbinding-getsubimage-layer-frame-eye-frame" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-getsubimage-layer-frame-eye-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#dom-xrwebglbinding-getsubimage-layer-frame-eye-frame">#dom-xrwebglbinding-getsubimage-layer-frame-eye-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-getsubimage-layer-frame-eye-frame">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebglbinding-context">
-   <b><a href="#xrwebglbinding-context">#xrwebglbinding-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebglbinding-context" class="dfn-panel" data-for="xrwebglbinding-context" id="infopanel-for-xrwebglbinding-context" role="dialog">
+   <span id="infopaneltitle-for-xrwebglbinding-context" style="display:none">Info about the 'context' definition.</span><b><a href="#xrwebglbinding-context">#xrwebglbinding-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding-context">6.9. XRWebGLBinding</a> <a href="#ref-for-xrwebglbinding-context①">(2)</a> <a href="#ref-for-xrwebglbinding-context②">(3)</a> <a href="#ref-for-xrwebglbinding-context③">(4)</a> <a href="#ref-for-xrwebglbinding-context④">(5)</a> <a href="#ref-for-xrwebglbinding-context⑤">(6)</a> <a href="#ref-for-xrwebglbinding-context⑥">(7)</a> <a href="#ref-for-xrwebglbinding-context⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebglbinding-session">
-   <b><a href="#xrwebglbinding-session">#xrwebglbinding-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebglbinding-session" class="dfn-panel" data-for="xrwebglbinding-session" id="infopanel-for-xrwebglbinding-session" role="dialog">
+   <span id="infopaneltitle-for-xrwebglbinding-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrwebglbinding-session">#xrwebglbinding-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding-session">6.9. XRWebGLBinding</a> <a href="#ref-for-xrwebglbinding-session①">(2)</a> <a href="#ref-for-xrwebglbinding-session②">(3)</a> <a href="#ref-for-xrwebglbinding-session③">(4)</a> <a href="#ref-for-xrwebglbinding-session④">(5)</a> <a href="#ref-for-xrwebglbinding-session⑤">(6)</a> <a href="#ref-for-xrwebglbinding-session⑥">(7)</a> <a href="#ref-for-xrwebglbinding-session⑦">(8)</a> <a href="#ref-for-xrwebglbinding-session⑧">(9)</a> <a href="#ref-for-xrwebglbinding-session⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="colortextures">
-   <b><a href="#colortextures">#colortextures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-colortextures" class="dfn-panel" data-for="colortextures" id="infopanel-for-colortextures" role="dialog">
+   <span id="infopaneltitle-for-colortextures" style="display:none">Info about the 'colorTextures' definition.</span><b><a href="#colortextures">#colortextures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-colortextures">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-colortextures①">3.4. XRProjectionLayer</a> <a href="#ref-for-colortextures②">(2)</a> <a href="#ref-for-colortextures③">(3)</a>
     <li><a href="#ref-for-colortextures④">6.9. XRWebGLBinding</a> <a href="#ref-for-colortextures⑤">(2)</a> <a href="#ref-for-colortextures⑥">(3)</a> <a href="#ref-for-colortextures⑦">(4)</a> <a href="#ref-for-colortextures⑧">(5)</a> <a href="#ref-for-colortextures⑨">(6)</a> <a href="#ref-for-colortextures①⓪">(7)</a> <a href="#ref-for-colortextures①①">(8)</a> <a href="#ref-for-colortextures①②">(9)</a> <a href="#ref-for-colortextures①③">(10)</a> <a href="#ref-for-colortextures①④">(11)</a> <a href="#ref-for-colortextures①⑤">(12)</a> <a href="#ref-for-colortextures①⑥">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="depthstenciltextures">
-   <b><a href="#depthstenciltextures">#depthstenciltextures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-depthstenciltextures" class="dfn-panel" data-for="depthstenciltextures" id="infopanel-for-depthstenciltextures" role="dialog">
+   <span id="infopaneltitle-for-depthstenciltextures" style="display:none">Info about the 'depthStencilTextures' definition.</span><b><a href="#depthstenciltextures">#depthstenciltextures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depthstenciltextures">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-depthstenciltextures①">6.9. XRWebGLBinding</a> <a href="#ref-for-depthstenciltextures②">(2)</a> <a href="#ref-for-depthstenciltextures③">(3)</a> <a href="#ref-for-depthstenciltextures④">(4)</a> <a href="#ref-for-depthstenciltextures⑤">(5)</a> <a href="#ref-for-depthstenciltextures⑥">(6)</a> <a href="#ref-for-depthstenciltextures⑦">(7)</a> <a href="#ref-for-depthstenciltextures⑧">(8)</a> <a href="#ref-for-depthstenciltextures⑨">(9)</a> <a href="#ref-for-depthstenciltextures①⓪">(10)</a> <a href="#ref-for-depthstenciltextures①①">(11)</a> <a href="#ref-for-depthstenciltextures①②">(12)</a> <a href="#ref-for-depthstenciltextures①③">(13)</a> <a href="#ref-for-depthstenciltextures①④">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrprojectionlayer-colortextures-for-secondary-views">
-   <b><a href="#xrprojectionlayer-colortextures-for-secondary-views">#xrprojectionlayer-colortextures-for-secondary-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrprojectionlayer-colortextures-for-secondary-views" class="dfn-panel" data-for="xrprojectionlayer-colortextures-for-secondary-views" id="infopanel-for-xrprojectionlayer-colortextures-for-secondary-views" role="dialog">
+   <span id="infopaneltitle-for-xrprojectionlayer-colortextures-for-secondary-views" style="display:none">Info about the 'colorTextures for secondary views' definition.</span><b><a href="#xrprojectionlayer-colortextures-for-secondary-views">#xrprojectionlayer-colortextures-for-secondary-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrprojectionlayer-colortextures-for-secondary-views">6.9. XRWebGLBinding</a> <a href="#ref-for-xrprojectionlayer-colortextures-for-secondary-views①">(2)</a> <a href="#ref-for-xrprojectionlayer-colortextures-for-secondary-views②">(3)</a> <a href="#ref-for-xrprojectionlayer-colortextures-for-secondary-views③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrprojectionlayer-depthstenciltextures-for-secondary-views">
-   <b><a href="#xrprojectionlayer-depthstenciltextures-for-secondary-views">#xrprojectionlayer-depthstenciltextures-for-secondary-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrprojectionlayer-depthstenciltextures-for-secondary-views" class="dfn-panel" data-for="xrprojectionlayer-depthstenciltextures-for-secondary-views" id="infopanel-for-xrprojectionlayer-depthstenciltextures-for-secondary-views" role="dialog">
+   <span id="infopaneltitle-for-xrprojectionlayer-depthstenciltextures-for-secondary-views" style="display:none">Info about the 'depthStencilTextures for secondary views' definition.</span><b><a href="#xrprojectionlayer-depthstenciltextures-for-secondary-views">#xrprojectionlayer-depthstenciltextures-for-secondary-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrprojectionlayer-depthstenciltextures-for-secondary-views">6.9. XRWebGLBinding</a> <a href="#ref-for-xrprojectionlayer-depthstenciltextures-for-secondary-views①">(2)</a> <a href="#ref-for-xrprojectionlayer-depthstenciltextures-for-secondary-views②">(3)</a> <a href="#ref-for-xrprojectionlayer-depthstenciltextures-for-secondary-views③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-xrwebglbinding">
-   <b><a href="#dom-xrwebglbinding-xrwebglbinding">#dom-xrwebglbinding-xrwebglbinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-xrwebglbinding" class="dfn-panel" data-for="dom-xrwebglbinding-xrwebglbinding" id="infopanel-for-dom-xrwebglbinding-xrwebglbinding" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-xrwebglbinding" style="display:none">Info about the 'XRWebGLBinding(session, context)' definition.</span><b><a href="#dom-xrwebglbinding-xrwebglbinding">#dom-xrwebglbinding-xrwebglbinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-xrwebglbinding">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-layout-attribute">
-   <b><a href="#determine-the-layout-attribute">#determine-the-layout-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-layout-attribute" class="dfn-panel" data-for="determine-the-layout-attribute" id="infopanel-for-determine-the-layout-attribute" role="dialog">
+   <span id="infopaneltitle-for-determine-the-layout-attribute" style="display:none">Info about the 'determine the layout attribute' definition.</span><b><a href="#determine-the-layout-attribute">#determine-the-layout-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-layout-attribute">6.9. XRWebGLBinding</a> <a href="#ref-for-determine-the-layout-attribute①">(2)</a> <a href="#ref-for-determine-the-layout-attribute②">(3)</a> <a href="#ref-for-determine-the-layout-attribute③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-maximum-scalefactor">
-   <b><a href="#determine-the-maximum-scalefactor">#determine-the-maximum-scalefactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-maximum-scalefactor" class="dfn-panel" data-for="determine-the-maximum-scalefactor" id="infopanel-for-determine-the-maximum-scalefactor" role="dialog">
+   <span id="infopaneltitle-for-determine-the-maximum-scalefactor" style="display:none">Info about the 'determine the maximum scalefactor' definition.</span><b><a href="#determine-the-maximum-scalefactor">#determine-the-maximum-scalefactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-maximum-scalefactor">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-color-textures-for-projection-layers">
-   <b><a href="#allocate-color-textures-for-projection-layers">#allocate-color-textures-for-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-color-textures-for-projection-layers" class="dfn-panel" data-for="allocate-color-textures-for-projection-layers" id="infopanel-for-allocate-color-textures-for-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-allocate-color-textures-for-projection-layers" style="display:none">Info about the 'allocate color textures for projection layers' definition.</span><b><a href="#allocate-color-textures-for-projection-layers">#allocate-color-textures-for-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-color-textures-for-projection-layers">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-depth-textures-for-projection-layers">
-   <b><a href="#allocate-depth-textures-for-projection-layers">#allocate-depth-textures-for-projection-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-depth-textures-for-projection-layers" class="dfn-panel" data-for="allocate-depth-textures-for-projection-layers" id="infopanel-for-allocate-depth-textures-for-projection-layers" role="dialog">
+   <span id="infopaneltitle-for-allocate-depth-textures-for-projection-layers" style="display:none">Info about the 'allocate depth textures for projection layers' definition.</span><b><a href="#allocate-depth-textures-for-projection-layers">#allocate-depth-textures-for-projection-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-depth-textures-for-projection-layers">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-the-color-textures-for-the-secondary-views">
-   <b><a href="#allocate-the-color-textures-for-the-secondary-views">#allocate-the-color-textures-for-the-secondary-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-the-color-textures-for-the-secondary-views" class="dfn-panel" data-for="allocate-the-color-textures-for-the-secondary-views" id="infopanel-for-allocate-the-color-textures-for-the-secondary-views" role="dialog">
+   <span id="infopaneltitle-for-allocate-the-color-textures-for-the-secondary-views" style="display:none">Info about the 'allocate the color textures for the secondary views' definition.</span><b><a href="#allocate-the-color-textures-for-the-secondary-views">#allocate-the-color-textures-for-the-secondary-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-the-color-textures-for-the-secondary-views">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-the-depth-textures-for-the-secondary-views">
-   <b><a href="#allocate-the-depth-textures-for-the-secondary-views">#allocate-the-depth-textures-for-the-secondary-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-the-depth-textures-for-the-secondary-views" class="dfn-panel" data-for="allocate-the-depth-textures-for-the-secondary-views" id="infopanel-for-allocate-the-depth-textures-for-the-secondary-views" role="dialog">
+   <span id="infopaneltitle-for-allocate-the-depth-textures-for-the-secondary-views" style="display:none">Info about the 'allocate the depth textures for the secondary views' definition.</span><b><a href="#allocate-the-depth-textures-for-the-secondary-views">#allocate-the-depth-textures-for-the-secondary-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-the-depth-textures-for-the-secondary-views">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-color-textures">
-   <b><a href="#allocate-color-textures">#allocate-color-textures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-color-textures" class="dfn-panel" data-for="allocate-color-textures" id="infopanel-for-allocate-color-textures" role="dialog">
+   <span id="infopaneltitle-for-allocate-color-textures" style="display:none">Info about the 'allocate color textures' definition.</span><b><a href="#allocate-color-textures">#allocate-color-textures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-color-textures">6.2. Opaque textures</a>
     <li><a href="#ref-for-allocate-color-textures①">6.9. XRWebGLBinding</a> <a href="#ref-for-allocate-color-textures②">(2)</a> <a href="#ref-for-allocate-color-textures③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allocate-depth-textures">
-   <b><a href="#allocate-depth-textures">#allocate-depth-textures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allocate-depth-textures" class="dfn-panel" data-for="allocate-depth-textures" id="infopanel-for-allocate-depth-textures" role="dialog">
+   <span id="infopaneltitle-for-allocate-depth-textures" style="display:none">Info about the 'allocate depth textures' definition.</span><b><a href="#allocate-depth-textures">#allocate-depth-textures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allocate-depth-textures">6.2. Opaque textures</a>
     <li><a href="#ref-for-allocate-depth-textures①">6.9. XRWebGLBinding</a> <a href="#ref-for-allocate-depth-textures②">(2)</a> <a href="#ref-for-allocate-depth-textures③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-createprojectionlayer">
-   <b><a href="#dom-xrwebglbinding-createprojectionlayer">#dom-xrwebglbinding-createprojectionlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-createprojectionlayer" class="dfn-panel" data-for="dom-xrwebglbinding-createprojectionlayer" id="infopanel-for-dom-xrwebglbinding-createprojectionlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-createprojectionlayer" style="display:none">Info about the 'createProjectionLayer(optional XRProjectionLayerInit init)' definition.</span><b><a href="#dom-xrwebglbinding-createprojectionlayer">#dom-xrwebglbinding-createprojectionlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-createprojectionlayer">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-createquadlayer">
-   <b><a href="#dom-xrwebglbinding-createquadlayer">#dom-xrwebglbinding-createquadlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-createquadlayer" class="dfn-panel" data-for="dom-xrwebglbinding-createquadlayer" id="infopanel-for-dom-xrwebglbinding-createquadlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-createquadlayer" style="display:none">Info about the 'createQuadLayer(XRQuadLayerInit init)' definition.</span><b><a href="#dom-xrwebglbinding-createquadlayer">#dom-xrwebglbinding-createquadlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-createquadlayer">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-createcylinderlayer">
-   <b><a href="#dom-xrwebglbinding-createcylinderlayer">#dom-xrwebglbinding-createcylinderlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-createcylinderlayer" class="dfn-panel" data-for="dom-xrwebglbinding-createcylinderlayer" id="infopanel-for-dom-xrwebglbinding-createcylinderlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-createcylinderlayer" style="display:none">Info about the 'createCylinderLayer(XRCylinderLayerInit init)' definition.</span><b><a href="#dom-xrwebglbinding-createcylinderlayer">#dom-xrwebglbinding-createcylinderlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-createcylinderlayer">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-createequirectlayer">
-   <b><a href="#dom-xrwebglbinding-createequirectlayer">#dom-xrwebglbinding-createequirectlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-createequirectlayer" class="dfn-panel" data-for="dom-xrwebglbinding-createequirectlayer" id="infopanel-for-dom-xrwebglbinding-createequirectlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-createequirectlayer" style="display:none">Info about the 'createEquirectLayer(XREquirectLayerLayerInit init)' definition.</span><b><a href="#dom-xrwebglbinding-createequirectlayer">#dom-xrwebglbinding-createequirectlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-createequirectlayer">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-createcubelayer">
-   <b><a href="#dom-xrwebglbinding-createcubelayer">#dom-xrwebglbinding-createcubelayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-createcubelayer" class="dfn-panel" data-for="dom-xrwebglbinding-createcubelayer" id="infopanel-for-dom-xrwebglbinding-createcubelayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-createcubelayer" style="display:none">Info about the 'createCubeLayer(XRCubeLayerInit init)' definition.</span><b><a href="#dom-xrwebglbinding-createcubelayer">#dom-xrwebglbinding-createcubelayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-createcubelayer">6.9. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-the-state-of-the-xrwebglsubimage-creation-function">
-   <b><a href="#validate-the-state-of-the-xrwebglsubimage-creation-function">#validate-the-state-of-the-xrwebglsubimage-creation-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-the-state-of-the-xrwebglsubimage-creation-function" class="dfn-panel" data-for="validate-the-state-of-the-xrwebglsubimage-creation-function" id="infopanel-for-validate-the-state-of-the-xrwebglsubimage-creation-function" role="dialog">
+   <span id="infopaneltitle-for-validate-the-state-of-the-xrwebglsubimage-creation-function" style="display:none">Info about the 'validate the state of the XRWebGLSubImage creation function' definition.</span><b><a href="#validate-the-state-of-the-xrwebglsubimage-creation-function">#validate-the-state-of-the-xrwebglsubimage-creation-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-the-state-of-the-xrwebglsubimage-creation-function">6.9. XRWebGLBinding</a> <a href="#ref-for-validate-the-state-of-the-xrwebglsubimage-creation-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-the-viewport">
-   <b><a href="#initialize-the-viewport">#initialize-the-viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-the-viewport" class="dfn-panel" data-for="initialize-the-viewport" id="infopanel-for-initialize-the-viewport" role="dialog">
+   <span id="infopaneltitle-for-initialize-the-viewport" style="display:none">Info about the 'initialize the viewport' definition.</span><b><a href="#initialize-the-viewport">#initialize-the-viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-the-viewport">6.9. XRWebGLBinding</a> <a href="#ref-for-initialize-the-viewport①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-getsubimage">
-   <b><a href="#dom-xrwebglbinding-getsubimage">#dom-xrwebglbinding-getsubimage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-getsubimage" class="dfn-panel" data-for="dom-xrwebglbinding-getsubimage" id="infopanel-for-dom-xrwebglbinding-getsubimage" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-getsubimage" style="display:none">Info about the 'getSubImage(XRCompositionLayer layer, XRFrame frame, optional XREye eye = "none")' definition.</span><b><a href="#dom-xrwebglbinding-getsubimage">#dom-xrwebglbinding-getsubimage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-getsubimage">6.2. Opaque textures</a> <a href="#ref-for-dom-xrwebglbinding-getsubimage①">(2)</a>
     <li><a href="#ref-for-dom-xrwebglbinding-getsubimage②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglbinding-getsubimage③">(2)</a> <a href="#ref-for-dom-xrwebglbinding-getsubimage④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-getviewsubimage">
-   <b><a href="#dom-xrwebglbinding-getviewsubimage">#dom-xrwebglbinding-getviewsubimage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-getviewsubimage" class="dfn-panel" data-for="dom-xrwebglbinding-getviewsubimage" id="infopanel-for-dom-xrwebglbinding-getviewsubimage" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-getviewsubimage" style="display:none">Info about the 'getViewSubImage(XRProjectionLayer layer, XRView view)' definition.</span><b><a href="#dom-xrwebglbinding-getviewsubimage">#dom-xrwebglbinding-getviewsubimage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-getviewsubimage">6.2. Opaque textures</a> <a href="#ref-for-dom-xrwebglbinding-getviewsubimage①">(2)</a>
     <li><a href="#ref-for-dom-xrwebglbinding-getviewsubimage②">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrwebglbinding-getviewsubimage③">(2)</a> <a href="#ref-for-dom-xrwebglbinding-getviewsubimage④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmedialayerinit">
-   <b><a href="#dictdef-xrmedialayerinit">#dictdef-xrmedialayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmedialayerinit" class="dfn-panel" data-for="dictdef-xrmedialayerinit" id="infopanel-for-dictdef-xrmedialayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmedialayerinit" style="display:none">Info about the 'XRMediaLayerInit' definition.</span><b><a href="#dictdef-xrmedialayerinit">#dictdef-xrmedialayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmedialayerinit">7.1. XRMediaLayerInit</a>
     <li><a href="#ref-for-dictdef-xrmedialayerinit①">7.2. XRMediaQuadLayerInit</a>
@@ -5313,128 +5313,128 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dictdef-xrmedialayerinit③">7.4. XRMediaEquirectLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmedialayerinit-space">
-   <b><a href="#dom-xrmedialayerinit-space">#dom-xrmedialayerinit-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmedialayerinit-space" class="dfn-panel" data-for="dom-xrmedialayerinit-space" id="infopanel-for-dom-xrmedialayerinit-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmedialayerinit-space" style="display:none">Info about the 'space' definition.</span><b><a href="#dom-xrmedialayerinit-space">#dom-xrmedialayerinit-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmedialayerinit-space">7.1. XRMediaLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmedialayerinit-layout">
-   <b><a href="#dom-xrmedialayerinit-layout">#dom-xrmedialayerinit-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmedialayerinit-layout" class="dfn-panel" data-for="dom-xrmedialayerinit-layout" id="infopanel-for-dom-xrmedialayerinit-layout" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmedialayerinit-layout" style="display:none">Info about the 'layout' definition.</span><b><a href="#dom-xrmedialayerinit-layout">#dom-xrmedialayerinit-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmedialayerinit-layout">7.1. XRMediaLayerInit</a>
     <li><a href="#ref-for-dom-xrmedialayerinit-layout①">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrmedialayerinit-layout②">(2)</a> <a href="#ref-for-dom-xrmedialayerinit-layout③">(3)</a> <a href="#ref-for-dom-xrmedialayerinit-layout④">(4)</a> <a href="#ref-for-dom-xrmedialayerinit-layout⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmedialayerinit-invertstereo">
-   <b><a href="#dom-xrmedialayerinit-invertstereo">#dom-xrmedialayerinit-invertstereo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmedialayerinit-invertstereo" class="dfn-panel" data-for="dom-xrmedialayerinit-invertstereo" id="infopanel-for-dom-xrmedialayerinit-invertstereo" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmedialayerinit-invertstereo" style="display:none">Info about the 'invertStereo' definition.</span><b><a href="#dom-xrmedialayerinit-invertstereo">#dom-xrmedialayerinit-invertstereo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmedialayerinit-invertstereo">7.1. XRMediaLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmediaquadlayerinit">
-   <b><a href="#dictdef-xrmediaquadlayerinit">#dictdef-xrmediaquadlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmediaquadlayerinit" class="dfn-panel" data-for="dictdef-xrmediaquadlayerinit" id="infopanel-for-dictdef-xrmediaquadlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmediaquadlayerinit" style="display:none">Info about the 'XRMediaQuadLayerInit' definition.</span><b><a href="#dictdef-xrmediaquadlayerinit">#dictdef-xrmediaquadlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmediaquadlayerinit">7.2. XRMediaQuadLayerInit</a>
     <li><a href="#ref-for-dictdef-xrmediaquadlayerinit①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediaquadlayerinit-width">
-   <b><a href="#dom-xrmediaquadlayerinit-width">#dom-xrmediaquadlayerinit-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediaquadlayerinit-width" class="dfn-panel" data-for="dom-xrmediaquadlayerinit-width" id="infopanel-for-dom-xrmediaquadlayerinit-width" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediaquadlayerinit-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-xrmediaquadlayerinit-width">#dom-xrmediaquadlayerinit-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediaquadlayerinit-width">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrmediaquadlayerinit-width①">(2)</a> <a href="#ref-for-dom-xrmediaquadlayerinit-width②">(3)</a> <a href="#ref-for-dom-xrmediaquadlayerinit-width③">(4)</a> <a href="#ref-for-dom-xrmediaquadlayerinit-width④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediaquadlayerinit-height">
-   <b><a href="#dom-xrmediaquadlayerinit-height">#dom-xrmediaquadlayerinit-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediaquadlayerinit-height" class="dfn-panel" data-for="dom-xrmediaquadlayerinit-height" id="infopanel-for-dom-xrmediaquadlayerinit-height" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediaquadlayerinit-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-xrmediaquadlayerinit-height">#dom-xrmediaquadlayerinit-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediaquadlayerinit-height">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrmediaquadlayerinit-height①">(2)</a> <a href="#ref-for-dom-xrmediaquadlayerinit-height②">(3)</a> <a href="#ref-for-dom-xrmediaquadlayerinit-height③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmediacylinderlayerinit">
-   <b><a href="#dictdef-xrmediacylinderlayerinit">#dictdef-xrmediacylinderlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmediacylinderlayerinit" class="dfn-panel" data-for="dictdef-xrmediacylinderlayerinit" id="infopanel-for-dictdef-xrmediacylinderlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmediacylinderlayerinit" style="display:none">Info about the 'XRMediaCylinderLayerInit' definition.</span><b><a href="#dictdef-xrmediacylinderlayerinit">#dictdef-xrmediacylinderlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmediacylinderlayerinit">7.3. XRMediaCylinderLayerInit</a>
     <li><a href="#ref-for-dictdef-xrmediacylinderlayerinit①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediacylinderlayerinit-aspectratio">
-   <b><a href="#dom-xrmediacylinderlayerinit-aspectratio">#dom-xrmediacylinderlayerinit-aspectratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediacylinderlayerinit-aspectratio" class="dfn-panel" data-for="dom-xrmediacylinderlayerinit-aspectratio" id="infopanel-for-dom-xrmediacylinderlayerinit-aspectratio" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediacylinderlayerinit-aspectratio" style="display:none">Info about the 'aspectRatio' definition.</span><b><a href="#dom-xrmediacylinderlayerinit-aspectratio">#dom-xrmediacylinderlayerinit-aspectratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediacylinderlayerinit-aspectratio">7.5. XRMediaBinding</a> <a href="#ref-for-dom-xrmediacylinderlayerinit-aspectratio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmediaequirectlayerinit">
-   <b><a href="#dictdef-xrmediaequirectlayerinit">#dictdef-xrmediaequirectlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmediaequirectlayerinit" class="dfn-panel" data-for="dictdef-xrmediaequirectlayerinit" id="infopanel-for-dictdef-xrmediaequirectlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmediaequirectlayerinit" style="display:none">Info about the 'XRMediaEquirectLayerInit' definition.</span><b><a href="#dictdef-xrmediaequirectlayerinit">#dictdef-xrmediaequirectlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmediaequirectlayerinit">7.4. XRMediaEquirectLayerInit</a>
     <li><a href="#ref-for-dictdef-xrmediaequirectlayerinit①">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrmediabinding">
-   <b><a href="#xrmediabinding">#xrmediabinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrmediabinding" class="dfn-panel" data-for="xrmediabinding" id="infopanel-for-xrmediabinding" role="dialog">
+   <span id="infopaneltitle-for-xrmediabinding" style="display:none">Info about the 'XRMediaBinding' definition.</span><b><a href="#xrmediabinding">#xrmediabinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrmediabinding">1.2. Application flow</a>
     <li><a href="#ref-for-xrmediabinding①">7.5. XRMediaBinding</a> <a href="#ref-for-xrmediabinding②">(2)</a> <a href="#ref-for-xrmediabinding③">(3)</a> <a href="#ref-for-xrmediabinding④">(4)</a> <a href="#ref-for-xrmediabinding⑤">(5)</a> <a href="#ref-for-xrmediabinding⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrmediabinding-session">
-   <b><a href="#xrmediabinding-session">#xrmediabinding-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrmediabinding-session" class="dfn-panel" data-for="xrmediabinding-session" id="infopanel-for-xrmediabinding-session" role="dialog">
+   <span id="infopaneltitle-for-xrmediabinding-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrmediabinding-session">#xrmediabinding-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrmediabinding-session">7.5. XRMediaBinding</a> <a href="#ref-for-xrmediabinding-session①">(2)</a> <a href="#ref-for-xrmediabinding-session②">(3)</a> <a href="#ref-for-xrmediabinding-session③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediabinding-xrmediabinding">
-   <b><a href="#dom-xrmediabinding-xrmediabinding">#dom-xrmediabinding-xrmediabinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediabinding-xrmediabinding" class="dfn-panel" data-for="dom-xrmediabinding-xrmediabinding" id="infopanel-for-dom-xrmediabinding-xrmediabinding" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediabinding-xrmediabinding" style="display:none">Info about the 'XRMediaBinding(XRSession session)' definition.</span><b><a href="#dom-xrmediabinding-xrmediabinding">#dom-xrmediabinding-xrmediabinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediabinding-xrmediabinding">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-the-aspect-ratio">
-   <b><a href="#calculate-the-aspect-ratio">#calculate-the-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculate-the-aspect-ratio" class="dfn-panel" data-for="calculate-the-aspect-ratio" id="infopanel-for-calculate-the-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-calculate-the-aspect-ratio" style="display:none">Info about the 'calculate the aspect ratio' definition.</span><b><a href="#calculate-the-aspect-ratio">#calculate-the-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-the-aspect-ratio">7.5. XRMediaBinding</a> <a href="#ref-for-calculate-the-aspect-ratio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediabinding-createquadlayer">
-   <b><a href="#dom-xrmediabinding-createquadlayer">#dom-xrmediabinding-createquadlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediabinding-createquadlayer" class="dfn-panel" data-for="dom-xrmediabinding-createquadlayer" id="infopanel-for-dom-xrmediabinding-createquadlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediabinding-createquadlayer" style="display:none">Info about the 'createQuadLayer(HTMLVideoElement video, XRMediaQuadLayerInit init)' definition.</span><b><a href="#dom-xrmediabinding-createquadlayer">#dom-xrmediabinding-createquadlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediabinding-createquadlayer">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediabinding-createcylinderlayer">
-   <b><a href="#dom-xrmediabinding-createcylinderlayer">#dom-xrmediabinding-createcylinderlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediabinding-createcylinderlayer" class="dfn-panel" data-for="dom-xrmediabinding-createcylinderlayer" id="infopanel-for-dom-xrmediabinding-createcylinderlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediabinding-createcylinderlayer" style="display:none">Info about the 'createCylinderLayer(HTMLVideoElement video, XRMediaCylinderLayerInit init)' definition.</span><b><a href="#dom-xrmediabinding-createcylinderlayer">#dom-xrmediabinding-createcylinderlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediabinding-createcylinderlayer">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmediabinding-createequirectlayer">
-   <b><a href="#dom-xrmediabinding-createequirectlayer">#dom-xrmediabinding-createequirectlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmediabinding-createequirectlayer" class="dfn-panel" data-for="dom-xrmediabinding-createequirectlayer" id="infopanel-for-dom-xrmediabinding-createequirectlayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmediabinding-createequirectlayer" style="display:none">Info about the 'createEquirectLayer(HTMLVideoElement video, XRMediaEquirectLayerInit init)' definition.</span><b><a href="#dom-xrmediabinding-createequirectlayer">#dom-xrmediabinding-createequirectlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmediabinding-createequirectlayer">7.5. XRMediaBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrlayerevent">
-   <b><a href="#xrlayerevent">#xrlayerevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlayerevent" class="dfn-panel" data-for="xrlayerevent" id="infopanel-for-xrlayerevent" role="dialog">
+   <span id="infopaneltitle-for-xrlayerevent" style="display:none">Info about the 'XRLayerEvent' definition.</span><b><a href="#xrlayerevent">#xrlayerevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlayerevent">8.1. XRLayerEvent</a>
     <li><a href="#ref-for-xrlayerevent①">8.2. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrlayereventinit">
-   <b><a href="#dictdef-xrlayereventinit">#dictdef-xrlayereventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrlayereventinit" class="dfn-panel" data-for="dictdef-xrlayereventinit" id="infopanel-for-dictdef-xrlayereventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrlayereventinit" style="display:none">Info about the 'XRLayerEventInit' definition.</span><b><a href="#dictdef-xrlayereventinit">#dictdef-xrlayereventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrlayereventinit">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlayerevent-layer">
-   <b><a href="#dom-xrlayerevent-layer">#dom-xrlayerevent-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlayerevent-layer" class="dfn-panel" data-for="dom-xrlayerevent-layer" id="infopanel-for-dom-xrlayerevent-layer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlayerevent-layer" style="display:none">Info about the 'layer' definition.</span><b><a href="#dom-xrlayerevent-layer">#dom-xrlayerevent-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlayerevent-layer">8.1. XRLayerEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrlayer-redraw">
-   <b><a href="#eventdef-xrlayer-redraw">#eventdef-xrlayer-redraw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrlayer-redraw" class="dfn-panel" data-for="eventdef-xrlayer-redraw" id="infopanel-for-eventdef-xrlayer-redraw" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrlayer-redraw" style="display:none">Info about the 'redraw' definition.</span><b><a href="#eventdef-xrlayer-redraw">#eventdef-xrlayer-redraw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrlayer-redraw">3.3. XRCompositionLayer</a>
     <li><a href="#ref-for-eventdef-xrlayer-redraw①">3.5. XRQuadLayer</a>
@@ -5443,8 +5443,8 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-eventdef-xrlayer-redraw④">3.8. XRCubeLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstate-layers">
-   <b><a href="#dom-xrrenderstate-layers">#dom-xrrenderstate-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstate-layers" class="dfn-panel" data-for="dom-xrrenderstate-layers" id="infopanel-for-dom-xrrenderstate-layers" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstate-layers" style="display:none">Info about the 'layers' definition.</span><b><a href="#dom-xrrenderstate-layers">#dom-xrrenderstate-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-layers">6.9. XRWebGLBinding</a> <a href="#ref-for-dom-xrrenderstate-layers①">(2)</a> <a href="#ref-for-dom-xrrenderstate-layers②">(3)</a> <a href="#ref-for-dom-xrrenderstate-layers③">(4)</a>
     <li><a href="#ref-for-dom-xrrenderstate-layers④">9.1. XRRenderState changes</a> <a href="#ref-for-dom-xrrenderstate-layers⑤">(2)</a>
@@ -5452,79 +5452,135 @@ Moreover, content in a layer MUST not be observable in other layers.</p>
     <li><a href="#ref-for-dom-xrrenderstate-layers⑧">9.3. XRCompositor changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layers-initialize-the-render-state">
-   <b><a href="#layers-initialize-the-render-state">#layers-initialize-the-render-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layers-initialize-the-render-state" class="dfn-panel" data-for="layers-initialize-the-render-state" id="infopanel-for-layers-initialize-the-render-state" role="dialog">
+   <span id="infopaneltitle-for-layers-initialize-the-render-state" style="display:none">Info about the 'initialize the render state' definition.</span><b><a href="#layers-initialize-the-render-state">#layers-initialize-the-render-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layers-initialize-the-render-state">9.1. XRRenderState changes</a> <a href="#ref-for-layers-initialize-the-render-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layers-update-the-pending-layers-state">
-   <b><a href="#layers-update-the-pending-layers-state">#layers-update-the-pending-layers-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layers-update-the-pending-layers-state" class="dfn-panel" data-for="layers-update-the-pending-layers-state" id="infopanel-for-layers-update-the-pending-layers-state" role="dialog">
+   <span id="infopaneltitle-for-layers-update-the-pending-layers-state" style="display:none">Info about the 'update the pending layers state' definition.</span><b><a href="#layers-update-the-pending-layers-state">#layers-update-the-pending-layers-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layers-update-the-pending-layers-state">9.2. updateRenderState changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-the-layers-state">
-   <b><a href="#check-the-layers-state">#check-the-layers-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-the-layers-state" class="dfn-panel" data-for="check-the-layers-state" id="infopanel-for-check-the-layers-state" role="dialog">
+   <span id="infopaneltitle-for-check-the-layers-state" style="display:none">Info about the 'check the layers state' definition.</span><b><a href="#check-the-layers-state">#check-the-layers-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-layers-state">9.5. Animation frames changes</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/lighting-estimation/index.html
+++ b/tests/github/immersive-web/lighting-estimation/index.html
@@ -1020,235 +1020,235 @@ consider.</p>
    <li><a href="#dictdef-xrlightprobeinit">XRLightProbeInit</a><span>, in § 3.2</span>
    <li><a href="#enumdef-xrreflectionformat">XRReflectionFormat</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-security-and-privacy">
-   <a href="https://www.w3.org/TR/ambient-light/#security-and-privacy">https://www.w3.org/TR/ambient-light/#security-and-privacy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-security-and-privacy" class="dfn-panel" data-for="term-for-security-and-privacy" id="infopanel-for-term-for-security-and-privacy" role="menu">
+   <span id="infopaneltitle-for-term-for-security-and-privacy" style="display:none">Info about the 'privacy and security risks' external reference.</span><a href="https://www.w3.org/TR/ambient-light/#security-and-privacy">https://www.w3.org/TR/ambient-light/#security-and-privacy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-and-privacy">6. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.1. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2.1. XRLightProbe</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">2.3. XRLightEstimate</a> <a href="#ref-for-dompointreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-w">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-w" class="dfn-panel" data-for="term-for-dom-dompointreadonly-w" id="infopanel-for-term-for-dom-dompointreadonly-w" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-w" style="display:none">Info about the 'w' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-w">2.3. XRLightEstimate</a> <a href="#ref-for-dom-dompointreadonly-w①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-x" class="dfn-panel" data-for="term-for-dom-dompointreadonly-x" id="infopanel-for-term-for-dom-dompointreadonly-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-x" style="display:none">Info about the 'x' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-x">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-y" class="dfn-panel" data-for="term-for-dom-dompointreadonly-y" id="infopanel-for-term-for-dom-dompointreadonly-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-y" style="display:none">Info about the 'y' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-y">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-z">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-z" class="dfn-panel" data-for="term-for-dom-dompointreadonly-z" id="infopanel-for-term-for-dom-dompointreadonly-z" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-z" style="display:none">Info about the 'z' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-z">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">2.1. XRLightProbe</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">2.1. XRLightProbe</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLTexture">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLTexture" class="dfn-panel" data-for="term-for-WebGLTexture" id="infopanel-for-term-for-WebGLTexture" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLTexture" style="display:none">Info about the 'WebGLTexture' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLTexture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLTexture">4.1. XRWebGLBinding</a> <a href="#ref-for-WebGLTexture①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. XRLightProbe</a>
     <li><a href="#ref-for-Exposed①">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">2.3. XRLightEstimate</a> <a href="#ref-for-idl-Float32Array①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2. XRSession</a>
     <li><a href="#ref-for-invalidstateerror①">3.3. XRFrame</a> <a href="#ref-for-invalidstateerror②">(2)</a>
     <li><a href="#ref-for-invalidstateerror③">4.1. XRWebGLBinding</a> <a href="#ref-for-invalidstateerror④">(2)</a> <a href="#ref-for-invalidstateerror⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.2. XRSession</a> <a href="#ref-for-notsupportederror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.1. XRLightProbe</a>
     <li><a href="#ref-for-SecureContext①">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2. XRSession</a> <a href="#ref-for-reject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">2.1. XRLightProbe</a> <a href="#ref-for-xrspace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">3.3. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-interface" class="dfn-panel" data-for="term-for-xrframe-interface" id="infopanel-for-term-for-xrframe-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-interface" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-interface">https://www.w3.org/TR/webxr/#xrframe-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-interface">2.3. XRLightEstimate</a> <a href="#ref-for-xrframe-interface①">(2)</a>
     <li><a href="#ref-for-xrframe-interface②">3. WebXR Device API Integration</a>
     <li><a href="#ref-for-xrframe-interface③">3.3. XRFrame</a> <a href="#ref-for-xrframe-interface④">(2)</a> <a href="#ref-for-xrframe-interface⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-interface">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-interface" class="dfn-panel" data-for="term-for-xrsession-interface" id="infopanel-for-term-for-xrsession-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-interface" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-interface">https://www.w3.org/TR/webxr/#xrsession-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-interface">3. WebXR Device API Integration</a>
     <li><a href="#ref-for-xrsession-interface①">3.2. XRSession</a> <a href="#ref-for-xrsession-interface②">(2)</a> <a href="#ref-for-xrsession-interface③">(3)</a> <a href="#ref-for-xrsession-interface④">(4)</a> <a href="#ref-for-xrsession-interface⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-active">https://www.w3.org/TR/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">3.3. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ended">
-   <a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ended" class="dfn-panel" data-for="term-for-ended" id="infopanel-for-term-for-ended" role="menu">
+   <span id="infopaneltitle-for-term-for-ended" style="display:none">Info about the 'ended' external reference.</span><a href="https://www.w3.org/TR/webxr/#ended">https://www.w3.org/TR/webxr/#ended</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ended">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-enabled-features">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features">https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-enabled-features" class="dfn-panel" data-for="term-for-xrsession-list-of-enabled-features" id="infopanel-for-term-for-xrsession-list-of-enabled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-enabled-features" style="display:none">Info about the 'list of enabled features' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features">https://www.w3.org/TR/webxr/#xrsession-list-of-enabled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-enabled-features">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-native-origin">
-   <a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-native-origin" class="dfn-panel" data-for="term-for-xrspace-native-origin" id="infopanel-for-term-for-xrspace-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrspace-native-origin">https://www.w3.org/TR/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-native-origin">2.1. XRLightProbe</a>
     <li><a href="#ref-for-xrspace-native-origin①">2.3. XRLightEstimate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-xr-device" class="dfn-panel" data-for="term-for-xrsession-xr-device" id="infopanel-for-term-for-xrsession-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-xr-device">https://www.w3.org/TR/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">3.2. XRSession</a>
     <li><a href="#ref-for-xrsession-xr-device①">3.3. XRFrame</a>
     <li><a href="#ref-for-xrsession-xr-device②">4.1. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-task-source">
-   <a href="https://www.w3.org/TR/webxr/#xr-task-source">https://www.w3.org/TR/webxr/#xr-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-task-source" class="dfn-panel" data-for="term-for-xr-task-source" id="infopanel-for-term-for-xr-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-task-source" style="display:none">Info about the 'xr task source' external reference.</span><a href="https://www.w3.org/TR/webxr/#xr-task-source">https://www.w3.org/TR/webxr/#xr-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-task-source">5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebglbinding">
-   <a href="https://immersive-web.github.io/layers/#xrwebglbinding">https://immersive-web.github.io/layers/#xrwebglbinding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebglbinding" class="dfn-panel" data-for="term-for-xrwebglbinding" id="infopanel-for-term-for-xrwebglbinding" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebglbinding" style="display:none">Info about the 'XRWebGLBinding' external reference.</span><a href="https://immersive-web.github.io/layers/#xrwebglbinding">https://immersive-web.github.io/layers/#xrwebglbinding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding">4. WebXR Layers Integration</a>
     <li><a href="#ref-for-xrwebglbinding①">4.1. XRWebGLBinding</a> <a href="#ref-for-xrwebglbinding②">(2)</a> <a href="#ref-for-xrwebglbinding③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrwebglbinding-context">
-   <a href="https://immersive-web.github.io/layers/#xrwebglbinding-context">https://immersive-web.github.io/layers/#xrwebglbinding-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrwebglbinding-context" class="dfn-panel" data-for="term-for-xrwebglbinding-context" id="infopanel-for-term-for-xrwebglbinding-context" role="menu">
+   <span id="infopaneltitle-for-term-for-xrwebglbinding-context" style="display:none">Info about the 'context' external reference.</span><a href="https://immersive-web.github.io/layers/#xrwebglbinding-context">https://immersive-web.github.io/layers/#xrwebglbinding-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebglbinding-context">4.1. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session">
-   <a href="https://immersive-web.github.io/layers/#session">https://immersive-web.github.io/layers/#session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session" class="dfn-panel" data-for="term-for-session" id="infopanel-for-term-for-session" role="menu">
+   <span id="infopaneltitle-for-term-for-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/layers/#session">https://immersive-web.github.io/layers/#session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session">4.1. XRWebGLBinding</a>
    </ul>
@@ -1392,8 +1392,8 @@ consider.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="xrlightprobe">
-   <b><a href="#xrlightprobe">#xrlightprobe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlightprobe" class="dfn-panel" data-for="xrlightprobe" id="infopanel-for-xrlightprobe" role="dialog">
+   <span id="infopaneltitle-for-xrlightprobe" style="display:none">Info about the 'XRLightProbe' definition.</span><b><a href="#xrlightprobe">#xrlightprobe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlightprobe">2.1. XRLightProbe</a> <a href="#ref-for-xrlightprobe①">(2)</a>
     <li><a href="#ref-for-xrlightprobe②">2.3. XRLightEstimate</a> <a href="#ref-for-xrlightprobe③">(2)</a> <a href="#ref-for-xrlightprobe④">(3)</a> <a href="#ref-for-xrlightprobe⑤">(4)</a>
@@ -1403,189 +1403,245 @@ consider.</p>
     <li><a href="#ref-for-xrlightprobe①⑤">5.1. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightprobe-probespace">
-   <b><a href="#dom-xrlightprobe-probespace">#dom-xrlightprobe-probespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightprobe-probespace" class="dfn-panel" data-for="dom-xrlightprobe-probespace" id="infopanel-for-dom-xrlightprobe-probespace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightprobe-probespace" style="display:none">Info about the 'probeSpace' definition.</span><b><a href="#dom-xrlightprobe-probespace">#dom-xrlightprobe-probespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightprobe-probespace">2.1. XRLightProbe</a>
     <li><a href="#ref-for-dom-xrlightprobe-probespace①">2.3. XRLightEstimate</a> <a href="#ref-for-dom-xrlightprobe-probespace②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightprobe-onreflectionchange">
-   <b><a href="#dom-xrlightprobe-onreflectionchange">#dom-xrlightprobe-onreflectionchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightprobe-onreflectionchange" class="dfn-panel" data-for="dom-xrlightprobe-onreflectionchange" id="infopanel-for-dom-xrlightprobe-onreflectionchange" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightprobe-onreflectionchange" style="display:none">Info about the 'onreflectionchange' definition.</span><b><a href="#dom-xrlightprobe-onreflectionchange">#dom-xrlightprobe-onreflectionchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightprobe-onreflectionchange">2.1. XRLightProbe</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrreflectionformat">
-   <b><a href="#enumdef-xrreflectionformat">#enumdef-xrreflectionformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrreflectionformat" class="dfn-panel" data-for="enumdef-xrreflectionformat" id="infopanel-for-enumdef-xrreflectionformat" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrreflectionformat" style="display:none">Info about the 'XRReflectionFormat' definition.</span><b><a href="#enumdef-xrreflectionformat">#enumdef-xrreflectionformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrreflectionformat">2.2. XRReflectionFormat</a>
     <li><a href="#ref-for-enumdef-xrreflectionformat①">3.2. XRSession</a> <a href="#ref-for-enumdef-xrreflectionformat②">(2)</a> <a href="#ref-for-enumdef-xrreflectionformat③">(3)</a> <a href="#ref-for-enumdef-xrreflectionformat④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreflectionformat-srgba8">
-   <b><a href="#dom-xrreflectionformat-srgba8">#dom-xrreflectionformat-srgba8</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreflectionformat-srgba8" class="dfn-panel" data-for="dom-xrreflectionformat-srgba8" id="infopanel-for-dom-xrreflectionformat-srgba8" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreflectionformat-srgba8" style="display:none">Info about the '"srgba8"' definition.</span><b><a href="#dom-xrreflectionformat-srgba8">#dom-xrreflectionformat-srgba8</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreflectionformat-srgba8">2.2. XRReflectionFormat</a> <a href="#ref-for-dom-xrreflectionformat-srgba8①">(2)</a>
     <li><a href="#ref-for-dom-xrreflectionformat-srgba8②">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreflectionformat-rgba16f">
-   <b><a href="#dom-xrreflectionformat-rgba16f">#dom-xrreflectionformat-rgba16f</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreflectionformat-rgba16f" class="dfn-panel" data-for="dom-xrreflectionformat-rgba16f" id="infopanel-for-dom-xrreflectionformat-rgba16f" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreflectionformat-rgba16f" style="display:none">Info about the '"rgba16f"' definition.</span><b><a href="#dom-xrreflectionformat-rgba16f">#dom-xrreflectionformat-rgba16f</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreflectionformat-rgba16f">2.2. XRReflectionFormat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrlightestimate">
-   <b><a href="#xrlightestimate">#xrlightestimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlightestimate" class="dfn-panel" data-for="xrlightestimate" id="infopanel-for-xrlightestimate" role="dialog">
+   <span id="infopaneltitle-for-xrlightestimate" style="display:none">Info about the 'XRLightEstimate' definition.</span><b><a href="#xrlightestimate">#xrlightestimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlightestimate">2.3. XRLightEstimate</a> <a href="#ref-for-xrlightestimate①">(2)</a> <a href="#ref-for-xrlightestimate②">(3)</a> <a href="#ref-for-xrlightestimate③">(4)</a>
     <li><a href="#ref-for-xrlightestimate④">3.3. XRFrame</a> <a href="#ref-for-xrlightestimate⑤">(2)</a> <a href="#ref-for-xrlightestimate⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightestimate-sphericalharmonicscoefficients">
-   <b><a href="#dom-xrlightestimate-sphericalharmonicscoefficients">#dom-xrlightestimate-sphericalharmonicscoefficients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightestimate-sphericalharmonicscoefficients" class="dfn-panel" data-for="dom-xrlightestimate-sphericalharmonicscoefficients" id="infopanel-for-dom-xrlightestimate-sphericalharmonicscoefficients" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightestimate-sphericalharmonicscoefficients" style="display:none">Info about the 'sphericalHarmonicsCoefficients' definition.</span><b><a href="#dom-xrlightestimate-sphericalharmonicscoefficients">#dom-xrlightestimate-sphericalharmonicscoefficients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightestimate-sphericalharmonicscoefficients">2.3. XRLightEstimate</a> <a href="#ref-for-dom-xrlightestimate-sphericalharmonicscoefficients①">(2)</a> <a href="#ref-for-dom-xrlightestimate-sphericalharmonicscoefficients②">(3)</a>
     <li><a href="#ref-for-dom-xrlightestimate-sphericalharmonicscoefficients③">3.3. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightestimate-primarylightdirection">
-   <b><a href="#dom-xrlightestimate-primarylightdirection">#dom-xrlightestimate-primarylightdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightestimate-primarylightdirection" class="dfn-panel" data-for="dom-xrlightestimate-primarylightdirection" id="infopanel-for-dom-xrlightestimate-primarylightdirection" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightestimate-primarylightdirection" style="display:none">Info about the 'primaryLightDirection' definition.</span><b><a href="#dom-xrlightestimate-primarylightdirection">#dom-xrlightestimate-primarylightdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightestimate-primarylightdirection">2.3. XRLightEstimate</a> <a href="#ref-for-dom-xrlightestimate-primarylightdirection①">(2)</a>
     <li><a href="#ref-for-dom-xrlightestimate-primarylightdirection②">3.3. XRFrame</a> <a href="#ref-for-dom-xrlightestimate-primarylightdirection③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightestimate-primarylightintensity">
-   <b><a href="#dom-xrlightestimate-primarylightintensity">#dom-xrlightestimate-primarylightintensity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightestimate-primarylightintensity" class="dfn-panel" data-for="dom-xrlightestimate-primarylightintensity" id="infopanel-for-dom-xrlightestimate-primarylightintensity" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightestimate-primarylightintensity" style="display:none">Info about the 'primaryLightIntensity' definition.</span><b><a href="#dom-xrlightestimate-primarylightintensity">#dom-xrlightestimate-primarylightintensity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightestimate-primarylightintensity">2.3. XRLightEstimate</a> <a href="#ref-for-dom-xrlightestimate-primarylightintensity①">(2)</a>
     <li><a href="#ref-for-dom-xrlightestimate-primarylightintensity②">3.3. XRFrame</a> <a href="#ref-for-dom-xrlightestimate-primarylightintensity③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-descriptor-light-estimation">
-   <b><a href="#feature-descriptor-light-estimation">#feature-descriptor-light-estimation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-descriptor-light-estimation" class="dfn-panel" data-for="feature-descriptor-light-estimation" id="infopanel-for-feature-descriptor-light-estimation" role="dialog">
+   <span id="infopaneltitle-for-feature-descriptor-light-estimation" style="display:none">Info about the 'light-estimation' definition.</span><b><a href="#feature-descriptor-light-estimation">#feature-descriptor-light-estimation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor-light-estimation">3.1. Session Initialization</a>
     <li><a href="#ref-for-feature-descriptor-light-estimation①">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrlightprobe-session">
-   <b><a href="#xrlightprobe-session">#xrlightprobe-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlightprobe-session" class="dfn-panel" data-for="xrlightprobe-session" id="infopanel-for-xrlightprobe-session" role="dialog">
+   <span id="infopaneltitle-for-xrlightprobe-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrlightprobe-session">#xrlightprobe-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlightprobe-session">3.2. XRSession</a>
     <li><a href="#ref-for-xrlightprobe-session①">3.3. XRFrame</a>
     <li><a href="#ref-for-xrlightprobe-session②">4.1. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrlightprobe-reflection-format">
-   <b><a href="#xrlightprobe-reflection-format">#xrlightprobe-reflection-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlightprobe-reflection-format" class="dfn-panel" data-for="xrlightprobe-reflection-format" id="infopanel-for-xrlightprobe-reflection-format" role="dialog">
+   <span id="infopaneltitle-for-xrlightprobe-reflection-format" style="display:none">Info about the 'reflection format' definition.</span><b><a href="#xrlightprobe-reflection-format">#xrlightprobe-reflection-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlightprobe-reflection-format">3.2. XRSession</a>
     <li><a href="#ref-for-xrlightprobe-reflection-format①">4.1. XRWebGLBinding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrlightprobeinit">
-   <b><a href="#dictdef-xrlightprobeinit">#dictdef-xrlightprobeinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrlightprobeinit" class="dfn-panel" data-for="dictdef-xrlightprobeinit" id="infopanel-for-dictdef-xrlightprobeinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrlightprobeinit" style="display:none">Info about the 'XRLightProbeInit' definition.</span><b><a href="#dictdef-xrlightprobeinit">#dictdef-xrlightprobeinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrlightprobeinit">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrlightprobeinit-reflectionformat">
-   <b><a href="#dom-xrlightprobeinit-reflectionformat">#dom-xrlightprobeinit-reflectionformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrlightprobeinit-reflectionformat" class="dfn-panel" data-for="dom-xrlightprobeinit-reflectionformat" id="infopanel-for-dom-xrlightprobeinit-reflectionformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrlightprobeinit-reflectionformat" style="display:none">Info about the 'reflectionFormat' definition.</span><b><a href="#dom-xrlightprobeinit-reflectionformat">#dom-xrlightprobeinit-reflectionformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrlightprobeinit-reflectionformat">3.2. XRSession</a> <a href="#ref-for-dom-xrlightprobeinit-reflectionformat①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-preferredreflectionformat">
-   <b><a href="#dom-xrsession-preferredreflectionformat">#dom-xrsession-preferredreflectionformat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-preferredreflectionformat" class="dfn-panel" data-for="dom-xrsession-preferredreflectionformat" id="infopanel-for-dom-xrsession-preferredreflectionformat" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-preferredreflectionformat" style="display:none">Info about the 'preferredReflectionFormat' definition.</span><b><a href="#dom-xrsession-preferredreflectionformat">#dom-xrsession-preferredreflectionformat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-preferredreflectionformat">2.2. XRReflectionFormat</a>
     <li><a href="#ref-for-dom-xrsession-preferredreflectionformat①">3.2. XRSession</a> <a href="#ref-for-dom-xrsession-preferredreflectionformat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-requestlightprobe">
-   <b><a href="#dom-xrsession-requestlightprobe">#dom-xrsession-requestlightprobe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-requestlightprobe" class="dfn-panel" data-for="dom-xrsession-requestlightprobe" id="infopanel-for-dom-xrsession-requestlightprobe" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-requestlightprobe" style="display:none">Info about the 'requestLightProbe(options)' definition.</span><b><a href="#dom-xrsession-requestlightprobe">#dom-xrsession-requestlightprobe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestlightprobe">3.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-getlightestimate">
-   <b><a href="#dom-xrframe-getlightestimate">#dom-xrframe-getlightestimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-getlightestimate" class="dfn-panel" data-for="dom-xrframe-getlightestimate" id="infopanel-for-dom-xrframe-getlightestimate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-getlightestimate" style="display:none">Info about the 'getLightEstimate(lightProbe)' definition.</span><b><a href="#dom-xrframe-getlightestimate">#dom-xrframe-getlightestimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getlightestimate">2.3. XRLightEstimate</a>
     <li><a href="#ref-for-dom-xrframe-getlightestimate①">3.3. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebglbinding-getreflectioncubemap">
-   <b><a href="#dom-xrwebglbinding-getreflectioncubemap">#dom-xrwebglbinding-getreflectioncubemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebglbinding-getreflectioncubemap" class="dfn-panel" data-for="dom-xrwebglbinding-getreflectioncubemap" id="infopanel-for-dom-xrwebglbinding-getreflectioncubemap" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebglbinding-getreflectioncubemap" style="display:none">Info about the 'getReflectionCubeMap(lightProbe)' definition.</span><b><a href="#dom-xrwebglbinding-getreflectioncubemap">#dom-xrwebglbinding-getreflectioncubemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebglbinding-getreflectioncubemap">4.1. XRWebGLBinding</a>
     <li><a href="#ref-for-dom-xrwebglbinding-getreflectioncubemap①">5.1. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrlightprobe-reflectionchange">
-   <b><a href="#eventdef-xrlightprobe-reflectionchange">#eventdef-xrlightprobe-reflectionchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrlightprobe-reflectionchange" class="dfn-panel" data-for="eventdef-xrlightprobe-reflectionchange" id="infopanel-for-eventdef-xrlightprobe-reflectionchange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrlightprobe-reflectionchange" style="display:none">Info about the 'reflectionchange' definition.</span><b><a href="#eventdef-xrlightprobe-reflectionchange">#eventdef-xrlightprobe-reflectionchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrlightprobe-reflectionchange">2.1. XRLightProbe</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/real-world-geometry/plane-detection.html
+++ b/tests/github/immersive-web/real-world-geometry/plane-detection.html
@@ -974,133 +974,133 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#enumdef-xrplaneorientation">XRPlaneOrientation</a><span>, in § 3.1</span>
    <li><a href="#xrplaneset">XRPlaneSet</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">4.1. XRPlaneSet</a> <a href="#ref-for-xrframe①">(2)</a> <a href="#ref-for-xrframe②">(3)</a> <a href="#ref-for-xrframe③">(4)</a> <a href="#ref-for-xrframe④">(5)</a>
     <li><a href="#ref-for-xrframe⑤">5.1. Native plane detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">3.2. XRPlane</a> <a href="#ref-for-xrspace①">(2)</a> <a href="#ref-for-xrspace②">(3)</a>
     <li><a href="#ref-for-xrspace③">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-getpose">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-getpose">https://immersive-web.github.io/webxr/#dom-xrframe-getpose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-getpose" class="dfn-panel" data-for="term-for-dom-xrframe-getpose" id="infopanel-for-term-for-dom-xrframe-getpose" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-getpose" style="display:none">Info about the 'getPose(space, baseSpace)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-getpose">https://immersive-web.github.io/webxr/#dom-xrframe-getpose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getpose">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">4.1. XRPlaneSet</a> <a href="#ref-for-dom-xrframe-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xr-anchor">
-   <a href="https://immersive-web.github.io/anchors/#xr-anchor">https://immersive-web.github.io/anchors/#xr-anchor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xr-anchor" class="dfn-panel" data-for="term-for-xr-anchor" id="infopanel-for-term-for-xr-anchor" role="menu">
+   <span id="infopaneltitle-for-term-for-xr-anchor" style="display:none">Info about the 'XRAnchor' external reference.</span><a href="https://immersive-web.github.io/anchors/#xr-anchor">https://immersive-web.github.io/anchors/#xr-anchor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-anchor">5.1. Native plane detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-active">
-   <a href="https://immersive-web.github.io/webxr/#xrframe-active">https://immersive-web.github.io/webxr/#xrframe-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-active" class="dfn-panel" data-for="term-for-xrframe-active" id="infopanel-for-term-for-xrframe-active" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-active" style="display:none">Info about the 'active' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe-active">https://immersive-web.github.io/webxr/#xrframe-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-capable-of-supporting">
-   <a href="https://immersive-web.github.io/webxr/#capable-of-supporting">https://immersive-web.github.io/webxr/#capable-of-supporting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-capable-of-supporting" class="dfn-panel" data-for="term-for-capable-of-supporting" id="infopanel-for-term-for-capable-of-supporting" role="menu">
+   <span id="infopaneltitle-for-term-for-capable-of-supporting" style="display:none">Info about the 'capable of supporting' external reference.</span><a href="https://immersive-web.github.io/webxr/#capable-of-supporting">https://immersive-web.github.io/webxr/#capable-of-supporting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capable-of-supporting">2.1. Feature descriptor</a> <a href="#ref-for-capable-of-supporting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-feature-descriptor">
-   <a href="https://immersive-web.github.io/webxr/#feature-descriptor">https://immersive-web.github.io/webxr/#feature-descriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-feature-descriptor" class="dfn-panel" data-for="term-for-feature-descriptor" id="infopanel-for-term-for-feature-descriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' external reference.</span><a href="https://immersive-web.github.io/webxr/#feature-descriptor">https://immersive-web.github.io/webxr/#feature-descriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-xr-device">
-   <a href="https://immersive-web.github.io/webxr/#inline-xr-device">https://immersive-web.github.io/webxr/#inline-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-xr-device" class="dfn-panel" data-for="term-for-inline-xr-device" id="infopanel-for-term-for-inline-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-xr-device" style="display:none">Info about the 'inline xr device' external reference.</span><a href="https://immersive-web.github.io/webxr/#inline-xr-device">https://immersive-web.github.io/webxr/#inline-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-xr-device">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates">
-   <a href="https://immersive-web.github.io/webxr/#xrsession-list-of-frame-updates">https://immersive-web.github.io/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates" id="infopanel-for-term-for-xrsession-list-of-frame-updates" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" style="display:none">Info about the 'list of frame updates' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession-list-of-frame-updates">https://immersive-web.github.io/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-frame-updates">2.1. Feature descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-native-origin">
-   <a href="https://immersive-web.github.io/webxr/#xrspace-native-origin">https://immersive-web.github.io/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-native-origin" class="dfn-panel" data-for="term-for-xrspace-native-origin" id="infopanel-for-term-for-xrspace-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace-native-origin">https://immersive-web.github.io/webxr/#xrspace-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-native-origin">3.2. XRPlane</a>
     <li><a href="#ref-for-xrspace-native-origin①">4.1. XRPlaneSet</a>
     <li><a href="#ref-for-xrspace-native-origin②">5.1. Native plane detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session①" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session①" style="display:none">Info about the 'session (for XRFrame)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">4.1. XRPlaneSet</a> <a href="#ref-for-dom-xrframe-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace-session">
-   <a href="https://immersive-web.github.io/webxr/#xrspace-session">https://immersive-web.github.io/webxr/#xrspace-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace-session" class="dfn-panel" data-for="term-for-xrspace-session" id="infopanel-for-term-for-xrspace-session" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace-session" style="display:none">Info about the 'session (for XRSpace)' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace-session">https://immersive-web.github.io/webxr/#xrspace-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-session">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-time">
-   <a href="https://immersive-web.github.io/webxr/#xrframe-time">https://immersive-web.github.io/webxr/#xrframe-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-time" class="dfn-panel" data-for="term-for-xrframe-time" id="infopanel-for-term-for-xrframe-time" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-time" style="display:none">Info about the 'time' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe-time">https://immersive-web.github.io/webxr/#xrframe-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-time">4.1. XRPlaneSet</a> <a href="#ref-for-xrframe-time①">(2)</a>
     <li><a href="#ref-for-xrframe-time②">5.1. Native plane detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-xr-device">
-   <a href="https://immersive-web.github.io/webxr/#xrsession-xr-device">https://immersive-web.github.io/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-xr-device" class="dfn-panel" data-for="term-for-xrsession-xr-device" id="infopanel-for-term-for-xrsession-xr-device" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-xr-device" style="display:none">Info about the 'xr device' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession-xr-device">https://immersive-web.github.io/webxr/#xrsession-xr-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">4.1. XRPlaneSet</a>
    </ul>
@@ -1195,188 +1195,244 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-xrplaneorientation">
-   <b><a href="#enumdef-xrplaneorientation">#enumdef-xrplaneorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrplaneorientation" class="dfn-panel" data-for="enumdef-xrplaneorientation" id="infopanel-for-enumdef-xrplaneorientation" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrplaneorientation" style="display:none">Info about the 'XRPlaneOrientation' definition.</span><b><a href="#enumdef-xrplaneorientation">#enumdef-xrplaneorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrplaneorientation">3.2. XRPlane</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplaneorientation-horizontal">
-   <b><a href="#dom-xrplaneorientation-horizontal">#dom-xrplaneorientation-horizontal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplaneorientation-horizontal" class="dfn-panel" data-for="dom-xrplaneorientation-horizontal" id="infopanel-for-dom-xrplaneorientation-horizontal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplaneorientation-horizontal" style="display:none">Info about the '"horizontal"' definition.</span><b><a href="#dom-xrplaneorientation-horizontal">#dom-xrplaneorientation-horizontal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplaneorientation-horizontal">3.1. XRPlaneOrientation</a>
     <li><a href="#ref-for-dom-xrplaneorientation-horizontal①">3.2. XRPlane</a>
     <li><a href="#ref-for-dom-xrplaneorientation-horizontal②">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplaneorientation-vertical">
-   <b><a href="#dom-xrplaneorientation-vertical">#dom-xrplaneorientation-vertical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplaneorientation-vertical" class="dfn-panel" data-for="dom-xrplaneorientation-vertical" id="infopanel-for-dom-xrplaneorientation-vertical" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplaneorientation-vertical" style="display:none">Info about the '"vertical"' definition.</span><b><a href="#dom-xrplaneorientation-vertical">#dom-xrplaneorientation-vertical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplaneorientation-vertical">3.1. XRPlaneOrientation</a>
     <li><a href="#ref-for-dom-xrplaneorientation-vertical①">3.2. XRPlane</a>
     <li><a href="#ref-for-dom-xrplaneorientation-vertical②">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrplane">
-   <b><a href="#xrplane">#xrplane</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrplane" class="dfn-panel" data-for="xrplane" id="infopanel-for-xrplane" role="dialog">
+   <span id="infopaneltitle-for-xrplane" style="display:none">Info about the 'XRPlane' definition.</span><b><a href="#xrplane">#xrplane</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrplane">3.2. XRPlane</a> <a href="#ref-for-xrplane①">(2)</a> <a href="#ref-for-xrplane②">(3)</a>
     <li><a href="#ref-for-xrplane③">4.1. XRPlaneSet</a> <a href="#ref-for-xrplane④">(2)</a> <a href="#ref-for-xrplane⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplane-planespace">
-   <b><a href="#dom-xrplane-planespace">#dom-xrplane-planespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplane-planespace" class="dfn-panel" data-for="dom-xrplane-planespace" id="infopanel-for-dom-xrplane-planespace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplane-planespace" style="display:none">Info about the 'planeSpace' definition.</span><b><a href="#dom-xrplane-planespace">#dom-xrplane-planespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplane-planespace">3.2. XRPlane</a> <a href="#ref-for-dom-xrplane-planespace①">(2)</a> <a href="#ref-for-dom-xrplane-planespace②">(3)</a> <a href="#ref-for-dom-xrplane-planespace③">(4)</a> <a href="#ref-for-dom-xrplane-planespace④">(5)</a>
     <li><a href="#ref-for-dom-xrplane-planespace⑤">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplane-polygon">
-   <b><a href="#dom-xrplane-polygon">#dom-xrplane-polygon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplane-polygon" class="dfn-panel" data-for="dom-xrplane-polygon" id="infopanel-for-dom-xrplane-polygon" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplane-polygon" style="display:none">Info about the 'polygon' definition.</span><b><a href="#dom-xrplane-polygon">#dom-xrplane-polygon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplane-polygon">3.2. XRPlane</a>
     <li><a href="#ref-for-dom-xrplane-polygon①">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplane-orientation">
-   <b><a href="#dom-xrplane-orientation">#dom-xrplane-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplane-orientation" class="dfn-panel" data-for="dom-xrplane-orientation" id="infopanel-for-dom-xrplane-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplane-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-xrplane-orientation">#dom-xrplane-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplane-orientation">3.2. XRPlane</a>
     <li><a href="#ref-for-dom-xrplane-orientation①">4.1. XRPlaneSet</a> <a href="#ref-for-dom-xrplane-orientation②">(2)</a> <a href="#ref-for-dom-xrplane-orientation③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrplane-lastchangedtime">
-   <b><a href="#dom-xrplane-lastchangedtime">#dom-xrplane-lastchangedtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrplane-lastchangedtime" class="dfn-panel" data-for="dom-xrplane-lastchangedtime" id="infopanel-for-dom-xrplane-lastchangedtime" role="dialog">
+   <span id="infopaneltitle-for-dom-xrplane-lastchangedtime" style="display:none">Info about the 'lastChangedTime' definition.</span><b><a href="#dom-xrplane-lastchangedtime">#dom-xrplane-lastchangedtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrplane-lastchangedtime">3.2. XRPlane</a> <a href="#ref-for-dom-xrplane-lastchangedtime①">(2)</a>
     <li><a href="#ref-for-dom-xrplane-lastchangedtime②">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrplane-native-entity">
-   <b><a href="#xrplane-native-entity">#xrplane-native-entity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrplane-native-entity" class="dfn-panel" data-for="xrplane-native-entity" id="infopanel-for-xrplane-native-entity" role="dialog">
+   <span id="infopaneltitle-for-xrplane-native-entity" style="display:none">Info about the 'native entity' definition.</span><b><a href="#xrplane-native-entity">#xrplane-native-entity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrplane-native-entity">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrplane-frame">
-   <b><a href="#xrplane-frame">#xrplane-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrplane-frame" class="dfn-panel" data-for="xrplane-frame" id="infopanel-for-xrplane-frame" role="dialog">
+   <span id="infopaneltitle-for-xrplane-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#xrplane-frame">#xrplane-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrplane-frame">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrplaneset">
-   <b><a href="#xrplaneset">#xrplaneset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrplaneset" class="dfn-panel" data-for="xrplaneset" id="infopanel-for-xrplaneset" role="dialog">
+   <span id="infopaneltitle-for-xrplaneset" style="display:none">Info about the 'XRPlaneSet' definition.</span><b><a href="#xrplaneset">#xrplaneset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrplaneset">4.1. XRPlaneSet</a> <a href="#ref-for-xrplaneset①">(2)</a> <a href="#ref-for-xrplaneset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-detectedplanes">
-   <b><a href="#dom-xrframe-detectedplanes">#dom-xrframe-detectedplanes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-detectedplanes" class="dfn-panel" data-for="dom-xrframe-detectedplanes" id="infopanel-for-dom-xrframe-detectedplanes" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-detectedplanes" style="display:none">Info about the 'detectedPlanes' definition.</span><b><a href="#dom-xrframe-detectedplanes">#dom-xrframe-detectedplanes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-detectedplanes">4.1. XRPlaneSet</a> <a href="#ref-for-dom-xrframe-detectedplanes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-set-of-tracked-planes">
-   <b><a href="#xrsession-set-of-tracked-planes">#xrsession-set-of-tracked-planes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-set-of-tracked-planes" class="dfn-panel" data-for="xrsession-set-of-tracked-planes" id="infopanel-for-xrsession-set-of-tracked-planes" role="dialog">
+   <span id="infopaneltitle-for-xrsession-set-of-tracked-planes" style="display:none">Info about the 'set of tracked planes' definition.</span><b><a href="#xrsession-set-of-tracked-planes">#xrsession-set-of-tracked-planes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-set-of-tracked-planes">4.1. XRPlaneSet</a> <a href="#ref-for-xrsession-set-of-tracked-planes①">(2)</a> <a href="#ref-for-xrsession-set-of-tracked-planes②">(3)</a> <a href="#ref-for-xrsession-set-of-tracked-planes③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-planes">
-   <b><a href="#update-planes">#update-planes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-planes" class="dfn-panel" data-for="update-planes" id="infopanel-for-update-planes" role="dialog">
+   <span id="infopaneltitle-for-update-planes" style="display:none">Info about the 'update planes' definition.</span><b><a href="#update-planes">#update-planes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-planes">2.1. Feature descriptor</a>
     <li><a href="#ref-for-update-planes①">4.1. XRPlaneSet</a>
     <li><a href="#ref-for-update-planes②">6. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-plane-object">
-   <b><a href="#create-plane-object">#create-plane-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-plane-object" class="dfn-panel" data-for="create-plane-object" id="infopanel-for-create-plane-object" role="dialog">
+   <span id="infopaneltitle-for-create-plane-object" style="display:none">Info about the 'create plane object' definition.</span><b><a href="#create-plane-object">#create-plane-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-plane-object">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="correspond-to">
-   <b><a href="#correspond-to">#correspond-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-correspond-to" class="dfn-panel" data-for="correspond-to" id="infopanel-for-correspond-to" role="dialog">
+   <span id="infopaneltitle-for-correspond-to" style="display:none">Info about the 'correspond to' definition.</span><b><a href="#correspond-to">#correspond-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-correspond-to">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-plane-object">
-   <b><a href="#update-plane-object">#update-plane-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-plane-object" class="dfn-panel" data-for="update-plane-object" id="infopanel-for-update-plane-object" role="dialog">
+   <span id="infopaneltitle-for-update-plane-object" style="display:none">Info about the 'update plane object' definition.</span><b><a href="#update-plane-object">#update-plane-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-plane-object">4.1. XRPlaneSet</a> <a href="#ref-for-update-plane-object①">(2)</a>
     <li><a href="#ref-for-update-plane-object②">6. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-plane-detection">
-   <b><a href="#native-plane-detection">#native-plane-detection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-plane-detection" class="dfn-panel" data-for="native-plane-detection" id="infopanel-for-native-plane-detection" role="dialog">
+   <span id="infopaneltitle-for-native-plane-detection" style="display:none">Info about the 'native plane detection' definition.</span><b><a href="#native-plane-detection">#native-plane-detection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-plane-detection">2.1. Feature descriptor</a>
     <li><a href="#ref-for-native-plane-detection①">4.1. XRPlaneSet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-plane-objects">
-   <b><a href="#native-plane-objects">#native-plane-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-plane-objects" class="dfn-panel" data-for="native-plane-objects" id="infopanel-for-native-plane-objects" role="dialog">
+   <span id="infopaneltitle-for-native-plane-objects" style="display:none">Info about the 'native plane objects' definition.</span><b><a href="#native-plane-objects">#native-plane-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-plane-objects">4.1. XRPlaneSet</a> <a href="#ref-for-native-plane-objects①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
+++ b/tests/github/immersive-web/real-world-geometry/webxrmeshing-1.html
@@ -2510,45 +2510,45 @@ A UA MUST ask permission from the user during session creation before meshing da
    <li><a href="#xrworldmesh">XRWorldMesh</a><span>, in § 3.1</span>
    <li><a href="#dictdef-xrworldmeshfeature">XRWorldMeshFeature</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">3.1. XRMesh structures</a> <a href="#ref-for-idl-Float32Array①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint16Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint16Array">https://webidl.spec.whatwg.org/#idl-Uint16Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint16Array" class="dfn-panel" data-for="term-for-idl-Uint16Array" id="infopanel-for-term-for-idl-Uint16Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint16Array" style="display:none">Info about the 'Uint16Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint16Array">https://webidl.spec.whatwg.org/#idl-Uint16Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint16Array">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.2. XRWorldMeshFeature</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">3.2. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">2.2. XRWorldMeshFeature</a>
     <li><a href="#ref-for-xrsession①">2.3. XRNearMeshFeature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar" id="infopanel-for-term-for-dom-xrsessionmode-immersive-ar" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the 'immersive-ar' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">2.2. XRWorldMeshFeature</a>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar①">2.3. XRNearMeshFeature</a>
@@ -2633,121 +2633,177 @@ A UA MUST ask permission from the user during session creation before meshing da
    <div class="issue"> should the mesh data persist per browser session or per xr session? <a class="issue-return" href="#issue-ffb06508" title="Jump to section">↵</a></div>
    <div class="issue"> clarify this section <a class="issue-return" href="#issue-22eb3e63" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="enumdef-xrmeshquality">
-   <b><a href="#enumdef-xrmeshquality">#enumdef-xrmeshquality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrmeshquality" class="dfn-panel" data-for="enumdef-xrmeshquality" id="infopanel-for-enumdef-xrmeshquality" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrmeshquality" style="display:none">Info about the 'XRMeshQuality' definition.</span><b><a href="#enumdef-xrmeshquality">#enumdef-xrmeshquality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrmeshquality">2.1. XRMeshQuality</a>
     <li><a href="#ref-for-enumdef-xrmeshquality①">2.2. XRWorldMeshFeature</a>
     <li><a href="#ref-for-enumdef-xrmeshquality②">2.3. XRNearMeshFeature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmeshblock">
-   <b><a href="#dictdef-xrmeshblock">#dictdef-xrmeshblock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmeshblock" class="dfn-panel" data-for="dictdef-xrmeshblock" id="infopanel-for-dictdef-xrmeshblock" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmeshblock" style="display:none">Info about the 'XRMeshBlock' definition.</span><b><a href="#dictdef-xrmeshblock">#dictdef-xrmeshblock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmeshblock">3.1. XRMesh structures</a> <a href="#ref-for-dictdef-xrmeshblock①">(2)</a> <a href="#ref-for-dictdef-xrmeshblock②">(3)</a> <a href="#ref-for-dictdef-xrmeshblock③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmeshblock-vertices">
-   <b><a href="#dom-xrmeshblock-vertices">#dom-xrmeshblock-vertices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmeshblock-vertices" class="dfn-panel" data-for="dom-xrmeshblock-vertices" id="infopanel-for-dom-xrmeshblock-vertices" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmeshblock-vertices" style="display:none">Info about the 'vertices' definition.</span><b><a href="#dom-xrmeshblock-vertices">#dom-xrmeshblock-vertices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmeshblock-vertices">3.1. XRMesh structures</a> <a href="#ref-for-dom-xrmeshblock-vertices①">(2)</a> <a href="#ref-for-dom-xrmeshblock-vertices②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmeshblock-indices">
-   <b><a href="#dom-xrmeshblock-indices">#dom-xrmeshblock-indices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmeshblock-indices" class="dfn-panel" data-for="dom-xrmeshblock-indices" id="infopanel-for-dom-xrmeshblock-indices" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmeshblock-indices" style="display:none">Info about the 'indices' definition.</span><b><a href="#dom-xrmeshblock-indices">#dom-xrmeshblock-indices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmeshblock-indices">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmeshblock-normals">
-   <b><a href="#dom-xrmeshblock-normals">#dom-xrmeshblock-normals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmeshblock-normals" class="dfn-panel" data-for="dom-xrmeshblock-normals" id="infopanel-for-dom-xrmeshblock-normals" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmeshblock-normals" style="display:none">Info about the 'normals' definition.</span><b><a href="#dom-xrmeshblock-normals">#dom-xrmeshblock-normals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmeshblock-normals">3.1. XRMesh structures</a> <a href="#ref-for-dom-xrmeshblock-normals①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrnearmesh">
-   <b><a href="#xrnearmesh">#xrnearmesh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrnearmesh" class="dfn-panel" data-for="xrnearmesh" id="infopanel-for-xrnearmesh" role="dialog">
+   <span id="infopaneltitle-for-xrnearmesh" style="display:none">Info about the 'XRNearMesh' definition.</span><b><a href="#xrnearmesh">#xrnearmesh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrnearmesh">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrworldmesh">
-   <b><a href="#xrworldmesh">#xrworldmesh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrworldmesh" class="dfn-panel" data-for="xrworldmesh" id="infopanel-for-xrworldmesh" role="dialog">
+   <span id="infopaneltitle-for-xrworldmesh" style="display:none">Info about the 'XRWorldMesh' definition.</span><b><a href="#xrworldmesh">#xrworldmesh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrworldmesh">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrmetadata">
-   <b><a href="#dictdef-xrmetadata">#dictdef-xrmetadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrmetadata" class="dfn-panel" data-for="dictdef-xrmetadata" id="infopanel-for-dictdef-xrmetadata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrmetadata" style="display:none">Info about the 'XRMetadata' definition.</span><b><a href="#dictdef-xrmetadata">#dictdef-xrmetadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrmetadata">3.2. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmetadata-worldmesh">
-   <b><a href="#dom-xrmetadata-worldmesh">#dom-xrmetadata-worldmesh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmetadata-worldmesh" class="dfn-panel" data-for="dom-xrmetadata-worldmesh" id="infopanel-for-dom-xrmetadata-worldmesh" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmetadata-worldmesh" style="display:none">Info about the 'worldMesh' definition.</span><b><a href="#dom-xrmetadata-worldmesh">#dom-xrmetadata-worldmesh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmetadata-worldmesh">3.1. XRMesh structures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrmetadata-nearmesh">
-   <b><a href="#dom-xrmetadata-nearmesh">#dom-xrmetadata-nearmesh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrmetadata-nearmesh" class="dfn-panel" data-for="dom-xrmetadata-nearmesh" id="infopanel-for-dom-xrmetadata-nearmesh" role="dialog">
+   <span id="infopaneltitle-for-dom-xrmetadata-nearmesh" style="display:none">Info about the 'nearMesh' definition.</span><b><a href="#dom-xrmetadata-nearmesh">#dom-xrmetadata-nearmesh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrmetadata-nearmesh">3.1. XRMesh structures</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/immersive-web/webvr/spec/1.1/index.html
+++ b/tests/github/immersive-web/webvr/spec/1.1/index.html
@@ -1396,83 +1396,83 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
    <li><a href="#typedefdef-vrsource">VRSource</a><span>, in § 2.2</span>
    <li><a href="#vrstageparameters">VRStageParameters</a><span>, in § 2.9</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-domhighrestimestamp">
-   <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domhighrestimestamp" class="dfn-panel" data-for="term-for-domhighrestimestamp" id="infopanel-for-term-for-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domhighrestimestamp">2.7. VRFrameData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gamepad">
-   <a href="https://www.w3.org/TR/gamepad/#gamepad">https://www.w3.org/TR/gamepad/#gamepad</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gamepad" class="dfn-panel" data-for="term-for-gamepad" id="infopanel-for-term-for-gamepad" role="menu">
+   <span id="infopaneltitle-for-term-for-gamepad" style="display:none">Info about the 'Gamepad' external reference.</span><a href="https://www.w3.org/TR/gamepad/#gamepad">https://www.w3.org/TR/gamepad/#gamepad</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gamepad">2.14. Gamepad Interface extension</a>
     <li><a href="#ref-for-gamepad①">2.14.1. Attributes</a> <a href="#ref-for-gamepad②">(2)</a> <a href="#ref-for-gamepad③">(3)</a>
     <li><a href="#ref-for-gamepad④">3. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-offscreencanvas">
-   <a href="https://wiki.whatwg.org/wiki/OffscreenCanvas#offscreencanvas">https://wiki.whatwg.org/wiki/OffscreenCanvas#offscreencanvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-offscreencanvas" class="dfn-panel" data-for="term-for-offscreencanvas" id="infopanel-for-term-for-offscreencanvas" role="menu">
+   <span id="infopaneltitle-for-term-for-offscreencanvas" style="display:none">Info about the 'OffscreenCanvas' external reference.</span><a href="https://wiki.whatwg.org/wiki/OffscreenCanvas#offscreencanvas">https://wiki.whatwg.org/wiki/OffscreenCanvas#offscreencanvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offscreencanvas">2.2. VRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">2.13. Window Interface extension</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a> <a href="#ref-for-eventhandler⑥">(7)</a> <a href="#ref-for-eventhandler⑦">(8)</a> <a href="#ref-for-eventhandler⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-framerequestcallback">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-framerequestcallback" class="dfn-panel" data-for="term-for-framerequestcallback" id="infopanel-for-term-for-framerequestcallback" role="menu">
+   <span id="infopaneltitle-for-term-for-framerequestcallback" style="display:none">Info about the 'FrameRequestCallback' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#framerequestcallback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-framerequestcallback">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlcanvaselement">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlcanvaselement" class="dfn-panel" data-for="term-for-htmlcanvaselement" id="infopanel-for-term-for-htmlcanvaselement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlcanvaselement" style="display:none">Info about the 'HTMLCanvasElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcanvaselement">2.2. VRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2.10. Navigator Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1. VRDisplay</a>
     <li><a href="#ref-for-idl-DOMString①">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">2.6. VRPose</a> <a href="#ref-for-idl-Float32Array①">(2)</a> <a href="#ref-for-idl-Float32Array②">(3)</a> <a href="#ref-for-idl-Float32Array③">(4)</a> <a href="#ref-for-idl-Float32Array④">(5)</a> <a href="#ref-for-idl-Float32Array⑤">(6)</a>
     <li><a href="#ref-for-idl-Float32Array⑥">2.7. VRFrameData</a> <a href="#ref-for-idl-Float32Array⑦">(2)</a> <a href="#ref-for-idl-Float32Array⑧">(3)</a> <a href="#ref-for-idl-Float32Array⑨">(4)</a>
@@ -1480,69 +1480,69 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-idl-Float32Array①①">2.9. VRStageParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.10. Navigator Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.1. VRDisplay</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">2.10. Navigator Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.1. VRDisplay</a>
     <li><a href="#ref-for-SameObject①">2.8. VREyeParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.1. VRDisplay</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
     <li><a href="#ref-for-idl-boolean③">2.3. VRDisplayCapabilities</a> <a href="#ref-for-idl-boolean④">(2)</a> <a href="#ref-for-idl-boolean⑤">(3)</a> <a href="#ref-for-idl-boolean⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.1. VRDisplay</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">2.5. VRFieldOfView</a> <a href="#ref-for-idl-double③">(2)</a> <a href="#ref-for-idl-double④">(3)</a> <a href="#ref-for-idl-double⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">2.2. VRLayerInit</a> <a href="#ref-for-idl-float①">(2)</a>
     <li><a href="#ref-for-idl-float②">2.9. VRStageParameters</a> <a href="#ref-for-idl-float③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">2.1. VRDisplay</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.1. VRDisplay</a> <a href="#ref-for-idl-sequence①">(2)</a>
     <li><a href="#ref-for-idl-sequence②">2.2. VRLayerInit</a> <a href="#ref-for-idl-sequence③">(2)</a>
     <li><a href="#ref-for-idl-sequence④">2.10. Navigator Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2.1. VRDisplay</a>
     <li><a href="#ref-for-idl-unsigned-long①">2.3. VRDisplayCapabilities</a>
@@ -1836,8 +1836,8 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="vrdisplay">
-   <b><a href="#vrdisplay">#vrdisplay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrdisplay" class="dfn-panel" data-for="vrdisplay" id="infopanel-for-vrdisplay" role="dialog">
+   <span id="infopaneltitle-for-vrdisplay" style="display:none">Info about the 'VRDisplay' definition.</span><b><a href="#vrdisplay">#vrdisplay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrdisplay">2.1. VRDisplay</a>
     <li><a href="#ref-for-vrdisplay①">2.1.1. Attributes</a> <a href="#ref-for-vrdisplay②">(2)</a> <a href="#ref-for-vrdisplay③">(3)</a> <a href="#ref-for-vrdisplay④">(4)</a> <a href="#ref-for-vrdisplay⑤">(5)</a> <a href="#ref-for-vrdisplay⑥">(6)</a> <a href="#ref-for-vrdisplay⑦">(7)</a> <a href="#ref-for-vrdisplay⑧">(8)</a> <a href="#ref-for-vrdisplay⑨">(9)</a> <a href="#ref-for-vrdisplay①⓪">(10)</a> <a href="#ref-for-vrdisplay①①">(11)</a> <a href="#ref-for-vrdisplay①②">(12)</a> <a href="#ref-for-vrdisplay①③">(13)</a> <a href="#ref-for-vrdisplay①④">(14)</a> <a href="#ref-for-vrdisplay①⑤">(15)</a> <a href="#ref-for-vrdisplay①⑥">(16)</a> <a href="#ref-for-vrdisplay①⑦">(17)</a> <a href="#ref-for-vrdisplay①⑧">(18)</a> <a href="#ref-for-vrdisplay①⑨">(19)</a> <a href="#ref-for-vrdisplay②⓪">(20)</a> <a href="#ref-for-vrdisplay②①">(21)</a> <a href="#ref-for-vrdisplay②②">(22)</a> <a href="#ref-for-vrdisplay②③">(23)</a> <a href="#ref-for-vrdisplay②④">(24)</a> <a href="#ref-for-vrdisplay②⑤">(25)</a> <a href="#ref-for-vrdisplay②⑥">(26)</a> <a href="#ref-for-vrdisplay②⑦">(27)</a> <a href="#ref-for-vrdisplay②⑧">(28)</a> <a href="#ref-for-vrdisplay②⑨">(29)</a> <a href="#ref-for-vrdisplay③⓪">(30)</a> <a href="#ref-for-vrdisplay③①">(31)</a> <a href="#ref-for-vrdisplay③②">(32)</a>
@@ -1858,107 +1858,107 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-vrdisplay⑦②">3. Security Considerations</a> <a href="#ref-for-vrdisplay⑦③">(2)</a> <a href="#ref-for-vrdisplay⑦④">(3)</a> <a href="#ref-for-vrdisplay⑦⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-geteyeparameters">
-   <b><a href="#dom-vrdisplay-geteyeparameters">#dom-vrdisplay-geteyeparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-geteyeparameters" class="dfn-panel" data-for="dom-vrdisplay-geteyeparameters" id="infopanel-for-dom-vrdisplay-geteyeparameters" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-geteyeparameters" style="display:none">Info about the 'getEyeParameters' definition.</span><b><a href="#dom-vrdisplay-geteyeparameters">#dom-vrdisplay-geteyeparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-geteyeparameters">2.3.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-displayid">
-   <b><a href="#dom-vrdisplay-displayid">#dom-vrdisplay-displayid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-displayid" class="dfn-panel" data-for="dom-vrdisplay-displayid" id="infopanel-for-dom-vrdisplay-displayid" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-displayid" style="display:none">Info about the 'displayId' definition.</span><b><a href="#dom-vrdisplay-displayid">#dom-vrdisplay-displayid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-displayid">2.14.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-getframedata">
-   <b><a href="#dom-vrdisplay-getframedata">#dom-vrdisplay-getframedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-getframedata" class="dfn-panel" data-for="dom-vrdisplay-getframedata" id="infopanel-for-dom-vrdisplay-getframedata" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-getframedata" style="display:none">Info about the 'getFrameData' definition.</span><b><a href="#dom-vrdisplay-getframedata">#dom-vrdisplay-getframedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-getframedata">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-getframedata①">(2)</a> <a href="#ref-for-dom-vrdisplay-getframedata②">(3)</a> <a href="#ref-for-dom-vrdisplay-getframedata③">(4)</a>
     <li><a href="#ref-for-dom-vrdisplay-getframedata④">2.7.1. Attributes</a>
     <li><a href="#ref-for-dom-vrdisplay-getframedata⑤">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-requestanimationframe">
-   <b><a href="#dom-vrdisplay-requestanimationframe">#dom-vrdisplay-requestanimationframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-requestanimationframe" class="dfn-panel" data-for="dom-vrdisplay-requestanimationframe" id="infopanel-for-dom-vrdisplay-requestanimationframe" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame' definition.</span><b><a href="#dom-vrdisplay-requestanimationframe">#dom-vrdisplay-requestanimationframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-requestanimationframe">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-requestanimationframe①">(2)</a> <a href="#ref-for-dom-vrdisplay-requestanimationframe②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-requestpresent">
-   <b><a href="#dom-vrdisplay-requestpresent">#dom-vrdisplay-requestpresent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-requestpresent" class="dfn-panel" data-for="dom-vrdisplay-requestpresent" id="infopanel-for-dom-vrdisplay-requestpresent" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-requestpresent" style="display:none">Info about the 'requestPresent' definition.</span><b><a href="#dom-vrdisplay-requestpresent">#dom-vrdisplay-requestpresent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-requestpresent">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-requestpresent①">(2)</a> <a href="#ref-for-dom-vrdisplay-requestpresent②">(3)</a> <a href="#ref-for-dom-vrdisplay-requestpresent③">(4)</a> <a href="#ref-for-dom-vrdisplay-requestpresent④">(5)</a> <a href="#ref-for-dom-vrdisplay-requestpresent⑤">(6)</a> <a href="#ref-for-dom-vrdisplay-requestpresent⑥">(7)</a> <a href="#ref-for-dom-vrdisplay-requestpresent⑦">(8)</a>
     <li><a href="#ref-for-dom-vrdisplay-requestpresent⑧">2.3.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-requestpresent⑨">(2)</a> <a href="#ref-for-dom-vrdisplay-requestpresent①⓪">(3)</a>
     <li><a href="#ref-for-dom-vrdisplay-requestpresent①①">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-isconnected">
-   <b><a href="#dom-vrdisplay-isconnected">#dom-vrdisplay-isconnected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-isconnected" class="dfn-panel" data-for="dom-vrdisplay-isconnected" id="infopanel-for-dom-vrdisplay-isconnected" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-isconnected" style="display:none">Info about the 'isConnected' definition.</span><b><a href="#dom-vrdisplay-isconnected">#dom-vrdisplay-isconnected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-isconnected">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-isconnected①">2.1.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-ispresenting">
-   <b><a href="#dom-vrdisplay-ispresenting">#dom-vrdisplay-ispresenting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-ispresenting" class="dfn-panel" data-for="dom-vrdisplay-ispresenting" id="infopanel-for-dom-vrdisplay-ispresenting" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-ispresenting" style="display:none">Info about the 'isPresenting' definition.</span><b><a href="#dom-vrdisplay-ispresenting">#dom-vrdisplay-ispresenting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-ispresenting">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-ispresenting①">2.1.1. Attributes</a>
     <li><a href="#ref-for-dom-vrdisplay-ispresenting②">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-capabilities">
-   <b><a href="#dom-vrdisplay-capabilities">#dom-vrdisplay-capabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-capabilities" class="dfn-panel" data-for="dom-vrdisplay-capabilities" id="infopanel-for-dom-vrdisplay-capabilities" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-capabilities" style="display:none">Info about the 'capabilities' definition.</span><b><a href="#dom-vrdisplay-capabilities">#dom-vrdisplay-capabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-capabilities">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-capabilities①">2.1.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-getpose">
-   <b><a href="#dom-vrdisplay-getpose">#dom-vrdisplay-getpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-getpose" class="dfn-panel" data-for="dom-vrdisplay-getpose" id="infopanel-for-dom-vrdisplay-getpose" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-getpose" style="display:none">Info about the 'getPose()' definition.</span><b><a href="#dom-vrdisplay-getpose">#dom-vrdisplay-getpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-getpose">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-getpose①">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-getpose②">(2)</a>
     <li><a href="#ref-for-dom-vrdisplay-getpose③">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-resetpose">
-   <b><a href="#dom-vrdisplay-resetpose">#dom-vrdisplay-resetpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-resetpose" class="dfn-panel" data-for="dom-vrdisplay-resetpose" id="infopanel-for-dom-vrdisplay-resetpose" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-resetpose" style="display:none">Info about the 'resetPose()' definition.</span><b><a href="#dom-vrdisplay-resetpose">#dom-vrdisplay-resetpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-resetpose">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-resetpose①">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-resetpose②">(2)</a> <a href="#ref-for-dom-vrdisplay-resetpose③">(3)</a> <a href="#ref-for-dom-vrdisplay-resetpose④">(4)</a>
     <li><a href="#ref-for-dom-vrdisplay-resetpose⑤">2.6.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-resetpose⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-exitpresent">
-   <b><a href="#dom-vrdisplay-exitpresent">#dom-vrdisplay-exitpresent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-exitpresent" class="dfn-panel" data-for="dom-vrdisplay-exitpresent" id="infopanel-for-dom-vrdisplay-exitpresent" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-exitpresent" style="display:none">Info about the 'exitPresent()' definition.</span><b><a href="#dom-vrdisplay-exitpresent">#dom-vrdisplay-exitpresent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-exitpresent">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-getlayers">
-   <b><a href="#dom-vrdisplay-getlayers">#dom-vrdisplay-getlayers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-getlayers" class="dfn-panel" data-for="dom-vrdisplay-getlayers" id="infopanel-for-dom-vrdisplay-getlayers" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-getlayers" style="display:none">Info about the 'getLayers()' definition.</span><b><a href="#dom-vrdisplay-getlayers">#dom-vrdisplay-getlayers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-getlayers">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplay-submitframe">
-   <b><a href="#dom-vrdisplay-submitframe">#dom-vrdisplay-submitframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplay-submitframe" class="dfn-panel" data-for="dom-vrdisplay-submitframe" id="infopanel-for-dom-vrdisplay-submitframe" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplay-submitframe" style="display:none">Info about the 'submitFrame()' definition.</span><b><a href="#dom-vrdisplay-submitframe">#dom-vrdisplay-submitframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplay-submitframe">2.1. VRDisplay</a>
     <li><a href="#ref-for-dom-vrdisplay-submitframe①">2.1.1. Attributes</a> <a href="#ref-for-dom-vrdisplay-submitframe②">(2)</a>
     <li><a href="#ref-for-dom-vrdisplay-submitframe③">2.2.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-vrsource">
-   <b><a href="#typedefdef-vrsource">#typedefdef-vrsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-vrsource" class="dfn-panel" data-for="typedefdef-vrsource" id="infopanel-for-typedefdef-vrsource" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-vrsource" style="display:none">Info about the 'VRSource' definition.</span><b><a href="#typedefdef-vrsource">#typedefdef-vrsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-vrsource">2.1.1. Attributes</a> <a href="#ref-for-typedefdef-vrsource①">(2)</a> <a href="#ref-for-typedefdef-vrsource②">(3)</a>
     <li><a href="#ref-for-typedefdef-vrsource③">2.2. VRLayerInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-vrlayerinit">
-   <b><a href="#dictdef-vrlayerinit">#dictdef-vrlayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-vrlayerinit" class="dfn-panel" data-for="dictdef-vrlayerinit" id="infopanel-for-dictdef-vrlayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-vrlayerinit" style="display:none">Info about the 'VRLayerInit' definition.</span><b><a href="#dictdef-vrlayerinit">#dictdef-vrlayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-vrlayerinit">2.1. VRDisplay</a> <a href="#ref-for-dictdef-vrlayerinit①">(2)</a>
     <li><a href="#ref-for-dictdef-vrlayerinit②">2.1.1. Attributes</a> <a href="#ref-for-dictdef-vrlayerinit③">(2)</a> <a href="#ref-for-dictdef-vrlayerinit④">(3)</a> <a href="#ref-for-dictdef-vrlayerinit⑤">(4)</a> <a href="#ref-for-dictdef-vrlayerinit⑥">(5)</a> <a href="#ref-for-dictdef-vrlayerinit⑦">(6)</a> <a href="#ref-for-dictdef-vrlayerinit⑧">(7)</a> <a href="#ref-for-dictdef-vrlayerinit⑨">(8)</a> <a href="#ref-for-dictdef-vrlayerinit①⓪">(9)</a>
@@ -1966,30 +1966,30 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-dictdef-vrlayerinit①②">3. Security Considerations</a> <a href="#ref-for-dictdef-vrlayerinit①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrlayerinit-source">
-   <b><a href="#dom-vrlayerinit-source">#dom-vrlayerinit-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrlayerinit-source" class="dfn-panel" data-for="dom-vrlayerinit-source" id="infopanel-for-dom-vrlayerinit-source" role="dialog">
+   <span id="infopaneltitle-for-dom-vrlayerinit-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-vrlayerinit-source">#dom-vrlayerinit-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrlayerinit-source">2.2. VRLayerInit</a>
     <li><a href="#ref-for-dom-vrlayerinit-source①">2.2.1. Attributes</a> <a href="#ref-for-dom-vrlayerinit-source②">(2)</a> <a href="#ref-for-dom-vrlayerinit-source③">(3)</a>
     <li><a href="#ref-for-dom-vrlayerinit-source④">3. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrlayerinit-leftbounds">
-   <b><a href="#dom-vrlayerinit-leftbounds">#dom-vrlayerinit-leftbounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrlayerinit-leftbounds" class="dfn-panel" data-for="dom-vrlayerinit-leftbounds" id="infopanel-for-dom-vrlayerinit-leftbounds" role="dialog">
+   <span id="infopaneltitle-for-dom-vrlayerinit-leftbounds" style="display:none">Info about the 'leftBounds' definition.</span><b><a href="#dom-vrlayerinit-leftbounds">#dom-vrlayerinit-leftbounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrlayerinit-leftbounds">2.2. VRLayerInit</a>
     <li><a href="#ref-for-dom-vrlayerinit-leftbounds①">2.2.1. Attributes</a> <a href="#ref-for-dom-vrlayerinit-leftbounds②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrlayerinit-rightbounds">
-   <b><a href="#dom-vrlayerinit-rightbounds">#dom-vrlayerinit-rightbounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrlayerinit-rightbounds" class="dfn-panel" data-for="dom-vrlayerinit-rightbounds" id="infopanel-for-dom-vrlayerinit-rightbounds" role="dialog">
+   <span id="infopaneltitle-for-dom-vrlayerinit-rightbounds" style="display:none">Info about the 'rightBounds' definition.</span><b><a href="#dom-vrlayerinit-rightbounds">#dom-vrlayerinit-rightbounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrlayerinit-rightbounds">2.2. VRLayerInit</a>
     <li><a href="#ref-for-dom-vrlayerinit-rightbounds①">2.2.1. Attributes</a> <a href="#ref-for-dom-vrlayerinit-rightbounds②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrdisplaycapabilities">
-   <b><a href="#vrdisplaycapabilities">#vrdisplaycapabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrdisplaycapabilities" class="dfn-panel" data-for="vrdisplaycapabilities" id="infopanel-for-vrdisplaycapabilities" role="dialog">
+   <span id="infopaneltitle-for-vrdisplaycapabilities" style="display:none">Info about the 'VRDisplayCapabilities' definition.</span><b><a href="#vrdisplaycapabilities">#vrdisplaycapabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrdisplaycapabilities">2.1. VRDisplay</a>
     <li><a href="#ref-for-vrdisplaycapabilities①">2.1.1. Attributes</a>
@@ -1997,58 +1997,58 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-vrdisplaycapabilities③">2.6.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasposition">
-   <b><a href="#dom-vrdisplaycapabilities-hasposition">#dom-vrdisplaycapabilities-hasposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplaycapabilities-hasposition" class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasposition" id="infopanel-for-dom-vrdisplaycapabilities-hasposition" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplaycapabilities-hasposition" style="display:none">Info about the 'hasPosition' definition.</span><b><a href="#dom-vrdisplaycapabilities-hasposition">#dom-vrdisplaycapabilities-hasposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasposition">2.3. VRDisplayCapabilities</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasposition①">2.3.1. Attributes</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasposition②">2.6.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasorientation">
-   <b><a href="#dom-vrdisplaycapabilities-hasorientation">#dom-vrdisplaycapabilities-hasorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplaycapabilities-hasorientation" class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasorientation" id="infopanel-for-dom-vrdisplaycapabilities-hasorientation" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplaycapabilities-hasorientation" style="display:none">Info about the 'hasOrientation' definition.</span><b><a href="#dom-vrdisplaycapabilities-hasorientation">#dom-vrdisplaycapabilities-hasorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasorientation">2.3. VRDisplayCapabilities</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasorientation①">2.3.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasexternaldisplay">
-   <b><a href="#dom-vrdisplaycapabilities-hasexternaldisplay">#dom-vrdisplaycapabilities-hasexternaldisplay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplaycapabilities-hasexternaldisplay" class="dfn-panel" data-for="dom-vrdisplaycapabilities-hasexternaldisplay" id="infopanel-for-dom-vrdisplaycapabilities-hasexternaldisplay" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplaycapabilities-hasexternaldisplay" style="display:none">Info about the 'hasExternalDisplay' definition.</span><b><a href="#dom-vrdisplaycapabilities-hasexternaldisplay">#dom-vrdisplaycapabilities-hasexternaldisplay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasexternaldisplay">2.3. VRDisplayCapabilities</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-hasexternaldisplay①">2.3.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplaycapabilities-canpresent">
-   <b><a href="#dom-vrdisplaycapabilities-canpresent">#dom-vrdisplaycapabilities-canpresent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplaycapabilities-canpresent" class="dfn-panel" data-for="dom-vrdisplaycapabilities-canpresent" id="infopanel-for-dom-vrdisplaycapabilities-canpresent" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplaycapabilities-canpresent" style="display:none">Info about the 'canPresent' definition.</span><b><a href="#dom-vrdisplaycapabilities-canpresent">#dom-vrdisplaycapabilities-canpresent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-canpresent">2.1.1. Attributes</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-canpresent①">2.3. VRDisplayCapabilities</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-canpresent②">2.3.1. Attributes</a> <a href="#ref-for-dom-vrdisplaycapabilities-canpresent③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplaycapabilities-maxlayers">
-   <b><a href="#dom-vrdisplaycapabilities-maxlayers">#dom-vrdisplaycapabilities-maxlayers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplaycapabilities-maxlayers" class="dfn-panel" data-for="dom-vrdisplaycapabilities-maxlayers" id="infopanel-for-dom-vrdisplaycapabilities-maxlayers" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplaycapabilities-maxlayers" style="display:none">Info about the 'maxLayers' definition.</span><b><a href="#dom-vrdisplaycapabilities-maxlayers">#dom-vrdisplaycapabilities-maxlayers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-maxlayers">2.1.1. Attributes</a>
     <li><a href="#ref-for-dom-vrdisplaycapabilities-maxlayers①">2.3. VRDisplayCapabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-vreye">
-   <b><a href="#enumdef-vreye">#enumdef-vreye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-vreye" class="dfn-panel" data-for="enumdef-vreye" id="infopanel-for-enumdef-vreye" role="dialog">
+   <span id="infopaneltitle-for-enumdef-vreye" style="display:none">Info about the 'VREye' definition.</span><b><a href="#enumdef-vreye">#enumdef-vreye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-vreye">2.1. VRDisplay</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrfieldofview">
-   <b><a href="#vrfieldofview">#vrfieldofview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrfieldofview" class="dfn-panel" data-for="vrfieldofview" id="infopanel-for-vrfieldofview" role="dialog">
+   <span id="infopaneltitle-for-vrfieldofview" style="display:none">Info about the 'VRFieldOfView' definition.</span><b><a href="#vrfieldofview">#vrfieldofview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrfieldofview">2.5. VRFieldOfView</a>
     <li><a href="#ref-for-vrfieldofview①">2.8. VREyeParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrpose">
-   <b><a href="#vrpose">#vrpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrpose" class="dfn-panel" data-for="vrpose" id="infopanel-for-vrpose" role="dialog">
+   <span id="infopaneltitle-for-vrpose" style="display:none">Info about the 'VRPose' definition.</span><b><a href="#vrpose">#vrpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrpose">2.1. VRDisplay</a>
     <li><a href="#ref-for-vrpose①">2.1.1. Attributes</a> <a href="#ref-for-vrpose②">(2)</a> <a href="#ref-for-vrpose③">(3)</a> <a href="#ref-for-vrpose④">(4)</a> <a href="#ref-for-vrpose⑤">(5)</a>
@@ -2058,44 +2058,44 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-vrpose⑨">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-position">
-   <b><a href="#dom-vrpose-position">#dom-vrpose-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-position" class="dfn-panel" data-for="dom-vrpose-position" id="infopanel-for-dom-vrpose-position" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-vrpose-position">#dom-vrpose-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-position">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-linearvelocity">
-   <b><a href="#dom-vrpose-linearvelocity">#dom-vrpose-linearvelocity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-linearvelocity" class="dfn-panel" data-for="dom-vrpose-linearvelocity" id="infopanel-for-dom-vrpose-linearvelocity" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-linearvelocity" style="display:none">Info about the 'linearVelocity' definition.</span><b><a href="#dom-vrpose-linearvelocity">#dom-vrpose-linearvelocity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-linearvelocity">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-linearacceleration">
-   <b><a href="#dom-vrpose-linearacceleration">#dom-vrpose-linearacceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-linearacceleration" class="dfn-panel" data-for="dom-vrpose-linearacceleration" id="infopanel-for-dom-vrpose-linearacceleration" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-linearacceleration" style="display:none">Info about the 'linearAcceleration' definition.</span><b><a href="#dom-vrpose-linearacceleration">#dom-vrpose-linearacceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-linearacceleration">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-orientation">
-   <b><a href="#dom-vrpose-orientation">#dom-vrpose-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-orientation" class="dfn-panel" data-for="dom-vrpose-orientation" id="infopanel-for-dom-vrpose-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-vrpose-orientation">#dom-vrpose-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-orientation">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-angularvelocity">
-   <b><a href="#dom-vrpose-angularvelocity">#dom-vrpose-angularvelocity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-angularvelocity" class="dfn-panel" data-for="dom-vrpose-angularvelocity" id="infopanel-for-dom-vrpose-angularvelocity" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-angularvelocity" style="display:none">Info about the 'angularVelocity' definition.</span><b><a href="#dom-vrpose-angularvelocity">#dom-vrpose-angularvelocity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-angularvelocity">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrpose-angularacceleration">
-   <b><a href="#dom-vrpose-angularacceleration">#dom-vrpose-angularacceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrpose-angularacceleration" class="dfn-panel" data-for="dom-vrpose-angularacceleration" id="infopanel-for-dom-vrpose-angularacceleration" role="dialog">
+   <span id="infopaneltitle-for-dom-vrpose-angularacceleration" style="display:none">Info about the 'angularAcceleration' definition.</span><b><a href="#dom-vrpose-angularacceleration">#dom-vrpose-angularacceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrpose-angularacceleration">2.6. VRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrframedata">
-   <b><a href="#vrframedata">#vrframedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrframedata" class="dfn-panel" data-for="vrframedata" id="infopanel-for-vrframedata" role="dialog">
+   <span id="infopaneltitle-for-vrframedata" style="display:none">Info about the 'VRFrameData' definition.</span><b><a href="#vrframedata">#vrframedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrframedata">2.1. VRDisplay</a>
     <li><a href="#ref-for-vrframedata①">2.1.1. Attributes</a> <a href="#ref-for-vrframedata②">(2)</a> <a href="#ref-for-vrframedata③">(3)</a>
@@ -2104,246 +2104,302 @@ navigator<c- p>.</c->getVRDisplays<c- p>().</c->then<c- p>(</c-><c- a>function</
     <li><a href="#ref-for-vrframedata⑦">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-timestamp">
-   <b><a href="#dom-vrframedata-timestamp">#dom-vrframedata-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-timestamp" class="dfn-panel" data-for="dom-vrframedata-timestamp" id="infopanel-for-dom-vrframedata-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#dom-vrframedata-timestamp">#dom-vrframedata-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-timestamp">2.7. VRFrameData</a>
     <li><a href="#ref-for-dom-vrframedata-timestamp①">2.7.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-leftprojectionmatrix">
-   <b><a href="#dom-vrframedata-leftprojectionmatrix">#dom-vrframedata-leftprojectionmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-leftprojectionmatrix" class="dfn-panel" data-for="dom-vrframedata-leftprojectionmatrix" id="infopanel-for-dom-vrframedata-leftprojectionmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-leftprojectionmatrix" style="display:none">Info about the 'leftProjectionMatrix' definition.</span><b><a href="#dom-vrframedata-leftprojectionmatrix">#dom-vrframedata-leftprojectionmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-leftprojectionmatrix">2.7. VRFrameData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-leftviewmatrix">
-   <b><a href="#dom-vrframedata-leftviewmatrix">#dom-vrframedata-leftviewmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-leftviewmatrix" class="dfn-panel" data-for="dom-vrframedata-leftviewmatrix" id="infopanel-for-dom-vrframedata-leftviewmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-leftviewmatrix" style="display:none">Info about the 'leftViewMatrix' definition.</span><b><a href="#dom-vrframedata-leftviewmatrix">#dom-vrframedata-leftviewmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-leftviewmatrix">2.7. VRFrameData</a>
     <li><a href="#ref-for-dom-vrframedata-leftviewmatrix①">2.9.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-rightprojectionmatrix">
-   <b><a href="#dom-vrframedata-rightprojectionmatrix">#dom-vrframedata-rightprojectionmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-rightprojectionmatrix" class="dfn-panel" data-for="dom-vrframedata-rightprojectionmatrix" id="infopanel-for-dom-vrframedata-rightprojectionmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-rightprojectionmatrix" style="display:none">Info about the 'rightProjectionMatrix' definition.</span><b><a href="#dom-vrframedata-rightprojectionmatrix">#dom-vrframedata-rightprojectionmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-rightprojectionmatrix">2.7. VRFrameData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-rightviewmatrix">
-   <b><a href="#dom-vrframedata-rightviewmatrix">#dom-vrframedata-rightviewmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-rightviewmatrix" class="dfn-panel" data-for="dom-vrframedata-rightviewmatrix" id="infopanel-for-dom-vrframedata-rightviewmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-rightviewmatrix" style="display:none">Info about the 'rightViewMatrix' definition.</span><b><a href="#dom-vrframedata-rightviewmatrix">#dom-vrframedata-rightviewmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-rightviewmatrix">2.7. VRFrameData</a>
     <li><a href="#ref-for-dom-vrframedata-rightviewmatrix①">2.9.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrframedata-pose">
-   <b><a href="#dom-vrframedata-pose">#dom-vrframedata-pose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrframedata-pose" class="dfn-panel" data-for="dom-vrframedata-pose" id="infopanel-for-dom-vrframedata-pose" role="dialog">
+   <span id="infopaneltitle-for-dom-vrframedata-pose" style="display:none">Info about the 'pose' definition.</span><b><a href="#dom-vrframedata-pose">#dom-vrframedata-pose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrframedata-pose">2.7. VRFrameData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vreyeparameters">
-   <b><a href="#vreyeparameters">#vreyeparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vreyeparameters" class="dfn-panel" data-for="vreyeparameters" id="infopanel-for-vreyeparameters" role="dialog">
+   <span id="infopaneltitle-for-vreyeparameters" style="display:none">Info about the 'VREyeParameters' definition.</span><b><a href="#vreyeparameters">#vreyeparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vreyeparameters">2.1. VRDisplay</a>
     <li><a href="#ref-for-vreyeparameters①">2.1.1. Attributes</a>
     <li><a href="#ref-for-vreyeparameters②">2.8. VREyeParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vreyeparameters-offset">
-   <b><a href="#dom-vreyeparameters-offset">#dom-vreyeparameters-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vreyeparameters-offset" class="dfn-panel" data-for="dom-vreyeparameters-offset" id="infopanel-for-dom-vreyeparameters-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-vreyeparameters-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-vreyeparameters-offset">#dom-vreyeparameters-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vreyeparameters-offset">2.8. VREyeParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vreyeparameters-fieldofview">
-   <b><a href="#dom-vreyeparameters-fieldofview">#dom-vreyeparameters-fieldofview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vreyeparameters-fieldofview" class="dfn-panel" data-for="dom-vreyeparameters-fieldofview" id="infopanel-for-dom-vreyeparameters-fieldofview" role="dialog">
+   <span id="infopaneltitle-for-dom-vreyeparameters-fieldofview" style="display:none">Info about the 'fieldOfView' definition.</span><b><a href="#dom-vreyeparameters-fieldofview">#dom-vreyeparameters-fieldofview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vreyeparameters-fieldofview">2.8. VREyeParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vreyeparameters-renderwidth">
-   <b><a href="#dom-vreyeparameters-renderwidth">#dom-vreyeparameters-renderwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vreyeparameters-renderwidth" class="dfn-panel" data-for="dom-vreyeparameters-renderwidth" id="infopanel-for-dom-vreyeparameters-renderwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-vreyeparameters-renderwidth" style="display:none">Info about the 'renderWidth' definition.</span><b><a href="#dom-vreyeparameters-renderwidth">#dom-vreyeparameters-renderwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vreyeparameters-renderwidth">2.8. VREyeParameters</a>
     <li><a href="#ref-for-dom-vreyeparameters-renderwidth①">2.8.1. Attributes</a> <a href="#ref-for-dom-vreyeparameters-renderwidth②">(2)</a> <a href="#ref-for-dom-vreyeparameters-renderwidth③">(3)</a> <a href="#ref-for-dom-vreyeparameters-renderwidth④">(4)</a> <a href="#ref-for-dom-vreyeparameters-renderwidth⑤">(5)</a> <a href="#ref-for-dom-vreyeparameters-renderwidth⑥">(6)</a> <a href="#ref-for-dom-vreyeparameters-renderwidth⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vreyeparameters-renderheight">
-   <b><a href="#dom-vreyeparameters-renderheight">#dom-vreyeparameters-renderheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vreyeparameters-renderheight" class="dfn-panel" data-for="dom-vreyeparameters-renderheight" id="infopanel-for-dom-vreyeparameters-renderheight" role="dialog">
+   <span id="infopaneltitle-for-dom-vreyeparameters-renderheight" style="display:none">Info about the 'renderHeight' definition.</span><b><a href="#dom-vreyeparameters-renderheight">#dom-vreyeparameters-renderheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vreyeparameters-renderheight">2.8. VREyeParameters</a>
     <li><a href="#ref-for-dom-vreyeparameters-renderheight①">2.8.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrstageparameters">
-   <b><a href="#vrstageparameters">#vrstageparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrstageparameters" class="dfn-panel" data-for="vrstageparameters" id="infopanel-for-vrstageparameters" role="dialog">
+   <span id="infopaneltitle-for-vrstageparameters" style="display:none">Info about the 'VRStageParameters' definition.</span><b><a href="#vrstageparameters">#vrstageparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrstageparameters">2.1. VRDisplay</a>
     <li><a href="#ref-for-vrstageparameters①">2.1.1. Attributes</a>
     <li><a href="#ref-for-vrstageparameters②">2.9. VRStageParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrstageparameters-sittingtostandingtransform">
-   <b><a href="#dom-vrstageparameters-sittingtostandingtransform">#dom-vrstageparameters-sittingtostandingtransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrstageparameters-sittingtostandingtransform" class="dfn-panel" data-for="dom-vrstageparameters-sittingtostandingtransform" id="infopanel-for-dom-vrstageparameters-sittingtostandingtransform" role="dialog">
+   <span id="infopaneltitle-for-dom-vrstageparameters-sittingtostandingtransform" style="display:none">Info about the 'sittingToStandingTransform' definition.</span><b><a href="#dom-vrstageparameters-sittingtostandingtransform">#dom-vrstageparameters-sittingtostandingtransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrstageparameters-sittingtostandingtransform">2.1.1. Attributes</a>
     <li><a href="#ref-for-dom-vrstageparameters-sittingtostandingtransform①">2.9. VRStageParameters</a>
     <li><a href="#ref-for-dom-vrstageparameters-sittingtostandingtransform②">2.9.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrstageparameters-sizex">
-   <b><a href="#dom-vrstageparameters-sizex">#dom-vrstageparameters-sizex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrstageparameters-sizex" class="dfn-panel" data-for="dom-vrstageparameters-sizex" id="infopanel-for-dom-vrstageparameters-sizex" role="dialog">
+   <span id="infopaneltitle-for-dom-vrstageparameters-sizex" style="display:none">Info about the 'sizeX' definition.</span><b><a href="#dom-vrstageparameters-sizex">#dom-vrstageparameters-sizex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrstageparameters-sizex">2.9. VRStageParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrstageparameters-sizez">
-   <b><a href="#dom-vrstageparameters-sizez">#dom-vrstageparameters-sizez</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrstageparameters-sizez" class="dfn-panel" data-for="dom-vrstageparameters-sizez" id="infopanel-for-dom-vrstageparameters-sizez" role="dialog">
+   <span id="infopaneltitle-for-dom-vrstageparameters-sizez" style="display:none">Info about the 'sizeZ' definition.</span><b><a href="#dom-vrstageparameters-sizez">#dom-vrstageparameters-sizez</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrstageparameters-sizez">2.9. VRStageParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-getvrdisplays-attribute">
-   <b><a href="#navigator-getvrdisplays-attribute">#navigator-getvrdisplays-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-getvrdisplays-attribute" class="dfn-panel" data-for="navigator-getvrdisplays-attribute" id="infopanel-for-navigator-getvrdisplays-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-getvrdisplays-attribute" style="display:none">Info about the 'getVRDisplays()' definition.</span><b><a href="#navigator-getvrdisplays-attribute">#navigator-getvrdisplays-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-getvrdisplays-attribute">2.10. Navigator Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-activevrdisplays-attribute">
-   <b><a href="#navigator-activevrdisplays-attribute">#navigator-activevrdisplays-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-activevrdisplays-attribute" class="dfn-panel" data-for="navigator-activevrdisplays-attribute" id="infopanel-for-navigator-activevrdisplays-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-activevrdisplays-attribute" style="display:none">Info about the 'activeVRDisplays' definition.</span><b><a href="#navigator-activevrdisplays-attribute">#navigator-activevrdisplays-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-activevrdisplays-attribute">2.10. Navigator Interface extension</a>
     <li><a href="#ref-for-navigator-activevrdisplays-attribute①">2.10.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-vrdisplayeventreason">
-   <b><a href="#enumdef-vrdisplayeventreason">#enumdef-vrdisplayeventreason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-vrdisplayeventreason" class="dfn-panel" data-for="enumdef-vrdisplayeventreason" id="infopanel-for-enumdef-vrdisplayeventreason" role="dialog">
+   <span id="infopaneltitle-for-enumdef-vrdisplayeventreason" style="display:none">Info about the 'VRDisplayEventReason' definition.</span><b><a href="#enumdef-vrdisplayeventreason">#enumdef-vrdisplayeventreason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-vrdisplayeventreason">2.12. VRDisplayEvent</a> <a href="#ref-for-enumdef-vrdisplayeventreason①">(2)</a>
     <li><a href="#ref-for-enumdef-vrdisplayeventreason②">2.12.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayeventreason-mounted">
-   <b><a href="#dom-vrdisplayeventreason-mounted">#dom-vrdisplayeventreason-mounted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayeventreason-mounted" class="dfn-panel" data-for="dom-vrdisplayeventreason-mounted" id="infopanel-for-dom-vrdisplayeventreason-mounted" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayeventreason-mounted" style="display:none">Info about the 'mounted' definition.</span><b><a href="#dom-vrdisplayeventreason-mounted">#dom-vrdisplayeventreason-mounted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayeventreason-mounted">2.11. VRDisplayEventReason</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayeventreason-navigation">
-   <b><a href="#dom-vrdisplayeventreason-navigation">#dom-vrdisplayeventreason-navigation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayeventreason-navigation" class="dfn-panel" data-for="dom-vrdisplayeventreason-navigation" id="infopanel-for-dom-vrdisplayeventreason-navigation" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayeventreason-navigation" style="display:none">Info about the 'navigation' definition.</span><b><a href="#dom-vrdisplayeventreason-navigation">#dom-vrdisplayeventreason-navigation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayeventreason-navigation">2.11. VRDisplayEventReason</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayeventreason-requested">
-   <b><a href="#dom-vrdisplayeventreason-requested">#dom-vrdisplayeventreason-requested</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayeventreason-requested" class="dfn-panel" data-for="dom-vrdisplayeventreason-requested" id="infopanel-for-dom-vrdisplayeventreason-requested" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayeventreason-requested" style="display:none">Info about the 'requested' definition.</span><b><a href="#dom-vrdisplayeventreason-requested">#dom-vrdisplayeventreason-requested</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayeventreason-requested">2.11. VRDisplayEventReason</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayeventreason-unmounted">
-   <b><a href="#dom-vrdisplayeventreason-unmounted">#dom-vrdisplayeventreason-unmounted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayeventreason-unmounted" class="dfn-panel" data-for="dom-vrdisplayeventreason-unmounted" id="infopanel-for-dom-vrdisplayeventreason-unmounted" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayeventreason-unmounted" style="display:none">Info about the 'unmounted' definition.</span><b><a href="#dom-vrdisplayeventreason-unmounted">#dom-vrdisplayeventreason-unmounted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayeventreason-unmounted">2.11. VRDisplayEventReason</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vrdisplayevent">
-   <b><a href="#vrdisplayevent">#vrdisplayevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vrdisplayevent" class="dfn-panel" data-for="vrdisplayevent" id="infopanel-for-vrdisplayevent" role="dialog">
+   <span id="infopaneltitle-for-vrdisplayevent" style="display:none">Info about the 'VRDisplayEvent' definition.</span><b><a href="#vrdisplayevent">#vrdisplayevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vrdisplayevent">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-vrdisplayeventinit">
-   <b><a href="#dictdef-vrdisplayeventinit">#dictdef-vrdisplayeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-vrdisplayeventinit" class="dfn-panel" data-for="dictdef-vrdisplayeventinit" id="infopanel-for-dictdef-vrdisplayeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-vrdisplayeventinit" style="display:none">Info about the 'VRDisplayEventInit' definition.</span><b><a href="#dictdef-vrdisplayeventinit">#dictdef-vrdisplayeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-vrdisplayeventinit">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayevent-display">
-   <b><a href="#dom-vrdisplayevent-display">#dom-vrdisplayevent-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayevent-display" class="dfn-panel" data-for="dom-vrdisplayevent-display" id="infopanel-for-dom-vrdisplayevent-display" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayevent-display" style="display:none">Info about the 'display' definition.</span><b><a href="#dom-vrdisplayevent-display">#dom-vrdisplayevent-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayevent-display">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vrdisplayevent-reason">
-   <b><a href="#dom-vrdisplayevent-reason">#dom-vrdisplayevent-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vrdisplayevent-reason" class="dfn-panel" data-for="dom-vrdisplayevent-reason" id="infopanel-for-dom-vrdisplayevent-reason" role="dialog">
+   <span id="infopaneltitle-for-dom-vrdisplayevent-reason" style="display:none">Info about the 'reason' definition.</span><b><a href="#dom-vrdisplayevent-reason">#dom-vrdisplayevent-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vrdisplayevent-reason">2.12. VRDisplayEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-onvrdisplaypointerrestricted">
-   <b><a href="#dom-window-onvrdisplaypointerrestricted">#dom-window-onvrdisplaypointerrestricted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-onvrdisplaypointerrestricted" class="dfn-panel" data-for="dom-window-onvrdisplaypointerrestricted" id="infopanel-for-dom-window-onvrdisplaypointerrestricted" role="dialog">
+   <span id="infopaneltitle-for-dom-window-onvrdisplaypointerrestricted" style="display:none">Info about the 'onvrdisplaypointerrestricted' definition.</span><b><a href="#dom-window-onvrdisplaypointerrestricted">#dom-window-onvrdisplaypointerrestricted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-onvrdisplaypointerrestricted">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-onvrdisplaypointerunrestricted">
-   <b><a href="#dom-window-onvrdisplaypointerunrestricted">#dom-window-onvrdisplaypointerunrestricted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-onvrdisplaypointerunrestricted" class="dfn-panel" data-for="dom-window-onvrdisplaypointerunrestricted" id="infopanel-for-dom-window-onvrdisplaypointerunrestricted" role="dialog">
+   <span id="infopaneltitle-for-dom-window-onvrdisplaypointerunrestricted" style="display:none">Info about the 'onvrdisplaypointerunrestricted' definition.</span><b><a href="#dom-window-onvrdisplaypointerunrestricted">#dom-window-onvrdisplaypointerunrestricted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-onvrdisplaypointerunrestricted">2.13. Window Interface extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gamepad-getvrdisplays-attribute">
-   <b><a href="#gamepad-getvrdisplays-attribute">#gamepad-getvrdisplays-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gamepad-getvrdisplays-attribute" class="dfn-panel" data-for="gamepad-getvrdisplays-attribute" id="infopanel-for-gamepad-getvrdisplays-attribute" role="dialog">
+   <span id="infopaneltitle-for-gamepad-getvrdisplays-attribute" style="display:none">Info about the 'displayId' definition.</span><b><a href="#gamepad-getvrdisplays-attribute">#gamepad-getvrdisplays-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gamepad-getvrdisplays-attribute">2.14. Gamepad Interface extension</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/immersive-web/webxr-ar-module/index.html
+++ b/tests/github/immersive-web/webxr-ar-module/index.html
@@ -969,68 +969,68 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
    <li><a href="#enumdef-xrenvironmentblendmode">XREnvironmentBlendMode</a><span>, in § 2.2</span>
    <li><a href="#enumdef-xrinteractionmode">XRInteractionMode</a><span>, in § 2.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-porterduffcompositingoperators_plus">
-   <a href="https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_plus">https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-porterduffcompositingoperators_plus" class="dfn-panel" data-for="term-for-porterduffcompositingoperators_plus" id="infopanel-for-term-for-porterduffcompositingoperators_plus" role="menu">
+   <span id="infopaneltitle-for-term-for-porterduffcompositingoperators_plus" style="display:none">Info about the 'lighter' external reference.</span><a href="https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_plus">https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-porterduffcompositingoperators_plus">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-porterduffcompositingoperators_srcover">
-   <a href="https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_srcover">https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_srcover</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-porterduffcompositingoperators_srcover" class="dfn-panel" data-for="term-for-porterduffcompositingoperators_srcover" id="infopanel-for-term-for-porterduffcompositingoperators_srcover" role="menu">
+   <span id="infopaneltitle-for-term-for-porterduffcompositingoperators_srcover" style="display:none">Info about the 'source-over' external reference.</span><a href="https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_srcover">https://www.w3.org/TR/compositing-1#porterduffcompositingoperators_srcover</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-porterduffcompositingoperators_srcover">2.4. XR Compositor Behaviors</a> <a href="#ref-for-porterduffcompositingoperators_srcover①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-select">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-select">https://html.spec.whatwg.org/multipage/indices.html#event-select</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-select" class="dfn-panel" data-for="term-for-event-select" id="infopanel-for-term-for-event-select" role="menu">
+   <span id="infopaneltitle-for-term-for-event-select" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-select">https://html.spec.whatwg.org/multipage/indices.html#event-select</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-select">2.3. XRInteractionMode</a> <a href="#ref-for-event-select①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.5. First Person Observer Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrtargetraymode-gaze">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-gaze">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-gaze</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrtargetraymode-gaze" class="dfn-panel" data-for="term-for-dom-xrtargetraymode-gaze" id="infopanel-for-term-for-dom-xrtargetraymode-gaze" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrtargetraymode-gaze" style="display:none">Info about the '"gaze"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-gaze">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-gaze</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-gaze">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xreye-none">
-   <a href="https://immersive-web.github.io/webxr/#dom-xreye-none">https://immersive-web.github.io/webxr/#dom-xreye-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xreye-none" class="dfn-panel" data-for="term-for-dom-xreye-none" id="infopanel-for-term-for-dom-xreye-none" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xreye-none" style="display:none">Info about the '"none"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xreye-none">https://immersive-web.github.io/webxr/#dom-xreye-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xreye-none">2.5. First Person Observer Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrtargetraymode-screen">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-screen">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-screen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrtargetraymode-screen" class="dfn-panel" data-for="term-for-dom-xrtargetraymode-screen" id="infopanel-for-term-for-dom-xrtargetraymode-screen" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrtargetraymode-screen" style="display:none">Info about the '"screen"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-screen">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-screen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-screen">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrtargetraymode-tracked-pointer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrtargetraymode-tracked-pointer" class="dfn-panel" data-for="term-for-dom-xrtargetraymode-tracked-pointer" id="infopanel-for-term-for-dom-xrtargetraymode-tracked-pointer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrtargetraymode-tracked-pointer" style="display:none">Info about the '"tracked-pointer"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-tracked-pointer">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform" class="dfn-panel" data-for="term-for-xrrigidtransform" id="infopanel-for-term-for-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">2.1. XRSessionMode</a> <a href="#ref-for-xrsession①">(2)</a>
     <li><a href="#ref-for-xrsession②">2.2. XREnvironmentBlendMode</a>
@@ -1038,44 +1038,44 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
     <li><a href="#ref-for-xrsession④">2.5. First Person Observer Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrview">
-   <a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrview" class="dfn-panel" data-for="term-for-xrview" id="infopanel-for-term-for-xrview" role="menu">
+   <span id="infopaneltitle-for-term-for-xrview" style="display:none">Info about the 'XRView' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrview">https://immersive-web.github.io/webxr/#xrview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview">2.5. First Person Observer Views</a> <a href="#ref-for-xrview①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstate-baselayer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstate-baselayer" class="dfn-panel" data-for="term-for-dom-xrrenderstate-baselayer" id="infopanel-for-term-for-dom-xrrenderstate-baselayer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstate-baselayer" style="display:none">Info about the 'baseLayer' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer">https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-baselayer">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsourceevent-inputsource">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsourceevent-inputsource">https://immersive-web.github.io/webxr/#dom-xrinputsourceevent-inputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsourceevent-inputsource" class="dfn-panel" data-for="term-for-dom-xrinputsourceevent-inputsource" id="infopanel-for-term-for-dom-xrinputsourceevent-inputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsourceevent-inputsource" style="display:none">Info about the 'inputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsourceevent-inputsource">https://immersive-web.github.io/webxr/#dom-xrinputsourceevent-inputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceevent-inputsource">2.3. XRInteractionMode</a> <a href="#ref-for-dom-xrinputsourceevent-inputsource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsystem-requestsession" class="dfn-panel" data-for="term-for-dom-xrsystem-requestsession" id="infopanel-for-term-for-dom-xrsystem-requestsession" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsystem-requestsession" style="display:none">Info about the 'requestSession(mode)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession">https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-requestsession">2.5. First Person Observer Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode" id="infopanel-for-term-for-dom-xrinputsource-targetraymode" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" style="display:none">Info about the 'targetRayMode' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode">2.3. XRInteractionMode</a> <a href="#ref-for-dom-xrinputsource-targetraymode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrview-transform">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrview-transform">https://immersive-web.github.io/webxr/#dom-xrview-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrview-transform" class="dfn-panel" data-for="term-for-dom-xrview-transform" id="infopanel-for-term-for-dom-xrview-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrview-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrview-transform">https://immersive-web.github.io/webxr/#dom-xrview-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-transform">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrviewerpose-views">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrviewerpose-views">https://immersive-web.github.io/webxr/#dom-xrviewerpose-views</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrviewerpose-views" class="dfn-panel" data-for="term-for-dom-xrviewerpose-views" id="infopanel-for-term-for-dom-xrviewerpose-views" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrviewerpose-views" style="display:none">Info about the 'views' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrviewerpose-views">https://immersive-web.github.io/webxr/#dom-xrviewerpose-views</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewerpose-views">2.4. XR Compositor Behaviors</a>
     <li><a href="#ref-for-dom-xrviewerpose-views①">2.5. First Person Observer Views</a> <a href="#ref-for-dom-xrviewerpose-views②">(2)</a>
@@ -1164,8 +1164,8 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="real-world-environment">
-   <b><a href="#real-world-environment">#real-world-environment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-real-world-environment" class="dfn-panel" data-for="real-world-environment" id="infopanel-for-real-world-environment" role="dialog">
+   <span id="infopaneltitle-for-real-world-environment" style="display:none">Info about the 'real-world environment' definition.</span><b><a href="#real-world-environment">#real-world-environment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-real-world-environment">1.1. Terminology</a> <a href="#ref-for-real-world-environment①">(2)</a> <a href="#ref-for-real-world-environment②">(3)</a> <a href="#ref-for-real-world-environment③">(4)</a> <a href="#ref-for-real-world-environment④">(5)</a>
     <li><a href="#ref-for-real-world-environment⑤">2.1. XRSessionMode</a>
@@ -1173,36 +1173,36 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
     <li><a href="#ref-for-real-world-environment⑦">2.4. XR Compositor Behaviors</a> <a href="#ref-for-real-world-environment⑧">(2)</a> <a href="#ref-for-real-world-environment⑨">(3)</a> <a href="#ref-for-real-world-environment①⓪">(4)</a> <a href="#ref-for-real-world-environment①①">(5)</a> <a href="#ref-for-real-world-environment①②">(6)</a> <a href="#ref-for-real-world-environment①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="display-technology">
-   <b><a href="#display-technology">#display-technology</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-display-technology" class="dfn-panel" data-for="display-technology" id="infopanel-for-display-technology" role="dialog">
+   <span id="infopaneltitle-for-display-technology" style="display:none">Info about the 'display technology' definition.</span><b><a href="#display-technology">#display-technology</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-technology">1.1. Terminology</a> <a href="#ref-for-display-technology①">(2)</a> <a href="#ref-for-display-technology②">(3)</a>
     <li><a href="#ref-for-display-technology③">2.4. XR Compositor Behaviors</a> <a href="#ref-for-display-technology④">(2)</a> <a href="#ref-for-display-technology⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="additive-light">
-   <b><a href="#additive-light">#additive-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-additive-light" class="dfn-panel" data-for="additive-light" id="infopanel-for-additive-light" role="dialog">
+   <span id="infopaneltitle-for-additive-light" style="display:none">Info about the 'additive light' definition.</span><b><a href="#additive-light">#additive-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-additive-light">1.1. Terminology</a>
     <li><a href="#ref-for-additive-light①">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pass-through">
-   <b><a href="#pass-through">#pass-through</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pass-through" class="dfn-panel" data-for="pass-through" id="infopanel-for-pass-through" role="dialog">
+   <span id="infopaneltitle-for-pass-through" style="display:none">Info about the 'pass-through' definition.</span><b><a href="#pass-through">#pass-through</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pass-through">1.1. Terminology</a>
     <li><a href="#ref-for-pass-through①">2.4. XR Compositor Behaviors</a> <a href="#ref-for-pass-through②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque">
-   <b><a href="#opaque">#opaque</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque" class="dfn-panel" data-for="opaque" id="infopanel-for-opaque" role="dialog">
+   <span id="infopaneltitle-for-opaque" style="display:none">Info about the 'opaque' definition.</span><b><a href="#opaque">#opaque</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque">1.1. Terminology</a>
     <li><a href="#ref-for-opaque①">2.4. XR Compositor Behaviors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionmode-immersive-ar">
-   <b><a href="#dom-xrsessionmode-immersive-ar">#dom-xrsessionmode-immersive-ar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="dom-xrsessionmode-immersive-ar" id="infopanel-for-dom-xrsessionmode-immersive-ar" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the '"immersive-ar"' definition.</span><b><a href="#dom-xrsessionmode-immersive-ar">#dom-xrsessionmode-immersive-ar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">1.1. Terminology</a>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar①">2.1. XRSessionMode</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar②">(2)</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar③">(3)</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar④">(4)</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar⑤">(5)</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar⑥">(6)</a>
@@ -1210,65 +1210,65 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar⑨">3. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrenvironmentblendmode">
-   <b><a href="#enumdef-xrenvironmentblendmode">#enumdef-xrenvironmentblendmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrenvironmentblendmode" class="dfn-panel" data-for="enumdef-xrenvironmentblendmode" id="infopanel-for-enumdef-xrenvironmentblendmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrenvironmentblendmode" style="display:none">Info about the 'XREnvironmentBlendMode' definition.</span><b><a href="#enumdef-xrenvironmentblendmode">#enumdef-xrenvironmentblendmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrenvironmentblendmode">2.2. XREnvironmentBlendMode</a> <a href="#ref-for-enumdef-xrenvironmentblendmode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-environmentblendmode">
-   <b><a href="#dom-xrsession-environmentblendmode">#dom-xrsession-environmentblendmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-environmentblendmode" class="dfn-panel" data-for="dom-xrsession-environmentblendmode" id="infopanel-for-dom-xrsession-environmentblendmode" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-environmentblendmode" style="display:none">Info about the 'environmentBlendMode' definition.</span><b><a href="#dom-xrsession-environmentblendmode">#dom-xrsession-environmentblendmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-environmentblendmode">2.2. XREnvironmentBlendMode</a>
     <li><a href="#ref-for-dom-xrsession-environmentblendmode①">2.5. First Person Observer Views</a>
     <li><a href="#ref-for-dom-xrsession-environmentblendmode②">3. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrenvironmentblendmode-opaque">
-   <b><a href="#dom-xrenvironmentblendmode-opaque">#dom-xrenvironmentblendmode-opaque</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrenvironmentblendmode-opaque" class="dfn-panel" data-for="dom-xrenvironmentblendmode-opaque" id="infopanel-for-dom-xrenvironmentblendmode-opaque" role="dialog">
+   <span id="infopaneltitle-for-dom-xrenvironmentblendmode-opaque" style="display:none">Info about the 'opaque' definition.</span><b><a href="#dom-xrenvironmentblendmode-opaque">#dom-xrenvironmentblendmode-opaque</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrenvironmentblendmode-opaque">2.2. XREnvironmentBlendMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrenvironmentblendmode-alpha-blend">
-   <b><a href="#dom-xrenvironmentblendmode-alpha-blend">#dom-xrenvironmentblendmode-alpha-blend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrenvironmentblendmode-alpha-blend" class="dfn-panel" data-for="dom-xrenvironmentblendmode-alpha-blend" id="infopanel-for-dom-xrenvironmentblendmode-alpha-blend" role="dialog">
+   <span id="infopaneltitle-for-dom-xrenvironmentblendmode-alpha-blend" style="display:none">Info about the 'alpha-blend' definition.</span><b><a href="#dom-xrenvironmentblendmode-alpha-blend">#dom-xrenvironmentblendmode-alpha-blend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrenvironmentblendmode-alpha-blend">2.2. XREnvironmentBlendMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrenvironmentblendmode-additive">
-   <b><a href="#dom-xrenvironmentblendmode-additive">#dom-xrenvironmentblendmode-additive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrenvironmentblendmode-additive" class="dfn-panel" data-for="dom-xrenvironmentblendmode-additive" id="infopanel-for-dom-xrenvironmentblendmode-additive" role="dialog">
+   <span id="infopaneltitle-for-dom-xrenvironmentblendmode-additive" style="display:none">Info about the 'additive' definition.</span><b><a href="#dom-xrenvironmentblendmode-additive">#dom-xrenvironmentblendmode-additive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrenvironmentblendmode-additive">2.2. XREnvironmentBlendMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrinteractionmode">
-   <b><a href="#enumdef-xrinteractionmode">#enumdef-xrinteractionmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrinteractionmode" class="dfn-panel" data-for="enumdef-xrinteractionmode" id="infopanel-for-enumdef-xrinteractionmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrinteractionmode" style="display:none">Info about the 'XRInteractionMode' definition.</span><b><a href="#enumdef-xrinteractionmode">#enumdef-xrinteractionmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrinteractionmode">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinteractionmode-screen-space">
-   <b><a href="#dom-xrinteractionmode-screen-space">#dom-xrinteractionmode-screen-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinteractionmode-screen-space" class="dfn-panel" data-for="dom-xrinteractionmode-screen-space" id="infopanel-for-dom-xrinteractionmode-screen-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinteractionmode-screen-space" style="display:none">Info about the '"screen-space"' definition.</span><b><a href="#dom-xrinteractionmode-screen-space">#dom-xrinteractionmode-screen-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinteractionmode-screen-space">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinteractionmode-world-space">
-   <b><a href="#dom-xrinteractionmode-world-space">#dom-xrinteractionmode-world-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinteractionmode-world-space" class="dfn-panel" data-for="dom-xrinteractionmode-world-space" id="infopanel-for-dom-xrinteractionmode-world-space" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinteractionmode-world-space" style="display:none">Info about the '"world-space"' definition.</span><b><a href="#dom-xrinteractionmode-world-space">#dom-xrinteractionmode-world-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinteractionmode-world-space">2.3. XRInteractionMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-interactionmode">
-   <b><a href="#dom-xrsession-interactionmode">#dom-xrsession-interactionmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-interactionmode" class="dfn-panel" data-for="dom-xrsession-interactionmode" id="infopanel-for-dom-xrsession-interactionmode" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-interactionmode" style="display:none">Info about the 'interactionMode' definition.</span><b><a href="#dom-xrsession-interactionmode">#dom-xrsession-interactionmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-interactionmode">2.3. XRInteractionMode</a> <a href="#ref-for-dom-xrsession-interactionmode①">(2)</a> <a href="#ref-for-dom-xrsession-interactionmode②">(3)</a>
     <li><a href="#ref-for-dom-xrsession-interactionmode③">3. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blend-technique">
-   <b><a href="#blend-technique">#blend-technique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blend-technique" class="dfn-panel" data-for="blend-technique" id="infopanel-for-blend-technique" role="dialog">
+   <span id="infopaneltitle-for-blend-technique" style="display:none">Info about the 'blend technique' definition.</span><b><a href="#blend-technique">#blend-technique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blend-technique">2.1. XRSessionMode</a>
     <li><a href="#ref-for-blend-technique①">2.2. XREnvironmentBlendMode</a>
@@ -1276,91 +1276,147 @@ not be obvious to end users and user agents SHOULD clarify this.</p>
     <li><a href="#ref-for-blend-technique③">2.5. First Person Observer Views</a> <a href="#ref-for-blend-technique④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-environment-blending">
-   <b><a href="#opaque-environment-blending">#opaque-environment-blending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-environment-blending" class="dfn-panel" data-for="opaque-environment-blending" id="infopanel-for-opaque-environment-blending" role="dialog">
+   <span id="infopaneltitle-for-opaque-environment-blending" style="display:none">Info about the 'opaque environment blending' definition.</span><b><a href="#opaque-environment-blending">#opaque-environment-blending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-environment-blending">2.2. XREnvironmentBlendMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alpha-blend-environment-blending">
-   <b><a href="#alpha-blend-environment-blending">#alpha-blend-environment-blending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alpha-blend-environment-blending" class="dfn-panel" data-for="alpha-blend-environment-blending" id="infopanel-for-alpha-blend-environment-blending" role="dialog">
+   <span id="infopaneltitle-for-alpha-blend-environment-blending" style="display:none">Info about the 'alpha-blend environment blending' definition.</span><b><a href="#alpha-blend-environment-blending">#alpha-blend-environment-blending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alpha-blend-environment-blending">2.2. XREnvironmentBlendMode</a>
     <li><a href="#ref-for-alpha-blend-environment-blending①">2.4. XR Compositor Behaviors</a>
     <li><a href="#ref-for-alpha-blend-environment-blending②">2.5. First Person Observer Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="additive-environment-blending">
-   <b><a href="#additive-environment-blending">#additive-environment-blending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-additive-environment-blending" class="dfn-panel" data-for="additive-environment-blending" id="infopanel-for-additive-environment-blending" role="dialog">
+   <span id="infopaneltitle-for-additive-environment-blending" style="display:none">Info about the 'additive environment blending' definition.</span><b><a href="#additive-environment-blending">#additive-environment-blending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-additive-environment-blending">2.2. XREnvironmentBlendMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-person-observer-view">
-   <b><a href="#first-person-observer-view">#first-person-observer-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-person-observer-view" class="dfn-panel" data-for="first-person-observer-view" id="infopanel-for-first-person-observer-view" role="dialog">
+   <span id="infopaneltitle-for-first-person-observer-view" style="display:none">Info about the 'first-person observer view' definition.</span><b><a href="#first-person-observer-view">#first-person-observer-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-person-observer-view">2.5. First Person Observer Views</a> <a href="#ref-for-first-person-observer-view①">(2)</a> <a href="#ref-for-first-person-observer-view②">(3)</a> <a href="#ref-for-first-person-observer-view③">(4)</a> <a href="#ref-for-first-person-observer-view④">(5)</a> <a href="#ref-for-first-person-observer-view⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-isfirstpersonobserver">
-   <b><a href="#dom-xrview-isfirstpersonobserver">#dom-xrview-isfirstpersonobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-isfirstpersonobserver" class="dfn-panel" data-for="dom-xrview-isfirstpersonobserver" id="infopanel-for-dom-xrview-isfirstpersonobserver" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-isfirstpersonobserver" style="display:none">Info about the 'isFirstPersonObserver' definition.</span><b><a href="#dom-xrview-isfirstpersonobserver">#dom-xrview-isfirstpersonobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-isfirstpersonobserver">2.5. First Person Observer Views</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/immersive-web/webxr-gamepads-module/index.html
+++ b/tests/github/immersive-web/webxr-gamepads-module/index.html
@@ -932,8 +932,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#xr-input-source">XR input source</a><span>, in § 2</span>
    <li><a href="#xr-standard-gamepad-mapping">"xr-standard" Gamepad Mapping</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad">https://w3c.github.io/gamepad/#dom-gamepad</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad" class="dfn-panel" data-for="term-for-dom-gamepad" id="infopanel-for-term-for-dom-gamepad" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad" style="display:none">Info about the 'Gamepad' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad">https://w3c.github.io/gamepad/#dom-gamepad</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad">2.1. XRInputSource</a> <a href="#ref-for-dom-gamepad①">(2)</a> <a href="#ref-for-dom-gamepad②">(3)</a>
     <li><a href="#ref-for-dom-gamepad③">3. Gamepad API Integration</a>
@@ -942,101 +942,101 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-dom-gamepad⑧">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadbutton">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadbutton">https://w3c.github.io/gamepad/#dom-gamepadbutton</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadbutton" class="dfn-panel" data-for="term-for-dom-gamepadbutton" id="infopanel-for-term-for-dom-gamepadbutton" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadbutton" style="display:none">Info about the 'GamepadButton' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadbutton">https://w3c.github.io/gamepad/#dom-gamepadbutton</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadbutton">3.2. Gamepad</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-axes">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-axes">https://w3c.github.io/gamepad/#dom-gamepad-axes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-axes" class="dfn-panel" data-for="term-for-dom-gamepad-axes" id="infopanel-for-term-for-dom-gamepad-axes" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-axes" style="display:none">Info about the 'axes' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-axes">https://w3c.github.io/gamepad/#dom-gamepad-axes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-axes">3.2. Gamepad</a>
     <li><a href="#ref-for-dom-gamepad-axes①">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-buttons">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-buttons">https://w3c.github.io/gamepad/#dom-gamepad-buttons</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-buttons" class="dfn-panel" data-for="term-for-dom-gamepad-buttons" id="infopanel-for-term-for-dom-gamepad-buttons" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-buttons" style="display:none">Info about the 'buttons' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-buttons">https://w3c.github.io/gamepad/#dom-gamepad-buttons</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-buttons">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-connected">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-connected">https://w3c.github.io/gamepad/#dom-gamepad-connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-connected" class="dfn-panel" data-for="term-for-dom-gamepad-connected" id="infopanel-for-term-for-dom-gamepad-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-connected">https://w3c.github.io/gamepad/#dom-gamepad-connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-connected">3.2. Gamepad</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-id">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-id">https://w3c.github.io/gamepad/#dom-gamepad-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-id" class="dfn-panel" data-for="term-for-dom-gamepad-id" id="infopanel-for-term-for-dom-gamepad-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-id" style="display:none">Info about the 'id' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-id">https://w3c.github.io/gamepad/#dom-gamepad-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-id">3.2. Gamepad</a>
     <li><a href="#ref-for-dom-gamepad-id①">4.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-index">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-index">https://w3c.github.io/gamepad/#dom-gamepad-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-index" class="dfn-panel" data-for="term-for-dom-gamepad-index" id="infopanel-for-term-for-dom-gamepad-index" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-index" style="display:none">Info about the 'index' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-index">https://w3c.github.io/gamepad/#dom-gamepad-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-index">3.2. Gamepad</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepad-mapping">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepad-mapping">https://w3c.github.io/gamepad/#dom-gamepad-mapping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepad-mapping" class="dfn-panel" data-for="term-for-dom-gamepad-mapping" id="infopanel-for-term-for-dom-gamepad-mapping" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepad-mapping" style="display:none">Info about the 'mapping' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepad-mapping">https://w3c.github.io/gamepad/#dom-gamepad-mapping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepad-mapping">3.3. "xr-standard" Gamepad Mapping</a> <a href="#ref-for-dom-gamepad-mapping①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-getgamepads">
-   <a href="https://w3c.github.io/gamepad/#dom-navigator-getgamepads">https://w3c.github.io/gamepad/#dom-navigator-getgamepads</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-getgamepads" class="dfn-panel" data-for="term-for-dom-navigator-getgamepads" id="infopanel-for-term-for-dom-navigator-getgamepads" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-getgamepads" style="display:none">Info about the 'navigator.getGamepads()' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-navigator-getgamepads">https://w3c.github.io/gamepad/#dom-navigator-getgamepads</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-getgamepads">3.1. Navigator</a> <a href="#ref-for-dom-navigator-getgamepads①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadbutton-pressed">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed">https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadbutton-pressed" class="dfn-panel" data-for="term-for-dom-gamepadbutton-pressed" id="infopanel-for-term-for-dom-gamepadbutton-pressed" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadbutton-pressed" style="display:none">Info about the 'pressed' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed">https://w3c.github.io/gamepad/#dom-gamepadbutton-pressed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadbutton-pressed">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadbutton-touched">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-touched">https://w3c.github.io/gamepad/#dom-gamepadbutton-touched</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadbutton-touched" class="dfn-panel" data-for="term-for-dom-gamepadbutton-touched" id="infopanel-for-term-for-dom-gamepadbutton-touched" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadbutton-touched" style="display:none">Info about the 'touched' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-touched">https://w3c.github.io/gamepad/#dom-gamepadbutton-touched</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadbutton-touched">3.2. Gamepad</a>
     <li><a href="#ref-for-dom-gamepadbutton-touched①">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadbutton-value">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-value">https://w3c.github.io/gamepad/#dom-gamepadbutton-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadbutton-value" class="dfn-panel" data-for="term-for-dom-gamepadbutton-value" id="infopanel-for-term-for-dom-gamepadbutton-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadbutton-value" style="display:none">Info about the 'value' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadbutton-value">https://w3c.github.io/gamepad/#dom-gamepadbutton-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadbutton-value">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadmappingtype-xr-standard">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard">https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadmappingtype-xr-standard" class="dfn-panel" data-for="term-for-dom-gamepadmappingtype-xr-standard" id="infopanel-for-term-for-dom-gamepadmappingtype-xr-standard" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadmappingtype-xr-standard" style="display:none">Info about the 'xr-standard' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard">https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadmappingtype-xr-standard">3.3. "xr-standard" Gamepad Mapping</a> <a href="#ref-for-dom-gamepadmappingtype-xr-standard①">(2)</a> <a href="#ref-for-dom-gamepadmappingtype-xr-standard②">(3)</a> <a href="#ref-for-dom-gamepadmappingtype-xr-standard③">(4)</a> <a href="#ref-for-dom-gamepadmappingtype-xr-standard④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrtargetraymode-tracked-pointer">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrtargetraymode-tracked-pointer" class="dfn-panel" data-for="term-for-dom-xrtargetraymode-tracked-pointer" id="infopanel-for-term-for-dom-xrtargetraymode-tracked-pointer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrtargetraymode-tracked-pointer" style="display:none">Info about the '"tracked-pointer"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer">https://immersive-web.github.io/webxr/#dom-xrtargetraymode-tracked-pointer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-tracked-pointer">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">2.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource">
-   <a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource" class="dfn-panel" data-for="term-for-xrinputsource" id="infopanel-for-term-for-xrinputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource" style="display:none">Info about the 'XRInputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">2. WebXR Device API Integration</a> <a href="#ref-for-xrinputsource①">(2)</a>
     <li><a href="#ref-for-xrinputsource②">2.1. XRInputSource</a> <a href="#ref-for-xrinputsource③">(2)</a>
@@ -1048,45 +1048,45 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xrinputsource①③">4.1. Fingerprinting</a> <a href="#ref-for-xrinputsource①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">3.2. Gamepad</a>
     <li><a href="#ref-for-xrsession①">4.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-gripspace">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-gripspace" class="dfn-panel" data-for="term-for-dom-xrinputsource-gripspace" id="infopanel-for-term-for-dom-xrinputsource-gripspace" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-gripspace" style="display:none">Info about the 'gripSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-gripspace">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-inputsources">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-inputsources">https://immersive-web.github.io/webxr/#dom-xrsession-inputsources</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-inputsources" class="dfn-panel" data-for="term-for-dom-xrsession-inputsources" id="infopanel-for-term-for-dom-xrsession-inputsources" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-inputsources" style="display:none">Info about the 'inputSources' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-inputsources">https://immersive-web.github.io/webxr/#dom-xrsession-inputsources</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-inputsources">2.2. XRSession</a> <a href="#ref-for-dom-xrsession-inputsources①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">2.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode" id="infopanel-for-term-for-dom-xrinputsource-targetraymode" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" style="display:none">Info about the 'targetRayMode' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates">
-   <a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" class="dfn-panel" data-for="term-for-xrsession-list-of-frame-updates" id="infopanel-for-term-for-xrsession-list-of-frame-updates" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession-list-of-frame-updates" style="display:none">Info about the 'list of frame updates' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates">https://www.w3.org/TR/webxr/#xrsession-list-of-frame-updates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-frame-updates">2.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe-time">
-   <a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe-time" class="dfn-panel" data-for="term-for-xrframe-time" id="infopanel-for-term-for-xrframe-time" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe-time" style="display:none">Info about the 'time' external reference.</span><a href="https://www.w3.org/TR/webxr/#xrframe-time">https://www.w3.org/TR/webxr/#xrframe-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-time">2.2. XRSession</a>
    </ul>
@@ -1152,15 +1152,15 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="xr-input-source">
-   <b><a href="#xr-input-source">#xr-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-input-source" class="dfn-panel" data-for="xr-input-source" id="infopanel-for-xr-input-source" role="dialog">
+   <span id="infopaneltitle-for-xr-input-source" style="display:none">Info about the 'XR input source' definition.</span><b><a href="#xr-input-source">#xr-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-input-source">2. WebXR Device API Integration</a> <a href="#ref-for-xr-input-source①">(2)</a>
     <li><a href="#ref-for-xr-input-source②">2.1. XRInputSource</a> <a href="#ref-for-xr-input-source③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-gamepad">
-   <b><a href="#dom-xrinputsource-gamepad">#dom-xrinputsource-gamepad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-gamepad" class="dfn-panel" data-for="dom-xrinputsource-gamepad" id="infopanel-for-dom-xrinputsource-gamepad" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-gamepad" style="display:none">Info about the 'gamepad' definition.</span><b><a href="#dom-xrinputsource-gamepad">#dom-xrinputsource-gamepad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-gamepad">2.1. XRInputSource</a>
     <li><a href="#ref-for-dom-xrinputsource-gamepad①">2.2. XRSession</a> <a href="#ref-for-dom-xrinputsource-gamepad②">(2)</a> <a href="#ref-for-dom-xrinputsource-gamepad③">(3)</a>
@@ -1171,89 +1171,145 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-dom-xrinputsource-gamepad①③">4.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-apply-gamepad-frame-updates">
-   <b><a href="#xrframe-apply-gamepad-frame-updates">#xrframe-apply-gamepad-frame-updates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-apply-gamepad-frame-updates" class="dfn-panel" data-for="xrframe-apply-gamepad-frame-updates" id="infopanel-for-xrframe-apply-gamepad-frame-updates" role="dialog">
+   <span id="infopaneltitle-for-xrframe-apply-gamepad-frame-updates" style="display:none">Info about the 'apply gamepad frame updates' definition.</span><b><a href="#xrframe-apply-gamepad-frame-updates">#xrframe-apply-gamepad-frame-updates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-apply-gamepad-frame-updates">2.2. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-trigger">
-   <b><a href="#primary-trigger">#primary-trigger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-trigger" class="dfn-panel" data-for="primary-trigger" id="infopanel-for-primary-trigger" role="dialog">
+   <span id="infopaneltitle-for-primary-trigger" style="display:none">Info about the 'primary trigger' definition.</span><b><a href="#primary-trigger">#primary-trigger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-trigger">3.3. "xr-standard" Gamepad Mapping</a> <a href="#ref-for-primary-trigger①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-squeeze-button">
-   <b><a href="#primary-squeeze-button">#primary-squeeze-button</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-squeeze-button" class="dfn-panel" data-for="primary-squeeze-button" id="infopanel-for-primary-squeeze-button" role="dialog">
+   <span id="infopaneltitle-for-primary-squeeze-button" style="display:none">Info about the 'primary squeeze button' definition.</span><b><a href="#primary-squeeze-button">#primary-squeeze-button</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-squeeze-button">3.3. "xr-standard" Gamepad Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="placeholder-button">
-   <b><a href="#placeholder-button">#placeholder-button</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-placeholder-button" class="dfn-panel" data-for="placeholder-button" id="infopanel-for-placeholder-button" role="dialog">
+   <span id="infopaneltitle-for-placeholder-button" style="display:none">Info about the 'placeholder button' definition.</span><b><a href="#placeholder-button">#placeholder-button</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-placeholder-button">3.3. "xr-standard" Gamepad Mapping</a> <a href="#ref-for-placeholder-button①">(2)</a> <a href="#ref-for-placeholder-button②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="placeholder-axis">
-   <b><a href="#placeholder-axis">#placeholder-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-placeholder-axis" class="dfn-panel" data-for="placeholder-axis" id="infopanel-for-placeholder-axis" role="dialog">
+   <span id="infopaneltitle-for-placeholder-axis" style="display:none">Info about the 'placeholder axis' definition.</span><b><a href="#placeholder-axis">#placeholder-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-placeholder-axis">3.3. "xr-standard" Gamepad Mapping</a> <a href="#ref-for-placeholder-axis①">(2)</a> <a href="#ref-for-placeholder-axis②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/immersive-web/webxr-hand-input/index.html
+++ b/tests/github/immersive-web/webxr-hand-input/index.html
@@ -1609,173 +1609,173 @@ before revealing it through the WebXR Hand Input API.</p>
    <li><a href="#xrjointpose">XRJointPose</a><span>, in § 4.2</span>
    <li><a href="#xrjointspace">XRJointSpace</a><span>, in § 3.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">5. Privacy &amp; Security Considerations</a> <a href="#ref-for-browsing-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.1. XRFrame</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent-active">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent-active">https://w3c.github.io/ServiceWorker/#extendableevent-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent-active" class="dfn-panel" data-for="term-for-extendableevent-active" id="infopanel-for-term-for-extendableevent-active" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent-active" style="display:none">Info about the 'active' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent-active">https://w3c.github.io/ServiceWorker/#extendableevent-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-active">4.1. XRFrame</a> <a href="#ref-for-extendableevent-active①">(2)</a> <a href="#ref-for-extendableevent-active②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.3. XRHand</a>
     <li><a href="#ref-for-Exposed①">3.4. XRJointSpace</a>
     <li><a href="#ref-for-Exposed②">4.2. XRJointPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">4.1. XRFrame</a> <a href="#ref-for-idl-Float32Array①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1. XRFrame</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a> <a href="#ref-for-invalidstateerror④">(5)</a> <a href="#ref-for-invalidstateerror⑤">(6)</a> <a href="#ref-for-invalidstateerror⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">4.1. XRFrame</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.1. XRFrame</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">4.2. XRJointPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">4.1. XRFrame</a> <a href="#ref-for-new①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.1. XRFrame</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. XRInputSource</a>
     <li><a href="#ref-for-this①">3.3. XRHand</a> <a href="#ref-for-this②">(2)</a>
     <li><a href="#ref-for-this③">4.1. XRFrame</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a> <a href="#ref-for-this⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-pair">
-   <a href="https://webidl.spec.whatwg.org/#value-pair">https://webidl.spec.whatwg.org/#value-pair</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-pair" class="dfn-panel" data-for="term-for-value-pair" id="infopanel-for-term-for-value-pair" role="menu">
+   <span id="infopaneltitle-for-term-for-value-pair" style="display:none">Info about the 'value pair' external reference.</span><a href="https://webidl.spec.whatwg.org/#value-pair">https://webidl.spec.whatwg.org/#value-pair</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-pair">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over">
-   <a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over" id="infopanel-for-term-for-dfn-value-pairs-to-iterate-over" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-vr" id="infopanel-for-term-for-dom-xrsessionmode-immersive-vr" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-vr" style="display:none">Info about the '"immersive-vr"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr">https://immersive-web.github.io/webxr/#dom-xrsessionmode-immersive-vr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr">5. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-inline">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline">https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-inline" class="dfn-panel" data-for="term-for-dom-xrsessionmode-inline" id="infopanel-for-term-for-dom-xrsessionmode-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-inline" style="display:none">Info about the '"inline"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline">https://immersive-web.github.io/webxr/#dom-xrsessionmode-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-inline">5. Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrframe">
-   <a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrframe" class="dfn-panel" data-for="term-for-xrframe" id="infopanel-for-term-for-xrframe" role="menu">
+   <span id="infopaneltitle-for-term-for-xrframe" style="display:none">Info about the 'XRFrame' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrframe">https://immersive-web.github.io/webxr/#xrframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">4.1. XRFrame</a> <a href="#ref-for-xrframe①">(2)</a> <a href="#ref-for-xrframe②">(3)</a> <a href="#ref-for-xrframe③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource">
-   <a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource" class="dfn-panel" data-for="term-for-xrinputsource" id="infopanel-for-term-for-xrinputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource" style="display:none">Info about the 'XRInputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">2. Initialization</a>
     <li><a href="#ref-for-xrinputsource①">3. Physical Hand Input Sources</a>
     <li><a href="#ref-for-xrinputsource②">3.1. XRInputSource</a> <a href="#ref-for-xrinputsource③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrpose">
-   <a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrpose" class="dfn-panel" data-for="term-for-xrpose" id="infopanel-for-term-for-xrpose" role="menu">
+   <span id="infopaneltitle-for-term-for-xrpose" style="display:none">Info about the 'XRPose' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpose">4.1. XRFrame</a>
     <li><a href="#ref-for-xrpose①">4.2. XRJointPose</a> <a href="#ref-for-xrpose②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">2. Initialization</a> <a href="#ref-for-xrsession①">(2)</a>
     <li><a href="#ref-for-xrsession②">3.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrspace">
-   <a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrspace" class="dfn-panel" data-for="term-for-xrspace" id="infopanel-for-term-for-xrspace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrspace" style="display:none">Info about the 'XRSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrspace">https://immersive-web.github.io/webxr/#xrspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">3.4. XRJointSpace</a>
     <li><a href="#ref-for-xrspace①">4.1. XRFrame</a> <a href="#ref-for-xrspace②">(2)</a> <a href="#ref-for-xrspace③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-matrix">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-matrix" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-matrix" id="infopanel-for-term-for-dom-xrrigidtransform-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-matrix" style="display:none">Info about the 'matrix' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-matrix">4.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-profiles" class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles" id="infopanel-for-term-for-dom-xrinputsource-profiles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-profiles" style="display:none">Info about the 'profiles' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-profiles">3. Physical Hand Input Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrframe-session">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrframe-session" class="dfn-panel" data-for="term-for-dom-xrframe-session" id="infopanel-for-term-for-dom-xrframe-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrframe-session" style="display:none">Info about the 'session' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrframe-session">https://immersive-web.github.io/webxr/#dom-xrframe-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">4.1. XRFrame</a> <a href="#ref-for-dom-xrframe-session①">(2)</a> <a href="#ref-for-dom-xrframe-session②">(3)</a> <a href="#ref-for-dom-xrframe-session③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar">
-   <a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="term-for-dom-xrsessionmode-immersive-ar" id="infopanel-for-term-for-dom-xrsessionmode-immersive-ar" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the '"immersive-ar"' external reference.</span><a href="https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar">https://immersive-web.github.io/webxr-ar-module/#dom-xrsessionmode-immersive-ar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">5. Privacy &amp; Security Considerations</a>
    </ul>
@@ -1920,15 +1920,15 @@ before revealing it through the WebXR Hand Input API.</p>
   <div style="counter-reset:issue">
    <div class="issue"> This by default precludes faithfully exposing polydactyl/oligodactyl hands, however for fingerprinting concerns it will likely need to be a separate opt-in, anyway. See <a href="https://github.com/immersive-web/webxr-hand-input/issues/11">Issue 11</a> for more details. <a class="issue-return" href="#issue-9a52d08f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="feature-descriptor-hand-tracking">
-   <b><a href="#feature-descriptor-hand-tracking">#feature-descriptor-hand-tracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-descriptor-hand-tracking" class="dfn-panel" data-for="feature-descriptor-hand-tracking" id="infopanel-for-feature-descriptor-hand-tracking" role="dialog">
+   <span id="infopaneltitle-for-feature-descriptor-hand-tracking" style="display:none">Info about the 'hand-tracking' definition.</span><b><a href="#feature-descriptor-hand-tracking">#feature-descriptor-hand-tracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor-hand-tracking">2. Initialization</a> <a href="#ref-for-feature-descriptor-hand-tracking①">(2)</a>
     <li><a href="#ref-for-feature-descriptor-hand-tracking②">3.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="physical-hand-input-source">
-   <b><a href="#physical-hand-input-source">#physical-hand-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-physical-hand-input-source" class="dfn-panel" data-for="physical-hand-input-source" id="infopanel-for-physical-hand-input-source" role="dialog">
+   <span id="infopaneltitle-for-physical-hand-input-source" style="display:none">Info about the 'physical hand input source' definition.</span><b><a href="#physical-hand-input-source">#physical-hand-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-hand-input-source">2. Initialization</a>
     <li><a href="#ref-for-physical-hand-input-source①">3. Physical Hand Input Sources</a> <a href="#ref-for-physical-hand-input-source②">(2)</a> <a href="#ref-for-physical-hand-input-source③">(3)</a>
@@ -1937,21 +1937,21 @@ before revealing it through the WebXR Hand Input API.</p>
     <li><a href="#ref-for-physical-hand-input-source⑥">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supports-hand-tracking">
-   <b><a href="#supports-hand-tracking">#supports-hand-tracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supports-hand-tracking" class="dfn-panel" data-for="supports-hand-tracking" id="infopanel-for-supports-hand-tracking" role="dialog">
+   <span id="infopaneltitle-for-supports-hand-tracking" style="display:none">Info about the 'supports hand tracking' definition.</span><b><a href="#supports-hand-tracking">#supports-hand-tracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supports-hand-tracking">2. Initialization</a>
     <li><a href="#ref-for-supports-hand-tracking①">3.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-hand">
-   <b><a href="#dom-xrinputsource-hand">#dom-xrinputsource-hand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-hand" class="dfn-panel" data-for="dom-xrinputsource-hand" id="infopanel-for-dom-xrinputsource-hand" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-hand" style="display:none">Info about the 'hand' definition.</span><b><a href="#dom-xrinputsource-hand">#dom-xrinputsource-hand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-hand">3.1. XRInputSource</a> <a href="#ref-for-dom-xrinputsource-hand①">(2)</a> <a href="#ref-for-dom-xrinputsource-hand②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="skeleton-joints">
-   <b><a href="#skeleton-joints">#skeleton-joints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-skeleton-joints" class="dfn-panel" data-for="skeleton-joints" id="infopanel-for-skeleton-joints" role="dialog">
+   <span id="infopaneltitle-for-skeleton-joints" style="display:none">Info about the 'skeleton joints' definition.</span><b><a href="#skeleton-joints">#skeleton-joints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skeleton-joints">1. Introduction</a>
     <li><a href="#ref-for-skeleton-joints①">3. Physical Hand Input Sources</a>
@@ -1961,269 +1961,269 @@ before revealing it through the WebXR Hand Input API.</p>
     <li><a href="#ref-for-skeleton-joints①③">4.2. XRJointPose</a> <a href="#ref-for-skeleton-joints①④">(2)</a> <a href="#ref-for-skeleton-joints①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="skeleton-joint-name">
-   <b><a href="#skeleton-joint-name">#skeleton-joint-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-skeleton-joint-name" class="dfn-panel" data-for="skeleton-joint-name" id="infopanel-for-skeleton-joint-name" role="dialog">
+   <span id="infopaneltitle-for-skeleton-joint-name" style="display:none">Info about the 'skeleton joint name' definition.</span><b><a href="#skeleton-joint-name">#skeleton-joint-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skeleton-joint-name">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-bone">
-   <b><a href="#associated-bone">#associated-bone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-bone" class="dfn-panel" data-for="associated-bone" id="infopanel-for-associated-bone" role="dialog">
+   <span id="infopaneltitle-for-associated-bone" style="display:none">Info about the 'associated bone' definition.</span><b><a href="#associated-bone">#associated-bone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-bone">3.2. Skeleton Joints</a> <a href="#ref-for-associated-bone①">(2)</a>
     <li><a href="#ref-for-associated-bone②">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="skeleton-joint-radius">
-   <b><a href="#skeleton-joint-radius">#skeleton-joint-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-skeleton-joint-radius" class="dfn-panel" data-for="skeleton-joint-radius" id="infopanel-for-skeleton-joint-radius" role="dialog">
+   <span id="infopaneltitle-for-skeleton-joint-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#skeleton-joint-radius">#skeleton-joint-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skeleton-joint-radius">4.1. XRFrame</a> <a href="#ref-for-skeleton-joint-radius①">(2)</a>
     <li><a href="#ref-for-skeleton-joint-radius②">4.2. XRJointPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-joints">
-   <b><a href="#list-of-joints">#list-of-joints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-joints" class="dfn-panel" data-for="list-of-joints" id="infopanel-for-list-of-joints" role="dialog">
+   <span id="infopaneltitle-for-list-of-joints" style="display:none">Info about the 'list of joints' definition.</span><b><a href="#list-of-joints">#list-of-joints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-joints">3.3. XRHand</a> <a href="#ref-for-list-of-joints①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrhandjoint">
-   <b><a href="#enumdef-xrhandjoint">#enumdef-xrhandjoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrhandjoint" class="dfn-panel" data-for="enumdef-xrhandjoint" id="infopanel-for-enumdef-xrhandjoint" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrhandjoint" style="display:none">Info about the 'XRHandJoint' definition.</span><b><a href="#enumdef-xrhandjoint">#enumdef-xrhandjoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrhandjoint">3.2. Skeleton Joints</a>
     <li><a href="#ref-for-enumdef-xrhandjoint①">3.3. XRHand</a> <a href="#ref-for-enumdef-xrhandjoint②">(2)</a> <a href="#ref-for-enumdef-xrhandjoint③">(3)</a> <a href="#ref-for-enumdef-xrhandjoint④">(4)</a> <a href="#ref-for-enumdef-xrhandjoint⑤">(5)</a> <a href="#ref-for-enumdef-xrhandjoint⑥">(6)</a>
     <li><a href="#ref-for-enumdef-xrhandjoint⑦">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-wrist">
-   <b><a href="#dom-xrhandjoint-wrist">#dom-xrhandjoint-wrist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-wrist" class="dfn-panel" data-for="dom-xrhandjoint-wrist" id="infopanel-for-dom-xrhandjoint-wrist" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-wrist" style="display:none">Info about the '"wrist"' definition.</span><b><a href="#dom-xrhandjoint-wrist">#dom-xrhandjoint-wrist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-wrist">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-thumb-metacarpal">
-   <b><a href="#dom-xrhandjoint-thumb-metacarpal">#dom-xrhandjoint-thumb-metacarpal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-thumb-metacarpal" class="dfn-panel" data-for="dom-xrhandjoint-thumb-metacarpal" id="infopanel-for-dom-xrhandjoint-thumb-metacarpal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-thumb-metacarpal" style="display:none">Info about the '"thumb-metacarpal"' definition.</span><b><a href="#dom-xrhandjoint-thumb-metacarpal">#dom-xrhandjoint-thumb-metacarpal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-thumb-metacarpal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-thumb-phalanx-proximal">
-   <b><a href="#dom-xrhandjoint-thumb-phalanx-proximal">#dom-xrhandjoint-thumb-phalanx-proximal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-thumb-phalanx-proximal" class="dfn-panel" data-for="dom-xrhandjoint-thumb-phalanx-proximal" id="infopanel-for-dom-xrhandjoint-thumb-phalanx-proximal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-thumb-phalanx-proximal" style="display:none">Info about the '"thumb-phalanx-proximal"' definition.</span><b><a href="#dom-xrhandjoint-thumb-phalanx-proximal">#dom-xrhandjoint-thumb-phalanx-proximal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-thumb-phalanx-proximal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-thumb-phalanx-distal">
-   <b><a href="#dom-xrhandjoint-thumb-phalanx-distal">#dom-xrhandjoint-thumb-phalanx-distal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-thumb-phalanx-distal" class="dfn-panel" data-for="dom-xrhandjoint-thumb-phalanx-distal" id="infopanel-for-dom-xrhandjoint-thumb-phalanx-distal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-thumb-phalanx-distal" style="display:none">Info about the '"thumb-phalanx-distal"' definition.</span><b><a href="#dom-xrhandjoint-thumb-phalanx-distal">#dom-xrhandjoint-thumb-phalanx-distal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-thumb-phalanx-distal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-thumb-tip">
-   <b><a href="#dom-xrhandjoint-thumb-tip">#dom-xrhandjoint-thumb-tip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-thumb-tip" class="dfn-panel" data-for="dom-xrhandjoint-thumb-tip" id="infopanel-for-dom-xrhandjoint-thumb-tip" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-thumb-tip" style="display:none">Info about the '"thumb-tip"' definition.</span><b><a href="#dom-xrhandjoint-thumb-tip">#dom-xrhandjoint-thumb-tip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-thumb-tip">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-index-finger-metacarpal">
-   <b><a href="#dom-xrhandjoint-index-finger-metacarpal">#dom-xrhandjoint-index-finger-metacarpal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-index-finger-metacarpal" class="dfn-panel" data-for="dom-xrhandjoint-index-finger-metacarpal" id="infopanel-for-dom-xrhandjoint-index-finger-metacarpal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-index-finger-metacarpal" style="display:none">Info about the '"index-finger-metacarpal"' definition.</span><b><a href="#dom-xrhandjoint-index-finger-metacarpal">#dom-xrhandjoint-index-finger-metacarpal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-index-finger-metacarpal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-proximal">
-   <b><a href="#dom-xrhandjoint-index-finger-phalanx-proximal">#dom-xrhandjoint-index-finger-phalanx-proximal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-proximal" class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-proximal" id="infopanel-for-dom-xrhandjoint-index-finger-phalanx-proximal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-proximal" style="display:none">Info about the '"index-finger-phalanx-proximal"' definition.</span><b><a href="#dom-xrhandjoint-index-finger-phalanx-proximal">#dom-xrhandjoint-index-finger-phalanx-proximal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-index-finger-phalanx-proximal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-intermediate">
-   <b><a href="#dom-xrhandjoint-index-finger-phalanx-intermediate">#dom-xrhandjoint-index-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-intermediate" class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-intermediate" id="infopanel-for-dom-xrhandjoint-index-finger-phalanx-intermediate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-intermediate" style="display:none">Info about the '"index-finger-phalanx-intermediate"' definition.</span><b><a href="#dom-xrhandjoint-index-finger-phalanx-intermediate">#dom-xrhandjoint-index-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-index-finger-phalanx-intermediate">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-distal">
-   <b><a href="#dom-xrhandjoint-index-finger-phalanx-distal">#dom-xrhandjoint-index-finger-phalanx-distal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-distal" class="dfn-panel" data-for="dom-xrhandjoint-index-finger-phalanx-distal" id="infopanel-for-dom-xrhandjoint-index-finger-phalanx-distal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-index-finger-phalanx-distal" style="display:none">Info about the '"index-finger-phalanx-distal"' definition.</span><b><a href="#dom-xrhandjoint-index-finger-phalanx-distal">#dom-xrhandjoint-index-finger-phalanx-distal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-index-finger-phalanx-distal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-index-finger-tip">
-   <b><a href="#dom-xrhandjoint-index-finger-tip">#dom-xrhandjoint-index-finger-tip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-index-finger-tip" class="dfn-panel" data-for="dom-xrhandjoint-index-finger-tip" id="infopanel-for-dom-xrhandjoint-index-finger-tip" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-index-finger-tip" style="display:none">Info about the '"index-finger-tip"' definition.</span><b><a href="#dom-xrhandjoint-index-finger-tip">#dom-xrhandjoint-index-finger-tip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-index-finger-tip">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-metacarpal">
-   <b><a href="#dom-xrhandjoint-middle-finger-metacarpal">#dom-xrhandjoint-middle-finger-metacarpal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-middle-finger-metacarpal" class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-metacarpal" id="infopanel-for-dom-xrhandjoint-middle-finger-metacarpal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-middle-finger-metacarpal" style="display:none">Info about the '"middle-finger-metacarpal"' definition.</span><b><a href="#dom-xrhandjoint-middle-finger-metacarpal">#dom-xrhandjoint-middle-finger-metacarpal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-middle-finger-metacarpal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-proximal">
-   <b><a href="#dom-xrhandjoint-middle-finger-phalanx-proximal">#dom-xrhandjoint-middle-finger-phalanx-proximal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-proximal" class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-proximal" id="infopanel-for-dom-xrhandjoint-middle-finger-phalanx-proximal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-proximal" style="display:none">Info about the '"middle-finger-phalanx-proximal"' definition.</span><b><a href="#dom-xrhandjoint-middle-finger-phalanx-proximal">#dom-xrhandjoint-middle-finger-phalanx-proximal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-middle-finger-phalanx-proximal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-intermediate">
-   <b><a href="#dom-xrhandjoint-middle-finger-phalanx-intermediate">#dom-xrhandjoint-middle-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-intermediate" class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-intermediate" id="infopanel-for-dom-xrhandjoint-middle-finger-phalanx-intermediate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-intermediate" style="display:none">Info about the '"middle-finger-phalanx-intermediate"' definition.</span><b><a href="#dom-xrhandjoint-middle-finger-phalanx-intermediate">#dom-xrhandjoint-middle-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-middle-finger-phalanx-intermediate">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-distal">
-   <b><a href="#dom-xrhandjoint-middle-finger-phalanx-distal">#dom-xrhandjoint-middle-finger-phalanx-distal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-distal" class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-phalanx-distal" id="infopanel-for-dom-xrhandjoint-middle-finger-phalanx-distal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-middle-finger-phalanx-distal" style="display:none">Info about the '"middle-finger-phalanx-distal"' definition.</span><b><a href="#dom-xrhandjoint-middle-finger-phalanx-distal">#dom-xrhandjoint-middle-finger-phalanx-distal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-middle-finger-phalanx-distal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-tip">
-   <b><a href="#dom-xrhandjoint-middle-finger-tip">#dom-xrhandjoint-middle-finger-tip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-middle-finger-tip" class="dfn-panel" data-for="dom-xrhandjoint-middle-finger-tip" id="infopanel-for-dom-xrhandjoint-middle-finger-tip" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-middle-finger-tip" style="display:none">Info about the '"middle-finger-tip"' definition.</span><b><a href="#dom-xrhandjoint-middle-finger-tip">#dom-xrhandjoint-middle-finger-tip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-middle-finger-tip">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-metacarpal">
-   <b><a href="#dom-xrhandjoint-ring-finger-metacarpal">#dom-xrhandjoint-ring-finger-metacarpal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-ring-finger-metacarpal" class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-metacarpal" id="infopanel-for-dom-xrhandjoint-ring-finger-metacarpal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-ring-finger-metacarpal" style="display:none">Info about the '"ring-finger-metacarpal"' definition.</span><b><a href="#dom-xrhandjoint-ring-finger-metacarpal">#dom-xrhandjoint-ring-finger-metacarpal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-ring-finger-metacarpal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-proximal">
-   <b><a href="#dom-xrhandjoint-ring-finger-phalanx-proximal">#dom-xrhandjoint-ring-finger-phalanx-proximal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-proximal" class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-proximal" id="infopanel-for-dom-xrhandjoint-ring-finger-phalanx-proximal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-proximal" style="display:none">Info about the '"ring-finger-phalanx-proximal"' definition.</span><b><a href="#dom-xrhandjoint-ring-finger-phalanx-proximal">#dom-xrhandjoint-ring-finger-phalanx-proximal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-ring-finger-phalanx-proximal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-intermediate">
-   <b><a href="#dom-xrhandjoint-ring-finger-phalanx-intermediate">#dom-xrhandjoint-ring-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-intermediate" class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-intermediate" id="infopanel-for-dom-xrhandjoint-ring-finger-phalanx-intermediate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-intermediate" style="display:none">Info about the '"ring-finger-phalanx-intermediate"' definition.</span><b><a href="#dom-xrhandjoint-ring-finger-phalanx-intermediate">#dom-xrhandjoint-ring-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-ring-finger-phalanx-intermediate">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-distal">
-   <b><a href="#dom-xrhandjoint-ring-finger-phalanx-distal">#dom-xrhandjoint-ring-finger-phalanx-distal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-distal" class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-phalanx-distal" id="infopanel-for-dom-xrhandjoint-ring-finger-phalanx-distal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-ring-finger-phalanx-distal" style="display:none">Info about the '"ring-finger-phalanx-distal"' definition.</span><b><a href="#dom-xrhandjoint-ring-finger-phalanx-distal">#dom-xrhandjoint-ring-finger-phalanx-distal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-ring-finger-phalanx-distal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-tip">
-   <b><a href="#dom-xrhandjoint-ring-finger-tip">#dom-xrhandjoint-ring-finger-tip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-ring-finger-tip" class="dfn-panel" data-for="dom-xrhandjoint-ring-finger-tip" id="infopanel-for-dom-xrhandjoint-ring-finger-tip" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-ring-finger-tip" style="display:none">Info about the '"ring-finger-tip"' definition.</span><b><a href="#dom-xrhandjoint-ring-finger-tip">#dom-xrhandjoint-ring-finger-tip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-ring-finger-tip">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-metacarpal">
-   <b><a href="#dom-xrhandjoint-pinky-finger-metacarpal">#dom-xrhandjoint-pinky-finger-metacarpal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-pinky-finger-metacarpal" class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-metacarpal" id="infopanel-for-dom-xrhandjoint-pinky-finger-metacarpal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-pinky-finger-metacarpal" style="display:none">Info about the '"pinky-finger-metacarpal"' definition.</span><b><a href="#dom-xrhandjoint-pinky-finger-metacarpal">#dom-xrhandjoint-pinky-finger-metacarpal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-pinky-finger-metacarpal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-proximal">
-   <b><a href="#dom-xrhandjoint-pinky-finger-phalanx-proximal">#dom-xrhandjoint-pinky-finger-phalanx-proximal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-proximal" class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-proximal" id="infopanel-for-dom-xrhandjoint-pinky-finger-phalanx-proximal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-proximal" style="display:none">Info about the '"pinky-finger-phalanx-proximal"' definition.</span><b><a href="#dom-xrhandjoint-pinky-finger-phalanx-proximal">#dom-xrhandjoint-pinky-finger-phalanx-proximal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-pinky-finger-phalanx-proximal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-intermediate">
-   <b><a href="#dom-xrhandjoint-pinky-finger-phalanx-intermediate">#dom-xrhandjoint-pinky-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-intermediate" class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-intermediate" id="infopanel-for-dom-xrhandjoint-pinky-finger-phalanx-intermediate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-intermediate" style="display:none">Info about the '"pinky-finger-phalanx-intermediate"' definition.</span><b><a href="#dom-xrhandjoint-pinky-finger-phalanx-intermediate">#dom-xrhandjoint-pinky-finger-phalanx-intermediate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-pinky-finger-phalanx-intermediate">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-distal">
-   <b><a href="#dom-xrhandjoint-pinky-finger-phalanx-distal">#dom-xrhandjoint-pinky-finger-phalanx-distal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-distal" class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-phalanx-distal" id="infopanel-for-dom-xrhandjoint-pinky-finger-phalanx-distal" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-pinky-finger-phalanx-distal" style="display:none">Info about the '"pinky-finger-phalanx-distal"' definition.</span><b><a href="#dom-xrhandjoint-pinky-finger-phalanx-distal">#dom-xrhandjoint-pinky-finger-phalanx-distal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-pinky-finger-phalanx-distal">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-tip">
-   <b><a href="#dom-xrhandjoint-pinky-finger-tip">#dom-xrhandjoint-pinky-finger-tip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandjoint-pinky-finger-tip" class="dfn-panel" data-for="dom-xrhandjoint-pinky-finger-tip" id="infopanel-for-dom-xrhandjoint-pinky-finger-tip" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandjoint-pinky-finger-tip" style="display:none">Info about the '"pinky-finger-tip"' definition.</span><b><a href="#dom-xrhandjoint-pinky-finger-tip">#dom-xrhandjoint-pinky-finger-tip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandjoint-pinky-finger-tip">3.2. Skeleton Joints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhand">
-   <b><a href="#xrhand">#xrhand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhand" class="dfn-panel" data-for="xrhand" id="infopanel-for-xrhand" role="dialog">
+   <span id="infopaneltitle-for-xrhand" style="display:none">Info about the 'XRHand' definition.</span><b><a href="#xrhand">#xrhand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhand">3.1. XRInputSource</a> <a href="#ref-for-xrhand①">(2)</a>
     <li><a href="#ref-for-xrhand②">3.3. XRHand</a> <a href="#ref-for-xrhand③">(2)</a> <a href="#ref-for-xrhand④">(3)</a> <a href="#ref-for-xrhand⑤">(4)</a> <a href="#ref-for-xrhand⑥">(5)</a>
     <li><a href="#ref-for-xrhand⑦">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrhand-input-source">
-   <b><a href="#xrhand-input-source">#xrhand-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrhand-input-source" class="dfn-panel" data-for="xrhand-input-source" id="infopanel-for-xrhand-input-source" role="dialog">
+   <span id="infopaneltitle-for-xrhand-input-source" style="display:none">Info about the 'input source' definition.</span><b><a href="#xrhand-input-source">#xrhand-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrhand-input-source">3.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhand-joints-slot">
-   <b><a href="#dom-xrhand-joints-slot">#dom-xrhand-joints-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhand-joints-slot" class="dfn-panel" data-for="dom-xrhand-joints-slot" id="infopanel-for-dom-xrhand-joints-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhand-joints-slot" style="display:none">Info about the '[[joints]]' definition.</span><b><a href="#dom-xrhand-joints-slot">#dom-xrhand-joints-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhand-joints-slot">3.3. XRHand</a> <a href="#ref-for-dom-xrhand-joints-slot①">(2)</a> <a href="#ref-for-dom-xrhand-joints-slot②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhand-size">
-   <b><a href="#dom-xrhand-size">#dom-xrhand-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhand-size" class="dfn-panel" data-for="dom-xrhand-size" id="infopanel-for-dom-xrhand-size" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhand-size" style="display:none">Info about the 'size' definition.</span><b><a href="#dom-xrhand-size">#dom-xrhand-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhand-size">3.3. XRHand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrjointspace">
-   <b><a href="#xrjointspace">#xrjointspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrjointspace" class="dfn-panel" data-for="xrjointspace" id="infopanel-for-xrjointspace" role="dialog">
+   <span id="infopaneltitle-for-xrjointspace" style="display:none">Info about the 'XRJointSpace' definition.</span><b><a href="#xrjointspace">#xrjointspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrjointspace">3.3. XRHand</a> <a href="#ref-for-xrjointspace①">(2)</a> <a href="#ref-for-xrjointspace②">(3)</a> <a href="#ref-for-xrjointspace③">(4)</a>
     <li><a href="#ref-for-xrjointspace④">3.4. XRJointSpace</a> <a href="#ref-for-xrjointspace⑤">(2)</a> <a href="#ref-for-xrjointspace⑥">(3)</a> <a href="#ref-for-xrjointspace⑦">(4)</a> <a href="#ref-for-xrjointspace⑧">(5)</a>
     <li><a href="#ref-for-xrjointspace⑨">4.1. XRFrame</a> <a href="#ref-for-xrjointspace①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrjointspace-hand">
-   <b><a href="#xrjointspace-hand">#xrjointspace-hand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrjointspace-hand" class="dfn-panel" data-for="xrjointspace-hand" id="infopanel-for-xrjointspace-hand" role="dialog">
+   <span id="infopaneltitle-for-xrjointspace-hand" style="display:none">Info about the 'hand' definition.</span><b><a href="#xrjointspace-hand">#xrjointspace-hand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrjointspace-hand">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrjointspace-jointname">
-   <b><a href="#xrjointspace-jointname">#xrjointspace-jointname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrjointspace-jointname" class="dfn-panel" data-for="xrjointspace-jointname" id="infopanel-for-xrjointspace-jointname" role="dialog">
+   <span id="infopaneltitle-for-xrjointspace-jointname" style="display:none">Info about the 'jointName' definition.</span><b><a href="#xrjointspace-jointname">#xrjointspace-jointname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrjointspace-jointname">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrjointspace-joint">
-   <b><a href="#xrjointspace-joint">#xrjointspace-joint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrjointspace-joint" class="dfn-panel" data-for="xrjointspace-joint" id="infopanel-for-xrjointspace-joint" role="dialog">
+   <span id="infopaneltitle-for-xrjointspace-joint" style="display:none">Info about the 'joint' definition.</span><b><a href="#xrjointspace-joint">#xrjointspace-joint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrjointspace-joint">3.4. XRJointSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-getjointpose">
-   <b><a href="#dom-xrframe-getjointpose">#dom-xrframe-getjointpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-getjointpose" class="dfn-panel" data-for="dom-xrframe-getjointpose" id="infopanel-for-dom-xrframe-getjointpose" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-getjointpose" style="display:none">Info about the 'getJointPose(XRJointSpace joint, XRSpace baseSpace)' definition.</span><b><a href="#dom-xrframe-getjointpose">#dom-xrframe-getjointpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getjointpose">4.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-filljointradii">
-   <b><a href="#dom-xrframe-filljointradii">#dom-xrframe-filljointradii</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-filljointradii" class="dfn-panel" data-for="dom-xrframe-filljointradii" id="infopanel-for-dom-xrframe-filljointradii" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-filljointradii" style="display:none">Info about the 'fillJointRadii(sequence&lt;XRJointSpace> jointSpaces, Float32Array radii)' definition.</span><b><a href="#dom-xrframe-filljointradii">#dom-xrframe-filljointradii</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-filljointradii">4.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-fillposes">
-   <b><a href="#dom-xrframe-fillposes">#dom-xrframe-fillposes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-fillposes" class="dfn-panel" data-for="dom-xrframe-fillposes" id="infopanel-for-dom-xrframe-fillposes" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-fillposes" style="display:none">Info about the 'fillPoses(sequence&lt;XRSpace> spaces, XRSpace baseSpace, Float32Array transforms)' definition.</span><b><a href="#dom-xrframe-fillposes">#dom-xrframe-fillposes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-fillposes">4.1. XRFrame</a> <a href="#ref-for-dom-xrframe-fillposes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrjointpose">
-   <b><a href="#xrjointpose">#xrjointpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrjointpose" class="dfn-panel" data-for="xrjointpose" id="infopanel-for-xrjointpose" role="dialog">
+   <span id="infopaneltitle-for-xrjointpose" style="display:none">Info about the 'XRJointPose' definition.</span><b><a href="#xrjointpose">#xrjointpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrjointpose">4.1. XRFrame</a> <a href="#ref-for-xrjointpose①">(2)</a> <a href="#ref-for-xrjointpose②">(3)</a>
     <li><a href="#ref-for-xrjointpose③">4.2. XRJointPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrjointpose-radius">
-   <b><a href="#dom-xrjointpose-radius">#dom-xrjointpose-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrjointpose-radius" class="dfn-panel" data-for="dom-xrjointpose-radius" id="infopanel-for-dom-xrjointpose-radius" role="dialog">
+   <span id="infopaneltitle-for-dom-xrjointpose-radius" style="display:none">Info about the 'radius' definition.</span><b><a href="#dom-xrjointpose-radius">#dom-xrjointpose-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrjointpose-radius">4.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrjointpose-radius①">4.2. XRJointPose</a> <a href="#ref-for-dom-xrjointpose-radius②">(2)</a>
@@ -2231,59 +2231,115 @@ before revealing it through the WebXR Hand Input API.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/immersive-web/webxr-test-api/index.html
+++ b/tests/github/immersive-web/webxr-test-api/index.html
@@ -1695,123 +1695,123 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-fakexrbuttonstateinit-yvalue">yValue</a><span>, in § 5.2</span>
    <li><a href="#dom-fakexrboundspoint-z">z</a><span>, in § 4.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-gamepadmappingtype-xr-standard">
-   <a href="https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard">https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-gamepadmappingtype-xr-standard" class="dfn-panel" data-for="term-for-dom-gamepadmappingtype-xr-standard" id="infopanel-for-term-for-dom-gamepadmappingtype-xr-standard" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-gamepadmappingtype-xr-standard" style="display:none">Info about the 'xr-standard' external reference.</span><a href="https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard">https://w3c.github.io/gamepad/#dom-gamepadmappingtype-xr-standard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gamepadmappingtype-xr-standard">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-dompointinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-dompointinit" class="dfn-panel" data-for="term-for-dictdef-dompointinit" id="infopanel-for-term-for-dictdef-dompointinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dictdef-dompointinit①">(2)</a>
     <li><a href="#ref-for-dictdef-dompointinit②">6. Hit test extensions</a> <a href="#ref-for-dictdef-dompointinit③">(2)</a>
     <li><a href="#ref-for-dictdef-dompointinit④">9. Lighting estimation extensions</a> <a href="#ref-for-dictdef-dompointinit⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-w">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-w" class="dfn-panel" data-for="term-for-dom-dompointinit-w" id="infopanel-for-term-for-dom-dompointinit-w" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-w" style="display:none">Info about the 'w' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-w</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-w">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-dompointinit-w①">(2)</a>
     <li><a href="#ref-for-dom-dompointinit-w②">9. Lighting estimation extensions</a> <a href="#ref-for-dom-dompointinit-w③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-x" class="dfn-panel" data-for="term-for-dom-dompointinit-x" id="infopanel-for-term-for-dom-dompointinit-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-x" style="display:none">Info about the 'x' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-x">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-dompointinit-x①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-y" class="dfn-panel" data-for="term-for-dom-dompointinit-y" id="infopanel-for-term-for-dom-dompointinit-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-y" style="display:none">Info about the 'y' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-y">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-dompointinit-y①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointinit-z">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointinit-z" class="dfn-panel" data-for="term-for-dom-dompointinit-z" id="infopanel-for-term-for-dom-dompointinit-z" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointinit-z" style="display:none">Info about the 'z' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z">https://drafts.fxtf.org/geometry-1/#dom-dompointinit-z</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-z">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-dompointinit-z①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.2. XRTest</a>
     <li><a href="#ref-for-list-append①">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-idl-DOMString①">5.2. FakeXRInputController</a> <a href="#ref-for-idl-DOMString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Function">
-   <a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Function" class="dfn-panel" data-for="term-for-Function" id="infopanel-for-term-for-Function" role="menu">
+   <span id="infopaneltitle-for-term-for-Function" style="display:none">Info about the 'Function' external reference.</span><a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Function">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.2. XRTest</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-idl-promise③">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.1. navigator.xr.test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">4.2. XRTest</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">4.3. FakeXRDeviceInit</a> <a href="#ref-for-exceptiondef-typeerror②">(2)</a> <a href="#ref-for-exceptiondef-typeerror③">(3)</a>
@@ -1821,20 +1821,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-exceptiondef-typeerror①①">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.3. FakeXRDeviceInit</a>
     <li><a href="#ref-for-idl-boolean①">5.1. FakeXRDevice</a>
@@ -1842,14 +1842,14 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-idl-boolean⑧">8. Anchors extensions</a> <a href="#ref-for-idl-boolean⑨">(2)</a> <a href="#ref-for-idl-boolean①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.3. FakeXRDeviceInit</a> <a href="#ref-for-idl-double①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-float">
-   <a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-float" class="dfn-panel" data-for="term-for-idl-float" id="infopanel-for-term-for-idl-float" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-float" style="display:none">Info about the 'float' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-float">https://webidl.spec.whatwg.org/#idl-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-float">4.3. FakeXRDeviceInit</a> <a href="#ref-for-idl-float①">(2)</a> <a href="#ref-for-idl-float②">(3)</a> <a href="#ref-for-idl-float③">(4)</a> <a href="#ref-for-idl-float④">(5)</a> <a href="#ref-for-idl-float⑤">(6)</a> <a href="#ref-for-idl-float⑥">(7)</a>
     <li><a href="#ref-for-idl-float⑦">5.2. FakeXRInputController</a> <a href="#ref-for-idl-float⑧">(2)</a> <a href="#ref-for-idl-float⑨">(3)</a>
@@ -1858,26 +1858,26 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-idl-float①③">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">4.3. FakeXRDeviceInit</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'react' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.3. FakeXRDeviceInit</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a> <a href="#ref-for-idl-sequence④">(5)</a> <a href="#ref-for-idl-sequence⑤">(6)</a> <a href="#ref-for-idl-sequence⑥">(7)</a>
     <li><a href="#ref-for-idl-sequence⑦">5.1. FakeXRDevice</a> <a href="#ref-for-idl-sequence⑧">(2)</a>
@@ -1886,64 +1886,64 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-idl-sequence①⑥">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">10. Depth sensing extensions</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrreferencespacetype-local" class="dfn-panel" data-for="term-for-dom-xrreferencespacetype-local" id="infopanel-for-term-for-dom-xrreferencespacetype-local" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrreferencespacetype-local" style="display:none">Info about the '"local"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local">https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-local">4.4. FakeXRRigidTransformInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrvisibilitystate-visible">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrvisibilitystate-visible">https://immersive-web.github.io/webxr/#dom-xrvisibilitystate-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrvisibilitystate-visible" class="dfn-panel" data-for="term-for-dom-xrvisibilitystate-visible" id="infopanel-for-term-for-dom-xrvisibilitystate-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrvisibilitystate-visible" style="display:none">Info about the '"visible"' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrvisibilitystate-visible">https://immersive-web.github.io/webxr/#dom-xrvisibilitystate-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrboundedreferencespace">
-   <a href="https://immersive-web.github.io/webxr/#xrboundedreferencespace">https://immersive-web.github.io/webxr/#xrboundedreferencespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrboundedreferencespace" class="dfn-panel" data-for="term-for-xrboundedreferencespace" id="infopanel-for-term-for-xrboundedreferencespace" role="menu">
+   <span id="infopaneltitle-for-term-for-xrboundedreferencespace" style="display:none">Info about the 'XRBoundedReferenceSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrboundedreferencespace">https://immersive-web.github.io/webxr/#xrboundedreferencespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrboundedreferencespace">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xreye">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xreye">https://immersive-web.github.io/webxr/#enumdef-xreye</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xreye" class="dfn-panel" data-for="term-for-enumdef-xreye" id="infopanel-for-term-for-enumdef-xreye" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xreye" style="display:none">Info about the 'XREye' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xreye">https://immersive-web.github.io/webxr/#enumdef-xreye</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xreye">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xrhandedness">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xrhandedness">https://immersive-web.github.io/webxr/#enumdef-xrhandedness</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xrhandedness" class="dfn-panel" data-for="term-for-enumdef-xrhandedness" id="infopanel-for-term-for-enumdef-xrhandedness" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xrhandedness" style="display:none">Info about the 'XRHandedness' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xrhandedness">https://immersive-web.github.io/webxr/#enumdef-xrhandedness</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrhandedness">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-enumdef-xrhandedness①">5.2. FakeXRInputController</a> <a href="#ref-for-enumdef-xrhandedness②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrinputsource">
-   <a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrinputsource" class="dfn-panel" data-for="term-for-xrinputsource" id="infopanel-for-term-for-xrinputsource" role="menu">
+   <span id="infopaneltitle-for-term-for-xrinputsource" style="display:none">Info about the 'XRInputSource' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrinputsource">https://immersive-web.github.io/webxr/#xrinputsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrpose">
-   <a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrpose" class="dfn-panel" data-for="term-for-xrpose" id="infopanel-for-term-for-xrpose" role="menu">
+   <span id="infopaneltitle-for-term-for-xrpose" style="display:none">Info about the 'XRPose' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrpose">https://immersive-web.github.io/webxr/#xrpose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpose">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrrigidtransform" class="dfn-panel" data-for="term-for-xrrigidtransform" id="infopanel-for-term-for-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrrigidtransform">https://immersive-web.github.io/webxr/#xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">3.1. Simulated XR Device</a> <a href="#ref-for-xrrigidtransform①">(2)</a>
     <li><a href="#ref-for-xrrigidtransform②">3.2. Simulated Input Device</a> <a href="#ref-for-xrrigidtransform③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsession">
-   <a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsession" class="dfn-panel" data-for="term-for-xrsession" id="infopanel-for-term-for-xrsession" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsession" style="display:none">Info about the 'XRSession' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsession">https://immersive-web.github.io/webxr/#xrsession</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">3.1. Simulated XR Device</a> <a href="#ref-for-xrsession①">(2)</a>
     <li><a href="#ref-for-xrsession②">4.3. FakeXRDeviceInit</a>
@@ -1951,212 +1951,212 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xrsession④">5.2. FakeXRInputController</a> <a href="#ref-for-xrsession⑤">(2)</a> <a href="#ref-for-xrsession⑥">(3)</a> <a href="#ref-for-xrsession⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xrsessionmode">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xrsessionmode">https://immersive-web.github.io/webxr/#enumdef-xrsessionmode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xrsessionmode" class="dfn-panel" data-for="term-for-enumdef-xrsessionmode" id="infopanel-for-term-for-enumdef-xrsessionmode" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xrsessionmode" style="display:none">Info about the 'XRSessionMode' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xrsessionmode">https://immersive-web.github.io/webxr/#enumdef-xrsessionmode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrsessionmode">4.2. XRTest</a> <a href="#ref-for-enumdef-xrsessionmode①">(2)</a>
     <li><a href="#ref-for-enumdef-xrsessionmode②">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrsystem">
-   <a href="https://immersive-web.github.io/webxr/#xrsystem">https://immersive-web.github.io/webxr/#xrsystem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrsystem" class="dfn-panel" data-for="term-for-xrsystem" id="infopanel-for-term-for-xrsystem" role="menu">
+   <span id="infopaneltitle-for-term-for-xrsystem" style="display:none">Info about the 'XRSystem' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrsystem">https://immersive-web.github.io/webxr/#xrsystem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsystem">4.1. navigator.xr.test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xrtargetraymode">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xrtargetraymode">https://immersive-web.github.io/webxr/#enumdef-xrtargetraymode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xrtargetraymode" class="dfn-panel" data-for="term-for-enumdef-xrtargetraymode" id="infopanel-for-term-for-enumdef-xrtargetraymode" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xrtargetraymode" style="display:none">Info about the 'XRTargetRayMode' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xrtargetraymode">https://immersive-web.github.io/webxr/#enumdef-xrtargetraymode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrtargetraymode">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-enumdef-xrtargetraymode①">5.2. FakeXRInputController</a> <a href="#ref-for-enumdef-xrtargetraymode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrviewport">
-   <a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrviewport" class="dfn-panel" data-for="term-for-xrviewport" id="infopanel-for-term-for-xrviewport" role="menu">
+   <span id="infopaneltitle-for-term-for-xrviewport" style="display:none">Info about the 'XRViewport' external reference.</span><a href="https://immersive-web.github.io/webxr/#xrviewport">https://immersive-web.github.io/webxr/#xrviewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrviewport">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-xrvisibilitystate">
-   <a href="https://immersive-web.github.io/webxr/#enumdef-xrvisibilitystate">https://immersive-web.github.io/webxr/#enumdef-xrvisibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-xrvisibilitystate" class="dfn-panel" data-for="term-for-enumdef-xrvisibilitystate" id="infopanel-for-term-for-enumdef-xrvisibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-xrvisibilitystate" style="display:none">Info about the 'XRVisibilityState' external reference.</span><a href="https://immersive-web.github.io/webxr/#enumdef-xrvisibilitystate">https://immersive-web.github.io/webxr/#enumdef-xrvisibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrvisibilitystate">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-enumdef-xrvisibilitystate①">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-xrrigidtransform">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-xrrigidtransform">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-xrrigidtransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-xrrigidtransform" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-xrrigidtransform" id="infopanel-for-term-for-dom-xrrigidtransform-xrrigidtransform" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-xrrigidtransform" style="display:none">Info about the 'constructor()' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-xrrigidtransform">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-xrrigidtransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-xrrigidtransform">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstate-depthfar">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar">https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstate-depthfar" class="dfn-panel" data-for="term-for-dom-xrrenderstate-depthfar" id="infopanel-for-term-for-dom-xrrenderstate-depthfar" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstate-depthfar" style="display:none">Info about the 'depthFar' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar">https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-depthfar">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthfar①">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstate-depthnear">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear">https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstate-depthnear" class="dfn-panel" data-for="term-for-dom-xrrenderstate-depthnear" id="infopanel-for-term-for-dom-xrrenderstate-depthnear" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstate-depthnear" style="display:none">Info about the 'depthNear' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear">https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthnear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-depthnear">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthnear①">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrpose-emulatedposition">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrpose-emulatedposition">https://immersive-web.github.io/webxr/#dom-xrpose-emulatedposition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrpose-emulatedposition" class="dfn-panel" data-for="term-for-dom-xrpose-emulatedposition" id="infopanel-for-term-for-dom-xrpose-emulatedposition" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrpose-emulatedposition" style="display:none">Info about the 'emulatedPosition' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrpose-emulatedposition">https://immersive-web.github.io/webxr/#dom-xrpose-emulatedposition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpose-emulatedposition">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-gripspace">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-gripspace" class="dfn-panel" data-for="term-for-dom-xrinputsource-gripspace" id="infopanel-for-term-for-dom-xrinputsource-gripspace" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-gripspace" style="display:none">Info about the 'gripSpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-gripspace">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-handedness">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness">https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-handedness" class="dfn-panel" data-for="term-for-dom-xrinputsource-handedness" id="infopanel-for-term-for-dom-xrinputsource-handedness" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-handedness" style="display:none">Info about the 'handedness' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness">https://immersive-web.github.io/webxr/#dom-xrinputsource-handedness</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-handedness">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-inputsources">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-inputsources">https://immersive-web.github.io/webxr/#dom-xrsession-inputsources</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-inputsources" class="dfn-panel" data-for="term-for-dom-xrsession-inputsources" id="infopanel-for-term-for-dom-xrsession-inputsources" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-inputsources" style="display:none">Info about the 'inputSources' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-inputsources">https://immersive-web.github.io/webxr/#dom-xrsession-inputsources</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-inputsources">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-dom-xrsession-inputsources①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-xrsession-inputsourceschange">
-   <a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange">https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-xrsession-inputsourceschange" class="dfn-panel" data-for="term-for-eventdef-xrsession-inputsourceschange" id="infopanel-for-term-for-eventdef-xrsession-inputsourceschange" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-xrsession-inputsourceschange" style="display:none">Info about the 'inputsourceschange' external reference.</span><a href="https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange">https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-inputsourceschange">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-oninputsourceschange">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-oninputsourceschange">https://immersive-web.github.io/webxr/#dom-xrsession-oninputsourceschange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-oninputsourceschange" class="dfn-panel" data-for="term-for-dom-xrsession-oninputsourceschange" id="infopanel-for-term-for-dom-xrsession-oninputsourceschange" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-oninputsourceschange" style="display:none">Info about the 'oninputsourceschange' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-oninputsourceschange">https://immersive-web.github.io/webxr/#dom-xrsession-oninputsourceschange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-oninputsourceschange">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-onselect">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-onselect">https://immersive-web.github.io/webxr/#dom-xrsession-onselect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-onselect" class="dfn-panel" data-for="term-for-dom-xrsession-onselect" id="infopanel-for-term-for-dom-xrsession-onselect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-onselect" style="display:none">Info about the 'onselect' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-onselect">https://immersive-web.github.io/webxr/#dom-xrsession-onselect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onselect">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-onselectend">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-onselectend">https://immersive-web.github.io/webxr/#dom-xrsession-onselectend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-onselectend" class="dfn-panel" data-for="term-for-dom-xrsession-onselectend" id="infopanel-for-term-for-dom-xrsession-onselectend" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-onselectend" style="display:none">Info about the 'onselectend' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-onselectend">https://immersive-web.github.io/webxr/#dom-xrsession-onselectend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onselectend">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-onvisibilitychange">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-onvisibilitychange">https://immersive-web.github.io/webxr/#dom-xrsession-onvisibilitychange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-onvisibilitychange" class="dfn-panel" data-for="term-for-dom-xrsession-onvisibilitychange" id="infopanel-for-term-for-dom-xrsession-onvisibilitychange" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-onvisibilitychange" style="display:none">Info about the 'onvisibilitychange' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-onvisibilitychange">https://immersive-web.github.io/webxr/#dom-xrsession-onvisibilitychange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onvisibilitychange">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-orientation">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-orientation" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-orientation" id="infopanel-for-term-for-dom-xrrigidtransform-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-orientation" style="display:none">Info about the 'orientation' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrigidtransform-position">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrigidtransform-position" class="dfn-panel" data-for="term-for-dom-xrrigidtransform-position" id="infopanel-for-term-for-dom-xrrigidtransform-position" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrigidtransform-position" style="display:none">Info about the 'position' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position">https://immersive-web.github.io/webxr/#dom-xrrigidtransform-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-position">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-profiles" class="dfn-panel" data-for="term-for-dom-xrinputsource-profiles" id="infopanel-for-term-for-dom-xrinputsource-profiles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-profiles" style="display:none">Info about the 'profiles' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles">https://immersive-web.github.io/webxr/#dom-xrinputsource-profiles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-profiles">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" class="dfn-panel" data-for="term-for-dom-xrsession-requestanimationframe" id="infopanel-for-term-for-dom-xrsession-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe">https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe">5.1. FakeXRDevice</a> <a href="#ref-for-dom-xrsession-requestanimationframe①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetraymode" id="infopanel-for-term-for-dom-xrinputsource-targetraymode" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetraymode" style="display:none">Info about the 'targetRayMode' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" class="dfn-panel" data-for="term-for-dom-xrinputsource-targetrayspace" id="infopanel-for-term-for-dom-xrinputsource-targetrayspace" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-targetrayspace" style="display:none">Info about the 'targetRaySpace' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace">https://immersive-web.github.io/webxr/#dom-xrinputsource-targetrayspace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace">3.2. Simulated Input Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrsession-visibilitystate">
-   <a href="https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate">https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrsession-visibilitystate" class="dfn-panel" data-for="term-for-dom-xrsession-visibilitystate" id="infopanel-for-term-for-dom-xrsession-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrsession-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate">https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-visibilitystate">3.1. Simulated XR Device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-xr">
-   <a href="https://immersive-web.github.io/webxr/#dom-navigator-xr">https://immersive-web.github.io/webxr/#dom-navigator-xr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-xr" class="dfn-panel" data-for="term-for-dom-navigator-xr" id="infopanel-for-term-for-dom-navigator-xr" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-xr" style="display:none">Info about the 'xr' external reference.</span><a href="https://immersive-web.github.io/webxr/#dom-navigator-xr">https://immersive-web.github.io/webxr/#dom-navigator-xr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-xr">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xranchor-delete">
-   <a href="https://immersive-web.github.io/anchors/#dom-xranchor-delete">https://immersive-web.github.io/anchors/#dom-xranchor-delete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xranchor-delete" class="dfn-panel" data-for="term-for-dom-xranchor-delete" id="infopanel-for-term-for-dom-xranchor-delete" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xranchor-delete" style="display:none">Info about the 'delete()' external reference.</span><a href="https://immersive-web.github.io/anchors/#dom-xranchor-delete">https://immersive-web.github.io/anchors/#dom-xranchor-delete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xranchor-delete">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xranchor-native-origin">
-   <a href="https://immersive-web.github.io/anchors/#xranchor-native-origin">https://immersive-web.github.io/anchors/#xranchor-native-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xranchor-native-origin" class="dfn-panel" data-for="term-for-xranchor-native-origin" id="infopanel-for-term-for-xranchor-native-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-xranchor-native-origin" style="display:none">Info about the 'native origin' external reference.</span><a href="https://immersive-web.github.io/anchors/#xranchor-native-origin">https://immersive-web.github.io/anchors/#xranchor-native-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xranchor-native-origin">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-cpu-depth-information-instance">
-   <a href="https://immersive-web.github.io/depth-sensing/#create-a-cpu-depth-information-instance">https://immersive-web.github.io/depth-sensing/#create-a-cpu-depth-information-instance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-cpu-depth-information-instance" class="dfn-panel" data-for="term-for-create-a-cpu-depth-information-instance" id="infopanel-for-term-for-create-a-cpu-depth-information-instance" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-cpu-depth-information-instance" style="display:none">Info about the 'create a cpu depth information instance' external reference.</span><a href="https://immersive-web.github.io/depth-sensing/#create-a-cpu-depth-information-instance">https://immersive-web.github.io/depth-sensing/#create-a-cpu-depth-information-instance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cpu-depth-information-instance">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-gpu-depth-information-instance">
-   <a href="https://immersive-web.github.io/depth-sensing/#create-a-gpu-depth-information-instance">https://immersive-web.github.io/depth-sensing/#create-a-gpu-depth-information-instance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-gpu-depth-information-instance" class="dfn-panel" data-for="term-for-create-a-gpu-depth-information-instance" id="infopanel-for-term-for-create-a-gpu-depth-information-instance" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-gpu-depth-information-instance" style="display:none">Info about the 'create a gpu depth information instance' external reference.</span><a href="https://immersive-web.github.io/depth-sensing/#create-a-gpu-depth-information-instance">https://immersive-web.github.io/depth-sensing/#create-a-gpu-depth-information-instance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-gpu-depth-information-instance">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-depth-coordinates-transformation-matrix">
-   <a href="https://immersive-web.github.io/depth-sensing/#depth-coordinates-transformation-matrix">https://immersive-web.github.io/depth-sensing/#depth-coordinates-transformation-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-depth-coordinates-transformation-matrix" class="dfn-panel" data-for="term-for-depth-coordinates-transformation-matrix" id="infopanel-for-term-for-depth-coordinates-transformation-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-depth-coordinates-transformation-matrix" style="display:none">Info about the 'depth coordinates transformation matrix' external reference.</span><a href="https://immersive-web.github.io/depth-sensing/#depth-coordinates-transformation-matrix">https://immersive-web.github.io/depth-sensing/#depth-coordinates-transformation-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-depth-coordinates-transformation-matrix">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-native-depth-sensing">
-   <a href="https://immersive-web.github.io/depth-sensing/#native-depth-sensing">https://immersive-web.github.io/depth-sensing/#native-depth-sensing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-native-depth-sensing" class="dfn-panel" data-for="term-for-native-depth-sensing" id="infopanel-for-term-for-native-depth-sensing" role="menu">
+   <span id="infopaneltitle-for-term-for-native-depth-sensing" style="display:none">Info about the 'native depth sensing' external reference.</span><a href="https://immersive-web.github.io/depth-sensing/#native-depth-sensing">https://immersive-web.github.io/depth-sensing/#native-depth-sensing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-depth-sensing">10. Depth sensing extensions</a> <a href="#ref-for-native-depth-sensing①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xrlightestimate-interface">
-   <a href="https://immersive-web.github.io/lighting-estimation/#xrlightestimate-interface">https://immersive-web.github.io/lighting-estimation/#xrlightestimate-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xrlightestimate-interface" class="dfn-panel" data-for="term-for-xrlightestimate-interface" id="infopanel-for-term-for-xrlightestimate-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-xrlightestimate-interface" style="display:none">Info about the 'XRLightEstimate' external reference.</span><a href="https://immersive-web.github.io/lighting-estimation/#xrlightestimate-interface">https://immersive-web.github.io/lighting-estimation/#xrlightestimate-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlightestimate-interface">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-beforexrselect">
-   <a href="https://immersive-web.github.io/dom-overlays#beforexrselect">https://immersive-web.github.io/dom-overlays#beforexrselect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-beforexrselect" class="dfn-panel" data-for="term-for-beforexrselect" id="infopanel-for-term-for-beforexrselect" role="menu">
+   <span id="infopaneltitle-for-term-for-beforexrselect" style="display:none">Info about the 'beforexrselect' external reference.</span><a href="https://immersive-web.github.io/dom-overlays#beforexrselect">https://immersive-web.github.io/dom-overlays#beforexrselect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-beforexrselect">7. DOM overlay extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrinputsource-gamepad">
-   <a href="https://immersive-web.github.io/webxr-gamepads-module/#dom-xrinputsource-gamepad">https://immersive-web.github.io/webxr-gamepads-module/#dom-xrinputsource-gamepad</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrinputsource-gamepad" class="dfn-panel" data-for="term-for-dom-xrinputsource-gamepad" id="infopanel-for-term-for-dom-xrinputsource-gamepad" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrinputsource-gamepad" style="display:none">Info about the 'gamepad' external reference.</span><a href="https://immersive-web.github.io/webxr-gamepads-module/#dom-xrinputsource-gamepad">https://immersive-web.github.io/webxr-gamepads-module/#dom-xrinputsource-gamepad</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-gamepad">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-dom-xrinputsource-gamepad①">5.2. FakeXRInputController</a>
@@ -2511,264 +2511,264 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 
 
 </pre>
-  <aside class="dfn-panel" data-for="simulated-xr-device">
-   <b><a href="#simulated-xr-device">#simulated-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device" class="dfn-panel" data-for="simulated-xr-device" id="infopanel-for-simulated-xr-device" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device" style="display:none">Info about the 'simulated XR device' definition.</span><b><a href="#simulated-xr-device">#simulated-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device">3.1. Simulated XR Device</a> <a href="#ref-for-simulated-xr-device①">(2)</a> <a href="#ref-for-simulated-xr-device②">(3)</a> <a href="#ref-for-simulated-xr-device③">(4)</a> <a href="#ref-for-simulated-xr-device④">(5)</a> <a href="#ref-for-simulated-xr-device⑤">(6)</a> <a href="#ref-for-simulated-xr-device⑥">(7)</a> <a href="#ref-for-simulated-xr-device⑦">(8)</a> <a href="#ref-for-simulated-xr-device⑧">(9)</a>
     <li><a href="#ref-for-simulated-xr-device⑨">4.2. XRTest</a> <a href="#ref-for-simulated-xr-device①⓪">(2)</a> <a href="#ref-for-simulated-xr-device①①">(3)</a> <a href="#ref-for-simulated-xr-device①②">(4)</a>
     <li><a href="#ref-for-simulated-xr-device①③">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-device-native-bounds-geometry">
-   <b><a href="#simulated-xr-device-native-bounds-geometry">#simulated-xr-device-native-bounds-geometry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device-native-bounds-geometry" class="dfn-panel" data-for="simulated-xr-device-native-bounds-geometry" id="infopanel-for-simulated-xr-device-native-bounds-geometry" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device-native-bounds-geometry" style="display:none">Info about the 'native bounds geometry' definition.</span><b><a href="#simulated-xr-device-native-bounds-geometry">#simulated-xr-device-native-bounds-geometry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device-native-bounds-geometry">4.2. XRTest</a>
     <li><a href="#ref-for-simulated-xr-device-native-bounds-geometry①">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-device-floor-origin">
-   <b><a href="#simulated-xr-device-floor-origin">#simulated-xr-device-floor-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device-floor-origin" class="dfn-panel" data-for="simulated-xr-device-floor-origin" id="infopanel-for-simulated-xr-device-floor-origin" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device-floor-origin" style="display:none">Info about the 'floor origin' definition.</span><b><a href="#simulated-xr-device-floor-origin">#simulated-xr-device-floor-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device-floor-origin">4.2. XRTest</a>
     <li><a href="#ref-for-simulated-xr-device-floor-origin①">5.1. FakeXRDevice</a> <a href="#ref-for-simulated-xr-device-floor-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-device-viewer-origin">
-   <b><a href="#simulated-xr-device-viewer-origin">#simulated-xr-device-viewer-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device-viewer-origin" class="dfn-panel" data-for="simulated-xr-device-viewer-origin" id="infopanel-for-simulated-xr-device-viewer-origin" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device-viewer-origin" style="display:none">Info about the 'viewer origin' definition.</span><b><a href="#simulated-xr-device-viewer-origin">#simulated-xr-device-viewer-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device-viewer-origin">4.2. XRTest</a>
     <li><a href="#ref-for-simulated-xr-device-viewer-origin①">5.1. FakeXRDevice</a> <a href="#ref-for-simulated-xr-device-viewer-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-device-emulated-position-boolean">
-   <b><a href="#simulated-xr-device-emulated-position-boolean">#simulated-xr-device-emulated-position-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device-emulated-position-boolean" class="dfn-panel" data-for="simulated-xr-device-emulated-position-boolean" id="infopanel-for-simulated-xr-device-emulated-position-boolean" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device-emulated-position-boolean" style="display:none">Info about the 'emulated position boolean' definition.</span><b><a href="#simulated-xr-device-emulated-position-boolean">#simulated-xr-device-emulated-position-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device-emulated-position-boolean">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-device-visibility-state">
-   <b><a href="#simulated-xr-device-visibility-state">#simulated-xr-device-visibility-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-device-visibility-state" class="dfn-panel" data-for="simulated-xr-device-visibility-state" id="infopanel-for-simulated-xr-device-visibility-state" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-device-visibility-state" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#simulated-xr-device-visibility-state">#simulated-xr-device-visibility-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-device-visibility-state">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-device-resolution">
-   <b><a href="#view-device-resolution">#view-device-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-device-resolution" class="dfn-panel" data-for="view-device-resolution" id="infopanel-for-view-device-resolution" role="dialog">
+   <span id="infopaneltitle-for-view-device-resolution" style="display:none">Info about the 'device resolution' definition.</span><b><a href="#view-device-resolution">#view-device-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-device-resolution">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-field-of-view">
-   <b><a href="#view-field-of-view">#view-field-of-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-field-of-view" class="dfn-panel" data-for="view-field-of-view" id="infopanel-for-view-field-of-view" role="dialog">
+   <span id="infopaneltitle-for-view-field-of-view" style="display:none">Info about the 'field of view' definition.</span><b><a href="#view-field-of-view">#view-field-of-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-field-of-view">3.1. Simulated XR Device</a> <a href="#ref-for-view-field-of-view①">(2)</a>
     <li><a href="#ref-for-view-field-of-view②">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source">
-   <b><a href="#simulated-xr-input-source">#simulated-xr-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source" class="dfn-panel" data-for="simulated-xr-input-source" id="infopanel-for-simulated-xr-input-source" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source" style="display:none">Info about the 'simulated XR input source' definition.</span><b><a href="#simulated-xr-input-source">#simulated-xr-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source">3.2. Simulated Input Device</a> <a href="#ref-for-simulated-xr-input-source①">(2)</a> <a href="#ref-for-simulated-xr-input-source②">(3)</a> <a href="#ref-for-simulated-xr-input-source③">(4)</a> <a href="#ref-for-simulated-xr-input-source④">(5)</a> <a href="#ref-for-simulated-xr-input-source⑤">(6)</a> <a href="#ref-for-simulated-xr-input-source⑥">(7)</a> <a href="#ref-for-simulated-xr-input-source⑦">(8)</a> <a href="#ref-for-simulated-xr-input-source⑧">(9)</a> <a href="#ref-for-simulated-xr-input-source⑨">(10)</a>
     <li><a href="#ref-for-simulated-xr-input-source①⓪">5.1. FakeXRDevice</a> <a href="#ref-for-simulated-xr-input-source①①">(2)</a>
     <li><a href="#ref-for-simulated-xr-input-source①②">5.2. FakeXRInputController</a> <a href="#ref-for-simulated-xr-input-source①③">(2)</a> <a href="#ref-for-simulated-xr-input-source①④">(3)</a> <a href="#ref-for-simulated-xr-input-source①⑤">(4)</a> <a href="#ref-for-simulated-xr-input-source①⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-handedness">
-   <b><a href="#simulated-xr-input-source-handedness">#simulated-xr-input-source-handedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-handedness" class="dfn-panel" data-for="simulated-xr-input-source-handedness" id="infopanel-for-simulated-xr-input-source-handedness" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-handedness" style="display:none">Info about the 'handedness' definition.</span><b><a href="#simulated-xr-input-source-handedness">#simulated-xr-input-source-handedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-handedness">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-handedness①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-targetraymode">
-   <b><a href="#simulated-xr-input-source-targetraymode">#simulated-xr-input-source-targetraymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-targetraymode" class="dfn-panel" data-for="simulated-xr-input-source-targetraymode" id="infopanel-for-simulated-xr-input-source-targetraymode" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-targetraymode" style="display:none">Info about the 'targetRayMode' definition.</span><b><a href="#simulated-xr-input-source-targetraymode">#simulated-xr-input-source-targetraymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-targetraymode">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-targetraymode①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-pointerorigin">
-   <b><a href="#simulated-xr-input-source-pointerorigin">#simulated-xr-input-source-pointerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-pointerorigin" class="dfn-panel" data-for="simulated-xr-input-source-pointerorigin" id="infopanel-for-simulated-xr-input-source-pointerorigin" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-pointerorigin" style="display:none">Info about the 'pointerOrigin' definition.</span><b><a href="#simulated-xr-input-source-pointerorigin">#simulated-xr-input-source-pointerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-pointerorigin">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-pointerorigin①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-griporigin">
-   <b><a href="#simulated-xr-input-source-griporigin">#simulated-xr-input-source-griporigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-griporigin" class="dfn-panel" data-for="simulated-xr-input-source-griporigin" id="infopanel-for-simulated-xr-input-source-griporigin" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-griporigin" style="display:none">Info about the 'gripOrigin' definition.</span><b><a href="#simulated-xr-input-source-griporigin">#simulated-xr-input-source-griporigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-griporigin">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-griporigin①">5.2. FakeXRInputController</a> <a href="#ref-for-simulated-xr-input-source-griporigin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-profiles">
-   <b><a href="#simulated-xr-input-source-profiles">#simulated-xr-input-source-profiles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-profiles" class="dfn-panel" data-for="simulated-xr-input-source-profiles" id="infopanel-for-simulated-xr-input-source-profiles" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-profiles" style="display:none">Info about the 'profiles' definition.</span><b><a href="#simulated-xr-input-source-profiles">#simulated-xr-input-source-profiles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-profiles">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-profiles①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-buttonstate">
-   <b><a href="#simulated-xr-input-source-buttonstate">#simulated-xr-input-source-buttonstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-buttonstate" class="dfn-panel" data-for="simulated-xr-input-source-buttonstate" id="infopanel-for-simulated-xr-input-source-buttonstate" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-buttonstate" style="display:none">Info about the 'buttonState' definition.</span><b><a href="#simulated-xr-input-source-buttonstate">#simulated-xr-input-source-buttonstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-buttonstate">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-simulated-xr-input-source-buttonstate①">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulated-xr-input-source-buttonstate②">5.2. FakeXRInputController</a> <a href="#ref-for-simulated-xr-input-source-buttonstate③">(2)</a> <a href="#ref-for-simulated-xr-input-source-buttonstate④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-connectionstate">
-   <b><a href="#simulated-xr-input-source-connectionstate">#simulated-xr-input-source-connectionstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-connectionstate" class="dfn-panel" data-for="simulated-xr-input-source-connectionstate" id="infopanel-for-simulated-xr-input-source-connectionstate" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-connectionstate" style="display:none">Info about the 'connectionState' definition.</span><b><a href="#simulated-xr-input-source-connectionstate">#simulated-xr-input-source-connectionstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-connectionstate">5.2. FakeXRInputController</a> <a href="#ref-for-simulated-xr-input-source-connectionstate①">(2)</a> <a href="#ref-for-simulated-xr-input-source-connectionstate②">(3)</a> <a href="#ref-for-simulated-xr-input-source-connectionstate③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulated-xr-input-source-primaryactionstarted">
-   <b><a href="#simulated-xr-input-source-primaryactionstarted">#simulated-xr-input-source-primaryactionstarted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulated-xr-input-source-primaryactionstarted" class="dfn-panel" data-for="simulated-xr-input-source-primaryactionstarted" id="infopanel-for-simulated-xr-input-source-primaryactionstarted" role="dialog">
+   <span id="infopaneltitle-for-simulated-xr-input-source-primaryactionstarted" style="display:none">Info about the 'primaryActionStarted' definition.</span><b><a href="#simulated-xr-input-source-primaryactionstarted">#simulated-xr-input-source-primaryactionstarted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulated-xr-input-source-primaryactionstarted">5.2. FakeXRInputController</a> <a href="#ref-for-simulated-xr-input-source-primaryactionstarted①">(2)</a> <a href="#ref-for-simulated-xr-input-source-primaryactionstarted②">(3)</a> <a href="#ref-for-simulated-xr-input-source-primaryactionstarted③">(4)</a> <a href="#ref-for-simulated-xr-input-source-primaryactionstarted④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsystem-test">
-   <b><a href="#dom-xrsystem-test">#dom-xrsystem-test</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsystem-test" class="dfn-panel" data-for="dom-xrsystem-test" id="infopanel-for-dom-xrsystem-test" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsystem-test" style="display:none">Info about the 'test' definition.</span><b><a href="#dom-xrsystem-test">#dom-xrsystem-test</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-test">4.1. navigator.xr.test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrtest">
-   <b><a href="#xrtest">#xrtest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrtest" class="dfn-panel" data-for="xrtest" id="infopanel-for-xrtest" role="dialog">
+   <span id="infopaneltitle-for-xrtest" style="display:none">Info about the 'XRTest' definition.</span><b><a href="#xrtest">#xrtest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrtest">4.1. navigator.xr.test</a> <a href="#ref-for-xrtest①">(2)</a>
     <li><a href="#ref-for-xrtest②">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtest-simulatedeviceconnection">
-   <b><a href="#dom-xrtest-simulatedeviceconnection">#dom-xrtest-simulatedeviceconnection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtest-simulatedeviceconnection" class="dfn-panel" data-for="dom-xrtest-simulatedeviceconnection" id="infopanel-for-dom-xrtest-simulatedeviceconnection" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtest-simulatedeviceconnection" style="display:none">Info about the 'simulateDeviceConnection(init)' definition.</span><b><a href="#dom-xrtest-simulatedeviceconnection">#dom-xrtest-simulatedeviceconnection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtest-simulatedeviceconnection">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtest-simulateuseractivation">
-   <b><a href="#dom-xrtest-simulateuseractivation">#dom-xrtest-simulateuseractivation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtest-simulateuseractivation" class="dfn-panel" data-for="dom-xrtest-simulateuseractivation" id="infopanel-for-dom-xrtest-simulateuseractivation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtest-simulateuseractivation" style="display:none">Info about the 'simulateUserActivation(f)' definition.</span><b><a href="#dom-xrtest-simulateuseractivation">#dom-xrtest-simulateuseractivation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtest-simulateuseractivation">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtest-disconnectalldevices">
-   <b><a href="#dom-xrtest-disconnectalldevices">#dom-xrtest-disconnectalldevices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtest-disconnectalldevices" class="dfn-panel" data-for="dom-xrtest-disconnectalldevices" id="infopanel-for-dom-xrtest-disconnectalldevices" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtest-disconnectalldevices" style="display:none">Info about the 'disconnectAllDevices()' definition.</span><b><a href="#dom-xrtest-disconnectalldevices">#dom-xrtest-disconnectalldevices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtest-disconnectalldevices">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrdeviceinit">
-   <b><a href="#dictdef-fakexrdeviceinit">#dictdef-fakexrdeviceinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrdeviceinit" class="dfn-panel" data-for="dictdef-fakexrdeviceinit" id="infopanel-for-dictdef-fakexrdeviceinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrdeviceinit" style="display:none">Info about the 'FakeXRDeviceInit' definition.</span><b><a href="#dictdef-fakexrdeviceinit">#dictdef-fakexrdeviceinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrdeviceinit">4.2. XRTest</a> <a href="#ref-for-dictdef-fakexrdeviceinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-supportsimmersive">
-   <b><a href="#dom-fakexrdeviceinit-supportsimmersive">#dom-fakexrdeviceinit-supportsimmersive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-supportsimmersive" class="dfn-panel" data-for="dom-fakexrdeviceinit-supportsimmersive" id="infopanel-for-dom-fakexrdeviceinit-supportsimmersive" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-supportsimmersive" style="display:none">Info about the 'supportsImmersive' definition.</span><b><a href="#dom-fakexrdeviceinit-supportsimmersive">#dom-fakexrdeviceinit-supportsimmersive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-supportsimmersive">4.2. XRTest</a>
     <li><a href="#ref-for-dom-fakexrdeviceinit-supportsimmersive①">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-supportedmodes">
-   <b><a href="#dom-fakexrdeviceinit-supportedmodes">#dom-fakexrdeviceinit-supportedmodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-supportedmodes" class="dfn-panel" data-for="dom-fakexrdeviceinit-supportedmodes" id="infopanel-for-dom-fakexrdeviceinit-supportedmodes" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-supportedmodes" style="display:none">Info about the 'supportedModes' definition.</span><b><a href="#dom-fakexrdeviceinit-supportedmodes">#dom-fakexrdeviceinit-supportedmodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-supportedmodes">4.2. XRTest</a> <a href="#ref-for-dom-fakexrdeviceinit-supportedmodes①">(2)</a>
     <li><a href="#ref-for-dom-fakexrdeviceinit-supportedmodes②">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-views">
-   <b><a href="#dom-fakexrdeviceinit-views">#dom-fakexrdeviceinit-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-views" class="dfn-panel" data-for="dom-fakexrdeviceinit-views" id="infopanel-for-dom-fakexrdeviceinit-views" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-views" style="display:none">Info about the 'views' definition.</span><b><a href="#dom-fakexrdeviceinit-views">#dom-fakexrdeviceinit-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-views">4.2. XRTest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-supportedfeatures">
-   <b><a href="#dom-fakexrdeviceinit-supportedfeatures">#dom-fakexrdeviceinit-supportedfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-supportedfeatures" class="dfn-panel" data-for="dom-fakexrdeviceinit-supportedfeatures" id="infopanel-for-dom-fakexrdeviceinit-supportedfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-supportedfeatures" style="display:none">Info about the 'supportedFeatures' definition.</span><b><a href="#dom-fakexrdeviceinit-supportedfeatures">#dom-fakexrdeviceinit-supportedfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-supportedfeatures">4.2. XRTest</a> <a href="#ref-for-dom-fakexrdeviceinit-supportedfeatures①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-boundscoordinates">
-   <b><a href="#dom-fakexrdeviceinit-boundscoordinates">#dom-fakexrdeviceinit-boundscoordinates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-boundscoordinates" class="dfn-panel" data-for="dom-fakexrdeviceinit-boundscoordinates" id="infopanel-for-dom-fakexrdeviceinit-boundscoordinates" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-boundscoordinates" style="display:none">Info about the 'boundsCoordinates' definition.</span><b><a href="#dom-fakexrdeviceinit-boundscoordinates">#dom-fakexrdeviceinit-boundscoordinates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-boundscoordinates">4.2. XRTest</a> <a href="#ref-for-dom-fakexrdeviceinit-boundscoordinates①">(2)</a> <a href="#ref-for-dom-fakexrdeviceinit-boundscoordinates②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-floororigin">
-   <b><a href="#dom-fakexrdeviceinit-floororigin">#dom-fakexrdeviceinit-floororigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-floororigin" class="dfn-panel" data-for="dom-fakexrdeviceinit-floororigin" id="infopanel-for-dom-fakexrdeviceinit-floororigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-floororigin" style="display:none">Info about the 'floorOrigin' definition.</span><b><a href="#dom-fakexrdeviceinit-floororigin">#dom-fakexrdeviceinit-floororigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-floororigin">4.2. XRTest</a> <a href="#ref-for-dom-fakexrdeviceinit-floororigin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdeviceinit-viewerorigin">
-   <b><a href="#dom-fakexrdeviceinit-viewerorigin">#dom-fakexrdeviceinit-viewerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdeviceinit-viewerorigin" class="dfn-panel" data-for="dom-fakexrdeviceinit-viewerorigin" id="infopanel-for-dom-fakexrdeviceinit-viewerorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdeviceinit-viewerorigin" style="display:none">Info about the 'viewerOrigin' definition.</span><b><a href="#dom-fakexrdeviceinit-viewerorigin">#dom-fakexrdeviceinit-viewerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdeviceinit-viewerorigin">4.2. XRTest</a> <a href="#ref-for-dom-fakexrdeviceinit-viewerorigin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrviewinit">
-   <b><a href="#dictdef-fakexrviewinit">#dictdef-fakexrviewinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrviewinit" class="dfn-panel" data-for="dictdef-fakexrviewinit" id="infopanel-for-dictdef-fakexrviewinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrviewinit" style="display:none">Info about the 'FakeXRViewInit' definition.</span><b><a href="#dictdef-fakexrviewinit">#dictdef-fakexrviewinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrviewinit">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dictdef-fakexrviewinit①">(2)</a>
     <li><a href="#ref-for-dictdef-fakexrviewinit②">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrviewinit-eye">
-   <b><a href="#dom-fakexrviewinit-eye">#dom-fakexrviewinit-eye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrviewinit-eye" class="dfn-panel" data-for="dom-fakexrviewinit-eye" id="infopanel-for-dom-fakexrviewinit-eye" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrviewinit-eye" style="display:none">Info about the 'eye' definition.</span><b><a href="#dom-fakexrviewinit-eye">#dom-fakexrviewinit-eye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrviewinit-eye">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrviewinit-projectionmatrix">
-   <b><a href="#dom-fakexrviewinit-projectionmatrix">#dom-fakexrviewinit-projectionmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrviewinit-projectionmatrix" class="dfn-panel" data-for="dom-fakexrviewinit-projectionmatrix" id="infopanel-for-dom-fakexrviewinit-projectionmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrviewinit-projectionmatrix" style="display:none">Info about the 'projectionMatrix' definition.</span><b><a href="#dom-fakexrviewinit-projectionmatrix">#dom-fakexrviewinit-projectionmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrviewinit-projectionmatrix">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-fakexrviewinit-projectionmatrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrviewinit-resolution">
-   <b><a href="#dom-fakexrviewinit-resolution">#dom-fakexrviewinit-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrviewinit-resolution" class="dfn-panel" data-for="dom-fakexrviewinit-resolution" id="infopanel-for-dom-fakexrviewinit-resolution" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrviewinit-resolution" style="display:none">Info about the 'resolution' definition.</span><b><a href="#dom-fakexrviewinit-resolution">#dom-fakexrviewinit-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrviewinit-resolution">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrviewinit-viewoffset">
-   <b><a href="#dom-fakexrviewinit-viewoffset">#dom-fakexrviewinit-viewoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrviewinit-viewoffset" class="dfn-panel" data-for="dom-fakexrviewinit-viewoffset" id="infopanel-for-dom-fakexrviewinit-viewoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrviewinit-viewoffset" style="display:none">Info about the 'viewOffset' definition.</span><b><a href="#dom-fakexrviewinit-viewoffset">#dom-fakexrviewinit-viewoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrviewinit-viewoffset">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrviewinit-fieldofview">
-   <b><a href="#dom-fakexrviewinit-fieldofview">#dom-fakexrviewinit-fieldofview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrviewinit-fieldofview" class="dfn-panel" data-for="dom-fakexrviewinit-fieldofview" id="infopanel-for-dom-fakexrviewinit-fieldofview" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrviewinit-fieldofview" style="display:none">Info about the 'fieldOfView' definition.</span><b><a href="#dom-fakexrviewinit-fieldofview">#dom-fakexrviewinit-fieldofview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrviewinit-fieldofview">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dom-fakexrviewinit-fieldofview①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrfieldofviewinit">
-   <b><a href="#dictdef-fakexrfieldofviewinit">#dictdef-fakexrfieldofviewinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrfieldofviewinit" class="dfn-panel" data-for="dictdef-fakexrfieldofviewinit" id="infopanel-for-dictdef-fakexrfieldofviewinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrfieldofviewinit" style="display:none">Info about the 'FakeXRFieldOfViewInit' definition.</span><b><a href="#dictdef-fakexrfieldofviewinit">#dictdef-fakexrfieldofviewinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrfieldofviewinit">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-dictdef-fakexrfieldofviewinit①">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrdeviceresolution">
-   <b><a href="#dictdef-fakexrdeviceresolution">#dictdef-fakexrdeviceresolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrdeviceresolution" class="dfn-panel" data-for="dictdef-fakexrdeviceresolution" id="infopanel-for-dictdef-fakexrdeviceresolution" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrdeviceresolution" style="display:none">Info about the 'FakeXRDeviceResolution' definition.</span><b><a href="#dictdef-fakexrdeviceresolution">#dictdef-fakexrdeviceresolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrdeviceresolution">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-dictdef-fakexrdeviceresolution①">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrboundspoint">
-   <b><a href="#dictdef-fakexrboundspoint">#dictdef-fakexrboundspoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrboundspoint" class="dfn-panel" data-for="dictdef-fakexrboundspoint" id="infopanel-for-dictdef-fakexrboundspoint" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrboundspoint" style="display:none">Info about the 'FakeXRBoundsPoint' definition.</span><b><a href="#dictdef-fakexrboundspoint">#dictdef-fakexrboundspoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrboundspoint">4.3. FakeXRDeviceInit</a>
     <li><a href="#ref-for-dictdef-fakexrboundspoint①">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrrigidtransforminit">
-   <b><a href="#dictdef-fakexrrigidtransforminit">#dictdef-fakexrrigidtransforminit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrrigidtransforminit" class="dfn-panel" data-for="dictdef-fakexrrigidtransforminit" id="infopanel-for-dictdef-fakexrrigidtransforminit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrrigidtransforminit" style="display:none">Info about the 'FakeXRRigidTransformInit' definition.</span><b><a href="#dictdef-fakexrrigidtransforminit">#dictdef-fakexrrigidtransforminit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrrigidtransforminit">4.3. FakeXRDeviceInit</a> <a href="#ref-for-dictdef-fakexrrigidtransforminit①">(2)</a> <a href="#ref-for-dictdef-fakexrrigidtransforminit②">(3)</a> <a href="#ref-for-dictdef-fakexrrigidtransforminit③">(4)</a>
     <li><a href="#ref-for-dictdef-fakexrrigidtransforminit④">4.4. FakeXRRigidTransformInit</a> <a href="#ref-for-dictdef-fakexrrigidtransforminit⑤">(2)</a>
@@ -2778,42 +2778,42 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-dictdef-fakexrrigidtransforminit①⑤">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrrigidtransforminit-position">
-   <b><a href="#dom-fakexrrigidtransforminit-position">#dom-fakexrrigidtransforminit-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrrigidtransforminit-position" class="dfn-panel" data-for="dom-fakexrrigidtransforminit-position" id="infopanel-for-dom-fakexrrigidtransforminit-position" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrrigidtransforminit-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-fakexrrigidtransforminit-position">#dom-fakexrrigidtransforminit-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrrigidtransforminit-position">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrrigidtransforminit-orientation">
-   <b><a href="#dom-fakexrrigidtransforminit-orientation">#dom-fakexrrigidtransforminit-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrrigidtransforminit-orientation" class="dfn-panel" data-for="dom-fakexrrigidtransforminit-orientation" id="infopanel-for-dom-fakexrrigidtransforminit-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrrigidtransforminit-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-fakexrrigidtransforminit-orientation">#dom-fakexrrigidtransforminit-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrrigidtransforminit-orientation">4.3. FakeXRDeviceInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-rigid-transform">
-   <b><a href="#parse-a-rigid-transform">#parse-a-rigid-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-rigid-transform" class="dfn-panel" data-for="parse-a-rigid-transform" id="infopanel-for-parse-a-rigid-transform" role="dialog">
+   <span id="infopaneltitle-for-parse-a-rigid-transform" style="display:none">Info about the 'parse a rigid transform' definition.</span><b><a href="#parse-a-rigid-transform">#parse-a-rigid-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-rigid-transform">4.3. FakeXRDeviceInit</a>
     <li><a href="#ref-for-parse-a-rigid-transform①">5.1. FakeXRDevice</a> <a href="#ref-for-parse-a-rigid-transform②">(2)</a> <a href="#ref-for-parse-a-rigid-transform③">(3)</a> <a href="#ref-for-parse-a-rigid-transform④">(4)</a>
     <li><a href="#ref-for-parse-a-rigid-transform⑤">5.2. FakeXRInputController</a> <a href="#ref-for-parse-a-rigid-transform⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-view">
-   <b><a href="#parse-a-view">#parse-a-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-view" class="dfn-panel" data-for="parse-a-view" id="infopanel-for-parse-a-view" role="dialog">
+   <span id="infopaneltitle-for-parse-a-view" style="display:none">Info about the 'parse a view' definition.</span><b><a href="#parse-a-view">#parse-a-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-view">4.2. XRTest</a> <a href="#ref-for-parse-a-view①">(2)</a>
     <li><a href="#ref-for-parse-a-view②">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-reference-space">
-   <b><a href="#base-reference-space">#base-reference-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-reference-space" class="dfn-panel" data-for="base-reference-space" id="infopanel-for-base-reference-space" role="dialog">
+   <span id="infopaneltitle-for-base-reference-space" style="display:none">Info about the 'base reference space' definition.</span><b><a href="#base-reference-space">#base-reference-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-reference-space">4.4. FakeXRRigidTransformInit</a> <a href="#ref-for-base-reference-space①">(2)</a>
     <li><a href="#ref-for-base-reference-space②">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrdevice">
-   <b><a href="#fakexrdevice">#fakexrdevice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrdevice" class="dfn-panel" data-for="fakexrdevice" id="infopanel-for-fakexrdevice" role="dialog">
+   <span id="infopaneltitle-for-fakexrdevice" style="display:none">Info about the 'FakeXRDevice' definition.</span><b><a href="#fakexrdevice">#fakexrdevice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrdevice">3.1. Simulated XR Device</a>
     <li><a href="#ref-for-fakexrdevice①">4.2. XRTest</a> <a href="#ref-for-fakexrdevice②">(2)</a>
@@ -2824,27 +2824,27 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-fakexrdevice①③">10. Depth sensing extensions</a> <a href="#ref-for-fakexrdevice①④">(2)</a> <a href="#ref-for-fakexrdevice①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setdepthsensingdata">
-   <b><a href="#dom-fakexrdevice-setdepthsensingdata">#dom-fakexrdevice-setdepthsensingdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setdepthsensingdata" class="dfn-panel" data-for="dom-fakexrdevice-setdepthsensingdata" id="infopanel-for-dom-fakexrdevice-setdepthsensingdata" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setdepthsensingdata" style="display:none">Info about the 'setDepthSensingData' definition.</span><b><a href="#dom-fakexrdevice-setdepthsensingdata">#dom-fakexrdevice-setdepthsensingdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setdepthsensingdata">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-cleardepthsensingdata">
-   <b><a href="#dom-fakexrdevice-cleardepthsensingdata">#dom-fakexrdevice-cleardepthsensingdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-cleardepthsensingdata" class="dfn-panel" data-for="dom-fakexrdevice-cleardepthsensingdata" id="infopanel-for-dom-fakexrdevice-cleardepthsensingdata" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-cleardepthsensingdata" style="display:none">Info about the 'clearDepthSensingData' definition.</span><b><a href="#dom-fakexrdevice-cleardepthsensingdata">#dom-fakexrdevice-cleardepthsensingdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-cleardepthsensingdata">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrdevice-device">
-   <b><a href="#fakexrdevice-device">#fakexrdevice-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrdevice-device" class="dfn-panel" data-for="fakexrdevice-device" id="infopanel-for-fakexrdevice-device" role="dialog">
+   <span id="infopaneltitle-for-fakexrdevice-device" style="display:none">Info about the 'device' definition.</span><b><a href="#fakexrdevice-device">#fakexrdevice-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrdevice-device">4.2. XRTest</a>
     <li><a href="#ref-for-fakexrdevice-device①">5.1. FakeXRDevice</a> <a href="#ref-for-fakexrdevice-device②">(2)</a> <a href="#ref-for-fakexrdevice-device③">(3)</a> <a href="#ref-for-fakexrdevice-device④">(4)</a> <a href="#ref-for-fakexrdevice-device⑤">(5)</a> <a href="#ref-for-fakexrdevice-device⑥">(6)</a> <a href="#ref-for-fakexrdevice-device⑦">(7)</a> <a href="#ref-for-fakexrdevice-device⑧">(8)</a> <a href="#ref-for-fakexrdevice-device⑨">(9)</a> <a href="#ref-for-fakexrdevice-device①⓪">(10)</a> <a href="#ref-for-fakexrdevice-device①①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-next-animation-frame">
-   <b><a href="#xrsession-next-animation-frame">#xrsession-next-animation-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-next-animation-frame" class="dfn-panel" data-for="xrsession-next-animation-frame" id="infopanel-for-xrsession-next-animation-frame" role="dialog">
+   <span id="infopaneltitle-for-xrsession-next-animation-frame" style="display:none">Info about the 'next animation frame' definition.</span><b><a href="#xrsession-next-animation-frame">#xrsession-next-animation-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-next-animation-frame">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-xrsession-next-animation-frame①">5.1. FakeXRDevice</a> <a href="#ref-for-xrsession-next-animation-frame②">(2)</a> <a href="#ref-for-xrsession-next-animation-frame③">(3)</a> <a href="#ref-for-xrsession-next-animation-frame④">(4)</a> <a href="#ref-for-xrsession-next-animation-frame⑤">(5)</a> <a href="#ref-for-xrsession-next-animation-frame⑥">(6)</a> <a href="#ref-for-xrsession-next-animation-frame⑦">(7)</a>
@@ -2852,123 +2852,123 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-xrsession-next-animation-frame②①">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setviews">
-   <b><a href="#dom-fakexrdevice-setviews">#dom-fakexrdevice-setviews</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setviews" class="dfn-panel" data-for="dom-fakexrdevice-setviews" id="infopanel-for-dom-fakexrdevice-setviews" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setviews" style="display:none">Info about the 'setViews(views)' definition.</span><b><a href="#dom-fakexrdevice-setviews">#dom-fakexrdevice-setviews</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setviews">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-disconnect">
-   <b><a href="#dom-fakexrdevice-disconnect">#dom-fakexrdevice-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-disconnect" class="dfn-panel" data-for="dom-fakexrdevice-disconnect" id="infopanel-for-dom-fakexrdevice-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-fakexrdevice-disconnect">#dom-fakexrdevice-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-disconnect">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setviewerorigin">
-   <b><a href="#dom-fakexrdevice-setviewerorigin">#dom-fakexrdevice-setviewerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setviewerorigin" class="dfn-panel" data-for="dom-fakexrdevice-setviewerorigin" id="infopanel-for-dom-fakexrdevice-setviewerorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setviewerorigin" style="display:none">Info about the 'setViewerOrigin(origin, emulatedPosition)' definition.</span><b><a href="#dom-fakexrdevice-setviewerorigin">#dom-fakexrdevice-setviewerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setviewerorigin">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-clearviewerorigin">
-   <b><a href="#dom-fakexrdevice-clearviewerorigin">#dom-fakexrdevice-clearviewerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-clearviewerorigin" class="dfn-panel" data-for="dom-fakexrdevice-clearviewerorigin" id="infopanel-for-dom-fakexrdevice-clearviewerorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-clearviewerorigin" style="display:none">Info about the 'clearViewerOrigin()' definition.</span><b><a href="#dom-fakexrdevice-clearviewerorigin">#dom-fakexrdevice-clearviewerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-clearviewerorigin">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-simulatevisibilitychange">
-   <b><a href="#dom-fakexrdevice-simulatevisibilitychange">#dom-fakexrdevice-simulatevisibilitychange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-simulatevisibilitychange" class="dfn-panel" data-for="dom-fakexrdevice-simulatevisibilitychange" id="infopanel-for-dom-fakexrdevice-simulatevisibilitychange" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-simulatevisibilitychange" style="display:none">Info about the 'simulateVisibilityChange(state)' definition.</span><b><a href="#dom-fakexrdevice-simulatevisibilitychange">#dom-fakexrdevice-simulatevisibilitychange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-simulatevisibilitychange">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setfloororigin">
-   <b><a href="#dom-fakexrdevice-setfloororigin">#dom-fakexrdevice-setfloororigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setfloororigin" class="dfn-panel" data-for="dom-fakexrdevice-setfloororigin" id="infopanel-for-dom-fakexrdevice-setfloororigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setfloororigin" style="display:none">Info about the 'setFloorOrigin(origin)' definition.</span><b><a href="#dom-fakexrdevice-setfloororigin">#dom-fakexrdevice-setfloororigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setfloororigin">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-clearfloororigin">
-   <b><a href="#dom-fakexrdevice-clearfloororigin">#dom-fakexrdevice-clearfloororigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-clearfloororigin" class="dfn-panel" data-for="dom-fakexrdevice-clearfloororigin" id="infopanel-for-dom-fakexrdevice-clearfloororigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-clearfloororigin" style="display:none">Info about the 'clearFloorOrigin()' definition.</span><b><a href="#dom-fakexrdevice-clearfloororigin">#dom-fakexrdevice-clearfloororigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-clearfloororigin">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setboundsgeometry">
-   <b><a href="#dom-fakexrdevice-setboundsgeometry">#dom-fakexrdevice-setboundsgeometry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setboundsgeometry" class="dfn-panel" data-for="dom-fakexrdevice-setboundsgeometry" id="infopanel-for-dom-fakexrdevice-setboundsgeometry" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setboundsgeometry" style="display:none">Info about the 'setBoundsGeometry(boundsCoordinates)' definition.</span><b><a href="#dom-fakexrdevice-setboundsgeometry">#dom-fakexrdevice-setboundsgeometry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setboundsgeometry">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-simulateresetpose">
-   <b><a href="#dom-fakexrdevice-simulateresetpose">#dom-fakexrdevice-simulateresetpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-simulateresetpose" class="dfn-panel" data-for="dom-fakexrdevice-simulateresetpose" id="infopanel-for-dom-fakexrdevice-simulateresetpose" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-simulateresetpose" style="display:none">Info about the 'simulateResetPose()' definition.</span><b><a href="#dom-fakexrdevice-simulateresetpose">#dom-fakexrdevice-simulateresetpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-simulateresetpose">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-simulateinputsourceconnection">
-   <b><a href="#dom-fakexrdevice-simulateinputsourceconnection">#dom-fakexrdevice-simulateinputsourceconnection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-simulateinputsourceconnection" class="dfn-panel" data-for="dom-fakexrdevice-simulateinputsourceconnection" id="infopanel-for-dom-fakexrdevice-simulateinputsourceconnection" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-simulateinputsourceconnection" style="display:none">Info about the 'simulateInputSourceConnection(init)' definition.</span><b><a href="#dom-fakexrdevice-simulateinputsourceconnection">#dom-fakexrdevice-simulateinputsourceconnection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-simulateinputsourceconnection">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-dom-fakexrdevice-simulateinputsourceconnection①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrinputsourceinit">
-   <b><a href="#dictdef-fakexrinputsourceinit">#dictdef-fakexrinputsourceinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrinputsourceinit" class="dfn-panel" data-for="dictdef-fakexrinputsourceinit" id="infopanel-for-dictdef-fakexrinputsourceinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrinputsourceinit" style="display:none">Info about the 'FakeXRInputSourceInit' definition.</span><b><a href="#dictdef-fakexrinputsourceinit">#dictdef-fakexrinputsourceinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrinputsourceinit">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-handedness">
-   <b><a href="#dom-fakexrinputsourceinit-handedness">#dom-fakexrinputsourceinit-handedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-handedness" class="dfn-panel" data-for="dom-fakexrinputsourceinit-handedness" id="infopanel-for-dom-fakexrinputsourceinit-handedness" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-handedness" style="display:none">Info about the 'handedness' definition.</span><b><a href="#dom-fakexrinputsourceinit-handedness">#dom-fakexrinputsourceinit-handedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-handedness">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-targetraymode">
-   <b><a href="#dom-fakexrinputsourceinit-targetraymode">#dom-fakexrinputsourceinit-targetraymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-targetraymode" class="dfn-panel" data-for="dom-fakexrinputsourceinit-targetraymode" id="infopanel-for-dom-fakexrinputsourceinit-targetraymode" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-targetraymode" style="display:none">Info about the 'targetRayMode' definition.</span><b><a href="#dom-fakexrinputsourceinit-targetraymode">#dom-fakexrinputsourceinit-targetraymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-targetraymode">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-pointerorigin">
-   <b><a href="#dom-fakexrinputsourceinit-pointerorigin">#dom-fakexrinputsourceinit-pointerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-pointerorigin" class="dfn-panel" data-for="dom-fakexrinputsourceinit-pointerorigin" id="infopanel-for-dom-fakexrinputsourceinit-pointerorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-pointerorigin" style="display:none">Info about the 'pointerOrigin' definition.</span><b><a href="#dom-fakexrinputsourceinit-pointerorigin">#dom-fakexrinputsourceinit-pointerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-pointerorigin">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-profiles">
-   <b><a href="#dom-fakexrinputsourceinit-profiles">#dom-fakexrinputsourceinit-profiles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-profiles" class="dfn-panel" data-for="dom-fakexrinputsourceinit-profiles" id="infopanel-for-dom-fakexrinputsourceinit-profiles" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-profiles" style="display:none">Info about the 'profiles' definition.</span><b><a href="#dom-fakexrinputsourceinit-profiles">#dom-fakexrinputsourceinit-profiles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-profiles">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-selectionstarted">
-   <b><a href="#dom-fakexrinputsourceinit-selectionstarted">#dom-fakexrinputsourceinit-selectionstarted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-selectionstarted" class="dfn-panel" data-for="dom-fakexrinputsourceinit-selectionstarted" id="infopanel-for-dom-fakexrinputsourceinit-selectionstarted" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-selectionstarted" style="display:none">Info about the 'selectionStarted' definition.</span><b><a href="#dom-fakexrinputsourceinit-selectionstarted">#dom-fakexrinputsourceinit-selectionstarted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-selectionstarted">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-selectionclicked">
-   <b><a href="#dom-fakexrinputsourceinit-selectionclicked">#dom-fakexrinputsourceinit-selectionclicked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-selectionclicked" class="dfn-panel" data-for="dom-fakexrinputsourceinit-selectionclicked" id="infopanel-for-dom-fakexrinputsourceinit-selectionclicked" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-selectionclicked" style="display:none">Info about the 'selectionClicked' definition.</span><b><a href="#dom-fakexrinputsourceinit-selectionclicked">#dom-fakexrinputsourceinit-selectionclicked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-selectionclicked">5.1. FakeXRDevice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-supportedbuttons">
-   <b><a href="#dom-fakexrinputsourceinit-supportedbuttons">#dom-fakexrinputsourceinit-supportedbuttons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-supportedbuttons" class="dfn-panel" data-for="dom-fakexrinputsourceinit-supportedbuttons" id="infopanel-for-dom-fakexrinputsourceinit-supportedbuttons" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-supportedbuttons" style="display:none">Info about the 'supportedButtons' definition.</span><b><a href="#dom-fakexrinputsourceinit-supportedbuttons">#dom-fakexrinputsourceinit-supportedbuttons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-supportedbuttons">5.1. FakeXRDevice</a> <a href="#ref-for-dom-fakexrinputsourceinit-supportedbuttons①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputsourceinit-griporigin">
-   <b><a href="#dom-fakexrinputsourceinit-griporigin">#dom-fakexrinputsourceinit-griporigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputsourceinit-griporigin" class="dfn-panel" data-for="dom-fakexrinputsourceinit-griporigin" id="infopanel-for-dom-fakexrinputsourceinit-griporigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputsourceinit-griporigin" style="display:none">Info about the 'gripOrigin' definition.</span><b><a href="#dom-fakexrinputsourceinit-griporigin">#dom-fakexrinputsourceinit-griporigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputsourceinit-griporigin">5.1. FakeXRDevice</a> <a href="#ref-for-dom-fakexrinputsourceinit-griporigin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrinputcontroller">
-   <b><a href="#fakexrinputcontroller">#fakexrinputcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrinputcontroller" class="dfn-panel" data-for="fakexrinputcontroller" id="infopanel-for-fakexrinputcontroller" role="dialog">
+   <span id="infopaneltitle-for-fakexrinputcontroller" style="display:none">Info about the 'FakeXRInputController' definition.</span><b><a href="#fakexrinputcontroller">#fakexrinputcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrinputcontroller">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-fakexrinputcontroller①">5.1. FakeXRDevice</a> <a href="#ref-for-fakexrinputcontroller②">(2)</a>
@@ -2976,479 +2976,535 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-fakexrinputcontroller⑤">7. DOM overlay extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fakexrbuttontype">
-   <b><a href="#enumdef-fakexrbuttontype">#enumdef-fakexrbuttontype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fakexrbuttontype" class="dfn-panel" data-for="enumdef-fakexrbuttontype" id="infopanel-for-enumdef-fakexrbuttontype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fakexrbuttontype" style="display:none">Info about the 'FakeXRButtonType' definition.</span><b><a href="#enumdef-fakexrbuttontype">#enumdef-fakexrbuttontype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fakexrbuttontype">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttontype-grip">
-   <b><a href="#dom-fakexrbuttontype-grip">#dom-fakexrbuttontype-grip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttontype-grip" class="dfn-panel" data-for="dom-fakexrbuttontype-grip" id="infopanel-for-dom-fakexrbuttontype-grip" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttontype-grip" style="display:none">Info about the '"grip"' definition.</span><b><a href="#dom-fakexrbuttontype-grip">#dom-fakexrbuttontype-grip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttontype-grip">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-dom-fakexrbuttontype-grip①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttontype-touchpad">
-   <b><a href="#dom-fakexrbuttontype-touchpad">#dom-fakexrbuttontype-touchpad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttontype-touchpad" class="dfn-panel" data-for="dom-fakexrbuttontype-touchpad" id="infopanel-for-dom-fakexrbuttontype-touchpad" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttontype-touchpad" style="display:none">Info about the '"touchpad"' definition.</span><b><a href="#dom-fakexrbuttontype-touchpad">#dom-fakexrbuttontype-touchpad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttontype-touchpad">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttontype-thumbstick">
-   <b><a href="#dom-fakexrbuttontype-thumbstick">#dom-fakexrbuttontype-thumbstick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttontype-thumbstick" class="dfn-panel" data-for="dom-fakexrbuttontype-thumbstick" id="infopanel-for-dom-fakexrbuttontype-thumbstick" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttontype-thumbstick" style="display:none">Info about the '"thumbstick"' definition.</span><b><a href="#dom-fakexrbuttontype-thumbstick">#dom-fakexrbuttontype-thumbstick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttontype-thumbstick">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttontype-optional-thumbstick">
-   <b><a href="#dom-fakexrbuttontype-optional-thumbstick">#dom-fakexrbuttontype-optional-thumbstick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttontype-optional-thumbstick" class="dfn-panel" data-for="dom-fakexrbuttontype-optional-thumbstick" id="infopanel-for-dom-fakexrbuttontype-optional-thumbstick" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttontype-optional-thumbstick" style="display:none">Info about the '"optional-thumbstick"' definition.</span><b><a href="#dom-fakexrbuttontype-optional-thumbstick">#dom-fakexrbuttontype-optional-thumbstick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttontype-optional-thumbstick">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrbuttonstateinit">
-   <b><a href="#dictdef-fakexrbuttonstateinit">#dictdef-fakexrbuttonstateinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrbuttonstateinit" class="dfn-panel" data-for="dictdef-fakexrbuttonstateinit" id="infopanel-for-dictdef-fakexrbuttonstateinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrbuttonstateinit" style="display:none">Info about the 'FakeXRButtonStateInit' definition.</span><b><a href="#dictdef-fakexrbuttonstateinit">#dictdef-fakexrbuttonstateinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrbuttonstateinit">3.2. Simulated Input Device</a>
     <li><a href="#ref-for-dictdef-fakexrbuttonstateinit①">5.2. FakeXRInputController</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit②">(2)</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit③">(3)</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit④">(4)</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit⑤">(5)</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit⑥">(6)</a> <a href="#ref-for-dictdef-fakexrbuttonstateinit⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-buttontype">
-   <b><a href="#dom-fakexrbuttonstateinit-buttontype">#dom-fakexrbuttonstateinit-buttontype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-buttontype" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-buttontype" id="infopanel-for-dom-fakexrbuttonstateinit-buttontype" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-buttontype" style="display:none">Info about the 'buttonType' definition.</span><b><a href="#dom-fakexrbuttonstateinit-buttontype">#dom-fakexrbuttonstateinit-buttontype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-buttontype">5.2. FakeXRInputController</a> <a href="#ref-for-dom-fakexrbuttonstateinit-buttontype①">(2)</a> <a href="#ref-for-dom-fakexrbuttonstateinit-buttontype②">(3)</a> <a href="#ref-for-dom-fakexrbuttonstateinit-buttontype③">(4)</a> <a href="#ref-for-dom-fakexrbuttonstateinit-buttontype④">(5)</a> <a href="#ref-for-dom-fakexrbuttonstateinit-buttontype⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-pressed">
-   <b><a href="#dom-fakexrbuttonstateinit-pressed">#dom-fakexrbuttonstateinit-pressed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-pressed" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-pressed" id="infopanel-for-dom-fakexrbuttonstateinit-pressed" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-pressed" style="display:none">Info about the 'pressed' definition.</span><b><a href="#dom-fakexrbuttonstateinit-pressed">#dom-fakexrbuttonstateinit-pressed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-pressed">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-touched">
-   <b><a href="#dom-fakexrbuttonstateinit-touched">#dom-fakexrbuttonstateinit-touched</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-touched" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-touched" id="infopanel-for-dom-fakexrbuttonstateinit-touched" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-touched" style="display:none">Info about the 'touched' definition.</span><b><a href="#dom-fakexrbuttonstateinit-touched">#dom-fakexrbuttonstateinit-touched</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-touched">5.2. FakeXRInputController</a> <a href="#ref-for-dom-fakexrbuttonstateinit-touched①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-pressedvalue">
-   <b><a href="#dom-fakexrbuttonstateinit-pressedvalue">#dom-fakexrbuttonstateinit-pressedvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-pressedvalue" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-pressedvalue" id="infopanel-for-dom-fakexrbuttonstateinit-pressedvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-pressedvalue" style="display:none">Info about the 'pressedValue' definition.</span><b><a href="#dom-fakexrbuttonstateinit-pressedvalue">#dom-fakexrbuttonstateinit-pressedvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-pressedvalue">5.2. FakeXRInputController</a> <a href="#ref-for-dom-fakexrbuttonstateinit-pressedvalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-xvalue">
-   <b><a href="#dom-fakexrbuttonstateinit-xvalue">#dom-fakexrbuttonstateinit-xvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-xvalue" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-xvalue" id="infopanel-for-dom-fakexrbuttonstateinit-xvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-xvalue" style="display:none">Info about the 'xValue' definition.</span><b><a href="#dom-fakexrbuttonstateinit-xvalue">#dom-fakexrbuttonstateinit-xvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-xvalue">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrbuttonstateinit-yvalue">
-   <b><a href="#dom-fakexrbuttonstateinit-yvalue">#dom-fakexrbuttonstateinit-yvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrbuttonstateinit-yvalue" class="dfn-panel" data-for="dom-fakexrbuttonstateinit-yvalue" id="infopanel-for-dom-fakexrbuttonstateinit-yvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrbuttonstateinit-yvalue" style="display:none">Info about the 'yValue' definition.</span><b><a href="#dom-fakexrbuttonstateinit-yvalue">#dom-fakexrbuttonstateinit-yvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrbuttonstateinit-yvalue">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrinputcontroller-inputsource">
-   <b><a href="#fakexrinputcontroller-inputsource">#fakexrinputcontroller-inputsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrinputcontroller-inputsource" class="dfn-panel" data-for="fakexrinputcontroller-inputsource" id="infopanel-for-fakexrinputcontroller-inputsource" role="dialog">
+   <span id="infopaneltitle-for-fakexrinputcontroller-inputsource" style="display:none">Info about the 'inputSource' definition.</span><b><a href="#fakexrinputcontroller-inputsource">#fakexrinputcontroller-inputsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrinputcontroller-inputsource">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-fakexrinputcontroller-inputsource①">5.2. FakeXRInputController</a> <a href="#ref-for-fakexrinputcontroller-inputsource②">(2)</a> <a href="#ref-for-fakexrinputcontroller-inputsource③">(3)</a> <a href="#ref-for-fakexrinputcontroller-inputsource④">(4)</a> <a href="#ref-for-fakexrinputcontroller-inputsource⑤">(5)</a> <a href="#ref-for-fakexrinputcontroller-inputsource⑥">(6)</a> <a href="#ref-for-fakexrinputcontroller-inputsource⑦">(7)</a> <a href="#ref-for-fakexrinputcontroller-inputsource⑧">(8)</a> <a href="#ref-for-fakexrinputcontroller-inputsource⑨">(9)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①⓪">(10)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①①">(11)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①②">(12)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①③">(13)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①④">(14)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①⑤">(15)</a> <a href="#ref-for-fakexrinputcontroller-inputsource①⑥">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-a-primary-action">
-   <b><a href="#start-a-primary-action">#start-a-primary-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-a-primary-action" class="dfn-panel" data-for="start-a-primary-action" id="infopanel-for-start-a-primary-action" role="dialog">
+   <span id="infopaneltitle-for-start-a-primary-action" style="display:none">Info about the 'start a primary action' definition.</span><b><a href="#start-a-primary-action">#start-a-primary-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-a-primary-action">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-start-a-primary-action①">5.2. FakeXRInputController</a> <a href="#ref-for-start-a-primary-action②">(2)</a> <a href="#ref-for-start-a-primary-action③">(3)</a> <a href="#ref-for-start-a-primary-action④">(4)</a> <a href="#ref-for-start-a-primary-action⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stop-a-primary-action">
-   <b><a href="#stop-a-primary-action">#stop-a-primary-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stop-a-primary-action" class="dfn-panel" data-for="stop-a-primary-action" id="infopanel-for-stop-a-primary-action" role="dialog">
+   <span id="infopaneltitle-for-stop-a-primary-action" style="display:none">Info about the 'stop a primary action' definition.</span><b><a href="#stop-a-primary-action">#stop-a-primary-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-a-primary-action">5.2. FakeXRInputController</a> <a href="#ref-for-stop-a-primary-action①">(2)</a> <a href="#ref-for-stop-a-primary-action②">(3)</a> <a href="#ref-for-stop-a-primary-action③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simulate-a-full-primary-action">
-   <b><a href="#simulate-a-full-primary-action">#simulate-a-full-primary-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simulate-a-full-primary-action" class="dfn-panel" data-for="simulate-a-full-primary-action" id="infopanel-for-simulate-a-full-primary-action" role="dialog">
+   <span id="infopaneltitle-for-simulate-a-full-primary-action" style="display:none">Info about the 'simulate a full primary action' definition.</span><b><a href="#simulate-a-full-primary-action">#simulate-a-full-primary-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simulate-a-full-primary-action">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-simulate-a-full-primary-action①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-supported-buttons">
-   <b><a href="#parse-supported-buttons">#parse-supported-buttons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-supported-buttons" class="dfn-panel" data-for="parse-supported-buttons" id="infopanel-for-parse-supported-buttons" role="dialog">
+   <span id="infopaneltitle-for-parse-supported-buttons" style="display:none">Info about the 'parse supported buttons' definition.</span><b><a href="#parse-supported-buttons">#parse-supported-buttons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-supported-buttons">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-parse-supported-buttons①">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-sethandedness">
-   <b><a href="#dom-fakexrinputcontroller-sethandedness">#dom-fakexrinputcontroller-sethandedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-sethandedness" class="dfn-panel" data-for="dom-fakexrinputcontroller-sethandedness" id="infopanel-for-dom-fakexrinputcontroller-sethandedness" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-sethandedness" style="display:none">Info about the 'setHandedness(handedness)' definition.</span><b><a href="#dom-fakexrinputcontroller-sethandedness">#dom-fakexrinputcontroller-sethandedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-sethandedness">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-settargetraymode">
-   <b><a href="#dom-fakexrinputcontroller-settargetraymode">#dom-fakexrinputcontroller-settargetraymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-settargetraymode" class="dfn-panel" data-for="dom-fakexrinputcontroller-settargetraymode" id="infopanel-for-dom-fakexrinputcontroller-settargetraymode" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-settargetraymode" style="display:none">Info about the 'setTargetRayMode(targetRayMode)' definition.</span><b><a href="#dom-fakexrinputcontroller-settargetraymode">#dom-fakexrinputcontroller-settargetraymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-settargetraymode">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-setprofiles">
-   <b><a href="#dom-fakexrinputcontroller-setprofiles">#dom-fakexrinputcontroller-setprofiles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-setprofiles" class="dfn-panel" data-for="dom-fakexrinputcontroller-setprofiles" id="infopanel-for-dom-fakexrinputcontroller-setprofiles" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-setprofiles" style="display:none">Info about the 'setProfiles(profiles)' definition.</span><b><a href="#dom-fakexrinputcontroller-setprofiles">#dom-fakexrinputcontroller-setprofiles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-setprofiles">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-setgriporigin">
-   <b><a href="#dom-fakexrinputcontroller-setgriporigin">#dom-fakexrinputcontroller-setgriporigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-setgriporigin" class="dfn-panel" data-for="dom-fakexrinputcontroller-setgriporigin" id="infopanel-for-dom-fakexrinputcontroller-setgriporigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-setgriporigin" style="display:none">Info about the 'setGripOrigin(gripOrigin)' definition.</span><b><a href="#dom-fakexrinputcontroller-setgriporigin">#dom-fakexrinputcontroller-setgriporigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-setgriporigin">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-cleargriporigin">
-   <b><a href="#dom-fakexrinputcontroller-cleargriporigin">#dom-fakexrinputcontroller-cleargriporigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-cleargriporigin" class="dfn-panel" data-for="dom-fakexrinputcontroller-cleargriporigin" id="infopanel-for-dom-fakexrinputcontroller-cleargriporigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-cleargriporigin" style="display:none">Info about the 'clearGripOrigin()' definition.</span><b><a href="#dom-fakexrinputcontroller-cleargriporigin">#dom-fakexrinputcontroller-cleargriporigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-cleargriporigin">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-setpointerorigin">
-   <b><a href="#dom-fakexrinputcontroller-setpointerorigin">#dom-fakexrinputcontroller-setpointerorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-setpointerorigin" class="dfn-panel" data-for="dom-fakexrinputcontroller-setpointerorigin" id="infopanel-for-dom-fakexrinputcontroller-setpointerorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-setpointerorigin" style="display:none">Info about the 'setPointerOrigin(pointerOrigin)' definition.</span><b><a href="#dom-fakexrinputcontroller-setpointerorigin">#dom-fakexrinputcontroller-setpointerorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-setpointerorigin">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-disconnect">
-   <b><a href="#dom-fakexrinputcontroller-disconnect">#dom-fakexrinputcontroller-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-disconnect" class="dfn-panel" data-for="dom-fakexrinputcontroller-disconnect" id="infopanel-for-dom-fakexrinputcontroller-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-fakexrinputcontroller-disconnect">#dom-fakexrinputcontroller-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-disconnect">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-reconnect">
-   <b><a href="#dom-fakexrinputcontroller-reconnect">#dom-fakexrinputcontroller-reconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-reconnect" class="dfn-panel" data-for="dom-fakexrinputcontroller-reconnect" id="infopanel-for-dom-fakexrinputcontroller-reconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-reconnect" style="display:none">Info about the 'reconnect()' definition.</span><b><a href="#dom-fakexrinputcontroller-reconnect">#dom-fakexrinputcontroller-reconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-reconnect">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-startselection">
-   <b><a href="#dom-fakexrinputcontroller-startselection">#dom-fakexrinputcontroller-startselection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-startselection" class="dfn-panel" data-for="dom-fakexrinputcontroller-startselection" id="infopanel-for-dom-fakexrinputcontroller-startselection" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-startselection" style="display:none">Info about the 'startSelection()' definition.</span><b><a href="#dom-fakexrinputcontroller-startselection">#dom-fakexrinputcontroller-startselection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-startselection">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-endselection">
-   <b><a href="#dom-fakexrinputcontroller-endselection">#dom-fakexrinputcontroller-endselection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-endselection" class="dfn-panel" data-for="dom-fakexrinputcontroller-endselection" id="infopanel-for-dom-fakexrinputcontroller-endselection" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-endselection" style="display:none">Info about the 'endSelection()' definition.</span><b><a href="#dom-fakexrinputcontroller-endselection">#dom-fakexrinputcontroller-endselection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-endselection">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-simulateselect">
-   <b><a href="#dom-fakexrinputcontroller-simulateselect">#dom-fakexrinputcontroller-simulateselect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-simulateselect" class="dfn-panel" data-for="dom-fakexrinputcontroller-simulateselect" id="infopanel-for-dom-fakexrinputcontroller-simulateselect" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-simulateselect" style="display:none">Info about the 'simulateSelect()' definition.</span><b><a href="#dom-fakexrinputcontroller-simulateselect">#dom-fakexrinputcontroller-simulateselect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-simulateselect">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-setsupportedbuttons">
-   <b><a href="#dom-fakexrinputcontroller-setsupportedbuttons">#dom-fakexrinputcontroller-setsupportedbuttons</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-setsupportedbuttons" class="dfn-panel" data-for="dom-fakexrinputcontroller-setsupportedbuttons" id="infopanel-for-dom-fakexrinputcontroller-setsupportedbuttons" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-setsupportedbuttons" style="display:none">Info about the 'setSupportedButtons(supportedButtons)' definition.</span><b><a href="#dom-fakexrinputcontroller-setsupportedbuttons">#dom-fakexrinputcontroller-setsupportedbuttons</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-setsupportedbuttons">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-updatebuttonstate">
-   <b><a href="#dom-fakexrinputcontroller-updatebuttonstate">#dom-fakexrinputcontroller-updatebuttonstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-updatebuttonstate" class="dfn-panel" data-for="dom-fakexrinputcontroller-updatebuttonstate" id="infopanel-for-dom-fakexrinputcontroller-updatebuttonstate" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-updatebuttonstate" style="display:none">Info about the 'updateButtonState(buttonState)' definition.</span><b><a href="#dom-fakexrinputcontroller-updatebuttonstate">#dom-fakexrinputcontroller-updatebuttonstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-updatebuttonstate">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-a-button-state">
-   <b><a href="#validate-a-button-state">#validate-a-button-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-a-button-state" class="dfn-panel" data-for="validate-a-button-state" id="infopanel-for-validate-a-button-state" role="dialog">
+   <span id="infopaneltitle-for-validate-a-button-state" style="display:none">Info about the 'validate a button state' definition.</span><b><a href="#validate-a-button-state">#validate-a-button-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-a-button-state">5.2. FakeXRInputController</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrworldinit">
-   <b><a href="#dictdef-fakexrworldinit">#dictdef-fakexrworldinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrworldinit" class="dfn-panel" data-for="dictdef-fakexrworldinit" id="infopanel-for-dictdef-fakexrworldinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrworldinit" style="display:none">Info about the 'FakeXRWorldInit' definition.</span><b><a href="#dictdef-fakexrworldinit">#dictdef-fakexrworldinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrworldinit">4.3. FakeXRDeviceInit</a>
     <li><a href="#ref-for-dictdef-fakexrworldinit①">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-dictdef-fakexrworldinit②">6. Hit test extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrworldinit-hittestregions">
-   <b><a href="#dom-fakexrworldinit-hittestregions">#dom-fakexrworldinit-hittestregions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrworldinit-hittestregions" class="dfn-panel" data-for="dom-fakexrworldinit-hittestregions" id="infopanel-for-dom-fakexrworldinit-hittestregions" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrworldinit-hittestregions" style="display:none">Info about the 'hitTestRegions' definition.</span><b><a href="#dom-fakexrworldinit-hittestregions">#dom-fakexrworldinit-hittestregions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrworldinit-hittestregions">6. Hit test extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrregioninit">
-   <b><a href="#dictdef-fakexrregioninit">#dictdef-fakexrregioninit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrregioninit" class="dfn-panel" data-for="dictdef-fakexrregioninit" id="infopanel-for-dictdef-fakexrregioninit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrregioninit" style="display:none">Info about the 'FakeXRRegionInit' definition.</span><b><a href="#dictdef-fakexrregioninit">#dictdef-fakexrregioninit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrregioninit">6. Hit test extensions</a> <a href="#ref-for-dictdef-fakexrregioninit①">(2)</a> <a href="#ref-for-dictdef-fakexrregioninit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrregioninit-faces">
-   <b><a href="#dom-fakexrregioninit-faces">#dom-fakexrregioninit-faces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrregioninit-faces" class="dfn-panel" data-for="dom-fakexrregioninit-faces" id="infopanel-for-dom-fakexrregioninit-faces" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrregioninit-faces" style="display:none">Info about the 'faces' definition.</span><b><a href="#dom-fakexrregioninit-faces">#dom-fakexrregioninit-faces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrregioninit-faces">6. Hit test extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrregioninit-type">
-   <b><a href="#dom-fakexrregioninit-type">#dom-fakexrregioninit-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrregioninit-type" class="dfn-panel" data-for="dom-fakexrregioninit-type" id="infopanel-for-dom-fakexrregioninit-type" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrregioninit-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-fakexrregioninit-type">#dom-fakexrregioninit-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrregioninit-type">6. Hit test extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrtriangleinit">
-   <b><a href="#dictdef-fakexrtriangleinit">#dictdef-fakexrtriangleinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrtriangleinit" class="dfn-panel" data-for="dictdef-fakexrtriangleinit" id="infopanel-for-dictdef-fakexrtriangleinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrtriangleinit" style="display:none">Info about the 'FakeXRTriangleInit' definition.</span><b><a href="#dictdef-fakexrtriangleinit">#dictdef-fakexrtriangleinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrtriangleinit">6. Hit test extensions</a> <a href="#ref-for-dictdef-fakexrtriangleinit①">(2)</a> <a href="#ref-for-dictdef-fakexrtriangleinit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrtriangleinit-vertices">
-   <b><a href="#dom-fakexrtriangleinit-vertices">#dom-fakexrtriangleinit-vertices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrtriangleinit-vertices" class="dfn-panel" data-for="dom-fakexrtriangleinit-vertices" id="infopanel-for-dom-fakexrtriangleinit-vertices" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrtriangleinit-vertices" style="display:none">Info about the 'vertices' definition.</span><b><a href="#dom-fakexrtriangleinit-vertices">#dom-fakexrtriangleinit-vertices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrtriangleinit-vertices">6. Hit test extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fakexrregiontype">
-   <b><a href="#enumdef-fakexrregiontype">#enumdef-fakexrregiontype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fakexrregiontype" class="dfn-panel" data-for="enumdef-fakexrregiontype" id="infopanel-for-enumdef-fakexrregiontype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fakexrregiontype" style="display:none">Info about the 'FakeXRRegionType' definition.</span><b><a href="#enumdef-fakexrregiontype">#enumdef-fakexrregiontype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fakexrregiontype">6. Hit test extensions</a> <a href="#ref-for-enumdef-fakexrregiontype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrinputcontroller-setoverlaypointerposition">
-   <b><a href="#dom-fakexrinputcontroller-setoverlaypointerposition">#dom-fakexrinputcontroller-setoverlaypointerposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrinputcontroller-setoverlaypointerposition" class="dfn-panel" data-for="dom-fakexrinputcontroller-setoverlaypointerposition" id="infopanel-for-dom-fakexrinputcontroller-setoverlaypointerposition" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrinputcontroller-setoverlaypointerposition" style="display:none">Info about the 'setOverlayPointerPosition(x, y)' definition.</span><b><a href="#dom-fakexrinputcontroller-setoverlaypointerposition">#dom-fakexrinputcontroller-setoverlaypointerposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrinputcontroller-setoverlaypointerposition">7. DOM overlay extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexranchorcreationparameters">
-   <b><a href="#dictdef-fakexranchorcreationparameters">#dictdef-fakexranchorcreationparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexranchorcreationparameters" class="dfn-panel" data-for="dictdef-fakexranchorcreationparameters" id="infopanel-for-dictdef-fakexranchorcreationparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexranchorcreationparameters" style="display:none">Info about the 'FakeXRAnchorCreationParameters' definition.</span><b><a href="#dictdef-fakexranchorcreationparameters">#dictdef-fakexranchorcreationparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexranchorcreationparameters">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcreationparameters-requestedanchororigin">
-   <b><a href="#dom-fakexranchorcreationparameters-requestedanchororigin">#dom-fakexranchorcreationparameters-requestedanchororigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcreationparameters-requestedanchororigin" class="dfn-panel" data-for="dom-fakexranchorcreationparameters-requestedanchororigin" id="infopanel-for-dom-fakexranchorcreationparameters-requestedanchororigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcreationparameters-requestedanchororigin" style="display:none">Info about the 'requestedAnchorOrigin' definition.</span><b><a href="#dom-fakexranchorcreationparameters-requestedanchororigin">#dom-fakexranchorcreationparameters-requestedanchororigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcreationparameters-requestedanchororigin">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcreationparameters-isattachedtoentity">
-   <b><a href="#dom-fakexranchorcreationparameters-isattachedtoentity">#dom-fakexranchorcreationparameters-isattachedtoentity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcreationparameters-isattachedtoentity" class="dfn-panel" data-for="dom-fakexranchorcreationparameters-isattachedtoentity" id="infopanel-for-dom-fakexranchorcreationparameters-isattachedtoentity" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcreationparameters-isattachedtoentity" style="display:none">Info about the 'isAttachedToEntity' definition.</span><b><a href="#dom-fakexranchorcreationparameters-isattachedtoentity">#dom-fakexranchorcreationparameters-isattachedtoentity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcreationparameters-isattachedtoentity">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-fakexranchorcreationcallback">
-   <b><a href="#callbackdef-fakexranchorcreationcallback">#callbackdef-fakexranchorcreationcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-fakexranchorcreationcallback" class="dfn-panel" data-for="callbackdef-fakexranchorcreationcallback" id="infopanel-for-callbackdef-fakexranchorcreationcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-fakexranchorcreationcallback" style="display:none">Info about the 'FakeXRAnchorCreationCallback' definition.</span><b><a href="#callbackdef-fakexranchorcreationcallback">#callbackdef-fakexranchorcreationcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-fakexranchorcreationcallback">8. Anchors extensions</a> <a href="#ref-for-callbackdef-fakexranchorcreationcallback①">(2)</a> <a href="#ref-for-callbackdef-fakexranchorcreationcallback②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setanchorcreationcallback">
-   <b><a href="#dom-fakexrdevice-setanchorcreationcallback">#dom-fakexrdevice-setanchorcreationcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setanchorcreationcallback" class="dfn-panel" data-for="dom-fakexrdevice-setanchorcreationcallback" id="infopanel-for-dom-fakexrdevice-setanchorcreationcallback" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setanchorcreationcallback" style="display:none">Info about the 'setAnchorCreationCallback' definition.</span><b><a href="#dom-fakexrdevice-setanchorcreationcallback">#dom-fakexrdevice-setanchorcreationcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setanchorcreationcallback">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrdevice-anchorcreationcallback">
-   <b><a href="#fakexrdevice-anchorcreationcallback">#fakexrdevice-anchorcreationcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrdevice-anchorcreationcallback" class="dfn-panel" data-for="fakexrdevice-anchorcreationcallback" id="infopanel-for-fakexrdevice-anchorcreationcallback" role="dialog">
+   <span id="infopaneltitle-for-fakexrdevice-anchorcreationcallback" style="display:none">Info about the 'anchorCreationCallback' definition.</span><b><a href="#fakexrdevice-anchorcreationcallback">#fakexrdevice-anchorcreationcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrdevice-anchorcreationcallback">8. Anchors extensions</a> <a href="#ref-for-fakexrdevice-anchorcreationcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-if-the-anchor-creation-succeeded">
-   <b><a href="#determine-if-the-anchor-creation-succeeded">#determine-if-the-anchor-creation-succeeded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-if-the-anchor-creation-succeeded" class="dfn-panel" data-for="determine-if-the-anchor-creation-succeeded" id="infopanel-for-determine-if-the-anchor-creation-succeeded" role="dialog">
+   <span id="infopaneltitle-for-determine-if-the-anchor-creation-succeeded" style="display:none">Info about the 'determine if the anchor creation succeeded' definition.</span><b><a href="#determine-if-the-anchor-creation-succeeded">#determine-if-the-anchor-creation-succeeded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-if-the-anchor-creation-succeeded">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexranchorcreationcallback-anchorcontroller">
-   <b><a href="#fakexranchorcreationcallback-anchorcontroller">#fakexranchorcreationcallback-anchorcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexranchorcreationcallback-anchorcontroller" class="dfn-panel" data-for="fakexranchorcreationcallback-anchorcontroller" id="infopanel-for-fakexranchorcreationcallback-anchorcontroller" role="dialog">
+   <span id="infopaneltitle-for-fakexranchorcreationcallback-anchorcontroller" style="display:none">Info about the 'anchorController' definition.</span><b><a href="#fakexranchorcreationcallback-anchorcontroller">#fakexranchorcreationcallback-anchorcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexranchorcreationcallback-anchorcontroller">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexranchorcontroller">
-   <b><a href="#fakexranchorcontroller">#fakexranchorcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexranchorcontroller" class="dfn-panel" data-for="fakexranchorcontroller" id="infopanel-for-fakexranchorcontroller" role="dialog">
+   <span id="infopaneltitle-for-fakexranchorcontroller" style="display:none">Info about the 'FakeXRAnchorController' definition.</span><b><a href="#fakexranchorcontroller">#fakexranchorcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexranchorcontroller">8. Anchors extensions</a> <a href="#ref-for-fakexranchorcontroller①">(2)</a> <a href="#ref-for-fakexranchorcontroller②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcontroller-deleted">
-   <b><a href="#dom-fakexranchorcontroller-deleted">#dom-fakexranchorcontroller-deleted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcontroller-deleted" class="dfn-panel" data-for="dom-fakexranchorcontroller-deleted" id="infopanel-for-dom-fakexranchorcontroller-deleted" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcontroller-deleted" style="display:none">Info about the 'deleted' definition.</span><b><a href="#dom-fakexranchorcontroller-deleted">#dom-fakexranchorcontroller-deleted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcontroller-deleted">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcontroller-pausetracking">
-   <b><a href="#dom-fakexranchorcontroller-pausetracking">#dom-fakexranchorcontroller-pausetracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcontroller-pausetracking" class="dfn-panel" data-for="dom-fakexranchorcontroller-pausetracking" id="infopanel-for-dom-fakexranchorcontroller-pausetracking" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcontroller-pausetracking" style="display:none">Info about the 'pauseTracking' definition.</span><b><a href="#dom-fakexranchorcontroller-pausetracking">#dom-fakexranchorcontroller-pausetracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcontroller-pausetracking">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcontroller-resumetracking">
-   <b><a href="#dom-fakexranchorcontroller-resumetracking">#dom-fakexranchorcontroller-resumetracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcontroller-resumetracking" class="dfn-panel" data-for="dom-fakexranchorcontroller-resumetracking" id="infopanel-for-dom-fakexranchorcontroller-resumetracking" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcontroller-resumetracking" style="display:none">Info about the 'resumeTracking' definition.</span><b><a href="#dom-fakexranchorcontroller-resumetracking">#dom-fakexranchorcontroller-resumetracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcontroller-resumetracking">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcontroller-stoptracking">
-   <b><a href="#dom-fakexranchorcontroller-stoptracking">#dom-fakexranchorcontroller-stoptracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcontroller-stoptracking" class="dfn-panel" data-for="dom-fakexranchorcontroller-stoptracking" id="infopanel-for-dom-fakexranchorcontroller-stoptracking" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcontroller-stoptracking" style="display:none">Info about the 'stopTracking' definition.</span><b><a href="#dom-fakexranchorcontroller-stoptracking">#dom-fakexranchorcontroller-stoptracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcontroller-stoptracking">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexranchorcontroller-setanchororigin">
-   <b><a href="#dom-fakexranchorcontroller-setanchororigin">#dom-fakexranchorcontroller-setanchororigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexranchorcontroller-setanchororigin" class="dfn-panel" data-for="dom-fakexranchorcontroller-setanchororigin" id="infopanel-for-dom-fakexranchorcontroller-setanchororigin" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexranchorcontroller-setanchororigin" style="display:none">Info about the 'setAnchorOrigin' definition.</span><b><a href="#dom-fakexranchorcontroller-setanchororigin">#dom-fakexranchorcontroller-setanchororigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexranchorcontroller-setanchororigin">8. Anchors extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexranchorcontroller-anchor-origin">
-   <b><a href="#fakexranchorcontroller-anchor-origin">#fakexranchorcontroller-anchor-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexranchorcontroller-anchor-origin" class="dfn-panel" data-for="fakexranchorcontroller-anchor-origin" id="infopanel-for-fakexranchorcontroller-anchor-origin" role="dialog">
+   <span id="infopaneltitle-for-fakexranchorcontroller-anchor-origin" style="display:none">Info about the 'anchor origin' definition.</span><b><a href="#fakexranchorcontroller-anchor-origin">#fakexranchorcontroller-anchor-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexranchorcontroller-anchor-origin">8. Anchors extensions</a> <a href="#ref-for-fakexranchorcontroller-anchor-origin①">(2)</a> <a href="#ref-for-fakexranchorcontroller-anchor-origin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrlightestimateinit">
-   <b><a href="#dictdef-fakexrlightestimateinit">#dictdef-fakexrlightestimateinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrlightestimateinit" class="dfn-panel" data-for="dictdef-fakexrlightestimateinit" id="infopanel-for-dictdef-fakexrlightestimateinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrlightestimateinit" style="display:none">Info about the 'FakeXRLightEstimateInit' definition.</span><b><a href="#dictdef-fakexrlightestimateinit">#dictdef-fakexrlightestimateinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrlightestimateinit">9. Lighting estimation extensions</a> <a href="#ref-for-dictdef-fakexrlightestimateinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrlightestimateinit-sphericalharmonicscoefficients">
-   <b><a href="#dom-fakexrlightestimateinit-sphericalharmonicscoefficients">#dom-fakexrlightestimateinit-sphericalharmonicscoefficients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrlightestimateinit-sphericalharmonicscoefficients" class="dfn-panel" data-for="dom-fakexrlightestimateinit-sphericalharmonicscoefficients" id="infopanel-for-dom-fakexrlightestimateinit-sphericalharmonicscoefficients" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrlightestimateinit-sphericalharmonicscoefficients" style="display:none">Info about the 'sphericalHarmonicsCoefficients' definition.</span><b><a href="#dom-fakexrlightestimateinit-sphericalharmonicscoefficients">#dom-fakexrlightestimateinit-sphericalharmonicscoefficients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrlightestimateinit-sphericalharmonicscoefficients">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrlightestimateinit-primarylightdirection">
-   <b><a href="#dom-fakexrlightestimateinit-primarylightdirection">#dom-fakexrlightestimateinit-primarylightdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrlightestimateinit-primarylightdirection" class="dfn-panel" data-for="dom-fakexrlightestimateinit-primarylightdirection" id="infopanel-for-dom-fakexrlightestimateinit-primarylightdirection" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrlightestimateinit-primarylightdirection" style="display:none">Info about the 'primaryLightDirection' definition.</span><b><a href="#dom-fakexrlightestimateinit-primarylightdirection">#dom-fakexrlightestimateinit-primarylightdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrlightestimateinit-primarylightdirection">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrlightestimateinit-primarylightintensity">
-   <b><a href="#dom-fakexrlightestimateinit-primarylightintensity">#dom-fakexrlightestimateinit-primarylightintensity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrlightestimateinit-primarylightintensity" class="dfn-panel" data-for="dom-fakexrlightestimateinit-primarylightintensity" id="infopanel-for-dom-fakexrlightestimateinit-primarylightintensity" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrlightestimateinit-primarylightintensity" style="display:none">Info about the 'primaryLightIntensity' definition.</span><b><a href="#dom-fakexrlightestimateinit-primarylightintensity">#dom-fakexrlightestimateinit-primarylightintensity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrlightestimateinit-primarylightintensity">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrdevice-light-estimate">
-   <b><a href="#fakexrdevice-light-estimate">#fakexrdevice-light-estimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrdevice-light-estimate" class="dfn-panel" data-for="fakexrdevice-light-estimate" id="infopanel-for-fakexrdevice-light-estimate" role="dialog">
+   <span id="infopaneltitle-for-fakexrdevice-light-estimate" style="display:none">Info about the 'light estimate' definition.</span><b><a href="#fakexrdevice-light-estimate">#fakexrdevice-light-estimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrdevice-light-estimate">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdevice-setlightestimate">
-   <b><a href="#dom-fakexrdevice-setlightestimate">#dom-fakexrdevice-setlightestimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdevice-setlightestimate" class="dfn-panel" data-for="dom-fakexrdevice-setlightestimate" id="infopanel-for-dom-fakexrdevice-setlightestimate" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdevice-setlightestimate" style="display:none">Info about the 'setLightEstimate(init)' definition.</span><b><a href="#dom-fakexrdevice-setlightestimate">#dom-fakexrdevice-setlightestimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdevice-setlightestimate">9. Lighting estimation extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fakexrdevice-depth-sensing-data">
-   <b><a href="#fakexrdevice-depth-sensing-data">#fakexrdevice-depth-sensing-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fakexrdevice-depth-sensing-data" class="dfn-panel" data-for="fakexrdevice-depth-sensing-data" id="infopanel-for-fakexrdevice-depth-sensing-data" role="dialog">
+   <span id="infopaneltitle-for-fakexrdevice-depth-sensing-data" style="display:none">Info about the 'depth sensing data' definition.</span><b><a href="#fakexrdevice-depth-sensing-data">#fakexrdevice-depth-sensing-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fakexrdevice-depth-sensing-data">10. Depth sensing extensions</a> <a href="#ref-for-fakexrdevice-depth-sensing-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fakexrdepthsensingdatainit">
-   <b><a href="#dictdef-fakexrdepthsensingdatainit">#dictdef-fakexrdepthsensingdatainit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fakexrdepthsensingdatainit" class="dfn-panel" data-for="dictdef-fakexrdepthsensingdatainit" id="infopanel-for-dictdef-fakexrdepthsensingdatainit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fakexrdepthsensingdatainit" style="display:none">Info about the 'FakeXRDepthSensingDataInit' definition.</span><b><a href="#dictdef-fakexrdepthsensingdatainit">#dictdef-fakexrdepthsensingdatainit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fakexrdepthsensingdatainit">4.3. FakeXRDeviceInit</a>
     <li><a href="#ref-for-dictdef-fakexrdepthsensingdatainit①">5.1. FakeXRDevice</a>
     <li><a href="#ref-for-dictdef-fakexrdepthsensingdatainit②">10. Depth sensing extensions</a> <a href="#ref-for-dictdef-fakexrdepthsensingdatainit③">(2)</a> <a href="#ref-for-dictdef-fakexrdepthsensingdatainit④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-depthdata">
-   <b><a href="#dom-fakexrdepthsensingdatainit-depthdata">#dom-fakexrdepthsensingdatainit-depthdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdepthsensingdatainit-depthdata" class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-depthdata" id="infopanel-for-dom-fakexrdepthsensingdatainit-depthdata" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdepthsensingdatainit-depthdata" style="display:none">Info about the 'depthData' definition.</span><b><a href="#dom-fakexrdepthsensingdatainit-depthdata">#dom-fakexrdepthsensingdatainit-depthdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdepthsensingdatainit-depthdata">10. Depth sensing extensions</a> <a href="#ref-for-dom-fakexrdepthsensingdatainit-depthdata①">(2)</a> <a href="#ref-for-dom-fakexrdepthsensingdatainit-depthdata②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview">
-   <b><a href="#dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview">#dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview" class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview" id="infopanel-for-dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview" style="display:none">Info about the 'normDepthBufferFromNormView' definition.</span><b><a href="#dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview">#dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdepthsensingdatainit-normdepthbufferfromnormview">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-rawvaluetometers">
-   <b><a href="#dom-fakexrdepthsensingdatainit-rawvaluetometers">#dom-fakexrdepthsensingdatainit-rawvaluetometers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdepthsensingdatainit-rawvaluetometers" class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-rawvaluetometers" id="infopanel-for-dom-fakexrdepthsensingdatainit-rawvaluetometers" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdepthsensingdatainit-rawvaluetometers" style="display:none">Info about the 'rawValueToMeters' definition.</span><b><a href="#dom-fakexrdepthsensingdatainit-rawvaluetometers">#dom-fakexrdepthsensingdatainit-rawvaluetometers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdepthsensingdatainit-rawvaluetometers">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-width">
-   <b><a href="#dom-fakexrdepthsensingdatainit-width">#dom-fakexrdepthsensingdatainit-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdepthsensingdatainit-width" class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-width" id="infopanel-for-dom-fakexrdepthsensingdatainit-width" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdepthsensingdatainit-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-fakexrdepthsensingdatainit-width">#dom-fakexrdepthsensingdatainit-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdepthsensingdatainit-width">10. Depth sensing extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-height">
-   <b><a href="#dom-fakexrdepthsensingdatainit-height">#dom-fakexrdepthsensingdatainit-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fakexrdepthsensingdatainit-height" class="dfn-panel" data-for="dom-fakexrdepthsensingdatainit-height" id="infopanel-for-dom-fakexrdepthsensingdatainit-height" role="dialog">
+   <span id="infopaneltitle-for-dom-fakexrdepthsensingdatainit-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-fakexrdepthsensingdatainit-height">#dom-fakexrdepthsensingdatainit-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fakexrdepthsensingdatainit-height">10. Depth sensing extensions</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/immersive-web/webxr/index.html
+++ b/tests/github/immersive-web/webxr/index.html
@@ -5991,14 +5991,14 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
    <li><a href="#typedefdef-xrwebglrenderingcontext">XRWebGLRenderingContext</a><span>, in § 11.2</span>
    <li><a href="#dom-xrviewport-y">y</a><span>, in § 7.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">12.1. XRSessionEvent</a>
     <li><a href="#ref-for-event①">12.2. XRInputSourceEvent</a>
@@ -6007,8 +6007,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-event④">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">12.1. XRSessionEvent</a>
     <li><a href="#ref-for-dictdef-eventinit①">12.2. XRInputSourceEvent</a>
@@ -6016,8 +6016,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dictdef-eventinit③">12.4. XRReferenceSpaceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.2. XRSystem</a>
     <li><a href="#ref-for-eventtarget①">4.1. XRSession</a>
@@ -6025,83 +6025,83 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-eventtarget③">11.1. XRLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-ancestor">https://dom.spec.whatwg.org/#concept-tree-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-ancestor" class="dfn-panel" data-for="term-for-concept-tree-ancestor" id="infopanel-for-term-for-concept-tree-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-ancestor" style="display:none">Info about the 'ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-ancestor">https://dom.spec.whatwg.org/#concept-tree-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-ancestor">13.2. User intention</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">13.2. User intention</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands">
-   <a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands" class="dfn-panel" data-for="term-for-sec-returnifabrupt-shorthands" id="infopanel-for-term-for-sec-returnifabrupt-shorthands" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-returnifabrupt-shorthands" style="display:none">Info about the '?' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands">https://tc39.github.io/ecma262/#sec-returnifabrupt-shorthands</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-returnifabrupt-shorthands">14.2. Permissions API Integration</a> <a href="#ref-for-sec-returnifabrupt-shorthands①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isdetachedbuffer">
-   <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isdetachedbuffer" class="dfn-panel" data-for="term-for-sec-isdetachedbuffer" id="infopanel-for-term-for-sec-isdetachedbuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isdetachedbuffer" style="display:none">Info about the 'IsDetachedBuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer">https://tc39.github.io/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isdetachedbuffer">7.1. XRView</a>
     <li><a href="#ref-for-sec-isdetachedbuffer①">8.3. XRRigidTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'ToString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-sec-tostring①">14.2. Permissions API Integration</a> <a href="#ref-for-sec-tostring②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">8.3. XRRigidTransform</a>
     <li><a href="#ref-for-realm①">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrix">
-   <a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrix" class="dfn-panel" data-for="term-for-dommatrix" id="infopanel-for-term-for-dommatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrix" style="display:none">Info about the 'DOMMatrix' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrix">8.1. Matrices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-dompointinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-dompointinit" class="dfn-panel" data-for="term-for-dictdef-dompointinit" id="infopanel-for-term-for-dictdef-dompointinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">8.3. XRRigidTransform</a> <a href="#ref-for-dictdef-dompointinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompointreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompointreadonly" class="dfn-panel" data-for="term-for-dompointreadonly" id="infopanel-for-term-for-dompointreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompointreadonly">https://drafts.fxtf.org/geometry-1/#dompointreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-dompointreadonly①">(2)</a> <a href="#ref-for-dompointreadonly②">(3)</a>
     <li><a href="#ref-for-dompointreadonly③">8.1. Matrices</a>
@@ -6109,85 +6109,85 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dompointreadonly①⓪">9.1. XRPose</a> <a href="#ref-for-dompointreadonly①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-w">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-w" class="dfn-panel" data-for="term-for-dom-dompointreadonly-w" id="infopanel-for-term-for-dom-dompointreadonly-w" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-w" style="display:none">Info about the 'w' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-w</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-w">6.3. XRBoundedReferenceSpace</a>
     <li><a href="#ref-for-dom-dompointreadonly-w①">8.3. XRRigidTransform</a> <a href="#ref-for-dom-dompointreadonly-w②">(2)</a> <a href="#ref-for-dom-dompointreadonly-w③">(3)</a> <a href="#ref-for-dom-dompointreadonly-w④">(4)</a> <a href="#ref-for-dom-dompointreadonly-w⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-x" class="dfn-panel" data-for="term-for-dom-dompointreadonly-x" id="infopanel-for-term-for-dom-dompointreadonly-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-x" style="display:none">Info about the 'x' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-x">8.3. XRRigidTransform</a> <a href="#ref-for-dom-dompointreadonly-x①">(2)</a> <a href="#ref-for-dom-dompointreadonly-x②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-y" class="dfn-panel" data-for="term-for-dom-dompointreadonly-y" id="infopanel-for-term-for-dom-dompointreadonly-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-y" style="display:none">Info about the 'y' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-y">6.3. XRBoundedReferenceSpace</a>
     <li><a href="#ref-for-dom-dompointreadonly-y①">8.3. XRRigidTransform</a> <a href="#ref-for-dom-dompointreadonly-y②">(2)</a> <a href="#ref-for-dom-dompointreadonly-y③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dompointreadonly-z">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dompointreadonly-z" class="dfn-panel" data-for="term-for-dom-dompointreadonly-z" id="infopanel-for-term-for-dom-dompointreadonly-z" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dompointreadonly-z" style="display:none">Info about the 'z' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z">https://drafts.fxtf.org/geometry-1/#dom-dompointreadonly-z</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-z">8.3. XRRigidTransform</a> <a href="#ref-for-dom-dompointreadonly-z①">(2)</a> <a href="#ref-for-dom-dompointreadonly-z②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-high-resolution-time" class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time" id="infopanel-for-term-for-dfn-current-high-resolution-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-high-resolution-time" style="display:none">Info about the 'current high resolution time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-high-resolution-time">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.2. XRSystem</a>
     <li><a href="#ref-for-eventhandler①">4.1. XRSession</a> <a href="#ref-for-eventhandler②">(2)</a> <a href="#ref-for-eventhandler③">(3)</a> <a href="#ref-for-eventhandler④">(4)</a> <a href="#ref-for-eventhandler⑤">(5)</a> <a href="#ref-for-eventhandler⑥">(6)</a> <a href="#ref-for-eventhandler⑦">(7)</a> <a href="#ref-for-eventhandler⑧">(8)</a> <a href="#ref-for-eventhandler⑨">(9)</a>
     <li><a href="#ref-for-eventhandler①⓪">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlcanvaselement">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlcanvaselement" class="dfn-panel" data-for="term-for-htmlcanvaselement" id="infopanel-for-term-for-htmlcanvaselement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlcanvaselement" style="display:none">Info about the 'HTMLCanvasElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement">https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcanvaselement">4.2. XRRenderState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.1. navigator.xr</a>
     <li><a href="#ref-for-navigator①">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.3. Animation Frames</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a> <a href="#ref-for-window③">(4)</a> <a href="#ref-for-window④">(5)</a> <a href="#ref-for-window⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">13.2. User intention</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-appversion">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-appversion">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-appversion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-appversion" class="dfn-panel" data-for="term-for-dom-navigator-appversion" id="infopanel-for-term-for-dom-navigator-appversion" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-appversion" style="display:none">Info about the 'appVersion' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-appversion">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-appversion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-appversion">13.9.1. Considerations for when to automatically grant "xr-session-supported"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4.3. Animation Frames</a> <a href="#ref-for-browsing-context①">(2)</a>
     <li><a href="#ref-for-browsing-context②">13.2. User intention</a>
@@ -6195,34 +6195,34 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-browsing-context④">13.7. Context Isolation</a> <a href="#ref-for-browsing-context⑤">(2)</a> <a href="#ref-for-browsing-context⑥">(3)</a> <a href="#ref-for-browsing-context⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current">https://html.spec.whatwg.org/multipage/webappapis.html#current</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current" class="dfn-panel" data-for="term-for-current" id="infopanel-for-term-for-current" role="menu">
+   <span id="infopaneltitle-for-term-for-current" style="display:none">Info about the 'current realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current">https://html.spec.whatwg.org/multipage/webappapis.html#current</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current">8.3. XRRigidTransform</a> <a href="#ref-for-current①">(2)</a> <a href="#ref-for-current②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context" id="infopanel-for-term-for-currently-focused-area-of-a-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" style="display:none">Info about the 'currently focused area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context">13.6. Trusted Environment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.2. XRSystem</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">4.1. XRSession</a> <a href="#ref-for-event-handler-idl-attributes②">(2)</a> <a href="#ref-for-event-handler-idl-attributes③">(3)</a> <a href="#ref-for-event-handler-idl-attributes④">(4)</a> <a href="#ref-for-event-handler-idl-attributes⑤">(5)</a> <a href="#ref-for-event-handler-idl-attributes⑥">(6)</a> <a href="#ref-for-event-handler-idl-attributes⑦">(7)</a> <a href="#ref-for-event-handler-idl-attributes⑧">(8)</a> <a href="#ref-for-event-handler-idl-attributes⑨">(9)</a>
     <li><a href="#ref-for-event-handler-idl-attributes①⓪">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.1. XR device</a>
     <li><a href="#ref-for-in-parallel①">3.2. XRSystem</a> <a href="#ref-for-in-parallel②">(2)</a> <a href="#ref-for-in-parallel③">(3)</a> <a href="#ref-for-in-parallel④">(4)</a> <a href="#ref-for-in-parallel⑤">(5)</a>
@@ -6230,14 +6230,14 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-in-parallel⑦">11.3. WebGL Context Compatibility</a> <a href="#ref-for-in-parallel⑧">(2)</a> <a href="#ref-for-in-parallel⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator" class="dfn-panel" data-for="term-for-dom-navigator" id="infopanel-for-term-for-dom-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator" style="display:none">Info about the 'navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3.2. XRSystem</a>
     <li><a href="#ref-for-concept-origin①">11.3. WebGL Context Compatibility</a> <a href="#ref-for-concept-origin②">(2)</a>
@@ -6247,15 +6247,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-concept-origin⑥">14.2. Permissions API Integration</a> <a href="#ref-for-concept-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-permissions-policy">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-permissions-policy" class="dfn-panel" data-for="term-for-concept-document-permissions-policy" id="infopanel-for-term-for-concept-document-permissions-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-permissions-policy" style="display:none">Info about the 'permissions policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-permissions-policy">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-concept-document-permissions-policy①">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.2. XRSystem</a> <a href="#ref-for-queue-a-task①">(2)</a> <a href="#ref-for-queue-a-task②">(3)</a> <a href="#ref-for-queue-a-task③">(4)</a> <a href="#ref-for-queue-a-task④">(5)</a> <a href="#ref-for-queue-a-task⑤">(6)</a> <a href="#ref-for-queue-a-task⑥">(7)</a> <a href="#ref-for-queue-a-task⑦">(8)</a>
     <li><a href="#ref-for-queue-a-task⑧">4.1. XRSession</a> <a href="#ref-for-queue-a-task⑨">(2)</a> <a href="#ref-for-queue-a-task①⓪">(3)</a> <a href="#ref-for-queue-a-task①①">(4)</a> <a href="#ref-for-queue-a-task①②">(5)</a> <a href="#ref-for-queue-a-task①③">(6)</a> <a href="#ref-for-queue-a-task①④">(7)</a> <a href="#ref-for-queue-a-task①⑤">(8)</a>
@@ -6266,15 +6266,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-queue-a-task③③">12. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.2. XRSystem</a>
     <li><a href="#ref-for-concept-relevant-global①">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.2. XRSystem</a> <a href="#ref-for-concept-relevant-realm①">(2)</a> <a href="#ref-for-concept-relevant-realm②">(3)</a>
     <li><a href="#ref-for-concept-relevant-realm③">4.1. XRSession</a> <a href="#ref-for-concept-relevant-realm④">(2)</a> <a href="#ref-for-concept-relevant-realm⑤">(3)</a> <a href="#ref-for-concept-relevant-realm⑥">(4)</a>
@@ -6289,50 +6289,50 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-concept-relevant-realm③②">13.7. Context Isolation</a> <a href="#ref-for-concept-relevant-realm③③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rendering-opportunity">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rendering-opportunity" class="dfn-panel" data-for="term-for-rendering-opportunity" id="infopanel-for-term-for-rendering-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-rendering-opportunity" style="display:none">Info about the 'rendering opportunity' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity">https://html.spec.whatwg.org/multipage/webappapis.html#rendering-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendering-opportunity">4.3. Animation Frames</a> <a href="#ref-for-rendering-opportunity①">(2)</a> <a href="#ref-for-rendering-opportunity②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe" id="infopanel-for-term-for-dom-animationframeprovider-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationframeprovider-requestanimationframe">4.3. Animation Frames</a> <a href="#ref-for-dom-animationframeprovider-requestanimationframe①">(2)</a> <a href="#ref-for-dom-animationframeprovider-requestanimationframe②">(3)</a> <a href="#ref-for-dom-animationframeprovider-requestanimationframe③">(4)</a> <a href="#ref-for-dom-animationframeprovider-requestanimationframe④">(5)</a> <a href="#ref-for-dom-animationframeprovider-requestanimationframe⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-document">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-document" class="dfn-panel" data-for="term-for-responsible-document" id="infopanel-for-term-for-responsible-document" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-document" style="display:none">Info about the 'responsible' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-document">13.5.1. Immersiveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">13.7. Context Isolation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain">https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">13.2. User intention</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">12. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">1.2. Application flow</a>
     <li><a href="#ref-for-transient-activation①">13.2. User intention</a>
@@ -6340,21 +6340,21 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-transient-activation③">13.5.1. Immersiveness</a> <a href="#ref-for-transient-activation④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-useragent">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-useragent" class="dfn-panel" data-for="term-for-dom-navigator-useragent" id="infopanel-for-term-for-dom-navigator-useragent" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-useragent" style="display:none">Info about the 'userAgent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-useragent">13.9.1. Considerations for when to automatically grant "xr-session-supported"</a> <a href="#ref-for-dom-navigator-useragent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.1. XRFrame</a>
     <li><a href="#ref-for-list-append①">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.1. XR device</a> <a href="#ref-for-list-contain①">(2)</a> <a href="#ref-for-list-contain②">(3)</a>
     <li><a href="#ref-for-list-contain③">3.2. XRSystem</a> <a href="#ref-for-list-contain④">(2)</a> <a href="#ref-for-list-contain⑤">(3)</a>
@@ -6362,26 +6362,26 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-list-contain⑦">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">14.2. Permissions API Integration</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-extend">
-   <a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-extend" class="dfn-panel" data-for="term-for-list-extend" id="infopanel-for-term-for-list-extend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-extend" style="display:none">Info about the 'extend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-extend">4.1. XRSession</a> <a href="#ref-for-list-extend①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">14.2. Permissions API Integration</a> <a href="#ref-for-list-is-empty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.1. XR device</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
     <li><a href="#ref-for-list③">3.2. XRSystem</a>
@@ -6396,388 +6396,388 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-list②③">14.2. Permissions API Integration</a> <a href="#ref-for-list②④">(2)</a> <a href="#ref-for-list②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.1. XRSession</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.1. XR device</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">3.2. XRSystem</a>
     <li><a href="#ref-for-ordered-set③">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.1. XR device</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">14.2. Permissions API Integration</a> <a href="#ref-for-tuple①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor">
-   <a href="https://w3c.github.io/orientation-sensor/#absoluteorientationsensor">https://w3c.github.io/orientation-sensor/#absoluteorientationsensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor" class="dfn-panel" data-for="term-for-absoluteorientationsensor" id="infopanel-for-term-for-absoluteorientationsensor" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor" style="display:none">Info about the 'AbsoluteOrientationSensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor/#absoluteorientationsensor">https://w3c.github.io/orientation-sensor/#absoluteorientationsensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relativeorientationsensor">
-   <a href="https://w3c.github.io/orientation-sensor/#relativeorientationsensor">https://w3c.github.io/orientation-sensor/#relativeorientationsensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relativeorientationsensor" class="dfn-panel" data-for="term-for-relativeorientationsensor" id="infopanel-for-term-for-relativeorientationsensor" role="menu">
+   <span id="infopaneltitle-for-term-for-relativeorientationsensor" style="display:none">Info about the 'RelativeOrientationSensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor/#relativeorientationsensor">https://w3c.github.io/orientation-sensor/#relativeorientationsensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relativeorientationsensor">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-visibilitystate-attribute">
-   <a href="https://www.w3.org/TR/page-visibility-2/#visibilitystate-attribute">https://www.w3.org/TR/page-visibility-2/#visibilitystate-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-visibilitystate-attribute" class="dfn-panel" data-for="term-for-visibilitystate-attribute" id="infopanel-for-term-for-visibilitystate-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-visibilitystate-attribute" style="display:none">Info about the 'visibilitystate' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#visibilitystate-attribute">https://www.w3.org/TR/page-visibility-2/#visibilitystate-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visibilitystate-attribute">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">13.9. Fingerprinting considerations of isSessionSupported()</a>
     <li><a href="#ref-for-dom-permissiondescriptor①">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus" class="dfn-panel" data-for="term-for-dom-permissionstatus" id="infopanel-for-term-for-dom-permissionstatus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus" style="display:none">Info about the 'PermissionStatus' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus">https://w3c.github.io/permissions/#dom-permissionstatus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-denied">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-denied">https://w3c.github.io/permissions/#dom-permissionstate-denied</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-denied" class="dfn-panel" data-for="term-for-dom-permissionstate-denied" id="infopanel-for-term-for-dom-permissionstate-denied" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-denied" style="display:none">Info about the 'denied' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-denied">https://w3c.github.io/permissions/#dom-permissionstate-denied</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-denied">3.2. XRSystem</a> <a href="#ref-for-dom-permissionstate-denied①">(2)</a>
     <li><a href="#ref-for-dom-permissionstate-denied②">14.2. Permissions API Integration</a> <a href="#ref-for-dom-permissionstate-denied③">(2)</a> <a href="#ref-for-dom-permissionstate-denied④">(3)</a> <a href="#ref-for-dom-permissionstate-denied⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">14.2. Permissions API Integration</a> <a href="#ref-for-dom-permissionstate-granted①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="term-for-dom-permissiondescriptor-name" id="infopanel-for-term-for-dom-permissiondescriptor-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor-name">https://w3c.github.io/permissions/#dom-permissiondescriptor-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">13.9. Fingerprinting considerations of isSessionSupported()</a>
     <li><a href="#ref-for-dom-permissiondescriptor-name①">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">13.9. Fingerprinting considerations of isSessionSupported()</a>
     <li><a href="#ref-for-dfn-permission-descriptor-type①">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-query-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-query-algorithm" id="infopanel-for-term-for-dfn-permission-query-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-query-algorithm" style="display:none">Info about the 'permission query algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-query-algorithm">https://w3c.github.io/permissions/#dfn-permission-query-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-query-algorithm">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-result-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-result-type" class="dfn-panel" data-for="term-for-dfn-permission-result-type" id="infopanel-for-term-for-dfn-permission-result-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-result-type" style="display:none">Info about the 'permission result type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-result-type">https://w3c.github.io/permissions/#dfn-permission-result-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-result-type">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-prompt">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-prompt" class="dfn-panel" data-for="term-for-dom-permissionstate-prompt" id="infopanel-for-term-for-dom-permissionstate-prompt" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-prompt" style="display:none">Info about the 'prompt' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-prompt">https://w3c.github.io/permissions/#dom-permissionstate-prompt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-prompt">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstatus-state">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstatus-state" class="dfn-panel" data-for="term-for-dom-permissionstatus-state" id="infopanel-for-term-for-dom-permissionstatus-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstatus-state" style="display:none">Info about the 'state' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstatus-state">https://w3c.github.io/permissions/#dom-permissionstatus-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-permissionstatus-state①">14.2. Permissions API Integration</a> <a href="#ref-for-dom-permissionstatus-state②">(2)</a> <a href="#ref-for-dom-permissionstatus-state③">(3)</a> <a href="#ref-for-dom-permissionstatus-state④">(4)</a> <a href="#ref-for-dom-permissionstatus-state⑤">(5)</a> <a href="#ref-for-dom-permissionstatus-state⑥">(6)</a> <a href="#ref-for-dom-permissionstatus-state⑦">(7)</a> <a href="#ref-for-dom-permissionstatus-state⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
-   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-request-algorithm" class="dfn-panel" data-for="term-for-permission-request-algorithm" id="infopanel-for-term-for-permission-request-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-request-algorithm" style="display:none">Info about the 'permission request algorithm' external reference.</span><a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-primary-pointer">
-   <a href="https://www.w3.org/TR/pointerevents/#dfn-primary-pointer">https://www.w3.org/TR/pointerevents/#dfn-primary-pointer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-primary-pointer" class="dfn-panel" data-for="term-for-dfn-primary-pointer" id="infopanel-for-term-for-dfn-primary-pointer" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-primary-pointer" style="display:none">Info about the 'primary pointer' external reference.</span><a href="https://www.w3.org/TR/pointerevents/#dfn-primary-pointer">https://www.w3.org/TR/pointerevents/#dfn-primary-pointer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-primary-pointer">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-requestidlecallback-method">
-   <a href="https://w3c.github.io/requestidlecallback/#the-requestidlecallback-method">https://w3c.github.io/requestidlecallback/#the-requestidlecallback-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-requestidlecallback-method" class="dfn-panel" data-for="term-for-the-requestidlecallback-method" id="infopanel-for-term-for-the-requestidlecallback-method" role="menu">
+   <span id="infopaneltitle-for-term-for-the-requestidlecallback-method" style="display:none">Info about the 'requestIdleCallback()' external reference.</span><a href="https://w3c.github.io/requestidlecallback/#the-requestidlecallback-method">https://w3c.github.io/requestidlecallback/#the-requestidlecallback-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-requestidlecallback-method">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-orientationlocktype-any">
-   <a href="https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any">https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-orientationlocktype-any" class="dfn-panel" data-for="term-for-dom-orientationlocktype-any" id="infopanel-for-term-for-dom-orientationlocktype-any" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-orientationlocktype-any" style="display:none">Info about the 'any' external reference.</span><a href="https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any">https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-orientationlocktype-any">3.4. Feature Dependencies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGL2RenderingContext">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext">https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGL2RenderingContext" class="dfn-panel" data-for="term-for-WebGL2RenderingContext" id="infopanel-for-term-for-WebGL2RenderingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGL2RenderingContext" style="display:none">Info about the 'WebGL2RenderingContext' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext">https://www.khronos.org/registry/webgl/specs/latest/2.0/#WebGL2RenderingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGL2RenderingContext">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGL2RenderingContext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContextBase">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContextBase" class="dfn-panel" data-for="term-for-WebGLRenderingContextBase" id="infopanel-for-term-for-WebGLRenderingContextBase" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContextBase" style="display:none">Info about the 'FRAMEBUFFER_UNSUPPORTED' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContextBase">3.2. XRSystem</a>
     <li><a href="#ref-for-WebGLRenderingContextBase①">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLRenderingContextBase②">(2)</a> <a href="#ref-for-WebGLRenderingContextBase③">(3)</a>
     <li><a href="#ref-for-WebGLRenderingContextBase④">11.3. WebGL Context Compatibility</a> <a href="#ref-for-WebGLRenderingContextBase⑤">(2)</a> <a href="#ref-for-WebGLRenderingContextBase⑥">(3)</a> <a href="#ref-for-WebGLRenderingContextBase⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContextBase">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContextBase" class="dfn-panel" data-for="term-for-WebGLRenderingContextBase" id="infopanel-for-term-for-WebGLRenderingContextBase①" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContextBase①" style="display:none">Info about the 'INVALID_FRAMEBUFFER_OPERATION' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContextBase">3.2. XRSystem</a>
     <li><a href="#ref-for-WebGLRenderingContextBase①">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLRenderingContextBase②">(2)</a> <a href="#ref-for-WebGLRenderingContextBase③">(3)</a>
     <li><a href="#ref-for-WebGLRenderingContextBase④">11.3. WebGL Context Compatibility</a> <a href="#ref-for-WebGLRenderingContextBase⑤">(2)</a> <a href="#ref-for-WebGLRenderingContextBase⑥">(3)</a> <a href="#ref-for-WebGLRenderingContextBase⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContextBase">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContextBase" class="dfn-panel" data-for="term-for-WebGLRenderingContextBase" id="infopanel-for-term-for-WebGLRenderingContextBase②" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContextBase②" style="display:none">Info about the 'INVALID_OPERATION' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContextBase">3.2. XRSystem</a>
     <li><a href="#ref-for-WebGLRenderingContextBase①">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLRenderingContextBase②">(2)</a> <a href="#ref-for-WebGLRenderingContextBase③">(3)</a>
     <li><a href="#ref-for-WebGLRenderingContextBase④">11.3. WebGL Context Compatibility</a> <a href="#ref-for-WebGLRenderingContextBase⑤">(2)</a> <a href="#ref-for-WebGLRenderingContextBase⑥">(3)</a> <a href="#ref-for-WebGLRenderingContextBase⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLContextAttributes">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLContextAttributes">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLContextAttributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLContextAttributes" class="dfn-panel" data-for="term-for-WebGLContextAttributes" id="infopanel-for-term-for-WebGLContextAttributes" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLContextAttributes" style="display:none">Info about the 'WebGLContextAttributes' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLContextAttributes">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLContextAttributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLContextAttributes">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLContextAttributes①">(2)</a> <a href="#ref-for-WebGLContextAttributes②">(3)</a>
     <li><a href="#ref-for-WebGLContextAttributes③">11.3. WebGL Context Compatibility</a> <a href="#ref-for-WebGLContextAttributes④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLFramebuffer">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLFramebuffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLFramebuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLFramebuffer" class="dfn-panel" data-for="term-for-WebGLFramebuffer" id="infopanel-for-term-for-WebGLFramebuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLFramebuffer" style="display:none">Info about the 'WebGLFramebuffer' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLFramebuffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLFramebuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLFramebuffer">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLFramebuffer①">(2)</a> <a href="#ref-for-WebGLFramebuffer②">(3)</a> <a href="#ref-for-WebGLFramebuffer③">(4)</a> <a href="#ref-for-WebGLFramebuffer④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLObject">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLObject">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLObject" class="dfn-panel" data-for="term-for-WebGLObject" id="infopanel-for-term-for-WebGLObject" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLObject" style="display:none">Info about the 'WebGLObject' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLObject">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLObject">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContext">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContext" class="dfn-panel" data-for="term-for-WebGLRenderingContext" id="infopanel-for-term-for-WebGLRenderingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContext" style="display:none">Info about the 'WebGLRenderingContext' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContext">4.1. XRSession</a>
     <li><a href="#ref-for-WebGLRenderingContext①">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLRenderingContext②">(2)</a> <a href="#ref-for-WebGLRenderingContext③">(3)</a> <a href="#ref-for-WebGLRenderingContext④">(4)</a> <a href="#ref-for-WebGLRenderingContext⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-WebGLRenderingContextBase">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-WebGLRenderingContextBase" class="dfn-panel" data-for="term-for-WebGLRenderingContextBase" id="infopanel-for-term-for-WebGLRenderingContextBase③" role="menu">
+   <span id="infopaneltitle-for-term-for-WebGLRenderingContextBase③" style="display:none">Info about the 'WebGLRenderingContextBase' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase">https://www.khronos.org/registry/webgl/specs/latest/1.0/#WebGLRenderingContextBase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WebGLRenderingContextBase">3.2. XRSystem</a>
     <li><a href="#ref-for-WebGLRenderingContextBase①">11.2. XRWebGLLayer</a> <a href="#ref-for-WebGLRenderingContextBase②">(2)</a> <a href="#ref-for-WebGLRenderingContextBase③">(3)</a>
     <li><a href="#ref-for-WebGLRenderingContextBase④">11.3. WebGL Context Compatibility</a> <a href="#ref-for-WebGLRenderingContextBase⑤">(2)</a> <a href="#ref-for-WebGLRenderingContextBase⑥">(3)</a> <a href="#ref-for-WebGLRenderingContextBase⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-actual-context-parameters">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#actual-context-parameters">https://www.khronos.org/registry/webgl/specs/latest/1.0/#actual-context-parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-actual-context-parameters" class="dfn-panel" data-for="term-for-actual-context-parameters" id="infopanel-for-term-for-actual-context-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-actual-context-parameters" style="display:none">Info about the 'actual context parameters' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#actual-context-parameters">https://www.khronos.org/registry/webgl/specs/latest/1.0/#actual-context-parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-context-parameters">11.2. XRWebGLLayer</a> <a href="#ref-for-actual-context-parameters①">(2)</a> <a href="#ref-for-actual-context-parameters②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-context-canvas">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-canvas">https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-context-canvas" class="dfn-panel" data-for="term-for-context-canvas" id="infopanel-for-term-for-context-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-context-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-canvas">https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-context-canvas">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.6" class="dfn-panel" data-for="term-for-5.14.6" id="infopanel-for-term-for-5.14.6" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.6" style="display:none">Info about the 'checkFramebufferStatus' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.6">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.6①">(2)</a> <a href="#ref-for-5.14.6②">(3)</a> <a href="#ref-for-5.14.6③">(4)</a> <a href="#ref-for-5.14.6④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11" style="display:none">Info about the 'clear' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-drawing-buffer">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#create-a-drawing-buffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#create-a-drawing-buffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-drawing-buffer" class="dfn-panel" data-for="term-for-create-a-drawing-buffer" id="infopanel-for-term-for-create-a-drawing-buffer" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-drawing-buffer" style="display:none">Info about the 'create a drawing buffer' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#create-a-drawing-buffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#create-a-drawing-buffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-drawing-buffer">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-2.1">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-2.1" class="dfn-panel" data-for="term-for-2.1" id="infopanel-for-term-for-2.1" role="menu">
+   <span id="infopaneltitle-for-term-for-2.1" style="display:none">Info about the 'create the webgl context' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-2.1">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-2.2">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2">https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-2.2" class="dfn-panel" data-for="term-for-2.2" id="infopanel-for-term-for-2.2" role="menu">
+   <span id="infopaneltitle-for-term-for-2.2" style="display:none">Info about the 'default framebuffer' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2">https://www.khronos.org/registry/webgl/specs/latest/1.0/#2.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-2.2">11.2. XRWebGLLayer</a> <a href="#ref-for-2.2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.6" class="dfn-panel" data-for="term-for-5.14.6" id="infopanel-for-term-for-5.14.6①" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.6①" style="display:none">Info about the 'deleteFramebuffer' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.6">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.6①">(2)</a> <a href="#ref-for-5.14.6②">(3)</a> <a href="#ref-for-5.14.6③">(4)</a> <a href="#ref-for-5.14.6④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11①" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11①" style="display:none">Info about the 'drawArrays' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.11">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.11" class="dfn-panel" data-for="term-for-5.14.11" id="infopanel-for-term-for-5.14.11②" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.11②" style="display:none">Info about the 'drawElements' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.11">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.11①">(2)</a> <a href="#ref-for-5.14.11②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-a-webgl-context-event">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event">https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-a-webgl-context-event" class="dfn-panel" data-for="term-for-fire-a-webgl-context-event" id="infopanel-for-term-for-fire-a-webgl-context-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-a-webgl-context-event" style="display:none">Info about the 'fire a webgl context event' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event">https://www.khronos.org/registry/webgl/specs/latest/1.0/#fire-a-webgl-context-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-webgl-context-event">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.6" class="dfn-panel" data-for="term-for-5.14.6" id="infopanel-for-term-for-5.14.6②" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.6②" style="display:none">Info about the 'framebufferRenderbuffer' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.6">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.6①">(2)</a> <a href="#ref-for-5.14.6②">(3)</a> <a href="#ref-for-5.14.6③">(4)</a> <a href="#ref-for-5.14.6④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.6" class="dfn-panel" data-for="term-for-5.14.6" id="infopanel-for-term-for-5.14.6③" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.6③" style="display:none">Info about the 'framebufferTexture2D' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.6">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.6①">(2)</a> <a href="#ref-for-5.14.6②">(3)</a> <a href="#ref-for-5.14.6③">(4)</a> <a href="#ref-for-5.14.6④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.6">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.6" class="dfn-panel" data-for="term-for-5.14.6" id="infopanel-for-term-for-5.14.6④" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.6④" style="display:none">Info about the 'getFramebufferAttachmentParameter' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.6">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.6①">(2)</a> <a href="#ref-for-5.14.6②">(3)</a> <a href="#ref-for-5.14.6③">(4)</a> <a href="#ref-for-5.14.6④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-CONTEXT_LOST">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#CONTEXT_LOST">https://www.khronos.org/registry/webgl/specs/latest/1.0/#CONTEXT_LOST</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-CONTEXT_LOST" class="dfn-panel" data-for="term-for-CONTEXT_LOST" id="infopanel-for-term-for-CONTEXT_LOST" role="menu">
+   <span id="infopaneltitle-for-term-for-CONTEXT_LOST" style="display:none">Info about the 'handle the context loss' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#CONTEXT_LOST">https://www.khronos.org/registry/webgl/specs/latest/1.0/#CONTEXT_LOST</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CONTEXT_LOST">11.3. WebGL Context Compatibility</a> <a href="#ref-for-CONTEXT_LOST①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl-object-invalidated-flag">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-object-invalidated-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-object-invalidated-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl-object-invalidated-flag" class="dfn-panel" data-for="term-for-webgl-object-invalidated-flag" id="infopanel-for-term-for-webgl-object-invalidated-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl-object-invalidated-flag" style="display:none">Info about the 'invalidated' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-object-invalidated-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-object-invalidated-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl-object-invalidated-flag">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-restore-the-drawing-buffer">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#restore-the-drawing-buffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#restore-the-drawing-buffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-restore-the-drawing-buffer" class="dfn-panel" data-for="term-for-restore-the-drawing-buffer" id="infopanel-for-term-for-restore-the-drawing-buffer" role="menu">
+   <span id="infopaneltitle-for-term-for-restore-the-drawing-buffer" style="display:none">Info about the 'restore the context' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#restore-the-drawing-buffer">https://www.khronos.org/registry/webgl/specs/latest/1.0/#restore-the-drawing-buffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-restore-the-drawing-buffer">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.15.1">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.15.1" class="dfn-panel" data-for="term-for-5.15.1" id="infopanel-for-term-for-5.15.1" role="menu">
+   <span id="infopaneltitle-for-term-for-5.15.1" style="display:none">Info about the 'statusMessage' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.1">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.15.1">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.10">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.10" class="dfn-panel" data-for="term-for-5.14.10" id="infopanel-for-term-for-5.14.10" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.10" style="display:none">Info about the 'uniformMatrix4fv' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.10">8.1. Matrices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl-context-lost-flag">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl-context-lost-flag" class="dfn-panel" data-for="term-for-webgl-context-lost-flag" id="infopanel-for-term-for-webgl-context-lost-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl-context-lost-flag" style="display:none">Info about the 'webgl context lost flag' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl-context-lost-flag">11.3. WebGL Context Compatibility</a> <a href="#ref-for-webgl-context-lost-flag①">(2)</a> <a href="#ref-for-webgl-context-lost-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webgl-context-lost-flag">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webgl-context-lost-flag" class="dfn-panel" data-for="term-for-webgl-context-lost-flag" id="infopanel-for-term-for-webgl-context-lost-flag①" role="menu">
+   <span id="infopaneltitle-for-term-for-webgl-context-lost-flag①" style="display:none">Info about the 'webgl context lost flag (for WebGLRenderingContext)' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag">https://www.khronos.org/registry/webgl/specs/latest/1.0/#webgl-context-lost-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webgl-context-lost-flag">11.3. WebGL Context Compatibility</a> <a href="#ref-for-webgl-context-lost-flag①">(2)</a> <a href="#ref-for-webgl-context-lost-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.15">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.15" class="dfn-panel" data-for="term-for-5.15" id="infopanel-for-term-for-5.15" role="menu">
+   <span id="infopaneltitle-for-term-for-5.15" style="display:none">Info about the 'webgl task source' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.15">11.3. WebGL Context Compatibility</a> <a href="#ref-for-5.15①">(2)</a> <a href="#ref-for-5.15②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-5.14.4">
-   <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-5.14.4" class="dfn-panel" data-for="term-for-5.14.4" id="infopanel-for-term-for-5.14.4" role="menu">
+   <span id="infopaneltitle-for-term-for-5.14.4" style="display:none">Info about the 'webgl viewport' external reference.</span><a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4">https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-5.14.4">7.1. XRView</a> <a href="#ref-for-5.14.4①">(2)</a>
     <li><a href="#ref-for-5.14.4②">7.3. XRViewport</a> <a href="#ref-for-5.14.4③">(2)</a>
     <li><a href="#ref-for-5.14.4④">11.2. XRWebGLLayer</a> <a href="#ref-for-5.14.4⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2. XRSystem</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a>
     <li><a href="#ref-for-idl-DOMException⑥">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.1. XRSession</a>
     <li><a href="#ref-for-idl-DOMString①">10.1. XRInputSource</a> <a href="#ref-for-idl-DOMString②">(2)</a>
@@ -6788,8 +6788,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-idl-DOMString⑦">14.2. Permissions API Integration</a> <a href="#ref-for-idl-DOMString⑧">(2)</a> <a href="#ref-for-idl-DOMString⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.2. XRSystem</a>
     <li><a href="#ref-for-Exposed①">4.1. XRSession</a>
@@ -6814,16 +6814,16 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-Exposed②⓪">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">7.1. XRView</a>
     <li><a href="#ref-for-idl-Float32Array①">8.1. Matrices</a> <a href="#ref-for-idl-Float32Array②">(2)</a>
     <li><a href="#ref-for-idl-Float32Array③">8.3. XRRigidTransform</a> <a href="#ref-for-idl-Float32Array④">(2)</a> <a href="#ref-for-idl-Float32Array⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">6.3. XRBoundedReferenceSpace</a>
     <li><a href="#ref-for-idl-frozen-array①">9.2. XRViewerPose</a>
@@ -6832,8 +6832,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-idl-frozen-array⑦">14.2. Permissions API Integration</a> <a href="#ref-for-idl-frozen-array⑧">(2)</a> <a href="#ref-for-idl-frozen-array⑨">(3)</a> <a href="#ref-for-idl-frozen-array①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2. XRSystem</a>
     <li><a href="#ref-for-invalidstateerror①">4.1. XRSession</a> <a href="#ref-for-invalidstateerror②">(2)</a> <a href="#ref-for-invalidstateerror③">(3)</a> <a href="#ref-for-invalidstateerror④">(4)</a> <a href="#ref-for-invalidstateerror⑤">(5)</a>
@@ -6844,8 +6844,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-invalidstateerror①⑦">11.3. WebGL Context Compatibility</a> <a href="#ref-for-invalidstateerror①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. XRSystem</a>
     <li><a href="#ref-for-NewObject①">4.1. XRSession</a>
@@ -6853,29 +6853,29 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-NewObject③">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.2. XRSystem</a> <a href="#ref-for-notsupportederror①">(2)</a>
     <li><a href="#ref-for-notsupportederror②">4.1. XRSession</a> <a href="#ref-for-notsupportederror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-operationerror">
-   <a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-operationerror" class="dfn-panel" data-for="term-for-operationerror" id="infopanel-for-term-for-operationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-operationerror" style="display:none">Info about the 'OperationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operationerror">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. XRSystem</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">4.1. XRSession</a> <a href="#ref-for-idl-promise③">(2)</a>
     <li><a href="#ref-for-idl-promise④">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.1. navigator.xr</a>
     <li><a href="#ref-for-SameObject①">4.1. XRSession</a> <a href="#ref-for-SameObject②">(2)</a>
@@ -6892,8 +6892,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-SameObject②②">12.4. XRReferenceSpaceEvent</a> <a href="#ref-for-SameObject②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. navigator.xr</a>
     <li><a href="#ref-for-SecureContext①">3.2. XRSystem</a>
@@ -6918,36 +6918,36 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-SecureContext②⓪">12.4. XRReferenceSpaceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.2. XRSystem</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
     <li><a href="#ref-for-securityerror③">6.1. XRSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">8.3. XRRigidTransform</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2. XRSystem</a> <a href="#ref-for-a-new-promise①">(2)</a>
     <li><a href="#ref-for-a-new-promise②">4.1. XRSession</a> <a href="#ref-for-a-new-promise③">(2)</a>
     <li><a href="#ref-for-a-new-promise④">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.4. Feature Dependencies</a> <a href="#ref-for-idl-any①">(2)</a>
     <li><a href="#ref-for-idl-any②">14.2. Permissions API Integration</a> <a href="#ref-for-idl-any③">(2)</a> <a href="#ref-for-idl-any④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. XRSystem</a>
     <li><a href="#ref-for-idl-boolean①">9.1. XRPose</a>
@@ -6955,40 +6955,40 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-idl-boolean⑨">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.2. XRRenderState</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a> <a href="#ref-for-idl-double⑤">(6)</a>
     <li><a href="#ref-for-idl-double⑥">7.1. XRView</a> <a href="#ref-for-idl-double⑦">(2)</a>
     <li><a href="#ref-for-idl-double⑧">11.2. XRWebGLLayer</a> <a href="#ref-for-idl-double⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">10.3. XRInputSourceArray</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-indexed-property-getter">
-   <a href="https://webidl.spec.whatwg.org/#dfn-indexed-property-getter">https://webidl.spec.whatwg.org/#dfn-indexed-property-getter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-indexed-property-getter" class="dfn-panel" data-for="term-for-dfn-indexed-property-getter" id="infopanel-for-term-for-dfn-indexed-property-getter" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-indexed-property-getter" style="display:none">Info about the 'indexed property getter' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-indexed-property-getter">https://webidl.spec.whatwg.org/#dfn-indexed-property-getter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-getter">10.3. XRInputSourceArray</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://heycam.github.io/webidl/#invoke-a-callback-function">https://heycam.github.io/webidl/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke the web idl callback function' external reference.</span><a href="https://heycam.github.io/webidl/#invoke-a-callback-function">https://heycam.github.io/webidl/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">7.3. XRViewport</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">3.2. XRSystem</a>
     <li><a href="#ref-for-new①">4.1. XRSession</a> <a href="#ref-for-new②">(2)</a>
@@ -7002,32 +7002,32 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-new③⓪">11.2. XRWebGLLayer</a> <a href="#ref-for-new③①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2. XRSystem</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a> <a href="#ref-for-reject④">(5)</a> <a href="#ref-for-reject⑤">(6)</a>
     <li><a href="#ref-for-reject⑥">4.1. XRSession</a> <a href="#ref-for-reject⑦">(2)</a> <a href="#ref-for-reject⑧">(3)</a>
     <li><a href="#ref-for-reject⑨">11.3. WebGL Context Compatibility</a> <a href="#ref-for-reject①⓪">(2)</a> <a href="#ref-for-reject①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.2. XRSystem</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a> <a href="#ref-for-resolve④">(5)</a> <a href="#ref-for-resolve⑤">(6)</a> <a href="#ref-for-resolve⑥">(7)</a> <a href="#ref-for-resolve⑦">(8)</a>
     <li><a href="#ref-for-resolve⑧">4.1. XRSession</a> <a href="#ref-for-resolve⑨">(2)</a>
     <li><a href="#ref-for-resolve①⓪">11.3. WebGL Context Compatibility</a> <a href="#ref-for-resolve①①">(2)</a> <a href="#ref-for-resolve①②">(3)</a> <a href="#ref-for-resolve①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.4. Feature Dependencies</a> <a href="#ref-for-idl-sequence①">(2)</a>
     <li><a href="#ref-for-idl-sequence②">4.2. XRRenderState</a>
     <li><a href="#ref-for-idl-sequence③">14.2. Permissions API Integration</a> <a href="#ref-for-idl-sequence④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">4.1. XRSession</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
     <li><a href="#ref-for-this③">4.3. Animation Frames</a> <a href="#ref-for-this④">(2)</a>
@@ -7036,8 +7036,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-this⑧">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.1. XRSession</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a>
     <li><a href="#ref-for-idl-undefined③">4.3. Animation Frames</a>
@@ -7045,22 +7045,22 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-idl-undefined⑤">11.3. WebGL Context Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.1. XRSession</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">10.3. XRInputSourceArray</a> <a href="#ref-for-idl-unsigned-long③">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long④">11.2. XRWebGLLayer</a> <a href="#ref-for-idl-unsigned-long⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-person-observer-view">
-   <a href="https://immersive-web.github.io/webxr-ar-module/#first-person-observer-view">https://immersive-web.github.io/webxr-ar-module/#first-person-observer-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-person-observer-view" class="dfn-panel" data-for="term-for-first-person-observer-view" id="infopanel-for-term-for-first-person-observer-view" role="menu">
+   <span id="infopaneltitle-for-term-for-first-person-observer-view" style="display:none">Info about the 'first-person observer view' external reference.</span><a href="https://immersive-web.github.io/webxr-ar-module/#first-person-observer-view">https://immersive-web.github.io/webxr-ar-module/#first-person-observer-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-person-observer-view">7.2. Primary and Secondary Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xrrenderstate-layers">
-   <a href="https://immersive-web.github.io/layers/#dom-xrrenderstate-layers">https://immersive-web.github.io/layers/#dom-xrrenderstate-layers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xrrenderstate-layers" class="dfn-panel" data-for="term-for-dom-xrrenderstate-layers" id="infopanel-for-term-for-dom-xrrenderstate-layers" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xrrenderstate-layers" style="display:none">Info about the 'layers' external reference.</span><a href="https://immersive-web.github.io/layers/#dom-xrrenderstate-layers">https://immersive-web.github.io/layers/#dom-xrrenderstate-layers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-layers">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstate-layers①">(2)</a>
    </ul>
@@ -7625,15 +7625,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="3dof">
-   <b><a href="#3dof">#3dof</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-3dof" class="dfn-panel" data-for="3dof" id="infopanel-for-3dof" role="dialog">
+   <span id="infopaneltitle-for-3dof" style="display:none">Info about the '3DoF' definition.</span><b><a href="#3dof">#3dof</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3dof">1.1. Terminology</a> <a href="#ref-for-3dof①">(2)</a>
     <li><a href="#ref-for-3dof②">6.1. XRSpace</a> <a href="#ref-for-3dof③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="6dof">
-   <b><a href="#6dof">#6dof</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-6dof" class="dfn-panel" data-for="6dof" id="infopanel-for-6dof" role="dialog">
+   <span id="infopaneltitle-for-6dof" style="display:none">Info about the '6DoF' definition.</span><b><a href="#6dof">#6dof</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-6dof">1. Introduction</a>
     <li><a href="#ref-for-6dof①">1.1. Terminology</a>
@@ -7643,8 +7643,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-6dof⑦">13.5.3. Reference spaces</a> <a href="#ref-for-6dof⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-device">
-   <b><a href="#xr-device">#xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-device" class="dfn-panel" data-for="xr-device" id="infopanel-for-xr-device" role="dialog">
+   <span id="infopaneltitle-for-xr-device" style="display:none">Info about the 'XR device' definition.</span><b><a href="#xr-device">#xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device">1.1. Terminology</a> <a href="#ref-for-xr-device①">(2)</a>
     <li><a href="#ref-for-xr-device②">2.1. XR device</a> <a href="#ref-for-xr-device③">(2)</a> <a href="#ref-for-xr-device④">(3)</a> <a href="#ref-for-xr-device⑤">(4)</a> <a href="#ref-for-xr-device⑥">(5)</a> <a href="#ref-for-xr-device⑦">(6)</a> <a href="#ref-for-xr-device⑧">(7)</a> <a href="#ref-for-xr-device⑨">(8)</a> <a href="#ref-for-xr-device①⓪">(9)</a>
@@ -7657,8 +7657,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xr-device①⑦">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-supported-modes">
-   <b><a href="#list-of-supported-modes">#list-of-supported-modes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-supported-modes" class="dfn-panel" data-for="list-of-supported-modes" id="infopanel-for-list-of-supported-modes" role="dialog">
+   <span id="infopaneltitle-for-list-of-supported-modes" style="display:none">Info about the 'list of supported modes' definition.</span><b><a href="#list-of-supported-modes">#list-of-supported-modes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-supported-modes">2.1. XR device</a> <a href="#ref-for-list-of-supported-modes①">(2)</a> <a href="#ref-for-list-of-supported-modes②">(3)</a>
     <li><a href="#ref-for-list-of-supported-modes③">3.2. XRSystem</a> <a href="#ref-for-list-of-supported-modes④">(2)</a>
@@ -7666,21 +7666,21 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-list-of-supported-modes⑥">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-device-set-of-granted-features">
-   <b><a href="#xr-device-set-of-granted-features">#xr-device-set-of-granted-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-device-set-of-granted-features" class="dfn-panel" data-for="xr-device-set-of-granted-features" id="infopanel-for-xr-device-set-of-granted-features" role="dialog">
+   <span id="infopaneltitle-for-xr-device-set-of-granted-features" style="display:none">Info about the 'set of granted features' definition.</span><b><a href="#xr-device-set-of-granted-features">#xr-device-set-of-granted-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-device-set-of-granted-features">14.2. Permissions API Integration</a> <a href="#ref-for-xr-device-set-of-granted-features①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-immersive-xr-devices">
-   <b><a href="#list-of-immersive-xr-devices">#list-of-immersive-xr-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-immersive-xr-devices" class="dfn-panel" data-for="list-of-immersive-xr-devices" id="infopanel-for-list-of-immersive-xr-devices" role="dialog">
+   <span id="infopaneltitle-for-list-of-immersive-xr-devices" style="display:none">Info about the 'list of immersive XR devices' definition.</span><b><a href="#list-of-immersive-xr-devices">#list-of-immersive-xr-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-immersive-xr-devices">2.1. XR device</a> <a href="#ref-for-list-of-immersive-xr-devices①">(2)</a>
     <li><a href="#ref-for-list-of-immersive-xr-devices②">3.2. XRSystem</a> <a href="#ref-for-list-of-immersive-xr-devices③">(2)</a> <a href="#ref-for-list-of-immersive-xr-devices④">(3)</a> <a href="#ref-for-list-of-immersive-xr-devices⑤">(4)</a> <a href="#ref-for-list-of-immersive-xr-devices⑥">(5)</a> <a href="#ref-for-list-of-immersive-xr-devices⑦">(6)</a> <a href="#ref-for-list-of-immersive-xr-devices⑧">(7)</a> <a href="#ref-for-list-of-immersive-xr-devices⑨">(8)</a> <a href="#ref-for-list-of-immersive-xr-devices①⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="immersive-xr-device">
-   <b><a href="#immersive-xr-device">#immersive-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-immersive-xr-device" class="dfn-panel" data-for="immersive-xr-device" id="infopanel-for-immersive-xr-device" role="dialog">
+   <span id="infopaneltitle-for-immersive-xr-device" style="display:none">Info about the 'immersive XR device' definition.</span><b><a href="#immersive-xr-device">#immersive-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immersive-xr-device">2.1. XR device</a> <a href="#ref-for-immersive-xr-device①">(2)</a>
     <li><a href="#ref-for-immersive-xr-device②">3.2. XRSystem</a> <a href="#ref-for-immersive-xr-device③">(2)</a> <a href="#ref-for-immersive-xr-device④">(3)</a> <a href="#ref-for-immersive-xr-device⑤">(4)</a> <a href="#ref-for-immersive-xr-device⑥">(5)</a> <a href="#ref-for-immersive-xr-device⑦">(6)</a> <a href="#ref-for-immersive-xr-device⑧">(7)</a> <a href="#ref-for-immersive-xr-device⑨">(8)</a> <a href="#ref-for-immersive-xr-device①⓪">(9)</a> <a href="#ref-for-immersive-xr-device①①">(10)</a> <a href="#ref-for-immersive-xr-device①②">(11)</a> <a href="#ref-for-immersive-xr-device①③">(12)</a>
@@ -7691,30 +7691,30 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-immersive-xr-device③②">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-inline-xr-device">
-   <b><a href="#default-inline-xr-device">#default-inline-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-inline-xr-device" class="dfn-panel" data-for="default-inline-xr-device" id="infopanel-for-default-inline-xr-device" role="dialog">
+   <span id="infopaneltitle-for-default-inline-xr-device" style="display:none">Info about the 'default inline XR device' definition.</span><b><a href="#default-inline-xr-device">#default-inline-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-inline-xr-device">2.1. XR device</a> <a href="#ref-for-default-inline-xr-device①">(2)</a> <a href="#ref-for-default-inline-xr-device②">(3)</a> <a href="#ref-for-default-inline-xr-device③">(4)</a> <a href="#ref-for-default-inline-xr-device④">(5)</a> <a href="#ref-for-default-inline-xr-device⑤">(6)</a>
     <li><a href="#ref-for-default-inline-xr-device⑥">3.2. XRSystem</a> <a href="#ref-for-default-inline-xr-device⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-xr-device">
-   <b><a href="#inline-xr-device">#inline-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-xr-device" class="dfn-panel" data-for="inline-xr-device" id="infopanel-for-inline-xr-device" role="dialog">
+   <span id="infopaneltitle-for-inline-xr-device" style="display:none">Info about the 'inline XR device' definition.</span><b><a href="#inline-xr-device">#inline-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-xr-device">2.1. XR device</a> <a href="#ref-for-inline-xr-device①">(2)</a> <a href="#ref-for-inline-xr-device②">(3)</a> <a href="#ref-for-inline-xr-device③">(4)</a> <a href="#ref-for-inline-xr-device④">(5)</a>
     <li><a href="#ref-for-inline-xr-device⑤">3.2. XRSystem</a> <a href="#ref-for-inline-xr-device⑥">(2)</a> <a href="#ref-for-inline-xr-device⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-xr">
-   <b><a href="#dom-navigator-xr">#dom-navigator-xr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-xr" class="dfn-panel" data-for="dom-navigator-xr" id="infopanel-for-dom-navigator-xr" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-xr" style="display:none">Info about the 'xr' definition.</span><b><a href="#dom-navigator-xr">#dom-navigator-xr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-xr">3.1. navigator.xr</a>
     <li><a href="#ref-for-dom-navigator-xr①">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-navigator-xr②">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsystem">
-   <b><a href="#xrsystem">#xrsystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsystem" class="dfn-panel" data-for="xrsystem" id="infopanel-for-xrsystem" role="dialog">
+   <span id="infopaneltitle-for-xrsystem" style="display:none">Info about the 'XRSystem' definition.</span><b><a href="#xrsystem">#xrsystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsystem">3.1. navigator.xr</a> <a href="#ref-for-xrsystem①">(2)</a>
     <li><a href="#ref-for-xrsystem②">3.2. XRSystem</a> <a href="#ref-for-xrsystem③">(2)</a> <a href="#ref-for-xrsystem④">(3)</a> <a href="#ref-for-xrsystem⑤">(4)</a> <a href="#ref-for-xrsystem⑥">(5)</a> <a href="#ref-for-xrsystem⑦">(6)</a> <a href="#ref-for-xrsystem⑧">(7)</a>
@@ -7722,33 +7722,33 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrsystem①⓪">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumerate-immersive-xr-devices">
-   <b><a href="#enumerate-immersive-xr-devices">#enumerate-immersive-xr-devices</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumerate-immersive-xr-devices" class="dfn-panel" data-for="enumerate-immersive-xr-devices" id="infopanel-for-enumerate-immersive-xr-devices" role="dialog">
+   <span id="infopaneltitle-for-enumerate-immersive-xr-devices" style="display:none">Info about the 'enumerate immersive XR devices' definition.</span><b><a href="#enumerate-immersive-xr-devices">#enumerate-immersive-xr-devices</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumerate-immersive-xr-devices">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="select-an-immersive-xr-device">
-   <b><a href="#select-an-immersive-xr-device">#select-an-immersive-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-select-an-immersive-xr-device" class="dfn-panel" data-for="select-an-immersive-xr-device" id="infopanel-for-select-an-immersive-xr-device" role="dialog">
+   <span id="infopaneltitle-for-select-an-immersive-xr-device" style="display:none">Info about the 'select an immersive XR device' definition.</span><b><a href="#select-an-immersive-xr-device">#select-an-immersive-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-select-an-immersive-xr-device">3.2. XRSystem</a> <a href="#ref-for-select-an-immersive-xr-device①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ensure-an-immersive-xr-device-is-selected">
-   <b><a href="#ensure-an-immersive-xr-device-is-selected">#ensure-an-immersive-xr-device-is-selected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ensure-an-immersive-xr-device-is-selected" class="dfn-panel" data-for="ensure-an-immersive-xr-device-is-selected" id="infopanel-for-ensure-an-immersive-xr-device-is-selected" role="dialog">
+   <span id="infopaneltitle-for-ensure-an-immersive-xr-device-is-selected" style="display:none">Info about the 'ensure an immersive XR device is selected' definition.</span><b><a href="#ensure-an-immersive-xr-device-is-selected">#ensure-an-immersive-xr-device-is-selected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ensure-an-immersive-xr-device-is-selected">3.2. XRSystem</a> <a href="#ref-for-ensure-an-immersive-xr-device-is-selected①">(2)</a>
     <li><a href="#ref-for-ensure-an-immersive-xr-device-is-selected②">11.3. WebGL Context Compatibility</a> <a href="#ref-for-ensure-an-immersive-xr-device-is-selected③">(2)</a> <a href="#ref-for-ensure-an-immersive-xr-device-is-selected④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsystem-ondevicechange">
-   <b><a href="#dom-xrsystem-ondevicechange">#dom-xrsystem-ondevicechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsystem-ondevicechange" class="dfn-panel" data-for="dom-xrsystem-ondevicechange" id="infopanel-for-dom-xrsystem-ondevicechange" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsystem-ondevicechange" style="display:none">Info about the 'ondevicechange' definition.</span><b><a href="#dom-xrsystem-ondevicechange">#dom-xrsystem-ondevicechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-ondevicechange">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsystem-issessionsupported">
-   <b><a href="#dom-xrsystem-issessionsupported">#dom-xrsystem-issessionsupported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsystem-issessionsupported" class="dfn-panel" data-for="dom-xrsystem-issessionsupported" id="infopanel-for-dom-xrsystem-issessionsupported" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsystem-issessionsupported" style="display:none">Info about the 'isSessionSupported(mode)' definition.</span><b><a href="#dom-xrsystem-issessionsupported">#dom-xrsystem-issessionsupported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-issessionsupported">1.2. Application flow</a>
     <li><a href="#ref-for-dom-xrsystem-issessionsupported①">3.2. XRSystem</a> <a href="#ref-for-dom-xrsystem-issessionsupported②">(2)</a> <a href="#ref-for-dom-xrsystem-issessionsupported③">(3)</a> <a href="#ref-for-dom-xrsystem-issessionsupported④">(4)</a> <a href="#ref-for-dom-xrsystem-issessionsupported⑤">(5)</a>
@@ -7757,14 +7757,14 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrsystem-issessionsupported①⑤">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-immersive-session">
-   <b><a href="#pending-immersive-session">#pending-immersive-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-immersive-session" class="dfn-panel" data-for="pending-immersive-session" id="infopanel-for-pending-immersive-session" role="dialog">
+   <span id="infopaneltitle-for-pending-immersive-session" style="display:none">Info about the 'pending immersive session' definition.</span><b><a href="#pending-immersive-session">#pending-immersive-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-immersive-session">3.2. XRSystem</a> <a href="#ref-for-pending-immersive-session①">(2)</a> <a href="#ref-for-pending-immersive-session②">(3)</a> <a href="#ref-for-pending-immersive-session③">(4)</a> <a href="#ref-for-pending-immersive-session④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-immersive-session">
-   <b><a href="#active-immersive-session">#active-immersive-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-immersive-session" class="dfn-panel" data-for="active-immersive-session" id="infopanel-for-active-immersive-session" role="dialog">
+   <span id="infopaneltitle-for-active-immersive-session" style="display:none">Info about the 'active immersive session' definition.</span><b><a href="#active-immersive-session">#active-immersive-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-immersive-session">3.2. XRSystem</a> <a href="#ref-for-active-immersive-session①">(2)</a> <a href="#ref-for-active-immersive-session②">(3)</a>
     <li><a href="#ref-for-active-immersive-session③">4.1. XRSession</a> <a href="#ref-for-active-immersive-session④">(2)</a>
@@ -7772,15 +7772,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-active-immersive-session⑧">13.3. Mid-session consent</a> <a href="#ref-for-active-immersive-session⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-inline-sessions">
-   <b><a href="#list-of-inline-sessions">#list-of-inline-sessions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-inline-sessions" class="dfn-panel" data-for="list-of-inline-sessions" id="infopanel-for-list-of-inline-sessions" role="dialog">
+   <span id="infopaneltitle-for-list-of-inline-sessions" style="display:none">Info about the 'list of inline sessions' definition.</span><b><a href="#list-of-inline-sessions">#list-of-inline-sessions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-inline-sessions">3.2. XRSystem</a>
     <li><a href="#ref-for-list-of-inline-sessions①">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsystem-requestsession">
-   <b><a href="#dom-xrsystem-requestsession">#dom-xrsystem-requestsession</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsystem-requestsession" class="dfn-panel" data-for="dom-xrsystem-requestsession" id="infopanel-for-dom-xrsystem-requestsession" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsystem-requestsession" style="display:none">Info about the 'requestSession(mode, options)' definition.</span><b><a href="#dom-xrsystem-requestsession">#dom-xrsystem-requestsession</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsystem-requestsession">1.2. Application flow</a>
     <li><a href="#ref-for-dom-xrsystem-requestsession①">3.2. XRSystem</a>
@@ -7790,15 +7790,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrsystem-requestsession⑤">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-the-current-device">
-   <b><a href="#obtain-the-current-device">#obtain-the-current-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-the-current-device" class="dfn-panel" data-for="obtain-the-current-device" id="infopanel-for-obtain-the-current-device" role="dialog">
+   <span id="infopaneltitle-for-obtain-the-current-device" style="display:none">Info about the 'obtain the current device' definition.</span><b><a href="#obtain-the-current-device">#obtain-the-current-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-the-current-device">3.2. XRSystem</a>
     <li><a href="#ref-for-obtain-the-current-device①">14.2. Permissions API Integration</a> <a href="#ref-for-obtain-the-current-device②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrsessionmode">
-   <b><a href="#enumdef-xrsessionmode">#enumdef-xrsessionmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrsessionmode" class="dfn-panel" data-for="enumdef-xrsessionmode" id="infopanel-for-enumdef-xrsessionmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrsessionmode" style="display:none">Info about the 'XRSessionMode' definition.</span><b><a href="#enumdef-xrsessionmode">#enumdef-xrsessionmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrsessionmode">2.1. XR device</a> <a href="#ref-for-enumdef-xrsessionmode①">(2)</a>
     <li><a href="#ref-for-enumdef-xrsessionmode②">3.2. XRSystem</a> <a href="#ref-for-enumdef-xrsessionmode③">(2)</a> <a href="#ref-for-enumdef-xrsessionmode④">(3)</a>
@@ -7810,8 +7810,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-enumdef-xrsessionmode①⑥">14.2. Permissions API Integration</a> <a href="#ref-for-enumdef-xrsessionmode①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionmode-inline">
-   <b><a href="#dom-xrsessionmode-inline">#dom-xrsessionmode-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionmode-inline" class="dfn-panel" data-for="dom-xrsessionmode-inline" id="infopanel-for-dom-xrsessionmode-inline" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionmode-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#dom-xrsessionmode-inline">#dom-xrsessionmode-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-inline">2.1. XR device</a> <a href="#ref-for-dom-xrsessionmode-inline①">(2)</a>
     <li><a href="#ref-for-dom-xrsessionmode-inline②">3.2. XRSystem</a>
@@ -7827,22 +7827,22 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrsessionmode-inline②⓪">13.5.1. Immersiveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionmode-immersive-vr">
-   <b><a href="#dom-xrsessionmode-immersive-vr">#dom-xrsessionmode-immersive-vr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionmode-immersive-vr" class="dfn-panel" data-for="dom-xrsessionmode-immersive-vr" id="infopanel-for-dom-xrsessionmode-immersive-vr" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionmode-immersive-vr" style="display:none">Info about the 'immersive-vr' definition.</span><b><a href="#dom-xrsessionmode-immersive-vr">#dom-xrsessionmode-immersive-vr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr">3.2. XRSystem</a> <a href="#ref-for-dom-xrsessionmode-immersive-vr①">(2)</a>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr②">3.3. XRSessionMode</a> <a href="#ref-for-dom-xrsessionmode-immersive-vr③">(2)</a>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-vr④">13.9.1. Considerations for when to automatically grant "xr-session-supported"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionmode-immersive-ar">
-   <b><a href="#dom-xrsessionmode-immersive-ar">#dom-xrsessionmode-immersive-ar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionmode-immersive-ar" class="dfn-panel" data-for="dom-xrsessionmode-immersive-ar" id="infopanel-for-dom-xrsessionmode-immersive-ar" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionmode-immersive-ar" style="display:none">Info about the 'immersive-ar' definition.</span><b><a href="#dom-xrsessionmode-immersive-ar">#dom-xrsessionmode-immersive-ar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionmode-immersive-ar">3.3. XRSessionMode</a> <a href="#ref-for-dom-xrsessionmode-immersive-ar①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-session">
-   <b><a href="#inline-session">#inline-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-session" class="dfn-panel" data-for="inline-session" id="infopanel-for-inline-session" role="dialog">
+   <span id="infopaneltitle-for-inline-session" style="display:none">Info about the 'inline session' definition.</span><b><a href="#inline-session">#inline-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-session">3.4. Feature Dependencies</a> <a href="#ref-for-inline-session①">(2)</a>
     <li><a href="#ref-for-inline-session②">4.1. XRSession</a>
@@ -7851,8 +7851,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-inline-session⑤">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="immersive-session">
-   <b><a href="#immersive-session">#immersive-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-immersive-session" class="dfn-panel" data-for="immersive-session" id="infopanel-for-immersive-session" role="dialog">
+   <span id="infopaneltitle-for-immersive-session" style="display:none">Info about the 'immersive session' definition.</span><b><a href="#immersive-session">#immersive-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immersive-session">3.2. XRSystem</a> <a href="#ref-for-immersive-session①">(2)</a>
     <li><a href="#ref-for-immersive-session②">3.3. XRSessionMode</a> <a href="#ref-for-immersive-session③">(2)</a> <a href="#ref-for-immersive-session④">(3)</a> <a href="#ref-for-immersive-session⑤">(4)</a> <a href="#ref-for-immersive-session⑥">(5)</a> <a href="#ref-for-immersive-session⑦">(6)</a> <a href="#ref-for-immersive-session⑧">(7)</a>
@@ -7868,51 +7868,51 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-immersive-session③③">14.1. Permissions Policy</a> <a href="#ref-for-immersive-session③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exclusive-access">
-   <b><a href="#exclusive-access">#exclusive-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusive-access" class="dfn-panel" data-for="exclusive-access" id="infopanel-for-exclusive-access" role="dialog">
+   <span id="infopaneltitle-for-exclusive-access" style="display:none">Info about the 'exclusive access' definition.</span><b><a href="#exclusive-access">#exclusive-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusive-access">3.3. XRSessionMode</a> <a href="#ref-for-exclusive-access①">(2)</a> <a href="#ref-for-exclusive-access②">(3)</a>
     <li><a href="#ref-for-exclusive-access③">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="required-features">
-   <b><a href="#required-features">#required-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-required-features" class="dfn-panel" data-for="required-features" id="infopanel-for-required-features" role="dialog">
+   <span id="infopaneltitle-for-required-features" style="display:none">Info about the 'required features' definition.</span><b><a href="#required-features">#required-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-required-features">3.4. Feature Dependencies</a> <a href="#ref-for-required-features①">(2)</a>
     <li><a href="#ref-for-required-features②">13.5.1. Immersiveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optional-features">
-   <b><a href="#optional-features">#optional-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optional-features" class="dfn-panel" data-for="optional-features" id="infopanel-for-optional-features" role="dialog">
+   <span id="infopaneltitle-for-optional-features" style="display:none">Info about the 'Optional features' definition.</span><b><a href="#optional-features">#optional-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optional-features">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-optional-features①">13.5.1. Immersiveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrsessioninit">
-   <b><a href="#dictdef-xrsessioninit">#dictdef-xrsessioninit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrsessioninit" class="dfn-panel" data-for="dictdef-xrsessioninit" id="infopanel-for-dictdef-xrsessioninit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrsessioninit" style="display:none">Info about the 'XRSessionInit' definition.</span><b><a href="#dictdef-xrsessioninit">#dictdef-xrsessioninit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrsessioninit">3.2. XRSystem</a>
     <li><a href="#ref-for-dictdef-xrsessioninit①">3.4. Feature Dependencies</a> <a href="#ref-for-dictdef-xrsessioninit②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessioninit-requiredfeatures">
-   <b><a href="#dom-xrsessioninit-requiredfeatures">#dom-xrsessioninit-requiredfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessioninit-requiredfeatures" class="dfn-panel" data-for="dom-xrsessioninit-requiredfeatures" id="infopanel-for-dom-xrsessioninit-requiredfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessioninit-requiredfeatures" style="display:none">Info about the 'requiredFeatures' definition.</span><b><a href="#dom-xrsessioninit-requiredfeatures">#dom-xrsessioninit-requiredfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-requiredfeatures">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-xrsessioninit-requiredfeatures①">3.4. Feature Dependencies</a> <a href="#ref-for-dom-xrsessioninit-requiredfeatures②">(2)</a> <a href="#ref-for-dom-xrsessioninit-requiredfeatures③">(3)</a> <a href="#ref-for-dom-xrsessioninit-requiredfeatures④">(4)</a> <a href="#ref-for-dom-xrsessioninit-requiredfeatures⑤">(5)</a> <a href="#ref-for-dom-xrsessioninit-requiredfeatures⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessioninit-optionalfeatures">
-   <b><a href="#dom-xrsessioninit-optionalfeatures">#dom-xrsessioninit-optionalfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessioninit-optionalfeatures" class="dfn-panel" data-for="dom-xrsessioninit-optionalfeatures" id="infopanel-for-dom-xrsessioninit-optionalfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessioninit-optionalfeatures" style="display:none">Info about the 'optionalFeatures' definition.</span><b><a href="#dom-xrsessioninit-optionalfeatures">#dom-xrsessioninit-optionalfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessioninit-optionalfeatures">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-xrsessioninit-optionalfeatures①">3.4. Feature Dependencies</a> <a href="#ref-for-dom-xrsessioninit-optionalfeatures②">(2)</a> <a href="#ref-for-dom-xrsessioninit-optionalfeatures③">(3)</a> <a href="#ref-for-dom-xrsessioninit-optionalfeatures④">(4)</a>
     <li><a href="#ref-for-dom-xrsessioninit-optionalfeatures⑤">7.2. Primary and Secondary Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-descriptor">
-   <b><a href="#feature-descriptor">#feature-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-descriptor" class="dfn-panel" data-for="feature-descriptor" id="infopanel-for-feature-descriptor" role="dialog">
+   <span id="infopaneltitle-for-feature-descriptor" style="display:none">Info about the 'feature descriptor' definition.</span><b><a href="#feature-descriptor">#feature-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-descriptor">2.1. XR device</a>
     <li><a href="#ref-for-feature-descriptor①">3.4. Feature Dependencies</a> <a href="#ref-for-feature-descriptor②">(2)</a> <a href="#ref-for-feature-descriptor③">(3)</a> <a href="#ref-for-feature-descriptor④">(4)</a> <a href="#ref-for-feature-descriptor⑤">(5)</a> <a href="#ref-for-feature-descriptor⑥">(6)</a> <a href="#ref-for-feature-descriptor⑦">(7)</a>
@@ -7921,48 +7921,48 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-feature-descriptor①⓪">14.2. Permissions API Integration</a> <a href="#ref-for-feature-descriptor①①">(2)</a> <a href="#ref-for-feature-descriptor①②">(3)</a> <a href="#ref-for-feature-descriptor①③">(4)</a> <a href="#ref-for-feature-descriptor①④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-features">
-   <b><a href="#default-features">#default-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-features" class="dfn-panel" data-for="default-features" id="infopanel-for-default-features" role="dialog">
+   <span id="infopaneltitle-for-default-features" style="display:none">Info about the 'default features' definition.</span><b><a href="#default-features">#default-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-features">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-default-features①">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requested-features">
-   <b><a href="#requested-features">#requested-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requested-features" class="dfn-panel" data-for="requested-features" id="infopanel-for-requested-features" role="dialog">
+   <span id="infopaneltitle-for-requested-features" style="display:none">Info about the 'requested features' definition.</span><b><a href="#requested-features">#requested-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requested-features">3.4. Feature Dependencies</a> <a href="#ref-for-requested-features①">(2)</a> <a href="#ref-for-requested-features②">(3)</a>
     <li><a href="#ref-for-requested-features③">13.5.1. Immersiveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-requirements">
-   <b><a href="#feature-requirements">#feature-requirements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-requirements" class="dfn-panel" data-for="feature-requirements" id="infopanel-for-feature-requirements" role="dialog">
+   <span id="infopaneltitle-for-feature-requirements" style="display:none">Info about the 'feature requirements' definition.</span><b><a href="#feature-requirements">#feature-requirements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-requirements">13.5.3. Reference spaces</a>
     <li><a href="#ref-for-feature-requirements①">14.2. Permissions API Integration</a> <a href="#ref-for-feature-requirements②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="capable-of-supporting">
-   <b><a href="#capable-of-supporting">#capable-of-supporting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-capable-of-supporting" class="dfn-panel" data-for="capable-of-supporting" id="infopanel-for-capable-of-supporting" role="dialog">
+   <span id="infopaneltitle-for-capable-of-supporting" style="display:none">Info about the 'capable of supporting' definition.</span><b><a href="#capable-of-supporting">#capable-of-supporting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capable-of-supporting">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-capable-of-supporting①">14.2. Permissions API Integration</a> <a href="#ref-for-capable-of-supporting②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-not-initialize-device-tracking">
-   <b><a href="#should-not-initialize-device-tracking">#should-not-initialize-device-tracking</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-not-initialize-device-tracking" class="dfn-panel" data-for="should-not-initialize-device-tracking" id="infopanel-for-should-not-initialize-device-tracking" role="dialog">
+   <span id="infopaneltitle-for-should-not-initialize-device-tracking" style="display:none">Info about the 'SHOULD NOT initialize device tracking' definition.</span><b><a href="#should-not-initialize-device-tracking">#should-not-initialize-device-tracking</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-not-initialize-device-tracking">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrvisibilitystate">
-   <b><a href="#enumdef-xrvisibilitystate">#enumdef-xrvisibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrvisibilitystate" class="dfn-panel" data-for="enumdef-xrvisibilitystate" id="infopanel-for-enumdef-xrvisibilitystate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrvisibilitystate" style="display:none">Info about the 'XRVisibilityState' definition.</span><b><a href="#enumdef-xrvisibilitystate">#enumdef-xrvisibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrvisibilitystate">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession">
-   <b><a href="#xrsession">#xrsession</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession" class="dfn-panel" data-for="xrsession" id="infopanel-for-xrsession" role="dialog">
+   <span id="infopaneltitle-for-xrsession" style="display:none">Info about the 'XRSession' definition.</span><b><a href="#xrsession">#xrsession</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession">1.2. Application flow</a> <a href="#ref-for-xrsession①">(2)</a>
     <li><a href="#ref-for-xrsession②">3.2. XRSystem</a> <a href="#ref-for-xrsession③">(2)</a> <a href="#ref-for-xrsession④">(3)</a> <a href="#ref-for-xrsession⑤">(4)</a> <a href="#ref-for-xrsession⑥">(5)</a> <a href="#ref-for-xrsession⑦">(6)</a> <a href="#ref-for-xrsession⑧">(7)</a> <a href="#ref-for-xrsession⑨">(8)</a>
@@ -7991,8 +7991,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrsession①④①">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-mode">
-   <b><a href="#xrsession-mode">#xrsession-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-mode" class="dfn-panel" data-for="xrsession-mode" id="infopanel-for-xrsession-mode" role="dialog">
+   <span id="infopaneltitle-for-xrsession-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#xrsession-mode">#xrsession-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-mode">4.1. XRSession</a> <a href="#ref-for-xrsession-mode①">(2)</a>
     <li><a href="#ref-for-xrsession-mode②">4.3. Animation Frames</a>
@@ -8000,28 +8000,28 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrsession-mode④">11.2. XRWebGLLayer</a> <a href="#ref-for-xrsession-mode⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-animation-frame">
-   <b><a href="#xrsession-animation-frame">#xrsession-animation-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-animation-frame" class="dfn-panel" data-for="xrsession-animation-frame" id="infopanel-for-xrsession-animation-frame" role="dialog">
+   <span id="infopaneltitle-for-xrsession-animation-frame" style="display:none">Info about the 'animation frame' definition.</span><b><a href="#xrsession-animation-frame">#xrsession-animation-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-animation-frame">4.3. Animation Frames</a>
     <li><a href="#ref-for-xrsession-animation-frame①">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-set-of-granted-features">
-   <b><a href="#xrsession-set-of-granted-features">#xrsession-set-of-granted-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-set-of-granted-features" class="dfn-panel" data-for="xrsession-set-of-granted-features" id="infopanel-for-xrsession-set-of-granted-features" role="dialog">
+   <span id="infopaneltitle-for-xrsession-set-of-granted-features" style="display:none">Info about the 'set of granted features' definition.</span><b><a href="#xrsession-set-of-granted-features">#xrsession-set-of-granted-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-set-of-granted-features">4.1. XRSession</a>
     <li><a href="#ref-for-xrsession-set-of-granted-features①">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-the-session">
-   <b><a href="#initialize-the-session">#initialize-the-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-the-session" class="dfn-panel" data-for="initialize-the-session" id="infopanel-for-initialize-the-session" role="dialog">
+   <span id="infopaneltitle-for-initialize-the-session" style="display:none">Info about the 'initialize the session' definition.</span><b><a href="#initialize-the-session">#initialize-the-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-the-session">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shut-down-the-session">
-   <b><a href="#shut-down-the-session">#shut-down-the-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shut-down-the-session" class="dfn-panel" data-for="shut-down-the-session" id="infopanel-for-shut-down-the-session" role="dialog">
+   <span id="infopaneltitle-for-shut-down-the-session" style="display:none">Info about the 'shut down the session' definition.</span><b><a href="#shut-down-the-session">#shut-down-the-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shut-down-the-session">1.2. Application flow</a>
     <li><a href="#ref-for-shut-down-the-session①">3.2. XRSystem</a>
@@ -8029,8 +8029,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-shut-down-the-session③">13.3. Mid-session consent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ended">
-   <b><a href="#ended">#ended</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ended" class="dfn-panel" data-for="ended" id="infopanel-for-ended" role="dialog">
+   <span id="infopaneltitle-for-ended" style="display:none">Info about the 'ended' definition.</span><b><a href="#ended">#ended</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ended">4.1. XRSession</a> <a href="#ref-for-ended①">(2)</a> <a href="#ref-for-ended②">(3)</a>
     <li><a href="#ref-for-ended③">4.3. Animation Frames</a>
@@ -8038,28 +8038,28 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-ended⑥">13.2.4. Duration of consent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-end">
-   <b><a href="#dom-xrsession-end">#dom-xrsession-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-end" class="dfn-panel" data-for="dom-xrsession-end" id="infopanel-for-dom-xrsession-end" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-end" style="display:none">Info about the 'end()' definition.</span><b><a href="#dom-xrsession-end">#dom-xrsession-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-end">4.1. XRSession</a> <a href="#ref-for-dom-xrsession-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-render-state">
-   <b><a href="#active-render-state">#active-render-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-render-state" class="dfn-panel" data-for="active-render-state" id="infopanel-for-active-render-state" role="dialog">
+   <span id="infopaneltitle-for-active-render-state" style="display:none">Info about the 'active render state' definition.</span><b><a href="#active-render-state">#active-render-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-render-state">4.1. XRSession</a> <a href="#ref-for-active-render-state①">(2)</a> <a href="#ref-for-active-render-state②">(3)</a> <a href="#ref-for-active-render-state③">(4)</a>
     <li><a href="#ref-for-active-render-state④">4.2. XRRenderState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-render-state">
-   <b><a href="#pending-render-state">#pending-render-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-render-state" class="dfn-panel" data-for="pending-render-state" id="infopanel-for-pending-render-state" role="dialog">
+   <span id="infopaneltitle-for-pending-render-state" style="display:none">Info about the 'pending render state' definition.</span><b><a href="#pending-render-state">#pending-render-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-render-state">4.1. XRSession</a> <a href="#ref-for-pending-render-state①">(2)</a> <a href="#ref-for-pending-render-state②">(3)</a> <a href="#ref-for-pending-render-state③">(4)</a> <a href="#ref-for-pending-render-state④">(5)</a> <a href="#ref-for-pending-render-state⑤">(6)</a> <a href="#ref-for-pending-render-state⑥">(7)</a>
     <li><a href="#ref-for-pending-render-state⑦">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-renderstate">
-   <b><a href="#dom-xrsession-renderstate">#dom-xrsession-renderstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-renderstate" class="dfn-panel" data-for="dom-xrsession-renderstate" id="infopanel-for-dom-xrsession-renderstate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-renderstate" style="display:none">Info about the 'renderState' definition.</span><b><a href="#dom-xrsession-renderstate">#dom-xrsession-renderstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-renderstate">4.1. XRSession</a> <a href="#ref-for-dom-xrsession-renderstate①">(2)</a>
     <li><a href="#ref-for-dom-xrsession-renderstate②">4.3. Animation Frames</a> <a href="#ref-for-dom-xrsession-renderstate③">(2)</a> <a href="#ref-for-dom-xrsession-renderstate④">(3)</a>
@@ -8067,58 +8067,58 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrsession-renderstate⑥">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-inline-field-of-view">
-   <b><a href="#minimum-inline-field-of-view">#minimum-inline-field-of-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-inline-field-of-view" class="dfn-panel" data-for="minimum-inline-field-of-view" id="infopanel-for-minimum-inline-field-of-view" role="dialog">
+   <span id="infopaneltitle-for-minimum-inline-field-of-view" style="display:none">Info about the 'minimum inline field of view' definition.</span><b><a href="#minimum-inline-field-of-view">#minimum-inline-field-of-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-inline-field-of-view">4.1. XRSession</a> <a href="#ref-for-minimum-inline-field-of-view①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-inline-field-of-view">
-   <b><a href="#maximum-inline-field-of-view">#maximum-inline-field-of-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-inline-field-of-view" class="dfn-panel" data-for="maximum-inline-field-of-view" id="infopanel-for-maximum-inline-field-of-view" role="dialog">
+   <span id="infopaneltitle-for-maximum-inline-field-of-view" style="display:none">Info about the 'maximum inline field of view' definition.</span><b><a href="#maximum-inline-field-of-view">#maximum-inline-field-of-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-inline-field-of-view">4.1. XRSession</a> <a href="#ref-for-maximum-inline-field-of-view①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-near-clip-plane">
-   <b><a href="#minimum-near-clip-plane">#minimum-near-clip-plane</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-near-clip-plane" class="dfn-panel" data-for="minimum-near-clip-plane" id="infopanel-for-minimum-near-clip-plane" role="dialog">
+   <span id="infopaneltitle-for-minimum-near-clip-plane" style="display:none">Info about the 'minimum near clip plane' definition.</span><b><a href="#minimum-near-clip-plane">#minimum-near-clip-plane</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-near-clip-plane">4.1. XRSession</a> <a href="#ref-for-minimum-near-clip-plane①">(2)</a> <a href="#ref-for-minimum-near-clip-plane②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-far-clip-plane">
-   <b><a href="#maximum-far-clip-plane">#maximum-far-clip-plane</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-far-clip-plane" class="dfn-panel" data-for="maximum-far-clip-plane" id="infopanel-for-maximum-far-clip-plane" role="dialog">
+   <span id="infopaneltitle-for-maximum-far-clip-plane" style="display:none">Info about the 'maximum far clip plane' definition.</span><b><a href="#maximum-far-clip-plane">#maximum-far-clip-plane</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-far-clip-plane">4.1. XRSession</a> <a href="#ref-for-maximum-far-clip-plane①">(2)</a> <a href="#ref-for-maximum-far-clip-plane②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-the-pending-layers-state">
-   <b><a href="#update-the-pending-layers-state">#update-the-pending-layers-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-the-pending-layers-state" class="dfn-panel" data-for="update-the-pending-layers-state" id="infopanel-for-update-the-pending-layers-state" role="dialog">
+   <span id="infopaneltitle-for-update-the-pending-layers-state" style="display:none">Info about the 'update the pending layers state' definition.</span><b><a href="#update-the-pending-layers-state">#update-the-pending-layers-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-pending-layers-state">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-updaterenderstate">
-   <b><a href="#dom-xrsession-updaterenderstate">#dom-xrsession-updaterenderstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-updaterenderstate" class="dfn-panel" data-for="dom-xrsession-updaterenderstate" id="infopanel-for-dom-xrsession-updaterenderstate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-updaterenderstate" style="display:none">Info about the 'updateRenderState(newState)' definition.</span><b><a href="#dom-xrsession-updaterenderstate">#dom-xrsession-updaterenderstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-updaterenderstate">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrsession-updaterenderstate①">4.2. XRRenderState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply-the-pending-render-state">
-   <b><a href="#apply-the-pending-render-state">#apply-the-pending-render-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply-the-pending-render-state" class="dfn-panel" data-for="apply-the-pending-render-state" id="infopanel-for-apply-the-pending-render-state" role="dialog">
+   <span id="infopaneltitle-for-apply-the-pending-render-state" style="display:none">Info about the 'apply the pending render state' definition.</span><b><a href="#apply-the-pending-render-state">#apply-the-pending-render-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply-the-pending-render-state">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-requestreferencespace">
-   <b><a href="#dom-xrsession-requestreferencespace">#dom-xrsession-requestreferencespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-requestreferencespace" class="dfn-panel" data-for="dom-xrsession-requestreferencespace" id="infopanel-for-dom-xrsession-requestreferencespace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-requestreferencespace" style="display:none">Info about the 'requestReferenceSpace(type)' definition.</span><b><a href="#dom-xrsession-requestreferencespace">#dom-xrsession-requestreferencespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestreferencespace">4.1. XRSession</a> <a href="#ref-for-dom-xrsession-requestreferencespace①">(2)</a>
     <li><a href="#ref-for-dom-xrsession-requestreferencespace②">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-active-xr-input-sources">
-   <b><a href="#list-of-active-xr-input-sources">#list-of-active-xr-input-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-active-xr-input-sources" class="dfn-panel" data-for="list-of-active-xr-input-sources" id="infopanel-for-list-of-active-xr-input-sources" role="dialog">
+   <span id="infopaneltitle-for-list-of-active-xr-input-sources" style="display:none">Info about the 'list of active XR input sources' definition.</span><b><a href="#list-of-active-xr-input-sources">#list-of-active-xr-input-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-active-xr-input-sources">3.2. XRSystem</a>
     <li><a href="#ref-for-list-of-active-xr-input-sources①">4.1. XRSession</a> <a href="#ref-for-list-of-active-xr-input-sources②">(2)</a> <a href="#ref-for-list-of-active-xr-input-sources③">(3)</a> <a href="#ref-for-list-of-active-xr-input-sources④">(4)</a> <a href="#ref-for-list-of-active-xr-input-sources⑤">(5)</a> <a href="#ref-for-list-of-active-xr-input-sources⑥">(6)</a> <a href="#ref-for-list-of-active-xr-input-sources⑦">(7)</a>
@@ -8126,8 +8126,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-list-of-active-xr-input-sources①②">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-xr-device">
-   <b><a href="#xrsession-xr-device">#xrsession-xr-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-xr-device" class="dfn-panel" data-for="xrsession-xr-device" id="infopanel-for-xrsession-xr-device" role="dialog">
+   <span id="infopaneltitle-for-xrsession-xr-device" style="display:none">Info about the 'XR device' definition.</span><b><a href="#xrsession-xr-device">#xrsession-xr-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-xr-device">1.2. Application flow</a>
     <li><a href="#ref-for-xrsession-xr-device①">3.4. Feature Dependencies</a> <a href="#ref-for-xrsession-xr-device②">(2)</a> <a href="#ref-for-xrsession-xr-device③">(3)</a> <a href="#ref-for-xrsession-xr-device④">(4)</a> <a href="#ref-for-xrsession-xr-device⑤">(5)</a>
@@ -8143,93 +8143,93 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrsession-xr-device②⑨">14.2. Permissions API Integration</a> <a href="#ref-for-xrsession-xr-device③⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-inputsources">
-   <b><a href="#dom-xrsession-inputsources">#dom-xrsession-inputsources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-inputsources" class="dfn-panel" data-for="dom-xrsession-inputsources" id="infopanel-for-dom-xrsession-inputsources" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-inputsources" style="display:none">Info about the 'inputSources' definition.</span><b><a href="#dom-xrsession-inputsources">#dom-xrsession-inputsources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-inputsources">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrsession-inputsources①">10.1. XRInputSource</a>
     <li><a href="#ref-for-dom-xrsession-inputsources②">10.3. XRInputSourceArray</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-promise-resolved">
-   <b><a href="#xrsession-promise-resolved">#xrsession-promise-resolved</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-promise-resolved" class="dfn-panel" data-for="xrsession-promise-resolved" id="infopanel-for-xrsession-promise-resolved" role="dialog">
+   <span id="infopaneltitle-for-xrsession-promise-resolved" style="display:none">Info about the 'promise resolved' definition.</span><b><a href="#xrsession-promise-resolved">#xrsession-promise-resolved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-promise-resolved">3.2. XRSystem</a>
     <li><a href="#ref-for-xrsession-promise-resolved①">4.1. XRSession</a> <a href="#ref-for-xrsession-promise-resolved②">(2)</a> <a href="#ref-for-xrsession-promise-resolved③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-add-input-source">
-   <b><a href="#xrsession-add-input-source">#xrsession-add-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-add-input-source" class="dfn-panel" data-for="xrsession-add-input-source" id="infopanel-for-xrsession-add-input-source" role="dialog">
+   <span id="infopaneltitle-for-xrsession-add-input-source" style="display:none">Info about the 'new XR input sources become available' definition.</span><b><a href="#xrsession-add-input-source">#xrsession-add-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-add-input-source">4.1. XRSession</a>
     <li><a href="#ref-for-xrsession-add-input-source①">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-remove-input-source">
-   <b><a href="#xrsession-remove-input-source">#xrsession-remove-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-remove-input-source" class="dfn-panel" data-for="xrsession-remove-input-source" id="infopanel-for-xrsession-remove-input-source" role="dialog">
+   <span id="infopaneltitle-for-xrsession-remove-input-source" style="display:none">Info about the 'XR input sources are no longer available' definition.</span><b><a href="#xrsession-remove-input-source">#xrsession-remove-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-remove-input-source">4.1. XRSession</a>
     <li><a href="#ref-for-xrsession-remove-input-source①">10.2. Transient input</a> <a href="#ref-for-xrsession-remove-input-source②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-change-input-source">
-   <b><a href="#xrsession-change-input-source">#xrsession-change-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-change-input-source" class="dfn-panel" data-for="xrsession-change-input-source" id="infopanel-for-xrsession-change-input-source" role="dialog">
+   <span id="infopaneltitle-for-xrsession-change-input-source" style="display:none">Info about the 'handedness, targetRayMode, profiles, or presence of a gripSpace for any XR input sources change' definition.</span><b><a href="#xrsession-change-input-source">#xrsession-change-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-change-input-source">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-visibility-state">
-   <b><a href="#xrsession-visibility-state">#xrsession-visibility-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-visibility-state" class="dfn-panel" data-for="xrsession-visibility-state" id="infopanel-for-xrsession-visibility-state" role="dialog">
+   <span id="infopaneltitle-for-xrsession-visibility-state" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#xrsession-visibility-state">#xrsession-visibility-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-visibility-state">4.1. XRSession</a> <a href="#ref-for-xrsession-visibility-state①">(2)</a> <a href="#ref-for-xrsession-visibility-state②">(3)</a> <a href="#ref-for-xrsession-visibility-state③">(4)</a> <a href="#ref-for-xrsession-visibility-state④">(5)</a> <a href="#ref-for-xrsession-visibility-state⑤">(6)</a> <a href="#ref-for-xrsession-visibility-state⑥">(7)</a> <a href="#ref-for-xrsession-visibility-state⑦">(8)</a>
     <li><a href="#ref-for-xrsession-visibility-state⑧">12.5. Event Types</a>
     <li><a href="#ref-for-xrsession-visibility-state⑨">13.6. Trusted Environment</a> <a href="#ref-for-xrsession-visibility-state①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrvisibilitystate-visible">
-   <b><a href="#dom-xrvisibilitystate-visible">#dom-xrvisibilitystate-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrvisibilitystate-visible" class="dfn-panel" data-for="dom-xrvisibilitystate-visible" id="infopanel-for-dom-xrvisibilitystate-visible" role="dialog">
+   <span id="infopaneltitle-for-dom-xrvisibilitystate-visible" style="display:none">Info about the 'visible' definition.</span><b><a href="#dom-xrvisibilitystate-visible">#dom-xrvisibilitystate-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible">3.3. XRSessionMode</a>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible①">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible②">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrvisibilitystate-visible-blurred">
-   <b><a href="#dom-xrvisibilitystate-visible-blurred">#dom-xrvisibilitystate-visible-blurred</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrvisibilitystate-visible-blurred" class="dfn-panel" data-for="dom-xrvisibilitystate-visible-blurred" id="infopanel-for-dom-xrvisibilitystate-visible-blurred" role="dialog">
+   <span id="infopaneltitle-for-dom-xrvisibilitystate-visible-blurred" style="display:none">Info about the 'visible-blurred' definition.</span><b><a href="#dom-xrvisibilitystate-visible-blurred">#dom-xrvisibilitystate-visible-blurred</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible-blurred">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrvisibilitystate-visible-blurred①">13.6. Trusted Environment</a> <a href="#ref-for-dom-xrvisibilitystate-visible-blurred②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrvisibilitystate-hidden">
-   <b><a href="#dom-xrvisibilitystate-hidden">#dom-xrvisibilitystate-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrvisibilitystate-hidden" class="dfn-panel" data-for="dom-xrvisibilitystate-hidden" id="infopanel-for-dom-xrvisibilitystate-hidden" role="dialog">
+   <span id="infopaneltitle-for-dom-xrvisibilitystate-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#dom-xrvisibilitystate-hidden">#dom-xrvisibilitystate-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrvisibilitystate-hidden">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrvisibilitystate-hidden①">13.6. Trusted Environment</a> <a href="#ref-for-dom-xrvisibilitystate-hidden②">(2)</a> <a href="#ref-for-dom-xrvisibilitystate-hidden③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-visibilitystate">
-   <b><a href="#dom-xrsession-visibilitystate">#dom-xrsession-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-visibilitystate" class="dfn-panel" data-for="dom-xrsession-visibilitystate" id="infopanel-for-dom-xrsession-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-visibilitystate" style="display:none">Info about the 'visibilityState' definition.</span><b><a href="#dom-xrsession-visibilitystate">#dom-xrsession-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-visibilitystate">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrsession-visibilitystate①">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onvisibilitychange">
-   <b><a href="#dom-xrsession-onvisibilitychange">#dom-xrsession-onvisibilitychange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onvisibilitychange" class="dfn-panel" data-for="dom-xrsession-onvisibilitychange" id="infopanel-for-dom-xrsession-onvisibilitychange" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onvisibilitychange" style="display:none">Info about the 'onvisibilitychange' definition.</span><b><a href="#dom-xrsession-onvisibilitychange">#dom-xrsession-onvisibilitychange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onvisibilitychange">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-viewer-reference-space">
-   <b><a href="#xrsession-viewer-reference-space">#xrsession-viewer-reference-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-viewer-reference-space" class="dfn-panel" data-for="xrsession-viewer-reference-space" id="infopanel-for-xrsession-viewer-reference-space" role="dialog">
+   <span id="infopaneltitle-for-xrsession-viewer-reference-space" style="display:none">Info about the 'viewer reference space' definition.</span><b><a href="#xrsession-viewer-reference-space">#xrsession-viewer-reference-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-viewer-reference-space">5.1. XRFrame</a>
     <li><a href="#ref-for-xrsession-viewer-reference-space①">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-list-of-views">
-   <b><a href="#xrsession-list-of-views">#xrsession-list-of-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-list-of-views" class="dfn-panel" data-for="xrsession-list-of-views" id="infopanel-for-xrsession-list-of-views" role="dialog">
+   <span id="infopaneltitle-for-xrsession-list-of-views" style="display:none">Info about the 'list of views' definition.</span><b><a href="#xrsession-list-of-views">#xrsession-list-of-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-views">4.1. XRSession</a> <a href="#ref-for-xrsession-list-of-views①">(2)</a>
     <li><a href="#ref-for-xrsession-list-of-views②">4.3. Animation Frames</a> <a href="#ref-for-xrsession-list-of-views③">(2)</a>
@@ -8237,99 +8237,99 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrsession-list-of-views⑤">7.1. XRView</a> <a href="#ref-for-xrsession-list-of-views⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onend">
-   <b><a href="#dom-xrsession-onend">#dom-xrsession-onend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onend" class="dfn-panel" data-for="dom-xrsession-onend" id="infopanel-for-dom-xrsession-onend" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onend" style="display:none">Info about the 'onend' definition.</span><b><a href="#dom-xrsession-onend">#dom-xrsession-onend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onend">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-oninputsourceschange">
-   <b><a href="#dom-xrsession-oninputsourceschange">#dom-xrsession-oninputsourceschange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-oninputsourceschange" class="dfn-panel" data-for="dom-xrsession-oninputsourceschange" id="infopanel-for-dom-xrsession-oninputsourceschange" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-oninputsourceschange" style="display:none">Info about the 'oninputsourceschange' definition.</span><b><a href="#dom-xrsession-oninputsourceschange">#dom-xrsession-oninputsourceschange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-oninputsourceschange">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onselectstart">
-   <b><a href="#dom-xrsession-onselectstart">#dom-xrsession-onselectstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onselectstart" class="dfn-panel" data-for="dom-xrsession-onselectstart" id="infopanel-for-dom-xrsession-onselectstart" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onselectstart" style="display:none">Info about the 'onselectstart' definition.</span><b><a href="#dom-xrsession-onselectstart">#dom-xrsession-onselectstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onselectstart">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onselectend">
-   <b><a href="#dom-xrsession-onselectend">#dom-xrsession-onselectend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onselectend" class="dfn-panel" data-for="dom-xrsession-onselectend" id="infopanel-for-dom-xrsession-onselectend" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onselectend" style="display:none">Info about the 'onselectend' definition.</span><b><a href="#dom-xrsession-onselectend">#dom-xrsession-onselectend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onselectend">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onselect">
-   <b><a href="#dom-xrsession-onselect">#dom-xrsession-onselect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onselect" class="dfn-panel" data-for="dom-xrsession-onselect" id="infopanel-for-dom-xrsession-onselect" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onselect" style="display:none">Info about the 'onselect' definition.</span><b><a href="#dom-xrsession-onselect">#dom-xrsession-onselect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onselect">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onsqueezestart">
-   <b><a href="#dom-xrsession-onsqueezestart">#dom-xrsession-onsqueezestart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onsqueezestart" class="dfn-panel" data-for="dom-xrsession-onsqueezestart" id="infopanel-for-dom-xrsession-onsqueezestart" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onsqueezestart" style="display:none">Info about the 'onsqueezestart' definition.</span><b><a href="#dom-xrsession-onsqueezestart">#dom-xrsession-onsqueezestart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onsqueezestart">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onsqueezeend">
-   <b><a href="#dom-xrsession-onsqueezeend">#dom-xrsession-onsqueezeend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onsqueezeend" class="dfn-panel" data-for="dom-xrsession-onsqueezeend" id="infopanel-for-dom-xrsession-onsqueezeend" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onsqueezeend" style="display:none">Info about the 'onsqueezeend' definition.</span><b><a href="#dom-xrsession-onsqueezeend">#dom-xrsession-onsqueezeend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onsqueezeend">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-onsqueeze">
-   <b><a href="#dom-xrsession-onsqueeze">#dom-xrsession-onsqueeze</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-onsqueeze" class="dfn-panel" data-for="dom-xrsession-onsqueeze" id="infopanel-for-dom-xrsession-onsqueeze" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-onsqueeze" style="display:none">Info about the 'onsqueeze' definition.</span><b><a href="#dom-xrsession-onsqueeze">#dom-xrsession-onsqueeze</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-onsqueeze">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrrenderstateinit">
-   <b><a href="#dictdef-xrrenderstateinit">#dictdef-xrrenderstateinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrrenderstateinit" class="dfn-panel" data-for="dictdef-xrrenderstateinit" id="infopanel-for-dictdef-xrrenderstateinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrrenderstateinit" style="display:none">Info about the 'XRRenderStateInit' definition.</span><b><a href="#dictdef-xrrenderstateinit">#dictdef-xrrenderstateinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrrenderstateinit">4.1. XRSession</a> <a href="#ref-for-dictdef-xrrenderstateinit①">(2)</a> <a href="#ref-for-dictdef-xrrenderstateinit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstateinit-depthnear">
-   <b><a href="#dom-xrrenderstateinit-depthnear">#dom-xrrenderstateinit-depthnear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstateinit-depthnear" class="dfn-panel" data-for="dom-xrrenderstateinit-depthnear" id="infopanel-for-dom-xrrenderstateinit-depthnear" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstateinit-depthnear" style="display:none">Info about the 'depthNear' definition.</span><b><a href="#dom-xrrenderstateinit-depthnear">#dom-xrrenderstateinit-depthnear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-depthnear">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstateinit-depthnear①">(2)</a> <a href="#ref-for-dom-xrrenderstateinit-depthnear②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstateinit-depthfar">
-   <b><a href="#dom-xrrenderstateinit-depthfar">#dom-xrrenderstateinit-depthfar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstateinit-depthfar" class="dfn-panel" data-for="dom-xrrenderstateinit-depthfar" id="infopanel-for-dom-xrrenderstateinit-depthfar" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstateinit-depthfar" style="display:none">Info about the 'depthFar' definition.</span><b><a href="#dom-xrrenderstateinit-depthfar">#dom-xrrenderstateinit-depthfar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-depthfar">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstateinit-depthfar①">(2)</a> <a href="#ref-for-dom-xrrenderstateinit-depthfar②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstateinit-inlineverticalfieldofview">
-   <b><a href="#dom-xrrenderstateinit-inlineverticalfieldofview">#dom-xrrenderstateinit-inlineverticalfieldofview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstateinit-inlineverticalfieldofview" class="dfn-panel" data-for="dom-xrrenderstateinit-inlineverticalfieldofview" id="infopanel-for-dom-xrrenderstateinit-inlineverticalfieldofview" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstateinit-inlineverticalfieldofview" style="display:none">Info about the 'inlineVerticalFieldOfView' definition.</span><b><a href="#dom-xrrenderstateinit-inlineverticalfieldofview">#dom-xrrenderstateinit-inlineverticalfieldofview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-inlineverticalfieldofview">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstateinit-inlineverticalfieldofview①">(2)</a> <a href="#ref-for-dom-xrrenderstateinit-inlineverticalfieldofview②">(3)</a> <a href="#ref-for-dom-xrrenderstateinit-inlineverticalfieldofview③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstateinit-baselayer">
-   <b><a href="#dom-xrrenderstateinit-baselayer">#dom-xrrenderstateinit-baselayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstateinit-baselayer" class="dfn-panel" data-for="dom-xrrenderstateinit-baselayer" id="infopanel-for-dom-xrrenderstateinit-baselayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstateinit-baselayer" style="display:none">Info about the 'baseLayer' definition.</span><b><a href="#dom-xrrenderstateinit-baselayer">#dom-xrrenderstateinit-baselayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-baselayer">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstateinit-baselayer①">(2)</a> <a href="#ref-for-dom-xrrenderstateinit-baselayer②">(3)</a> <a href="#ref-for-dom-xrrenderstateinit-baselayer③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstateinit-layers">
-   <b><a href="#dom-xrrenderstateinit-layers">#dom-xrrenderstateinit-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstateinit-layers" class="dfn-panel" data-for="dom-xrrenderstateinit-layers" id="infopanel-for-dom-xrrenderstateinit-layers" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstateinit-layers" style="display:none">Info about the 'layers' definition.</span><b><a href="#dom-xrrenderstateinit-layers">#dom-xrrenderstateinit-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstateinit-layers">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstateinit-layers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrenderstate">
-   <b><a href="#xrrenderstate">#xrrenderstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrenderstate" class="dfn-panel" data-for="xrrenderstate" id="infopanel-for-xrrenderstate" role="dialog">
+   <span id="infopaneltitle-for-xrrenderstate" style="display:none">Info about the 'XRRenderState' definition.</span><b><a href="#xrrenderstate">#xrrenderstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrenderstate">4.1. XRSession</a> <a href="#ref-for-xrrenderstate①">(2)</a> <a href="#ref-for-xrrenderstate②">(3)</a>
     <li><a href="#ref-for-xrrenderstate③">4.2. XRRenderState</a> <a href="#ref-for-xrrenderstate④">(2)</a> <a href="#ref-for-xrrenderstate⑤">(3)</a> <a href="#ref-for-xrrenderstate⑥">(4)</a> <a href="#ref-for-xrrenderstate⑦">(5)</a> <a href="#ref-for-xrrenderstate⑧">(6)</a> <a href="#ref-for-xrrenderstate⑨">(7)</a> <a href="#ref-for-xrrenderstate①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrenderstate-output-canvas">
-   <b><a href="#xrrenderstate-output-canvas">#xrrenderstate-output-canvas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrenderstate-output-canvas" class="dfn-panel" data-for="xrrenderstate-output-canvas" id="infopanel-for-xrrenderstate-output-canvas" role="dialog">
+   <span id="infopaneltitle-for-xrrenderstate-output-canvas" style="display:none">Info about the 'output canvas' definition.</span><b><a href="#xrrenderstate-output-canvas">#xrrenderstate-output-canvas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrenderstate-output-canvas">4.1. XRSession</a> <a href="#ref-for-xrrenderstate-output-canvas①">(2)</a> <a href="#ref-for-xrrenderstate-output-canvas②">(3)</a>
     <li><a href="#ref-for-xrrenderstate-output-canvas③">4.2. XRRenderState</a> <a href="#ref-for-xrrenderstate-output-canvas④">(2)</a> <a href="#ref-for-xrrenderstate-output-canvas⑤">(3)</a> <a href="#ref-for-xrrenderstate-output-canvas⑥">(4)</a> <a href="#ref-for-xrrenderstate-output-canvas⑦">(5)</a>
@@ -8337,44 +8337,44 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrrenderstate-output-canvas⑨">11.2. XRWebGLLayer</a> <a href="#ref-for-xrrenderstate-output-canvas①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrenderstate-composition-enabled">
-   <b><a href="#xrrenderstate-composition-enabled">#xrrenderstate-composition-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrenderstate-composition-enabled" class="dfn-panel" data-for="xrrenderstate-composition-enabled" id="infopanel-for-xrrenderstate-composition-enabled" role="dialog">
+   <span id="infopaneltitle-for-xrrenderstate-composition-enabled" style="display:none">Info about the 'composition enabled' definition.</span><b><a href="#xrrenderstate-composition-enabled">#xrrenderstate-composition-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrenderstate-composition-enabled">4.1. XRSession</a> <a href="#ref-for-xrrenderstate-composition-enabled①">(2)</a> <a href="#ref-for-xrrenderstate-composition-enabled②">(3)</a> <a href="#ref-for-xrrenderstate-composition-enabled③">(4)</a>
     <li><a href="#ref-for-xrrenderstate-composition-enabled④">4.2. XRRenderState</a> <a href="#ref-for-xrrenderstate-composition-enabled⑤">(2)</a> <a href="#ref-for-xrrenderstate-composition-enabled⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-the-render-state">
-   <b><a href="#initialize-the-render-state">#initialize-the-render-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-the-render-state" class="dfn-panel" data-for="initialize-the-render-state" id="infopanel-for-initialize-the-render-state" role="dialog">
+   <span id="infopaneltitle-for-initialize-the-render-state" style="display:none">Info about the 'initialize the render state' definition.</span><b><a href="#initialize-the-render-state">#initialize-the-render-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-the-render-state">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstate-depthnear">
-   <b><a href="#dom-xrrenderstate-depthnear">#dom-xrrenderstate-depthnear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstate-depthnear" class="dfn-panel" data-for="dom-xrrenderstate-depthnear" id="infopanel-for-dom-xrrenderstate-depthnear" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstate-depthnear" style="display:none">Info about the 'depthNear' definition.</span><b><a href="#dom-xrrenderstate-depthnear">#dom-xrrenderstate-depthnear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-depthnear">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstate-depthnear①">(2)</a> <a href="#ref-for-dom-xrrenderstate-depthnear②">(3)</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthnear③">4.2. XRRenderState</a> <a href="#ref-for-dom-xrrenderstate-depthnear④">(2)</a> <a href="#ref-for-dom-xrrenderstate-depthnear⑤">(3)</a> <a href="#ref-for-dom-xrrenderstate-depthnear⑥">(4)</a> <a href="#ref-for-dom-xrrenderstate-depthnear⑦">(5)</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthnear⑧">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstate-depthfar">
-   <b><a href="#dom-xrrenderstate-depthfar">#dom-xrrenderstate-depthfar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstate-depthfar" class="dfn-panel" data-for="dom-xrrenderstate-depthfar" id="infopanel-for-dom-xrrenderstate-depthfar" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstate-depthfar" style="display:none">Info about the 'depthFar' definition.</span><b><a href="#dom-xrrenderstate-depthfar">#dom-xrrenderstate-depthfar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-depthfar">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstate-depthfar①">(2)</a> <a href="#ref-for-dom-xrrenderstate-depthfar②">(3)</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthfar③">4.2. XRRenderState</a> <a href="#ref-for-dom-xrrenderstate-depthfar④">(2)</a> <a href="#ref-for-dom-xrrenderstate-depthfar⑤">(3)</a> <a href="#ref-for-dom-xrrenderstate-depthfar⑥">(4)</a> <a href="#ref-for-dom-xrrenderstate-depthfar⑦">(5)</a>
     <li><a href="#ref-for-dom-xrrenderstate-depthfar⑧">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstate-inlineverticalfieldofview">
-   <b><a href="#dom-xrrenderstate-inlineverticalfieldofview">#dom-xrrenderstate-inlineverticalfieldofview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstate-inlineverticalfieldofview" class="dfn-panel" data-for="dom-xrrenderstate-inlineverticalfieldofview" id="infopanel-for-dom-xrrenderstate-inlineverticalfieldofview" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstate-inlineverticalfieldofview" style="display:none">Info about the 'inlineVerticalFieldOfView' definition.</span><b><a href="#dom-xrrenderstate-inlineverticalfieldofview">#dom-xrrenderstate-inlineverticalfieldofview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview①">(2)</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview②">(3)</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview③">(4)</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview④">(5)</a>
     <li><a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview⑤">4.2. XRRenderState</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview⑥">(2)</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview⑦">(3)</a> <a href="#ref-for-dom-xrrenderstate-inlineverticalfieldofview⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrenderstate-baselayer">
-   <b><a href="#dom-xrrenderstate-baselayer">#dom-xrrenderstate-baselayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrenderstate-baselayer" class="dfn-panel" data-for="dom-xrrenderstate-baselayer" id="infopanel-for-dom-xrrenderstate-baselayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrenderstate-baselayer" style="display:none">Info about the 'baseLayer' definition.</span><b><a href="#dom-xrrenderstate-baselayer">#dom-xrrenderstate-baselayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrenderstate-baselayer">4.1. XRSession</a> <a href="#ref-for-dom-xrrenderstate-baselayer①">(2)</a> <a href="#ref-for-dom-xrrenderstate-baselayer②">(3)</a> <a href="#ref-for-dom-xrrenderstate-baselayer③">(4)</a>
     <li><a href="#ref-for-dom-xrrenderstate-baselayer④">4.2. XRRenderState</a> <a href="#ref-for-dom-xrrenderstate-baselayer⑤">(2)</a>
@@ -8383,40 +8383,40 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrrenderstate-baselayer⑧">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrrenderstate-baselayer⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-xrframerequestcallback">
-   <b><a href="#callbackdef-xrframerequestcallback">#callbackdef-xrframerequestcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-xrframerequestcallback" class="dfn-panel" data-for="callbackdef-xrframerequestcallback" id="infopanel-for-callbackdef-xrframerequestcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-xrframerequestcallback" style="display:none">Info about the 'XRFrameRequestCallback' definition.</span><b><a href="#callbackdef-xrframerequestcallback">#callbackdef-xrframerequestcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-xrframerequestcallback">4.1. XRSession</a>
     <li><a href="#ref-for-callbackdef-xrframerequestcallback①">4.3. Animation Frames</a>
     <li><a href="#ref-for-callbackdef-xrframerequestcallback②">5.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframerequestcallback-cancelled">
-   <b><a href="#xrframerequestcallback-cancelled">#xrframerequestcallback-cancelled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframerequestcallback-cancelled" class="dfn-panel" data-for="xrframerequestcallback-cancelled" id="infopanel-for-xrframerequestcallback-cancelled" role="dialog">
+   <span id="infopaneltitle-for-xrframerequestcallback-cancelled" style="display:none">Info about the 'cancelled' definition.</span><b><a href="#xrframerequestcallback-cancelled">#xrframerequestcallback-cancelled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframerequestcallback-cancelled">4.3. Animation Frames</a> <a href="#ref-for-xrframerequestcallback-cancelled①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-animation-frame-callbacks">
-   <b><a href="#list-of-animation-frame-callbacks">#list-of-animation-frame-callbacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-animation-frame-callbacks" class="dfn-panel" data-for="list-of-animation-frame-callbacks" id="infopanel-for-list-of-animation-frame-callbacks" role="dialog">
+   <span id="infopaneltitle-for-list-of-animation-frame-callbacks" style="display:none">Info about the 'list of animation frame callbacks' definition.</span><b><a href="#list-of-animation-frame-callbacks">#list-of-animation-frame-callbacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-animation-frame-callbacks">4.3. Animation Frames</a> <a href="#ref-for-list-of-animation-frame-callbacks①">(2)</a> <a href="#ref-for-list-of-animation-frame-callbacks②">(3)</a> <a href="#ref-for-list-of-animation-frame-callbacks③">(4)</a> <a href="#ref-for-list-of-animation-frame-callbacks④">(5)</a> <a href="#ref-for-list-of-animation-frame-callbacks⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-currently-running-animation-frame-callbacks">
-   <b><a href="#list-of-currently-running-animation-frame-callbacks">#list-of-currently-running-animation-frame-callbacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-currently-running-animation-frame-callbacks" class="dfn-panel" data-for="list-of-currently-running-animation-frame-callbacks" id="infopanel-for-list-of-currently-running-animation-frame-callbacks" role="dialog">
+   <span id="infopaneltitle-for-list-of-currently-running-animation-frame-callbacks" style="display:none">Info about the 'list of currently running animation frame callbacks' definition.</span><b><a href="#list-of-currently-running-animation-frame-callbacks">#list-of-currently-running-animation-frame-callbacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-currently-running-animation-frame-callbacks">4.3. Animation Frames</a> <a href="#ref-for-list-of-currently-running-animation-frame-callbacks①">(2)</a> <a href="#ref-for-list-of-currently-running-animation-frame-callbacks②">(3)</a> <a href="#ref-for-list-of-currently-running-animation-frame-callbacks③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-frame-callback-identifier">
-   <b><a href="#animation-frame-callback-identifier">#animation-frame-callback-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-frame-callback-identifier" class="dfn-panel" data-for="animation-frame-callback-identifier" id="infopanel-for-animation-frame-callback-identifier" role="dialog">
+   <span id="infopaneltitle-for-animation-frame-callback-identifier" style="display:none">Info about the 'animation frame callback identifier' definition.</span><b><a href="#animation-frame-callback-identifier">#animation-frame-callback-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-frame-callback-identifier">4.3. Animation Frames</a> <a href="#ref-for-animation-frame-callback-identifier①">(2)</a> <a href="#ref-for-animation-frame-callback-identifier②">(3)</a> <a href="#ref-for-animation-frame-callback-identifier③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-requestanimationframe">
-   <b><a href="#dom-xrsession-requestanimationframe">#dom-xrsession-requestanimationframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-requestanimationframe" class="dfn-panel" data-for="dom-xrsession-requestanimationframe" id="infopanel-for-dom-xrsession-requestanimationframe" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' definition.</span><b><a href="#dom-xrsession-requestanimationframe">#dom-xrsession-requestanimationframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe">4.1. XRSession</a> <a href="#ref-for-dom-xrsession-requestanimationframe①">(2)</a> <a href="#ref-for-dom-xrsession-requestanimationframe②">(3)</a> <a href="#ref-for-dom-xrsession-requestanimationframe③">(4)</a>
     <li><a href="#ref-for-dom-xrsession-requestanimationframe④">4.3. Animation Frames</a> <a href="#ref-for-dom-xrsession-requestanimationframe⑤">(2)</a> <a href="#ref-for-dom-xrsession-requestanimationframe⑥">(3)</a> <a href="#ref-for-dom-xrsession-requestanimationframe⑦">(4)</a> <a href="#ref-for-dom-xrsession-requestanimationframe⑧">(5)</a>
@@ -8424,26 +8424,26 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrsession-requestanimationframe①⓪">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrsession-requestanimationframe①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsession-cancelanimationframe">
-   <b><a href="#dom-xrsession-cancelanimationframe">#dom-xrsession-cancelanimationframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsession-cancelanimationframe" class="dfn-panel" data-for="dom-xrsession-cancelanimationframe" id="infopanel-for-dom-xrsession-cancelanimationframe" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsession-cancelanimationframe" style="display:none">Info about the 'cancelAnimationFrame(handle)' definition.</span><b><a href="#dom-xrsession-cancelanimationframe">#dom-xrsession-cancelanimationframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsession-cancelanimationframe">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-the-layers-state">
-   <b><a href="#check-the-layers-state">#check-the-layers-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-the-layers-state" class="dfn-panel" data-for="check-the-layers-state" id="infopanel-for-check-the-layers-state" role="dialog">
+   <span id="infopaneltitle-for-check-the-layers-state" style="display:none">Info about the 'check the layers state' definition.</span><b><a href="#check-the-layers-state">#check-the-layers-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-layers-state">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-be-rendered">
-   <b><a href="#should-be-rendered">#should-be-rendered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-be-rendered" class="dfn-panel" data-for="should-be-rendered" id="infopanel-for-should-be-rendered" role="dialog">
+   <span id="infopaneltitle-for-should-be-rendered" style="display:none">Info about the 'should be rendered' definition.</span><b><a href="#should-be-rendered">#should-be-rendered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-be-rendered">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-animation-frame">
-   <b><a href="#xr-animation-frame">#xr-animation-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-animation-frame" class="dfn-panel" data-for="xr-animation-frame" id="infopanel-for-xr-animation-frame" role="dialog">
+   <span id="infopaneltitle-for-xr-animation-frame" style="display:none">Info about the 'XR animation frame' definition.</span><b><a href="#xr-animation-frame">#xr-animation-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-animation-frame">4.1. XRSession</a>
     <li><a href="#ref-for-xr-animation-frame①">4.3. Animation Frames</a>
@@ -8451,16 +8451,16 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xr-animation-frame⑤">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-compositor">
-   <b><a href="#xr-compositor">#xr-compositor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-compositor" class="dfn-panel" data-for="xr-compositor" id="infopanel-for-xr-compositor" role="dialog">
+   <span id="infopaneltitle-for-xr-compositor" style="display:none">Info about the 'XR Compositor' definition.</span><b><a href="#xr-compositor">#xr-compositor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-compositor">4.2. XRRenderState</a> <a href="#ref-for-xr-compositor①">(2)</a>
     <li><a href="#ref-for-xr-compositor②">11.2. XRWebGLLayer</a> <a href="#ref-for-xr-compositor③">(2)</a> <a href="#ref-for-xr-compositor④">(3)</a> <a href="#ref-for-xr-compositor⑤">(4)</a>
     <li><a href="#ref-for-xr-compositor⑥">13.6. Trusted Environment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe">
-   <b><a href="#xrframe">#xrframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe" class="dfn-panel" data-for="xrframe" id="infopanel-for-xrframe" role="dialog">
+   <span id="infopaneltitle-for-xrframe" style="display:none">Info about the 'XRFrame' definition.</span><b><a href="#xrframe">#xrframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe">4.1. XRSession</a>
     <li><a href="#ref-for-xrframe①">4.3. Animation Frames</a>
@@ -8472,8 +8472,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrframe②⑧">12.2. XRInputSourceEvent</a> <a href="#ref-for-xrframe②⑨">(2)</a> <a href="#ref-for-xrframe③⓪">(3)</a> <a href="#ref-for-xrframe③①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-active">
-   <b><a href="#xrframe-active">#xrframe-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-active" class="dfn-panel" data-for="xrframe-active" id="infopanel-for-xrframe-active" role="dialog">
+   <span id="infopaneltitle-for-xrframe-active" style="display:none">Info about the 'active' definition.</span><b><a href="#xrframe-active">#xrframe-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-active">4.1. XRSession</a>
     <li><a href="#ref-for-xrframe-active①">4.3. Animation Frames</a> <a href="#ref-for-xrframe-active②">(2)</a>
@@ -8482,15 +8482,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrframe-active⑤">12.2. XRInputSourceEvent</a> <a href="#ref-for-xrframe-active⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-animationframe">
-   <b><a href="#xrframe-animationframe">#xrframe-animationframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-animationframe" class="dfn-panel" data-for="xrframe-animationframe" id="infopanel-for-xrframe-animationframe" role="dialog">
+   <span id="infopaneltitle-for-xrframe-animationframe" style="display:none">Info about the 'animationFrame' definition.</span><b><a href="#xrframe-animationframe">#xrframe-animationframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-animationframe">4.1. XRSession</a>
     <li><a href="#ref-for-xrframe-animationframe①">5.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-session">
-   <b><a href="#dom-xrframe-session">#dom-xrframe-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-session" class="dfn-panel" data-for="dom-xrframe-session" id="infopanel-for-dom-xrframe-session" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-session" style="display:none">Info about the 'session' definition.</span><b><a href="#dom-xrframe-session">#dom-xrframe-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-session">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrframe-session①">5.1. XRFrame</a> <a href="#ref-for-dom-xrframe-session②">(2)</a> <a href="#ref-for-dom-xrframe-session③">(3)</a> <a href="#ref-for-dom-xrframe-session④">(4)</a>
@@ -8500,8 +8500,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrframe-session①⑤">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-time">
-   <b><a href="#xrframe-time">#xrframe-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-time" class="dfn-panel" data-for="xrframe-time" id="infopanel-for-xrframe-time" role="dialog">
+   <span id="infopaneltitle-for-xrframe-time" style="display:none">Info about the 'time' definition.</span><b><a href="#xrframe-time">#xrframe-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-time">4.3. Animation Frames</a>
     <li><a href="#ref-for-xrframe-time①">5.1. XRFrame</a> <a href="#ref-for-xrframe-time②">(2)</a>
@@ -8509,8 +8509,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrframe-time④">10.1. XRInputSource</a> <a href="#ref-for-xrframe-time⑤">(2)</a> <a href="#ref-for-xrframe-time⑥">(3)</a> <a href="#ref-for-xrframe-time⑦">(4)</a> <a href="#ref-for-xrframe-time⑧">(5)</a> <a href="#ref-for-xrframe-time⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-getviewerpose">
-   <b><a href="#dom-xrframe-getviewerpose">#dom-xrframe-getviewerpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-getviewerpose" class="dfn-panel" data-for="dom-xrframe-getviewerpose" id="infopanel-for-dom-xrframe-getviewerpose" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-getviewerpose" style="display:none">Info about the 'getViewerPose(referenceSpace)' definition.</span><b><a href="#dom-xrframe-getviewerpose">#dom-xrframe-getviewerpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getviewerpose">4.1. XRSession</a> <a href="#ref-for-dom-xrframe-getviewerpose①">(2)</a>
     <li><a href="#ref-for-dom-xrframe-getviewerpose②">5.1. XRFrame</a>
@@ -8518,34 +8518,34 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrframe-getviewerpose④">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrframe-getpose">
-   <b><a href="#dom-xrframe-getpose">#dom-xrframe-getpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrframe-getpose" class="dfn-panel" data-for="dom-xrframe-getpose" id="infopanel-for-dom-xrframe-getpose" role="dialog">
+   <span id="infopaneltitle-for-dom-xrframe-getpose" style="display:none">Info about the 'getPose(space, baseSpace)' definition.</span><b><a href="#dom-xrframe-getpose">#dom-xrframe-getpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrframe-getpose">5.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrframe-getpose①">6.1. XRSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-update">
-   <b><a href="#frame-update">#frame-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-update" class="dfn-panel" data-for="frame-update" id="infopanel-for-frame-update" role="dialog">
+   <span id="infopaneltitle-for-frame-update" style="display:none">Info about the 'frame update' definition.</span><b><a href="#frame-update">#frame-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-update">5.1. XRFrame</a> <a href="#ref-for-frame-update①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsession-list-of-frame-updates">
-   <b><a href="#xrsession-list-of-frame-updates">#xrsession-list-of-frame-updates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsession-list-of-frame-updates" class="dfn-panel" data-for="xrsession-list-of-frame-updates" id="infopanel-for-xrsession-list-of-frame-updates" role="dialog">
+   <span id="infopaneltitle-for-xrsession-list-of-frame-updates" style="display:none">Info about the 'list of frame updates' definition.</span><b><a href="#xrsession-list-of-frame-updates">#xrsession-list-of-frame-updates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsession-list-of-frame-updates">5.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrframe-apply-frame-updates">
-   <b><a href="#xrframe-apply-frame-updates">#xrframe-apply-frame-updates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrframe-apply-frame-updates" class="dfn-panel" data-for="xrframe-apply-frame-updates" id="infopanel-for-xrframe-apply-frame-updates" role="dialog">
+   <span id="infopaneltitle-for-xrframe-apply-frame-updates" style="display:none">Info about the 'apply frame updates' definition.</span><b><a href="#xrframe-apply-frame-updates">#xrframe-apply-frame-updates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrframe-apply-frame-updates">4.3. Animation Frames</a>
     <li><a href="#ref-for-xrframe-apply-frame-updates①">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace">
-   <b><a href="#xrspace">#xrspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace" class="dfn-panel" data-for="xrspace" id="infopanel-for-xrspace" role="dialog">
+   <span id="infopaneltitle-for-xrspace" style="display:none">Info about the 'XRSpace' definition.</span><b><a href="#xrspace">#xrspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace">5.1. XRFrame</a> <a href="#ref-for-xrspace①">(2)</a>
     <li><a href="#ref-for-xrspace②">6.1. XRSpace</a> <a href="#ref-for-xrspace③">(2)</a> <a href="#ref-for-xrspace④">(3)</a> <a href="#ref-for-xrspace⑤">(4)</a> <a href="#ref-for-xrspace⑥">(5)</a> <a href="#ref-for-xrspace⑦">(6)</a> <a href="#ref-for-xrspace⑧">(7)</a> <a href="#ref-for-xrspace⑨">(8)</a> <a href="#ref-for-xrspace①⓪">(9)</a> <a href="#ref-for-xrspace①①">(10)</a> <a href="#ref-for-xrspace①②">(11)</a> <a href="#ref-for-xrspace①③">(12)</a> <a href="#ref-for-xrspace①④">(13)</a> <a href="#ref-for-xrspace①⑤">(14)</a>
@@ -8554,15 +8554,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrspace②②">10.1. XRInputSource</a> <a href="#ref-for-xrspace②③">(2)</a> <a href="#ref-for-xrspace②④">(3)</a> <a href="#ref-for-xrspace②⑤">(4)</a> <a href="#ref-for-xrspace②⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace-session">
-   <b><a href="#xrspace-session">#xrspace-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace-session" class="dfn-panel" data-for="xrspace-session" id="infopanel-for-xrspace-session" role="dialog">
+   <span id="infopaneltitle-for-xrspace-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrspace-session">#xrspace-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-session">6.1. XRSpace</a> <a href="#ref-for-xrspace-session①">(2)</a>
     <li><a href="#ref-for-xrspace-session②">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace-native-origin">
-   <b><a href="#xrspace-native-origin">#xrspace-native-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace-native-origin" class="dfn-panel" data-for="xrspace-native-origin" id="infopanel-for-xrspace-native-origin" role="dialog">
+   <span id="infopaneltitle-for-xrspace-native-origin" style="display:none">Info about the 'native origin' definition.</span><b><a href="#xrspace-native-origin">#xrspace-native-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-native-origin">6.1. XRSpace</a> <a href="#ref-for-xrspace-native-origin①">(2)</a> <a href="#ref-for-xrspace-native-origin②">(3)</a> <a href="#ref-for-xrspace-native-origin③">(4)</a>
     <li><a href="#ref-for-xrspace-native-origin④">6.2. XRReferenceSpace</a> <a href="#ref-for-xrspace-native-origin⑤">(2)</a> <a href="#ref-for-xrspace-native-origin⑥">(3)</a> <a href="#ref-for-xrspace-native-origin⑦">(4)</a> <a href="#ref-for-xrspace-native-origin⑧">(5)</a> <a href="#ref-for-xrspace-native-origin⑨">(6)</a> <a href="#ref-for-xrspace-native-origin①⓪">(7)</a>
@@ -8573,23 +8573,23 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrspace-native-origin②⓪">13.5.3. Reference spaces</a> <a href="#ref-for-xrspace-native-origin②①">(2)</a> <a href="#ref-for-xrspace-native-origin②②">(3)</a> <a href="#ref-for-xrspace-native-origin②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace-effective-origin">
-   <b><a href="#xrspace-effective-origin">#xrspace-effective-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace-effective-origin" class="dfn-panel" data-for="xrspace-effective-origin" id="infopanel-for-xrspace-effective-origin" role="dialog">
+   <span id="infopaneltitle-for-xrspace-effective-origin" style="display:none">Info about the 'effective origin' definition.</span><b><a href="#xrspace-effective-origin">#xrspace-effective-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-effective-origin">6.1. XRSpace</a> <a href="#ref-for-xrspace-effective-origin①">(2)</a> <a href="#ref-for-xrspace-effective-origin②">(3)</a> <a href="#ref-for-xrspace-effective-origin③">(4)</a> <a href="#ref-for-xrspace-effective-origin④">(5)</a> <a href="#ref-for-xrspace-effective-origin⑤">(6)</a> <a href="#ref-for-xrspace-effective-origin⑥">(7)</a> <a href="#ref-for-xrspace-effective-origin⑦">(8)</a> <a href="#ref-for-xrspace-effective-origin⑧">(9)</a> <a href="#ref-for-xrspace-effective-origin⑨">(10)</a>
     <li><a href="#ref-for-xrspace-effective-origin①⓪">6.3. XRBoundedReferenceSpace</a>
     <li><a href="#ref-for-xrspace-effective-origin①①">12.5. Event Types</a> <a href="#ref-for-xrspace-effective-origin①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace-coordinate-system">
-   <b><a href="#xrspace-coordinate-system">#xrspace-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace-coordinate-system" class="dfn-panel" data-for="xrspace-coordinate-system" id="infopanel-for-xrspace-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-xrspace-coordinate-system" style="display:none">Info about the 'coordinate system' definition.</span><b><a href="#xrspace-coordinate-system">#xrspace-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-coordinate-system">6.1. XRSpace</a> <a href="#ref-for-xrspace-coordinate-system①">(2)</a> <a href="#ref-for-xrspace-coordinate-system②">(3)</a> <a href="#ref-for-xrspace-coordinate-system③">(4)</a> <a href="#ref-for-xrspace-coordinate-system④">(5)</a> <a href="#ref-for-xrspace-coordinate-system⑤">(6)</a> <a href="#ref-for-xrspace-coordinate-system⑥">(7)</a> <a href="#ref-for-xrspace-coordinate-system⑦">(8)</a>
     <li><a href="#ref-for-xrspace-coordinate-system⑧">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrspace-origin-offset">
-   <b><a href="#xrspace-origin-offset">#xrspace-origin-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrspace-origin-offset" class="dfn-panel" data-for="xrspace-origin-offset" id="infopanel-for-xrspace-origin-offset" role="dialog">
+   <span id="infopaneltitle-for-xrspace-origin-offset" style="display:none">Info about the 'origin offset' definition.</span><b><a href="#xrspace-origin-offset">#xrspace-origin-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrspace-origin-offset">4.1. XRSession</a>
     <li><a href="#ref-for-xrspace-origin-offset①">6.1. XRSpace</a>
@@ -8597,22 +8597,22 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrspace-origin-offset④">6.3. XRBoundedReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="populate-the-pose">
-   <b><a href="#populate-the-pose">#populate-the-pose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-populate-the-pose" class="dfn-panel" data-for="populate-the-pose" id="infopanel-for-populate-the-pose" role="dialog">
+   <span id="infopaneltitle-for-populate-the-pose" style="display:none">Info about the 'populate the pose' definition.</span><b><a href="#populate-the-pose">#populate-the-pose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-populate-the-pose">5.1. XRFrame</a> <a href="#ref-for-populate-the-pose①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrreferencespacetype">
-   <b><a href="#enumdef-xrreferencespacetype">#enumdef-xrreferencespacetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrreferencespacetype" class="dfn-panel" data-for="enumdef-xrreferencespacetype" id="infopanel-for-enumdef-xrreferencespacetype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrreferencespacetype" style="display:none">Info about the 'XRReferenceSpaceType' definition.</span><b><a href="#enumdef-xrreferencespacetype">#enumdef-xrreferencespacetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrreferencespacetype">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-enumdef-xrreferencespacetype①">4.1. XRSession</a>
     <li><a href="#ref-for-enumdef-xrreferencespacetype②">6.2. XRReferenceSpace</a> <a href="#ref-for-enumdef-xrreferencespacetype③">(2)</a> <a href="#ref-for-enumdef-xrreferencespacetype④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrreferencespace">
-   <b><a href="#xrreferencespace">#xrreferencespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrreferencespace" class="dfn-panel" data-for="xrreferencespace" id="infopanel-for-xrreferencespace" role="dialog">
+   <span id="infopaneltitle-for-xrreferencespace" style="display:none">Info about the 'XRReferenceSpace' definition.</span><b><a href="#xrreferencespace">#xrreferencespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrreferencespace">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-xrreferencespace①">4.1. XRSession</a> <a href="#ref-for-xrreferencespace②">(2)</a> <a href="#ref-for-xrreferencespace③">(3)</a>
@@ -8628,15 +8628,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrreferencespace③⑧">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrreferencespace-type">
-   <b><a href="#xrreferencespace-type">#xrreferencespace-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrreferencespace-type" class="dfn-panel" data-for="xrreferencespace-type" id="infopanel-for-xrreferencespace-type" role="dialog">
+   <span id="infopaneltitle-for-xrreferencespace-type" style="display:none">Info about the 'type' definition.</span><b><a href="#xrreferencespace-type">#xrreferencespace-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrreferencespace-type">6.2. XRReferenceSpace</a> <a href="#ref-for-xrreferencespace-type①">(2)</a> <a href="#ref-for-xrreferencespace-type②">(3)</a>
     <li><a href="#ref-for-xrreferencespace-type③">13.5.3. Reference spaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespacetype-viewer">
-   <b><a href="#dom-xrreferencespacetype-viewer">#dom-xrreferencespacetype-viewer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespacetype-viewer" class="dfn-panel" data-for="dom-xrreferencespacetype-viewer" id="infopanel-for-dom-xrreferencespacetype-viewer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespacetype-viewer" style="display:none">Info about the 'viewer' definition.</span><b><a href="#dom-xrreferencespacetype-viewer">#dom-xrreferencespacetype-viewer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer①">4.1. XRSession</a>
@@ -8644,31 +8644,31 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrreferencespacetype-viewer⑥">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespacetype-local">
-   <b><a href="#dom-xrreferencespacetype-local">#dom-xrreferencespacetype-local</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespacetype-local" class="dfn-panel" data-for="dom-xrreferencespacetype-local" id="infopanel-for-dom-xrreferencespacetype-local" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespacetype-local" style="display:none">Info about the 'local' definition.</span><b><a href="#dom-xrreferencespacetype-local">#dom-xrreferencespacetype-local</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-local">3.4. Feature Dependencies</a> <a href="#ref-for-dom-xrreferencespacetype-local①">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local②">(3)</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-local③">6.2. XRReferenceSpace</a> <a href="#ref-for-dom-xrreferencespacetype-local④">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local⑤">(3)</a> <a href="#ref-for-dom-xrreferencespacetype-local⑥">(4)</a> <a href="#ref-for-dom-xrreferencespacetype-local⑦">(5)</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-local⑧">13.5.3. Reference spaces</a> <a href="#ref-for-dom-xrreferencespacetype-local⑨">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local①⓪">(3)</a> <a href="#ref-for-dom-xrreferencespacetype-local①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespacetype-local-floor">
-   <b><a href="#dom-xrreferencespacetype-local-floor">#dom-xrreferencespacetype-local-floor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespacetype-local-floor" class="dfn-panel" data-for="dom-xrreferencespacetype-local-floor" id="infopanel-for-dom-xrreferencespacetype-local-floor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespacetype-local-floor" style="display:none">Info about the 'local-floor' definition.</span><b><a href="#dom-xrreferencespacetype-local-floor">#dom-xrreferencespacetype-local-floor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-local-floor">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-local-floor①">6.2. XRReferenceSpace</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor②">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor③">(3)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor④">(4)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor⑤">(5)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor⑥">(6)</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-local-floor⑦">13.5.3. Reference spaces</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor⑧">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor⑨">(3)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor①⓪">(4)</a> <a href="#ref-for-dom-xrreferencespacetype-local-floor①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="estimated-floor-level">
-   <b><a href="#estimated-floor-level">#estimated-floor-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-estimated-floor-level" class="dfn-panel" data-for="estimated-floor-level" id="infopanel-for-estimated-floor-level" role="dialog">
+   <span id="infopaneltitle-for-estimated-floor-level" style="display:none">Info about the 'estimated floor level' definition.</span><b><a href="#estimated-floor-level">#estimated-floor-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-estimated-floor-level">6.2. XRReferenceSpace</a>
     <li><a href="#ref-for-estimated-floor-level①">9.1. XRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespacetype-bounded-floor">
-   <b><a href="#dom-xrreferencespacetype-bounded-floor">#dom-xrreferencespacetype-bounded-floor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespacetype-bounded-floor" class="dfn-panel" data-for="dom-xrreferencespacetype-bounded-floor" id="infopanel-for-dom-xrreferencespacetype-bounded-floor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespacetype-bounded-floor" style="display:none">Info about the 'bounded-floor' definition.</span><b><a href="#dom-xrreferencespacetype-bounded-floor">#dom-xrreferencespacetype-bounded-floor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-bounded-floor">3.4. Feature Dependencies</a> <a href="#ref-for-dom-xrreferencespacetype-bounded-floor①">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-bounded-floor②">(3)</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-bounded-floor③">4.1. XRSession</a>
@@ -8677,8 +8677,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrreferencespacetype-bounded-floor⑨">13.5.3. Reference spaces</a> <a href="#ref-for-dom-xrreferencespacetype-bounded-floor①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespacetype-unbounded">
-   <b><a href="#dom-xrreferencespacetype-unbounded">#dom-xrreferencespacetype-unbounded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespacetype-unbounded" class="dfn-panel" data-for="dom-xrreferencespacetype-unbounded" id="infopanel-for-dom-xrreferencespacetype-unbounded" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespacetype-unbounded" style="display:none">Info about the 'unbounded' definition.</span><b><a href="#dom-xrreferencespacetype-unbounded">#dom-xrreferencespacetype-unbounded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespacetype-unbounded">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-dom-xrreferencespacetype-unbounded①">6.2. XRReferenceSpace</a> <a href="#ref-for-dom-xrreferencespacetype-unbounded②">(2)</a> <a href="#ref-for-dom-xrreferencespacetype-unbounded③">(3)</a> <a href="#ref-for-dom-xrreferencespacetype-unbounded④">(4)</a>
@@ -8687,34 +8687,34 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrreferencespacetype-unbounded⑦">13.5.3. Reference spaces</a> <a href="#ref-for-dom-xrreferencespacetype-unbounded⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespace-onreset">
-   <b><a href="#dom-xrreferencespace-onreset">#dom-xrreferencespace-onreset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespace-onreset" class="dfn-panel" data-for="dom-xrreferencespace-onreset" id="infopanel-for-dom-xrreferencespace-onreset" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespace-onreset" style="display:none">Info about the 'onreset' definition.</span><b><a href="#dom-xrreferencespace-onreset">#dom-xrreferencespace-onreset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespace-onreset">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-reference-space">
-   <b><a href="#create-a-reference-space">#create-a-reference-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-reference-space" class="dfn-panel" data-for="create-a-reference-space" id="infopanel-for-create-a-reference-space" role="dialog">
+   <span id="infopaneltitle-for-create-a-reference-space" style="display:none">Info about the 'create a reference space' definition.</span><b><a href="#create-a-reference-space">#create-a-reference-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-reference-space">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reference-space-is-supported">
-   <b><a href="#reference-space-is-supported">#reference-space-is-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reference-space-is-supported" class="dfn-panel" data-for="reference-space-is-supported" id="infopanel-for-reference-space-is-supported" role="dialog">
+   <span id="infopaneltitle-for-reference-space-is-supported" style="display:none">Info about the 'reference space is supported' definition.</span><b><a href="#reference-space-is-supported">#reference-space-is-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-space-is-supported">4.1. XRSession</a>
     <li><a href="#ref-for-reference-space-is-supported①">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespace-getoffsetreferencespace">
-   <b><a href="#dom-xrreferencespace-getoffsetreferencespace">#dom-xrreferencespace-getoffsetreferencespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespace-getoffsetreferencespace" class="dfn-panel" data-for="dom-xrreferencespace-getoffsetreferencespace" id="infopanel-for-dom-xrreferencespace-getoffsetreferencespace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespace-getoffsetreferencespace" style="display:none">Info about the 'getOffsetReferenceSpace(originOffset)' definition.</span><b><a href="#dom-xrreferencespace-getoffsetreferencespace">#dom-xrreferencespace-getoffsetreferencespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespace-getoffsetreferencespace">6.2. XRReferenceSpace</a> <a href="#ref-for-dom-xrreferencespace-getoffsetreferencespace①">(2)</a> <a href="#ref-for-dom-xrreferencespace-getoffsetreferencespace②">(3)</a> <a href="#ref-for-dom-xrreferencespace-getoffsetreferencespace③">(4)</a>
     <li><a href="#ref-for-dom-xrreferencespace-getoffsetreferencespace④">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrboundedreferencespace">
-   <b><a href="#xrboundedreferencespace">#xrboundedreferencespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrboundedreferencespace" class="dfn-panel" data-for="xrboundedreferencespace" id="infopanel-for-xrboundedreferencespace" role="dialog">
+   <span id="infopaneltitle-for-xrboundedreferencespace" style="display:none">Info about the 'XRBoundedReferenceSpace' definition.</span><b><a href="#xrboundedreferencespace">#xrboundedreferencespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrboundedreferencespace">6.2. XRReferenceSpace</a> <a href="#ref-for-xrboundedreferencespace①">(2)</a> <a href="#ref-for-xrboundedreferencespace②">(3)</a> <a href="#ref-for-xrboundedreferencespace③">(4)</a>
     <li><a href="#ref-for-xrboundedreferencespace④">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-xrboundedreferencespace⑤">(2)</a> <a href="#ref-for-xrboundedreferencespace⑥">(3)</a> <a href="#ref-for-xrboundedreferencespace⑦">(4)</a> <a href="#ref-for-xrboundedreferencespace⑧">(5)</a> <a href="#ref-for-xrboundedreferencespace⑨">(6)</a> <a href="#ref-for-xrboundedreferencespace①⓪">(7)</a>
@@ -8722,29 +8722,29 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrboundedreferencespace①③">13.5.3. Reference spaces</a> <a href="#ref-for-xrboundedreferencespace①④">(2)</a> <a href="#ref-for-xrboundedreferencespace①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrboundedreferencespace-native-bounds-geometry">
-   <b><a href="#xrboundedreferencespace-native-bounds-geometry">#xrboundedreferencespace-native-bounds-geometry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrboundedreferencespace-native-bounds-geometry" class="dfn-panel" data-for="xrboundedreferencespace-native-bounds-geometry" id="infopanel-for-xrboundedreferencespace-native-bounds-geometry" role="dialog">
+   <span id="infopaneltitle-for-xrboundedreferencespace-native-bounds-geometry" style="display:none">Info about the 'native bounds geometry' definition.</span><b><a href="#xrboundedreferencespace-native-bounds-geometry">#xrboundedreferencespace-native-bounds-geometry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrboundedreferencespace-native-bounds-geometry">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry①">(2)</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry②">(3)</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry③">(4)</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry④">(5)</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry⑤">(6)</a>
     <li><a href="#ref-for-xrboundedreferencespace-native-bounds-geometry⑥">13.5.3. Reference spaces</a> <a href="#ref-for-xrboundedreferencespace-native-bounds-geometry⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrboundedreferencespace-boundsgeometry">
-   <b><a href="#dom-xrboundedreferencespace-boundsgeometry">#dom-xrboundedreferencespace-boundsgeometry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrboundedreferencespace-boundsgeometry" class="dfn-panel" data-for="dom-xrboundedreferencespace-boundsgeometry" id="infopanel-for-dom-xrboundedreferencespace-boundsgeometry" role="dialog">
+   <span id="infopaneltitle-for-dom-xrboundedreferencespace-boundsgeometry" style="display:none">Info about the 'boundsGeometry' definition.</span><b><a href="#dom-xrboundedreferencespace-boundsgeometry">#dom-xrboundedreferencespace-boundsgeometry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry">6.2. XRReferenceSpace</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry①">(2)</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry②">(3)</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry③">(4)</a>
     <li><a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry④">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry⑤">(2)</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry⑥">(3)</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry⑦">(4)</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry⑧">(5)</a>
     <li><a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry⑨">12.5. Event Types</a> <a href="#ref-for-dom-xrboundedreferencespace-boundsgeometry①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bounded-reference-spaces-are-supported">
-   <b><a href="#bounded-reference-spaces-are-supported">#bounded-reference-spaces-are-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bounded-reference-spaces-are-supported" class="dfn-panel" data-for="bounded-reference-spaces-are-supported" id="infopanel-for-bounded-reference-spaces-are-supported" role="dialog">
+   <span id="infopaneltitle-for-bounded-reference-spaces-are-supported" style="display:none">Info about the 'bounded reference spaces are supported' definition.</span><b><a href="#bounded-reference-spaces-are-supported">#bounded-reference-spaces-are-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bounded-reference-spaces-are-supported">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view">
-   <b><a href="#view">#view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view" class="dfn-panel" data-for="view" id="infopanel-for-view" role="dialog">
+   <span id="infopaneltitle-for-view" style="display:none">Info about the 'view' definition.</span><b><a href="#view">#view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view">2.1. XR device</a>
     <li><a href="#ref-for-view①">3.3. XRSessionMode</a>
@@ -8757,28 +8757,28 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-view③④">11.2. XRWebGLLayer</a> <a href="#ref-for-view③⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-offset">
-   <b><a href="#view-offset">#view-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-offset" class="dfn-panel" data-for="view-offset" id="infopanel-for-view-offset" role="dialog">
+   <span id="infopaneltitle-for-view-offset" style="display:none">Info about the 'view offset' definition.</span><b><a href="#view-offset">#view-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-offset">5.1. XRFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-projection-matrix">
-   <b><a href="#view-projection-matrix">#view-projection-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-projection-matrix" class="dfn-panel" data-for="view-projection-matrix" id="infopanel-for-view-projection-matrix" role="dialog">
+   <span id="infopaneltitle-for-view-projection-matrix" style="display:none">Info about the 'projection matrix' definition.</span><b><a href="#view-projection-matrix">#view-projection-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-projection-matrix">7.1. XRView</a> <a href="#ref-for-view-projection-matrix①">(2)</a> <a href="#ref-for-view-projection-matrix②">(3)</a> <a href="#ref-for-view-projection-matrix③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-eye">
-   <b><a href="#view-eye">#view-eye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-eye" class="dfn-panel" data-for="view-eye" id="infopanel-for-view-eye" role="dialog">
+   <span id="infopaneltitle-for-view-eye" style="display:none">Info about the 'eye' definition.</span><b><a href="#view-eye">#view-eye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-eye">5.1. XRFrame</a>
     <li><a href="#ref-for-view-eye①">7.1. XRView</a>
     <li><a href="#ref-for-view-eye②">7.2. Primary and Secondary Views</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-active">
-   <b><a href="#view-active">#view-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-active" class="dfn-panel" data-for="view-active" id="infopanel-for-view-active" role="dialog">
+   <span id="infopaneltitle-for-view-active" style="display:none">Info about the 'active' definition.</span><b><a href="#view-active">#view-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-active">4.1. XRSession</a>
     <li><a href="#ref-for-view-active①">4.3. Animation Frames</a>
@@ -8788,41 +8788,41 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-view-active⑧">11.2. XRWebGLLayer</a> <a href="#ref-for-view-active⑨">(2)</a> <a href="#ref-for-view-active①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-viewport-modifiable">
-   <b><a href="#view-viewport-modifiable">#view-viewport-modifiable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-viewport-modifiable" class="dfn-panel" data-for="view-viewport-modifiable" id="infopanel-for-view-viewport-modifiable" role="dialog">
+   <span id="infopaneltitle-for-view-viewport-modifiable" style="display:none">Info about the 'viewport modifiable' definition.</span><b><a href="#view-viewport-modifiable">#view-viewport-modifiable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-viewport-modifiable">4.3. Animation Frames</a>
     <li><a href="#ref-for-view-viewport-modifiable①">11.2. XRWebGLLayer</a> <a href="#ref-for-view-viewport-modifiable②">(2)</a> <a href="#ref-for-view-viewport-modifiable③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-requested-viewport-scale">
-   <b><a href="#view-requested-viewport-scale">#view-requested-viewport-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-requested-viewport-scale" class="dfn-panel" data-for="view-requested-viewport-scale" id="infopanel-for-view-requested-viewport-scale" role="dialog">
+   <span id="infopaneltitle-for-view-requested-viewport-scale" style="display:none">Info about the 'requested viewport scale' definition.</span><b><a href="#view-requested-viewport-scale">#view-requested-viewport-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-requested-viewport-scale">7.1. XRView</a> <a href="#ref-for-view-requested-viewport-scale①">(2)</a> <a href="#ref-for-view-requested-viewport-scale②">(3)</a>
     <li><a href="#ref-for-view-requested-viewport-scale③">11.2. XRWebGLLayer</a> <a href="#ref-for-view-requested-viewport-scale④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="view-current-viewport-scale">
-   <b><a href="#view-current-viewport-scale">#view-current-viewport-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-view-current-viewport-scale" class="dfn-panel" data-for="view-current-viewport-scale" id="infopanel-for-view-current-viewport-scale" role="dialog">
+   <span id="infopaneltitle-for-view-current-viewport-scale" style="display:none">Info about the 'current viewport scale' definition.</span><b><a href="#view-current-viewport-scale">#view-current-viewport-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-view-current-viewport-scale">7.1. XRView</a>
     <li><a href="#ref-for-view-current-viewport-scale①">11.2. XRWebGLLayer</a> <a href="#ref-for-view-current-viewport-scale②">(2)</a> <a href="#ref-for-view-current-viewport-scale③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xreye">
-   <b><a href="#enumdef-xreye">#enumdef-xreye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xreye" class="dfn-panel" data-for="enumdef-xreye" id="infopanel-for-enumdef-xreye" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xreye" style="display:none">Info about the 'XREye' definition.</span><b><a href="#enumdef-xreye">#enumdef-xreye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xreye">7.1. XRView</a> <a href="#ref-for-enumdef-xreye①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xreye-none">
-   <b><a href="#dom-xreye-none">#dom-xreye-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xreye-none" class="dfn-panel" data-for="dom-xreye-none" id="infopanel-for-dom-xreye-none" role="dialog">
+   <span id="infopaneltitle-for-dom-xreye-none" style="display:none">Info about the '"none"' definition.</span><b><a href="#dom-xreye-none">#dom-xreye-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xreye-none">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview">
-   <b><a href="#xrview">#xrview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview" class="dfn-panel" data-for="xrview" id="infopanel-for-xrview" role="dialog">
+   <span id="infopaneltitle-for-xrview" style="display:none">Info about the 'XRView' definition.</span><b><a href="#xrview">#xrview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview">4.2. XRRenderState</a>
     <li><a href="#ref-for-xrview①">5.1. XRFrame</a>
@@ -8833,110 +8833,110 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrview②⓪">13.5.2. Poses</a> <a href="#ref-for-xrview②①">(2)</a> <a href="#ref-for-xrview②②">(3)</a> <a href="#ref-for-xrview②③">(4)</a> <a href="#ref-for-xrview②④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-eye">
-   <b><a href="#dom-xrview-eye">#dom-xrview-eye</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-eye" class="dfn-panel" data-for="dom-xrview-eye" id="infopanel-for-dom-xrview-eye" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-eye" style="display:none">Info about the 'eye' definition.</span><b><a href="#dom-xrview-eye">#dom-xrview-eye</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-eye">5.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrview-eye①">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-projectionmatrix">
-   <b><a href="#dom-xrview-projectionmatrix">#dom-xrview-projectionmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-projectionmatrix" class="dfn-panel" data-for="dom-xrview-projectionmatrix" id="infopanel-for-dom-xrview-projectionmatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-projectionmatrix" style="display:none">Info about the 'projectionMatrix' definition.</span><b><a href="#dom-xrview-projectionmatrix">#dom-xrview-projectionmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-projectionmatrix">4.2. XRRenderState</a> <a href="#ref-for-dom-xrview-projectionmatrix①">(2)</a>
     <li><a href="#ref-for-dom-xrview-projectionmatrix②">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-transform">
-   <b><a href="#dom-xrview-transform">#dom-xrview-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-transform" class="dfn-panel" data-for="dom-xrview-transform" id="infopanel-for-dom-xrview-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrview-transform">#dom-xrview-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-transform">5.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrview-transform①">7.1. XRView</a> <a href="#ref-for-dom-xrview-transform②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-recommendedviewportscale">
-   <b><a href="#dom-xrview-recommendedviewportscale">#dom-xrview-recommendedviewportscale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-recommendedviewportscale" class="dfn-panel" data-for="dom-xrview-recommendedviewportscale" id="infopanel-for-dom-xrview-recommendedviewportscale" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-recommendedviewportscale" style="display:none">Info about the 'recommendedViewportScale' definition.</span><b><a href="#dom-xrview-recommendedviewportscale">#dom-xrview-recommendedviewportscale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-recommendedviewportscale">7.1. XRView</a> <a href="#ref-for-dom-xrview-recommendedviewportscale①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-session">
-   <b><a href="#xrview-session">#xrview-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-session" class="dfn-panel" data-for="xrview-session" id="infopanel-for-xrview-session" role="dialog">
+   <span id="infopaneltitle-for-xrview-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrview-session">#xrview-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-session">5.1. XRFrame</a>
     <li><a href="#ref-for-xrview-session①">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-frame">
-   <b><a href="#xrview-frame">#xrview-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-frame" class="dfn-panel" data-for="xrview-frame" id="infopanel-for-xrview-frame" role="dialog">
+   <span id="infopaneltitle-for-xrview-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#xrview-frame">#xrview-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-frame">5.1. XRFrame</a>
     <li><a href="#ref-for-xrview-frame①">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-underlying-view">
-   <b><a href="#xrview-underlying-view">#xrview-underlying-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-underlying-view" class="dfn-panel" data-for="xrview-underlying-view" id="infopanel-for-xrview-underlying-view" role="dialog">
+   <span id="infopaneltitle-for-xrview-underlying-view" style="display:none">Info about the 'underlying view' definition.</span><b><a href="#xrview-underlying-view">#xrview-underlying-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-underlying-view">5.1. XRFrame</a>
     <li><a href="#ref-for-xrview-underlying-view①">7.1. XRView</a> <a href="#ref-for-xrview-underlying-view②">(2)</a> <a href="#ref-for-xrview-underlying-view③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-internal-projection-matrix">
-   <b><a href="#xrview-internal-projection-matrix">#xrview-internal-projection-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-internal-projection-matrix" class="dfn-panel" data-for="xrview-internal-projection-matrix" id="infopanel-for-xrview-internal-projection-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrview-internal-projection-matrix" style="display:none">Info about the 'internal projection matrix' definition.</span><b><a href="#xrview-internal-projection-matrix">#xrview-internal-projection-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-internal-projection-matrix">7.1. XRView</a> <a href="#ref-for-xrview-internal-projection-matrix①">(2)</a> <a href="#ref-for-xrview-internal-projection-matrix②">(3)</a> <a href="#ref-for-xrview-internal-projection-matrix③">(4)</a> <a href="#ref-for-xrview-internal-projection-matrix④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrview-requestviewportscale">
-   <b><a href="#dom-xrview-requestviewportscale">#dom-xrview-requestviewportscale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrview-requestviewportscale" class="dfn-panel" data-for="dom-xrview-requestviewportscale" id="infopanel-for-dom-xrview-requestviewportscale" role="dialog">
+   <span id="infopaneltitle-for-dom-xrview-requestviewportscale" style="display:none">Info about the 'requestViewportScale(scale)' definition.</span><b><a href="#dom-xrview-requestviewportscale">#dom-xrview-requestviewportscale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrview-requestviewportscale">7.1. XRView</a> <a href="#ref-for-dom-xrview-requestviewportscale①">(2)</a> <a href="#ref-for-dom-xrview-requestviewportscale②">(3)</a> <a href="#ref-for-dom-xrview-requestviewportscale③">(4)</a> <a href="#ref-for-dom-xrview-requestviewportscale④">(5)</a>
     <li><a href="#ref-for-dom-xrview-requestviewportscale⑤">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-obtain-the-projection-matrix">
-   <b><a href="#xrview-obtain-the-projection-matrix">#xrview-obtain-the-projection-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-obtain-the-projection-matrix" class="dfn-panel" data-for="xrview-obtain-the-projection-matrix" id="infopanel-for-xrview-obtain-the-projection-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrview-obtain-the-projection-matrix" style="display:none">Info about the 'obtain the projection matrix' definition.</span><b><a href="#xrview-obtain-the-projection-matrix">#xrview-obtain-the-projection-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-obtain-the-projection-matrix">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-the-viewports">
-   <b><a href="#update-the-viewports">#update-the-viewports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-the-viewports" class="dfn-panel" data-for="update-the-viewports" id="infopanel-for-update-the-viewports" role="dialog">
+   <span id="infopaneltitle-for-update-the-viewports" style="display:none">Info about the 'update the viewports' definition.</span><b><a href="#update-the-viewports">#update-the-viewports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-viewports">4.1. XRSession</a>
     <li><a href="#ref-for-update-the-viewports①">4.3. Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrview-obtain-a-scaled-viewport">
-   <b><a href="#xrview-obtain-a-scaled-viewport">#xrview-obtain-a-scaled-viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrview-obtain-a-scaled-viewport" class="dfn-panel" data-for="xrview-obtain-a-scaled-viewport" id="infopanel-for-xrview-obtain-a-scaled-viewport" role="dialog">
+   <span id="infopaneltitle-for-xrview-obtain-a-scaled-viewport" style="display:none">Info about the 'obtain a scaled viewport' definition.</span><b><a href="#xrview-obtain-a-scaled-viewport">#xrview-obtain-a-scaled-viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrview-obtain-a-scaled-viewport">7.1. XRView</a>
     <li><a href="#ref-for-xrview-obtain-a-scaled-viewport①">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-view">
-   <b><a href="#primary-view">#primary-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-view" class="dfn-panel" data-for="primary-view" id="infopanel-for-primary-view" role="dialog">
+   <span id="infopaneltitle-for-primary-view" style="display:none">Info about the 'primary view' definition.</span><b><a href="#primary-view">#primary-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-view">7.1. XRView</a>
     <li><a href="#ref-for-primary-view①">7.2. Primary and Secondary Views</a> <a href="#ref-for-primary-view②">(2)</a> <a href="#ref-for-primary-view③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="secondary-view">
-   <b><a href="#secondary-view">#secondary-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-secondary-view" class="dfn-panel" data-for="secondary-view" id="infopanel-for-secondary-view" role="dialog">
+   <span id="infopaneltitle-for-secondary-view" style="display:none">Info about the 'secondary view' definition.</span><b><a href="#secondary-view">#secondary-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secondary-view">4.1. XRSession</a>
     <li><a href="#ref-for-secondary-view①">7.2. Primary and Secondary Views</a> <a href="#ref-for-secondary-view②">(2)</a> <a href="#ref-for-secondary-view③">(3)</a> <a href="#ref-for-secondary-view④">(4)</a> <a href="#ref-for-secondary-view⑤">(5)</a> <a href="#ref-for-secondary-view⑥">(6)</a> <a href="#ref-for-secondary-view⑦">(7)</a> <a href="#ref-for-secondary-view⑧">(8)</a> <a href="#ref-for-secondary-view⑨">(9)</a> <a href="#ref-for-secondary-view①⓪">(10)</a> <a href="#ref-for-secondary-view①①">(11)</a>
     <li><a href="#ref-for-secondary-view①②">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="secondary-view-secondary-views">
-   <b><a href="#secondary-view-secondary-views">#secondary-view-secondary-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-secondary-view-secondary-views" class="dfn-panel" data-for="secondary-view-secondary-views" id="infopanel-for-secondary-view-secondary-views" role="dialog">
+   <span id="infopaneltitle-for-secondary-view-secondary-views" style="display:none">Info about the 'secondary-views' definition.</span><b><a href="#secondary-view-secondary-views">#secondary-view-secondary-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secondary-view-secondary-views">7.2. Primary and Secondary Views</a> <a href="#ref-for-secondary-view-secondary-views①">(2)</a> <a href="#ref-for-secondary-view-secondary-views②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrviewport">
-   <b><a href="#xrviewport">#xrviewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrviewport" class="dfn-panel" data-for="xrviewport" id="infopanel-for-xrviewport" role="dialog">
+   <span id="infopaneltitle-for-xrviewport" style="display:none">Info about the 'XRViewport' definition.</span><b><a href="#xrviewport">#xrviewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrviewport">7.1. XRView</a> <a href="#ref-for-xrviewport①">(2)</a>
     <li><a href="#ref-for-xrviewport②">7.3. XRViewport</a> <a href="#ref-for-xrviewport③">(2)</a>
@@ -8944,57 +8944,57 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrviewport⑤">11.2. XRWebGLLayer</a> <a href="#ref-for-xrviewport⑥">(2)</a> <a href="#ref-for-xrviewport⑦">(3)</a> <a href="#ref-for-xrviewport⑧">(4)</a> <a href="#ref-for-xrviewport⑨">(5)</a> <a href="#ref-for-xrviewport①⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrviewport-x">
-   <b><a href="#dom-xrviewport-x">#dom-xrviewport-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrviewport-x" class="dfn-panel" data-for="dom-xrviewport-x" id="infopanel-for-dom-xrviewport-x" role="dialog">
+   <span id="infopaneltitle-for-dom-xrviewport-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-xrviewport-x">#dom-xrviewport-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-x">7.1. XRView</a>
     <li><a href="#ref-for-dom-xrviewport-x①">7.3. XRViewport</a> <a href="#ref-for-dom-xrviewport-x②">(2)</a> <a href="#ref-for-dom-xrviewport-x③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrviewport-y">
-   <b><a href="#dom-xrviewport-y">#dom-xrviewport-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrviewport-y" class="dfn-panel" data-for="dom-xrviewport-y" id="infopanel-for-dom-xrviewport-y" role="dialog">
+   <span id="infopaneltitle-for-dom-xrviewport-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-xrviewport-y">#dom-xrviewport-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-y">7.1. XRView</a>
     <li><a href="#ref-for-dom-xrviewport-y①">7.3. XRViewport</a> <a href="#ref-for-dom-xrviewport-y②">(2)</a> <a href="#ref-for-dom-xrviewport-y③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrviewport-width">
-   <b><a href="#dom-xrviewport-width">#dom-xrviewport-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrviewport-width" class="dfn-panel" data-for="dom-xrviewport-width" id="infopanel-for-dom-xrviewport-width" role="dialog">
+   <span id="infopaneltitle-for-dom-xrviewport-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-xrviewport-width">#dom-xrviewport-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-width">7.1. XRView</a>
     <li><a href="#ref-for-dom-xrviewport-width①">7.3. XRViewport</a> <a href="#ref-for-dom-xrviewport-width②">(2)</a>
     <li><a href="#ref-for-dom-xrviewport-width③">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrviewport-height">
-   <b><a href="#dom-xrviewport-height">#dom-xrviewport-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrviewport-height" class="dfn-panel" data-for="dom-xrviewport-height" id="infopanel-for-dom-xrviewport-height" role="dialog">
+   <span id="infopaneltitle-for-dom-xrviewport-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-xrviewport-height">#dom-xrviewport-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewport-height">7.1. XRView</a>
     <li><a href="#ref-for-dom-xrviewport-height①">7.3. XRViewport</a> <a href="#ref-for-dom-xrviewport-height②">(2)</a>
     <li><a href="#ref-for-dom-xrviewport-height③">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix">
-   <b><a href="#matrix">#matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix" class="dfn-panel" data-for="matrix" id="infopanel-for-matrix" role="dialog">
+   <span id="infopaneltitle-for-matrix" style="display:none">Info about the 'matrices' definition.</span><b><a href="#matrix">#matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix">7.1. XRView</a> <a href="#ref-for-matrix①">(2)</a>
     <li><a href="#ref-for-matrix②">8.3. XRRigidTransform</a> <a href="#ref-for-matrix③">(2)</a> <a href="#ref-for-matrix④">(3)</a> <a href="#ref-for-matrix⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normalize">
-   <b><a href="#normalize">#normalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalize" class="dfn-panel" data-for="normalize" id="infopanel-for-normalize" role="dialog">
+   <span id="infopaneltitle-for-normalize" style="display:none">Info about the 'normalize' definition.</span><b><a href="#normalize">#normalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize">8.3. XRRigidTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrigidtransform-internal-matrix">
-   <b><a href="#xrrigidtransform-internal-matrix">#xrrigidtransform-internal-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrigidtransform-internal-matrix" class="dfn-panel" data-for="xrrigidtransform-internal-matrix" id="infopanel-for-xrrigidtransform-internal-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrrigidtransform-internal-matrix" style="display:none">Info about the 'internal matrix' definition.</span><b><a href="#xrrigidtransform-internal-matrix">#xrrigidtransform-internal-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform-internal-matrix">8.3. XRRigidTransform</a> <a href="#ref-for-xrrigidtransform-internal-matrix①">(2)</a> <a href="#ref-for-xrrigidtransform-internal-matrix②">(3)</a> <a href="#ref-for-xrrigidtransform-internal-matrix③">(4)</a> <a href="#ref-for-xrrigidtransform-internal-matrix④">(5)</a> <a href="#ref-for-xrrigidtransform-internal-matrix⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrigidtransform">
-   <b><a href="#xrrigidtransform">#xrrigidtransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrigidtransform" class="dfn-panel" data-for="xrrigidtransform" id="infopanel-for-xrrigidtransform" role="dialog">
+   <span id="infopaneltitle-for-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform' definition.</span><b><a href="#xrrigidtransform">#xrrigidtransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform">5.1. XRFrame</a>
     <li><a href="#ref-for-xrrigidtransform①">6.1. XRSpace</a>
@@ -9005,64 +9005,64 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrrigidtransform②①">12.4. XRReferenceSpaceEvent</a> <a href="#ref-for-xrrigidtransform②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrigidtransform-xrrigidtransform">
-   <b><a href="#dom-xrrigidtransform-xrrigidtransform">#dom-xrrigidtransform-xrrigidtransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrigidtransform-xrrigidtransform" class="dfn-panel" data-for="dom-xrrigidtransform-xrrigidtransform" id="infopanel-for-dom-xrrigidtransform-xrrigidtransform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrigidtransform-xrrigidtransform" style="display:none">Info about the 'XRRigidTransform(position, orientation)' definition.</span><b><a href="#dom-xrrigidtransform-xrrigidtransform">#dom-xrrigidtransform-xrrigidtransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-xrrigidtransform">8.3. XRRigidTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrigidtransform-position">
-   <b><a href="#dom-xrrigidtransform-position">#dom-xrrigidtransform-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrigidtransform-position" class="dfn-panel" data-for="dom-xrrigidtransform-position" id="infopanel-for-dom-xrrigidtransform-position" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrigidtransform-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-xrrigidtransform-position">#dom-xrrigidtransform-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-position">6.1. XRSpace</a> <a href="#ref-for-dom-xrrigidtransform-position①">(2)</a> <a href="#ref-for-dom-xrrigidtransform-position②">(3)</a>
     <li><a href="#ref-for-dom-xrrigidtransform-position③">8.3. XRRigidTransform</a> <a href="#ref-for-dom-xrrigidtransform-position④">(2)</a> <a href="#ref-for-dom-xrrigidtransform-position⑤">(3)</a> <a href="#ref-for-dom-xrrigidtransform-position⑥">(4)</a> <a href="#ref-for-dom-xrrigidtransform-position⑦">(5)</a> <a href="#ref-for-dom-xrrigidtransform-position⑧">(6)</a> <a href="#ref-for-dom-xrrigidtransform-position⑨">(7)</a> <a href="#ref-for-dom-xrrigidtransform-position①⓪">(8)</a> <a href="#ref-for-dom-xrrigidtransform-position①①">(9)</a> <a href="#ref-for-dom-xrrigidtransform-position①②">(10)</a> <a href="#ref-for-dom-xrrigidtransform-position①③">(11)</a> <a href="#ref-for-dom-xrrigidtransform-position①④">(12)</a> <a href="#ref-for-dom-xrrigidtransform-position①⑤">(13)</a> <a href="#ref-for-dom-xrrigidtransform-position①⑥">(14)</a> <a href="#ref-for-dom-xrrigidtransform-position①⑦">(15)</a> <a href="#ref-for-dom-xrrigidtransform-position①⑧">(16)</a>
     <li><a href="#ref-for-dom-xrrigidtransform-position①⑨">9.1. XRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrigidtransform-orientation">
-   <b><a href="#dom-xrrigidtransform-orientation">#dom-xrrigidtransform-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrigidtransform-orientation" class="dfn-panel" data-for="dom-xrrigidtransform-orientation" id="infopanel-for-dom-xrrigidtransform-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrigidtransform-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-xrrigidtransform-orientation">#dom-xrrigidtransform-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation">6.1. XRSpace</a> <a href="#ref-for-dom-xrrigidtransform-orientation①">(2)</a> <a href="#ref-for-dom-xrrigidtransform-orientation②">(3)</a>
     <li><a href="#ref-for-dom-xrrigidtransform-orientation③">8.3. XRRigidTransform</a> <a href="#ref-for-dom-xrrigidtransform-orientation④">(2)</a> <a href="#ref-for-dom-xrrigidtransform-orientation⑤">(3)</a> <a href="#ref-for-dom-xrrigidtransform-orientation⑥">(4)</a> <a href="#ref-for-dom-xrrigidtransform-orientation⑦">(5)</a> <a href="#ref-for-dom-xrrigidtransform-orientation⑧">(6)</a> <a href="#ref-for-dom-xrrigidtransform-orientation⑨">(7)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①⓪">(8)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①①">(9)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①②">(10)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①③">(11)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①④">(12)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①⑤">(13)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①⑥">(14)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①⑦">(15)</a> <a href="#ref-for-dom-xrrigidtransform-orientation①⑧">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrigidtransform-matrix">
-   <b><a href="#dom-xrrigidtransform-matrix">#dom-xrrigidtransform-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrigidtransform-matrix" class="dfn-panel" data-for="dom-xrrigidtransform-matrix" id="infopanel-for-dom-xrrigidtransform-matrix" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrigidtransform-matrix" style="display:none">Info about the 'matrix' definition.</span><b><a href="#dom-xrrigidtransform-matrix">#dom-xrrigidtransform-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-matrix">8.3. XRRigidTransform</a> <a href="#ref-for-dom-xrrigidtransform-matrix①">(2)</a> <a href="#ref-for-dom-xrrigidtransform-matrix②">(3)</a> <a href="#ref-for-dom-xrrigidtransform-matrix③">(4)</a> <a href="#ref-for-dom-xrrigidtransform-matrix④">(5)</a> <a href="#ref-for-dom-xrrigidtransform-matrix⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrrigidtransform-obtain-the-matrix">
-   <b><a href="#xrrigidtransform-obtain-the-matrix">#xrrigidtransform-obtain-the-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrrigidtransform-obtain-the-matrix" class="dfn-panel" data-for="xrrigidtransform-obtain-the-matrix" id="infopanel-for-xrrigidtransform-obtain-the-matrix" role="dialog">
+   <span id="infopaneltitle-for-xrrigidtransform-obtain-the-matrix" style="display:none">Info about the 'obtain the matrix' definition.</span><b><a href="#xrrigidtransform-obtain-the-matrix">#xrrigidtransform-obtain-the-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrrigidtransform-obtain-the-matrix">8.3. XRRigidTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrrigidtransform-inverse">
-   <b><a href="#dom-xrrigidtransform-inverse">#dom-xrrigidtransform-inverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrrigidtransform-inverse" class="dfn-panel" data-for="dom-xrrigidtransform-inverse" id="infopanel-for-dom-xrrigidtransform-inverse" role="dialog">
+   <span id="infopaneltitle-for-dom-xrrigidtransform-inverse" style="display:none">Info about the 'inverse' definition.</span><b><a href="#dom-xrrigidtransform-inverse">#dom-xrrigidtransform-inverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrrigidtransform-inverse">6.2. XRReferenceSpace</a>
     <li><a href="#ref-for-dom-xrrigidtransform-inverse①">6.3. XRBoundedReferenceSpace</a>
     <li><a href="#ref-for-dom-xrrigidtransform-inverse②">8.3. XRRigidTransform</a> <a href="#ref-for-dom-xrrigidtransform-inverse③">(2)</a> <a href="#ref-for-dom-xrrigidtransform-inverse④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identity-transform">
-   <b><a href="#identity-transform">#identity-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identity-transform" class="dfn-panel" data-for="identity-transform" id="infopanel-for-identity-transform" role="dialog">
+   <span id="infopaneltitle-for-identity-transform" style="display:none">Info about the 'identity transform' definition.</span><b><a href="#identity-transform">#identity-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform">4.1. XRSession</a>
     <li><a href="#ref-for-identity-transform①">6.1. XRSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multiply-transforms">
-   <b><a href="#multiply-transforms">#multiply-transforms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multiply-transforms" class="dfn-panel" data-for="multiply-transforms" id="infopanel-for-multiply-transforms" role="dialog">
+   <span id="infopaneltitle-for-multiply-transforms" style="display:none">Info about the 'multiply two XRRigidTransforms' definition.</span><b><a href="#multiply-transforms">#multiply-transforms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multiply-transforms">5.1. XRFrame</a>
     <li><a href="#ref-for-multiply-transforms①">6.1. XRSpace</a>
     <li><a href="#ref-for-multiply-transforms②">6.2. XRReferenceSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrpose">
-   <b><a href="#xrpose">#xrpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrpose" class="dfn-panel" data-for="xrpose" id="infopanel-for-xrpose" role="dialog">
+   <span id="infopaneltitle-for-xrpose" style="display:none">Info about the 'XRPose' definition.</span><b><a href="#xrpose">#xrpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpose">5.1. XRFrame</a> <a href="#ref-for-xrpose①">(2)</a> <a href="#ref-for-xrpose②">(3)</a>
     <li><a href="#ref-for-xrpose③">6.1. XRSpace</a> <a href="#ref-for-xrpose④">(2)</a> <a href="#ref-for-xrpose⑤">(3)</a>
@@ -9072,8 +9072,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrpose①②">13.5.2. Poses</a> <a href="#ref-for-xrpose①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpose-transform">
-   <b><a href="#dom-xrpose-transform">#dom-xrpose-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpose-transform" class="dfn-panel" data-for="dom-xrpose-transform" id="infopanel-for-dom-xrpose-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpose-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrpose-transform">#dom-xrpose-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpose-transform">5.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrpose-transform①">6.1. XRSpace</a>
@@ -9081,36 +9081,36 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-dom-xrpose-transform④">9.2. XRViewerPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpose-linearvelocity">
-   <b><a href="#dom-xrpose-linearvelocity">#dom-xrpose-linearvelocity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpose-linearvelocity" class="dfn-panel" data-for="dom-xrpose-linearvelocity" id="infopanel-for-dom-xrpose-linearvelocity" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpose-linearvelocity" style="display:none">Info about the 'linearVelocity' definition.</span><b><a href="#dom-xrpose-linearvelocity">#dom-xrpose-linearvelocity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpose-linearvelocity">6.1. XRSpace</a> <a href="#ref-for-dom-xrpose-linearvelocity①">(2)</a> <a href="#ref-for-dom-xrpose-linearvelocity②">(3)</a>
     <li><a href="#ref-for-dom-xrpose-linearvelocity③">9.1. XRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpose-angularvelocity">
-   <b><a href="#dom-xrpose-angularvelocity">#dom-xrpose-angularvelocity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpose-angularvelocity" class="dfn-panel" data-for="dom-xrpose-angularvelocity" id="infopanel-for-dom-xrpose-angularvelocity" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpose-angularvelocity" style="display:none">Info about the 'angularVelocity' definition.</span><b><a href="#dom-xrpose-angularvelocity">#dom-xrpose-angularvelocity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpose-angularvelocity">6.1. XRSpace</a> <a href="#ref-for-dom-xrpose-angularvelocity①">(2)</a> <a href="#ref-for-dom-xrpose-angularvelocity②">(3)</a>
     <li><a href="#ref-for-dom-xrpose-angularvelocity③">9.1. XRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpose-emulatedposition">
-   <b><a href="#dom-xrpose-emulatedposition">#dom-xrpose-emulatedposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpose-emulatedposition" class="dfn-panel" data-for="dom-xrpose-emulatedposition" id="infopanel-for-dom-xrpose-emulatedposition" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpose-emulatedposition" style="display:none">Info about the 'emulatedPosition' definition.</span><b><a href="#dom-xrpose-emulatedposition">#dom-xrpose-emulatedposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpose-emulatedposition">6.1. XRSpace</a> <a href="#ref-for-dom-xrpose-emulatedposition①">(2)</a> <a href="#ref-for-dom-xrpose-emulatedposition②">(3)</a> <a href="#ref-for-dom-xrpose-emulatedposition③">(4)</a> <a href="#ref-for-dom-xrpose-emulatedposition④">(5)</a> <a href="#ref-for-dom-xrpose-emulatedposition⑤">(6)</a>
     <li><a href="#ref-for-dom-xrpose-emulatedposition⑥">9.1. XRPose</a>
     <li><a href="#ref-for-dom-xrpose-emulatedposition⑦">12.5. Event Types</a> <a href="#ref-for-dom-xrpose-emulatedposition⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrpose-computed-offset">
-   <b><a href="#xrpose-computed-offset">#xrpose-computed-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrpose-computed-offset" class="dfn-panel" data-for="xrpose-computed-offset" id="infopanel-for-xrpose-computed-offset" role="dialog">
+   <span id="infopaneltitle-for-xrpose-computed-offset" style="display:none">Info about the 'computed offset' definition.</span><b><a href="#xrpose-computed-offset">#xrpose-computed-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpose-computed-offset">9.1. XRPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="viewer">
-   <b><a href="#viewer">#viewer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-viewer" class="dfn-panel" data-for="viewer" id="infopanel-for-viewer" role="dialog">
+   <span id="infopaneltitle-for-viewer" style="display:none">Info about the 'viewer' definition.</span><b><a href="#viewer">#viewer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewer">3.3. XRSessionMode</a> <a href="#ref-for-viewer①">(2)</a>
     <li><a href="#ref-for-viewer②">4.2. XRRenderState</a> <a href="#ref-for-viewer③">(2)</a> <a href="#ref-for-viewer④">(3)</a>
@@ -9122,8 +9122,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-viewer①②">12.5. Event Types</a> <a href="#ref-for-viewer①③">(2)</a> <a href="#ref-for-viewer①④">(3)</a> <a href="#ref-for-viewer①⑤">(4)</a> <a href="#ref-for-viewer①⑥">(5)</a> <a href="#ref-for-viewer①⑦">(6)</a> <a href="#ref-for-viewer①⑧">(7)</a> <a href="#ref-for-viewer①⑨">(8)</a> <a href="#ref-for-viewer②⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrviewerpose">
-   <b><a href="#xrviewerpose">#xrviewerpose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrviewerpose" class="dfn-panel" data-for="xrviewerpose" id="infopanel-for-xrviewerpose" role="dialog">
+   <span id="infopaneltitle-for-xrviewerpose" style="display:none">Info about the 'XRViewerPose' definition.</span><b><a href="#xrviewerpose">#xrviewerpose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrviewerpose">5.1. XRFrame</a> <a href="#ref-for-xrviewerpose①">(2)</a> <a href="#ref-for-xrviewerpose②">(3)</a> <a href="#ref-for-xrviewerpose③">(4)</a>
     <li><a href="#ref-for-xrviewerpose④">7.3. XRViewport</a>
@@ -9131,16 +9131,16 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrviewerpose⑨">13.5.2. Poses</a> <a href="#ref-for-xrviewerpose①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrviewerpose-views">
-   <b><a href="#dom-xrviewerpose-views">#dom-xrviewerpose-views</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrviewerpose-views" class="dfn-panel" data-for="dom-xrviewerpose-views" id="infopanel-for-dom-xrviewerpose-views" role="dialog">
+   <span id="infopaneltitle-for-dom-xrviewerpose-views" style="display:none">Info about the 'views' definition.</span><b><a href="#dom-xrviewerpose-views">#dom-xrviewerpose-views</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrviewerpose-views">5.1. XRFrame</a>
     <li><a href="#ref-for-dom-xrviewerpose-views①">7.2. Primary and Secondary Views</a> <a href="#ref-for-dom-xrviewerpose-views②">(2)</a> <a href="#ref-for-dom-xrviewerpose-views③">(3)</a> <a href="#ref-for-dom-xrviewerpose-views④">(4)</a>
     <li><a href="#ref-for-dom-xrviewerpose-views⑤">9.2. XRViewerPose</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-input-source">
-   <b><a href="#xr-input-source">#xr-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-input-source" class="dfn-panel" data-for="xr-input-source" id="infopanel-for-xr-input-source" role="dialog">
+   <span id="infopaneltitle-for-xr-input-source" style="display:none">Info about the 'XR input source' definition.</span><b><a href="#xr-input-source">#xr-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-input-source">2.1. XR device</a>
     <li><a href="#ref-for-xr-input-source①">4.1. XRSession</a> <a href="#ref-for-xr-input-source②">(2)</a> <a href="#ref-for-xr-input-source③">(3)</a> <a href="#ref-for-xr-input-source④">(4)</a> <a href="#ref-for-xr-input-source⑤">(5)</a> <a href="#ref-for-xr-input-source⑥">(6)</a> <a href="#ref-for-xr-input-source⑦">(7)</a> <a href="#ref-for-xr-input-source⑧">(8)</a> <a href="#ref-for-xr-input-source⑨">(9)</a> <a href="#ref-for-xr-input-source①⓪">(10)</a>
@@ -9148,26 +9148,26 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xr-input-source②④">10.2. Transient input</a> <a href="#ref-for-xr-input-source②⑤">(2)</a> <a href="#ref-for-xr-input-source②⑥">(3)</a> <a href="#ref-for-xr-input-source②⑦">(4)</a> <a href="#ref-for-xr-input-source②⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrhandedness">
-   <b><a href="#enumdef-xrhandedness">#enumdef-xrhandedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrhandedness" class="dfn-panel" data-for="enumdef-xrhandedness" id="infopanel-for-enumdef-xrhandedness" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrhandedness" style="display:none">Info about the 'XRHandedness' definition.</span><b><a href="#enumdef-xrhandedness">#enumdef-xrhandedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrhandedness">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrhandedness-none">
-   <b><a href="#dom-xrhandedness-none">#dom-xrhandedness-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrhandedness-none" class="dfn-panel" data-for="dom-xrhandedness-none" id="infopanel-for-dom-xrhandedness-none" role="dialog">
+   <span id="infopaneltitle-for-dom-xrhandedness-none" style="display:none">Info about the '"none"' definition.</span><b><a href="#dom-xrhandedness-none">#dom-xrhandedness-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrhandedness-none">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-xrtargetraymode">
-   <b><a href="#enumdef-xrtargetraymode">#enumdef-xrtargetraymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-xrtargetraymode" class="dfn-panel" data-for="enumdef-xrtargetraymode" id="infopanel-for-enumdef-xrtargetraymode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-xrtargetraymode" style="display:none">Info about the 'XRTargetRayMode' definition.</span><b><a href="#enumdef-xrtargetraymode">#enumdef-xrtargetraymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-xrtargetraymode">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrinputsource">
-   <b><a href="#xrinputsource">#xrinputsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrinputsource" class="dfn-panel" data-for="xrinputsource" id="infopanel-for-xrinputsource" role="dialog">
+   <span id="infopaneltitle-for-xrinputsource" style="display:none">Info about the 'XRInputSource' definition.</span><b><a href="#xrinputsource">#xrinputsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource">4.1. XRSession</a> <a href="#ref-for-xrinputsource①">(2)</a> <a href="#ref-for-xrinputsource②">(3)</a> <a href="#ref-for-xrinputsource③">(4)</a> <a href="#ref-for-xrinputsource④">(5)</a> <a href="#ref-for-xrinputsource⑤">(6)</a> <a href="#ref-for-xrinputsource⑥">(7)</a>
     <li><a href="#ref-for-xrinputsource⑦">10.1. XRInputSource</a> <a href="#ref-for-xrinputsource⑧">(2)</a> <a href="#ref-for-xrinputsource⑨">(3)</a> <a href="#ref-for-xrinputsource①⓪">(4)</a> <a href="#ref-for-xrinputsource①①">(5)</a>
@@ -9178,186 +9178,186 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrinputsource③⓪">12.5. Event Types</a> <a href="#ref-for-xrinputsource③①">(2)</a> <a href="#ref-for-xrinputsource③②">(3)</a> <a href="#ref-for-xrinputsource③③">(4)</a> <a href="#ref-for-xrinputsource③④">(5)</a> <a href="#ref-for-xrinputsource③⑤">(6)</a> <a href="#ref-for-xrinputsource③⑥">(7)</a> <a href="#ref-for-xrinputsource③⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-handedness">
-   <b><a href="#dom-xrinputsource-handedness">#dom-xrinputsource-handedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-handedness" class="dfn-panel" data-for="dom-xrinputsource-handedness" id="infopanel-for-dom-xrinputsource-handedness" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-handedness" style="display:none">Info about the 'handedness' definition.</span><b><a href="#dom-xrinputsource-handedness">#dom-xrinputsource-handedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-handedness">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrinputsource-handedness①">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-targetraymode">
-   <b><a href="#dom-xrinputsource-targetraymode">#dom-xrinputsource-targetraymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-targetraymode" class="dfn-panel" data-for="dom-xrinputsource-targetraymode" id="infopanel-for-dom-xrinputsource-targetraymode" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-targetraymode" style="display:none">Info about the 'targetRayMode' definition.</span><b><a href="#dom-xrinputsource-targetraymode">#dom-xrinputsource-targetraymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode①">10.1. XRInputSource</a> <a href="#ref-for-dom-xrinputsource-targetraymode②">(2)</a> <a href="#ref-for-dom-xrinputsource-targetraymode③">(3)</a>
     <li><a href="#ref-for-dom-xrinputsource-targetraymode④">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtargetraymode-gaze">
-   <b><a href="#dom-xrtargetraymode-gaze">#dom-xrtargetraymode-gaze</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtargetraymode-gaze" class="dfn-panel" data-for="dom-xrtargetraymode-gaze" id="infopanel-for-dom-xrtargetraymode-gaze" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtargetraymode-gaze" style="display:none">Info about the 'gaze' definition.</span><b><a href="#dom-xrtargetraymode-gaze">#dom-xrtargetraymode-gaze</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-gaze">10.1. XRInputSource</a> <a href="#ref-for-dom-xrtargetraymode-gaze①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtargetraymode-tracked-pointer">
-   <b><a href="#dom-xrtargetraymode-tracked-pointer">#dom-xrtargetraymode-tracked-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtargetraymode-tracked-pointer" class="dfn-panel" data-for="dom-xrtargetraymode-tracked-pointer" id="infopanel-for-dom-xrtargetraymode-tracked-pointer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtargetraymode-tracked-pointer" style="display:none">Info about the 'tracked-pointer' definition.</span><b><a href="#dom-xrtargetraymode-tracked-pointer">#dom-xrtargetraymode-tracked-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-tracked-pointer">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrtargetraymode-screen">
-   <b><a href="#dom-xrtargetraymode-screen">#dom-xrtargetraymode-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrtargetraymode-screen" class="dfn-panel" data-for="dom-xrtargetraymode-screen" id="infopanel-for-dom-xrtargetraymode-screen" role="dialog">
+   <span id="infopaneltitle-for-dom-xrtargetraymode-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#dom-xrtargetraymode-screen">#dom-xrtargetraymode-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrtargetraymode-screen">10.1. XRInputSource</a> <a href="#ref-for-dom-xrtargetraymode-screen①">(2)</a>
     <li><a href="#ref-for-dom-xrtargetraymode-screen②">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-targetrayspace">
-   <b><a href="#dom-xrinputsource-targetrayspace">#dom-xrinputsource-targetrayspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-targetrayspace" class="dfn-panel" data-for="dom-xrinputsource-targetrayspace" id="infopanel-for-dom-xrinputsource-targetrayspace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-targetrayspace" style="display:none">Info about the 'targetRaySpace' definition.</span><b><a href="#dom-xrinputsource-targetrayspace">#dom-xrinputsource-targetrayspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace">6.1. XRSpace</a> <a href="#ref-for-dom-xrinputsource-targetrayspace①">(2)</a>
     <li><a href="#ref-for-dom-xrinputsource-targetrayspace②">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-gripspace">
-   <b><a href="#dom-xrinputsource-gripspace">#dom-xrinputsource-gripspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-gripspace" class="dfn-panel" data-for="dom-xrinputsource-gripspace" id="infopanel-for-dom-xrinputsource-gripspace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-gripspace" style="display:none">Info about the 'gripSpace' definition.</span><b><a href="#dom-xrinputsource-gripspace">#dom-xrinputsource-gripspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-gripspace">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrinputsource-gripspace①">6.1. XRSpace</a> <a href="#ref-for-dom-xrinputsource-gripspace②">(2)</a>
     <li><a href="#ref-for-dom-xrinputsource-gripspace③">10.1. XRInputSource</a> <a href="#ref-for-dom-xrinputsource-gripspace④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsource-profiles">
-   <b><a href="#dom-xrinputsource-profiles">#dom-xrinputsource-profiles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsource-profiles" class="dfn-panel" data-for="dom-xrinputsource-profiles" id="infopanel-for-dom-xrinputsource-profiles" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsource-profiles" style="display:none">Info about the 'profiles' definition.</span><b><a href="#dom-xrinputsource-profiles">#dom-xrinputsource-profiles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsource-profiles">4.1. XRSession</a>
     <li><a href="#ref-for-dom-xrinputsource-profiles①">10.1. XRInputSource</a> <a href="#ref-for-dom-xrinputsource-profiles②">(2)</a> <a href="#ref-for-dom-xrinputsource-profiles③">(3)</a> <a href="#ref-for-dom-xrinputsource-profiles④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrinputsource-input-profile-name">
-   <b><a href="#xrinputsource-input-profile-name">#xrinputsource-input-profile-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrinputsource-input-profile-name" class="dfn-panel" data-for="xrinputsource-input-profile-name" id="infopanel-for-xrinputsource-input-profile-name" role="dialog">
+   <span id="infopaneltitle-for-xrinputsource-input-profile-name" style="display:none">Info about the 'input profile name' definition.</span><b><a href="#xrinputsource-input-profile-name">#xrinputsource-input-profile-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsource-input-profile-name">10.1. XRInputSource</a> <a href="#ref-for-xrinputsource-input-profile-name①">(2)</a> <a href="#ref-for-xrinputsource-input-profile-name②">(3)</a> <a href="#ref-for-xrinputsource-input-profile-name③">(4)</a> <a href="#ref-for-xrinputsource-input-profile-name④">(5)</a> <a href="#ref-for-xrinputsource-input-profile-name⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-input-source">
-   <b><a href="#primary-input-source">#primary-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-input-source" class="dfn-panel" data-for="primary-input-source" id="infopanel-for-primary-input-source" role="dialog">
+   <span id="infopaneltitle-for-primary-input-source" style="display:none">Info about the 'primary input source' definition.</span><b><a href="#primary-input-source">#primary-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-input-source">10.1. XRInputSource</a>
     <li><a href="#ref-for-primary-input-source①">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-action">
-   <b><a href="#primary-action">#primary-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-action" class="dfn-panel" data-for="primary-action" id="infopanel-for-primary-action" role="dialog">
+   <span id="infopaneltitle-for-primary-action" style="display:none">Info about the 'primary action' definition.</span><b><a href="#primary-action">#primary-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-action">10.1. XRInputSource</a> <a href="#ref-for-primary-action①">(2)</a> <a href="#ref-for-primary-action②">(3)</a> <a href="#ref-for-primary-action③">(4)</a> <a href="#ref-for-primary-action④">(5)</a> <a href="#ref-for-primary-action⑤">(6)</a> <a href="#ref-for-primary-action⑥">(7)</a> <a href="#ref-for-primary-action⑦">(8)</a> <a href="#ref-for-primary-action⑧">(9)</a>
     <li><a href="#ref-for-primary-action⑨">10.2. Transient input</a> <a href="#ref-for-primary-action①⓪">(2)</a> <a href="#ref-for-primary-action①①">(3)</a> <a href="#ref-for-primary-action①②">(4)</a> <a href="#ref-for-primary-action①③">(5)</a> <a href="#ref-for-primary-action①④">(6)</a> <a href="#ref-for-primary-action①⑤">(7)</a>
     <li><a href="#ref-for-primary-action①⑥">12.5. Event Types</a> <a href="#ref-for-primary-action①⑦">(2)</a> <a href="#ref-for-primary-action①⑧">(3)</a> <a href="#ref-for-primary-action①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auxiliary-input-source">
-   <b><a href="#auxiliary-input-source">#auxiliary-input-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auxiliary-input-source" class="dfn-panel" data-for="auxiliary-input-source" id="infopanel-for-auxiliary-input-source" role="dialog">
+   <span id="infopaneltitle-for-auxiliary-input-source" style="display:none">Info about the 'auxiliary input source' definition.</span><b><a href="#auxiliary-input-source">#auxiliary-input-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-input-source">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-squeeze-action">
-   <b><a href="#primary-squeeze-action">#primary-squeeze-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-squeeze-action" class="dfn-panel" data-for="primary-squeeze-action" id="infopanel-for-primary-squeeze-action" role="dialog">
+   <span id="infopaneltitle-for-primary-squeeze-action" style="display:none">Info about the 'primary squeeze action' definition.</span><b><a href="#primary-squeeze-action">#primary-squeeze-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-squeeze-action">10.1. XRInputSource</a> <a href="#ref-for-primary-squeeze-action①">(2)</a> <a href="#ref-for-primary-squeeze-action②">(3)</a> <a href="#ref-for-primary-squeeze-action③">(4)</a> <a href="#ref-for-primary-squeeze-action④">(5)</a> <a href="#ref-for-primary-squeeze-action⑤">(6)</a> <a href="#ref-for-primary-squeeze-action⑥">(7)</a> <a href="#ref-for-primary-squeeze-action⑦">(8)</a> <a href="#ref-for-primary-squeeze-action⑧">(9)</a>
     <li><a href="#ref-for-primary-squeeze-action⑨">12.5. Event Types</a> <a href="#ref-for-primary-squeeze-action①⓪">(2)</a> <a href="#ref-for-primary-squeeze-action①①">(3)</a> <a href="#ref-for-primary-squeeze-action①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transient-input-sources">
-   <b><a href="#transient-input-sources">#transient-input-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transient-input-sources" class="dfn-panel" data-for="transient-input-sources" id="infopanel-for-transient-input-sources" role="dialog">
+   <span id="infopaneltitle-for-transient-input-sources" style="display:none">Info about the 'transient input sources' definition.</span><b><a href="#transient-input-sources">#transient-input-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-input-sources">10.1. XRInputSource</a>
     <li><a href="#ref-for-transient-input-sources①">10.2. Transient input</a> <a href="#ref-for-transient-input-sources②">(2)</a> <a href="#ref-for-transient-input-sources③">(3)</a> <a href="#ref-for-transient-input-sources④">(4)</a> <a href="#ref-for-transient-input-sources⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transient-action">
-   <b><a href="#transient-action">#transient-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transient-action" class="dfn-panel" data-for="transient-action" id="infopanel-for-transient-action" role="dialog">
+   <span id="infopaneltitle-for-transient-action" style="display:none">Info about the 'transient action' definition.</span><b><a href="#transient-action">#transient-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-action">10.2. Transient input</a> <a href="#ref-for-transient-action①">(2)</a> <a href="#ref-for-transient-action②">(3)</a> <a href="#ref-for-transient-action③">(4)</a> <a href="#ref-for-transient-action④">(5)</a> <a href="#ref-for-transient-action⑤">(6)</a> <a href="#ref-for-transient-action⑥">(7)</a> <a href="#ref-for-transient-action⑦">(8)</a> <a href="#ref-for-transient-action⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auxiliary-action">
-   <b><a href="#auxiliary-action">#auxiliary-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auxiliary-action" class="dfn-panel" data-for="auxiliary-action" id="infopanel-for-auxiliary-action" role="dialog">
+   <span id="infopaneltitle-for-auxiliary-action" style="display:none">Info about the 'auxiliary action' definition.</span><b><a href="#auxiliary-action">#auxiliary-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-action">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrinputsourcearray">
-   <b><a href="#xrinputsourcearray">#xrinputsourcearray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrinputsourcearray" class="dfn-panel" data-for="xrinputsourcearray" id="infopanel-for-xrinputsourcearray" role="dialog">
+   <span id="infopaneltitle-for-xrinputsourcearray" style="display:none">Info about the 'XRInputSourceArray' definition.</span><b><a href="#xrinputsourcearray">#xrinputsourcearray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsourcearray">4.1. XRSession</a>
     <li><a href="#ref-for-xrinputsourcearray①">10.3. XRInputSourceArray</a> <a href="#ref-for-xrinputsourcearray②">(2)</a> <a href="#ref-for-xrinputsourcearray③">(3)</a> <a href="#ref-for-xrinputsourcearray④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourcearray-length">
-   <b><a href="#dom-xrinputsourcearray-length">#dom-xrinputsourcearray-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourcearray-length" class="dfn-panel" data-for="dom-xrinputsourcearray-length" id="infopanel-for-dom-xrinputsourcearray-length" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourcearray-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-xrinputsourcearray-length">#dom-xrinputsourcearray-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourcearray-length">10.3. XRInputSourceArray</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrlayer">
-   <b><a href="#xrlayer">#xrlayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrlayer" class="dfn-panel" data-for="xrlayer" id="infopanel-for-xrlayer" role="dialog">
+   <span id="infopaneltitle-for-xrlayer" style="display:none">Info about the 'XRLayer' definition.</span><b><a href="#xrlayer">#xrlayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrlayer">4.2. XRRenderState</a>
     <li><a href="#ref-for-xrlayer①">11.1. XRLayer</a>
     <li><a href="#ref-for-xrlayer②">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-xrwebglrenderingcontext">
-   <b><a href="#typedefdef-xrwebglrenderingcontext">#typedefdef-xrwebglrenderingcontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-xrwebglrenderingcontext" class="dfn-panel" data-for="typedefdef-xrwebglrenderingcontext" id="infopanel-for-typedefdef-xrwebglrenderingcontext" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-xrwebglrenderingcontext" style="display:none">Info about the 'XRWebGLRenderingContext' definition.</span><b><a href="#typedefdef-xrwebglrenderingcontext">#typedefdef-xrwebglrenderingcontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-xrwebglrenderingcontext">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrwebgllayerinit">
-   <b><a href="#dictdef-xrwebgllayerinit">#dictdef-xrwebgllayerinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrwebgllayerinit" class="dfn-panel" data-for="dictdef-xrwebgllayerinit" id="infopanel-for-dictdef-xrwebgllayerinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrwebgllayerinit" style="display:none">Info about the 'XRWebGLLayerInit' definition.</span><b><a href="#dictdef-xrwebgllayerinit">#dictdef-xrwebgllayerinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrwebgllayerinit">11.2. XRWebGLLayer</a> <a href="#ref-for-dictdef-xrwebgllayerinit①">(2)</a> <a href="#ref-for-dictdef-xrwebgllayerinit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-antialias">
-   <b><a href="#dom-xrwebgllayerinit-antialias">#dom-xrwebgllayerinit-antialias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-antialias" class="dfn-panel" data-for="dom-xrwebgllayerinit-antialias" id="infopanel-for-dom-xrwebgllayerinit-antialias" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-antialias" style="display:none">Info about the 'antialias' definition.</span><b><a href="#dom-xrwebgllayerinit-antialias">#dom-xrwebgllayerinit-antialias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-antialias">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-depth">
-   <b><a href="#dom-xrwebgllayerinit-depth">#dom-xrwebgllayerinit-depth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-depth" class="dfn-panel" data-for="dom-xrwebgllayerinit-depth" id="infopanel-for-dom-xrwebgllayerinit-depth" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-depth" style="display:none">Info about the 'depth' definition.</span><b><a href="#dom-xrwebgllayerinit-depth">#dom-xrwebgllayerinit-depth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-depth">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayerinit-depth①">(2)</a> <a href="#ref-for-dom-xrwebgllayerinit-depth②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-stencil">
-   <b><a href="#dom-xrwebgllayerinit-stencil">#dom-xrwebgllayerinit-stencil</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-stencil" class="dfn-panel" data-for="dom-xrwebgllayerinit-stencil" id="infopanel-for-dom-xrwebgllayerinit-stencil" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-stencil" style="display:none">Info about the 'stencil' definition.</span><b><a href="#dom-xrwebgllayerinit-stencil">#dom-xrwebgllayerinit-stencil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-stencil">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayerinit-stencil①">(2)</a> <a href="#ref-for-dom-xrwebgllayerinit-stencil②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-alpha">
-   <b><a href="#dom-xrwebgllayerinit-alpha">#dom-xrwebgllayerinit-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-alpha" class="dfn-panel" data-for="dom-xrwebgllayerinit-alpha" id="infopanel-for-dom-xrwebgllayerinit-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-xrwebgllayerinit-alpha">#dom-xrwebgllayerinit-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-alpha">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayerinit-alpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-ignoredepthvalues">
-   <b><a href="#dom-xrwebgllayerinit-ignoredepthvalues">#dom-xrwebgllayerinit-ignoredepthvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-ignoredepthvalues" class="dfn-panel" data-for="dom-xrwebgllayerinit-ignoredepthvalues" id="infopanel-for-dom-xrwebgllayerinit-ignoredepthvalues" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-ignoredepthvalues" style="display:none">Info about the 'ignoreDepthValues' definition.</span><b><a href="#dom-xrwebgllayerinit-ignoredepthvalues">#dom-xrwebgllayerinit-ignoredepthvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-ignoredepthvalues">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayerinit-framebufferscalefactor">
-   <b><a href="#dom-xrwebgllayerinit-framebufferscalefactor">#dom-xrwebgllayerinit-framebufferscalefactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayerinit-framebufferscalefactor" class="dfn-panel" data-for="dom-xrwebgllayerinit-framebufferscalefactor" id="infopanel-for-dom-xrwebgllayerinit-framebufferscalefactor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayerinit-framebufferscalefactor" style="display:none">Info about the 'framebufferScaleFactor' definition.</span><b><a href="#dom-xrwebgllayerinit-framebufferscalefactor">#dom-xrwebgllayerinit-framebufferscalefactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayerinit-framebufferscalefactor">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayerinit-framebufferscalefactor①">(2)</a> <a href="#ref-for-dom-xrwebgllayerinit-framebufferscalefactor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgllayer">
-   <b><a href="#xrwebgllayer">#xrwebgllayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgllayer" class="dfn-panel" data-for="xrwebgllayer" id="infopanel-for-xrwebgllayer" role="dialog">
+   <span id="infopaneltitle-for-xrwebgllayer" style="display:none">Info about the 'XRWebGLLayer' definition.</span><b><a href="#xrwebgllayer">#xrwebgllayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer">4.1. XRSession</a>
     <li><a href="#ref-for-xrwebgllayer①">4.2. XRRenderState</a> <a href="#ref-for-xrwebgllayer②">(2)</a> <a href="#ref-for-xrwebgllayer③">(3)</a> <a href="#ref-for-xrwebgllayer④">(4)</a>
@@ -9369,207 +9369,207 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrwebgllayer②⑨">13.7. Context Isolation</a> <a href="#ref-for-xrwebgllayer③⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgllayer-context">
-   <b><a href="#xrwebgllayer-context">#xrwebgllayer-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgllayer-context" class="dfn-panel" data-for="xrwebgllayer-context" id="infopanel-for-xrwebgllayer-context" role="dialog">
+   <span id="infopaneltitle-for-xrwebgllayer-context" style="display:none">Info about the 'context' definition.</span><b><a href="#xrwebgllayer-context">#xrwebgllayer-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer-context">4.1. XRSession</a>
     <li><a href="#ref-for-xrwebgllayer-context①">11.2. XRWebGLLayer</a> <a href="#ref-for-xrwebgllayer-context②">(2)</a> <a href="#ref-for-xrwebgllayer-context③">(3)</a> <a href="#ref-for-xrwebgllayer-context④">(4)</a>
     <li><a href="#ref-for-xrwebgllayer-context⑤">13.7. Context Isolation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgllayer-session">
-   <b><a href="#xrwebgllayer-session">#xrwebgllayer-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgllayer-session" class="dfn-panel" data-for="xrwebgllayer-session" id="infopanel-for-xrwebgllayer-session" role="dialog">
+   <span id="infopaneltitle-for-xrwebgllayer-session" style="display:none">Info about the 'session' definition.</span><b><a href="#xrwebgllayer-session">#xrwebgllayer-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer-session">11.2. XRWebGLLayer</a> <a href="#ref-for-xrwebgllayer-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-xrwebgllayer">
-   <b><a href="#dom-xrwebgllayer-xrwebgllayer">#dom-xrwebgllayer-xrwebgllayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-xrwebgllayer" class="dfn-panel" data-for="dom-xrwebgllayer-xrwebgllayer" id="infopanel-for-dom-xrwebgllayer-xrwebgllayer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-xrwebgllayer" style="display:none">Info about the 'XRWebGLLayer(session, context, layerInit)' definition.</span><b><a href="#dom-xrwebgllayer-xrwebgllayer">#dom-xrwebgllayer-xrwebgllayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-xrwebgllayer">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-context">
-   <b><a href="#dom-xrwebgllayer-context">#dom-xrwebgllayer-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-context" class="dfn-panel" data-for="dom-xrwebgllayer-context" id="infopanel-for-dom-xrwebgllayer-context" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-context" style="display:none">Info about the 'context' definition.</span><b><a href="#dom-xrwebgllayer-context">#dom-xrwebgllayer-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-context">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgllayer-composition-enabled">
-   <b><a href="#xrwebgllayer-composition-enabled">#xrwebgllayer-composition-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgllayer-composition-enabled" class="dfn-panel" data-for="xrwebgllayer-composition-enabled" id="infopanel-for-xrwebgllayer-composition-enabled" role="dialog">
+   <span id="infopaneltitle-for-xrwebgllayer-composition-enabled" style="display:none">Info about the 'composition enabled' definition.</span><b><a href="#xrwebgllayer-composition-enabled">#xrwebgllayer-composition-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer-composition-enabled">4.1. XRSession</a>
     <li><a href="#ref-for-xrwebgllayer-composition-enabled①">11.2. XRWebGLLayer</a> <a href="#ref-for-xrwebgllayer-composition-enabled②">(2)</a> <a href="#ref-for-xrwebgllayer-composition-enabled③">(3)</a> <a href="#ref-for-xrwebgllayer-composition-enabled④">(4)</a> <a href="#ref-for-xrwebgllayer-composition-enabled⑤">(5)</a> <a href="#ref-for-xrwebgllayer-composition-enabled⑥">(6)</a> <a href="#ref-for-xrwebgllayer-composition-enabled⑦">(7)</a> <a href="#ref-for-xrwebgllayer-composition-enabled⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-framebuffer">
-   <b><a href="#dom-xrwebgllayer-framebuffer">#dom-xrwebgllayer-framebuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-framebuffer" class="dfn-panel" data-for="dom-xrwebgllayer-framebuffer" id="infopanel-for-dom-xrwebgllayer-framebuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-framebuffer" style="display:none">Info about the 'framebuffer' definition.</span><b><a href="#dom-xrwebgllayer-framebuffer">#dom-xrwebgllayer-framebuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-framebuffer">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-framebuffer①">(2)</a> <a href="#ref-for-dom-xrwebgllayer-framebuffer②">(3)</a> <a href="#ref-for-dom-xrwebgllayer-framebuffer③">(4)</a> <a href="#ref-for-dom-xrwebgllayer-framebuffer④">(5)</a> <a href="#ref-for-dom-xrwebgllayer-framebuffer⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-framebuffer">
-   <b><a href="#opaque-framebuffer">#opaque-framebuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-framebuffer" class="dfn-panel" data-for="opaque-framebuffer" id="infopanel-for-opaque-framebuffer" role="dialog">
+   <span id="infopaneltitle-for-opaque-framebuffer" style="display:none">Info about the 'opaque framebuffer' definition.</span><b><a href="#opaque-framebuffer">#opaque-framebuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-framebuffer">11.2. XRWebGLLayer</a> <a href="#ref-for-opaque-framebuffer①">(2)</a> <a href="#ref-for-opaque-framebuffer②">(3)</a> <a href="#ref-for-opaque-framebuffer③">(4)</a> <a href="#ref-for-opaque-framebuffer④">(5)</a> <a href="#ref-for-opaque-framebuffer⑤">(6)</a> <a href="#ref-for-opaque-framebuffer⑥">(7)</a> <a href="#ref-for-opaque-framebuffer⑦">(8)</a> <a href="#ref-for-opaque-framebuffer⑧">(9)</a> <a href="#ref-for-opaque-framebuffer⑨">(10)</a> <a href="#ref-for-opaque-framebuffer①⓪">(11)</a> <a href="#ref-for-opaque-framebuffer①①">(12)</a> <a href="#ref-for-opaque-framebuffer①②">(13)</a> <a href="#ref-for-opaque-framebuffer①③">(14)</a> <a href="#ref-for-opaque-framebuffer①④">(15)</a> <a href="#ref-for-opaque-framebuffer①⑤">(16)</a> <a href="#ref-for-opaque-framebuffer①⑥">(17)</a> <a href="#ref-for-opaque-framebuffer①⑦">(18)</a> <a href="#ref-for-opaque-framebuffer①⑧">(19)</a> <a href="#ref-for-opaque-framebuffer①⑨">(20)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-framebuffer-session">
-   <b><a href="#opaque-framebuffer-session">#opaque-framebuffer-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-framebuffer-session" class="dfn-panel" data-for="opaque-framebuffer-session" id="infopanel-for-opaque-framebuffer-session" role="dialog">
+   <span id="infopaneltitle-for-opaque-framebuffer-session" style="display:none">Info about the 'session' definition.</span><b><a href="#opaque-framebuffer-session">#opaque-framebuffer-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-framebuffer-session">11.2. XRWebGLLayer</a> <a href="#ref-for-opaque-framebuffer-session①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrwebgllayer-target-framebuffer">
-   <b><a href="#xrwebgllayer-target-framebuffer">#xrwebgllayer-target-framebuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrwebgllayer-target-framebuffer" class="dfn-panel" data-for="xrwebgllayer-target-framebuffer" id="infopanel-for-xrwebgllayer-target-framebuffer" role="dialog">
+   <span id="infopaneltitle-for-xrwebgllayer-target-framebuffer" style="display:none">Info about the 'target framebuffer' definition.</span><b><a href="#xrwebgllayer-target-framebuffer">#xrwebgllayer-target-framebuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrwebgllayer-target-framebuffer">11.2. XRWebGLLayer</a> <a href="#ref-for-xrwebgllayer-target-framebuffer①">(2)</a> <a href="#ref-for-xrwebgllayer-target-framebuffer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-framebufferwidth">
-   <b><a href="#dom-xrwebgllayer-framebufferwidth">#dom-xrwebgllayer-framebufferwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-framebufferwidth" class="dfn-panel" data-for="dom-xrwebgllayer-framebufferwidth" id="infopanel-for-dom-xrwebgllayer-framebufferwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-framebufferwidth" style="display:none">Info about the 'framebufferWidth' definition.</span><b><a href="#dom-xrwebgllayer-framebufferwidth">#dom-xrwebgllayer-framebufferwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-framebufferwidth">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-framebufferheight">
-   <b><a href="#dom-xrwebgllayer-framebufferheight">#dom-xrwebgllayer-framebufferheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-framebufferheight" class="dfn-panel" data-for="dom-xrwebgllayer-framebufferheight" id="infopanel-for-dom-xrwebgllayer-framebufferheight" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-framebufferheight" style="display:none">Info about the 'framebufferHeight' definition.</span><b><a href="#dom-xrwebgllayer-framebufferheight">#dom-xrwebgllayer-framebufferheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-framebufferheight">11.2. XRWebGLLayer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-antialias">
-   <b><a href="#dom-xrwebgllayer-antialias">#dom-xrwebgllayer-antialias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-antialias" class="dfn-panel" data-for="dom-xrwebgllayer-antialias" id="infopanel-for-dom-xrwebgllayer-antialias" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-antialias" style="display:none">Info about the 'antialias' definition.</span><b><a href="#dom-xrwebgllayer-antialias">#dom-xrwebgllayer-antialias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-antialias">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-antialias①">(2)</a> <a href="#ref-for-dom-xrwebgllayer-antialias②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-ignoredepthvalues">
-   <b><a href="#dom-xrwebgllayer-ignoredepthvalues">#dom-xrwebgllayer-ignoredepthvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-ignoredepthvalues" class="dfn-panel" data-for="dom-xrwebgllayer-ignoredepthvalues" id="infopanel-for-dom-xrwebgllayer-ignoredepthvalues" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-ignoredepthvalues" style="display:none">Info about the 'ignoreDepthValues' definition.</span><b><a href="#dom-xrwebgllayer-ignoredepthvalues">#dom-xrwebgllayer-ignoredepthvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-ignoredepthvalues">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-ignoredepthvalues①">(2)</a> <a href="#ref-for-dom-xrwebgllayer-ignoredepthvalues②">(3)</a> <a href="#ref-for-dom-xrwebgllayer-ignoredepthvalues③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-full-sized-viewports">
-   <b><a href="#list-of-full-sized-viewports">#list-of-full-sized-viewports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-full-sized-viewports" class="dfn-panel" data-for="list-of-full-sized-viewports" id="infopanel-for-list-of-full-sized-viewports" role="dialog">
+   <span id="infopaneltitle-for-list-of-full-sized-viewports" style="display:none">Info about the 'list of full-sized viewports' definition.</span><b><a href="#list-of-full-sized-viewports">#list-of-full-sized-viewports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-full-sized-viewports">7.1. XRView</a> <a href="#ref-for-list-of-full-sized-viewports①">(2)</a>
     <li><a href="#ref-for-list-of-full-sized-viewports②">11.2. XRWebGLLayer</a> <a href="#ref-for-list-of-full-sized-viewports③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-viewport-objects">
-   <b><a href="#list-of-viewport-objects">#list-of-viewport-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-viewport-objects" class="dfn-panel" data-for="list-of-viewport-objects" id="infopanel-for-list-of-viewport-objects" role="dialog">
+   <span id="infopaneltitle-for-list-of-viewport-objects" style="display:none">Info about the 'list of viewport objects' definition.</span><b><a href="#list-of-viewport-objects">#list-of-viewport-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-viewport-objects">7.1. XRView</a> <a href="#ref-for-list-of-viewport-objects①">(2)</a>
     <li><a href="#ref-for-list-of-viewport-objects②">11.2. XRWebGLLayer</a> <a href="#ref-for-list-of-viewport-objects③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-getviewport">
-   <b><a href="#dom-xrwebgllayer-getviewport">#dom-xrwebgllayer-getviewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-getviewport" class="dfn-panel" data-for="dom-xrwebgllayer-getviewport" id="infopanel-for-dom-xrwebgllayer-getviewport" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-getviewport" style="display:none">Info about the 'getViewport(view)' definition.</span><b><a href="#dom-xrwebgllayer-getviewport">#dom-xrwebgllayer-getviewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-getviewport">7.1. XRView</a> <a href="#ref-for-dom-xrwebgllayer-getviewport①">(2)</a> <a href="#ref-for-dom-xrwebgllayer-getviewport②">(3)</a>
     <li><a href="#ref-for-dom-xrwebgllayer-getviewport③">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-getviewport④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-webgl-framebuffer-resolution">
-   <b><a href="#native-webgl-framebuffer-resolution">#native-webgl-framebuffer-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-webgl-framebuffer-resolution" class="dfn-panel" data-for="native-webgl-framebuffer-resolution" id="infopanel-for-native-webgl-framebuffer-resolution" role="dialog">
+   <span id="infopaneltitle-for-native-webgl-framebuffer-resolution" style="display:none">Info about the 'native WebGL framebuffer resolution' definition.</span><b><a href="#native-webgl-framebuffer-resolution">#native-webgl-framebuffer-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-webgl-framebuffer-resolution">11.2. XRWebGLLayer</a> <a href="#ref-for-native-webgl-framebuffer-resolution①">(2)</a> <a href="#ref-for-native-webgl-framebuffer-resolution②">(3)</a> <a href="#ref-for-native-webgl-framebuffer-resolution③">(4)</a> <a href="#ref-for-native-webgl-framebuffer-resolution④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="recommended-webgl-framebuffer-resolution">
-   <b><a href="#recommended-webgl-framebuffer-resolution">#recommended-webgl-framebuffer-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-recommended-webgl-framebuffer-resolution" class="dfn-panel" data-for="recommended-webgl-framebuffer-resolution" id="infopanel-for-recommended-webgl-framebuffer-resolution" role="dialog">
+   <span id="infopaneltitle-for-recommended-webgl-framebuffer-resolution" style="display:none">Info about the 'recommended WebGL framebuffer resolution' definition.</span><b><a href="#recommended-webgl-framebuffer-resolution">#recommended-webgl-framebuffer-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-recommended-webgl-framebuffer-resolution">11.2. XRWebGLLayer</a> <a href="#ref-for-recommended-webgl-framebuffer-resolution①">(2)</a> <a href="#ref-for-recommended-webgl-framebuffer-resolution②">(3)</a> <a href="#ref-for-recommended-webgl-framebuffer-resolution③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrwebgllayer-getnativeframebufferscalefactor">
-   <b><a href="#dom-xrwebgllayer-getnativeframebufferscalefactor">#dom-xrwebgllayer-getnativeframebufferscalefactor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrwebgllayer-getnativeframebufferscalefactor" class="dfn-panel" data-for="dom-xrwebgllayer-getnativeframebufferscalefactor" id="infopanel-for-dom-xrwebgllayer-getnativeframebufferscalefactor" role="dialog">
+   <span id="infopaneltitle-for-dom-xrwebgllayer-getnativeframebufferscalefactor" style="display:none">Info about the 'getNativeFramebufferScaleFactor(session)' definition.</span><b><a href="#dom-xrwebgllayer-getnativeframebufferscalefactor">#dom-xrwebgllayer-getnativeframebufferscalefactor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrwebgllayer-getnativeframebufferscalefactor">11.2. XRWebGLLayer</a> <a href="#ref-for-dom-xrwebgllayer-getnativeframebufferscalefactor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compatible-graphics-adapter">
-   <b><a href="#compatible-graphics-adapter">#compatible-graphics-adapter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compatible-graphics-adapter" class="dfn-panel" data-for="compatible-graphics-adapter" id="infopanel-for-compatible-graphics-adapter" role="dialog">
+   <span id="infopaneltitle-for-compatible-graphics-adapter" style="display:none">Info about the 'compatible graphics adapter' definition.</span><b><a href="#compatible-graphics-adapter">#compatible-graphics-adapter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compatible-graphics-adapter">11.3. WebGL Context Compatibility</a> <a href="#ref-for-compatible-graphics-adapter①">(2)</a> <a href="#ref-for-compatible-graphics-adapter②">(3)</a> <a href="#ref-for-compatible-graphics-adapter③">(4)</a> <a href="#ref-for-compatible-graphics-adapter④">(5)</a> <a href="#ref-for-compatible-graphics-adapter⑤">(6)</a> <a href="#ref-for-compatible-graphics-adapter⑥">(7)</a> <a href="#ref-for-compatible-graphics-adapter⑦">(8)</a> <a href="#ref-for-compatible-graphics-adapter⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webglcontextattributes-xrcompatible">
-   <b><a href="#dom-webglcontextattributes-xrcompatible">#dom-webglcontextattributes-xrcompatible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webglcontextattributes-xrcompatible" class="dfn-panel" data-for="dom-webglcontextattributes-xrcompatible" id="infopanel-for-dom-webglcontextattributes-xrcompatible" role="dialog">
+   <span id="infopaneltitle-for-dom-webglcontextattributes-xrcompatible" style="display:none">Info about the 'xrCompatible' definition.</span><b><a href="#dom-webglcontextattributes-xrcompatible">#dom-webglcontextattributes-xrcompatible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webglcontextattributes-xrcompatible">11.3. WebGL Context Compatibility</a> <a href="#ref-for-dom-webglcontextattributes-xrcompatible①">(2)</a> <a href="#ref-for-dom-webglcontextattributes-xrcompatible②">(3)</a> <a href="#ref-for-dom-webglcontextattributes-xrcompatible③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xr-compatible">
-   <b><a href="#xr-compatible">#xr-compatible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xr-compatible" class="dfn-panel" data-for="xr-compatible" id="infopanel-for-xr-compatible" role="dialog">
+   <span id="infopaneltitle-for-xr-compatible" style="display:none">Info about the 'XR compatible' definition.</span><b><a href="#xr-compatible">#xr-compatible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xr-compatible">3.2. XRSystem</a>
     <li><a href="#ref-for-xr-compatible①">11.2. XRWebGLLayer</a>
     <li><a href="#ref-for-xr-compatible②">11.3. WebGL Context Compatibility</a> <a href="#ref-for-xr-compatible③">(2)</a> <a href="#ref-for-xr-compatible④">(3)</a> <a href="#ref-for-xr-compatible⑤">(4)</a> <a href="#ref-for-xr-compatible⑥">(5)</a> <a href="#ref-for-xr-compatible⑦">(6)</a> <a href="#ref-for-xr-compatible⑧">(7)</a> <a href="#ref-for-xr-compatible⑨">(8)</a> <a href="#ref-for-xr-compatible①⓪">(9)</a> <a href="#ref-for-xr-compatible①①">(10)</a> <a href="#ref-for-xr-compatible①②">(11)</a> <a href="#ref-for-xr-compatible①③">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webglrenderingcontextbase-makexrcompatible">
-   <b><a href="#dom-webglrenderingcontextbase-makexrcompatible">#dom-webglrenderingcontextbase-makexrcompatible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webglrenderingcontextbase-makexrcompatible" class="dfn-panel" data-for="dom-webglrenderingcontextbase-makexrcompatible" id="infopanel-for-dom-webglrenderingcontextbase-makexrcompatible" role="dialog">
+   <span id="infopaneltitle-for-dom-webglrenderingcontextbase-makexrcompatible" style="display:none">Info about the 'makeXRCompatible()' definition.</span><b><a href="#dom-webglrenderingcontextbase-makexrcompatible">#dom-webglrenderingcontextbase-makexrcompatible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible">11.3. WebGL Context Compatibility</a> <a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible①">(2)</a> <a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible②">(3)</a> <a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible③">(4)</a> <a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible④">(5)</a> <a href="#ref-for-dom-webglrenderingcontextbase-makexrcompatible⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrsessionevent">
-   <b><a href="#xrsessionevent">#xrsessionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrsessionevent" class="dfn-panel" data-for="xrsessionevent" id="infopanel-for-xrsessionevent" role="dialog">
+   <span id="infopaneltitle-for-xrsessionevent" style="display:none">Info about the 'XRSessionEvent' definition.</span><b><a href="#xrsessionevent">#xrsessionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrsessionevent">4.1. XRSession</a>
     <li><a href="#ref-for-xrsessionevent①">12.1. XRSessionEvent</a>
     <li><a href="#ref-for-xrsessionevent②">12.5. Event Types</a> <a href="#ref-for-xrsessionevent③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrsessioneventinit">
-   <b><a href="#dictdef-xrsessioneventinit">#dictdef-xrsessioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrsessioneventinit" class="dfn-panel" data-for="dictdef-xrsessioneventinit" id="infopanel-for-dictdef-xrsessioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrsessioneventinit" style="display:none">Info about the 'XRSessionEventInit' definition.</span><b><a href="#dictdef-xrsessioneventinit">#dictdef-xrsessioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrsessioneventinit">12.1. XRSessionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionevent-session">
-   <b><a href="#dom-xrsessionevent-session">#dom-xrsessionevent-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionevent-session" class="dfn-panel" data-for="dom-xrsessionevent-session" id="infopanel-for-dom-xrsessionevent-session" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionevent-session" style="display:none">Info about the 'session' definition.</span><b><a href="#dom-xrsessionevent-session">#dom-xrsessionevent-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionevent-session">12.1. XRSessionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrinputsourceevent">
-   <b><a href="#xrinputsourceevent">#xrinputsourceevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrinputsourceevent" class="dfn-panel" data-for="xrinputsourceevent" id="infopanel-for-xrinputsourceevent" role="dialog">
+   <span id="infopaneltitle-for-xrinputsourceevent" style="display:none">Info about the 'XRInputSourceEvent' definition.</span><b><a href="#xrinputsourceevent">#xrinputsourceevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsourceevent">10.1. XRInputSource</a> <a href="#ref-for-xrinputsourceevent①">(2)</a>
     <li><a href="#ref-for-xrinputsourceevent②">12.2. XRInputSourceEvent</a> <a href="#ref-for-xrinputsourceevent③">(2)</a>
     <li><a href="#ref-for-xrinputsourceevent④">12.5. Event Types</a> <a href="#ref-for-xrinputsourceevent⑤">(2)</a> <a href="#ref-for-xrinputsourceevent⑥">(3)</a> <a href="#ref-for-xrinputsourceevent⑦">(4)</a> <a href="#ref-for-xrinputsourceevent⑧">(5)</a> <a href="#ref-for-xrinputsourceevent⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrinputsourceeventinit">
-   <b><a href="#dictdef-xrinputsourceeventinit">#dictdef-xrinputsourceeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrinputsourceeventinit" class="dfn-panel" data-for="dictdef-xrinputsourceeventinit" id="infopanel-for-dictdef-xrinputsourceeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrinputsourceeventinit" style="display:none">Info about the 'XRInputSourceEventInit' definition.</span><b><a href="#dictdef-xrinputsourceeventinit">#dictdef-xrinputsourceeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrinputsourceeventinit">12.2. XRInputSourceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourceevent-inputsource">
-   <b><a href="#dom-xrinputsourceevent-inputsource">#dom-xrinputsourceevent-inputsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourceevent-inputsource" class="dfn-panel" data-for="dom-xrinputsourceevent-inputsource" id="infopanel-for-dom-xrinputsourceevent-inputsource" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourceevent-inputsource" style="display:none">Info about the 'inputSource' definition.</span><b><a href="#dom-xrinputsourceevent-inputsource">#dom-xrinputsourceevent-inputsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceevent-inputsource">12.2. XRInputSourceEvent</a> <a href="#ref-for-dom-xrinputsourceevent-inputsource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourceevent-frame">
-   <b><a href="#dom-xrinputsourceevent-frame">#dom-xrinputsourceevent-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourceevent-frame" class="dfn-panel" data-for="dom-xrinputsourceevent-frame" id="infopanel-for-dom-xrinputsourceevent-frame" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourceevent-frame" style="display:none">Info about the 'frame' definition.</span><b><a href="#dom-xrinputsourceevent-frame">#dom-xrinputsourceevent-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceevent-frame">12.2. XRInputSourceEvent</a> <a href="#ref-for-dom-xrinputsourceevent-frame①">(2)</a> <a href="#ref-for-dom-xrinputsourceevent-frame②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-an-input-source-event">
-   <b><a href="#fire-an-input-source-event">#fire-an-input-source-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-an-input-source-event" class="dfn-panel" data-for="fire-an-input-source-event" id="infopanel-for-fire-an-input-source-event" role="dialog">
+   <span id="infopaneltitle-for-fire-an-input-source-event" style="display:none">Info about the 'fire an input source event' definition.</span><b><a href="#fire-an-input-source-event">#fire-an-input-source-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-input-source-event">10.1. XRInputSource</a> <a href="#ref-for-fire-an-input-source-event①">(2)</a> <a href="#ref-for-fire-an-input-source-event②">(3)</a> <a href="#ref-for-fire-an-input-source-event③">(4)</a> <a href="#ref-for-fire-an-input-source-event④">(5)</a> <a href="#ref-for-fire-an-input-source-event⑤">(6)</a> <a href="#ref-for-fire-an-input-source-event⑥">(7)</a> <a href="#ref-for-fire-an-input-source-event⑦">(8)</a>
     <li><a href="#ref-for-fire-an-input-source-event⑧">10.2. Transient input</a> <a href="#ref-for-fire-an-input-source-event⑨">(2)</a> <a href="#ref-for-fire-an-input-source-event①⓪">(3)</a> <a href="#ref-for-fire-an-input-source-event①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrinputsourceschangeevent">
-   <b><a href="#xrinputsourceschangeevent">#xrinputsourceschangeevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrinputsourceschangeevent" class="dfn-panel" data-for="xrinputsourceschangeevent" id="infopanel-for-xrinputsourceschangeevent" role="dialog">
+   <span id="infopaneltitle-for-xrinputsourceschangeevent" style="display:none">Info about the 'XRInputSourcesChangeEvent' definition.</span><b><a href="#xrinputsourceschangeevent">#xrinputsourceschangeevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrinputsourceschangeevent">3.2. XRSystem</a>
     <li><a href="#ref-for-xrinputsourceschangeevent①">4.1. XRSession</a> <a href="#ref-for-xrinputsourceschangeevent②">(2)</a> <a href="#ref-for-xrinputsourceschangeevent③">(3)</a>
@@ -9577,101 +9577,101 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-xrinputsourceschangeevent⑤">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrinputsourceschangeeventinit">
-   <b><a href="#dictdef-xrinputsourceschangeeventinit">#dictdef-xrinputsourceschangeeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrinputsourceschangeeventinit" class="dfn-panel" data-for="dictdef-xrinputsourceschangeeventinit" id="infopanel-for-dictdef-xrinputsourceschangeeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrinputsourceschangeeventinit" style="display:none">Info about the 'XRInputSourcesChangeEventInit' definition.</span><b><a href="#dictdef-xrinputsourceschangeeventinit">#dictdef-xrinputsourceschangeeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrinputsourceschangeeventinit">12.3. XRInputSourcesChangeEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourceschangeevent-session">
-   <b><a href="#dom-xrinputsourceschangeevent-session">#dom-xrinputsourceschangeevent-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourceschangeevent-session" class="dfn-panel" data-for="dom-xrinputsourceschangeevent-session" id="infopanel-for-dom-xrinputsourceschangeevent-session" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourceschangeevent-session" style="display:none">Info about the 'session' definition.</span><b><a href="#dom-xrinputsourceschangeevent-session">#dom-xrinputsourceschangeevent-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-session">12.3. XRInputSourcesChangeEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourceschangeevent-added">
-   <b><a href="#dom-xrinputsourceschangeevent-added">#dom-xrinputsourceschangeevent-added</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourceschangeevent-added" class="dfn-panel" data-for="dom-xrinputsourceschangeevent-added" id="infopanel-for-dom-xrinputsourceschangeevent-added" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourceschangeevent-added" style="display:none">Info about the 'added' definition.</span><b><a href="#dom-xrinputsourceschangeevent-added">#dom-xrinputsourceschangeevent-added</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-added">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-added①">4.1. XRSession</a> <a href="#ref-for-dom-xrinputsourceschangeevent-added②">(2)</a>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-added③">12.3. XRInputSourcesChangeEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrinputsourceschangeevent-removed">
-   <b><a href="#dom-xrinputsourceschangeevent-removed">#dom-xrinputsourceschangeevent-removed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrinputsourceschangeevent-removed" class="dfn-panel" data-for="dom-xrinputsourceschangeevent-removed" id="infopanel-for-dom-xrinputsourceschangeevent-removed" role="dialog">
+   <span id="infopaneltitle-for-dom-xrinputsourceschangeevent-removed" style="display:none">Info about the 'removed' definition.</span><b><a href="#dom-xrinputsourceschangeevent-removed">#dom-xrinputsourceschangeevent-removed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-removed">4.1. XRSession</a> <a href="#ref-for-dom-xrinputsourceschangeevent-removed①">(2)</a>
     <li><a href="#ref-for-dom-xrinputsourceschangeevent-removed②">12.3. XRInputSourcesChangeEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrreferencespaceevent">
-   <b><a href="#xrreferencespaceevent">#xrreferencespaceevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrreferencespaceevent" class="dfn-panel" data-for="xrreferencespaceevent" id="infopanel-for-xrreferencespaceevent" role="dialog">
+   <span id="infopaneltitle-for-xrreferencespaceevent" style="display:none">Info about the 'XRReferenceSpaceEvent' definition.</span><b><a href="#xrreferencespaceevent">#xrreferencespaceevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrreferencespaceevent">12.4. XRReferenceSpaceEvent</a>
     <li><a href="#ref-for-xrreferencespaceevent①">12.5. Event Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrreferencespaceeventinit">
-   <b><a href="#dictdef-xrreferencespaceeventinit">#dictdef-xrreferencespaceeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrreferencespaceeventinit" class="dfn-panel" data-for="dictdef-xrreferencespaceeventinit" id="infopanel-for-dictdef-xrreferencespaceeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrreferencespaceeventinit" style="display:none">Info about the 'XRReferenceSpaceEventInit' definition.</span><b><a href="#dictdef-xrreferencespaceeventinit">#dictdef-xrreferencespaceeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrreferencespaceeventinit">12.4. XRReferenceSpaceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespaceevent-referencespace">
-   <b><a href="#dom-xrreferencespaceevent-referencespace">#dom-xrreferencespaceevent-referencespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespaceevent-referencespace" class="dfn-panel" data-for="dom-xrreferencespaceevent-referencespace" id="infopanel-for-dom-xrreferencespaceevent-referencespace" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespaceevent-referencespace" style="display:none">Info about the 'referenceSpace' definition.</span><b><a href="#dom-xrreferencespaceevent-referencespace">#dom-xrreferencespaceevent-referencespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespaceevent-referencespace">12.4. XRReferenceSpaceEvent</a> <a href="#ref-for-dom-xrreferencespaceevent-referencespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrreferencespaceevent-transform">
-   <b><a href="#dom-xrreferencespaceevent-transform">#dom-xrreferencespaceevent-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrreferencespaceevent-transform" class="dfn-panel" data-for="dom-xrreferencespaceevent-transform" id="infopanel-for-dom-xrreferencespaceevent-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-xrreferencespaceevent-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-xrreferencespaceevent-transform">#dom-xrreferencespaceevent-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrreferencespaceevent-transform">12.4. XRReferenceSpaceEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsystem-devicechange">
-   <b><a href="#eventdef-xrsystem-devicechange">#eventdef-xrsystem-devicechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsystem-devicechange" class="dfn-panel" data-for="eventdef-xrsystem-devicechange" id="infopanel-for-eventdef-xrsystem-devicechange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsystem-devicechange" style="display:none">Info about the 'devicechange' definition.</span><b><a href="#eventdef-xrsystem-devicechange">#eventdef-xrsystem-devicechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsystem-devicechange">3.2. XRSystem</a> <a href="#ref-for-eventdef-xrsystem-devicechange①">(2)</a>
     <li><a href="#ref-for-eventdef-xrsystem-devicechange②">13.7. Context Isolation</a>
     <li><a href="#ref-for-eventdef-xrsystem-devicechange③">14.1. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-visibilitychange">
-   <b><a href="#eventdef-xrsession-visibilitychange">#eventdef-xrsession-visibilitychange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-visibilitychange" class="dfn-panel" data-for="eventdef-xrsession-visibilitychange" id="infopanel-for-eventdef-xrsession-visibilitychange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-visibilitychange" style="display:none">Info about the 'visibilitychange' definition.</span><b><a href="#eventdef-xrsession-visibilitychange">#eventdef-xrsession-visibilitychange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-visibilitychange">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-end">
-   <b><a href="#eventdef-xrsession-end">#eventdef-xrsession-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-end" class="dfn-panel" data-for="eventdef-xrsession-end" id="infopanel-for-eventdef-xrsession-end" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-end" style="display:none">Info about the 'end' definition.</span><b><a href="#eventdef-xrsession-end">#eventdef-xrsession-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-end">4.1. XRSession</a> <a href="#ref-for-eventdef-xrsession-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-inputsourceschange">
-   <b><a href="#eventdef-xrsession-inputsourceschange">#eventdef-xrsession-inputsourceschange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-inputsourceschange" class="dfn-panel" data-for="eventdef-xrsession-inputsourceschange" id="infopanel-for-eventdef-xrsession-inputsourceschange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-inputsourceschange" style="display:none">Info about the 'inputsourceschange' definition.</span><b><a href="#eventdef-xrsession-inputsourceschange">#eventdef-xrsession-inputsourceschange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-inputsourceschange">3.2. XRSystem</a> <a href="#ref-for-eventdef-xrsession-inputsourceschange①">(2)</a>
     <li><a href="#ref-for-eventdef-xrsession-inputsourceschange②">4.1. XRSession</a> <a href="#ref-for-eventdef-xrsession-inputsourceschange③">(2)</a> <a href="#ref-for-eventdef-xrsession-inputsourceschange④">(3)</a> <a href="#ref-for-eventdef-xrsession-inputsourceschange⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-selectstart">
-   <b><a href="#eventdef-xrsession-selectstart">#eventdef-xrsession-selectstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-selectstart" class="dfn-panel" data-for="eventdef-xrsession-selectstart" id="infopanel-for-eventdef-xrsession-selectstart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-selectstart" style="display:none">Info about the 'selectstart' definition.</span><b><a href="#eventdef-xrsession-selectstart">#eventdef-xrsession-selectstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-selectstart">10.1. XRInputSource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-selectend">
-   <b><a href="#eventdef-xrsession-selectend">#eventdef-xrsession-selectend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-selectend" class="dfn-panel" data-for="eventdef-xrsession-selectend" id="infopanel-for-eventdef-xrsession-selectend" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-selectend" style="display:none">Info about the 'selectend' definition.</span><b><a href="#eventdef-xrsession-selectend">#eventdef-xrsession-selectend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-selectend">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrsession-selectend①">10.1. XRInputSource</a> <a href="#ref-for-eventdef-xrsession-selectend②">(2)</a> <a href="#ref-for-eventdef-xrsession-selectend③">(3)</a>
     <li><a href="#ref-for-eventdef-xrsession-selectend④">10.2. Transient input</a> <a href="#ref-for-eventdef-xrsession-selectend⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-select">
-   <b><a href="#eventdef-xrsession-select">#eventdef-xrsession-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-select" class="dfn-panel" data-for="eventdef-xrsession-select" id="infopanel-for-eventdef-xrsession-select" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-select" style="display:none">Info about the 'select' definition.</span><b><a href="#eventdef-xrsession-select">#eventdef-xrsession-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-select">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrsession-select①">5.1. XRFrame</a>
@@ -9679,37 +9679,37 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-eventdef-xrsession-select④">10.2. Transient input</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-squeezestart">
-   <b><a href="#eventdef-xrsession-squeezestart">#eventdef-xrsession-squeezestart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-squeezestart" class="dfn-panel" data-for="eventdef-xrsession-squeezestart" id="infopanel-for-eventdef-xrsession-squeezestart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-squeezestart" style="display:none">Info about the 'squeezestart' definition.</span><b><a href="#eventdef-xrsession-squeezestart">#eventdef-xrsession-squeezestart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-squeezestart">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrsession-squeezestart①">10.1. XRInputSource</a> <a href="#ref-for-eventdef-xrsession-squeezestart②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-squeezeend">
-   <b><a href="#eventdef-xrsession-squeezeend">#eventdef-xrsession-squeezeend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-squeezeend" class="dfn-panel" data-for="eventdef-xrsession-squeezeend" id="infopanel-for-eventdef-xrsession-squeezeend" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-squeezeend" style="display:none">Info about the 'squeezeend' definition.</span><b><a href="#eventdef-xrsession-squeezeend">#eventdef-xrsession-squeezeend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-squeezeend">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrsession-squeezeend①">10.1. XRInputSource</a> <a href="#ref-for-eventdef-xrsession-squeezeend②">(2)</a> <a href="#ref-for-eventdef-xrsession-squeezeend③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrsession-squeeze">
-   <b><a href="#eventdef-xrsession-squeeze">#eventdef-xrsession-squeeze</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrsession-squeeze" class="dfn-panel" data-for="eventdef-xrsession-squeeze" id="infopanel-for-eventdef-xrsession-squeeze" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrsession-squeeze" style="display:none">Info about the 'squeeze' definition.</span><b><a href="#eventdef-xrsession-squeeze">#eventdef-xrsession-squeeze</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrsession-squeeze">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrsession-squeeze①">10.1. XRInputSource</a> <a href="#ref-for-eventdef-xrsession-squeeze②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-xrreferencespace-reset">
-   <b><a href="#eventdef-xrreferencespace-reset">#eventdef-xrreferencespace-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-xrreferencespace-reset" class="dfn-panel" data-for="eventdef-xrreferencespace-reset" id="infopanel-for-eventdef-xrreferencespace-reset" role="dialog">
+   <span id="infopaneltitle-for-eventdef-xrreferencespace-reset" style="display:none">Info about the 'reset' definition.</span><b><a href="#eventdef-xrreferencespace-reset">#eventdef-xrreferencespace-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-xrreferencespace-reset">4.1. XRSession</a>
     <li><a href="#ref-for-eventdef-xrreferencespace-reset①">6.2. XRReferenceSpace</a>
     <li><a href="#ref-for-eventdef-xrreferencespace-reset②">12.5. Event Types</a> <a href="#ref-for-eventdef-xrreferencespace-reset③">(2)</a> <a href="#ref-for-eventdef-xrreferencespace-reset④">(3)</a> <a href="#ref-for-eventdef-xrreferencespace-reset⑤">(4)</a> <a href="#ref-for-eventdef-xrreferencespace-reset⑥">(5)</a> <a href="#ref-for-eventdef-xrreferencespace-reset⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensitive-information">
-   <b><a href="#sensitive-information">#sensitive-information</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensitive-information" class="dfn-panel" data-for="sensitive-information" id="infopanel-for-sensitive-information" role="dialog">
+   <span id="infopaneltitle-for-sensitive-information" style="display:none">Info about the 'sensitive information' definition.</span><b><a href="#sensitive-information">#sensitive-information</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensitive-information">3.4. Feature Dependencies</a> <a href="#ref-for-sensitive-information①">(2)</a>
     <li><a href="#ref-for-sensitive-information②">13.2.4. Duration of consent</a>
@@ -9720,8 +9720,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-sensitive-information⑨">13.8. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-intent">
-   <b><a href="#user-intent">#user-intent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-intent" class="dfn-panel" data-for="user-intent" id="infopanel-for-user-intent" role="dialog">
+   <span id="infopaneltitle-for-user-intent" style="display:none">Info about the 'User intent' definition.</span><b><a href="#user-intent">#user-intent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-intent">3.4. Feature Dependencies</a> <a href="#ref-for-user-intent①">(2)</a> <a href="#ref-for-user-intent②">(3)</a> <a href="#ref-for-user-intent③">(4)</a> <a href="#ref-for-user-intent④">(5)</a> <a href="#ref-for-user-intent⑤">(6)</a>
     <li><a href="#ref-for-user-intent⑥">13.2. User intention</a>
@@ -9735,15 +9735,15 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-user-intent①④">14.2. Permissions API Integration</a> <a href="#ref-for-user-intent①⑤">(2)</a> <a href="#ref-for-user-intent①⑥">(3)</a> <a href="#ref-for-user-intent①⑦">(4)</a> <a href="#ref-for-user-intent①⑧">(5)</a> <a href="#ref-for-user-intent①⑨">(6)</a> <a href="#ref-for-user-intent②⓪">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="launching-a-web-application">
-   <b><a href="#launching-a-web-application">#launching-a-web-application</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-launching-a-web-application" class="dfn-panel" data-for="launching-a-web-application" id="infopanel-for-launching-a-web-application" role="dialog">
+   <span id="infopaneltitle-for-launching-a-web-application" style="display:none">Info about the 'launching a web application' definition.</span><b><a href="#launching-a-web-application">#launching-a-web-application</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-launching-a-web-application">13.5.1. Immersiveness</a> <a href="#ref-for-launching-a-web-application①">(2)</a>
     <li><a href="#ref-for-launching-a-web-application②">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-consent">
-   <b><a href="#implicit-consent">#implicit-consent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-consent" class="dfn-panel" data-for="implicit-consent" id="infopanel-for-implicit-consent" role="dialog">
+   <span id="infopaneltitle-for-implicit-consent" style="display:none">Info about the 'Implicit consent' definition.</span><b><a href="#implicit-consent">#implicit-consent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-consent">3.4. Feature Dependencies</a> <a href="#ref-for-implicit-consent①">(2)</a>
     <li><a href="#ref-for-implicit-consent②">13.5.1. Immersiveness</a>
@@ -9751,8 +9751,8 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-implicit-consent④">13.5.3. Reference spaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-consent">
-   <b><a href="#explicit-consent">#explicit-consent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-consent" class="dfn-panel" data-for="explicit-consent" id="infopanel-for-explicit-consent" role="dialog">
+   <span id="infopaneltitle-for-explicit-consent" style="display:none">Info about the 'Explicit consent' definition.</span><b><a href="#explicit-consent">#explicit-consent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-consent">3.4. Feature Dependencies</a> <a href="#ref-for-explicit-consent①">(2)</a>
     <li><a href="#ref-for-explicit-consent②">13.2.3. Implicit and Explicit consent</a> <a href="#ref-for-explicit-consent③">(2)</a> <a href="#ref-for-explicit-consent④">(3)</a>
@@ -9765,168 +9765,168 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
     <li><a href="#ref-for-explicit-consent①⑥">14.2. Permissions API Integration</a> <a href="#ref-for-explicit-consent①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-adjustment">
-   <b><a href="#data-adjustment">#data-adjustment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-adjustment" class="dfn-panel" data-for="data-adjustment" id="infopanel-for-data-adjustment" role="dialog">
+   <span id="infopaneltitle-for-data-adjustment" style="display:none">Info about the 'data adjustment' definition.</span><b><a href="#data-adjustment">#data-adjustment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-adjustment">13.4. Data adjustments</a>
     <li><a href="#ref-for-data-adjustment①">13.5.2. Poses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="throttling">
-   <b><a href="#throttling">#throttling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-throttling" class="dfn-panel" data-for="throttling" id="infopanel-for-throttling" role="dialog">
+   <span id="infopaneltitle-for-throttling" style="display:none">Info about the 'Throttling' definition.</span><b><a href="#throttling">#throttling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-throttling">4.1. XRSession</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rounding">
-   <b><a href="#rounding">#rounding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rounding" class="dfn-panel" data-for="rounding" id="infopanel-for-rounding" role="dialog">
+   <span id="infopaneltitle-for-rounding" style="display:none">Info about the 'Rounding' definition.</span><b><a href="#rounding">#rounding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rounding">6.2. XRReferenceSpace</a> <a href="#ref-for-rounding①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quantization">
-   <b><a href="#quantization">#quantization</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quantization" class="dfn-panel" data-for="quantization" id="infopanel-for-quantization" role="dialog">
+   <span id="infopaneltitle-for-quantization" style="display:none">Info about the 'Quantization' definition.</span><b><a href="#quantization">#quantization</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quantization">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-quantization①">(2)</a>
     <li><a href="#ref-for-quantization②">7.1. XRView</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="limiting">
-   <b><a href="#limiting">#limiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limiting" class="dfn-panel" data-for="limiting" id="infopanel-for-limiting" role="dialog">
+   <span id="infopaneltitle-for-limiting" style="display:none">Info about the 'Limiting' definition.</span><b><a href="#limiting">#limiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limiting">6.3. XRBoundedReferenceSpace</a> <a href="#ref-for-limiting①">(2)</a>
     <li><a href="#ref-for-limiting②">13.5.3. Reference spaces</a> <a href="#ref-for-limiting③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="immersive-session-request-is-allowed">
-   <b><a href="#immersive-session-request-is-allowed">#immersive-session-request-is-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-immersive-session-request-is-allowed" class="dfn-panel" data-for="immersive-session-request-is-allowed" id="infopanel-for-immersive-session-request-is-allowed" role="dialog">
+   <span id="infopaneltitle-for-immersive-session-request-is-allowed" style="display:none">Info about the 'immersive session request is allowed' definition.</span><b><a href="#immersive-session-request-is-allowed">#immersive-session-request-is-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immersive-session-request-is-allowed">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-session-request-is-allowed">
-   <b><a href="#inline-session-request-is-allowed">#inline-session-request-is-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-session-request-is-allowed" class="dfn-panel" data-for="inline-session-request-is-allowed" id="infopanel-for-inline-session-request-is-allowed" role="dialog">
+   <span id="infopaneltitle-for-inline-session-request-is-allowed" style="display:none">Info about the 'inline session request is allowed' definition.</span><b><a href="#inline-session-request-is-allowed">#inline-session-request-is-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-session-request-is-allowed">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="poses-may-be-reported">
-   <b><a href="#poses-may-be-reported">#poses-may-be-reported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-poses-may-be-reported" class="dfn-panel" data-for="poses-may-be-reported" id="infopanel-for-poses-may-be-reported" role="dialog">
+   <span id="infopaneltitle-for-poses-may-be-reported" style="display:none">Info about the 'poses may be reported' definition.</span><b><a href="#poses-may-be-reported">#poses-may-be-reported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-poses-may-be-reported">6.1. XRSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="poses-must-be-limited">
-   <b><a href="#poses-must-be-limited">#poses-must-be-limited</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-poses-must-be-limited" class="dfn-panel" data-for="poses-must-be-limited" id="infopanel-for-poses-must-be-limited" role="dialog">
+   <span id="infopaneltitle-for-poses-must-be-limited" style="display:none">Info about the 'poses must be limited' definition.</span><b><a href="#poses-must-be-limited">#poses-must-be-limited</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-poses-must-be-limited">6.1. XRSpace</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trusted-ui">
-   <b><a href="#trusted-ui">#trusted-ui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trusted-ui" class="dfn-panel" data-for="trusted-ui" id="infopanel-for-trusted-ui" role="dialog">
+   <span id="infopaneltitle-for-trusted-ui" style="display:none">Info about the 'Trusted UI' definition.</span><b><a href="#trusted-ui">#trusted-ui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trusted-ui">13.6. Trusted Environment</a> <a href="#ref-for-trusted-ui①">(2)</a> <a href="#ref-for-trusted-ui②">(3)</a> <a href="#ref-for-trusted-ui③">(4)</a> <a href="#ref-for-trusted-ui④">(5)</a> <a href="#ref-for-trusted-ui⑤">(6)</a> <a href="#ref-for-trusted-ui⑥">(7)</a> <a href="#ref-for-trusted-ui⑦">(8)</a> <a href="#ref-for-trusted-ui⑧">(9)</a> <a href="#ref-for-trusted-ui⑨">(10)</a> <a href="#ref-for-trusted-ui①⓪">(11)</a> <a href="#ref-for-trusted-ui①①">(12)</a> <a href="#ref-for-trusted-ui①②">(13)</a> <a href="#ref-for-trusted-ui①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trusted-immersive-ui">
-   <b><a href="#trusted-immersive-ui">#trusted-immersive-ui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trusted-immersive-ui" class="dfn-panel" data-for="trusted-immersive-ui" id="infopanel-for-trusted-immersive-ui" role="dialog">
+   <span id="infopaneltitle-for-trusted-immersive-ui" style="display:none">Info about the 'trusted immersive UI' definition.</span><b><a href="#trusted-immersive-ui">#trusted-immersive-ui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trusted-immersive-ui">13.6. Trusted Environment</a> <a href="#ref-for-trusted-immersive-ui①">(2)</a> <a href="#ref-for-trusted-immersive-ui②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-xr-session-supported">
-   <b><a href="#dom-permissionname-xr-session-supported">#dom-permissionname-xr-session-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-xr-session-supported" class="dfn-panel" data-for="dom-permissionname-xr-session-supported" id="infopanel-for-dom-permissionname-xr-session-supported" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-xr-session-supported" style="display:none">Info about the '"xr-session-supported"' definition.</span><b><a href="#dom-permissionname-xr-session-supported">#dom-permissionname-xr-session-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-xr-session-supported">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-permissionname-xr-session-supported①">13.9. Fingerprinting considerations of isSessionSupported()</a> <a href="#ref-for-dom-permissionname-xr-session-supported②">(2)</a>
     <li><a href="#ref-for-dom-permissionname-xr-session-supported③">13.9.1. Considerations for when to automatically grant "xr-session-supported"</a> <a href="#ref-for-dom-permissionname-xr-session-supported④">(2)</a> <a href="#ref-for-dom-permissionname-xr-session-supported⑤">(3)</a> <a href="#ref-for-dom-permissionname-xr-session-supported⑥">(4)</a> <a href="#ref-for-dom-permissionname-xr-session-supported⑦">(5)</a> <a href="#ref-for-dom-permissionname-xr-session-supported⑧">(6)</a> <a href="#ref-for-dom-permissionname-xr-session-supported⑨">(7)</a> <a href="#ref-for-dom-permissionname-xr-session-supported①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrsessionsupportedpermissiondescriptor">
-   <b><a href="#dictdef-xrsessionsupportedpermissiondescriptor">#dictdef-xrsessionsupportedpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrsessionsupportedpermissiondescriptor" class="dfn-panel" data-for="dictdef-xrsessionsupportedpermissiondescriptor" id="infopanel-for-dictdef-xrsessionsupportedpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrsessionsupportedpermissiondescriptor" style="display:none">Info about the 'XRSessionSupportedPermissionDescriptor' definition.</span><b><a href="#dictdef-xrsessionsupportedpermissiondescriptor">#dictdef-xrsessionsupportedpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrsessionsupportedpermissiondescriptor">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrsessionsupportedpermissiondescriptor-mode">
-   <b><a href="#dom-xrsessionsupportedpermissiondescriptor-mode">#dom-xrsessionsupportedpermissiondescriptor-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrsessionsupportedpermissiondescriptor-mode" class="dfn-panel" data-for="dom-xrsessionsupportedpermissiondescriptor-mode" id="infopanel-for-dom-xrsessionsupportedpermissiondescriptor-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-xrsessionsupportedpermissiondescriptor-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-xrsessionsupportedpermissiondescriptor-mode">#dom-xrsessionsupportedpermissiondescriptor-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrsessionsupportedpermissiondescriptor-mode">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="indistinguishable-by-user-agent-string">
-   <b><a href="#indistinguishable-by-user-agent-string">#indistinguishable-by-user-agent-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-indistinguishable-by-user-agent-string" class="dfn-panel" data-for="indistinguishable-by-user-agent-string" id="infopanel-for-indistinguishable-by-user-agent-string" role="dialog">
+   <span id="infopaneltitle-for-indistinguishable-by-user-agent-string" style="display:none">Info about the 'indistinguishable by user-agent string' definition.</span><b><a href="#indistinguishable-by-user-agent-string">#indistinguishable-by-user-agent-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indistinguishable-by-user-agent-string">3.2. XRSystem</a>
     <li><a href="#ref-for-indistinguishable-by-user-agent-string①">13.9.1. Considerations for when to automatically grant "xr-session-supported"</a> <a href="#ref-for-indistinguishable-by-user-agent-string②">(2)</a> <a href="#ref-for-indistinguishable-by-user-agent-string③">(3)</a> <a href="#ref-for-indistinguishable-by-user-agent-string④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="never-support">
-   <b><a href="#never-support">#never-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-never-support" class="dfn-panel" data-for="never-support" id="infopanel-for-never-support" role="dialog">
+   <span id="infopaneltitle-for-never-support" style="display:none">Info about the 'never support' definition.</span><b><a href="#never-support">#never-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-never-support">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usually-support">
-   <b><a href="#usually-support">#usually-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usually-support" class="dfn-panel" data-for="usually-support" id="infopanel-for-usually-support" role="dialog">
+   <span id="infopaneltitle-for-usually-support" style="display:none">Info about the 'usually support' definition.</span><b><a href="#usually-support">#usually-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usually-support">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-xr">
-   <b><a href="#dom-permissionname-xr">#dom-permissionname-xr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-xr" class="dfn-panel" data-for="dom-permissionname-xr" id="infopanel-for-dom-permissionname-xr" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-xr" style="display:none">Info about the '"xr"' definition.</span><b><a href="#dom-permissionname-xr">#dom-permissionname-xr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-xr">14.2. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-xrpermissiondescriptor">
-   <b><a href="#dictdef-xrpermissiondescriptor">#dictdef-xrpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-xrpermissiondescriptor" class="dfn-panel" data-for="dictdef-xrpermissiondescriptor" id="infopanel-for-dictdef-xrpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-xrpermissiondescriptor" style="display:none">Info about the 'XRPermissionDescriptor' definition.</span><b><a href="#dictdef-xrpermissiondescriptor">#dictdef-xrpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-xrpermissiondescriptor">3.2. XRSystem</a>
     <li><a href="#ref-for-dictdef-xrpermissiondescriptor①">13.9. Fingerprinting considerations of isSessionSupported()</a>
     <li><a href="#ref-for-dictdef-xrpermissiondescriptor②">14.2. Permissions API Integration</a> <a href="#ref-for-dictdef-xrpermissiondescriptor③">(2)</a> <a href="#ref-for-dictdef-xrpermissiondescriptor④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpermissiondescriptor-mode">
-   <b><a href="#dom-xrpermissiondescriptor-mode">#dom-xrpermissiondescriptor-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpermissiondescriptor-mode" class="dfn-panel" data-for="dom-xrpermissiondescriptor-mode" id="infopanel-for-dom-xrpermissiondescriptor-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpermissiondescriptor-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-xrpermissiondescriptor-mode">#dom-xrpermissiondescriptor-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissiondescriptor-mode">14.2. Permissions API Integration</a> <a href="#ref-for-dom-xrpermissiondescriptor-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpermissiondescriptor-requiredfeatures">
-   <b><a href="#dom-xrpermissiondescriptor-requiredfeatures">#dom-xrpermissiondescriptor-requiredfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpermissiondescriptor-requiredfeatures" class="dfn-panel" data-for="dom-xrpermissiondescriptor-requiredfeatures" id="infopanel-for-dom-xrpermissiondescriptor-requiredfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpermissiondescriptor-requiredfeatures" style="display:none">Info about the 'requiredFeatures' definition.</span><b><a href="#dom-xrpermissiondescriptor-requiredfeatures">#dom-xrpermissiondescriptor-requiredfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissiondescriptor-requiredfeatures">14.2. Permissions API Integration</a> <a href="#ref-for-dom-xrpermissiondescriptor-requiredfeatures①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpermissiondescriptor-optionalfeatures">
-   <b><a href="#dom-xrpermissiondescriptor-optionalfeatures">#dom-xrpermissiondescriptor-optionalfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpermissiondescriptor-optionalfeatures" class="dfn-panel" data-for="dom-xrpermissiondescriptor-optionalfeatures" id="infopanel-for-dom-xrpermissiondescriptor-optionalfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpermissiondescriptor-optionalfeatures" style="display:none">Info about the 'optionalFeatures' definition.</span><b><a href="#dom-xrpermissiondescriptor-optionalfeatures">#dom-xrpermissiondescriptor-optionalfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissiondescriptor-optionalfeatures">14.2. Permissions API Integration</a> <a href="#ref-for-dom-xrpermissiondescriptor-optionalfeatures①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xrpermissionstatus">
-   <b><a href="#xrpermissionstatus">#xrpermissionstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xrpermissionstatus" class="dfn-panel" data-for="xrpermissionstatus" id="infopanel-for-xrpermissionstatus" role="dialog">
+   <span id="infopaneltitle-for-xrpermissionstatus" style="display:none">Info about the 'XRPermissionStatus' definition.</span><b><a href="#xrpermissionstatus">#xrpermissionstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xrpermissionstatus">3.2. XRSystem</a> <a href="#ref-for-xrpermissionstatus①">(2)</a>
     <li><a href="#ref-for-xrpermissionstatus②">14.2. Permissions API Integration</a> <a href="#ref-for-xrpermissionstatus③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xrpermissionstatus-granted">
-   <b><a href="#dom-xrpermissionstatus-granted">#dom-xrpermissionstatus-granted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xrpermissionstatus-granted" class="dfn-panel" data-for="dom-xrpermissionstatus-granted" id="infopanel-for-dom-xrpermissionstatus-granted" role="dialog">
+   <span id="infopaneltitle-for-dom-xrpermissionstatus-granted" style="display:none">Info about the 'granted' definition.</span><b><a href="#dom-xrpermissionstatus-granted">#dom-xrpermissionstatus-granted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xrpermissionstatus-granted">3.2. XRSystem</a>
     <li><a href="#ref-for-dom-xrpermissionstatus-granted①">14.2. Permissions API Integration</a> <a href="#ref-for-dom-xrpermissionstatus-granted②">(2)</a> <a href="#ref-for-dom-xrpermissionstatus-granted③">(3)</a> <a href="#ref-for-dom-xrpermissionstatus-granted④">(4)</a> <a href="#ref-for-dom-xrpermissionstatus-granted⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-the-xr-permission">
-   <b><a href="#request-the-xr-permission">#request-the-xr-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-the-xr-permission" class="dfn-panel" data-for="request-the-xr-permission" id="infopanel-for-request-the-xr-permission" role="dialog">
+   <span id="infopaneltitle-for-request-the-xr-permission" style="display:none">Info about the 'request the "xr" permission' definition.</span><b><a href="#request-the-xr-permission">#request-the-xr-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-the-xr-permission">3.2. XRSystem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-the-requested-features">
-   <b><a href="#resolve-the-requested-features">#resolve-the-requested-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-the-requested-features" class="dfn-panel" data-for="resolve-the-requested-features" id="infopanel-for-resolve-the-requested-features" role="dialog">
+   <span id="infopaneltitle-for-resolve-the-requested-features" style="display:none">Info about the 'resolve the requested features' definition.</span><b><a href="#resolve-the-requested-features">#resolve-the-requested-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-the-requested-features">3.4. Feature Dependencies</a>
     <li><a href="#ref-for-resolve-the-requested-features①">14.2. Permissions API Integration</a> <a href="#ref-for-resolve-the-requested-features②">(2)</a>
@@ -9934,59 +9934,115 @@ have been the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipa
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/privacycg/private-click-measurement/private-click-measurement.html
+++ b/tests/github/privacycg/private-click-measurement/private-click-measurement.html
@@ -992,83 +992,83 @@ for their feedback on this proposal.</p>
    <li><a href="#trigger-data">trigger data</a><span>, in § 1.2</span>
    <li><a href="#triggering-event">triggering event</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">2. Click Source Link Format</a> <a href="#ref-for-cereactions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlanchorelement">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement">https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlanchorelement" class="dfn-panel" data-for="term-for-htmlanchorelement" id="infopanel-for-term-for-htmlanchorelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlanchorelement" style="display:none">Info about the 'HTMLAnchorElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement">https://html.spec.whatwg.org/multipage/text-level-semantics.html#htmlanchorelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlanchorelement">2. Click Source Link Format</a> <a href="#ref-for-htmlanchorelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhyperlinkelementutils">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlhyperlinkelementutils" class="dfn-panel" data-for="term-for-htmlhyperlinkelementutils" id="infopanel-for-term-for-htmlhyperlinkelementutils" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlhyperlinkelementutils" style="display:none">Info about the 'HTMLHyperlinkElementUtils' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlhyperlinkelementutils">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-site" class="dfn-panel" data-for="term-for-site" id="infopanel-for-term-for-site" role="menu">
+   <span id="infopaneltitle-for-term-for-site" style="display:none">Info about the 'site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-site">7. Click source/attribute-on pairs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit">
-   <a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit" class="dfn-panel" data-for="term-for-code-unit" id="infopanel-for-term-for-code-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit" style="display:none">Info about the 'code unit' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit">8. N-bit decimal values</a> <a href="#ref-for-code-unit①">(2)</a> <a href="#ref-for-code-unit②">(3)</a> <a href="#ref-for-code-unit③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenate' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">6.1. Triggering Event URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">8. N-bit decimal values</a> <a href="#ref-for-string-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">8. N-bit decimal values</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a> <a href="#ref-for-string③">(4)</a> <a href="#ref-for-string④">(5)</a> <a href="#ref-for-string⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">2. Click Source Link Format</a>
     <li><a href="#ref-for-tuple①">7. Click source/attribute-on pairs</a>
     <li><a href="#ref-for-tuple②">10. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-url-url">
-   <a href="https://url.spec.whatwg.org/#dom-url-url">https://url.spec.whatwg.org/#dom-url-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-url-url" class="dfn-panel" data-for="term-for-dom-url-url" id="infopanel-for-term-for-dom-url-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-url-url" style="display:none">Info about the 'URL(url, base)' external reference.</span><a href="https://url.spec.whatwg.org/#dom-url-url">https://url.spec.whatwg.org/#dom-url-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-url">6.1. Triggering Event URL</a>
     <li><a href="#ref-for-dom-url-url①">6.2. Attribution Report URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2. Click Source Link Format</a>
    </ul>
@@ -1149,14 +1149,14 @@ for their feedback on this proposal.</p>
    <div class="issue"> Should these attributes be on <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils">HTMLHyperlinkElementUtils</a></code> instead? <a href="https://github.com/privacycg/private-click-measurement/issues/1">[Issue #1]</a> <a class="issue-return" href="#issue-717d647e" title="Jump to section">↵</a></div>
    <div class="issue"> This needs to be reworked to monkeypatch HTML’s "follows a hyperlink" algorithm. <a class="issue-return" href="#issue-3bd5b5fa" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="attribution">
-   <b><a href="#attribution">#attribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribution" class="dfn-panel" data-for="attribution" id="infopanel-for-attribution" role="dialog">
+   <span id="infopaneltitle-for-attribution" style="display:none">Info about the 'attribution' definition.</span><b><a href="#attribution">#attribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribution">1.2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="click-source-website">
-   <b><a href="#click-source-website">#click-source-website</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-click-source-website" class="dfn-panel" data-for="click-source-website" id="infopanel-for-click-source-website" role="dialog">
+   <span id="infopaneltitle-for-click-source-website" style="display:none">Info about the 'click source website' definition.</span><b><a href="#click-source-website">#click-source-website</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-click-source-website">1.2. Terminology</a>
     <li><a href="#ref-for-click-source-website①">1.3. A High Level Scenario</a> <a href="#ref-for-click-source-website②">(2)</a>
@@ -1168,8 +1168,8 @@ for their feedback on this proposal.</p>
     <li><a href="#ref-for-click-source-website①③">11. Performance Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribution-destination-website">
-   <b><a href="#attribution-destination-website">#attribution-destination-website</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribution-destination-website" class="dfn-panel" data-for="attribution-destination-website" id="infopanel-for-attribution-destination-website" role="dialog">
+   <span id="infopaneltitle-for-attribution-destination-website" style="display:none">Info about the 'attribution destination website' definition.</span><b><a href="#attribution-destination-website">#attribution-destination-website</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribution-destination-website">1.2. Terminology</a>
     <li><a href="#ref-for-attribution-destination-website①">1.3. A High Level Scenario</a> <a href="#ref-for-attribution-destination-website②">(2)</a> <a href="#ref-for-attribution-destination-website③">(3)</a> <a href="#ref-for-attribution-destination-website④">(4)</a>
@@ -1180,8 +1180,8 @@ for their feedback on this proposal.</p>
     <li><a href="#ref-for-attribution-destination-website①⑤">11. Performance Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribution-source-id">
-   <b><a href="#attribution-source-id">#attribution-source-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribution-source-id" class="dfn-panel" data-for="attribution-source-id" id="infopanel-for-attribution-source-id" role="dialog">
+   <span id="infopaneltitle-for-attribution-source-id" style="display:none">Info about the 'attribution source id' definition.</span><b><a href="#attribution-source-id">#attribution-source-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribution-source-id">1.2. Terminology</a>
     <li><a href="#ref-for-attribution-source-id①">1.3. A High Level Scenario</a>
@@ -1189,157 +1189,213 @@ for their feedback on this proposal.</p>
     <li><a href="#ref-for-attribution-source-id⑤">10. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trigger-data">
-   <b><a href="#trigger-data">#trigger-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trigger-data" class="dfn-panel" data-for="trigger-data" id="infopanel-for-trigger-data" role="dialog">
+   <span id="infopaneltitle-for-trigger-data" style="display:none">Info about the 'trigger data' definition.</span><b><a href="#trigger-data">#trigger-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trigger-data">1.2. Terminology</a>
     <li><a href="#ref-for-trigger-data①">1.3. A High Level Scenario</a>
     <li><a href="#ref-for-trigger-data②">3. Triggering of Click Attribution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optional-trigger-priority">
-   <b><a href="#optional-trigger-priority">#optional-trigger-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optional-trigger-priority" class="dfn-panel" data-for="optional-trigger-priority" id="infopanel-for-optional-trigger-priority" role="dialog">
+   <span id="infopaneltitle-for-optional-trigger-priority" style="display:none">Info about the 'optional trigger priority' definition.</span><b><a href="#optional-trigger-priority">#optional-trigger-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optional-trigger-priority">3. Triggering of Click Attribution</a>
     <li><a href="#ref-for-optional-trigger-priority①">5. Receiving Attribution Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribution-report">
-   <b><a href="#attribution-report">#attribution-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribution-report" class="dfn-panel" data-for="attribution-report" id="infopanel-for-attribution-report" role="dialog">
+   <span id="infopaneltitle-for-attribution-report" style="display:none">Info about the 'attribution report' definition.</span><b><a href="#attribution-report">#attribution-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribution-report">1.3. A High Level Scenario</a> <a href="#ref-for-attribution-report①">(2)</a>
     <li><a href="#ref-for-attribution-report②">5. Receiving Attribution Reports</a>
     <li><a href="#ref-for-attribution-report③">10. Privacy Considerations</a> <a href="#ref-for-attribution-report④">(2)</a> <a href="#ref-for-attribution-report⑤">(3)</a> <a href="#ref-for-attribution-report⑥">(4)</a> <a href="#ref-for-attribution-report⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlanchorelement-attributionsourceid">
-   <b><a href="#dom-htmlanchorelement-attributionsourceid">#dom-htmlanchorelement-attributionsourceid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlanchorelement-attributionsourceid" class="dfn-panel" data-for="dom-htmlanchorelement-attributionsourceid" id="infopanel-for-dom-htmlanchorelement-attributionsourceid" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlanchorelement-attributionsourceid" style="display:none">Info about the 'attributionSourceId' definition.</span><b><a href="#dom-htmlanchorelement-attributionsourceid">#dom-htmlanchorelement-attributionsourceid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlanchorelement-attributionsourceid">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlanchorelement-attributiondestination">
-   <b><a href="#dom-htmlanchorelement-attributiondestination">#dom-htmlanchorelement-attributiondestination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlanchorelement-attributiondestination" class="dfn-panel" data-for="dom-htmlanchorelement-attributiondestination" id="infopanel-for-dom-htmlanchorelement-attributiondestination" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlanchorelement-attributiondestination" style="display:none">Info about the 'attributionDestination' definition.</span><b><a href="#dom-htmlanchorelement-attributiondestination">#dom-htmlanchorelement-attributiondestination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlanchorelement-attributiondestination">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="triggering-event">
-   <b><a href="#triggering-event">#triggering-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-triggering-event" class="dfn-panel" data-for="triggering-event" id="infopanel-for-triggering-event" role="dialog">
+   <span id="infopaneltitle-for-triggering-event" style="display:none">Info about the 'triggering event' definition.</span><b><a href="#triggering-event">#triggering-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-triggering-event">1.3. A High Level Scenario</a>
     <li><a href="#ref-for-triggering-event①">3. Triggering of Click Attribution</a>
     <li><a href="#ref-for-triggering-event②">9. Modern Triggering of Attribution</a> <a href="#ref-for-triggering-event③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-tiggering-event-url">
-   <b><a href="#generate-a-tiggering-event-url">#generate-a-tiggering-event-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-tiggering-event-url" class="dfn-panel" data-for="generate-a-tiggering-event-url" id="infopanel-for-generate-a-tiggering-event-url" role="dialog">
+   <span id="infopaneltitle-for-generate-a-tiggering-event-url" style="display:none">Info about the 'generate a tiggering event URL' definition.</span><b><a href="#generate-a-tiggering-event-url">#generate-a-tiggering-event-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-tiggering-event-url">3. Triggering of Click Attribution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-an-attribution-report-url">
-   <b><a href="#generate-an-attribution-report-url">#generate-an-attribution-report-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-an-attribution-report-url" class="dfn-panel" data-for="generate-an-attribution-report-url" id="infopanel-for-generate-an-attribution-report-url" role="dialog">
+   <span id="infopaneltitle-for-generate-an-attribution-report-url" style="display:none">Info about the 'generate an attribution report URL' definition.</span><b><a href="#generate-an-attribution-report-url">#generate-an-attribution-report-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-an-attribution-report-url">5. Receiving Attribution Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="click-source-attribute-on-pair">
-   <b><a href="#click-source-attribute-on-pair">#click-source-attribute-on-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-click-source-attribute-on-pair" class="dfn-panel" data-for="click-source-attribute-on-pair" id="infopanel-for-click-source-attribute-on-pair" role="dialog">
+   <span id="infopaneltitle-for-click-source-attribute-on-pair" style="display:none">Info about the 'click source-attribute-on pair' definition.</span><b><a href="#click-source-attribute-on-pair">#click-source-attribute-on-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-click-source-attribute-on-pair">1.3. A High Level Scenario</a>
     <li><a href="#ref-for-click-source-attribute-on-pair①">5. Receiving Attribution Reports</a>
     <li><a href="#ref-for-click-source-attribute-on-pair②">10. Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="four-bit-decimal-value">
-   <b><a href="#four-bit-decimal-value">#four-bit-decimal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-four-bit-decimal-value" class="dfn-panel" data-for="four-bit-decimal-value" id="infopanel-for-four-bit-decimal-value" role="dialog">
+   <span id="infopaneltitle-for-four-bit-decimal-value" style="display:none">Info about the 'four-bit decimal value' definition.</span><b><a href="#four-bit-decimal-value">#four-bit-decimal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-four-bit-decimal-value">1.2. Terminology</a>
     <li><a href="#ref-for-four-bit-decimal-value①">8. N-bit decimal values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="six-bit-decimal-value">
-   <b><a href="#six-bit-decimal-value">#six-bit-decimal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-six-bit-decimal-value" class="dfn-panel" data-for="six-bit-decimal-value" id="infopanel-for-six-bit-decimal-value" role="dialog">
+   <span id="infopaneltitle-for-six-bit-decimal-value" style="display:none">Info about the 'six-bit decimal value' definition.</span><b><a href="#six-bit-decimal-value">#six-bit-decimal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-six-bit-decimal-value">1.2. Terminology</a>
     <li><a href="#ref-for-six-bit-decimal-value①">8. N-bit decimal values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eight-bit-decimal-value">
-   <b><a href="#eight-bit-decimal-value">#eight-bit-decimal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eight-bit-decimal-value" class="dfn-panel" data-for="eight-bit-decimal-value" id="infopanel-for-eight-bit-decimal-value" role="dialog">
+   <span id="infopaneltitle-for-eight-bit-decimal-value" style="display:none">Info about the 'eight-bit decimal value' definition.</span><b><a href="#eight-bit-decimal-value">#eight-bit-decimal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eight-bit-decimal-value">1.2. Terminology</a>
     <li><a href="#ref-for-eight-bit-decimal-value①">2. Click Source Link Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-a-four-bit-decimal-value">
-   <b><a href="#extract-a-four-bit-decimal-value">#extract-a-four-bit-decimal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-a-four-bit-decimal-value" class="dfn-panel" data-for="extract-a-four-bit-decimal-value" id="infopanel-for-extract-a-four-bit-decimal-value" role="dialog">
+   <span id="infopaneltitle-for-extract-a-four-bit-decimal-value" style="display:none">Info about the 'extract a four-bit decimal value' definition.</span><b><a href="#extract-a-four-bit-decimal-value">#extract-a-four-bit-decimal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-a-four-bit-decimal-value">8. N-bit decimal values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-a-six-bit-decimal-value">
-   <b><a href="#extract-a-six-bit-decimal-value">#extract-a-six-bit-decimal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-a-six-bit-decimal-value" class="dfn-panel" data-for="extract-a-six-bit-decimal-value" id="infopanel-for-extract-a-six-bit-decimal-value" role="dialog">
+   <span id="infopaneltitle-for-extract-a-six-bit-decimal-value" style="display:none">Info about the 'extract a six-bit decimal value' definition.</span><b><a href="#extract-a-six-bit-decimal-value">#extract-a-six-bit-decimal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-a-six-bit-decimal-value">8. N-bit decimal values</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/privacycg/storage-access/storage-access.html
+++ b/tests/github/privacycg/storage-access/storage-access.html
@@ -1122,8 +1122,8 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
    <li><a href="#unpartitioned-data">Unpartitioned data</a><span>, in § 3</span>
    <li><a href="#was-expressly-denied-storage-access-flag">was expressly denied storage access flag</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. The Storage Access API</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a> <a href="#ref-for-document③">(4)</a>
     <li><a href="#ref-for-document④">3.1. User Agent state related to storage access</a> <a href="#ref-for-document⑤">(2)</a>
@@ -1132,144 +1132,144 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
     <li><a href="#ref-for-document①②">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">3.2. Changes to Document</a> <a href="#ref-for-concept-document-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-agent-clusters">
-   <a href="https://tc39.github.io/ecma262/#sec-agent-clusters">https://tc39.github.io/ecma262/#sec-agent-clusters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-agent-clusters" class="dfn-panel" data-for="term-for-sec-agent-clusters" id="infopanel-for-term-for-sec-agent-clusters" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-agent-clusters" style="display:none">Info about the 'agent cluster' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-agent-clusters">https://tc39.github.io/ecma262/#sec-agent-clusters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-agent-clusters">3.1. User Agent state related to storage access</a> <a href="#ref-for-sec-agent-clusters①">(2)</a> <a href="#ref-for-sec-agent-clusters②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.2. Changes to Document</a>
     <li><a href="#ref-for-window①">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">3. The Storage Access API</a> <a href="#ref-for-nav-document①">(2)</a>
     <li><a href="#ref-for-nav-document②">3.2. Changes to Document</a> <a href="#ref-for-nav-document③">(2)</a>
     <li><a href="#ref-for-nav-document④">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-sandboxing-flag-set">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-sandboxing-flag-set" class="dfn-panel" data-for="term-for-active-sandboxing-flag-set" id="infopanel-for-term-for-active-sandboxing-flag-set" role="menu">
+   <span id="infopaneltitle-for-term-for-active-sandboxing-flag-set" style="display:none">Info about the 'active sandboxing flag set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#active-sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-sandboxing-flag-set">3.2. Changes to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-concept-document-bc①">3.2. Changes to Document</a> <a href="#ref-for-concept-document-bc②">(2)</a> <a href="#ref-for-concept-document-bc③">(3)</a> <a href="#ref-for-concept-document-bc④">(4)</a> <a href="#ref-for-concept-document-bc⑤">(5)</a>
     <li><a href="#ref-for-concept-document-bc⑥">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-consume-user-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation">https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-consume-user-activation" class="dfn-panel" data-for="term-for-consume-user-activation" id="infopanel-for-term-for-consume-user-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-consume-user-activation" style="display:none">Info about the 'consume user activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation">https://html.spec.whatwg.org/multipage/interaction.html#consume-user-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-user-activation">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-cookie">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie">https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-cookie" class="dfn-panel" data-for="term-for-dom-document-cookie" id="infopanel-for-term-for-dom-document-cookie" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-cookie" style="display:none">Info about the 'cookie' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie">https://html.spec.whatwg.org/multipage/dom.html#dom-document-cookie</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-cookie">3. The Storage Access API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">3.2. Changes to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">1. Introduction</a> <a href="#ref-for-the-iframe-element①">(2)</a>
     <li><a href="#ref-for-the-iframe-element②">3. The Storage Access API</a> <a href="#ref-for-the-iframe-element③">(2)</a> <a href="#ref-for-the-iframe-element④">(3)</a>
     <li><a href="#ref-for-the-iframe-element⑤">3.2. Changes to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-site" class="dfn-panel" data-for="term-for-obtain-a-site" id="infopanel-for-term-for-obtain-a-site" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-site" style="display:none">Info about the 'obtain a site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-site">3.1. User Agent state related to storage access</a> <a href="#ref-for-obtain-a-site①">(2)</a>
     <li><a href="#ref-for-obtain-a-site②">6.1. Set Storage Access</a> <a href="#ref-for-obtain-a-site③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">3.2. Changes to Document</a> <a href="#ref-for-concept-origin-opaque①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">3. The Storage Access API</a>
     <li><a href="#ref-for-concept-settings-object-origin①">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-concept-settings-object-origin②">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-sandboxing-directive" class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive" id="infopanel-for-term-for-parse-a-sandboxing-directive" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-sandboxing-directive" style="display:none">Info about the 'parse a sandboxing directive' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-sandboxing-directive">3.5. Sandboxing storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-agent" class="dfn-panel" data-for="term-for-relevant-agent" id="infopanel-for-term-for-relevant-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-agent" style="display:none">Info about the 'relevant agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-agent">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3. The Storage Access API</a>
     <li><a href="#ref-for-relevant-settings-object①">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-relevant-settings-object②">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.2. Changes to Document</a> <a href="#ref-for-same-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-site-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-site-same-site" class="dfn-panel" data-for="term-for-concept-site-same-site" id="infopanel-for-term-for-concept-site-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-site-same-site" style="display:none">Info about the 'same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-site-same-site">3. The Storage Access API</a>
     <li><a href="#ref-for-concept-site-same-site①">3.2. Changes to Document</a> <a href="#ref-for-concept-site-same-site②">(2)</a>
     <li><a href="#ref-for-concept-site-same-site③">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxing-flag-set">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#sandboxing-flag-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandboxing-flag-set" class="dfn-panel" data-for="term-for-sandboxing-flag-set" id="infopanel-for-term-for-sandboxing-flag-set" role="menu">
+   <span id="infopaneltitle-for-term-for-sandboxing-flag-set" style="display:none">Info about the 'sandboxing flag set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxing-flag-set">https://html.spec.whatwg.org/multipage/browsers.html#sandboxing-flag-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandboxing-flag-set">3.5. Sandboxing storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-site" class="dfn-panel" data-for="term-for-site" id="infopanel-for-term-for-site" role="menu">
+   <span id="infopaneltitle-for-term-for-site" style="display:none">Info about the 'site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-site">3. The Storage Access API</a>
     <li><a href="#ref-for-site①">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-site②">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3. The Storage Access API</a>
     <li><a href="#ref-for-top-level-browsing-context①">3.1. User Agent state related to storage access</a>
@@ -1278,172 +1278,172 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
     <li><a href="#ref-for-top-level-browsing-context⑧">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">3. The Storage Access API</a>
     <li><a href="#ref-for-concept-environment-top-level-origin①">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">3.2. Changes to Document</a>
     <li><a href="#ref-for-transient-activation①">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boolean">
-   <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boolean" class="dfn-panel" data-for="term-for-boolean" id="infopanel-for-term-for-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">3.2.1. User Agent storage access policies</a> <a href="#ref-for-boolean①">(2)</a> <a href="#ref-for-boolean②">(3)</a>
     <li><a href="#ref-for-boolean③">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-clone">
-   <a href="https://infra.spec.whatwg.org/#map-clone">https://infra.spec.whatwg.org/#map-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-clone" class="dfn-panel" data-for="term-for-map-clone" id="infopanel-for-term-for-map-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-map-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#map-clone">https://infra.spec.whatwg.org/#map-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-clone">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">3.2.1. User Agent storage access policies</a> <a href="#ref-for-implementation-defined①">(2)</a> <a href="#ref-for-implementation-defined②">(3)</a>
     <li><a href="#ref-for-implementation-defined③">6.1. Set Storage Access</a> <a href="#ref-for-implementation-defined④">(2)</a> <a href="#ref-for-implementation-defined⑤">(3)</a> <a href="#ref-for-implementation-defined⑥">(4)</a> <a href="#ref-for-implementation-defined⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.1. User Agent state related to storage access</a> <a href="#ref-for-map-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">3.1. User Agent state related to storage access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-browsing-context">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-current-browsing-context">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-current-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-browsing-context" class="dfn-panel" data-for="term-for-dfn-current-browsing-context" id="infopanel-for-term-for-dfn-current-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-browsing-context" style="display:none">Info about the 'current browsing context' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-current-browsing-context">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-current-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-browsing-context">6.1. Set Storage Access</a> <a href="#ref-for-dfn-current-browsing-context①">(2)</a> <a href="#ref-for-dfn-current-browsing-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-commands">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-extension-commands">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-extension-commands</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-commands" class="dfn-panel" data-for="term-for-dfn-extension-commands" id="infopanel-for-term-for-dfn-extension-commands" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-commands" style="display:none">Info about the 'extension command' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-extension-commands">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-extension-commands</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-commands">6. Automation</a>
     <li><a href="#ref-for-dfn-extension-commands①">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-getting-properties">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-getting-properties">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-getting-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-getting-properties" class="dfn-panel" data-for="term-for-dfn-getting-properties" id="infopanel-for-term-for-dfn-getting-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-getting-properties" style="display:none">Info about the 'getting a property' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-getting-properties">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-getting-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-getting-properties">6.1. Set Storage Access</a> <a href="#ref-for-dfn-getting-properties①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-invalid-argument">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-invalid-argument">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-invalid-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-invalid-argument" class="dfn-panel" data-for="term-for-dfn-invalid-argument" id="infopanel-for-term-for-dfn-invalid-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-invalid-argument" style="display:none">Info about the 'invalid argument' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-invalid-argument">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-invalid-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-invalid-argument">6.1. Set Storage Access</a> <a href="#ref-for-dfn-invalid-argument①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-remote-end-steps">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-remote-end-steps">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-success">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'success' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-success">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-unknown-error">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unknown-error">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unknown-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-unknown-error" class="dfn-panel" data-for="term-for-dfn-unknown-error" id="infopanel-for-term-for-dfn-unknown-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-unknown-error" style="display:none">Info about the 'unknown error' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unknown-error">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unknown-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unknown-error">6.1. Set Storage Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-unsupported-operation">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unsupported-operation">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unsupported-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-unsupported-operation" class="dfn-panel" data-for="term-for-dfn-unsupported-operation" id="infopanel-for-term-for-dfn-unsupported-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-unsupported-operation" style="display:none">Info about the 'unsupported operation' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unsupported-operation">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-unsupported-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unsupported-operation">6.1. Set Storage Access</a> <a href="#ref-for-dfn-unsupported-operation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error" class="dfn-panel" data-for="term-for-dfn-error" id="infopanel-for-term-for-dfn-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error" style="display:none">Info about the 'webdriver error' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error">6.1. Set Storage Access</a> <a href="#ref-for-dfn-error①">(2)</a> <a href="#ref-for-dfn-error②">(3)</a> <a href="#ref-for-dfn-error③">(4)</a> <a href="#ref-for-dfn-error④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error-code">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'webdriver error code' external reference.</span><a href="https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error-code">https://w3c.github.io/webdriver/webdriver-spec.html#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">6.1. Set Storage Access</a> <a href="#ref-for-dfn-error-code①">(2)</a> <a href="#ref-for-dfn-error-code②">(3)</a> <a href="#ref-for-dfn-error-code③">(4)</a> <a href="#ref-for-dfn-error-code④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. Changes to Document</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2. Changes to Document</a> <a href="#ref-for-a-new-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. Changes to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.2. Changes to Document</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a> <a href="#ref-for-reject③">(4)</a> <a href="#ref-for-reject④">(5)</a> <a href="#ref-for-reject⑤">(6)</a>
     <li><a href="#ref-for-reject⑥">3.2.1. User Agent storage access policies</a> <a href="#ref-for-reject⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.2. Changes to Document</a> <a href="#ref-for-resolve①">(2)</a> <a href="#ref-for-resolve②">(3)</a> <a href="#ref-for-resolve③">(4)</a> <a href="#ref-for-resolve④">(5)</a> <a href="#ref-for-resolve⑤">(6)</a> <a href="#ref-for-resolve⑥">(7)</a> <a href="#ref-for-resolve⑦">(8)</a> <a href="#ref-for-resolve⑧">(9)</a> <a href="#ref-for-resolve⑨">(10)</a>
     <li><a href="#ref-for-resolve①⓪">3.2.1. User Agent storage access policies</a> <a href="#ref-for-resolve①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3.2. Changes to Document</a>
    </ul>
@@ -1577,8 +1577,8 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
    <div class="issue"> Write this section. <a class="issue-return" href="#issue-089b92ec①" title="Jump to section">↵</a></div>
    <div class="issue"> Write this section. <a class="issue-return" href="#issue-089b92ec②" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="unpartitioned-data">
-   <b><a href="#unpartitioned-data">#unpartitioned-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unpartitioned-data" class="dfn-panel" data-for="unpartitioned-data" id="infopanel-for-unpartitioned-data" role="dialog">
+   <span id="infopaneltitle-for-unpartitioned-data" style="display:none">Info about the 'Unpartitioned data' definition.</span><b><a href="#unpartitioned-data">#unpartitioned-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unpartitioned-data">3. The Storage Access API</a> <a href="#ref-for-unpartitioned-data①">(2)</a>
     <li><a href="#ref-for-unpartitioned-data②">3.1. User Agent state related to storage access</a> <a href="#ref-for-unpartitioned-data③">(2)</a>
@@ -1586,14 +1586,14 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
     <li><a href="#ref-for-unpartitioned-data⑦">6.1. Set Storage Access</a> <a href="#ref-for-unpartitioned-data⑧">(2)</a> <a href="#ref-for-unpartitioned-data⑨">(3)</a> <a href="#ref-for-unpartitioned-data①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-party-site-context">
-   <b><a href="#first-party-site-context">#first-party-site-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-party-site-context" class="dfn-panel" data-for="first-party-site-context" id="infopanel-for-first-party-site-context" role="dialog">
+   <span id="infopaneltitle-for-first-party-site-context" style="display:none">Info about the 'first-party-site context' definition.</span><b><a href="#first-party-site-context">#first-party-site-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-party-site-context">3. The Storage Access API</a> <a href="#ref-for-first-party-site-context①">(2)</a> <a href="#ref-for-first-party-site-context②">(3)</a> <a href="#ref-for-first-party-site-context③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="third-party-context">
-   <b><a href="#third-party-context">#third-party-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-third-party-context" class="dfn-panel" data-for="third-party-context" id="infopanel-for-third-party-context" role="dialog">
+   <span id="infopaneltitle-for-third-party-context" style="display:none">Info about the 'third party context' definition.</span><b><a href="#third-party-context">#third-party-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-third-party-context">3. The Storage Access API</a>
     <li><a href="#ref-for-third-party-context①">3.1. User Agent state related to storage access</a> <a href="#ref-for-third-party-context②">(2)</a> <a href="#ref-for-third-party-context③">(3)</a>
@@ -1601,107 +1601,107 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
     <li><a href="#ref-for-third-party-context⑥">6.1. Set Storage Access</a> <a href="#ref-for-third-party-context⑦">(2)</a> <a href="#ref-for-third-party-context⑧">(3)</a> <a href="#ref-for-third-party-context⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-access-map">
-   <b><a href="#storage-access-map">#storage-access-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-access-map" class="dfn-panel" data-for="storage-access-map" id="infopanel-for-storage-access-map" role="dialog">
+   <span id="infopaneltitle-for-storage-access-map" style="display:none">Info about the 'storage access map' definition.</span><b><a href="#storage-access-map">#storage-access-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-access-map">3.1. User Agent state related to storage access</a> <a href="#ref-for-storage-access-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-storage-access-map">
-   <b><a href="#global-storage-access-map">#global-storage-access-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-storage-access-map" class="dfn-panel" data-for="global-storage-access-map" id="infopanel-for-global-storage-access-map" role="dialog">
+   <span id="infopaneltitle-for-global-storage-access-map" style="display:none">Info about the 'global storage access map' definition.</span><b><a href="#global-storage-access-map">#global-storage-access-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-storage-access-map">3.1. User Agent state related to storage access</a> <a href="#ref-for-global-storage-access-map①">(2)</a> <a href="#ref-for-global-storage-access-map②">(3)</a> <a href="#ref-for-global-storage-access-map③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="agent-cluster-storage-access-map">
-   <b><a href="#agent-cluster-storage-access-map">#agent-cluster-storage-access-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-agent-cluster-storage-access-map" class="dfn-panel" data-for="agent-cluster-storage-access-map" id="infopanel-for-agent-cluster-storage-access-map" role="dialog">
+   <span id="infopaneltitle-for-agent-cluster-storage-access-map" style="display:none">Info about the 'storage access map' definition.</span><b><a href="#agent-cluster-storage-access-map">#agent-cluster-storage-access-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-agent-cluster-storage-access-map">3.1. User Agent state related to storage access</a> <a href="#ref-for-agent-cluster-storage-access-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-the-storage-access-map">
-   <b><a href="#obtain-the-storage-access-map">#obtain-the-storage-access-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-the-storage-access-map" class="dfn-panel" data-for="obtain-the-storage-access-map" id="infopanel-for-obtain-the-storage-access-map" role="dialog">
+   <span id="infopaneltitle-for-obtain-the-storage-access-map" style="display:none">Info about the 'obtain the storage access map' definition.</span><b><a href="#obtain-the-storage-access-map">#obtain-the-storage-access-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-the-storage-access-map">3.2. Changes to Document</a> <a href="#ref-for-obtain-the-storage-access-map①">(2)</a>
     <li><a href="#ref-for-obtain-the-storage-access-map②">3.2.1. User Agent storage access policies</a> <a href="#ref-for-obtain-the-storage-access-map③">(2)</a>
     <li><a href="#ref-for-obtain-the-storage-access-map④">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partitioned-storage-key">
-   <b><a href="#partitioned-storage-key">#partitioned-storage-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partitioned-storage-key" class="dfn-panel" data-for="partitioned-storage-key" id="infopanel-for-partitioned-storage-key" role="dialog">
+   <span id="infopaneltitle-for-partitioned-storage-key" style="display:none">Info about the 'partitioned storage key' definition.</span><b><a href="#partitioned-storage-key">#partitioned-storage-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partitioned-storage-key">3.1. User Agent state related to storage access</a> <a href="#ref-for-partitioned-storage-key①">(2)</a> <a href="#ref-for-partitioned-storage-key②">(3)</a> <a href="#ref-for-partitioned-storage-key③">(4)</a> <a href="#ref-for-partitioned-storage-key④">(5)</a> <a href="#ref-for-partitioned-storage-key⑤">(6)</a>
     <li><a href="#ref-for-partitioned-storage-key⑥">3.2.1. User Agent storage access policies</a> <a href="#ref-for-partitioned-storage-key⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partitioned-storage-key-top-level-site">
-   <b><a href="#partitioned-storage-key-top-level-site">#partitioned-storage-key-top-level-site</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partitioned-storage-key-top-level-site" class="dfn-panel" data-for="partitioned-storage-key-top-level-site" id="infopanel-for-partitioned-storage-key-top-level-site" role="dialog">
+   <span id="infopaneltitle-for-partitioned-storage-key-top-level-site" style="display:none">Info about the 'top-level site' definition.</span><b><a href="#partitioned-storage-key-top-level-site">#partitioned-storage-key-top-level-site</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partitioned-storage-key-top-level-site">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-partitioned-storage-key-top-level-site①">3.2.1. User Agent storage access policies</a> <a href="#ref-for-partitioned-storage-key-top-level-site②">(2)</a> <a href="#ref-for-partitioned-storage-key-top-level-site③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partitioned-storage-key-embedded-site">
-   <b><a href="#partitioned-storage-key-embedded-site">#partitioned-storage-key-embedded-site</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partitioned-storage-key-embedded-site" class="dfn-panel" data-for="partitioned-storage-key-embedded-site" id="infopanel-for-partitioned-storage-key-embedded-site" role="dialog">
+   <span id="infopaneltitle-for-partitioned-storage-key-embedded-site" style="display:none">Info about the 'embedded site' definition.</span><b><a href="#partitioned-storage-key-embedded-site">#partitioned-storage-key-embedded-site</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partitioned-storage-key-embedded-site">3.1. User Agent state related to storage access</a>
     <li><a href="#ref-for-partitioned-storage-key-embedded-site①">3.2.1. User Agent storage access policies</a> <a href="#ref-for-partitioned-storage-key-embedded-site②">(2)</a> <a href="#ref-for-partitioned-storage-key-embedded-site③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-partitioned-storage-key">
-   <b><a href="#generate-a-partitioned-storage-key">#generate-a-partitioned-storage-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-partitioned-storage-key" class="dfn-panel" data-for="generate-a-partitioned-storage-key" id="infopanel-for-generate-a-partitioned-storage-key" role="dialog">
+   <span id="infopaneltitle-for-generate-a-partitioned-storage-key" style="display:none">Info about the 'generate a partitioned storage key' definition.</span><b><a href="#generate-a-partitioned-storage-key">#generate-a-partitioned-storage-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-partitioned-storage-key">3.2. Changes to Document</a> <a href="#ref-for-generate-a-partitioned-storage-key①">(2)</a> <a href="#ref-for-generate-a-partitioned-storage-key②">(3)</a>
     <li><a href="#ref-for-generate-a-partitioned-storage-key③">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-access-flag-set">
-   <b><a href="#storage-access-flag-set">#storage-access-flag-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-access-flag-set" class="dfn-panel" data-for="storage-access-flag-set" id="infopanel-for-storage-access-flag-set" role="dialog">
+   <span id="infopaneltitle-for-storage-access-flag-set" style="display:none">Info about the 'storage access flag set' definition.</span><b><a href="#storage-access-flag-set">#storage-access-flag-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-access-flag-set">3.1. User Agent state related to storage access</a> <a href="#ref-for-storage-access-flag-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-storage-access-flag">
-   <b><a href="#has-storage-access-flag">#has-storage-access-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-storage-access-flag" class="dfn-panel" data-for="has-storage-access-flag" id="infopanel-for-has-storage-access-flag" role="dialog">
+   <span id="infopaneltitle-for-has-storage-access-flag" style="display:none">Info about the 'has storage access flag' definition.</span><b><a href="#has-storage-access-flag">#has-storage-access-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-storage-access-flag">3.2. Changes to Document</a> <a href="#ref-for-has-storage-access-flag①">(2)</a>
     <li><a href="#ref-for-has-storage-access-flag②">3.2.1. User Agent storage access policies</a> <a href="#ref-for-has-storage-access-flag③">(2)</a> <a href="#ref-for-has-storage-access-flag④">(3)</a> <a href="#ref-for-has-storage-access-flag⑤">(4)</a>
     <li><a href="#ref-for-has-storage-access-flag⑥">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="was-expressly-denied-storage-access-flag">
-   <b><a href="#was-expressly-denied-storage-access-flag">#was-expressly-denied-storage-access-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-was-expressly-denied-storage-access-flag" class="dfn-panel" data-for="was-expressly-denied-storage-access-flag" id="infopanel-for-was-expressly-denied-storage-access-flag" role="dialog">
+   <span id="infopaneltitle-for-was-expressly-denied-storage-access-flag" style="display:none">Info about the 'was expressly denied storage access flag' definition.</span><b><a href="#was-expressly-denied-storage-access-flag">#was-expressly-denied-storage-access-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-was-expressly-denied-storage-access-flag">3.2. Changes to Document</a> <a href="#ref-for-was-expressly-denied-storage-access-flag①">(2)</a>
     <li><a href="#ref-for-was-expressly-denied-storage-access-flag②">3.2.1. User Agent storage access policies</a> <a href="#ref-for-was-expressly-denied-storage-access-flag③">(2)</a> <a href="#ref-for-was-expressly-denied-storage-access-flag④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-storage-access-flag-set">
-   <b><a href="#obtain-a-storage-access-flag-set">#obtain-a-storage-access-flag-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-storage-access-flag-set" class="dfn-panel" data-for="obtain-a-storage-access-flag-set" id="infopanel-for-obtain-a-storage-access-flag-set" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-storage-access-flag-set" style="display:none">Info about the 'obtain a storage access flag set' definition.</span><b><a href="#obtain-a-storage-access-flag-set">#obtain-a-storage-access-flag-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-storage-access-flag-set">3.2. Changes to Document</a> <a href="#ref-for-obtain-a-storage-access-flag-set①">(2)</a>
     <li><a href="#ref-for-obtain-a-storage-access-flag-set②">3.2.1. User Agent storage access policies</a> <a href="#ref-for-obtain-a-storage-access-flag-set③">(2)</a>
     <li><a href="#ref-for-obtain-a-storage-access-flag-set④">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="save-the-storage-access-flag-set">
-   <b><a href="#save-the-storage-access-flag-set">#save-the-storage-access-flag-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-save-the-storage-access-flag-set" class="dfn-panel" data-for="save-the-storage-access-flag-set" id="infopanel-for-save-the-storage-access-flag-set" role="dialog">
+   <span id="infopaneltitle-for-save-the-storage-access-flag-set" style="display:none">Info about the 'save the storage access flag set' definition.</span><b><a href="#save-the-storage-access-flag-set">#save-the-storage-access-flag-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-save-the-storage-access-flag-set">3.2. Changes to Document</a>
     <li><a href="#ref-for-save-the-storage-access-flag-set①">3.2.1. User Agent storage access policies</a> <a href="#ref-for-save-the-storage-access-flag-set②">(2)</a> <a href="#ref-for-save-the-storage-access-flag-set③">(3)</a>
     <li><a href="#ref-for-save-the-storage-access-flag-set④">3.3. Changes to navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-hasstorageaccess">
-   <b><a href="#dom-document-hasstorageaccess">#dom-document-hasstorageaccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-hasstorageaccess" class="dfn-panel" data-for="dom-document-hasstorageaccess" id="infopanel-for-dom-document-hasstorageaccess" role="dialog">
+   <span id="infopaneltitle-for-dom-document-hasstorageaccess" style="display:none">Info about the 'hasStorageAccess()' definition.</span><b><a href="#dom-document-hasstorageaccess">#dom-document-hasstorageaccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-hasstorageaccess">3. The Storage Access API</a> <a href="#ref-for-dom-document-hasstorageaccess①">(2)</a>
     <li><a href="#ref-for-dom-document-hasstorageaccess②">3.2. Changes to Document</a>
     <li><a href="#ref-for-dom-document-hasstorageaccess③">3.2.1. User Agent storage access policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-requeststorageaccess">
-   <b><a href="#dom-document-requeststorageaccess">#dom-document-requeststorageaccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-requeststorageaccess" class="dfn-panel" data-for="dom-document-requeststorageaccess" id="infopanel-for-dom-document-requeststorageaccess" role="dialog">
+   <span id="infopaneltitle-for-dom-document-requeststorageaccess" style="display:none">Info about the 'requestStorageAccess()' definition.</span><b><a href="#dom-document-requeststorageaccess">#dom-document-requeststorageaccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-requeststorageaccess">3. The Storage Access API</a> <a href="#ref-for-dom-document-requeststorageaccess①">(2)</a>
     <li><a href="#ref-for-dom-document-requeststorageaccess②">3.2. Changes to Document</a>
@@ -1709,21 +1709,21 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
     <li><a href="#ref-for-dom-document-requeststorageaccess④">4. Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-if-a-site-has-storage-access">
-   <b><a href="#determine-if-a-site-has-storage-access">#determine-if-a-site-has-storage-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-if-a-site-has-storage-access" class="dfn-panel" data-for="determine-if-a-site-has-storage-access" id="infopanel-for-determine-if-a-site-has-storage-access" role="dialog">
+   <span id="infopaneltitle-for-determine-if-a-site-has-storage-access" style="display:none">Info about the 'determine if a site has storage access' definition.</span><b><a href="#determine-if-a-site-has-storage-access">#determine-if-a-site-has-storage-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-if-a-site-has-storage-access">3.2. Changes to Document</a>
     <li><a href="#ref-for-determine-if-a-site-has-storage-access①">3.4. Changes to various client-side storage mechanisms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-storage-access-policy">
-   <b><a href="#determine-the-storage-access-policy">#determine-the-storage-access-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-storage-access-policy" class="dfn-panel" data-for="determine-the-storage-access-policy" id="infopanel-for-determine-the-storage-access-policy" role="dialog">
+   <span id="infopaneltitle-for-determine-the-storage-access-policy" style="display:none">Info about the 'determine the storage access policy' definition.</span><b><a href="#determine-the-storage-access-policy">#determine-the-storage-access-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-storage-access-policy">3.2. Changes to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sandbox-storage-access-by-user-activation-flag">
-   <b><a href="#sandbox-storage-access-by-user-activation-flag">#sandbox-storage-access-by-user-activation-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sandbox-storage-access-by-user-activation-flag" class="dfn-panel" data-for="sandbox-storage-access-by-user-activation-flag" id="infopanel-for-sandbox-storage-access-by-user-activation-flag" role="dialog">
+   <span id="infopaneltitle-for-sandbox-storage-access-by-user-activation-flag" style="display:none">Info about the 'sandbox storage access by user activation flag' definition.</span><b><a href="#sandbox-storage-access-by-user-activation-flag">#sandbox-storage-access-by-user-activation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox-storage-access-by-user-activation-flag">3.2. Changes to Document</a>
     <li><a href="#ref-for-sandbox-storage-access-by-user-activation-flag①">3.5. Sandboxing storage access</a>
@@ -1731,57 +1731,113 @@ and everyone who commented on <a href="https://github.com/whatwg/html/issues/333
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/FileAPI/index.html
+++ b/tests/github/w3c/FileAPI/index.html
@@ -3266,277 +3266,277 @@ No invocations to these APIs occur silently without user intervention.</p>
    <li><a href="#UnixEpoch">Unix Epoch</a><span>, in § 2</span>
    <li><a href="#UnsafeFileFR">UnsafeFile</a><span>, in § 7.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">8.3.2. Lifetime of blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">6.4.1. Event Summary</a>
     <li><a href="#ref-for-concept-event-fire①">6.4.2. Summary of Event Invariants</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-constructor">
-   <a href="http://tc39.github.io/ecma262/#sec-array-constructor">http://tc39.github.io/ecma262/#sec-array-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-constructor" class="dfn-panel" data-for="term-for-sec-array-constructor" id="infopanel-for-term-for-sec-array-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-constructor" style="display:none">Info about the 'Array' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-array-constructor">http://tc39.github.io/ecma262/#sec-array-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-constructor">5. The FileList Interface</a> <a href="#ref-for-sec-array-constructor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-date-constructor">
-   <a href="http://tc39.github.io/ecma262/#sec-date-constructor">http://tc39.github.io/ecma262/#sec-date-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-date-constructor" class="dfn-panel" data-for="term-for-sec-date-constructor" id="infopanel-for-term-for-sec-date-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-date-constructor" style="display:none">Info about the 'Date' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-date-constructor">http://tc39.github.io/ecma262/#sec-date-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-date-constructor">4.1. Constructor</a> <a href="#ref-for-sec-date-constructor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decode">
-   <a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decode" class="dfn-panel" data-for="term-for-decode" id="infopanel-for-term-for-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-decode" style="display:none">Info about the 'decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode">6.3. Packaging data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-encoding-get">
-   <a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-encoding-get" class="dfn-panel" data-for="term-for-concept-encoding-get" id="infopanel-for-term-for-concept-encoding-get" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-encoding-get" style="display:none">Info about the 'getting an encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-get">6.3. Packaging data</a> <a href="#ref-for-concept-encoding-get①">(2)</a> <a href="#ref-for-concept-encoding-get②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">6.3. Packaging data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">3.3.3. The text() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">3.2. Attributes</a>
     <li><a href="#ref-for-concept-fetch①">8.4.1. Examples of blob URL Creation and Revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">8.4. Creating and Revoking a blob URL</a> <a href="#ref-for-concept-network-error①">(2)</a> <a href="#ref-for-concept-network-error②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-body-text">
-   <a href="https://fetch.spec.whatwg.org/#dom-body-text">https://fetch.spec.whatwg.org/#dom-body-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-body-text" class="dfn-panel" data-for="term-for-dom-body-text" id="infopanel-for-term-for-dom-body-text" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-body-text" style="display:none">Info about the 'text()' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-body-text">https://fetch.spec.whatwg.org/#dom-body-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-text">3.3.3. The text() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransfer">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransfer" class="dfn-panel" data-for="term-for-datatransfer" id="infopanel-for-term-for-datatransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransfer" style="display:none">Info about the 'DataTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransfer">Unnumbered Section</a>
     <li><a href="#ref-for-datatransfer①">5.2. Methods and Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">6.2. The FileReader API</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlinputelement">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlinputelement" class="dfn-panel" data-for="term-for-htmlinputelement" id="infopanel-for-term-for-htmlinputelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlinputelement" style="display:none">Info about the 'HTMLInputElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#htmlinputelement">https://html.spec.whatwg.org/multipage/input.html#htmlinputelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlinputelement">5.2. Methods and Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serializable">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serializable" class="dfn-panel" data-for="term-for-serializable" id="infopanel-for-term-for-serializable" role="menu">
+   <span id="infopaneltitle-for-term-for-serializable" style="display:none">Info about the 'Serializable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializable">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-serializable①">4. The File Interface</a>
     <li><a href="#ref-for-serializable②">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">10. Requirements and Use Cases</a> <a href="#ref-for-the-a-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">8.2. Model</a> <a href="#ref-for-current-settings-object①">(2)</a>
     <li><a href="#ref-for-current-settings-object②">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deserialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deserialization-steps" class="dfn-panel" data-for="term-for-deserialization-steps" id="infopanel-for-term-for-deserialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-deserialization-steps" style="display:none">Info about the 'deserialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deserialization-steps">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-deserialization-steps①">4. The File Interface</a>
     <li><a href="#ref-for-deserialization-steps②">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-hyperlink-download">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download">https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-hyperlink-download" class="dfn-panel" data-for="term-for-attr-hyperlink-download" id="infopanel-for-term-for-attr-hyperlink-download" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-hyperlink-download" style="display:none">Info about the 'download' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download">https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-hyperlink-download">10. Requirements and Use Cases</a> <a href="#ref-for-attr-hyperlink-download①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-content-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-content-attributes" class="dfn-panel" data-for="term-for-event-handler-content-attributes" id="infopanel-for-term-for-event-handler-content-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-content-attributes" style="display:none">Info about the 'event handler content attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-content-attributes">6.2.1. Event Handler Content Attributes</a> <a href="#ref-for-event-handler-content-attributes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">6.2.1. Event Handler Content Attributes</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">8.1. Introduction</a>
     <li><a href="#ref-for-the-img-element①">8.4.1. Examples of blob URL Creation and Revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-in-parallel①">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">8.2. Model</a>
     <li><a href="#ref-for-concept-settings-object-origin①">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-worker-postmessage-options">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage-options">https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-worker-postmessage-options" class="dfn-panel" data-for="term-for-dom-worker-postmessage-options" id="infopanel-for-term-for-dom-worker-postmessage-options" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-worker-postmessage-options" style="display:none">Info about the 'postMessage(message, options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage-options">https://html.spec.whatwg.org/multipage/workers.html#dom-worker-postmessage-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-worker-postmessage-options">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">6.1. The File Reading Task Source</a>
     <li><a href="#ref-for-queue-a-task①">6.2. The FileReader API</a> <a href="#ref-for-queue-a-task②">(2)</a> <a href="#ref-for-queue-a-task③">(3)</a> <a href="#ref-for-queue-a-task④">(4)</a>
     <li><a href="#ref-for-queue-a-task⑤">6.2.3.5. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">8.3.2. Lifetime of blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">8.4. Creating and Revoking a blob URL</a> <a href="#ref-for-same-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialization-steps" class="dfn-panel" data-for="term-for-serialization-steps" id="infopanel-for-term-for-serialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-serialization-steps" style="display:none">Info about the 'serialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialization-steps">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-serialization-steps①">4. The File Interface</a>
     <li><a href="#ref-for-serialization-steps②">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sub-deserialization">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sub-deserialization" class="dfn-panel" data-for="term-for-sub-deserialization" id="infopanel-for-term-for-sub-deserialization" role="menu">
+   <span id="infopaneltitle-for-term-for-sub-deserialization" style="display:none">Info about the 'sub-deserialization' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sub-deserialization">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sub-serialization">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sub-serialization" class="dfn-panel" data-for="term-for-sub-serialization" id="infopanel-for-term-for-sub-serialization" role="menu">
+   <span id="infopaneltitle-for-term-for-sub-serialization" style="display:none">Info about the 'sub-serialization' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sub-serialization">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">6.2.3.5. The abort() method</a> <a href="#ref-for-concept-task①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">6.1. The File Reading Task Source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps">
-   <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unloading-document-cleanup-steps" class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps" id="infopanel-for-term-for-unloading-document-cleanup-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-unloading-document-cleanup-steps" style="display:none">Info about the 'unloading document cleanup steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unloading-document-cleanup-steps">8.3.2. Lifetime of blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">3.1. Constructors</a>
     <li><a href="#ref-for-ascii-lowercase①">3.3.1. The slice() method</a>
     <li><a href="#ref-for-ascii-lowercase②">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">8.3. Dereferencing Model for blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte">
-   <a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte" class="dfn-panel" data-for="term-for-byte" id="infopanel-for-term-for-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">3. The Blob Interface and Binary Data</a> <a href="#ref-for-byte①">(2)</a>
     <li><a href="#ref-for-byte②">3.1. Constructors</a>
@@ -3546,8 +3546,8 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-byte①⓪">4.1. Constructor</a> <a href="#ref-for-byte①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-byte-sequence①">6.2. The FileReader API</a> <a href="#ref-for-byte-sequence②">(2)</a>
@@ -3557,86 +3557,86 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-byte-sequence⑥">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">3.1.1. Constructor Parameters</a> <a href="#ref-for-code-point①">(2)</a> <a href="#ref-for-code-point②">(3)</a> <a href="#ref-for-code-point③">(4)</a> <a href="#ref-for-code-point④">(5)</a> <a href="#ref-for-code-point⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collecting a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">3.1.1. Constructor Parameters</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">8.3. Dereferencing Model for blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">8.2. Model</a> <a href="#ref-for-map-getting-the-keys①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-position-variable">
-   <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-position-variable" class="dfn-panel" data-for="term-for-string-position-variable" id="infopanel-for-term-for-string-position-variable" role="menu">
+   <span id="infopaneltitle-for-term-for-string-position-variable" style="display:none">Info about the 'position variable' external reference.</span><a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-position-variable">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3.1.1. Constructor Parameters</a> <a href="#ref-for-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">8.3.2. Lifetime of blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediasource">
-   <a href="http://w3c.github.io/media-source/#mediasource">http://w3c.github.io/media-source/#mediasource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediasource" class="dfn-panel" data-for="term-for-mediasource" id="infopanel-for-term-for-mediasource" role="menu">
+   <span id="infopaneltitle-for-term-for-mediasource" style="display:none">Info about the 'MediaSource' external reference.</span><a href="http://w3c.github.io/media-source/#mediasource">http://w3c.github.io/media-source/#mediasource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediasource">8. A URL for Blob and MediaSource reference</a>
     <li><a href="#ref-for-mediasource①">8.1. Introduction</a>
@@ -3644,40 +3644,40 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-mediasource③">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parameters">
-   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parameters" class="dfn-panel" data-for="term-for-parameters" id="infopanel-for-term-for-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-parameters" style="display:none">Info about the 'parameters' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">6.3. Packaging data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parsable-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">https://mimesniff.spec.whatwg.org/#parsable-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parsable-mime-type" class="dfn-panel" data-for="term-for-parsable-mime-type" id="infopanel-for-term-for-parsable-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-parsable-mime-type" style="display:none">Info about the 'parsable mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parsable-mime-type">https://mimesniff.spec.whatwg.org/#parsable-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsable-mime-type">3.2. Attributes</a> <a href="#ref-for-parsable-mime-type①">(2)</a>
     <li><a href="#ref-for-parsable-mime-type②">4. The File Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-mime-type" class="dfn-panel" data-for="term-for-parse-a-mime-type" id="infopanel-for-term-for-parse-a-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-mime-type" style="display:none">Info about the 'parse a mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type">3.2. Attributes</a>
     <li><a href="#ref-for-parse-a-mime-type①">6.3. Packaging data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-chunk">
-   <a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-chunk" class="dfn-panel" data-for="term-for-chunk" id="infopanel-for-term-for-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-chunk" style="display:none">Info about the 'chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">3. The Blob Interface and Binary Data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">3. The Blob Interface and Binary Data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">3.3.3. The text() method</a>
     <li><a href="#ref-for-readablestream-get-a-reader①">3.3.4. The arrayBuffer() method</a>
@@ -3688,14 +3688,14 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-readablestream-get-a-reader⑥">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk" id="infopanel-for-term-for-readablestreamdefaultreader-read-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" style="display:none">Info about the 'read a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk">6.2. The FileReader API</a> <a href="#ref-for-readablestreamdefaultreader-read-a-chunk①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes" id="infopanel-for-term-for-readablestreamdefaultreader-read-all-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" style="display:none">Info about the 'read all bytes' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes">3.3.3. The text() method</a>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes①">3.3.4. The arrayBuffer() method</a>
@@ -3705,33 +3705,33 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes⑤">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url">
-   <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url" class="dfn-panel" data-for="term-for-url" id="infopanel-for-term-for-url" role="menu">
+   <span id="infopaneltitle-for-term-for-url" style="display:none">Info about the 'URL' external reference.</span><a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">8.1. Introduction</a>
     <li><a href="#ref-for-url①">8.4. Creating and Revoking a blob URL</a> <a href="#ref-for-url②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-empty-host">
-   <a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-empty-host" class="dfn-panel" data-for="term-for-empty-host" id="infopanel-for-term-for-empty-host" role="menu">
+   <span id="infopaneltitle-for-term-for-empty-host" style="display:none">Info about the 'empty host' external reference.</span><a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-host">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">8. A URL for Blob and MediaSource reference</a>
     <li><a href="#ref-for-concept-url-scheme①">8.2. Model</a>
@@ -3739,8 +3739,8 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-concept-url-scheme③">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">8. A URL for Blob and MediaSource reference</a>
     <li><a href="#ref-for-concept-url①">8.1. Introduction</a>
@@ -3748,28 +3748,28 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-concept-url③">8.3. Dereferencing Model for blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">8.2. Model</a>
     <li><a href="#ref-for-concept-url-parser①">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">8.2. Model</a>
     <li><a href="#ref-for-concept-url-serializer①">8.3. Dereferencing Model for blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-url-string">
-   <a href="https://url.spec.whatwg.org/#valid-url-string">https://url.spec.whatwg.org/#valid-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-url-string" class="dfn-panel" data-for="term-for-valid-url-string" id="infopanel-for-term-for-valid-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-url-string" style="display:none">Info about the 'valid url string' external reference.</span><a href="https://url.spec.whatwg.org/#valid-url-string">https://url.spec.whatwg.org/#valid-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-url-string">8.2. Model</a> <a href="#ref-for-valid-url-string①">(2)</a> <a href="#ref-for-valid-url-string②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-idl-ArrayBuffer①">3.3.4. The arrayBuffer() method</a>
@@ -3777,29 +3777,29 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-idl-ArrayBuffer④">6.5.1. The FileReaderSync API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-BufferSource①">3.1.1. Constructor Parameters</a> <a href="#ref-for-BufferSource②">(2)</a>
     <li><a href="#ref-for-BufferSource③">4.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Clamp">
-   <a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Clamp" class="dfn-panel" data-for="term-for-Clamp" id="infopanel-for-term-for-Clamp" role="menu">
+   <span id="infopaneltitle-for-term-for-Clamp" style="display:none">Info about the 'Clamp' external reference.</span><a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Clamp">3. The Blob Interface and Binary Data</a> <a href="#ref-for-Clamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.2. The FileReader API</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a>
     <li><a href="#ref-for-idl-DOMException③">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. The Blob Interface and Binary Data</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">3.2. Attributes</a>
@@ -3810,8 +3810,8 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-idl-DOMString①③">8.4. Creating and Revoking a blob URL</a> <a href="#ref-for-idl-DOMString①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-Exposed①">4. The File Interface</a>
@@ -3821,50 +3821,50 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-Exposed⑤">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6.2. The FileReader API</a>
     <li><a href="#ref-for-invalidstateerror①">6.2.3. Reading a File or Blob</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3. The Blob Interface and Binary Data</a> <a href="#ref-for-NewObject①">(2)</a> <a href="#ref-for-NewObject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">4.2. Attributes</a> <a href="#ref-for-notfounderror①">(2)</a>
     <li><a href="#ref-for-notfounderror②">7. Errors and Exceptions</a>
     <li><a href="#ref-for-notfounderror③">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-notfounderror④">(2)</a> <a href="#ref-for-notfounderror⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notreadableerror">
-   <a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notreadableerror" class="dfn-panel" data-for="term-for-notreadableerror" id="infopanel-for-term-for-notreadableerror" role="menu">
+   <span id="infopaneltitle-for-term-for-notreadableerror" style="display:none">Info about the 'NotReadableError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notreadableerror">7. Errors and Exceptions</a>
     <li><a href="#ref-for-notreadableerror①">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-notreadableerror②">(2)</a> <a href="#ref-for-notreadableerror③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. The Blob Interface and Binary Data</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">7. Errors and Exceptions</a>
     <li><a href="#ref-for-securityerror①">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-securityerror②">(2)</a> <a href="#ref-for-securityerror③">(3)</a>
     <li><a href="#ref-for-securityerror④">9. Security and Privacy Considerations</a> <a href="#ref-for-securityerror⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. The Blob Interface and Binary Data</a> <a href="#ref-for-idl-USVString①">(2)</a>
     <li><a href="#ref-for-idl-USVString②">3.1.1. Constructor Parameters</a> <a href="#ref-for-idl-USVString③">(2)</a> <a href="#ref-for-idl-USVString④">(3)</a>
@@ -3872,82 +3872,82 @@ No invocations to these APIs occur silently without user intervention.</p>
     <li><a href="#ref-for-idl-USVString⑥">4.1.1. Constructor Parameters</a> <a href="#ref-for-idl-USVString⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long-long" class="dfn-panel" data-for="term-for-idl-long-long" id="infopanel-for-term-for-idl-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long-long" style="display:none">Info about the 'long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">3. The Blob Interface and Binary Data</a> <a href="#ref-for-idl-long-long①">(2)</a>
     <li><a href="#ref-for-idl-long-long②">4. The File Interface</a> <a href="#ref-for-idl-long-long③">(2)</a>
     <li><a href="#ref-for-idl-long-long④">4.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-idl-sequence①">4. The File Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-supported-property-indices">
-   <a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-supported-property-indices" class="dfn-panel" data-for="term-for-dfn-supported-property-indices" id="infopanel-for-term-for-dfn-supported-property-indices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-supported-property-indices" style="display:none">Info about the 'supported property indices' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices">5.2. Methods and Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a>
     <li><a href="#ref-for-dfn-throw④">9. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6.2. The FileReader API</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a>
     <li><a href="#ref-for-idl-undefined⑤">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">5. The FileList Interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">5.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-idl-unsigned-long-long①">3.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">6.2. The FileReader API</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a> <a href="#ref-for-idl-unsigned-short③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-progressevent">
-   <a href="https://xhr.spec.whatwg.org/#progressevent">https://xhr.spec.whatwg.org/#progressevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-progressevent" class="dfn-panel" data-for="term-for-progressevent" id="infopanel-for-term-for-progressevent" role="menu">
+   <span id="infopaneltitle-for-term-for-progressevent" style="display:none">Info about the 'ProgressEvent' external reference.</span><a href="https://xhr.spec.whatwg.org/#progressevent">https://xhr.spec.whatwg.org/#progressevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-progressevent">6.4. Events</a>
     <li><a href="#ref-for-progressevent①">6.4.1. Event Summary</a> <a href="#ref-for-progressevent②">(2)</a> <a href="#ref-for-progressevent③">(3)</a> <a href="#ref-for-progressevent④">(4)</a> <a href="#ref-for-progressevent⑤">(5)</a> <a href="#ref-for-progressevent⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequest" class="dfn-panel" data-for="term-for-xmlhttprequest" id="infopanel-for-term-for-xmlhttprequest" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xmlhttprequest-send">
-   <a href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xmlhttprequest-send" class="dfn-panel" data-for="term-for-dom-xmlhttprequest-send" id="infopanel-for-term-for-dom-xmlhttprequest-send" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xmlhttprequest-send" style="display:none">Info about the 'send()' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-send">Unnumbered Section</a>
    </ul>
@@ -4250,21 +4250,21 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
    <div class="issue"> This needs a similar hook when a worker is unloaded. <a class="issue-return" href="#issue-5f2e5a9d" title="Jump to section">↵</a></div>
    <div class="issue"> This section is provisional; more security data may supplement this in subsequent drafts. <a class="issue-return" href="#issue-61296551" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="terminate-an-algorithm">
-   <b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-terminate-an-algorithm" class="dfn-panel" data-for="terminate-an-algorithm" id="infopanel-for-terminate-an-algorithm" role="dialog">
+   <span id="infopaneltitle-for-terminate-an-algorithm" style="display:none">Info about the 'terminate an algorithm' definition.</span><b><a href="#terminate-an-algorithm">#terminate-an-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-an-algorithm">6.2.3.5. The abort() method</a> <a href="#ref-for-terminate-an-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="UnixEpoch">
-   <b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-UnixEpoch" class="dfn-panel" data-for="UnixEpoch" id="infopanel-for-UnixEpoch" role="dialog">
+   <span id="infopaneltitle-for-UnixEpoch" style="display:none">Info about the 'Unix Epoch' definition.</span><b><a href="#UnixEpoch">#UnixEpoch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-UnixEpoch">4.1. Constructor</a> <a href="#ref-for-UnixEpoch①">(2)</a>
     <li><a href="#ref-for-UnixEpoch②">4.2. Attributes</a> <a href="#ref-for-UnixEpoch③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="snapshot-state">
-   <b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-snapshot-state" class="dfn-panel" data-for="snapshot-state" id="infopanel-for-snapshot-state" role="dialog">
+   <span id="infopaneltitle-for-snapshot-state" style="display:none">Info about the 'snapshot state' definition.</span><b><a href="#snapshot-state">#snapshot-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-snapshot-state">3. The Blob Interface and Binary Data</a> <a href="#ref-for-snapshot-state①">(2)</a> <a href="#ref-for-snapshot-state②">(3)</a>
     <li><a href="#ref-for-snapshot-state③">4. The File Interface</a> <a href="#ref-for-snapshot-state④">(2)</a> <a href="#ref-for-snapshot-state⑤">(3)</a> <a href="#ref-for-snapshot-state⑥">(4)</a> <a href="#ref-for-snapshot-state⑦">(5)</a> <a href="#ref-for-snapshot-state⑧">(6)</a>
@@ -4272,8 +4272,8 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-snapshot-state①⓪">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-snapshot-state①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-Blob">
-   <b><a href="#dfn-Blob">#dfn-Blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-Blob" class="dfn-panel" data-for="dfn-Blob" id="infopanel-for-dfn-Blob" role="dialog">
+   <span id="infopaneltitle-for-dfn-Blob" style="display:none">Info about the 'Blob' definition.</span><b><a href="#dfn-Blob">#dfn-Blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob⑤">1. Introduction</a> <a href="#ref-for-dfn-Blob⑥">(2)</a> <a href="#ref-for-dfn-Blob⑦">(3)</a>
     <li><a href="#ref-for-dfn-Blob⑧">3. The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-Blob⑨">(2)</a> <a href="#ref-for-dfn-Blob①⓪">(3)</a> <a href="#ref-for-dfn-Blob①①">(4)</a> <a href="#ref-for-dfn-Blob①②">(5)</a> <a href="#ref-for-dfn-Blob①③">(6)</a>
@@ -4299,39 +4299,39 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-Blob⑥⑤">8.4.1. Examples of blob URL Creation and Revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blob-blob">
-   <b><a href="#dom-blob-blob">#dom-blob-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blob-blob" class="dfn-panel" data-for="dom-blob-blob" id="infopanel-for-dom-blob-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-blob-blob" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-blob-blob">#dom-blob-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blob-blob">3.1. Constructors</a> <a href="#ref-for-dom-blob-blob①">(2)</a>
     <li><a href="#ref-for-dom-blob-blob②">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blob-blob-blobparts-options-options">
-   <b><a href="#dom-blob-blob-blobparts-options-options">#dom-blob-blob-blobparts-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blob-blob-blobparts-options-options" class="dfn-panel" data-for="dom-blob-blob-blobparts-options-options" id="infopanel-for-dom-blob-blob-blobparts-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-blob-blob-blobparts-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-blob-blob-blobparts-options-options">#dom-blob-blob-blobparts-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blob-blob-blobparts-options-options">3.1. Constructors</a> <a href="#ref-for-dom-blob-blob-blobparts-options-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-endingtype">
-   <b><a href="#enumdef-endingtype">#enumdef-endingtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-endingtype" class="dfn-panel" data-for="enumdef-endingtype" id="infopanel-for-enumdef-endingtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-endingtype" style="display:none">Info about the 'EndingType' definition.</span><b><a href="#enumdef-endingtype">#enumdef-endingtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-endingtype">3. The Blob Interface and Binary Data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endingtype-transparent">
-   <b><a href="#dom-endingtype-transparent">#dom-endingtype-transparent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endingtype-transparent" class="dfn-panel" data-for="dom-endingtype-transparent" id="infopanel-for-dom-endingtype-transparent" role="dialog">
+   <span id="infopaneltitle-for-dom-endingtype-transparent" style="display:none">Info about the '"transparent"' definition.</span><b><a href="#dom-endingtype-transparent">#dom-endingtype-transparent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endingtype-transparent">3.1.1. Constructor Parameters</a> <a href="#ref-for-dom-endingtype-transparent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endingtype-native">
-   <b><a href="#dom-endingtype-native">#dom-endingtype-native</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endingtype-native" class="dfn-panel" data-for="dom-endingtype-native" id="infopanel-for-dom-endingtype-native" role="dialog">
+   <span id="infopaneltitle-for-dom-endingtype-native" style="display:none">Info about the '"native"' definition.</span><b><a href="#dom-endingtype-native">#dom-endingtype-native</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endingtype-native">3.1.1. Constructor Parameters</a> <a href="#ref-for-dom-endingtype-native①">(2)</a> <a href="#ref-for-dom-endingtype-native②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-BlobPropertyBag">
-   <b><a href="#dfn-BlobPropertyBag">#dfn-BlobPropertyBag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-BlobPropertyBag" class="dfn-panel" data-for="dfn-BlobPropertyBag" id="infopanel-for-dfn-BlobPropertyBag" role="dialog">
+   <span id="infopaneltitle-for-dfn-BlobPropertyBag" style="display:none">Info about the 'BlobPropertyBag' definition.</span><b><a href="#dfn-BlobPropertyBag">#dfn-BlobPropertyBag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-BlobPropertyBag">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-BlobPropertyBag①">3.1.1. Constructor Parameters</a> <a href="#ref-for-dfn-BlobPropertyBag②">(2)</a>
@@ -4339,16 +4339,16 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-BlobPropertyBag④">4.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-blobpart">
-   <b><a href="#typedefdef-blobpart">#typedefdef-blobpart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-blobpart" class="dfn-panel" data-for="typedefdef-blobpart" id="infopanel-for-typedefdef-blobpart" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-blobpart" style="display:none">Info about the 'BlobPart' definition.</span><b><a href="#typedefdef-blobpart">#typedefdef-blobpart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-blobpart">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-typedefdef-blobpart①">3.1.1. Constructor Parameters</a>
     <li><a href="#ref-for-typedefdef-blobpart②">4. The File Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blob-get-stream">
-   <b><a href="#blob-get-stream">#blob-get-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blob-get-stream" class="dfn-panel" data-for="blob-get-stream" id="infopanel-for-blob-get-stream" role="dialog">
+   <span id="infopaneltitle-for-blob-get-stream" style="display:none">Info about the 'get stream' definition.</span><b><a href="#blob-get-stream">#blob-get-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-get-stream">3.3.2. The stream() method</a>
     <li><a href="#ref-for-blob-get-stream①">3.3.3. The text() method</a>
@@ -4361,44 +4361,45 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-blob-get-stream⑧">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-blobParts">
-   <b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-blobParts" class="dfn-panel" data-for="dfn-blobParts" id="infopanel-for-dfn-blobParts" role="dialog">
+   <span id="infopaneltitle-for-dfn-blobParts" style="display:none">Info about the 'blobParts' definition.</span><b><a href="#dfn-blobParts">#dfn-blobParts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-blobParts">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-blobParts①">3.1. Constructors</a>
     <li><a href="#ref-for-dfn-blobParts②">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-BPtype">
-   <b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-BPtype" class="dfn-panel" data-for="dfn-BPtype" id="infopanel-for-dfn-BPtype" role="dialog">
+   <span id="infopaneltitle-for-dfn-BPtype" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-BPtype">#dfn-BPtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-BPtype">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-BPtype①">3.1. Constructors</a> <a href="#ref-for-dfn-BPtype②">(2)</a>
     <li><a href="#ref-for-dfn-BPtype③">4.1. Constructor</a> <a href="#ref-for-dfn-BPtype④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobpropertybag-endings">
-   <b><a href="#dom-blobpropertybag-endings">#dom-blobpropertybag-endings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobpropertybag-endings" class="dfn-panel" data-for="dom-blobpropertybag-endings" id="infopanel-for-dom-blobpropertybag-endings" role="dialog">
+   <span id="infopaneltitle-for-dom-blobpropertybag-endings" style="display:none">Info about the 'endings' definition.</span><b><a href="#dom-blobpropertybag-endings">#dom-blobpropertybag-endings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobpropertybag-endings">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dom-blobpropertybag-endings①">3.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-blob-parts">
-   <b><a href="#process-blob-parts">#process-blob-parts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-blob-parts" class="dfn-panel" data-for="process-blob-parts" id="infopanel-for-process-blob-parts" role="dialog">
+   <span id="infopaneltitle-for-process-blob-parts" style="display:none">Info about the 'process blob parts' definition.</span><b><a href="#process-blob-parts">#process-blob-parts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-blob-parts">3.1. Constructors</a>
     <li><a href="#ref-for-process-blob-parts①">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-line-endings-to-native">
-   <b><a href="#convert-line-endings-to-native">#convert-line-endings-to-native</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-line-endings-to-native" class="dfn-panel" data-for="convert-line-endings-to-native" id="infopanel-for-convert-line-endings-to-native" role="dialog">
+   <span id="infopaneltitle-for-convert-line-endings-to-native" style="display:none">Info about the '
+convert line endings to native' definition.</span><b><a href="#convert-line-endings-to-native">#convert-line-endings-to-native</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-line-endings-to-native">3.1.1. Constructor Parameters</a> <a href="#ref-for-convert-line-endings-to-native①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-size">
-   <b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-size" class="dfn-panel" data-for="dfn-size" id="infopanel-for-dfn-size" role="dialog">
+   <span id="infopaneltitle-for-dfn-size" style="display:none">Info about the 'size' definition.</span><b><a href="#dfn-size">#dfn-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-size">3. The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-size①">(2)</a>
     <li><a href="#ref-for-dfn-size②">3.1. Constructors</a> <a href="#ref-for-dfn-size③">(2)</a>
@@ -4406,8 +4407,8 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-size⑦">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type">
-   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type" class="dfn-panel" data-for="dfn-type" id="infopanel-for-dfn-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3. The Blob Interface and Binary Data</a> <a href="#ref-for-dfn-type①">(2)</a>
     <li><a href="#ref-for-dfn-type②">3.1. Constructors</a> <a href="#ref-for-dfn-type③">(2)</a>
@@ -4424,64 +4425,64 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-type①⑨">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-slice">
-   <b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-slice" class="dfn-panel" data-for="dfn-slice" id="infopanel-for-dfn-slice" role="dialog">
+   <span id="infopaneltitle-for-dfn-slice" style="display:none">Info about the 'slice()' definition.</span><b><a href="#dfn-slice">#dfn-slice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-slice">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-slice①">3.2. Attributes</a>
     <li><a href="#ref-for-dfn-slice②">3.3.1. The slice() method</a> <a href="#ref-for-dfn-slice③">(2)</a> <a href="#ref-for-dfn-slice④">(3)</a> <a href="#ref-for-dfn-slice⑤">(4)</a> <a href="#ref-for-dfn-slice⑥">(5)</a> <a href="#ref-for-dfn-slice⑦">(6)</a> <a href="#ref-for-dfn-slice⑧">(7)</a> <a href="#ref-for-dfn-slice⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-start">
-   <b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-start" class="dfn-panel" data-for="dfn-start" id="infopanel-for-dfn-start" role="dialog">
+   <span id="infopaneltitle-for-dfn-start" style="display:none">Info about the 'start' definition.</span><b><a href="#dfn-start">#dfn-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-start">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-start①">3.3.1. The slice() method</a> <a href="#ref-for-dfn-start②">(2)</a> <a href="#ref-for-dfn-start③">(3)</a> <a href="#ref-for-dfn-start④">(4)</a> <a href="#ref-for-dfn-start⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-end">
-   <b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-end" class="dfn-panel" data-for="dfn-end" id="infopanel-for-dfn-end" role="dialog">
+   <span id="infopaneltitle-for-dfn-end" style="display:none">Info about the 'end' definition.</span><b><a href="#dfn-end">#dfn-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-end">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-end①">3.3.1. The slice() method</a> <a href="#ref-for-dfn-end②">(2)</a> <a href="#ref-for-dfn-end③">(3)</a> <a href="#ref-for-dfn-end④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-contentTypeBlob">
-   <b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-contentTypeBlob" class="dfn-panel" data-for="dfn-contentTypeBlob" id="infopanel-for-dfn-contentTypeBlob" role="dialog">
+   <span id="infopaneltitle-for-dfn-contentTypeBlob" style="display:none">Info about the 'contentType' definition.</span><b><a href="#dfn-contentTypeBlob">#dfn-contentTypeBlob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-contentTypeBlob">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dfn-contentTypeBlob①">3.3.1. The slice() method</a> <a href="#ref-for-dfn-contentTypeBlob②">(2)</a> <a href="#ref-for-dfn-contentTypeBlob③">(3)</a> <a href="#ref-for-dfn-contentTypeBlob④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blob-stream">
-   <b><a href="#dom-blob-stream">#dom-blob-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blob-stream" class="dfn-panel" data-for="dom-blob-stream" id="infopanel-for-dom-blob-stream" role="dialog">
+   <span id="infopaneltitle-for-dom-blob-stream" style="display:none">Info about the 'stream()' definition.</span><b><a href="#dom-blob-stream">#dom-blob-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blob-stream">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dom-blob-stream①">3.3.2. The stream() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blob-text">
-   <b><a href="#dom-blob-text">#dom-blob-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blob-text" class="dfn-panel" data-for="dom-blob-text" id="infopanel-for-dom-blob-text" role="dialog">
+   <span id="infopaneltitle-for-dom-blob-text" style="display:none">Info about the 'text()' definition.</span><b><a href="#dom-blob-text">#dom-blob-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blob-text">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dom-blob-text①">3.3.3. The text() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blob-arraybuffer">
-   <b><a href="#dom-blob-arraybuffer">#dom-blob-arraybuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blob-arraybuffer" class="dfn-panel" data-for="dom-blob-arraybuffer" id="infopanel-for-dom-blob-arraybuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-blob-arraybuffer" style="display:none">Info about the 'arrayBuffer()' definition.</span><b><a href="#dom-blob-arraybuffer">#dom-blob-arraybuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blob-arraybuffer">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-dom-blob-arraybuffer①">3.3.4. The arrayBuffer() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-type-guidelines">
-   <b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-type-guidelines" class="dfn-panel" data-for="file-type-guidelines" id="infopanel-for-file-type-guidelines" role="dialog">
+   <span id="infopaneltitle-for-file-type-guidelines" style="display:none">Info about the 'file type guidelines' definition.</span><b><a href="#file-type-guidelines">#file-type-guidelines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-type-guidelines">3.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-file">
-   <b><a href="#dfn-file">#dfn-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-file" class="dfn-panel" data-for="dfn-file" id="infopanel-for-dfn-file" role="dialog">
+   <span id="infopaneltitle-for-dfn-file" style="display:none">Info about the 'File' definition.</span><b><a href="#dfn-file">#dfn-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file③">1. Introduction</a> <a href="#ref-for-dfn-file④">(2)</a> <a href="#ref-for-dfn-file⑤">(3)</a>
     <li><a href="#ref-for-dfn-file⑥">3. The Blob Interface and Binary Data</a>
@@ -4501,64 +4502,64 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-file④⑤">10. Requirements and Use Cases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-file-file">
-   <b><a href="#dom-file-file">#dom-file-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-file-file" class="dfn-panel" data-for="dom-file-file" id="infopanel-for-dom-file-file" role="dialog">
+   <span id="infopaneltitle-for-dom-file-file" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-file-file">#dom-file-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-file-file">4.1. Constructor</a>
     <li><a href="#ref-for-dom-file-file①">4.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-file-file-filebits-filename-options-options">
-   <b><a href="#dom-file-file-filebits-filename-options-options">#dom-file-file-filebits-filename-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-file-file-filebits-filename-options-options" class="dfn-panel" data-for="dom-file-file-filebits-filename-options-options" id="infopanel-for-dom-file-file-filebits-filename-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-file-file-filebits-filename-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-file-file-filebits-filename-options-options">#dom-file-file-filebits-filename-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-file-file-filebits-filename-options-options">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-FilePropertyBag">
-   <b><a href="#dfn-FilePropertyBag">#dfn-FilePropertyBag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-FilePropertyBag" class="dfn-panel" data-for="dfn-FilePropertyBag" id="infopanel-for-dfn-FilePropertyBag" role="dialog">
+   <span id="infopaneltitle-for-dfn-FilePropertyBag" style="display:none">Info about the 'FilePropertyBag' definition.</span><b><a href="#dfn-FilePropertyBag">#dfn-FilePropertyBag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-FilePropertyBag">4. The File Interface</a>
     <li><a href="#ref-for-dfn-FilePropertyBag①">4.1. Constructor</a>
     <li><a href="#ref-for-dfn-FilePropertyBag②">4.1.1. Constructor Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-fileBits">
-   <b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-fileBits" class="dfn-panel" data-for="dfn-fileBits" id="infopanel-for-dfn-fileBits" role="dialog">
+   <span id="infopaneltitle-for-dfn-fileBits" style="display:none">Info about the 'fileBits' definition.</span><b><a href="#dfn-fileBits">#dfn-fileBits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fileBits">4. The File Interface</a>
     <li><a href="#ref-for-dfn-fileBits①">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-fileName">
-   <b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-fileName" class="dfn-panel" data-for="dfn-fileName" id="infopanel-for-dfn-fileName" role="dialog">
+   <span id="infopaneltitle-for-dfn-fileName" style="display:none">Info about the 'fileName' definition.</span><b><a href="#dfn-fileName">#dfn-fileName</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fileName">4. The File Interface</a>
     <li><a href="#ref-for-dfn-fileName①">4.1. Constructor</a> <a href="#ref-for-dfn-fileName②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-FPdate">
-   <b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-FPdate" class="dfn-panel" data-for="dfn-FPdate" id="infopanel-for-dfn-FPdate" role="dialog">
+   <span id="infopaneltitle-for-dfn-FPdate" style="display:none">Info about the 'lastModified' definition.</span><b><a href="#dfn-FPdate">#dfn-FPdate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-FPdate">4. The File Interface</a>
     <li><a href="#ref-for-dfn-FPdate①">4.1. Constructor</a> <a href="#ref-for-dfn-FPdate②">(2)</a> <a href="#ref-for-dfn-FPdate③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-name">
-   <b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-name" class="dfn-panel" data-for="dfn-name" id="infopanel-for-dfn-name" role="dialog">
+   <span id="infopaneltitle-for-dfn-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dfn-name">#dfn-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">4. The File Interface</a> <a href="#ref-for-dfn-name①">(2)</a> <a href="#ref-for-dfn-name②">(3)</a> <a href="#ref-for-dfn-name③">(4)</a>
     <li><a href="#ref-for-dfn-name④">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-lastModified">
-   <b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-lastModified" class="dfn-panel" data-for="dfn-lastModified" id="infopanel-for-dfn-lastModified" role="dialog">
+   <span id="infopaneltitle-for-dfn-lastModified" style="display:none">Info about the 'lastModified' definition.</span><b><a href="#dfn-lastModified">#dfn-lastModified</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lastModified">4. The File Interface</a> <a href="#ref-for-dfn-lastModified①">(2)</a> <a href="#ref-for-dfn-lastModified②">(3)</a>
     <li><a href="#ref-for-dfn-lastModified③">4.1. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-filelist">
-   <b><a href="#dfn-filelist">#dfn-filelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-filelist" class="dfn-panel" data-for="dfn-filelist" id="infopanel-for-dfn-filelist" role="dialog">
+   <span id="infopaneltitle-for-dfn-filelist" style="display:none">Info about the 'FileList' definition.</span><b><a href="#dfn-filelist">#dfn-filelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-filelist①">4.2. Attributes</a>
     <li><a href="#ref-for-dfn-filelist②">5. The FileList Interface</a> <a href="#ref-for-dfn-filelist③">(2)</a> <a href="#ref-for-dfn-filelist④">(3)</a>
@@ -4567,33 +4568,33 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-filelist①②">9. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-length">
-   <b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-length" class="dfn-panel" data-for="dfn-length" id="infopanel-for-dfn-length" role="dialog">
+   <span id="infopaneltitle-for-dfn-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dfn-length">#dfn-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-length">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-item">
-   <b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-item" class="dfn-panel" data-for="dfn-item" id="infopanel-for-dfn-item" role="dialog">
+   <span id="infopaneltitle-for-dfn-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dfn-item">#dfn-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-item">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-index">
-   <b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-index" class="dfn-panel" data-for="dfn-index" id="infopanel-for-dfn-index" role="dialog">
+   <span id="infopaneltitle-for-dfn-index" style="display:none">Info about the 'index' definition.</span><b><a href="#dfn-index">#dfn-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-index">5. The FileList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fileReadingTaskSource">
-   <b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fileReadingTaskSource" class="dfn-panel" data-for="fileReadingTaskSource" id="infopanel-for-fileReadingTaskSource" role="dialog">
+   <span id="infopaneltitle-for-fileReadingTaskSource" style="display:none">Info about the 'file reading task source' definition.</span><b><a href="#fileReadingTaskSource">#fileReadingTaskSource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fileReadingTaskSource">6.2. The FileReader API</a>
     <li><a href="#ref-for-fileReadingTaskSource①">6.2.3.5. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-filereader">
-   <b><a href="#dfn-filereader">#dfn-filereader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-filereader" class="dfn-panel" data-for="dfn-filereader" id="infopanel-for-dfn-filereader" role="dialog">
+   <span id="infopaneltitle-for-dfn-filereader" style="display:none">Info about the 'FileReader' definition.</span><b><a href="#dfn-filereader">#dfn-filereader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-filereader①">1. Introduction</a>
     <li><a href="#ref-for-dfn-filereader②">3.2. Attributes</a>
@@ -4609,78 +4610,78 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-filereader②④">9. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-empty">
-   <b><a href="#dom-filereader-empty">#dom-filereader-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-empty" class="dfn-panel" data-for="dom-filereader-empty" id="infopanel-for-dom-filereader-empty" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-empty" style="display:none">Info about the 'EMPTY' definition.</span><b><a href="#dom-filereader-empty">#dom-filereader-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-empty">6.2. The FileReader API</a>
     <li><a href="#ref-for-dom-filereader-empty①">6.2.2. FileReader States</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-loading">
-   <b><a href="#dom-filereader-loading">#dom-filereader-loading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-loading" class="dfn-panel" data-for="dom-filereader-loading" id="infopanel-for-dom-filereader-loading" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-loading" style="display:none">Info about the 'LOADING' definition.</span><b><a href="#dom-filereader-loading">#dom-filereader-loading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-loading">6.2. The FileReader API</a>
     <li><a href="#ref-for-dom-filereader-loading①">6.2.2. FileReader States</a>
     <li><a href="#ref-for-dom-filereader-loading②">6.2.3. Reading a File or Blob</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-done">
-   <b><a href="#dom-filereader-done">#dom-filereader-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-done" class="dfn-panel" data-for="dom-filereader-done" id="infopanel-for-dom-filereader-done" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-done" style="display:none">Info about the 'DONE' definition.</span><b><a href="#dom-filereader-done">#dom-filereader-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-done">6.2. The FileReader API</a>
     <li><a href="#ref-for-dom-filereader-done①">6.2.2. FileReader States</a> <a href="#ref-for-dom-filereader-done②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filereader-state">
-   <b><a href="#filereader-state">#filereader-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filereader-state" class="dfn-panel" data-for="filereader-state" id="infopanel-for-filereader-state" role="dialog">
+   <span id="infopaneltitle-for-filereader-state" style="display:none">Info about the 'state' definition.</span><b><a href="#filereader-state">#filereader-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filereader-state">6.2. The FileReader API</a> <a href="#ref-for-filereader-state①">(2)</a> <a href="#ref-for-filereader-state②">(3)</a> <a href="#ref-for-filereader-state③">(4)</a> <a href="#ref-for-filereader-state④">(5)</a> <a href="#ref-for-filereader-state⑤">(6)</a> <a href="#ref-for-filereader-state⑥">(7)</a>
     <li><a href="#ref-for-filereader-state⑦">6.2.3.5. The abort() method</a> <a href="#ref-for-filereader-state⑧">(2)</a> <a href="#ref-for-filereader-state⑨">(3)</a> <a href="#ref-for-filereader-state①⓪">(4)</a> <a href="#ref-for-filereader-state①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filereader-result">
-   <b><a href="#filereader-result">#filereader-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filereader-result" class="dfn-panel" data-for="filereader-result" id="infopanel-for-filereader-result" role="dialog">
+   <span id="infopaneltitle-for-filereader-result" style="display:none">Info about the 'result' definition.</span><b><a href="#filereader-result">#filereader-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filereader-result">6.2. The FileReader API</a> <a href="#ref-for-filereader-result①">(2)</a> <a href="#ref-for-filereader-result②">(3)</a>
     <li><a href="#ref-for-filereader-result③">6.2.3.5. The abort() method</a> <a href="#ref-for-filereader-result④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filereader-error">
-   <b><a href="#filereader-error">#filereader-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filereader-error" class="dfn-panel" data-for="filereader-error" id="infopanel-for-filereader-error" role="dialog">
+   <span id="infopaneltitle-for-filereader-error" style="display:none">Info about the 'error' definition.</span><b><a href="#filereader-error">#filereader-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filereader-error">6.2. The FileReader API</a> <a href="#ref-for-filereader-error①">(2)</a> <a href="#ref-for-filereader-error②">(3)</a> <a href="#ref-for-filereader-error③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="filereaderConstrctr">
-   <b><a href="#filereaderConstrctr">#filereaderConstrctr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-filereaderConstrctr" class="dfn-panel" data-for="filereaderConstrctr" id="infopanel-for-filereaderConstrctr" role="dialog">
+   <span id="infopaneltitle-for-filereaderConstrctr" style="display:none">Info about the 'FileReader()' definition.</span><b><a href="#filereaderConstrctr">#filereaderConstrctr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-filereaderConstrctr">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-readystate">
-   <b><a href="#dom-filereader-readystate">#dom-filereader-readystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-readystate" class="dfn-panel" data-for="dom-filereader-readystate" id="infopanel-for-dom-filereader-readystate" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-readystate" style="display:none">Info about the 'readyState' definition.</span><b><a href="#dom-filereader-readystate">#dom-filereader-readystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-readystate">6.2. The FileReader API</a>
     <li><a href="#ref-for-dom-filereader-readystate①">6.2.2. FileReader States</a> <a href="#ref-for-dom-filereader-readystate②">(2)</a>
     <li><a href="#ref-for-dom-filereader-readystate③">6.2.3. Reading a File or Blob</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-result">
-   <b><a href="#dom-filereader-result">#dom-filereader-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-result" class="dfn-panel" data-for="dom-filereader-result" id="infopanel-for-dom-filereader-result" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-result" style="display:none">Info about the 'result' definition.</span><b><a href="#dom-filereader-result">#dom-filereader-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-result">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereader-error">
-   <b><a href="#dom-filereader-error">#dom-filereader-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereader-error" class="dfn-panel" data-for="dom-filereader-error" id="infopanel-for-dom-filereader-error" role="dialog">
+   <span id="infopaneltitle-for-dom-filereader-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-filereader-error">#dom-filereader-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereader-error">4.2. Attributes</a>
     <li><a href="#ref-for-dom-filereader-error①">6.2. The FileReader API</a>
     <li><a href="#ref-for-dom-filereader-error②">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-dom-filereader-error③">(2)</a> <a href="#ref-for-dom-filereader-error④">(3)</a> <a href="#ref-for-dom-filereader-error⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readOperation">
-   <b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readOperation" class="dfn-panel" data-for="readOperation" id="infopanel-for-readOperation" role="dialog">
+   <span id="infopaneltitle-for-readOperation" style="display:none">Info about the 'read operation' definition.</span><b><a href="#readOperation">#readOperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readOperation">4.2. Attributes</a>
     <li><a href="#ref-for-readOperation①">6.2.3.1. The readAsDataURL() method</a>
@@ -4690,50 +4691,50 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-readOperation⑤">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onloadstart">
-   <b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onloadstart" class="dfn-panel" data-for="dfn-onloadstart" id="infopanel-for-dfn-onloadstart" role="dialog">
+   <span id="infopaneltitle-for-dfn-onloadstart" style="display:none">Info about the 'onloadstart' definition.</span><b><a href="#dfn-onloadstart">#dfn-onloadstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onloadstart">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onprogress">
-   <b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onprogress" class="dfn-panel" data-for="dfn-onprogress" id="infopanel-for-dfn-onprogress" role="dialog">
+   <span id="infopaneltitle-for-dfn-onprogress" style="display:none">Info about the 'onprogress' definition.</span><b><a href="#dfn-onprogress">#dfn-onprogress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onprogress">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onabort">
-   <b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onabort" class="dfn-panel" data-for="dfn-onabort" id="infopanel-for-dfn-onabort" role="dialog">
+   <span id="infopaneltitle-for-dfn-onabort" style="display:none">Info about the 'onabort' definition.</span><b><a href="#dfn-onabort">#dfn-onabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onabort">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onerror">
-   <b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onerror" class="dfn-panel" data-for="dfn-onerror" id="infopanel-for-dfn-onerror" role="dialog">
+   <span id="infopaneltitle-for-dfn-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dfn-onerror">#dfn-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onerror">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onload">
-   <b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onload" class="dfn-panel" data-for="dfn-onload" id="infopanel-for-dfn-onload" role="dialog">
+   <span id="infopaneltitle-for-dfn-onload" style="display:none">Info about the 'onload' definition.</span><b><a href="#dfn-onload">#dfn-onload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onload">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-onloadend">
-   <b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-onloadend" class="dfn-panel" data-for="dfn-onloadend" id="infopanel-for-dfn-onloadend" role="dialog">
+   <span id="infopaneltitle-for-dfn-onloadend" style="display:none">Info about the 'onloadend' definition.</span><b><a href="#dfn-onloadend">#dfn-onloadend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-onloadend">6.2. The FileReader API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="asynchronous-read-methods">
-   <b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-asynchronous-read-methods" class="dfn-panel" data-for="asynchronous-read-methods" id="infopanel-for-asynchronous-read-methods" role="dialog">
+   <span id="infopaneltitle-for-asynchronous-read-methods" style="display:none">Info about the 'asynchronous read methods' definition.</span><b><a href="#asynchronous-read-methods">#asynchronous-read-methods</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-read-methods">7. Errors and Exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-method">
-   <b><a href="#read-method">#read-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-method" class="dfn-panel" data-for="read-method" id="infopanel-for-read-method" role="dialog">
+   <span id="infopaneltitle-for-read-method" style="display:none">Info about the 'read methods' definition.</span><b><a href="#read-method">#read-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-method">2. Terminology and Algorithms</a>
     <li><a href="#ref-for-read-method①">6.2.2. FileReader States</a> <a href="#ref-for-read-method②">(2)</a> <a href="#ref-for-read-method③">(3)</a> <a href="#ref-for-read-method④">(4)</a>
@@ -4741,16 +4742,16 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-read-method⑥">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-read-method⑦">(2)</a> <a href="#ref-for-read-method⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsDataURL">
-   <b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsDataURL" class="dfn-panel" data-for="dfn-readAsDataURL" id="infopanel-for-dfn-readAsDataURL" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsDataURL" style="display:none">Info about the 'readAsDataURL(blob)' definition.</span><b><a href="#dfn-readAsDataURL">#dfn-readAsDataURL</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsDataURL">6.2. The FileReader API</a>
     <li><a href="#ref-for-dfn-readAsDataURL①">6.2.3. Reading a File or Blob</a>
     <li><a href="#ref-for-dfn-readAsDataURL②">6.2.3.1. The readAsDataURL() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsText">
-   <b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsText" class="dfn-panel" data-for="dfn-readAsText" id="infopanel-for-dfn-readAsText" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsText" style="display:none">Info about the 'readAsText(blob, encoding)' definition.</span><b><a href="#dfn-readAsText">#dfn-readAsText</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsText">3.3.3. The text() method</a>
     <li><a href="#ref-for-dfn-readAsText①">6.2. The FileReader API</a>
@@ -4758,8 +4759,8 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-readAsText③">6.2.3.2. The readAsText() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsArrayBuffer">
-   <b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsArrayBuffer" class="dfn-panel" data-for="dfn-readAsArrayBuffer" id="infopanel-for-dfn-readAsArrayBuffer" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsArrayBuffer" style="display:none">Info about the 'readAsArrayBuffer(blob)' definition.</span><b><a href="#dfn-readAsArrayBuffer">#dfn-readAsArrayBuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsArrayBuffer">6.2. The FileReader API</a>
     <li><a href="#ref-for-dfn-readAsArrayBuffer①">6.2.3. Reading a File or Blob</a>
@@ -4767,16 +4768,16 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-readAsArrayBuffer③">6.2.3.4. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsBinaryString">
-   <b><a href="#dfn-readAsBinaryString">#dfn-readAsBinaryString</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsBinaryString" class="dfn-panel" data-for="dfn-readAsBinaryString" id="infopanel-for-dfn-readAsBinaryString" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsBinaryString" style="display:none">Info about the 'readAsBinaryString(blob)' definition.</span><b><a href="#dfn-readAsBinaryString">#dfn-readAsBinaryString</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsBinaryString">6.2. The FileReader API</a>
     <li><a href="#ref-for-dfn-readAsBinaryString①">6.2.3. Reading a File or Blob</a>
     <li><a href="#ref-for-dfn-readAsBinaryString②">6.2.3.4. The readAsBinaryString() method</a> <a href="#ref-for-dfn-readAsBinaryString③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-abort">
-   <b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-abort" class="dfn-panel" data-for="dfn-abort" id="infopanel-for-dfn-abort" role="dialog">
+   <span id="infopaneltitle-for-dfn-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dfn-abort">#dfn-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-abort">2. Terminology and Algorithms</a>
     <li><a href="#ref-for-dfn-abort①">6.2. The FileReader API</a>
@@ -4786,8 +4787,8 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-abort⑤">6.4.2. Summary of Event Invariants</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blob-package-data">
-   <b><a href="#blob-package-data">#blob-package-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blob-package-data" class="dfn-panel" data-for="blob-package-data" id="infopanel-for-blob-package-data" role="dialog">
+   <span id="infopaneltitle-for-blob-package-data" style="display:none">Info about the 'package data' definition.</span><b><a href="#blob-package-data">#blob-package-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-package-data">3.2. Attributes</a>
     <li><a href="#ref-for-blob-package-data①">6.2. The FileReader API</a> <a href="#ref-for-blob-package-data②">(2)</a>
@@ -4797,39 +4798,39 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-blob-package-data⑥">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-progress-event">
-   <b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-progress-event" class="dfn-panel" data-for="fire-a-progress-event" id="infopanel-for-fire-a-progress-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-progress-event" style="display:none">Info about the 'fire a progress event' definition.</span><b><a href="#fire-a-progress-event">#fire-a-progress-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-progress-event">6.2. The FileReader API</a> <a href="#ref-for-fire-a-progress-event①">(2)</a> <a href="#ref-for-fire-a-progress-event②">(3)</a> <a href="#ref-for-fire-a-progress-event③">(4)</a> <a href="#ref-for-fire-a-progress-event④">(5)</a> <a href="#ref-for-fire-a-progress-event⑤">(6)</a> <a href="#ref-for-fire-a-progress-event⑥">(7)</a>
     <li><a href="#ref-for-fire-a-progress-event⑦">6.2.3.5. The abort() method</a> <a href="#ref-for-fire-a-progress-event⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-loadstart-event">
-   <b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-loadstart-event" class="dfn-panel" data-for="dfn-loadstart-event" id="infopanel-for-dfn-loadstart-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-loadstart-event" style="display:none">Info about the 'loadstart' definition.</span><b><a href="#dfn-loadstart-event">#dfn-loadstart-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-loadstart-event">6.2. The FileReader API</a> <a href="#ref-for-dfn-loadstart-event①">(2)</a>
     <li><a href="#ref-for-dfn-loadstart-event②">6.2.1. Event Handler Content Attributes</a>
     <li><a href="#ref-for-dfn-loadstart-event③">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-loadstart-event④">(2)</a> <a href="#ref-for-dfn-loadstart-event⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-progress-event">
-   <b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-progress-event" class="dfn-panel" data-for="dfn-progress-event" id="infopanel-for-dfn-progress-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-progress-event" style="display:none">Info about the 'progress' definition.</span><b><a href="#dfn-progress-event">#dfn-progress-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-progress-event">6.2. The FileReader API</a>
     <li><a href="#ref-for-dfn-progress-event①">6.2.1. Event Handler Content Attributes</a>
     <li><a href="#ref-for-dfn-progress-event②">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-progress-event③">(2)</a> <a href="#ref-for-dfn-progress-event④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-abort-event">
-   <b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-abort-event" class="dfn-panel" data-for="dfn-abort-event" id="infopanel-for-dfn-abort-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-abort-event" style="display:none">Info about the 'abort' definition.</span><b><a href="#dfn-abort-event">#dfn-abort-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-abort-event">6.2.1. Event Handler Content Attributes</a>
     <li><a href="#ref-for-dfn-abort-event①">6.2.3.5. The abort() method</a>
     <li><a href="#ref-for-dfn-abort-event②">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-abort-event③">(2)</a> <a href="#ref-for-dfn-abort-event④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-error-event">
-   <b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-error-event" class="dfn-panel" data-for="dfn-error-event" id="infopanel-for-dfn-error-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-error-event" style="display:none">Info about the 'error' definition.</span><b><a href="#dfn-error-event">#dfn-error-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-event">4.2. Attributes</a>
     <li><a href="#ref-for-dfn-error-event①">6.2. The FileReader API</a> <a href="#ref-for-dfn-error-event②">(2)</a> <a href="#ref-for-dfn-error-event③">(3)</a> <a href="#ref-for-dfn-error-event④">(4)</a>
@@ -4837,16 +4838,16 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-error-event⑥">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-error-event⑦">(2)</a> <a href="#ref-for-dfn-error-event⑧">(3)</a> <a href="#ref-for-dfn-error-event⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-load-event">
-   <b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-load-event" class="dfn-panel" data-for="dfn-load-event" id="infopanel-for-dfn-load-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-load-event" style="display:none">Info about the 'load' definition.</span><b><a href="#dfn-load-event">#dfn-load-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-load-event">6.2. The FileReader API</a> <a href="#ref-for-dfn-load-event①">(2)</a>
     <li><a href="#ref-for-dfn-load-event②">6.2.1. Event Handler Content Attributes</a>
     <li><a href="#ref-for-dfn-load-event③">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-load-event④">(2)</a> <a href="#ref-for-dfn-load-event⑤">(3)</a> <a href="#ref-for-dfn-load-event⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-loadend-event">
-   <b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-loadend-event" class="dfn-panel" data-for="dfn-loadend-event" id="infopanel-for-dfn-loadend-event" role="dialog">
+   <span id="infopaneltitle-for-dfn-loadend-event" style="display:none">Info about the 'loadend' definition.</span><b><a href="#dfn-loadend-event">#dfn-loadend-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-loadend-event">6.2. The FileReader API</a> <a href="#ref-for-dfn-loadend-event①">(2)</a> <a href="#ref-for-dfn-loadend-event②">(3)</a> <a href="#ref-for-dfn-loadend-event③">(4)</a>
     <li><a href="#ref-for-dfn-loadend-event④">6.2.1. Event Handler Content Attributes</a>
@@ -4854,15 +4855,15 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-loadend-event⑥">6.4.2. Summary of Event Invariants</a> <a href="#ref-for-dfn-loadend-event⑦">(2)</a> <a href="#ref-for-dfn-loadend-event⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-method-sync">
-   <b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-method-sync" class="dfn-panel" data-for="read-method-sync" id="infopanel-for-read-method-sync" role="dialog">
+   <span id="infopaneltitle-for-read-method-sync" style="display:none">Info about the 'synchronously read' definition.</span><b><a href="#read-method-sync">#read-method-sync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-method-sync">6.2.3. Reading a File or Blob</a>
     <li><a href="#ref-for-read-method-sync①">7. Errors and Exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-FileReaderSync">
-   <b><a href="#dfn-FileReaderSync">#dfn-FileReaderSync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-FileReaderSync" class="dfn-panel" data-for="dfn-FileReaderSync" id="infopanel-for-dfn-FileReaderSync" role="dialog">
+   <span id="infopaneltitle-for-dfn-FileReaderSync" style="display:none">Info about the 'FileReaderSync' definition.</span><b><a href="#dfn-FileReaderSync">#dfn-FileReaderSync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-FileReaderSync">3.2. Attributes</a>
     <li><a href="#ref-for-dfn-FileReaderSync①">4.2. Attributes</a>
@@ -4872,43 +4873,43 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-dfn-FileReaderSync⑥">6.5.1.1. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filereadersync-filereadersync">
-   <b><a href="#dom-filereadersync-filereadersync">#dom-filereadersync-filereadersync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filereadersync-filereadersync" class="dfn-panel" data-for="dom-filereadersync-filereadersync" id="infopanel-for-dom-filereadersync-filereadersync" role="dialog">
+   <span id="infopaneltitle-for-dom-filereadersync-filereadersync" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-filereadersync-filereadersync">#dom-filereadersync-filereadersync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filereadersync-filereadersync">6.5.1.1. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsTextSync">
-   <b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsTextSync" class="dfn-panel" data-for="dfn-readAsTextSync" id="infopanel-for-dfn-readAsTextSync" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsTextSync" style="display:none">Info about the 'readAsText(blob, encoding)' definition.</span><b><a href="#dfn-readAsTextSync">#dfn-readAsTextSync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsTextSync">6.5.1. The FileReaderSync API</a>
     <li><a href="#ref-for-dfn-readAsTextSync①">6.5.1.2. The readAsText()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsDataURLSync">
-   <b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsDataURLSync" class="dfn-panel" data-for="dfn-readAsDataURLSync" id="infopanel-for-dfn-readAsDataURLSync" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsDataURLSync" style="display:none">Info about the 'readAsDataURL(blob)' definition.</span><b><a href="#dfn-readAsDataURLSync">#dfn-readAsDataURLSync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsDataURLSync">6.5.1. The FileReaderSync API</a>
     <li><a href="#ref-for-dfn-readAsDataURLSync①">6.5.1.3. The readAsDataURL() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsArrayBufferSync">
-   <b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsArrayBufferSync" class="dfn-panel" data-for="dfn-readAsArrayBufferSync" id="infopanel-for-dfn-readAsArrayBufferSync" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsArrayBufferSync" style="display:none">Info about the 'readAsArrayBuffer(blob)' definition.</span><b><a href="#dfn-readAsArrayBufferSync">#dfn-readAsArrayBufferSync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsArrayBufferSync">6.5.1. The FileReaderSync API</a>
     <li><a href="#ref-for-dfn-readAsArrayBufferSync①">6.5.1.4. The readAsArrayBuffer() method</a>
     <li><a href="#ref-for-dfn-readAsArrayBufferSync②">6.5.1.5. The readAsBinaryString() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-readAsBinaryStringSync">
-   <b><a href="#dfn-readAsBinaryStringSync">#dfn-readAsBinaryStringSync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-readAsBinaryStringSync" class="dfn-panel" data-for="dfn-readAsBinaryStringSync" id="infopanel-for-dfn-readAsBinaryStringSync" role="dialog">
+   <span id="infopaneltitle-for-dfn-readAsBinaryStringSync" style="display:none">Info about the 'readAsBinaryString(blob)' definition.</span><b><a href="#dfn-readAsBinaryStringSync">#dfn-readAsBinaryStringSync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-readAsBinaryStringSync">6.5.1. The FileReaderSync API</a>
     <li><a href="#ref-for-dfn-readAsBinaryStringSync①">6.5.1.5. The readAsBinaryString() method</a> <a href="#ref-for-dfn-readAsBinaryStringSync②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-error-read">
-   <b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-error-read" class="dfn-panel" data-for="file-error-read" id="infopanel-for-file-error-read" role="dialog">
+   <span id="infopaneltitle-for-file-error-read" style="display:none">Info about the 'File read errors' definition.</span><b><a href="#file-error-read">#file-error-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-error-read">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-file-error-read①">4.2. Attributes</a>
@@ -4916,45 +4917,45 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-file-error-read③">6.4.1. Event Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="failureReason">
-   <b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-failureReason" class="dfn-panel" data-for="failureReason" id="infopanel-for-failureReason" role="dialog">
+   <span id="infopaneltitle-for-failureReason" style="display:none">Info about the 'failure reason' definition.</span><b><a href="#failureReason">#failureReason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-failureReason">3. The Blob Interface and Binary Data</a>
     <li><a href="#ref-for-failureReason①">7.1. Throwing an Exception or Returning an Error</a> <a href="#ref-for-failureReason②">(2)</a> <a href="#ref-for-failureReason③">(3)</a> <a href="#ref-for-failureReason④">(4)</a> <a href="#ref-for-failureReason⑤">(5)</a> <a href="#ref-for-failureReason⑥">(6)</a> <a href="#ref-for-failureReason⑦">(7)</a> <a href="#ref-for-failureReason⑧">(8)</a> <a href="#ref-for-failureReason⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="NotFoundFR">
-   <b><a href="#NotFoundFR">#NotFoundFR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-NotFoundFR" class="dfn-panel" data-for="NotFoundFR" id="infopanel-for-NotFoundFR" role="dialog">
+   <span id="infopaneltitle-for-NotFoundFR" style="display:none">Info about the 'NotFound' definition.</span><b><a href="#NotFoundFR">#NotFoundFR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NotFoundFR">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="UnsafeFileFR">
-   <b><a href="#UnsafeFileFR">#UnsafeFileFR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-UnsafeFileFR" class="dfn-panel" data-for="UnsafeFileFR" id="infopanel-for-UnsafeFileFR" role="dialog">
+   <span id="infopaneltitle-for-UnsafeFileFR" style="display:none">Info about the 'UnsafeFile' definition.</span><b><a href="#UnsafeFileFR">#UnsafeFileFR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-UnsafeFileFR">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="TooManyReadsFR">
-   <b><a href="#TooManyReadsFR">#TooManyReadsFR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-TooManyReadsFR" class="dfn-panel" data-for="TooManyReadsFR" id="infopanel-for-TooManyReadsFR" role="dialog">
+   <span id="infopaneltitle-for-TooManyReadsFR" style="display:none">Info about the 'TooManyReads' definition.</span><b><a href="#TooManyReadsFR">#TooManyReadsFR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TooManyReadsFR">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="SnapshotStateFR">
-   <b><a href="#SnapshotStateFR">#SnapshotStateFR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-SnapshotStateFR" class="dfn-panel" data-for="SnapshotStateFR" id="infopanel-for-SnapshotStateFR" role="dialog">
+   <span id="infopaneltitle-for-SnapshotStateFR" style="display:none">Info about the 'SnapshotState' definition.</span><b><a href="#SnapshotStateFR">#SnapshotStateFR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SnapshotStateFR">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="FileLockFR">
-   <b><a href="#FileLockFR">#FileLockFR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-FileLockFR" class="dfn-panel" data-for="FileLockFR" id="infopanel-for-FileLockFR" role="dialog">
+   <span id="infopaneltitle-for-FileLockFR" style="display:none">Info about the 'FileLock' definition.</span><b><a href="#FileLockFR">#FileLockFR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FileLockFR">7.1. Throwing an Exception or Returning an Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="BlobURLStore">
-   <b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-BlobURLStore" class="dfn-panel" data-for="BlobURLStore" id="infopanel-for-BlobURLStore" role="dialog">
+   <span id="infopaneltitle-for-BlobURLStore" style="display:none">Info about the 'blob URL store' definition.</span><b><a href="#BlobURLStore">#BlobURLStore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BlobURLStore">8.2. Model</a> <a href="#ref-for-BlobURLStore①">(2)</a> <a href="#ref-for-BlobURLStore②">(3)</a> <a href="#ref-for-BlobURLStore③">(4)</a>
     <li><a href="#ref-for-BlobURLStore④">8.3. Dereferencing Model for blob URLs</a>
@@ -4963,20 +4964,20 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-BlobURLStore⑦">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blob-url-entry">
-   <b><a href="#blob-url-entry">#blob-url-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blob-url-entry" class="dfn-panel" data-for="blob-url-entry" id="infopanel-for-blob-url-entry" role="dialog">
+   <span id="infopaneltitle-for-blob-url-entry" style="display:none">Info about the 'blob URL entry' definition.</span><b><a href="#blob-url-entry">#blob-url-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry">8.2. Model</a> <a href="#ref-for-blob-url-entry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blob-url-entry-environment">
-   <b><a href="#blob-url-entry-environment">#blob-url-entry-environment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blob-url-entry-environment" class="dfn-panel" data-for="blob-url-entry-environment" id="infopanel-for-blob-url-entry-environment" role="dialog">
+   <span id="infopaneltitle-for-blob-url-entry-environment" style="display:none">Info about the 'environment' definition.</span><b><a href="#blob-url-entry-environment">#blob-url-entry-environment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry-environment">8.3.2. Lifetime of blob URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blob-url">
-   <b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blob-url" class="dfn-panel" data-for="blob-url" id="infopanel-for-blob-url" role="dialog">
+   <span id="infopaneltitle-for-blob-url" style="display:none">Info about the 'blob URLs' definition.</span><b><a href="#blob-url">#blob-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url">3.2. Attributes</a>
     <li><a href="#ref-for-blob-url①">8.1. Introduction</a> <a href="#ref-for-blob-url②">(2)</a>
@@ -4986,41 +4987,44 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
     <li><a href="#ref-for-blob-url①④">9. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unicodeBlobURL">
-   <b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unicodeBlobURL" class="dfn-panel" data-for="unicodeBlobURL" id="infopanel-for-unicodeBlobURL" role="dialog">
+   <span id="infopaneltitle-for-unicodeBlobURL" style="display:none">Info about the '
+generate a new blob URL' definition.</span><b><a href="#unicodeBlobURL">#unicodeBlobURL</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicodeBlobURL">8.2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-an-entry">
-   <b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-an-entry" class="dfn-panel" data-for="add-an-entry" id="infopanel-for-add-an-entry" role="dialog">
+   <span id="infopaneltitle-for-add-an-entry" style="display:none">Info about the '
+add an entry to the blob URL store' definition.</span><b><a href="#add-an-entry">#add-an-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-an-entry">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="removeTheEntry">
-   <b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-removeTheEntry" class="dfn-panel" data-for="removeTheEntry" id="infopanel-for-removeTheEntry" role="dialog">
+   <span id="infopaneltitle-for-removeTheEntry" style="display:none">Info about the '
+remove an entry from the blob URL store' definition.</span><b><a href="#removeTheEntry">#removeTheEntry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-removeTheEntry">8.4. Creating and Revoking a blob URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lifeTime">
-   <b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lifeTime" class="dfn-panel" data-for="lifeTime" id="infopanel-for-lifeTime" role="dialog">
+   <span id="infopaneltitle-for-lifeTime" style="display:none">Info about the '8.3.2. Lifetime of blob URLs' definition.</span><b><a href="#lifeTime">#lifeTime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lifeTime">8.3.2. Lifetime of blob URLs</a>
     <li><a href="#ref-for-lifeTime">8.4.1. Examples of blob URL Creation and Revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-createObjectURL">
-   <b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-createObjectURL" class="dfn-panel" data-for="dfn-createObjectURL" id="infopanel-for-dfn-createObjectURL" role="dialog">
+   <span id="infopaneltitle-for-dfn-createObjectURL" style="display:none">Info about the 'createObjectURL(obj)' definition.</span><b><a href="#dfn-createObjectURL">#dfn-createObjectURL</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-createObjectURL">8.1. Introduction</a>
     <li><a href="#ref-for-dfn-createObjectURL①">8.4. Creating and Revoking a blob URL</a>
     <li><a href="#ref-for-dfn-createObjectURL②">8.4.1. Examples of blob URL Creation and Revocation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-revokeObjectURL">
-   <b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-revokeObjectURL" class="dfn-panel" data-for="dfn-revokeObjectURL" id="infopanel-for-dfn-revokeObjectURL" role="dialog">
+   <span id="infopaneltitle-for-dfn-revokeObjectURL" style="display:none">Info about the 'revokeObjectURL(url)' definition.</span><b><a href="#dfn-revokeObjectURL">#dfn-revokeObjectURL</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-revokeObjectURL">8.1. Introduction</a>
     <li><a href="#ref-for-dfn-revokeObjectURL①">8.4. Creating and Revoking a blob URL</a> <a href="#ref-for-dfn-revokeObjectURL②">(2)</a>
@@ -5029,59 +5033,115 @@ what possible errors can happen, perhaps something about chunk sizes, etc. <a cl
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/IndexedDB/index.html
+++ b/tests/github/w3c/IndexedDB/index.html
@@ -8323,30 +8323,30 @@ specification.</p>
    <li><a href="#dom-idbtransactionmode-versionchange">"versionchange"</a><span>, in § 4.9</span>
    <li><a href="#eventdef-connection-versionchange">versionchange</a><span>, in § 2.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.2. Event interfaces</a>
     <li><a href="#ref-for-event①">5.9. Firing a success event</a>
     <li><a href="#ref-for-event②">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.2. Event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.1. The IDBRequest interface</a>
     <li><a href="#ref-for-eventtarget①">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-eventtarget②">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">4.2. Event interfaces</a>
     <li><a href="#ref-for-dom-event-bubbles①">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-event-bubbles②">(2)</a>
@@ -8355,8 +8355,8 @@ specification.</p>
     <li><a href="#ref-for-dom-event-bubbles⑥">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">4.2. Event interfaces</a>
     <li><a href="#ref-for-dom-event-cancelable①">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-event-cancelable②">(2)</a>
@@ -8365,22 +8365,22 @@ specification.</p>
     <li><a href="#ref-for-dom-event-cancelable⑤">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">5.10. Firing an error event</a> <a href="#ref-for-canceled-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">4.2. Event interfaces</a>
     <li><a href="#ref-for-concept-event-create①">5.9. Firing a success event</a>
     <li><a href="#ref-for-concept-event-create②">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-concept-event-dispatch①">4.2. Event interfaces</a>
@@ -8388,14 +8388,14 @@ specification.</p>
     <li><a href="#ref-for-concept-event-dispatch③">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">2.7.1. Transaction lifecycle</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">4.3. The IDBFactory interface</a> <a href="#ref-for-concept-event-fire①">(2)</a> <a href="#ref-for-concept-event-fire②">(3)</a>
     <li><a href="#ref-for-concept-event-fire③">5.2. Closing a database</a>
@@ -8403,8 +8403,8 @@ specification.</p>
     <li><a href="#ref-for-concept-event-fire⑤">5.5. Aborting a transaction</a> <a href="#ref-for-concept-event-fire⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-the-parent">
-   <a href="https://dom.spec.whatwg.org/#get-the-parent">https://dom.spec.whatwg.org/#get-the-parent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-the-parent" class="dfn-panel" data-for="term-for-get-the-parent" id="infopanel-for-term-for-get-the-parent" role="menu">
+   <span id="infopaneltitle-for-term-for-get-the-parent" style="display:none">Info about the 'get the parent' external reference.</span><a href="https://dom.spec.whatwg.org/#get-the-parent">https://dom.spec.whatwg.org/#get-the-parent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-parent">2.1.1. Database connection</a>
     <li><a href="#ref-for-get-the-parent①">2.7. Transactions</a>
@@ -8412,22 +8412,22 @@ specification.</p>
     <li><a href="#ref-for-get-the-parent③">2.8.1. Open requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
-   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-preventdefault" class="dfn-panel" data-for="term-for-dom-event-preventdefault" id="infopanel-for-term-for-dom-event-preventdefault" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-preventdefault" style="display:none">Info about the 'preventDefault()' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">4.2. Event interfaces</a>
     <li><a href="#ref-for-dom-event-type①">5.9. Firing a success event</a>
     <li><a href="#ref-for-dom-event-type②">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the '!' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">5.11. Clone a value</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a>
     <li><a href="#ref-for-sec-algorithm-conventions②">6. Database operations</a>
@@ -8440,8 +8440,8 @@ specification.</p>
     <li><a href="#ref-for-sec-algorithm-conventions①⑧">7.4. Convert a value to a key</a> <a href="#ref-for-sec-algorithm-conventions①⑨">(2)</a> <a href="#ref-for-sec-algorithm-conventions②⓪">(3)</a> <a href="#ref-for-sec-algorithm-conventions②①">(4)</a> <a href="#ref-for-sec-algorithm-conventions②②">(5)</a> <a href="#ref-for-sec-algorithm-conventions②③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions①" style="display:none">Info about the '?' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">5.11. Clone a value</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a>
     <li><a href="#ref-for-sec-algorithm-conventions②">6. Database operations</a>
@@ -8454,16 +8454,16 @@ specification.</p>
     <li><a href="#ref-for-sec-algorithm-conventions①⑧">7.4. Convert a value to a key</a> <a href="#ref-for-sec-algorithm-conventions①⑨">(2)</a> <a href="#ref-for-sec-algorithm-conventions②⓪">(3)</a> <a href="#ref-for-sec-algorithm-conventions②①">(4)</a> <a href="#ref-for-sec-algorithm-conventions②②">(5)</a> <a href="#ref-for-sec-algorithm-conventions②③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'abrupt completion' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-completion-record-specification-type">https://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">7.1. Extract a key from a value</a> <a href="#ref-for-sec-completion-record-specification-type①">(2)</a>
     <li><a href="#ref-for-sec-completion-record-specification-type②">7.3. Convert a key to a value</a> <a href="#ref-for-sec-completion-record-specification-type③">(2)</a> <a href="#ref-for-sec-completion-record-specification-type④">(3)</a>
     <li><a href="#ref-for-sec-completion-record-specification-type⑤">7.4. Convert a value to a key</a> <a href="#ref-for-sec-completion-record-specification-type⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array-objects" class="dfn-panel" data-for="term-for-sec-array-objects" id="infopanel-for-term-for-sec-array-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array-objects" style="display:none">Info about the 'array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array-objects">https://tc39.github.io/ecma262/#sec-array-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array-objects">2. Constructs</a>
     <li><a href="#ref-for-sec-array-objects①">2.3. Values</a>
@@ -8477,43 +8477,43 @@ specification.</p>
     <li><a href="#ref-for-sec-array-objects①⑧">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-array-exotic-objects">
-   <a href="https://tc39.github.io/ecma262/#array-exotic-objects">https://tc39.github.io/ecma262/#array-exotic-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-array-exotic-objects" class="dfn-panel" data-for="term-for-array-exotic-objects" id="infopanel-for-term-for-array-exotic-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-array-exotic-objects" style="display:none">Info about the 'array exotic object' external reference.</span><a href="https://tc39.github.io/ecma262/#array-exotic-objects">https://tc39.github.io/ecma262/#array-exotic-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-array-exotic-objects">7.4. Convert a value to a key</a> <a href="#ref-for-array-exotic-objects①">(2)</a>
     <li><a href="#ref-for-array-exotic-objects②">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.sort">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.sort">https://tc39.github.io/ecma262/#sec-array.prototype.sort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.sort" class="dfn-panel" data-for="term-for-sec-array.prototype.sort" id="infopanel-for-term-for-sec-array.prototype.sort" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.sort" style="display:none">Info about the 'array.prototype.sort' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.sort">https://tc39.github.io/ecma262/#sec-array.prototype.sort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.sort">2. Constructs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">https://tc39.github.io/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-objects" class="dfn-panel" data-for="term-for-sec-arraybuffer-objects" id="infopanel-for-term-for-sec-arraybuffer-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-objects" style="display:none">Info about the 'arraybuffer' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-objects">https://tc39.github.io/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-objects">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdataproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdataproperty" class="dfn-panel" data-for="term-for-sec-createdataproperty" id="infopanel-for-term-for-sec-createdataproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdataproperty" style="display:none">Info about the 'createdataproperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createdataproperty">https://tc39.github.io/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdataproperty">7.1. Extract a key from a value</a>
     <li><a href="#ref-for-sec-createdataproperty①">7.2. Inject a key into a value</a> <a href="#ref-for-sec-createdataproperty②">(2)</a>
     <li><a href="#ref-for-sec-createdataproperty③">7.3. Convert a key to a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">4.5. The IDBObjectStore interface</a> <a href="#ref-for-current-realm①">(2)</a> <a href="#ref-for-current-realm②">(3)</a> <a href="#ref-for-current-realm③">(4)</a>
     <li><a href="#ref-for-current-realm④">4.6. The IDBIndex interface</a> <a href="#ref-for-current-realm⑤">(2)</a> <a href="#ref-for-current-realm⑥">(3)</a> <a href="#ref-for-current-realm⑦">(4)</a>
     <li><a href="#ref-for-current-realm⑧">4.8. The IDBCursor interface</a> <a href="#ref-for-current-realm⑨">(2)</a> <a href="#ref-for-current-realm①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-date-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-date-objects" class="dfn-panel" data-for="term-for-sec-date-objects" id="infopanel-for-term-for-sec-date-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-date-objects" style="display:none">Info about the 'date' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-date-objects">2.3. Values</a>
     <li><a href="#ref-for-sec-date-objects①">2.4. Keys</a>
@@ -8521,69 +8521,69 @@ specification.</p>
     <li><a href="#ref-for-sec-date-objects④">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">7.1. Extract a key from a value</a> <a href="#ref-for-sec-get-o-p①">(2)</a>
     <li><a href="#ref-for-sec-get-o-p②">7.2. Inject a key into a value</a> <a href="#ref-for-sec-get-o-p③">(2)</a>
     <li><a href="#ref-for-sec-get-o-p④">7.4. Convert a value to a key</a> <a href="#ref-for-sec-get-o-p⑤">(2)</a> <a href="#ref-for-sec-get-o-p⑥">(3)</a> <a href="#ref-for-sec-get-o-p⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-hasownproperty">
-   <a href="https://tc39.github.io/ecma262/#sec-hasownproperty">https://tc39.github.io/ecma262/#sec-hasownproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-hasownproperty" class="dfn-panel" data-for="term-for-sec-hasownproperty" id="infopanel-for-term-for-sec-hasownproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-hasownproperty" style="display:none">Info about the 'hasownproperty' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-hasownproperty">https://tc39.github.io/ecma262/#sec-hasownproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-hasownproperty">7.1. Extract a key from a value</a>
     <li><a href="#ref-for-sec-hasownproperty①">7.2. Inject a key into a value</a> <a href="#ref-for-sec-hasownproperty②">(2)</a>
     <li><a href="#ref-for-sec-hasownproperty③">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prod-IdentifierName">
-   <a href="https://tc39.github.io/ecma262/#prod-IdentifierName">https://tc39.github.io/ecma262/#prod-IdentifierName</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prod-IdentifierName" class="dfn-panel" data-for="term-for-prod-IdentifierName" id="infopanel-for-term-for-prod-IdentifierName" role="menu">
+   <span id="infopaneltitle-for-term-for-prod-IdentifierName" style="display:none">Info about the 'identifiername' external reference.</span><a href="https://tc39.github.io/ecma262/#prod-IdentifierName">https://tc39.github.io/ecma262/#prod-IdentifierName</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prod-IdentifierName">2.5. Key path</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-terms-and-definitions-number-type">
-   <a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-terms-and-definitions-number-type" class="dfn-panel" data-for="term-for-sec-terms-and-definitions-number-type" id="infopanel-for-term-for-sec-terms-and-definitions-number-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-terms-and-definitions-number-type" style="display:none">Info about the 'number' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type">https://tc39.github.io/ecma262/#sec-terms-and-definitions-number-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-terms-and-definitions-number-type">2.4. Keys</a>
     <li><a href="#ref-for-sec-terms-and-definitions-number-type①">2.11. Key generators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-object-objects">https://tc39.github.io/ecma262/#sec-object-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-objects" class="dfn-panel" data-for="term-for-sec-object-objects" id="infopanel-for-term-for-sec-object-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-objects" style="display:none">Info about the 'object' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-objects">https://tc39.github.io/ecma262/#sec-object-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-objects">2.3. Values</a>
     <li><a href="#ref-for-sec-object-objects①">7.2. Inject a key into a value</a> <a href="#ref-for-sec-object-objects②">(2)</a> <a href="#ref-for-sec-object-objects③">(3)</a> <a href="#ref-for-sec-object-objects④">(4)</a> <a href="#ref-for-sec-object-objects⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-realm①">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">https://tc39.github.io/ecma262/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type" style="display:none">Info about the 'record' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">https://tc39.github.io/ecma262/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">2.3. Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-regexp-regular-expression-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects">https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-regexp-regular-expression-objects" class="dfn-panel" data-for="term-for-sec-regexp-regular-expression-objects" id="infopanel-for-term-for-sec-regexp-regular-expression-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-regexp-regular-expression-objects" style="display:none">Info about the 'regexp' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects">https://tc39.github.io/ecma262/#sec-regexp-regular-expression-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-regexp-regular-expression-objects">9.4. Persistence risks</a> <a href="#ref-for-sec-regexp-regular-expression-objects①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-returnifabrupt">
-   <a href="https://tc39.github.io/ecma262/#sec-returnifabrupt">https://tc39.github.io/ecma262/#sec-returnifabrupt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-returnifabrupt" class="dfn-panel" data-for="term-for-sec-returnifabrupt" id="infopanel-for-term-for-sec-returnifabrupt" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-returnifabrupt" style="display:none">Info about the 'returnifabrupt' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-returnifabrupt">https://tc39.github.io/ecma262/#sec-returnifabrupt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-returnifabrupt">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-terms-and-definitions-string-type">
-   <a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-terms-and-definitions-string-type" class="dfn-panel" data-for="term-for-sec-terms-and-definitions-string-type" id="infopanel-for-term-for-sec-terms-and-definitions-string-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-terms-and-definitions-string-type" style="display:none">Info about the 'string' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type">https://tc39.github.io/ecma262/#sec-terms-and-definitions-string-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-terms-and-definitions-string-type">2. Constructs</a> <a href="#ref-for-sec-terms-and-definitions-string-type①">(2)</a>
     <li><a href="#ref-for-sec-terms-and-definitions-string-type②">2.3. Values</a>
@@ -8591,42 +8591,42 @@ specification.</p>
     <li><a href="#ref-for-sec-terms-and-definitions-string-type④">2.5. Key path</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tolength">
-   <a href="https://tc39.github.io/ecma262/#sec-tolength">https://tc39.github.io/ecma262/#sec-tolength</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tolength" class="dfn-panel" data-for="term-for-sec-tolength" id="infopanel-for-term-for-sec-tolength" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tolength" style="display:none">Info about the 'tolength' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tolength">https://tc39.github.io/ecma262/#sec-tolength</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tolength">7.1. Extract a key from a value</a>
     <li><a href="#ref-for-sec-tolength①">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'tostring' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">7.1. Extract a key from a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">7.1. Extract a key from a value</a> <a href="#ref-for-sec-ecmascript-data-types-and-values①">(2)</a>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values②">7.4. Convert a value to a key</a> <a href="#ref-for-sec-ecmascript-data-types-and-values③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'typeerror' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-typedarray-objects">https://tc39.github.io/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-objects" class="dfn-panel" data-for="term-for-sec-typedarray-objects" id="infopanel-for-term-for-sec-typedarray-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-objects" style="display:none">Info about the 'uint8array' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-typedarray-objects">https://tc39.github.io/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-objects">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">2.3. Values</a>
     <li><a href="#ref-for-dfn-Blob①">2.5. Key path</a>
@@ -8634,8 +8634,8 @@ specification.</p>
     <li><a href="#ref-for-dfn-Blob④">10. Accessibility considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">2.3. Values</a>
     <li><a href="#ref-for-dfn-file①">2.5. Key path</a>
@@ -8644,65 +8644,65 @@ specification.</p>
     <li><a href="#ref-for-dfn-file⑤">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-lastModified">
-   <a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-lastModified" class="dfn-panel" data-for="term-for-dfn-lastModified" id="infopanel-for-term-for-dfn-lastModified" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-lastModified" style="display:none">Info about the 'lastModified' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lastModified">2.5. Key path</a>
     <li><a href="#ref-for-dfn-lastModified①">7.1. Extract a key from a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">2.5. Key path</a>
     <li><a href="#ref-for-dfn-name①">7.1. Extract a key from a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-size">
-   <a href="https://w3c.github.io/FileAPI/#dfn-size">https://w3c.github.io/FileAPI/#dfn-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-size" class="dfn-panel" data-for="term-for-dfn-size" id="infopanel-for-term-for-dfn-size" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-size" style="display:none">Info about the 'size' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-size">https://w3c.github.io/FileAPI/#dfn-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-size">2.5. Key path</a>
     <li><a href="#ref-for-dfn-size①">7.1. Extract a key from a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">2.5. Key path</a>
     <li><a href="#ref-for-dfn-type①">7.1. Extract a key from a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domstringlist">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#domstringlist">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#domstringlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domstringlist" class="dfn-panel" data-for="term-for-domstringlist" id="infopanel-for-term-for-domstringlist" role="menu">
+   <span id="infopaneltitle-for-term-for-domstringlist" style="display:none">Info about the 'DOMStringList' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#domstringlist">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#domstringlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domstringlist">4.4. The IDBDatabase interface</a> <a href="#ref-for-domstringlist①">(2)</a>
     <li><a href="#ref-for-domstringlist②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-domstringlist③">(2)</a>
     <li><a href="#ref-for-domstringlist④">4.9. The IDBTransaction interface</a> <a href="#ref-for-domstringlist⑤">(2)</a> <a href="#ref-for-domstringlist⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#document">https://html.spec.whatwg.org/multipage/dom.html#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#document">https://html.spec.whatwg.org/multipage/dom.html#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1.1. Database connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.1. The IDBRequest interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
     <li><a href="#ref-for-eventhandler④">4.4. The IDBDatabase interface</a> <a href="#ref-for-eventhandler⑤">(2)</a> <a href="#ref-for-eventhandler⑥">(3)</a> <a href="#ref-for-eventhandler⑦">(4)</a>
     <li><a href="#ref-for-eventhandler⑧">4.9. The IDBTransaction interface</a> <a href="#ref-for-eventhandler⑨">(2)</a> <a href="#ref-for-eventhandler①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagedata">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#imagedata">https://html.spec.whatwg.org/multipage/canvas.html#imagedata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagedata" class="dfn-panel" data-for="term-for-imagedata" id="infopanel-for-term-for-imagedata" role="menu">
+   <span id="infopaneltitle-for-term-for-imagedata" style="display:none">Info about the 'ImageData' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#imagedata">https://html.spec.whatwg.org/multipage/canvas.html#imagedata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagedata">2.3. Values</a>
     <li><a href="#ref-for-imagedata①">10. Accessibility considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">5.11. Clone a value</a>
     <li><a href="#ref-for-structureddeserialize①">6. Database operations</a>
@@ -8713,8 +8713,8 @@ specification.</p>
     <li><a href="#ref-for-structureddeserialize⑧">7.2. Inject a key into a value</a> <a href="#ref-for-structureddeserialize⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializeforstorage">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializeforstorage" class="dfn-panel" data-for="term-for-structuredserializeforstorage" id="infopanel-for-term-for-structuredserializeforstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializeforstorage" style="display:none">Info about the 'StructuredSerializeForStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializeforstorage">2.3. Values</a>
     <li><a href="#ref-for-structuredserializeforstorage①">2.5. Key path</a>
@@ -8724,50 +8724,50 @@ specification.</p>
     <li><a href="#ref-for-structuredserializeforstorage⑤">9.4. Persistence risks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-windoworworkerglobalscope①">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.8.1. Open requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-close">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-close">https://html.spec.whatwg.org/multipage/indices.html#event-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-close" class="dfn-panel" data-for="term-for-event-close" id="infopanel-for-term-for-event-close" role="menu">
+   <span id="infopaneltitle-for-term-for-event-close" style="display:none">Info about the 'close' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-close">https://html.spec.whatwg.org/multipage/indices.html#event-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-close">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-event-close①">5.2. Closing a database</a> <a href="#ref-for-event-close②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-domain" class="dfn-panel" data-for="term-for-dom-document-domain" id="infopanel-for-term-for-dom-document-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-domain">2.1.1. Database connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.1. The IDBRequest interface</a> <a href="#ref-for-event-handler-event-type①">(2)</a> <a href="#ref-for-event-handler-event-type②">(3)</a> <a href="#ref-for-event-handler-event-type③">(4)</a>
     <li><a href="#ref-for-event-handler-event-type④">4.4. The IDBDatabase interface</a> <a href="#ref-for-event-handler-event-type⑤">(2)</a> <a href="#ref-for-event-handler-event-type⑥">(3)</a> <a href="#ref-for-event-handler-event-type⑦">(4)</a>
     <li><a href="#ref-for-event-handler-event-type⑧">4.9. The IDBTransaction interface</a> <a href="#ref-for-event-handler-event-type⑨">(2)</a> <a href="#ref-for-event-handler-event-type①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">4.1. The IDBRequest interface</a> <a href="#ref-for-event-handler-idl-attributes①">(2)</a> <a href="#ref-for-event-handler-idl-attributes②">(3)</a> <a href="#ref-for-event-handler-idl-attributes③">(4)</a> <a href="#ref-for-event-handler-idl-attributes④">(5)</a>
     <li><a href="#ref-for-event-handler-idl-attributes⑤">4.4. The IDBDatabase interface</a> <a href="#ref-for-event-handler-idl-attributes⑥">(2)</a> <a href="#ref-for-event-handler-idl-attributes⑦">(3)</a> <a href="#ref-for-event-handler-idl-attributes⑧">(4)</a>
     <li><a href="#ref-for-event-handler-idl-attributes⑨">4.9. The IDBTransaction interface</a> <a href="#ref-for-event-handler-idl-attributes①⓪">(2)</a> <a href="#ref-for-event-handler-idl-attributes①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">2.7. Transactions</a>
     <li><a href="#ref-for-event-loop①">2.7.1. Transaction lifecycle</a> <a href="#ref-for-event-loop②">(2)</a>
@@ -8775,22 +8775,22 @@ specification.</p>
     <li><a href="#ref-for-event-loop⑤">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.3. The IDBFactory interface</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a>
     <li><a href="#ref-for-in-parallel③">5.4. Committing a transaction</a>
     <li><a href="#ref-for-in-parallel④">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">4.3. The IDBFactory interface</a> <a href="#ref-for-concept-origin-opaque①">(2)</a> <a href="#ref-for-concept-origin-opaque②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.1. Database</a> <a href="#ref-for-concept-origin①">(2)</a>
     <li><a href="#ref-for-concept-origin②">2.1.1. Database connection</a>
@@ -8798,14 +8798,14 @@ specification.</p>
     <li><a href="#ref-for-concept-origin④">8.1. User tracking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.3. The IDBFactory interface</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a> <a href="#ref-for-concept-settings-object-origin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-queue-a-task①">4.3. The IDBFactory interface</a> <a href="#ref-for-queue-a-task②">(2)</a>
@@ -8818,33 +8818,33 @@ specification.</p>
     <li><a href="#ref-for-queue-a-task①②">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.3. The IDBFactory interface</a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queues' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">2.8.1. Open requests</a> <a href="#ref-for-task-queue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-list-append①">7.4. Convert a value to a key</a> <a href="#ref-for-list-append②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">2.4. Keys</a>
     <li><a href="#ref-for-assert①">5.6. Asynchronously executing a request</a>
@@ -8855,38 +8855,38 @@ specification.</p>
     <li><a href="#ref-for-assert①③">7.3. Convert a key to a value</a> <a href="#ref-for-assert①④">(2)</a> <a href="#ref-for-assert①⑤">(3)</a> <a href="#ref-for-assert①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte">
-   <a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte" class="dfn-panel" data-for="term-for-byte" id="infopanel-for-term-for-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-less-than">
-   <a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-less-than" class="dfn-panel" data-for="term-for-byte-less-than" id="infopanel-for-term-for-byte-less-than" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-less-than" style="display:none">Info about the 'byte less than' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-less-than">2.4. Keys</a> <a href="#ref-for-byte-less-than①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit-less-than">
-   <a href="https://infra.spec.whatwg.org/#code-unit-less-than">https://infra.spec.whatwg.org/#code-unit-less-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit-less-than" class="dfn-panel" data-for="term-for-code-unit-less-than" id="infopanel-for-term-for-code-unit-less-than" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit-less-than" style="display:none">Info about the 'code unit less than' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit-less-than">https://infra.spec.whatwg.org/#code-unit-less-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit-less-than">2.4. Keys</a> <a href="#ref-for-code-unit-less-than①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-list-iterate①">5.1. Opening a database</a>
@@ -8898,22 +8898,22 @@ specification.</p>
     <li><a href="#ref-for-list-iterate①⓪">7.2. Inject a key into a value</a> <a href="#ref-for-list-iterate①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.4. Keys</a>
     <li><a href="#ref-for-list-item①">7.2. Inject a key into a value</a> <a href="#ref-for-list-item②">(2)</a>
     <li><a href="#ref-for-list-item③">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">7.3. Convert a key to a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.4. Keys</a>
     <li><a href="#ref-for-list①">4.3. The IDBFactory interface</a>
@@ -8923,8 +8923,8 @@ specification.</p>
     <li><a href="#ref-for-list⑧">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.7. Transactions</a>
     <li><a href="#ref-for-ordered-set①">4.3. The IDBFactory interface</a>
@@ -8933,35 +8933,35 @@ specification.</p>
     <li><a href="#ref-for-ordered-set④">7.4. Convert a value to a key</a> <a href="#ref-for-ordered-set⑤">(2)</a> <a href="#ref-for-ordered-set⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">2.4. Keys</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a> <a href="#ref-for-list-size③">(4)</a> <a href="#ref-for-list-size④">(5)</a> <a href="#ref-for-list-size⑤">(6)</a>
     <li><a href="#ref-for-list-size⑥">7.3. Convert a key to a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split a string' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">7.1. Extract a key from a value</a>
     <li><a href="#ref-for-strictly-split①">7.2. Inject a key into a value</a> <a href="#ref-for-strictly-split②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-orientationlocktype-any">
-   <a href="https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any">https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-orientationlocktype-any" class="dfn-panel" data-for="term-for-dom-orientationlocktype-any" id="infopanel-for-term-for-dom-orientationlocktype-any" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-orientationlocktype-any" style="display:none">Info about the 'any' external reference.</span><a href="https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any">https://w3c.github.io/screen-orientation/#dom-orientationlocktype-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-orientationlocktype-any">6.2. Object store retrieval operations</a> <a href="#ref-for-dom-orientationlocktype-any①">(2)</a>
     <li><a href="#ref-for-dom-orientationlocktype-any②">6.3. Index retrieval operations</a> <a href="#ref-for-dom-orientationlocktype-any③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-bucket">
-   <a href="https://storage.spec.whatwg.org/#storage-bucket">https://storage.spec.whatwg.org/#storage-bucket</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-bucket" class="dfn-panel" data-for="term-for-storage-bucket" id="infopanel-for-term-for-storage-bucket" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-bucket" style="display:none">Info about the 'storage bucket' external reference.</span><a href="https://storage.spec.whatwg.org/#storage-bucket">https://storage.spec.whatwg.org/#storage-bucket</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bucket">2.7. Transactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">3. Exceptions</a>
     <li><a href="#ref-for-aborterror①">4.9. The IDBTransaction interface</a> <a href="#ref-for-aborterror②">(2)</a>
@@ -8973,8 +8973,8 @@ specification.</p>
     <li><a href="#ref-for-aborterror⑨">5.10. Firing an error event</a> <a href="#ref-for-aborterror①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constrainterror">
-   <a href="https://webidl.spec.whatwg.org/#constrainterror">https://webidl.spec.whatwg.org/#constrainterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constrainterror" class="dfn-panel" data-for="term-for-constrainterror" id="infopanel-for-term-for-constrainterror" role="menu">
+   <span id="infopaneltitle-for-term-for-constrainterror" style="display:none">Info about the 'ConstraintError' external reference.</span><a href="https://webidl.spec.whatwg.org/#constrainterror">https://webidl.spec.whatwg.org/#constrainterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constrainterror">2.11. Key generators</a>
     <li><a href="#ref-for-constrainterror①">3. Exceptions</a>
@@ -8985,8 +8985,8 @@ specification.</p>
     <li><a href="#ref-for-constrainterror①⓪">6.1. Object store storage operation</a> <a href="#ref-for-constrainterror①①">(2)</a> <a href="#ref-for-constrainterror①②">(3)</a> <a href="#ref-for-constrainterror①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.9. Key range</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">2.11. Key generators</a>
@@ -9010,8 +9010,8 @@ specification.</p>
     <li><a href="#ref-for-idl-DOMException①⑧①">6.1. Object store storage operation</a> <a href="#ref-for-idl-DOMException①⑧②">(2)</a> <a href="#ref-for-idl-DOMException①⑧③">(3)</a> <a href="#ref-for-idl-DOMException①⑧④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Constructs</a>
     <li><a href="#ref-for-idl-DOMString①">2.4. Keys</a>
@@ -9023,14 +9023,14 @@ specification.</p>
     <li><a href="#ref-for-idl-DOMString②④">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datacloneerror">
-   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datacloneerror" class="dfn-panel" data-for="term-for-datacloneerror" id="infopanel-for-term-for-datacloneerror" role="menu">
+   <span id="infopaneltitle-for-term-for-datacloneerror" style="display:none">Info about the 'DataCloneError' external reference.</span><a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacloneerror">3. Exceptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dataerror">
-   <a href="https://webidl.spec.whatwg.org/#dataerror">https://webidl.spec.whatwg.org/#dataerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dataerror" class="dfn-panel" data-for="term-for-dataerror" id="infopanel-for-term-for-dataerror" role="menu">
+   <span id="infopaneltitle-for-term-for-dataerror" style="display:none">Info about the 'DataError' external reference.</span><a href="https://webidl.spec.whatwg.org/#dataerror">https://webidl.spec.whatwg.org/#dataerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dataerror">2.9. Key range</a> <a href="#ref-for-dataerror①">(2)</a>
     <li><a href="#ref-for-dataerror②">3. Exceptions</a>
@@ -9040,8 +9040,8 @@ specification.</p>
     <li><a href="#ref-for-dataerror②⓪">4.8. The IDBCursor interface</a> <a href="#ref-for-dataerror②①">(2)</a> <a href="#ref-for-dataerror②②">(3)</a> <a href="#ref-for-dataerror②③">(4)</a> <a href="#ref-for-dataerror②④">(5)</a> <a href="#ref-for-dataerror②⑤">(6)</a> <a href="#ref-for-dataerror②⑥">(7)</a> <a href="#ref-for-dataerror②⑦">(8)</a> <a href="#ref-for-dataerror②⑧">(9)</a> <a href="#ref-for-dataerror②⑨">(10)</a> <a href="#ref-for-dataerror③⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-EnforceRange①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-EnforceRange②">(2)</a>
@@ -9049,8 +9049,8 @@ specification.</p>
     <li><a href="#ref-for-EnforceRange⑤">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1. The IDBRequest interface</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">4.2. Event interfaces</a>
@@ -9063,8 +9063,8 @@ specification.</p>
     <li><a href="#ref-for-Exposed①⓪">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">3. Exceptions</a>
     <li><a href="#ref-for-invalidaccesserror①">4.4. The IDBDatabase interface</a> <a href="#ref-for-invalidaccesserror②">(2)</a>
@@ -9072,8 +9072,8 @@ specification.</p>
     <li><a href="#ref-for-invalidaccesserror④">4.8. The IDBCursor interface</a> <a href="#ref-for-invalidaccesserror⑤">(2)</a> <a href="#ref-for-invalidaccesserror⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3. Exceptions</a>
     <li><a href="#ref-for-invalidstateerror①">4.1. The IDBRequest interface</a> <a href="#ref-for-invalidstateerror②">(2)</a> <a href="#ref-for-invalidstateerror③">(3)</a> <a href="#ref-for-invalidstateerror④">(4)</a>
@@ -9084,8 +9084,8 @@ specification.</p>
     <li><a href="#ref-for-invalidstateerror⑥⓪">4.9. The IDBTransaction interface</a> <a href="#ref-for-invalidstateerror⑥①">(2)</a> <a href="#ref-for-invalidstateerror⑥②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">4.3. The IDBFactory interface</a> <a href="#ref-for-NewObject①">(2)</a>
     <li><a href="#ref-for-NewObject②">4.4. The IDBDatabase interface</a> <a href="#ref-for-NewObject③">(2)</a>
@@ -9095,8 +9095,8 @@ specification.</p>
     <li><a href="#ref-for-NewObject②⑦">4.8. The IDBCursor interface</a> <a href="#ref-for-NewObject②⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">3. Exceptions</a>
     <li><a href="#ref-for-notfounderror①">4.4. The IDBDatabase interface</a> <a href="#ref-for-notfounderror②">(2)</a>
@@ -9104,14 +9104,14 @@ specification.</p>
     <li><a href="#ref-for-notfounderror⑤">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">3. Exceptions</a>
     <li><a href="#ref-for-quotaexceedederror①">4.4. The IDBDatabase interface</a>
@@ -9122,16 +9122,16 @@ specification.</p>
     <li><a href="#ref-for-quotaexceedederror⑥">5.4. Committing a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readonlyerror">
-   <a href="https://webidl.spec.whatwg.org/#readonlyerror">https://webidl.spec.whatwg.org/#readonlyerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readonlyerror" class="dfn-panel" data-for="term-for-readonlyerror" id="infopanel-for-term-for-readonlyerror" role="menu">
+   <span id="infopaneltitle-for-term-for-readonlyerror" style="display:none">Info about the 'ReadOnlyError' external reference.</span><a href="https://webidl.spec.whatwg.org/#readonlyerror">https://webidl.spec.whatwg.org/#readonlyerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readonlyerror">3. Exceptions</a>
     <li><a href="#ref-for-readonlyerror①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-readonlyerror②">(2)</a> <a href="#ref-for-readonlyerror③">(3)</a> <a href="#ref-for-readonlyerror④">(4)</a>
     <li><a href="#ref-for-readonlyerror⑤">4.8. The IDBCursor interface</a> <a href="#ref-for-readonlyerror⑥">(2)</a> <a href="#ref-for-readonlyerror⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-SameObject①">4.5. The IDBObjectStore interface</a>
@@ -9140,22 +9140,22 @@ specification.</p>
     <li><a href="#ref-for-SameObject④">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">4.3. The IDBFactory interface</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">3. Exceptions</a>
     <li><a href="#ref-for-syntaxerror①">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-syntaxerror②">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transactioninactiveerror">
-   <a href="https://webidl.spec.whatwg.org/#transactioninactiveerror">https://webidl.spec.whatwg.org/#transactioninactiveerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transactioninactiveerror" class="dfn-panel" data-for="term-for-transactioninactiveerror" id="infopanel-for-term-for-transactioninactiveerror" role="menu">
+   <span id="infopaneltitle-for-term-for-transactioninactiveerror" style="display:none">Info about the 'TransactionInactiveError' external reference.</span><a href="https://webidl.spec.whatwg.org/#transactioninactiveerror">https://webidl.spec.whatwg.org/#transactioninactiveerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transactioninactiveerror">3. Exceptions</a>
     <li><a href="#ref-for-transactioninactiveerror①">4.4. The IDBDatabase interface</a> <a href="#ref-for-transactioninactiveerror②">(2)</a>
@@ -9164,8 +9164,8 @@ specification.</p>
     <li><a href="#ref-for-transactioninactiveerror②⑨">4.8. The IDBCursor interface</a> <a href="#ref-for-transactioninactiveerror③⓪">(2)</a> <a href="#ref-for-transactioninactiveerror③①">(3)</a> <a href="#ref-for-transactioninactiveerror③②">(4)</a> <a href="#ref-for-transactioninactiveerror③③">(5)</a> <a href="#ref-for-transactioninactiveerror③④">(6)</a> <a href="#ref-for-transactioninactiveerror③⑤">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">3. Exceptions</a>
     <li><a href="#ref-for-unknownerror①">4.3. The IDBFactory interface</a>
@@ -9175,27 +9175,27 @@ specification.</p>
     <li><a href="#ref-for-unknownerror⑤">5.4. Committing a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-versionerror">
-   <a href="https://webidl.spec.whatwg.org/#versionerror">https://webidl.spec.whatwg.org/#versionerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-versionerror" class="dfn-panel" data-for="term-for-versionerror" id="infopanel-for-term-for-versionerror" role="menu">
+   <span id="infopaneltitle-for-term-for-versionerror" style="display:none">Info about the 'VersionError' external reference.</span><a href="https://webidl.spec.whatwg.org/#versionerror">https://webidl.spec.whatwg.org/#versionerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-versionerror">3. Exceptions</a>
     <li><a href="#ref-for-versionerror①">5.1. Opening a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">4.1. The IDBRequest interface</a>
     <li><a href="#ref-for-idl-any①">4.3. The IDBFactory interface</a> <a href="#ref-for-idl-any②">(2)</a>
@@ -9205,8 +9205,8 @@ specification.</p>
     <li><a href="#ref-for-idl-any③②">4.8. The IDBCursor interface</a> <a href="#ref-for-idl-any③③">(2)</a> <a href="#ref-for-idl-any③④">(3)</a> <a href="#ref-for-idl-any③⑤">(4)</a> <a href="#ref-for-idl-any③⑥">(5)</a> <a href="#ref-for-idl-any③⑦">(6)</a> <a href="#ref-for-idl-any③⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-idl-boolean①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-idl-boolean②">(2)</a> <a href="#ref-for-idl-boolean③">(3)</a>
@@ -9214,20 +9214,20 @@ specification.</p>
     <li><a href="#ref-for-idl-boolean⑥">4.7. The IDBKeyRange interface</a> <a href="#ref-for-idl-boolean⑦">(2)</a> <a href="#ref-for-idl-boolean⑧">(3)</a> <a href="#ref-for-idl-boolean⑨">(4)</a> <a href="#ref-for-idl-boolean①⓪">(5)</a> <a href="#ref-for-idl-boolean①①">(6)</a> <a href="#ref-for-idl-boolean①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-buffer-source-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-buffer-source-type">https://webidl.spec.whatwg.org/#dfn-buffer-source-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-buffer-source-type" class="dfn-panel" data-for="term-for-dfn-buffer-source-type" id="infopanel-for-term-for-dfn-buffer-source-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-buffer-source-type" style="display:none">Info about the 'buffer source types' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-buffer-source-type">https://webidl.spec.whatwg.org/#dfn-buffer-source-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-buffer-source-type">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-byte">
-   <a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-byte" class="dfn-panel" data-for="term-for-idl-byte" id="infopanel-for-term-for-idl-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-byte">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-exception" class="dfn-panel" data-for="term-for-dfn-create-exception" id="infopanel-for-term-for-dfn-create-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-exception" style="display:none">Info about the 'created' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">5.1. Opening a database</a> <a href="#ref-for-dfn-create-exception①">(2)</a> <a href="#ref-for-dfn-create-exception②">(3)</a>
     <li><a href="#ref-for-dfn-create-exception③">5.2. Closing a database</a>
@@ -9237,26 +9237,26 @@ specification.</p>
     <li><a href="#ref-for-dfn-create-exception⑦">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-idl-sequence①">4.4. The IDBDatabase interface</a> <a href="#ref-for-idl-sequence②">(2)</a>
@@ -9266,21 +9266,21 @@ specification.</p>
     <li><a href="#ref-for-idl-sequence⑧">6.3. Index retrieval operations</a> <a href="#ref-for-idl-sequence⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-given-value">
-   <a href="https://webidl.spec.whatwg.org/#the-given-value">https://webidl.spec.whatwg.org/#the-given-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-given-value" class="dfn-panel" data-for="term-for-the-given-value" id="infopanel-for-term-for-the-given-value" role="menu">
+   <span id="infopaneltitle-for-term-for-the-given-value" style="display:none">Info about the 'the given value' external reference.</span><a href="https://webidl.spec.whatwg.org/#the-given-value">https://webidl.spec.whatwg.org/#the-given-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-given-value">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-the-given-value①">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">4.1. The IDBRequest interface</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a>
     <li><a href="#ref-for-this⑦">4.3. The IDBFactory interface</a> <a href="#ref-for-this⑧">(2)</a> <a href="#ref-for-this⑨">(3)</a>
@@ -9292,8 +9292,8 @@ specification.</p>
     <li><a href="#ref-for-this①⑤⑦">4.9. The IDBTransaction interface</a> <a href="#ref-for-this①⑤⑧">(2)</a> <a href="#ref-for-this①⑤⑨">(3)</a> <a href="#ref-for-this①⑥⓪">(4)</a> <a href="#ref-for-this①⑥①">(5)</a> <a href="#ref-for-this①⑥②">(6)</a> <a href="#ref-for-this①⑥③">(7)</a> <a href="#ref-for-this①⑥④">(8)</a> <a href="#ref-for-this①⑥⑤">(9)</a> <a href="#ref-for-this①⑥⑥">(10)</a> <a href="#ref-for-this①⑥⑦">(11)</a> <a href="#ref-for-this①⑥⑧">(12)</a> <a href="#ref-for-this①⑥⑨">(13)</a> <a href="#ref-for-this①⑦⓪">(14)</a> <a href="#ref-for-this①⑦①">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">2.9. Key range</a> <a href="#ref-for-dfn-throw①">(2)</a>
     <li><a href="#ref-for-dfn-throw②">4.1. The IDBRequest interface</a> <a href="#ref-for-dfn-throw③">(2)</a>
@@ -9306,8 +9306,8 @@ specification.</p>
     <li><a href="#ref-for-dfn-throw①②⑤">4.9. The IDBTransaction interface</a> <a href="#ref-for-dfn-throw①②⑥">(2)</a> <a href="#ref-for-dfn-throw①②⑦">(3)</a> <a href="#ref-for-dfn-throw①②⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.4. The IDBDatabase interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">4.5. The IDBObjectStore interface</a>
@@ -9315,22 +9315,22 @@ specification.</p>
     <li><a href="#ref-for-idl-undefined⑥">4.9. The IDBTransaction interface</a> <a href="#ref-for-idl-undefined⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">2.4. Keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.5. The IDBObjectStore interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">4.6. The IDBIndex interface</a> <a href="#ref-for-idl-unsigned-long③">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long④">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">4.2. Event interfaces</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a>
     <li><a href="#ref-for-idl-unsigned-long-long④">4.3. The IDBFactory interface</a> <a href="#ref-for-idl-unsigned-long-long⑤">(2)</a>
@@ -9748,8 +9748,8 @@ specification.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="name">
-   <b><a href="#name">#name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-name" class="dfn-panel" data-for="name" id="infopanel-for-name" role="dialog">
+   <span id="infopaneltitle-for-name" style="display:none">Info about the 'name' definition.</span><b><a href="#name">#name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name">2. Constructs</a> <a href="#ref-for-name①">(2)</a> <a href="#ref-for-name②">(3)</a>
     <li><a href="#ref-for-name③">2.1. Database</a>
@@ -9757,16 +9757,16 @@ specification.</p>
     <li><a href="#ref-for-name⑤">2.6. Index</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sorted-name-list">
-   <b><a href="#sorted-name-list">#sorted-name-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sorted-name-list" class="dfn-panel" data-for="sorted-name-list" id="infopanel-for-sorted-name-list" role="dialog">
+   <span id="infopaneltitle-for-sorted-name-list" style="display:none">Info about the 'sorted name list' definition.</span><b><a href="#sorted-name-list">#sorted-name-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sorted-name-list">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-sorted-name-list①">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-sorted-name-list②">4.9. The IDBTransaction interface</a> <a href="#ref-for-sorted-name-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="database">
-   <b><a href="#database">#database</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-database" class="dfn-panel" data-for="database" id="infopanel-for-database" role="dialog">
+   <span id="infopaneltitle-for-database" style="display:none">Info about the 'database' definition.</span><b><a href="#database">#database</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-database">2.1. Database</a> <a href="#ref-for-database①">(2)</a> <a href="#ref-for-database②">(3)</a> <a href="#ref-for-database③">(4)</a> <a href="#ref-for-database④">(5)</a> <a href="#ref-for-database⑤">(6)</a>
     <li><a href="#ref-for-database⑥">2.1.1. Database connection</a> <a href="#ref-for-database⑦">(2)</a> <a href="#ref-for-database⑧">(3)</a> <a href="#ref-for-database⑨">(4)</a> <a href="#ref-for-database①⓪">(5)</a> <a href="#ref-for-database①①">(6)</a> <a href="#ref-for-database①②">(7)</a> <a href="#ref-for-database①③">(8)</a> <a href="#ref-for-database①④">(9)</a>
@@ -9792,8 +9792,8 @@ specification.</p>
     <li><a href="#ref-for-database⑦③">6. Database operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="database-name">
-   <b><a href="#database-name">#database-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-database-name" class="dfn-panel" data-for="database-name" id="infopanel-for-database-name" role="dialog">
+   <span id="infopaneltitle-for-database-name" style="display:none">Info about the 'name' definition.</span><b><a href="#database-name">#database-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-database-name">2.8.1. Open requests</a>
     <li><a href="#ref-for-database-name①">4.3. The IDBFactory interface</a>
@@ -9802,8 +9802,8 @@ specification.</p>
     <li><a href="#ref-for-database-name⑥">5.3. Deleting a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="database-version">
-   <b><a href="#database-version">#database-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-database-version" class="dfn-panel" data-for="database-version" id="infopanel-for-database-version" role="dialog">
+   <span id="infopaneltitle-for-database-version" style="display:none">Info about the 'version' definition.</span><b><a href="#database-version">#database-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-database-version">2.1. Database</a>
     <li><a href="#ref-for-database-version①">2.7.3. Upgrade transactions</a> <a href="#ref-for-database-version②">(2)</a>
@@ -9816,8 +9816,8 @@ specification.</p>
     <li><a href="#ref-for-database-version②①">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-database-version②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="database-upgrade-transaction">
-   <b><a href="#database-upgrade-transaction">#database-upgrade-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-database-upgrade-transaction" class="dfn-panel" data-for="database-upgrade-transaction" id="infopanel-for-database-upgrade-transaction" role="dialog">
+   <span id="infopaneltitle-for-database-upgrade-transaction" style="display:none">Info about the 'upgrade transaction' definition.</span><b><a href="#database-upgrade-transaction">#database-upgrade-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-database-upgrade-transaction">4.4. The IDBDatabase interface</a> <a href="#ref-for-database-upgrade-transaction①">(2)</a>
     <li><a href="#ref-for-database-upgrade-transaction②">5.4. Committing a transaction</a>
@@ -9825,8 +9825,8 @@ specification.</p>
     <li><a href="#ref-for-database-upgrade-transaction④">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection">
-   <b><a href="#connection">#connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection" class="dfn-panel" data-for="connection" id="infopanel-for-connection" role="dialog">
+   <span id="infopaneltitle-for-connection" style="display:none">Info about the 'connection' definition.</span><b><a href="#connection">#connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection">1. Introduction</a> <a href="#ref-for-connection①">(2)</a>
     <li><a href="#ref-for-connection②">2.1.1. Database connection</a> <a href="#ref-for-connection③">(2)</a> <a href="#ref-for-connection④">(3)</a> <a href="#ref-for-connection⑤">(4)</a> <a href="#ref-for-connection⑥">(5)</a> <a href="#ref-for-connection⑦">(6)</a> <a href="#ref-for-connection⑧">(7)</a> <a href="#ref-for-connection⑨">(8)</a> <a href="#ref-for-connection①⓪">(9)</a> <a href="#ref-for-connection①①">(10)</a> <a href="#ref-for-connection①②">(11)</a> <a href="#ref-for-connection①③">(12)</a> <a href="#ref-for-connection①④">(13)</a> <a href="#ref-for-connection①⑤">(14)</a> <a href="#ref-for-connection①⑥">(15)</a> <a href="#ref-for-connection①⑦">(16)</a> <a href="#ref-for-connection①⑧">(17)</a> <a href="#ref-for-connection①⑨">(18)</a>
@@ -9844,8 +9844,8 @@ specification.</p>
     <li><a href="#ref-for-connection⑥⑥">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-version">
-   <b><a href="#connection-version">#connection-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-version" class="dfn-panel" data-for="connection-version" id="infopanel-for-connection-version" role="dialog">
+   <span id="infopaneltitle-for-connection-version" style="display:none">Info about the 'version' definition.</span><b><a href="#connection-version">#connection-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-version">2.1.1. Database connection</a>
     <li><a href="#ref-for-connection-version①">4.4. The IDBDatabase interface</a>
@@ -9853,8 +9853,8 @@ specification.</p>
     <li><a href="#ref-for-connection-version③">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-close-pending-flag">
-   <b><a href="#connection-close-pending-flag">#connection-close-pending-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-close-pending-flag" class="dfn-panel" data-for="connection-close-pending-flag" id="infopanel-for-connection-close-pending-flag" role="dialog">
+   <span id="infopaneltitle-for-connection-close-pending-flag" style="display:none">Info about the 'close pending flag' definition.</span><b><a href="#connection-close-pending-flag">#connection-close-pending-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-close-pending-flag">2.1.1. Database connection</a>
     <li><a href="#ref-for-connection-close-pending-flag①">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-close-pending-flag②">(2)</a> <a href="#ref-for-connection-close-pending-flag③">(3)</a>
@@ -9863,8 +9863,8 @@ specification.</p>
     <li><a href="#ref-for-connection-close-pending-flag⑧">5.3. Deleting a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-closed">
-   <b><a href="#connection-closed">#connection-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-closed" class="dfn-panel" data-for="connection-closed" id="infopanel-for-connection-closed" role="dialog">
+   <span id="infopaneltitle-for-connection-closed" style="display:none">Info about the 'closed' definition.</span><b><a href="#connection-closed">#connection-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-closed">2.8.1. Open requests</a>
     <li><a href="#ref-for-connection-closed①">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-closed②">(2)</a> <a href="#ref-for-connection-closed③">(3)</a> <a href="#ref-for-connection-closed④">(4)</a>
@@ -9873,16 +9873,16 @@ specification.</p>
     <li><a href="#ref-for-connection-closed⑧">5.3. Deleting a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-object-store-set">
-   <b><a href="#connection-object-store-set">#connection-object-store-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-object-store-set" class="dfn-panel" data-for="connection-object-store-set" id="infopanel-for-connection-object-store-set" role="dialog">
+   <span id="infopaneltitle-for-connection-object-store-set" style="display:none">Info about the 'object store set' definition.</span><b><a href="#connection-object-store-set">#connection-object-store-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-object-store-set">4.4. The IDBDatabase interface</a> <a href="#ref-for-connection-object-store-set①">(2)</a>
     <li><a href="#ref-for-connection-object-store-set②">4.9. The IDBTransaction interface</a>
     <li><a href="#ref-for-connection-object-store-set③">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-connection-versionchange">
-   <b><a href="#eventdef-connection-versionchange">#eventdef-connection-versionchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-connection-versionchange" class="dfn-panel" data-for="eventdef-connection-versionchange" id="infopanel-for-eventdef-connection-versionchange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-connection-versionchange" style="display:none">Info about the 'versionchange' definition.</span><b><a href="#eventdef-connection-versionchange">#eventdef-connection-versionchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-connection-versionchange">1. Introduction</a> <a href="#ref-for-eventdef-connection-versionchange①">(2)</a> <a href="#ref-for-eventdef-connection-versionchange②">(3)</a>
     <li><a href="#ref-for-eventdef-connection-versionchange③">4.3. The IDBFactory interface</a> <a href="#ref-for-eventdef-connection-versionchange④">(2)</a> <a href="#ref-for-eventdef-connection-versionchange⑤">(3)</a>
@@ -9891,8 +9891,8 @@ specification.</p>
     <li><a href="#ref-for-eventdef-connection-versionchange①⓪">5.3. Deleting a database</a> <a href="#ref-for-eventdef-connection-versionchange①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store">
-   <b><a href="#object-store">#object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store" class="dfn-panel" data-for="object-store" id="infopanel-for-object-store" role="dialog">
+   <span id="infopaneltitle-for-object-store" style="display:none">Info about the 'object store' definition.</span><b><a href="#object-store">#object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store">2.1. Database</a>
     <li><a href="#ref-for-object-store①">2.1.1. Database connection</a>
@@ -9919,16 +9919,16 @@ specification.</p>
     <li><a href="#ref-for-object-store①⓪⑦">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-list-of-records">
-   <b><a href="#object-store-list-of-records">#object-store-list-of-records</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-list-of-records" class="dfn-panel" data-for="object-store-list-of-records" id="infopanel-for-object-store-list-of-records" role="dialog">
+   <span id="infopaneltitle-for-object-store-list-of-records" style="display:none">Info about the 'list of records' definition.</span><b><a href="#object-store-list-of-records">#object-store-list-of-records</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-list-of-records">6.1. Object store storage operation</a>
     <li><a href="#ref-for-object-store-list-of-records①">6.2. Object store retrieval operations</a> <a href="#ref-for-object-store-list-of-records②">(2)</a> <a href="#ref-for-object-store-list-of-records③">(3)</a> <a href="#ref-for-object-store-list-of-records④">(4)</a>
     <li><a href="#ref-for-object-store-list-of-records⑤">6.4. Object store deletion operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-record">
-   <b><a href="#object-store-record">#object-store-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-record" class="dfn-panel" data-for="object-store-record" id="infopanel-for-object-store-record" role="dialog">
+   <span id="infopaneltitle-for-object-store-record" style="display:none">Info about the 'record' definition.</span><b><a href="#object-store-record">#object-store-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-record">2.2. Object store</a>
     <li><a href="#ref-for-object-store-record①">2.4. Keys</a> <a href="#ref-for-object-store-record②">(2)</a>
@@ -9946,8 +9946,8 @@ specification.</p>
     <li><a href="#ref-for-object-store-record⑨①">6.7. Cursor iteration operation</a> <a href="#ref-for-object-store-record⑨②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-name">
-   <b><a href="#object-store-name">#object-store-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-name" class="dfn-panel" data-for="object-store-name" id="infopanel-for-object-store-name" role="dialog">
+   <span id="infopaneltitle-for-object-store-name" style="display:none">Info about the 'name' definition.</span><b><a href="#object-store-name">#object-store-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-name">2.2.1. Object store handle</a>
     <li><a href="#ref-for-object-store-name①">4.4. The IDBDatabase interface</a> <a href="#ref-for-object-store-name②">(2)</a> <a href="#ref-for-object-store-name③">(3)</a> <a href="#ref-for-object-store-name④">(4)</a> <a href="#ref-for-object-store-name⑤">(5)</a> <a href="#ref-for-object-store-name⑥">(6)</a> <a href="#ref-for-object-store-name⑦">(7)</a> <a href="#ref-for-object-store-name⑧">(8)</a>
@@ -9956,8 +9956,8 @@ specification.</p>
     <li><a href="#ref-for-object-store-name②⓪">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-key-path">
-   <b><a href="#object-store-key-path">#object-store-key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-key-path" class="dfn-panel" data-for="object-store-key-path" id="infopanel-for-object-store-key-path" role="dialog">
+   <span id="infopaneltitle-for-object-store-key-path" style="display:none">Info about the 'key path' definition.</span><b><a href="#object-store-key-path">#object-store-key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-key-path">2.2. Object store</a>
     <li><a href="#ref-for-object-store-key-path①">2.11. Key generators</a> <a href="#ref-for-object-store-key-path②">(2)</a> <a href="#ref-for-object-store-key-path③">(3)</a> <a href="#ref-for-object-store-key-path④">(4)</a> <a href="#ref-for-object-store-key-path⑤">(5)</a> <a href="#ref-for-object-store-key-path⑥">(6)</a> <a href="#ref-for-object-store-key-path⑦">(7)</a> <a href="#ref-for-object-store-key-path⑧">(8)</a> <a href="#ref-for-object-store-key-path⑨">(9)</a>
@@ -9969,8 +9969,8 @@ specification.</p>
     <li><a href="#ref-for-object-store-key-path①⑧">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-in-line-keys">
-   <b><a href="#object-store-in-line-keys">#object-store-in-line-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-in-line-keys" class="dfn-panel" data-for="object-store-in-line-keys" id="infopanel-for-object-store-in-line-keys" role="dialog">
+   <span id="infopaneltitle-for-object-store-in-line-keys" style="display:none">Info about the 'in-line keys' definition.</span><b><a href="#object-store-in-line-keys">#object-store-in-line-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-in-line-keys">2.11. Key generators</a>
     <li><a href="#ref-for-object-store-in-line-keys①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-in-line-keys②">(2)</a> <a href="#ref-for-object-store-in-line-keys③">(3)</a>
@@ -9978,15 +9978,15 @@ specification.</p>
     <li><a href="#ref-for-object-store-in-line-keys⑥">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-out-of-line-keys">
-   <b><a href="#object-store-out-of-line-keys">#object-store-out-of-line-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-out-of-line-keys" class="dfn-panel" data-for="object-store-out-of-line-keys" id="infopanel-for-object-store-out-of-line-keys" role="dialog">
+   <span id="infopaneltitle-for-object-store-out-of-line-keys" style="display:none">Info about the 'out-of-line keys' definition.</span><b><a href="#object-store-out-of-line-keys">#object-store-out-of-line-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-out-of-line-keys">2.11. Key generators</a>
     <li><a href="#ref-for-object-store-out-of-line-keys①">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-handle">
-   <b><a href="#object-store-handle">#object-store-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-handle" class="dfn-panel" data-for="object-store-handle" id="infopanel-for-object-store-handle" role="dialog">
+   <span id="infopaneltitle-for-object-store-handle" style="display:none">Info about the 'object store handle' definition.</span><b><a href="#object-store-handle">#object-store-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-handle">2.2.1. Object store handle</a> <a href="#ref-for-object-store-handle①">(2)</a> <a href="#ref-for-object-store-handle②">(3)</a> <a href="#ref-for-object-store-handle③">(4)</a> <a href="#ref-for-object-store-handle④">(5)</a> <a href="#ref-for-object-store-handle⑤">(6)</a>
     <li><a href="#ref-for-object-store-handle⑥">2.6.1. Index handle</a>
@@ -9997,38 +9997,38 @@ specification.</p>
     <li><a href="#ref-for-object-store-handle①②">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-handle-object-store">
-   <b><a href="#object-store-handle-object-store">#object-store-handle-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-handle-object-store" class="dfn-panel" data-for="object-store-handle-object-store" id="infopanel-for-object-store-handle-object-store" role="dialog">
+   <span id="infopaneltitle-for-object-store-handle-object-store" style="display:none">Info about the 'object store' definition.</span><b><a href="#object-store-handle-object-store">#object-store-handle-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-handle-object-store">2.2.1. Object store handle</a> <a href="#ref-for-object-store-handle-object-store①">(2)</a>
     <li><a href="#ref-for-object-store-handle-object-store②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-object-store③">(2)</a> <a href="#ref-for-object-store-handle-object-store④">(3)</a> <a href="#ref-for-object-store-handle-object-store⑤">(4)</a> <a href="#ref-for-object-store-handle-object-store⑥">(5)</a> <a href="#ref-for-object-store-handle-object-store⑦">(6)</a> <a href="#ref-for-object-store-handle-object-store⑧">(7)</a> <a href="#ref-for-object-store-handle-object-store⑨">(8)</a> <a href="#ref-for-object-store-handle-object-store①⓪">(9)</a> <a href="#ref-for-object-store-handle-object-store①①">(10)</a> <a href="#ref-for-object-store-handle-object-store①②">(11)</a> <a href="#ref-for-object-store-handle-object-store①③">(12)</a> <a href="#ref-for-object-store-handle-object-store①④">(13)</a> <a href="#ref-for-object-store-handle-object-store①⑤">(14)</a> <a href="#ref-for-object-store-handle-object-store①⑥">(15)</a> <a href="#ref-for-object-store-handle-object-store①⑦">(16)</a>
     <li><a href="#ref-for-object-store-handle-object-store①⑧">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-object-store-handle-object-store①⑨">(2)</a> <a href="#ref-for-object-store-handle-object-store②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-handle-transaction">
-   <b><a href="#object-store-handle-transaction">#object-store-handle-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-handle-transaction" class="dfn-panel" data-for="object-store-handle-transaction" id="infopanel-for-object-store-handle-transaction" role="dialog">
+   <span id="infopaneltitle-for-object-store-handle-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#object-store-handle-transaction">#object-store-handle-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-handle-transaction">2.6.1. Index handle</a>
     <li><a href="#ref-for-object-store-handle-transaction①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-transaction②">(2)</a> <a href="#ref-for-object-store-handle-transaction③">(3)</a> <a href="#ref-for-object-store-handle-transaction④">(4)</a> <a href="#ref-for-object-store-handle-transaction⑤">(5)</a> <a href="#ref-for-object-store-handle-transaction⑥">(6)</a> <a href="#ref-for-object-store-handle-transaction⑦">(7)</a> <a href="#ref-for-object-store-handle-transaction⑧">(8)</a> <a href="#ref-for-object-store-handle-transaction⑨">(9)</a> <a href="#ref-for-object-store-handle-transaction①⓪">(10)</a> <a href="#ref-for-object-store-handle-transaction①①">(11)</a> <a href="#ref-for-object-store-handle-transaction①②">(12)</a> <a href="#ref-for-object-store-handle-transaction①③">(13)</a> <a href="#ref-for-object-store-handle-transaction①④">(14)</a> <a href="#ref-for-object-store-handle-transaction①⑤">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-handle-index-set">
-   <b><a href="#object-store-handle-index-set">#object-store-handle-index-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-handle-index-set" class="dfn-panel" data-for="object-store-handle-index-set" id="infopanel-for-object-store-handle-index-set" role="dialog">
+   <span id="infopaneltitle-for-object-store-handle-index-set" style="display:none">Info about the 'index set' definition.</span><b><a href="#object-store-handle-index-set">#object-store-handle-index-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-handle-index-set">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-object-store-handle-index-set①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-object-store-handle-index-set②">(2)</a> <a href="#ref-for-object-store-handle-index-set③">(3)</a> <a href="#ref-for-object-store-handle-index-set④">(4)</a>
     <li><a href="#ref-for-object-store-handle-index-set⑤">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-store-handle-name">
-   <b><a href="#object-store-handle-name">#object-store-handle-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-store-handle-name" class="dfn-panel" data-for="object-store-handle-name" id="infopanel-for-object-store-handle-name" role="dialog">
+   <span id="infopaneltitle-for-object-store-handle-name" style="display:none">Info about the 'name' definition.</span><b><a href="#object-store-handle-name">#object-store-handle-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-store-handle-name">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-object-store-handle-name①">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value">
-   <b><a href="#value">#value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value" class="dfn-panel" data-for="value" id="infopanel-for-value" role="dialog">
+   <span id="infopaneltitle-for-value" style="display:none">Info about the 'value' definition.</span><b><a href="#value">#value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value">2.2. Object store</a> <a href="#ref-for-value①">(2)</a>
     <li><a href="#ref-for-value②">2.3. Values</a> <a href="#ref-for-value③">(2)</a>
@@ -10042,8 +10042,8 @@ specification.</p>
     <li><a href="#ref-for-value②①">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key">
-   <b><a href="#key">#key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key" class="dfn-panel" data-for="key" id="infopanel-for-key" role="dialog">
+   <span id="infopaneltitle-for-key" style="display:none">Info about the 'key' definition.</span><b><a href="#key">#key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key">2.2. Object store</a> <a href="#ref-for-key①">(2)</a>
     <li><a href="#ref-for-key②">2.4. Keys</a> <a href="#ref-for-key③">(2)</a> <a href="#ref-for-key④">(3)</a> <a href="#ref-for-key⑤">(4)</a> <a href="#ref-for-key⑥">(5)</a> <a href="#ref-for-key⑦">(6)</a> <a href="#ref-for-key⑧">(7)</a> <a href="#ref-for-key⑨">(8)</a> <a href="#ref-for-key①⓪">(9)</a> <a href="#ref-for-key①①">(10)</a> <a href="#ref-for-key①②">(11)</a> <a href="#ref-for-key①③">(12)</a> <a href="#ref-for-key①④">(13)</a> <a href="#ref-for-key①⑤">(14)</a> <a href="#ref-for-key①⑥">(15)</a> <a href="#ref-for-key①⑦">(16)</a>
@@ -10064,8 +10064,8 @@ specification.</p>
     <li><a href="#ref-for-key⑨④">7.4. Convert a value to a key</a> <a href="#ref-for-key⑨⑤">(2)</a> <a href="#ref-for-key⑨⑥">(3)</a> <a href="#ref-for-key⑨⑦">(4)</a> <a href="#ref-for-key⑨⑧">(5)</a> <a href="#ref-for-key⑨⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-type">
-   <b><a href="#key-type">#key-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-type" class="dfn-panel" data-for="key-type" id="infopanel-for-key-type" role="dialog">
+   <span id="infopaneltitle-for-key-type" style="display:none">Info about the 'type' definition.</span><b><a href="#key-type">#key-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-type">2.4. Keys</a> <a href="#ref-for-key-type①">(2)</a> <a href="#ref-for-key-type②">(3)</a>
     <li><a href="#ref-for-key-type③">2.11. Key generators</a> <a href="#ref-for-key-type④">(2)</a> <a href="#ref-for-key-type⑤">(3)</a> <a href="#ref-for-key-type⑥">(4)</a>
@@ -10073,8 +10073,8 @@ specification.</p>
     <li><a href="#ref-for-key-type⑧">7.4. Convert a value to a key</a> <a href="#ref-for-key-type⑨">(2)</a> <a href="#ref-for-key-type①⓪">(3)</a> <a href="#ref-for-key-type①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-value">
-   <b><a href="#key-value">#key-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-value" class="dfn-panel" data-for="key-value" id="infopanel-for-key-value" role="dialog">
+   <span id="infopaneltitle-for-key-value" style="display:none">Info about the 'value' definition.</span><b><a href="#key-value">#key-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-value">2.4. Keys</a> <a href="#ref-for-key-value①">(2)</a> <a href="#ref-for-key-value②">(3)</a>
     <li><a href="#ref-for-key-value③">2.11. Key generators</a> <a href="#ref-for-key-value④">(2)</a>
@@ -10082,8 +10082,8 @@ specification.</p>
     <li><a href="#ref-for-key-value⑥">7.4. Convert a value to a key</a> <a href="#ref-for-key-value⑦">(2)</a> <a href="#ref-for-key-value⑧">(3)</a> <a href="#ref-for-key-value⑨">(4)</a> <a href="#ref-for-key-value①⓪">(5)</a> <a href="#ref-for-key-value①①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="array-key">
-   <b><a href="#array-key">#array-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-array-key" class="dfn-panel" data-for="array-key" id="infopanel-for-array-key" role="dialog">
+   <span id="infopaneltitle-for-array-key" style="display:none">Info about the 'array key' definition.</span><b><a href="#array-key">#array-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-array-key">2.4. Keys</a> <a href="#ref-for-array-key①">(2)</a>
     <li><a href="#ref-for-array-key②">2.6. Index</a> <a href="#ref-for-array-key③">(2)</a>
@@ -10091,23 +10091,23 @@ specification.</p>
     <li><a href="#ref-for-array-key①①">7.4. Convert a value to a key</a> <a href="#ref-for-array-key①②">(2)</a> <a href="#ref-for-array-key①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subkeys">
-   <b><a href="#subkeys">#subkeys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subkeys" class="dfn-panel" data-for="subkeys" id="infopanel-for-subkeys" role="dialog">
+   <span id="infopaneltitle-for-subkeys" style="display:none">Info about the 'subkeys' definition.</span><b><a href="#subkeys">#subkeys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subkeys">2.6. Index</a>
     <li><a href="#ref-for-subkeys①">6.1. Object store storage operation</a> <a href="#ref-for-subkeys②">(2)</a> <a href="#ref-for-subkeys③">(3)</a> <a href="#ref-for-subkeys④">(4)</a>
     <li><a href="#ref-for-subkeys⑤">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compare-two-keys">
-   <b><a href="#compare-two-keys">#compare-two-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compare-two-keys" class="dfn-panel" data-for="compare-two-keys" id="infopanel-for-compare-two-keys" role="dialog">
+   <span id="infopaneltitle-for-compare-two-keys" style="display:none">Info about the 'compare two keys' definition.</span><b><a href="#compare-two-keys">#compare-two-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compare-two-keys">2.4. Keys</a> <a href="#ref-for-compare-two-keys①">(2)</a> <a href="#ref-for-compare-two-keys②">(3)</a> <a href="#ref-for-compare-two-keys③">(4)</a>
     <li><a href="#ref-for-compare-two-keys④">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="greater-than">
-   <b><a href="#greater-than">#greater-than</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-greater-than" class="dfn-panel" data-for="greater-than" id="infopanel-for-greater-than" role="dialog">
+   <span id="infopaneltitle-for-greater-than" style="display:none">Info about the 'greater than' definition.</span><b><a href="#greater-than">#greater-than</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-greater-than">2.2. Object store</a>
     <li><a href="#ref-for-greater-than①">2.9. Key range</a> <a href="#ref-for-greater-than②">(2)</a>
@@ -10118,8 +10118,8 @@ specification.</p>
     <li><a href="#ref-for-greater-than①①">6.7. Cursor iteration operation</a> <a href="#ref-for-greater-than①②">(2)</a> <a href="#ref-for-greater-than①③">(3)</a> <a href="#ref-for-greater-than①④">(4)</a> <a href="#ref-for-greater-than①⑤">(5)</a> <a href="#ref-for-greater-than①⑥">(6)</a> <a href="#ref-for-greater-than①⑦">(7)</a> <a href="#ref-for-greater-than①⑧">(8)</a> <a href="#ref-for-greater-than①⑨">(9)</a> <a href="#ref-for-greater-than②⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="less-than">
-   <b><a href="#less-than">#less-than</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-less-than" class="dfn-panel" data-for="less-than" id="infopanel-for-less-than" role="dialog">
+   <span id="infopaneltitle-for-less-than" style="display:none">Info about the 'less than' definition.</span><b><a href="#less-than">#less-than</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-less-than">2.9. Key range</a>
     <li><a href="#ref-for-less-than①">2.10. Cursor</a>
@@ -10127,8 +10127,8 @@ specification.</p>
     <li><a href="#ref-for-less-than⑤">6.7. Cursor iteration operation</a> <a href="#ref-for-less-than⑥">(2)</a> <a href="#ref-for-less-than⑦">(3)</a> <a href="#ref-for-less-than⑧">(4)</a> <a href="#ref-for-less-than⑨">(5)</a> <a href="#ref-for-less-than①⓪">(6)</a> <a href="#ref-for-less-than①①">(7)</a> <a href="#ref-for-less-than①②">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="equal-to">
-   <b><a href="#equal-to">#equal-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-equal-to" class="dfn-panel" data-for="equal-to" id="infopanel-for-equal-to" role="dialog">
+   <span id="infopaneltitle-for-equal-to" style="display:none">Info about the 'equal to' definition.</span><b><a href="#equal-to">#equal-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-equal-to">2.9. Key range</a> <a href="#ref-for-equal-to①">(2)</a> <a href="#ref-for-equal-to②">(3)</a>
     <li><a href="#ref-for-equal-to③">4.8. The IDBCursor interface</a> <a href="#ref-for-equal-to④">(2)</a> <a href="#ref-for-equal-to⑤">(3)</a> <a href="#ref-for-equal-to⑥">(4)</a> <a href="#ref-for-equal-to⑦">(5)</a> <a href="#ref-for-equal-to⑧">(6)</a> <a href="#ref-for-equal-to⑨">(7)</a>
@@ -10137,8 +10137,8 @@ specification.</p>
     <li><a href="#ref-for-equal-to②⑤">7.4. Convert a value to a key</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-path">
-   <b><a href="#key-path">#key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-path" class="dfn-panel" data-for="key-path" id="infopanel-for-key-path" role="dialog">
+   <span id="infopaneltitle-for-key-path" style="display:none">Info about the 'key path' definition.</span><b><a href="#key-path">#key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-path">2.5. Key path</a>
     <li><a href="#ref-for-key-path①">4.5. The IDBObjectStore interface</a>
@@ -10148,21 +10148,21 @@ specification.</p>
     <li><a href="#ref-for-key-path⑥">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-key-path">
-   <b><a href="#valid-key-path">#valid-key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-key-path" class="dfn-panel" data-for="valid-key-path" id="infopanel-for-valid-key-path" role="dialog">
+   <span id="infopaneltitle-for-valid-key-path" style="display:none">Info about the 'valid key path' definition.</span><b><a href="#valid-key-path">#valid-key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-key-path">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-valid-key-path①">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier">
-   <b><a href="#identifier">#identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier" class="dfn-panel" data-for="identifier" id="infopanel-for-identifier" role="dialog">
+   <span id="infopaneltitle-for-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#identifier">#identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier">2.5. Key path</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-concept">
-   <b><a href="#index-concept">#index-concept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-concept" class="dfn-panel" data-for="index-concept" id="infopanel-for-index-concept" role="dialog">
+   <span id="infopaneltitle-for-index-concept" style="display:none">Info about the 'index' definition.</span><b><a href="#index-concept">#index-concept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-concept">2.2.1. Object store handle</a>
     <li><a href="#ref-for-index-concept①">2.6. Index</a> <a href="#ref-for-index-concept②">(2)</a> <a href="#ref-for-index-concept③">(3)</a> <a href="#ref-for-index-concept④">(4)</a> <a href="#ref-for-index-concept⑤">(5)</a>
@@ -10181,8 +10181,8 @@ specification.</p>
     <li><a href="#ref-for-index-concept④⑦">6.7. Cursor iteration operation</a> <a href="#ref-for-index-concept④⑧">(2)</a> <a href="#ref-for-index-concept④⑨">(3)</a> <a href="#ref-for-index-concept⑤⓪">(4)</a> <a href="#ref-for-index-concept⑤①">(5)</a> <a href="#ref-for-index-concept⑤②">(6)</a> <a href="#ref-for-index-concept⑤③">(7)</a> <a href="#ref-for-index-concept⑤④">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-referenced">
-   <b><a href="#index-referenced">#index-referenced</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-referenced" class="dfn-panel" data-for="index-referenced" id="infopanel-for-index-referenced" role="dialog">
+   <span id="infopaneltitle-for-index-referenced" style="display:none">Info about the 'referenced' definition.</span><b><a href="#index-referenced">#index-referenced</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-referenced">2.6. Index</a> <a href="#ref-for-index-referenced①">(2)</a> <a href="#ref-for-index-referenced②">(3)</a> <a href="#ref-for-index-referenced③">(4)</a> <a href="#ref-for-index-referenced④">(5)</a>
     <li><a href="#ref-for-index-referenced⑤">2.10. Cursor</a>
@@ -10193,52 +10193,52 @@ specification.</p>
     <li><a href="#ref-for-index-referenced①①">6.6. Object store clear operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-list-of-records">
-   <b><a href="#index-list-of-records">#index-list-of-records</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-list-of-records" class="dfn-panel" data-for="index-list-of-records" id="infopanel-for-index-list-of-records" role="dialog">
+   <span id="infopaneltitle-for-index-list-of-records" style="display:none">Info about the 'list of records' definition.</span><b><a href="#index-list-of-records">#index-list-of-records</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-list-of-records">6.1. Object store storage operation</a> <a href="#ref-for-index-list-of-records①">(2)</a>
     <li><a href="#ref-for-index-list-of-records②">6.3. Index retrieval operations</a> <a href="#ref-for-index-list-of-records③">(2)</a> <a href="#ref-for-index-list-of-records④">(3)</a> <a href="#ref-for-index-list-of-records⑤">(4)</a>
     <li><a href="#ref-for-index-list-of-records⑥">6.4. Object store deletion operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-records">
-   <b><a href="#index-records">#index-records</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-records" class="dfn-panel" data-for="index-records" id="infopanel-for-index-records" role="dialog">
+   <span id="infopaneltitle-for-index-records" style="display:none">Info about the 'records' definition.</span><b><a href="#index-records">#index-records</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-records">2.6. Index</a>
     <li><a href="#ref-for-index-records①">6.3. Index retrieval operations</a> <a href="#ref-for-index-records②">(2)</a> <a href="#ref-for-index-records③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-values">
-   <b><a href="#index-values">#index-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-values" class="dfn-panel" data-for="index-values" id="infopanel-for-index-values" role="dialog">
+   <span id="infopaneltitle-for-index-values" style="display:none">Info about the 'values' definition.</span><b><a href="#index-values">#index-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-values">6.3. Index retrieval operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-keys">
-   <b><a href="#index-keys">#index-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-keys" class="dfn-panel" data-for="index-keys" id="infopanel-for-index-keys" role="dialog">
+   <span id="infopaneltitle-for-index-keys" style="display:none">Info about the 'keys' definition.</span><b><a href="#index-keys">#index-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-keys">2.6. Index</a>
     <li><a href="#ref-for-index-keys①">6.3. Index retrieval operations</a> <a href="#ref-for-index-keys②">(2)</a> <a href="#ref-for-index-keys③">(3)</a> <a href="#ref-for-index-keys④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-key-path">
-   <b><a href="#index-key-path">#index-key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-key-path" class="dfn-panel" data-for="index-key-path" id="infopanel-for-index-key-path" role="dialog">
+   <span id="infopaneltitle-for-index-key-path" style="display:none">Info about the 'key path' definition.</span><b><a href="#index-key-path">#index-key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-key-path">2.6. Index</a> <a href="#ref-for-index-key-path①">(2)</a> <a href="#ref-for-index-key-path②">(3)</a>
     <li><a href="#ref-for-index-key-path③">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-key-path④">(2)</a>
     <li><a href="#ref-for-index-key-path⑤">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-referenced-value">
-   <b><a href="#index-referenced-value">#index-referenced-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-referenced-value" class="dfn-panel" data-for="index-referenced-value" id="infopanel-for-index-referenced-value" role="dialog">
+   <span id="infopaneltitle-for-index-referenced-value" style="display:none">Info about the 'referenced value' definition.</span><b><a href="#index-referenced-value">#index-referenced-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-referenced-value">2.6. Index</a> <a href="#ref-for-index-referenced-value①">(2)</a>
     <li><a href="#ref-for-index-referenced-value②">6.3. Index retrieval operations</a> <a href="#ref-for-index-referenced-value③">(2)</a>
     <li><a href="#ref-for-index-referenced-value④">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-name">
-   <b><a href="#index-name">#index-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-name" class="dfn-panel" data-for="index-name" id="infopanel-for-index-name" role="dialog">
+   <span id="infopaneltitle-for-index-name" style="display:none">Info about the 'name' definition.</span><b><a href="#index-name">#index-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-name">2.6.1. Index handle</a>
     <li><a href="#ref-for-index-name①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-name②">(2)</a> <a href="#ref-for-index-name③">(3)</a> <a href="#ref-for-index-name④">(4)</a> <a href="#ref-for-index-name⑤">(5)</a> <a href="#ref-for-index-name⑥">(6)</a> <a href="#ref-for-index-name⑦">(7)</a>
@@ -10246,8 +10246,8 @@ specification.</p>
     <li><a href="#ref-for-index-name①⑥">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-unique-flag">
-   <b><a href="#index-unique-flag">#index-unique-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-unique-flag" class="dfn-panel" data-for="index-unique-flag" id="infopanel-for-index-unique-flag" role="dialog">
+   <span id="infopaneltitle-for-index-unique-flag" style="display:none">Info about the 'unique flag' definition.</span><b><a href="#index-unique-flag">#index-unique-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-unique-flag">2.10. Cursor</a> <a href="#ref-for-index-unique-flag①">(2)</a>
     <li><a href="#ref-for-index-unique-flag②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-unique-flag③">(2)</a> <a href="#ref-for-index-unique-flag④">(3)</a>
@@ -10255,8 +10255,8 @@ specification.</p>
     <li><a href="#ref-for-index-unique-flag⑦">6.1. Object store storage operation</a> <a href="#ref-for-index-unique-flag⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-multientry-flag">
-   <b><a href="#index-multientry-flag">#index-multientry-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-multientry-flag" class="dfn-panel" data-for="index-multientry-flag" id="infopanel-for-index-multientry-flag" role="dialog">
+   <span id="infopaneltitle-for-index-multientry-flag" style="display:none">Info about the 'multiEntry flag' definition.</span><b><a href="#index-multientry-flag">#index-multientry-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-multientry-flag">2.6. Index</a> <a href="#ref-for-index-multientry-flag①">(2)</a>
     <li><a href="#ref-for-index-multientry-flag②">4.5. The IDBObjectStore interface</a>
@@ -10264,8 +10264,9 @@ specification.</p>
     <li><a href="#ref-for-index-multientry-flag⑤">6.1. Object store storage operation</a> <a href="#ref-for-index-multientry-flag⑥">(2)</a> <a href="#ref-for-index-multientry-flag⑦">(3)</a> <a href="#ref-for-index-multientry-flag⑧">(4)</a> <a href="#ref-for-index-multientry-flag⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-handle">
-   <b><a href="#index-handle">#index-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-handle" class="dfn-panel" data-for="index-handle" id="infopanel-for-index-handle" role="dialog">
+   <span id="infopaneltitle-for-index-handle" style="display:none">Info about the 'index
+handle' definition.</span><b><a href="#index-handle">#index-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-handle">2.6.1. Index handle</a> <a href="#ref-for-index-handle①">(2)</a> <a href="#ref-for-index-handle②">(3)</a> <a href="#ref-for-index-handle③">(4)</a> <a href="#ref-for-index-handle④">(5)</a>
     <li><a href="#ref-for-index-handle⑤">4.5. The IDBObjectStore interface</a> <a href="#ref-for-index-handle⑥">(2)</a>
@@ -10274,35 +10275,35 @@ specification.</p>
     <li><a href="#ref-for-index-handle⑨">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-handle-index">
-   <b><a href="#index-handle-index">#index-handle-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-handle-index" class="dfn-panel" data-for="index-handle-index" id="infopanel-for-index-handle-index" role="dialog">
+   <span id="infopaneltitle-for-index-handle-index" style="display:none">Info about the 'index' definition.</span><b><a href="#index-handle-index">#index-handle-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-handle-index">2.6.1. Index handle</a>
     <li><a href="#ref-for-index-handle-index①">4.6. The IDBIndex interface</a> <a href="#ref-for-index-handle-index②">(2)</a> <a href="#ref-for-index-handle-index③">(3)</a> <a href="#ref-for-index-handle-index④">(4)</a> <a href="#ref-for-index-handle-index⑤">(5)</a> <a href="#ref-for-index-handle-index⑥">(6)</a> <a href="#ref-for-index-handle-index⑦">(7)</a> <a href="#ref-for-index-handle-index⑧">(8)</a> <a href="#ref-for-index-handle-index⑨">(9)</a> <a href="#ref-for-index-handle-index①⓪">(10)</a> <a href="#ref-for-index-handle-index①①">(11)</a>
     <li><a href="#ref-for-index-handle-index①②">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-index-handle-index①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-handle-object-store-handle">
-   <b><a href="#index-handle-object-store-handle">#index-handle-object-store-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-handle-object-store-handle" class="dfn-panel" data-for="index-handle-object-store-handle" id="infopanel-for-index-handle-object-store-handle" role="dialog">
+   <span id="infopaneltitle-for-index-handle-object-store-handle" style="display:none">Info about the 'object store handle' definition.</span><b><a href="#index-handle-object-store-handle">#index-handle-object-store-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-handle-object-store-handle">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-handle-transaction">
-   <b><a href="#index-handle-transaction">#index-handle-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-handle-transaction" class="dfn-panel" data-for="index-handle-transaction" id="infopanel-for-index-handle-transaction" role="dialog">
+   <span id="infopaneltitle-for-index-handle-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#index-handle-transaction">#index-handle-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-handle-transaction">4.6. The IDBIndex interface</a> <a href="#ref-for-index-handle-transaction①">(2)</a> <a href="#ref-for-index-handle-transaction②">(3)</a> <a href="#ref-for-index-handle-transaction③">(4)</a> <a href="#ref-for-index-handle-transaction④">(5)</a> <a href="#ref-for-index-handle-transaction⑤">(6)</a> <a href="#ref-for-index-handle-transaction⑥">(7)</a> <a href="#ref-for-index-handle-transaction⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-handle-name">
-   <b><a href="#index-handle-name">#index-handle-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-handle-name" class="dfn-panel" data-for="index-handle-name" id="infopanel-for-index-handle-name" role="dialog">
+   <span id="infopaneltitle-for-index-handle-name" style="display:none">Info about the 'name' definition.</span><b><a href="#index-handle-name">#index-handle-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-handle-name">4.6. The IDBIndex interface</a>
     <li><a href="#ref-for-index-handle-name①">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-concept">
-   <b><a href="#transaction-concept">#transaction-concept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-concept" class="dfn-panel" data-for="transaction-concept" id="infopanel-for-transaction-concept" role="dialog">
+   <span id="infopaneltitle-for-transaction-concept" style="display:none">Info about the 'transaction' definition.</span><b><a href="#transaction-concept">#transaction-concept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-concept">2.1.1. Database connection</a>
     <li><a href="#ref-for-transaction-concept①">2.2.1. Object store handle</a> <a href="#ref-for-transaction-concept②">(2)</a> <a href="#ref-for-transaction-concept③">(3)</a>
@@ -10328,8 +10329,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-concept⑧②">5.11. Clone a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-connection">
-   <b><a href="#transaction-connection">#transaction-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-connection" class="dfn-panel" data-for="transaction-connection" id="infopanel-for-transaction-connection" role="dialog">
+   <span id="infopaneltitle-for-transaction-connection" style="display:none">Info about the 'connection' definition.</span><b><a href="#transaction-connection">#transaction-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-connection">2.7. Transactions</a>
     <li><a href="#ref-for-transaction-connection①">4.9. The IDBTransaction interface</a> <a href="#ref-for-transaction-connection②">(2)</a>
@@ -10337,8 +10338,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-connection④">5.5. Aborting a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-scope">
-   <b><a href="#transaction-scope">#transaction-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-scope" class="dfn-panel" data-for="transaction-scope" id="infopanel-for-transaction-scope" role="dialog">
+   <span id="infopaneltitle-for-transaction-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#transaction-scope">#transaction-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-scope">2.7. Transactions</a> <a href="#ref-for-transaction-scope①">(2)</a> <a href="#ref-for-transaction-scope②">(3)</a>
     <li><a href="#ref-for-transaction-scope③">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-scope④">(2)</a>
@@ -10348,15 +10349,15 @@ specification.</p>
     <li><a href="#ref-for-transaction-scope①②">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-overlap">
-   <b><a href="#transaction-overlap">#transaction-overlap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-overlap" class="dfn-panel" data-for="transaction-overlap" id="infopanel-for-transaction-overlap" role="dialog">
+   <span id="infopaneltitle-for-transaction-overlap" style="display:none">Info about the 'overlapping scope' definition.</span><b><a href="#transaction-overlap">#transaction-overlap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-overlap">2.7. Transactions</a> <a href="#ref-for-transaction-overlap①">(2)</a>
     <li><a href="#ref-for-transaction-overlap②">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-overlap③">(2)</a> <a href="#ref-for-transaction-overlap④">(3)</a> <a href="#ref-for-transaction-overlap⑤">(4)</a> <a href="#ref-for-transaction-overlap⑥">(5)</a> <a href="#ref-for-transaction-overlap⑦">(6)</a> <a href="#ref-for-transaction-overlap⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-mode">
-   <b><a href="#transaction-mode">#transaction-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-mode" class="dfn-panel" data-for="transaction-mode" id="infopanel-for-transaction-mode" role="dialog">
+   <span id="infopaneltitle-for-transaction-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#transaction-mode">#transaction-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-mode">2.7. Transactions</a> <a href="#ref-for-transaction-mode①">(2)</a> <a href="#ref-for-transaction-mode②">(3)</a> <a href="#ref-for-transaction-mode③">(4)</a>
     <li><a href="#ref-for-transaction-mode④">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-mode⑤">(2)</a> <a href="#ref-for-transaction-mode⑥">(3)</a>
@@ -10364,23 +10365,23 @@ specification.</p>
     <li><a href="#ref-for-transaction-mode⑧">4.9. The IDBTransaction interface</a> <a href="#ref-for-transaction-mode⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-durability-hint">
-   <b><a href="#transaction-durability-hint">#transaction-durability-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-durability-hint" class="dfn-panel" data-for="transaction-durability-hint" id="infopanel-for-transaction-durability-hint" role="dialog">
+   <span id="infopaneltitle-for-transaction-durability-hint" style="display:none">Info about the 'durability hint' definition.</span><b><a href="#transaction-durability-hint">#transaction-durability-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-durability-hint">2.7. Transactions</a>
     <li><a href="#ref-for-transaction-durability-hint①">4.9. The IDBTransaction interface</a> <a href="#ref-for-transaction-durability-hint②">(2)</a>
     <li><a href="#ref-for-transaction-durability-hint③">5.4. Committing a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-cleanup-event-loop">
-   <b><a href="#transaction-cleanup-event-loop">#transaction-cleanup-event-loop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-cleanup-event-loop" class="dfn-panel" data-for="transaction-cleanup-event-loop" id="infopanel-for-transaction-cleanup-event-loop" role="dialog">
+   <span id="infopaneltitle-for-transaction-cleanup-event-loop" style="display:none">Info about the 'cleanup event loop' definition.</span><b><a href="#transaction-cleanup-event-loop">#transaction-cleanup-event-loop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-cleanup-event-loop">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-cleanup-event-loop①">(2)</a> <a href="#ref-for-transaction-cleanup-event-loop②">(3)</a>
     <li><a href="#ref-for-transaction-cleanup-event-loop③">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-request-list">
-   <b><a href="#transaction-request-list">#transaction-request-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-request-list" class="dfn-panel" data-for="transaction-request-list" id="infopanel-for-transaction-request-list" role="dialog">
+   <span id="infopaneltitle-for-transaction-request-list" style="display:none">Info about the 'request list' definition.</span><b><a href="#transaction-request-list">#transaction-request-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-request-list">5.4. Committing a transaction</a>
     <li><a href="#ref-for-transaction-request-list①">5.5. Aborting a transaction</a>
@@ -10389,15 +10390,15 @@ specification.</p>
     <li><a href="#ref-for-transaction-request-list⑥">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-error">
-   <b><a href="#transaction-error">#transaction-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-error" class="dfn-panel" data-for="transaction-error" id="infopanel-for-transaction-error" role="dialog">
+   <span id="infopaneltitle-for-transaction-error" style="display:none">Info about the 'error' definition.</span><b><a href="#transaction-error">#transaction-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-error">4.9. The IDBTransaction interface</a>
     <li><a href="#ref-for-transaction-error①">5.5. Aborting a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-read-only-transaction">
-   <b><a href="#transaction-read-only-transaction">#transaction-read-only-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-read-only-transaction" class="dfn-panel" data-for="transaction-read-only-transaction" id="infopanel-for-transaction-read-only-transaction" role="dialog">
+   <span id="infopaneltitle-for-transaction-read-only-transaction" style="display:none">Info about the 'read-only transaction' definition.</span><b><a href="#transaction-read-only-transaction">#transaction-read-only-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-read-only-transaction">2.7. Transactions</a>
     <li><a href="#ref-for-transaction-read-only-transaction①">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-read-only-transaction②">(2)</a> <a href="#ref-for-transaction-read-only-transaction③">(3)</a>
@@ -10405,14 +10406,14 @@ specification.</p>
     <li><a href="#ref-for-transaction-read-only-transaction⑧">4.8. The IDBCursor interface</a> <a href="#ref-for-transaction-read-only-transaction⑨">(2)</a> <a href="#ref-for-transaction-read-only-transaction①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-read-write-transaction">
-   <b><a href="#transaction-read-write-transaction">#transaction-read-write-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-read-write-transaction" class="dfn-panel" data-for="transaction-read-write-transaction" id="infopanel-for-transaction-read-write-transaction" role="dialog">
+   <span id="infopaneltitle-for-transaction-read-write-transaction" style="display:none">Info about the 'read/write transaction' definition.</span><b><a href="#transaction-read-write-transaction">#transaction-read-write-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-read-write-transaction">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-read-write-transaction①">(2)</a> <a href="#ref-for-transaction-read-write-transaction②">(3)</a> <a href="#ref-for-transaction-read-write-transaction③">(4)</a> <a href="#ref-for-transaction-read-write-transaction④">(5)</a> <a href="#ref-for-transaction-read-write-transaction⑤">(6)</a> <a href="#ref-for-transaction-read-write-transaction⑥">(7)</a> <a href="#ref-for-transaction-read-write-transaction⑦">(8)</a> <a href="#ref-for-transaction-read-write-transaction⑧">(9)</a> <a href="#ref-for-transaction-read-write-transaction⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-state">
-   <b><a href="#transaction-state">#transaction-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-state" class="dfn-panel" data-for="transaction-state" id="infopanel-for-transaction-state" role="dialog">
+   <span id="infopaneltitle-for-transaction-state" style="display:none">Info about the 'state' definition.</span><b><a href="#transaction-state">#transaction-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-state">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-state①">(2)</a> <a href="#ref-for-transaction-state②">(3)</a> <a href="#ref-for-transaction-state③">(4)</a> <a href="#ref-for-transaction-state④">(5)</a> <a href="#ref-for-transaction-state⑤">(6)</a>
     <li><a href="#ref-for-transaction-state⑥">4.4. The IDBDatabase interface</a> <a href="#ref-for-transaction-state⑦">(2)</a>
@@ -10429,8 +10430,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-state⑤⑥">5.11. Clone a value</a> <a href="#ref-for-transaction-state⑤⑦">(2)</a> <a href="#ref-for-transaction-state⑤⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-active">
-   <b><a href="#transaction-active">#transaction-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-active" class="dfn-panel" data-for="transaction-active" id="infopanel-for-transaction-active" role="dialog">
+   <span id="infopaneltitle-for-transaction-active" style="display:none">Info about the 'active' definition.</span><b><a href="#transaction-active">#transaction-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-active">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-active①">(2)</a> <a href="#ref-for-transaction-active②">(3)</a> <a href="#ref-for-transaction-active③">(4)</a>
     <li><a href="#ref-for-transaction-active④">2.10. Cursor</a>
@@ -10446,8 +10447,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-active④⑧">5.11. Clone a value</a> <a href="#ref-for-transaction-active④⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-inactive">
-   <b><a href="#transaction-inactive">#transaction-inactive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-inactive" class="dfn-panel" data-for="transaction-inactive" id="infopanel-for-transaction-inactive" role="dialog">
+   <span id="infopaneltitle-for-transaction-inactive" style="display:none">Info about the 'inactive' definition.</span><b><a href="#transaction-inactive">#transaction-inactive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-inactive">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-inactive①">(2)</a>
     <li><a href="#ref-for-transaction-inactive②">4.9. The IDBTransaction interface</a>
@@ -10457,8 +10458,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-inactive⑨">5.11. Clone a value</a> <a href="#ref-for-transaction-inactive①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-committing">
-   <b><a href="#transaction-committing">#transaction-committing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-committing" class="dfn-panel" data-for="transaction-committing" id="infopanel-for-transaction-committing" role="dialog">
+   <span id="infopaneltitle-for-transaction-committing" style="display:none">Info about the 'committing' definition.</span><b><a href="#transaction-committing">#transaction-committing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-committing">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-transaction-committing①">4.9. The IDBTransaction interface</a>
@@ -10467,8 +10468,8 @@ specification.</p>
     <li><a href="#ref-for-transaction-committing⑤">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-finished">
-   <b><a href="#transaction-finished">#transaction-finished</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-finished" class="dfn-panel" data-for="transaction-finished" id="infopanel-for-transaction-finished" role="dialog">
+   <span id="infopaneltitle-for-transaction-finished" style="display:none">Info about the 'finished' definition.</span><b><a href="#transaction-finished">#transaction-finished</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-finished">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-finished①">(2)</a>
     <li><a href="#ref-for-transaction-finished②">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-finished③">(2)</a> <a href="#ref-for-transaction-finished④">(3)</a> <a href="#ref-for-transaction-finished⑤">(4)</a>
@@ -10481,15 +10482,15 @@ specification.</p>
     <li><a href="#ref-for-transaction-finished①⑧">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-lifetime">
-   <b><a href="#transaction-lifetime">#transaction-lifetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-lifetime" class="dfn-panel" data-for="transaction-lifetime" id="infopanel-for-transaction-lifetime" role="dialog">
+   <span id="infopaneltitle-for-transaction-lifetime" style="display:none">Info about the 'lifetime' definition.</span><b><a href="#transaction-lifetime">#transaction-lifetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-lifetime">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-transaction-lifetime①">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-created">
-   <b><a href="#transaction-created">#transaction-created</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-created" class="dfn-panel" data-for="transaction-created" id="infopanel-for-transaction-created" role="dialog">
+   <span id="infopaneltitle-for-transaction-created" style="display:none">Info about the 'created' definition.</span><b><a href="#transaction-created">#transaction-created</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-created">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-transaction-created①">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-created②">(2)</a> <a href="#ref-for-transaction-created③">(3)</a> <a href="#ref-for-transaction-created④">(4)</a>
@@ -10497,15 +10498,15 @@ specification.</p>
     <li><a href="#ref-for-transaction-created⑥">5.2. Closing a database</a> <a href="#ref-for-transaction-created⑦">(2)</a> <a href="#ref-for-transaction-created⑧">(3)</a> <a href="#ref-for-transaction-created⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-start">
-   <b><a href="#transaction-start">#transaction-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-start" class="dfn-panel" data-for="transaction-start" id="infopanel-for-transaction-start" role="dialog">
+   <span id="infopaneltitle-for-transaction-start" style="display:none">Info about the 'start' definition.</span><b><a href="#transaction-start">#transaction-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-start">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-start①">(2)</a> <a href="#ref-for-transaction-start②">(3)</a> <a href="#ref-for-transaction-start③">(4)</a>
     <li><a href="#ref-for-transaction-start④">2.7.2. Transaction scheduling</a> <a href="#ref-for-transaction-start⑤">(2)</a> <a href="#ref-for-transaction-start⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-abort">
-   <b><a href="#transaction-abort">#transaction-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-abort" class="dfn-panel" data-for="transaction-abort" id="infopanel-for-transaction-abort" role="dialog">
+   <span id="infopaneltitle-for-transaction-abort" style="display:none">Info about the 'aborted' definition.</span><b><a href="#transaction-abort">#transaction-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-abort">2.7. Transactions</a>
     <li><a href="#ref-for-transaction-abort①">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-abort②">(2)</a> <a href="#ref-for-transaction-abort③">(3)</a> <a href="#ref-for-transaction-abort④">(4)</a>
@@ -10515,38 +10516,38 @@ specification.</p>
     <li><a href="#ref-for-transaction-abort⑨">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transaction-commit">
-   <b><a href="#transaction-commit">#transaction-commit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transaction-commit" class="dfn-panel" data-for="transaction-commit" id="infopanel-for-transaction-commit" role="dialog">
+   <span id="infopaneltitle-for-transaction-commit" style="display:none">Info about the 'commit' definition.</span><b><a href="#transaction-commit">#transaction-commit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transaction-commit">2.7. Transactions</a> <a href="#ref-for-transaction-commit①">(2)</a>
     <li><a href="#ref-for-transaction-commit②">2.7.1. Transaction lifecycle</a> <a href="#ref-for-transaction-commit③">(2)</a> <a href="#ref-for-transaction-commit④">(3)</a> <a href="#ref-for-transaction-commit⑤">(4)</a> <a href="#ref-for-transaction-commit⑥">(5)</a>
     <li><a href="#ref-for-transaction-commit⑦">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cleanup-indexed-database-transactions">
-   <b><a href="#cleanup-indexed-database-transactions">#cleanup-indexed-database-transactions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cleanup-indexed-database-transactions" class="dfn-panel" data-for="cleanup-indexed-database-transactions" id="infopanel-for-cleanup-indexed-database-transactions" role="dialog">
+   <span id="infopaneltitle-for-cleanup-indexed-database-transactions" style="display:none">Info about the 'cleanup Indexed Database transactions' definition.</span><b><a href="#cleanup-indexed-database-transactions">#cleanup-indexed-database-transactions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cleanup-indexed-database-transactions">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-transaction-complete">
-   <b><a href="#eventdef-transaction-complete">#eventdef-transaction-complete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-transaction-complete" class="dfn-panel" data-for="eventdef-transaction-complete" id="infopanel-for-eventdef-transaction-complete" role="dialog">
+   <span id="infopaneltitle-for-eventdef-transaction-complete" style="display:none">Info about the 'complete' definition.</span><b><a href="#eventdef-transaction-complete">#eventdef-transaction-complete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-transaction-complete">2.7. Transactions</a>
     <li><a href="#ref-for-eventdef-transaction-complete①">4.9. The IDBTransaction interface</a> <a href="#ref-for-eventdef-transaction-complete②">(2)</a>
     <li><a href="#ref-for-eventdef-transaction-complete③">5.4. Committing a transaction</a> <a href="#ref-for-eventdef-transaction-complete④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-transaction-abort">
-   <b><a href="#eventdef-transaction-abort">#eventdef-transaction-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-transaction-abort" class="dfn-panel" data-for="eventdef-transaction-abort" id="infopanel-for-eventdef-transaction-abort" role="dialog">
+   <span id="infopaneltitle-for-eventdef-transaction-abort" style="display:none">Info about the 'abort' definition.</span><b><a href="#eventdef-transaction-abort">#eventdef-transaction-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-transaction-abort">4.4. The IDBDatabase interface</a> <a href="#ref-for-eventdef-transaction-abort①">(2)</a>
     <li><a href="#ref-for-eventdef-transaction-abort②">4.9. The IDBTransaction interface</a>
     <li><a href="#ref-for-eventdef-transaction-abort③">5.5. Aborting a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-transaction">
-   <b><a href="#upgrade-transaction">#upgrade-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-transaction" class="dfn-panel" data-for="upgrade-transaction" id="infopanel-for-upgrade-transaction" role="dialog">
+   <span id="infopaneltitle-for-upgrade-transaction" style="display:none">Info about the 'upgrade transaction' definition.</span><b><a href="#upgrade-transaction">#upgrade-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-transaction">2.1. Database</a> <a href="#ref-for-upgrade-transaction①">(2)</a>
     <li><a href="#ref-for-upgrade-transaction②">2.1.1. Database connection</a>
@@ -10568,8 +10569,8 @@ specification.</p>
     <li><a href="#ref-for-upgrade-transaction⑤⑤">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request">
-   <b><a href="#request">#request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request" class="dfn-panel" data-for="request" id="infopanel-for-request" role="dialog">
+   <span id="infopaneltitle-for-request" style="display:none">Info about the 'request' definition.</span><b><a href="#request">#request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">2.7. Transactions</a>
     <li><a href="#ref-for-request①">2.7.1. Transaction lifecycle</a> <a href="#ref-for-request②">(2)</a> <a href="#ref-for-request③">(3)</a> <a href="#ref-for-request④">(4)</a> <a href="#ref-for-request⑤">(5)</a> <a href="#ref-for-request⑥">(6)</a> <a href="#ref-for-request⑦">(7)</a> <a href="#ref-for-request⑧">(8)</a> <a href="#ref-for-request⑨">(9)</a> <a href="#ref-for-request①⓪">(10)</a> <a href="#ref-for-request①①">(11)</a>
@@ -10586,8 +10587,8 @@ specification.</p>
     <li><a href="#ref-for-request④⓪">5.10. Firing an error event</a> <a href="#ref-for-request④①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-processed-flag">
-   <b><a href="#request-processed-flag">#request-processed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-processed-flag" class="dfn-panel" data-for="request-processed-flag" id="infopanel-for-request-processed-flag" role="dialog">
+   <span id="infopaneltitle-for-request-processed-flag" style="display:none">Info about the 'processed flag' definition.</span><b><a href="#request-processed-flag">#request-processed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-processed-flag">2.8. Requests</a>
     <li><a href="#ref-for-request-processed-flag①">4.3. The IDBFactory interface</a>
@@ -10597,16 +10598,16 @@ specification.</p>
     <li><a href="#ref-for-request-processed-flag⑧">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-processed">
-   <b><a href="#request-processed">#request-processed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-processed" class="dfn-panel" data-for="request-processed" id="infopanel-for-request-processed" role="dialog">
+   <span id="infopaneltitle-for-request-processed" style="display:none">Info about the 'processed' definition.</span><b><a href="#request-processed">#request-processed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-processed">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-request-processed①">5.4. Committing a transaction</a>
     <li><a href="#ref-for-request-processed②">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-done-flag">
-   <b><a href="#request-done-flag">#request-done-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-done-flag" class="dfn-panel" data-for="request-done-flag" id="infopanel-for-request-done-flag" role="dialog">
+   <span id="infopaneltitle-for-request-done-flag" style="display:none">Info about the 'done flag' definition.</span><b><a href="#request-done-flag">#request-done-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-done-flag">2.8. Requests</a> <a href="#ref-for-request-done-flag①">(2)</a> <a href="#ref-for-request-done-flag②">(3)</a> <a href="#ref-for-request-done-flag③">(4)</a> <a href="#ref-for-request-done-flag④">(5)</a>
     <li><a href="#ref-for-request-done-flag⑤">4.1. The IDBRequest interface</a> <a href="#ref-for-request-done-flag⑥">(2)</a> <a href="#ref-for-request-done-flag⑦">(3)</a>
@@ -10617,16 +10618,16 @@ specification.</p>
     <li><a href="#ref-for-request-done-flag①⑧">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-source">
-   <b><a href="#request-source">#request-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-source" class="dfn-panel" data-for="request-source" id="infopanel-for-request-source" role="dialog">
+   <span id="infopaneltitle-for-request-source" style="display:none">Info about the 'source' definition.</span><b><a href="#request-source">#request-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-source">2.8.1. Open requests</a>
     <li><a href="#ref-for-request-source①">4.1. The IDBRequest interface</a> <a href="#ref-for-request-source②">(2)</a>
     <li><a href="#ref-for-request-source③">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-result">
-   <b><a href="#request-result">#request-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-result" class="dfn-panel" data-for="request-result" id="infopanel-for-request-result" role="dialog">
+   <span id="infopaneltitle-for-request-result" style="display:none">Info about the 'result' definition.</span><b><a href="#request-result">#request-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-result">2.8. Requests</a> <a href="#ref-for-request-result①">(2)</a>
     <li><a href="#ref-for-request-result②">4.1. The IDBRequest interface</a> <a href="#ref-for-request-result③">(2)</a>
@@ -10636,8 +10637,8 @@ specification.</p>
     <li><a href="#ref-for-request-result①①">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-error">
-   <b><a href="#request-error">#request-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-error" class="dfn-panel" data-for="request-error" id="infopanel-for-request-error" role="dialog">
+   <span id="infopaneltitle-for-request-error" style="display:none">Info about the 'error' definition.</span><b><a href="#request-error">#request-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-error">2.8. Requests</a> <a href="#ref-for-request-error①">(2)</a>
     <li><a href="#ref-for-request-error②">4.1. The IDBRequest interface</a> <a href="#ref-for-request-error③">(2)</a>
@@ -10648,8 +10649,8 @@ specification.</p>
     <li><a href="#ref-for-request-error①⓪">5.10. Firing an error event</a> <a href="#ref-for-request-error①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-transaction">
-   <b><a href="#request-transaction">#request-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-transaction" class="dfn-panel" data-for="request-transaction" id="infopanel-for-request-transaction" role="dialog">
+   <span id="infopaneltitle-for-request-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#request-transaction">#request-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-transaction">2.8. Requests</a>
     <li><a href="#ref-for-request-transaction①">2.8.1. Open requests</a>
@@ -10659,14 +10660,14 @@ specification.</p>
     <li><a href="#ref-for-request-transaction⑤">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-placed">
-   <b><a href="#request-placed">#request-placed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-placed" class="dfn-panel" data-for="request-placed" id="infopanel-for-request-placed" role="dialog">
+   <span id="infopaneltitle-for-request-placed" style="display:none">Info about the 'placed' definition.</span><b><a href="#request-placed">#request-placed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-placed">2.7.1. Transaction lifecycle</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-request-success">
-   <b><a href="#eventdef-request-success">#eventdef-request-success</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-request-success" class="dfn-panel" data-for="eventdef-request-success" id="infopanel-for-eventdef-request-success" role="dialog">
+   <span id="infopaneltitle-for-eventdef-request-success" style="display:none">Info about the 'success' definition.</span><b><a href="#eventdef-request-success">#eventdef-request-success</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-request-success">1. Introduction</a>
     <li><a href="#ref-for-eventdef-request-success①">2.7.1. Transaction lifecycle</a>
@@ -10677,8 +10678,8 @@ specification.</p>
     <li><a href="#ref-for-eventdef-request-success⑧">4.9. The IDBTransaction interface</a> <a href="#ref-for-eventdef-request-success⑨">(2)</a> <a href="#ref-for-eventdef-request-success①⓪">(3)</a> <a href="#ref-for-eventdef-request-success①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-request-error">
-   <b><a href="#eventdef-request-error">#eventdef-request-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-request-error" class="dfn-panel" data-for="eventdef-request-error" id="infopanel-for-eventdef-request-error" role="dialog">
+   <span id="infopaneltitle-for-eventdef-request-error" style="display:none">Info about the 'error' definition.</span><b><a href="#eventdef-request-error">#eventdef-request-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-request-error">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-eventdef-request-error①">2.8.1. Open requests</a>
@@ -10689,8 +10690,8 @@ specification.</p>
     <li><a href="#ref-for-eventdef-request-error⑨">5.5. Aborting a transaction</a> <a href="#ref-for-eventdef-request-error①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-open-request">
-   <b><a href="#request-open-request">#request-open-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-open-request" class="dfn-panel" data-for="request-open-request" id="infopanel-for-request-open-request" role="dialog">
+   <span id="infopaneltitle-for-request-open-request" style="display:none">Info about the 'open request' definition.</span><b><a href="#request-open-request">#request-open-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-open-request">2.8. Requests</a>
     <li><a href="#ref-for-request-open-request①">2.8.1. Open requests</a> <a href="#ref-for-request-open-request②">(2)</a> <a href="#ref-for-request-open-request③">(3)</a> <a href="#ref-for-request-open-request④">(4)</a> <a href="#ref-for-request-open-request⑤">(5)</a> <a href="#ref-for-request-open-request⑥">(6)</a> <a href="#ref-for-request-open-request⑦">(7)</a>
@@ -10699,8 +10700,8 @@ specification.</p>
     <li><a href="#ref-for-request-open-request①③">5.5. Aborting a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-request-blocked">
-   <b><a href="#eventdef-request-blocked">#eventdef-request-blocked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-request-blocked" class="dfn-panel" data-for="eventdef-request-blocked" id="infopanel-for-eventdef-request-blocked" role="dialog">
+   <span id="infopaneltitle-for-eventdef-request-blocked" style="display:none">Info about the 'blocked' definition.</span><b><a href="#eventdef-request-blocked">#eventdef-request-blocked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-request-blocked">1. Introduction</a> <a href="#ref-for-eventdef-request-blocked①">(2)</a>
     <li><a href="#ref-for-eventdef-request-blocked②">4.1. The IDBRequest interface</a> <a href="#ref-for-eventdef-request-blocked③">(2)</a>
@@ -10708,8 +10709,8 @@ specification.</p>
     <li><a href="#ref-for-eventdef-request-blocked⑤">5.3. Deleting a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-request-upgradeneeded">
-   <b><a href="#eventdef-request-upgradeneeded">#eventdef-request-upgradeneeded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-request-upgradeneeded" class="dfn-panel" data-for="eventdef-request-upgradeneeded" id="infopanel-for-eventdef-request-upgradeneeded" role="dialog">
+   <span id="infopaneltitle-for-eventdef-request-upgradeneeded" style="display:none">Info about the 'upgradeneeded' definition.</span><b><a href="#eventdef-request-upgradeneeded">#eventdef-request-upgradeneeded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-request-upgradeneeded">1. Introduction</a> <a href="#ref-for-eventdef-request-upgradeneeded①">(2)</a>
     <li><a href="#ref-for-eventdef-request-upgradeneeded②">2.2. Object store</a>
@@ -10721,16 +10722,16 @@ specification.</p>
     <li><a href="#ref-for-eventdef-request-upgradeneeded①⓪">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-connection-queue">
-   <b><a href="#request-connection-queue">#request-connection-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-connection-queue" class="dfn-panel" data-for="request-connection-queue" id="infopanel-for-request-connection-queue" role="dialog">
+   <span id="infopaneltitle-for-request-connection-queue" style="display:none">Info about the 'connection queue' definition.</span><b><a href="#request-connection-queue">#request-connection-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-connection-queue">2.8.1. Open requests</a> <a href="#ref-for-request-connection-queue①">(2)</a>
     <li><a href="#ref-for-request-connection-queue②">5.1. Opening a database</a>
     <li><a href="#ref-for-request-connection-queue③">5.3. Deleting a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-range">
-   <b><a href="#key-range">#key-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-range" class="dfn-panel" data-for="key-range" id="infopanel-for-key-range" role="dialog">
+   <span id="infopaneltitle-for-key-range" style="display:none">Info about the 'key range' definition.</span><b><a href="#key-range">#key-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-range">2.9. Key range</a> <a href="#ref-for-key-range①">(2)</a> <a href="#ref-for-key-range②">(3)</a> <a href="#ref-for-key-range③">(4)</a> <a href="#ref-for-key-range④">(5)</a> <a href="#ref-for-key-range⑤">(6)</a> <a href="#ref-for-key-range⑥">(7)</a> <a href="#ref-for-key-range⑦">(8)</a> <a href="#ref-for-key-range⑧">(9)</a> <a href="#ref-for-key-range⑨">(10)</a> <a href="#ref-for-key-range①⓪">(11)</a> <a href="#ref-for-key-range①①">(12)</a> <a href="#ref-for-key-range①②">(13)</a> <a href="#ref-for-key-range①③">(14)</a> <a href="#ref-for-key-range①④">(15)</a> <a href="#ref-for-key-range①⑤">(16)</a> <a href="#ref-for-key-range①⑥">(17)</a> <a href="#ref-for-key-range①⑦">(18)</a> <a href="#ref-for-key-range①⑧">(19)</a>
     <li><a href="#ref-for-key-range①⑨">4.5. The IDBObjectStore interface</a> <a href="#ref-for-key-range②⓪">(2)</a> <a href="#ref-for-key-range②①">(3)</a> <a href="#ref-for-key-range②②">(4)</a> <a href="#ref-for-key-range②③">(5)</a> <a href="#ref-for-key-range②④">(6)</a> <a href="#ref-for-key-range②⑤">(7)</a> <a href="#ref-for-key-range②⑥">(8)</a> <a href="#ref-for-key-range②⑦">(9)</a> <a href="#ref-for-key-range②⑧">(10)</a> <a href="#ref-for-key-range②⑨">(11)</a> <a href="#ref-for-key-range③⓪">(12)</a> <a href="#ref-for-key-range③①">(13)</a> <a href="#ref-for-key-range③②">(14)</a>
@@ -10738,43 +10739,43 @@ specification.</p>
     <li><a href="#ref-for-key-range④⑤">4.7. The IDBKeyRange interface</a> <a href="#ref-for-key-range④⑥">(2)</a> <a href="#ref-for-key-range④⑦">(3)</a> <a href="#ref-for-key-range④⑧">(4)</a> <a href="#ref-for-key-range④⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-range-lower-bound">
-   <b><a href="#key-range-lower-bound">#key-range-lower-bound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-range-lower-bound" class="dfn-panel" data-for="key-range-lower-bound" id="infopanel-for-key-range-lower-bound" role="dialog">
+   <span id="infopaneltitle-for-key-range-lower-bound" style="display:none">Info about the 'lower bound' definition.</span><b><a href="#key-range-lower-bound">#key-range-lower-bound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-range-lower-bound">2.9. Key range</a> <a href="#ref-for-key-range-lower-bound①">(2)</a> <a href="#ref-for-key-range-lower-bound②">(3)</a> <a href="#ref-for-key-range-lower-bound③">(4)</a> <a href="#ref-for-key-range-lower-bound④">(5)</a> <a href="#ref-for-key-range-lower-bound⑤">(6)</a> <a href="#ref-for-key-range-lower-bound⑥">(7)</a>
     <li><a href="#ref-for-key-range-lower-bound⑦">4.7. The IDBKeyRange interface</a> <a href="#ref-for-key-range-lower-bound⑧">(2)</a> <a href="#ref-for-key-range-lower-bound⑨">(3)</a> <a href="#ref-for-key-range-lower-bound①⓪">(4)</a> <a href="#ref-for-key-range-lower-bound①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-range-upper-bound">
-   <b><a href="#key-range-upper-bound">#key-range-upper-bound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-range-upper-bound" class="dfn-panel" data-for="key-range-upper-bound" id="infopanel-for-key-range-upper-bound" role="dialog">
+   <span id="infopaneltitle-for-key-range-upper-bound" style="display:none">Info about the 'upper bound' definition.</span><b><a href="#key-range-upper-bound">#key-range-upper-bound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-range-upper-bound">2.9. Key range</a> <a href="#ref-for-key-range-upper-bound①">(2)</a> <a href="#ref-for-key-range-upper-bound②">(3)</a> <a href="#ref-for-key-range-upper-bound③">(4)</a> <a href="#ref-for-key-range-upper-bound④">(5)</a> <a href="#ref-for-key-range-upper-bound⑤">(6)</a> <a href="#ref-for-key-range-upper-bound⑥">(7)</a>
     <li><a href="#ref-for-key-range-upper-bound⑦">4.7. The IDBKeyRange interface</a> <a href="#ref-for-key-range-upper-bound⑧">(2)</a> <a href="#ref-for-key-range-upper-bound⑨">(3)</a> <a href="#ref-for-key-range-upper-bound①⓪">(4)</a> <a href="#ref-for-key-range-upper-bound①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-range-lower-open-flag">
-   <b><a href="#key-range-lower-open-flag">#key-range-lower-open-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-range-lower-open-flag" class="dfn-panel" data-for="key-range-lower-open-flag" id="infopanel-for-key-range-lower-open-flag" role="dialog">
+   <span id="infopaneltitle-for-key-range-lower-open-flag" style="display:none">Info about the 'lower open flag' definition.</span><b><a href="#key-range-lower-open-flag">#key-range-lower-open-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-range-lower-open-flag">2.9. Key range</a> <a href="#ref-for-key-range-lower-open-flag①">(2)</a> <a href="#ref-for-key-range-lower-open-flag②">(3)</a>
     <li><a href="#ref-for-key-range-lower-open-flag③">4.7. The IDBKeyRange interface</a> <a href="#ref-for-key-range-lower-open-flag④">(2)</a> <a href="#ref-for-key-range-lower-open-flag⑤">(3)</a> <a href="#ref-for-key-range-lower-open-flag⑥">(4)</a> <a href="#ref-for-key-range-lower-open-flag⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-range-upper-open-flag">
-   <b><a href="#key-range-upper-open-flag">#key-range-upper-open-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-range-upper-open-flag" class="dfn-panel" data-for="key-range-upper-open-flag" id="infopanel-for-key-range-upper-open-flag" role="dialog">
+   <span id="infopaneltitle-for-key-range-upper-open-flag" style="display:none">Info about the 'upper open flag' definition.</span><b><a href="#key-range-upper-open-flag">#key-range-upper-open-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-range-upper-open-flag">2.9. Key range</a> <a href="#ref-for-key-range-upper-open-flag①">(2)</a> <a href="#ref-for-key-range-upper-open-flag②">(3)</a>
     <li><a href="#ref-for-key-range-upper-open-flag③">4.7. The IDBKeyRange interface</a> <a href="#ref-for-key-range-upper-open-flag④">(2)</a> <a href="#ref-for-key-range-upper-open-flag⑤">(3)</a> <a href="#ref-for-key-range-upper-open-flag⑥">(4)</a> <a href="#ref-for-key-range-upper-open-flag⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containing-only">
-   <b><a href="#containing-only">#containing-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containing-only" class="dfn-panel" data-for="containing-only" id="infopanel-for-containing-only" role="dialog">
+   <span id="infopaneltitle-for-containing-only" style="display:none">Info about the 'containing only' definition.</span><b><a href="#containing-only">#containing-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-only">2.9. Key range</a>
     <li><a href="#ref-for-containing-only①">4.7. The IDBKeyRange interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in">
-   <b><a href="#in">#in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in" class="dfn-panel" data-for="in" id="infopanel-for-in" role="dialog">
+   <span id="infopaneltitle-for-in" style="display:none">Info about the 'in a key range' definition.</span><b><a href="#in">#in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">2.9. Key range</a>
     <li><a href="#ref-for-in①">4.7. The IDBKeyRange interface</a>
@@ -10785,23 +10786,23 @@ specification.</p>
     <li><a href="#ref-for-in①③">6.7. Cursor iteration operation</a> <a href="#ref-for-in①④">(2)</a> <a href="#ref-for-in①⑤">(3)</a> <a href="#ref-for-in①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unbounded-key-range">
-   <b><a href="#unbounded-key-range">#unbounded-key-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unbounded-key-range" class="dfn-panel" data-for="unbounded-key-range" id="infopanel-for-unbounded-key-range" role="dialog">
+   <span id="infopaneltitle-for-unbounded-key-range" style="display:none">Info about the 'unbounded key range' definition.</span><b><a href="#unbounded-key-range">#unbounded-key-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unbounded-key-range">2.9. Key range</a> <a href="#ref-for-unbounded-key-range①">(2)</a>
     <li><a href="#ref-for-unbounded-key-range②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-unbounded-key-range③">(2)</a> <a href="#ref-for-unbounded-key-range④">(3)</a> <a href="#ref-for-unbounded-key-range⑤">(4)</a> <a href="#ref-for-unbounded-key-range⑥">(5)</a>
     <li><a href="#ref-for-unbounded-key-range⑦">4.6. The IDBIndex interface</a> <a href="#ref-for-unbounded-key-range⑧">(2)</a> <a href="#ref-for-unbounded-key-range⑨">(3)</a> <a href="#ref-for-unbounded-key-range①⓪">(4)</a> <a href="#ref-for-unbounded-key-range①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-value-to-a-key-range">
-   <b><a href="#convert-a-value-to-a-key-range">#convert-a-value-to-a-key-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-value-to-a-key-range" class="dfn-panel" data-for="convert-a-value-to-a-key-range" id="infopanel-for-convert-a-value-to-a-key-range" role="dialog">
+   <span id="infopaneltitle-for-convert-a-value-to-a-key-range" style="display:none">Info about the 'convert a value to a key range' definition.</span><b><a href="#convert-a-value-to-a-key-range">#convert-a-value-to-a-key-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-value-to-a-key-range">4.5. The IDBObjectStore interface</a> <a href="#ref-for-convert-a-value-to-a-key-range①">(2)</a> <a href="#ref-for-convert-a-value-to-a-key-range②">(3)</a> <a href="#ref-for-convert-a-value-to-a-key-range③">(4)</a> <a href="#ref-for-convert-a-value-to-a-key-range④">(5)</a> <a href="#ref-for-convert-a-value-to-a-key-range⑤">(6)</a> <a href="#ref-for-convert-a-value-to-a-key-range⑥">(7)</a> <a href="#ref-for-convert-a-value-to-a-key-range⑦">(8)</a>
     <li><a href="#ref-for-convert-a-value-to-a-key-range⑧">4.6. The IDBIndex interface</a> <a href="#ref-for-convert-a-value-to-a-key-range⑨">(2)</a> <a href="#ref-for-convert-a-value-to-a-key-range①⓪">(3)</a> <a href="#ref-for-convert-a-value-to-a-key-range①①">(4)</a> <a href="#ref-for-convert-a-value-to-a-key-range①②">(5)</a> <a href="#ref-for-convert-a-value-to-a-key-range①③">(6)</a> <a href="#ref-for-convert-a-value-to-a-key-range①④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor">
-   <b><a href="#cursor">#cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor" class="dfn-panel" data-for="cursor" id="infopanel-for-cursor" role="dialog">
+   <span id="infopaneltitle-for-cursor" style="display:none">Info about the 'cursor' definition.</span><b><a href="#cursor">#cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor">2.8. Requests</a>
     <li><a href="#ref-for-cursor①">2.10. Cursor</a> <a href="#ref-for-cursor②">(2)</a> <a href="#ref-for-cursor③">(3)</a> <a href="#ref-for-cursor④">(4)</a> <a href="#ref-for-cursor⑤">(5)</a> <a href="#ref-for-cursor⑥">(6)</a> <a href="#ref-for-cursor⑦">(7)</a> <a href="#ref-for-cursor⑧">(8)</a> <a href="#ref-for-cursor⑨">(9)</a> <a href="#ref-for-cursor①⓪">(10)</a> <a href="#ref-for-cursor①①">(11)</a> <a href="#ref-for-cursor①②">(12)</a> <a href="#ref-for-cursor①③">(13)</a> <a href="#ref-for-cursor①④">(14)</a> <a href="#ref-for-cursor①⑤">(15)</a>
@@ -10810,16 +10811,16 @@ specification.</p>
     <li><a href="#ref-for-cursor②⑧">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor②⑨">(2)</a> <a href="#ref-for-cursor③⓪">(3)</a> <a href="#ref-for-cursor③①">(4)</a> <a href="#ref-for-cursor③②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-transaction">
-   <b><a href="#cursor-transaction">#cursor-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-transaction" class="dfn-panel" data-for="cursor-transaction" id="infopanel-for-cursor-transaction" role="dialog">
+   <span id="infopaneltitle-for-cursor-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#cursor-transaction">#cursor-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-transaction">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-transaction①">(2)</a>
     <li><a href="#ref-for-cursor-transaction②">4.6. The IDBIndex interface</a> <a href="#ref-for-cursor-transaction③">(2)</a>
     <li><a href="#ref-for-cursor-transaction④">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor-transaction⑤">(2)</a> <a href="#ref-for-cursor-transaction⑥">(3)</a> <a href="#ref-for-cursor-transaction⑦">(4)</a> <a href="#ref-for-cursor-transaction⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-range">
-   <b><a href="#cursor-range">#cursor-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-range" class="dfn-panel" data-for="cursor-range" id="infopanel-for-cursor-range" role="dialog">
+   <span id="infopaneltitle-for-cursor-range" style="display:none">Info about the 'range' definition.</span><b><a href="#cursor-range">#cursor-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-range">2.10. Cursor</a> <a href="#ref-for-cursor-range①">(2)</a>
     <li><a href="#ref-for-cursor-range②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-range③">(2)</a> <a href="#ref-for-cursor-range④">(3)</a> <a href="#ref-for-cursor-range⑤">(4)</a>
@@ -10827,8 +10828,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-range①⓪">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-source">
-   <b><a href="#cursor-source">#cursor-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-source" class="dfn-panel" data-for="cursor-source" id="infopanel-for-cursor-source" role="dialog">
+   <span id="infopaneltitle-for-cursor-source" style="display:none">Info about the 'source' definition.</span><b><a href="#cursor-source">#cursor-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-source">2.10. Cursor</a> <a href="#ref-for-cursor-source①">(2)</a> <a href="#ref-for-cursor-source②">(3)</a> <a href="#ref-for-cursor-source③">(4)</a> <a href="#ref-for-cursor-source④">(5)</a> <a href="#ref-for-cursor-source⑤">(6)</a> <a href="#ref-for-cursor-source⑥">(7)</a> <a href="#ref-for-cursor-source⑦">(8)</a> <a href="#ref-for-cursor-source⑧">(9)</a>
     <li><a href="#ref-for-cursor-source⑨">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-source①⓪">(2)</a>
@@ -10837,8 +10838,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-source②④">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-direction">
-   <b><a href="#cursor-direction">#cursor-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-direction" class="dfn-panel" data-for="cursor-direction" id="infopanel-for-cursor-direction" role="dialog">
+   <span id="infopaneltitle-for-cursor-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#cursor-direction">#cursor-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-direction">2.10. Cursor</a>
     <li><a href="#ref-for-cursor-direction①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-direction②">(2)</a>
@@ -10847,8 +10848,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-direction①④">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-position">
-   <b><a href="#cursor-position">#cursor-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-position" class="dfn-panel" data-for="cursor-position" id="infopanel-for-cursor-position" role="dialog">
+   <span id="infopaneltitle-for-cursor-position" style="display:none">Info about the 'position' definition.</span><b><a href="#cursor-position">#cursor-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-position">2.10. Cursor</a> <a href="#ref-for-cursor-position①">(2)</a> <a href="#ref-for-cursor-position②">(3)</a>
     <li><a href="#ref-for-cursor-position③">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-position④">(2)</a>
@@ -10857,16 +10858,16 @@ specification.</p>
     <li><a href="#ref-for-cursor-position①③">6.7. Cursor iteration operation</a> <a href="#ref-for-cursor-position①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-object-store-position">
-   <b><a href="#cursor-object-store-position">#cursor-object-store-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-object-store-position" class="dfn-panel" data-for="cursor-object-store-position" id="infopanel-for-cursor-object-store-position" role="dialog">
+   <span id="infopaneltitle-for-cursor-object-store-position" style="display:none">Info about the 'object store position' definition.</span><b><a href="#cursor-object-store-position">#cursor-object-store-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-object-store-position">2.10. Cursor</a> <a href="#ref-for-cursor-object-store-position①">(2)</a>
     <li><a href="#ref-for-cursor-object-store-position②">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor-object-store-position③">(2)</a>
     <li><a href="#ref-for-cursor-object-store-position④">6.7. Cursor iteration operation</a> <a href="#ref-for-cursor-object-store-position⑤">(2)</a> <a href="#ref-for-cursor-object-store-position⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-key">
-   <b><a href="#cursor-key">#cursor-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-key" class="dfn-panel" data-for="cursor-key" id="infopanel-for-cursor-key" role="dialog">
+   <span id="infopaneltitle-for-cursor-key" style="display:none">Info about the 'key' definition.</span><b><a href="#cursor-key">#cursor-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-key">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-key①">(2)</a>
     <li><a href="#ref-for-cursor-key②">4.6. The IDBIndex interface</a> <a href="#ref-for-cursor-key③">(2)</a>
@@ -10874,8 +10875,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-key⑦">6.7. Cursor iteration operation</a> <a href="#ref-for-cursor-key⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-value">
-   <b><a href="#cursor-value">#cursor-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-value" class="dfn-panel" data-for="cursor-value" id="infopanel-for-cursor-value" role="dialog">
+   <span id="infopaneltitle-for-cursor-value" style="display:none">Info about the 'value' definition.</span><b><a href="#cursor-value">#cursor-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-value">2.10. Cursor</a>
     <li><a href="#ref-for-cursor-value①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-value②">(2)</a>
@@ -10884,8 +10885,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-value⑧">6.7. Cursor iteration operation</a> <a href="#ref-for-cursor-value⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-got-value-flag">
-   <b><a href="#cursor-got-value-flag">#cursor-got-value-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-got-value-flag" class="dfn-panel" data-for="cursor-got-value-flag" id="infopanel-for-cursor-got-value-flag" role="dialog">
+   <span id="infopaneltitle-for-cursor-got-value-flag" style="display:none">Info about the 'got value flag' definition.</span><b><a href="#cursor-got-value-flag">#cursor-got-value-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-got-value-flag">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-got-value-flag①">(2)</a>
     <li><a href="#ref-for-cursor-got-value-flag②">4.6. The IDBIndex interface</a> <a href="#ref-for-cursor-got-value-flag③">(2)</a>
@@ -10893,30 +10894,30 @@ specification.</p>
     <li><a href="#ref-for-cursor-got-value-flag①⑤">6.7. Cursor iteration operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-effective-object-store">
-   <b><a href="#cursor-effective-object-store">#cursor-effective-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-effective-object-store" class="dfn-panel" data-for="cursor-effective-object-store" id="infopanel-for-cursor-effective-object-store" role="dialog">
+   <span id="infopaneltitle-for-cursor-effective-object-store" style="display:none">Info about the 'effective object store' definition.</span><b><a href="#cursor-effective-object-store">#cursor-effective-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-effective-object-store">2.10. Cursor</a>
     <li><a href="#ref-for-cursor-effective-object-store①">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor-effective-object-store②">(2)</a> <a href="#ref-for-cursor-effective-object-store③">(3)</a> <a href="#ref-for-cursor-effective-object-store④">(4)</a> <a href="#ref-for-cursor-effective-object-store⑤">(5)</a> <a href="#ref-for-cursor-effective-object-store⑥">(6)</a> <a href="#ref-for-cursor-effective-object-store⑦">(7)</a> <a href="#ref-for-cursor-effective-object-store⑧">(8)</a> <a href="#ref-for-cursor-effective-object-store⑨">(9)</a> <a href="#ref-for-cursor-effective-object-store①⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-effective-key">
-   <b><a href="#cursor-effective-key">#cursor-effective-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-effective-key" class="dfn-panel" data-for="cursor-effective-key" id="infopanel-for-cursor-effective-key" role="dialog">
+   <span id="infopaneltitle-for-cursor-effective-key" style="display:none">Info about the 'effective key' definition.</span><b><a href="#cursor-effective-key">#cursor-effective-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-effective-key">2.10. Cursor</a>
     <li><a href="#ref-for-cursor-effective-key①">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor-effective-key②">(2)</a> <a href="#ref-for-cursor-effective-key③">(3)</a> <a href="#ref-for-cursor-effective-key④">(4)</a> <a href="#ref-for-cursor-effective-key⑤">(5)</a> <a href="#ref-for-cursor-effective-key⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-request">
-   <b><a href="#cursor-request">#cursor-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-request" class="dfn-panel" data-for="cursor-request" id="infopanel-for-cursor-request" role="dialog">
+   <span id="infopaneltitle-for-cursor-request" style="display:none">Info about the 'request' definition.</span><b><a href="#cursor-request">#cursor-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-request">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-request①">(2)</a>
     <li><a href="#ref-for-cursor-request②">4.6. The IDBIndex interface</a> <a href="#ref-for-cursor-request③">(2)</a>
     <li><a href="#ref-for-cursor-request④">4.8. The IDBCursor interface</a> <a href="#ref-for-cursor-request⑤">(2)</a> <a href="#ref-for-cursor-request⑥">(3)</a> <a href="#ref-for-cursor-request⑦">(4)</a> <a href="#ref-for-cursor-request⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursor-key-only-flag">
-   <b><a href="#cursor-key-only-flag">#cursor-key-only-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursor-key-only-flag" class="dfn-panel" data-for="cursor-key-only-flag" id="infopanel-for-cursor-key-only-flag" role="dialog">
+   <span id="infopaneltitle-for-cursor-key-only-flag" style="display:none">Info about the 'key only flag' definition.</span><b><a href="#cursor-key-only-flag">#cursor-key-only-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursor-key-only-flag">4.5. The IDBObjectStore interface</a> <a href="#ref-for-cursor-key-only-flag①">(2)</a> <a href="#ref-for-cursor-key-only-flag②">(3)</a>
     <li><a href="#ref-for-cursor-key-only-flag③">4.6. The IDBIndex interface</a> <a href="#ref-for-cursor-key-only-flag④">(2)</a> <a href="#ref-for-cursor-key-only-flag⑤">(3)</a>
@@ -10924,8 +10925,8 @@ specification.</p>
     <li><a href="#ref-for-cursor-key-only-flag⑨">6.7. Cursor iteration operation</a> <a href="#ref-for-cursor-key-only-flag①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-generator">
-   <b><a href="#key-generator">#key-generator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-generator" class="dfn-panel" data-for="key-generator" id="infopanel-for-key-generator" role="dialog">
+   <span id="infopaneltitle-for-key-generator" style="display:none">Info about the 'key generator' definition.</span><b><a href="#key-generator">#key-generator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-generator">2.2. Object store</a> <a href="#ref-for-key-generator①">(2)</a>
     <li><a href="#ref-for-key-generator②">2.11. Key generators</a> <a href="#ref-for-key-generator③">(2)</a> <a href="#ref-for-key-generator④">(3)</a> <a href="#ref-for-key-generator⑤">(4)</a> <a href="#ref-for-key-generator⑥">(5)</a> <a href="#ref-for-key-generator⑦">(6)</a> <a href="#ref-for-key-generator⑧">(7)</a> <a href="#ref-for-key-generator⑨">(8)</a> <a href="#ref-for-key-generator①⓪">(9)</a> <a href="#ref-for-key-generator①①">(10)</a> <a href="#ref-for-key-generator①②">(11)</a>
@@ -10935,26 +10936,26 @@ specification.</p>
     <li><a href="#ref-for-key-generator①⑨">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="key-generator-current-number">
-   <b><a href="#key-generator-current-number">#key-generator-current-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-key-generator-current-number" class="dfn-panel" data-for="key-generator-current-number" id="infopanel-for-key-generator-current-number" role="dialog">
+   <span id="infopaneltitle-for-key-generator-current-number" style="display:none">Info about the 'current number' definition.</span><b><a href="#key-generator-current-number">#key-generator-current-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-generator-current-number">2.11. Key generators</a> <a href="#ref-for-key-generator-current-number①">(2)</a> <a href="#ref-for-key-generator-current-number②">(3)</a> <a href="#ref-for-key-generator-current-number③">(4)</a> <a href="#ref-for-key-generator-current-number④">(5)</a> <a href="#ref-for-key-generator-current-number⑤">(6)</a> <a href="#ref-for-key-generator-current-number⑥">(7)</a> <a href="#ref-for-key-generator-current-number⑦">(8)</a> <a href="#ref-for-key-generator-current-number⑧">(9)</a> <a href="#ref-for-key-generator-current-number⑨">(10)</a> <a href="#ref-for-key-generator-current-number①⓪">(11)</a> <a href="#ref-for-key-generator-current-number①①">(12)</a> <a href="#ref-for-key-generator-current-number①②">(13)</a> <a href="#ref-for-key-generator-current-number①③">(14)</a> <a href="#ref-for-key-generator-current-number①④">(15)</a> <a href="#ref-for-key-generator-current-number①⑤">(16)</a> <a href="#ref-for-key-generator-current-number①⑥">(17)</a> <a href="#ref-for-key-generator-current-number①⑦">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-key">
-   <b><a href="#generate-a-key">#generate-a-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-key" class="dfn-panel" data-for="generate-a-key" id="infopanel-for-generate-a-key" role="dialog">
+   <span id="infopaneltitle-for-generate-a-key" style="display:none">Info about the 'generate a key' definition.</span><b><a href="#generate-a-key">#generate-a-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-key">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="possibly-update-the-key-generator">
-   <b><a href="#possibly-update-the-key-generator">#possibly-update-the-key-generator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-possibly-update-the-key-generator" class="dfn-panel" data-for="possibly-update-the-key-generator" id="infopanel-for-possibly-update-the-key-generator" role="dialog">
+   <span id="infopaneltitle-for-possibly-update-the-key-generator" style="display:none">Info about the 'possibly update the key generator' definition.</span><b><a href="#possibly-update-the-key-generator">#possibly-update-the-key-generator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-possibly-update-the-key-generator">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbrequest">
-   <b><a href="#idbrequest">#idbrequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbrequest" class="dfn-panel" data-for="idbrequest" id="infopanel-for-idbrequest" role="dialog">
+   <span id="infopaneltitle-for-idbrequest" style="display:none">Info about the 'IDBRequest' definition.</span><b><a href="#idbrequest">#idbrequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbrequest">4. API</a> <a href="#ref-for-idbrequest①">(2)</a>
     <li><a href="#ref-for-idbrequest②">4.1. The IDBRequest interface</a> <a href="#ref-for-idbrequest③">(2)</a> <a href="#ref-for-idbrequest④">(3)</a> <a href="#ref-for-idbrequest⑤">(4)</a>
@@ -10963,26 +10964,26 @@ specification.</p>
     <li><a href="#ref-for-idbrequest③⑨">4.8. The IDBCursor interface</a> <a href="#ref-for-idbrequest④⓪">(2)</a> <a href="#ref-for-idbrequest④①">(3)</a> <a href="#ref-for-idbrequest④②">(4)</a> <a href="#ref-for-idbrequest④③">(5)</a> <a href="#ref-for-idbrequest④④">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-idbrequestreadystate">
-   <b><a href="#enumdef-idbrequestreadystate">#enumdef-idbrequestreadystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-idbrequestreadystate" class="dfn-panel" data-for="enumdef-idbrequestreadystate" id="infopanel-for-enumdef-idbrequestreadystate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-idbrequestreadystate" style="display:none">Info about the 'IDBRequestReadyState' definition.</span><b><a href="#enumdef-idbrequestreadystate">#enumdef-idbrequestreadystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-idbrequestreadystate">4.1. The IDBRequest interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequestreadystate-pending">
-   <b><a href="#dom-idbrequestreadystate-pending">#dom-idbrequestreadystate-pending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequestreadystate-pending" class="dfn-panel" data-for="dom-idbrequestreadystate-pending" id="infopanel-for-dom-idbrequestreadystate-pending" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequestreadystate-pending" style="display:none">Info about the '"pending"' definition.</span><b><a href="#dom-idbrequestreadystate-pending">#dom-idbrequestreadystate-pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequestreadystate-pending">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequestreadystate-pending①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequestreadystate-done">
-   <b><a href="#dom-idbrequestreadystate-done">#dom-idbrequestreadystate-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequestreadystate-done" class="dfn-panel" data-for="dom-idbrequestreadystate-done" id="infopanel-for-dom-idbrequestreadystate-done" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequestreadystate-done" style="display:none">Info about the '"done"' definition.</span><b><a href="#dom-idbrequestreadystate-done">#dom-idbrequestreadystate-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequestreadystate-done">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequestreadystate-done①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-result">
-   <b><a href="#dom-idbrequest-result">#dom-idbrequest-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-result" class="dfn-panel" data-for="dom-idbrequest-result" id="infopanel-for-dom-idbrequest-result" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-result" style="display:none">Info about the 'result' definition.</span><b><a href="#dom-idbrequest-result">#dom-idbrequest-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-result">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequest-result①">(2)</a>
     <li><a href="#ref-for-dom-idbrequest-result②">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbrequest-result③">(2)</a> <a href="#ref-for-dom-idbrequest-result④">(3)</a>
@@ -10991,90 +10992,90 @@ specification.</p>
     <li><a href="#ref-for-dom-idbrequest-result②②">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbrequest-result②③">(2)</a> <a href="#ref-for-dom-idbrequest-result②④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-error">
-   <b><a href="#dom-idbrequest-error">#dom-idbrequest-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-error" class="dfn-panel" data-for="dom-idbrequest-error" id="infopanel-for-dom-idbrequest-error" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-idbrequest-error">#dom-idbrequest-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-error">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequest-error①">(2)</a>
     <li><a href="#ref-for-dom-idbrequest-error②">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-source">
-   <b><a href="#dom-idbrequest-source">#dom-idbrequest-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-source" class="dfn-panel" data-for="dom-idbrequest-source" id="infopanel-for-dom-idbrequest-source" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-idbrequest-source">#dom-idbrequest-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-source">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequest-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-transaction">
-   <b><a href="#dom-idbrequest-transaction">#dom-idbrequest-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-transaction" class="dfn-panel" data-for="dom-idbrequest-transaction" id="infopanel-for-dom-idbrequest-transaction" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#dom-idbrequest-transaction">#dom-idbrequest-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-transaction">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequest-transaction①">(2)</a> <a href="#ref-for-dom-idbrequest-transaction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-readystate">
-   <b><a href="#dom-idbrequest-readystate">#dom-idbrequest-readystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-readystate" class="dfn-panel" data-for="dom-idbrequest-readystate" id="infopanel-for-dom-idbrequest-readystate" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-readystate" style="display:none">Info about the 'readyState' definition.</span><b><a href="#dom-idbrequest-readystate">#dom-idbrequest-readystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-readystate">4.1. The IDBRequest interface</a> <a href="#ref-for-dom-idbrequest-readystate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-onsuccess">
-   <b><a href="#dom-idbrequest-onsuccess">#dom-idbrequest-onsuccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-onsuccess" class="dfn-panel" data-for="dom-idbrequest-onsuccess" id="infopanel-for-dom-idbrequest-onsuccess" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-onsuccess" style="display:none">Info about the 'onsuccess' definition.</span><b><a href="#dom-idbrequest-onsuccess">#dom-idbrequest-onsuccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-onsuccess">4.1. The IDBRequest interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbrequest-onerror">
-   <b><a href="#dom-idbrequest-onerror">#dom-idbrequest-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbrequest-onerror" class="dfn-panel" data-for="dom-idbrequest-onerror" id="infopanel-for-dom-idbrequest-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-idbrequest-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-idbrequest-onerror">#dom-idbrequest-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-onerror">4.1. The IDBRequest interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbopendbrequest">
-   <b><a href="#idbopendbrequest">#idbopendbrequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbopendbrequest" class="dfn-panel" data-for="idbopendbrequest" id="infopanel-for-idbopendbrequest" role="dialog">
+   <span id="infopaneltitle-for-idbopendbrequest" style="display:none">Info about the 'IDBOpenDBRequest' definition.</span><b><a href="#idbopendbrequest">#idbopendbrequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbopendbrequest">4.3. The IDBFactory interface</a> <a href="#ref-for-idbopendbrequest①">(2)</a> <a href="#ref-for-idbopendbrequest②">(3)</a> <a href="#ref-for-idbopendbrequest③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbopendbrequest-onblocked">
-   <b><a href="#dom-idbopendbrequest-onblocked">#dom-idbopendbrequest-onblocked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbopendbrequest-onblocked" class="dfn-panel" data-for="dom-idbopendbrequest-onblocked" id="infopanel-for-dom-idbopendbrequest-onblocked" role="dialog">
+   <span id="infopaneltitle-for-dom-idbopendbrequest-onblocked" style="display:none">Info about the 'onblocked' definition.</span><b><a href="#dom-idbopendbrequest-onblocked">#dom-idbopendbrequest-onblocked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbopendbrequest-onblocked">4.1. The IDBRequest interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbopendbrequest-onupgradeneeded">
-   <b><a href="#dom-idbopendbrequest-onupgradeneeded">#dom-idbopendbrequest-onupgradeneeded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbopendbrequest-onupgradeneeded" class="dfn-panel" data-for="dom-idbopendbrequest-onupgradeneeded" id="infopanel-for-dom-idbopendbrequest-onupgradeneeded" role="dialog">
+   <span id="infopaneltitle-for-dom-idbopendbrequest-onupgradeneeded" style="display:none">Info about the 'onupgradeneeded' definition.</span><b><a href="#dom-idbopendbrequest-onupgradeneeded">#dom-idbopendbrequest-onupgradeneeded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbopendbrequest-onupgradeneeded">4.1. The IDBRequest interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbversionchangeevent">
-   <b><a href="#idbversionchangeevent">#idbversionchangeevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbversionchangeevent" class="dfn-panel" data-for="idbversionchangeevent" id="infopanel-for-idbversionchangeevent" role="dialog">
+   <span id="infopaneltitle-for-idbversionchangeevent" style="display:none">Info about the 'IDBVersionChangeEvent' definition.</span><b><a href="#idbversionchangeevent">#idbversionchangeevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbversionchangeevent">4.2. Event interfaces</a>
     <li><a href="#ref-for-idbversionchangeevent①">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idbversionchangeeventinit">
-   <b><a href="#dictdef-idbversionchangeeventinit">#dictdef-idbversionchangeeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idbversionchangeeventinit" class="dfn-panel" data-for="dictdef-idbversionchangeeventinit" id="infopanel-for-dictdef-idbversionchangeeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idbversionchangeeventinit" style="display:none">Info about the 'IDBVersionChangeEventInit' definition.</span><b><a href="#dictdef-idbversionchangeeventinit">#dictdef-idbversionchangeeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idbversionchangeeventinit">4.2. Event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbversionchangeevent-oldversion">
-   <b><a href="#dom-idbversionchangeevent-oldversion">#dom-idbversionchangeevent-oldversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbversionchangeevent-oldversion" class="dfn-panel" data-for="dom-idbversionchangeevent-oldversion" id="infopanel-for-dom-idbversionchangeevent-oldversion" role="dialog">
+   <span id="infopaneltitle-for-dom-idbversionchangeevent-oldversion" style="display:none">Info about the 'oldVersion' definition.</span><b><a href="#dom-idbversionchangeevent-oldversion">#dom-idbversionchangeevent-oldversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbversionchangeevent-oldversion">4.2. Event interfaces</a> <a href="#ref-for-dom-idbversionchangeevent-oldversion①">(2)</a>
     <li><a href="#ref-for-dom-idbversionchangeevent-oldversion②">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbversionchangeevent-newversion">
-   <b><a href="#dom-idbversionchangeevent-newversion">#dom-idbversionchangeevent-newversion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbversionchangeevent-newversion" class="dfn-panel" data-for="dom-idbversionchangeevent-newversion" id="infopanel-for-dom-idbversionchangeevent-newversion" role="dialog">
+   <span id="infopaneltitle-for-dom-idbversionchangeevent-newversion" style="display:none">Info about the 'newVersion' definition.</span><b><a href="#dom-idbversionchangeevent-newversion">#dom-idbversionchangeevent-newversion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbversionchangeevent-newversion">4.2. Event interfaces</a> <a href="#ref-for-dom-idbversionchangeevent-newversion①">(2)</a>
     <li><a href="#ref-for-dom-idbversionchangeevent-newversion②">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-version-change-event">
-   <b><a href="#fire-a-version-change-event">#fire-a-version-change-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-version-change-event" class="dfn-panel" data-for="fire-a-version-change-event" id="infopanel-for-fire-a-version-change-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-version-change-event" style="display:none">Info about the 'fire a version change event' definition.</span><b><a href="#fire-a-version-change-event">#fire-a-version-change-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-version-change-event">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-fire-a-version-change-event①">5.1. Opening a database</a> <a href="#ref-for-fire-a-version-change-event②">(2)</a>
@@ -11082,64 +11083,64 @@ specification.</p>
     <li><a href="#ref-for-fire-a-version-change-event⑤">5.7. Running an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windoworworkerglobalscope-indexeddb">
-   <b><a href="#dom-windoworworkerglobalscope-indexeddb">#dom-windoworworkerglobalscope-indexeddb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windoworworkerglobalscope-indexeddb" class="dfn-panel" data-for="dom-windoworworkerglobalscope-indexeddb" id="infopanel-for-dom-windoworworkerglobalscope-indexeddb" role="dialog">
+   <span id="infopaneltitle-for-dom-windoworworkerglobalscope-indexeddb" style="display:none">Info about the 'indexedDB' definition.</span><b><a href="#dom-windoworworkerglobalscope-indexeddb">#dom-windoworworkerglobalscope-indexeddb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-indexeddb">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbfactory">
-   <b><a href="#idbfactory">#idbfactory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbfactory" class="dfn-panel" data-for="idbfactory" id="infopanel-for-idbfactory" role="dialog">
+   <span id="infopaneltitle-for-idbfactory" style="display:none">Info about the 'IDBFactory' definition.</span><b><a href="#idbfactory">#idbfactory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbfactory">4.3. The IDBFactory interface</a> <a href="#ref-for-idbfactory①">(2)</a> <a href="#ref-for-idbfactory②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idbdatabaseinfo">
-   <b><a href="#dictdef-idbdatabaseinfo">#dictdef-idbdatabaseinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idbdatabaseinfo" class="dfn-panel" data-for="dictdef-idbdatabaseinfo" id="infopanel-for-dictdef-idbdatabaseinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idbdatabaseinfo" style="display:none">Info about the 'IDBDatabaseInfo' definition.</span><b><a href="#dictdef-idbdatabaseinfo">#dictdef-idbdatabaseinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idbdatabaseinfo">4.3. The IDBFactory interface</a> <a href="#ref-for-dictdef-idbdatabaseinfo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabaseinfo-name">
-   <b><a href="#dom-idbdatabaseinfo-name">#dom-idbdatabaseinfo-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabaseinfo-name" class="dfn-panel" data-for="dom-idbdatabaseinfo-name" id="infopanel-for-dom-idbdatabaseinfo-name" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabaseinfo-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-idbdatabaseinfo-name">#dom-idbdatabaseinfo-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabaseinfo-name">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabaseinfo-version">
-   <b><a href="#dom-idbdatabaseinfo-version">#dom-idbdatabaseinfo-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabaseinfo-version" class="dfn-panel" data-for="dom-idbdatabaseinfo-version" id="infopanel-for-dom-idbdatabaseinfo-version" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabaseinfo-version" style="display:none">Info about the 'version' definition.</span><b><a href="#dom-idbdatabaseinfo-version">#dom-idbdatabaseinfo-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabaseinfo-version">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbfactory-open">
-   <b><a href="#dom-idbfactory-open">#dom-idbfactory-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbfactory-open" class="dfn-panel" data-for="dom-idbfactory-open" id="infopanel-for-dom-idbfactory-open" role="dialog">
+   <span id="infopaneltitle-for-dom-idbfactory-open" style="display:none">Info about the 'open(name, version)' definition.</span><b><a href="#dom-idbfactory-open">#dom-idbfactory-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-open">4.1. The IDBRequest interface</a>
     <li><a href="#ref-for-dom-idbfactory-open①">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-open②">(2)</a> <a href="#ref-for-dom-idbfactory-open③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbfactory-deletedatabase">
-   <b><a href="#dom-idbfactory-deletedatabase">#dom-idbfactory-deletedatabase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbfactory-deletedatabase" class="dfn-panel" data-for="dom-idbfactory-deletedatabase" id="infopanel-for-dom-idbfactory-deletedatabase" role="dialog">
+   <span id="infopaneltitle-for-dom-idbfactory-deletedatabase" style="display:none">Info about the 'deleteDatabase(name)' definition.</span><b><a href="#dom-idbfactory-deletedatabase">#dom-idbfactory-deletedatabase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-deletedatabase">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-deletedatabase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbfactory-databases">
-   <b><a href="#dom-idbfactory-databases">#dom-idbfactory-databases</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbfactory-databases" class="dfn-panel" data-for="dom-idbfactory-databases" id="infopanel-for-dom-idbfactory-databases" role="dialog">
+   <span id="infopaneltitle-for-dom-idbfactory-databases" style="display:none">Info about the 'databases()' definition.</span><b><a href="#dom-idbfactory-databases">#dom-idbfactory-databases</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-databases">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-databases①">(2)</a> <a href="#ref-for-dom-idbfactory-databases②">(3)</a>
     <li><a href="#ref-for-dom-idbfactory-databases③">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbfactory-cmp">
-   <b><a href="#dom-idbfactory-cmp">#dom-idbfactory-cmp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbfactory-cmp" class="dfn-panel" data-for="dom-idbfactory-cmp" id="infopanel-for-dom-idbfactory-cmp" role="dialog">
+   <span id="infopaneltitle-for-dom-idbfactory-cmp" style="display:none">Info about the 'cmp(first, second)' definition.</span><b><a href="#dom-idbfactory-cmp">#dom-idbfactory-cmp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbfactory-cmp">4.3. The IDBFactory interface</a> <a href="#ref-for-dom-idbfactory-cmp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbdatabase">
-   <b><a href="#idbdatabase">#idbdatabase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbdatabase" class="dfn-panel" data-for="idbdatabase" id="infopanel-for-idbdatabase" role="dialog">
+   <span id="infopaneltitle-for-idbdatabase" style="display:none">Info about the 'IDBDatabase' definition.</span><b><a href="#idbdatabase">#idbdatabase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbdatabase">4.1. The IDBRequest interface</a>
     <li><a href="#ref-for-idbdatabase①">4.4. The IDBDatabase interface</a> <a href="#ref-for-idbdatabase②">(2)</a> <a href="#ref-for-idbdatabase③">(3)</a> <a href="#ref-for-idbdatabase④">(4)</a> <a href="#ref-for-idbdatabase⑤">(5)</a> <a href="#ref-for-idbdatabase⑥">(6)</a> <a href="#ref-for-idbdatabase⑦">(7)</a>
@@ -11147,143 +11148,143 @@ specification.</p>
     <li><a href="#ref-for-idbdatabase⑨">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-idbdatabase①⓪">(2)</a> <a href="#ref-for-idbdatabase①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-idbtransactiondurability">
-   <b><a href="#enumdef-idbtransactiondurability">#enumdef-idbtransactiondurability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-idbtransactiondurability" class="dfn-panel" data-for="enumdef-idbtransactiondurability" id="infopanel-for-enumdef-idbtransactiondurability" role="dialog">
+   <span id="infopaneltitle-for-enumdef-idbtransactiondurability" style="display:none">Info about the 'IDBTransactionDurability' definition.</span><b><a href="#enumdef-idbtransactiondurability">#enumdef-idbtransactiondurability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-idbtransactiondurability">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-enumdef-idbtransactiondurability①">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactiondurability-default">
-   <b><a href="#dom-idbtransactiondurability-default">#dom-idbtransactiondurability-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactiondurability-default" class="dfn-panel" data-for="dom-idbtransactiondurability-default" id="infopanel-for-dom-idbtransactiondurability-default" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactiondurability-default" style="display:none">Info about the '"default"' definition.</span><b><a href="#dom-idbtransactiondurability-default">#dom-idbtransactiondurability-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactiondurability-default">2.7. Transactions</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-default①">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbtransactiondurability-default②">(2)</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-default③">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactiondurability-strict">
-   <b><a href="#dom-idbtransactiondurability-strict">#dom-idbtransactiondurability-strict</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactiondurability-strict" class="dfn-panel" data-for="dom-idbtransactiondurability-strict" id="infopanel-for-dom-idbtransactiondurability-strict" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactiondurability-strict" style="display:none">Info about the '"strict"' definition.</span><b><a href="#dom-idbtransactiondurability-strict">#dom-idbtransactiondurability-strict</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactiondurability-strict">2.7. Transactions</a> <a href="#ref-for-dom-idbtransactiondurability-strict①">(2)</a> <a href="#ref-for-dom-idbtransactiondurability-strict②">(3)</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-strict③">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-strict④">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactiondurability-relaxed">
-   <b><a href="#dom-idbtransactiondurability-relaxed">#dom-idbtransactiondurability-relaxed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactiondurability-relaxed" class="dfn-panel" data-for="dom-idbtransactiondurability-relaxed" id="infopanel-for-dom-idbtransactiondurability-relaxed" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactiondurability-relaxed" style="display:none">Info about the '"relaxed"' definition.</span><b><a href="#dom-idbtransactiondurability-relaxed">#dom-idbtransactiondurability-relaxed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactiondurability-relaxed">2.7. Transactions</a> <a href="#ref-for-dom-idbtransactiondurability-relaxed①">(2)</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-relaxed②">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-dom-idbtransactiondurability-relaxed③">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idbtransactionoptions">
-   <b><a href="#dictdef-idbtransactionoptions">#dictdef-idbtransactionoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idbtransactionoptions" class="dfn-panel" data-for="dictdef-idbtransactionoptions" id="infopanel-for-dictdef-idbtransactionoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idbtransactionoptions" style="display:none">Info about the 'IDBTransactionOptions' definition.</span><b><a href="#dictdef-idbtransactionoptions">#dictdef-idbtransactionoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idbtransactionoptions">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactionoptions-durability">
-   <b><a href="#dom-idbtransactionoptions-durability">#dom-idbtransactionoptions-durability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactionoptions-durability" class="dfn-panel" data-for="dom-idbtransactionoptions-durability" id="infopanel-for-dom-idbtransactionoptions-durability" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactionoptions-durability" style="display:none">Info about the 'durability' definition.</span><b><a href="#dom-idbtransactionoptions-durability">#dom-idbtransactionoptions-durability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactionoptions-durability">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbtransactionoptions-durability①">(2)</a> <a href="#ref-for-dom-idbtransactionoptions-durability②">(3)</a> <a href="#ref-for-dom-idbtransactionoptions-durability③">(4)</a>
     <li><a href="#ref-for-dom-idbtransactionoptions-durability④">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idbobjectstoreparameters">
-   <b><a href="#dictdef-idbobjectstoreparameters">#dictdef-idbobjectstoreparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idbobjectstoreparameters" class="dfn-panel" data-for="dictdef-idbobjectstoreparameters" id="infopanel-for-dictdef-idbobjectstoreparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idbobjectstoreparameters" style="display:none">Info about the 'IDBObjectStoreParameters' definition.</span><b><a href="#dictdef-idbobjectstoreparameters">#dictdef-idbobjectstoreparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idbobjectstoreparameters">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstoreparameters-keypath">
-   <b><a href="#dom-idbobjectstoreparameters-keypath">#dom-idbobjectstoreparameters-keypath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstoreparameters-keypath" class="dfn-panel" data-for="dom-idbobjectstoreparameters-keypath" id="infopanel-for-dom-idbobjectstoreparameters-keypath" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstoreparameters-keypath" style="display:none">Info about the 'keyPath' definition.</span><b><a href="#dom-idbobjectstoreparameters-keypath">#dom-idbobjectstoreparameters-keypath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstoreparameters-keypath">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstoreparameters-autoincrement">
-   <b><a href="#dom-idbobjectstoreparameters-autoincrement">#dom-idbobjectstoreparameters-autoincrement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstoreparameters-autoincrement" class="dfn-panel" data-for="dom-idbobjectstoreparameters-autoincrement" id="infopanel-for-dom-idbobjectstoreparameters-autoincrement" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstoreparameters-autoincrement" style="display:none">Info about the 'autoIncrement' definition.</span><b><a href="#dom-idbobjectstoreparameters-autoincrement">#dom-idbobjectstoreparameters-autoincrement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstoreparameters-autoincrement">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-name">
-   <b><a href="#dom-idbdatabase-name">#dom-idbdatabase-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-name" class="dfn-panel" data-for="dom-idbdatabase-name" id="infopanel-for-dom-idbdatabase-name" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-idbdatabase-name">#dom-idbdatabase-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-name">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-name①">(2)</a> <a href="#ref-for-dom-idbdatabase-name②">(3)</a>
     <li><a href="#ref-for-dom-idbdatabase-name③">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-version">
-   <b><a href="#dom-idbdatabase-version">#dom-idbdatabase-version</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-version" class="dfn-panel" data-for="dom-idbdatabase-version" id="infopanel-for-dom-idbdatabase-version" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-version" style="display:none">Info about the 'version' definition.</span><b><a href="#dom-idbdatabase-version">#dom-idbdatabase-version</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-version">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-version①">(2)</a>
     <li><a href="#ref-for-dom-idbdatabase-version②">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-objectstorenames">
-   <b><a href="#dom-idbdatabase-objectstorenames">#dom-idbdatabase-objectstorenames</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-objectstorenames" class="dfn-panel" data-for="dom-idbdatabase-objectstorenames" id="infopanel-for-dom-idbdatabase-objectstorenames" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-objectstorenames" style="display:none">Info about the 'objectStoreNames' definition.</span><b><a href="#dom-idbdatabase-objectstorenames">#dom-idbdatabase-objectstorenames</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-objectstorenames">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-objectstorenames①">(2)</a> <a href="#ref-for-dom-idbdatabase-objectstorenames②">(3)</a> <a href="#ref-for-dom-idbdatabase-objectstorenames③">(4)</a>
     <li><a href="#ref-for-dom-idbdatabase-objectstorenames④">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-createobjectstore">
-   <b><a href="#dom-idbdatabase-createobjectstore">#dom-idbdatabase-createobjectstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-createobjectstore" class="dfn-panel" data-for="dom-idbdatabase-createobjectstore" id="infopanel-for-dom-idbdatabase-createobjectstore" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-createobjectstore" style="display:none">Info about the 'createObjectStore(name, options)' definition.</span><b><a href="#dom-idbdatabase-createobjectstore">#dom-idbdatabase-createobjectstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-createobjectstore">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-createobjectstore①">(2)</a> <a href="#ref-for-dom-idbdatabase-createobjectstore②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-deleteobjectstore">
-   <b><a href="#dom-idbdatabase-deleteobjectstore">#dom-idbdatabase-deleteobjectstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-deleteobjectstore" class="dfn-panel" data-for="dom-idbdatabase-deleteobjectstore" id="infopanel-for-dom-idbdatabase-deleteobjectstore" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-deleteobjectstore" style="display:none">Info about the 'deleteObjectStore(name)' definition.</span><b><a href="#dom-idbdatabase-deleteobjectstore">#dom-idbdatabase-deleteobjectstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-deleteobjectstore">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-deleteobjectstore①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-transaction">
-   <b><a href="#dom-idbdatabase-transaction">#dom-idbdatabase-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-transaction" class="dfn-panel" data-for="dom-idbdatabase-transaction" id="infopanel-for-dom-idbdatabase-transaction" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-transaction" style="display:none">Info about the 'transaction(storeNames, mode, options)' definition.</span><b><a href="#dom-idbdatabase-transaction">#dom-idbdatabase-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-transaction">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-dom-idbdatabase-transaction①">2.7.3. Upgrade transactions</a>
     <li><a href="#ref-for-dom-idbdatabase-transaction②">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-transaction③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-close">
-   <b><a href="#dom-idbdatabase-close">#dom-idbdatabase-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-close" class="dfn-panel" data-for="dom-idbdatabase-close" id="infopanel-for-dom-idbdatabase-close" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#dom-idbdatabase-close">#dom-idbdatabase-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-close">1. Introduction</a>
     <li><a href="#ref-for-dom-idbdatabase-close①">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbdatabase-close②">(2)</a> <a href="#ref-for-dom-idbdatabase-close③">(3)</a>
     <li><a href="#ref-for-dom-idbdatabase-close④">5.2. Closing a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-onabort">
-   <b><a href="#dom-idbdatabase-onabort">#dom-idbdatabase-onabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-onabort" class="dfn-panel" data-for="dom-idbdatabase-onabort" id="infopanel-for-dom-idbdatabase-onabort" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-onabort" style="display:none">Info about the 'onabort' definition.</span><b><a href="#dom-idbdatabase-onabort">#dom-idbdatabase-onabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-onabort">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-onclose">
-   <b><a href="#dom-idbdatabase-onclose">#dom-idbdatabase-onclose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-onclose" class="dfn-panel" data-for="dom-idbdatabase-onclose" id="infopanel-for-dom-idbdatabase-onclose" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-onclose" style="display:none">Info about the 'onclose' definition.</span><b><a href="#dom-idbdatabase-onclose">#dom-idbdatabase-onclose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-onclose">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-onerror">
-   <b><a href="#dom-idbdatabase-onerror">#dom-idbdatabase-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-onerror" class="dfn-panel" data-for="dom-idbdatabase-onerror" id="infopanel-for-dom-idbdatabase-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-idbdatabase-onerror">#dom-idbdatabase-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-onerror">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbdatabase-onversionchange">
-   <b><a href="#dom-idbdatabase-onversionchange">#dom-idbdatabase-onversionchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbdatabase-onversionchange" class="dfn-panel" data-for="dom-idbdatabase-onversionchange" id="infopanel-for-dom-idbdatabase-onversionchange" role="dialog">
+   <span id="infopaneltitle-for-dom-idbdatabase-onversionchange" style="display:none">Info about the 'onversionchange' definition.</span><b><a href="#dom-idbdatabase-onversionchange">#dom-idbdatabase-onversionchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbdatabase-onversionchange">4.4. The IDBDatabase interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbobjectstore">
-   <b><a href="#idbobjectstore">#idbobjectstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbobjectstore" class="dfn-panel" data-for="idbobjectstore" id="infopanel-for-idbobjectstore" role="dialog">
+   <span id="infopaneltitle-for-idbobjectstore" style="display:none">Info about the 'IDBObjectStore' definition.</span><b><a href="#idbobjectstore">#idbobjectstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbobjectstore">4.1. The IDBRequest interface</a> <a href="#ref-for-idbobjectstore①">(2)</a>
     <li><a href="#ref-for-idbobjectstore②">4.4. The IDBDatabase interface</a> <a href="#ref-for-idbobjectstore③">(2)</a> <a href="#ref-for-idbobjectstore④">(3)</a>
@@ -11294,151 +11295,151 @@ specification.</p>
     <li><a href="#ref-for-idbobjectstore②①">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-idbobjectstore②②">(2)</a> <a href="#ref-for-idbobjectstore②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-idbindexparameters">
-   <b><a href="#dictdef-idbindexparameters">#dictdef-idbindexparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-idbindexparameters" class="dfn-panel" data-for="dictdef-idbindexparameters" id="infopanel-for-dictdef-idbindexparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-idbindexparameters" style="display:none">Info about the 'IDBIndexParameters' definition.</span><b><a href="#dictdef-idbindexparameters">#dictdef-idbindexparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-idbindexparameters">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindexparameters-unique">
-   <b><a href="#dom-idbindexparameters-unique">#dom-idbindexparameters-unique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindexparameters-unique" class="dfn-panel" data-for="dom-idbindexparameters-unique" id="infopanel-for-dom-idbindexparameters-unique" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindexparameters-unique" style="display:none">Info about the 'unique' definition.</span><b><a href="#dom-idbindexparameters-unique">#dom-idbindexparameters-unique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindexparameters-unique">1. Introduction</a>
     <li><a href="#ref-for-dom-idbindexparameters-unique①">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindexparameters-multientry">
-   <b><a href="#dom-idbindexparameters-multientry">#dom-idbindexparameters-multientry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindexparameters-multientry" class="dfn-panel" data-for="dom-idbindexparameters-multientry" id="infopanel-for-dom-idbindexparameters-multientry" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindexparameters-multientry" style="display:none">Info about the 'multiEntry' definition.</span><b><a href="#dom-idbindexparameters-multientry">#dom-idbindexparameters-multientry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindexparameters-multientry">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-name">
-   <b><a href="#dom-idbobjectstore-name">#dom-idbobjectstore-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-name" class="dfn-panel" data-for="dom-idbobjectstore-name" id="infopanel-for-dom-idbobjectstore-name" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-idbobjectstore-name">#dom-idbobjectstore-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-name">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-name①">(2)</a> <a href="#ref-for-dom-idbobjectstore-name②">(3)</a> <a href="#ref-for-dom-idbobjectstore-name③">(4)</a>
     <li><a href="#ref-for-dom-idbobjectstore-name④">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-dom-idbobjectstore-name⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-keypath">
-   <b><a href="#dom-idbobjectstore-keypath">#dom-idbobjectstore-keypath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-keypath" class="dfn-panel" data-for="dom-idbobjectstore-keypath" id="infopanel-for-dom-idbobjectstore-keypath" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-keypath" style="display:none">Info about the 'keyPath' definition.</span><b><a href="#dom-idbobjectstore-keypath">#dom-idbobjectstore-keypath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-keypath">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-keypath①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-indexnames">
-   <b><a href="#dom-idbobjectstore-indexnames">#dom-idbobjectstore-indexnames</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-indexnames" class="dfn-panel" data-for="dom-idbobjectstore-indexnames" id="infopanel-for-dom-idbobjectstore-indexnames" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-indexnames" style="display:none">Info about the 'indexNames' definition.</span><b><a href="#dom-idbobjectstore-indexnames">#dom-idbobjectstore-indexnames</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-indexnames">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-indexnames①">(2)</a> <a href="#ref-for-dom-idbobjectstore-indexnames②">(3)</a> <a href="#ref-for-dom-idbobjectstore-indexnames③">(4)</a>
     <li><a href="#ref-for-dom-idbobjectstore-indexnames④">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-dom-idbobjectstore-indexnames⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-transaction">
-   <b><a href="#dom-idbobjectstore-transaction">#dom-idbobjectstore-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-transaction" class="dfn-panel" data-for="dom-idbobjectstore-transaction" id="infopanel-for-dom-idbobjectstore-transaction" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-transaction" style="display:none">Info about the 'transaction' definition.</span><b><a href="#dom-idbobjectstore-transaction">#dom-idbobjectstore-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-transaction">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-transaction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-autoincrement">
-   <b><a href="#dom-idbobjectstore-autoincrement">#dom-idbobjectstore-autoincrement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-autoincrement" class="dfn-panel" data-for="dom-idbobjectstore-autoincrement" id="infopanel-for-dom-idbobjectstore-autoincrement" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-autoincrement" style="display:none">Info about the 'autoIncrement' definition.</span><b><a href="#dom-idbobjectstore-autoincrement">#dom-idbobjectstore-autoincrement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-autoincrement">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-autoincrement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-put">
-   <b><a href="#dom-idbobjectstore-put">#dom-idbobjectstore-put</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-put" class="dfn-panel" data-for="dom-idbobjectstore-put" id="infopanel-for-dom-idbobjectstore-put" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-put" style="display:none">Info about the 'put(value, key)' definition.</span><b><a href="#dom-idbobjectstore-put">#dom-idbobjectstore-put</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-put">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-put①">(2)</a> <a href="#ref-for-dom-idbobjectstore-put②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-add">
-   <b><a href="#dom-idbobjectstore-add">#dom-idbobjectstore-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-add" class="dfn-panel" data-for="dom-idbobjectstore-add" id="infopanel-for-dom-idbobjectstore-add" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-add" style="display:none">Info about the 'add(value, key)' definition.</span><b><a href="#dom-idbobjectstore-add">#dom-idbobjectstore-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-add">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-add①">(2)</a> <a href="#ref-for-dom-idbobjectstore-add②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-or-put">
-   <b><a href="#add-or-put">#add-or-put</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-or-put" class="dfn-panel" data-for="add-or-put" id="infopanel-for-add-or-put" role="dialog">
+   <span id="infopaneltitle-for-add-or-put" style="display:none">Info about the 'add or put' definition.</span><b><a href="#add-or-put">#add-or-put</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-or-put">4.5. The IDBObjectStore interface</a> <a href="#ref-for-add-or-put①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-delete">
-   <b><a href="#dom-idbobjectstore-delete">#dom-idbobjectstore-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-delete" class="dfn-panel" data-for="dom-idbobjectstore-delete" id="infopanel-for-dom-idbobjectstore-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-delete" style="display:none">Info about the 'delete(query)' definition.</span><b><a href="#dom-idbobjectstore-delete">#dom-idbobjectstore-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-delete">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-clear">
-   <b><a href="#dom-idbobjectstore-clear">#dom-idbobjectstore-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-clear" class="dfn-panel" data-for="dom-idbobjectstore-clear" id="infopanel-for-dom-idbobjectstore-clear" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-clear" style="display:none">Info about the 'clear()' definition.</span><b><a href="#dom-idbobjectstore-clear">#dom-idbobjectstore-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-clear">2.11. Key generators</a> <a href="#ref-for-dom-idbobjectstore-clear①">(2)</a>
     <li><a href="#ref-for-dom-idbobjectstore-clear②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-clear③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-get">
-   <b><a href="#dom-idbobjectstore-get">#dom-idbobjectstore-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-get" class="dfn-panel" data-for="dom-idbobjectstore-get" id="infopanel-for-dom-idbobjectstore-get" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-get" style="display:none">Info about the 'get(query)' definition.</span><b><a href="#dom-idbobjectstore-get">#dom-idbobjectstore-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-get">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-getkey">
-   <b><a href="#dom-idbobjectstore-getkey">#dom-idbobjectstore-getkey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-getkey" class="dfn-panel" data-for="dom-idbobjectstore-getkey" id="infopanel-for-dom-idbobjectstore-getkey" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-getkey" style="display:none">Info about the 'getKey(query)' definition.</span><b><a href="#dom-idbobjectstore-getkey">#dom-idbobjectstore-getkey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-getkey">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-getkey①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-getall">
-   <b><a href="#dom-idbobjectstore-getall">#dom-idbobjectstore-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-getall" class="dfn-panel" data-for="dom-idbobjectstore-getall" id="infopanel-for-dom-idbobjectstore-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-getall" style="display:none">Info about the 'getAll(query, count)' definition.</span><b><a href="#dom-idbobjectstore-getall">#dom-idbobjectstore-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-getall">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-getall①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-getallkeys">
-   <b><a href="#dom-idbobjectstore-getallkeys">#dom-idbobjectstore-getallkeys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-getallkeys" class="dfn-panel" data-for="dom-idbobjectstore-getallkeys" id="infopanel-for-dom-idbobjectstore-getallkeys" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-getallkeys" style="display:none">Info about the 'getAllKeys(query, count)' definition.</span><b><a href="#dom-idbobjectstore-getallkeys">#dom-idbobjectstore-getallkeys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-getallkeys">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-getallkeys①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-count">
-   <b><a href="#dom-idbobjectstore-count">#dom-idbobjectstore-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-count" class="dfn-panel" data-for="dom-idbobjectstore-count" id="infopanel-for-dom-idbobjectstore-count" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-count" style="display:none">Info about the 'count(query)' definition.</span><b><a href="#dom-idbobjectstore-count">#dom-idbobjectstore-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-count">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-count①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-opencursor">
-   <b><a href="#dom-idbobjectstore-opencursor">#dom-idbobjectstore-opencursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-opencursor" class="dfn-panel" data-for="dom-idbobjectstore-opencursor" id="infopanel-for-dom-idbobjectstore-opencursor" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-opencursor" style="display:none">Info about the 'openCursor(query, direction)' definition.</span><b><a href="#dom-idbobjectstore-opencursor">#dom-idbobjectstore-opencursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-opencursor">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-opencursor①">(2)</a> <a href="#ref-for-dom-idbobjectstore-opencursor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-openkeycursor">
-   <b><a href="#dom-idbobjectstore-openkeycursor">#dom-idbobjectstore-openkeycursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-openkeycursor" class="dfn-panel" data-for="dom-idbobjectstore-openkeycursor" id="infopanel-for-dom-idbobjectstore-openkeycursor" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-openkeycursor" style="display:none">Info about the 'openKeyCursor(query, direction)' definition.</span><b><a href="#dom-idbobjectstore-openkeycursor">#dom-idbobjectstore-openkeycursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-openkeycursor">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-openkeycursor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-createindex">
-   <b><a href="#dom-idbobjectstore-createindex">#dom-idbobjectstore-createindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-createindex" class="dfn-panel" data-for="dom-idbobjectstore-createindex" id="infopanel-for-dom-idbobjectstore-createindex" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-createindex" style="display:none">Info about the 'createIndex(name, keyPath, options)' definition.</span><b><a href="#dom-idbobjectstore-createindex">#dom-idbobjectstore-createindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-createindex">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-createindex①">(2)</a> <a href="#ref-for-dom-idbobjectstore-createindex②">(3)</a> <a href="#ref-for-dom-idbobjectstore-createindex③">(4)</a> <a href="#ref-for-dom-idbobjectstore-createindex④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-index">
-   <b><a href="#dom-idbobjectstore-index">#dom-idbobjectstore-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-index" class="dfn-panel" data-for="dom-idbobjectstore-index" id="infopanel-for-dom-idbobjectstore-index" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-index" style="display:none">Info about the 'index(name)' definition.</span><b><a href="#dom-idbobjectstore-index">#dom-idbobjectstore-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-index">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-dom-idbobjectstore-index①">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbobjectstore-deleteindex">
-   <b><a href="#dom-idbobjectstore-deleteindex">#dom-idbobjectstore-deleteindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbobjectstore-deleteindex" class="dfn-panel" data-for="dom-idbobjectstore-deleteindex" id="infopanel-for-dom-idbobjectstore-deleteindex" role="dialog">
+   <span id="infopaneltitle-for-dom-idbobjectstore-deleteindex" style="display:none">Info about the 'deleteIndex(name)' definition.</span><b><a href="#dom-idbobjectstore-deleteindex">#dom-idbobjectstore-deleteindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbobjectstore-deleteindex">4.5. The IDBObjectStore interface</a> <a href="#ref-for-dom-idbobjectstore-deleteindex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbindex">
-   <b><a href="#idbindex">#idbindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbindex" class="dfn-panel" data-for="idbindex" id="infopanel-for-idbindex" role="dialog">
+   <span id="infopaneltitle-for-idbindex" style="display:none">Info about the 'IDBIndex' definition.</span><b><a href="#idbindex">#idbindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbindex">4.1. The IDBRequest interface</a> <a href="#ref-for-idbindex①">(2)</a>
     <li><a href="#ref-for-idbindex②">4.5. The IDBObjectStore interface</a> <a href="#ref-for-idbindex③">(2)</a> <a href="#ref-for-idbindex④">(3)</a> <a href="#ref-for-idbindex⑤">(4)</a> <a href="#ref-for-idbindex⑥">(5)</a> <a href="#ref-for-idbindex⑦">(6)</a> <a href="#ref-for-idbindex⑧">(7)</a> <a href="#ref-for-idbindex⑨">(8)</a> <a href="#ref-for-idbindex①⓪">(9)</a>
@@ -11447,144 +11448,144 @@ specification.</p>
     <li><a href="#ref-for-idbindex①⑤">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-idbindex①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-name">
-   <b><a href="#dom-idbindex-name">#dom-idbindex-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-name" class="dfn-panel" data-for="dom-idbindex-name" id="infopanel-for-dom-idbindex-name" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-idbindex-name">#dom-idbindex-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-name">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-name①">(2)</a> <a href="#ref-for-dom-idbindex-name②">(3)</a> <a href="#ref-for-dom-idbindex-name③">(4)</a>
     <li><a href="#ref-for-dom-idbindex-name④">5.8. Aborting an upgrade transaction</a> <a href="#ref-for-dom-idbindex-name⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-objectstore">
-   <b><a href="#dom-idbindex-objectstore">#dom-idbindex-objectstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-objectstore" class="dfn-panel" data-for="dom-idbindex-objectstore" id="infopanel-for-dom-idbindex-objectstore" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-objectstore" style="display:none">Info about the 'objectStore' definition.</span><b><a href="#dom-idbindex-objectstore">#dom-idbindex-objectstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-objectstore">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-objectstore①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-keypath">
-   <b><a href="#dom-idbindex-keypath">#dom-idbindex-keypath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-keypath" class="dfn-panel" data-for="dom-idbindex-keypath" id="infopanel-for-dom-idbindex-keypath" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-keypath" style="display:none">Info about the 'keyPath' definition.</span><b><a href="#dom-idbindex-keypath">#dom-idbindex-keypath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-keypath">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-multientry">
-   <b><a href="#dom-idbindex-multientry">#dom-idbindex-multientry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-multientry" class="dfn-panel" data-for="dom-idbindex-multientry" id="infopanel-for-dom-idbindex-multientry" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-multientry" style="display:none">Info about the 'multiEntry' definition.</span><b><a href="#dom-idbindex-multientry">#dom-idbindex-multientry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-multientry">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-unique">
-   <b><a href="#dom-idbindex-unique">#dom-idbindex-unique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-unique" class="dfn-panel" data-for="dom-idbindex-unique" id="infopanel-for-dom-idbindex-unique" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-unique" style="display:none">Info about the 'unique' definition.</span><b><a href="#dom-idbindex-unique">#dom-idbindex-unique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-unique">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-get">
-   <b><a href="#dom-idbindex-get">#dom-idbindex-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-get" class="dfn-panel" data-for="dom-idbindex-get" id="infopanel-for-dom-idbindex-get" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-get" style="display:none">Info about the 'get(query)' definition.</span><b><a href="#dom-idbindex-get">#dom-idbindex-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-get">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-getkey">
-   <b><a href="#dom-idbindex-getkey">#dom-idbindex-getkey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-getkey" class="dfn-panel" data-for="dom-idbindex-getkey" id="infopanel-for-dom-idbindex-getkey" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-getkey" style="display:none">Info about the 'getKey(query)' definition.</span><b><a href="#dom-idbindex-getkey">#dom-idbindex-getkey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-getkey">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-getkey①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-getall">
-   <b><a href="#dom-idbindex-getall">#dom-idbindex-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-getall" class="dfn-panel" data-for="dom-idbindex-getall" id="infopanel-for-dom-idbindex-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-getall" style="display:none">Info about the 'getAll(query, count)' definition.</span><b><a href="#dom-idbindex-getall">#dom-idbindex-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-getall">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-getall①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-getallkeys">
-   <b><a href="#dom-idbindex-getallkeys">#dom-idbindex-getallkeys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-getallkeys" class="dfn-panel" data-for="dom-idbindex-getallkeys" id="infopanel-for-dom-idbindex-getallkeys" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-getallkeys" style="display:none">Info about the 'getAllKeys(query, count)' definition.</span><b><a href="#dom-idbindex-getallkeys">#dom-idbindex-getallkeys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-getallkeys">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-getallkeys①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-count">
-   <b><a href="#dom-idbindex-count">#dom-idbindex-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-count" class="dfn-panel" data-for="dom-idbindex-count" id="infopanel-for-dom-idbindex-count" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-count" style="display:none">Info about the 'count(query)' definition.</span><b><a href="#dom-idbindex-count">#dom-idbindex-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-count">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-count①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-opencursor">
-   <b><a href="#dom-idbindex-opencursor">#dom-idbindex-opencursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-opencursor" class="dfn-panel" data-for="dom-idbindex-opencursor" id="infopanel-for-dom-idbindex-opencursor" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-opencursor" style="display:none">Info about the 'openCursor(query, direction)' definition.</span><b><a href="#dom-idbindex-opencursor">#dom-idbindex-opencursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-opencursor">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-opencursor①">(2)</a> <a href="#ref-for-dom-idbindex-opencursor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbindex-openkeycursor">
-   <b><a href="#dom-idbindex-openkeycursor">#dom-idbindex-openkeycursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbindex-openkeycursor" class="dfn-panel" data-for="dom-idbindex-openkeycursor" id="infopanel-for-dom-idbindex-openkeycursor" role="dialog">
+   <span id="infopaneltitle-for-dom-idbindex-openkeycursor" style="display:none">Info about the 'openKeyCursor(query, direction)' definition.</span><b><a href="#dom-idbindex-openkeycursor">#dom-idbindex-openkeycursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbindex-openkeycursor">4.6. The IDBIndex interface</a> <a href="#ref-for-dom-idbindex-openkeycursor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbkeyrange">
-   <b><a href="#idbkeyrange">#idbkeyrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbkeyrange" class="dfn-panel" data-for="idbkeyrange" id="infopanel-for-idbkeyrange" role="dialog">
+   <span id="infopaneltitle-for-idbkeyrange" style="display:none">Info about the 'IDBKeyRange' definition.</span><b><a href="#idbkeyrange">#idbkeyrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbkeyrange">4.5. The IDBObjectStore interface</a> <a href="#ref-for-idbkeyrange①">(2)</a> <a href="#ref-for-idbkeyrange②">(3)</a> <a href="#ref-for-idbkeyrange③">(4)</a> <a href="#ref-for-idbkeyrange④">(5)</a> <a href="#ref-for-idbkeyrange⑤">(6)</a> <a href="#ref-for-idbkeyrange⑥">(7)</a> <a href="#ref-for-idbkeyrange⑦">(8)</a>
     <li><a href="#ref-for-idbkeyrange⑧">4.6. The IDBIndex interface</a> <a href="#ref-for-idbkeyrange⑨">(2)</a> <a href="#ref-for-idbkeyrange①⓪">(3)</a> <a href="#ref-for-idbkeyrange①①">(4)</a> <a href="#ref-for-idbkeyrange①②">(5)</a> <a href="#ref-for-idbkeyrange①③">(6)</a> <a href="#ref-for-idbkeyrange①④">(7)</a>
     <li><a href="#ref-for-idbkeyrange①⑤">4.7. The IDBKeyRange interface</a> <a href="#ref-for-idbkeyrange①⑥">(2)</a> <a href="#ref-for-idbkeyrange①⑦">(3)</a> <a href="#ref-for-idbkeyrange①⑧">(4)</a> <a href="#ref-for-idbkeyrange①⑨">(5)</a> <a href="#ref-for-idbkeyrange②⓪">(6)</a> <a href="#ref-for-idbkeyrange②①">(7)</a> <a href="#ref-for-idbkeyrange②②">(8)</a> <a href="#ref-for-idbkeyrange②③">(9)</a> <a href="#ref-for-idbkeyrange②④">(10)</a> <a href="#ref-for-idbkeyrange②⑤">(11)</a> <a href="#ref-for-idbkeyrange②⑥">(12)</a> <a href="#ref-for-idbkeyrange②⑦">(13)</a> <a href="#ref-for-idbkeyrange②⑧">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-lower">
-   <b><a href="#dom-idbkeyrange-lower">#dom-idbkeyrange-lower</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-lower" class="dfn-panel" data-for="dom-idbkeyrange-lower" id="infopanel-for-dom-idbkeyrange-lower" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-lower" style="display:none">Info about the 'lower' definition.</span><b><a href="#dom-idbkeyrange-lower">#dom-idbkeyrange-lower</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-lower">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-lower①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-upper">
-   <b><a href="#dom-idbkeyrange-upper">#dom-idbkeyrange-upper</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-upper" class="dfn-panel" data-for="dom-idbkeyrange-upper" id="infopanel-for-dom-idbkeyrange-upper" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-upper" style="display:none">Info about the 'upper' definition.</span><b><a href="#dom-idbkeyrange-upper">#dom-idbkeyrange-upper</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-upper">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-upper①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-loweropen">
-   <b><a href="#dom-idbkeyrange-loweropen">#dom-idbkeyrange-loweropen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-loweropen" class="dfn-panel" data-for="dom-idbkeyrange-loweropen" id="infopanel-for-dom-idbkeyrange-loweropen" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-loweropen" style="display:none">Info about the 'lowerOpen' definition.</span><b><a href="#dom-idbkeyrange-loweropen">#dom-idbkeyrange-loweropen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-loweropen">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-loweropen①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-upperopen">
-   <b><a href="#dom-idbkeyrange-upperopen">#dom-idbkeyrange-upperopen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-upperopen" class="dfn-panel" data-for="dom-idbkeyrange-upperopen" id="infopanel-for-dom-idbkeyrange-upperopen" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-upperopen" style="display:none">Info about the 'upperOpen' definition.</span><b><a href="#dom-idbkeyrange-upperopen">#dom-idbkeyrange-upperopen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-upperopen">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-upperopen①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-only">
-   <b><a href="#dom-idbkeyrange-only">#dom-idbkeyrange-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-only" class="dfn-panel" data-for="dom-idbkeyrange-only" id="infopanel-for-dom-idbkeyrange-only" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-only" style="display:none">Info about the 'only(value)' definition.</span><b><a href="#dom-idbkeyrange-only">#dom-idbkeyrange-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-only">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-only①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-lowerbound">
-   <b><a href="#dom-idbkeyrange-lowerbound">#dom-idbkeyrange-lowerbound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-lowerbound" class="dfn-panel" data-for="dom-idbkeyrange-lowerbound" id="infopanel-for-dom-idbkeyrange-lowerbound" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-lowerbound" style="display:none">Info about the 'lowerBound(lower, open)' definition.</span><b><a href="#dom-idbkeyrange-lowerbound">#dom-idbkeyrange-lowerbound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-lowerbound">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-lowerbound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-upperbound">
-   <b><a href="#dom-idbkeyrange-upperbound">#dom-idbkeyrange-upperbound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-upperbound" class="dfn-panel" data-for="dom-idbkeyrange-upperbound" id="infopanel-for-dom-idbkeyrange-upperbound" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-upperbound" style="display:none">Info about the 'upperBound(upper, open)' definition.</span><b><a href="#dom-idbkeyrange-upperbound">#dom-idbkeyrange-upperbound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-upperbound">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-upperbound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-bound">
-   <b><a href="#dom-idbkeyrange-bound">#dom-idbkeyrange-bound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-bound" class="dfn-panel" data-for="dom-idbkeyrange-bound" id="infopanel-for-dom-idbkeyrange-bound" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-bound" style="display:none">Info about the 'bound(lower, upper, lowerOpen, upperOpen)' definition.</span><b><a href="#dom-idbkeyrange-bound">#dom-idbkeyrange-bound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-bound">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-bound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbkeyrange-includes">
-   <b><a href="#dom-idbkeyrange-includes">#dom-idbkeyrange-includes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbkeyrange-includes" class="dfn-panel" data-for="dom-idbkeyrange-includes" id="infopanel-for-dom-idbkeyrange-includes" role="dialog">
+   <span id="infopaneltitle-for-dom-idbkeyrange-includes" style="display:none">Info about the 'includes(key)' definition.</span><b><a href="#dom-idbkeyrange-includes">#dom-idbkeyrange-includes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbkeyrange-includes">4.7. The IDBKeyRange interface</a> <a href="#ref-for-dom-idbkeyrange-includes①">(2)</a>
     <li><a href="#ref-for-dom-idbkeyrange-includes②">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbcursor">
-   <b><a href="#idbcursor">#idbcursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbcursor" class="dfn-panel" data-for="idbcursor" id="infopanel-for-idbcursor" role="dialog">
+   <span id="infopaneltitle-for-idbcursor" style="display:none">Info about the 'IDBCursor' definition.</span><b><a href="#idbcursor">#idbcursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbcursor">4.1. The IDBRequest interface</a> <a href="#ref-for-idbcursor①">(2)</a>
     <li><a href="#ref-for-idbcursor②">4.5. The IDBObjectStore interface</a>
@@ -11592,123 +11593,123 @@ specification.</p>
     <li><a href="#ref-for-idbcursor④">4.8. The IDBCursor interface</a> <a href="#ref-for-idbcursor⑤">(2)</a> <a href="#ref-for-idbcursor⑥">(3)</a> <a href="#ref-for-idbcursor⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-idbcursordirection">
-   <b><a href="#enumdef-idbcursordirection">#enumdef-idbcursordirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-idbcursordirection" class="dfn-panel" data-for="enumdef-idbcursordirection" id="infopanel-for-enumdef-idbcursordirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-idbcursordirection" style="display:none">Info about the 'IDBCursorDirection' definition.</span><b><a href="#enumdef-idbcursordirection">#enumdef-idbcursordirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-idbcursordirection">4.5. The IDBObjectStore interface</a> <a href="#ref-for-enumdef-idbcursordirection①">(2)</a>
     <li><a href="#ref-for-enumdef-idbcursordirection②">4.6. The IDBIndex interface</a> <a href="#ref-for-enumdef-idbcursordirection③">(2)</a>
     <li><a href="#ref-for-enumdef-idbcursordirection④">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursordirection-next">
-   <b><a href="#dom-idbcursordirection-next">#dom-idbcursordirection-next</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursordirection-next" class="dfn-panel" data-for="dom-idbcursordirection-next" id="infopanel-for-dom-idbcursordirection-next" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursordirection-next" style="display:none">Info about the '"next"' definition.</span><b><a href="#dom-idbcursordirection-next">#dom-idbcursordirection-next</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursordirection-next">2.10. Cursor</a> <a href="#ref-for-dom-idbcursordirection-next①">(2)</a>
     <li><a href="#ref-for-dom-idbcursordirection-next②">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursordirection-next③">(2)</a> <a href="#ref-for-dom-idbcursordirection-next④">(3)</a> <a href="#ref-for-dom-idbcursordirection-next⑤">(4)</a> <a href="#ref-for-dom-idbcursordirection-next⑥">(5)</a>
     <li><a href="#ref-for-dom-idbcursordirection-next⑦">6.7. Cursor iteration operation</a> <a href="#ref-for-dom-idbcursordirection-next⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursordirection-nextunique">
-   <b><a href="#dom-idbcursordirection-nextunique">#dom-idbcursordirection-nextunique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursordirection-nextunique" class="dfn-panel" data-for="dom-idbcursordirection-nextunique" id="infopanel-for-dom-idbcursordirection-nextunique" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursordirection-nextunique" style="display:none">Info about the '"nextunique"' definition.</span><b><a href="#dom-idbcursordirection-nextunique">#dom-idbcursordirection-nextunique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursordirection-nextunique">2.10. Cursor</a>
     <li><a href="#ref-for-dom-idbcursordirection-nextunique①">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursordirection-nextunique②">(2)</a>
     <li><a href="#ref-for-dom-idbcursordirection-nextunique③">6.7. Cursor iteration operation</a> <a href="#ref-for-dom-idbcursordirection-nextunique④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursordirection-prev">
-   <b><a href="#dom-idbcursordirection-prev">#dom-idbcursordirection-prev</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursordirection-prev" class="dfn-panel" data-for="dom-idbcursordirection-prev" id="infopanel-for-dom-idbcursordirection-prev" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursordirection-prev" style="display:none">Info about the '"prev"' definition.</span><b><a href="#dom-idbcursordirection-prev">#dom-idbcursordirection-prev</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursordirection-prev">2.10. Cursor</a> <a href="#ref-for-dom-idbcursordirection-prev①">(2)</a>
     <li><a href="#ref-for-dom-idbcursordirection-prev②">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursordirection-prev③">(2)</a> <a href="#ref-for-dom-idbcursordirection-prev④">(3)</a> <a href="#ref-for-dom-idbcursordirection-prev⑤">(4)</a> <a href="#ref-for-dom-idbcursordirection-prev⑥">(5)</a>
     <li><a href="#ref-for-dom-idbcursordirection-prev⑦">6.7. Cursor iteration operation</a> <a href="#ref-for-dom-idbcursordirection-prev⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursordirection-prevunique">
-   <b><a href="#dom-idbcursordirection-prevunique">#dom-idbcursordirection-prevunique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursordirection-prevunique" class="dfn-panel" data-for="dom-idbcursordirection-prevunique" id="infopanel-for-dom-idbcursordirection-prevunique" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursordirection-prevunique" style="display:none">Info about the '"prevunique"' definition.</span><b><a href="#dom-idbcursordirection-prevunique">#dom-idbcursordirection-prevunique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursordirection-prevunique">2.10. Cursor</a>
     <li><a href="#ref-for-dom-idbcursordirection-prevunique①">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursordirection-prevunique②">(2)</a>
     <li><a href="#ref-for-dom-idbcursordirection-prevunique③">6.7. Cursor iteration operation</a> <a href="#ref-for-dom-idbcursordirection-prevunique④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-source">
-   <b><a href="#dom-idbcursor-source">#dom-idbcursor-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-source" class="dfn-panel" data-for="dom-idbcursor-source" id="infopanel-for-dom-idbcursor-source" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-idbcursor-source">#dom-idbcursor-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-source">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-source①">(2)</a> <a href="#ref-for-dom-idbcursor-source②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-direction">
-   <b><a href="#dom-idbcursor-direction">#dom-idbcursor-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-direction" class="dfn-panel" data-for="dom-idbcursor-direction" id="infopanel-for-dom-idbcursor-direction" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#dom-idbcursor-direction">#dom-idbcursor-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-direction">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-key">
-   <b><a href="#dom-idbcursor-key">#dom-idbcursor-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-key" class="dfn-panel" data-for="dom-idbcursor-key" id="infopanel-for-dom-idbcursor-key" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-key" style="display:none">Info about the 'key' definition.</span><b><a href="#dom-idbcursor-key">#dom-idbcursor-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-key">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-key①">(2)</a> <a href="#ref-for-dom-idbcursor-key②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-primarykey">
-   <b><a href="#dom-idbcursor-primarykey">#dom-idbcursor-primarykey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-primarykey" class="dfn-panel" data-for="dom-idbcursor-primarykey" id="infopanel-for-dom-idbcursor-primarykey" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-primarykey" style="display:none">Info about the 'primaryKey' definition.</span><b><a href="#dom-idbcursor-primarykey">#dom-idbcursor-primarykey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-primarykey">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-primarykey①">(2)</a> <a href="#ref-for-dom-idbcursor-primarykey②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-request">
-   <b><a href="#dom-idbcursor-request">#dom-idbcursor-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-request" class="dfn-panel" data-for="dom-idbcursor-request" id="infopanel-for-dom-idbcursor-request" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-idbcursor-request">#dom-idbcursor-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-request">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-request①">(2)</a> <a href="#ref-for-dom-idbcursor-request②">(3)</a>
     <li><a href="#ref-for-dom-idbcursor-request③">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-advance">
-   <b><a href="#dom-idbcursor-advance">#dom-idbcursor-advance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-advance" class="dfn-panel" data-for="dom-idbcursor-advance" id="infopanel-for-dom-idbcursor-advance" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-advance" style="display:none">Info about the 'advance(count)' definition.</span><b><a href="#dom-idbcursor-advance">#dom-idbcursor-advance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-advance">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-advance①">(2)</a> <a href="#ref-for-dom-idbcursor-advance②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-continue">
-   <b><a href="#dom-idbcursor-continue">#dom-idbcursor-continue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-continue" class="dfn-panel" data-for="dom-idbcursor-continue" id="infopanel-for-dom-idbcursor-continue" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-continue" style="display:none">Info about the 'continue(key)' definition.</span><b><a href="#dom-idbcursor-continue">#dom-idbcursor-continue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-continue">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-continue①">(2)</a> <a href="#ref-for-dom-idbcursor-continue②">(3)</a> <a href="#ref-for-dom-idbcursor-continue③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-continueprimarykey">
-   <b><a href="#dom-idbcursor-continueprimarykey">#dom-idbcursor-continueprimarykey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-continueprimarykey" class="dfn-panel" data-for="dom-idbcursor-continueprimarykey" id="infopanel-for-dom-idbcursor-continueprimarykey" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-continueprimarykey" style="display:none">Info about the 'continuePrimaryKey(key, primaryKey)' definition.</span><b><a href="#dom-idbcursor-continueprimarykey">#dom-idbcursor-continueprimarykey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-continueprimarykey">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-continueprimarykey①">(2)</a> <a href="#ref-for-dom-idbcursor-continueprimarykey②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-update">
-   <b><a href="#dom-idbcursor-update">#dom-idbcursor-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-update" class="dfn-panel" data-for="dom-idbcursor-update" id="infopanel-for-dom-idbcursor-update" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-update" style="display:none">Info about the 'update(value)' definition.</span><b><a href="#dom-idbcursor-update">#dom-idbcursor-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-update">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-update①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursor-delete">
-   <b><a href="#dom-idbcursor-delete">#dom-idbcursor-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursor-delete" class="dfn-panel" data-for="dom-idbcursor-delete" id="infopanel-for-dom-idbcursor-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursor-delete" style="display:none">Info about the 'delete()' definition.</span><b><a href="#dom-idbcursor-delete">#dom-idbcursor-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursor-delete">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursor-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbcursorwithvalue">
-   <b><a href="#idbcursorwithvalue">#idbcursorwithvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbcursorwithvalue" class="dfn-panel" data-for="idbcursorwithvalue" id="infopanel-for-idbcursorwithvalue" role="dialog">
+   <span id="infopaneltitle-for-idbcursorwithvalue" style="display:none">Info about the 'IDBCursorWithValue' definition.</span><b><a href="#idbcursorwithvalue">#idbcursorwithvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbcursorwithvalue">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-idbcursorwithvalue①">4.6. The IDBIndex interface</a>
     <li><a href="#ref-for-idbcursorwithvalue②">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbcursorwithvalue-value">
-   <b><a href="#dom-idbcursorwithvalue-value">#dom-idbcursorwithvalue-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbcursorwithvalue-value" class="dfn-panel" data-for="dom-idbcursorwithvalue-value" id="infopanel-for-dom-idbcursorwithvalue-value" role="dialog">
+   <span id="infopaneltitle-for-dom-idbcursorwithvalue-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-idbcursorwithvalue-value">#dom-idbcursorwithvalue-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbcursorwithvalue-value">4.8. The IDBCursor interface</a> <a href="#ref-for-dom-idbcursorwithvalue-value①">(2)</a> <a href="#ref-for-dom-idbcursorwithvalue-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idbtransaction">
-   <b><a href="#idbtransaction">#idbtransaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idbtransaction" class="dfn-panel" data-for="idbtransaction" id="infopanel-for-idbtransaction" role="dialog">
+   <span id="infopaneltitle-for-idbtransaction" style="display:none">Info about the 'IDBTransaction' definition.</span><b><a href="#idbtransaction">#idbtransaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbtransaction">4.1. The IDBRequest interface</a> <a href="#ref-for-idbtransaction①">(2)</a>
     <li><a href="#ref-for-idbtransaction②">4.4. The IDBDatabase interface</a> <a href="#ref-for-idbtransaction③">(2)</a>
@@ -11717,133 +11718,133 @@ specification.</p>
     <li><a href="#ref-for-idbtransaction⑨">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-idbtransactionmode">
-   <b><a href="#enumdef-idbtransactionmode">#enumdef-idbtransactionmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-idbtransactionmode" class="dfn-panel" data-for="enumdef-idbtransactionmode" id="infopanel-for-enumdef-idbtransactionmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-idbtransactionmode" style="display:none">Info about the 'IDBTransactionMode' definition.</span><b><a href="#enumdef-idbtransactionmode">#enumdef-idbtransactionmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-idbtransactionmode">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-enumdef-idbtransactionmode①">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactionmode-readonly">
-   <b><a href="#dom-idbtransactionmode-readonly">#dom-idbtransactionmode-readonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactionmode-readonly" class="dfn-panel" data-for="dom-idbtransactionmode-readonly" id="infopanel-for-dom-idbtransactionmode-readonly" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactionmode-readonly" style="display:none">Info about the '"readonly"' definition.</span><b><a href="#dom-idbtransactionmode-readonly">#dom-idbtransactionmode-readonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactionmode-readonly">2.7. Transactions</a> <a href="#ref-for-dom-idbtransactionmode-readonly①">(2)</a>
     <li><a href="#ref-for-dom-idbtransactionmode-readonly②">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbtransactionmode-readonly③">(2)</a> <a href="#ref-for-dom-idbtransactionmode-readonly④">(3)</a>
     <li><a href="#ref-for-dom-idbtransactionmode-readonly⑤">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactionmode-readwrite">
-   <b><a href="#dom-idbtransactionmode-readwrite">#dom-idbtransactionmode-readwrite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactionmode-readwrite" class="dfn-panel" data-for="dom-idbtransactionmode-readwrite" id="infopanel-for-dom-idbtransactionmode-readwrite" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactionmode-readwrite" style="display:none">Info about the '"readwrite"' definition.</span><b><a href="#dom-idbtransactionmode-readwrite">#dom-idbtransactionmode-readwrite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactionmode-readwrite">2.7. Transactions</a> <a href="#ref-for-dom-idbtransactionmode-readwrite①">(2)</a> <a href="#ref-for-dom-idbtransactionmode-readwrite②">(3)</a>
     <li><a href="#ref-for-dom-idbtransactionmode-readwrite③">4.4. The IDBDatabase interface</a> <a href="#ref-for-dom-idbtransactionmode-readwrite④">(2)</a>
     <li><a href="#ref-for-dom-idbtransactionmode-readwrite⑤">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransactionmode-versionchange">
-   <b><a href="#dom-idbtransactionmode-versionchange">#dom-idbtransactionmode-versionchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransactionmode-versionchange" class="dfn-panel" data-for="dom-idbtransactionmode-versionchange" id="infopanel-for-dom-idbtransactionmode-versionchange" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransactionmode-versionchange" style="display:none">Info about the '"versionchange"' definition.</span><b><a href="#dom-idbtransactionmode-versionchange">#dom-idbtransactionmode-versionchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransactionmode-versionchange">2.7. Transactions</a>
     <li><a href="#ref-for-dom-idbtransactionmode-versionchange①">2.7.3. Upgrade transactions</a>
     <li><a href="#ref-for-dom-idbtransactionmode-versionchange②">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-objectstorenames">
-   <b><a href="#dom-idbtransaction-objectstorenames">#dom-idbtransaction-objectstorenames</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-objectstorenames" class="dfn-panel" data-for="dom-idbtransaction-objectstorenames" id="infopanel-for-dom-idbtransaction-objectstorenames" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-objectstorenames" style="display:none">Info about the 'objectStoreNames' definition.</span><b><a href="#dom-idbtransaction-objectstorenames">#dom-idbtransaction-objectstorenames</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-objectstorenames">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-objectstorenames①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-mode">
-   <b><a href="#dom-idbtransaction-mode">#dom-idbtransaction-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-mode" class="dfn-panel" data-for="dom-idbtransaction-mode" id="infopanel-for-dom-idbtransaction-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-idbtransaction-mode">#dom-idbtransaction-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-mode">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-durability">
-   <b><a href="#dom-idbtransaction-durability">#dom-idbtransaction-durability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-durability" class="dfn-panel" data-for="dom-idbtransaction-durability" id="infopanel-for-dom-idbtransaction-durability" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-durability" style="display:none">Info about the 'durability' definition.</span><b><a href="#dom-idbtransaction-durability">#dom-idbtransaction-durability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-durability">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-durability①">(2)</a> <a href="#ref-for-dom-idbtransaction-durability②">(3)</a>
     <li><a href="#ref-for-dom-idbtransaction-durability③">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-db">
-   <b><a href="#dom-idbtransaction-db">#dom-idbtransaction-db</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-db" class="dfn-panel" data-for="dom-idbtransaction-db" id="infopanel-for-dom-idbtransaction-db" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-db" style="display:none">Info about the 'db' definition.</span><b><a href="#dom-idbtransaction-db">#dom-idbtransaction-db</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-db">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-db①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-error">
-   <b><a href="#dom-idbtransaction-error">#dom-idbtransaction-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-error" class="dfn-panel" data-for="dom-idbtransaction-error" id="infopanel-for-dom-idbtransaction-error" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-idbtransaction-error">#dom-idbtransaction-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-error">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-error①">(2)</a>
     <li><a href="#ref-for-dom-idbtransaction-error②">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-objectstore">
-   <b><a href="#dom-idbtransaction-objectstore">#dom-idbtransaction-objectstore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-objectstore" class="dfn-panel" data-for="dom-idbtransaction-objectstore" id="infopanel-for-dom-idbtransaction-objectstore" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-objectstore" style="display:none">Info about the 'objectStore(name)' definition.</span><b><a href="#dom-idbtransaction-objectstore">#dom-idbtransaction-objectstore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-objectstore">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-objectstore①">(2)</a>
     <li><a href="#ref-for-dom-idbtransaction-objectstore②">5.8. Aborting an upgrade transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-abort">
-   <b><a href="#dom-idbtransaction-abort">#dom-idbtransaction-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-abort" class="dfn-panel" data-for="dom-idbtransaction-abort" id="infopanel-for-dom-idbtransaction-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-idbtransaction-abort">#dom-idbtransaction-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-abort">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-dom-idbtransaction-abort①">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-abort②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-commit">
-   <b><a href="#dom-idbtransaction-commit">#dom-idbtransaction-commit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-commit" class="dfn-panel" data-for="dom-idbtransaction-commit" id="infopanel-for-dom-idbtransaction-commit" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-commit" style="display:none">Info about the 'commit()' definition.</span><b><a href="#dom-idbtransaction-commit">#dom-idbtransaction-commit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-commit">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-dom-idbtransaction-commit①">4.9. The IDBTransaction interface</a> <a href="#ref-for-dom-idbtransaction-commit②">(2)</a> <a href="#ref-for-dom-idbtransaction-commit③">(3)</a> <a href="#ref-for-dom-idbtransaction-commit④">(4)</a>
     <li><a href="#ref-for-dom-idbtransaction-commit⑤">11. Revision history</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-onabort">
-   <b><a href="#dom-idbtransaction-onabort">#dom-idbtransaction-onabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-onabort" class="dfn-panel" data-for="dom-idbtransaction-onabort" id="infopanel-for-dom-idbtransaction-onabort" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-onabort" style="display:none">Info about the 'onabort' definition.</span><b><a href="#dom-idbtransaction-onabort">#dom-idbtransaction-onabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-onabort">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-oncomplete">
-   <b><a href="#dom-idbtransaction-oncomplete">#dom-idbtransaction-oncomplete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-oncomplete" class="dfn-panel" data-for="dom-idbtransaction-oncomplete" id="infopanel-for-dom-idbtransaction-oncomplete" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-oncomplete" style="display:none">Info about the 'oncomplete' definition.</span><b><a href="#dom-idbtransaction-oncomplete">#dom-idbtransaction-oncomplete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-oncomplete">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-idbtransaction-onerror">
-   <b><a href="#dom-idbtransaction-onerror">#dom-idbtransaction-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-idbtransaction-onerror" class="dfn-panel" data-for="dom-idbtransaction-onerror" id="infopanel-for-dom-idbtransaction-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-idbtransaction-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-idbtransaction-onerror">#dom-idbtransaction-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbtransaction-onerror">4.9. The IDBTransaction interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="open-a-database">
-   <b><a href="#open-a-database">#open-a-database</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-open-a-database" class="dfn-panel" data-for="open-a-database" id="infopanel-for-open-a-database" role="dialog">
+   <span id="infopaneltitle-for-open-a-database" style="display:none">Info about the 'open a database' definition.</span><b><a href="#open-a-database">#open-a-database</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-open-a-database">2.7.3. Upgrade transactions</a>
     <li><a href="#ref-for-open-a-database①">4.3. The IDBFactory interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="close-a-database-connection">
-   <b><a href="#close-a-database-connection">#close-a-database-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-close-a-database-connection" class="dfn-panel" data-for="close-a-database-connection" id="infopanel-for-close-a-database-connection" role="dialog">
+   <span id="infopaneltitle-for-close-a-database-connection" style="display:none">Info about the 'close a database connection' definition.</span><b><a href="#close-a-database-connection">#close-a-database-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-a-database-connection">2.1.1. Database connection</a> <a href="#ref-for-close-a-database-connection①">(2)</a>
     <li><a href="#ref-for-close-a-database-connection②">4.4. The IDBDatabase interface</a>
     <li><a href="#ref-for-close-a-database-connection③">5.1. Opening a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delete-a-database">
-   <b><a href="#delete-a-database">#delete-a-database</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delete-a-database" class="dfn-panel" data-for="delete-a-database" id="infopanel-for-delete-a-database" role="dialog">
+   <span id="infopaneltitle-for-delete-a-database" style="display:none">Info about the 'delete a database' definition.</span><b><a href="#delete-a-database">#delete-a-database</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delete-a-database">4.3. The IDBFactory interface</a>
     <li><a href="#ref-for-delete-a-database①">5.2. Closing a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="commit-a-transaction">
-   <b><a href="#commit-a-transaction">#commit-a-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-commit-a-transaction" class="dfn-panel" data-for="commit-a-transaction" id="infopanel-for-commit-a-transaction" role="dialog">
+   <span id="infopaneltitle-for-commit-a-transaction" style="display:none">Info about the 'commit a transaction' definition.</span><b><a href="#commit-a-transaction">#commit-a-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-commit-a-transaction">4.9. The IDBTransaction interface</a>
     <li><a href="#ref-for-commit-a-transaction①">5.7. Running an upgrade transaction</a>
@@ -11851,8 +11852,8 @@ specification.</p>
     <li><a href="#ref-for-commit-a-transaction③">5.10. Firing an error event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-a-transaction">
-   <b><a href="#abort-a-transaction">#abort-a-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-a-transaction" class="dfn-panel" data-for="abort-a-transaction" id="infopanel-for-abort-a-transaction" role="dialog">
+   <span id="infopaneltitle-for-abort-a-transaction" style="display:none">Info about the 'abort a transaction' definition.</span><b><a href="#abort-a-transaction">#abort-a-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-a-transaction">2.7.1. Transaction lifecycle</a>
     <li><a href="#ref-for-abort-a-transaction①">4.4. The IDBDatabase interface</a>
@@ -11867,8 +11868,8 @@ specification.</p>
     <li><a href="#ref-for-abort-a-transaction①②">5.10. Firing an error event</a> <a href="#ref-for-abort-a-transaction①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="asynchronously-execute-a-request">
-   <b><a href="#asynchronously-execute-a-request">#asynchronously-execute-a-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-asynchronously-execute-a-request" class="dfn-panel" data-for="asynchronously-execute-a-request" id="infopanel-for-asynchronously-execute-a-request" role="dialog">
+   <span id="infopaneltitle-for-asynchronously-execute-a-request" style="display:none">Info about the 'asynchronously execute a request' definition.</span><b><a href="#asynchronously-execute-a-request">#asynchronously-execute-a-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronously-execute-a-request">2.8. Requests</a>
     <li><a href="#ref-for-asynchronously-execute-a-request①">4.5. The IDBObjectStore interface</a> <a href="#ref-for-asynchronously-execute-a-request②">(2)</a> <a href="#ref-for-asynchronously-execute-a-request③">(3)</a> <a href="#ref-for-asynchronously-execute-a-request④">(4)</a> <a href="#ref-for-asynchronously-execute-a-request⑤">(5)</a> <a href="#ref-for-asynchronously-execute-a-request⑥">(6)</a> <a href="#ref-for-asynchronously-execute-a-request⑦">(7)</a> <a href="#ref-for-asynchronously-execute-a-request⑧">(8)</a> <a href="#ref-for-asynchronously-execute-a-request⑨">(9)</a> <a href="#ref-for-asynchronously-execute-a-request①⓪">(10)</a>
@@ -11878,8 +11879,8 @@ specification.</p>
     <li><a href="#ref-for-asynchronously-execute-a-request②④">6. Database operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-an-upgrade-transaction">
-   <b><a href="#run-an-upgrade-transaction">#run-an-upgrade-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-an-upgrade-transaction" class="dfn-panel" data-for="run-an-upgrade-transaction" id="infopanel-for-run-an-upgrade-transaction" role="dialog">
+   <span id="infopaneltitle-for-run-an-upgrade-transaction" style="display:none">Info about the 'run an upgrade transaction' definition.</span><b><a href="#run-an-upgrade-transaction">#run-an-upgrade-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-an-upgrade-transaction">2.7.3. Upgrade transactions</a>
     <li><a href="#ref-for-run-an-upgrade-transaction①">4.2. Event interfaces</a>
@@ -11887,120 +11888,122 @@ specification.</p>
     <li><a href="#ref-for-run-an-upgrade-transaction③">5.2. Closing a database</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-an-upgrade-transaction">
-   <b><a href="#abort-an-upgrade-transaction">#abort-an-upgrade-transaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-an-upgrade-transaction" class="dfn-panel" data-for="abort-an-upgrade-transaction" id="infopanel-for-abort-an-upgrade-transaction" role="dialog">
+   <span id="infopaneltitle-for-abort-an-upgrade-transaction" style="display:none">Info about the 'abort an upgrade transaction' definition.</span><b><a href="#abort-an-upgrade-transaction">#abort-an-upgrade-transaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-an-upgrade-transaction">2.1.1. Database connection</a>
     <li><a href="#ref-for-abort-an-upgrade-transaction①">5.5. Aborting a transaction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-success-event">
-   <b><a href="#fire-a-success-event">#fire-a-success-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-success-event" class="dfn-panel" data-for="fire-a-success-event" id="infopanel-for-fire-a-success-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-success-event" style="display:none">Info about the 'fire a success event' definition.</span><b><a href="#fire-a-success-event">#fire-a-success-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-success-event">4.3. The IDBFactory interface</a> <a href="#ref-for-fire-a-success-event①">(2)</a>
     <li><a href="#ref-for-fire-a-success-event②">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-an-error-event">
-   <b><a href="#fire-an-error-event">#fire-an-error-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-an-error-event" class="dfn-panel" data-for="fire-an-error-event" id="infopanel-for-fire-an-error-event" role="dialog">
+   <span id="infopaneltitle-for-fire-an-error-event" style="display:none">Info about the 'fire an error event' definition.</span><b><a href="#fire-an-error-event">#fire-an-error-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-error-event">4.3. The IDBFactory interface</a> <a href="#ref-for-fire-an-error-event①">(2)</a>
     <li><a href="#ref-for-fire-an-error-event②">5.6. Asynchronously executing a request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clone">
-   <b><a href="#clone">#clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clone" class="dfn-panel" data-for="clone" id="infopanel-for-clone" role="dialog">
+   <span id="infopaneltitle-for-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#clone">#clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clone">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-clone①">4.8. The IDBCursor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="store-a-record-into-an-object-store">
-   <b><a href="#store-a-record-into-an-object-store">#store-a-record-into-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-store-a-record-into-an-object-store" class="dfn-panel" data-for="store-a-record-into-an-object-store" id="infopanel-for-store-a-record-into-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-store-a-record-into-an-object-store" style="display:none">Info about the 'store a record into an object store' definition.</span><b><a href="#store-a-record-into-an-object-store">#store-a-record-into-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-store-a-record-into-an-object-store">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-store-a-record-into-an-object-store①">4.8. The IDBCursor interface</a> <a href="#ref-for-store-a-record-into-an-object-store②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-a-value-from-an-object-store">
-   <b><a href="#retrieve-a-value-from-an-object-store">#retrieve-a-value-from-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-a-value-from-an-object-store" class="dfn-panel" data-for="retrieve-a-value-from-an-object-store" id="infopanel-for-retrieve-a-value-from-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-retrieve-a-value-from-an-object-store" style="display:none">Info about the 'retrieve a value from an object store' definition.</span><b><a href="#retrieve-a-value-from-an-object-store">#retrieve-a-value-from-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-a-value-from-an-object-store">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-multiple-values-from-an-object-store">
-   <b><a href="#retrieve-multiple-values-from-an-object-store">#retrieve-multiple-values-from-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-multiple-values-from-an-object-store" class="dfn-panel" data-for="retrieve-multiple-values-from-an-object-store" id="infopanel-for-retrieve-multiple-values-from-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-retrieve-multiple-values-from-an-object-store" style="display:none">Info about the 'retrieve multiple values from an object
+store' definition.</span><b><a href="#retrieve-multiple-values-from-an-object-store">#retrieve-multiple-values-from-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-multiple-values-from-an-object-store">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-a-key-from-an-object-store">
-   <b><a href="#retrieve-a-key-from-an-object-store">#retrieve-a-key-from-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-a-key-from-an-object-store" class="dfn-panel" data-for="retrieve-a-key-from-an-object-store" id="infopanel-for-retrieve-a-key-from-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-retrieve-a-key-from-an-object-store" style="display:none">Info about the 'retrieve a key from an object store' definition.</span><b><a href="#retrieve-a-key-from-an-object-store">#retrieve-a-key-from-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-a-key-from-an-object-store">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-multiple-keys-from-an-object-store">
-   <b><a href="#retrieve-multiple-keys-from-an-object-store">#retrieve-multiple-keys-from-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-multiple-keys-from-an-object-store" class="dfn-panel" data-for="retrieve-multiple-keys-from-an-object-store" id="infopanel-for-retrieve-multiple-keys-from-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-retrieve-multiple-keys-from-an-object-store" style="display:none">Info about the 'retrieve multiple keys from an object store' definition.</span><b><a href="#retrieve-multiple-keys-from-an-object-store">#retrieve-multiple-keys-from-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-multiple-keys-from-an-object-store">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-a-referenced-value-from-an-index">
-   <b><a href="#retrieve-a-referenced-value-from-an-index">#retrieve-a-referenced-value-from-an-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-a-referenced-value-from-an-index" class="dfn-panel" data-for="retrieve-a-referenced-value-from-an-index" id="infopanel-for-retrieve-a-referenced-value-from-an-index" role="dialog">
+   <span id="infopaneltitle-for-retrieve-a-referenced-value-from-an-index" style="display:none">Info about the 'retrieve a referenced value from an index' definition.</span><b><a href="#retrieve-a-referenced-value-from-an-index">#retrieve-a-referenced-value-from-an-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-a-referenced-value-from-an-index">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-multiple-referenced-values-from-an-index">
-   <b><a href="#retrieve-multiple-referenced-values-from-an-index">#retrieve-multiple-referenced-values-from-an-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-multiple-referenced-values-from-an-index" class="dfn-panel" data-for="retrieve-multiple-referenced-values-from-an-index" id="infopanel-for-retrieve-multiple-referenced-values-from-an-index" role="dialog">
+   <span id="infopaneltitle-for-retrieve-multiple-referenced-values-from-an-index" style="display:none">Info about the 'retrieve multiple referenced values from an
+index' definition.</span><b><a href="#retrieve-multiple-referenced-values-from-an-index">#retrieve-multiple-referenced-values-from-an-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-multiple-referenced-values-from-an-index">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-a-value-from-an-index">
-   <b><a href="#retrieve-a-value-from-an-index">#retrieve-a-value-from-an-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-a-value-from-an-index" class="dfn-panel" data-for="retrieve-a-value-from-an-index" id="infopanel-for-retrieve-a-value-from-an-index" role="dialog">
+   <span id="infopaneltitle-for-retrieve-a-value-from-an-index" style="display:none">Info about the 'retrieve a value from an index' definition.</span><b><a href="#retrieve-a-value-from-an-index">#retrieve-a-value-from-an-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-a-value-from-an-index">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retrieve-multiple-values-from-an-index">
-   <b><a href="#retrieve-multiple-values-from-an-index">#retrieve-multiple-values-from-an-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retrieve-multiple-values-from-an-index" class="dfn-panel" data-for="retrieve-multiple-values-from-an-index" id="infopanel-for-retrieve-multiple-values-from-an-index" role="dialog">
+   <span id="infopaneltitle-for-retrieve-multiple-values-from-an-index" style="display:none">Info about the 'retrieve multiple values from an index' definition.</span><b><a href="#retrieve-multiple-values-from-an-index">#retrieve-multiple-values-from-an-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retrieve-multiple-values-from-an-index">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="delete-records-from-an-object-store">
-   <b><a href="#delete-records-from-an-object-store">#delete-records-from-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-delete-records-from-an-object-store" class="dfn-panel" data-for="delete-records-from-an-object-store" id="infopanel-for-delete-records-from-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-delete-records-from-an-object-store" style="display:none">Info about the 'delete records from an object store' definition.</span><b><a href="#delete-records-from-an-object-store">#delete-records-from-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delete-records-from-an-object-store">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-delete-records-from-an-object-store①">4.8. The IDBCursor interface</a>
     <li><a href="#ref-for-delete-records-from-an-object-store②">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="count-the-records-in-a-range">
-   <b><a href="#count-the-records-in-a-range">#count-the-records-in-a-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-count-the-records-in-a-range" class="dfn-panel" data-for="count-the-records-in-a-range" id="infopanel-for-count-the-records-in-a-range" role="dialog">
+   <span id="infopaneltitle-for-count-the-records-in-a-range" style="display:none">Info about the 'count the records in a range' definition.</span><b><a href="#count-the-records-in-a-range">#count-the-records-in-a-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-count-the-records-in-a-range">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-count-the-records-in-a-range①">4.6. The IDBIndex interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clear-an-object-store">
-   <b><a href="#clear-an-object-store">#clear-an-object-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clear-an-object-store" class="dfn-panel" data-for="clear-an-object-store" id="infopanel-for-clear-an-object-store" role="dialog">
+   <span id="infopaneltitle-for-clear-an-object-store" style="display:none">Info about the 'clear an object store' definition.</span><b><a href="#clear-an-object-store">#clear-an-object-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear-an-object-store">4.5. The IDBObjectStore interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iterate-a-cursor">
-   <b><a href="#iterate-a-cursor">#iterate-a-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iterate-a-cursor" class="dfn-panel" data-for="iterate-a-cursor" id="infopanel-for-iterate-a-cursor" role="dialog">
+   <span id="infopaneltitle-for-iterate-a-cursor" style="display:none">Info about the 'iterate a cursor' definition.</span><b><a href="#iterate-a-cursor">#iterate-a-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iterate-a-cursor">4.5. The IDBObjectStore interface</a> <a href="#ref-for-iterate-a-cursor①">(2)</a>
     <li><a href="#ref-for-iterate-a-cursor②">4.6. The IDBIndex interface</a> <a href="#ref-for-iterate-a-cursor③">(2)</a>
     <li><a href="#ref-for-iterate-a-cursor④">4.8. The IDBCursor interface</a> <a href="#ref-for-iterate-a-cursor⑤">(2)</a> <a href="#ref-for-iterate-a-cursor⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-a-key-from-a-value-using-a-key-path">
-   <b><a href="#extract-a-key-from-a-value-using-a-key-path">#extract-a-key-from-a-value-using-a-key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-a-key-from-a-value-using-a-key-path" class="dfn-panel" data-for="extract-a-key-from-a-value-using-a-key-path" id="infopanel-for-extract-a-key-from-a-value-using-a-key-path" role="dialog">
+   <span id="infopaneltitle-for-extract-a-key-from-a-value-using-a-key-path" style="display:none">Info about the 'extract a key from a value using a key path' definition.</span><b><a href="#extract-a-key-from-a-value-using-a-key-path">#extract-a-key-from-a-value-using-a-key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-a-key-from-a-value-using-a-key-path">2.6. Index</a>
     <li><a href="#ref-for-extract-a-key-from-a-value-using-a-key-path①">4.5. The IDBObjectStore interface</a>
@@ -12008,27 +12011,27 @@ specification.</p>
     <li><a href="#ref-for-extract-a-key-from-a-value-using-a-key-path③">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="evaluate-a-key-path-on-a-value">
-   <b><a href="#evaluate-a-key-path-on-a-value">#evaluate-a-key-path-on-a-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-evaluate-a-key-path-on-a-value" class="dfn-panel" data-for="evaluate-a-key-path-on-a-value" id="infopanel-for-evaluate-a-key-path-on-a-value" role="dialog">
+   <span id="infopaneltitle-for-evaluate-a-key-path-on-a-value" style="display:none">Info about the 'evaluate a key path on a value' definition.</span><b><a href="#evaluate-a-key-path-on-a-value">#evaluate-a-key-path-on-a-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-evaluate-a-key-path-on-a-value">7.1. Extract a key from a value</a> <a href="#ref-for-evaluate-a-key-path-on-a-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-that-a-key-could-be-injected-into-a-value">
-   <b><a href="#check-that-a-key-could-be-injected-into-a-value">#check-that-a-key-could-be-injected-into-a-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-that-a-key-could-be-injected-into-a-value" class="dfn-panel" data-for="check-that-a-key-could-be-injected-into-a-value" id="infopanel-for-check-that-a-key-could-be-injected-into-a-value" role="dialog">
+   <span id="infopaneltitle-for-check-that-a-key-could-be-injected-into-a-value" style="display:none">Info about the 'check that a key could be injected into a value' definition.</span><b><a href="#check-that-a-key-could-be-injected-into-a-value">#check-that-a-key-could-be-injected-into-a-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-that-a-key-could-be-injected-into-a-value">4.5. The IDBObjectStore interface</a>
     <li><a href="#ref-for-check-that-a-key-could-be-injected-into-a-value①">7.2. Inject a key into a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inject-a-key-into-a-value-using-a-key-path">
-   <b><a href="#inject-a-key-into-a-value-using-a-key-path">#inject-a-key-into-a-value-using-a-key-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inject-a-key-into-a-value-using-a-key-path" class="dfn-panel" data-for="inject-a-key-into-a-value-using-a-key-path" id="infopanel-for-inject-a-key-into-a-value-using-a-key-path" role="dialog">
+   <span id="infopaneltitle-for-inject-a-key-into-a-value-using-a-key-path" style="display:none">Info about the 'inject a key into a value using a key path' definition.</span><b><a href="#inject-a-key-into-a-value-using-a-key-path">#inject-a-key-into-a-value-using-a-key-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inject-a-key-into-a-value-using-a-key-path">6.1. Object store storage operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-key-to-a-value">
-   <b><a href="#convert-a-key-to-a-value">#convert-a-key-to-a-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-key-to-a-value" class="dfn-panel" data-for="convert-a-key-to-a-value" id="infopanel-for-convert-a-key-to-a-value" role="dialog">
+   <span id="infopaneltitle-for-convert-a-key-to-a-value" style="display:none">Info about the 'convert a key to a value' definition.</span><b><a href="#convert-a-key-to-a-value">#convert-a-key-to-a-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-key-to-a-value">4.7. The IDBKeyRange interface</a> <a href="#ref-for-convert-a-key-to-a-value①">(2)</a>
     <li><a href="#ref-for-convert-a-key-to-a-value②">4.8. The IDBCursor interface</a> <a href="#ref-for-convert-a-key-to-a-value③">(2)</a>
@@ -12038,8 +12041,8 @@ specification.</p>
     <li><a href="#ref-for-convert-a-key-to-a-value⑨">7.3. Convert a key to a value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-value-to-a-key">
-   <b><a href="#convert-a-value-to-a-key">#convert-a-value-to-a-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-value-to-a-key" class="dfn-panel" data-for="convert-a-value-to-a-key" id="infopanel-for-convert-a-value-to-a-key" role="dialog">
+   <span id="infopaneltitle-for-convert-a-value-to-a-key" style="display:none">Info about the 'convert a value to a key' definition.</span><b><a href="#convert-a-value-to-a-key">#convert-a-value-to-a-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-value-to-a-key">2.4. Keys</a>
     <li><a href="#ref-for-convert-a-value-to-a-key①">2.9. Key range</a>
@@ -12051,67 +12054,123 @@ specification.</p>
     <li><a href="#ref-for-convert-a-value-to-a-key①⑤">7.4. Convert a value to a key</a> <a href="#ref-for-convert-a-value-to-a-key①⑥">(2)</a> <a href="#ref-for-convert-a-value-to-a-key①⑦">(3)</a> <a href="#ref-for-convert-a-value-to-a-key①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-value-to-a-multientry-key">
-   <b><a href="#convert-a-value-to-a-multientry-key">#convert-a-value-to-a-multientry-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-value-to-a-multientry-key" class="dfn-panel" data-for="convert-a-value-to-a-multientry-key" id="infopanel-for-convert-a-value-to-a-multientry-key" role="dialog">
+   <span id="infopaneltitle-for-convert-a-value-to-a-multientry-key" style="display:none">Info about the 'convert a value to a multiEntry key' definition.</span><b><a href="#convert-a-value-to-a-multientry-key">#convert-a-value-to-a-multientry-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-value-to-a-multientry-key">7.1. Extract a key from a value</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/IntersectionObserver/index.html
+++ b/tests/github/w3c/IntersectionObserver/index.html
@@ -1994,8 +1994,8 @@ specification.</p>
    <li><a href="#unobserve-a-target-element">unobserve a target Element</a><span>, in § 3.2.3</span>
    <li><a href="#dom-intersectionobserver-unobserve">unobserve(target)</a><span>, in § 2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-domhighrestimestamp">
-   <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domhighrestimestamp" class="dfn-panel" data-for="term-for-domhighrestimestamp" id="infopanel-for-term-for-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domhighrestimestamp">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-domhighrestimestamp①">(2)</a> <a href="#ref-for-domhighrestimestamp②">(3)</a> <a href="#ref-for-domhighrestimestamp③">(4)</a>
@@ -2004,20 +2004,20 @@ Queue an IntersectionObserverEntry</a>
     <li><a href="#ref-for-domhighrestimestamp⑤">5. Privacy and Security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-simple-exception">
-   <a href="https://heycam.github.io/webidl/#dfn-simple-exception">https://heycam.github.io/webidl/#dfn-simple-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-simple-exception" class="dfn-panel" data-for="term-for-dfn-simple-exception" id="infopanel-for-term-for-dfn-simple-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-simple-exception" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-simple-exception">https://heycam.github.io/webidl/#dfn-simple-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-simple-exception">3.2.1. Initialize a new IntersectionObserver</a> <a href="#ref-for-dfn-simple-exception①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-simple-exception">
-   <a href="https://heycam.github.io/webidl/#dfn-simple-exception">https://heycam.github.io/webidl/#dfn-simple-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-simple-exception" class="dfn-panel" data-for="term-for-dfn-simple-exception" id="infopanel-for-term-for-dfn-simple-exception①" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-simple-exception①" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-simple-exception">https://heycam.github.io/webidl/#dfn-simple-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-simple-exception">3.2.1. Initialize a new IntersectionObserver</a> <a href="#ref-for-dfn-simple-exception①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.3. 
 The IntersectionObserverEntry interface</a>
@@ -2025,36 +2025,36 @@ The IntersectionObserverEntry interface</a>
 Compute the Intersection of a Target Element and the Root</a> <a href="#ref-for-browsing-context②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context-container">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context-container" class="dfn-panel" data-for="term-for-browsing-context-container" id="infopanel-for-term-for-browsing-context-container" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context-container" style="display:none">Info about the 'browsing context container' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-container">3.2.7. 
 Compute the Intersection of a Target Element and the Root</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-this-value">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value">https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-this-value" class="dfn-panel" data-for="term-for-dfn-callback-this-value" id="infopanel-for-term-for-dfn-callback-this-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value">https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">3.2.5. 
 Notify Intersection Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">http://www.w3.org/TR/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="http://www.w3.org/TR/css-masking-1/#propdef-clip-path">http://www.w3.org/TR/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">3.2.7. 
 Compute the Intersection of a Target Element and the Root</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-box/#containing-block">https://drafts.csswg.org/css-box/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-box/#containing-block">https://drafts.csswg.org/css-box/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3.2.7. 
 Compute the Intersection of a Target Element and the Root</a> <a href="#ref-for-containing-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://drafts.csswg.org/css-display/#containing-block-chain">https://drafts.csswg.org/css-display/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://drafts.csswg.org/css-display/#containing-block-chain">https://drafts.csswg.org/css-display/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">2.2. 
 The IntersectionObserver interface</a>
@@ -2062,22 +2062,22 @@ The IntersectionObserver interface</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-area">
-   <a href="https://drafts.csswg.org/css-box/#content-area">https://drafts.csswg.org/css-box/#content-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-area" class="dfn-panel" data-for="term-for-content-area" id="infopanel-for-term-for-content-area" role="menu">
+   <span id="infopaneltitle-for-term-for-content-area" style="display:none">Info about the 'content area' external reference.</span><a href="https://drafts.csswg.org/css-box/#content-area">https://drafts.csswg.org/css-box/#content-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#document">https://html.spec.whatwg.org/multipage/dom.html#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#document">https://html.spec.whatwg.org/multipage/dom.html#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://heycam.github.io/webidl/#idl-double">https://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://heycam.github.io/webidl/#idl-double">https://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-idl-double①">(2)</a>
@@ -2087,15 +2087,15 @@ The IntersectionObserverEntry interface</a> <a href="#ref-for-idl-double③">(2)
 The IntersectionObserverInit dictionary</a> <a href="#ref-for-idl-double⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">3.2.4. 
 Queue an Intersection Observer Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">https://html.spec.whatwg.org/multipage/browsers.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#fully-active">https://html.spec.whatwg.org/multipage/browsers.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">2.2. 
 The IntersectionObserver interface</a>
@@ -2103,23 +2103,23 @@ The IntersectionObserver interface</a>
 HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop-processing-model">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop-processing-model" class="dfn-panel" data-for="term-for-event-loop-processing-model" id="infopanel-for-term-for-event-loop-processing-model" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop-processing-model" style="display:none">Info about the 'html processing model' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop-processing-model">3.4.1. 
 HTML Processing Model: Event Loop</a>
     <li><a href="#ref-for-event-loop-processing-model①">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts" id="infopanel-for-term-for-list-of-the-descendant-browsing-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" style="display:none">Info about the 'list of the descendant browsing contexts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-the-descendant-browsing-contexts">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nested-browsing-context" class="dfn-panel" data-for="term-for-nested-browsing-context" id="infopanel-for-term-for-nested-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-nested-browsing-context" style="display:none">Info about the 'nested browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">2.2. 
 The IntersectionObserver interface</a>
@@ -2127,63 +2127,63 @@ The IntersectionObserver interface</a>
 Compute the Intersection of a Target Element and the Root</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#origin">https://html.spec.whatwg.org/multipage/origin.html#origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin" class="dfn-panel" data-for="term-for-origin" id="infopanel-for-term-for-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#origin">https://html.spec.whatwg.org/multipage/origin.html#origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pinch-zoom">
-   <a href="https://drafts.csswg.org/cssom-view-1/#pinch-zoom">https://drafts.csswg.org/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pinch-zoom" class="dfn-panel" data-for="term-for-pinch-zoom" id="infopanel-for-term-for-pinch-zoom" role="menu">
+   <span id="infopaneltitle-for-term-for-pinch-zoom" style="display:none">Info about the 'pinch zoom' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#pinch-zoom">https://drafts.csswg.org/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinch-zoom">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.2.4. 
 Queue an Intersection Observer Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">3.2.5. 
 Notify Intersection Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/webappapis.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks" id="infopanel-for-term-for-run-the-animation-frame-callbacks" role="menu">
+   <span id="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" style="display:none">Info about the 'run the animation frame callbacks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/webappapis.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-animation-frame-callbacks">3.4.1. 
 HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.2.1. Initialize a new IntersectionObserver</a> <a href="#ref-for-dfn-throw①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-origin">
-   <a href="http://www.w3.org/TR/hr-time/#time-origin">http://www.w3.org/TR/hr-time/#time-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-origin" class="dfn-panel" data-for="term-for-time-origin" id="infopanel-for-term-for-time-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-time-origin" style="display:none">Info about the 'time origin' external reference.</span><a href="http://www.w3.org/TR/hr-time/#time-origin">http://www.w3.org/TR/hr-time/#time-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-origin">2.3. 
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-top-level-browsing-context①">(2)</a> <a href="#ref-for-top-level-browsing-context②">(3)</a> <a href="#ref-for-top-level-browsing-context③">(4)</a>
@@ -2192,15 +2192,15 @@ Run the Update Intersection Observations Steps</a>
     <li><a href="#ref-for-top-level-browsing-context⑤">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://heycam.github.io/webidl/#idl-undefined">https://heycam.github.io/webidl/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.1. 
 The IntersectionObserverCallback</a>
@@ -2208,8 +2208,8 @@ The IntersectionObserverCallback</a>
 The IntersectionObserver interface</a> <a href="#ref-for-idl-undefined②">(2)</a> <a href="#ref-for-idl-undefined③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://drafts.csswg.org/css2/visuren.html#viewport">https://drafts.csswg.org/css2/visuren.html#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://drafts.csswg.org/css2/visuren.html#viewport">https://drafts.csswg.org/css2/visuren.html#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">1. Introduction</a> <a href="#ref-for-viewport①">(2)</a>
     <li><a href="#ref-for-viewport②">2.2. 
@@ -2218,8 +2218,8 @@ The IntersectionObserver interface</a> <a href="#ref-for-viewport③">(2)</a>
 Compute the Intersection of a Target Element and the Root</a> <a href="#ref-for-viewport⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">2.2. 
 The IntersectionObserver interface</a>
@@ -2227,15 +2227,15 @@ The IntersectionObserver interface</a>
 The IntersectionObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-list-of-component-values">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-list-of-component-values" class="dfn-panel" data-for="term-for-parse-a-list-of-component-values" id="infopanel-for-term-for-parse-a-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-list-of-component-values" style="display:none">Info about the 'parse a list of component values' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-component-values">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-length">
-   <a href="https://drafts.csswg.org/css-values-3/#absolute-length">https://drafts.csswg.org/css-values-3/#absolute-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-length" class="dfn-panel" data-for="term-for-absolute-length" id="infopanel-for-term-for-absolute-length" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-length" style="display:none">Info about the 'absolute length' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#absolute-length">https://drafts.csswg.org/css-values-3/#absolute-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-length">2.2. 
 The IntersectionObserver interface</a>
@@ -2243,22 +2243,22 @@ The IntersectionObserver interface</a>
 The IntersectionObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dimension">
-   <a href="https://drafts.csswg.org/css-values-3/#dimension">https://drafts.csswg.org/css-values-3/#dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dimension" class="dfn-panel" data-for="term-for-dimension" id="infopanel-for-term-for-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-dimension" style="display:none">Info about the 'dimension' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#dimension">https://drafts.csswg.org/css-values-3/#dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">2.2. 
 The IntersectionObserver interface</a>
@@ -2272,8 +2272,8 @@ Compute the Intersection of a Target Element and the Root</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document①" role="menu">
+   <span id="infopaneltitle-for-term-for-document①" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document①">2.2. 
 The IntersectionObserver interface</a>
@@ -2281,8 +2281,8 @@ The IntersectionObserver interface</a>
 The IntersectionObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a> <a href="#ref-for-element④">(5)</a> <a href="#ref-for-element⑤">(6)</a> <a href="#ref-for-element⑥">(7)</a> <a href="#ref-for-element⑦">(8)</a>
@@ -2300,50 +2300,50 @@ Queue an IntersectionObserverEntry</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mutationobserver">
-   <a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mutationobserver" class="dfn-panel" data-for="term-for-mutationobserver" id="infopanel-for-term-for-mutationobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-mutationobserver" style="display:none">Info about the 'MutationObserver' external reference.</span><a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationobserver">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-mutationobserver①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-mutationobserverinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-mutationobserverinit">https://dom.spec.whatwg.org/#dictdef-mutationobserverinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-mutationobserverinit" class="dfn-panel" data-for="term-for-dictdef-mutationobserverinit" id="infopanel-for-term-for-dictdef-mutationobserverinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-mutationobserverinit" style="display:none">Info about the 'MutationObserverInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-mutationobserverinit">https://dom.spec.whatwg.org/#dictdef-mutationobserverinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mutationobserverinit">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mutationobserver-observe">
-   <a href="https://dom.spec.whatwg.org/#dom-mutationobserver-observe">https://dom.spec.whatwg.org/#dom-mutationobserver-observe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mutationobserver-observe" class="dfn-panel" data-for="term-for-dom-mutationobserver-observe" id="infopanel-for-term-for-dom-mutationobserver-observe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mutationobserver-observe" style="display:none">Info about the 'observe(target)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-mutationobserver-observe">https://dom.spec.whatwg.org/#dom-mutationobserver-observe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserver-observe">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrect">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrect" class="dfn-panel" data-for="term-for-domrect" id="infopanel-for-term-for-domrect" role="menu">
+   <span id="infopaneltitle-for-term-for-domrect" style="display:none">Info about the 'DOMRect' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">3.2.6. 
 Queue an IntersectionObserverEntry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-domrectinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-domrectinit">https://drafts.fxtf.org/geometry-1/#dictdef-domrectinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-domrectinit" class="dfn-panel" data-for="term-for-dictdef-domrectinit" id="infopanel-for-term-for-dictdef-domrectinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-domrectinit" style="display:none">Info about the 'DOMRectInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-domrectinit">https://drafts.fxtf.org/geometry-1/#dictdef-domrectinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-domrectinit">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-dictdef-domrectinit①">(2)</a> <a href="#ref-for-dictdef-domrectinit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-domrectreadonly①">(2)</a> <a href="#ref-for-domrectreadonly②">(3)</a> <a href="#ref-for-domrectreadonly③">(4)</a> <a href="#ref-for-domrectreadonly④">(5)</a> <a href="#ref-for-domrectreadonly⑤">(6)</a> <a href="#ref-for-domrectreadonly⑥">(7)</a>
@@ -2351,8 +2351,8 @@ The IntersectionObserverEntry interface</a> <a href="#ref-for-domrectreadonly①
 Run the Update Intersection Observations Steps</a> <a href="#ref-for-domrectreadonly⑧">(2)</a> <a href="#ref-for-domrectreadonly⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-2">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-2" class="dfn-panel" data-for="term-for-dom-document-2" id="infopanel-for-term-for-dom-document-2" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-2" style="display:none">Info about the 'document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-2">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-document-2①">(2)</a> <a href="#ref-for-dom-document-2②">(3)</a> <a href="#ref-for-dom-document-2③">(4)</a> <a href="#ref-for-dom-document-2④">(5)</a> <a href="#ref-for-dom-document-2⑤">(6)</a>
@@ -2373,22 +2373,22 @@ HTML Processing Model: Event Loop</a> <a href="#ref-for-dom-document-2①⑧">(2
     <li><a href="#ref-for-dom-document-2①⑨">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">3.2.4. 
 Queue an Intersection Observer Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
@@ -2396,8 +2396,8 @@ The IntersectionObserver interface</a> <a href="#ref-for-idl-DOMString①">(2)</
 The IntersectionObserverInit dictionary</a> <a href="#ref-for-idl-DOMString③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. 
 The IntersectionObserver interface</a>
@@ -2405,22 +2405,22 @@ The IntersectionObserver interface</a>
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.1. 
 The IntersectionObserverCallback</a>
@@ -2595,8 +2595,8 @@ The IntersectionObserverInit dictionary</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="intersection-observer">
-   <b><a href="#intersection-observer">#intersection-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersection-observer" class="dfn-panel" data-for="intersection-observer" id="infopanel-for-intersection-observer" role="dialog">
+   <span id="infopaneltitle-for-intersection-observer" style="display:none">Info about the 'Intersection Observer' definition.</span><b><a href="#intersection-observer">#intersection-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersection-observer">3. 
 Processing Model</a>
@@ -2604,16 +2604,16 @@ Processing Model</a>
 HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-intersectionobservercallback">
-   <b><a href="#callbackdef-intersectionobservercallback">#callbackdef-intersectionobservercallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-intersectionobservercallback" class="dfn-panel" data-for="callbackdef-intersectionobservercallback" id="infopanel-for-callbackdef-intersectionobservercallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-intersectionobservercallback" style="display:none">Info about the 'IntersectionObserverCallback' definition.</span><b><a href="#callbackdef-intersectionobservercallback">#callbackdef-intersectionobservercallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-intersectionobservercallback">2.2. 
 The IntersectionObserver interface</a>
     <li><a href="#ref-for-callbackdef-intersectionobservercallback①">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-intersection-root">
-   <b><a href="#intersectionobserver-intersection-root">#intersectionobserver-intersection-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-intersection-root" class="dfn-panel" data-for="intersectionobserver-intersection-root" id="infopanel-for-intersectionobserver-intersection-root" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-intersection-root" style="display:none">Info about the 'intersection root' definition.</span><b><a href="#intersectionobserver-intersection-root">#intersectionobserver-intersection-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-intersection-root">2. Intersection Observer</a>
     <li><a href="#ref-for-intersectionobserver-intersection-root①">2.1. 
@@ -2628,8 +2628,8 @@ Compute the Intersection of a Target Element and the Root</a> <a href="#ref-for-
 Run the Update Intersection Observations Steps</a> <a href="#ref-for-intersectionobserver-intersection-root①⑤">(2)</a> <a href="#ref-for-intersectionobserver-intersection-root①⑥">(3)</a> <a href="#ref-for-intersectionobserver-intersection-root①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-implicit-root">
-   <b><a href="#intersectionobserver-implicit-root">#intersectionobserver-implicit-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-implicit-root" class="dfn-panel" data-for="intersectionobserver-implicit-root" id="infopanel-for-intersectionobserver-implicit-root" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-implicit-root" style="display:none">Info about the 'implicit root' definition.</span><b><a href="#intersectionobserver-implicit-root">#intersectionobserver-implicit-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-implicit-root">2.4. 
 The IntersectionObserverInit dictionary</a>
@@ -2637,15 +2637,15 @@ The IntersectionObserverInit dictionary</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-explicit-root-observer">
-   <b><a href="#intersectionobserver-explicit-root-observer">#intersectionobserver-explicit-root-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-explicit-root-observer" class="dfn-panel" data-for="intersectionobserver-explicit-root-observer" id="infopanel-for-intersectionobserver-explicit-root-observer" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-explicit-root-observer" style="display:none">Info about the 'explicit root observer' definition.</span><b><a href="#intersectionobserver-explicit-root-observer">#intersectionobserver-explicit-root-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-explicit-root-observer">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-implicit-root-observer">
-   <b><a href="#intersectionobserver-implicit-root-observer">#intersectionobserver-implicit-root-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-implicit-root-observer" class="dfn-panel" data-for="intersectionobserver-implicit-root-observer" id="infopanel-for-intersectionobserver-implicit-root-observer" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-implicit-root-observer" style="display:none">Info about the 'implicit root observer' definition.</span><b><a href="#intersectionobserver-implicit-root-observer">#intersectionobserver-implicit-root-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-implicit-root-observer">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-intersectionobserver-implicit-root-observer①">(2)</a> <a href="#ref-for-intersectionobserver-implicit-root-observer②">(3)</a>
@@ -2654,8 +2654,8 @@ Run the Update Intersection Observations Steps</a>
     <li><a href="#ref-for-intersectionobserver-implicit-root-observer④">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-same-origin-domain-target">
-   <b><a href="#intersectionobserver-same-origin-domain-target">#intersectionobserver-same-origin-domain-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-same-origin-domain-target" class="dfn-panel" data-for="intersectionobserver-same-origin-domain-target" id="infopanel-for-intersectionobserver-same-origin-domain-target" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-same-origin-domain-target" style="display:none">Info about the 'same-origin-domain target' definition.</span><b><a href="#intersectionobserver-same-origin-domain-target">#intersectionobserver-same-origin-domain-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-same-origin-domain-target">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-intersectionobserver-same-origin-domain-target①">(2)</a> <a href="#ref-for-intersectionobserver-same-origin-domain-target②">(3)</a>
@@ -2663,16 +2663,16 @@ The IntersectionObserver interface</a> <a href="#ref-for-intersectionobserver-sa
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-cross-origin-domain-target">
-   <b><a href="#intersectionobserver-cross-origin-domain-target">#intersectionobserver-cross-origin-domain-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-cross-origin-domain-target" class="dfn-panel" data-for="intersectionobserver-cross-origin-domain-target" id="infopanel-for-intersectionobserver-cross-origin-domain-target" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-cross-origin-domain-target" style="display:none">Info about the 'cross-origin-domain target' definition.</span><b><a href="#intersectionobserver-cross-origin-domain-target">#intersectionobserver-cross-origin-domain-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-cross-origin-domain-target">2.2. 
 The IntersectionObserver interface</a>
     <li><a href="#ref-for-intersectionobserver-cross-origin-domain-target①">5. Privacy and Security</a> <a href="#ref-for-intersectionobserver-cross-origin-domain-target②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver">
-   <b><a href="#intersectionobserver">#intersectionobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver" class="dfn-panel" data-for="intersectionobserver" id="infopanel-for-intersectionobserver" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver" style="display:none">Info about the 'IntersectionObserver' definition.</span><b><a href="#intersectionobserver">#intersectionobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver">2.1. 
 The IntersectionObserverCallback</a>
@@ -2699,8 +2699,9 @@ IntersectionObserver Lifetime</a> <a href="#ref-for-intersectionobserver②⑦">
     <li><a href="#ref-for-intersectionobserver③⓪">5. Privacy and Security</a> <a href="#ref-for-intersectionobserver③①">(2)</a> <a href="#ref-for-intersectionobserver③②">(3)</a> <a href="#ref-for-intersectionobserver③③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-intersectionobserver">
-   <b><a href="#dom-intersectionobserver-intersectionobserver">#dom-intersectionobserver-intersectionobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-intersectionobserver" class="dfn-panel" data-for="dom-intersectionobserver-intersectionobserver" id="infopanel-for-dom-intersectionobserver-intersectionobserver" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-intersectionobserver" style="display:none">Info about the '
+new IntersectionObserver(callback, options)' definition.</span><b><a href="#dom-intersectionobserver-intersectionobserver">#dom-intersectionobserver-intersectionobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-intersectionobserver">2.2. 
 The IntersectionObserver interface</a>
@@ -2708,8 +2709,8 @@ The IntersectionObserver interface</a>
 IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-observe">
-   <b><a href="#dom-intersectionobserver-observe">#dom-intersectionobserver-observe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-observe" class="dfn-panel" data-for="dom-intersectionobserver-observe" id="infopanel-for-dom-intersectionobserver-observe" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-observe" style="display:none">Info about the 'observe(target)' definition.</span><b><a href="#dom-intersectionobserver-observe">#dom-intersectionobserver-observe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-observe">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-observe①">(2)</a> <a href="#ref-for-dom-intersectionobserver-observe②">(3)</a>
@@ -2717,8 +2718,8 @@ The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserve
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-unobserve">
-   <b><a href="#dom-intersectionobserver-unobserve">#dom-intersectionobserver-unobserve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-unobserve" class="dfn-panel" data-for="dom-intersectionobserver-unobserve" id="infopanel-for-dom-intersectionobserver-unobserve" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-unobserve" style="display:none">Info about the 'unobserve(target)' definition.</span><b><a href="#dom-intersectionobserver-unobserve">#dom-intersectionobserver-unobserve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-unobserve">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-unobserve①">(2)</a> <a href="#ref-for-dom-intersectionobserver-unobserve②">(3)</a>
@@ -2726,8 +2727,8 @@ The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserve
 IntersectionObserver Lifetime</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-disconnect">
-   <b><a href="#dom-intersectionobserver-disconnect">#dom-intersectionobserver-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-disconnect" class="dfn-panel" data-for="dom-intersectionobserver-disconnect" id="infopanel-for-dom-intersectionobserver-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-intersectionobserver-disconnect">#dom-intersectionobserver-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-disconnect">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-disconnect①">(2)</a>
@@ -2735,15 +2736,15 @@ The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserve
 IntersectionObserver Lifetime</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-takerecords">
-   <b><a href="#dom-intersectionobserver-takerecords">#dom-intersectionobserver-takerecords</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-takerecords" class="dfn-panel" data-for="dom-intersectionobserver-takerecords" id="infopanel-for-dom-intersectionobserver-takerecords" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-takerecords" style="display:none">Info about the 'takeRecords()' definition.</span><b><a href="#dom-intersectionobserver-takerecords">#dom-intersectionobserver-takerecords</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-takerecords">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-root">
-   <b><a href="#dom-intersectionobserver-root">#dom-intersectionobserver-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-root" class="dfn-panel" data-for="dom-intersectionobserver-root" id="infopanel-for-dom-intersectionobserver-root" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-intersectionobserver-root">#dom-intersectionobserver-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-root">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-root①">(2)</a> <a href="#ref-for-dom-intersectionobserver-root②">(3)</a> <a href="#ref-for-dom-intersectionobserver-root③">(4)</a> <a href="#ref-for-dom-intersectionobserver-root④">(5)</a>
@@ -2755,16 +2756,16 @@ Notify Intersection Observers</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-rootmargin">
-   <b><a href="#dom-intersectionobserver-rootmargin">#dom-intersectionobserver-rootmargin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-rootmargin" class="dfn-panel" data-for="dom-intersectionobserver-rootmargin" id="infopanel-for-dom-intersectionobserver-rootmargin" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-rootmargin" style="display:none">Info about the 'rootMargin' definition.</span><b><a href="#dom-intersectionobserver-rootmargin">#dom-intersectionobserver-rootmargin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-rootmargin">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-rootmargin①">(2)</a> <a href="#ref-for-dom-intersectionobserver-rootmargin②">(3)</a>
     <li><a href="#ref-for-dom-intersectionobserver-rootmargin③">5. Privacy and Security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-thresholds">
-   <b><a href="#dom-intersectionobserver-thresholds">#dom-intersectionobserver-thresholds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-thresholds" class="dfn-panel" data-for="dom-intersectionobserver-thresholds" id="infopanel-for-dom-intersectionobserver-thresholds" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-thresholds" style="display:none">Info about the 'thresholds' definition.</span><b><a href="#dom-intersectionobserver-thresholds">#dom-intersectionobserver-thresholds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-thresholds">2.2. 
 The IntersectionObserver interface</a>
@@ -2775,8 +2776,8 @@ Element</a>
 Run the Update Intersection Observations Steps</a> <a href="#ref-for-dom-intersectionobserver-thresholds④">(2)</a> <a href="#ref-for-dom-intersectionobserver-thresholds⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-root-intersection-rectangle">
-   <b><a href="#intersectionobserver-root-intersection-rectangle">#intersectionobserver-root-intersection-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-root-intersection-rectangle" class="dfn-panel" data-for="intersectionobserver-root-intersection-rectangle" id="infopanel-for-intersectionobserver-root-intersection-rectangle" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-root-intersection-rectangle" style="display:none">Info about the 'root intersection rectangle' definition.</span><b><a href="#intersectionobserver-root-intersection-rectangle">#intersectionobserver-root-intersection-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-root-intersection-rectangle">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-intersectionobserver-root-intersection-rectangle①">(2)</a> <a href="#ref-for-intersectionobserver-root-intersection-rectangle②">(3)</a>
@@ -2788,14 +2789,14 @@ Compute the Intersection of a Target Element and the Root</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-root-margin">
-   <b><a href="#parse-a-root-margin">#parse-a-root-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-root-margin" class="dfn-panel" data-for="parse-a-root-margin" id="infopanel-for-parse-a-root-margin" role="dialog">
+   <span id="infopaneltitle-for-parse-a-root-margin" style="display:none">Info about the 'parse a root margin' definition.</span><b><a href="#parse-a-root-margin">#parse-a-root-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-root-margin">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserverentry">
-   <b><a href="#intersectionobserverentry">#intersectionobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserverentry" class="dfn-panel" data-for="intersectionobserverentry" id="infopanel-for-intersectionobserverentry" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserverentry" style="display:none">Info about the 'IntersectionObserverEntry' definition.</span><b><a href="#intersectionobserverentry">#intersectionobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserverentry">2.1. 
 The IntersectionObserverCallback</a>
@@ -2808,73 +2809,73 @@ Queue an IntersectionObserverEntry</a>
     <li><a href="#ref-for-intersectionobserverentry⑤">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-intersectionobserverentryinit">
-   <b><a href="#dictdef-intersectionobserverentryinit">#dictdef-intersectionobserverentryinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-intersectionobserverentryinit" class="dfn-panel" data-for="dictdef-intersectionobserverentryinit" id="infopanel-for-dictdef-intersectionobserverentryinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-intersectionobserverentryinit" style="display:none">Info about the 'IntersectionObserverEntryInit' definition.</span><b><a href="#dictdef-intersectionobserverentryinit">#dictdef-intersectionobserverentryinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-intersectionobserverentryinit">2.3. 
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-boundingclientrect">
-   <b><a href="#dom-intersectionobserverentry-boundingclientrect">#dom-intersectionobserverentry-boundingclientrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-boundingclientrect" class="dfn-panel" data-for="dom-intersectionobserverentry-boundingclientrect" id="infopanel-for-dom-intersectionobserverentry-boundingclientrect" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-boundingclientrect" style="display:none">Info about the 'boundingClientRect' definition.</span><b><a href="#dom-intersectionobserverentry-boundingclientrect">#dom-intersectionobserverentry-boundingclientrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-boundingclientrect">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-dom-intersectionobserverentry-boundingclientrect①">(2)</a> <a href="#ref-for-dom-intersectionobserverentry-boundingclientrect②">(3)</a> <a href="#ref-for-dom-intersectionobserverentry-boundingclientrect③">(4)</a> <a href="#ref-for-dom-intersectionobserverentry-boundingclientrect④">(5)</a> <a href="#ref-for-dom-intersectionobserverentry-boundingclientrect⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-intersectionrect">
-   <b><a href="#dom-intersectionobserverentry-intersectionrect">#dom-intersectionobserverentry-intersectionrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-intersectionrect" class="dfn-panel" data-for="dom-intersectionobserverentry-intersectionrect" id="infopanel-for-dom-intersectionobserverentry-intersectionrect" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-intersectionrect" style="display:none">Info about the 'intersectionRect' definition.</span><b><a href="#dom-intersectionobserverentry-intersectionrect">#dom-intersectionobserverentry-intersectionrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-intersectionrect">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-dom-intersectionobserverentry-intersectionrect①">(2)</a> <a href="#ref-for-dom-intersectionobserverentry-intersectionrect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-isintersecting">
-   <b><a href="#dom-intersectionobserverentry-isintersecting">#dom-intersectionobserverentry-isintersecting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-isintersecting" class="dfn-panel" data-for="dom-intersectionobserverentry-isintersecting" id="infopanel-for-dom-intersectionobserverentry-isintersecting" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-isintersecting" style="display:none">Info about the 'isIntersecting' definition.</span><b><a href="#dom-intersectionobserverentry-isintersecting">#dom-intersectionobserverentry-isintersecting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-isintersecting">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-dom-intersectionobserverentry-isintersecting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-intersectionratio">
-   <b><a href="#dom-intersectionobserverentry-intersectionratio">#dom-intersectionobserverentry-intersectionratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-intersectionratio" class="dfn-panel" data-for="dom-intersectionobserverentry-intersectionratio" id="infopanel-for-dom-intersectionobserverentry-intersectionratio" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-intersectionratio" style="display:none">Info about the 'intersectionRatio' definition.</span><b><a href="#dom-intersectionobserverentry-intersectionratio">#dom-intersectionobserverentry-intersectionratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-intersectionratio">2.3. 
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-rootbounds">
-   <b><a href="#dom-intersectionobserverentry-rootbounds">#dom-intersectionobserverentry-rootbounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-rootbounds" class="dfn-panel" data-for="dom-intersectionobserverentry-rootbounds" id="infopanel-for-dom-intersectionobserverentry-rootbounds" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-rootbounds" style="display:none">Info about the 'rootBounds' definition.</span><b><a href="#dom-intersectionobserverentry-rootbounds">#dom-intersectionobserverentry-rootbounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-rootbounds">2.3. 
 The IntersectionObserverEntry interface</a>
     <li><a href="#ref-for-dom-intersectionobserverentry-rootbounds①">5. Privacy and Security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-target">
-   <b><a href="#dom-intersectionobserverentry-target">#dom-intersectionobserverentry-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-target" class="dfn-panel" data-for="dom-intersectionobserverentry-target" id="infopanel-for-dom-intersectionobserverentry-target" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-intersectionobserverentry-target">#dom-intersectionobserverentry-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-target">2.3. 
 The IntersectionObserverEntry interface</a> <a href="#ref-for-dom-intersectionobserverentry-target①">(2)</a> <a href="#ref-for-dom-intersectionobserverentry-target②">(3)</a> <a href="#ref-for-dom-intersectionobserverentry-target③">(4)</a> <a href="#ref-for-dom-intersectionobserverentry-target④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverentry-time">
-   <b><a href="#dom-intersectionobserverentry-time">#dom-intersectionobserverentry-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverentry-time" class="dfn-panel" data-for="dom-intersectionobserverentry-time" id="infopanel-for-dom-intersectionobserverentry-time" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverentry-time" style="display:none">Info about the 'time' definition.</span><b><a href="#dom-intersectionobserverentry-time">#dom-intersectionobserverentry-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverentry-time">2.3. 
 The IntersectionObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-intersectionobserverinit">
-   <b><a href="#dictdef-intersectionobserverinit">#dictdef-intersectionobserverinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-intersectionobserverinit" class="dfn-panel" data-for="dictdef-intersectionobserverinit" id="infopanel-for-dictdef-intersectionobserverinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-intersectionobserverinit" style="display:none">Info about the 'IntersectionObserverInit' definition.</span><b><a href="#dictdef-intersectionobserverinit">#dictdef-intersectionobserverinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-intersectionobserverinit">2.2. 
 The IntersectionObserver interface</a>
     <li><a href="#ref-for-dictdef-intersectionobserverinit①">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverinit-root">
-   <b><a href="#dom-intersectionobserverinit-root">#dom-intersectionobserverinit-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverinit-root" class="dfn-panel" data-for="dom-intersectionobserverinit-root" id="infopanel-for-dom-intersectionobserverinit-root" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverinit-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-intersectionobserverinit-root">#dom-intersectionobserverinit-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverinit-root">2.2. 
 The IntersectionObserver interface</a>
@@ -2882,8 +2883,8 @@ The IntersectionObserver interface</a>
 The IntersectionObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverinit-rootmargin">
-   <b><a href="#dom-intersectionobserverinit-rootmargin">#dom-intersectionobserverinit-rootmargin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverinit-rootmargin" class="dfn-panel" data-for="dom-intersectionobserverinit-rootmargin" id="infopanel-for-dom-intersectionobserverinit-rootmargin" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverinit-rootmargin" style="display:none">Info about the 'rootMargin' definition.</span><b><a href="#dom-intersectionobserverinit-rootmargin">#dom-intersectionobserverinit-rootmargin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverinit-rootmargin">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserverinit-rootmargin①">(2)</a> <a href="#ref-for-dom-intersectionobserverinit-rootmargin②">(3)</a>
@@ -2892,8 +2893,8 @@ The IntersectionObserverInit dictionary</a>
     <li><a href="#ref-for-dom-intersectionobserverinit-rootmargin④">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverinit-threshold">
-   <b><a href="#dom-intersectionobserverinit-threshold">#dom-intersectionobserverinit-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverinit-threshold" class="dfn-panel" data-for="dom-intersectionobserverinit-threshold" id="infopanel-for-dom-intersectionobserverinit-threshold" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverinit-threshold" style="display:none">Info about the 'threshold' definition.</span><b><a href="#dom-intersectionobserverinit-threshold">#dom-intersectionobserverinit-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverinit-threshold">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserverinit-threshold①">(2)</a>
@@ -2902,8 +2903,9 @@ The IntersectionObserverInit dictionary</a>
     <li><a href="#ref-for-dom-intersectionobserverinit-threshold③">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersection-observer-processing-model">
-   <b><a href="#intersection-observer-processing-model">#intersection-observer-processing-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersection-observer-processing-model" class="dfn-panel" data-for="intersection-observer-processing-model" id="infopanel-for-intersection-observer-processing-model" role="dialog">
+   <span id="infopaneltitle-for-intersection-observer-processing-model" style="display:none">Info about the '3. 
+Processing Model' definition.</span><b><a href="#intersection-observer-processing-model">#intersection-observer-processing-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersection-observer-processing-model">2.1. 
 The IntersectionObserverCallback</a>
@@ -2911,8 +2913,8 @@ The IntersectionObserverCallback</a>
 Processing Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-intersectionobservertaskqueued">
-   <b><a href="#document-intersectionobservertaskqueued">#document-intersectionobservertaskqueued</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-intersectionobservertaskqueued" class="dfn-panel" data-for="document-intersectionobservertaskqueued" id="infopanel-for-document-intersectionobservertaskqueued" role="dialog">
+   <span id="infopaneltitle-for-document-intersectionobservertaskqueued" style="display:none">Info about the 'IntersectionObserverTaskQueued' definition.</span><b><a href="#document-intersectionobservertaskqueued">#document-intersectionobservertaskqueued</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-intersectionobservertaskqueued">3.2.4. 
 Queue an Intersection Observer Task</a> <a href="#ref-for-document-intersectionobservertaskqueued①">(2)</a>
@@ -2920,8 +2922,8 @@ Queue an Intersection Observer Task</a> <a href="#ref-for-document-intersectiono
 Notify Intersection Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-registeredintersectionobservers-slot">
-   <b><a href="#dom-element-registeredintersectionobservers-slot">#dom-element-registeredintersectionobservers-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-registeredintersectionobservers-slot" class="dfn-panel" data-for="dom-element-registeredintersectionobservers-slot" id="infopanel-for-dom-element-registeredintersectionobservers-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-element-registeredintersectionobservers-slot" style="display:none">Info about the '[[RegisteredIntersectionObservers]]' definition.</span><b><a href="#dom-element-registeredintersectionobservers-slot">#dom-element-registeredintersectionobservers-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-registeredintersectionobservers-slot">2.2. 
 The IntersectionObserver interface</a>
@@ -2931,8 +2933,8 @@ The IntersectionObserver interface</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserverregistration">
-   <b><a href="#intersectionobserverregistration">#intersectionobserverregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserverregistration" class="dfn-panel" data-for="intersectionobserverregistration" id="infopanel-for-intersectionobserverregistration" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserverregistration" style="display:none">Info about the 'IntersectionObserverRegistration' definition.</span><b><a href="#intersectionobserverregistration">#intersectionobserverregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserverregistration">2.2. 
 The IntersectionObserver interface</a>
@@ -2942,8 +2944,8 @@ The IntersectionObserver interface</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverregistration-observer">
-   <b><a href="#dom-intersectionobserverregistration-observer">#dom-intersectionobserverregistration-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverregistration-observer" class="dfn-panel" data-for="dom-intersectionobserverregistration-observer" id="infopanel-for-dom-intersectionobserverregistration-observer" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverregistration-observer" style="display:none">Info about the 'observer' definition.</span><b><a href="#dom-intersectionobserverregistration-observer">#dom-intersectionobserverregistration-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverregistration-observer">2.2. 
 The IntersectionObserver interface</a>
@@ -2953,24 +2955,24 @@ The IntersectionObserver interface</a>
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverregistration-previousthresholdindex">
-   <b><a href="#dom-intersectionobserverregistration-previousthresholdindex">#dom-intersectionobserverregistration-previousthresholdindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverregistration-previousthresholdindex" class="dfn-panel" data-for="dom-intersectionobserverregistration-previousthresholdindex" id="infopanel-for-dom-intersectionobserverregistration-previousthresholdindex" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverregistration-previousthresholdindex" style="display:none">Info about the 'previousThresholdIndex' definition.</span><b><a href="#dom-intersectionobserverregistration-previousthresholdindex">#dom-intersectionobserverregistration-previousthresholdindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverregistration-previousthresholdindex">3.2.2. Observe a target Element</a>
     <li><a href="#ref-for-dom-intersectionobserverregistration-previousthresholdindex①">3.2.8. 
 Run the Update Intersection Observations Steps</a> <a href="#ref-for-dom-intersectionobserverregistration-previousthresholdindex②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserverregistration-previousisintersecting">
-   <b><a href="#dom-intersectionobserverregistration-previousisintersecting">#dom-intersectionobserverregistration-previousisintersecting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserverregistration-previousisintersecting" class="dfn-panel" data-for="dom-intersectionobserverregistration-previousisintersecting" id="infopanel-for-dom-intersectionobserverregistration-previousisintersecting" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserverregistration-previousisintersecting" style="display:none">Info about the 'previousIsIntersecting' definition.</span><b><a href="#dom-intersectionobserverregistration-previousisintersecting">#dom-intersectionobserverregistration-previousisintersecting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserverregistration-previousisintersecting">3.2.2. Observe a target Element</a>
     <li><a href="#ref-for-dom-intersectionobserverregistration-previousisintersecting①">3.2.8. 
 Run the Update Intersection Observations Steps</a> <a href="#ref-for-dom-intersectionobserverregistration-previousisintersecting②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-queuedentries-slot">
-   <b><a href="#dom-intersectionobserver-queuedentries-slot">#dom-intersectionobserver-queuedentries-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-queuedentries-slot" class="dfn-panel" data-for="dom-intersectionobserver-queuedentries-slot" id="infopanel-for-dom-intersectionobserver-queuedentries-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-queuedentries-slot" style="display:none">Info about the '[[QueuedEntries]]' definition.</span><b><a href="#dom-intersectionobserver-queuedentries-slot">#dom-intersectionobserver-queuedentries-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-queuedentries-slot">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-queuedentries-slot①">(2)</a>
@@ -2980,8 +2982,8 @@ Notify Intersection Observers</a> <a href="#ref-for-dom-intersectionobserver-que
 Queue an IntersectionObserverEntry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-observationtargets-slot">
-   <b><a href="#dom-intersectionobserver-observationtargets-slot">#dom-intersectionobserver-observationtargets-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-observationtargets-slot" class="dfn-panel" data-for="dom-intersectionobserver-observationtargets-slot" id="infopanel-for-dom-intersectionobserver-observationtargets-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-observationtargets-slot" style="display:none">Info about the '[[ObservationTargets]]' definition.</span><b><a href="#dom-intersectionobserver-observationtargets-slot">#dom-intersectionobserver-observationtargets-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-observationtargets-slot">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-observationtargets-slot①">(2)</a>
@@ -2992,146 +2994,202 @@ Run the Update Intersection Observations Steps</a>
     <li><a href="#ref-for-dom-intersectionobserver-observationtargets-slot⑥">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-callback-slot">
-   <b><a href="#dom-intersectionobserver-callback-slot">#dom-intersectionobserver-callback-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-callback-slot" class="dfn-panel" data-for="dom-intersectionobserver-callback-slot" id="infopanel-for-dom-intersectionobserver-callback-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-callback-slot" style="display:none">Info about the '[[callback]]' definition.</span><b><a href="#dom-intersectionobserver-callback-slot">#dom-intersectionobserver-callback-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-callback-slot">3.2.1. Initialize a new IntersectionObserver</a>
     <li><a href="#ref-for-dom-intersectionobserver-callback-slot①">3.2.5. 
 Notify Intersection Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intersectionobserver-rootmargin-slot">
-   <b><a href="#dom-intersectionobserver-rootmargin-slot">#dom-intersectionobserver-rootmargin-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intersectionobserver-rootmargin-slot" class="dfn-panel" data-for="dom-intersectionobserver-rootmargin-slot" id="infopanel-for-dom-intersectionobserver-rootmargin-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-intersectionobserver-rootmargin-slot" style="display:none">Info about the '[[rootMargin]]' definition.</span><b><a href="#dom-intersectionobserver-rootmargin-slot">#dom-intersectionobserver-rootmargin-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intersectionobserver-rootmargin-slot">2.2. 
 The IntersectionObserver interface</a> <a href="#ref-for-dom-intersectionobserver-rootmargin-slot①">(2)</a>
     <li><a href="#ref-for-dom-intersectionobserver-rootmargin-slot②">3.2.1. Initialize a new IntersectionObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-a-new-intersectionobserver">
-   <b><a href="#initialize-a-new-intersectionobserver">#initialize-a-new-intersectionobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-a-new-intersectionobserver" class="dfn-panel" data-for="initialize-a-new-intersectionobserver" id="infopanel-for-initialize-a-new-intersectionobserver" role="dialog">
+   <span id="infopaneltitle-for-initialize-a-new-intersectionobserver" style="display:none">Info about the 'initialize a new IntersectionObserver' definition.</span><b><a href="#initialize-a-new-intersectionobserver">#initialize-a-new-intersectionobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-new-intersectionobserver">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observe-a-target-element">
-   <b><a href="#observe-a-target-element">#observe-a-target-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observe-a-target-element" class="dfn-panel" data-for="observe-a-target-element" id="infopanel-for-observe-a-target-element" role="dialog">
+   <span id="infopaneltitle-for-observe-a-target-element" style="display:none">Info about the 'observe a target Element' definition.</span><b><a href="#observe-a-target-element">#observe-a-target-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observe-a-target-element">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unobserve-a-target-element">
-   <b><a href="#unobserve-a-target-element">#unobserve-a-target-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unobserve-a-target-element" class="dfn-panel" data-for="unobserve-a-target-element" id="infopanel-for-unobserve-a-target-element" role="dialog">
+   <span id="infopaneltitle-for-unobserve-a-target-element" style="display:none">Info about the 'unobserve a target Element' definition.</span><b><a href="#unobserve-a-target-element">#unobserve-a-target-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unobserve-a-target-element">2.2. 
 The IntersectionObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intersectionobserver-task-source">
-   <b><a href="#intersectionobserver-task-source">#intersectionobserver-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intersectionobserver-task-source" class="dfn-panel" data-for="intersectionobserver-task-source" id="infopanel-for-intersectionobserver-task-source" role="dialog">
+   <span id="infopaneltitle-for-intersectionobserver-task-source" style="display:none">Info about the 'IntersectionObserver task source' definition.</span><b><a href="#intersectionobserver-task-source">#intersectionobserver-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-task-source">3.2.4. 
 Queue an Intersection Observer Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-an-intersection-observer-task">
-   <b><a href="#queue-an-intersection-observer-task">#queue-an-intersection-observer-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-an-intersection-observer-task" class="dfn-panel" data-for="queue-an-intersection-observer-task" id="infopanel-for-queue-an-intersection-observer-task" role="dialog">
+   <span id="infopaneltitle-for-queue-an-intersection-observer-task" style="display:none">Info about the 'queue an intersection observer task' definition.</span><b><a href="#queue-an-intersection-observer-task">#queue-an-intersection-observer-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-an-intersection-observer-task">3.2.6. 
 Queue an IntersectionObserverEntry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-intersection-observers">
-   <b><a href="#notify-intersection-observers">#notify-intersection-observers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-intersection-observers" class="dfn-panel" data-for="notify-intersection-observers" id="infopanel-for-notify-intersection-observers" role="dialog">
+   <span id="infopaneltitle-for-notify-intersection-observers" style="display:none">Info about the 'notify intersection observers' definition.</span><b><a href="#notify-intersection-observers">#notify-intersection-observers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-intersection-observers">3.2.4. 
 Queue an Intersection Observer Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-an-intersectionobserverentry">
-   <b><a href="#queue-an-intersectionobserverentry">#queue-an-intersectionobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-an-intersectionobserverentry" class="dfn-panel" data-for="queue-an-intersectionobserverentry" id="infopanel-for-queue-an-intersectionobserverentry" role="dialog">
+   <span id="infopaneltitle-for-queue-an-intersectionobserverentry" style="display:none">Info about the 'queue an IntersectionObserverEntry' definition.</span><b><a href="#queue-an-intersectionobserverentry">#queue-an-intersectionobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-an-intersectionobserverentry">3.2.8. 
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-the-intersection">
-   <b><a href="#compute-the-intersection">#compute-the-intersection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-the-intersection" class="dfn-panel" data-for="compute-the-intersection" id="infopanel-for-compute-the-intersection" role="dialog">
+   <span id="infopaneltitle-for-compute-the-intersection" style="display:none">Info about the 'compute the intersection' definition.</span><b><a href="#compute-the-intersection">#compute-the-intersection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-the-intersection">3.2.8. 
 Run the Update Intersection Observations Steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-the-update-intersection-observations-steps">
-   <b><a href="#run-the-update-intersection-observations-steps">#run-the-update-intersection-observations-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-the-update-intersection-observations-steps" class="dfn-panel" data-for="run-the-update-intersection-observations-steps" id="infopanel-for-run-the-update-intersection-observations-steps" role="dialog">
+   <span id="infopaneltitle-for-run-the-update-intersection-observations-steps" style="display:none">Info about the 'run the update intersection observations steps' definition.</span><b><a href="#run-the-update-intersection-observations-steps">#run-the-update-intersection-observations-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-update-intersection-observations-steps">3.4.1. 
 HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-initial-intersectionobserver-targets">
-   <b><a href="#pending-initial-intersectionobserver-targets">#pending-initial-intersectionobserver-targets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-initial-intersectionobserver-targets" class="dfn-panel" data-for="pending-initial-intersectionobserver-targets" id="infopanel-for-pending-initial-intersectionobserver-targets" role="dialog">
+   <span id="infopaneltitle-for-pending-initial-intersectionobserver-targets" style="display:none">Info about the 'pending initial IntersectionObserver targets' definition.</span><b><a href="#pending-initial-intersectionobserver-targets">#pending-initial-intersectionobserver-targets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-initial-intersectionobserver-targets">3.4.2. Pending initial IntersectionObserver targets</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/ServiceWorker/docs/index.html
+++ b/tests/github/w3c/ServiceWorker/docs/index.html
@@ -7907,53 +7907,53 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <li><a href="#dfn-worker-client">worker client</a><span>, in § 2.3</span>
    <li><a href="#dfn-job-worker-type">worker type</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-enforced">
-   <a href="https://w3c.github.io/webappsec-csp/#enforced">https://w3c.github.io/webappsec-csp/#enforced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforced" class="dfn-panel" data-for="term-for-enforced" id="infopanel-for-term-for-enforced" role="menu">
+   <span id="infopaneltitle-for-term-for-enforced" style="display:none">Info about the 'enforced' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#enforced">https://w3c.github.io/webappsec-csp/#enforced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforced">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2.11. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.5. Events</a> <a href="#ref-for-event①">(2)</a> <a href="#ref-for-event②">(3)</a> <a href="#ref-for-event③">(4)</a> <a href="#ref-for-event④">(5)</a>
     <li><a href="#ref-for-event⑤">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventtarget①">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-eventtarget②">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">3.1.5. postMessage(message, options)</a> <a href="#ref-for-concept-event-create①">(2)</a>
     <li><a href="#ref-for-concept-event-create②">Install</a>
@@ -7962,8 +7962,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-create⑤">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.5. Task Sources</a> <a href="#ref-for-concept-event-dispatch①">(2)</a>
     <li><a href="#ref-for-concept-event-dispatch②">3.1.5. postMessage(message, options)</a>
@@ -7974,23 +7974,23 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-dispatch⑦">Fire Functional Event</a> <a href="#ref-for-concept-event-dispatch⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dispatch-flag①">4.5.7. event.respondWith(r)</a>
     <li><a href="#ref-for-dispatch-flag②">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2.4.1. The window client case</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a> <a href="#ref-for-concept-document③">(4)</a>
     <li><a href="#ref-for-concept-document④">2.4. Control and Use</a> <a href="#ref-for-concept-document⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">2.1.2. Events</a> <a href="#ref-for-concept-event①">(2)</a>
     <li><a href="#ref-for-concept-event②">4.5.2. event.preloadResponse</a>
@@ -8001,15 +8001,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event⑦">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-event-listener①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">4.2.6. postMessage(message, options)</a>
     <li><a href="#ref-for-concept-event-fire①">Install</a>
@@ -8017,68 +8017,68 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-fire③">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-signal-abort">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-signal-abort" class="dfn-panel" data-for="term-for-abortsignal-signal-abort" id="infopanel-for-term-for-abortsignal-signal-abort" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-signal-abort" style="display:none">Info about the 'signal abort' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-signal-abort">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-immediate-propagation-flag" class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag" id="infopanel-for-term-for-stop-immediate-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-immediate-propagation-flag" style="display:none">Info about the 'stop immediate propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-immediate-propagation-flag">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-propagation-flag" class="dfn-panel" data-for="term-for-stop-propagation-flag" id="infopanel-for-term-for-stop-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">Install</a>
     <li><a href="#ref-for-dom-event-type①">Activate</a>
     <li><a href="#ref-for-dom-event-type②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="http://tc39.github.io/ecma262/#sec-completion-record-specification-type">http://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'abrupt completion' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-completion-record-specification-type">http://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">2.1. Service Worker</a>
     <li><a href="#ref-for-sec-completion-record-specification-type①">Update</a>
     <li><a href="#ref-for-sec-completion-record-specification-type②">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="http://tc39.github.io/ecma262/#sec-completion-record-specification-type">http://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type①" style="display:none">Info about the 'completion' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-completion-record-specification-type">http://tc39.github.io/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">2.1. Service Worker</a>
     <li><a href="#ref-for-sec-completion-record-specification-type①">Update</a>
     <li><a href="#ref-for-sec-completion-record-specification-type②">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-detacharraybuffer">
-   <a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">http://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-detacharraybuffer" class="dfn-panel" data-for="term-for-sec-detacharraybuffer" id="infopanel-for-term-for-sec-detacharraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-detacharraybuffer" style="display:none">Info about the 'detacharraybuffer' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">http://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-detacharraybuffer">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-map-objects">http://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'map objects' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-map-objects">http://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3.2.8. update()</a>
     <li><a href="#ref-for-sec-promise-objects①">3.4. ServiceWorkerContainer</a>
@@ -8100,34 +8100,34 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-promise-objects③⓪">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-surrounding-agent">
-   <a href="https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#surrounding-agent">https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#surrounding-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-surrounding-agent" class="dfn-panel" data-for="term-for-surrounding-agent" id="infopanel-for-term-for-surrounding-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-surrounding-agent" style="display:none">Info about the 'surrounding agent' external reference.</span><a href="https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#surrounding-agent">https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#surrounding-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrounding-agent">4.2.10. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-requestdestination-report">
-   <a href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">https://fetch.spec.whatwg.org/#dom-requestdestination-report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-requestdestination-report" class="dfn-panel" data-for="term-for-dom-requestdestination-report" id="infopanel-for-term-for-dom-requestdestination-report" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-requestdestination-report" style="display:none">Info about the '"report"' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">https://fetch.spec.whatwg.org/#dom-requestdestination-report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdestination-report">Handle Fetch</a> <a href="#ref-for-dom-requestdestination-report①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-headers①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-headers②">Handle Fetch</a> <a href="#ref-for-headers③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">4.5. FetchEvent</a> <a href="#ref-for-request①">(2)</a>
     <li><a href="#ref-for-request②">5.4. Cache</a>
@@ -8139,15 +8139,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-request①④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-requestinfo">
-   <a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-requestinfo" class="dfn-panel" data-for="term-for-requestinfo" id="infopanel-for-term-for-requestinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-requestinfo" style="display:none">Info about the 'RequestInfo' external reference.</span><a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">5.4. Cache</a> <a href="#ref-for-requestinfo①">(2)</a> <a href="#ref-for-requestinfo②">(3)</a> <a href="#ref-for-requestinfo③">(4)</a> <a href="#ref-for-requestinfo④">(5)</a> <a href="#ref-for-requestinfo⑤">(6)</a> <a href="#ref-for-requestinfo⑥">(7)</a>
     <li><a href="#ref-for-requestinfo⑦">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.5. FetchEvent</a>
     <li><a href="#ref-for-response①">4.5.7. event.respondWith(r)</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a>
@@ -8159,60 +8159,60 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-response①④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-aborted">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-aborted" class="dfn-panel" data-for="term-for-concept-response-aborted" id="infopanel-for-term-for-concept-response-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-aborted" style="display:none">Info about the 'aborted flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-aborted">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-append">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-append" class="dfn-panel" data-for="term-for-concept-header-list-append" id="infopanel-for-term-for-concept-header-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-append">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-basic">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-basic" class="dfn-panel" data-for="term-for-concept-filtered-response-basic" id="infopanel-for-term-for-concept-filtered-response-basic" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-basic" style="display:none">Info about the 'basic filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-basic">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-filtered-response-basic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body" class="dfn-panel" data-for="term-for-concept-body" id="infopanel-for-term-for-concept-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">Handle Fetch</a> <a href="#ref-for-concept-request-body①">(2)</a> <a href="#ref-for-concept-request-body②">(3)</a> <a href="#ref-for-concept-request-body③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">4.5.7. event.respondWith(r)</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a> <a href="#ref-for-concept-response-body③">(4)</a> <a href="#ref-for-concept-response-body④">(5)</a>
     <li><a href="#ref-for-concept-response-body⑤">5.4.5. put(request, response)</a> <a href="#ref-for-concept-response-body⑥">(2)</a> <a href="#ref-for-concept-response-body⑦">(3)</a> <a href="#ref-for-concept-response-body⑧">(4)</a>
     <li><a href="#ref-for-concept-response-body⑨">Update</a> <a href="#ref-for-concept-response-body①⓪">(2)</a> <a href="#ref-for-concept-response-body①①">(3)</a> <a href="#ref-for-concept-response-body①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-request-cache-mode①">Update</a> <a href="#ref-for-concept-request-cache-mode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-cache-state">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-cache-state">https://fetch.spec.whatwg.org/#concept-response-cache-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-cache-state" class="dfn-panel" data-for="term-for-concept-response-cache-state" id="infopanel-for-term-for-concept-response-cache-state" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-cache-state" style="display:none">Info about the 'cache state' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-cache-state">https://fetch.spec.whatwg.org/#concept-response-cache-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-cache-state">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-response-cache-state①">Update</a> <a href="#ref-for-concept-response-cache-state②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-client①">6.3.2. importScripts(urls)</a>
@@ -8220,65 +8220,65 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-client③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-clone">https://fetch.spec.whatwg.org/#concept-request-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-clone" class="dfn-panel" data-for="term-for-concept-request-clone" id="infopanel-for-term-for-concept-request-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-clone" style="display:none">Info about the 'clone (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-clone">https://fetch.spec.whatwg.org/#concept-request-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-clone">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-clone" class="dfn-panel" data-for="term-for-concept-response-clone" id="infopanel-for-term-for-concept-response-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-clone" style="display:none">Info about the 'clone (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-clone">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-combine">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-combine" class="dfn-panel" data-for="term-for-concept-header-list-combine" id="infopanel-for-term-for-concept-header-list-combine" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-combine" style="display:none">Info about the 'combine' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-combine">Request Matches Cached Item</a> <a href="#ref-for-concept-header-list-combine①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-cors">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-cors" class="dfn-panel" data-for="term-for-concept-filtered-response-cors" id="infopanel-for-term-for-concept-filtered-response-cors" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-cors" style="display:none">Info about the 'cors filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-cors">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cross-origin-resource-policy-check">
-   <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check">https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cross-origin-resource-policy-check" class="dfn-panel" data-for="term-for-cross-origin-resource-policy-check" id="infopanel-for-term-for-cross-origin-resource-policy-check" role="menu">
+   <span id="infopaneltitle-for-term-for-cross-origin-resource-policy-check" style="display:none">Info about the 'cross-origin resource policy check' external reference.</span><a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check">https://fetch.spec.whatwg.org/#cross-origin-resource-policy-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-resource-policy-check">5.4.2. matchAll(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-destination①">Update</a>
     <li><a href="#ref-for-concept-request-destination②">Handle Fetch</a> <a href="#ref-for-concept-request-destination③">(2)</a> <a href="#ref-for-concept-request-destination④">(3)</a> <a href="#ref-for-concept-request-destination⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extract a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">Appendix A: Algorithms</a>
     <li><a href="#ref-for-concept-header-extract-mime-type①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extract-header-list-values" class="dfn-panel" data-for="term-for-extract-header-list-values" id="infopanel-for-term-for-extract-header-list-values" role="menu">
+   <span id="infopaneltitle-for-term-for-extract-header-list-values" style="display:none">Info about the 'extracting header list values' external reference.</span><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.4.1. The window client case</a>
     <li><a href="#ref-for-concept-fetch①">2.4.2. The worker client case</a>
@@ -8291,28 +8291,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-fetch①⑨">Service Worker Script Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input, init)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response" class="dfn-panel" data-for="term-for-concept-filtered-response" id="infopanel-for-term-for-concept-filtered-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response" style="display:none">Info about the 'filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-headers-guard">
-   <a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-headers-guard" class="dfn-panel" data-for="term-for-concept-headers-guard" id="infopanel-for-term-for-concept-headers-guard" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-headers-guard" style="display:none">Info about the 'guard' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-guard">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-headers-guard①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-concept-headers-guard②">Handle Fetch</a> <a href="#ref-for-concept-headers-guard③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header①">5.4.5. put(request, response)</a>
@@ -8322,16 +8322,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header⑤">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">Update</a>
     <li><a href="#ref-for-concept-request-header-list①">Handle Fetch</a>
     <li><a href="#ref-for-concept-request-header-list②">Request Matches Cached Item</a> <a href="#ref-for-concept-request-header-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-header-list①">5.4.5. put(request, response)</a>
@@ -8340,22 +8340,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-header-list⑤">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">2.4.1. The window client case</a>
     <li><a href="#ref-for-concept-http-fetch①">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-http-fetch②">4.7. Events</a> <a href="#ref-for-concept-http-fetch③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-request-method①">5.4.4. addAll(requests)</a>
@@ -8367,8 +8367,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-method⑦">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header-name①">5.4.5. put(request, response)</a>
@@ -8376,14 +8376,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header-name③">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">Handle Fetch</a> <a href="#ref-for-navigation-request①">(2)</a> <a href="#ref-for-navigation-request②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.5.7. event.respondWith(r)</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">6.3.2. importScripts(urls)</a> <a href="#ref-for-concept-network-error③">(2)</a>
@@ -8391,51 +8391,51 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-network-error⑦">Handle Fetch</a> <a href="#ref-for-concept-network-error⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-subresource-request" class="dfn-panel" data-for="term-for-non-subresource-request" id="infopanel-for-term-for-non-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-non-subresource-request" style="display:none">Info about the 'non-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-subresource-request">Handle Fetch</a> <a href="#ref-for-non-subresource-request①">(2)</a> <a href="#ref-for-non-subresource-request②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-ok-status①">Appendix A: Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-opaque">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-opaque" class="dfn-panel" data-for="term-for-concept-filtered-response-opaque" id="infopanel-for-term-for-concept-filtered-response-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-opaque" style="display:none">Info about the 'opaque filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-parser-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-parser-metadata" class="dfn-panel" data-for="term-for-concept-request-parser-metadata" id="infopanel-for-term-for-concept-request-parser-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-parser-metadata" style="display:none">Info about the 'parser metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-replaces-client-id">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-replaces-client-id">https://fetch.spec.whatwg.org/#concept-request-replaces-client-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-replaces-client-id" class="dfn-panel" data-for="term-for-concept-request-replaces-client-id" id="infopanel-for-term-for-concept-request-replaces-client-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-replaces-client-id" style="display:none">Info about the 'replaces client id' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-replaces-client-id">https://fetch.spec.whatwg.org/#concept-request-replaces-client-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-replaces-client-id">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-request①">2.4. Control and Use</a>
@@ -8448,8 +8448,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request⑧">Request Matches Cached Item</a> <a href="#ref-for-concept-request⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request (for Request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">5.4.2. matchAll(request, options)</a> <a href="#ref-for-concept-request-request①">(2)</a>
     <li><a href="#ref-for-concept-request-request②">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-request③">(2)</a>
@@ -8459,14 +8459,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-request①⓪">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-reserved-client" class="dfn-panel" data-for="term-for-concept-request-reserved-client" id="infopanel-for-term-for-concept-request-reserved-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-reserved-client" style="display:none">Info about the 'reserved client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-reserved-client">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-response①">4.5. FetchEvent</a>
@@ -8479,16 +8479,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response①⓪">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response (for Response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">4.5.7. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-response-response①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-response-response②">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-response-response③">(2)</a> <a href="#ref-for-concept-response-response④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-request-service-workers-mode①">6.3.2. importScripts(urls)</a>
@@ -8496,35 +8496,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-request-service-workers-mode③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-signal">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-signal">https://fetch.spec.whatwg.org/#dom-request-signal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-signal" class="dfn-panel" data-for="term-for-dom-request-signal" id="infopanel-for-term-for-dom-request-signal" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-signal" style="display:none">Info about the 'signal' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-signal">https://fetch.spec.whatwg.org/#dom-request-signal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-signal">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-status①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-response-status②">Appendix A: Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">4.5.7. event.respondWith(r)</a> <a href="#ref-for-concept-body-stream①">(2)</a> <a href="#ref-for-concept-body-stream②">(3)</a>
     <li><a href="#ref-for-concept-body-stream③">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subresource-request" class="dfn-panel" data-for="term-for-subresource-request" id="infopanel-for-term-for-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-subresource-request" style="display:none">Info about the 'subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">Handle Fetch</a> <a href="#ref-for-subresource-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-response-type①">5.4.4. addAll(requests)</a>
@@ -8532,14 +8532,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-type③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-body-unusable">
-   <a href="https://fetch.spec.whatwg.org/#body-unusable">https://fetch.spec.whatwg.org/#body-unusable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-body-unusable" class="dfn-panel" data-for="term-for-body-unusable" id="infopanel-for-term-for-body-unusable" role="menu">
+   <span id="infopaneltitle-for-term-for-body-unusable" style="display:none">Info about the 'unusable' external reference.</span><a href="https://fetch.spec.whatwg.org/#body-unusable">https://fetch.spec.whatwg.org/#body-unusable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body-unusable">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-request-url①">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-url②">(2)</a>
@@ -8551,46 +8551,46 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-url①②">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag" id="infopanel-for-term-for-concept-request-use-url-credentials-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" style="display:none">Info about the 'use-url-credentials flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-use-url-credentials-flag">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">Handle Fetch</a>
     <li><a href="#ref-for-concept-header-value①">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url">
-   <a href="https://w3c.github.io/FileAPI/#blob-url">https://w3c.github.io/FileAPI/#blob-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url" class="dfn-panel" data-for="term-for-blob-url" id="infopanel-for-term-for-blob-url" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url" style="display:none">Info about the 'blob url' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url">https://w3c.github.io/FileAPI/#blob-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url">2.4.2. The worker client case</a>
     <li><a href="#ref-for-blob-url①">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstractworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstractworker" class="dfn-panel" data-for="term-for-abstractworker" id="infopanel-for-term-for-abstractworker" role="menu">
+   <span id="infopaneltitle-for-term-for-abstractworker" style="display:none">Info about the 'AbstractWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractworker">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-domcontentloaded">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-domcontentloaded" class="dfn-panel" data-for="term-for-event-domcontentloaded" id="infopanel-for-term-for-event-domcontentloaded" role="menu">
+   <span id="infopaneltitle-for-term-for-event-domcontentloaded" style="display:none">Info about the 'DOMContentLoaded' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-domcontentloaded">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventhandler①">3.2. ServiceWorkerRegistration</a>
@@ -8598,8 +8598,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventhandler⑤">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-eventhandler⑥">(2)</a> <a href="#ref-for-eventhandler⑦">(3)</a> <a href="#ref-for-eventhandler⑧">(4)</a> <a href="#ref-for-eventhandler⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">4.2.10. focus()</a>
     <li><a href="#ref-for-location①">4.2.11. navigate(url)</a>
@@ -8608,15 +8608,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-location④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageevent">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageevent" class="dfn-panel" data-for="term-for-messageevent" id="infopanel-for-term-for-messageevent" role="menu">
+   <span id="infopaneltitle-for-term-for-messageevent" style="display:none">Info about the 'MessageEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageevent">4.2.6. postMessage(message, options)</a> <a href="#ref-for-messageevent①">(2)</a>
     <li><a href="#ref-for-messageevent②">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-messageport①">4.2.6. postMessage(message, options)</a>
@@ -8624,35 +8624,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-messageport⑥">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-navigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-navigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserializewithtransfer" class="dfn-panel" data-for="term-for-structureddeserializewithtransfer" id="infopanel-for-term-for-structureddeserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserializewithtransfer" style="display:none">Info about the 'StructuredDeserializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserializewithtransfer">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-structureddeserializewithtransfer①">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-structuredserializewithtransfer①">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.3. Service Worker Client</a>
     <li><a href="#ref-for-window①">3.1.5. postMessage(message, options)</a>
@@ -8663,47 +8663,47 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window⑧">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-workerglobalscope①">5. Caches</a>
     <li><a href="#ref-for-workerglobalscope②">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerlocation">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerlocation" class="dfn-panel" data-for="term-for-workerlocation" id="infopanel-for-term-for-workerlocation" role="menu">
+   <span id="infopaneltitle-for-term-for-workerlocation" style="display:none">Info about the 'WorkerLocation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerlocation">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-workernavigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-workernavigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workertype">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workertype" class="dfn-panel" data-for="term-for-workertype" id="infopanel-for-term-for-workertype" role="menu">
+   <span id="infopaneltitle-for-term-for-workertype" style="display:none">Info about the 'WorkerType' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workertype">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">2.4.1. The window client case</a>
     <li><a href="#ref-for-nav-document①">4.2.10. focus()</a> <a href="#ref-for-nav-document②">(2)</a> <a href="#ref-for-nav-document③">(3)</a>
@@ -8713,8 +8713,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-nav-document①④">Resolve Get Client Promise</a> <a href="#ref-for-nav-document①⑤">(2)</a> <a href="#ref-for-nav-document①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-active-service-worker">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-active-service-worker" class="dfn-panel" data-for="term-for-concept-environment-active-service-worker" id="infopanel-for-term-for-concept-environment-active-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-active-service-worker" style="display:none">Info about the 'active service worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-active-service-worker">2.4. Control and Use</a> <a href="#ref-for-concept-environment-active-service-worker①">(2)</a> <a href="#ref-for-concept-environment-active-service-worker②">(3)</a> <a href="#ref-for-concept-environment-active-service-worker③">(4)</a> <a href="#ref-for-concept-environment-active-service-worker①④">(5)</a> <a href="#ref-for-concept-environment-active-service-worker①⑤">(6)</a> <a href="#ref-for-concept-environment-active-service-worker①⑥">(7)</a>
     <li><a href="#ref-for-concept-environment-active-service-worker④">2.4.1. The window client case</a> <a href="#ref-for-concept-environment-active-service-worker⑤">(2)</a> <a href="#ref-for-concept-environment-active-service-worker⑥">(3)</a> <a href="#ref-for-concept-environment-active-service-worker⑦">(4)</a> <a href="#ref-for-concept-environment-active-service-worker⑧">(5)</a> <a href="#ref-for-concept-environment-active-service-worker⑨">(6)</a> <a href="#ref-for-concept-environment-active-service-worker①⓪">(7)</a>
@@ -8729,8 +8729,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-environment-active-service-worker②⑥">Handle Fetch</a> <a href="#ref-for-concept-environment-active-service-worker②⑦">(2)</a> <a href="#ref-for-concept-environment-active-service-worker②⑧">(3)</a> <a href="#ref-for-concept-environment-active-service-worker②⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list" id="infopanel-for-term-for-concept-location-ancestor-origins-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" style="display:none">Info about the 'ancestor origins list' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-location-ancestor-origins-list">4.2.10. focus()</a>
     <li><a href="#ref-for-concept-location-ancestor-origins-list①">4.2.11. navigate(url)</a>
@@ -8739,8 +8739,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-location-ancestor-origins-list④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-api-base-url①">(2)</a>
     <li><a href="#ref-for-api-base-url②">3.4.4. getRegistration(clientURL)</a>
@@ -8749,26 +8749,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-api-base-url⑤">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-url-character-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-url-character-encoding" class="dfn-panel" data-for="term-for-api-url-character-encoding" id="infopanel-for-term-for-api-url-character-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-api-url-character-encoding" style="display:none">Info about the 'api url character encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-url-character-encoding">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">Get Frame Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script-base-url" class="dfn-panel" data-for="term-for-concept-script-base-url" id="infopanel-for-term-for-concept-script-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script-base-url">Update</a> <a href="#ref-for-concept-script-base-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.4.1. The window client case</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a> <a href="#ref-for-browsing-context③">(4)</a> <a href="#ref-for-browsing-context④">(5)</a>
     <li><a href="#ref-for-browsing-context⑤">4.2. Client</a>
@@ -8777,20 +8777,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-browsing-context⑧">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-classic-script" class="dfn-panel" data-for="term-for-classic-script" id="infopanel-for-term-for-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-classic-script" style="display:none">Info about the 'classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-workerglobalscope-closing">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-workerglobalscope-closing" class="dfn-panel" data-for="term-for-dom-workerglobalscope-closing" id="infopanel-for-term-for-dom-workerglobalscope-closing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-workerglobalscope-closing" style="display:none">Info about the 'closing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workerglobalscope-closing">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-creation-url" class="dfn-panel" data-for="term-for-concept-environment-creation-url" id="infopanel-for-term-for-concept-environment-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-creation-url">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-environment-creation-url①">3.4.2. ready</a>
@@ -8805,8 +8805,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-environment-creation-url①⓪">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4.2.11. navigate(url)</a>
     <li><a href="#ref-for-current-global-object①">4.3.3. openWindow(url)</a>
@@ -8814,14 +8814,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-current-global-object③">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-data">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-data" class="dfn-panel" data-for="term-for-dom-messageevent-data" id="infopanel-for-term-for-dom-messageevent-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-data" style="display:none">Info about the 'data' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-data">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-dom-manipulation-task-source①">3.4.2. ready</a>
@@ -8845,32 +8845,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-manipulation-task-source②⑥">Resolve Get Client Promise</a> <a href="#ref-for-dom-manipulation-task-source②⑦">(2)</a> <a href="#ref-for-dom-manipulation-task-source②⑧">(3)</a> <a href="#ref-for-dom-manipulation-task-source②⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy" class="dfn-panel" data-for="term-for-embedder-policy" id="infopanel-for-term-for-embedder-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy" style="display:none">Info about the 'embedder policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-embedder-policy">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-embedder-policy">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-embedder-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-embedder-policy" class="dfn-panel" data-for="term-for-concept-workerglobalscope-embedder-policy" id="infopanel-for-term-for-concept-workerglobalscope-embedder-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-embedder-policy" style="display:none">Info about the 'embedder policy (for WorkerGlobalScope)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-embedder-policy">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-embedder-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-embedder-policy">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-embedder-policy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment" class="dfn-panel" data-for="term-for-environment" id="infopanel-for-term-for-environment" role="menu">
+   <span id="infopaneltitle-for-term-for-environment" style="display:none">Info about the 'environment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-discarding-steps">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-discarding-steps" class="dfn-panel" data-for="term-for-environment-discarding-steps" id="infopanel-for-term-for-environment-discarding-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-discarding-steps" style="display:none">Info about the 'environment discarding steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-discarding-steps">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.3. Service Worker Client</a>
     <li><a href="#ref-for-environment-settings-object①">2.4.2. The worker client case</a>
@@ -8891,8 +8891,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object②⑤">Resolve Get Client Promise</a> <a href="#ref-for-environment-settings-object②⑥">(2)</a> <a href="#ref-for-environment-settings-object②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.1.6. Event handler</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">3.2.10. Event handler</a> <a href="#ref-for-event-handlers③">(2)</a>
@@ -8900,8 +8900,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handlers⑥">4.1.5. Event handlers</a> <a href="#ref-for-event-handlers⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.1.6. Event handler</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">3.2.10. Event handler</a> <a href="#ref-for-event-handler-event-type③">(2)</a>
@@ -8909,8 +8909,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-event-type⑥">4.1.5. Event handlers</a> <a href="#ref-for-event-handler-event-type⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.1.6. Event handler</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">3.2.10. Event handler</a>
@@ -8918,8 +8918,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-idl-attributes③">4.1.5. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">2.1. Service Worker</a>
     <li><a href="#ref-for-event-loop①">2.2. Service Worker Registration</a> <a href="#ref-for-event-loop②">(2)</a> <a href="#ref-for-event-loop③">(3)</a> <a href="#ref-for-event-loop④">(4)</a>
@@ -8936,53 +8936,53 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-loop①⑥">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop (for agent)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">4.2.10. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag" id="infopanel-for-term-for-concept-environment-execution-ready-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" style="display:none">Info about the 'execution ready flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-execution-ready-flag">4.3.1. get(id)</a> <a href="#ref-for-concept-environment-execution-ready-flag①">(2)</a>
     <li><a href="#ref-for-concept-environment-execution-ready-flag②">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-concept-environment-execution-ready-flag③">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-classic-worker-script" class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script" id="infopanel-for-term-for-fetch-a-classic-worker-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-classic-worker-script" style="display:none">Info about the 'fetch a classic worker script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-classic-worker-script">Update</a> <a href="#ref-for-fetch-a-classic-worker-script①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-classic-worker-imported-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-classic-worker-imported-script" class="dfn-panel" data-for="term-for-fetch-a-classic-worker-imported-script" id="infopanel-for-term-for-fetch-a-classic-worker-imported-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-classic-worker-imported-script" style="display:none">Info about the 'fetch a classic worker-imported script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-imported-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-classic-worker-imported-script">Appendix A: Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree" id="infopanel-for-term-for-fetch-a-module-worker-script-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" style="display:none">Info about the 'fetch a module worker script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-module-worker-script-tree">Update</a> <a href="#ref-for-fetch-a-module-worker-script-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusing-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusing-steps" class="dfn-panel" data-for="term-for-focusing-steps" id="infopanel-for-term-for-focusing-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-focusing-steps" style="display:none">Info about the 'focusing steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusing-steps">4.2.10. focus()</a>
     <li><a href="#ref-for-focusing-steps①">4.3.2. matchAll(options)</a> <a href="#ref-for-focusing-steps②">(2)</a> <a href="#ref-for-focusing-steps③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">2.4.2. The worker client case</a> <a href="#ref-for-global-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.3. Service Worker Client</a> <a href="#ref-for-concept-settings-object-global①">(2)</a> <a href="#ref-for-concept-settings-object-global②">(3)</a>
     <li><a href="#ref-for-concept-settings-object-global③">3.1.5. postMessage(message, options)</a>
@@ -8996,8 +8996,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-settings-object-global①②">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-focus-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-focus-steps" class="dfn-panel" data-for="term-for-has-focus-steps" id="infopanel-for-term-for-has-focus-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-has-focus-steps" style="display:none">Info about the 'has focus steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-focus-steps">4.2.10. focus()</a>
     <li><a href="#ref-for-has-focus-steps①">4.2.11. navigate(url)</a>
@@ -9006,8 +9006,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-has-focus-steps④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-id">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-id" class="dfn-panel" data-for="term-for-concept-environment-id" id="infopanel-for-term-for-concept-environment-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-id" style="display:none">Info about the 'id' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-id">4.2.3. id</a>
     <li><a href="#ref-for-concept-environment-id①">4.3.1. get(id)</a>
@@ -9015,20 +9015,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-environment-id③">Handle Fetch</a> <a href="#ref-for-concept-environment-id④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.4.1. The window client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope" id="infopanel-for-term-for-import-scripts-into-worker-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" style="display:none">Info about the 'import scripts into worker global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-scripts-into-worker-global-scope">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-in-parallel①">3.4.2. ready</a>
@@ -9065,32 +9065,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-in-parallel③⑨">Handle User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-message">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-message" class="dfn-panel" data-for="term-for-event-message" id="infopanel-for-term-for-event-message" role="menu">
+   <span id="infopaneltitle-for-term-for-event-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-message">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-module-map">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-module-map">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-module-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-module-map" class="dfn-panel" data-for="term-for-concept-workerglobalscope-module-map" id="infopanel-for-term-for-concept-workerglobalscope-module-map" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-module-map" style="display:none">Info about the 'module map (for WorkerGlobalScope)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-module-map">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-module-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-module-map">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-module-map">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-module-map">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-module-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-module-map" class="dfn-panel" data-for="term-for-concept-settings-object-module-map" id="infopanel-for-term-for-concept-settings-object-module-map" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-module-map" style="display:none">Info about the 'module map (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-module-map">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-module-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-module-map">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-module-script" class="dfn-panel" data-for="term-for-module-script" id="infopanel-for-term-for-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-module-script" style="display:none">Info about the 'module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">2.4.1. The window client case</a> <a href="#ref-for-navigate①">(2)</a> <a href="#ref-for-navigate②">(3)</a>
     <li><a href="#ref-for-navigate③">3.2.9. unregister()</a>
@@ -9099,28 +9099,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-navigate⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-service-worker-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#obtain-a-service-worker-agent">https://html.spec.whatwg.org/multipage/webappapis.html#obtain-a-service-worker-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-service-worker-agent" class="dfn-panel" data-for="term-for-obtain-a-service-worker-agent" id="infopanel-for-term-for-obtain-a-service-worker-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-service-worker-agent" style="display:none">Info about the 'obtain a service worker agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#obtain-a-service-worker-agent">https://html.spec.whatwg.org/multipage/webappapis.html#obtain-a-service-worker-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-service-worker-agent">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-an-embedder-policy">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-an-embedder-policy">https://html.spec.whatwg.org/multipage/browsers.html#obtain-an-embedder-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-an-embedder-policy" class="dfn-panel" data-for="term-for-obtain-an-embedder-policy" id="infopanel-for-term-for-obtain-an-embedder-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-an-embedder-policy" style="display:none">Info about the 'obtain an embedder policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-an-embedder-policy">https://html.spec.whatwg.org/multipage/browsers.html#obtain-an-embedder-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-an-embedder-policy">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.4.1. The window client case</a> <a href="#ref-for-concept-origin-opaque①">(2)</a> <a href="#ref-for-concept-origin-opaque②">(3)</a>
     <li><a href="#ref-for-concept-origin-opaque③">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-origin-opaque④">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-origin①">2.4.1. The window client case</a> <a href="#ref-for-concept-origin②">(2)</a> <a href="#ref-for-concept-origin③">(3)</a> <a href="#ref-for-concept-origin④">(4)</a>
@@ -9131,14 +9131,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-origin①⓪">6.3.1. Origin restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-origin">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-origin" class="dfn-panel" data-for="term-for-dom-messageevent-origin" id="infopanel-for-term-for-dom-messageevent-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-origin" style="display:none">Info about the 'origin (for MessageEvent)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-origin">4.2.6. postMessage(message, options)</a> <a href="#ref-for-dom-messageevent-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-settings-object-origin①">3.1.5. postMessage(message, options)</a>
@@ -9164,26 +9164,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-settings-object-origin②⑥">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set" id="infopanel-for-term-for-concept-WorkerGlobalScope-owner-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" style="display:none">Info about the 'owner set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">2.4.2. The worker client case</a> <a href="#ref-for-concept-WorkerGlobalScope-owner-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-ports">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-ports" class="dfn-panel" data-for="term-for-dom-messageevent-ports" id="infopanel-for-term-for-dom-messageevent-ports" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-ports" style="display:none">Info about the 'ports' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-ports">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-queue-a-task①">3.1.5. postMessage(message, options)</a>
@@ -9214,8 +9214,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-queue-a-task④①">Resolve Get Client Promise</a> <a href="#ref-for-queue-a-task④②">(2)</a> <a href="#ref-for-queue-a-task④③">(3)</a> <a href="#ref-for-queue-a-task④④">(4)</a> <a href="#ref-for-queue-a-task④⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm" id="infopanel-for-term-for-environment-settings-object&apos;s-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" style="display:none">Info about the 'realm (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -9227,20 +9227,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object&apos;s-realm⑨">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'realm (for global object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">3.1.5. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-execution-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-execution-context" class="dfn-panel" data-for="term-for-realm-execution-context" id="infopanel-for-term-for-realm-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-execution-context" style="display:none">Info about the 'realm execution context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-execution-context">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.2.8. update()</a>
     <li><a href="#ref-for-concept-relevant-global①">3.4. ServiceWorkerContainer</a>
@@ -9252,8 +9252,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-relevant-global⑧">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.2.6. postMessage(message, options)</a>
@@ -9268,8 +9268,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-relevant-realm①⓪">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.1.5. postMessage(message, options)</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
     <li><a href="#ref-for-relevant-settings-object②">3.2.8. update()</a>
@@ -9296,8 +9296,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-relevant-settings-object③②">Resolve Get Client Promise</a> <a href="#ref-for-relevant-settings-object③③">(2)</a> <a href="#ref-for-relevant-settings-object③④">(3)</a> <a href="#ref-for-relevant-settings-object③⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">3.4.2. ready</a>
     <li><a href="#ref-for-responsible-event-loop①">3.4.5. getRegistrations()</a>
@@ -9321,26 +9321,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-responsible-event-loop②①">Resolve Get Client Promise</a> <a href="#ref-for-responsible-event-loop②②">(2)</a> <a href="#ref-for-responsible-event-loop②③">(3)</a> <a href="#ref-for-responsible-event-loop②④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-classic-script" class="dfn-panel" data-for="term-for-run-a-classic-script" id="infopanel-for-term-for-run-a-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-classic-script" style="display:none">Info about the 'run a classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-module-script" class="dfn-panel" data-for="term-for-run-a-module-script" id="infopanel-for-term-for-run-a-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-module-script" style="display:none">Info about the 'run a module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-worker" class="dfn-panel" data-for="term-for-run-a-worker" id="infopanel-for-term-for-run-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-worker" style="display:none">Info about the 'run a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-worker">2.4.2. The worker client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.4.1. The window client case</a>
     <li><a href="#ref-for-same-origin①">2.4.2. The worker client case</a>
@@ -9355,20 +9355,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-same-origin①①">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">2.4.1. The window client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script" class="dfn-panel" data-for="term-for-concept-script" id="infopanel-for-term-for-concept-script" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-secure-context①">4.3.4. claim()</a>
@@ -9377,29 +9377,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-secure-context⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-source">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-source" class="dfn-panel" data-for="term-for-dom-messageevent-source" id="infopanel-for-term-for-dom-messageevent-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-source" style="display:none">Info about the 'source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-source">4.2.6. postMessage(message, options)</a> <a href="#ref-for-dom-messageevent-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-concept-environment-target-browsing-context①">Run Service Worker</a>
     <li><a href="#ref-for-concept-environment-target-browsing-context②">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2.2. Service Worker Registration</a> <a href="#ref-for-concept-task①">(2)</a>
     <li><a href="#ref-for-concept-task②">3.4. ServiceWorkerContainer</a>
@@ -9411,16 +9411,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-task①⓪">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queues' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-task-queue①">(2)</a> <a href="#ref-for-task-queue②">(3)</a>
     <li><a href="#ref-for-task-queue③">Run Service Worker</a>
     <li><a href="#ref-for-task-queue④">Terminate Service Worker</a> <a href="#ref-for-task-queue⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2.5. Task Sources</a> <a href="#ref-for-task-source①">(2)</a> <a href="#ref-for-task-source②">(3)</a>
     <li><a href="#ref-for-task-source③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-task-source④">(2)</a>
@@ -9428,45 +9428,45 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-task-source⑥">Terminate Service Worker</a> <a href="#ref-for-task-source⑦">(2)</a> <a href="#ref-for-task-source⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-creation-url" class="dfn-panel" data-for="term-for-concept-environment-top-level-creation-url" id="infopanel-for-term-for-concept-environment-top-level-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-creation-url" style="display:none">Info about the 'top-level creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-creation-url">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-type">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-type" class="dfn-panel" data-for="term-for-concept-workerglobalscope-type" id="infopanel-for-term-for-concept-workerglobalscope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unsafe-response">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unsafe-response" class="dfn-panel" data-for="term-for-unsafe-response" id="infopanel-for-term-for-unsafe-response" role="menu">
+   <span id="infopaneltitle-for-term-for-unsafe-response" style="display:none">Info about the 'unsafe response' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-response">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-unsafe-response①">Update</a> <a href="#ref-for-unsafe-response②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-url">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-url" class="dfn-panel" data-for="term-for-concept-workerglobalscope-url" id="infopanel-for-term-for-concept-workerglobalscope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-url" style="display:none">Info about the 'url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-url">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-interaction-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-interaction-task-source" class="dfn-panel" data-for="term-for-user-interaction-task-source" id="infopanel-for-term-for-user-interaction-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-user-interaction-task-source" style="display:none">Info about the 'user interaction task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-interaction-task-source">4.2.10. focus()</a>
     <li><a href="#ref-for-user-interaction-task-source①">4.2.11. navigate(url)</a>
@@ -9475,8 +9475,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-user-interaction-task-source④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.4.5. getRegistrations()</a> <a href="#ref-for-list-append①">(2)</a>
     <li><a href="#ref-for-list-append②">4.3.2. matchAll(options)</a> <a href="#ref-for-list-append③">(2)</a>
@@ -9486,42 +9486,42 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-append⑦">Batch Cache Operations</a> <a href="#ref-for-list-append⑧">(2)</a> <a href="#ref-for-list-append⑨">(3)</a> <a href="#ref-for-list-append①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">6.3.2. importScripts(urls)</a> <a href="#ref-for-set-append①">(2)</a>
     <li><a href="#ref-for-set-append②">Run Service Worker</a>
     <li><a href="#ref-for-set-append③">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">Start Register</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a> <a href="#ref-for-ascii-case-insensitive②">(3)</a> <a href="#ref-for-ascii-case-insensitive③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.2. Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">Install</a>
     <li><a href="#ref-for-list-contain①">Handle Fetch</a>
     <li><a href="#ref-for-list-contain②">Should Skip Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">4.3.1. get(id)</a>
     <li><a href="#ref-for-iteration-continue①">4.3.2. matchAll(options)</a> <a href="#ref-for-iteration-continue②">(2)</a> <a href="#ref-for-iteration-continue③">(3)</a>
@@ -9530,26 +9530,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-iteration-continue⑧">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-dequeue">
-   <a href="https://infra.spec.whatwg.org/#queue-dequeue">https://infra.spec.whatwg.org/#queue-dequeue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-dequeue" class="dfn-panel" data-for="term-for-queue-dequeue" id="infopanel-for-term-for-queue-dequeue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-dequeue" style="display:none">Info about the 'dequeue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-dequeue">https://infra.spec.whatwg.org/#queue-dequeue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-dequeue">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-enqueue">
-   <a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-enqueue" class="dfn-panel" data-for="term-for-queue-enqueue" id="infopanel-for-term-for-queue-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-enqueue">Schedule Job</a> <a href="#ref-for-queue-enqueue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5.1. Constructs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-exists①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -9560,8 +9560,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-exists⑦">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-list-iterate①">4.3.2. matchAll(options)</a> <a href="#ref-for-list-iterate②">(2)</a>
@@ -9574,8 +9574,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-iterate①⑤">Batch Cache Operations</a> <a href="#ref-for-list-iterate①⑥">(2)</a> <a href="#ref-for-list-iterate①⑦">(3)</a> <a href="#ref-for-list-iterate①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-map-iterate①">5.5.1. match(request, options)</a> <a href="#ref-for-map-iterate②">(2)</a>
@@ -9587,8 +9587,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-iterate⑧">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'get the keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-keys①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -9597,14 +9597,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-getting-the-keys④">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">5.4.6. delete(request, options)</a>
     <li><a href="#ref-for-list-is-empty①">Run Job</a>
@@ -9612,8 +9612,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-is-empty③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.1. Service Worker</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a>
     <li><a href="#ref-for-list-item③">2.4.2. The worker client case</a> <a href="#ref-for-list-item④">(2)</a>
@@ -9626,20 +9626,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-item①①">Batch Cache Operations</a> <a href="#ref-for-list-item①②">(2)</a> <a href="#ref-for-list-item①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item (for struct)' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">5.1. Constructs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys①" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys①" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-keys①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -9648,8 +9648,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-getting-the-keys④">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.4.5. getRegistrations()</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">4.3.2. matchAll(options)</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a>
@@ -9665,8 +9665,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list②②">Batch Cache Operations</a> <a href="#ref-for-list②③">(2)</a> <a href="#ref-for-list②④">(3)</a> <a href="#ref-for-list②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.1. Service Worker</a>
     <li><a href="#ref-for-ordered-map①">3.1.1. Getting ServiceWorker instances</a>
@@ -9676,8 +9676,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-ordered-map⑥">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.1. Service Worker</a>
     <li><a href="#ref-for-ordered-map①">3.1.1. Getting ServiceWorker instances</a>
@@ -9687,29 +9687,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-ordered-map⑥">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.1. Service Worker</a> <a href="#ref-for-ordered-set①">(2)</a> <a href="#ref-for-ordered-set②">(3)</a> <a href="#ref-for-ordered-set③">(4)</a> <a href="#ref-for-ordered-set④">(5)</a> <a href="#ref-for-ordered-set⑤">(6)</a>
     <li><a href="#ref-for-ordered-set⑥">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue">
-   <a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue" class="dfn-panel" data-for="term-for-queue" id="infopanel-for-term-for-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue" style="display:none">Info about the 'queue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">Appendix A: Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">Terminate Service Worker</a>
     <li><a href="#ref-for-list-remove①">Update Service Worker Extended Events Set</a>
     <li><a href="#ref-for-list-remove②">Batch Cache Operations</a> <a href="#ref-for-list-remove③">(2)</a> <a href="#ref-for-list-remove④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">5.5.4. delete(cacheName)</a>
     <li><a href="#ref-for-map-remove①">Update</a> <a href="#ref-for-map-remove②">(2)</a>
@@ -9717,8 +9717,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-remove⑤">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.5.3. open(cacheName)</a>
     <li><a href="#ref-for-map-set①">6.3.2. importScripts(urls)</a>
@@ -9726,48 +9726,48 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-set③">Set Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">5.4. Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">5.1. Constructs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-values①">3.2.1. Getting ServiceWorkerRegistration instances</a>
     <li><a href="#ref-for-map-getting-the-values②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-mime-type" class="dfn-panel" data-for="term-for-javascript-mime-type" id="infopanel-for-term-for-javascript-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-mime-type" style="display:none">Info about the 'javascript mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-mime-type">6.6. Service worker script request</a>
     <li><a href="#ref-for-javascript-mime-type①">Appendix A: Algorithms</a>
     <li><a href="#ref-for-javascript-mime-type②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discarded">
-   <a href="https://wicg.github.io/page-lifecycle/#discarded">https://wicg.github.io/page-lifecycle/#discarded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discarded" class="dfn-panel" data-for="term-for-discarded" id="infopanel-for-term-for-discarded" role="menu">
+   <span id="infopaneltitle-for-term-for-discarded" style="display:none">Info about the 'discard' external reference.</span><a href="https://wicg.github.io/page-lifecycle/#discarded">https://wicg.github.io/page-lifecycle/#discarded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discarded">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VisibilityState">
-   <a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VisibilityState" class="dfn-panel" data-for="term-for-VisibilityState" id="infopanel-for-term-for-VisibilityState" role="menu">
+   <span id="infopaneltitle-for-term-for-VisibilityState" style="display:none">Info about the 'VisibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VisibilityState">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-visibilitystate" class="dfn-panel" data-for="term-for-dom-document-visibilitystate" id="infopanel-for-term-for-dom-document-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-document-visibilitystate①">4.2.10. focus()</a>
@@ -9777,161 +9777,161 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-document-visibilitystate⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-h-the-push-event">
-   <a href="https://w3c.github.io/push-api/#h-the-push-event">https://w3c.github.io/push-api/#h-the-push-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-h-the-push-event" class="dfn-panel" data-for="term-for-h-the-push-event" id="infopanel-for-term-for-h-the-push-event" role="menu">
+   <span id="infopaneltitle-for-term-for-h-the-push-event" style="display:none">Info about the 'push' external reference.</span><a href="https://w3c.github.io/push-api/#h-the-push-event">https://w3c.github.io/push-api/#h-the-push-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-h-the-push-event">2.5. Task Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy" class="dfn-panel" data-for="term-for-referrer-policy" id="infopanel-for-term-for-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'field-value' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-3.2①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-3.2②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-7.1.4①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-7.1.4②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-monitor">
-   <a href="https://w3c.github.io/mediacapture-screen-share/#dfn-monitor">https://w3c.github.io/mediacapture-screen-share/#dfn-monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-monitor" class="dfn-panel" data-for="term-for-dfn-monitor" id="infopanel-for-term-for-dfn-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://w3c.github.io/mediacapture-screen-share/#dfn-monitor">https://w3c.github.io/mediacapture-screen-share/#dfn-monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-monitor">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-origin">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-origin" class="dfn-panel" data-for="term-for-potentially-trustworthy-origin" id="infopanel-for-term-for-potentially-trustworthy-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-origin" style="display:none">Info about the 'potentially trustworthy origin' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-origin">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-url" class="dfn-panel" data-for="term-for-potentially-trustworthy-url" id="infopanel-for-term-for-potentially-trustworthy-url" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-url" style="display:none">Info about the 'potentially trustworthy url' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-url">Handle Fetch</a>
     <li><a href="#ref-for-potentially-trustworthy-url①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-cancel" class="dfn-panel" data-for="term-for-readablestream-cancel" id="infopanel-for-term-for-readablestream-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-cancel" style="display:none">Info about the 'cancel (for ReadableStream)' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-cancel">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-cancel">https://streams.spec.whatwg.org/#readablestreamdefaultreader-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-cancel" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-cancel" id="infopanel-for-term-for-readablestreamdefaultreader-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-cancel" style="display:none">Info about the 'cancel (for ReadableStreamDefaultReader)' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-cancel">https://streams.spec.whatwg.org/#readablestreamdefaultreader-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-cancel">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-chunk">
-   <a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-chunk" class="dfn-panel" data-for="term-for-chunk" id="infopanel-for-term-for-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-chunk" style="display:none">Info about the 'chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-chunk-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-chunk-steps">https://streams.spec.whatwg.org/#read-request-chunk-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-chunk-steps" class="dfn-panel" data-for="term-for-read-request-chunk-steps" id="infopanel-for-term-for-read-request-chunk-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-chunk-steps" style="display:none">Info about the 'chunk steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-chunk-steps">https://streams.spec.whatwg.org/#read-request-chunk-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-chunk-steps">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-close">
-   <a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-close" class="dfn-panel" data-for="term-for-readablestream-close" id="infopanel-for-term-for-readablestream-close" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-close" style="display:none">Info about the 'close' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-close">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-close-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-close-steps">https://streams.spec.whatwg.org/#read-request-close-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-close-steps" class="dfn-panel" data-for="term-for-read-request-close-steps" id="infopanel-for-term-for-read-request-close-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-close-steps" style="display:none">Info about the 'close steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-close-steps">https://streams.spec.whatwg.org/#read-request-close-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-close-steps">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-error">
-   <a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-error" class="dfn-panel" data-for="term-for-readablestream-error" id="infopanel-for-term-for-readablestream-error" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-error" style="display:none">Info about the 'error' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-error">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-error-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-error-steps">https://streams.spec.whatwg.org/#read-request-error-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-error-steps" class="dfn-panel" data-for="term-for-read-request-error-steps" id="infopanel-for-term-for-read-request-error-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-error-steps" style="display:none">Info about the 'error steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-error-steps">https://streams.spec.whatwg.org/#read-request-error-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-error-steps">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-errored">
-   <a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-errored" class="dfn-panel" data-for="term-for-readablestream-errored" id="infopanel-for-term-for-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-errored">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'getting a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">4.5.7. event.respondWith(r)</a>
     <li><a href="#ref-for-readablestream-get-a-reader①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk" id="infopanel-for-term-for-readablestreamdefaultreader-read-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" style="display:none">Info about the 'read a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request">
-   <a href="https://streams.spec.whatwg.org/#read-request">https://streams.spec.whatwg.org/#read-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request" class="dfn-panel" data-for="term-for-read-request" id="infopanel-for-term-for-read-request" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request" style="display:none">Info about the 'read request' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request">https://streams.spec.whatwg.org/#read-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes" id="infopanel-for-term-for-readablestreamdefaultreader-read-all-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" style="display:none">Info about the 'reading all bytes' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">Register</a>
     <li><a href="#ref-for-concept-url-equals①">Update</a>
     <li><a href="#ref-for-concept-url-equals②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-concept-url-fragment①">Start Register</a> <a href="#ref-for-concept-url-fragment②">(2)</a> <a href="#ref-for-concept-url-fragment③">(3)</a> <a href="#ref-for-concept-url-fragment④">(4)</a> <a href="#ref-for-concept-url-fragment⑤">(5)</a> <a href="#ref-for-concept-url-fragment⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-url-origin①">3.4.5. getRegistrations()</a>
@@ -9943,22 +9943,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-origin①①">Match Service Worker Registration</a> <a href="#ref-for-concept-url-origin①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">6.5. Path restriction</a>
     <li><a href="#ref-for-concept-url-path①">Start Register</a> <a href="#ref-for-concept-url-path②">(2)</a>
     <li><a href="#ref-for-concept-url-path③">Update</a> <a href="#ref-for-concept-url-path④">(2)</a> <a href="#ref-for-concept-url-path⑤">(3)</a> <a href="#ref-for-concept-url-path⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">Request Matches Cached Item</a> <a href="#ref-for-concept-url-query①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
     <li><a href="#ref-for-concept-url-scheme②">5.4.5. put(request, response)</a>
@@ -9966,8 +9966,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-scheme⑤">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">2.1. Service Worker</a> <a href="#ref-for-concept-url①">(2)</a> <a href="#ref-for-concept-url②">(3)</a>
     <li><a href="#ref-for-concept-url③">2.2. Service Worker Registration</a>
@@ -9980,8 +9980,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url①⑤">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-parser①">(2)</a>
     <li><a href="#ref-for-concept-url-parser②">3.4.4. getRegistration(clientURL)</a>
@@ -9993,8 +9993,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-parser⑨">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">2.2.1. Lifetime</a>
     <li><a href="#ref-for-concept-url-serializer①">3.1.2. scriptURL</a>
@@ -10009,32 +10009,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-serializer①⑤">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-referrer-policy-from-header">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header">https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-referrer-policy-from-header" class="dfn-panel" data-for="term-for-parse-referrer-policy-from-header" id="infopanel-for-term-for-parse-referrer-policy-from-header" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-referrer-policy-from-header" style="display:none">Info about the 'parse a referrer policy from a referrer-policy header' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header">https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-referrer-policy-from-header">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">3.6. NavigationPreloadManager</a> <a href="#ref-for-idl-ByteString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2.8. update()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">3.4.4. getRegistration(clientURL)</a>
@@ -10056,8 +10056,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMException②⑥">Batch Cache Operations</a> <a href="#ref-for-idl-DOMException②⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.2. Client</a>
     <li><a href="#ref-for-idl-DOMString①">4.3. Clients</a>
@@ -10067,8 +10067,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMString①③">5.5. CacheStorage</a> <a href="#ref-for-idl-DOMString①④">(2)</a> <a href="#ref-for-idl-DOMString①⑤">(3)</a> <a href="#ref-for-idl-DOMString①⑥">(4)</a> <a href="#ref-for-idl-DOMString①⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. ServiceWorker</a>
     <li><a href="#ref-for-Exposed①">3.2. ServiceWorkerRegistration</a>
@@ -10084,8 +10084,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-Exposed①②">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-idl-frozen-array①">4.2. Client</a>
@@ -10094,21 +10094,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-frozen-array④">5.4. Cache</a> <a href="#ref-for-idl-frozen-array⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">4.2.10. focus()</a>
     <li><a href="#ref-for-invalidaccesserror①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2.8. update()</a> <a href="#ref-for-invalidstateerror①">(2)</a>
     <li><a href="#ref-for-invalidstateerror②">3.6.1. enable()</a>
@@ -10120,14 +10120,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-invalidstateerror①⓪">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networkerror">
-   <a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networkerror" class="dfn-panel" data-for="term-for-networkerror" id="infopanel-for-term-for-networkerror" role="menu">
+   <span id="infopaneltitle-for-term-for-networkerror" style="display:none">Info about the 'NetworkError' external reference.</span><a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">Handle Fetch</a> <a href="#ref-for-networkerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-NewObject①">(2)</a>
     <li><a href="#ref-for-NewObject②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-NewObject③">(2)</a> <a href="#ref-for-NewObject④">(3)</a>
@@ -10138,8 +10138,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-NewObject①⑨">5.5. CacheStorage</a> <a href="#ref-for-NewObject②⓪">(2)</a> <a href="#ref-for-NewObject②①">(3)</a> <a href="#ref-for-NewObject②②">(4)</a> <a href="#ref-for-NewObject②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-idl-promise③">(2)</a> <a href="#ref-for-idl-promise④">(3)</a> <a href="#ref-for-idl-promise⑤">(4)</a>
@@ -10153,15 +10153,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-promise③⓪">5.5. CacheStorage</a> <a href="#ref-for-idl-promise③①">(2)</a> <a href="#ref-for-idl-promise③②">(3)</a> <a href="#ref-for-idl-promise③③">(4)</a> <a href="#ref-for-idl-promise③④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">5.5.3. open(cacheName)</a>
     <li><a href="#ref-for-quotaexceedederror①">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-SameObject①">3.3. navigator.serviceWorker</a> <a href="#ref-for-SameObject②">(2)</a>
@@ -10172,8 +10172,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SameObject⑨">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. ServiceWorker</a>
     <li><a href="#ref-for-SecureContext①">3.2. ServiceWorkerRegistration</a>
@@ -10185,8 +10185,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SecureContext⑧">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-securityerror①">Register</a> <a href="#ref-for-securityerror②">(2)</a> <a href="#ref-for-securityerror③">(3)</a>
@@ -10195,14 +10195,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-securityerror⑧">Resolve Get Client Promise</a> <a href="#ref-for-securityerror⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-USVString①">3.2. ServiceWorkerRegistration</a>
@@ -10212,14 +10212,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-USVString⑨">4.6. ExtendableMessageEvent</a> <a href="#ref-for-idl-USVString①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">4.5.7. event.respondWith(r)</a> <a href="#ref-for-idl-Uint8Array①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2.9. unregister()</a>
     <li><a href="#ref-for-a-new-promise①">3.4.2. ready</a>
@@ -10243,8 +10243,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-new-promise②⓪">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2.8. update()</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a>
     <li><a href="#ref-for-a-promise-rejected-with②">5.4.2. matchAll(request, options)</a>
@@ -10254,8 +10254,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-promise-rejected-with①②">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">4.5.2. event.preloadResponse</a>
     <li><a href="#ref-for-a-promise-resolved-with①">5.4.2. matchAll(request, options)</a>
@@ -10265,8 +10265,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-promise-resolved-with⑤">5.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.1. ServiceWorker</a> <a href="#ref-for-idl-any①">(2)</a>
     <li><a href="#ref-for-idl-any②">4.2. Client</a> <a href="#ref-for-idl-any③">(2)</a>
@@ -10275,8 +10275,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-any⑦">4.6. ExtendableMessageEvent</a> <a href="#ref-for-idl-any⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-idl-boolean①">3.6. NavigationPreloadManager</a>
@@ -10286,8 +10286,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-boolean⑧">5.5. CacheStorage</a> <a href="#ref-for-idl-boolean⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-frozen-array" class="dfn-panel" data-for="term-for-dfn-create-frozen-array" id="infopanel-for-term-for-dfn-create-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-dfn-create-frozen-array①">4.3.2. matchAll(options)</a>
@@ -10295,8 +10295,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-create-frozen-array③">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-exception" class="dfn-panel" data-for="term-for-dfn-create-exception" id="infopanel-for-term-for-dfn-create-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-exception" style="display:none">Info about the 'created' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-create-exception①">5.4.5. put(request, response)</a>
@@ -10304,8 +10304,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-create-exception③">Reject Job Promise</a> <a href="#ref-for-dfn-create-exception④">(2)</a> <a href="#ref-for-dfn-create-exception⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception" class="dfn-panel" data-for="term-for-dfn-exception" id="infopanel-for-term-for-dfn-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception" style="display:none">Info about the 'exception' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-exception①">5.4.5. put(request, response)</a>
@@ -10313,8 +10313,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-exception③">Reject Job Promise</a> <a href="#ref-for-dfn-exception④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">4.2.6. postMessage(message, options)</a>
@@ -10323,15 +10323,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-frozen-array-type④">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all-promise">
-   <a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all-promise" class="dfn-panel" data-for="term-for-waiting-for-all-promise" id="infopanel-for-term-for-waiting-for-all-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all-promise" style="display:none">Info about the 'getting a promise to wait for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all-promise">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-waiting-for-all-promise①">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception-message">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception-message">https://webidl.spec.whatwg.org/#dfn-exception-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception-message" class="dfn-panel" data-for="term-for-dfn-exception-message" id="infopanel-for-term-for-dfn-exception-message" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception-message" style="display:none">Info about the 'message' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception-message">https://webidl.spec.whatwg.org/#dfn-exception-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception-message">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-exception-message①">5.4.5. put(request, response)</a>
@@ -10339,22 +10339,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-exception-message③">Reject Job Promise</a> <a href="#ref-for-dfn-exception-message④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-object①">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-partial-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-partial-interface" class="dfn-panel" data-for="term-for-dfn-partial-interface" id="infopanel-for-term-for-dfn-partial-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-partial-interface" style="display:none">Info about the 'partial interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-interface">7.1. Define API bound to Service Worker Registration</a>
     <li><a href="#ref-for-dfn-partial-interface①">7.3. Define Event Handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'reacting' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">5.4.3. add(request)</a>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">5.4.4. addAll(requests)</a>
@@ -10362,8 +10362,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled③">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.6.1. enable()</a>
     <li><a href="#ref-for-reject①">3.6.2. disable()</a>
@@ -10371,14 +10371,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-reject③">Handle Fetch</a> <a href="#ref-for-reject④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">Handle Fetch</a> <a href="#ref-for-resolve①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-sequence①">4.2. Client</a>
@@ -10387,8 +10387,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-sequence④">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-this①">3.2.8. update()</a> <a href="#ref-for-this②">(2)</a>
@@ -10430,8 +10430,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-this⑤⑨">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.2.11. navigate(url)</a>
     <li><a href="#ref-for-dfn-throw①">4.3.3. openWindow(url)</a>
@@ -10445,8 +10445,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-throw①④">Batch Cache Operations</a> <a href="#ref-for-dfn-throw①⑤">(2)</a> <a href="#ref-for-dfn-throw①⑥">(3)</a> <a href="#ref-for-dfn-throw①⑦">(4)</a> <a href="#ref-for-dfn-throw①⑧">(5)</a> <a href="#ref-for-dfn-throw①⑨">(6)</a> <a href="#ref-for-dfn-throw②⓪">(7)</a> <a href="#ref-for-dfn-throw②①">(8)</a> <a href="#ref-for-dfn-throw②②">(9)</a> <a href="#ref-for-dfn-throw②③">(10)</a> <a href="#ref-for-dfn-throw②④">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3.1. ServiceWorker</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">3.2. ServiceWorkerRegistration</a>
@@ -10461,16 +10461,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-undefined②①">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-upon-fulfillment①">4.5.7. event.respondWith(r)</a>
     <li><a href="#ref-for-upon-fulfillment②">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-upon-rejection①">4.5.7. event.respondWith(r)</a>
@@ -11150,8 +11150,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <div class="issue"> Using the to-be-created <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> rather than a concrete <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a>. This is used due to the unique processing model of service workers compared to the processing model of other <a data-link-type="dfn">web workers</a>. The script fetching algorithms of HTML standard originally designed for other <a data-link-type="dfn">web workers</a> require an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">environment settings object</a> of the execution environment, but service workers fetch a script separately in the <a data-link-type="dfn" href="#update">Update</a> algorithm before the script later runs multiple times through the <a data-link-type="dfn" href="#run-service-worker">Run Service Worker</a> algorithm. <a class="issue-return" href="#issue-02e2fe82" title="Jump to section">↵</a></div>
    <div class="issue"> The <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">fetch a classic worker script</a> algorithm and the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">fetch a module worker script graph</a> algorithm in HTML take <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client">client</a> as an argument. <var>job</var>’s <a data-link-type="dfn" href="#dfn-job-client">client</a> is null when passed from the <a data-link-type="dfn" href="#soft-update">Soft Update</a> algorithm. <a class="issue-return" href="#issue-9d9e65b5" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dfn-service-worker">
-   <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker" class="dfn-panel" data-for="dfn-service-worker" id="infopanel-for-dfn-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1. Motivations</a> <a href="#ref-for-dfn-service-worker①">(2)</a> <a href="#ref-for-dfn-service-worker②">(3)</a> <a href="#ref-for-dfn-service-worker③">(4)</a> <a href="#ref-for-dfn-service-worker④">(5)</a> <a href="#ref-for-dfn-service-worker⑤">(6)</a> <a href="#ref-for-dfn-service-worker⑥">(7)</a> <a href="#ref-for-dfn-service-worker⑦">(8)</a> <a href="#ref-for-dfn-service-worker⑧">(9)</a> <a href="#ref-for-dfn-service-worker⑨">(10)</a> <a href="#ref-for-dfn-service-worker①⓪">(11)</a> <a href="#ref-for-dfn-service-worker①①">(12)</a> <a href="#ref-for-dfn-service-worker①②">(13)</a> <a href="#ref-for-dfn-service-worker①③">(14)</a>
     <li><a href="#ref-for-dfn-service-worker①④">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker①⑤">(2)</a> <a href="#ref-for-dfn-service-worker①⑥">(3)</a> <a href="#ref-for-dfn-service-worker①⑦">(4)</a> <a href="#ref-for-dfn-service-worker①⑧">(5)</a> <a href="#ref-for-dfn-service-worker①⑨">(6)</a> <a href="#ref-for-dfn-service-worker②⓪">(7)</a> <a href="#ref-for-dfn-service-worker②①">(8)</a> <a href="#ref-for-dfn-service-worker②②">(9)</a> <a href="#ref-for-dfn-service-worker②③">(10)</a> <a href="#ref-for-dfn-service-worker②④">(11)</a> <a href="#ref-for-dfn-service-worker②⑤">(12)</a> <a href="#ref-for-dfn-service-worker②⑥">(13)</a> <a href="#ref-for-dfn-service-worker②⑦">(14)</a> <a href="#ref-for-dfn-service-worker②⑧">(15)</a> <a href="#ref-for-dfn-service-worker②⑨">(16)</a>
@@ -11198,16 +11198,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker①①⓪">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-state">
-   <b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-state" class="dfn-panel" data-for="dfn-state" id="infopanel-for-dfn-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state①">(2)</a> <a href="#ref-for-dfn-state②">(3)</a>
     <li><a href="#ref-for-dfn-state③">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-dfn-state④">Update Worker State</a> <a href="#ref-for-dfn-state⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-url">
-   <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-url" class="dfn-panel" data-for="dfn-script-url" id="infopanel-for-dfn-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url">3.1.2. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url①">3.2.8. update()</a>
@@ -11218,8 +11218,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-url①⓪">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type">
-   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type" class="dfn-panel" data-for="dfn-type" id="infopanel-for-dfn-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.2.8. update()</a>
     <li><a href="#ref-for-dfn-type①">Register</a>
@@ -11228,8 +11228,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-type⑤">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-service-worker-registration">
-   <b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-service-worker-registration" class="dfn-panel" data-for="dfn-containing-service-worker-registration" id="infopanel-for-dfn-containing-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-service-worker-registration" style="display:none">Info about the 'containing service worker registration' definition.</span><b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.4. Control and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration①">3.2.9. unregister()</a>
@@ -11244,8 +11244,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-containing-service-worker-registration①④">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-global-object">
-   <b><a href="#dfn-service-worker-global-object">#dfn-service-worker-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-global-object" class="dfn-panel" data-for="dfn-service-worker-global-object" id="infopanel-for-dfn-service-worker-global-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#dfn-service-worker-global-object">#dfn-service-worker-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-global-object">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-dfn-service-worker-global-object①">Install</a>
@@ -11256,8 +11256,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-global-object⑦">Fire Functional Event</a> <a href="#ref-for-dfn-service-worker-global-object⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource">
-   <b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource" class="dfn-panel" data-for="dfn-script-resource" id="infopanel-for-dfn-script-resource" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource" style="display:none">Info about the 'script resource' definition.</span><b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource①">(2)</a>
     <li><a href="#ref-for-dfn-script-resource②">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource③">(2)</a>
@@ -11268,28 +11268,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-resource①①">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
-   <b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag" id="infopanel-for-dfn-has-ever-been-evaluated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" style="display:none">Info about the 'has ever been evaluated flag' definition.</span><b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-has-ever-been-evaluated-flag">Run Service Worker</a> <a href="#ref-for-dfn-has-ever-been-evaluated-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-referrer-policy">
-   <b><a href="#dfn-referrer-policy">#dfn-referrer-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-referrer-policy" class="dfn-panel" data-for="dfn-referrer-policy" id="infopanel-for-dfn-referrer-policy" role="dialog">
+   <span id="infopaneltitle-for-dfn-referrer-policy" style="display:none">Info about the 'referrer policy' definition.</span><b><a href="#dfn-referrer-policy">#dfn-referrer-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-referrer-policy">Update</a>
     <li><a href="#ref-for-dfn-referrer-policy①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-embedder-policy">
-   <b><a href="#service-worker-embedder-policy">#service-worker-embedder-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-embedder-policy" class="dfn-panel" data-for="service-worker-embedder-policy" id="infopanel-for-service-worker-embedder-policy" role="dialog">
+   <span id="infopaneltitle-for-service-worker-embedder-policy" style="display:none">Info about the 'embedder policy' definition.</span><b><a href="#service-worker-embedder-policy">#service-worker-embedder-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-embedder-policy">Update</a>
     <li><a href="#ref-for-service-worker-embedder-policy①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource-map">
-   <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource-map" class="dfn-panel" data-for="dfn-script-resource-map" id="infopanel-for-dfn-script-resource-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource-map" style="display:none">Info about the 'script resource map' definition.</span><b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-script-resource-map①">6.8. Privacy</a>
@@ -11297,8 +11297,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-resource-map⑤">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-used-scripts">
-   <b><a href="#dfn-set-of-used-scripts">#dfn-set-of-used-scripts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-used-scripts" class="dfn-panel" data-for="dfn-set-of-used-scripts" id="infopanel-for-dfn-set-of-used-scripts" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-used-scripts" style="display:none">Info about the 'set of used scripts' definition.</span><b><a href="#dfn-set-of-used-scripts">#dfn-set-of-used-scripts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-used-scripts">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-used-scripts①">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-set-of-used-scripts②">(2)</a>
@@ -11306,65 +11306,65 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-set-of-used-scripts④">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
-   <b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-skip-waiting-flag" class="dfn-panel" data-for="dfn-skip-waiting-flag" id="infopanel-for-dfn-skip-waiting-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-skip-waiting-flag" style="display:none">Info about the 'skip waiting flag' definition.</span><b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag①">4.1.4. skipWaiting()</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag②">Try Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-classic-scripts-imported-flag">
-   <b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-classic-scripts-imported-flag" class="dfn-panel" data-for="dfn-classic-scripts-imported-flag" id="infopanel-for-dfn-classic-scripts-imported-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-classic-scripts-imported-flag" style="display:none">Info about the 'classic scripts imported flag' definition.</span><b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-classic-scripts-imported-flag">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-classic-scripts-imported-flag①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
-   <b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-event-types-to-handle" class="dfn-panel" data-for="dfn-set-of-event-types-to-handle" id="infopanel-for-dfn-set-of-event-types-to-handle" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-event-types-to-handle" style="display:none">Info about the 'set of event types to handle' definition.</span><b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle①">Handle Fetch</a> <a href="#ref-for-dfn-set-of-event-types-to-handle②">(2)</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle③">Should Skip Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
-   <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-extended-events" class="dfn-panel" data-for="dfn-set-of-extended-events" id="infopanel-for-dfn-set-of-extended-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-extended-events" style="display:none">Info about the 'set of extended events' definition.</span><b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-extended-events">Terminate Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-extended-events①">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events②">(2)</a> <a href="#ref-for-dfn-set-of-extended-events③">(3)</a>
     <li><a href="#ref-for-dfn-set-of-extended-events④">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-start-status">
-   <b><a href="#service-worker-start-status">#service-worker-start-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-start-status" class="dfn-panel" data-for="service-worker-start-status" id="infopanel-for-service-worker-start-status" role="dialog">
+   <span id="infopaneltitle-for-service-worker-start-status" style="display:none">Info about the 'start status' definition.</span><b><a href="#service-worker-start-status">#service-worker-start-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-start-status">Run Service Worker</a> <a href="#ref-for-service-worker-start-status①">(2)</a> <a href="#ref-for-service-worker-start-status②">(3)</a> <a href="#ref-for-service-worker-start-status③">(4)</a>
     <li><a href="#ref-for-service-worker-start-status④">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-running">
-   <b><a href="#service-worker-running">#service-worker-running</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-running" class="dfn-panel" data-for="service-worker-running" id="infopanel-for-service-worker-running" role="dialog">
+   <span id="infopaneltitle-for-service-worker-running" style="display:none">Info about the 'running' definition.</span><b><a href="#service-worker-running">#service-worker-running</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-running">Run Service Worker</a> <a href="#ref-for-service-worker-running①">(2)</a> <a href="#ref-for-service-worker-running②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-events">
-   <b><a href="#dfn-service-worker-events">#dfn-service-worker-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-events" class="dfn-panel" data-for="dfn-service-worker-events" id="infopanel-for-dfn-service-worker-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-events" style="display:none">Info about the 'service worker events' definition.</span><b><a href="#dfn-service-worker-events">#dfn-service-worker-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-events">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-lifecycle-events">
-   <b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-lifecycle-events" class="dfn-panel" data-for="dfn-lifecycle-events" id="infopanel-for-dfn-lifecycle-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-lifecycle-events" style="display:none">Info about the 'Lifecycle events' definition.</span><b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lifecycle-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-lifecycle-events①">4.7. Events</a> <a href="#ref-for-dfn-lifecycle-events②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-functional-events">
-   <b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-functional-events" class="dfn-panel" data-for="dfn-functional-events" id="infopanel-for-dfn-functional-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-functional-events" style="display:none">Info about the 'Functional events' definition.</span><b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-functional-events">2.5. Task Sources</a>
     <li><a href="#ref-for-dfn-functional-events①">4.4. ExtendableEvent</a>
@@ -11375,8 +11375,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-functional-events①②">7.4. Firing Functional Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration" id="infopanel-for-dfn-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration②">(2)</a> <a href="#ref-for-dfn-service-worker-registration③">(3)</a> <a href="#ref-for-dfn-service-worker-registration④">(4)</a> <a href="#ref-for-dfn-service-worker-registration⑤">(5)</a> <a href="#ref-for-dfn-service-worker-registration⑥">(6)</a> <a href="#ref-for-dfn-service-worker-registration⑦">(7)</a> <a href="#ref-for-dfn-service-worker-registration⑧">(8)</a> <a href="#ref-for-dfn-service-worker-registration⑨">(9)</a> <a href="#ref-for-dfn-service-worker-registration①⓪">(10)</a> <a href="#ref-for-dfn-service-worker-registration①①">(11)</a> <a href="#ref-for-dfn-service-worker-registration①②">(12)</a> <a href="#ref-for-dfn-service-worker-registration①③">(13)</a> <a href="#ref-for-dfn-service-worker-registration①④">(14)</a> <a href="#ref-for-dfn-service-worker-registration①⑤">(15)</a> <a href="#ref-for-dfn-service-worker-registration①⑥">(16)</a> <a href="#ref-for-dfn-service-worker-registration①⑦">(17)</a> <a href="#ref-for-dfn-service-worker-registration①⑧">(18)</a> <a href="#ref-for-dfn-service-worker-registration①⑨">(19)</a> <a href="#ref-for-dfn-service-worker-registration②⓪">(20)</a>
@@ -11414,8 +11414,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration⑥⑤">Get Newest Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-url">
-   <b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-url" class="dfn-panel" data-for="dfn-scope-url" id="infopanel-for-dfn-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-scope-url①">(2)</a> <a href="#ref-for-dfn-scope-url②">(3)</a> <a href="#ref-for-dfn-scope-url③">(4)</a>
     <li><a href="#ref-for-dfn-scope-url④">2.2.1. Lifetime</a>
@@ -11433,8 +11433,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-url②⓪">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-installing-worker">
-   <b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-installing-worker" class="dfn-panel" data-for="dfn-installing-worker" id="infopanel-for-dfn-installing-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-installing-worker" style="display:none">Info about the 'installing worker' definition.</span><b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-installing-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-installing-worker①">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker②">(2)</a>
@@ -11450,8 +11450,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-installing-worker②③">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-waiting-worker">
-   <b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-waiting-worker" class="dfn-panel" data-for="dfn-waiting-worker" id="infopanel-for-dfn-waiting-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-waiting-worker" style="display:none">Info about the 'waiting worker' definition.</span><b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-waiting-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-waiting-worker①">2.6. User Agent Shutdown</a>
@@ -11467,8 +11467,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-waiting-worker②③">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-active-worker">
-   <b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-active-worker" class="dfn-panel" data-for="dfn-active-worker" id="infopanel-for-dfn-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-active-worker①">(2)</a> <a href="#ref-for-dfn-active-worker②">(3)</a> <a href="#ref-for-dfn-active-worker③">(4)</a> <a href="#ref-for-dfn-active-worker④">(5)</a> <a href="#ref-for-dfn-active-worker⑤">(6)</a>
     <li><a href="#ref-for-dfn-active-worker⑥">2.6. User Agent Shutdown</a>
@@ -11496,16 +11496,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-active-worker⑤②">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker⑤③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-last-update-check-time">
-   <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-last-update-check-time" class="dfn-panel" data-for="dfn-last-update-check-time" id="infopanel-for-dfn-last-update-check-time" role="dialog">
+   <span id="infopaneltitle-for-dfn-last-update-check-time" style="display:none">Info about the 'last update check time' definition.</span><b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-last-update-check-time①">(2)</a>
     <li><a href="#ref-for-dfn-last-update-check-time②">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-stale">
-   <b><a href="#service-worker-registration-stale">#service-worker-registration-stale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-stale" class="dfn-panel" data-for="service-worker-registration-stale" id="infopanel-for-service-worker-registration-stale" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-stale" style="display:none">Info about the 'stale' definition.</span><b><a href="#service-worker-registration-stale">#service-worker-registration-stale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-stale">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-service-worker-registration-stale①">Update</a> <a href="#ref-for-service-worker-registration-stale②">(2)</a>
@@ -11513,8 +11513,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-registration-stale④">Fire Functional Event</a> <a href="#ref-for-service-worker-registration-stale⑤">(2)</a> <a href="#ref-for-service-worker-registration-stale⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-update-via-cache">
-   <b><a href="#dfn-update-via-cache">#dfn-update-via-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-update-via-cache" class="dfn-panel" data-for="dfn-update-via-cache" id="infopanel-for-dfn-update-via-cache" role="dialog">
+   <span id="infopaneltitle-for-dfn-update-via-cache" style="display:none">Info about the 'update via cache mode' definition.</span><b><a href="#dfn-update-via-cache">#dfn-update-via-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-update-via-cache">3.2.7. updateViaCache</a>
     <li><a href="#ref-for-dfn-update-via-cache①">6.3.2. importScripts(urls)</a>
@@ -11525,16 +11525,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-update-via-cache⑧">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
-   <b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-task-queue" class="dfn-panel" data-for="dfn-service-worker-registration-task-queue" id="infopanel-for-dfn-service-worker-registration-task-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-task-queue" style="display:none">Info about the 'task queues' definition.</span><b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration-task-queue①">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue②">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue③">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-navigation-preload-enabled-flag">
-   <b><a href="#service-worker-registration-navigation-preload-enabled-flag">#service-worker-registration-navigation-preload-enabled-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-navigation-preload-enabled-flag" class="dfn-panel" data-for="service-worker-registration-navigation-preload-enabled-flag" id="infopanel-for-service-worker-registration-navigation-preload-enabled-flag" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-navigation-preload-enabled-flag" style="display:none">Info about the 'navigation preload enabled flag' definition.</span><b><a href="#service-worker-registration-navigation-preload-enabled-flag">#service-worker-registration-navigation-preload-enabled-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-navigation-preload-enabled-flag">3.6.1. enable()</a>
     <li><a href="#ref-for-service-worker-registration-navigation-preload-enabled-flag①">3.6.2. disable()</a>
@@ -11542,16 +11542,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-registration-navigation-preload-enabled-flag③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-navigation-preload-header-value">
-   <b><a href="#service-worker-registration-navigation-preload-header-value">#service-worker-registration-navigation-preload-header-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-navigation-preload-header-value" class="dfn-panel" data-for="service-worker-registration-navigation-preload-header-value" id="infopanel-for-service-worker-registration-navigation-preload-header-value" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-navigation-preload-header-value" style="display:none">Info about the 'navigation preload header value' definition.</span><b><a href="#service-worker-registration-navigation-preload-header-value">#service-worker-registration-navigation-preload-header-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-navigation-preload-header-value">3.6.3. setHeaderValue(value)</a>
     <li><a href="#ref-for-service-worker-registration-navigation-preload-header-value①">3.6.4. getState()</a>
     <li><a href="#ref-for-service-worker-registration-navigation-preload-header-value②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-unregistered">
-   <b><a href="#dfn-service-worker-registration-unregistered">#dfn-service-worker-registration-unregistered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-unregistered" class="dfn-panel" data-for="dfn-service-worker-registration-unregistered" id="infopanel-for-dfn-service-worker-registration-unregistered" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-unregistered" style="display:none">Info about the 'unregistered' definition.</span><b><a href="#dfn-service-worker-registration-unregistered">#dfn-service-worker-registration-unregistered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered①">4.3.4. claim()</a>
@@ -11559,8 +11559,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered③">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client">
-   <b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client" id="infopanel-for-dfn-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client①">2.1.1. Lifetime</a>
@@ -11596,8 +11596,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client⑤①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-client-discarded-flag">
-   <b><a href="#service-worker-client-discarded-flag">#service-worker-client-discarded-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-client-discarded-flag" class="dfn-panel" data-for="service-worker-client-discarded-flag" id="infopanel-for-service-worker-client-discarded-flag" role="dialog">
+   <span id="infopaneltitle-for-service-worker-client-discarded-flag" style="display:none">Info about the 'discarded flag' definition.</span><b><a href="#service-worker-client-discarded-flag">#service-worker-client-discarded-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-discarded-flag">2.3. Service Worker Client</a> <a href="#ref-for-service-worker-client-discarded-flag①">(2)</a>
     <li><a href="#ref-for-service-worker-client-discarded-flag②">4.3.1. get(id)</a>
@@ -11606,8 +11606,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-client-discarded-flag⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-client-origin">
-   <b><a href="#service-worker-client-origin">#service-worker-client-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-client-origin" class="dfn-panel" data-for="service-worker-client-origin" id="infopanel-for-service-worker-client-origin" role="dialog">
+   <span id="infopaneltitle-for-service-worker-client-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#service-worker-client-origin">#service-worker-client-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-origin">2.4.2. The worker client case</a> <a href="#ref-for-service-worker-client-origin①">(2)</a>
     <li><a href="#ref-for-service-worker-client-origin②">4.3.1. get(id)</a>
@@ -11615,8 +11615,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-client-origin④">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-window-client">
-   <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-window-client" class="dfn-panel" data-for="dfn-window-client" id="infopanel-for-dfn-window-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-window-client" style="display:none">Info about the 'window client' definition.</span><b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-window-client">2.4.1. The window client case</a> <a href="#ref-for-dfn-window-client①">(2)</a> <a href="#ref-for-dfn-window-client②">(3)</a> <a href="#ref-for-dfn-window-client③">(4)</a> <a href="#ref-for-dfn-window-client④">(5)</a> <a href="#ref-for-dfn-window-client⑤">(6)</a> <a href="#ref-for-dfn-window-client⑥">(7)</a>
     <li><a href="#ref-for-dfn-window-client⑦">2.4. Control and Use</a> <a href="#ref-for-dfn-window-client⑧">(2)</a>
@@ -11626,16 +11626,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-window-client①④">Resolve Get Client Promise</a> <a href="#ref-for-dfn-window-client①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
-   <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dedicatedworker-client" class="dfn-panel" data-for="dfn-dedicatedworker-client" id="infopanel-for-dfn-dedicatedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-dedicatedworker-client" style="display:none">Info about the 'dedicated worker client' definition.</span><b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client①">4.2.4. type</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client②">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-sharedworker-client">
-   <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-sharedworker-client" class="dfn-panel" data-for="dfn-sharedworker-client" id="infopanel-for-dfn-sharedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-sharedworker-client" style="display:none">Info about the 'shared worker client' definition.</span><b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-sharedworker-client①">4.2.4. type</a>
@@ -11643,16 +11643,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-sharedworker-client③">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-worker-client">
-   <b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-worker-client" class="dfn-panel" data-for="dfn-worker-client" id="infopanel-for-dfn-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-worker-client" style="display:none">Info about the 'worker client' definition.</span><b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-worker-client">2.4.2. The worker client case</a> <a href="#ref-for-dfn-worker-client①">(2)</a> <a href="#ref-for-dfn-worker-client②">(3)</a> <a href="#ref-for-dfn-worker-client③">(4)</a> <a href="#ref-for-dfn-worker-client④">(5)</a> <a href="#ref-for-dfn-worker-client⑤">(6)</a> <a href="#ref-for-dfn-worker-client⑥">(7)</a> <a href="#ref-for-dfn-worker-client⑦">(8)</a>
     <li><a href="#ref-for-dfn-worker-client⑧">2.4. Control and Use</a> <a href="#ref-for-dfn-worker-client⑨">(2)</a>
     <li><a href="#ref-for-dfn-worker-client①⓪">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-worker-client①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-control">
-   <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-control" class="dfn-panel" data-for="dfn-control" id="infopanel-for-dfn-control" role="dialog">
+   <span id="infopaneltitle-for-dfn-control" style="display:none">Info about the 'controlled' definition.</span><b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control">2.4. Control and Use</a>
     <li><a href="#ref-for-dfn-control①">3.2.9. unregister()</a>
@@ -11660,8 +11660,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-control③">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-use">
-   <b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-use" class="dfn-panel" data-for="dfn-use" id="infopanel-for-dfn-use" role="dialog">
+   <span id="infopaneltitle-for-dfn-use" style="display:none">Info about the 'using' definition.</span><b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use">3.5. Events</a>
     <li><a href="#ref-for-dfn-use①">4.1.4. skipWaiting()</a>
@@ -11673,24 +11673,24 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-use⑧">Try Clear Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
-   <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-fetch-task-source" class="dfn-panel" data-for="dfn-handle-fetch-task-source" id="infopanel-for-dfn-handle-fetch-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-fetch-task-source" style="display:none">Info about the 'handle fetch task source' definition.</span><b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source①">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source②">(2)</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
-   <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-functional-event-task-source" class="dfn-panel" data-for="dfn-handle-functional-event-task-source" id="infopanel-for-dfn-handle-functional-event-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-functional-event-task-source" style="display:none">Info about the 'handle functional event task source' definition.</span><b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source①">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source②">(2)</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source③">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworker">
-   <b><a href="#serviceworker">#serviceworker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworker" class="dfn-panel" data-for="serviceworker" id="infopanel-for-serviceworker" role="dialog">
+   <span id="infopaneltitle-for-serviceworker" style="display:none">Info about the 'ServiceWorker' definition.</span><b><a href="#serviceworker">#serviceworker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">2.1.1. Lifetime</a>
     <li><a href="#ref-for-serviceworker①">3.1. ServiceWorker</a> <a href="#ref-for-serviceworker②">(2)</a> <a href="#ref-for-serviceworker③">(3)</a> <a href="#ref-for-serviceworker④">(4)</a> <a href="#ref-for-serviceworker⑤">(5)</a> <a href="#ref-for-serviceworker⑥">(6)</a>
@@ -11706,22 +11706,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworker②②">4.6. ExtendableMessageEvent</a> <a href="#ref-for-serviceworker②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-serviceworkerstate">
-   <b><a href="#enumdef-serviceworkerstate">#enumdef-serviceworkerstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-serviceworkerstate" class="dfn-panel" data-for="enumdef-serviceworkerstate" id="infopanel-for-enumdef-serviceworkerstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-serviceworkerstate" style="display:none">Info about the 'ServiceWorkerState' definition.</span><b><a href="#enumdef-serviceworkerstate">#enumdef-serviceworkerstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-serviceworkerstate">3.1. ServiceWorker</a> <a href="#ref-for-enumdef-serviceworkerstate①">(2)</a>
     <li><a href="#ref-for-enumdef-serviceworkerstate②">3.1.3. state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-service-worker-object-map">
-   <b><a href="#environment-settings-object-service-worker-object-map">#environment-settings-object-service-worker-object-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-service-worker-object-map" class="dfn-panel" data-for="environment-settings-object-service-worker-object-map" id="infopanel-for-environment-settings-object-service-worker-object-map" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-service-worker-object-map" style="display:none">Info about the 'service worker object map' definition.</span><b><a href="#environment-settings-object-service-worker-object-map">#environment-settings-object-service-worker-object-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-service-worker-object-map">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-environment-settings-object-service-worker-object-map①">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-service-worker-object">
-   <b><a href="#get-the-service-worker-object">#get-the-service-worker-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-service-worker-object" class="dfn-panel" data-for="get-the-service-worker-object" id="infopanel-for-get-the-service-worker-object" role="dialog">
+   <span id="infopaneltitle-for-get-the-service-worker-object" style="display:none">Info about the 'get the service worker object' definition.</span><b><a href="#get-the-service-worker-object">#get-the-service-worker-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-service-worker-object">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-get-the-service-worker-object①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-get-the-service-worker-object②">(2)</a> <a href="#ref-for-get-the-service-worker-object③">(3)</a>
@@ -11731,15 +11731,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-the-service-worker-object⑦">Update Registration State</a> <a href="#ref-for-get-the-service-worker-object⑧">(2)</a> <a href="#ref-for-get-the-service-worker-object⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-scripturl">
-   <b><a href="#dom-serviceworker-scripturl">#dom-serviceworker-scripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-scripturl" class="dfn-panel" data-for="dom-serviceworker-scripturl" id="infopanel-for-dom-serviceworker-scripturl" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-scripturl" style="display:none">Info about the 'scriptURL' definition.</span><b><a href="#dom-serviceworker-scripturl">#dom-serviceworker-scripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-scripturl">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-scripturl①">3.1.2. scriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-state">
-   <b><a href="#dom-serviceworker-state">#dom-serviceworker-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-state" class="dfn-panel" data-for="dom-serviceworker-state" id="infopanel-for-dom-serviceworker-state" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-serviceworker-state">#dom-serviceworker-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-state">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-state①">3.1.1. Getting ServiceWorker instances</a>
@@ -11748,29 +11748,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworker-state④">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-postmessage">
-   <b><a href="#dom-serviceworker-postmessage">#dom-serviceworker-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-postmessage" class="dfn-panel" data-for="dom-serviceworker-postmessage" id="infopanel-for-dom-serviceworker-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-postmessage" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#dom-serviceworker-postmessage">#dom-serviceworker-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-postmessage">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-postmessage①">3.1.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-postmessage-message-options">
-   <b><a href="#dom-serviceworker-postmessage-message-options">#dom-serviceworker-postmessage-message-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-postmessage-message-options" class="dfn-panel" data-for="dom-serviceworker-postmessage-message-options" id="infopanel-for-dom-serviceworker-postmessage-message-options" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-postmessage-message-options" style="display:none">Info about the 'postMessage(message, options)' definition.</span><b><a href="#dom-serviceworker-postmessage-message-options">#dom-serviceworker-postmessage-message-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-postmessage-message-options">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-postmessage-message-options①">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-serviceworker-postmessage-message-options②">3.1.5. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-onstatechange">
-   <b><a href="#dom-serviceworker-onstatechange">#dom-serviceworker-onstatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-onstatechange" class="dfn-panel" data-for="dom-serviceworker-onstatechange" id="infopanel-for-dom-serviceworker-onstatechange" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-onstatechange" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#dom-serviceworker-onstatechange">#dom-serviceworker-onstatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-onstatechange">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration">
-   <b><a href="#serviceworkerregistration">#serviceworkerregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration" class="dfn-panel" data-for="serviceworkerregistration" id="infopanel-for-serviceworkerregistration" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' definition.</span><b><a href="#serviceworkerregistration">#serviceworkerregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">2.2.1. Lifetime</a>
     <li><a href="#ref-for-serviceworkerregistration①">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration②">(2)</a>
@@ -11784,15 +11784,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerregistration①⑤">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache">
-   <b><a href="#enumdef-serviceworkerupdateviacache">#enumdef-serviceworkerupdateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-serviceworkerupdateviacache" class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache" id="infopanel-for-enumdef-serviceworkerupdateviacache" role="dialog">
+   <span id="infopaneltitle-for-enumdef-serviceworkerupdateviacache" style="display:none">Info about the 'ServiceWorkerUpdateViaCache' definition.</span><b><a href="#enumdef-serviceworkerupdateviacache">#enumdef-serviceworkerupdateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-serviceworkerupdateviacache">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-enumdef-serviceworkerupdateviacache①">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-service-worker-registration">
-   <b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-service-worker-registration" class="dfn-panel" data-for="serviceworkerregistration-service-worker-registration" id="infopanel-for-serviceworkerregistration-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration">3.2.1. Getting ServiceWorkerRegistration instances</a>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration①">3.2.5. navigationPreload</a>
@@ -11804,14 +11804,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration⑦">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-service-worker-registration-object-map">
-   <b><a href="#environment-settings-object-service-worker-registration-object-map">#environment-settings-object-service-worker-registration-object-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-service-worker-registration-object-map" class="dfn-panel" data-for="environment-settings-object-service-worker-registration-object-map" id="infopanel-for-environment-settings-object-service-worker-registration-object-map" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-service-worker-registration-object-map" style="display:none">Info about the 'service worker registration object map' definition.</span><b><a href="#environment-settings-object-service-worker-registration-object-map">#environment-settings-object-service-worker-registration-object-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-service-worker-registration-object-map">3.2.1. Getting ServiceWorkerRegistration instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-service-worker-registration-object">
-   <b><a href="#get-the-service-worker-registration-object">#get-the-service-worker-registration-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-service-worker-registration-object" class="dfn-panel" data-for="get-the-service-worker-registration-object" id="infopanel-for-get-the-service-worker-registration-object" role="dialog">
+   <span id="infopaneltitle-for-get-the-service-worker-registration-object" style="display:none">Info about the 'get the service worker registration object' definition.</span><b><a href="#get-the-service-worker-registration-object">#get-the-service-worker-registration-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-service-worker-registration-object">3.4.2. ready</a>
     <li><a href="#ref-for-get-the-service-worker-registration-object①">3.4.4. getRegistration(clientURL)</a>
@@ -11821,8 +11821,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-the-service-worker-registration-object⑥">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-installing">
-   <b><a href="#dom-serviceworkerregistration-installing">#dom-serviceworkerregistration-installing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-installing" class="dfn-panel" data-for="dom-serviceworkerregistration-installing" id="infopanel-for-dom-serviceworkerregistration-installing" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-installing" style="display:none">Info about the 'installing' definition.</span><b><a href="#dom-serviceworkerregistration-installing">#dom-serviceworkerregistration-installing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-installing">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-installing①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-installing②">(2)</a>
@@ -11830,8 +11830,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-installing④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-waiting">
-   <b><a href="#dom-serviceworkerregistration-waiting">#dom-serviceworkerregistration-waiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-waiting" class="dfn-panel" data-for="dom-serviceworkerregistration-waiting" id="infopanel-for-dom-serviceworkerregistration-waiting" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-waiting" style="display:none">Info about the 'waiting' definition.</span><b><a href="#dom-serviceworkerregistration-waiting">#dom-serviceworkerregistration-waiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-waiting②">(2)</a>
@@ -11839,8 +11839,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-active">
-   <b><a href="#dom-serviceworkerregistration-active">#dom-serviceworkerregistration-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-active" class="dfn-panel" data-for="dom-serviceworkerregistration-active" id="infopanel-for-dom-serviceworkerregistration-active" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-active" style="display:none">Info about the 'active' definition.</span><b><a href="#dom-serviceworkerregistration-active">#dom-serviceworkerregistration-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-active">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-active①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-active②">(2)</a>
@@ -11848,55 +11848,55 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-active④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-navigationpreload">
-   <b><a href="#dom-serviceworkerregistration-navigationpreload">#dom-serviceworkerregistration-navigationpreload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-navigationpreload" class="dfn-panel" data-for="dom-serviceworkerregistration-navigationpreload" id="infopanel-for-dom-serviceworkerregistration-navigationpreload" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-navigationpreload" style="display:none">Info about the 'navigationPreload' definition.</span><b><a href="#dom-serviceworkerregistration-navigationpreload">#dom-serviceworkerregistration-navigationpreload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-navigationpreload">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-navigationpreload①">3.2.5. navigationPreload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-scope">
-   <b><a href="#dom-serviceworkerregistration-scope">#dom-serviceworkerregistration-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-scope" class="dfn-panel" data-for="dom-serviceworkerregistration-scope" id="infopanel-for-dom-serviceworkerregistration-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-serviceworkerregistration-scope">#dom-serviceworkerregistration-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-scope">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-scope①">3.2.6. scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-updateviacache">
-   <b><a href="#dom-serviceworkerregistration-updateviacache">#dom-serviceworkerregistration-updateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-updateviacache" class="dfn-panel" data-for="dom-serviceworkerregistration-updateviacache" id="infopanel-for-dom-serviceworkerregistration-updateviacache" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-updateviacache" style="display:none">Info about the 'updateViaCache' definition.</span><b><a href="#dom-serviceworkerregistration-updateviacache">#dom-serviceworkerregistration-updateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-updateviacache">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-updateviacache①">3.2.7. updateViaCache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-update">
-   <b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-update" class="dfn-panel" data-for="dom-serviceworkerregistration-update" id="infopanel-for-dom-serviceworkerregistration-update" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-update" style="display:none">Info about the 'update()' definition.</span><b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-update">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-update①">3.2.8. update()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-unregister">
-   <b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-unregister" class="dfn-panel" data-for="dom-serviceworkerregistration-unregister" id="infopanel-for-dom-serviceworkerregistration-unregister" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-unregister" style="display:none">Info about the 'unregister()' definition.</span><b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister①">3.2.9. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister②">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound">
-   <b><a href="#dom-serviceworkerregistration-onupdatefound">#dom-serviceworkerregistration-onupdatefound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-onupdatefound" class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound" id="infopanel-for-dom-serviceworkerregistration-onupdatefound" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-onupdatefound" style="display:none">Info about the 'onupdatefound' definition.</span><b><a href="#dom-serviceworkerregistration-onupdatefound">#dom-serviceworkerregistration-onupdatefound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-onupdatefound">3.2. ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-service-worker-attribute">
-   <b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-service-worker-attribute" class="dfn-panel" data-for="navigator-service-worker-attribute" id="infopanel-for-navigator-service-worker-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-service-worker-attribute" style="display:none">Info about the 'serviceWorker' definition.</span><b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-service-worker-attribute">3.3. navigator.serviceWorker</a> <a href="#ref-for-navigator-service-worker-attribute①">(2)</a> <a href="#ref-for-navigator-service-worker-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer">
-   <b><a href="#serviceworkercontainer">#serviceworkercontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer" class="dfn-panel" data-for="serviceworkercontainer" id="infopanel-for-serviceworkercontainer" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer" style="display:none">Info about the 'ServiceWorkerContainer' definition.</span><b><a href="#serviceworkercontainer">#serviceworkercontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer">3.3. navigator.serviceWorker</a> <a href="#ref-for-serviceworkercontainer①">(2)</a> <a href="#ref-for-serviceworkercontainer②">(3)</a>
     <li><a href="#ref-for-serviceworkercontainer③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkercontainer④">(2)</a> <a href="#ref-for-serviceworkercontainer⑤">(3)</a> <a href="#ref-for-serviceworkercontainer⑥">(4)</a> <a href="#ref-for-serviceworkercontainer⑦">(5)</a> <a href="#ref-for-serviceworkercontainer⑧">(6)</a> <a href="#ref-for-serviceworkercontainer⑨">(7)</a> <a href="#ref-for-serviceworkercontainer①⓪">(8)</a> <a href="#ref-for-serviceworkercontainer①①">(9)</a>
@@ -11907,32 +11907,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkercontainer①⑥">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-registrationoptions">
-   <b><a href="#dictdef-registrationoptions">#dictdef-registrationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-registrationoptions" class="dfn-panel" data-for="dictdef-registrationoptions" id="infopanel-for-dictdef-registrationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-registrationoptions" style="display:none">Info about the 'RegistrationOptions' definition.</span><b><a href="#dictdef-registrationoptions">#dictdef-registrationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-registrationoptions">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-scope">
-   <b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-scope" class="dfn-panel" data-for="dom-registrationoptions-scope" id="infopanel-for-dom-registrationoptions-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-scope">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-registrationoptions-scope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-type">
-   <b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-type" class="dfn-panel" data-for="dom-registrationoptions-type" id="infopanel-for-dom-registrationoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-type">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-updateviacache">
-   <b><a href="#dom-registrationoptions-updateviacache">#dom-registrationoptions-updateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-updateviacache" class="dfn-panel" data-for="dom-registrationoptions-updateviacache" id="infopanel-for-dom-registrationoptions-updateviacache" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-updateviacache" style="display:none">Info about the 'updateViaCache' definition.</span><b><a href="#dom-registrationoptions-updateviacache">#dom-registrationoptions-updateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-updateviacache">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer-service-worker-client">
-   <b><a href="#serviceworkercontainer-service-worker-client">#serviceworkercontainer-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer-service-worker-client" class="dfn-panel" data-for="serviceworkercontainer-service-worker-client" id="infopanel-for-serviceworkercontainer-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#serviceworkercontainer-service-worker-client">#serviceworkercontainer-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client">3.4.1. controller</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client①">3.4.2. ready</a>
@@ -11944,15 +11944,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client⑨">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer-ready-promise">
-   <b><a href="#serviceworkercontainer-ready-promise">#serviceworkercontainer-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer-ready-promise" class="dfn-panel" data-for="serviceworkercontainer-ready-promise" id="infopanel-for-serviceworkercontainer-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer-ready-promise" style="display:none">Info about the 'ready promise' definition.</span><b><a href="#serviceworkercontainer-ready-promise">#serviceworkercontainer-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer-ready-promise">3.4.2. ready</a> <a href="#ref-for-serviceworkercontainer-ready-promise①">(2)</a> <a href="#ref-for-serviceworkercontainer-ready-promise②">(3)</a> <a href="#ref-for-serviceworkercontainer-ready-promise③">(4)</a>
     <li><a href="#ref-for-serviceworkercontainer-ready-promise④">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-client-message-queue">
-   <b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-client-message-queue" class="dfn-panel" data-for="dfn-client-message-queue" id="infopanel-for-dfn-client-message-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-client-message-queue" style="display:none">Info about the 'client message queue' definition.</span><b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-client-message-queue">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue①">(2)</a> <a href="#ref-for-dfn-client-message-queue②">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue③">3.4.6. startMessages()</a>
@@ -11960,101 +11960,101 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-client-message-queue⑤">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-controller">
-   <b><a href="#dom-serviceworkercontainer-controller">#dom-serviceworkercontainer-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-controller" class="dfn-panel" data-for="dom-serviceworkercontainer-controller" id="infopanel-for-dom-serviceworkercontainer-controller" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-controller" style="display:none">Info about the 'controller' definition.</span><b><a href="#dom-serviceworkercontainer-controller">#dom-serviceworkercontainer-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller①">3.4.1. controller</a> <a href="#ref-for-dom-serviceworkercontainer-controller②">(2)</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller③">3.5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-ready">
-   <b><a href="#dom-serviceworkercontainer-ready">#dom-serviceworkercontainer-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-ready" class="dfn-panel" data-for="dom-serviceworkercontainer-ready" id="infopanel-for-dom-serviceworkercontainer-ready" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#dom-serviceworkercontainer-ready">#dom-serviceworkercontainer-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-ready">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-ready①">3.4.2. ready</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-register">
-   <b><a href="#dom-serviceworkercontainer-register">#dom-serviceworkercontainer-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-register" class="dfn-panel" data-for="dom-serviceworkercontainer-register" id="infopanel-for-dom-serviceworkercontainer-register" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-register" style="display:none">Info about the 'register(scriptURL, options)' definition.</span><b><a href="#dom-serviceworkercontainer-register">#dom-serviceworkercontainer-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-register">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-register①">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-serviceworkercontainer-register②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-getregistration">
-   <b><a href="#dom-serviceworkercontainer-getregistration">#dom-serviceworkercontainer-getregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-getregistration" class="dfn-panel" data-for="dom-serviceworkercontainer-getregistration" id="infopanel-for-dom-serviceworkercontainer-getregistration" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-getregistration" style="display:none">Info about the 'getRegistration(clientURL)' definition.</span><b><a href="#dom-serviceworkercontainer-getregistration">#dom-serviceworkercontainer-getregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistration">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistration①">3.4.4. getRegistration(clientURL)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-getregistrations">
-   <b><a href="#dom-serviceworkercontainer-getregistrations">#dom-serviceworkercontainer-getregistrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-getregistrations" class="dfn-panel" data-for="dom-serviceworkercontainer-getregistrations" id="infopanel-for-dom-serviceworkercontainer-getregistrations" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-getregistrations" style="display:none">Info about the 'getRegistrations()' definition.</span><b><a href="#dom-serviceworkercontainer-getregistrations">#dom-serviceworkercontainer-getregistrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistrations">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistrations①">3.4.5. getRegistrations()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-startmessages">
-   <b><a href="#dom-serviceworkercontainer-startmessages">#dom-serviceworkercontainer-startmessages</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-startmessages" class="dfn-panel" data-for="dom-serviceworkercontainer-startmessages" id="infopanel-for-dom-serviceworkercontainer-startmessages" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-startmessages" style="display:none">Info about the 'startMessages()' definition.</span><b><a href="#dom-serviceworkercontainer-startmessages">#dom-serviceworkercontainer-startmessages</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-startmessages">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-startmessages①">3.4.6. startMessages()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-oncontrollerchange">
-   <b><a href="#dom-serviceworkercontainer-oncontrollerchange">#dom-serviceworkercontainer-oncontrollerchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-oncontrollerchange" class="dfn-panel" data-for="dom-serviceworkercontainer-oncontrollerchange" id="infopanel-for-dom-serviceworkercontainer-oncontrollerchange" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-oncontrollerchange" style="display:none">Info about the 'oncontrollerchange' definition.</span><b><a href="#dom-serviceworkercontainer-oncontrollerchange">#dom-serviceworkercontainer-oncontrollerchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-oncontrollerchange">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-onmessage">
-   <b><a href="#dom-serviceworkercontainer-onmessage">#dom-serviceworkercontainer-onmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-onmessage" class="dfn-panel" data-for="dom-serviceworkercontainer-onmessage" id="infopanel-for-dom-serviceworkercontainer-onmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-onmessage" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#dom-serviceworkercontainer-onmessage">#dom-serviceworkercontainer-onmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessage">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessage①">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-onmessageerror">
-   <b><a href="#dom-serviceworkercontainer-onmessageerror">#dom-serviceworkercontainer-onmessageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-onmessageerror" class="dfn-panel" data-for="dom-serviceworkercontainer-onmessageerror" id="infopanel-for-dom-serviceworkercontainer-onmessageerror" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-onmessageerror" style="display:none">Info about the 'onmessageerror' definition.</span><b><a href="#dom-serviceworkercontainer-onmessageerror">#dom-serviceworkercontainer-onmessageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessageerror">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworker-statechange">
-   <b><a href="#eventdef-serviceworker-statechange">#eventdef-serviceworker-statechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworker-statechange" class="dfn-panel" data-for="eventdef-serviceworker-statechange" id="infopanel-for-eventdef-serviceworker-statechange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworker-statechange" style="display:none">Info about the 'statechange' definition.</span><b><a href="#eventdef-serviceworker-statechange">#eventdef-serviceworker-statechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworker-statechange">3.1.6. Event handler</a>
     <li><a href="#ref-for-eventdef-serviceworker-statechange①">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
-   <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-updatefound-event" class="dfn-panel" data-for="service-worker-registration-updatefound-event" id="infopanel-for-service-worker-registration-updatefound-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-updatefound-event" style="display:none">Info about the 'updatefound' definition.</span><b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-updatefound-event">3.2.10. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
-   <b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controllerchange-event" class="dfn-panel" data-for="service-worker-container-controllerchange-event" id="infopanel-for-service-worker-container-controllerchange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controllerchange-event" style="display:none">Info about the 'controllerchange' definition.</span><b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controllerchange-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-message-event">
-   <b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-message-event" class="dfn-panel" data-for="service-worker-container-message-event" id="infopanel-for-service-worker-container-message-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-message-event" style="display:none">Info about the 'message' definition.</span><b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-message-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-messageerror-event">
-   <b><a href="#service-worker-container-messageerror-event">#service-worker-container-messageerror-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-messageerror-event" class="dfn-panel" data-for="service-worker-container-messageerror-event" id="infopanel-for-service-worker-container-messageerror-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-messageerror-event" style="display:none">Info about the 'messageerror' definition.</span><b><a href="#service-worker-container-messageerror-event">#service-worker-container-messageerror-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-messageerror-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigationpreloadmanager">
-   <b><a href="#navigationpreloadmanager">#navigationpreloadmanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigationpreloadmanager" class="dfn-panel" data-for="navigationpreloadmanager" id="infopanel-for-navigationpreloadmanager" role="dialog">
+   <span id="infopaneltitle-for-navigationpreloadmanager" style="display:none">Info about the 'NavigationPreloadManager' definition.</span><b><a href="#navigationpreloadmanager">#navigationpreloadmanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigationpreloadmanager">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-navigationpreloadmanager①">3.2. ServiceWorkerRegistration</a>
@@ -12062,55 +12062,55 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-navigationpreloadmanager③">3.6. NavigationPreloadManager</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-navigationpreloadstate">
-   <b><a href="#dictdef-navigationpreloadstate">#dictdef-navigationpreloadstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-navigationpreloadstate" class="dfn-panel" data-for="dictdef-navigationpreloadstate" id="infopanel-for-dictdef-navigationpreloadstate" role="dialog">
+   <span id="infopaneltitle-for-dictdef-navigationpreloadstate" style="display:none">Info about the 'NavigationPreloadState' definition.</span><b><a href="#dictdef-navigationpreloadstate">#dictdef-navigationpreloadstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-navigationpreloadstate">3.6. NavigationPreloadManager</a>
     <li><a href="#ref-for-dictdef-navigationpreloadstate①">3.6.4. getState()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadstate-enabled">
-   <b><a href="#dom-navigationpreloadstate-enabled">#dom-navigationpreloadstate-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadstate-enabled" class="dfn-panel" data-for="dom-navigationpreloadstate-enabled" id="infopanel-for-dom-navigationpreloadstate-enabled" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadstate-enabled" style="display:none">Info about the 'enabled' definition.</span><b><a href="#dom-navigationpreloadstate-enabled">#dom-navigationpreloadstate-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadstate-enabled">3.6.4. getState()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadstate-headervalue">
-   <b><a href="#dom-navigationpreloadstate-headervalue">#dom-navigationpreloadstate-headervalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadstate-headervalue" class="dfn-panel" data-for="dom-navigationpreloadstate-headervalue" id="infopanel-for-dom-navigationpreloadstate-headervalue" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadstate-headervalue" style="display:none">Info about the 'headerValue' definition.</span><b><a href="#dom-navigationpreloadstate-headervalue">#dom-navigationpreloadstate-headervalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadstate-headervalue">3.6.4. getState()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadmanager-enable">
-   <b><a href="#dom-navigationpreloadmanager-enable">#dom-navigationpreloadmanager-enable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadmanager-enable" class="dfn-panel" data-for="dom-navigationpreloadmanager-enable" id="infopanel-for-dom-navigationpreloadmanager-enable" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadmanager-enable" style="display:none">Info about the 'enable()' definition.</span><b><a href="#dom-navigationpreloadmanager-enable">#dom-navigationpreloadmanager-enable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadmanager-enable">3.6. NavigationPreloadManager</a>
     <li><a href="#ref-for-dom-navigationpreloadmanager-enable①">3.6.1. enable()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadmanager-disable">
-   <b><a href="#dom-navigationpreloadmanager-disable">#dom-navigationpreloadmanager-disable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadmanager-disable" class="dfn-panel" data-for="dom-navigationpreloadmanager-disable" id="infopanel-for-dom-navigationpreloadmanager-disable" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadmanager-disable" style="display:none">Info about the 'disable()' definition.</span><b><a href="#dom-navigationpreloadmanager-disable">#dom-navigationpreloadmanager-disable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadmanager-disable">3.6. NavigationPreloadManager</a>
     <li><a href="#ref-for-dom-navigationpreloadmanager-disable①">3.6.2. disable()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadmanager-setheadervalue">
-   <b><a href="#dom-navigationpreloadmanager-setheadervalue">#dom-navigationpreloadmanager-setheadervalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadmanager-setheadervalue" class="dfn-panel" data-for="dom-navigationpreloadmanager-setheadervalue" id="infopanel-for-dom-navigationpreloadmanager-setheadervalue" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadmanager-setheadervalue" style="display:none">Info about the 'setHeaderValue(value)' definition.</span><b><a href="#dom-navigationpreloadmanager-setheadervalue">#dom-navigationpreloadmanager-setheadervalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadmanager-setheadervalue">3.6. NavigationPreloadManager</a>
     <li><a href="#ref-for-dom-navigationpreloadmanager-setheadervalue①">3.6.3. setHeaderValue(value)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationpreloadmanager-getstate">
-   <b><a href="#dom-navigationpreloadmanager-getstate">#dom-navigationpreloadmanager-getstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationpreloadmanager-getstate" class="dfn-panel" data-for="dom-navigationpreloadmanager-getstate" id="infopanel-for-dom-navigationpreloadmanager-getstate" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationpreloadmanager-getstate" style="display:none">Info about the 'getState()' definition.</span><b><a href="#dom-navigationpreloadmanager-getstate">#dom-navigationpreloadmanager-getstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationpreloadmanager-getstate">3.6. NavigationPreloadManager</a>
     <li><a href="#ref-for-dom-navigationpreloadmanager-getstate①">3.6.4. getState()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope">
-   <b><a href="#serviceworkerglobalscope">#serviceworkerglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope" class="dfn-panel" data-for="serviceworkerglobalscope" id="infopanel-for-serviceworkerglobalscope" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' definition.</span><b><a href="#serviceworkerglobalscope">#serviceworkerglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope①">3.1.5. postMessage(message, options)</a> <a href="#ref-for-serviceworkerglobalscope②">(2)</a>
@@ -12125,8 +12125,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerglobalscope①⑥">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope-service-worker">
-   <b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope-service-worker" class="dfn-panel" data-for="serviceworkerglobalscope-service-worker" id="infopanel-for-serviceworkerglobalscope-service-worker" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker①">3.2.8. update()</a>
@@ -12145,74 +12145,74 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker②④">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">
-   <b><a href="#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" id="infopanel-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" style="display:none">Info about the 'force bypass cache for import scripts flag' definition.</span><b><a href="#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients">
-   <b><a href="#dom-serviceworkerglobalscope-clients">#dom-serviceworkerglobalscope-clients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-clients" class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients" id="infopanel-for-dom-serviceworkerglobalscope-clients" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-clients" style="display:none">Info about the 'clients' definition.</span><b><a href="#dom-serviceworkerglobalscope-clients">#dom-serviceworkerglobalscope-clients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-clients">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-clients①">4.1.1. clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-registration">
-   <b><a href="#dom-serviceworkerglobalscope-registration">#dom-serviceworkerglobalscope-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-registration" class="dfn-panel" data-for="dom-serviceworkerglobalscope-registration" id="infopanel-for-dom-serviceworkerglobalscope-registration" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-registration" style="display:none">Info about the 'registration' definition.</span><b><a href="#dom-serviceworkerglobalscope-registration">#dom-serviceworkerglobalscope-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-registration">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-registration①">4.1.2. registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-serviceworker">
-   <b><a href="#dom-serviceworkerglobalscope-serviceworker">#dom-serviceworkerglobalscope-serviceworker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-serviceworker" class="dfn-panel" data-for="dom-serviceworkerglobalscope-serviceworker" id="infopanel-for-dom-serviceworkerglobalscope-serviceworker" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-serviceworker" style="display:none">Info about the 'serviceWorker' definition.</span><b><a href="#dom-serviceworkerglobalscope-serviceworker">#dom-serviceworkerglobalscope-serviceworker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-serviceworker">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-serviceworker①">4.1.3. serviceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-skipwaiting">
-   <b><a href="#dom-serviceworkerglobalscope-skipwaiting">#dom-serviceworkerglobalscope-skipwaiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-skipwaiting" class="dfn-panel" data-for="dom-serviceworkerglobalscope-skipwaiting" id="infopanel-for-dom-serviceworkerglobalscope-skipwaiting" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-skipwaiting" style="display:none">Info about the 'skipWaiting()' definition.</span><b><a href="#dom-serviceworkerglobalscope-skipwaiting">#dom-serviceworkerglobalscope-skipwaiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting①">4.1.4. skipWaiting()</a> <a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting②">(2)</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting③">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall">
-   <b><a href="#dom-serviceworkerglobalscope-oninstall">#dom-serviceworkerglobalscope-oninstall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-oninstall" class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall" id="infopanel-for-dom-serviceworkerglobalscope-oninstall" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-oninstall" style="display:none">Info about the 'oninstall' definition.</span><b><a href="#dom-serviceworkerglobalscope-oninstall">#dom-serviceworkerglobalscope-oninstall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-oninstall">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onactivate">
-   <b><a href="#dom-serviceworkerglobalscope-onactivate">#dom-serviceworkerglobalscope-onactivate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onactivate" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onactivate" id="infopanel-for-dom-serviceworkerglobalscope-onactivate" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onactivate" style="display:none">Info about the 'onactivate' definition.</span><b><a href="#dom-serviceworkerglobalscope-onactivate">#dom-serviceworkerglobalscope-onactivate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onactivate">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onfetch">
-   <b><a href="#dom-serviceworkerglobalscope-onfetch">#dom-serviceworkerglobalscope-onfetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onfetch" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onfetch" id="infopanel-for-dom-serviceworkerglobalscope-onfetch" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onfetch" style="display:none">Info about the 'onfetch' definition.</span><b><a href="#dom-serviceworkerglobalscope-onfetch">#dom-serviceworkerglobalscope-onfetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onfetch">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessage">
-   <b><a href="#dom-serviceworkerglobalscope-onmessage">#dom-serviceworkerglobalscope-onmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onmessage" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessage" id="infopanel-for-dom-serviceworkerglobalscope-onmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onmessage" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#dom-serviceworkerglobalscope-onmessage">#dom-serviceworkerglobalscope-onmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onmessage">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessageerror">
-   <b><a href="#dom-serviceworkerglobalscope-onmessageerror">#dom-serviceworkerglobalscope-onmessageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onmessageerror" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessageerror" id="infopanel-for-dom-serviceworkerglobalscope-onmessageerror" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onmessageerror" style="display:none">Info about the 'onmessageerror' definition.</span><b><a href="#dom-serviceworkerglobalscope-onmessageerror">#dom-serviceworkerglobalscope-onmessageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onmessageerror">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client">
-   <b><a href="#client">#client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client" class="dfn-panel" data-for="client" id="infopanel-for-client" role="dialog">
+   <span id="infopaneltitle-for-client" style="display:none">Info about the 'Client' definition.</span><b><a href="#client">#client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-client①">4.2. Client</a> <a href="#ref-for-client②">(2)</a> <a href="#ref-for-client③">(3)</a> <a href="#ref-for-client④">(4)</a>
@@ -12223,8 +12223,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-client①①">Create Client</a> <a href="#ref-for-client①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windowclient">
-   <b><a href="#windowclient">#windowclient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windowclient" class="dfn-panel" data-for="windowclient" id="infopanel-for-windowclient" role="dialog">
+   <span id="infopaneltitle-for-windowclient" style="display:none">Info about the 'WindowClient' definition.</span><b><a href="#windowclient">#windowclient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowclient">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-windowclient①">4.2. Client</a> <a href="#ref-for-windowclient②">(2)</a> <a href="#ref-for-windowclient③">(3)</a> <a href="#ref-for-windowclient④">(4)</a> <a href="#ref-for-windowclient⑤">(5)</a> <a href="#ref-for-windowclient⑥">(6)</a>
@@ -12233,14 +12233,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-windowclient①⓪">Create Window Client</a> <a href="#ref-for-windowclient①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-frametype">
-   <b><a href="#enumdef-frametype">#enumdef-frametype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-frametype" class="dfn-panel" data-for="enumdef-frametype" id="infopanel-for-enumdef-frametype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-frametype" style="display:none">Info about the 'FrameType' definition.</span><b><a href="#enumdef-frametype">#enumdef-frametype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-frametype">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-service-worker-client">
-   <b><a href="#dfn-service-worker-client-service-worker-client">#dfn-service-worker-client-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client-service-worker-client" id="infopanel-for-dfn-service-worker-client-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client-service-worker-client">#dfn-service-worker-client-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client">4.2. Client</a>
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client①">4.2.1. url</a>
@@ -12254,80 +12254,80 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client①④">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-frame-type">
-   <b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="dfn-service-worker-client-frame-type" id="infopanel-for-dfn-service-worker-client-frame-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' definition.</span><b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">4.2.2. frameType</a>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-browsing-context">
-   <b><a href="#dfn-service-worker-client-browsing-context">#dfn-service-worker-client-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-browsing-context" class="dfn-panel" data-for="dfn-service-worker-client-browsing-context" id="infopanel-for-dfn-service-worker-client-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-browsing-context" style="display:none">Info about the 'browsing context' definition.</span><b><a href="#dfn-service-worker-client-browsing-context">#dfn-service-worker-client-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context">4.2.10. focus()</a> <a href="#ref-for-dfn-service-worker-client-browsing-context①">(2)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context②">(3)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context③">(4)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context④">(5)</a>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context⑤">4.2.11. navigate(url)</a>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context⑥">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
-   <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-visibilitystate" class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate" id="infopanel-for-dfn-service-worker-client-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-visibilitystate" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">4.2.7. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
-   <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-focusstate" class="dfn-panel" data-for="dfn-service-worker-client-focusstate" id="infopanel-for-dfn-service-worker-client-focusstate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-focusstate" style="display:none">Info about the 'focus state' definition.</span><b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.8. focused</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate①">4.2.10. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate②">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windowclient-ancestor-origins-array">
-   <b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windowclient-ancestor-origins-array" class="dfn-panel" data-for="windowclient-ancestor-origins-array" id="infopanel-for-windowclient-ancestor-origins-array" role="dialog">
+   <span id="infopaneltitle-for-windowclient-ancestor-origins-array" style="display:none">Info about the 'ancestor origins array' definition.</span><b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowclient-ancestor-origins-array">4.2.9. ancestorOrigins</a>
     <li><a href="#ref-for-windowclient-ancestor-origins-array①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-url">
-   <b><a href="#dom-client-url">#dom-client-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-url" class="dfn-panel" data-for="dom-client-url" id="infopanel-for-dom-client-url" role="dialog">
+   <span id="infopaneltitle-for-dom-client-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-client-url">#dom-client-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-url">4.2. Client</a>
     <li><a href="#ref-for-dom-client-url①">4.2.1. url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-frametype">
-   <b><a href="#dom-client-frametype">#dom-client-frametype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-frametype" class="dfn-panel" data-for="dom-client-frametype" id="infopanel-for-dom-client-frametype" role="dialog">
+   <span id="infopaneltitle-for-dom-client-frametype" style="display:none">Info about the 'frameType' definition.</span><b><a href="#dom-client-frametype">#dom-client-frametype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-frametype">4.2. Client</a>
     <li><a href="#ref-for-dom-client-frametype①">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-id">
-   <b><a href="#dom-client-id">#dom-client-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-id" class="dfn-panel" data-for="dom-client-id" id="infopanel-for-dom-client-id" role="dialog">
+   <span id="infopaneltitle-for-dom-client-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-client-id">#dom-client-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-id">4.2. Client</a>
     <li><a href="#ref-for-dom-client-id①">4.2.3. id</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-type">
-   <b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-type" class="dfn-panel" data-for="dom-client-type" id="infopanel-for-dom-client-type" role="dialog">
+   <span id="infopaneltitle-for-dom-client-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-type">4.2. Client</a>
     <li><a href="#ref-for-dom-client-type①">4.2.4. type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-postmessage">
-   <b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-postmessage" class="dfn-panel" data-for="dom-client-postmessage" id="infopanel-for-dom-client-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-client-postmessage" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-postmessage">4.2. Client</a>
     <li><a href="#ref-for-dom-client-postmessage①">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-postmessage-message-options">
-   <b><a href="#dom-client-postmessage-message-options">#dom-client-postmessage-message-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-postmessage-message-options" class="dfn-panel" data-for="dom-client-postmessage-message-options" id="infopanel-for-dom-client-postmessage-message-options" role="dialog">
+   <span id="infopaneltitle-for-dom-client-postmessage-message-options" style="display:none">Info about the 'postMessage(message, options)' definition.</span><b><a href="#dom-client-postmessage-message-options">#dom-client-postmessage-message-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-postmessage-message-options">3.5. Events</a> <a href="#ref-for-dom-client-postmessage-message-options①">(2)</a>
     <li><a href="#ref-for-dom-client-postmessage-message-options②">4.2. Client</a>
@@ -12335,131 +12335,131 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-client-postmessage-message-options④">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-visibilitystate">
-   <b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-visibilitystate" class="dfn-panel" data-for="dom-windowclient-visibilitystate" id="infopanel-for-dom-windowclient-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-visibilitystate" style="display:none">Info about the 'visibilityState' definition.</span><b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-visibilitystate①">4.2.7. visibilityState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-focused">
-   <b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-focused" class="dfn-panel" data-for="dom-windowclient-focused" id="infopanel-for-dom-windowclient-focused" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-focused" style="display:none">Info about the 'focused' definition.</span><b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focused">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-focused①">4.2.8. focused</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-ancestororigins">
-   <b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-ancestororigins" class="dfn-panel" data-for="dom-windowclient-ancestororigins" id="infopanel-for-dom-windowclient-ancestororigins" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-ancestororigins" style="display:none">Info about the 'ancestorOrigins' definition.</span><b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-ancestororigins">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-ancestororigins①">4.2.9. ancestorOrigins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-focus">
-   <b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-focus" class="dfn-panel" data-for="dom-windowclient-focus" id="infopanel-for-dom-windowclient-focus" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-focus" style="display:none">Info about the 'focus()' definition.</span><b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focus">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-focus①">4.2.10. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-navigate">
-   <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-navigate" class="dfn-panel" data-for="dom-windowclient-navigate" id="infopanel-for-dom-windowclient-navigate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-navigate" style="display:none">Info about the 'navigate(url)' definition.</span><b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-navigate①">4.2.11. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients">
-   <b><a href="#clients">#clients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients" class="dfn-panel" data-for="clients" id="infopanel-for-clients" role="dialog">
+   <span id="infopaneltitle-for-clients" style="display:none">Info about the 'Clients' definition.</span><b><a href="#clients">#clients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-clients①">4.1.1. clients</a>
     <li><a href="#ref-for-clients②">4.3. Clients</a> <a href="#ref-for-clients③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clientqueryoptions">
-   <b><a href="#dictdef-clientqueryoptions">#dictdef-clientqueryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clientqueryoptions" class="dfn-panel" data-for="dictdef-clientqueryoptions" id="infopanel-for-dictdef-clientqueryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clientqueryoptions" style="display:none">Info about the 'ClientQueryOptions' definition.</span><b><a href="#dictdef-clientqueryoptions">#dictdef-clientqueryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clientqueryoptions">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled">
-   <b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled" id="infopanel-for-dom-clientqueryoptions-includeuncontrolled" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" style="display:none">Info about the 'includeUncontrolled' definition.</span><b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-includeuncontrolled">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-type">
-   <b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-type" class="dfn-panel" data-for="dom-clientqueryoptions-type" id="infopanel-for-dom-clientqueryoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-type">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clientqueryoptions-type①">(2)</a> <a href="#ref-for-dom-clientqueryoptions-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-clienttype">
-   <b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-clienttype" class="dfn-panel" data-for="enumdef-clienttype" id="infopanel-for-enumdef-clienttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-clienttype" style="display:none">Info about the 'ClientType' definition.</span><b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-clienttype">4.2. Client</a>
     <li><a href="#ref-for-enumdef-clienttype①">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-window">
-   <b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-window" class="dfn-panel" data-for="dom-clienttype-window" id="infopanel-for-dom-clienttype-window" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-window" style="display:none">Info about the '"window"' definition.</span><b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-window">4.2.4. type</a> <a href="#ref-for-dom-clienttype-window①">(2)</a>
     <li><a href="#ref-for-dom-clienttype-window②">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-worker">
-   <b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-worker" class="dfn-panel" data-for="dom-clienttype-worker" id="infopanel-for-dom-clienttype-worker" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-worker" style="display:none">Info about the '"worker"' definition.</span><b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-worker">4.2.4. type</a>
     <li><a href="#ref-for-dom-clienttype-worker①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-sharedworker">
-   <b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-sharedworker" class="dfn-panel" data-for="dom-clienttype-sharedworker" id="infopanel-for-dom-clienttype-sharedworker" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-sharedworker" style="display:none">Info about the '"sharedworker"' definition.</span><b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-sharedworker">4.2.4. type</a>
     <li><a href="#ref-for-dom-clienttype-sharedworker①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-all">
-   <b><a href="#dom-clienttype-all">#dom-clienttype-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-all" class="dfn-panel" data-for="dom-clienttype-all" id="infopanel-for-dom-clienttype-all" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-all" style="display:none">Info about the '"all"' definition.</span><b><a href="#dom-clienttype-all">#dom-clienttype-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-all">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clienttype-all①">(2)</a> <a href="#ref-for-dom-clienttype-all②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-get">
-   <b><a href="#dom-clients-get">#dom-clients-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-get" class="dfn-panel" data-for="dom-clients-get" id="infopanel-for-dom-clients-get" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-get" style="display:none">Info about the 'get(id)' definition.</span><b><a href="#dom-clients-get">#dom-clients-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-get">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-get①">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-matchall">
-   <b><a href="#dom-clients-matchall">#dom-clients-matchall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-matchall" class="dfn-panel" data-for="dom-clients-matchall" id="infopanel-for-dom-clients-matchall" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-matchall" style="display:none">Info about the 'matchAll(options)' definition.</span><b><a href="#dom-clients-matchall">#dom-clients-matchall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-matchall">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-matchall①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-openwindow">
-   <b><a href="#dom-clients-openwindow">#dom-clients-openwindow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-openwindow" class="dfn-panel" data-for="dom-clients-openwindow" id="infopanel-for-dom-clients-openwindow" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-openwindow" style="display:none">Info about the 'openWindow(url)' definition.</span><b><a href="#dom-clients-openwindow">#dom-clients-openwindow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-openwindow">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-openwindow①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-claim">
-   <b><a href="#dom-clients-claim">#dom-clients-claim</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-claim" class="dfn-panel" data-for="dom-clients-claim" id="infopanel-for-dom-clients-claim" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-claim" style="display:none">Info about the 'claim()' definition.</span><b><a href="#dom-clients-claim">#dom-clients-claim</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-claim">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-claim①">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent">
-   <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent" class="dfn-panel" data-for="extendableevent" id="infopanel-for-extendableevent" role="dialog">
+   <span id="infopaneltitle-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' definition.</span><b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">2.1. Service Worker</a>
     <li><a href="#ref-for-extendableevent①">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent②">(2)</a> <a href="#ref-for-extendableevent③">(3)</a> <a href="#ref-for-extendableevent④">(4)</a> <a href="#ref-for-extendableevent⑤">(5)</a> <a href="#ref-for-extendableevent⑥">(6)</a> <a href="#ref-for-extendableevent⑦">(7)</a> <a href="#ref-for-extendableevent⑧">(8)</a>
@@ -12472,37 +12472,37 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendableevent①⑧">Fire Functional Event</a> <a href="#ref-for-extendableevent①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
-   <b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendableeventinit" class="dfn-panel" data-for="dictdef-extendableeventinit" id="infopanel-for-dictdef-extendableeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' definition.</span><b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit①">4.5. FetchEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit②">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-extend-lifetime-promises">
-   <b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-extend-lifetime-promises" class="dfn-panel" data-for="extendableevent-extend-lifetime-promises" id="infopanel-for-extendableevent-extend-lifetime-promises" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' definition.</span><b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises①">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises②">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises③">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises④">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises⑤">(6)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises⑥">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises⑦">(2)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises⑧">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
-   <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-pending-promises-count" class="dfn-panel" data-for="extendableevent-pending-promises-count" id="infopanel-for-extendableevent-pending-promises-count" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-pending-promises-count" style="display:none">Info about the 'pending promises count' definition.</span><b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-pending-promises-count">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-pending-promises-count①">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count②">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count③">(4)</a> <a href="#ref-for-extendableevent-pending-promises-count④">(5)</a> <a href="#ref-for-extendableevent-pending-promises-count⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-timed-out-flag">
-   <b><a href="#extendableevent-timed-out-flag">#extendableevent-timed-out-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-timed-out-flag" class="dfn-panel" data-for="extendableevent-timed-out-flag" id="infopanel-for-extendableevent-timed-out-flag" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-timed-out-flag" style="display:none">Info about the 'timed out flag' definition.</span><b><a href="#extendableevent-timed-out-flag">#extendableevent-timed-out-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-timed-out-flag">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendableevent-timed-out-flag①">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-active">
-   <b><a href="#extendableevent-active">#extendableevent-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-active" class="dfn-panel" data-for="extendableevent-active" id="infopanel-for-extendableevent-active" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-active" style="display:none">Info about the 'active' definition.</span><b><a href="#extendableevent-active">#extendableevent-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-active">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendableevent-active①">Install</a>
@@ -12511,8 +12511,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendableevent-active⑤">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
-   <b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendableevent-waituntil" class="dfn-panel" data-for="dom-extendableevent-waituntil" id="infopanel-for-dom-extendableevent-waituntil" role="dialog">
+   <span id="infopaneltitle-for-dom-extendableevent-waituntil" style="display:none">Info about the 'waitUntil(f)' definition.</span><b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendableevent-waituntil">4.4. ExtendableEvent</a> <a href="#ref-for-dom-extendableevent-waituntil③">(2)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil①">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil②">(2)</a>
@@ -12520,166 +12520,166 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-extendableevent-waituntil⑤">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-add-lifetime-promise">
-   <b><a href="#extendableevent-add-lifetime-promise">#extendableevent-add-lifetime-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-add-lifetime-promise" class="dfn-panel" data-for="extendableevent-add-lifetime-promise" id="infopanel-for-extendableevent-add-lifetime-promise" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-add-lifetime-promise" style="display:none">Info about the 'add lifetime promise' definition.</span><b><a href="#extendableevent-add-lifetime-promise">#extendableevent-add-lifetime-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-add-lifetime-promise">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-add-lifetime-promise①">4.5.7. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent">
-   <b><a href="#fetchevent">#fetchevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent" class="dfn-panel" data-for="fetchevent" id="infopanel-for-fetchevent" role="dialog">
+   <span id="infopaneltitle-for-fetchevent" style="display:none">Info about the 'FetchEvent' definition.</span><b><a href="#fetchevent">#fetchevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent">4.5. FetchEvent</a> <a href="#ref-for-fetchevent①">(2)</a> <a href="#ref-for-fetchevent②">(3)</a>
     <li><a href="#ref-for-fetchevent③">4.7. Events</a>
     <li><a href="#ref-for-fetchevent④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fetcheventinit">
-   <b><a href="#dictdef-fetcheventinit">#dictdef-fetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fetcheventinit" class="dfn-panel" data-for="dictdef-fetcheventinit" id="infopanel-for-dictdef-fetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fetcheventinit" style="display:none">Info about the 'FetchEventInit' definition.</span><b><a href="#dictdef-fetcheventinit">#dictdef-fetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fetcheventinit">4.5. FetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-potential-response">
-   <b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-potential-response" class="dfn-panel" data-for="fetchevent-potential-response" id="infopanel-for-fetchevent-potential-response" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-potential-response" style="display:none">Info about the 'potential response' definition.</span><b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-potential-response">4.5.7. event.respondWith(r)</a>
     <li><a href="#ref-for-fetchevent-potential-response①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-wait-to-respond-flag">
-   <b><a href="#fetchevent-wait-to-respond-flag">#fetchevent-wait-to-respond-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-wait-to-respond-flag" class="dfn-panel" data-for="fetchevent-wait-to-respond-flag" id="infopanel-for-fetchevent-wait-to-respond-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-wait-to-respond-flag" style="display:none">Info about the 'wait to respond flag' definition.</span><b><a href="#fetchevent-wait-to-respond-flag">#fetchevent-wait-to-respond-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-wait-to-respond-flag">4.5.7. event.respondWith(r)</a> <a href="#ref-for-fetchevent-wait-to-respond-flag①">(2)</a> <a href="#ref-for-fetchevent-wait-to-respond-flag②">(3)</a>
     <li><a href="#ref-for-fetchevent-wait-to-respond-flag③">Handle Fetch</a> <a href="#ref-for-fetchevent-wait-to-respond-flag④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-respond-with-entered-flag">
-   <b><a href="#fetchevent-respond-with-entered-flag">#fetchevent-respond-with-entered-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-respond-with-entered-flag" class="dfn-panel" data-for="fetchevent-respond-with-entered-flag" id="infopanel-for-fetchevent-respond-with-entered-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-respond-with-entered-flag" style="display:none">Info about the 'respond-with entered flag' definition.</span><b><a href="#fetchevent-respond-with-entered-flag">#fetchevent-respond-with-entered-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-respond-with-entered-flag">4.5.7. event.respondWith(r)</a> <a href="#ref-for-fetchevent-respond-with-entered-flag①">(2)</a>
     <li><a href="#ref-for-fetchevent-respond-with-entered-flag②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-respond-with-error-flag">
-   <b><a href="#fetchevent-respond-with-error-flag">#fetchevent-respond-with-error-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-respond-with-error-flag" class="dfn-panel" data-for="fetchevent-respond-with-error-flag" id="infopanel-for-fetchevent-respond-with-error-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-respond-with-error-flag" style="display:none">Info about the 'respond-with error flag' definition.</span><b><a href="#fetchevent-respond-with-error-flag">#fetchevent-respond-with-error-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-respond-with-error-flag">4.5.7. event.respondWith(r)</a> <a href="#ref-for-fetchevent-respond-with-error-flag①">(2)</a> <a href="#ref-for-fetchevent-respond-with-error-flag②">(3)</a>
     <li><a href="#ref-for-fetchevent-respond-with-error-flag③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-request">
-   <b><a href="#dom-fetchevent-request">#dom-fetchevent-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-request" class="dfn-panel" data-for="dom-fetchevent-request" id="infopanel-for-dom-fetchevent-request" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-fetchevent-request">#dom-fetchevent-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-request">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-request①">4.5.1. event.request</a>
     <li><a href="#ref-for-dom-fetchevent-request②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-preloadresponse">
-   <b><a href="#dom-fetchevent-preloadresponse">#dom-fetchevent-preloadresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-preloadresponse" class="dfn-panel" data-for="dom-fetchevent-preloadresponse" id="infopanel-for-dom-fetchevent-preloadresponse" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-preloadresponse" style="display:none">Info about the 'preloadResponse' definition.</span><b><a href="#dom-fetchevent-preloadresponse">#dom-fetchevent-preloadresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-preloadresponse">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-preloadresponse①">4.5.2. event.preloadResponse</a>
     <li><a href="#ref-for-dom-fetchevent-preloadresponse②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-clientid">
-   <b><a href="#dom-fetchevent-clientid">#dom-fetchevent-clientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-clientid" class="dfn-panel" data-for="dom-fetchevent-clientid" id="infopanel-for-dom-fetchevent-clientid" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-clientid" style="display:none">Info about the 'clientId' definition.</span><b><a href="#dom-fetchevent-clientid">#dom-fetchevent-clientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-clientid">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-clientid①">4.5.3. event.clientId</a>
     <li><a href="#ref-for-dom-fetchevent-clientid②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-resultingclientid">
-   <b><a href="#dom-fetchevent-resultingclientid">#dom-fetchevent-resultingclientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-resultingclientid" class="dfn-panel" data-for="dom-fetchevent-resultingclientid" id="infopanel-for-dom-fetchevent-resultingclientid" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-resultingclientid" style="display:none">Info about the 'resultingClientId' definition.</span><b><a href="#dom-fetchevent-resultingclientid">#dom-fetchevent-resultingclientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-resultingclientid">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-resultingclientid①">4.5.4. event.resultingClientId</a>
     <li><a href="#ref-for-dom-fetchevent-resultingclientid②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-replacesclientid">
-   <b><a href="#dom-fetchevent-replacesclientid">#dom-fetchevent-replacesclientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-replacesclientid" class="dfn-panel" data-for="dom-fetchevent-replacesclientid" id="infopanel-for-dom-fetchevent-replacesclientid" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-replacesclientid" style="display:none">Info about the 'replacesClientId' definition.</span><b><a href="#dom-fetchevent-replacesclientid">#dom-fetchevent-replacesclientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-replacesclientid">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-replacesclientid①">4.5.5. event.replacesClientId</a>
     <li><a href="#ref-for-dom-fetchevent-replacesclientid②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-handled">
-   <b><a href="#dom-fetchevent-handled">#dom-fetchevent-handled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-handled" class="dfn-panel" data-for="dom-fetchevent-handled" id="infopanel-for-dom-fetchevent-handled" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-handled" style="display:none">Info about the 'handled' definition.</span><b><a href="#dom-fetchevent-handled">#dom-fetchevent-handled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-handled">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-handled①">4.5.6. event.handled</a>
     <li><a href="#ref-for-dom-fetchevent-handled②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-respondwith">
-   <b><a href="#dom-fetchevent-respondwith">#dom-fetchevent-respondwith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-respondwith" class="dfn-panel" data-for="dom-fetchevent-respondwith" id="infopanel-for-dom-fetchevent-respondwith" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-respondwith" style="display:none">Info about the 'respondWith(r)' definition.</span><b><a href="#dom-fetchevent-respondwith">#dom-fetchevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-respondwith">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-respondwith①">4.5.7. event.respondWith(r)</a> <a href="#ref-for-dom-fetchevent-respondwith②">(2)</a>
     <li><a href="#ref-for-dom-fetchevent-respondwith③">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessageevent">
-   <b><a href="#extendablemessageevent">#extendablemessageevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessageevent" class="dfn-panel" data-for="extendablemessageevent" id="infopanel-for-extendablemessageevent" role="dialog">
+   <span id="infopaneltitle-for-extendablemessageevent" style="display:none">Info about the 'ExtendableMessageEvent' definition.</span><b><a href="#extendablemessageevent">#extendablemessageevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessageevent">3.1.5. postMessage(message, options)</a> <a href="#ref-for-extendablemessageevent①">(2)</a>
     <li><a href="#ref-for-extendablemessageevent②">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendablemessageevent③">(2)</a>
     <li><a href="#ref-for-extendablemessageevent④">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendablemessageeventinit">
-   <b><a href="#dictdef-extendablemessageeventinit">#dictdef-extendablemessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendablemessageeventinit" class="dfn-panel" data-for="dictdef-extendablemessageeventinit" id="infopanel-for-dictdef-extendablemessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendablemessageeventinit" style="display:none">Info about the 'ExtendableMessageEventInit' definition.</span><b><a href="#dictdef-extendablemessageeventinit">#dictdef-extendablemessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendablemessageeventinit">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-data">
-   <b><a href="#dom-extendablemessageevent-data">#dom-extendablemessageevent-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-data" class="dfn-panel" data-for="dom-extendablemessageevent-data" id="infopanel-for-dom-extendablemessageevent-data" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-extendablemessageevent-data">#dom-extendablemessageevent-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-data">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-data①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-data②">4.6.1. event.data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-origin">
-   <b><a href="#dom-extendablemessageevent-origin">#dom-extendablemessageevent-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-origin" class="dfn-panel" data-for="dom-extendablemessageevent-origin" id="infopanel-for-dom-extendablemessageevent-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-extendablemessageevent-origin">#dom-extendablemessageevent-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-origin">3.1.5. postMessage(message, options)</a> <a href="#ref-for-dom-extendablemessageevent-origin①">(2)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-origin②">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-origin③">4.6.2. event.origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-lasteventid">
-   <b><a href="#dom-extendablemessageevent-lasteventid">#dom-extendablemessageevent-lasteventid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-lasteventid" class="dfn-panel" data-for="dom-extendablemessageevent-lasteventid" id="infopanel-for-dom-extendablemessageevent-lasteventid" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-lasteventid" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#dom-extendablemessageevent-lasteventid">#dom-extendablemessageevent-lasteventid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-lasteventid">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-lasteventid①">4.6.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-source">
-   <b><a href="#dom-extendablemessageevent-source">#dom-extendablemessageevent-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-source" class="dfn-panel" data-for="dom-extendablemessageevent-source" id="infopanel-for-dom-extendablemessageevent-source" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-extendablemessageevent-source">#dom-extendablemessageevent-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-source">3.1.5. postMessage(message, options)</a> <a href="#ref-for-dom-extendablemessageevent-source①">(2)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-source②">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-source③">4.6.4. event.source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-ports">
-   <b><a href="#dom-extendablemessageevent-ports">#dom-extendablemessageevent-ports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-ports" class="dfn-panel" data-for="dom-extendablemessageevent-ports" id="infopanel-for-dom-extendablemessageevent-ports" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-ports" style="display:none">Info about the 'ports' definition.</span><b><a href="#dom-extendablemessageevent-ports">#dom-extendablemessageevent-ports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-ports">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-ports①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-ports②">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-install-event">
-   <b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-install-event" class="dfn-panel" data-for="service-worker-global-scope-install-event" id="infopanel-for-service-worker-global-scope-install-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-install-event" style="display:none">Info about the 'install' definition.</span><b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-install-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-install-event①">4.1.5. Event handlers</a>
@@ -12687,8 +12687,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-install-event⑤">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-activate-event">
-   <b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-activate-event" class="dfn-panel" data-for="service-worker-global-scope-activate-event" id="infopanel-for-service-worker-global-scope-activate-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-activate-event" style="display:none">Info about the 'activate' definition.</span><b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-activate-event①">4.1.5. Event handlers</a>
@@ -12696,8 +12696,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-activate-event⑤">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-fetch-event">
-   <b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="service-worker-global-scope-fetch-event" id="infopanel-for-service-worker-global-scope-fetch-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' definition.</span><b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event①">2.5. Task Sources</a>
@@ -12707,8 +12707,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-fetch-event⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-message">
-   <b><a href="#eventdef-serviceworkerglobalscope-message">#eventdef-serviceworkerglobalscope-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworkerglobalscope-message" class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-message" id="infopanel-for-eventdef-serviceworkerglobalscope-message" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworkerglobalscope-message" style="display:none">Info about the 'message' definition.</span><b><a href="#eventdef-serviceworkerglobalscope-message">#eventdef-serviceworkerglobalscope-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message">2.1.2. Events</a>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message①">3.1.5. postMessage(message, options)</a>
@@ -12716,8 +12716,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message③">4.6. ExtendableMessageEvent</a> <a href="#ref-for-eventdef-serviceworkerglobalscope-message④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-messageerror">
-   <b><a href="#eventdef-serviceworkerglobalscope-messageerror">#eventdef-serviceworkerglobalscope-messageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworkerglobalscope-messageerror" class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-messageerror" id="infopanel-for-eventdef-serviceworkerglobalscope-messageerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworkerglobalscope-messageerror" style="display:none">Info about the 'messageerror' definition.</span><b><a href="#eventdef-serviceworkerglobalscope-messageerror">#eventdef-serviceworkerglobalscope-messageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror">2.1.2. Events</a>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror①">3.1.5. postMessage(message, options)</a>
@@ -12725,8 +12725,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror③">4.2.6. postMessage(message, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-request-response-list">
-   <b><a href="#dfn-request-response-list">#dfn-request-response-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-request-response-list" class="dfn-panel" data-for="dfn-request-response-list" id="infopanel-for-dfn-request-response-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-request-response-list" style="display:none">Info about the 'request response list' definition.</span><b><a href="#dfn-request-response-list">#dfn-request-response-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-response-list">5.1. Constructs</a> <a href="#ref-for-dfn-request-response-list①">(2)</a>
     <li><a href="#ref-for-dfn-request-response-list②">5.4. Cache</a> <a href="#ref-for-dfn-request-response-list③">(2)</a>
@@ -12736,8 +12736,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-request-response-list⑧">Batch Cache Operations</a> <a href="#ref-for-dfn-request-response-list⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-relevant-request-response-list">
-   <b><a href="#dfn-relevant-request-response-list">#dfn-relevant-request-response-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-relevant-request-response-list" class="dfn-panel" data-for="dfn-relevant-request-response-list" id="infopanel-for-dfn-relevant-request-response-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-relevant-request-response-list" style="display:none">Info about the 'relevant request response list' definition.</span><b><a href="#dfn-relevant-request-response-list">#dfn-relevant-request-response-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-relevant-request-response-list">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-dfn-relevant-request-response-list①">5.4.7. keys(request, options)</a>
@@ -12745,8 +12745,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-relevant-request-response-list③">Batch Cache Operations</a> <a href="#ref-for-dfn-relevant-request-response-list④">(2)</a> <a href="#ref-for-dfn-relevant-request-response-list⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-name-to-cache-map">
-   <b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-name-to-cache-map" class="dfn-panel" data-for="dfn-name-to-cache-map" id="infopanel-for-dfn-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-name-to-cache-map" style="display:none">Info about the 'name to cache map' definition.</span><b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name-to-cache-map">5.1. Constructs</a>
     <li><a href="#ref-for-dfn-name-to-cache-map①">5.5. CacheStorage</a> <a href="#ref-for-dfn-name-to-cache-map②">(2)</a>
@@ -12754,8 +12754,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-name-to-cache-map④">6.8. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-relevant-name-to-cache-map">
-   <b><a href="#dfn-relevant-name-to-cache-map">#dfn-relevant-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-relevant-name-to-cache-map" class="dfn-panel" data-for="dfn-relevant-name-to-cache-map" id="infopanel-for-dfn-relevant-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-relevant-name-to-cache-map" style="display:none">Info about the 'relevant name to cache map' definition.</span><b><a href="#dfn-relevant-name-to-cache-map">#dfn-relevant-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map">5.5.1. match(request, options)</a> <a href="#ref-for-dfn-relevant-name-to-cache-map①">(2)</a>
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map②">5.5.2. has(cacheName)</a>
@@ -12764,15 +12764,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map⑥">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-caches-attribute">
-   <b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-caches-attribute" class="dfn-panel" data-for="global-caches-attribute" id="infopanel-for-global-caches-attribute" role="dialog">
+   <span id="infopaneltitle-for-global-caches-attribute" style="display:none">Info about the 'caches' definition.</span><b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-caches-attribute">5.3. self.caches</a> <a href="#ref-for-global-caches-attribute①">(2)</a>
     <li><a href="#ref-for-global-caches-attribute②">5.3.1. caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache">
-   <b><a href="#cache">#cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache" class="dfn-panel" data-for="cache" id="infopanel-for-cache" role="dialog">
+   <span id="infopaneltitle-for-cache" style="display:none">Info about the 'Cache' definition.</span><b><a href="#cache">#cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">4.7. Events</a>
     <li><a href="#ref-for-cache①">5. Caches</a> <a href="#ref-for-cache②">(2)</a>
@@ -12784,8 +12784,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-cache①⑥">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-cache①⑦">(2)</a> <a href="#ref-for-cache①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cachequeryoptions">
-   <b><a href="#dictdef-cachequeryoptions">#dictdef-cachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cachequeryoptions" class="dfn-panel" data-for="dictdef-cachequeryoptions" id="infopanel-for-dictdef-cachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cachequeryoptions" style="display:none">Info about the 'CacheQueryOptions' definition.</span><b><a href="#dictdef-cachequeryoptions">#dictdef-cachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cachequeryoptions">5.4. Cache</a> <a href="#ref-for-dictdef-cachequeryoptions①">(2)</a> <a href="#ref-for-dictdef-cachequeryoptions②">(3)</a> <a href="#ref-for-dictdef-cachequeryoptions③">(4)</a> <a href="#ref-for-dictdef-cachequeryoptions④">(5)</a>
     <li><a href="#ref-for-dictdef-cachequeryoptions⑤">5.5. CacheStorage</a>
@@ -12793,26 +12793,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dictdef-cachequeryoptions⑦">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch">
-   <b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch" id="infopanel-for-dom-cachequeryoptions-ignoresearch" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" style="display:none">Info about the 'ignoreSearch' definition.</span><b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoresearch">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod">
-   <b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod" id="infopanel-for-dom-cachequeryoptions-ignoremethod" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" style="display:none">Info about the 'ignoreMethod' definition.</span><b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoremethod">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary">
-   <b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignorevary" class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary" id="infopanel-for-dom-cachequeryoptions-ignorevary" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignorevary" style="display:none">Info about the 'ignoreVary' definition.</span><b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignorevary">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation">
-   <b><a href="#dfn-cache-batch-operation">#dfn-cache-batch-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation" class="dfn-panel" data-for="dfn-cache-batch-operation" id="infopanel-for-dfn-cache-batch-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation" style="display:none">Info about the 'cache batch operation' definition.</span><b><a href="#dfn-cache-batch-operation">#dfn-cache-batch-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation①">5.4.5. put(request, response)</a>
@@ -12820,8 +12820,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-type">
-   <b><a href="#dfn-cache-batch-operation-type">#dfn-cache-batch-operation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-type" class="dfn-panel" data-for="dfn-cache-batch-operation-type" id="infopanel-for-dfn-cache-batch-operation-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-cache-batch-operation-type">#dfn-cache-batch-operation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-type">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-type①">5.4.5. put(request, response)</a>
@@ -12829,8 +12829,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation-type③">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-type④">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-type⑤">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-type⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-request">
-   <b><a href="#dfn-cache-batch-operation-request">#dfn-cache-batch-operation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-request" class="dfn-panel" data-for="dfn-cache-batch-operation-request" id="infopanel-for-dfn-cache-batch-operation-request" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dfn-cache-batch-operation-request">#dfn-cache-batch-operation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-request">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-request①">5.4.5. put(request, response)</a>
@@ -12838,145 +12838,145 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation-request③">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-request④">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑤">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑥">(4)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑦">(5)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑧">(6)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-response">
-   <b><a href="#dfn-cache-batch-operation-response">#dfn-cache-batch-operation-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-response" class="dfn-panel" data-for="dfn-cache-batch-operation-response" id="infopanel-for-dfn-cache-batch-operation-response" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dfn-cache-batch-operation-response">#dfn-cache-batch-operation-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-response">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-response①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-response②">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-response③">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-response④">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-response⑤">(4)</a> <a href="#ref-for-dfn-cache-batch-operation-response⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-options">
-   <b><a href="#dfn-cache-batch-operation-options">#dfn-cache-batch-operation-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-options" class="dfn-panel" data-for="dfn-cache-batch-operation-options" id="infopanel-for-dfn-cache-batch-operation-options" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dfn-cache-batch-operation-options">#dfn-cache-batch-operation-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-options">5.4.6. delete(request, options)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-options①">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-options②">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-options③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-match">
-   <b><a href="#dom-cache-match">#dom-cache-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-match" class="dfn-panel" data-for="dom-cache-match" id="infopanel-for-dom-cache-match" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-match" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#dom-cache-match">#dom-cache-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-match">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-match①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-dom-cache-match②">5.5.1. match(request, options)</a> <a href="#ref-for-dom-cache-match③">(2)</a> <a href="#ref-for-dom-cache-match④">(3)</a> <a href="#ref-for-dom-cache-match⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-matchall">
-   <b><a href="#dom-cache-matchall">#dom-cache-matchall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-matchall" class="dfn-panel" data-for="dom-cache-matchall" id="infopanel-for-dom-cache-matchall" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-matchall" style="display:none">Info about the 'matchAll(request, options)' definition.</span><b><a href="#dom-cache-matchall">#dom-cache-matchall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-matchall">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-matchall①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-dom-cache-matchall②">5.4.2. matchAll(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-add">
-   <b><a href="#dom-cache-add">#dom-cache-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-add" class="dfn-panel" data-for="dom-cache-add" id="infopanel-for-dom-cache-add" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-add" style="display:none">Info about the 'add(request)' definition.</span><b><a href="#dom-cache-add">#dom-cache-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-add">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-add①">5.4.3. add(request)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-addall">
-   <b><a href="#dom-cache-addall">#dom-cache-addall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-addall" class="dfn-panel" data-for="dom-cache-addall" id="infopanel-for-dom-cache-addall" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-addall" style="display:none">Info about the 'addAll(requests)' definition.</span><b><a href="#dom-cache-addall">#dom-cache-addall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-addall">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-addall①">5.4.3. add(request)</a>
     <li><a href="#ref-for-dom-cache-addall②">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-put">
-   <b><a href="#dom-cache-put">#dom-cache-put</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-put" class="dfn-panel" data-for="dom-cache-put" id="infopanel-for-dom-cache-put" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-put" style="display:none">Info about the 'put(request, response)' definition.</span><b><a href="#dom-cache-put">#dom-cache-put</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-put">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-put①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-delete">
-   <b><a href="#dom-cache-delete">#dom-cache-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-delete" class="dfn-panel" data-for="dom-cache-delete" id="infopanel-for-dom-cache-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-delete" style="display:none">Info about the 'delete(request, options)' definition.</span><b><a href="#dom-cache-delete">#dom-cache-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-delete">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-delete①">5.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-keys">
-   <b><a href="#dom-cache-keys">#dom-cache-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-keys" class="dfn-panel" data-for="dom-cache-keys" id="infopanel-for-dom-cache-keys" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-keys" style="display:none">Info about the 'keys(request, options)' definition.</span><b><a href="#dom-cache-keys">#dom-cache-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-keys">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-keys①">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cachestorage">
-   <b><a href="#cachestorage">#cachestorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cachestorage" class="dfn-panel" data-for="cachestorage" id="infopanel-for-cachestorage" role="dialog">
+   <span id="infopaneltitle-for-cachestorage" style="display:none">Info about the 'CacheStorage' definition.</span><b><a href="#cachestorage">#cachestorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cachestorage">5.3. self.caches</a>
     <li><a href="#ref-for-cachestorage①">5.3.1. caches</a>
     <li><a href="#ref-for-cachestorage②">5.5. CacheStorage</a> <a href="#ref-for-cachestorage③">(2)</a> <a href="#ref-for-cachestorage④">(3)</a> <a href="#ref-for-cachestorage⑤">(4)</a> <a href="#ref-for-cachestorage⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-multicachequeryoptions">
-   <b><a href="#dictdef-multicachequeryoptions">#dictdef-multicachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-multicachequeryoptions" class="dfn-panel" data-for="dictdef-multicachequeryoptions" id="infopanel-for-dictdef-multicachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-multicachequeryoptions" style="display:none">Info about the 'MultiCacheQueryOptions' definition.</span><b><a href="#dictdef-multicachequeryoptions">#dictdef-multicachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-multicachequeryoptions">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-multicachequeryoptions-cachename">
-   <b><a href="#dom-multicachequeryoptions-cachename">#dom-multicachequeryoptions-cachename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-multicachequeryoptions-cachename" class="dfn-panel" data-for="dom-multicachequeryoptions-cachename" id="infopanel-for-dom-multicachequeryoptions-cachename" role="dialog">
+   <span id="infopaneltitle-for-dom-multicachequeryoptions-cachename" style="display:none">Info about the 'cacheName' definition.</span><b><a href="#dom-multicachequeryoptions-cachename">#dom-multicachequeryoptions-cachename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-multicachequeryoptions-cachename">5.5.1. match(request, options)</a> <a href="#ref-for-dom-multicachequeryoptions-cachename①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cachestorage-global-object">
-   <b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cachestorage-global-object" class="dfn-panel" data-for="cachestorage-global-object" id="infopanel-for-cachestorage-global-object" role="dialog">
+   <span id="infopaneltitle-for-cachestorage-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cachestorage-global-object">5.1. Constructs</a>
     <li><a href="#ref-for-cachestorage-global-object①">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-match">
-   <b><a href="#dom-cachestorage-match">#dom-cachestorage-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-match" class="dfn-panel" data-for="dom-cachestorage-match" id="infopanel-for-dom-cachestorage-match" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-match" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#dom-cachestorage-match">#dom-cachestorage-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-match">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-match①">5.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-has">
-   <b><a href="#dom-cachestorage-has">#dom-cachestorage-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-has" class="dfn-panel" data-for="dom-cachestorage-has" id="infopanel-for-dom-cachestorage-has" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-has" style="display:none">Info about the 'has(cacheName)' definition.</span><b><a href="#dom-cachestorage-has">#dom-cachestorage-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-has">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-has①">5.5.2. has(cacheName)</a>
     <li><a href="#ref-for-dom-cachestorage-has②">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-open">
-   <b><a href="#dom-cachestorage-open">#dom-cachestorage-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-open" class="dfn-panel" data-for="dom-cachestorage-open" id="infopanel-for-dom-cachestorage-open" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-open" style="display:none">Info about the 'open(cacheName)' definition.</span><b><a href="#dom-cachestorage-open">#dom-cachestorage-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-open">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-open①">5.5.3. open(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-delete">
-   <b><a href="#dom-cachestorage-delete">#dom-cachestorage-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-delete" class="dfn-panel" data-for="dom-cachestorage-delete" id="infopanel-for-dom-cachestorage-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-delete" style="display:none">Info about the 'delete(cacheName)' definition.</span><b><a href="#dom-cachestorage-delete">#dom-cachestorage-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-delete">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-delete①">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-keys">
-   <b><a href="#dom-cachestorage-keys">#dom-cachestorage-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-keys" class="dfn-panel" data-for="dom-cachestorage-keys" id="infopanel-for-dom-cachestorage-keys" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-keys" style="display:none">Info about the 'keys()' definition.</span><b><a href="#dom-cachestorage-keys">#dom-cachestorage-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-keys">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-keys①">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="importscripts-method">
-   <b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-importscripts-method" class="dfn-panel" data-for="importscripts-method" id="infopanel-for-importscripts-method" role="dialog">
+   <span id="infopaneltitle-for-importscripts-method" style="display:none">Info about the 'importScripts(urls)' definition.</span><b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-importscripts-method">6.3.1. Origin restriction</a>
     <li><a href="#ref-for-importscripts-method①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-registration-map">
-   <b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-registration-map" class="dfn-panel" data-for="dfn-scope-to-registration-map" id="infopanel-for-dfn-scope-to-registration-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-registration-map" style="display:none">Info about the 'scope to registration map' definition.</span><b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-scope-to-registration-map①">2.2.1. Lifetime</a>
@@ -12991,8 +12991,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-to-registration-map①①">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job">
-   <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job" class="dfn-panel" data-for="dfn-job" id="infopanel-for-dfn-job" role="dialog">
+   <span id="infopaneltitle-for-dfn-job" style="display:none">Info about the 'job' definition.</span><b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job①">(2)</a> <a href="#ref-for-dfn-job②">(3)</a> <a href="#ref-for-dfn-job③">(4)</a> <a href="#ref-for-dfn-job④">(5)</a> <a href="#ref-for-dfn-job⑤">(6)</a> <a href="#ref-for-dfn-job⑥">(7)</a> <a href="#ref-for-dfn-job⑦">(8)</a> <a href="#ref-for-dfn-job⑧">(9)</a> <a href="#ref-for-dfn-job⑨">(10)</a> <a href="#ref-for-dfn-job①⓪">(11)</a> <a href="#ref-for-dfn-job①①">(12)</a> <a href="#ref-for-dfn-job①②">(13)</a> <a href="#ref-for-dfn-job①③">(14)</a> <a href="#ref-for-dfn-job①④">(15)</a> <a href="#ref-for-dfn-job①⑤">(16)</a> <a href="#ref-for-dfn-job①⑥">(17)</a>
     <li><a href="#ref-for-dfn-job①⑦">Create Job</a> <a href="#ref-for-dfn-job①⑧">(2)</a>
@@ -13006,8 +13006,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job②⑥">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-type">
-   <b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-type" class="dfn-panel" data-for="dfn-job-type" id="infopanel-for-dfn-job-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-type" style="display:none">Info about the 'job type' definition.</span><b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-type">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type①">Create Job</a> <a href="#ref-for-dfn-job-type②">(2)</a>
@@ -13016,8 +13016,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-type⑧">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-scope-url">
-   <b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-scope-url" class="dfn-panel" data-for="dfn-job-scope-url" id="infopanel-for-dfn-job-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-scope-url">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-scope-url①">(2)</a>
     <li><a href="#ref-for-dfn-job-scope-url②">Create Job</a>
@@ -13027,8 +13027,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-scope-url⑧">Unregister</a> <a href="#ref-for-dfn-job-scope-url⑨">(2)</a> <a href="#ref-for-dfn-job-scope-url①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-script-url">
-   <b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-script-url" class="dfn-panel" data-for="dfn-job-script-url" id="infopanel-for-dfn-job-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url①">Create Job</a>
@@ -13036,8 +13036,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a> <a href="#ref-for-dfn-job-script-url①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-worker-type">
-   <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-worker-type" class="dfn-panel" data-for="dfn-job-worker-type" id="infopanel-for-dfn-job-worker-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-worker-type" style="display:none">Info about the 'worker type' definition.</span><b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-worker-type">3.2.8. update()</a>
     <li><a href="#ref-for-dfn-job-worker-type①">Appendix A: Algorithms</a>
@@ -13047,8 +13047,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-worker-type⑧">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-update-via-cache-mode">
-   <b><a href="#dfn-job-update-via-cache-mode">#dfn-job-update-via-cache-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-update-via-cache-mode" class="dfn-panel" data-for="dfn-job-update-via-cache-mode" id="infopanel-for-dfn-job-update-via-cache-mode" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-update-via-cache-mode" style="display:none">Info about the 'update via cache mode' definition.</span><b><a href="#dfn-job-update-via-cache-mode">#dfn-job-update-via-cache-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-update-via-cache-mode">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-update-via-cache-mode①">Start Register</a>
@@ -13057,8 +13057,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-update-via-cache-mode⑤">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-client">
-   <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-client" class="dfn-panel" data-for="dfn-job-client" id="infopanel-for-dfn-job-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-client" style="display:none">Info about the 'client' definition.</span><b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client">Create Job</a>
     <li><a href="#ref-for-dfn-job-client①">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client②">(2)</a> <a href="#ref-for-dfn-job-client③">(3)</a> <a href="#ref-for-dfn-job-client④">(4)</a> <a href="#ref-for-dfn-job-client⑤">(5)</a> <a href="#ref-for-dfn-job-client⑥">(6)</a> <a href="#ref-for-dfn-job-client⑦">(7)</a> <a href="#ref-for-dfn-job-client⑧">(8)</a>
@@ -13067,16 +13067,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-client②⓪">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="job-referrer">
-   <b><a href="#job-referrer">#job-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-job-referrer" class="dfn-panel" data-for="job-referrer" id="infopanel-for-job-referrer" role="dialog">
+   <span id="infopaneltitle-for-job-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#job-referrer">#job-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-job-referrer">Create Job</a>
     <li><a href="#ref-for-job-referrer①">Start Register</a>
     <li><a href="#ref-for-job-referrer②">Register</a> <a href="#ref-for-job-referrer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-promise">
-   <b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-promise" class="dfn-panel" data-for="dfn-job-promise" id="infopanel-for-dfn-job-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-promise" style="display:none">Info about the 'job promise' definition.</span><b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-promise">Create Job</a>
     <li><a href="#ref-for-dfn-job-promise①">Schedule Job</a>
@@ -13085,58 +13085,58 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-promise⑥">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-job-queue">
-   <b><a href="#dfn-containing-job-queue">#dfn-containing-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-job-queue" class="dfn-panel" data-for="dfn-containing-job-queue" id="infopanel-for-dfn-containing-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-job-queue" style="display:none">Info about the 'containing job queue' definition.</span><b><a href="#dfn-containing-job-queue">#dfn-containing-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-job-queue">Schedule Job</a> <a href="#ref-for-dfn-containing-job-queue①">(2)</a>
     <li><a href="#ref-for-dfn-containing-job-queue②">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs">
-   <b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs" id="infopanel-for-dfn-job-list-of-equivalent-jobs" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" style="display:none">Info about the 'list of equivalent jobs' definition.</span><b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs①">Resolve Job Promise</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs②">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
-   <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-force-bypass-cache-flag" class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag" id="infopanel-for-dfn-job-force-bypass-cache-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-force-bypass-cache-flag" style="display:none">Info about the 'force bypass cache flag' definition.</span><b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag②">(3)</a>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Soft Update</a>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag④">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-equivalent">
-   <b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-equivalent" class="dfn-panel" data-for="dfn-job-equivalent" id="infopanel-for-dfn-job-equivalent" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-equivalent" style="display:none">Info about the 'equivalent' definition.</span><b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-equivalent">Schedule Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-queue">
-   <b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-queue" class="dfn-panel" data-for="dfn-job-queue" id="infopanel-for-dfn-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-queue" style="display:none">Info about the 'job queue' definition.</span><b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-queue">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-queue①">(2)</a> <a href="#ref-for-dfn-job-queue②">(3)</a> <a href="#ref-for-dfn-job-queue③">(4)</a>
     <li><a href="#ref-for-dfn-job-queue④">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-queue⑤">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-job-queue-map">
-   <b><a href="#dfn-scope-to-job-queue-map">#dfn-scope-to-job-queue-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-job-queue-map" class="dfn-panel" data-for="dfn-scope-to-job-queue-map" id="infopanel-for-dfn-scope-to-job-queue-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-job-queue-map" style="display:none">Info about the 'scope to job queue map' definition.</span><b><a href="#dfn-scope-to-job-queue-map">#dfn-scope-to-job-queue-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-job-queue-map">Schedule Job</a> <a href="#ref-for-dfn-scope-to-job-queue-map①">(2)</a> <a href="#ref-for-dfn-scope-to-job-queue-map②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-bad-import-script-response">
-   <b><a href="#dfn-bad-import-script-response">#dfn-bad-import-script-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-bad-import-script-response" class="dfn-panel" data-for="dfn-bad-import-script-response" id="infopanel-for-dfn-bad-import-script-response" role="dialog">
+   <span id="infopaneltitle-for-dfn-bad-import-script-response" style="display:none">Info about the 'bad import script response' definition.</span><b><a href="#dfn-bad-import-script-response">#dfn-bad-import-script-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-bad-import-script-response">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-bad-import-script-response①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-job">
-   <b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-job" class="dfn-panel" data-for="create-job" id="infopanel-for-create-job" role="dialog">
+   <span id="infopaneltitle-for-create-job" style="display:none">Info about the 'Create Job' definition.</span><b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-job">3.2.8. update()</a>
     <li><a href="#ref-for-create-job①">3.2.9. unregister()</a>
@@ -13144,8 +13144,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-create-job③">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="schedule-job">
-   <b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-schedule-job" class="dfn-panel" data-for="schedule-job" id="infopanel-for-schedule-job" role="dialog">
+   <span id="infopaneltitle-for-schedule-job" style="display:none">Info about the 'Schedule Job' definition.</span><b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-schedule-job">3.2.8. update()</a>
     <li><a href="#ref-for-schedule-job①">3.2.9. unregister()</a>
@@ -13153,15 +13153,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-schedule-job③">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-job">
-   <b><a href="#run-job">#run-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-job" class="dfn-panel" data-for="run-job" id="infopanel-for-run-job" role="dialog">
+   <span id="infopaneltitle-for-run-job" style="display:none">Info about the 'Run Job' definition.</span><b><a href="#run-job">#run-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-job">Schedule Job</a>
     <li><a href="#ref-for-run-job①">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finish-job">
-   <b><a href="#finish-job">#finish-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finish-job" class="dfn-panel" data-for="finish-job" id="infopanel-for-finish-job" role="dialog">
+   <span id="infopaneltitle-for-finish-job" style="display:none">Info about the 'Finish Job' definition.</span><b><a href="#finish-job">#finish-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finish-job">Register</a> <a href="#ref-for-finish-job①">(2)</a> <a href="#ref-for-finish-job②">(3)</a> <a href="#ref-for-finish-job③">(4)</a>
     <li><a href="#ref-for-finish-job④">Update</a> <a href="#ref-for-finish-job⑤">(2)</a> <a href="#ref-for-finish-job⑥">(3)</a> <a href="#ref-for-finish-job⑦">(4)</a> <a href="#ref-for-finish-job⑧">(5)</a>
@@ -13169,8 +13169,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-finish-job①①">Unregister</a> <a href="#ref-for-finish-job①②">(2)</a> <a href="#ref-for-finish-job①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-job-promise">
-   <b><a href="#resolve-job-promise">#resolve-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-job-promise" class="dfn-panel" data-for="resolve-job-promise" id="infopanel-for-resolve-job-promise" role="dialog">
+   <span id="infopaneltitle-for-resolve-job-promise" style="display:none">Info about the 'Resolve Job Promise' definition.</span><b><a href="#resolve-job-promise">#resolve-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-job-promise">Register</a>
     <li><a href="#ref-for-resolve-job-promise①">Update</a>
@@ -13178,54 +13178,54 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-resolve-job-promise③">Unregister</a> <a href="#ref-for-resolve-job-promise④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reject-job-promise">
-   <b><a href="#reject-job-promise">#reject-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reject-job-promise" class="dfn-panel" data-for="reject-job-promise" id="infopanel-for-reject-job-promise" role="dialog">
+   <span id="infopaneltitle-for-reject-job-promise" style="display:none">Info about the 'Reject Job Promise' definition.</span><b><a href="#reject-job-promise">#reject-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject-job-promise">Register</a> <a href="#ref-for-reject-job-promise①">(2)</a> <a href="#ref-for-reject-job-promise②">(3)</a>
     <li><a href="#ref-for-reject-job-promise③">Update</a> <a href="#ref-for-reject-job-promise④">(2)</a> <a href="#ref-for-reject-job-promise⑤">(3)</a> <a href="#ref-for-reject-job-promise⑥">(4)</a> <a href="#ref-for-reject-job-promise⑦">(5)</a> <a href="#ref-for-reject-job-promise⑧">(6)</a> <a href="#ref-for-reject-job-promise⑨">(7)</a>
     <li><a href="#ref-for-reject-job-promise①⓪">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-register">
-   <b><a href="#start-register">#start-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-register" class="dfn-panel" data-for="start-register" id="infopanel-for-start-register" role="dialog">
+   <span id="infopaneltitle-for-start-register" style="display:none">Info about the 'Start Register' definition.</span><b><a href="#start-register">#start-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-register">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register">
-   <b><a href="#register">#register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-register" class="dfn-panel" data-for="register" id="infopanel-for-register" role="dialog">
+   <span id="infopaneltitle-for-register" style="display:none">Info about the 'Register' definition.</span><b><a href="#register">#register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-register">2.2.1. Lifetime</a>
     <li><a href="#ref-for-register①">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-register②">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update">
-   <b><a href="#update">#update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update" class="dfn-panel" data-for="update" id="infopanel-for-update" role="dialog">
+   <span id="infopaneltitle-for-update" style="display:none">Info about the 'Update' definition.</span><b><a href="#update">#update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update">Run Job</a>
     <li><a href="#ref-for-update①">Register</a>
     <li><a href="#ref-for-update②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="soft-update">
-   <b><a href="#soft-update">#soft-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-soft-update" class="dfn-panel" data-for="soft-update" id="infopanel-for-soft-update" role="dialog">
+   <span id="infopaneltitle-for-soft-update" style="display:none">Info about the 'Soft Update' definition.</span><b><a href="#soft-update">#soft-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-update">Update</a>
     <li><a href="#ref-for-soft-update①">Handle Fetch</a> <a href="#ref-for-soft-update②">(2)</a>
     <li><a href="#ref-for-soft-update③">Fire Functional Event</a> <a href="#ref-for-soft-update④">(2)</a> <a href="#ref-for-soft-update⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="install">
-   <b><a href="#install">#install</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-install" class="dfn-panel" data-for="install" id="infopanel-for-install" role="dialog">
+   <span id="infopaneltitle-for-install" style="display:none">Info about the 'Install' definition.</span><b><a href="#install">#install</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-install">3.5. Events</a>
     <li><a href="#ref-for-install①">4.7. Events</a>
     <li><a href="#ref-for-install②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activate">
-   <b><a href="#activate">#activate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activate" class="dfn-panel" data-for="activate" id="infopanel-for-activate" role="dialog">
+   <span id="infopaneltitle-for-activate" style="display:none">Info about the 'Activate' definition.</span><b><a href="#activate">#activate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activate">3.5. Events</a> <a href="#ref-for-activate①">(2)</a>
     <li><a href="#ref-for-activate②">4.7. Events</a>
@@ -13234,8 +13234,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-activate⑥">Handle User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="try-activate">
-   <b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-try-activate" class="dfn-panel" data-for="try-activate" id="infopanel-for-try-activate" role="dialog">
+   <span id="infopaneltitle-for-try-activate" style="display:none">Info about the 'Try Activate' definition.</span><b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-try-activate">4.1.4. skipWaiting()</a>
     <li><a href="#ref-for-try-activate①">4.4. ExtendableEvent</a>
@@ -13243,8 +13243,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-try-activate④">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-service-worker">
-   <b><a href="#run-service-worker">#run-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-service-worker" class="dfn-panel" data-for="run-service-worker" id="infopanel-for-run-service-worker" role="dialog">
+   <span id="infopaneltitle-for-run-service-worker" style="display:none">Info about the 'Run Service Worker' definition.</span><b><a href="#run-service-worker">#run-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-service-worker">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-run-service-worker①">6.2. Content Security Policy</a>
@@ -13255,8 +13255,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-run-service-worker⑦">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="terminate-service-worker">
-   <b><a href="#terminate-service-worker">#terminate-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-terminate-service-worker" class="dfn-panel" data-for="terminate-service-worker" id="infopanel-for-terminate-service-worker" role="dialog">
+   <span id="infopaneltitle-for-terminate-service-worker" style="display:none">Info about the 'Terminate Service Worker' definition.</span><b><a href="#terminate-service-worker">#terminate-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-service-worker">2.1.1. Lifetime</a>
     <li><a href="#ref-for-terminate-service-worker①">2.2. Service Worker Registration</a>
@@ -13268,8 +13268,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-terminate-service-worker⑦">Clear Registration</a> <a href="#ref-for-terminate-service-worker⑧">(2)</a> <a href="#ref-for-terminate-service-worker⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-fetch">
-   <b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-fetch" class="dfn-panel" data-for="handle-fetch" id="infopanel-for-handle-fetch" role="dialog">
+   <span id="infopaneltitle-for-handle-fetch" style="display:none">Info about the 'Handle Fetch' definition.</span><b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-fetch①">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-handle-fetch②">4.5.7. event.respondWith(r)</a> <a href="#ref-for-handle-fetch③">(2)</a>
@@ -13278,8 +13278,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-handle-fetch⑦">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-skip-event">
-   <b><a href="#should-skip-event">#should-skip-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-skip-event" class="dfn-panel" data-for="should-skip-event" id="infopanel-for-should-skip-event" role="dialog">
+   <span id="infopaneltitle-for-should-skip-event" style="display:none">Info about the 'Should Skip Event' definition.</span><b><a href="#should-skip-event">#should-skip-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-skip-event">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-should-skip-event①">Install</a>
@@ -13288,88 +13288,88 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-should-skip-event④">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-functional-event">
-   <b><a href="#fire-functional-event">#fire-functional-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-functional-event" class="dfn-panel" data-for="fire-functional-event" id="infopanel-for-fire-functional-event" role="dialog">
+   <span id="infopaneltitle-for-fire-functional-event" style="display:none">Info about the 'Fire Functional Event' definition.</span><b><a href="#fire-functional-event">#fire-functional-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">7.4. Firing Functional Events</a>
     <li><a href="#ref-for-fire-functional-event①">Fire Functional Event</a> <a href="#ref-for-fire-functional-event②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-service-worker-client-unload">
-   <b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-service-worker-client-unload" class="dfn-panel" data-for="handle-service-worker-client-unload" id="infopanel-for-handle-service-worker-client-unload" role="dialog">
+   <span id="infopaneltitle-for-handle-service-worker-client-unload" style="display:none">Info about the 'Handle Service Worker Client Unload' definition.</span><b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload">4.3.4. claim()</a>
     <li><a href="#ref-for-handle-service-worker-client-unload①">Install</a>
     <li><a href="#ref-for-handle-service-worker-client-unload②">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
-   <b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-user-agent-shutdown" class="dfn-panel" data-for="handle-user-agent-shutdown" id="infopanel-for-handle-user-agent-shutdown" role="dialog">
+   <span id="infopaneltitle-for-handle-user-agent-shutdown" style="display:none">Info about the 'Handle User Agent Shutdown' definition.</span><b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-user-agent-shutdown">2.6. User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-service-worker-extended-events-set">
-   <b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-service-worker-extended-events-set" class="dfn-panel" data-for="update-service-worker-extended-events-set" id="infopanel-for-update-service-worker-extended-events-set" role="dialog">
+   <span id="infopaneltitle-for-update-service-worker-extended-events-set" style="display:none">Info about the 'Update Service Worker Extended Events Set' definition.</span><b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-service-worker-extended-events-set">3.1.5. postMessage(message, options)</a>
     <li><a href="#ref-for-update-service-worker-extended-events-set①">Handle Fetch</a>
     <li><a href="#ref-for-update-service-worker-extended-events-set②">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unregister">
-   <b><a href="#unregister">#unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unregister" class="dfn-panel" data-for="unregister" id="infopanel-for-unregister" role="dialog">
+   <span id="infopaneltitle-for-unregister" style="display:none">Info about the 'Unregister' definition.</span><b><a href="#unregister">#unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unregister">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-registration">
-   <b><a href="#set-registration">#set-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-registration" class="dfn-panel" data-for="set-registration" id="infopanel-for-set-registration" role="dialog">
+   <span id="infopaneltitle-for-set-registration" style="display:none">Info about the 'Set Registration' definition.</span><b><a href="#set-registration">#set-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-registration">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clear-registration">
-   <b><a href="#clear-registration">#clear-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clear-registration" class="dfn-panel" data-for="clear-registration" id="infopanel-for-clear-registration" role="dialog">
+   <span id="infopaneltitle-for-clear-registration" style="display:none">Info about the 'Clear Registration' definition.</span><b><a href="#clear-registration">#clear-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear-registration">Handle User Agent Shutdown</a>
     <li><a href="#ref-for-clear-registration①">Unregister</a> <a href="#ref-for-clear-registration②">(2)</a>
     <li><a href="#ref-for-clear-registration③">Try Clear Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="try-clear-registration">
-   <b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-try-clear-registration" class="dfn-panel" data-for="try-clear-registration" id="infopanel-for-try-clear-registration" role="dialog">
+   <span id="infopaneltitle-for-try-clear-registration" style="display:none">Info about the 'Try Clear Registration' definition.</span><b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-try-clear-registration">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-try-clear-registration①">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-try-clear-registration②">Unregister</a> <a href="#ref-for-try-clear-registration③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-registration-state">
-   <b><a href="#update-registration-state">#update-registration-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-registration-state" class="dfn-panel" data-for="update-registration-state" id="infopanel-for-update-registration-state" role="dialog">
+   <span id="infopaneltitle-for-update-registration-state" style="display:none">Info about the 'Update Registration State' definition.</span><b><a href="#update-registration-state">#update-registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-registration-state">Install</a> <a href="#ref-for-update-registration-state①">(2)</a> <a href="#ref-for-update-registration-state②">(3)</a> <a href="#ref-for-update-registration-state③">(4)</a>
     <li><a href="#ref-for-update-registration-state④">Activate</a> <a href="#ref-for-update-registration-state⑤">(2)</a>
     <li><a href="#ref-for-update-registration-state⑥">Clear Registration</a> <a href="#ref-for-update-registration-state⑦">(2)</a> <a href="#ref-for-update-registration-state⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-worker-state">
-   <b><a href="#update-worker-state">#update-worker-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-worker-state" class="dfn-panel" data-for="update-worker-state" id="infopanel-for-update-worker-state" role="dialog">
+   <span id="infopaneltitle-for-update-worker-state" style="display:none">Info about the 'Update Worker State' definition.</span><b><a href="#update-worker-state">#update-worker-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-worker-state">Install</a> <a href="#ref-for-update-worker-state①">(2)</a> <a href="#ref-for-update-worker-state②">(3)</a> <a href="#ref-for-update-worker-state③">(4)</a> <a href="#ref-for-update-worker-state④">(5)</a>
     <li><a href="#ref-for-update-worker-state⑤">Activate</a> <a href="#ref-for-update-worker-state⑥">(2)</a> <a href="#ref-for-update-worker-state⑦">(3)</a>
     <li><a href="#ref-for-update-worker-state⑧">Clear Registration</a> <a href="#ref-for-update-worker-state⑨">(2)</a> <a href="#ref-for-update-worker-state①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-controller-change">
-   <b><a href="#notify-controller-change">#notify-controller-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-controller-change" class="dfn-panel" data-for="notify-controller-change" id="infopanel-for-notify-controller-change" role="dialog">
+   <span id="infopaneltitle-for-notify-controller-change" style="display:none">Info about the 'Notify Controller Change' definition.</span><b><a href="#notify-controller-change">#notify-controller-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-controller-change">4.3.4. claim()</a>
     <li><a href="#ref-for-notify-controller-change①">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-service-worker-registration">
-   <b><a href="#match-service-worker-registration">#match-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-service-worker-registration" class="dfn-panel" data-for="match-service-worker-registration" id="infopanel-for-match-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-match-service-worker-registration" style="display:none">Info about the 'Match Service Worker Registration' definition.</span><b><a href="#match-service-worker-registration">#match-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-service-worker-registration">2.4.1. The window client case</a>
     <li><a href="#ref-for-match-service-worker-registration①">2.4.2. The worker client case</a>
@@ -13381,8 +13381,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-match-service-worker-registration⑦">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-registration">
-   <b><a href="#get-registration">#get-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-registration" class="dfn-panel" data-for="get-registration" id="infopanel-for-get-registration" role="dialog">
+   <span id="infopaneltitle-for-get-registration" style="display:none">Info about the 'Get Registration' definition.</span><b><a href="#get-registration">#get-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-registration">Register</a>
     <li><a href="#ref-for-get-registration①">Update</a>
@@ -13390,8 +13390,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-registration③">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-newest-worker">
-   <b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-newest-worker" class="dfn-panel" data-for="get-newest-worker" id="infopanel-for-get-newest-worker" role="dialog">
+   <span id="infopaneltitle-for-get-newest-worker" style="display:none">Info about the 'Get Newest Worker' definition.</span><b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-newest-worker">3.2.8. update()</a>
     <li><a href="#ref-for-get-newest-worker①">Register</a>
@@ -13400,23 +13400,23 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-newest-worker④">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-has-no-pending-events">
-   <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-has-no-pending-events" class="dfn-panel" data-for="service-worker-has-no-pending-events" id="infopanel-for-service-worker-has-no-pending-events" role="dialog">
+   <span id="infopaneltitle-for-service-worker-has-no-pending-events" style="display:none">Info about the 'Service Worker Has No Pending Events' definition.</span><b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-has-no-pending-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-service-worker-has-no-pending-events①">Try Activate</a>
     <li><a href="#ref-for-service-worker-has-no-pending-events②">Try Clear Registration</a> <a href="#ref-for-service-worker-has-no-pending-events③">(2)</a> <a href="#ref-for-service-worker-has-no-pending-events④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-client">
-   <b><a href="#create-client">#create-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-client" class="dfn-panel" data-for="create-client" id="infopanel-for-create-client" role="dialog">
+   <span id="infopaneltitle-for-create-client" style="display:none">Info about the 'Create Client' definition.</span><b><a href="#create-client">#create-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-client">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-create-client①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-window-client">
-   <b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-window-client" class="dfn-panel" data-for="create-window-client" id="infopanel-for-create-window-client" role="dialog">
+   <span id="infopaneltitle-for-create-window-client" style="display:none">Info about the 'Create Window Client' definition.</span><b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-window-client">4.2.10. focus()</a>
     <li><a href="#ref-for-create-window-client①">4.2.11. navigate(url)</a>
@@ -13425,8 +13425,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-create-window-client④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-frame-type">
-   <b><a href="#get-frame-type">#get-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-frame-type" class="dfn-panel" data-for="get-frame-type" id="infopanel-for-get-frame-type" role="dialog">
+   <span id="infopaneltitle-for-get-frame-type" style="display:none">Info about the 'Get Frame Type' definition.</span><b><a href="#get-frame-type">#get-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-frame-type">4.2.10. focus()</a>
     <li><a href="#ref-for-get-frame-type①">4.2.11. navigate(url)</a>
@@ -13435,42 +13435,42 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-frame-type④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-get-client-promise">
-   <b><a href="#resolve-get-client-promise">#resolve-get-client-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-get-client-promise" class="dfn-panel" data-for="resolve-get-client-promise" id="infopanel-for-resolve-get-client-promise" role="dialog">
+   <span id="infopaneltitle-for-resolve-get-client-promise" style="display:none">Info about the 'Resolve Get Client Promise' definition.</span><b><a href="#resolve-get-client-promise">#resolve-get-client-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-get-client-promise">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-cache">
-   <b><a href="#query-cache">#query-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-cache" class="dfn-panel" data-for="query-cache" id="infopanel-for-query-cache" role="dialog">
+   <span id="infopaneltitle-for-query-cache" style="display:none">Info about the 'Query Cache' definition.</span><b><a href="#query-cache">#query-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-cache">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-query-cache①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-query-cache②">Batch Cache Operations</a> <a href="#ref-for-query-cache③">(2)</a> <a href="#ref-for-query-cache④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-matches-cached-item">
-   <b><a href="#request-matches-cached-item">#request-matches-cached-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-matches-cached-item" class="dfn-panel" data-for="request-matches-cached-item" id="infopanel-for-request-matches-cached-item" role="dialog">
+   <span id="infopaneltitle-for-request-matches-cached-item" style="display:none">Info about the 'Request Matches Cached Item' definition.</span><b><a href="#request-matches-cached-item">#request-matches-cached-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-matches-cached-item">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="batch-cache-operations">
-   <b><a href="#batch-cache-operations">#batch-cache-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-batch-cache-operations" class="dfn-panel" data-for="batch-cache-operations" id="infopanel-for-batch-cache-operations" role="dialog">
+   <span id="infopaneltitle-for-batch-cache-operations" style="display:none">Info about the 'Batch Cache Operations' definition.</span><b><a href="#batch-cache-operations">#batch-cache-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-batch-cache-operations">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-batch-cache-operations①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-batch-cache-operations②">5.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker">
-   <b><a href="#service-worker">#service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker" class="dfn-panel" data-for="service-worker" id="infopanel-for-service-worker" role="dialog">
+   <span id="infopaneltitle-for-service-worker" style="display:none">Info about the 'Service-Worker' definition.</span><b><a href="#service-worker">#service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker">6.6. Service worker script request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-allowed">
-   <b><a href="#service-worker-allowed">#service-worker-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-allowed" class="dfn-panel" data-for="service-worker-allowed" id="infopanel-for-service-worker-allowed" role="dialog">
+   <span id="infopaneltitle-for-service-worker-allowed" style="display:none">Info about the 'Service-Worker-Allowed' definition.</span><b><a href="#service-worker-allowed">#service-worker-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-allowed">6.5. Path restriction</a>
     <li><a href="#ref-for-service-worker-allowed①">Update</a>
@@ -13478,59 +13478,115 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/ServiceWorker/docs/v1/index.html
+++ b/tests/github/w3c/ServiceWorker/docs/v1/index.html
@@ -7314,53 +7314,53 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <li><a href="#dfn-worker-client">worker client</a><span>, in § 2.3</span>
    <li><a href="#dfn-job-worker-type">worker type</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-enforced">
-   <a href="https://w3c.github.io/webappsec-csp/#enforced">https://w3c.github.io/webappsec-csp/#enforced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforced" class="dfn-panel" data-for="term-for-enforced" id="infopanel-for-term-for-enforced" role="menu">
+   <span id="infopaneltitle-for-term-for-enforced" style="display:none">Info about the 'enforced' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#enforced">https://w3c.github.io/webappsec-csp/#enforced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforced">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2.10. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.5. Events</a> <a href="#ref-for-event①">(2)</a> <a href="#ref-for-event②">(3)</a>
     <li><a href="#ref-for-event③">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventtarget①">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-eventtarget②">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-concept-event-create①">Install</a>
@@ -7369,8 +7369,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-create④">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.5. Task Sources</a> <a href="#ref-for-concept-event-dispatch①">(2)</a>
     <li><a href="#ref-for-concept-event-dispatch②">3.1.4. postMessage(message, transfer)</a>
@@ -7381,38 +7381,38 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-dispatch⑦">Fire Functional Event</a> <a href="#ref-for-concept-event-dispatch⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dispatch-flag①">4.5.3. event.respondWith(r)</a>
     <li><a href="#ref-for-dispatch-flag②">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2.4.1. The window client case</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a> <a href="#ref-for-concept-document③">(4)</a>
     <li><a href="#ref-for-concept-document④">2.4. Control and Use</a> <a href="#ref-for-concept-document⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">2.1.2. Events</a> <a href="#ref-for-concept-event①">(2)</a>
     <li><a href="#ref-for-concept-event②">4.5.2. event.clientId</a>
     <li><a href="#ref-for-concept-event③">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-event-listener①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-concept-event-fire①">4.2.5. postMessage(message, transfer)</a>
@@ -7421,64 +7421,64 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-fire④">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-immediate-propagation-flag" class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag" id="infopanel-for-term-for-stop-immediate-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-immediate-propagation-flag" style="display:none">Info about the 'stop immediate propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-immediate-propagation-flag">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-propagation-flag" class="dfn-panel" data-for="term-for-stop-propagation-flag" id="infopanel-for-term-for-stop-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">Install</a>
     <li><a href="#ref-for-dom-event-type①">Activate</a>
     <li><a href="#ref-for-dom-event-type②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-completion-record-specification-type">https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'abrupt completion' external reference.</span><a href="https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-completion-record-specification-type">https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-detacharraybuffer">
-   <a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">http://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-detacharraybuffer" class="dfn-panel" data-for="term-for-sec-detacharraybuffer" id="infopanel-for-term-for-sec-detacharraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-detacharraybuffer" style="display:none">Info about the 'detacharraybuffer' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-detacharraybuffer">http://tc39.github.io/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-detacharraybuffer">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-execution-contexts">
-   <a href="http://tc39.github.io/ecma262/#sec-execution-contexts">http://tc39.github.io/ecma262/#sec-execution-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-execution-contexts" class="dfn-panel" data-for="term-for-sec-execution-contexts" id="infopanel-for-term-for-sec-execution-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-execution-contexts" style="display:none">Info about the 'execution context' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-execution-contexts">http://tc39.github.io/ecma262/#sec-execution-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-execution-contexts">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-initializehostdefinedrealm">
-   <a href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-initializehostdefinedrealm" class="dfn-panel" data-for="term-for-sec-initializehostdefinedrealm" id="infopanel-for-term-for-sec-initializehostdefinedrealm" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-initializehostdefinedrealm" style="display:none">Info about the 'initializehostdefinedrealm' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm">http://tc39.github.io/ecma262/#sec-initializehostdefinedrealm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-initializehostdefinedrealm">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-map-objects">http://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'map objects' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-map-objects">http://tc39.github.io/ecma262/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3.2.7. update()</a>
     <li><a href="#ref-for-sec-promise-objects①">3.4. ServiceWorkerContainer</a>
@@ -7497,22 +7497,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-promise-objects②⑦">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-requestdestination-report">
-   <a href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">https://fetch.spec.whatwg.org/#dom-requestdestination-report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-requestdestination-report" class="dfn-panel" data-for="term-for-dom-requestdestination-report" id="infopanel-for-term-for-dom-requestdestination-report" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-requestdestination-report" style="display:none">Info about the '"report"' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-requestdestination-report">https://fetch.spec.whatwg.org/#dom-requestdestination-report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestdestination-report">Handle Fetch</a> <a href="#ref-for-dom-requestdestination-report①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-headers①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-headers②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">4.5. FetchEvent</a> <a href="#ref-for-request①">(2)</a>
     <li><a href="#ref-for-request②">5.4. Cache</a>
@@ -7524,15 +7524,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-request①④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-requestinfo">
-   <a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-requestinfo" class="dfn-panel" data-for="term-for-requestinfo" id="infopanel-for-term-for-requestinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-requestinfo" style="display:none">Info about the 'RequestInfo' external reference.</span><a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">5.4. Cache</a> <a href="#ref-for-requestinfo①">(2)</a> <a href="#ref-for-requestinfo②">(3)</a> <a href="#ref-for-requestinfo③">(4)</a> <a href="#ref-for-requestinfo④">(5)</a> <a href="#ref-for-requestinfo⑤">(6)</a> <a href="#ref-for-requestinfo⑥">(7)</a>
     <li><a href="#ref-for-requestinfo⑦">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.5. FetchEvent</a>
     <li><a href="#ref-for-response①">4.5.3. event.respondWith(r)</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a>
@@ -7542,49 +7542,49 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-response⑨">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-response①⓪">(2)</a> <a href="#ref-for-response①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-aborted">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-aborted" class="dfn-panel" data-for="term-for-concept-response-aborted" id="infopanel-for-term-for-concept-response-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-aborted" style="display:none">Info about the 'aborted flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-aborted">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-basic">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-basic" class="dfn-panel" data-for="term-for-concept-filtered-response-basic" id="infopanel-for-term-for-concept-filtered-response-basic" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-basic" style="display:none">Info about the 'basic filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-basic">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-filtered-response-basic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body" class="dfn-panel" data-for="term-for-concept-body" id="infopanel-for-term-for-concept-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body">https://fetch.spec.whatwg.org/#concept-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body">4.5.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">4.5.3. event.respondWith(r)</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a> <a href="#ref-for-concept-response-body③">(4)</a> <a href="#ref-for-concept-response-body④">(5)</a> <a href="#ref-for-concept-response-body⑤">(6)</a> <a href="#ref-for-concept-response-body⑥">(7)</a>
     <li><a href="#ref-for-concept-response-body⑦">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-response-body⑧">Update</a> <a href="#ref-for-concept-response-body⑨">(2)</a> <a href="#ref-for-concept-response-body①⓪">(3)</a> <a href="#ref-for-concept-response-body①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-request-cache-mode①">Update</a> <a href="#ref-for-concept-request-cache-mode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-cache-state">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-cache-state">https://fetch.spec.whatwg.org/#concept-response-cache-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-cache-state" class="dfn-panel" data-for="term-for-concept-response-cache-state" id="infopanel-for-term-for-concept-response-cache-state" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-cache-state" style="display:none">Info about the 'cache state' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-cache-state">https://fetch.spec.whatwg.org/#concept-response-cache-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-cache-state">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-response-cache-state①">Update</a> <a href="#ref-for-concept-response-cache-state②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-client①">6.3.2. importScripts(urls)</a>
@@ -7592,53 +7592,53 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-client③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-clone">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-clone" class="dfn-panel" data-for="term-for-concept-response-clone" id="infopanel-for-term-for-concept-response-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-clone">https://fetch.spec.whatwg.org/#concept-response-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-clone">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-combine">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-combine" class="dfn-panel" data-for="term-for-concept-header-list-combine" id="infopanel-for-term-for-concept-header-list-combine" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-combine" style="display:none">Info about the 'combine' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-combine">Request Matches Cached Item</a> <a href="#ref-for-concept-header-list-combine①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-cors">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-cors" class="dfn-panel" data-for="term-for-concept-filtered-response-cors" id="infopanel-for-term-for-concept-filtered-response-cors" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-cors" style="display:none">Info about the 'cors filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-cors">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-destination①">Update</a>
     <li><a href="#ref-for-concept-request-destination②">Handle Fetch</a> <a href="#ref-for-concept-request-destination③">(2)</a> <a href="#ref-for-concept-request-destination④">(3)</a> <a href="#ref-for-concept-request-destination⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extract a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-header-extract-mime-type①">Update</a> <a href="#ref-for-concept-header-extract-mime-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extract-header-list-values" class="dfn-panel" data-for="term-for-extract-header-list-values" id="infopanel-for-term-for-extract-header-list-values" role="menu">
+   <span id="infopaneltitle-for-term-for-extract-header-list-values" style="display:none">Info about the 'extracting header list values' external reference.</span><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.4.1. The window client case</a>
     <li><a href="#ref-for-concept-fetch①">2.4.2. The worker client case</a>
@@ -7651,28 +7651,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-fetch①⑥">Service Worker Script Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input, init)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response" class="dfn-panel" data-for="term-for-concept-filtered-response" id="infopanel-for-term-for-concept-filtered-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response" style="display:none">Info about the 'filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-headers-guard">
-   <a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-headers-guard" class="dfn-panel" data-for="term-for-concept-headers-guard" id="infopanel-for-term-for-concept-headers-guard" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-headers-guard" style="display:none">Info about the 'guard' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-guard">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-headers-guard①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-concept-headers-guard②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header①">5.4.5. put(request, response)</a>
@@ -7681,15 +7681,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header④">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">Update</a>
     <li><a href="#ref-for-concept-request-header-list①">Request Matches Cached Item</a> <a href="#ref-for-concept-request-header-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-header-list①">5.4.5. put(request, response)</a>
@@ -7698,22 +7698,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-header-list⑥">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">2.4.1. The window client case</a>
     <li><a href="#ref-for-concept-http-fetch①">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-http-fetch②">4.7. Events</a> <a href="#ref-for-concept-http-fetch③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-request-method①">5.4.4. addAll(requests)</a>
@@ -7724,22 +7724,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-method⑥">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header-name①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-header-name②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.5.3. event.respondWith(r)</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">6.3.2. importScripts(urls)</a> <a href="#ref-for-concept-network-error③">(2)</a>
@@ -7747,46 +7747,46 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-network-error⑨">Handle Fetch</a> <a href="#ref-for-concept-network-error①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-subresource-request" class="dfn-panel" data-for="term-for-non-subresource-request" id="infopanel-for-term-for-non-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-non-subresource-request" style="display:none">Info about the 'non-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-subresource-request">Handle Fetch</a> <a href="#ref-for-non-subresource-request①">(2)</a> <a href="#ref-for-non-subresource-request②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-ok-status①">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-ok-status②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-opaque">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-opaque" class="dfn-panel" data-for="term-for-concept-filtered-response-opaque" id="infopanel-for-term-for-concept-filtered-response-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-opaque" style="display:none">Info about the 'opaque filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-parser-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-parser-metadata" class="dfn-panel" data-for="term-for-concept-request-parser-metadata" id="infopanel-for-term-for-concept-request-parser-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-parser-metadata" style="display:none">Info about the 'parser metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-request①">2.4. Control and Use</a>
@@ -7799,8 +7799,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request⑧">Request Matches Cached Item</a> <a href="#ref-for-concept-request⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request (for Request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">5.4.2. matchAll(request, options)</a> <a href="#ref-for-concept-request-request①">(2)</a>
     <li><a href="#ref-for-concept-request-request②">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-request③">(2)</a>
@@ -7810,14 +7810,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-request①⓪">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-reserved-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-reserved-client" class="dfn-panel" data-for="term-for-concept-request-reserved-client" id="infopanel-for-term-for-concept-request-reserved-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-reserved-client" style="display:none">Info about the 'reserved client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-reserved-client">https://fetch.spec.whatwg.org/#concept-request-reserved-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-reserved-client">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-response①">4.5. FetchEvent</a>
@@ -7829,24 +7829,24 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response⑨">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response (for Response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">4.5.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-response-response①">5.4.5. put(request, response)</a> <a href="#ref-for-concept-response-response②">(2)</a> <a href="#ref-for-concept-response-response③">(3)</a>
     <li><a href="#ref-for-concept-response-response④">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-response-response⑤">(2)</a> <a href="#ref-for-concept-response-response⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-request-service-workers-mode①">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-request-service-workers-mode②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-status①">5.4.5. put(request, response)</a>
@@ -7854,29 +7854,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-status③">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">4.5.3. event.respondWith(r)</a> <a href="#ref-for-concept-body-stream①">(2)</a> <a href="#ref-for-concept-body-stream②">(3)</a> <a href="#ref-for-concept-body-stream③">(4)</a> <a href="#ref-for-concept-body-stream④">(5)</a>
     <li><a href="#ref-for-concept-body-stream⑤">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subresource-request" class="dfn-panel" data-for="term-for-subresource-request" id="infopanel-for-term-for-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-subresource-request" style="display:none">Info about the 'subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">Handle Fetch</a> <a href="#ref-for-subresource-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-type①">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-response-type②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-request-url①">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-url②">(2)</a>
@@ -7888,45 +7888,45 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-url①⑤">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag" id="infopanel-for-term-for-concept-request-use-url-credentials-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" style="display:none">Info about the 'use-url-credentials flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-use-url-credentials-flag">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url">
-   <a href="https://w3c.github.io/FileAPI/#blob-url">https://w3c.github.io/FileAPI/#blob-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url" class="dfn-panel" data-for="term-for-blob-url" id="infopanel-for-term-for-blob-url" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url" style="display:none">Info about the 'blob url' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url">https://w3c.github.io/FileAPI/#blob-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url">2.4.2. The worker client case</a>
     <li><a href="#ref-for-blob-url①">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstractworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstractworker" class="dfn-panel" data-for="term-for-abstractworker" id="infopanel-for-term-for-abstractworker" role="menu">
+   <span id="infopaneltitle-for-term-for-abstractworker" style="display:none">Info about the 'AbstractWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractworker">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-domcontentloaded">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-domcontentloaded" class="dfn-panel" data-for="term-for-event-domcontentloaded" id="infopanel-for-term-for-event-domcontentloaded" role="menu">
+   <span id="infopaneltitle-for-term-for-event-domcontentloaded" style="display:none">Info about the 'DOMContentLoaded' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-domcontentloaded">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventhandler①">3.2. ServiceWorkerRegistration</a>
@@ -7934,8 +7934,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventhandler⑤">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-eventhandler⑥">(2)</a> <a href="#ref-for-eventhandler⑦">(3)</a> <a href="#ref-for-eventhandler⑧">(4)</a> <a href="#ref-for-eventhandler⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">4.2.9. focus()</a>
     <li><a href="#ref-for-location①">4.2.10. navigate(url)</a>
@@ -7944,16 +7944,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-location④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageevent">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageevent" class="dfn-panel" data-for="term-for-messageevent" id="infopanel-for-term-for-messageevent" role="menu">
+   <span id="infopaneltitle-for-term-for-messageevent" style="display:none">Info about the 'MessageEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageevent">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-messageevent①">4.2.5. postMessage(message, transfer)</a> <a href="#ref-for-messageevent②">(2)</a>
     <li><a href="#ref-for-messageevent③">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-messageport①">4.2.5. postMessage(message, transfer)</a>
@@ -7961,35 +7961,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-messageport⑥">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-navigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-navigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserializewithtransfer" class="dfn-panel" data-for="term-for-structureddeserializewithtransfer" id="infopanel-for-term-for-structureddeserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserializewithtransfer" style="display:none">Info about the 'StructuredDeserializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserializewithtransfer">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-structureddeserializewithtransfer①">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-structuredserializewithtransfer①">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.3. Service Worker Client</a>
     <li><a href="#ref-for-window①">3.1.4. postMessage(message, transfer)</a>
@@ -8000,47 +8000,47 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window⑧">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-workerglobalscope①">5. Caches</a>
     <li><a href="#ref-for-workerglobalscope②">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerlocation">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerlocation" class="dfn-panel" data-for="term-for-workerlocation" id="infopanel-for-term-for-workerlocation" role="menu">
+   <span id="infopaneltitle-for-term-for-workerlocation" style="display:none">Info about the 'WorkerLocation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerlocation">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-workernavigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-workernavigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workertype">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workertype" class="dfn-panel" data-for="term-for-workertype" id="infopanel-for-term-for-workertype" role="menu">
+   <span id="infopaneltitle-for-term-for-workertype" style="display:none">Info about the 'WorkerType' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workertype">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">2.4.1. The window client case</a>
     <li><a href="#ref-for-nav-document①">4.2.9. focus()</a> <a href="#ref-for-nav-document②">(2)</a> <a href="#ref-for-nav-document③">(3)</a>
@@ -8050,8 +8050,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-nav-document①④">Resolve Get Client Promise</a> <a href="#ref-for-nav-document①⑤">(2)</a> <a href="#ref-for-nav-document①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-active-service-worker">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-active-service-worker" class="dfn-panel" data-for="term-for-concept-environment-active-service-worker" id="infopanel-for-term-for-concept-environment-active-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-active-service-worker" style="display:none">Info about the 'active service worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-active-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-active-service-worker">2.4. Control and Use</a> <a href="#ref-for-concept-environment-active-service-worker①">(2)</a> <a href="#ref-for-concept-environment-active-service-worker②">(3)</a> <a href="#ref-for-concept-environment-active-service-worker③">(4)</a> <a href="#ref-for-concept-environment-active-service-worker①④">(5)</a> <a href="#ref-for-concept-environment-active-service-worker①⑤">(6)</a> <a href="#ref-for-concept-environment-active-service-worker①⑥">(7)</a>
     <li><a href="#ref-for-concept-environment-active-service-worker④">2.4.1. The window client case</a> <a href="#ref-for-concept-environment-active-service-worker⑤">(2)</a> <a href="#ref-for-concept-environment-active-service-worker⑥">(3)</a> <a href="#ref-for-concept-environment-active-service-worker⑦">(4)</a> <a href="#ref-for-concept-environment-active-service-worker⑧">(5)</a> <a href="#ref-for-concept-environment-active-service-worker⑨">(6)</a> <a href="#ref-for-concept-environment-active-service-worker①⓪">(7)</a>
@@ -8065,8 +8065,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-environment-active-service-worker②⑤">Handle Fetch</a> <a href="#ref-for-concept-environment-active-service-worker②⑥">(2)</a> <a href="#ref-for-concept-environment-active-service-worker②⑦">(3)</a> <a href="#ref-for-concept-environment-active-service-worker②⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" class="dfn-panel" data-for="term-for-concept-location-ancestor-origins-list" id="infopanel-for-term-for-concept-location-ancestor-origins-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-location-ancestor-origins-list" style="display:none">Info about the 'ancestor origins list' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list">https://html.spec.whatwg.org/multipage/browsers.html#concept-location-ancestor-origins-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-location-ancestor-origins-list">4.2.9. focus()</a>
     <li><a href="#ref-for-concept-location-ancestor-origins-list①">4.2.10. navigate(url)</a>
@@ -8075,8 +8075,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-location-ancestor-origins-list④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-api-base-url①">(2)</a>
     <li><a href="#ref-for-api-base-url②">3.4.4. getRegistration(clientURL)</a>
@@ -8085,26 +8085,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-api-base-url⑤">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-url-character-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-url-character-encoding" class="dfn-panel" data-for="term-for-api-url-character-encoding" id="infopanel-for-term-for-api-url-character-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-api-url-character-encoding" style="display:none">Info about the 'api url character encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-url-character-encoding">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">Get Frame Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script-base-url" class="dfn-panel" data-for="term-for-concept-script-base-url" id="infopanel-for-term-for-concept-script-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script-base-url">Update</a> <a href="#ref-for-concept-script-base-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.4.1. The window client case</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a> <a href="#ref-for-browsing-context③">(4)</a> <a href="#ref-for-browsing-context④">(5)</a>
     <li><a href="#ref-for-browsing-context⑤">4.2. Client</a>
@@ -8113,20 +8113,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-browsing-context⑧">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-classic-script" class="dfn-panel" data-for="term-for-classic-script" id="infopanel-for-term-for-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-classic-script" style="display:none">Info about the 'classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-workerglobalscope-closing">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-workerglobalscope-closing" class="dfn-panel" data-for="term-for-dom-workerglobalscope-closing" id="infopanel-for-term-for-dom-workerglobalscope-closing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-workerglobalscope-closing" style="display:none">Info about the 'closing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing">https://html.spec.whatwg.org/multipage/workers.html#dom-workerglobalscope-closing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workerglobalscope-closing">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-creation-url" class="dfn-panel" data-for="term-for-concept-environment-creation-url" id="infopanel-for-term-for-concept-environment-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-creation-url">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-environment-creation-url①">3.4.2. ready</a>
@@ -8139,8 +8139,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-environment-creation-url⑧">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4.2.9. focus()</a>
     <li><a href="#ref-for-current-global-object①">4.2.10. navigate(url)</a>
@@ -8149,14 +8149,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-current-global-object④">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-data">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-data" class="dfn-panel" data-for="term-for-dom-messageevent-data" id="infopanel-for-term-for-dom-messageevent-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-data" style="display:none">Info about the 'data' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-data">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-manipulation-task-source①">3.4.2. ready</a>
@@ -8180,20 +8180,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-manipulation-task-source②⑥">Resolve Get Client Promise</a> <a href="#ref-for-dom-manipulation-task-source②⑦">(2)</a> <a href="#ref-for-dom-manipulation-task-source②⑧">(3)</a> <a href="#ref-for-dom-manipulation-task-source②⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment" class="dfn-panel" data-for="term-for-environment" id="infopanel-for-term-for-environment" role="menu">
+   <span id="infopaneltitle-for-term-for-environment" style="display:none">Info about the 'environment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-discarding-steps">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-discarding-steps" class="dfn-panel" data-for="term-for-environment-discarding-steps" id="infopanel-for-term-for-environment-discarding-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-discarding-steps" style="display:none">Info about the 'environment discarding steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps">https://html.spec.whatwg.org/multipage/webappapis.html#environment-discarding-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-discarding-steps">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.3. Service Worker Client</a>
     <li><a href="#ref-for-environment-settings-object①">2.4.2. The worker client case</a>
@@ -8214,8 +8214,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object②⑤">Resolve Get Client Promise</a> <a href="#ref-for-environment-settings-object②⑥">(2)</a> <a href="#ref-for-environment-settings-object②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.1.5. Event handler</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">3.2.9. Event handler</a> <a href="#ref-for-event-handlers③">(2)</a>
@@ -8223,8 +8223,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handlers⑥">4.1.4. Event handlers</a> <a href="#ref-for-event-handlers⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.1.5. Event handler</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">3.2.9. Event handler</a> <a href="#ref-for-event-handler-event-type③">(2)</a>
@@ -8232,8 +8232,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-event-type⑥">4.1.4. Event handlers</a> <a href="#ref-for-event-handler-event-type⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.1.5. Event handler</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">3.2.9. Event handler</a>
@@ -8241,8 +8241,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-idl-attributes③">4.1.4. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-agent-event-loop①">2.2. Service Worker Registration</a> <a href="#ref-for-concept-agent-event-loop②">(2)</a> <a href="#ref-for-concept-agent-event-loop③">(3)</a> <a href="#ref-for-concept-agent-event-loop④">(4)</a>
@@ -8260,41 +8260,41 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-agent-event-loop①⑧">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag" id="infopanel-for-term-for-concept-environment-execution-ready-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" style="display:none">Info about the 'execution ready flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-execution-ready-flag">4.3.1. get(id)</a> <a href="#ref-for-concept-environment-execution-ready-flag①">(2)</a>
     <li><a href="#ref-for-concept-environment-execution-ready-flag②">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-concept-environment-execution-ready-flag③">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-classic-worker-script" class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script" id="infopanel-for-term-for-fetch-a-classic-worker-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-classic-worker-script" style="display:none">Info about the 'fetch a classic worker script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-classic-worker-script">Update</a> <a href="#ref-for-fetch-a-classic-worker-script①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree" id="infopanel-for-term-for-fetch-a-module-worker-script-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" style="display:none">Info about the 'fetch a module worker script graph' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-module-worker-script-tree">Update</a> <a href="#ref-for-fetch-a-module-worker-script-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusing-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusing-steps" class="dfn-panel" data-for="term-for-focusing-steps" id="infopanel-for-term-for-focusing-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-focusing-steps" style="display:none">Info about the 'focusing steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusing-steps">4.2.9. focus()</a>
     <li><a href="#ref-for-focusing-steps①">4.3.2. matchAll(options)</a> <a href="#ref-for-focusing-steps②">(2)</a> <a href="#ref-for-focusing-steps③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">2.4.2. The worker client case</a> <a href="#ref-for-global-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.3. Service Worker Client</a> <a href="#ref-for-concept-settings-object-global①">(2)</a> <a href="#ref-for-concept-settings-object-global②">(3)</a>
     <li><a href="#ref-for-concept-settings-object-global③">3.1.4. postMessage(message, transfer)</a>
@@ -8309,8 +8309,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-settings-object-global①④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-focus-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-focus-steps" class="dfn-panel" data-for="term-for-has-focus-steps" id="infopanel-for-term-for-has-focus-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-has-focus-steps" style="display:none">Info about the 'has focus steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-focus-steps">4.2.9. focus()</a>
     <li><a href="#ref-for-has-focus-steps①">4.2.10. navigate(url)</a>
@@ -8319,28 +8319,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-has-focus-steps④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-id">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-id" class="dfn-panel" data-for="term-for-concept-environment-id" id="infopanel-for-term-for-concept-environment-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-id" style="display:none">Info about the 'id' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-id">4.2.3. id</a>
     <li><a href="#ref-for-concept-environment-id①">4.3.1. get(id)</a>
     <li><a href="#ref-for-concept-environment-id②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.4.1. The window client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope" id="infopanel-for-term-for-import-scripts-into-worker-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" style="display:none">Info about the 'import scripts into worker global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-scripts-into-worker-global-scope">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-in-parallel①">3.4.2. ready</a>
@@ -8373,20 +8373,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-in-parallel③④">Handle User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-message">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-message" class="dfn-panel" data-for="term-for-event-message" id="infopanel-for-term-for-event-message" role="menu">
+   <span id="infopaneltitle-for-term-for-event-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-message">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-module-script" class="dfn-panel" data-for="term-for-module-script" id="infopanel-for-term-for-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-module-script" style="display:none">Info about the 'module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">2.4.1. The window client case</a> <a href="#ref-for-navigate①">(2)</a> <a href="#ref-for-navigate②">(3)</a>
     <li><a href="#ref-for-navigate③">3.2.8. unregister()</a>
@@ -8395,16 +8395,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-navigate⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.4.1. The window client case</a> <a href="#ref-for-concept-origin-opaque①">(2)</a> <a href="#ref-for-concept-origin-opaque②">(3)</a>
     <li><a href="#ref-for-concept-origin-opaque③">2.4.2. The worker client case</a>
     <li><a href="#ref-for-concept-origin-opaque④">2.4. Control and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-origin①">2.4.1. The window client case</a> <a href="#ref-for-concept-origin②">(2)</a> <a href="#ref-for-concept-origin③">(3)</a> <a href="#ref-for-concept-origin④">(4)</a>
@@ -8415,15 +8415,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-origin①⓪">6.3.1. Origin restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-origin">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-origin" class="dfn-panel" data-for="term-for-dom-messageevent-origin" id="infopanel-for-term-for-dom-messageevent-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-origin" style="display:none">Info about the 'origin (for MessageEvent)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-origin">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-messageevent-origin①">4.2.5. postMessage(message, transfer)</a> <a href="#ref-for-dom-messageevent-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-settings-object-origin①">3.1.4. postMessage(message, transfer)</a>
@@ -8448,26 +8448,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-settings-object-origin②⑨">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set" id="infopanel-for-term-for-concept-WorkerGlobalScope-owner-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" style="display:none">Info about the 'owner set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">2.4.2. The worker client case</a> <a href="#ref-for-concept-WorkerGlobalScope-owner-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-ports">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-ports" class="dfn-panel" data-for="term-for-dom-messageevent-ports" id="infopanel-for-term-for-dom-messageevent-ports" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-ports" style="display:none">Info about the 'ports' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-ports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-ports">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-queue-a-task①">3.1.4. postMessage(message, transfer)</a>
@@ -8498,8 +8498,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-queue-a-task④⓪">Resolve Get Client Promise</a> <a href="#ref-for-queue-a-task④①">(2)</a> <a href="#ref-for-queue-a-task④②">(3)</a> <a href="#ref-for-queue-a-task④③">(4)</a> <a href="#ref-for-queue-a-task④④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm" id="infopanel-for-term-for-environment-settings-object&apos;s-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" style="display:none">Info about the 'realm (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object's-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -8511,20 +8511,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object&apos;s-realm⑨">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'realm (for global object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">3.1.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-execution-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-execution-context" class="dfn-panel" data-for="term-for-realm-execution-context" id="infopanel-for-term-for-realm-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-execution-context" style="display:none">Info about the 'realm execution context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-execution-context">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-concept-relevant-global①">4.2.5. postMessage(message, transfer)</a>
@@ -8535,8 +8535,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-relevant-global⑦">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.2.5. postMessage(message, transfer)</a>
@@ -8550,8 +8550,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-relevant-realm⑨">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.1.4. postMessage(message, transfer)</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
     <li><a href="#ref-for-relevant-settings-object②">3.2.7. update()</a> <a href="#ref-for-relevant-settings-object③">(2)</a>
@@ -8577,8 +8577,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-relevant-settings-object③⓪">Resolve Get Client Promise</a> <a href="#ref-for-relevant-settings-object③①">(2)</a> <a href="#ref-for-relevant-settings-object③②">(3)</a> <a href="#ref-for-relevant-settings-object③③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">3.4.2. ready</a>
     <li><a href="#ref-for-responsible-event-loop①">3.4.5. getRegistrations()</a>
@@ -8602,26 +8602,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-responsible-event-loop②②">Resolve Get Client Promise</a> <a href="#ref-for-responsible-event-loop②③">(2)</a> <a href="#ref-for-responsible-event-loop②④">(3)</a> <a href="#ref-for-responsible-event-loop②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-classic-script" class="dfn-panel" data-for="term-for-run-a-classic-script" id="infopanel-for-term-for-run-a-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-classic-script" style="display:none">Info about the 'run a classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-module-script" class="dfn-panel" data-for="term-for-run-a-module-script" id="infopanel-for-term-for-run-a-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-module-script" style="display:none">Info about the 'run a module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-worker" class="dfn-panel" data-for="term-for-run-a-worker" id="infopanel-for-term-for-run-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-worker" style="display:none">Info about the 'run a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-worker">2.4.2. The worker client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.4.1. The window client case</a>
     <li><a href="#ref-for-same-origin①">2.4.2. The worker client case</a>
@@ -8635,20 +8635,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-same-origin⑨">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">2.4.1. The window client case</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script" class="dfn-panel" data-for="term-for-concept-script" id="infopanel-for-term-for-concept-script" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-secure-context①">4.3.4. claim()</a>
@@ -8657,29 +8657,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-secure-context⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageevent-source">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageevent-source" class="dfn-panel" data-for="term-for-dom-messageevent-source" id="infopanel-for-term-for-dom-messageevent-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageevent-source" style="display:none">Info about the 'source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source">https://html.spec.whatwg.org/multipage/comms.html#dom-messageevent-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageevent-source">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-messageevent-source①">4.2.5. postMessage(message, transfer)</a> <a href="#ref-for-dom-messageevent-source②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-concept-environment-target-browsing-context①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2.2. Service Worker Registration</a> <a href="#ref-for-concept-task①">(2)</a>
     <li><a href="#ref-for-concept-task②">3.4. ServiceWorkerContainer</a>
@@ -8691,16 +8691,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-task①⓪">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queues' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-task-queue①">(2)</a> <a href="#ref-for-task-queue②">(3)</a>
     <li><a href="#ref-for-task-queue③">Run Service Worker</a>
     <li><a href="#ref-for-task-queue④">Terminate Service Worker</a> <a href="#ref-for-task-queue⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2.5. Task Sources</a> <a href="#ref-for-task-source①">(2)</a> <a href="#ref-for-task-source②">(3)</a>
     <li><a href="#ref-for-task-source③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-task-source④">(2)</a>
@@ -8708,33 +8708,33 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-task-source⑥">Terminate Service Worker</a> <a href="#ref-for-task-source⑦">(2)</a> <a href="#ref-for-task-source⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-type">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-type" class="dfn-panel" data-for="term-for-concept-workerglobalscope-type" id="infopanel-for-term-for-concept-workerglobalscope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unsafe-response">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unsafe-response" class="dfn-panel" data-for="term-for-unsafe-response" id="infopanel-for-term-for-unsafe-response" role="menu">
+   <span id="infopaneltitle-for-term-for-unsafe-response" style="display:none">Info about the 'unsafe response' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-response">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-unsafe-response①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-url">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-url" class="dfn-panel" data-for="term-for-concept-workerglobalscope-url" id="infopanel-for-term-for-concept-workerglobalscope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-url" style="display:none">Info about the 'url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-url">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-interaction-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-interaction-task-source" class="dfn-panel" data-for="term-for-user-interaction-task-source" id="infopanel-for-term-for-user-interaction-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-user-interaction-task-source" style="display:none">Info about the 'user interaction task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-interaction-task-source">4.2.9. focus()</a>
     <li><a href="#ref-for-user-interaction-task-source①">4.2.10. navigate(url)</a>
@@ -8743,8 +8743,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-user-interaction-task-source④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.4.5. getRegistrations()</a> <a href="#ref-for-list-append①">(2)</a>
     <li><a href="#ref-for-list-append②">4.3.2. matchAll(options)</a> <a href="#ref-for-list-append③">(2)</a>
@@ -8754,33 +8754,33 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-append⑦">Batch Cache Operations</a> <a href="#ref-for-list-append⑧">(2)</a> <a href="#ref-for-list-append⑨">(3)</a> <a href="#ref-for-list-append①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">Run Service Worker</a>
     <li><a href="#ref-for-set-append①">Update Service Worker Extended Events Set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a> <a href="#ref-for-ascii-case-insensitive②">(3)</a> <a href="#ref-for-ascii-case-insensitive③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">Should Skip Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">4.3.1. get(id)</a>
     <li><a href="#ref-for-iteration-continue①">4.3.2. matchAll(options)</a> <a href="#ref-for-iteration-continue②">(2)</a> <a href="#ref-for-iteration-continue③">(3)</a>
@@ -8789,27 +8789,27 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-iteration-continue⑧">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-dequeue">
-   <a href="https://infra.spec.whatwg.org/#queue-dequeue">https://infra.spec.whatwg.org/#queue-dequeue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-dequeue" class="dfn-panel" data-for="term-for-queue-dequeue" id="infopanel-for-term-for-queue-dequeue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-dequeue" style="display:none">Info about the 'dequeue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-dequeue">https://infra.spec.whatwg.org/#queue-dequeue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-dequeue">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-enqueue">
-   <a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-enqueue" class="dfn-panel" data-for="term-for-queue-enqueue" id="infopanel-for-term-for-queue-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-enqueue">Schedule Job</a> <a href="#ref-for-queue-enqueue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5.1. Constructs</a>
     <li><a href="#ref-for-map-entry①">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-exists①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -8818,8 +8818,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-exists④">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-list-iterate①">4.3.2. matchAll(options)</a> <a href="#ref-for-list-iterate②">(2)</a>
@@ -8832,8 +8832,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-iterate①④">Batch Cache Operations</a> <a href="#ref-for-list-iterate①⑤">(2)</a> <a href="#ref-for-list-iterate①⑥">(3)</a> <a href="#ref-for-list-iterate①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-map-iterate①">5.5.1. match(request, options)</a> <a href="#ref-for-map-iterate②">(2)</a>
@@ -8844,8 +8844,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-iterate⑧">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'get the keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-keys①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -8854,8 +8854,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-getting-the-keys④">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">5.4.6. delete(request, options)</a>
     <li><a href="#ref-for-list-is-empty①">Run Job</a>
@@ -8863,8 +8863,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-is-empty③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.1. Service Worker</a> <a href="#ref-for-list-item①">(2)</a>
     <li><a href="#ref-for-list-item②">2.4.2. The worker client case</a> <a href="#ref-for-list-item③">(2)</a>
@@ -8877,14 +8877,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list-item①⓪">Batch Cache Operations</a> <a href="#ref-for-list-item①①">(2)</a> <a href="#ref-for-list-item①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">5.1. Constructs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys①" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys①" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-keys①">3.2.1. Getting ServiceWorkerRegistration instances</a>
@@ -8893,8 +8893,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-getting-the-keys④">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.4.5. getRegistrations()</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">4.3.2. matchAll(options)</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a>
@@ -8910,8 +8910,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-list②②">Batch Cache Operations</a> <a href="#ref-for-list②③">(2)</a> <a href="#ref-for-list②④">(3)</a> <a href="#ref-for-list②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.1. Service Worker</a>
     <li><a href="#ref-for-ordered-map①">3.1.1. Getting ServiceWorker instances</a>
@@ -8921,8 +8921,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-ordered-map⑥">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">2.1. Service Worker</a>
     <li><a href="#ref-for-ordered-map①">3.1.1. Getting ServiceWorker instances</a>
@@ -8932,29 +8932,29 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-ordered-map⑥">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.1. Service Worker</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue">
-   <a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue" class="dfn-panel" data-for="term-for-queue" id="infopanel-for-term-for-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue" style="display:none">Info about the 'queue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">Appendix A: Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">Terminate Service Worker</a>
     <li><a href="#ref-for-list-remove①">Update Service Worker Extended Events Set</a>
     <li><a href="#ref-for-list-remove②">Batch Cache Operations</a> <a href="#ref-for-list-remove③">(2)</a> <a href="#ref-for-list-remove④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">5.5.4. delete(cacheName)</a>
     <li><a href="#ref-for-map-remove①">Update</a> <a href="#ref-for-map-remove②">(2)</a>
@@ -8962,8 +8962,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-remove④">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.5.3. open(cacheName)</a>
     <li><a href="#ref-for-map-set①">6.3.2. importScripts(urls)</a>
@@ -8971,49 +8971,49 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-map-set③">Set Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">5.4. Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">5.1. Constructs</a>
     <li><a href="#ref-for-map-value①">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-map-getting-the-values①">3.2.1. Getting ServiceWorkerRegistration instances</a>
     <li><a href="#ref-for-map-getting-the-values②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-mime-type" class="dfn-panel" data-for="term-for-javascript-mime-type" id="infopanel-for-term-for-javascript-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-mime-type" style="display:none">Info about the 'javascript mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-mime-type">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-javascript-mime-type①">6.6. Service worker script request</a>
     <li><a href="#ref-for-javascript-mime-type②">Update</a> <a href="#ref-for-javascript-mime-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discarded">
-   <a href="https://wicg.github.io/page-lifecycle/#discarded">https://wicg.github.io/page-lifecycle/#discarded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discarded" class="dfn-panel" data-for="term-for-discarded" id="infopanel-for-term-for-discarded" role="menu">
+   <span id="infopaneltitle-for-term-for-discarded" style="display:none">Info about the 'discard' external reference.</span><a href="https://wicg.github.io/page-lifecycle/#discarded">https://wicg.github.io/page-lifecycle/#discarded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discarded">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VisibilityState">
-   <a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VisibilityState" class="dfn-panel" data-for="term-for-VisibilityState" id="infopanel-for-term-for-VisibilityState" role="menu">
+   <span id="infopaneltitle-for-term-for-VisibilityState" style="display:none">Info about the 'VisibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VisibilityState">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-visibilitystate" class="dfn-panel" data-for="term-for-dom-document-visibilitystate" id="infopanel-for-term-for-dom-document-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-document-visibilitystate①">4.2.9. focus()</a>
@@ -9023,125 +9023,125 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-document-visibilitystate⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-h-the-push-event">
-   <a href="https://w3c.github.io/push-api/#h-the-push-event">https://w3c.github.io/push-api/#h-the-push-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-h-the-push-event" class="dfn-panel" data-for="term-for-h-the-push-event" id="infopanel-for-term-for-h-the-push-event" role="menu">
+   <span id="infopaneltitle-for-term-for-h-the-push-event" style="display:none">Info about the 'push' external reference.</span><a href="https://w3c.github.io/push-api/#h-the-push-event">https://w3c.github.io/push-api/#h-the-push-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-h-the-push-event">2.5. Task Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy" class="dfn-panel" data-for="term-for-referrer-policy" id="infopanel-for-term-for-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'field-value' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-3.2①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-3.2②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-7.1.4①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-7.1.4②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-monitor">
-   <a href="https://w3c.github.io/mediacapture-screen-share/#dfn-monitor">https://w3c.github.io/mediacapture-screen-share/#dfn-monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-monitor" class="dfn-panel" data-for="term-for-dfn-monitor" id="infopanel-for-term-for-dfn-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://w3c.github.io/mediacapture-screen-share/#dfn-monitor">https://w3c.github.io/mediacapture-screen-share/#dfn-monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-monitor">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-origin">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-origin" class="dfn-panel" data-for="term-for-potentially-trustworthy-origin" id="infopanel-for-term-for-potentially-trustworthy-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-origin" style="display:none">Info about the 'potentially trustworthy origin' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-origin">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-url" class="dfn-panel" data-for="term-for-potentially-trustworthy-url" id="infopanel-for-term-for-potentially-trustworthy-url" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-url" style="display:none">Info about the 'potentially trustworthy url' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-url">Handle Fetch</a>
     <li><a href="#ref-for-potentially-trustworthy-url①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-cancel" class="dfn-panel" data-for="term-for-readablestream-cancel" id="infopanel-for-term-for-readablestream-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-cancel" style="display:none">Info about the 'cancel' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-cancel">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-chunk">
-   <a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-chunk" class="dfn-panel" data-for="term-for-chunk" id="infopanel-for-term-for-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-chunk" style="display:none">Info about the 'chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-close">
-   <a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-close" class="dfn-panel" data-for="term-for-readablestream-close" id="infopanel-for-term-for-readablestream-close" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-close" style="display:none">Info about the 'close' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-close">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-error">
-   <a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-error" class="dfn-panel" data-for="term-for-readablestream-error" id="infopanel-for-term-for-readablestream-error" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-error" style="display:none">Info about the 'error' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-error">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-errored">
-   <a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-errored" class="dfn-panel" data-for="term-for-readablestream-errored" id="infopanel-for-term-for-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-errored">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">4.5.3. event.respondWith(r)</a>
     <li><a href="#ref-for-readablestream-get-a-reader①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk" id="infopanel-for-term-for-readablestreamdefaultreader-read-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" style="display:none">Info about the 'read a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes" id="infopanel-for-term-for-readablestreamdefaultreader-read-all-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" style="display:none">Info about the 'read all bytes' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">Register</a>
     <li><a href="#ref-for-concept-url-equals①">Update</a>
     <li><a href="#ref-for-concept-url-equals②">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-fragment①">(2)</a> <a href="#ref-for-concept-url-fragment②">(3)</a> <a href="#ref-for-concept-url-fragment③">(4)</a> <a href="#ref-for-concept-url-fragment④">(5)</a> <a href="#ref-for-concept-url-fragment⑤">(6)</a>
     <li><a href="#ref-for-concept-url-fragment⑥">3.4.4. getRegistration(clientURL)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2.3. Service Worker Client</a>
     <li><a href="#ref-for-concept-url-origin①">3.4.5. getRegistrations()</a>
@@ -9152,22 +9152,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-origin⑦">Match Service Worker Registration</a> <a href="#ref-for-concept-url-origin⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-path①">(2)</a>
     <li><a href="#ref-for-concept-url-path②">6.5. Path restriction</a>
     <li><a href="#ref-for-concept-url-path③">Update</a> <a href="#ref-for-concept-url-path④">(2)</a> <a href="#ref-for-concept-url-path⑤">(3)</a> <a href="#ref-for-concept-url-path⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">Request Matches Cached Item</a> <a href="#ref-for-concept-url-query①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
     <li><a href="#ref-for-concept-url-scheme②">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-url-scheme③">(2)</a>
@@ -9175,8 +9175,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-scheme⑥">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">2.1. Service Worker</a> <a href="#ref-for-concept-url①">(2)</a>
     <li><a href="#ref-for-concept-url②">2.2. Service Worker Registration</a>
@@ -9188,8 +9188,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url①⓪">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-parser①">(2)</a> <a href="#ref-for-concept-url-parser②">(3)</a>
     <li><a href="#ref-for-concept-url-parser③">3.4.4. getRegistration(clientURL)</a>
@@ -9200,8 +9200,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-parser⑨">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">2.2.1. Lifetime</a>
     <li><a href="#ref-for-concept-url-serializer①">3.1.2. scriptURL</a>
@@ -9216,20 +9216,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-serializer①⑤">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-referrer-policy-from-header">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header">https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-referrer-policy-from-header" class="dfn-panel" data-for="term-for-parse-referrer-policy-from-header" id="infopanel-for-term-for-parse-referrer-policy-from-header" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-referrer-policy-from-header" style="display:none">Info about the 'parse a referrer policy from a referrer-policy header' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header">https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-referrer-policy-from-header">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2.7. update()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">3.4.4. getRegistration(clientURL)</a>
@@ -9247,8 +9247,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMException②①">Batch Cache Operations</a> <a href="#ref-for-idl-DOMException②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.2. Client</a>
     <li><a href="#ref-for-idl-DOMString①">4.3. Clients</a>
@@ -9258,8 +9258,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMString⑨">5.5. CacheStorage</a> <a href="#ref-for-idl-DOMString①⓪">(2)</a> <a href="#ref-for-idl-DOMString①①">(3)</a> <a href="#ref-for-idl-DOMString①②">(4)</a> <a href="#ref-for-idl-DOMString①③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. ServiceWorker</a>
     <li><a href="#ref-for-Exposed①">3.2. ServiceWorkerRegistration</a>
@@ -9274,8 +9274,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-Exposed①①">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-idl-frozen-array①">4.2. Client</a>
@@ -9284,21 +9284,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-frozen-array④">5.4. Cache</a> <a href="#ref-for-idl-frozen-array⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">4.2.9. focus()</a>
     <li><a href="#ref-for-invalidaccesserror①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2.7. update()</a> <a href="#ref-for-invalidstateerror①">(2)</a>
     <li><a href="#ref-for-invalidstateerror②">4.3.4. claim()</a>
@@ -9307,8 +9307,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-invalidstateerror⑦">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-NewObject①">(2)</a>
     <li><a href="#ref-for-NewObject②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-NewObject③">(2)</a> <a href="#ref-for-NewObject④">(3)</a>
@@ -9319,8 +9319,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-NewObject①⑨">5.5. CacheStorage</a> <a href="#ref-for-NewObject②⓪">(2)</a> <a href="#ref-for-NewObject②①">(3)</a> <a href="#ref-for-NewObject②②">(4)</a> <a href="#ref-for-NewObject②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-idl-promise③">(2)</a> <a href="#ref-for-idl-promise④">(3)</a> <a href="#ref-for-idl-promise⑤">(4)</a>
@@ -9333,15 +9333,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-promise②②">5.5. CacheStorage</a> <a href="#ref-for-idl-promise②③">(2)</a> <a href="#ref-for-idl-promise②④">(3)</a> <a href="#ref-for-idl-promise②⑤">(4)</a> <a href="#ref-for-idl-promise②⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://webidl.spec.whatwg.org/#quotaexceedederror">https://webidl.spec.whatwg.org/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">5.5.3. open(cacheName)</a>
     <li><a href="#ref-for-quotaexceedederror①">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.3. navigator.serviceWorker</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject②">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-SameObject③">(2)</a>
@@ -9351,8 +9351,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SameObject⑦">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. ServiceWorker</a>
     <li><a href="#ref-for-SecureContext①">3.2. ServiceWorkerRegistration</a>
@@ -9363,8 +9363,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SecureContext⑦">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-securityerror①">Register</a> <a href="#ref-for-securityerror②">(2)</a> <a href="#ref-for-securityerror③">(3)</a>
@@ -9373,8 +9373,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-securityerror⑧">Resolve Get Client Promise</a> <a href="#ref-for-securityerror⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-USVString①">3.2. ServiceWorkerRegistration</a>
@@ -9384,8 +9384,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-USVString⑨">4.6. ExtendableMessageEvent</a> <a href="#ref-for-idl-USVString①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2.8. unregister()</a>
     <li><a href="#ref-for-a-new-promise①">3.4.2. ready</a>
@@ -9404,8 +9404,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-new-promise①⑤">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2.7. update()</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a>
     <li><a href="#ref-for-a-promise-rejected-with②">5.4.2. matchAll(request, options)</a>
@@ -9415,8 +9415,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-promise-rejected-with①③">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-a-promise-resolved-with①">5.4.6. delete(request, options)</a>
@@ -9424,8 +9424,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-a-promise-resolved-with③">5.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-any①">3.4. ServiceWorkerContainer</a>
@@ -9437,8 +9437,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-any⑧">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-idl-boolean①">4.2. Client</a>
@@ -9447,8 +9447,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-boolean⑦">5.5. CacheStorage</a> <a href="#ref-for-idl-boolean⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-frozen-array" class="dfn-panel" data-for="term-for-dfn-create-frozen-array" id="infopanel-for-term-for-dfn-create-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-dfn-create-frozen-array①">4.3.2. matchAll(options)</a>
@@ -9456,8 +9456,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-create-frozen-array③">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-exception" class="dfn-panel" data-for="term-for-dfn-create-exception" id="infopanel-for-term-for-dfn-create-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-exception" style="display:none">Info about the 'created' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-create-exception①">5.4.5. put(request, response)</a>
@@ -9465,8 +9465,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-create-exception③">Reject Job Promise</a> <a href="#ref-for-dfn-create-exception④">(2)</a> <a href="#ref-for-dfn-create-exception⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception" class="dfn-panel" data-for="term-for-dfn-exception" id="infopanel-for-term-for-dfn-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception" style="display:none">Info about the 'exception' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-exception①">5.4.5. put(request, response)</a>
@@ -9474,8 +9474,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-exception③">Reject Job Promise</a> <a href="#ref-for-dfn-exception④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">4.2.5. postMessage(message, transfer)</a>
@@ -9484,15 +9484,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-frozen-array-type④">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all-promise">
-   <a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all-promise" class="dfn-panel" data-for="term-for-waiting-for-all-promise" id="infopanel-for-term-for-waiting-for-all-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all-promise" style="display:none">Info about the 'getting a promise to wait for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all-promise">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-waiting-for-all-promise①">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception-message">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception-message">https://webidl.spec.whatwg.org/#dfn-exception-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception-message" class="dfn-panel" data-for="term-for-dfn-exception-message" id="infopanel-for-term-for-dfn-exception-message" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception-message" style="display:none">Info about the 'message' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception-message">https://webidl.spec.whatwg.org/#dfn-exception-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception-message">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-exception-message①">5.4.5. put(request, response)</a>
@@ -9500,22 +9500,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-exception-message③">Reject Job Promise</a> <a href="#ref-for-dfn-exception-message④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-object①">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-partial-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-partial-interface" class="dfn-panel" data-for="term-for-dfn-partial-interface" id="infopanel-for-term-for-dfn-partial-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-partial-interface" style="display:none">Info about the 'partial interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-interface">7.1. Define API bound to Service Worker Registration</a>
     <li><a href="#ref-for-dfn-partial-interface①">7.3. Define Event Handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'reacting' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">5.4.3. add(request)</a>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">5.4.4. addAll(requests)</a>
@@ -9523,8 +9523,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled③">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-sequence①">4.2. Client</a>
@@ -9533,8 +9533,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-sequence④">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.2.10. navigate(url)</a>
     <li><a href="#ref-for-dfn-throw①">4.3.3. openWindow(url)</a>
@@ -9548,15 +9548,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-throw①④">Batch Cache Operations</a> <a href="#ref-for-dfn-throw①⑤">(2)</a> <a href="#ref-for-dfn-throw①⑥">(3)</a> <a href="#ref-for-dfn-throw①⑦">(4)</a> <a href="#ref-for-dfn-throw①⑧">(5)</a> <a href="#ref-for-dfn-throw①⑨">(6)</a> <a href="#ref-for-dfn-throw②⓪">(7)</a> <a href="#ref-for-dfn-throw②①">(8)</a> <a href="#ref-for-dfn-throw②②">(9)</a> <a href="#ref-for-dfn-throw②③">(10)</a> <a href="#ref-for-dfn-throw②④">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-upon-fulfillment①">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-upon-rejection①">4.5.3. event.respondWith(r)</a>
@@ -10161,8 +10161,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dfn-service-worker">
-   <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker" class="dfn-panel" data-for="dfn-service-worker" id="infopanel-for-dfn-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1. Motivations</a> <a href="#ref-for-dfn-service-worker①">(2)</a> <a href="#ref-for-dfn-service-worker②">(3)</a> <a href="#ref-for-dfn-service-worker③">(4)</a> <a href="#ref-for-dfn-service-worker④">(5)</a> <a href="#ref-for-dfn-service-worker⑤">(6)</a> <a href="#ref-for-dfn-service-worker⑥">(7)</a> <a href="#ref-for-dfn-service-worker⑦">(8)</a> <a href="#ref-for-dfn-service-worker⑧">(9)</a> <a href="#ref-for-dfn-service-worker⑨">(10)</a> <a href="#ref-for-dfn-service-worker①⓪">(11)</a> <a href="#ref-for-dfn-service-worker①①">(12)</a> <a href="#ref-for-dfn-service-worker①②">(13)</a> <a href="#ref-for-dfn-service-worker①③">(14)</a>
     <li><a href="#ref-for-dfn-service-worker①④">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker①⑤">(2)</a> <a href="#ref-for-dfn-service-worker①⑥">(3)</a> <a href="#ref-for-dfn-service-worker①⑦">(4)</a> <a href="#ref-for-dfn-service-worker①⑧">(5)</a> <a href="#ref-for-dfn-service-worker①⑨">(6)</a> <a href="#ref-for-dfn-service-worker②⓪">(7)</a> <a href="#ref-for-dfn-service-worker②①">(8)</a> <a href="#ref-for-dfn-service-worker②②">(9)</a> <a href="#ref-for-dfn-service-worker②③">(10)</a> <a href="#ref-for-dfn-service-worker②④">(11)</a> <a href="#ref-for-dfn-service-worker②⑤">(12)</a> <a href="#ref-for-dfn-service-worker②⑧">(13)</a> <a href="#ref-for-dfn-service-worker②⑨">(14)</a>
@@ -10209,16 +10209,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker①⓪⑤">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-state">
-   <b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-state" class="dfn-panel" data-for="dfn-state" id="infopanel-for-dfn-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state①">(2)</a> <a href="#ref-for-dfn-state②">(3)</a>
     <li><a href="#ref-for-dfn-state③">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-dfn-state④">Update Worker State</a> <a href="#ref-for-dfn-state⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-url">
-   <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-url" class="dfn-panel" data-for="dfn-script-url" id="infopanel-for-dfn-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url">3.1.2. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url①">3.2.7. update()</a>
@@ -10229,8 +10229,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-url⑧">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type">
-   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type" class="dfn-panel" data-for="dfn-type" id="infopanel-for-dfn-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.2.7. update()</a>
     <li><a href="#ref-for-dfn-type①">Update</a>
@@ -10238,8 +10238,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-type③">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-service-worker-registration">
-   <b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-service-worker-registration" class="dfn-panel" data-for="dfn-containing-service-worker-registration" id="infopanel-for-dfn-containing-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-service-worker-registration" style="display:none">Info about the 'containing service worker registration' definition.</span><b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.4. Control and Use</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration①">3.2.8. unregister()</a>
@@ -10254,8 +10254,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-containing-service-worker-registration①④">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-global-object">
-   <b><a href="#dfn-service-worker-global-object">#dfn-service-worker-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-global-object" class="dfn-panel" data-for="dfn-service-worker-global-object" id="infopanel-for-dfn-service-worker-global-object" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#dfn-service-worker-global-object">#dfn-service-worker-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-global-object">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-service-worker-global-object①">Install</a>
@@ -10266,8 +10266,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-global-object⑥">Fire Functional Event</a> <a href="#ref-for-dfn-service-worker-global-object⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource">
-   <b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource" class="dfn-panel" data-for="dfn-script-resource" id="infopanel-for-dfn-script-resource" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource" style="display:none">Info about the 'script resource' definition.</span><b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource①">(2)</a> <a href="#ref-for-dfn-script-resource②">(3)</a>
     <li><a href="#ref-for-dfn-script-resource③">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource④">(2)</a>
@@ -10278,92 +10278,92 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-resource①④">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
-   <b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag" id="infopanel-for-dfn-has-ever-been-evaluated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" style="display:none">Info about the 'has ever been evaluated flag' definition.</span><b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-has-ever-been-evaluated-flag">Run Service Worker</a> <a href="#ref-for-dfn-has-ever-been-evaluated-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-https-state">
-   <b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-https-state" class="dfn-panel" data-for="dfn-https-state" id="infopanel-for-dfn-https-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-https-state" style="display:none">Info about the 'HTTPS state' definition.</span><b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-https-state">Update</a>
     <li><a href="#ref-for-dfn-https-state①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-referrer-policy">
-   <b><a href="#dfn-referrer-policy">#dfn-referrer-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-referrer-policy" class="dfn-panel" data-for="dfn-referrer-policy" id="infopanel-for-dfn-referrer-policy" role="dialog">
+   <span id="infopaneltitle-for-dfn-referrer-policy" style="display:none">Info about the 'referrer policy' definition.</span><b><a href="#dfn-referrer-policy">#dfn-referrer-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-referrer-policy">Update</a>
     <li><a href="#ref-for-dfn-referrer-policy①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource-map">
-   <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource-map" class="dfn-panel" data-for="dfn-script-resource-map" id="infopanel-for-dfn-script-resource-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource-map" style="display:none">Info about the 'script resource map' definition.</span><b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map①">(2)</a>
     <li><a href="#ref-for-dfn-script-resource-map②">6.8. Privacy</a>
     <li><a href="#ref-for-dfn-script-resource-map③">Update</a> <a href="#ref-for-dfn-script-resource-map④">(2)</a> <a href="#ref-for-dfn-script-resource-map⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
-   <b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-skip-waiting-flag" class="dfn-panel" data-for="dfn-skip-waiting-flag" id="infopanel-for-dfn-skip-waiting-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-skip-waiting-flag" style="display:none">Info about the 'skip waiting flag' definition.</span><b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag">3.5. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag①">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag②">Try Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-classic-scripts-imported-flag">
-   <b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-classic-scripts-imported-flag" class="dfn-panel" data-for="dfn-classic-scripts-imported-flag" id="infopanel-for-dfn-classic-scripts-imported-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-classic-scripts-imported-flag" style="display:none">Info about the 'classic scripts imported flag' definition.</span><b><a href="#dfn-classic-scripts-imported-flag">#dfn-classic-scripts-imported-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-classic-scripts-imported-flag">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-classic-scripts-imported-flag①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
-   <b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-event-types-to-handle" class="dfn-panel" data-for="dfn-set-of-event-types-to-handle" id="infopanel-for-dfn-set-of-event-types-to-handle" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-event-types-to-handle" style="display:none">Info about the 'set of event types to handle' definition.</span><b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle①">Should Skip Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-extended-events">
-   <b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-extended-events" class="dfn-panel" data-for="dfn-set-of-extended-events" id="infopanel-for-dfn-set-of-extended-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-extended-events" style="display:none">Info about the 'set of extended events' definition.</span><b><a href="#dfn-set-of-extended-events">#dfn-set-of-extended-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-extended-events">Terminate Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-extended-events①">Update Service Worker Extended Events Set</a> <a href="#ref-for-dfn-set-of-extended-events②">(2)</a> <a href="#ref-for-dfn-set-of-extended-events③">(3)</a>
     <li><a href="#ref-for-dfn-set-of-extended-events④">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-start-status">
-   <b><a href="#service-worker-start-status">#service-worker-start-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-start-status" class="dfn-panel" data-for="service-worker-start-status" id="infopanel-for-service-worker-start-status" role="dialog">
+   <span id="infopaneltitle-for-service-worker-start-status" style="display:none">Info about the 'start status' definition.</span><b><a href="#service-worker-start-status">#service-worker-start-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-start-status">Run Service Worker</a> <a href="#ref-for-service-worker-start-status①">(2)</a> <a href="#ref-for-service-worker-start-status②">(3)</a> <a href="#ref-for-service-worker-start-status③">(4)</a>
     <li><a href="#ref-for-service-worker-start-status④">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-running">
-   <b><a href="#service-worker-running">#service-worker-running</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-running" class="dfn-panel" data-for="service-worker-running" id="infopanel-for-service-worker-running" role="dialog">
+   <span id="infopaneltitle-for-service-worker-running" style="display:none">Info about the 'running' definition.</span><b><a href="#service-worker-running">#service-worker-running</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-running">Run Service Worker</a> <a href="#ref-for-service-worker-running①">(2)</a> <a href="#ref-for-service-worker-running②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-events">
-   <b><a href="#dfn-service-worker-events">#dfn-service-worker-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-events" class="dfn-panel" data-for="dfn-service-worker-events" id="infopanel-for-dfn-service-worker-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-events" style="display:none">Info about the 'service worker events' definition.</span><b><a href="#dfn-service-worker-events">#dfn-service-worker-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-events">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-lifecycle-events">
-   <b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-lifecycle-events" class="dfn-panel" data-for="dfn-lifecycle-events" id="infopanel-for-dfn-lifecycle-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-lifecycle-events" style="display:none">Info about the 'Lifecycle events' definition.</span><b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lifecycle-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-lifecycle-events①">4.7. Events</a> <a href="#ref-for-dfn-lifecycle-events②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-functional-events">
-   <b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-functional-events" class="dfn-panel" data-for="dfn-functional-events" id="infopanel-for-dfn-functional-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-functional-events" style="display:none">Info about the 'Functional events' definition.</span><b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-functional-events">2.5. Task Sources</a>
     <li><a href="#ref-for-dfn-functional-events①">4.4. ExtendableEvent</a>
@@ -10374,8 +10374,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-functional-events①②">7.4. Firing Functional Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration" id="infopanel-for-dfn-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration①">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration②">(2)</a> <a href="#ref-for-dfn-service-worker-registration③">(3)</a> <a href="#ref-for-dfn-service-worker-registration④">(4)</a> <a href="#ref-for-dfn-service-worker-registration⑤">(5)</a> <a href="#ref-for-dfn-service-worker-registration⑥">(6)</a> <a href="#ref-for-dfn-service-worker-registration⑦">(7)</a> <a href="#ref-for-dfn-service-worker-registration⑧">(8)</a> <a href="#ref-for-dfn-service-worker-registration⑨">(9)</a> <a href="#ref-for-dfn-service-worker-registration①⓪">(10)</a> <a href="#ref-for-dfn-service-worker-registration①①">(11)</a> <a href="#ref-for-dfn-service-worker-registration①②">(12)</a> <a href="#ref-for-dfn-service-worker-registration①③">(13)</a> <a href="#ref-for-dfn-service-worker-registration①④">(14)</a> <a href="#ref-for-dfn-service-worker-registration①⑤">(15)</a> <a href="#ref-for-dfn-service-worker-registration①⑥">(16)</a> <a href="#ref-for-dfn-service-worker-registration①⑦">(17)</a>
@@ -10408,8 +10408,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration⑤⑧">Get Newest Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-url">
-   <b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-url" class="dfn-panel" data-for="dfn-scope-url" id="infopanel-for-dfn-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-scope-url①">(2)</a> <a href="#ref-for-dfn-scope-url②">(3)</a> <a href="#ref-for-dfn-scope-url③">(4)</a>
     <li><a href="#ref-for-dfn-scope-url④">2.2.1. Lifetime</a>
@@ -10427,8 +10427,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-url②⓪">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-installing-worker">
-   <b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-installing-worker" class="dfn-panel" data-for="dfn-installing-worker" id="infopanel-for-dfn-installing-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-installing-worker" style="display:none">Info about the 'installing worker' definition.</span><b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-installing-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-installing-worker①">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker②">(2)</a>
@@ -10444,8 +10444,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-installing-worker②①">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-waiting-worker">
-   <b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-waiting-worker" class="dfn-panel" data-for="dfn-waiting-worker" id="infopanel-for-dfn-waiting-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-waiting-worker" style="display:none">Info about the 'waiting worker' definition.</span><b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-waiting-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-waiting-worker①">2.6. User Agent Shutdown</a>
@@ -10461,8 +10461,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-waiting-worker②③">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-active-worker">
-   <b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-active-worker" class="dfn-panel" data-for="dfn-active-worker" id="infopanel-for-dfn-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-active-worker①">(2)</a> <a href="#ref-for-dfn-active-worker②">(3)</a> <a href="#ref-for-dfn-active-worker③">(4)</a> <a href="#ref-for-dfn-active-worker④">(5)</a> <a href="#ref-for-dfn-active-worker⑤">(6)</a>
     <li><a href="#ref-for-dfn-active-worker⑥">2.6. User Agent Shutdown</a>
@@ -10487,16 +10487,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-active-worker④⑦">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker④⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-last-update-check-time">
-   <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-last-update-check-time" class="dfn-panel" data-for="dfn-last-update-check-time" id="infopanel-for-dfn-last-update-check-time" role="dialog">
+   <span id="infopaneltitle-for-dfn-last-update-check-time" style="display:none">Info about the 'last update check time' definition.</span><b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-last-update-check-time①">(2)</a>
     <li><a href="#ref-for-dfn-last-update-check-time②">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-last-update-check-time③">Update</a> <a href="#ref-for-dfn-last-update-check-time④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-stale">
-   <b><a href="#service-worker-registration-stale">#service-worker-registration-stale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-stale" class="dfn-panel" data-for="service-worker-registration-stale" id="infopanel-for-service-worker-registration-stale" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-stale" style="display:none">Info about the 'stale' definition.</span><b><a href="#service-worker-registration-stale">#service-worker-registration-stale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-stale">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-service-worker-registration-stale①">Update</a> <a href="#ref-for-service-worker-registration-stale②">(2)</a>
@@ -10504,8 +10504,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-registration-stale④">Fire Functional Event</a> <a href="#ref-for-service-worker-registration-stale⑤">(2)</a> <a href="#ref-for-service-worker-registration-stale⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-update-via-cache">
-   <b><a href="#dfn-update-via-cache">#dfn-update-via-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-update-via-cache" class="dfn-panel" data-for="dfn-update-via-cache" id="infopanel-for-dfn-update-via-cache" role="dialog">
+   <span id="infopaneltitle-for-dfn-update-via-cache" style="display:none">Info about the 'update via cache mode' definition.</span><b><a href="#dfn-update-via-cache">#dfn-update-via-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-update-via-cache">3.2.6. updateViaCache</a>
     <li><a href="#ref-for-dfn-update-via-cache①">6.3.2. importScripts(urls)</a>
@@ -10514,16 +10514,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-update-via-cache⑤">Set Registration</a> <a href="#ref-for-dfn-update-via-cache⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
-   <b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-task-queue" class="dfn-panel" data-for="dfn-service-worker-registration-task-queue" id="infopanel-for-dfn-service-worker-registration-task-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-task-queue" style="display:none">Info about the 'task queues' definition.</span><b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration-task-queue①">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue②">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue③">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-unregistered">
-   <b><a href="#dfn-service-worker-registration-unregistered">#dfn-service-worker-registration-unregistered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-unregistered" class="dfn-panel" data-for="dfn-service-worker-registration-unregistered" id="infopanel-for-dfn-service-worker-registration-unregistered" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-unregistered" style="display:none">Info about the 'unregistered' definition.</span><b><a href="#dfn-service-worker-registration-unregistered">#dfn-service-worker-registration-unregistered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered①">4.3.4. claim()</a>
@@ -10531,8 +10531,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration-unregistered③">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client">
-   <b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client" id="infopanel-for-dfn-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client①">2.1.1. Lifetime</a>
@@ -10567,8 +10567,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client⑤⓪">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-client-discarded-flag">
-   <b><a href="#service-worker-client-discarded-flag">#service-worker-client-discarded-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-client-discarded-flag" class="dfn-panel" data-for="service-worker-client-discarded-flag" id="infopanel-for-service-worker-client-discarded-flag" role="dialog">
+   <span id="infopaneltitle-for-service-worker-client-discarded-flag" style="display:none">Info about the 'discarded flag' definition.</span><b><a href="#service-worker-client-discarded-flag">#service-worker-client-discarded-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-discarded-flag">2.3. Service Worker Client</a> <a href="#ref-for-service-worker-client-discarded-flag①">(2)</a>
     <li><a href="#ref-for-service-worker-client-discarded-flag②">4.3.1. get(id)</a>
@@ -10577,8 +10577,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-client-discarded-flag⑤">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-client-origin">
-   <b><a href="#service-worker-client-origin">#service-worker-client-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-client-origin" class="dfn-panel" data-for="service-worker-client-origin" id="infopanel-for-service-worker-client-origin" role="dialog">
+   <span id="infopaneltitle-for-service-worker-client-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#service-worker-client-origin">#service-worker-client-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-client-origin">2.4.2. The worker client case</a> <a href="#ref-for-service-worker-client-origin①">(2)</a>
     <li><a href="#ref-for-service-worker-client-origin②">4.3.1. get(id)</a>
@@ -10586,8 +10586,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-client-origin④">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-window-client">
-   <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-window-client" class="dfn-panel" data-for="dfn-window-client" id="infopanel-for-dfn-window-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-window-client" style="display:none">Info about the 'window client' definition.</span><b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-window-client">2.4.1. The window client case</a> <a href="#ref-for-dfn-window-client①">(2)</a> <a href="#ref-for-dfn-window-client②">(3)</a> <a href="#ref-for-dfn-window-client③">(4)</a> <a href="#ref-for-dfn-window-client④">(5)</a> <a href="#ref-for-dfn-window-client⑤">(6)</a> <a href="#ref-for-dfn-window-client⑥">(7)</a>
     <li><a href="#ref-for-dfn-window-client⑦">2.4. Control and Use</a> <a href="#ref-for-dfn-window-client⑧">(2)</a>
@@ -10597,16 +10597,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-window-client①④">Resolve Get Client Promise</a> <a href="#ref-for-dfn-window-client①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
-   <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dedicatedworker-client" class="dfn-panel" data-for="dfn-dedicatedworker-client" id="infopanel-for-dfn-dedicatedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-dedicatedworker-client" style="display:none">Info about the 'dedicated worker client' definition.</span><b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client①">4.2.4. type</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client②">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-sharedworker-client">
-   <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-sharedworker-client" class="dfn-panel" data-for="dfn-sharedworker-client" id="infopanel-for-dfn-sharedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-sharedworker-client" style="display:none">Info about the 'shared worker client' definition.</span><b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-sharedworker-client①">4.2.4. type</a>
@@ -10614,16 +10614,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-sharedworker-client③">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-worker-client">
-   <b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-worker-client" class="dfn-panel" data-for="dfn-worker-client" id="infopanel-for-dfn-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-worker-client" style="display:none">Info about the 'worker client' definition.</span><b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-worker-client">2.4.2. The worker client case</a> <a href="#ref-for-dfn-worker-client①">(2)</a> <a href="#ref-for-dfn-worker-client②">(3)</a> <a href="#ref-for-dfn-worker-client③">(4)</a> <a href="#ref-for-dfn-worker-client④">(5)</a> <a href="#ref-for-dfn-worker-client⑤">(6)</a> <a href="#ref-for-dfn-worker-client⑥">(7)</a> <a href="#ref-for-dfn-worker-client⑦">(8)</a>
     <li><a href="#ref-for-dfn-worker-client⑧">2.4. Control and Use</a> <a href="#ref-for-dfn-worker-client⑨">(2)</a>
     <li><a href="#ref-for-dfn-worker-client①⓪">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-worker-client①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-control">
-   <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-control" class="dfn-panel" data-for="dfn-control" id="infopanel-for-dfn-control" role="dialog">
+   <span id="infopaneltitle-for-dfn-control" style="display:none">Info about the 'controlled' definition.</span><b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control">2.4. Control and Use</a>
     <li><a href="#ref-for-dfn-control①">3.2.8. unregister()</a>
@@ -10631,8 +10631,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-control③">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-use">
-   <b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-use" class="dfn-panel" data-for="dfn-use" id="infopanel-for-dfn-use" role="dialog">
+   <span id="infopaneltitle-for-dfn-use" style="display:none">Info about the 'using' definition.</span><b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use">3.5. Events</a>
     <li><a href="#ref-for-dfn-use①">4.1.3. skipWaiting()</a>
@@ -10644,24 +10644,24 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-use⑧">Try Clear Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
-   <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-fetch-task-source" class="dfn-panel" data-for="dfn-handle-fetch-task-source" id="infopanel-for-dfn-handle-fetch-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-fetch-task-source" style="display:none">Info about the 'handle fetch task source' definition.</span><b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source①">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source②">(2)</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
-   <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-functional-event-task-source" class="dfn-panel" data-for="dfn-handle-functional-event-task-source" id="infopanel-for-dfn-handle-functional-event-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-functional-event-task-source" style="display:none">Info about the 'handle functional event task source' definition.</span><b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source①">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source②">(2)</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source③">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworker">
-   <b><a href="#serviceworker">#serviceworker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworker" class="dfn-panel" data-for="serviceworker" id="infopanel-for-serviceworker" role="dialog">
+   <span id="infopaneltitle-for-serviceworker" style="display:none">Info about the 'ServiceWorker' definition.</span><b><a href="#serviceworker">#serviceworker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">2.1.1. Lifetime</a>
     <li><a href="#ref-for-serviceworker①">3.1. ServiceWorker</a> <a href="#ref-for-serviceworker②">(2)</a> <a href="#ref-for-serviceworker③">(3)</a> <a href="#ref-for-serviceworker④">(4)</a> <a href="#ref-for-serviceworker⑤">(5)</a> <a href="#ref-for-serviceworker⑥">(6)</a>
@@ -10677,22 +10677,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworker②①">4.6. ExtendableMessageEvent</a> <a href="#ref-for-serviceworker②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-serviceworkerstate">
-   <b><a href="#enumdef-serviceworkerstate">#enumdef-serviceworkerstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-serviceworkerstate" class="dfn-panel" data-for="enumdef-serviceworkerstate" id="infopanel-for-enumdef-serviceworkerstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-serviceworkerstate" style="display:none">Info about the 'ServiceWorkerState' definition.</span><b><a href="#enumdef-serviceworkerstate">#enumdef-serviceworkerstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-serviceworkerstate">3.1. ServiceWorker</a> <a href="#ref-for-enumdef-serviceworkerstate①">(2)</a>
     <li><a href="#ref-for-enumdef-serviceworkerstate②">3.1.3. state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-service-worker-object-map">
-   <b><a href="#environment-settings-object-service-worker-object-map">#environment-settings-object-service-worker-object-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-service-worker-object-map" class="dfn-panel" data-for="environment-settings-object-service-worker-object-map" id="infopanel-for-environment-settings-object-service-worker-object-map" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-service-worker-object-map" style="display:none">Info about the 'service worker object map' definition.</span><b><a href="#environment-settings-object-service-worker-object-map">#environment-settings-object-service-worker-object-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-service-worker-object-map">3.1.1. Getting ServiceWorker instances</a>
     <li><a href="#ref-for-environment-settings-object-service-worker-object-map①">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-service-worker-object">
-   <b><a href="#get-the-service-worker-object">#get-the-service-worker-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-service-worker-object" class="dfn-panel" data-for="get-the-service-worker-object" id="infopanel-for-get-the-service-worker-object" role="dialog">
+   <span id="infopaneltitle-for-get-the-service-worker-object" style="display:none">Info about the 'get the service worker object' definition.</span><b><a href="#get-the-service-worker-object">#get-the-service-worker-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-service-worker-object">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-get-the-service-worker-object①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-get-the-service-worker-object②">(2)</a> <a href="#ref-for-get-the-service-worker-object③">(3)</a>
@@ -10701,15 +10701,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-the-service-worker-object⑥">Update Registration State</a> <a href="#ref-for-get-the-service-worker-object⑦">(2)</a> <a href="#ref-for-get-the-service-worker-object⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-scripturl">
-   <b><a href="#dom-serviceworker-scripturl">#dom-serviceworker-scripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-scripturl" class="dfn-panel" data-for="dom-serviceworker-scripturl" id="infopanel-for-dom-serviceworker-scripturl" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-scripturl" style="display:none">Info about the 'scriptURL' definition.</span><b><a href="#dom-serviceworker-scripturl">#dom-serviceworker-scripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-scripturl">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-scripturl①">3.1.2. scriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-state">
-   <b><a href="#dom-serviceworker-state">#dom-serviceworker-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-state" class="dfn-panel" data-for="dom-serviceworker-state" id="infopanel-for-dom-serviceworker-state" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-serviceworker-state">#dom-serviceworker-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-state">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-state①">3.1.1. Getting ServiceWorker instances</a>
@@ -10718,21 +10718,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworker-state④">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-postmessage">
-   <b><a href="#dom-serviceworker-postmessage">#dom-serviceworker-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-postmessage" class="dfn-panel" data-for="dom-serviceworker-postmessage" id="infopanel-for-dom-serviceworker-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-postmessage" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#dom-serviceworker-postmessage">#dom-serviceworker-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-postmessage">3.1. ServiceWorker</a>
     <li><a href="#ref-for-dom-serviceworker-postmessage①">3.1.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworker-onstatechange">
-   <b><a href="#dom-serviceworker-onstatechange">#dom-serviceworker-onstatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworker-onstatechange" class="dfn-panel" data-for="dom-serviceworker-onstatechange" id="infopanel-for-dom-serviceworker-onstatechange" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworker-onstatechange" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#dom-serviceworker-onstatechange">#dom-serviceworker-onstatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworker-onstatechange">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration">
-   <b><a href="#serviceworkerregistration">#serviceworkerregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration" class="dfn-panel" data-for="serviceworkerregistration" id="infopanel-for-serviceworkerregistration" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' definition.</span><b><a href="#serviceworkerregistration">#serviceworkerregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">2.2.1. Lifetime</a>
     <li><a href="#ref-for-serviceworkerregistration①">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-serviceworkerregistration②">(2)</a>
@@ -10746,15 +10746,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerregistration①④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache">
-   <b><a href="#enumdef-serviceworkerupdateviacache">#enumdef-serviceworkerupdateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-serviceworkerupdateviacache" class="dfn-panel" data-for="enumdef-serviceworkerupdateviacache" id="infopanel-for-enumdef-serviceworkerupdateviacache" role="dialog">
+   <span id="infopaneltitle-for-enumdef-serviceworkerupdateviacache" style="display:none">Info about the 'ServiceWorkerUpdateViaCache' definition.</span><b><a href="#enumdef-serviceworkerupdateviacache">#enumdef-serviceworkerupdateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-serviceworkerupdateviacache">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-enumdef-serviceworkerupdateviacache①">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerregistration-service-worker-registration">
-   <b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerregistration-service-worker-registration" class="dfn-panel" data-for="serviceworkerregistration-service-worker-registration" id="infopanel-for-serviceworkerregistration-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerregistration-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#serviceworkerregistration-service-worker-registration">#serviceworkerregistration-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration">3.2.1. Getting ServiceWorkerRegistration instances</a>
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration①">3.2.5. scope</a>
@@ -10765,14 +10765,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerregistration-service-worker-registration⑥">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-service-worker-registration-object-map">
-   <b><a href="#environment-settings-object-service-worker-registration-object-map">#environment-settings-object-service-worker-registration-object-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-settings-object-service-worker-registration-object-map" class="dfn-panel" data-for="environment-settings-object-service-worker-registration-object-map" id="infopanel-for-environment-settings-object-service-worker-registration-object-map" role="dialog">
+   <span id="infopaneltitle-for-environment-settings-object-service-worker-registration-object-map" style="display:none">Info about the 'service worker registration object map' definition.</span><b><a href="#environment-settings-object-service-worker-registration-object-map">#environment-settings-object-service-worker-registration-object-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object-service-worker-registration-object-map">3.2.1. Getting ServiceWorkerRegistration instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-service-worker-registration-object">
-   <b><a href="#get-the-service-worker-registration-object">#get-the-service-worker-registration-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-service-worker-registration-object" class="dfn-panel" data-for="get-the-service-worker-registration-object" id="infopanel-for-get-the-service-worker-registration-object" role="dialog">
+   <span id="infopaneltitle-for-get-the-service-worker-registration-object" style="display:none">Info about the 'get the service worker registration object' definition.</span><b><a href="#get-the-service-worker-registration-object">#get-the-service-worker-registration-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-service-worker-registration-object">3.4.2. ready</a>
     <li><a href="#ref-for-get-the-service-worker-registration-object①">3.4.4. getRegistration(clientURL)</a>
@@ -10782,8 +10782,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-the-service-worker-registration-object⑥">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-installing">
-   <b><a href="#dom-serviceworkerregistration-installing">#dom-serviceworkerregistration-installing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-installing" class="dfn-panel" data-for="dom-serviceworkerregistration-installing" id="infopanel-for-dom-serviceworkerregistration-installing" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-installing" style="display:none">Info about the 'installing' definition.</span><b><a href="#dom-serviceworkerregistration-installing">#dom-serviceworkerregistration-installing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-installing">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-installing①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-installing②">(2)</a>
@@ -10791,8 +10791,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-installing④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-waiting">
-   <b><a href="#dom-serviceworkerregistration-waiting">#dom-serviceworkerregistration-waiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-waiting" class="dfn-panel" data-for="dom-serviceworkerregistration-waiting" id="infopanel-for-dom-serviceworkerregistration-waiting" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-waiting" style="display:none">Info about the 'waiting' definition.</span><b><a href="#dom-serviceworkerregistration-waiting">#dom-serviceworkerregistration-waiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-waiting②">(2)</a>
@@ -10800,8 +10800,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-waiting④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-active">
-   <b><a href="#dom-serviceworkerregistration-active">#dom-serviceworkerregistration-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-active" class="dfn-panel" data-for="dom-serviceworkerregistration-active" id="infopanel-for-dom-serviceworkerregistration-active" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-active" style="display:none">Info about the 'active' definition.</span><b><a href="#dom-serviceworkerregistration-active">#dom-serviceworkerregistration-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-active">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-active①">3.2.1. Getting ServiceWorkerRegistration instances</a> <a href="#ref-for-dom-serviceworkerregistration-active②">(2)</a>
@@ -10809,48 +10809,48 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-serviceworkerregistration-active④">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-scope">
-   <b><a href="#dom-serviceworkerregistration-scope">#dom-serviceworkerregistration-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-scope" class="dfn-panel" data-for="dom-serviceworkerregistration-scope" id="infopanel-for-dom-serviceworkerregistration-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-serviceworkerregistration-scope">#dom-serviceworkerregistration-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-scope">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-scope①">3.2.5. scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-updateviacache">
-   <b><a href="#dom-serviceworkerregistration-updateviacache">#dom-serviceworkerregistration-updateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-updateviacache" class="dfn-panel" data-for="dom-serviceworkerregistration-updateviacache" id="infopanel-for-dom-serviceworkerregistration-updateviacache" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-updateviacache" style="display:none">Info about the 'updateViaCache' definition.</span><b><a href="#dom-serviceworkerregistration-updateviacache">#dom-serviceworkerregistration-updateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-updateviacache">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-updateviacache①">3.2.6. updateViaCache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-update">
-   <b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-update" class="dfn-panel" data-for="dom-serviceworkerregistration-update" id="infopanel-for-dom-serviceworkerregistration-update" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-update" style="display:none">Info about the 'update()' definition.</span><b><a href="#dom-serviceworkerregistration-update">#dom-serviceworkerregistration-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-update">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-update①">3.2.7. update()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-unregister">
-   <b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-unregister" class="dfn-panel" data-for="dom-serviceworkerregistration-unregister" id="infopanel-for-dom-serviceworkerregistration-unregister" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-unregister" style="display:none">Info about the 'unregister()' definition.</span><b><a href="#dom-serviceworkerregistration-unregister">#dom-serviceworkerregistration-unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-unregister①">3.2.8. unregister()</a> <a href="#ref-for-dom-serviceworkerregistration-unregister②">(2)</a> <a href="#ref-for-dom-serviceworkerregistration-unregister③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound">
-   <b><a href="#dom-serviceworkerregistration-onupdatefound">#dom-serviceworkerregistration-onupdatefound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-onupdatefound" class="dfn-panel" data-for="dom-serviceworkerregistration-onupdatefound" id="infopanel-for-dom-serviceworkerregistration-onupdatefound" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-onupdatefound" style="display:none">Info about the 'onupdatefound' definition.</span><b><a href="#dom-serviceworkerregistration-onupdatefound">#dom-serviceworkerregistration-onupdatefound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-onupdatefound">3.2. ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-service-worker-attribute">
-   <b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-service-worker-attribute" class="dfn-panel" data-for="navigator-service-worker-attribute" id="infopanel-for-navigator-service-worker-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-service-worker-attribute" style="display:none">Info about the 'serviceWorker' definition.</span><b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-service-worker-attribute">3.3. navigator.serviceWorker</a> <a href="#ref-for-navigator-service-worker-attribute①">(2)</a> <a href="#ref-for-navigator-service-worker-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer">
-   <b><a href="#serviceworkercontainer">#serviceworkercontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer" class="dfn-panel" data-for="serviceworkercontainer" id="infopanel-for-serviceworkercontainer" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer" style="display:none">Info about the 'ServiceWorkerContainer' definition.</span><b><a href="#serviceworkercontainer">#serviceworkercontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer">3.3. navigator.serviceWorker</a> <a href="#ref-for-serviceworkercontainer①">(2)</a> <a href="#ref-for-serviceworkercontainer②">(3)</a>
     <li><a href="#ref-for-serviceworkercontainer③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-serviceworkercontainer④">(2)</a> <a href="#ref-for-serviceworkercontainer⑤">(3)</a> <a href="#ref-for-serviceworkercontainer⑥">(4)</a> <a href="#ref-for-serviceworkercontainer⑦">(5)</a> <a href="#ref-for-serviceworkercontainer⑧">(6)</a> <a href="#ref-for-serviceworkercontainer⑨">(7)</a> <a href="#ref-for-serviceworkercontainer①⓪">(8)</a> <a href="#ref-for-serviceworkercontainer①①">(9)</a>
@@ -10861,32 +10861,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkercontainer①⑥">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-registrationoptions">
-   <b><a href="#dictdef-registrationoptions">#dictdef-registrationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-registrationoptions" class="dfn-panel" data-for="dictdef-registrationoptions" id="infopanel-for-dictdef-registrationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-registrationoptions" style="display:none">Info about the 'RegistrationOptions' definition.</span><b><a href="#dictdef-registrationoptions">#dictdef-registrationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-registrationoptions">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-scope">
-   <b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-scope" class="dfn-panel" data-for="dom-registrationoptions-scope" id="infopanel-for-dom-registrationoptions-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-scope">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-registrationoptions-scope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-type">
-   <b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-type" class="dfn-panel" data-for="dom-registrationoptions-type" id="infopanel-for-dom-registrationoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-type">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-updateviacache">
-   <b><a href="#dom-registrationoptions-updateviacache">#dom-registrationoptions-updateviacache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-updateviacache" class="dfn-panel" data-for="dom-registrationoptions-updateviacache" id="infopanel-for-dom-registrationoptions-updateviacache" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-updateviacache" style="display:none">Info about the 'updateViaCache' definition.</span><b><a href="#dom-registrationoptions-updateviacache">#dom-registrationoptions-updateviacache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-updateviacache">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer-service-worker-client">
-   <b><a href="#serviceworkercontainer-service-worker-client">#serviceworkercontainer-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer-service-worker-client" class="dfn-panel" data-for="serviceworkercontainer-service-worker-client" id="infopanel-for-serviceworkercontainer-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#serviceworkercontainer-service-worker-client">#serviceworkercontainer-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client">3.4.1. controller</a>
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client①">3.4.2. ready</a>
@@ -10898,15 +10898,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkercontainer-service-worker-client⑦">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkercontainer-ready-promise">
-   <b><a href="#serviceworkercontainer-ready-promise">#serviceworkercontainer-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkercontainer-ready-promise" class="dfn-panel" data-for="serviceworkercontainer-ready-promise" id="infopanel-for-serviceworkercontainer-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-serviceworkercontainer-ready-promise" style="display:none">Info about the 'ready promise' definition.</span><b><a href="#serviceworkercontainer-ready-promise">#serviceworkercontainer-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer-ready-promise">3.4.2. ready</a> <a href="#ref-for-serviceworkercontainer-ready-promise①">(2)</a> <a href="#ref-for-serviceworkercontainer-ready-promise②">(3)</a> <a href="#ref-for-serviceworkercontainer-ready-promise③">(4)</a>
     <li><a href="#ref-for-serviceworkercontainer-ready-promise④">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-client-message-queue">
-   <b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-client-message-queue" class="dfn-panel" data-for="dfn-client-message-queue" id="infopanel-for-dfn-client-message-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-client-message-queue" style="display:none">Info about the 'client message queue' definition.</span><b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-client-message-queue">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue①">(2)</a> <a href="#ref-for-dfn-client-message-queue②">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue③">3.4.6. startMessages()</a>
@@ -10914,89 +10914,89 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-client-message-queue⑤">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-controller">
-   <b><a href="#dom-serviceworkercontainer-controller">#dom-serviceworkercontainer-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-controller" class="dfn-panel" data-for="dom-serviceworkercontainer-controller" id="infopanel-for-dom-serviceworkercontainer-controller" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-controller" style="display:none">Info about the 'controller' definition.</span><b><a href="#dom-serviceworkercontainer-controller">#dom-serviceworkercontainer-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller①">3.4.1. controller</a> <a href="#ref-for-dom-serviceworkercontainer-controller②">(2)</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-controller③">3.5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-ready">
-   <b><a href="#dom-serviceworkercontainer-ready">#dom-serviceworkercontainer-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-ready" class="dfn-panel" data-for="dom-serviceworkercontainer-ready" id="infopanel-for-dom-serviceworkercontainer-ready" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#dom-serviceworkercontainer-ready">#dom-serviceworkercontainer-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-ready">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-ready①">3.4.2. ready</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-register">
-   <b><a href="#dom-serviceworkercontainer-register">#dom-serviceworkercontainer-register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-register" class="dfn-panel" data-for="dom-serviceworkercontainer-register" id="infopanel-for-dom-serviceworkercontainer-register" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-register" style="display:none">Info about the 'register(scriptURL, options)' definition.</span><b><a href="#dom-serviceworkercontainer-register">#dom-serviceworkercontainer-register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-register">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-register①">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-serviceworkercontainer-register②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-getregistration">
-   <b><a href="#dom-serviceworkercontainer-getregistration">#dom-serviceworkercontainer-getregistration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-getregistration" class="dfn-panel" data-for="dom-serviceworkercontainer-getregistration" id="infopanel-for-dom-serviceworkercontainer-getregistration" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-getregistration" style="display:none">Info about the 'getRegistration(clientURL)' definition.</span><b><a href="#dom-serviceworkercontainer-getregistration">#dom-serviceworkercontainer-getregistration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistration">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistration①">3.4.4. getRegistration(clientURL)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-getregistrations">
-   <b><a href="#dom-serviceworkercontainer-getregistrations">#dom-serviceworkercontainer-getregistrations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-getregistrations" class="dfn-panel" data-for="dom-serviceworkercontainer-getregistrations" id="infopanel-for-dom-serviceworkercontainer-getregistrations" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-getregistrations" style="display:none">Info about the 'getRegistrations()' definition.</span><b><a href="#dom-serviceworkercontainer-getregistrations">#dom-serviceworkercontainer-getregistrations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistrations">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-getregistrations①">3.4.5. getRegistrations()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-startmessages">
-   <b><a href="#dom-serviceworkercontainer-startmessages">#dom-serviceworkercontainer-startmessages</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-startmessages" class="dfn-panel" data-for="dom-serviceworkercontainer-startmessages" id="infopanel-for-dom-serviceworkercontainer-startmessages" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-startmessages" style="display:none">Info about the 'startMessages()' definition.</span><b><a href="#dom-serviceworkercontainer-startmessages">#dom-serviceworkercontainer-startmessages</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-startmessages">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-startmessages①">3.4.6. startMessages()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-oncontrollerchange">
-   <b><a href="#dom-serviceworkercontainer-oncontrollerchange">#dom-serviceworkercontainer-oncontrollerchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-oncontrollerchange" class="dfn-panel" data-for="dom-serviceworkercontainer-oncontrollerchange" id="infopanel-for-dom-serviceworkercontainer-oncontrollerchange" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-oncontrollerchange" style="display:none">Info about the 'oncontrollerchange' definition.</span><b><a href="#dom-serviceworkercontainer-oncontrollerchange">#dom-serviceworkercontainer-oncontrollerchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-oncontrollerchange">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-onmessage">
-   <b><a href="#dom-serviceworkercontainer-onmessage">#dom-serviceworkercontainer-onmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-onmessage" class="dfn-panel" data-for="dom-serviceworkercontainer-onmessage" id="infopanel-for-dom-serviceworkercontainer-onmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-onmessage" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#dom-serviceworkercontainer-onmessage">#dom-serviceworkercontainer-onmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessage">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessage①">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkercontainer-onmessageerror">
-   <b><a href="#dom-serviceworkercontainer-onmessageerror">#dom-serviceworkercontainer-onmessageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkercontainer-onmessageerror" class="dfn-panel" data-for="dom-serviceworkercontainer-onmessageerror" id="infopanel-for-dom-serviceworkercontainer-onmessageerror" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkercontainer-onmessageerror" style="display:none">Info about the 'onmessageerror' definition.</span><b><a href="#dom-serviceworkercontainer-onmessageerror">#dom-serviceworkercontainer-onmessageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkercontainer-onmessageerror">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworker-statechange">
-   <b><a href="#eventdef-serviceworker-statechange">#eventdef-serviceworker-statechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworker-statechange" class="dfn-panel" data-for="eventdef-serviceworker-statechange" id="infopanel-for-eventdef-serviceworker-statechange" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworker-statechange" style="display:none">Info about the 'statechange' definition.</span><b><a href="#eventdef-serviceworker-statechange">#eventdef-serviceworker-statechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworker-statechange">3.1.5. Event handler</a>
     <li><a href="#ref-for-eventdef-serviceworker-statechange①">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
-   <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-updatefound-event" class="dfn-panel" data-for="service-worker-registration-updatefound-event" id="infopanel-for-service-worker-registration-updatefound-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-updatefound-event" style="display:none">Info about the 'updatefound' definition.</span><b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-updatefound-event">3.2.9. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
-   <b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controllerchange-event" class="dfn-panel" data-for="service-worker-container-controllerchange-event" id="infopanel-for-service-worker-container-controllerchange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controllerchange-event" style="display:none">Info about the 'controllerchange' definition.</span><b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controllerchange-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope">
-   <b><a href="#serviceworkerglobalscope">#serviceworkerglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope" class="dfn-panel" data-for="serviceworkerglobalscope" id="infopanel-for-serviceworkerglobalscope" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' definition.</span><b><a href="#serviceworkerglobalscope">#serviceworkerglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">2.1. Service Worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope①">3.1.4. postMessage(message, transfer)</a> <a href="#ref-for-serviceworkerglobalscope②">(2)</a>
@@ -11011,8 +11011,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerglobalscope①⑥">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope-service-worker">
-   <b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope-service-worker" class="dfn-panel" data-for="serviceworkerglobalscope-service-worker" id="infopanel-for-serviceworkerglobalscope-service-worker" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#serviceworkerglobalscope-service-worker">#serviceworkerglobalscope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker①">3.2.7. update()</a>
@@ -11030,67 +11030,67 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker②③">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">
-   <b><a href="#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" class="dfn-panel" data-for="serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" id="infopanel-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" role="dialog">
+   <span id="infopaneltitle-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag" style="display:none">Info about the 'force bypass cache for import scripts flag' definition.</span><b><a href="#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">#serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-serviceworkerglobalscope-force-bypass-cache-for-import-scripts-flag①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients">
-   <b><a href="#dom-serviceworkerglobalscope-clients">#dom-serviceworkerglobalscope-clients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-clients" class="dfn-panel" data-for="dom-serviceworkerglobalscope-clients" id="infopanel-for-dom-serviceworkerglobalscope-clients" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-clients" style="display:none">Info about the 'clients' definition.</span><b><a href="#dom-serviceworkerglobalscope-clients">#dom-serviceworkerglobalscope-clients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-clients">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-clients①">4.1.1. clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-registration">
-   <b><a href="#dom-serviceworkerglobalscope-registration">#dom-serviceworkerglobalscope-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-registration" class="dfn-panel" data-for="dom-serviceworkerglobalscope-registration" id="infopanel-for-dom-serviceworkerglobalscope-registration" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-registration" style="display:none">Info about the 'registration' definition.</span><b><a href="#dom-serviceworkerglobalscope-registration">#dom-serviceworkerglobalscope-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-registration">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-registration①">4.1.2. registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-skipwaiting">
-   <b><a href="#dom-serviceworkerglobalscope-skipwaiting">#dom-serviceworkerglobalscope-skipwaiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-skipwaiting" class="dfn-panel" data-for="dom-serviceworkerglobalscope-skipwaiting" id="infopanel-for-dom-serviceworkerglobalscope-skipwaiting" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-skipwaiting" style="display:none">Info about the 'skipWaiting()' definition.</span><b><a href="#dom-serviceworkerglobalscope-skipwaiting">#dom-serviceworkerglobalscope-skipwaiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting①">4.1.3. skipWaiting()</a> <a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting②">(2)</a>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-skipwaiting③">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall">
-   <b><a href="#dom-serviceworkerglobalscope-oninstall">#dom-serviceworkerglobalscope-oninstall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-oninstall" class="dfn-panel" data-for="dom-serviceworkerglobalscope-oninstall" id="infopanel-for-dom-serviceworkerglobalscope-oninstall" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-oninstall" style="display:none">Info about the 'oninstall' definition.</span><b><a href="#dom-serviceworkerglobalscope-oninstall">#dom-serviceworkerglobalscope-oninstall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-oninstall">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onactivate">
-   <b><a href="#dom-serviceworkerglobalscope-onactivate">#dom-serviceworkerglobalscope-onactivate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onactivate" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onactivate" id="infopanel-for-dom-serviceworkerglobalscope-onactivate" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onactivate" style="display:none">Info about the 'onactivate' definition.</span><b><a href="#dom-serviceworkerglobalscope-onactivate">#dom-serviceworkerglobalscope-onactivate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onactivate">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onfetch">
-   <b><a href="#dom-serviceworkerglobalscope-onfetch">#dom-serviceworkerglobalscope-onfetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onfetch" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onfetch" id="infopanel-for-dom-serviceworkerglobalscope-onfetch" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onfetch" style="display:none">Info about the 'onfetch' definition.</span><b><a href="#dom-serviceworkerglobalscope-onfetch">#dom-serviceworkerglobalscope-onfetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onfetch">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessage">
-   <b><a href="#dom-serviceworkerglobalscope-onmessage">#dom-serviceworkerglobalscope-onmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onmessage" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessage" id="infopanel-for-dom-serviceworkerglobalscope-onmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onmessage" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#dom-serviceworkerglobalscope-onmessage">#dom-serviceworkerglobalscope-onmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onmessage">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessageerror">
-   <b><a href="#dom-serviceworkerglobalscope-onmessageerror">#dom-serviceworkerglobalscope-onmessageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onmessageerror" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onmessageerror" id="infopanel-for-dom-serviceworkerglobalscope-onmessageerror" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onmessageerror" style="display:none">Info about the 'onmessageerror' definition.</span><b><a href="#dom-serviceworkerglobalscope-onmessageerror">#dom-serviceworkerglobalscope-onmessageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onmessageerror">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client">
-   <b><a href="#client">#client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client" class="dfn-panel" data-for="client" id="infopanel-for-client" role="dialog">
+   <span id="infopaneltitle-for-client" style="display:none">Info about the 'Client' definition.</span><b><a href="#client">#client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-client①">4.2. Client</a> <a href="#ref-for-client②">(2)</a> <a href="#ref-for-client③">(3)</a> <a href="#ref-for-client④">(4)</a>
@@ -11101,8 +11101,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-client①⓪">Create Client</a> <a href="#ref-for-client①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windowclient">
-   <b><a href="#windowclient">#windowclient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windowclient" class="dfn-panel" data-for="windowclient" id="infopanel-for-windowclient" role="dialog">
+   <span id="infopaneltitle-for-windowclient" style="display:none">Info about the 'WindowClient' definition.</span><b><a href="#windowclient">#windowclient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowclient">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-windowclient①">4.2. Client</a> <a href="#ref-for-windowclient②">(2)</a> <a href="#ref-for-windowclient③">(3)</a> <a href="#ref-for-windowclient④">(4)</a> <a href="#ref-for-windowclient⑤">(5)</a> <a href="#ref-for-windowclient⑥">(6)</a>
@@ -11111,14 +11111,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-windowclient①⓪">Create Window Client</a> <a href="#ref-for-windowclient①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-frametype">
-   <b><a href="#enumdef-frametype">#enumdef-frametype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-frametype" class="dfn-panel" data-for="enumdef-frametype" id="infopanel-for-enumdef-frametype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-frametype" style="display:none">Info about the 'FrameType' definition.</span><b><a href="#enumdef-frametype">#enumdef-frametype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-frametype">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-service-worker-client">
-   <b><a href="#dfn-service-worker-client-service-worker-client">#dfn-service-worker-client-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client-service-worker-client" id="infopanel-for-dfn-service-worker-client-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client-service-worker-client">#dfn-service-worker-client-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client">4.2. Client</a>
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client①">4.2.1. url</a>
@@ -11132,203 +11132,203 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-service-worker-client①④">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-frame-type">
-   <b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="dfn-service-worker-client-frame-type" id="infopanel-for-dfn-service-worker-client-frame-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' definition.</span><b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">4.2.2. frameType</a>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-browsing-context">
-   <b><a href="#dfn-service-worker-client-browsing-context">#dfn-service-worker-client-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-browsing-context" class="dfn-panel" data-for="dfn-service-worker-client-browsing-context" id="infopanel-for-dfn-service-worker-client-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-browsing-context" style="display:none">Info about the 'browsing context' definition.</span><b><a href="#dfn-service-worker-client-browsing-context">#dfn-service-worker-client-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context">4.2.9. focus()</a> <a href="#ref-for-dfn-service-worker-client-browsing-context①">(2)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context②">(3)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context③">(4)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context④">(5)</a>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context⑤">4.2.10. navigate(url)</a>
     <li><a href="#ref-for-dfn-service-worker-client-browsing-context⑥">4.3.2. matchAll(options)</a> <a href="#ref-for-dfn-service-worker-client-browsing-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
-   <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-visibilitystate" class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate" id="infopanel-for-dfn-service-worker-client-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-visibilitystate" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">4.2.6. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
-   <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-focusstate" class="dfn-panel" data-for="dfn-service-worker-client-focusstate" id="infopanel-for-dfn-service-worker-client-focusstate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-focusstate" style="display:none">Info about the 'focus state' definition.</span><b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.7. focused</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate①">4.2.9. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate②">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windowclient-ancestor-origins-array">
-   <b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windowclient-ancestor-origins-array" class="dfn-panel" data-for="windowclient-ancestor-origins-array" id="infopanel-for-windowclient-ancestor-origins-array" role="dialog">
+   <span id="infopaneltitle-for-windowclient-ancestor-origins-array" style="display:none">Info about the 'ancestor origins array' definition.</span><b><a href="#windowclient-ancestor-origins-array">#windowclient-ancestor-origins-array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowclient-ancestor-origins-array">4.2.8. ancestorOrigins</a>
     <li><a href="#ref-for-windowclient-ancestor-origins-array①">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-url">
-   <b><a href="#dom-client-url">#dom-client-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-url" class="dfn-panel" data-for="dom-client-url" id="infopanel-for-dom-client-url" role="dialog">
+   <span id="infopaneltitle-for-dom-client-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-client-url">#dom-client-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-url">4.2. Client</a>
     <li><a href="#ref-for-dom-client-url①">4.2.1. url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-frametype">
-   <b><a href="#dom-client-frametype">#dom-client-frametype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-frametype" class="dfn-panel" data-for="dom-client-frametype" id="infopanel-for-dom-client-frametype" role="dialog">
+   <span id="infopaneltitle-for-dom-client-frametype" style="display:none">Info about the 'frameType' definition.</span><b><a href="#dom-client-frametype">#dom-client-frametype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-frametype">4.2. Client</a>
     <li><a href="#ref-for-dom-client-frametype①">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-id">
-   <b><a href="#dom-client-id">#dom-client-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-id" class="dfn-panel" data-for="dom-client-id" id="infopanel-for-dom-client-id" role="dialog">
+   <span id="infopaneltitle-for-dom-client-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-client-id">#dom-client-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-id">4.2. Client</a>
     <li><a href="#ref-for-dom-client-id①">4.2.3. id</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-type">
-   <b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-type" class="dfn-panel" data-for="dom-client-type" id="infopanel-for-dom-client-type" role="dialog">
+   <span id="infopaneltitle-for-dom-client-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-client-type">#dom-client-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-type">4.2. Client</a>
     <li><a href="#ref-for-dom-client-type①">4.2.4. type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-postmessage">
-   <b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-postmessage" class="dfn-panel" data-for="dom-client-postmessage" id="infopanel-for-dom-client-postmessage" role="dialog">
+   <span id="infopaneltitle-for-dom-client-postmessage" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#dom-client-postmessage">#dom-client-postmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-postmessage">4.2. Client</a>
     <li><a href="#ref-for-dom-client-postmessage①">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-visibilitystate">
-   <b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-visibilitystate" class="dfn-panel" data-for="dom-windowclient-visibilitystate" id="infopanel-for-dom-windowclient-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-visibilitystate" style="display:none">Info about the 'visibilityState' definition.</span><b><a href="#dom-windowclient-visibilitystate">#dom-windowclient-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-visibilitystate①">4.2.6. visibilityState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-focused">
-   <b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-focused" class="dfn-panel" data-for="dom-windowclient-focused" id="infopanel-for-dom-windowclient-focused" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-focused" style="display:none">Info about the 'focused' definition.</span><b><a href="#dom-windowclient-focused">#dom-windowclient-focused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focused">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-focused①">4.2.7. focused</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-ancestororigins">
-   <b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-ancestororigins" class="dfn-panel" data-for="dom-windowclient-ancestororigins" id="infopanel-for-dom-windowclient-ancestororigins" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-ancestororigins" style="display:none">Info about the 'ancestorOrigins' definition.</span><b><a href="#dom-windowclient-ancestororigins">#dom-windowclient-ancestororigins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-ancestororigins">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-ancestororigins①">4.2.8. ancestorOrigins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-focus">
-   <b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-focus" class="dfn-panel" data-for="dom-windowclient-focus" id="infopanel-for-dom-windowclient-focus" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-focus" style="display:none">Info about the 'focus()' definition.</span><b><a href="#dom-windowclient-focus">#dom-windowclient-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-focus">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-focus①">4.2.9. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-navigate">
-   <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-navigate" class="dfn-panel" data-for="dom-windowclient-navigate" id="infopanel-for-dom-windowclient-navigate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-navigate" style="display:none">Info about the 'navigate(url)' definition.</span><b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate">4.2. Client</a>
     <li><a href="#ref-for-dom-windowclient-navigate①">4.2.10. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients">
-   <b><a href="#clients">#clients</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients" class="dfn-panel" data-for="clients" id="infopanel-for-clients" role="dialog">
+   <span id="infopaneltitle-for-clients" style="display:none">Info about the 'Clients' definition.</span><b><a href="#clients">#clients</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-clients①">4.1.1. clients</a>
     <li><a href="#ref-for-clients②">4.3. Clients</a> <a href="#ref-for-clients③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clientqueryoptions">
-   <b><a href="#dictdef-clientqueryoptions">#dictdef-clientqueryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clientqueryoptions" class="dfn-panel" data-for="dictdef-clientqueryoptions" id="infopanel-for-dictdef-clientqueryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clientqueryoptions" style="display:none">Info about the 'ClientQueryOptions' definition.</span><b><a href="#dictdef-clientqueryoptions">#dictdef-clientqueryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clientqueryoptions">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled">
-   <b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled" id="infopanel-for-dom-clientqueryoptions-includeuncontrolled" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" style="display:none">Info about the 'includeUncontrolled' definition.</span><b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-includeuncontrolled">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-type">
-   <b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-type" class="dfn-panel" data-for="dom-clientqueryoptions-type" id="infopanel-for-dom-clientqueryoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-type">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clientqueryoptions-type①">(2)</a> <a href="#ref-for-dom-clientqueryoptions-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-clienttype">
-   <b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-clienttype" class="dfn-panel" data-for="enumdef-clienttype" id="infopanel-for-enumdef-clienttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-clienttype" style="display:none">Info about the 'ClientType' definition.</span><b><a href="#enumdef-clienttype">#enumdef-clienttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-clienttype">4.2. Client</a>
     <li><a href="#ref-for-enumdef-clienttype①">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-window">
-   <b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-window" class="dfn-panel" data-for="dom-clienttype-window" id="infopanel-for-dom-clienttype-window" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-window" style="display:none">Info about the '"window"' definition.</span><b><a href="#dom-clienttype-window">#dom-clienttype-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-window">4.2.4. type</a> <a href="#ref-for-dom-clienttype-window①">(2)</a>
     <li><a href="#ref-for-dom-clienttype-window②">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-worker">
-   <b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-worker" class="dfn-panel" data-for="dom-clienttype-worker" id="infopanel-for-dom-clienttype-worker" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-worker" style="display:none">Info about the '"worker"' definition.</span><b><a href="#dom-clienttype-worker">#dom-clienttype-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-worker">4.2.4. type</a>
     <li><a href="#ref-for-dom-clienttype-worker①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-sharedworker">
-   <b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-sharedworker" class="dfn-panel" data-for="dom-clienttype-sharedworker" id="infopanel-for-dom-clienttype-sharedworker" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-sharedworker" style="display:none">Info about the '"sharedworker"' definition.</span><b><a href="#dom-clienttype-sharedworker">#dom-clienttype-sharedworker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-sharedworker">4.2.4. type</a>
     <li><a href="#ref-for-dom-clienttype-sharedworker①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clienttype-all">
-   <b><a href="#dom-clienttype-all">#dom-clienttype-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clienttype-all" class="dfn-panel" data-for="dom-clienttype-all" id="infopanel-for-dom-clienttype-all" role="dialog">
+   <span id="infopaneltitle-for-dom-clienttype-all" style="display:none">Info about the '"all"' definition.</span><b><a href="#dom-clienttype-all">#dom-clienttype-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clienttype-all">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clienttype-all①">(2)</a> <a href="#ref-for-dom-clienttype-all②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-get">
-   <b><a href="#dom-clients-get">#dom-clients-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-get" class="dfn-panel" data-for="dom-clients-get" id="infopanel-for-dom-clients-get" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-get" style="display:none">Info about the 'get(id)' definition.</span><b><a href="#dom-clients-get">#dom-clients-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-get">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-get①">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-matchall">
-   <b><a href="#dom-clients-matchall">#dom-clients-matchall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-matchall" class="dfn-panel" data-for="dom-clients-matchall" id="infopanel-for-dom-clients-matchall" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-matchall" style="display:none">Info about the 'matchAll(options)' definition.</span><b><a href="#dom-clients-matchall">#dom-clients-matchall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-matchall">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-matchall①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-openwindow">
-   <b><a href="#dom-clients-openwindow">#dom-clients-openwindow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-openwindow" class="dfn-panel" data-for="dom-clients-openwindow" id="infopanel-for-dom-clients-openwindow" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-openwindow" style="display:none">Info about the 'openWindow(url)' definition.</span><b><a href="#dom-clients-openwindow">#dom-clients-openwindow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-openwindow">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-openwindow①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clients-claim">
-   <b><a href="#dom-clients-claim">#dom-clients-claim</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clients-claim" class="dfn-panel" data-for="dom-clients-claim" id="infopanel-for-dom-clients-claim" role="dialog">
+   <span id="infopaneltitle-for-dom-clients-claim" style="display:none">Info about the 'claim()' definition.</span><b><a href="#dom-clients-claim">#dom-clients-claim</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clients-claim">4.3. Clients</a>
     <li><a href="#ref-for-dom-clients-claim①">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent">
-   <b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent" class="dfn-panel" data-for="extendableevent" id="infopanel-for-extendableevent" role="dialog">
+   <span id="infopaneltitle-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' definition.</span><b><a href="#extendableevent">#extendableevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">2.1. Service Worker</a>
     <li><a href="#ref-for-extendableevent①">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent②">(2)</a> <a href="#ref-for-extendableevent③">(3)</a> <a href="#ref-for-extendableevent④">(4)</a> <a href="#ref-for-extendableevent⑤">(5)</a> <a href="#ref-for-extendableevent⑥">(6)</a> <a href="#ref-for-extendableevent⑦">(7)</a> <a href="#ref-for-extendableevent⑧">(8)</a>
@@ -11341,37 +11341,37 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendableevent①⑧">Fire Functional Event</a> <a href="#ref-for-extendableevent①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
-   <b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendableeventinit" class="dfn-panel" data-for="dictdef-extendableeventinit" id="infopanel-for-dictdef-extendableeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' definition.</span><b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit①">4.5. FetchEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit②">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-extend-lifetime-promises">
-   <b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-extend-lifetime-promises" class="dfn-panel" data-for="extendableevent-extend-lifetime-promises" id="infopanel-for-extendableevent-extend-lifetime-promises" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' definition.</span><b><a href="#extendableevent-extend-lifetime-promises">#extendableevent-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-extend-lifetime-promises①">(2)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises②">(3)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises③">(4)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises④">(5)</a> <a href="#ref-for-extendableevent-extend-lifetime-promises⑤">(6)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises⑥">Install</a> <a href="#ref-for-extendableevent-extend-lifetime-promises⑦">(2)</a>
     <li><a href="#ref-for-extendableevent-extend-lifetime-promises⑧">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-pending-promises-count">
-   <b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-pending-promises-count" class="dfn-panel" data-for="extendableevent-pending-promises-count" id="infopanel-for-extendableevent-pending-promises-count" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-pending-promises-count" style="display:none">Info about the 'pending promises count' definition.</span><b><a href="#extendableevent-pending-promises-count">#extendableevent-pending-promises-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-pending-promises-count">4.4. ExtendableEvent</a> <a href="#ref-for-extendableevent-pending-promises-count①">(2)</a> <a href="#ref-for-extendableevent-pending-promises-count②">(3)</a> <a href="#ref-for-extendableevent-pending-promises-count③">(4)</a> <a href="#ref-for-extendableevent-pending-promises-count④">(5)</a> <a href="#ref-for-extendableevent-pending-promises-count⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-timed-out-flag">
-   <b><a href="#extendableevent-timed-out-flag">#extendableevent-timed-out-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-timed-out-flag" class="dfn-panel" data-for="extendableevent-timed-out-flag" id="infopanel-for-extendableevent-timed-out-flag" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-timed-out-flag" style="display:none">Info about the 'timed out flag' definition.</span><b><a href="#extendableevent-timed-out-flag">#extendableevent-timed-out-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-timed-out-flag">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendableevent-timed-out-flag①">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-active">
-   <b><a href="#extendableevent-active">#extendableevent-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-active" class="dfn-panel" data-for="extendableevent-active" id="infopanel-for-extendableevent-active" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-active" style="display:none">Info about the 'active' definition.</span><b><a href="#extendableevent-active">#extendableevent-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-active">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendableevent-active①">Install</a>
@@ -11380,8 +11380,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendableevent-active⑤">Service Worker Has No Pending Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendableevent-waituntil">
-   <b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendableevent-waituntil" class="dfn-panel" data-for="dom-extendableevent-waituntil" id="infopanel-for-dom-extendableevent-waituntil" role="dialog">
+   <span id="infopaneltitle-for-dom-extendableevent-waituntil" style="display:none">Info about the 'waitUntil(f)' definition.</span><b><a href="#dom-extendableevent-waituntil">#dom-extendableevent-waituntil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendableevent-waituntil">4.4. ExtendableEvent</a> <a href="#ref-for-dom-extendableevent-waituntil③">(2)</a>
     <li><a href="#ref-for-dom-extendableevent-waituntil①">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-dom-extendableevent-waituntil②">(2)</a>
@@ -11389,134 +11389,134 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-extendableevent-waituntil⑤">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendableevent-add-lifetime-promise">
-   <b><a href="#extendableevent-add-lifetime-promise">#extendableevent-add-lifetime-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendableevent-add-lifetime-promise" class="dfn-panel" data-for="extendableevent-add-lifetime-promise" id="infopanel-for-extendableevent-add-lifetime-promise" role="dialog">
+   <span id="infopaneltitle-for-extendableevent-add-lifetime-promise" style="display:none">Info about the 'add lifetime promise' definition.</span><b><a href="#extendableevent-add-lifetime-promise">#extendableevent-add-lifetime-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent-add-lifetime-promise">4.4.1. event.waitUntil(f)</a>
     <li><a href="#ref-for-extendableevent-add-lifetime-promise①">4.5.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent">
-   <b><a href="#fetchevent">#fetchevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent" class="dfn-panel" data-for="fetchevent" id="infopanel-for-fetchevent" role="dialog">
+   <span id="infopaneltitle-for-fetchevent" style="display:none">Info about the 'FetchEvent' definition.</span><b><a href="#fetchevent">#fetchevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent">4.5. FetchEvent</a> <a href="#ref-for-fetchevent①">(2)</a> <a href="#ref-for-fetchevent②">(3)</a>
     <li><a href="#ref-for-fetchevent③">4.7. Events</a>
     <li><a href="#ref-for-fetchevent④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fetcheventinit">
-   <b><a href="#dictdef-fetcheventinit">#dictdef-fetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fetcheventinit" class="dfn-panel" data-for="dictdef-fetcheventinit" id="infopanel-for-dictdef-fetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fetcheventinit" style="display:none">Info about the 'FetchEventInit' definition.</span><b><a href="#dictdef-fetcheventinit">#dictdef-fetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fetcheventinit">4.5. FetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-potential-response">
-   <b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-potential-response" class="dfn-panel" data-for="fetchevent-potential-response" id="infopanel-for-fetchevent-potential-response" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-potential-response" style="display:none">Info about the 'potential response' definition.</span><b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-potential-response">4.5.3. event.respondWith(r)</a>
     <li><a href="#ref-for-fetchevent-potential-response①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-wait-to-respond-flag">
-   <b><a href="#fetchevent-wait-to-respond-flag">#fetchevent-wait-to-respond-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-wait-to-respond-flag" class="dfn-panel" data-for="fetchevent-wait-to-respond-flag" id="infopanel-for-fetchevent-wait-to-respond-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-wait-to-respond-flag" style="display:none">Info about the 'wait to respond flag' definition.</span><b><a href="#fetchevent-wait-to-respond-flag">#fetchevent-wait-to-respond-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-wait-to-respond-flag">4.5.3. event.respondWith(r)</a> <a href="#ref-for-fetchevent-wait-to-respond-flag①">(2)</a> <a href="#ref-for-fetchevent-wait-to-respond-flag②">(3)</a>
     <li><a href="#ref-for-fetchevent-wait-to-respond-flag③">Handle Fetch</a> <a href="#ref-for-fetchevent-wait-to-respond-flag④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-respond-with-entered-flag">
-   <b><a href="#fetchevent-respond-with-entered-flag">#fetchevent-respond-with-entered-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-respond-with-entered-flag" class="dfn-panel" data-for="fetchevent-respond-with-entered-flag" id="infopanel-for-fetchevent-respond-with-entered-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-respond-with-entered-flag" style="display:none">Info about the 'respond-with entered flag' definition.</span><b><a href="#fetchevent-respond-with-entered-flag">#fetchevent-respond-with-entered-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-respond-with-entered-flag">4.5.3. event.respondWith(r)</a> <a href="#ref-for-fetchevent-respond-with-entered-flag①">(2)</a>
     <li><a href="#ref-for-fetchevent-respond-with-entered-flag②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-respond-with-error-flag">
-   <b><a href="#fetchevent-respond-with-error-flag">#fetchevent-respond-with-error-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-respond-with-error-flag" class="dfn-panel" data-for="fetchevent-respond-with-error-flag" id="infopanel-for-fetchevent-respond-with-error-flag" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-respond-with-error-flag" style="display:none">Info about the 'respond-with error flag' definition.</span><b><a href="#fetchevent-respond-with-error-flag">#fetchevent-respond-with-error-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-respond-with-error-flag">4.5.3. event.respondWith(r)</a> <a href="#ref-for-fetchevent-respond-with-error-flag①">(2)</a> <a href="#ref-for-fetchevent-respond-with-error-flag②">(3)</a>
     <li><a href="#ref-for-fetchevent-respond-with-error-flag③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-request">
-   <b><a href="#dom-fetchevent-request">#dom-fetchevent-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-request" class="dfn-panel" data-for="dom-fetchevent-request" id="infopanel-for-dom-fetchevent-request" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-fetchevent-request">#dom-fetchevent-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-request">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-request①">4.5.1. event.request</a>
     <li><a href="#ref-for-dom-fetchevent-request②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-clientid">
-   <b><a href="#dom-fetchevent-clientid">#dom-fetchevent-clientid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-clientid" class="dfn-panel" data-for="dom-fetchevent-clientid" id="infopanel-for-dom-fetchevent-clientid" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-clientid" style="display:none">Info about the 'clientId' definition.</span><b><a href="#dom-fetchevent-clientid">#dom-fetchevent-clientid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-clientid">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-clientid①">4.5.2. event.clientId</a>
     <li><a href="#ref-for-dom-fetchevent-clientid②">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fetchevent-respondwith">
-   <b><a href="#dom-fetchevent-respondwith">#dom-fetchevent-respondwith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fetchevent-respondwith" class="dfn-panel" data-for="dom-fetchevent-respondwith" id="infopanel-for-dom-fetchevent-respondwith" role="dialog">
+   <span id="infopaneltitle-for-dom-fetchevent-respondwith" style="display:none">Info about the 'respondWith(r)' definition.</span><b><a href="#dom-fetchevent-respondwith">#dom-fetchevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fetchevent-respondwith">4.5. FetchEvent</a>
     <li><a href="#ref-for-dom-fetchevent-respondwith①">4.5.3. event.respondWith(r)</a> <a href="#ref-for-dom-fetchevent-respondwith②">(2)</a>
     <li><a href="#ref-for-dom-fetchevent-respondwith③">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessageevent">
-   <b><a href="#extendablemessageevent">#extendablemessageevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessageevent" class="dfn-panel" data-for="extendablemessageevent" id="infopanel-for-extendablemessageevent" role="dialog">
+   <span id="infopaneltitle-for-extendablemessageevent" style="display:none">Info about the 'ExtendableMessageEvent' definition.</span><b><a href="#extendablemessageevent">#extendablemessageevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessageevent">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessageevent①">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendablemessageevent②">(2)</a>
     <li><a href="#ref-for-extendablemessageevent③">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendablemessageeventinit">
-   <b><a href="#dictdef-extendablemessageeventinit">#dictdef-extendablemessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendablemessageeventinit" class="dfn-panel" data-for="dictdef-extendablemessageeventinit" id="infopanel-for-dictdef-extendablemessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendablemessageeventinit" style="display:none">Info about the 'ExtendableMessageEventInit' definition.</span><b><a href="#dictdef-extendablemessageeventinit">#dictdef-extendablemessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendablemessageeventinit">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-data">
-   <b><a href="#dom-extendablemessageevent-data">#dom-extendablemessageevent-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-data" class="dfn-panel" data-for="dom-extendablemessageevent-data" id="infopanel-for-dom-extendablemessageevent-data" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-extendablemessageevent-data">#dom-extendablemessageevent-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-data">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-data①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-data②">4.6.1. event.data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-origin">
-   <b><a href="#dom-extendablemessageevent-origin">#dom-extendablemessageevent-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-origin" class="dfn-panel" data-for="dom-extendablemessageevent-origin" id="infopanel-for-dom-extendablemessageevent-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-extendablemessageevent-origin">#dom-extendablemessageevent-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-origin">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-origin①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-origin②">4.6.2. event.origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-lasteventid">
-   <b><a href="#dom-extendablemessageevent-lasteventid">#dom-extendablemessageevent-lasteventid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-lasteventid" class="dfn-panel" data-for="dom-extendablemessageevent-lasteventid" id="infopanel-for-dom-extendablemessageevent-lasteventid" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-lasteventid" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#dom-extendablemessageevent-lasteventid">#dom-extendablemessageevent-lasteventid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-lasteventid">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-lasteventid①">4.6.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-source">
-   <b><a href="#dom-extendablemessageevent-source">#dom-extendablemessageevent-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-source" class="dfn-panel" data-for="dom-extendablemessageevent-source" id="infopanel-for-dom-extendablemessageevent-source" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-extendablemessageevent-source">#dom-extendablemessageevent-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-source">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-source①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-source②">4.6.4. event.source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-extendablemessageevent-ports">
-   <b><a href="#dom-extendablemessageevent-ports">#dom-extendablemessageevent-ports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-extendablemessageevent-ports" class="dfn-panel" data-for="dom-extendablemessageevent-ports" id="infopanel-for-dom-extendablemessageevent-ports" role="dialog">
+   <span id="infopaneltitle-for-dom-extendablemessageevent-ports" style="display:none">Info about the 'ports' definition.</span><b><a href="#dom-extendablemessageevent-ports">#dom-extendablemessageevent-ports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-extendablemessageevent-ports">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-extendablemessageevent-ports①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-dom-extendablemessageevent-ports②">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-install-event">
-   <b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-install-event" class="dfn-panel" data-for="service-worker-global-scope-install-event" id="infopanel-for-service-worker-global-scope-install-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-install-event" style="display:none">Info about the 'install' definition.</span><b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-install-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-install-event①">4.1.4. Event handlers</a>
@@ -11524,8 +11524,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-install-event⑤">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-activate-event">
-   <b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-activate-event" class="dfn-panel" data-for="service-worker-global-scope-activate-event" id="infopanel-for-service-worker-global-scope-activate-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-activate-event" style="display:none">Info about the 'activate' definition.</span><b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-activate-event①">4.1.4. Event handlers</a>
@@ -11533,8 +11533,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-activate-event⑤">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-fetch-event">
-   <b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="service-worker-global-scope-fetch-event" id="infopanel-for-service-worker-global-scope-fetch-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' definition.</span><b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.1.2. Events</a>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event①">2.5. Task Sources</a>
@@ -11544,8 +11544,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-fetch-event⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-message">
-   <b><a href="#eventdef-serviceworkerglobalscope-message">#eventdef-serviceworkerglobalscope-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworkerglobalscope-message" class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-message" id="infopanel-for-eventdef-serviceworkerglobalscope-message" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworkerglobalscope-message" style="display:none">Info about the 'message' definition.</span><b><a href="#eventdef-serviceworkerglobalscope-message">#eventdef-serviceworkerglobalscope-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message">2.1.2. Events</a>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message①">3.1.4. postMessage(message, transfer)</a>
@@ -11554,8 +11554,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-message④">4.6. ExtendableMessageEvent</a> <a href="#ref-for-eventdef-serviceworkerglobalscope-message⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-messageerror">
-   <b><a href="#eventdef-serviceworkerglobalscope-messageerror">#eventdef-serviceworkerglobalscope-messageerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-serviceworkerglobalscope-messageerror" class="dfn-panel" data-for="eventdef-serviceworkerglobalscope-messageerror" id="infopanel-for-eventdef-serviceworkerglobalscope-messageerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-serviceworkerglobalscope-messageerror" style="display:none">Info about the 'messageerror' definition.</span><b><a href="#eventdef-serviceworkerglobalscope-messageerror">#eventdef-serviceworkerglobalscope-messageerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror">2.1.2. Events</a>
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror①">3.1.4. postMessage(message, transfer)</a>
@@ -11564,8 +11564,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventdef-serviceworkerglobalscope-messageerror④">4.2.5. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-request-response-list">
-   <b><a href="#dfn-request-response-list">#dfn-request-response-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-request-response-list" class="dfn-panel" data-for="dfn-request-response-list" id="infopanel-for-dfn-request-response-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-request-response-list" style="display:none">Info about the 'request response list' definition.</span><b><a href="#dfn-request-response-list">#dfn-request-response-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-response-list">5.1. Constructs</a> <a href="#ref-for-dfn-request-response-list①">(2)</a>
     <li><a href="#ref-for-dfn-request-response-list②">5.4. Cache</a> <a href="#ref-for-dfn-request-response-list③">(2)</a>
@@ -11575,8 +11575,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-request-response-list⑧">Batch Cache Operations</a> <a href="#ref-for-dfn-request-response-list⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-relevant-request-response-list">
-   <b><a href="#dfn-relevant-request-response-list">#dfn-relevant-request-response-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-relevant-request-response-list" class="dfn-panel" data-for="dfn-relevant-request-response-list" id="infopanel-for-dfn-relevant-request-response-list" role="dialog">
+   <span id="infopaneltitle-for-dfn-relevant-request-response-list" style="display:none">Info about the 'relevant request response list' definition.</span><b><a href="#dfn-relevant-request-response-list">#dfn-relevant-request-response-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-relevant-request-response-list">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-dfn-relevant-request-response-list①">5.4.7. keys(request, options)</a>
@@ -11584,8 +11584,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-relevant-request-response-list③">Batch Cache Operations</a> <a href="#ref-for-dfn-relevant-request-response-list④">(2)</a> <a href="#ref-for-dfn-relevant-request-response-list⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-name-to-cache-map">
-   <b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-name-to-cache-map" class="dfn-panel" data-for="dfn-name-to-cache-map" id="infopanel-for-dfn-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-name-to-cache-map" style="display:none">Info about the 'name to cache map' definition.</span><b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name-to-cache-map">5.1. Constructs</a>
     <li><a href="#ref-for-dfn-name-to-cache-map①">5.5. CacheStorage</a> <a href="#ref-for-dfn-name-to-cache-map②">(2)</a>
@@ -11593,8 +11593,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-name-to-cache-map④">6.8. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-relevant-name-to-cache-map">
-   <b><a href="#dfn-relevant-name-to-cache-map">#dfn-relevant-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-relevant-name-to-cache-map" class="dfn-panel" data-for="dfn-relevant-name-to-cache-map" id="infopanel-for-dfn-relevant-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-relevant-name-to-cache-map" style="display:none">Info about the 'relevant name to cache map' definition.</span><b><a href="#dfn-relevant-name-to-cache-map">#dfn-relevant-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map">5.5.1. match(request, options)</a> <a href="#ref-for-dfn-relevant-name-to-cache-map①">(2)</a>
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map②">5.5.2. has(cacheName)</a>
@@ -11603,15 +11603,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-relevant-name-to-cache-map⑥">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-caches-attribute">
-   <b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-caches-attribute" class="dfn-panel" data-for="global-caches-attribute" id="infopanel-for-global-caches-attribute" role="dialog">
+   <span id="infopaneltitle-for-global-caches-attribute" style="display:none">Info about the 'caches' definition.</span><b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-caches-attribute">5.3. self.caches</a> <a href="#ref-for-global-caches-attribute①">(2)</a>
     <li><a href="#ref-for-global-caches-attribute②">5.3.1. caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache">
-   <b><a href="#cache">#cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache" class="dfn-panel" data-for="cache" id="infopanel-for-cache" role="dialog">
+   <span id="infopaneltitle-for-cache" style="display:none">Info about the 'Cache' definition.</span><b><a href="#cache">#cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache">4.7. Events</a>
     <li><a href="#ref-for-cache①">5. Caches</a> <a href="#ref-for-cache②">(2)</a>
@@ -11623,8 +11623,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-cache①⑥">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-cache①⑦">(2)</a> <a href="#ref-for-cache①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cachequeryoptions">
-   <b><a href="#dictdef-cachequeryoptions">#dictdef-cachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cachequeryoptions" class="dfn-panel" data-for="dictdef-cachequeryoptions" id="infopanel-for-dictdef-cachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cachequeryoptions" style="display:none">Info about the 'CacheQueryOptions' definition.</span><b><a href="#dictdef-cachequeryoptions">#dictdef-cachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cachequeryoptions">5.4. Cache</a> <a href="#ref-for-dictdef-cachequeryoptions①">(2)</a> <a href="#ref-for-dictdef-cachequeryoptions②">(3)</a> <a href="#ref-for-dictdef-cachequeryoptions③">(4)</a> <a href="#ref-for-dictdef-cachequeryoptions④">(5)</a>
     <li><a href="#ref-for-dictdef-cachequeryoptions⑤">5.5. CacheStorage</a>
@@ -11632,26 +11632,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dictdef-cachequeryoptions⑦">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch">
-   <b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch" id="infopanel-for-dom-cachequeryoptions-ignoresearch" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" style="display:none">Info about the 'ignoreSearch' definition.</span><b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoresearch">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod">
-   <b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod" id="infopanel-for-dom-cachequeryoptions-ignoremethod" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" style="display:none">Info about the 'ignoreMethod' definition.</span><b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoremethod">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary">
-   <b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignorevary" class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary" id="infopanel-for-dom-cachequeryoptions-ignorevary" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignorevary" style="display:none">Info about the 'ignoreVary' definition.</span><b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignorevary">Request Matches Cached Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation">
-   <b><a href="#dfn-cache-batch-operation">#dfn-cache-batch-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation" class="dfn-panel" data-for="dfn-cache-batch-operation" id="infopanel-for-dfn-cache-batch-operation" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation" style="display:none">Info about the 'cache batch operation' definition.</span><b><a href="#dfn-cache-batch-operation">#dfn-cache-batch-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation①">5.4.5. put(request, response)</a>
@@ -11659,8 +11659,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-type">
-   <b><a href="#dfn-cache-batch-operation-type">#dfn-cache-batch-operation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-type" class="dfn-panel" data-for="dfn-cache-batch-operation-type" id="infopanel-for-dfn-cache-batch-operation-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-cache-batch-operation-type">#dfn-cache-batch-operation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-type">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-type①">5.4.5. put(request, response)</a>
@@ -11668,8 +11668,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation-type③">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-type④">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-type⑤">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-type⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-request">
-   <b><a href="#dfn-cache-batch-operation-request">#dfn-cache-batch-operation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-request" class="dfn-panel" data-for="dfn-cache-batch-operation-request" id="infopanel-for-dfn-cache-batch-operation-request" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dfn-cache-batch-operation-request">#dfn-cache-batch-operation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-request">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-request①">5.4.5. put(request, response)</a>
@@ -11677,144 +11677,144 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-cache-batch-operation-request③">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-request④">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑤">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑥">(4)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑦">(5)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑧">(6)</a> <a href="#ref-for-dfn-cache-batch-operation-request⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-response">
-   <b><a href="#dfn-cache-batch-operation-response">#dfn-cache-batch-operation-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-response" class="dfn-panel" data-for="dfn-cache-batch-operation-response" id="infopanel-for-dfn-cache-batch-operation-response" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dfn-cache-batch-operation-response">#dfn-cache-batch-operation-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-response">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-response①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-response②">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-response③">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-response④">(3)</a> <a href="#ref-for-dfn-cache-batch-operation-response⑤">(4)</a> <a href="#ref-for-dfn-cache-batch-operation-response⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-cache-batch-operation-options">
-   <b><a href="#dfn-cache-batch-operation-options">#dfn-cache-batch-operation-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-cache-batch-operation-options" class="dfn-panel" data-for="dfn-cache-batch-operation-options" id="infopanel-for-dfn-cache-batch-operation-options" role="dialog">
+   <span id="infopaneltitle-for-dfn-cache-batch-operation-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dfn-cache-batch-operation-options">#dfn-cache-batch-operation-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-cache-batch-operation-options">5.4.6. delete(request, options)</a>
     <li><a href="#ref-for-dfn-cache-batch-operation-options①">Batch Cache Operations</a> <a href="#ref-for-dfn-cache-batch-operation-options②">(2)</a> <a href="#ref-for-dfn-cache-batch-operation-options③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-match">
-   <b><a href="#dom-cache-match">#dom-cache-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-match" class="dfn-panel" data-for="dom-cache-match" id="infopanel-for-dom-cache-match" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-match" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#dom-cache-match">#dom-cache-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-match">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-match①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-dom-cache-match②">5.5.1. match(request, options)</a> <a href="#ref-for-dom-cache-match③">(2)</a> <a href="#ref-for-dom-cache-match④">(3)</a> <a href="#ref-for-dom-cache-match⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-matchall">
-   <b><a href="#dom-cache-matchall">#dom-cache-matchall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-matchall" class="dfn-panel" data-for="dom-cache-matchall" id="infopanel-for-dom-cache-matchall" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-matchall" style="display:none">Info about the 'matchAll(request, options)' definition.</span><b><a href="#dom-cache-matchall">#dom-cache-matchall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-matchall">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-matchall①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-dom-cache-matchall②">5.4.2. matchAll(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-add">
-   <b><a href="#dom-cache-add">#dom-cache-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-add" class="dfn-panel" data-for="dom-cache-add" id="infopanel-for-dom-cache-add" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-add" style="display:none">Info about the 'add(request)' definition.</span><b><a href="#dom-cache-add">#dom-cache-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-add">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-add①">5.4.3. add(request)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-addall">
-   <b><a href="#dom-cache-addall">#dom-cache-addall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-addall" class="dfn-panel" data-for="dom-cache-addall" id="infopanel-for-dom-cache-addall" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-addall" style="display:none">Info about the 'addAll(requests)' definition.</span><b><a href="#dom-cache-addall">#dom-cache-addall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-addall">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-addall①">5.4.3. add(request)</a>
     <li><a href="#ref-for-dom-cache-addall②">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-put">
-   <b><a href="#dom-cache-put">#dom-cache-put</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-put" class="dfn-panel" data-for="dom-cache-put" id="infopanel-for-dom-cache-put" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-put" style="display:none">Info about the 'put(request, response)' definition.</span><b><a href="#dom-cache-put">#dom-cache-put</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-put">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-put①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-delete">
-   <b><a href="#dom-cache-delete">#dom-cache-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-delete" class="dfn-panel" data-for="dom-cache-delete" id="infopanel-for-dom-cache-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-delete" style="display:none">Info about the 'delete(request, options)' definition.</span><b><a href="#dom-cache-delete">#dom-cache-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-delete">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-delete①">5.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cache-keys">
-   <b><a href="#dom-cache-keys">#dom-cache-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cache-keys" class="dfn-panel" data-for="dom-cache-keys" id="infopanel-for-dom-cache-keys" role="dialog">
+   <span id="infopaneltitle-for-dom-cache-keys" style="display:none">Info about the 'keys(request, options)' definition.</span><b><a href="#dom-cache-keys">#dom-cache-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cache-keys">5.4. Cache</a>
     <li><a href="#ref-for-dom-cache-keys①">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cachestorage">
-   <b><a href="#cachestorage">#cachestorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cachestorage" class="dfn-panel" data-for="cachestorage" id="infopanel-for-cachestorage" role="dialog">
+   <span id="infopaneltitle-for-cachestorage" style="display:none">Info about the 'CacheStorage' definition.</span><b><a href="#cachestorage">#cachestorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cachestorage">5.3. self.caches</a>
     <li><a href="#ref-for-cachestorage①">5.3.1. caches</a>
     <li><a href="#ref-for-cachestorage②">5.5. CacheStorage</a> <a href="#ref-for-cachestorage③">(2)</a> <a href="#ref-for-cachestorage④">(3)</a> <a href="#ref-for-cachestorage⑤">(4)</a> <a href="#ref-for-cachestorage⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-multicachequeryoptions">
-   <b><a href="#dictdef-multicachequeryoptions">#dictdef-multicachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-multicachequeryoptions" class="dfn-panel" data-for="dictdef-multicachequeryoptions" id="infopanel-for-dictdef-multicachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-multicachequeryoptions" style="display:none">Info about the 'MultiCacheQueryOptions' definition.</span><b><a href="#dictdef-multicachequeryoptions">#dictdef-multicachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-multicachequeryoptions">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-multicachequeryoptions-cachename">
-   <b><a href="#dom-multicachequeryoptions-cachename">#dom-multicachequeryoptions-cachename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-multicachequeryoptions-cachename" class="dfn-panel" data-for="dom-multicachequeryoptions-cachename" id="infopanel-for-dom-multicachequeryoptions-cachename" role="dialog">
+   <span id="infopaneltitle-for-dom-multicachequeryoptions-cachename" style="display:none">Info about the 'cacheName' definition.</span><b><a href="#dom-multicachequeryoptions-cachename">#dom-multicachequeryoptions-cachename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-multicachequeryoptions-cachename">5.5.1. match(request, options)</a> <a href="#ref-for-dom-multicachequeryoptions-cachename①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cachestorage-global-object">
-   <b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cachestorage-global-object" class="dfn-panel" data-for="cachestorage-global-object" id="infopanel-for-cachestorage-global-object" role="dialog">
+   <span id="infopaneltitle-for-cachestorage-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cachestorage-global-object">5.1. Constructs</a>
     <li><a href="#ref-for-cachestorage-global-object①">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-match">
-   <b><a href="#dom-cachestorage-match">#dom-cachestorage-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-match" class="dfn-panel" data-for="dom-cachestorage-match" id="infopanel-for-dom-cachestorage-match" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-match" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#dom-cachestorage-match">#dom-cachestorage-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-match">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-match①">5.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-has">
-   <b><a href="#dom-cachestorage-has">#dom-cachestorage-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-has" class="dfn-panel" data-for="dom-cachestorage-has" id="infopanel-for-dom-cachestorage-has" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-has" style="display:none">Info about the 'has(cacheName)' definition.</span><b><a href="#dom-cachestorage-has">#dom-cachestorage-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-has">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-has①">5.5.2. has(cacheName)</a>
     <li><a href="#ref-for-dom-cachestorage-has②">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-open">
-   <b><a href="#dom-cachestorage-open">#dom-cachestorage-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-open" class="dfn-panel" data-for="dom-cachestorage-open" id="infopanel-for-dom-cachestorage-open" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-open" style="display:none">Info about the 'open(cacheName)' definition.</span><b><a href="#dom-cachestorage-open">#dom-cachestorage-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-open">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-open①">5.5.3. open(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-delete">
-   <b><a href="#dom-cachestorage-delete">#dom-cachestorage-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-delete" class="dfn-panel" data-for="dom-cachestorage-delete" id="infopanel-for-dom-cachestorage-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-delete" style="display:none">Info about the 'delete(cacheName)' definition.</span><b><a href="#dom-cachestorage-delete">#dom-cachestorage-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-delete">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-delete①">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachestorage-keys">
-   <b><a href="#dom-cachestorage-keys">#dom-cachestorage-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachestorage-keys" class="dfn-panel" data-for="dom-cachestorage-keys" id="infopanel-for-dom-cachestorage-keys" role="dialog">
+   <span id="infopaneltitle-for-dom-cachestorage-keys" style="display:none">Info about the 'keys()' definition.</span><b><a href="#dom-cachestorage-keys">#dom-cachestorage-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachestorage-keys">5.5. CacheStorage</a>
     <li><a href="#ref-for-dom-cachestorage-keys①">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="importscripts-method">
-   <b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-importscripts-method" class="dfn-panel" data-for="importscripts-method" id="infopanel-for-importscripts-method" role="dialog">
+   <span id="infopaneltitle-for-importscripts-method" style="display:none">Info about the 'importScripts(urls)' definition.</span><b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-importscripts-method">6.3.1. Origin restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-registration-map">
-   <b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-registration-map" class="dfn-panel" data-for="dfn-scope-to-registration-map" id="infopanel-for-dfn-scope-to-registration-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-registration-map" style="display:none">Info about the 'scope to registration map' definition.</span><b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-scope-to-registration-map①">2.2.1. Lifetime</a>
@@ -11829,8 +11829,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-to-registration-map①①">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job">
-   <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job" class="dfn-panel" data-for="dfn-job" id="infopanel-for-dfn-job" role="dialog">
+   <span id="infopaneltitle-for-dfn-job" style="display:none">Info about the 'job' definition.</span><b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job①">(2)</a> <a href="#ref-for-dfn-job②">(3)</a> <a href="#ref-for-dfn-job③">(4)</a> <a href="#ref-for-dfn-job④">(5)</a> <a href="#ref-for-dfn-job⑤">(6)</a> <a href="#ref-for-dfn-job⑥">(7)</a> <a href="#ref-for-dfn-job⑦">(8)</a> <a href="#ref-for-dfn-job⑧">(9)</a> <a href="#ref-for-dfn-job⑨">(10)</a> <a href="#ref-for-dfn-job①⓪">(11)</a> <a href="#ref-for-dfn-job①①">(12)</a> <a href="#ref-for-dfn-job①②">(13)</a> <a href="#ref-for-dfn-job①③">(14)</a> <a href="#ref-for-dfn-job①④">(15)</a> <a href="#ref-for-dfn-job①⑤">(16)</a>
     <li><a href="#ref-for-dfn-job①⑥">Create Job</a> <a href="#ref-for-dfn-job①⑦">(2)</a>
@@ -11844,8 +11844,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job②⑤">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-type">
-   <b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-type" class="dfn-panel" data-for="dfn-job-type" id="infopanel-for-dfn-job-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-type" style="display:none">Info about the 'job type' definition.</span><b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-type">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type①">Create Job</a> <a href="#ref-for-dfn-job-type②">(2)</a>
@@ -11854,8 +11854,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-type⑧">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-scope-url">
-   <b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-scope-url" class="dfn-panel" data-for="dfn-job-scope-url" id="infopanel-for-dfn-job-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-scope-url">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-scope-url①">(2)</a>
     <li><a href="#ref-for-dfn-job-scope-url②">Create Job</a>
@@ -11865,8 +11865,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-scope-url⑧">Unregister</a> <a href="#ref-for-dfn-job-scope-url⑨">(2)</a> <a href="#ref-for-dfn-job-scope-url①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-script-url">
-   <b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-script-url" class="dfn-panel" data-for="dfn-job-script-url" id="infopanel-for-dfn-job-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url①">Create Job</a>
@@ -11874,8 +11874,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-script-url⑤">Update</a> <a href="#ref-for-dfn-job-script-url⑥">(2)</a> <a href="#ref-for-dfn-job-script-url⑦">(3)</a> <a href="#ref-for-dfn-job-script-url⑧">(4)</a> <a href="#ref-for-dfn-job-script-url⑨">(5)</a> <a href="#ref-for-dfn-job-script-url①⓪">(6)</a> <a href="#ref-for-dfn-job-script-url①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-worker-type">
-   <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-worker-type" class="dfn-panel" data-for="dfn-job-worker-type" id="infopanel-for-dfn-job-worker-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-worker-type" style="display:none">Info about the 'worker type' definition.</span><b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-worker-type">3.2.7. update()</a>
     <li><a href="#ref-for-dfn-job-worker-type①">3.4.3. register(scriptURL, options)</a>
@@ -11883,15 +11883,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-worker-type④">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-update-via-cache-mode">
-   <b><a href="#dfn-job-update-via-cache-mode">#dfn-job-update-via-cache-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-update-via-cache-mode" class="dfn-panel" data-for="dfn-job-update-via-cache-mode" id="infopanel-for-dfn-job-update-via-cache-mode" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-update-via-cache-mode" style="display:none">Info about the 'update via cache mode' definition.</span><b><a href="#dfn-job-update-via-cache-mode">#dfn-job-update-via-cache-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-update-via-cache-mode">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-dfn-job-update-via-cache-mode①">Register</a> <a href="#ref-for-dfn-job-update-via-cache-mode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-client">
-   <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-client" class="dfn-panel" data-for="dfn-job-client" id="infopanel-for-dfn-job-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-client" style="display:none">Info about the 'client' definition.</span><b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client">Create Job</a>
     <li><a href="#ref-for-dfn-job-client①">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client②">(2)</a> <a href="#ref-for-dfn-job-client③">(3)</a> <a href="#ref-for-dfn-job-client④">(4)</a> <a href="#ref-for-dfn-job-client⑤">(5)</a> <a href="#ref-for-dfn-job-client⑥">(6)</a> <a href="#ref-for-dfn-job-client⑦">(7)</a> <a href="#ref-for-dfn-job-client⑧">(8)</a>
@@ -11901,8 +11901,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-client②②">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-promise">
-   <b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-promise" class="dfn-panel" data-for="dfn-job-promise" id="infopanel-for-dfn-job-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-promise" style="display:none">Info about the 'job promise' definition.</span><b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-promise">Create Job</a>
     <li><a href="#ref-for-dfn-job-promise①">Schedule Job</a>
@@ -11911,51 +11911,51 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-promise⑥">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-job-queue">
-   <b><a href="#dfn-containing-job-queue">#dfn-containing-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-job-queue" class="dfn-panel" data-for="dfn-containing-job-queue" id="infopanel-for-dfn-containing-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-job-queue" style="display:none">Info about the 'containing job queue' definition.</span><b><a href="#dfn-containing-job-queue">#dfn-containing-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-job-queue">Schedule Job</a> <a href="#ref-for-dfn-containing-job-queue①">(2)</a>
     <li><a href="#ref-for-dfn-containing-job-queue②">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs">
-   <b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs" id="infopanel-for-dfn-job-list-of-equivalent-jobs" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" style="display:none">Info about the 'list of equivalent jobs' definition.</span><b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs①">Resolve Job Promise</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs②">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
-   <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-force-bypass-cache-flag" class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag" id="infopanel-for-dfn-job-force-bypass-cache-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-force-bypass-cache-flag" style="display:none">Info about the 'force bypass cache flag' definition.</span><b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Update</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag①">(2)</a> <a href="#ref-for-dfn-job-force-bypass-cache-flag②">(3)</a>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag③">Soft Update</a>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag④">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-equivalent">
-   <b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-equivalent" class="dfn-panel" data-for="dfn-job-equivalent" id="infopanel-for-dfn-job-equivalent" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-equivalent" style="display:none">Info about the 'equivalent' definition.</span><b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-equivalent">Schedule Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-queue">
-   <b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-queue" class="dfn-panel" data-for="dfn-job-queue" id="infopanel-for-dfn-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-queue" style="display:none">Info about the 'job queue' definition.</span><b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-queue">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-queue①">(2)</a> <a href="#ref-for-dfn-job-queue②">(3)</a> <a href="#ref-for-dfn-job-queue③">(4)</a>
     <li><a href="#ref-for-dfn-job-queue④">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-queue⑤">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-job-queue-map">
-   <b><a href="#dfn-scope-to-job-queue-map">#dfn-scope-to-job-queue-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-job-queue-map" class="dfn-panel" data-for="dfn-scope-to-job-queue-map" id="infopanel-for-dfn-scope-to-job-queue-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-job-queue-map" style="display:none">Info about the 'scope to job queue map' definition.</span><b><a href="#dfn-scope-to-job-queue-map">#dfn-scope-to-job-queue-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-job-queue-map">Schedule Job</a> <a href="#ref-for-dfn-scope-to-job-queue-map①">(2)</a> <a href="#ref-for-dfn-scope-to-job-queue-map②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-job">
-   <b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-job" class="dfn-panel" data-for="create-job" id="infopanel-for-create-job" role="dialog">
+   <span id="infopaneltitle-for-create-job" style="display:none">Info about the 'Create Job' definition.</span><b><a href="#create-job">#create-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-job">3.2.7. update()</a>
     <li><a href="#ref-for-create-job①">3.2.8. unregister()</a>
@@ -11963,8 +11963,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-create-job③">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="schedule-job">
-   <b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-schedule-job" class="dfn-panel" data-for="schedule-job" id="infopanel-for-schedule-job" role="dialog">
+   <span id="infopaneltitle-for-schedule-job" style="display:none">Info about the 'Schedule Job' definition.</span><b><a href="#schedule-job">#schedule-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-schedule-job">3.2.7. update()</a>
     <li><a href="#ref-for-schedule-job①">3.2.8. unregister()</a>
@@ -11972,15 +11972,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-schedule-job③">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-job">
-   <b><a href="#run-job">#run-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-job" class="dfn-panel" data-for="run-job" id="infopanel-for-run-job" role="dialog">
+   <span id="infopaneltitle-for-run-job" style="display:none">Info about the 'Run Job' definition.</span><b><a href="#run-job">#run-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-job">Schedule Job</a>
     <li><a href="#ref-for-run-job①">Finish Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finish-job">
-   <b><a href="#finish-job">#finish-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finish-job" class="dfn-panel" data-for="finish-job" id="infopanel-for-finish-job" role="dialog">
+   <span id="infopaneltitle-for-finish-job" style="display:none">Info about the 'Finish Job' definition.</span><b><a href="#finish-job">#finish-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finish-job">Register</a> <a href="#ref-for-finish-job①">(2)</a> <a href="#ref-for-finish-job②">(3)</a> <a href="#ref-for-finish-job③">(4)</a>
     <li><a href="#ref-for-finish-job④">Update</a> <a href="#ref-for-finish-job⑤">(2)</a> <a href="#ref-for-finish-job⑥">(3)</a> <a href="#ref-for-finish-job⑦">(4)</a> <a href="#ref-for-finish-job⑧">(5)</a>
@@ -11988,8 +11988,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-finish-job①①">Unregister</a> <a href="#ref-for-finish-job①②">(2)</a> <a href="#ref-for-finish-job①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-job-promise">
-   <b><a href="#resolve-job-promise">#resolve-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-job-promise" class="dfn-panel" data-for="resolve-job-promise" id="infopanel-for-resolve-job-promise" role="dialog">
+   <span id="infopaneltitle-for-resolve-job-promise" style="display:none">Info about the 'Resolve Job Promise' definition.</span><b><a href="#resolve-job-promise">#resolve-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-job-promise">Register</a>
     <li><a href="#ref-for-resolve-job-promise①">Update</a>
@@ -11997,48 +11997,48 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-resolve-job-promise③">Unregister</a> <a href="#ref-for-resolve-job-promise④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reject-job-promise">
-   <b><a href="#reject-job-promise">#reject-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reject-job-promise" class="dfn-panel" data-for="reject-job-promise" id="infopanel-for-reject-job-promise" role="dialog">
+   <span id="infopaneltitle-for-reject-job-promise" style="display:none">Info about the 'Reject Job Promise' definition.</span><b><a href="#reject-job-promise">#reject-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject-job-promise">Register</a> <a href="#ref-for-reject-job-promise①">(2)</a> <a href="#ref-for-reject-job-promise②">(3)</a>
     <li><a href="#ref-for-reject-job-promise③">Update</a> <a href="#ref-for-reject-job-promise④">(2)</a> <a href="#ref-for-reject-job-promise⑤">(3)</a> <a href="#ref-for-reject-job-promise⑥">(4)</a> <a href="#ref-for-reject-job-promise⑦">(5)</a> <a href="#ref-for-reject-job-promise⑧">(6)</a> <a href="#ref-for-reject-job-promise⑨">(7)</a>
     <li><a href="#ref-for-reject-job-promise①⓪">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register">
-   <b><a href="#register">#register</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-register" class="dfn-panel" data-for="register" id="infopanel-for-register" role="dialog">
+   <span id="infopaneltitle-for-register" style="display:none">Info about the 'Register' definition.</span><b><a href="#register">#register</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-register">2.2.1. Lifetime</a>
     <li><a href="#ref-for-register①">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-register②">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update">
-   <b><a href="#update">#update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update" class="dfn-panel" data-for="update" id="infopanel-for-update" role="dialog">
+   <span id="infopaneltitle-for-update" style="display:none">Info about the 'Update' definition.</span><b><a href="#update">#update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update">Run Job</a>
     <li><a href="#ref-for-update①">Register</a>
     <li><a href="#ref-for-update②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="soft-update">
-   <b><a href="#soft-update">#soft-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-soft-update" class="dfn-panel" data-for="soft-update" id="infopanel-for-soft-update" role="dialog">
+   <span id="infopaneltitle-for-soft-update" style="display:none">Info about the 'Soft Update' definition.</span><b><a href="#soft-update">#soft-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-update">Update</a>
     <li><a href="#ref-for-soft-update①">Handle Fetch</a> <a href="#ref-for-soft-update②">(2)</a>
     <li><a href="#ref-for-soft-update③">Fire Functional Event</a> <a href="#ref-for-soft-update④">(2)</a> <a href="#ref-for-soft-update⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="install">
-   <b><a href="#install">#install</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-install" class="dfn-panel" data-for="install" id="infopanel-for-install" role="dialog">
+   <span id="infopaneltitle-for-install" style="display:none">Info about the 'Install' definition.</span><b><a href="#install">#install</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-install">3.5. Events</a>
     <li><a href="#ref-for-install①">4.7. Events</a>
     <li><a href="#ref-for-install②">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activate">
-   <b><a href="#activate">#activate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activate" class="dfn-panel" data-for="activate" id="infopanel-for-activate" role="dialog">
+   <span id="infopaneltitle-for-activate" style="display:none">Info about the 'Activate' definition.</span><b><a href="#activate">#activate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activate">3.5. Events</a> <a href="#ref-for-activate①">(2)</a>
     <li><a href="#ref-for-activate②">4.7. Events</a>
@@ -12047,8 +12047,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-activate⑥">Handle User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="try-activate">
-   <b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-try-activate" class="dfn-panel" data-for="try-activate" id="infopanel-for-try-activate" role="dialog">
+   <span id="infopaneltitle-for-try-activate" style="display:none">Info about the 'Try Activate' definition.</span><b><a href="#try-activate">#try-activate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-try-activate">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-try-activate①">4.4. ExtendableEvent</a>
@@ -12056,8 +12056,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-try-activate④">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-service-worker">
-   <b><a href="#run-service-worker">#run-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-service-worker" class="dfn-panel" data-for="run-service-worker" id="infopanel-for-run-service-worker" role="dialog">
+   <span id="infopaneltitle-for-run-service-worker" style="display:none">Info about the 'Run Service Worker' definition.</span><b><a href="#run-service-worker">#run-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-service-worker">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-run-service-worker①">6.2. Content Security Policy</a>
@@ -12068,8 +12068,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-run-service-worker⑦">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="terminate-service-worker">
-   <b><a href="#terminate-service-worker">#terminate-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-terminate-service-worker" class="dfn-panel" data-for="terminate-service-worker" id="infopanel-for-terminate-service-worker" role="dialog">
+   <span id="infopaneltitle-for-terminate-service-worker" style="display:none">Info about the 'Terminate Service Worker' definition.</span><b><a href="#terminate-service-worker">#terminate-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-service-worker">2.1.1. Lifetime</a>
     <li><a href="#ref-for-terminate-service-worker①">2.2. Service Worker Registration</a>
@@ -12081,8 +12081,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-terminate-service-worker⑦">Clear Registration</a> <a href="#ref-for-terminate-service-worker⑧">(2)</a> <a href="#ref-for-terminate-service-worker⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-fetch">
-   <b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-fetch" class="dfn-panel" data-for="handle-fetch" id="infopanel-for-handle-fetch" role="dialog">
+   <span id="infopaneltitle-for-handle-fetch" style="display:none">Info about the 'Handle Fetch' definition.</span><b><a href="#handle-fetch">#handle-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-fetch">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-handle-fetch①">4.5.3. event.respondWith(r)</a> <a href="#ref-for-handle-fetch②">(2)</a>
@@ -12091,8 +12091,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-handle-fetch⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-skip-event">
-   <b><a href="#should-skip-event">#should-skip-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-skip-event" class="dfn-panel" data-for="should-skip-event" id="infopanel-for-should-skip-event" role="dialog">
+   <span id="infopaneltitle-for-should-skip-event" style="display:none">Info about the 'Should Skip Event' definition.</span><b><a href="#should-skip-event">#should-skip-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-skip-event">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-should-skip-event①">Install</a>
@@ -12101,88 +12101,88 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-should-skip-event④">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-functional-event">
-   <b><a href="#fire-functional-event">#fire-functional-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-functional-event" class="dfn-panel" data-for="fire-functional-event" id="infopanel-for-fire-functional-event" role="dialog">
+   <span id="infopaneltitle-for-fire-functional-event" style="display:none">Info about the 'Fire Functional Event' definition.</span><b><a href="#fire-functional-event">#fire-functional-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">7.4. Firing Functional Events</a>
     <li><a href="#ref-for-fire-functional-event①">Fire Functional Event</a> <a href="#ref-for-fire-functional-event②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-service-worker-client-unload">
-   <b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-service-worker-client-unload" class="dfn-panel" data-for="handle-service-worker-client-unload" id="infopanel-for-handle-service-worker-client-unload" role="dialog">
+   <span id="infopaneltitle-for-handle-service-worker-client-unload" style="display:none">Info about the 'Handle Service Worker Client Unload' definition.</span><b><a href="#handle-service-worker-client-unload">#handle-service-worker-client-unload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-service-worker-client-unload">4.3.4. claim()</a>
     <li><a href="#ref-for-handle-service-worker-client-unload①">Install</a>
     <li><a href="#ref-for-handle-service-worker-client-unload②">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-user-agent-shutdown">
-   <b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-user-agent-shutdown" class="dfn-panel" data-for="handle-user-agent-shutdown" id="infopanel-for-handle-user-agent-shutdown" role="dialog">
+   <span id="infopaneltitle-for-handle-user-agent-shutdown" style="display:none">Info about the 'Handle User Agent Shutdown' definition.</span><b><a href="#handle-user-agent-shutdown">#handle-user-agent-shutdown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-user-agent-shutdown">2.6. User Agent Shutdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-service-worker-extended-events-set">
-   <b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-service-worker-extended-events-set" class="dfn-panel" data-for="update-service-worker-extended-events-set" id="infopanel-for-update-service-worker-extended-events-set" role="dialog">
+   <span id="infopaneltitle-for-update-service-worker-extended-events-set" style="display:none">Info about the 'Update Service Worker Extended Events Set' definition.</span><b><a href="#update-service-worker-extended-events-set">#update-service-worker-extended-events-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-service-worker-extended-events-set">3.1.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-update-service-worker-extended-events-set①">Handle Fetch</a>
     <li><a href="#ref-for-update-service-worker-extended-events-set②">Fire Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unregister">
-   <b><a href="#unregister">#unregister</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unregister" class="dfn-panel" data-for="unregister" id="infopanel-for-unregister" role="dialog">
+   <span id="infopaneltitle-for-unregister" style="display:none">Info about the 'Unregister' definition.</span><b><a href="#unregister">#unregister</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unregister">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-registration">
-   <b><a href="#set-registration">#set-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-registration" class="dfn-panel" data-for="set-registration" id="infopanel-for-set-registration" role="dialog">
+   <span id="infopaneltitle-for-set-registration" style="display:none">Info about the 'Set Registration' definition.</span><b><a href="#set-registration">#set-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-registration">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clear-registration">
-   <b><a href="#clear-registration">#clear-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clear-registration" class="dfn-panel" data-for="clear-registration" id="infopanel-for-clear-registration" role="dialog">
+   <span id="infopaneltitle-for-clear-registration" style="display:none">Info about the 'Clear Registration' definition.</span><b><a href="#clear-registration">#clear-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear-registration">Handle User Agent Shutdown</a>
     <li><a href="#ref-for-clear-registration①">Unregister</a> <a href="#ref-for-clear-registration②">(2)</a>
     <li><a href="#ref-for-clear-registration③">Try Clear Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="try-clear-registration">
-   <b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-try-clear-registration" class="dfn-panel" data-for="try-clear-registration" id="infopanel-for-try-clear-registration" role="dialog">
+   <span id="infopaneltitle-for-try-clear-registration" style="display:none">Info about the 'Try Clear Registration' definition.</span><b><a href="#try-clear-registration">#try-clear-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-try-clear-registration">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-try-clear-registration①">Handle Service Worker Client Unload</a>
     <li><a href="#ref-for-try-clear-registration②">Unregister</a> <a href="#ref-for-try-clear-registration③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-registration-state">
-   <b><a href="#update-registration-state">#update-registration-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-registration-state" class="dfn-panel" data-for="update-registration-state" id="infopanel-for-update-registration-state" role="dialog">
+   <span id="infopaneltitle-for-update-registration-state" style="display:none">Info about the 'Update Registration State' definition.</span><b><a href="#update-registration-state">#update-registration-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-registration-state">Install</a> <a href="#ref-for-update-registration-state①">(2)</a> <a href="#ref-for-update-registration-state②">(3)</a> <a href="#ref-for-update-registration-state③">(4)</a>
     <li><a href="#ref-for-update-registration-state④">Activate</a> <a href="#ref-for-update-registration-state⑤">(2)</a>
     <li><a href="#ref-for-update-registration-state⑥">Clear Registration</a> <a href="#ref-for-update-registration-state⑦">(2)</a> <a href="#ref-for-update-registration-state⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-worker-state">
-   <b><a href="#update-worker-state">#update-worker-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-worker-state" class="dfn-panel" data-for="update-worker-state" id="infopanel-for-update-worker-state" role="dialog">
+   <span id="infopaneltitle-for-update-worker-state" style="display:none">Info about the 'Update Worker State' definition.</span><b><a href="#update-worker-state">#update-worker-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-worker-state">Install</a> <a href="#ref-for-update-worker-state①">(2)</a> <a href="#ref-for-update-worker-state②">(3)</a> <a href="#ref-for-update-worker-state③">(4)</a> <a href="#ref-for-update-worker-state④">(5)</a>
     <li><a href="#ref-for-update-worker-state⑤">Activate</a> <a href="#ref-for-update-worker-state⑥">(2)</a> <a href="#ref-for-update-worker-state⑦">(3)</a>
     <li><a href="#ref-for-update-worker-state⑧">Clear Registration</a> <a href="#ref-for-update-worker-state⑨">(2)</a> <a href="#ref-for-update-worker-state①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-controller-change">
-   <b><a href="#notify-controller-change">#notify-controller-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-controller-change" class="dfn-panel" data-for="notify-controller-change" id="infopanel-for-notify-controller-change" role="dialog">
+   <span id="infopaneltitle-for-notify-controller-change" style="display:none">Info about the 'Notify Controller Change' definition.</span><b><a href="#notify-controller-change">#notify-controller-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-controller-change">4.3.4. claim()</a>
     <li><a href="#ref-for-notify-controller-change①">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-service-worker-registration">
-   <b><a href="#match-service-worker-registration">#match-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-service-worker-registration" class="dfn-panel" data-for="match-service-worker-registration" id="infopanel-for-match-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-match-service-worker-registration" style="display:none">Info about the 'Match Service Worker Registration' definition.</span><b><a href="#match-service-worker-registration">#match-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-service-worker-registration">2.4.1. The window client case</a>
     <li><a href="#ref-for-match-service-worker-registration①">2.4.2. The worker client case</a>
@@ -12194,8 +12194,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-match-service-worker-registration⑦">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-registration">
-   <b><a href="#get-registration">#get-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-registration" class="dfn-panel" data-for="get-registration" id="infopanel-for-get-registration" role="dialog">
+   <span id="infopaneltitle-for-get-registration" style="display:none">Info about the 'Get Registration' definition.</span><b><a href="#get-registration">#get-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-registration">Register</a>
     <li><a href="#ref-for-get-registration①">Update</a>
@@ -12203,8 +12203,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-registration③">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-newest-worker">
-   <b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-newest-worker" class="dfn-panel" data-for="get-newest-worker" id="infopanel-for-get-newest-worker" role="dialog">
+   <span id="infopaneltitle-for-get-newest-worker" style="display:none">Info about the 'Get Newest Worker' definition.</span><b><a href="#get-newest-worker">#get-newest-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-newest-worker">3.2.7. update()</a>
     <li><a href="#ref-for-get-newest-worker①">Register</a>
@@ -12213,23 +12213,23 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-newest-worker④">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-has-no-pending-events">
-   <b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-has-no-pending-events" class="dfn-panel" data-for="service-worker-has-no-pending-events" id="infopanel-for-service-worker-has-no-pending-events" role="dialog">
+   <span id="infopaneltitle-for-service-worker-has-no-pending-events" style="display:none">Info about the 'Service Worker Has No Pending Events' definition.</span><b><a href="#service-worker-has-no-pending-events">#service-worker-has-no-pending-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-has-no-pending-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-service-worker-has-no-pending-events①">Try Activate</a>
     <li><a href="#ref-for-service-worker-has-no-pending-events②">Try Clear Registration</a> <a href="#ref-for-service-worker-has-no-pending-events③">(2)</a> <a href="#ref-for-service-worker-has-no-pending-events④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-client">
-   <b><a href="#create-client">#create-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-client" class="dfn-panel" data-for="create-client" id="infopanel-for-create-client" role="dialog">
+   <span id="infopaneltitle-for-create-client" style="display:none">Info about the 'Create Client' definition.</span><b><a href="#create-client">#create-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-client">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-create-client①">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-window-client">
-   <b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-window-client" class="dfn-panel" data-for="create-window-client" id="infopanel-for-create-window-client" role="dialog">
+   <span id="infopaneltitle-for-create-window-client" style="display:none">Info about the 'Create Window Client' definition.</span><b><a href="#create-window-client">#create-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-window-client">4.2.9. focus()</a>
     <li><a href="#ref-for-create-window-client①">4.2.10. navigate(url)</a>
@@ -12238,8 +12238,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-create-window-client④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-frame-type">
-   <b><a href="#get-frame-type">#get-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-frame-type" class="dfn-panel" data-for="get-frame-type" id="infopanel-for-get-frame-type" role="dialog">
+   <span id="infopaneltitle-for-get-frame-type" style="display:none">Info about the 'Get Frame Type' definition.</span><b><a href="#get-frame-type">#get-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-frame-type">4.2.9. focus()</a>
     <li><a href="#ref-for-get-frame-type①">4.2.10. navigate(url)</a>
@@ -12248,42 +12248,42 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-get-frame-type④">Resolve Get Client Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-get-client-promise">
-   <b><a href="#resolve-get-client-promise">#resolve-get-client-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-get-client-promise" class="dfn-panel" data-for="resolve-get-client-promise" id="infopanel-for-resolve-get-client-promise" role="dialog">
+   <span id="infopaneltitle-for-resolve-get-client-promise" style="display:none">Info about the 'Resolve Get Client Promise' definition.</span><b><a href="#resolve-get-client-promise">#resolve-get-client-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-get-client-promise">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-cache">
-   <b><a href="#query-cache">#query-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-cache" class="dfn-panel" data-for="query-cache" id="infopanel-for-query-cache" role="dialog">
+   <span id="infopaneltitle-for-query-cache" style="display:none">Info about the 'Query Cache' definition.</span><b><a href="#query-cache">#query-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-cache">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-query-cache①">5.4.7. keys(request, options)</a>
     <li><a href="#ref-for-query-cache②">Batch Cache Operations</a> <a href="#ref-for-query-cache③">(2)</a> <a href="#ref-for-query-cache④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-matches-cached-item">
-   <b><a href="#request-matches-cached-item">#request-matches-cached-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-matches-cached-item" class="dfn-panel" data-for="request-matches-cached-item" id="infopanel-for-request-matches-cached-item" role="dialog">
+   <span id="infopaneltitle-for-request-matches-cached-item" style="display:none">Info about the 'Request Matches Cached Item' definition.</span><b><a href="#request-matches-cached-item">#request-matches-cached-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-matches-cached-item">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="batch-cache-operations">
-   <b><a href="#batch-cache-operations">#batch-cache-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-batch-cache-operations" class="dfn-panel" data-for="batch-cache-operations" id="infopanel-for-batch-cache-operations" role="dialog">
+   <span id="infopaneltitle-for-batch-cache-operations" style="display:none">Info about the 'Batch Cache Operations' definition.</span><b><a href="#batch-cache-operations">#batch-cache-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-batch-cache-operations">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-batch-cache-operations①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-batch-cache-operations②">5.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker">
-   <b><a href="#service-worker">#service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker" class="dfn-panel" data-for="service-worker" id="infopanel-for-service-worker" role="dialog">
+   <span id="infopaneltitle-for-service-worker" style="display:none">Info about the 'Service-Worker' definition.</span><b><a href="#service-worker">#service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker">6.6. Service worker script request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-allowed">
-   <b><a href="#service-worker-allowed">#service-worker-allowed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-allowed" class="dfn-panel" data-for="service-worker-allowed" id="infopanel-for-service-worker-allowed" role="dialog">
+   <span id="infopaneltitle-for-service-worker-allowed" style="display:none">Info about the 'Service-Worker-Allowed' definition.</span><b><a href="#service-worker-allowed">#service-worker-allowed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-allowed">6.5. Path restriction</a>
     <li><a href="#ref-for-service-worker-allowed①">Update</a>
@@ -12291,59 +12291,115 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/ServiceWorker/publish/service_worker/WD-service-workers-20160830/index.html
+++ b/tests/github/w3c/ServiceWorker/publish/service_worker/WD-service-workers-20160830/index.html
@@ -4612,56 +4612,56 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <li><a href="#link-workertype-attribute">workerType</a><span>, in § 5.2</span>
    <li><a href="#element-attrdef-link-workertype">workertype</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://w3c.github.io/webappsec-csp/2/#enforce">https://w3c.github.io/webappsec-csp/2/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce" style="display:none">Info about the 'enforce' external reference.</span><a href="https://w3c.github.io/webappsec-csp/2/#enforce">https://w3c.github.io/webappsec-csp/2/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">7.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://w3c.github.io/webappsec-csp/2/#monitor">https://w3c.github.io/webappsec-csp/2/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://w3c.github.io/webappsec-csp/2/#monitor">https://w3c.github.io/webappsec-csp/2/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">7.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2.8. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-event①">3.6. Events</a> <a href="#ref-for-event②">(2)</a> <a href="#ref-for-event③">(3)</a>
     <li><a href="#ref-for-event④">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-dictdef-eventinit①">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventtarget①">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-eventtarget②">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">Handle Fetch</a>
     <li><a href="#ref-for-canceled-flag①">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.5. Task Sources</a> <a href="#ref-for-concept-event-dispatch①">(2)</a>
     <li><a href="#ref-for-concept-event-dispatch②">3.1.3. postMessage(message, transfer)</a>
@@ -4673,68 +4673,68 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-dispatch⑧">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">4.5.1. event.registerForeignFetch(options)</a>
     <li><a href="#ref-for-dispatch-flag①">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-dispatch-flag②">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">4.6.2. event.clientId</a>
     <li><a href="#ref-for-concept-event①">4.6.3. event.isReload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-event-listener①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-a-document">
-   <a href="https://dom.spec.whatwg.org/#in-a-document">https://dom.spec.whatwg.org/#in-a-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-a-document" class="dfn-panel" data-for="term-for-in-a-document" id="infopanel-for-term-for-in-a-document" role="menu">
+   <span id="infopaneltitle-for-term-for-in-a-document" style="display:none">Info about the 'in a document' external reference.</span><a href="https://dom.spec.whatwg.org/#in-a-document">https://dom.spec.whatwg.org/#in-a-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-a-document">5.1. Processing</a> <a href="#ref-for-in-a-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">5.2. Link element interface extensions</a> <a href="#ref-for-concept-reflect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-immediate-propagation-flag" class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag" id="infopanel-for-term-for-stop-immediate-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-immediate-propagation-flag" style="display:none">Info about the 'stop immediate propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-immediate-propagation-flag">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-stop-immediate-propagation-flag①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-propagation-flag" class="dfn-panel" data-for="term-for-stop-propagation-flag" id="infopanel-for-term-for-stop-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-stop-propagation-flag①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">https://dom.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">https://dom.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">Start Register</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a> <a href="#ref-for-ascii-case-insensitive②">(3)</a> <a href="#ref-for-ascii-case-insensitive③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" class="dfn-panel" data-for="term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" id="infopanel-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" style="display:none">Info about the '[[call]]' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-function-objects-call-thisargument-argumentslist">6.5.1. match(request, options)</a> <a href="#ref-for-sec-ecmascript-function-objects-call-thisargument-argumentslist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the 'assert' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">Run Job</a>
     <li><a href="#ref-for-sec-algorithm-conventions①">Finish Job</a>
@@ -4743,8 +4743,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-algorithm-conventions⑤">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type" style="display:none">Info about the 'list' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">2.1. Service Worker</a> <a href="#ref-for-sec-list-and-record-specification-type①">(2)</a>
     <li><a href="#ref-for-sec-list-and-record-specification-type②">3.4.5. getRegistrations()</a>
@@ -4762,15 +4762,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-list-and-record-specification-type②⓪">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'map objects' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">6.4. Cache</a>
     <li><a href="#ref-for-sec-map-objects①">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3.2.5. update()</a>
     <li><a href="#ref-for-sec-promise-objects①">3.2.6. unregister()</a>
@@ -4808,8 +4808,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-promise-objects⑥④">Batch Cache Operations</a> <a href="#ref-for-sec-promise-objects⑥⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type①" style="display:none">Info about the 'record' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">2.1. Service Worker</a> <a href="#ref-for-sec-list-and-record-specification-type①">(2)</a>
     <li><a href="#ref-for-sec-list-and-record-specification-type②">3.4.5. getRegistrations()</a>
@@ -4827,15 +4827,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-list-and-record-specification-type②⓪">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">6.4.4. addAll(requests)</a> <a href="#ref-for-headers①">(2)</a>
     <li><a href="#ref-for-headers②">6.4.5. put(request, response)</a> <a href="#ref-for-headers③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">4.6. FetchEvent</a> <a href="#ref-for-request①">(2)</a>
     <li><a href="#ref-for-request②">4.7. ForeignFetchEvent</a> <a href="#ref-for-request③">(2)</a>
@@ -4851,15 +4851,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-request②④">Query Cache</a> <a href="#ref-for-request②⑤">(2)</a> <a href="#ref-for-request②⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-requestinfo">
-   <a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-requestinfo" class="dfn-panel" data-for="term-for-requestinfo" id="infopanel-for-term-for-requestinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-requestinfo" style="display:none">Info about the 'RequestInfo' external reference.</span><a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">6.4. Cache</a> <a href="#ref-for-requestinfo①">(2)</a> <a href="#ref-for-requestinfo②">(3)</a> <a href="#ref-for-requestinfo③">(4)</a> <a href="#ref-for-requestinfo④">(5)</a> <a href="#ref-for-requestinfo⑤">(6)</a> <a href="#ref-for-requestinfo⑥">(7)</a>
     <li><a href="#ref-for-requestinfo⑦">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.6. FetchEvent</a>
     <li><a href="#ref-for-response①">4.6.4. event.respondWith(r)</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a>
@@ -4875,34 +4875,34 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-response②③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-basic">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-basic" class="dfn-panel" data-for="term-for-concept-filtered-response-basic" id="infopanel-for-term-for-concept-filtered-response-basic" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-basic" style="display:none">Info about the 'basic filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-basic">7.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-filtered-response-basic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-body①">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cancel-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-cancel-readablestream">https://fetch.spec.whatwg.org/#concept-cancel-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cancel-readablestream" class="dfn-panel" data-for="term-for-concept-cancel-readablestream" id="infopanel-for-term-for-concept-cancel-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cancel-readablestream" style="display:none">Info about the 'cancel a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-cancel-readablestream">https://fetch.spec.whatwg.org/#concept-cancel-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cancel-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-cancel-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">5.1. Processing</a>
     <li><a href="#ref-for-concept-request-client①">7.3.2. importScripts(urls)</a>
@@ -4910,83 +4910,83 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-client④">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-close-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-close-readablestream">https://fetch.spec.whatwg.org/#concept-close-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-close-readablestream" class="dfn-panel" data-for="term-for-concept-close-readablestream" id="infopanel-for-term-for-concept-close-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-close-readablestream" style="display:none">Info about the 'close readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-close-readablestream">https://fetch.spec.whatwg.org/#concept-close-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-close-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-close-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-construct-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-construct-readablestream">https://fetch.spec.whatwg.org/#concept-construct-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-construct-readablestream" class="dfn-panel" data-for="term-for-concept-construct-readablestream" id="infopanel-for-term-for-concept-construct-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-construct-readablestream" style="display:none">Info about the 'construct a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-construct-readablestream">https://fetch.spec.whatwg.org/#concept-construct-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-construct-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-construct-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-cors">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-cors" class="dfn-panel" data-for="term-for-concept-filtered-response-cors" id="infopanel-for-term-for-concept-filtered-response-cors" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-cors" style="display:none">Info about the 'cors filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-cors">7.4. Cross-Origin Resources and CORS</a>
     <li><a href="#ref-for-concept-filtered-response-cors①">Handle Foreign Fetch</a> <a href="#ref-for-concept-filtered-response-cors②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-cors-exposed-header-name-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list">https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-cors-exposed-header-name-list" class="dfn-panel" data-for="term-for-concept-response-cors-exposed-header-name-list" id="infopanel-for-term-for-concept-response-cors-exposed-header-name-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-cors-exposed-header-name-list" style="display:none">Info about the 'cors-exposed header-name list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list">https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-cors-exposed-header-name-list">Handle Foreign Fetch</a> <a href="#ref-for-concept-response-cors-exposed-header-name-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-destination①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-disturbed">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-disturbed">https://fetch.spec.whatwg.org/#concept-body-disturbed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-disturbed" class="dfn-panel" data-for="term-for-concept-body-disturbed" id="infopanel-for-term-for-concept-body-disturbed" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-disturbed" style="display:none">Info about the 'disturbed' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-disturbed">https://fetch.spec.whatwg.org/#concept-body-disturbed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-disturbed">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-disturbed①">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-disturbed②">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-empty-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-empty-readablestream">https://fetch.spec.whatwg.org/#concept-empty-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-empty-readablestream" class="dfn-panel" data-for="term-for-concept-empty-readablestream" id="infopanel-for-term-for-concept-empty-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-empty-readablestream" style="display:none">Info about the 'empty' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-empty-readablestream">https://fetch.spec.whatwg.org/#concept-empty-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-empty-readablestream">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-enqueue-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">https://fetch.spec.whatwg.org/#concept-enqueue-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-enqueue-readablestream" class="dfn-panel" data-for="term-for-concept-enqueue-readablestream" id="infopanel-for-term-for-concept-enqueue-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-enqueue-readablestream" style="display:none">Info about the 'enqueue a chunk to readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">https://fetch.spec.whatwg.org/#concept-enqueue-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-enqueue-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-enqueue-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-error-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-error-readablestream">https://fetch.spec.whatwg.org/#concept-error-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-error-readablestream" class="dfn-panel" data-for="term-for-concept-error-readablestream" id="infopanel-for-term-for-concept-error-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-error-readablestream" style="display:none">Info about the 'error readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-error-readablestream">https://fetch.spec.whatwg.org/#concept-error-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-error-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-error-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-readablestream-errored">
-   <a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">https://fetch.spec.whatwg.org/#concept-readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-readablestream-errored" class="dfn-panel" data-for="term-for-concept-readablestream-errored" id="infopanel-for-term-for-concept-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">https://fetch.spec.whatwg.org/#concept-readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-readablestream-errored">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-readablestream-errored①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extract a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.4. Selection and Use</a>
     <li><a href="#ref-for-concept-fetch①">4.6.4. event.respondWith(r)</a> <a href="#ref-for-concept-fetch②">(2)</a> <a href="#ref-for-concept-fetch③">(3)</a> <a href="#ref-for-concept-fetch④">(4)</a>
@@ -5000,44 +5000,44 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-fetch①⑦">Service Worker Script Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input, init)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">4.9. Events</a> <a href="#ref-for-dom-global-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response" class="dfn-panel" data-for="term-for-concept-filtered-response" id="infopanel-for-term-for-concept-filtered-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response" style="display:none">Info about the 'filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-filtered-response①">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-filtered-response②">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-get-reader">
-   <a href="https://fetch.spec.whatwg.org/#concept-get-reader">https://fetch.spec.whatwg.org/#concept-get-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-get-reader" class="dfn-panel" data-for="term-for-concept-get-reader" id="infopanel-for-term-for-concept-get-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-get-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-get-reader">https://fetch.spec.whatwg.org/#concept-get-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-get-reader">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-get-reader①">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-get-reader②">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-headers-get">
-   <a href="https://fetch.spec.whatwg.org/#dom-headers-get">https://fetch.spec.whatwg.org/#dom-headers-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-headers-get" class="dfn-panel" data-for="term-for-dom-headers-get" id="infopanel-for-term-for-dom-headers-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-headers-get" style="display:none">Info about the 'get(name)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-headers-get">https://fetch.spec.whatwg.org/#dom-headers-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-get">Query Cache</a> <a href="#ref-for-dom-headers-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-headers-guard">
-   <a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-headers-guard" class="dfn-panel" data-for="term-for-concept-headers-guard" id="infopanel-for-term-for-concept-headers-guard" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-headers-guard" style="display:none">Info about the 'guard' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-guard">6.4.4. addAll(requests)</a> <a href="#ref-for-concept-headers-guard①">(2)</a>
     <li><a href="#ref-for-concept-headers-guard②">6.4.5. put(request, response)</a> <a href="#ref-for-concept-headers-guard③">(2)</a>
     <li><a href="#ref-for-concept-headers-guard④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header①">6.4.5. put(request, response)</a>
@@ -5046,14 +5046,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header④">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-header-list①">6.4.5. put(request, response)</a>
@@ -5061,41 +5061,41 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-header-list④">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-headers">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-headers">https://fetch.spec.whatwg.org/#dom-request-headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-headers" class="dfn-panel" data-for="term-for-dom-request-headers" id="infopanel-for-term-for-dom-request-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-headers" style="display:none">Info about the 'headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-headers">https://fetch.spec.whatwg.org/#dom-request-headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-headers">Handle Fetch</a>
     <li><a href="#ref-for-dom-request-headers①">Query Cache</a> <a href="#ref-for-dom-request-headers②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">4.9. Events</a> <a href="#ref-for-concept-http-fetch①">(2)</a> <a href="#ref-for-concept-http-fetch②">(3)</a> <a href="#ref-for-concept-http-fetch③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">6.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-internal-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-internal-response" class="dfn-panel" data-for="term-for-concept-internal-response" id="infopanel-for-term-for-concept-internal-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-internal-response" style="display:none">Info about the 'internal response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-internal-response">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-locked">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-locked">https://fetch.spec.whatwg.org/#concept-body-locked</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-locked" class="dfn-panel" data-for="term-for-concept-body-locked" id="infopanel-for-term-for-concept-body-locked" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-locked" style="display:none">Info about the 'locked' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-locked">https://fetch.spec.whatwg.org/#concept-body-locked</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-locked">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-locked①">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-locked②">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">6.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-request-method①">6.4.4. addAll(requests)</a>
@@ -5105,22 +5105,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-method⑤">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header-name①">6.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-header-name②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.6.4. event.respondWith(r)</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">4.7.3. event.respondWith(r)</a> <a href="#ref-for-concept-network-error③">(2)</a>
@@ -5130,92 +5130,92 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-network-error①⓪">Handle Foreign Fetch</a> <a href="#ref-for-concept-network-error①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-subresource-request" class="dfn-panel" data-for="term-for-non-subresource-request" id="infopanel-for-term-for-non-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-non-subresource-request" style="display:none">Info about the 'non-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-subresource-request">2.4. Selection and Use</a>
     <li><a href="#ref-for-non-subresource-request①">Handle Fetch</a> <a href="#ref-for-non-subresource-request②">(2)</a> <a href="#ref-for-non-subresource-request③">(3)</a> <a href="#ref-for-non-subresource-request④">(4)</a> <a href="#ref-for-non-subresource-request⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-ok-status①">7.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-opaque">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-opaque" class="dfn-panel" data-for="term-for-concept-filtered-response-opaque" id="infopanel-for-term-for-concept-filtered-response-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-opaque" style="display:none">Info about the 'opaque filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque">7.4. Cross-Origin Resources and CORS</a>
     <li><a href="#ref-for-concept-filtered-response-opaque①">Handle Foreign Fetch</a> <a href="#ref-for-concept-filtered-response-opaque②">(2)</a> <a href="#ref-for-concept-filtered-response-opaque③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-opaque-redirect">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-opaque-redirect" class="dfn-panel" data-for="term-for-concept-filtered-response-opaque-redirect" id="infopanel-for-term-for-concept-filtered-response-opaque-redirect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-opaque-redirect" style="display:none">Info about the 'opaque-redirect filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque-redirect">Handle Foreign Fetch</a> <a href="#ref-for-concept-filtered-response-opaque-redirect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">Handle Foreign Fetch</a> <a href="#ref-for-concept-request-origin①">(2)</a> <a href="#ref-for-concept-request-origin②">(3)</a> <a href="#ref-for-concept-request-origin③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-parse">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-parse" class="dfn-panel" data-for="term-for-concept-header-parse" id="infopanel-for-term-for-concept-header-parse" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-parse" style="display:none">Info about the 'parsing' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-parse">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potential-navigation-or-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potential-navigation-or-subresource-request" class="dfn-panel" data-for="term-for-potential-navigation-or-subresource-request" id="infopanel-for-term-for-potential-navigation-or-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-potential-navigation-or-subresource-request" style="display:none">Info about the 'potential-navigation-or-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potential-navigation-or-subresource-request">7.5. Implementer Concerns</a>
     <li><a href="#ref-for-potential-navigation-or-subresource-request①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-response">
-   <a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-response" class="dfn-panel" data-for="term-for-process-response" id="infopanel-for-term-for-process-response" role="menu">
+   <span id="infopaneltitle-for-term-for-process-response" style="display:none">Info about the 'process response' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-process-response①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-response-end-of-file">
-   <a href="https://fetch.spec.whatwg.org/#process-response-end-of-file">https://fetch.spec.whatwg.org/#process-response-end-of-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-response-end-of-file" class="dfn-panel" data-for="term-for-process-response-end-of-file" id="infopanel-for-term-for-process-response-end-of-file" role="menu">
+   <span id="infopaneltitle-for-term-for-process-response-end-of-file" style="display:none">Info about the 'process response end-of-file' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-response-end-of-file">https://fetch.spec.whatwg.org/#process-response-end-of-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response-end-of-file">6.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-read-chunk-from-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-read-chunk-from-readablestream" class="dfn-panel" data-for="term-for-concept-read-chunk-from-readablestream" id="infopanel-for-term-for-concept-read-chunk-from-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-read-chunk-from-readablestream" style="display:none">Info about the 'read a chunk from a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-read-chunk-from-readablestream">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-read-chunk-from-readablestream①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-read-all-bytes-from-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-read-all-bytes-from-readablestream" class="dfn-panel" data-for="term-for-concept-read-all-bytes-from-readablestream" id="infopanel-for-term-for-concept-read-all-bytes-from-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-read-all-bytes-from-readablestream" style="display:none">Info about the 'read all bytes' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-read-all-bytes-from-readablestream">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-readablestream">https://fetch.spec.whatwg.org/#concept-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-readablestream" class="dfn-panel" data-for="term-for-concept-readablestream" id="infopanel-for-term-for-concept-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-readablestream" style="display:none">Info about the 'readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-readablestream">https://fetch.spec.whatwg.org/#concept-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-readablestream">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request (for fetch)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">5.1. Processing</a>
     <li><a href="#ref-for-concept-request①">7.3.2. importScripts(urls)</a>
@@ -5223,8 +5223,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request③">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">6.4.2. matchAll(request, options)</a> <a href="#ref-for-concept-request-request①">(2)</a>
     <li><a href="#ref-for-concept-request-request②">6.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-request③">(2)</a>
@@ -5235,8 +5235,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-request①④">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response (for fetch)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">4.6. FetchEvent</a>
     <li><a href="#ref-for-concept-response①">4.7. ForeignFetchEvent</a>
@@ -5246,8 +5246,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response⑧">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">2.1. Service Worker</a>
     <li><a href="#termref-for-concept-response-response">4.6.4. event.respondWith(r)</a>
@@ -5258,61 +5258,61 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-response⑦">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-response-tainting">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-response-tainting">https://fetch.spec.whatwg.org/#concept-request-response-tainting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-response-tainting" class="dfn-panel" data-for="term-for-concept-request-response-tainting" id="infopanel-for-term-for-concept-request-response-tainting" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-response-tainting" style="display:none">Info about the 'response tainting' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-response-tainting">https://fetch.spec.whatwg.org/#concept-request-response-tainting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-response-tainting">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-skip-service-worker-flag">
-   <a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">https://fetch.spec.whatwg.org/#skip-service-worker-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-skip-service-worker-flag" class="dfn-panel" data-for="term-for-skip-service-worker-flag" id="infopanel-for-term-for-skip-service-worker-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-skip-service-worker-flag" style="display:none">Info about the 'skip service worker flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">https://fetch.spec.whatwg.org/#skip-service-worker-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skip-service-worker-flag">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">7.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">4.6.4. event.respondWith(r)</a> <a href="#ref-for-concept-body-stream①">(2)</a> <a href="#ref-for-concept-body-stream②">(3)</a> <a href="#ref-for-concept-body-stream③">(4)</a> <a href="#ref-for-concept-body-stream④">(5)</a>
     <li><a href="#ref-for-concept-body-stream⑤">4.7.3. event.respondWith(r)</a> <a href="#ref-for-concept-body-stream⑥">(2)</a> <a href="#ref-for-concept-body-stream⑦">(3)</a> <a href="#ref-for-concept-body-stream⑧">(4)</a>
     <li><a href="#ref-for-concept-body-stream⑨">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subresource-request" class="dfn-panel" data-for="term-for-subresource-request" id="infopanel-for-term-for-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-subresource-request" style="display:none">Info about the 'subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">Handle Fetch</a> <a href="#ref-for-subresource-request①">(2)</a> <a href="#ref-for-subresource-request②">(3)</a> <a href="#ref-for-subresource-request③">(4)</a>
     <li><a href="#ref-for-subresource-request④">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch-terminate">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">https://fetch.spec.whatwg.org/#concept-fetch-terminate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch-terminate" class="dfn-panel" data-for="term-for-concept-fetch-terminate" id="infopanel-for-term-for-concept-fetch-terminate" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch-terminate" style="display:none">Info about the 'terminate' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">https://fetch.spec.whatwg.org/#concept-fetch-terminate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-terminate">6.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-termination-reason">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-termination-reason">https://fetch.spec.whatwg.org/#concept-response-termination-reason</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-termination-reason" class="dfn-panel" data-for="term-for-concept-response-termination-reason" id="infopanel-for-term-for-concept-response-termination-reason" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-termination-reason" style="display:none">Info about the 'termination reason' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-termination-reason">https://fetch.spec.whatwg.org/#concept-response-termination-reason</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-termination-reason">6.4.4. addAll(requests)</a> <a href="#ref-for-concept-response-termination-reason①">(2)</a>
     <li><a href="#ref-for-concept-response-termination-reason②">6.4.5. put(request, response)</a> <a href="#ref-for-concept-response-termination-reason③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-type①">7.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.4. Selection and Use</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a>
     <li><a href="#ref-for-concept-request-url③">6.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-url④">(2)</a>
@@ -5324,32 +5324,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-url①④">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstractworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstractworker" class="dfn-panel" data-for="term-for-abstractworker" id="infopanel-for-term-for-abstractworker" role="menu">
+   <span id="infopaneltitle-for-term-for-abstractworker" style="display:none">Info about the 'AbstractWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractworker">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">5.2. Link element interface extensions</a> <a href="#ref-for-cereactions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-domcontentloaded">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-domcontentloaded" class="dfn-panel" data-for="term-for-event-domcontentloaded" id="infopanel-for-term-for-event-domcontentloaded" role="menu">
+   <span id="infopaneltitle-for-term-for-event-domcontentloaded" style="display:none">Info about the 'DOMContentLoaded' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-domcontentloaded">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventhandler①">3.2. ServiceWorkerRegistration</a>
@@ -5357,14 +5357,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventhandler④">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-eventhandler⑤">(2)</a> <a href="#ref-for-eventhandler⑥">(3)</a> <a href="#ref-for-eventhandler⑦">(4)</a> <a href="#ref-for-eventhandler⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmllinkelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmllinkelement" class="dfn-panel" data-for="term-for-htmllinkelement" id="infopanel-for-term-for-htmllinkelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmllinkelement" style="display:none">Info about the 'HTMLLinkElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement">https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmllinkelement">5.2. Link element interface extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-messageport①">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-messageport②">(2)</a> <a href="#ref-for-messageport③">(3)</a> <a href="#ref-for-messageport④">(4)</a>
@@ -5374,21 +5374,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-messageport①①">4.8.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-navigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-navigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.3. Service Worker Client</a>
     <li><a href="#ref-for-window①">3.1.3. postMessage(message, transfer)</a>
@@ -5399,56 +5399,56 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window⑨">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">6.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-workerglobalscope①">6. Caches</a>
     <li><a href="#ref-for-workerglobalscope②">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerlocation">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerlocation" class="dfn-panel" data-for="term-for-workerlocation" id="infopanel-for-term-for-workerlocation" role="menu">
+   <span id="infopaneltitle-for-term-for-workerlocation" style="display:none">Info about the 'WorkerLocation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerlocation">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-workernavigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-workernavigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workertype">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workertype" class="dfn-panel" data-for="term-for-workertype" id="infopanel-for-term-for-workertype" role="menu">
+   <span id="infopaneltitle-for-term-for-workertype" style="display:none">Info about the 'WorkerType' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workertype">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-workertype①">5.1. Processing</a> <a href="#ref-for-workertype②">(2)</a>
     <li><a href="#ref-for-workertype③">5.2. Link element interface extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-about:blank">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank">https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-about:blank" class="dfn-panel" data-for="term-for-about:blank" id="infopanel-for-term-for-about:blank" role="menu">
+   <span id="infopaneltitle-for-term-for-about:blank" style="display:none">Info about the 'about:blank' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank">https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-about:blank">4.2.8. navigate(url)</a>
     <li><a href="#ref-for-about:blank①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#active-document">https://html.spec.whatwg.org/multipage/document-sequences.html#active-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-document" class="dfn-panel" data-for="term-for-active-document" id="infopanel-for-term-for-active-document" role="menu">
+   <span id="infopaneltitle-for-term-for-active-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#active-document">https://html.spec.whatwg.org/multipage/document-sequences.html#active-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-document">4.2.7. focus()</a> <a href="#ref-for-active-document①">(2)</a>
     <li><a href="#ref-for-active-document②">4.2.8. navigate(url)</a> <a href="#ref-for-active-document③">(2)</a>
@@ -5457,8 +5457,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-active-document①②">4.3.3. openWindow(url)</a> <a href="#ref-for-active-document①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-api-base-url①">3.4.4. getRegistration(clientURL)</a>
@@ -5469,20 +5469,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-api-base-url⑥">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-url-character-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-url-character-encoding" class="dfn-panel" data-for="term-for-api-url-character-encoding" id="infopanel-for-term-for-api-url-character-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-api-url-character-encoding" style="display:none">Info about the 'api url character encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-url-character-encoding">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-browsing-context①">4.2.2. frameType</a> <a href="#ref-for-browsing-context②">(2)</a> <a href="#ref-for-browsing-context③">(3)</a>
@@ -5492,14 +5492,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-browsing-context⑦">4.3.2. matchAll(options)</a> <a href="#ref-for-browsing-context⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-classic-script" class="dfn-panel" data-for="term-for-classic-script" id="infopanel-for-term-for-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-classic-script" style="display:none">Info about the 'classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-creation-url" class="dfn-panel" data-for="term-for-creation-url" id="infopanel-for-term-for-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creation-url">2.4. Selection and Use</a>
     <li><a href="#ref-for-creation-url①">3.4.2. ready</a>
@@ -5515,14 +5515,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-creation-url①①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-base-url" class="dfn-panel" data-for="term-for-document-base-url" id="infopanel-for-term-for-document-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-document-base-url" style="display:none">Info about the 'document base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-base-url">5.1. Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-manipulation-task-source①">Resolve Job Promise</a> <a href="#ref-for-dom-manipulation-task-source②">(2)</a>
@@ -5532,16 +5532,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-manipulation-task-source⑦">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-entry-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-entry-settings-object" class="dfn-panel" data-for="term-for-entry-settings-object" id="infopanel-for-term-for-entry-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-entry-settings-object" style="display:none">Info about the 'entry settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-settings-object">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-entry-settings-object①">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-entry-settings-object②">Start Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.3. Service Worker Client</a> <a href="#ref-for-environment-settings-object①">(2)</a>
     <li><a href="#ref-for-environment-settings-object②">3.5.2. event.origin</a>
@@ -5558,8 +5558,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object①⑥">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.1.4. Event handler</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">3.2.7. Event handler</a> <a href="#ref-for-event-handlers③">(2)</a>
@@ -5568,8 +5568,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handlers⑧">Update Worker State</a> <a href="#ref-for-event-handlers⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.1.4. Event handler</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">3.2.7. Event handler</a> <a href="#ref-for-event-handler-event-type③">(2)</a>
@@ -5577,8 +5577,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-event-type⑥">4.1.4. Event handlers</a> <a href="#ref-for-event-handler-event-type⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.1.4. Event handler</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">3.2.7. Event handler</a>
@@ -5586,8 +5586,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-idl-attributes③">4.1.4. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">2.2. Service Worker Registration</a> <a href="#ref-for-concept-agent-event-loop①">(2)</a> <a href="#ref-for-concept-agent-event-loop②">(3)</a> <a href="#ref-for-concept-agent-event-loop③">(4)</a>
     <li><a href="#ref-for-concept-agent-event-loop④">3.4. ServiceWorkerContainer</a>
@@ -5598,20 +5598,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-agent-event-loop①①">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-external-resource-link">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#external-resource-link">https://html.spec.whatwg.org/multipage/semantics.html#external-resource-link</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-external-resource-link" class="dfn-panel" data-for="term-for-external-resource-link" id="infopanel-for-term-for-external-resource-link" role="menu">
+   <span id="infopaneltitle-for-term-for-external-resource-link" style="display:none">Info about the 'external resource link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#external-resource-link">https://html.spec.whatwg.org/multipage/semantics.html#external-resource-link</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-external-resource-link">5. Link type "serviceworker"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-classic-worker-script" class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script" id="infopanel-for-term-for-fetch-a-classic-worker-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-classic-worker-script" style="display:none">Info about the 'fetch a classic worker script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-classic-worker-script">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-a-simple-event">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-a-simple-event" class="dfn-panel" data-for="term-for-fire-a-simple-event" id="infopanel-for-term-for-fire-a-simple-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-a-simple-event" style="display:none">Info about the 'fire a simple event' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-simple-event">5.1. Processing</a> <a href="#ref-for-fire-a-simple-event①">(2)</a> <a href="#ref-for-fire-a-simple-event②">(3)</a> <a href="#ref-for-fire-a-simple-event③">(4)</a>
     <li><a href="#ref-for-fire-a-simple-event④">Install</a>
@@ -5619,15 +5619,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-fire-a-simple-event⑥">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusing-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusing-steps" class="dfn-panel" data-for="term-for-focusing-steps" id="infopanel-for-term-for-focusing-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-focusing-steps" style="display:none">Info about the 'focusing steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusing-steps">4.2.7. focus()</a>
     <li><a href="#ref-for-focusing-steps①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-realm-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-realm-global" class="dfn-panel" data-for="term-for-concept-realm-global" id="infopanel-for-term-for-concept-realm-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-realm-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-realm-global">2.3. Service Worker Client</a> <a href="#ref-for-concept-realm-global①">(2)</a> <a href="#ref-for-concept-realm-global②">(3)</a>
     <li><a href="#ref-for-concept-realm-global③">3.2.5. update()</a>
@@ -5649,8 +5649,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-realm-global②⑤">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-focus-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-focus-steps" class="dfn-panel" data-for="term-for-has-focus-steps" id="infopanel-for-term-for-has-focus-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-has-focus-steps" style="display:none">Info about the 'has focus steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-focus-steps">4.2.7. focus()</a>
     <li><a href="#ref-for-has-focus-steps①">4.2.8. navigate(url)</a>
@@ -5659,32 +5659,32 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-has-focus-steps⑤">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-href">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-href" class="dfn-panel" data-for="term-for-attr-link-href" id="infopanel-for-term-for-attr-link-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-href" style="display:none">Info about the 'href' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-link-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-href">5.1. Processing</a> <a href="#ref-for-attr-link-href①">(2)</a> <a href="#ref-for-attr-link-href②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-https-state">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-https-state" class="dfn-panel" data-for="term-for-https-state" id="infopanel-for-term-for-https-state" role="menu">
+   <span id="infopaneltitle-for-term-for-https-state" style="display:none">Info about the 'https state (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-https-state">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-https-state">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-https-state" class="dfn-panel" data-for="term-for-concept-workerglobalscope-https-state" id="infopanel-for-term-for-concept-workerglobalscope-https-state" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-https-state" style="display:none">Info about the 'https state (for workerglobalscope)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-https-state">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-https-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope" id="infopanel-for-term-for-import-scripts-into-worker-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" style="display:none">Info about the 'import scripts into worker global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-scripts-into-worker-global-scope">7.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.4.2. ready</a>
     <li><a href="#ref-for-in-parallel①">3.4.4. getRegistration(clientURL)</a>
@@ -5716,41 +5716,41 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-in-parallel③⑧">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-incumbent-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-incumbent-settings-object" class="dfn-panel" data-for="term-for-incumbent-settings-object" id="infopanel-for-term-for-incumbent-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-incumbent-settings-object" style="display:none">Info about the 'incumbent settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incumbent-settings-object">3.1.3. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-kill-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-kill-a-worker" class="dfn-panel" data-for="term-for-kill-a-worker" id="infopanel-for-term-for-kill-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-kill-a-worker" style="display:none">Info about the 'kill a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker">https://html.spec.whatwg.org/multipage/workers.html#kill-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kill-a-worker">Run Service Worker</a>
     <li><a href="#ref-for-kill-a-worker①">Handle Service Worker Client Unload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">5. Link type "serviceworker"</a>
     <li><a href="#ref-for-the-link-element①">5.1. Processing</a> <a href="#ref-for-the-link-element②">(2)</a> <a href="#ref-for-the-link-element③">(3)</a> <a href="#ref-for-the-link-element④">(4)</a> <a href="#ref-for-the-link-element⑤">(5)</a> <a href="#ref-for-the-link-element⑥">(6)</a> <a href="#ref-for-the-link-element⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-message">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-message" class="dfn-panel" data-for="term-for-event-message" id="infopanel-for-term-for-event-message" role="menu">
+   <span id="infopaneltitle-for-term-for-event-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-message">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-event-message①">4.8. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-module-script" class="dfn-panel" data-for="term-for-module-script" id="infopanel-for-term-for-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-module-script" style="display:none">Info about the 'module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">3.2.6. unregister()</a>
     <li><a href="#ref-for-navigate①">4.2.8. navigate(url)</a>
@@ -5758,8 +5758,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-navigate③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-2">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">https://html.spec.whatwg.org/multipage/browsers.html#origin-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-2" class="dfn-panel" data-for="term-for-origin-2" id="infopanel-for-term-for-origin-2" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-2" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">https://html.spec.whatwg.org/multipage/browsers.html#origin-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-2">2.1. Service Worker</a>
     <li><a href="#ref-for-origin-2①">3.1.3. postMessage(message, transfer)</a>
@@ -5785,8 +5785,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-origin-2③⑥">Unregister</a> <a href="#ref-for-origin-2③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-queue-a-task①">3.1.3. postMessage(message, transfer)</a>
@@ -5813,30 +5813,30 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-queue-a-task③②">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-execution-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-execution-context" class="dfn-panel" data-for="term-for-realm-execution-context" id="infopanel-for-term-for-realm-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-execution-context" style="display:none">Info about the 'realm execution context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-execution-context">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-concept-relevant-global①">4.2.8. navigate(url)</a>
     <li><a href="#ref-for-concept-relevant-global②">4.5.1. event.registerForeignFetch(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.2.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-relevant-realm②">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.2.5. update()</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
     <li><a href="#ref-for-relevant-settings-object②">3.2.6. unregister()</a>
@@ -5850,8 +5850,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-relevant-settings-object①⓪">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">4.2.7. focus()</a>
     <li><a href="#ref-for-responsible-event-loop①">4.2.8. navigate(url)</a>
@@ -5865,20 +5865,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-responsible-event-loop①③">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-classic-script" class="dfn-panel" data-for="term-for-run-a-classic-script" id="infopanel-for-term-for-run-a-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-classic-script" style="display:none">Info about the 'run a classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-module-script" class="dfn-panel" data-for="term-for-run-a-module-script" id="infopanel-for-term-for-run-a-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-module-script" style="display:none">Info about the 'run a module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-same-origin①">4.2.8. navigate(url)</a>
@@ -5888,27 +5888,27 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-same-origin⑤">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script" class="dfn-panel" data-for="term-for-concept-script" id="infopanel-for-term-for-concept-script" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-workers">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">https://html.spec.whatwg.org/multipage/workers.html#shared-workers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-workers" class="dfn-panel" data-for="term-for-shared-workers" id="infopanel-for-term-for-shared-workers" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-workers" style="display:none">Info about the 'shared workers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">https://html.spec.whatwg.org/multipage/workers.html#shared-workers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-workers">1. Motivations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredclonewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer">https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredclonewithtransfer" class="dfn-panel" data-for="term-for-structuredclonewithtransfer" id="infopanel-for-term-for-structuredclonewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredclonewithtransfer" style="display:none">Info about the 'structuredclonewithtransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer">https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredclonewithtransfer">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-structuredclonewithtransfer①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2.2. Service Worker Registration</a> <a href="#ref-for-concept-task①">(2)</a>
     <li><a href="#ref-for-concept-task②">3.1.3. postMessage(message, transfer)</a>
@@ -5923,16 +5923,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-task①③">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-task-queue①">(2)</a> <a href="#ref-for-task-queue②">(3)</a>
     <li><a href="#ref-for-task-queue③">Run Service Worker</a>
     <li><a href="#ref-for-task-queue④">Terminate Service Worker</a> <a href="#ref-for-task-queue⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2.5. Task Sources</a> <a href="#ref-for-task-source①">(2)</a> <a href="#ref-for-task-source②">(3)</a>
     <li><a href="#ref-for-task-source③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-task-source④">(2)</a>
@@ -5942,39 +5942,39 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-task-source①⓪">Terminate Service Worker</a> <a href="#ref-for-task-source①①">(2)</a> <a href="#ref-for-task-source①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-terminate-a-worker" class="dfn-panel" data-for="term-for-terminate-a-worker" id="infopanel-for-term-for-terminate-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-terminate-a-worker" style="display:none">Info about the 'terminate a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-a-worker">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bc-tlbc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc">https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bc-tlbc" class="dfn-panel" data-for="term-for-bc-tlbc" id="infopanel-for-term-for-bc-tlbc" role="menu">
+   <span id="infopaneltitle-for-term-for-bc-tlbc" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc">https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bc-tlbc">4.2.2. frameType</a>
     <li><a href="#ref-for-bc-tlbc①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-type">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-type" class="dfn-panel" data-for="term-for-concept-workerglobalscope-type" id="infopanel-for-term-for-concept-workerglobalscope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unsafe-response">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unsafe-response" class="dfn-panel" data-for="term-for-unsafe-response" id="infopanel-for-term-for-unsafe-response" role="menu">
+   <span id="infopaneltitle-for-term-for-unsafe-response" style="display:none">Info about the 'unsafe response' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-response">7.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-url">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-url" class="dfn-panel" data-for="term-for-concept-workerglobalscope-url" id="infopanel-for-term-for-concept-workerglobalscope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-url" style="display:none">Info about the 'url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-url">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-interaction-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-interaction-task-source" class="dfn-panel" data-for="term-for-user-interaction-task-source" id="infopanel-for-term-for-user-interaction-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-user-interaction-task-source" style="display:none">Info about the 'user interaction task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-interaction-task-source">4.2.7. focus()</a>
     <li><a href="#ref-for-user-interaction-task-source①">4.2.8. navigate(url)</a>
@@ -5982,21 +5982,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-user-interaction-task-source④">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workers">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workers">https://html.spec.whatwg.org/multipage/workers.html#workers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workers" class="dfn-panel" data-for="term-for-workers" id="infopanel-for-term-for-workers" role="menu">
+   <span id="infopaneltitle-for-term-for-workers" style="display:none">Info about the 'web worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workers">https://html.spec.whatwg.org/multipage/workers.html#workers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workers">Unnumbered Section</a>
     <li><a href="#ref-for-workers①">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VisibilityState">
-   <a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VisibilityState" class="dfn-panel" data-for="term-for-VisibilityState" id="infopanel-for-term-for-VisibilityState" role="menu">
+   <span id="infopaneltitle-for-term-for-VisibilityState" style="display:none">Info about the 'VisibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VisibilityState">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-visibilitystate" class="dfn-panel" data-for="term-for-dom-document-visibilitystate" id="infopanel-for-term-for-dom-document-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-document-visibilitystate①">4.2.7. focus()</a>
@@ -6006,8 +6006,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-document-visibilitystate⑥">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transforming-by">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">https://www.w3.org/2001/tag/doc/promises-guide#transforming-by</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transforming-by" class="dfn-panel" data-for="term-for-transforming-by" id="infopanel-for-term-for-transforming-by" role="menu">
+   <span id="infopaneltitle-for-term-for-transforming-by" style="display:none">Info about the 'transforming' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">https://www.w3.org/2001/tag/doc/promises-guide#transforming-by</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transforming-by">6.4.3. add(request)</a>
     <li><a href="#ref-for-transforming-by①">6.4.4. addAll(requests)</a> <a href="#ref-for-transforming-by②">(2)</a> <a href="#ref-for-transforming-by③">(3)</a>
@@ -6018,74 +6018,74 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-transforming-by⑧">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all" class="dfn-panel" data-for="term-for-waiting-for-all" id="infopanel-for-term-for-waiting-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all">6.4.4. addAll(requests)</a> <a href="#ref-for-waiting-for-all①">(2)</a>
     <li><a href="#ref-for-waiting-for-all②">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted">
-   <a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" id="infopanel-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" style="display:none">Info about the 'onbeforeevicted' external reference.</span><a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-ServiceWorkerGlobalScope-onbeforeevicted">8. Storage Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onevicted">
-   <a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onevicted" id="infopanel-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" style="display:none">Info about the 'onevicted' external reference.</span><a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-ServiceWorkerGlobalScope-onevicted">8. Storage Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2">
-   <a href="https://tools.ietf.org/html/rfc5988#section-5.2">https://tools.ietf.org/html/rfc5988#section-5.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2" class="dfn-panel" data-for="term-for-section-5.2" id="infopanel-for-term-for-section-5.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2" style="display:none">Info about the 'context iri' external reference.</span><a href="https://tools.ietf.org/html/rfc5988#section-5.2">https://tools.ietf.org/html/rfc5988#section-5.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2">5.1. Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.4">
-   <a href="https://tools.ietf.org/html/rfc5988#section-5.4">https://tools.ietf.org/html/rfc5988#section-5.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.4" class="dfn-panel" data-for="term-for-section-5.4" id="infopanel-for-term-for-section-5.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.4" style="display:none">Info about the 'target attribute' external reference.</span><a href="https://tools.ietf.org/html/rfc5988#section-5.4">https://tools.ietf.org/html/rfc5988#section-5.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.4">5.1. Processing</a> <a href="#ref-for-section-5.4①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.1">
-   <a href="https://tools.ietf.org/html/rfc5988#section-5.1">https://tools.ietf.org/html/rfc5988#section-5.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.1" class="dfn-panel" data-for="term-for-section-5.1" id="infopanel-for-term-for-section-5.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.1" style="display:none">Info about the 'target iri' external reference.</span><a href="https://tools.ietf.org/html/rfc5988#section-5.1">https://tools.ietf.org/html/rfc5988#section-5.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.1">5.1. Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'field-value' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-3.2①">6.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-3.2②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-7.1.4①">6.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-7.1.4②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-origin-trustworthy">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-origin-trustworthy" class="dfn-panel" data-for="term-for-is-origin-trustworthy" id="infopanel-for-term-for-is-origin-trustworthy" role="menu">
+   <span id="infopaneltitle-for-term-for-is-origin-trustworthy" style="display:none">Info about the 'is origin potentially trustworthy' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-origin-trustworthy">5.1. Processing</a>
     <li><a href="#ref-for-is-origin-trustworthy①">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-threat-risks">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks">https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-threat-risks" class="dfn-panel" data-for="term-for-threat-risks" id="infopanel-for-term-for-threat-risks" role="menu">
+   <span id="infopaneltitle-for-term-for-threat-risks" style="display:none">Info about the 'risks associated with insecure contexts' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks">https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-threat-risks">7.1. Secure Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4.3.1. get(id)</a>
     <li><a href="#ref-for-secure-context①">4.3.2. matchAll(options)</a>
@@ -6096,16 +6096,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-secure-context⑨">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">Register</a>
     <li><a href="#ref-for-concept-url-equals①">Update</a> <a href="#ref-for-concept-url-equals②">(2)</a>
     <li><a href="#ref-for-concept-url-equals③">Query Cache</a> <a href="#ref-for-concept-url-equals④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'parsing' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.4.3. register(scriptURL, options)</a>
     <li><a href="#ref-for-concept-url-parser①">3.4.4. getRegistration(clientURL)</a>
@@ -6120,21 +6120,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-parser①④">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">Start Register</a> <a href="#ref-for-concept-url-path①">(2)</a>
     <li><a href="#ref-for-concept-url-path②">Update</a> <a href="#ref-for-concept-url-path③">(2)</a> <a href="#ref-for-concept-url-path④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">Query Cache</a> <a href="#ref-for-concept-url-query①">(2)</a> <a href="#ref-for-concept-url-query②">(3)</a> <a href="#ref-for-concept-url-query③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">6.4.4. addAll(requests)</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
     <li><a href="#ref-for-concept-url-scheme②">6.4.5. put(request, response)</a> <a href="#ref-for-concept-url-scheme③">(2)</a>
@@ -6142,8 +6142,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-scheme⑥">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'serialized' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3.1.1. scriptURL</a>
     <li><a href="#ref-for-concept-url-serializer①">3.2.4. scope</a>
@@ -6156,14 +6156,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-serializer①①">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">4.7. ForeignFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a>
     <li><a href="#ref-for-idl-DOMString⑤">4.2. Client</a>
@@ -6177,8 +6177,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMString②⓪">6.5. CacheStorage</a> <a href="#ref-for-idl-DOMString②①">(2)</a> <a href="#ref-for-idl-DOMString②②">(3)</a> <a href="#ref-for-idl-DOMString②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. ServiceWorker</a>
     <li><a href="#ref-for-Exposed①">3.2. ServiceWorkerRegistration</a>
@@ -6196,28 +6196,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-Exposed①④">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-idl-frozen-array①">4.8. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">4.2.7. focus()</a>
     <li><a href="#ref-for-invalidaccesserror①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-invalidstateerror①">3.2.5. update()</a> <a href="#ref-for-invalidstateerror②">(2)</a>
@@ -6229,8 +6229,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-invalidstateerror①⓪">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-NewObject①">(2)</a>
     <li><a href="#ref-for-NewObject②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-NewObject③">(2)</a> <a href="#ref-for-NewObject④">(3)</a>
@@ -6241,8 +6241,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-NewObject①⑨">6.5. CacheStorage</a> <a href="#ref-for-NewObject②⓪">(2)</a> <a href="#ref-for-NewObject②①">(3)</a> <a href="#ref-for-NewObject②②">(4)</a> <a href="#ref-for-NewObject②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-idl-promise③">(2)</a> <a href="#ref-for-idl-promise④">(3)</a> <a href="#ref-for-idl-promise⑤">(4)</a>
@@ -6256,16 +6256,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-promise②③">6.5. CacheStorage</a> <a href="#ref-for-idl-promise②④">(2)</a> <a href="#ref-for-idl-promise②⑤">(3)</a> <a href="#ref-for-idl-promise②⑥">(4)</a> <a href="#ref-for-idl-promise②⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://heycam.github.io/webidl/#quotaexceedederror">https://heycam.github.io/webidl/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://heycam.github.io/webidl/#quotaexceedederror">https://heycam.github.io/webidl/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">6.5.3. open(cacheName)</a>
     <li><a href="#ref-for-quotaexceedederror①">8. Storage Considerations</a>
     <li><a href="#ref-for-quotaexceedederror②">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.3. navigator.serviceWorker</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject②">3.4. ServiceWorkerContainer</a>
@@ -6277,8 +6277,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SameObject⑨">6.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. ServiceWorker</a>
     <li><a href="#ref-for-SecureContext①">3.2. ServiceWorkerRegistration</a>
@@ -6289,8 +6289,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SecureContext⑦">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-securityerror①">4.3.1. get(id)</a>
@@ -6299,8 +6299,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-securityerror⑧">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-USVString①">3.2. ServiceWorkerRegistration</a>
@@ -6312,8 +6312,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-USVString①④">5.2. Link element interface extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-any①">3.4. ServiceWorkerContainer</a>
@@ -6326,8 +6326,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-any①⓪">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-idl-boolean①">4.2. Client</a>
@@ -6337,35 +6337,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-boolean⑨">6.5. CacheStorage</a> <a href="#ref-for-idl-boolean①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception" class="dfn-panel" data-for="term-for-dfn-exception" id="infopanel-for-term-for-dfn-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception" style="display:none">Info about the 'exception' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-object①">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-partial-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-partial-interface" class="dfn-panel" data-for="term-for-dfn-partial-interface" id="infopanel-for-term-for-dfn-partial-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-partial-interface" style="display:none">Info about the 'partial interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-interface">9.1. Define API bound to Service Worker Registration</a>
     <li><a href="#ref-for-dfn-partial-interface①">9.3. Define Event Handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-sequence①">3.4. ServiceWorkerContainer</a>
@@ -6379,8 +6379,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-sequence①②">6.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">4.2.4. postMessage(message, transfer)</a> <a href="#ref-for-dfn-throw④">(2)</a> <a href="#ref-for-dfn-throw⑤">(3)</a>
@@ -6968,8 +6968,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <div class="issue">The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state. <a class="issue-return" href="#issue-b27ba9d2" title="Jump to section">↵</a></div>
    <div class="issue">Remove this definition after sorting out the referencing sites. <a class="issue-return" href="#issue-b739bfcf" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dfn-service-worker">
-   <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker" class="dfn-panel" data-for="dfn-service-worker" id="infopanel-for-dfn-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1. Motivations</a> <a href="#ref-for-dfn-service-worker">(2)</a> <a href="#ref-for-dfn-service-worker">(3)</a> <a href="#ref-for-dfn-service-worker">(4)</a> <a href="#ref-for-dfn-service-worker">(5)</a> <a href="#ref-for-dfn-service-worker">(6)</a> <a href="#ref-for-dfn-service-worker">(7)</a> <a href="#ref-for-dfn-service-worker">(8)</a> <a href="#ref-for-dfn-service-worker">(9)</a> <a href="#ref-for-dfn-service-worker">(10)</a> <a href="#ref-for-dfn-service-worker">(11)</a> <a href="#ref-for-dfn-service-worker">(12)</a> <a href="#ref-for-dfn-service-worker">(13)</a> <a href="#ref-for-dfn-service-worker">(14)</a>
     <li><a href="#ref-for-dfn-service-worker">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker">(2)</a> <a href="#ref-for-dfn-service-worker">(3)</a> <a href="#ref-for-dfn-service-worker">(4)</a> <a href="#ref-for-dfn-service-worker">(5)</a> <a href="#ref-for-dfn-service-worker">(6)</a> <a href="#ref-for-dfn-service-worker">(7)</a> <a href="#ref-for-dfn-service-worker">(8)</a> <a href="#ref-for-dfn-service-worker">(9)</a> <a href="#ref-for-dfn-service-worker">(10)</a> <a href="#ref-for-dfn-service-worker">(11)</a> <a href="#ref-for-dfn-service-worker">(12)</a> <a href="#ref-for-dfn-service-worker">(13)</a> <a href="#ref-for-dfn-service-worker">(14)</a>
@@ -7021,8 +7021,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-state">
-   <b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-state" class="dfn-panel" data-for="dfn-state" id="infopanel-for-dfn-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state">(2)</a> <a href="#ref-for-dfn-state">(3)</a>
     <li><a href="#ref-for-dfn-state">3.1. ServiceWorker</a>
@@ -7035,8 +7035,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-state">Update Worker State</a> <a href="#ref-for-dfn-state">(2)</a> <a href="#ref-for-dfn-state">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-url">
-   <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-url" class="dfn-panel" data-for="dfn-script-url" id="infopanel-for-dfn-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url">3.1.1. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url">3.2.5. update()</a>
@@ -7046,8 +7046,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-url">Run Service Worker</a> <a href="#ref-for-dfn-script-url">(2)</a> <a href="#ref-for-dfn-script-url">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type">
-   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type" class="dfn-panel" data-for="dfn-type" id="infopanel-for-dfn-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.2.5. update()</a>
     <li><a href="#ref-for-dfn-type">Update</a>
@@ -7055,8 +7055,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-service-worker-registration">
-   <b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-service-worker-registration" class="dfn-panel" data-for="dfn-containing-service-worker-registration" id="infopanel-for-dfn-containing-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-service-worker-registration" style="display:none">Info about the 'containing service worker registration' definition.</span><b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.4. Selection and Use</a>
@@ -7072,21 +7072,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-containing-service-worker-registration">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-id">
-   <b><a href="#dfn-service-worker-id">#dfn-service-worker-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-id" class="dfn-panel" data-for="dfn-service-worker-id" id="infopanel-for-dfn-service-worker-id" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dfn-service-worker-id">#dfn-service-worker-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-id">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-lifecycle-events">
-   <b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-lifecycle-events" class="dfn-panel" data-for="dfn-lifecycle-events" id="infopanel-for-dfn-lifecycle-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-lifecycle-events" style="display:none">Info about the 'lifecycle events' definition.</span><b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lifecycle-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-lifecycle-events">4.9. Events</a> <a href="#ref-for-dfn-lifecycle-events">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-functional-events">
-   <b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-functional-events" class="dfn-panel" data-for="dfn-functional-events" id="infopanel-for-dfn-functional-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-functional-events" style="display:none">Info about the 'functional events' definition.</span><b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-functional-events">2.5. Task Sources</a>
     <li><a href="#ref-for-dfn-functional-events">4.4. ExtendableEvent</a>
@@ -7099,8 +7099,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-functional-events">Update Worker State</a> <a href="#ref-for-dfn-functional-events">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource">
-   <b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource" class="dfn-panel" data-for="dfn-script-resource" id="infopanel-for-dfn-script-resource" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource" style="display:none">Info about the 'script resource' definition.</span><b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource">(2)</a>
     <li><a href="#ref-for-dfn-script-resource">7.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource">(2)</a>
@@ -7111,64 +7111,64 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-resource">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
-   <b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag" id="infopanel-for-dfn-has-ever-been-evaluated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" style="display:none">Info about the 'has ever been evaluated flag' definition.</span><b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-has-ever-been-evaluated-flag">Run Service Worker</a> <a href="#ref-for-dfn-has-ever-been-evaluated-flag">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-https-state">
-   <b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-https-state" class="dfn-panel" data-for="dfn-https-state" id="infopanel-for-dfn-https-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-https-state" style="display:none">Info about the 'HTTPS state' definition.</span><b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-https-state">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource-map">
-   <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource-map" class="dfn-panel" data-for="dfn-script-resource-map" id="infopanel-for-dfn-script-resource-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource-map" style="display:none">Info about the 'script resource map' definition.</span><b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource-map">7.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map">(2)</a> <a href="#ref-for-dfn-script-resource-map">(3)</a>
     <li><a href="#ref-for-dfn-script-resource-map">7.6. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
-   <b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-skip-waiting-flag" class="dfn-panel" data-for="dfn-skip-waiting-flag" id="infopanel-for-dfn-skip-waiting-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-skip-waiting-flag" style="display:none">Info about the 'skip waiting flag' definition.</span><b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag">3.6. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag">Install</a> <a href="#ref-for-dfn-skip-waiting-flag">(2)</a> <a href="#ref-for-dfn-skip-waiting-flag">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
-   <b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-imported-scripts-updated-flag" class="dfn-panel" data-for="dfn-imported-scripts-updated-flag" id="infopanel-for-dfn-imported-scripts-updated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-imported-scripts-updated-flag" style="display:none">Info about the 'imported scripts updated flag' definition.</span><b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-imported-scripts-updated-flag">7.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-imported-scripts-updated-flag">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
-   <b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-event-types-to-handle" class="dfn-panel" data-for="dfn-set-of-event-types-to-handle" id="infopanel-for-dfn-set-of-event-types-to-handle" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-event-types-to-handle" style="display:none">Info about the 'set of event types to handle' definition.</span><b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Handle Fetch</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-foreign-fetch-scopes">
-   <b><a href="#dfn-foreign-fetch-scopes">#dfn-foreign-fetch-scopes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-foreign-fetch-scopes" class="dfn-panel" data-for="dfn-foreign-fetch-scopes" id="infopanel-for-dfn-foreign-fetch-scopes" role="dialog">
+   <span id="infopaneltitle-for-dfn-foreign-fetch-scopes" style="display:none">Info about the 'list of foreign fetch scopes' definition.</span><b><a href="#dfn-foreign-fetch-scopes">#dfn-foreign-fetch-scopes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-foreign-fetch-scopes">4.5.1. event.registerForeignFetch(options)</a>
     <li><a href="#ref-for-dfn-foreign-fetch-scopes①">Match Service Worker for Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-foreign-fetch-origins">
-   <b><a href="#dfn-foreign-fetch-origins">#dfn-foreign-fetch-origins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-foreign-fetch-origins" class="dfn-panel" data-for="dfn-foreign-fetch-origins" id="infopanel-for-dfn-foreign-fetch-origins" role="dialog">
+   <span id="infopaneltitle-for-dfn-foreign-fetch-origins" style="display:none">Info about the 'list of foreign fetch origins' definition.</span><b><a href="#dfn-foreign-fetch-origins">#dfn-foreign-fetch-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-foreign-fetch-origins">4.5.1. event.registerForeignFetch(options)</a>
     <li><a href="#ref-for-dfn-foreign-fetch-origins①">Handle Foreign Fetch</a> <a href="#ref-for-dfn-foreign-fetch-origins②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration" id="infopanel-for-dfn-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration">(2)</a> <a href="#ref-for-dfn-service-worker-registration">(3)</a> <a href="#ref-for-dfn-service-worker-registration">(4)</a> <a href="#ref-for-dfn-service-worker-registration">(5)</a> <a href="#ref-for-dfn-service-worker-registration">(6)</a> <a href="#ref-for-dfn-service-worker-registration">(7)</a> <a href="#ref-for-dfn-service-worker-registration">(8)</a> <a href="#ref-for-dfn-service-worker-registration">(9)</a> <a href="#ref-for-dfn-service-worker-registration">(10)</a> <a href="#ref-for-dfn-service-worker-registration">(11)</a> <a href="#ref-for-dfn-service-worker-registration">(12)</a> <a href="#ref-for-dfn-service-worker-registration">(13)</a> <a href="#ref-for-dfn-service-worker-registration">(14)</a>
@@ -7200,8 +7200,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration">Get Newest Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-url">
-   <b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-url" class="dfn-panel" data-for="dfn-scope-url" id="infopanel-for-dfn-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-scope-url">(2)</a> <a href="#ref-for-dfn-scope-url">(3)</a>
     <li><a href="#ref-for-dfn-scope-url">2.2.1. Lifetime</a>
@@ -7222,8 +7222,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-url">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-installing-worker">
-   <b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-installing-worker" class="dfn-panel" data-for="dfn-installing-worker" id="infopanel-for-dfn-installing-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-installing-worker" style="display:none">Info about the 'installing worker' definition.</span><b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-installing-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-installing-worker">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker①">(2)</a>
@@ -7238,8 +7238,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-installing-worker">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-waiting-worker">
-   <b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-waiting-worker" class="dfn-panel" data-for="dfn-waiting-worker" id="infopanel-for-dfn-waiting-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-waiting-worker" style="display:none">Info about the 'waiting worker' definition.</span><b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-waiting-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-waiting-worker">2.6. User Agent Shutdown</a>
@@ -7255,8 +7255,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-waiting-worker">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-active-worker">
-   <b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-active-worker" class="dfn-panel" data-for="dfn-active-worker" id="infopanel-for-dfn-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-active-worker">(2)</a> <a href="#ref-for-dfn-active-worker">(3)</a> <a href="#ref-for-dfn-active-worker">(4)</a> <a href="#ref-for-dfn-active-worker">(5)</a> <a href="#ref-for-dfn-active-worker">(6)</a>
     <li><a href="#ref-for-dfn-active-worker">2.3. Service Worker Client</a>
@@ -7279,16 +7279,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-active-worker">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-last-update-check-time">
-   <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-last-update-check-time" class="dfn-panel" data-for="dfn-last-update-check-time" id="infopanel-for-dfn-last-update-check-time" role="dialog">
+   <span id="infopaneltitle-for-dfn-last-update-check-time" style="display:none">Info about the 'last update check time' definition.</span><b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">Update</a> <a href="#ref-for-dfn-last-update-check-time">(2)</a> <a href="#ref-for-dfn-last-update-check-time">(3)</a>
     <li><a href="#ref-for-dfn-last-update-check-time">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time">(2)</a> <a href="#ref-for-dfn-last-update-check-time">(3)</a>
     <li><a href="#ref-for-dfn-last-update-check-time">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
-   <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-uninstalling-flag" class="dfn-panel" data-for="dfn-uninstalling-flag" id="infopanel-for-dfn-uninstalling-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-uninstalling-flag" style="display:none">Info about the 'uninstalling flag' definition.</span><b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-uninstalling-flag">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-dfn-uninstalling-flag">Register</a>
@@ -7298,16 +7298,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-uninstalling-flag">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
-   <b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-task-queue" class="dfn-panel" data-for="dfn-service-worker-registration-task-queue" id="infopanel-for-dfn-service-worker-registration-task-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-task-queue" style="display:none">Info about the 'task queues' definition.</span><b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration-task-queue">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client">
-   <b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client" id="infopanel-for-dfn-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client">2.1.1. Lifetime</a>
@@ -7339,8 +7339,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-active-worker">
-   <b><a href="#dfn-service-worker-client-active-worker">#dfn-service-worker-client-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-active-worker" class="dfn-panel" data-for="dfn-service-worker-client-active-worker" id="infopanel-for-dfn-service-worker-client-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-service-worker-client-active-worker">#dfn-service-worker-client-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">3.2.6. unregister()</a>
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">3.4.1. controller</a>
@@ -7350,22 +7350,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">Handle Fetch</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(2)</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(3)</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-id">
-   <b><a href="#dfn-service-worker-client-id">#dfn-service-worker-client-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-id" class="dfn-panel" data-for="dfn-service-worker-client-id" id="infopanel-for-dfn-service-worker-client-id" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dfn-service-worker-client-id">#dfn-service-worker-client-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-id">4.2.3. id</a>
     <li><a href="#ref-for-dfn-service-worker-client-id">4.3.1. get(id)</a>
     <li><a href="#ref-for-dfn-service-worker-client-id">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-frame-type">
-   <b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="dfn-service-worker-client-frame-type" id="infopanel-for-dfn-service-worker-client-frame-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' definition.</span><b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-window-client">
-   <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-window-client" class="dfn-panel" data-for="dfn-window-client" id="infopanel-for-dfn-window-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-window-client" style="display:none">Info about the 'window client' definition.</span><b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-window-client">4.2.2. frameType</a> <a href="#ref-for-dfn-window-client">(2)</a> <a href="#ref-for-dfn-window-client">(3)</a>
     <li><a href="#ref-for-dfn-window-client">4.3.1. get(id)</a>
@@ -7374,35 +7374,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-window-client">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
-   <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dedicatedworker-client" class="dfn-panel" data-for="dfn-dedicatedworker-client" id="infopanel-for-dfn-dedicatedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-dedicatedworker-client" style="display:none">Info about the 'dedicated worker client' definition.</span><b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-sharedworker-client">
-   <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-sharedworker-client" class="dfn-panel" data-for="dfn-sharedworker-client" id="infopanel-for-dfn-sharedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-sharedworker-client" style="display:none">Info about the 'shared worker client' definition.</span><b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-sharedworker-client">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-dfn-sharedworker-client">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-worker-client">
-   <b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-worker-client" class="dfn-panel" data-for="dfn-worker-client" id="infopanel-for-dfn-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-worker-client" style="display:none">Info about the 'worker client' definition.</span><b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-worker-client">2.4. Selection and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-selection">
-   <b><a href="#dfn-service-worker-registration-selection">#dfn-service-worker-registration-selection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-selection" class="dfn-panel" data-for="dfn-service-worker-registration-selection" id="infopanel-for-dfn-service-worker-registration-selection" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-selection" style="display:none">Info about the 'selection' definition.</span><b><a href="#dfn-service-worker-registration-selection">#dfn-service-worker-registration-selection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-selection">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-registration-selection">(2)</a> <a href="#ref-for-dfn-service-worker-registration-selection">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-control">
-   <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-control" class="dfn-panel" data-for="dfn-control" id="infopanel-for-dfn-control" role="dialog">
+   <span id="infopaneltitle-for-dfn-control" style="display:none">Info about the 'control' definition.</span><b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-control">2.4. Selection and Use</a>
@@ -7411,8 +7411,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-control">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-use">
-   <b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-use" class="dfn-panel" data-for="dfn-use" id="infopanel-for-dfn-use" role="dialog">
+   <span id="infopaneltitle-for-dfn-use" style="display:none">Info about the 'using' definition.</span><b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-use">3.6. Events</a>
@@ -7424,8 +7424,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-use">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
-   <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-fetch-task-source" class="dfn-panel" data-for="dfn-handle-fetch-task-source" id="infopanel-for-dfn-handle-fetch-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-fetch-task-source" style="display:none">Info about the 'handle fetch task source' definition.</span><b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source">(2)</a>
@@ -7433,16 +7433,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-handle-fetch-task-source">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
-   <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-functional-event-task-source" class="dfn-panel" data-for="dfn-handle-functional-event-task-source" id="infopanel-for-dfn-handle-functional-event-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-functional-event-task-source" style="display:none">Info about the 'handle functional event task source' definition.</span><b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source">(2)</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-interface">
-   <b><a href="#service-worker-interface">#service-worker-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-interface" class="dfn-panel" data-for="service-worker-interface" id="infopanel-for-service-worker-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-interface" style="display:none">Info about the 'ServiceWorker' definition.</span><b><a href="#service-worker-interface">#service-worker-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-interface">2.1.1. Lifetime</a>
     <li><a href="#ref-for-service-worker-interface">3.1. ServiceWorker</a> <a href="#ref-for-service-worker-interface①">(2)</a> <a href="#ref-for-service-worker-interface②">(3)</a> <a href="#ref-for-service-worker-interface③">(4)</a> <a href="#ref-for-service-worker-interface④">(5)</a> <a href="#ref-for-service-worker-interface⑤">(6)</a>
@@ -7464,15 +7464,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-interface">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-url-attribute">
-   <b><a href="#service-worker-url-attribute">#service-worker-url-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-url-attribute" class="dfn-panel" data-for="service-worker-url-attribute" id="infopanel-for-service-worker-url-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-url-attribute" style="display:none">Info about the 'scriptURL' definition.</span><b><a href="#service-worker-url-attribute">#service-worker-url-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-url-attribute">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-url-attribute①">3.1.1. scriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-state-attribute">
-   <b><a href="#service-worker-state-attribute">#service-worker-state-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-state-attribute" class="dfn-panel" data-for="service-worker-state-attribute" id="infopanel-for-service-worker-state-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-state-attribute" style="display:none">Info about the 'state' definition.</span><b><a href="#service-worker-state-attribute">#service-worker-state-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-state-attribute">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-state-attribute①">3.1.2. state</a>
@@ -7481,28 +7481,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-state-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-state-enum">
-   <b><a href="#service-worker-state-enum">#service-worker-state-enum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-state-enum" class="dfn-panel" data-for="service-worker-state-enum" id="infopanel-for-service-worker-state-enum" role="dialog">
+   <span id="infopaneltitle-for-service-worker-state-enum" style="display:none">Info about the 'ServiceWorkerState' definition.</span><b><a href="#service-worker-state-enum">#service-worker-state-enum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-state-enum">3.1. ServiceWorker</a> <a href="#ref-for-service-worker-state-enum①">(2)</a> <a href="#ref-for-service-worker-state-enum②">(3)</a>
     <li><a href="#ref-for-service-worker-state-enum③">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-postmessage-method">
-   <b><a href="#service-worker-postmessage-method">#service-worker-postmessage-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-postmessage-method" class="dfn-panel" data-for="service-worker-postmessage-method" id="infopanel-for-service-worker-postmessage-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-postmessage-method" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#service-worker-postmessage-method">#service-worker-postmessage-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-postmessage-method">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-postmessage-method①">3.1.3. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-onstatechange-attribute">
-   <b><a href="#service-worker-onstatechange-attribute">#service-worker-onstatechange-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-onstatechange-attribute" class="dfn-panel" data-for="service-worker-onstatechange-attribute" id="infopanel-for-service-worker-onstatechange-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-onstatechange-attribute" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#service-worker-onstatechange-attribute">#service-worker-onstatechange-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-onstatechange-attribute">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-interface">
-   <b><a href="#service-worker-registration-interface">#service-worker-registration-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-interface" class="dfn-panel" data-for="service-worker-registration-interface" id="infopanel-for-service-worker-registration-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-interface" style="display:none">Info about the 'ServiceWorkerRegistration' definition.</span><b><a href="#service-worker-registration-interface">#service-worker-registration-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-interface">2.2.1. Lifetime</a>
     <li><a href="#ref-for-service-worker-registration-interface">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-service-worker-registration-interface①">(2)</a> <a href="#ref-for-service-worker-registration-interface②">(3)</a> <a href="#ref-for-service-worker-registration-interface③">(4)</a>
@@ -7521,8 +7521,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-registration-interface①⑧">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-interface-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration-interface-service-worker-registration">#dfn-service-worker-registration-interface-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-interface-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration-interface-service-worker-registration" id="infopanel-for-dfn-service-worker-registration-interface-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-interface-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration-interface-service-worker-registration">#dfn-service-worker-registration-interface-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.2.4. scope</a>
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.2.5. update()</a>
@@ -7530,83 +7530,83 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.6. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-installing-attribute">
-   <b><a href="#service-worker-registration-installing-attribute">#service-worker-registration-installing-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-installing-attribute" class="dfn-panel" data-for="service-worker-registration-installing-attribute" id="infopanel-for-service-worker-registration-installing-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-installing-attribute" style="display:none">Info about the 'installing' definition.</span><b><a href="#service-worker-registration-installing-attribute">#service-worker-registration-installing-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-installing-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-installing-attribute①">3.2.1. installing</a>
     <li><a href="#ref-for-service-worker-registration-installing-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-waiting-attribute">
-   <b><a href="#service-worker-registration-waiting-attribute">#service-worker-registration-waiting-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-waiting-attribute" class="dfn-panel" data-for="service-worker-registration-waiting-attribute" id="infopanel-for-service-worker-registration-waiting-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-waiting-attribute" style="display:none">Info about the 'waiting' definition.</span><b><a href="#service-worker-registration-waiting-attribute">#service-worker-registration-waiting-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute①">3.2.2. waiting</a>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-active-attribute">
-   <b><a href="#service-worker-registration-active-attribute">#service-worker-registration-active-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-active-attribute" class="dfn-panel" data-for="service-worker-registration-active-attribute" id="infopanel-for-service-worker-registration-active-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-active-attribute" style="display:none">Info about the 'active' definition.</span><b><a href="#service-worker-registration-active-attribute">#service-worker-registration-active-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-active-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-active-attribute①">3.2.3. active</a>
     <li><a href="#ref-for-service-worker-registration-active-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-scope-attribute">
-   <b><a href="#service-worker-registration-scope-attribute">#service-worker-registration-scope-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-scope-attribute" class="dfn-panel" data-for="service-worker-registration-scope-attribute" id="infopanel-for-service-worker-registration-scope-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-scope-attribute" style="display:none">Info about the 'scope' definition.</span><b><a href="#service-worker-registration-scope-attribute">#service-worker-registration-scope-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-scope-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-scope-attribute①">3.2.4. scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-update-method">
-   <b><a href="#service-worker-registration-update-method">#service-worker-registration-update-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-update-method" class="dfn-panel" data-for="service-worker-registration-update-method" id="infopanel-for-service-worker-registration-update-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-update-method" style="display:none">Info about the 'update()' definition.</span><b><a href="#service-worker-registration-update-method">#service-worker-registration-update-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-update-method">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-update-method①">3.2.5. update()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-unregister-method">
-   <b><a href="#service-worker-registration-unregister-method">#service-worker-registration-unregister-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-unregister-method" class="dfn-panel" data-for="service-worker-registration-unregister-method" id="infopanel-for-service-worker-registration-unregister-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-unregister-method" style="display:none">Info about the 'unregister()' definition.</span><b><a href="#service-worker-registration-unregister-method">#service-worker-registration-unregister-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-unregister-method">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-unregister-method①">3.2.6. unregister()</a> <a href="#ref-for-service-worker-registration-unregister-method②">(2)</a> <a href="#ref-for-service-worker-registration-unregister-method③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-onupdatefound-attribute">
-   <b><a href="#service-worker-registration-onupdatefound-attribute">#service-worker-registration-onupdatefound-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-onupdatefound-attribute" class="dfn-panel" data-for="service-worker-registration-onupdatefound-attribute" id="infopanel-for-service-worker-registration-onupdatefound-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-onupdatefound-attribute" style="display:none">Info about the 'onupdatefound' definition.</span><b><a href="#service-worker-registration-onupdatefound-attribute">#service-worker-registration-onupdatefound-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-onupdatefound-attribute">3.2. ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-service-worker-attribute">
-   <b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-service-worker-attribute" class="dfn-panel" data-for="navigator-service-worker-attribute" id="infopanel-for-navigator-service-worker-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-service-worker-attribute" style="display:none">Info about the 'serviceWorker' definition.</span><b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-service-worker-attribute">3.3. navigator.serviceWorker</a> <a href="#ref-for-navigator-service-worker-attribute①">(2)</a> <a href="#ref-for-navigator-service-worker-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-serviceworkercontainer-registrationoptions">
-   <b><a href="#dictdef-serviceworkercontainer-registrationoptions">#dictdef-serviceworkercontainer-registrationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-serviceworkercontainer-registrationoptions" class="dfn-panel" data-for="dictdef-serviceworkercontainer-registrationoptions" id="infopanel-for-dictdef-serviceworkercontainer-registrationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-serviceworkercontainer-registrationoptions" style="display:none">Info about the 'RegistrationOptions' definition.</span><b><a href="#dictdef-serviceworkercontainer-registrationoptions">#dictdef-serviceworkercontainer-registrationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-serviceworkercontainer-registrationoptions">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-scope">
-   <b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-scope" class="dfn-panel" data-for="dom-registrationoptions-scope" id="infopanel-for-dom-registrationoptions-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-scope">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-registrationoptions-scope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-type">
-   <b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-type" class="dfn-panel" data-for="dom-registrationoptions-type" id="infopanel-for-dom-registrationoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-registrationoptions-type">#dom-registrationoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-type">3.4.3. register(scriptURL, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-interface">
-   <b><a href="#service-worker-container-interface">#service-worker-container-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-interface" class="dfn-panel" data-for="service-worker-container-interface" id="infopanel-for-service-worker-container-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-interface" style="display:none">Info about the 'ServiceWorkerContainer' definition.</span><b><a href="#service-worker-container-interface">#service-worker-container-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-interface">3.3. navigator.serviceWorker</a> <a href="#ref-for-service-worker-container-interface①">(2)</a> <a href="#ref-for-service-worker-container-interface②">(3)</a>
     <li><a href="#ref-for-service-worker-container-interface③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-service-worker-container-interface④">(2)</a> <a href="#ref-for-service-worker-container-interface⑤">(3)</a> <a href="#ref-for-service-worker-container-interface⑥">(4)</a> <a href="#ref-for-service-worker-container-interface⑦">(5)</a> <a href="#ref-for-service-worker-container-interface⑧">(6)</a> <a href="#ref-for-service-worker-container-interface⑨">(7)</a> <a href="#ref-for-service-worker-container-interface①⓪">(8)</a> <a href="#ref-for-service-worker-container-interface①①">(9)</a>
@@ -7616,8 +7616,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-container-interface">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-container-interface-client">
-   <b><a href="#dfn-service-worker-container-interface-client">#dfn-service-worker-container-interface-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-container-interface-client" class="dfn-panel" data-for="dfn-service-worker-container-interface-client" id="infopanel-for-dfn-service-worker-container-interface-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-container-interface-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-container-interface-client">#dfn-service-worker-container-interface-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">3.4.1. controller</a>
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">3.4.2. ready</a>
@@ -7630,14 +7630,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-ready-promise">
-   <b><a href="#dfn-ready-promise">#dfn-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-ready-promise" class="dfn-panel" data-for="dfn-ready-promise" id="infopanel-for-dfn-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-ready-promise" style="display:none">Info about the 'ready promise' definition.</span><b><a href="#dfn-ready-promise">#dfn-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-ready-promise">3.4.2. ready</a> <a href="#ref-for-dfn-ready-promise">(2)</a> <a href="#ref-for-dfn-ready-promise">(3)</a> <a href="#ref-for-dfn-ready-promise">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-client-message-queue">
-   <b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-client-message-queue" class="dfn-panel" data-for="dfn-client-message-queue" id="infopanel-for-dfn-client-message-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-client-message-queue" style="display:none">Info about the 'client message queue' definition.</span><b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-client-message-queue">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue①">(2)</a> <a href="#ref-for-dfn-client-message-queue②">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue③">3.4.6. startMessages()</a>
@@ -7645,143 +7645,143 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-client-message-queue⑤">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controller-attribute">
-   <b><a href="#service-worker-container-controller-attribute">#service-worker-container-controller-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controller-attribute" class="dfn-panel" data-for="service-worker-container-controller-attribute" id="infopanel-for-service-worker-container-controller-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controller-attribute" style="display:none">Info about the 'controller' definition.</span><b><a href="#service-worker-container-controller-attribute">#service-worker-container-controller-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controller-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-controller-attribute①">3.4.1. controller</a> <a href="#ref-for-service-worker-container-controller-attribute②">(2)</a>
     <li><a href="#ref-for-service-worker-container-controller-attribute③">3.6. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-ready-attribute">
-   <b><a href="#service-worker-container-ready-attribute">#service-worker-container-ready-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-ready-attribute" class="dfn-panel" data-for="service-worker-container-ready-attribute" id="infopanel-for-service-worker-container-ready-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-ready-attribute" style="display:none">Info about the 'ready' definition.</span><b><a href="#service-worker-container-ready-attribute">#service-worker-container-ready-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-ready-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-ready-attribute①">3.4.2. ready</a> <a href="#ref-for-service-worker-container-ready-attribute">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-register-method">
-   <b><a href="#service-worker-container-register-method">#service-worker-container-register-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-register-method" class="dfn-panel" data-for="service-worker-container-register-method" id="infopanel-for-service-worker-container-register-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-register-method" style="display:none">Info about the 'register(scriptURL, options)' definition.</span><b><a href="#service-worker-container-register-method">#service-worker-container-register-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-register-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-register-method①">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-service-worker-container-register-method②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-getregistration-method">
-   <b><a href="#service-worker-container-getregistration-method">#service-worker-container-getregistration-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-getregistration-method" class="dfn-panel" data-for="service-worker-container-getregistration-method" id="infopanel-for-service-worker-container-getregistration-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-getregistration-method" style="display:none">Info about the 'getRegistration(clientURL)' definition.</span><b><a href="#service-worker-container-getregistration-method">#service-worker-container-getregistration-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-getregistration-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-getregistration-method①">3.4.4. getRegistration(clientURL)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-getregistrations-method">
-   <b><a href="#service-worker-container-getregistrations-method">#service-worker-container-getregistrations-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-getregistrations-method" class="dfn-panel" data-for="service-worker-container-getregistrations-method" id="infopanel-for-service-worker-container-getregistrations-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-getregistrations-method" style="display:none">Info about the 'getRegistrations()' definition.</span><b><a href="#service-worker-container-getregistrations-method">#service-worker-container-getregistrations-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-getregistrations-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-getregistrations-method①">3.4.5. getRegistrations()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-startMessages-method">
-   <b><a href="#service-worker-container-startMessages-method">#service-worker-container-startMessages-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-startMessages-method" class="dfn-panel" data-for="service-worker-container-startMessages-method" id="infopanel-for-service-worker-container-startMessages-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-startMessages-method" style="display:none">Info about the 'startMessages()' definition.</span><b><a href="#service-worker-container-startMessages-method">#service-worker-container-startMessages-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-startMessages-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-startMessages-method①">3.4.6. startMessages()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-oncontrollerchange-attribute">
-   <b><a href="#service-worker-container-oncontrollerchange-attribute">#service-worker-container-oncontrollerchange-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-oncontrollerchange-attribute" class="dfn-panel" data-for="service-worker-container-oncontrollerchange-attribute" id="infopanel-for-service-worker-container-oncontrollerchange-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-oncontrollerchange-attribute" style="display:none">Info about the 'oncontrollerchange' definition.</span><b><a href="#service-worker-container-oncontrollerchange-attribute">#service-worker-container-oncontrollerchange-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-oncontrollerchange-attribute">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-onmessage-attribute">
-   <b><a href="#service-worker-container-onmessage-attribute">#service-worker-container-onmessage-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-onmessage-attribute" class="dfn-panel" data-for="service-worker-container-onmessage-attribute" id="infopanel-for-service-worker-container-onmessage-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-onmessage-attribute" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#service-worker-container-onmessage-attribute">#service-worker-container-onmessage-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-onmessage-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-onmessage-attribute">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-serviceworkermessageevent-serviceworkermessageeventinit">
-   <b><a href="#dictdef-serviceworkermessageevent-serviceworkermessageeventinit">#dictdef-serviceworkermessageevent-serviceworkermessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" class="dfn-panel" data-for="dictdef-serviceworkermessageevent-serviceworkermessageeventinit" id="infopanel-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" style="display:none">Info about the 'ServiceWorkerMessageEventInit' definition.</span><b><a href="#dictdef-serviceworkermessageevent-serviceworkermessageeventinit">#dictdef-serviceworkermessageevent-serviceworkermessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit">3.5. ServiceWorkerMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-interface">
-   <b><a href="#serviceworkermessage-event-interface">#serviceworkermessage-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-interface" class="dfn-panel" data-for="serviceworkermessage-event-interface" id="infopanel-for-serviceworkermessage-event-interface" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-interface" style="display:none">Info about the 'ServiceWorkerMessageEvent' definition.</span><b><a href="#serviceworkermessage-event-interface">#serviceworkermessage-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-interface">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-serviceworkermessage-event-interface①">(2)</a>
     <li><a href="#ref-for-serviceworkermessage-event-interface②">3.6. Events</a>
     <li><a href="#ref-for-serviceworkermessage-event-interface③">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-data-attribute">
-   <b><a href="#serviceworkermessage-event-data-attribute">#serviceworkermessage-event-data-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-data-attribute" class="dfn-panel" data-for="serviceworkermessage-event-data-attribute" id="infopanel-for-serviceworkermessage-event-data-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-data-attribute" style="display:none">Info about the 'data' definition.</span><b><a href="#serviceworkermessage-event-data-attribute">#serviceworkermessage-event-data-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute①">3.5.1. event.data</a>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-origin-attribute">
-   <b><a href="#serviceworkermessage-event-origin-attribute">#serviceworkermessage-event-origin-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-origin-attribute" class="dfn-panel" data-for="serviceworkermessage-event-origin-attribute" id="infopanel-for-serviceworkermessage-event-origin-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-origin-attribute" style="display:none">Info about the 'origin' definition.</span><b><a href="#serviceworkermessage-event-origin-attribute">#serviceworkermessage-event-origin-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute①">3.5.2. event.origin</a>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-lasteventid-attribute">
-   <b><a href="#serviceworkermessage-event-lasteventid-attribute">#serviceworkermessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-lasteventid-attribute" class="dfn-panel" data-for="serviceworkermessage-event-lasteventid-attribute" id="infopanel-for-serviceworkermessage-event-lasteventid-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-lasteventid-attribute" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#serviceworkermessage-event-lasteventid-attribute">#serviceworkermessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-lasteventid-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-lasteventid-attribute①">3.5.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-source-attribute">
-   <b><a href="#serviceworkermessage-event-source-attribute">#serviceworkermessage-event-source-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-source-attribute" class="dfn-panel" data-for="serviceworkermessage-event-source-attribute" id="infopanel-for-serviceworkermessage-event-source-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-source-attribute" style="display:none">Info about the 'source' definition.</span><b><a href="#serviceworkermessage-event-source-attribute">#serviceworkermessage-event-source-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute①">3.5.4. event.source</a>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-ports-attribute">
-   <b><a href="#serviceworkermessage-event-ports-attribute">#serviceworkermessage-event-ports-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-ports-attribute" class="dfn-panel" data-for="serviceworkermessage-event-ports-attribute" id="infopanel-for-serviceworkermessage-event-ports-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-ports-attribute" style="display:none">Info about the 'ports' definition.</span><b><a href="#serviceworkermessage-event-ports-attribute">#serviceworkermessage-event-ports-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute①">3.5.5. event.ports</a>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-statechange-event">
-   <b><a href="#service-worker-statechange-event">#service-worker-statechange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-statechange-event" class="dfn-panel" data-for="service-worker-statechange-event" id="infopanel-for-service-worker-statechange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-statechange-event" style="display:none">Info about the 'statechange' definition.</span><b><a href="#service-worker-statechange-event">#service-worker-statechange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-statechange-event">3.1.4. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
-   <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-updatefound-event" class="dfn-panel" data-for="service-worker-registration-updatefound-event" id="infopanel-for-service-worker-registration-updatefound-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-updatefound-event" style="display:none">Info about the 'updatefound' definition.</span><b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-updatefound-event">3.2.7. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
-   <b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controllerchange-event" class="dfn-panel" data-for="service-worker-container-controllerchange-event" id="infopanel-for-service-worker-container-controllerchange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controllerchange-event" style="display:none">Info about the 'controllerchange' definition.</span><b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controllerchange-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-message-event">
-   <b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-message-event" class="dfn-panel" data-for="service-worker-container-message-event" id="infopanel-for-service-worker-container-message-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-message-event" style="display:none">Info about the 'message' definition.</span><b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-message-event">3.4.7. Event handlers</a>
     <li><a href="#ref-for-service-worker-container-message-event">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-service-worker-container-message-event">(2)</a>
     <li><a href="#ref-for-service-worker-container-message-event">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-interface">
-   <b><a href="#service-worker-global-scope-interface">#service-worker-global-scope-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-interface" class="dfn-panel" data-for="service-worker-global-scope-interface" id="infopanel-for-service-worker-global-scope-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-interface" style="display:none">Info about the 'ServiceWorkerGlobalScope' definition.</span><b><a href="#service-worker-global-scope-interface">#service-worker-global-scope-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-interface">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-service-worker-global-scope-interface①">(2)</a>
     <li><a href="#ref-for-service-worker-global-scope-interface②">3.2.5. update()</a>
@@ -7796,8 +7796,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-interface①②">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-global-scope-service-worker">
-   <b><a href="#dfn-service-worker-global-scope-service-worker">#dfn-service-worker-global-scope-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-global-scope-service-worker" class="dfn-panel" data-for="dfn-service-worker-global-scope-service-worker" id="infopanel-for-dfn-service-worker-global-scope-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-global-scope-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker-global-scope-service-worker">#dfn-service-worker-global-scope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">3.2.5. update()</a>
@@ -7814,67 +7814,67 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-clients-attribute">
-   <b><a href="#service-worker-global-scope-clients-attribute">#service-worker-global-scope-clients-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-clients-attribute" class="dfn-panel" data-for="service-worker-global-scope-clients-attribute" id="infopanel-for-service-worker-global-scope-clients-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-clients-attribute" style="display:none">Info about the 'clients' definition.</span><b><a href="#service-worker-global-scope-clients-attribute">#service-worker-global-scope-clients-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-clients-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-clients-attribute①">4.1.1. clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-scope-attribute">
-   <b><a href="#service-worker-global-scope-scope-attribute">#service-worker-global-scope-scope-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-scope-attribute" class="dfn-panel" data-for="service-worker-global-scope-scope-attribute" id="infopanel-for-service-worker-global-scope-scope-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-scope-attribute" style="display:none">Info about the 'registration' definition.</span><b><a href="#service-worker-global-scope-scope-attribute">#service-worker-global-scope-scope-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-scope-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-scope-attribute①">4.1.2. registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-skipwaiting-method">
-   <b><a href="#service-worker-global-scope-skipwaiting-method">#service-worker-global-scope-skipwaiting-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-skipwaiting-method" class="dfn-panel" data-for="service-worker-global-scope-skipwaiting-method" id="infopanel-for-service-worker-global-scope-skipwaiting-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-skipwaiting-method" style="display:none">Info about the 'skipWaiting()' definition.</span><b><a href="#service-worker-global-scope-skipwaiting-method">#service-worker-global-scope-skipwaiting-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-skipwaiting-method">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-skipwaiting-method①">4.1.3. skipWaiting()</a> <a href="#ref-for-service-worker-global-scope-skipwaiting-method②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-oninstall-attribute">
-   <b><a href="#service-worker-global-scope-oninstall-attribute">#service-worker-global-scope-oninstall-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-oninstall-attribute" class="dfn-panel" data-for="service-worker-global-scope-oninstall-attribute" id="infopanel-for-service-worker-global-scope-oninstall-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-oninstall-attribute" style="display:none">Info about the 'oninstall' definition.</span><b><a href="#service-worker-global-scope-oninstall-attribute">#service-worker-global-scope-oninstall-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-oninstall-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-oninstall-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onactivate-attribute">
-   <b><a href="#service-worker-global-scope-onactivate-attribute">#service-worker-global-scope-onactivate-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onactivate-attribute" class="dfn-panel" data-for="service-worker-global-scope-onactivate-attribute" id="infopanel-for-service-worker-global-scope-onactivate-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onactivate-attribute" style="display:none">Info about the 'onactivate' definition.</span><b><a href="#service-worker-global-scope-onactivate-attribute">#service-worker-global-scope-onactivate-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onactivate-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-onactivate-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onfetch-attribute">
-   <b><a href="#service-worker-global-scope-onfetch-attribute">#service-worker-global-scope-onfetch-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onfetch-attribute" class="dfn-panel" data-for="service-worker-global-scope-onfetch-attribute" id="infopanel-for-service-worker-global-scope-onfetch-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onfetch-attribute" style="display:none">Info about the 'onfetch' definition.</span><b><a href="#service-worker-global-scope-onfetch-attribute">#service-worker-global-scope-onfetch-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onfetch-attribute">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onforeignfetch">
-   <b><a href="#dom-serviceworkerglobalscope-onforeignfetch">#dom-serviceworkerglobalscope-onforeignfetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onforeignfetch" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onforeignfetch" id="infopanel-for-dom-serviceworkerglobalscope-onforeignfetch" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onforeignfetch" style="display:none">Info about the 'onforeignfetch' definition.</span><b><a href="#dom-serviceworkerglobalscope-onforeignfetch">#dom-serviceworkerglobalscope-onforeignfetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onforeignfetch">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onmessage-attribute">
-   <b><a href="#service-worker-global-scope-onmessage-attribute">#service-worker-global-scope-onmessage-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onmessage-attribute" class="dfn-panel" data-for="service-worker-global-scope-onmessage-attribute" id="infopanel-for-service-worker-global-scope-onmessage-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onmessage-attribute" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#service-worker-global-scope-onmessage-attribute">#service-worker-global-scope-onmessage-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onmessage-attribute">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-navigate">
-   <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-navigate" class="dfn-panel" data-for="dom-windowclient-navigate" id="infopanel-for-dom-windowclient-navigate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-navigate" style="display:none">Info about the 'navigate' definition.</span><b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate">4.2.8. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-interface">
-   <b><a href="#client-interface">#client-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-interface" class="dfn-panel" data-for="client-interface" id="infopanel-for-client-interface" role="dialog">
+   <span id="infopaneltitle-for-client-interface" style="display:none">Info about the 'Client' definition.</span><b><a href="#client-interface">#client-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-client-interface①">4.2. Client</a> <a href="#ref-for-client-interface②">(2)</a> <a href="#ref-for-client-interface③">(3)</a>
@@ -7884,8 +7884,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-client-interface⑧">Create Client</a> <a href="#ref-for-client-interface⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-client">
-   <b><a href="#dfn-service-worker-client-client">#dfn-service-worker-client-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-client" class="dfn-panel" data-for="dfn-service-worker-client-client" id="infopanel-for-dfn-service-worker-client-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client-client">#dfn-service-worker-client-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-client">4.2.1. url</a>
     <li><a href="#ref-for-dfn-service-worker-client-client">4.2.2. frameType</a>
@@ -7897,8 +7897,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-client">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="window-client-interface">
-   <b><a href="#window-client-interface">#window-client-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-client-interface" class="dfn-panel" data-for="window-client-interface" id="infopanel-for-window-client-interface" role="dialog">
+   <span id="infopaneltitle-for-window-client-interface" style="display:none">Info about the 'WindowClient' definition.</span><b><a href="#window-client-interface">#window-client-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-client-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-window-client-interface①">4.2. Client</a> <a href="#ref-for-window-client-interface②">(2)</a> <a href="#ref-for-window-client-interface③">(3)</a> <a href="#ref-for-window-client-interface④">(4)</a>
@@ -7906,138 +7906,138 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window-client-interface⑥">Create Window Client</a> <a href="#ref-for-window-client-interface⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
-   <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-visibilitystate" class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate" id="infopanel-for-dfn-service-worker-client-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-visibilitystate" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">4.2.5. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
-   <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-focusstate" class="dfn-panel" data-for="dfn-service-worker-client-focusstate" id="infopanel-for-dfn-service-worker-client-focusstate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-focusstate" style="display:none">Info about the 'focus state' definition.</span><b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.6. focused</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.7. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-url-attribute">
-   <b><a href="#client-url-attribute">#client-url-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-url-attribute" class="dfn-panel" data-for="client-url-attribute" id="infopanel-for-client-url-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-url-attribute" style="display:none">Info about the 'url' definition.</span><b><a href="#client-url-attribute">#client-url-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-url-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-url-attribute①">4.2.1. url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-frametype-attribute">
-   <b><a href="#client-frametype-attribute">#client-frametype-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-frametype-attribute" class="dfn-panel" data-for="client-frametype-attribute" id="infopanel-for-client-frametype-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-frametype-attribute" style="display:none">Info about the 'frameType' definition.</span><b><a href="#client-frametype-attribute">#client-frametype-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-frametype-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-frametype-attribute①">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contextframetype-enum">
-   <b><a href="#contextframetype-enum">#contextframetype-enum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contextframetype-enum" class="dfn-panel" data-for="contextframetype-enum" id="infopanel-for-contextframetype-enum" role="dialog">
+   <span id="infopaneltitle-for-contextframetype-enum" style="display:none">Info about the 'FrameType' definition.</span><b><a href="#contextframetype-enum">#contextframetype-enum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contextframetype-enum">4.2. Client</a> <a href="#ref-for-contextframetype-enum①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-id-attribute">
-   <b><a href="#client-id-attribute">#client-id-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-id-attribute" class="dfn-panel" data-for="client-id-attribute" id="infopanel-for-client-id-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-id-attribute" style="display:none">Info about the 'id' definition.</span><b><a href="#client-id-attribute">#client-id-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-id-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-id-attribute①">4.2.3. id</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-postmessage-method">
-   <b><a href="#client-postmessage-method">#client-postmessage-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-postmessage-method" class="dfn-panel" data-for="client-postmessage-method" id="infopanel-for-client-postmessage-method" role="dialog">
+   <span id="infopaneltitle-for-client-postmessage-method" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#client-postmessage-method">#client-postmessage-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-postmessage-method">4.2. Client</a>
     <li><a href="#ref-for-client-postmessage-method①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-visibilitystate-attribute">
-   <b><a href="#client-visibilitystate-attribute">#client-visibilitystate-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-visibilitystate-attribute" class="dfn-panel" data-for="client-visibilitystate-attribute" id="infopanel-for-client-visibilitystate-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-visibilitystate-attribute" style="display:none">Info about the 'visibilityState' definition.</span><b><a href="#client-visibilitystate-attribute">#client-visibilitystate-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-visibilitystate-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-visibilitystate-attribute①">4.2.5. visibilityState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-focused-attribute">
-   <b><a href="#client-focused-attribute">#client-focused-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-focused-attribute" class="dfn-panel" data-for="client-focused-attribute" id="infopanel-for-client-focused-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-focused-attribute" style="display:none">Info about the 'focused' definition.</span><b><a href="#client-focused-attribute">#client-focused-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-focused-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-focused-attribute①">4.2.6. focused</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-focus-method">
-   <b><a href="#client-focus-method">#client-focus-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-focus-method" class="dfn-panel" data-for="client-focus-method" id="infopanel-for-client-focus-method" role="dialog">
+   <span id="infopaneltitle-for-client-focus-method" style="display:none">Info about the 'focus()' definition.</span><b><a href="#client-focus-method">#client-focus-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-focus-method">4.2. Client</a>
     <li><a href="#ref-for-client-focus-method①">4.2.7. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clients-clientqueryoptions">
-   <b><a href="#dictdef-clients-clientqueryoptions">#dictdef-clients-clientqueryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clients-clientqueryoptions" class="dfn-panel" data-for="dictdef-clients-clientqueryoptions" id="infopanel-for-dictdef-clients-clientqueryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clients-clientqueryoptions" style="display:none">Info about the 'ClientQueryOptions' definition.</span><b><a href="#dictdef-clients-clientqueryoptions">#dictdef-clients-clientqueryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clients-clientqueryoptions">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled">
-   <b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled" id="infopanel-for-dom-clientqueryoptions-includeuncontrolled" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" style="display:none">Info about the 'includeUncontrolled' definition.</span><b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-includeuncontrolled">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-type">
-   <b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-type" class="dfn-panel" data-for="dom-clientqueryoptions-type" id="infopanel-for-dom-clientqueryoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-type">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clientqueryoptions-type①">(2)</a> <a href="#ref-for-dom-clientqueryoptions-type②">(3)</a> <a href="#ref-for-dom-clientqueryoptions-type③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-clients-clienttype">
-   <b><a href="#enumdef-clients-clienttype">#enumdef-clients-clienttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-clients-clienttype" class="dfn-panel" data-for="enumdef-clients-clienttype" id="infopanel-for-enumdef-clients-clienttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-clients-clienttype" style="display:none">Info about the 'ClientType' definition.</span><b><a href="#enumdef-clients-clienttype">#enumdef-clients-clienttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-clients-clienttype">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-interface">
-   <b><a href="#clients-interface">#clients-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-interface" class="dfn-panel" data-for="clients-interface" id="infopanel-for-clients-interface" role="dialog">
+   <span id="infopaneltitle-for-clients-interface" style="display:none">Info about the 'Clients' definition.</span><b><a href="#clients-interface">#clients-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-interface">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-clients-interface①">4.1.1. clients</a>
     <li><a href="#ref-for-clients-interface②">4.3. Clients</a> <a href="#ref-for-clients-interface③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-get-method">
-   <b><a href="#clients-get-method">#clients-get-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-get-method" class="dfn-panel" data-for="clients-get-method" id="infopanel-for-clients-get-method" role="dialog">
+   <span id="infopaneltitle-for-clients-get-method" style="display:none">Info about the 'get(id)' definition.</span><b><a href="#clients-get-method">#clients-get-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-get-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-get-method①">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-matchall-method">
-   <b><a href="#clients-matchall-method">#clients-matchall-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-matchall-method" class="dfn-panel" data-for="clients-matchall-method" id="infopanel-for-clients-matchall-method" role="dialog">
+   <span id="infopaneltitle-for-clients-matchall-method" style="display:none">Info about the 'matchAll(options)' definition.</span><b><a href="#clients-matchall-method">#clients-matchall-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-matchall-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-matchall-method①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-openwindow-method">
-   <b><a href="#clients-openwindow-method">#clients-openwindow-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-openwindow-method" class="dfn-panel" data-for="clients-openwindow-method" id="infopanel-for-clients-openwindow-method" role="dialog">
+   <span id="infopaneltitle-for-clients-openwindow-method" style="display:none">Info about the 'openWindow(url)' definition.</span><b><a href="#clients-openwindow-method">#clients-openwindow-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-openwindow-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-openwindow-method①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-claim-method">
-   <b><a href="#clients-claim-method">#clients-claim-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-claim-method" class="dfn-panel" data-for="clients-claim-method" id="infopanel-for-clients-claim-method" role="dialog">
+   <span id="infopaneltitle-for-clients-claim-method" style="display:none">Info about the 'claim()' definition.</span><b><a href="#clients-claim-method">#clients-claim-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-claim-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-claim-method①">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
-   <b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendableeventinit" class="dfn-panel" data-for="dictdef-extendableeventinit" id="infopanel-for-dictdef-extendableeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' definition.</span><b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit①">4.5. InstallEvent</a>
@@ -8046,8 +8046,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dictdef-extendableeventinit④">4.8. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendable-event-interface">
-   <b><a href="#extendable-event-interface">#extendable-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendable-event-interface" class="dfn-panel" data-for="extendable-event-interface" id="infopanel-for-extendable-event-interface" role="dialog">
+   <span id="infopaneltitle-for-extendable-event-interface" style="display:none">Info about the 'ExtendableEvent' definition.</span><b><a href="#extendable-event-interface">#extendable-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-interface">4.4. ExtendableEvent</a> <a href="#ref-for-extendable-event-interface①">(2)</a> <a href="#ref-for-extendable-event-interface②">(3)</a> <a href="#ref-for-extendable-event-interface③">(4)</a> <a href="#ref-for-extendable-event-interface④">(5)</a> <a href="#ref-for-extendable-event-interface⑤">(6)</a>
     <li><a href="#ref-for-extendable-event-interface⑥">4.5. InstallEvent</a>
@@ -8059,8 +8059,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendable-event-interface①⑤">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-extend-lifetime-promises">
-   <b><a href="#dfn-extend-lifetime-promises">#dfn-extend-lifetime-promises</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-extend-lifetime-promises" class="dfn-panel" data-for="dfn-extend-lifetime-promises" id="infopanel-for-dfn-extend-lifetime-promises" role="dialog">
+   <span id="infopaneltitle-for-dfn-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' definition.</span><b><a href="#dfn-extend-lifetime-promises">#dfn-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extend-lifetime-promises">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-extend-lifetime-promises①">(2)</a> <a href="#ref-for-dfn-extend-lifetime-promises②">(3)</a> <a href="#ref-for-dfn-extend-lifetime-promises">(4)</a> <a href="#ref-for-dfn-extend-lifetime-promises">(5)</a> <a href="#ref-for-dfn-extend-lifetime-promises③">(6)</a> <a href="#ref-for-dfn-extend-lifetime-promises④">(7)</a> <a href="#ref-for-dfn-extend-lifetime-promises⑤">(8)</a> <a href="#ref-for-dfn-extend-lifetime-promises⑥">(9)</a>
     <li><a href="#ref-for-dfn-extend-lifetime-promises">4.4.1. event.waitUntil(f)</a>
@@ -8069,8 +8069,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-extend-lifetime-promises⑨">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extensions-allowed-flag">
-   <b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extensions-allowed-flag" class="dfn-panel" data-for="extensions-allowed-flag" id="infopanel-for-extensions-allowed-flag" role="dialog">
+   <span id="infopaneltitle-for-extensions-allowed-flag" style="display:none">Info about the 'extensions allowed flag' definition.</span><b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extensions-allowed-flag">4.4. ExtendableEvent</a> <a href="#ref-for-extensions-allowed-flag①">(2)</a> <a href="#ref-for-extensions-allowed-flag②">(3)</a>
     <li><a href="#ref-for-extensions-allowed-flag③">4.4.1. event.waitUntil(f)</a>
@@ -8078,8 +8078,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extensions-allowed-flag⑤">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendable-event-waituntil-method">
-   <b><a href="#extendable-event-waituntil-method">#extendable-event-waituntil-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendable-event-waituntil-method" class="dfn-panel" data-for="extendable-event-waituntil-method" id="infopanel-for-extendable-event-waituntil-method" role="dialog">
+   <span id="infopaneltitle-for-extendable-event-waituntil-method" style="display:none">Info about the 'waitUntil(f)' definition.</span><b><a href="#extendable-event-waituntil-method">#extendable-event-waituntil-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-waituntil-method">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendable-event-waituntil-method①">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendable-event-waituntil-method②">(2)</a>
@@ -8088,264 +8088,264 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendable-event-waituntil-method">Update Worker State</a> <a href="#ref-for-extendable-event-waituntil-method">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="installevent-installevent">
-   <b><a href="#installevent-installevent">#installevent-installevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-installevent-installevent" class="dfn-panel" data-for="installevent-installevent" id="infopanel-for-installevent-installevent" role="dialog">
+   <span id="infopaneltitle-for-installevent-installevent" style="display:none">Info about the 'InstallEvent' definition.</span><b><a href="#installevent-installevent">#installevent-installevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-installevent-installevent">4.5. InstallEvent</a>
     <li><a href="#ref-for-installevent-installevent①">4.9. Events</a>
     <li><a href="#ref-for-installevent-installevent②">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-installevent-foreignfetchoptions">
-   <b><a href="#dictdef-installevent-foreignfetchoptions">#dictdef-installevent-foreignfetchoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-installevent-foreignfetchoptions" class="dfn-panel" data-for="dictdef-installevent-foreignfetchoptions" id="infopanel-for-dictdef-installevent-foreignfetchoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-installevent-foreignfetchoptions" style="display:none">Info about the 'ForeignFetchOptions' definition.</span><b><a href="#dictdef-installevent-foreignfetchoptions">#dictdef-installevent-foreignfetchoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-installevent-foreignfetchoptions">4.5. InstallEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchoptions-scopes">
-   <b><a href="#dom-foreignfetchoptions-scopes">#dom-foreignfetchoptions-scopes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchoptions-scopes" class="dfn-panel" data-for="dom-foreignfetchoptions-scopes" id="infopanel-for-dom-foreignfetchoptions-scopes" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchoptions-scopes" style="display:none">Info about the 'scopes' definition.</span><b><a href="#dom-foreignfetchoptions-scopes">#dom-foreignfetchoptions-scopes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchoptions-scopes">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dom-foreignfetchoptions-scopes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchoptions-origins">
-   <b><a href="#dom-foreignfetchoptions-origins">#dom-foreignfetchoptions-origins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchoptions-origins" class="dfn-panel" data-for="dom-foreignfetchoptions-origins" id="infopanel-for-dom-foreignfetchoptions-origins" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchoptions-origins" style="display:none">Info about the 'origins' definition.</span><b><a href="#dom-foreignfetchoptions-origins">#dom-foreignfetchoptions-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchoptions-origins">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dom-foreignfetchoptions-origins①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-installevent-registerforeignfetch">
-   <b><a href="#dom-installevent-registerforeignfetch">#dom-installevent-registerforeignfetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-installevent-registerforeignfetch" class="dfn-panel" data-for="dom-installevent-registerforeignfetch" id="infopanel-for-dom-installevent-registerforeignfetch" role="dialog">
+   <span id="infopaneltitle-for-dom-installevent-registerforeignfetch" style="display:none">Info about the 'registerForeignFetch(options)' definition.</span><b><a href="#dom-installevent-registerforeignfetch">#dom-installevent-registerforeignfetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-installevent-registerforeignfetch">4.5. InstallEvent</a>
     <li><a href="#ref-for-dom-installevent-registerforeignfetch①">4.5.1. event.registerForeignFetch(options)</a> <a href="#ref-for-dom-installevent-registerforeignfetch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fetchevent-fetcheventinit">
-   <b><a href="#dictdef-fetchevent-fetcheventinit">#dictdef-fetchevent-fetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fetchevent-fetcheventinit" class="dfn-panel" data-for="dictdef-fetchevent-fetcheventinit" id="infopanel-for-dictdef-fetchevent-fetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fetchevent-fetcheventinit" style="display:none">Info about the 'FetchEventInit' definition.</span><b><a href="#dictdef-fetchevent-fetcheventinit">#dictdef-fetchevent-fetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fetchevent-fetcheventinit">4.6. FetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-interface">
-   <b><a href="#fetch-event-interface">#fetch-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-interface" class="dfn-panel" data-for="fetch-event-interface" id="infopanel-for-fetch-event-interface" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-interface" style="display:none">Info about the 'FetchEvent' definition.</span><b><a href="#fetch-event-interface">#fetch-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-interface">4.6. FetchEvent</a> <a href="#ref-for-fetch-event-interface①">(2)</a> <a href="#ref-for-fetch-event-interface②">(3)</a>
     <li><a href="#ref-for-fetch-event-interface③">4.9. Events</a> <a href="#ref-for-fetch-event-interface④">(2)</a>
     <li><a href="#ref-for-fetch-event-interface⑤">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-potential-response">
-   <b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-potential-response" class="dfn-panel" data-for="fetchevent-potential-response" id="infopanel-for-fetchevent-potential-response" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-potential-response" style="display:none">Info about the 'potential response' definition.</span><b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-potential-response">4.6.4. event.respondWith(r)</a>
     <li><a href="#ref-for-fetchevent-potential-response①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wait-to-respond-flag">
-   <b><a href="#wait-to-respond-flag">#wait-to-respond-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wait-to-respond-flag" class="dfn-panel" data-for="wait-to-respond-flag" id="infopanel-for-wait-to-respond-flag" role="dialog">
+   <span id="infopaneltitle-for-wait-to-respond-flag" style="display:none">Info about the 'wait to respond flag' definition.</span><b><a href="#wait-to-respond-flag">#wait-to-respond-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-to-respond-flag">4.6.4. event.respondWith(r)</a> <a href="#ref-for-wait-to-respond-flag">(2)</a>
     <li><a href="#ref-for-wait-to-respond-flag">4.7.3. event.respondWith(r)</a> <a href="#ref-for-wait-to-respond-flag">(2)</a>
     <li><a href="#ref-for-wait-to-respond-flag">Handle Fetch</a> <a href="#ref-for-wait-to-respond-flag">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-with-entered-flag">
-   <b><a href="#respond-with-entered-flag">#respond-with-entered-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-with-entered-flag" class="dfn-panel" data-for="respond-with-entered-flag" id="infopanel-for-respond-with-entered-flag" role="dialog">
+   <span id="infopaneltitle-for-respond-with-entered-flag" style="display:none">Info about the 'respond-with entered flag' definition.</span><b><a href="#respond-with-entered-flag">#respond-with-entered-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-with-entered-flag">4.6.4. event.respondWith(r)</a> <a href="#ref-for-respond-with-entered-flag">(2)</a>
     <li><a href="#ref-for-respond-with-entered-flag">4.7.3. event.respondWith(r)</a> <a href="#ref-for-respond-with-entered-flag">(2)</a>
     <li><a href="#ref-for-respond-with-entered-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-with-error-flag">
-   <b><a href="#respond-with-error-flag">#respond-with-error-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-with-error-flag" class="dfn-panel" data-for="respond-with-error-flag" id="infopanel-for-respond-with-error-flag" role="dialog">
+   <span id="infopaneltitle-for-respond-with-error-flag" style="display:none">Info about the 'respond-with error flag' definition.</span><b><a href="#respond-with-error-flag">#respond-with-error-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-with-error-flag">4.6.4. event.respondWith(r)</a> <a href="#ref-for-respond-with-error-flag">(2)</a> <a href="#ref-for-respond-with-error-flag">(3)</a> <a href="#ref-for-respond-with-error-flag">(4)</a>
     <li><a href="#ref-for-respond-with-error-flag">4.7.3. event.respondWith(r)</a> <a href="#ref-for-respond-with-error-flag">(2)</a> <a href="#ref-for-respond-with-error-flag">(3)</a> <a href="#ref-for-respond-with-error-flag">(4)</a>
     <li><a href="#ref-for-respond-with-error-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-request-attribute">
-   <b><a href="#fetch-event-request-attribute">#fetch-event-request-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-request-attribute" class="dfn-panel" data-for="fetch-event-request-attribute" id="infopanel-for-fetch-event-request-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-request-attribute" style="display:none">Info about the 'request' definition.</span><b><a href="#fetch-event-request-attribute">#fetch-event-request-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-request-attribute">4.6. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-request-attribute①">4.6.1. event.request</a>
     <li><a href="#ref-for-fetch-event-request-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-clientid-attribute">
-   <b><a href="#fetch-event-clientid-attribute">#fetch-event-clientid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-clientid-attribute" class="dfn-panel" data-for="fetch-event-clientid-attribute" id="infopanel-for-fetch-event-clientid-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-clientid-attribute" style="display:none">Info about the 'clientId' definition.</span><b><a href="#fetch-event-clientid-attribute">#fetch-event-clientid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-clientid-attribute">4.6. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-clientid-attribute①">4.6.2. event.clientId</a>
     <li><a href="#ref-for-fetch-event-clientid-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-isreload-attribute">
-   <b><a href="#fetch-event-isreload-attribute">#fetch-event-isreload-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-isreload-attribute" class="dfn-panel" data-for="fetch-event-isreload-attribute" id="infopanel-for-fetch-event-isreload-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-isreload-attribute" style="display:none">Info about the 'isReload' definition.</span><b><a href="#fetch-event-isreload-attribute">#fetch-event-isreload-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-isreload-attribute">4.6. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-isreload-attribute①">4.6.3. event.isReload</a>
     <li><a href="#ref-for-fetch-event-isreload-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-respondwith-method">
-   <b><a href="#fetch-event-respondwith-method">#fetch-event-respondwith-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-respondwith-method" class="dfn-panel" data-for="fetch-event-respondwith-method" id="infopanel-for-fetch-event-respondwith-method" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-respondwith-method" style="display:none">Info about the 'respondWith(r)' definition.</span><b><a href="#fetch-event-respondwith-method">#fetch-event-respondwith-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-respondwith-method">4.6. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-respondwith-method①">4.6.4. event.respondWith(r)</a> <a href="#ref-for-fetch-event-respondwith-method②">(2)</a>
     <li><a href="#ref-for-fetch-event-respondwith-method③">7.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-foreignfetchevent-foreignfetcheventinit">
-   <b><a href="#dictdef-foreignfetchevent-foreignfetcheventinit">#dictdef-foreignfetchevent-foreignfetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-foreignfetchevent-foreignfetcheventinit" class="dfn-panel" data-for="dictdef-foreignfetchevent-foreignfetcheventinit" id="infopanel-for-dictdef-foreignfetchevent-foreignfetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-foreignfetchevent-foreignfetcheventinit" style="display:none">Info about the 'ForeignFetchEventInit' definition.</span><b><a href="#dictdef-foreignfetchevent-foreignfetcheventinit">#dictdef-foreignfetchevent-foreignfetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-foreignfetchevent-foreignfetcheventinit">4.7. ForeignFetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-foreignfetchevent-foreignfetchresponse">
-   <b><a href="#dictdef-foreignfetchevent-foreignfetchresponse">#dictdef-foreignfetchevent-foreignfetchresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-foreignfetchevent-foreignfetchresponse" class="dfn-panel" data-for="dictdef-foreignfetchevent-foreignfetchresponse" id="infopanel-for-dictdef-foreignfetchevent-foreignfetchresponse" role="dialog">
+   <span id="infopaneltitle-for-dictdef-foreignfetchevent-foreignfetchresponse" style="display:none">Info about the 'ForeignFetchResponse' definition.</span><b><a href="#dictdef-foreignfetchevent-foreignfetchresponse">#dictdef-foreignfetchevent-foreignfetchresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-foreignfetchevent-foreignfetchresponse">4.7. ForeignFetchEvent</a>
     <li><a href="#ref-for-dictdef-foreignfetchevent-foreignfetchresponse①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchresponse-response">
-   <b><a href="#dom-foreignfetchresponse-response">#dom-foreignfetchresponse-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchresponse-response" class="dfn-panel" data-for="dom-foreignfetchresponse-response" id="infopanel-for-dom-foreignfetchresponse-response" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchresponse-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dom-foreignfetchresponse-response">#dom-foreignfetchresponse-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchresponse-response">4.7.3. event.respondWith(r)</a> <a href="#ref-for-dom-foreignfetchresponse-response①">(2)</a> <a href="#ref-for-dom-foreignfetchresponse-response②">(3)</a> <a href="#ref-for-dom-foreignfetchresponse-response③">(4)</a> <a href="#ref-for-dom-foreignfetchresponse-response④">(5)</a> <a href="#ref-for-dom-foreignfetchresponse-response⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchresponse-origin">
-   <b><a href="#dom-foreignfetchresponse-origin">#dom-foreignfetchresponse-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchresponse-origin" class="dfn-panel" data-for="dom-foreignfetchresponse-origin" id="infopanel-for-dom-foreignfetchresponse-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchresponse-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-foreignfetchresponse-origin">#dom-foreignfetchresponse-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchresponse-origin">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchresponse-headers">
-   <b><a href="#dom-foreignfetchresponse-headers">#dom-foreignfetchresponse-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchresponse-headers" class="dfn-panel" data-for="dom-foreignfetchresponse-headers" id="infopanel-for-dom-foreignfetchresponse-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchresponse-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#dom-foreignfetchresponse-headers">#dom-foreignfetchresponse-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchresponse-headers">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreignfetchevent-foreignfetchevent">
-   <b><a href="#foreignfetchevent-foreignfetchevent">#foreignfetchevent-foreignfetchevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreignfetchevent-foreignfetchevent" class="dfn-panel" data-for="foreignfetchevent-foreignfetchevent" id="infopanel-for-foreignfetchevent-foreignfetchevent" role="dialog">
+   <span id="infopaneltitle-for-foreignfetchevent-foreignfetchevent" style="display:none">Info about the 'ForeignFetchEvent' definition.</span><b><a href="#foreignfetchevent-foreignfetchevent">#foreignfetchevent-foreignfetchevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreignfetchevent-foreignfetchevent">4.7. ForeignFetchEvent</a> <a href="#ref-for-foreignfetchevent-foreignfetchevent①">(2)</a> <a href="#ref-for-foreignfetchevent-foreignfetchevent②">(3)</a>
     <li><a href="#ref-for-foreignfetchevent-foreignfetchevent③">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreignfetchevent-potential-response">
-   <b><a href="#foreignfetchevent-potential-response">#foreignfetchevent-potential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreignfetchevent-potential-response" class="dfn-panel" data-for="foreignfetchevent-potential-response" id="infopanel-for-foreignfetchevent-potential-response" role="dialog">
+   <span id="infopaneltitle-for-foreignfetchevent-potential-response" style="display:none">Info about the 'potential response' definition.</span><b><a href="#foreignfetchevent-potential-response">#foreignfetchevent-potential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreignfetchevent-potential-response">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-foreignfetchevent-potential-response①">Handle Foreign Fetch</a> <a href="#ref-for-foreignfetchevent-potential-response②">(2)</a> <a href="#ref-for-foreignfetchevent-potential-response③">(3)</a> <a href="#ref-for-foreignfetchevent-potential-response④">(4)</a> <a href="#ref-for-foreignfetchevent-potential-response⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreignfetchevent-list-of-exposed-headers">
-   <b><a href="#foreignfetchevent-list-of-exposed-headers">#foreignfetchevent-list-of-exposed-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreignfetchevent-list-of-exposed-headers" class="dfn-panel" data-for="foreignfetchevent-list-of-exposed-headers" id="infopanel-for-foreignfetchevent-list-of-exposed-headers" role="dialog">
+   <span id="infopaneltitle-for-foreignfetchevent-list-of-exposed-headers" style="display:none">Info about the 'list of exposed headers' definition.</span><b><a href="#foreignfetchevent-list-of-exposed-headers">#foreignfetchevent-list-of-exposed-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreignfetchevent-list-of-exposed-headers">4.7.3. event.respondWith(r)</a>
     <li><a href="#ref-for-foreignfetchevent-list-of-exposed-headers①">Handle Foreign Fetch</a> <a href="#ref-for-foreignfetchevent-list-of-exposed-headers②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreign-fetch-wait-to-respond-flag">
-   <b><a href="#foreign-fetch-wait-to-respond-flag">#foreign-fetch-wait-to-respond-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreign-fetch-wait-to-respond-flag" class="dfn-panel" data-for="foreign-fetch-wait-to-respond-flag" id="infopanel-for-foreign-fetch-wait-to-respond-flag" role="dialog">
+   <span id="infopaneltitle-for-foreign-fetch-wait-to-respond-flag" style="display:none">Info about the 'wait to respond flag' definition.</span><b><a href="#foreign-fetch-wait-to-respond-flag">#foreign-fetch-wait-to-respond-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreign-fetch-wait-to-respond-flag">Handle Foreign Fetch</a> <a href="#ref-for-foreign-fetch-wait-to-respond-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreign-fetch-respond-with-entered-flag">
-   <b><a href="#foreign-fetch-respond-with-entered-flag">#foreign-fetch-respond-with-entered-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreign-fetch-respond-with-entered-flag" class="dfn-panel" data-for="foreign-fetch-respond-with-entered-flag" id="infopanel-for-foreign-fetch-respond-with-entered-flag" role="dialog">
+   <span id="infopaneltitle-for-foreign-fetch-respond-with-entered-flag" style="display:none">Info about the 'respond-with entered flag' definition.</span><b><a href="#foreign-fetch-respond-with-entered-flag">#foreign-fetch-respond-with-entered-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreign-fetch-respond-with-entered-flag">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foreign-fetch-respond-with-error-flag">
-   <b><a href="#foreign-fetch-respond-with-error-flag">#foreign-fetch-respond-with-error-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foreign-fetch-respond-with-error-flag" class="dfn-panel" data-for="foreign-fetch-respond-with-error-flag" id="infopanel-for-foreign-fetch-respond-with-error-flag" role="dialog">
+   <span id="infopaneltitle-for-foreign-fetch-respond-with-error-flag" style="display:none">Info about the 'respond-with error flag' definition.</span><b><a href="#foreign-fetch-respond-with-error-flag">#foreign-fetch-respond-with-error-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foreign-fetch-respond-with-error-flag">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchevent-request">
-   <b><a href="#dom-foreignfetchevent-request">#dom-foreignfetchevent-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchevent-request" class="dfn-panel" data-for="dom-foreignfetchevent-request" id="infopanel-for-dom-foreignfetchevent-request" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchevent-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-foreignfetchevent-request">#dom-foreignfetchevent-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchevent-request">4.7. ForeignFetchEvent</a>
     <li><a href="#ref-for-dom-foreignfetchevent-request①">4.7.1. event.request</a>
     <li><a href="#ref-for-dom-foreignfetchevent-request②">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchevent-origin">
-   <b><a href="#dom-foreignfetchevent-origin">#dom-foreignfetchevent-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchevent-origin" class="dfn-panel" data-for="dom-foreignfetchevent-origin" id="infopanel-for-dom-foreignfetchevent-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchevent-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-foreignfetchevent-origin">#dom-foreignfetchevent-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchevent-origin">4.7. ForeignFetchEvent</a>
     <li><a href="#ref-for-dom-foreignfetchevent-origin①">4.7.2. event.origin</a>
     <li><a href="#ref-for-dom-foreignfetchevent-origin②">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foreignfetchevent-respondwith">
-   <b><a href="#dom-foreignfetchevent-respondwith">#dom-foreignfetchevent-respondwith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foreignfetchevent-respondwith" class="dfn-panel" data-for="dom-foreignfetchevent-respondwith" id="infopanel-for-dom-foreignfetchevent-respondwith" role="dialog">
+   <span id="infopaneltitle-for-dom-foreignfetchevent-respondwith" style="display:none">Info about the 'respondWith(r)' definition.</span><b><a href="#dom-foreignfetchevent-respondwith">#dom-foreignfetchevent-respondwith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foreignfetchevent-respondwith">4.7. ForeignFetchEvent</a>
     <li><a href="#ref-for-dom-foreignfetchevent-respondwith①">4.7.3. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendablemessageevent-extendablemessageeventinit">
-   <b><a href="#dictdef-extendablemessageevent-extendablemessageeventinit">#dictdef-extendablemessageevent-extendablemessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendablemessageevent-extendablemessageeventinit" class="dfn-panel" data-for="dictdef-extendablemessageevent-extendablemessageeventinit" id="infopanel-for-dictdef-extendablemessageevent-extendablemessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendablemessageevent-extendablemessageeventinit" style="display:none">Info about the 'ExtendableMessageEventInit' definition.</span><b><a href="#dictdef-extendablemessageevent-extendablemessageeventinit">#dictdef-extendablemessageevent-extendablemessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendablemessageevent-extendablemessageeventinit">4.8. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-interface">
-   <b><a href="#extendablemessage-event-interface">#extendablemessage-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-interface" class="dfn-panel" data-for="extendablemessage-event-interface" id="infopanel-for-extendablemessage-event-interface" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-interface" style="display:none">Info about the 'ExtendableMessageEvent' definition.</span><b><a href="#extendablemessage-event-interface">#extendablemessage-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-interface①">4.8. ExtendableMessageEvent</a> <a href="#ref-for-extendablemessage-event-interface②">(2)</a>
     <li><a href="#ref-for-extendablemessage-event-interface③">4.9. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-data-attribute">
-   <b><a href="#extendablemessage-event-data-attribute">#extendablemessage-event-data-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-data-attribute" class="dfn-panel" data-for="extendablemessage-event-data-attribute" id="infopanel-for-extendablemessage-event-data-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-data-attribute" style="display:none">Info about the 'data' definition.</span><b><a href="#extendablemessage-event-data-attribute">#extendablemessage-event-data-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-data-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-data-attribute①">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-data-attribute②">4.8.1. event.data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-origin-attribute">
-   <b><a href="#extendablemessage-event-origin-attribute">#extendablemessage-event-origin-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-origin-attribute" class="dfn-panel" data-for="extendablemessage-event-origin-attribute" id="infopanel-for-extendablemessage-event-origin-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-origin-attribute" style="display:none">Info about the 'origin' definition.</span><b><a href="#extendablemessage-event-origin-attribute">#extendablemessage-event-origin-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute①">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute②">4.8.2. event.origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-lasteventid-attribute">
-   <b><a href="#extendablemessage-event-lasteventid-attribute">#extendablemessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-lasteventid-attribute" class="dfn-panel" data-for="extendablemessage-event-lasteventid-attribute" id="infopanel-for-extendablemessage-event-lasteventid-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-lasteventid-attribute" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#extendablemessage-event-lasteventid-attribute">#extendablemessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-lasteventid-attribute">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-lasteventid-attribute①">4.8.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-source-attribute">
-   <b><a href="#extendablemessage-event-source-attribute">#extendablemessage-event-source-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-source-attribute" class="dfn-panel" data-for="extendablemessage-event-source-attribute" id="infopanel-for-extendablemessage-event-source-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-source-attribute" style="display:none">Info about the 'source' definition.</span><b><a href="#extendablemessage-event-source-attribute">#extendablemessage-event-source-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-source-attribute">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-extendablemessage-event-source-attribute①">(2)</a>
     <li><a href="#ref-for-extendablemessage-event-source-attribute②">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-source-attribute③">4.8.4. event.source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-ports-attribute">
-   <b><a href="#extendablemessage-event-ports-attribute">#extendablemessage-event-ports-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-ports-attribute" class="dfn-panel" data-for="extendablemessage-event-ports-attribute" id="infopanel-for-extendablemessage-event-ports-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-ports-attribute" style="display:none">Info about the 'ports' definition.</span><b><a href="#extendablemessage-event-ports-attribute">#extendablemessage-event-ports-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute①">4.8. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute②">4.8.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-install-event">
-   <b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-install-event" class="dfn-panel" data-for="service-worker-global-scope-install-event" id="infopanel-for-service-worker-global-scope-install-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-install-event" style="display:none">Info about the 'install' definition.</span><b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-install-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-install-event">4.1.4. Event handlers</a>
@@ -8353,8 +8353,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-install-event">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-activate-event">
-   <b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-activate-event" class="dfn-panel" data-for="service-worker-global-scope-activate-event" id="infopanel-for-service-worker-global-scope-activate-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-activate-event" style="display:none">Info about the 'activate' definition.</span><b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">4.1.4. Event handlers</a>
@@ -8362,8 +8362,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-activate-event">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-fetch-event">
-   <b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="service-worker-global-scope-fetch-event" id="infopanel-for-service-worker-global-scope-fetch-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' definition.</span><b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.5. Task Sources</a>
@@ -8373,54 +8373,54 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-foreignfetch-event">
-   <b><a href="#service-worker-global-scope-foreignfetch-event">#service-worker-global-scope-foreignfetch-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-foreignfetch-event" class="dfn-panel" data-for="service-worker-global-scope-foreignfetch-event" id="infopanel-for-service-worker-global-scope-foreignfetch-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-foreignfetch-event" style="display:none">Info about the 'foreignfetch' definition.</span><b><a href="#service-worker-global-scope-foreignfetch-event">#service-worker-global-scope-foreignfetch-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-foreignfetch-event">4.1.4. Event handlers</a>
     <li><a href="#ref-for-service-worker-global-scope-foreignfetch-event">4.7. ForeignFetchEvent</a> <a href="#ref-for-service-worker-global-scope-foreignfetch-event">(2)</a>
     <li><a href="#ref-for-service-worker-global-scope-foreignfetch-event">Handle Foreign Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-message-event">
-   <b><a href="#service-worker-global-scope-message-event">#service-worker-global-scope-message-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-message-event" class="dfn-panel" data-for="service-worker-global-scope-message-event" id="infopanel-for-service-worker-global-scope-message-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-message-event" style="display:none">Info about the 'message' definition.</span><b><a href="#service-worker-global-scope-message-event">#service-worker-global-scope-message-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-message-event">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-service-worker-global-scope-message-event">4.1.4. Event handlers</a>
     <li><a href="#ref-for-service-worker-global-scope-message-event">4.8. ExtendableMessageEvent</a> <a href="#ref-for-service-worker-global-scope-message-event">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-serviceworker-link">
-   <b><a href="#dfn-serviceworker-link">#dfn-serviceworker-link</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-serviceworker-link" class="dfn-panel" data-for="dfn-serviceworker-link" id="infopanel-for-dfn-serviceworker-link" role="dialog">
+   <span id="infopaneltitle-for-dfn-serviceworker-link" style="display:none">Info about the 'serviceworker link' definition.</span><b><a href="#dfn-serviceworker-link">#dfn-serviceworker-link</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-serviceworker-link">5.1. Processing</a> <a href="#ref-for-dfn-serviceworker-link①">(2)</a> <a href="#ref-for-dfn-serviceworker-link②">(3)</a> <a href="#ref-for-dfn-serviceworker-link③">(4)</a> <a href="#ref-for-dfn-serviceworker-link">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="link-scope-attribute">
-   <b><a href="#link-scope-attribute">#link-scope-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-link-scope-attribute" class="dfn-panel" data-for="link-scope-attribute" id="infopanel-for-link-scope-attribute" role="dialog">
+   <span id="infopaneltitle-for-link-scope-attribute" style="display:none">Info about the 'scope' definition.</span><b><a href="#link-scope-attribute">#link-scope-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-scope-attribute">5.2. Link element interface extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-link-scope">
-   <b><a href="#element-attrdef-link-scope">#element-attrdef-link-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-link-scope" class="dfn-panel" data-for="element-attrdef-link-scope" id="infopanel-for-element-attrdef-link-scope" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-link-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#element-attrdef-link-scope">#element-attrdef-link-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-link-scope">5.1. Processing</a> <a href="#ref-for-element-attrdef-link-scope①">(2)</a> <a href="#ref-for-element-attrdef-link-scope②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="link-workertype-attribute">
-   <b><a href="#link-workertype-attribute">#link-workertype-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-link-workertype-attribute" class="dfn-panel" data-for="link-workertype-attribute" id="infopanel-for-link-workertype-attribute" role="dialog">
+   <span id="infopaneltitle-for-link-workertype-attribute" style="display:none">Info about the 'workerType' definition.</span><b><a href="#link-workertype-attribute">#link-workertype-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-workertype-attribute">5.2. Link element interface extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-link-workertype">
-   <b><a href="#element-attrdef-link-workertype">#element-attrdef-link-workertype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-link-workertype" class="dfn-panel" data-for="element-attrdef-link-workertype" id="infopanel-for-element-attrdef-link-workertype" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-link-workertype" style="display:none">Info about the 'workertype' definition.</span><b><a href="#element-attrdef-link-workertype">#element-attrdef-link-workertype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-link-workertype">5.1. Processing</a> <a href="#ref-for-element-attrdef-link-workertype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-fetching-record">
-   <b><a href="#dfn-fetching-record">#dfn-fetching-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-fetching-record" class="dfn-panel" data-for="dfn-fetching-record" id="infopanel-for-dfn-fetching-record" role="dialog">
+   <span id="infopaneltitle-for-dfn-fetching-record" style="display:none">Info about the 'fetching record' definition.</span><b><a href="#dfn-fetching-record">#dfn-fetching-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fetching-record">6.1. Constructs</a> <a href="#ref-for-dfn-fetching-record">(2)</a> <a href="#ref-for-dfn-fetching-record">(3)</a>
     <li><a href="#ref-for-dfn-fetching-record">6.4.2. matchAll(request, options)</a> <a href="#ref-for-dfn-fetching-record">(2)</a>
@@ -8431,16 +8431,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-fetching-record">Batch Cache Operations</a> <a href="#ref-for-dfn-fetching-record">(2)</a> <a href="#ref-for-dfn-fetching-record">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-incumbent-record">
-   <b><a href="#dfn-incumbent-record">#dfn-incumbent-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-incumbent-record" class="dfn-panel" data-for="dfn-incumbent-record" id="infopanel-for-dfn-incumbent-record" role="dialog">
+   <span id="infopaneltitle-for-dfn-incumbent-record" style="display:none">Info about the 'incumbent record' definition.</span><b><a href="#dfn-incumbent-record">#dfn-incumbent-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-incumbent-record">6.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-dfn-incumbent-record">6.4.4. addAll(requests)</a> <a href="#ref-for-dfn-incumbent-record">(2)</a>
     <li><a href="#ref-for-dfn-incumbent-record">6.4.5. put(request, response)</a> <a href="#ref-for-dfn-incumbent-record">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-request-to-response-map">
-   <b><a href="#dfn-request-to-response-map">#dfn-request-to-response-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-request-to-response-map" class="dfn-panel" data-for="dfn-request-to-response-map" id="infopanel-for-dfn-request-to-response-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-request-to-response-map" style="display:none">Info about the 'request to response map' definition.</span><b><a href="#dfn-request-to-response-map">#dfn-request-to-response-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-to-response-map">6.4. Cache</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a>
     <li><a href="#ref-for-dfn-request-to-response-map">6.4.2. matchAll(request, options)</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a>
@@ -8452,8 +8452,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-request-to-response-map">Batch Cache Operations</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a> <a href="#ref-for-dfn-request-to-response-map">(3)</a> <a href="#ref-for-dfn-request-to-response-map">(4)</a> <a href="#ref-for-dfn-request-to-response-map">(5)</a> <a href="#ref-for-dfn-request-to-response-map">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-name-to-cache-map">
-   <b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-name-to-cache-map" class="dfn-panel" data-for="dfn-name-to-cache-map" id="infopanel-for-dfn-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-name-to-cache-map" style="display:none">Info about the 'name to cache map' definition.</span><b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name-to-cache-map">6.1. Constructs</a>
     <li><a href="#ref-for-dfn-name-to-cache-map">6.5. CacheStorage</a> <a href="#ref-for-dfn-name-to-cache-map">(2)</a>
@@ -8465,48 +8465,48 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-name-to-cache-map">7.6. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-caches-attribute">
-   <b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-caches-attribute" class="dfn-panel" data-for="global-caches-attribute" id="infopanel-for-global-caches-attribute" role="dialog">
+   <span id="infopaneltitle-for-global-caches-attribute" style="display:none">Info about the 'caches' definition.</span><b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-caches-attribute">6.3. self.caches</a> <a href="#ref-for-global-caches-attribute①">(2)</a>
     <li><a href="#ref-for-global-caches-attribute②">6.3.1. caches</a>
     <li><a href="#ref-for-global-caches-attribute③">6.4. Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cache-cachequeryoptions">
-   <b><a href="#dictdef-cache-cachequeryoptions">#dictdef-cache-cachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cache-cachequeryoptions" class="dfn-panel" data-for="dictdef-cache-cachequeryoptions" id="infopanel-for-dictdef-cache-cachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cache-cachequeryoptions" style="display:none">Info about the 'CacheQueryOptions' definition.</span><b><a href="#dictdef-cache-cachequeryoptions">#dictdef-cache-cachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions">6.4. Cache</a> <a href="#ref-for-dictdef-cache-cachequeryoptions①">(2)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions②">(3)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions③">(4)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions④">(5)</a>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions⑤">6.5. CacheStorage</a>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions⑥">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch">
-   <b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch" id="infopanel-for-dom-cachequeryoptions-ignoresearch" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" style="display:none">Info about the 'ignoreSearch' definition.</span><b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoresearch">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod">
-   <b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod" id="infopanel-for-dom-cachequeryoptions-ignoremethod" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" style="display:none">Info about the 'ignoreMethod' definition.</span><b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoremethod">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary">
-   <b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignorevary" class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary" id="infopanel-for-dom-cachequeryoptions-ignorevary" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignorevary" style="display:none">Info about the 'ignoreVary' definition.</span><b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignorevary">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-cachename">
-   <b><a href="#dom-cachequeryoptions-cachename">#dom-cachequeryoptions-cachename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-cachename" class="dfn-panel" data-for="dom-cachequeryoptions-cachename" id="infopanel-for-dom-cachequeryoptions-cachename" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-cachename" style="display:none">Info about the 'cacheName' definition.</span><b><a href="#dom-cachequeryoptions-cachename">#dom-cachequeryoptions-cachename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-cachename">6.5.1. match(request, options)</a> <a href="#ref-for-dom-cachequeryoptions-cachename①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cache-cachebatchoperation">
-   <b><a href="#dictdef-cache-cachebatchoperation">#dictdef-cache-cachebatchoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cache-cachebatchoperation" class="dfn-panel" data-for="dictdef-cache-cachebatchoperation" id="infopanel-for-dictdef-cache-cachebatchoperation" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cache-cachebatchoperation" style="display:none">Info about the 'CacheBatchOperation' definition.</span><b><a href="#dictdef-cache-cachebatchoperation">#dictdef-cache-cachebatchoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation①">6.4.5. put(request, response)</a>
@@ -8514,8 +8514,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-type">
-   <b><a href="#dom-cachebatchoperation-type">#dom-cachebatchoperation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-type" class="dfn-panel" data-for="dom-cachebatchoperation-type" id="infopanel-for-dom-cachebatchoperation-type" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-cachebatchoperation-type">#dom-cachebatchoperation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-type">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-type①">6.4.5. put(request, response)</a>
@@ -8523,8 +8523,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-cachebatchoperation-type③">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-type④">(2)</a> <a href="#ref-for-dom-cachebatchoperation-type⑤">(3)</a> <a href="#ref-for-dom-cachebatchoperation-type⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-request">
-   <b><a href="#dom-cachebatchoperation-request">#dom-cachebatchoperation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-request" class="dfn-panel" data-for="dom-cachebatchoperation-request" id="infopanel-for-dom-cachebatchoperation-request" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-cachebatchoperation-request">#dom-cachebatchoperation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-request">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-request①">6.4.5. put(request, response)</a>
@@ -8532,23 +8532,23 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-cachebatchoperation-request③">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-request④">(2)</a> <a href="#ref-for-dom-cachebatchoperation-request⑤">(3)</a> <a href="#ref-for-dom-cachebatchoperation-request⑥">(4)</a> <a href="#ref-for-dom-cachebatchoperation-request⑦">(5)</a> <a href="#ref-for-dom-cachebatchoperation-request⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-response">
-   <b><a href="#dom-cachebatchoperation-response">#dom-cachebatchoperation-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-response" class="dfn-panel" data-for="dom-cachebatchoperation-response" id="infopanel-for-dom-cachebatchoperation-response" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dom-cachebatchoperation-response">#dom-cachebatchoperation-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-response">6.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-response①">6.4.5. put(request, response)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-response②">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-response③">(2)</a> <a href="#ref-for-dom-cachebatchoperation-response④">(3)</a> <a href="#ref-for-dom-cachebatchoperation-response⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-options">
-   <b><a href="#dom-cachebatchoperation-options">#dom-cachebatchoperation-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-options" class="dfn-panel" data-for="dom-cachebatchoperation-options" id="infopanel-for-dom-cachebatchoperation-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-cachebatchoperation-options">#dom-cachebatchoperation-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-options">6.4.6. delete(request, options)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-options①">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-options②">(2)</a> <a href="#ref-for-dom-cachebatchoperation-options③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-interface">
-   <b><a href="#cache-interface">#cache-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-interface" class="dfn-panel" data-for="cache-interface" id="infopanel-for-cache-interface" role="dialog">
+   <span id="infopaneltitle-for-cache-interface" style="display:none">Info about the 'Cache' definition.</span><b><a href="#cache-interface">#cache-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-interface">4.9. Events</a> <a href="#ref-for-cache-interface①">(2)</a>
     <li><a href="#ref-for-cache-interface②">6. Caches</a> <a href="#ref-for-cache-interface③">(2)</a>
@@ -8561,110 +8561,110 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-cache-interface②⓪">7.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-cache-interface②①">(2)</a> <a href="#ref-for-cache-interface②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-match-method">
-   <b><a href="#cache-match-method">#cache-match-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-match-method" class="dfn-panel" data-for="cache-match-method" id="infopanel-for-cache-match-method" role="dialog">
+   <span id="infopaneltitle-for-cache-match-method" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#cache-match-method">#cache-match-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-match-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-match-method①">6.4.1. match(request, options)</a>
     <li><a href="#ref-for-cache-match-method②">6.5.1. match(request, options)</a> <a href="#ref-for-cache-match-method③">(2)</a> <a href="#ref-for-cache-match-method④">(3)</a> <a href="#ref-for-cache-match-method⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-matchall-method">
-   <b><a href="#cache-matchall-method">#cache-matchall-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-matchall-method" class="dfn-panel" data-for="cache-matchall-method" id="infopanel-for-cache-matchall-method" role="dialog">
+   <span id="infopaneltitle-for-cache-matchall-method" style="display:none">Info about the 'matchAll(request, options)' definition.</span><b><a href="#cache-matchall-method">#cache-matchall-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-matchall-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-matchall-method①">6.4.1. match(request, options)</a>
     <li><a href="#ref-for-cache-matchall-method②">6.4.2. matchAll(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-add-method">
-   <b><a href="#cache-add-method">#cache-add-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-add-method" class="dfn-panel" data-for="cache-add-method" id="infopanel-for-cache-add-method" role="dialog">
+   <span id="infopaneltitle-for-cache-add-method" style="display:none">Info about the 'add(request)' definition.</span><b><a href="#cache-add-method">#cache-add-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-add-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-add-method①">6.4.3. add(request)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-addAll-method">
-   <b><a href="#cache-addAll-method">#cache-addAll-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-addAll-method" class="dfn-panel" data-for="cache-addAll-method" id="infopanel-for-cache-addAll-method" role="dialog">
+   <span id="infopaneltitle-for-cache-addAll-method" style="display:none">Info about the 'addAll(requests)' definition.</span><b><a href="#cache-addAll-method">#cache-addAll-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-addAll-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-addAll-method①">6.4.3. add(request)</a>
     <li><a href="#ref-for-cache-addAll-method②">6.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-put-method">
-   <b><a href="#cache-put-method">#cache-put-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-put-method" class="dfn-panel" data-for="cache-put-method" id="infopanel-for-cache-put-method" role="dialog">
+   <span id="infopaneltitle-for-cache-put-method" style="display:none">Info about the 'put(request, response)' definition.</span><b><a href="#cache-put-method">#cache-put-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-put-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-put-method①">6.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-delete-method">
-   <b><a href="#cache-delete-method">#cache-delete-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-delete-method" class="dfn-panel" data-for="cache-delete-method" id="infopanel-for-cache-delete-method" role="dialog">
+   <span id="infopaneltitle-for-cache-delete-method" style="display:none">Info about the 'delete(request, options)' definition.</span><b><a href="#cache-delete-method">#cache-delete-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-delete-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-delete-method①">6.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-keys-method">
-   <b><a href="#cache-keys-method">#cache-keys-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-keys-method" class="dfn-panel" data-for="cache-keys-method" id="infopanel-for-cache-keys-method" role="dialog">
+   <span id="infopaneltitle-for-cache-keys-method" style="display:none">Info about the 'keys(request, options)' definition.</span><b><a href="#cache-keys-method">#cache-keys-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-keys-method">6.4. Cache</a>
     <li><a href="#ref-for-cache-keys-method①">6.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-interface">
-   <b><a href="#cache-storage-interface">#cache-storage-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-interface" class="dfn-panel" data-for="cache-storage-interface" id="infopanel-for-cache-storage-interface" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-interface" style="display:none">Info about the 'CacheStorage' definition.</span><b><a href="#cache-storage-interface">#cache-storage-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-interface">6.3. self.caches</a>
     <li><a href="#ref-for-cache-storage-interface①">6.3.1. caches</a>
     <li><a href="#ref-for-cache-storage-interface②">6.5. CacheStorage</a> <a href="#ref-for-cache-storage-interface③">(2)</a> <a href="#ref-for-cache-storage-interface④">(3)</a> <a href="#ref-for-cache-storage-interface⑤">(4)</a> <a href="#ref-for-cache-storage-interface⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-match-method">
-   <b><a href="#cache-storage-match-method">#cache-storage-match-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-match-method" class="dfn-panel" data-for="cache-storage-match-method" id="infopanel-for-cache-storage-match-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-match-method" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#cache-storage-match-method">#cache-storage-match-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-match-method">6.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-match-method①">6.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-has-method">
-   <b><a href="#cache-storage-has-method">#cache-storage-has-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-has-method" class="dfn-panel" data-for="cache-storage-has-method" id="infopanel-for-cache-storage-has-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-has-method" style="display:none">Info about the 'has(cacheName)' definition.</span><b><a href="#cache-storage-has-method">#cache-storage-has-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-has-method">6.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-has-method①">6.5.2. has(cacheName)</a>
     <li><a href="#ref-for-cache-storage-has-method②">6.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-open-method">
-   <b><a href="#cache-storage-open-method">#cache-storage-open-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-open-method" class="dfn-panel" data-for="cache-storage-open-method" id="infopanel-for-cache-storage-open-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-open-method" style="display:none">Info about the 'open(cacheName)' definition.</span><b><a href="#cache-storage-open-method">#cache-storage-open-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-open-method">6.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-open-method①">6.5.3. open(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-delete-method">
-   <b><a href="#cache-storage-delete-method">#cache-storage-delete-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-delete-method" class="dfn-panel" data-for="cache-storage-delete-method" id="infopanel-for-cache-storage-delete-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-delete-method" style="display:none">Info about the 'delete(cacheName)' definition.</span><b><a href="#cache-storage-delete-method">#cache-storage-delete-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-delete-method">6.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-delete-method①">6.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-keys-method">
-   <b><a href="#cache-storage-keys-method">#cache-storage-keys-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-keys-method" class="dfn-panel" data-for="cache-storage-keys-method" id="infopanel-for-cache-storage-keys-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-keys-method" style="display:none">Info about the 'keys()' definition.</span><b><a href="#cache-storage-keys-method">#cache-storage-keys-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-keys-method">6.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-keys-method①">6.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="importscripts-method">
-   <b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-importscripts-method" class="dfn-panel" data-for="importscripts-method" id="infopanel-for-importscripts-method" role="dialog">
+   <span id="infopaneltitle-for-importscripts-method" style="display:none">Info about the 'importScripts(urls)' definition.</span><b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-importscripts-method">7.3.1. Origin restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-registration-map">
-   <b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-registration-map" class="dfn-panel" data-for="dfn-scope-to-registration-map" id="infopanel-for-dfn-scope-to-registration-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-registration-map" style="display:none">Info about the 'scope to registration map' definition.</span><b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.4. Selection and Use</a> <a href="#ref-for-dfn-scope-to-registration-map">(2)</a>
@@ -8679,8 +8679,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-to-registration-map">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job">
-   <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job" class="dfn-panel" data-for="dfn-job" id="infopanel-for-dfn-job" role="dialog">
+   <span id="infopaneltitle-for-dfn-job" style="display:none">Info about the 'job' definition.</span><b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job">(2)</a> <a href="#ref-for-dfn-job">(3)</a> <a href="#ref-for-dfn-job">(4)</a> <a href="#ref-for-dfn-job">(5)</a> <a href="#ref-for-dfn-job">(6)</a> <a href="#ref-for-dfn-job">(7)</a> <a href="#ref-for-dfn-job">(8)</a> <a href="#ref-for-dfn-job">(9)</a> <a href="#ref-for-dfn-job">(10)</a> <a href="#ref-for-dfn-job">(11)</a> <a href="#ref-for-dfn-job">(12)</a> <a href="#ref-for-dfn-job">(13)</a> <a href="#ref-for-dfn-job">(14)</a> <a href="#ref-for-dfn-job">(15)</a> <a href="#ref-for-dfn-job">(16)</a>
     <li><a href="#ref-for-dfn-job">Create Job</a> <a href="#ref-for-dfn-job">(2)</a>
@@ -8694,8 +8694,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-type">
-   <b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-type" class="dfn-panel" data-for="dfn-job-type" id="infopanel-for-dfn-job-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-type" style="display:none">Info about the 'job type' definition.</span><b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-type">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type">Create Job</a> <a href="#ref-for-dfn-job-type">(2)</a>
@@ -8703,8 +8703,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-type">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-scope-url">
-   <b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-scope-url" class="dfn-panel" data-for="dfn-job-scope-url" id="infopanel-for-dfn-job-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-scope-url">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-scope-url">(2)</a> <a href="#ref-for-dfn-job-scope-url">(3)</a>
     <li><a href="#ref-for-dfn-job-scope-url">Create Job</a>
@@ -8713,8 +8713,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-scope-url">Unregister</a> <a href="#ref-for-dfn-job-scope-url">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-script-url">
-   <b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-script-url" class="dfn-panel" data-for="dfn-job-script-url" id="infopanel-for-dfn-job-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url">Create Job</a>
@@ -8722,8 +8722,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-script-url">Update</a> <a href="#ref-for-dfn-job-script-url">(2)</a> <a href="#ref-for-dfn-job-script-url">(3)</a> <a href="#ref-for-dfn-job-script-url">(4)</a> <a href="#ref-for-dfn-job-script-url">(5)</a> <a href="#ref-for-dfn-job-script-url">(6)</a> <a href="#ref-for-dfn-job-script-url">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-worker-type">
-   <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-worker-type" class="dfn-panel" data-for="dfn-job-worker-type" id="infopanel-for-dfn-job-worker-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-worker-type" style="display:none">Info about the 'worker type' definition.</span><b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-worker-type">3.2.5. update()</a>
     <li><a href="#ref-for-dfn-job-worker-type①">Start Register</a> <a href="#ref-for-dfn-job-worker-type②">(2)</a>
@@ -8731,8 +8731,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-worker-type⑤">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-client">
-   <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-client" class="dfn-panel" data-for="dfn-job-client" id="infopanel-for-dfn-job-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-client" style="display:none">Info about the 'client' definition.</span><b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client">Create Job</a>
     <li><a href="#ref-for-dfn-job-client">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client">(2)</a> <a href="#ref-for-dfn-job-client">(3)</a> <a href="#ref-for-dfn-job-client">(4)</a>
@@ -8741,16 +8741,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-client">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="job-referrer">
-   <b><a href="#job-referrer">#job-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-job-referrer" class="dfn-panel" data-for="job-referrer" id="infopanel-for-job-referrer" role="dialog">
+   <span id="infopaneltitle-for-job-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#job-referrer">#job-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-job-referrer">Create Job</a>
     <li><a href="#ref-for-job-referrer①">Start Register</a>
     <li><a href="#ref-for-job-referrer②">Register</a> <a href="#ref-for-job-referrer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-promise">
-   <b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-promise" class="dfn-panel" data-for="dfn-job-promise" id="infopanel-for-dfn-job-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-promise" style="display:none">Info about the 'promise' definition.</span><b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-promise">Create Job</a>
     <li><a href="#ref-for-dfn-job-promise">Schedule Job</a>
@@ -8759,28 +8759,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-promise">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs">
-   <b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs" id="infopanel-for-dfn-job-list-of-equivalent-jobs" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" style="display:none">Info about the 'list of equivalent jobs' definition.</span><b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Resolve Job Promise</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
-   <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-force-bypass-cache-flag" class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag" id="infopanel-for-dfn-job-force-bypass-cache-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-force-bypass-cache-flag" style="display:none">Info about the 'force bypass cache flag' definition.</span><b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-equivalent">
-   <b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-equivalent" class="dfn-panel" data-for="dfn-job-equivalent" id="infopanel-for-dfn-job-equivalent" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-equivalent" style="display:none">Info about the 'equivalent' definition.</span><b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-equivalent">Schedule Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-queue">
-   <b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-queue" class="dfn-panel" data-for="dfn-job-queue" id="infopanel-for-dfn-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-queue" style="display:none">Info about the 'job queue' definition.</span><b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-queue">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-queue">(2)</a> <a href="#ref-for-dfn-job-queue">(3)</a> <a href="#ref-for-dfn-job-queue">(4)</a> <a href="#ref-for-dfn-job-queue">(5)</a> <a href="#ref-for-dfn-job-queue">(6)</a>
     <li><a href="#ref-for-dfn-job-queue">Schedule Job</a> <a href="#ref-for-dfn-job-queue">(2)</a> <a href="#ref-for-dfn-job-queue">(3)</a> <a href="#ref-for-dfn-job-queue">(4)</a>
@@ -8790,59 +8790,115 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/ServiceWorker/publish/service_worker_1/WD-service-workers-1-20161011/index.html
+++ b/tests/github/w3c/ServiceWorker/publish/service_worker_1/WD-service-workers-1-20161011/index.html
@@ -4132,55 +4132,55 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <li><a href="#dfn-worker-client">worker client</a><span>, in § 2.3</span>
    <li><a href="#dfn-job-worker-type">worker type</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://w3c.github.io/webappsec-csp/2/#enforce">https://w3c.github.io/webappsec-csp/2/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce" style="display:none">Info about the 'enforce' external reference.</span><a href="https://w3c.github.io/webappsec-csp/2/#enforce">https://w3c.github.io/webappsec-csp/2/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://w3c.github.io/webappsec-csp/2/#monitor">https://w3c.github.io/webappsec-csp/2/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://w3c.github.io/webappsec-csp/2/#monitor">https://w3c.github.io/webappsec-csp/2/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">6.2. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2.8. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-event①">3.6. Events</a> <a href="#ref-for-event②">(2)</a> <a href="#ref-for-event③">(3)</a>
     <li><a href="#ref-for-event④">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-dictdef-eventinit①">4.4. ExtendableEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventtarget①">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-eventtarget②">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.5. Task Sources</a> <a href="#ref-for-concept-event-dispatch①">(2)</a>
     <li><a href="#ref-for-concept-event-dispatch②">3.1.3. postMessage(message, transfer)</a>
@@ -4191,52 +4191,52 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-event-dispatch⑦">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">4.5.2. event.clientId</a>
     <li><a href="#ref-for-concept-event①">4.5.3. event.isReload</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">2.1. Service Worker</a>
     <li><a href="#ref-for-concept-event-listener①">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-immediate-propagation-flag" class="dfn-panel" data-for="term-for-stop-immediate-propagation-flag" id="infopanel-for-term-for-stop-immediate-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-immediate-propagation-flag" style="display:none">Info about the 'stop immediate propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-immediate-propagation-flag">https://dom.spec.whatwg.org/#stop-immediate-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-immediate-propagation-flag">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-propagation-flag" class="dfn-panel" data-for="term-for-stop-propagation-flag" id="infopanel-for-term-for-stop-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">https://dom.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://dom.spec.whatwg.org/#ascii-case-insensitive">https://dom.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a> <a href="#ref-for-ascii-case-insensitive②">(3)</a> <a href="#ref-for-ascii-case-insensitive③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" class="dfn-panel" data-for="term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" id="infopanel-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-function-objects-call-thisargument-argumentslist" style="display:none">Info about the '[[call]]' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-function-objects-call-thisargument-argumentslist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-function-objects-call-thisargument-argumentslist">5.5.1. match(request, options)</a> <a href="#ref-for-sec-ecmascript-function-objects-call-thisargument-argumentslist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the 'assert' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions">http://www.ecma-international.org/ecma-262/6.0/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">Run Job</a>
     <li><a href="#ref-for-sec-algorithm-conventions①">Finish Job</a>
@@ -4245,8 +4245,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-algorithm-conventions⑤">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type" style="display:none">Info about the 'list' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">2.1. Service Worker</a> <a href="#ref-for-sec-list-and-record-specification-type①">(2)</a>
     <li><a href="#ref-for-sec-list-and-record-specification-type②">3.4.5. getRegistrations()</a>
@@ -4264,15 +4264,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-list-and-record-specification-type②⓪">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-map-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-map-objects" class="dfn-panel" data-for="term-for-sec-map-objects" id="infopanel-for-term-for-sec-map-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-map-objects" style="display:none">Info about the 'map objects' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-map-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-map-objects">5.4. Cache</a>
     <li><a href="#ref-for-sec-map-objects①">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3.2.5. update()</a>
     <li><a href="#ref-for-sec-promise-objects①">3.2.6. unregister()</a>
@@ -4307,8 +4307,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-promise-objects⑥⓪">Batch Cache Operations</a> <a href="#ref-for-sec-promise-objects⑥①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type①" style="display:none">Info about the 'record' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">2.1. Service Worker</a> <a href="#ref-for-sec-list-and-record-specification-type①">(2)</a>
     <li><a href="#ref-for-sec-list-and-record-specification-type②">3.4.5. getRegistrations()</a>
@@ -4326,15 +4326,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-sec-list-and-record-specification-type②⓪">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-headers">
-   <a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-headers" class="dfn-panel" data-for="term-for-headers" id="infopanel-for-term-for-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-headers" style="display:none">Info about the 'Headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#headers">https://fetch.spec.whatwg.org/#headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">5.4.4. addAll(requests)</a> <a href="#ref-for-headers①">(2)</a>
     <li><a href="#ref-for-headers②">5.4.5. put(request, response)</a> <a href="#ref-for-headers③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">4.5. FetchEvent</a> <a href="#ref-for-request①">(2)</a>
     <li><a href="#ref-for-request②">5.1. Constructs</a>
@@ -4348,15 +4348,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-request②①">Query Cache</a> <a href="#ref-for-request②②">(2)</a> <a href="#ref-for-request②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-requestinfo">
-   <a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-requestinfo" class="dfn-panel" data-for="term-for-requestinfo" id="infopanel-for-term-for-requestinfo" role="menu">
+   <span id="infopaneltitle-for-term-for-requestinfo" style="display:none">Info about the 'RequestInfo' external reference.</span><a href="https://fetch.spec.whatwg.org/#requestinfo">https://fetch.spec.whatwg.org/#requestinfo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">5.4. Cache</a> <a href="#ref-for-requestinfo①">(2)</a> <a href="#ref-for-requestinfo②">(3)</a> <a href="#ref-for-requestinfo③">(4)</a> <a href="#ref-for-requestinfo④">(5)</a> <a href="#ref-for-requestinfo⑤">(6)</a> <a href="#ref-for-requestinfo⑥">(7)</a>
     <li><a href="#ref-for-requestinfo⑦">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.5. FetchEvent</a>
     <li><a href="#ref-for-response①">4.5.4. event.respondWith(r)</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a>
@@ -4370,102 +4370,102 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-response①⑧">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-basic">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-basic" class="dfn-panel" data-for="term-for-concept-filtered-response-basic" id="infopanel-for-term-for-concept-filtered-response-basic" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-basic" style="display:none">Info about the 'basic filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-basic">https://fetch.spec.whatwg.org/#concept-filtered-response-basic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-basic">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-concept-filtered-response-basic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-body①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cancel-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-cancel-readablestream">https://fetch.spec.whatwg.org/#concept-cancel-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cancel-readablestream" class="dfn-panel" data-for="term-for-concept-cancel-readablestream" id="infopanel-for-term-for-concept-cancel-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cancel-readablestream" style="display:none">Info about the 'cancel a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-cancel-readablestream">https://fetch.spec.whatwg.org/#concept-cancel-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cancel-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-request-client①">Handle Fetch</a> <a href="#ref-for-concept-request-client②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-close-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-close-readablestream">https://fetch.spec.whatwg.org/#concept-close-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-close-readablestream" class="dfn-panel" data-for="term-for-concept-close-readablestream" id="infopanel-for-term-for-concept-close-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-close-readablestream" style="display:none">Info about the 'close readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-close-readablestream">https://fetch.spec.whatwg.org/#concept-close-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-close-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-construct-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-construct-readablestream">https://fetch.spec.whatwg.org/#concept-construct-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-construct-readablestream" class="dfn-panel" data-for="term-for-concept-construct-readablestream" id="infopanel-for-term-for-concept-construct-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-construct-readablestream" style="display:none">Info about the 'construct a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-construct-readablestream">https://fetch.spec.whatwg.org/#concept-construct-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-construct-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-cors">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-cors" class="dfn-panel" data-for="term-for-concept-filtered-response-cors" id="infopanel-for-term-for-concept-filtered-response-cors" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-cors" style="display:none">Info about the 'cors filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-cors">https://fetch.spec.whatwg.org/#concept-filtered-response-cors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-cors">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-request-destination①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-disturbed">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-disturbed">https://fetch.spec.whatwg.org/#concept-body-disturbed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-disturbed" class="dfn-panel" data-for="term-for-concept-body-disturbed" id="infopanel-for-term-for-concept-body-disturbed" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-disturbed" style="display:none">Info about the 'disturbed' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-disturbed">https://fetch.spec.whatwg.org/#concept-body-disturbed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-disturbed">4.5.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-disturbed①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-empty-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-empty-readablestream">https://fetch.spec.whatwg.org/#concept-empty-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-empty-readablestream" class="dfn-panel" data-for="term-for-concept-empty-readablestream" id="infopanel-for-term-for-concept-empty-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-empty-readablestream" style="display:none">Info about the 'empty' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-empty-readablestream">https://fetch.spec.whatwg.org/#concept-empty-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-empty-readablestream">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-enqueue-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">https://fetch.spec.whatwg.org/#concept-enqueue-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-enqueue-readablestream" class="dfn-panel" data-for="term-for-concept-enqueue-readablestream" id="infopanel-for-term-for-concept-enqueue-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-enqueue-readablestream" style="display:none">Info about the 'enqueue a chunk to readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-enqueue-readablestream">https://fetch.spec.whatwg.org/#concept-enqueue-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-enqueue-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-error-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-error-readablestream">https://fetch.spec.whatwg.org/#concept-error-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-error-readablestream" class="dfn-panel" data-for="term-for-concept-error-readablestream" id="infopanel-for-term-for-concept-error-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-error-readablestream" style="display:none">Info about the 'error readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-error-readablestream">https://fetch.spec.whatwg.org/#concept-error-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-error-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-readablestream-errored">
-   <a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">https://fetch.spec.whatwg.org/#concept-readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-readablestream-errored" class="dfn-panel" data-for="term-for-concept-readablestream-errored" id="infopanel-for-term-for-concept-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-readablestream-errored">https://fetch.spec.whatwg.org/#concept-readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-readablestream-errored">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extract a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.4. Selection and Use</a>
     <li><a href="#ref-for-concept-fetch①">4.5.4. event.respondWith(r)</a> <a href="#ref-for-concept-fetch②">(2)</a> <a href="#ref-for-concept-fetch③">(3)</a> <a href="#ref-for-concept-fetch④">(4)</a>
@@ -4477,41 +4477,41 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-fetch①②">Service Worker Script Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-global-fetch">
-   <a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-global-fetch" class="dfn-panel" data-for="term-for-dom-global-fetch" id="infopanel-for-term-for-dom-global-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-global-fetch" style="display:none">Info about the 'fetch(input, init)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-global-fetch">https://fetch.spec.whatwg.org/#dom-global-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response" class="dfn-panel" data-for="term-for-concept-filtered-response" id="infopanel-for-term-for-concept-filtered-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response" style="display:none">Info about the 'filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response">https://fetch.spec.whatwg.org/#concept-filtered-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-get-reader">
-   <a href="https://fetch.spec.whatwg.org/#concept-get-reader">https://fetch.spec.whatwg.org/#concept-get-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-get-reader" class="dfn-panel" data-for="term-for-concept-get-reader" id="infopanel-for-term-for-concept-get-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-get-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-get-reader">https://fetch.spec.whatwg.org/#concept-get-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-get-reader">4.5.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-get-reader①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-headers-get">
-   <a href="https://fetch.spec.whatwg.org/#dom-headers-get">https://fetch.spec.whatwg.org/#dom-headers-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-headers-get" class="dfn-panel" data-for="term-for-dom-headers-get" id="infopanel-for-term-for-dom-headers-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-headers-get" style="display:none">Info about the 'get(name)' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-headers-get">https://fetch.spec.whatwg.org/#dom-headers-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-get">Query Cache</a> <a href="#ref-for-dom-headers-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-headers-guard">
-   <a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-headers-guard" class="dfn-panel" data-for="term-for-concept-headers-guard" id="infopanel-for-term-for-concept-headers-guard" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-headers-guard" style="display:none">Info about the 'guard' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-headers-guard">https://fetch.spec.whatwg.org/#concept-headers-guard</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-guard">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-headers-guard①">(2)</a>
     <li><a href="#ref-for-concept-headers-guard②">5.4.5. put(request, response)</a> <a href="#ref-for-concept-headers-guard③">(2)</a>
     <li><a href="#ref-for-concept-headers-guard④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header①">5.4.5. put(request, response)</a>
@@ -4520,14 +4520,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-header④">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-header-list①">5.4.5. put(request, response)</a>
@@ -4535,34 +4535,34 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-header-list④">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-request-headers">
-   <a href="https://fetch.spec.whatwg.org/#dom-request-headers">https://fetch.spec.whatwg.org/#dom-request-headers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-request-headers" class="dfn-panel" data-for="term-for-dom-request-headers" id="infopanel-for-term-for-dom-request-headers" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-request-headers" style="display:none">Info about the 'headers' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-request-headers">https://fetch.spec.whatwg.org/#dom-request-headers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-headers">Handle Fetch</a>
     <li><a href="#ref-for-dom-request-headers①">Query Cache</a> <a href="#ref-for-dom-request-headers②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">4.7. Events</a> <a href="#ref-for-concept-http-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-locked">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-locked">https://fetch.spec.whatwg.org/#concept-body-locked</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-locked" class="dfn-panel" data-for="term-for-concept-body-locked" id="infopanel-for-term-for-concept-body-locked" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-locked" style="display:none">Info about the 'locked' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-locked">https://fetch.spec.whatwg.org/#concept-body-locked</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-locked">4.5.4. event.respondWith(r)</a>
     <li><a href="#ref-for-concept-body-locked①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-concept-request-method①">5.4.4. addAll(requests)</a>
@@ -4572,22 +4572,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-method⑤">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-header-name①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-concept-header-name②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.5.4. event.respondWith(r)</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">6.3.2. importScripts(urls)</a>
@@ -4595,85 +4595,85 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-network-error⑥">Handle Fetch</a> <a href="#ref-for-concept-network-error⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-subresource-request" class="dfn-panel" data-for="term-for-non-subresource-request" id="infopanel-for-term-for-non-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-non-subresource-request" style="display:none">Info about the 'non-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#non-subresource-request">https://fetch.spec.whatwg.org/#non-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-subresource-request">2.4. Selection and Use</a>
     <li><a href="#ref-for-non-subresource-request①">Handle Fetch</a> <a href="#ref-for-non-subresource-request②">(2)</a> <a href="#ref-for-non-subresource-request③">(3)</a> <a href="#ref-for-non-subresource-request④">(4)</a> <a href="#ref-for-non-subresource-request⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-ok-status①">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-filtered-response-opaque">
-   <a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-filtered-response-opaque" class="dfn-panel" data-for="term-for-concept-filtered-response-opaque" id="infopanel-for-term-for-concept-filtered-response-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-filtered-response-opaque" style="display:none">Info about the 'opaque filtered response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque">https://fetch.spec.whatwg.org/#concept-filtered-response-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-parse">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-parse" class="dfn-panel" data-for="term-for-concept-header-parse" id="infopanel-for-term-for-concept-header-parse" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-parse" style="display:none">Info about the 'parsing' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-parse">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potential-navigation-or-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potential-navigation-or-subresource-request" class="dfn-panel" data-for="term-for-potential-navigation-or-subresource-request" id="infopanel-for-term-for-potential-navigation-or-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-potential-navigation-or-subresource-request" style="display:none">Info about the 'potential-navigation-or-subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request">https://fetch.spec.whatwg.org/#potential-navigation-or-subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potential-navigation-or-subresource-request">6.5. Implementer Concerns</a>
     <li><a href="#ref-for-potential-navigation-or-subresource-request①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-response">
-   <a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-response" class="dfn-panel" data-for="term-for-process-response" id="infopanel-for-term-for-process-response" role="menu">
+   <span id="infopaneltitle-for-term-for-process-response" style="display:none">Info about the 'process response' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-process-response①">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-response-end-of-file">
-   <a href="https://fetch.spec.whatwg.org/#process-response-end-of-file">https://fetch.spec.whatwg.org/#process-response-end-of-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-response-end-of-file" class="dfn-panel" data-for="term-for-process-response-end-of-file" id="infopanel-for-term-for-process-response-end-of-file" role="menu">
+   <span id="infopaneltitle-for-term-for-process-response-end-of-file" style="display:none">Info about the 'process response end-of-file' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-response-end-of-file">https://fetch.spec.whatwg.org/#process-response-end-of-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response-end-of-file">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-read-chunk-from-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-read-chunk-from-readablestream" class="dfn-panel" data-for="term-for-concept-read-chunk-from-readablestream" id="infopanel-for-term-for-concept-read-chunk-from-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-read-chunk-from-readablestream" style="display:none">Info about the 'read a chunk from a readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-chunk-from-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-read-chunk-from-readablestream">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-read-all-bytes-from-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-read-all-bytes-from-readablestream" class="dfn-panel" data-for="term-for-concept-read-all-bytes-from-readablestream" id="infopanel-for-term-for-concept-read-all-bytes-from-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-read-all-bytes-from-readablestream" style="display:none">Info about the 'read all bytes' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream">https://fetch.spec.whatwg.org/#concept-read-all-bytes-from-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-read-all-bytes-from-readablestream">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-readablestream">
-   <a href="https://fetch.spec.whatwg.org/#concept-readablestream">https://fetch.spec.whatwg.org/#concept-readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-readablestream" class="dfn-panel" data-for="term-for-concept-readablestream" id="infopanel-for-term-for-concept-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-readablestream" style="display:none">Info about the 'readablestream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-readablestream">https://fetch.spec.whatwg.org/#concept-readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-readablestream">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request (for fetch)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-concept-request①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-request" class="dfn-panel" data-for="term-for-concept-request-request" id="infopanel-for-term-for-concept-request-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-request" style="display:none">Info about the 'request (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-request">https://fetch.spec.whatwg.org/#concept-request-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">5.4.2. matchAll(request, options)</a> <a href="#ref-for-concept-request-request①">(2)</a>
     <li><a href="#ref-for-concept-request-request②">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-request③">(2)</a>
@@ -4684,8 +4684,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-request①④">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response (for fetch)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">4.5. FetchEvent</a>
     <li><a href="#ref-for-concept-response①">4.7. Events</a> <a href="#ref-for-concept-response②">(2)</a>
@@ -4693,8 +4693,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">2.1. Service Worker</a>
     <li><a href="#termref-for-concept-response-response">4.5.4. event.respondWith(r)</a>
@@ -4704,53 +4704,53 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-response-response⑦">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-skip-service-worker-flag">
-   <a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">https://fetch.spec.whatwg.org/#skip-service-worker-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-skip-service-worker-flag" class="dfn-panel" data-for="term-for-skip-service-worker-flag" id="infopanel-for-term-for-skip-service-worker-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-skip-service-worker-flag" style="display:none">Info about the 'skip service worker flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#skip-service-worker-flag">https://fetch.spec.whatwg.org/#skip-service-worker-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skip-service-worker-flag">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-stream">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-stream" class="dfn-panel" data-for="term-for-concept-body-stream" id="infopanel-for-term-for-concept-body-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-stream" style="display:none">Info about the 'stream' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-stream">https://fetch.spec.whatwg.org/#concept-body-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">4.5.4. event.respondWith(r)</a> <a href="#ref-for-concept-body-stream①">(2)</a> <a href="#ref-for-concept-body-stream②">(3)</a> <a href="#ref-for-concept-body-stream③">(4)</a> <a href="#ref-for-concept-body-stream④">(5)</a>
     <li><a href="#ref-for-concept-body-stream⑤">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subresource-request">
-   <a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subresource-request" class="dfn-panel" data-for="term-for-subresource-request" id="infopanel-for-term-for-subresource-request" role="menu">
+   <span id="infopaneltitle-for-term-for-subresource-request" style="display:none">Info about the 'subresource request' external reference.</span><a href="https://fetch.spec.whatwg.org/#subresource-request">https://fetch.spec.whatwg.org/#subresource-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">Handle Fetch</a> <a href="#ref-for-subresource-request①">(2)</a> <a href="#ref-for-subresource-request②">(3)</a> <a href="#ref-for-subresource-request③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch-terminate">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">https://fetch.spec.whatwg.org/#concept-fetch-terminate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch-terminate" class="dfn-panel" data-for="term-for-concept-fetch-terminate" id="infopanel-for-term-for-concept-fetch-terminate" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch-terminate" style="display:none">Info about the 'terminate' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch-terminate">https://fetch.spec.whatwg.org/#concept-fetch-terminate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-terminate">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-termination-reason">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-termination-reason">https://fetch.spec.whatwg.org/#concept-response-termination-reason</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-termination-reason" class="dfn-panel" data-for="term-for-concept-response-termination-reason" id="infopanel-for-term-for-concept-response-termination-reason" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-termination-reason" style="display:none">Info about the 'termination reason' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-termination-reason">https://fetch.spec.whatwg.org/#concept-response-termination-reason</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-termination-reason">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-response-termination-reason①">(2)</a>
     <li><a href="#ref-for-concept-response-termination-reason②">5.4.5. put(request, response)</a> <a href="#ref-for-concept-response-termination-reason③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-concept-response-type①">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.4. Selection and Use</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a>
     <li><a href="#ref-for-concept-request-url③">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-request-url④">(2)</a>
@@ -4761,26 +4761,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-request-url①③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstractworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstractworker" class="dfn-panel" data-for="term-for-abstractworker" id="infopanel-for-term-for-abstractworker" role="menu">
+   <span id="infopaneltitle-for-term-for-abstractworker" style="display:none">Info about the 'AbstractWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#abstractworker">https://html.spec.whatwg.org/multipage/workers.html#abstractworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractworker">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-domcontentloaded">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-domcontentloaded" class="dfn-panel" data-for="term-for-event-domcontentloaded" id="infopanel-for-term-for-event-domcontentloaded" role="menu">
+   <span id="infopaneltitle-for-term-for-event-domcontentloaded" style="display:none">Info about the 'DOMContentLoaded' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded">https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-domcontentloaded">Run Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.1. ServiceWorker</a>
     <li><a href="#ref-for-eventhandler①">3.2. ServiceWorkerRegistration</a>
@@ -4788,8 +4788,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-eventhandler④">4.1. ServiceWorkerGlobalScope</a> <a href="#ref-for-eventhandler⑤">(2)</a> <a href="#ref-for-eventhandler⑥">(3)</a> <a href="#ref-for-eventhandler⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-messageport①">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-messageport②">(2)</a> <a href="#ref-for-messageport③">(3)</a> <a href="#ref-for-messageport④">(4)</a>
@@ -4799,21 +4799,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-messageport①①">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-navigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-navigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">2.3. Service Worker Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.3. Service Worker Client</a>
     <li><a href="#ref-for-window①">3.1.3. postMessage(message, transfer)</a>
@@ -4824,54 +4824,54 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window⑨">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-workerglobalscope①">5. Caches</a>
     <li><a href="#ref-for-workerglobalscope②">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerlocation">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerlocation" class="dfn-panel" data-for="term-for-workerlocation" id="infopanel-for-term-for-workerlocation" role="menu">
+   <span id="infopaneltitle-for-term-for-workerlocation" style="display:none">Info about the 'WorkerLocation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerlocation">https://html.spec.whatwg.org/multipage/workers.html#workerlocation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerlocation">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3.3. navigator.serviceWorker</a>
     <li><a href="#ref-for-workernavigator①">3.4. ServiceWorkerContainer</a> <a href="#ref-for-workernavigator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workertype">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workertype" class="dfn-panel" data-for="term-for-workertype" id="infopanel-for-term-for-workertype" role="menu">
+   <span id="infopaneltitle-for-term-for-workertype" style="display:none">Info about the 'WorkerType' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workertype">https://html.spec.whatwg.org/multipage/workers.html#workertype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workertype">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-about:blank">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank">https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-about:blank" class="dfn-panel" data-for="term-for-about:blank" id="infopanel-for-term-for-about:blank" role="menu">
+   <span id="infopaneltitle-for-term-for-about:blank" style="display:none">Info about the 'about:blank' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank">https://html.spec.whatwg.org/multipage/infrastructure.html#about:blank</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-about:blank">4.2.8. navigate(url)</a>
     <li><a href="#ref-for-about:blank①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#active-document">https://html.spec.whatwg.org/multipage/document-sequences.html#active-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-document" class="dfn-panel" data-for="term-for-active-document" id="infopanel-for-term-for-active-document" role="menu">
+   <span id="infopaneltitle-for-term-for-active-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#active-document">https://html.spec.whatwg.org/multipage/document-sequences.html#active-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-document">4.2.7. focus()</a> <a href="#ref-for-active-document①">(2)</a>
     <li><a href="#ref-for-active-document②">4.2.8. navigate(url)</a> <a href="#ref-for-active-document③">(2)</a>
@@ -4880,8 +4880,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-active-document①②">4.3.3. openWindow(url)</a> <a href="#ref-for-active-document①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-api-base-url①">(2)</a>
     <li><a href="#ref-for-api-base-url②">3.4.4. getRegistration(clientURL)</a>
@@ -4890,20 +4890,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-api-base-url⑤">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-url-character-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-url-character-encoding" class="dfn-panel" data-for="term-for-api-url-character-encoding" id="infopanel-for-term-for-api-url-character-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-api-url-character-encoding" style="display:none">Info about the 'api url character encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-url-character-encoding">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-browsing-context①">4.2.2. frameType</a> <a href="#ref-for-browsing-context②">(2)</a> <a href="#ref-for-browsing-context③">(3)</a>
@@ -4913,14 +4913,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-browsing-context⑦">4.3.2. matchAll(options)</a> <a href="#ref-for-browsing-context⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-classic-script" class="dfn-panel" data-for="term-for-classic-script" id="infopanel-for-term-for-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-classic-script" style="display:none">Info about the 'classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-creation-url" class="dfn-panel" data-for="term-for-creation-url" id="infopanel-for-term-for-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-creation-url" style="display:none">Info about the 'creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creation-url">2.4. Selection and Use</a>
     <li><a href="#ref-for-creation-url①">3.4.2. ready</a>
@@ -4933,8 +4933,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-creation-url⑧">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dom-manipulation-task-source①">Resolve Job Promise</a> <a href="#ref-for-dom-manipulation-task-source②">(2)</a>
@@ -4944,8 +4944,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-manipulation-task-source⑦">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.3. Service Worker Client</a> <a href="#ref-for-environment-settings-object①">(2)</a>
     <li><a href="#ref-for-environment-settings-object②">3.5.2. event.origin</a>
@@ -4961,8 +4961,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-environment-settings-object①⑤">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.1.4. Event handler</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">3.2.7. Event handler</a> <a href="#ref-for-event-handlers③">(2)</a>
@@ -4971,8 +4971,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handlers⑧">Update Worker State</a> <a href="#ref-for-event-handlers⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.1.4. Event handler</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">3.2.7. Event handler</a> <a href="#ref-for-event-handler-event-type③">(2)</a>
@@ -4980,8 +4980,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-event-type⑥">4.1.4. Event handlers</a> <a href="#ref-for-event-handler-event-type⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.1.4. Event handler</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">3.2.7. Event handler</a>
@@ -4989,8 +4989,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-event-handler-idl-attributes③">4.1.4. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">2.2. Service Worker Registration</a> <a href="#ref-for-concept-agent-event-loop①">(2)</a> <a href="#ref-for-concept-agent-event-loop②">(3)</a> <a href="#ref-for-concept-agent-event-loop③">(4)</a>
     <li><a href="#ref-for-concept-agent-event-loop④">3.4. ServiceWorkerContainer</a>
@@ -5000,35 +5000,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-agent-event-loop①⓪">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-classic-worker-script" class="dfn-panel" data-for="term-for-fetch-a-classic-worker-script" id="infopanel-for-term-for-fetch-a-classic-worker-script" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-classic-worker-script" style="display:none">Info about the 'fetch a classic worker script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-classic-worker-script">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" class="dfn-panel" data-for="term-for-fetch-a-module-worker-script-tree" id="infopanel-for-term-for-fetch-a-module-worker-script-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-a-module-worker-script-tree" style="display:none">Info about the 'fetch a module worker script tree' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree">https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-module-worker-script-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-module-worker-script-tree">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-a-simple-event">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-a-simple-event" class="dfn-panel" data-for="term-for-fire-a-simple-event" id="infopanel-for-term-for-fire-a-simple-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-a-simple-event" style="display:none">Info about the 'fire a simple event' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-simple-event">Install</a>
     <li><a href="#ref-for-fire-a-simple-event①">Update Worker State</a>
     <li><a href="#ref-for-fire-a-simple-event②">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusing-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusing-steps" class="dfn-panel" data-for="term-for-focusing-steps" id="infopanel-for-term-for-focusing-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-focusing-steps" style="display:none">Info about the 'focusing steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusing-steps">4.2.7. focus()</a>
     <li><a href="#ref-for-focusing-steps①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.3. Service Worker Client</a> <a href="#ref-for-concept-settings-object-global①">(2)</a> <a href="#ref-for-concept-settings-object-global②">(3)</a>
     <li><a href="#ref-for-concept-settings-object-global③">3.1.3. postMessage(message, transfer)</a>
@@ -5050,8 +5050,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-settings-object-global②④">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-has-focus-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-has-focus-steps" class="dfn-panel" data-for="term-for-has-focus-steps" id="infopanel-for-term-for-has-focus-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-has-focus-steps" style="display:none">Info about the 'has focus steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps">https://html.spec.whatwg.org/multipage/interaction.html#has-focus-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-focus-steps">4.2.7. focus()</a>
     <li><a href="#ref-for-has-focus-steps①">4.2.8. navigate(url)</a>
@@ -5060,26 +5060,26 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-has-focus-steps⑤">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-https-state">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-https-state" class="dfn-panel" data-for="term-for-https-state" id="infopanel-for-term-for-https-state" role="menu">
+   <span id="infopaneltitle-for-term-for-https-state" style="display:none">Info about the 'https state (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#https-state">https://html.spec.whatwg.org/multipage/webappapis.html#https-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-https-state">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-https-state">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-https-state" class="dfn-panel" data-for="term-for-concept-workerglobalscope-https-state" id="infopanel-for-term-for-concept-workerglobalscope-https-state" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-https-state" style="display:none">Info about the 'https state (for workerglobalscope)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-https-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-https-state">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-https-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" class="dfn-panel" data-for="term-for-import-scripts-into-worker-global-scope" id="infopanel-for-term-for-import-scripts-into-worker-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-import-scripts-into-worker-global-scope" style="display:none">Info about the 'import scripts into worker global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope">https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-scripts-into-worker-global-scope">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.4.2. ready</a>
     <li><a href="#ref-for-in-parallel①">3.4.4. getRegistration(clientURL)</a>
@@ -5109,27 +5109,27 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-in-parallel③⑤">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-incumbent-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-incumbent-settings-object" class="dfn-panel" data-for="term-for-incumbent-settings-object" id="infopanel-for-term-for-incumbent-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-incumbent-settings-object" style="display:none">Info about the 'incumbent settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incumbent-settings-object">3.1.3. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-message">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-message" class="dfn-panel" data-for="term-for-event-message" id="infopanel-for-term-for-event-message" role="menu">
+   <span id="infopaneltitle-for-term-for-event-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-message">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-event-message①">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-module-script" class="dfn-panel" data-for="term-for-module-script" id="infopanel-for-term-for-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-module-script" style="display:none">Info about the 'module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#module-script">https://html.spec.whatwg.org/multipage/webappapis.html#module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">3.2.6. unregister()</a>
     <li><a href="#ref-for-navigate①">4.2.8. navigate(url)</a>
@@ -5137,8 +5137,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-navigate③">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-2">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">https://html.spec.whatwg.org/multipage/browsers.html#origin-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-2" class="dfn-panel" data-for="term-for-origin-2" id="infopanel-for-term-for-origin-2" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-2" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin-2">https://html.spec.whatwg.org/multipage/browsers.html#origin-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-2">2.1. Service Worker</a>
     <li><a href="#ref-for-origin-2①">3.1.3. postMessage(message, transfer)</a>
@@ -5162,8 +5162,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-origin-2③④">Unregister</a> <a href="#ref-for-origin-2③⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-queue-a-task①">3.1.3. postMessage(message, transfer)</a>
@@ -5188,28 +5188,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-queue-a-task②⑦">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-execution-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-execution-context" class="dfn-panel" data-for="term-for-realm-execution-context" id="infopanel-for-term-for-realm-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-execution-context" style="display:none">Info about the 'realm execution context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-execution-context">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-concept-relevant-global①">4.2.8. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.2.4. postMessage(message, transfer)</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.5.4. event.respondWith(r)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.2.5. update()</a> <a href="#ref-for-relevant-settings-object①">(2)</a>
     <li><a href="#ref-for-relevant-settings-object②">3.2.6. unregister()</a>
@@ -5224,8 +5224,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-relevant-settings-object①②">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">4.2.7. focus()</a>
     <li><a href="#ref-for-responsible-event-loop①">4.2.8. navigate(url)</a>
@@ -5239,20 +5239,20 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-responsible-event-loop①③">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-classic-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-classic-script" class="dfn-panel" data-for="term-for-run-a-classic-script" id="infopanel-for-term-for-run-a-classic-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-classic-script" style="display:none">Info about the 'run a classic script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-classic-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-module-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-module-script" class="dfn-panel" data-for="term-for-run-a-module-script" id="infopanel-for-term-for-run-a-module-script" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-module-script" style="display:none">Info about the 'run a module script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script">https://html.spec.whatwg.org/multipage/webappapis.html#run-a-module-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-module-script">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-same-origin①">4.2.8. navigate(url)</a>
@@ -5262,27 +5262,27 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-same-origin⑤">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-script">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-script" class="dfn-panel" data-for="term-for-concept-script" id="infopanel-for-term-for-concept-script" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-script">https://html.spec.whatwg.org/multipage/webappapis.html#concept-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-script">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-workers">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">https://html.spec.whatwg.org/multipage/workers.html#shared-workers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-workers" class="dfn-panel" data-for="term-for-shared-workers" id="infopanel-for-term-for-shared-workers" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-workers" style="display:none">Info about the 'shared workers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#shared-workers">https://html.spec.whatwg.org/multipage/workers.html#shared-workers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-workers">1. Motivations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredclonewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer">https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredclonewithtransfer" class="dfn-panel" data-for="term-for-structuredclonewithtransfer" id="infopanel-for-term-for-structuredclonewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredclonewithtransfer" style="display:none">Info about the 'structuredclonewithtransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer">https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredclonewithtransfer">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-structuredclonewithtransfer①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2.2. Service Worker Registration</a> <a href="#ref-for-concept-task①">(2)</a>
     <li><a href="#ref-for-concept-task②">3.1.3. postMessage(message, transfer)</a>
@@ -5297,16 +5297,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-task①③">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-task-queue①">(2)</a> <a href="#ref-for-task-queue②">(3)</a>
     <li><a href="#ref-for-task-queue③">Run Service Worker</a>
     <li><a href="#ref-for-task-queue④">Terminate Service Worker</a> <a href="#ref-for-task-queue⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">2.5. Task Sources</a> <a href="#ref-for-task-source①">(2)</a> <a href="#ref-for-task-source②">(3)</a>
     <li><a href="#ref-for-task-source③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-task-source④">(2)</a>
@@ -5316,51 +5316,51 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-task-source①⓪">Terminate Service Worker</a> <a href="#ref-for-task-source①①">(2)</a> <a href="#ref-for-task-source①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-terminate-a-worker" class="dfn-panel" data-for="term-for-terminate-a-worker" id="infopanel-for-term-for-terminate-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-terminate-a-worker" style="display:none">Info about the 'terminate a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-a-worker">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'the global object's realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">3.1.3. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-realm-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-realm-global" class="dfn-panel" data-for="term-for-concept-realm-global" id="infopanel-for-term-for-concept-realm-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-realm-global" style="display:none">Info about the 'the realm's global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-realm-global">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bc-tlbc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc">https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bc-tlbc" class="dfn-panel" data-for="term-for-bc-tlbc" id="infopanel-for-term-for-bc-tlbc" role="menu">
+   <span id="infopaneltitle-for-term-for-bc-tlbc" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc">https://html.spec.whatwg.org/multipage/document-sequences.html#bc-tlbc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bc-tlbc">4.2.2. frameType</a>
     <li><a href="#ref-for-bc-tlbc①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-type">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-type" class="dfn-panel" data-for="term-for-concept-workerglobalscope-type" id="infopanel-for-term-for-concept-workerglobalscope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unsafe-response">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unsafe-response" class="dfn-panel" data-for="term-for-unsafe-response" id="infopanel-for-term-for-unsafe-response" role="menu">
+   <span id="infopaneltitle-for-term-for-unsafe-response" style="display:none">Info about the 'unsafe response' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#unsafe-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-response">6.3.2. importScripts(urls)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-workerglobalscope-url">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-workerglobalscope-url" class="dfn-panel" data-for="term-for-concept-workerglobalscope-url" id="infopanel-for-term-for-concept-workerglobalscope-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-workerglobalscope-url" style="display:none">Info about the 'url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url">https://html.spec.whatwg.org/multipage/workers.html#concept-workerglobalscope-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-workerglobalscope-url">Run Service Worker</a> <a href="#ref-for-concept-workerglobalscope-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-interaction-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-interaction-task-source" class="dfn-panel" data-for="term-for-user-interaction-task-source" id="infopanel-for-term-for-user-interaction-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-user-interaction-task-source" style="display:none">Info about the 'user interaction task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-interaction-task-source">4.2.7. focus()</a>
     <li><a href="#ref-for-user-interaction-task-source①">4.2.8. navigate(url)</a>
@@ -5368,21 +5368,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-user-interaction-task-source④">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workers">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workers">https://html.spec.whatwg.org/multipage/workers.html#workers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workers" class="dfn-panel" data-for="term-for-workers" id="infopanel-for-term-for-workers" role="menu">
+   <span id="infopaneltitle-for-term-for-workers" style="display:none">Info about the 'web worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workers">https://html.spec.whatwg.org/multipage/workers.html#workers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workers">Unnumbered Section</a>
     <li><a href="#ref-for-workers①">2.1. Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VisibilityState">
-   <a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VisibilityState" class="dfn-panel" data-for="term-for-VisibilityState" id="infopanel-for-term-for-VisibilityState" role="menu">
+   <span id="infopaneltitle-for-term-for-VisibilityState" style="display:none">Info about the 'VisibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#VisibilityState">https://www.w3.org/TR/page-visibility/#VisibilityState</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VisibilityState">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-visibilitystate" class="dfn-panel" data-for="term-for-dom-document-visibilitystate" id="infopanel-for-term-for-dom-document-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-document-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-visibilitystate">4.2. Client</a>
     <li><a href="#ref-for-dom-document-visibilitystate①">4.2.7. focus()</a>
@@ -5392,8 +5392,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-document-visibilitystate⑥">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transforming-by">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">https://www.w3.org/2001/tag/doc/promises-guide#transforming-by</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transforming-by" class="dfn-panel" data-for="term-for-transforming-by" id="infopanel-for-term-for-transforming-by" role="menu">
+   <span id="infopaneltitle-for-term-for-transforming-by" style="display:none">Info about the 'transforming' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#transforming-by">https://www.w3.org/2001/tag/doc/promises-guide#transforming-by</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transforming-by">5.4.3. add(request)</a>
     <li><a href="#ref-for-transforming-by①">5.4.4. addAll(requests)</a> <a href="#ref-for-transforming-by②">(2)</a> <a href="#ref-for-transforming-by③">(3)</a>
@@ -5404,55 +5404,55 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-transforming-by⑧">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all">
-   <a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all" class="dfn-panel" data-for="term-for-waiting-for-all" id="infopanel-for-term-for-waiting-for-all" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all" style="display:none">Info about the 'waiting for all' external reference.</span><a href="https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all">https://www.w3.org/2001/tag/doc/promises-guide#waiting-for-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all">5.4.4. addAll(requests)</a> <a href="#ref-for-waiting-for-all①">(2)</a>
     <li><a href="#ref-for-waiting-for-all②">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted">
-   <a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" id="infopanel-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onbeforeevicted" style="display:none">Info about the 'onbeforeevicted' external reference.</span><a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onbeforeevicted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-ServiceWorkerGlobalScope-onbeforeevicted">7. Storage Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onevicted">
-   <a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" class="dfn-panel" data-for="term-for-widl-ServiceWorkerGlobalScope-onevicted" id="infopanel-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-ServiceWorkerGlobalScope-onevicted" style="display:none">Info about the 'onevicted' external reference.</span><a href="http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted">http://www.w3.org/TR/quota-api/#widl-ServiceWorkerGlobalScope-onevicted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-ServiceWorkerGlobalScope-onevicted">7. Storage Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'field-value' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-3.2①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-3.2②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-section-7.1.4①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-section-7.1.4②">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-origin-trustworthy">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-origin-trustworthy" class="dfn-panel" data-for="term-for-is-origin-trustworthy" id="infopanel-for-term-for-is-origin-trustworthy" role="menu">
+   <span id="infopaneltitle-for-term-for-is-origin-trustworthy" style="display:none">Info about the 'is origin potentially trustworthy' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy">https://w3c.github.io/webappsec/specs/powerfulfeatures/#is-origin-trustworthy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-origin-trustworthy">Register</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-threat-risks">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks">https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-threat-risks" class="dfn-panel" data-for="term-for-threat-risks" id="infopanel-for-term-for-threat-risks" role="menu">
+   <span id="infopaneltitle-for-term-for-threat-risks" style="display:none">Info about the 'risks associated with insecure contexts' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks">https://w3c.github.io/webappsec/specs/powerfulfeatures/#threat-risks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-threat-risks">6.1. Secure Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context">https://w3c.github.io/webappsec/specs/powerfulfeatures/#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4.3.1. get(id)</a>
     <li><a href="#ref-for-secure-context①">4.3.2. matchAll(options)</a>
@@ -5461,16 +5461,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-secure-context⑥">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-equals">
-   <a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-equals" class="dfn-panel" data-for="term-for-concept-url-equals" id="infopanel-for-term-for-concept-url-equals" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-equals" style="display:none">Info about the 'equal' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-equals">https://url.spec.whatwg.org/#concept-url-equals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">Register</a>
     <li><a href="#ref-for-concept-url-equals①">Update</a> <a href="#ref-for-concept-url-equals②">(2)</a>
     <li><a href="#ref-for-concept-url-equals③">Query Cache</a> <a href="#ref-for-concept-url-equals④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'parsing' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-parser①">(2)</a> <a href="#ref-for-concept-url-parser②">(3)</a>
     <li><a href="#ref-for-concept-url-parser③">3.4.4. getRegistration(clientURL)</a>
@@ -5482,21 +5482,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-parser⑨">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-path①">(2)</a>
     <li><a href="#ref-for-concept-url-path②">Update</a> <a href="#ref-for-concept-url-path③">(2)</a> <a href="#ref-for-concept-url-path④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">Query Cache</a> <a href="#ref-for-concept-url-query①">(2)</a> <a href="#ref-for-concept-url-query②">(3)</a> <a href="#ref-for-concept-url-query③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
     <li><a href="#ref-for-concept-url-scheme②">5.4.4. addAll(requests)</a> <a href="#ref-for-concept-url-scheme③">(2)</a>
@@ -5504,8 +5504,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-scheme⑥">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'serialized' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3.1.1. scriptURL</a>
     <li><a href="#ref-for-concept-url-serializer①">3.2.4. scope</a>
@@ -5516,8 +5516,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-concept-url-serializer⑦">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a>
     <li><a href="#ref-for-idl-DOMString⑤">4.2. Client</a>
@@ -5529,8 +5529,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-DOMString①⑧">5.5. CacheStorage</a> <a href="#ref-for-idl-DOMString①⑨">(2)</a> <a href="#ref-for-idl-DOMString②⓪">(3)</a> <a href="#ref-for-idl-DOMString②①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. ServiceWorker</a>
     <li><a href="#ref-for-Exposed①">3.2. ServiceWorkerRegistration</a>
@@ -5546,28 +5546,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-Exposed①②">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-idl-frozen-array①">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidaccesserror">https://heycam.github.io/webidl/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">4.2.7. focus()</a>
     <li><a href="#ref-for-invalidaccesserror①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-invalidstateerror①">3.2.5. update()</a> <a href="#ref-for-invalidstateerror②">(2)</a>
@@ -5578,8 +5578,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-invalidstateerror⑧">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-NewObject①">(2)</a>
     <li><a href="#ref-for-NewObject②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-NewObject③">(2)</a> <a href="#ref-for-NewObject④">(3)</a>
@@ -5590,8 +5590,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-NewObject①⑨">5.5. CacheStorage</a> <a href="#ref-for-NewObject②⓪">(2)</a> <a href="#ref-for-NewObject②①">(3)</a> <a href="#ref-for-NewObject②②">(4)</a> <a href="#ref-for-NewObject②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">3.4. ServiceWorkerContainer</a> <a href="#ref-for-idl-promise③">(2)</a> <a href="#ref-for-idl-promise④">(3)</a> <a href="#ref-for-idl-promise⑤">(4)</a>
@@ -5604,16 +5604,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-promise②②">5.5. CacheStorage</a> <a href="#ref-for-idl-promise②③">(2)</a> <a href="#ref-for-idl-promise②④">(3)</a> <a href="#ref-for-idl-promise②⑤">(4)</a> <a href="#ref-for-idl-promise②⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-quotaexceedederror">
-   <a href="https://heycam.github.io/webidl/#quotaexceedederror">https://heycam.github.io/webidl/#quotaexceedederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-quotaexceedederror" class="dfn-panel" data-for="term-for-quotaexceedederror" id="infopanel-for-term-for-quotaexceedederror" role="menu">
+   <span id="infopaneltitle-for-term-for-quotaexceedederror" style="display:none">Info about the 'QuotaExceededError' external reference.</span><a href="https://heycam.github.io/webidl/#quotaexceedederror">https://heycam.github.io/webidl/#quotaexceedederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quotaexceedederror">5.5.3. open(cacheName)</a>
     <li><a href="#ref-for-quotaexceedederror①">7. Storage Considerations</a>
     <li><a href="#ref-for-quotaexceedederror②">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.3. navigator.serviceWorker</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject②">3.4. ServiceWorkerContainer</a>
@@ -5624,8 +5624,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SameObject⑧">5.3. self.caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3.1. ServiceWorker</a>
     <li><a href="#ref-for-SecureContext①">3.2. ServiceWorkerRegistration</a>
@@ -5636,8 +5636,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-SecureContext⑦">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.4.4. getRegistration(clientURL)</a>
     <li><a href="#ref-for-securityerror①">4.3.1. get(id)</a>
@@ -5646,8 +5646,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-securityerror⑧">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-USVString①">3.2. ServiceWorkerRegistration</a>
@@ -5656,8 +5656,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-USVString⑦">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-any①">3.4. ServiceWorkerContainer</a>
@@ -5670,8 +5670,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-any①⓪">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-idl-boolean①">4.2. Client</a>
@@ -5681,35 +5681,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-boolean⑨">5.5. CacheStorage</a> <a href="#ref-for-idl-boolean①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception" class="dfn-panel" data-for="term-for-dfn-exception" id="infopanel-for-term-for-dfn-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception" style="display:none">Info about the 'exception' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-frozen-array-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-frozen-array-type" class="dfn-panel" data-for="term-for-dfn-frozen-array-type" id="infopanel-for-term-for-dfn-frozen-array-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-frozen-array-type" style="display:none">Info about the 'frozen array type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-frozen-array-type">https://webidl.spec.whatwg.org/#dfn-frozen-array-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-frozen-array-type">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-frozen-array-type①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-object①">4.2. Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-partial-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-partial-interface" class="dfn-panel" data-for="term-for-dfn-partial-interface" id="infopanel-for-term-for-dfn-partial-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-partial-interface" style="display:none">Info about the 'partial interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-partial-interface">https://webidl.spec.whatwg.org/#dfn-partial-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-partial-interface">8.1. Define API bound to Service Worker Registration</a>
     <li><a href="#ref-for-dfn-partial-interface①">8.3. Define Event Handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1. ServiceWorker</a>
     <li><a href="#ref-for-idl-sequence①">3.4. ServiceWorkerContainer</a>
@@ -5721,8 +5721,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-idl-sequence⑨">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">4.2.4. postMessage(message, transfer)</a> <a href="#ref-for-dfn-throw④">(2)</a> <a href="#ref-for-dfn-throw⑤">(3)</a>
@@ -6251,8 +6251,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
    <div class="issue">The response’s cache state concept had been removed from fetch. The fetch issue <a href="https://github.com/whatwg/fetch/issues/376">#376</a> tracks the request to restore the concept or add some similar way to check this state. <a class="issue-return" href="#issue-b27ba9d2" title="Jump to section">↵</a></div>
    <div class="issue">Remove this definition after sorting out the referencing sites. <a class="issue-return" href="#issue-b739bfcf" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dfn-service-worker">
-   <b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker" class="dfn-panel" data-for="dfn-service-worker" id="infopanel-for-dfn-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker">#dfn-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker">1. Motivations</a> <a href="#ref-for-dfn-service-worker">(2)</a> <a href="#ref-for-dfn-service-worker">(3)</a> <a href="#ref-for-dfn-service-worker">(4)</a> <a href="#ref-for-dfn-service-worker">(5)</a> <a href="#ref-for-dfn-service-worker">(6)</a> <a href="#ref-for-dfn-service-worker">(7)</a> <a href="#ref-for-dfn-service-worker">(8)</a> <a href="#ref-for-dfn-service-worker">(9)</a> <a href="#ref-for-dfn-service-worker">(10)</a> <a href="#ref-for-dfn-service-worker">(11)</a> <a href="#ref-for-dfn-service-worker">(12)</a> <a href="#ref-for-dfn-service-worker">(13)</a> <a href="#ref-for-dfn-service-worker">(14)</a>
     <li><a href="#ref-for-dfn-service-worker">2.1. Service Worker</a> <a href="#ref-for-dfn-service-worker">(2)</a> <a href="#ref-for-dfn-service-worker">(3)</a> <a href="#ref-for-dfn-service-worker">(4)</a> <a href="#ref-for-dfn-service-worker">(5)</a> <a href="#ref-for-dfn-service-worker">(6)</a> <a href="#ref-for-dfn-service-worker">(7)</a> <a href="#ref-for-dfn-service-worker">(8)</a> <a href="#ref-for-dfn-service-worker">(9)</a> <a href="#ref-for-dfn-service-worker">(10)</a> <a href="#ref-for-dfn-service-worker">(11)</a> <a href="#ref-for-dfn-service-worker">(12)</a>
@@ -6300,8 +6300,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-state">
-   <b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-state" class="dfn-panel" data-for="dfn-state" id="infopanel-for-dfn-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dfn-state">#dfn-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-state">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-state">(2)</a> <a href="#ref-for-dfn-state">(3)</a>
     <li><a href="#ref-for-dfn-state">3.1. ServiceWorker</a>
@@ -6313,8 +6313,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-state">Update Worker State</a> <a href="#ref-for-dfn-state">(2)</a> <a href="#ref-for-dfn-state">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-url">
-   <b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-url" class="dfn-panel" data-for="dfn-script-url" id="infopanel-for-dfn-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-script-url">#dfn-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-url">3.1.1. scriptURL</a>
     <li><a href="#ref-for-dfn-script-url">3.2.5. update()</a>
@@ -6324,8 +6324,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-url">Run Service Worker</a> <a href="#ref-for-dfn-script-url">(2)</a> <a href="#ref-for-dfn-script-url">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-type">
-   <b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-type" class="dfn-panel" data-for="dfn-type" id="infopanel-for-dfn-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dfn-type">#dfn-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.2.5. update()</a>
     <li><a href="#ref-for-dfn-type">Update</a>
@@ -6333,8 +6333,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-type">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-containing-service-worker-registration">
-   <b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-containing-service-worker-registration" class="dfn-panel" data-for="dfn-containing-service-worker-registration" id="infopanel-for-dfn-containing-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-containing-service-worker-registration" style="display:none">Info about the 'containing service worker registration' definition.</span><b><a href="#dfn-containing-service-worker-registration">#dfn-containing-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-containing-service-worker-registration">2.4. Selection and Use</a>
@@ -6349,21 +6349,21 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-containing-service-worker-registration">Handle Fetch</a> <a href="#ref-for-dfn-containing-service-worker-registration">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-id">
-   <b><a href="#dfn-service-worker-id">#dfn-service-worker-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-id" class="dfn-panel" data-for="dfn-service-worker-id" id="infopanel-for-dfn-service-worker-id" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dfn-service-worker-id">#dfn-service-worker-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-id">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-lifecycle-events">
-   <b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-lifecycle-events" class="dfn-panel" data-for="dfn-lifecycle-events" id="infopanel-for-dfn-lifecycle-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-lifecycle-events" style="display:none">Info about the 'lifecycle events' definition.</span><b><a href="#dfn-lifecycle-events">#dfn-lifecycle-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lifecycle-events">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dfn-lifecycle-events">4.7. Events</a> <a href="#ref-for-dfn-lifecycle-events">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-functional-events">
-   <b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-functional-events" class="dfn-panel" data-for="dfn-functional-events" id="infopanel-for-dfn-functional-events" role="dialog">
+   <span id="infopaneltitle-for-dfn-functional-events" style="display:none">Info about the 'functional events' definition.</span><b><a href="#dfn-functional-events">#dfn-functional-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-functional-events">2.5. Task Sources</a>
     <li><a href="#ref-for-dfn-functional-events">4.4. ExtendableEvent</a>
@@ -6375,8 +6375,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-functional-events">Update Worker State</a> <a href="#ref-for-dfn-functional-events">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource">
-   <b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource" class="dfn-panel" data-for="dfn-script-resource" id="infopanel-for-dfn-script-resource" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource" style="display:none">Info about the 'script resource' definition.</span><b><a href="#dfn-script-resource">#dfn-script-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.1. Service Worker</a> <a href="#ref-for-dfn-script-resource">(2)</a>
     <li><a href="#ref-for-dfn-script-resource">6.2. Content Security Policy</a> <a href="#ref-for-dfn-script-resource">(2)</a>
@@ -6387,50 +6387,50 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-script-resource">Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag">
-   <b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" class="dfn-panel" data-for="dfn-has-ever-been-evaluated-flag" id="infopanel-for-dfn-has-ever-been-evaluated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-has-ever-been-evaluated-flag" style="display:none">Info about the 'has ever been evaluated flag' definition.</span><b><a href="#dfn-has-ever-been-evaluated-flag">#dfn-has-ever-been-evaluated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-has-ever-been-evaluated-flag">Run Service Worker</a> <a href="#ref-for-dfn-has-ever-been-evaluated-flag">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-https-state">
-   <b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-https-state" class="dfn-panel" data-for="dfn-https-state" id="infopanel-for-dfn-https-state" role="dialog">
+   <span id="infopaneltitle-for-dfn-https-state" style="display:none">Info about the 'HTTPS state' definition.</span><b><a href="#dfn-https-state">#dfn-https-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-https-state">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-script-resource-map">
-   <b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-script-resource-map" class="dfn-panel" data-for="dfn-script-resource-map" id="infopanel-for-dfn-script-resource-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-script-resource-map" style="display:none">Info about the 'script resource map' definition.</span><b><a href="#dfn-script-resource-map">#dfn-script-resource-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource-map">6.3.2. importScripts(urls)</a> <a href="#ref-for-dfn-script-resource-map">(2)</a> <a href="#ref-for-dfn-script-resource-map">(3)</a>
     <li><a href="#ref-for-dfn-script-resource-map">6.6. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-skip-waiting-flag">
-   <b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-skip-waiting-flag" class="dfn-panel" data-for="dfn-skip-waiting-flag" id="infopanel-for-dfn-skip-waiting-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-skip-waiting-flag" style="display:none">Info about the 'skip waiting flag' definition.</span><b><a href="#dfn-skip-waiting-flag">#dfn-skip-waiting-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-skip-waiting-flag">3.6. Events</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag">4.1.3. skipWaiting()</a>
     <li><a href="#ref-for-dfn-skip-waiting-flag">Install</a> <a href="#ref-for-dfn-skip-waiting-flag">(2)</a> <a href="#ref-for-dfn-skip-waiting-flag">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-imported-scripts-updated-flag">
-   <b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-imported-scripts-updated-flag" class="dfn-panel" data-for="dfn-imported-scripts-updated-flag" id="infopanel-for-dfn-imported-scripts-updated-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-imported-scripts-updated-flag" style="display:none">Info about the 'imported scripts updated flag' definition.</span><b><a href="#dfn-imported-scripts-updated-flag">#dfn-imported-scripts-updated-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-imported-scripts-updated-flag">6.3.2. importScripts(urls)</a>
     <li><a href="#ref-for-dfn-imported-scripts-updated-flag">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-set-of-event-types-to-handle">
-   <b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-set-of-event-types-to-handle" class="dfn-panel" data-for="dfn-set-of-event-types-to-handle" id="infopanel-for-dfn-set-of-event-types-to-handle" role="dialog">
+   <span id="infopaneltitle-for-dfn-set-of-event-types-to-handle" style="display:none">Info about the 'set of event types to handle' definition.</span><b><a href="#dfn-set-of-event-types-to-handle">#dfn-set-of-event-types-to-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Run Service Worker</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Handle Fetch</a>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration" id="infopanel-for-dfn-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration">#dfn-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration">(2)</a> <a href="#ref-for-dfn-service-worker-registration">(3)</a> <a href="#ref-for-dfn-service-worker-registration">(4)</a> <a href="#ref-for-dfn-service-worker-registration">(5)</a> <a href="#ref-for-dfn-service-worker-registration">(6)</a> <a href="#ref-for-dfn-service-worker-registration">(7)</a> <a href="#ref-for-dfn-service-worker-registration">(8)</a> <a href="#ref-for-dfn-service-worker-registration">(9)</a> <a href="#ref-for-dfn-service-worker-registration">(10)</a> <a href="#ref-for-dfn-service-worker-registration">(11)</a> <a href="#ref-for-dfn-service-worker-registration">(12)</a> <a href="#ref-for-dfn-service-worker-registration">(13)</a> <a href="#ref-for-dfn-service-worker-registration">(14)</a>
@@ -6461,8 +6461,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration">Get Newest Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-url">
-   <b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-url" class="dfn-panel" data-for="dfn-scope-url" id="infopanel-for-dfn-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-scope-url">#dfn-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-url">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-scope-url">(2)</a> <a href="#ref-for-dfn-scope-url">(3)</a>
     <li><a href="#ref-for-dfn-scope-url">2.2.1. Lifetime</a>
@@ -6481,8 +6481,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-url">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-installing-worker">
-   <b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-installing-worker" class="dfn-panel" data-for="dfn-installing-worker" id="infopanel-for-dfn-installing-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-installing-worker" style="display:none">Info about the 'installing worker' definition.</span><b><a href="#dfn-installing-worker">#dfn-installing-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-installing-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-installing-worker">2.6. User Agent Shutdown</a> <a href="#ref-for-dfn-installing-worker①">(2)</a>
@@ -6497,8 +6497,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-installing-worker">Get Newest Worker</a> <a href="#ref-for-dfn-installing-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-waiting-worker">
-   <b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-waiting-worker" class="dfn-panel" data-for="dfn-waiting-worker" id="infopanel-for-dfn-waiting-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-waiting-worker" style="display:none">Info about the 'waiting worker' definition.</span><b><a href="#dfn-waiting-worker">#dfn-waiting-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-waiting-worker">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-waiting-worker">2.6. User Agent Shutdown</a>
@@ -6514,8 +6514,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-waiting-worker">Get Newest Worker</a> <a href="#ref-for-dfn-waiting-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-active-worker">
-   <b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-active-worker" class="dfn-panel" data-for="dfn-active-worker" id="infopanel-for-dfn-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-active-worker">#dfn-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-active-worker">(2)</a> <a href="#ref-for-dfn-active-worker">(3)</a> <a href="#ref-for-dfn-active-worker">(4)</a> <a href="#ref-for-dfn-active-worker">(5)</a> <a href="#ref-for-dfn-active-worker">(6)</a>
     <li><a href="#ref-for-dfn-active-worker">2.3. Service Worker Client</a>
@@ -6537,16 +6537,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-active-worker">Get Newest Worker</a> <a href="#ref-for-dfn-active-worker">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-last-update-check-time">
-   <b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-last-update-check-time" class="dfn-panel" data-for="dfn-last-update-check-time" id="infopanel-for-dfn-last-update-check-time" role="dialog">
+   <span id="infopaneltitle-for-dfn-last-update-check-time" style="display:none">Info about the 'last update check time' definition.</span><b><a href="#dfn-last-update-check-time">#dfn-last-update-check-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-last-update-check-time">Update</a> <a href="#ref-for-dfn-last-update-check-time">(2)</a> <a href="#ref-for-dfn-last-update-check-time">(3)</a>
     <li><a href="#ref-for-dfn-last-update-check-time">Handle Fetch</a> <a href="#ref-for-dfn-last-update-check-time">(2)</a> <a href="#ref-for-dfn-last-update-check-time">(3)</a>
     <li><a href="#ref-for-dfn-last-update-check-time">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-uninstalling-flag">
-   <b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-uninstalling-flag" class="dfn-panel" data-for="dfn-uninstalling-flag" id="infopanel-for-dfn-uninstalling-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-uninstalling-flag" style="display:none">Info about the 'uninstalling flag' definition.</span><b><a href="#dfn-uninstalling-flag">#dfn-uninstalling-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-uninstalling-flag">3.4.5. getRegistrations()</a>
     <li><a href="#ref-for-dfn-uninstalling-flag">Register</a>
@@ -6556,16 +6556,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-uninstalling-flag">Match Service Worker Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-task-queue">
-   <b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-task-queue" class="dfn-panel" data-for="dfn-service-worker-registration-task-queue" id="infopanel-for-dfn-service-worker-registration-task-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-task-queue" style="display:none">Info about the 'task queues' definition.</span><b><a href="#dfn-service-worker-registration-task-queue">#dfn-service-worker-registration-task-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">2.2. Service Worker Registration</a> <a href="#ref-for-dfn-service-worker-registration-task-queue">(2)</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">Run Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-registration-task-queue">Terminate Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client">
-   <b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client" class="dfn-panel" data-for="dfn-service-worker-client" id="infopanel-for-dfn-service-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client">#dfn-service-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client">2.1. Service Worker</a>
     <li><a href="#ref-for-dfn-service-worker-client">2.1.1. Lifetime</a>
@@ -6596,8 +6596,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-active-worker">
-   <b><a href="#dfn-service-worker-client-active-worker">#dfn-service-worker-client-active-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-active-worker" class="dfn-panel" data-for="dfn-service-worker-client-active-worker" id="infopanel-for-dfn-service-worker-client-active-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-active-worker" style="display:none">Info about the 'active worker' definition.</span><b><a href="#dfn-service-worker-client-active-worker">#dfn-service-worker-client-active-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">3.2.6. unregister()</a>
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">3.4.1. controller</a>
@@ -6607,22 +6607,22 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-active-worker">Handle Fetch</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(2)</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(3)</a> <a href="#ref-for-dfn-service-worker-client-active-worker">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-id">
-   <b><a href="#dfn-service-worker-client-id">#dfn-service-worker-client-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-id" class="dfn-panel" data-for="dfn-service-worker-client-id" id="infopanel-for-dfn-service-worker-client-id" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dfn-service-worker-client-id">#dfn-service-worker-client-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-id">4.2.3. id</a>
     <li><a href="#ref-for-dfn-service-worker-client-id">4.3.1. get(id)</a>
     <li><a href="#ref-for-dfn-service-worker-client-id">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-frame-type">
-   <b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-frame-type" class="dfn-panel" data-for="dfn-service-worker-client-frame-type" id="infopanel-for-dfn-service-worker-client-frame-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-frame-type" style="display:none">Info about the 'frame type' definition.</span><b><a href="#dfn-service-worker-client-frame-type">#dfn-service-worker-client-frame-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-frame-type">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-window-client">
-   <b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-window-client" class="dfn-panel" data-for="dfn-window-client" id="infopanel-for-dfn-window-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-window-client" style="display:none">Info about the 'window client' definition.</span><b><a href="#dfn-window-client">#dfn-window-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-window-client">4.2.2. frameType</a> <a href="#ref-for-dfn-window-client">(2)</a> <a href="#ref-for-dfn-window-client">(3)</a>
     <li><a href="#ref-for-dfn-window-client">4.3.1. get(id)</a>
@@ -6631,35 +6631,35 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-window-client">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-dedicatedworker-client">
-   <b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-dedicatedworker-client" class="dfn-panel" data-for="dfn-dedicatedworker-client" id="infopanel-for-dfn-dedicatedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-dedicatedworker-client" style="display:none">Info about the 'dedicated worker client' definition.</span><b><a href="#dfn-dedicatedworker-client">#dfn-dedicatedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dedicatedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-dedicatedworker-client">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-sharedworker-client">
-   <b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-sharedworker-client" class="dfn-panel" data-for="dfn-sharedworker-client" id="infopanel-for-dfn-sharedworker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-sharedworker-client" style="display:none">Info about the 'shared worker client' definition.</span><b><a href="#dfn-sharedworker-client">#dfn-sharedworker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sharedworker-client">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-sharedworker-client">4.3.2. matchAll(options)</a>
     <li><a href="#ref-for-dfn-sharedworker-client">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-worker-client">
-   <b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-worker-client" class="dfn-panel" data-for="dfn-worker-client" id="infopanel-for-dfn-worker-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-worker-client" style="display:none">Info about the 'worker client' definition.</span><b><a href="#dfn-worker-client">#dfn-worker-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-worker-client">2.4. Selection and Use</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-selection">
-   <b><a href="#dfn-service-worker-registration-selection">#dfn-service-worker-registration-selection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-selection" class="dfn-panel" data-for="dfn-service-worker-registration-selection" id="infopanel-for-dfn-service-worker-registration-selection" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-selection" style="display:none">Info about the 'selection' definition.</span><b><a href="#dfn-service-worker-registration-selection">#dfn-service-worker-registration-selection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-selection">2.4. Selection and Use</a> <a href="#ref-for-dfn-service-worker-registration-selection">(2)</a> <a href="#ref-for-dfn-service-worker-registration-selection">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-control">
-   <b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-control" class="dfn-panel" data-for="dfn-control" id="infopanel-for-dfn-control" role="dialog">
+   <span id="infopaneltitle-for-dfn-control" style="display:none">Info about the 'control' definition.</span><b><a href="#dfn-control">#dfn-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-control">2.3. Service Worker Client</a>
     <li><a href="#ref-for-dfn-control">2.4. Selection and Use</a>
@@ -6668,8 +6668,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-control">Service Worker Script Response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-use">
-   <b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-use" class="dfn-panel" data-for="dfn-use" id="infopanel-for-dfn-use" role="dialog">
+   <span id="infopaneltitle-for-dfn-use" style="display:none">Info about the 'using' definition.</span><b><a href="#dfn-use">#dfn-use</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-use">2.4. Selection and Use</a>
     <li><a href="#ref-for-dfn-use">3.6. Events</a>
@@ -6681,24 +6681,24 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-use">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-fetch-task-source">
-   <b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-fetch-task-source" class="dfn-panel" data-for="dfn-handle-fetch-task-source" id="infopanel-for-dfn-handle-fetch-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-fetch-task-source" style="display:none">Info about the 'handle fetch task source' definition.</span><b><a href="#dfn-handle-fetch-task-source">#dfn-handle-fetch-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-fetch-task-source">(2)</a>
     <li><a href="#ref-for-dfn-handle-fetch-task-source">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-handle-functional-event-task-source">
-   <b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-handle-functional-event-task-source" class="dfn-panel" data-for="dfn-handle-functional-event-task-source" id="infopanel-for-dfn-handle-functional-event-task-source" role="dialog">
+   <span id="infopaneltitle-for-dfn-handle-functional-event-task-source" style="display:none">Info about the 'handle functional event task source' definition.</span><b><a href="#dfn-handle-functional-event-task-source">#dfn-handle-functional-event-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">2.2. Service Worker Registration</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">Terminate Service Worker</a> <a href="#ref-for-dfn-handle-functional-event-task-source">(2)</a>
     <li><a href="#ref-for-dfn-handle-functional-event-task-source">Handle Functional Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-interface">
-   <b><a href="#service-worker-interface">#service-worker-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-interface" class="dfn-panel" data-for="service-worker-interface" id="infopanel-for-service-worker-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-interface" style="display:none">Info about the 'ServiceWorker' definition.</span><b><a href="#service-worker-interface">#service-worker-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-interface">2.1.1. Lifetime</a>
     <li><a href="#ref-for-service-worker-interface">3.1. ServiceWorker</a> <a href="#ref-for-service-worker-interface①">(2)</a> <a href="#ref-for-service-worker-interface②">(3)</a> <a href="#ref-for-service-worker-interface③">(4)</a> <a href="#ref-for-service-worker-interface④">(5)</a> <a href="#ref-for-service-worker-interface⑤">(6)</a>
@@ -6720,15 +6720,15 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-interface">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-url-attribute">
-   <b><a href="#service-worker-url-attribute">#service-worker-url-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-url-attribute" class="dfn-panel" data-for="service-worker-url-attribute" id="infopanel-for-service-worker-url-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-url-attribute" style="display:none">Info about the 'scriptURL' definition.</span><b><a href="#service-worker-url-attribute">#service-worker-url-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-url-attribute">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-url-attribute①">3.1.1. scriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-state-attribute">
-   <b><a href="#service-worker-state-attribute">#service-worker-state-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-state-attribute" class="dfn-panel" data-for="service-worker-state-attribute" id="infopanel-for-service-worker-state-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-state-attribute" style="display:none">Info about the 'state' definition.</span><b><a href="#service-worker-state-attribute">#service-worker-state-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-state-attribute">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-state-attribute①">3.1.2. state</a>
@@ -6737,28 +6737,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-state-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-state-enum">
-   <b><a href="#service-worker-state-enum">#service-worker-state-enum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-state-enum" class="dfn-panel" data-for="service-worker-state-enum" id="infopanel-for-service-worker-state-enum" role="dialog">
+   <span id="infopaneltitle-for-service-worker-state-enum" style="display:none">Info about the 'ServiceWorkerState' definition.</span><b><a href="#service-worker-state-enum">#service-worker-state-enum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-state-enum">3.1. ServiceWorker</a> <a href="#ref-for-service-worker-state-enum①">(2)</a> <a href="#ref-for-service-worker-state-enum②">(3)</a>
     <li><a href="#ref-for-service-worker-state-enum③">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-postmessage-method">
-   <b><a href="#service-worker-postmessage-method">#service-worker-postmessage-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-postmessage-method" class="dfn-panel" data-for="service-worker-postmessage-method" id="infopanel-for-service-worker-postmessage-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-postmessage-method" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#service-worker-postmessage-method">#service-worker-postmessage-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-postmessage-method">3.1. ServiceWorker</a>
     <li><a href="#ref-for-service-worker-postmessage-method①">3.1.3. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-onstatechange-attribute">
-   <b><a href="#service-worker-onstatechange-attribute">#service-worker-onstatechange-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-onstatechange-attribute" class="dfn-panel" data-for="service-worker-onstatechange-attribute" id="infopanel-for-service-worker-onstatechange-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-onstatechange-attribute" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#service-worker-onstatechange-attribute">#service-worker-onstatechange-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-onstatechange-attribute">3.1. ServiceWorker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-interface">
-   <b><a href="#service-worker-registration-interface">#service-worker-registration-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-interface" class="dfn-panel" data-for="service-worker-registration-interface" id="infopanel-for-service-worker-registration-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-interface" style="display:none">Info about the 'ServiceWorkerRegistration' definition.</span><b><a href="#service-worker-registration-interface">#service-worker-registration-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-interface">2.2.1. Lifetime</a>
     <li><a href="#ref-for-service-worker-registration-interface">3.2. ServiceWorkerRegistration</a> <a href="#ref-for-service-worker-registration-interface①">(2)</a> <a href="#ref-for-service-worker-registration-interface②">(3)</a> <a href="#ref-for-service-worker-registration-interface③">(4)</a>
@@ -6777,8 +6777,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-registration-interface①⑧">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-registration-interface-service-worker-registration">
-   <b><a href="#dfn-service-worker-registration-interface-service-worker-registration">#dfn-service-worker-registration-interface-service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-registration-interface-service-worker-registration" class="dfn-panel" data-for="dfn-service-worker-registration-interface-service-worker-registration" id="infopanel-for-dfn-service-worker-registration-interface-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-registration-interface-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#dfn-service-worker-registration-interface-service-worker-registration">#dfn-service-worker-registration-interface-service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.2.4. scope</a>
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.2.5. update()</a>
@@ -6786,77 +6786,77 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-registration-interface-service-worker-registration">3.6. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-installing-attribute">
-   <b><a href="#service-worker-registration-installing-attribute">#service-worker-registration-installing-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-installing-attribute" class="dfn-panel" data-for="service-worker-registration-installing-attribute" id="infopanel-for-service-worker-registration-installing-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-installing-attribute" style="display:none">Info about the 'installing' definition.</span><b><a href="#service-worker-registration-installing-attribute">#service-worker-registration-installing-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-installing-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-installing-attribute①">3.2.1. installing</a>
     <li><a href="#ref-for-service-worker-registration-installing-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-waiting-attribute">
-   <b><a href="#service-worker-registration-waiting-attribute">#service-worker-registration-waiting-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-waiting-attribute" class="dfn-panel" data-for="service-worker-registration-waiting-attribute" id="infopanel-for-service-worker-registration-waiting-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-waiting-attribute" style="display:none">Info about the 'waiting' definition.</span><b><a href="#service-worker-registration-waiting-attribute">#service-worker-registration-waiting-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute①">3.2.2. waiting</a>
     <li><a href="#ref-for-service-worker-registration-waiting-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-active-attribute">
-   <b><a href="#service-worker-registration-active-attribute">#service-worker-registration-active-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-active-attribute" class="dfn-panel" data-for="service-worker-registration-active-attribute" id="infopanel-for-service-worker-registration-active-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-active-attribute" style="display:none">Info about the 'active' definition.</span><b><a href="#service-worker-registration-active-attribute">#service-worker-registration-active-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-active-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-active-attribute①">3.2.3. active</a>
     <li><a href="#ref-for-service-worker-registration-active-attribute">Update Registration State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-scope-attribute">
-   <b><a href="#service-worker-registration-scope-attribute">#service-worker-registration-scope-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-scope-attribute" class="dfn-panel" data-for="service-worker-registration-scope-attribute" id="infopanel-for-service-worker-registration-scope-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-scope-attribute" style="display:none">Info about the 'scope' definition.</span><b><a href="#service-worker-registration-scope-attribute">#service-worker-registration-scope-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-scope-attribute">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-scope-attribute①">3.2.4. scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-update-method">
-   <b><a href="#service-worker-registration-update-method">#service-worker-registration-update-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-update-method" class="dfn-panel" data-for="service-worker-registration-update-method" id="infopanel-for-service-worker-registration-update-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-update-method" style="display:none">Info about the 'update()' definition.</span><b><a href="#service-worker-registration-update-method">#service-worker-registration-update-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-update-method">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-update-method①">3.2.5. update()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-unregister-method">
-   <b><a href="#service-worker-registration-unregister-method">#service-worker-registration-unregister-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-unregister-method" class="dfn-panel" data-for="service-worker-registration-unregister-method" id="infopanel-for-service-worker-registration-unregister-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-unregister-method" style="display:none">Info about the 'unregister()' definition.</span><b><a href="#service-worker-registration-unregister-method">#service-worker-registration-unregister-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-unregister-method">3.2. ServiceWorkerRegistration</a>
     <li><a href="#ref-for-service-worker-registration-unregister-method①">3.2.6. unregister()</a> <a href="#ref-for-service-worker-registration-unregister-method②">(2)</a> <a href="#ref-for-service-worker-registration-unregister-method③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-onupdatefound-attribute">
-   <b><a href="#service-worker-registration-onupdatefound-attribute">#service-worker-registration-onupdatefound-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-onupdatefound-attribute" class="dfn-panel" data-for="service-worker-registration-onupdatefound-attribute" id="infopanel-for-service-worker-registration-onupdatefound-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-onupdatefound-attribute" style="display:none">Info about the 'onupdatefound' definition.</span><b><a href="#service-worker-registration-onupdatefound-attribute">#service-worker-registration-onupdatefound-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-onupdatefound-attribute">3.2. ServiceWorkerRegistration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-service-worker-attribute">
-   <b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-service-worker-attribute" class="dfn-panel" data-for="navigator-service-worker-attribute" id="infopanel-for-navigator-service-worker-attribute" role="dialog">
+   <span id="infopaneltitle-for-navigator-service-worker-attribute" style="display:none">Info about the 'serviceWorker' definition.</span><b><a href="#navigator-service-worker-attribute">#navigator-service-worker-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-service-worker-attribute">3.3. navigator.serviceWorker</a> <a href="#ref-for-navigator-service-worker-attribute①">(2)</a> <a href="#ref-for-navigator-service-worker-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-serviceworkercontainer-registrationoptions">
-   <b><a href="#dictdef-serviceworkercontainer-registrationoptions">#dictdef-serviceworkercontainer-registrationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-serviceworkercontainer-registrationoptions" class="dfn-panel" data-for="dictdef-serviceworkercontainer-registrationoptions" id="infopanel-for-dictdef-serviceworkercontainer-registrationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-serviceworkercontainer-registrationoptions" style="display:none">Info about the 'RegistrationOptions' definition.</span><b><a href="#dictdef-serviceworkercontainer-registrationoptions">#dictdef-serviceworkercontainer-registrationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-serviceworkercontainer-registrationoptions">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-registrationoptions-scope">
-   <b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-registrationoptions-scope" class="dfn-panel" data-for="dom-registrationoptions-scope" id="infopanel-for-dom-registrationoptions-scope" role="dialog">
+   <span id="infopaneltitle-for-dom-registrationoptions-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#dom-registrationoptions-scope">#dom-registrationoptions-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-registrationoptions-scope">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-dom-registrationoptions-scope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-interface">
-   <b><a href="#service-worker-container-interface">#service-worker-container-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-interface" class="dfn-panel" data-for="service-worker-container-interface" id="infopanel-for-service-worker-container-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-interface" style="display:none">Info about the 'ServiceWorkerContainer' definition.</span><b><a href="#service-worker-container-interface">#service-worker-container-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-interface">3.3. navigator.serviceWorker</a> <a href="#ref-for-service-worker-container-interface①">(2)</a> <a href="#ref-for-service-worker-container-interface②">(3)</a>
     <li><a href="#ref-for-service-worker-container-interface③">3.4. ServiceWorkerContainer</a> <a href="#ref-for-service-worker-container-interface④">(2)</a> <a href="#ref-for-service-worker-container-interface⑤">(3)</a> <a href="#ref-for-service-worker-container-interface⑥">(4)</a> <a href="#ref-for-service-worker-container-interface⑦">(5)</a> <a href="#ref-for-service-worker-container-interface⑧">(6)</a> <a href="#ref-for-service-worker-container-interface⑨">(7)</a> <a href="#ref-for-service-worker-container-interface①⓪">(8)</a> <a href="#ref-for-service-worker-container-interface①①">(9)</a>
@@ -6866,8 +6866,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-container-interface">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-container-interface-client">
-   <b><a href="#dfn-service-worker-container-interface-client">#dfn-service-worker-container-interface-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-container-interface-client" class="dfn-panel" data-for="dfn-service-worker-container-interface-client" id="infopanel-for-dfn-service-worker-container-interface-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-container-interface-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-container-interface-client">#dfn-service-worker-container-interface-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">3.4.1. controller</a>
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">3.4.2. ready</a>
@@ -6879,14 +6879,14 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-container-interface-client">Notify Controller Change</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-ready-promise">
-   <b><a href="#dfn-ready-promise">#dfn-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-ready-promise" class="dfn-panel" data-for="dfn-ready-promise" id="infopanel-for-dfn-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-ready-promise" style="display:none">Info about the 'ready promise' definition.</span><b><a href="#dfn-ready-promise">#dfn-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-ready-promise">3.4.2. ready</a> <a href="#ref-for-dfn-ready-promise">(2)</a> <a href="#ref-for-dfn-ready-promise">(3)</a> <a href="#ref-for-dfn-ready-promise">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-client-message-queue">
-   <b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-client-message-queue" class="dfn-panel" data-for="dfn-client-message-queue" id="infopanel-for-dfn-client-message-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-client-message-queue" style="display:none">Info about the 'client message queue' definition.</span><b><a href="#dfn-client-message-queue">#dfn-client-message-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-client-message-queue">3.4. ServiceWorkerContainer</a> <a href="#ref-for-dfn-client-message-queue①">(2)</a> <a href="#ref-for-dfn-client-message-queue②">(3)</a>
     <li><a href="#ref-for-dfn-client-message-queue③">3.4.6. startMessages()</a>
@@ -6894,143 +6894,143 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-client-message-queue⑤">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controller-attribute">
-   <b><a href="#service-worker-container-controller-attribute">#service-worker-container-controller-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controller-attribute" class="dfn-panel" data-for="service-worker-container-controller-attribute" id="infopanel-for-service-worker-container-controller-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controller-attribute" style="display:none">Info about the 'controller' definition.</span><b><a href="#service-worker-container-controller-attribute">#service-worker-container-controller-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controller-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-controller-attribute①">3.4.1. controller</a> <a href="#ref-for-service-worker-container-controller-attribute②">(2)</a>
     <li><a href="#ref-for-service-worker-container-controller-attribute③">3.6. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-ready-attribute">
-   <b><a href="#service-worker-container-ready-attribute">#service-worker-container-ready-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-ready-attribute" class="dfn-panel" data-for="service-worker-container-ready-attribute" id="infopanel-for-service-worker-container-ready-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-ready-attribute" style="display:none">Info about the 'ready' definition.</span><b><a href="#service-worker-container-ready-attribute">#service-worker-container-ready-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-ready-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-ready-attribute①">3.4.2. ready</a> <a href="#ref-for-service-worker-container-ready-attribute">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-register-method">
-   <b><a href="#service-worker-container-register-method">#service-worker-container-register-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-register-method" class="dfn-panel" data-for="service-worker-container-register-method" id="infopanel-for-service-worker-container-register-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-register-method" style="display:none">Info about the 'register(scriptURL, options)' definition.</span><b><a href="#service-worker-container-register-method">#service-worker-container-register-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-register-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-register-method①">3.4.3. register(scriptURL, options)</a> <a href="#ref-for-service-worker-container-register-method②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-getregistration-method">
-   <b><a href="#service-worker-container-getregistration-method">#service-worker-container-getregistration-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-getregistration-method" class="dfn-panel" data-for="service-worker-container-getregistration-method" id="infopanel-for-service-worker-container-getregistration-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-getregistration-method" style="display:none">Info about the 'getRegistration(clientURL)' definition.</span><b><a href="#service-worker-container-getregistration-method">#service-worker-container-getregistration-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-getregistration-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-getregistration-method①">3.4.4. getRegistration(clientURL)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-getregistrations-method">
-   <b><a href="#service-worker-container-getregistrations-method">#service-worker-container-getregistrations-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-getregistrations-method" class="dfn-panel" data-for="service-worker-container-getregistrations-method" id="infopanel-for-service-worker-container-getregistrations-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-getregistrations-method" style="display:none">Info about the 'getRegistrations()' definition.</span><b><a href="#service-worker-container-getregistrations-method">#service-worker-container-getregistrations-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-getregistrations-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-getregistrations-method①">3.4.5. getRegistrations()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-startMessages-method">
-   <b><a href="#service-worker-container-startMessages-method">#service-worker-container-startMessages-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-startMessages-method" class="dfn-panel" data-for="service-worker-container-startMessages-method" id="infopanel-for-service-worker-container-startMessages-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-startMessages-method" style="display:none">Info about the 'startMessages()' definition.</span><b><a href="#service-worker-container-startMessages-method">#service-worker-container-startMessages-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-startMessages-method">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-startMessages-method①">3.4.6. startMessages()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-oncontrollerchange-attribute">
-   <b><a href="#service-worker-container-oncontrollerchange-attribute">#service-worker-container-oncontrollerchange-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-oncontrollerchange-attribute" class="dfn-panel" data-for="service-worker-container-oncontrollerchange-attribute" id="infopanel-for-service-worker-container-oncontrollerchange-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-oncontrollerchange-attribute" style="display:none">Info about the 'oncontrollerchange' definition.</span><b><a href="#service-worker-container-oncontrollerchange-attribute">#service-worker-container-oncontrollerchange-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-oncontrollerchange-attribute">3.4. ServiceWorkerContainer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-onmessage-attribute">
-   <b><a href="#service-worker-container-onmessage-attribute">#service-worker-container-onmessage-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-onmessage-attribute" class="dfn-panel" data-for="service-worker-container-onmessage-attribute" id="infopanel-for-service-worker-container-onmessage-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-onmessage-attribute" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#service-worker-container-onmessage-attribute">#service-worker-container-onmessage-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-onmessage-attribute">3.4. ServiceWorkerContainer</a>
     <li><a href="#ref-for-service-worker-container-onmessage-attribute">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-serviceworkermessageevent-serviceworkermessageeventinit">
-   <b><a href="#dictdef-serviceworkermessageevent-serviceworkermessageeventinit">#dictdef-serviceworkermessageevent-serviceworkermessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" class="dfn-panel" data-for="dictdef-serviceworkermessageevent-serviceworkermessageeventinit" id="infopanel-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit" style="display:none">Info about the 'ServiceWorkerMessageEventInit' definition.</span><b><a href="#dictdef-serviceworkermessageevent-serviceworkermessageeventinit">#dictdef-serviceworkermessageevent-serviceworkermessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-serviceworkermessageevent-serviceworkermessageeventinit">3.5. ServiceWorkerMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-interface">
-   <b><a href="#serviceworkermessage-event-interface">#serviceworkermessage-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-interface" class="dfn-panel" data-for="serviceworkermessage-event-interface" id="infopanel-for-serviceworkermessage-event-interface" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-interface" style="display:none">Info about the 'ServiceWorkerMessageEvent' definition.</span><b><a href="#serviceworkermessage-event-interface">#serviceworkermessage-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-interface">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-serviceworkermessage-event-interface①">(2)</a>
     <li><a href="#ref-for-serviceworkermessage-event-interface②">3.6. Events</a>
     <li><a href="#ref-for-serviceworkermessage-event-interface③">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-data-attribute">
-   <b><a href="#serviceworkermessage-event-data-attribute">#serviceworkermessage-event-data-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-data-attribute" class="dfn-panel" data-for="serviceworkermessage-event-data-attribute" id="infopanel-for-serviceworkermessage-event-data-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-data-attribute" style="display:none">Info about the 'data' definition.</span><b><a href="#serviceworkermessage-event-data-attribute">#serviceworkermessage-event-data-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute①">3.5.1. event.data</a>
     <li><a href="#ref-for-serviceworkermessage-event-data-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-origin-attribute">
-   <b><a href="#serviceworkermessage-event-origin-attribute">#serviceworkermessage-event-origin-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-origin-attribute" class="dfn-panel" data-for="serviceworkermessage-event-origin-attribute" id="infopanel-for-serviceworkermessage-event-origin-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-origin-attribute" style="display:none">Info about the 'origin' definition.</span><b><a href="#serviceworkermessage-event-origin-attribute">#serviceworkermessage-event-origin-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute①">3.5.2. event.origin</a>
     <li><a href="#ref-for-serviceworkermessage-event-origin-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-lasteventid-attribute">
-   <b><a href="#serviceworkermessage-event-lasteventid-attribute">#serviceworkermessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-lasteventid-attribute" class="dfn-panel" data-for="serviceworkermessage-event-lasteventid-attribute" id="infopanel-for-serviceworkermessage-event-lasteventid-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-lasteventid-attribute" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#serviceworkermessage-event-lasteventid-attribute">#serviceworkermessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-lasteventid-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-lasteventid-attribute①">3.5.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-source-attribute">
-   <b><a href="#serviceworkermessage-event-source-attribute">#serviceworkermessage-event-source-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-source-attribute" class="dfn-panel" data-for="serviceworkermessage-event-source-attribute" id="infopanel-for-serviceworkermessage-event-source-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-source-attribute" style="display:none">Info about the 'source' definition.</span><b><a href="#serviceworkermessage-event-source-attribute">#serviceworkermessage-event-source-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute①">3.5.4. event.source</a>
     <li><a href="#ref-for-serviceworkermessage-event-source-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serviceworkermessage-event-ports-attribute">
-   <b><a href="#serviceworkermessage-event-ports-attribute">#serviceworkermessage-event-ports-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serviceworkermessage-event-ports-attribute" class="dfn-panel" data-for="serviceworkermessage-event-ports-attribute" id="infopanel-for-serviceworkermessage-event-ports-attribute" role="dialog">
+   <span id="infopaneltitle-for-serviceworkermessage-event-ports-attribute" style="display:none">Info about the 'ports' definition.</span><b><a href="#serviceworkermessage-event-ports-attribute">#serviceworkermessage-event-ports-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute">3.5. ServiceWorkerMessageEvent</a>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute①">3.5.5. event.ports</a>
     <li><a href="#ref-for-serviceworkermessage-event-ports-attribute②">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-statechange-event">
-   <b><a href="#service-worker-statechange-event">#service-worker-statechange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-statechange-event" class="dfn-panel" data-for="service-worker-statechange-event" id="infopanel-for-service-worker-statechange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-statechange-event" style="display:none">Info about the 'statechange' definition.</span><b><a href="#service-worker-statechange-event">#service-worker-statechange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-statechange-event">3.1.4. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration-updatefound-event">
-   <b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration-updatefound-event" class="dfn-panel" data-for="service-worker-registration-updatefound-event" id="infopanel-for-service-worker-registration-updatefound-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration-updatefound-event" style="display:none">Info about the 'updatefound' definition.</span><b><a href="#service-worker-registration-updatefound-event">#service-worker-registration-updatefound-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration-updatefound-event">3.2.7. Event handler</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-controllerchange-event">
-   <b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-controllerchange-event" class="dfn-panel" data-for="service-worker-container-controllerchange-event" id="infopanel-for-service-worker-container-controllerchange-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-controllerchange-event" style="display:none">Info about the 'controllerchange' definition.</span><b><a href="#service-worker-container-controllerchange-event">#service-worker-container-controllerchange-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-controllerchange-event">3.4.7. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-container-message-event">
-   <b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-container-message-event" class="dfn-panel" data-for="service-worker-container-message-event" id="infopanel-for-service-worker-container-message-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-container-message-event" style="display:none">Info about the 'message' definition.</span><b><a href="#service-worker-container-message-event">#service-worker-container-message-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-container-message-event">3.4.7. Event handlers</a>
     <li><a href="#ref-for-service-worker-container-message-event">3.5. ServiceWorkerMessageEvent</a> <a href="#ref-for-service-worker-container-message-event">(2)</a>
     <li><a href="#ref-for-service-worker-container-message-event">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-interface">
-   <b><a href="#service-worker-global-scope-interface">#service-worker-global-scope-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-interface" class="dfn-panel" data-for="service-worker-global-scope-interface" id="infopanel-for-service-worker-global-scope-interface" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-interface" style="display:none">Info about the 'ServiceWorkerGlobalScope' definition.</span><b><a href="#service-worker-global-scope-interface">#service-worker-global-scope-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-interface">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-service-worker-global-scope-interface①">(2)</a>
     <li><a href="#ref-for-service-worker-global-scope-interface②">3.2.5. update()</a>
@@ -7045,8 +7045,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-interface①②">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-global-scope-service-worker">
-   <b><a href="#dfn-service-worker-global-scope-service-worker">#dfn-service-worker-global-scope-service-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-global-scope-service-worker" class="dfn-panel" data-for="dfn-service-worker-global-scope-service-worker" id="infopanel-for-dfn-service-worker-global-scope-service-worker" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-global-scope-service-worker" style="display:none">Info about the 'service worker' definition.</span><b><a href="#dfn-service-worker-global-scope-service-worker">#dfn-service-worker-global-scope-service-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">3.2.5. update()</a>
@@ -7062,61 +7062,61 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-global-scope-service-worker">Run Service Worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-clients-attribute">
-   <b><a href="#service-worker-global-scope-clients-attribute">#service-worker-global-scope-clients-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-clients-attribute" class="dfn-panel" data-for="service-worker-global-scope-clients-attribute" id="infopanel-for-service-worker-global-scope-clients-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-clients-attribute" style="display:none">Info about the 'clients' definition.</span><b><a href="#service-worker-global-scope-clients-attribute">#service-worker-global-scope-clients-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-clients-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-clients-attribute①">4.1.1. clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-scope-attribute">
-   <b><a href="#service-worker-global-scope-scope-attribute">#service-worker-global-scope-scope-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-scope-attribute" class="dfn-panel" data-for="service-worker-global-scope-scope-attribute" id="infopanel-for-service-worker-global-scope-scope-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-scope-attribute" style="display:none">Info about the 'registration' definition.</span><b><a href="#service-worker-global-scope-scope-attribute">#service-worker-global-scope-scope-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-scope-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-scope-attribute①">4.1.2. registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-skipwaiting-method">
-   <b><a href="#service-worker-global-scope-skipwaiting-method">#service-worker-global-scope-skipwaiting-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-skipwaiting-method" class="dfn-panel" data-for="service-worker-global-scope-skipwaiting-method" id="infopanel-for-service-worker-global-scope-skipwaiting-method" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-skipwaiting-method" style="display:none">Info about the 'skipWaiting()' definition.</span><b><a href="#service-worker-global-scope-skipwaiting-method">#service-worker-global-scope-skipwaiting-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-skipwaiting-method">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-skipwaiting-method①">4.1.3. skipWaiting()</a> <a href="#ref-for-service-worker-global-scope-skipwaiting-method②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-oninstall-attribute">
-   <b><a href="#service-worker-global-scope-oninstall-attribute">#service-worker-global-scope-oninstall-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-oninstall-attribute" class="dfn-panel" data-for="service-worker-global-scope-oninstall-attribute" id="infopanel-for-service-worker-global-scope-oninstall-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-oninstall-attribute" style="display:none">Info about the 'oninstall' definition.</span><b><a href="#service-worker-global-scope-oninstall-attribute">#service-worker-global-scope-oninstall-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-oninstall-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-oninstall-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onactivate-attribute">
-   <b><a href="#service-worker-global-scope-onactivate-attribute">#service-worker-global-scope-onactivate-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onactivate-attribute" class="dfn-panel" data-for="service-worker-global-scope-onactivate-attribute" id="infopanel-for-service-worker-global-scope-onactivate-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onactivate-attribute" style="display:none">Info about the 'onactivate' definition.</span><b><a href="#service-worker-global-scope-onactivate-attribute">#service-worker-global-scope-onactivate-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onactivate-attribute">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-service-worker-global-scope-onactivate-attribute">Update Worker State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onfetch-attribute">
-   <b><a href="#service-worker-global-scope-onfetch-attribute">#service-worker-global-scope-onfetch-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onfetch-attribute" class="dfn-panel" data-for="service-worker-global-scope-onfetch-attribute" id="infopanel-for-service-worker-global-scope-onfetch-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onfetch-attribute" style="display:none">Info about the 'onfetch' definition.</span><b><a href="#service-worker-global-scope-onfetch-attribute">#service-worker-global-scope-onfetch-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onfetch-attribute">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-onmessage-attribute">
-   <b><a href="#service-worker-global-scope-onmessage-attribute">#service-worker-global-scope-onmessage-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-onmessage-attribute" class="dfn-panel" data-for="service-worker-global-scope-onmessage-attribute" id="infopanel-for-service-worker-global-scope-onmessage-attribute" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-onmessage-attribute" style="display:none">Info about the 'onmessage' definition.</span><b><a href="#service-worker-global-scope-onmessage-attribute">#service-worker-global-scope-onmessage-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-onmessage-attribute">4.1. ServiceWorkerGlobalScope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windowclient-navigate">
-   <b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windowclient-navigate" class="dfn-panel" data-for="dom-windowclient-navigate" id="infopanel-for-dom-windowclient-navigate" role="dialog">
+   <span id="infopaneltitle-for-dom-windowclient-navigate" style="display:none">Info about the 'navigate' definition.</span><b><a href="#dom-windowclient-navigate">#dom-windowclient-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowclient-navigate">4.2.8. navigate(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-interface">
-   <b><a href="#client-interface">#client-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-interface" class="dfn-panel" data-for="client-interface" id="infopanel-for-client-interface" role="dialog">
+   <span id="infopaneltitle-for-client-interface" style="display:none">Info about the 'Client' definition.</span><b><a href="#client-interface">#client-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-client-interface①">4.2. Client</a> <a href="#ref-for-client-interface②">(2)</a> <a href="#ref-for-client-interface③">(3)</a>
@@ -7126,8 +7126,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-client-interface⑧">Create Client</a> <a href="#ref-for-client-interface⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-client">
-   <b><a href="#dfn-service-worker-client-client">#dfn-service-worker-client-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-client" class="dfn-panel" data-for="dfn-service-worker-client-client" id="infopanel-for-dfn-service-worker-client-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-client" style="display:none">Info about the 'service worker client' definition.</span><b><a href="#dfn-service-worker-client-client">#dfn-service-worker-client-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-client">4.2.1. url</a>
     <li><a href="#ref-for-dfn-service-worker-client-client">4.2.2. frameType</a>
@@ -7139,8 +7139,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-service-worker-client-client">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="window-client-interface">
-   <b><a href="#window-client-interface">#window-client-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-client-interface" class="dfn-panel" data-for="window-client-interface" id="infopanel-for-window-client-interface" role="dialog">
+   <span id="infopaneltitle-for-window-client-interface" style="display:none">Info about the 'WindowClient' definition.</span><b><a href="#window-client-interface">#window-client-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-client-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-window-client-interface①">4.2. Client</a> <a href="#ref-for-window-client-interface②">(2)</a> <a href="#ref-for-window-client-interface③">(3)</a> <a href="#ref-for-window-client-interface④">(4)</a>
@@ -7148,146 +7148,146 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-window-client-interface⑥">Create Window Client</a> <a href="#ref-for-window-client-interface⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate">
-   <b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-visibilitystate" class="dfn-panel" data-for="dfn-service-worker-client-visibilitystate" id="infopanel-for-dfn-service-worker-client-visibilitystate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-visibilitystate" style="display:none">Info about the 'visibility state' definition.</span><b><a href="#dfn-service-worker-client-visibilitystate">#dfn-service-worker-client-visibilitystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">4.2.5. visibilityState</a>
     <li><a href="#ref-for-dfn-service-worker-client-visibilitystate">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-service-worker-client-focusstate">
-   <b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-service-worker-client-focusstate" class="dfn-panel" data-for="dfn-service-worker-client-focusstate" id="infopanel-for-dfn-service-worker-client-focusstate" role="dialog">
+   <span id="infopaneltitle-for-dfn-service-worker-client-focusstate" style="display:none">Info about the 'focus state' definition.</span><b><a href="#dfn-service-worker-client-focusstate">#dfn-service-worker-client-focusstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.6. focused</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">4.2.7. focus()</a>
     <li><a href="#ref-for-dfn-service-worker-client-focusstate">Create Window Client</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-url-attribute">
-   <b><a href="#client-url-attribute">#client-url-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-url-attribute" class="dfn-panel" data-for="client-url-attribute" id="infopanel-for-client-url-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-url-attribute" style="display:none">Info about the 'url' definition.</span><b><a href="#client-url-attribute">#client-url-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-url-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-url-attribute①">4.2.1. url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-frametype-attribute">
-   <b><a href="#client-frametype-attribute">#client-frametype-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-frametype-attribute" class="dfn-panel" data-for="client-frametype-attribute" id="infopanel-for-client-frametype-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-frametype-attribute" style="display:none">Info about the 'frameType' definition.</span><b><a href="#client-frametype-attribute">#client-frametype-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-frametype-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-frametype-attribute①">4.2.2. frameType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contextframetype-enum">
-   <b><a href="#contextframetype-enum">#contextframetype-enum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contextframetype-enum" class="dfn-panel" data-for="contextframetype-enum" id="infopanel-for-contextframetype-enum" role="dialog">
+   <span id="infopaneltitle-for-contextframetype-enum" style="display:none">Info about the 'FrameType' definition.</span><b><a href="#contextframetype-enum">#contextframetype-enum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contextframetype-enum">4.2. Client</a> <a href="#ref-for-contextframetype-enum①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-id-attribute">
-   <b><a href="#client-id-attribute">#client-id-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-id-attribute" class="dfn-panel" data-for="client-id-attribute" id="infopanel-for-client-id-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-id-attribute" style="display:none">Info about the 'id' definition.</span><b><a href="#client-id-attribute">#client-id-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-id-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-id-attribute①">4.2.3. id</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-postmessage-method">
-   <b><a href="#client-postmessage-method">#client-postmessage-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-postmessage-method" class="dfn-panel" data-for="client-postmessage-method" id="infopanel-for-client-postmessage-method" role="dialog">
+   <span id="infopaneltitle-for-client-postmessage-method" style="display:none">Info about the 'postMessage(message, transfer)' definition.</span><b><a href="#client-postmessage-method">#client-postmessage-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-postmessage-method">4.2. Client</a>
     <li><a href="#ref-for-client-postmessage-method①">4.2.4. postMessage(message, transfer)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-visibilitystate-attribute">
-   <b><a href="#client-visibilitystate-attribute">#client-visibilitystate-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-visibilitystate-attribute" class="dfn-panel" data-for="client-visibilitystate-attribute" id="infopanel-for-client-visibilitystate-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-visibilitystate-attribute" style="display:none">Info about the 'visibilityState' definition.</span><b><a href="#client-visibilitystate-attribute">#client-visibilitystate-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-visibilitystate-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-visibilitystate-attribute①">4.2.5. visibilityState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-focused-attribute">
-   <b><a href="#client-focused-attribute">#client-focused-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-focused-attribute" class="dfn-panel" data-for="client-focused-attribute" id="infopanel-for-client-focused-attribute" role="dialog">
+   <span id="infopaneltitle-for-client-focused-attribute" style="display:none">Info about the 'focused' definition.</span><b><a href="#client-focused-attribute">#client-focused-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-focused-attribute">4.2. Client</a>
     <li><a href="#ref-for-client-focused-attribute①">4.2.6. focused</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-focus-method">
-   <b><a href="#client-focus-method">#client-focus-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-focus-method" class="dfn-panel" data-for="client-focus-method" id="infopanel-for-client-focus-method" role="dialog">
+   <span id="infopaneltitle-for-client-focus-method" style="display:none">Info about the 'focus()' definition.</span><b><a href="#client-focus-method">#client-focus-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-focus-method">4.2. Client</a>
     <li><a href="#ref-for-client-focus-method①">4.2.7. focus()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clients-clientqueryoptions">
-   <b><a href="#dictdef-clients-clientqueryoptions">#dictdef-clients-clientqueryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clients-clientqueryoptions" class="dfn-panel" data-for="dictdef-clients-clientqueryoptions" id="infopanel-for-dictdef-clients-clientqueryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clients-clientqueryoptions" style="display:none">Info about the 'ClientQueryOptions' definition.</span><b><a href="#dictdef-clients-clientqueryoptions">#dictdef-clients-clientqueryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clients-clientqueryoptions">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled">
-   <b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" class="dfn-panel" data-for="dom-clientqueryoptions-includeuncontrolled" id="infopanel-for-dom-clientqueryoptions-includeuncontrolled" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-includeuncontrolled" style="display:none">Info about the 'includeUncontrolled' definition.</span><b><a href="#dom-clientqueryoptions-includeuncontrolled">#dom-clientqueryoptions-includeuncontrolled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-includeuncontrolled">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clientqueryoptions-type">
-   <b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clientqueryoptions-type" class="dfn-panel" data-for="dom-clientqueryoptions-type" id="infopanel-for-dom-clientqueryoptions-type" role="dialog">
+   <span id="infopaneltitle-for-dom-clientqueryoptions-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-clientqueryoptions-type">#dom-clientqueryoptions-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clientqueryoptions-type">4.3.2. matchAll(options)</a> <a href="#ref-for-dom-clientqueryoptions-type①">(2)</a> <a href="#ref-for-dom-clientqueryoptions-type②">(3)</a> <a href="#ref-for-dom-clientqueryoptions-type③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-clients-clienttype">
-   <b><a href="#enumdef-clients-clienttype">#enumdef-clients-clienttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-clients-clienttype" class="dfn-panel" data-for="enumdef-clients-clienttype" id="infopanel-for-enumdef-clients-clienttype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-clients-clienttype" style="display:none">Info about the 'ClientType' definition.</span><b><a href="#enumdef-clients-clienttype">#enumdef-clients-clienttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-clients-clienttype">4.3. Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-interface">
-   <b><a href="#clients-interface">#clients-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-interface" class="dfn-panel" data-for="clients-interface" id="infopanel-for-clients-interface" role="dialog">
+   <span id="infopaneltitle-for-clients-interface" style="display:none">Info about the 'Clients' definition.</span><b><a href="#clients-interface">#clients-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-interface">4.1. ServiceWorkerGlobalScope</a>
     <li><a href="#ref-for-clients-interface①">4.1.1. clients</a>
     <li><a href="#ref-for-clients-interface②">4.3. Clients</a> <a href="#ref-for-clients-interface③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-get-method">
-   <b><a href="#clients-get-method">#clients-get-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-get-method" class="dfn-panel" data-for="clients-get-method" id="infopanel-for-clients-get-method" role="dialog">
+   <span id="infopaneltitle-for-clients-get-method" style="display:none">Info about the 'get(id)' definition.</span><b><a href="#clients-get-method">#clients-get-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-get-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-get-method①">4.3.1. get(id)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-matchall-method">
-   <b><a href="#clients-matchall-method">#clients-matchall-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-matchall-method" class="dfn-panel" data-for="clients-matchall-method" id="infopanel-for-clients-matchall-method" role="dialog">
+   <span id="infopaneltitle-for-clients-matchall-method" style="display:none">Info about the 'matchAll(options)' definition.</span><b><a href="#clients-matchall-method">#clients-matchall-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-matchall-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-matchall-method①">4.3.2. matchAll(options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-openwindow-method">
-   <b><a href="#clients-openwindow-method">#clients-openwindow-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-openwindow-method" class="dfn-panel" data-for="clients-openwindow-method" id="infopanel-for-clients-openwindow-method" role="dialog">
+   <span id="infopaneltitle-for-clients-openwindow-method" style="display:none">Info about the 'openWindow(url)' definition.</span><b><a href="#clients-openwindow-method">#clients-openwindow-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-openwindow-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-openwindow-method①">4.3.3. openWindow(url)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clients-claim-method">
-   <b><a href="#clients-claim-method">#clients-claim-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clients-claim-method" class="dfn-panel" data-for="clients-claim-method" id="infopanel-for-clients-claim-method" role="dialog">
+   <span id="infopaneltitle-for-clients-claim-method" style="display:none">Info about the 'claim()' definition.</span><b><a href="#clients-claim-method">#clients-claim-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clients-claim-method">4.3. Clients</a>
     <li><a href="#ref-for-clients-claim-method①">4.3.4. claim()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendableeventinit">
-   <b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendableeventinit" class="dfn-panel" data-for="dictdef-extendableeventinit" id="infopanel-for-dictdef-extendableeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' definition.</span><b><a href="#dictdef-extendableeventinit">#dictdef-extendableeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit①">4.5. FetchEvent</a>
     <li><a href="#ref-for-dictdef-extendableeventinit②">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendable-event-interface">
-   <b><a href="#extendable-event-interface">#extendable-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendable-event-interface" class="dfn-panel" data-for="extendable-event-interface" id="infopanel-for-extendable-event-interface" role="dialog">
+   <span id="infopaneltitle-for-extendable-event-interface" style="display:none">Info about the 'ExtendableEvent' definition.</span><b><a href="#extendable-event-interface">#extendable-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-interface">4.4. ExtendableEvent</a> <a href="#ref-for-extendable-event-interface①">(2)</a> <a href="#ref-for-extendable-event-interface②">(3)</a> <a href="#ref-for-extendable-event-interface③">(4)</a> <a href="#ref-for-extendable-event-interface④">(5)</a> <a href="#ref-for-extendable-event-interface⑤">(6)</a>
     <li><a href="#ref-for-extendable-event-interface⑥">4.5. FetchEvent</a> <a href="#ref-for-extendable-event-interface⑦">(2)</a>
@@ -7298,8 +7298,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendable-event-interface①④">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-extend-lifetime-promises">
-   <b><a href="#dfn-extend-lifetime-promises">#dfn-extend-lifetime-promises</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-extend-lifetime-promises" class="dfn-panel" data-for="dfn-extend-lifetime-promises" id="infopanel-for-dfn-extend-lifetime-promises" role="dialog">
+   <span id="infopaneltitle-for-dfn-extend-lifetime-promises" style="display:none">Info about the 'extend lifetime promises' definition.</span><b><a href="#dfn-extend-lifetime-promises">#dfn-extend-lifetime-promises</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extend-lifetime-promises">4.4. ExtendableEvent</a> <a href="#ref-for-dfn-extend-lifetime-promises①">(2)</a> <a href="#ref-for-dfn-extend-lifetime-promises②">(3)</a> <a href="#ref-for-dfn-extend-lifetime-promises">(4)</a> <a href="#ref-for-dfn-extend-lifetime-promises">(5)</a> <a href="#ref-for-dfn-extend-lifetime-promises③">(6)</a> <a href="#ref-for-dfn-extend-lifetime-promises④">(7)</a> <a href="#ref-for-dfn-extend-lifetime-promises⑤">(8)</a> <a href="#ref-for-dfn-extend-lifetime-promises⑥">(9)</a>
     <li><a href="#ref-for-dfn-extend-lifetime-promises">4.4.1. event.waitUntil(f)</a>
@@ -7307,8 +7307,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-extend-lifetime-promises⑧">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extensions-allowed-flag">
-   <b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extensions-allowed-flag" class="dfn-panel" data-for="extensions-allowed-flag" id="infopanel-for-extensions-allowed-flag" role="dialog">
+   <span id="infopaneltitle-for-extensions-allowed-flag" style="display:none">Info about the 'extensions allowed flag' definition.</span><b><a href="#extensions-allowed-flag">#extensions-allowed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extensions-allowed-flag">4.4. ExtendableEvent</a> <a href="#ref-for-extensions-allowed-flag①">(2)</a> <a href="#ref-for-extensions-allowed-flag②">(3)</a>
     <li><a href="#ref-for-extensions-allowed-flag③">4.4.1. event.waitUntil(f)</a>
@@ -7316,8 +7316,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extensions-allowed-flag⑤">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendable-event-waituntil-method">
-   <b><a href="#extendable-event-waituntil-method">#extendable-event-waituntil-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendable-event-waituntil-method" class="dfn-panel" data-for="extendable-event-waituntil-method" id="infopanel-for-extendable-event-waituntil-method" role="dialog">
+   <span id="infopaneltitle-for-extendable-event-waituntil-method" style="display:none">Info about the 'waitUntil(f)' definition.</span><b><a href="#extendable-event-waituntil-method">#extendable-event-waituntil-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendable-event-waituntil-method">4.4. ExtendableEvent</a>
     <li><a href="#ref-for-extendable-event-waituntil-method①">4.4.1. event.waitUntil(f)</a> <a href="#ref-for-extendable-event-waituntil-method②">(2)</a>
@@ -7326,135 +7326,135 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-extendable-event-waituntil-method">Update Worker State</a> <a href="#ref-for-extendable-event-waituntil-method">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fetchevent-fetcheventinit">
-   <b><a href="#dictdef-fetchevent-fetcheventinit">#dictdef-fetchevent-fetcheventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fetchevent-fetcheventinit" class="dfn-panel" data-for="dictdef-fetchevent-fetcheventinit" id="infopanel-for-dictdef-fetchevent-fetcheventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fetchevent-fetcheventinit" style="display:none">Info about the 'FetchEventInit' definition.</span><b><a href="#dictdef-fetchevent-fetcheventinit">#dictdef-fetchevent-fetcheventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fetchevent-fetcheventinit">4.5. FetchEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-interface">
-   <b><a href="#fetch-event-interface">#fetch-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-interface" class="dfn-panel" data-for="fetch-event-interface" id="infopanel-for-fetch-event-interface" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-interface" style="display:none">Info about the 'FetchEvent' definition.</span><b><a href="#fetch-event-interface">#fetch-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-interface">4.5. FetchEvent</a> <a href="#ref-for-fetch-event-interface①">(2)</a> <a href="#ref-for-fetch-event-interface②">(3)</a>
     <li><a href="#ref-for-fetch-event-interface③">4.7. Events</a>
     <li><a href="#ref-for-fetch-event-interface④">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetchevent-potential-response">
-   <b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetchevent-potential-response" class="dfn-panel" data-for="fetchevent-potential-response" id="infopanel-for-fetchevent-potential-response" role="dialog">
+   <span id="infopaneltitle-for-fetchevent-potential-response" style="display:none">Info about the 'potential response' definition.</span><b><a href="#fetchevent-potential-response">#fetchevent-potential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetchevent-potential-response">4.5.4. event.respondWith(r)</a>
     <li><a href="#ref-for-fetchevent-potential-response①">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wait-to-respond-flag">
-   <b><a href="#wait-to-respond-flag">#wait-to-respond-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wait-to-respond-flag" class="dfn-panel" data-for="wait-to-respond-flag" id="infopanel-for-wait-to-respond-flag" role="dialog">
+   <span id="infopaneltitle-for-wait-to-respond-flag" style="display:none">Info about the 'wait to respond flag' definition.</span><b><a href="#wait-to-respond-flag">#wait-to-respond-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wait-to-respond-flag">4.5.4. event.respondWith(r)</a> <a href="#ref-for-wait-to-respond-flag">(2)</a>
     <li><a href="#ref-for-wait-to-respond-flag">Handle Fetch</a> <a href="#ref-for-wait-to-respond-flag">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-with-entered-flag">
-   <b><a href="#respond-with-entered-flag">#respond-with-entered-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-with-entered-flag" class="dfn-panel" data-for="respond-with-entered-flag" id="infopanel-for-respond-with-entered-flag" role="dialog">
+   <span id="infopaneltitle-for-respond-with-entered-flag" style="display:none">Info about the 'respond-with entered flag' definition.</span><b><a href="#respond-with-entered-flag">#respond-with-entered-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-with-entered-flag">4.5.4. event.respondWith(r)</a> <a href="#ref-for-respond-with-entered-flag">(2)</a>
     <li><a href="#ref-for-respond-with-entered-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-with-error-flag">
-   <b><a href="#respond-with-error-flag">#respond-with-error-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-with-error-flag" class="dfn-panel" data-for="respond-with-error-flag" id="infopanel-for-respond-with-error-flag" role="dialog">
+   <span id="infopaneltitle-for-respond-with-error-flag" style="display:none">Info about the 'respond-with error flag' definition.</span><b><a href="#respond-with-error-flag">#respond-with-error-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-with-error-flag">4.5.4. event.respondWith(r)</a> <a href="#ref-for-respond-with-error-flag">(2)</a> <a href="#ref-for-respond-with-error-flag">(3)</a> <a href="#ref-for-respond-with-error-flag">(4)</a>
     <li><a href="#ref-for-respond-with-error-flag">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-request-attribute">
-   <b><a href="#fetch-event-request-attribute">#fetch-event-request-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-request-attribute" class="dfn-panel" data-for="fetch-event-request-attribute" id="infopanel-for-fetch-event-request-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-request-attribute" style="display:none">Info about the 'request' definition.</span><b><a href="#fetch-event-request-attribute">#fetch-event-request-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-request-attribute">4.5. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-request-attribute①">4.5.1. event.request</a>
     <li><a href="#ref-for-fetch-event-request-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-clientid-attribute">
-   <b><a href="#fetch-event-clientid-attribute">#fetch-event-clientid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-clientid-attribute" class="dfn-panel" data-for="fetch-event-clientid-attribute" id="infopanel-for-fetch-event-clientid-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-clientid-attribute" style="display:none">Info about the 'clientId' definition.</span><b><a href="#fetch-event-clientid-attribute">#fetch-event-clientid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-clientid-attribute">4.5. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-clientid-attribute①">4.5.2. event.clientId</a>
     <li><a href="#ref-for-fetch-event-clientid-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-isreload-attribute">
-   <b><a href="#fetch-event-isreload-attribute">#fetch-event-isreload-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-isreload-attribute" class="dfn-panel" data-for="fetch-event-isreload-attribute" id="infopanel-for-fetch-event-isreload-attribute" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-isreload-attribute" style="display:none">Info about the 'isReload' definition.</span><b><a href="#fetch-event-isreload-attribute">#fetch-event-isreload-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-isreload-attribute">4.5. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-isreload-attribute①">4.5.3. event.isReload</a>
     <li><a href="#ref-for-fetch-event-isreload-attribute">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-event-respondwith-method">
-   <b><a href="#fetch-event-respondwith-method">#fetch-event-respondwith-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-event-respondwith-method" class="dfn-panel" data-for="fetch-event-respondwith-method" id="infopanel-for-fetch-event-respondwith-method" role="dialog">
+   <span id="infopaneltitle-for-fetch-event-respondwith-method" style="display:none">Info about the 'respondWith(r)' definition.</span><b><a href="#fetch-event-respondwith-method">#fetch-event-respondwith-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-event-respondwith-method">4.5. FetchEvent</a>
     <li><a href="#ref-for-fetch-event-respondwith-method①">4.5.4. event.respondWith(r)</a> <a href="#ref-for-fetch-event-respondwith-method②">(2)</a>
     <li><a href="#ref-for-fetch-event-respondwith-method③">6.4. Cross-Origin Resources and CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendablemessageevent-extendablemessageeventinit">
-   <b><a href="#dictdef-extendablemessageevent-extendablemessageeventinit">#dictdef-extendablemessageevent-extendablemessageeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendablemessageevent-extendablemessageeventinit" class="dfn-panel" data-for="dictdef-extendablemessageevent-extendablemessageeventinit" id="infopanel-for-dictdef-extendablemessageevent-extendablemessageeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendablemessageevent-extendablemessageeventinit" style="display:none">Info about the 'ExtendableMessageEventInit' definition.</span><b><a href="#dictdef-extendablemessageevent-extendablemessageeventinit">#dictdef-extendablemessageevent-extendablemessageeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendablemessageevent-extendablemessageeventinit">4.6. ExtendableMessageEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-interface">
-   <b><a href="#extendablemessage-event-interface">#extendablemessage-event-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-interface" class="dfn-panel" data-for="extendablemessage-event-interface" id="infopanel-for-extendablemessage-event-interface" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-interface" style="display:none">Info about the 'ExtendableMessageEvent' definition.</span><b><a href="#extendablemessage-event-interface">#extendablemessage-event-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-interface">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-interface①">4.6. ExtendableMessageEvent</a> <a href="#ref-for-extendablemessage-event-interface②">(2)</a>
     <li><a href="#ref-for-extendablemessage-event-interface③">4.7. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-data-attribute">
-   <b><a href="#extendablemessage-event-data-attribute">#extendablemessage-event-data-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-data-attribute" class="dfn-panel" data-for="extendablemessage-event-data-attribute" id="infopanel-for-extendablemessage-event-data-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-data-attribute" style="display:none">Info about the 'data' definition.</span><b><a href="#extendablemessage-event-data-attribute">#extendablemessage-event-data-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-data-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-data-attribute①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-data-attribute②">4.6.1. event.data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-origin-attribute">
-   <b><a href="#extendablemessage-event-origin-attribute">#extendablemessage-event-origin-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-origin-attribute" class="dfn-panel" data-for="extendablemessage-event-origin-attribute" id="infopanel-for-extendablemessage-event-origin-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-origin-attribute" style="display:none">Info about the 'origin' definition.</span><b><a href="#extendablemessage-event-origin-attribute">#extendablemessage-event-origin-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-origin-attribute②">4.6.2. event.origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-lasteventid-attribute">
-   <b><a href="#extendablemessage-event-lasteventid-attribute">#extendablemessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-lasteventid-attribute" class="dfn-panel" data-for="extendablemessage-event-lasteventid-attribute" id="infopanel-for-extendablemessage-event-lasteventid-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-lasteventid-attribute" style="display:none">Info about the 'lastEventId' definition.</span><b><a href="#extendablemessage-event-lasteventid-attribute">#extendablemessage-event-lasteventid-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-lasteventid-attribute">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-lasteventid-attribute①">4.6.3. event.lastEventId</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-source-attribute">
-   <b><a href="#extendablemessage-event-source-attribute">#extendablemessage-event-source-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-source-attribute" class="dfn-panel" data-for="extendablemessage-event-source-attribute" id="infopanel-for-extendablemessage-event-source-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-source-attribute" style="display:none">Info about the 'source' definition.</span><b><a href="#extendablemessage-event-source-attribute">#extendablemessage-event-source-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-source-attribute">3.1.3. postMessage(message, transfer)</a> <a href="#ref-for-extendablemessage-event-source-attribute①">(2)</a>
     <li><a href="#ref-for-extendablemessage-event-source-attribute②">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-source-attribute③">4.6.4. event.source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extendablemessage-event-ports-attribute">
-   <b><a href="#extendablemessage-event-ports-attribute">#extendablemessage-event-ports-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extendablemessage-event-ports-attribute" class="dfn-panel" data-for="extendablemessage-event-ports-attribute" id="infopanel-for-extendablemessage-event-ports-attribute" role="dialog">
+   <span id="infopaneltitle-for-extendablemessage-event-ports-attribute" style="display:none">Info about the 'ports' definition.</span><b><a href="#extendablemessage-event-ports-attribute">#extendablemessage-event-ports-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute①">4.6. ExtendableMessageEvent</a>
     <li><a href="#ref-for-extendablemessage-event-ports-attribute②">4.6.5. event.ports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-install-event">
-   <b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-install-event" class="dfn-panel" data-for="service-worker-global-scope-install-event" id="infopanel-for-service-worker-global-scope-install-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-install-event" style="display:none">Info about the 'install' definition.</span><b><a href="#service-worker-global-scope-install-event">#service-worker-global-scope-install-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-install-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-install-event">4.1.4. Event handlers</a>
@@ -7462,8 +7462,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-install-event">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-activate-event">
-   <b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-activate-event" class="dfn-panel" data-for="service-worker-global-scope-activate-event" id="infopanel-for-service-worker-global-scope-activate-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-activate-event" style="display:none">Info about the 'activate' definition.</span><b><a href="#service-worker-global-scope-activate-event">#service-worker-global-scope-activate-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-activate-event">4.1.4. Event handlers</a>
@@ -7471,8 +7471,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-activate-event">Activate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-fetch-event">
-   <b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="service-worker-global-scope-fetch-event" id="infopanel-for-service-worker-global-scope-fetch-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' definition.</span><b><a href="#service-worker-global-scope-fetch-event">#service-worker-global-scope-fetch-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.1. Service Worker</a>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.5. Task Sources</a>
@@ -7482,16 +7482,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">Handle Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-global-scope-message-event">
-   <b><a href="#service-worker-global-scope-message-event">#service-worker-global-scope-message-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-global-scope-message-event" class="dfn-panel" data-for="service-worker-global-scope-message-event" id="infopanel-for-service-worker-global-scope-message-event" role="dialog">
+   <span id="infopaneltitle-for-service-worker-global-scope-message-event" style="display:none">Info about the 'message' definition.</span><b><a href="#service-worker-global-scope-message-event">#service-worker-global-scope-message-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-message-event">3.1.3. postMessage(message, transfer)</a>
     <li><a href="#ref-for-service-worker-global-scope-message-event">4.1.4. Event handlers</a>
     <li><a href="#ref-for-service-worker-global-scope-message-event">4.6. ExtendableMessageEvent</a> <a href="#ref-for-service-worker-global-scope-message-event">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-fetching-record">
-   <b><a href="#dfn-fetching-record">#dfn-fetching-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-fetching-record" class="dfn-panel" data-for="dfn-fetching-record" id="infopanel-for-dfn-fetching-record" role="dialog">
+   <span id="infopaneltitle-for-dfn-fetching-record" style="display:none">Info about the 'fetching record' definition.</span><b><a href="#dfn-fetching-record">#dfn-fetching-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fetching-record">5.1. Constructs</a> <a href="#ref-for-dfn-fetching-record">(2)</a> <a href="#ref-for-dfn-fetching-record">(3)</a>
     <li><a href="#ref-for-dfn-fetching-record">5.4.2. matchAll(request, options)</a> <a href="#ref-for-dfn-fetching-record">(2)</a>
@@ -7502,16 +7502,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-fetching-record">Batch Cache Operations</a> <a href="#ref-for-dfn-fetching-record">(2)</a> <a href="#ref-for-dfn-fetching-record">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-incumbent-record">
-   <b><a href="#dfn-incumbent-record">#dfn-incumbent-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-incumbent-record" class="dfn-panel" data-for="dfn-incumbent-record" id="infopanel-for-dfn-incumbent-record" role="dialog">
+   <span id="infopaneltitle-for-dfn-incumbent-record" style="display:none">Info about the 'incumbent record' definition.</span><b><a href="#dfn-incumbent-record">#dfn-incumbent-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-incumbent-record">5.4.2. matchAll(request, options)</a>
     <li><a href="#ref-for-dfn-incumbent-record">5.4.4. addAll(requests)</a> <a href="#ref-for-dfn-incumbent-record">(2)</a>
     <li><a href="#ref-for-dfn-incumbent-record">5.4.5. put(request, response)</a> <a href="#ref-for-dfn-incumbent-record">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-request-to-response-map">
-   <b><a href="#dfn-request-to-response-map">#dfn-request-to-response-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-request-to-response-map" class="dfn-panel" data-for="dfn-request-to-response-map" id="infopanel-for-dfn-request-to-response-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-request-to-response-map" style="display:none">Info about the 'request to response map' definition.</span><b><a href="#dfn-request-to-response-map">#dfn-request-to-response-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-to-response-map">5.4. Cache</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a>
     <li><a href="#ref-for-dfn-request-to-response-map">5.4.2. matchAll(request, options)</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a>
@@ -7523,8 +7523,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-request-to-response-map">Batch Cache Operations</a> <a href="#ref-for-dfn-request-to-response-map">(2)</a> <a href="#ref-for-dfn-request-to-response-map">(3)</a> <a href="#ref-for-dfn-request-to-response-map">(4)</a> <a href="#ref-for-dfn-request-to-response-map">(5)</a> <a href="#ref-for-dfn-request-to-response-map">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-name-to-cache-map">
-   <b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-name-to-cache-map" class="dfn-panel" data-for="dfn-name-to-cache-map" id="infopanel-for-dfn-name-to-cache-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-name-to-cache-map" style="display:none">Info about the 'name to cache map' definition.</span><b><a href="#dfn-name-to-cache-map">#dfn-name-to-cache-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name-to-cache-map">5.1. Constructs</a>
     <li><a href="#ref-for-dfn-name-to-cache-map">5.5. CacheStorage</a> <a href="#ref-for-dfn-name-to-cache-map">(2)</a>
@@ -7536,48 +7536,48 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-name-to-cache-map">6.6. Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-caches-attribute">
-   <b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-caches-attribute" class="dfn-panel" data-for="global-caches-attribute" id="infopanel-for-global-caches-attribute" role="dialog">
+   <span id="infopaneltitle-for-global-caches-attribute" style="display:none">Info about the 'caches' definition.</span><b><a href="#global-caches-attribute">#global-caches-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-caches-attribute">5.3. self.caches</a> <a href="#ref-for-global-caches-attribute①">(2)</a>
     <li><a href="#ref-for-global-caches-attribute②">5.3.1. caches</a>
     <li><a href="#ref-for-global-caches-attribute③">5.4. Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cache-cachequeryoptions">
-   <b><a href="#dictdef-cache-cachequeryoptions">#dictdef-cache-cachequeryoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cache-cachequeryoptions" class="dfn-panel" data-for="dictdef-cache-cachequeryoptions" id="infopanel-for-dictdef-cache-cachequeryoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cache-cachequeryoptions" style="display:none">Info about the 'CacheQueryOptions' definition.</span><b><a href="#dictdef-cache-cachequeryoptions">#dictdef-cache-cachequeryoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions">5.4. Cache</a> <a href="#ref-for-dictdef-cache-cachequeryoptions①">(2)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions②">(3)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions③">(4)</a> <a href="#ref-for-dictdef-cache-cachequeryoptions④">(5)</a>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions⑤">5.5. CacheStorage</a>
     <li><a href="#ref-for-dictdef-cache-cachequeryoptions⑥">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch">
-   <b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" class="dfn-panel" data-for="dom-cachequeryoptions-ignoresearch" id="infopanel-for-dom-cachequeryoptions-ignoresearch" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoresearch" style="display:none">Info about the 'ignoreSearch' definition.</span><b><a href="#dom-cachequeryoptions-ignoresearch">#dom-cachequeryoptions-ignoresearch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoresearch">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod">
-   <b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" class="dfn-panel" data-for="dom-cachequeryoptions-ignoremethod" id="infopanel-for-dom-cachequeryoptions-ignoremethod" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignoremethod" style="display:none">Info about the 'ignoreMethod' definition.</span><b><a href="#dom-cachequeryoptions-ignoremethod">#dom-cachequeryoptions-ignoremethod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignoremethod">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary">
-   <b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-ignorevary" class="dfn-panel" data-for="dom-cachequeryoptions-ignorevary" id="infopanel-for-dom-cachequeryoptions-ignorevary" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-ignorevary" style="display:none">Info about the 'ignoreVary' definition.</span><b><a href="#dom-cachequeryoptions-ignorevary">#dom-cachequeryoptions-ignorevary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-ignorevary">Query Cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachequeryoptions-cachename">
-   <b><a href="#dom-cachequeryoptions-cachename">#dom-cachequeryoptions-cachename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachequeryoptions-cachename" class="dfn-panel" data-for="dom-cachequeryoptions-cachename" id="infopanel-for-dom-cachequeryoptions-cachename" role="dialog">
+   <span id="infopaneltitle-for-dom-cachequeryoptions-cachename" style="display:none">Info about the 'cacheName' definition.</span><b><a href="#dom-cachequeryoptions-cachename">#dom-cachequeryoptions-cachename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachequeryoptions-cachename">5.5.1. match(request, options)</a> <a href="#ref-for-dom-cachequeryoptions-cachename①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cache-cachebatchoperation">
-   <b><a href="#dictdef-cache-cachebatchoperation">#dictdef-cache-cachebatchoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cache-cachebatchoperation" class="dfn-panel" data-for="dictdef-cache-cachebatchoperation" id="infopanel-for-dictdef-cache-cachebatchoperation" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cache-cachebatchoperation" style="display:none">Info about the 'CacheBatchOperation' definition.</span><b><a href="#dictdef-cache-cachebatchoperation">#dictdef-cache-cachebatchoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation①">5.4.5. put(request, response)</a>
@@ -7585,8 +7585,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dictdef-cache-cachebatchoperation③">Batch Cache Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-type">
-   <b><a href="#dom-cachebatchoperation-type">#dom-cachebatchoperation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-type" class="dfn-panel" data-for="dom-cachebatchoperation-type" id="infopanel-for-dom-cachebatchoperation-type" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-cachebatchoperation-type">#dom-cachebatchoperation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-type">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-type①">5.4.5. put(request, response)</a>
@@ -7594,8 +7594,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-cachebatchoperation-type③">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-type④">(2)</a> <a href="#ref-for-dom-cachebatchoperation-type⑤">(3)</a> <a href="#ref-for-dom-cachebatchoperation-type⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-request">
-   <b><a href="#dom-cachebatchoperation-request">#dom-cachebatchoperation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-request" class="dfn-panel" data-for="dom-cachebatchoperation-request" id="infopanel-for-dom-cachebatchoperation-request" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-request" style="display:none">Info about the 'request' definition.</span><b><a href="#dom-cachebatchoperation-request">#dom-cachebatchoperation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-request">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-request①">5.4.5. put(request, response)</a>
@@ -7603,23 +7603,23 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dom-cachebatchoperation-request③">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-request④">(2)</a> <a href="#ref-for-dom-cachebatchoperation-request⑤">(3)</a> <a href="#ref-for-dom-cachebatchoperation-request⑥">(4)</a> <a href="#ref-for-dom-cachebatchoperation-request⑦">(5)</a> <a href="#ref-for-dom-cachebatchoperation-request⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-response">
-   <b><a href="#dom-cachebatchoperation-response">#dom-cachebatchoperation-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-response" class="dfn-panel" data-for="dom-cachebatchoperation-response" id="infopanel-for-dom-cachebatchoperation-response" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dom-cachebatchoperation-response">#dom-cachebatchoperation-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-response">5.4.4. addAll(requests)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-response①">5.4.5. put(request, response)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-response②">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-response③">(2)</a> <a href="#ref-for-dom-cachebatchoperation-response④">(3)</a> <a href="#ref-for-dom-cachebatchoperation-response⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cachebatchoperation-options">
-   <b><a href="#dom-cachebatchoperation-options">#dom-cachebatchoperation-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cachebatchoperation-options" class="dfn-panel" data-for="dom-cachebatchoperation-options" id="infopanel-for-dom-cachebatchoperation-options" role="dialog">
+   <span id="infopaneltitle-for-dom-cachebatchoperation-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-cachebatchoperation-options">#dom-cachebatchoperation-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cachebatchoperation-options">5.4.6. delete(request, options)</a>
     <li><a href="#ref-for-dom-cachebatchoperation-options①">Batch Cache Operations</a> <a href="#ref-for-dom-cachebatchoperation-options②">(2)</a> <a href="#ref-for-dom-cachebatchoperation-options③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-interface">
-   <b><a href="#cache-interface">#cache-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-interface" class="dfn-panel" data-for="cache-interface" id="infopanel-for-cache-interface" role="dialog">
+   <span id="infopaneltitle-for-cache-interface" style="display:none">Info about the 'Cache' definition.</span><b><a href="#cache-interface">#cache-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-interface">4.7. Events</a>
     <li><a href="#ref-for-cache-interface①">5. Caches</a> <a href="#ref-for-cache-interface②">(2)</a>
@@ -7632,116 +7632,116 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-cache-interface①⑨">6.4. Cross-Origin Resources and CORS</a> <a href="#ref-for-cache-interface②⓪">(2)</a> <a href="#ref-for-cache-interface②①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-match-method">
-   <b><a href="#cache-match-method">#cache-match-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-match-method" class="dfn-panel" data-for="cache-match-method" id="infopanel-for-cache-match-method" role="dialog">
+   <span id="infopaneltitle-for-cache-match-method" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#cache-match-method">#cache-match-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-match-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-match-method①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-cache-match-method②">5.5.1. match(request, options)</a> <a href="#ref-for-cache-match-method③">(2)</a> <a href="#ref-for-cache-match-method④">(3)</a> <a href="#ref-for-cache-match-method⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-matchall-method">
-   <b><a href="#cache-matchall-method">#cache-matchall-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-matchall-method" class="dfn-panel" data-for="cache-matchall-method" id="infopanel-for-cache-matchall-method" role="dialog">
+   <span id="infopaneltitle-for-cache-matchall-method" style="display:none">Info about the 'matchAll(request, options)' definition.</span><b><a href="#cache-matchall-method">#cache-matchall-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-matchall-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-matchall-method①">5.4.1. match(request, options)</a>
     <li><a href="#ref-for-cache-matchall-method②">5.4.2. matchAll(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-add-method">
-   <b><a href="#cache-add-method">#cache-add-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-add-method" class="dfn-panel" data-for="cache-add-method" id="infopanel-for-cache-add-method" role="dialog">
+   <span id="infopaneltitle-for-cache-add-method" style="display:none">Info about the 'add(request)' definition.</span><b><a href="#cache-add-method">#cache-add-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-add-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-add-method①">5.4.3. add(request)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-addAll-method">
-   <b><a href="#cache-addAll-method">#cache-addAll-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-addAll-method" class="dfn-panel" data-for="cache-addAll-method" id="infopanel-for-cache-addAll-method" role="dialog">
+   <span id="infopaneltitle-for-cache-addAll-method" style="display:none">Info about the 'addAll(requests)' definition.</span><b><a href="#cache-addAll-method">#cache-addAll-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-addAll-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-addAll-method①">5.4.3. add(request)</a>
     <li><a href="#ref-for-cache-addAll-method②">5.4.4. addAll(requests)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-put-method">
-   <b><a href="#cache-put-method">#cache-put-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-put-method" class="dfn-panel" data-for="cache-put-method" id="infopanel-for-cache-put-method" role="dialog">
+   <span id="infopaneltitle-for-cache-put-method" style="display:none">Info about the 'put(request, response)' definition.</span><b><a href="#cache-put-method">#cache-put-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-put-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-put-method①">5.4.5. put(request, response)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-delete-method">
-   <b><a href="#cache-delete-method">#cache-delete-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-delete-method" class="dfn-panel" data-for="cache-delete-method" id="infopanel-for-cache-delete-method" role="dialog">
+   <span id="infopaneltitle-for-cache-delete-method" style="display:none">Info about the 'delete(request, options)' definition.</span><b><a href="#cache-delete-method">#cache-delete-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-delete-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-delete-method①">5.4.6. delete(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-keys-method">
-   <b><a href="#cache-keys-method">#cache-keys-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-keys-method" class="dfn-panel" data-for="cache-keys-method" id="infopanel-for-cache-keys-method" role="dialog">
+   <span id="infopaneltitle-for-cache-keys-method" style="display:none">Info about the 'keys(request, options)' definition.</span><b><a href="#cache-keys-method">#cache-keys-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-keys-method">5.4. Cache</a>
     <li><a href="#ref-for-cache-keys-method①">5.4.7. keys(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cachestorage-global-object">
-   <b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cachestorage-global-object" class="dfn-panel" data-for="cachestorage-global-object" id="infopanel-for-cachestorage-global-object" role="dialog">
+   <span id="infopaneltitle-for-cachestorage-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#cachestorage-global-object">#cachestorage-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cachestorage-global-object">5.5. CacheStorage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-interface">
-   <b><a href="#cache-storage-interface">#cache-storage-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-interface" class="dfn-panel" data-for="cache-storage-interface" id="infopanel-for-cache-storage-interface" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-interface" style="display:none">Info about the 'CacheStorage' definition.</span><b><a href="#cache-storage-interface">#cache-storage-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-interface">5.3. self.caches</a>
     <li><a href="#ref-for-cache-storage-interface①">5.3.1. caches</a>
     <li><a href="#ref-for-cache-storage-interface②">5.5. CacheStorage</a> <a href="#ref-for-cache-storage-interface③">(2)</a> <a href="#ref-for-cache-storage-interface④">(3)</a> <a href="#ref-for-cache-storage-interface⑤">(4)</a> <a href="#ref-for-cache-storage-interface⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-match-method">
-   <b><a href="#cache-storage-match-method">#cache-storage-match-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-match-method" class="dfn-panel" data-for="cache-storage-match-method" id="infopanel-for-cache-storage-match-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-match-method" style="display:none">Info about the 'match(request, options)' definition.</span><b><a href="#cache-storage-match-method">#cache-storage-match-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-match-method">5.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-match-method①">5.5.1. match(request, options)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-has-method">
-   <b><a href="#cache-storage-has-method">#cache-storage-has-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-has-method" class="dfn-panel" data-for="cache-storage-has-method" id="infopanel-for-cache-storage-has-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-has-method" style="display:none">Info about the 'has(cacheName)' definition.</span><b><a href="#cache-storage-has-method">#cache-storage-has-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-has-method">5.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-has-method①">5.5.2. has(cacheName)</a>
     <li><a href="#ref-for-cache-storage-has-method②">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-open-method">
-   <b><a href="#cache-storage-open-method">#cache-storage-open-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-open-method" class="dfn-panel" data-for="cache-storage-open-method" id="infopanel-for-cache-storage-open-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-open-method" style="display:none">Info about the 'open(cacheName)' definition.</span><b><a href="#cache-storage-open-method">#cache-storage-open-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-open-method">5.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-open-method①">5.5.3. open(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-delete-method">
-   <b><a href="#cache-storage-delete-method">#cache-storage-delete-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-delete-method" class="dfn-panel" data-for="cache-storage-delete-method" id="infopanel-for-cache-storage-delete-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-delete-method" style="display:none">Info about the 'delete(cacheName)' definition.</span><b><a href="#cache-storage-delete-method">#cache-storage-delete-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-delete-method">5.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-delete-method①">5.5.4. delete(cacheName)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-storage-keys-method">
-   <b><a href="#cache-storage-keys-method">#cache-storage-keys-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-storage-keys-method" class="dfn-panel" data-for="cache-storage-keys-method" id="infopanel-for-cache-storage-keys-method" role="dialog">
+   <span id="infopaneltitle-for-cache-storage-keys-method" style="display:none">Info about the 'keys()' definition.</span><b><a href="#cache-storage-keys-method">#cache-storage-keys-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-storage-keys-method">5.5. CacheStorage</a>
     <li><a href="#ref-for-cache-storage-keys-method①">5.5.5. keys()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="importscripts-method">
-   <b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-importscripts-method" class="dfn-panel" data-for="importscripts-method" id="infopanel-for-importscripts-method" role="dialog">
+   <span id="infopaneltitle-for-importscripts-method" style="display:none">Info about the 'importScripts(urls)' definition.</span><b><a href="#importscripts-method">#importscripts-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-importscripts-method">6.3.1. Origin restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-scope-to-registration-map">
-   <b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-scope-to-registration-map" class="dfn-panel" data-for="dfn-scope-to-registration-map" id="infopanel-for-dfn-scope-to-registration-map" role="dialog">
+   <span id="infopaneltitle-for-dfn-scope-to-registration-map" style="display:none">Info about the 'scope to registration map' definition.</span><b><a href="#dfn-scope-to-registration-map">#dfn-scope-to-registration-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.2.1. Lifetime</a>
     <li><a href="#ref-for-dfn-scope-to-registration-map">2.4. Selection and Use</a> <a href="#ref-for-dfn-scope-to-registration-map">(2)</a>
@@ -7756,8 +7756,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-scope-to-registration-map">Get Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job">
-   <b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job" class="dfn-panel" data-for="dfn-job" id="infopanel-for-dfn-job" role="dialog">
+   <span id="infopaneltitle-for-dfn-job" style="display:none">Info about the 'job' definition.</span><b><a href="#dfn-job">#dfn-job</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job">(2)</a> <a href="#ref-for-dfn-job">(3)</a> <a href="#ref-for-dfn-job">(4)</a> <a href="#ref-for-dfn-job">(5)</a> <a href="#ref-for-dfn-job">(6)</a> <a href="#ref-for-dfn-job">(7)</a> <a href="#ref-for-dfn-job">(8)</a> <a href="#ref-for-dfn-job">(9)</a> <a href="#ref-for-dfn-job">(10)</a> <a href="#ref-for-dfn-job">(11)</a> <a href="#ref-for-dfn-job">(12)</a> <a href="#ref-for-dfn-job">(13)</a> <a href="#ref-for-dfn-job">(14)</a> <a href="#ref-for-dfn-job">(15)</a>
     <li><a href="#ref-for-dfn-job">Create Job</a> <a href="#ref-for-dfn-job">(2)</a>
@@ -7771,8 +7771,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-type">
-   <b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-type" class="dfn-panel" data-for="dfn-job-type" id="infopanel-for-dfn-job-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-type" style="display:none">Info about the 'job type' definition.</span><b><a href="#dfn-job-type">#dfn-job-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-type">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-type">Create Job</a> <a href="#ref-for-dfn-job-type">(2)</a>
@@ -7780,8 +7780,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-type">Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-scope-url">
-   <b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-scope-url" class="dfn-panel" data-for="dfn-job-scope-url" id="infopanel-for-dfn-job-scope-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-scope-url" style="display:none">Info about the 'scope url' definition.</span><b><a href="#dfn-job-scope-url">#dfn-job-scope-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-scope-url">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-scope-url">(2)</a> <a href="#ref-for-dfn-job-scope-url">(3)</a>
     <li><a href="#ref-for-dfn-job-scope-url">Create Job</a>
@@ -7790,8 +7790,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-scope-url">Unregister</a> <a href="#ref-for-dfn-job-scope-url">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-script-url">
-   <b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-script-url" class="dfn-panel" data-for="dfn-job-script-url" id="infopanel-for-dfn-job-script-url" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-script-url" style="display:none">Info about the 'script url' definition.</span><b><a href="#dfn-job-script-url">#dfn-job-script-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-script-url">Appendix A: Algorithms</a>
     <li><a href="#ref-for-dfn-job-script-url">Create Job</a>
@@ -7799,16 +7799,16 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-script-url">Update</a> <a href="#ref-for-dfn-job-script-url">(2)</a> <a href="#ref-for-dfn-job-script-url">(3)</a> <a href="#ref-for-dfn-job-script-url">(4)</a> <a href="#ref-for-dfn-job-script-url">(5)</a> <a href="#ref-for-dfn-job-script-url">(6)</a> <a href="#ref-for-dfn-job-script-url">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-worker-type">
-   <b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-worker-type" class="dfn-panel" data-for="dfn-job-worker-type" id="infopanel-for-dfn-job-worker-type" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-worker-type" style="display:none">Info about the 'worker type' definition.</span><b><a href="#dfn-job-worker-type">#dfn-job-worker-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-worker-type">3.2.5. update()</a>
     <li><a href="#ref-for-dfn-job-worker-type①">Update</a> <a href="#ref-for-dfn-job-worker-type②">(2)</a>
     <li><a href="#ref-for-dfn-job-worker-type③">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-client">
-   <b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-client" class="dfn-panel" data-for="dfn-job-client" id="infopanel-for-dfn-job-client" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-client" style="display:none">Info about the 'client' definition.</span><b><a href="#dfn-job-client">#dfn-job-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-client">Create Job</a>
     <li><a href="#ref-for-dfn-job-client">Resolve Job Promise</a> <a href="#ref-for-dfn-job-client">(2)</a> <a href="#ref-for-dfn-job-client">(3)</a> <a href="#ref-for-dfn-job-client">(4)</a>
@@ -7818,8 +7818,8 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-client">Unregister</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-promise">
-   <b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-promise" class="dfn-panel" data-for="dfn-job-promise" id="infopanel-for-dfn-job-promise" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-promise" style="display:none">Info about the 'promise' definition.</span><b><a href="#dfn-job-promise">#dfn-job-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-promise">Create Job</a>
     <li><a href="#ref-for-dfn-job-promise">Schedule Job</a>
@@ -7828,28 +7828,28 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
     <li><a href="#ref-for-dfn-job-promise">Install</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs">
-   <b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" class="dfn-panel" data-for="dfn-job-list-of-equivalent-jobs" id="infopanel-for-dfn-job-list-of-equivalent-jobs" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-list-of-equivalent-jobs" style="display:none">Info about the 'list of equivalent jobs' definition.</span><b><a href="#dfn-job-list-of-equivalent-jobs">#dfn-job-list-of-equivalent-jobs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Schedule Job</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Resolve Job Promise</a>
     <li><a href="#ref-for-dfn-job-list-of-equivalent-jobs">Reject Job Promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag">
-   <b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-force-bypass-cache-flag" class="dfn-panel" data-for="dfn-job-force-bypass-cache-flag" id="infopanel-for-dfn-job-force-bypass-cache-flag" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-force-bypass-cache-flag" style="display:none">Info about the 'force bypass cache flag' definition.</span><b><a href="#dfn-job-force-bypass-cache-flag">#dfn-job-force-bypass-cache-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-force-bypass-cache-flag">Soft Update</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-equivalent">
-   <b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-equivalent" class="dfn-panel" data-for="dfn-job-equivalent" id="infopanel-for-dfn-job-equivalent" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-equivalent" style="display:none">Info about the 'equivalent' definition.</span><b><a href="#dfn-job-equivalent">#dfn-job-equivalent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-equivalent">Schedule Job</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-job-queue">
-   <b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-job-queue" class="dfn-panel" data-for="dfn-job-queue" id="infopanel-for-dfn-job-queue" role="dialog">
+   <span id="infopaneltitle-for-dfn-job-queue" style="display:none">Info about the 'job queue' definition.</span><b><a href="#dfn-job-queue">#dfn-job-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-job-queue">Appendix A: Algorithms</a> <a href="#ref-for-dfn-job-queue">(2)</a> <a href="#ref-for-dfn-job-queue">(3)</a> <a href="#ref-for-dfn-job-queue">(4)</a> <a href="#ref-for-dfn-job-queue">(5)</a> <a href="#ref-for-dfn-job-queue">(6)</a>
     <li><a href="#ref-for-dfn-job-queue">Schedule Job</a> <a href="#ref-for-dfn-job-queue">(2)</a> <a href="#ref-for-dfn-job-queue">(3)</a> <a href="#ref-for-dfn-job-queue">(4)</a>
@@ -7859,59 +7859,115 @@ navigator<c- p>.</c->serviceWorker<c- p>.</c->register<c- p>(</c-><c- u>"/foo/ba
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/accelerometer/index.html
+++ b/tests/github/w3c/accelerometer/index.html
@@ -1015,87 +1015,87 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#dom-accelerometerreadingvalues-z">dict-member for AccelerometerReadingValues</a><span>, in § 8.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-accelerometer">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-accelerometer">https://w3c.github.io/sensors/#dom-mocksensortype-accelerometer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-accelerometer" class="dfn-panel" data-for="term-for-dom-mocksensortype-accelerometer" id="infopanel-for-term-for-dom-mocksensortype-accelerometer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-accelerometer" style="display:none">Info about the '"accelerometer"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-accelerometer">https://w3c.github.io/sensors/#dom-mocksensortype-accelerometer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-accelerometer">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-gravity">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-gravity">https://w3c.github.io/sensors/#dom-mocksensortype-gravity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-gravity" class="dfn-panel" data-for="term-for-dom-mocksensortype-gravity" id="infopanel-for-term-for-dom-mocksensortype-gravity" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-gravity" style="display:none">Info about the '"gravity"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-gravity">https://w3c.github.io/sensors/#dom-mocksensortype-gravity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-gravity">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-linear-acceleration">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-linear-acceleration">https://w3c.github.io/sensors/#dom-mocksensortype-linear-acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-linear-acceleration" class="dfn-panel" data-for="term-for-dom-mocksensortype-linear-acceleration" id="infopanel-for-term-for-dom-mocksensortype-linear-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-linear-acceleration" style="display:none">Info about the '"linear-acceleration"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-linear-acceleration">https://w3c.github.io/sensors/#dom-mocksensortype-linear-acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-linear-acceleration">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">5. Model</a> <a href="#ref-for-sensor①">(2)</a>
     <li><a href="#ref-for-sensor②">6.1. The Accelerometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">6.1. The Accelerometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">8. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sensor">
-   <a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sensor" class="dfn-panel" data-for="term-for-default-sensor" id="infopanel-for-term-for-default-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sensor" style="display:none">Info about the 'default sensor' external reference.</span><a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sensor">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-device-fingerprinting">
-   <a href="https://w3c.github.io/sensors/#device-fingerprinting">https://w3c.github.io/sensors/#device-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-fingerprinting" class="dfn-panel" data-for="term-for-device-fingerprinting" id="infopanel-for-term-for-device-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-device-fingerprinting" style="display:none">Info about the 'fingerprinting' external reference.</span><a href="https://w3c.github.io/sensors/#device-fingerprinting">https://w3c.github.io/sensors/#device-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-fingerprinting">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
-   <a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mitigation-strategies" class="dfn-panel" data-for="term-for-mitigation-strategies" id="infopanel-for-term-for-mitigation-strategies" role="menu">
+   <span id="infopaneltitle-for-term-for-mitigation-strategies" style="display:none">Info about the 'generic mitigations' external reference.</span><a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mitigation-strategies">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keystroke-monitoring">
-   <a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keystroke-monitoring" class="dfn-panel" data-for="term-for-keystroke-monitoring" id="infopanel-for-term-for-keystroke-monitoring" role="menu">
+   <span id="infopaneltitle-for-term-for-keystroke-monitoring" style="display:none">Info about the 'keylogging' external reference.</span><a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keystroke-monitoring">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">5. Model</a> <a href="#ref-for-latest-reading①">(2)</a> <a href="#ref-for-latest-reading②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">1. Introduction</a>
     <li><a href="#ref-for-local-coordinate-system①">5. Model</a>
@@ -1103,143 +1103,143 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-local-coordinate-system③">7.1. Construct an accelerometer object</a> <a href="#ref-for-local-coordinate-system④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location-tracking">
-   <a href="https://w3c.github.io/sensors/#location-tracking">https://w3c.github.io/sensors/#location-tracking</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location-tracking" class="dfn-panel" data-for="term-for-location-tracking" id="infopanel-for-term-for-location-tracking" role="menu">
+   <span id="infopaneltitle-for-term-for-location-tracking" style="display:none">Info about the 'location tracking' external reference.</span><a href="https://w3c.github.io/sensors/#location-tracking">https://w3c.github.io/sensors/#location-tracking</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location-tracking">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">8.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-reading-values①">(2)</a> <a href="#ref-for-mock-sensor-reading-values②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">8.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-type①">(2)</a> <a href="#ref-for-mock-sensor-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-permission-names">
-   <a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-permission-names" class="dfn-panel" data-for="term-for-sensor-permission-names" id="infopanel-for-term-for-sensor-permission-names" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-permission-names" style="display:none">Info about the 'sensor permission name' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-reading">
-   <a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-reading" class="dfn-panel" data-for="term-for-sensor-reading" id="infopanel-for-term-for-sensor-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-reading" style="display:none">Info about the 'sensor readings' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-reading">4. Security and Privacy Considerations</a> <a href="#ref-for-sensor-reading①">(2)</a>
     <li><a href="#ref-for-sensor-reading②">5.1. Reference Frame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">5. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-sensor-options">
-   <a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-sensor-options" class="dfn-panel" data-for="term-for-supported-sensor-options" id="infopanel-for-term-for-supported-sensor-options" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-sensor-options" style="display:none">Info about the 'supported sensor options' external reference.</span><a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-sensor-options">6.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-supported-sensor-options①">6.2. The LinearAccelerationSensor Interface</a>
     <li><a href="#ref-for-supported-sensor-options②">6.3. The GravitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-identifying">
-   <a href="https://w3c.github.io/sensors/#user-identifying">https://w3c.github.io/sensors/#user-identifying</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-identifying" class="dfn-panel" data-for="term-for-user-identifying" id="infopanel-for-term-for-user-identifying" role="menu">
+   <span id="infopaneltitle-for-term-for-user-identifying" style="display:none">Info about the 'user identifying' external reference.</span><a href="https://w3c.github.io/sensors/#user-identifying">https://w3c.github.io/sensors/#user-identifying</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-identifying">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-orientation-type">
-   <a href="https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type">https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-orientation-type" class="dfn-panel" data-for="term-for-dfn-current-orientation-type" id="infopanel-for-term-for-dfn-current-orientation-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-orientation-type" style="display:none">Info about the 'current orientation type' external reference.</span><a href="https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type">https://www.w3.org/TR/screen-orientation/#dfn-current-orientation-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-orientation-type">5.1. Reference Frame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-screen">
-   <a href="https://www.w3.org/TR/screen-orientation/#dom-screen">https://www.w3.org/TR/screen-orientation/#dom-screen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-screen" class="dfn-panel" data-for="term-for-dom-screen" id="infopanel-for-term-for-dom-screen" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-screen" style="display:none">Info about the 'dom screen' external reference.</span><a href="https://www.w3.org/TR/screen-orientation/#dom-screen">https://www.w3.org/TR/screen-orientation/#dom-screen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen">2. Examples</a> <a href="#ref-for-dom-screen①">(2)</a>
     <li><a href="#ref-for-dom-screen②">5.1. Reference Frame</a> <a href="#ref-for-dom-screen③">(2)</a> <a href="#ref-for-dom-screen④">(3)</a> <a href="#ref-for-dom-screen⑤">(4)</a> <a href="#ref-for-dom-screen⑥">(5)</a> <a href="#ref-for-dom-screen⑦">(6)</a> <a href="#ref-for-dom-screen⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-Exposed①">6.2. The LinearAccelerationSensor Interface</a>
     <li><a href="#ref-for-Exposed②">6.3. The GravitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">6.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-SecureContext①">6.2. The LinearAccelerationSensor Interface</a>
     <li><a href="#ref-for-SecureContext②">6.3. The GravitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.1. The Accelerometer Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
     <li><a href="#ref-for-idl-double③">8.1. Mock Sensor Type</a> <a href="#ref-for-idl-double④">(2)</a> <a href="#ref-for-idl-double⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">7.1. Construct an accelerometer object</a> <a href="#ref-for-dfn-identifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherited-interfaces">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherited-interfaces" class="dfn-panel" data-for="term-for-dfn-inherited-interfaces" id="infopanel-for-term-for-dfn-inherited-interfaces" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherited-interfaces" style="display:none">Info about the 'inherited interfaces' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-interfaces">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface" class="dfn-panel" data-for="term-for-dfn-interface" id="infopanel-for-term-for-dfn-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface" style="display:none">Info about the 'interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface">7.1. Construct an accelerometer object</a> <a href="#ref-for-dfn-interface①">(2)</a> <a href="#ref-for-dfn-interface②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">7.1. Construct an accelerometer object</a>
    </ul>
@@ -1364,15 +1364,15 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="accelerometer-sensor-type">
-   <b><a href="#accelerometer-sensor-type">#accelerometer-sensor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accelerometer-sensor-type" class="dfn-panel" data-for="accelerometer-sensor-type" id="infopanel-for-accelerometer-sensor-type" role="dialog">
+   <span id="infopaneltitle-for-accelerometer-sensor-type" style="display:none">Info about the 'Accelerometer' definition.</span><b><a href="#accelerometer-sensor-type">#accelerometer-sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-sensor-type">5. Model</a> <a href="#ref-for-accelerometer-sensor-type①">(2)</a> <a href="#ref-for-accelerometer-sensor-type②">(3)</a>
     <li><a href="#ref-for-accelerometer-sensor-type③">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acceleration">
-   <b><a href="#acceleration">#acceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acceleration" class="dfn-panel" data-for="acceleration" id="infopanel-for-acceleration" role="dialog">
+   <span id="infopaneltitle-for-acceleration" style="display:none">Info about the 'acceleration' definition.</span><b><a href="#acceleration">#acceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration①">1. Introduction</a>
     <li><a href="#ref-for-acceleration②">5. Model</a> <a href="#ref-for-acceleration③">(2)</a> <a href="#ref-for-acceleration④">(3)</a> <a href="#ref-for-acceleration⑤">(4)</a> <a href="#ref-for-acceleration⑥">(5)</a> <a href="#ref-for-acceleration⑦">(6)</a>
@@ -1385,8 +1385,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-acceleration①④">8. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-acceleration">
-   <b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-acceleration" class="dfn-panel" data-for="linear-acceleration" id="infopanel-for-linear-acceleration" role="dialog">
+   <span id="infopaneltitle-for-linear-acceleration" style="display:none">Info about the 'linear acceleration' definition.</span><b><a href="#linear-acceleration">#linear-acceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration">5. Model</a> <a href="#ref-for-linear-acceleration①">(2)</a> <a href="#ref-for-linear-acceleration②">(3)</a>
     <li><a href="#ref-for-linear-acceleration③">6.2.1. LinearAccelerationSensor.x</a>
@@ -1394,8 +1394,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-linear-acceleration⑤">6.2.3. LinearAccelerationSensor.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gravity">
-   <b><a href="#gravity">#gravity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gravity" class="dfn-panel" data-for="gravity" id="infopanel-for-gravity" role="dialog">
+   <span id="infopaneltitle-for-gravity" style="display:none">Info about the 'gravity' definition.</span><b><a href="#gravity">#gravity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity">5. Model</a> <a href="#ref-for-gravity①">(2)</a> <a href="#ref-for-gravity②">(3)</a> <a href="#ref-for-gravity③">(4)</a>
     <li><a href="#ref-for-gravity④">6.3.1. GravitySensor.x</a>
@@ -1403,23 +1403,23 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-gravity⑥">6.3.3. GravitySensor.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="device-coordinate-system">
-   <b><a href="#device-coordinate-system">#device-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-device-coordinate-system" class="dfn-panel" data-for="device-coordinate-system" id="infopanel-for-device-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-device-coordinate-system" style="display:none">Info about the 'device coordinate system' definition.</span><b><a href="#device-coordinate-system">#device-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-coordinate-system">5.1. Reference Frame</a> <a href="#ref-for-device-coordinate-system①">(2)</a> <a href="#ref-for-device-coordinate-system②">(3)</a> <a href="#ref-for-device-coordinate-system③">(4)</a> <a href="#ref-for-device-coordinate-system④">(5)</a>
     <li><a href="#ref-for-device-coordinate-system⑤">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="screen-coordinate-system">
-   <b><a href="#screen-coordinate-system">#screen-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-screen-coordinate-system" class="dfn-panel" data-for="screen-coordinate-system" id="infopanel-for-screen-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-screen-coordinate-system" style="display:none">Info about the 'screen coordinate system' definition.</span><b><a href="#screen-coordinate-system">#screen-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screen-coordinate-system">2. Examples</a>
     <li><a href="#ref-for-screen-coordinate-system①">5.1. Reference Frame</a> <a href="#ref-for-screen-coordinate-system②">(2)</a> <a href="#ref-for-screen-coordinate-system③">(3)</a> <a href="#ref-for-screen-coordinate-system④">(4)</a>
     <li><a href="#ref-for-screen-coordinate-system⑤">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accelerometer">
-   <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accelerometer" class="dfn-panel" data-for="accelerometer" id="infopanel-for-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-accelerometer" style="display:none">Info about the 'Accelerometer' definition.</span><b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer①">1. Introduction</a>
     <li><a href="#ref-for-accelerometer②">5. Model</a> <a href="#ref-for-accelerometer③">(2)</a> <a href="#ref-for-accelerometer④">(3)</a>
@@ -1435,38 +1435,38 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-accelerometer①⑧">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometer-x">
-   <b><a href="#dom-accelerometer-x">#dom-accelerometer-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-accelerometer-x" class="dfn-panel" data-for="dom-accelerometer-x" id="infopanel-for-dom-accelerometer-x" role="dialog">
+   <span id="infopaneltitle-for-dom-accelerometer-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-accelerometer-x">#dom-accelerometer-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-x">6.1.1. Accelerometer.x</a>
     <li><a href="#ref-for-dom-accelerometer-x①">6.2.1. LinearAccelerationSensor.x</a>
     <li><a href="#ref-for-dom-accelerometer-x②">6.3.1. GravitySensor.x</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometer-y">
-   <b><a href="#dom-accelerometer-y">#dom-accelerometer-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-accelerometer-y" class="dfn-panel" data-for="dom-accelerometer-y" id="infopanel-for-dom-accelerometer-y" role="dialog">
+   <span id="infopaneltitle-for-dom-accelerometer-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-accelerometer-y">#dom-accelerometer-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-y">6.1.2. Accelerometer.y</a>
     <li><a href="#ref-for-dom-accelerometer-y①">6.2.2. LinearAccelerationSensor.y</a>
     <li><a href="#ref-for-dom-accelerometer-y②">6.3.2. GravitySensor.y</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometer-z">
-   <b><a href="#dom-accelerometer-z">#dom-accelerometer-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-accelerometer-z" class="dfn-panel" data-for="dom-accelerometer-z" id="infopanel-for-dom-accelerometer-z" role="dialog">
+   <span id="infopaneltitle-for-dom-accelerometer-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-accelerometer-z">#dom-accelerometer-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometer-z">6.1.3. Accelerometer.z</a>
     <li><a href="#ref-for-dom-accelerometer-z①">6.2.3. LinearAccelerationSensor.z</a>
     <li><a href="#ref-for-dom-accelerometer-z②">6.3.3. GravitySensor.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-accelerometerlocalcoordinatesystem">
-   <b><a href="#enumdef-accelerometerlocalcoordinatesystem">#enumdef-accelerometerlocalcoordinatesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-accelerometerlocalcoordinatesystem" class="dfn-panel" data-for="enumdef-accelerometerlocalcoordinatesystem" id="infopanel-for-enumdef-accelerometerlocalcoordinatesystem" role="dialog">
+   <span id="infopaneltitle-for-enumdef-accelerometerlocalcoordinatesystem" style="display:none">Info about the 'AccelerometerLocalCoordinateSystem' definition.</span><b><a href="#enumdef-accelerometerlocalcoordinatesystem">#enumdef-accelerometerlocalcoordinatesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-accelerometerlocalcoordinatesystem">6.1. The Accelerometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-accelerometersensoroptions">
-   <b><a href="#dictdef-accelerometersensoroptions">#dictdef-accelerometersensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-accelerometersensoroptions" class="dfn-panel" data-for="dictdef-accelerometersensoroptions" id="infopanel-for-dictdef-accelerometersensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-accelerometersensoroptions" style="display:none">Info about the 'AccelerometerSensorOptions' definition.</span><b><a href="#dictdef-accelerometersensoroptions">#dictdef-accelerometersensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-accelerometersensoroptions">6.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-dictdef-accelerometersensoroptions①">6.2. The LinearAccelerationSensor Interface</a>
@@ -1474,14 +1474,14 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-dictdef-accelerometersensoroptions③">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-accelerometersensoroptions-referenceframe">
-   <b><a href="#dom-accelerometersensoroptions-referenceframe">#dom-accelerometersensoroptions-referenceframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-accelerometersensoroptions-referenceframe" class="dfn-panel" data-for="dom-accelerometersensoroptions-referenceframe" id="infopanel-for-dom-accelerometersensoroptions-referenceframe" role="dialog">
+   <span id="infopaneltitle-for-dom-accelerometersensoroptions-referenceframe" style="display:none">Info about the 'referenceFrame' definition.</span><b><a href="#dom-accelerometersensoroptions-referenceframe">#dom-accelerometersensoroptions-referenceframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-accelerometersensoroptions-referenceframe">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linearaccelerationsensor">
-   <b><a href="#linearaccelerationsensor">#linearaccelerationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linearaccelerationsensor" class="dfn-panel" data-for="linearaccelerationsensor" id="infopanel-for-linearaccelerationsensor" role="dialog">
+   <span id="infopaneltitle-for-linearaccelerationsensor" style="display:none">Info about the 'LinearAccelerationSensor' definition.</span><b><a href="#linearaccelerationsensor">#linearaccelerationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor①">1. Introduction</a>
     <li><a href="#ref-for-linearaccelerationsensor②">5. Model</a> <a href="#ref-for-linearaccelerationsensor③">(2)</a>
@@ -1494,8 +1494,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-linearaccelerationsensor①②">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gravitysensor">
-   <b><a href="#gravitysensor">#gravitysensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gravitysensor" class="dfn-panel" data-for="gravitysensor" id="infopanel-for-gravitysensor" role="dialog">
+   <span id="infopaneltitle-for-gravitysensor" style="display:none">Info about the 'GravitySensor' definition.</span><b><a href="#gravitysensor">#gravitysensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor①">1. Introduction</a>
     <li><a href="#ref-for-gravitysensor②">5. Model</a> <a href="#ref-for-gravitysensor③">(2)</a>
@@ -1508,8 +1508,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-gravitysensor①②">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-an-accelerometer-object">
-   <b><a href="#construct-an-accelerometer-object">#construct-an-accelerometer-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-an-accelerometer-object" class="dfn-panel" data-for="construct-an-accelerometer-object" id="infopanel-for-construct-an-accelerometer-object" role="dialog">
+   <span id="infopaneltitle-for-construct-an-accelerometer-object" style="display:none">Info about the '7.1. Construct an accelerometer object' definition.</span><b><a href="#construct-an-accelerometer-object">#construct-an-accelerometer-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-an-accelerometer-object">6.1. The Accelerometer Interface</a>
     <li><a href="#ref-for-construct-an-accelerometer-object①">6.2. The LinearAccelerationSensor Interface</a>
@@ -1517,67 +1517,123 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-construct-an-accelerometer-object">7.1. Construct an accelerometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-accelerometerreadingvalues">
-   <b><a href="#dictdef-accelerometerreadingvalues">#dictdef-accelerometerreadingvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-accelerometerreadingvalues" class="dfn-panel" data-for="dictdef-accelerometerreadingvalues" id="infopanel-for-dictdef-accelerometerreadingvalues" role="dialog">
+   <span id="infopaneltitle-for-dictdef-accelerometerreadingvalues" style="display:none">Info about the 'AccelerometerReadingValues' definition.</span><b><a href="#dictdef-accelerometerreadingvalues">#dictdef-accelerometerreadingvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-accelerometerreadingvalues">8.1. Mock Sensor Type</a> <a href="#ref-for-dictdef-accelerometerreadingvalues①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/ambient-light/index.html
+++ b/tests/github/w3c/ambient-light/index.html
@@ -937,143 +937,143 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#dom-ambientlightreadingvalues-illuminance">dict-member for AmbientLightReadingValues</a><span>, in § 7.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-ambient-light">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-ambient-light">https://w3c.github.io/sensors/#dom-mocksensortype-ambient-light</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-ambient-light" class="dfn-panel" data-for="term-for-dom-mocksensortype-ambient-light" id="infopanel-for-term-for-dom-mocksensortype-ambient-light" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-ambient-light" style="display:none">Info about the '"ambient-light"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-ambient-light">https://w3c.github.io/sensors/#dom-mocksensortype-ambient-light</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-ambient-light">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">4. Model</a>
     <li><a href="#ref-for-sensor①">5.1. The AmbientLightSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">5.1. The AmbientLightSensor Interface</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">6.1. Construct an ambient light sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">6.1. Construct an ambient light sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sensor">
-   <a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sensor" class="dfn-panel" data-for="term-for-default-sensor" id="infopanel-for-term-for-default-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sensor" style="display:none">Info about the 'default sensor' external reference.</span><a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sensor">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-high-level">
-   <a href="https://w3c.github.io/sensors/#high-level">https://w3c.github.io/sensors/#high-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-high-level" class="dfn-panel" data-for="term-for-high-level" id="infopanel-for-term-for-high-level" role="menu">
+   <span id="infopaneltitle-for-term-for-high-level" style="display:none">Info about the 'high-level' external reference.</span><a href="https://w3c.github.io/sensors/#high-level">https://w3c.github.io/sensors/#high-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-level">1.1. Scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">6.1. Construct an ambient light sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-limit-max-frequency">
-   <a href="https://w3c.github.io/sensors/#limit-max-frequency">https://w3c.github.io/sensors/#limit-max-frequency</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-limit-max-frequency" class="dfn-panel" data-for="term-for-limit-max-frequency" id="infopanel-for-term-for-limit-max-frequency" role="menu">
+   <span id="infopaneltitle-for-term-for-limit-max-frequency" style="display:none">Info about the 'limit maximum sampling frequency' external reference.</span><a href="https://w3c.github.io/sensors/#limit-max-frequency">https://w3c.github.io/sensors/#limit-max-frequency</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limit-max-frequency">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
-   <a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mitigation-strategies" class="dfn-panel" data-for="term-for-mitigation-strategies" id="infopanel-for-term-for-mitigation-strategies" role="menu">
+   <span id="infopaneltitle-for-term-for-mitigation-strategies" style="display:none">Info about the 'mitigation strategies' external reference.</span><a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mitigation-strategies">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reduce-accuracy">
-   <a href="https://w3c.github.io/sensors/#reduce-accuracy">https://w3c.github.io/sensors/#reduce-accuracy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reduce-accuracy" class="dfn-panel" data-for="term-for-reduce-accuracy" id="infopanel-for-term-for-reduce-accuracy" role="menu">
+   <span id="infopaneltitle-for-term-for-reduce-accuracy" style="display:none">Info about the 'reduce accuracy' external reference.</span><a href="https://w3c.github.io/sensors/#reduce-accuracy">https://w3c.github.io/sensors/#reduce-accuracy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reduce-accuracy">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sampling-frequency">
-   <a href="https://w3c.github.io/sensors/#sampling-frequency">https://w3c.github.io/sensors/#sampling-frequency</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sampling-frequency" class="dfn-panel" data-for="term-for-sampling-frequency" id="infopanel-for-term-for-sampling-frequency" role="menu">
+   <span id="infopaneltitle-for-term-for-sampling-frequency" style="display:none">Info about the 'sampling frequency' external reference.</span><a href="https://w3c.github.io/sensors/#sampling-frequency">https://w3c.github.io/sensors/#sampling-frequency</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sampling-frequency">8. Use Cases and Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-permission-names">
-   <a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-permission-names" class="dfn-panel" data-for="term-for-sensor-permission-names" id="infopanel-for-term-for-sensor-permission-names" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-permission-names" style="display:none">Info about the 'sensor permission name' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-reading">
-   <a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-reading" class="dfn-panel" data-for="term-for-sensor-reading" id="infopanel-for-term-for-sensor-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-reading" style="display:none">Info about the 'sensor reading' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-reading">2. Examples</a> <a href="#ref-for-sensor-reading①">(2)</a> <a href="#ref-for-sensor-reading②">(3)</a> <a href="#ref-for-sensor-reading③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1. Construct an ambient light sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The AmbientLightSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. The AmbientLightSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">6.1. Construct an ambient light sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5.1. The AmbientLightSensor Interface</a>
     <li><a href="#ref-for-idl-double①">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1. Construct an ambient light sensor object</a>
    </ul>
@@ -1143,21 +1143,21 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="ambient-light-sensor">
-   <b><a href="#ambient-light-sensor">#ambient-light-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ambient-light-sensor" class="dfn-panel" data-for="ambient-light-sensor" id="infopanel-for-ambient-light-sensor" role="dialog">
+   <span id="infopaneltitle-for-ambient-light-sensor" style="display:none">Info about the 'Ambient Light Sensor' definition.</span><b><a href="#ambient-light-sensor">#ambient-light-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ambient-light-sensor">4. Model</a> <a href="#ref-for-ambient-light-sensor①">(2)</a>
     <li><a href="#ref-for-ambient-light-sensor②">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-light-level">
-   <b><a href="#current-light-level">#current-light-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-light-level" class="dfn-panel" data-for="current-light-level" id="infopanel-for-current-light-level" role="dialog">
+   <span id="infopaneltitle-for-current-light-level" style="display:none">Info about the 'current light level' definition.</span><b><a href="#current-light-level">#current-light-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-light-level">5.1.1. The illuminance attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ambientlightsensor">
-   <b><a href="#ambientlightsensor">#ambientlightsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ambientlightsensor" class="dfn-panel" data-for="ambientlightsensor" id="infopanel-for-ambientlightsensor" role="dialog">
+   <span id="infopaneltitle-for-ambientlightsensor" style="display:none">Info about the 'AmbientLightSensor' definition.</span><b><a href="#ambientlightsensor">#ambientlightsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ambientlightsensor">4. Model</a>
     <li><a href="#ref-for-ambientlightsensor①">5.1. The AmbientLightSensor Interface</a>
@@ -1166,15 +1166,15 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-ambientlightsensor⑥">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-ambientlightsensor-illuminance">
-   <b><a href="#dom-ambientlightsensor-illuminance">#dom-ambientlightsensor-illuminance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-ambientlightsensor-illuminance" class="dfn-panel" data-for="dom-ambientlightsensor-illuminance" id="infopanel-for-dom-ambientlightsensor-illuminance" role="dialog">
+   <span id="infopaneltitle-for-dom-ambientlightsensor-illuminance" style="display:none">Info about the 'illuminance' definition.</span><b><a href="#dom-ambientlightsensor-illuminance">#dom-ambientlightsensor-illuminance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-ambientlightsensor-illuminance">2. Examples</a>
     <li><a href="#ref-for-dom-ambientlightsensor-illuminance①">5.1.1. The illuminance attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-an-ambient-light-sensor-object">
-   <b><a href="#construct-an-ambient-light-sensor-object">#construct-an-ambient-light-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-an-ambient-light-sensor-object" class="dfn-panel" data-for="construct-an-ambient-light-sensor-object" id="infopanel-for-construct-an-ambient-light-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-construct-an-ambient-light-sensor-object" style="display:none">Info about the '6.1. Construct an ambient light sensor object' definition.</span><b><a href="#construct-an-ambient-light-sensor-object">#construct-an-ambient-light-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-an-ambient-light-sensor-object">5.1. The AmbientLightSensor Interface</a>
     <li><a href="#ref-for-construct-an-ambient-light-sensor-object">6.1. Construct an ambient light sensor object</a>
@@ -1182,59 +1182,115 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/clipboard-apis/index.html
+++ b/tests/github/w3c/clipboard-apis/index.html
@@ -2763,146 +2763,146 @@ HTML code.</p>
    <li><a href="#dom-clipboard-write">write(data)</a><span>, in § 7.2</span>
    <li><a href="#dom-clipboard-writetext">writeText(data)</a><span>, in § 7.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-show-a-popup">
-   <a href="http://www.w3.org/TR/html5/browsers.html#allowed-to-show-a-popup">http://www.w3.org/TR/html5/browsers.html#allowed-to-show-a-popup</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-show-a-popup" class="dfn-panel" data-for="term-for-allowed-to-show-a-popup" id="infopanel-for-term-for-allowed-to-show-a-popup" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-show-a-popup" style="display:none">Info about the 'allowed to show a popup' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#allowed-to-show-a-popup">http://www.w3.org/TR/html5/browsers.html#allowed-to-show-a-popup</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-show-a-popup">5.3.1. Event handlers that are allowed to modify the clipboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-blobparts">
-   <a href="https://w3c.github.io/FileAPI/#dfn-blobparts">https://w3c.github.io/FileAPI/#dfn-blobparts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-blobparts" class="dfn-panel" data-for="term-for-dfn-blobparts" id="infopanel-for-term-for-dfn-blobparts" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-blobparts" style="display:none">Info about the 'blobparts' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-blobparts">https://w3c.github.io/FileAPI/#dfn-blobparts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-blobparts">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-p">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-p">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-p" class="dfn-panel" data-for="term-for-concept-dnd-p" id="infopanel-for-term-for-concept-dnd-p" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-p" style="display:none">Info about the 'concept dnd p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-p">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-p">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-ro">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-ro" class="dfn-panel" data-for="term-for-concept-dnd-ro" id="infopanel-for-term-for-concept-dnd-ro" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-ro" style="display:none">Info about the 'concept dnd ro' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-ro</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-ro">6.3. Overriding the paste event</a>
     <li><a href="#ref-for-concept-dnd-ro①">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-dnd-rw">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-dnd-rw" class="dfn-panel" data-for="term-for-concept-dnd-rw" id="infopanel-for-term-for-concept-dnd-rw" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-dnd-rw" style="display:none">Info about the 'concept dnd rw' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw">https://html.spec.whatwg.org/multipage/interaction.html#concept-dnd-rw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dnd-rw">fire a clipboard event</a> <a href="#ref-for-concept-dnd-rw①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constructing-events">
-   <a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructing-events" class="dfn-panel" data-for="term-for-constructing-events" id="infopanel-for-term-for-constructing-events" role="menu">
+   <span id="infopaneltitle-for-term-for-constructing-events" style="display:none">Info about the 'constructing events' external reference.</span><a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructing-events">5.1. Clipboard event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-denied">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-denied">https://w3c.github.io/permissions/#dom-permissionstate-denied</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-denied" class="dfn-panel" data-for="term-for-dom-permissionstate-denied" id="infopanel-for-term-for-dom-permissionstate-denied" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-denied" style="display:none">Info about the 'denied' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-denied">https://w3c.github.io/permissions/#dom-permissionstate-denied</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-denied">9. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drag-data-item-kind">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-kind">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drag-data-item-kind" class="dfn-panel" data-for="term-for-drag-data-item-kind" id="infopanel-for-term-for-drag-data-item-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-drag-data-item-kind" style="display:none">Info about the 'drag data item kind' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-kind">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drag-data-item-kind">fire a clipboard event</a> <a href="#ref-for-drag-data-item-kind①">(2)</a> <a href="#ref-for-drag-data-item-kind②">(3)</a>
     <li><a href="#ref-for-drag-data-item-kind③">process an HTML paste event</a> <a href="#ref-for-drag-data-item-kind④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drag-data-item-type-string">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-type-string">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-type-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drag-data-item-type-string" class="dfn-panel" data-for="term-for-drag-data-item-type-string" id="infopanel-for-term-for-drag-data-item-type-string" role="menu">
+   <span id="infopaneltitle-for-term-for-drag-data-item-type-string" style="display:none">Info about the 'drag data item type string' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-type-string">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-item-type-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drag-data-item-type-string">fire a clipboard event</a> <a href="#ref-for-drag-data-item-type-string①">(2)</a> <a href="#ref-for-drag-data-item-type-string②">(3)</a> <a href="#ref-for-drag-data-item-type-string③">(4)</a>
     <li><a href="#ref-for-drag-data-item-type-string④">process an HTML paste event</a> <a href="#ref-for-drag-data-item-type-string⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drag-data-store-mode">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-mode">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drag-data-store-mode" class="dfn-panel" data-for="term-for-drag-data-store-mode" id="infopanel-for-term-for-drag-data-store-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-drag-data-store-mode" style="display:none">Info about the 'drag data store mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-mode">https://html.spec.whatwg.org/multipage/interaction.html#drag-data-store-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drag-data-store-mode">6.3. Overriding the paste event</a>
     <li><a href="#ref-for-drag-data-store-mode①">fire a clipboard event</a> <a href="#ref-for-drag-data-store-mode②">(2)</a> <a href="#ref-for-drag-data-store-mode③">(3)</a> <a href="#ref-for-drag-data-store-mode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-editing-host">
-   <a href="http://w3c.github.io/editing/contentEditable.html#dfn-editing-host">http://w3c.github.io/editing/contentEditable.html#dfn-editing-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-editing-host" class="dfn-panel" data-for="term-for-dfn-editing-host" id="infopanel-for-term-for-dfn-editing-host" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-editing-host" style="display:none">Info about the 'editing host' external reference.</span><a href="http://w3c.github.io/editing/contentEditable.html#dfn-editing-host">http://w3c.github.io/editing/contentEditable.html#dfn-editing-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-editing-host">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusable-area">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#focusable-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusable-area" class="dfn-panel" data-for="term-for-focusable-area" id="infopanel-for-term-for-focusable-area" role="menu">
+   <span id="infopaneltitle-for-term-for-focusable-area" style="display:none">Info about the 'focusable area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#focusable-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusable-area">5.3.5. Event listeners that modify selection or focus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">9.2.1. check clipboard write permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element-2">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element-2" class="dfn-panel" data-for="term-for-the-body-element-2" id="infopanel-for-term-for-the-body-element-2" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element-2" style="display:none">Info about the 'the body element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element-2">fire a clipboard event</a> <a href="#ref-for-the-body-element-2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">7.2.4. writeText(data)</a> <a href="#ref-for-dfn-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.1. Clipboard event interfaces</a> <a href="#ref-for-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">5.1. Clipboard event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-composed">
-   <a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-composed" class="dfn-panel" data-for="term-for-dom-event-composed" id="infopanel-for-term-for-dom-event-composed" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-composed" style="display:none">Info about the 'composed' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-composed">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cd-data">
-   <a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cd-data" class="dfn-panel" data-for="term-for-concept-cd-data" id="infopanel-for-term-for-concept-cd-data" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cd-data" style="display:none">Info about the 'data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-data">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
-   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-preventdefault" class="dfn-panel" data-for="term-for-dom-event-preventdefault" id="infopanel-for-term-for-dom-event-preventdefault" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-preventdefault" style="display:none">Info about the 'preventDefault()' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">6.1. Overriding the copy event</a>
     <li><a href="#ref-for-dom-event-preventdefault①">6.2. Overriding the cut event</a>
     <li><a href="#ref-for-dom-event-preventdefault②">6.3. Overriding the paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://tc39.github.io/ecma262/#sec-promise-objects">http://tc39.github.io/ecma262/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">7.2.1. read()</a>
     <li><a href="#ref-for-sec-promise-objects①">7.2.2. readText()</a>
@@ -2910,34 +2910,34 @@ HTML code.</p>
     <li><a href="#ref-for-sec-promise-objects③">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">7.2. Clipboard Interface</a> <a href="#ref-for-dfn-Blob①">(2)</a>
     <li><a href="#ref-for-dfn-Blob②">7.2.3. write(data)</a> <a href="#ref-for-dfn-Blob③">(2)</a>
     <li><a href="#ref-for-dfn-Blob④">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">process an HTML paste event</a> <a href="#ref-for-dfn-file①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-lastModified">
-   <a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-lastModified" class="dfn-panel" data-for="term-for-dfn-lastModified" id="infopanel-for-term-for-dfn-lastModified" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-lastModified" style="display:none">Info about the 'lastModified' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-lastModified">https://w3c.github.io/FileAPI/#dfn-lastModified</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-lastModified">process an HTML paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">process an HTML paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransfer">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransfer" class="dfn-panel" data-for="term-for-datatransfer" id="infopanel-for-term-for-datatransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransfer" style="display:none">Info about the 'DataTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransfer">https://html.spec.whatwg.org/multipage/dnd.html#datatransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransfer">4. Model</a>
     <li><a href="#ref-for-datatransfer①">5.1. Clipboard event interfaces</a> <a href="#ref-for-datatransfer②">(2)</a> <a href="#ref-for-datatransfer③">(3)</a> <a href="#ref-for-datatransfer④">(4)</a>
@@ -2949,15 +2949,15 @@ HTML code.</p>
     <li><a href="#ref-for-datatransfer①③">process an HTML paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransferitem">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransferitem" class="dfn-panel" data-for="term-for-datatransferitem" id="infopanel-for-term-for-datatransferitem" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransferitem" style="display:none">Info about the 'DataTransferItem' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransferitem">fire a clipboard event</a> <a href="#ref-for-datatransferitem①">(2)</a> <a href="#ref-for-datatransferitem②">(3)</a>
     <li><a href="#ref-for-datatransferitem③">process an HTML paste event</a> <a href="#ref-for-datatransferitem④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datatransferitemlist">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datatransferitemlist" class="dfn-panel" data-for="term-for-datatransferitemlist" id="infopanel-for-term-for-datatransferitemlist" role="menu">
+   <span id="infopaneltitle-for-term-for-datatransferitemlist" style="display:none">Info about the 'DataTransferItemList' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist">https://html.spec.whatwg.org/multipage/dnd.html#datatransferitemlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datatransferitemlist">6.4. Mandatory data types</a>
     <li><a href="#ref-for-datatransferitemlist①">8.1. The copy action</a>
@@ -2968,41 +2968,41 @@ HTML code.</p>
     <li><a href="#ref-for-datatransferitemlist⑦">process an HTML paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">7.1. Navigator Interface</a>
     <li><a href="#ref-for-navigator①">7.1.1. clipboard</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransferitemlist-clear">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransferitemlist-clear" class="dfn-panel" data-for="term-for-dom-datatransferitemlist-clear" id="infopanel-for-term-for-dom-datatransferitemlist-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransferitemlist-clear" style="display:none">Info about the 'clear()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransferitemlist-clear">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-cleardata">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-cleardata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-cleardata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-cleardata" class="dfn-panel" data-for="term-for-dom-datatransfer-cleardata" id="infopanel-for-term-for-dom-datatransfer-cleardata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-cleardata" style="display:none">Info about the 'clearData(format)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-cleardata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-cleardata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-cleardata">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-files">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-files" class="dfn-panel" data-for="term-for-dom-datatransfer-files" id="infopanel-for-term-for-dom-datatransfer-files" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-files" style="display:none">Info about the 'files' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-files">5.1. Clipboard event interfaces</a>
     <li><a href="#ref-for-dom-datatransfer-files①">10.2. General security policies</a>
     <li><a href="#ref-for-dom-datatransfer-files②">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-getdata">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-getdata" class="dfn-panel" data-for="term-for-dom-datatransfer-getdata" id="infopanel-for-term-for-dom-datatransfer-getdata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-getdata" style="display:none">Info about the 'getData(format)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-getdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-getdata">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">7.2.1. read()</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">7.2.2. readText()</a> <a href="#ref-for-in-parallel③">(2)</a>
@@ -3010,8 +3010,8 @@ HTML code.</p>
     <li><a href="#ref-for-in-parallel⑥">7.2.4. writeText(data)</a> <a href="#ref-for-in-parallel⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-items">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-items" class="dfn-panel" data-for="term-for-dom-datatransfer-items" id="infopanel-for-term-for-dom-datatransfer-items" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-items" style="display:none">Info about the 'items' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-items">5.1. Clipboard event interfaces</a>
     <li><a href="#ref-for-dom-datatransfer-items①">6. Clipboard Event API</a>
@@ -3019,138 +3019,138 @@ HTML code.</p>
     <li><a href="#ref-for-dom-datatransfer-items⑧">process an HTML paste event</a> <a href="#ref-for-dom-datatransfer-items⑨">(2)</a> <a href="#ref-for-dom-datatransfer-items①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">9.1.1. check clipboard read permission</a>
     <li><a href="#ref-for-concept-relevant-global①">9.2.1. check clipboard write permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-setdata">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-setdata" class="dfn-panel" data-for="term-for-dom-datatransfer-setdata" id="infopanel-for-term-for-dom-datatransfer-setdata" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-setdata" style="display:none">Info about the 'setData(format, data)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdata">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-setdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-setdata">6.3. Overriding the paste event</a>
     <li><a href="#ref-for-dom-datatransfer-setdata①">write content to the clipboard</a>
     <li><a href="#ref-for-dom-datatransfer-setdata②">fire a clipboard event</a> <a href="#ref-for-dom-datatransfer-setdata③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">9.1.1. check clipboard read permission</a>
     <li><a href="#ref-for-transient-activation①">9.2.1. check clipboard write permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-datatransfer-types">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-datatransfer-types" class="dfn-panel" data-for="term-for-dom-datatransfer-types" id="infopanel-for-term-for-dom-datatransfer-types" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-datatransfer-types" style="display:none">Info about the 'types' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types">https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datatransfer-types">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">9. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-descriptor-type" class="dfn-panel" data-for="term-for-dfn-permission-descriptor-type" id="infopanel-for-term-for-dfn-permission-descriptor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-descriptor-type">https://w3c.github.io/permissions/#dfn-permission-descriptor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-descriptor-type">9. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">9.2.1. check clipboard write permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">1. Introduction</a>
     <li><a href="#ref-for-dfn-powerful-feature①">9. Permissions API Integration</a> <a href="#ref-for-dfn-powerful-feature②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">9.2.1. check clipboard write permission</a> <a href="#ref-for-dfn-request-permission-to-use①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5.1. Clipboard event interfaces</a>
     <li><a href="#ref-for-idl-DOMString①">7.2. Clipboard Interface</a> <a href="#ref-for-idl-DOMString②">(2)</a> <a href="#ref-for-idl-DOMString③">(3)</a> <a href="#ref-for-idl-DOMString④">(4)</a> <a href="#ref-for-idl-DOMString⑤">(5)</a> <a href="#ref-for-idl-DOMString⑥">(6)</a> <a href="#ref-for-idl-DOMString⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. Clipboard event interfaces</a>
     <li><a href="#ref-for-Exposed①">7.2. Clipboard Interface</a> <a href="#ref-for-Exposed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">7.2. Clipboard Interface</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a> <a href="#ref-for-idl-promise④">(5)</a> <a href="#ref-for-idl-promise⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">7.1. Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">7.1. Navigator Interface</a>
     <li><a href="#ref-for-SecureContext①">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.2. Clipboard Interface</a>
     <li><a href="#ref-for-idl-boolean①">9. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long-long" class="dfn-panel" data-for="term-for-idl-long-long" id="infopanel-for-term-for-idl-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long-long" style="display:none">Info about the 'long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">7.2. Clipboard Interface</a> <a href="#ref-for-idl-record①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">9.1.1. check clipboard read permission</a>
     <li><a href="#ref-for-this①">9.2.1. check clipboard write permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">7.2. Clipboard Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
@@ -3344,8 +3344,8 @@ references? <a class="issue-return" href="#issue-096a5049" title="Jump to sectio
    <div class="issue"> This feature is at risk because it’s unclear whether it is
 required, and because it’s hard to test in a cross-platform way. <a class="issue-return" href="#issue-6be1122f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="editable-context">
-   <b><a href="#editable-context">#editable-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editable-context" class="dfn-panel" data-for="editable-context" id="infopanel-for-editable-context" role="dialog">
+   <span id="infopaneltitle-for-editable-context" style="display:none">Info about the 'editable context' definition.</span><b><a href="#editable-context">#editable-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editable-context">5.2.3. The cut event</a> <a href="#ref-for-editable-context①">(2)</a>
     <li><a href="#ref-for-editable-context②">5.2.4. The paste event</a> <a href="#ref-for-editable-context③">(2)</a>
@@ -3353,8 +3353,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-editable-context⑤">8.3. The paste action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="system-clipboard">
-   <b><a href="#system-clipboard">#system-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-system-clipboard" class="dfn-panel" data-for="system-clipboard" id="infopanel-for-system-clipboard" role="dialog">
+   <span id="infopaneltitle-for-system-clipboard" style="display:none">Info about the 'system clipboard' definition.</span><b><a href="#system-clipboard">#system-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-system-clipboard">4. Model</a>
     <li><a href="#ref-for-system-clipboard①">5.2.1. The clipboardchange event</a> <a href="#ref-for-system-clipboard②">(2)</a>
@@ -3365,8 +3365,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-system-clipboard⑨">6.3. Overriding the paste event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="system-clipboard-data">
-   <b><a href="#system-clipboard-data">#system-clipboard-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-system-clipboard-data" class="dfn-panel" data-for="system-clipboard-data" id="infopanel-for-system-clipboard-data" role="dialog">
+   <span id="infopaneltitle-for-system-clipboard-data" style="display:none">Info about the 'system clipboard data' definition.</span><b><a href="#system-clipboard-data">#system-clipboard-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-system-clipboard-data">4. Model</a> <a href="#ref-for-system-clipboard-data①">(2)</a>
     <li><a href="#ref-for-system-clipboard-data②">7.2.1. read()</a>
@@ -3375,14 +3375,14 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-system-clipboard-data⑤">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clipboardeventinit">
-   <b><a href="#dictdef-clipboardeventinit">#dictdef-clipboardeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clipboardeventinit" class="dfn-panel" data-for="dictdef-clipboardeventinit" id="infopanel-for-dictdef-clipboardeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clipboardeventinit" style="display:none">Info about the 'ClipboardEventInit' definition.</span><b><a href="#dictdef-clipboardeventinit">#dictdef-clipboardeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clipboardeventinit">5.1. Clipboard event interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clipboardevent">
-   <b><a href="#clipboardevent">#clipboardevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipboardevent" class="dfn-panel" data-for="clipboardevent" id="infopanel-for-clipboardevent" role="dialog">
+   <span id="infopaneltitle-for-clipboardevent" style="display:none">Info about the 'ClipboardEvent' definition.</span><b><a href="#clipboardevent">#clipboardevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipboardevent">6. Clipboard Event API</a> <a href="#ref-for-clipboardevent①">(2)</a>
     <li><a href="#ref-for-clipboardevent②">6.1. Overriding the copy event</a>
@@ -3390,8 +3390,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-clipboardevent④">fire a clipboard event</a> <a href="#ref-for-clipboardevent⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clipboardevent-clipboarddata">
-   <b><a href="#dom-clipboardevent-clipboarddata">#dom-clipboardevent-clipboarddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clipboardevent-clipboarddata" class="dfn-panel" data-for="dom-clipboardevent-clipboarddata" id="infopanel-for-dom-clipboardevent-clipboarddata" role="dialog">
+   <span id="infopaneltitle-for-dom-clipboardevent-clipboarddata" style="display:none">Info about the 'clipboardData' definition.</span><b><a href="#dom-clipboardevent-clipboarddata">#dom-clipboardevent-clipboarddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clipboardevent-clipboarddata">5.2.3. The cut event</a>
     <li><a href="#ref-for-dom-clipboardevent-clipboarddata①">6. Clipboard Event API</a>
@@ -3400,8 +3400,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-dom-clipboardevent-clipboarddata④">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clipboardchange">
-   <b><a href="#clipboardchange">#clipboardchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipboardchange" class="dfn-panel" data-for="clipboardchange" id="infopanel-for-clipboardchange" role="dialog">
+   <span id="infopaneltitle-for-clipboardchange" style="display:none">Info about the 'clipboardchange' definition.</span><b><a href="#clipboardchange">#clipboardchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipboardchange">2.2. Remote Clipboard Synchronization</a>
     <li><a href="#ref-for-clipboardchange①">5.2.1. The clipboardchange event</a> <a href="#ref-for-clipboardchange②">(2)</a>
@@ -3409,8 +3409,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-clipboardchange④">8.2. The cut action</a> <a href="#ref-for-clipboardchange⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="copy">
-   <b><a href="#copy">#copy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-copy" class="dfn-panel" data-for="copy" id="infopanel-for-copy" role="dialog">
+   <span id="infopaneltitle-for-copy" style="display:none">Info about the 'copy' definition.</span><b><a href="#copy">#copy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-copy">5.2.1. The clipboardchange event</a>
     <li><a href="#ref-for-copy①">5.2.2. The copy event</a> <a href="#ref-for-copy②">(2)</a> <a href="#ref-for-copy③">(3)</a>
@@ -3419,8 +3419,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-copy⑦">8.1. The copy action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cut">
-   <b><a href="#cut">#cut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cut" class="dfn-panel" data-for="cut" id="infopanel-for-cut" role="dialog">
+   <span id="infopaneltitle-for-cut" style="display:none">Info about the 'cut' definition.</span><b><a href="#cut">#cut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cut">5.2.1. The clipboardchange event</a>
     <li><a href="#ref-for-cut①">5.2.3. The cut event</a> <a href="#ref-for-cut②">(2)</a> <a href="#ref-for-cut③">(3)</a> <a href="#ref-for-cut④">(4)</a> <a href="#ref-for-cut⑤">(5)</a>
@@ -3429,8 +3429,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-cut①⓪">8.2. The cut action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paste">
-   <b><a href="#paste">#paste</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paste" class="dfn-panel" data-for="paste" id="infopanel-for-paste" role="dialog">
+   <span id="infopaneltitle-for-paste" style="display:none">Info about the 'paste' definition.</span><b><a href="#paste">#paste</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paste">5.2.4. The paste event</a> <a href="#ref-for-paste①">(2)</a> <a href="#ref-for-paste②">(3)</a> <a href="#ref-for-paste③">(4)</a>
     <li><a href="#ref-for-paste④">5.3.2. Event handlers that are allowed to read from clipboard</a>
@@ -3438,64 +3438,64 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-paste⑨">8.3. The paste action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-to-modify-the-clipboard">
-   <b><a href="#allowed-to-modify-the-clipboard">#allowed-to-modify-the-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-to-modify-the-clipboard" class="dfn-panel" data-for="allowed-to-modify-the-clipboard" id="infopanel-for-allowed-to-modify-the-clipboard" role="dialog">
+   <span id="infopaneltitle-for-allowed-to-modify-the-clipboard" style="display:none">Info about the 'allowed to modify the clipboard' definition.</span><b><a href="#allowed-to-modify-the-clipboard">#allowed-to-modify-the-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-modify-the-clipboard">8. Clipboard Actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-to-read-from-clipboard">
-   <b><a href="#allowed-to-read-from-clipboard">#allowed-to-read-from-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-to-read-from-clipboard" class="dfn-panel" data-for="allowed-to-read-from-clipboard" id="infopanel-for-allowed-to-read-from-clipboard" role="dialog">
+   <span id="infopaneltitle-for-allowed-to-read-from-clipboard" style="display:none">Info about the 'allowed to read from clipboard' definition.</span><b><a href="#allowed-to-read-from-clipboard">#allowed-to-read-from-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-read-from-clipboard">8. Clipboard Actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mandatory-data-types">
-   <b><a href="#mandatory-data-types">#mandatory-data-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mandatory-data-types" class="dfn-panel" data-for="mandatory-data-types" id="infopanel-for-mandatory-data-types" role="dialog">
+   <span id="infopaneltitle-for-mandatory-data-types" style="display:none">Info about the 'Mandatory data types' definition.</span><b><a href="#mandatory-data-types">#mandatory-data-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mandatory-data-types">5.1. Clipboard event interfaces</a>
     <li><a href="#ref-for-mandatory-data-types①">write content to the clipboard</a> <a href="#ref-for-mandatory-data-types②">(2)</a>
     <li><a href="#ref-for-mandatory-data-types③">fire a clipboard event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigator-clipboard">
-   <b><a href="#navigator-clipboard">#navigator-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigator-clipboard" class="dfn-panel" data-for="navigator-clipboard" id="infopanel-for-navigator-clipboard" role="dialog">
+   <span id="infopaneltitle-for-navigator-clipboard" style="display:none">Info about the 'clipboard' definition.</span><b><a href="#navigator-clipboard">#navigator-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-clipboard">7.1.1. clipboard</a> <a href="#ref-for-navigator-clipboard①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-clipboarditems">
-   <b><a href="#typedefdef-clipboarditems">#typedefdef-clipboarditems</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-clipboarditems" class="dfn-panel" data-for="typedefdef-clipboarditems" id="infopanel-for-typedefdef-clipboarditems" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-clipboarditems" style="display:none">Info about the 'ClipboardItems' definition.</span><b><a href="#typedefdef-clipboarditems">#typedefdef-clipboarditems</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-clipboarditems">7.2. Clipboard Interface</a> <a href="#ref-for-typedefdef-clipboarditems①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clipboard">
-   <b><a href="#clipboard">#clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipboard" class="dfn-panel" data-for="clipboard" id="infopanel-for-clipboard" role="dialog">
+   <span id="infopaneltitle-for-clipboard" style="display:none">Info about the 'Clipboard' definition.</span><b><a href="#clipboard">#clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipboard">7.1. Navigator Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-clipboarditemdatatype">
-   <b><a href="#typedefdef-clipboarditemdatatype">#typedefdef-clipboarditemdatatype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-clipboarditemdatatype" class="dfn-panel" data-for="typedefdef-clipboarditemdatatype" id="infopanel-for-typedefdef-clipboarditemdatatype" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-clipboarditemdatatype" style="display:none">Info about the 'ClipboardItemDataType' definition.</span><b><a href="#typedefdef-clipboarditemdatatype">#typedefdef-clipboarditemdatatype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-clipboarditemdatatype">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-clipboarditemdata">
-   <b><a href="#typedefdef-clipboarditemdata">#typedefdef-clipboarditemdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-clipboarditemdata" class="dfn-panel" data-for="typedefdef-clipboarditemdata" id="infopanel-for-typedefdef-clipboarditemdata" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-clipboarditemdata" style="display:none">Info about the 'ClipboardItemData' definition.</span><b><a href="#typedefdef-clipboarditemdata">#typedefdef-clipboarditemdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-clipboarditemdata">7.2. Clipboard Interface</a> <a href="#ref-for-typedefdef-clipboarditemdata①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-clipboarditemdelayedcallback">
-   <b><a href="#callbackdef-clipboarditemdelayedcallback">#callbackdef-clipboarditemdelayedcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-clipboarditemdelayedcallback" class="dfn-panel" data-for="callbackdef-clipboarditemdelayedcallback" id="infopanel-for-callbackdef-clipboarditemdelayedcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-clipboarditemdelayedcallback" style="display:none">Info about the 'ClipboardItemDelayedCallback' definition.</span><b><a href="#callbackdef-clipboarditemdelayedcallback">#callbackdef-clipboarditemdelayedcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-clipboarditemdelayedcallback">7.2. Clipboard Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clipboarditem">
-   <b><a href="#clipboarditem">#clipboarditem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipboarditem" class="dfn-panel" data-for="clipboarditem" id="infopanel-for-clipboarditem" role="dialog">
+   <span id="infopaneltitle-for-clipboarditem" style="display:none">Info about the 'ClipboardItem' definition.</span><b><a href="#clipboarditem">#clipboarditem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipboarditem">4. Model</a>
     <li><a href="#ref-for-clipboarditem①">7.2. Clipboard Interface</a> <a href="#ref-for-clipboarditem②">(2)</a>
@@ -3503,50 +3503,50 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-clipboarditem④">7.2.4. writeText(data)</a> <a href="#ref-for-clipboarditem⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-presentationstyle">
-   <b><a href="#enumdef-presentationstyle">#enumdef-presentationstyle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-presentationstyle" class="dfn-panel" data-for="enumdef-presentationstyle" id="infopanel-for-enumdef-presentationstyle" role="dialog">
+   <span id="infopaneltitle-for-enumdef-presentationstyle" style="display:none">Info about the 'PresentationStyle' definition.</span><b><a href="#enumdef-presentationstyle">#enumdef-presentationstyle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-presentationstyle">7.2. Clipboard Interface</a> <a href="#ref-for-enumdef-presentationstyle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clipboarditemoptions">
-   <b><a href="#dictdef-clipboarditemoptions">#dictdef-clipboarditemoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clipboarditemoptions" class="dfn-panel" data-for="dictdef-clipboarditemoptions" id="infopanel-for-dictdef-clipboarditemoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clipboarditemoptions" style="display:none">Info about the 'ClipboardItemOptions' definition.</span><b><a href="#dictdef-clipboarditemoptions">#dictdef-clipboarditemoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clipboarditemoptions">7.2. Clipboard Interface</a> <a href="#ref-for-dictdef-clipboarditemoptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clipboard-read">
-   <b><a href="#dom-clipboard-read">#dom-clipboard-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clipboard-read" class="dfn-panel" data-for="dom-clipboard-read" id="infopanel-for-dom-clipboard-read" role="dialog">
+   <span id="infopaneltitle-for-dom-clipboard-read" style="display:none">Info about the '7.2.1. read()' definition.</span><b><a href="#dom-clipboard-read">#dom-clipboard-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clipboard-read">2.2. Remote Clipboard Synchronization</a>
     <li><a href="#ref-for-dom-clipboard-read①">7.2. Clipboard Interface</a>
     <li><a href="#ref-for-dom-clipboard-read">7.2.1. read()</a> <a href="#ref-for-dom-clipboard-read②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clipboard-readtext">
-   <b><a href="#dom-clipboard-readtext">#dom-clipboard-readtext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clipboard-readtext" class="dfn-panel" data-for="dom-clipboard-readtext" id="infopanel-for-dom-clipboard-readtext" role="dialog">
+   <span id="infopaneltitle-for-dom-clipboard-readtext" style="display:none">Info about the '7.2.2. readText()' definition.</span><b><a href="#dom-clipboard-readtext">#dom-clipboard-readtext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clipboard-readtext">7.2. Clipboard Interface</a>
     <li><a href="#ref-for-dom-clipboard-readtext">7.2.2. readText()</a> <a href="#ref-for-dom-clipboard-readtext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clipboard-write">
-   <b><a href="#dom-clipboard-write">#dom-clipboard-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clipboard-write" class="dfn-panel" data-for="dom-clipboard-write" id="infopanel-for-dom-clipboard-write" role="dialog">
+   <span id="infopaneltitle-for-dom-clipboard-write" style="display:none">Info about the '7.2.3. write(data)' definition.</span><b><a href="#dom-clipboard-write">#dom-clipboard-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clipboard-write">2.2. Remote Clipboard Synchronization</a>
     <li><a href="#ref-for-dom-clipboard-write①">7.2. Clipboard Interface</a>
     <li><a href="#ref-for-dom-clipboard-write">7.2.3. write(data)</a> <a href="#ref-for-dom-clipboard-write②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-clipboard-writetext">
-   <b><a href="#dom-clipboard-writetext">#dom-clipboard-writetext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-clipboard-writetext" class="dfn-panel" data-for="dom-clipboard-writetext" id="infopanel-for-dom-clipboard-writetext" role="dialog">
+   <span id="infopaneltitle-for-dom-clipboard-writetext" style="display:none">Info about the '7.2.4. writeText(data)' definition.</span><b><a href="#dom-clipboard-writetext">#dom-clipboard-writetext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-clipboard-writetext">7.2. Clipboard Interface</a>
     <li><a href="#ref-for-dom-clipboard-writetext">7.2.4. writeText(data)</a> <a href="#ref-for-dom-clipboard-writetext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-triggered">
-   <b><a href="#script-triggered">#script-triggered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-triggered" class="dfn-panel" data-for="script-triggered" id="infopanel-for-script-triggered" role="dialog">
+   <span id="infopaneltitle-for-script-triggered" style="display:none">Info about the 'script-triggered' definition.</span><b><a href="#script-triggered">#script-triggered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-triggered">8. Clipboard Actions</a> <a href="#ref-for-script-triggered①">(2)</a>
     <li><a href="#ref-for-script-triggered②">8.1. The copy action</a>
@@ -3554,8 +3554,8 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-script-triggered④">8.3. The paste action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-may-access-clipboard">
-   <b><a href="#script-may-access-clipboard">#script-may-access-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-may-access-clipboard" class="dfn-panel" data-for="script-may-access-clipboard" id="infopanel-for-script-may-access-clipboard" role="dialog">
+   <span id="infopaneltitle-for-script-may-access-clipboard" style="display:none">Info about the 'script-may-access-clipboard' definition.</span><b><a href="#script-may-access-clipboard">#script-may-access-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-may-access-clipboard">8. Clipboard Actions</a> <a href="#ref-for-script-may-access-clipboard①">(2)</a> <a href="#ref-for-script-may-access-clipboard②">(3)</a>
     <li><a href="#ref-for-script-may-access-clipboard③">8.1. The copy action</a>
@@ -3563,35 +3563,35 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-script-may-access-clipboard⑤">8.3. The paste action</a> <a href="#ref-for-script-may-access-clipboard⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-clipboardpermissiondescriptor">
-   <b><a href="#dictdef-clipboardpermissiondescriptor">#dictdef-clipboardpermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-clipboardpermissiondescriptor" class="dfn-panel" data-for="dictdef-clipboardpermissiondescriptor" id="infopanel-for-dictdef-clipboardpermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-clipboardpermissiondescriptor" style="display:none">Info about the 'ClipboardPermissionDescriptor' definition.</span><b><a href="#dictdef-clipboardpermissiondescriptor">#dictdef-clipboardpermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-clipboardpermissiondescriptor">9. Permissions API Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-clipboard-read-permission">
-   <b><a href="#check-clipboard-read-permission">#check-clipboard-read-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-clipboard-read-permission" class="dfn-panel" data-for="check-clipboard-read-permission" id="infopanel-for-check-clipboard-read-permission" role="dialog">
+   <span id="infopaneltitle-for-check-clipboard-read-permission" style="display:none">Info about the 'check clipboard read permission' definition.</span><b><a href="#check-clipboard-read-permission">#check-clipboard-read-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-clipboard-read-permission">7.2.1. read()</a>
     <li><a href="#ref-for-check-clipboard-read-permission①">7.2.2. readText()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-clipboard-write-permission">
-   <b><a href="#check-clipboard-write-permission">#check-clipboard-write-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-clipboard-write-permission" class="dfn-panel" data-for="check-clipboard-write-permission" id="infopanel-for-check-clipboard-write-permission" role="dialog">
+   <span id="infopaneltitle-for-check-clipboard-write-permission" style="display:none">Info about the 'check clipboard write permission' definition.</span><b><a href="#check-clipboard-write-permission">#check-clipboard-write-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-clipboard-write-permission">7.2.3. write(data)</a>
     <li><a href="#ref-for-check-clipboard-write-permission①">7.2.4. writeText(data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="write-content-to-the-clipboard">
-   <b><a href="#write-content-to-the-clipboard">#write-content-to-the-clipboard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-write-content-to-the-clipboard" class="dfn-panel" data-for="write-content-to-the-clipboard" id="infopanel-for-write-content-to-the-clipboard" role="dialog">
+   <span id="infopaneltitle-for-write-content-to-the-clipboard" style="display:none">Info about the 'write content to the clipboard' definition.</span><b><a href="#write-content-to-the-clipboard">#write-content-to-the-clipboard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-write-content-to-the-clipboard">8.1. The copy action</a>
     <li><a href="#ref-for-write-content-to-the-clipboard①">8.2. The cut action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-clipboard-event">
-   <b><a href="#fire-a-clipboard-event">#fire-a-clipboard-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-clipboard-event" class="dfn-panel" data-for="fire-a-clipboard-event" id="infopanel-for-fire-a-clipboard-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-clipboard-event" style="display:none">Info about the 'fire a clipboard event' definition.</span><b><a href="#fire-a-clipboard-event">#fire-a-clipboard-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-clipboard-event">5.2.2. The copy event</a>
     <li><a href="#ref-for-fire-a-clipboard-event①">5.2.3. The cut event</a>
@@ -3601,67 +3601,123 @@ required, and because it’s hard to test in a cross-platform way. <a class="iss
     <li><a href="#ref-for-fire-a-clipboard-event">8.3. The paste action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-an-html-paste-event">
-   <b><a href="#process-an-html-paste-event">#process-an-html-paste-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-an-html-paste-event" class="dfn-panel" data-for="process-an-html-paste-event" id="infopanel-for-process-an-html-paste-event" role="dialog">
+   <span id="infopaneltitle-for-process-an-html-paste-event" style="display:none">Info about the 'process an HTML paste event' definition.</span><b><a href="#process-an-html-paste-event">#process-an-html-paste-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-an-html-paste-event">fire a clipboard event</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/css-houdini-drafts/box-tree-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/box-tree-api/Overview.html
@@ -2309,50 +2309,50 @@ an element generates multiple fragment trees, the element that generates a least
    <li><a href="#dom-deadfragmentinformation-top">top</a><span>, in § 3</span>
    <li><a href="#dom-deadfragmentinformation-width">width</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3. API</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a>
    </ul>
@@ -2418,71 +2418,127 @@ an element generates multiple fragment trees, the element that generates a least
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="deadfragmentinformation">
-   <b><a href="#deadfragmentinformation">#deadfragmentinformation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deadfragmentinformation" class="dfn-panel" data-for="deadfragmentinformation" id="infopanel-for-deadfragmentinformation" role="dialog">
+   <span id="infopaneltitle-for-deadfragmentinformation" style="display:none">Info about the 'DeadFragmentInformation' definition.</span><b><a href="#deadfragmentinformation">#deadfragmentinformation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deadfragmentinformation">3. API</a> <a href="#ref-for-deadfragmentinformation①">(2)</a> <a href="#ref-for-deadfragmentinformation②">(3)</a> <a href="#ref-for-deadfragmentinformation③">(4)</a> <a href="#ref-for-deadfragmentinformation④">(5)</a> <a href="#ref-for-deadfragmentinformation⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fragmentfilter">
-   <b><a href="#enumdef-fragmentfilter">#enumdef-fragmentfilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fragmentfilter" class="dfn-panel" data-for="enumdef-fragmentfilter" id="infopanel-for-enumdef-fragmentfilter" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fragmentfilter" style="display:none">Info about the 'FragmentFilter' definition.</span><b><a href="#enumdef-fragmentfilter">#enumdef-fragmentfilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fragmentfilter">3. API</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/css-houdini-drafts/css-animation-worklet-1/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-animation-worklet-1/Overview.html
@@ -1878,20 +1878,20 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
    <li><a href="#workletanimationeffect">WorkletAnimationEffect</a><span>, in § 3.5</span>
    <li><a href="#workletgroupeffect">WorkletGroupEffect</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-scrolltimeline">
-   <a href="https://wicg.github.io/scroll-animations/#scrolltimeline">https://wicg.github.io/scroll-animations/#scrolltimeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrolltimeline" class="dfn-panel" data-for="term-for-scrolltimeline" id="infopanel-for-term-for-scrolltimeline" role="menu">
+   <span id="infopaneltitle-for-term-for-scrolltimeline" style="display:none">Info about the 'ScrollTimeline' external reference.</span><a href="https://wicg.github.io/scroll-animations/#scrolltimeline">https://wicg.github.io/scroll-animations/#scrolltimeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrolltimeline">6.2. ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active">
-   <a href="https://drafts.csswg.org/web-animations#active">https://drafts.csswg.org/web-animations#active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active" class="dfn-panel" data-for="term-for-active" id="infopanel-for-term-for-active" role="menu">
+   <span id="infopaneltitle-for-term-for-active" style="display:none">Info about the 'active' external reference.</span><a href="https://drafts.csswg.org/web-animations#active">https://drafts.csswg.org/web-animations#active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-animation">
-   <a href="https://drafts.csswg.org/web-animations#concept-animation">https://drafts.csswg.org/web-animations#concept-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-animation" class="dfn-panel" data-for="term-for-concept-animation" id="infopanel-for-term-for-concept-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/web-animations#concept-animation">https://drafts.csswg.org/web-animations#concept-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-animation">3. Animator</a>
     <li><a href="#ref-for-concept-animation①">5.1. Worklet Animation</a> <a href="#ref-for-concept-animation②">(2)</a>
@@ -1899,14 +1899,14 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-concept-animation④">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-class">
-   <a href="https://drafts.csswg.org/web-animations#animation-class">https://drafts.csswg.org/web-animations#animation-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-class" class="dfn-panel" data-for="term-for-animation-class" id="infopanel-for-term-for-animation-class" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-class" style="display:none">Info about the 'animation class' external reference.</span><a href="https://drafts.csswg.org/web-animations#animation-class">https://drafts.csswg.org/web-animations#animation-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-class">5.5. Effect Stack and Composite Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations#animation-effect">https://drafts.csswg.org/web-animations#animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-effect" class="dfn-panel" data-for="term-for-animation-effect" id="infopanel-for-term-for-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-effect" style="display:none">Info about the 'animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations#animation-effect">https://drafts.csswg.org/web-animations#animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect">1. Introduction</a>
     <li><a href="#ref-for-animation-effect①">3. Animator</a>
@@ -1917,144 +1917,144 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-animation-effect⑧">6.1. Worklet Group Effect</a> <a href="#ref-for-animation-effect⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-this-value">
-   <a href="https://heycam.github.io/webidl/#dfn-callback-this-value">https://heycam.github.io/webidl/#dfn-callback-this-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-this-value" class="dfn-panel" data-for="term-for-dfn-callback-this-value" id="infopanel-for-term-for-dfn-callback-this-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-callback-this-value">https://heycam.github.io/webidl/#dfn-callback-this-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">4.2. Running Animators</a>
     <li><a href="#ref-for-dfn-callback-this-value①">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-child-effect">
-   <a href="https://w3c.github.io/web-animations/level-2/#child-effect">https://w3c.github.io/web-animations/level-2/#child-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-child-effect" class="dfn-panel" data-for="term-for-child-effect" id="infopanel-for-term-for-child-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-child-effect" style="display:none">Info about the 'child effect' external reference.</span><a href="https://w3c.github.io/web-animations/level-2/#child-effect">https://w3c.github.io/web-animations/level-2/#child-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-effect">6.1. Worklet Group Effect</a> <a href="#ref-for-child-effect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-construct-a-callback-function">
-   <a href="https://heycam.github.io/webidl/#construct-a-callback-function">https://heycam.github.io/webidl/#construct-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-construct-a-callback-function" class="dfn-panel" data-for="term-for-construct-a-callback-function" id="infopanel-for-term-for-construct-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-construct-a-callback-function" style="display:none">Info about the 'constructing' external reference.</span><a href="https://heycam.github.io/webidl/#construct-a-callback-function">https://heycam.github.io/webidl/#construct-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-callback-function">4.1. Creating an Animator Instance</a> <a href="#ref-for-construct-a-callback-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-es-type-mapping">
-   <a href="https://heycam.github.io/webidl/#es-type-mapping">https://heycam.github.io/webidl/#es-type-mapping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-es-type-mapping" class="dfn-panel" data-for="term-for-es-type-mapping" id="infopanel-for-term-for-es-type-mapping" role="menu">
+   <span id="infopaneltitle-for-term-for-es-type-mapping" style="display:none">Info about the 'converting' external reference.</span><a href="https://heycam.github.io/webidl/#es-type-mapping">https://heycam.github.io/webidl/#es-type-mapping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-es-type-mapping">3.4. Registering an Animator Definition</a> <a href="#ref-for-es-type-mapping①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-time">
-   <a href="https://drafts.csswg.org/web-animations#current-time">https://drafts.csswg.org/web-animations#current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-time" class="dfn-panel" data-for="term-for-current-time" id="infopanel-for-term-for-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-current-time" style="display:none">Info about the 'current time' external reference.</span><a href="https://drafts.csswg.org/web-animations#current-time">https://drafts.csswg.org/web-animations#current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">4.5. Requesting Animation Frames</a> <a href="#ref-for-current-time①">(2)</a>
     <li><a href="#ref-for-current-time②">5.1. Worklet Animation</a>
     <li><a href="#ref-for-current-time③">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-current-time④">(2)</a> <a href="#ref-for-current-time⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-documents-default-timeline">
-   <a href="https://drafts.csswg.org/web-animations#the-documents-default-timeline">https://drafts.csswg.org/web-animations#the-documents-default-timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-documents-default-timeline" class="dfn-panel" data-for="term-for-the-documents-default-timeline" id="infopanel-for-term-for-the-documents-default-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-the-documents-default-timeline" style="display:none">Info about the 'default document timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations#the-documents-default-timeline">https://drafts.csswg.org/web-animations#the-documents-default-timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-documents-default-timeline">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-effect-stack">
-   <a href="https://drafts.csswg.org/web-animations#effect-stack">https://drafts.csswg.org/web-animations#effect-stack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-effect-stack" class="dfn-panel" data-for="term-for-effect-stack" id="infopanel-for-term-for-effect-stack" role="menu">
+   <span id="infopaneltitle-for-term-for-effect-stack" style="display:none">Info about the 'effect stack' external reference.</span><a href="https://drafts.csswg.org/web-animations#effect-stack">https://drafts.csswg.org/web-animations#effect-stack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-stack">5.5. Effect Stack and Composite Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-effect-value">
-   <a href="https://drafts.csswg.org/web-animations#effect-value">https://drafts.csswg.org/web-animations#effect-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-effect-value" class="dfn-panel" data-for="term-for-effect-value" id="infopanel-for-term-for-effect-value" role="menu">
+   <span id="infopaneltitle-for-term-for-effect-value" style="display:none">Info about the 'effect value' external reference.</span><a href="https://drafts.csswg.org/web-animations#effect-value">https://drafts.csswg.org/web-animations#effect-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-value">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-end-delay">
-   <a href="https://drafts.csswg.org/web-animations#end-delay">https://drafts.csswg.org/web-animations#end-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-end-delay" class="dfn-panel" data-for="term-for-end-delay" id="infopanel-for-term-for-end-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-end-delay" style="display:none">Info about the 'end delay' external reference.</span><a href="https://drafts.csswg.org/web-animations#end-delay">https://drafts.csswg.org/web-animations#end-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-delay">3.5. Animator Effect</a>
     <li><a href="#ref-for-end-delay①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fill-mode">
-   <a href="https://drafts.csswg.org/web-animations#fill-mode">https://drafts.csswg.org/web-animations#fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fill-mode" class="dfn-panel" data-for="term-for-fill-mode" id="infopanel-for-term-for-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-fill-mode" style="display:none">Info about the 'fill mode' external reference.</span><a href="https://drafts.csswg.org/web-animations#fill-mode">https://drafts.csswg.org/web-animations#fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-mode">3.5. Animator Effect</a>
     <li><a href="#ref-for-fill-mode①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-finished">
-   <a href="https://drafts.csswg.org/web-animations#finished">https://drafts.csswg.org/web-animations#finished</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-finished" class="dfn-panel" data-for="term-for-finished" id="infopanel-for-term-for-finished" role="menu">
+   <span id="infopaneltitle-for-term-for-finished" style="display:none">Info about the 'finished' external reference.</span><a href="https://drafts.csswg.org/web-animations#finished">https://drafts.csswg.org/web-animations#finished</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finished">5.4. Web Animations Overrides</a> <a href="#ref-for-finished①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Function">
-   <a href="https://heycam.github.io/webidl/#Function">https://heycam.github.io/webidl/#Function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Function" class="dfn-panel" data-for="term-for-Function" id="infopanel-for-term-for-Function" role="menu">
+   <span id="infopaneltitle-for-term-for-Function" style="display:none">Info about the 'function' external reference.</span><a href="https://heycam.github.io/webidl/#Function">https://heycam.github.io/webidl/#Function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Function">3.3. Animator Definition</a> <a href="#ref-for-Function①">(2)</a>
     <li><a href="#ref-for-Function②">3.4. Registering an Animator Definition</a> <a href="#ref-for-Function③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">3.4. Registering an Animator Definition</a> <a href="#ref-for-sec-get-o-p①">(2)</a> <a href="#ref-for-sec-get-o-p②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-group-effect">
-   <a href="https://w3c.github.io/web-animations/level-2/#group-effect">https://w3c.github.io/web-animations/level-2/#group-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-group-effect" class="dfn-panel" data-for="term-for-group-effect" id="infopanel-for-term-for-group-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-group-effect" style="display:none">Info about the 'group effect' external reference.</span><a href="https://w3c.github.io/web-animations/level-2/#group-effect">https://w3c.github.io/web-animations/level-2/#group-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group-effect">6.1. Worklet Group Effect</a> <a href="#ref-for-group-effect①">(2)</a> <a href="#ref-for-group-effect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idle">
-   <a href="https://drafts.csswg.org/web-animations#idle">https://drafts.csswg.org/web-animations#idle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idle" class="dfn-panel" data-for="term-for-idle" id="infopanel-for-term-for-idle" role="menu">
+   <span id="infopaneltitle-for-term-for-idle" style="display:none">Info about the 'idle' external reference.</span><a href="https://drafts.csswg.org/web-animations#idle">https://drafts.csswg.org/web-animations#idle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle">5.4. Web Animations Overrides</a> <a href="#ref-for-idle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-time">
-   <a href="https://drafts.csswg.org/web-animations#inherited-time">https://drafts.csswg.org/web-animations#inherited-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-time" class="dfn-panel" data-for="term-for-inherited-time" id="infopanel-for-term-for-inherited-time" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-time" style="display:none">Info about the 'inherited time' external reference.</span><a href="https://drafts.csswg.org/web-animations#inherited-time">https://drafts.csswg.org/web-animations#inherited-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-time">5.1. Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://heycam.github.io/webidl/#invoke-a-callback-function">https://heycam.github.io/webidl/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://heycam.github.io/webidl/#invoke-a-callback-function">https://heycam.github.io/webidl/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.2. Running Animators</a>
     <li><a href="#ref-for-invoke-a-callback-function①">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isconstructor">
-   <a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isconstructor" class="dfn-panel" data-for="term-for-sec-isconstructor" id="infopanel-for-term-for-sec-isconstructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isconstructor" style="display:none">Info about the 'isconstructor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isconstructor">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-count">
-   <a href="https://drafts.csswg.org/web-animations#iteration-count">https://drafts.csswg.org/web-animations#iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-count" class="dfn-panel" data-for="term-for-iteration-count" id="infopanel-for-term-for-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-count" style="display:none">Info about the 'iteration count' external reference.</span><a href="https://drafts.csswg.org/web-animations#iteration-count">https://drafts.csswg.org/web-animations#iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-count">3.5. Animator Effect</a>
     <li><a href="#ref-for-iteration-count①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-duration">
-   <a href="https://drafts.csswg.org/web-animations#iteration-duration">https://drafts.csswg.org/web-animations#iteration-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-duration" class="dfn-panel" data-for="term-for-iteration-duration" id="infopanel-for-term-for-iteration-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-duration" style="display:none">Info about the 'iteration duration' external reference.</span><a href="https://drafts.csswg.org/web-animations#iteration-duration">https://drafts.csswg.org/web-animations#iteration-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-duration">3.5. Animator Effect</a>
     <li><a href="#ref-for-iteration-duration①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-start">
-   <a href="https://drafts.csswg.org/web-animations#iteration-start">https://drafts.csswg.org/web-animations#iteration-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-start" class="dfn-panel" data-for="term-for-iteration-start" id="infopanel-for-term-for-iteration-start" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-start" style="display:none">Info about the 'iteration start' external reference.</span><a href="https://drafts.csswg.org/web-animations#iteration-start">https://drafts.csswg.org/web-animations#iteration-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-start">3.5. Animator Effect</a>
     <li><a href="#ref-for-iteration-start①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-time">
-   <a href="https://drafts.csswg.org/web-animations#local-time">https://drafts.csswg.org/web-animations#local-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-time" class="dfn-panel" data-for="term-for-local-time" id="infopanel-for-term-for-local-time" role="menu">
+   <span id="infopaneltitle-for-term-for-local-time" style="display:none">Info about the 'local time' external reference.</span><a href="https://drafts.csswg.org/web-animations#local-time">https://drafts.csswg.org/web-animations#local-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-time">3.5. Animator Effect</a> <a href="#ref-for-local-time①">(2)</a> <a href="#ref-for-local-time②">(3)</a> <a href="#ref-for-local-time③">(4)</a>
     <li><a href="#ref-for-local-time④">5.1. Worklet Animation</a> <a href="#ref-for-local-time⑤">(2)</a>
@@ -2062,136 +2062,136 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-local-time⑧">6.1. Worklet Group Effect</a> <a href="#ref-for-local-time⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://heycam.github.io/webidl/#notsupportederror">https://heycam.github.io/webidl/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'notsupportederror' external reference.</span><a href="https://heycam.github.io/webidl/#notsupportederror">https://heycam.github.io/webidl/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paused">
-   <a href="https://drafts.csswg.org/web-animations#paused">https://drafts.csswg.org/web-animations#paused</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paused" class="dfn-panel" data-for="term-for-paused" id="infopanel-for-term-for-paused" role="menu">
+   <span id="infopaneltitle-for-term-for-paused" style="display:none">Info about the 'paused' external reference.</span><a href="https://drafts.csswg.org/web-animations#paused">https://drafts.csswg.org/web-animations#paused</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paused">5.4. Web Animations Overrides</a> <a href="#ref-for-paused①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-persisted">
-   <a href="https://drafts.csswg.org/web-animations#persisted">https://drafts.csswg.org/web-animations#persisted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-persisted" class="dfn-panel" data-for="term-for-persisted" id="infopanel-for-term-for-persisted" role="menu">
+   <span id="infopaneltitle-for-term-for-persisted" style="display:none">Info about the 'persisted' external reference.</span><a href="https://drafts.csswg.org/web-animations#persisted">https://drafts.csswg.org/web-animations#persisted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-persisted">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-play-state">
-   <a href="https://drafts.csswg.org/web-animations#play-state">https://drafts.csswg.org/web-animations#play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-play-state" class="dfn-panel" data-for="term-for-play-state" id="infopanel-for-term-for-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-play-state" style="display:none">Info about the 'play state' external reference.</span><a href="https://drafts.csswg.org/web-animations#play-state">https://drafts.csswg.org/web-animations#play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-state">5.1. Worklet Animation</a>
     <li><a href="#ref-for-play-state①">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-play-state②">(2)</a>
     <li><a href="#ref-for-play-state③">5.4. Web Animations Overrides</a> <a href="#ref-for-play-state④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-playback-direction">
-   <a href="https://drafts.csswg.org/web-animations#playback-direction">https://drafts.csswg.org/web-animations#playback-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-playback-direction" class="dfn-panel" data-for="term-for-playback-direction" id="infopanel-for-term-for-playback-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-playback-direction" style="display:none">Info about the 'playback direction' external reference.</span><a href="https://drafts.csswg.org/web-animations#playback-direction">https://drafts.csswg.org/web-animations#playback-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-direction">3.5. Animator Effect</a>
     <li><a href="#ref-for-playback-direction①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-playback-rate">
-   <a href="https://drafts.csswg.org/web-animations#playback-rate">https://drafts.csswg.org/web-animations#playback-rate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-playback-rate" class="dfn-panel" data-for="term-for-playback-rate" id="infopanel-for-term-for-playback-rate" role="menu">
+   <span id="infopaneltitle-for-term-for-playback-rate" style="display:none">Info about the 'playback rate' external reference.</span><a href="https://drafts.csswg.org/web-animations#playback-rate">https://drafts.csswg.org/web-animations#playback-rate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-rate">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ready">
-   <a href="https://drafts.csswg.org/web-animations#ready">https://drafts.csswg.org/web-animations#ready</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ready" class="dfn-panel" data-for="term-for-ready" id="infopanel-for-term-for-ready" role="menu">
+   <span id="infopaneltitle-for-term-for-ready" style="display:none">Info about the 'ready' external reference.</span><a href="https://drafts.csswg.org/web-animations#ready">https://drafts.csswg.org/web-animations#ready</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ready">5.4. Web Animations Overrides</a> <a href="#ref-for-ready①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-removed">
-   <a href="https://drafts.csswg.org/web-animations#removed">https://drafts.csswg.org/web-animations#removed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-removed" class="dfn-panel" data-for="term-for-removed" id="infopanel-for-term-for-removed" role="menu">
+   <span id="infopaneltitle-for-term-for-removed" style="display:none">Info about the 'removed' external reference.</span><a href="https://drafts.csswg.org/web-animations#removed">https://drafts.csswg.org/web-animations#removed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-removed">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replace-state">
-   <a href="https://drafts.csswg.org/web-animations#replace-state">https://drafts.csswg.org/web-animations#replace-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replace-state" class="dfn-panel" data-for="term-for-replace-state" id="infopanel-for-term-for-replace-state" role="menu">
+   <span id="infopaneltitle-for-term-for-replace-state" style="display:none">Info about the 'replace state' external reference.</span><a href="https://drafts.csswg.org/web-animations#replace-state">https://drafts.csswg.org/web-animations#replace-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replace-state">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-running">
-   <a href="https://drafts.csswg.org/web-animations#running">https://drafts.csswg.org/web-animations#running</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-running" class="dfn-panel" data-for="term-for-running" id="infopanel-for-term-for-running" role="menu">
+   <span id="infopaneltitle-for-term-for-running" style="display:none">Info about the 'running' external reference.</span><a href="https://drafts.csswg.org/web-animations#running">https://drafts.csswg.org/web-animations#running</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running">5.4. Web Animations Overrides</a> <a href="#ref-for-running①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks">
-   <a href="https://html.spec.whatwg.org/#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks" id="infopanel-for-term-for-run-the-animation-frame-callbacks" role="menu">
+   <span id="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" style="display:none">Info about the 'running the animation frame callbacks' external reference.</span><a href="https://html.spec.whatwg.org/#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-animation-frame-callbacks">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-run-the-animation-frame-callbacks①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-current-time">
-   <a href="https://drafts.csswg.org/web-animations#set-the-current-time">https://drafts.csswg.org/web-animations#set-the-current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-current-time" class="dfn-panel" data-for="term-for-set-the-current-time" id="infopanel-for-term-for-set-the-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-current-time" style="display:none">Info about the 'set the current time' external reference.</span><a href="https://drafts.csswg.org/web-animations#set-the-current-time">https://drafts.csswg.org/web-animations#set-the-current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-current-time">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-start-time">
-   <a href="https://drafts.csswg.org/web-animations#set-the-start-time">https://drafts.csswg.org/web-animations#set-the-start-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-start-time" class="dfn-panel" data-for="term-for-set-the-start-time" id="infopanel-for-term-for-set-the-start-time" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-start-time" style="display:none">Info about the 'set the start time' external reference.</span><a href="https://drafts.csswg.org/web-animations#set-the-start-time">https://drafts.csswg.org/web-animations#set-the-start-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-start-time">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-target-effect-of-an-animation">
-   <a href="https://drafts.csswg.org/web-animations#set-the-target-effect-of-an-animation">https://drafts.csswg.org/web-animations#set-the-target-effect-of-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-target-effect-of-an-animation" class="dfn-panel" data-for="term-for-set-the-target-effect-of-an-animation" id="infopanel-for-term-for-set-the-target-effect-of-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-target-effect-of-an-animation" style="display:none">Info about the 'set the target effect of an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations#set-the-target-effect-of-an-animation">https://drafts.csswg.org/web-animations#set-the-target-effect-of-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-target-effect-of-an-animation">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-set-the-target-effect-of-an-animation①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-timeline-of-an-animation">
-   <a href="https://drafts.csswg.org/web-animations#set-the-timeline-of-an-animation">https://drafts.csswg.org/web-animations#set-the-timeline-of-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-timeline-of-an-animation" class="dfn-panel" data-for="term-for-set-the-timeline-of-an-animation" id="infopanel-for-term-for-set-the-timeline-of-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-timeline-of-an-animation" style="display:none">Info about the 'set the timeline of an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations#set-the-timeline-of-an-animation">https://drafts.csswg.org/web-animations#set-the-timeline-of-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-timeline-of-an-animation">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-set-the-timeline-of-an-animation①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-start-delay">
-   <a href="https://drafts.csswg.org/web-animations#start-delay">https://drafts.csswg.org/web-animations#start-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-start-delay" class="dfn-panel" data-for="term-for-start-delay" id="infopanel-for-term-for-start-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-start-delay" style="display:none">Info about the 'start delay' external reference.</span><a href="https://drafts.csswg.org/web-animations#start-delay">https://drafts.csswg.org/web-animations#start-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">3.5. Animator Effect</a>
     <li><a href="#ref-for-start-delay①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="http://w3c.github.io/html/infrastructure.html#structureddeserialize">http://w3c.github.io/html/infrastructure.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'structureddeserialize' external reference.</span><a href="http://w3c.github.io/html/infrastructure.html#structureddeserialize">http://w3c.github.io/html/infrastructure.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">4.1. Creating an Animator Instance</a> <a href="#ref-for-structureddeserialize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserialize">
-   <a href="http://w3c.github.io/html/infrastructure.html#structuredserialize">http://w3c.github.io/html/infrastructure.html#structuredserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserialize" class="dfn-panel" data-for="term-for-structuredserialize" id="infopanel-for-term-for-structuredserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserialize" style="display:none">Info about the 'structuredserialize' external reference.</span><a href="http://w3c.github.io/html/infrastructure.html#structuredserialize">http://w3c.github.io/html/infrastructure.html#structuredserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserialize">4.4. Migrating an Animator Instance</a>
     <li><a href="#ref-for-structuredserialize①">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-property">
-   <a href="https://drafts.csswg.org/web-animations#target-property">https://drafts.csswg.org/web-animations#target-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-property" class="dfn-panel" data-for="term-for-target-property" id="infopanel-for-term-for-target-property" role="menu">
+   <span id="infopaneltitle-for-term-for-target-property" style="display:none">Info about the 'target property' external reference.</span><a href="https://drafts.csswg.org/web-animations#target-property">https://drafts.csswg.org/web-animations#target-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-property">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.4. Registering an Animator Definition</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">5.2. Creating a Worklet Animation</a> <a href="#ref-for-dfn-throw④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline">
-   <a href="https://drafts.csswg.org/web-animations#timeline">https://drafts.csswg.org/web-animations#timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline" class="dfn-panel" data-for="term-for-timeline" id="infopanel-for-term-for-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline" style="display:none">Info about the 'timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations#timeline">https://drafts.csswg.org/web-animations#timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline">4. Animator Instance</a>
     <li><a href="#ref-for-timeline①">4.5. Requesting Animation Frames</a>
@@ -2199,87 +2199,87 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-timeline④">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timing-function">
-   <a href="https://drafts.csswg.org/web-animations#timing-function">https://drafts.csswg.org/web-animations#timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timing-function" class="dfn-panel" data-for="term-for-timing-function" id="infopanel-for-term-for-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-timing-function" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/web-animations#timing-function">https://drafts.csswg.org/web-animations#timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timing-function">3.5. Animator Effect</a>
     <li><a href="#ref-for-timing-function①">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'typeerror' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">3.4. Registering an Animator Definition</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">5.2. Creating a Worklet Animation</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-timing-properties-of-an-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations#update-the-timing-properties-of-an-animation-effect">https://drafts.csswg.org/web-animations#update-the-timing-properties-of-an-animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-timing-properties-of-an-animation-effect" class="dfn-panel" data-for="term-for-update-the-timing-properties-of-an-animation-effect" id="infopanel-for-term-for-update-the-timing-properties-of-an-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-timing-properties-of-an-animation-effect" style="display:none">Info about the 'update the timing properties of an animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations#update-the-timing-properties-of-an-animation-effect">https://drafts.csswg.org/web-animations#update-the-timing-properties-of-an-animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-timing-properties-of-an-animation-effect">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-start-time">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transition-start-time">https://drafts.csswg.org/css-transitions-1/#transition-start-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-start-time" class="dfn-panel" data-for="term-for-transition-start-time" id="infopanel-for-term-for-transition-start-time" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-start-time" style="display:none">Info about the 'start time' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transition-start-time">https://drafts.csswg.org/css-transitions-1/#transition-start-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-start-time">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3.3. Animator Definition</a>
     <li><a href="#ref-for-typedef-ident①">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">2. Animation Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.3. Animator Definition</a>
     <li><a href="#ref-for-concept-document①">3.4. Registering an Animator Definition</a> <a href="#ref-for-concept-document②">(2)</a>
     <li><a href="#ref-for-concept-document③">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet" class="dfn-panel" data-for="term-for-worklet" id="infopanel-for-term-for-worklet" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet" style="display:none">Info about the 'Worklet' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet">2. Animation Worklet</a> <a href="#ref-for-worklet①">(2)</a> <a href="#ref-for-worklet②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">2. Animation Worklet</a>
     <li><a href="#ref-for-workletglobalscope①">3.2. Stateful Animator</a>
     <li><a href="#ref-for-workletglobalscope②">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-queue-a-task①">4.4. Migrating an Animator Instance</a> <a href="#ref-for-queue-a-task②">(2)</a>
@@ -2287,111 +2287,111 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-queue-a-task⑤">5.4. Web Animations Overrides</a> <a href="#ref-for-queue-a-task⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-global-scope-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-global-scope-type" class="dfn-panel" data-for="term-for-worklet-global-scope-type" id="infopanel-for-term-for-worklet-global-scope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-global-scope-type" style="display:none">Info about the 'worklet global scope type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-global-scope-type">2. Animation Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.4. Registering an Animator Definition</a> <a href="#ref-for-map-exists①">(2)</a>
     <li><a href="#ref-for-map-exists②">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-get">
-   <a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-get" class="dfn-panel" data-for="term-for-map-get" id="infopanel-for-term-for-map-get" role="menu">
+   <span id="infopaneltitle-for-term-for-map-get" style="display:none">Info about the 'get' external reference.</span><a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-get">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.4. Registering an Animator Definition</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a> <a href="#ref-for-ordered-map③">(4)</a>
     <li><a href="#ref-for-ordered-map④">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.4. Registering an Animator Definition</a> <a href="#ref-for-map-set①">(2)</a> <a href="#ref-for-map-set②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3.3. Animator Definition</a> <a href="#ref-for-struct①">(2)</a>
     <li><a href="#ref-for-struct②">4. Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-animation" style="display:none">Info about the 'Animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">1.1. Relationship to the Web Animations API</a>
     <li><a href="#ref-for-animation①">5.1. Worklet Animation</a> <a href="#ref-for-animation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationeffect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationeffect" class="dfn-panel" data-for="term-for-animationeffect" id="infopanel-for-term-for-animationeffect" role="menu">
+   <span id="infopaneltitle-for-term-for-animationeffect" style="display:none">Info about the 'AnimationEffect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationeffect">3.5. Animator Effect</a>
     <li><a href="#ref-for-animationeffect①">5.1. Worklet Animation</a> <a href="#ref-for-animationeffect②">(2)</a>
     <li><a href="#ref-for-animationeffect③">5.2. Creating a Worklet Animation</a> <a href="#ref-for-animationeffect④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationtimeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationtimeline" class="dfn-panel" data-for="term-for-animationtimeline" id="infopanel-for-term-for-animationtimeline" role="menu">
+   <span id="infopaneltitle-for-term-for-animationtimeline" style="display:none">Info about the 'AnimationTimeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationtimeline">5.1. Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-computedeffecttiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-computedeffecttiming" class="dfn-panel" data-for="term-for-dictdef-computedeffecttiming" id="infopanel-for-term-for-dictdef-computedeffecttiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-computedeffecttiming" style="display:none">Info about the 'ComputedEffectTiming' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-computedeffecttiming">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-effecttiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-effecttiming" class="dfn-panel" data-for="term-for-dictdef-effecttiming" id="infopanel-for-term-for-dictdef-effecttiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-effecttiming" style="display:none">Info about the 'EffectTiming' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-effecttiming">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-finish">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-finish">https://drafts.csswg.org/web-animations-1/#dom-animation-finish</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-finish" class="dfn-panel" data-for="term-for-dom-animation-finish" id="infopanel-for-term-for-dom-animation-finish" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-finish" style="display:none">Info about the 'finish()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-finish">https://drafts.csswg.org/web-animations-1/#dom-animation-finish</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-finish">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationeffect-updatetiming" class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming" id="infopanel-for-term-for-dom-animationeffect-updatetiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationeffect-updatetiming" style="display:none">Info about the 'updateTiming()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-updatetiming">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationeffect-getcomputedtiming">
-   <a href="https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming">https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationeffect-getcomputedtiming" class="dfn-panel" data-for="term-for-dom-animationeffect-getcomputedtiming" id="infopanel-for-term-for-dom-animationeffect-getcomputedtiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationeffect-getcomputedtiming" style="display:none">Info about the 'getComputedTiming()' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming">https://drafts.csswg.org/web-animations-2/#dom-animationeffect-getcomputedtiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-getcomputedtiming">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Animation Worklet</a>
     <li><a href="#ref-for-idl-DOMString①">5.1. Worklet Animation</a> <a href="#ref-for-idl-DOMString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Animation Worklet</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">3.5. Animator Effect</a>
@@ -2399,47 +2399,47 @@ registerAnimator<c- p>(</c-><c- t>'parallax'</c-><c- p>,</c-> <c- a>class</c-> P
     <li><a href="#ref-for-Exposed④">6.1. Worklet Group Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">2. Animation Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2. Animation Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2. Animation Worklet</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a>
     <li><a href="#ref-for-idl-any③">5.1. Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-function" class="dfn-panel" data-for="term-for-dfn-callback-function" id="infopanel-for-term-for-dfn-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-function" style="display:none">Info about the 'callback function' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">3.3. Animator Definition</a> <a href="#ref-for-dfn-callback-function①">(2)</a> <a href="#ref-for-dfn-callback-function②">(3)</a>
     <li><a href="#ref-for-dfn-callback-function③">3.4. Registering an Animator Definition</a> <a href="#ref-for-dfn-callback-function④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3.5. Animator Effect</a> <a href="#ref-for-idl-double①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.1. Worklet Animation</a>
     <li><a href="#ref-for-idl-sequence①">6.1. Worklet Group Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2. Animation Worklet</a>
    </ul>
@@ -2658,22 +2658,22 @@ async operation. <a class="issue-return" href="#issue-e070ee55" title="Jump to s
 proposed as part of web-animation-2. We should instead move this into a delta spec against the
 web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue #w3c/csswg-drafts#2071]</a> <a class="issue-return" href="#issue-9ff2b6cb" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="animation-worklet">
-   <b><a href="#animation-worklet">#animation-worklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-worklet" class="dfn-panel" data-for="animation-worklet" id="infopanel-for-animation-worklet" role="dialog">
+   <span id="infopaneltitle-for-animation-worklet" style="display:none">Info about the 'Animation Worklet' definition.</span><b><a href="#animation-worklet">#animation-worklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-worklet">1. Introduction</a>
     <li><a href="#ref-for-animation-worklet①">1.1. Relationship to the Web Animations API</a>
     <li><a href="#ref-for-animation-worklet②">3.2. Stateful Animator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-animationworklet">
-   <b><a href="#dom-css-animationworklet">#dom-css-animationworklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-animationworklet" class="dfn-panel" data-for="dom-css-animationworklet" id="infopanel-for-dom-css-animationworklet" role="dialog">
+   <span id="infopaneltitle-for-dom-css-animationworklet" style="display:none">Info about the 'animationWorklet' definition.</span><b><a href="#dom-css-animationworklet">#dom-css-animationworklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-animationworklet">2. Animation Worklet</a> <a href="#ref-for-dom-css-animationworklet①">(2)</a> <a href="#ref-for-dom-css-animationworklet②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationworkletglobalscope">
-   <b><a href="#animationworkletglobalscope">#animationworkletglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animationworkletglobalscope" class="dfn-panel" data-for="animationworkletglobalscope" id="infopanel-for-animationworkletglobalscope" role="dialog">
+   <span id="infopaneltitle-for-animationworkletglobalscope" style="display:none">Info about the 'AnimationWorkletGlobalScope' definition.</span><b><a href="#animationworkletglobalscope">#animationworkletglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationworkletglobalscope">2. Animation Worklet</a> <a href="#ref-for-animationworkletglobalscope①">(2)</a>
     <li><a href="#ref-for-animationworkletglobalscope②">3. Animator</a>
@@ -2686,34 +2686,34 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animationworkletglobalscope①④">5.4. Web Animations Overrides</a> <a href="#ref-for-animationworkletglobalscope①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-animatorinstanceconstructor">
-   <b><a href="#callbackdef-animatorinstanceconstructor">#callbackdef-animatorinstanceconstructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-animatorinstanceconstructor" class="dfn-panel" data-for="callbackdef-animatorinstanceconstructor" id="infopanel-for-callbackdef-animatorinstanceconstructor" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-animatorinstanceconstructor" style="display:none">Info about the 'AnimatorInstanceConstructor' definition.</span><b><a href="#callbackdef-animatorinstanceconstructor">#callbackdef-animatorinstanceconstructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-animatorinstanceconstructor">2. Animation Worklet</a>
     <li><a href="#ref-for-callbackdef-animatorinstanceconstructor①">3.3. Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator">
-   <b><a href="#animator">#animator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator" class="dfn-panel" data-for="animator" id="infopanel-for-animator" role="dialog">
+   <span id="infopaneltitle-for-animator" style="display:none">Info about the 'Animator' definition.</span><b><a href="#animator">#animator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator">4. Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stateless-animator">
-   <b><a href="#stateless-animator">#stateless-animator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stateless-animator" class="dfn-panel" data-for="stateless-animator" id="infopanel-for-stateless-animator" role="dialog">
+   <span id="infopaneltitle-for-stateless-animator" style="display:none">Info about the 'Stateless Animator' definition.</span><b><a href="#stateless-animator">#stateless-animator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stateless-animator">3. Animator</a>
     <li><a href="#ref-for-stateless-animator①">3.1. Stateless Animator</a> <a href="#ref-for-stateless-animator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stateful-animator">
-   <b><a href="#stateful-animator">#stateful-animator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stateful-animator" class="dfn-panel" data-for="stateful-animator" id="infopanel-for-stateful-animator" role="dialog">
+   <span id="infopaneltitle-for-stateful-animator" style="display:none">Info about the 'Stateful Animator' definition.</span><b><a href="#stateful-animator">#stateful-animator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stateful-animator">3. Animator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-definition">
-   <b><a href="#animator-definition">#animator-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-definition" class="dfn-panel" data-for="animator-definition" id="infopanel-for-animator-definition" role="dialog">
+   <span id="infopaneltitle-for-animator-definition" style="display:none">Info about the 'animator definition' definition.</span><b><a href="#animator-definition">#animator-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-definition">3.3. Animator Definition</a>
     <li><a href="#ref-for-animator-definition①">3.4. Registering an Animator Definition</a>
@@ -2721,8 +2721,8 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animator-definition③">5.1. Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-name">
-   <b><a href="#animator-name">#animator-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-name" class="dfn-panel" data-for="animator-name" id="infopanel-for-animator-name" role="dialog">
+   <span id="infopaneltitle-for-animator-name" style="display:none">Info about the 'animator name' definition.</span><b><a href="#animator-name">#animator-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-name">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-animator-name①">4. Animator Instance</a>
@@ -2731,64 +2731,64 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animator-name④">4.4. Migrating an Animator Instance</a> <a href="#ref-for-animator-name⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="class-constructor">
-   <b><a href="#class-constructor">#class-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-class-constructor" class="dfn-panel" data-for="class-constructor" id="infopanel-for-class-constructor" role="dialog">
+   <span id="infopaneltitle-for-class-constructor" style="display:none">Info about the 'class constructor' definition.</span><b><a href="#class-constructor">#class-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-class-constructor">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-class-constructor①">4.1. Creating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animate-function">
-   <b><a href="#animate-function">#animate-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animate-function" class="dfn-panel" data-for="animate-function" id="infopanel-for-animate-function" role="dialog">
+   <span id="infopaneltitle-for-animate-function" style="display:none">Info about the 'animate function' definition.</span><b><a href="#animate-function">#animate-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animate-function">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-animate-function①">4.2. Running Animators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="state-function">
-   <b><a href="#state-function">#state-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-state-function" class="dfn-panel" data-for="state-function" id="infopanel-for-state-function" role="dialog">
+   <span id="infopaneltitle-for-state-function" style="display:none">Info about the 'state function' definition.</span><b><a href="#state-function">#state-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-state-function">3.2. Stateful Animator</a>
     <li><a href="#ref-for-state-function①">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-state-function②">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-definition-stateful-flag">
-   <b><a href="#animator-definition-stateful-flag">#animator-definition-stateful-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-definition-stateful-flag" class="dfn-panel" data-for="animator-definition-stateful-flag" id="infopanel-for-animator-definition-stateful-flag" role="dialog">
+   <span id="infopaneltitle-for-animator-definition-stateful-flag" style="display:none">Info about the 'stateful flag' definition.</span><b><a href="#animator-definition-stateful-flag">#animator-definition-stateful-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-definition-stateful-flag">3.3. Animator Definition</a>
     <li><a href="#ref-for-animator-definition-stateful-flag①">3.4. Registering an Animator Definition</a> <a href="#ref-for-animator-definition-stateful-flag②">(2)</a>
     <li><a href="#ref-for-animator-definition-stateful-flag③">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stateful-animator-definition">
-   <b><a href="#stateful-animator-definition">#stateful-animator-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stateful-animator-definition" class="dfn-panel" data-for="stateful-animator-definition" id="infopanel-for-stateful-animator-definition" role="dialog">
+   <span id="infopaneltitle-for-stateful-animator-definition" style="display:none">Info about the 'stateful animator definition' definition.</span><b><a href="#stateful-animator-definition">#stateful-animator-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stateful-animator-definition">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-stateful-animator-definition①">4. Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-animator-definition">
-   <b><a href="#document-animator-definition">#document-animator-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-animator-definition" class="dfn-panel" data-for="document-animator-definition" id="infopanel-for-document-animator-definition" role="dialog">
+   <span id="infopaneltitle-for-document-animator-definition" style="display:none">Info about the 'document animator definition' definition.</span><b><a href="#document-animator-definition">#document-animator-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-animator-definition">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-animator-definition-stateful-flag">
-   <b><a href="#document-animator-definition-stateful-flag">#document-animator-definition-stateful-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-animator-definition-stateful-flag" class="dfn-panel" data-for="document-animator-definition-stateful-flag" id="infopanel-for-document-animator-definition-stateful-flag" role="dialog">
+   <span id="infopaneltitle-for-document-animator-definition-stateful-flag" style="display:none">Info about the 'stateful flag' definition.</span><b><a href="#document-animator-definition-stateful-flag">#document-animator-definition-stateful-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-animator-definition-stateful-flag">3.4. Registering an Animator Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-animator-definitions">
-   <b><a href="#document-animator-definitions">#document-animator-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-animator-definitions" class="dfn-panel" data-for="document-animator-definitions" id="infopanel-for-document-animator-definitions" role="dialog">
+   <span id="infopaneltitle-for-document-animator-definitions" style="display:none">Info about the 'document animator definitions' definition.</span><b><a href="#document-animator-definitions">#document-animator-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-animator-definitions">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-document-animator-definitions①">5.2. Creating a Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-definitions">
-   <b><a href="#animator-definitions">#animator-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-definitions" class="dfn-panel" data-for="animator-definitions" id="infopanel-for-animator-definitions" role="dialog">
+   <span id="infopaneltitle-for-animator-definitions" style="display:none">Info about the 'animator definitions' definition.</span><b><a href="#animator-definitions">#animator-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-definitions">3.4. Registering an Animator Definition</a>
     <li><a href="#ref-for-animator-definitions①">4.1. Creating an Animator Instance</a>
@@ -2796,55 +2796,55 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animator-definitions③">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationworkletglobalscope-registeranimator">
-   <b><a href="#dom-animationworkletglobalscope-registeranimator">#dom-animationworkletglobalscope-registeranimator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationworkletglobalscope-registeranimator" class="dfn-panel" data-for="dom-animationworkletglobalscope-registeranimator" id="infopanel-for-dom-animationworkletglobalscope-registeranimator" role="dialog">
+   <span id="infopaneltitle-for-dom-animationworkletglobalscope-registeranimator" style="display:none">Info about the 'registerAnimator(name, animatorCtor)' definition.</span><b><a href="#dom-animationworkletglobalscope-registeranimator">#dom-animationworkletglobalscope-registeranimator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationworkletglobalscope-registeranimator">2. Animation Worklet</a>
     <li><a href="#ref-for-dom-animationworkletglobalscope-registeranimator①">3.4. Registering an Animator Definition</a> <a href="#ref-for-dom-animationworkletglobalscope-registeranimator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-effect">
-   <b><a href="#animator-effect">#animator-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-effect" class="dfn-panel" data-for="animator-effect" id="infopanel-for-animator-effect" role="dialog">
+   <span id="infopaneltitle-for-animator-effect" style="display:none">Info about the 'Animator Effect' definition.</span><b><a href="#animator-effect">#animator-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-effect">3.5. Animator Effect</a>
     <li><a href="#ref-for-animator-effect①">4. Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="corresponding-effect">
-   <b><a href="#corresponding-effect">#corresponding-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-corresponding-effect" class="dfn-panel" data-for="corresponding-effect" id="infopanel-for-corresponding-effect" role="dialog">
+   <span id="infopaneltitle-for-corresponding-effect" style="display:none">Info about the 'corresponding effect' definition.</span><b><a href="#corresponding-effect">#corresponding-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corresponding-effect">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-corresponding-effect①">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-corresponding-effect②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="workletanimationeffect">
-   <b><a href="#workletanimationeffect">#workletanimationeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-workletanimationeffect" class="dfn-panel" data-for="workletanimationeffect" id="infopanel-for-workletanimationeffect" role="dialog">
+   <span id="infopaneltitle-for-workletanimationeffect" style="display:none">Info about the 'WorkletAnimationEffect' definition.</span><b><a href="#workletanimationeffect">#workletanimationeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletanimationeffect">3.5. Animator Effect</a> <a href="#ref-for-workletanimationeffect①">(2)</a>
     <li><a href="#ref-for-workletanimationeffect②">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-workletanimationeffect③">6.1. Worklet Group Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workletanimationeffect-gettiming">
-   <b><a href="#dom-workletanimationeffect-gettiming">#dom-workletanimationeffect-gettiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workletanimationeffect-gettiming" class="dfn-panel" data-for="dom-workletanimationeffect-gettiming" id="infopanel-for-dom-workletanimationeffect-gettiming" role="dialog">
+   <span id="infopaneltitle-for-dom-workletanimationeffect-gettiming" style="display:none">Info about the 'getTiming()' definition.</span><b><a href="#dom-workletanimationeffect-gettiming">#dom-workletanimationeffect-gettiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workletanimationeffect-gettiming">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workletanimationeffect-getcomputedtiming">
-   <b><a href="#dom-workletanimationeffect-getcomputedtiming">#dom-workletanimationeffect-getcomputedtiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workletanimationeffect-getcomputedtiming" class="dfn-panel" data-for="dom-workletanimationeffect-getcomputedtiming" id="infopanel-for-dom-workletanimationeffect-getcomputedtiming" role="dialog">
+   <span id="infopaneltitle-for-dom-workletanimationeffect-getcomputedtiming" style="display:none">Info about the 'getComputedTiming()' definition.</span><b><a href="#dom-workletanimationeffect-getcomputedtiming">#dom-workletanimationeffect-getcomputedtiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workletanimationeffect-getcomputedtiming">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workletanimationeffect-localtime">
-   <b><a href="#dom-workletanimationeffect-localtime">#dom-workletanimationeffect-localtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workletanimationeffect-localtime" class="dfn-panel" data-for="dom-workletanimationeffect-localtime" id="infopanel-for-dom-workletanimationeffect-localtime" role="dialog">
+   <span id="infopaneltitle-for-dom-workletanimationeffect-localtime" style="display:none">Info about the 'localTime' definition.</span><b><a href="#dom-workletanimationeffect-localtime">#dom-workletanimationeffect-localtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workletanimationeffect-localtime">3.5. Animator Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-instance">
-   <b><a href="#animator-instance">#animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-instance" class="dfn-panel" data-for="animator-instance" id="infopanel-for-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-animator-instance" style="display:none">Info about the 'animator instance' definition.</span><b><a href="#animator-instance">#animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-instance">3.2. Stateful Animator</a>
     <li><a href="#ref-for-animator-instance①">4. Animator Instance</a>
@@ -2856,8 +2856,8 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animator-instance①⑥">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sync-requested-flag">
-   <b><a href="#sync-requested-flag">#sync-requested-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sync-requested-flag" class="dfn-panel" data-for="sync-requested-flag" id="infopanel-for-sync-requested-flag" role="dialog">
+   <span id="infopaneltitle-for-sync-requested-flag" style="display:none">Info about the 'sync requested flag' definition.</span><b><a href="#sync-requested-flag">#sync-requested-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sync-requested-flag">3.5. Animator Effect</a>
     <li><a href="#ref-for-sync-requested-flag①">4.1. Creating an Animator Instance</a>
@@ -2865,8 +2865,8 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-sync-requested-flag③">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-sync-requested-flag④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effect">
-   <b><a href="#effect">#effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effect" class="dfn-panel" data-for="effect" id="infopanel-for-effect" role="dialog">
+   <span id="infopaneltitle-for-effect" style="display:none">Info about the 'effect' definition.</span><b><a href="#effect">#effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-effect①">4.2. Running Animators</a>
@@ -2874,36 +2874,36 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-effect③">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-effect④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-current-time">
-   <b><a href="#animator-current-time">#animator-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-current-time" class="dfn-panel" data-for="animator-current-time" id="infopanel-for-animator-current-time" role="dialog">
+   <span id="infopaneltitle-for-animator-current-time" style="display:none">Info about the 'animator current time' definition.</span><b><a href="#animator-current-time">#animator-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-current-time">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-animator-current-time①">4.2. Running Animators</a>
     <li><a href="#ref-for-animator-current-time②">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-timeline">
-   <b><a href="#animator-timeline">#animator-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-timeline" class="dfn-panel" data-for="animator-timeline" id="infopanel-for-animator-timeline" role="dialog">
+   <span id="infopaneltitle-for-animator-timeline" style="display:none">Info about the 'animator timeline' definition.</span><b><a href="#animator-timeline">#animator-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-timeline">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-animator-timeline①">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-serialized-options">
-   <b><a href="#animator-serialized-options">#animator-serialized-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-serialized-options" class="dfn-panel" data-for="animator-serialized-options" id="infopanel-for-animator-serialized-options" role="dialog">
+   <span id="infopaneltitle-for-animator-serialized-options" style="display:none">Info about the 'animator serialized options' definition.</span><b><a href="#animator-serialized-options">#animator-serialized-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-serialized-options">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-animator-serialized-options①">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stateful-animator-instance">
-   <b><a href="#stateful-animator-instance">#stateful-animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stateful-animator-instance" class="dfn-panel" data-for="stateful-animator-instance" id="infopanel-for-stateful-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-stateful-animator-instance" style="display:none">Info about the 'stateful animator instance' definition.</span><b><a href="#stateful-animator-instance">#stateful-animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stateful-animator-instance">4.4. Migrating an Animator Instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animator-instance-set">
-   <b><a href="#animator-instance-set">#animator-instance-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animator-instance-set" class="dfn-panel" data-for="animator-instance-set" id="infopanel-for-animator-instance-set" role="dialog">
+   <span id="infopaneltitle-for-animator-instance-set" style="display:none">Info about the 'animator instance set' definition.</span><b><a href="#animator-instance-set">#animator-instance-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animator-instance-set">4.1. Creating an Animator Instance</a>
     <li><a href="#ref-for-animator-instance-set①">4.2. Running Animators</a> <a href="#ref-for-animator-instance-set②">(2)</a>
@@ -2911,35 +2911,35 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-animator-instance-set④">5.3. Worklet Animation Timing and Sync Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-new-animator-instance">
-   <b><a href="#create-a-new-animator-instance">#create-a-new-animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-new-animator-instance" class="dfn-panel" data-for="create-a-new-animator-instance" id="infopanel-for-create-a-new-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-create-a-new-animator-instance" style="display:none">Info about the 'create a new animator instance' definition.</span><b><a href="#create-a-new-animator-instance">#create-a-new-animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-new-animator-instance">4.4. Migrating an Animator Instance</a>
     <li><a href="#ref-for-create-a-new-animator-instance①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-animators">
-   <b><a href="#run-animators">#run-animators</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-animators" class="dfn-panel" data-for="run-animators" id="infopanel-for-run-animators" role="dialog">
+   <span id="infopaneltitle-for-run-animators" style="display:none">Info about the 'run animators' definition.</span><b><a href="#run-animators">#run-animators</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-animators">4.2. Running Animators</a> <a href="#ref-for-run-animators①">(2)</a>
     <li><a href="#ref-for-run-animators②">4.5. Requesting Animation Frames</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-an-animator-instance">
-   <b><a href="#remove-an-animator-instance">#remove-an-animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-an-animator-instance" class="dfn-panel" data-for="remove-an-animator-instance" id="infopanel-for-remove-an-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-remove-an-animator-instance" style="display:none">Info about the 'remove an animator instance' definition.</span><b><a href="#remove-an-animator-instance">#remove-an-animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-an-animator-instance">4.4. Migrating an Animator Instance</a>
     <li><a href="#ref-for-remove-an-animator-instance①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="migrate-an-animator-instance">
-   <b><a href="#migrate-an-animator-instance">#migrate-an-animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-migrate-an-animator-instance" class="dfn-panel" data-for="migrate-an-animator-instance" id="infopanel-for-migrate-an-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-migrate-an-animator-instance" style="display:none">Info about the 'migrate an animator instance' definition.</span><b><a href="#migrate-an-animator-instance">#migrate-an-animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-migrate-an-animator-instance">3.2. Stateful Animator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-requested-flag">
-   <b><a href="#frame-requested-flag">#frame-requested-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-requested-flag" class="dfn-panel" data-for="frame-requested-flag" id="infopanel-for-frame-requested-flag" role="dialog">
+   <span id="infopaneltitle-for-frame-requested-flag" style="display:none">Info about the 'frame requested flag' definition.</span><b><a href="#frame-requested-flag">#frame-requested-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-requested-flag">4. Animator Instance</a>
     <li><a href="#ref-for-frame-requested-flag①">4.1. Creating an Animator Instance</a>
@@ -2947,8 +2947,8 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-frame-requested-flag④">4.5. Requesting Animation Frames</a> <a href="#ref-for-frame-requested-flag⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="worklet-animation">
-   <b><a href="#worklet-animation">#worklet-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-worklet-animation" class="dfn-panel" data-for="worklet-animation" id="infopanel-for-worklet-animation" role="dialog">
+   <span id="infopaneltitle-for-worklet-animation" style="display:none">Info about the 'Worklet animation' definition.</span><b><a href="#worklet-animation">#worklet-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-animation">4. Animator Instance</a> <a href="#ref-for-worklet-animation①">(2)</a>
     <li><a href="#ref-for-worklet-animation②">4.5. Requesting Animation Frames</a>
@@ -2960,22 +2960,22 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-worklet-animation①④">6.2. ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-animator-name">
-   <b><a href="#animation-animator-name">#animation-animator-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-animator-name" class="dfn-panel" data-for="animation-animator-name" id="infopanel-for-animation-animator-name" role="dialog">
+   <span id="infopaneltitle-for-animation-animator-name" style="display:none">Info about the 'animation animator name' definition.</span><b><a href="#animation-animator-name">#animation-animator-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-animator-name">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-animation-animator-name①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-options">
-   <b><a href="#serialized-options">#serialized-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-options" class="dfn-panel" data-for="serialized-options" id="infopanel-for-serialized-options" role="dialog">
+   <span id="infopaneltitle-for-serialized-options" style="display:none">Info about the 'serialized options' definition.</span><b><a href="#serialized-options">#serialized-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-options">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-serialized-options①">5.4. Web Animations Overrides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="corresponding-animator-instance">
-   <b><a href="#corresponding-animator-instance">#corresponding-animator-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-corresponding-animator-instance" class="dfn-panel" data-for="corresponding-animator-instance" id="infopanel-for-corresponding-animator-instance" role="dialog">
+   <span id="infopaneltitle-for-corresponding-animator-instance" style="display:none">Info about the 'corresponding animator instance' definition.</span><b><a href="#corresponding-animator-instance">#corresponding-animator-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corresponding-animator-instance">5.1. Worklet Animation</a> <a href="#ref-for-corresponding-animator-instance①">(2)</a>
     <li><a href="#ref-for-corresponding-animator-instance②">5.3. Worklet Animation Timing and Sync Model</a> <a href="#ref-for-corresponding-animator-instance③">(2)</a>
@@ -2983,52 +2983,52 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
     <li><a href="#ref-for-corresponding-animator-instance①⓪">6.1. Worklet Group Effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="workletanimation">
-   <b><a href="#workletanimation">#workletanimation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-workletanimation" class="dfn-panel" data-for="workletanimation" id="infopanel-for-workletanimation" role="dialog">
+   <span id="infopaneltitle-for-workletanimation" style="display:none">Info about the 'WorkletAnimation' definition.</span><b><a href="#workletanimation">#workletanimation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletanimation">3. Animator</a> <a href="#ref-for-workletanimation①">(2)</a>
     <li><a href="#ref-for-workletanimation②">5.2. Creating a Worklet Animation</a> <a href="#ref-for-workletanimation③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workletanimation-workletanimation">
-   <b><a href="#dom-workletanimation-workletanimation">#dom-workletanimation-workletanimation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workletanimation-workletanimation" class="dfn-panel" data-for="dom-workletanimation-workletanimation" id="infopanel-for-dom-workletanimation-workletanimation" role="dialog">
+   <span id="infopaneltitle-for-dom-workletanimation-workletanimation" style="display:none">Info about the 'WorkletAnimation(animatorName, effects, timeline, options)' definition.</span><b><a href="#dom-workletanimation-workletanimation">#dom-workletanimation-workletanimation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workletanimation-workletanimation">5.1. Worklet Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sync-local-times-to-document">
-   <b><a href="#sync-local-times-to-document">#sync-local-times-to-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sync-local-times-to-document" class="dfn-panel" data-for="sync-local-times-to-document" id="infopanel-for-sync-local-times-to-document" role="dialog">
+   <span id="infopaneltitle-for-sync-local-times-to-document" style="display:none">Info about the 'sync local times to document' definition.</span><b><a href="#sync-local-times-to-document">#sync-local-times-to-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sync-local-times-to-document">4.2. Running Animators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sync-animation-timings-to-worklet">
-   <b><a href="#sync-animation-timings-to-worklet">#sync-animation-timings-to-worklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sync-animation-timings-to-worklet" class="dfn-panel" data-for="sync-animation-timings-to-worklet" id="infopanel-for-sync-animation-timings-to-worklet" role="dialog">
+   <span id="infopaneltitle-for-sync-animation-timings-to-worklet" style="display:none">Info about the 'sync animation timings to worklet' definition.</span><b><a href="#sync-animation-timings-to-worklet">#sync-animation-timings-to-worklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sync-animation-timings-to-worklet">5.4. Web Animations Overrides</a> <a href="#ref-for-sync-animation-timings-to-worklet①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associate-animator-instance-of-worklet-animation">
-   <b><a href="#associate-animator-instance-of-worklet-animation">#associate-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associate-animator-instance-of-worklet-animation" class="dfn-panel" data-for="associate-animator-instance-of-worklet-animation" id="infopanel-for-associate-animator-instance-of-worklet-animation" role="dialog">
+   <span id="infopaneltitle-for-associate-animator-instance-of-worklet-animation" style="display:none">Info about the 'associate animator instance of worklet animation' definition.</span><b><a href="#associate-animator-instance-of-worklet-animation">#associate-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associate-animator-instance-of-worklet-animation">5.4. Web Animations Overrides</a> <a href="#ref-for-associate-animator-instance-of-worklet-animation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disassociate-animator-instance-of-worklet-animation">
-   <b><a href="#disassociate-animator-instance-of-worklet-animation">#disassociate-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disassociate-animator-instance-of-worklet-animation" class="dfn-panel" data-for="disassociate-animator-instance-of-worklet-animation" id="infopanel-for-disassociate-animator-instance-of-worklet-animation" role="dialog">
+   <span id="infopaneltitle-for-disassociate-animator-instance-of-worklet-animation" style="display:none">Info about the 'disassociate animator instance of worklet animation' definition.</span><b><a href="#disassociate-animator-instance-of-worklet-animation">#disassociate-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disassociate-animator-instance-of-worklet-animation">5.4. Web Animations Overrides</a> <a href="#ref-for-disassociate-animator-instance-of-worklet-animation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-animator-instance-of-worklet-animation">
-   <b><a href="#set-animator-instance-of-worklet-animation">#set-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-animator-instance-of-worklet-animation" class="dfn-panel" data-for="set-animator-instance-of-worklet-animation" id="infopanel-for-set-animator-instance-of-worklet-animation" role="dialog">
+   <span id="infopaneltitle-for-set-animator-instance-of-worklet-animation" style="display:none">Info about the 'set animator instance of worklet animation' definition.</span><b><a href="#set-animator-instance-of-worklet-animation">#set-animator-instance-of-worklet-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-animator-instance-of-worklet-animation">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-set-animator-instance-of-worklet-animation①">5.4. Web Animations Overrides</a> <a href="#ref-for-set-animator-instance-of-worklet-animation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="workletgroupeffect">
-   <b><a href="#workletgroupeffect">#workletgroupeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-workletgroupeffect" class="dfn-panel" data-for="workletgroupeffect" id="infopanel-for-workletgroupeffect" role="dialog">
+   <span id="infopaneltitle-for-workletgroupeffect" style="display:none">Info about the 'WorkletGroupEffect' definition.</span><b><a href="#workletgroupeffect">#workletgroupeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletgroupeffect">5.2. Creating a Worklet Animation</a>
     <li><a href="#ref-for-workletgroupeffect①">6.1. Worklet Group Effect</a> <a href="#ref-for-workletgroupeffect②">(2)</a> <a href="#ref-for-workletgroupeffect③">(3)</a>
@@ -3036,59 +3036,115 @@ web-animation. <a href="https://github.com/w3c/csswg-drafts/issues/2071">[Issue 
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/css-houdini-drafts/css-layout-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-layout-api/Overview.html
@@ -3141,86 +3141,86 @@ resume the layout.</p>
    <li><a href="#update-a-layout-child-style">update a layout child style</a><span>, in § 4.1.1</span>
    <li><a href="#layout-api-context-work-queue">work queue</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-box-dimensions">
-   <a href="https://www.w3.org/TR/CSS21/box.html#box-dimensions">https://www.w3.org/TR/CSS21/box.html#box-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-dimensions" class="dfn-panel" data-for="term-for-box-dimensions" id="infopanel-for-term-for-box-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-box-dimensions" style="display:none">Info about the 'box model edges' external reference.</span><a href="https://www.w3.org/TR/CSS21/box.html#box-dimensions">https://www.w3.org/TR/CSS21/box.html#box-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-dimensions">4.6. Edges</a>
     <li><a href="#ref-for-box-dimensions①">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-box-dimensions②">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-construct">
-   <a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-construct" class="dfn-panel" data-for="term-for-sec-construct" id="infopanel-for-term-for-sec-construct" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-construct" style="display:none">Info about the 'construct' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-construct">6.2.4. Utility Algorithms</a> <a href="#ref-for-sec-construct①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-constructor">https://tc39.github.io/ecma262/#sec-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-constructor" class="dfn-panel" data-for="term-for-sec-constructor" id="infopanel-for-term-for-sec-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-constructor" style="display:none">Info about the 'constructor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-constructor">https://tc39.github.io/ecma262/#sec-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-constructor">3.1. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-terms-and-definitions-function">
-   <a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-function">https://tc39.github.io/ecma262/#sec-terms-and-definitions-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-terms-and-definitions-function" class="dfn-panel" data-for="term-for-sec-terms-and-definitions-function" id="infopanel-for-term-for-sec-terms-and-definitions-function" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-terms-and-definitions-function" style="display:none">Info about the 'function' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-terms-and-definitions-function">https://tc39.github.io/ecma262/#sec-terms-and-definitions-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-terms-and-definitions-function">3.1. Concepts</a> <a href="#ref-for-sec-terms-and-definitions-function①">(2)</a>
     <li><a href="#ref-for-sec-terms-and-definitions-function②">3.2. Registering A Layout</a> <a href="#ref-for-sec-terms-and-definitions-function③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">3.2. Registering A Layout</a> <a href="#ref-for-sec-get-o-p①">(2)</a> <a href="#ref-for-sec-get-o-p②">(3)</a> <a href="#ref-for-sec-get-o-p③">(4)</a> <a href="#ref-for-sec-get-o-p④">(5)</a> <a href="#ref-for-sec-get-o-p⑤">(6)</a>
     <li><a href="#ref-for-sec-get-o-p⑥">6.2.4. Utility Algorithms</a> <a href="#ref-for-sec-get-o-p⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-static-position">
-   <a href="https://www.w3.org/TR/CSS21/visudet.html#static-position">https://www.w3.org/TR/CSS21/visudet.html#static-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-static-position" class="dfn-panel" data-for="term-for-static-position" id="infopanel-for-term-for-static-position" role="menu">
+   <span id="infopaneltitle-for-term-for-static-position" style="display:none">Info about the 'static position' external reference.</span><a href="https://www.w3.org/TR/CSS21/visudet.html#static-position">https://www.w3.org/TR/CSS21/visudet.html#static-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position">5.2. Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/#structureddeserialize">https://html.spec.whatwg.org/#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'structureddeserialize' external reference.</span><a href="https://html.spec.whatwg.org/#structureddeserialize">https://html.spec.whatwg.org/#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializeforstorage">
-   <a href="https://html.spec.whatwg.org/#structuredserializeforstorage">https://html.spec.whatwg.org/#structuredserializeforstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializeforstorage" class="dfn-panel" data-for="term-for-structuredserializeforstorage" id="infopanel-for-term-for-structuredserializeforstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializeforstorage" style="display:none">Info about the 'structuredserializeforstorage' external reference.</span><a href="https://html.spec.whatwg.org/#structuredserializeforstorage">https://html.spec.whatwg.org/#structuredserializeforstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializeforstorage">4.4.1. Constraints for Layout Children</a>
     <li><a href="#ref-for-structuredserializeforstorage①">6.2. Performing Layout</a> <a href="#ref-for-structuredserializeforstorage②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">3.2. Registering A Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'typeerror' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">3.2. Registering A Layout</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">6.2. Performing Layout</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">2. Layout API Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">4.4. Layout Constraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">1. Introduction</a>
     <li><a href="#ref-for-fragment①">4.2. Layout Fragments</a> <a href="#ref-for-fragment②">(2)</a>
@@ -3229,15 +3229,15 @@ resume the layout.</p>
     <li><a href="#ref-for-fragment⑧">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-break">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-break" class="dfn-panel" data-for="term-for-fragmentation-break" id="infopanel-for-term-for-fragmentation-break" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">6.2. Performing Layout</a>
     <li><a href="#ref-for-fragmentation-break①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2. Layout API Containers</a>
     <li><a href="#ref-for-computed-value①">2.2. Box Tree Transformations</a>
@@ -3249,133 +3249,133 @@ resume the layout.</p>
     <li><a href="#ref-for-computed-value①①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2.2. Box Tree Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">2.2. Box Tree Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">2.2. Box Tree Transformations</a> <a href="#ref-for-root-inline-box①">(2)</a>
     <li><a href="#ref-for-root-inline-box②">4.1. Layout Children</a> <a href="#ref-for-root-inline-box③">(2)</a> <a href="#ref-for-root-inline-box④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. Layout API Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow" class="dfn-panel" data-for="term-for-scrollable-overflow" id="infopanel-for-term-for-scrollable-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow" style="display:none">Info about the 'scrollable overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow">5.3. Overflow</a> <a href="#ref-for-scrollable-overflow①">(2)</a> <a href="#ref-for-scrollable-overflow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-float">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-float" class="dfn-panel" data-for="term-for-float" id="infopanel-for-term-for-float" role="menu">
+   <span id="infopaneltitle-for-term-for-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float">2.2. Box Tree Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">2.1. Layout API Container Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-position">
-   <a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-position" class="dfn-panel" data-for="term-for-relative-position" id="infopanel-for-term-for-relative-position" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-position" style="display:none">Info about the 'relatively position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-position">4.2. Layout Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">2.1. Layout API Container Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-shape-inside-display">
-   <a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-inside-display">https://drafts.csswg.org/css-shapes-2/#valdef-shape-inside-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-shape-inside-display" class="dfn-panel" data-for="term-for-valdef-shape-inside-display" id="infopanel-for-term-for-valdef-shape-inside-display" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-shape-inside-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-inside-display">https://drafts.csswg.org/css-shapes-2/#valdef-shape-inside-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-inside-display">2. Layout API Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">4.4. Layout Constraints</a>
     <li><a href="#ref-for-valdef-width-auto①">5.1. Sizing</a> <a href="#ref-for-valdef-width-auto②">(2)</a> <a href="#ref-for-valdef-width-auto③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">4.4. Layout Constraints</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a>
     <li><a href="#ref-for-available③">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-available④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size" class="dfn-panel" data-for="term-for-intrinsic-size" id="infopanel-for-term-for-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-intrinsic-size①">(2)</a> <a href="#ref-for-intrinsic-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">4.3. Intrinsic Sizes</a>
     <li><a href="#ref-for-max-content①">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">4.3. Intrinsic Sizes</a>
     <li><a href="#ref-for-min-content①">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-inline-size" class="dfn-panel" data-for="term-for-stretch-fit-inline-size" id="infopanel-for-term-for-stretch-fit-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-inline-size" style="display:none">Info about the 'stretch-fit inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-inline-size">5.1. Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stylepropertymapreadonly">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stylepropertymapreadonly" class="dfn-panel" data-for="term-for-stylepropertymapreadonly" id="infopanel-for-term-for-stylepropertymapreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-stylepropertymapreadonly" style="display:none">Info about the 'StylePropertyMapReadOnly' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymapreadonly">3.2. Registering A Layout</a> <a href="#ref-for-stylepropertymapreadonly①">(2)</a>
     <li><a href="#ref-for-stylepropertymapreadonly②">4.1. Layout Children</a> <a href="#ref-for-stylepropertymapreadonly③">(2)</a> <a href="#ref-for-stylepropertymapreadonly④">(3)</a> <a href="#ref-for-stylepropertymapreadonly⑤">(4)</a> <a href="#ref-for-stylepropertymapreadonly⑥">(5)</a>
@@ -3383,26 +3383,26 @@ resume the layout.</p>
     <li><a href="#ref-for-stylepropertymapreadonly⑧">6.2.4. Utility Algorithms</a> <a href="#ref-for-stylepropertymapreadonly⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">2. Layout API Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">3.2. Registering A Layout</a> <a href="#ref-for-custom-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstract-dimensions">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#abstract-dimensions">https://drafts.csswg.org/css-writing-modes-4/#abstract-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-dimensions" class="dfn-panel" data-for="term-for-abstract-dimensions" id="infopanel-for-term-for-abstract-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-dimensions" style="display:none">Info about the 'abstract dimensions' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#abstract-dimensions">https://drafts.csswg.org/css-writing-modes-4/#abstract-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-dimensions">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">4.4. Layout Constraints</a> <a href="#ref-for-block-size①">(2)</a> <a href="#ref-for-block-size②">(3)</a>
     <li><a href="#ref-for-block-size③">5.1. Sizing</a>
@@ -3411,14 +3411,14 @@ resume the layout.</p>
     <li><a href="#ref-for-block-size⑥">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">5.2. Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">4.4. Layout Constraints</a>
     <li><a href="#ref-for-inline-size①">5.1. Sizing</a>
@@ -3427,86 +3427,86 @@ resume the layout.</p>
     <li><a href="#ref-for-inline-size④">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">5.2. Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">2.1. Layout API Container Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">2.1. Layout API Container Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-display-inside">
-   <a href="https://drafts.csswg.org/css-display-3/#typedef-display-inside">https://drafts.csswg.org/css-display-3/#typedef-display-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-display-inside" class="dfn-panel" data-for="term-for-typedef-display-inside" id="infopanel-for-term-for-typedef-display-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-display-inside" style="display:none">Info about the '&lt;display-inside>' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#typedef-display-inside">https://drafts.csswg.org/css-display-3/#typedef-display-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-inside">2. Layout API Containers</a> <a href="#ref-for-typedef-display-inside①">(2)</a>
     <li><a href="#ref-for-typedef-display-inside②">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-typedef-display-inside③">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-display-outside">
-   <a href="https://drafts.csswg.org/css-display-3/#typedef-display-outside">https://drafts.csswg.org/css-display-3/#typedef-display-outside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-display-outside" class="dfn-panel" data-for="term-for-typedef-display-outside" id="infopanel-for-term-for-typedef-display-outside" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-display-outside" style="display:none">Info about the '&lt;display-outside>' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#typedef-display-outside">https://drafts.csswg.org/css-display-3/#typedef-display-outside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-outside">2.2. Box Tree Transformations</a> <a href="#ref-for-typedef-display-outside①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2.2. Box Tree Transformations</a> <a href="#ref-for-atomic-inline①">(2)</a>
     <li><a href="#ref-for-atomic-inline②">4.1. Layout Children</a> <a href="#ref-for-atomic-inline③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">5.1. Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">5.1. Sizing</a> <a href="#ref-for-block-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2.2. Box Tree Transformations</a> <a href="#ref-for-block-level①">(2)</a>
     <li><a href="#ref-for-block-level②">5.1. Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockification' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">2.2. Box Tree Transformations</a> <a href="#ref-for-blockify①">(2)</a>
     <li><a href="#ref-for-blockify②">4.1. Layout Children</a> <a href="#ref-for-blockify③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify①" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify①" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">2.2. Box Tree Transformations</a> <a href="#ref-for-blockify①">(2)</a>
     <li><a href="#ref-for-blockify②">4.1. Layout Children</a> <a href="#ref-for-blockify③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">1. Introduction</a>
     <li><a href="#ref-for-box①">3.2. Registering A Layout</a> <a href="#ref-for-box②">(2)</a> <a href="#ref-for-box③">(3)</a> <a href="#ref-for-box④">(4)</a> <a href="#ref-for-box⑤">(5)</a> <a href="#ref-for-box⑥">(6)</a>
@@ -3522,102 +3522,102 @@ resume the layout.</p>
     <li><a href="#ref-for-box②②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-tree">
-   <a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-tree" class="dfn-panel" data-for="term-for-box-tree" id="infopanel-for-term-for-box-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-box-tree" style="display:none">Info about the 'box tree' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">1. Introduction</a> <a href="#ref-for-box-tree①">(2)</a>
     <li><a href="#ref-for-box-tree②">3.2. Registering A Layout</a>
     <li><a href="#ref-for-box-tree③">4.1.1. LayoutChildren and the Box Tree</a> <a href="#ref-for-box-tree④">(2)</a> <a href="#ref-for-box-tree⑤">(3)</a> <a href="#ref-for-box-tree⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">4.1.1. LayoutChildren and the Box Tree</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a>
     <li><a href="#ref-for-containing-block③">5.2. Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.2. Box Tree Transformations</a>
     <li><a href="#ref-for-propdef-display①">4.1. Layout Children</a> <a href="#ref-for-propdef-display②">(2)</a> <a href="#ref-for-propdef-display③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-layout" class="dfn-panel" data-for="term-for-flow-layout" id="infopanel-for-term-for-flow-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-layout" style="display:none">Info about the 'flow layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">6.2. Performing Layout</a>
     <li><a href="#ref-for-flow-layout①">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-flow-layout②">(2)</a> <a href="#ref-for-flow-layout③">(3)</a> <a href="#ref-for-flow-layout④">(4)</a> <a href="#ref-for-flow-layout⑤">(5)</a> <a href="#ref-for-flow-layout⑥">(6)</a>
     <li><a href="#ref-for-flow-layout⑦">6.2.2. Generating Fragments</a> <a href="#ref-for-flow-layout⑧">(2)</a> <a href="#ref-for-flow-layout⑨">(3)</a> <a href="#ref-for-flow-layout①⓪">(4)</a> <a href="#ref-for-flow-layout①①">(5)</a> <a href="#ref-for-flow-layout①②">(6)</a> <a href="#ref-for-flow-layout①③">(7)</a> <a href="#ref-for-flow-layout①④">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">2.2. Box Tree Transformations</a> <a href="#ref-for-valdef-display-inline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">5.1. Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.2. Box Tree Transformations</a> <a href="#ref-for-inline-level①">(2)</a>
     <li><a href="#ref-for-inline-level②">4.5. Breaking and Fragmentation</a>
     <li><a href="#ref-for-inline-level③">5.1. Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inlinify">
-   <a href="https://drafts.csswg.org/css-display-3/#inlinify">https://drafts.csswg.org/css-display-3/#inlinify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inlinify" class="dfn-panel" data-for="term-for-inlinify" id="infopanel-for-term-for-inlinify" role="menu">
+   <span id="infopaneltitle-for-term-for-inlinify" style="display:none">Info about the 'inlinify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inlinify">https://drafts.csswg.org/css-display-3/#inlinify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inlinify">2.2. Box Tree Transformations</a> <a href="#ref-for-inlinify①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">4.4. Layout Constraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-css-property">
-   <a href="https://drafts.csswg.org/cssom-1/#supported-css-property">https://drafts.csswg.org/cssom-1/#supported-css-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-css-property" class="dfn-panel" data-for="term-for-supported-css-property" id="infopanel-for-term-for-supported-css-property" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-css-property" style="display:none">Info about the 'supported css property' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#supported-css-property">https://drafts.csswg.org/cssom-1/#supported-css-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-css-property">3.2. Registering A Layout</a> <a href="#ref-for-supported-css-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.1. Concepts</a>
     <li><a href="#ref-for-concept-document①">3.2. Registering A Layout</a> <a href="#ref-for-concept-document②">(2)</a>
     <li><a href="#ref-for-concept-document③">6.2.4. Utility Algorithms</a> <a href="#ref-for-concept-document④">(2)</a> <a href="#ref-for-concept-document⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet" class="dfn-panel" data-for="term-for-worklet" id="infopanel-for-term-for-worklet" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet" style="display:none">Info about the 'Worklet' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet">3. Layout Worklet</a> <a href="#ref-for-worklet①">(2)</a> <a href="#ref-for-worklet②">(3)</a>
     <li><a href="#ref-for-worklet③">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-worklet④">(2)</a>
@@ -3625,93 +3625,93 @@ resume the layout.</p>
     <li><a href="#ref-for-worklet⑦">6.2.3. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-worklet-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-worklet-global-scope" class="dfn-panel" data-for="term-for-create-a-worklet-global-scope" id="infopanel-for-term-for-create-a-worklet-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-worklet-global-scope" style="display:none">Info about the 'create a worklet global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-worklet-global-scope">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-create-a-worklet-global-scope①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-worklet-global-scopes">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes">https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-worklet-global-scopes" class="dfn-panel" data-for="term-for-concept-worklet-global-scopes" id="infopanel-for-term-for-concept-worklet-global-scopes" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-worklet-global-scopes" style="display:none">Info about the 'global scopes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes">https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-worklet-global-scopes">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-concept-worklet-global-scopes①">6.2.2. Generating Fragments</a>
     <li><a href="#ref-for-concept-worklet-global-scopes②">6.2.3. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">6.2.2. Generating Fragments</a> <a href="#ref-for-in-parallel③">(2)</a>
     <li><a href="#ref-for-in-parallel④">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.2. Registering A Layout</a>
     <li><a href="#ref-for-queue-a-task①">6.2.4. Utility Algorithms</a> <a href="#ref-for-queue-a-task②">(2)</a> <a href="#ref-for-queue-a-task③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-global-scope-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-global-scope-type" class="dfn-panel" data-for="term-for-worklet-global-scope-type" id="infopanel-for-term-for-worklet-global-scope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-global-scope-type" style="display:none">Info about the 'worklet global scope type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-global-scope-type">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.1. Layout Children</a> <a href="#ref-for-list-append①">(2)</a>
     <li><a href="#ref-for-list-append②">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-list-append③">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">3.2. Registering A Layout</a> <a href="#ref-for-javascript-string-convert①">(2)</a> <a href="#ref-for-javascript-string-convert②">(3)</a> <a href="#ref-for-javascript-string-convert③">(4)</a> <a href="#ref-for-javascript-string-convert④">(5)</a>
     <li><a href="#ref-for-javascript-string-convert⑤">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-javascript-string-convert⑥">6.2.2. Generating Fragments</a> <a href="#ref-for-javascript-string-convert⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">6.1. Processing Model</a>
     <li><a href="#ref-for-list-empty①">6.2.4. Utility Algorithms</a> <a href="#ref-for-list-empty②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.2. Registering A Layout</a> <a href="#ref-for-map-exists①">(2)</a>
     <li><a href="#ref-for-map-exists②">4.1.1. LayoutChildren and the Box Tree</a>
     <li><a href="#ref-for-map-exists③">6.2.4. Utility Algorithms</a> <a href="#ref-for-map-exists④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">6.2. Performing Layout</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">6.2.1. Determining Intrinsic Sizes</a>
@@ -3719,22 +3719,22 @@ resume the layout.</p>
     <li><a href="#ref-for-list-iterate④">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-get">
-   <a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-get" class="dfn-panel" data-for="term-for-map-get" id="infopanel-for-term-for-map-get" role="menu">
+   <span id="infopaneltitle-for-term-for-map-get" style="display:none">Info about the 'get' external reference.</span><a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-get">3.2. Registering A Layout</a>
     <li><a href="#ref-for-map-get①">4.1.1. LayoutChildren and the Box Tree</a>
     <li><a href="#ref-for-map-get②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.1. Concepts</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a> <a href="#ref-for-list③">(4)</a>
     <li><a href="#ref-for-list④">6.1. Processing Model</a> <a href="#ref-for-list⑤">(2)</a>
@@ -3743,49 +3743,49 @@ resume the layout.</p>
     <li><a href="#ref-for-list⑧">6.2.3. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.2. Registering A Layout</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a> <a href="#ref-for-ordered-map③">(4)</a>
     <li><a href="#ref-for-ordered-map④">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.2. Registering A Layout</a> <a href="#ref-for-map-set①">(2)</a> <a href="#ref-for-map-set②">(3)</a>
     <li><a href="#ref-for-map-set③">4.1.1. LayoutChildren and the Box Tree</a>
     <li><a href="#ref-for-map-set④">6.2.4. Utility Algorithms</a> <a href="#ref-for-map-set⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3.1. Concepts</a> <a href="#ref-for-struct①">(2)</a>
     <li><a href="#ref-for-struct②">6.1. Processing Model</a> <a href="#ref-for-struct③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-while">
-   <a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-while" class="dfn-panel" data-for="term-for-iteration-while" id="infopanel-for-term-for-iteration-while" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-while" style="display:none">Info about the 'while' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2. Registering A Layout</a>
     <li><a href="#ref-for-idl-DOMException①">4.1. Layout Children</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Layout Worklet</a>
     <li><a href="#ref-for-Exposed①">3.2. Registering A Layout</a> <a href="#ref-for-Exposed②">(2)</a> <a href="#ref-for-Exposed③">(3)</a>
@@ -3798,56 +3798,56 @@ resume the layout.</p>
     <li><a href="#ref-for-Exposed①①">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">4.5. Breaking and Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">3.2. Registering A Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1. Layout Children</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">4.1. Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.1. Layout Children</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VoidFunction">
-   <a href="https://webidl.spec.whatwg.org/#VoidFunction">https://webidl.spec.whatwg.org/#VoidFunction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VoidFunction" class="dfn-panel" data-for="term-for-VoidFunction" id="infopanel-for-term-for-VoidFunction" role="menu">
+   <span id="infopaneltitle-for-term-for-VoidFunction" style="display:none">Info about the 'VoidFunction' external reference.</span><a href="https://webidl.spec.whatwg.org/#VoidFunction">https://webidl.spec.whatwg.org/#VoidFunction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VoidFunction">3. Layout Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">4.2. Layout Fragments</a>
     <li><a href="#ref-for-idl-any①">4.4. Layout Constraints</a>
@@ -3856,14 +3856,14 @@ resume the layout.</p>
     <li><a href="#ref-for-idl-any⑤">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-function" class="dfn-panel" data-for="term-for-dfn-callback-function" id="infopanel-for-term-for-dfn-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-function" style="display:none">Info about the 'callback function' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">3.2. Registering A Layout</a> <a href="#ref-for-dfn-callback-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.2. Layout Fragments</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a>
     <li><a href="#ref-for-idl-double④">4.3. Intrinsic Sizes</a> <a href="#ref-for-idl-double⑤">(2)</a>
@@ -3873,28 +3873,28 @@ resume the layout.</p>
     <li><a href="#ref-for-idl-double②⑥">6.2. Performing Layout</a> <a href="#ref-for-idl-double②⑦">(2)</a> <a href="#ref-for-idl-double②⑧">(3)</a> <a href="#ref-for-idl-double②⑨">(4)</a> <a href="#ref-for-idl-double③⓪">(5)</a> <a href="#ref-for-idl-double③①">(6)</a> <a href="#ref-for-idl-double③②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-invoke-a-callback-function①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-platform-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-platform-object" class="dfn-panel" data-for="term-for-dfn-platform-object" id="infopanel-for-term-for-dfn-platform-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-platform-object" style="display:none">Info about the 'platform object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.5. Breaking and Fragmentation</a>
     <li><a href="#ref-for-idl-sequence①">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.2. Registering A Layout</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a> <a href="#ref-for-dfn-throw④">(5)</a> <a href="#ref-for-dfn-throw⑤">(6)</a>
     <li><a href="#ref-for-dfn-throw⑥">6.2. Performing Layout</a> <a href="#ref-for-dfn-throw⑦">(2)</a>
@@ -3902,8 +3902,8 @@ resume the layout.</p>
     <li><a href="#ref-for-dfn-throw①⓪">6.2.2. Generating Fragments</a> <a href="#ref-for-dfn-throw①①">(2)</a> <a href="#ref-for-dfn-throw①②">(3)</a> <a href="#ref-for-dfn-throw①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. Layout Worklet</a>
    </ul>
@@ -4328,8 +4328,8 @@ resume the layout.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="valdef-display-layout">
-   <b><a href="#valdef-display-layout">#valdef-display-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-layout" class="dfn-panel" data-for="valdef-display-layout" id="infopanel-for-valdef-display-layout" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-layout" style="display:none">Info about the 'layout()' definition.</span><b><a href="#valdef-display-layout">#valdef-display-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-layout">2. Layout API Containers</a> <a href="#ref-for-valdef-display-layout①">(2)</a>
     <li><a href="#ref-for-valdef-display-layout②">3.1. Concepts</a> <a href="#ref-for-valdef-display-layout③">(2)</a>
@@ -4338,8 +4338,8 @@ resume the layout.</p>
     <li><a href="#ref-for-valdef-display-layout⑥">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-container">
-   <b><a href="#layout-api-container">#layout-api-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-container" class="dfn-panel" data-for="layout-api-container" id="infopanel-for-layout-api-container" role="dialog">
+   <span id="infopaneltitle-for-layout-api-container" style="display:none">Info about the 'layout API container' definition.</span><b><a href="#layout-api-container">#layout-api-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-container">2. Layout API Containers</a> <a href="#ref-for-layout-api-container①">(2)</a> <a href="#ref-for-layout-api-container②">(3)</a> <a href="#ref-for-layout-api-container③">(4)</a>
     <li><a href="#ref-for-layout-api-container④">2.1. Layout API Container Painting</a>
@@ -4355,21 +4355,21 @@ resume the layout.</p>
     <li><a href="#ref-for-layout-api-container②⑥">5.5. Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-formatting-context">
-   <b><a href="#layout-api-formatting-context">#layout-api-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-formatting-context" class="dfn-panel" data-for="layout-api-formatting-context" id="infopanel-for-layout-api-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-layout-api-formatting-context" style="display:none">Info about the 'layout API formatting context' definition.</span><b><a href="#layout-api-formatting-context">#layout-api-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-formatting-context">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-layout-api-formatting-context①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-layoutworklet">
-   <b><a href="#dom-css-layoutworklet">#dom-css-layoutworklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-layoutworklet" class="dfn-panel" data-for="dom-css-layoutworklet" id="infopanel-for-dom-css-layoutworklet" role="dialog">
+   <span id="infopaneltitle-for-dom-css-layoutworklet" style="display:none">Info about the 'layoutWorklet' definition.</span><b><a href="#dom-css-layoutworklet">#dom-css-layoutworklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-layoutworklet">3. Layout Worklet</a> <a href="#ref-for-dom-css-layoutworklet①">(2)</a> <a href="#ref-for-dom-css-layoutworklet②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutworkletglobalscope">
-   <b><a href="#layoutworkletglobalscope">#layoutworkletglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutworkletglobalscope" class="dfn-panel" data-for="layoutworkletglobalscope" id="infopanel-for-layoutworkletglobalscope" role="dialog">
+   <span id="infopaneltitle-for-layoutworkletglobalscope" style="display:none">Info about the 'LayoutWorkletGlobalScope' definition.</span><b><a href="#layoutworkletglobalscope">#layoutworkletglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutworkletglobalscope">3. Layout Worklet</a> <a href="#ref-for-layoutworkletglobalscope①">(2)</a>
     <li><a href="#ref-for-layoutworkletglobalscope②">3.1. Concepts</a>
@@ -4381,86 +4381,86 @@ resume the layout.</p>
     <li><a href="#ref-for-layoutworkletglobalscope①③">6.2.4. Utility Algorithms</a> <a href="#ref-for-layoutworkletglobalscope①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition">
-   <b><a href="#layout-definition">#layout-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition" class="dfn-panel" data-for="layout-definition" id="infopanel-for-layout-definition" role="dialog">
+   <span id="infopaneltitle-for-layout-definition" style="display:none">Info about the 'layout definition' definition.</span><b><a href="#layout-definition">#layout-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-class-constructor">
-   <b><a href="#layout-definition-class-constructor">#layout-definition-class-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-class-constructor" class="dfn-panel" data-for="layout-definition-class-constructor" id="infopanel-for-layout-definition-class-constructor" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-class-constructor" style="display:none">Info about the 'class constructor' definition.</span><b><a href="#layout-definition-class-constructor">#layout-definition-class-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-class-constructor">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-class-constructor①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-layout-function">
-   <b><a href="#layout-definition-layout-function">#layout-definition-layout-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-layout-function" class="dfn-panel" data-for="layout-definition-layout-function" id="infopanel-for-layout-definition-layout-function" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-layout-function" style="display:none">Info about the 'layout function' definition.</span><b><a href="#layout-definition-layout-function">#layout-definition-layout-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-layout-function">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-layout-function①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-intrinsic-sizes-function">
-   <b><a href="#layout-definition-intrinsic-sizes-function">#layout-definition-intrinsic-sizes-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-intrinsic-sizes-function" class="dfn-panel" data-for="layout-definition-intrinsic-sizes-function" id="infopanel-for-layout-definition-intrinsic-sizes-function" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-intrinsic-sizes-function" style="display:none">Info about the 'intrinsic sizes function' definition.</span><b><a href="#layout-definition-intrinsic-sizes-function">#layout-definition-intrinsic-sizes-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-intrinsic-sizes-function">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-intrinsic-sizes-function①">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-constructor-valid-flag">
-   <b><a href="#layout-definition-constructor-valid-flag">#layout-definition-constructor-valid-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-constructor-valid-flag" class="dfn-panel" data-for="layout-definition-constructor-valid-flag" id="infopanel-for-layout-definition-constructor-valid-flag" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-constructor-valid-flag" style="display:none">Info about the 'constructor valid flag' definition.</span><b><a href="#layout-definition-constructor-valid-flag">#layout-definition-constructor-valid-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-constructor-valid-flag">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-constructor-valid-flag①">6.2.4. Utility Algorithms</a> <a href="#ref-for-layout-definition-constructor-valid-flag②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-input-properties">
-   <b><a href="#layout-definition-input-properties">#layout-definition-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-input-properties" class="dfn-panel" data-for="layout-definition-input-properties" id="infopanel-for-layout-definition-input-properties" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-input-properties" style="display:none">Info about the 'input properties' definition.</span><b><a href="#layout-definition-input-properties">#layout-definition-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-input-properties">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-input-properties①">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-layout-definition-input-properties②">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-child-input-properties">
-   <b><a href="#layout-definition-child-input-properties">#layout-definition-child-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-child-input-properties" class="dfn-panel" data-for="layout-definition-child-input-properties" id="infopanel-for-layout-definition-child-input-properties" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-child-input-properties" style="display:none">Info about the 'child input properties' definition.</span><b><a href="#layout-definition-child-input-properties">#layout-definition-child-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-child-input-properties">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-child-input-properties①">4.1. Layout Children</a> <a href="#ref-for-layout-definition-child-input-properties②">(2)</a>
     <li><a href="#ref-for-layout-definition-child-input-properties③">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definition-layout-options">
-   <b><a href="#layout-definition-layout-options">#layout-definition-layout-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definition-layout-options" class="dfn-panel" data-for="layout-definition-layout-options" id="infopanel-for-layout-definition-layout-options" role="dialog">
+   <span id="infopaneltitle-for-layout-definition-layout-options" style="display:none">Info about the 'layout options' definition.</span><b><a href="#layout-definition-layout-options">#layout-definition-layout-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definition-layout-options">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definition-layout-options①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-layout-definition">
-   <b><a href="#document-layout-definition">#document-layout-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-layout-definition" class="dfn-panel" data-for="document-layout-definition" id="infopanel-for-document-layout-definition" role="dialog">
+   <span id="infopaneltitle-for-document-layout-definition" style="display:none">Info about the 'document layout definition' definition.</span><b><a href="#document-layout-definition">#document-layout-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-layout-definition">3.2. Registering A Layout</a>
     <li><a href="#ref-for-document-layout-definition①">6.2.4. Utility Algorithms</a> <a href="#ref-for-document-layout-definition②">(2)</a> <a href="#ref-for-document-layout-definition③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-layout-definition-input-properties">
-   <b><a href="#document-layout-definition-input-properties">#document-layout-definition-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-layout-definition-input-properties" class="dfn-panel" data-for="document-layout-definition-input-properties" id="infopanel-for-document-layout-definition-input-properties" role="dialog">
+   <span id="infopaneltitle-for-document-layout-definition-input-properties" style="display:none">Info about the 'input properties' definition.</span><b><a href="#document-layout-definition-input-properties">#document-layout-definition-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-layout-definition-input-properties">3.2. Registering A Layout</a> <a href="#ref-for-document-layout-definition-input-properties①">(2)</a> <a href="#ref-for-document-layout-definition-input-properties②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-layout-definition-child-input-properties">
-   <b><a href="#document-layout-definition-child-input-properties">#document-layout-definition-child-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-layout-definition-child-input-properties" class="dfn-panel" data-for="document-layout-definition-child-input-properties" id="infopanel-for-document-layout-definition-child-input-properties" role="dialog">
+   <span id="infopaneltitle-for-document-layout-definition-child-input-properties" style="display:none">Info about the 'child input properties' definition.</span><b><a href="#document-layout-definition-child-input-properties">#document-layout-definition-child-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-layout-definition-child-input-properties">3.2. Registering A Layout</a> <a href="#ref-for-document-layout-definition-child-input-properties①">(2)</a>
     <li><a href="#ref-for-document-layout-definition-child-input-properties②">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-layout-definition-layout-options">
-   <b><a href="#document-layout-definition-layout-options">#document-layout-definition-layout-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-layout-definition-layout-options" class="dfn-panel" data-for="document-layout-definition-layout-options" id="infopanel-for-document-layout-definition-layout-options" role="dialog">
+   <span id="infopaneltitle-for-document-layout-definition-layout-options" style="display:none">Info about the 'layout options' definition.</span><b><a href="#document-layout-definition-layout-options">#document-layout-definition-layout-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-layout-definition-layout-options">2.2. Box Tree Transformations</a> <a href="#ref-for-document-layout-definition-layout-options①">(2)</a> <a href="#ref-for-document-layout-definition-layout-options②">(3)</a>
     <li><a href="#ref-for-document-layout-definition-layout-options③">3.2. Registering A Layout</a> <a href="#ref-for-document-layout-definition-layout-options④">(2)</a>
@@ -4468,69 +4468,70 @@ resume the layout.</p>
     <li><a href="#ref-for-document-layout-definition-layout-options⑥">5.1. Sizing</a> <a href="#ref-for-document-layout-definition-layout-options⑦">(2)</a> <a href="#ref-for-document-layout-definition-layout-options⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-layoutoptions">
-   <b><a href="#dictdef-layoutoptions">#dictdef-layoutoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-layoutoptions" class="dfn-panel" data-for="dictdef-layoutoptions" id="infopanel-for-dictdef-layoutoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-layoutoptions" style="display:none">Info about the 'LayoutOptions' definition.</span><b><a href="#dictdef-layoutoptions">#dictdef-layoutoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-layoutoptions">3.1. Concepts</a> <a href="#ref-for-dictdef-layoutoptions①">(2)</a>
     <li><a href="#ref-for-dictdef-layoutoptions②">3.2. Registering A Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutoptions-childdisplay">
-   <b><a href="#dom-layoutoptions-childdisplay">#dom-layoutoptions-childdisplay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutoptions-childdisplay" class="dfn-panel" data-for="dom-layoutoptions-childdisplay" id="infopanel-for-dom-layoutoptions-childdisplay" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutoptions-childdisplay" style="display:none">Info about the 'childDisplay' definition.</span><b><a href="#dom-layoutoptions-childdisplay">#dom-layoutoptions-childdisplay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutoptions-childdisplay">2.2. Box Tree Transformations</a> <a href="#ref-for-dom-layoutoptions-childdisplay①">(2)</a> <a href="#ref-for-dom-layoutoptions-childdisplay②">(3)</a>
     <li><a href="#ref-for-dom-layoutoptions-childdisplay③">4.5. Breaking and Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutoptions-sizing">
-   <b><a href="#dom-layoutoptions-sizing">#dom-layoutoptions-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutoptions-sizing" class="dfn-panel" data-for="dom-layoutoptions-sizing" id="infopanel-for-dom-layoutoptions-sizing" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutoptions-sizing" style="display:none">Info about the 'sizing' definition.</span><b><a href="#dom-layoutoptions-sizing">#dom-layoutoptions-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutoptions-sizing">4.4. Layout Constraints</a>
     <li><a href="#ref-for-dom-layoutoptions-sizing①">5.1. Sizing</a> <a href="#ref-for-dom-layoutoptions-sizing②">(2)</a> <a href="#ref-for-dom-layoutoptions-sizing③">(3)</a>
     <li><a href="#ref-for-dom-layoutoptions-sizing④">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-childdisplaytype">
-   <b><a href="#enumdef-childdisplaytype">#enumdef-childdisplaytype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-childdisplaytype" class="dfn-panel" data-for="enumdef-childdisplaytype" id="infopanel-for-enumdef-childdisplaytype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-childdisplaytype" style="display:none">Info about the 'ChildDisplayType' definition.</span><b><a href="#enumdef-childdisplaytype">#enumdef-childdisplaytype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-childdisplaytype">3.2. Registering A Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-layoutsizingmode">
-   <b><a href="#enumdef-layoutsizingmode">#enumdef-layoutsizingmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-layoutsizingmode" class="dfn-panel" data-for="enumdef-layoutsizingmode" id="infopanel-for-enumdef-layoutsizingmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-layoutsizingmode" style="display:none">Info about the 'LayoutSizingMode' definition.</span><b><a href="#enumdef-layoutsizingmode">#enumdef-layoutsizingmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-layoutsizingmode">3.2. Registering A Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-layout-definitions">
-   <b><a href="#document-layout-definitions">#document-layout-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-layout-definitions" class="dfn-panel" data-for="document-layout-definitions" id="infopanel-for-document-layout-definitions" role="dialog">
+   <span id="infopaneltitle-for-document-layout-definitions" style="display:none">Info about the 'document layout definitions' definition.</span><b><a href="#document-layout-definitions">#document-layout-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-layout-definitions">3.2. Registering A Layout</a>
     <li><a href="#ref-for-document-layout-definitions①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-definitions">
-   <b><a href="#layout-definitions">#layout-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-definitions" class="dfn-panel" data-for="layout-definitions" id="infopanel-for-layout-definitions" role="dialog">
+   <span id="infopaneltitle-for-layout-definitions" style="display:none">Info about the 'layout definitions' definition.</span><b><a href="#layout-definitions">#layout-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-definitions">3.2. Registering A Layout</a>
     <li><a href="#ref-for-layout-definitions①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-class-instances">
-   <b><a href="#layout-class-instances">#layout-class-instances</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-class-instances" class="dfn-panel" data-for="layout-class-instances" id="infopanel-for-layout-class-instances" role="dialog">
+   <span id="infopaneltitle-for-layout-class-instances" style="display:none">Info about the 'layout class
+instances' definition.</span><b><a href="#layout-class-instances">#layout-class-instances</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-class-instances">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stylemap">
-   <b><a href="#stylemap">#stylemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stylemap" class="dfn-panel" data-for="stylemap" id="infopanel-for-stylemap" role="dialog">
+   <span id="infopaneltitle-for-stylemap" style="display:none">Info about the 'styleMap' definition.</span><b><a href="#stylemap">#stylemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylemap">3.2. Registering A Layout</a>
     <li><a href="#ref-for-stylemap①">6.2.4. Utility Algorithms</a> <a href="#ref-for-stylemap②">(2)</a> <a href="#ref-for-stylemap③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutworkletglobalscope-registerlayout">
-   <b><a href="#dom-layoutworkletglobalscope-registerlayout">#dom-layoutworkletglobalscope-registerlayout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutworkletglobalscope-registerlayout" class="dfn-panel" data-for="dom-layoutworkletglobalscope-registerlayout" id="infopanel-for-dom-layoutworkletglobalscope-registerlayout" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutworkletglobalscope-registerlayout" style="display:none">Info about the 'registerLayout(name, layoutCtor)' definition.</span><b><a href="#dom-layoutworkletglobalscope-registerlayout">#dom-layoutworkletglobalscope-registerlayout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutworkletglobalscope-registerlayout">3. Layout Worklet</a>
     <li><a href="#ref-for-dom-layoutworkletglobalscope-registerlayout①">3.1. Concepts</a>
@@ -4538,8 +4539,8 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutworkletglobalscope-registerlayout⑥">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-layout">
-   <b><a href="#current-layout">#current-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-layout" class="dfn-panel" data-for="current-layout" id="infopanel-for-current-layout" role="dialog">
+   <span id="infopaneltitle-for-current-layout" style="display:none">Info about the 'current layout' definition.</span><b><a href="#current-layout">#current-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-layout">3.3. Terminology</a> <a href="#ref-for-current-layout①">(2)</a>
     <li><a href="#ref-for-current-layout②">4.1. Layout Children</a> <a href="#ref-for-current-layout③">(2)</a>
@@ -4554,23 +4555,23 @@ resume the layout.</p>
     <li><a href="#ref-for-current-layout②⑥">6.2.4. Utility Algorithms</a> <a href="#ref-for-current-layout②⑦">(2)</a> <a href="#ref-for-current-layout②⑧">(3)</a> <a href="#ref-for-current-layout②⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parent-layout">
-   <b><a href="#parent-layout">#parent-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parent-layout" class="dfn-panel" data-for="parent-layout" id="infopanel-for-parent-layout" role="dialog">
+   <span id="infopaneltitle-for-parent-layout" style="display:none">Info about the 'parent layout' definition.</span><b><a href="#parent-layout">#parent-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-layout">4.4. Layout Constraints</a> <a href="#ref-for-parent-layout①">(2)</a> <a href="#ref-for-parent-layout②">(3)</a>
     <li><a href="#ref-for-parent-layout③">5.4. Fragmentation</a>
     <li><a href="#ref-for-parent-layout④">5.5. Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="child-layout">
-   <b><a href="#child-layout">#child-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-child-layout" class="dfn-panel" data-for="child-layout" id="infopanel-for-child-layout" role="dialog">
+   <span id="infopaneltitle-for-child-layout" style="display:none">Info about the 'child layout' definition.</span><b><a href="#child-layout">#child-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-layout">4.4.1. Constraints for Layout Children</a>
     <li><a href="#ref-for-child-layout①">4.5. Breaking and Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutchild">
-   <b><a href="#layoutchild">#layoutchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutchild" class="dfn-panel" data-for="layoutchild" id="infopanel-for-layoutchild" role="dialog">
+   <span id="infopaneltitle-for-layoutchild" style="display:none">Info about the 'LayoutChild' definition.</span><b><a href="#layoutchild">#layoutchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutchild">2.2. Box Tree Transformations</a> <a href="#ref-for-layoutchild①">(2)</a>
     <li><a href="#ref-for-layoutchild②">3.3. Terminology</a>
@@ -4587,43 +4588,43 @@ resume the layout.</p>
     <li><a href="#ref-for-layoutchild④①">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-box-slot">
-   <b><a href="#dom-layoutchild-box-slot">#dom-layoutchild-box-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-box-slot" class="dfn-panel" data-for="dom-layoutchild-box-slot" id="infopanel-for-dom-layoutchild-box-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-box-slot" style="display:none">Info about the '[[box]]' definition.</span><b><a href="#dom-layoutchild-box-slot">#dom-layoutchild-box-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-box-slot">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-box-slot①">(2)</a>
     <li><a href="#ref-for-dom-layoutchild-box-slot②">4.1.1. LayoutChildren and the Box Tree</a>
     <li><a href="#ref-for-dom-layoutchild-box-slot③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-stylemap-slot">
-   <b><a href="#dom-layoutchild-stylemap-slot">#dom-layoutchild-stylemap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-stylemap-slot" class="dfn-panel" data-for="dom-layoutchild-stylemap-slot" id="infopanel-for-dom-layoutchild-stylemap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-stylemap-slot" style="display:none">Info about the '[[styleMap]]' definition.</span><b><a href="#dom-layoutchild-stylemap-slot">#dom-layoutchild-stylemap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-stylemap-slot">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-stylemap-slot①">(2)</a> <a href="#ref-for-dom-layoutchild-stylemap-slot②">(3)</a> <a href="#ref-for-dom-layoutchild-stylemap-slot③">(4)</a> <a href="#ref-for-dom-layoutchild-stylemap-slot④">(5)</a>
     <li><a href="#ref-for-dom-layoutchild-stylemap-slot⑤">4.1.1. LayoutChildren and the Box Tree</a> <a href="#ref-for-dom-layoutchild-stylemap-slot⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-unique-id-slot">
-   <b><a href="#dom-layoutchild-unique-id-slot">#dom-layoutchild-unique-id-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-unique-id-slot" class="dfn-panel" data-for="dom-layoutchild-unique-id-slot" id="infopanel-for-dom-layoutchild-unique-id-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-unique-id-slot" style="display:none">Info about the '[[unique id]]' definition.</span><b><a href="#dom-layoutchild-unique-id-slot">#dom-layoutchild-unique-id-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-unique-id-slot">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-unique-id-slot①">(2)</a>
     <li><a href="#ref-for-dom-layoutchild-unique-id-slot②">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-stylemap">
-   <b><a href="#dom-layoutchild-stylemap">#dom-layoutchild-stylemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-stylemap" class="dfn-panel" data-for="dom-layoutchild-stylemap" id="infopanel-for-dom-layoutchild-stylemap" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-stylemap" style="display:none">Info about the 'styleMap' definition.</span><b><a href="#dom-layoutchild-stylemap">#dom-layoutchild-stylemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-stylemap">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-stylemap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-intrinsicsizes">
-   <b><a href="#dom-layoutchild-intrinsicsizes">#dom-layoutchild-intrinsicsizes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-intrinsicsizes" class="dfn-panel" data-for="dom-layoutchild-intrinsicsizes" id="infopanel-for-dom-layoutchild-intrinsicsizes" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-intrinsicsizes" style="display:none">Info about the 'intrinsicSizes()' definition.</span><b><a href="#dom-layoutchild-intrinsicsizes">#dom-layoutchild-intrinsicsizes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-intrinsicsizes">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-intrinsicsizes①">(2)</a>
     <li><a href="#ref-for-dom-layoutchild-intrinsicsizes②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutchild-layoutnextfragment">
-   <b><a href="#dom-layoutchild-layoutnextfragment">#dom-layoutchild-layoutnextfragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutchild-layoutnextfragment" class="dfn-panel" data-for="dom-layoutchild-layoutnextfragment" id="infopanel-for-dom-layoutchild-layoutnextfragment" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutchild-layoutnextfragment" style="display:none">Info about the 'layoutNextFragment(constraints, breakToken)' definition.</span><b><a href="#dom-layoutchild-layoutnextfragment">#dom-layoutchild-layoutnextfragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutchild-layoutnextfragment">2.2. Box Tree Transformations</a>
     <li><a href="#ref-for-dom-layoutchild-layoutnextfragment①">4.1. Layout Children</a> <a href="#ref-for-dom-layoutchild-layoutnextfragment②">(2)</a> <a href="#ref-for-dom-layoutchild-layoutnextfragment③">(3)</a>
@@ -4632,28 +4633,28 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutchild-layoutnextfragment⑨">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-box-layoutchildmap-slot">
-   <b><a href="#dom-box-layoutchildmap-slot">#dom-box-layoutchildmap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-box-layoutchildmap-slot" class="dfn-panel" data-for="dom-box-layoutchildmap-slot" id="infopanel-for-dom-box-layoutchildmap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-box-layoutchildmap-slot" style="display:none">Info about the '[[layoutChildMap]]' definition.</span><b><a href="#dom-box-layoutchildmap-slot">#dom-box-layoutchildmap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-box-layoutchildmap-slot">4.1.1. LayoutChildren and the Box Tree</a> <a href="#ref-for-dom-box-layoutchildmap-slot①">(2)</a> <a href="#ref-for-dom-box-layoutchildmap-slot②">(3)</a> <a href="#ref-for-dom-box-layoutchildmap-slot③">(4)</a> <a href="#ref-for-dom-box-layoutchildmap-slot④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-layout-child">
-   <b><a href="#get-a-layout-child">#get-a-layout-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-layout-child" class="dfn-panel" data-for="get-a-layout-child" id="infopanel-for-get-a-layout-child" role="dialog">
+   <span id="infopaneltitle-for-get-a-layout-child" style="display:none">Info about the 'get a layout child' definition.</span><b><a href="#get-a-layout-child">#get-a-layout-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-layout-child">4.1.1. LayoutChildren and the Box Tree</a>
     <li><a href="#ref-for-get-a-layout-child①">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-get-a-layout-child②">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-a-layout-child-style">
-   <b><a href="#update-a-layout-child-style">#update-a-layout-child-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-a-layout-child-style" class="dfn-panel" data-for="update-a-layout-child-style" id="infopanel-for-update-a-layout-child-style" role="dialog">
+   <span id="infopaneltitle-for-update-a-layout-child-style" style="display:none">Info about the 'update a layout child style' definition.</span><b><a href="#update-a-layout-child-style">#update-a-layout-child-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-a-layout-child-style">4.1.1. LayoutChildren and the Box Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutfragment">
-   <b><a href="#layoutfragment">#layoutfragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutfragment" class="dfn-panel" data-for="layoutfragment" id="infopanel-for-layoutfragment" role="dialog">
+   <span id="infopaneltitle-for-layoutfragment" style="display:none">Info about the 'LayoutFragment' definition.</span><b><a href="#layoutfragment">#layoutfragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutfragment">2.2. Box Tree Transformations</a>
     <li><a href="#ref-for-layoutfragment①">4.1. Layout Children</a> <a href="#ref-for-layoutfragment②">(2)</a> <a href="#ref-for-layoutfragment③">(3)</a> <a href="#ref-for-layoutfragment④">(4)</a>
@@ -4667,22 +4668,22 @@ resume the layout.</p>
     <li><a href="#ref-for-layoutfragment②⑦">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-inlinesize">
-   <b><a href="#dom-layoutfragment-inlinesize">#dom-layoutfragment-inlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-inlinesize" class="dfn-panel" data-for="dom-layoutfragment-inlinesize" id="infopanel-for-dom-layoutfragment-inlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-inlinesize" style="display:none">Info about the 'inlineSize' definition.</span><b><a href="#dom-layoutfragment-inlinesize">#dom-layoutfragment-inlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-inlinesize">4.2. Layout Fragments</a> <a href="#ref-for-dom-layoutfragment-inlinesize①">(2)</a> <a href="#ref-for-dom-layoutfragment-inlinesize②">(3)</a>
     <li><a href="#ref-for-dom-layoutfragment-inlinesize③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-blocksize">
-   <b><a href="#dom-layoutfragment-blocksize">#dom-layoutfragment-blocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-blocksize" class="dfn-panel" data-for="dom-layoutfragment-blocksize" id="infopanel-for-dom-layoutfragment-blocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-blocksize" style="display:none">Info about the 'blockSize' definition.</span><b><a href="#dom-layoutfragment-blocksize">#dom-layoutfragment-blocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-blocksize">4.2. Layout Fragments</a> <a href="#ref-for-dom-layoutfragment-blocksize①">(2)</a> <a href="#ref-for-dom-layoutfragment-blocksize②">(3)</a>
     <li><a href="#ref-for-dom-layoutfragment-blocksize③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-inlineoffset">
-   <b><a href="#dom-layoutfragment-inlineoffset">#dom-layoutfragment-inlineoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-inlineoffset" class="dfn-panel" data-for="dom-layoutfragment-inlineoffset" id="infopanel-for-dom-layoutfragment-inlineoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-inlineoffset" style="display:none">Info about the 'inlineOffset' definition.</span><b><a href="#dom-layoutfragment-inlineoffset">#dom-layoutfragment-inlineoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-inlineoffset">4.2. Layout Fragments</a> <a href="#ref-for-dom-layoutfragment-inlineoffset①">(2)</a> <a href="#ref-for-dom-layoutfragment-inlineoffset②">(3)</a>
     <li><a href="#ref-for-dom-layoutfragment-inlineoffset③">5.2. Positioning</a> <a href="#ref-for-dom-layoutfragment-inlineoffset④">(2)</a>
@@ -4690,8 +4691,8 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutfragment-inlineoffset⑥">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-blockoffset">
-   <b><a href="#dom-layoutfragment-blockoffset">#dom-layoutfragment-blockoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-blockoffset" class="dfn-panel" data-for="dom-layoutfragment-blockoffset" id="infopanel-for-dom-layoutfragment-blockoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-blockoffset" style="display:none">Info about the 'blockOffset' definition.</span><b><a href="#dom-layoutfragment-blockoffset">#dom-layoutfragment-blockoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-blockoffset">4.2. Layout Fragments</a> <a href="#ref-for-dom-layoutfragment-blockoffset①">(2)</a> <a href="#ref-for-dom-layoutfragment-blockoffset②">(3)</a>
     <li><a href="#ref-for-dom-layoutfragment-blockoffset③">5.2. Positioning</a> <a href="#ref-for-dom-layoutfragment-blockoffset④">(2)</a>
@@ -4699,15 +4700,15 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutfragment-blockoffset⑥">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-data">
-   <b><a href="#dom-layoutfragment-data">#dom-layoutfragment-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-data" class="dfn-panel" data-for="dom-layoutfragment-data" id="infopanel-for-dom-layoutfragment-data" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-layoutfragment-data">#dom-layoutfragment-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-data">4.2. Layout Fragments</a>
     <li><a href="#ref-for-dom-layoutfragment-data①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-breaktoken">
-   <b><a href="#dom-layoutfragment-breaktoken">#dom-layoutfragment-breaktoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-breaktoken" class="dfn-panel" data-for="dom-layoutfragment-breaktoken" id="infopanel-for-dom-layoutfragment-breaktoken" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-breaktoken" style="display:none">Info about the 'breakToken' definition.</span><b><a href="#dom-layoutfragment-breaktoken">#dom-layoutfragment-breaktoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-breaktoken">4.2. Layout Fragments</a> <a href="#ref-for-dom-layoutfragment-breaktoken①">(2)</a> <a href="#ref-for-dom-layoutfragment-breaktoken②">(3)</a> <a href="#ref-for-dom-layoutfragment-breaktoken③">(4)</a> <a href="#ref-for-dom-layoutfragment-breaktoken④">(5)</a>
     <li><a href="#ref-for-dom-layoutfragment-breaktoken⑤">4.5. Breaking and Fragmentation</a>
@@ -4715,91 +4716,91 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutfragment-breaktoken⑦">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutfragment-unique-id-slot">
-   <b><a href="#dom-layoutfragment-unique-id-slot">#dom-layoutfragment-unique-id-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutfragment-unique-id-slot" class="dfn-panel" data-for="dom-layoutfragment-unique-id-slot" id="infopanel-for-dom-layoutfragment-unique-id-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutfragment-unique-id-slot" style="display:none">Info about the '[[unique id]]' definition.</span><b><a href="#dom-layoutfragment-unique-id-slot">#dom-layoutfragment-unique-id-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutfragment-unique-id-slot">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsicsizes">
-   <b><a href="#intrinsicsizes">#intrinsicsizes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsicsizes" class="dfn-panel" data-for="intrinsicsizes" id="infopanel-for-intrinsicsizes" role="dialog">
+   <span id="infopaneltitle-for-intrinsicsizes" style="display:none">Info about the 'IntrinsicSizes' definition.</span><b><a href="#intrinsicsizes">#intrinsicsizes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsicsizes">4.1. Layout Children</a>
     <li><a href="#ref-for-intrinsicsizes①">4.3. Intrinsic Sizes</a>
     <li><a href="#ref-for-intrinsicsizes②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intrinsicsizes-mincontentsize">
-   <b><a href="#dom-intrinsicsizes-mincontentsize">#dom-intrinsicsizes-mincontentsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intrinsicsizes-mincontentsize" class="dfn-panel" data-for="dom-intrinsicsizes-mincontentsize" id="infopanel-for-dom-intrinsicsizes-mincontentsize" role="dialog">
+   <span id="infopaneltitle-for-dom-intrinsicsizes-mincontentsize" style="display:none">Info about the 'minContentSize' definition.</span><b><a href="#dom-intrinsicsizes-mincontentsize">#dom-intrinsicsizes-mincontentsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intrinsicsizes-mincontentsize">4.3. Intrinsic Sizes</a> <a href="#ref-for-dom-intrinsicsizes-mincontentsize①">(2)</a>
     <li><a href="#ref-for-dom-intrinsicsizes-mincontentsize②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intrinsicsizes-maxcontentsize">
-   <b><a href="#dom-intrinsicsizes-maxcontentsize">#dom-intrinsicsizes-maxcontentsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intrinsicsizes-maxcontentsize" class="dfn-panel" data-for="dom-intrinsicsizes-maxcontentsize" id="infopanel-for-dom-intrinsicsizes-maxcontentsize" role="dialog">
+   <span id="infopaneltitle-for-dom-intrinsicsizes-maxcontentsize" style="display:none">Info about the 'maxContentSize' definition.</span><b><a href="#dom-intrinsicsizes-maxcontentsize">#dom-intrinsicsizes-maxcontentsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intrinsicsizes-maxcontentsize">4.3. Intrinsic Sizes</a> <a href="#ref-for-dom-intrinsicsizes-maxcontentsize①">(2)</a>
     <li><a href="#ref-for-dom-intrinsicsizes-maxcontentsize②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutconstraints">
-   <b><a href="#layoutconstraints">#layoutconstraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutconstraints" class="dfn-panel" data-for="layoutconstraints" id="infopanel-for-layoutconstraints" role="dialog">
+   <span id="infopaneltitle-for-layoutconstraints" style="display:none">Info about the 'LayoutConstraints' definition.</span><b><a href="#layoutconstraints">#layoutconstraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutconstraints">4.4. Layout Constraints</a> <a href="#ref-for-layoutconstraints①">(2)</a> <a href="#ref-for-layoutconstraints②">(3)</a> <a href="#ref-for-layoutconstraints③">(4)</a> <a href="#ref-for-layoutconstraints④">(5)</a> <a href="#ref-for-layoutconstraints⑤">(6)</a> <a href="#ref-for-layoutconstraints⑥">(7)</a> <a href="#ref-for-layoutconstraints⑦">(8)</a>
     <li><a href="#ref-for-layoutconstraints⑧">5.1. Sizing</a> <a href="#ref-for-layoutconstraints⑨">(2)</a>
     <li><a href="#ref-for-layoutconstraints①⓪">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-availableinlinesize">
-   <b><a href="#dom-layoutconstraints-availableinlinesize">#dom-layoutconstraints-availableinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-availableinlinesize" class="dfn-panel" data-for="dom-layoutconstraints-availableinlinesize" id="infopanel-for-dom-layoutconstraints-availableinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-availableinlinesize" style="display:none">Info about the 'availableInlineSize' definition.</span><b><a href="#dom-layoutconstraints-availableinlinesize">#dom-layoutconstraints-availableinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-availableinlinesize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-availableinlinesize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-availableinlinesize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-availableblocksize">
-   <b><a href="#dom-layoutconstraints-availableblocksize">#dom-layoutconstraints-availableblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-availableblocksize" class="dfn-panel" data-for="dom-layoutconstraints-availableblocksize" id="infopanel-for-dom-layoutconstraints-availableblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-availableblocksize" style="display:none">Info about the 'availableBlockSize' definition.</span><b><a href="#dom-layoutconstraints-availableblocksize">#dom-layoutconstraints-availableblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-availableblocksize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-availableblocksize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-availableblocksize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-fixedinlinesize">
-   <b><a href="#dom-layoutconstraints-fixedinlinesize">#dom-layoutconstraints-fixedinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-fixedinlinesize" class="dfn-panel" data-for="dom-layoutconstraints-fixedinlinesize" id="infopanel-for-dom-layoutconstraints-fixedinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-fixedinlinesize" style="display:none">Info about the 'fixedInlineSize' definition.</span><b><a href="#dom-layoutconstraints-fixedinlinesize">#dom-layoutconstraints-fixedinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-fixedinlinesize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize②">(3)</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize③">(4)</a>
     <li><a href="#ref-for-dom-layoutconstraints-fixedinlinesize④">5.1. Sizing</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize⑤">(2)</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize⑥">(3)</a> <a href="#ref-for-dom-layoutconstraints-fixedinlinesize⑦">(4)</a>
     <li><a href="#ref-for-dom-layoutconstraints-fixedinlinesize⑧">5.1.1. Positioned layout sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-fixedblocksize">
-   <b><a href="#dom-layoutconstraints-fixedblocksize">#dom-layoutconstraints-fixedblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-fixedblocksize" class="dfn-panel" data-for="dom-layoutconstraints-fixedblocksize" id="infopanel-for-dom-layoutconstraints-fixedblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-fixedblocksize" style="display:none">Info about the 'fixedBlockSize' definition.</span><b><a href="#dom-layoutconstraints-fixedblocksize">#dom-layoutconstraints-fixedblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-fixedblocksize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize②">(3)</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize③">(4)</a>
     <li><a href="#ref-for-dom-layoutconstraints-fixedblocksize④">5.1. Sizing</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize⑤">(2)</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize⑥">(3)</a> <a href="#ref-for-dom-layoutconstraints-fixedblocksize⑦">(4)</a>
     <li><a href="#ref-for-dom-layoutconstraints-fixedblocksize⑧">5.1.1. Positioned layout sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-percentageinlinesize">
-   <b><a href="#dom-layoutconstraints-percentageinlinesize">#dom-layoutconstraints-percentageinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-percentageinlinesize" class="dfn-panel" data-for="dom-layoutconstraints-percentageinlinesize" id="infopanel-for-dom-layoutconstraints-percentageinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-percentageinlinesize" style="display:none">Info about the 'percentageInlineSize' definition.</span><b><a href="#dom-layoutconstraints-percentageinlinesize">#dom-layoutconstraints-percentageinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-percentageinlinesize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-percentageinlinesize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-percentageinlinesize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-percentageblocksize">
-   <b><a href="#dom-layoutconstraints-percentageblocksize">#dom-layoutconstraints-percentageblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-percentageblocksize" class="dfn-panel" data-for="dom-layoutconstraints-percentageblocksize" id="infopanel-for-dom-layoutconstraints-percentageblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-percentageblocksize" style="display:none">Info about the 'percentageBlockSize' definition.</span><b><a href="#dom-layoutconstraints-percentageblocksize">#dom-layoutconstraints-percentageblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-percentageblocksize">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-percentageblocksize①">(2)</a> <a href="#ref-for-dom-layoutconstraints-percentageblocksize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-blockfragmentationoffset">
-   <b><a href="#dom-layoutconstraints-blockfragmentationoffset">#dom-layoutconstraints-blockfragmentationoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-blockfragmentationoffset" class="dfn-panel" data-for="dom-layoutconstraints-blockfragmentationoffset" id="infopanel-for-dom-layoutconstraints-blockfragmentationoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-blockfragmentationoffset" style="display:none">Info about the 'blockFragmentationOffset' definition.</span><b><a href="#dom-layoutconstraints-blockfragmentationoffset">#dom-layoutconstraints-blockfragmentationoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-blockfragmentationoffset">4.4. Layout Constraints</a>
     <li><a href="#ref-for-dom-layoutconstraints-blockfragmentationoffset①">5.4. Fragmentation</a> <a href="#ref-for-dom-layoutconstraints-blockfragmentationoffset②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-blockfragmentationtype">
-   <b><a href="#dom-layoutconstraints-blockfragmentationtype">#dom-layoutconstraints-blockfragmentationtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-blockfragmentationtype" class="dfn-panel" data-for="dom-layoutconstraints-blockfragmentationtype" id="infopanel-for-dom-layoutconstraints-blockfragmentationtype" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-blockfragmentationtype" style="display:none">Info about the 'blockFragmentationType' definition.</span><b><a href="#dom-layoutconstraints-blockfragmentationtype">#dom-layoutconstraints-blockfragmentationtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-blockfragmentationtype">4.4. Layout Constraints</a> <a href="#ref-for-dom-layoutconstraints-blockfragmentationtype①">(2)</a>
     <li><a href="#ref-for-dom-layoutconstraints-blockfragmentationtype②">4.5. Breaking and Fragmentation</a>
@@ -4807,28 +4808,28 @@ resume the layout.</p>
     <li><a href="#ref-for-dom-layoutconstraints-blockfragmentationtype⑤">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraints-data">
-   <b><a href="#dom-layoutconstraints-data">#dom-layoutconstraints-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraints-data" class="dfn-panel" data-for="dom-layoutconstraints-data" id="infopanel-for-dom-layoutconstraints-data" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraints-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-layoutconstraints-data">#dom-layoutconstraints-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraints-data">4.4.1. Constraints for Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-blockfragmentationtype">
-   <b><a href="#enumdef-blockfragmentationtype">#enumdef-blockfragmentationtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-blockfragmentationtype" class="dfn-panel" data-for="enumdef-blockfragmentationtype" id="infopanel-for-enumdef-blockfragmentationtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-blockfragmentationtype" style="display:none">Info about the 'BlockFragmentationType' definition.</span><b><a href="#enumdef-blockfragmentationtype">#enumdef-blockfragmentationtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-blockfragmentationtype">4.4. Layout Constraints</a>
     <li><a href="#ref-for-enumdef-blockfragmentationtype①">4.4.1. Constraints for Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-layout-constraints-object">
-   <b><a href="#create-a-layout-constraints-object">#create-a-layout-constraints-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-layout-constraints-object" class="dfn-panel" data-for="create-a-layout-constraints-object" id="infopanel-for-create-a-layout-constraints-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-layout-constraints-object" style="display:none">Info about the 'create a layout constraints object' definition.</span><b><a href="#create-a-layout-constraints-object">#create-a-layout-constraints-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-layout-constraints-object">4.4. Layout Constraints</a>
     <li><a href="#ref-for-create-a-layout-constraints-object①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-layoutconstraintsoptions">
-   <b><a href="#dictdef-layoutconstraintsoptions">#dictdef-layoutconstraintsoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-layoutconstraintsoptions" class="dfn-panel" data-for="dictdef-layoutconstraintsoptions" id="infopanel-for-dictdef-layoutconstraintsoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-layoutconstraintsoptions" style="display:none">Info about the 'LayoutConstraintsOptions' definition.</span><b><a href="#dictdef-layoutconstraintsoptions">#dictdef-layoutconstraintsoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-layoutconstraintsoptions">4.1. Layout Children</a>
     <li><a href="#ref-for-dictdef-layoutconstraintsoptions①">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dictdef-layoutconstraintsoptions②">(2)</a> <a href="#ref-for-dictdef-layoutconstraintsoptions③">(3)</a>
@@ -4836,57 +4837,57 @@ resume the layout.</p>
     <li><a href="#ref-for-dictdef-layoutconstraintsoptions⑤">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-availableinlinesize">
-   <b><a href="#dom-layoutconstraintsoptions-availableinlinesize">#dom-layoutconstraintsoptions-availableinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-availableinlinesize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-availableinlinesize" id="infopanel-for-dom-layoutconstraintsoptions-availableinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-availableinlinesize" style="display:none">Info about the 'availableInlineSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-availableinlinesize">#dom-layoutconstraintsoptions-availableinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize①">(2)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize②">(3)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize③">(4)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize④">(5)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableinlinesize⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-availableblocksize">
-   <b><a href="#dom-layoutconstraintsoptions-availableblocksize">#dom-layoutconstraintsoptions-availableblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-availableblocksize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-availableblocksize" id="infopanel-for-dom-layoutconstraintsoptions-availableblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-availableblocksize" style="display:none">Info about the 'availableBlockSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-availableblocksize">#dom-layoutconstraintsoptions-availableblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize①">(2)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize②">(3)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize③">(4)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize④">(5)</a> <a href="#ref-for-dom-layoutconstraintsoptions-availableblocksize⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-fixedinlinesize">
-   <b><a href="#dom-layoutconstraintsoptions-fixedinlinesize">#dom-layoutconstraintsoptions-fixedinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-fixedinlinesize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-fixedinlinesize" id="infopanel-for-dom-layoutconstraintsoptions-fixedinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-fixedinlinesize" style="display:none">Info about the 'fixedInlineSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-fixedinlinesize">#dom-layoutconstraintsoptions-fixedinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-fixedinlinesize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-fixedinlinesize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-fixedblocksize">
-   <b><a href="#dom-layoutconstraintsoptions-fixedblocksize">#dom-layoutconstraintsoptions-fixedblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-fixedblocksize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-fixedblocksize" id="infopanel-for-dom-layoutconstraintsoptions-fixedblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-fixedblocksize" style="display:none">Info about the 'fixedBlockSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-fixedblocksize">#dom-layoutconstraintsoptions-fixedblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-fixedblocksize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-fixedblocksize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-percentageinlinesize">
-   <b><a href="#dom-layoutconstraintsoptions-percentageinlinesize">#dom-layoutconstraintsoptions-percentageinlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-percentageinlinesize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-percentageinlinesize" id="infopanel-for-dom-layoutconstraintsoptions-percentageinlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-percentageinlinesize" style="display:none">Info about the 'percentageInlineSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-percentageinlinesize">#dom-layoutconstraintsoptions-percentageinlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-percentageinlinesize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-percentageinlinesize①">(2)</a> <a href="#ref-for-dom-layoutconstraintsoptions-percentageinlinesize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-percentageblocksize">
-   <b><a href="#dom-layoutconstraintsoptions-percentageblocksize">#dom-layoutconstraintsoptions-percentageblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-percentageblocksize" class="dfn-panel" data-for="dom-layoutconstraintsoptions-percentageblocksize" id="infopanel-for-dom-layoutconstraintsoptions-percentageblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-percentageblocksize" style="display:none">Info about the 'percentageBlockSize' definition.</span><b><a href="#dom-layoutconstraintsoptions-percentageblocksize">#dom-layoutconstraintsoptions-percentageblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-percentageblocksize">4.4.1. Constraints for Layout Children</a> <a href="#ref-for-dom-layoutconstraintsoptions-percentageblocksize①">(2)</a> <a href="#ref-for-dom-layoutconstraintsoptions-percentageblocksize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutconstraintsoptions-data">
-   <b><a href="#dom-layoutconstraintsoptions-data">#dom-layoutconstraintsoptions-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutconstraintsoptions-data" class="dfn-panel" data-for="dom-layoutconstraintsoptions-data" id="infopanel-for-dom-layoutconstraintsoptions-data" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutconstraintsoptions-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-layoutconstraintsoptions-data">#dom-layoutconstraintsoptions-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutconstraintsoptions-data">4.4.1. Constraints for Layout Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="translate-a-layoutconstraintsoptions-to-internal-constraints">
-   <b><a href="#translate-a-layoutconstraintsoptions-to-internal-constraints">#translate-a-layoutconstraintsoptions-to-internal-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-translate-a-layoutconstraintsoptions-to-internal-constraints" class="dfn-panel" data-for="translate-a-layoutconstraintsoptions-to-internal-constraints" id="infopanel-for-translate-a-layoutconstraintsoptions-to-internal-constraints" role="dialog">
+   <span id="infopaneltitle-for-translate-a-layoutconstraintsoptions-to-internal-constraints" style="display:none">Info about the 'translate a LayoutConstraintsOptions to internal constraints' definition.</span><b><a href="#translate-a-layoutconstraintsoptions-to-internal-constraints">#translate-a-layoutconstraintsoptions-to-internal-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-translate-a-layoutconstraintsoptions-to-internal-constraints">4.4.1. Constraints for Layout Children</a>
     <li><a href="#ref-for-translate-a-layoutconstraintsoptions-to-internal-constraints①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="childbreaktoken">
-   <b><a href="#childbreaktoken">#childbreaktoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-childbreaktoken" class="dfn-panel" data-for="childbreaktoken" id="infopanel-for-childbreaktoken" role="dialog">
+   <span id="infopaneltitle-for-childbreaktoken" style="display:none">Info about the 'ChildBreakToken' definition.</span><b><a href="#childbreaktoken">#childbreaktoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-childbreaktoken">4.1. Layout Children</a>
     <li><a href="#ref-for-childbreaktoken①">4.2. Layout Fragments</a>
@@ -4895,132 +4896,132 @@ resume the layout.</p>
     <li><a href="#ref-for-childbreaktoken⑧">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="breaktoken">
-   <b><a href="#breaktoken">#breaktoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-breaktoken" class="dfn-panel" data-for="breaktoken" id="infopanel-for-breaktoken" role="dialog">
+   <span id="infopaneltitle-for-breaktoken" style="display:none">Info about the 'BreakToken' definition.</span><b><a href="#breaktoken">#breaktoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-breaktoken">6.2.2. Generating Fragments</a>
     <li><a href="#ref-for-breaktoken①">7. Examples</a> <a href="#ref-for-breaktoken②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-breaktokenoptions">
-   <b><a href="#dictdef-breaktokenoptions">#dictdef-breaktokenoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-breaktokenoptions" class="dfn-panel" data-for="dictdef-breaktokenoptions" id="infopanel-for-dictdef-breaktokenoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-breaktokenoptions" style="display:none">Info about the 'BreakTokenOptions' definition.</span><b><a href="#dictdef-breaktokenoptions">#dictdef-breaktokenoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-breaktokenoptions">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-breaktokenoptions-childbreaktokens">
-   <b><a href="#dom-breaktokenoptions-childbreaktokens">#dom-breaktokenoptions-childbreaktokens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-breaktokenoptions-childbreaktokens" class="dfn-panel" data-for="dom-breaktokenoptions-childbreaktokens" id="infopanel-for-dom-breaktokenoptions-childbreaktokens" role="dialog">
+   <span id="infopaneltitle-for-dom-breaktokenoptions-childbreaktokens" style="display:none">Info about the 'childBreakTokens' definition.</span><b><a href="#dom-breaktokenoptions-childbreaktokens">#dom-breaktokenoptions-childbreaktokens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-breaktokenoptions-childbreaktokens">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-breaktokenoptions-data">
-   <b><a href="#dom-breaktokenoptions-data">#dom-breaktokenoptions-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-breaktokenoptions-data" class="dfn-panel" data-for="dom-breaktokenoptions-data" id="infopanel-for-dom-breaktokenoptions-data" role="dialog">
+   <span id="infopaneltitle-for-dom-breaktokenoptions-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-breaktokenoptions-data">#dom-breaktokenoptions-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-breaktokenoptions-data">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-breaktype">
-   <b><a href="#enumdef-breaktype">#enumdef-breaktype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-breaktype" class="dfn-panel" data-for="enumdef-breaktype" id="infopanel-for-enumdef-breaktype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-breaktype" style="display:none">Info about the 'BreakType' definition.</span><b><a href="#enumdef-breaktype">#enumdef-breaktype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-breaktype">4.5. Breaking and Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-childbreaktoken-unique-id-slot">
-   <b><a href="#dom-childbreaktoken-unique-id-slot">#dom-childbreaktoken-unique-id-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-childbreaktoken-unique-id-slot" class="dfn-panel" data-for="dom-childbreaktoken-unique-id-slot" id="infopanel-for-dom-childbreaktoken-unique-id-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-childbreaktoken-unique-id-slot" style="display:none">Info about the '[[unique id]]' definition.</span><b><a href="#dom-childbreaktoken-unique-id-slot">#dom-childbreaktoken-unique-id-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-childbreaktoken-unique-id-slot">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layoutedges">
-   <b><a href="#layoutedges">#layoutedges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layoutedges" class="dfn-panel" data-for="layoutedges" id="infopanel-for-layoutedges" role="dialog">
+   <span id="infopaneltitle-for-layoutedges" style="display:none">Info about the 'LayoutEdges' definition.</span><b><a href="#layoutedges">#layoutedges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layoutedges">4.6. Edges</a> <a href="#ref-for-layoutedges①">(2)</a> <a href="#ref-for-layoutedges②">(3)</a> <a href="#ref-for-layoutedges③">(4)</a>
     <li><a href="#ref-for-layoutedges④">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-layoutedges⑤">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-inlinestart">
-   <b><a href="#dom-layoutedges-inlinestart">#dom-layoutedges-inlinestart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-inlinestart" class="dfn-panel" data-for="dom-layoutedges-inlinestart" id="infopanel-for-dom-layoutedges-inlinestart" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-inlinestart" style="display:none">Info about the 'inlineStart' definition.</span><b><a href="#dom-layoutedges-inlinestart">#dom-layoutedges-inlinestart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-inlinestart">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-inlineend">
-   <b><a href="#dom-layoutedges-inlineend">#dom-layoutedges-inlineend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-inlineend" class="dfn-panel" data-for="dom-layoutedges-inlineend" id="infopanel-for-dom-layoutedges-inlineend" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-inlineend" style="display:none">Info about the 'inlineEnd' definition.</span><b><a href="#dom-layoutedges-inlineend">#dom-layoutedges-inlineend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-inlineend">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-blockstart">
-   <b><a href="#dom-layoutedges-blockstart">#dom-layoutedges-blockstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-blockstart" class="dfn-panel" data-for="dom-layoutedges-blockstart" id="infopanel-for-dom-layoutedges-blockstart" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-blockstart" style="display:none">Info about the 'blockStart' definition.</span><b><a href="#dom-layoutedges-blockstart">#dom-layoutedges-blockstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-blockstart">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-blockend">
-   <b><a href="#dom-layoutedges-blockend">#dom-layoutedges-blockend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-blockend" class="dfn-panel" data-for="dom-layoutedges-blockend" id="infopanel-for-dom-layoutedges-blockend" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-blockend" style="display:none">Info about the 'blockEnd' definition.</span><b><a href="#dom-layoutedges-blockend">#dom-layoutedges-blockend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-blockend">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-inline">
-   <b><a href="#dom-layoutedges-inline">#dom-layoutedges-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-inline" class="dfn-panel" data-for="dom-layoutedges-inline" id="infopanel-for-dom-layoutedges-inline" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#dom-layoutedges-inline">#dom-layoutedges-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-inline">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-layoutedges-block">
-   <b><a href="#dom-layoutedges-block">#dom-layoutedges-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-layoutedges-block" class="dfn-panel" data-for="dom-layoutedges-block" id="infopanel-for-dom-layoutedges-block" role="dialog">
+   <span id="infopaneltitle-for-dom-layoutedges-block" style="display:none">Info about the 'block' definition.</span><b><a href="#dom-layoutedges-block">#dom-layoutedges-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-layoutedges-block">4.6. Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task">
-   <b><a href="#layout-api-work-task">#layout-api-work-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task" class="dfn-panel" data-for="layout-api-work-task" id="infopanel-for-layout-api-work-task" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task" style="display:none">Info about the 'layout API work task' definition.</span><b><a href="#layout-api-work-task">#layout-api-work-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task">4.1. Layout Children</a> <a href="#ref-for-layout-api-work-task①">(2)</a>
     <li><a href="#ref-for-layout-api-work-task②">6.1. Processing Model</a>
     <li><a href="#ref-for-layout-api-work-task③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task-layout-constraints">
-   <b><a href="#layout-api-work-task-layout-constraints">#layout-api-work-task-layout-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task-layout-constraints" class="dfn-panel" data-for="layout-api-work-task-layout-constraints" id="infopanel-for-layout-api-work-task-layout-constraints" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task-layout-constraints" style="display:none">Info about the 'layout constraints' definition.</span><b><a href="#layout-api-work-task-layout-constraints">#layout-api-work-task-layout-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task-layout-constraints">4.1. Layout Children</a>
     <li><a href="#ref-for-layout-api-work-task-layout-constraints①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task-layout-child">
-   <b><a href="#layout-api-work-task-layout-child">#layout-api-work-task-layout-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task-layout-child" class="dfn-panel" data-for="layout-api-work-task-layout-child" id="infopanel-for-layout-api-work-task-layout-child" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task-layout-child" style="display:none">Info about the 'layout child' definition.</span><b><a href="#layout-api-work-task-layout-child">#layout-api-work-task-layout-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task-layout-child">4.1. Layout Children</a> <a href="#ref-for-layout-api-work-task-layout-child①">(2)</a>
     <li><a href="#ref-for-layout-api-work-task-layout-child②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task-child-break-token">
-   <b><a href="#layout-api-work-task-child-break-token">#layout-api-work-task-child-break-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task-child-break-token" class="dfn-panel" data-for="layout-api-work-task-child-break-token" id="infopanel-for-layout-api-work-task-child-break-token" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task-child-break-token" style="display:none">Info about the 'child break token' definition.</span><b><a href="#layout-api-work-task-child-break-token">#layout-api-work-task-child-break-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task-child-break-token">4.1. Layout Children</a>
     <li><a href="#ref-for-layout-api-work-task-child-break-token①">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task-task-type">
-   <b><a href="#layout-api-work-task-task-type">#layout-api-work-task-task-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task-task-type" class="dfn-panel" data-for="layout-api-work-task-task-type" id="infopanel-for-layout-api-work-task-task-type" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task-task-type" style="display:none">Info about the 'task type' definition.</span><b><a href="#layout-api-work-task-task-type">#layout-api-work-task-task-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task-task-type">4.1. Layout Children</a> <a href="#ref-for-layout-api-work-task-task-type①">(2)</a>
     <li><a href="#ref-for-layout-api-work-task-task-type②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-work-task-promise">
-   <b><a href="#layout-api-work-task-promise">#layout-api-work-task-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-work-task-promise" class="dfn-panel" data-for="layout-api-work-task-promise" id="infopanel-for-layout-api-work-task-promise" role="dialog">
+   <span id="infopaneltitle-for-layout-api-work-task-promise" style="display:none">Info about the 'promise' definition.</span><b><a href="#layout-api-work-task-promise">#layout-api-work-task-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-work-task-promise">4.1. Layout Children</a> <a href="#ref-for-layout-api-work-task-promise①">(2)</a>
     <li><a href="#ref-for-layout-api-work-task-promise②">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-context">
-   <b><a href="#layout-api-context">#layout-api-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-context" class="dfn-panel" data-for="layout-api-context" id="infopanel-for-layout-api-context" role="dialog">
+   <span id="infopaneltitle-for-layout-api-context" style="display:none">Info about the 'layout API context' definition.</span><b><a href="#layout-api-context">#layout-api-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-context">4.1. Layout Children</a> <a href="#ref-for-layout-api-context①">(2)</a> <a href="#ref-for-layout-api-context②">(3)</a>
     <li><a href="#ref-for-layout-api-context③">4.2. Layout Fragments</a>
@@ -5029,16 +5030,16 @@ resume the layout.</p>
     <li><a href="#ref-for-layout-api-context⑥">6.2. Performing Layout</a> <a href="#ref-for-layout-api-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-context-work-queue">
-   <b><a href="#layout-api-context-work-queue">#layout-api-context-work-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-context-work-queue" class="dfn-panel" data-for="layout-api-context-work-queue" id="infopanel-for-layout-api-context-work-queue" role="dialog">
+   <span id="infopaneltitle-for-layout-api-context-work-queue" style="display:none">Info about the 'work queue' definition.</span><b><a href="#layout-api-context-work-queue">#layout-api-context-work-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-context-work-queue">4.1. Layout Children</a> <a href="#ref-for-layout-api-context-work-queue①">(2)</a>
     <li><a href="#ref-for-layout-api-context-work-queue②">6.1. Processing Model</a>
     <li><a href="#ref-for-layout-api-context-work-queue③">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-context-unique-id">
-   <b><a href="#layout-api-context-unique-id">#layout-api-context-unique-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-context-unique-id" class="dfn-panel" data-for="layout-api-context-unique-id" id="infopanel-for-layout-api-context-unique-id" role="dialog">
+   <span id="infopaneltitle-for-layout-api-context-unique-id" style="display:none">Info about the 'unique id' definition.</span><b><a href="#layout-api-context-unique-id">#layout-api-context-unique-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-context-unique-id">4.1. Layout Children</a> <a href="#ref-for-layout-api-context-unique-id①">(2)</a> <a href="#ref-for-layout-api-context-unique-id②">(3)</a> <a href="#ref-for-layout-api-context-unique-id③">(4)</a>
     <li><a href="#ref-for-layout-api-context-unique-id④">4.2. Layout Fragments</a>
@@ -5049,22 +5050,22 @@ resume the layout.</p>
     <li><a href="#ref-for-layout-api-context-unique-id①⓪">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-api-context-mode">
-   <b><a href="#layout-api-context-mode">#layout-api-context-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-api-context-mode" class="dfn-panel" data-for="layout-api-context-mode" id="infopanel-for-layout-api-context-mode" role="dialog">
+   <span id="infopaneltitle-for-layout-api-context-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#layout-api-context-mode">#layout-api-context-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-api-context-mode">4.1. Layout Children</a>
     <li><a href="#ref-for-layout-api-context-mode①">6.1. Processing Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-layout-api-context">
-   <b><a href="#create-a-layout-api-context">#create-a-layout-api-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-layout-api-context" class="dfn-panel" data-for="create-a-layout-api-context" id="infopanel-for-create-a-layout-api-context" role="dialog">
+   <span id="infopaneltitle-for-create-a-layout-api-context" style="display:none">Info about the 'create a layout API context' definition.</span><b><a href="#create-a-layout-api-context">#create-a-layout-api-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-layout-api-context">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-create-a-layout-api-context①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fragmentresultoptions">
-   <b><a href="#dictdef-fragmentresultoptions">#dictdef-fragmentresultoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fragmentresultoptions" class="dfn-panel" data-for="dictdef-fragmentresultoptions" id="infopanel-for-dictdef-fragmentresultoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fragmentresultoptions" style="display:none">Info about the 'FragmentResultOptions' definition.</span><b><a href="#dictdef-fragmentresultoptions">#dictdef-fragmentresultoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fragmentresultoptions">4.2. Layout Fragments</a>
     <li><a href="#ref-for-dictdef-fragmentresultoptions①">6.1. Processing Model</a>
@@ -5073,180 +5074,180 @@ resume the layout.</p>
     <li><a href="#ref-for-dictdef-fragmentresultoptions⑦">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-inlinesize">
-   <b><a href="#dom-fragmentresultoptions-inlinesize">#dom-fragmentresultoptions-inlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-inlinesize" class="dfn-panel" data-for="dom-fragmentresultoptions-inlinesize" id="infopanel-for-dom-fragmentresultoptions-inlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-inlinesize" style="display:none">Info about the 'inlineSize' definition.</span><b><a href="#dom-fragmentresultoptions-inlinesize">#dom-fragmentresultoptions-inlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-inlinesize">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-blocksize">
-   <b><a href="#dom-fragmentresultoptions-blocksize">#dom-fragmentresultoptions-blocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-blocksize" class="dfn-panel" data-for="dom-fragmentresultoptions-blocksize" id="infopanel-for-dom-fragmentresultoptions-blocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-blocksize" style="display:none">Info about the 'blockSize' definition.</span><b><a href="#dom-fragmentresultoptions-blocksize">#dom-fragmentresultoptions-blocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-blocksize">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-autoblocksize">
-   <b><a href="#dom-fragmentresultoptions-autoblocksize">#dom-fragmentresultoptions-autoblocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-autoblocksize" class="dfn-panel" data-for="dom-fragmentresultoptions-autoblocksize" id="infopanel-for-dom-fragmentresultoptions-autoblocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-autoblocksize" style="display:none">Info about the 'autoBlockSize' definition.</span><b><a href="#dom-fragmentresultoptions-autoblocksize">#dom-fragmentresultoptions-autoblocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-autoblocksize">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-childfragments">
-   <b><a href="#dom-fragmentresultoptions-childfragments">#dom-fragmentresultoptions-childfragments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-childfragments" class="dfn-panel" data-for="dom-fragmentresultoptions-childfragments" id="infopanel-for-dom-fragmentresultoptions-childfragments" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-childfragments" style="display:none">Info about the 'childFragments' definition.</span><b><a href="#dom-fragmentresultoptions-childfragments">#dom-fragmentresultoptions-childfragments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-childfragments">2.1. Layout API Container Painting</a>
     <li><a href="#ref-for-dom-fragmentresultoptions-childfragments①">5.5. Alignment</a>
     <li><a href="#ref-for-dom-fragmentresultoptions-childfragments②">6.2. Performing Layout</a> <a href="#ref-for-dom-fragmentresultoptions-childfragments③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-data">
-   <b><a href="#dom-fragmentresultoptions-data">#dom-fragmentresultoptions-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-data" class="dfn-panel" data-for="dom-fragmentresultoptions-data" id="infopanel-for-dom-fragmentresultoptions-data" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-fragmentresultoptions-data">#dom-fragmentresultoptions-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-data">4.2. Layout Fragments</a>
     <li><a href="#ref-for-dom-fragmentresultoptions-data①">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresultoptions-breaktoken">
-   <b><a href="#dom-fragmentresultoptions-breaktoken">#dom-fragmentresultoptions-breaktoken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresultoptions-breaktoken" class="dfn-panel" data-for="dom-fragmentresultoptions-breaktoken" id="infopanel-for-dom-fragmentresultoptions-breaktoken" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresultoptions-breaktoken" style="display:none">Info about the 'breakToken' definition.</span><b><a href="#dom-fragmentresultoptions-breaktoken">#dom-fragmentresultoptions-breaktoken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresultoptions-breaktoken">6.2. Performing Layout</a>
     <li><a href="#ref-for-dom-fragmentresultoptions-breaktoken①">7. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentresult">
-   <b><a href="#fragmentresult">#fragmentresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentresult" class="dfn-panel" data-for="fragmentresult" id="infopanel-for-fragmentresult" role="dialog">
+   <span id="infopaneltitle-for-fragmentresult" style="display:none">Info about the 'FragmentResult' definition.</span><b><a href="#fragmentresult">#fragmentresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentresult">6.2. Performing Layout</a> <a href="#ref-for-fragmentresult①">(2)</a> <a href="#ref-for-fragmentresult②">(3)</a> <a href="#ref-for-fragmentresult③">(4)</a> <a href="#ref-for-fragmentresult④">(5)</a> <a href="#ref-for-fragmentresult⑤">(6)</a> <a href="#ref-for-fragmentresult⑥">(7)</a> <a href="#ref-for-fragmentresult⑦">(8)</a>
     <li><a href="#ref-for-fragmentresult⑧">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-intrinsicsizesresultoptions">
-   <b><a href="#dictdef-intrinsicsizesresultoptions">#dictdef-intrinsicsizesresultoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-intrinsicsizesresultoptions" class="dfn-panel" data-for="dictdef-intrinsicsizesresultoptions" id="infopanel-for-dictdef-intrinsicsizesresultoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-intrinsicsizesresultoptions" style="display:none">Info about the 'IntrinsicSizesResultOptions' definition.</span><b><a href="#dictdef-intrinsicsizesresultoptions">#dictdef-intrinsicsizesresultoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-intrinsicsizesresultoptions">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intrinsicsizesresultoptions-maxcontentsize">
-   <b><a href="#dom-intrinsicsizesresultoptions-maxcontentsize">#dom-intrinsicsizesresultoptions-maxcontentsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intrinsicsizesresultoptions-maxcontentsize" class="dfn-panel" data-for="dom-intrinsicsizesresultoptions-maxcontentsize" id="infopanel-for-dom-intrinsicsizesresultoptions-maxcontentsize" role="dialog">
+   <span id="infopaneltitle-for-dom-intrinsicsizesresultoptions-maxcontentsize" style="display:none">Info about the 'maxContentSize' definition.</span><b><a href="#dom-intrinsicsizesresultoptions-maxcontentsize">#dom-intrinsicsizesresultoptions-maxcontentsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intrinsicsizesresultoptions-maxcontentsize">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-intrinsicsizesresultoptions-mincontentsize">
-   <b><a href="#dom-intrinsicsizesresultoptions-mincontentsize">#dom-intrinsicsizesresultoptions-mincontentsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-intrinsicsizesresultoptions-mincontentsize" class="dfn-panel" data-for="dom-intrinsicsizesresultoptions-mincontentsize" id="infopanel-for-dom-intrinsicsizesresultoptions-mincontentsize" role="dialog">
+   <span id="infopaneltitle-for-dom-intrinsicsizesresultoptions-mincontentsize" style="display:none">Info about the 'minContentSize' definition.</span><b><a href="#dom-intrinsicsizesresultoptions-mincontentsize">#dom-intrinsicsizesresultoptions-mincontentsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-intrinsicsizesresultoptions-mincontentsize">6.2.1. Determining Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-box-slot">
-   <b><a href="#dom-fragmentresult-box-slot">#dom-fragmentresult-box-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-box-slot" class="dfn-panel" data-for="dom-fragmentresult-box-slot" id="infopanel-for-dom-fragmentresult-box-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-box-slot" style="display:none">Info about the '[[box]]' definition.</span><b><a href="#dom-fragmentresult-box-slot">#dom-fragmentresult-box-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-box-slot">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-inline-size-slot">
-   <b><a href="#dom-fragmentresult-inline-size-slot">#dom-fragmentresult-inline-size-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-inline-size-slot" class="dfn-panel" data-for="dom-fragmentresult-inline-size-slot" id="infopanel-for-dom-fragmentresult-inline-size-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-inline-size-slot" style="display:none">Info about the '[[inline size]]' definition.</span><b><a href="#dom-fragmentresult-inline-size-slot">#dom-fragmentresult-inline-size-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-inline-size-slot">6.2. Performing Layout</a> <a href="#ref-for-dom-fragmentresult-inline-size-slot①">(2)</a>
     <li><a href="#ref-for-dom-fragmentresult-inline-size-slot②">6.2.2. Generating Fragments</a> <a href="#ref-for-dom-fragmentresult-inline-size-slot③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-block-size-slot">
-   <b><a href="#dom-fragmentresult-block-size-slot">#dom-fragmentresult-block-size-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-block-size-slot" class="dfn-panel" data-for="dom-fragmentresult-block-size-slot" id="infopanel-for-dom-fragmentresult-block-size-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-block-size-slot" style="display:none">Info about the '[[block size]]' definition.</span><b><a href="#dom-fragmentresult-block-size-slot">#dom-fragmentresult-block-size-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-block-size-slot">6.2. Performing Layout</a> <a href="#ref-for-dom-fragmentresult-block-size-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-child-fragments-slot">
-   <b><a href="#dom-fragmentresult-child-fragments-slot">#dom-fragmentresult-child-fragments-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-child-fragments-slot" class="dfn-panel" data-for="dom-fragmentresult-child-fragments-slot" id="infopanel-for-dom-fragmentresult-child-fragments-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-child-fragments-slot" style="display:none">Info about the '[[child fragments]]' definition.</span><b><a href="#dom-fragmentresult-child-fragments-slot">#dom-fragmentresult-child-fragments-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-child-fragments-slot">6.2. Performing Layout</a>
     <li><a href="#ref-for-dom-fragmentresult-child-fragments-slot①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-data-slot">
-   <b><a href="#dom-fragmentresult-data-slot">#dom-fragmentresult-data-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-data-slot" class="dfn-panel" data-for="dom-fragmentresult-data-slot" id="infopanel-for-dom-fragmentresult-data-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-data-slot" style="display:none">Info about the '[[data]]' definition.</span><b><a href="#dom-fragmentresult-data-slot">#dom-fragmentresult-data-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-data-slot">6.2. Performing Layout</a>
     <li><a href="#ref-for-dom-fragmentresult-data-slot①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-internal-break-token-slot">
-   <b><a href="#dom-fragmentresult-internal-break-token-slot">#dom-fragmentresult-internal-break-token-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-internal-break-token-slot" class="dfn-panel" data-for="dom-fragmentresult-internal-break-token-slot" id="infopanel-for-dom-fragmentresult-internal-break-token-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-internal-break-token-slot" style="display:none">Info about the '[[internal break token]]' definition.</span><b><a href="#dom-fragmentresult-internal-break-token-slot">#dom-fragmentresult-internal-break-token-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-internal-break-token-slot">6.2. Performing Layout</a>
     <li><a href="#ref-for-dom-fragmentresult-internal-break-token-slot①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-unique-id-slot">
-   <b><a href="#dom-fragmentresult-unique-id-slot">#dom-fragmentresult-unique-id-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-unique-id-slot" class="dfn-panel" data-for="dom-fragmentresult-unique-id-slot" id="infopanel-for-dom-fragmentresult-unique-id-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-unique-id-slot" style="display:none">Info about the '[[unique id]]' definition.</span><b><a href="#dom-fragmentresult-unique-id-slot">#dom-fragmentresult-unique-id-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-unique-id-slot">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-inlinesize">
-   <b><a href="#dom-fragmentresult-inlinesize">#dom-fragmentresult-inlinesize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-inlinesize" class="dfn-panel" data-for="dom-fragmentresult-inlinesize" id="infopanel-for-dom-fragmentresult-inlinesize" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-inlinesize" style="display:none">Info about the 'inlineSize' definition.</span><b><a href="#dom-fragmentresult-inlinesize">#dom-fragmentresult-inlinesize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-inlinesize">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-blocksize">
-   <b><a href="#dom-fragmentresult-blocksize">#dom-fragmentresult-blocksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-blocksize" class="dfn-panel" data-for="dom-fragmentresult-blocksize" id="infopanel-for-dom-fragmentresult-blocksize" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-blocksize" style="display:none">Info about the 'blockSize' definition.</span><b><a href="#dom-fragmentresult-blocksize">#dom-fragmentresult-blocksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-blocksize">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fragmentresult-fragmentresult">
-   <b><a href="#dom-fragmentresult-fragmentresult">#dom-fragmentresult-fragmentresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fragmentresult-fragmentresult" class="dfn-panel" data-for="dom-fragmentresult-fragmentresult" id="infopanel-for-dom-fragmentresult-fragmentresult" role="dialog">
+   <span id="infopaneltitle-for-dom-fragmentresult-fragmentresult" style="display:none">Info about the 'FragmentResult(options)' definition.</span><b><a href="#dom-fragmentresult-fragmentresult">#dom-fragmentresult-fragmentresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fragmentresult-fragmentresult">6.2. Performing Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-fragment-result">
-   <b><a href="#construct-a-fragment-result">#construct-a-fragment-result</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-fragment-result" class="dfn-panel" data-for="construct-a-fragment-result" id="infopanel-for-construct-a-fragment-result" role="dialog">
+   <span id="infopaneltitle-for-construct-a-fragment-result" style="display:none">Info about the 'construct a fragment result' definition.</span><b><a href="#construct-a-fragment-result">#construct-a-fragment-result</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-fragment-result">6.2. Performing Layout</a> <a href="#ref-for-construct-a-fragment-result①">(2)</a>
     <li><a href="#ref-for-construct-a-fragment-result②">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-intrinsic-sizes">
-   <b><a href="#determine-the-intrinsic-sizes">#determine-the-intrinsic-sizes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-intrinsic-sizes" class="dfn-panel" data-for="determine-the-intrinsic-sizes" id="infopanel-for-determine-the-intrinsic-sizes" role="dialog">
+   <span id="infopaneltitle-for-determine-the-intrinsic-sizes" style="display:none">Info about the 'determine the intrinsic sizes' definition.</span><b><a href="#determine-the-intrinsic-sizes">#determine-the-intrinsic-sizes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-intrinsic-sizes">3.2. Registering A Layout</a>
     <li><a href="#ref-for-determine-the-intrinsic-sizes①">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-determine-the-intrinsic-sizes②">(2)</a>
     <li><a href="#ref-for-determine-the-intrinsic-sizes③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-an-intrinsic-sizes-callback">
-   <b><a href="#invoke-an-intrinsic-sizes-callback">#invoke-an-intrinsic-sizes-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-an-intrinsic-sizes-callback" class="dfn-panel" data-for="invoke-an-intrinsic-sizes-callback" id="infopanel-for-invoke-an-intrinsic-sizes-callback" role="dialog">
+   <span id="infopaneltitle-for-invoke-an-intrinsic-sizes-callback" style="display:none">Info about the 'invoke an intrinsic sizes callback' definition.</span><b><a href="#invoke-an-intrinsic-sizes-callback">#invoke-an-intrinsic-sizes-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-an-intrinsic-sizes-callback">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-invoke-an-intrinsic-sizes-callback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-fragment">
-   <b><a href="#generate-a-fragment">#generate-a-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-fragment" class="dfn-panel" data-for="generate-a-fragment" id="infopanel-for-generate-a-fragment" role="dialog">
+   <span id="infopaneltitle-for-generate-a-fragment" style="display:none">Info about the 'generate a fragment' definition.</span><b><a href="#generate-a-fragment">#generate-a-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-fragment">3.2. Registering A Layout</a>
     <li><a href="#ref-for-generate-a-fragment①">6.2.2. Generating Fragments</a> <a href="#ref-for-generate-a-fragment②">(2)</a>
     <li><a href="#ref-for-generate-a-fragment③">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-a-layout-callback">
-   <b><a href="#invoke-a-layout-callback">#invoke-a-layout-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-a-layout-callback" class="dfn-panel" data-for="invoke-a-layout-callback" id="infopanel-for-invoke-a-layout-callback" role="dialog">
+   <span id="infopaneltitle-for-invoke-a-layout-callback" style="display:none">Info about the 'invoke a layout callback' definition.</span><b><a href="#invoke-a-layout-callback">#invoke-a-layout-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-layout-callback">6.2.2. Generating Fragments</a> <a href="#ref-for-invoke-a-layout-callback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-document-layout-definition">
-   <b><a href="#get-a-document-layout-definition">#get-a-document-layout-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-document-layout-definition" class="dfn-panel" data-for="get-a-document-layout-definition" id="infopanel-for-get-a-document-layout-definition" role="dialog">
+   <span id="infopaneltitle-for-get-a-document-layout-definition" style="display:none">Info about the 'get a document layout definition' definition.</span><b><a href="#get-a-document-layout-definition">#get-a-document-layout-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-document-layout-definition">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-get-a-document-layout-definition①">(2)</a>
     <li><a href="#ref-for-get-a-document-layout-definition②">6.2.2. Generating Fragments</a> <a href="#ref-for-get-a-document-layout-definition③">(2)</a>
     <li><a href="#ref-for-get-a-document-layout-definition④">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-layout-definition">
-   <b><a href="#get-a-layout-definition">#get-a-layout-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-layout-definition" class="dfn-panel" data-for="get-a-layout-definition" id="infopanel-for-get-a-layout-definition" role="dialog">
+   <span id="infopaneltitle-for-get-a-layout-definition" style="display:none">Info about the 'get a layout definition' definition.</span><b><a href="#get-a-layout-definition">#get-a-layout-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-layout-definition">4.1. Layout Children</a>
     <li><a href="#ref-for-get-a-layout-definition①">4.1.1. LayoutChildren and the Box Tree</a> <a href="#ref-for-get-a-layout-definition②">(2)</a>
@@ -5255,23 +5256,23 @@ resume the layout.</p>
     <li><a href="#ref-for-get-a-layout-definition⑦">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-layout-class-instance">
-   <b><a href="#get-a-layout-class-instance">#get-a-layout-class-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-layout-class-instance" class="dfn-panel" data-for="get-a-layout-class-instance" id="infopanel-for-get-a-layout-class-instance" role="dialog">
+   <span id="infopaneltitle-for-get-a-layout-class-instance" style="display:none">Info about the 'get a layout class instance' definition.</span><b><a href="#get-a-layout-class-instance">#get-a-layout-class-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-layout-class-instance">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-get-a-layout-class-instance①">(2)</a>
     <li><a href="#ref-for-get-a-layout-class-instance②">6.2.2. Generating Fragments</a> <a href="#ref-for-get-a-layout-class-instance③">(2)</a>
     <li><a href="#ref-for-get-a-layout-class-instance④">6.2.4. Utility Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-style-map">
-   <b><a href="#get-a-style-map">#get-a-style-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-style-map" class="dfn-panel" data-for="get-a-style-map" id="infopanel-for-get-a-style-map" role="dialog">
+   <span id="infopaneltitle-for-get-a-style-map" style="display:none">Info about the 'get a style map' definition.</span><b><a href="#get-a-style-map">#get-a-style-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-style-map">6.2.1. Determining Intrinsic Sizes</a>
     <li><a href="#ref-for-get-a-style-map①">6.2.2. Generating Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-a-work-queue">
-   <b><a href="#run-a-work-queue">#run-a-work-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-a-work-queue" class="dfn-panel" data-for="run-a-work-queue" id="infopanel-for-run-a-work-queue" role="dialog">
+   <span id="infopaneltitle-for-run-a-work-queue" style="display:none">Info about the 'run a work queue' definition.</span><b><a href="#run-a-work-queue">#run-a-work-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-work-queue">6.2.1. Determining Intrinsic Sizes</a> <a href="#ref-for-run-a-work-queue①">(2)</a>
     <li><a href="#ref-for-run-a-work-queue②">6.2.2. Generating Fragments</a> <a href="#ref-for-run-a-work-queue③">(2)</a>
@@ -5280,59 +5281,115 @@ resume the layout.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/css-houdini-drafts/css-paint-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-paint-api/Overview.html
@@ -1969,64 +1969,64 @@ to fix all such channels.</p>
    <li><a href="#dom-paintworkletglobalscope-registerpaint">registerPaint(name, paintCtor)</a><span>, in § 4</span>
    <li><a href="#dom-paintsize-width">width</a><span>, in § 7</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-construct">
-   <a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-construct" class="dfn-panel" data-for="term-for-sec-construct" id="infopanel-for-term-for-sec-construct" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-construct" style="display:none">Info about the 'construct' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-construct">https://tc39.github.io/ecma262/#sec-construct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-construct">7. Drawing an image</a> <a href="#ref-for-sec-construct①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-constructor">https://tc39.github.io/ecma262/#sec-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-constructor" class="dfn-panel" data-for="term-for-sec-constructor" id="infopanel-for-term-for-sec-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-constructor" style="display:none">Info about the 'constructor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-constructor">https://tc39.github.io/ecma262/#sec-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-constructor">3. Concepts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">4. Registering Custom Paint</a> <a href="#ref-for-sec-get-o-p①">(2)</a> <a href="#ref-for-sec-get-o-p②">(3)</a> <a href="#ref-for-sec-get-o-p③">(4)</a> <a href="#ref-for-sec-get-o-p④">(5)</a>
     <li><a href="#ref-for-sec-get-o-p⑤">7. Drawing an image</a> <a href="#ref-for-sec-get-o-p⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isconstructor">
-   <a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isconstructor" class="dfn-panel" data-for="term-for-sec-isconstructor" id="infopanel-for-term-for-sec-isconstructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isconstructor" style="display:none">Info about the 'isconstructor' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isconstructor">https://tc39.github.io/ecma262/#sec-isconstructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isconstructor">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'typeerror' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">4. Registering Custom Paint</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">(3)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">8.5. Example 5: Drawing outside an element’s area</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">5. Paint Notation</a>
     <li><a href="#ref-for-computed-value①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">7. Drawing an image</a> <a href="#ref-for-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">Unnumbered Section</a>
     <li><a href="#ref-for-typedef-image①">1. Introduction</a>
@@ -2035,333 +2035,333 @@ to fix all such channels.</p>
     <li><a href="#ref-for-typedef-image⑥">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concrete-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concrete-object-size" class="dfn-panel" data-for="term-for-concrete-object-size" id="infopanel-for-term-for-concrete-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-concrete-object-size" style="display:none">Info about the 'concrete object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concrete-object-size">6. The 2D rendering context</a>
     <li><a href="#ref-for-concrete-object-size①">7. Drawing an image</a> <a href="#ref-for-concrete-object-size②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">7. Drawing an image</a> <a href="#ref-for-natural-dimensions①">(2)</a> <a href="#ref-for-natural-dimensions②">(3)</a> <a href="#ref-for-natural-dimensions③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-size-negotiation">
-   <a href="https://drafts.csswg.org/css-images-3/#object-size-negotiation">https://drafts.csswg.org/css-images-3/#object-size-negotiation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-size-negotiation" class="dfn-panel" data-for="term-for-object-size-negotiation" id="infopanel-for-term-for-object-size-negotiation" role="menu">
+   <span id="infopaneltitle-for-term-for-object-size-negotiation" style="display:none">Info about the 'object size negotiation' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#object-size-negotiation">https://drafts.csswg.org/css-images-3/#object-size-negotiation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-size-negotiation">7. Drawing an image</a> <a href="#ref-for-object-size-negotiation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-image">
-   <a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-image" class="dfn-panel" data-for="term-for-invalid-image" id="infopanel-for-term-for-invalid-image" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-image" style="display:none">Info about the 'invalid image' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">5. Paint Notation</a> <a href="#ref-for-invalid-image①">(2)</a>
     <li><a href="#ref-for-invalid-image②">7. Drawing an image</a> <a href="#ref-for-invalid-image③">(2)</a> <a href="#ref-for-invalid-image④">(3)</a> <a href="#ref-for-invalid-image⑤">(4)</a> <a href="#ref-for-invalid-image⑥">(5)</a> <a href="#ref-for-invalid-image⑦">(6)</a> <a href="#ref-for-invalid-image⑧">(7)</a> <a href="#ref-for-invalid-image⑨">(8)</a> <a href="#ref-for-invalid-image①⓪">(9)</a> <a href="#ref-for-invalid-image①①">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-consume-a-syntax-definition">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#consume-a-syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#consume-a-syntax-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-consume-a-syntax-definition" class="dfn-panel" data-for="term-for-consume-a-syntax-definition" id="infopanel-for-term-for-consume-a-syntax-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-consume-a-syntax-definition" style="display:none">Info about the 'consume a syntax definition' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#consume-a-syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#consume-a-syntax-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-syntax-definition">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntax-definition">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntax-definition" class="dfn-panel" data-for="term-for-syntax-definition" id="infopanel-for-term-for-syntax-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-syntax-definition" style="display:none">Info about the 'syntax definition' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-definition">3. Concepts</a>
     <li><a href="#ref-for-syntax-definition①">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">5. Paint Notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-function">
-   <a href="https://drafts.csswg.org/css-syntax-3/#function">https://drafts.csswg.org/css-syntax-3/#function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-function" class="dfn-panel" data-for="term-for-function" id="infopanel-for-term-for-function" role="menu">
+   <span id="infopaneltitle-for-term-for-function" style="display:none">Info about the 'function' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#function">https://drafts.csswg.org/css-syntax-3/#function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-function">3. Concepts</a>
     <li><a href="#ref-for-function①">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssimagevalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssimagevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssimagevalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssimagevalue" class="dfn-panel" data-for="term-for-cssimagevalue" id="infopanel-for-term-for-cssimagevalue" role="menu">
+   <span id="infopaneltitle-for-term-for-cssimagevalue" style="display:none">Info about the 'CSSImageValue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssimagevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssimagevalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssimagevalue">6.1. Drawing a CSSImageValue</a> <a href="#ref-for-cssimagevalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stylepropertymap">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stylepropertymap" class="dfn-panel" data-for="term-for-stylepropertymap" id="infopanel-for-term-for-stylepropertymap" role="menu">
+   <span id="infopaneltitle-for-term-for-stylepropertymap" style="display:none">Info about the 'StylePropertyMap' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymap">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stylepropertymapreadonly">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stylepropertymapreadonly" class="dfn-panel" data-for="term-for-stylepropertymapreadonly" id="infopanel-for-term-for-stylepropertymapreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-stylepropertymapreadonly" style="display:none">Info about the 'StylePropertyMapReadOnly' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymapreadonly">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">5. Paint Notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">5. Paint Notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">5. Paint Notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5. Paint Notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-css-property">
-   <a href="https://drafts.csswg.org/cssom-1/#supported-css-property">https://drafts.csswg.org/cssom-1/#supported-css-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-css-property" class="dfn-panel" data-for="term-for-supported-css-property" id="infopanel-for-term-for-supported-css-property" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-css-property" style="display:none">Info about the 'supported css property' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#supported-css-property">https://drafts.csswg.org/cssom-1/#supported-css-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-css-property">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-devicepixelratio">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio">https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-devicepixelratio" class="dfn-panel" data-for="term-for-dom-window-devicepixelratio" id="infopanel-for-term-for-dom-window-devicepixelratio" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-devicepixelratio" style="display:none">Info about the 'devicePixelRatio' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio">https://drafts.csswg.org/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-devicepixelratio">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3. Concepts</a>
     <li><a href="#ref-for-concept-document①">4. Registering Custom Paint</a> <a href="#ref-for-concept-document②">(2)</a>
     <li><a href="#ref-for-concept-document③">7. Drawing an image</a> <a href="#ref-for-concept-document④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvascompositing">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing">https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvascompositing" class="dfn-panel" data-for="term-for-canvascompositing" id="infopanel-for-term-for-canvascompositing" role="menu">
+   <span id="infopaneltitle-for-term-for-canvascompositing" style="display:none">Info about the 'CanvasCompositing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing">https://html.spec.whatwg.org/multipage/canvas.html#canvascompositing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvascompositing">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasdrawimage">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawimage">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawimage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasdrawimage" class="dfn-panel" data-for="term-for-canvasdrawimage" id="infopanel-for-term-for-canvasdrawimage" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasdrawimage" style="display:none">Info about the 'CanvasDrawImage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawimage">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawimage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasdrawimage">6. The 2D rendering context</a>
     <li><a href="#ref-for-canvasdrawimage①">6.1. Drawing a CSSImageValue</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasdrawpath">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasdrawpath" class="dfn-panel" data-for="term-for-canvasdrawpath" id="infopanel-for-term-for-canvasdrawpath" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasdrawpath" style="display:none">Info about the 'CanvasDrawPath' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasdrawpath">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasfillstrokestyles">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles">https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasfillstrokestyles" class="dfn-panel" data-for="term-for-canvasfillstrokestyles" id="infopanel-for-term-for-canvasfillstrokestyles" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasfillstrokestyles" style="display:none">Info about the 'CanvasFillStrokeStyles' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles">https://html.spec.whatwg.org/multipage/canvas.html#canvasfillstrokestyles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasfillstrokestyles">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasimagedata">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata">https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasimagedata" class="dfn-panel" data-for="term-for-canvasimagedata" id="infopanel-for-term-for-canvasimagedata" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasimagedata" style="display:none">Info about the 'CanvasImageData' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata">https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasimagedata">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasimagesmoothing">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing">https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasimagesmoothing" class="dfn-panel" data-for="term-for-canvasimagesmoothing" id="infopanel-for-term-for-canvasimagesmoothing" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasimagesmoothing" style="display:none">Info about the 'CanvasImageSmoothing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing">https://html.spec.whatwg.org/multipage/canvas.html#canvasimagesmoothing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasimagesmoothing">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvaspath">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvaspath">https://html.spec.whatwg.org/multipage/canvas.html#canvaspath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvaspath" class="dfn-panel" data-for="term-for-canvaspath" id="infopanel-for-term-for-canvaspath" role="menu">
+   <span id="infopaneltitle-for-term-for-canvaspath" style="display:none">Info about the 'CanvasPath' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvaspath">https://html.spec.whatwg.org/multipage/canvas.html#canvaspath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvaspath">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvaspathdrawingstyles">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvaspathdrawingstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvaspathdrawingstyles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvaspathdrawingstyles" class="dfn-panel" data-for="term-for-canvaspathdrawingstyles" id="infopanel-for-term-for-canvaspathdrawingstyles" role="menu">
+   <span id="infopaneltitle-for-term-for-canvaspathdrawingstyles" style="display:none">Info about the 'CanvasPathDrawingStyles' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvaspathdrawingstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvaspathdrawingstyles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvaspathdrawingstyles">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasrect">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasrect">https://html.spec.whatwg.org/multipage/canvas.html#canvasrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasrect" class="dfn-panel" data-for="term-for-canvasrect" id="infopanel-for-term-for-canvasrect" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasrect" style="display:none">Info about the 'CanvasRect' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasrect">https://html.spec.whatwg.org/multipage/canvas.html#canvasrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasrect">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasrenderingcontext2d">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d">https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasrenderingcontext2d" class="dfn-panel" data-for="term-for-canvasrenderingcontext2d" id="infopanel-for-term-for-canvasrenderingcontext2d" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasrenderingcontext2d" style="display:none">Info about the 'CanvasRenderingContext2D' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d">https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasrenderingcontext2d">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasshadowstyles">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasshadowstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvasshadowstyles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasshadowstyles" class="dfn-panel" data-for="term-for-canvasshadowstyles" id="infopanel-for-term-for-canvasshadowstyles" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasshadowstyles" style="display:none">Info about the 'CanvasShadowStyles' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasshadowstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvasshadowstyles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasshadowstyles">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasstate">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasstate">https://html.spec.whatwg.org/multipage/canvas.html#canvasstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasstate" class="dfn-panel" data-for="term-for-canvasstate" id="infopanel-for-term-for-canvasstate" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasstate" style="display:none">Info about the 'CanvasState' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasstate">https://html.spec.whatwg.org/multipage/canvas.html#canvasstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasstate">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvastext">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastext">https://html.spec.whatwg.org/multipage/canvas.html#canvastext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvastext" class="dfn-panel" data-for="term-for-canvastext" id="infopanel-for-term-for-canvastext" role="menu">
+   <span id="infopaneltitle-for-term-for-canvastext" style="display:none">Info about the 'CanvasText' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastext">https://html.spec.whatwg.org/multipage/canvas.html#canvastext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvastext">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvastextdrawingstyles">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvastextdrawingstyles" class="dfn-panel" data-for="term-for-canvastextdrawingstyles" id="infopanel-for-term-for-canvastextdrawingstyles" role="menu">
+   <span id="infopaneltitle-for-term-for-canvastextdrawingstyles" style="display:none">Info about the 'CanvasTextDrawingStyles' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles">https://html.spec.whatwg.org/multipage/canvas.html#canvastextdrawingstyles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvastextdrawingstyles">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvastransform">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastransform">https://html.spec.whatwg.org/multipage/canvas.html#canvastransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvastransform" class="dfn-panel" data-for="term-for-canvastransform" id="infopanel-for-term-for-canvastransform" role="menu">
+   <span id="infopaneltitle-for-term-for-canvastransform" style="display:none">Info about the 'CanvasTransform' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvastransform">https://html.spec.whatwg.org/multipage/canvas.html#canvastransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvastransform">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvasuserinterface">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasuserinterface">https://html.spec.whatwg.org/multipage/canvas.html#canvasuserinterface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvasuserinterface" class="dfn-panel" data-for="term-for-canvasuserinterface" id="infopanel-for-term-for-canvasuserinterface" role="menu">
+   <span id="infopaneltitle-for-term-for-canvasuserinterface" style="display:none">Info about the 'CanvasUserInterface' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasuserinterface">https://html.spec.whatwg.org/multipage/canvas.html#canvasuserinterface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvasuserinterface">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet" class="dfn-panel" data-for="term-for-worklet" id="infopanel-for-term-for-worklet" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet" style="display:none">Info about the 'Worklet' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet">https://html.spec.whatwg.org/multipage/worklets.html#worklet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet">2. Paint Worklet</a> <a href="#ref-for-worklet①">(2)</a> <a href="#ref-for-worklet②">(3)</a>
     <li><a href="#ref-for-worklet③">7. Drawing an image</a> <a href="#ref-for-worklet④">(2)</a>
     <li><a href="#ref-for-worklet⑤">7.1. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-worklet-global-scope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-worklet-global-scope" class="dfn-panel" data-for="term-for-create-a-worklet-global-scope" id="infopanel-for-term-for-create-a-worklet-global-scope" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-worklet-global-scope" style="display:none">Info about the 'create a worklet global scope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope">https://html.spec.whatwg.org/multipage/worklets.html#create-a-worklet-global-scope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-worklet-global-scope">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-context-2d-drawimage">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-context-2d-drawimage" class="dfn-panel" data-for="term-for-dom-context-2d-drawimage" id="infopanel-for-term-for-dom-context-2d-drawimage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-context-2d-drawimage" style="display:none">Info about the 'drawImage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-drawimage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-context-2d-drawimage">6.1. Drawing a CSSImageValue</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-worklet-global-scopes">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes">https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-worklet-global-scopes" class="dfn-panel" data-for="term-for-concept-worklet-global-scopes" id="infopanel-for-term-for-concept-worklet-global-scopes" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-worklet-global-scopes" style="display:none">Info about the 'global scopes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes">https://html.spec.whatwg.org/multipage/worklets.html#concept-worklet-global-scopes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-worklet-global-scopes">7. Drawing an image</a>
     <li><a href="#ref-for-concept-worklet-global-scopes①">7.1. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">7. Drawing an image</a> <a href="#ref-for-in-parallel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4. Registering Custom Paint</a>
     <li><a href="#ref-for-queue-a-task①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reset-the-rendering-context-to-its-default-state">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#reset-the-rendering-context-to-its-default-state">https://html.spec.whatwg.org/multipage/canvas.html#reset-the-rendering-context-to-its-default-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reset-the-rendering-context-to-its-default-state" class="dfn-panel" data-for="term-for-reset-the-rendering-context-to-its-default-state" id="infopanel-for-term-for-reset-the-rendering-context-to-its-default-state" role="menu">
+   <span id="infopaneltitle-for-term-for-reset-the-rendering-context-to-its-default-state" style="display:none">Info about the 'reset the rendering context to its default state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#reset-the-rendering-context-to-its-default-state">https://html.spec.whatwg.org/multipage/canvas.html#reset-the-rendering-context-to-its-default-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-the-rendering-context-to-its-default-state">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-canvas-set-bitmap-dimensions">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-set-bitmap-dimensions">https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-set-bitmap-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-canvas-set-bitmap-dimensions" class="dfn-panel" data-for="term-for-concept-canvas-set-bitmap-dimensions" id="infopanel-for-term-for-concept-canvas-set-bitmap-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-canvas-set-bitmap-dimensions" style="display:none">Info about the 'set bitmap dimensions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-set-bitmap-dimensions">https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-set-bitmap-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-canvas-set-bitmap-dimensions">6. The 2D rendering context</a> <a href="#ref-for-concept-canvas-set-bitmap-dimensions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-destination-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-destination-type" class="dfn-panel" data-for="term-for-worklet-destination-type" id="infopanel-for-term-for-worklet-destination-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-destination-type" style="display:none">Info about the 'worklet destination type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-destination-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-destination-type">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worklet-global-scope-type">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worklet-global-scope-type" class="dfn-panel" data-for="term-for-worklet-global-scope-type" id="infopanel-for-term-for-worklet-global-scope-type" role="menu">
+   <span id="infopaneltitle-for-term-for-worklet-global-scope-type" style="display:none">Info about the 'worklet global scope type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type">https://html.spec.whatwg.org/multipage/worklets.html#worklet-global-scope-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worklet-global-scope-type">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4. Registering Custom Paint</a> <a href="#ref-for-map-exists①">(2)</a>
     <li><a href="#ref-for-map-exists②">7. Drawing an image</a> <a href="#ref-for-map-exists③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-get">
-   <a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-get" class="dfn-panel" data-for="term-for-map-get" id="infopanel-for-term-for-map-get" role="menu">
+   <span id="infopaneltitle-for-term-for-map-get" style="display:none">Info about the 'get' external reference.</span><a href="https://infra.spec.whatwg.org/#map-get">https://infra.spec.whatwg.org/#map-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-get">4. Registering Custom Paint</a>
     <li><a href="#ref-for-map-get①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3. Concepts</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
     <li><a href="#ref-for-list③">4. Registering Custom Paint</a>
@@ -2369,121 +2369,121 @@ to fix all such channels.</p>
     <li><a href="#ref-for-list⑤">7.1. Global Scope Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4. Registering Custom Paint</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a> <a href="#ref-for-ordered-map③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">4. Registering Custom Paint</a> <a href="#ref-for-map-set①">(2)</a> <a href="#ref-for-map-set②">(3)</a>
     <li><a href="#ref-for-map-set③">7. Drawing an image</a> <a href="#ref-for-map-set④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3. Concepts</a> <a href="#ref-for-struct①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Paint Worklet</a>
     <li><a href="#ref-for-Exposed①">6. The 2D rendering context</a>
     <li><a href="#ref-for-Exposed②">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Global">
-   <a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Global" class="dfn-panel" data-for="term-for-Global" id="infopanel-for-term-for-Global" role="menu">
+   <span id="infopaneltitle-for-term-for-Global" style="display:none">Info about the 'Global' external reference.</span><a href="https://webidl.spec.whatwg.org/#Global">https://webidl.spec.whatwg.org/#Global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Global">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VoidFunction">
-   <a href="https://webidl.spec.whatwg.org/#VoidFunction">https://webidl.spec.whatwg.org/#VoidFunction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VoidFunction" class="dfn-panel" data-for="term-for-VoidFunction" id="infopanel-for-term-for-VoidFunction" role="menu">
+   <span id="infopaneltitle-for-term-for-VoidFunction" style="display:none">Info about the 'VoidFunction' external reference.</span><a href="https://webidl.spec.whatwg.org/#VoidFunction">https://webidl.spec.whatwg.org/#VoidFunction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VoidFunction">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-function" class="dfn-panel" data-for="term-for-dfn-callback-function" id="infopanel-for-term-for-dfn-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-function" style="display:none">Info about the 'callback function' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">3. Concepts</a>
     <li><a href="#ref-for-dfn-callback-function①">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-this-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-this-value">https://webidl.spec.whatwg.org/#dfn-callback-this-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-this-value" class="dfn-panel" data-for="term-for-dfn-callback-this-value" id="infopanel-for-term-for-dfn-callback-this-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-this-value">https://webidl.spec.whatwg.org/#dfn-callback-this-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-web-idl-arguments-list-converting">
-   <a href="https://webidl.spec.whatwg.org/#web-idl-arguments-list-converting">https://webidl.spec.whatwg.org/#web-idl-arguments-list-converting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-web-idl-arguments-list-converting" class="dfn-panel" data-for="term-for-web-idl-arguments-list-converting" id="infopanel-for-term-for-web-idl-arguments-list-converting" role="menu">
+   <span id="infopaneltitle-for-term-for-web-idl-arguments-list-converting" style="display:none">Info about the 'converting' external reference.</span><a href="https://webidl.spec.whatwg.org/#web-idl-arguments-list-converting">https://webidl.spec.whatwg.org/#web-idl-arguments-list-converting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-idl-arguments-list-converting">4. Registering Custom Paint</a> <a href="#ref-for-web-idl-arguments-list-converting①">(2)</a> <a href="#ref-for-web-idl-arguments-list-converting②">(3)</a> <a href="#ref-for-web-idl-arguments-list-converting③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">7. Drawing an image</a> <a href="#ref-for-idl-double①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4. Registering Custom Paint</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a> <a href="#ref-for-dfn-throw④">(5)</a> <a href="#ref-for-dfn-throw⑤">(6)</a> <a href="#ref-for-dfn-throw⑥">(7)</a>
     <li><a href="#ref-for-dfn-throw⑦">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">2. Paint Worklet</a>
    </ul>
@@ -2722,14 +2722,14 @@ to fix all such channels.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-css-paintworklet">
-   <b><a href="#dom-css-paintworklet">#dom-css-paintworklet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-paintworklet" class="dfn-panel" data-for="dom-css-paintworklet" id="infopanel-for-dom-css-paintworklet" role="dialog">
+   <span id="infopaneltitle-for-dom-css-paintworklet" style="display:none">Info about the 'paintWorklet' definition.</span><b><a href="#dom-css-paintworklet">#dom-css-paintworklet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-paintworklet">2. Paint Worklet</a> <a href="#ref-for-dom-css-paintworklet①">(2)</a> <a href="#ref-for-dom-css-paintworklet②">(3)</a> <a href="#ref-for-dom-css-paintworklet③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintworkletglobalscope">
-   <b><a href="#paintworkletglobalscope">#paintworkletglobalscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintworkletglobalscope" class="dfn-panel" data-for="paintworkletglobalscope" id="infopanel-for-paintworkletglobalscope" role="dialog">
+   <span id="infopaneltitle-for-paintworkletglobalscope" style="display:none">Info about the 'PaintWorkletGlobalScope' definition.</span><b><a href="#paintworkletglobalscope">#paintworkletglobalscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintworkletglobalscope">2. Paint Worklet</a> <a href="#ref-for-paintworkletglobalscope①">(2)</a> <a href="#ref-for-paintworkletglobalscope②">(3)</a>
     <li><a href="#ref-for-paintworkletglobalscope③">3. Concepts</a>
@@ -2738,114 +2738,114 @@ to fix all such channels.</p>
     <li><a href="#ref-for-paintworkletglobalscope⑨">7.1. Global Scope Selection</a> <a href="#ref-for-paintworkletglobalscope①⓪">(2)</a> <a href="#ref-for-paintworkletglobalscope①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-paintworkletglobalscope-devicepixelratio">
-   <b><a href="#dom-paintworkletglobalscope-devicepixelratio">#dom-paintworkletglobalscope-devicepixelratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-paintworkletglobalscope-devicepixelratio" class="dfn-panel" data-for="dom-paintworkletglobalscope-devicepixelratio" id="infopanel-for-dom-paintworkletglobalscope-devicepixelratio" role="dialog">
+   <span id="infopaneltitle-for-dom-paintworkletglobalscope-devicepixelratio" style="display:none">Info about the 'devicePixelRatio' definition.</span><b><a href="#dom-paintworkletglobalscope-devicepixelratio">#dom-paintworkletglobalscope-devicepixelratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paintworkletglobalscope-devicepixelratio">2. Paint Worklet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-paintrenderingcontext2dsettings">
-   <b><a href="#dictdef-paintrenderingcontext2dsettings">#dictdef-paintrenderingcontext2dsettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-paintrenderingcontext2dsettings" class="dfn-panel" data-for="dictdef-paintrenderingcontext2dsettings" id="infopanel-for-dictdef-paintrenderingcontext2dsettings" role="dialog">
+   <span id="infopaneltitle-for-dictdef-paintrenderingcontext2dsettings" style="display:none">Info about the 'PaintRenderingContext2DSettings' definition.</span><b><a href="#dictdef-paintrenderingcontext2dsettings">#dictdef-paintrenderingcontext2dsettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-paintrenderingcontext2dsettings">2. Paint Worklet</a> <a href="#ref-for-dictdef-paintrenderingcontext2dsettings①">(2)</a>
     <li><a href="#ref-for-dictdef-paintrenderingcontext2dsettings②">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-paintrenderingcontext2dsettings-alpha">
-   <b><a href="#dom-paintrenderingcontext2dsettings-alpha">#dom-paintrenderingcontext2dsettings-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-paintrenderingcontext2dsettings-alpha" class="dfn-panel" data-for="dom-paintrenderingcontext2dsettings-alpha" id="infopanel-for-dom-paintrenderingcontext2dsettings-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-paintrenderingcontext2dsettings-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-paintrenderingcontext2dsettings-alpha">#dom-paintrenderingcontext2dsettings-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paintrenderingcontext2dsettings-alpha">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition">
-   <b><a href="#paint-definition">#paint-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition" class="dfn-panel" data-for="paint-definition" id="infopanel-for-paint-definition" role="dialog">
+   <span id="infopaneltitle-for-paint-definition" style="display:none">Info about the 'paint definition' definition.</span><b><a href="#paint-definition">#paint-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition-class-constructor">
-   <b><a href="#paint-definition-class-constructor">#paint-definition-class-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition-class-constructor" class="dfn-panel" data-for="paint-definition-class-constructor" id="infopanel-for-paint-definition-class-constructor" role="dialog">
+   <span id="infopaneltitle-for-paint-definition-class-constructor" style="display:none">Info about the 'class constructor' definition.</span><b><a href="#paint-definition-class-constructor">#paint-definition-class-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition-class-constructor">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definition-class-constructor①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition-paint-function">
-   <b><a href="#paint-definition-paint-function">#paint-definition-paint-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition-paint-function" class="dfn-panel" data-for="paint-definition-paint-function" id="infopanel-for-paint-definition-paint-function" role="dialog">
+   <span id="infopaneltitle-for-paint-definition-paint-function" style="display:none">Info about the 'paint function' definition.</span><b><a href="#paint-definition-paint-function">#paint-definition-paint-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition-paint-function">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definition-paint-function①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition-constructor-valid-flag">
-   <b><a href="#paint-definition-constructor-valid-flag">#paint-definition-constructor-valid-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition-constructor-valid-flag" class="dfn-panel" data-for="paint-definition-constructor-valid-flag" id="infopanel-for-paint-definition-constructor-valid-flag" role="dialog">
+   <span id="infopaneltitle-for-paint-definition-constructor-valid-flag" style="display:none">Info about the 'constructor valid flag' definition.</span><b><a href="#paint-definition-constructor-valid-flag">#paint-definition-constructor-valid-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition-constructor-valid-flag">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definition-constructor-valid-flag①">7. Drawing an image</a> <a href="#ref-for-paint-definition-constructor-valid-flag②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition-input-properties">
-   <b><a href="#paint-definition-input-properties">#paint-definition-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition-input-properties" class="dfn-panel" data-for="paint-definition-input-properties" id="infopanel-for-paint-definition-input-properties" role="dialog">
+   <span id="infopaneltitle-for-paint-definition-input-properties" style="display:none">Info about the 'input properties' definition.</span><b><a href="#paint-definition-input-properties">#paint-definition-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition-input-properties">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definition-input-properties①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definition-paintrenderingcontext2dsettings-object">
-   <b><a href="#paint-definition-paintrenderingcontext2dsettings-object">#paint-definition-paintrenderingcontext2dsettings-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definition-paintrenderingcontext2dsettings-object" class="dfn-panel" data-for="paint-definition-paintrenderingcontext2dsettings-object" id="infopanel-for-paint-definition-paintrenderingcontext2dsettings-object" role="dialog">
+   <span id="infopaneltitle-for-paint-definition-paintrenderingcontext2dsettings-object" style="display:none">Info about the 'PaintRenderingContext2DSettings object' definition.</span><b><a href="#paint-definition-paintrenderingcontext2dsettings-object">#paint-definition-paintrenderingcontext2dsettings-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definition-paintrenderingcontext2dsettings-object">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definition-paintrenderingcontext2dsettings-object①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-paint-definition">
-   <b><a href="#document-paint-definition">#document-paint-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-paint-definition" class="dfn-panel" data-for="document-paint-definition" id="infopanel-for-document-paint-definition" role="dialog">
+   <span id="infopaneltitle-for-document-paint-definition" style="display:none">Info about the 'document paint definition' definition.</span><b><a href="#document-paint-definition">#document-paint-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-paint-definition">4. Registering Custom Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-paint-definition-input-properties">
-   <b><a href="#document-paint-definition-input-properties">#document-paint-definition-input-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-paint-definition-input-properties" class="dfn-panel" data-for="document-paint-definition-input-properties" id="infopanel-for-document-paint-definition-input-properties" role="dialog">
+   <span id="infopaneltitle-for-document-paint-definition-input-properties" style="display:none">Info about the 'input properties' definition.</span><b><a href="#document-paint-definition-input-properties">#document-paint-definition-input-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-paint-definition-input-properties">4. Registering Custom Paint</a> <a href="#ref-for-document-paint-definition-input-properties①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-paint-definition-input-argument-syntaxes">
-   <b><a href="#document-paint-definition-input-argument-syntaxes">#document-paint-definition-input-argument-syntaxes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-paint-definition-input-argument-syntaxes" class="dfn-panel" data-for="document-paint-definition-input-argument-syntaxes" id="infopanel-for-document-paint-definition-input-argument-syntaxes" role="dialog">
+   <span id="infopaneltitle-for-document-paint-definition-input-argument-syntaxes" style="display:none">Info about the 'input argument syntaxes' definition.</span><b><a href="#document-paint-definition-input-argument-syntaxes">#document-paint-definition-input-argument-syntaxes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-paint-definition-input-argument-syntaxes">4. Registering Custom Paint</a> <a href="#ref-for-document-paint-definition-input-argument-syntaxes①">(2)</a>
     <li><a href="#ref-for-document-paint-definition-input-argument-syntaxes②">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-paint-definition-paintrenderingcontext2dsettings-object">
-   <b><a href="#document-paint-definition-paintrenderingcontext2dsettings-object">#document-paint-definition-paintrenderingcontext2dsettings-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-paint-definition-paintrenderingcontext2dsettings-object" class="dfn-panel" data-for="document-paint-definition-paintrenderingcontext2dsettings-object" id="infopanel-for-document-paint-definition-paintrenderingcontext2dsettings-object" role="dialog">
+   <span id="infopaneltitle-for-document-paint-definition-paintrenderingcontext2dsettings-object" style="display:none">Info about the 'PaintRenderingContext2DSettings object' definition.</span><b><a href="#document-paint-definition-paintrenderingcontext2dsettings-object">#document-paint-definition-paintrenderingcontext2dsettings-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-paint-definition-paintrenderingcontext2dsettings-object">4. Registering Custom Paint</a> <a href="#ref-for-document-paint-definition-paintrenderingcontext2dsettings-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-paint-definitions">
-   <b><a href="#document-paint-definitions">#document-paint-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-paint-definitions" class="dfn-panel" data-for="document-paint-definitions" id="infopanel-for-document-paint-definitions" role="dialog">
+   <span id="infopaneltitle-for-document-paint-definitions" style="display:none">Info about the 'document paint definitions' definition.</span><b><a href="#document-paint-definitions">#document-paint-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-paint-definitions">4. Registering Custom Paint</a>
     <li><a href="#ref-for-document-paint-definitions①">7. Drawing an image</a> <a href="#ref-for-document-paint-definitions②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-definitions">
-   <b><a href="#paint-definitions">#paint-definitions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-definitions" class="dfn-panel" data-for="paint-definitions" id="infopanel-for-paint-definitions" role="dialog">
+   <span id="infopaneltitle-for-paint-definitions" style="display:none">Info about the 'paint definitions' definition.</span><b><a href="#paint-definitions">#paint-definitions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-definitions">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-definitions①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-class-instances">
-   <b><a href="#paint-class-instances">#paint-class-instances</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-class-instances" class="dfn-panel" data-for="paint-class-instances" id="infopanel-for-paint-class-instances" role="dialog">
+   <span id="infopaneltitle-for-paint-class-instances" style="display:none">Info about the 'paint class instances' definition.</span><b><a href="#paint-class-instances">#paint-class-instances</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-class-instances">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paint-class-instances①">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-paintworkletglobalscope-registerpaint">
-   <b><a href="#dom-paintworkletglobalscope-registerpaint">#dom-paintworkletglobalscope-registerpaint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-paintworkletglobalscope-registerpaint" class="dfn-panel" data-for="dom-paintworkletglobalscope-registerpaint" id="infopanel-for-dom-paintworkletglobalscope-registerpaint" role="dialog">
+   <span id="infopaneltitle-for-dom-paintworkletglobalscope-registerpaint" style="display:none">Info about the 'registerPaint(name, paintCtor)' definition.</span><b><a href="#dom-paintworkletglobalscope-registerpaint">#dom-paintworkletglobalscope-registerpaint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paintworkletglobalscope-registerpaint">2. Paint Worklet</a>
     <li><a href="#ref-for-dom-paintworkletglobalscope-registerpaint①">4. Registering Custom Paint</a> <a href="#ref-for-dom-paintworkletglobalscope-registerpaint②">(2)</a>
@@ -2853,8 +2853,8 @@ to fix all such channels.</p>
     <li><a href="#ref-for-dom-paintworkletglobalscope-registerpaint④">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-paint">
-   <b><a href="#funcdef-paint">#funcdef-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-paint" class="dfn-panel" data-for="funcdef-paint" id="infopanel-for-funcdef-paint" role="dialog">
+   <span id="infopaneltitle-for-funcdef-paint" style="display:none">Info about the 'paint()' definition.</span><b><a href="#funcdef-paint">#funcdef-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-paint">3. Concepts</a>
     <li><a href="#ref-for-funcdef-paint①">4. Registering Custom Paint</a>
@@ -2863,107 +2863,163 @@ to fix all such channels.</p>
     <li><a href="#ref-for-funcdef-paint①①">8.1. Example 1: Colored Circle</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintrenderingcontext2d">
-   <b><a href="#paintrenderingcontext2d">#paintrenderingcontext2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintrenderingcontext2d" class="dfn-panel" data-for="paintrenderingcontext2d" id="infopanel-for-paintrenderingcontext2d" role="dialog">
+   <span id="infopaneltitle-for-paintrenderingcontext2d" style="display:none">Info about the 'PaintRenderingContext2D' definition.</span><b><a href="#paintrenderingcontext2d">#paintrenderingcontext2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintrenderingcontext2d">6. The 2D rendering context</a> <a href="#ref-for-paintrenderingcontext2d①">(2)</a> <a href="#ref-for-paintrenderingcontext2d②">(3)</a> <a href="#ref-for-paintrenderingcontext2d③">(4)</a> <a href="#ref-for-paintrenderingcontext2d④">(5)</a> <a href="#ref-for-paintrenderingcontext2d⑤">(6)</a> <a href="#ref-for-paintrenderingcontext2d⑥">(7)</a> <a href="#ref-for-paintrenderingcontext2d⑦">(8)</a> <a href="#ref-for-paintrenderingcontext2d⑧">(9)</a> <a href="#ref-for-paintrenderingcontext2d⑨">(10)</a> <a href="#ref-for-paintrenderingcontext2d①⓪">(11)</a> <a href="#ref-for-paintrenderingcontext2d①①">(12)</a> <a href="#ref-for-paintrenderingcontext2d①②">(13)</a> <a href="#ref-for-paintrenderingcontext2d①③">(14)</a> <a href="#ref-for-paintrenderingcontext2d①④">(15)</a> <a href="#ref-for-paintrenderingcontext2d①⑤">(16)</a> <a href="#ref-for-paintrenderingcontext2d①⑥">(17)</a> <a href="#ref-for-paintrenderingcontext2d①⑦">(18)</a> <a href="#ref-for-paintrenderingcontext2d①⑧">(19)</a>
     <li><a href="#ref-for-paintrenderingcontext2d①⑨">11. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintrenderingcontext2d-output-bitmap">
-   <b><a href="#paintrenderingcontext2d-output-bitmap">#paintrenderingcontext2d-output-bitmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintrenderingcontext2d-output-bitmap" class="dfn-panel" data-for="paintrenderingcontext2d-output-bitmap" id="infopanel-for-paintrenderingcontext2d-output-bitmap" role="dialog">
+   <span id="infopaneltitle-for-paintrenderingcontext2d-output-bitmap" style="display:none">Info about the 'output bitmap' definition.</span><b><a href="#paintrenderingcontext2d-output-bitmap">#paintrenderingcontext2d-output-bitmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintrenderingcontext2d-output-bitmap">6. The 2D rendering context</a> <a href="#ref-for-paintrenderingcontext2d-output-bitmap①">(2)</a> <a href="#ref-for-paintrenderingcontext2d-output-bitmap②">(3)</a> <a href="#ref-for-paintrenderingcontext2d-output-bitmap③">(4)</a> <a href="#ref-for-paintrenderingcontext2d-output-bitmap④">(5)</a> <a href="#ref-for-paintrenderingcontext2d-output-bitmap⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintrenderingcontext2d-alpha">
-   <b><a href="#paintrenderingcontext2d-alpha">#paintrenderingcontext2d-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintrenderingcontext2d-alpha" class="dfn-panel" data-for="paintrenderingcontext2d-alpha" id="infopanel-for-paintrenderingcontext2d-alpha" role="dialog">
+   <span id="infopaneltitle-for-paintrenderingcontext2d-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#paintrenderingcontext2d-alpha">#paintrenderingcontext2d-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintrenderingcontext2d-alpha">6. The 2D rendering context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-paintrenderingcontext2d-object">
-   <b><a href="#create-a-paintrenderingcontext2d-object">#create-a-paintrenderingcontext2d-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-paintrenderingcontext2d-object" class="dfn-panel" data-for="create-a-paintrenderingcontext2d-object" id="infopanel-for-create-a-paintrenderingcontext2d-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-paintrenderingcontext2d-object" style="display:none">Info about the 'create a PaintRenderingContext2D object' definition.</span><b><a href="#create-a-paintrenderingcontext2d-object">#create-a-paintrenderingcontext2d-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-paintrenderingcontext2d-object">7. Drawing an image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintsize">
-   <b><a href="#paintsize">#paintsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintsize" class="dfn-panel" data-for="paintsize" id="infopanel-for-paintsize" role="dialog">
+   <span id="infopaneltitle-for-paintsize" style="display:none">Info about the 'PaintSize' definition.</span><b><a href="#paintsize">#paintsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintsize">4. Registering Custom Paint</a>
     <li><a href="#ref-for-paintsize①">7. Drawing an image</a> <a href="#ref-for-paintsize②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="draw-a-paint-image">
-   <b><a href="#draw-a-paint-image">#draw-a-paint-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-draw-a-paint-image" class="dfn-panel" data-for="draw-a-paint-image" id="infopanel-for-draw-a-paint-image" role="dialog">
+   <span id="infopaneltitle-for-draw-a-paint-image" style="display:none">Info about the 'draw a paint image' definition.</span><b><a href="#draw-a-paint-image">#draw-a-paint-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-draw-a-paint-image">4. Registering Custom Paint</a>
     <li><a href="#ref-for-draw-a-paint-image①">5. Paint Notation</a>
     <li><a href="#ref-for-draw-a-paint-image②">7. Drawing an image</a> <a href="#ref-for-draw-a-paint-image③">(2)</a> <a href="#ref-for-draw-a-paint-image④">(3)</a> <a href="#ref-for-draw-a-paint-image⑤">(4)</a> <a href="#ref-for-draw-a-paint-image⑥">(5)</a> <a href="#ref-for-draw-a-paint-image⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invoke-a-paint-callback">
-   <b><a href="#invoke-a-paint-callback">#invoke-a-paint-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invoke-a-paint-callback" class="dfn-panel" data-for="invoke-a-paint-callback" id="infopanel-for-invoke-a-paint-callback" role="dialog">
+   <span id="infopaneltitle-for-invoke-a-paint-callback" style="display:none">Info about the 'invoke a paint callback' definition.</span><b><a href="#invoke-a-paint-callback">#invoke-a-paint-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-paint-callback">7. Drawing an image</a> <a href="#ref-for-invoke-a-paint-callback①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-properties-values-api/Overview.html
@@ -2244,157 +2244,157 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
    <li><a href="#syntax-string">syntax string</a><span>, in § 5</span>
    <li><a href="#universal-syntax-definition">universal syntax definition</a><span>, in § 5.4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2.4. Computed Value-Time Behavior</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a> <a href="#ref-for-computed-value③">(4)</a> <a href="#ref-for-computed-value④">(5)</a>
     <li><a href="#ref-for-computed-value⑤">2.6. Conditional Rules</a>
     <li><a href="#ref-for-computed-value⑥">3.1. The syntax Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.3. Specified Value-Time Behavior</a>
     <li><a href="#ref-for-valdef-all-inherit①">4.1. The registerProperty() Function</a> <a href="#ref-for-valdef-all-inherit②">(2)</a> <a href="#ref-for-valdef-all-inherit③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">3.3. The initial-value Descriptor</a> <a href="#ref-for-initial-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-revert">
-   <a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-revert" class="dfn-panel" data-for="term-for-valdef-all-revert" id="infopanel-for-term-for-valdef-all-revert" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-revert" style="display:none">Info about the 'revert' external reference.</span><a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert">2.3. Specified Value-Time Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">2.3. Specified Value-Time Behavior</a>
     <li><a href="#ref-for-specified-value①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-unset">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-unset" class="dfn-panel" data-for="term-for-valdef-all-unset" id="infopanel-for-term-for-valdef-all-unset" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-unset" style="display:none">Info about the 'unset' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">5.1. Supported Names</a>
     <li><a href="#ref-for-typedef-color①">5.3. The '|' Combinator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-black">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-black">https://drafts.csswg.org/css-color-4/#valdef-color-black</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-black" class="dfn-panel" data-for="term-for-valdef-color-black" id="infopanel-for-term-for-valdef-color-black" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-black" style="display:none">Info about the 'black' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-black">https://drafts.csswg.org/css-color-4/#valdef-color-black</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-black">4.1. The registerProperty() Function</a> <a href="#ref-for-valdef-color-black①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-blue">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-blue" class="dfn-panel" data-for="term-for-valdef-color-blue" id="infopanel-for-term-for-valdef-color-blue" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-blue" style="display:none">Info about the 'blue' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-blue">5.3. The '|' Combinator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">4.1. The registerProperty() Function</a> <a href="#ref-for-propdef-color①">(2)</a> <a href="#ref-for-propdef-color②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-red">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-red" class="dfn-panel" data-for="term-for-valdef-color-red" id="infopanel-for-term-for-valdef-color-red" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-red" style="display:none">Info about the 'red' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">5.1. Supported Names</a> <a href="#ref-for-valdef-color-red①">(2)</a> <a href="#ref-for-valdef-color-red②">(3)</a>
     <li><a href="#ref-for-valdef-color-red③">5.3. The '|' Combinator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2.6. Conditional Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">2.7.2. Dependency Cycles via Relative Units</a>
     <li><a href="#ref-for-propdef-font-size①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">5.1. Supported Names</a>
     <li><a href="#ref-for-typedef-image①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-image">
-   <a href="https://drafts.csswg.org/css-images-4/#computed-image">https://drafts.csswg.org/css-images-4/#computed-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-image" class="dfn-panel" data-for="term-for-computed-image" id="infopanel-for-term-for-computed-image" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-image" style="display:none">Info about the 'computed &lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#computed-image">https://drafts.csswg.org/css-images-4/#computed-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-image">2.4. Computed Value-Time Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">3. The @property Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">3.3. The initial-value Descriptor</a>
     <li><a href="#ref-for-typedef-declaration-value①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension-token" class="dfn-panel" data-for="term-for-typedef-dimension-token" id="infopanel-for-term-for-typedef-dimension-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">2.7. Substitution via var()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-input-code-point">
-   <a href="https://drafts.csswg.org/css-syntax-3/#current-input-code-point">https://drafts.csswg.org/css-syntax-3/#current-input-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-input-code-point" class="dfn-panel" data-for="term-for-current-input-code-point" id="infopanel-for-term-for-current-input-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-current-input-code-point" style="display:none">Info about the 'current input code point' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#current-input-code-point">https://drafts.csswg.org/css-syntax-3/#current-input-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-input-code-point">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-input-stream">
-   <a href="https://drafts.csswg.org/css-syntax-3/#input-stream">https://drafts.csswg.org/css-syntax-3/#input-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-input-stream" class="dfn-panel" data-for="term-for-input-stream" id="infopanel-for-term-for-input-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-input-stream" style="display:none">Info about the 'input stream' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#input-stream">https://drafts.csswg.org/css-syntax-3/#input-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-stream">5.4.2. Consume a Syntax Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ident-start-code-point">
-   <a href="https://drafts.csswg.org/css-syntax-3/#ident-start-code-point">https://drafts.csswg.org/css-syntax-3/#ident-start-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ident-start-code-point" class="dfn-panel" data-for="term-for-ident-start-code-point" id="infopanel-for-term-for-ident-start-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-ident-start-code-point" style="display:none">Info about the 'name-start code point' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#ident-start-code-point">https://drafts.csswg.org/css-syntax-3/#ident-start-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ident-start-code-point">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-next-input-code-point">
-   <a href="https://drafts.csswg.org/css-syntax-3/#next-input-code-point">https://drafts.csswg.org/css-syntax-3/#next-input-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-next-input-code-point" class="dfn-panel" data-for="term-for-next-input-code-point" id="infopanel-for-term-for-next-input-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-next-input-code-point" style="display:none">Info about the 'next input code point' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#next-input-code-point">https://drafts.csswg.org/css-syntax-3/#next-input-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-input-code-point">5.4.2. Consume a Syntax Definition</a>
     <li><a href="#ref-for-next-input-code-point①">5.4.3. Consume a Syntax Component</a> <a href="#ref-for-next-input-code-point②">(2)</a> <a href="#ref-for-next-input-code-point③">(3)</a>
     <li><a href="#ref-for-next-input-code-point④">5.4.4. Consume a Data Type Name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">2.1. Determining the Registration</a>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar①">2.4. Computed Value-Time Behavior</a>
@@ -2402,124 +2402,124 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar④">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reconsume-the-current-input-code-point">
-   <a href="https://drafts.csswg.org/css-syntax-3/#reconsume-the-current-input-code-point">https://drafts.csswg.org/css-syntax-3/#reconsume-the-current-input-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reconsume-the-current-input-code-point" class="dfn-panel" data-for="term-for-reconsume-the-current-input-code-point" id="infopanel-for-term-for-reconsume-the-current-input-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-reconsume-the-current-input-code-point" style="display:none">Info about the 'reconsume the current input code point' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#reconsume-the-current-input-code-point">https://drafts.csswg.org/css-syntax-3/#reconsume-the-current-input-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reconsume-the-current-input-code-point">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-whitespace">
-   <a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-whitespace" class="dfn-panel" data-for="term-for-whitespace" id="infopanel-for-term-for-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-whitespace" style="display:none">Info about the 'whitespace' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">5.4.2. Consume a Syntax Definition</a>
     <li><a href="#ref-for-whitespace①">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-function">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-function">https://drafts.csswg.org/css-transforms-1/#typedef-transform-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-function" class="dfn-panel" data-for="term-for-typedef-transform-function" id="infopanel-for-term-for-typedef-transform-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-function" style="display:none">Info about the '&lt;transform-function>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-function">https://drafts.csswg.org/css-transforms-1/#typedef-transform-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-function">5.1. Supported Names</a> <a href="#ref-for-typedef-transform-function①">(2)</a>
     <li><a href="#ref-for-typedef-transform-function②">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-list">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-list" class="dfn-panel" data-for="term-for-typedef-transform-list" id="infopanel-for-term-for-typedef-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">2.5. Animation Behavior</a> <a href="#ref-for-propdef-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstylevalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylevalue" class="dfn-panel" data-for="term-for-cssstylevalue" id="infopanel-for-term-for-cssstylevalue" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylevalue" style="display:none">Info about the 'CSSStyleValue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylevalue">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cssstylevalue-associatedproperty-slot">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot">https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cssstylevalue-associatedproperty-slot" class="dfn-panel" data-for="term-for-dom-cssstylevalue-associatedproperty-slot" id="infopanel-for-term-for-dom-cssstylevalue-associatedproperty-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cssstylevalue-associatedproperty-slot" style="display:none">Info about the '[[associatedProperty]]' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot">https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-associatedproperty-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylevalue-associatedproperty-slot">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property-name-string">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string">https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property-name-string" class="dfn-panel" data-for="term-for-custom-property-name-string" id="infopanel-for-term-for-custom-property-name-string" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property-name-string" style="display:none">Info about the 'custom property name string' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string">https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property-name-string">2.1. Determining the Registration</a>
     <li><a href="#ref-for-custom-property-name-string①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-a-transform-function">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-function">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-a-transform-function" class="dfn-panel" data-for="term-for-reify-a-transform-function" id="infopanel-for-term-for-reify-a-transform-function" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-a-transform-function" style="display:none">Info about the 'reify a &lt;transform-function>' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-function">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-transform-function">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-a-transform-list">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-list">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-a-transform-list" class="dfn-panel" data-for="term-for-reify-a-transform-list" id="infopanel-for-term-for-reify-a-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-a-transform-list" style="display:none">Info about the 'reify a &lt;transform-list>' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-list">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-transform-list">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-a-list-of-component-values">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-a-list-of-component-values" class="dfn-panel" data-for="term-for-reify-a-list-of-component-values" id="infopanel-for-term-for-reify-a-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-a-list-of-component-values" style="display:none">Info about the 'reify a list of component values' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-list-of-component-values">6.2. CSSStyleValue Reification</a> <a href="#ref-for-reify-a-list-of-component-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-a-numeric-value">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-a-numeric-value" class="dfn-panel" data-for="term-for-reify-a-numeric-value" id="infopanel-for-term-for-reify-a-numeric-value" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-a-numeric-value" style="display:none">Info about the 'reify a numeric value' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value">https://drafts.css-houdini.org/css-typed-om-1/#reify-a-numeric-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-numeric-value">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-an-identifier">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-an-identifier">https://drafts.css-houdini.org/css-typed-om-1/#reify-an-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-an-identifier" class="dfn-panel" data-for="term-for-reify-an-identifier" id="infopanel-for-term-for-reify-an-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-an-identifier" style="display:none">Info about the 'reify an identifier' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-an-identifier">https://drafts.css-houdini.org/css-typed-om-1/#reify-an-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-an-identifier">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reify-as-a-cssstylevalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reify-as-a-cssstylevalue" class="dfn-panel" data-for="term-for-reify-as-a-cssstylevalue" id="infopanel-for-term-for-reify-as-a-cssstylevalue" role="menu">
+   <span id="infopaneltitle-for-term-for-reify-as-a-cssstylevalue" style="display:none">Info about the 'reify as a cssstylevalue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue">https://drafts.css-houdini.org/css-typed-om-1/#reify-as-a-cssstylevalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-as-a-cssstylevalue">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5.1. Supported Names</a>
     <li><a href="#ref-for-angle-value①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">5.1. Supported Names</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a>
     <li><a href="#ref-for-identifier-value③">5.4.1. Definitions</a>
     <li><a href="#ref-for-identifier-value④">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">5.1. Supported Names</a>
     <li><a href="#ref-for-integer-value①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">2.7.2. Dependency Cycles via Relative Units</a>
     <li><a href="#ref-for-typedef-length-percentage①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2.7. Substitution via var()</a>
     <li><a href="#ref-for-length-value①">2.7.2. Dependency Cycles via Relative Units</a>
@@ -2527,152 +2527,152 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-length-value⑤">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5.1. Supported Names</a>
     <li><a href="#ref-for-number-value①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">5.1. Supported Names</a> <a href="#ref-for-percentage-value①">(2)</a> <a href="#ref-for-percentage-value②">(3)</a>
     <li><a href="#ref-for-percentage-value③">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">5.1. Supported Names</a>
     <li><a href="#ref-for-resolution-value①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.1. The syntax Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">5.1. Supported Names</a>
     <li><a href="#ref-for-time-value①">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2.4. Computed Value-Time Behavior</a>
     <li><a href="#ref-for-url-value①">5.1. Supported Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">5.1. Supported Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canonical-unit">
-   <a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canonical-unit" class="dfn-panel" data-for="term-for-canonical-unit" id="infopanel-for-term-for-canonical-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-canonical-unit" style="display:none">Info about the 'canonical unit' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canonical-unit">2.4. Computed Value-Time Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cap">
-   <a href="https://drafts.csswg.org/css-values-4/#cap">https://drafts.csswg.org/css-values-4/#cap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cap" class="dfn-panel" data-for="term-for-cap" id="infopanel-for-term-for-cap" role="menu">
+   <span id="infopaneltitle-for-term-for-cap" style="display:none">Info about the 'cap' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#cap">https://drafts.csswg.org/css-values-4/#cap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cap">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">2.3. Specified Value-Time Behavior</a>
     <li><a href="#ref-for-css-wide-keywords①">5. Syntax Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dimension" class="dfn-panel" data-for="term-for-dimension" id="infopanel-for-term-for-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-dimension" style="display:none">Info about the 'dimension' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">2.4. Computed Value-Time Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ic">
-   <a href="https://drafts.csswg.org/css-values-4/#ic">https://drafts.csswg.org/css-values-4/#ic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ic" class="dfn-panel" data-for="term-for-ic" id="infopanel-for-term-for-ic" role="menu">
+   <span id="infopaneltitle-for-term-for-ic" style="display:none">Info about the 'ic' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ic">https://drafts.csswg.org/css-values-4/#ic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ic">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation" style="display:none">Info about the 'interpolate' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">2.5. Animation Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-lh">
-   <a href="https://drafts.csswg.org/css-values-4/#lh">https://drafts.csswg.org/css-values-4/#lh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-lh" class="dfn-panel" data-for="term-for-lh" id="infopanel-for-term-for-lh" role="menu">
+   <span id="infopaneltitle-for-term-for-lh" style="display:none">Info about the 'lh' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#lh">https://drafts.csswg.org/css-values-4/#lh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lh">2.7.2. Dependency Cycles via Relative Units</a> <a href="#ref-for-lh①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-math-function">
-   <a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-math-function" class="dfn-panel" data-for="term-for-math-function" id="infopanel-for-term-for-math-function" role="menu">
+   <span id="infopaneltitle-for-term-for-math-function" style="display:none">Info about the 'math function' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-math-function">2.4. Computed Value-Time Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rem">
-   <a href="https://drafts.csswg.org/css-values-4/#rem">https://drafts.csswg.org/css-values-4/#rem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rem" class="dfn-panel" data-for="term-for-rem" id="infopanel-for-term-for-rem" role="menu">
+   <span id="infopaneltitle-for-term-for-rem" style="display:none">Info about the 'rem' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#rem">https://drafts.csswg.org/css-values-4/#rem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rem">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rlh">
-   <a href="https://drafts.csswg.org/css-values-4/#rlh">https://drafts.csswg.org/css-values-4/#rlh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rlh" class="dfn-panel" data-for="term-for-rlh" id="infopanel-for-term-for-rlh" role="menu">
+   <span id="infopaneltitle-for-term-for-rlh" style="display:none">Info about the 'rlh' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#rlh">https://drafts.csswg.org/css-values-4/#rlh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rlh">2.7.2. Dependency Cycles via Relative Units</a> <a href="#ref-for-rlh①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.2. The inherits Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-custom-property-name">
-   <a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-custom-property-name" class="dfn-panel" data-for="term-for-typedef-custom-property-name" id="infopanel-for-term-for-typedef-custom-property-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-custom-property-name" style="display:none">Info about the '&lt;custom-property-name>' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-property-name">3. The @property Rule</a> <a href="#ref-for-typedef-custom-property-name①">(2)</a> <a href="#ref-for-typedef-custom-property-name②">(3)</a> <a href="#ref-for-typedef-custom-property-name③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">2. Registered Custom Properties</a> <a href="#ref-for-custom-property①">(2)</a> <a href="#ref-for-custom-property②">(3)</a>
     <li><a href="#ref-for-custom-property③">2.1. Determining the Registration</a> <a href="#ref-for-custom-property④">(2)</a> <a href="#ref-for-custom-property⑤">(3)</a>
@@ -2684,23 +2684,23 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-custom-property①④">4.1. The registerProperty() Function</a> <a href="#ref-for-custom-property①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-guaranteed-invalid-value">
-   <a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-guaranteed-invalid-value" class="dfn-panel" data-for="term-for-guaranteed-invalid-value" id="infopanel-for-term-for-guaranteed-invalid-value" role="menu">
+   <span id="infopaneltitle-for-term-for-guaranteed-invalid-value" style="display:none">Info about the 'guaranteed-invalid value' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-guaranteed-invalid-value">2.4. Computed Value-Time Behavior</a>
     <li><a href="#ref-for-guaranteed-invalid-value①">3.3. The initial-value Descriptor</a> <a href="#ref-for-guaranteed-invalid-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-at-computed-value-time">
-   <a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-at-computed-value-time" class="dfn-panel" data-for="term-for-invalid-at-computed-value-time" id="infopanel-for-term-for-invalid-at-computed-value-time" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-at-computed-value-time" style="display:none">Info about the 'invalid at computed-value time' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-at-computed-value-time">2.4. Computed Value-Time Behavior</a>
     <li><a href="#ref-for-invalid-at-computed-value-time①">2.7.1. Fallbacks In var() References</a>
     <li><a href="#ref-for-invalid-at-computed-value-time②">4.1. The registerProperty() Function</a> <a href="#ref-for-invalid-at-computed-value-time③">(2)</a> <a href="#ref-for-invalid-at-computed-value-time④">(3)</a> <a href="#ref-for-invalid-at-computed-value-time⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">2.2. Parse-Time Behavior</a>
     <li><a href="#ref-for-funcdef-var①">2.7. Substitution via var()</a> <a href="#ref-for-funcdef-var②">(2)</a> <a href="#ref-for-funcdef-var③">(3)</a>
@@ -2708,51 +2708,51 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-funcdef-var⑥">4.1. The registerProperty() Function</a> <a href="#ref-for-funcdef-var⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">2.7.2. Dependency Cycles via Relative Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">4. Registering Custom Properties in JS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">6.1. The CSSPropertyRule Interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a> <a href="#ref-for-cssomstring⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-css-value">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-value">https://drafts.csswg.org/cssom-1/#serialize-a-css-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-css-value" class="dfn-panel" data-for="term-for-serialize-a-css-value" id="infopanel-for-term-for-serialize-a-css-value" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-css-value" style="display:none">Info about the 'serialize a css value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-value">https://drafts.csswg.org/cssom-1/#serialize-a-css-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-value">2.7. Substitution via var()</a>
     <li><a href="#ref-for-serialize-a-css-value①">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-string">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-string">https://drafts.csswg.org/cssom-1/#serialize-a-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-string" class="dfn-panel" data-for="term-for-serialize-a-string" id="infopanel-for-term-for-serialize-a-string" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-string" style="display:none">Info about the 'serialize a string' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-string">https://drafts.csswg.org/cssom-1/#serialize-a-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-string">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-an-identifier">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-an-identifier">https://drafts.csswg.org/cssom-1/#serialize-an-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-an-identifier" class="dfn-panel" data-for="term-for-serialize-an-identifier" id="infopanel-for-term-for-serialize-an-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-an-identifier" style="display:none">Info about the 'serialize an identifier' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-an-identifier">https://drafts.csswg.org/cssom-1/#serialize-an-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-identifier">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Registered Custom Properties</a>
     <li><a href="#ref-for-document①">2.1. Determining the Registration</a> <a href="#ref-for-document②">(2)</a>
@@ -2760,50 +2760,50 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-document④">6. CSSOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">3. The @property Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.4.2. Consume a Syntax Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">5.1. Supported Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boolean">
-   <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boolean" class="dfn-panel" data-for="term-for-boolean" id="infopanel-for-term-for-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">2.1. Determining the Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">5.4.1. Definitions</a> <a href="#ref-for-code-point①">(2)</a>
     <li><a href="#ref-for-code-point②">5.4.2. Consume a Syntax Definition</a> <a href="#ref-for-code-point③">(2)</a>
@@ -2811,32 +2811,32 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-code-point⑤">5.4.4. Consume a Data Type Name</a> <a href="#ref-for-code-point⑥">(2)</a> <a href="#ref-for-code-point⑦">(3)</a> <a href="#ref-for-code-point⑧">(4)</a> <a href="#ref-for-code-point⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.1. Determining the Registration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'contain (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">2. Registered Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">5.4.2. Consume a Syntax Definition</a> <a href="#ref-for-string-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.4.2. Consume a Syntax Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.1. Determining the Registration</a>
     <li><a href="#ref-for-string①">5.4.2. Consume a Syntax Definition</a>
@@ -2844,66 +2844,66 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
     <li><a href="#ref-for-string③">5.4.4. Consume a Data Type Name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">5.4.2. Consume a Syntax Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">2.1. Determining the Registration</a>
     <li><a href="#ref-for-struct①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-by-computed-value">
-   <a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-by-computed-value" class="dfn-panel" data-for="term-for-by-computed-value" id="infopanel-for-term-for-by-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-by-computed-value" style="display:none">Info about the 'by computed value' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-by-computed-value">2.5. Animation Behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4. Registering Custom Properties in JS</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">4.2. The PropertyDefinition Dictionary</a> <a href="#ref-for-idl-DOMString④">(2)</a> <a href="#ref-for-idl-DOMString⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">4.1. The registerProperty() Function</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a> <a href="#ref-for-syntaxerror③">(4)</a> <a href="#ref-for-syntaxerror④">(5)</a> <a href="#ref-for-syntaxerror⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4. Registering Custom Properties in JS</a>
     <li><a href="#ref-for-idl-boolean①">4.2. The PropertyDefinition Dictionary</a>
     <li><a href="#ref-for-idl-boolean②">6.1. The CSSPropertyRule Interface</a> <a href="#ref-for-idl-boolean③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.1. The registerProperty() Function</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a> <a href="#ref-for-dfn-throw④">(5)</a> <a href="#ref-for-dfn-throw⑤">(6)</a> <a href="#ref-for-dfn-throw⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4. Registering Custom Properties in JS</a>
    </ul>
@@ -3201,8 +3201,8 @@ registerPaint<c- p>(</c-><c- t>'circle'</c-><c- p>,</c-> <c- a>class</c-> <c- p>
 as the behavior of concept-defining at-rules in shadow trees
 becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-drafts/issues/939">[Issue #939]</a> <a class="issue-return" href="#issue-14fa952d" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="registered-custom-property">
-   <b><a href="#registered-custom-property">#registered-custom-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-custom-property" class="dfn-panel" data-for="registered-custom-property" id="infopanel-for-registered-custom-property" role="dialog">
+   <span id="infopaneltitle-for-registered-custom-property" style="display:none">Info about the 'registered custom property' definition.</span><b><a href="#registered-custom-property">#registered-custom-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-custom-property">2. Registered Custom Properties</a>
     <li><a href="#ref-for-registered-custom-property①">2.1. Determining the Registration</a> <a href="#ref-for-registered-custom-property②">(2)</a>
@@ -3215,8 +3215,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-registered-custom-property①①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-property-registration">
-   <b><a href="#custom-property-registration">#custom-property-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-property-registration" class="dfn-panel" data-for="custom-property-registration" id="infopanel-for-custom-property-registration" role="dialog">
+   <span id="infopaneltitle-for-custom-property-registration" style="display:none">Info about the 'custom property registration' definition.</span><b><a href="#custom-property-registration">#custom-property-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property-registration">2.4. Computed Value-Time Behavior</a> <a href="#ref-for-custom-property-registration①">(2)</a>
     <li><a href="#ref-for-custom-property-registration②">3. The @property Rule</a> <a href="#ref-for-custom-property-registration③">(2)</a>
@@ -3225,8 +3225,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-custom-property-registration⑥">3.3. The initial-value Descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-property">
-   <b><a href="#at-ruledef-property">#at-ruledef-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-property" class="dfn-panel" data-for="at-ruledef-property" id="infopanel-for-at-ruledef-property" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-property" style="display:none">Info about the '@property' definition.</span><b><a href="#at-ruledef-property">#at-ruledef-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-property">1. Introduction</a>
     <li><a href="#ref-for-at-ruledef-property①">2. Registered Custom Properties</a> <a href="#ref-for-at-ruledef-property②">(2)</a>
@@ -3239,8 +3239,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-at-ruledef-property③⓪">7.2. Example 2: Using @property to register a property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-registeredpropertyset-slot">
-   <b><a href="#dom-window-registeredpropertyset-slot">#dom-window-registeredpropertyset-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-registeredpropertyset-slot" class="dfn-panel" data-for="dom-window-registeredpropertyset-slot" id="infopanel-for-dom-window-registeredpropertyset-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-window-registeredpropertyset-slot" style="display:none">Info about the '[[registeredPropertySet]]' definition.</span><b><a href="#dom-window-registeredpropertyset-slot">#dom-window-registeredpropertyset-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-registeredpropertyset-slot">2. Registered Custom Properties</a>
     <li><a href="#ref-for-dom-window-registeredpropertyset-slot①">2.1. Determining the Registration</a>
@@ -3248,8 +3248,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-dom-window-registeredpropertyset-slot③">6. CSSOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-registerproperty">
-   <b><a href="#dom-css-registerproperty">#dom-css-registerproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-registerproperty" class="dfn-panel" data-for="dom-css-registerproperty" id="infopanel-for-dom-css-registerproperty" role="dialog">
+   <span id="infopaneltitle-for-dom-css-registerproperty" style="display:none">Info about the 'registerProperty(PropertyDefinition definition)' definition.</span><b><a href="#dom-css-registerproperty">#dom-css-registerproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-registerproperty">1. Introduction</a>
     <li><a href="#ref-for-dom-css-registerproperty①">2. Registered Custom Properties</a> <a href="#ref-for-dom-css-registerproperty②">(2)</a>
@@ -3258,81 +3258,81 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-dom-css-registerproperty⑦">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="register-a-custom-property">
-   <b><a href="#register-a-custom-property">#register-a-custom-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-register-a-custom-property" class="dfn-panel" data-for="register-a-custom-property" id="infopanel-for-register-a-custom-property" role="dialog">
+   <span id="infopaneltitle-for-register-a-custom-property" style="display:none">Info about the 'register a custom property' definition.</span><b><a href="#register-a-custom-property">#register-a-custom-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-register-a-custom-property">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computationally-independent">
-   <b><a href="#computationally-independent">#computationally-independent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computationally-independent" class="dfn-panel" data-for="computationally-independent" id="infopanel-for-computationally-independent" role="dialog">
+   <span id="infopaneltitle-for-computationally-independent" style="display:none">Info about the 'computationally independent' definition.</span><b><a href="#computationally-independent">#computationally-independent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computationally-independent">3.3. The initial-value Descriptor</a>
     <li><a href="#ref-for-computationally-independent①">4.1. The registerProperty() Function</a> <a href="#ref-for-computationally-independent②">(2)</a> <a href="#ref-for-computationally-independent③">(3)</a> <a href="#ref-for-computationally-independent④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-propertydefinition">
-   <b><a href="#dictdef-propertydefinition">#dictdef-propertydefinition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-propertydefinition" class="dfn-panel" data-for="dictdef-propertydefinition" id="infopanel-for-dictdef-propertydefinition" role="dialog">
+   <span id="infopaneltitle-for-dictdef-propertydefinition" style="display:none">Info about the 'PropertyDefinition' definition.</span><b><a href="#dictdef-propertydefinition">#dictdef-propertydefinition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-propertydefinition">4. Registering Custom Properties in JS</a> <a href="#ref-for-dictdef-propertydefinition①">(2)</a>
     <li><a href="#ref-for-dictdef-propertydefinition②">4.2. The PropertyDefinition Dictionary</a> <a href="#ref-for-dictdef-propertydefinition③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-propertydefinition-name">
-   <b><a href="#dom-propertydefinition-name">#dom-propertydefinition-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-propertydefinition-name" class="dfn-panel" data-for="dom-propertydefinition-name" id="infopanel-for-dom-propertydefinition-name" role="dialog">
+   <span id="infopaneltitle-for-dom-propertydefinition-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-propertydefinition-name">#dom-propertydefinition-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-propertydefinition-name">4. Registering Custom Properties in JS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-propertydefinition-syntax">
-   <b><a href="#dom-propertydefinition-syntax">#dom-propertydefinition-syntax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-propertydefinition-syntax" class="dfn-panel" data-for="dom-propertydefinition-syntax" id="infopanel-for-dom-propertydefinition-syntax" role="dialog">
+   <span id="infopaneltitle-for-dom-propertydefinition-syntax" style="display:none">Info about the 'syntax' definition.</span><b><a href="#dom-propertydefinition-syntax">#dom-propertydefinition-syntax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-propertydefinition-syntax">4. Registering Custom Properties in JS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-propertydefinition-inherits">
-   <b><a href="#dom-propertydefinition-inherits">#dom-propertydefinition-inherits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-propertydefinition-inherits" class="dfn-panel" data-for="dom-propertydefinition-inherits" id="infopanel-for-dom-propertydefinition-inherits" role="dialog">
+   <span id="infopaneltitle-for-dom-propertydefinition-inherits" style="display:none">Info about the 'inherits' definition.</span><b><a href="#dom-propertydefinition-inherits">#dom-propertydefinition-inherits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-propertydefinition-inherits">4. Registering Custom Properties in JS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-propertydefinition-initialvalue">
-   <b><a href="#dom-propertydefinition-initialvalue">#dom-propertydefinition-initialvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-propertydefinition-initialvalue" class="dfn-panel" data-for="dom-propertydefinition-initialvalue" id="infopanel-for-dom-propertydefinition-initialvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-propertydefinition-initialvalue" style="display:none">Info about the 'initialValue' definition.</span><b><a href="#dom-propertydefinition-initialvalue">#dom-propertydefinition-initialvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-propertydefinition-initialvalue">4. Registering Custom Properties in JS</a>
     <li><a href="#ref-for-dom-propertydefinition-initialvalue①">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syntax-string">
-   <b><a href="#syntax-string">#syntax-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syntax-string" class="dfn-panel" data-for="syntax-string" id="infopanel-for-syntax-string" role="dialog">
+   <span id="infopaneltitle-for-syntax-string" style="display:none">Info about the 'syntax string' definition.</span><b><a href="#syntax-string">#syntax-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-string">2.1. Determining the Registration</a>
     <li><a href="#ref-for-syntax-string①">3.1. The syntax Descriptor</a>
     <li><a href="#ref-for-syntax-string②">5.3. The '|' Combinator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-supported-syntax-component-name">
-   <b><a href="#css-supported-syntax-component-name">#css-supported-syntax-component-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-supported-syntax-component-name" class="dfn-panel" data-for="css-supported-syntax-component-name" id="infopanel-for-css-supported-syntax-component-name" role="dialog">
+   <span id="infopaneltitle-for-css-supported-syntax-component-name" style="display:none">Info about the 'supported syntax component names' definition.</span><b><a href="#css-supported-syntax-component-name">#css-supported-syntax-component-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-supported-syntax-component-name">5.4.4. Consume a Data Type Name</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-type-name">
-   <b><a href="#data-type-name">#data-type-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-type-name" class="dfn-panel" data-for="data-type-name" id="infopanel-for-data-type-name" role="dialog">
+   <span id="infopaneltitle-for-data-type-name" style="display:none">Info about the 'data type name' definition.</span><b><a href="#data-type-name">#data-type-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-type-name">5.4.1. Definitions</a> <a href="#ref-for-data-type-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pre-multiplied-data-type-name">
-   <b><a href="#pre-multiplied-data-type-name">#pre-multiplied-data-type-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pre-multiplied-data-type-name" class="dfn-panel" data-for="pre-multiplied-data-type-name" id="infopanel-for-pre-multiplied-data-type-name" role="dialog">
+   <span id="infopaneltitle-for-pre-multiplied-data-type-name" style="display:none">Info about the 'pre-multiplied data type name' definition.</span><b><a href="#pre-multiplied-data-type-name">#pre-multiplied-data-type-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pre-multiplied-data-type-name">5.1. Supported Names</a>
     <li><a href="#ref-for-pre-multiplied-data-type-name①">5.2. The '+' and '#' Multipliers</a>
     <li><a href="#ref-for-pre-multiplied-data-type-name②">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syntax-component">
-   <b><a href="#syntax-component">#syntax-component</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syntax-component" class="dfn-panel" data-for="syntax-component" id="infopanel-for-syntax-component" role="dialog">
+   <span id="infopaneltitle-for-syntax-component" style="display:none">Info about the 'syntax component' definition.</span><b><a href="#syntax-component">#syntax-component</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-component">5. Syntax Strings</a>
     <li><a href="#ref-for-syntax-component①">5.1. Supported Names</a> <a href="#ref-for-syntax-component②">(2)</a>
@@ -3342,8 +3342,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-syntax-component⑨">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syntax-component-name">
-   <b><a href="#syntax-component-name">#syntax-component-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syntax-component-name" class="dfn-panel" data-for="syntax-component-name" id="infopanel-for-syntax-component-name" role="dialog">
+   <span id="infopaneltitle-for-syntax-component-name" style="display:none">Info about the 'syntax component name' definition.</span><b><a href="#syntax-component-name">#syntax-component-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-component-name">5. Syntax Strings</a>
     <li><a href="#ref-for-syntax-component-name①">5.2. The '+' and '#' Multipliers</a> <a href="#ref-for-syntax-component-name②">(2)</a>
@@ -3351,8 +3351,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-syntax-component-name④">5.4.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="syntax-definition">
-   <b><a href="#syntax-definition">#syntax-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-syntax-definition" class="dfn-panel" data-for="syntax-definition" id="infopanel-for-syntax-definition" role="dialog">
+   <span id="infopaneltitle-for-syntax-definition" style="display:none">Info about the 'syntax definition' definition.</span><b><a href="#syntax-definition">#syntax-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-definition">2.7.1. Fallbacks In var() References</a>
     <li><a href="#ref-for-syntax-definition①">3.3. The initial-value Descriptor</a>
@@ -3363,8 +3363,8 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-syntax-definition⑦">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="universal-syntax-definition">
-   <b><a href="#universal-syntax-definition">#universal-syntax-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-universal-syntax-definition" class="dfn-panel" data-for="universal-syntax-definition" id="infopanel-for-universal-syntax-definition" role="dialog">
+   <span id="infopaneltitle-for-universal-syntax-definition" style="display:none">Info about the 'universal syntax definition' definition.</span><b><a href="#universal-syntax-definition">#universal-syntax-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-universal-syntax-definition">2.4. Computed Value-Time Behavior</a>
     <li><a href="#ref-for-universal-syntax-definition①">3. The @property Rule</a>
@@ -3376,111 +3376,167 @@ becomes more consistently defined. <a href="https://github.com/w3c/css-houdini-d
     <li><a href="#ref-for-universal-syntax-definition①⓪">6.2. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-syntax-definition">
-   <b><a href="#consume-a-syntax-definition">#consume-a-syntax-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-syntax-definition" class="dfn-panel" data-for="consume-a-syntax-definition" id="infopanel-for-consume-a-syntax-definition" role="dialog">
+   <span id="infopaneltitle-for-consume-a-syntax-definition" style="display:none">Info about the 'consume a syntax definition' definition.</span><b><a href="#consume-a-syntax-definition">#consume-a-syntax-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-syntax-definition">3.1. The syntax Descriptor</a>
     <li><a href="#ref-for-consume-a-syntax-definition①">3.3. The initial-value Descriptor</a>
     <li><a href="#ref-for-consume-a-syntax-definition②">4.1. The registerProperty() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-syntax-component">
-   <b><a href="#consume-a-syntax-component">#consume-a-syntax-component</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-syntax-component" class="dfn-panel" data-for="consume-a-syntax-component" id="infopanel-for-consume-a-syntax-component" role="dialog">
+   <span id="infopaneltitle-for-consume-a-syntax-component" style="display:none">Info about the 'consume a syntax component' definition.</span><b><a href="#consume-a-syntax-component">#consume-a-syntax-component</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-syntax-component">5.4.2. Consume a Syntax Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-data-type-name">
-   <b><a href="#consume-a-data-type-name">#consume-a-data-type-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-data-type-name" class="dfn-panel" data-for="consume-a-data-type-name" id="infopanel-for-consume-a-data-type-name" role="dialog">
+   <span id="infopaneltitle-for-consume-a-data-type-name" style="display:none">Info about the 'consume a data type name' definition.</span><b><a href="#consume-a-data-type-name">#consume-a-data-type-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-data-type-name">5.4.3. Consume a Syntax Component</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csspropertyrule">
-   <b><a href="#csspropertyrule">#csspropertyrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csspropertyrule" class="dfn-panel" data-for="csspropertyrule" id="infopanel-for-csspropertyrule" role="dialog">
+   <span id="infopaneltitle-for-csspropertyrule" style="display:none">Info about the 'CSSPropertyRule' definition.</span><b><a href="#csspropertyrule">#csspropertyrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspropertyrule">6.1. The CSSPropertyRule Interface</a> <a href="#ref-for-csspropertyrule①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspropertyrule-name">
-   <b><a href="#dom-csspropertyrule-name">#dom-csspropertyrule-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspropertyrule-name" class="dfn-panel" data-for="dom-csspropertyrule-name" id="infopanel-for-dom-csspropertyrule-name" role="dialog">
+   <span id="infopaneltitle-for-dom-csspropertyrule-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-csspropertyrule-name">#dom-csspropertyrule-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspropertyrule-name">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspropertyrule-syntax">
-   <b><a href="#dom-csspropertyrule-syntax">#dom-csspropertyrule-syntax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspropertyrule-syntax" class="dfn-panel" data-for="dom-csspropertyrule-syntax" id="infopanel-for-dom-csspropertyrule-syntax" role="dialog">
+   <span id="infopaneltitle-for-dom-csspropertyrule-syntax" style="display:none">Info about the 'syntax' definition.</span><b><a href="#dom-csspropertyrule-syntax">#dom-csspropertyrule-syntax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspropertyrule-syntax">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspropertyrule-inherits">
-   <b><a href="#dom-csspropertyrule-inherits">#dom-csspropertyrule-inherits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspropertyrule-inherits" class="dfn-panel" data-for="dom-csspropertyrule-inherits" id="infopanel-for-dom-csspropertyrule-inherits" role="dialog">
+   <span id="infopaneltitle-for-dom-csspropertyrule-inherits" style="display:none">Info about the 'inherits' definition.</span><b><a href="#dom-csspropertyrule-inherits">#dom-csspropertyrule-inherits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspropertyrule-inherits">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspropertyrule-initialvalue">
-   <b><a href="#dom-csspropertyrule-initialvalue">#dom-csspropertyrule-initialvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspropertyrule-initialvalue" class="dfn-panel" data-for="dom-csspropertyrule-initialvalue" id="infopanel-for-dom-csspropertyrule-initialvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-csspropertyrule-initialvalue" style="display:none">Info about the 'initialValue' definition.</span><b><a href="#dom-csspropertyrule-initialvalue">#dom-csspropertyrule-initialvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspropertyrule-initialvalue">6.1. The CSSPropertyRule Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/css-houdini-drafts/css-typed-om-2/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-typed-om-2/Overview.html
@@ -2092,32 +2092,32 @@ Parts of this work may be from another specification document.  If so, those par
     Questions should be directed to the <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list.</p>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">Unnamed section</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-identifier">
-   <a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-identifier" class="dfn-panel" data-for="term-for-value-def-identifier" id="infopanel-for-term-for-value-def-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-identifier" style="display:none">Info about the '&lt;identifier>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-identifier">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-uri">
-   <a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-uri" class="dfn-panel" data-for="term-for-value-def-uri" id="infopanel-for-term-for-value-def-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-uri" style="display:none">Info about the '&lt;uri>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-uri">Unnamed section</a>
    </ul>
@@ -2165,57 +2165,113 @@ Parts of this work may be from another specification document.  If so, those par
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/css-houdini-drafts/css-typed-om/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/css-typed-om/Overview.html
@@ -8018,2372 +8018,2372 @@ return the result of serializing the <a class="production css" data-link-type="t
      <li><a href="#dom-csstranslate-z">attribute for CSSTranslate</a><span>, in § 4.4</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-blend-mode">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-background-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-background-blend-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-blend-mode" class="dfn-panel" data-for="term-for-propdef-background-blend-mode" id="infopanel-for-term-for-propdef-background-blend-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-blend-mode" style="display:none">Info about the 'background-blend-mode' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-background-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-background-blend-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-blend-mode">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-isolation">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-isolation" class="dfn-panel" data-for="term-for-propdef-isolation" id="infopanel-for-term-for-propdef-isolation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-isolation" style="display:none">Info about the 'isolation' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-isolation">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mix-blend-mode">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mix-blend-mode" class="dfn-panel" data-for="term-for-propdef-mix-blend-mode" id="infopanel-for-term-for-propdef-mix-blend-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mix-blend-mode" style="display:none">Info about the 'mix-blend-mode' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mix-blend-mode">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-overflow-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-overflow-position">https://drafts.csswg.org/css-align-3/#typedef-overflow-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-overflow-position" class="dfn-panel" data-for="term-for-typedef-overflow-position" id="infopanel-for-term-for-typedef-overflow-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-overflow-position" style="display:none">Info about the '&lt;overflow-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-overflow-position">https://drafts.csswg.org/css-align-3/#typedef-overflow-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-overflow-position">5.1. Property-specific Rules</a> <a href="#ref-for-typedef-overflow-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-self-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-self-position">https://drafts.csswg.org/css-align-3/#typedef-self-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-self-position" class="dfn-panel" data-for="term-for-typedef-self-position" id="infopanel-for-term-for-typedef-self-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-self-position" style="display:none">Info about the '&lt;self-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-self-position">https://drafts.csswg.org/css-align-3/#typedef-self-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-self-position">5.1. Property-specific Rules</a> <a href="#ref-for-typedef-self-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-items" class="dfn-panel" data-for="term-for-propdef-align-items" id="infopanel-for-term-for-propdef-align-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-items" style="display:none">Info about the 'align-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-gap" class="dfn-panel" data-for="term-for-propdef-gap" id="infopanel-for-term-for-propdef-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-gap" style="display:none">Info about the 'gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column-gap" class="dfn-panel" data-for="term-for-propdef-grid-column-gap" id="infopanel-for-term-for-propdef-grid-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column-gap" style="display:none">Info about the 'grid-column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-gap" class="dfn-panel" data-for="term-for-propdef-grid-gap" id="infopanel-for-term-for-propdef-grid-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-gap" style="display:none">Info about the 'grid-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row-gap" class="dfn-panel" data-for="term-for-propdef-grid-row-gap" id="infopanel-for-term-for-propdef-grid-row-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row-gap" style="display:none">Info about the 'grid-row-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-items" class="dfn-panel" data-for="term-for-propdef-justify-items" id="infopanel-for-term-for-propdef-justify-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-items" style="display:none">Info about the 'justify-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-items">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-content" class="dfn-panel" data-for="term-for-propdef-place-content" id="infopanel-for-term-for-propdef-place-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-content" style="display:none">Info about the 'place-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-content">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-items">https://drafts.csswg.org/css-align-3/#propdef-place-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-items" class="dfn-panel" data-for="term-for-propdef-place-items" id="infopanel-for-term-for-propdef-place-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-items" style="display:none">Info about the 'place-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-items">https://drafts.csswg.org/css-align-3/#propdef-place-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-items">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-self">https://drafts.csswg.org/css-align-3/#propdef-place-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-self" class="dfn-panel" data-for="term-for-propdef-place-self" id="infopanel-for-term-for-propdef-place-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-self" style="display:none">Info about the 'place-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-self">https://drafts.csswg.org/css-align-3/#propdef-place-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-self">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-row-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-row-gap" class="dfn-panel" data-for="term-for-propdef-row-gap" id="infopanel-for-term-for-propdef-row-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-row-gap" style="display:none">Info about the 'row-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-row-gap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-composition">
-   <a href="https://drafts.csswg.org/css-animations-2/#propdef-animation-composition">https://drafts.csswg.org/css-animations-2/#propdef-animation-composition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-composition" class="dfn-panel" data-for="term-for-propdef-animation-composition" id="infopanel-for-term-for-propdef-animation-composition" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-composition" style="display:none">Info about the 'animation-composition' external reference.</span><a href="https://drafts.csswg.org/css-animations-2/#propdef-animation-composition">https://drafts.csswg.org/css-animations-2/#propdef-animation-composition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-composition">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-background-color①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3. The StylePropertyMap</a> <a href="#ref-for-propdef-background-image①">(2)</a>
     <li><a href="#ref-for-propdef-background-image②">4.5. CSSImageValue objects</a> <a href="#ref-for-propdef-background-image③">(2)</a>
     <li><a href="#ref-for-propdef-background-image④">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom" class="dfn-panel" data-for="term-for-propdef-border-bottom" id="infopanel-for-term-for-propdef-border-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom" style="display:none">Info about the 'border-bottom' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-color" class="dfn-panel" data-for="term-for-propdef-border-bottom-color" id="infopanel-for-term-for-propdef-border-bottom-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-style" class="dfn-panel" data-for="term-for-propdef-border-bottom-style" id="infopanel-for-term-for-propdef-border-bottom-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-style" style="display:none">Info about the 'border-bottom-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-border-color①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-outset">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-outset">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-outset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-outset" class="dfn-panel" data-for="term-for-propdef-border-image-outset" id="infopanel-for-term-for-propdef-border-image-outset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-outset" style="display:none">Info about the 'border-image-outset' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-outset">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-outset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-outset">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-propdef-border-image-outset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-repeat" class="dfn-panel" data-for="term-for-propdef-border-image-repeat" id="infopanel-for-term-for-propdef-border-image-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-repeat" style="display:none">Info about the 'border-image-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-repeat">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-propdef-border-image-repeat①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-slice">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-slice" class="dfn-panel" data-for="term-for-propdef-border-image-slice" id="infopanel-for-term-for-propdef-border-image-slice" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-slice" style="display:none">Info about the 'border-image-slice' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-slice">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-propdef-border-image-slice①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-source">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-source" class="dfn-panel" data-for="term-for-propdef-border-image-source" id="infopanel-for-term-for-propdef-border-image-source" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-source" style="display:none">Info about the 'border-image-source' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-source">4.5. CSSImageValue objects</a>
     <li><a href="#ref-for-propdef-border-image-source①">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-propdef-border-image-source②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-width" class="dfn-panel" data-for="term-for-propdef-border-image-width" id="infopanel-for-term-for-propdef-border-image-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-width" style="display:none">Info about the 'border-image-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-width">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-propdef-border-image-width①">(2)</a> <a href="#ref-for-propdef-border-image-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left" class="dfn-panel" data-for="term-for-propdef-border-left" id="infopanel-for-term-for-propdef-border-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left" style="display:none">Info about the 'border-left' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-color" class="dfn-panel" data-for="term-for-propdef-border-left-color" id="infopanel-for-term-for-propdef-border-left-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-style" class="dfn-panel" data-for="term-for-propdef-border-left-style" id="infopanel-for-term-for-propdef-border-left-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-style" style="display:none">Info about the 'border-left-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right" class="dfn-panel" data-for="term-for-propdef-border-right" id="infopanel-for-term-for-propdef-border-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right" style="display:none">Info about the 'border-right' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-color" class="dfn-panel" data-for="term-for-propdef-border-right-color" id="infopanel-for-term-for-propdef-border-right-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-style" class="dfn-panel" data-for="term-for-propdef-border-right-style" id="infopanel-for-term-for-propdef-border-right-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-style" style="display:none">Info about the 'border-right-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top" class="dfn-panel" data-for="term-for-propdef-border-top" id="infopanel-for-term-for-propdef-border-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top" style="display:none">Info about the 'border-top' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-border-top①">(2)</a> <a href="#ref-for-propdef-border-top②">(3)</a> <a href="#ref-for-propdef-border-top③">(4)</a> <a href="#ref-for-propdef-border-top④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-border-top-color①">(2)</a> <a href="#ref-for-propdef-border-top-color②">(3)</a> <a href="#ref-for-propdef-border-top-color③">(4)</a> <a href="#ref-for-propdef-border-top-color④">(5)</a> <a href="#ref-for-propdef-border-top-color⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-style" class="dfn-panel" data-for="term-for-propdef-border-top-style" id="infopanel-for-term-for-propdef-border-top-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-style" style="display:none">Info about the 'border-top-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-style">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-border-top-style①">(2)</a> <a href="#ref-for-propdef-border-top-style②">(3)</a> <a href="#ref-for-propdef-border-top-style③">(4)</a> <a href="#ref-for-propdef-border-top-style④">(5)</a> <a href="#ref-for-propdef-border-top-style⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-border-top-width①">(2)</a> <a href="#ref-for-propdef-border-top-width②">(3)</a> <a href="#ref-for-propdef-border-top-width③">(4)</a> <a href="#ref-for-propdef-border-top-width④">(5)</a> <a href="#ref-for-propdef-border-top-width⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-image-slice-fill">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill">https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-image-slice-fill" class="dfn-panel" data-for="term-for-border-image-slice-fill" id="infopanel-for-term-for-border-image-slice-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-border-image-slice-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill">https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-image-slice-fill">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-border-image-repeat-stretch">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-border-image-repeat-stretch">https://drafts.csswg.org/css-backgrounds-3/#valdef-border-image-repeat-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-border-image-repeat-stretch" class="dfn-panel" data-for="term-for-valdef-border-image-repeat-stretch" id="infopanel-for-term-for-valdef-border-image-repeat-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-border-image-repeat-stretch" style="display:none">Info about the 'stretch' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-border-image-repeat-stretch">https://drafts.csswg.org/css-backgrounds-3/#valdef-border-image-repeat-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-repeat-stretch">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-margin-top①">(2)</a> <a href="#ref-for-propdef-margin-top②">(3)</a> <a href="#ref-for-propdef-margin-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-padding-top①">(2)</a> <a href="#ref-for-propdef-padding-top②">(3)</a> <a href="#ref-for-propdef-padding-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-widows">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-widows" class="dfn-panel" data-for="term-for-propdef-widows" id="infopanel-for-term-for-propdef-widows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-widows" style="display:none">Info about the 'widows' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a> <a href="#ref-for-computed-value③">(4)</a>
     <li><a href="#ref-for-computed-value④">4.5. CSSImageValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">4.6. CSSColorValue objects</a> <a href="#ref-for-typedef-color①">(2)</a>
     <li><a href="#ref-for-typedef-color②">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-typedef-color③">(2)</a> <a href="#ref-for-typedef-color④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3. The StylePropertyMap</a>
     <li><a href="#ref-for-propdef-color①">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-color②">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-valdef-color-currentcolor①">(2)</a> <a href="#ref-for-valdef-color-currentcolor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">4.3. Numeric Values:</a>
     <li><a href="#ref-for-propdef-opacity①">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-opacity②">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color-adjust">
-   <a href="https://drafts.csswg.org/css-color-adjust-1/#propdef-color-adjust">https://drafts.csswg.org/css-color-adjust-1/#propdef-color-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color-adjust" class="dfn-panel" data-for="term-for-propdef-color-adjust" id="infopanel-for-term-for-propdef-color-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color-adjust" style="display:none">Info about the 'color-adjust' external reference.</span><a href="https://drafts.csswg.org/css-color-adjust-1/#propdef-color-adjust">https://drafts.csswg.org/css-color-adjust-1/#propdef-color-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color-adjust">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bookmark-label">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-label">https://drafts.csswg.org/css-content-3/#propdef-bookmark-label</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bookmark-label" class="dfn-panel" data-for="term-for-propdef-bookmark-label" id="infopanel-for-term-for-propdef-bookmark-label" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bookmark-label" style="display:none">Info about the 'bookmark-label' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-label">https://drafts.csswg.org/css-content-3/#propdef-bookmark-label</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-label">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bookmark-level">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-level">https://drafts.csswg.org/css-content-3/#propdef-bookmark-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bookmark-level" class="dfn-panel" data-for="term-for-propdef-bookmark-level" id="infopanel-for-term-for-propdef-bookmark-level" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bookmark-level" style="display:none">Info about the 'bookmark-level' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-level">https://drafts.csswg.org/css-content-3/#propdef-bookmark-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-level">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bookmark-state">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-state">https://drafts.csswg.org/css-content-3/#propdef-bookmark-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bookmark-state" class="dfn-panel" data-for="term-for-propdef-bookmark-state" id="infopanel-for-term-for-propdef-bookmark-state" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bookmark-state" style="display:none">Info about the 'bookmark-state' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-state">https://drafts.csswg.org/css-content-3/#propdef-bookmark-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-state">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-quotes">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-quotes">https://drafts.csswg.org/css-content-3/#propdef-quotes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-quotes" class="dfn-panel" data-for="term-for-propdef-quotes" id="infopanel-for-term-for-propdef-quotes" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-quotes" style="display:none">Info about the 'quotes' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-quotes">https://drafts.csswg.org/css-content-3/#propdef-quotes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-quotes">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-order">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-order" class="dfn-panel" data-for="term-for-propdef-order" id="infopanel-for-term-for-propdef-order" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-order" style="display:none">Info about the 'order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-basis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-basis" class="dfn-panel" data-for="term-for-propdef-flex-basis" id="infopanel-for-term-for-propdef-flex-basis" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-basis" style="display:none">Info about the 'flex-basis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-basis">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-direction">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-direction" class="dfn-panel" data-for="term-for-propdef-flex-direction" id="infopanel-for-term-for-propdef-flex-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-direction" style="display:none">Info about the 'flex-direction' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-direction">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-grow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-grow" class="dfn-panel" data-for="term-for-propdef-flex-grow" id="infopanel-for-term-for-propdef-flex-grow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-grow" style="display:none">Info about the 'flex-grow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-grow">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-shrink">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-shrink" class="dfn-panel" data-for="term-for-propdef-flex-shrink" id="infopanel-for-term-for-propdef-flex-shrink" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-shrink" style="display:none">Info about the 'flex-shrink' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-shrink">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-wrap">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-wrap" class="dfn-panel" data-for="term-for-propdef-flex-wrap" id="infopanel-for-term-for-propdef-flex-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-wrap" style="display:none">Info about the 'flex-wrap' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-wrap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-language-override">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-language-override" class="dfn-panel" data-for="term-for-propdef-font-language-override" id="infopanel-for-term-for-propdef-font-language-override" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-language-override" style="display:none">Info about the 'font-language-override' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-language-override">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-optical-sizing">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing">https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-optical-sizing" class="dfn-panel" data-for="term-for-propdef-font-optical-sizing" id="infopanel-for-term-for-propdef-font-optical-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-optical-sizing" style="display:none">Info about the 'font-optical-sizing' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing">https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-optical-sizing">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-palette">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-palette">https://drafts.csswg.org/css-fonts-4/#propdef-font-palette</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-palette" class="dfn-panel" data-for="term-for-propdef-font-palette" id="infopanel-for-term-for-propdef-font-palette" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-palette" style="display:none">Info about the 'font-palette' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-palette">https://drafts.csswg.org/css-fonts-4/#propdef-font-palette</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-palette">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-font-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-stretch">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-stretch" class="dfn-panel" data-for="term-for-propdef-font-stretch" id="infopanel-for-term-for-propdef-font-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-synthesis">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-synthesis">https://drafts.csswg.org/css-fonts-4/#propdef-font-synthesis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-synthesis" class="dfn-panel" data-for="term-for-propdef-font-synthesis" id="infopanel-for-term-for-propdef-font-synthesis" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-synthesis" style="display:none">Info about the 'font-synthesis' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-synthesis">https://drafts.csswg.org/css-fonts-4/#propdef-font-synthesis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant-alternates">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant-alternates" class="dfn-panel" data-for="term-for-propdef-font-variant-alternates" id="infopanel-for-term-for-propdef-font-variant-alternates" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant-alternates" style="display:none">Info about the 'font-variant-alternates' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-alternates</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-alternates">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant-emoji">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-emoji">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-emoji</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant-emoji" class="dfn-panel" data-for="term-for-propdef-font-variant-emoji" id="infopanel-for-term-for-propdef-font-variant-emoji" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant-emoji" style="display:none">Info about the 'font-variant-emoji' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-emoji">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-emoji</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-emoji">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variation-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variation-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-variation-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variation-settings" class="dfn-panel" data-for="term-for-propdef-font-variation-settings" id="infopanel-for-term-for-propdef-font-variation-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variation-settings" style="display:none">Info about the 'font-variation-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variation-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-variation-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variation-settings">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-copy-into">
-   <a href="https://drafts.csswg.org/css-gcpm-4/#propdef-copy-into">https://drafts.csswg.org/css-gcpm-4/#propdef-copy-into</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-copy-into" class="dfn-panel" data-for="term-for-propdef-copy-into" id="infopanel-for-term-for-propdef-copy-into" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-copy-into" style="display:none">Info about the 'copy-into' external reference.</span><a href="https://drafts.csswg.org/css-gcpm-4/#propdef-copy-into">https://drafts.csswg.org/css-gcpm-4/#propdef-copy-into</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-copy-into">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-flex">
-   <a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-flex" class="dfn-panel" data-for="term-for-typedef-flex" id="infopanel-for-term-for-typedef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-flex" style="display:none">Info about the '&lt;flex>' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-flex">4.3.2. Numeric Value Typing</a> <a href="#ref-for-typedef-flex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid">https://drafts.csswg.org/css-grid-2/#propdef-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid" class="dfn-panel" data-for="term-for-propdef-grid" id="infopanel-for-term-for-propdef-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid" style="display:none">Info about the 'grid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid">https://drafts.csswg.org/css-grid-2/#propdef-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-area">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-area">https://drafts.csswg.org/css-grid-2/#propdef-grid-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-area" class="dfn-panel" data-for="term-for-propdef-grid-area" id="infopanel-for-term-for-propdef-grid-area" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-area" style="display:none">Info about the 'grid-area' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-area">https://drafts.csswg.org/css-grid-2/#propdef-grid-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-area">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-auto-columns">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-auto-columns" class="dfn-panel" data-for="term-for-propdef-grid-auto-columns" id="infopanel-for-term-for-propdef-grid-auto-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-auto-columns" style="display:none">Info about the 'grid-auto-columns' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-columns">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-auto-flow">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-flow">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-auto-flow" class="dfn-panel" data-for="term-for-propdef-grid-auto-flow" id="infopanel-for-term-for-propdef-grid-auto-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-auto-flow" style="display:none">Info about the 'grid-auto-flow' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-flow">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-flow">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-auto-rows">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-rows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-auto-rows" class="dfn-panel" data-for="term-for-propdef-grid-auto-rows" id="infopanel-for-term-for-propdef-grid-auto-rows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-auto-rows" style="display:none">Info about the 'grid-auto-rows' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-auto-rows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-rows">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column">https://drafts.csswg.org/css-grid-2/#propdef-grid-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column" class="dfn-panel" data-for="term-for-propdef-grid-column" id="infopanel-for-term-for-propdef-grid-column" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column" style="display:none">Info about the 'grid-column' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column">https://drafts.csswg.org/css-grid-2/#propdef-grid-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column-end">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column-end">https://drafts.csswg.org/css-grid-2/#propdef-grid-column-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column-end" class="dfn-panel" data-for="term-for-propdef-grid-column-end" id="infopanel-for-term-for-propdef-grid-column-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column-end" style="display:none">Info about the 'grid-column-end' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column-end">https://drafts.csswg.org/css-grid-2/#propdef-grid-column-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column-start">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column-start">https://drafts.csswg.org/css-grid-2/#propdef-grid-column-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column-start" class="dfn-panel" data-for="term-for-propdef-grid-column-start" id="infopanel-for-term-for-propdef-grid-column-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column-start" style="display:none">Info about the 'grid-column-start' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column-start">https://drafts.csswg.org/css-grid-2/#propdef-grid-column-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row">https://drafts.csswg.org/css-grid-2/#propdef-grid-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row" class="dfn-panel" data-for="term-for-propdef-grid-row" id="infopanel-for-term-for-propdef-grid-row" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row" style="display:none">Info about the 'grid-row' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row">https://drafts.csswg.org/css-grid-2/#propdef-grid-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row-end">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row-end">https://drafts.csswg.org/css-grid-2/#propdef-grid-row-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row-end" class="dfn-panel" data-for="term-for-propdef-grid-row-end" id="infopanel-for-term-for-propdef-grid-row-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row-end" style="display:none">Info about the 'grid-row-end' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row-end">https://drafts.csswg.org/css-grid-2/#propdef-grid-row-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row-start">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row-start">https://drafts.csswg.org/css-grid-2/#propdef-grid-row-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row-start" class="dfn-panel" data-for="term-for-propdef-grid-row-start" id="infopanel-for-term-for-propdef-grid-row-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row-start" style="display:none">Info about the 'grid-row-start' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row-start">https://drafts.csswg.org/css-grid-2/#propdef-grid-row-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template">https://drafts.csswg.org/css-grid-2/#propdef-grid-template</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template" class="dfn-panel" data-for="term-for-propdef-grid-template" id="infopanel-for-term-for-propdef-grid-template" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template" style="display:none">Info about the 'grid-template' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template">https://drafts.csswg.org/css-grid-2/#propdef-grid-template</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template-areas">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-areas">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-areas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template-areas" class="dfn-panel" data-for="term-for-propdef-grid-template-areas" id="infopanel-for-term-for-propdef-grid-template-areas" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template-areas" style="display:none">Info about the 'grid-template-areas' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-areas">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-areas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-areas">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template-columns">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template-columns" class="dfn-panel" data-for="term-for-propdef-grid-template-columns" id="infopanel-for-term-for-propdef-grid-template-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template-columns" style="display:none">Info about the 'grid-template-columns' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-columns">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template-rows">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template-rows" class="dfn-panel" data-for="term-for-propdef-grid-template-rows" id="infopanel-for-term-for-propdef-grid-template-rows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template-rows" style="display:none">Info about the 'grid-template-rows' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-rows">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">3. The StylePropertyMap</a>
     <li><a href="#ref-for-typedef-image①">4.5. CSSImageValue objects</a> <a href="#ref-for-typedef-image②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-rendering">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-image-rendering">https://drafts.csswg.org/css-images-3/#propdef-image-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-rendering" class="dfn-panel" data-for="term-for-propdef-image-rendering" id="infopanel-for-term-for-propdef-image-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-rendering" style="display:none">Info about the 'image-rendering' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-image-rendering">https://drafts.csswg.org/css-images-3/#propdef-image-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-rendering">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-image">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-image">https://drafts.csswg.org/css-images-4/#funcdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-image" class="dfn-panel" data-for="term-for-funcdef-image" id="infopanel-for-term-for-funcdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-image" style="display:none">Info about the 'image()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-image">https://drafts.csswg.org/css-images-4/#funcdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image">4.5. CSSImageValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-resolution">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-resolution" class="dfn-panel" data-for="term-for-propdef-image-resolution" id="infopanel-for-term-for-propdef-image-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-resolution" style="display:none">Info about the 'image-resolution' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-resolution">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-fit">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-fit" class="dfn-panel" data-for="term-for-propdef-object-fit" id="infopanel-for-term-for-propdef-object-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-fit" style="display:none">Info about the 'object-fit' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-fit">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-alignment-baseline" class="dfn-panel" data-for="term-for-propdef-alignment-baseline" id="infopanel-for-term-for-propdef-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-alignment-baseline" style="display:none">Info about the 'alignment-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-alignment-baseline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-baseline-shift">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-baseline-shift" class="dfn-panel" data-for="term-for-propdef-baseline-shift" id="infopanel-for-term-for-propdef-baseline-shift" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-baseline-shift" style="display:none">Info about the 'baseline-shift' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-baseline-shift">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-dominant-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-dominant-baseline" class="dfn-panel" data-for="term-for-propdef-dominant-baseline" id="infopanel-for-term-for-propdef-dominant-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-dominant-baseline" style="display:none">Info about the 'dominant-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-dominant-baseline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter" class="dfn-panel" data-for="term-for-propdef-initial-letter" id="infopanel-for-term-for-propdef-initial-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter" style="display:none">Info about the 'initial-letter' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter-align" class="dfn-panel" data-for="term-for-propdef-initial-letter-align" id="infopanel-for-term-for-propdef-initial-letter-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter-align" style="display:none">Info about the 'initial-letter-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter-wrap">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-wrap">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter-wrap" class="dfn-panel" data-for="term-for-propdef-initial-letter-wrap" id="infopanel-for-term-for-propdef-initial-letter-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter-wrap" style="display:none">Info about the 'initial-letter-wrap' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-wrap">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter-wrap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-snap">
-   <a href="https://drafts.csswg.org/css-line-grid-1/#propdef-box-snap">https://drafts.csswg.org/css-line-grid-1/#propdef-box-snap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-snap" class="dfn-panel" data-for="term-for-propdef-box-snap" id="infopanel-for-term-for-propdef-box-snap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-snap" style="display:none">Info about the 'box-snap' external reference.</span><a href="https://drafts.csswg.org/css-line-grid-1/#propdef-box-snap">https://drafts.csswg.org/css-line-grid-1/#propdef-box-snap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-snap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-grid">
-   <a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid">https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-grid" class="dfn-panel" data-for="term-for-propdef-line-grid" id="infopanel-for-term-for-propdef-line-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-grid" style="display:none">Info about the 'line-grid' external reference.</span><a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid">https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-grid">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-snap">
-   <a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-snap">https://drafts.csswg.org/css-line-grid-1/#propdef-line-snap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-snap" class="dfn-panel" data-for="term-for-propdef-line-snap" id="infopanel-for-term-for-propdef-line-snap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-snap" style="display:none">Info about the 'line-snap' external reference.</span><a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-snap">https://drafts.csswg.org/css-line-grid-1/#propdef-line-snap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-snap">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-increment">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-increment" class="dfn-panel" data-for="term-for-propdef-counter-increment" id="infopanel-for-term-for-propdef-counter-increment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-reset">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-reset" class="dfn-panel" data-for="term-for-propdef-counter-reset" id="infopanel-for-term-for-propdef-counter-reset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-propdef-counter-reset①">3. The StylePropertyMap</a>
     <li><a href="#ref-for-propdef-counter-reset②">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-set">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-set">https://drafts.csswg.org/css-lists-3/#propdef-counter-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-set" class="dfn-panel" data-for="term-for-propdef-counter-set" id="infopanel-for-term-for-propdef-counter-set" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-set" style="display:none">Info about the 'counter-set' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-set">https://drafts.csswg.org/css-lists-3/#propdef-counter-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-set">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style" class="dfn-panel" data-for="term-for-propdef-list-style" id="infopanel-for-term-for-propdef-list-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style" style="display:none">Info about the 'list-style' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-image">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-image" class="dfn-panel" data-for="term-for-propdef-list-style-image" id="infopanel-for-term-for-propdef-list-style-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">4.5. CSSImageValue objects</a>
     <li><a href="#ref-for-propdef-list-style-image①">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-marker-side">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-marker-side">https://drafts.csswg.org/css-lists-3/#propdef-marker-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-marker-side" class="dfn-panel" data-for="term-for-propdef-marker-side" id="infopanel-for-term-for-propdef-marker-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-marker-side" style="display:none">Info about the 'marker-side' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-marker-side">https://drafts.csswg.org/css-lists-3/#propdef-marker-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-side">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-size" class="dfn-panel" data-for="term-for-propdef-block-size" id="infopanel-for-term-for-propdef-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-size" style="display:none">Info about the 'block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block">https://drafts.csswg.org/css-logical-1/#propdef-border-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block" class="dfn-panel" data-for="term-for-propdef-border-block" id="infopanel-for-term-for-propdef-border-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block" style="display:none">Info about the 'border-block' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block">https://drafts.csswg.org/css-logical-1/#propdef-border-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-color" class="dfn-panel" data-for="term-for-propdef-border-block-color" id="infopanel-for-term-for-propdef-border-block-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-color" style="display:none">Info about the 'border-block-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-end" class="dfn-panel" data-for="term-for-propdef-border-block-end" id="infopanel-for-term-for-propdef-border-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-end" style="display:none">Info about the 'border-block-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-end-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-end-color" class="dfn-panel" data-for="term-for-propdef-border-block-end-color" id="infopanel-for-term-for-propdef-border-block-end-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-end-color" style="display:none">Info about the 'border-block-end-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-end-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-end-style" class="dfn-panel" data-for="term-for-propdef-border-block-end-style" id="infopanel-for-term-for-propdef-border-block-end-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-end-style" style="display:none">Info about the 'border-block-end-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-end-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-end-width" class="dfn-panel" data-for="term-for-propdef-border-block-end-width" id="infopanel-for-term-for-propdef-border-block-end-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-end-width" style="display:none">Info about the 'border-block-end-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-start" class="dfn-panel" data-for="term-for-propdef-border-block-start" id="infopanel-for-term-for-propdef-border-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-start" style="display:none">Info about the 'border-block-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-border-block-start①">(2)</a> <a href="#ref-for-propdef-border-block-start②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-start-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-start-color" class="dfn-panel" data-for="term-for-propdef-border-block-start-color" id="infopanel-for-term-for-propdef-border-block-start-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-start-color" style="display:none">Info about the 'border-block-start-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-start-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-start-style" class="dfn-panel" data-for="term-for-propdef-border-block-start-style" id="infopanel-for-term-for-propdef-border-block-start-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-start-style" style="display:none">Info about the 'border-block-start-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-start-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-start-width" class="dfn-panel" data-for="term-for-propdef-border-block-start-width" id="infopanel-for-term-for-propdef-border-block-start-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-start-width" style="display:none">Info about the 'border-block-start-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-style" class="dfn-panel" data-for="term-for-propdef-border-block-style" id="infopanel-for-term-for-propdef-border-block-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-style" style="display:none">Info about the 'border-block-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-style">https://drafts.csswg.org/css-logical-1/#propdef-border-block-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-width" class="dfn-panel" data-for="term-for-propdef-border-block-width" id="infopanel-for-term-for-propdef-border-block-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-width" style="display:none">Info about the 'border-block-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-width">https://drafts.csswg.org/css-logical-1/#propdef-border-block-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline">https://drafts.csswg.org/css-logical-1/#propdef-border-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline" class="dfn-panel" data-for="term-for-propdef-border-inline" id="infopanel-for-term-for-propdef-border-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline" style="display:none">Info about the 'border-inline' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline">https://drafts.csswg.org/css-logical-1/#propdef-border-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-color" class="dfn-panel" data-for="term-for-propdef-border-inline-color" id="infopanel-for-term-for-propdef-border-inline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-color" style="display:none">Info about the 'border-inline-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-end" class="dfn-panel" data-for="term-for-propdef-border-inline-end" id="infopanel-for-term-for-propdef-border-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-end" style="display:none">Info about the 'border-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-end-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-end-color" class="dfn-panel" data-for="term-for-propdef-border-inline-end-color" id="infopanel-for-term-for-propdef-border-inline-end-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-end-color" style="display:none">Info about the 'border-inline-end-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-end-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-end-style" class="dfn-panel" data-for="term-for-propdef-border-inline-end-style" id="infopanel-for-term-for-propdef-border-inline-end-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-end-style" style="display:none">Info about the 'border-inline-end-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-end-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-end-width" class="dfn-panel" data-for="term-for-propdef-border-inline-end-width" id="infopanel-for-term-for-propdef-border-inline-end-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-end-width" style="display:none">Info about the 'border-inline-end-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-start" class="dfn-panel" data-for="term-for-propdef-border-inline-start" id="infopanel-for-term-for-propdef-border-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-start" style="display:none">Info about the 'border-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-start-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-start-color" class="dfn-panel" data-for="term-for-propdef-border-inline-start-color" id="infopanel-for-term-for-propdef-border-inline-start-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-start-color" style="display:none">Info about the 'border-inline-start-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-start-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-start-style" class="dfn-panel" data-for="term-for-propdef-border-inline-start-style" id="infopanel-for-term-for-propdef-border-inline-start-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-start-style" style="display:none">Info about the 'border-inline-start-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-start-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-start-width" class="dfn-panel" data-for="term-for-propdef-border-inline-start-width" id="infopanel-for-term-for-propdef-border-inline-start-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-start-width" style="display:none">Info about the 'border-inline-start-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-style">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-style" class="dfn-panel" data-for="term-for-propdef-border-inline-style" id="infopanel-for-term-for-propdef-border-inline-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-style" style="display:none">Info about the 'border-inline-style' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-style">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-width">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-width" class="dfn-panel" data-for="term-for-propdef-border-inline-width" id="infopanel-for-term-for-propdef-border-inline-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-width" style="display:none">Info about the 'border-inline-width' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-width">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inline-size" class="dfn-panel" data-for="term-for-propdef-inline-size" id="infopanel-for-term-for-propdef-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inline-size" style="display:none">Info about the 'inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block">https://drafts.csswg.org/css-logical-1/#propdef-margin-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block" class="dfn-panel" data-for="term-for-propdef-margin-block" id="infopanel-for-term-for-propdef-margin-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block" style="display:none">Info about the 'margin-block' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block">https://drafts.csswg.org/css-logical-1/#propdef-margin-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block-end" class="dfn-panel" data-for="term-for-propdef-margin-block-end" id="infopanel-for-term-for-propdef-margin-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block-end" style="display:none">Info about the 'margin-block-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block-start" class="dfn-panel" data-for="term-for-propdef-margin-block-start" id="infopanel-for-term-for-propdef-margin-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block-start" style="display:none">Info about the 'margin-block-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-inline">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-inline" class="dfn-panel" data-for="term-for-propdef-margin-inline" id="infopanel-for-term-for-propdef-margin-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-inline" style="display:none">Info about the 'margin-inline' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-inline-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-inline-end" class="dfn-panel" data-for="term-for-propdef-margin-inline-end" id="infopanel-for-term-for-propdef-margin-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-inline-end" style="display:none">Info about the 'margin-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-inline-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-inline-start" class="dfn-panel" data-for="term-for-propdef-margin-inline-start" id="infopanel-for-term-for-propdef-margin-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-inline-start" style="display:none">Info about the 'margin-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-block-size" class="dfn-panel" data-for="term-for-propdef-max-block-size" id="infopanel-for-term-for-propdef-max-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-block-size" style="display:none">Info about the 'max-block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-block-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-inline-size" class="dfn-panel" data-for="term-for-propdef-max-inline-size" id="infopanel-for-term-for-propdef-max-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-inline-size" style="display:none">Info about the 'max-inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-inline-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-min-block-size">https://drafts.csswg.org/css-logical-1/#propdef-min-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-block-size" class="dfn-panel" data-for="term-for-propdef-min-block-size" id="infopanel-for-term-for-propdef-min-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-block-size" style="display:none">Info about the 'min-block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-min-block-size">https://drafts.csswg.org/css-logical-1/#propdef-min-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-block-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-inline-size" class="dfn-panel" data-for="term-for-propdef-min-inline-size" id="infopanel-for-term-for-propdef-min-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-inline-size" style="display:none">Info about the 'min-inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-inline-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-block">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block">https://drafts.csswg.org/css-logical-1/#propdef-padding-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-block" class="dfn-panel" data-for="term-for-propdef-padding-block" id="infopanel-for-term-for-propdef-padding-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-block" style="display:none">Info about the 'padding-block' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block">https://drafts.csswg.org/css-logical-1/#propdef-padding-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-block-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-block-end" class="dfn-panel" data-for="term-for-propdef-padding-block-end" id="infopanel-for-term-for-propdef-padding-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-block-end" style="display:none">Info about the 'padding-block-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-block-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-block-start" class="dfn-panel" data-for="term-for-propdef-padding-block-start" id="infopanel-for-term-for-propdef-padding-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-block-start" style="display:none">Info about the 'padding-block-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-inline">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-inline" class="dfn-panel" data-for="term-for-propdef-padding-inline" id="infopanel-for-term-for-propdef-padding-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-inline" style="display:none">Info about the 'padding-inline' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-inline-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-inline-end" class="dfn-panel" data-for="term-for-propdef-padding-inline-end" id="infopanel-for-term-for-propdef-padding-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-inline-end" style="display:none">Info about the 'padding-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-inline-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-inline-start" class="dfn-panel" data-for="term-for-propdef-padding-inline-start" id="infopanel-for-term-for-propdef-padding-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-inline-start" style="display:none">Info about the 'padding-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-rule">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-rule">https://drafts.fxtf.org/css-masking-1/#propdef-clip-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-rule" class="dfn-panel" data-for="term-for-propdef-clip-rule" id="infopanel-for-term-for-propdef-clip-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-rule" style="display:none">Info about the 'clip-rule' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-rule">https://drafts.fxtf.org/css-masking-1/#propdef-clip-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-rule">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask" class="dfn-panel" data-for="term-for-propdef-mask" id="infopanel-for-term-for-propdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border" class="dfn-panel" data-for="term-for-propdef-mask-border" id="infopanel-for-term-for-propdef-mask-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border" style="display:none">Info about the 'mask-border' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-mode">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-mode">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-mode" class="dfn-panel" data-for="term-for-propdef-mask-border-mode" id="infopanel-for-term-for-propdef-mask-border-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-mode" style="display:none">Info about the 'mask-border-mode' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-mode">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-mode">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-outset">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-outset" class="dfn-panel" data-for="term-for-propdef-mask-border-outset" id="infopanel-for-term-for-propdef-mask-border-outset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-outset" style="display:none">Info about the 'mask-border-outset' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-outset">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-repeat">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-repeat" class="dfn-panel" data-for="term-for-propdef-mask-border-repeat" id="infopanel-for-term-for-propdef-mask-border-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-repeat" style="display:none">Info about the 'mask-border-repeat' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-repeat">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-slice">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-slice" class="dfn-panel" data-for="term-for-propdef-mask-border-slice" id="infopanel-for-term-for-propdef-mask-border-slice" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-slice" style="display:none">Info about the 'mask-border-slice' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-slice">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-source">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-source" class="dfn-panel" data-for="term-for-propdef-mask-border-source" id="infopanel-for-term-for-propdef-mask-border-source" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-source" style="display:none">Info about the 'mask-border-source' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-source">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-width">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-width" class="dfn-panel" data-for="term-for-propdef-mask-border-width" id="infopanel-for-term-for-propdef-mask-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-width" style="display:none">Info about the 'mask-border-width' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip">https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-clip" class="dfn-panel" data-for="term-for-propdef-mask-clip" id="infopanel-for-term-for-propdef-mask-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-clip" style="display:none">Info about the 'mask-clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip">https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-clip">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-composite">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite">https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-composite" class="dfn-panel" data-for="term-for-propdef-mask-composite" id="infopanel-for-term-for-propdef-mask-composite" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-composite" style="display:none">Info about the 'mask-composite' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite">https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-composite">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-image">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-image" class="dfn-panel" data-for="term-for-propdef-mask-image" id="infopanel-for-term-for-propdef-mask-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-image" style="display:none">Info about the 'mask-image' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-mode">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-mode">https://drafts.fxtf.org/css-masking-1/#propdef-mask-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-mode" class="dfn-panel" data-for="term-for-propdef-mask-mode" id="infopanel-for-term-for-propdef-mask-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-mode" style="display:none">Info about the 'mask-mode' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-mode">https://drafts.fxtf.org/css-masking-1/#propdef-mask-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-mode">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-origin">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin">https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-origin" class="dfn-panel" data-for="term-for-propdef-mask-origin" id="infopanel-for-term-for-propdef-mask-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-origin" style="display:none">Info about the 'mask-origin' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin">https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-origin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-position">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-position">https://drafts.fxtf.org/css-masking-1/#propdef-mask-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-position" class="dfn-panel" data-for="term-for-propdef-mask-position" id="infopanel-for-term-for-propdef-mask-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-position" style="display:none">Info about the 'mask-position' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-position">https://drafts.fxtf.org/css-masking-1/#propdef-mask-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-repeat">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-repeat" class="dfn-panel" data-for="term-for-propdef-mask-repeat" id="infopanel-for-term-for-propdef-mask-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-repeat" style="display:none">Info about the 'mask-repeat' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-repeat">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-size">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-size">https://drafts.fxtf.org/css-masking-1/#propdef-mask-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-size" class="dfn-panel" data-for="term-for-propdef-mask-size" id="infopanel-for-term-for-propdef-mask-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-size" style="display:none">Info about the 'mask-size' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-size">https://drafts.fxtf.org/css-masking-1/#propdef-mask-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-type">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-type">https://drafts.fxtf.org/css-masking-1/#propdef-mask-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-type" class="dfn-panel" data-for="term-for-propdef-mask-type" id="infopanel-for-term-for-propdef-mask-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-type" style="display:none">Info about the 'mask-type' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-type">https://drafts.fxtf.org/css-masking-1/#propdef-mask-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-type">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-span">
-   <a href="https://drafts.csswg.org/css-multicol-2/#propdef-column-span">https://drafts.csswg.org/css-multicol-2/#propdef-column-span</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-span" class="dfn-panel" data-for="term-for-propdef-column-span" id="infopanel-for-term-for-propdef-column-span" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-span" style="display:none">Info about the 'column-span' external reference.</span><a href="https://drafts.csswg.org/css-multicol-2/#propdef-column-span">https://drafts.csswg.org/css-multicol-2/#propdef-column-span</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-span">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-x">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-x" class="dfn-panel" data-for="term-for-propdef-overflow-x" id="infopanel-for-term-for-propdef-overflow-x" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-y">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-y" class="dfn-panel" data-for="term-for-propdef-overflow-y" id="infopanel-for-term-for-propdef-overflow-y" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-behavior">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior">https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-behavior" class="dfn-panel" data-for="term-for-propdef-scroll-behavior" id="infopanel-for-term-for-propdef-scroll-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-behavior" style="display:none">Info about the 'scroll-behavior' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior">https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-behavior">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scrollbar-gutter">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-scrollbar-gutter">https://drafts.csswg.org/css-overflow-3/#propdef-scrollbar-gutter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scrollbar-gutter" class="dfn-panel" data-for="term-for-propdef-scrollbar-gutter" id="infopanel-for-term-for-propdef-scrollbar-gutter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scrollbar-gutter" style="display:none">Info about the 'scrollbar-gutter' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-scrollbar-gutter">https://drafts.csswg.org/css-overflow-3/#propdef-scrollbar-gutter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scrollbar-gutter">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-continue">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-continue">https://drafts.csswg.org/css-overflow-4/#propdef-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-continue" class="dfn-panel" data-for="term-for-propdef-continue" id="infopanel-for-term-for-propdef-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-continue">https://drafts.csswg.org/css-overflow-4/#propdef-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-continue">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-lines">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-max-lines">https://drafts.csswg.org/css-overflow-4/#propdef-max-lines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-lines" class="dfn-panel" data-for="term-for-propdef-max-lines" id="infopanel-for-term-for-propdef-max-lines" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-lines" style="display:none">Info about the 'max-lines' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-max-lines">https://drafts.csswg.org/css-overflow-4/#propdef-max-lines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-lines">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page" class="dfn-panel" data-for="term-for-propdef-page" id="infopanel-for-term-for-propdef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float-defer">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#propdef-float-defer">https://drafts.csswg.org/css-page-floats-3/#propdef-float-defer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float-defer" class="dfn-panel" data-for="term-for-propdef-float-defer" id="infopanel-for-term-for-propdef-float-defer" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float-defer" style="display:none">Info about the 'float-defer' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#propdef-float-defer">https://drafts.csswg.org/css-page-floats-3/#propdef-float-defer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float-defer">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-top-auto">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-top-auto">https://drafts.csswg.org/css-position-3/#valdef-top-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-top-auto" class="dfn-panel" data-for="term-for-valdef-top-auto" id="infopanel-for-term-for-valdef-top-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-top-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-top-auto">https://drafts.csswg.org/css-position-3/#valdef-top-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-top-auto">3. The StylePropertyMap</a> <a href="#ref-for-valdef-top-auto①">(2)</a>
     <li><a href="#ref-for-valdef-top-auto②">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-valdef-top-auto③">(2)</a> <a href="#ref-for-valdef-top-auto④">(3)</a> <a href="#ref-for-valdef-top-auto⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-bottom①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset">https://drafts.csswg.org/css-position-3/#propdef-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset" class="dfn-panel" data-for="term-for-propdef-inset" id="infopanel-for-term-for-propdef-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset">https://drafts.csswg.org/css-position-3/#propdef-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-block">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block">https://drafts.csswg.org/css-position-3/#propdef-inset-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-block" class="dfn-panel" data-for="term-for-propdef-inset-block" id="infopanel-for-term-for-propdef-inset-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-block" style="display:none">Info about the 'inset-block' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block">https://drafts.csswg.org/css-position-3/#propdef-inset-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-block-end">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-end">https://drafts.csswg.org/css-position-3/#propdef-inset-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-block-end" class="dfn-panel" data-for="term-for-propdef-inset-block-end" id="infopanel-for-term-for-propdef-inset-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-block-end" style="display:none">Info about the 'inset-block-end' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-end">https://drafts.csswg.org/css-position-3/#propdef-inset-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-block-start">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-start">https://drafts.csswg.org/css-position-3/#propdef-inset-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-block-start" class="dfn-panel" data-for="term-for-propdef-inset-block-start" id="infopanel-for-term-for-propdef-inset-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-block-start" style="display:none">Info about the 'inset-block-start' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-start">https://drafts.csswg.org/css-position-3/#propdef-inset-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-inline">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline">https://drafts.csswg.org/css-position-3/#propdef-inset-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-inline" class="dfn-panel" data-for="term-for-propdef-inset-inline" id="infopanel-for-term-for-propdef-inset-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-inline" style="display:none">Info about the 'inset-inline' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline">https://drafts.csswg.org/css-position-3/#propdef-inset-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-inline-end">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-inline-end" class="dfn-panel" data-for="term-for-propdef-inset-inline-end" id="infopanel-for-term-for-propdef-inset-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-inline-end" style="display:none">Info about the 'inset-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-inline-start">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-inline-start" class="dfn-panel" data-for="term-for-propdef-inset-inline-start" id="infopanel-for-term-for-propdef-inset-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-inline-start" style="display:none">Info about the 'inset-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-left①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-right①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-propdef-top①">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-region-fragment">
-   <a href="https://drafts.csswg.org/css-regions-1/#propdef-region-fragment">https://drafts.csswg.org/css-regions-1/#propdef-region-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-region-fragment" class="dfn-panel" data-for="term-for-propdef-region-fragment" id="infopanel-for-term-for-propdef-region-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-region-fragment" style="display:none">Info about the 'region-fragment' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#propdef-region-fragment">https://drafts.csswg.org/css-regions-1/#propdef-region-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-region-fragment">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step" class="dfn-panel" data-for="term-for-propdef-block-step" id="infopanel-for-term-for-propdef-block-step" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step" style="display:none">Info about the 'block-step' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step-align">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-align">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step-align" class="dfn-panel" data-for="term-for-propdef-block-step-align" id="infopanel-for-term-for-propdef-block-step-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step-align" style="display:none">Info about the 'block-step-align' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-align">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step-insert">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-insert">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-insert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step-insert" class="dfn-panel" data-for="term-for-propdef-block-step-insert" id="infopanel-for-term-for-propdef-block-step-insert" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step-insert" style="display:none">Info about the 'block-step-insert' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-insert">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-insert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-insert">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step-round">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-round">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-round</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step-round" class="dfn-panel" data-for="term-for-propdef-block-step-round" id="infopanel-for-term-for-propdef-block-step-round" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step-round" style="display:none">Info about the 'block-step-round' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-round">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-round</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-round">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step-size">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step-size" class="dfn-panel" data-for="term-for-propdef-block-step-size" id="infopanel-for-term-for-propdef-block-step-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step-size" style="display:none">Info about the 'block-step-size' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height-step">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step">https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height-step" class="dfn-panel" data-for="term-for-propdef-line-height-step" id="infopanel-for-term-for-propdef-line-height-step" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height-step" style="display:none">Info about the 'line-height-step' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step">https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height-step">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-boundary">
-   <a href="https://drafts.csswg.org/css-round-display-1/#propdef-border-boundary">https://drafts.csswg.org/css-round-display-1/#propdef-border-boundary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-boundary" class="dfn-panel" data-for="term-for-propdef-border-boundary" id="infopanel-for-term-for-propdef-border-boundary" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-boundary" style="display:none">Info about the 'border-boundary' external reference.</span><a href="https://drafts.csswg.org/css-round-display-1/#propdef-border-boundary">https://drafts.csswg.org/css-round-display-1/#propdef-border-boundary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-boundary">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-ruby-align">
-   <a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-align">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-ruby-align" class="dfn-panel" data-for="term-for-propdef-ruby-align" id="infopanel-for-term-for-propdef-ruby-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-ruby-align" style="display:none">Info about the 'ruby-align' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-align">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-ruby-merge">
-   <a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-merge">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-merge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-ruby-merge" class="dfn-panel" data-for="term-for-propdef-ruby-merge" id="infopanel-for-term-for-propdef-ruby-merge" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-ruby-merge" style="display:none">Info about the 'ruby-merge' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-merge">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-merge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-merge">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-ruby-position">
-   <a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-ruby-position" class="dfn-panel" data-for="term-for-propdef-ruby-position" id="infopanel-for-term-for-propdef-ruby-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-ruby-position" style="display:none">Info about the 'ruby-position' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-anchor">
-   <a href="https://drafts.csswg.org/css-scroll-anchoring-1/#propdef-overflow-anchor">https://drafts.csswg.org/css-scroll-anchoring-1/#propdef-overflow-anchor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-anchor" class="dfn-panel" data-for="term-for-propdef-overflow-anchor" id="infopanel-for-term-for-propdef-overflow-anchor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-anchor" style="display:none">Info about the 'overflow-anchor' external reference.</span><a href="https://drafts.csswg.org/css-scroll-anchoring-1/#propdef-overflow-anchor">https://drafts.csswg.org/css-scroll-anchoring-1/#propdef-overflow-anchor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-anchor">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin" class="dfn-panel" data-for="term-for-propdef-scroll-margin" id="infopanel-for-term-for-propdef-scroll-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin" style="display:none">Info about the 'scroll-margin' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-block">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-block" class="dfn-panel" data-for="term-for-propdef-scroll-margin-block" id="infopanel-for-term-for-propdef-scroll-margin-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-block" style="display:none">Info about the 'scroll-margin-block' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-block-end">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-block-end" class="dfn-panel" data-for="term-for-propdef-scroll-margin-block-end" id="infopanel-for-term-for-propdef-scroll-margin-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-block-end" style="display:none">Info about the 'scroll-margin-block-end' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-block-start">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-block-start" class="dfn-panel" data-for="term-for-propdef-scroll-margin-block-start" id="infopanel-for-term-for-propdef-scroll-margin-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-block-start" style="display:none">Info about the 'scroll-margin-block-start' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-block-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-bottom">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-bottom">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-bottom" class="dfn-panel" data-for="term-for-propdef-scroll-margin-bottom" id="infopanel-for-term-for-propdef-scroll-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-bottom" style="display:none">Info about the 'scroll-margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-bottom">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-bottom">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-inline" class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline" id="infopanel-for-term-for-propdef-scroll-margin-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-inline" style="display:none">Info about the 'scroll-margin-inline' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline-end">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-inline-end" class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline-end" id="infopanel-for-term-for-propdef-scroll-margin-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-inline-end" style="display:none">Info about the 'scroll-margin-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline-start">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-inline-start" class="dfn-panel" data-for="term-for-propdef-scroll-margin-inline-start" id="infopanel-for-term-for-propdef-scroll-margin-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-inline-start" style="display:none">Info about the 'scroll-margin-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-left">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-left">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-left" class="dfn-panel" data-for="term-for-propdef-scroll-margin-left" id="infopanel-for-term-for-propdef-scroll-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-left" style="display:none">Info about the 'scroll-margin-left' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-left">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-right">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-right">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-right" class="dfn-panel" data-for="term-for-propdef-scroll-margin-right" id="infopanel-for-term-for-propdef-scroll-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-right" style="display:none">Info about the 'scroll-margin-right' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-right">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin-top">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-top">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin-top" class="dfn-panel" data-for="term-for-propdef-scroll-margin-top" id="infopanel-for-term-for-propdef-scroll-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin-top" style="display:none">Info about the 'scroll-margin-top' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-top">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-top">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding" class="dfn-panel" data-for="term-for-propdef-scroll-padding" id="infopanel-for-term-for-propdef-scroll-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding" style="display:none">Info about the 'scroll-padding' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-block">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-block" class="dfn-panel" data-for="term-for-propdef-scroll-padding-block" id="infopanel-for-term-for-propdef-scroll-padding-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-block" style="display:none">Info about the 'scroll-padding-block' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-block-end">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-block-end" class="dfn-panel" data-for="term-for-propdef-scroll-padding-block-end" id="infopanel-for-term-for-propdef-scroll-padding-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-block-end" style="display:none">Info about the 'scroll-padding-block-end' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-block-start">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-block-start" class="dfn-panel" data-for="term-for-propdef-scroll-padding-block-start" id="infopanel-for-term-for-propdef-scroll-padding-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-block-start" style="display:none">Info about the 'scroll-padding-block-start' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-bottom">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-bottom">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-bottom" class="dfn-panel" data-for="term-for-propdef-scroll-padding-bottom" id="infopanel-for-term-for-propdef-scroll-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-bottom" style="display:none">Info about the 'scroll-padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-bottom">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-bottom">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-inline" class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline" id="infopanel-for-term-for-propdef-scroll-padding-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-inline" style="display:none">Info about the 'scroll-padding-inline' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline-end">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-inline-end" class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline-end" id="infopanel-for-term-for-propdef-scroll-padding-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-inline-end" style="display:none">Info about the 'scroll-padding-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-end">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline-end">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline-start">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-inline-start" class="dfn-panel" data-for="term-for-propdef-scroll-padding-inline-start" id="infopanel-for-term-for-propdef-scroll-padding-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-inline-start" style="display:none">Info about the 'scroll-padding-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-start">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline-start">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-left">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-left">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-left" class="dfn-panel" data-for="term-for-propdef-scroll-padding-left" id="infopanel-for-term-for-propdef-scroll-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-left" style="display:none">Info about the 'scroll-padding-left' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-left">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-right">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-right">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-right" class="dfn-panel" data-for="term-for-propdef-scroll-padding-right" id="infopanel-for-term-for-propdef-scroll-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-right" style="display:none">Info about the 'scroll-padding-right' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-right">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding-top">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-top">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding-top" class="dfn-panel" data-for="term-for-propdef-scroll-padding-top" id="infopanel-for-term-for-propdef-scroll-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding-top" style="display:none">Info about the 'scroll-padding-top' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-top">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-top">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-snap-align">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-snap-align" class="dfn-panel" data-for="term-for-propdef-scroll-snap-align" id="infopanel-for-term-for-propdef-scroll-snap-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-snap-align" style="display:none">Info about the 'scroll-snap-align' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-snap-stop">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-snap-stop" class="dfn-panel" data-for="term-for-propdef-scroll-snap-stop" id="infopanel-for-term-for-propdef-scroll-snap-stop" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-snap-stop" style="display:none">Info about the 'scroll-snap-stop' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-stop">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-snap-type">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-snap-type" class="dfn-panel" data-for="term-for-propdef-scroll-snap-type" id="infopanel-for-term-for-propdef-scroll-snap-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-snap-type" style="display:none">Info about the 'scroll-snap-type' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-type">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-margin">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-margin" class="dfn-panel" data-for="term-for-propdef-shape-margin" id="infopanel-for-term-for-propdef-shape-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-margin" style="display:none">Info about the 'shape-margin' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-margin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-inside">
-   <a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-inside">https://drafts.csswg.org/css-shapes-2/#propdef-shape-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-inside" class="dfn-panel" data-for="term-for-propdef-shape-inside" id="infopanel-for-term-for-propdef-shape-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-inside" style="display:none">Info about the 'shape-inside' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-inside">https://drafts.csswg.org/css-shapes-2/#propdef-shape-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-inside">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-padding">
-   <a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding">https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-padding" class="dfn-panel" data-for="term-for-propdef-shape-padding" id="infopanel-for-term-for-propdef-shape-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-padding" style="display:none">Info about the 'shape-padding' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding">https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-padding">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-size-adjust">
-   <a href="https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust">https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-size-adjust" class="dfn-panel" data-for="term-for-propdef-text-size-adjust" id="infopanel-for-term-for-propdef-text-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-size-adjust" style="display:none">Info about the 'text-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust">https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-size-adjust">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">3. The StylePropertyMap</a>
     <li><a href="#ref-for-propdef-width①">3.1. Computed StylePropertyMapReadOnly objects</a>
     <li><a href="#ref-for-propdef-width②">5.1. Property-specific Rules</a> <a href="#ref-for-propdef-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cue">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-cue">https://drafts.csswg.org/css-speech-1/#propdef-cue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cue" class="dfn-panel" data-for="term-for-propdef-cue" id="infopanel-for-term-for-propdef-cue" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cue" style="display:none">Info about the 'cue' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-cue">https://drafts.csswg.org/css-speech-1/#propdef-cue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cue-after">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-cue-after">https://drafts.csswg.org/css-speech-1/#propdef-cue-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cue-after" class="dfn-panel" data-for="term-for-propdef-cue-after" id="infopanel-for-term-for-propdef-cue-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cue-after" style="display:none">Info about the 'cue-after' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-cue-after">https://drafts.csswg.org/css-speech-1/#propdef-cue-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue-after">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cue-before">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-cue-before">https://drafts.csswg.org/css-speech-1/#propdef-cue-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cue-before" class="dfn-panel" data-for="term-for-propdef-cue-before" id="infopanel-for-term-for-propdef-cue-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cue-before" style="display:none">Info about the 'cue-before' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-cue-before">https://drafts.csswg.org/css-speech-1/#propdef-cue-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue-before">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pause">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-pause">https://drafts.csswg.org/css-speech-1/#propdef-pause</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pause" class="dfn-panel" data-for="term-for-propdef-pause" id="infopanel-for-term-for-propdef-pause" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pause" style="display:none">Info about the 'pause' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-pause">https://drafts.csswg.org/css-speech-1/#propdef-pause</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pause-after">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-pause-after">https://drafts.csswg.org/css-speech-1/#propdef-pause-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pause-after" class="dfn-panel" data-for="term-for-propdef-pause-after" id="infopanel-for-term-for-propdef-pause-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pause-after" style="display:none">Info about the 'pause-after' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-pause-after">https://drafts.csswg.org/css-speech-1/#propdef-pause-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause-after">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pause-before">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-pause-before">https://drafts.csswg.org/css-speech-1/#propdef-pause-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pause-before" class="dfn-panel" data-for="term-for-propdef-pause-before" id="infopanel-for-term-for-propdef-pause-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pause-before" style="display:none">Info about the 'pause-before' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-pause-before">https://drafts.csswg.org/css-speech-1/#propdef-pause-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause-before">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-rest">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-rest">https://drafts.csswg.org/css-speech-1/#propdef-rest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-rest" class="dfn-panel" data-for="term-for-propdef-rest" id="infopanel-for-term-for-propdef-rest" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-rest" style="display:none">Info about the 'rest' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-rest">https://drafts.csswg.org/css-speech-1/#propdef-rest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-rest-after">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-rest-after">https://drafts.csswg.org/css-speech-1/#propdef-rest-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-rest-after" class="dfn-panel" data-for="term-for-propdef-rest-after" id="infopanel-for-term-for-propdef-rest-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-rest-after" style="display:none">Info about the 'rest-after' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-rest-after">https://drafts.csswg.org/css-speech-1/#propdef-rest-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest-after">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-rest-before">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-rest-before">https://drafts.csswg.org/css-speech-1/#propdef-rest-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-rest-before" class="dfn-panel" data-for="term-for-propdef-rest-before" id="infopanel-for-term-for-propdef-rest-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-rest-before" style="display:none">Info about the 'rest-before' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-rest-before">https://drafts.csswg.org/css-speech-1/#propdef-rest-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest-before">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-speak">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-speak">https://drafts.csswg.org/css-speech-1/#propdef-speak</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-speak" class="dfn-panel" data-for="term-for-propdef-speak" id="infopanel-for-term-for-propdef-speak" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-speak" style="display:none">Info about the 'speak' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-speak">https://drafts.csswg.org/css-speech-1/#propdef-speak</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-speak">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-speak-as">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-speak-as">https://drafts.csswg.org/css-speech-1/#propdef-speak-as</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-speak-as" class="dfn-panel" data-for="term-for-propdef-speak-as" id="infopanel-for-term-for-propdef-speak-as" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-speak-as" style="display:none">Info about the 'speak-as' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-speak-as">https://drafts.csswg.org/css-speech-1/#propdef-speak-as</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-speak-as">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-balance">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-balance">https://drafts.csswg.org/css-speech-1/#propdef-voice-balance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-balance" class="dfn-panel" data-for="term-for-propdef-voice-balance" id="infopanel-for-term-for-propdef-voice-balance" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-balance" style="display:none">Info about the 'voice-balance' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-balance">https://drafts.csswg.org/css-speech-1/#propdef-voice-balance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-balance">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-duration">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-duration">https://drafts.csswg.org/css-speech-1/#propdef-voice-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-duration" class="dfn-panel" data-for="term-for-propdef-voice-duration" id="infopanel-for-term-for-propdef-voice-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-duration" style="display:none">Info about the 'voice-duration' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-duration">https://drafts.csswg.org/css-speech-1/#propdef-voice-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-duration">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-family">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-family">https://drafts.csswg.org/css-speech-1/#propdef-voice-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-family" class="dfn-panel" data-for="term-for-propdef-voice-family" id="infopanel-for-term-for-propdef-voice-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-family" style="display:none">Info about the 'voice-family' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-family">https://drafts.csswg.org/css-speech-1/#propdef-voice-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-family">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-pitch">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-pitch">https://drafts.csswg.org/css-speech-1/#propdef-voice-pitch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-pitch" class="dfn-panel" data-for="term-for-propdef-voice-pitch" id="infopanel-for-term-for-propdef-voice-pitch" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-pitch" style="display:none">Info about the 'voice-pitch' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-pitch">https://drafts.csswg.org/css-speech-1/#propdef-voice-pitch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-pitch">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-range">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-range">https://drafts.csswg.org/css-speech-1/#propdef-voice-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-range" class="dfn-panel" data-for="term-for-propdef-voice-range" id="infopanel-for-term-for-propdef-voice-range" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-range" style="display:none">Info about the 'voice-range' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-range">https://drafts.csswg.org/css-speech-1/#propdef-voice-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-range">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-rate">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-rate">https://drafts.csswg.org/css-speech-1/#propdef-voice-rate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-rate" class="dfn-panel" data-for="term-for-propdef-voice-rate" id="infopanel-for-term-for-propdef-voice-rate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-rate" style="display:none">Info about the 'voice-rate' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-rate">https://drafts.csswg.org/css-speech-1/#propdef-voice-rate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-rate">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-stress">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-stress">https://drafts.csswg.org/css-speech-1/#propdef-voice-stress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-stress" class="dfn-panel" data-for="term-for-propdef-voice-stress" id="infopanel-for-term-for-propdef-voice-stress" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-stress" style="display:none">Info about the 'voice-stress' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-stress">https://drafts.csswg.org/css-speech-1/#propdef-voice-stress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-stress">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-volume">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-volume">https://drafts.csswg.org/css-speech-1/#propdef-voice-volume</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-volume" class="dfn-panel" data-for="term-for-propdef-voice-volume" id="infopanel-for-term-for-propdef-voice-volume" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-volume" style="display:none">Info about the 'voice-volume' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-volume">https://drafts.csswg.org/css-speech-1/#propdef-voice-volume</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-volume">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension-token" class="dfn-panel" data-for="term-for-typedef-dimension-token" id="infopanel-for-term-for-typedef-dimension-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-number-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-number-token" class="dfn-panel" data-for="term-for-typedef-number-token" id="infopanel-for-term-for-typedef-number-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-percentage-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-percentage-token" class="dfn-panel" data-for="term-for-typedef-percentage-token" id="infopanel-for-term-for-typedef-percentage-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-percentage-token" style="display:none">Info about the '&lt;percentage-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-percentage-token">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-component-value" class="dfn-panel" data-for="term-for-component-value" id="infopanel-for-term-for-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-component-value" style="display:none">Info about the 'component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-value">3. The StylePropertyMap</a>
     <li><a href="#ref-for-component-value①">5.3. Raw CSS tokens: properties with var() references</a> <a href="#ref-for-component-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar①">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-component-value">https://drafts.csswg.org/css-syntax-3/#parse-a-component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-component-value" class="dfn-panel" data-for="term-for-parse-a-component-value" id="infopanel-for-term-for-parse-a-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-component-value" style="display:none">Info about the 'parse a component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-component-value">https://drafts.csswg.org/css-syntax-3/#parse-a-component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-component-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css-tables-3/#propdef-border-collapse">https://drafts.csswg.org/css-tables-3/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#propdef-border-collapse">https://drafts.csswg.org/css-tables-3/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caption-side">
-   <a href="https://drafts.csswg.org/css-tables-3/#propdef-caption-side">https://drafts.csswg.org/css-tables-3/#propdef-caption-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caption-side" class="dfn-panel" data-for="term-for-propdef-caption-side" id="infopanel-for-term-for-propdef-caption-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caption-side" style="display:none">Info about the 'caption-side' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#propdef-caption-side">https://drafts.csswg.org/css-tables-3/#propdef-caption-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-empty-cells">
-   <a href="https://drafts.csswg.org/css-tables-3/#propdef-empty-cells">https://drafts.csswg.org/css-tables-3/#propdef-empty-cells</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-empty-cells" class="dfn-panel" data-for="term-for-propdef-empty-cells" id="infopanel-for-term-for-propdef-empty-cells" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-empty-cells" style="display:none">Info about the 'empty-cells' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#propdef-empty-cells">https://drafts.csswg.org/css-tables-3/#propdef-empty-cells</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-empty-cells">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-table-layout">
-   <a href="https://drafts.csswg.org/css-tables-3/#propdef-table-layout">https://drafts.csswg.org/css-tables-3/#propdef-table-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-table-layout" class="dfn-panel" data-for="term-for-propdef-table-layout" id="infopanel-for-term-for-propdef-table-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-table-layout" style="display:none">Info about the 'table-layout' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#propdef-table-layout">https://drafts.csswg.org/css-tables-3/#propdef-table-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-table-layout">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-skip">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-skip" class="dfn-panel" data-for="term-for-propdef-text-decoration-skip" id="infopanel-for-term-for-propdef-text-decoration-skip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-skip" style="display:none">Info about the 'text-decoration-skip' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-skip-ink">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-ink">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-ink</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-skip-ink" class="dfn-panel" data-for="term-for-propdef-text-decoration-skip-ink" id="infopanel-for-term-for-propdef-text-decoration-skip-ink" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-skip-ink" style="display:none">Info about the 'text-decoration-skip-ink' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-ink">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-ink</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-ink">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-skip">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-skip">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-skip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-skip" class="dfn-panel" data-for="term-for-propdef-text-emphasis-skip" id="infopanel-for-term-for-propdef-text-emphasis-skip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-skip" style="display:none">Info about the 'text-emphasis-skip' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-skip">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-skip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-skip">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-underline-offset">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset">https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-underline-offset" class="dfn-panel" data-for="term-for-propdef-text-underline-offset" id="infopanel-for-term-for-propdef-text-underline-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-underline-offset" style="display:none">Info about the 'text-underline-offset' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset">https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-underline-offset">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-function">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-function">https://drafts.csswg.org/css-transforms-1/#typedef-transform-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-function" class="dfn-panel" data-for="term-for-typedef-transform-function" id="infopanel-for-term-for-typedef-transform-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-function" style="display:none">Info about the '&lt;transform-function>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-function">https://drafts.csswg.org/css-transforms-1/#typedef-transform-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-function">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-typedef-transform-function①">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-typedef-transform-function②">(2)</a> <a href="#ref-for-typedef-transform-function③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-list">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-list" class="dfn-panel" data-for="term-for-typedef-transform-list" id="infopanel-for-term-for-typedef-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">3. The StylePropertyMap</a>
     <li><a href="#ref-for-typedef-transform-list①">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-typedef-transform-list②">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-typedef-transform-list③">(2)</a> <a href="#ref-for-typedef-transform-list④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-matrix" class="dfn-panel" data-for="term-for-funcdef-transform-matrix" id="infopanel-for-term-for-funcdef-transform-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-matrix" style="display:none">Info about the 'matrix()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-matrix">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-transform-matrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-rotate" class="dfn-panel" data-for="term-for-funcdef-transform-rotate" id="infopanel-for-term-for-funcdef-transform-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-rotate" style="display:none">Info about the 'rotate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-rotate">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-transform-rotate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-skew">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-skew" class="dfn-panel" data-for="term-for-funcdef-transform-skew" id="infopanel-for-term-for-funcdef-transform-skew" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-skew" style="display:none">Info about the 'skew()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skew</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skew">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-funcdef-transform-skew①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-skewx">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewx">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewx</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-skewx" class="dfn-panel" data-for="term-for-funcdef-transform-skewx" id="infopanel-for-term-for-funcdef-transform-skewx" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-skewx" style="display:none">Info about the 'skewx()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewx">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewx</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skewx">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-funcdef-transform-skewx①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-skewy">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewy">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-skewy" class="dfn-panel" data-for="term-for-funcdef-transform-skewy" id="infopanel-for-term-for-funcdef-transform-skewy" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-skewy" style="display:none">Info about the 'skewy()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewy">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-skewy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skewy">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-funcdef-transform-skewy①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translate" class="dfn-panel" data-for="term-for-funcdef-transform-translate" id="infopanel-for-term-for-funcdef-transform-translate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translate" style="display:none">Info about the 'translate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translate">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-transform-translate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translatex">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translatex" class="dfn-panel" data-for="term-for-funcdef-transform-translatex" id="infopanel-for-term-for-funcdef-transform-translatex" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translatex" style="display:none">Info about the 'translatex()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatex">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-transform-translatex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translatey">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translatey" class="dfn-panel" data-for="term-for-funcdef-transform-translatey" id="infopanel-for-term-for-funcdef-transform-translatey" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translatey" style="display:none">Info about the 'translatey()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatey">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-transform-translatey①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-backface-visibility">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-backface-visibility" class="dfn-panel" data-for="term-for-propdef-backface-visibility" id="infopanel-for-term-for-propdef-backface-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-backface-visibility" style="display:none">Info about the 'backface-visibility' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-backface-visibility">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-matrix3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d">https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-matrix3d" class="dfn-panel" data-for="term-for-funcdef-matrix3d" id="infopanel-for-term-for-funcdef-matrix3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-matrix3d" style="display:none">Info about the 'matrix3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d">https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-matrix3d">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-perspective">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-perspective" class="dfn-panel" data-for="term-for-propdef-perspective" id="infopanel-for-term-for-propdef-perspective" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-perspective" style="display:none">Info about the 'perspective' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-perspective">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-perspective">https://drafts.csswg.org/css-transforms-2/#funcdef-perspective</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-perspective" class="dfn-panel" data-for="term-for-funcdef-perspective" id="infopanel-for-term-for-funcdef-perspective" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-perspective" style="display:none">Info about the 'perspective()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-perspective">https://drafts.csswg.org/css-transforms-2/#funcdef-perspective</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-perspective">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-funcdef-perspective①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-perspective-origin">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin">https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-perspective-origin" class="dfn-panel" data-for="term-for-propdef-perspective-origin" id="infopanel-for-term-for-propdef-perspective-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-perspective-origin" style="display:none">Info about the 'perspective-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin">https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective-origin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">https://drafts.csswg.org/css-transforms-2/#propdef-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-rotate" class="dfn-panel" data-for="term-for-propdef-rotate" id="infopanel-for-term-for-propdef-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-rotate" style="display:none">Info about the 'rotate' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">https://drafts.csswg.org/css-transforms-2/#propdef-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rotate">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rotate3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rotate3d" class="dfn-panel" data-for="term-for-funcdef-rotate3d" id="infopanel-for-term-for-funcdef-rotate3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rotate3d" style="display:none">Info about the 'rotate3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-rotate3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotate3d">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rotatex">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rotatex" class="dfn-panel" data-for="term-for-funcdef-rotatex" id="infopanel-for-term-for-funcdef-rotatex" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rotatex" style="display:none">Info about the 'rotatex()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatex">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rotatey">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rotatey" class="dfn-panel" data-for="term-for-funcdef-rotatey" id="infopanel-for-term-for-funcdef-rotatey" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rotatey" style="display:none">Info about the 'rotatey()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatey</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatey">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rotatez">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rotatez" class="dfn-panel" data-for="term-for-funcdef-rotatez" id="infopanel-for-term-for-funcdef-rotatez" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rotatez" style="display:none">Info about the 'rotatez()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez">https://drafts.csswg.org/css-transforms-2/#funcdef-rotatez</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatez">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scale">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scale" class="dfn-panel" data-for="term-for-propdef-scale" id="infopanel-for-term-for-propdef-scale" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scale" style="display:none">Info about the 'scale' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scale">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-scale">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scale">https://drafts.csswg.org/css-transforms-2/#funcdef-scale</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-scale" class="dfn-panel" data-for="term-for-funcdef-scale" id="infopanel-for-term-for-funcdef-scale" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-scale" style="display:none">Info about the 'scale()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scale">https://drafts.csswg.org/css-transforms-2/#funcdef-scale</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scale">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-scale①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-scale3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d">https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-scale3d" class="dfn-panel" data-for="term-for-funcdef-scale3d" id="infopanel-for-term-for-funcdef-scale3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-scale3d" style="display:none">Info about the 'scale3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d">https://drafts.csswg.org/css-transforms-2/#funcdef-scale3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scale3d">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-scalex">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scalex">https://drafts.csswg.org/css-transforms-2/#funcdef-scalex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-scalex" class="dfn-panel" data-for="term-for-funcdef-scalex" id="infopanel-for-term-for-funcdef-scalex" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-scalex" style="display:none">Info about the 'scalex()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scalex">https://drafts.csswg.org/css-transforms-2/#funcdef-scalex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scalex">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-scalex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-scaley">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scaley">https://drafts.csswg.org/css-transforms-2/#funcdef-scaley</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-scaley" class="dfn-panel" data-for="term-for-funcdef-scaley" id="infopanel-for-term-for-funcdef-scaley" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-scaley" style="display:none">Info about the 'scaley()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scaley">https://drafts.csswg.org/css-transforms-2/#funcdef-scaley</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scaley">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-funcdef-scaley①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-scalez">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scalez">https://drafts.csswg.org/css-transforms-2/#funcdef-scalez</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-scalez" class="dfn-panel" data-for="term-for-funcdef-scalez" id="infopanel-for-term-for-funcdef-scalez" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-scalez" style="display:none">Info about the 'scalez()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-scalez">https://drafts.csswg.org/css-transforms-2/#funcdef-scalez</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scalez">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-style">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-style" class="dfn-panel" data-for="term-for-propdef-transform-style" id="infopanel-for-term-for-propdef-transform-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-style" style="display:none">Info about the 'transform-style' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-translate">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">https://drafts.csswg.org/css-transforms-2/#propdef-translate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-translate" class="dfn-panel" data-for="term-for-propdef-translate" id="infopanel-for-term-for-propdef-translate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-translate" style="display:none">Info about the 'translate' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">https://drafts.csswg.org/css-transforms-2/#propdef-translate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-translate">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-translate3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-translate3d" class="dfn-panel" data-for="term-for-funcdef-translate3d" id="infopanel-for-term-for-funcdef-translate3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-translate3d" style="display:none">Info about the 'translate3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-translate3d">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-translatez">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translatez">https://drafts.csswg.org/css-transforms-2/#funcdef-translatez</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-translatez" class="dfn-panel" data-for="term-for-funcdef-translatez" id="infopanel-for-term-for-funcdef-translatez" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-translatez" style="display:none">Info about the 'translatez()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translatez">https://drafts.csswg.org/css-transforms-2/#funcdef-translatez</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-translatez">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition">https://drafts.csswg.org/css-transitions-1/#propdef-transition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition" class="dfn-panel" data-for="term-for-propdef-transition" id="infopanel-for-term-for-propdef-transition" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition" style="display:none">Info about the 'transition' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition">https://drafts.csswg.org/css-transitions-1/#propdef-transition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-delay">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-delay" class="dfn-panel" data-for="term-for-propdef-transition-delay" id="infopanel-for-term-for-propdef-transition-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-delay" style="display:none">Info about the 'transition-delay' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-delay">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-duration">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-duration" class="dfn-panel" data-for="term-for-propdef-transition-duration" id="infopanel-for-term-for-propdef-transition-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-duration" style="display:none">Info about the 'transition-duration' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-duration">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-property">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-property" class="dfn-panel" data-for="term-for-propdef-transition-property" id="infopanel-for-term-for-propdef-transition-property" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-property" style="display:none">Info about the 'transition-property' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-property">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-timing-function">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-timing-function" class="dfn-panel" data-for="term-for-propdef-transition-timing-function" id="infopanel-for-term-for-propdef-transition-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-timing-function" style="display:none">Info about the 'transition-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-timing-function">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-csscolor-channels">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-csscolor-channels">https://drafts.css-houdini.org/css-typed-om-1/#dom-csscolor-channels</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-csscolor-channels" class="dfn-panel" data-for="term-for-dom-csscolor-channels" id="infopanel-for-term-for-dom-csscolor-channels" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-csscolor-channels" style="display:none">Info about the 'channels' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#dom-csscolor-channels">https://drafts.css-houdini.org/css-typed-om-1/#dom-csscolor-channels</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolor-channels">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-cssunitvalue-from-a-pair">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#create-a-cssunitvalue-from-a-pair">https://drafts.css-houdini.org/css-typed-om-1/#create-a-cssunitvalue-from-a-pair</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-cssunitvalue-from-a-pair" class="dfn-panel" data-for="term-for-create-a-cssunitvalue-from-a-pair" id="infopanel-for-term-for-create-a-cssunitvalue-from-a-pair" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-cssunitvalue-from-a-pair" style="display:none">Info about the 'new unit value' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#create-a-cssunitvalue-from-a-pair">https://drafts.css-houdini.org/css-typed-om-1/#create-a-cssunitvalue-from-a-pair</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cssunitvalue-from-a-pair⑤">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-appearance">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-appearance">https://drafts.csswg.org/css-ui-4/#propdef-appearance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-appearance" class="dfn-panel" data-for="term-for-propdef-appearance" id="infopanel-for-term-for-propdef-appearance" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-appearance" style="display:none">Info about the 'appearance' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-appearance">https://drafts.csswg.org/css-ui-4/#propdef-appearance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-appearance">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caret">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-caret">https://drafts.csswg.org/css-ui-4/#propdef-caret</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caret" class="dfn-panel" data-for="term-for-propdef-caret" id="infopanel-for-term-for-propdef-caret" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caret" style="display:none">Info about the 'caret' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-caret">https://drafts.csswg.org/css-ui-4/#propdef-caret</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caret-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-color">https://drafts.csswg.org/css-ui-4/#propdef-caret-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caret-color" class="dfn-panel" data-for="term-for-propdef-caret-color" id="infopanel-for-term-for-propdef-caret-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caret-color" style="display:none">Info about the 'caret-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-color">https://drafts.csswg.org/css-ui-4/#propdef-caret-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caret-shape">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-shape">https://drafts.csswg.org/css-ui-4/#propdef-caret-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caret-shape" class="dfn-panel" data-for="term-for-propdef-caret-shape" id="infopanel-for-term-for-propdef-caret-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caret-shape" style="display:none">Info about the 'caret-shape' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-shape">https://drafts.csswg.org/css-ui-4/#propdef-caret-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-shape">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-nav-down">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-down">https://drafts.csswg.org/css-ui-4/#propdef-nav-down</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-nav-down" class="dfn-panel" data-for="term-for-propdef-nav-down" id="infopanel-for-term-for-propdef-nav-down" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-nav-down" style="display:none">Info about the 'nav-down' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-down">https://drafts.csswg.org/css-ui-4/#propdef-nav-down</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-down">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-nav-left">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-left">https://drafts.csswg.org/css-ui-4/#propdef-nav-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-nav-left" class="dfn-panel" data-for="term-for-propdef-nav-left" id="infopanel-for-term-for-propdef-nav-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-nav-left" style="display:none">Info about the 'nav-left' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-left">https://drafts.csswg.org/css-ui-4/#propdef-nav-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-left">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-nav-right">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-right">https://drafts.csswg.org/css-ui-4/#propdef-nav-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-nav-right" class="dfn-panel" data-for="term-for-propdef-nav-right" id="infopanel-for-term-for-propdef-nav-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-nav-right" style="display:none">Info about the 'nav-right' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-right">https://drafts.csswg.org/css-ui-4/#propdef-nav-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-right">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-nav-up">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-up">https://drafts.csswg.org/css-ui-4/#propdef-nav-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-nav-up" class="dfn-panel" data-for="term-for-propdef-nav-up" id="infopanel-for-term-for-propdef-nav-up" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-nav-up" style="display:none">Info about the 'nav-up' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-nav-up">https://drafts.csswg.org/css-ui-4/#propdef-nav-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-up">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline" class="dfn-panel" data-for="term-for-propdef-outline" id="infopanel-for-term-for-propdef-outline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline" style="display:none">Info about the 'outline' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-color" class="dfn-panel" data-for="term-for-propdef-outline-color" id="infopanel-for-term-for-propdef-outline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-color" style="display:none">Info about the 'outline-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-offset">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-offset">https://drafts.csswg.org/css-ui-4/#propdef-outline-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-offset" class="dfn-panel" data-for="term-for-propdef-outline-offset" id="infopanel-for-term-for-propdef-outline-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-offset" style="display:none">Info about the 'outline-offset' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-offset">https://drafts.csswg.org/css-ui-4/#propdef-outline-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-offset">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-style">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-style">https://drafts.csswg.org/css-ui-4/#propdef-outline-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-style" class="dfn-panel" data-for="term-for-propdef-outline-style" id="infopanel-for-term-for-propdef-outline-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-style" style="display:none">Info about the 'outline-style' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-style">https://drafts.csswg.org/css-ui-4/#propdef-outline-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-style">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-width">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-width">https://drafts.csswg.org/css-ui-4/#propdef-outline-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-width" class="dfn-panel" data-for="term-for-propdef-outline-width" id="infopanel-for-term-for-propdef-outline-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-width" style="display:none">Info about the 'outline-width' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-width">https://drafts.csswg.org/css-ui-4/#propdef-outline-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-width">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pointer-events">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pointer-events" class="dfn-panel" data-for="term-for-propdef-pointer-events" id="infopanel-for-term-for-propdef-pointer-events" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pointer-events" style="display:none">Info about the 'pointer-events' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pointer-events">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-resize">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-resize" class="dfn-panel" data-for="term-for-propdef-resize" id="infopanel-for-term-for-propdef-resize" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-resize" style="display:none">Info about the 'resize' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-resize">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-user-select">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-user-select">https://drafts.csswg.org/css-ui-4/#propdef-user-select</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-user-select" class="dfn-panel" data-for="term-for-propdef-user-select" id="infopanel-for-term-for-propdef-user-select" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-user-select" style="display:none">Info about the 'user-select' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-user-select">https://drafts.csswg.org/css-ui-4/#propdef-user-select</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-user-select">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-angle-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-angle-percentage">https://drafts.csswg.org/css-values-4/#typedef-angle-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-angle-percentage" class="dfn-panel" data-for="term-for-typedef-angle-percentage" id="infopanel-for-term-for-typedef-angle-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-angle-percentage" style="display:none">Info about the '&lt;angle-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-angle-percentage">https://drafts.csswg.org/css-values-4/#typedef-angle-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angle-percentage">4.3.2. Numeric Value Typing</a> <a href="#ref-for-typedef-angle-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">4.3.2. Numeric Value Typing</a> <a href="#ref-for-angle-value①">(2)</a>
     <li><a href="#ref-for-angle-value②">4.4. CSSTransformValue objects</a> <a href="#ref-for-angle-value③">(2)</a> <a href="#ref-for-angle-value④">(3)</a> <a href="#ref-for-angle-value⑤">(4)</a> <a href="#ref-for-angle-value⑥">(5)</a>
     <li><a href="#ref-for-angle-value⑦">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">5.4. var() References</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension" class="dfn-panel" data-for="term-for-typedef-dimension" id="infopanel-for-term-for-typedef-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">4.3. Numeric Values:</a>
     <li><a href="#ref-for-typedef-dimension①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-typedef-dimension②">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a> <a href="#ref-for-typedef-dimension③">(2)</a> <a href="#ref-for-typedef-dimension④">(3)</a> <a href="#ref-for-typedef-dimension⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frequency-value">
-   <a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frequency-value" class="dfn-panel" data-for="term-for-frequency-value" id="infopanel-for-term-for-frequency-value" role="menu">
+   <span id="infopaneltitle-for-term-for-frequency-value" style="display:none">Info about the '&lt;frequency>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-value">4.3.2. Numeric Value Typing</a> <a href="#ref-for-frequency-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.3.2. Numeric Value Typing</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
     <li><a href="#ref-for-typedef-length-percentage③">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.3.2. Numeric Value Typing</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a> <a href="#ref-for-length-value④">(5)</a>
     <li><a href="#ref-for-length-value⑤">4.4. CSSTransformValue objects</a> <a href="#ref-for-length-value⑥">(2)</a> <a href="#ref-for-length-value⑦">(3)</a>
@@ -10391,8 +10391,8 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-length-value①①">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-length-value①②">(2)</a> <a href="#ref-for-length-value①③">(3)</a> <a href="#ref-for-length-value①④">(4)</a> <a href="#ref-for-length-value①⑤">(5)</a> <a href="#ref-for-length-value①⑥">(6)</a> <a href="#ref-for-length-value①⑦">(7)</a> <a href="#ref-for-length-value①⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">4.3. Numeric Values:</a>
     <li><a href="#ref-for-number-value①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
@@ -10404,8 +10404,8 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-number-value①⓪">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-number-value①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.3. Numeric Values:</a>
     <li><a href="#ref-for-percentage-value①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
@@ -10415,136 +10415,136 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-percentage-value①①">6.7. Serialization from CSSOM Values</a> <a href="#ref-for-percentage-value①②">(2)</a> <a href="#ref-for-percentage-value①③">(3)</a> <a href="#ref-for-percentage-value①④">(4)</a> <a href="#ref-for-percentage-value①⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">4.3.2. Numeric Value Typing</a> <a href="#ref-for-resolution-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-time-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-time-percentage">https://drafts.csswg.org/css-values-4/#typedef-time-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-time-percentage" class="dfn-panel" data-for="term-for-typedef-time-percentage" id="infopanel-for-term-for-typedef-time-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-time-percentage" style="display:none">Info about the '&lt;time-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-time-percentage">https://drafts.csswg.org/css-values-4/#typedef-time-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-time-percentage">4.3.2. Numeric Value Typing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">4.3.2. Numeric Value Typing</a> <a href="#ref-for-time-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">3. The StylePropertyMap</a>
     <li><a href="#ref-for-url-value①">5.8. &lt;url> (and subtype) Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
     <li><a href="#ref-for-funcdef-calc①">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a> <a href="#ref-for-funcdef-calc②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canonical-unit">
-   <a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canonical-unit" class="dfn-panel" data-for="term-for-canonical-unit" id="infopanel-for-term-for-canonical-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-canonical-unit" style="display:none">Info about the 'canonical unit' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canonical-unit">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-canonical-unit①">(2)</a> <a href="#ref-for-canonical-unit②">(3)</a> <a href="#ref-for-canonical-unit③">(4)</a>
     <li><a href="#ref-for-canonical-unit④">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a> <a href="#ref-for-canonical-unit⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compatible-units">
-   <a href="https://drafts.csswg.org/css-values-4/#compatible-units">https://drafts.csswg.org/css-values-4/#compatible-units</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compatible-units" class="dfn-panel" data-for="term-for-compatible-units" id="infopanel-for-term-for-compatible-units" role="menu">
+   <span id="infopaneltitle-for-term-for-compatible-units" style="display:none">Info about the 'compatible units' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#compatible-units">https://drafts.csswg.org/css-values-4/#compatible-units</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compatible-units">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-compatible-units①">(2)</a> <a href="#ref-for-compatible-units②">(3)</a>
     <li><a href="#ref-for-compatible-units③">4.3.3. Value + Unit: CSSUnitValue objects</a>
     <li><a href="#ref-for-compatible-units④">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'ident' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">3. The StylePropertyMap</a> <a href="#ref-for-css-css-identifier①">(2)</a> <a href="#ref-for-css-css-identifier②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in">
-   <a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in" class="dfn-panel" data-for="term-for-in" id="infopanel-for-term-for-in" role="menu">
+   <span id="infopaneltitle-for-term-for-in" style="display:none">Info about the 'in' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-math-function">
-   <a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-math-function" class="dfn-panel" data-for="term-for-math-function" id="infopanel-for-term-for-math-function" role="menu">
+   <span id="infopaneltitle-for-term-for-math-function" style="display:none">Info about the 'math function' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-math-function">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-math-function①">4.3.2. Numeric Value Typing</a>
     <li><a href="#ref-for-math-function②">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-max">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-max">https://drafts.csswg.org/css-values-4/#funcdef-max</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-max" class="dfn-panel" data-for="term-for-funcdef-max" id="infopanel-for-term-for-funcdef-max" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-max" style="display:none">Info about the 'max()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-max">https://drafts.csswg.org/css-values-4/#funcdef-max</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-max">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
     <li><a href="#ref-for-funcdef-max①">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-min">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-min">https://drafts.csswg.org/css-values-4/#funcdef-min</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-min" class="dfn-panel" data-for="term-for-funcdef-min" id="infopanel-for-term-for-funcdef-min" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-min" style="display:none">Info about the 'min()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-min">https://drafts.csswg.org/css-values-4/#funcdef-min</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-min">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
     <li><a href="#ref-for-funcdef-min①">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage">https://drafts.csswg.org/css-values-4/#percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage" class="dfn-panel" data-for="term-for-percentage" id="infopanel-for-term-for-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage" style="display:none">Info about the 'percentage' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage">https://drafts.csswg.org/css-values-4/#percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-px①">(2)</a>
     <li><a href="#ref-for-px②">4.4. CSSTransformValue objects</a> <a href="#ref-for-px③">(2)</a>
     <li><a href="#ref-for-px④">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#relative-length">https://drafts.csswg.org/css-values-4/#relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-length" class="dfn-panel" data-for="term-for-relative-length" id="infopanel-for-term-for-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-length" style="display:none">Info about the 'relative length' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#relative-length">https://drafts.csswg.org/css-values-4/#relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-length">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">4.5. CSSImageValue objects</a>
     <li><a href="#ref-for-funcdef-url①">5.1. Property-specific Rules</a> <a href="#ref-for-funcdef-url②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-custom-property-name">
-   <a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-custom-property-name" class="dfn-panel" data-for="term-for-typedef-custom-property-name" id="infopanel-for-term-for-typedef-custom-property-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-custom-property-name" style="display:none">Info about the '&lt;custom-property-name>' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-property-name">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">3. The StylePropertyMap</a> <a href="#ref-for-custom-property①">(2)</a>
     <li><a href="#ref-for-custom-property②">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-custom-property③">(2)</a>
     <li><a href="#ref-for-custom-property④">5.1. Property-specific Rules</a> <a href="#ref-for-custom-property⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">3. The StylePropertyMap</a> <a href="#ref-for-funcdef-var①">(2)</a> <a href="#ref-for-funcdef-var②">(3)</a> <a href="#ref-for-funcdef-var③">(4)</a> <a href="#ref-for-funcdef-var④">(5)</a>
     <li><a href="#ref-for-funcdef-var⑤">5. CSSStyleValue Reification</a>
@@ -10552,321 +10552,321 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-funcdef-var⑨">5.4. var() References</a> <a href="#ref-for-funcdef-var①⓪">(2)</a> <a href="#ref-for-funcdef-var①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical" id="infopanel-for-term-for-propdef-glyph-orientation-vertical" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" style="display:none">Info about the 'glyph-orientation-vertical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-combine-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-combine-upright" class="dfn-panel" data-for="term-for-propdef-text-combine-upright" id="infopanel-for-term-for-propdef-text-combine-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-absolute-size">
-   <a href="https://drafts.csswg.org/css2/#value-def-absolute-size">https://drafts.csswg.org/css2/#value-def-absolute-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-absolute-size" class="dfn-panel" data-for="term-for-value-def-absolute-size" id="infopanel-for-term-for-value-def-absolute-size" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-absolute-size" style="display:none">Info about the '&lt;absolute-size>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-absolute-size">https://drafts.csswg.org/css2/#value-def-absolute-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-absolute-size">5.1. Property-specific Rules</a> <a href="#ref-for-value-def-absolute-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-relative-size">
-   <a href="https://drafts.csswg.org/css2/#value-def-relative-size">https://drafts.csswg.org/css2/#value-def-relative-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-relative-size" class="dfn-panel" data-for="term-for-value-def-relative-size" id="infopanel-for-term-for-value-def-relative-size" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-relative-size" style="display:none">Info about the '&lt;relative-size>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-relative-size">https://drafts.csswg.org/css2/#value-def-relative-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-relative-size">5.1. Property-specific Rules</a> <a href="#ref-for-value-def-relative-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-inside">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-inside" class="dfn-panel" data-for="term-for-propdef-page-break-inside" id="infopanel-for-term-for-propdef-page-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-inside" style="display:none">Info about the 'page-break-inside' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-inside">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">4.3. Numeric Values:</a>
     <li><a href="#ref-for-propdef-z-index①">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">4.3.5. Numeric Factory Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstylerule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstylerule">https://drafts.csswg.org/cssom-1/#cssstylerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylerule" class="dfn-panel" data-for="term-for-cssstylerule" id="infopanel-for-term-for-cssstylerule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylerule" style="display:none">Info about the 'CSSStyleRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstylerule">https://drafts.csswg.org/cssom-1/#cssstylerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylerule">3.2. Declared &amp; Inline StylePropertyMap objects</a> <a href="#ref-for-cssstylerule①">(2)</a> <a href="#ref-for-cssstylerule②">(3)</a> <a href="#ref-for-cssstylerule③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementcssinlinestyle">
-   <a href="https://drafts.csswg.org/cssom-1/#elementcssinlinestyle">https://drafts.csswg.org/cssom-1/#elementcssinlinestyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementcssinlinestyle" class="dfn-panel" data-for="term-for-elementcssinlinestyle" id="infopanel-for-term-for-elementcssinlinestyle" role="menu">
+   <span id="infopaneltitle-for-term-for-elementcssinlinestyle" style="display:none">Info about the 'ElementCSSInlineStyle' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#elementcssinlinestyle">https://drafts.csswg.org/cssom-1/#elementcssinlinestyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementcssinlinestyle">3.2. Declared &amp; Inline StylePropertyMap objects</a> <a href="#ref-for-elementcssinlinestyle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-declaration-block">
-   <a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">https://drafts.csswg.org/cssom-1/#css-declaration-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-declaration-block" class="dfn-panel" data-for="term-for-css-declaration-block" id="infopanel-for-term-for-css-declaration-block" role="menu">
+   <span id="infopaneltitle-for-term-for-css-declaration-block" style="display:none">Info about the 'css declaration block' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">https://drafts.csswg.org/cssom-1/#css-declaration-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-block">3. The StylePropertyMap</a> <a href="#ref-for-css-declaration-block①">(2)</a> <a href="#ref-for-css-declaration-block②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations" id="infopanel-for-term-for-cssstyledeclaration-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">3. The StylePropertyMap</a> <a href="#ref-for-cssstyledeclaration-declarations①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-dom-window-getcomputedstyle①">(2)</a> <a href="#ref-for-dom-window-getcomputedstyle②">(3)</a> <a href="#ref-for-dom-window-getcomputedstyle③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag" id="infopanel-for-term-for-concept-css-style-sheet-origin-clean-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" style="display:none">Info about the 'origin-clean flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag">3.1. Computed StylePropertyMapReadOnly objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">3.1. Computed StylePropertyMapReadOnly objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-break">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-break">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-break" class="dfn-panel" data-for="term-for-propdef-fill-break" id="infopanel-for-term-for-propdef-fill-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-break" style="display:none">Info about the 'fill-break' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-break">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-break">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-color">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-color" class="dfn-panel" data-for="term-for-propdef-fill-color" id="infopanel-for-term-for-propdef-fill-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-color" style="display:none">Info about the 'fill-color' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-image">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-image">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-image" class="dfn-panel" data-for="term-for-propdef-fill-image" id="infopanel-for-term-for-propdef-fill-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-image" style="display:none">Info about the 'fill-image' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-image">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-image">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-origin">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-origin">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-origin" class="dfn-panel" data-for="term-for-propdef-fill-origin" id="infopanel-for-term-for-propdef-fill-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-origin" style="display:none">Info about the 'fill-origin' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-origin">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-origin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-position">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-position">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-position" class="dfn-panel" data-for="term-for-propdef-fill-position" id="infopanel-for-term-for-propdef-fill-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-position" style="display:none">Info about the 'fill-position' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-position">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-repeat">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-repeat">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-repeat" class="dfn-panel" data-for="term-for-propdef-fill-repeat" id="infopanel-for-term-for-propdef-fill-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-repeat" style="display:none">Info about the 'fill-repeat' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-repeat">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-repeat">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-size">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-size">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-size" class="dfn-panel" data-for="term-for-propdef-fill-size" id="infopanel-for-term-for-propdef-fill-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-size" style="display:none">Info about the 'fill-size' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-size">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-align">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-align">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-align" class="dfn-panel" data-for="term-for-propdef-stroke-align" id="infopanel-for-term-for-propdef-stroke-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-align" style="display:none">Info about the 'stroke-align' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-align">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-align">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-break">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-break">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-break" class="dfn-panel" data-for="term-for-propdef-stroke-break" id="infopanel-for-term-for-propdef-stroke-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-break" style="display:none">Info about the 'stroke-break' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-break">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-break">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-color">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-color" class="dfn-panel" data-for="term-for-propdef-stroke-color" id="infopanel-for-term-for-propdef-stroke-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-color" style="display:none">Info about the 'stroke-color' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-color">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-dash-corner">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-corner">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-corner</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-dash-corner" class="dfn-panel" data-for="term-for-propdef-stroke-dash-corner" id="infopanel-for-term-for-propdef-stroke-dash-corner" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-dash-corner" style="display:none">Info about the 'stroke-dash-corner' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-corner">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-corner</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dash-corner">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-dash-justify">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-justify">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-justify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-dash-justify" class="dfn-panel" data-for="term-for-propdef-stroke-dash-justify" id="infopanel-for-term-for-propdef-stroke-dash-justify" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-dash-justify" style="display:none">Info about the 'stroke-dash-justify' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-justify">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-dash-justify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dash-justify">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-image">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-image">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-image" class="dfn-panel" data-for="term-for-propdef-stroke-image" id="infopanel-for-term-for-propdef-stroke-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-image" style="display:none">Info about the 'stroke-image' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-image">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-image">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-origin">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-origin">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-origin" class="dfn-panel" data-for="term-for-propdef-stroke-origin" id="infopanel-for-term-for-propdef-stroke-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-origin" style="display:none">Info about the 'stroke-origin' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-origin">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-origin">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-position">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-position">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-position" class="dfn-panel" data-for="term-for-propdef-stroke-position" id="infopanel-for-term-for-propdef-stroke-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-position" style="display:none">Info about the 'stroke-position' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-position">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-repeat">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-repeat">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-repeat" class="dfn-panel" data-for="term-for-propdef-stroke-repeat" id="infopanel-for-term-for-propdef-stroke-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-repeat" style="display:none">Info about the 'stroke-repeat' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-repeat">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-repeat">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-size">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-size">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-size" class="dfn-panel" data-for="term-for-propdef-stroke-size" id="infopanel-for-term-for-propdef-stroke-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-size" style="display:none">Info about the 'stroke-size' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-size">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-size">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-backdrop-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-2/#propdef-backdrop-filter">https://drafts.fxtf.org/filter-effects-2/#propdef-backdrop-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-backdrop-filter" class="dfn-panel" data-for="term-for-propdef-backdrop-filter" id="infopanel-for-term-for-propdef-backdrop-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-backdrop-filter" style="display:none">Info about the 'backdrop-filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-2/#propdef-backdrop-filter">https://drafts.fxtf.org/filter-effects-2/#propdef-backdrop-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-backdrop-filter">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrix">
-   <a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrix" class="dfn-panel" data-for="term-for-dommatrix" id="infopanel-for-term-for-dommatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrix" style="display:none">Info about the 'DOMMatrix' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrix">4.4. CSSTransformValue objects</a> <a href="#ref-for-dommatrix①">(2)</a> <a href="#ref-for-dommatrix②">(3)</a> <a href="#ref-for-dommatrix③">(4)</a> <a href="#ref-for-dommatrix④">(5)</a> <a href="#ref-for-dommatrix⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrixreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#dommatrixreadonly">https://drafts.fxtf.org/geometry-1/#dommatrixreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrixreadonly" class="dfn-panel" data-for="term-for-dommatrixreadonly" id="infopanel-for-term-for-dommatrixreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrixreadonly" style="display:none">Info about the 'DOMMatrixReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dommatrixreadonly">https://drafts.fxtf.org/geometry-1/#dommatrixreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrixreadonly">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dommatrixreadonly-is2d">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-is2d">https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-is2d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dommatrixreadonly-is2d" class="dfn-panel" data-for="term-for-dom-dommatrixreadonly-is2d" id="infopanel-for-term-for-dom-dommatrixreadonly-is2d" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dommatrixreadonly-is2d" style="display:none">Info about the 'is2D' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-is2d">https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-is2d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-is2d">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-dommatrixreadonly-is2d①">(2)</a> <a href="#ref-for-dom-dommatrixreadonly-is2d②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrixreadonly-stringification-behavior">
-   <a href="https://www.w3.org/TR/geometry-1/#dommatrixreadonly-stringification-behavior">https://www.w3.org/TR/geometry-1/#dommatrixreadonly-stringification-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrixreadonly-stringification-behavior" class="dfn-panel" data-for="term-for-dommatrixreadonly-stringification-behavior" id="infopanel-for-term-for-dommatrixreadonly-stringification-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrixreadonly-stringification-behavior" style="display:none">Info about the 'stringification behavior' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#dommatrixreadonly-stringification-behavior">https://www.w3.org/TR/geometry-1/#dommatrixreadonly-stringification-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrixreadonly-stringification-behavior">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlelement" class="dfn-panel" data-for="term-for-htmlelement" id="infopanel-for-term-for-htmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlelement" style="display:none">Info about the 'HTMLElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlelement">3.2. Declared &amp; Inline StylePropertyMap objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">4.5. CSSImageValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-style">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-style">https://html.spec.whatwg.org/multipage/dom.html#attr-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-style" class="dfn-panel" data-for="term-for-attr-style" id="infopanel-for-term-for-attr-style" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-style" style="display:none">Info about the 'style (for html-global)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-style">https://html.spec.whatwg.org/multipage/dom.html#attr-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-style">4.5. CSSImageValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3. The StylePropertyMap</a> <a href="#ref-for-list-append①">(2)</a>
     <li><a href="#ref-for-list-append②">4.1. CSSUnparsedValue objects</a>
@@ -10874,51 +10874,51 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-list-append⑥">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-ascii-lowercase①">3. The StylePropertyMap</a> <a href="#ref-for-ascii-lowercase②">(2)</a> <a href="#ref-for-ascii-lowercase③">(3)</a> <a href="#ref-for-ascii-lowercase④">(4)</a> <a href="#ref-for-ascii-lowercase⑤">(5)</a> <a href="#ref-for-ascii-lowercase⑥">(6)</a> <a href="#ref-for-ascii-lowercase⑦">(7)</a> <a href="#ref-for-ascii-lowercase⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3. The StylePropertyMap</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a> <a href="#ref-for-map-exists④">(5)</a> <a href="#ref-for-map-exists⑤">(6)</a>
     <li><a href="#ref-for-map-exists⑥">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-map-exists⑦">4.3.2. Numeric Value Typing</a> <a href="#ref-for-map-exists⑧">(2)</a> <a href="#ref-for-map-exists⑨">(3)</a> <a href="#ref-for-map-exists①⓪">(4)</a> <a href="#ref-for-map-exists①①">(5)</a> <a href="#ref-for-map-exists①②">(6)</a> <a href="#ref-for-map-exists①③">(7)</a> <a href="#ref-for-map-exists①④">(8)</a> <a href="#ref-for-map-exists①⑤">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-list-empty①">(2)</a>
     <li><a href="#ref-for-list-empty②">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a> <a href="#ref-for-map-entry③">(4)</a> <a href="#ref-for-map-entry④">(5)</a> <a href="#ref-for-map-entry⑤">(6)</a> <a href="#ref-for-map-entry⑥">(7)</a>
     <li><a href="#ref-for-map-entry⑦">4.3.2. Numeric Value Typing</a> <a href="#ref-for-map-entry⑧">(2)</a> <a href="#ref-for-map-entry⑨">(3)</a> <a href="#ref-for-map-entry①⓪">(4)</a> <a href="#ref-for-map-entry①①">(5)</a> <a href="#ref-for-map-entry①②">(6)</a> <a href="#ref-for-map-entry①③">(7)</a> <a href="#ref-for-map-entry①④">(8)</a> <a href="#ref-for-map-entry①⑤">(9)</a> <a href="#ref-for-map-entry①⑥">(10)</a> <a href="#ref-for-map-entry①⑦">(11)</a> <a href="#ref-for-map-entry①⑧">(12)</a> <a href="#ref-for-map-entry①⑨">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists①" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists①" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3. The StylePropertyMap</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a> <a href="#ref-for-map-exists④">(5)</a> <a href="#ref-for-map-exists⑤">(6)</a>
     <li><a href="#ref-for-map-exists⑥">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-map-exists⑦">4.3.2. Numeric Value Typing</a> <a href="#ref-for-map-exists⑧">(2)</a> <a href="#ref-for-map-exists⑨">(3)</a> <a href="#ref-for-map-exists①⓪">(4)</a> <a href="#ref-for-map-exists①①">(5)</a> <a href="#ref-for-map-exists①②">(6)</a> <a href="#ref-for-map-exists①③">(7)</a> <a href="#ref-for-map-exists①④">(8)</a> <a href="#ref-for-map-exists①⑤">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-list-iterate①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-list-iterate②">(2)</a> <a href="#ref-for-list-iterate③">(3)</a> <a href="#ref-for-list-iterate④">(4)</a> <a href="#ref-for-list-iterate⑤">(5)</a> <a href="#ref-for-list-iterate⑥">(6)</a> <a href="#ref-for-list-iterate⑦">(7)</a> <a href="#ref-for-list-iterate⑧">(8)</a> <a href="#ref-for-list-iterate⑨">(9)</a> <a href="#ref-for-list-iterate①⓪">(10)</a> <a href="#ref-for-list-iterate①①">(11)</a>
@@ -10927,23 +10927,23 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-list-iterate①⑤">6.4. CSSMathValue Serialization</a> <a href="#ref-for-list-iterate①⑥">(2)</a> <a href="#ref-for-list-iterate①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3. The StylePropertyMap</a>
     <li><a href="#ref-for-map-iterate①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-map-iterate②">(2)</a>
     <li><a href="#ref-for-map-iterate③">4.3.2. Numeric Value Typing</a> <a href="#ref-for-map-iterate④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
     <li><a href="#ref-for-list-is-empty①">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">3. The StylePropertyMap</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a> <a href="#ref-for-list-item③">(4)</a> <a href="#ref-for-list-item④">(5)</a> <a href="#ref-for-list-item⑤">(6)</a> <a href="#ref-for-list-item⑥">(7)</a>
     <li><a href="#ref-for-list-item⑦">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-list-item⑧">(2)</a> <a href="#ref-for-list-item⑨">(3)</a> <a href="#ref-for-list-item①⓪">(4)</a> <a href="#ref-for-list-item①①">(5)</a> <a href="#ref-for-list-item①②">(6)</a> <a href="#ref-for-list-item①③">(7)</a> <a href="#ref-for-list-item①④">(8)</a> <a href="#ref-for-list-item①⑤">(9)</a> <a href="#ref-for-list-item①⑥">(10)</a> <a href="#ref-for-list-item①⑦">(11)</a> <a href="#ref-for-list-item①⑧">(12)</a> <a href="#ref-for-list-item①⑨">(13)</a> <a href="#ref-for-list-item②⓪">(14)</a> <a href="#ref-for-list-item②①">(15)</a> <a href="#ref-for-list-item②②">(16)</a> <a href="#ref-for-list-item②③">(17)</a> <a href="#ref-for-list-item②④">(18)</a> <a href="#ref-for-list-item②⑤">(19)</a> <a href="#ref-for-list-item②⑥">(20)</a> <a href="#ref-for-list-item②⑦">(21)</a> <a href="#ref-for-list-item②⑧">(22)</a> <a href="#ref-for-list-item②⑨">(23)</a> <a href="#ref-for-list-item③⓪">(24)</a> <a href="#ref-for-list-item③①">(25)</a> <a href="#ref-for-list-item③②">(26)</a> <a href="#ref-for-list-item③③">(27)</a> <a href="#ref-for-list-item③④">(28)</a> <a href="#ref-for-list-item③⑤">(29)</a> <a href="#ref-for-list-item③⑥">(30)</a> <a href="#ref-for-list-item③⑦">(31)</a> <a href="#ref-for-list-item③⑧">(32)</a> <a href="#ref-for-list-item③⑨">(33)</a> <a href="#ref-for-list-item④⓪">(34)</a> <a href="#ref-for-list-item④①">(35)</a> <a href="#ref-for-list-item④②">(36)</a> <a href="#ref-for-list-item④③">(37)</a> <a href="#ref-for-list-item④④">(38)</a> <a href="#ref-for-list-item④⑤">(39)</a> <a href="#ref-for-list-item④⑥">(40)</a> <a href="#ref-for-list-item④⑦">(41)</a> <a href="#ref-for-list-item④⑧">(42)</a> <a href="#ref-for-list-item④⑨">(43)</a> <a href="#ref-for-list-item⑤⓪">(44)</a> <a href="#ref-for-list-item⑤①">(45)</a> <a href="#ref-for-list-item⑤②">(46)</a> <a href="#ref-for-list-item⑤③">(47)</a> <a href="#ref-for-list-item⑤④">(48)</a> <a href="#ref-for-list-item⑤⑤">(49)</a> <a href="#ref-for-list-item⑤⑥">(50)</a> <a href="#ref-for-list-item⑤⑦">(51)</a> <a href="#ref-for-list-item⑤⑧">(52)</a> <a href="#ref-for-list-item⑤⑨">(53)</a> <a href="#ref-for-list-item⑥⓪">(54)</a> <a href="#ref-for-list-item⑥①">(55)</a> <a href="#ref-for-list-item⑥②">(56)</a> <a href="#ref-for-list-item⑥③">(57)</a>
@@ -10952,14 +10952,14 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-list-item⑦①">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2. CSSStyleValue objects</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">3. The StylePropertyMap</a> <a href="#ref-for-list③">(2)</a> <a href="#ref-for-list④">(3)</a> <a href="#ref-for-list⑤">(4)</a> <a href="#ref-for-list⑥">(5)</a>
@@ -10970,48 +10970,48 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-list①⑥">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3. The StylePropertyMap</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a>
     <li><a href="#ref-for-ordered-map③">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-ordered-map④">4.3.2. Numeric Value Typing</a> <a href="#ref-for-ordered-map⑤">(2)</a> <a href="#ref-for-ordered-map⑥">(3)</a> <a href="#ref-for-ordered-map⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3. The StylePropertyMap</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a>
     <li><a href="#ref-for-ordered-map③">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-ordered-map④">4.3.2. Numeric Value Typing</a> <a href="#ref-for-ordered-map⑤">(2)</a> <a href="#ref-for-ordered-map⑥">(3)</a> <a href="#ref-for-ordered-map⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-list-prepend①">(2)</a> <a href="#ref-for-list-prepend②">(3)</a> <a href="#ref-for-list-prepend③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">3. The StylePropertyMap</a> <a href="#ref-for-map-remove①">(2)</a> <a href="#ref-for-map-remove②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3. The StylePropertyMap</a>
     <li><a href="#ref-for-list-size①">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-list-size②">(2)</a> <a href="#ref-for-list-size③">(3)</a>
@@ -11019,14 +11019,14 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-list-size⑤">4.4. CSSTransformValue objects</a> <a href="#ref-for-list-size⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-size">
-   <a href="https://infra.spec.whatwg.org/#map-size">https://infra.spec.whatwg.org/#map-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-size" class="dfn-panel" data-for="term-for-map-size" id="infopanel-for-term-for-map-size" role="menu">
+   <span id="infopaneltitle-for-term-for-map-size" style="display:none">Info about the 'size (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-size">https://infra.spec.whatwg.org/#map-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-size">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2. CSSStyleValue objects</a> <a href="#ref-for-string①">(2)</a>
     <li><a href="#ref-for-string②">2.1. Direct CSSStyleValue Objects</a>
@@ -11036,280 +11036,280 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-string①①">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-string①②">(2)</a> <a href="#ref-for-string①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-tuple①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-map-value①">(2)</a> <a href="#ref-for-map-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4.3.2. Numeric Value Typing</a>
     <li><a href="#ref-for-map-getting-the-values①">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset" class="dfn-panel" data-for="term-for-propdef-offset" id="infopanel-for-term-for-propdef-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset" style="display:none">Info about the 'offset' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-anchor">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-anchor">https://drafts.fxtf.org/motion-1/#propdef-offset-anchor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-anchor" class="dfn-panel" data-for="term-for-propdef-offset-anchor" id="infopanel-for-term-for-propdef-offset-anchor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-anchor" style="display:none">Info about the 'offset-anchor' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-anchor">https://drafts.fxtf.org/motion-1/#propdef-offset-anchor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-anchor">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-distance">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-distance">https://drafts.fxtf.org/motion-1/#propdef-offset-distance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-distance" class="dfn-panel" data-for="term-for-propdef-offset-distance" id="infopanel-for-term-for-propdef-offset-distance" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-distance" style="display:none">Info about the 'offset-distance' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-distance">https://drafts.fxtf.org/motion-1/#propdef-offset-distance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-distance">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-path">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-path">https://drafts.fxtf.org/motion-1/#propdef-offset-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-path" class="dfn-panel" data-for="term-for-propdef-offset-path" id="infopanel-for-term-for-propdef-offset-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-path" style="display:none">Info about the 'offset-path' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-path">https://drafts.fxtf.org/motion-1/#propdef-offset-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-path">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-position">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-position">https://drafts.fxtf.org/motion-1/#propdef-offset-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-position" class="dfn-panel" data-for="term-for-propdef-offset-position" id="infopanel-for-term-for-propdef-offset-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-position" style="display:none">Info about the 'offset-position' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-position">https://drafts.fxtf.org/motion-1/#propdef-offset-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-position">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-rotate">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-rotate">https://drafts.fxtf.org/motion-1/#propdef-offset-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-rotate" class="dfn-panel" data-for="term-for-propdef-offset-rotate" id="infopanel-for-term-for-propdef-offset-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-rotate" style="display:none">Info about the 'offset-rotate' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-rotate">https://drafts.fxtf.org/motion-1/#propdef-offset-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-rotate">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorInterpolationProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorInterpolationProperty" class="dfn-panel" data-for="term-for-ColorInterpolationProperty" id="infopanel-for-term-for-ColorInterpolationProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorInterpolationProperty" style="display:none">Info about the 'color-interpolation' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorInterpolationProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorRenderingProperty">
-   <a href="https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty">https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorRenderingProperty" class="dfn-panel" data-for="term-for-ColorRenderingProperty" id="infopanel-for-term-for-ColorRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorRenderingProperty" style="display:none">Info about the 'color-rendering' external reference.</span><a href="https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty">https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorRenderingProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-CxProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#CxProperty">https://svgwg.org/svg2-draft/geometry.html#CxProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-CxProperty" class="dfn-panel" data-for="term-for-CxProperty" id="infopanel-for-term-for-CxProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-CxProperty" style="display:none">Info about the 'cx' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#CxProperty">https://svgwg.org/svg2-draft/geometry.html#CxProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CxProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-CyProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#CyProperty">https://svgwg.org/svg2-draft/geometry.html#CyProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-CyProperty" class="dfn-panel" data-for="term-for-CyProperty" id="infopanel-for-term-for-CyProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-CyProperty" style="display:none">Info about the 'cy' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#CyProperty">https://svgwg.org/svg2-draft/geometry.html#CyProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CyProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-DProperty">
-   <a href="https://svgwg.org/svg2-draft/paths.html#DProperty">https://svgwg.org/svg2-draft/paths.html#DProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-DProperty" class="dfn-panel" data-for="term-for-DProperty" id="infopanel-for-term-for-DProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-DProperty" style="display:none">Info about the 'd' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#DProperty">https://svgwg.org/svg2-draft/paths.html#DProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillProperty">https://svgwg.org/svg2-draft/painting.html#FillProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillProperty" class="dfn-panel" data-for="term-for-FillProperty" id="infopanel-for-term-for-FillProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillProperty" style="display:none">Info about the 'fill' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillProperty">https://svgwg.org/svg2-draft/painting.html#FillProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty">https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillOpacityProperty" class="dfn-panel" data-for="term-for-FillOpacityProperty" id="infopanel-for-term-for-FillOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillOpacityProperty" style="display:none">Info about the 'fill-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty">https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillOpacityProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillRuleProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillRuleProperty" class="dfn-panel" data-for="term-for-FillRuleProperty" id="infopanel-for-term-for-FillRuleProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillRuleProperty" style="display:none">Info about the 'fill-rule' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillRuleProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerProperty" class="dfn-panel" data-for="term-for-MarkerProperty" id="infopanel-for-term-for-MarkerProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerProperty" style="display:none">Info about the 'marker' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerEndProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerEndProperty" class="dfn-panel" data-for="term-for-MarkerEndProperty" id="infopanel-for-term-for-MarkerEndProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerEndProperty" style="display:none">Info about the 'marker-end' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerEndProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerMidProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerMidProperty" class="dfn-panel" data-for="term-for-MarkerMidProperty" id="infopanel-for-term-for-MarkerMidProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerMidProperty" style="display:none">Info about the 'marker-mid' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerMidProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerStartProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerStartProperty" class="dfn-panel" data-for="term-for-MarkerStartProperty" id="infopanel-for-term-for-MarkerStartProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerStartProperty" style="display:none">Info about the 'marker-start' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerStartProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PaintOrderProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty">https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PaintOrderProperty" class="dfn-panel" data-for="term-for-PaintOrderProperty" id="infopanel-for-term-for-PaintOrderProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-PaintOrderProperty" style="display:none">Info about the 'paint-order' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty">https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PaintOrderProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RProperty">https://svgwg.org/svg2-draft/geometry.html#RProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RProperty" class="dfn-panel" data-for="term-for-RProperty" id="infopanel-for-term-for-RProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RProperty" style="display:none">Info about the 'r' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RProperty">https://svgwg.org/svg2-draft/geometry.html#RProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RxProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RxProperty">https://svgwg.org/svg2-draft/geometry.html#RxProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RxProperty" class="dfn-panel" data-for="term-for-RxProperty" id="infopanel-for-term-for-RxProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RxProperty" style="display:none">Info about the 'rx' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RxProperty">https://svgwg.org/svg2-draft/geometry.html#RxProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RxProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RyProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RyProperty">https://svgwg.org/svg2-draft/geometry.html#RyProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RyProperty" class="dfn-panel" data-for="term-for-RyProperty" id="infopanel-for-term-for-RyProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RyProperty" style="display:none">Info about the 'ry' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RyProperty">https://svgwg.org/svg2-draft/geometry.html#RyProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RyProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ShapeRenderingProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty">https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ShapeRenderingProperty" class="dfn-panel" data-for="term-for-ShapeRenderingProperty" id="infopanel-for-term-for-ShapeRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ShapeRenderingProperty" style="display:none">Info about the 'shape-rendering' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty">https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ShapeRenderingProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ShapesubtractProperty">
-   <a href="https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty">https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ShapesubtractProperty" class="dfn-panel" data-for="term-for-ShapesubtractProperty" id="infopanel-for-term-for-ShapesubtractProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ShapesubtractProperty" style="display:none">Info about the 'shape-subtract' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty">https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ShapesubtractProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StopColorProperty">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StopColorProperty" class="dfn-panel" data-for="term-for-StopColorProperty" id="infopanel-for-term-for-StopColorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StopColorProperty" style="display:none">Info about the 'stop-color' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StopColorProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StopOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty">https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StopOpacityProperty" class="dfn-panel" data-for="term-for-StopOpacityProperty" id="infopanel-for-term-for-StopOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StopOpacityProperty" style="display:none">Info about the 'stop-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty">https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StopOpacityProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">https://svgwg.org/svg2-draft/painting.html#StrokeProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeProperty" class="dfn-panel" data-for="term-for-StrokeProperty" id="infopanel-for-term-for-StrokeProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeProperty" style="display:none">Info about the 'stroke' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">https://svgwg.org/svg2-draft/painting.html#StrokeProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeDasharrayProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeDasharrayProperty" class="dfn-panel" data-for="term-for-StrokeDasharrayProperty" id="infopanel-for-term-for-StrokeDasharrayProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeDasharrayProperty" style="display:none">Info about the 'stroke-dasharray' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeDasharrayProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeDashoffsetProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeDashoffsetProperty" class="dfn-panel" data-for="term-for-StrokeDashoffsetProperty" id="infopanel-for-term-for-StrokeDashoffsetProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeDashoffsetProperty" style="display:none">Info about the 'stroke-dashoffset' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeDashoffsetProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeLinecapProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeLinecapProperty" class="dfn-panel" data-for="term-for-StrokeLinecapProperty" id="infopanel-for-term-for-StrokeLinecapProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeLinecapProperty" style="display:none">Info about the 'stroke-linecap' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeLinecapProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeLinejoinProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeLinejoinProperty" class="dfn-panel" data-for="term-for-StrokeLinejoinProperty" id="infopanel-for-term-for-StrokeLinejoinProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeLinejoinProperty" style="display:none">Info about the 'stroke-linejoin' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeLinejoinProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeMiterlimitProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeMiterlimitProperty" class="dfn-panel" data-for="term-for-StrokeMiterlimitProperty" id="infopanel-for-term-for-StrokeMiterlimitProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeMiterlimitProperty" style="display:none">Info about the 'stroke-miterlimit' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeMiterlimitProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty">https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeOpacityProperty" class="dfn-panel" data-for="term-for-StrokeOpacityProperty" id="infopanel-for-term-for-StrokeOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeOpacityProperty" style="display:none">Info about the 'stroke-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty">https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeOpacityProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeWidthProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeWidthProperty" class="dfn-panel" data-for="term-for-StrokeWidthProperty" id="infopanel-for-term-for-StrokeWidthProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeWidthProperty" style="display:none">Info about the 'stroke-width' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeWidthProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextAnchorProperty">
-   <a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextAnchorProperty" class="dfn-panel" data-for="term-for-TextAnchorProperty" id="infopanel-for-term-for-TextAnchorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextAnchorProperty" style="display:none">Info about the 'text-anchor' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextAnchorProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextDecorationFillProperty">
-   <a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextDecorationFillProperty" class="dfn-panel" data-for="term-for-TextDecorationFillProperty" id="infopanel-for-term-for-TextDecorationFillProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextDecorationFillProperty" style="display:none">Info about the 'text-decoration-fill' external reference.</span><a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextDecorationFillProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextDecorationStrokeProperty">
-   <a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextDecorationStrokeProperty" class="dfn-panel" data-for="term-for-TextDecorationStrokeProperty" id="infopanel-for-term-for-TextDecorationStrokeProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextDecorationStrokeProperty" style="display:none">Info about the 'text-decoration-stroke' external reference.</span><a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextDecorationStrokeProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextRenderingProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextRenderingProperty" class="dfn-panel" data-for="term-for-TextRenderingProperty" id="infopanel-for-term-for-TextRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextRenderingProperty" style="display:none">Info about the 'text-rendering' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextRenderingProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VectorEffectProperty">
-   <a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VectorEffectProperty" class="dfn-panel" data-for="term-for-VectorEffectProperty" id="infopanel-for-term-for-VectorEffectProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-VectorEffectProperty" style="display:none">Info about the 'vector-effect' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VectorEffectProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-XProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">https://svgwg.org/svg2-draft/geometry.html#XProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-XProperty" class="dfn-panel" data-for="term-for-XProperty" id="infopanel-for-term-for-XProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-XProperty" style="display:none">Info about the 'x' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">https://svgwg.org/svg2-draft/geometry.html#XProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-XProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-YProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#YProperty">https://svgwg.org/svg2-draft/geometry.html#YProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-YProperty" class="dfn-panel" data-for="term-for-YProperty" id="infopanel-for-term-for-YProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-YProperty" style="display:none">Info about the 'y' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#YProperty">https://svgwg.org/svg2-draft/geometry.html#YProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-YProperty">5.1. Property-specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.2. CSSKeywordValue objects</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. CSSStyleValue objects</a> <a href="#ref-for-Exposed①">(2)</a> <a href="#ref-for-Exposed②">(3)</a>
     <li><a href="#ref-for-Exposed③">3. The StylePropertyMap</a> <a href="#ref-for-Exposed④">(2)</a>
@@ -11323,31 +11323,31 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-Exposed③①">4.6. CSSColorValue objects</a> <a href="#ref-for-Exposed③②">(2)</a> <a href="#ref-for-Exposed③③">(3)</a> <a href="#ref-for-Exposed③④">(4)</a> <a href="#ref-for-Exposed③⑤">(5)</a> <a href="#ref-for-Exposed③⑥">(6)</a> <a href="#ref-for-Exposed③⑦">(7)</a> <a href="#ref-for-Exposed③⑧">(8)</a> <a href="#ref-for-Exposed③⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-exceptiondef-rangeerror①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-exceptiondef-rangeerror②">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.1. Computed StylePropertyMapReadOnly objects</a>
     <li><a href="#ref-for-SameObject①">3.2. Declared &amp; Inline StylePropertyMap objects</a> <a href="#ref-for-SameObject②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a> <a href="#ref-for-syntaxerror③">(4)</a>
     <li><a href="#ref-for-syntaxerror④">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
     <li><a href="#ref-for-syntaxerror⑤">4.6. CSSColorValue objects</a> <a href="#ref-for-syntaxerror⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2. CSSStyleValue objects</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a>
     <li><a href="#ref-for-exceptiondef-typeerror③">3. The StylePropertyMap</a> <a href="#ref-for-exceptiondef-typeerror④">(2)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑥">(4)</a> <a href="#ref-for-exceptiondef-typeerror⑦">(5)</a> <a href="#ref-for-exceptiondef-typeerror⑧">(6)</a> <a href="#ref-for-exceptiondef-typeerror⑨">(7)</a> <a href="#ref-for-exceptiondef-typeerror①⓪">(8)</a> <a href="#ref-for-exceptiondef-typeerror①①">(9)</a> <a href="#ref-for-exceptiondef-typeerror①②">(10)</a> <a href="#ref-for-exceptiondef-typeerror①③">(11)</a> <a href="#ref-for-exceptiondef-typeerror①④">(12)</a> <a href="#ref-for-exceptiondef-typeerror①⑤">(13)</a> <a href="#ref-for-exceptiondef-typeerror①⑥">(14)</a> <a href="#ref-for-exceptiondef-typeerror①⑦">(15)</a>
@@ -11360,8 +11360,8 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-exceptiondef-typeerror④⑦">4.6. CSSColorValue objects</a> <a href="#ref-for-exceptiondef-typeerror④⑧">(2)</a> <a href="#ref-for-exceptiondef-typeerror④⑨">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑤⓪">(4)</a> <a href="#ref-for-exceptiondef-typeerror⑤①">(5)</a> <a href="#ref-for-exceptiondef-typeerror⑤②">(6)</a> <a href="#ref-for-exceptiondef-typeerror⑤③">(7)</a> <a href="#ref-for-exceptiondef-typeerror⑤④">(8)</a> <a href="#ref-for-exceptiondef-typeerror⑤⑤">(9)</a> <a href="#ref-for-exceptiondef-typeerror⑤⑥">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2. CSSStyleValue objects</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a>
     <li><a href="#ref-for-idl-USVString④">3. The StylePropertyMap</a> <a href="#ref-for-idl-USVString⑤">(2)</a> <a href="#ref-for-idl-USVString⑥">(3)</a> <a href="#ref-for-idl-USVString⑦">(4)</a> <a href="#ref-for-idl-USVString⑧">(5)</a> <a href="#ref-for-idl-USVString⑨">(6)</a> <a href="#ref-for-idl-USVString①⓪">(7)</a> <a href="#ref-for-idl-USVString①①">(8)</a> <a href="#ref-for-idl-USVString①②">(9)</a> <a href="#ref-for-idl-USVString①③">(10)</a>
@@ -11373,29 +11373,29 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-idl-USVString②⑦">6.1. CSSUnparsedValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. The StylePropertyMap</a>
     <li><a href="#ref-for-idl-boolean①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-idl-boolean②">4.4. CSSTransformValue objects</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-determine-the-value-of-an-indexed-property">
-   <a href="https://webidl.spec.whatwg.org/#dfn-determine-the-value-of-an-indexed-property">https://webidl.spec.whatwg.org/#dfn-determine-the-value-of-an-indexed-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-determine-the-value-of-an-indexed-property" class="dfn-panel" data-for="term-for-dfn-determine-the-value-of-an-indexed-property" id="infopanel-for-term-for-dfn-determine-the-value-of-an-indexed-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-determine-the-value-of-an-indexed-property" style="display:none">Info about the 'determine the value of an indexed property' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-determine-the-value-of-an-indexed-property">https://webidl.spec.whatwg.org/#dfn-determine-the-value-of-an-indexed-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-dfn-determine-the-value-of-an-indexed-property①">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.3. Numeric Values:</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
     <li><a href="#ref-for-idl-double③">4.3.3. Value + Unit: CSSUnitValue objects</a> <a href="#ref-for-idl-double④">(2)</a>
@@ -11403,20 +11403,20 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-idl-double③⑨">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-indexed-property-getter">
-   <a href="https://webidl.spec.whatwg.org/#dfn-indexed-property-getter">https://webidl.spec.whatwg.org/#dfn-indexed-property-getter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-indexed-property-getter" class="dfn-panel" data-for="term-for-dfn-indexed-property-getter" id="infopanel-for-term-for-dfn-indexed-property-getter" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-indexed-property-getter" style="display:none">Info about the 'indexed property getter' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-indexed-property-getter">https://webidl.spec.whatwg.org/#dfn-indexed-property-getter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-indexed-property-getter">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a> <a href="#ref-for-idl-long④">(5)</a> <a href="#ref-for-idl-long⑤">(6)</a> <a href="#ref-for-idl-long⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-idl-sequence①">3. The StylePropertyMap</a> <a href="#ref-for-idl-sequence②">(2)</a>
@@ -11425,29 +11425,29 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-idl-sequence⑤">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-the-value-of-a-new-indexed-property">
-   <a href="https://webidl.spec.whatwg.org/#dfn-set-the-value-of-a-new-indexed-property">https://webidl.spec.whatwg.org/#dfn-set-the-value-of-a-new-indexed-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-the-value-of-a-new-indexed-property" class="dfn-panel" data-for="term-for-dfn-set-the-value-of-a-new-indexed-property" id="infopanel-for-term-for-dfn-set-the-value-of-a-new-indexed-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-the-value-of-a-new-indexed-property" style="display:none">Info about the 'set the value of a new indexed property' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-set-the-value-of-a-new-indexed-property">https://webidl.spec.whatwg.org/#dfn-set-the-value-of-a-new-indexed-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-dfn-set-the-value-of-a-new-indexed-property①">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-the-value-of-an-existing-indexed-property">
-   <a href="https://webidl.spec.whatwg.org/#dfn-set-the-value-of-an-existing-indexed-property">https://webidl.spec.whatwg.org/#dfn-set-the-value-of-an-existing-indexed-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-the-value-of-an-existing-indexed-property" class="dfn-panel" data-for="term-for-dfn-set-the-value-of-an-existing-indexed-property" id="infopanel-for-term-for-dfn-set-the-value-of-an-existing-indexed-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-the-value-of-an-existing-indexed-property" style="display:none">Info about the 'set the value of an existing indexed property' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-set-the-value-of-an-existing-indexed-property">https://webidl.spec.whatwg.org/#dfn-set-the-value-of-an-existing-indexed-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-dfn-set-the-value-of-an-existing-indexed-property①">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-supported-property-indices">
-   <a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-supported-property-indices" class="dfn-panel" data-for="term-for-dfn-supported-property-indices" id="infopanel-for-term-for-dfn-supported-property-indices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-supported-property-indices" style="display:none">Info about the 'supported property indices' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-dfn-supported-property-indices①">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">2. CSSStyleValue objects</a> <a href="#ref-for-dfn-throw①">(2)</a>
     <li><a href="#ref-for-dfn-throw②">3. The StylePropertyMap</a> <a href="#ref-for-dfn-throw③">(2)</a> <a href="#ref-for-dfn-throw④">(3)</a> <a href="#ref-for-dfn-throw⑤">(4)</a> <a href="#ref-for-dfn-throw⑥">(5)</a> <a href="#ref-for-dfn-throw⑦">(6)</a> <a href="#ref-for-dfn-throw⑧">(7)</a> <a href="#ref-for-dfn-throw⑨">(8)</a> <a href="#ref-for-dfn-throw①⓪">(9)</a> <a href="#ref-for-dfn-throw①①">(10)</a> <a href="#ref-for-dfn-throw①②">(11)</a> <a href="#ref-for-dfn-throw①③">(12)</a> <a href="#ref-for-dfn-throw①④">(13)</a> <a href="#ref-for-dfn-throw①⑤">(14)</a>
@@ -11460,14 +11460,14 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-dfn-throw⑤③">4.6. CSSColorValue objects</a> <a href="#ref-for-dfn-throw⑤④">(2)</a> <a href="#ref-for-dfn-throw⑤⑤">(3)</a> <a href="#ref-for-dfn-throw⑤⑥">(4)</a> <a href="#ref-for-dfn-throw⑤⑦">(5)</a> <a href="#ref-for-dfn-throw⑤⑧">(6)</a> <a href="#ref-for-dfn-throw⑤⑨">(7)</a> <a href="#ref-for-dfn-throw⑥⓪">(8)</a> <a href="#ref-for-dfn-throw⑥①">(9)</a> <a href="#ref-for-dfn-throw⑥②">(10)</a> <a href="#ref-for-dfn-throw⑥③">(11)</a> <a href="#ref-for-dfn-throw⑥④">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. The StylePropertyMap</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3. The StylePropertyMap</a>
     <li><a href="#ref-for-idl-unsigned-long①">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-idl-unsigned-long②">(2)</a> <a href="#ref-for-idl-unsigned-long③">(3)</a>
@@ -11475,8 +11475,8 @@ return the result of serializing the <a class="production css" data-link-type="t
     <li><a href="#ref-for-idl-unsigned-long⑥">4.4. CSSTransformValue objects</a> <a href="#ref-for-idl-unsigned-long⑦">(2)</a> <a href="#ref-for-idl-unsigned-long⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over">
-   <a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over" id="infopanel-for-term-for-dfn-value-pairs-to-iterate-over" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">3. The StylePropertyMap</a>
    </ul>
@@ -12871,8 +12871,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
    <div class="issue"> TODO add stringifiers <a class="issue-return" href="#issue-0e2e471e" title="Jump to section">↵</a></div>
    <div class="issue"> Phrase the per-item channels setting. <a class="issue-return" href="#issue-76f66623" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="css-internal-representation">
-   <b><a href="#css-internal-representation">#css-internal-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-internal-representation" class="dfn-panel" data-for="css-internal-representation" id="infopanel-for-css-internal-representation" role="dialog">
+   <span id="infopaneltitle-for-css-internal-representation" style="display:none">Info about the 'internal representations' definition.</span><b><a href="#css-internal-representation">#css-internal-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-internal-representation">1. Introduction</a> <a href="#ref-for-css-internal-representation①">(2)</a> <a href="#ref-for-css-internal-representation②">(3)</a> <a href="#ref-for-css-internal-representation③">(4)</a> <a href="#ref-for-css-internal-representation④">(5)</a> <a href="#ref-for-css-internal-representation⑤">(6)</a> <a href="#ref-for-css-internal-representation⑥">(7)</a>
     <li><a href="#ref-for-css-internal-representation⑦">2.1. Direct CSSStyleValue Objects</a> <a href="#ref-for-css-internal-representation⑧">(2)</a> <a href="#ref-for-css-internal-representation⑨">(3)</a>
@@ -12881,8 +12881,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-css-internal-representation①④">5.2. Unrepresentable Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylevalue">
-   <b><a href="#cssstylevalue">#cssstylevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylevalue" class="dfn-panel" data-for="cssstylevalue" id="infopanel-for-cssstylevalue" role="dialog">
+   <span id="infopaneltitle-for-cssstylevalue" style="display:none">Info about the 'CSSStyleValue' definition.</span><b><a href="#cssstylevalue">#cssstylevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylevalue">2. CSSStyleValue objects</a> <a href="#ref-for-cssstylevalue①">(2)</a> <a href="#ref-for-cssstylevalue②">(3)</a> <a href="#ref-for-cssstylevalue③">(4)</a> <a href="#ref-for-cssstylevalue④">(5)</a>
     <li><a href="#ref-for-cssstylevalue⑤">2.1. Direct CSSStyleValue Objects</a> <a href="#ref-for-cssstylevalue⑥">(2)</a> <a href="#ref-for-cssstylevalue⑦">(3)</a> <a href="#ref-for-cssstylevalue⑧">(4)</a> <a href="#ref-for-cssstylevalue⑨">(5)</a> <a href="#ref-for-cssstylevalue①⓪">(6)</a>
@@ -12901,55 +12901,55 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssstylevalue⑥⑤">6.7. Serialization from CSSOM Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="CSSStyleValue-stringification-behavior">
-   <b><a href="#CSSStyleValue-stringification-behavior">#CSSStyleValue-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-CSSStyleValue-stringification-behavior" class="dfn-panel" data-for="CSSStyleValue-stringification-behavior" id="infopanel-for-CSSStyleValue-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-CSSStyleValue-stringification-behavior" style="display:none">Info about the 'stringifier' definition.</span><b><a href="#CSSStyleValue-stringification-behavior">#CSSStyleValue-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CSSStyleValue-stringification-behavior">2. CSSStyleValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylevalue-parse">
-   <b><a href="#dom-cssstylevalue-parse">#dom-cssstylevalue-parse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylevalue-parse" class="dfn-panel" data-for="dom-cssstylevalue-parse" id="infopanel-for-dom-cssstylevalue-parse" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylevalue-parse" style="display:none">Info about the 'parse(property, cssText)' definition.</span><b><a href="#dom-cssstylevalue-parse">#dom-cssstylevalue-parse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylevalue-parse">2. CSSStyleValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylevalue-parseall">
-   <b><a href="#dom-cssstylevalue-parseall">#dom-cssstylevalue-parseall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylevalue-parseall" class="dfn-panel" data-for="dom-cssstylevalue-parseall" id="infopanel-for-dom-cssstylevalue-parseall" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylevalue-parseall" style="display:none">Info about the 'parseAll(property, cssText)' definition.</span><b><a href="#dom-cssstylevalue-parseall">#dom-cssstylevalue-parseall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylevalue-parseall">2. CSSStyleValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-cssstylevalue">
-   <b><a href="#parse-a-cssstylevalue">#parse-a-cssstylevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-cssstylevalue" class="dfn-panel" data-for="parse-a-cssstylevalue" id="infopanel-for-parse-a-cssstylevalue" role="dialog">
+   <span id="infopaneltitle-for-parse-a-cssstylevalue" style="display:none">Info about the 'parse a CSSStyleValue' definition.</span><b><a href="#parse-a-cssstylevalue">#parse-a-cssstylevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-cssstylevalue">2. CSSStyleValue objects</a> <a href="#ref-for-parse-a-cssstylevalue①">(2)</a>
     <li><a href="#ref-for-parse-a-cssstylevalue②">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subdivide-into-iterations">
-   <b><a href="#subdivide-into-iterations">#subdivide-into-iterations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subdivide-into-iterations" class="dfn-panel" data-for="subdivide-into-iterations" id="infopanel-for-subdivide-into-iterations" role="dialog">
+   <span id="infopaneltitle-for-subdivide-into-iterations" style="display:none">Info about the 'subdivide into iterations' definition.</span><b><a href="#subdivide-into-iterations">#subdivide-into-iterations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subdivide-into-iterations">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-subdivide-into-iterations①">3. The StylePropertyMap</a> <a href="#ref-for-subdivide-into-iterations②">(2)</a> <a href="#ref-for-subdivide-into-iterations③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylevalue-associatedproperty-slot">
-   <b><a href="#dom-cssstylevalue-associatedproperty-slot">#dom-cssstylevalue-associatedproperty-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylevalue-associatedproperty-slot" class="dfn-panel" data-for="dom-cssstylevalue-associatedproperty-slot" id="infopanel-for-dom-cssstylevalue-associatedproperty-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylevalue-associatedproperty-slot" style="display:none">Info about the '[[associatedProperty]]' definition.</span><b><a href="#dom-cssstylevalue-associatedproperty-slot">#dom-cssstylevalue-associatedproperty-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylevalue-associatedproperty-slot">2.1. Direct CSSStyleValue Objects</a>
     <li><a href="#ref-for-dom-cssstylevalue-associatedproperty-slot①">3. The StylePropertyMap</a> <a href="#ref-for-dom-cssstylevalue-associatedproperty-slot②">(2)</a> <a href="#ref-for-dom-cssstylevalue-associatedproperty-slot③">(3)</a> <a href="#ref-for-dom-cssstylevalue-associatedproperty-slot④">(4)</a>
     <li><a href="#ref-for-dom-cssstylevalue-associatedproperty-slot⑤">5.2. Unrepresentable Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stylepropertymapreadonly">
-   <b><a href="#stylepropertymapreadonly">#stylepropertymapreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stylepropertymapreadonly" class="dfn-panel" data-for="stylepropertymapreadonly" id="infopanel-for-stylepropertymapreadonly" role="dialog">
+   <span id="infopaneltitle-for-stylepropertymapreadonly" style="display:none">Info about the 'StylePropertyMapReadOnly' definition.</span><b><a href="#stylepropertymapreadonly">#stylepropertymapreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymapreadonly">3. The StylePropertyMap</a> <a href="#ref-for-stylepropertymapreadonly①">(2)</a> <a href="#ref-for-stylepropertymapreadonly②">(3)</a>
     <li><a href="#ref-for-stylepropertymapreadonly③">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-stylepropertymapreadonly④">(2)</a> <a href="#ref-for-stylepropertymapreadonly⑤">(3)</a> <a href="#ref-for-stylepropertymapreadonly⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stylepropertymap">
-   <b><a href="#stylepropertymap">#stylepropertymap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stylepropertymap" class="dfn-panel" data-for="stylepropertymap" id="infopanel-for-stylepropertymap" role="dialog">
+   <span id="infopaneltitle-for-stylepropertymap" style="display:none">Info about the 'StylePropertyMap' definition.</span><b><a href="#stylepropertymap">#stylepropertymap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymap">2.1. Direct CSSStyleValue Objects</a>
     <li><a href="#ref-for-stylepropertymap①">3. The StylePropertyMap</a> <a href="#ref-for-stylepropertymap②">(2)</a> <a href="#ref-for-stylepropertymap③">(3)</a> <a href="#ref-for-stylepropertymap④">(4)</a> <a href="#ref-for-stylepropertymap⑤">(5)</a> <a href="#ref-for-stylepropertymap⑥">(6)</a> <a href="#ref-for-stylepropertymap⑦">(7)</a> <a href="#ref-for-stylepropertymap⑧">(8)</a> <a href="#ref-for-stylepropertymap⑨">(9)</a> <a href="#ref-for-stylepropertymap①⓪">(10)</a> <a href="#ref-for-stylepropertymap①①">(11)</a> <a href="#ref-for-stylepropertymap①②">(12)</a>
@@ -12957,135 +12957,135 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-stylepropertymap①⑥">5. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymapreadonly-declarations-slot">
-   <b><a href="#dom-stylepropertymapreadonly-declarations-slot">#dom-stylepropertymapreadonly-declarations-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymapreadonly-declarations-slot" class="dfn-panel" data-for="dom-stylepropertymapreadonly-declarations-slot" id="infopanel-for-dom-stylepropertymapreadonly-declarations-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymapreadonly-declarations-slot" style="display:none">Info about the '[[declarations]]' definition.</span><b><a href="#dom-stylepropertymapreadonly-declarations-slot">#dom-stylepropertymapreadonly-declarations-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot">3. The StylePropertyMap</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot①">(2)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot②">(3)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot③">(4)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot④">(5)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot⑤">(6)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot⑥">(7)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot⑦">(8)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot⑧">(9)</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot⑨">(10)</a>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot①⓪">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot①①">(2)</a>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-declarations-slot①②">3.2. Declared &amp; Inline StylePropertyMap objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-valued-properties">
-   <b><a href="#list-valued-properties">#list-valued-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-valued-properties" class="dfn-panel" data-for="list-valued-properties" id="infopanel-for-list-valued-properties" role="dialog">
+   <span id="infopaneltitle-for-list-valued-properties" style="display:none">Info about the 'list-valued properties' definition.</span><b><a href="#list-valued-properties">#list-valued-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-valued-properties">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-list-valued-properties①">3. The StylePropertyMap</a> <a href="#ref-for-list-valued-properties②">(2)</a> <a href="#ref-for-list-valued-properties③">(3)</a>
     <li><a href="#ref-for-list-valued-properties④">5. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-valued-properties">
-   <b><a href="#single-valued-properties">#single-valued-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-valued-properties" class="dfn-panel" data-for="single-valued-properties" id="infopanel-for-single-valued-properties" role="dialog">
+   <span id="infopaneltitle-for-single-valued-properties" style="display:none">Info about the 'single-valued properties' definition.</span><b><a href="#single-valued-properties">#single-valued-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-valued-properties">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-single-valued-properties①">3. The StylePropertyMap</a> <a href="#ref-for-single-valued-properties②">(2)</a> <a href="#ref-for-single-valued-properties③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymapreadonly-get">
-   <b><a href="#dom-stylepropertymapreadonly-get">#dom-stylepropertymapreadonly-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymapreadonly-get" class="dfn-panel" data-for="dom-stylepropertymapreadonly-get" id="infopanel-for-dom-stylepropertymapreadonly-get" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymapreadonly-get" style="display:none">Info about the 'get(property)' definition.</span><b><a href="#dom-stylepropertymapreadonly-get">#dom-stylepropertymapreadonly-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-get">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymapreadonly-getall">
-   <b><a href="#dom-stylepropertymapreadonly-getall">#dom-stylepropertymapreadonly-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymapreadonly-getall" class="dfn-panel" data-for="dom-stylepropertymapreadonly-getall" id="infopanel-for-dom-stylepropertymapreadonly-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymapreadonly-getall" style="display:none">Info about the 'getAll(property)' definition.</span><b><a href="#dom-stylepropertymapreadonly-getall">#dom-stylepropertymapreadonly-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-getall">3. The StylePropertyMap</a>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-getall①">5. CSSStyleValue Reification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymapreadonly-has">
-   <b><a href="#dom-stylepropertymapreadonly-has">#dom-stylepropertymapreadonly-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymapreadonly-has" class="dfn-panel" data-for="dom-stylepropertymapreadonly-has" id="infopanel-for-dom-stylepropertymapreadonly-has" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymapreadonly-has" style="display:none">Info about the 'has(property)' definition.</span><b><a href="#dom-stylepropertymapreadonly-has">#dom-stylepropertymapreadonly-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymapreadonly-has">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymap-set">
-   <b><a href="#dom-stylepropertymap-set">#dom-stylepropertymap-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymap-set" class="dfn-panel" data-for="dom-stylepropertymap-set" id="infopanel-for-dom-stylepropertymap-set" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymap-set" style="display:none">Info about the 'set(property, ...values)' definition.</span><b><a href="#dom-stylepropertymap-set">#dom-stylepropertymap-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymap-set">2.1. Direct CSSStyleValue Objects</a>
     <li><a href="#ref-for-dom-stylepropertymap-set①">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymap-append">
-   <b><a href="#dom-stylepropertymap-append">#dom-stylepropertymap-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymap-append" class="dfn-panel" data-for="dom-stylepropertymap-append" id="infopanel-for-dom-stylepropertymap-append" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymap-append" style="display:none">Info about the 'append(property, ...values)' definition.</span><b><a href="#dom-stylepropertymap-append">#dom-stylepropertymap-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymap-append">2.1. Direct CSSStyleValue Objects</a>
     <li><a href="#ref-for-dom-stylepropertymap-append①">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymap-delete">
-   <b><a href="#dom-stylepropertymap-delete">#dom-stylepropertymap-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymap-delete" class="dfn-panel" data-for="dom-stylepropertymap-delete" id="infopanel-for-dom-stylepropertymap-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymap-delete" style="display:none">Info about the 'delete(property)' definition.</span><b><a href="#dom-stylepropertymap-delete">#dom-stylepropertymap-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymap-delete">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylepropertymap-clear">
-   <b><a href="#dom-stylepropertymap-clear">#dom-stylepropertymap-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylepropertymap-clear" class="dfn-panel" data-for="dom-stylepropertymap-clear" id="infopanel-for-dom-stylepropertymap-clear" role="dialog">
+   <span id="infopaneltitle-for-dom-stylepropertymap-clear" style="display:none">Info about the 'clear()' definition.</span><b><a href="#dom-stylepropertymap-clear">#dom-stylepropertymap-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylepropertymap-clear">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-internal-representation">
-   <b><a href="#create-an-internal-representation">#create-an-internal-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-internal-representation" class="dfn-panel" data-for="create-an-internal-representation" id="infopanel-for-create-an-internal-representation" role="dialog">
+   <span id="infopaneltitle-for-create-an-internal-representation" style="display:none">Info about the 'create an internal representation' definition.</span><b><a href="#create-an-internal-representation">#create-an-internal-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-internal-representation">3. The StylePropertyMap</a> <a href="#ref-for-create-an-internal-representation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylevalue-match-a-grammar">
-   <b><a href="#cssstylevalue-match-a-grammar">#cssstylevalue-match-a-grammar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylevalue-match-a-grammar" class="dfn-panel" data-for="cssstylevalue-match-a-grammar" id="infopanel-for-cssstylevalue-match-a-grammar" role="dialog">
+   <span id="infopaneltitle-for-cssstylevalue-match-a-grammar" style="display:none">Info about the 'match a grammar' definition.</span><b><a href="#cssstylevalue-match-a-grammar">#cssstylevalue-match-a-grammar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylevalue-match-a-grammar">3. The StylePropertyMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-property-name-string">
-   <b><a href="#custom-property-name-string">#custom-property-name-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-property-name-string" class="dfn-panel" data-for="custom-property-name-string" id="infopanel-for-custom-property-name-string" role="dialog">
+   <span id="infopaneltitle-for-custom-property-name-string" style="display:none">Info about the 'custom property name string' definition.</span><b><a href="#custom-property-name-string">#custom-property-name-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property-name-string">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-custom-property-name-string①">3. The StylePropertyMap</a> <a href="#ref-for-custom-property-name-string②">(2)</a> <a href="#ref-for-custom-property-name-string③">(3)</a> <a href="#ref-for-custom-property-name-string④">(4)</a> <a href="#ref-for-custom-property-name-string⑤">(5)</a> <a href="#ref-for-custom-property-name-string⑥">(6)</a> <a href="#ref-for-custom-property-name-string⑦">(7)</a>
     <li><a href="#ref-for-custom-property-name-string⑧">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-custom-property-name-string⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-css-property">
-   <b><a href="#valid-css-property">#valid-css-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-css-property" class="dfn-panel" data-for="valid-css-property" id="infopanel-for-valid-css-property" role="dialog">
+   <span id="infopaneltitle-for-valid-css-property" style="display:none">Info about the 'valid CSS property' definition.</span><b><a href="#valid-css-property">#valid-css-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-css-property">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-valid-css-property①">3. The StylePropertyMap</a> <a href="#ref-for-valid-css-property②">(2)</a> <a href="#ref-for-valid-css-property③">(3)</a> <a href="#ref-for-valid-css-property④">(4)</a> <a href="#ref-for-valid-css-property⑤">(5)</a> <a href="#ref-for-valid-css-property⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-computedstylemapcache-slot">
-   <b><a href="#dom-element-computedstylemapcache-slot">#dom-element-computedstylemapcache-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-computedstylemapcache-slot" class="dfn-panel" data-for="dom-element-computedstylemapcache-slot" id="infopanel-for-dom-element-computedstylemapcache-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-element-computedstylemapcache-slot" style="display:none">Info about the '[[computedStyleMapCache]]' definition.</span><b><a href="#dom-element-computedstylemapcache-slot">#dom-element-computedstylemapcache-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-computedstylemapcache-slot">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-dom-element-computedstylemapcache-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-computedstylemap">
-   <b><a href="#dom-element-computedstylemap">#dom-element-computedstylemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-computedstylemap" class="dfn-panel" data-for="dom-element-computedstylemap" id="infopanel-for-dom-element-computedstylemap" role="dialog">
+   <span id="infopaneltitle-for-dom-element-computedstylemap" style="display:none">Info about the 'computedStyleMap()' definition.</span><b><a href="#dom-element-computedstylemap">#dom-element-computedstylemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-computedstylemap">3.1. Computed StylePropertyMapReadOnly objects</a> <a href="#ref-for-dom-element-computedstylemap①">(2)</a> <a href="#ref-for-dom-element-computedstylemap②">(3)</a>
     <li><a href="#ref-for-dom-element-computedstylemap③">4.5. CSSImageValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-stylepropertymap">
-   <b><a href="#declared-stylepropertymap">#declared-stylepropertymap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-stylepropertymap" class="dfn-panel" data-for="declared-stylepropertymap" id="infopanel-for-declared-stylepropertymap" role="dialog">
+   <span id="infopaneltitle-for-declared-stylepropertymap" style="display:none">Info about the 'Declared StylePropertyMap' definition.</span><b><a href="#declared-stylepropertymap">#declared-stylepropertymap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-stylepropertymap">3.2. Declared &amp; Inline StylePropertyMap objects</a>
     <li><a href="#ref-for-declared-stylepropertymap①">4.3. Numeric Values:</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-stylemap">
-   <b><a href="#dom-cssstylerule-stylemap">#dom-cssstylerule-stylemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-stylemap" class="dfn-panel" data-for="dom-cssstylerule-stylemap" id="infopanel-for-dom-cssstylerule-stylemap" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-stylemap" style="display:none">Info about the 'styleMap' definition.</span><b><a href="#dom-cssstylerule-stylemap">#dom-cssstylerule-stylemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-stylemap">3.2. Declared &amp; Inline StylePropertyMap objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementcssinlinestyle-attributestylemap">
-   <b><a href="#dom-elementcssinlinestyle-attributestylemap">#dom-elementcssinlinestyle-attributestylemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementcssinlinestyle-attributestylemap" class="dfn-panel" data-for="dom-elementcssinlinestyle-attributestylemap" id="infopanel-for-dom-elementcssinlinestyle-attributestylemap" role="dialog">
+   <span id="infopaneltitle-for-dom-elementcssinlinestyle-attributestylemap" style="display:none">Info about the 'attributeStyleMap' definition.</span><b><a href="#dom-elementcssinlinestyle-attributestylemap">#dom-elementcssinlinestyle-attributestylemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementcssinlinestyle-attributestylemap">3.2. Declared &amp; Inline StylePropertyMap objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssunparsedvalue">
-   <b><a href="#cssunparsedvalue">#cssunparsedvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssunparsedvalue" class="dfn-panel" data-for="cssunparsedvalue" id="infopanel-for-cssunparsedvalue" role="dialog">
+   <span id="infopaneltitle-for-cssunparsedvalue" style="display:none">Info about the 'CSSUnparsedValue' definition.</span><b><a href="#cssunparsedvalue">#cssunparsedvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssunparsedvalue">3. The StylePropertyMap</a> <a href="#ref-for-cssunparsedvalue①">(2)</a> <a href="#ref-for-cssunparsedvalue②">(3)</a>
     <li><a href="#ref-for-cssunparsedvalue③">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-cssunparsedvalue④">(2)</a> <a href="#ref-for-cssunparsedvalue⑤">(3)</a> <a href="#ref-for-cssunparsedvalue⑥">(4)</a> <a href="#ref-for-cssunparsedvalue⑦">(5)</a> <a href="#ref-for-cssunparsedvalue⑧">(6)</a> <a href="#ref-for-cssunparsedvalue⑨">(7)</a> <a href="#ref-for-cssunparsedvalue①⓪">(8)</a>
@@ -13094,14 +13094,14 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssunparsedvalue①⑦">6.1. CSSUnparsedValue Serialization</a> <a href="#ref-for-cssunparsedvalue①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-cssunparsedsegment">
-   <b><a href="#typedefdef-cssunparsedsegment">#typedefdef-cssunparsedsegment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cssunparsedsegment" class="dfn-panel" data-for="typedefdef-cssunparsedsegment" id="infopanel-for-typedefdef-cssunparsedsegment" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cssunparsedsegment" style="display:none">Info about the 'CSSUnparsedSegment' definition.</span><b><a href="#typedefdef-cssunparsedsegment">#typedefdef-cssunparsedsegment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cssunparsedsegment">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-typedefdef-cssunparsedsegment①">(2)</a> <a href="#ref-for-typedefdef-cssunparsedsegment②">(3)</a> <a href="#ref-for-typedefdef-cssunparsedsegment③">(4)</a> <a href="#ref-for-typedefdef-cssunparsedsegment④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssvariablereferencevalue">
-   <b><a href="#cssvariablereferencevalue">#cssvariablereferencevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssvariablereferencevalue" class="dfn-panel" data-for="cssvariablereferencevalue" id="infopanel-for-cssvariablereferencevalue" role="dialog">
+   <span id="infopaneltitle-for-cssvariablereferencevalue" style="display:none">Info about the 'CSSVariableReferenceValue' definition.</span><b><a href="#cssvariablereferencevalue">#cssvariablereferencevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssvariablereferencevalue">3. The StylePropertyMap</a> <a href="#ref-for-cssvariablereferencevalue①">(2)</a>
     <li><a href="#ref-for-cssvariablereferencevalue②">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-cssvariablereferencevalue③">(2)</a> <a href="#ref-for-cssvariablereferencevalue④">(3)</a> <a href="#ref-for-cssvariablereferencevalue⑤">(4)</a> <a href="#ref-for-cssvariablereferencevalue⑥">(5)</a>
@@ -13110,8 +13110,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssvariablereferencevalue①③">6.1. CSSUnparsedValue Serialization</a> <a href="#ref-for-cssvariablereferencevalue①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssvariablereferencevalue-fallback">
-   <b><a href="#dom-cssvariablereferencevalue-fallback">#dom-cssvariablereferencevalue-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssvariablereferencevalue-fallback" class="dfn-panel" data-for="dom-cssvariablereferencevalue-fallback" id="infopanel-for-dom-cssvariablereferencevalue-fallback" role="dialog">
+   <span id="infopaneltitle-for-dom-cssvariablereferencevalue-fallback" style="display:none">Info about the 'fallback' definition.</span><b><a href="#dom-cssvariablereferencevalue-fallback">#dom-cssvariablereferencevalue-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssvariablereferencevalue-fallback">4.1. CSSUnparsedValue objects</a>
     <li><a href="#ref-for-dom-cssvariablereferencevalue-fallback①">5.3. Raw CSS tokens: properties with var() references</a> <a href="#ref-for-dom-cssvariablereferencevalue-fallback②">(2)</a> <a href="#ref-for-dom-cssvariablereferencevalue-fallback③">(3)</a>
@@ -13119,22 +13119,22 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssvariablereferencevalue-fallback⑤">6.1. CSSUnparsedValue Serialization</a> <a href="#ref-for-dom-cssvariablereferencevalue-fallback⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssunparsedvalue-tokens-slot">
-   <b><a href="#dom-cssunparsedvalue-tokens-slot">#dom-cssunparsedvalue-tokens-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssunparsedvalue-tokens-slot" class="dfn-panel" data-for="dom-cssunparsedvalue-tokens-slot" id="infopanel-for-dom-cssunparsedvalue-tokens-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-cssunparsedvalue-tokens-slot" style="display:none">Info about the '[[tokens]]' definition.</span><b><a href="#dom-cssunparsedvalue-tokens-slot">#dom-cssunparsedvalue-tokens-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssunparsedvalue-tokens-slot">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-dom-cssunparsedvalue-tokens-slot①">(2)</a> <a href="#ref-for-dom-cssunparsedvalue-tokens-slot②">(3)</a> <a href="#ref-for-dom-cssunparsedvalue-tokens-slot③">(4)</a> <a href="#ref-for-dom-cssunparsedvalue-tokens-slot④">(5)</a>
     <li><a href="#ref-for-dom-cssunparsedvalue-tokens-slot⑤">5.3. Raw CSS tokens: properties with var() references</a>
     <li><a href="#ref-for-dom-cssunparsedvalue-tokens-slot⑥">6.1. CSSUnparsedValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssunparsedvalue-length">
-   <b><a href="#dom-cssunparsedvalue-length">#dom-cssunparsedvalue-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssunparsedvalue-length" class="dfn-panel" data-for="dom-cssunparsedvalue-length" id="infopanel-for-dom-cssunparsedvalue-length" role="dialog">
+   <span id="infopaneltitle-for-dom-cssunparsedvalue-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-cssunparsedvalue-length">#dom-cssunparsedvalue-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssunparsedvalue-length">4.1. CSSUnparsedValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssvariablereferencevalue-variable">
-   <b><a href="#dom-cssvariablereferencevalue-variable">#dom-cssvariablereferencevalue-variable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssvariablereferencevalue-variable" class="dfn-panel" data-for="dom-cssvariablereferencevalue-variable" id="infopanel-for-dom-cssvariablereferencevalue-variable" role="dialog">
+   <span id="infopaneltitle-for-dom-cssvariablereferencevalue-variable" style="display:none">Info about the 'variable' definition.</span><b><a href="#dom-cssvariablereferencevalue-variable">#dom-cssvariablereferencevalue-variable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssvariablereferencevalue-variable">4.1. CSSUnparsedValue objects</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable①">(2)</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable②">(3)</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable③">(4)</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable④">(5)</a>
     <li><a href="#ref-for-dom-cssvariablereferencevalue-variable⑤">5.3. Raw CSS tokens: properties with var() references</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable⑥">(2)</a> <a href="#ref-for-dom-cssvariablereferencevalue-variable⑦">(3)</a>
@@ -13142,14 +13142,14 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssvariablereferencevalue-variable⑨">6.1. CSSUnparsedValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssvariablereferencevalue-cssvariablereferencevalue">
-   <b><a href="#dom-cssvariablereferencevalue-cssvariablereferencevalue">#dom-cssvariablereferencevalue-cssvariablereferencevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssvariablereferencevalue-cssvariablereferencevalue" class="dfn-panel" data-for="dom-cssvariablereferencevalue-cssvariablereferencevalue" id="infopanel-for-dom-cssvariablereferencevalue-cssvariablereferencevalue" role="dialog">
+   <span id="infopaneltitle-for-dom-cssvariablereferencevalue-cssvariablereferencevalue" style="display:none">Info about the 'CSSVariableReferenceValue(variable, fallback)' definition.</span><b><a href="#dom-cssvariablereferencevalue-cssvariablereferencevalue">#dom-cssvariablereferencevalue-cssvariablereferencevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssvariablereferencevalue-cssvariablereferencevalue">4.1. CSSUnparsedValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csskeywordvalue">
-   <b><a href="#csskeywordvalue">#csskeywordvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csskeywordvalue" class="dfn-panel" data-for="csskeywordvalue" id="infopanel-for-csskeywordvalue" role="dialog">
+   <span id="infopaneltitle-for-csskeywordvalue" style="display:none">Info about the 'CSSKeywordValue' definition.</span><b><a href="#csskeywordvalue">#csskeywordvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeywordvalue">3. The StylePropertyMap</a>
     <li><a href="#ref-for-csskeywordvalue①">4.2. CSSKeywordValue objects</a> <a href="#ref-for-csskeywordvalue②">(2)</a> <a href="#ref-for-csskeywordvalue③">(3)</a> <a href="#ref-for-csskeywordvalue④">(4)</a> <a href="#ref-for-csskeywordvalue⑤">(5)</a> <a href="#ref-for-csskeywordvalue⑥">(6)</a> <a href="#ref-for-csskeywordvalue⑦">(7)</a> <a href="#ref-for-csskeywordvalue⑧">(8)</a>
@@ -13158,26 +13158,26 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-csskeywordvalue①②">6.2. CSSKeywordValue Serialization</a> <a href="#ref-for-csskeywordvalue①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeywordvalue-csskeywordvalue">
-   <b><a href="#dom-csskeywordvalue-csskeywordvalue">#dom-csskeywordvalue-csskeywordvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeywordvalue-csskeywordvalue" class="dfn-panel" data-for="dom-csskeywordvalue-csskeywordvalue" id="infopanel-for-dom-csskeywordvalue-csskeywordvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeywordvalue-csskeywordvalue" style="display:none">Info about the 'CSSKeywordValue(value)' definition.</span><b><a href="#dom-csskeywordvalue-csskeywordvalue">#dom-csskeywordvalue-csskeywordvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeywordvalue-csskeywordvalue">4.2. CSSKeywordValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-csskeywordish">
-   <b><a href="#typedefdef-csskeywordish">#typedefdef-csskeywordish</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-csskeywordish" class="dfn-panel" data-for="typedefdef-csskeywordish" id="infopanel-for-typedefdef-csskeywordish" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-csskeywordish" style="display:none">Info about the 'CSSKeywordish' definition.</span><b><a href="#typedefdef-csskeywordish">#typedefdef-csskeywordish</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-csskeywordish">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectify-a-keywordish-value">
-   <b><a href="#rectify-a-keywordish-value">#rectify-a-keywordish-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectify-a-keywordish-value" class="dfn-panel" data-for="rectify-a-keywordish-value" id="infopanel-for-rectify-a-keywordish-value" role="dialog">
+   <span id="infopaneltitle-for-rectify-a-keywordish-value" style="display:none">Info about the 'rectify a keywordish value' definition.</span><b><a href="#rectify-a-keywordish-value">#rectify-a-keywordish-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectify-a-keywordish-value">4.6. CSSColorValue objects</a> <a href="#ref-for-rectify-a-keywordish-value①">(2)</a> <a href="#ref-for-rectify-a-keywordish-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeywordvalue-value">
-   <b><a href="#dom-csskeywordvalue-value">#dom-csskeywordvalue-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeywordvalue-value" class="dfn-panel" data-for="dom-csskeywordvalue-value" id="infopanel-for-dom-csskeywordvalue-value" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeywordvalue-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-csskeywordvalue-value">#dom-csskeywordvalue-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeywordvalue-value">3. The StylePropertyMap</a>
     <li><a href="#ref-for-dom-csskeywordvalue-value①">4.2. CSSKeywordValue objects</a> <a href="#ref-for-dom-csskeywordvalue-value②">(2)</a> <a href="#ref-for-dom-csskeywordvalue-value③">(3)</a> <a href="#ref-for-dom-csskeywordvalue-value④">(4)</a>
@@ -13185,8 +13185,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-csskeywordvalue-value⑥">6.2. CSSKeywordValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-cssnumberish">
-   <b><a href="#typedefdef-cssnumberish">#typedefdef-cssnumberish</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cssnumberish" class="dfn-panel" data-for="typedefdef-cssnumberish" id="infopanel-for-typedefdef-cssnumberish" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cssnumberish" style="display:none">Info about the 'CSSNumberish' definition.</span><b><a href="#typedefdef-cssnumberish">#typedefdef-cssnumberish</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cssnumberish">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-typedefdef-cssnumberish①">(2)</a> <a href="#ref-for-typedefdef-cssnumberish②">(3)</a> <a href="#ref-for-typedefdef-cssnumberish③">(4)</a> <a href="#ref-for-typedefdef-cssnumberish④">(5)</a> <a href="#ref-for-typedefdef-cssnumberish⑤">(6)</a> <a href="#ref-for-typedefdef-cssnumberish⑥">(7)</a>
     <li><a href="#ref-for-typedefdef-cssnumberish⑦">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-typedefdef-cssnumberish⑧">(2)</a> <a href="#ref-for-typedefdef-cssnumberish⑨">(3)</a> <a href="#ref-for-typedefdef-cssnumberish①⓪">(4)</a> <a href="#ref-for-typedefdef-cssnumberish①①">(5)</a> <a href="#ref-for-typedefdef-cssnumberish①②">(6)</a> <a href="#ref-for-typedefdef-cssnumberish①③">(7)</a> <a href="#ref-for-typedefdef-cssnumberish①④">(8)</a> <a href="#ref-for-typedefdef-cssnumberish①⑤">(9)</a>
@@ -13194,34 +13194,34 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-typedefdef-cssnumberish②⑧">4.6. CSSColorValue objects</a> <a href="#ref-for-typedefdef-cssnumberish②⑨">(2)</a> <a href="#ref-for-typedefdef-cssnumberish③⓪">(3)</a> <a href="#ref-for-typedefdef-cssnumberish③①">(4)</a> <a href="#ref-for-typedefdef-cssnumberish③②">(5)</a> <a href="#ref-for-typedefdef-cssnumberish③③">(6)</a> <a href="#ref-for-typedefdef-cssnumberish③④">(7)</a> <a href="#ref-for-typedefdef-cssnumberish③⑤">(8)</a> <a href="#ref-for-typedefdef-cssnumberish③⑥">(9)</a> <a href="#ref-for-typedefdef-cssnumberish③⑦">(10)</a> <a href="#ref-for-typedefdef-cssnumberish③⑧">(11)</a> <a href="#ref-for-typedefdef-cssnumberish③⑨">(12)</a> <a href="#ref-for-typedefdef-cssnumberish④⓪">(13)</a> <a href="#ref-for-typedefdef-cssnumberish④①">(14)</a> <a href="#ref-for-typedefdef-cssnumberish④②">(15)</a> <a href="#ref-for-typedefdef-cssnumberish④③">(16)</a> <a href="#ref-for-typedefdef-cssnumberish④④">(17)</a> <a href="#ref-for-typedefdef-cssnumberish④⑤">(18)</a> <a href="#ref-for-typedefdef-cssnumberish④⑥">(19)</a> <a href="#ref-for-typedefdef-cssnumberish④⑦">(20)</a> <a href="#ref-for-typedefdef-cssnumberish④⑧">(21)</a> <a href="#ref-for-typedefdef-cssnumberish④⑨">(22)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⓪">(23)</a> <a href="#ref-for-typedefdef-cssnumberish⑤①">(24)</a> <a href="#ref-for-typedefdef-cssnumberish⑤②">(25)</a> <a href="#ref-for-typedefdef-cssnumberish⑤③">(26)</a> <a href="#ref-for-typedefdef-cssnumberish⑤④">(27)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⑤">(28)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⑥">(29)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⑦">(30)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⑧">(31)</a> <a href="#ref-for-typedefdef-cssnumberish⑤⑨">(32)</a> <a href="#ref-for-typedefdef-cssnumberish⑥⓪">(33)</a> <a href="#ref-for-typedefdef-cssnumberish⑥①">(34)</a> <a href="#ref-for-typedefdef-cssnumberish⑥②">(35)</a> <a href="#ref-for-typedefdef-cssnumberish⑥③">(36)</a> <a href="#ref-for-typedefdef-cssnumberish⑥④">(37)</a> <a href="#ref-for-typedefdef-cssnumberish⑥⑤">(38)</a> <a href="#ref-for-typedefdef-cssnumberish⑥⑥">(39)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectify-a-numberish-value">
-   <b><a href="#rectify-a-numberish-value">#rectify-a-numberish-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectify-a-numberish-value" class="dfn-panel" data-for="rectify-a-numberish-value" id="infopanel-for-rectify-a-numberish-value" role="dialog">
+   <span id="infopaneltitle-for-rectify-a-numberish-value" style="display:none">Info about the 'rectify a numberish value' definition.</span><b><a href="#rectify-a-numberish-value">#rectify-a-numberish-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectify-a-numberish-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-rectify-a-numberish-value①">(2)</a> <a href="#ref-for-rectify-a-numberish-value②">(3)</a> <a href="#ref-for-rectify-a-numberish-value③">(4)</a> <a href="#ref-for-rectify-a-numberish-value④">(5)</a> <a href="#ref-for-rectify-a-numberish-value⑤">(6)</a> <a href="#ref-for-rectify-a-numberish-value⑥">(7)</a>
     <li><a href="#ref-for-rectify-a-numberish-value⑦">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-rectify-a-numberish-value⑧">(2)</a> <a href="#ref-for-rectify-a-numberish-value⑨">(3)</a>
     <li><a href="#ref-for-rectify-a-numberish-value①⓪">4.4. CSSTransformValue objects</a> <a href="#ref-for-rectify-a-numberish-value①①">(2)</a> <a href="#ref-for-rectify-a-numberish-value①②">(3)</a> <a href="#ref-for-rectify-a-numberish-value①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-cssnumericbasetype">
-   <b><a href="#enumdef-cssnumericbasetype">#enumdef-cssnumericbasetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-cssnumericbasetype" class="dfn-panel" data-for="enumdef-cssnumericbasetype" id="infopanel-for-enumdef-cssnumericbasetype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-cssnumericbasetype" style="display:none">Info about the 'CSSNumericBaseType' definition.</span><b><a href="#enumdef-cssnumericbasetype">#enumdef-cssnumericbasetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-cssnumericbasetype">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cssnumerictype">
-   <b><a href="#dictdef-cssnumerictype">#dictdef-cssnumerictype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cssnumerictype" class="dfn-panel" data-for="dictdef-cssnumerictype" id="infopanel-for-dictdef-cssnumerictype" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cssnumerictype" style="display:none">Info about the 'CSSNumericType' definition.</span><b><a href="#dictdef-cssnumerictype">#dictdef-cssnumerictype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cssnumerictype">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dictdef-cssnumerictype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumerictype-percenthint">
-   <b><a href="#dom-cssnumerictype-percenthint">#dom-cssnumerictype-percenthint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumerictype-percenthint" class="dfn-panel" data-for="dom-cssnumerictype-percenthint" id="infopanel-for-dom-cssnumerictype-percenthint" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumerictype-percenthint" style="display:none">Info about the 'percentHint' definition.</span><b><a href="#dom-cssnumerictype-percenthint">#dom-cssnumerictype-percenthint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumerictype-percenthint">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue">
-   <b><a href="#cssnumericvalue">#cssnumericvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue" class="dfn-panel" data-for="cssnumericvalue" id="infopanel-for-cssnumericvalue" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue" style="display:none">Info about the 'CSSNumericValue' definition.</span><b><a href="#cssnumericvalue">#cssnumericvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue">3. The StylePropertyMap</a>
     <li><a href="#ref-for-cssnumericvalue①">4.3. Numeric Values:</a> <a href="#ref-for-cssnumericvalue②">(2)</a> <a href="#ref-for-cssnumericvalue③">(3)</a> <a href="#ref-for-cssnumericvalue④">(4)</a> <a href="#ref-for-cssnumericvalue⑤">(5)</a> <a href="#ref-for-cssnumericvalue⑥">(6)</a> <a href="#ref-for-cssnumericvalue⑦">(7)</a>
@@ -13234,176 +13234,176 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssnumericvalue⑦④">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-add">
-   <b><a href="#dom-cssnumericvalue-add">#dom-cssnumericvalue-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-add" class="dfn-panel" data-for="dom-cssnumericvalue-add" id="infopanel-for-dom-cssnumericvalue-add" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-add" style="display:none">Info about the 'add(...values)' definition.</span><b><a href="#dom-cssnumericvalue-add">#dom-cssnumericvalue-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-add">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssnumericvalue-add①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-sub">
-   <b><a href="#dom-cssnumericvalue-sub">#dom-cssnumericvalue-sub</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-sub" class="dfn-panel" data-for="dom-cssnumericvalue-sub" id="infopanel-for-dom-cssnumericvalue-sub" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-sub" style="display:none">Info about the 'sub(...values)' definition.</span><b><a href="#dom-cssnumericvalue-sub">#dom-cssnumericvalue-sub</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-sub">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmath-negate-a-cssnumericvalue">
-   <b><a href="#cssmath-negate-a-cssnumericvalue">#cssmath-negate-a-cssnumericvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmath-negate-a-cssnumericvalue" class="dfn-panel" data-for="cssmath-negate-a-cssnumericvalue" id="infopanel-for-cssmath-negate-a-cssnumericvalue" role="dialog">
+   <span id="infopaneltitle-for-cssmath-negate-a-cssnumericvalue" style="display:none">Info about the 'negate a CSSNumericValue' definition.</span><b><a href="#cssmath-negate-a-cssnumericvalue">#cssmath-negate-a-cssnumericvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmath-negate-a-cssnumericvalue">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-mul">
-   <b><a href="#dom-cssnumericvalue-mul">#dom-cssnumericvalue-mul</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-mul" class="dfn-panel" data-for="dom-cssnumericvalue-mul" id="infopanel-for-dom-cssnumericvalue-mul" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-mul" style="display:none">Info about the 'mul(...values)' definition.</span><b><a href="#dom-cssnumericvalue-mul">#dom-cssnumericvalue-mul</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-mul">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssnumericvalue-mul①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-div">
-   <b><a href="#dom-cssnumericvalue-div">#dom-cssnumericvalue-div</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-div" class="dfn-panel" data-for="dom-cssnumericvalue-div" id="infopanel-for-dom-cssnumericvalue-div" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-div" style="display:none">Info about the 'div(...values)' definition.</span><b><a href="#dom-cssnumericvalue-div">#dom-cssnumericvalue-div</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-div">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmath-invert-a-cssnumericvalue">
-   <b><a href="#cssmath-invert-a-cssnumericvalue">#cssmath-invert-a-cssnumericvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmath-invert-a-cssnumericvalue" class="dfn-panel" data-for="cssmath-invert-a-cssnumericvalue" id="infopanel-for-cssmath-invert-a-cssnumericvalue" role="dialog">
+   <span id="infopaneltitle-for-cssmath-invert-a-cssnumericvalue" style="display:none">Info about the 'invert a CSSNumericValue' definition.</span><b><a href="#cssmath-invert-a-cssnumericvalue">#cssmath-invert-a-cssnumericvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmath-invert-a-cssnumericvalue">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-min">
-   <b><a href="#dom-cssnumericvalue-min">#dom-cssnumericvalue-min</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-min" class="dfn-panel" data-for="dom-cssnumericvalue-min" id="infopanel-for-dom-cssnumericvalue-min" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-min" style="display:none">Info about the 'min(...values)' definition.</span><b><a href="#dom-cssnumericvalue-min">#dom-cssnumericvalue-min</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-min">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-max">
-   <b><a href="#dom-cssnumericvalue-max">#dom-cssnumericvalue-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-max" class="dfn-panel" data-for="dom-cssnumericvalue-max" id="infopanel-for-dom-cssnumericvalue-max" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-max" style="display:none">Info about the 'max(...values)' definition.</span><b><a href="#dom-cssnumericvalue-max">#dom-cssnumericvalue-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-max">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-equals">
-   <b><a href="#dom-cssnumericvalue-equals">#dom-cssnumericvalue-equals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-equals" class="dfn-panel" data-for="dom-cssnumericvalue-equals" id="infopanel-for-dom-cssnumericvalue-equals" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-equals" style="display:none">Info about the 'equals(...values)' definition.</span><b><a href="#dom-cssnumericvalue-equals">#dom-cssnumericvalue-equals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-equals">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="equal-numeric-value">
-   <b><a href="#equal-numeric-value">#equal-numeric-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-equal-numeric-value" class="dfn-panel" data-for="equal-numeric-value" id="infopanel-for-equal-numeric-value" role="dialog">
+   <span id="infopaneltitle-for-equal-numeric-value" style="display:none">Info about the 'equal numeric values' definition.</span><b><a href="#equal-numeric-value">#equal-numeric-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-equal-numeric-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-equal-numeric-value①">(2)</a> <a href="#ref-for-equal-numeric-value②">(3)</a>
     <li><a href="#ref-for-equal-numeric-value③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-to">
-   <b><a href="#dom-cssnumericvalue-to">#dom-cssnumericvalue-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-to" class="dfn-panel" data-for="dom-cssnumericvalue-to" id="infopanel-for-dom-cssnumericvalue-to" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-to" style="display:none">Info about the 'to(unit)' definition.</span><b><a href="#dom-cssnumericvalue-to">#dom-cssnumericvalue-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-to">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssnumericvalue-to①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-cssunitvalue-from-a-sum-value-item">
-   <b><a href="#create-a-cssunitvalue-from-a-sum-value-item">#create-a-cssunitvalue-from-a-sum-value-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-cssunitvalue-from-a-sum-value-item" class="dfn-panel" data-for="create-a-cssunitvalue-from-a-sum-value-item" id="infopanel-for-create-a-cssunitvalue-from-a-sum-value-item" role="dialog">
+   <span id="infopaneltitle-for-create-a-cssunitvalue-from-a-sum-value-item" style="display:none">Info about the 'create a CSSUnitValue from a sum value item' definition.</span><b><a href="#create-a-cssunitvalue-from-a-sum-value-item">#create-a-cssunitvalue-from-a-sum-value-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cssunitvalue-from-a-sum-value-item">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-create-a-cssunitvalue-from-a-sum-value-item①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-tosum">
-   <b><a href="#dom-cssnumericvalue-tosum">#dom-cssnumericvalue-tosum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-tosum" class="dfn-panel" data-for="dom-cssnumericvalue-tosum" id="infopanel-for-dom-cssnumericvalue-tosum" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-tosum" style="display:none">Info about the 'toSum(...units)' definition.</span><b><a href="#dom-cssnumericvalue-tosum">#dom-cssnumericvalue-tosum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-tosum">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-type">
-   <b><a href="#dom-cssnumericvalue-type">#dom-cssnumericvalue-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-type" class="dfn-panel" data-for="dom-cssnumericvalue-type" id="infopanel-for-dom-cssnumericvalue-type" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-type" style="display:none">Info about the 'type()' definition.</span><b><a href="#dom-cssnumericvalue-type">#dom-cssnumericvalue-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-type">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-sum-value">
-   <b><a href="#cssnumericvalue-sum-value">#cssnumericvalue-sum-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-sum-value" class="dfn-panel" data-for="cssnumericvalue-sum-value" id="infopanel-for-cssnumericvalue-sum-value" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-sum-value" style="display:none">Info about the 'sum value' definition.</span><b><a href="#cssnumericvalue-sum-value">#cssnumericvalue-sum-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-sum-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssnumericvalue-sum-value①">(2)</a> <a href="#ref-for-cssnumericvalue-sum-value②">(3)</a> <a href="#ref-for-cssnumericvalue-sum-value③">(4)</a> <a href="#ref-for-cssnumericvalue-sum-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sum-value-value">
-   <b><a href="#sum-value-value">#sum-value-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sum-value-value" class="dfn-panel" data-for="sum-value-value" id="infopanel-for-sum-value-value" role="dialog">
+   <span id="infopaneltitle-for-sum-value-value" style="display:none">Info about the 'value' definition.</span><b><a href="#sum-value-value">#sum-value-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sum-value-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-sum-value-value①">(2)</a> <a href="#ref-for-sum-value-value②">(3)</a> <a href="#ref-for-sum-value-value③">(4)</a> <a href="#ref-for-sum-value-value④">(5)</a> <a href="#ref-for-sum-value-value⑤">(6)</a> <a href="#ref-for-sum-value-value⑥">(7)</a> <a href="#ref-for-sum-value-value⑦">(8)</a> <a href="#ref-for-sum-value-value⑧">(9)</a> <a href="#ref-for-sum-value-value⑨">(10)</a> <a href="#ref-for-sum-value-value①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sum-value-unit-map">
-   <b><a href="#sum-value-unit-map">#sum-value-unit-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sum-value-unit-map" class="dfn-panel" data-for="sum-value-unit-map" id="infopanel-for-sum-value-unit-map" role="dialog">
+   <span id="infopaneltitle-for-sum-value-unit-map" style="display:none">Info about the 'unit map' definition.</span><b><a href="#sum-value-unit-map">#sum-value-unit-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sum-value-unit-map">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-sum-value-unit-map①">(2)</a> <a href="#ref-for-sum-value-unit-map②">(3)</a> <a href="#ref-for-sum-value-unit-map③">(4)</a> <a href="#ref-for-sum-value-unit-map④">(5)</a> <a href="#ref-for-sum-value-unit-map⑤">(6)</a> <a href="#ref-for-sum-value-unit-map⑥">(7)</a> <a href="#ref-for-sum-value-unit-map⑦">(8)</a> <a href="#ref-for-sum-value-unit-map⑧">(9)</a> <a href="#ref-for-sum-value-unit-map⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-sum-value">
-   <b><a href="#create-a-sum-value">#create-a-sum-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-sum-value" class="dfn-panel" data-for="create-a-sum-value" id="infopanel-for-create-a-sum-value" role="dialog">
+   <span id="infopaneltitle-for-create-a-sum-value" style="display:none">Info about the 'create a sum value' definition.</span><b><a href="#create-a-sum-value">#create-a-sum-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-sum-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-create-a-sum-value①">(2)</a> <a href="#ref-for-create-a-sum-value②">(3)</a> <a href="#ref-for-create-a-sum-value③">(4)</a> <a href="#ref-for-create-a-sum-value④">(5)</a> <a href="#ref-for-create-a-sum-value⑤">(6)</a> <a href="#ref-for-create-a-sum-value⑥">(7)</a> <a href="#ref-for-create-a-sum-value⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-type-from-a-unit-map">
-   <b><a href="#create-a-type-from-a-unit-map">#create-a-type-from-a-unit-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-type-from-a-unit-map" class="dfn-panel" data-for="create-a-type-from-a-unit-map" id="infopanel-for-create-a-type-from-a-unit-map" role="dialog">
+   <span id="infopaneltitle-for-create-a-type-from-a-unit-map" style="display:none">Info about the 'create a type from a unit map' definition.</span><b><a href="#create-a-type-from-a-unit-map">#create-a-type-from-a-unit-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-type-from-a-unit-map">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="product-of-two-unit-maps">
-   <b><a href="#product-of-two-unit-maps">#product-of-two-unit-maps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-product-of-two-unit-maps" class="dfn-panel" data-for="product-of-two-unit-maps" id="infopanel-for-product-of-two-unit-maps" role="dialog">
+   <span id="infopaneltitle-for-product-of-two-unit-maps" style="display:none">Info about the 'product of two unit maps' definition.</span><b><a href="#product-of-two-unit-maps">#product-of-two-unit-maps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-product-of-two-unit-maps">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericvalue-parse">
-   <b><a href="#dom-cssnumericvalue-parse">#dom-cssnumericvalue-parse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericvalue-parse" class="dfn-panel" data-for="dom-cssnumericvalue-parse" id="infopanel-for-dom-cssnumericvalue-parse" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericvalue-parse" style="display:none">Info about the 'parse(cssText)' definition.</span><b><a href="#dom-cssnumericvalue-parse">#dom-cssnumericvalue-parse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericvalue-parse">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssnumericvalue-parse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-base-type">
-   <b><a href="#cssnumericvalue-base-type">#cssnumericvalue-base-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-base-type" class="dfn-panel" data-for="cssnumericvalue-base-type" id="infopanel-for-cssnumericvalue-base-type" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-base-type" style="display:none">Info about the 'base types' definition.</span><b><a href="#cssnumericvalue-base-type">#cssnumericvalue-base-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-base-type">4.3.2. Numeric Value Typing</a> <a href="#ref-for-cssnumericvalue-base-type①">(2)</a> <a href="#ref-for-cssnumericvalue-base-type②">(3)</a> <a href="#ref-for-cssnumericvalue-base-type③">(4)</a> <a href="#ref-for-cssnumericvalue-base-type④">(5)</a> <a href="#ref-for-cssnumericvalue-base-type⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-percent-hint">
-   <b><a href="#cssnumericvalue-percent-hint">#cssnumericvalue-percent-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-percent-hint" class="dfn-panel" data-for="cssnumericvalue-percent-hint" id="infopanel-for-cssnumericvalue-percent-hint" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-percent-hint" style="display:none">Info about the 'percent hint' definition.</span><b><a href="#cssnumericvalue-percent-hint">#cssnumericvalue-percent-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-percent-hint">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssnumericvalue-percent-hint①">(2)</a>
     <li><a href="#ref-for-cssnumericvalue-percent-hint②">4.3.2. Numeric Value Typing</a> <a href="#ref-for-cssnumericvalue-percent-hint③">(2)</a> <a href="#ref-for-cssnumericvalue-percent-hint④">(3)</a> <a href="#ref-for-cssnumericvalue-percent-hint⑤">(4)</a> <a href="#ref-for-cssnumericvalue-percent-hint⑥">(5)</a> <a href="#ref-for-cssnumericvalue-percent-hint⑦">(6)</a> <a href="#ref-for-cssnumericvalue-percent-hint⑧">(7)</a> <a href="#ref-for-cssnumericvalue-percent-hint⑨">(8)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⓪">(9)</a> <a href="#ref-for-cssnumericvalue-percent-hint①①">(10)</a> <a href="#ref-for-cssnumericvalue-percent-hint①②">(11)</a> <a href="#ref-for-cssnumericvalue-percent-hint①③">(12)</a> <a href="#ref-for-cssnumericvalue-percent-hint①④">(13)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⑤">(14)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⑥">(15)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⑦">(16)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⑧">(17)</a> <a href="#ref-for-cssnumericvalue-percent-hint①⑨">(18)</a> <a href="#ref-for-cssnumericvalue-percent-hint②⓪">(19)</a> <a href="#ref-for-cssnumericvalue-percent-hint②①">(20)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-create-a-type">
-   <b><a href="#cssnumericvalue-create-a-type">#cssnumericvalue-create-a-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-create-a-type" class="dfn-panel" data-for="cssnumericvalue-create-a-type" id="infopanel-for-cssnumericvalue-create-a-type" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-create-a-type" style="display:none">Info about the 'create a type' definition.</span><b><a href="#cssnumericvalue-create-a-type">#cssnumericvalue-create-a-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-create-a-type">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssnumericvalue-create-a-type①">(2)</a> <a href="#ref-for-cssnumericvalue-create-a-type②">(3)</a>
     <li><a href="#ref-for-cssnumericvalue-create-a-type③">4.3.3. Value + Unit: CSSUnitValue objects</a> <a href="#ref-for-cssnumericvalue-create-a-type④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-add-two-types">
-   <b><a href="#cssnumericvalue-add-two-types">#cssnumericvalue-add-two-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-add-two-types" class="dfn-panel" data-for="cssnumericvalue-add-two-types" id="infopanel-for-cssnumericvalue-add-two-types" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-add-two-types" style="display:none">Info about the 'add two types' definition.</span><b><a href="#cssnumericvalue-add-two-types">#cssnumericvalue-add-two-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-add-two-types">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssnumericvalue-add-two-types①">(2)</a> <a href="#ref-for-cssnumericvalue-add-two-types②">(3)</a> <a href="#ref-for-cssnumericvalue-add-two-types③">(4)</a>
     <li><a href="#ref-for-cssnumericvalue-add-two-types④">4.3.2. Numeric Value Typing</a> <a href="#ref-for-cssnumericvalue-add-two-types⑤">(2)</a>
     <li><a href="#ref-for-cssnumericvalue-add-two-types⑥">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssnumericvalue-add-two-types⑦">(2)</a> <a href="#ref-for-cssnumericvalue-add-two-types⑧">(3)</a> <a href="#ref-for-cssnumericvalue-add-two-types⑨">(4)</a> <a href="#ref-for-cssnumericvalue-add-two-types①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply-the-percent-hint">
-   <b><a href="#apply-the-percent-hint">#apply-the-percent-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply-the-percent-hint" class="dfn-panel" data-for="apply-the-percent-hint" id="infopanel-for-apply-the-percent-hint" role="dialog">
+   <span id="infopaneltitle-for-apply-the-percent-hint" style="display:none">Info about the 'apply the percent hint' definition.</span><b><a href="#apply-the-percent-hint">#apply-the-percent-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply-the-percent-hint">4.3.2. Numeric Value Typing</a> <a href="#ref-for-apply-the-percent-hint①">(2)</a> <a href="#ref-for-apply-the-percent-hint②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-multiply-two-types">
-   <b><a href="#cssnumericvalue-multiply-two-types">#cssnumericvalue-multiply-two-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-multiply-two-types" class="dfn-panel" data-for="cssnumericvalue-multiply-two-types" id="infopanel-for-cssnumericvalue-multiply-two-types" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-multiply-two-types" style="display:none">Info about the 'multiply two types' definition.</span><b><a href="#cssnumericvalue-multiply-two-types">#cssnumericvalue-multiply-two-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-multiply-two-types">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssnumericvalue-multiply-two-types①">(2)</a>
     <li><a href="#ref-for-cssnumericvalue-multiply-two-types②">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssnumericvalue-multiply-two-types③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericvalue-match">
-   <b><a href="#cssnumericvalue-match">#cssnumericvalue-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericvalue-match" class="dfn-panel" data-for="cssnumericvalue-match" id="infopanel-for-cssnumericvalue-match" role="dialog">
+   <span id="infopaneltitle-for-cssnumericvalue-match" style="display:none">Info about the 'match' definition.</span><b><a href="#cssnumericvalue-match">#cssnumericvalue-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-match">3. The StylePropertyMap</a>
     <li><a href="#ref-for-cssnumericvalue-match①">4.3.2. Numeric Value Typing</a>
@@ -13411,8 +13411,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssnumericvalue-match①②">4.6. CSSColorValue objects</a> <a href="#ref-for-cssnumericvalue-match①③">(2)</a> <a href="#ref-for-cssnumericvalue-match①④">(3)</a> <a href="#ref-for-cssnumericvalue-match①⑤">(4)</a> <a href="#ref-for-cssnumericvalue-match①⑥">(5)</a> <a href="#ref-for-cssnumericvalue-match①⑦">(6)</a> <a href="#ref-for-cssnumericvalue-match①⑧">(7)</a> <a href="#ref-for-cssnumericvalue-match①⑨">(8)</a> <a href="#ref-for-cssnumericvalue-match②⓪">(9)</a> <a href="#ref-for-cssnumericvalue-match②①">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssunitvalue">
-   <b><a href="#cssunitvalue">#cssunitvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssunitvalue" class="dfn-panel" data-for="cssunitvalue" id="infopanel-for-cssunitvalue" role="dialog">
+   <span id="infopaneltitle-for-cssunitvalue" style="display:none">Info about the 'CSSUnitValue' definition.</span><b><a href="#cssunitvalue">#cssunitvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssunitvalue">3. The StylePropertyMap</a>
     <li><a href="#ref-for-cssunitvalue①">4.3. Numeric Values:</a> <a href="#ref-for-cssunitvalue②">(2)</a>
@@ -13425,8 +13425,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssunitvalue⑦④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssunitvalue-value">
-   <b><a href="#dom-cssunitvalue-value">#dom-cssunitvalue-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssunitvalue-value" class="dfn-panel" data-for="dom-cssunitvalue-value" id="infopanel-for-dom-cssunitvalue-value" role="dialog">
+   <span id="infopaneltitle-for-dom-cssunitvalue-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-cssunitvalue-value">#dom-cssunitvalue-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssunitvalue-value">4.3. Numeric Values:</a>
     <li><a href="#ref-for-dom-cssunitvalue-value①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssunitvalue-value②">(2)</a> <a href="#ref-for-dom-cssunitvalue-value③">(3)</a> <a href="#ref-for-dom-cssunitvalue-value④">(4)</a> <a href="#ref-for-dom-cssunitvalue-value⑤">(5)</a> <a href="#ref-for-dom-cssunitvalue-value⑥">(6)</a> <a href="#ref-for-dom-cssunitvalue-value⑦">(7)</a> <a href="#ref-for-dom-cssunitvalue-value⑧">(8)</a> <a href="#ref-for-dom-cssunitvalue-value⑨">(9)</a> <a href="#ref-for-dom-cssunitvalue-value①⓪">(10)</a> <a href="#ref-for-dom-cssunitvalue-value①①">(11)</a> <a href="#ref-for-dom-cssunitvalue-value①②">(12)</a> <a href="#ref-for-dom-cssunitvalue-value①③">(13)</a> <a href="#ref-for-dom-cssunitvalue-value①④">(14)</a> <a href="#ref-for-dom-cssunitvalue-value①⑤">(15)</a> <a href="#ref-for-dom-cssunitvalue-value①⑥">(16)</a> <a href="#ref-for-dom-cssunitvalue-value①⑦">(17)</a> <a href="#ref-for-dom-cssunitvalue-value①⑧">(18)</a> <a href="#ref-for-dom-cssunitvalue-value①⑨">(19)</a> <a href="#ref-for-dom-cssunitvalue-value②⓪">(20)</a>
@@ -13437,8 +13437,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssunitvalue-value②⑨">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssunitvalue-unit">
-   <b><a href="#dom-cssunitvalue-unit">#dom-cssunitvalue-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssunitvalue-unit" class="dfn-panel" data-for="dom-cssunitvalue-unit" id="infopanel-for-dom-cssunitvalue-unit" role="dialog">
+   <span id="infopaneltitle-for-dom-cssunitvalue-unit" style="display:none">Info about the 'unit' definition.</span><b><a href="#dom-cssunitvalue-unit">#dom-cssunitvalue-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssunitvalue-unit">4.3. Numeric Values:</a>
     <li><a href="#ref-for-dom-cssunitvalue-unit①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssunitvalue-unit②">(2)</a> <a href="#ref-for-dom-cssunitvalue-unit③">(3)</a> <a href="#ref-for-dom-cssunitvalue-unit④">(4)</a> <a href="#ref-for-dom-cssunitvalue-unit⑤">(5)</a> <a href="#ref-for-dom-cssunitvalue-unit⑥">(6)</a> <a href="#ref-for-dom-cssunitvalue-unit⑦">(7)</a> <a href="#ref-for-dom-cssunitvalue-unit⑧">(8)</a> <a href="#ref-for-dom-cssunitvalue-unit⑨">(9)</a> <a href="#ref-for-dom-cssunitvalue-unit①⓪">(10)</a> <a href="#ref-for-dom-cssunitvalue-unit①①">(11)</a> <a href="#ref-for-dom-cssunitvalue-unit①②">(12)</a> <a href="#ref-for-dom-cssunitvalue-unit①③">(13)</a> <a href="#ref-for-dom-cssunitvalue-unit①④">(14)</a> <a href="#ref-for-dom-cssunitvalue-unit①⑤">(15)</a> <a href="#ref-for-dom-cssunitvalue-unit①⑥">(16)</a> <a href="#ref-for-dom-cssunitvalue-unit①⑦">(17)</a> <a href="#ref-for-dom-cssunitvalue-unit①⑧">(18)</a> <a href="#ref-for-dom-cssunitvalue-unit①⑨">(19)</a> <a href="#ref-for-dom-cssunitvalue-unit②⓪">(20)</a> <a href="#ref-for-dom-cssunitvalue-unit②①">(21)</a> <a href="#ref-for-dom-cssunitvalue-unit②②">(22)</a> <a href="#ref-for-dom-cssunitvalue-unit②③">(23)</a>
@@ -13448,35 +13448,35 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssunitvalue-unit③②">6.3. CSSUnitValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssunitvalue-cssunitvalue">
-   <b><a href="#dom-cssunitvalue-cssunitvalue">#dom-cssunitvalue-cssunitvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssunitvalue-cssunitvalue" class="dfn-panel" data-for="dom-cssunitvalue-cssunitvalue" id="infopanel-for-dom-cssunitvalue-cssunitvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-cssunitvalue-cssunitvalue" style="display:none">Info about the 'CSSUnitValue(value, unit)' definition.</span><b><a href="#dom-cssunitvalue-cssunitvalue">#dom-cssunitvalue-cssunitvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssunitvalue-cssunitvalue">4.3.3. Value + Unit: CSSUnitValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-cssunitvalue-from-a-pair">
-   <b><a href="#create-a-cssunitvalue-from-a-pair">#create-a-cssunitvalue-from-a-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-cssunitvalue-from-a-pair" class="dfn-panel" data-for="create-a-cssunitvalue-from-a-pair" id="infopanel-for-create-a-cssunitvalue-from-a-pair" role="dialog">
+   <span id="infopaneltitle-for-create-a-cssunitvalue-from-a-pair" style="display:none">Info about the 'create a CSSUnitValue from a pair' definition.</span><b><a href="#create-a-cssunitvalue-from-a-pair">#create-a-cssunitvalue-from-a-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-cssunitvalue-from-a-pair">4.3.3. Value + Unit: CSSUnitValue objects</a>
     <li><a href="#ref-for-create-a-cssunitvalue-from-a-pair①">4.4. CSSTransformValue objects</a> <a href="#ref-for-create-a-cssunitvalue-from-a-pair②">(2)</a> <a href="#ref-for-create-a-cssunitvalue-from-a-pair③">(3)</a> <a href="#ref-for-create-a-cssunitvalue-from-a-pair④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-cssunitvalue">
-   <b><a href="#convert-a-cssunitvalue">#convert-a-cssunitvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-cssunitvalue" class="dfn-panel" data-for="convert-a-cssunitvalue" id="infopanel-for-convert-a-cssunitvalue" role="dialog">
+   <span id="infopaneltitle-for-convert-a-cssunitvalue" style="display:none">Info about the 'convert a CSSUnitValue' definition.</span><b><a href="#convert-a-cssunitvalue">#convert-a-cssunitvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-cssunitvalue">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-convert-a-cssunitvalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathvalue">
-   <b><a href="#cssmathvalue">#cssmathvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathvalue" class="dfn-panel" data-for="cssmathvalue" id="infopanel-for-cssmathvalue" role="dialog">
+   <span id="infopaneltitle-for-cssmathvalue" style="display:none">Info about the 'CSSMathValue' definition.</span><b><a href="#cssmathvalue">#cssmathvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathvalue">4.3. Numeric Values:</a>
     <li><a href="#ref-for-cssmathvalue①">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathvalue②">(2)</a> <a href="#ref-for-cssmathvalue③">(3)</a> <a href="#ref-for-cssmathvalue④">(4)</a> <a href="#ref-for-cssmathvalue⑤">(5)</a> <a href="#ref-for-cssmathvalue⑥">(6)</a> <a href="#ref-for-cssmathvalue⑦">(7)</a> <a href="#ref-for-cssmathvalue⑧">(8)</a> <a href="#ref-for-cssmathvalue⑨">(9)</a> <a href="#ref-for-cssmathvalue①⓪">(10)</a>
     <li><a href="#ref-for-cssmathvalue①①">6.4. CSSMathValue Serialization</a> <a href="#ref-for-cssmathvalue①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathsum">
-   <b><a href="#cssmathsum">#cssmathsum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathsum" class="dfn-panel" data-for="cssmathsum" id="infopanel-for-cssmathsum" role="dialog">
+   <span id="infopaneltitle-for-cssmathsum" style="display:none">Info about the 'CSSMathSum' definition.</span><b><a href="#cssmathsum">#cssmathsum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathsum">3. The StylePropertyMap</a>
     <li><a href="#ref-for-cssmathsum①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathsum②">(2)</a> <a href="#ref-for-cssmathsum③">(3)</a> <a href="#ref-for-cssmathsum④">(4)</a> <a href="#ref-for-cssmathsum⑤">(5)</a> <a href="#ref-for-cssmathsum⑥">(6)</a> <a href="#ref-for-cssmathsum⑦">(7)</a> <a href="#ref-for-cssmathsum⑧">(8)</a>
@@ -13485,8 +13485,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathsum①④">6.4. CSSMathValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathsum-values">
-   <b><a href="#dom-cssmathsum-values">#dom-cssmathsum-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathsum-values" class="dfn-panel" data-for="dom-cssmathsum-values" id="infopanel-for-dom-cssmathsum-values" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathsum-values" style="display:none">Info about the 'values' definition.</span><b><a href="#dom-cssmathsum-values">#dom-cssmathsum-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathsum-values">3. The StylePropertyMap</a>
     <li><a href="#ref-for-dom-cssmathsum-values①">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathsum-values②">(2)</a> <a href="#ref-for-dom-cssmathsum-values③">(3)</a> <a href="#ref-for-dom-cssmathsum-values④">(4)</a> <a href="#ref-for-dom-cssmathsum-values⑤">(5)</a> <a href="#ref-for-dom-cssmathsum-values⑥">(6)</a> <a href="#ref-for-dom-cssmathsum-values⑦">(7)</a> <a href="#ref-for-dom-cssmathsum-values⑧">(8)</a> <a href="#ref-for-dom-cssmathsum-values⑨">(9)</a>
@@ -13495,8 +13495,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssmathsum-values①③">6.4. CSSMathValue Serialization</a> <a href="#ref-for-dom-cssmathsum-values①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathproduct">
-   <b><a href="#cssmathproduct">#cssmathproduct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathproduct" class="dfn-panel" data-for="cssmathproduct" id="infopanel-for-cssmathproduct" role="dialog">
+   <span id="infopaneltitle-for-cssmathproduct" style="display:none">Info about the 'CSSMathProduct' definition.</span><b><a href="#cssmathproduct">#cssmathproduct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathproduct">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathproduct①">(2)</a> <a href="#ref-for-cssmathproduct②">(3)</a> <a href="#ref-for-cssmathproduct③">(4)</a>
     <li><a href="#ref-for-cssmathproduct④">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathproduct⑤">(2)</a> <a href="#ref-for-cssmathproduct⑥">(3)</a>
@@ -13504,8 +13504,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathproduct⑧">6.4. CSSMathValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathproduct-values">
-   <b><a href="#dom-cssmathproduct-values">#dom-cssmathproduct-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathproduct-values" class="dfn-panel" data-for="dom-cssmathproduct-values" id="infopanel-for-dom-cssmathproduct-values" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathproduct-values" style="display:none">Info about the 'values' definition.</span><b><a href="#dom-cssmathproduct-values">#dom-cssmathproduct-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathproduct-values">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathproduct-values①">(2)</a> <a href="#ref-for-dom-cssmathproduct-values②">(3)</a>
     <li><a href="#ref-for-dom-cssmathproduct-values③">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
@@ -13513,8 +13513,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssmathproduct-values⑤">6.4. CSSMathValue Serialization</a> <a href="#ref-for-dom-cssmathproduct-values⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathnegate">
-   <b><a href="#cssmathnegate">#cssmathnegate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathnegate" class="dfn-panel" data-for="cssmathnegate" id="infopanel-for-cssmathnegate" role="dialog">
+   <span id="infopaneltitle-for-cssmathnegate" style="display:none">Info about the 'CSSMathNegate' definition.</span><b><a href="#cssmathnegate">#cssmathnegate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathnegate">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathnegate①">(2)</a> <a href="#ref-for-cssmathnegate②">(3)</a> <a href="#ref-for-cssmathnegate③">(4)</a>
     <li><a href="#ref-for-cssmathnegate④">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathnegate⑤">(2)</a> <a href="#ref-for-cssmathnegate⑥">(3)</a>
@@ -13522,8 +13522,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathnegate⑧">6.4. CSSMathValue Serialization</a> <a href="#ref-for-cssmathnegate⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathnegate-value">
-   <b><a href="#dom-cssmathnegate-value">#dom-cssmathnegate-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathnegate-value" class="dfn-panel" data-for="dom-cssmathnegate-value" id="infopanel-for-dom-cssmathnegate-value" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathnegate-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-cssmathnegate-value">#dom-cssmathnegate-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathnegate-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathnegate-value①">(2)</a> <a href="#ref-for-dom-cssmathnegate-value②">(3)</a> <a href="#ref-for-dom-cssmathnegate-value③">(4)</a> <a href="#ref-for-dom-cssmathnegate-value④">(5)</a>
     <li><a href="#ref-for-dom-cssmathnegate-value⑤">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-dom-cssmathnegate-value⑥">(2)</a>
@@ -13531,8 +13531,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssmathnegate-value⑧">6.4. CSSMathValue Serialization</a> <a href="#ref-for-dom-cssmathnegate-value⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathinvert">
-   <b><a href="#cssmathinvert">#cssmathinvert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathinvert" class="dfn-panel" data-for="cssmathinvert" id="infopanel-for-cssmathinvert" role="dialog">
+   <span id="infopaneltitle-for-cssmathinvert" style="display:none">Info about the 'CSSMathInvert' definition.</span><b><a href="#cssmathinvert">#cssmathinvert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathinvert">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathinvert①">(2)</a> <a href="#ref-for-cssmathinvert②">(3)</a> <a href="#ref-for-cssmathinvert③">(4)</a>
     <li><a href="#ref-for-cssmathinvert④">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathinvert⑤">(2)</a> <a href="#ref-for-cssmathinvert⑥">(3)</a>
@@ -13540,8 +13540,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathinvert⑧">6.4. CSSMathValue Serialization</a> <a href="#ref-for-cssmathinvert⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathinvert-value">
-   <b><a href="#dom-cssmathinvert-value">#dom-cssmathinvert-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathinvert-value" class="dfn-panel" data-for="dom-cssmathinvert-value" id="infopanel-for-dom-cssmathinvert-value" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathinvert-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-cssmathinvert-value">#dom-cssmathinvert-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathinvert-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathinvert-value①">(2)</a> <a href="#ref-for-dom-cssmathinvert-value②">(3)</a>
     <li><a href="#ref-for-dom-cssmathinvert-value③">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
@@ -13549,8 +13549,8 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-dom-cssmathinvert-value⑤">6.4. CSSMathValue Serialization</a> <a href="#ref-for-dom-cssmathinvert-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathmin">
-   <b><a href="#cssmathmin">#cssmathmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathmin" class="dfn-panel" data-for="cssmathmin" id="infopanel-for-cssmathmin" role="dialog">
+   <span id="infopaneltitle-for-cssmathmin" style="display:none">Info about the 'CSSMathMin' definition.</span><b><a href="#cssmathmin">#cssmathmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathmin">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathmin①">(2)</a> <a href="#ref-for-cssmathmin②">(3)</a> <a href="#ref-for-cssmathmin③">(4)</a>
     <li><a href="#ref-for-cssmathmin④">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathmin⑤">(2)</a> <a href="#ref-for-cssmathmin⑥">(3)</a>
@@ -13558,16 +13558,16 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathmin⑧">6.4. CSSMathValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathmin-values">
-   <b><a href="#dom-cssmathmin-values">#dom-cssmathmin-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathmin-values" class="dfn-panel" data-for="dom-cssmathmin-values" id="infopanel-for-dom-cssmathmin-values" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathmin-values" style="display:none">Info about the 'values' definition.</span><b><a href="#dom-cssmathmin-values">#dom-cssmathmin-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathmin-values">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathmin-values①">(2)</a> <a href="#ref-for-dom-cssmathmin-values②">(3)</a>
     <li><a href="#ref-for-dom-cssmathmin-values③">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a>
     <li><a href="#ref-for-dom-cssmathmin-values④">6.4. CSSMathValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathmax">
-   <b><a href="#cssmathmax">#cssmathmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathmax" class="dfn-panel" data-for="cssmathmax" id="infopanel-for-cssmathmax" role="dialog">
+   <span id="infopaneltitle-for-cssmathmax" style="display:none">Info about the 'CSSMathMax' definition.</span><b><a href="#cssmathmax">#cssmathmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathmax">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-cssmathmax①">(2)</a> <a href="#ref-for-cssmathmax②">(3)</a> <a href="#ref-for-cssmathmax③">(4)</a>
     <li><a href="#ref-for-cssmathmax④">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathmax⑤">(2)</a> <a href="#ref-for-cssmathmax⑥">(3)</a>
@@ -13575,104 +13575,104 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-cssmathmax⑧">6.4. CSSMathValue Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathmax-values">
-   <b><a href="#dom-cssmathmax-values">#dom-cssmathmax-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathmax-values" class="dfn-panel" data-for="dom-cssmathmax-values" id="infopanel-for-dom-cssmathmax-values" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathmax-values" style="display:none">Info about the 'values' definition.</span><b><a href="#dom-cssmathmax-values">#dom-cssmathmax-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathmax-values">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a> <a href="#ref-for-dom-cssmathmax-values①">(2)</a> <a href="#ref-for-dom-cssmathmax-values②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmathclamp">
-   <b><a href="#cssmathclamp">#cssmathclamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmathclamp" class="dfn-panel" data-for="cssmathclamp" id="infopanel-for-cssmathclamp" role="dialog">
+   <span id="infopaneltitle-for-cssmathclamp" style="display:none">Info about the 'CSSMathClamp' definition.</span><b><a href="#cssmathclamp">#cssmathclamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmathclamp">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssmathclamp①">(2)</a> <a href="#ref-for-cssmathclamp②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathclamp-min">
-   <b><a href="#dom-cssmathclamp-min">#dom-cssmathclamp-min</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathclamp-min" class="dfn-panel" data-for="dom-cssmathclamp-min" id="infopanel-for-dom-cssmathclamp-min" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathclamp-min" style="display:none">Info about the 'min' definition.</span><b><a href="#dom-cssmathclamp-min">#dom-cssmathclamp-min</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathclamp-min">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-dom-cssmathclamp-min①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathclamp-val">
-   <b><a href="#dom-cssmathclamp-val">#dom-cssmathclamp-val</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathclamp-val" class="dfn-panel" data-for="dom-cssmathclamp-val" id="infopanel-for-dom-cssmathclamp-val" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathclamp-val" style="display:none">Info about the 'val' definition.</span><b><a href="#dom-cssmathclamp-val">#dom-cssmathclamp-val</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathclamp-val">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-dom-cssmathclamp-val①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathclamp-max">
-   <b><a href="#dom-cssmathclamp-max">#dom-cssmathclamp-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathclamp-max" class="dfn-panel" data-for="dom-cssmathclamp-max" id="infopanel-for-dom-cssmathclamp-max" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathclamp-max" style="display:none">Info about the 'max' definition.</span><b><a href="#dom-cssmathclamp-max">#dom-cssmathclamp-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathclamp-max">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-dom-cssmathclamp-max①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnumericarray">
-   <b><a href="#cssnumericarray">#cssnumericarray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnumericarray" class="dfn-panel" data-for="cssnumericarray" id="infopanel-for-cssnumericarray" role="dialog">
+   <span id="infopaneltitle-for-cssnumericarray" style="display:none">Info about the 'CSSNumericArray' definition.</span><b><a href="#cssnumericarray">#cssnumericarray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericarray">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-cssnumericarray①">(2)</a> <a href="#ref-for-cssnumericarray②">(3)</a> <a href="#ref-for-cssnumericarray③">(4)</a> <a href="#ref-for-cssnumericarray④">(5)</a> <a href="#ref-for-cssnumericarray⑤">(6)</a> <a href="#ref-for-cssnumericarray⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-cssmathoperator">
-   <b><a href="#enumdef-cssmathoperator">#enumdef-cssmathoperator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-cssmathoperator" class="dfn-panel" data-for="enumdef-cssmathoperator" id="infopanel-for-enumdef-cssmathoperator" role="dialog">
+   <span id="infopaneltitle-for-enumdef-cssmathoperator" style="display:none">Info about the 'CSSMathOperator' definition.</span><b><a href="#enumdef-cssmathoperator">#enumdef-cssmathoperator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-cssmathoperator">4.3.4. Complex Numeric Values: CSSMathValue objects</a> <a href="#ref-for-enumdef-cssmathoperator①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathvalue-operator">
-   <b><a href="#dom-cssmathvalue-operator">#dom-cssmathvalue-operator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathvalue-operator" class="dfn-panel" data-for="dom-cssmathvalue-operator" id="infopanel-for-dom-cssmathvalue-operator" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathvalue-operator" style="display:none">Info about the 'operator' definition.</span><b><a href="#dom-cssmathvalue-operator">#dom-cssmathvalue-operator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathvalue-operator">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathsum-cssmathsum">
-   <b><a href="#dom-cssmathsum-cssmathsum">#dom-cssmathsum-cssmathsum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathsum-cssmathsum" class="dfn-panel" data-for="dom-cssmathsum-cssmathsum" id="infopanel-for-dom-cssmathsum-cssmathsum" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathsum-cssmathsum" style="display:none">Info about the 'CSSMathSum(...args)' definition.</span><b><a href="#dom-cssmathsum-cssmathsum">#dom-cssmathsum-cssmathsum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathsum-cssmathsum">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathmin-cssmathmin">
-   <b><a href="#dom-cssmathmin-cssmathmin">#dom-cssmathmin-cssmathmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathmin-cssmathmin" class="dfn-panel" data-for="dom-cssmathmin-cssmathmin" id="infopanel-for-dom-cssmathmin-cssmathmin" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathmin-cssmathmin" style="display:none">Info about the 'CSSMathMin(...args)' definition.</span><b><a href="#dom-cssmathmin-cssmathmin">#dom-cssmathmin-cssmathmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathmin-cssmathmin">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathmax-cssmathmax">
-   <b><a href="#dom-cssmathmax-cssmathmax">#dom-cssmathmax-cssmathmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathmax-cssmathmax" class="dfn-panel" data-for="dom-cssmathmax-cssmathmax" id="infopanel-for-dom-cssmathmax-cssmathmax" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathmax-cssmathmax" style="display:none">Info about the 'CSSMathMax(...args)' definition.</span><b><a href="#dom-cssmathmax-cssmathmax">#dom-cssmathmax-cssmathmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathmax-cssmathmax">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathproduct-cssmathproduct">
-   <b><a href="#dom-cssmathproduct-cssmathproduct">#dom-cssmathproduct-cssmathproduct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathproduct-cssmathproduct" class="dfn-panel" data-for="dom-cssmathproduct-cssmathproduct" id="infopanel-for-dom-cssmathproduct-cssmathproduct" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathproduct-cssmathproduct" style="display:none">Info about the 'CSSMathProduct(...args)' definition.</span><b><a href="#dom-cssmathproduct-cssmathproduct">#dom-cssmathproduct-cssmathproduct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathproduct-cssmathproduct">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathclamp-cssmathclamp">
-   <b><a href="#dom-cssmathclamp-cssmathclamp">#dom-cssmathclamp-cssmathclamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathclamp-cssmathclamp" class="dfn-panel" data-for="dom-cssmathclamp-cssmathclamp" id="infopanel-for-dom-cssmathclamp-cssmathclamp" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathclamp-cssmathclamp" style="display:none">Info about the 'CSSMathClamp(min, val, max)' definition.</span><b><a href="#dom-cssmathclamp-cssmathclamp">#dom-cssmathclamp-cssmathclamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathclamp-cssmathclamp">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathnegate-cssmathnegate">
-   <b><a href="#dom-cssmathnegate-cssmathnegate">#dom-cssmathnegate-cssmathnegate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathnegate-cssmathnegate" class="dfn-panel" data-for="dom-cssmathnegate-cssmathnegate" id="infopanel-for-dom-cssmathnegate-cssmathnegate" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathnegate-cssmathnegate" style="display:none">Info about the 'CSSMathNegate(arg)' definition.</span><b><a href="#dom-cssmathnegate-cssmathnegate">#dom-cssmathnegate-cssmathnegate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathnegate-cssmathnegate">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmathinvert-cssmathinvert">
-   <b><a href="#dom-cssmathinvert-cssmathinvert">#dom-cssmathinvert-cssmathinvert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmathinvert-cssmathinvert" class="dfn-panel" data-for="dom-cssmathinvert-cssmathinvert" id="infopanel-for-dom-cssmathinvert-cssmathinvert" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmathinvert-cssmathinvert" style="display:none">Info about the 'CSSMathInvert(arg)' definition.</span><b><a href="#dom-cssmathinvert-cssmathinvert">#dom-cssmathinvert-cssmathinvert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmathinvert-cssmathinvert">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnumericarray-length">
-   <b><a href="#dom-cssnumericarray-length">#dom-cssnumericarray-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnumericarray-length" class="dfn-panel" data-for="dom-cssnumericarray-length" id="infopanel-for-dom-cssnumericarray-length" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnumericarray-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-cssnumericarray-length">#dom-cssnumericarray-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnumericarray-length">4.3.4. Complex Numeric Values: CSSMathValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csstransformvalue">
-   <b><a href="#csstransformvalue">#csstransformvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csstransformvalue" class="dfn-panel" data-for="csstransformvalue" id="infopanel-for-csstransformvalue" role="dialog">
+   <span id="infopaneltitle-for-csstransformvalue" style="display:none">Info about the 'CSSTransformValue' definition.</span><b><a href="#csstransformvalue">#csstransformvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csstransformvalue">3. The StylePropertyMap</a>
     <li><a href="#ref-for-csstransformvalue①">4.4. CSSTransformValue objects</a> <a href="#ref-for-csstransformvalue②">(2)</a> <a href="#ref-for-csstransformvalue③">(3)</a> <a href="#ref-for-csstransformvalue④">(4)</a> <a href="#ref-for-csstransformvalue⑤">(5)</a> <a href="#ref-for-csstransformvalue⑥">(6)</a> <a href="#ref-for-csstransformvalue⑦">(7)</a> <a href="#ref-for-csstransformvalue⑧">(8)</a> <a href="#ref-for-csstransformvalue⑨">(9)</a> <a href="#ref-for-csstransformvalue①⓪">(10)</a> <a href="#ref-for-csstransformvalue①①">(11)</a>
@@ -13680,559 +13680,559 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-csstransformvalue①④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-csstransformvalue①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformvalue-csstransformvalue">
-   <b><a href="#dom-csstransformvalue-csstransformvalue">#dom-csstransformvalue-csstransformvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformvalue-csstransformvalue" class="dfn-panel" data-for="dom-csstransformvalue-csstransformvalue" id="infopanel-for-dom-csstransformvalue-csstransformvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformvalue-csstransformvalue" style="display:none">Info about the 'CSSTransformValue(transforms)' definition.</span><b><a href="#dom-csstransformvalue-csstransformvalue">#dom-csstransformvalue-csstransformvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformvalue-csstransformvalue">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformvalue-is2d">
-   <b><a href="#dom-csstransformvalue-is2d">#dom-csstransformvalue-is2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformvalue-is2d" class="dfn-panel" data-for="dom-csstransformvalue-is2d" id="infopanel-for-dom-csstransformvalue-is2d" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformvalue-is2d" style="display:none">Info about the 'is2D' definition.</span><b><a href="#dom-csstransformvalue-is2d">#dom-csstransformvalue-is2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformvalue-is2d">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-csstransformvalue-is2d①">(2)</a> <a href="#ref-for-dom-csstransformvalue-is2d②">(3)</a>
     <li><a href="#ref-for-dom-csstransformvalue-is2d③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-csstransformvalue-is2d④">(2)</a> <a href="#ref-for-dom-csstransformvalue-is2d⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformvalue-tomatrix">
-   <b><a href="#dom-csstransformvalue-tomatrix">#dom-csstransformvalue-tomatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformvalue-tomatrix" class="dfn-panel" data-for="dom-csstransformvalue-tomatrix" id="infopanel-for-dom-csstransformvalue-tomatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformvalue-tomatrix" style="display:none">Info about the 'toMatrix()' definition.</span><b><a href="#dom-csstransformvalue-tomatrix">#dom-csstransformvalue-tomatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformvalue-tomatrix">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformvalue-length">
-   <b><a href="#dom-csstransformvalue-length">#dom-csstransformvalue-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformvalue-length" class="dfn-panel" data-for="dom-csstransformvalue-length" id="infopanel-for-dom-csstransformvalue-length" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformvalue-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-csstransformvalue-length">#dom-csstransformvalue-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformvalue-length">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformvalue-values-slot">
-   <b><a href="#dom-csstransformvalue-values-slot">#dom-csstransformvalue-values-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformvalue-values-slot" class="dfn-panel" data-for="dom-csstransformvalue-values-slot" id="infopanel-for-dom-csstransformvalue-values-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformvalue-values-slot" style="display:none">Info about the '[[values]]' definition.</span><b><a href="#dom-csstransformvalue-values-slot">#dom-csstransformvalue-values-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformvalue-values-slot">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-csstransformvalue-values-slot①">(2)</a> <a href="#ref-for-dom-csstransformvalue-values-slot②">(3)</a> <a href="#ref-for-dom-csstransformvalue-values-slot③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csstransformcomponent">
-   <b><a href="#csstransformcomponent">#csstransformcomponent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csstransformcomponent" class="dfn-panel" data-for="csstransformcomponent" id="infopanel-for-csstransformcomponent" role="dialog">
+   <span id="infopaneltitle-for-csstransformcomponent" style="display:none">Info about the 'CSSTransformComponent' definition.</span><b><a href="#csstransformcomponent">#csstransformcomponent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csstransformcomponent">4.4. CSSTransformValue objects</a> <a href="#ref-for-csstransformcomponent①">(2)</a> <a href="#ref-for-csstransformcomponent②">(3)</a> <a href="#ref-for-csstransformcomponent③">(4)</a> <a href="#ref-for-csstransformcomponent④">(5)</a> <a href="#ref-for-csstransformcomponent⑤">(6)</a> <a href="#ref-for-csstransformcomponent⑥">(7)</a> <a href="#ref-for-csstransformcomponent⑦">(8)</a> <a href="#ref-for-csstransformcomponent⑧">(9)</a> <a href="#ref-for-csstransformcomponent⑨">(10)</a> <a href="#ref-for-csstransformcomponent①⓪">(11)</a> <a href="#ref-for-csstransformcomponent①①">(12)</a> <a href="#ref-for-csstransformcomponent①②">(13)</a> <a href="#ref-for-csstransformcomponent①③">(14)</a> <a href="#ref-for-csstransformcomponent①④">(15)</a> <a href="#ref-for-csstransformcomponent①⑤">(16)</a> <a href="#ref-for-csstransformcomponent①⑥">(17)</a> <a href="#ref-for-csstransformcomponent①⑦">(18)</a> <a href="#ref-for-csstransformcomponent①⑧">(19)</a>
     <li><a href="#ref-for-csstransformcomponent①⑨">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-csstransformcomponent②⓪">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csstranslate">
-   <b><a href="#csstranslate">#csstranslate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csstranslate" class="dfn-panel" data-for="csstranslate" id="infopanel-for-csstranslate" role="dialog">
+   <span id="infopaneltitle-for-csstranslate" style="display:none">Info about the 'CSSTranslate' definition.</span><b><a href="#csstranslate">#csstranslate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csstranslate">4.4. CSSTransformValue objects</a> <a href="#ref-for-csstranslate①">(2)</a>
     <li><a href="#ref-for-csstranslate②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-csstranslate③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstranslate-x">
-   <b><a href="#dom-csstranslate-x">#dom-csstranslate-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstranslate-x" class="dfn-panel" data-for="dom-csstranslate-x" id="infopanel-for-dom-csstranslate-x" role="dialog">
+   <span id="infopaneltitle-for-dom-csstranslate-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-csstranslate-x">#dom-csstranslate-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstranslate-x">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-csstranslate-x①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-csstranslate-x②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-csstranslate-x③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstranslate-y">
-   <b><a href="#dom-csstranslate-y">#dom-csstranslate-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstranslate-y" class="dfn-panel" data-for="dom-csstranslate-y" id="infopanel-for-dom-csstranslate-y" role="dialog">
+   <span id="infopaneltitle-for-dom-csstranslate-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-csstranslate-y">#dom-csstranslate-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstranslate-y">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-csstranslate-y①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-csstranslate-y②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-csstranslate-y③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstranslate-z">
-   <b><a href="#dom-csstranslate-z">#dom-csstranslate-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstranslate-z" class="dfn-panel" data-for="dom-csstranslate-z" id="infopanel-for-dom-csstranslate-z" role="dialog">
+   <span id="infopaneltitle-for-dom-csstranslate-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-csstranslate-z">#dom-csstranslate-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstranslate-z">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-csstranslate-z①">(2)</a> <a href="#ref-for-dom-csstranslate-z②">(3)</a>
     <li><a href="#ref-for-dom-csstranslate-z③">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-csstranslate-z④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssrotate">
-   <b><a href="#cssrotate">#cssrotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssrotate" class="dfn-panel" data-for="cssrotate" id="infopanel-for-cssrotate" role="dialog">
+   <span id="infopaneltitle-for-cssrotate" style="display:none">Info about the 'CSSRotate' definition.</span><b><a href="#cssrotate">#cssrotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrotate">4.4. CSSTransformValue objects</a> <a href="#ref-for-cssrotate①">(2)</a>
     <li><a href="#ref-for-cssrotate②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssrotate③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-angle">
-   <b><a href="#dom-cssrotate-angle">#dom-cssrotate-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-angle" class="dfn-panel" data-for="dom-cssrotate-angle" id="infopanel-for-dom-cssrotate-angle" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-angle" style="display:none">Info about the 'angle' definition.</span><b><a href="#dom-cssrotate-angle">#dom-cssrotate-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-angle">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssrotate-angle①">(2)</a>
     <li><a href="#ref-for-dom-cssrotate-angle②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssrotate-angle③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-cssrotate-angle④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssscale">
-   <b><a href="#cssscale">#cssscale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssscale" class="dfn-panel" data-for="cssscale" id="infopanel-for-cssscale" role="dialog">
+   <span id="infopaneltitle-for-cssscale" style="display:none">Info about the 'CSSScale' definition.</span><b><a href="#cssscale">#cssscale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssscale">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-cssscale①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssscale②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssskew">
-   <b><a href="#cssskew">#cssskew</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssskew" class="dfn-panel" data-for="cssskew" id="infopanel-for-cssskew" role="dialog">
+   <span id="infopaneltitle-for-cssskew" style="display:none">Info about the 'CSSSkew' definition.</span><b><a href="#cssskew">#cssskew</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssskew">4.4. CSSTransformValue objects</a> <a href="#ref-for-cssskew①">(2)</a>
     <li><a href="#ref-for-cssskew②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssskew③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskew-ax">
-   <b><a href="#dom-cssskew-ax">#dom-cssskew-ax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskew-ax" class="dfn-panel" data-for="dom-cssskew-ax" id="infopanel-for-dom-cssskew-ax" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskew-ax" style="display:none">Info about the 'ax' definition.</span><b><a href="#dom-cssskew-ax">#dom-cssskew-ax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskew-ax">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssskew-ax①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssskew-ax②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskew-ay">
-   <b><a href="#dom-cssskew-ay">#dom-cssskew-ay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskew-ay" class="dfn-panel" data-for="dom-cssskew-ay" id="infopanel-for-dom-cssskew-ay" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskew-ay" style="display:none">Info about the 'ay' definition.</span><b><a href="#dom-cssskew-ay">#dom-cssskew-ay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskew-ay">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssskew-ay①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssskew-ay②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-cssskew-ay③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssskewx">
-   <b><a href="#cssskewx">#cssskewx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssskewx" class="dfn-panel" data-for="cssskewx" id="infopanel-for-cssskewx" role="dialog">
+   <span id="infopaneltitle-for-cssskewx" style="display:none">Info about the 'CSSSkewX' definition.</span><b><a href="#cssskewx">#cssskewx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssskewx">4.4. CSSTransformValue objects</a> <a href="#ref-for-cssskewx①">(2)</a>
     <li><a href="#ref-for-cssskewx②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssskewx③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskewx-ax">
-   <b><a href="#dom-cssskewx-ax">#dom-cssskewx-ax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskewx-ax" class="dfn-panel" data-for="dom-cssskewx-ax" id="infopanel-for-dom-cssskewx-ax" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskewx-ax" style="display:none">Info about the 'ax' definition.</span><b><a href="#dom-cssskewx-ax">#dom-cssskewx-ax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskewx-ax">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssskewx-ax①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssskewx-ax②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssskewy">
-   <b><a href="#cssskewy">#cssskewy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssskewy" class="dfn-panel" data-for="cssskewy" id="infopanel-for-cssskewy" role="dialog">
+   <span id="infopaneltitle-for-cssskewy" style="display:none">Info about the 'CSSSkewY' definition.</span><b><a href="#cssskewy">#cssskewy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssskewy">4.4. CSSTransformValue objects</a> <a href="#ref-for-cssskewy①">(2)</a>
     <li><a href="#ref-for-cssskewy②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssskewy③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskewy-ay">
-   <b><a href="#dom-cssskewy-ay">#dom-cssskewy-ay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskewy-ay" class="dfn-panel" data-for="dom-cssskewy-ay" id="infopanel-for-dom-cssskewy-ay" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskewy-ay" style="display:none">Info about the 'ay' definition.</span><b><a href="#dom-cssskewy-ay">#dom-cssskewy-ay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskewy-ay">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssskewy-ay①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssskewy-ay②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssperspective">
-   <b><a href="#cssperspective">#cssperspective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssperspective" class="dfn-panel" data-for="cssperspective" id="infopanel-for-cssperspective" role="dialog">
+   <span id="infopaneltitle-for-cssperspective" style="display:none">Info about the 'CSSPerspective' definition.</span><b><a href="#cssperspective">#cssperspective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssperspective">4.4. CSSTransformValue objects</a> <a href="#ref-for-cssperspective①">(2)</a>
     <li><a href="#ref-for-cssperspective②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssperspective③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssperspective-length">
-   <b><a href="#dom-cssperspective-length">#dom-cssperspective-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssperspective-length" class="dfn-panel" data-for="dom-cssperspective-length" id="infopanel-for-dom-cssperspective-length" role="dialog">
+   <span id="infopaneltitle-for-dom-cssperspective-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-cssperspective-length">#dom-cssperspective-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssperspective-length">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssperspective-length①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssperspective-length②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmatrixcomponent">
-   <b><a href="#cssmatrixcomponent">#cssmatrixcomponent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmatrixcomponent" class="dfn-panel" data-for="cssmatrixcomponent" id="infopanel-for-cssmatrixcomponent" role="dialog">
+   <span id="infopaneltitle-for-cssmatrixcomponent" style="display:none">Info about the 'CSSMatrixComponent' definition.</span><b><a href="#cssmatrixcomponent">#cssmatrixcomponent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmatrixcomponent">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-cssmatrixcomponent①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-cssmatrixcomponent②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmatrixcomponent-matrix">
-   <b><a href="#dom-cssmatrixcomponent-matrix">#dom-cssmatrixcomponent-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmatrixcomponent-matrix" class="dfn-panel" data-for="dom-cssmatrixcomponent-matrix" id="infopanel-for-dom-cssmatrixcomponent-matrix" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmatrixcomponent-matrix" style="display:none">Info about the 'matrix' definition.</span><b><a href="#dom-cssmatrixcomponent-matrix">#dom-cssmatrixcomponent-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmatrixcomponent-matrix">4.4. CSSTransformValue objects</a>
     <li><a href="#ref-for-dom-cssmatrixcomponent-matrix①">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssmatrixcomponent-matrix②">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-cssmatrixcomponentoptions">
-   <b><a href="#dictdef-cssmatrixcomponentoptions">#dictdef-cssmatrixcomponentoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-cssmatrixcomponentoptions" class="dfn-panel" data-for="dictdef-cssmatrixcomponentoptions" id="infopanel-for-dictdef-cssmatrixcomponentoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-cssmatrixcomponentoptions" style="display:none">Info about the 'CSSMatrixComponentOptions' definition.</span><b><a href="#dictdef-cssmatrixcomponentoptions">#dictdef-cssmatrixcomponentoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-cssmatrixcomponentoptions">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmatrixcomponentoptions-is2d">
-   <b><a href="#dom-cssmatrixcomponentoptions-is2d">#dom-cssmatrixcomponentoptions-is2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmatrixcomponentoptions-is2d" class="dfn-panel" data-for="dom-cssmatrixcomponentoptions-is2d" id="infopanel-for-dom-cssmatrixcomponentoptions-is2d" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmatrixcomponentoptions-is2d" style="display:none">Info about the 'is2D' definition.</span><b><a href="#dom-cssmatrixcomponentoptions-is2d">#dom-cssmatrixcomponentoptions-is2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmatrixcomponentoptions-is2d">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformcomponent-is2d">
-   <b><a href="#dom-csstransformcomponent-is2d">#dom-csstransformcomponent-is2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformcomponent-is2d" class="dfn-panel" data-for="dom-csstransformcomponent-is2d" id="infopanel-for-dom-csstransformcomponent-is2d" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformcomponent-is2d" style="display:none">Info about the 'is2D' definition.</span><b><a href="#dom-csstransformcomponent-is2d">#dom-csstransformcomponent-is2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformcomponent-is2d">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-csstransformcomponent-is2d①">(2)</a> <a href="#ref-for-dom-csstransformcomponent-is2d②">(3)</a> <a href="#ref-for-dom-csstransformcomponent-is2d③">(4)</a> <a href="#ref-for-dom-csstransformcomponent-is2d④">(5)</a> <a href="#ref-for-dom-csstransformcomponent-is2d⑤">(6)</a> <a href="#ref-for-dom-csstransformcomponent-is2d⑥">(7)</a> <a href="#ref-for-dom-csstransformcomponent-is2d⑦">(8)</a> <a href="#ref-for-dom-csstransformcomponent-is2d⑧">(9)</a> <a href="#ref-for-dom-csstransformcomponent-is2d⑨">(10)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①⓪">(11)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①①">(12)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①②">(13)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①③">(14)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①④">(15)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①⑤">(16)</a>
     <li><a href="#ref-for-dom-csstransformcomponent-is2d①⑥">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-dom-csstransformcomponent-is2d①⑦">(2)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①⑧">(3)</a> <a href="#ref-for-dom-csstransformcomponent-is2d①⑨">(4)</a> <a href="#ref-for-dom-csstransformcomponent-is2d②⓪">(5)</a> <a href="#ref-for-dom-csstransformcomponent-is2d②①">(6)</a> <a href="#ref-for-dom-csstransformcomponent-is2d②②">(7)</a> <a href="#ref-for-dom-csstransformcomponent-is2d②③">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransformcomponent-tomatrix">
-   <b><a href="#dom-csstransformcomponent-tomatrix">#dom-csstransformcomponent-tomatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransformcomponent-tomatrix" class="dfn-panel" data-for="dom-csstransformcomponent-tomatrix" id="infopanel-for-dom-csstransformcomponent-tomatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransformcomponent-tomatrix" style="display:none">Info about the 'toMatrix()' definition.</span><b><a href="#dom-csstransformcomponent-tomatrix">#dom-csstransformcomponent-tomatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransformcomponent-tomatrix">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-csstransformcomponent-tomatrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstranslate-csstranslate">
-   <b><a href="#dom-csstranslate-csstranslate">#dom-csstranslate-csstranslate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstranslate-csstranslate" class="dfn-panel" data-for="dom-csstranslate-csstranslate" id="infopanel-for-dom-csstranslate-csstranslate" role="dialog">
+   <span id="infopaneltitle-for-dom-csstranslate-csstranslate" style="display:none">Info about the 'CSSTranslate(x, y, z)' definition.</span><b><a href="#dom-csstranslate-csstranslate">#dom-csstranslate-csstranslate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstranslate-csstranslate">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-cssrotate">
-   <b><a href="#dom-cssrotate-cssrotate">#dom-cssrotate-cssrotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-cssrotate" class="dfn-panel" data-for="dom-cssrotate-cssrotate" id="infopanel-for-dom-cssrotate-cssrotate" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-cssrotate" style="display:none">Info about the 'CSSRotate(angle)' definition.</span><b><a href="#dom-cssrotate-cssrotate">#dom-cssrotate-cssrotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-cssrotate">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-cssrotate-x-y-z-angle">
-   <b><a href="#dom-cssrotate-cssrotate-x-y-z-angle">#dom-cssrotate-cssrotate-x-y-z-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-cssrotate-x-y-z-angle" class="dfn-panel" data-for="dom-cssrotate-cssrotate-x-y-z-angle" id="infopanel-for-dom-cssrotate-cssrotate-x-y-z-angle" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-cssrotate-x-y-z-angle" style="display:none">Info about the 'CSSRotate(x, y, z, angle)' definition.</span><b><a href="#dom-cssrotate-cssrotate-x-y-z-angle">#dom-cssrotate-cssrotate-x-y-z-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-cssrotate-x-y-z-angle">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-x">
-   <b><a href="#dom-cssrotate-x">#dom-cssrotate-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-x" class="dfn-panel" data-for="dom-cssrotate-x" id="infopanel-for-dom-cssrotate-x" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-cssrotate-x">#dom-cssrotate-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-x">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssrotate-x①">(2)</a> <a href="#ref-for-dom-cssrotate-x②">(3)</a>
     <li><a href="#ref-for-dom-cssrotate-x③">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssrotate-x④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-y">
-   <b><a href="#dom-cssrotate-y">#dom-cssrotate-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-y" class="dfn-panel" data-for="dom-cssrotate-y" id="infopanel-for-dom-cssrotate-y" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-cssrotate-y">#dom-cssrotate-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-y">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssrotate-y①">(2)</a> <a href="#ref-for-dom-cssrotate-y②">(3)</a>
     <li><a href="#ref-for-dom-cssrotate-y③">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssrotate-y④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrotate-z">
-   <b><a href="#dom-cssrotate-z">#dom-cssrotate-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrotate-z" class="dfn-panel" data-for="dom-cssrotate-z" id="infopanel-for-dom-cssrotate-z" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrotate-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-cssrotate-z">#dom-cssrotate-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrotate-z">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssrotate-z①">(2)</a> <a href="#ref-for-dom-cssrotate-z②">(3)</a>
     <li><a href="#ref-for-dom-cssrotate-z③">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssrotate-z④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscale-cssscale">
-   <b><a href="#dom-cssscale-cssscale">#dom-cssscale-cssscale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscale-cssscale" class="dfn-panel" data-for="dom-cssscale-cssscale" id="infopanel-for-dom-cssscale-cssscale" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscale-cssscale" style="display:none">Info about the 'CSSScale(x, y, z)' definition.</span><b><a href="#dom-cssscale-cssscale">#dom-cssscale-cssscale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscale-cssscale">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscale-x">
-   <b><a href="#dom-cssscale-x">#dom-cssscale-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscale-x" class="dfn-panel" data-for="dom-cssscale-x" id="infopanel-for-dom-cssscale-x" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscale-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-cssscale-x">#dom-cssscale-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscale-x">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssscale-x①">(2)</a>
     <li><a href="#ref-for-dom-cssscale-x②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssscale-x③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-cssscale-x④">(2)</a> <a href="#ref-for-dom-cssscale-x⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscale-y">
-   <b><a href="#dom-cssscale-y">#dom-cssscale-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscale-y" class="dfn-panel" data-for="dom-cssscale-y" id="infopanel-for-dom-cssscale-y" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscale-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-cssscale-y">#dom-cssscale-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscale-y">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssscale-y①">(2)</a>
     <li><a href="#ref-for-dom-cssscale-y②">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssscale-y③">6.5. CSSTransformValue and CSSTransformComponent Serialization</a> <a href="#ref-for-dom-cssscale-y④">(2)</a> <a href="#ref-for-dom-cssscale-y⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscale-z">
-   <b><a href="#dom-cssscale-z">#dom-cssscale-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscale-z" class="dfn-panel" data-for="dom-cssscale-z" id="infopanel-for-dom-cssscale-z" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscale-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-cssscale-z">#dom-cssscale-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscale-z">4.4. CSSTransformValue objects</a> <a href="#ref-for-dom-cssscale-z①">(2)</a> <a href="#ref-for-dom-cssscale-z②">(3)</a>
     <li><a href="#ref-for-dom-cssscale-z③">5.7. &lt;transform-list> and &lt;transform-function> values</a>
     <li><a href="#ref-for-dom-cssscale-z④">6.5. CSSTransformValue and CSSTransformComponent Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskew-cssskew">
-   <b><a href="#dom-cssskew-cssskew">#dom-cssskew-cssskew</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskew-cssskew" class="dfn-panel" data-for="dom-cssskew-cssskew" id="infopanel-for-dom-cssskew-cssskew" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskew-cssskew" style="display:none">Info about the 'CSSSkew(ax, ay)' definition.</span><b><a href="#dom-cssskew-cssskew">#dom-cssskew-cssskew</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskew-cssskew">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskewx-cssskewx">
-   <b><a href="#dom-cssskewx-cssskewx">#dom-cssskewx-cssskewx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskewx-cssskewx" class="dfn-panel" data-for="dom-cssskewx-cssskewx" id="infopanel-for-dom-cssskewx-cssskewx" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskewx-cssskewx" style="display:none">Info about the 'CSSSkewX(ax)' definition.</span><b><a href="#dom-cssskewx-cssskewx">#dom-cssskewx-cssskewx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskewx-cssskewx">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssskewy-cssskewy">
-   <b><a href="#dom-cssskewy-cssskewy">#dom-cssskewy-cssskewy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssskewy-cssskewy" class="dfn-panel" data-for="dom-cssskewy-cssskewy" id="infopanel-for-dom-cssskewy-cssskewy" role="dialog">
+   <span id="infopaneltitle-for-dom-cssskewy-cssskewy" style="display:none">Info about the 'CSSSkewY(ay)' definition.</span><b><a href="#dom-cssskewy-cssskewy">#dom-cssskewy-cssskewy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssskewy-cssskewy">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssperspective-cssperspective">
-   <b><a href="#dom-cssperspective-cssperspective">#dom-cssperspective-cssperspective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssperspective-cssperspective" class="dfn-panel" data-for="dom-cssperspective-cssperspective" id="infopanel-for-dom-cssperspective-cssperspective" role="dialog">
+   <span id="infopaneltitle-for-dom-cssperspective-cssperspective" style="display:none">Info about the 'CSSPerspective(length)' definition.</span><b><a href="#dom-cssperspective-cssperspective">#dom-cssperspective-cssperspective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssperspective-cssperspective">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmatrixcomponent-cssmatrixcomponent">
-   <b><a href="#dom-cssmatrixcomponent-cssmatrixcomponent">#dom-cssmatrixcomponent-cssmatrixcomponent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmatrixcomponent-cssmatrixcomponent" class="dfn-panel" data-for="dom-cssmatrixcomponent-cssmatrixcomponent" id="infopanel-for-dom-cssmatrixcomponent-cssmatrixcomponent" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmatrixcomponent-cssmatrixcomponent" style="display:none">Info about the 'CSSMatrixComponent(matrix, options)' definition.</span><b><a href="#dom-cssmatrixcomponent-cssmatrixcomponent">#dom-cssmatrixcomponent-cssmatrixcomponent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmatrixcomponent-cssmatrixcomponent">4.4. CSSTransformValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssimagevalue">
-   <b><a href="#cssimagevalue">#cssimagevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssimagevalue" class="dfn-panel" data-for="cssimagevalue" id="infopanel-for-cssimagevalue" role="dialog">
+   <span id="infopaneltitle-for-cssimagevalue" style="display:none">Info about the 'CSSImageValue' definition.</span><b><a href="#cssimagevalue">#cssimagevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssimagevalue">3. The StylePropertyMap</a>
     <li><a href="#ref-for-cssimagevalue①">4.5. CSSImageValue objects</a> <a href="#ref-for-cssimagevalue②">(2)</a> <a href="#ref-for-cssimagevalue③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csscolorvalue">
-   <b><a href="#csscolorvalue">#csscolorvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csscolorvalue" class="dfn-panel" data-for="csscolorvalue" id="infopanel-for-csscolorvalue" role="dialog">
+   <span id="infopaneltitle-for-csscolorvalue" style="display:none">Info about the 'CSSColorValue' definition.</span><b><a href="#csscolorvalue">#csscolorvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csscolorvalue">4.6. CSSColorValue objects</a> <a href="#ref-for-csscolorvalue①">(2)</a> <a href="#ref-for-csscolorvalue②">(3)</a> <a href="#ref-for-csscolorvalue③">(4)</a> <a href="#ref-for-csscolorvalue④">(5)</a> <a href="#ref-for-csscolorvalue⑤">(6)</a> <a href="#ref-for-csscolorvalue⑥">(7)</a> <a href="#ref-for-csscolorvalue⑦">(8)</a> <a href="#ref-for-csscolorvalue⑧">(9)</a> <a href="#ref-for-csscolorvalue⑨">(10)</a> <a href="#ref-for-csscolorvalue①⓪">(11)</a> <a href="#ref-for-csscolorvalue①①">(12)</a> <a href="#ref-for-csscolorvalue①②">(13)</a> <a href="#ref-for-csscolorvalue①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-torgb">
-   <b><a href="#dom-csscolorvalue-torgb">#dom-csscolorvalue-torgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-torgb" class="dfn-panel" data-for="dom-csscolorvalue-torgb" id="infopanel-for-dom-csscolorvalue-torgb" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-torgb" style="display:none">Info about the 'toRGB()' definition.</span><b><a href="#dom-csscolorvalue-torgb">#dom-csscolorvalue-torgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-torgb">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csscolorvalue-torgb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-tohsl">
-   <b><a href="#dom-csscolorvalue-tohsl">#dom-csscolorvalue-tohsl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-tohsl" class="dfn-panel" data-for="dom-csscolorvalue-tohsl" id="infopanel-for-dom-csscolorvalue-tohsl" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-tohsl" style="display:none">Info about the 'toHSL()' definition.</span><b><a href="#dom-csscolorvalue-tohsl">#dom-csscolorvalue-tohsl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-tohsl">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-tohwb">
-   <b><a href="#dom-csscolorvalue-tohwb">#dom-csscolorvalue-tohwb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-tohwb" class="dfn-panel" data-for="dom-csscolorvalue-tohwb" id="infopanel-for-dom-csscolorvalue-tohwb" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-tohwb" style="display:none">Info about the 'toHWB()' definition.</span><b><a href="#dom-csscolorvalue-tohwb">#dom-csscolorvalue-tohwb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-tohwb">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-togray">
-   <b><a href="#dom-csscolorvalue-togray">#dom-csscolorvalue-togray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-togray" class="dfn-panel" data-for="dom-csscolorvalue-togray" id="infopanel-for-dom-csscolorvalue-togray" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-togray" style="display:none">Info about the 'toGray()' definition.</span><b><a href="#dom-csscolorvalue-togray">#dom-csscolorvalue-togray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-togray">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-tolch">
-   <b><a href="#dom-csscolorvalue-tolch">#dom-csscolorvalue-tolch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-tolch" class="dfn-panel" data-for="dom-csscolorvalue-tolch" id="infopanel-for-dom-csscolorvalue-tolch" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-tolch" style="display:none">Info about the 'toLCH()' definition.</span><b><a href="#dom-csscolorvalue-tolch">#dom-csscolorvalue-tolch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-tolch">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-tolab">
-   <b><a href="#dom-csscolorvalue-tolab">#dom-csscolorvalue-tolab</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-tolab" class="dfn-panel" data-for="dom-csscolorvalue-tolab" id="infopanel-for-dom-csscolorvalue-tolab" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-tolab" style="display:none">Info about the 'toLab()' definition.</span><b><a href="#dom-csscolorvalue-tolab">#dom-csscolorvalue-tolab</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-tolab">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-tocolor">
-   <b><a href="#dom-csscolorvalue-tocolor">#dom-csscolorvalue-tocolor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-tocolor" class="dfn-panel" data-for="dom-csscolorvalue-tocolor" id="infopanel-for-dom-csscolorvalue-tocolor" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-tocolor" style="display:none">Info about the 'toColor(colorspace)' definition.</span><b><a href="#dom-csscolorvalue-tocolor">#dom-csscolorvalue-tocolor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-tocolor">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolorvalue-parse">
-   <b><a href="#dom-csscolorvalue-parse">#dom-csscolorvalue-parse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolorvalue-parse" class="dfn-panel" data-for="dom-csscolorvalue-parse" id="infopanel-for-dom-csscolorvalue-parse" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolorvalue-parse" style="display:none">Info about the 'parse(cssText)' definition.</span><b><a href="#dom-csscolorvalue-parse">#dom-csscolorvalue-parse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolorvalue-parse">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssrgb">
-   <b><a href="#cssrgb">#cssrgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssrgb" class="dfn-panel" data-for="cssrgb" id="infopanel-for-cssrgb" role="dialog">
+   <span id="infopaneltitle-for-cssrgb" style="display:none">Info about the 'CSSRGB' definition.</span><b><a href="#cssrgb">#cssrgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrgb">4.6. CSSColorValue objects</a> <a href="#ref-for-cssrgb①">(2)</a> <a href="#ref-for-cssrgb②">(3)</a> <a href="#ref-for-cssrgb③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csshsl">
-   <b><a href="#csshsl">#csshsl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csshsl" class="dfn-panel" data-for="csshsl" id="infopanel-for-csshsl" role="dialog">
+   <span id="infopaneltitle-for-csshsl" style="display:none">Info about the 'CSSHSL' definition.</span><b><a href="#csshsl">#csshsl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csshsl">4.6. CSSColorValue objects</a> <a href="#ref-for-csshsl①">(2)</a> <a href="#ref-for-csshsl②">(3)</a> <a href="#ref-for-csshsl③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshsl-h">
-   <b><a href="#dom-csshsl-h">#dom-csshsl-h</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshsl-h" class="dfn-panel" data-for="dom-csshsl-h" id="infopanel-for-dom-csshsl-h" role="dialog">
+   <span id="infopaneltitle-for-dom-csshsl-h" style="display:none">Info about the 'h' definition.</span><b><a href="#dom-csshsl-h">#dom-csshsl-h</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshsl-h">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csshwb">
-   <b><a href="#csshwb">#csshwb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csshwb" class="dfn-panel" data-for="csshwb" id="infopanel-for-csshwb" role="dialog">
+   <span id="infopaneltitle-for-csshwb" style="display:none">Info about the 'CSSHWB' definition.</span><b><a href="#csshwb">#csshwb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csshwb">4.6. CSSColorValue objects</a> <a href="#ref-for-csshwb①">(2)</a> <a href="#ref-for-csshwb②">(3)</a> <a href="#ref-for-csshwb③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshwb-h">
-   <b><a href="#dom-csshwb-h">#dom-csshwb-h</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshwb-h" class="dfn-panel" data-for="dom-csshwb-h" id="infopanel-for-dom-csshwb-h" role="dialog">
+   <span id="infopaneltitle-for-dom-csshwb-h" style="display:none">Info about the 'h' definition.</span><b><a href="#dom-csshwb-h">#dom-csshwb-h</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshwb-h">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssgray">
-   <b><a href="#cssgray">#cssgray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssgray" class="dfn-panel" data-for="cssgray" id="infopanel-for-cssgray" role="dialog">
+   <span id="infopaneltitle-for-cssgray" style="display:none">Info about the 'CSSGray' definition.</span><b><a href="#cssgray">#cssgray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssgray">4.6. CSSColorValue objects</a> <a href="#ref-for-cssgray①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csslch">
-   <b><a href="#csslch">#csslch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csslch" class="dfn-panel" data-for="csslch" id="infopanel-for-csslch" role="dialog">
+   <span id="infopaneltitle-for-csslch" style="display:none">Info about the 'CSSLCH' definition.</span><b><a href="#csslch">#csslch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csslch">4.6. CSSColorValue objects</a> <a href="#ref-for-csslch①">(2)</a> <a href="#ref-for-csslch②">(3)</a> <a href="#ref-for-csslch③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslch-h">
-   <b><a href="#dom-csslch-h">#dom-csslch-h</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslch-h" class="dfn-panel" data-for="dom-csslch-h" id="infopanel-for-dom-csslch-h" role="dialog">
+   <span id="infopaneltitle-for-dom-csslch-h" style="display:none">Info about the 'h' definition.</span><b><a href="#dom-csslch-h">#dom-csslch-h</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslch-h">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csslab">
-   <b><a href="#csslab">#csslab</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csslab" class="dfn-panel" data-for="csslab" id="infopanel-for-csslab" role="dialog">
+   <span id="infopaneltitle-for-csslab" style="display:none">Info about the 'CSSLab' definition.</span><b><a href="#csslab">#csslab</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csslab">4.6. CSSColorValue objects</a> <a href="#ref-for-csslab①">(2)</a> <a href="#ref-for-csslab②">(3)</a> <a href="#ref-for-csslab③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csscolor">
-   <b><a href="#csscolor">#csscolor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csscolor" class="dfn-panel" data-for="csscolor" id="infopanel-for-csscolor" role="dialog">
+   <span id="infopaneltitle-for-csscolor" style="display:none">Info about the 'CSSColor' definition.</span><b><a href="#csscolor">#csscolor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csscolor">4.6. CSSColorValue objects</a> <a href="#ref-for-csscolor①">(2)</a> <a href="#ref-for-csscolor②">(3)</a> <a href="#ref-for-csscolor③">(4)</a> <a href="#ref-for-csscolor④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrgb-r">
-   <b><a href="#dom-cssrgb-r">#dom-cssrgb-r</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrgb-r" class="dfn-panel" data-for="dom-cssrgb-r" id="infopanel-for-dom-cssrgb-r" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrgb-r" style="display:none">Info about the 'r' definition.</span><b><a href="#dom-cssrgb-r">#dom-cssrgb-r</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrgb-r">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-cssrgb-r①">(2)</a> <a href="#ref-for-dom-cssrgb-r②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrgb-g">
-   <b><a href="#dom-cssrgb-g">#dom-cssrgb-g</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrgb-g" class="dfn-panel" data-for="dom-cssrgb-g" id="infopanel-for-dom-cssrgb-g" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrgb-g" style="display:none">Info about the 'g' definition.</span><b><a href="#dom-cssrgb-g">#dom-cssrgb-g</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrgb-g">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-cssrgb-g①">(2)</a> <a href="#ref-for-dom-cssrgb-g②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrgb-b">
-   <b><a href="#dom-cssrgb-b">#dom-cssrgb-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrgb-b" class="dfn-panel" data-for="dom-cssrgb-b" id="infopanel-for-dom-cssrgb-b" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrgb-b" style="display:none">Info about the 'b' definition.</span><b><a href="#dom-cssrgb-b">#dom-cssrgb-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrgb-b">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-cssrgb-b①">(2)</a> <a href="#ref-for-dom-cssrgb-b②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrgb-alpha">
-   <b><a href="#dom-cssrgb-alpha">#dom-cssrgb-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrgb-alpha" class="dfn-panel" data-for="dom-cssrgb-alpha" id="infopanel-for-dom-cssrgb-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrgb-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-cssrgb-alpha">#dom-cssrgb-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrgb-alpha">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-cssrgb-alpha①">(2)</a> <a href="#ref-for-dom-cssrgb-alpha②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshsl-s">
-   <b><a href="#dom-csshsl-s">#dom-csshsl-s</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshsl-s" class="dfn-panel" data-for="dom-csshsl-s" id="infopanel-for-dom-csshsl-s" role="dialog">
+   <span id="infopaneltitle-for-dom-csshsl-s" style="display:none">Info about the 's' definition.</span><b><a href="#dom-csshsl-s">#dom-csshsl-s</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshsl-s">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshsl-s①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshsl-l">
-   <b><a href="#dom-csshsl-l">#dom-csshsl-l</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshsl-l" class="dfn-panel" data-for="dom-csshsl-l" id="infopanel-for-dom-csshsl-l" role="dialog">
+   <span id="infopaneltitle-for-dom-csshsl-l" style="display:none">Info about the 'l' definition.</span><b><a href="#dom-csshsl-l">#dom-csshsl-l</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshsl-l">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshsl-l①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshsl-alpha">
-   <b><a href="#dom-csshsl-alpha">#dom-csshsl-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshsl-alpha" class="dfn-panel" data-for="dom-csshsl-alpha" id="infopanel-for-dom-csshsl-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-csshsl-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-csshsl-alpha">#dom-csshsl-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshsl-alpha">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshsl-alpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshwb-w">
-   <b><a href="#dom-csshwb-w">#dom-csshwb-w</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshwb-w" class="dfn-panel" data-for="dom-csshwb-w" id="infopanel-for-dom-csshwb-w" role="dialog">
+   <span id="infopaneltitle-for-dom-csshwb-w" style="display:none">Info about the 'w' definition.</span><b><a href="#dom-csshwb-w">#dom-csshwb-w</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshwb-w">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshwb-w①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshwb-b">
-   <b><a href="#dom-csshwb-b">#dom-csshwb-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshwb-b" class="dfn-panel" data-for="dom-csshwb-b" id="infopanel-for-dom-csshwb-b" role="dialog">
+   <span id="infopaneltitle-for-dom-csshwb-b" style="display:none">Info about the 'b' definition.</span><b><a href="#dom-csshwb-b">#dom-csshwb-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshwb-b">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshwb-b①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csshwb-alpha">
-   <b><a href="#dom-csshwb-alpha">#dom-csshwb-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csshwb-alpha" class="dfn-panel" data-for="dom-csshwb-alpha" id="infopanel-for-dom-csshwb-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-csshwb-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-csshwb-alpha">#dom-csshwb-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csshwb-alpha">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csshwb-alpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslch-l">
-   <b><a href="#dom-csslch-l">#dom-csslch-l</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslch-l" class="dfn-panel" data-for="dom-csslch-l" id="infopanel-for-dom-csslch-l" role="dialog">
+   <span id="infopaneltitle-for-dom-csslch-l" style="display:none">Info about the 'l' definition.</span><b><a href="#dom-csslch-l">#dom-csslch-l</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslch-l">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslch-l①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslch-c">
-   <b><a href="#dom-csslch-c">#dom-csslch-c</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslch-c" class="dfn-panel" data-for="dom-csslch-c" id="infopanel-for-dom-csslch-c" role="dialog">
+   <span id="infopaneltitle-for-dom-csslch-c" style="display:none">Info about the 'c' definition.</span><b><a href="#dom-csslch-c">#dom-csslch-c</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslch-c">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslch-c①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslch-alpha">
-   <b><a href="#dom-csslch-alpha">#dom-csslch-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslch-alpha" class="dfn-panel" data-for="dom-csslch-alpha" id="infopanel-for-dom-csslch-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-csslch-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-csslch-alpha">#dom-csslch-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslch-alpha">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslch-alpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslab-l">
-   <b><a href="#dom-csslab-l">#dom-csslab-l</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslab-l" class="dfn-panel" data-for="dom-csslab-l" id="infopanel-for-dom-csslab-l" role="dialog">
+   <span id="infopaneltitle-for-dom-csslab-l" style="display:none">Info about the 'l' definition.</span><b><a href="#dom-csslab-l">#dom-csslab-l</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslab-l">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslab-l①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslab-a">
-   <b><a href="#dom-csslab-a">#dom-csslab-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslab-a" class="dfn-panel" data-for="dom-csslab-a" id="infopanel-for-dom-csslab-a" role="dialog">
+   <span id="infopaneltitle-for-dom-csslab-a" style="display:none">Info about the 'a' definition.</span><b><a href="#dom-csslab-a">#dom-csslab-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslab-a">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslab-a①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslab-b">
-   <b><a href="#dom-csslab-b">#dom-csslab-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslab-b" class="dfn-panel" data-for="dom-csslab-b" id="infopanel-for-dom-csslab-b" role="dialog">
+   <span id="infopaneltitle-for-dom-csslab-b" style="display:none">Info about the 'b' definition.</span><b><a href="#dom-csslab-b">#dom-csslab-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslab-b">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslab-b①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csslab-alpha">
-   <b><a href="#dom-csslab-alpha">#dom-csslab-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csslab-alpha" class="dfn-panel" data-for="dom-csslab-alpha" id="infopanel-for-dom-csslab-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-csslab-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-csslab-alpha">#dom-csslab-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csslab-alpha">4.6. CSSColorValue objects</a> <a href="#ref-for-dom-csslab-alpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolor-colorspace">
-   <b><a href="#dom-csscolor-colorspace">#dom-csscolor-colorspace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolor-colorspace" class="dfn-panel" data-for="dom-csscolor-colorspace" id="infopanel-for-dom-csscolor-colorspace" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolor-colorspace" style="display:none">Info about the 'colorspace' definition.</span><b><a href="#dom-csscolor-colorspace">#dom-csscolor-colorspace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolor-colorspace">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscolor-alpha">
-   <b><a href="#dom-csscolor-alpha">#dom-csscolor-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscolor-alpha" class="dfn-panel" data-for="dom-csscolor-alpha" id="infopanel-for-dom-csscolor-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-csscolor-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-csscolor-alpha">#dom-csscolor-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscolor-alpha">4.6. CSSColorValue objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectify-a-percentish-value">
-   <b><a href="#rectify-a-percentish-value">#rectify-a-percentish-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectify-a-percentish-value" class="dfn-panel" data-for="rectify-a-percentish-value" id="infopanel-for-rectify-a-percentish-value" role="dialog">
+   <span id="infopaneltitle-for-rectify-a-percentish-value" style="display:none">Info about the 'rectify a percentish value' definition.</span><b><a href="#rectify-a-percentish-value">#rectify-a-percentish-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectify-a-percentish-value">4.6. CSSColorValue objects</a> <a href="#ref-for-rectify-a-percentish-value①">(2)</a> <a href="#ref-for-rectify-a-percentish-value②">(3)</a> <a href="#ref-for-rectify-a-percentish-value③">(4)</a> <a href="#ref-for-rectify-a-percentish-value④">(5)</a> <a href="#ref-for-rectify-a-percentish-value⑤">(6)</a> <a href="#ref-for-rectify-a-percentish-value⑥">(7)</a> <a href="#ref-for-rectify-a-percentish-value⑦">(8)</a> <a href="#ref-for-rectify-a-percentish-value⑧">(9)</a> <a href="#ref-for-rectify-a-percentish-value⑨">(10)</a> <a href="#ref-for-rectify-a-percentish-value①⓪">(11)</a> <a href="#ref-for-rectify-a-percentish-value①①">(12)</a> <a href="#ref-for-rectify-a-percentish-value①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-reify">
-   <b><a href="#css-reify">#css-reify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-reify" class="dfn-panel" data-for="css-reify" id="infopanel-for-css-reify" role="dialog">
+   <span id="infopaneltitle-for-css-reify" style="display:none">Info about the 'reification' definition.</span><b><a href="#css-reify">#css-reify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-reify">2. CSSStyleValue objects</a>
     <li><a href="#ref-for-css-reify①">2.1. Direct CSSStyleValue Objects</a>
@@ -14241,101 +14241,157 @@ probably in an appendix. <a href="https://github.com/w3c/css-houdini-drafts/issu
     <li><a href="#ref-for-css-reify⑥">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a> <a href="#ref-for-css-reify⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-as-a-cssstylevalue">
-   <b><a href="#reify-as-a-cssstylevalue">#reify-as-a-cssstylevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-as-a-cssstylevalue" class="dfn-panel" data-for="reify-as-a-cssstylevalue" id="infopanel-for-reify-as-a-cssstylevalue" role="dialog">
+   <span id="infopaneltitle-for-reify-as-a-cssstylevalue" style="display:none">Info about the 'reify as a CSSStyleValue' definition.</span><b><a href="#reify-as-a-cssstylevalue">#reify-as-a-cssstylevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-as-a-cssstylevalue">5.2. Unrepresentable Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-a-list-of-component-values">
-   <b><a href="#reify-a-list-of-component-values">#reify-a-list-of-component-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-a-list-of-component-values" class="dfn-panel" data-for="reify-a-list-of-component-values" id="infopanel-for-reify-a-list-of-component-values" role="dialog">
+   <span id="infopaneltitle-for-reify-a-list-of-component-values" style="display:none">Info about the 'reify a list of component values' definition.</span><b><a href="#reify-a-list-of-component-values">#reify-a-list-of-component-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-list-of-component-values">5. CSSStyleValue Reification</a>
     <li><a href="#ref-for-reify-a-list-of-component-values①">5.1. Property-specific Rules</a>
     <li><a href="#ref-for-reify-a-list-of-component-values②">5.4. var() References</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-an-identifier">
-   <b><a href="#reify-an-identifier">#reify-an-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-an-identifier" class="dfn-panel" data-for="reify-an-identifier" id="infopanel-for-reify-an-identifier" role="dialog">
+   <span id="infopaneltitle-for-reify-an-identifier" style="display:none">Info about the 'reify an identifier' definition.</span><b><a href="#reify-an-identifier">#reify-an-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-an-identifier">5.1. Property-specific Rules</a> <a href="#ref-for-reify-an-identifier①">(2)</a> <a href="#ref-for-reify-an-identifier②">(3)</a> <a href="#ref-for-reify-an-identifier③">(4)</a> <a href="#ref-for-reify-an-identifier④">(5)</a> <a href="#ref-for-reify-an-identifier⑤">(6)</a> <a href="#ref-for-reify-an-identifier⑥">(7)</a> <a href="#ref-for-reify-an-identifier⑦">(8)</a> <a href="#ref-for-reify-an-identifier⑧">(9)</a> <a href="#ref-for-reify-an-identifier⑨">(10)</a> <a href="#ref-for-reify-an-identifier①⓪">(11)</a> <a href="#ref-for-reify-an-identifier①①">(12)</a> <a href="#ref-for-reify-an-identifier①②">(13)</a> <a href="#ref-for-reify-an-identifier①③">(14)</a> <a href="#ref-for-reify-an-identifier①④">(15)</a> <a href="#ref-for-reify-an-identifier①⑤">(16)</a> <a href="#ref-for-reify-an-identifier①⑥">(17)</a> <a href="#ref-for-reify-an-identifier①⑦">(18)</a> <a href="#ref-for-reify-an-identifier①⑧">(19)</a> <a href="#ref-for-reify-an-identifier①⑨">(20)</a> <a href="#ref-for-reify-an-identifier②⓪">(21)</a> <a href="#ref-for-reify-an-identifier②①">(22)</a> <a href="#ref-for-reify-an-identifier②②">(23)</a> <a href="#ref-for-reify-an-identifier②③">(24)</a> <a href="#ref-for-reify-an-identifier②④">(25)</a> <a href="#ref-for-reify-an-identifier②⑤">(26)</a> <a href="#ref-for-reify-an-identifier②⑥">(27)</a> <a href="#ref-for-reify-an-identifier②⑦">(28)</a> <a href="#ref-for-reify-an-identifier②⑧">(29)</a> <a href="#ref-for-reify-an-identifier②⑨">(30)</a> <a href="#ref-for-reify-an-identifier③⓪">(31)</a> <a href="#ref-for-reify-an-identifier③①">(32)</a> <a href="#ref-for-reify-an-identifier③②">(33)</a> <a href="#ref-for-reify-an-identifier③③">(34)</a> <a href="#ref-for-reify-an-identifier③④">(35)</a> <a href="#ref-for-reify-an-identifier③⑤">(36)</a> <a href="#ref-for-reify-an-identifier③⑥">(37)</a> <a href="#ref-for-reify-an-identifier③⑦">(38)</a> <a href="#ref-for-reify-an-identifier③⑧">(39)</a> <a href="#ref-for-reify-an-identifier③⑨">(40)</a> <a href="#ref-for-reify-an-identifier④⓪">(41)</a> <a href="#ref-for-reify-an-identifier④①">(42)</a> <a href="#ref-for-reify-an-identifier④②">(43)</a> <a href="#ref-for-reify-an-identifier④③">(44)</a> <a href="#ref-for-reify-an-identifier④④">(45)</a> <a href="#ref-for-reify-an-identifier④⑤">(46)</a> <a href="#ref-for-reify-an-identifier④⑥">(47)</a> <a href="#ref-for-reify-an-identifier④⑦">(48)</a> <a href="#ref-for-reify-an-identifier④⑧">(49)</a> <a href="#ref-for-reify-an-identifier④⑨">(50)</a> <a href="#ref-for-reify-an-identifier⑤⓪">(51)</a> <a href="#ref-for-reify-an-identifier⑤①">(52)</a> <a href="#ref-for-reify-an-identifier⑤②">(53)</a> <a href="#ref-for-reify-an-identifier⑤③">(54)</a> <a href="#ref-for-reify-an-identifier⑤④">(55)</a> <a href="#ref-for-reify-an-identifier⑤⑤">(56)</a> <a href="#ref-for-reify-an-identifier⑤⑥">(57)</a> <a href="#ref-for-reify-an-identifier⑤⑦">(58)</a> <a href="#ref-for-reify-an-identifier⑤⑧">(59)</a> <a href="#ref-for-reify-an-identifier⑤⑨">(60)</a> <a href="#ref-for-reify-an-identifier⑥⓪">(61)</a> <a href="#ref-for-reify-an-identifier⑥①">(62)</a> <a href="#ref-for-reify-an-identifier⑥②">(63)</a> <a href="#ref-for-reify-an-identifier⑥③">(64)</a> <a href="#ref-for-reify-an-identifier⑥④">(65)</a> <a href="#ref-for-reify-an-identifier⑥⑤">(66)</a> <a href="#ref-for-reify-an-identifier⑥⑥">(67)</a> <a href="#ref-for-reify-an-identifier⑥⑦">(68)</a> <a href="#ref-for-reify-an-identifier⑥⑧">(69)</a> <a href="#ref-for-reify-an-identifier⑥⑨">(70)</a> <a href="#ref-for-reify-an-identifier⑦⓪">(71)</a> <a href="#ref-for-reify-an-identifier⑦①">(72)</a> <a href="#ref-for-reify-an-identifier⑦②">(73)</a> <a href="#ref-for-reify-an-identifier⑦③">(74)</a> <a href="#ref-for-reify-an-identifier⑦④">(75)</a> <a href="#ref-for-reify-an-identifier⑦⑤">(76)</a> <a href="#ref-for-reify-an-identifier⑦⑥">(77)</a> <a href="#ref-for-reify-an-identifier⑦⑦">(78)</a> <a href="#ref-for-reify-an-identifier⑦⑧">(79)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-a-numeric-value">
-   <b><a href="#reify-a-numeric-value">#reify-a-numeric-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-a-numeric-value" class="dfn-panel" data-for="reify-a-numeric-value" id="infopanel-for-reify-a-numeric-value" role="dialog">
+   <span id="infopaneltitle-for-reify-a-numeric-value" style="display:none">Info about the 'reify a numeric value' definition.</span><b><a href="#reify-a-numeric-value">#reify-a-numeric-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-numeric-value">4.3.1. Common Numeric Operations, and the CSSNumericValue Superclass</a>
     <li><a href="#ref-for-reify-a-numeric-value①">5.1. Property-specific Rules</a> <a href="#ref-for-reify-a-numeric-value②">(2)</a> <a href="#ref-for-reify-a-numeric-value③">(3)</a> <a href="#ref-for-reify-a-numeric-value④">(4)</a> <a href="#ref-for-reify-a-numeric-value⑤">(5)</a> <a href="#ref-for-reify-a-numeric-value⑥">(6)</a> <a href="#ref-for-reify-a-numeric-value⑦">(7)</a> <a href="#ref-for-reify-a-numeric-value⑧">(8)</a> <a href="#ref-for-reify-a-numeric-value⑨">(9)</a> <a href="#ref-for-reify-a-numeric-value①⓪">(10)</a> <a href="#ref-for-reify-a-numeric-value①①">(11)</a> <a href="#ref-for-reify-a-numeric-value①②">(12)</a> <a href="#ref-for-reify-a-numeric-value①③">(13)</a> <a href="#ref-for-reify-a-numeric-value①④">(14)</a> <a href="#ref-for-reify-a-numeric-value①⑤">(15)</a> <a href="#ref-for-reify-a-numeric-value①⑥">(16)</a> <a href="#ref-for-reify-a-numeric-value①⑦">(17)</a> <a href="#ref-for-reify-a-numeric-value①⑧">(18)</a> <a href="#ref-for-reify-a-numeric-value①⑨">(19)</a> <a href="#ref-for-reify-a-numeric-value②⓪">(20)</a> <a href="#ref-for-reify-a-numeric-value②①">(21)</a> <a href="#ref-for-reify-a-numeric-value②②">(22)</a>
     <li><a href="#ref-for-reify-a-numeric-value②③">5.7. &lt;transform-list> and &lt;transform-function> values</a> <a href="#ref-for-reify-a-numeric-value②④">(2)</a> <a href="#ref-for-reify-a-numeric-value②⑤">(3)</a> <a href="#ref-for-reify-a-numeric-value②⑥">(4)</a> <a href="#ref-for-reify-a-numeric-value②⑦">(5)</a> <a href="#ref-for-reify-a-numeric-value②⑧">(6)</a> <a href="#ref-for-reify-a-numeric-value②⑨">(7)</a> <a href="#ref-for-reify-a-numeric-value③⓪">(8)</a> <a href="#ref-for-reify-a-numeric-value③①">(9)</a> <a href="#ref-for-reify-a-numeric-value③②">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-a-math-expression">
-   <b><a href="#reify-a-math-expression">#reify-a-math-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-a-math-expression" class="dfn-panel" data-for="reify-a-math-expression" id="infopanel-for-reify-a-math-expression" role="dialog">
+   <span id="infopaneltitle-for-reify-a-math-expression" style="display:none">Info about the 'reify a math expression' definition.</span><b><a href="#reify-a-math-expression">#reify-a-math-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-math-expression">5.6. &lt;number>, &lt;percentage>, and &lt;dimension> values</a> <a href="#ref-for-reify-a-math-expression①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reify-a-transform-function">
-   <b><a href="#reify-a-transform-function">#reify-a-transform-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reify-a-transform-function" class="dfn-panel" data-for="reify-a-transform-function" id="infopanel-for-reify-a-transform-function" role="dialog">
+   <span id="infopaneltitle-for-reify-a-transform-function" style="display:none">Info about the 'reify a &lt;transform-function>' definition.</span><b><a href="#reify-a-transform-function">#reify-a-transform-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reify-a-transform-function">5.7. &lt;transform-list> and &lt;transform-function> values</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/css-houdini-drafts/font-metrics-api/Overview.html
+++ b/tests/github/w3c/css-houdini-drafts/font-metrics-api/Overview.html
@@ -2364,55 +2364,55 @@ codepoints.</p>
    <li><a href="#dom-baseline-value">value</a><span>, in § 2.2</span>
    <li><a href="#dom-fontmetrics-width">width</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-stylepropertymapreadonly">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stylepropertymapreadonly" class="dfn-panel" data-for="term-for-stylepropertymapreadonly" id="infopanel-for-term-for-stylepropertymapreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-stylepropertymapreadonly" style="display:none">Info about the 'StylePropertyMapReadOnly' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly">https://drafts.css-houdini.org/css-typed-om-1/#stylepropertymapreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylepropertymapreadonly">2. Measure API</a> <a href="#ref-for-stylepropertymapreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Measure API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2. Measure API</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Measure API</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">2.2. Baseline object</a>
     <li><a href="#ref-for-idl-DOMString③">2.3. Font object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. FontMetrics object</a>
     <li><a href="#ref-for-Exposed①">2.2. Baseline object</a>
     <li><a href="#ref-for-Exposed②">2.3. Font object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.1. FontMetrics object</a> <a href="#ref-for-idl-frozen-array①">(2)</a> <a href="#ref-for-idl-frozen-array②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.1. FontMetrics object</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a> <a href="#ref-for-idl-double⑤">(6)</a> <a href="#ref-for-idl-double⑥">(7)</a> <a href="#ref-for-idl-double⑦">(8)</a> <a href="#ref-for-idl-double⑧">(9)</a> <a href="#ref-for-idl-double⑨">(10)</a> <a href="#ref-for-idl-double①⓪">(11)</a>
     <li><a href="#ref-for-idl-double①①">2.2. Baseline object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2.3. Font object</a>
    </ul>
@@ -2492,195 +2492,251 @@ codepoints.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-document-measureelement">
-   <b><a href="#dom-document-measureelement">#dom-document-measureelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-measureelement" class="dfn-panel" data-for="dom-document-measureelement" id="infopanel-for-dom-document-measureelement" role="dialog">
+   <span id="infopaneltitle-for-dom-document-measureelement" style="display:none">Info about the 'measureElement' definition.</span><b><a href="#dom-document-measureelement">#dom-document-measureelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-measureelement">2. Measure API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-measuretext">
-   <b><a href="#dom-document-measuretext">#dom-document-measuretext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-measuretext" class="dfn-panel" data-for="dom-document-measuretext" id="infopanel-for-dom-document-measuretext" role="dialog">
+   <span id="infopaneltitle-for-dom-document-measuretext" style="display:none">Info about the 'measureText' definition.</span><b><a href="#dom-document-measuretext">#dom-document-measuretext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-measuretext">2. Measure API</a> <a href="#ref-for-dom-document-measuretext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontmetrics">
-   <b><a href="#fontmetrics">#fontmetrics</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontmetrics" class="dfn-panel" data-for="fontmetrics" id="infopanel-for-fontmetrics" role="dialog">
+   <span id="infopaneltitle-for-fontmetrics" style="display:none">Info about the 'FontMetrics' definition.</span><b><a href="#fontmetrics">#fontmetrics</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontmetrics">2. Measure API</a> <a href="#ref-for-fontmetrics①">(2)</a> <a href="#ref-for-fontmetrics②">(3)</a> <a href="#ref-for-fontmetrics③">(4)</a> <a href="#ref-for-fontmetrics④">(5)</a> <a href="#ref-for-fontmetrics⑤">(6)</a>
     <li><a href="#ref-for-fontmetrics⑥">2.1. FontMetrics object</a> <a href="#ref-for-fontmetrics⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-width">
-   <b><a href="#dom-fontmetrics-width">#dom-fontmetrics-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-width" class="dfn-panel" data-for="dom-fontmetrics-width" id="infopanel-for-dom-fontmetrics-width" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-fontmetrics-width">#dom-fontmetrics-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-width">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-advances">
-   <b><a href="#dom-fontmetrics-advances">#dom-fontmetrics-advances</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-advances" class="dfn-panel" data-for="dom-fontmetrics-advances" id="infopanel-for-dom-fontmetrics-advances" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-advances" style="display:none">Info about the 'advances' definition.</span><b><a href="#dom-fontmetrics-advances">#dom-fontmetrics-advances</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-advances">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-boundingboxleft">
-   <b><a href="#dom-fontmetrics-boundingboxleft">#dom-fontmetrics-boundingboxleft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-boundingboxleft" class="dfn-panel" data-for="dom-fontmetrics-boundingboxleft" id="infopanel-for-dom-fontmetrics-boundingboxleft" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-boundingboxleft" style="display:none">Info about the 'boundingBoxLeft' definition.</span><b><a href="#dom-fontmetrics-boundingboxleft">#dom-fontmetrics-boundingboxleft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-boundingboxleft">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-boundingboxright">
-   <b><a href="#dom-fontmetrics-boundingboxright">#dom-fontmetrics-boundingboxright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-boundingboxright" class="dfn-panel" data-for="dom-fontmetrics-boundingboxright" id="infopanel-for-dom-fontmetrics-boundingboxright" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-boundingboxright" style="display:none">Info about the 'boundingBoxRight' definition.</span><b><a href="#dom-fontmetrics-boundingboxright">#dom-fontmetrics-boundingboxright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-boundingboxright">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-boundingboxright①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-height">
-   <b><a href="#dom-fontmetrics-height">#dom-fontmetrics-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-height" class="dfn-panel" data-for="dom-fontmetrics-height" id="infopanel-for-dom-fontmetrics-height" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-fontmetrics-height">#dom-fontmetrics-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-height">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-emheightascent">
-   <b><a href="#dom-fontmetrics-emheightascent">#dom-fontmetrics-emheightascent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-emheightascent" class="dfn-panel" data-for="dom-fontmetrics-emheightascent" id="infopanel-for-dom-fontmetrics-emheightascent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-emheightascent" style="display:none">Info about the 'emHeightAscent' definition.</span><b><a href="#dom-fontmetrics-emheightascent">#dom-fontmetrics-emheightascent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-emheightascent">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-emheightdescent">
-   <b><a href="#dom-fontmetrics-emheightdescent">#dom-fontmetrics-emheightdescent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-emheightdescent" class="dfn-panel" data-for="dom-fontmetrics-emheightdescent" id="infopanel-for-dom-fontmetrics-emheightdescent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-emheightdescent" style="display:none">Info about the 'emHeightDescent' definition.</span><b><a href="#dom-fontmetrics-emheightdescent">#dom-fontmetrics-emheightdescent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-emheightdescent">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-boundingboxascent">
-   <b><a href="#dom-fontmetrics-boundingboxascent">#dom-fontmetrics-boundingboxascent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-boundingboxascent" class="dfn-panel" data-for="dom-fontmetrics-boundingboxascent" id="infopanel-for-dom-fontmetrics-boundingboxascent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-boundingboxascent" style="display:none">Info about the 'boundingBoxAscent' definition.</span><b><a href="#dom-fontmetrics-boundingboxascent">#dom-fontmetrics-boundingboxascent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-boundingboxascent">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-boundingboxascent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-boundingboxdescent">
-   <b><a href="#dom-fontmetrics-boundingboxdescent">#dom-fontmetrics-boundingboxdescent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-boundingboxdescent" class="dfn-panel" data-for="dom-fontmetrics-boundingboxdescent" id="infopanel-for-dom-fontmetrics-boundingboxdescent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-boundingboxdescent" style="display:none">Info about the 'boundingBoxDescent' definition.</span><b><a href="#dom-fontmetrics-boundingboxdescent">#dom-fontmetrics-boundingboxdescent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-boundingboxdescent">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-fontboundingboxascent">
-   <b><a href="#dom-fontmetrics-fontboundingboxascent">#dom-fontmetrics-fontboundingboxascent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-fontboundingboxascent" class="dfn-panel" data-for="dom-fontmetrics-fontboundingboxascent" id="infopanel-for-dom-fontmetrics-fontboundingboxascent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-fontboundingboxascent" style="display:none">Info about the 'fontBoundingBoxAscent' definition.</span><b><a href="#dom-fontmetrics-fontboundingboxascent">#dom-fontmetrics-fontboundingboxascent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-fontboundingboxascent">2.1. FontMetrics object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-fontboundingboxdescent">
-   <b><a href="#dom-fontmetrics-fontboundingboxdescent">#dom-fontmetrics-fontboundingboxdescent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-fontboundingboxdescent" class="dfn-panel" data-for="dom-fontmetrics-fontboundingboxdescent" id="infopanel-for-dom-fontmetrics-fontboundingboxdescent" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-fontboundingboxdescent" style="display:none">Info about the 'fontBoundingBoxDescent' definition.</span><b><a href="#dom-fontmetrics-fontboundingboxdescent">#dom-fontmetrics-fontboundingboxdescent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-fontboundingboxdescent">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-fontboundingboxdescent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-dominantbaseline">
-   <b><a href="#dom-fontmetrics-dominantbaseline">#dom-fontmetrics-dominantbaseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-dominantbaseline" class="dfn-panel" data-for="dom-fontmetrics-dominantbaseline" id="infopanel-for-dom-fontmetrics-dominantbaseline" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-dominantbaseline" style="display:none">Info about the 'dominantBaseline' definition.</span><b><a href="#dom-fontmetrics-dominantbaseline">#dom-fontmetrics-dominantbaseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-dominantbaseline">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①">(2)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline②">(3)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline③">(4)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline④">(5)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline⑤">(6)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline⑥">(7)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline⑦">(8)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline⑧">(9)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline⑨">(10)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①⓪">(11)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①①">(12)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①②">(13)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①③">(14)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①④">(15)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①⑤">(16)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①⑥">(17)</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①⑦">(18)</a>
     <li><a href="#ref-for-dom-fontmetrics-dominantbaseline①⑧">2.2. Baseline object</a> <a href="#ref-for-dom-fontmetrics-dominantbaseline①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontmetrics-baselines">
-   <b><a href="#dom-fontmetrics-baselines">#dom-fontmetrics-baselines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontmetrics-baselines" class="dfn-panel" data-for="dom-fontmetrics-baselines" id="infopanel-for-dom-fontmetrics-baselines" role="dialog">
+   <span id="infopaneltitle-for-dom-fontmetrics-baselines" style="display:none">Info about the 'baselines' definition.</span><b><a href="#dom-fontmetrics-baselines">#dom-fontmetrics-baselines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontmetrics-baselines">2.1. FontMetrics object</a> <a href="#ref-for-dom-fontmetrics-baselines①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline">
-   <b><a href="#baseline">#baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline" class="dfn-panel" data-for="baseline" id="infopanel-for-baseline" role="dialog">
+   <span id="infopaneltitle-for-baseline" style="display:none">Info about the 'Baseline' definition.</span><b><a href="#baseline">#baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline">2.1. FontMetrics object</a> <a href="#ref-for-baseline①">(2)</a> <a href="#ref-for-baseline②">(3)</a> <a href="#ref-for-baseline③">(4)</a>
     <li><a href="#ref-for-baseline④">2.2. Baseline object</a> <a href="#ref-for-baseline⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseline-name">
-   <b><a href="#dom-baseline-name">#dom-baseline-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseline-name" class="dfn-panel" data-for="dom-baseline-name" id="infopanel-for-dom-baseline-name" role="dialog">
+   <span id="infopaneltitle-for-dom-baseline-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-baseline-name">#dom-baseline-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseline-name">2.2. Baseline object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-baseline-value">
-   <b><a href="#dom-baseline-value">#dom-baseline-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-baseline-value" class="dfn-panel" data-for="dom-baseline-value" id="infopanel-for-dom-baseline-value" role="dialog">
+   <span id="infopaneltitle-for-dom-baseline-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-baseline-value">#dom-baseline-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-baseline-value">2.2. Baseline object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font">
-   <b><a href="#font">#font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font" class="dfn-panel" data-for="font" id="infopanel-for-font" role="dialog">
+   <span id="infopaneltitle-for-font" style="display:none">Info about the 'Font' definition.</span><b><a href="#font">#font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font">2.1. FontMetrics object</a>
     <li><a href="#ref-for-font①">2.3. Font object</a> <a href="#ref-for-font②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-font-name">
-   <b><a href="#dom-font-name">#dom-font-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-font-name" class="dfn-panel" data-for="dom-font-name" id="infopanel-for-dom-font-name" role="dialog">
+   <span id="infopaneltitle-for-dom-font-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-font-name">#dom-font-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-font-name">2.3. Font object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-font-glyphsrendered">
-   <b><a href="#dom-font-glyphsrendered">#dom-font-glyphsrendered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-font-glyphsrendered" class="dfn-panel" data-for="dom-font-glyphsrendered" id="infopanel-for-dom-font-glyphsrendered" role="dialog">
+   <span id="infopaneltitle-for-dom-font-glyphsrendered" style="display:none">Info about the 'glyphsRendered' definition.</span><b><a href="#dom-font-glyphsrendered">#dom-font-glyphsrendered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-font-glyphsrendered">2.3. Font object</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-2015/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-2015/Overview.html
@@ -1473,77 +1473,77 @@ that this feature should exist and be released,</p>
    <li><a href="#vendor-prefix">vendor prefix</a><span>, in § 3.2.2</span>
    <li><a href="#vendor-prefix">vendor-prefixed</a><span>, in § 3.2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter-style" class="dfn-panel" data-for="term-for-typedef-counter-style" id="infopanel-for-term-for-typedef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter-style" style="display:none">Info about the '&lt;counter-style>' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-counter-style" class="dfn-panel" data-for="term-for-at-ruledef-counter-style" id="infopanel-for-term-for-at-ruledef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-counter-style" style="display:none">Info about the '@counter-style' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-counter-style">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline" class="dfn-panel" data-for="term-for-propdef-outline" id="infopanel-for-term-for-propdef-outline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline" style="display:none">Info about the 'outline' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-lang">
-   <a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-lang" class="dfn-panel" data-for="term-for-selectordef-lang" id="infopanel-for-term-for-selectordef-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-lang" style="display:none">Info about the ':lang()' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dir-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#dir-pseudo">https://drafts.csswg.org/selectors-4/#dir-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dir-pseudo" class="dfn-panel" data-for="term-for-dir-pseudo" id="infopanel-for-term-for-dir-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-dir-pseudo" style="display:none">Info about the ':dir()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#dir-pseudo">https://drafts.csswg.org/selectors-4/#dir-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dir-pseudo">3.2.1. 
 Experimentation and Unstable Features</a>
@@ -1675,36 +1675,36 @@ Experimentation and Unstable Features</a>
    <div class="issue"> Bikeshed should be amended shortly to allow auto-genning the propdef index. <a class="issue-return" href="#issue-b27f825f" title="Jump to section">↵</a></div>
    <div class="issue"> Cross-linking from CSS Backgrounds and Borders is kinda broken atm... <a class="issue-return" href="#issue-156dad38" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="editors-draft">
-   <b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editors-draft" class="dfn-panel" data-for="editors-draft" id="infopanel-for-editors-draft" role="dialog">
+   <span id="infopaneltitle-for-editors-draft" style="display:none">Info about the 'Editor’s Draft' definition.</span><b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editors-draft">1.1. 
 Background: The W3C Process and CSS</a> <a href="#ref-for-editors-draft①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-1">
-   <b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-1" class="dfn-panel" data-for="css-level-1" id="infopanel-for-css-level-1" role="dialog">
+   <span id="infopaneltitle-for-css-level-1" style="display:none">Info about the 'CSS Level 1' definition.</span><b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-1">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-2">
-   <b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-2" class="dfn-panel" data-for="css-level-2" id="infopanel-for-css-level-2" role="dialog">
+   <span id="infopaneltitle-for-css-level-2" style="display:none">Info about the 'CSS Level 2' definition.</span><b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-2">2.1. 
 CSS Levels</a> <a href="#ref-for-css-level-2①">(2)</a> <a href="#ref-for-css-level-2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-3">
-   <b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-3" class="dfn-panel" data-for="css-level-3" id="infopanel-for-css-level-3" role="dialog">
+   <span id="infopaneltitle-for-css-level-3" style="display:none">Info about the 'CSS Level 3' definition.</span><b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-3">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable">
-   <b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable" class="dfn-panel" data-for="unstable" id="infopanel-for-unstable" role="dialog">
+   <span id="infopaneltitle-for-unstable" style="display:none">Info about the 'unstable' definition.</span><b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-unstable①">3.2.1. 
@@ -1715,8 +1715,8 @@ Market Pressure and De Facto Standards</a> <a href="#ref-for-unstable④">(2)</a
 Vendor-prefixing Unstable Features</a> <a href="#ref-for-unstable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vendor-prefix">
-   <b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vendor-prefix" class="dfn-panel" data-for="vendor-prefix" id="infopanel-for-vendor-prefix" role="dialog">
+   <span id="infopaneltitle-for-vendor-prefix" style="display:none">Info about the 'prefixed syntax' definition.</span><b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-prefix">3.2.2. 
 Proprietary and Non-standardized Features</a>
@@ -1727,16 +1727,16 @@ Vendor-prefixing Unstable Features</a> <a href="#ref-for-vendor-prefix③">(2)</
     <li><a href="#ref-for-vendor-prefix⑤">3.3. Implementations of CR-level Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proprietary-extension">
-   <b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proprietary-extension" class="dfn-panel" data-for="proprietary-extension" id="infopanel-for-proprietary-extension" role="dialog">
+   <span id="infopaneltitle-for-proprietary-extension" style="display:none">Info about the 'proprietary extension' definition.</span><b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proprietary-extension">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-proprietary-extension①">3.2.2. 
 Proprietary and Non-standardized Features</a> <a href="#ref-for-proprietary-extension②">(2)</a> <a href="#ref-for-proprietary-extension③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rough-interoperability">
-   <b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rough-interoperability" class="dfn-panel" data-for="rough-interoperability" id="infopanel-for-rough-interoperability" role="dialog">
+   <span id="infopaneltitle-for-rough-interoperability" style="display:none">Info about the 'Rough interoperability' definition.</span><b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rough-interoperability">2. Cascading Style Sheets (CSS) — The Official Definition</a>
     <li><a href="#ref-for-rough-interoperability①">3.2.3. 
@@ -1745,57 +1745,113 @@ Market Pressure and De Facto Standards</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-2017/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-2017/Overview.html
@@ -3542,77 +3542,77 @@ that this feature should exist and be released,</p>
    <li><a href="#vendor-prefix">vendor prefix</a><span>, in § 3.2.2</span>
    <li><a href="#vendor-prefix">vendor-prefixed</a><span>, in § 3.2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter-style" class="dfn-panel" data-for="term-for-typedef-counter-style" id="infopanel-for-term-for-typedef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter-style" style="display:none">Info about the '&lt;counter-style>' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-counter-style" class="dfn-panel" data-for="term-for-at-ruledef-counter-style" id="infopanel-for-term-for-at-ruledef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-counter-style" style="display:none">Info about the '@counter-style' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-counter-style">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-3/#propdef-cursor">https://drafts.csswg.org/css-ui-3/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-3/#propdef-cursor">https://drafts.csswg.org/css-ui-3/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline">
-   <a href="https://drafts.csswg.org/css-ui-3/#propdef-outline">https://drafts.csswg.org/css-ui-3/#propdef-outline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline" class="dfn-panel" data-for="term-for-propdef-outline" id="infopanel-for-term-for-propdef-outline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline" style="display:none">Info about the 'outline' external reference.</span><a href="https://drafts.csswg.org/css-ui-3/#propdef-outline">https://drafts.csswg.org/css-ui-3/#propdef-outline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-lang">
-   <a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-lang" class="dfn-panel" data-for="term-for-selectordef-lang" id="infopanel-for-term-for-selectordef-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-lang" style="display:none">Info about the ':lang()' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">3.2.1. 
 Experimentation and Unstable Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2. Cascading Style Sheets (CSS) — The Official Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dir-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#dir-pseudo">https://drafts.csswg.org/selectors-4/#dir-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dir-pseudo" class="dfn-panel" data-for="term-for-dir-pseudo" id="infopanel-for-term-for-dir-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-dir-pseudo" style="display:none">Info about the ':dir()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#dir-pseudo">https://drafts.csswg.org/selectors-4/#dir-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dir-pseudo">3.2.1. 
 Experimentation and Unstable Features</a>
@@ -3748,36 +3748,36 @@ Experimentation and Unstable Features</a>
    <dt id="biblio-filter-effects-1">[FILTER-EFFECTS-1]
    <dd>Dirk Schulze; Dean Jackson. <a href="https://drafts.fxtf.org/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. URL: <a href="https://drafts.fxtf.org/filter-effects-1/">https://drafts.fxtf.org/filter-effects-1/</a>
   </dl>
-  <aside class="dfn-panel" data-for="editors-draft">
-   <b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editors-draft" class="dfn-panel" data-for="editors-draft" id="infopanel-for-editors-draft" role="dialog">
+   <span id="infopaneltitle-for-editors-draft" style="display:none">Info about the 'Editor’s Draft' definition.</span><b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editors-draft">1.1. 
 Background: The W3C Process and CSS</a> <a href="#ref-for-editors-draft①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-1">
-   <b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-1" class="dfn-panel" data-for="css-level-1" id="infopanel-for-css-level-1" role="dialog">
+   <span id="infopaneltitle-for-css-level-1" style="display:none">Info about the 'CSS Level 1' definition.</span><b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-1">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-2">
-   <b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-2" class="dfn-panel" data-for="css-level-2" id="infopanel-for-css-level-2" role="dialog">
+   <span id="infopaneltitle-for-css-level-2" style="display:none">Info about the 'CSS Level 2' definition.</span><b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-2">2.1. 
 CSS Levels</a> <a href="#ref-for-css-level-2①">(2)</a> <a href="#ref-for-css-level-2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-3">
-   <b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-3" class="dfn-panel" data-for="css-level-3" id="infopanel-for-css-level-3" role="dialog">
+   <span id="infopaneltitle-for-css-level-3" style="display:none">Info about the 'CSS Level 3' definition.</span><b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-3">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable">
-   <b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable" class="dfn-panel" data-for="unstable" id="infopanel-for-unstable" role="dialog">
+   <span id="infopaneltitle-for-unstable" style="display:none">Info about the 'unstable' definition.</span><b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-unstable①">3.2.1. 
@@ -3788,8 +3788,8 @@ Market Pressure and De Facto Standards</a> <a href="#ref-for-unstable④">(2)</a
 Vendor-prefixing Unstable Features</a> <a href="#ref-for-unstable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vendor-prefix">
-   <b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vendor-prefix" class="dfn-panel" data-for="vendor-prefix" id="infopanel-for-vendor-prefix" role="dialog">
+   <span id="infopaneltitle-for-vendor-prefix" style="display:none">Info about the 'prefixed syntax' definition.</span><b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-prefix">3.2.2. 
 Proprietary and Non-standardized Features</a>
@@ -3800,16 +3800,16 @@ Vendor-prefixing Unstable Features</a> <a href="#ref-for-vendor-prefix③">(2)</
     <li><a href="#ref-for-vendor-prefix⑤">3.3. Implementations of CR-level Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proprietary-extension">
-   <b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proprietary-extension" class="dfn-panel" data-for="proprietary-extension" id="infopanel-for-proprietary-extension" role="dialog">
+   <span id="infopaneltitle-for-proprietary-extension" style="display:none">Info about the 'proprietary extension' definition.</span><b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proprietary-extension">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-proprietary-extension①">3.2.2. 
 Proprietary and Non-standardized Features</a> <a href="#ref-for-proprietary-extension②">(2)</a> <a href="#ref-for-proprietary-extension③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rough-interoperability">
-   <b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rough-interoperability" class="dfn-panel" data-for="rough-interoperability" id="infopanel-for-rough-interoperability" role="dialog">
+   <span id="infopaneltitle-for-rough-interoperability" style="display:none">Info about the 'Rough interoperability' definition.</span><b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rough-interoperability">2. Cascading Style Sheets (CSS) — The Official Definition</a>
     <li><a href="#ref-for-rough-interoperability①">3.2.3. 
@@ -3818,57 +3818,113 @@ Market Pressure and De Facto Standards</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-2018/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-2018/Overview.html
@@ -3889,36 +3889,36 @@ that this feature should exist and be released,</p>
    <dt id="biblio-mediaqueries-4">[MEDIAQUERIES-4]
    <dd>Florian Rivoal; Tab Atkins Jr.. <a href="https://drafts.csswg.org/mediaqueries-4/"><cite>Media Queries Level 4</cite></a>. URL: <a href="https://drafts.csswg.org/mediaqueries-4/">https://drafts.csswg.org/mediaqueries-4/</a>
   </dl>
-  <aside class="dfn-panel" data-for="editors-draft">
-   <b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editors-draft" class="dfn-panel" data-for="editors-draft" id="infopanel-for-editors-draft" role="dialog">
+   <span id="infopaneltitle-for-editors-draft" style="display:none">Info about the 'Editor’s Draft' definition.</span><b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editors-draft">1.1. 
 Background: The W3C Process and CSS</a> <a href="#ref-for-editors-draft①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-1">
-   <b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-1" class="dfn-panel" data-for="css-level-1" id="infopanel-for-css-level-1" role="dialog">
+   <span id="infopaneltitle-for-css-level-1" style="display:none">Info about the 'CSS Level 1' definition.</span><b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-1">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-2">
-   <b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-2" class="dfn-panel" data-for="css-level-2" id="infopanel-for-css-level-2" role="dialog">
+   <span id="infopaneltitle-for-css-level-2" style="display:none">Info about the 'CSS Level 2' definition.</span><b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-2">2.1. 
 CSS Levels</a> <a href="#ref-for-css-level-2①">(2)</a> <a href="#ref-for-css-level-2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-3">
-   <b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-3" class="dfn-panel" data-for="css-level-3" id="infopanel-for-css-level-3" role="dialog">
+   <span id="infopaneltitle-for-css-level-3" style="display:none">Info about the 'CSS Level 3' definition.</span><b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-3">2.1. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable">
-   <b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable" class="dfn-panel" data-for="unstable" id="infopanel-for-unstable" role="dialog">
+   <span id="infopaneltitle-for-unstable" style="display:none">Info about the 'unstable' definition.</span><b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-unstable①">3.2.1. 
@@ -3929,8 +3929,8 @@ Market Pressure and De Facto Standards</a> <a href="#ref-for-unstable④">(2)</a
 Vendor-prefixing Unstable Features</a> <a href="#ref-for-unstable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vendor-prefix">
-   <b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vendor-prefix" class="dfn-panel" data-for="vendor-prefix" id="infopanel-for-vendor-prefix" role="dialog">
+   <span id="infopaneltitle-for-vendor-prefix" style="display:none">Info about the 'prefixed syntax' definition.</span><b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-prefix">3.2.2. 
 Proprietary and Non-standardized Features</a>
@@ -3941,16 +3941,16 @@ Vendor-prefixing Unstable Features</a> <a href="#ref-for-vendor-prefix③">(2)</
     <li><a href="#ref-for-vendor-prefix⑤">3.3. Implementations of CR-level Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proprietary-extension">
-   <b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proprietary-extension" class="dfn-panel" data-for="proprietary-extension" id="infopanel-for-proprietary-extension" role="dialog">
+   <span id="infopaneltitle-for-proprietary-extension" style="display:none">Info about the 'proprietary extension' definition.</span><b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proprietary-extension">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-proprietary-extension①">3.2.2. 
 Proprietary and Non-standardized Features</a> <a href="#ref-for-proprietary-extension②">(2)</a> <a href="#ref-for-proprietary-extension③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rough-interoperability">
-   <b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rough-interoperability" class="dfn-panel" data-for="rough-interoperability" id="infopanel-for-rough-interoperability" role="dialog">
+   <span id="infopaneltitle-for-rough-interoperability" style="display:none">Info about the 'Rough interoperability' definition.</span><b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rough-interoperability">2. Cascading Style Sheets (CSS) — The Official Definition</a>
     <li><a href="#ref-for-rough-interoperability①">3.2.3. 
@@ -3959,57 +3959,113 @@ Market Pressure and De Facto Standards</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-2020/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-2020/Overview.html
@@ -3732,36 +3732,36 @@ that this feature should exist and be released,</p>
    <dt id="biblio-mediaqueries-4">[MEDIAQUERIES-4]
    <dd>Florian Rivoal; Tab Atkins Jr.. <a href="https://www.w3.org/TR/mediaqueries-4/"><cite>Media Queries Level 4</cite></a>. 25 December 2021. CR. URL: <a href="https://www.w3.org/TR/mediaqueries-4/">https://www.w3.org/TR/mediaqueries-4/</a>
   </dl>
-  <aside class="dfn-panel" data-for="editors-draft">
-   <b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editors-draft" class="dfn-panel" data-for="editors-draft" id="infopanel-for-editors-draft" role="dialog">
+   <span id="infopaneltitle-for-editors-draft" style="display:none">Info about the 'Editor’s Draft' definition.</span><b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editors-draft">1.1. 
 Background: The W3C Process and CSS</a> <a href="#ref-for-editors-draft①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-1">
-   <b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-1" class="dfn-panel" data-for="css-level-1" id="infopanel-for-css-level-1" role="dialog">
+   <span id="infopaneltitle-for-css-level-1" style="display:none">Info about the 'CSS Level 1' definition.</span><b><a href="#css-level-1">#css-level-1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-1">2.4. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-2">
-   <b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-2" class="dfn-panel" data-for="css-level-2" id="infopanel-for-css-level-2" role="dialog">
+   <span id="infopaneltitle-for-css-level-2" style="display:none">Info about the 'CSS Level 2' definition.</span><b><a href="#css-level-2">#css-level-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-2">2.4. 
 CSS Levels</a> <a href="#ref-for-css-level-2①">(2)</a> <a href="#ref-for-css-level-2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-level-3">
-   <b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-level-3" class="dfn-panel" data-for="css-level-3" id="infopanel-for-css-level-3" role="dialog">
+   <span id="infopaneltitle-for-css-level-3" style="display:none">Info about the 'CSS Level 3' definition.</span><b><a href="#css-level-3">#css-level-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-level-3">2.4. 
 CSS Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unstable">
-   <b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unstable" class="dfn-panel" data-for="unstable" id="infopanel-for-unstable" role="dialog">
+   <span id="infopaneltitle-for-unstable" style="display:none">Info about the 'unstable' definition.</span><b><a href="#unstable">#unstable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unstable">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-unstable①">3.2.1. 
@@ -3772,8 +3772,8 @@ Market Pressure and De Facto Standards</a> <a href="#ref-for-unstable④">(2)</a
 Vendor-prefixing Unstable Features</a> <a href="#ref-for-unstable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vendor-prefix">
-   <b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vendor-prefix" class="dfn-panel" data-for="vendor-prefix" id="infopanel-for-vendor-prefix" role="dialog">
+   <span id="infopaneltitle-for-vendor-prefix" style="display:none">Info about the 'prefixed syntax' definition.</span><b><a href="#vendor-prefix">#vendor-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-prefix">3.2.2. 
 Proprietary and Non-standardized Features</a>
@@ -3784,16 +3784,16 @@ Vendor-prefixing Unstable Features</a> <a href="#ref-for-vendor-prefix③">(2)</
     <li><a href="#ref-for-vendor-prefix⑤">3.3. Implementations of CR-level Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proprietary-extension">
-   <b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proprietary-extension" class="dfn-panel" data-for="proprietary-extension" id="infopanel-for-proprietary-extension" role="dialog">
+   <span id="infopaneltitle-for-proprietary-extension" style="display:none">Info about the 'proprietary extension' definition.</span><b><a href="#proprietary-extension">#proprietary-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proprietary-extension">3.2. Implementations of Unstable and Proprietary Features</a>
     <li><a href="#ref-for-proprietary-extension①">3.2.2. 
 Proprietary and Non-standardized Features</a> <a href="#ref-for-proprietary-extension②">(2)</a> <a href="#ref-for-proprietary-extension③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rough-interoperability">
-   <b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rough-interoperability" class="dfn-panel" data-for="rough-interoperability" id="infopanel-for-rough-interoperability" role="dialog">
+   <span id="infopaneltitle-for-rough-interoperability" style="display:none">Info about the 'Rough interoperability' definition.</span><b><a href="#rough-interoperability">#rough-interoperability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rough-interoperability">2.3. 
 Modules with Rough Interoperability</a>
@@ -3803,57 +3803,113 @@ Market Pressure and De Facto Standards</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-align-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-align-3/Overview.html
@@ -3287,56 +3287,56 @@ whichever is orthogonal to the box’s own <span class="property" id="ref-for-pr
    <li><a href="#synthesize-baseline">synthesized baseline</a><span>, in § 9.1</span>
    <li><a href="#valdef-overflow-position-unsafe">unsafe</a><span>, in § 4.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">8.3. 
 Percentages In gap Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge"> Appendix A: Static Position Terminology</a> <a href="#ref-for-content-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">8. 
 Gaps Between Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-edge" class="dfn-panel" data-for="term-for-margin-edge" id="infopanel-for-term-for-margin-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-edge" style="display:none">Info about the 'margin edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">8. 
 Gaps Between Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-value" class="dfn-panel" data-for="term-for-inherited-value" id="infopanel-for-term-for-inherited-value" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-value" style="display:none">Info about the 'inherited value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">7.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-items property</a> <a href="#ref-for-inherited-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">5.2. 
 Content-Distribution Shorthand: the place-content property</a>
@@ -3348,8 +3348,8 @@ Self-Alignment Shorthand: the place-items property</a>
 Gap Shorthand: the gap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property①" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property①" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">5.2. 
 Content-Distribution Shorthand: the place-content property</a>
@@ -3361,8 +3361,8 @@ Self-Alignment Shorthand: the place-items property</a>
 Gap Shorthand: the gap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Overview of Alignment Properties</a> <a href="#ref-for-block-container①">(2)</a>
@@ -3371,27 +3371,27 @@ Overview of Alignment Properties</a> <a href="#ref-for-block-container①">(2)</
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">6.1.1. Block-Level Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">6.1.1. Block-Level Boxes</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a>
     <li><a href="#ref-for-containing-block③">6.1.2. Absolutely-Positioned Boxes</a> <a href="#ref-for-containing-block④">(2)</a>
@@ -3401,55 +3401,55 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
     <li><a href="#ref-for-containing-block①③"> Appendix A: Static Position Terminology</a> <a href="#ref-for-containing-block①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establish an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">5.1.1. Block Containers (Including Table Cells)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level-box" class="dfn-panel" data-for="term-for-inline-level-box" id="infopanel-for-term-for-inline-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level-box" style="display:none">Info about the 'inline-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level-box"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-table" class="dfn-panel" data-for="term-for-valdef-display-inline-table" id="infopanel-for-term-for-valdef-display-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">5.4. 
 Baseline Content-Alignment</a> <a href="#ref-for-non-replaced①">(2)</a> <a href="#ref-for-non-replaced②">(3)</a>
@@ -3457,8 +3457,8 @@ Baseline Content-Alignment</a> <a href="#ref-for-non-replaced①">(2)</a> <a hre
     <li><a href="#ref-for-non-replaced④">6.2.5. Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced①" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced①" style="display:none">Info about the 'non-replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">5.4. 
 Baseline Content-Alignment</a> <a href="#ref-for-non-replaced①">(2)</a> <a href="#ref-for-non-replaced②">(3)</a>
@@ -3466,29 +3466,29 @@ Baseline Content-Alignment</a> <a href="#ref-for-non-replaced①">(2)</a> <a hre
     <li><a href="#ref-for-non-replaced④">6.2.5. Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">6.1.5. Grid Items</a>
     <li><a href="#ref-for-replaced-element①">6.2.5. Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-direction-column">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-direction-column" class="dfn-panel" data-for="term-for-valdef-flex-direction-column" id="infopanel-for-term-for-valdef-flex-direction-column" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-direction-column" style="display:none">Info about the 'column' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-column">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-direction-column-reverse">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column-reverse">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column-reverse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-direction-column-reverse" class="dfn-panel" data-for="term-for-valdef-flex-direction-column-reverse" id="infopanel-for-term-for-valdef-flex-direction-column-reverse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-direction-column-reverse" style="display:none">Info about the 'column-reverse' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column-reverse">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column-reverse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-column-reverse">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cross-axis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#cross-axis">https://drafts.csswg.org/css-flexbox-1/#cross-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cross-axis" class="dfn-panel" data-for="term-for-cross-axis" id="infopanel-for-term-for-cross-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-cross-axis" style="display:none">Info about the 'cross axis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#cross-axis">https://drafts.csswg.org/css-flexbox-1/#cross-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-axis">2. 
 Overview of Alignment Properties</a>
@@ -3500,15 +3500,15 @@ Positional Alignment: the center, start, end, self-start, self-end, flex-start, 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">5.1.3. Flex Containers</a>
     <li><a href="#ref-for-propdef-flex①">6.1.4. Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2. 
 Overview of Alignment Properties</a> <a href="#ref-for-flex-container①">(2)</a>
@@ -3527,15 +3527,15 @@ Baseline Alignment Grouping</a>
     <li><a href="#ref-for-flex-container①⑧"> Appendix A: Static Position Terminology</a> <a href="#ref-for-flex-container①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-formatting-context">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context">https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-formatting-context" class="dfn-panel" data-for="term-for-flex-formatting-context" id="infopanel-for-term-for-flex-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-formatting-context" style="display:none">Info about the 'flex formatting context' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context">https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-formatting-context">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-flex-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">2. 
 Overview of Alignment Properties</a>
@@ -3552,15 +3552,15 @@ Baseline Self-Alignment</a>
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-layout">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-layout">https://drafts.csswg.org/css-flexbox-1/#flex-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-layout" class="dfn-panel" data-for="term-for-flex-layout" id="infopanel-for-term-for-flex-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-layout" style="display:none">Info about the 'flex layout' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-layout">https://drafts.csswg.org/css-flexbox-1/#flex-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-layout">10. 
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-line">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-line">https://drafts.csswg.org/css-flexbox-1/#flex-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-line" class="dfn-panel" data-for="term-for-flex-line" id="infopanel-for-term-for-flex-line" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-line" style="display:none">Info about the 'flex line' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-line">https://drafts.csswg.org/css-flexbox-1/#flex-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-line">5.1.3. Flex Containers</a> <a href="#ref-for-flex-line①">(2)</a>
     <li><a href="#ref-for-flex-line②">6.2.4. Flex Items</a>
@@ -3568,22 +3568,22 @@ Changes</a>
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-direction">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-direction" class="dfn-panel" data-for="term-for-propdef-flex-direction" id="infopanel-for-term-for-propdef-flex-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-direction" style="display:none">Info about the 'flex-direction' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-direction">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-propdef-flex-direction①">(2)</a> <a href="#ref-for-propdef-flex-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">5.3. 
 Overflow and Scroll Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-main-axis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#main-axis">https://drafts.csswg.org/css-flexbox-1/#main-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-main-axis" class="dfn-panel" data-for="term-for-main-axis" id="infopanel-for-term-for-main-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-main-axis" style="display:none">Info about the 'main axis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#main-axis">https://drafts.csswg.org/css-flexbox-1/#main-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-axis">2. 
 Overview of Alignment Properties</a>
@@ -3597,8 +3597,8 @@ Baseline Content-Alignment</a>
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-main-axis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#main-axis">https://drafts.csswg.org/css-flexbox-1/#main-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-main-axis" class="dfn-panel" data-for="term-for-main-axis" id="infopanel-for-term-for-main-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-main-axis①" style="display:none">Info about the 'main-axis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#main-axis">https://drafts.csswg.org/css-flexbox-1/#main-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-axis">2. 
 Overview of Alignment Properties</a>
@@ -3612,50 +3612,50 @@ Baseline Content-Alignment</a>
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-line-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container">https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-line-flex-container" class="dfn-panel" data-for="term-for-multi-line-flex-container" id="infopanel-for-term-for-multi-line-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-line-flex-container" style="display:none">Info about the 'multi-line flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container">https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-line-flex-container">5.1.3. Flex Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-direction-row">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-direction-row" class="dfn-panel" data-for="term-for-valdef-flex-direction-row" id="infopanel-for-term-for-valdef-flex-direction-row" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-direction-row" style="display:none">Info about the 'row' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-row">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-direction-row-reverse">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row-reverse">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row-reverse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-direction-row-reverse" class="dfn-panel" data-for="term-for-valdef-flex-direction-row-reverse" id="infopanel-for-term-for-valdef-flex-direction-row-reverse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-direction-row-reverse" style="display:none">Info about the 'row-reverse' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row-reverse">https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-row-reverse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-row-reverse">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collapsed-gutter">
-   <a href="https://drafts.csswg.org/css-grid-1/#collapsed-gutter">https://drafts.csswg.org/css-grid-1/#collapsed-gutter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collapsed-gutter" class="dfn-panel" data-for="term-for-collapsed-gutter" id="infopanel-for-term-for-collapsed-gutter" role="menu">
+   <span id="infopaneltitle-for-term-for-collapsed-gutter" style="display:none">Info about the 'collapsed gutter' external reference.</span><a href="https://drafts.csswg.org/css-grid-1/#collapsed-gutter">https://drafts.csswg.org/css-grid-1/#collapsed-gutter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-gutter">5.1.4. Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-area">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-area" class="dfn-panel" data-for="term-for-grid-area" id="infopanel-for-term-for-grid-area" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-area" style="display:none">Info about the 'grid area' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-area">6.1.5. Grid Items</a>
     <li><a href="#ref-for-grid-area①">6.2.5. Grid Items</a>
     <li><a href="#ref-for-grid-area②"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-column">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-column">https://drafts.csswg.org/css-grid-2/#grid-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-column" class="dfn-panel" data-for="term-for-grid-column" id="infopanel-for-term-for-grid-column" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-column" style="display:none">Info about the 'grid column' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-column">https://drafts.csswg.org/css-grid-2/#grid-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-column">5.1.4. Grid Containers</a>
     <li><a href="#ref-for-grid-column①">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">2. 
 Overview of Alignment Properties</a> <a href="#ref-for-grid-container①">(2)</a> <a href="#ref-for-grid-container②">(3)</a>
@@ -3671,8 +3671,8 @@ Baseline Alignment Grouping</a> <a href="#ref-for-grid-container①①">(2)</a>
     <li><a href="#ref-for-grid-container①②"> Appendix A: Static Position Terminology</a> <a href="#ref-for-grid-container①③">(2)</a> <a href="#ref-for-grid-container①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-item">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-item" class="dfn-panel" data-for="term-for-grid-item" id="infopanel-for-term-for-grid-item" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-item" style="display:none">Info about the 'grid item' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">2. 
 Overview of Alignment Properties</a> <a href="#ref-for-grid-item①">(2)</a>
@@ -3684,35 +3684,35 @@ Baseline Content-Alignment</a>
 Baseline Self-Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-layout">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-layout">https://drafts.csswg.org/css-grid-2/#grid-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-layout" class="dfn-panel" data-for="term-for-grid-layout" id="infopanel-for-term-for-grid-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-layout" style="display:none">Info about the 'grid layout' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-layout">https://drafts.csswg.org/css-grid-2/#grid-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-layout">10. 
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-row">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-row">https://drafts.csswg.org/css-grid-2/#grid-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-row" class="dfn-panel" data-for="term-for-grid-row" id="infopanel-for-term-for-grid-row" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-row" style="display:none">Info about the 'grid row' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-row">https://drafts.csswg.org/css-grid-2/#grid-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-row">5.1.4. Grid Containers</a>
     <li><a href="#ref-for-grid-row①">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-track">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-track" class="dfn-panel" data-for="term-for-grid-track" id="infopanel-for-term-for-grid-track" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-track" style="display:none">Info about the 'grid track' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-track">5.1.4. Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-placement-property">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-placement-property">https://drafts.csswg.org/css-grid-2/#grid-placement-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-placement-property" class="dfn-panel" data-for="term-for-grid-placement-property" id="infopanel-for-term-for-grid-placement-property" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-placement-property" style="display:none">Info about the 'grid-placement property' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-placement-property">https://drafts.csswg.org/css-grid-2/#grid-placement-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-property"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-alignment-baseline" class="dfn-panel" data-for="term-for-propdef-alignment-baseline" id="infopanel-for-term-for-propdef-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-alignment-baseline" style="display:none">Info about the 'alignment-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-alignment-baseline">9.1. 
 Determining the Baselines of a Box</a>
@@ -3720,58 +3720,58 @@ Determining the Baselines of a Box</a>
 Aligning Boxes by Baseline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-bottom">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-bottom" class="dfn-panel" data-for="term-for-valdef-baseline-shift-bottom" id="infopanel-for-term-for-valdef-baseline-shift-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-bottom">5.1.1. Block Containers (Including Table Cells)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-dominant-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-dominant-baseline" class="dfn-panel" data-for="term-for-propdef-dominant-baseline" id="infopanel-for-term-for-propdef-dominant-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-dominant-baseline" style="display:none">Info about the 'dominant-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-dominant-baseline">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-middle">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-middle">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-middle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-middle" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-middle" id="infopanel-for-term-for-valdef-alignment-baseline-middle" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-middle" style="display:none">Info about the 'middle' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-middle">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-middle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-middle">5.1.1. Block Containers (Including Table Cells)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-top">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-top" class="dfn-panel" data-for="term-for-valdef-baseline-shift-top" id="infopanel-for-term-for-valdef-baseline-shift-top" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-top">5.1.1. Block Containers (Including Table Cells)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inset-properties">
-   <a href="https://drafts.csswg.org/css-logical-1/#inset-properties">https://drafts.csswg.org/css-logical-1/#inset-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inset-properties" class="dfn-panel" data-for="term-for-inset-properties" id="infopanel-for-term-for-inset-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-inset-properties" style="display:none">Info about the 'inset properties' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#inset-properties">https://drafts.csswg.org/css-logical-1/#inset-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inset-properties"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-column-width-auto">
-   <a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-column-width-auto" class="dfn-panel" data-for="term-for-valdef-column-width-auto" id="infopanel-for-term-for-valdef-column-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-column-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-auto">5.1.2. Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-column-box">
-   <a href="https://drafts.csswg.org/css-multicol-1/#column-box">https://drafts.csswg.org/css-multicol-1/#column-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-column-box" class="dfn-panel" data-for="term-for-column-box" id="infopanel-for-term-for-column-box" role="menu">
+   <span id="infopaneltitle-for-term-for-column-box" style="display:none">Info about the 'column box' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#column-box">https://drafts.csswg.org/css-multicol-1/#column-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-box">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">5.1.2. Multicol Containers</a> <a href="#ref-for-propdef-column-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">5.1.2. Multicol Containers</a>
     <li><a href="#ref-for-multi-column-container①">8.1. 
@@ -3782,22 +3782,22 @@ Gap Shorthand: the gap property</a>
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-scroll-position">
-   <a href="https://www.w3.org/TR/css-overflow-3/#initial-scroll-position">https://www.w3.org/TR/css-overflow-3/#initial-scroll-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-scroll-position" class="dfn-panel" data-for="term-for-initial-scroll-position" id="infopanel-for-term-for-initial-scroll-position" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-scroll-position" style="display:none">Info about the 'initial scroll position' external reference.</span><a href="https://www.w3.org/TR/css-overflow-3/#initial-scroll-position">https://www.w3.org/TR/css-overflow-3/#initial-scroll-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-scroll-position">5.3. 
 Overflow and Scroll Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">4.4. 
 Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a>
@@ -3809,8 +3809,8 @@ Determining the Baselines of a Box</a> <a href="#ref-for-scroll-container⑨">(2
 Changes</a> <a href="#ref-for-scroll-container①①">(2)</a> <a href="#ref-for-scroll-container①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow area' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">4.4. 
 Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a>
@@ -3818,15 +3818,15 @@ Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a>
 Overflow and Scroll Positions</a> <a href="#ref-for-scrollable-overflow-region②">(2)</a> <a href="#ref-for-scrollable-overflow-region③">(3)</a> <a href="#ref-for-scrollable-overflow-region④">(4)</a> <a href="#ref-for-scrollable-overflow-region⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">5.3. 
 Overflow and Scroll Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-top-auto">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-top-auto">https://drafts.csswg.org/css-position-3/#valdef-top-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-top-auto" class="dfn-panel" data-for="term-for-valdef-top-auto" id="infopanel-for-term-for-valdef-top-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-top-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-top-auto">https://drafts.csswg.org/css-position-3/#valdef-top-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-top-auto">Unnumbered Section</a>
     <li><a href="#ref-for-valdef-top-auto①">6.1.2. Absolutely-Positioned Boxes</a> <a href="#ref-for-valdef-top-auto②">(2)</a> <a href="#ref-for-valdef-top-auto③">(3)</a> <a href="#ref-for-valdef-top-auto④">(4)</a>
@@ -3838,36 +3838,36 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">6.1.2. Absolutely-Positioned Boxes</a>
     <li><a href="#ref-for-propdef-bottom①">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">6.1.2. Absolutely-Positioned Boxes</a>
     <li><a href="#ref-for-propdef-left①">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">6.1.2. Absolutely-Positioned Boxes</a>
     <li><a href="#ref-for-propdef-right①">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">6.1.2. Absolutely-Positioned Boxes</a>
     <li><a href="#ref-for-propdef-top①">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#ref-for-valdef-width-auto①">(2)</a>
@@ -3875,22 +3875,22 @@ Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#re
     <li><a href="#ref-for-valdef-width-auto④">6.2.2. Absolutely-Positioned Boxes</a> <a href="#ref-for-valdef-width-auto⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cyclic-percentage-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-size">https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cyclic-percentage-size" class="dfn-panel" data-for="term-for-cyclic-percentage-size" id="infopanel-for-term-for-cyclic-percentage-size" role="menu">
+   <span id="infopaneltitle-for-term-for-cyclic-percentage-size" style="display:none">Info about the 'cyclic percentage size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-size">https://drafts.csswg.org/css-sizing-3/#cyclic-percentage-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cyclic-percentage-size">8.3. 
 Percentages In gap Properties</a> <a href="#ref-for-cyclic-percentage-size①">(2)</a> <a href="#ref-for-cyclic-percentage-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">6.1.2. Absolutely-Positioned Boxes</a>
     <li><a href="#ref-for-fit-content-size①">6.2.2. Absolutely-Positioned Boxes</a>
@@ -3898,8 +3898,8 @@ Percentages In gap Properties</a> <a href="#ref-for-cyclic-percentage-size①">(
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#ref-for-propdef-height①">(2)</a>
@@ -3907,15 +3907,15 @@ Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#re
     <li><a href="#ref-for-propdef-height③">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#ref-for-propdef-width①">(2)</a>
@@ -3923,22 +3923,22 @@ Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#re
     <li><a href="#ref-for-propdef-width③">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -3946,15 +3946,15 @@ Baseline Alignment: the baseline keyword and first/last modifiers</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-items property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -3978,15 +3978,15 @@ Self-Alignment Shorthand: the place-items property</a>
 Gap Shorthand: the gap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a>
@@ -4010,22 +4010,22 @@ Block-Axis (or Cross-Axis) Alignment: the align-items property</a> <a href="#ref
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a> <a href="#ref-for-propdef-direction④">(5)</a> <a href="#ref-for-propdef-direction⑤">(6)</a> <a href="#ref-for-propdef-direction⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dominant-baseline">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#dominant-baseline">https://drafts.csswg.org/css-writing-modes-3/#dominant-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dominant-baseline" class="dfn-panel" data-for="term-for-dominant-baseline" id="infopanel-for-term-for-dominant-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-dominant-baseline" style="display:none">Info about the 'dominant baseline' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#dominant-baseline">https://drafts.csswg.org/css-writing-modes-3/#dominant-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dominant-baseline">9.3. 
 Aligning Boxes by Baseline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2. 
 Overview of Alignment Properties</a>
@@ -4043,8 +4043,8 @@ Baseline Content-Alignment</a>
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-block-flow-direction①">(2)</a>
@@ -4052,35 +4052,35 @@ Determining the Baselines of a Box</a> <a href="#ref-for-block-flow-direction①
 Baseline Alignment Grouping</a> <a href="#ref-for-block-flow-direction③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-flow-relative①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb" id="infopanel-for-term-for-valdef-writing-mode-horizontal-tb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">2. 
 Overview of Alignment Properties</a>
@@ -4099,15 +4099,15 @@ Row and Column Gutters: the row-gap and column-gap properties</a> <a href="#ref-
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis①" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">2. 
 Overview of Alignment Properties</a>
@@ -4126,88 +4126,88 @@ Row and Column Gutters: the row-gap and column-gap properties</a> <a href="#ref-
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
     <li><a href="#ref-for-inline-start①"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-orientation">https://drafts.csswg.org/css-writing-modes-4/#line-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-orientation" class="dfn-panel" data-for="term-for-line-orientation" id="infopanel-for-term-for-line-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-line-orientation" style="display:none">Info about the 'line orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-orientation">https://drafts.csswg.org/css-writing-modes-4/#line-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-orientation">9.3. 
 Aligning Boxes by Baseline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-left" class="dfn-panel" data-for="term-for-line-left" id="infopanel-for-term-for-line-left" role="menu">
+   <span id="infopaneltitle-for-term-for-line-left" style="display:none">Info about the 'line-left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-over" class="dfn-panel" data-for="term-for-line-over" id="infopanel-for-term-for-line-over" role="menu">
+   <span id="infopaneltitle-for-term-for-line-over" style="display:none">Info about the 'line-over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">9.1. 
 Determining the Baselines of a Box</a>
     <li><a href="#ref-for-line-over①"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-right" class="dfn-panel" data-for="term-for-line-right" id="infopanel-for-term-for-line-right" role="menu">
+   <span id="infopaneltitle-for-term-for-line-right" style="display:none">Info about the 'line-right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-under" class="dfn-panel" data-for="term-for-line-under" id="infopanel-for-term-for-line-under" role="menu">
+   <span id="infopaneltitle-for-term-for-line-under" style="display:none">Info about the 'line-under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-line-under①">(2)</a>
     <li><a href="#ref-for-line-under②"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a> <a href="#ref-for-valdef-direction-ltr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical-left">https://drafts.csswg.org/css-writing-modes-4/#physical-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-left" class="dfn-panel" data-for="term-for-physical-left" id="infopanel-for-term-for-physical-left" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-left" style="display:none">Info about the 'physical left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical-left">https://drafts.csswg.org/css-writing-modes-4/#physical-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-left">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical-right">https://drafts.csswg.org/css-writing-modes-4/#physical-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-right" class="dfn-panel" data-for="term-for-physical-right" id="infopanel-for-term-for-physical-right" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-right" style="display:none">Info about the 'physical right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical-right">https://drafts.csswg.org/css-writing-modes-4/#physical-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-right">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-rtl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-rtl" class="dfn-panel" data-for="term-for-valdef-direction-rtl" id="infopanel-for-term-for-valdef-direction-rtl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">6.5. 
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a> <a href="#ref-for-valdef-direction-rtl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
@@ -4215,15 +4215,15 @@ Positional Alignment: the center, start, end, self-start, self-end, flex-start, 
     <li><a href="#ref-for-vertical-writing-mode②">6.2.2. Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr" id="infopanel-for-term-for-valdef-writing-mode-vertical-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">9.1. 
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3. 
 Alignment Terminology</a> <a href="#ref-for-writing-mode①">(2)</a> <a href="#ref-for-writing-mode②">(3)</a>
@@ -4243,28 +4243,28 @@ Baseline Alignment Details</a>
 Determining the Baselines of a Box</a> <a href="#ref-for-writing-mode②①">(2)</a> <a href="#ref-for-writing-mode②②">(3)</a> <a href="#ref-for-writing-mode②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css2/#line-box">https://drafts.csswg.org/css2/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css2/#line-box">https://drafts.csswg.org/css2/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -4272,8 +4272,8 @@ Distributed Alignment: the stretch, space-between, space-around, and space-evenl
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -4281,22 +4281,22 @@ Distributed Alignment: the stretch, space-between, space-around, and space-evenl
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css2/#propdef-vertical-align">https://drafts.csswg.org/css2/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-vertical-align">https://drafts.csswg.org/css2/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">1.1. 
 Module Interactions</a>
@@ -4307,8 +4307,8 @@ Baseline Alignment: the baseline keyword and first/last modifiers</a>
 Baseline Alignment Grouping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-formatted-line0">
-   <a href="https://drafts.csswg.org/selectors-3/#first-formatted-line0">https://drafts.csswg.org/selectors-3/#first-formatted-line0</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-formatted-line0" class="dfn-panel" data-for="term-for-first-formatted-line0" id="infopanel-for-term-for-first-formatted-line0" role="menu">
+   <span id="infopaneltitle-for-term-for-first-formatted-line0" style="display:none">Info about the 'first formatted line' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#first-formatted-line0">https://drafts.csswg.org/selectors-3/#first-formatted-line0</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line0">9. 
 Baseline Alignment Details</a>
@@ -4712,16 +4712,16 @@ Baseline Alignment Details</a>
    <div class="issue"> Coordinate wording with css-overflow once it’s less of a mess. <a class="issue-return" href="#issue-9ce4b594" title="Jump to section">↵</a></div>
    <div class="issue"> Replace this image too. <a class="issue-return" href="#issue-f4825563" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="box-alignment-properties">
-   <b><a href="#box-alignment-properties">#box-alignment-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-alignment-properties" class="dfn-panel" data-for="box-alignment-properties" id="infopanel-for-box-alignment-properties" role="dialog">
+   <span id="infopaneltitle-for-box-alignment-properties" style="display:none">Info about the 'box alignment properties' definition.</span><b><a href="#box-alignment-properties">#box-alignment-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-alignment-properties①">2. 
 Overview of Alignment Properties</a>
     <li><a href="#ref-for-box-alignment-properties②"> Appendix A: Static Position Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alignment-subject">
-   <b><a href="#alignment-subject">#alignment-subject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alignment-subject" class="dfn-panel" data-for="alignment-subject" id="infopanel-for-alignment-subject" role="dialog">
+   <span id="infopaneltitle-for-alignment-subject" style="display:none">Info about the 'alignment subject' definition.</span><b><a href="#alignment-subject">#alignment-subject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-subject">3. 
 Alignment Terminology</a> <a href="#ref-for-alignment-subject①">(2)</a> <a href="#ref-for-alignment-subject②">(3)</a> <a href="#ref-for-alignment-subject③">(4)</a> <a href="#ref-for-alignment-subject④">(5)</a> <a href="#ref-for-alignment-subject⑤">(6)</a>
@@ -4757,8 +4757,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-self property</a>
 Aligning Boxes by Baseline</a> <a href="#ref-for-alignment-subject⑥⑧">(2)</a> <a href="#ref-for-alignment-subject⑥⑨">(3)</a> <a href="#ref-for-alignment-subject⑦⓪">(4)</a> <a href="#ref-for-alignment-subject⑦①">(5)</a> <a href="#ref-for-alignment-subject⑦②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alignment-container">
-   <b><a href="#alignment-container">#alignment-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alignment-container" class="dfn-panel" data-for="alignment-container" id="infopanel-for-alignment-container" role="dialog">
+   <span id="infopaneltitle-for-alignment-container" style="display:none">Info about the 'alignment container' definition.</span><b><a href="#alignment-container">#alignment-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-container">3. 
 Alignment Terminology</a>
@@ -4794,8 +4794,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-self property</a> <a href="#ref-
 Aligning Boxes by Baseline</a> <a href="#ref-for-alignment-container⑤⓪">(2)</a> <a href="#ref-for-alignment-container⑤①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fallback-alignment">
-   <b><a href="#fallback-alignment">#fallback-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fallback-alignment" class="dfn-panel" data-for="fallback-alignment" id="infopanel-for-fallback-alignment" role="dialog">
+   <span id="infopaneltitle-for-fallback-alignment" style="display:none">Info about the 'fallback alignment' definition.</span><b><a href="#fallback-alignment">#fallback-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback-alignment">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-fallback-alignment①">(2)</a> <a href="#ref-for-fallback-alignment②">(3)</a> <a href="#ref-for-fallback-alignment③">(4)</a> <a href="#ref-for-fallback-alignment④">(5)</a>
@@ -4813,15 +4813,15 @@ Aligning Boxes by Baseline</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="positional-alignment">
-   <b><a href="#positional-alignment">#positional-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-positional-alignment" class="dfn-panel" data-for="positional-alignment" id="infopanel-for-positional-alignment" role="dialog">
+   <span id="infopaneltitle-for-positional-alignment" style="display:none">Info about the 'positional alignment' definition.</span><b><a href="#positional-alignment">#positional-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positional-alignment">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-center">
-   <b><a href="#valdef-self-position-center">#valdef-self-position-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-center" class="dfn-panel" data-for="valdef-self-position-center" id="infopanel-for-valdef-self-position-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-self-position-center">#valdef-self-position-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
@@ -4832,8 +4832,8 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-items property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-start">
-   <b><a href="#valdef-self-position-start">#valdef-self-position-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-start" class="dfn-panel" data-for="valdef-self-position-start" id="infopanel-for-valdef-self-position-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-self-position-start">#valdef-self-position-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">1.3. 
 Partial Implementations</a>
@@ -4860,8 +4860,8 @@ Baseline Content-Alignment</a>
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-end">
-   <b><a href="#valdef-self-position-end">#valdef-self-position-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-end" class="dfn-panel" data-for="valdef-self-position-end" id="infopanel-for-valdef-self-position-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-self-position-end">#valdef-self-position-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-end">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-valdef-self-position-end①">(2)</a> <a href="#ref-for-valdef-self-position-end②">(3)</a> <a href="#ref-for-valdef-self-position-end③">(4)</a> <a href="#ref-for-valdef-self-position-end④">(5)</a> <a href="#ref-for-valdef-self-position-end⑤">(6)</a> <a href="#ref-for-valdef-self-position-end⑥">(7)</a> <a href="#ref-for-valdef-self-position-end⑦">(8)</a> <a href="#ref-for-valdef-self-position-end⑧">(9)</a> <a href="#ref-for-valdef-self-position-end⑨">(10)</a> <a href="#ref-for-valdef-self-position-end①⓪">(11)</a> <a href="#ref-for-valdef-self-position-end①①">(12)</a> <a href="#ref-for-valdef-self-position-end①②">(13)</a>
@@ -4876,8 +4876,8 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-self-start">
-   <b><a href="#valdef-self-position-self-start">#valdef-self-position-self-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-self-start" class="dfn-panel" data-for="valdef-self-position-self-start" id="infopanel-for-valdef-self-position-self-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-self-start" style="display:none">Info about the 'self-start' definition.</span><b><a href="#valdef-self-position-self-start">#valdef-self-position-self-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-self-start">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-valdef-self-position-self-start①">(2)</a> <a href="#ref-for-valdef-self-position-self-start②">(3)</a> <a href="#ref-for-valdef-self-position-self-start③">(4)</a>
@@ -4887,8 +4887,8 @@ Baseline Content-Alignment</a> <a href="#ref-for-valdef-self-position-self-start
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-self-end">
-   <b><a href="#valdef-self-position-self-end">#valdef-self-position-self-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-self-end" class="dfn-panel" data-for="valdef-self-position-self-end" id="infopanel-for-valdef-self-position-self-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-self-end" style="display:none">Info about the 'self-end' definition.</span><b><a href="#valdef-self-position-self-end">#valdef-self-position-self-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-self-end">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-valdef-self-position-self-end①">(2)</a>
@@ -4898,8 +4898,8 @@ Baseline Content-Alignment</a> <a href="#ref-for-valdef-self-position-self-end�
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-flex-start">
-   <b><a href="#valdef-self-position-flex-start">#valdef-self-position-flex-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-flex-start" class="dfn-panel" data-for="valdef-self-position-flex-start" id="infopanel-for-valdef-self-position-flex-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-flex-start" style="display:none">Info about the 'flex-start' definition.</span><b><a href="#valdef-self-position-flex-start">#valdef-self-position-flex-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-flex-start">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
@@ -4912,8 +4912,8 @@ Baseline Content-Alignment</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-self-position-flex-end">
-   <b><a href="#valdef-self-position-flex-end">#valdef-self-position-flex-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-self-position-flex-end" class="dfn-panel" data-for="valdef-self-position-flex-end" id="infopanel-for-valdef-self-position-flex-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-self-position-flex-end" style="display:none">Info about the 'flex-end' definition.</span><b><a href="#valdef-self-position-flex-end">#valdef-self-position-flex-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-flex-end">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a>
@@ -4921,8 +4921,8 @@ Positional Alignment: the center, start, end, self-start, self-end, flex-start, 
 Baseline Content-Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-content-left">
-   <b><a href="#valdef-justify-content-left">#valdef-justify-content-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-content-left" class="dfn-panel" data-for="valdef-justify-content-left" id="infopanel-for-valdef-justify-content-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-content-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-justify-content-left">#valdef-justify-content-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-left">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-valdef-justify-content-left①">(2)</a> <a href="#ref-for-valdef-justify-content-left②">(3)</a> <a href="#ref-for-valdef-justify-content-left③">(4)</a> <a href="#ref-for-valdef-justify-content-left④">(5)</a> <a href="#ref-for-valdef-justify-content-left⑤">(6)</a>
@@ -4932,8 +4932,8 @@ Inline-Axis (or Main-Axis) Alignment: the justify-items property</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-content-right">
-   <b><a href="#valdef-justify-content-right">#valdef-justify-content-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-content-right" class="dfn-panel" data-for="valdef-justify-content-right" id="infopanel-for-valdef-justify-content-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-content-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-justify-content-right">#valdef-justify-content-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-right">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-valdef-justify-content-right①">(2)</a> <a href="#ref-for-valdef-justify-content-right②">(3)</a> <a href="#ref-for-valdef-justify-content-right③">(4)</a> <a href="#ref-for-valdef-justify-content-right④">(5)</a> <a href="#ref-for-valdef-justify-content-right⑤">(6)</a>
@@ -4943,8 +4943,8 @@ Inline-Axis (or Main-Axis) Alignment: the justify-items property</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-self-position">
-   <b><a href="#typedef-self-position">#typedef-self-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-self-position" class="dfn-panel" data-for="typedef-self-position" id="infopanel-for-typedef-self-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-self-position" style="display:none">Info about the '&lt;self-position>' definition.</span><b><a href="#typedef-self-position">#typedef-self-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-self-position">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-typedef-self-position①">(2)</a>
@@ -4958,8 +4958,8 @@ Inline-Axis (or Main-Axis) Alignment: the justify-items property</a>
 Block-Axis (or Cross-Axis) Alignment: the align-items property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-content-position">
-   <b><a href="#typedef-content-position">#typedef-content-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-content-position" class="dfn-panel" data-for="typedef-content-position" id="infopanel-for-typedef-content-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-content-position" style="display:none">Info about the '&lt;content-position>' definition.</span><b><a href="#typedef-content-position">#typedef-content-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-position">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-typedef-content-position①">(2)</a>
@@ -4969,8 +4969,8 @@ The justify-content and align-content Properties</a> <a href="#ref-for-typedef-c
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-alignment">
-   <b><a href="#baseline-alignment">#baseline-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-alignment" class="dfn-panel" data-for="baseline-alignment" id="infopanel-for-baseline-alignment" role="dialog">
+   <span id="infopaneltitle-for-baseline-alignment" style="display:none">Info about the 'Baseline alignment' definition.</span><b><a href="#baseline-alignment">#baseline-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-baseline-alignment①">(2)</a>
@@ -4978,8 +4978,8 @@ Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-baseline-position">
-   <b><a href="#typedef-baseline-position">#typedef-baseline-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-baseline-position" class="dfn-panel" data-for="typedef-baseline-position" id="infopanel-for-typedef-baseline-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-baseline-position" style="display:none">Info about the '&lt;baseline-position>' definition.</span><b><a href="#typedef-baseline-position">#typedef-baseline-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-baseline-position">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -4999,8 +4999,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-items property</a>
 Changes</a> <a href="#ref-for-typedef-baseline-position①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-alignment-preference">
-   <b><a href="#baseline-alignment-preference">#baseline-alignment-preference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-alignment-preference" class="dfn-panel" data-for="baseline-alignment-preference" id="infopanel-for-baseline-alignment-preference" role="dialog">
+   <span id="infopaneltitle-for-baseline-alignment-preference" style="display:none">Info about the 'baseline alignment preference' definition.</span><b><a href="#baseline-alignment-preference">#baseline-alignment-preference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment-preference">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -5012,8 +5012,8 @@ Baseline Alignment Grouping</a> <a href="#ref-for-baseline-alignment-preference�
 Aligning Boxes by Baseline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-self-baseline">
-   <b><a href="#valdef-justify-self-baseline">#valdef-justify-self-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-self-baseline" class="dfn-panel" data-for="valdef-justify-self-baseline" id="infopanel-for-valdef-justify-self-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-self-baseline" style="display:none">Info about the 'baseline' definition.</span><b><a href="#valdef-justify-self-baseline">#valdef-justify-self-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-baseline">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-valdef-justify-self-baseline①">(2)</a> <a href="#ref-for-valdef-justify-self-baseline②">(3)</a> <a href="#ref-for-valdef-justify-self-baseline③">(4)</a>
@@ -5022,8 +5022,8 @@ Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-self-first-baseline">
-   <b><a href="#valdef-justify-self-first-baseline">#valdef-justify-self-first-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-self-first-baseline" class="dfn-panel" data-for="valdef-justify-self-first-baseline" id="infopanel-for-valdef-justify-self-first-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-self-first-baseline" style="display:none">Info about the 'first baseline' definition.</span><b><a href="#valdef-justify-self-first-baseline">#valdef-justify-self-first-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-first-baseline">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-valdef-justify-self-first-baseline①">(2)</a> <a href="#ref-for-valdef-justify-self-first-baseline②">(3)</a> <a href="#ref-for-valdef-justify-self-first-baseline③">(4)</a> <a href="#ref-for-valdef-justify-self-first-baseline④">(5)</a> <a href="#ref-for-valdef-justify-self-first-baseline⑤">(6)</a>
@@ -5035,15 +5035,15 @@ Baseline Self-Alignment</a> <a href="#ref-for-valdef-justify-self-first-baseline
 Determining the Baselines of a Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-baseline-alignment">
-   <b><a href="#first-baseline-alignment">#first-baseline-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-baseline-alignment" class="dfn-panel" data-for="first-baseline-alignment" id="infopanel-for-first-baseline-alignment" role="dialog">
+   <span id="infopaneltitle-for-first-baseline-alignment" style="display:none">Info about the 'first-baseline alignment' definition.</span><b><a href="#first-baseline-alignment">#first-baseline-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-baseline-alignment">9.2. 
 Baseline Alignment Grouping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-self-last-baseline">
-   <b><a href="#valdef-justify-self-last-baseline">#valdef-justify-self-last-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-self-last-baseline" class="dfn-panel" data-for="valdef-justify-self-last-baseline" id="infopanel-for-valdef-justify-self-last-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-self-last-baseline" style="display:none">Info about the 'last baseline' definition.</span><b><a href="#valdef-justify-self-last-baseline">#valdef-justify-self-last-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-last-baseline">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-valdef-justify-self-last-baseline①">(2)</a> <a href="#ref-for-valdef-justify-self-last-baseline②">(3)</a>
@@ -5057,15 +5057,15 @@ Determining the Baselines of a Box</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-baseline-alignment">
-   <b><a href="#last-baseline-alignment">#last-baseline-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-baseline-alignment" class="dfn-panel" data-for="last-baseline-alignment" id="infopanel-for-last-baseline-alignment" role="dialog">
+   <span id="infopaneltitle-for-last-baseline-alignment" style="display:none">Info about the 'last-baseline alignment' definition.</span><b><a href="#last-baseline-alignment">#last-baseline-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-alignment">9.2. 
 Baseline Alignment Grouping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distributed-alignment">
-   <b><a href="#distributed-alignment">#distributed-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distributed-alignment" class="dfn-panel" data-for="distributed-alignment" id="infopanel-for-distributed-alignment" role="dialog">
+   <span id="infopaneltitle-for-distributed-alignment" style="display:none">Info about the 'distributed alignment' definition.</span><b><a href="#distributed-alignment">#distributed-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distributed-alignment">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -5073,8 +5073,8 @@ Distributed Alignment: the stretch, space-between, space-around, and space-evenl
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-space-between">
-   <b><a href="#valdef-align-content-space-between">#valdef-align-content-space-between</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-space-between" class="dfn-panel" data-for="valdef-align-content-space-between" id="infopanel-for-valdef-align-content-space-between" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-space-between" style="display:none">Info about the 'space-between' definition.</span><b><a href="#valdef-align-content-space-between">#valdef-align-content-space-between</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-between">3. 
 Alignment Terminology</a>
@@ -5086,8 +5086,8 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
 Row and Column Gutters: the row-gap and column-gap properties</a> <a href="#ref-for-valdef-align-content-space-between④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-space-around">
-   <b><a href="#valdef-align-content-space-around">#valdef-align-content-space-around</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-space-around" class="dfn-panel" data-for="valdef-align-content-space-around" id="infopanel-for-valdef-align-content-space-around" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-space-around" style="display:none">Info about the 'space-around' definition.</span><b><a href="#valdef-align-content-space-around">#valdef-align-content-space-around</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-around">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -5095,8 +5095,8 @@ Distributed Alignment: the stretch, space-between, space-around, and space-evenl
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-space-evenly">
-   <b><a href="#valdef-align-content-space-evenly">#valdef-align-content-space-evenly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-space-evenly" class="dfn-panel" data-for="valdef-align-content-space-evenly" id="infopanel-for-valdef-align-content-space-evenly" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-space-evenly" style="display:none">Info about the 'space-evenly' definition.</span><b><a href="#valdef-align-content-space-evenly">#valdef-align-content-space-evenly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-evenly">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -5106,8 +5106,8 @@ Row and Column Gutters: the row-gap and column-gap properties</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-stretch">
-   <b><a href="#valdef-align-content-stretch">#valdef-align-content-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-stretch" class="dfn-panel" data-for="valdef-align-content-stretch" id="infopanel-for-valdef-align-content-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-align-content-stretch">#valdef-align-content-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-stretch">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -5116,8 +5116,8 @@ Distributed Alignment: the stretch, space-between, space-around, and space-evenl
     <li><a href="#ref-for-valdef-align-content-stretch⑤">5.1.4. Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-content-distribution">
-   <b><a href="#typedef-content-distribution">#typedef-content-distribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-content-distribution" class="dfn-panel" data-for="typedef-content-distribution" id="infopanel-for-typedef-content-distribution" role="dialog">
+   <span id="infopaneltitle-for-typedef-content-distribution" style="display:none">Info about the '&lt;content-distribution>' definition.</span><b><a href="#typedef-content-distribution">#typedef-content-distribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-distribution">4.3. 
 Distributed Alignment: the stretch, space-between, space-around, and space-evenly keywords</a>
@@ -5127,8 +5127,8 @@ The justify-content and align-content Properties</a> <a href="#ref-for-typedef-c
     <li><a href="#ref-for-typedef-content-distribution④">5.1.2. Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overflow-alignment">
-   <b><a href="#overflow-alignment">#overflow-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow-alignment" class="dfn-panel" data-for="overflow-alignment" id="infopanel-for-overflow-alignment" role="dialog">
+   <span id="infopaneltitle-for-overflow-alignment" style="display:none">Info about the 'overflow alignment' definition.</span><b><a href="#overflow-alignment">#overflow-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-alignment">4.4. 
 Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a> <a href="#ref-for-overflow-alignment①">(2)</a>
@@ -5136,8 +5136,8 @@ Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a> <a
 Baseline Content-Alignment</a> <a href="#ref-for-overflow-alignment③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-overflow-position">
-   <b><a href="#typedef-overflow-position">#typedef-overflow-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-overflow-position" class="dfn-panel" data-for="typedef-overflow-position" id="infopanel-for-typedef-overflow-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-overflow-position" style="display:none">Info about the '&lt;overflow-position>' definition.</span><b><a href="#typedef-overflow-position">#typedef-overflow-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-overflow-position②">5.1. 
 The justify-content and align-content Properties</a> <a href="#ref-for-typedef-overflow-position③">(2)</a>
@@ -5153,8 +5153,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-items property</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-position-safe">
-   <b><a href="#valdef-overflow-position-safe">#valdef-overflow-position-safe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-position-safe" class="dfn-panel" data-for="valdef-overflow-position-safe" id="infopanel-for-valdef-overflow-position-safe" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-position-safe" style="display:none">Info about the 'safe' definition.</span><b><a href="#valdef-overflow-position-safe">#valdef-overflow-position-safe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-position-safe①">4.4. 
 Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a>
@@ -5162,8 +5162,8 @@ Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-position-unsafe">
-   <b><a href="#valdef-overflow-position-unsafe">#valdef-overflow-position-unsafe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-position-unsafe" class="dfn-panel" data-for="valdef-overflow-position-unsafe" id="infopanel-for-valdef-overflow-position-unsafe" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-position-unsafe" style="display:none">Info about the 'unsafe' definition.</span><b><a href="#valdef-overflow-position-unsafe">#valdef-overflow-position-unsafe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-position-unsafe">4.4. 
 Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a> <a href="#ref-for-valdef-overflow-position-unsafe①">(2)</a>
@@ -5171,15 +5171,15 @@ Overflow Alignment: the safe and unsafe keywords and scroll safety limits</a> <a
 Baseline Content-Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-distribute">
-   <b><a href="#content-distribute">#content-distribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-distribute" class="dfn-panel" data-for="content-distribute" id="infopanel-for-content-distribute" role="dialog">
+   <span id="infopaneltitle-for-content-distribute" style="display:none">Info about the 'Content-distribution' definition.</span><b><a href="#content-distribute">#content-distribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-distribute">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-content-distribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-distribution-properties">
-   <b><a href="#content-distribution-properties">#content-distribution-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-distribution-properties" class="dfn-panel" data-for="content-distribution-properties" id="infopanel-for-content-distribution-properties" role="dialog">
+   <span id="infopaneltitle-for-content-distribution-properties" style="display:none">Info about the 'content-distribution properties' definition.</span><b><a href="#content-distribution-properties">#content-distribution-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-distribution-properties">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-content-distribution-properties①">(2)</a>
@@ -5191,8 +5191,8 @@ Row and Column Gutters: the row-gap and column-gap properties</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-content">
-   <b><a href="#propdef-align-content">#propdef-align-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-content" class="dfn-panel" data-for="propdef-align-content" id="infopanel-for-propdef-align-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-content" style="display:none">Info about the 'align-content' definition.</span><b><a href="#propdef-align-content">#propdef-align-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">2. 
 Overview of Alignment Properties</a>
@@ -5226,8 +5226,8 @@ Baseline Alignment Details</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-justify-content">
-   <b><a href="#propdef-justify-content">#propdef-justify-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-justify-content" class="dfn-panel" data-for="propdef-justify-content" id="infopanel-for-propdef-justify-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-justify-content" style="display:none">Info about the 'justify-content' definition.</span><b><a href="#propdef-justify-content">#propdef-justify-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">2. 
 Overview of Alignment Properties</a>
@@ -5258,8 +5258,8 @@ Row and Column Gutters: the row-gap and column-gap properties</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-content-normal">
-   <b><a href="#valdef-justify-content-normal">#valdef-justify-content-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-content-normal" class="dfn-panel" data-for="valdef-justify-content-normal" id="infopanel-for-valdef-justify-content-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-content-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-justify-content-normal">#valdef-justify-content-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-normal">5.1.1. Block Containers (Including Table Cells)</a> <a href="#ref-for-valdef-justify-content-normal①">(2)</a> <a href="#ref-for-valdef-justify-content-normal②">(3)</a>
     <li><a href="#ref-for-valdef-justify-content-normal③">5.1.2. Multicol Containers</a> <a href="#ref-for-valdef-justify-content-normal④">(2)</a> <a href="#ref-for-valdef-justify-content-normal⑤">(3)</a>
@@ -5269,8 +5269,8 @@ Changes</a>
 Overflow and Scroll Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-place-content">
-   <b><a href="#propdef-place-content">#propdef-place-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-place-content" class="dfn-panel" data-for="propdef-place-content" id="infopanel-for-propdef-place-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-place-content" style="display:none">Info about the 'place-content' definition.</span><b><a href="#propdef-place-content">#propdef-place-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-content">5. 
 Content Distribution: Aligning a Box’s Contents Within Itself</a>
@@ -5278,8 +5278,8 @@ Content Distribution: Aligning a Box’s Contents Within Itself</a>
 Content-Distribution Shorthand: the place-content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-content-alignment">
-   <b><a href="#baseline-content-alignment">#baseline-content-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-content-alignment" class="dfn-panel" data-for="baseline-content-alignment" id="infopanel-for-baseline-content-alignment" role="dialog">
+   <span id="infopaneltitle-for-baseline-content-alignment" style="display:none">Info about the 'Baseline content-alignment' definition.</span><b><a href="#baseline-content-alignment">#baseline-content-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-content-alignment">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-baseline-content-alignment①">(2)</a>
@@ -5293,8 +5293,8 @@ Baseline Alignment Grouping</a>
 Aligning Boxes by Baseline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="self-align">
-   <b><a href="#self-align">#self-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-self-align" class="dfn-panel" data-for="self-align" id="infopanel-for-self-align" role="dialog">
+   <span id="infopaneltitle-for-self-align" style="display:none">Info about the 'Self-alignment' definition.</span><b><a href="#self-align">#self-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-align">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-self-align①">(2)</a>
@@ -5304,8 +5304,8 @@ Baseline Content-Alignment</a>
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="self-alignment-properties">
-   <b><a href="#self-alignment-properties">#self-alignment-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-self-alignment-properties" class="dfn-panel" data-for="self-alignment-properties" id="infopanel-for-self-alignment-properties" role="dialog">
+   <span id="infopaneltitle-for-self-alignment-properties" style="display:none">Info about the 'self-alignment properties' definition.</span><b><a href="#self-alignment-properties">#self-alignment-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-alignment-properties">4.1. 
 Positional Alignment: the center, start, end, self-start, self-end, flex-start, flex-end, left, and right keywords</a> <a href="#ref-for-self-alignment-properties①">(2)</a>
@@ -5317,8 +5317,8 @@ Baseline Content-Alignment</a>
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-justify-self">
-   <b><a href="#propdef-justify-self">#propdef-justify-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-justify-self" class="dfn-panel" data-for="propdef-justify-self" id="infopanel-for-propdef-justify-self" role="dialog">
+   <span id="infopaneltitle-for-propdef-justify-self" style="display:none">Info about the 'justify-self' definition.</span><b><a href="#propdef-justify-self">#propdef-justify-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">2. 
 Overview of Alignment Properties</a>
@@ -5349,8 +5349,8 @@ Default Alignment</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-items property</a> <a href="#ref-for-propdef-justify-self②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-self-normal">
-   <b><a href="#valdef-justify-self-normal">#valdef-justify-self-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-self-normal" class="dfn-panel" data-for="valdef-justify-self-normal" id="infopanel-for-valdef-justify-self-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-self-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-justify-self-normal">#valdef-justify-self-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-normal">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
@@ -5362,8 +5362,8 @@ Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
 Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-self-stretch">
-   <b><a href="#valdef-justify-self-stretch">#valdef-justify-self-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-self-stretch" class="dfn-panel" data-for="valdef-justify-self-stretch" id="infopanel-for-valdef-justify-self-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-self-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-justify-self-stretch">#valdef-justify-self-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-stretch">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#ref-for-valdef-justify-self-stretch①">(2)</a>
@@ -5373,8 +5373,8 @@ Inline-Axis (or Main-Axis) Alignment: the justify-self property</a> <a href="#re
     <li><a href="#ref-for-valdef-justify-self-stretch⑦">6.2.5. Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-self">
-   <b><a href="#propdef-align-self">#propdef-align-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-self" class="dfn-panel" data-for="propdef-align-self" id="infopanel-for-propdef-align-self" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-self" style="display:none">Info about the 'align-self' definition.</span><b><a href="#propdef-align-self">#propdef-align-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">1.3. 
 Partial Implementations</a> <a href="#ref-for-propdef-align-self①">(2)</a> <a href="#ref-for-propdef-align-self②">(3)</a>
@@ -5410,8 +5410,8 @@ Baseline Alignment Grouping</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-self-normal">
-   <b><a href="#valdef-align-self-normal">#valdef-align-self-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-self-normal" class="dfn-panel" data-for="valdef-align-self-normal" id="infopanel-for-valdef-align-self-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-self-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-align-self-normal">#valdef-align-self-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-normal">6.2. 
 Block-Axis (or Cross-Axis) Alignment: the align-self property</a>
@@ -5420,8 +5420,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-self property</a>
     <li><a href="#ref-for-valdef-align-self-normal⑥">6.2.5. Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-self-stretch">
-   <b><a href="#valdef-align-self-stretch">#valdef-align-self-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-self-stretch" class="dfn-panel" data-for="valdef-align-self-stretch" id="infopanel-for-valdef-align-self-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-align-self-stretch">#valdef-align-self-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">5.4. 
 Baseline Content-Alignment</a>
@@ -5430,8 +5430,8 @@ Baseline Content-Alignment</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-place-self">
-   <b><a href="#propdef-place-self">#propdef-place-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-place-self" class="dfn-panel" data-for="propdef-place-self" id="infopanel-for-propdef-place-self" role="dialog">
+   <span id="infopaneltitle-for-propdef-place-self" style="display:none">Info about the 'place-self' definition.</span><b><a href="#propdef-place-self">#propdef-place-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-self">6. 
 Self-Alignment: Aligning the Box Within Its Parent</a>
@@ -5439,8 +5439,8 @@ Self-Alignment: Aligning the Box Within Its Parent</a>
 Self-Alignment Shorthand: the place-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-self-alignment">
-   <b><a href="#baseline-self-alignment">#baseline-self-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-self-alignment" class="dfn-panel" data-for="baseline-self-alignment" id="infopanel-for-baseline-self-alignment" role="dialog">
+   <span id="infopaneltitle-for-baseline-self-alignment" style="display:none">Info about the 'Baseline self-alignment' definition.</span><b><a href="#baseline-self-alignment">#baseline-self-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-self-alignment">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-baseline-self-alignment①">(2)</a> <a href="#ref-for-baseline-self-alignment②">(3)</a>
@@ -5454,8 +5454,8 @@ Baseline Self-Alignment</a> <a href="#ref-for-baseline-self-alignment⑥">(2)</a
 Baseline Alignment Grouping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-justify-items">
-   <b><a href="#propdef-justify-items">#propdef-justify-items</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-justify-items" class="dfn-panel" data-for="propdef-justify-items" id="infopanel-for-propdef-justify-items" role="dialog">
+   <span id="infopaneltitle-for-propdef-justify-items" style="display:none">Info about the 'justify-items' definition.</span><b><a href="#propdef-justify-items">#propdef-justify-items</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-items①">2. 
 Overview of Alignment Properties</a>
@@ -5473,8 +5473,8 @@ Self-Alignment Shorthand: the place-items property</a> <a href="#ref-for-propdef
 Changes</a> <a href="#ref-for-propdef-justify-items①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-items-legacy">
-   <b><a href="#valdef-justify-items-legacy">#valdef-justify-items-legacy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-items-legacy" class="dfn-panel" data-for="valdef-justify-items-legacy" id="infopanel-for-valdef-justify-items-legacy" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-items-legacy" style="display:none">Info about the 'legacy' definition.</span><b><a href="#valdef-justify-items-legacy">#valdef-justify-items-legacy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-items-legacy①">6.1. 
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
@@ -5484,8 +5484,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-self property</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-items property</a> <a href="#ref-for-valdef-justify-items-legacy④">(2)</a> <a href="#ref-for-valdef-justify-items-legacy⑤">(3)</a> <a href="#ref-for-valdef-justify-items-legacy⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-items">
-   <b><a href="#propdef-align-items">#propdef-align-items</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-items" class="dfn-panel" data-for="propdef-align-items" id="infopanel-for-propdef-align-items" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-items" style="display:none">Info about the 'align-items' definition.</span><b><a href="#propdef-align-items">#propdef-align-items</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">2. 
 Overview of Alignment Properties</a>
@@ -5501,8 +5501,8 @@ Block-Axis (or Cross-Axis) Alignment: the align-items property</a>
 Self-Alignment Shorthand: the place-items property</a> <a href="#ref-for-propdef-align-items⑥">(2)</a> <a href="#ref-for-propdef-align-items⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-place-items">
-   <b><a href="#propdef-place-items">#propdef-place-items</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-place-items" class="dfn-panel" data-for="propdef-place-items" id="infopanel-for-propdef-place-items" role="dialog">
+   <span id="infopaneltitle-for-propdef-place-items" style="display:none">Info about the 'place-items' definition.</span><b><a href="#propdef-place-items">#propdef-place-items</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-items">7. 
 Default Alignment</a>
@@ -5510,8 +5510,8 @@ Default Alignment</a>
 Self-Alignment Shorthand: the place-items property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-row-gap">
-   <b><a href="#propdef-row-gap">#propdef-row-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-row-gap" class="dfn-panel" data-for="propdef-row-gap" id="infopanel-for-propdef-row-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-row-gap" style="display:none">Info about the 'row-gap' definition.</span><b><a href="#propdef-row-gap">#propdef-row-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-row-gap">8. 
 Gaps Between Boxes</a>
@@ -5525,8 +5525,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-gap">
-   <b><a href="#propdef-column-gap">#propdef-column-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-gap" class="dfn-panel" data-for="propdef-column-gap" id="infopanel-for-propdef-column-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-gap" style="display:none">Info about the 'column-gap' definition.</span><b><a href="#propdef-column-gap">#propdef-column-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">8. 
 Gaps Between Boxes</a>
@@ -5540,8 +5540,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gutter">
-   <b><a href="#gutter">#gutter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gutter" class="dfn-panel" data-for="gutter" id="infopanel-for-gutter" role="dialog">
+   <span id="infopaneltitle-for-gutter" style="display:none">Info about the 'gutters' definition.</span><b><a href="#gutter">#gutter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gutter">5.1.4. Grid Containers</a>
     <li><a href="#ref-for-gutter①">8.1. 
@@ -5550,15 +5550,15 @@ Row and Column Gutters: the row-gap and column-gap properties</a> <a href="#ref-
 Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-row-gap-normal">
-   <b><a href="#valdef-row-gap-normal">#valdef-row-gap-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-row-gap-normal" class="dfn-panel" data-for="valdef-row-gap-normal" id="infopanel-for-valdef-row-gap-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-row-gap-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-row-gap-normal">#valdef-row-gap-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-row-gap-normal">8.1. 
 Row and Column Gutters: the row-gap and column-gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-gap">
-   <b><a href="#propdef-gap">#propdef-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-gap" class="dfn-panel" data-for="propdef-gap" id="infopanel-for-propdef-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-gap" style="display:none">Info about the 'gap' definition.</span><b><a href="#propdef-gap">#propdef-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-gap">8. 
 Gaps Between Boxes</a>
@@ -5574,8 +5574,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a> <a href="#ref-for-propdef-gap①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row-gap">
-   <b><a href="#propdef-grid-row-gap">#propdef-grid-row-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row-gap" class="dfn-panel" data-for="propdef-grid-row-gap" id="infopanel-for-propdef-grid-row-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row-gap" style="display:none">Info about the 'grid-row-gap' definition.</span><b><a href="#propdef-grid-row-gap">#propdef-grid-row-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-gap">8.4. 
 Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap properties</a>
@@ -5583,8 +5583,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column-gap">
-   <b><a href="#propdef-grid-column-gap">#propdef-grid-column-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column-gap" class="dfn-panel" data-for="propdef-grid-column-gap" id="infopanel-for-propdef-grid-column-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column-gap" style="display:none">Info about the 'grid-column-gap' definition.</span><b><a href="#propdef-grid-column-gap">#propdef-grid-column-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-gap">8.4. 
 Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap properties</a>
@@ -5592,8 +5592,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-gap">
-   <b><a href="#propdef-grid-gap">#propdef-grid-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-gap" class="dfn-panel" data-for="propdef-grid-gap" id="infopanel-for-propdef-grid-gap" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-gap" style="display:none">Info about the 'grid-gap' definition.</span><b><a href="#propdef-grid-gap">#propdef-grid-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-gap">8.4. 
 Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap properties</a>
@@ -5601,8 +5601,8 @@ Legacy Gap Properties: the grid-row-gap, grid-column-gap, and grid-gap propertie
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-set">
-   <b><a href="#baseline-set">#baseline-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-set" class="dfn-panel" data-for="baseline-set" id="infopanel-for-baseline-set" role="dialog">
+   <span id="infopaneltitle-for-baseline-set" style="display:none">Info about the 'baseline set' definition.</span><b><a href="#baseline-set">#baseline-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-set">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-baseline-set①">(2)</a> <a href="#ref-for-baseline-set②">(3)</a> <a href="#ref-for-baseline-set③">(4)</a> <a href="#ref-for-baseline-set④">(5)</a> <a href="#ref-for-baseline-set⑤">(6)</a> <a href="#ref-for-baseline-set⑥">(7)</a> <a href="#ref-for-baseline-set⑦">(8)</a> <a href="#ref-for-baseline-set⑧">(9)</a> <a href="#ref-for-baseline-set⑨">(10)</a> <a href="#ref-for-baseline-set①⓪">(11)</a> <a href="#ref-for-baseline-set①①">(12)</a> <a href="#ref-for-baseline-set①②">(13)</a>
@@ -5610,8 +5610,8 @@ Determining the Baselines of a Box</a> <a href="#ref-for-baseline-set①">(2)</a
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-baseline-set">
-   <b><a href="#first-baseline-set">#first-baseline-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-baseline-set" class="dfn-panel" data-for="first-baseline-set" id="infopanel-for-first-baseline-set" role="dialog">
+   <span id="infopaneltitle-for-first-baseline-set" style="display:none">Info about the 'first baseline set' definition.</span><b><a href="#first-baseline-set">#first-baseline-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-baseline-set">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -5619,8 +5619,8 @@ Baseline Alignment: the baseline keyword and first/last modifiers</a>
 Inline-Axis (or Main-Axis) Alignment: the justify-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-baseline-set">
-   <b><a href="#last-baseline-set">#last-baseline-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-baseline-set" class="dfn-panel" data-for="last-baseline-set" id="infopanel-for-last-baseline-set" role="dialog">
+   <span id="infopaneltitle-for-last-baseline-set" style="display:none">Info about the 'last baseline set' definition.</span><b><a href="#last-baseline-set">#last-baseline-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-set">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a>
@@ -5632,8 +5632,8 @@ Determining the Baselines of a Box</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alignment-baseline">
-   <b><a href="#alignment-baseline">#alignment-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alignment-baseline" class="dfn-panel" data-for="alignment-baseline" id="infopanel-for-alignment-baseline" role="dialog">
+   <span id="infopaneltitle-for-alignment-baseline" style="display:none">Info about the 'alignment baseline' definition.</span><b><a href="#alignment-baseline">#alignment-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-baseline">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-alignment-baseline①">(2)</a> <a href="#ref-for-alignment-baseline②">(3)</a>
@@ -5651,22 +5651,22 @@ Aligning Boxes by Baseline</a> <a href="#ref-for-alignment-baseline⑨">(2)</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-baselines">
-   <b><a href="#generate-baselines">#generate-baselines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-baselines" class="dfn-panel" data-for="generate-baselines" id="infopanel-for-generate-baselines" role="dialog">
+   <span id="infopaneltitle-for-generate-baselines" style="display:none">Info about the 'generate baselines' definition.</span><b><a href="#generate-baselines">#generate-baselines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-baselines">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-generate-baselines①">(2)</a> <a href="#ref-for-generate-baselines②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="synthesize-baseline">
-   <b><a href="#synthesize-baseline">#synthesize-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-synthesize-baseline" class="dfn-panel" data-for="synthesize-baseline" id="infopanel-for-synthesize-baseline" role="dialog">
+   <span id="infopaneltitle-for-synthesize-baseline" style="display:none">Info about the 'synthesize baselines' definition.</span><b><a href="#synthesize-baseline">#synthesize-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">9.1. 
 Determining the Baselines of a Box</a> <a href="#ref-for-synthesize-baseline①">(2)</a> <a href="#ref-for-synthesize-baseline②">(3)</a> <a href="#ref-for-synthesize-baseline③">(4)</a> <a href="#ref-for-synthesize-baseline④">(5)</a> <a href="#ref-for-synthesize-baseline⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-sharing-group">
-   <b><a href="#baseline-sharing-group">#baseline-sharing-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-sharing-group" class="dfn-panel" data-for="baseline-sharing-group" id="infopanel-for-baseline-sharing-group" role="dialog">
+   <span id="infopaneltitle-for-baseline-sharing-group" style="display:none">Info about the 'baseline-sharing group' definition.</span><b><a href="#baseline-sharing-group">#baseline-sharing-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-sharing-group">4.2. 
 Baseline Alignment: the baseline keyword and first/last modifiers</a> <a href="#ref-for-baseline-sharing-group①">(2)</a> <a href="#ref-for-baseline-sharing-group②">(3)</a> <a href="#ref-for-baseline-sharing-group③">(4)</a>
@@ -5682,8 +5682,8 @@ Baseline Alignment Grouping</a> <a href="#ref-for-baseline-sharing-group⑧">(2)
 Aligning Boxes by Baseline</a> <a href="#ref-for-baseline-sharing-group①⓪">(2)</a> <a href="#ref-for-baseline-sharing-group①①">(3)</a> <a href="#ref-for-baseline-sharing-group①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shared-alignment-context">
-   <b><a href="#shared-alignment-context">#shared-alignment-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shared-alignment-context" class="dfn-panel" data-for="shared-alignment-context" id="infopanel-for-shared-alignment-context" role="dialog">
+   <span id="infopaneltitle-for-shared-alignment-context" style="display:none">Info about the 'alignment context' definition.</span><b><a href="#shared-alignment-context">#shared-alignment-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-alignment-context">4. 
 Alignment Keywords</a>
@@ -5701,15 +5701,15 @@ Baseline Alignment Grouping</a> <a href="#ref-for-shared-alignment-context①①
 Aligning Boxes by Baseline</a> <a href="#ref-for-shared-alignment-context①④">(2)</a> <a href="#ref-for-shared-alignment-context①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compatible-baseline-alignment-preferences">
-   <b><a href="#compatible-baseline-alignment-preferences">#compatible-baseline-alignment-preferences</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compatible-baseline-alignment-preferences" class="dfn-panel" data-for="compatible-baseline-alignment-preferences" id="infopanel-for-compatible-baseline-alignment-preferences" role="dialog">
+   <span id="infopaneltitle-for-compatible-baseline-alignment-preferences" style="display:none">Info about the 'compatible' definition.</span><b><a href="#compatible-baseline-alignment-preferences">#compatible-baseline-alignment-preferences</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compatible-baseline-alignment-preferences">9.2. 
 Baseline Alignment Grouping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="static-position-rectangle">
-   <b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-static-position-rectangle" class="dfn-panel" data-for="static-position-rectangle" id="infopanel-for-static-position-rectangle" role="dialog">
+   <span id="infopaneltitle-for-static-position-rectangle" style="display:none">Info about the 'static position rectangle' definition.</span><b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position-rectangle">6.1.2. Absolutely-Positioned Boxes</a> <a href="#ref-for-static-position-rectangle①">(2)</a>
     <li><a href="#ref-for-static-position-rectangle②">6.2.2. Absolutely-Positioned Boxes</a> <a href="#ref-for-static-position-rectangle③">(2)</a>
@@ -5720,59 +5720,115 @@ Effects on Sizing of Absolutely Positioned Boxes with Static-Position Insets</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-1/Overview.html
@@ -2876,29 +2876,29 @@ objects</a>.</p>
      <li><a href="#valdef-animation-duration-time">value for animation-duration</a><span>, in § 3.3</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-constructing-events">
-   <a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructing-events" class="dfn-panel" data-for="term-for-constructing-events" id="infopanel-for-term-for-constructing-events" role="menu">
+   <span id="infopaneltitle-for-term-for-constructing-events" style="display:none">Info about the 'event constructor' external reference.</span><a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructing-events">4.1.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.2. 
 The animation-name property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">2. 
 Animations</a> <a href="#ref-for-valdef-display-none①">(2)</a> <a href="#ref-for-valdef-display-none②">(3)</a> <a href="#ref-for-valdef-display-none③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">3.4. 
 The animation-timing-function property</a> <a href="#ref-for-typedef-easing-function①">(2)</a>
@@ -2906,64 +2906,64 @@ The animation-timing-function property</a> <a href="#ref-for-typedef-easing-func
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-in" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" style="display:none">Info about the 'ease-in' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in">3.6. 
 The animation-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-out" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" style="display:none">Info about the 'ease-out' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-out">3.6. 
 The animation-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-input-progress-value">
-   <a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-input-progress-value" class="dfn-panel" data-for="term-for-input-progress-value" id="infopanel-for-term-for-input-progress-value" role="menu">
+   <span id="infopaneltitle-for-term-for-input-progress-value" style="display:none">Info about the 'input progress value' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-progress-value">3.4. 
 The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-output-progress-value">
-   <a href="https://drafts.csswg.org/css-easing-2/#output-progress-value">https://drafts.csswg.org/css-easing-2/#output-progress-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-output-progress-value" class="dfn-panel" data-for="term-for-output-progress-value" id="infopanel-for-term-for-output-progress-value" role="menu">
+   <span id="infopaneltitle-for-term-for-output-progress-value" style="display:none">Info about the 'output progress value' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#output-progress-value">https://drafts.csswg.org/css-easing-2/#output-progress-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-progress-value">3.4. 
 The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-steps-start">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-steps-start">https://drafts.csswg.org/css-easing-2/#valdef-steps-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-steps-start" class="dfn-panel" data-for="term-for-valdef-steps-start" id="infopanel-for-term-for-valdef-steps-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-steps-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-steps-start">https://drafts.csswg.org/css-easing-2/#valdef-steps-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-start">3.4. 
 The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-step-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#step-easing-function">https://drafts.csswg.org/css-easing-2/#step-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-step-easing-function" class="dfn-panel" data-for="term-for-step-easing-function" id="infopanel-for-term-for-step-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-step-easing-function" style="display:none">Info about the 'step easing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#step-easing-function">https://drafts.csswg.org/css-easing-2/#step-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-step-easing-function">3.4. 
 The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-step-position">
-   <a href="https://drafts.csswg.org/css-easing-2/#step-position">https://drafts.csswg.org/css-easing-2/#step-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-step-position" class="dfn-panel" data-for="term-for-step-position" id="infopanel-for-term-for-step-position" role="menu">
+   <span id="infopaneltitle-for-term-for-step-position" style="display:none">Info about the 'step position' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#step-position">https://drafts.csswg.org/css-easing-2/#step-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-step-position">3.4. 
 The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">3. 
 Keyframes</a> <a href="#ref-for-propdef-left①">(2)</a> <a href="#ref-for-propdef-left②">(3)</a> <a href="#ref-for-propdef-left③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-shape-to">
-   <a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-to">https://drafts.csswg.org/css-shapes-2/#valdef-shape-to</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-shape-to" class="dfn-panel" data-for="term-for-valdef-shape-to" id="infopanel-for-term-for-valdef-shape-to" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-shape-to" style="display:none">Info about the 'to' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-to">https://drafts.csswg.org/css-shapes-2/#valdef-shape-to</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-to">3. 
 Keyframes</a> <a href="#ref-for-valdef-shape-to①">(2)</a> <a href="#ref-for-valdef-shape-to②">(3)</a>
@@ -2979,22 +2979,22 @@ The deleteRule method</a>
 The findRule method</a> <a href="#ref-for-valdef-shape-to⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">3. 
 Keyframes</a> <a href="#ref-for-typedef-declaration-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-rule-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-rule-list">https://drafts.csswg.org/css-syntax-3/#typedef-rule-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-rule-list" class="dfn-panel" data-for="term-for-typedef-rule-list" id="infopanel-for-term-for-typedef-rule-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-rule-list" style="display:none">Info about the '&lt;rule-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-rule-list">https://drafts.csswg.org/css-syntax-3/#typedef-rule-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-rule-list">3. 
 Keyframes</a> <a href="#ref-for-typedef-rule-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">3.3. 
 The animation-duration property</a> <a href="#ref-for-time-value①">(2)</a> <a href="#ref-for-time-value②">(3)</a> <a href="#ref-for-time-value③">(4)</a> <a href="#ref-for-time-value④">(5)</a>
@@ -3004,8 +3004,8 @@ The animation-delay property</a> <a href="#ref-for-time-value⑥">(2)</a> <a hre
 The animation shorthand property</a> <a href="#ref-for-time-value⑨">(2)</a> <a href="#ref-for-time-value①⓪">(3)</a> <a href="#ref-for-time-value①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.2. 
 The animation-name property</a>
@@ -3027,71 +3027,71 @@ The animation-fill-mode property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3. 
 Keyframes</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a> <a href="#ref-for-identifier-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.5. 
 The animation-iteration-count property</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3. 
 Keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3. 
 Keyframes</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a> <a href="#ref-for-string-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'css identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">3.2. 
 The animation-name property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.2. 
 The animation-name property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">2. 
 Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Animations</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a> <a href="#ref-for-propdef-display③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">4.1.1. 
 IDL Definition</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a>
@@ -3113,8 +3113,8 @@ The deleteRule method</a>
 The findRule method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">5.1. 
 The CSSRule Interface</a>
@@ -3126,8 +3126,8 @@ IDL Definition</a>
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrulelist">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrulelist">https://drafts.csswg.org/cssom-1/#cssrulelist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrulelist" class="dfn-panel" data-for="term-for-cssrulelist" id="infopanel-for-term-for-cssrulelist" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrulelist" style="display:none">Info about the 'CSSRuleList' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrulelist">https://drafts.csswg.org/cssom-1/#cssrulelist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrulelist">5.3.1. 
 IDL Definition</a>
@@ -3135,8 +3135,8 @@ IDL Definition</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">5.2.1. 
 IDL Definition</a>
@@ -3144,72 +3144,72 @@ IDL Definition</a>
 Attributes</a> <a href="#ref-for-cssstyledeclaration②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-csstext">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cssstyledeclaration-csstext" class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-csstext" id="infopanel-for-term-for-dom-cssstyledeclaration-csstext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cssstyledeclaration-csstext" style="display:none">Info about the 'cssText' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-csstext">5.2.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations" id="infopanel-for-term-for-cssstyledeclaration-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">5.2.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node" id="infopanel-for-term-for-cssstyledeclaration-owner-node" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" style="display:none">Info about the 'owner node' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-owner-node">5.2.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-parent-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-parent-css-rule" class="dfn-panel" data-for="term-for-cssstyledeclaration-parent-css-rule" id="infopanel-for-term-for-cssstyledeclaration-parent-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-parent-css-rule" style="display:none">Info about the 'parent css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-parent-css-rule">5.2.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-declarations-specified-order">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order">https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-declarations-specified-order" class="dfn-panel" data-for="term-for-concept-declarations-specified-order" id="infopanel-for-term-for-concept-declarations-specified-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-declarations-specified-order" style="display:none">Info about the 'specified order' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order">https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-declarations-specified-order">5.2.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.1.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.1.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">5.4.1. 
 IDL Definition</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-globaleventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-globaleventhandlers" class="dfn-panel" data-for="term-for-globaleventhandlers" id="infopanel-for-term-for-globaleventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-globaleventhandlers" style="display:none">Info about the 'GlobalEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-globaleventhandlers">5.4. 
 Extensions to the GlobalEventHandlers Interface Mixin</a>
@@ -3217,32 +3217,32 @@ Extensions to the GlobalEventHandlers Interface Mixin</a>
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-content-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-content-attributes" class="dfn-panel" data-for="term-for-event-handler-content-attributes" id="infopanel-for-term-for-event-handler-content-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-content-attributes" style="display:none">Info about the 'event handler content attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-content-attributes">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">4.3. Event
 handlers on elements, Document objects, and Window
@@ -3251,24 +3251,24 @@ objects</a> <a href="#ref-for-event-handler-idl-attributes①">(2)</a>
 Extensions to the GlobalEventHandlers Interface Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-elements">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-elements" class="dfn-panel" data-for="term-for-html-elements" id="infopanel-for-term-for-html-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-html-elements" style="display:none">Info about the 'html elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-elements">4.3. Event
 handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1.1. 
 IDL Definition</a>
@@ -3278,29 +3278,29 @@ IDL Definition</a>
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">5.2.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.2.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">5.2.2. 
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.1.1. 
 IDL Definition</a> <a href="#ref-for-idl-double①">(2)</a>
@@ -3308,15 +3308,15 @@ IDL Definition</a> <a href="#ref-for-idl-double①">(2)</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.3.1. 
 IDL Definition</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">5.1.1. 
 IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
@@ -3642,8 +3642,8 @@ IDL Definition</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
 		like the section on <a href="https://drafts.csswg.org/css-transitions/#application">Application of transitions</a> does for CSS Transitions. <a class="issue-return" href="#issue-73aacf21" title="Jump to section">↵</a></div>
    <div class="issue">Need to <a href="https://lists.w3.org/Archives/Public/www-style/2015Jul/0391.html">specify how keyframes interact</a>. <a class="issue-return" href="#issue-c01277bc" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="at-ruledef-keyframes">
-   <b><a href="#at-ruledef-keyframes">#at-ruledef-keyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-keyframes" class="dfn-panel" data-for="at-ruledef-keyframes" id="infopanel-for-at-ruledef-keyframes" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' definition.</span><b><a href="#at-ruledef-keyframes">#at-ruledef-keyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">3. 
 Keyframes</a> <a href="#ref-for-at-ruledef-keyframes①">(2)</a> <a href="#ref-for-at-ruledef-keyframes②">(3)</a> <a href="#ref-for-at-ruledef-keyframes③">(4)</a> <a href="#ref-for-at-ruledef-keyframes④">(5)</a> <a href="#ref-for-at-ruledef-keyframes⑤">(6)</a> <a href="#ref-for-at-ruledef-keyframes⑥">(7)</a> <a href="#ref-for-at-ruledef-keyframes⑦">(8)</a>
@@ -3653,8 +3653,8 @@ The animation-name property</a>
 The appendRule method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-keyframes-name">
-   <b><a href="#typedef-keyframes-name">#typedef-keyframes-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-keyframes-name" class="dfn-panel" data-for="typedef-keyframes-name" id="infopanel-for-typedef-keyframes-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-keyframes-name" style="display:none">Info about the '&lt;keyframes-name>' definition.</span><b><a href="#typedef-keyframes-name">#typedef-keyframes-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframes-name">3. 
 Keyframes</a>
@@ -3664,22 +3664,22 @@ The animation-name property</a> <a href="#ref-for-typedef-keyframes-name②">(2)
 The animation shorthand property</a> <a href="#ref-for-typedef-keyframes-name⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-keyframe-block">
-   <b><a href="#typedef-keyframe-block">#typedef-keyframe-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-keyframe-block" class="dfn-panel" data-for="typedef-keyframe-block" id="infopanel-for-typedef-keyframe-block" role="dialog">
+   <span id="infopaneltitle-for-typedef-keyframe-block" style="display:none">Info about the '&lt;keyframe-block>' definition.</span><b><a href="#typedef-keyframe-block">#typedef-keyframe-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframe-block">3. 
 Keyframes</a> <a href="#ref-for-typedef-keyframe-block①">(2)</a> <a href="#ref-for-typedef-keyframe-block②">(3)</a> <a href="#ref-for-typedef-keyframe-block③">(4)</a> <a href="#ref-for-typedef-keyframe-block④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-keyframe-selector">
-   <b><a href="#typedef-keyframe-selector">#typedef-keyframe-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-keyframe-selector" class="dfn-panel" data-for="typedef-keyframe-selector" id="infopanel-for-typedef-keyframe-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-keyframe-selector" style="display:none">Info about the '&lt;keyframe-selector>' definition.</span><b><a href="#typedef-keyframe-selector">#typedef-keyframe-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframe-selector">3. 
 Keyframes</a> <a href="#ref-for-typedef-keyframe-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-name">
-   <b><a href="#propdef-animation-name">#propdef-animation-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-name" class="dfn-panel" data-for="propdef-animation-name" id="infopanel-for-propdef-animation-name" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-name" style="display:none">Info about the 'animation-name' definition.</span><b><a href="#propdef-animation-name">#propdef-animation-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">2. 
 Animations</a> <a href="#ref-for-propdef-animation-name①">(2)</a> <a href="#ref-for-propdef-animation-name②">(3)</a> <a href="#ref-for-propdef-animation-name③">(4)</a> <a href="#ref-for-propdef-animation-name④">(5)</a> <a href="#ref-for-propdef-animation-name⑤">(6)</a> <a href="#ref-for-propdef-animation-name⑥">(7)</a> <a href="#ref-for-propdef-animation-name⑦">(8)</a>
@@ -3699,8 +3699,8 @@ Types of AnimationEvent</a>
 Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-name-none">
-   <b><a href="#valdef-animation-name-none">#valdef-animation-name-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-name-none" class="dfn-panel" data-for="valdef-animation-name-none" id="infopanel-for-valdef-animation-name-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-name-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-animation-name-none">#valdef-animation-name-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-name-none">3. 
 Keyframes</a>
@@ -3710,8 +3710,8 @@ The animation-name property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-duration">
-   <b><a href="#propdef-animation-duration">#propdef-animation-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-duration" class="dfn-panel" data-for="propdef-animation-duration" id="infopanel-for-propdef-animation-duration" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-duration" style="display:none">Info about the 'animation-duration' definition.</span><b><a href="#propdef-animation-duration">#propdef-animation-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-duration">3.3. 
 The animation-duration property</a> <a href="#ref-for-propdef-animation-duration①">(2)</a>
@@ -3725,8 +3725,8 @@ The animation shorthand property</a>
 Types of AnimationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-timing-function">
-   <b><a href="#propdef-animation-timing-function">#propdef-animation-timing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-timing-function" class="dfn-panel" data-for="propdef-animation-timing-function" id="infopanel-for-propdef-animation-timing-function" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' definition.</span><b><a href="#propdef-animation-timing-function">#propdef-animation-timing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">3. 
 Keyframes</a> <a href="#ref-for-propdef-animation-timing-function①">(2)</a>
@@ -3736,15 +3736,15 @@ Timing functions for keyframes</a>
 The animation-timing-function property</a> <a href="#ref-for-propdef-animation-timing-function④">(2)</a> <a href="#ref-for-propdef-animation-timing-function⑤">(3)</a> <a href="#ref-for-propdef-animation-timing-function⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-duration">
-   <b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-duration" class="dfn-panel" data-for="active-duration" id="infopanel-for-active-duration" role="dialog">
+   <span id="infopaneltitle-for-active-duration" style="display:none">Info about the 'active duration' definition.</span><b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-duration">4.2. 
 Types of AnimationEvent</a> <a href="#ref-for-active-duration①">(2)</a> <a href="#ref-for-active-duration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-iteration-count">
-   <b><a href="#propdef-animation-iteration-count">#propdef-animation-iteration-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-iteration-count" class="dfn-panel" data-for="propdef-animation-iteration-count" id="infopanel-for-propdef-animation-iteration-count" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-iteration-count" style="display:none">Info about the 'animation-iteration-count' definition.</span><b><a href="#propdef-animation-iteration-count">#propdef-animation-iteration-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-iteration-count">3.5. 
 The animation-iteration-count property</a> <a href="#ref-for-propdef-animation-iteration-count①">(2)</a> <a href="#ref-for-propdef-animation-iteration-count②">(3)</a>
@@ -3752,8 +3752,8 @@ The animation-iteration-count property</a> <a href="#ref-for-propdef-animation-i
 The animation-fill-mode property</a> <a href="#ref-for-propdef-animation-iteration-count④">(2)</a> <a href="#ref-for-propdef-animation-iteration-count⑤">(3)</a> <a href="#ref-for-propdef-animation-iteration-count⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-iteration-count">
-   <b><a href="#typedef-single-animation-iteration-count">#typedef-single-animation-iteration-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-iteration-count" class="dfn-panel" data-for="typedef-single-animation-iteration-count" id="infopanel-for-typedef-single-animation-iteration-count" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-iteration-count" style="display:none">Info about the '&lt;single-animation-iteration-count>' definition.</span><b><a href="#typedef-single-animation-iteration-count">#typedef-single-animation-iteration-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-iteration-count">3.5. 
 The animation-iteration-count property</a>
@@ -3761,15 +3761,15 @@ The animation-iteration-count property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-iteration-count-infinite">
-   <b><a href="#valdef-animation-iteration-count-infinite">#valdef-animation-iteration-count-infinite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-iteration-count-infinite" class="dfn-panel" data-for="valdef-animation-iteration-count-infinite" id="infopanel-for-valdef-animation-iteration-count-infinite" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-iteration-count-infinite" style="display:none">Info about the 'infinite' definition.</span><b><a href="#valdef-animation-iteration-count-infinite">#valdef-animation-iteration-count-infinite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-iteration-count-infinite">3.5. 
 The animation-iteration-count property</a> <a href="#ref-for-valdef-animation-iteration-count-infinite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-direction">
-   <b><a href="#propdef-animation-direction">#propdef-animation-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-direction" class="dfn-panel" data-for="propdef-animation-direction" id="infopanel-for-propdef-animation-direction" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-direction" style="display:none">Info about the 'animation-direction' definition.</span><b><a href="#propdef-animation-direction">#propdef-animation-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-direction">3.3. 
 The animation-duration property</a> <a href="#ref-for-propdef-animation-direction①">(2)</a>
@@ -3783,8 +3783,8 @@ The animation-direction property</a> <a href="#ref-for-propdef-animation-directi
 The animation-fill-mode property</a> <a href="#ref-for-propdef-animation-direction⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-direction">
-   <b><a href="#typedef-single-animation-direction">#typedef-single-animation-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-direction" class="dfn-panel" data-for="typedef-single-animation-direction" id="infopanel-for-typedef-single-animation-direction" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-direction" style="display:none">Info about the '&lt;single-animation-direction>' definition.</span><b><a href="#typedef-single-animation-direction">#typedef-single-animation-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-direction">3.6. 
 The animation-direction property</a>
@@ -3792,22 +3792,22 @@ The animation-direction property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-direction-normal">
-   <b><a href="#valdef-animation-direction-normal">#valdef-animation-direction-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-direction-normal" class="dfn-panel" data-for="valdef-animation-direction-normal" id="infopanel-for-valdef-animation-direction-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-direction-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-animation-direction-normal">#valdef-animation-direction-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-direction-normal">3.9. 
 The animation-fill-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-direction-reverse">
-   <b><a href="#valdef-animation-direction-reverse">#valdef-animation-direction-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-direction-reverse" class="dfn-panel" data-for="valdef-animation-direction-reverse" id="infopanel-for-valdef-animation-direction-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-direction-reverse" style="display:none">Info about the 'reverse' definition.</span><b><a href="#valdef-animation-direction-reverse">#valdef-animation-direction-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-direction-reverse">3.9. 
 The animation-fill-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-direction-alternate">
-   <b><a href="#valdef-animation-direction-alternate">#valdef-animation-direction-alternate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-direction-alternate" class="dfn-panel" data-for="valdef-animation-direction-alternate" id="infopanel-for-valdef-animation-direction-alternate" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-direction-alternate" style="display:none">Info about the 'alternate' definition.</span><b><a href="#valdef-animation-direction-alternate">#valdef-animation-direction-alternate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-direction-alternate">3.5. 
 The animation-iteration-count property</a>
@@ -3815,15 +3815,15 @@ The animation-iteration-count property</a>
 The animation-fill-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-direction-alternate-reverse">
-   <b><a href="#valdef-animation-direction-alternate-reverse">#valdef-animation-direction-alternate-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-direction-alternate-reverse" class="dfn-panel" data-for="valdef-animation-direction-alternate-reverse" id="infopanel-for-valdef-animation-direction-alternate-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-direction-alternate-reverse" style="display:none">Info about the 'alternate-reverse' definition.</span><b><a href="#valdef-animation-direction-alternate-reverse">#valdef-animation-direction-alternate-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-direction-alternate-reverse">3.9. 
 The animation-fill-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-play-state">
-   <b><a href="#propdef-animation-play-state">#propdef-animation-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-play-state" class="dfn-panel" data-for="propdef-animation-play-state" id="infopanel-for-propdef-animation-play-state" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-play-state" style="display:none">Info about the 'animation-play-state' definition.</span><b><a href="#propdef-animation-play-state">#propdef-animation-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-play-state">3.7. 
 The animation-play-state property</a> <a href="#ref-for-propdef-animation-play-state①">(2)</a> <a href="#ref-for-propdef-animation-play-state②">(3)</a>
@@ -3831,8 +3831,8 @@ The animation-play-state property</a> <a href="#ref-for-propdef-animation-play-s
 Types of AnimationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-play-state">
-   <b><a href="#typedef-single-animation-play-state">#typedef-single-animation-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-play-state" class="dfn-panel" data-for="typedef-single-animation-play-state" id="infopanel-for-typedef-single-animation-play-state" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-play-state" style="display:none">Info about the '&lt;single-animation-play-state>' definition.</span><b><a href="#typedef-single-animation-play-state">#typedef-single-animation-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-play-state">3.7. 
 The animation-play-state property</a>
@@ -3840,8 +3840,8 @@ The animation-play-state property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-play-state-running">
-   <b><a href="#valdef-animation-play-state-running">#valdef-animation-play-state-running</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-play-state-running" class="dfn-panel" data-for="valdef-animation-play-state-running" id="infopanel-for-valdef-animation-play-state-running" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-play-state-running" style="display:none">Info about the 'running' definition.</span><b><a href="#valdef-animation-play-state-running">#valdef-animation-play-state-running</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-play-state-running">3.7. 
 The animation-play-state property</a> <a href="#ref-for-valdef-animation-play-state-running①">(2)</a> <a href="#ref-for-valdef-animation-play-state-running②">(3)</a>
@@ -3849,8 +3849,8 @@ The animation-play-state property</a> <a href="#ref-for-valdef-animation-play-st
 Types of AnimationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-play-state-paused">
-   <b><a href="#valdef-animation-play-state-paused">#valdef-animation-play-state-paused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-play-state-paused" class="dfn-panel" data-for="valdef-animation-play-state-paused" id="infopanel-for-valdef-animation-play-state-paused" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-play-state-paused" style="display:none">Info about the 'paused' definition.</span><b><a href="#valdef-animation-play-state-paused">#valdef-animation-play-state-paused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-play-state-paused">3.7. 
 The animation-play-state property</a> <a href="#ref-for-valdef-animation-play-state-paused①">(2)</a>
@@ -3860,8 +3860,8 @@ Animation Events</a>
 Types of AnimationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-delay">
-   <b><a href="#propdef-animation-delay">#propdef-animation-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-delay" class="dfn-panel" data-for="propdef-animation-delay" id="infopanel-for-propdef-animation-delay" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-delay" style="display:none">Info about the 'animation-delay' definition.</span><b><a href="#propdef-animation-delay">#propdef-animation-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-delay">2. 
 Animations</a> <a href="#ref-for-propdef-animation-delay①">(2)</a>
@@ -3879,8 +3879,8 @@ The animation shorthand property</a>
 Types of AnimationEvent</a> <a href="#ref-for-propdef-animation-delay①①">(2)</a> <a href="#ref-for-propdef-animation-delay①②">(3)</a> <a href="#ref-for-propdef-animation-delay①③">(4)</a> <a href="#ref-for-propdef-animation-delay①④">(5)</a> <a href="#ref-for-propdef-animation-delay①⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-fill-mode">
-   <b><a href="#propdef-animation-fill-mode">#propdef-animation-fill-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-fill-mode" class="dfn-panel" data-for="propdef-animation-fill-mode" id="infopanel-for-propdef-animation-fill-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-fill-mode" style="display:none">Info about the 'animation-fill-mode' definition.</span><b><a href="#propdef-animation-fill-mode">#propdef-animation-fill-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-fill-mode">2. 
 Animations</a> <a href="#ref-for-propdef-animation-fill-mode①">(2)</a>
@@ -3892,8 +3892,8 @@ The animation-fill-mode property</a> <a href="#ref-for-propdef-animation-fill-mo
 The animation shorthand property</a> <a href="#ref-for-propdef-animation-fill-mode①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-fill-mode">
-   <b><a href="#typedef-single-animation-fill-mode">#typedef-single-animation-fill-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-fill-mode" class="dfn-panel" data-for="typedef-single-animation-fill-mode" id="infopanel-for-typedef-single-animation-fill-mode" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-fill-mode" style="display:none">Info about the '&lt;single-animation-fill-mode>' definition.</span><b><a href="#typedef-single-animation-fill-mode">#typedef-single-animation-fill-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-fill-mode">3.9. 
 The animation-fill-mode property</a>
@@ -3901,8 +3901,8 @@ The animation-fill-mode property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-fill-mode-none">
-   <b><a href="#valdef-animation-fill-mode-none">#valdef-animation-fill-mode-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-fill-mode-none" class="dfn-panel" data-for="valdef-animation-fill-mode-none" id="infopanel-for-valdef-animation-fill-mode-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-fill-mode-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-animation-fill-mode-none">#valdef-animation-fill-mode-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-fill-mode-none">3.3. 
 The animation-duration property</a>
@@ -3910,8 +3910,8 @@ The animation-duration property</a>
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-fill-mode-forwards">
-   <b><a href="#valdef-animation-fill-mode-forwards">#valdef-animation-fill-mode-forwards</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-fill-mode-forwards" class="dfn-panel" data-for="valdef-animation-fill-mode-forwards" id="infopanel-for-valdef-animation-fill-mode-forwards" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-fill-mode-forwards" style="display:none">Info about the 'forwards' definition.</span><b><a href="#valdef-animation-fill-mode-forwards">#valdef-animation-fill-mode-forwards</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-fill-mode-forwards">2. 
 Animations</a>
@@ -3921,8 +3921,8 @@ The animation-duration property</a>
 The animation-fill-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-fill-mode-backwards">
-   <b><a href="#valdef-animation-fill-mode-backwards">#valdef-animation-fill-mode-backwards</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-fill-mode-backwards" class="dfn-panel" data-for="valdef-animation-fill-mode-backwards" id="infopanel-for-valdef-animation-fill-mode-backwards" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-fill-mode-backwards" style="display:none">Info about the 'backwards' definition.</span><b><a href="#valdef-animation-fill-mode-backwards">#valdef-animation-fill-mode-backwards</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-fill-mode-backwards">3.3. 
 The animation-duration property</a>
@@ -3932,8 +3932,8 @@ The animation-fill-mode property</a> <a href="#ref-for-valdef-animation-fill-mod
 The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-animation-fill-mode-both">
-   <b><a href="#valdef-animation-fill-mode-both">#valdef-animation-fill-mode-both</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-animation-fill-mode-both" class="dfn-panel" data-for="valdef-animation-fill-mode-both" id="infopanel-for-valdef-animation-fill-mode-both" role="dialog">
+   <span id="infopaneltitle-for-valdef-animation-fill-mode-both" style="display:none">Info about the 'both' definition.</span><b><a href="#valdef-animation-fill-mode-both">#valdef-animation-fill-mode-both</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-fill-mode-both">2. 
 Animations</a>
@@ -3941,36 +3941,36 @@ Animations</a>
 The animation-duration property</a> <a href="#ref-for-valdef-animation-fill-mode-both②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation">
-   <b><a href="#propdef-animation">#propdef-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation" class="dfn-panel" data-for="propdef-animation" id="infopanel-for-propdef-animation" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation" style="display:none">Info about the 'animation' definition.</span><b><a href="#propdef-animation">#propdef-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3.10. 
 The animation shorthand property</a> <a href="#ref-for-propdef-animation①">(2)</a> <a href="#ref-for-propdef-animation②">(3)</a> <a href="#ref-for-propdef-animation③">(4)</a> <a href="#ref-for-propdef-animation④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation">
-   <b><a href="#typedef-single-animation">#typedef-single-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation" class="dfn-panel" data-for="typedef-single-animation" id="infopanel-for-typedef-single-animation" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation" style="display:none">Info about the '&lt;single-animation>' definition.</span><b><a href="#typedef-single-animation">#typedef-single-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation">3.10. 
 The animation shorthand property</a> <a href="#ref-for-typedef-single-animation①">(2)</a> <a href="#ref-for-typedef-single-animation②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-animationeventinit">
-   <b><a href="#dictdef-animationeventinit">#dictdef-animationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-animationeventinit" class="dfn-panel" data-for="dictdef-animationeventinit" id="infopanel-for-dictdef-animationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-animationeventinit" style="display:none">Info about the 'AnimationEventInit' definition.</span><b><a href="#dictdef-animationeventinit">#dictdef-animationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-animationeventinit">4.1.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationevent-animationname">
-   <b><a href="#dom-animationevent-animationname">#dom-animationevent-animationname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationevent-animationname" class="dfn-panel" data-for="dom-animationevent-animationname" id="infopanel-for-dom-animationevent-animationname" role="dialog">
+   <span id="infopaneltitle-for-dom-animationevent-animationname" style="display:none">Info about the 'animationName' definition.</span><b><a href="#dom-animationevent-animationname">#dom-animationevent-animationname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationevent-animationname">4.1.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationevent-elapsedtime">
-   <b><a href="#dom-animationevent-elapsedtime">#dom-animationevent-elapsedtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationevent-elapsedtime" class="dfn-panel" data-for="dom-animationevent-elapsedtime" id="infopanel-for-dom-animationevent-elapsedtime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationevent-elapsedtime" style="display:none">Info about the 'elapsedTime' definition.</span><b><a href="#dom-animationevent-elapsedtime">#dom-animationevent-elapsedtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationevent-elapsedtime">4.1.1. 
 IDL Definition</a>
@@ -3978,15 +3978,15 @@ IDL Definition</a>
 Types of AnimationEvent</a> <a href="#ref-for-dom-animationevent-elapsedtime②">(2)</a> <a href="#ref-for-dom-animationevent-elapsedtime③">(3)</a> <a href="#ref-for-dom-animationevent-elapsedtime④">(4)</a> <a href="#ref-for-dom-animationevent-elapsedtime⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationevent-pseudoelement">
-   <b><a href="#dom-animationevent-pseudoelement">#dom-animationevent-pseudoelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationevent-pseudoelement" class="dfn-panel" data-for="dom-animationevent-pseudoelement" id="infopanel-for-dom-animationevent-pseudoelement" role="dialog">
+   <span id="infopaneltitle-for-dom-animationevent-pseudoelement" style="display:none">Info about the 'pseudoElement' definition.</span><b><a href="#dom-animationevent-pseudoelement">#dom-animationevent-pseudoelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationevent-pseudoelement">4.1.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-animationevent-animationstart">
-   <b><a href="#eventdef-animationevent-animationstart">#eventdef-animationevent-animationstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-animationevent-animationstart" class="dfn-panel" data-for="eventdef-animationevent-animationstart" id="infopanel-for-eventdef-animationevent-animationstart" role="dialog">
+   <span id="infopaneltitle-for-eventdef-animationevent-animationstart" style="display:none">Info about the 'animationstart' definition.</span><b><a href="#eventdef-animationevent-animationstart">#eventdef-animationevent-animationstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-animationevent-animationstart">2. 
 Animations</a>
@@ -3997,8 +3997,8 @@ handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-animationevent-animationend">
-   <b><a href="#eventdef-animationevent-animationend">#eventdef-animationevent-animationend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-animationevent-animationend" class="dfn-panel" data-for="eventdef-animationevent-animationend" id="infopanel-for-eventdef-animationevent-animationend" role="dialog">
+   <span id="infopaneltitle-for-eventdef-animationevent-animationend" style="display:none">Info about the 'animationend' definition.</span><b><a href="#eventdef-animationevent-animationend">#eventdef-animationevent-animationend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-animationevent-animationend">2. 
 Animations</a>
@@ -4009,8 +4009,8 @@ handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-animationevent-animationiteration">
-   <b><a href="#eventdef-animationevent-animationiteration">#eventdef-animationevent-animationiteration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-animationevent-animationiteration" class="dfn-panel" data-for="eventdef-animationevent-animationiteration" id="infopanel-for-eventdef-animationevent-animationiteration" role="dialog">
+   <span id="infopaneltitle-for-eventdef-animationevent-animationiteration" style="display:none">Info about the 'animationiteration' definition.</span><b><a href="#eventdef-animationevent-animationiteration">#eventdef-animationevent-animationiteration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-animationevent-animationiteration">4.2. 
 Types of AnimationEvent</a>
@@ -4019,8 +4019,8 @@ handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-animationevent-animationcancel">
-   <b><a href="#eventdef-animationevent-animationcancel">#eventdef-animationevent-animationcancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-animationevent-animationcancel" class="dfn-panel" data-for="eventdef-animationevent-animationcancel" id="infopanel-for-eventdef-animationevent-animationcancel" role="dialog">
+   <span id="infopaneltitle-for-eventdef-animationevent-animationcancel" style="display:none">Info about the 'animationcancel' definition.</span><b><a href="#eventdef-animationevent-animationcancel">#eventdef-animationevent-animationcancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-animationevent-animationcancel">4.2. 
 Types of AnimationEvent</a>
@@ -4029,8 +4029,8 @@ handlers on elements, Document objects, and Window
 objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csskeyframerule">
-   <b><a href="#csskeyframerule">#csskeyframerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csskeyframerule" class="dfn-panel" data-for="csskeyframerule" id="infopanel-for-csskeyframerule" role="dialog">
+   <span id="infopaneltitle-for-csskeyframerule" style="display:none">Info about the 'CSSKeyframeRule' definition.</span><b><a href="#csskeyframerule">#csskeyframerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeyframerule">5.2. 
 The CSSKeyframeRule Interface</a>
@@ -4046,8 +4046,8 @@ The deleteRule method</a>
 The findRule method</a> <a href="#ref-for-csskeyframerule⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframerule-keytext">
-   <b><a href="#dom-csskeyframerule-keytext">#dom-csskeyframerule-keytext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframerule-keytext" class="dfn-panel" data-for="dom-csskeyframerule-keytext" id="infopanel-for-dom-csskeyframerule-keytext" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframerule-keytext" style="display:none">Info about the 'keyText' definition.</span><b><a href="#dom-csskeyframerule-keytext">#dom-csskeyframerule-keytext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframerule-keytext">5.2.1. 
 IDL Definition</a>
@@ -4055,71 +4055,71 @@ IDL Definition</a>
 Attributes</a> <a href="#ref-for-dom-csskeyframerule-keytext②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframerule-style">
-   <b><a href="#dom-csskeyframerule-style">#dom-csskeyframerule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframerule-style" class="dfn-panel" data-for="dom-csskeyframerule-style" id="infopanel-for-dom-csskeyframerule-style" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframerule-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-csskeyframerule-style">#dom-csskeyframerule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframerule-style">5.2.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csskeyframesrule">
-   <b><a href="#csskeyframesrule">#csskeyframesrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csskeyframesrule" class="dfn-panel" data-for="csskeyframesrule" id="infopanel-for-csskeyframesrule" role="dialog">
+   <span id="infopaneltitle-for-csskeyframesrule" style="display:none">Info about the 'CSSKeyframesRule' definition.</span><b><a href="#csskeyframesrule">#csskeyframesrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeyframesrule">5.3. 
 The CSSKeyframesRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-name">
-   <b><a href="#dom-csskeyframesrule-name">#dom-csskeyframesrule-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-name" class="dfn-panel" data-for="dom-csskeyframesrule-name" id="infopanel-for-dom-csskeyframesrule-name" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-csskeyframesrule-name">#dom-csskeyframesrule-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-name">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-cssrules">
-   <b><a href="#dom-csskeyframesrule-cssrules">#dom-csskeyframesrule-cssrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-cssrules" class="dfn-panel" data-for="dom-csskeyframesrule-cssrules" id="infopanel-for-dom-csskeyframesrule-cssrules" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-cssrules" style="display:none">Info about the 'cssRules' definition.</span><b><a href="#dom-csskeyframesrule-cssrules">#dom-csskeyframesrule-cssrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-cssrules">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-appendrule">
-   <b><a href="#dom-csskeyframesrule-appendrule">#dom-csskeyframesrule-appendrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-appendrule" class="dfn-panel" data-for="dom-csskeyframesrule-appendrule" id="infopanel-for-dom-csskeyframesrule-appendrule" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-appendrule" style="display:none">Info about the 'appendRule' definition.</span><b><a href="#dom-csskeyframesrule-appendrule">#dom-csskeyframesrule-appendrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-appendrule">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-appendrule-rule-rule">
-   <b><a href="#dom-csskeyframesrule-appendrule-rule-rule">#dom-csskeyframesrule-appendrule-rule-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-appendrule-rule-rule" class="dfn-panel" data-for="dom-csskeyframesrule-appendrule-rule-rule" id="infopanel-for-dom-csskeyframesrule-appendrule-rule-rule" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-appendrule-rule-rule" style="display:none">Info about the 'rule' definition.</span><b><a href="#dom-csskeyframesrule-appendrule-rule-rule">#dom-csskeyframesrule-appendrule-rule-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-appendrule-rule-rule">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-deleterule">
-   <b><a href="#dom-csskeyframesrule-deleterule">#dom-csskeyframesrule-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-deleterule" class="dfn-panel" data-for="dom-csskeyframesrule-deleterule" id="infopanel-for-dom-csskeyframesrule-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-deleterule" style="display:none">Info about the 'deleteRule' definition.</span><b><a href="#dom-csskeyframesrule-deleterule">#dom-csskeyframesrule-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-deleterule">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-deleterule-select-select">
-   <b><a href="#dom-csskeyframesrule-deleterule-select-select">#dom-csskeyframesrule-deleterule-select-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-deleterule-select-select" class="dfn-panel" data-for="dom-csskeyframesrule-deleterule-select-select" id="infopanel-for-dom-csskeyframesrule-deleterule-select-select" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-deleterule-select-select" style="display:none">Info about the 'select' definition.</span><b><a href="#dom-csskeyframesrule-deleterule-select-select">#dom-csskeyframesrule-deleterule-select-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-deleterule-select-select">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-findrule">
-   <b><a href="#dom-csskeyframesrule-findrule">#dom-csskeyframesrule-findrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-findrule" class="dfn-panel" data-for="dom-csskeyframesrule-findrule" id="infopanel-for-dom-csskeyframesrule-findrule" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-findrule" style="display:none">Info about the 'findRule' definition.</span><b><a href="#dom-csskeyframesrule-findrule">#dom-csskeyframesrule-findrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-findrule">5.3.1. 
 IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csskeyframesrule-findrule-select-select">
-   <b><a href="#dom-csskeyframesrule-findrule-select-select">#dom-csskeyframesrule-findrule-select-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csskeyframesrule-findrule-select-select" class="dfn-panel" data-for="dom-csskeyframesrule-findrule-select-select" id="infopanel-for-dom-csskeyframesrule-findrule-select-select" role="dialog">
+   <span id="infopaneltitle-for-dom-csskeyframesrule-findrule-select-select" style="display:none">Info about the 'select' definition.</span><b><a href="#dom-csskeyframesrule-findrule-select-select">#dom-csskeyframesrule-findrule-select-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-findrule-select-select">5.3.1. 
 IDL Definition</a>
@@ -4127,59 +4127,115 @@ IDL Definition</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-animations-2/Overview.html
@@ -1810,166 +1810,166 @@ console<c- p>.</c->log<c- p>(</c->anim<c- p>.</c->playState<c- p>);</c-> <c- c1>
    <li><a href="#typedef-single-animation-timeline">&lt;single-animation-timeline></a><span>, in § 3.9</span>
    <li><a href="#typedef-timeline-name">&lt;timeline-name></a><span>, in § 3.9</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3. Keyframes</a> <a href="#ref-for-computed-value①">(2)</a>
     <li><a href="#ref-for-computed-value②">5.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-step-easing-function-step-end">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-step-easing-function-step-end">https://drafts.csswg.org/css-easing-2/#valdef-step-easing-function-step-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-step-easing-function-step-end" class="dfn-panel" data-for="term-for-valdef-step-easing-function-step-end" id="infopanel-for-term-for-valdef-step-easing-function-step-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-step-easing-function-step-end" style="display:none">Info about the 'step-end' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-step-easing-function-step-end">https://drafts.csswg.org/css-easing-2/#valdef-step-easing-function-step-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-step-easing-function-step-end">3. Keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">3.2. The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-mask-composite-add">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-composite-add">https://drafts.fxtf.org/css-masking-1/#valdef-mask-composite-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-mask-composite-add" class="dfn-panel" data-for="term-for-valdef-mask-composite-add" id="infopanel-for-term-for-valdef-mask-composite-add" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-mask-composite-add" style="display:none">Info about the 'add' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-composite-add">https://drafts.fxtf.org/css-masking-1/#valdef-mask-composite-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-composite-add">3.8. The animation-composition property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scale">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scale" class="dfn-panel" data-for="term-for-propdef-scale" id="infopanel-for-term-for-propdef-scale" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scale" style="display:none">Info about the 'scale' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scale">3.8. The animation-composition property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.8. The animation-composition property</a>
     <li><a href="#ref-for-mult-comma①">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">3.10. The animation shorthand property</a> <a href="#ref-for-time-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-identifier">https://drafts.csswg.org/css-values-4/#css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-identifier" class="dfn-panel" data-for="term-for-css-identifier" id="infopanel-for-term-for-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-identifier" style="display:none">Info about the 'css identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-identifier">https://drafts.csswg.org/css-values-4/#css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-identifier">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-to-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical">https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-to-physical" class="dfn-panel" data-for="term-for-logical-to-physical" id="infopanel-for-term-for-logical-to-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-to-physical" style="display:none">Info about the 'equivalent physical property' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical">https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-to-physical">3. Keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-keyframes-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name">https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-keyframes-name" class="dfn-panel" data-for="term-for-typedef-keyframes-name" id="infopanel-for-term-for-typedef-keyframes-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-keyframes-name" style="display:none">Info about the '&lt;keyframes-name>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name">https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframes-name">3. Keyframes</a> <a href="#ref-for-typedef-keyframes-name①">(2)</a>
     <li><a href="#ref-for-typedef-keyframes-name②">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-single-animation-direction">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-direction">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-single-animation-direction" class="dfn-panel" data-for="term-for-typedef-single-animation-direction" id="infopanel-for-term-for-typedef-single-animation-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-single-animation-direction" style="display:none">Info about the '&lt;single-animation-direction>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-direction">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-direction">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-single-animation-fill-mode">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-single-animation-fill-mode" class="dfn-panel" data-for="term-for-typedef-single-animation-fill-mode" id="infopanel-for-term-for-typedef-single-animation-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-single-animation-fill-mode" style="display:none">Info about the '&lt;single-animation-fill-mode>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-fill-mode">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-single-animation-iteration-count">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-single-animation-iteration-count" class="dfn-panel" data-for="term-for-typedef-single-animation-iteration-count" id="infopanel-for-term-for-typedef-single-animation-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-single-animation-iteration-count" style="display:none">Info about the '&lt;single-animation-iteration-count>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-iteration-count">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-single-animation-play-state">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-play-state">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-single-animation-play-state" class="dfn-panel" data-for="term-for-typedef-single-animation-play-state" id="infopanel-for-term-for-typedef-single-animation-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-single-animation-play-state" style="display:none">Info about the '&lt;single-animation-play-state>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-single-animation-play-state">https://drafts.csswg.org/css-animations-1/#typedef-single-animation-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-play-state">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-keyframes">
-   <a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-keyframes" class="dfn-panel" data-for="term-for-at-ruledef-keyframes" id="infopanel-for-term-for-at-ruledef-keyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">2. Animations</a> <a href="#ref-for-at-ruledef-keyframes①">(2)</a> <a href="#ref-for-at-ruledef-keyframes②">(3)</a> <a href="#ref-for-at-ruledef-keyframes③">(4)</a>
     <li><a href="#ref-for-at-ruledef-keyframes④">3. Keyframes</a> <a href="#ref-for-at-ruledef-keyframes⑤">(2)</a> <a href="#ref-for-at-ruledef-keyframes⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationevent">
-   <a href="https://drafts.csswg.org/css-animations-1/#animationevent">https://drafts.csswg.org/css-animations-1/#animationevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationevent" class="dfn-panel" data-for="term-for-animationevent" id="infopanel-for-term-for-animationevent" role="menu">
+   <span id="infopaneltitle-for-term-for-animationevent" style="display:none">Info about the 'AnimationEvent' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#animationevent">https://drafts.csswg.org/css-animations-1/#animationevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationevent">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3.10. The animation shorthand property</a> <a href="#ref-for-propdef-animation①">(2)</a>
     <li><a href="#ref-for-propdef-animation②">5.2. Requirements on pending style changes</a> <a href="#ref-for-propdef-animation③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-delay">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-delay">https://drafts.csswg.org/css-animations-1/#propdef-animation-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-delay" class="dfn-panel" data-for="term-for-propdef-animation-delay" id="infopanel-for-term-for-propdef-animation-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-delay" style="display:none">Info about the 'animation-delay' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-delay">https://drafts.csswg.org/css-animations-1/#propdef-animation-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-delay">2. Animations</a>
     <li><a href="#ref-for-propdef-animation-delay①">3.6. The animation-delay property</a> <a href="#ref-for-propdef-animation-delay②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-direction">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-direction">https://drafts.csswg.org/css-animations-1/#propdef-animation-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-direction" class="dfn-panel" data-for="term-for-propdef-animation-direction" id="infopanel-for-term-for-propdef-animation-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-direction" style="display:none">Info about the 'animation-direction' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-direction">https://drafts.csswg.org/css-animations-1/#propdef-animation-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-direction">3.4. The animation-direction property</a> <a href="#ref-for-propdef-animation-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-duration">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-duration">https://drafts.csswg.org/css-animations-1/#propdef-animation-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-duration" class="dfn-panel" data-for="term-for-propdef-animation-duration" id="infopanel-for-term-for-propdef-animation-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-duration" style="display:none">Info about the 'animation-duration' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-duration">https://drafts.csswg.org/css-animations-1/#propdef-animation-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-duration">2. Animations</a>
     <li><a href="#ref-for-propdef-animation-duration①">3.1. The animation-duration property</a> <a href="#ref-for-propdef-animation-duration②">(2)</a>
     <li><a href="#ref-for-propdef-animation-duration③">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-fill-mode">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-fill-mode" class="dfn-panel" data-for="term-for-propdef-animation-fill-mode" id="infopanel-for-term-for-propdef-animation-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-fill-mode" style="display:none">Info about the 'animation-fill-mode' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-fill-mode">3.7. The animation-fill-mode property</a> <a href="#ref-for-propdef-animation-fill-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-iteration-count">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-iteration-count" class="dfn-panel" data-for="term-for-propdef-animation-iteration-count" id="infopanel-for-term-for-propdef-animation-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-iteration-count" style="display:none">Info about the 'animation-iteration-count' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-iteration-count">3.3. The animation-iteration-count property</a> <a href="#ref-for-propdef-animation-iteration-count①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">2. Animations</a>
     <li><a href="#ref-for-propdef-animation-name①">2.1. Owning element</a> <a href="#ref-for-propdef-animation-name②">(2)</a> <a href="#ref-for-propdef-animation-name③">(3)</a>
@@ -1979,147 +1979,147 @@ console<c- p>.</c->log<c- p>(</c->anim<c- p>.</c->playState<c- p>);</c-> <c- c1>
     <li><a href="#ref-for-propdef-animation-name⑨">5.1. The CSSAnimation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-play-state">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state">https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-play-state" class="dfn-panel" data-for="term-for-propdef-animation-play-state" id="infopanel-for-term-for-propdef-animation-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-play-state" style="display:none">Info about the 'animation-play-state' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state">https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-play-state">2. Animations</a> <a href="#ref-for-propdef-animation-play-state①">(2)</a> <a href="#ref-for-propdef-animation-play-state②">(3)</a> <a href="#ref-for-propdef-animation-play-state③">(4)</a>
     <li><a href="#ref-for-propdef-animation-play-state④">3.5. The animation-play-state property</a> <a href="#ref-for-propdef-animation-play-state⑤">(2)</a> <a href="#ref-for-propdef-animation-play-state⑥">(3)</a> <a href="#ref-for-propdef-animation-play-state⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timing-function">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timing-function" class="dfn-panel" data-for="term-for-propdef-animation-timing-function" id="infopanel-for-term-for-propdef-animation-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">2. Animations</a>
     <li><a href="#ref-for-propdef-animation-timing-function①">3. Keyframes</a> <a href="#ref-for-propdef-animation-timing-function②">(2)</a>
     <li><a href="#ref-for-propdef-animation-timing-function③">3.2. The animation-timing-function property</a> <a href="#ref-for-propdef-animation-timing-function④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationcancel">
-   <a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationcancel">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationcancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationcancel" class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationcancel" id="infopanel-for-term-for-eventdef-globaleventhandlers-animationcancel" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationcancel" style="display:none">Info about the 'animationcancel' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationcancel">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationcancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-globaleventhandlers-animationcancel">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationend">
-   <a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationend">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationend" class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationend" id="infopanel-for-term-for-eventdef-globaleventhandlers-animationend" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationend" style="display:none">Info about the 'animationend' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationend">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-globaleventhandlers-animationend">4.1. Event dispatch</a> <a href="#ref-for-eventdef-globaleventhandlers-animationend①">(2)</a> <a href="#ref-for-eventdef-globaleventhandlers-animationend②">(3)</a> <a href="#ref-for-eventdef-globaleventhandlers-animationend③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationiteration">
-   <a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationiteration" class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationiteration" id="infopanel-for-term-for-eventdef-globaleventhandlers-animationiteration" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationiteration" style="display:none">Info about the 'animationiteration' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-globaleventhandlers-animationiteration">4.1. Event dispatch</a> <a href="#ref-for-eventdef-globaleventhandlers-animationiteration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationstart">
-   <a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationstart">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationstart</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationstart" class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationstart" id="infopanel-for-term-for-eventdef-globaleventhandlers-animationstart" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationstart" style="display:none">Info about the 'animationstart' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationstart">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationstart</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-globaleventhandlers-animationstart">4.1. Event dispatch</a> <a href="#ref-for-eventdef-globaleventhandlers-animationstart①">(2)</a> <a href="#ref-for-eventdef-globaleventhandlers-animationstart②">(3)</a> <a href="#ref-for-eventdef-globaleventhandlers-animationstart③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationevent-elapsedtime">
-   <a href="https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime">https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationevent-elapsedtime" class="dfn-panel" data-for="term-for-dom-animationevent-elapsedtime" id="infopanel-for-term-for-dom-animationevent-elapsedtime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationevent-elapsedtime" style="display:none">Info about the 'elapsedTime' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime">https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationevent-elapsedtime">4.1. Event dispatch</a> <a href="#ref-for-dom-animationevent-elapsedtime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-animation-play-state-paused">
-   <a href="https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-paused">https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-paused</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-animation-play-state-paused" class="dfn-panel" data-for="term-for-valdef-animation-play-state-paused" id="infopanel-for-term-for-valdef-animation-play-state-paused" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-animation-play-state-paused" style="display:none">Info about the 'paused' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-paused">https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-paused</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-play-state-paused">3.5. The animation-play-state property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-animation-play-state-running">
-   <a href="https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-running">https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-running</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-animation-play-state-running" class="dfn-panel" data-for="term-for-valdef-animation-play-state-running" id="infopanel-for-term-for-valdef-animation-play-state-running" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-animation-play-state-running" style="display:none">Info about the 'running' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-running">https://drafts.csswg.org/css-animations-1/#valdef-animation-play-state-running</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-animation-play-state-running">3.5. The animation-play-state property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">5.1. The CSSAnimation interface</a> <a href="#ref-for-cssomstring①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">3. Keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">2.2. Animation composite order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-animation" style="display:none">Info about the 'Animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">2.2. Animation composite order</a>
     <li><a href="#ref-for-animation①">3.9. The animation-timeline property</a>
     <li><a href="#ref-for-animation②">5.1. The CSSAnimation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationeffect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationeffect" class="dfn-panel" data-for="term-for-animationeffect" id="infopanel-for-term-for-animationeffect" role="menu">
+   <span id="infopaneltitle-for-term-for-animationeffect" style="display:none">Info about the 'AnimationEffect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationeffect">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documenttimeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#documenttimeline">https://drafts.csswg.org/web-animations-1/#documenttimeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documenttimeline" class="dfn-panel" data-for="term-for-documenttimeline" id="infopanel-for-term-for-documenttimeline" role="menu">
+   <span id="infopaneltitle-for-term-for-documenttimeline" style="display:none">Info about the 'DocumentTimeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#documenttimeline">https://drafts.csswg.org/web-animations-1/#documenttimeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documenttimeline">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyframeeffect">
-   <a href="https://drafts.csswg.org/web-animations-1/#keyframeeffect">https://drafts.csswg.org/web-animations-1/#keyframeeffect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyframeeffect" class="dfn-panel" data-for="term-for-keyframeeffect" id="infopanel-for-term-for-keyframeeffect" role="menu">
+   <span id="infopaneltitle-for-term-for-keyframeeffect" style="display:none">Info about the 'KeyframeEffect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#keyframeeffect">https://drafts.csswg.org/web-animations-1/#keyframeeffect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframeeffect">2. Animations</a> <a href="#ref-for-keyframeeffect①">(2)</a> <a href="#ref-for-keyframeeffect②">(3)</a> <a href="#ref-for-keyframeeffect③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-duration">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-duration">https://drafts.csswg.org/web-animations-1/#active-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-duration" class="dfn-panel" data-for="term-for-active-duration" id="infopanel-for-term-for-active-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-active-duration" style="display:none">Info about the 'active duration' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-duration">https://drafts.csswg.org/web-animations-1/#active-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-duration">4.1. Event dispatch</a> <a href="#ref-for-active-duration①">(2)</a> <a href="#ref-for-active-duration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-phase">https://drafts.csswg.org/web-animations-1/#active-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-phase" class="dfn-panel" data-for="term-for-active-phase" id="infopanel-for-term-for-active-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-active-phase" style="display:none">Info about the 'active phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-phase">https://drafts.csswg.org/web-animations-1/#active-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-phase">4.1. Event dispatch</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-phase②">(3)</a> <a href="#ref-for-active-phase③">(4)</a> <a href="#ref-for-active-phase④">(5)</a> <a href="#ref-for-active-phase⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-time">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-time">https://drafts.csswg.org/web-animations-1/#active-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-time" class="dfn-panel" data-for="term-for-active-time" id="infopanel-for-term-for-active-time" role="menu">
+   <span id="infopaneltitle-for-term-for-active-time" style="display:none">Info about the 'active time' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-time">https://drafts.csswg.org/web-animations-1/#active-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-time">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-after-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#after-phase">https://drafts.csswg.org/web-animations-1/#after-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-after-phase" class="dfn-panel" data-for="term-for-after-phase" id="infopanel-for-term-for-after-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-after-phase" style="display:none">Info about the 'after phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#after-phase">https://drafts.csswg.org/web-animations-1/#after-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-after-phase">4.1. Event dispatch</a> <a href="#ref-for-after-phase①">(2)</a> <a href="#ref-for-after-phase②">(3)</a> <a href="#ref-for-after-phase③">(4)</a> <a href="#ref-for-after-phase④">(5)</a> <a href="#ref-for-after-phase⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation①" role="menu">
+   <span id="infopaneltitle-for-term-for-animation①" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">2.2. Animation composite order</a>
     <li><a href="#ref-for-animation①">3.9. The animation-timeline property</a>
     <li><a href="#ref-for-animation②">5.1. The CSSAnimation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-class">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-class">https://drafts.csswg.org/web-animations-1/#animation-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-class" class="dfn-panel" data-for="term-for-animation-class" id="infopanel-for-term-for-animation-class" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-class" style="display:none">Info about the 'animation class' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-class">https://drafts.csswg.org/web-animations-1/#animation-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-class">2.2. Animation composite order</a> <a href="#ref-for-animation-class①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-effect">https://drafts.csswg.org/web-animations-1/#animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-effect" class="dfn-panel" data-for="term-for-animation-effect" id="infopanel-for-term-for-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-effect" style="display:none">Info about the 'animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-effect">https://drafts.csswg.org/web-animations-1/#animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect">3.1. The animation-duration property</a>
     <li><a href="#ref-for-animation-effect①">3.3. The animation-iteration-count property</a>
@@ -2129,230 +2129,230 @@ console<c- p>.</c->log<c- p>(</c->anim<c- p>.</c->playState<c- p>);</c-> <c- c1>
     <li><a href="#ref-for-animation-effect⑤">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-before-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#before-phase">https://drafts.csswg.org/web-animations-1/#before-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-before-phase" class="dfn-panel" data-for="term-for-before-phase" id="infopanel-for-term-for-before-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-before-phase" style="display:none">Info about the 'before phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#before-phase">https://drafts.csswg.org/web-animations-1/#before-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-phase">4.1. Event dispatch</a> <a href="#ref-for-before-phase①">(2)</a> <a href="#ref-for-before-phase②">(3)</a> <a href="#ref-for-before-phase③">(4)</a> <a href="#ref-for-before-phase④">(5)</a> <a href="#ref-for-before-phase⑤">(6)</a> <a href="#ref-for-before-phase⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-composite-operation">
-   <a href="https://drafts.csswg.org/web-animations-1/#composite-operation">https://drafts.csswg.org/web-animations-1/#composite-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-composite-operation" class="dfn-panel" data-for="term-for-composite-operation" id="infopanel-for-term-for-composite-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-composite-operation" style="display:none">Info about the 'composite operation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#composite-operation">https://drafts.csswg.org/web-animations-1/#composite-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-operation">3.8. The animation-composition property</a> <a href="#ref-for-composite-operation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-iteration">
-   <a href="https://drafts.csswg.org/web-animations-1/#current-iteration">https://drafts.csswg.org/web-animations-1/#current-iteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-iteration" class="dfn-panel" data-for="term-for-current-iteration" id="infopanel-for-term-for-current-iteration" role="menu">
+   <span id="infopaneltitle-for-term-for-current-iteration" style="display:none">Info about the 'current iteration' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#current-iteration">https://drafts.csswg.org/web-animations-1/#current-iteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-iteration">4.1. Event dispatch</a> <a href="#ref-for-current-iteration①">(2)</a> <a href="#ref-for-current-iteration②">(3)</a> <a href="#ref-for-current-iteration③">(4)</a> <a href="#ref-for-current-iteration④">(5)</a> <a href="#ref-for-current-iteration⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-time">
-   <a href="https://drafts.csswg.org/web-animations-1/#current-time">https://drafts.csswg.org/web-animations-1/#current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-time" class="dfn-panel" data-for="term-for-current-time" id="infopanel-for-term-for-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-current-time" style="display:none">Info about the 'current time' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#current-time">https://drafts.csswg.org/web-animations-1/#current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">4.1. Event dispatch</a> <a href="#ref-for-current-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-document-timeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#default-document-timeline">https://drafts.csswg.org/web-animations-1/#default-document-timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-document-timeline" class="dfn-panel" data-for="term-for-default-document-timeline" id="infopanel-for-term-for-default-document-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-default-document-timeline" style="display:none">Info about the 'default document timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#default-document-timeline">https://drafts.csswg.org/web-animations-1/#default-document-timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-document-timeline">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-effect">https://drafts.csswg.org/web-animations-1/#dom-animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-effect" class="dfn-panel" data-for="term-for-dom-animation-effect" id="infopanel-for-term-for-dom-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-effect" style="display:none">Info about the 'effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-effect">https://drafts.csswg.org/web-animations-1/#dom-animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-effect">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fill-mode">
-   <a href="https://drafts.csswg.org/web-animations-1/#fill-mode">https://drafts.csswg.org/web-animations-1/#fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fill-mode" class="dfn-panel" data-for="term-for-fill-mode" id="infopanel-for-term-for-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-fill-mode" style="display:none">Info about the 'fill mode' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#fill-mode">https://drafts.csswg.org/web-animations-1/#fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-mode">3.7. The animation-fill-mode property</a>
     <li><a href="#ref-for-fill-mode①">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-animation-list">
-   <a href="https://drafts.csswg.org/web-animations-1/#global-animation-list">https://drafts.csswg.org/web-animations-1/#global-animation-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-animation-list" class="dfn-panel" data-for="term-for-global-animation-list" id="infopanel-for-term-for-global-animation-list" role="menu">
+   <span id="infopaneltitle-for-term-for-global-animation-list" style="display:none">Info about the 'global animation list' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#global-animation-list">https://drafts.csswg.org/web-animations-1/#global-animation-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-animation-list">2.2. Animation composite order</a> <a href="#ref-for-global-animation-list①">(2)</a> <a href="#ref-for-global-animation-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idle-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#idle-phase">https://drafts.csswg.org/web-animations-1/#idle-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idle-phase" class="dfn-panel" data-for="term-for-idle-phase" id="infopanel-for-term-for-idle-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-idle-phase" style="display:none">Info about the 'idle phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#idle-phase">https://drafts.csswg.org/web-animations-1/#idle-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle-phase">4.1. Event dispatch</a> <a href="#ref-for-idle-phase①">(2)</a> <a href="#ref-for-idle-phase②">(3)</a> <a href="#ref-for-idle-phase③">(4)</a> <a href="#ref-for-idle-phase④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idle-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#idle-play-state">https://drafts.csswg.org/web-animations-1/#idle-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idle-play-state" class="dfn-panel" data-for="term-for-idle-play-state" id="infopanel-for-term-for-idle-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-idle-play-state" style="display:none">Info about the 'idle play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#idle-play-state">https://drafts.csswg.org/web-animations-1/#idle-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle-play-state">2.2. Animation composite order</a> <a href="#ref-for-idle-play-state①">(2)</a> <a href="#ref-for-idle-play-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-count">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-count">https://drafts.csswg.org/web-animations-1/#iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-count" class="dfn-panel" data-for="term-for-iteration-count" id="infopanel-for-term-for-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-count" style="display:none">Info about the 'iteration count' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-count">https://drafts.csswg.org/web-animations-1/#iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-count">3.3. The animation-iteration-count property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-duration">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-duration">https://drafts.csswg.org/web-animations-1/#iteration-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-duration" class="dfn-panel" data-for="term-for-iteration-duration" id="infopanel-for-term-for-iteration-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-duration" style="display:none">Info about the 'iteration duration' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-duration">https://drafts.csswg.org/web-animations-1/#iteration-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-duration">3.1. The animation-duration property</a>
     <li><a href="#ref-for-iteration-duration①">4.1. Event dispatch</a> <a href="#ref-for-iteration-duration②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-start">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-start">https://drafts.csswg.org/web-animations-1/#iteration-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-start" class="dfn-panel" data-for="term-for-iteration-start" id="infopanel-for-term-for-iteration-start" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-start" style="display:none">Info about the 'iteration start' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-start">https://drafts.csswg.org/web-animations-1/#iteration-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-start">4.1. Event dispatch</a> <a href="#ref-for-iteration-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyframe">
-   <a href="https://drafts.csswg.org/web-animations-1/#keyframe">https://drafts.csswg.org/web-animations-1/#keyframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyframe" class="dfn-panel" data-for="term-for-keyframe" id="infopanel-for-term-for-keyframe" role="menu">
+   <span id="infopaneltitle-for-term-for-keyframe" style="display:none">Info about the 'keyframe' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#keyframe">https://drafts.csswg.org/web-animations-1/#keyframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe">3. Keyframes</a> <a href="#ref-for-keyframe①">(2)</a> <a href="#ref-for-keyframe②">(3)</a> <a href="#ref-for-keyframe③">(4)</a>
     <li><a href="#ref-for-keyframe④">3.2. The animation-timing-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pause-an-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#pause-an-animation">https://drafts.csswg.org/web-animations-1/#pause-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pause-an-animation" class="dfn-panel" data-for="term-for-pause-an-animation" id="infopanel-for-term-for-pause-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-pause-an-animation" style="display:none">Info about the 'pause an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#pause-an-animation">https://drafts.csswg.org/web-animations-1/#pause-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pause-an-animation">3.5. The animation-play-state property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-pause">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-pause">https://drafts.csswg.org/web-animations-1/#dom-animation-pause</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-pause" class="dfn-panel" data-for="term-for-dom-animation-pause" id="infopanel-for-term-for-dom-animation-pause" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-pause" style="display:none">Info about the 'pause()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-pause">https://drafts.csswg.org/web-animations-1/#dom-animation-pause</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-pause">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paused-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#paused-play-state">https://drafts.csswg.org/web-animations-1/#paused-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paused-play-state" class="dfn-panel" data-for="term-for-paused-play-state" id="infopanel-for-term-for-paused-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-paused-play-state" style="display:none">Info about the 'paused play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#paused-play-state">https://drafts.csswg.org/web-animations-1/#paused-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paused-play-state">2. Animations</a> <a href="#ref-for-paused-play-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pending-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#pending-play-state">https://drafts.csswg.org/web-animations-1/#pending-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pending-play-state" class="dfn-panel" data-for="term-for-pending-play-state" id="infopanel-for-term-for-pending-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-pending-play-state" style="display:none">Info about the 'pending play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#pending-play-state">https://drafts.csswg.org/web-animations-1/#pending-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-play-state">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-play-an-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#play-an-animation">https://drafts.csswg.org/web-animations-1/#play-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-play-an-animation" class="dfn-panel" data-for="term-for-play-an-animation" id="infopanel-for-term-for-play-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-play-an-animation" style="display:none">Info about the 'play an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#play-an-animation">https://drafts.csswg.org/web-animations-1/#play-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-an-animation">3.5. The animation-play-state property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#play-state">https://drafts.csswg.org/web-animations-1/#play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-play-state" class="dfn-panel" data-for="term-for-play-state" id="infopanel-for-term-for-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-play-state" style="display:none">Info about the 'play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#play-state">https://drafts.csswg.org/web-animations-1/#play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-state">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-play">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-play">https://drafts.csswg.org/web-animations-1/#dom-animation-play</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-play" class="dfn-panel" data-for="term-for-dom-animation-play" id="infopanel-for-term-for-dom-animation-play" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-play" style="display:none">Info about the 'play()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-play">https://drafts.csswg.org/web-animations-1/#dom-animation-play</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-play">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-playstate">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-playstate">https://drafts.csswg.org/web-animations-1/#dom-animation-playstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-playstate" class="dfn-panel" data-for="term-for-dom-animation-playstate" id="infopanel-for-term-for-dom-animation-playstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-playstate" style="display:none">Info about the 'playState' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-playstate">https://drafts.csswg.org/web-animations-1/#dom-animation-playstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-playstate">5.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-playback-direction">
-   <a href="https://drafts.csswg.org/web-animations-1/#playback-direction">https://drafts.csswg.org/web-animations-1/#playback-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-playback-direction" class="dfn-panel" data-for="term-for-playback-direction" id="infopanel-for-term-for-playback-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-playback-direction" style="display:none">Info about the 'playback direction' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#playback-direction">https://drafts.csswg.org/web-animations-1/#playback-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-direction">3.4. The animation-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-reverse">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-reverse">https://drafts.csswg.org/web-animations-1/#dom-animation-reverse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-reverse" class="dfn-panel" data-for="term-for-dom-animation-reverse" id="infopanel-for-term-for-dom-animation-reverse" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-reverse" style="display:none">Info about the 'reverse()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-reverse">https://drafts.csswg.org/web-animations-1/#dom-animation-reverse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-reverse">2. Animations</a> <a href="#ref-for-dom-animation-reverse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sampling">
-   <a href="https://drafts.csswg.org/web-animations-1/#sampling">https://drafts.csswg.org/web-animations-1/#sampling</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sampling" class="dfn-panel" data-for="term-for-sampling" id="infopanel-for-term-for-sampling" role="menu">
+   <span id="infopaneltitle-for-term-for-sampling" style="display:none">Info about the 'sampling' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#sampling">https://drafts.csswg.org/web-animations-1/#sampling</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sampling">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyframeeffect-setkeyframes">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyframeeffect-setkeyframes" class="dfn-panel" data-for="term-for-dom-keyframeeffect-setkeyframes" id="infopanel-for-term-for-dom-keyframeeffect-setkeyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyframeeffect-setkeyframes" style="display:none">Info about the 'setKeyframes(keyframes)' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-setkeyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-setkeyframes">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-start-delay">
-   <a href="https://drafts.csswg.org/web-animations-1/#start-delay">https://drafts.csswg.org/web-animations-1/#start-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-start-delay" class="dfn-panel" data-for="term-for-start-delay" id="infopanel-for-term-for-start-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-start-delay" style="display:none">Info about the 'start delay' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#start-delay">https://drafts.csswg.org/web-animations-1/#start-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">3.6. The animation-delay property</a>
     <li><a href="#ref-for-start-delay①">4.1. Event dispatch</a> <a href="#ref-for-start-delay②">(2)</a> <a href="#ref-for-start-delay③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-effect">https://drafts.csswg.org/web-animations-1/#target-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect" class="dfn-panel" data-for="term-for-target-effect" id="infopanel-for-term-for-target-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect" style="display:none">Info about the 'target effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-effect">https://drafts.csswg.org/web-animations-1/#target-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect">2.1. Owning element</a>
     <li><a href="#ref-for-target-effect①">4.1. Event dispatch</a> <a href="#ref-for-target-effect②">(2)</a> <a href="#ref-for-target-effect③">(3)</a> <a href="#ref-for-target-effect④">(4)</a> <a href="#ref-for-target-effect⑤">(5)</a>
     <li><a href="#ref-for-target-effect⑥">5.1. The CSSAnimation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect-end">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-effect-end">https://drafts.csswg.org/web-animations-1/#target-effect-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect-end" class="dfn-panel" data-for="term-for-target-effect-end" id="infopanel-for-term-for-target-effect-end" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect-end" style="display:none">Info about the 'target effect end' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-effect-end">https://drafts.csswg.org/web-animations-1/#target-effect-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect-end">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-element">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-element">https://drafts.csswg.org/web-animations-1/#target-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-element" class="dfn-panel" data-for="term-for-target-element" id="infopanel-for-term-for-target-element" role="menu">
+   <span id="infopaneltitle-for-term-for-target-element" style="display:none">Info about the 'target element' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-element">https://drafts.csswg.org/web-animations-1/#target-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-element">2.1. Owning element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#timeline">https://drafts.csswg.org/web-animations-1/#timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline" class="dfn-panel" data-for="term-for-timeline" id="infopanel-for-term-for-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline" style="display:none">Info about the 'timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#timeline">https://drafts.csswg.org/web-animations-1/#timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline">3.9. The animation-timeline property</a> <a href="#ref-for-timeline①">(2)</a> <a href="#ref-for-timeline②">(3)</a> <a href="#ref-for-timeline③">(4)</a> <a href="#ref-for-timeline④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming-timing-timing">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming-timing-timing">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming-timing-timing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationeffect-updatetiming-timing-timing" class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming-timing-timing" id="infopanel-for-term-for-dom-animationeffect-updatetiming-timing-timing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationeffect-updatetiming-timing-timing" style="display:none">Info about the 'timing' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming-timing-timing">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming-timing-timing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-updatetiming-timing-timing">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unresolved">
-   <a href="https://drafts.csswg.org/web-animations-1/#unresolved">https://drafts.csswg.org/web-animations-1/#unresolved</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unresolved" class="dfn-panel" data-for="term-for-unresolved" id="infopanel-for-term-for-unresolved" role="menu">
+   <span id="infopaneltitle-for-term-for-unresolved" style="display:none">Info about the 'unresolved' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#unresolved">https://drafts.csswg.org/web-animations-1/#unresolved</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unresolved">4.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationeffect-updatetiming" class="dfn-panel" data-for="term-for-dom-animationeffect-updatetiming" id="infopanel-for-term-for-dom-animationeffect-updatetiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationeffect-updatetiming" style="display:none">Info about the 'updateTiming()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming">https://drafts.csswg.org/web-animations-1/#dom-animationeffect-updatetiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-updatetiming">2. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animatable-getanimations">
-   <a href="https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations">https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animatable-getanimations" class="dfn-panel" data-for="term-for-dom-animatable-getanimations" id="infopanel-for-term-for-dom-animatable-getanimations" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animatable-getanimations" style="display:none">Info about the 'getAnimations()' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations">https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-getanimations">5.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-starttime">
-   <a href="https://drafts.csswg.org/web-animations-2/#dom-animation-starttime">https://drafts.csswg.org/web-animations-2/#dom-animation-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-starttime" class="dfn-panel" data-for="term-for-dom-animation-starttime" id="infopanel-for-term-for-dom-animation-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#dom-animation-starttime">https://drafts.csswg.org/web-animations-2/#dom-animation-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-starttime">2. Animations</a> <a href="#ref-for-dom-animation-starttime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The CSSAnimation interface</a>
    </ul>
@@ -2598,142 +2598,198 @@ selecting timeline enables most common animations to have to use a single name
 for both their keyframes and timeline which is simple and ergonomics. The <span class="property">animation-timeline</span> property gives authors additional control to independently
 select keyframes and timeline if necessary. <a class="issue-return" href="#issue-89002fbe" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="owning-element">
-   <b><a href="#owning-element">#owning-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-owning-element" class="dfn-panel" data-for="owning-element" id="infopanel-for-owning-element" role="dialog">
+   <span id="infopaneltitle-for-owning-element" style="display:none">Info about the 'owning element' definition.</span><b><a href="#owning-element">#owning-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-owning-element">2.1. Owning element</a> <a href="#ref-for-owning-element①">(2)</a> <a href="#ref-for-owning-element②">(3)</a> <a href="#ref-for-owning-element③">(4)</a> <a href="#ref-for-owning-element④">(5)</a>
     <li><a href="#ref-for-owning-element⑤">2.2. Animation composite order</a> <a href="#ref-for-owning-element⑥">(2)</a> <a href="#ref-for-owning-element⑦">(3)</a> <a href="#ref-for-owning-element⑧">(4)</a> <a href="#ref-for-owning-element⑨">(5)</a> <a href="#ref-for-owning-element①⓪">(6)</a> <a href="#ref-for-owning-element①①">(7)</a> <a href="#ref-for-owning-element①②">(8)</a> <a href="#ref-for-owning-element①③">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-composition">
-   <b><a href="#propdef-animation-composition">#propdef-animation-composition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-composition" class="dfn-panel" data-for="propdef-animation-composition" id="infopanel-for-propdef-animation-composition" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-composition" style="display:none">Info about the 'animation-composition' definition.</span><b><a href="#propdef-animation-composition">#propdef-animation-composition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-composition">3.8. The animation-composition property</a> <a href="#ref-for-propdef-animation-composition①">(2)</a> <a href="#ref-for-propdef-animation-composition②">(3)</a> <a href="#ref-for-propdef-animation-composition③">(4)</a> <a href="#ref-for-propdef-animation-composition④">(5)</a> <a href="#ref-for-propdef-animation-composition⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-composition">
-   <b><a href="#typedef-single-animation-composition">#typedef-single-animation-composition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-composition" class="dfn-panel" data-for="typedef-single-animation-composition" id="infopanel-for-typedef-single-animation-composition" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-composition" style="display:none">Info about the '&lt;single-animation-composition>' definition.</span><b><a href="#typedef-single-animation-composition">#typedef-single-animation-composition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-composition">3.8. The animation-composition property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-animation-timeline">
-   <b><a href="#propdef-animation-timeline">#propdef-animation-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-animation-timeline" class="dfn-panel" data-for="propdef-animation-timeline" id="infopanel-for-propdef-animation-timeline" role="dialog">
+   <span id="infopaneltitle-for-propdef-animation-timeline" style="display:none">Info about the 'animation-timeline' definition.</span><b><a href="#propdef-animation-timeline">#propdef-animation-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timeline">3.9. The animation-timeline property</a> <a href="#ref-for-propdef-animation-timeline①">(2)</a> <a href="#ref-for-propdef-animation-timeline②">(3)</a> <a href="#ref-for-propdef-animation-timeline③">(4)</a> <a href="#ref-for-propdef-animation-timeline④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-single-animation-timeline">
-   <b><a href="#typedef-single-animation-timeline">#typedef-single-animation-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-single-animation-timeline" class="dfn-panel" data-for="typedef-single-animation-timeline" id="infopanel-for-typedef-single-animation-timeline" role="dialog">
+   <span id="infopaneltitle-for-typedef-single-animation-timeline" style="display:none">Info about the '&lt;single-animation-timeline>' definition.</span><b><a href="#typedef-single-animation-timeline">#typedef-single-animation-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-single-animation-timeline">3.9. The animation-timeline property</a> <a href="#ref-for-typedef-single-animation-timeline①">(2)</a>
     <li><a href="#ref-for-typedef-single-animation-timeline②">3.10. The animation shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-single-animation-timeline-auto">
-   <b><a href="#valdef-single-animation-timeline-auto">#valdef-single-animation-timeline-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-single-animation-timeline-auto" class="dfn-panel" data-for="valdef-single-animation-timeline-auto" id="infopanel-for-valdef-single-animation-timeline-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-single-animation-timeline-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-single-animation-timeline-auto">#valdef-single-animation-timeline-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-single-animation-timeline-auto">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-single-animation-timeline-none">
-   <b><a href="#valdef-single-animation-timeline-none">#valdef-single-animation-timeline-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-single-animation-timeline-none" class="dfn-panel" data-for="valdef-single-animation-timeline-none" id="infopanel-for-valdef-single-animation-timeline-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-single-animation-timeline-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-single-animation-timeline-none">#valdef-single-animation-timeline-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-single-animation-timeline-none">3.9. The animation-timeline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-timeline-name">
-   <b><a href="#typedef-timeline-name">#typedef-timeline-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-timeline-name" class="dfn-panel" data-for="typedef-timeline-name" id="infopanel-for-typedef-timeline-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-timeline-name" style="display:none">Info about the '&lt;timeline-name>' definition.</span><b><a href="#typedef-timeline-name">#typedef-timeline-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-timeline-name">3.9. The animation-timeline property</a> <a href="#ref-for-typedef-timeline-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interval-start">
-   <b><a href="#interval-start">#interval-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interval-start" class="dfn-panel" data-for="interval-start" id="infopanel-for-interval-start" role="dialog">
+   <span id="infopaneltitle-for-interval-start" style="display:none">Info about the 'interval start' definition.</span><b><a href="#interval-start">#interval-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interval-start">4.1. Event dispatch</a> <a href="#ref-for-interval-start①">(2)</a> <a href="#ref-for-interval-start②">(3)</a> <a href="#ref-for-interval-start③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interval-end">
-   <b><a href="#interval-end">#interval-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interval-end" class="dfn-panel" data-for="interval-end" id="infopanel-for-interval-end" role="dialog">
+   <span id="infopaneltitle-for-interval-end" style="display:none">Info about the 'interval end' definition.</span><b><a href="#interval-end">#interval-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interval-end">4.1. Event dispatch</a> <a href="#ref-for-interval-end①">(2)</a> <a href="#ref-for-interval-end②">(3)</a> <a href="#ref-for-interval-end③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elapsed-time">
-   <b><a href="#elapsed-time">#elapsed-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elapsed-time" class="dfn-panel" data-for="elapsed-time" id="infopanel-for-elapsed-time" role="dialog">
+   <span id="infopaneltitle-for-elapsed-time" style="display:none">Info about the 'Elapsed time' definition.</span><b><a href="#elapsed-time">#elapsed-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elapsed-time">4.1. Event dispatch</a> <a href="#ref-for-elapsed-time①">(2)</a> <a href="#ref-for-elapsed-time②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssanimation">
-   <b><a href="#cssanimation">#cssanimation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssanimation" class="dfn-panel" data-for="cssanimation" id="infopanel-for-cssanimation" role="dialog">
+   <span id="infopaneltitle-for-cssanimation" style="display:none">Info about the 'CSSAnimation' definition.</span><b><a href="#cssanimation">#cssanimation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssanimation">2. Animations</a> <a href="#ref-for-cssanimation①">(2)</a> <a href="#ref-for-cssanimation②">(3)</a> <a href="#ref-for-cssanimation③">(4)</a> <a href="#ref-for-cssanimation④">(5)</a> <a href="#ref-for-cssanimation⑤">(6)</a> <a href="#ref-for-cssanimation⑥">(7)</a> <a href="#ref-for-cssanimation⑦">(8)</a> <a href="#ref-for-cssanimation⑧">(9)</a> <a href="#ref-for-cssanimation⑨">(10)</a>
     <li><a href="#ref-for-cssanimation①⓪">5.2. Requirements on pending style changes</a> <a href="#ref-for-cssanimation①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssanimation-animationname">
-   <b><a href="#dom-cssanimation-animationname">#dom-cssanimation-animationname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssanimation-animationname" class="dfn-panel" data-for="dom-cssanimation-animationname" id="infopanel-for-dom-cssanimation-animationname" role="dialog">
+   <span id="infopaneltitle-for-dom-cssanimation-animationname" style="display:none">Info about the 'animationName' definition.</span><b><a href="#dom-cssanimation-animationname">#dom-cssanimation-animationname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssanimation-animationname">5.1. The CSSAnimation interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-3/Overview.html
@@ -3402,26 +3402,26 @@ the earlier definition.</p>
    <li><a href="#user-agent">user agent</a><span>, in § 7.1</span>
    <li><a href="#vertical-offset">vertical offset</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://www.w3.org/TR/css-box-4/#border-box">https://www.w3.org/TR/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://www.w3.org/TR/css-box-4/#border-box">https://www.w3.org/TR/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">4.1. Curve Radii: the border-radius properties</a> <a href="#ref-for-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://www.w3.org/TR/css-box-4/#propdef-margin">https://www.w3.org/TR/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://www.w3.org/TR/css-box-4/#propdef-margin">https://www.w3.org/TR/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.4. Border Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://www.w3.org/TR/css-box-4/#propdef-padding">https://www.w3.org/TR/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://www.w3.org/TR/css-box-4/#propdef-padding">https://www.w3.org/TR/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">3.4. Border Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break">https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break">https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">1. Introduction</a>
     <li><a href="#ref-for-propdef-box-decoration-break①">2.8. Positioning Area: the background-origin property</a>
@@ -3434,8 +3434,8 @@ Changes since the 24 July 2012 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2.2. Base Color: the background-color property</a>
     <li><a href="#ref-for-typedef-color①">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-typedef-color②">(2)</a>
@@ -3447,73 +3447,73 @@ Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for
 Changes since the 24 July 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">6.1. Drop Shadows: the box-shadow property</a>
     <li><a href="#ref-for-valdef-color-currentcolor①">8.2. 
 Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for-valdef-color-currentcolor②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://www.w3.org/TR/css-display-3/#replaced-element">https://www.w3.org/TR/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#replaced-element">https://www.w3.org/TR/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">4.3. Corner Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">2.3. Image Sources: the background-image property</a> <a href="#ref-for-typedef-image①">(2)</a>
     <li><a href="#ref-for-typedef-image②">5.1. Image Source: the border-image-source property</a> <a href="#ref-for-typedef-image③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://www.w3.org/TR/css-images-3/#default-object-size">https://www.w3.org/TR/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#default-object-size">https://www.w3.org/TR/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">5.2. Image Slicing: the border-image-slice property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-aspect-ratio">https://www.w3.org/TR/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-aspect-ratio">https://www.w3.org/TR/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-natural-aspect-ratio①">(2)</a> <a href="#ref-for-natural-aspect-ratio②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-dimensions">https://www.w3.org/TR/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-dimensions">https://www.w3.org/TR/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">5.2. Image Slicing: the border-image-slice property</a>
     <li><a href="#ref-for-natural-dimensions①">5.3. Drawing Areas: the border-image-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-height">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-height">https://www.w3.org/TR/css-images-3/#natural-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-height" class="dfn-panel" data-for="term-for-natural-height" id="infopanel-for-term-for-natural-height" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-height" style="display:none">Info about the 'natural height' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-height">https://www.w3.org/TR/css-images-3/#natural-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">2.9. Sizing Images: the background-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-size">https://www.w3.org/TR/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-size">https://www.w3.org/TR/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-natural-size①">(2)</a>
     <li><a href="#ref-for-natural-size②">5.3. Drawing Areas: the border-image-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-width">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-width">https://www.w3.org/TR/css-images-3/#natural-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-width" class="dfn-panel" data-for="term-for-natural-width" id="infopanel-for-term-for-natural-width" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-width" style="display:none">Info about the 'natural width' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-width">https://www.w3.org/TR/css-images-3/#natural-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-width">2.9. Sizing Images: the background-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-size">
-   <a href="https://www.w3.org/TR/css-images-3/#specified-size">https://www.w3.org/TR/css-images-3/#specified-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-size" class="dfn-panel" data-for="term-for-specified-size" id="infopanel-for-term-for-specified-size" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-size" style="display:none">Info about the 'specified size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#specified-size">https://www.w3.org/TR/css-images-3/#specified-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size">5.2. Image Slicing: the border-image-slice property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-container-box">
-   <a href="https://www.w3.org/TR/css-ruby-1/#ruby-annotation-container-box">https://www.w3.org/TR/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-container-box" class="dfn-panel" data-for="term-for-ruby-annotation-container-box" id="infopanel-for-term-for-ruby-annotation-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-container-box" style="display:none">Info about the 'ruby annotation container' external reference.</span><a href="https://www.w3.org/TR/css-ruby-1/#ruby-annotation-container-box">https://www.w3.org/TR/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-container-box">Unnumbered Section</a>
     <li><a href="#ref-for-ruby-annotation-container-box①">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-ruby-annotation-container-box②">(2)</a>
@@ -3522,8 +3522,8 @@ Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for
     <li><a href="#ref-for-ruby-annotation-container-box⑦">3.4. Border Shorthand Properties</a> <a href="#ref-for-ruby-annotation-container-box⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-container-box">
-   <a href="https://www.w3.org/TR/css-ruby-1/#ruby-base-container-box">https://www.w3.org/TR/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-container-box" class="dfn-panel" data-for="term-for-ruby-base-container-box" id="infopanel-for-term-for-ruby-base-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-container-box" style="display:none">Info about the 'ruby base container' external reference.</span><a href="https://www.w3.org/TR/css-ruby-1/#ruby-base-container-box">https://www.w3.org/TR/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-container-box">Unnumbered Section</a>
     <li><a href="#ref-for-ruby-base-container-box①">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-ruby-base-container-box②">(2)</a>
@@ -3532,15 +3532,15 @@ Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for
     <li><a href="#ref-for-ruby-base-container-box⑦">3.4. Border Shorthand Properties</a> <a href="#ref-for-ruby-base-container-box⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://www.w3.org/TR/css-text-decor-4/#propdef-text-shadow">https://www.w3.org/TR/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://www.w3.org/TR/css-text-decor-4/#propdef-text-shadow">https://www.w3.org/TR/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">8.2. 
 Changes since the 17 October 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://www.w3.org/TR/css-values-3/#typedef-position">https://www.w3.org/TR/css-values-3/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://www.w3.org/TR/css-values-3/#typedef-position">https://www.w3.org/TR/css-values-3/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">8.3. 
 Changes since the 9 September 2014 Candidate Recommendation</a>
@@ -3548,8 +3548,8 @@ Changes since the 9 September 2014 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-all">https://www.w3.org/TR/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-all">https://www.w3.org/TR/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">2.6. Positioning Images: the background-position property</a>
     <li><a href="#ref-for-comb-all①">6.1. Drop Shadows: the box-shadow property</a> <a href="#ref-for-comb-all②">(2)</a>
@@ -3557,8 +3557,8 @@ Changes Since the 15 February 2011 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://www.w3.org/TR/css-values-4/#typedef-length-percentage">https://www.w3.org/TR/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#typedef-length-percentage">https://www.w3.org/TR/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">2.6. Positioning Images: the background-position property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a> <a href="#ref-for-typedef-length-percentage④">(5)</a> <a href="#ref-for-typedef-length-percentage⑤">(6)</a> <a href="#ref-for-typedef-length-percentage⑥">(7)</a> <a href="#ref-for-typedef-length-percentage⑦">(8)</a> <a href="#ref-for-typedef-length-percentage⑧">(9)</a> <a href="#ref-for-typedef-length-percentage⑨">(10)</a>
     <li><a href="#ref-for-typedef-length-percentage①⓪">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-typedef-length-percentage①①">(2)</a> <a href="#ref-for-typedef-length-percentage①②">(3)</a>
@@ -3568,8 +3568,8 @@ Changes Since the 15 February 2011 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-for-typedef-length-percentage②②">(2)</a> <a href="#ref-for-typedef-length-percentage②③">(3)</a> <a href="#ref-for-typedef-length-percentage②④">(4)</a> <a href="#ref-for-typedef-length-percentage②⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2.6. Positioning Images: the background-position property</a>
     <li><a href="#ref-for-length-value①">3.3. Line Thickness: the border-width properties</a>
@@ -3581,23 +3581,23 @@ Changes since the 17 October 2017 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5.2. Image Slicing: the border-image-slice property</a> <a href="#ref-for-number-value①">(2)</a>
     <li><a href="#ref-for-number-value②">5.3. Drawing Areas: the border-image-width property</a> <a href="#ref-for-number-value③">(2)</a>
     <li><a href="#ref-for-number-value④">5.4. Edge Overhang: the border-image-outset property</a> <a href="#ref-for-number-value⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://www.w3.org/TR/css-values-4/#percentage-value">https://www.w3.org/TR/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#percentage-value">https://www.w3.org/TR/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.6. Positioning Images: the background-position property</a>
     <li><a href="#ref-for-percentage-value①">5.2. Image Slicing: the border-image-slice property</a> <a href="#ref-for-percentage-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.6. Positioning Images: the background-position property</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-mult-opt③">(2)</a>
@@ -3606,35 +3606,35 @@ Changes Since the 15 February 2011 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-for-mult-opt⑨">(2)</a> <a href="#ref-for-mult-opt①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-bracketed-range-notation">
-   <a href="https://www.w3.org/TR/css-values-4/#css-bracketed-range-notation">https://www.w3.org/TR/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-bracketed-range-notation" class="dfn-panel" data-for="term-for-css-bracketed-range-notation" id="infopanel-for-term-for-css-bracketed-range-notation" role="menu">
+   <span id="infopaneltitle-for-term-for-css-bracketed-range-notation" style="display:none">Info about the 'css bracketed range notation' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#css-bracketed-range-notation">https://www.w3.org/TR/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-bracketed-range-notation">8.2. 
 Changes since the 17 October 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-num-range">https://www.w3.org/TR/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-num-range">https://www.w3.org/TR/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">2.4. Tiling Images: the background-repeat property</a>
     <li><a href="#ref-for-mult-num-range①">2.9. Sizing Images: the background-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-num">https://www.w3.org/TR/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-num">https://www.w3.org/TR/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">6.1. Drop Shadows: the box-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.3. Image Sources: the background-image property</a>
     <li><a href="#ref-for-comb-one①">2.4. Tiling Images: the background-repeat property</a> <a href="#ref-for-comb-one②">(2)</a> <a href="#ref-for-comb-one③">(3)</a> <a href="#ref-for-comb-one④">(4)</a> <a href="#ref-for-comb-one⑤">(5)</a>
@@ -3648,14 +3648,14 @@ Value Definitions</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-for-comb-one④③">(2)</a> <a href="#ref-for-comb-one④④">(3)</a> <a href="#ref-for-comb-one④⑤">(4)</a> <a href="#ref-for-comb-one④⑥">(5)</a> <a href="#ref-for-comb-one④⑦">(6)</a> <a href="#ref-for-comb-one④⑧">(7)</a> <a href="#ref-for-comb-one④⑨">(8)</a> <a href="#ref-for-comb-one⑤⓪">(9)</a> <a href="#ref-for-comb-one⑤①">(10)</a> <a href="#ref-for-comb-one⑤②">(11)</a> <a href="#ref-for-comb-one⑤③">(12)</a> <a href="#ref-for-comb-one⑤④">(13)</a> <a href="#ref-for-comb-one⑤⑤">(14)</a> <a href="#ref-for-comb-one⑤⑥">(15)</a> <a href="#ref-for-comb-one⑤⑦">(16)</a> <a href="#ref-for-comb-one⑤⑧">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a> <a href="#ref-for-comb-any③">(4)</a> <a href="#ref-for-comb-any④">(5)</a> <a href="#ref-for-comb-any⑤">(6)</a> <a href="#ref-for-comb-any⑥">(7)</a> <a href="#ref-for-comb-any⑦">(8)</a> <a href="#ref-for-comb-any⑧">(9)</a> <a href="#ref-for-comb-any⑨">(10)</a> <a href="#ref-for-comb-any①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">4.6. Effect on Tables</a> <a href="#ref-for-propdef-border-collapse①">(2)</a>
     <li><a href="#ref-for-propdef-border-collapse②">5.1. Image Source: the border-image-source property</a>
@@ -3666,8 +3666,8 @@ Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-fo
     <li><a href="#ref-for-propdef-border-collapse⑦">5.8. Effect on Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-border-collapse-collapse">
-   <a href="https://drafts.csswg.org/css2/#valdef-border-collapse-collapse">https://drafts.csswg.org/css2/#valdef-border-collapse-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-border-collapse-collapse" class="dfn-panel" data-for="term-for-valdef-border-collapse-collapse" id="infopanel-for-term-for-valdef-border-collapse-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-border-collapse-collapse" style="display:none">Info about the 'collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-border-collapse-collapse">https://drafts.csswg.org/css2/#valdef-border-collapse-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-collapse-collapse">4.6. Effect on Tables</a>
     <li><a href="#ref-for-valdef-border-collapse-collapse①">5.1. Image Source: the border-image-source property</a>
@@ -3678,8 +3678,8 @@ Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-fo
     <li><a href="#ref-for-valdef-border-collapse-collapse⑥">5.8. Effect on Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.11. 
 Backgrounds of Special Elements</a>
@@ -3689,53 +3689,53 @@ Changes since the 22 December 2020 Candidate Recommendation Snapshot</a> <a href
 Changes since the 4 February 2014 Last Call Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-inline-table">
-   <a href="https://drafts.csswg.org/css2/#value-def-inline-table">https://drafts.csswg.org/css2/#value-def-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-inline-table" class="dfn-panel" data-for="term-for-value-def-inline-table" id="infopanel-for-term-for-value-def-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-inline-table">https://drafts.csswg.org/css2/#value-def-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-inline-table">4.6. Effect on Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2.5. Affixing Images: the background-attachment property</a>
     <li><a href="#ref-for-propdef-overflow①">4.3. Corner Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-table">
-   <a href="https://drafts.csswg.org/css2/#value-def-table">https://drafts.csswg.org/css2/#value-def-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-table" class="dfn-panel" data-for="term-for-value-def-table" id="infopanel-for-term-for-value-def-table" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-table">https://drafts.csswg.org/css2/#value-def-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table">4.6. Effect on Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-table-cell">
-   <a href="https://drafts.csswg.org/css2/#value-def-table-cell">https://drafts.csswg.org/css2/#value-def-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-table-cell" class="dfn-panel" data-for="term-for-value-def-table-cell" id="infopanel-for-term-for-value-def-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-table-cell">https://drafts.csswg.org/css2/#value-def-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-cell">4.6. Effect on Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css2/#valdef-overflow-visible">https://drafts.csswg.org/css2/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-overflow-visible">https://drafts.csswg.org/css2/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">4.3. Corner Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-filter-drop-shadow">
-   <a href="https://www.w3.org/TR/filter-effects-1/#funcdef-filter-drop-shadow">https://www.w3.org/TR/filter-effects-1/#funcdef-filter-drop-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-filter-drop-shadow" class="dfn-panel" data-for="term-for-funcdef-filter-drop-shadow" id="infopanel-for-term-for-funcdef-filter-drop-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-filter-drop-shadow" style="display:none">Info about the 'drop-shadow()' external reference.</span><a href="https://www.w3.org/TR/filter-effects-1/#funcdef-filter-drop-shadow">https://www.w3.org/TR/filter-effects-1/#funcdef-filter-drop-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-filter-drop-shadow">8.2. 
 Changes since the 17 October 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-letter0">
-   <a href="https://drafts.csswg.org/selectors-3/#first-letter0">https://drafts.csswg.org/selectors-3/#first-letter0</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-letter0" class="dfn-panel" data-for="term-for-first-letter0" id="infopanel-for-term-for-first-letter0" role="menu">
+   <span id="infopaneltitle-for-term-for-first-letter0" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#first-letter0">https://drafts.csswg.org/selectors-3/#first-letter0</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-letter0">8.7. 
 Changes since the 14 February 2012 “Last Call” Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sel-first-line">
-   <a href="https://drafts.csswg.org/selectors-3/#sel-first-line">https://drafts.csswg.org/selectors-3/#sel-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sel-first-line" class="dfn-panel" data-for="term-for-sel-first-line" id="infopanel-for-term-for-sel-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-sel-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#sel-first-line">https://drafts.csswg.org/selectors-3/#sel-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sel-first-line">2.11.3. 
 The ::first-line Pseudo-element‘s Background</a> <a href="#ref-for-sel-first-line①">(2)</a>
@@ -4349,8 +4349,8 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     plus a computed color and optionally also a inset keyword
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-background-color">
-   <b><a href="#propdef-background-color">#propdef-background-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-color" class="dfn-panel" data-for="propdef-background-color" id="infopanel-for-propdef-background-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-color" style="display:none">Info about the 'background-color' definition.</span><b><a href="#propdef-background-color">#propdef-background-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">2. 
 Backgrounds</a> <a href="#ref-for-propdef-background-color①">(2)</a>
@@ -4365,8 +4365,8 @@ The Canvas Background and the HTML &lt;body> Element</a>
 Changes since the 9 September 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-image">
-   <b><a href="#propdef-background-image">#propdef-background-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-image" class="dfn-panel" data-for="propdef-background-image" id="infopanel-for-propdef-background-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-image" style="display:none">Info about the 'background-image' definition.</span><b><a href="#propdef-background-image">#propdef-background-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">2. 
 Backgrounds</a>
@@ -4382,15 +4382,15 @@ The Canvas Background and the HTML &lt;body> Element</a>
 Changes since the 14 February 2012 “Last Call” Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bg-image">
-   <b><a href="#typedef-bg-image">#typedef-bg-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bg-image" class="dfn-panel" data-for="typedef-bg-image" id="infopanel-for-typedef-bg-image" role="dialog">
+   <span id="infopaneltitle-for-typedef-bg-image" style="display:none">Info about the '&lt;bg-image>' definition.</span><b><a href="#typedef-bg-image">#typedef-bg-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-image">2.3. Image Sources: the background-image property</a> <a href="#ref-for-typedef-bg-image①">(2)</a>
     <li><a href="#ref-for-typedef-bg-image②">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-bg-image③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-image-none">
-   <b><a href="#valdef-background-image-none">#valdef-background-image-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-image-none" class="dfn-panel" data-for="valdef-background-image-none" id="infopanel-for-valdef-background-image-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-image-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-background-image-none">#valdef-background-image-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-image-none">2.1. 
 Layering Multiple Background Images</a>
@@ -4398,8 +4398,8 @@ Layering Multiple Background Images</a>
 The Canvas Background and the HTML &lt;body> Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-repeat">
-   <b><a href="#propdef-background-repeat">#propdef-background-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-repeat" class="dfn-panel" data-for="propdef-background-repeat" id="infopanel-for-propdef-background-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' definition.</span><b><a href="#propdef-background-repeat">#propdef-background-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">2.1. 
 Layering Multiple Background Images</a>
@@ -4414,44 +4414,44 @@ Drawing the Border Image</a>
 Changes since the 14 February 2012 “Last Call” Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-repeat-style">
-   <b><a href="#typedef-repeat-style">#typedef-repeat-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-repeat-style" class="dfn-panel" data-for="typedef-repeat-style" id="infopanel-for-typedef-repeat-style" role="dialog">
+   <span id="infopaneltitle-for-typedef-repeat-style" style="display:none">Info about the '&lt;repeat-style>' definition.</span><b><a href="#typedef-repeat-style">#typedef-repeat-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-repeat-style">2.4. Tiling Images: the background-repeat property</a> <a href="#ref-for-typedef-repeat-style①">(2)</a> <a href="#ref-for-typedef-repeat-style②">(3)</a> <a href="#ref-for-typedef-repeat-style③">(4)</a>
     <li><a href="#ref-for-typedef-repeat-style④">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-repeat-style⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-repeat-x">
-   <b><a href="#valdef-background-repeat-repeat-x">#valdef-background-repeat-repeat-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-repeat-x" class="dfn-panel" data-for="valdef-background-repeat-repeat-x" id="infopanel-for-valdef-background-repeat-repeat-x" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-repeat-x" style="display:none">Info about the 'repeat-x' definition.</span><b><a href="#valdef-background-repeat-repeat-x">#valdef-background-repeat-repeat-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-repeat-x">7.2.1. Level 1</a>
     <li><a href="#ref-for-valdef-background-repeat-repeat-x①">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-repeat-y">
-   <b><a href="#valdef-background-repeat-repeat-y">#valdef-background-repeat-repeat-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-repeat-y" class="dfn-panel" data-for="valdef-background-repeat-repeat-y" id="infopanel-for-valdef-background-repeat-repeat-y" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-repeat-y" style="display:none">Info about the 'repeat-y' definition.</span><b><a href="#valdef-background-repeat-repeat-y">#valdef-background-repeat-repeat-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-repeat-y">2.4. Tiling Images: the background-repeat property</a>
     <li><a href="#ref-for-valdef-background-repeat-repeat-y①">7.2.1. Level 1</a>
     <li><a href="#ref-for-valdef-background-repeat-repeat-y②">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-repeat">
-   <b><a href="#valdef-background-repeat-repeat">#valdef-background-repeat-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-repeat" class="dfn-panel" data-for="valdef-background-repeat-repeat" id="infopanel-for-valdef-background-repeat-repeat" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-repeat" style="display:none">Info about the 'repeat' definition.</span><b><a href="#valdef-background-repeat-repeat">#valdef-background-repeat-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-repeat">2.4. Tiling Images: the background-repeat property</a>
     <li><a href="#ref-for-valdef-background-repeat-repeat①">7.2.1. Level 1</a>
     <li><a href="#ref-for-valdef-background-repeat-repeat②">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-space">
-   <b><a href="#valdef-background-repeat-space">#valdef-background-repeat-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-space" class="dfn-panel" data-for="valdef-background-repeat-space" id="infopanel-for-valdef-background-repeat-space" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-space" style="display:none">Info about the 'space' definition.</span><b><a href="#valdef-background-repeat-space">#valdef-background-repeat-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-space">2.4. Tiling Images: the background-repeat property</a> <a href="#ref-for-valdef-background-repeat-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-round">
-   <b><a href="#valdef-background-repeat-round">#valdef-background-repeat-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-round" class="dfn-panel" data-for="valdef-background-repeat-round" id="infopanel-for-valdef-background-repeat-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-background-repeat-round">#valdef-background-repeat-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-round">2.4. Tiling Images: the background-repeat property</a>
     <li><a href="#ref-for-valdef-background-repeat-round①">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-valdef-background-repeat-round②">(2)</a>
@@ -4459,16 +4459,16 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
 Drawing the Border Image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-repeat-no-repeat">
-   <b><a href="#valdef-background-repeat-no-repeat">#valdef-background-repeat-no-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-repeat-no-repeat" class="dfn-panel" data-for="valdef-background-repeat-no-repeat" id="infopanel-for-valdef-background-repeat-no-repeat" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-repeat-no-repeat" style="display:none">Info about the 'no-repeat' definition.</span><b><a href="#valdef-background-repeat-no-repeat">#valdef-background-repeat-no-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-no-repeat">2.4. Tiling Images: the background-repeat property</a> <a href="#ref-for-valdef-background-repeat-no-repeat①">(2)</a>
     <li><a href="#ref-for-valdef-background-repeat-no-repeat②">7.2.1. Level 1</a>
     <li><a href="#ref-for-valdef-background-repeat-no-repeat③">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-attachment">
-   <b><a href="#propdef-background-attachment">#propdef-background-attachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-attachment" class="dfn-panel" data-for="propdef-background-attachment" id="infopanel-for-propdef-background-attachment" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' definition.</span><b><a href="#propdef-background-attachment">#propdef-background-attachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">2.5. Affixing Images: the background-attachment property</a> <a href="#ref-for-propdef-background-attachment①">(2)</a>
     <li><a href="#ref-for-propdef-background-attachment②">2.8. Positioning Area: the background-origin property</a>
@@ -4479,15 +4479,15 @@ Drawing the Border Image</a>
 Changes since the 24 July 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attachment">
-   <b><a href="#typedef-attachment">#typedef-attachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attachment" class="dfn-panel" data-for="typedef-attachment" id="infopanel-for-typedef-attachment" role="dialog">
+   <span id="infopaneltitle-for-typedef-attachment" style="display:none">Info about the '&lt;attachment>' definition.</span><b><a href="#typedef-attachment">#typedef-attachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attachment">2.5. Affixing Images: the background-attachment property</a> <a href="#ref-for-typedef-attachment①">(2)</a>
     <li><a href="#ref-for-typedef-attachment②">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-attachment③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-attachment-fixed">
-   <b><a href="#valdef-background-attachment-fixed">#valdef-background-attachment-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-attachment-fixed" class="dfn-panel" data-for="valdef-background-attachment-fixed" id="infopanel-for-valdef-background-attachment-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-attachment-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-background-attachment-fixed">#valdef-background-attachment-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-fixed">2.5. Affixing Images: the background-attachment property</a> <a href="#ref-for-valdef-background-attachment-fixed①">(2)</a> <a href="#ref-for-valdef-background-attachment-fixed②">(3)</a> <a href="#ref-for-valdef-background-attachment-fixed③">(4)</a> <a href="#ref-for-valdef-background-attachment-fixed④">(5)</a>
     <li><a href="#ref-for-valdef-background-attachment-fixed⑤">2.8. Positioning Area: the background-origin property</a>
@@ -4495,22 +4495,22 @@ Changes since the 24 July 2012 Candidate Recommendation</a>
     <li><a href="#ref-for-valdef-background-attachment-fixed⑦">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-attachment-local">
-   <b><a href="#valdef-background-attachment-local">#valdef-background-attachment-local</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-attachment-local" class="dfn-panel" data-for="valdef-background-attachment-local" id="infopanel-for-valdef-background-attachment-local" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-attachment-local" style="display:none">Info about the 'local' definition.</span><b><a href="#valdef-background-attachment-local">#valdef-background-attachment-local</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-local">2.5. Affixing Images: the background-attachment property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-attachment-scroll">
-   <b><a href="#valdef-background-attachment-scroll">#valdef-background-attachment-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-attachment-scroll" class="dfn-panel" data-for="valdef-background-attachment-scroll" id="infopanel-for-valdef-background-attachment-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-attachment-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-background-attachment-scroll">#valdef-background-attachment-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-scroll">2.5. Affixing Images: the background-attachment property</a>
     <li><a href="#ref-for-valdef-background-attachment-scroll①">7.2.1. Level 1</a>
     <li><a href="#ref-for-valdef-background-attachment-scroll②">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position">
-   <b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position" class="dfn-panel" data-for="propdef-background-position" id="infopanel-for-propdef-background-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position" style="display:none">Info about the 'background-position' definition.</span><b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">2.4. Tiling Images: the background-repeat property</a> <a href="#ref-for-propdef-background-position①">(2)</a>
     <li><a href="#ref-for-propdef-background-position②">2.6. Positioning Images: the background-position property</a> <a href="#ref-for-propdef-background-position③">(2)</a> <a href="#ref-for-propdef-background-position④">(3)</a> <a href="#ref-for-propdef-background-position⑤">(4)</a> <a href="#ref-for-propdef-background-position⑥">(5)</a>
@@ -4526,8 +4526,8 @@ Changes since the 17 April 2012 Candidate Recommendation</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bg-position">
-   <b><a href="#typedef-bg-position">#typedef-bg-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bg-position" class="dfn-panel" data-for="typedef-bg-position" id="infopanel-for-typedef-bg-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-bg-position" style="display:none">Info about the '&lt;bg-position>' definition.</span><b><a href="#typedef-bg-position">#typedef-bg-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-position">2.6. Positioning Images: the background-position property</a> <a href="#ref-for-typedef-bg-position①">(2)</a>
     <li><a href="#ref-for-typedef-bg-position②">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-bg-position③">(2)</a>
@@ -4535,38 +4535,38 @@ Changes Since the 15 February 2011 Candidate Recommendation</a>
 Changes since the 9 September 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-top">
-   <b><a href="#valdef-background-position-top">#valdef-background-position-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-top" class="dfn-panel" data-for="valdef-background-position-top" id="infopanel-for-valdef-background-position-top" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-top" style="display:none">Info about the 'top' definition.</span><b><a href="#valdef-background-position-top">#valdef-background-position-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-top">2.6. Positioning Images: the background-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-right">
-   <b><a href="#valdef-background-position-right">#valdef-background-position-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-right" class="dfn-panel" data-for="valdef-background-position-right" id="infopanel-for-valdef-background-position-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-background-position-right">#valdef-background-position-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-right">2.6. Positioning Images: the background-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-bottom">
-   <b><a href="#valdef-background-position-bottom">#valdef-background-position-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-bottom" class="dfn-panel" data-for="valdef-background-position-bottom" id="infopanel-for-valdef-background-position-bottom" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-bottom" style="display:none">Info about the 'bottom' definition.</span><b><a href="#valdef-background-position-bottom">#valdef-background-position-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-bottom">2.6. Positioning Images: the background-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-left">
-   <b><a href="#valdef-background-position-left">#valdef-background-position-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-left" class="dfn-panel" data-for="valdef-background-position-left" id="infopanel-for-valdef-background-position-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-background-position-left">#valdef-background-position-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-left">2.6. Positioning Images: the background-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-center">
-   <b><a href="#valdef-background-position-center">#valdef-background-position-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-center" class="dfn-panel" data-for="valdef-background-position-center" id="infopanel-for-valdef-background-position-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-background-position-center">#valdef-background-position-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-center">2.6. Positioning Images: the background-position property</a> <a href="#ref-for-valdef-background-position-center①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-clip">
-   <b><a href="#propdef-background-clip">#propdef-background-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-clip" class="dfn-panel" data-for="propdef-background-clip" id="infopanel-for-propdef-background-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-clip" style="display:none">Info about the 'background-clip' definition.</span><b><a href="#propdef-background-clip">#propdef-background-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">2.2. Base Color: the background-color property</a>
     <li><a href="#ref-for-propdef-background-clip①">2.5. Affixing Images: the background-attachment property</a>
@@ -4580,43 +4580,43 @@ Changes since the 24 July 2012 Candidate Recommendation</a>
 Changes Since the 17 December 2009 Candidate Recommendation</a> <a href="#ref-for-propdef-background-clip①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-painting-area">
-   <b><a href="#background-painting-area">#background-painting-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-painting-area" class="dfn-panel" data-for="background-painting-area" id="infopanel-for-background-painting-area" role="dialog">
+   <span id="infopaneltitle-for-background-painting-area" style="display:none">Info about the 'background painting area' definition.</span><b><a href="#background-painting-area">#background-painting-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-painting-area">2.5. Affixing Images: the background-attachment property</a>
     <li><a href="#ref-for-background-painting-area①">2.7. Painting Area: the background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-box">
-   <b><a href="#typedef-box">#typedef-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-box" class="dfn-panel" data-for="typedef-box" id="infopanel-for-typedef-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-box" style="display:none">Info about the '&lt;box>' definition.</span><b><a href="#typedef-box">#typedef-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-box">2.7. Painting Area: the background-clip property</a> <a href="#ref-for-typedef-box①">(2)</a>
     <li><a href="#ref-for-typedef-box②">2.8. Positioning Area: the background-origin property</a>
     <li><a href="#ref-for-typedef-box③">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-box④">(2)</a> <a href="#ref-for-typedef-box⑤">(3)</a> <a href="#ref-for-typedef-box⑥">(4)</a> <a href="#ref-for-typedef-box⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-clip-border-box">
-   <b><a href="#valdef-background-clip-border-box">#valdef-background-clip-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-clip-border-box" class="dfn-panel" data-for="valdef-background-clip-border-box" id="infopanel-for-valdef-background-clip-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-clip-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-background-clip-border-box">#valdef-background-clip-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-border-box">2.5. Affixing Images: the background-attachment property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-clip-padding-box">
-   <b><a href="#valdef-background-clip-padding-box">#valdef-background-clip-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-clip-padding-box" class="dfn-panel" data-for="valdef-background-clip-padding-box" id="infopanel-for-valdef-background-clip-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-clip-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-background-clip-padding-box">#valdef-background-clip-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-padding-box">2.5. Affixing Images: the background-attachment property</a>
     <li><a href="#ref-for-valdef-background-clip-padding-box①">2.8. Positioning Area: the background-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-clip-content-box">
-   <b><a href="#valdef-background-clip-content-box">#valdef-background-clip-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-clip-content-box" class="dfn-panel" data-for="valdef-background-clip-content-box" id="infopanel-for-valdef-background-clip-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-clip-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-background-clip-content-box">#valdef-background-clip-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-content-box">8.9. 
 Changes Since the 17 December 2009 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-origin">
-   <b><a href="#propdef-background-origin">#propdef-background-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-origin" class="dfn-panel" data-for="propdef-background-origin" id="infopanel-for-propdef-background-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-origin" style="display:none">Info about the 'background-origin' definition.</span><b><a href="#propdef-background-origin">#propdef-background-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">2.1. 
 Layering Multiple Background Images</a>
@@ -4628,22 +4628,22 @@ Changes since the 24 July 2012 Candidate Recommendation</a>
 Changes Since the 17 December 2009 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="background-positioning-area">
-   <b><a href="#background-positioning-area">#background-positioning-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-background-positioning-area" class="dfn-panel" data-for="background-positioning-area" id="infopanel-for-background-positioning-area" role="dialog">
+   <span id="infopaneltitle-for-background-positioning-area" style="display:none">Info about the 'background positioning area' definition.</span><b><a href="#background-positioning-area">#background-positioning-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-positioning-area">2.5. Affixing Images: the background-attachment property</a>
     <li><a href="#ref-for-background-positioning-area">2.11.1. 
 The Canvas Background and the Root Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-origin-border-box">
-   <b><a href="#valdef-background-origin-border-box">#valdef-background-origin-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-origin-border-box" class="dfn-panel" data-for="valdef-background-origin-border-box" id="infopanel-for-valdef-background-origin-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-origin-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-background-origin-border-box">#valdef-background-origin-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-origin-border-box">2.8. Positioning Area: the background-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-size">
-   <b><a href="#propdef-background-size">#propdef-background-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-size" class="dfn-panel" data-for="propdef-background-size" id="infopanel-for-propdef-background-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-size" style="display:none">Info about the 'background-size' definition.</span><b><a href="#propdef-background-size">#propdef-background-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">2.4. Tiling Images: the background-repeat property</a>
     <li><a href="#ref-for-propdef-background-size①">2.6. Positioning Images: the background-position property</a>
@@ -4653,29 +4653,29 @@ The Canvas Background and the Root Element</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bg-size">
-   <b><a href="#typedef-bg-size">#typedef-bg-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bg-size" class="dfn-panel" data-for="typedef-bg-size" id="infopanel-for-typedef-bg-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-bg-size" style="display:none">Info about the '&lt;bg-size>' definition.</span><b><a href="#typedef-bg-size">#typedef-bg-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-size">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-typedef-bg-size①">(2)</a>
     <li><a href="#ref-for-typedef-bg-size②">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-bg-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-size-contain">
-   <b><a href="#valdef-background-size-contain">#valdef-background-size-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-size-contain" class="dfn-panel" data-for="valdef-background-size-contain" id="infopanel-for-valdef-background-size-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-size-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-background-size-contain">#valdef-background-size-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-size-contain">2.9. Sizing Images: the background-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-size-auto">
-   <b><a href="#valdef-background-size-auto">#valdef-background-size-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-size-auto" class="dfn-panel" data-for="valdef-background-size-auto" id="infopanel-for-valdef-background-size-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-size-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-background-size-auto">#valdef-background-size-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-size-auto">2.9. Sizing Images: the background-size property</a> <a href="#ref-for-valdef-background-size-auto①">(2)</a> <a href="#ref-for-valdef-background-size-auto②">(3)</a> <a href="#ref-for-valdef-background-size-auto③">(4)</a> <a href="#ref-for-valdef-background-size-auto④">(5)</a>
     <li><a href="#ref-for-valdef-background-size-auto⑤">8.8. 
 Changes Since the 15 February 2011 Candidate Recommendation</a> <a href="#ref-for-valdef-background-size-auto⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background">
-   <b><a href="#propdef-background">#propdef-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background" class="dfn-panel" data-for="propdef-background" id="infopanel-for-propdef-background" role="dialog">
+   <span id="infopaneltitle-for-propdef-background" style="display:none">Info about the 'background' definition.</span><b><a href="#propdef-background">#propdef-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2.6. Positioning Images: the background-position property</a>
     <li><a href="#ref-for-propdef-background①">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-propdef-background②">(2)</a>
@@ -4689,60 +4689,60 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
 Changes Since the 17 December 2009 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bg-layer">
-   <b><a href="#typedef-bg-layer">#typedef-bg-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bg-layer" class="dfn-panel" data-for="typedef-bg-layer" id="infopanel-for-typedef-bg-layer" role="dialog">
+   <span id="infopaneltitle-for-typedef-bg-layer" style="display:none">Info about the '&lt;bg-layer>' definition.</span><b><a href="#typedef-bg-layer">#typedef-bg-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-layer">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-bg-layer①">(2)</a> <a href="#ref-for-typedef-bg-layer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-final-bg-layer">
-   <b><a href="#typedef-final-bg-layer">#typedef-final-bg-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-final-bg-layer" class="dfn-panel" data-for="typedef-final-bg-layer" id="infopanel-for-typedef-final-bg-layer" role="dialog">
+   <span id="infopaneltitle-for-typedef-final-bg-layer" style="display:none">Info about the '&lt;final-bg-layer>' definition.</span><b><a href="#typedef-final-bg-layer">#typedef-final-bg-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-final-bg-layer">2.10. Backgrounds Shorthand: the background property</a> <a href="#ref-for-typedef-final-bg-layer①">(2)</a> <a href="#ref-for-typedef-final-bg-layer②">(3)</a>
     <li><a href="#ref-for-typedef-final-bg-layer③">8.3. 
 Changes since the 9 September 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canvas-surface">
-   <b><a href="#canvas-surface">#canvas-surface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canvas-surface" class="dfn-panel" data-for="canvas-surface" id="infopanel-for-canvas-surface" role="dialog">
+   <span id="infopaneltitle-for-canvas-surface" style="display:none">Info about the 'canvas surface' definition.</span><b><a href="#canvas-surface">#canvas-surface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas-surface">2.11. 
 Backgrounds of Special Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canvas-background">
-   <b><a href="#canvas-background">#canvas-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canvas-background" class="dfn-panel" data-for="canvas-background" id="infopanel-for-canvas-background" role="dialog">
+   <span id="infopaneltitle-for-canvas-background" style="display:none">Info about the 'canvas background' definition.</span><b><a href="#canvas-background">#canvas-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas-background">2.11. 
 Backgrounds of Special Elements</a> <a href="#ref-for-canvas-background①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-color">
-   <b><a href="#propdef-border-top-color">#propdef-border-top-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-color" class="dfn-panel" data-for="propdef-border-top-color" id="infopanel-for-propdef-border-top-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' definition.</span><b><a href="#propdef-border-top-color">#propdef-border-top-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">3.1. Line Colors: the border-color properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-color">
-   <b><a href="#propdef-border-right-color">#propdef-border-right-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-color" class="dfn-panel" data-for="propdef-border-right-color" id="infopanel-for-propdef-border-right-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' definition.</span><b><a href="#propdef-border-right-color">#propdef-border-right-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">3.1. Line Colors: the border-color properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-color">
-   <b><a href="#propdef-border-bottom-color">#propdef-border-bottom-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-color" class="dfn-panel" data-for="propdef-border-bottom-color" id="infopanel-for-propdef-border-bottom-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' definition.</span><b><a href="#propdef-border-bottom-color">#propdef-border-bottom-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">3.1. Line Colors: the border-color properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-color">
-   <b><a href="#propdef-border-left-color">#propdef-border-left-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-color" class="dfn-panel" data-for="propdef-border-left-color" id="infopanel-for-propdef-border-left-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' definition.</span><b><a href="#propdef-border-left-color">#propdef-border-left-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">3.1. Line Colors: the border-color properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-color">
-   <b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-color" class="dfn-panel" data-for="propdef-border-color" id="infopanel-for-propdef-border-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-color" style="display:none">Info about the 'border-color' definition.</span><b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">3. 
 Borders</a>
@@ -4752,32 +4752,32 @@ Borders</a>
     <li><a href="#ref-for-propdef-border-color⑤">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-style">
-   <b><a href="#propdef-border-top-style">#propdef-border-top-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-style" class="dfn-panel" data-for="propdef-border-top-style" id="infopanel-for-propdef-border-top-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-style" style="display:none">Info about the 'border-top-style' definition.</span><b><a href="#propdef-border-top-style">#propdef-border-top-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-style">3.2. Line Patterns: the border-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-style">
-   <b><a href="#propdef-border-right-style">#propdef-border-right-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-style" class="dfn-panel" data-for="propdef-border-right-style" id="infopanel-for-propdef-border-right-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-style" style="display:none">Info about the 'border-right-style' definition.</span><b><a href="#propdef-border-right-style">#propdef-border-right-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-style">3.2. Line Patterns: the border-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-style">
-   <b><a href="#propdef-border-bottom-style">#propdef-border-bottom-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-style" class="dfn-panel" data-for="propdef-border-bottom-style" id="infopanel-for-propdef-border-bottom-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-style" style="display:none">Info about the 'border-bottom-style' definition.</span><b><a href="#propdef-border-bottom-style">#propdef-border-bottom-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-style">3.2. Line Patterns: the border-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-style">
-   <b><a href="#propdef-border-left-style">#propdef-border-left-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-style" class="dfn-panel" data-for="propdef-border-left-style" id="infopanel-for-propdef-border-left-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-style" style="display:none">Info about the 'border-left-style' definition.</span><b><a href="#propdef-border-left-style">#propdef-border-left-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-style">3.2. Line Patterns: the border-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-style">
-   <b><a href="#propdef-border-style">#propdef-border-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-style" class="dfn-panel" data-for="propdef-border-style" id="infopanel-for-propdef-border-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-style" style="display:none">Info about the 'border-style' definition.</span><b><a href="#propdef-border-style">#propdef-border-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">3. 
 Borders</a>
@@ -4790,15 +4790,15 @@ Borders</a>
 Changes since the 24 July 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-line-style">
-   <b><a href="#typedef-line-style">#typedef-line-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-line-style" class="dfn-panel" data-for="typedef-line-style" id="infopanel-for-typedef-line-style" role="dialog">
+   <span id="infopaneltitle-for-typedef-line-style" style="display:none">Info about the '&lt;line-style>' definition.</span><b><a href="#typedef-line-style">#typedef-line-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-style">3.2. Line Patterns: the border-style properties</a> <a href="#ref-for-typedef-line-style①">(2)</a> <a href="#ref-for-typedef-line-style②">(3)</a>
     <li><a href="#ref-for-typedef-line-style③">3.4. Border Shorthand Properties</a> <a href="#ref-for-typedef-line-style④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-none">
-   <b><a href="#valdef-line-style-none">#valdef-line-style-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-none" class="dfn-panel" data-for="valdef-line-style-none" id="infopanel-for-valdef-line-style-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-line-style-none">#valdef-line-style-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-none">3.2. Line Patterns: the border-style properties</a>
     <li><a href="#ref-for-valdef-line-style-none①">3.3. Line Thickness: the border-width properties</a> <a href="#ref-for-valdef-line-style-none②">(2)</a>
@@ -4806,75 +4806,75 @@ Changes since the 24 July 2012 Candidate Recommendation</a>
 Changes since the 24 July 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-hidden">
-   <b><a href="#valdef-line-style-hidden">#valdef-line-style-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-hidden" class="dfn-panel" data-for="valdef-line-style-hidden" id="infopanel-for-valdef-line-style-hidden" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#valdef-line-style-hidden">#valdef-line-style-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-hidden">3.3. Line Thickness: the border-width properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-dotted">
-   <b><a href="#valdef-line-style-dotted">#valdef-line-style-dotted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-dotted" class="dfn-panel" data-for="valdef-line-style-dotted" id="infopanel-for-valdef-line-style-dotted" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-dotted" style="display:none">Info about the 'dotted' definition.</span><b><a href="#valdef-line-style-dotted">#valdef-line-style-dotted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-dotted">4.2. Corner Shaping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-solid">
-   <b><a href="#valdef-line-style-solid">#valdef-line-style-solid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-solid" class="dfn-panel" data-for="valdef-line-style-solid" id="infopanel-for-valdef-line-style-solid" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-solid" style="display:none">Info about the 'solid' definition.</span><b><a href="#valdef-line-style-solid">#valdef-line-style-solid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-solid">4.2. Corner Shaping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-groove">
-   <b><a href="#valdef-line-style-groove">#valdef-line-style-groove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-groove" class="dfn-panel" data-for="valdef-line-style-groove" id="infopanel-for-valdef-line-style-groove" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-groove" style="display:none">Info about the 'groove' definition.</span><b><a href="#valdef-line-style-groove">#valdef-line-style-groove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-groove">3.2. Line Patterns: the border-style properties</a> <a href="#ref-for-valdef-line-style-groove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-ridge">
-   <b><a href="#valdef-line-style-ridge">#valdef-line-style-ridge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-ridge" class="dfn-panel" data-for="valdef-line-style-ridge" id="infopanel-for-valdef-line-style-ridge" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-ridge" style="display:none">Info about the 'ridge' definition.</span><b><a href="#valdef-line-style-ridge">#valdef-line-style-ridge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-ridge">3.2. Line Patterns: the border-style properties</a> <a href="#ref-for-valdef-line-style-ridge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-inset">
-   <b><a href="#valdef-line-style-inset">#valdef-line-style-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-inset" class="dfn-panel" data-for="valdef-line-style-inset" id="infopanel-for-valdef-line-style-inset" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#valdef-line-style-inset">#valdef-line-style-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-inset">3.2. Line Patterns: the border-style properties</a>
     <li><a href="#ref-for-valdef-line-style-inset①">4.2. Corner Shaping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-style-outset">
-   <b><a href="#valdef-line-style-outset">#valdef-line-style-outset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-style-outset" class="dfn-panel" data-for="valdef-line-style-outset" id="infopanel-for-valdef-line-style-outset" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-style-outset" style="display:none">Info about the 'outset' definition.</span><b><a href="#valdef-line-style-outset">#valdef-line-style-outset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-outset">3.2. Line Patterns: the border-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-width">
-   <b><a href="#propdef-border-top-width">#propdef-border-top-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-width" class="dfn-panel" data-for="propdef-border-top-width" id="infopanel-for-propdef-border-top-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' definition.</span><b><a href="#propdef-border-top-width">#propdef-border-top-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">3.3. Line Thickness: the border-width properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-width">
-   <b><a href="#propdef-border-right-width">#propdef-border-right-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-width" class="dfn-panel" data-for="propdef-border-right-width" id="infopanel-for-propdef-border-right-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' definition.</span><b><a href="#propdef-border-right-width">#propdef-border-right-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">3.3. Line Thickness: the border-width properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-width">
-   <b><a href="#propdef-border-bottom-width">#propdef-border-bottom-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-width" class="dfn-panel" data-for="propdef-border-bottom-width" id="infopanel-for-propdef-border-bottom-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' definition.</span><b><a href="#propdef-border-bottom-width">#propdef-border-bottom-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">3.3. Line Thickness: the border-width properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-width">
-   <b><a href="#propdef-border-left-width">#propdef-border-left-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-width" class="dfn-panel" data-for="propdef-border-left-width" id="infopanel-for-propdef-border-left-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' definition.</span><b><a href="#propdef-border-left-width">#propdef-border-left-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">3.3. Line Thickness: the border-width properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-width">
-   <b><a href="#propdef-border-width">#propdef-border-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-width" class="dfn-panel" data-for="propdef-border-width" id="infopanel-for-propdef-border-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-width" style="display:none">Info about the 'border-width' definition.</span><b><a href="#propdef-border-width">#propdef-border-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">3. 
 Borders</a>
@@ -4891,50 +4891,50 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-line-width">
-   <b><a href="#typedef-line-width">#typedef-line-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-line-width" class="dfn-panel" data-for="typedef-line-width" id="infopanel-for-typedef-line-width" role="dialog">
+   <span id="infopaneltitle-for-typedef-line-width" style="display:none">Info about the '&lt;line-width>' definition.</span><b><a href="#typedef-line-width">#typedef-line-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-width">3.3. Line Thickness: the border-width properties</a> <a href="#ref-for-typedef-line-width①">(2)</a> <a href="#ref-for-typedef-line-width②">(3)</a>
     <li><a href="#ref-for-typedef-line-width③">3.4. Border Shorthand Properties</a> <a href="#ref-for-typedef-line-width④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-width-medium">
-   <b><a href="#valdef-line-width-medium">#valdef-line-width-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-width-medium" class="dfn-panel" data-for="valdef-line-width-medium" id="infopanel-for-valdef-line-width-medium" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-width-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#valdef-line-width-medium">#valdef-line-width-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-width-medium">3.3. Line Thickness: the border-width properties</a> <a href="#ref-for-valdef-line-width-medium①">(2)</a> <a href="#ref-for-valdef-line-width-medium②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top">
-   <b><a href="#propdef-border-top">#propdef-border-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top" class="dfn-panel" data-for="propdef-border-top" id="infopanel-for-propdef-border-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top" style="display:none">Info about the 'border-top' definition.</span><b><a href="#propdef-border-top">#propdef-border-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">7.2.1. Level 1</a>
     <li><a href="#ref-for-propdef-border-top①">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right">
-   <b><a href="#propdef-border-right">#propdef-border-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right" class="dfn-panel" data-for="propdef-border-right" id="infopanel-for-propdef-border-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right" style="display:none">Info about the 'border-right' definition.</span><b><a href="#propdef-border-right">#propdef-border-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">7.2.1. Level 1</a>
     <li><a href="#ref-for-propdef-border-right①">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom">
-   <b><a href="#propdef-border-bottom">#propdef-border-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom" class="dfn-panel" data-for="propdef-border-bottom" id="infopanel-for-propdef-border-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom" style="display:none">Info about the 'border-bottom' definition.</span><b><a href="#propdef-border-bottom">#propdef-border-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom">7.2.1. Level 1</a>
     <li><a href="#ref-for-propdef-border-bottom①">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left">
-   <b><a href="#propdef-border-left">#propdef-border-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left" class="dfn-panel" data-for="propdef-border-left" id="infopanel-for-propdef-border-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left" style="display:none">Info about the 'border-left' definition.</span><b><a href="#propdef-border-left">#propdef-border-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left">3.4. Border Shorthand Properties</a> <a href="#ref-for-propdef-border-left①">(2)</a> <a href="#ref-for-propdef-border-left②">(3)</a>
     <li><a href="#ref-for-propdef-border-left③">7.2.1. Level 1</a>
     <li><a href="#ref-for-propdef-border-left④">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border">
-   <b><a href="#propdef-border">#propdef-border</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border" class="dfn-panel" data-for="propdef-border" id="infopanel-for-propdef-border" role="dialog">
+   <span id="infopaneltitle-for-propdef-border" style="display:none">Info about the 'border' definition.</span><b><a href="#propdef-border">#propdef-border</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border①">3.4. Border Shorthand Properties</a> <a href="#ref-for-propdef-border②">(2)</a> <a href="#ref-for-propdef-border③">(3)</a> <a href="#ref-for-propdef-border④">(4)</a> <a href="#ref-for-propdef-border⑤">(5)</a> <a href="#ref-for-propdef-border⑥">(6)</a> <a href="#ref-for-propdef-border⑦">(7)</a>
     <li><a href="#ref-for-propdef-border⑧">5. Border Images</a>
@@ -4942,14 +4942,14 @@ Changes Since the 15 February 2011 Candidate Recommendation</a>
     <li><a href="#ref-for-propdef-border①⓪">7.2.2. Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-left-radius">
-   <b><a href="#propdef-border-top-left-radius">#propdef-border-top-left-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-left-radius" class="dfn-panel" data-for="propdef-border-top-left-radius" id="infopanel-for-propdef-border-top-left-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-left-radius" style="display:none">Info about the 'border-top-left-radius' definition.</span><b><a href="#propdef-border-top-left-radius">#propdef-border-top-left-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-left-radius">4.1. Curve Radii: the border-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-radius">
-   <b><a href="#propdef-border-radius">#propdef-border-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-radius" class="dfn-panel" data-for="propdef-border-radius" id="infopanel-for-propdef-border-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-radius" style="display:none">Info about the 'border-radius' definition.</span><b><a href="#propdef-border-radius">#propdef-border-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">2.7. Painting Area: the background-clip property</a>
     <li><a href="#ref-for-propdef-border-radius①">4.1. Curve Radii: the border-radius properties</a> <a href="#ref-for-propdef-border-radius②">(2)</a>
@@ -4968,8 +4968,8 @@ Changes Since the 17 December 2009 Candidate Recommendation</a>
     <li><a href="#ref-for-propdef-border-radius①③">9. Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-radii">
-   <b><a href="#border-radii">#border-radii</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-radii" class="dfn-panel" data-for="border-radii" id="infopanel-for-border-radii" role="dialog">
+   <span id="infopaneltitle-for-border-radii" style="display:none">Info about the 'radii' definition.</span><b><a href="#border-radii">#border-radii</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-radii">4.2. Corner Shaping</a>
     <li><a href="#ref-for-border-radii①">6.1.1. 
@@ -4978,8 +4978,8 @@ Shadow Shape, Spread, and Knockout</a>
 Changes since the 17 October 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image-source">
-   <b><a href="#propdef-border-image-source">#propdef-border-image-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image-source" class="dfn-panel" data-for="propdef-border-image-source" id="infopanel-for-propdef-border-image-source" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image-source" style="display:none">Info about the 'border-image-source' definition.</span><b><a href="#propdef-border-image-source">#propdef-border-image-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-source">5. Border Images</a> <a href="#ref-for-propdef-border-image-source①">(2)</a>
     <li><a href="#ref-for-propdef-border-image-source②">5.1. Image Source: the border-image-source property</a>
@@ -4988,8 +4988,8 @@ Drawing the Border Image</a> <a href="#ref-for-propdef-border-image-source④">(
     <li><a href="#ref-for-propdef-border-image-source⑤">5.7. Border Image Shorthand: the border-image property</a> <a href="#ref-for-propdef-border-image-source⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image-slice">
-   <b><a href="#propdef-border-image-slice">#propdef-border-image-slice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image-slice" class="dfn-panel" data-for="propdef-border-image-slice" id="infopanel-for-propdef-border-image-slice" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image-slice" style="display:none">Info about the 'border-image-slice' definition.</span><b><a href="#propdef-border-image-slice">#propdef-border-image-slice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-slice">5. Border Images</a>
     <li><a href="#ref-for-propdef-border-image-slice①">5.1. Image Source: the border-image-source property</a>
@@ -5000,8 +5000,8 @@ Drawing the Border Image</a>
     <li><a href="#ref-for-propdef-border-image-slice⑥">5.7. Border Image Shorthand: the border-image property</a> <a href="#ref-for-propdef-border-image-slice⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-image-slice-fill">
-   <b><a href="#border-image-slice-fill">#border-image-slice-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-image-slice-fill" class="dfn-panel" data-for="border-image-slice-fill" id="infopanel-for-border-image-slice-fill" role="dialog">
+   <span id="infopaneltitle-for-border-image-slice-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#border-image-slice-fill">#border-image-slice-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-image-slice-fill">5.1. Image Source: the border-image-source property</a>
     <li><a href="#ref-for-border-image-slice-fill①">5.2. Image Slicing: the border-image-slice property</a> <a href="#ref-for-border-image-slice-fill②">(2)</a> <a href="#ref-for-border-image-slice-fill③">(3)</a>
@@ -5009,8 +5009,8 @@ Drawing the Border Image</a>
 Drawing the Border Image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image-width">
-   <b><a href="#propdef-border-image-width">#propdef-border-image-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image-width" class="dfn-panel" data-for="propdef-border-image-width" id="infopanel-for-propdef-border-image-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image-width" style="display:none">Info about the 'border-image-width' definition.</span><b><a href="#propdef-border-image-width">#propdef-border-image-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-width">3.2. Line Patterns: the border-style properties</a>
     <li><a href="#ref-for-propdef-border-image-width①">5. Border Images</a>
@@ -5022,8 +5022,8 @@ Drawing the Border Image</a>
 Changes since the 24 July 2012 Candidate Recommendation</a> <a href="#ref-for-propdef-border-image-width①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-image-area">
-   <b><a href="#border-image-area">#border-image-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-image-area" class="dfn-panel" data-for="border-image-area" id="infopanel-for-border-image-area" role="dialog">
+   <span id="infopaneltitle-for-border-image-area" style="display:none">Info about the 'border image area' definition.</span><b><a href="#border-image-area">#border-image-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-image-area">5. Border Images</a>
     <li><a href="#ref-for-border-image-area①">5.2. Image Slicing: the border-image-slice property</a>
@@ -5033,22 +5033,22 @@ Changes since the 24 July 2012 Candidate Recommendation</a> <a href="#ref-for-pr
 Drawing the Border Image</a> <a href="#ref-for-border-image-area⑤">(2)</a> <a href="#ref-for-border-image-area⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-image-width-auto">
-   <b><a href="#valdef-border-image-width-auto">#valdef-border-image-width-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-image-width-auto" class="dfn-panel" data-for="valdef-border-image-width-auto" id="infopanel-for-valdef-border-image-width-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-image-width-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-border-image-width-auto">#valdef-border-image-width-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-width-auto">5.3. Drawing Areas: the border-image-width property</a> <a href="#ref-for-valdef-border-image-width-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image-outset">
-   <b><a href="#propdef-border-image-outset">#propdef-border-image-outset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image-outset" class="dfn-panel" data-for="propdef-border-image-outset" id="infopanel-for-propdef-border-image-outset" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image-outset" style="display:none">Info about the 'border-image-outset' definition.</span><b><a href="#propdef-border-image-outset">#propdef-border-image-outset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-outset">5.3. Drawing Areas: the border-image-width property</a>
     <li><a href="#ref-for-propdef-border-image-outset①">5.4. Edge Overhang: the border-image-outset property</a>
     <li><a href="#ref-for-propdef-border-image-outset②">5.7. Border Image Shorthand: the border-image property</a> <a href="#ref-for-propdef-border-image-outset③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image-repeat">
-   <b><a href="#propdef-border-image-repeat">#propdef-border-image-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image-repeat" class="dfn-panel" data-for="propdef-border-image-repeat" id="infopanel-for-propdef-border-image-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image-repeat" style="display:none">Info about the 'border-image-repeat' definition.</span><b><a href="#propdef-border-image-repeat">#propdef-border-image-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-repeat">5.5. Image Tiling: the border-image-repeat property</a>
     <li><a href="#ref-for-propdef-border-image-repeat①">5.6. 
@@ -5058,29 +5058,29 @@ Drawing the Border Image</a>
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-image-repeat-stretch">
-   <b><a href="#valdef-border-image-repeat-stretch">#valdef-border-image-repeat-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-image-repeat-stretch" class="dfn-panel" data-for="valdef-border-image-repeat-stretch" id="infopanel-for-valdef-border-image-repeat-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-image-repeat-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-border-image-repeat-stretch">#valdef-border-image-repeat-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-repeat-stretch">5.6. 
 Drawing the Border Image</a> <a href="#ref-for-valdef-border-image-repeat-stretch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-image-repeat-repeat">
-   <b><a href="#valdef-border-image-repeat-repeat">#valdef-border-image-repeat-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-image-repeat-repeat" class="dfn-panel" data-for="valdef-border-image-repeat-repeat" id="infopanel-for-valdef-border-image-repeat-repeat" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-image-repeat-repeat" style="display:none">Info about the 'repeat' definition.</span><b><a href="#valdef-border-image-repeat-repeat">#valdef-border-image-repeat-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-repeat-repeat">5.6. 
 Drawing the Border Image</a> <a href="#ref-for-valdef-border-image-repeat-repeat①">(2)</a> <a href="#ref-for-valdef-border-image-repeat-repeat②">(3)</a> <a href="#ref-for-valdef-border-image-repeat-repeat③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-image-repeat-round">
-   <b><a href="#valdef-border-image-repeat-round">#valdef-border-image-repeat-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-image-repeat-round" class="dfn-panel" data-for="valdef-border-image-repeat-round" id="infopanel-for-valdef-border-image-repeat-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-image-repeat-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-border-image-repeat-round">#valdef-border-image-repeat-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-repeat-round">5.6. 
 Drawing the Border Image</a> <a href="#ref-for-valdef-border-image-repeat-round①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-image-repeat-space">
-   <b><a href="#valdef-border-image-repeat-space">#valdef-border-image-repeat-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-image-repeat-space" class="dfn-panel" data-for="valdef-border-image-repeat-space" id="infopanel-for-valdef-border-image-repeat-space" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-image-repeat-space" style="display:none">Info about the 'space' definition.</span><b><a href="#valdef-border-image-repeat-space">#valdef-border-image-repeat-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-image-repeat-space">5.6. 
 Drawing the Border Image</a> <a href="#ref-for-valdef-border-image-repeat-space①">(2)</a> <a href="#ref-for-valdef-border-image-repeat-space②">(3)</a>
@@ -5088,8 +5088,8 @@ Drawing the Border Image</a> <a href="#ref-for-valdef-border-image-repeat-space�
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-image">
-   <b><a href="#propdef-border-image">#propdef-border-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-image" class="dfn-panel" data-for="propdef-border-image" id="infopanel-for-propdef-border-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-image" style="display:none">Info about the 'border-image' definition.</span><b><a href="#propdef-border-image">#propdef-border-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">1.1. 
 Module Interactions</a>
@@ -5104,8 +5104,8 @@ Changes since the 14 February 2012 “Last Call” Working Draft</a>
     <li><a href="#ref-for-propdef-border-image⑧">9. Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-box-shadow">
-   <b><a href="#propdef-box-shadow">#propdef-box-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-shadow" class="dfn-panel" data-for="propdef-box-shadow" id="infopanel-for-propdef-box-shadow" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' definition.</span><b><a href="#propdef-box-shadow">#propdef-box-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow①">1. Introduction</a>
     <li><a href="#ref-for-propdef-box-shadow②">1.1. 
@@ -5119,29 +5119,29 @@ Changes since the 24 July 2012 Candidate Recommendation</a> <a href="#ref-for-pr
 Changes Since the 15 February 2011 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-shadow-none">
-   <b><a href="#box-shadow-none">#box-shadow-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-shadow-none" class="dfn-panel" data-for="box-shadow-none" id="infopanel-for-box-shadow-none" role="dialog">
+   <span id="infopaneltitle-for-box-shadow-none" style="display:none">Info about the 'none' definition.</span><b><a href="#box-shadow-none">#box-shadow-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-shadow-none">6.1. Drop Shadows: the box-shadow property</a> <a href="#ref-for-box-shadow-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shadow">
-   <b><a href="#typedef-shadow">#typedef-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shadow" class="dfn-panel" data-for="typedef-shadow" id="infopanel-for-typedef-shadow" role="dialog">
+   <span id="infopaneltitle-for-typedef-shadow" style="display:none">Info about the '&lt;shadow>' definition.</span><b><a href="#typedef-shadow">#typedef-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shadow">6.1. Drop Shadows: the box-shadow property</a> <a href="#ref-for-typedef-shadow①">(2)</a> <a href="#ref-for-typedef-shadow②">(3)</a> <a href="#ref-for-typedef-shadow③">(4)</a>
     <li><a href="#ref-for-typedef-shadow④">8.2. 
 Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for-typedef-shadow⑤">(2)</a> <a href="#ref-for-typedef-shadow⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blur-radius">
-   <b><a href="#blur-radius">#blur-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blur-radius" class="dfn-panel" data-for="blur-radius" id="infopanel-for-blur-radius" role="dialog">
+   <span id="infopaneltitle-for-blur-radius" style="display:none">Info about the 'blur radius' definition.</span><b><a href="#blur-radius">#blur-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blur-radius">6.1.2. 
 Blurring Shadow Edges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spread-distance">
-   <b><a href="#spread-distance">#spread-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spread-distance" class="dfn-panel" data-for="spread-distance" id="infopanel-for-spread-distance" role="dialog">
+   <span id="infopaneltitle-for-spread-distance" style="display:none">Info about the 'spread distance' definition.</span><b><a href="#spread-distance">#spread-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spread-distance">6.1.1. 
 Shadow Shape, Spread, and Knockout</a> <a href="#ref-for-spread-distance①">(2)</a> <a href="#ref-for-spread-distance②">(3)</a> <a href="#ref-for-spread-distance③">(4)</a> <a href="#ref-for-spread-distance④">(5)</a> <a href="#ref-for-spread-distance⑤">(6)</a> <a href="#ref-for-spread-distance⑥">(7)</a> <a href="#ref-for-spread-distance⑦">(8)</a>
@@ -5149,16 +5149,16 @@ Shadow Shape, Spread, and Knockout</a> <a href="#ref-for-spread-distance①">(2)
 Changes since the 17 October 2017 Candidate Recommendation</a> <a href="#ref-for-spread-distance⑨">(2)</a> <a href="#ref-for-spread-distance①⓪">(3)</a> <a href="#ref-for-spread-distance①①">(4)</a> <a href="#ref-for-spread-distance①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadow-inset">
-   <b><a href="#shadow-inset">#shadow-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadow-inset" class="dfn-panel" data-for="shadow-inset" id="infopanel-for-shadow-inset" role="dialog">
+   <span id="infopaneltitle-for-shadow-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#shadow-inset">#shadow-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-inset">6.1. Drop Shadows: the box-shadow property</a> <a href="#ref-for-shadow-inset①">(2)</a> <a href="#ref-for-shadow-inset②">(3)</a> <a href="#ref-for-shadow-inset③">(4)</a>
     <li><a href="#ref-for-shadow-inset④">8.5. 
 Changes since the 24 July 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-box-shadow">
-   <b><a href="#outer-box-shadow">#outer-box-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-box-shadow" class="dfn-panel" data-for="outer-box-shadow" id="infopanel-for-outer-box-shadow" role="dialog">
+   <span id="infopaneltitle-for-outer-box-shadow" style="display:none">Info about the 'outer box-shadow' definition.</span><b><a href="#outer-box-shadow">#outer-box-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-box-shadow">6.1.1. 
 Shadow Shape, Spread, and Knockout</a> <a href="#ref-for-outer-box-shadow①">(2)</a>
@@ -5166,8 +5166,8 @@ Shadow Shape, Spread, and Knockout</a> <a href="#ref-for-outer-box-shadow①">(2
 Layering, Layout, and Other Details</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inner-box-shadow">
-   <b><a href="#inner-box-shadow">#inner-box-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inner-box-shadow" class="dfn-panel" data-for="inner-box-shadow" id="infopanel-for-inner-box-shadow" role="dialog">
+   <span id="infopaneltitle-for-inner-box-shadow" style="display:none">Info about the 'inner box-shadow' definition.</span><b><a href="#inner-box-shadow">#inner-box-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-box-shadow">6.1.1. 
 Shadow Shape, Spread, and Knockout</a> <a href="#ref-for-inner-box-shadow①">(2)</a>
@@ -5177,57 +5177,113 @@ Layering, Layout, and Other Details</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-backgrounds-4/Overview.html
@@ -2051,35 +2051,35 @@ border-clip-top: 3fr 10px 2fr 10px 1fr 10px 10px 10px 1fr 10px 2fr 10px 3fr;
    <li><a href="#valdef-background-clip-text">text</a><span>, in § 2.2</span>
    <li><a href="#valdef-border-limit-top">top</a><span>, in § 5.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-typedef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-cubic-bezier-easing-function-cubic-bezier">
-   <a href="https://drafts.csswg.org/css-easing-2/#funcdef-cubic-bezier-easing-function-cubic-bezier">https://drafts.csswg.org/css-easing-2/#funcdef-cubic-bezier-easing-function-cubic-bezier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-cubic-bezier-easing-function-cubic-bezier" class="dfn-panel" data-for="term-for-funcdef-cubic-bezier-easing-function-cubic-bezier" id="infopanel-for-term-for-funcdef-cubic-bezier-easing-function-cubic-bezier" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-cubic-bezier-easing-function-cubic-bezier" style="display:none">Info about the 'cubic-bezier()' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#funcdef-cubic-bezier-easing-function-cubic-bezier">https://drafts.csswg.org/css-easing-2/#funcdef-cubic-bezier-easing-function-cubic-bezier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-cubic-bezier-easing-function-cubic-bezier">4.2. 
 Corner Shaping: the corner-shape property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-flex">
-   <a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-flex" class="dfn-panel" data-for="term-for-typedef-flex" id="infopanel-for-term-for-typedef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-flex" style="display:none">Info about the '&lt;flex>' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-flex">5.2. 
 The border-clip properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-fr">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-fr" class="dfn-panel" data-for="term-for-valdef-flex-fr" id="infopanel-for-term-for-valdef-flex-fr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-fr" style="display:none">Info about the 'fr' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-fr">5.2. 
 The border-clip properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-space-collapse-collapse">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-space-collapse-collapse">https://drafts.csswg.org/css-text-4/#valdef-text-space-collapse-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-space-collapse-collapse" class="dfn-panel" data-for="term-for-valdef-text-space-collapse-collapse" id="infopanel-for-term-for-valdef-text-space-collapse-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-space-collapse-collapse" style="display:none">Info about the 'collapse' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-space-collapse-collapse">https://drafts.csswg.org/css-text-4/#valdef-text-space-collapse-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-space-collapse-collapse">4.1. 
 Corner Sizing: the 'border-radius property</a>
@@ -2089,15 +2089,15 @@ Corner Shaping: the corner-shape property</a>
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">2.1.1. 
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a> <a href="#ref-for-mult-req①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2108,22 +2108,22 @@ Painting Area: the background-clip property</a>
     <li><a href="#ref-for-mult-comma⑥">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-mult-comma⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">2.1. 
 Background Positioning: the background-position shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">5.2. 
 The border-clip properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">2.1. 
 Background Positioning: the background-position shorthand property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a> <a href="#ref-for-typedef-length-percentage④">(5)</a> <a href="#ref-for-typedef-length-percentage⑤">(6)</a> <a href="#ref-for-typedef-length-percentage⑥">(7)</a>
@@ -2137,8 +2137,8 @@ Partial Borders: the border-limit property</a> <a href="#ref-for-typedef-length-
 The border-clip properties</a> <a href="#ref-for-typedef-length-percentage②⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.1. 
 Background Positioning: the background-position shorthand property</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a>
@@ -2150,8 +2150,8 @@ Corner Sizing: the 'border-radius property</a>
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4.1. 
 Corner Sizing: the 'border-radius property</a> <a href="#ref-for-mult-num-range①">(2)</a>
@@ -2159,8 +2159,8 @@ Corner Sizing: the 'border-radius property</a> <a href="#ref-for-mult-num-range�
 Corner Shaping: the corner-shape property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Background Positioning: the background-position shorthand property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a> <a href="#ref-for-comb-one①⑤">(16)</a> <a href="#ref-for-comb-one①⑥">(17)</a> <a href="#ref-for-comb-one①⑦">(18)</a> <a href="#ref-for-comb-one①⑧">(19)</a> <a href="#ref-for-comb-one①⑨">(20)</a> <a href="#ref-for-comb-one②⓪">(21)</a> <a href="#ref-for-comb-one②①">(22)</a> <a href="#ref-for-comb-one②②">(23)</a> <a href="#ref-for-comb-one②③">(24)</a> <a href="#ref-for-comb-one②④">(25)</a> <a href="#ref-for-comb-one②⑤">(26)</a> <a href="#ref-for-comb-one②⑥">(27)</a> <a href="#ref-for-comb-one②⑦">(28)</a> <a href="#ref-for-comb-one②⑧">(29)</a> <a href="#ref-for-comb-one②⑨">(30)</a> <a href="#ref-for-comb-one③⓪">(31)</a> <a href="#ref-for-comb-one③①">(32)</a>
@@ -2176,15 +2176,15 @@ Partial Borders: the border-limit property</a> <a href="#ref-for-comb-one④⑧"
 The border-clip properties</a> <a href="#ref-for-comb-one⑤④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.3. 
 Corner Shape and Size: the corners shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">4.1. 
 Corner Sizing: the 'border-radius property</a>
@@ -2194,38 +2194,38 @@ Corner Shaping: the corner-shape property</a>
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-box" class="dfn-panel" data-for="term-for-typedef-box" id="infopanel-for-term-for-typedef-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-box" style="display:none">Info about the '&lt;box>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-box">2.2. 
 Painting Area: the background-clip property</a> <a href="#ref-for-typedef-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">Unnumbered Section</a>
     <li><a href="#ref-for-propdef-background-repeat①">6.1. 
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">2.2. 
 Painting Area: the background-clip property</a>
     <li><a href="#ref-for-propdef-border-style①">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-propdef-border-style②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">2.2. 
 Painting Area: the background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-position-center">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-position-center" class="dfn-panel" data-for="term-for-valdef-background-position-center" id="infopanel-for-term-for-valdef-background-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-center">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2553,8 +2553,8 @@ Background Positioning: the background-position shorthand property</a>
    <div class="issue">Should these properties be simplified to only accept <code>normal | <a class="production css" data-link-type="type" href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">&lt;length-percentage></a>+</code>? <a class="issue-return" href="#issue-3b47c92d" title="Jump to section">↵</a></div>
    <div class="issue">Additions are a work in progress... here’s what we’re planning to add. :) <a class="issue-return" href="#issue-faa8d599" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-background-position">
-   <b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position" class="dfn-panel" data-for="propdef-background-position" id="infopanel-for-propdef-background-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position" style="display:none">Info about the 'background-position' definition.</span><b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position①">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2562,15 +2562,15 @@ Background Positioning: the background-position shorthand property</a>
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-position">
-   <b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-position" class="dfn-panel" data-for="typedef-position" id="infopanel-for-typedef-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-position" style="display:none">Info about the '&lt;position>' definition.</span><b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">2.1. 
 Background Positioning: the background-position shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position-x">
-   <b><a href="#propdef-background-position-x">#propdef-background-position-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position-x" class="dfn-panel" data-for="propdef-background-position-x" id="infopanel-for-propdef-background-position-x" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position-x" style="display:none">Info about the 'background-position-x' definition.</span><b><a href="#propdef-background-position-x">#propdef-background-position-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position-x">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2578,8 +2578,8 @@ Background Positioning: the background-position shorthand property</a>
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position-y">
-   <b><a href="#propdef-background-position-y">#propdef-background-position-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position-y" class="dfn-panel" data-for="propdef-background-position-y" id="infopanel-for-propdef-background-position-y" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position-y" style="display:none">Info about the 'background-position-y' definition.</span><b><a href="#propdef-background-position-y">#propdef-background-position-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position-y">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2587,8 +2587,8 @@ Background Positioning: the background-position shorthand property</a>
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position-inline">
-   <b><a href="#propdef-background-position-inline">#propdef-background-position-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position-inline" class="dfn-panel" data-for="propdef-background-position-inline" id="infopanel-for-propdef-background-position-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position-inline" style="display:none">Info about the 'background-position-inline' definition.</span><b><a href="#propdef-background-position-inline">#propdef-background-position-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position-inline">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2596,8 +2596,8 @@ Background Positioning: the background-position shorthand property</a>
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position-block">
-   <b><a href="#propdef-background-position-block">#propdef-background-position-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position-block" class="dfn-panel" data-for="propdef-background-position-block" id="infopanel-for-propdef-background-position-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position-block" style="display:none">Info about the 'background-position-block' definition.</span><b><a href="#propdef-background-position-block">#propdef-background-position-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position-block">2.1. 
 Background Positioning: the background-position shorthand property</a>
@@ -2605,37 +2605,37 @@ Background Positioning: the background-position shorthand property</a>
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-clip">
-   <b><a href="#propdef-background-clip">#propdef-background-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-clip" class="dfn-panel" data-for="propdef-background-clip" id="infopanel-for-propdef-background-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-clip" style="display:none">Info about the 'background-clip' definition.</span><b><a href="#propdef-background-clip">#propdef-background-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">2.2. 
 Painting Area: the background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bg-clip">
-   <b><a href="#typedef-bg-clip">#typedef-bg-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bg-clip" class="dfn-panel" data-for="typedef-bg-clip" id="infopanel-for-typedef-bg-clip" role="dialog">
+   <span id="infopaneltitle-for-typedef-bg-clip" style="display:none">Info about the '&lt;bg-clip>' definition.</span><b><a href="#typedef-bg-clip">#typedef-bg-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-clip">2.2. 
 Painting Area: the background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-clip-text">
-   <b><a href="#valdef-background-clip-text">#valdef-background-clip-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-clip-text" class="dfn-panel" data-for="valdef-background-clip-text" id="infopanel-for-valdef-background-clip-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-clip-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-background-clip-text">#valdef-background-clip-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-text">2.2. 
 Painting Area: the background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-color">
-   <b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-color" class="dfn-panel" data-for="propdef-border-color" id="infopanel-for-propdef-border-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-color" style="display:none">Info about the 'border-color' definition.</span><b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">2.2. 
 Painting Area: the background-clip property</a>
     <li><a href="#ref-for-propdef-border-color①">3.1. Line Colors: the border-color properties</a> <a href="#ref-for-propdef-border-color②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-radius">
-   <b><a href="#propdef-border-radius">#propdef-border-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-radius" class="dfn-panel" data-for="propdef-border-radius" id="infopanel-for-propdef-border-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-radius" style="display:none">Info about the 'border-radius' definition.</span><b><a href="#propdef-border-radius">#propdef-border-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">4.2. 
 Corner Shaping: the corner-shape property</a>
@@ -2643,8 +2643,8 @@ Corner Shaping: the corner-shape property</a>
 Corner Shape and Size: the corners shorthand</a> <a href="#ref-for-propdef-border-radius②">(2)</a> <a href="#ref-for-propdef-border-radius③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-corner-shape">
-   <b><a href="#propdef-corner-shape">#propdef-corner-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-corner-shape" class="dfn-panel" data-for="propdef-corner-shape" id="infopanel-for-propdef-corner-shape" role="dialog">
+   <span id="infopaneltitle-for-propdef-corner-shape" style="display:none">Info about the 'corner-shape' definition.</span><b><a href="#propdef-corner-shape">#propdef-corner-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-corner-shape①">4.2. 
 Corner Shaping: the corner-shape property</a> <a href="#ref-for-propdef-corner-shape②">(2)</a>
@@ -2654,50 +2654,50 @@ Corner Shape and Size: the corners shorthand</a> <a href="#ref-for-propdef-corne
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-corner-shape-round">
-   <b><a href="#valdef-corner-shape-round">#valdef-corner-shape-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-corner-shape-round" class="dfn-panel" data-for="valdef-corner-shape-round" id="infopanel-for-valdef-corner-shape-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-corner-shape-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-corner-shape-round">#valdef-corner-shape-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-corner-shape-round">4.2. 
 Corner Shaping: the corner-shape property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-corner-shape-angle">
-   <b><a href="#valdef-corner-shape-angle">#valdef-corner-shape-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-corner-shape-angle" class="dfn-panel" data-for="valdef-corner-shape-angle" id="infopanel-for-valdef-corner-shape-angle" role="dialog">
+   <span id="infopaneltitle-for-valdef-corner-shape-angle" style="display:none">Info about the 'angle' definition.</span><b><a href="#valdef-corner-shape-angle">#valdef-corner-shape-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-corner-shape-angle">4.2. 
 Corner Shaping: the corner-shape property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-corners">
-   <b><a href="#propdef-corners">#propdef-corners</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-corners" class="dfn-panel" data-for="propdef-corners" id="infopanel-for-propdef-corners" role="dialog">
+   <span id="infopaneltitle-for-propdef-corners" style="display:none">Info about the 'corners' definition.</span><b><a href="#propdef-corners">#propdef-corners</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-corners">4.3. 
 Corner Shape and Size: the corners shorthand</a> <a href="#ref-for-propdef-corners①">(2)</a> <a href="#ref-for-propdef-corners②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-limit">
-   <b><a href="#propdef-border-limit">#propdef-border-limit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-limit" class="dfn-panel" data-for="propdef-border-limit" id="infopanel-for-propdef-border-limit" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-limit" style="display:none">Info about the 'border-limit' definition.</span><b><a href="#propdef-border-limit">#propdef-border-limit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-limit">5.1. 
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-sides">
-   <b><a href="#valdef-border-limit-sides">#valdef-border-limit-sides</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-sides" class="dfn-panel" data-for="valdef-border-limit-sides" id="infopanel-for-valdef-border-limit-sides" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-sides" style="display:none">Info about the 'sides' definition.</span><b><a href="#valdef-border-limit-sides">#valdef-border-limit-sides</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-sides">5.1. 
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-corners">
-   <b><a href="#valdef-border-limit-corners">#valdef-border-limit-corners</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-corners" class="dfn-panel" data-for="valdef-border-limit-corners" id="infopanel-for-valdef-border-limit-corners" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-corners" style="display:none">Info about the 'corners' definition.</span><b><a href="#valdef-border-limit-corners">#valdef-border-limit-corners</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-corners">5.1. 
 Partial Borders: the border-limit property</a> <a href="#ref-for-valdef-border-limit-corners①">(2)</a> <a href="#ref-for-valdef-border-limit-corners②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-left">
-   <b><a href="#valdef-border-limit-left">#valdef-border-limit-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-left" class="dfn-panel" data-for="valdef-border-limit-left" id="infopanel-for-valdef-border-limit-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-border-limit-left">#valdef-border-limit-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-left">2.1.1. 
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
@@ -2705,15 +2705,15 @@ Background Positioning Longhands: the background-position-x, background-position
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-right">
-   <b><a href="#valdef-border-limit-right">#valdef-border-limit-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-right" class="dfn-panel" data-for="valdef-border-limit-right" id="infopanel-for-valdef-border-limit-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-border-limit-right">#valdef-border-limit-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-right">5.1. 
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-top">
-   <b><a href="#valdef-border-limit-top">#valdef-border-limit-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-top" class="dfn-panel" data-for="valdef-border-limit-top" id="infopanel-for-valdef-border-limit-top" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-top" style="display:none">Info about the 'top' definition.</span><b><a href="#valdef-border-limit-top">#valdef-border-limit-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-top">2.1.1. 
 Background Positioning Longhands: the background-position-x, background-position-y, background-position-inline, and background-position-block properties</a>
@@ -2721,15 +2721,15 @@ Background Positioning Longhands: the background-position-x, background-position
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-limit-bottom">
-   <b><a href="#valdef-border-limit-bottom">#valdef-border-limit-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-limit-bottom" class="dfn-panel" data-for="valdef-border-limit-bottom" id="infopanel-for-valdef-border-limit-bottom" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-limit-bottom" style="display:none">Info about the 'bottom' definition.</span><b><a href="#valdef-border-limit-bottom">#valdef-border-limit-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-limit-bottom">5.1. 
 Partial Borders: the border-limit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-clip">
-   <b><a href="#propdef-border-clip">#propdef-border-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-clip" class="dfn-panel" data-for="propdef-border-clip" id="infopanel-for-propdef-border-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-clip" style="display:none">Info about the 'border-clip' definition.</span><b><a href="#propdef-border-clip">#propdef-border-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-clip①">5.2. 
 The border-clip properties</a> <a href="#ref-for-propdef-border-clip②">(2)</a>
@@ -2737,59 +2737,115 @@ The border-clip properties</a> <a href="#ref-for-propdef-border-clip②">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-box-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-box-3/Overview.html
@@ -1623,82 +1623,82 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
    <li><a href="#valdef-box-view-box">view-box</a><span>, in § 2.1</span>
    <li><a href="#typedef-visual-box">&lt;visual-box></a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">2.1. Box-edge Keywords</a>
     <li><a href="#ref-for-propdef-background-clip①">4. Padding</a>
     <li><a href="#ref-for-propdef-background-clip②">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">1. Introduction</a>
     <li><a href="#ref-for-propdef-border①">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-break">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-break" class="dfn-panel" data-for="term-for-fragmentation-break" id="infopanel-for-term-for-fragmentation-break" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">3. Margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">1. Introduction</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
     <li><a href="#ref-for-longhand③">3. Margins</a> <a href="#ref-for-longhand④">(2)</a> <a href="#ref-for-longhand⑤">(3)</a>
     <li><a href="#ref-for-longhand⑥">4. Padding</a> <a href="#ref-for-longhand⑦">(2)</a> <a href="#ref-for-longhand⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'longhand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">1. Introduction</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
     <li><a href="#ref-for-longhand③">3. Margins</a> <a href="#ref-for-longhand④">(2)</a> <a href="#ref-for-longhand⑤">(3)</a>
     <li><a href="#ref-for-longhand⑥">4. Padding</a> <a href="#ref-for-longhand⑦">(2)</a> <a href="#ref-for-longhand⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. Margins</a>
     <li><a href="#ref-for-shorthand-property①">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#block-layout">https://drafts.csswg.org/css-display-3/#block-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-layout" class="dfn-panel" data-for="term-for-block-layout" id="infopanel-for-term-for-block-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-block-layout" style="display:none">Info about the 'block layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-layout">https://drafts.csswg.org/css-display-3/#block-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-layout">3. Margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">1. Introduction</a> <a href="#ref-for-box①">(2)</a>
     <li><a href="#ref-for-box②">2. The CSS Box Model</a>
@@ -1706,20 +1706,20 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
     <li><a href="#ref-for-box④">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-tree">
-   <a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-tree" class="dfn-panel" data-for="term-for-box-tree" id="infopanel-for-term-for-box-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-box-tree" style="display:none">Info about the 'box tree' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-table-element">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-table-element" class="dfn-panel" data-for="term-for-internal-table-element" id="infopanel-for-term-for-internal-table-element" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-table-element" style="display:none">Info about the 'internal table element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-element">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-internal-table-element①">3.2. Margin Shorthand: the margin property</a>
@@ -1727,28 +1727,28 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
     <li><a href="#ref-for-internal-table-element③">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.2. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.2. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-container-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-container-box" class="dfn-panel" data-for="term-for-ruby-annotation-container-box" id="infopanel-for-term-for-ruby-annotation-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-container-box" style="display:none">Info about the 'ruby annotation container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-container-box">Unnumbered Section</a>
     <li><a href="#ref-for-ruby-annotation-container-box①">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
@@ -1758,8 +1758,8 @@ Module Interactions</a>
     <li><a href="#ref-for-ruby-annotation-container-box⑤">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-container-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-container-box" class="dfn-panel" data-for="term-for-ruby-base-container-box" id="infopanel-for-term-for-ruby-base-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-container-box" style="display:none">Info about the 'ruby base container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-container-box">Unnumbered Section</a>
     <li><a href="#ref-for-ruby-base-container-box①">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
@@ -1769,47 +1769,47 @@ Module Interactions</a>
     <li><a href="#ref-for-ruby-base-container-box⑤">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-box">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-box">https://drafts.csswg.org/css-transforms-1/#propdef-transform-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-box" class="dfn-panel" data-for="term-for-propdef-transform-box" id="infopanel-for-term-for-propdef-transform-box" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-box" style="display:none">Info about the 'transform-box' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-box">https://drafts.csswg.org/css-transforms-1/#propdef-transform-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
     <li><a href="#ref-for-typedef-length-percentage②">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a> <a href="#ref-for-typedef-length-percentage③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.2. Margin Shorthand: the margin property</a>
     <li><a href="#ref-for-mult-num-range①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">1. Introduction</a>
     <li><a href="#ref-for-flow-relative①">3. Margins</a>
@@ -1817,8 +1817,8 @@ Value Definitions</a>
     <li><a href="#ref-for-flow-relative③">5. Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-width">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-width" class="dfn-panel" data-for="term-for-logical-width" id="infopanel-for-term-for-logical-width" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-width" style="display:none">Info about the 'logical width' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-width">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-logical-width①">3.2. Margin Shorthand: the margin property</a>
@@ -1826,8 +1826,8 @@ Value Definitions</a>
     <li><a href="#ref-for-logical-width③">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">1. Introduction</a>
     <li><a href="#ref-for-physical①">3. Margins</a>
@@ -1835,50 +1835,50 @@ Value Definitions</a>
     <li><a href="#ref-for-physical③">5. Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-document-tree">https://dom.spec.whatwg.org/#concept-document-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-tree" class="dfn-panel" data-for="term-for-concept-document-tree" id="infopanel-for-term-for-concept-document-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-tree" style="display:none">Info about the 'document tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-tree">https://dom.spec.whatwg.org/#concept-document-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-tree">1. Introduction</a> <a href="#ref-for-concept-document-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermCanvas">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermCanvas">https://svgwg.org/svg2-draft/coords.html#TermCanvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermCanvas" class="dfn-panel" data-for="term-for-TermCanvas" id="infopanel-for-term-for-TermCanvas" role="menu">
+   <span id="infopaneltitle-for-term-for-TermCanvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermCanvas">https://svgwg.org/svg2-draft/coords.html#TermCanvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermCanvas">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermObjectBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermObjectBoundingBox" class="dfn-panel" data-for="term-for-TermObjectBoundingBox" id="infopanel-for-term-for-TermObjectBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermObjectBoundingBox" style="display:none">Info about the 'object bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermObjectBoundingBox">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStrokeBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStrokeBoundingBox" class="dfn-panel" data-for="term-for-TermStrokeBoundingBox" id="infopanel-for-term-for-TermStrokeBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStrokeBoundingBox" style="display:none">Info about the 'stroke bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStrokeBoundingBox">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermSVGViewport">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermSVGViewport">https://svgwg.org/svg2-draft/coords.html#TermSVGViewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermSVGViewport" class="dfn-panel" data-for="term-for-TermSVGViewport" id="infopanel-for-term-for-TermSVGViewport" role="menu">
+   <span id="infopaneltitle-for-term-for-TermSVGViewport" style="display:none">Info about the 'svg viewports' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermSVGViewport">https://svgwg.org/svg2-draft/coords.html#TermSVGViewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermSVGViewport">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermUserCoordinateSystem">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermUserCoordinateSystem">https://svgwg.org/svg2-draft/coords.html#TermUserCoordinateSystem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermUserCoordinateSystem" class="dfn-panel" data-for="term-for-TermUserCoordinateSystem" id="infopanel-for-term-for-TermUserCoordinateSystem" role="menu">
+   <span id="infopaneltitle-for-term-for-TermUserCoordinateSystem" style="display:none">Info about the 'user coordinate system' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermUserCoordinateSystem">https://svgwg.org/svg2-draft/coords.html#TermUserCoordinateSystem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermUserCoordinateSystem">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermViewBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermViewBox">https://svgwg.org/svg2-draft/coords.html#TermViewBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermViewBox" class="dfn-panel" data-for="term-for-TermViewBox" id="infopanel-for-term-for-TermViewBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermViewBox" style="display:none">Info about the 'viewbox' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermViewBox">https://svgwg.org/svg2-draft/coords.html#TermViewBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermViewBox">2.1. Box-edge Keywords</a> <a href="#ref-for-TermViewBox①">(2)</a> <a href="#ref-for-TermViewBox②">(3)</a>
    </ul>
@@ -2129,187 +2129,187 @@ Value Definitions</a>
       <td>a computed &lt;length-percentage> value
    </table>
   </div>
-  <aside class="dfn-panel" data-for="content-area">
-   <b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-area" class="dfn-panel" data-for="content-area" id="infopanel-for-content-area" role="dialog">
+   <span id="infopaneltitle-for-content-area" style="display:none">Info about the 'content area' definition.</span><b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2. The CSS Box Model</a> <a href="#ref-for-content-area①">(2)</a> <a href="#ref-for-content-area②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-area">
-   <b><a href="#padding-area">#padding-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-area" class="dfn-panel" data-for="padding-area" id="infopanel-for-padding-area" role="dialog">
+   <span id="infopaneltitle-for-padding-area" style="display:none">Info about the 'padding' definition.</span><b><a href="#padding-area">#padding-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-area">2. The CSS Box Model</a> <a href="#ref-for-padding-area①">(2)</a> <a href="#ref-for-padding-area②">(3)</a>
     <li><a href="#ref-for-padding-area③">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-area">
-   <b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-area" class="dfn-panel" data-for="border-area" id="infopanel-for-border-area" role="dialog">
+   <span id="infopaneltitle-for-border-area" style="display:none">Info about the 'border' definition.</span><b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">2. The CSS Box Model</a> <a href="#ref-for-border-area①">(2)</a>
     <li><a href="#ref-for-border-area②">4. Padding</a>
     <li><a href="#ref-for-border-area③">5. Borders</a> <a href="#ref-for-border-area④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-area">
-   <b><a href="#margin-area">#margin-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-area" class="dfn-panel" data-for="margin-area" id="infopanel-for-margin-area" role="dialog">
+   <span id="infopaneltitle-for-margin-area" style="display:none">Info about the 'margin areas' definition.</span><b><a href="#margin-area">#margin-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-area">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-area①">3. Margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-edge">
-   <b><a href="#box-edge">#box-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-edge" class="dfn-panel" data-for="box-edge" id="infopanel-for-box-edge" role="dialog">
+   <span id="infopaneltitle-for-box-edge" style="display:none">Info about the 'edge' definition.</span><b><a href="#box-edge">#box-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-edge">2. The CSS Box Model</a> <a href="#ref-for-box-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-edge">
-   <b><a href="#content-edge">#content-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-edge" class="dfn-panel" data-for="content-edge" id="infopanel-for-content-edge" role="dialog">
+   <span id="infopaneltitle-for-content-edge" style="display:none">Info about the 'content edge' definition.</span><b><a href="#content-edge">#content-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-content-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-box">
-   <b><a href="#content-box">#content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-box" class="dfn-panel" data-for="content-box" id="infopanel-for-content-box" role="dialog">
+   <span id="infopaneltitle-for-content-box" style="display:none">Info about the 'content box' definition.</span><b><a href="#content-box">#content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-content-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-edge">
-   <b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-edge" class="dfn-panel" data-for="padding-edge" id="infopanel-for-padding-edge" role="dialog">
+   <span id="infopaneltitle-for-padding-edge" style="display:none">Info about the 'padding edge' definition.</span><b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-padding-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-box">
-   <b><a href="#padding-box">#padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-box" class="dfn-panel" data-for="padding-box" id="infopanel-for-padding-box" role="dialog">
+   <span id="infopaneltitle-for-padding-box" style="display:none">Info about the 'padding box' definition.</span><b><a href="#padding-box">#padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-padding-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-edge">
-   <b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-edge" class="dfn-panel" data-for="border-edge" id="infopanel-for-border-edge" role="dialog">
+   <span id="infopaneltitle-for-border-edge" style="display:none">Info about the 'border edge' definition.</span><b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-border-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-box">
-   <b><a href="#border-box">#border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-box" class="dfn-panel" data-for="border-box" id="infopanel-for-border-box" role="dialog">
+   <span id="infopaneltitle-for-border-box" style="display:none">Info about the 'border box' definition.</span><b><a href="#border-box">#border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-border-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-edge">
-   <b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-edge" class="dfn-panel" data-for="margin-edge" id="infopanel-for-margin-edge" role="dialog">
+   <span id="infopaneltitle-for-margin-edge" style="display:none">Info about the 'margin edge' definition.</span><b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-box">
-   <b><a href="#margin-box">#margin-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-box" class="dfn-panel" data-for="margin-box" id="infopanel-for-margin-box" role="dialog">
+   <span id="infopaneltitle-for-margin-box" style="display:none">Info about the 'margin box' definition.</span><b><a href="#margin-box">#margin-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-content-box">
-   <b><a href="#valdef-box-content-box">#valdef-box-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-content-box" class="dfn-panel" data-for="valdef-box-content-box" id="infopanel-for-valdef-box-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-box-content-box">#valdef-box-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-content-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-border-box">
-   <b><a href="#valdef-box-border-box">#valdef-box-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-border-box" class="dfn-panel" data-for="valdef-box-border-box" id="infopanel-for-valdef-box-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-box-border-box">#valdef-box-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-border-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-fill-box">
-   <b><a href="#valdef-box-fill-box">#valdef-box-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-fill-box" class="dfn-panel" data-for="valdef-box-fill-box" id="infopanel-for-valdef-box-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-box-fill-box">#valdef-box-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-fill-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-stroke-box">
-   <b><a href="#valdef-box-stroke-box">#valdef-box-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-stroke-box" class="dfn-panel" data-for="valdef-box-stroke-box" id="infopanel-for-valdef-box-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-box-stroke-box">#valdef-box-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-stroke-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-stroke-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-svg-viewport-origin-box">
-   <b><a href="#box-svg-viewport-origin-box">#box-svg-viewport-origin-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-svg-viewport-origin-box" class="dfn-panel" data-for="box-svg-viewport-origin-box" id="infopanel-for-box-svg-viewport-origin-box" role="dialog">
+   <span id="infopaneltitle-for-box-svg-viewport-origin-box" style="display:none">Info about the 'origin box' definition.</span><b><a href="#box-svg-viewport-origin-box">#box-svg-viewport-origin-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-svg-viewport-origin-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-visual-box">
-   <b><a href="#typedef-visual-box">#typedef-visual-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-visual-box" class="dfn-panel" data-for="typedef-visual-box" id="infopanel-for-typedef-visual-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-visual-box" style="display:none">Info about the '&lt;visual-box>' definition.</span><b><a href="#typedef-visual-box">#typedef-visual-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-visual-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-layout-box">
-   <b><a href="#typedef-layout-box">#typedef-layout-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-layout-box" class="dfn-panel" data-for="typedef-layout-box" id="infopanel-for-typedef-layout-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-layout-box" style="display:none">Info about the '&lt;layout-box>' definition.</span><b><a href="#typedef-layout-box">#typedef-layout-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-layout-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-paint-box">
-   <b><a href="#typedef-paint-box">#typedef-paint-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-paint-box" class="dfn-panel" data-for="typedef-paint-box" id="infopanel-for-typedef-paint-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-paint-box" style="display:none">Info about the '&lt;paint-box>' definition.</span><b><a href="#typedef-paint-box">#typedef-paint-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-paint-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-coord-box">
-   <b><a href="#typedef-coord-box">#typedef-coord-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-coord-box" class="dfn-panel" data-for="typedef-coord-box" id="infopanel-for-typedef-coord-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-coord-box" style="display:none">Info about the '&lt;coord-box>' definition.</span><b><a href="#typedef-coord-box">#typedef-coord-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-coord-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin">
-   <b><a href="#margin">#margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin" class="dfn-panel" data-for="margin" id="infopanel-for-margin" role="dialog">
+   <span id="infopaneltitle-for-margin" style="display:none">Info about the 'Margins' definition.</span><b><a href="#margin">#margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">1. Introduction</a> <a href="#ref-for-margin①">(2)</a>
     <li><a href="#ref-for-margin②">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-top">
-   <b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-top" class="dfn-panel" data-for="propdef-margin-top" id="infopanel-for-propdef-margin-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-top" style="display:none">Info about the 'margin-top' definition.</span><b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-top①">3.2. Margin Shorthand: the margin property</a> <a href="#ref-for-propdef-margin-top②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-right">
-   <b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-right" class="dfn-panel" data-for="propdef-margin-right" id="infopanel-for-propdef-margin-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-right" style="display:none">Info about the 'margin-right' definition.</span><b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-right①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-bottom">
-   <b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-bottom" class="dfn-panel" data-for="propdef-margin-bottom" id="infopanel-for-propdef-margin-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' definition.</span><b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-bottom①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-left">
-   <b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-left" class="dfn-panel" data-for="propdef-margin-left" id="infopanel-for-propdef-margin-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-left" style="display:none">Info about the 'margin-left' definition.</span><b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-left①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin">
-   <b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin" class="dfn-panel" data-for="propdef-margin" id="infopanel-for-propdef-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin" style="display:none">Info about the 'margin' definition.</span><b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin①">1. Introduction</a>
     <li><a href="#ref-for-propdef-margin②">3. Margins</a> <a href="#ref-for-propdef-margin③">(2)</a> <a href="#ref-for-propdef-margin④">(3)</a>
@@ -2317,43 +2317,43 @@ Value Definitions</a>
     <li><a href="#ref-for-propdef-margin⑧">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding">
-   <b><a href="#padding">#padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding" class="dfn-panel" data-for="padding" id="infopanel-for-padding" role="dialog">
+   <span id="infopaneltitle-for-padding" style="display:none">Info about the 'Padding' definition.</span><b><a href="#padding">#padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding">1. Introduction</a> <a href="#ref-for-padding①">(2)</a>
     <li><a href="#ref-for-padding②">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-top">
-   <b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-top" class="dfn-panel" data-for="propdef-padding-top" id="infopanel-for-propdef-padding-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-top" style="display:none">Info about the 'padding-top' definition.</span><b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-top①">4.2. Padding Shorthand: the padding property</a> <a href="#ref-for-propdef-padding-top②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-right">
-   <b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-right" class="dfn-panel" data-for="propdef-padding-right" id="infopanel-for-propdef-padding-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-right" style="display:none">Info about the 'padding-right' definition.</span><b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-right①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-bottom">
-   <b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-bottom" class="dfn-panel" data-for="propdef-padding-bottom" id="infopanel-for-propdef-padding-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' definition.</span><b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-bottom①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-left">
-   <b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-left" class="dfn-panel" data-for="propdef-padding-left" id="infopanel-for-propdef-padding-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-left" style="display:none">Info about the 'padding-left' definition.</span><b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-left①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding">
-   <b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding" class="dfn-panel" data-for="propdef-padding" id="infopanel-for-propdef-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding" style="display:none">Info about the 'padding' definition.</span><b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding①">1. Introduction</a>
     <li><a href="#ref-for-propdef-padding②">4. Padding</a> <a href="#ref-for-propdef-padding③">(2)</a> <a href="#ref-for-propdef-padding④">(3)</a>
@@ -2361,67 +2361,123 @@ Value Definitions</a>
     <li><a href="#ref-for-propdef-padding⑧">6. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border">
-   <b><a href="#border">#border</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border" class="dfn-panel" data-for="border" id="infopanel-for-border" role="dialog">
+   <span id="infopaneltitle-for-border" style="display:none">Info about the 'Borders' definition.</span><b><a href="#border">#border</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border">1. Introduction</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-box-3/block-layout.html
+++ b/tests/github/w3c/csswg-drafts/css-box-3/block-layout.html
@@ -4344,8 +4344,8 @@ avoid the image, plus 2em more: </p>
    <li><a href="#propdef-visibility">visibility</a><span>, in § 20</span>
    <li><a href="#propdef-width">width</a><span>, in § 10</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-auto">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-auto" class="dfn-panel" data-for="term-for-valdef-align-self-auto" id="infopanel-for-term-for-valdef-align-self-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-auto">9. The margin properties</a> <a href="#ref-for-valdef-align-self-auto①">(2)</a> <a href="#ref-for-valdef-align-self-auto②">(3)</a>
     <li><a href="#ref-for-valdef-align-self-auto③">10. The width and height properties</a> <a href="#ref-for-valdef-align-self-auto④">(2)</a>
@@ -4371,79 +4371,79 @@ elements</a> <a href="#ref-for-valdef-align-self-auto⑧①">(2)</a> <a href="#r
     <li><a href="#ref-for-valdef-align-self-auto⑨⑤">The ‘float-displace’ property [alternative 3]</a> <a href="#ref-for-valdef-align-self-auto⑨⑥">(2)</a> <a href="#ref-for-valdef-align-self-auto⑨⑦">(3)</a> <a href="#ref-for-valdef-align-self-auto⑨⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">The ‘float-displace’ property [alternative 2]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-end">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-end" class="dfn-panel" data-for="term-for-valdef-self-position-end" id="infopanel-for-term-for-valdef-self-position-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-end">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-content-left">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-left">https://drafts.csswg.org/css-align-3/#valdef-justify-content-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-content-left" class="dfn-panel" data-for="term-for-valdef-justify-content-left" id="infopanel-for-term-for-valdef-justify-content-left" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-content-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-left">https://drafts.csswg.org/css-align-3/#valdef-justify-content-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-left">16. The float property</a> <a href="#ref-for-valdef-justify-content-left①">(2)</a> <a href="#ref-for-valdef-justify-content-left②">(3)</a> <a href="#ref-for-valdef-justify-content-left③">(4)</a> <a href="#ref-for-valdef-justify-content-left④">(5)</a>
     <li><a href="#ref-for-valdef-justify-content-left⑤">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-content-right">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-right">https://drafts.csswg.org/css-align-3/#valdef-justify-content-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-content-right" class="dfn-panel" data-for="term-for-valdef-justify-content-right" id="infopanel-for-term-for-valdef-justify-content-right" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-content-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-right">https://drafts.csswg.org/css-align-3/#valdef-justify-content-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-right">16. The float property</a> <a href="#ref-for-valdef-justify-content-right①">(2)</a> <a href="#ref-for-valdef-justify-content-right②">(3)</a> <a href="#ref-for-valdef-justify-content-right③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-bottom">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-bottom">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-bottom" class="dfn-panel" data-for="term-for-valdef-anchor-bottom" id="infopanel-for-term-for-valdef-anchor-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-bottom">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-bottom">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-size-inline">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-inline">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-size-inline" class="dfn-panel" data-for="term-for-valdef-anchor-size-inline" id="infopanel-for-term-for-valdef-anchor-size-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-size-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-inline">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-size-inline">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-top">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-top">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-top" class="dfn-panel" data-for="term-for-valdef-anchor-top" id="infopanel-for-term-for-valdef-anchor-top" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-top">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-top">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">4. Containing blocks</a>
     <li><a href="#ref-for-content-edge①">18. The clear-after property</a>
     <li><a href="#ref-for-content-edge②">The ‘float-displace’ property [alternative 2]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding" class="dfn-panel" data-for="term-for-padding" id="infopanel-for-term-for-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding">13. Collapsing margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a> <a href="#ref-for-computed-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-visibility-visible">
-   <a href="https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible">https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-visibility-visible" class="dfn-panel" data-for="term-for-valdef-content-visibility-visible" id="infopanel-for-term-for-valdef-content-visibility-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-visibility-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible">https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-visibility-visible">15.3. Block-level, non-replaced elements
 in normal flow
@@ -4453,14 +4453,14 @@ when overflow computes to visible</a> <a href="#ref-for-valdef-content-visibilit
     <li><a href="#ref-for-valdef-content-visibility-visible④">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-valdef-content-visibility-visible⑤">(2)</a> <a href="#ref-for-valdef-content-visibility-visible⑥">(3)</a> <a href="#ref-for-valdef-content-visibility-visible⑦">(4)</a> <a href="#ref-for-valdef-content-visibility-visible⑧">(5)</a> <a href="#ref-for-valdef-content-visibility-visible⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-viewport">
-   <a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-viewport" class="dfn-panel" data-for="term-for-at-ruledef-viewport" id="infopanel-for-term-for-at-ruledef-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-viewport" style="display:none">Info about the '@viewport' external reference.</span><a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-viewport">10. The width and height properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-block" class="dfn-panel" data-for="term-for-valdef-display-block" id="infopanel-for-term-for-valdef-display-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">4. Containing blocks</a> <a href="#ref-for-valdef-display-block①">(2)</a> <a href="#ref-for-valdef-display-block②">(3)</a>
     <li><a href="#ref-for-valdef-display-block③">5. Flows</a>
@@ -4471,8 +4471,8 @@ and anonymous boxes</a> <a href="#ref-for-valdef-display-block⑤">(2)</a>
     <li><a href="#ref-for-valdef-display-block⑧">The ‘float-displace’ property [alternative 3]</a> <a href="#ref-for-valdef-display-block⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
@@ -4481,14 +4481,14 @@ in normal flow
 when overflow computes to visible</a> <a href="#ref-for-block-level-box②">(2)</a> <a href="#ref-for-block-level-box③">(3)</a> <a href="#ref-for-block-level-box④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-collapse">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse">https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-collapse" class="dfn-panel" data-for="term-for-valdef-visibility-collapse" id="infopanel-for-term-for-valdef-visibility-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-collapse" style="display:none">Info about the 'collapse' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse">https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-collapse">20. The visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">4. Containing blocks</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a>
     <li><a href="#ref-for-propdef-display③">5. Flows</a>
@@ -4501,14 +4501,14 @@ and anonymous boxes</a> <a href="#ref-for-propdef-display⑥">(2)</a> <a href="#
     <li><a href="#ref-for-propdef-display①④">20. The visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flex">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flex" class="dfn-panel" data-for="term-for-valdef-display-flex" id="infopanel-for-term-for-valdef-display-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex">5. Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">3. The viewport and the canvas</a>
     <li><a href="#ref-for-initial-containing-block①">5. Flows</a>
@@ -4517,8 +4517,8 @@ in normal flow
 when overflow computes to visible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">4. Containing blocks</a>
     <li><a href="#ref-for-valdef-display-inline-block①">5. Flows</a>
@@ -4527,15 +4527,15 @@ and anonymous boxes</a>
     <li><a href="#ref-for-valdef-display-inline-block③">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-valdef-display-inline-block④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-table" class="dfn-panel" data-for="term-for-valdef-display-inline-table" id="infopanel-for-term-for-valdef-display-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-list-item">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-list-item" class="dfn-panel" data-for="term-for-valdef-display-list-item" id="infopanel-for-term-for-valdef-display-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-list-item" style="display:none">Info about the 'list-item' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-list-item">4. Containing blocks</a>
     <li><a href="#ref-for-valdef-display-list-item①">5. Flows</a>
@@ -4543,14 +4543,14 @@ and anonymous boxes</a>
 and anonymous boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">12. Aspect ratios of replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-element">
-   <a href="https://drafts.csswg.org/css-display-3/#root-element">https://drafts.csswg.org/css-display-3/#root-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-element" class="dfn-panel" data-for="term-for-root-element" id="infopanel-for-term-for-root-element" role="menu">
+   <span id="infopaneltitle-for-term-for-root-element" style="display:none">Info about the 'root element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#root-element">https://drafts.csswg.org/css-display-3/#root-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-element">4. Containing blocks</a>
     <li><a href="#ref-for-root-element①">15.3. Block-level, non-replaced elements
@@ -4558,51 +4558,51 @@ in normal flow
 when overflow computes to visible</a> <a href="#ref-for-root-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-ruby">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-ruby">https://drafts.csswg.org/css-display-3/#valdef-display-ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-ruby" class="dfn-panel" data-for="term-for-valdef-display-ruby" id="infopanel-for-term-for-valdef-display-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-ruby">https://drafts.csswg.org/css-display-3/#valdef-display-ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-run-in">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-run-in">https://drafts.csswg.org/css-display-3/#valdef-display-run-in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-run-in" class="dfn-panel" data-for="term-for-valdef-display-run-in" id="infopanel-for-term-for-valdef-display-run-in" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-run-in" style="display:none">Info about the 'run-in' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-run-in">https://drafts.csswg.org/css-display-3/#valdef-display-run-in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-run-in">4. Containing blocks</a>
     <li><a href="#ref-for-valdef-display-run-in①">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a> <a href="#ref-for-valdef-display-run-in②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">5. Flows</a>
     <li><a href="#ref-for-valdef-display-table①">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-caption">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-caption">https://drafts.csswg.org/css-display-3/#valdef-display-table-caption</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-caption" class="dfn-panel" data-for="term-for-valdef-display-table-caption" id="infopanel-for-term-for-valdef-display-table-caption" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-caption" style="display:none">Info about the 'table-caption' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-caption">https://drafts.csswg.org/css-display-3/#valdef-display-table-caption</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-caption">4. Containing blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-cell">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-cell" class="dfn-panel" data-for="term-for-valdef-display-table-cell" id="infopanel-for-term-for-valdef-display-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">4. Containing blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-template-columns-max-content">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-template-columns-max-content" class="dfn-panel" data-for="term-for-valdef-grid-template-columns-max-content" id="infopanel-for-term-for-valdef-grid-template-columns-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-template-columns-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-max-content">10. The width and height properties</a> <a href="#ref-for-valdef-grid-template-columns-max-content①">(2)</a> <a href="#ref-for-valdef-grid-template-columns-max-content②">(3)</a> <a href="#ref-for-valdef-grid-template-columns-max-content③">(4)</a>
     <li><a href="#ref-for-valdef-grid-template-columns-max-content④">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-valdef-grid-template-columns-max-content⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-template-columns-min-content">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-min-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-template-columns-min-content" class="dfn-panel" data-for="term-for-valdef-grid-template-columns-min-content" id="infopanel-for-term-for-valdef-grid-template-columns-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-template-columns-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-min-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-min-content">10. The width and height properties</a> <a href="#ref-for-valdef-grid-template-columns-min-content①">(2)</a> <a href="#ref-for-valdef-grid-template-columns-min-content②">(3)</a> <a href="#ref-for-valdef-grid-template-columns-min-content③">(4)</a> <a href="#ref-for-valdef-grid-template-columns-min-content④">(5)</a>
     <li><a href="#ref-for-valdef-grid-template-columns-min-content⑤">11. The min-width, max-width, min-height and
@@ -4612,40 +4612,40 @@ in normal flow
 when overflow computes to visible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-resolution">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-resolution" class="dfn-panel" data-for="term-for-propdef-image-resolution" id="infopanel-for-term-for-propdef-image-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-resolution" style="display:none">Info about the 'image-resolution' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-resolution">12. Aspect ratios of replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">19.1. The overflow, overflow-x and overflow-y properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-float">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-float" class="dfn-panel" data-for="term-for-float" id="infopanel-for-term-for-float" role="menu">
+   <span id="infopaneltitle-for-term-for-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float">16.2. Rules for positioning floats</a> <a href="#ref-for-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">10. The width and height properties</a> <a href="#ref-for-valdef-width-auto①">(2)</a> <a href="#ref-for-valdef-width-auto②">(3)</a> <a href="#ref-for-valdef-width-auto③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">10. The width and height properties</a> <a href="#ref-for-propdef-box-sizing①">(2)</a> <a href="#ref-for-propdef-box-sizing②">(3)</a>
     <li><a href="#ref-for-propdef-box-sizing③">11. The min-width, max-width, min-height and
 max-height properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">10. The width and height properties</a> <a href="#ref-for-valdef-width-fit-content①">(2)</a> <a href="#ref-for-valdef-width-fit-content②">(3)</a> <a href="#ref-for-valdef-width-fit-content③">(4)</a>
     <li><a href="#ref-for-valdef-width-fit-content④">11. The min-width, max-width, min-height and
@@ -4657,32 +4657,32 @@ elements</a> <a href="#ref-for-valdef-width-fit-content⑦">(2)</a>
     <li><a href="#ref-for-valdef-width-fit-content⑧">15.9. Floating, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-comb-all①">(2)</a>
     <li><a href="#ref-for-comb-all②">The ‘float-displace’ property [alternative 3]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">The ‘float-displace’ property [alternative 3]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">8. The padding properties</a>
     <li><a href="#ref-for-mult-num-range①">9. The margin properties</a>
     <li><a href="#ref-for-mult-num-range②">19.1. The overflow, overflow-x and overflow-y properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">9. The margin properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
     <li><a href="#ref-for-comb-one④">10. The width and height properties</a> <a href="#ref-for-comb-one⑤">(2)</a> <a href="#ref-for-comb-one⑥">(3)</a> <a href="#ref-for-comb-one⑦">(4)</a> <a href="#ref-for-comb-one⑧">(5)</a> <a href="#ref-for-comb-one⑨">(6)</a> <a href="#ref-for-comb-one①⓪">(7)</a> <a href="#ref-for-comb-one①①">(8)</a> <a href="#ref-for-comb-one①②">(9)</a> <a href="#ref-for-comb-one①③">(10)</a> <a href="#ref-for-comb-one①④">(11)</a> <a href="#ref-for-comb-one①⑤">(12)</a> <a href="#ref-for-comb-one①⑥">(13)</a>
@@ -4699,20 +4699,20 @@ max-height properties</a> <a href="#ref-for-comb-one①⑧">(2)</a> <a href="#re
     <li><a href="#ref-for-comb-one⑦②">The ‘float-displace’ property [alternative 3]</a> <a href="#ref-for-comb-one⑦③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb" id="infopanel-for-term-for-valdef-writing-mode-horizontal-tb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb①">(2)</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb②">(3)</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">2. Introduction &amp; definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-direction-ltr①">(2)</a> <a href="#ref-for-valdef-direction-ltr②">(3)</a> <a href="#ref-for-valdef-direction-ltr③">(4)</a> <a href="#ref-for-valdef-direction-ltr④">(5)</a> <a href="#ref-for-valdef-direction-ltr⑤">(6)</a>
     <li><a href="#ref-for-valdef-direction-ltr⑥">15.6. Absolutely positioned, non-replaced
@@ -4722,8 +4722,8 @@ elements</a> <a href="#ref-for-valdef-direction-ltr①②">(2)</a> <a href="#ref
     <li><a href="#ref-for-valdef-direction-ltr①④">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-rtl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-rtl" class="dfn-panel" data-for="term-for-valdef-direction-rtl" id="infopanel-for-term-for-valdef-direction-rtl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-direction-rtl①">(2)</a> <a href="#ref-for-valdef-direction-rtl②">(3)</a> <a href="#ref-for-valdef-direction-rtl③">(4)</a> <a href="#ref-for-valdef-direction-rtl④">(5)</a> <a href="#ref-for-valdef-direction-rtl⑤">(6)</a>
     <li><a href="#ref-for-valdef-direction-rtl⑥">15.6. Absolutely positioned, non-replaced
@@ -4733,76 +4733,76 @@ elements</a> <a href="#ref-for-valdef-direction-rtl①⓪">(2)</a> <a href="#ref
     <li><a href="#ref-for-valdef-direction-rtl①②">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr" id="infopanel-for-term-for-valdef-writing-mode-sideways-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" style="display:none">Info about the 'sideways-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-lr">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-writing-mode-sideways-lr①">(2)</a> <a href="#ref-for-valdef-writing-mode-sideways-lr②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-sideways-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-rl" id="infopanel-for-term-for-valdef-writing-mode-sideways-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-sideways-rl" style="display:none">Info about the 'sideways-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-rl">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-writing-mode-sideways-rl①">(2)</a> <a href="#ref-for-valdef-writing-mode-sideways-rl②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr" id="infopanel-for-term-for-valdef-writing-mode-vertical-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-writing-mode-vertical-lr①">(2)</a> <a href="#ref-for-valdef-writing-mode-vertical-lr②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl" id="infopanel-for-term-for-valdef-writing-mode-vertical-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">2. Introduction &amp; definitions</a> <a href="#ref-for-valdef-writing-mode-vertical-rl①">(2)</a> <a href="#ref-for-valdef-writing-mode-vertical-rl②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">2. Introduction &amp; definitions</a> <a href="#ref-for-propdef-writing-mode①">(2)</a> <a href="#ref-for-propdef-writing-mode②">(3)</a> <a href="#ref-for-propdef-writing-mode③">(4)</a> <a href="#ref-for-propdef-writing-mode④">(5)</a> <a href="#ref-for-propdef-writing-mode⑤">(6)</a>
     <li><a href="#ref-for-propdef-writing-mode⑥">4. Containing blocks</a> <a href="#ref-for-propdef-writing-mode⑦">(2)</a>
     <li><a href="#ref-for-propdef-writing-mode⑧">16. The float property</a> <a href="#ref-for-propdef-writing-mode⑨">(2)</a> <a href="#ref-for-propdef-writing-mode①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-print">
-   <a href="https://drafts.csswg.org/css2/#valdef-media-print">https://drafts.csswg.org/css2/#valdef-media-print</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-print" class="dfn-panel" data-for="term-for-valdef-media-print" id="infopanel-for-term-for-valdef-media-print" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-print" style="display:none">Info about the 'print' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-media-print">https://drafts.csswg.org/css2/#valdef-media-print</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-print">19.1. The overflow, overflow-x and overflow-y properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">21.2. Painting order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-wrap-flow">
-   <a href="https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow">https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-wrap-flow" class="dfn-panel" data-for="term-for-propdef-wrap-flow" id="infopanel-for-term-for-propdef-wrap-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-wrap-flow" style="display:none">Info about the 'wrap-flow' external reference.</span><a href="https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow">https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-flow">22. The float-displace and indent-edge-reset properties [alternative 1]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">5. Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flow-into">
-   <a href="https://drafts.csswg.org/css-regions-1/#propdef-flow-into">https://drafts.csswg.org/css-regions-1/#propdef-flow-into</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flow-into" class="dfn-panel" data-for="term-for-propdef-flow-into" id="infopanel-for-term-for-propdef-flow-into" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flow-into" style="display:none">Info about the 'flow-into' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#propdef-flow-into">https://drafts.csswg.org/css-regions-1/#propdef-flow-into</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flow-into">5. Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">15. Calculating widths, heights and margins</a> <a href="#ref-for-propdef-transform①">(2)</a> <a href="#ref-for-propdef-transform②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">2. Introduction &amp; definitions</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a>
     <li><a href="#ref-for-propdef-direction④">4. Containing blocks</a> <a href="#ref-for-propdef-direction⑤">(2)</a>
@@ -4814,15 +4814,15 @@ elements</a> <a href="#ref-for-propdef-direction①③">(2)</a> <a href="#ref-fo
     <li><a href="#ref-for-propdef-direction①⑧">18. The clear-after property</a> <a href="#ref-for-propdef-direction①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">13. Collapsing margins</a>
     <li><a href="#ref-for-propdef-border①">15.8. Block-level, replaced elements in normal flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -4830,16 +4830,16 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-clip-border-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-border-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-clip-border-box" class="dfn-panel" data-for="term-for-valdef-background-clip-border-box" id="infopanel-for-term-for-valdef-background-clip-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-clip-border-box" style="display:none">Info about the 'border-box' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-border-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-border-box">10. The width and height properties</a> <a href="#ref-for-valdef-background-clip-border-box①">(2)</a> <a href="#ref-for-valdef-background-clip-border-box②">(3)</a>
     <li><a href="#ref-for-valdef-background-clip-border-box③">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-valdef-background-clip-border-box④">(2)</a> <a href="#ref-for-valdef-background-clip-border-box⑤">(3)</a> <a href="#ref-for-valdef-background-clip-border-box⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -4847,20 +4847,20 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">2. Introduction &amp; definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right" class="dfn-panel" data-for="term-for-propdef-border-right" id="infopanel-for-term-for-propdef-border-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right" style="display:none">Info about the 'border-right' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">2. Introduction &amp; definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -4868,8 +4868,8 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -4877,58 +4877,58 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-clip-content-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-content-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-clip-content-box" class="dfn-panel" data-for="term-for-valdef-background-clip-content-box" id="infopanel-for-term-for-valdef-background-clip-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-clip-content-box" style="display:none">Info about the 'content-box' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-content-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-content-box">10. The width and height properties</a> <a href="#ref-for-valdef-background-clip-content-box①">(2)</a> <a href="#ref-for-valdef-background-clip-content-box②">(3)</a>
     <li><a href="#ref-for-valdef-background-clip-content-box③">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-valdef-background-clip-content-box④">(2)</a> <a href="#ref-for-valdef-background-clip-content-box⑤">(3)</a> <a href="#ref-for-valdef-background-clip-content-box⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-image-slice-fill">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill">https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-image-slice-fill" class="dfn-panel" data-for="term-for-border-image-slice-fill" id="infopanel-for-term-for-border-image-slice-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-border-image-slice-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill">https://drafts.csswg.org/css-backgrounds-3/#border-image-slice-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-image-slice-fill">13. Collapsing margins</a> <a href="#ref-for-border-image-slice-fill①">(2)</a>
     <li><a href="#ref-for-border-image-slice-fill②">15.1. Inline, non-replaced
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-hidden">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-hidden" class="dfn-panel" data-for="term-for-valdef-line-style-hidden" id="infopanel-for-term-for-valdef-line-style-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-hidden">19.1. The overflow, overflow-x and overflow-y properties</a>
     <li><a href="#ref-for-valdef-line-style-hidden①">20. The visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-attachment-scroll" class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll" id="infopanel-for-term-for-valdef-background-attachment-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-attachment-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-scroll">19.1. The overflow, overflow-x and overflow-y properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">15.3. Block-level, non-replaced elements
 in normal flow
 when overflow computes to visible</a> <a href="#ref-for-propdef-column-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-footnote-display-compact">
-   <a href="https://drafts.csswg.org/css-gcpm-3/#footnote-display-compact">https://drafts.csswg.org/css-gcpm-3/#footnote-display-compact</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-footnote-display-compact" class="dfn-panel" data-for="term-for-footnote-display-compact" id="infopanel-for-term-for-footnote-display-compact" role="menu">
+   <span id="infopaneltitle-for-term-for-footnote-display-compact" style="display:none">Info about the 'compact' external reference.</span><a href="https://drafts.csswg.org/css-gcpm-3/#footnote-display-compact">https://drafts.csswg.org/css-gcpm-3/#footnote-display-compact</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-footnote-display-compact">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a> <a href="#ref-for-footnote-display-compact①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-footnote-policy-line">
-   <a href="https://drafts.csswg.org/css-gcpm-3/#footnote-policy-line">https://drafts.csswg.org/css-gcpm-3/#footnote-policy-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-footnote-policy-line" class="dfn-panel" data-for="term-for-footnote-policy-line" id="infopanel-for-term-for-footnote-policy-line" role="menu">
+   <span id="infopaneltitle-for-term-for-footnote-policy-line" style="display:none">Info about the 'line' external reference.</span><a href="https://drafts.csswg.org/css-gcpm-3/#footnote-policy-line">https://drafts.csswg.org/css-gcpm-3/#footnote-policy-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-footnote-policy-line">The ‘float-displace’ property [alternative 2]</a> <a href="#ref-for-footnote-policy-line①">(2)</a> <a href="#ref-for-footnote-policy-line②">(3)</a> <a href="#ref-for-footnote-policy-line③">(4)</a> <a href="#ref-for-footnote-policy-line④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
@@ -4938,8 +4938,8 @@ when overflow computes to visible</a> <a href="#ref-for-line-box②">(2)</a> <a 
     <li><a href="#ref-for-line-box⑤">The ‘float-displace’ property [alternative 2]</a> <a href="#ref-for-line-box⑥">(2)</a> <a href="#ref-for-line-box⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">15. Calculating widths, heights and margins</a>
     <li><a href="#ref-for-propdef-bottom①">15.1. Inline, non-replaced
@@ -4950,8 +4950,8 @@ elements</a> <a href="#ref-for-propdef-bottom③">(2)</a> <a href="#ref-for-prop
 elements</a> <a href="#ref-for-propdef-bottom①⑦">(2)</a> <a href="#ref-for-propdef-bottom①⑧">(3)</a> <a href="#ref-for-propdef-bottom①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">15. Calculating widths, heights and margins</a>
     <li><a href="#ref-for-propdef-left①">15.1. Inline, non-replaced
@@ -4963,8 +4963,8 @@ elements</a> <a href="#ref-for-propdef-left①⑧">(2)</a> <a href="#ref-for-pro
     <li><a href="#ref-for-propdef-left②⑤">18. The clear-after property</a> <a href="#ref-for-propdef-left②⑥">(2)</a> <a href="#ref-for-propdef-left②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">4. Containing blocks</a>
     <li><a href="#ref-for-propdef-position①">5. Flows</a> <a href="#ref-for-propdef-position②">(2)</a>
@@ -4973,16 +4973,16 @@ elements</a>
     <li><a href="#ref-for-propdef-position④">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">4. Containing blocks</a>
     <li><a href="#ref-for-valdef-position-relative①">5. Flows</a>
     <li><a href="#ref-for-valdef-position-relative②">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">15. Calculating widths, heights and margins</a>
     <li><a href="#ref-for-propdef-right①">15.1. Inline, non-replaced
@@ -4994,8 +4994,8 @@ elements</a> <a href="#ref-for-propdef-right①⑧">(2)</a> <a href="#ref-for-pr
     <li><a href="#ref-for-propdef-right②⑤">18. The clear-after property</a> <a href="#ref-for-propdef-right②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">4. Containing blocks</a>
     <li><a href="#ref-for-valdef-position-static①">5. Flows</a>
@@ -5004,8 +5004,8 @@ elements</a>
     <li><a href="#ref-for-valdef-position-static③">16. The float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">15. Calculating widths, heights and margins</a>
     <li><a href="#ref-for-propdef-top①">15.1. Inline, non-replaced
@@ -5016,8 +5016,8 @@ elements</a> <a href="#ref-for-propdef-top③">(2)</a> <a href="#ref-for-propdef
 elements</a> <a href="#ref-for-propdef-top①⑥">(2)</a> <a href="#ref-for-propdef-top①⑦">(3)</a> <a href="#ref-for-propdef-top①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">The ‘float-displace’ property [alternative 2]</a>
    </ul>
@@ -5858,21 +5858,21 @@ the content edge, so that list markers stay close to the content: <a class="issu
 rather than one that depends on the context: <a class="issue-return" href="#issue-8f711f7a" title="Jump to section">↵</a></div>
    <div class="issue">To do… <a class="issue-return" href="#issue-5b645b7b①" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="border-area">
-   <b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-area" class="dfn-panel" data-for="border-area" id="infopanel-for-border-area" role="dialog">
+   <span id="infopaneltitle-for-border-area" style="display:none">Info about the 'border area' definition.</span><b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">13. Collapsing margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-edge">
-   <b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-edge" class="dfn-panel" data-for="margin-edge" id="infopanel-for-margin-edge" role="dialog">
+   <span id="infopaneltitle-for-margin-edge" style="display:none">Info about the 'margin edge' definition.</span><b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">16.2. Rules for positioning floats</a> <a href="#ref-for-margin-edge①">(2)</a> <a href="#ref-for-margin-edge②">(3)</a> <a href="#ref-for-margin-edge③">(4)</a> <a href="#ref-for-margin-edge④">(5)</a> <a href="#ref-for-margin-edge⑤">(6)</a> <a href="#ref-for-margin-edge⑥">(7)</a> <a href="#ref-for-margin-edge⑦">(8)</a> <a href="#ref-for-margin-edge⑧">(9)</a> <a href="#ref-for-margin-edge⑨">(10)</a> <a href="#ref-for-margin-edge①⓪">(11)</a> <a href="#ref-for-margin-edge①①">(12)</a> <a href="#ref-for-margin-edge①②">(13)</a> <a href="#ref-for-margin-edge①③">(14)</a> <a href="#ref-for-margin-edge①④">(15)</a> <a href="#ref-for-margin-edge①⑤">(16)</a>
     <li><a href="#ref-for-margin-edge①⑥">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal">
-   <b><a href="#horizontal">#horizontal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal" class="dfn-panel" data-for="horizontal" id="infopanel-for-horizontal" role="dialog">
+   <span id="infopaneltitle-for-horizontal" style="display:none">Info about the 'horizontal' definition.</span><b><a href="#horizontal">#horizontal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal">2. Introduction &amp; definitions</a> <a href="#ref-for-horizontal①">(2)</a> <a href="#ref-for-horizontal②">(3)</a>
     <li><a href="#ref-for-horizontal③">5. Flows</a> <a href="#ref-for-horizontal④">(2)</a>
@@ -5881,15 +5881,15 @@ in normal flow
 when overflow computes to visible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical">
-   <b><a href="#vertical">#vertical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical" class="dfn-panel" data-for="vertical" id="infopanel-for-vertical" role="dialog">
+   <span id="infopaneltitle-for-vertical" style="display:none">Info about the 'vertical' definition.</span><b><a href="#vertical">#vertical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical">2. Introduction &amp; definitions</a> <a href="#ref-for-vertical①">(2)</a>
     <li><a href="#ref-for-vertical②">5. Flows</a> <a href="#ref-for-vertical③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-start">
-   <b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-start" class="dfn-panel" data-for="block-start" id="infopanel-for-block-start" role="dialog">
+   <span id="infopaneltitle-for-block-start" style="display:none">Info about the 'block-start' definition.</span><b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">15.3. Block-level, non-replaced elements
 in normal flow
@@ -5898,8 +5898,8 @@ when overflow computes to visible</a> <a href="#ref-for-block-start①">(2)</a> 
     <li><a href="#ref-for-block-start⑥">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-end">
-   <b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-end" class="dfn-panel" data-for="block-end" id="infopanel-for-block-end" role="dialog">
+   <span id="infopaneltitle-for-block-end" style="display:none">Info about the 'block-end' definition.</span><b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">15.3. Block-level, non-replaced elements
 in normal flow
@@ -5908,8 +5908,8 @@ when overflow computes to visible</a> <a href="#ref-for-block-end①">(2)</a> <a
     <li><a href="#ref-for-block-end⑥">18. The clear-after property</a> <a href="#ref-for-block-end⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-start">
-   <b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-start" class="dfn-panel" data-for="inline-start" id="infopanel-for-inline-start" role="dialog">
+   <span id="infopaneltitle-for-inline-start" style="display:none">Info about the 'inline-start' definition.</span><b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">15.3. Block-level, non-replaced elements
 in normal flow
@@ -5917,8 +5917,8 @@ when overflow computes to visible</a> <a href="#ref-for-inline-start①">(2)</a>
     <li><a href="#ref-for-inline-start②">15.4. Other block-level, non-replaced elements in normal flow</a> <a href="#ref-for-inline-start③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-end">
-   <b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-end" class="dfn-panel" data-for="inline-end" id="infopanel-for-inline-end" role="dialog">
+   <span id="infopaneltitle-for-inline-end" style="display:none">Info about the 'inline-end' definition.</span><b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">15.3. Block-level, non-replaced elements
 in normal flow
@@ -5926,16 +5926,16 @@ when overflow computes to visible</a> <a href="#ref-for-inline-end①">(2)</a>
     <li><a href="#ref-for-inline-end②">15.4. Other block-level, non-replaced elements in normal flow</a> <a href="#ref-for-inline-end③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="measure">
-   <b><a href="#measure">#measure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-measure" class="dfn-panel" data-for="measure" id="infopanel-for-measure" role="dialog">
+   <span id="infopaneltitle-for-measure" style="display:none">Info about the 'measure' definition.</span><b><a href="#measure">#measure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-measure">15.3. Block-level, non-replaced elements
 in normal flow
 when overflow computes to visible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extent">
-   <b><a href="#extent">#extent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extent" class="dfn-panel" data-for="extent" id="infopanel-for-extent" role="dialog">
+   <span id="infopaneltitle-for-extent" style="display:none">Info about the 'extent' definition.</span><b><a href="#extent">#extent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extent">9. The margin properties</a>
     <li><a href="#ref-for-extent①">15.3. Block-level, non-replaced elements
@@ -5943,90 +5943,92 @@ in normal flow
 when overflow computes to visible</a> <a href="#ref-for-extent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="a">
-   <b><a href="#a">#a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-a" class="dfn-panel" data-for="a" id="infopanel-for-a" role="dialog">
+   <span id="infopaneltitle-for-a" style="display:none">Info about the 'A
+edge' definition.</span><b><a href="#a">#a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a">7. Block-level formatting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="b">
-   <b><a href="#b">#b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-b" class="dfn-panel" data-for="b" id="infopanel-for-b" role="dialog">
+   <span id="infopaneltitle-for-b" style="display:none">Info about the 'B edge' definition.</span><b><a href="#b">#b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-b">7. Block-level formatting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="c">
-   <b><a href="#c">#c</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-c" class="dfn-panel" data-for="c" id="infopanel-for-c" role="dialog">
+   <span id="infopaneltitle-for-c" style="display:none">Info about the 'C
+edge' definition.</span><b><a href="#c">#c</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c">7. Block-level formatting</a>
     <li><a href="#ref-for-c①">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="d">
-   <b><a href="#d">#d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-d" class="dfn-panel" data-for="d" id="infopanel-for-d" role="dialog">
+   <span id="infopaneltitle-for-d" style="display:none">Info about the 'D edge' definition.</span><b><a href="#d">#d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-d">7. Block-level formatting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="orthogonal">
-   <b><a href="#orthogonal">#orthogonal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-orthogonal" class="dfn-panel" data-for="orthogonal" id="infopanel-for-orthogonal" role="dialog">
+   <span id="infopaneltitle-for-orthogonal" style="display:none">Info about the 'orthogonal' definition.</span><b><a href="#orthogonal">#orthogonal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-orthogonal">5. Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="orthogonal-flow">
-   <b><a href="#orthogonal-flow">#orthogonal-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-orthogonal-flow" class="dfn-panel" data-for="orthogonal-flow" id="infopanel-for-orthogonal-flow" role="dialog">
+   <span id="infopaneltitle-for-orthogonal-flow" style="display:none">Info about the 'orthogonal flow' definition.</span><b><a href="#orthogonal-flow">#orthogonal-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-orthogonal-flow">15.3. Block-level, non-replaced elements
 in normal flow
 when overflow computes to visible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="viewport①">
-   <b><a href="#viewport①">#viewport①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-viewport①" class="dfn-panel" data-for="viewport①" id="infopanel-for-viewport①" role="dialog">
+   <span id="infopaneltitle-for-viewport①" style="display:none">Info about the 'viewport' definition.</span><b><a href="#viewport①">#viewport①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport①">4. Containing blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canvas">
-   <b><a href="#canvas">#canvas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canvas" class="dfn-panel" data-for="canvas" id="infopanel-for-canvas" role="dialog">
+   <span id="infopaneltitle-for-canvas" style="display:none">Info about the 'canvas' definition.</span><b><a href="#canvas">#canvas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">2. Introduction &amp; definitions</a>
     <li><a href="#ref-for-canvas①">3. The viewport and the canvas</a>
     <li><a href="#ref-for-canvas②">4. Containing blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containing-block">
-   <b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containing-block" class="dfn-panel" data-for="containing-block" id="infopanel-for-containing-block" role="dialog">
+   <span id="infopaneltitle-for-containing-block" style="display:none">Info about the 'containing block' definition.</span><b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. Introduction &amp; definitions</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a>
     <li><a href="#ref-for-containing-block③">7. Block-level formatting</a>
     <li><a href="#ref-for-containing-block④">16.2. Rules for positioning floats</a> <a href="#ref-for-containing-block⑤">(2)</a> <a href="#ref-for-containing-block⑥">(3)</a> <a href="#ref-for-containing-block⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-container-box">
-   <b><a href="#block-container-box">#block-container-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-container-box" class="dfn-panel" data-for="block-container-box" id="infopanel-for-block-container-box" role="dialog">
+   <span id="infopaneltitle-for-block-container-box" style="display:none">Info about the 'block container box' definition.</span><b><a href="#block-container-box">#block-container-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container-box">4. Containing blocks</a>
     <li><a href="#ref-for-block-container-box①">5. Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="principal-box">
-   <b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-principal-box" class="dfn-panel" data-for="principal-box" id="infopanel-for-principal-box" role="dialog">
+   <span id="infopaneltitle-for-principal-box" style="display:none">Info about the 'principal box' definition.</span><b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">4. Containing blocks</a> <a href="#ref-for-principal-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flow">
-   <b><a href="#flow">#flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flow" class="dfn-panel" data-for="flow" id="infopanel-for-flow" role="dialog">
+   <span id="infopaneltitle-for-flow" style="display:none">Info about the 'flow' definition.</span><b><a href="#flow">#flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow">2. Introduction &amp; definitions</a> <a href="#ref-for-flow①">(2)</a>
     <li><a href="#ref-for-flow②">18. The clear-after property</a>
     <li><a href="#ref-for-flow③">The ‘float-displace’ property [alternative 2]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flow-root">
-   <b><a href="#flow-root">#flow-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flow-root" class="dfn-panel" data-for="flow-root" id="infopanel-for-flow-root" role="dialog">
+   <span id="infopaneltitle-for-flow-root" style="display:none">Info about the 'flow root' definition.</span><b><a href="#flow-root">#flow-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-root">2. Introduction &amp; definitions</a>
     <li><a href="#ref-for-flow-root①">4. Containing blocks</a>
@@ -6034,8 +6036,8 @@ when overflow computes to visible</a>
     <li><a href="#ref-for-flow-root③">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-level">
-   <b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-level" class="dfn-panel" data-for="block-level" id="infopanel-for-block-level" role="dialog">
+   <span id="infopaneltitle-for-block-level" style="display:none">Info about the 'block-level' definition.</span><b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">6.1. Block-level boxes, containing blocks
 and anonymous boxes</a>
@@ -6050,22 +6052,22 @@ when overflow computes to visible</a>
     <li><a href="#ref-for-block-level⑧">21.2. Painting order</a> <a href="#ref-for-block-level⑨">(2)</a> <a href="#ref-for-block-level①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anonymous-box">
-   <b><a href="#anonymous-box">#anonymous-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anonymous-box" class="dfn-panel" data-for="anonymous-box" id="infopanel-for-anonymous-box" role="dialog">
+   <span id="infopaneltitle-for-anonymous-box" style="display:none">Info about the 'anonymous box,' definition.</span><b><a href="#anonymous-box">#anonymous-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous-box">2. Introduction &amp; definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding">
-   <b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding" class="dfn-panel" data-for="propdef-padding" id="infopanel-for-propdef-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding" style="display:none">Info about the 'padding' definition.</span><b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">8. The padding properties</a> <a href="#ref-for-propdef-padding①">(2)</a>
     <li><a href="#ref-for-propdef-padding②">13. Collapsing margins</a>
     <li><a href="#ref-for-propdef-padding③">15.8. Block-level, replaced elements in normal flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-top">
-   <b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-top" class="dfn-panel" data-for="propdef-padding-top" id="infopanel-for-propdef-padding-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-top" style="display:none">Info about the 'padding-top' definition.</span><b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">2. Introduction &amp; definitions</a>
     <li><a href="#ref-for-propdef-padding-top①">15.6. Absolutely positioned, non-replaced
@@ -6074,8 +6076,8 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-right">
-   <b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-right" class="dfn-panel" data-for="propdef-padding-right" id="infopanel-for-propdef-padding-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-right" style="display:none">Info about the 'padding-right' definition.</span><b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -6083,8 +6085,8 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-bottom">
-   <b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-bottom" class="dfn-panel" data-for="propdef-padding-bottom" id="infopanel-for-propdef-padding-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' definition.</span><b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -6092,8 +6094,8 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-left">
-   <b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-left" class="dfn-panel" data-for="propdef-padding-left" id="infopanel-for-propdef-padding-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-left" style="display:none">Info about the 'padding-left' definition.</span><b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">15.6. Absolutely positioned, non-replaced
 elements</a>
@@ -6101,8 +6103,8 @@ elements</a>
 elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-top">
-   <b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-top" class="dfn-panel" data-for="propdef-margin-top" id="infopanel-for-propdef-margin-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-top" style="display:none">Info about the 'margin-top' definition.</span><b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">9. The margin properties</a>
     <li><a href="#ref-for-propdef-margin-top①">15.1. Inline, non-replaced
@@ -6117,8 +6119,8 @@ elements</a> <a href="#ref-for-propdef-margin-top⑤">(2)</a> <a href="#ref-for-
 elements</a> <a href="#ref-for-propdef-margin-top①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-right">
-   <b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-right" class="dfn-panel" data-for="propdef-margin-right" id="infopanel-for-propdef-margin-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-right" style="display:none">Info about the 'margin-right' definition.</span><b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">9. The margin properties</a>
     <li><a href="#ref-for-propdef-margin-right①">15.1. Inline, non-replaced
@@ -6134,8 +6136,8 @@ elements</a> <a href="#ref-for-propdef-margin-right①②">(2)</a> <a href="#ref
     <li><a href="#ref-for-propdef-margin-right①⑧">15.8. Block-level, replaced elements in normal flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-bottom">
-   <b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-bottom" class="dfn-panel" data-for="propdef-margin-bottom" id="infopanel-for-propdef-margin-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' definition.</span><b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">9. The margin properties</a>
     <li><a href="#ref-for-propdef-margin-bottom①">15.1. Inline, non-replaced
@@ -6150,8 +6152,8 @@ elements</a> <a href="#ref-for-propdef-margin-bottom⑤">(2)</a> <a href="#ref-f
 elements</a> <a href="#ref-for-propdef-margin-bottom①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-left">
-   <b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-left" class="dfn-panel" data-for="propdef-margin-left" id="infopanel-for-propdef-margin-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-left" style="display:none">Info about the 'margin-left' definition.</span><b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">9. The margin properties</a>
     <li><a href="#ref-for-propdef-margin-left①">15.1. Inline, non-replaced
@@ -6167,16 +6169,16 @@ elements</a> <a href="#ref-for-propdef-margin-left①②">(2)</a> <a href="#ref-
     <li><a href="#ref-for-propdef-margin-left①⑧">15.8. Block-level, replaced elements in normal flow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin">
-   <b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin" class="dfn-panel" data-for="propdef-margin" id="infopanel-for-propdef-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin" style="display:none">Info about the 'margin' definition.</span><b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">9. The margin properties</a> <a href="#ref-for-propdef-margin①">(2)</a> <a href="#ref-for-propdef-margin②">(3)</a> <a href="#ref-for-propdef-margin③">(4)</a>
     <li><a href="#ref-for-propdef-margin④">13. Collapsing margins</a>
     <li><a href="#ref-for-propdef-margin⑤">15. Calculating widths, heights and margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-width">
-   <b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-width" class="dfn-panel" data-for="propdef-width" id="infopanel-for-propdef-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-width" style="display:none">Info about the 'width' definition.</span><b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">10. The width and height properties</a> <a href="#ref-for-propdef-width①">(2)</a>
     <li><a href="#ref-for-propdef-width②">11. The min-width, max-width, min-height and
@@ -6200,8 +6202,8 @@ elements</a> <a href="#ref-for-propdef-width④②">(2)</a>
     <li><a href="#ref-for-propdef-width④④">15.9. Floating, non-replaced elements</a> <a href="#ref-for-propdef-width④⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-height">
-   <b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-height" class="dfn-panel" data-for="propdef-height" id="infopanel-for-propdef-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-height" style="display:none">Info about the 'height' definition.</span><b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">10. The width and height properties</a> <a href="#ref-for-propdef-height①">(2)</a> <a href="#ref-for-propdef-height②">(3)</a>
     <li><a href="#ref-for-propdef-height③">11. The min-width, max-width, min-height and
@@ -6225,8 +6227,8 @@ elements</a> <a href="#ref-for-propdef-height④②">(2)</a>
     <li><a href="#ref-for-propdef-height④④">18. The clear-after property</a> <a href="#ref-for-propdef-height④⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-width">
-   <b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-width" class="dfn-panel" data-for="propdef-min-width" id="infopanel-for-propdef-min-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-width" style="display:none">Info about the 'min-width' definition.</span><b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-propdef-min-width①">(2)</a>
@@ -6234,8 +6236,8 @@ max-height properties</a> <a href="#ref-for-propdef-min-width①">(2)</a>
     <li><a href="#ref-for-propdef-min-width④">15. Calculating widths, heights and margins</a> <a href="#ref-for-propdef-min-width⑤">(2)</a> <a href="#ref-for-propdef-min-width⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-height">
-   <b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-height" class="dfn-panel" data-for="propdef-min-height" id="infopanel-for-propdef-min-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-height" style="display:none">Info about the 'min-height' definition.</span><b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-propdef-min-height①">(2)</a>
@@ -6244,16 +6246,16 @@ max-height properties</a> <a href="#ref-for-propdef-min-height①">(2)</a>
     <li><a href="#ref-for-propdef-min-height⑧">18. The clear-after property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-width">
-   <b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-width" class="dfn-panel" data-for="propdef-max-width" id="infopanel-for-propdef-max-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-width" style="display:none">Info about the 'max-width' definition.</span><b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-propdef-max-width①">(2)</a>
     <li><a href="#ref-for-propdef-max-width②">15. Calculating widths, heights and margins</a> <a href="#ref-for-propdef-max-width③">(2)</a> <a href="#ref-for-propdef-max-width④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-height">
-   <b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-height" class="dfn-panel" data-for="propdef-max-height" id="infopanel-for-propdef-max-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-height" style="display:none">Info about the 'max-height' definition.</span><b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">11. The min-width, max-width, min-height and
 max-height properties</a> <a href="#ref-for-propdef-max-height①">(2)</a>
@@ -6262,14 +6264,14 @@ max-height properties</a> <a href="#ref-for-propdef-max-height①">(2)</a>
     <li><a href="#ref-for-propdef-max-height⑥">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-propdef-max-height⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complex-aspect-ratio">
-   <b><a href="#complex-aspect-ratio">#complex-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complex-aspect-ratio" class="dfn-panel" data-for="complex-aspect-ratio" id="infopanel-for-complex-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-complex-aspect-ratio" style="display:none">Info about the 'complex aspect ratio' definition.</span><b><a href="#complex-aspect-ratio">#complex-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complex-aspect-ratio">10. The width and height properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float">
-   <b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float" class="dfn-panel" data-for="propdef-float" id="infopanel-for-propdef-float" role="dialog">
+   <span id="infopaneltitle-for-propdef-float" style="display:none">Info about the 'float' definition.</span><b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">5. Flows</a> <a href="#ref-for-propdef-float①">(2)</a>
     <li><a href="#ref-for-propdef-float②">15.6. Absolutely positioned, non-replaced
@@ -6278,21 +6280,21 @@ elements</a>
     <li><a href="#ref-for-propdef-float④">16.2. Rules for positioning floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clear">
-   <b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clear" class="dfn-panel" data-for="propdef-clear" id="infopanel-for-propdef-clear" role="dialog">
+   <span id="infopaneltitle-for-propdef-clear" style="display:none">Info about the 'clear' definition.</span><b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">16. The float property</a> <a href="#ref-for-propdef-clear①">(2)</a>
     <li><a href="#ref-for-propdef-clear②">16.1. Introduction to floats</a> <a href="#ref-for-propdef-clear③">(2)</a> <a href="#ref-for-propdef-clear④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clear-after">
-   <b><a href="#propdef-clear-after">#propdef-clear-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clear-after" class="dfn-panel" data-for="propdef-clear-after" id="infopanel-for-propdef-clear-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-clear-after" style="display:none">Info about the 'clear-after' definition.</span><b><a href="#propdef-clear-after">#propdef-clear-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear-after">18. The clear-after property</a> <a href="#ref-for-propdef-clear-after①">(2)</a> <a href="#ref-for-propdef-clear-after②">(3)</a> <a href="#ref-for-propdef-clear-after③">(4)</a> <a href="#ref-for-propdef-clear-after④">(5)</a> <a href="#ref-for-propdef-clear-after⑤">(6)</a> <a href="#ref-for-propdef-clear-after⑥">(7)</a> <a href="#ref-for-propdef-clear-after⑦">(8)</a> <a href="#ref-for-propdef-clear-after⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clear-after-none">
-   <b><a href="#valdef-clear-after-none">#valdef-clear-after-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clear-after-none" class="dfn-panel" data-for="valdef-clear-after-none" id="infopanel-for-valdef-clear-after-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-clear-after-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-clear-after-none">#valdef-clear-after-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clear-after-none">5. Flows</a> <a href="#ref-for-valdef-clear-after-none①">(2)</a>
     <li><a href="#ref-for-valdef-clear-after-none②">11. The min-width, max-width, min-height and
@@ -6305,20 +6307,20 @@ max-height properties</a> <a href="#ref-for-valdef-clear-after-none③">(2)</a>
     <li><a href="#ref-for-valdef-clear-after-none①④">22.2. The indent-edge-reset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-x">
-   <b><a href="#propdef-overflow-x">#propdef-overflow-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-x" class="dfn-panel" data-for="propdef-overflow-x" id="infopanel-for-propdef-overflow-x" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' definition.</span><b><a href="#propdef-overflow-x">#propdef-overflow-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-propdef-overflow-x①">(2)</a> <a href="#ref-for-propdef-overflow-x②">(3)</a> <a href="#ref-for-propdef-overflow-x③">(4)</a> <a href="#ref-for-propdef-overflow-x④">(5)</a> <a href="#ref-for-propdef-overflow-x⑤">(6)</a> <a href="#ref-for-propdef-overflow-x⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-y">
-   <b><a href="#propdef-overflow-y">#propdef-overflow-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-y" class="dfn-panel" data-for="propdef-overflow-y" id="infopanel-for-propdef-overflow-y" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' definition.</span><b><a href="#propdef-overflow-y">#propdef-overflow-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-propdef-overflow-y①">(2)</a> <a href="#ref-for-propdef-overflow-y②">(3)</a> <a href="#ref-for-propdef-overflow-y③">(4)</a> <a href="#ref-for-propdef-overflow-y④">(5)</a> <a href="#ref-for-propdef-overflow-y⑤">(6)</a> <a href="#ref-for-propdef-overflow-y⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow">
-   <b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow" class="dfn-panel" data-for="propdef-overflow" id="infopanel-for-propdef-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4. Containing blocks</a>
     <li><a href="#ref-for-propdef-overflow①">5. Flows</a>
@@ -6331,8 +6333,8 @@ when overflow computes to visible</a> <a href="#ref-for-propdef-overflow③">(2)
     <li><a href="#ref-for-propdef-overflow①①">19.1. The overflow, overflow-x and overflow-y properties</a> <a href="#ref-for-propdef-overflow①②">(2)</a> <a href="#ref-for-propdef-overflow①③">(3)</a> <a href="#ref-for-propdef-overflow①④">(4)</a> <a href="#ref-for-propdef-overflow①⑤">(5)</a> <a href="#ref-for-propdef-overflow①⑥">(6)</a> <a href="#ref-for-propdef-overflow①⑦">(7)</a> <a href="#ref-for-propdef-overflow①⑧">(8)</a> <a href="#ref-for-propdef-overflow①⑨">(9)</a> <a href="#ref-for-propdef-overflow②⓪">(10)</a> <a href="#ref-for-propdef-overflow②①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float-displace">
-   <b><a href="#propdef-float-displace">#propdef-float-displace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float-displace" class="dfn-panel" data-for="propdef-float-displace" id="infopanel-for-propdef-float-displace" role="dialog">
+   <span id="infopaneltitle-for-propdef-float-displace" style="display:none">Info about the 'float-displace' definition.</span><b><a href="#propdef-float-displace">#propdef-float-displace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float-displace">22. The float-displace and indent-edge-reset properties [alternative 1]</a> <a href="#ref-for-propdef-float-displace①">(2)</a>
     <li><a href="#ref-for-propdef-float-displace②">22.1. The float-displace property</a>
@@ -6341,8 +6343,8 @@ when overflow computes to visible</a> <a href="#ref-for-propdef-overflow③">(2)
     <li><a href="#ref-for-propdef-float-displace⑦">The ‘float-displace’ property [alternative 3]</a> <a href="#ref-for-propdef-float-displace⑧">(2)</a> <a href="#ref-for-propdef-float-displace⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-indent-edge-reset">
-   <b><a href="#propdef-indent-edge-reset">#propdef-indent-edge-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-indent-edge-reset" class="dfn-panel" data-for="propdef-indent-edge-reset" id="infopanel-for-propdef-indent-edge-reset" role="dialog">
+   <span id="infopaneltitle-for-propdef-indent-edge-reset" style="display:none">Info about the 'indent-edge-reset' definition.</span><b><a href="#propdef-indent-edge-reset">#propdef-indent-edge-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-indent-edge-reset">22. The float-displace and indent-edge-reset properties [alternative 1]</a>
     <li><a href="#ref-for-propdef-indent-edge-reset①">22.1. The float-displace property</a>
@@ -6350,65 +6352,121 @@ when overflow computes to visible</a> <a href="#ref-for-propdef-overflow③">(2)
     <li><a href="#ref-for-propdef-indent-edge-reset④">The ‘float-displace’ property [alternative 2]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-indent">
-   <b><a href="#relative-indent">#relative-indent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-indent" class="dfn-panel" data-for="relative-indent" id="infopanel-for-relative-indent" role="dialog">
+   <span id="infopaneltitle-for-relative-indent" style="display:none">Info about the 'relative indent' definition.</span><b><a href="#relative-indent">#relative-indent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-indent">The ‘float-displace’ property [alternative 2]</a> <a href="#ref-for-relative-indent①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-box-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-box-4/Overview.html
@@ -1579,106 +1579,106 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
    <li><a href="#valdef-box-view-box">view-box</a><span>, in § 2.1</span>
    <li><a href="#typedef-visual-box">&lt;visual-box></a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">2.1. Box-edge Keywords</a>
     <li><a href="#ref-for-propdef-background-clip①">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">1. Introduction</a>
     <li><a href="#ref-for-propdef-border①">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-break">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-break" class="dfn-panel" data-for="term-for-fragmentation-break" id="infopanel-for-term-for-fragmentation-break" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">3. Margins</a>
     <li><a href="#ref-for-fragmentation-break①">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-margin-break">https://drafts.csswg.org/css-break-4/#propdef-margin-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-break" class="dfn-panel" data-for="term-for-propdef-margin-break" id="infopanel-for-term-for-propdef-margin-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-break" style="display:none">Info about the 'margin-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-margin-break">https://drafts.csswg.org/css-break-4/#propdef-margin-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-break">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3. Margins</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
     <li><a href="#ref-for-longhand③">4. Padding</a> <a href="#ref-for-longhand④">(2)</a> <a href="#ref-for-longhand⑤">(3)</a>
     <li><a href="#ref-for-longhand⑥">5. Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'longhand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3. Margins</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
     <li><a href="#ref-for-longhand③">4. Padding</a> <a href="#ref-for-longhand④">(2)</a> <a href="#ref-for-longhand⑤">(3)</a>
     <li><a href="#ref-for-longhand⑥">5. Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. Margins</a>
     <li><a href="#ref-for-shorthand-property①">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context-root">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context-root">https://drafts.csswg.org/css-display-3/#block-formatting-context-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context-root" class="dfn-panel" data-for="term-for-block-formatting-context-root" id="infopanel-for-term-for-block-formatting-context-root" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context-root" style="display:none">Info about the 'block formatting context root' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context-root">https://drafts.csswg.org/css-display-3/#block-formatting-context-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context-root">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#block-layout">https://drafts.csswg.org/css-display-3/#block-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-layout" class="dfn-panel" data-for="term-for-block-layout" id="infopanel-for-term-for-block-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-block-layout" style="display:none">Info about the 'block layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-layout">https://drafts.csswg.org/css-display-3/#block-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-layout">3. Margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">1. Introduction</a> <a href="#ref-for-box①">(2)</a>
     <li><a href="#ref-for-box②">2. The CSS Box Model</a>
@@ -1686,21 +1686,21 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
     <li><a href="#ref-for-box④">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-tree">
-   <a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-tree" class="dfn-panel" data-for="term-for-box-tree" id="infopanel-for-term-for-box-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-box-tree" style="display:none">Info about the 'box tree' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. The CSS Box Model</a>
     <li><a href="#ref-for-containing-block①">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-table-element">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-table-element" class="dfn-panel" data-for="term-for-internal-table-element" id="infopanel-for-term-for-internal-table-element" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-table-element" style="display:none">Info about the 'internal table element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-element">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-internal-table-element①">3.2. Margin Shorthand: the margin property</a>
@@ -1708,46 +1708,46 @@ body { padding: 1em 2em 3em } /* top=1em, right=2em, bottom=3em, left=2em */
     <li><a href="#ref-for-internal-table-element③">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2. The CSS Box Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.2. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.2. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-container-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-container-box" class="dfn-panel" data-for="term-for-ruby-annotation-container-box" id="infopanel-for-term-for-ruby-annotation-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-container-box" style="display:none">Info about the 'ruby annotation container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-container-box">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-ruby-annotation-container-box①">3.2. Margin Shorthand: the margin property</a>
@@ -1756,8 +1756,8 @@ Module Interactions</a>
     <li><a href="#ref-for-ruby-annotation-container-box④">7. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-container-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-container-box" class="dfn-panel" data-for="term-for-ruby-base-container-box" id="infopanel-for-term-for-ruby-base-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-container-box" style="display:none">Info about the 'ruby base container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-container-box">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-ruby-base-container-box①">3.2. Margin Shorthand: the margin property</a>
@@ -1766,110 +1766,110 @@ Module Interactions</a>
     <li><a href="#ref-for-ruby-base-container-box④">7. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#size">https://drafts.csswg.org/css-sizing-3/#size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-size" class="dfn-panel" data-for="term-for-size" id="infopanel-for-term-for-size" role="menu">
+   <span id="infopaneltitle-for-term-for-size" style="display:none">Info about the 'size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#size">https://drafts.csswg.org/css-sizing-3/#size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-box">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-box">https://drafts.csswg.org/css-transforms-1/#propdef-transform-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-box" class="dfn-panel" data-for="term-for-propdef-transform-box" id="infopanel-for-term-for-propdef-transform-box" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-box" style="display:none">Info about the 'transform-box' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-box">https://drafts.csswg.org/css-transforms-1/#propdef-transform-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
     <li><a href="#ref-for-typedef-length-percentage②">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a> <a href="#ref-for-typedef-length-percentage③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.2. Margin Shorthand: the margin property</a>
     <li><a href="#ref-for-mult-num-range①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-comb-one①">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-comb-one②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-block-start①">(2)</a> <a href="#ref-for-block-start②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">3. Margins</a>
     <li><a href="#ref-for-flow-relative①">4. Padding</a>
     <li><a href="#ref-for-flow-relative②">5. Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-inline-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis①" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-inline-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-inline-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-inline-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-width">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-width" class="dfn-panel" data-for="term-for-logical-width" id="infopanel-for-term-for-logical-width" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-width" style="display:none">Info about the 'logical width' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-width">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-logical-width①">3.2. Margin Shorthand: the margin property</a>
@@ -1877,45 +1877,45 @@ Value Definitions</a>
     <li><a href="#ref-for-logical-width③">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">3. Margins</a>
     <li><a href="#ref-for-physical①">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">7. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-document-tree">https://dom.spec.whatwg.org/#concept-document-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-tree" class="dfn-panel" data-for="term-for-concept-document-tree" id="infopanel-for-term-for-concept-document-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-tree" style="display:none">Info about the 'document tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-tree">https://dom.spec.whatwg.org/#concept-document-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-tree">1. Introduction</a> <a href="#ref-for-concept-document-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermCanvas">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermCanvas">https://svgwg.org/svg2-draft/coords.html#TermCanvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermCanvas" class="dfn-panel" data-for="term-for-TermCanvas" id="infopanel-for-term-for-TermCanvas" role="menu">
+   <span id="infopaneltitle-for-term-for-TermCanvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermCanvas">https://svgwg.org/svg2-draft/coords.html#TermCanvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermCanvas">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermObjectBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermObjectBoundingBox" class="dfn-panel" data-for="term-for-TermObjectBoundingBox" id="infopanel-for-term-for-TermObjectBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermObjectBoundingBox" style="display:none">Info about the 'object bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermObjectBoundingBox">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStrokeBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStrokeBoundingBox" class="dfn-panel" data-for="term-for-TermStrokeBoundingBox" id="infopanel-for-term-for-TermStrokeBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStrokeBoundingBox" style="display:none">Info about the 'stroke bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStrokeBoundingBox">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermSVGViewport">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermSVGViewport">https://svgwg.org/svg2-draft/coords.html#TermSVGViewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermSVGViewport" class="dfn-panel" data-for="term-for-TermSVGViewport" id="infopanel-for-term-for-TermSVGViewport" role="menu">
+   <span id="infopaneltitle-for-term-for-TermSVGViewport" style="display:none">Info about the 'svg viewports' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermSVGViewport">https://svgwg.org/svg2-draft/coords.html#TermSVGViewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermSVGViewport">2.1. Box-edge Keywords</a> <a href="#ref-for-TermSVGViewport①">(2)</a> <a href="#ref-for-TermSVGViewport②">(3)</a> <a href="#ref-for-TermSVGViewport③">(4)</a>
    </ul>
@@ -2216,201 +2216,201 @@ Value Definitions</a>
 	if the box establishes a <a data-link-type="dfn" href="https://drafts.csswg.org/css-break-4/#fragmentation-context">fragmentation context</a>.
 	See also <a href="https://github.com/w3c/csswg-drafts/issues/3314">Issue 3314</a>. <a class="issue-return" href="#issue-c93b5c6f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="content-area">
-   <b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-area" class="dfn-panel" data-for="content-area" id="infopanel-for-content-area" role="dialog">
+   <span id="infopaneltitle-for-content-area" style="display:none">Info about the 'content area' definition.</span><b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2. The CSS Box Model</a> <a href="#ref-for-content-area①">(2)</a> <a href="#ref-for-content-area②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-area">
-   <b><a href="#padding-area">#padding-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-area" class="dfn-panel" data-for="padding-area" id="infopanel-for-padding-area" role="dialog">
+   <span id="infopaneltitle-for-padding-area" style="display:none">Info about the 'padding' definition.</span><b><a href="#padding-area">#padding-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-area">2. The CSS Box Model</a> <a href="#ref-for-padding-area①">(2)</a> <a href="#ref-for-padding-area②">(3)</a>
     <li><a href="#ref-for-padding-area③">4. Padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-area">
-   <b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-area" class="dfn-panel" data-for="border-area" id="infopanel-for-border-area" role="dialog">
+   <span id="infopaneltitle-for-border-area" style="display:none">Info about the 'border' definition.</span><b><a href="#border-area">#border-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">2. The CSS Box Model</a> <a href="#ref-for-border-area①">(2)</a>
     <li><a href="#ref-for-border-area②">4. Padding</a>
     <li><a href="#ref-for-border-area③">5. Borders</a> <a href="#ref-for-border-area④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-area">
-   <b><a href="#margin-area">#margin-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-area" class="dfn-panel" data-for="margin-area" id="infopanel-for-margin-area" role="dialog">
+   <span id="infopaneltitle-for-margin-area" style="display:none">Info about the 'margin areas' definition.</span><b><a href="#margin-area">#margin-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-area">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-area①">3. Margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-edge">
-   <b><a href="#box-edge">#box-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-edge" class="dfn-panel" data-for="box-edge" id="infopanel-for-box-edge" role="dialog">
+   <span id="infopaneltitle-for-box-edge" style="display:none">Info about the 'edge' definition.</span><b><a href="#box-edge">#box-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-edge">2. The CSS Box Model</a> <a href="#ref-for-box-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-edge">
-   <b><a href="#content-edge">#content-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-edge" class="dfn-panel" data-for="content-edge" id="infopanel-for-content-edge" role="dialog">
+   <span id="infopaneltitle-for-content-edge" style="display:none">Info about the 'content edge' definition.</span><b><a href="#content-edge">#content-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-content-edge①">2.1. Box-edge Keywords</a>
     <li><a href="#ref-for-content-edge②">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inner-edge">
-   <b><a href="#inner-edge">#inner-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inner-edge" class="dfn-panel" data-for="inner-edge" id="infopanel-for-inner-edge" role="dialog">
+   <span id="infopaneltitle-for-inner-edge" style="display:none">Info about the 'inner edge' definition.</span><b><a href="#inner-edge">#inner-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-edge">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-inner-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-box">
-   <b><a href="#content-box">#content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-box" class="dfn-panel" data-for="content-box" id="infopanel-for-content-box" role="dialog">
+   <span id="infopaneltitle-for-content-box" style="display:none">Info about the 'content box' definition.</span><b><a href="#content-box">#content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-content-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-edge">
-   <b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-edge" class="dfn-panel" data-for="padding-edge" id="infopanel-for-padding-edge" role="dialog">
+   <span id="infopaneltitle-for-padding-edge" style="display:none">Info about the 'padding edge' definition.</span><b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-padding-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-box">
-   <b><a href="#padding-box">#padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-box" class="dfn-panel" data-for="padding-box" id="infopanel-for-padding-box" role="dialog">
+   <span id="infopaneltitle-for-padding-box" style="display:none">Info about the 'padding box' definition.</span><b><a href="#padding-box">#padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-padding-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-edge">
-   <b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-edge" class="dfn-panel" data-for="border-edge" id="infopanel-for-border-edge" role="dialog">
+   <span id="infopaneltitle-for-border-edge" style="display:none">Info about the 'border edge' definition.</span><b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-border-edge①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-box">
-   <b><a href="#border-box">#border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-box" class="dfn-panel" data-for="border-box" id="infopanel-for-border-box" role="dialog">
+   <span id="infopaneltitle-for-border-box" style="display:none">Info about the 'border box' definition.</span><b><a href="#border-box">#border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-border-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-edge">
-   <b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-edge" class="dfn-panel" data-for="margin-edge" id="infopanel-for-margin-edge" role="dialog">
+   <span id="infopaneltitle-for-margin-edge" style="display:none">Info about the 'margin edge' definition.</span><b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-edge①">2.1. Box-edge Keywords</a>
     <li><a href="#ref-for-margin-edge②">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-edge">
-   <b><a href="#outer-edge">#outer-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-edge" class="dfn-panel" data-for="outer-edge" id="infopanel-for-outer-edge" role="dialog">
+   <span id="infopaneltitle-for-outer-edge" style="display:none">Info about the 'outer edge' definition.</span><b><a href="#outer-edge">#outer-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-edge">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-outer-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-box">
-   <b><a href="#margin-box">#margin-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-box" class="dfn-panel" data-for="margin-box" id="infopanel-for-margin-box" role="dialog">
+   <span id="infopaneltitle-for-margin-box" style="display:none">Info about the 'margin box' definition.</span><b><a href="#margin-box">#margin-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">2. The CSS Box Model</a>
     <li><a href="#ref-for-margin-box①">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-content-box">
-   <b><a href="#valdef-box-content-box">#valdef-box-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-content-box" class="dfn-panel" data-for="valdef-box-content-box" id="infopanel-for-valdef-box-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-box-content-box">#valdef-box-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-content-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-border-box">
-   <b><a href="#valdef-box-border-box">#valdef-box-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-border-box" class="dfn-panel" data-for="valdef-box-border-box" id="infopanel-for-valdef-box-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-box-border-box">#valdef-box-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-border-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-fill-box">
-   <b><a href="#valdef-box-fill-box">#valdef-box-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-fill-box" class="dfn-panel" data-for="valdef-box-fill-box" id="infopanel-for-valdef-box-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-box-fill-box">#valdef-box-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-fill-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-stroke-box">
-   <b><a href="#valdef-box-stroke-box">#valdef-box-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-stroke-box" class="dfn-panel" data-for="valdef-box-stroke-box" id="infopanel-for-valdef-box-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-box-stroke-box">#valdef-box-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-stroke-box">2.1. Box-edge Keywords</a> <a href="#ref-for-valdef-box-stroke-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-svg-viewport-origin-box">
-   <b><a href="#box-svg-viewport-origin-box">#box-svg-viewport-origin-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-svg-viewport-origin-box" class="dfn-panel" data-for="box-svg-viewport-origin-box" id="infopanel-for-box-svg-viewport-origin-box" role="dialog">
+   <span id="infopaneltitle-for-box-svg-viewport-origin-box" style="display:none">Info about the 'origin box' definition.</span><b><a href="#box-svg-viewport-origin-box">#box-svg-viewport-origin-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-svg-viewport-origin-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-visual-box">
-   <b><a href="#typedef-visual-box">#typedef-visual-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-visual-box" class="dfn-panel" data-for="typedef-visual-box" id="infopanel-for-typedef-visual-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-visual-box" style="display:none">Info about the '&lt;visual-box>' definition.</span><b><a href="#typedef-visual-box">#typedef-visual-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-visual-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-layout-box">
-   <b><a href="#typedef-layout-box">#typedef-layout-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-layout-box" class="dfn-panel" data-for="typedef-layout-box" id="infopanel-for-typedef-layout-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-layout-box" style="display:none">Info about the '&lt;layout-box>' definition.</span><b><a href="#typedef-layout-box">#typedef-layout-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-layout-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-paint-box">
-   <b><a href="#typedef-paint-box">#typedef-paint-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-paint-box" class="dfn-panel" data-for="typedef-paint-box" id="infopanel-for-typedef-paint-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-paint-box" style="display:none">Info about the '&lt;paint-box>' definition.</span><b><a href="#typedef-paint-box">#typedef-paint-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-paint-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-coord-box">
-   <b><a href="#typedef-coord-box">#typedef-coord-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-coord-box" class="dfn-panel" data-for="typedef-coord-box" id="infopanel-for-typedef-coord-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-coord-box" style="display:none">Info about the '&lt;coord-box>' definition.</span><b><a href="#typedef-coord-box">#typedef-coord-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-coord-box">2.1. Box-edge Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin">
-   <b><a href="#margin">#margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin" class="dfn-panel" data-for="margin" id="infopanel-for-margin" role="dialog">
+   <span id="infopaneltitle-for-margin" style="display:none">Info about the 'Margins' definition.</span><b><a href="#margin">#margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-margin①">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-margin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-top">
-   <b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-top" class="dfn-panel" data-for="propdef-margin-top" id="infopanel-for-propdef-margin-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-top" style="display:none">Info about the 'margin-top' definition.</span><b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-top①">3.2. Margin Shorthand: the margin property</a> <a href="#ref-for-propdef-margin-top②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-right">
-   <b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-right" class="dfn-panel" data-for="propdef-margin-right" id="infopanel-for-propdef-margin-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-right" style="display:none">Info about the 'margin-right' definition.</span><b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-right①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-bottom">
-   <b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-bottom" class="dfn-panel" data-for="propdef-margin-bottom" id="infopanel-for-propdef-margin-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' definition.</span><b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-bottom①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-left">
-   <b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-left" class="dfn-panel" data-for="propdef-margin-left" id="infopanel-for-propdef-margin-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-left" style="display:none">Info about the 'margin-left' definition.</span><b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">3.1. Page-relative (Physical) Margin Properties: the margin-top, margin-right, margin-bottom, and margin-left properties</a>
     <li><a href="#ref-for-propdef-margin-left①">3.2. Margin Shorthand: the margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin">
-   <b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin" class="dfn-panel" data-for="propdef-margin" id="infopanel-for-propdef-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin" style="display:none">Info about the 'margin' definition.</span><b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">1. Introduction</a>
     <li><a href="#ref-for-propdef-margin①">3. Margins</a> <a href="#ref-for-propdef-margin②">(2)</a> <a href="#ref-for-propdef-margin③">(3)</a>
@@ -2418,55 +2418,55 @@ Value Definitions</a>
     <li><a href="#ref-for-propdef-margin⑦">7. Changes Since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-trim">
-   <b><a href="#propdef-margin-trim">#propdef-margin-trim</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-trim" class="dfn-panel" data-for="propdef-margin-trim" id="infopanel-for-propdef-margin-trim" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-trim" style="display:none">Info about the 'margin-trim' definition.</span><b><a href="#propdef-margin-trim">#propdef-margin-trim</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-trim">3.3. Margins at Container Edges: the margin-trim property</a> <a href="#ref-for-propdef-margin-trim①">(2)</a> <a href="#ref-for-propdef-margin-trim②">(3)</a> <a href="#ref-for-propdef-margin-trim③">(4)</a>
     <li><a href="#ref-for-propdef-margin-trim④">6. Changes Since CSS Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-margin-trim-in-flow">
-   <b><a href="#valdef-margin-trim-in-flow">#valdef-margin-trim-in-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-margin-trim-in-flow" class="dfn-panel" data-for="valdef-margin-trim-in-flow" id="infopanel-for-valdef-margin-trim-in-flow" role="dialog">
+   <span id="infopaneltitle-for-valdef-margin-trim-in-flow" style="display:none">Info about the 'in-flow' definition.</span><b><a href="#valdef-margin-trim-in-flow">#valdef-margin-trim-in-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-margin-trim-in-flow">3.3. Margins at Container Edges: the margin-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding">
-   <b><a href="#padding">#padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding" class="dfn-panel" data-for="padding" id="infopanel-for-padding" role="dialog">
+   <span id="infopaneltitle-for-padding" style="display:none">Info about the 'Padding' definition.</span><b><a href="#padding">#padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-top">
-   <b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-top" class="dfn-panel" data-for="propdef-padding-top" id="infopanel-for-propdef-padding-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-top" style="display:none">Info about the 'padding-top' definition.</span><b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-top①">4.2. Padding Shorthand: the padding property</a> <a href="#ref-for-propdef-padding-top②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-right">
-   <b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-right" class="dfn-panel" data-for="propdef-padding-right" id="infopanel-for-propdef-padding-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-right" style="display:none">Info about the 'padding-right' definition.</span><b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-right①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-bottom">
-   <b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-bottom" class="dfn-panel" data-for="propdef-padding-bottom" id="infopanel-for-propdef-padding-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' definition.</span><b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-bottom①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-left">
-   <b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-left" class="dfn-panel" data-for="propdef-padding-left" id="infopanel-for-propdef-padding-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-left" style="display:none">Info about the 'padding-left' definition.</span><b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">4.1. Page-relative (Physical) Padding Properties: the padding-top, padding-right, padding-bottom, and padding-left properties</a>
     <li><a href="#ref-for-propdef-padding-left①">4.2. Padding Shorthand: the padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding">
-   <b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding" class="dfn-panel" data-for="propdef-padding" id="infopanel-for-propdef-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding" style="display:none">Info about the 'padding' definition.</span><b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">1. Introduction</a>
     <li><a href="#ref-for-propdef-padding①">4. Padding</a> <a href="#ref-for-propdef-padding②">(2)</a> <a href="#ref-for-propdef-padding③">(3)</a>
@@ -2476,59 +2476,115 @@ Value Definitions</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-break-3/Overview.html
@@ -2188,44 +2188,44 @@ on screen, on paper, etc.
    <li><a href="#valdef-break-before-verso">verso</a><span>, in § 3.1</span>
    <li><a href="#propdef-widows">widows</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-border-area">
-   <a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-area" class="dfn-panel" data-for="term-for-border-area" id="infopanel-for-term-for-border-area" role="menu">
+   <span id="infopaneltitle-for-term-for-border-area" style="display:none">Info about the 'border area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-area">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-area">https://drafts.csswg.org/css-box-4/#margin-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-area" class="dfn-panel" data-for="term-for-margin-area" id="infopanel-for-term-for-margin-area" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-area" style="display:none">Info about the 'margin area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-area">https://drafts.csswg.org/css-box-4/#margin-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-area">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-area">https://drafts.csswg.org/css-box-4/#padding-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-area" class="dfn-panel" data-for="term-for-padding-area" id="infopanel-for-term-for-padding-area" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-area" style="display:none">Info about the 'padding area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-area">https://drafts.csswg.org/css-box-4/#padding-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.1.1. 
 Child→Parent Break Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-legacy-shorthand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#legacy-shorthand">https://drafts.csswg.org/css-cascade-5/#legacy-shorthand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-legacy-shorthand" class="dfn-panel" data-for="term-for-legacy-shorthand" id="infopanel-for-term-for-legacy-shorthand" role="menu">
+   <span id="infopaneltitle-for-term-for-legacy-shorthand" style="display:none">Info about the 'legacy shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#legacy-shorthand">https://drafts.csswg.org/css-cascade-5/#legacy-shorthand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-shorthand">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a>
     <li><a href="#ref-for-legacy-shorthand①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.3. 
 Breaks Between Lines: orphans, widows</a>
@@ -2234,16 +2234,16 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a>
     <li><a href="#ref-for-block-container②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
     <li><a href="#ref-for-block-level-box①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">2. 
 Fragmentation Model and Terminology</a>
@@ -2254,130 +2254,130 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a>
     <li><a href="#ref-for-display-type③"> Changes</a> <a href="#ref-for-display-type④">(2)</a> <a href="#ref-for-display-type⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2.1. 
 Parallel Fragmentation Flows</a> <a href="#ref-for-formatting-context①">(2)</a> <a href="#ref-for-formatting-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">3.1.1. 
 Child→Parent Break Propagation</a> <a href="#ref-for-in-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">4.1. 
 Possible Break Points</a>
     <li><a href="#ref-for-independent-formatting-context①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
     <li><a href="#ref-for-inline-box①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">3.3. 
 Breaks Between Lines: orphans, widows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">4.1. 
 Possible Break Points</a>
     <li><a href="#ref-for-valdef-display-inline-block①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-table" class="dfn-panel" data-for="term-for-valdef-display-inline-table" id="infopanel-for-term-for-valdef-display-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">4.1. 
 Possible Break Points</a>
     <li><a href="#ref-for-valdef-display-inline-table①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-out-of-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-out-of-flow" class="dfn-panel" data-for="term-for-out-of-flow" id="infopanel-for-term-for-out-of-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-out-of-flow" style="display:none">Info about the 'out-of-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mask-positioning-area">
-   <a href="https://drafts.fxtf.org/css-masking-1/#mask-positioning-area">https://drafts.fxtf.org/css-masking-1/#mask-positioning-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mask-positioning-area" class="dfn-panel" data-for="term-for-mask-positioning-area" id="infopanel-for-term-for-mask-positioning-area" role="menu">
+   <span id="infopaneltitle-for-term-for-mask-positioning-area" style="display:none">Info about the 'mask positioning area' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#mask-positioning-area">https://drafts.fxtf.org/css-masking-1/#mask-positioning-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-positioning-area">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4.1. 
 Possible Break Points</a> <a href="#ref-for-propdef-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-scroll">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-scroll" class="dfn-panel" data-for="term-for-valdef-overflow-scroll" id="infopanel-for-term-for-valdef-overflow-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-basic-shape-reference-box">
-   <a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-basic-shape-reference-box" class="dfn-panel" data-for="term-for-basic-shape-reference-box" id="infopanel-for-term-for-basic-shape-reference-box" role="menu">
+   <span id="infopaneltitle-for-term-for-basic-shape-reference-box" style="display:none">Info about the 'reference box' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-shape-reference-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-break">
-   <a href="https://drafts.csswg.org/css-text-4/#line-break">https://drafts.csswg.org/css-text-4/#line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-break" class="dfn-panel" data-for="term-for-line-break" id="infopanel-for-term-for-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-line-break" style="display:none">Info about the 'line break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#line-break">https://drafts.csswg.org/css-text-4/#line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-break">4.2. 
 Types of Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">3.3. 
 Breaks Between Lines: orphans, widows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a>
@@ -2387,15 +2387,15 @@ Breaks Within Boxes: the break-inside property</a> <a href="#ref-for-comb-one①
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">5.4.1. 
 Joining Boxes for slice</a> <a href="#ref-for-block-flow-direction①">(2)</a> <a href="#ref-for-block-flow-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">4. 
 Rules for Breaking</a>
@@ -2405,22 +2405,22 @@ Breaking into Varying-size Fragmentainers</a>
 Splitting Boxes</a> <a href="#ref-for-block-size③">(2)</a> <a href="#ref-for-block-size④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">4.4. 
 Unforced Breaks</a>
@@ -2430,99 +2430,99 @@ Breaking into Varying-size Fragmentainers</a> <a href="#ref-for-block-start②">
 Transforms, Positioning, and Pagination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.1. 
 Breaking into Varying-size Fragmentainers</a> <a href="#ref-for-inline-size①">(2)</a> <a href="#ref-for-inline-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-writing-mode" class="dfn-panel" data-for="term-for-principal-writing-mode" id="infopanel-for-term-for-principal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-inside">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-inside" class="dfn-panel" data-for="term-for-propdef-page-break-inside" id="infopanel-for-term-for-propdef-page-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-inside" style="display:none">Info about the 'page-break-inside' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-inside">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-inside①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-region-chain">
-   <a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-region-chain" class="dfn-panel" data-for="term-for-region-chain" id="infopanel-for-term-for-region-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-region-chain" style="display:none">Info about the 'region chain' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-chain">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a>
@@ -2530,8 +2530,8 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a hre
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-border-image①">(2)</a>
@@ -2539,42 +2539,42 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a hre
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-border-radius①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page" class="dfn-panel" data-for="term-for-propdef-page" id="infopanel-for-term-for-propdef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">4.3. 
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-progression">
-   <a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-progression" class="dfn-panel" data-for="term-for-page-progression" id="infopanel-for-term-for-page-progression" role="menu">
+   <span id="infopaneltitle-for-term-for-page-progression" style="display:none">Info about the 'page progression' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-progression"> Page Break Values</a> <a href="#ref-for-page-progression①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">1. 
 Introduction</a> <a href="#ref-for-paged-media①">(2)</a>
@@ -2839,15 +2839,15 @@ Fragmentation Model and Terminology</a>
       <td>specified integer
    </table>
   </div>
-  <aside class="dfn-panel" data-for="fragmentation-container">
-   <b><a href="#fragmentation-container">#fragmentation-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-container" class="dfn-panel" data-for="fragmentation-container" id="infopanel-for-fragmentation-container" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' definition.</span><b><a href="#fragmentation-container">#fragmentation-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentainer">
-   <b><a href="#fragmentainer">#fragmentainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentainer" class="dfn-panel" data-for="fragmentainer" id="infopanel-for-fragmentainer" role="dialog">
+   <span id="infopaneltitle-for-fragmentainer" style="display:none">Info about the 'fragmentainer' definition.</span><b><a href="#fragmentainer">#fragmentainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentainer">1. 
 Introduction</a>
@@ -2868,8 +2868,8 @@ Splitting Boxes</a> <a href="#ref-for-fragmentainer②③">(2)</a> <a href="#ref
     <li><a href="#ref-for-fragmentainer②⑤"> Changes</a> <a href="#ref-for-fragmentainer②⑥">(2)</a> <a href="#ref-for-fragmentainer②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-context">
-   <b><a href="#fragmentation-context">#fragmentation-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-context" class="dfn-panel" data-for="fragmentation-context" id="infopanel-for-fragmentation-context" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' definition.</span><b><a href="#fragmentation-context">#fragmentation-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmentation-context①">(2)</a> <a href="#ref-for-fragmentation-context②">(3)</a> <a href="#ref-for-fragmentation-context③">(4)</a>
@@ -2877,8 +2877,8 @@ Fragmentation Model and Terminology</a> <a href="#ref-for-fragmentation-context�
 Nested Fragmentation Flows</a> <a href="#ref-for-fragmentation-context⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmented-flow">
-   <b><a href="#fragmented-flow">#fragmented-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmented-flow" class="dfn-panel" data-for="fragmented-flow" id="infopanel-for-fragmented-flow" role="dialog">
+   <span id="infopaneltitle-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' definition.</span><b><a href="#fragmented-flow">#fragmented-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmented-flow①">(2)</a>
@@ -2894,8 +2894,8 @@ Unforced Breaks</a>
 Optimizing Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-root">
-   <b><a href="#fragmentation-root">#fragmentation-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-root" class="dfn-panel" data-for="fragmentation-root" id="infopanel-for-fragmentation-root" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-root" style="display:none">Info about the 'fragmentation root' definition.</span><b><a href="#fragmentation-root">#fragmentation-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-root">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmentation-root①">(2)</a>
@@ -2905,15 +2905,15 @@ Parallel Fragmentation Flows</a>
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation">
-   <b><a href="#fragmentation">#fragmentation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation" class="dfn-panel" data-for="fragmentation" id="infopanel-for-fragmentation" role="dialog">
+   <span id="infopaneltitle-for-fragmentation" style="display:none">Info about the 'fragmentation' definition.</span><b><a href="#fragmentation">#fragmentation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-fragment">
-   <b><a href="#box-fragment">#box-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-fragment" class="dfn-panel" data-for="box-fragment" id="infopanel-for-box-fragment" role="dialog">
+   <span id="infopaneltitle-for-box-fragment" style="display:none">Info about the 'box fragment' definition.</span><b><a href="#box-fragment">#box-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2. 
 Fragmentation Model and Terminology</a>
@@ -2922,8 +2922,8 @@ Optimizing Unforced Breaks</a> <a href="#ref-for-box-fragment②">(2)</a>
     <li><a href="#ref-for-box-fragment③"> Changes</a> <a href="#ref-for-box-fragment④">(2)</a> <a href="#ref-for-box-fragment⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment">
-   <b><a href="#fragment">#fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment" class="dfn-panel" data-for="fragment" id="infopanel-for-fragment" role="dialog">
+   <span id="infopaneltitle-for-fragment" style="display:none">Info about the 'fragment' definition.</span><b><a href="#fragment">#fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 Fragmentation Model and Terminology</a>
@@ -2932,16 +2932,16 @@ Breaks Between Lines: orphans, widows</a> <a href="#ref-for-fragment②">(2)</a>
     <li><a href="#ref-for-fragment③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remaining-fragmentainer-extent">
-   <b><a href="#remaining-fragmentainer-extent">#remaining-fragmentainer-extent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remaining-fragmentainer-extent" class="dfn-panel" data-for="remaining-fragmentainer-extent" id="infopanel-for-remaining-fragmentainer-extent" role="dialog">
+   <span id="infopaneltitle-for-remaining-fragmentainer-extent" style="display:none">Info about the 'remaining fragmentainer extent' definition.</span><b><a href="#remaining-fragmentainer-extent">#remaining-fragmentainer-extent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remaining-fragmentainer-extent">5.3. 
 Splitting Boxes</a> <a href="#ref-for-remaining-fragmentainer-extent①">(2)</a>
     <li><a href="#ref-for-remaining-fragmentainer-extent②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-break">
-   <b><a href="#fragmentation-break">#fragmentation-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-break" class="dfn-panel" data-for="fragmentation-break" id="infopanel-for-fragmentation-break" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' definition.</span><b><a href="#fragmentation-break">#fragmentation-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">2. 
 Fragmentation Model and Terminology</a>
@@ -2954,8 +2954,8 @@ Transforms, Positioning, and Pagination</a>
     <li><a href="#ref-for-fragmentation-break④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-before">
-   <b><a href="#propdef-break-before">#propdef-break-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-before" class="dfn-panel" data-for="propdef-break-before" id="infopanel-for-propdef-break-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-before" style="display:none">Info about the 'break-before' definition.</span><b><a href="#propdef-break-before">#propdef-break-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">3. 
 Controlling Breaks</a>
@@ -2971,8 +2971,8 @@ Forced Breaks</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-after">
-   <b><a href="#propdef-break-after">#propdef-break-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-after" class="dfn-panel" data-for="propdef-break-after" id="infopanel-for-propdef-break-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-after" style="display:none">Info about the 'break-after' definition.</span><b><a href="#propdef-break-after">#propdef-break-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">3. 
 Controlling Breaks</a>
@@ -2988,29 +2988,29 @@ Forced Breaks</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-break-values">
-   <b><a href="#forced-break-values">#forced-break-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-break-values" class="dfn-panel" data-for="forced-break-values" id="infopanel-for-forced-break-values" role="dialog">
+   <span id="infopaneltitle-for-forced-break-values" style="display:none">Info about the 'forced break values' definition.</span><b><a href="#forced-break-values">#forced-break-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break-values">4.3. 
 Forced Breaks</a> <a href="#ref-for-forced-break-values①">(2)</a> <a href="#ref-for-forced-break-values②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="avoid-break-values">
-   <b><a href="#avoid-break-values">#avoid-break-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-avoid-break-values" class="dfn-panel" data-for="avoid-break-values" id="infopanel-for-avoid-break-values" role="dialog">
+   <span id="infopaneltitle-for-avoid-break-values" style="display:none">Info about the 'avoid break values' definition.</span><b><a href="#avoid-break-values">#avoid-break-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-avoid-break-values">4.3. 
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-auto">
-   <b><a href="#valdef-break-before-auto">#valdef-break-before-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-auto" class="dfn-panel" data-for="valdef-break-before-auto" id="infopanel-for-valdef-break-before-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-break-before-auto">#valdef-break-before-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-auto">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid">
-   <b><a href="#valdef-break-before-avoid">#valdef-break-before-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid" class="dfn-panel" data-for="valdef-break-before-avoid" id="infopanel-for-valdef-break-before-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-break-before-avoid">#valdef-break-before-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3018,8 +3018,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-page">
-   <b><a href="#valdef-break-before-avoid-page">#valdef-break-before-avoid-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-page" class="dfn-panel" data-for="valdef-break-before-avoid-page" id="infopanel-for-valdef-break-before-avoid-page" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-page" style="display:none">Info about the 'avoid-page' definition.</span><b><a href="#valdef-break-before-avoid-page">#valdef-break-before-avoid-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-page">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3027,15 +3027,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-page">
-   <b><a href="#valdef-break-before-page">#valdef-break-before-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-page" class="dfn-panel" data-for="valdef-break-before-page" id="infopanel-for-valdef-break-before-page" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-page" style="display:none">Info about the 'page' definition.</span><b><a href="#valdef-break-before-page">#valdef-break-before-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-page">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-left">
-   <b><a href="#valdef-break-before-left">#valdef-break-before-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-left" class="dfn-panel" data-for="valdef-break-before-left" id="infopanel-for-valdef-break-before-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-break-before-left">#valdef-break-before-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-left">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3043,8 +3043,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-right">
-   <b><a href="#valdef-break-before-right">#valdef-break-before-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-right" class="dfn-panel" data-for="valdef-break-before-right" id="infopanel-for-valdef-break-before-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-break-before-right">#valdef-break-before-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-right">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3052,8 +3052,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-recto">
-   <b><a href="#valdef-break-before-recto">#valdef-break-before-recto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-recto" class="dfn-panel" data-for="valdef-break-before-recto" id="infopanel-for-valdef-break-before-recto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-recto" style="display:none">Info about the 'recto' definition.</span><b><a href="#valdef-break-before-recto">#valdef-break-before-recto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-recto">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3061,8 +3061,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-verso">
-   <b><a href="#valdef-break-before-verso">#valdef-break-before-verso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-verso" class="dfn-panel" data-for="valdef-break-before-verso" id="infopanel-for-valdef-break-before-verso" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-verso" style="display:none">Info about the 'verso' definition.</span><b><a href="#valdef-break-before-verso">#valdef-break-before-verso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-verso">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3070,8 +3070,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-column">
-   <b><a href="#valdef-break-before-avoid-column">#valdef-break-before-avoid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-column" class="dfn-panel" data-for="valdef-break-before-avoid-column" id="infopanel-for-valdef-break-before-avoid-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-column" style="display:none">Info about the 'avoid-column' definition.</span><b><a href="#valdef-break-before-avoid-column">#valdef-break-before-avoid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-column">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3079,15 +3079,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-column">
-   <b><a href="#valdef-break-before-column">#valdef-break-before-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-column" class="dfn-panel" data-for="valdef-break-before-column" id="infopanel-for-valdef-break-before-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-column" style="display:none">Info about the 'column' definition.</span><b><a href="#valdef-break-before-column">#valdef-break-before-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-column">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-region">
-   <b><a href="#valdef-break-before-avoid-region">#valdef-break-before-avoid-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-region" class="dfn-panel" data-for="valdef-break-before-avoid-region" id="infopanel-for-valdef-break-before-avoid-region" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-region" style="display:none">Info about the 'avoid-region' definition.</span><b><a href="#valdef-break-before-avoid-region">#valdef-break-before-avoid-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-region①">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3095,15 +3095,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-region">
-   <b><a href="#valdef-break-before-region">#valdef-break-before-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-region" class="dfn-panel" data-for="valdef-break-before-region" id="infopanel-for-valdef-break-before-region" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-region" style="display:none">Info about the 'region' definition.</span><b><a href="#valdef-break-before-region">#valdef-break-before-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-region①">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propagate">
-   <b><a href="#propagate">#propagate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propagate" class="dfn-panel" data-for="propagate" id="infopanel-for-propagate" role="dialog">
+   <span id="infopaneltitle-for-propagate" style="display:none">Info about the 'propagated' definition.</span><b><a href="#propagate">#propagate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propagate">3.1.1. 
 Child→Parent Break Propagation</a> <a href="#ref-for-propagate①">(2)</a> <a href="#ref-for-propagate②">(3)</a>
@@ -3111,8 +3111,8 @@ Child→Parent Break Propagation</a> <a href="#ref-for-propagate①">(2)</a> <a 
 Forced Breaks</a> <a href="#ref-for-propagate④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-inside">
-   <b><a href="#propdef-break-inside">#propdef-break-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-inside" class="dfn-panel" data-for="propdef-break-inside" id="infopanel-for-propdef-break-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-inside" style="display:none">Info about the 'break-inside' definition.</span><b><a href="#propdef-break-inside">#propdef-break-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">3. 
 Controlling Breaks</a> <a href="#ref-for-propdef-break-inside①">(2)</a>
@@ -3124,22 +3124,22 @@ Page Break Aliases: the page-break-before, page-break-after, and page-break-insi
 Unforced Breaks</a> <a href="#ref-for-propdef-break-inside⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-inside-auto">
-   <b><a href="#valdef-break-inside-auto">#valdef-break-inside-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-inside-auto" class="dfn-panel" data-for="valdef-break-inside-auto" id="infopanel-for-valdef-break-inside-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-inside-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-break-inside-auto">#valdef-break-inside-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-inside-auto">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-inside-avoid">
-   <b><a href="#valdef-break-inside-avoid">#valdef-break-inside-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-inside-avoid" class="dfn-panel" data-for="valdef-break-inside-avoid" id="infopanel-for-valdef-break-inside-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-inside-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-break-inside-avoid">#valdef-break-inside-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-inside-avoid">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-orphans">
-   <b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-orphans" class="dfn-panel" data-for="propdef-orphans" id="infopanel-for-propdef-orphans" role="dialog">
+   <span id="infopaneltitle-for-propdef-orphans" style="display:none">Info about the 'orphans' definition.</span><b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">3. 
 Controlling Breaks</a>
@@ -3152,8 +3152,8 @@ Optimizing Unforced Breaks</a> <a href="#ref-for-propdef-orphans⑦">(2)</a>
     <li><a href="#ref-for-propdef-orphans⑧"> Changes</a> <a href="#ref-for-propdef-orphans⑨">(2)</a> <a href="#ref-for-propdef-orphans①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-widows">
-   <b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-widows" class="dfn-panel" data-for="propdef-widows" id="infopanel-for-propdef-widows" role="dialog">
+   <span id="infopaneltitle-for-propdef-widows" style="display:none">Info about the 'widows' definition.</span><b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">3. 
 Controlling Breaks</a>
@@ -3166,8 +3166,8 @@ Optimizing Unforced Breaks</a> <a href="#ref-for-propdef-widows⑦">(2)</a>
     <li><a href="#ref-for-propdef-widows⑧"> Changes</a> <a href="#ref-for-propdef-widows⑨">(2)</a> <a href="#ref-for-propdef-widows①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="monolithic">
-   <b><a href="#monolithic">#monolithic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-monolithic" class="dfn-panel" data-for="monolithic" id="infopanel-for-monolithic" role="dialog">
+   <span id="infopaneltitle-for-monolithic" style="display:none">Info about the 'monolithic' definition.</span><b><a href="#monolithic">#monolithic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monolithic">4.1. 
 Possible Break Points</a> <a href="#ref-for-monolithic①">(2)</a>
@@ -3178,22 +3178,22 @@ Breaking into Varying-size Fragmentainers</a>
     <li><a href="#ref-for-monolithic④"> Changes</a> <a href="#ref-for-monolithic⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-break">
-   <b><a href="#page-break">#page-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-break" class="dfn-panel" data-for="page-break" id="infopanel-for-page-break" role="dialog">
+   <span id="infopaneltitle-for-page-break" style="display:none">Info about the 'page break' definition.</span><b><a href="#page-break">#page-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-break">4.2. 
 Types of Breaks</a> <a href="#ref-for-page-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="region-break">
-   <b><a href="#region-break">#region-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-region-break" class="dfn-panel" data-for="region-break" id="infopanel-for-region-break" role="dialog">
+   <span id="infopaneltitle-for-region-break" style="display:none">Info about the 'region break' definition.</span><b><a href="#region-break">#region-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-break">4.2. 
 Types of Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-break">
-   <b><a href="#forced-break">#forced-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-break" class="dfn-panel" data-for="forced-break" id="infopanel-for-forced-break" role="dialog">
+   <span id="infopaneltitle-for-forced-break" style="display:none">Info about the 'forced break' definition.</span><b><a href="#forced-break">#forced-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">2.1. 
 Parallel Fragmentation Flows</a>
@@ -3201,15 +3201,15 @@ Parallel Fragmentation Flows</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unforced-break">
-   <b><a href="#unforced-break">#unforced-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unforced-break" class="dfn-panel" data-for="unforced-break" id="infopanel-for-unforced-break" role="dialog">
+   <span id="infopaneltitle-for-unforced-break" style="display:none">Info about the 'unforced break' definition.</span><b><a href="#unforced-break">#unforced-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unforced-break">2.1. 
 Parallel Fragmentation Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-box-decoration-break">
-   <b><a href="#propdef-box-decoration-break">#propdef-box-decoration-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-decoration-break" class="dfn-panel" data-for="propdef-box-decoration-break" id="infopanel-for-propdef-box-decoration-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' definition.</span><b><a href="#propdef-box-decoration-break">#propdef-box-decoration-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2. 
 Fragmentation Model and Terminology</a>
@@ -3224,8 +3224,8 @@ Joining Boxes for slice</a>
     <li><a href="#ref-for-propdef-box-decoration-break⑧"> Changes</a> <a href="#ref-for-propdef-box-decoration-break⑨">(2)</a> <a href="#ref-for-propdef-box-decoration-break①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-decoration-break-clone">
-   <b><a href="#valdef-box-decoration-break-clone">#valdef-box-decoration-break-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-decoration-break-clone" class="dfn-panel" data-for="valdef-box-decoration-break-clone" id="infopanel-for-valdef-box-decoration-break-clone" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-decoration-break-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#valdef-box-decoration-break-clone">#valdef-box-decoration-break-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-decoration-break-clone">4.4. 
 Unforced Breaks</a> <a href="#ref-for-valdef-box-decoration-break-clone">(2)</a>
@@ -3235,8 +3235,8 @@ Adjoining Margins at Breaks</a>
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-decoration-break-slice">
-   <b><a href="#valdef-box-decoration-break-slice">#valdef-box-decoration-break-slice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-decoration-break-slice" class="dfn-panel" data-for="valdef-box-decoration-break-slice" id="infopanel-for-valdef-box-decoration-break-slice" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-decoration-break-slice" style="display:none">Info about the 'slice' definition.</span><b><a href="#valdef-box-decoration-break-slice">#valdef-box-decoration-break-slice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-decoration-break-slice">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-valdef-box-decoration-break-slice①">(2)</a>
@@ -3247,59 +3247,115 @@ Joining Boxes for slice</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-break-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-break-4/Overview.html
@@ -2168,8 +2168,8 @@ on screen, on paper, etc.
    <li><a href="#valdef-break-before-verso">verso</a><span>, in § 3.1</span>
    <li><a href="#propdef-widows">widows</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-border-image①">(2)</a>
@@ -2177,71 +2177,71 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a hre
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-border-radius①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-area">
-   <a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-area" class="dfn-panel" data-for="term-for-border-area" id="infopanel-for-term-for-border-area" role="menu">
+   <span id="infopaneltitle-for-term-for-border-area" style="display:none">Info about the 'border area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin" class="dfn-panel" data-for="term-for-margin" id="infopanel-for-term-for-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">5.2. 
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-area">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-area">https://drafts.csswg.org/css-box-4/#margin-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-area" class="dfn-panel" data-for="term-for-margin-area" id="infopanel-for-term-for-margin-area" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-area" style="display:none">Info about the 'margin area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-area">https://drafts.csswg.org/css-box-4/#margin-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-trim">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-trim">https://drafts.csswg.org/css-box-4/#propdef-margin-trim</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-trim" class="dfn-panel" data-for="term-for-propdef-margin-trim" id="infopanel-for-term-for-propdef-margin-trim" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-trim" style="display:none">Info about the 'margin-trim' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-trim">https://drafts.csswg.org/css-box-4/#propdef-margin-trim</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-trim">5.2. 
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-area">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-area">https://drafts.csswg.org/css-box-4/#padding-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-area" class="dfn-panel" data-for="term-for-padding-area" id="infopanel-for-term-for-padding-area" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-area" style="display:none">Info about the 'padding area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-area">https://drafts.csswg.org/css-box-4/#padding-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-area">2. 
 Fragmentation Model and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.1.1. 
 Child→Parent Break Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-legacy-shorthand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#legacy-shorthand">https://drafts.csswg.org/css-cascade-5/#legacy-shorthand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-legacy-shorthand" class="dfn-panel" data-for="term-for-legacy-shorthand" id="infopanel-for-term-for-legacy-shorthand" role="menu">
+   <span id="infopaneltitle-for-term-for-legacy-shorthand" style="display:none">Info about the 'legacy shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#legacy-shorthand">https://drafts.csswg.org/css-cascade-5/#legacy-shorthand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-shorthand">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.3. 
 Breaks Between Lines: orphans, widows</a>
@@ -2249,15 +2249,15 @@ Breaks Between Lines: orphans, widows</a>
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">2. 
 Fragmentation Model and Terminology</a>
@@ -2267,187 +2267,187 @@ Possible Break Points</a>
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2.1. 
 Parallel Fragmentation Flows</a> <a href="#ref-for-formatting-context①">(2)</a> <a href="#ref-for-formatting-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">3.1.1. 
 Child→Parent Break Propagation</a> <a href="#ref-for-in-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">3.3. 
 Breaks Between Lines: orphans, widows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-table" class="dfn-panel" data-for="term-for-valdef-display-inline-table" id="infopanel-for-term-for-valdef-display-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box"> Generic Break Values</a> <a href="#ref-for-principal-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mask-positioning-area">
-   <a href="https://drafts.fxtf.org/css-masking-1/#mask-positioning-area">https://drafts.fxtf.org/css-masking-1/#mask-positioning-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mask-positioning-area" class="dfn-panel" data-for="term-for-mask-positioning-area" id="infopanel-for-term-for-mask-positioning-area" role="menu">
+   <span id="infopaneltitle-for-term-for-mask-positioning-area" style="display:none">Info about the 'mask positioning area' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#mask-positioning-area">https://drafts.fxtf.org/css-masking-1/#mask-positioning-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-positioning-area">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container"> Generic Break Values</a> <a href="#ref-for-multi-column-container①">(2)</a> <a href="#ref-for-multi-column-container②">(3)</a> <a href="#ref-for-multi-column-container③">(4)</a> <a href="#ref-for-multi-column-container④">(5)</a> <a href="#ref-for-multi-column-container⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-layout">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-layout">https://drafts.csswg.org/css-multicol-1/#multi-column-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-layout" class="dfn-panel" data-for="term-for-multi-column-layout" id="infopanel-for-term-for-multi-column-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-layout" style="display:none">Info about the 'multi-column layout' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-layout">https://drafts.csswg.org/css-multicol-1/#multi-column-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-layout">5.2. 
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4.1. 
 Possible Break Points</a> <a href="#ref-for-propdef-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-scroll">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-scroll" class="dfn-panel" data-for="term-for-valdef-overflow-scroll" id="infopanel-for-term-for-valdef-overflow-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page" class="dfn-panel" data-for="term-for-propdef-page" id="infopanel-for-term-for-propdef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">4.3. 
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-progression">
-   <a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-progression" class="dfn-panel" data-for="term-for-page-progression" id="infopanel-for-term-for-page-progression" role="menu">
+   <span id="infopaneltitle-for-term-for-page-progression" style="display:none">Info about the 'page progression' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-progression"> Page Break Values</a> <a href="#ref-for-page-progression①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-basic-shape-reference-box">
-   <a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-basic-shape-reference-box" class="dfn-panel" data-for="term-for-basic-shape-reference-box" id="infopanel-for-term-for-basic-shape-reference-box" role="menu">
+   <span id="infopaneltitle-for-term-for-basic-shape-reference-box" style="display:none">Info about the 'reference box' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-shape-reference-box">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">5.1. 
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-break">
-   <a href="https://drafts.csswg.org/css-text-4/#line-break">https://drafts.csswg.org/css-text-4/#line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-break" class="dfn-panel" data-for="term-for-line-break" id="infopanel-for-term-for-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-line-break" style="display:none">Info about the 'line break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#line-break">https://drafts.csswg.org/css-text-4/#line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-break">4.2. 
 Types of Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">3.3. 
 Breaks Between Lines: orphans, widows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a>
@@ -2459,8 +2459,8 @@ Adjoining Margins at Breaks: the margin-break property</a> <a href="#ref-for-com
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a>
@@ -2468,15 +2468,15 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a hre
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">5.4.1. 
 Joining Boxes for slice</a> <a href="#ref-for-block-flow-direction①">(2)</a> <a href="#ref-for-block-flow-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">4. 
 Rules for Breaking</a>
@@ -2486,8 +2486,8 @@ Breaking into Varying-size Fragmentainers</a>
 Splitting Boxes</a> <a href="#ref-for-block-size③">(2)</a> <a href="#ref-for-block-size④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2. 
 Fragmentation Model and Terminology</a>
@@ -2495,15 +2495,15 @@ Fragmentation Model and Terminology</a>
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">4.4. 
 Unforced Breaks</a>
@@ -2513,78 +2513,78 @@ Breaking into Varying-size Fragmentainers</a> <a href="#ref-for-block-start②">
 Transforms, Positioning, and Pagination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.1. 
 Breaking into Varying-size Fragmentainers</a> <a href="#ref-for-inline-size①">(2)</a> <a href="#ref-for-inline-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-height">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-height">https://drafts.csswg.org/css-writing-modes-4/#logical-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-height" class="dfn-panel" data-for="term-for-logical-height" id="infopanel-for-term-for-logical-height" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-height" style="display:none">Info about the 'logical height' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-height">https://drafts.csswg.org/css-writing-modes-4/#logical-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-height">4.1. 
 Possible Break Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-writing-mode" class="dfn-panel" data-for="term-for-principal-writing-mode" id="infopanel-for-term-for-principal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-inside">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-inside" class="dfn-panel" data-for="term-for-propdef-page-break-inside" id="infopanel-for-term-for-propdef-page-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-inside" style="display:none">Info about the 'page-break-inside' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-inside">3.4. 
 Page Break Aliases: the page-break-before, page-break-after, and page-break-inside properties</a> <a href="#ref-for-propdef-page-break-inside①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-region-chain">
-   <a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-region-chain" class="dfn-panel" data-for="term-for-region-chain" id="infopanel-for-term-for-region-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-region-chain" style="display:none">Info about the 'region chain' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-chain">5.4.1. 
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">1. 
 Introduction</a> <a href="#ref-for-paged-media①">(2)</a>
@@ -2879,8 +2879,8 @@ Fragmentation Model and Terminology</a>
 	Also, if only one <a class="css" data-link-type="maybe" href="#valdef-margin-break-keep">keep</a> is specified, does it apply only to the before margin or both sides?
 	See <a href="https://github.com/w3c/csswg-drafts/issues/3254">discussion</a>. <a class="issue-return" href="#issue-c8907d92" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="fragmentation-container">
-   <b><a href="#fragmentation-container">#fragmentation-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-container" class="dfn-panel" data-for="fragmentation-container" id="infopanel-for-fragmentation-container" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' definition.</span><b><a href="#fragmentation-container">#fragmentation-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">1. 
 Introduction</a>
@@ -2888,8 +2888,8 @@ Introduction</a>
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentainer">
-   <b><a href="#fragmentainer">#fragmentainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentainer" class="dfn-panel" data-for="fragmentainer" id="infopanel-for-fragmentainer" role="dialog">
+   <span id="infopaneltitle-for-fragmentainer" style="display:none">Info about the 'fragmentainer' definition.</span><b><a href="#fragmentainer">#fragmentainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentainer">1. 
 Introduction</a>
@@ -2909,8 +2909,8 @@ Optimizing Unforced Breaks</a> <a href="#ref-for-fragmentainer②⓪">(2)</a> <a
 Splitting Boxes</a> <a href="#ref-for-fragmentainer②③">(2)</a> <a href="#ref-for-fragmentainer②④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-context">
-   <b><a href="#fragmentation-context">#fragmentation-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-context" class="dfn-panel" data-for="fragmentation-context" id="infopanel-for-fragmentation-context" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' definition.</span><b><a href="#fragmentation-context">#fragmentation-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmentation-context①">(2)</a> <a href="#ref-for-fragmentation-context②">(3)</a> <a href="#ref-for-fragmentation-context③">(4)</a>
@@ -2921,8 +2921,8 @@ Nested Fragmentation Flows</a> <a href="#ref-for-fragmentation-context⑤">(2)</
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmented-flow">
-   <b><a href="#fragmented-flow">#fragmented-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmented-flow" class="dfn-panel" data-for="fragmented-flow" id="infopanel-for-fragmented-flow" role="dialog">
+   <span id="infopaneltitle-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' definition.</span><b><a href="#fragmented-flow">#fragmented-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmented-flow①">(2)</a>
@@ -2938,8 +2938,8 @@ Unforced Breaks</a>
 Optimizing Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-root">
-   <b><a href="#fragmentation-root">#fragmentation-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-root" class="dfn-panel" data-for="fragmentation-root" id="infopanel-for-fragmentation-root" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-root" style="display:none">Info about the 'fragmentation root' definition.</span><b><a href="#fragmentation-root">#fragmentation-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-root">2. 
 Fragmentation Model and Terminology</a> <a href="#ref-for-fragmentation-root①">(2)</a>
@@ -2949,15 +2949,15 @@ Parallel Fragmentation Flows</a>
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation">
-   <b><a href="#fragmentation">#fragmentation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation" class="dfn-panel" data-for="fragmentation" id="infopanel-for-fragmentation" role="dialog">
+   <span id="infopaneltitle-for-fragmentation" style="display:none">Info about the 'fragmentation' definition.</span><b><a href="#fragmentation">#fragmentation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-fragment">
-   <b><a href="#box-fragment">#box-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-fragment" class="dfn-panel" data-for="box-fragment" id="infopanel-for-box-fragment" role="dialog">
+   <span id="infopaneltitle-for-box-fragment" style="display:none">Info about the 'box fragment' definition.</span><b><a href="#box-fragment">#box-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2. 
 Fragmentation Model and Terminology</a>
@@ -2965,8 +2965,8 @@ Fragmentation Model and Terminology</a>
 Optimizing Unforced Breaks</a> <a href="#ref-for-box-fragment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment">
-   <b><a href="#fragment">#fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment" class="dfn-panel" data-for="fragment" id="infopanel-for-fragment" role="dialog">
+   <span id="infopaneltitle-for-fragment" style="display:none">Info about the 'fragment' definition.</span><b><a href="#fragment">#fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 Fragmentation Model and Terminology</a>
@@ -2974,8 +2974,8 @@ Fragmentation Model and Terminology</a>
 Breaks Between Lines: orphans, widows</a> <a href="#ref-for-fragment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remaining-fragmentainer-extent">
-   <b><a href="#remaining-fragmentainer-extent">#remaining-fragmentainer-extent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remaining-fragmentainer-extent" class="dfn-panel" data-for="remaining-fragmentainer-extent" id="infopanel-for-remaining-fragmentainer-extent" role="dialog">
+   <span id="infopaneltitle-for-remaining-fragmentainer-extent" style="display:none">Info about the 'remaining fragmentainer extent' definition.</span><b><a href="#remaining-fragmentainer-extent">#remaining-fragmentainer-extent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remaining-fragmentainer-extent">5.2. 
 Adjoining Margins at Breaks: the margin-break property</a>
@@ -2983,8 +2983,8 @@ Adjoining Margins at Breaks: the margin-break property</a>
 Splitting Boxes</a> <a href="#ref-for-remaining-fragmentainer-extent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragmentation-break">
-   <b><a href="#fragmentation-break">#fragmentation-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragmentation-break" class="dfn-panel" data-for="fragmentation-break" id="infopanel-for-fragmentation-break" role="dialog">
+   <span id="infopaneltitle-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' definition.</span><b><a href="#fragmentation-break">#fragmentation-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">4.5. 
 Optimizing Unforced Breaks</a>
@@ -2996,8 +2996,8 @@ Splitting Boxes</a>
 Transforms, Positioning, and Pagination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-before">
-   <b><a href="#propdef-break-before">#propdef-break-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-before" class="dfn-panel" data-for="propdef-break-before" id="infopanel-for-propdef-break-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-before" style="display:none">Info about the 'break-before' definition.</span><b><a href="#propdef-break-before">#propdef-break-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before①">1. 
 Introduction</a>
@@ -3016,8 +3016,8 @@ Unforced Breaks</a>
     <li><a href="#ref-for-propdef-break-before⑨"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-after">
-   <b><a href="#propdef-break-after">#propdef-break-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-after" class="dfn-panel" data-for="propdef-break-after" id="infopanel-for-propdef-break-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-after" style="display:none">Info about the 'break-after' definition.</span><b><a href="#propdef-break-after">#propdef-break-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after①">1. 
 Introduction</a>
@@ -3036,29 +3036,29 @@ Unforced Breaks</a>
     <li><a href="#ref-for-propdef-break-after⑨"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-break-values">
-   <b><a href="#forced-break-values">#forced-break-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-break-values" class="dfn-panel" data-for="forced-break-values" id="infopanel-for-forced-break-values" role="dialog">
+   <span id="infopaneltitle-for-forced-break-values" style="display:none">Info about the 'forced break values' definition.</span><b><a href="#forced-break-values">#forced-break-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break-values">4.3. 
 Forced Breaks</a> <a href="#ref-for-forced-break-values①">(2)</a> <a href="#ref-for-forced-break-values②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="avoid-break-values">
-   <b><a href="#avoid-break-values">#avoid-break-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-avoid-break-values" class="dfn-panel" data-for="avoid-break-values" id="infopanel-for-avoid-break-values" role="dialog">
+   <span id="infopaneltitle-for-avoid-break-values" style="display:none">Info about the 'avoid break values' definition.</span><b><a href="#avoid-break-values">#avoid-break-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-avoid-break-values">4.3. 
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-auto">
-   <b><a href="#valdef-break-before-auto">#valdef-break-before-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-auto" class="dfn-panel" data-for="valdef-break-before-auto" id="infopanel-for-valdef-break-before-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-break-before-auto">#valdef-break-before-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-auto">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid">
-   <b><a href="#valdef-break-before-avoid">#valdef-break-before-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid" class="dfn-panel" data-for="valdef-break-before-avoid" id="infopanel-for-valdef-break-before-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-break-before-avoid">#valdef-break-before-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3066,8 +3066,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-always">
-   <b><a href="#valdef-break-before-always">#valdef-break-before-always</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-always" class="dfn-panel" data-for="valdef-break-before-always" id="infopanel-for-valdef-break-before-always" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-always" style="display:none">Info about the 'always' definition.</span><b><a href="#valdef-break-before-always">#valdef-break-before-always</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-always">1. 
 Introduction</a>
@@ -3076,8 +3076,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
     <li><a href="#ref-for-valdef-break-before-always②"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-all">
-   <b><a href="#valdef-break-before-all">#valdef-break-before-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-all" class="dfn-panel" data-for="valdef-break-before-all" id="infopanel-for-valdef-break-before-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-break-before-all">#valdef-break-before-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-all①">1. 
 Introduction</a>
@@ -3086,8 +3086,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
     <li><a href="#ref-for-valdef-break-before-all③"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-page">
-   <b><a href="#valdef-break-before-avoid-page">#valdef-break-before-avoid-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-page" class="dfn-panel" data-for="valdef-break-before-avoid-page" id="infopanel-for-valdef-break-before-avoid-page" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-page" style="display:none">Info about the 'avoid-page' definition.</span><b><a href="#valdef-break-before-avoid-page">#valdef-break-before-avoid-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-page">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3095,15 +3095,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-page">
-   <b><a href="#valdef-break-before-page">#valdef-break-before-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-page" class="dfn-panel" data-for="valdef-break-before-page" id="infopanel-for-valdef-break-before-page" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-page" style="display:none">Info about the 'page' definition.</span><b><a href="#valdef-break-before-page">#valdef-break-before-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-page">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-left">
-   <b><a href="#valdef-break-before-left">#valdef-break-before-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-left" class="dfn-panel" data-for="valdef-break-before-left" id="infopanel-for-valdef-break-before-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-break-before-left">#valdef-break-before-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-left">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3111,8 +3111,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-right">
-   <b><a href="#valdef-break-before-right">#valdef-break-before-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-right" class="dfn-panel" data-for="valdef-break-before-right" id="infopanel-for-valdef-break-before-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-break-before-right">#valdef-break-before-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-right">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3120,8 +3120,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-recto">
-   <b><a href="#valdef-break-before-recto">#valdef-break-before-recto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-recto" class="dfn-panel" data-for="valdef-break-before-recto" id="infopanel-for-valdef-break-before-recto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-recto" style="display:none">Info about the 'recto' definition.</span><b><a href="#valdef-break-before-recto">#valdef-break-before-recto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-recto">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3129,8 +3129,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-verso">
-   <b><a href="#valdef-break-before-verso">#valdef-break-before-verso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-verso" class="dfn-panel" data-for="valdef-break-before-verso" id="infopanel-for-valdef-break-before-verso" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-verso" style="display:none">Info about the 'verso' definition.</span><b><a href="#valdef-break-before-verso">#valdef-break-before-verso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-verso">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3138,8 +3138,8 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-column">
-   <b><a href="#valdef-break-before-avoid-column">#valdef-break-before-avoid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-column" class="dfn-panel" data-for="valdef-break-before-avoid-column" id="infopanel-for-valdef-break-before-avoid-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-column" style="display:none">Info about the 'avoid-column' definition.</span><b><a href="#valdef-break-before-avoid-column">#valdef-break-before-avoid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-column">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3147,15 +3147,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-column">
-   <b><a href="#valdef-break-before-column">#valdef-break-before-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-column" class="dfn-panel" data-for="valdef-break-before-column" id="infopanel-for-valdef-break-before-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-column" style="display:none">Info about the 'column' definition.</span><b><a href="#valdef-break-before-column">#valdef-break-before-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-column">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-avoid-region">
-   <b><a href="#valdef-break-before-avoid-region">#valdef-break-before-avoid-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-avoid-region" class="dfn-panel" data-for="valdef-break-before-avoid-region" id="infopanel-for-valdef-break-before-avoid-region" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-avoid-region" style="display:none">Info about the 'avoid-region' definition.</span><b><a href="#valdef-break-before-avoid-region">#valdef-break-before-avoid-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-region">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
@@ -3163,15 +3163,15 @@ Breaks Between Boxes: the break-before and break-after properties</a>
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-before-region">
-   <b><a href="#valdef-break-before-region">#valdef-break-before-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-before-region" class="dfn-panel" data-for="valdef-break-before-region" id="infopanel-for-valdef-break-before-region" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-before-region" style="display:none">Info about the 'region' definition.</span><b><a href="#valdef-break-before-region">#valdef-break-before-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-region">3.1. 
 Breaks Between Boxes: the break-before and break-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propagate">
-   <b><a href="#propagate">#propagate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propagate" class="dfn-panel" data-for="propagate" id="infopanel-for-propagate" role="dialog">
+   <span id="infopaneltitle-for-propagate" style="display:none">Info about the 'propagated' definition.</span><b><a href="#propagate">#propagate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propagate">3.1.1. 
 Child→Parent Break Propagation</a> <a href="#ref-for-propagate①">(2)</a> <a href="#ref-for-propagate②">(3)</a>
@@ -3179,8 +3179,8 @@ Child→Parent Break Propagation</a> <a href="#ref-for-propagate①">(2)</a> <a 
 Forced Breaks</a> <a href="#ref-for-propagate④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-break-inside">
-   <b><a href="#propdef-break-inside">#propdef-break-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-break-inside" class="dfn-panel" data-for="propdef-break-inside" id="infopanel-for-propdef-break-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-break-inside" style="display:none">Info about the 'break-inside' definition.</span><b><a href="#propdef-break-inside">#propdef-break-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">3. 
 Controlling Breaks</a> <a href="#ref-for-propdef-break-inside①">(2)</a>
@@ -3192,22 +3192,22 @@ Page Break Aliases: the page-break-before, page-break-after, and page-break-insi
 Unforced Breaks</a> <a href="#ref-for-propdef-break-inside⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-inside-auto">
-   <b><a href="#valdef-break-inside-auto">#valdef-break-inside-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-inside-auto" class="dfn-panel" data-for="valdef-break-inside-auto" id="infopanel-for-valdef-break-inside-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-inside-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-break-inside-auto">#valdef-break-inside-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-inside-auto">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-break-inside-avoid">
-   <b><a href="#valdef-break-inside-avoid">#valdef-break-inside-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-break-inside-avoid" class="dfn-panel" data-for="valdef-break-inside-avoid" id="infopanel-for-valdef-break-inside-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-break-inside-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-break-inside-avoid">#valdef-break-inside-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-inside-avoid">4.4. 
 Unforced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-orphans">
-   <b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-orphans" class="dfn-panel" data-for="propdef-orphans" id="infopanel-for-propdef-orphans" role="dialog">
+   <span id="infopaneltitle-for-propdef-orphans" style="display:none">Info about the 'orphans' definition.</span><b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">3. 
 Controlling Breaks</a>
@@ -3219,8 +3219,8 @@ Unforced Breaks</a>
 Optimizing Unforced Breaks</a> <a href="#ref-for-propdef-orphans⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-widows">
-   <b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-widows" class="dfn-panel" data-for="propdef-widows" id="infopanel-for-propdef-widows" role="dialog">
+   <span id="infopaneltitle-for-propdef-widows" style="display:none">Info about the 'widows' definition.</span><b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">3. 
 Controlling Breaks</a>
@@ -3232,8 +3232,8 @@ Unforced Breaks</a>
 Optimizing Unforced Breaks</a> <a href="#ref-for-propdef-widows⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="monolithic">
-   <b><a href="#monolithic">#monolithic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-monolithic" class="dfn-panel" data-for="monolithic" id="infopanel-for-monolithic" role="dialog">
+   <span id="infopaneltitle-for-monolithic" style="display:none">Info about the 'monolithic' definition.</span><b><a href="#monolithic">#monolithic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monolithic">4.1. 
 Possible Break Points</a> <a href="#ref-for-monolithic①">(2)</a>
@@ -3243,30 +3243,30 @@ Unforced Breaks</a>
 Breaking into Varying-size Fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-break">
-   <b><a href="#page-break">#page-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-break" class="dfn-panel" data-for="page-break" id="infopanel-for-page-break" role="dialog">
+   <span id="infopaneltitle-for-page-break" style="display:none">Info about the 'page break' definition.</span><b><a href="#page-break">#page-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-break"> Generic Break Values</a> <a href="#ref-for-page-break①">(2)</a>
     <li><a href="#ref-for-page-break②">4.2. 
 Types of Breaks</a> <a href="#ref-for-page-break③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="column-break">
-   <b><a href="#column-break">#column-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-column-break" class="dfn-panel" data-for="column-break" id="infopanel-for-column-break" role="dialog">
+   <span id="infopaneltitle-for-column-break" style="display:none">Info about the 'column break' definition.</span><b><a href="#column-break">#column-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-break"> Generic Break Values</a> <a href="#ref-for-column-break①">(2)</a> <a href="#ref-for-column-break②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="region-break">
-   <b><a href="#region-break">#region-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-region-break" class="dfn-panel" data-for="region-break" id="infopanel-for-region-break" role="dialog">
+   <span id="infopaneltitle-for-region-break" style="display:none">Info about the 'region break' definition.</span><b><a href="#region-break">#region-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-break"> Generic Break Values</a>
     <li><a href="#ref-for-region-break①">4.2. 
 Types of Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-break">
-   <b><a href="#forced-break">#forced-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-break" class="dfn-panel" data-for="forced-break" id="infopanel-for-forced-break" role="dialog">
+   <span id="infopaneltitle-for-forced-break" style="display:none">Info about the 'forced break' definition.</span><b><a href="#forced-break">#forced-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">2.1. 
 Parallel Fragmentation Flows</a>
@@ -3274,15 +3274,15 @@ Parallel Fragmentation Flows</a>
 Forced Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unforced-break">
-   <b><a href="#unforced-break">#unforced-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unforced-break" class="dfn-panel" data-for="unforced-break" id="infopanel-for-unforced-break" role="dialog">
+   <span id="infopaneltitle-for-unforced-break" style="display:none">Info about the 'unforced break' definition.</span><b><a href="#unforced-break">#unforced-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unforced-break">2.1. 
 Parallel Fragmentation Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-break">
-   <b><a href="#propdef-margin-break">#propdef-margin-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-break" class="dfn-panel" data-for="propdef-margin-break" id="infopanel-for-propdef-margin-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-break" style="display:none">Info about the 'margin-break' definition.</span><b><a href="#propdef-margin-break">#propdef-margin-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-break">1. 
 Introduction</a>
@@ -3291,15 +3291,15 @@ Adjoining Margins at Breaks: the margin-break property</a> <a href="#ref-for-pro
     <li><a href="#ref-for-propdef-margin-break⑦"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-margin-break-keep">
-   <b><a href="#valdef-margin-break-keep">#valdef-margin-break-keep</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-margin-break-keep" class="dfn-panel" data-for="valdef-margin-break-keep" id="infopanel-for-valdef-margin-break-keep" role="dialog">
+   <span id="infopaneltitle-for-valdef-margin-break-keep" style="display:none">Info about the 'keep' definition.</span><b><a href="#valdef-margin-break-keep">#valdef-margin-break-keep</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-margin-break-keep">5.2. 
 Adjoining Margins at Breaks: the margin-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-box-decoration-break">
-   <b><a href="#propdef-box-decoration-break">#propdef-box-decoration-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-decoration-break" class="dfn-panel" data-for="propdef-box-decoration-break" id="infopanel-for-propdef-box-decoration-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' definition.</span><b><a href="#propdef-box-decoration-break">#propdef-box-decoration-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2. 
 Fragmentation Model and Terminology</a>
@@ -3313,8 +3313,8 @@ Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a hre
 Joining Boxes for slice</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-decoration-break-clone">
-   <b><a href="#valdef-box-decoration-break-clone">#valdef-box-decoration-break-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-decoration-break-clone" class="dfn-panel" data-for="valdef-box-decoration-break-clone" id="infopanel-for-valdef-box-decoration-break-clone" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-decoration-break-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#valdef-box-decoration-break-clone">#valdef-box-decoration-break-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-decoration-break-clone">4.4. 
 Unforced Breaks</a> <a href="#ref-for-valdef-box-decoration-break-clone">(2)</a>
@@ -3322,8 +3322,8 @@ Unforced Breaks</a> <a href="#ref-for-valdef-box-decoration-break-clone">(2)</a>
 Fragmented Borders and Backgrounds: the box-decoration-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-decoration-break-slice">
-   <b><a href="#valdef-box-decoration-break-slice">#valdef-box-decoration-break-slice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-decoration-break-slice" class="dfn-panel" data-for="valdef-box-decoration-break-slice" id="infopanel-for-valdef-box-decoration-break-slice" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-decoration-break-slice" style="display:none">Info about the 'slice' definition.</span><b><a href="#valdef-box-decoration-break-slice">#valdef-box-decoration-break-slice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-decoration-break-slice">5.4. 
 Fragmented Borders and Backgrounds: the box-decoration-break property</a> <a href="#ref-for-valdef-box-decoration-break-slice①">(2)</a>
@@ -3333,59 +3333,115 @@ Joining Boxes for slice</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-cascade-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-cascade-3/Overview.html
@@ -2198,8 +2198,8 @@ potentially allowing sensitive data to be inferred from the computed styles they
    <li><a href="#cascade-origin-user">user-origin</a><span>, in § 6.2</span>
    <li><a href="#cascade-origin-user">user style sheet</a><span>, in § 6.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-auto">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-auto" class="dfn-panel" data-for="term-for-valdef-align-self-auto" id="infopanel-for-term-for-valdef-align-self-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-auto">4.4. 
 Computed Values</a>
@@ -2207,92 +2207,92 @@ Computed Values</a>
 Used Values</a> <a href="#ref-for-valdef-align-self-auto②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-dotted">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-dotted" class="dfn-panel" data-for="term-for-valdef-line-style-dotted" id="infopanel-for-term-for-valdef-line-style-dotted" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-dotted" style="display:none">Info about the 'dotted' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-dotted">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">4.5. 
 Used Values</a> <a href="#ref-for-propdef-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">4.6. 
 Actual Values</a>
@@ -2300,92 +2300,92 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-page">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-page" class="dfn-panel" data-for="term-for-valdef-break-before-page" id="infopanel-for-term-for-valdef-break-before-page" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-page">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2.1. 
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">4.6. 
 Actual Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">4.7. 
 Examples</a> <a href="#ref-for-propdef-list-style-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.5. 
 Used Values</a>
@@ -2393,99 +2393,99 @@ Used Values</a>
 Examples</a> <a href="#ref-for-propdef-width②">(2)</a> <a href="#ref-for-propdef-width③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-charset">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-charset" class="dfn-panel" data-for="term-for-at-ruledef-charset" id="infopanel-for-term-for-at-ruledef-charset" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-charset" style="display:none">Info about the '@charset' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-charset">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-encoding">
-   <a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-encoding" class="dfn-panel" data-for="term-for-environment-encoding" id="infopanel-for-term-for-environment-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-encoding" style="display:none">Info about the 'environment encoding' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-encoding">2.2. 
 Processing Stylesheet Imports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-property-declarations">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-property-declarations" class="dfn-panel" data-for="term-for-css-property-declarations" id="infopanel-for-term-for-css-property-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-css-property-declarations" style="display:none">Info about the 'property declarations' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property-declarations">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">6.3. 
 Important Declarations: the !important annotation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">4.3. 
 Specified Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vh">
-   <a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vh" class="dfn-panel" data-for="term-for-vh" id="infopanel-for-term-for-vh" role="menu">
+   <span id="infopaneltitle-for-term-for-vh" style="display:none">Info about the 'vh' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vh">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vw">
-   <a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vw" class="dfn-panel" data-for="term-for-vw" id="infopanel-for-term-for-vw" role="menu">
+   <span id="infopaneltitle-for-term-for-vw" style="display:none">Info about the 'vw' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vw">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Importing Style Sheets: the @import rule</a>
@@ -2493,57 +2493,57 @@ Importing Style Sheets: the @import rule</a>
 Resetting All Properties: the all property</a> <a href="#ref-for-comb-one②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">3.1. 
 Resetting All Properties: the all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.1. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.1. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.1. 
 Resetting All Properties: the all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">4.6. 
 Actual Values</a>
@@ -2551,8 +2551,8 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-red">
-   <a href="https://drafts.csswg.org/css2/#valdef-color-red">https://drafts.csswg.org/css2/#valdef-color-red</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-red" class="dfn-panel" data-for="term-for-valdef-color-red" id="infopanel-for-term-for-valdef-color-red" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-red" style="display:none">Info about the 'red' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-color-red">https://drafts.csswg.org/css2/#valdef-color-red</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">1. 
 Introduction</a>
@@ -2560,28 +2560,28 @@ Introduction</a>
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-protocol">
-   <a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-protocol" class="dfn-panel" data-for="term-for-cors-protocol" id="infopanel-for-term-for-cors-protocol" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-protocol" style="display:none">Info about the 'cors protocol' external reference.</span><a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-protocol"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-s-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-s-element" class="dfn-panel" data-for="term-for-the-s-element" id="infopanel-for-term-for-the-s-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-s-element" style="display:none">Info about the 's' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-s-element">6.4. 
 Precedence of Non-CSS Presentational Hints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query-list" class="dfn-panel" data-for="term-for-typedef-media-query-list" id="infopanel-for-term-for-typedef-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
@@ -2589,15 +2589,15 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-que
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query" class="dfn-panel" data-for="term-for-typedef-media-query" id="infopanel-for-term-for-typedef-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query" style="display:none">Info about the '&lt;media-query>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">4.5. 
 Used Values</a> <a href="#ref-for-pseudo-element①">(2)</a>
@@ -2864,8 +2864,8 @@ Inheritance</a> <a href="#ref-for-pseudo-element③">(2)</a>
       <td>see individual properties
    </table>
   </div>
-  <aside class="dfn-panel" data-for="at-ruledef-import">
-   <b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-import" class="dfn-panel" data-for="at-ruledef-import" id="infopanel-for-at-ruledef-import" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-import" style="display:none">Info about the '@import' definition.</span><b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-at-ruledef-import①">(2)</a> <a href="#ref-for-at-ruledef-import②">(3)</a> <a href="#ref-for-at-ruledef-import③">(4)</a> <a href="#ref-for-at-ruledef-import④">(5)</a> <a href="#ref-for-at-ruledef-import⑤">(6)</a> <a href="#ref-for-at-ruledef-import⑥">(7)</a> <a href="#ref-for-at-ruledef-import⑦">(8)</a> <a href="#ref-for-at-ruledef-import⑧">(9)</a>
@@ -2876,15 +2876,15 @@ Cascade Sorting Order</a> <a href="#ref-for-at-ruledef-import①②">(2)</a>
     <li><a href="#ref-for-at-ruledef-import①③"> Privacy and Security Considerations</a> <a href="#ref-for-at-ruledef-import①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-conditions">
-   <b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-conditions" class="dfn-panel" data-for="import-conditions" id="infopanel-for-import-conditions" role="dialog">
+   <span id="infopaneltitle-for-import-conditions" style="display:none">Info about the 'import conditions' definition.</span><b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-conditions">2.1. 
 Conditional @import Rules</a> <a href="#ref-for-import-conditions①">(2)</a> <a href="#ref-for-import-conditions②">(3)</a> <a href="#ref-for-import-conditions③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shorthand-property">
-   <b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shorthand-property" class="dfn-panel" data-for="shorthand-property" id="infopanel-for-shorthand-property" role="dialog">
+   <span id="infopaneltitle-for-shorthand-property" style="display:none">Info about the 'shorthand properties' definition.</span><b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. 
 Shorthand Properties</a> <a href="#ref-for-shorthand-property①">(2)</a> <a href="#ref-for-shorthand-property②">(3)</a> <a href="#ref-for-shorthand-property③">(4)</a> <a href="#ref-for-shorthand-property④">(5)</a> <a href="#ref-for-shorthand-property⑤">(6)</a> <a href="#ref-for-shorthand-property⑥">(7)</a> <a href="#ref-for-shorthand-property⑦">(8)</a> <a href="#ref-for-shorthand-property⑧">(9)</a>
@@ -2896,22 +2896,22 @@ Important Declarations: the !important annotation</a>
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="longhand">
-   <b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-longhand" class="dfn-panel" data-for="longhand" id="infopanel-for-longhand" role="dialog">
+   <span id="infopaneltitle-for-longhand" style="display:none">Info about the 'longhand sub-properties' definition.</span><b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3. 
 Shorthand Properties</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a> <a href="#ref-for-longhand③">(4)</a> <a href="#ref-for-longhand④">(5)</a> <a href="#ref-for-longhand⑤">(6)</a> <a href="#ref-for-longhand⑥">(7)</a> <a href="#ref-for-longhand⑦">(8)</a> <a href="#ref-for-longhand⑧">(9)</a> <a href="#ref-for-longhand⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reset-only-sub-property">
-   <b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reset-only-sub-property" class="dfn-panel" data-for="reset-only-sub-property" id="infopanel-for-reset-only-sub-property" role="dialog">
+   <span id="infopaneltitle-for-reset-only-sub-property" style="display:none">Info about the 'reset-only sub-property' definition.</span><b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-only-sub-property">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-all">
-   <b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-all" class="dfn-panel" data-for="propdef-all" id="infopanel-for-propdef-all" role="dialog">
+   <span id="infopaneltitle-for-propdef-all" style="display:none">Info about the 'all' definition.</span><b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">3.1. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-all①">(2)</a> <a href="#ref-for-propdef-all②">(3)</a>
@@ -2919,8 +2919,8 @@ Resetting All Properties: the all property</a> <a href="#ref-for-propdef-all①"
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-value">
-   <b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-value" class="dfn-panel" data-for="declared-value" id="infopanel-for-declared-value" role="dialog">
+   <span id="infopaneltitle-for-declared-value" style="display:none">Info about the 'declared value' definition.</span><b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-value">4. 
 Value Processing</a> <a href="#ref-for-declared-value①">(2)</a>
@@ -2936,8 +2936,8 @@ Cascade Sorting Order</a>
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascaded-value">
-   <b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascaded-value" class="dfn-panel" data-for="cascaded-value" id="infopanel-for-cascaded-value" role="dialog">
+   <span id="infopaneltitle-for-cascaded-value" style="display:none">Info about the 'cascaded value' definition.</span><b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascaded-value">4. 
 Value Processing</a> <a href="#ref-for-cascaded-value①">(2)</a>
@@ -2955,8 +2955,8 @@ Explicit Inheritance: the inherit keyword</a>
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-value">
-   <b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-value" class="dfn-panel" data-for="specified-value" id="infopanel-for-specified-value" role="dialog">
+   <span id="infopaneltitle-for-specified-value" style="display:none">Info about the 'specified value' definition.</span><b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">1. 
 Introduction</a>
@@ -2976,8 +2976,8 @@ Resetting a Property: the initial keyword</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-value">
-   <b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-value" class="dfn-panel" data-for="computed-value" id="infopanel-for-computed-value" role="dialog">
+   <span id="infopaneltitle-for-computed-value" style="display:none">Info about the 'computed value' definition.</span><b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4. 
 Value Processing</a> <a href="#ref-for-computed-value①">(2)</a>
@@ -2991,8 +2991,8 @@ Inheritance</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-value">
-   <b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-value" class="dfn-panel" data-for="used-value" id="infopanel-for-used-value" role="dialog">
+   <span id="infopaneltitle-for-used-value" style="display:none">Info about the 'used value' definition.</span><b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4. 
 Value Processing</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a>
@@ -3004,22 +3004,22 @@ Used Values</a> <a href="#ref-for-used-value⑤">(2)</a> <a href="#ref-for-used-
 Actual Values</a> <a href="#ref-for-used-value⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="applies-to">
-   <b><a href="#applies-to">#applies-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-applies-to" class="dfn-panel" data-for="applies-to" id="infopanel-for-applies-to" role="dialog">
+   <span id="infopaneltitle-for-applies-to" style="display:none">Info about the 'apply to' definition.</span><b><a href="#applies-to">#applies-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-applies-to">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-value">
-   <b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-value" class="dfn-panel" data-for="actual-value" id="infopanel-for-actual-value" role="dialog">
+   <span id="infopaneltitle-for-actual-value" style="display:none">Info about the 'actual value' definition.</span><b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">4. 
 Value Processing</a> <a href="#ref-for-actual-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade">
-   <b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade" class="dfn-panel" data-for="cascade" id="infopanel-for-cascade" role="dialog">
+   <span id="infopaneltitle-for-cascade" style="display:none">Info about the 'cascade' definition.</span><b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">1. 
 Introduction</a> <a href="#ref-for-cascade">(2)</a>
@@ -3043,15 +3043,15 @@ Erasing All Declarations: the unset keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="output-of-the-cascade">
-   <b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-output-of-the-cascade" class="dfn-panel" data-for="output-of-the-cascade" id="infopanel-for-output-of-the-cascade" role="dialog">
+   <span id="infopaneltitle-for-output-of-the-cascade" style="display:none">Info about the 'output of the cascade' definition.</span><b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-of-the-cascade">4.2. 
 Cascaded Values</a> <a href="#ref-for-output-of-the-cascade①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin">
-   <b><a href="#origin">#origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin" class="dfn-panel" data-for="origin" id="infopanel-for-origin" role="dialog">
+   <span id="infopaneltitle-for-origin" style="display:none">Info about the 'cascade origin' definition.</span><b><a href="#origin">#origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.2. 
 Processing Stylesheet Imports</a> <a href="#ref-for-origin①">(2)</a>
@@ -3061,8 +3061,8 @@ Cascade Sorting Order</a> <a href="#ref-for-origin③">(2)</a> <a href="#ref-for
 Cascading Origins</a> <a href="#ref-for-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-author">
-   <b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-author" class="dfn-panel" data-for="cascade-origin-author" id="infopanel-for-cascade-origin-author" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-author" style="display:none">Info about the 'Author Origin' definition.</span><b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-author">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-author①">(2)</a>
@@ -3072,8 +3072,8 @@ Important Declarations: the !important annotation</a> <a href="#ref-for-cascade-
 Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-author⑤">(2)</a> <a href="#ref-for-cascade-origin-author⑥">(3)</a> <a href="#ref-for-cascade-origin-author⑦">(4)</a> <a href="#ref-for-cascade-origin-author⑧">(5)</a> <a href="#ref-for-cascade-origin-author⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-user">
-   <b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-user" class="dfn-panel" data-for="cascade-origin-user" id="infopanel-for-cascade-origin-user" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-user" style="display:none">Info about the 'User Origin' definition.</span><b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-user">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-user①">(2)</a>
@@ -3083,8 +3083,8 @@ Important Declarations: the !important annotation</a> <a href="#ref-for-cascade-
 Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-user⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-ua">
-   <b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-ua" class="dfn-panel" data-for="cascade-origin-ua" id="infopanel-for-cascade-origin-ua" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-ua" style="display:none">Info about the 'User-Agent Origin' definition.</span><b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-ua①">(2)</a>
@@ -3094,8 +3094,8 @@ Important Declarations: the !important annotation</a>
 Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-ua④">(2)</a> <a href="#ref-for-cascade-origin-ua⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="important">
-   <b><a href="#important">#important</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-important" class="dfn-panel" data-for="important" id="infopanel-for-important" role="dialog">
+   <span id="infopaneltitle-for-important" style="display:none">Info about the 'important' definition.</span><b><a href="#important">#important</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-important">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-important①">(2)</a> <a href="#ref-for-important②">(3)</a> <a href="#ref-for-important③">(4)</a>
@@ -3103,8 +3103,8 @@ Cascade Sorting Order</a> <a href="#ref-for-important①">(2)</a> <a href="#ref-
 Important Declarations: the !important annotation</a> <a href="#ref-for-important⑤">(2)</a> <a href="#ref-for-important⑥">(3)</a> <a href="#ref-for-important⑦">(4)</a> <a href="#ref-for-important⑧">(5)</a> <a href="#ref-for-important⑨">(6)</a> <a href="#ref-for-important①⓪">(7)</a> <a href="#ref-for-important①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normal">
-   <b><a href="#normal">#normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normal" class="dfn-panel" data-for="normal" id="infopanel-for-normal" role="dialog">
+   <span id="infopaneltitle-for-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#normal">#normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normal">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-normal①">(2)</a> <a href="#ref-for-normal②">(3)</a>
@@ -3112,8 +3112,8 @@ Cascade Sorting Order</a> <a href="#ref-for-normal①">(2)</a> <a href="#ref-for
 Important Declarations: the !important annotation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-value">
-   <b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-value" class="dfn-panel" data-for="initial-value" id="infopanel-for-initial-value" role="dialog">
+   <span id="infopaneltitle-for-initial-value" style="display:none">Info about the 'initial value' definition.</span><b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">1. 
 Introduction</a>
@@ -3129,8 +3129,8 @@ Inheritance</a>
 Resetting a Property: the initial keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inheritance">
-   <b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inheritance" class="dfn-panel" data-for="inheritance" id="infopanel-for-inheritance" role="dialog">
+   <span id="infopaneltitle-for-inheritance" style="display:none">Info about the 'Inheritance' definition.</span><b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inheritance">1. 
 Introduction</a>
@@ -3142,8 +3142,8 @@ Defaulting</a>
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-value">
-   <b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-value" class="dfn-panel" data-for="inherited-value" id="infopanel-for-inherited-value" role="dialog">
+   <span id="infopaneltitle-for-inherited-value" style="display:none">Info about the 'inherited value' definition.</span><b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">7.2. 
 Inheritance</a>
@@ -3151,8 +3151,8 @@ Inheritance</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-property">
-   <b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-property" class="dfn-panel" data-for="inherited-property" id="infopanel-for-inherited-property" role="dialog">
+   <span id="infopaneltitle-for-inherited-property" style="display:none">Info about the 'inherited properties' definition.</span><b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-property">7. 
 Defaulting</a>
@@ -3160,8 +3160,8 @@ Defaulting</a>
 Initial Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-initial">
-   <b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-initial" class="dfn-panel" data-for="valdef-all-initial" id="infopanel-for-valdef-all-initial" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-initial" style="display:none">Info about the 'initial' definition.</span><b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">7. 
 Defaulting</a>
@@ -3173,8 +3173,8 @@ Erasing All Declarations: the unset keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-inherit">
-   <b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-inherit" class="dfn-panel" data-for="valdef-all-inherit" id="infopanel-for-valdef-all-inherit" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-inherit" style="display:none">Info about the 'inherit' definition.</span><b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">7. 
 Defaulting</a>
@@ -3186,8 +3186,8 @@ Explicit Inheritance: the inherit keyword</a> <a href="#ref-for-valdef-all-inher
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-unset">
-   <b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-unset" class="dfn-panel" data-for="valdef-all-unset" id="infopanel-for-valdef-all-unset" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-unset" style="display:none">Info about the 'unset' definition.</span><b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">7.3.3. 
 Erasing All Declarations: the unset keyword</a> <a href="#ref-for-valdef-all-unset①">(2)</a>
@@ -3212,59 +3212,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-cascade-4/Overview.html
@@ -2512,8 +2512,8 @@ potentially allowing sensitive data to be inferred from the computed styles they
    <li><a href="#cascade-origin-user">user-origin</a><span>, in § 6.2</span>
    <li><a href="#cascade-origin-user">user style sheet</a><span>, in § 6.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-auto">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-auto" class="dfn-panel" data-for="term-for-valdef-align-self-auto" id="infopanel-for-term-for-valdef-align-self-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-auto">4.4. 
 Computed Values</a>
@@ -2521,85 +2521,85 @@ Computed Values</a>
 Used Values</a> <a href="#ref-for-valdef-align-self-auto②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-dotted">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-dotted" class="dfn-panel" data-for="term-for-valdef-line-style-dotted" id="infopanel-for-term-for-valdef-line-style-dotted" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-dotted" style="display:none">Info about the 'dotted' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-dotted">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">3.1. 
 Aliasing</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-for-propdef-break-before②">(3)</a> <a href="#ref-for-propdef-break-before③">(4)</a>
@@ -2607,8 +2607,8 @@ Aliasing</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-fo
 Used Values</a> <a href="#ref-for-propdef-break-before⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">4.6. 
 Actual Values</a>
@@ -2616,43 +2616,43 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-page">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-page" class="dfn-panel" data-for="term-for-valdef-break-before-page" id="infopanel-for-term-for-valdef-break-before-page" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-page">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2.1. 
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2.1. 
 Conditional @import Rules</a> <a href="#ref-for-at-ruledef-supports①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-supports" class="dfn-panel" data-for="term-for-funcdef-supports" id="infopanel-for-term-for-funcdef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-supports" style="display:none">Info about the 'supports()' external reference.</span><a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-supports">8.3. 
 Changes Since the 21 April 2015 Working Draft</a>
@@ -2660,15 +2660,15 @@ Changes Since the 21 April 2015 Working Draft</a>
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elements">
-   <a href="https://drafts.csswg.org/css-display-3/#elements">https://drafts.csswg.org/css-display-3/#elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elements" class="dfn-panel" data-for="term-for-elements" id="infopanel-for-term-for-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-elements" style="display:none">Info about the 'element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#elements">https://drafts.csswg.org/css-display-3/#elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elements">1.1. 
 Module Interactions</a>
@@ -2676,15 +2676,15 @@ Module Interactions</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">1.1. 
 Module Interactions</a>
@@ -2692,57 +2692,57 @@ Module Interactions</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">4.6. 
 Actual Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">4.7. 
 Examples</a> <a href="#ref-for-propdef-list-style-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flat tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">4. 
 Value Processing</a> <a href="#ref-for-flat-tree①">(2)</a>
@@ -2752,8 +2752,8 @@ Inheritance</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a> <a href="#ref-for-flat-tree④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree①" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree①" style="display:none">Info about the 'flattened element tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">4. 
 Value Processing</a> <a href="#ref-for-flat-tree①">(2)</a>
@@ -2763,22 +2763,22 @@ Inheritance</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a> <a href="#ref-for-flat-tree④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-context">
-   <a href="https://drafts.csswg.org/css-scoping-1/#tree-context">https://drafts.csswg.org/css-scoping-1/#tree-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-context" class="dfn-panel" data-for="term-for-tree-context" id="infopanel-for-term-for-tree-context" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-context" style="display:none">Info about the 'tree context' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#tree-context">https://drafts.csswg.org/css-scoping-1/#tree-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-context">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-tree-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.5. 
 Used Values</a>
@@ -2786,8 +2786,8 @@ Used Values</a>
 Examples</a> <a href="#ref-for-propdef-width②">(2)</a> <a href="#ref-for-propdef-width③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-charset">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-charset" class="dfn-panel" data-for="term-for-at-ruledef-charset" id="infopanel-for-term-for-at-ruledef-charset" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-charset" style="display:none">Info about the '@charset' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-charset">2. 
 Importing Style Sheets: the @import rule</a>
@@ -2795,106 +2795,106 @@ Importing Style Sheets: the @import rule</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-encoding">
-   <a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-encoding" class="dfn-panel" data-for="term-for-environment-encoding" id="infopanel-for-term-for-environment-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-encoding" style="display:none">Info about the 'environment encoding' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-encoding">2.2. 
 Processing Stylesheet Imports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-property-declarations">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-property-declarations" class="dfn-panel" data-for="term-for-css-property-declarations" id="infopanel-for-term-for-css-property-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-css-property-declarations" style="display:none">Info about the 'property declarations' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property-declarations">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">6.3. 
 Important Declarations: the !important annotation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">4.5.1. 
 Applicable Properties</a> <a href="#ref-for-propdef-text-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-3/#ch">https://drafts.csswg.org/css-values-3/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#ch">https://drafts.csswg.org/css-values-3/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">4.3. 
 Specified Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vh">
-   <a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vh" class="dfn-panel" data-for="term-for-vh" id="infopanel-for-term-for-vh" role="menu">
+   <span id="infopaneltitle-for-term-for-vh" style="display:none">Info about the 'vh' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vh">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vw">
-   <a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vw" class="dfn-panel" data-for="term-for-vw" id="infopanel-for-term-for-vw" role="menu">
+   <span id="infopaneltitle-for-term-for-vw" style="display:none">Info about the 'vw' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vw">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -2902,29 +2902,29 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-comb-one①">(2)<
 Resetting All Properties: the all property</a> <a href="#ref-for-comb-one③">(2)</a> <a href="#ref-for-comb-one④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">3.2. 
 Resetting All Properties: the all property</a>
@@ -2932,8 +2932,8 @@ Resetting All Properties: the all property</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a> <a href="#ref-for-custom-property②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-direction①">(2)</a>
@@ -2941,8 +2941,8 @@ Resetting All Properties: the all property</a> <a href="#ref-for-propdef-directi
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a>
@@ -2950,22 +2950,22 @@ Resetting All Properties: the all property</a> <a href="#ref-for-propdef-unicode
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Importing Style Sheets: the @import rule</a>
@@ -2977,15 +2977,15 @@ Applicable Properties</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">4.6. 
 Actual Values</a>
@@ -2993,15 +2993,15 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3.1. 
 Aliasing</a> <a href="#ref-for-propdef-page-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-red">
-   <a href="https://drafts.csswg.org/css2/#valdef-color-red">https://drafts.csswg.org/css2/#valdef-color-red</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-red" class="dfn-panel" data-for="term-for-valdef-color-red" id="infopanel-for-term-for-valdef-color-red" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-red" style="display:none">Info about the 'red' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-color-red">https://drafts.csswg.org/css2/#valdef-color-red</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">1. 
 Introduction</a>
@@ -3009,15 +3009,15 @@ Introduction</a>
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">4. 
 Value Processing</a>
@@ -3025,22 +3025,22 @@ Value Processing</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-light-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-light-tree" class="dfn-panel" data-for="term-for-concept-light-tree" id="infopanel-for-term-for-concept-light-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-light-tree" style="display:none">Info about the 'light tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-light-tree">7.2. 
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">6.1. 
 Cascade Sorting Order</a>
@@ -3048,71 +3048,71 @@ Cascade Sorting Order</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">6.1. 
 Cascade Sorting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-protocol">
-   <a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-protocol" class="dfn-panel" data-for="term-for-cors-protocol" id="infopanel-for-term-for-cors-protocol" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-protocol" style="display:none">Info about the 'cors protocol' external reference.</span><a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-protocol"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-type">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-type" class="dfn-panel" data-for="term-for-content-type" id="infopanel-for-term-for-content-type" role="menu">
+   <span id="infopaneltitle-for-term-for-content-type" style="display:none">Info about the 'content-type metadata' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-type">2.3. 
 Content-Type of CSS Style Sheets</a> <a href="#ref-for-content-type①">(2)</a>
     <li><a href="#termref-for-content-type"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-p-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-p-element" class="dfn-panel" data-for="term-for-the-p-element" id="infopanel-for-term-for-the-p-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-p-element" style="display:none">Info about the 'p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-p-element">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-s-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-s-element" class="dfn-panel" data-for="term-for-the-s-element" id="infopanel-for-term-for-the-s-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-s-element" style="display:none">Info about the 's' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-s-element">6.4. 
 Precedence of Non-CSS Presentational Hints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-slot-element">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-slot-element" class="dfn-panel" data-for="term-for-the-slot-element" id="infopanel-for-term-for-the-slot-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-slot-element" style="display:none">Info about the 'slot' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-slot-element">7.2. 
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query-list" class="dfn-panel" data-for="term-for-typedef-media-query-list" id="infopanel-for-term-for-typedef-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
@@ -3120,15 +3120,15 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-que
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#media-query">https://drafts.csswg.org/mediaqueries-4/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#media-query">https://drafts.csswg.org/mediaqueries-4/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">2.1. 
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">4.5.1. 
 Applicable Properties</a> <a href="#ref-for-pseudo-element①">(2)</a>
@@ -3451,8 +3451,8 @@ Inheritance</a> <a href="#ref-for-pseudo-element③">(2)</a>
       <td>see individual properties
    </table>
   </div>
-  <aside class="dfn-panel" data-for="at-ruledef-import">
-   <b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-import" class="dfn-panel" data-for="at-ruledef-import" id="infopanel-for-at-ruledef-import" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-import" style="display:none">Info about the '@import' definition.</span><b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import①">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-at-ruledef-import②">(2)</a> <a href="#ref-for-at-ruledef-import③">(3)</a> <a href="#ref-for-at-ruledef-import④">(4)</a> <a href="#ref-for-at-ruledef-import⑤">(5)</a> <a href="#ref-for-at-ruledef-import⑥">(6)</a> <a href="#ref-for-at-ruledef-import⑦">(7)</a> <a href="#ref-for-at-ruledef-import⑧">(8)</a> <a href="#ref-for-at-ruledef-import⑨">(9)</a>
@@ -3467,15 +3467,15 @@ Additions Since Level 3</a>
     <li><a href="#ref-for-at-ruledef-import①⑦"> Privacy and Security Considerations</a> <a href="#ref-for-at-ruledef-import①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-conditions">
-   <b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-conditions" class="dfn-panel" data-for="import-conditions" id="infopanel-for-import-conditions" role="dialog">
+   <span id="infopaneltitle-for-import-conditions" style="display:none">Info about the 'import conditions' definition.</span><b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-conditions">2.1. 
 Conditional @import Rules</a> <a href="#ref-for-import-conditions①">(2)</a> <a href="#ref-for-import-conditions②">(3)</a> <a href="#ref-for-import-conditions③">(4)</a> <a href="#ref-for-import-conditions④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query">
-   <b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query" class="dfn-panel" data-for="typedef-media-query" id="infopanel-for-typedef-media-query" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query" style="display:none">Info about the '&lt;media-query>' definition.</span><b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query">1.1. 
 Module Interactions</a>
@@ -3483,8 +3483,8 @@ Module Interactions</a>
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-condition">
-   <b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-condition" class="dfn-panel" data-for="typedef-supports-condition" id="infopanel-for-typedef-supports-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-condition" style="display:none">Info about the '&lt;supports-condition>' definition.</span><b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-condition①">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-supports-condition②">(2)</a>
@@ -3492,8 +3492,8 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-supports-
 Conditional @import Rules</a> <a href="#ref-for-typedef-supports-condition④">(2)</a> <a href="#ref-for-typedef-supports-condition⑤">(3)</a> <a href="#ref-for-typedef-supports-condition⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-declaration">
-   <b><a href="#typedef-declaration">#typedef-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-declaration" class="dfn-panel" data-for="typedef-declaration" id="infopanel-for-typedef-declaration" role="dialog">
+   <span id="infopaneltitle-for-typedef-declaration" style="display:none">Info about the '&lt;declaration>' definition.</span><b><a href="#typedef-declaration">#typedef-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-declaration①">(2)</a>
@@ -3501,8 +3501,8 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-declarati
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shorthand-property">
-   <b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shorthand-property" class="dfn-panel" data-for="shorthand-property" id="infopanel-for-shorthand-property" role="dialog">
+   <span id="infopaneltitle-for-shorthand-property" style="display:none">Info about the 'shorthand properties' definition.</span><b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. 
 Shorthand Properties</a> <a href="#ref-for-shorthand-property①">(2)</a> <a href="#ref-for-shorthand-property②">(3)</a> <a href="#ref-for-shorthand-property③">(4)</a> <a href="#ref-for-shorthand-property④">(5)</a> <a href="#ref-for-shorthand-property⑤">(6)</a> <a href="#ref-for-shorthand-property⑥">(7)</a> <a href="#ref-for-shorthand-property⑦">(8)</a> <a href="#ref-for-shorthand-property⑧">(9)</a>
@@ -3518,22 +3518,22 @@ Erasing All Declarations: the unset keyword</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="longhand">
-   <b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-longhand" class="dfn-panel" data-for="longhand" id="infopanel-for-longhand" role="dialog">
+   <span id="infopaneltitle-for-longhand" style="display:none">Info about the 'longhand sub-properties' definition.</span><b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3. 
 Shorthand Properties</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a> <a href="#ref-for-longhand③">(4)</a> <a href="#ref-for-longhand④">(5)</a> <a href="#ref-for-longhand⑤">(6)</a> <a href="#ref-for-longhand⑥">(7)</a> <a href="#ref-for-longhand⑦">(8)</a> <a href="#ref-for-longhand⑧">(9)</a> <a href="#ref-for-longhand⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reset-only-sub-property">
-   <b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reset-only-sub-property" class="dfn-panel" data-for="reset-only-sub-property" id="infopanel-for-reset-only-sub-property" role="dialog">
+   <span id="infopaneltitle-for-reset-only-sub-property" style="display:none">Info about the 'reset-only sub-property' definition.</span><b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-only-sub-property">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-name-alias">
-   <b><a href="#legacy-name-alias">#legacy-name-alias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-name-alias" class="dfn-panel" data-for="legacy-name-alias" id="infopanel-for-legacy-name-alias" role="dialog">
+   <span id="infopaneltitle-for-legacy-name-alias" style="display:none">Info about the 'legacy name aliases' definition.</span><b><a href="#legacy-name-alias">#legacy-name-alias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-name-alias">3.1. 
 Aliasing</a>
@@ -3541,15 +3541,15 @@ Aliasing</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-shorthand">
-   <b><a href="#legacy-shorthand">#legacy-shorthand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-shorthand" class="dfn-panel" data-for="legacy-shorthand" id="infopanel-for-legacy-shorthand" role="dialog">
+   <span id="infopaneltitle-for-legacy-shorthand" style="display:none">Info about the 'legacy shorthands' definition.</span><b><a href="#legacy-shorthand">#legacy-shorthand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-shorthand">3.1. 
 Aliasing</a> <a href="#ref-for-legacy-shorthand①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-all">
-   <b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-all" class="dfn-panel" data-for="propdef-all" id="infopanel-for-propdef-all" role="dialog">
+   <span id="infopaneltitle-for-propdef-all" style="display:none">Info about the 'all' definition.</span><b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-all①">(2)</a> <a href="#ref-for-propdef-all②">(3)</a>
@@ -3559,8 +3559,8 @@ Changes Since the 14 January 2016 Candidate Recommendation</a> <a href="#ref-for
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-value">
-   <b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-value" class="dfn-panel" data-for="declared-value" id="infopanel-for-declared-value" role="dialog">
+   <span id="infopaneltitle-for-declared-value" style="display:none">Info about the 'declared value' definition.</span><b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-value">4. 
 Value Processing</a> <a href="#ref-for-declared-value①">(2)</a> <a href="#ref-for-declared-value②">(3)</a>
@@ -3578,8 +3578,8 @@ Erasing All Declarations: the unset keyword</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascaded-value">
-   <b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascaded-value" class="dfn-panel" data-for="cascaded-value" id="infopanel-for-cascaded-value" role="dialog">
+   <span id="infopaneltitle-for-cascaded-value" style="display:none">Info about the 'cascaded value' definition.</span><b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascaded-value">4. 
 Value Processing</a> <a href="#ref-for-cascaded-value①">(2)</a> <a href="#ref-for-cascaded-value②">(3)</a>
@@ -3603,8 +3603,8 @@ Changes Since the 28 August 2018 Candidate Recommendation</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a> <a href="#ref-for-cascaded-value①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-value">
-   <b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-value" class="dfn-panel" data-for="specified-value" id="infopanel-for-specified-value" role="dialog">
+   <span id="infopaneltitle-for-specified-value" style="display:none">Info about the 'specified value' definition.</span><b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">1. 
 Introduction</a>
@@ -3630,8 +3630,8 @@ Changes Since the 28 August 2018 Candidate Recommendation</a>
 Changes Since the 14 January 2016 Candidate Recommendation</a> <a href="#ref-for-specified-value①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-value">
-   <b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-value" class="dfn-panel" data-for="computed-value" id="infopanel-for-computed-value" role="dialog">
+   <span id="infopaneltitle-for-computed-value" style="display:none">Info about the 'computed value' definition.</span><b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4. 
 Value Processing</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
@@ -3649,8 +3649,8 @@ Explicit Inheritance: the inherit keyword</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-value">
-   <b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-value" class="dfn-panel" data-for="used-value" id="infopanel-for-used-value" role="dialog">
+   <span id="infopaneltitle-for-used-value" style="display:none">Info about the 'used value' definition.</span><b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4. 
 Value Processing</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a> <a href="#ref-for-used-value③">(4)</a>
@@ -3664,8 +3664,8 @@ Actual Values</a> <a href="#ref-for-used-value⑨">(2)</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply">
-   <b><a href="#apply">#apply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply" class="dfn-panel" data-for="apply" id="infopanel-for-apply" role="dialog">
+   <span id="infopaneltitle-for-apply" style="display:none">Info about the 'apply to' definition.</span><b><a href="#apply">#apply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply">4.4. 
 Computed Values</a>
@@ -3675,8 +3675,8 @@ Used Values</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-value">
-   <b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-value" class="dfn-panel" data-for="actual-value" id="infopanel-for-actual-value" role="dialog">
+   <span id="infopaneltitle-for-actual-value" style="display:none">Info about the 'actual value' definition.</span><b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">4. 
 Value Processing</a> <a href="#ref-for-actual-value①">(2)</a> <a href="#ref-for-actual-value②">(3)</a>
@@ -3684,8 +3684,8 @@ Value Processing</a> <a href="#ref-for-actual-value①">(2)</a> <a href="#ref-fo
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade">
-   <b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade" class="dfn-panel" data-for="cascade" id="infopanel-for-cascade" role="dialog">
+   <span id="infopaneltitle-for-cascade" style="display:none">Info about the 'cascade' definition.</span><b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">1. 
 Introduction</a> <a href="#ref-for-cascade">(2)</a>
@@ -3713,8 +3713,8 @@ Additions Since Level 3</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encapsulation-contexts">
-   <b><a href="#encapsulation-contexts">#encapsulation-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encapsulation-contexts" class="dfn-panel" data-for="encapsulation-contexts" id="infopanel-for-encapsulation-contexts" role="dialog">
+   <span id="infopaneltitle-for-encapsulation-contexts" style="display:none">Info about the 'encapsulation contexts' definition.</span><b><a href="#encapsulation-contexts">#encapsulation-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encapsulation-contexts">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-encapsulation-contexts①">(2)</a> <a href="#ref-for-encapsulation-contexts②">(3)</a>
@@ -3722,15 +3722,15 @@ Cascade Sorting Order</a> <a href="#ref-for-encapsulation-contexts①">(2)</a> <
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="output-of-the-cascade">
-   <b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-output-of-the-cascade" class="dfn-panel" data-for="output-of-the-cascade" id="infopanel-for-output-of-the-cascade" role="dialog">
+   <span id="infopaneltitle-for-output-of-the-cascade" style="display:none">Info about the 'output of the cascade' definition.</span><b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-of-the-cascade">4.2. 
 Cascaded Values</a> <a href="#ref-for-output-of-the-cascade①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin">
-   <b><a href="#origin">#origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin" class="dfn-panel" data-for="origin" id="infopanel-for-origin" role="dialog">
+   <span id="infopaneltitle-for-origin" style="display:none">Info about the 'cascade origin' definition.</span><b><a href="#origin">#origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.2. 
 Processing Stylesheet Imports</a> <a href="#ref-for-origin①">(2)</a>
@@ -3742,8 +3742,8 @@ Cascading Origins</a> <a href="#ref-for-origin⑦">(2)</a>
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-origin⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-author">
-   <b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-author" class="dfn-panel" data-for="cascade-origin-author" id="infopanel-for-cascade-origin-author" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-author" style="display:none">Info about the 'Author Origin' definition.</span><b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-author">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-author①">(2)</a>
@@ -3755,8 +3755,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-cascade-origin-author①①">(2)</a> <a href="#ref-for-cascade-origin-author①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-user">
-   <b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-user" class="dfn-panel" data-for="cascade-origin-user" id="infopanel-for-cascade-origin-user" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-user" style="display:none">Info about the 'User Origin' definition.</span><b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-user">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-user①">(2)</a>
@@ -3768,8 +3768,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-cascade-origin-user⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-ua">
-   <b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-ua" class="dfn-panel" data-for="cascade-origin-ua" id="infopanel-for-cascade-origin-ua" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-ua" style="display:none">Info about the 'User-Agent Origin' definition.</span><b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-ua①">(2)</a>
@@ -3781,8 +3781,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="important">
-   <b><a href="#important">#important</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-important" class="dfn-panel" data-for="important" id="infopanel-for-important" role="dialog">
+   <span id="infopaneltitle-for-important" style="display:none">Info about the 'important' definition.</span><b><a href="#important">#important</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-important">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-important①">(2)</a> <a href="#ref-for-important②">(3)</a> <a href="#ref-for-important③">(4)</a> <a href="#ref-for-important④">(5)</a> <a href="#ref-for-important⑤">(6)</a>
@@ -3790,8 +3790,8 @@ Cascade Sorting Order</a> <a href="#ref-for-important①">(2)</a> <a href="#ref-
 Important Declarations: the !important annotation</a> <a href="#ref-for-important⑦">(2)</a> <a href="#ref-for-important⑧">(3)</a> <a href="#ref-for-important⑨">(4)</a> <a href="#ref-for-important①⓪">(5)</a> <a href="#ref-for-important①①">(6)</a> <a href="#ref-for-important①②">(7)</a> <a href="#ref-for-important①③">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normal">
-   <b><a href="#normal">#normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normal" class="dfn-panel" data-for="normal" id="infopanel-for-normal" role="dialog">
+   <span id="infopaneltitle-for-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#normal">#normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normal">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-normal①">(2)</a> <a href="#ref-for-normal②">(3)</a> <a href="#ref-for-normal③">(4)</a> <a href="#ref-for-normal④">(5)</a>
@@ -3799,8 +3799,8 @@ Cascade Sorting Order</a> <a href="#ref-for-normal①">(2)</a> <a href="#ref-for
 Important Declarations: the !important annotation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-value">
-   <b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-value" class="dfn-panel" data-for="initial-value" id="infopanel-for-initial-value" role="dialog">
+   <span id="infopaneltitle-for-initial-value" style="display:none">Info about the 'initial value' definition.</span><b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">1. 
 Introduction</a>
@@ -3816,8 +3816,8 @@ Inheritance</a>
 Resetting a Property: the initial keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inheritance">
-   <b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inheritance" class="dfn-panel" data-for="inheritance" id="infopanel-for-inheritance" role="dialog">
+   <span id="infopaneltitle-for-inheritance" style="display:none">Info about the 'Inheritance' definition.</span><b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inheritance">1. 
 Introduction</a>
@@ -3831,8 +3831,8 @@ Inheritance</a>
 Changes Since the 28 August 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-value">
-   <b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-value" class="dfn-panel" data-for="inherited-value" id="infopanel-for-inherited-value" role="dialog">
+   <span id="infopaneltitle-for-inherited-value" style="display:none">Info about the 'inherited value' definition.</span><b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">7.2. 
 Inheritance</a>
@@ -3840,8 +3840,8 @@ Inheritance</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-property">
-   <b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-property" class="dfn-panel" data-for="inherited-property" id="infopanel-for-inherited-property" role="dialog">
+   <span id="infopaneltitle-for-inherited-property" style="display:none">Info about the 'inherited properties' definition.</span><b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-property">7. 
 Defaulting</a>
@@ -3849,8 +3849,8 @@ Defaulting</a>
 Initial Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-initial">
-   <b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-initial" class="dfn-panel" data-for="valdef-all-initial" id="infopanel-for-valdef-all-initial" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-initial" style="display:none">Info about the 'initial' definition.</span><b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">7. 
 Defaulting</a>
@@ -3862,8 +3862,8 @@ Erasing All Declarations: the unset keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-inherit">
-   <b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-inherit" class="dfn-panel" data-for="valdef-all-inherit" id="infopanel-for-valdef-all-inherit" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-inherit" style="display:none">Info about the 'inherit' definition.</span><b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">7. 
 Defaulting</a>
@@ -3875,8 +3875,8 @@ Explicit Inheritance: the inherit keyword</a> <a href="#ref-for-valdef-all-inher
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-unset">
-   <b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-unset" class="dfn-panel" data-for="valdef-all-unset" id="infopanel-for-valdef-all-unset" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-unset" style="display:none">Info about the 'unset' definition.</span><b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">7.3.3. 
 Erasing All Declarations: the unset keyword</a> <a href="#ref-for-valdef-all-unset①">(2)</a>
@@ -3886,8 +3886,8 @@ Rolling Back Cascade Origins: the revert keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-revert">
-   <b><a href="#valdef-all-revert">#valdef-all-revert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-revert" class="dfn-panel" data-for="valdef-all-revert" id="infopanel-for-valdef-all-revert" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-revert" style="display:none">Info about the 'revert' definition.</span><b><a href="#valdef-all-revert">#valdef-all-revert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert①">7.3.4. 
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-valdef-all-revert②">(2)</a> <a href="#ref-for-valdef-all-revert③">(3)</a>
@@ -3916,59 +3916,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-cascade-5/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-cascade-5/Overview.html
@@ -2691,8 +2691,8 @@ potentially allowing sensitive data to be inferred from the computed styles they
    <li><a href="#cascade-origin-user">user-origin</a><span>, in § 6.2</span>
    <li><a href="#cascade-origin-user">user style sheet</a><span>, in § 6.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-auto">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-auto" class="dfn-panel" data-for="term-for-valdef-align-self-auto" id="infopanel-for-term-for-valdef-align-self-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-auto">4.4. 
 Computed Values</a>
@@ -2700,92 +2700,92 @@ Computed Values</a>
 Used Values</a> <a href="#ref-for-valdef-align-self-auto②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-dotted">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-dotted" class="dfn-panel" data-for="term-for-valdef-line-style-dotted" id="infopanel-for-term-for-valdef-line-style-dotted" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-dotted" style="display:none">Info about the 'dotted' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-dotted">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">3.1. 
 Aliasing</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-for-propdef-break-before②">(3)</a> <a href="#ref-for-propdef-break-before③">(4)</a>
@@ -2793,8 +2793,8 @@ Aliasing</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-fo
 Used Values</a> <a href="#ref-for-propdef-break-before⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">4.6. 
 Actual Values</a>
@@ -2802,43 +2802,43 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">4.8. 
 Per-Fragment Value Processing</a> <a href="#ref-for-box-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-page">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-page" class="dfn-panel" data-for="term-for-valdef-break-before-page" id="infopanel-for-term-for-valdef-break-before-page" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-page">https://drafts.csswg.org/css-break-4/#valdef-break-before-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-page">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-red">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-red" class="dfn-panel" data-for="term-for-valdef-color-red" id="infopanel-for-term-for-valdef-color-red" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-red" style="display:none">Info about the 'red' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">1. 
 Introduction</a>
@@ -2846,43 +2846,43 @@ Introduction</a>
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2.1. 
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2.1. 
 Conditional @import Rules</a> <a href="#ref-for-at-ruledef-supports①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-conditional-group-rule">
-   <a href="https://drafts.csswg.org/css-conditional-3/#conditional-group-rule">https://drafts.csswg.org/css-conditional-3/#conditional-group-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-conditional-group-rule" class="dfn-panel" data-for="term-for-conditional-group-rule" id="infopanel-for-term-for-conditional-group-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-conditional-group-rule" style="display:none">Info about the 'conditional group rule' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#conditional-group-rule">https://drafts.csswg.org/css-conditional-3/#conditional-group-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conditional-group-rule">6.4.1. 
 Declaring Cascade Layers: the @layer rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-supports" class="dfn-panel" data-for="term-for-funcdef-supports" id="infopanel-for-term-for-funcdef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-supports" style="display:none">Info about the 'supports()' external reference.</span><a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-supports">8.2. 
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Importing Style Sheets: the @import rule</a>
@@ -2892,8 +2892,8 @@ Resetting All Properties: the all property</a>
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">4.5. 
 Used Values</a>
@@ -2901,64 +2901,64 @@ Used Values</a>
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elements">
-   <a href="https://drafts.csswg.org/css-display-3/#elements">https://drafts.csswg.org/css-display-3/#elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elements" class="dfn-panel" data-for="term-for-elements" id="infopanel-for-term-for-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-elements" style="display:none">Info about the 'element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#elements">https://drafts.csswg.org/css-display-3/#elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elements">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">4.5. 
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">4.6. 
 Actual Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">4.7. 
 Examples</a> <a href="#ref-for-propdef-list-style-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">4.5. 
 Used Values</a>
@@ -2966,8 +2966,8 @@ Used Values</a>
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">4.5. 
 Used Values</a>
@@ -2975,22 +2975,22 @@ Used Values</a>
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">4.8. 
 Per-Fragment Value Processing</a> <a href="#ref-for-selectordef-first-line①">(2)</a> <a href="#ref-for-selectordef-first-line②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-abiding">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-abiding" class="dfn-panel" data-for="term-for-tree-abiding" id="infopanel-for-term-for-tree-abiding" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-abiding" style="display:none">Info about the 'tree-abiding' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-abiding">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flattened element tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">4. 
 Value Processing</a>
@@ -2998,22 +2998,22 @@ Value Processing</a>
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-context">
-   <a href="https://drafts.csswg.org/css-scoping-1/#tree-context">https://drafts.csswg.org/css-scoping-1/#tree-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-context" class="dfn-panel" data-for="term-for-tree-context" id="infopanel-for-term-for-tree-context" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-context" style="display:none">Info about the 'tree context' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#tree-context">https://drafts.csswg.org/css-scoping-1/#tree-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-context">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-tree-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.5. 
 Used Values</a>
@@ -3021,85 +3021,85 @@ Used Values</a>
 Examples</a> <a href="#ref-for-propdef-width②">(2)</a> <a href="#ref-for-propdef-width③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-stylesheet">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-stylesheet" class="dfn-panel" data-for="term-for-typedef-stylesheet" id="infopanel-for-term-for-typedef-stylesheet" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-stylesheet" style="display:none">Info about the '&lt;stylesheet>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-stylesheet">6.4.1. 
 Declaring Cascade Layers: the @layer rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-charset">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-charset" class="dfn-panel" data-for="term-for-at-ruledef-charset" id="infopanel-for-term-for-at-ruledef-charset" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-charset" style="display:none">Info about the '@charset' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-charset">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-encoding">
-   <a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-encoding" class="dfn-panel" data-for="term-for-environment-encoding" id="infopanel-for-term-for-environment-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-encoding" style="display:none">Info about the 'environment encoding' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-encoding">2.2. 
 Processing Stylesheet Imports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-property-declarations">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-property-declarations" class="dfn-panel" data-for="term-for-css-property-declarations" id="infopanel-for-term-for-css-property-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-css-property-declarations" style="display:none">Info about the 'property declarations' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-property-declarations">https://drafts.csswg.org/css-syntax-3/#css-property-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property-declarations">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">4.7. 
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">6.3. 
 Important Declarations: the !important annotation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">4.5.1. 
 Applicable Properties</a> <a href="#ref-for-propdef-text-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cursor-default">
-   <a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cursor-default" class="dfn-panel" data-for="term-for-valdef-cursor-default" id="infopanel-for-term-for-valdef-cursor-default" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cursor-default" style="display:none">Info about the 'default' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">6.4.1.1. 
 Nested Layers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-3/#mult-comma">https://drafts.csswg.org/css-values-3/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#mult-comma">https://drafts.csswg.org/css-values-3/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">6.4.1. 
 Declaring Cascade Layers: the @layer rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-ident">https://drafts.csswg.org/css-values-3/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-ident">https://drafts.csswg.org/css-values-3/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">6.4.1. 
 Declaring Cascade Layers: the @layer rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-length-percentage">https://drafts.csswg.org/css-values-3/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
@@ -3107,22 +3107,22 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-mult-opt①">(2)<
 Declaring Cascade Layers: the @layer rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-3/#ch">https://drafts.csswg.org/css-values-3/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#ch">https://drafts.csswg.org/css-values-3/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#css-wide-keywords">https://drafts.csswg.org/css-values-3/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">4.3. 
 Specified Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">4.4. 
 Computed Values</a>
@@ -3130,36 +3130,36 @@ Computed Values</a>
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#ex">https://drafts.csswg.org/css-values-3/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#funcdef-url">https://drafts.csswg.org/css-values-3/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2. 
 Importing Style Sheets: the @import rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vh">
-   <a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vh" class="dfn-panel" data-for="term-for-vh" id="infopanel-for-term-for-vh" role="menu">
+   <span id="infopaneltitle-for-term-for-vh" style="display:none">Info about the 'vh' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vh">https://drafts.csswg.org/css-values-3/#vh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vh">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vw">
-   <a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vw" class="dfn-panel" data-for="term-for-vw" id="infopanel-for-term-for-vw" role="menu">
+   <span id="infopaneltitle-for-term-for-vw" style="display:none">Info about the 'vw' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#vw">https://drafts.csswg.org/css-values-3/#vw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vw">4.4. 
 Computed Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
@@ -3167,71 +3167,71 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-comb-one①">(2)<
 Resetting All Properties: the all property</a> <a href="#ref-for-comb-one④">(2)</a> <a href="#ref-for-comb-one⑤">(3)</a> <a href="#ref-for-comb-one⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">3.2. 
 Resetting All Properties: the all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">4.6. 
 Actual Values</a>
@@ -3239,15 +3239,15 @@ Actual Values</a>
 Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3.1. 
 Aliasing</a> <a href="#ref-for-propdef-page-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">4.4. 
 Computed Values</a>
@@ -3255,120 +3255,120 @@ Computed Values</a>
 Per-Fragment Value Processing</a> <a href="#ref-for-dom-window-getcomputedstyle②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">4. 
 Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-light-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-light-tree" class="dfn-panel" data-for="term-for-concept-light-tree" id="infopanel-for-term-for-concept-light-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-light-tree" style="display:none">Info about the 'light tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-light-tree">7.2. 
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">6.1. 
 Cascade Sorting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">6.1. 
 Cascade Sorting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-protocol">
-   <a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-protocol" class="dfn-panel" data-for="term-for-cors-protocol" id="infopanel-for-term-for-cors-protocol" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-protocol" style="display:none">Info about the 'cors protocol' external reference.</span><a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-protocol"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audio">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audio" class="dfn-panel" data-for="term-for-audio" id="infopanel-for-term-for-audio" role="menu">
+   <span id="infopaneltitle-for-term-for-audio" style="display:none">Info about the 'audio' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio">6.4. 
 Cascade Layers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-type">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-type" class="dfn-panel" data-for="term-for-content-type" id="infopanel-for-term-for-content-type" role="menu">
+   <span id="infopaneltitle-for-term-for-content-type" style="display:none">Info about the 'content-type metadata' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#content-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-type">2.3. 
 Content-Type of CSS Style Sheets</a> <a href="#ref-for-content-type①">(2)</a>
     <li><a href="#termref-for-content-type"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-p-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-p-element" class="dfn-panel" data-for="term-for-the-p-element" id="infopanel-for-term-for-the-p-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-p-element" style="display:none">Info about the 'p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-p-element">4.5.1. 
 Applicable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-s-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-s-element" class="dfn-panel" data-for="term-for-the-s-element" id="infopanel-for-term-for-the-s-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-s-element" style="display:none">Info about the 's' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-s-element">6.5. 
 Precedence of Non-CSS Presentational Hints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.3. 
 Content-Type of CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-slot-element">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-slot-element" class="dfn-panel" data-for="term-for-the-slot-element" id="infopanel-for-term-for-the-slot-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-slot-element" style="display:none">Info about the 'slot' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-slot-element">7.2. 
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-span-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-span-element" class="dfn-panel" data-for="term-for-the-span-element" id="infopanel-for-term-for-the-span-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-span-element" style="display:none">Info about the 'span' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-span-element">4.8. 
 Per-Fragment Value Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query-list" class="dfn-panel" data-for="term-for-typedef-media-query-list" id="infopanel-for-term-for-typedef-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-4/#typedef-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
@@ -3376,15 +3376,15 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-media-que
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#media-query">https://drafts.csswg.org/mediaqueries-4/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#media-query">https://drafts.csswg.org/mediaqueries-4/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">2.1. 
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">4.5. 
 Used Values</a> <a href="#ref-for-pseudo-element①">(2)</a>
@@ -3735,8 +3735,8 @@ Inheritance</a> <a href="#ref-for-pseudo-element⑥">(2)</a>
    <div class="issue"> Provide an attribute for assigning link or style elements to cascade layers <a href="https://github.com/w3c/csswg-drafts/issues/5853">[Issue #w3c/csswg-drafts#5853]</a> <a class="issue-return" href="#issue-8650fc45" title="Jump to section">↵</a></div>
    <div class="issue"> What is the appropriate syntax for appending to nested layers? <a href="https://github.com/w3c/csswg-drafts/issues/5791">[Issue #w3c/csswg-drafts#5791]</a> <a class="issue-return" href="#issue-c2eaf2d9" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="at-ruledef-import">
-   <b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-import" class="dfn-panel" data-for="at-ruledef-import" id="infopanel-for-at-ruledef-import" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-import" style="display:none">Info about the '@import' definition.</span><b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-at-ruledef-import①">(2)</a> <a href="#ref-for-at-ruledef-import②">(3)</a> <a href="#ref-for-at-ruledef-import③">(4)</a> <a href="#ref-for-at-ruledef-import④">(5)</a> <a href="#ref-for-at-ruledef-import⑤">(6)</a> <a href="#ref-for-at-ruledef-import⑥">(7)</a> <a href="#ref-for-at-ruledef-import⑦">(8)</a> <a href="#ref-for-at-ruledef-import⑧">(9)</a>
@@ -3755,15 +3755,15 @@ Additions Since Level 3</a>
     <li><a href="#ref-for-at-ruledef-import①⑦"> Privacy and Security Considerations</a> <a href="#ref-for-at-ruledef-import①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="import-conditions">
-   <b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-import-conditions" class="dfn-panel" data-for="import-conditions" id="infopanel-for-import-conditions" role="dialog">
+   <span id="infopaneltitle-for-import-conditions" style="display:none">Info about the 'import conditions' definition.</span><b><a href="#import-conditions">#import-conditions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-import-conditions">2.1. 
 Conditional @import Rules</a> <a href="#ref-for-import-conditions①">(2)</a> <a href="#ref-for-import-conditions②">(3)</a> <a href="#ref-for-import-conditions③">(4)</a> <a href="#ref-for-import-conditions④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query">
-   <b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query" class="dfn-panel" data-for="typedef-media-query" id="infopanel-for-typedef-media-query" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query" style="display:none">Info about the '&lt;media-query>' definition.</span><b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query">1.1. 
 Module Interactions</a>
@@ -3771,8 +3771,8 @@ Module Interactions</a>
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-condition">
-   <b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-condition" class="dfn-panel" data-for="typedef-supports-condition" id="infopanel-for-typedef-supports-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-condition" style="display:none">Info about the '&lt;supports-condition>' definition.</span><b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-condition">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-supports-condition①">(2)</a>
@@ -3780,8 +3780,8 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-supports-
 Conditional @import Rules</a> <a href="#ref-for-typedef-supports-condition③">(2)</a> <a href="#ref-for-typedef-supports-condition④">(3)</a> <a href="#ref-for-typedef-supports-condition⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-declaration">
-   <b><a href="#typedef-declaration">#typedef-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-declaration" class="dfn-panel" data-for="typedef-declaration" id="infopanel-for-typedef-declaration" role="dialog">
+   <span id="infopaneltitle-for-typedef-declaration" style="display:none">Info about the '&lt;declaration>' definition.</span><b><a href="#typedef-declaration">#typedef-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-declaration①">(2)</a>
@@ -3789,8 +3789,8 @@ Importing Style Sheets: the @import rule</a> <a href="#ref-for-typedef-declarati
 Conditional @import Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shorthand-property">
-   <b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shorthand-property" class="dfn-panel" data-for="shorthand-property" id="infopanel-for-shorthand-property" role="dialog">
+   <span id="infopaneltitle-for-shorthand-property" style="display:none">Info about the 'shorthand properties' definition.</span><b><a href="#shorthand-property">#shorthand-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. 
 Shorthand Properties</a> <a href="#ref-for-shorthand-property①">(2)</a> <a href="#ref-for-shorthand-property②">(3)</a> <a href="#ref-for-shorthand-property③">(4)</a> <a href="#ref-for-shorthand-property④">(5)</a> <a href="#ref-for-shorthand-property⑤">(6)</a> <a href="#ref-for-shorthand-property⑥">(7)</a> <a href="#ref-for-shorthand-property⑦">(8)</a> <a href="#ref-for-shorthand-property⑧">(9)</a>
@@ -3804,36 +3804,36 @@ Important Declarations: the !important annotation</a>
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="longhand">
-   <b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-longhand" class="dfn-panel" data-for="longhand" id="infopanel-for-longhand" role="dialog">
+   <span id="infopaneltitle-for-longhand" style="display:none">Info about the 'longhand sub-properties' definition.</span><b><a href="#longhand">#longhand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3. 
 Shorthand Properties</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a> <a href="#ref-for-longhand③">(4)</a> <a href="#ref-for-longhand④">(5)</a> <a href="#ref-for-longhand⑤">(6)</a> <a href="#ref-for-longhand⑥">(7)</a> <a href="#ref-for-longhand⑦">(8)</a> <a href="#ref-for-longhand⑧">(9)</a> <a href="#ref-for-longhand⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reset-only-sub-property">
-   <b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reset-only-sub-property" class="dfn-panel" data-for="reset-only-sub-property" id="infopanel-for-reset-only-sub-property" role="dialog">
+   <span id="infopaneltitle-for-reset-only-sub-property" style="display:none">Info about the 'reset-only sub-property' definition.</span><b><a href="#reset-only-sub-property">#reset-only-sub-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-only-sub-property">3. 
 Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-name-alias">
-   <b><a href="#legacy-name-alias">#legacy-name-alias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-name-alias" class="dfn-panel" data-for="legacy-name-alias" id="infopanel-for-legacy-name-alias" role="dialog">
+   <span id="infopaneltitle-for-legacy-name-alias" style="display:none">Info about the 'legacy name aliases' definition.</span><b><a href="#legacy-name-alias">#legacy-name-alias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-name-alias">3.1. 
 Aliasing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-shorthand">
-   <b><a href="#legacy-shorthand">#legacy-shorthand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-shorthand" class="dfn-panel" data-for="legacy-shorthand" id="infopanel-for-legacy-shorthand" role="dialog">
+   <span id="infopaneltitle-for-legacy-shorthand" style="display:none">Info about the 'legacy shorthands' definition.</span><b><a href="#legacy-shorthand">#legacy-shorthand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-shorthand">3.1. 
 Aliasing</a> <a href="#ref-for-legacy-shorthand①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-all">
-   <b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-all" class="dfn-panel" data-for="propdef-all" id="infopanel-for-propdef-all" role="dialog">
+   <span id="infopaneltitle-for-propdef-all" style="display:none">Info about the 'all' definition.</span><b><a href="#propdef-all">#propdef-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">3.2. 
 Resetting All Properties: the all property</a> <a href="#ref-for-propdef-all①">(2)</a> <a href="#ref-for-propdef-all②">(3)</a>
@@ -3841,8 +3841,8 @@ Resetting All Properties: the all property</a> <a href="#ref-for-propdef-all①"
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-value">
-   <b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-value" class="dfn-panel" data-for="declared-value" id="infopanel-for-declared-value" role="dialog">
+   <span id="infopaneltitle-for-declared-value" style="display:none">Info about the 'declared value' definition.</span><b><a href="#declared-value">#declared-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-value">4. 
 Value Processing</a> <a href="#ref-for-declared-value①">(2)</a> <a href="#ref-for-declared-value②">(3)</a>
@@ -3858,8 +3858,8 @@ Cascade Sorting Order</a>
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascaded-value">
-   <b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascaded-value" class="dfn-panel" data-for="cascaded-value" id="infopanel-for-cascaded-value" role="dialog">
+   <span id="infopaneltitle-for-cascaded-value" style="display:none">Info about the 'cascaded value' definition.</span><b><a href="#cascaded-value">#cascaded-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascaded-value">4. 
 Value Processing</a> <a href="#ref-for-cascaded-value①">(2)</a> <a href="#ref-for-cascaded-value②">(3)</a>
@@ -3881,8 +3881,8 @@ Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-cascaded-
 Rolling Back Cascade Layers: the revert-layer keyword</a> <a href="#ref-for-cascaded-value①⑥">(2)</a> <a href="#ref-for-cascaded-value①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-value">
-   <b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-value" class="dfn-panel" data-for="specified-value" id="infopanel-for-specified-value" role="dialog">
+   <span id="infopaneltitle-for-specified-value" style="display:none">Info about the 'specified value' definition.</span><b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">1. 
 Introduction</a>
@@ -3908,8 +3908,8 @@ Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-specified
 Rolling Back Cascade Layers: the revert-layer keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-value">
-   <b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-value" class="dfn-panel" data-for="computed-value" id="infopanel-for-computed-value" role="dialog">
+   <span id="infopaneltitle-for-computed-value" style="display:none">Info about the 'computed value' definition.</span><b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4. 
 Value Processing</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
@@ -3927,8 +3927,8 @@ Inheritance</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-value">
-   <b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-value" class="dfn-panel" data-for="used-value" id="infopanel-for-used-value" role="dialog">
+   <span id="infopaneltitle-for-used-value" style="display:none">Info about the 'used value' definition.</span><b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4. 
 Value Processing</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a> <a href="#ref-for-used-value③">(4)</a>
@@ -3940,8 +3940,8 @@ Used Values</a> <a href="#ref-for-used-value⑥">(2)</a> <a href="#ref-for-used-
 Actual Values</a> <a href="#ref-for-used-value⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply">
-   <b><a href="#apply">#apply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply" class="dfn-panel" data-for="apply" id="infopanel-for-apply" role="dialog">
+   <span id="infopaneltitle-for-apply" style="display:none">Info about the 'apply to' definition.</span><b><a href="#apply">#apply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply">4.4. 
 Computed Values</a>
@@ -3949,15 +3949,15 @@ Computed Values</a>
 Used Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-value">
-   <b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-value" class="dfn-panel" data-for="actual-value" id="infopanel-for-actual-value" role="dialog">
+   <span id="infopaneltitle-for-actual-value" style="display:none">Info about the 'actual value' definition.</span><b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">4. 
 Value Processing</a> <a href="#ref-for-actual-value①">(2)</a> <a href="#ref-for-actual-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade">
-   <b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade" class="dfn-panel" data-for="cascade" id="infopanel-for-cascade" role="dialog">
+   <span id="infopaneltitle-for-cascade" style="display:none">Info about the 'cascade' definition.</span><b><a href="#cascade">#cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">1. 
 Introduction</a> <a href="#ref-for-cascade">(2)</a>
@@ -3987,8 +3987,8 @@ Additions Since Level 3</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encapsulation-contexts">
-   <b><a href="#encapsulation-contexts">#encapsulation-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encapsulation-contexts" class="dfn-panel" data-for="encapsulation-contexts" id="infopanel-for-encapsulation-contexts" role="dialog">
+   <span id="infopaneltitle-for-encapsulation-contexts" style="display:none">Info about the 'encapsulation contexts' definition.</span><b><a href="#encapsulation-contexts">#encapsulation-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encapsulation-contexts">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-encapsulation-contexts①">(2)</a> <a href="#ref-for-encapsulation-contexts②">(3)</a> <a href="#ref-for-encapsulation-contexts③">(4)</a>
@@ -3998,15 +3998,15 @@ Declaring Cascade Layers: the @layer rule</a>
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="output-of-the-cascade">
-   <b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-output-of-the-cascade" class="dfn-panel" data-for="output-of-the-cascade" id="infopanel-for-output-of-the-cascade" role="dialog">
+   <span id="infopaneltitle-for-output-of-the-cascade" style="display:none">Info about the 'output of the cascade' definition.</span><b><a href="#output-of-the-cascade">#output-of-the-cascade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-of-the-cascade">4.2. 
 Cascaded Values</a> <a href="#ref-for-output-of-the-cascade①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin">
-   <b><a href="#origin">#origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin" class="dfn-panel" data-for="origin" id="infopanel-for-origin" role="dialog">
+   <span id="infopaneltitle-for-origin" style="display:none">Info about the 'cascade origin' definition.</span><b><a href="#origin">#origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.2. 
 Processing Stylesheet Imports</a> <a href="#ref-for-origin①">(2)</a>
@@ -4024,8 +4024,8 @@ Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-origin①
 Rolling Back Cascade Layers: the revert-layer keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-author">
-   <b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-author" class="dfn-panel" data-for="cascade-origin-author" id="infopanel-for-cascade-origin-author" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-author" style="display:none">Info about the 'Author Origin' definition.</span><b><a href="#cascade-origin-author">#cascade-origin-author</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-author">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-author①">(2)</a>
@@ -4037,8 +4037,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-cascade-origin-author①②">(2)</a> <a href="#ref-for-cascade-origin-author①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-user">
-   <b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-user" class="dfn-panel" data-for="cascade-origin-user" id="infopanel-for-cascade-origin-user" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-user" style="display:none">Info about the 'User Origin' definition.</span><b><a href="#cascade-origin-user">#cascade-origin-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-user">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-user①">(2)</a>
@@ -4050,8 +4050,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-cascade-origin-user⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-origin-ua">
-   <b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-origin-ua" class="dfn-panel" data-for="cascade-origin-ua" id="infopanel-for-cascade-origin-ua" role="dialog">
+   <span id="infopaneltitle-for-cascade-origin-ua" style="display:none">Info about the 'User-Agent Origin' definition.</span><b><a href="#cascade-origin-ua">#cascade-origin-ua</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-cascade-origin-ua①">(2)</a>
@@ -4063,8 +4063,8 @@ Precedence of Non-CSS Presentational Hints</a> <a href="#ref-for-cascade-origin-
 Rolling Back Cascade Origins: the revert keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="important">
-   <b><a href="#important">#important</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-important" class="dfn-panel" data-for="important" id="infopanel-for-important" role="dialog">
+   <span id="infopaneltitle-for-important" style="display:none">Info about the 'important' definition.</span><b><a href="#important">#important</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-important">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-important①">(2)</a> <a href="#ref-for-important②">(3)</a> <a href="#ref-for-important③">(4)</a> <a href="#ref-for-important④">(5)</a> <a href="#ref-for-important⑤">(6)</a> <a href="#ref-for-important⑥">(7)</a> <a href="#ref-for-important⑦">(8)</a> <a href="#ref-for-important⑧">(9)</a> <a href="#ref-for-important⑨">(10)</a>
@@ -4076,8 +4076,8 @@ Precedence of Non-CSS Presentational Hints</a>
 Rolling Back Cascade Layers: the revert-layer keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normal">
-   <b><a href="#normal">#normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normal" class="dfn-panel" data-for="normal" id="infopanel-for-normal" role="dialog">
+   <span id="infopaneltitle-for-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#normal">#normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normal">6.1. 
 Cascade Sorting Order</a> <a href="#ref-for-normal①">(2)</a> <a href="#ref-for-normal②">(3)</a> <a href="#ref-for-normal③">(4)</a> <a href="#ref-for-normal④">(5)</a> <a href="#ref-for-normal⑤">(6)</a> <a href="#ref-for-normal⑥">(7)</a> <a href="#ref-for-normal⑦">(8)</a>
@@ -4087,8 +4087,8 @@ Important Declarations: the !important annotation</a>
 Rolling Back Cascade Layers: the revert-layer keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cascade-layers">
-   <b><a href="#cascade-layers">#cascade-layers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cascade-layers" class="dfn-panel" data-for="cascade-layers" id="infopanel-for-cascade-layers" role="dialog">
+   <span id="infopaneltitle-for-cascade-layers" style="display:none">Info about the 'cascade layers' definition.</span><b><a href="#cascade-layers">#cascade-layers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-layers①">2. 
 Importing Style Sheets: the @import rule</a> <a href="#ref-for-cascade-layers②">(2)</a>
@@ -4106,8 +4106,8 @@ Changes</a>
 Additions Since Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-layer">
-   <b><a href="#at-ruledef-layer">#at-ruledef-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-layer" class="dfn-panel" data-for="at-ruledef-layer" id="infopanel-for-at-ruledef-layer" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-layer" style="display:none">Info about the '@layer' definition.</span><b><a href="#at-ruledef-layer">#at-ruledef-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-layer">2. 
 Importing Style Sheets: the @import rule</a>
@@ -4121,8 +4121,8 @@ Changes</a>
 Additions Since Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-layer-layer-ident">
-   <b><a href="#typedef-layer-layer-ident">#typedef-layer-layer-ident</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-layer-layer-ident" class="dfn-panel" data-for="typedef-layer-layer-ident" id="infopanel-for-typedef-layer-layer-ident" role="dialog">
+   <span id="infopaneltitle-for-typedef-layer-layer-ident" style="display:none">Info about the '&lt;layer-ident>' definition.</span><b><a href="#typedef-layer-layer-ident">#typedef-layer-layer-ident</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-layer-layer-ident">2. 
 Importing Style Sheets: the @import rule</a>
@@ -4130,8 +4130,8 @@ Importing Style Sheets: the @import rule</a>
 Declaring Cascade Layers: the @layer rule</a> <a href="#ref-for-typedef-layer-layer-ident②">(2)</a> <a href="#ref-for-typedef-layer-layer-ident③">(3)</a> <a href="#ref-for-typedef-layer-layer-ident④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layer-name">
-   <b><a href="#layer-name">#layer-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layer-name" class="dfn-panel" data-for="layer-name" id="infopanel-for-layer-name" role="dialog">
+   <span id="infopaneltitle-for-layer-name" style="display:none">Info about the 'layer name' definition.</span><b><a href="#layer-name">#layer-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layer-name">6.4.1. 
 Declaring Cascade Layers: the @layer rule</a> <a href="#ref-for-layer-name①">(2)</a>
@@ -4141,8 +4141,8 @@ Nested Layers</a> <a href="#ref-for-layer-name③">(2)</a> <a href="#ref-for-lay
 Un-Named Layers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-value">
-   <b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-value" class="dfn-panel" data-for="initial-value" id="infopanel-for-initial-value" role="dialog">
+   <span id="infopaneltitle-for-initial-value" style="display:none">Info about the 'initial value' definition.</span><b><a href="#initial-value">#initial-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">1. 
 Introduction</a>
@@ -4158,8 +4158,8 @@ Inheritance</a>
 Resetting a Property: the initial keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inheritance">
-   <b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inheritance" class="dfn-panel" data-for="inheritance" id="infopanel-for-inheritance" role="dialog">
+   <span id="infopaneltitle-for-inheritance" style="display:none">Info about the 'Inheritance' definition.</span><b><a href="#inheritance">#inheritance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inheritance">1. 
 Introduction</a>
@@ -4171,8 +4171,8 @@ Defaulting</a>
 Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-value">
-   <b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-value" class="dfn-panel" data-for="inherited-value" id="infopanel-for-inherited-value" role="dialog">
+   <span id="infopaneltitle-for-inherited-value" style="display:none">Info about the 'inherited value' definition.</span><b><a href="#inherited-value">#inherited-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">7.2. 
 Inheritance</a>
@@ -4180,8 +4180,8 @@ Inheritance</a>
 Explicit Inheritance: the inherit keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-property">
-   <b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-property" class="dfn-panel" data-for="inherited-property" id="infopanel-for-inherited-property" role="dialog">
+   <span id="infopaneltitle-for-inherited-property" style="display:none">Info about the 'inherited properties' definition.</span><b><a href="#inherited-property">#inherited-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-property">7. 
 Defaulting</a>
@@ -4189,8 +4189,8 @@ Defaulting</a>
 Initial Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-initial">
-   <b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-initial" class="dfn-panel" data-for="valdef-all-initial" id="infopanel-for-valdef-all-initial" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-initial" style="display:none">Info about the 'initial' definition.</span><b><a href="#valdef-all-initial">#valdef-all-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">7. 
 Defaulting</a>
@@ -4202,8 +4202,8 @@ Erasing All Declarations: the unset keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-inherit">
-   <b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-inherit" class="dfn-panel" data-for="valdef-all-inherit" id="infopanel-for-valdef-all-inherit" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-inherit" style="display:none">Info about the 'inherit' definition.</span><b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">7. 
 Defaulting</a>
@@ -4215,8 +4215,8 @@ Explicit Inheritance: the inherit keyword</a> <a href="#ref-for-valdef-all-inher
 Erasing All Declarations: the unset keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-unset">
-   <b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-unset" class="dfn-panel" data-for="valdef-all-unset" id="infopanel-for-valdef-all-unset" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-unset" style="display:none">Info about the 'unset' definition.</span><b><a href="#valdef-all-unset">#valdef-all-unset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">7.3.3. 
 Erasing All Declarations: the unset keyword</a> <a href="#ref-for-valdef-all-unset①">(2)</a>
@@ -4226,8 +4226,8 @@ Rolling Back Cascade Origins: the revert keyword</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-revert">
-   <b><a href="#valdef-all-revert">#valdef-all-revert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-revert" class="dfn-panel" data-for="valdef-all-revert" id="infopanel-for-valdef-all-revert" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-revert" style="display:none">Info about the 'revert' definition.</span><b><a href="#valdef-all-revert">#valdef-all-revert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert">7.3.4. 
 Rolling Back Cascade Origins: the revert keyword</a> <a href="#ref-for-valdef-all-revert①">(2)</a> <a href="#ref-for-valdef-all-revert②">(3)</a>
@@ -4237,8 +4237,8 @@ Rolling Back Cascade Layers: the revert-layer keyword</a>
 Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-revert-layer">
-   <b><a href="#valdef-all-revert-layer">#valdef-all-revert-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-revert-layer" class="dfn-panel" data-for="valdef-all-revert-layer" id="infopanel-for-valdef-all-revert-layer" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-revert-layer" style="display:none">Info about the 'revert-layer' definition.</span><b><a href="#valdef-all-revert-layer">#valdef-all-revert-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert-layer①">7.3.5. 
 Rolling Back Cascade Layers: the revert-layer keyword</a> <a href="#ref-for-valdef-all-revert-layer②">(2)</a> <a href="#ref-for-valdef-all-revert-layer③">(3)</a>
@@ -4265,59 +4265,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-4/Overview.html
@@ -7565,14 +7565,14 @@ and thus do not constitute an increased security risk.</p>
    <li><a href="#valdef-color-yellow">yellow</a><span>, in § 6.1</span>
    <li><a href="#valdef-color-yellowgreen">yellowgreen</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-actual-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-actual-value" class="dfn-panel" data-for="term-for-actual-value" id="infopanel-for-term-for-actual-value" role="menu">
+   <span id="infopaneltitle-for-term-for-actual-value" style="display:none">Info about the 'actual value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">4.6.4. Resolving device-cmyk values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4.6. 
 Resolving &lt;color> Values</a>
@@ -7583,22 +7583,22 @@ Resolving &lt;color> Values</a>
     <li><a href="#ref-for-computed-value⑤">4.7.6. Serializing other colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-value" class="dfn-panel" data-for="term-for-inherited-value" id="infopanel-for-term-for-inherited-value" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-value" style="display:none">Info about the 'inherited value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">4.6.5. Resolving other colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">4.6. 
 Resolving &lt;color> Values</a>
     <li><a href="#ref-for-specified-value①">4.6.1. Resolving sRGB values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4.6. 
 Resolving &lt;color> Values</a> <a href="#ref-for-used-value①">(2)</a>
@@ -7606,29 +7606,29 @@ Resolving &lt;color> Values</a> <a href="#ref-for-used-value①">(2)</a>
 The currentcolor keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-colors-mode">
-   <a href="https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode">https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-colors-mode" class="dfn-panel" data-for="term-for-forced-colors-mode" id="infopanel-for-term-for-forced-colors-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-colors-mode" style="display:none">Info about the 'forced colors mode' external reference.</span><a href="https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode">https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-colors-mode">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">10.3. 
 Specifying a color profile: the @color-profile at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-hash-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-hash-token" class="dfn-panel" data-for="term-for-typedef-hash-token" id="infopanel-for-term-for-typedef-hash-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-hash-token" style="display:none">Info about the '&lt;hash-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hash-token">5.2. 
 The RGB hexadecimal notations: #RRGGBB</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-color">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-color" class="dfn-panel" data-for="term-for-propdef-text-emphasis-color" id="infopanel-for-term-for-propdef-text-emphasis-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-color" style="display:none">Info about the 'text-emphasis-color' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-color">6.4. 
 The currentcolor keyword</a>
@@ -7636,21 +7636,21 @@ The currentcolor keyword</a>
 Interpolation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">5.1. 
 The RGB functions: rgb() and rgba()</a> <a href="#ref-for-mult-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">10.1. Specifying profiled colors: the color() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">5.1. 
 The RGB functions: rgb() and rgba()</a> <a href="#ref-for-comb-comma①">(2)</a>
@@ -7660,15 +7660,15 @@ HSL Colors: hsl() and hsla() functions</a> <a href="#ref-for-comb-comma③">(2)<
 Device-dependent CMYK Colors: the device-cmyk() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">4.2. The &lt;hue> syntax</a>
     <li><a href="#ref-for-angle-value①"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dashed-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dashed-ident" class="dfn-panel" data-for="term-for-typedef-dashed-ident" id="infopanel-for-term-for-typedef-dashed-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dashed-ident" style="display:none">Info about the '&lt;dashed-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dashed-ident">10. 
 Profiled, Device-dependent Colors</a>
@@ -7677,23 +7677,23 @@ Profiled, Device-dependent Colors</a>
 Specifying a color profile: the @color-profile at-rule</a> <a href="#ref-for-typedef-dashed-ident⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">6.1. 
 Named Colors</a> <a href="#ref-for-typedef-ident①">(2)</a>
     <li><a href="#ref-for-typedef-ident②">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-typedef-ident③">(2)</a> <a href="#ref-for-typedef-ident④">(3)</a> <a href="#ref-for-typedef-ident⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">4.7.2. Serializing sRGB values</a> <a href="#ref-for-integer-value①">(2)</a>
     <li><a href="#ref-for-integer-value②"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">4.2. The &lt;hue> syntax</a>
     <li><a href="#ref-for-number-value①">4.6.2. Resolving Lab and LCH values</a>
@@ -7714,8 +7714,8 @@ Device-dependent CMYK Colors: the device-cmyk() function</a>
     <li><a href="#ref-for-number-value②⑥"> Changes from Colors 3</a> <a href="#ref-for-number-value②⑦">(2)</a> <a href="#ref-for-number-value②⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.6.2. Resolving Lab and LCH values</a>
     <li><a href="#ref-for-percentage-value①">4.6.3. Resolving values of the color() function</a>
@@ -7737,15 +7737,15 @@ Device-dependent CMYK Colors: the device-cmyk() function</a>
     <li><a href="#ref-for-percentage-value②⑤"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">10.3. 
 Specifying a color profile: the @color-profile at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5.1. 
 The RGB functions: rgb() and rgba()</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a>
@@ -7760,22 +7760,22 @@ Specifying Lab and LCH: the lab() and lch() functional notations</a> <a href="#r
 Device-dependent CMYK Colors: the device-cmyk() function</a> <a href="#ref-for-mult-opt①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-keyword">
-   <a href="https://drafts.csswg.org/css-values-4/#css-keyword">https://drafts.csswg.org/css-values-4/#css-keyword</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-keyword" class="dfn-panel" data-for="term-for-css-keyword" id="infopanel-for-term-for-css-keyword" role="menu">
+   <span id="infopaneltitle-for-term-for-css-keyword" style="display:none">Info about the 'keyword' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-keyword">https://drafts.csswg.org/css-values-4/#css-keyword</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-keyword">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">5.1. 
 The RGB functions: rgb() and rgba()</a> <a href="#ref-for-mult-num①">(2)</a>
@@ -7783,8 +7783,8 @@ The RGB functions: rgb() and rgba()</a> <a href="#ref-for-mult-num①">(2)</a>
 Device-dependent CMYK Colors: the device-cmyk() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. The &lt;color> syntax</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a>
     <li><a href="#ref-for-comb-one①③">4.2. The &lt;hue> syntax</a>
@@ -7797,43 +7797,43 @@ Specifying a color profile: the @color-profile at-rule</a> <a href="#ref-for-com
 Device-dependent CMYK Colors: the device-cmyk() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">12. 
 Transparency: the opacity property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">12. 
 Transparency: the opacity property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">4.6. 
 Resolving &lt;color> Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-mark-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-mark-element" class="dfn-panel" data-for="term-for-the-mark-element" id="infopanel-for-term-for-the-mark-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-mark-element" style="display:none">Info about the 'mark' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-mark-element">6.2. 
 System Colors</a> <a href="#ref-for-the-mark-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-feature">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-feature">https://drafts.csswg.org/mediaqueries-5/#media-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-feature" class="dfn-panel" data-for="term-for-media-feature" id="infopanel-for-term-for-media-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-media-feature" style="display:none">Info about the 'media feature' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-feature">https://drafts.csswg.org/mediaqueries-5/#media-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-feature">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">12. 
 Transparency: the opacity property</a>
@@ -8046,15 +8046,15 @@ Transparency: the opacity property</a>
    <div class="issue"> <a href="https://github.com/w3c/csswg-drafts/issues/4928">[Issue #4928]</a> <a class="issue-return" href="#issue-d41d8cd9③" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/csswg-drafts/issues/5277">[Issue #5277]</a> <a class="issue-return" href="#issue-d41d8cd9④" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="color">
-   <b><a href="#color">#color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color" class="dfn-panel" data-for="color" id="infopanel-for-color" role="dialog">
+   <span id="infopaneltitle-for-color" style="display:none">Info about the 'color' definition.</span><b><a href="#color">#color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color">10. 
 Profiled, Device-dependent Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-space">
-   <b><a href="#color-space">#color-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-space" class="dfn-panel" data-for="color-space" id="infopanel-for-color-space" role="dialog">
+   <span id="infopaneltitle-for-color-space" style="display:none">Info about the 'color space' definition.</span><b><a href="#color-space">#color-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-space">1. 
 Introduction</a> <a href="#ref-for-color-space①">(2)</a>
@@ -8065,14 +8065,14 @@ sRGB Colors</a>
     <li><a href="#ref-for-color-space⑥">10.1. Specifying profiled colors: the color() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calibrated">
-   <b><a href="#calibrated">#calibrated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calibrated" class="dfn-panel" data-for="calibrated" id="infopanel-for-calibrated" role="dialog">
+   <span id="infopaneltitle-for-calibrated" style="display:none">Info about the 'calibrated' definition.</span><b><a href="#calibrated">#calibrated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibrated">2. Color terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-color">
-   <b><a href="#propdef-color">#propdef-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-color" class="dfn-panel" data-for="propdef-color" id="infopanel-for-propdef-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-color" style="display:none">Info about the 'color' definition.</span><b><a href="#propdef-color">#propdef-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3. 
 Foreground Color: the color property</a>
@@ -8081,8 +8081,8 @@ Foreground Color: the color property</a>
 The currentcolor keyword</a> <a href="#ref-for-propdef-color⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color">
-   <b><a href="#typedef-color">#typedef-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color" class="dfn-panel" data-for="typedef-color" id="infopanel-for-typedef-color" role="dialog">
+   <span id="infopaneltitle-for-typedef-color" style="display:none">Info about the '&lt;color>' definition.</span><b><a href="#typedef-color">#typedef-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color①">1. 
 Introduction</a>
@@ -8109,43 +8109,43 @@ Interpolation</a>
     <li><a href="#ref-for-typedef-color①⑧"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-functions">
-   <b><a href="#color-functions">#color-functions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-functions" class="dfn-panel" data-for="color-functions" id="infopanel-for-color-functions" role="dialog">
+   <span id="infopaneltitle-for-color-functions" style="display:none">Info about the 'color-functions' definition.</span><b><a href="#color-functions">#color-functions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-functions">5. 
 sRGB Colors</a> <a href="#ref-for-color-functions①">(2)</a> <a href="#ref-for-color-functions②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cylindrical-polar-color">
-   <b><a href="#cylindrical-polar-color">#cylindrical-polar-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cylindrical-polar-color" class="dfn-panel" data-for="cylindrical-polar-color" id="infopanel-for-cylindrical-polar-color" role="dialog">
+   <span id="infopaneltitle-for-cylindrical-polar-color" style="display:none">Info about the 'cylindrical polar color' definition.</span><b><a href="#cylindrical-polar-color">#cylindrical-polar-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cylindrical-polar-color">13.2. 
 Interpolating with alpha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangular-orthogonal-color">
-   <b><a href="#rectangular-orthogonal-color">#rectangular-orthogonal-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangular-orthogonal-color" class="dfn-panel" data-for="rectangular-orthogonal-color" id="infopanel-for-rectangular-orthogonal-color" role="dialog">
+   <span id="infopaneltitle-for-rectangular-orthogonal-color" style="display:none">Info about the 'rectangular orthogonal color' definition.</span><b><a href="#rectangular-orthogonal-color">#rectangular-orthogonal-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangular-orthogonal-color">13.2. 
 Interpolating with alpha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-black">
-   <b><a href="#opaque-black">#opaque-black</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-black" class="dfn-panel" data-for="opaque-black" id="infopanel-for-opaque-black" role="dialog">
+   <span id="infopaneltitle-for-opaque-black" style="display:none">Info about the 'opaque black' definition.</span><b><a href="#opaque-black">#opaque-black</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-black">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-opaque-black①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transparent-black">
-   <b><a href="#transparent-black">#transparent-black</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transparent-black" class="dfn-panel" data-for="transparent-black" id="infopanel-for-transparent-black" role="dialog">
+   <span id="infopaneltitle-for-transparent-black" style="display:none">Info about the 'transparent black' definition.</span><b><a href="#transparent-black">#transparent-black</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transparent-black">4.6.5. Resolving other colors</a>
     <li><a href="#ref-for-transparent-black①">6.3. 
 The transparent keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hue">
-   <b><a href="#typedef-hue">#typedef-hue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hue" class="dfn-panel" data-for="typedef-hue" id="infopanel-for-typedef-hue" role="dialog">
+   <span id="infopaneltitle-for-typedef-hue" style="display:none">Info about the '&lt;hue>' definition.</span><b><a href="#typedef-hue">#typedef-hue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hue">4.1. The &lt;color> syntax</a>
     <li><a href="#ref-for-typedef-hue①">4.2. The &lt;hue> syntax</a>
@@ -8157,16 +8157,16 @@ HWB Colors: hwb() function</a>
 Specifying Lab and LCH: the lab() and lch() functional notations</a> <a href="#ref-for-typedef-hue⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="untagged-image">
-   <b><a href="#untagged-image">#untagged-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-untagged-image" class="dfn-panel" data-for="untagged-image" id="infopanel-for-untagged-image" role="dialog">
+   <span id="infopaneltitle-for-untagged-image" style="display:none">Info about the 'untagged image' definition.</span><b><a href="#untagged-image">#untagged-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-untagged-image">4.4. Color Space of Tagged Images</a>
     <li><a href="#ref-for-untagged-image①">4.5. 
 Color Spaces of Untagged Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rgb">
-   <b><a href="#funcdef-rgb">#funcdef-rgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rgb" class="dfn-panel" data-for="funcdef-rgb" id="infopanel-for-funcdef-rgb" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rgb" style="display:none">Info about the 'rgb()' definition.</span><b><a href="#funcdef-rgb">#funcdef-rgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rgb">4. 
 Representing Colors: the &lt;color> type</a>
@@ -8196,8 +8196,8 @@ Color space for interpolation</a>
     <li><a href="#ref-for-funcdef-rgb②③"> Changes from Colors 3</a> <a href="#ref-for-funcdef-rgb②④">(2)</a> <a href="#ref-for-funcdef-rgb②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-alpha-value">
-   <b><a href="#typedef-alpha-value">#typedef-alpha-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-alpha-value" class="dfn-panel" data-for="typedef-alpha-value" id="infopanel-for-typedef-alpha-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-alpha-value" style="display:none">Info about the '&lt;alpha-value>' definition.</span><b><a href="#typedef-alpha-value">#typedef-alpha-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-alpha-value">5.1. 
 The RGB functions: rgb() and rgba()</a> <a href="#ref-for-typedef-alpha-value①">(2)</a> <a href="#ref-for-typedef-alpha-value②">(3)</a> <a href="#ref-for-typedef-alpha-value③">(4)</a> <a href="#ref-for-typedef-alpha-value④">(5)</a>
@@ -8215,8 +8215,8 @@ Transparency: the opacity property</a> <a href="#ref-for-typedef-alpha-value①�
     <li><a href="#ref-for-typedef-alpha-value①⑧"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rgba">
-   <b><a href="#funcdef-rgba">#funcdef-rgba</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rgba" class="dfn-panel" data-for="funcdef-rgba" id="infopanel-for-funcdef-rgba" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rgba" style="display:none">Info about the 'rgba()' definition.</span><b><a href="#funcdef-rgba">#funcdef-rgba</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rgba">4.1. The &lt;color> syntax</a> <a href="#ref-for-funcdef-rgba①">(2)</a>
     <li><a href="#ref-for-funcdef-rgba②">4.6.1. Resolving sRGB values</a>
@@ -8228,8 +8228,8 @@ The RGB functions: rgb() and rgba()</a>
     <li><a href="#ref-for-funcdef-rgba⑨"> Changes from Colors 3</a> <a href="#ref-for-funcdef-rgba①⓪">(2)</a> <a href="#ref-for-funcdef-rgba①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hex-color">
-   <b><a href="#hex-color">#hex-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hex-color" class="dfn-panel" data-for="hex-color" id="infopanel-for-hex-color" role="dialog">
+   <span id="infopaneltitle-for-hex-color" style="display:none">Info about the 'hex color notation' definition.</span><b><a href="#hex-color">#hex-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hex-color">4. 
 Representing Colors: the &lt;color> type</a>
@@ -8239,14 +8239,14 @@ Representing Colors: the &lt;color> type</a>
 sRGB Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hex-color">
-   <b><a href="#typedef-hex-color">#typedef-hex-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hex-color" class="dfn-panel" data-for="typedef-hex-color" id="infopanel-for-typedef-hex-color" role="dialog">
+   <span id="infopaneltitle-for-typedef-hex-color" style="display:none">Info about the '&lt;hex-color>' definition.</span><b><a href="#typedef-hex-color">#typedef-hex-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hex-color">4.1. The &lt;color> syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="named-color">
-   <b><a href="#named-color">#named-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-named-color" class="dfn-panel" data-for="named-color" id="infopanel-for-named-color" role="dialog">
+   <span id="infopaneltitle-for-named-color" style="display:none">Info about the 'named colors' definition.</span><b><a href="#named-color">#named-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-color">4. 
 Representing Colors: the &lt;color> type</a>
@@ -8256,8 +8256,8 @@ Representing Colors: the &lt;color> type</a>
 sRGB Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-named-color">
-   <b><a href="#typedef-named-color">#typedef-named-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-named-color" class="dfn-panel" data-for="typedef-named-color" id="infopanel-for-typedef-named-color" role="dialog">
+   <span id="infopaneltitle-for-typedef-named-color" style="display:none">Info about the '&lt;named-color>' definition.</span><b><a href="#typedef-named-color">#typedef-named-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-named-color">4.1. The &lt;color> syntax</a>
     <li><a href="#ref-for-typedef-named-color①">6.3. 
@@ -8266,76 +8266,77 @@ The transparent keyword</a>
 The currentcolor keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-blue">
-   <b><a href="#valdef-color-blue">#valdef-color-blue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-blue" class="dfn-panel" data-for="valdef-color-blue" id="infopanel-for-valdef-color-blue" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-blue" style="display:none">Info about the 'blue' definition.</span><b><a href="#valdef-color-blue">#valdef-color-blue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-blue">7. 
 HSL Colors: hsl() and hsla() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-darkgray">
-   <b><a href="#valdef-color-darkgray">#valdef-color-darkgray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-darkgray" class="dfn-panel" data-for="valdef-color-darkgray" id="infopanel-for-valdef-color-darkgray" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-darkgray" style="display:none">Info about the 'darkgray' definition.</span><b><a href="#valdef-color-darkgray">#valdef-color-darkgray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-darkgray">6.1. 
 Named Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-goldenrod">
-   <b><a href="#valdef-color-goldenrod">#valdef-color-goldenrod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-goldenrod" class="dfn-panel" data-for="valdef-color-goldenrod" id="infopanel-for-valdef-color-goldenrod" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-goldenrod" style="display:none">Info about the 'goldenrod' definition.</span><b><a href="#valdef-color-goldenrod">#valdef-color-goldenrod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-goldenrod">4.7.2. Serializing sRGB values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-gray">
-   <b><a href="#valdef-color-gray">#valdef-color-gray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-gray" class="dfn-panel" data-for="valdef-color-gray" id="infopanel-for-valdef-color-gray" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-gray" style="display:none">Info about the 'gray' definition.</span><b><a href="#valdef-color-gray">#valdef-color-gray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-gray">6.1. 
 Named Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-indianred">
-   <b><a href="#valdef-color-indianred">#valdef-color-indianred</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-indianred" class="dfn-panel" data-for="valdef-color-indianred" id="infopanel-for-valdef-color-indianred" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-indianred" style="display:none">Info about the 'indianred' definition.</span><b><a href="#valdef-color-indianred">#valdef-color-indianred</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-indianred">6.1. 
 Named Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-lightpink">
-   <b><a href="#valdef-color-lightpink">#valdef-color-lightpink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-lightpink" class="dfn-panel" data-for="valdef-color-lightpink" id="infopanel-for-valdef-color-lightpink" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-lightpink" style="display:none">Info about the 'lightpink' definition.</span><b><a href="#valdef-color-lightpink">#valdef-color-lightpink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-lightpink">6.1. 
 Named Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-pink">
-   <b><a href="#valdef-color-pink">#valdef-color-pink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-pink" class="dfn-panel" data-for="valdef-color-pink" id="infopanel-for-valdef-color-pink" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-pink" style="display:none">Info about the 'pink' definition.</span><b><a href="#valdef-color-pink">#valdef-color-pink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-pink">6.1. 
 Named Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-rebeccapurple">
-   <b><a href="#valdef-color-rebeccapurple">#valdef-color-rebeccapurple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-rebeccapurple" class="dfn-panel" data-for="valdef-color-rebeccapurple" id="infopanel-for-valdef-color-rebeccapurple" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-rebeccapurple" style="display:none">Info about the 'rebeccapurple' definition.</span><b><a href="#valdef-color-rebeccapurple">#valdef-color-rebeccapurple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-rebeccapurple"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-red">
-   <b><a href="#valdef-color-red">#valdef-color-red</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-red" class="dfn-panel" data-for="valdef-color-red" id="infopanel-for-valdef-color-red" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-red" style="display:none">Info about the 'red' definition.</span><b><a href="#valdef-color-red">#valdef-color-red</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">7. 
 HSL Colors: hsl() and hsla() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-yellow">
-   <b><a href="#valdef-color-yellow">#valdef-color-yellow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-yellow" class="dfn-panel" data-for="valdef-color-yellow" id="infopanel-for-valdef-color-yellow" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-yellow" style="display:none">Info about the 'yellow' definition.</span><b><a href="#valdef-color-yellow">#valdef-color-yellow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-yellow">7. 
 HSL Colors: hsl() and hsla() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-system-colors">
-   <b><a href="#css-system-colors">#css-system-colors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-system-colors" class="dfn-panel" data-for="css-system-colors" id="infopanel-for-css-system-colors" role="dialog">
+   <span id="infopaneltitle-for-css-system-colors" style="display:none">Info about the '6.2. 
+System Colors' definition.</span><b><a href="#css-system-colors">#css-system-colors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-system-colors">4.6.5. Resolving other colors</a>
     <li><a href="#ref-for-css-system-colors①">4.7.6. Serializing other colors</a>
@@ -8345,8 +8346,8 @@ System Colors</a>
     <li><a href="#ref-for-css-system-colors">18. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-system-color">
-   <b><a href="#typedef-system-color">#typedef-system-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-system-color" class="dfn-panel" data-for="typedef-system-color" id="infopanel-for-typedef-system-color" role="dialog">
+   <span id="infopaneltitle-for-typedef-system-color" style="display:none">Info about the '&lt;system-color>' definition.</span><b><a href="#typedef-system-color">#typedef-system-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-system-color">4.1. The &lt;color> syntax</a>
     <li><a href="#ref-for-typedef-system-color①">4.6.5. Resolving other colors</a>
@@ -8354,118 +8355,118 @@ System Colors</a>
 System Colors</a> <a href="#ref-for-typedef-system-color③">(2)</a> <a href="#ref-for-typedef-system-color④">(3)</a> <a href="#ref-for-typedef-system-color⑤">(4)</a> <a href="#ref-for-typedef-system-color⑥">(5)</a> <a href="#ref-for-typedef-system-color⑦">(6)</a> <a href="#ref-for-typedef-system-color⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-canvas">
-   <b><a href="#valdef-system-color-canvas">#valdef-system-color-canvas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-canvas" class="dfn-panel" data-for="valdef-system-color-canvas" id="infopanel-for-valdef-system-color-canvas" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-canvas" style="display:none">Info about the 'Canvas' definition.</span><b><a href="#valdef-system-color-canvas">#valdef-system-color-canvas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-canvas">6.2. 
 System Colors</a> <a href="#ref-for-valdef-system-color-canvas①">(2)</a> <a href="#ref-for-valdef-system-color-canvas②">(3)</a> <a href="#ref-for-valdef-system-color-canvas③">(4)</a> <a href="#ref-for-valdef-system-color-canvas④">(5)</a>
     <li><a href="#ref-for-valdef-system-color-canvas⑤"> Appendix A: Deprecated CSS System Colors</a> <a href="#ref-for-valdef-system-color-canvas⑥">(2)</a> <a href="#ref-for-valdef-system-color-canvas⑦">(3)</a> <a href="#ref-for-valdef-system-color-canvas⑧">(4)</a> <a href="#ref-for-valdef-system-color-canvas⑨">(5)</a> <a href="#ref-for-valdef-system-color-canvas①⓪">(6)</a> <a href="#ref-for-valdef-system-color-canvas①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-canvastext">
-   <b><a href="#valdef-system-color-canvastext">#valdef-system-color-canvastext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-canvastext" class="dfn-panel" data-for="valdef-system-color-canvastext" id="infopanel-for-valdef-system-color-canvastext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-canvastext" style="display:none">Info about the 'CanvasText' definition.</span><b><a href="#valdef-system-color-canvastext">#valdef-system-color-canvastext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-canvastext">6.2. 
 System Colors</a>
     <li><a href="#ref-for-valdef-system-color-canvastext①"> Appendix A: Deprecated CSS System Colors</a> <a href="#ref-for-valdef-system-color-canvastext②">(2)</a> <a href="#ref-for-valdef-system-color-canvastext③">(3)</a> <a href="#ref-for-valdef-system-color-canvastext④">(4)</a> <a href="#ref-for-valdef-system-color-canvastext⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-linktext">
-   <b><a href="#valdef-system-color-linktext">#valdef-system-color-linktext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-linktext" class="dfn-panel" data-for="valdef-system-color-linktext" id="infopanel-for-valdef-system-color-linktext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-linktext" style="display:none">Info about the 'LinkText' definition.</span><b><a href="#valdef-system-color-linktext">#valdef-system-color-linktext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-linktext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-visitedtext">
-   <b><a href="#valdef-system-color-visitedtext">#valdef-system-color-visitedtext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-visitedtext" class="dfn-panel" data-for="valdef-system-color-visitedtext" id="infopanel-for-valdef-system-color-visitedtext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-visitedtext" style="display:none">Info about the 'VisitedText' definition.</span><b><a href="#valdef-system-color-visitedtext">#valdef-system-color-visitedtext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-visitedtext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-activetext">
-   <b><a href="#valdef-system-color-activetext">#valdef-system-color-activetext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-activetext" class="dfn-panel" data-for="valdef-system-color-activetext" id="infopanel-for-valdef-system-color-activetext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-activetext" style="display:none">Info about the 'ActiveText' definition.</span><b><a href="#valdef-system-color-activetext">#valdef-system-color-activetext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-activetext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-buttonface">
-   <b><a href="#valdef-system-color-buttonface">#valdef-system-color-buttonface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-buttonface" class="dfn-panel" data-for="valdef-system-color-buttonface" id="infopanel-for-valdef-system-color-buttonface" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-buttonface" style="display:none">Info about the 'ButtonFace' definition.</span><b><a href="#valdef-system-color-buttonface">#valdef-system-color-buttonface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-buttonface">6.2. 
 System Colors</a> <a href="#ref-for-valdef-system-color-buttonface①">(2)</a>
     <li><a href="#ref-for-valdef-system-color-buttonface②"> Appendix A: Deprecated CSS System Colors</a> <a href="#ref-for-valdef-system-color-buttonface③">(2)</a> <a href="#ref-for-valdef-system-color-buttonface④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-buttontext">
-   <b><a href="#valdef-system-color-buttontext">#valdef-system-color-buttontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-buttontext" class="dfn-panel" data-for="valdef-system-color-buttontext" id="infopanel-for-valdef-system-color-buttontext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-buttontext" style="display:none">Info about the 'ButtonText' definition.</span><b><a href="#valdef-system-color-buttontext">#valdef-system-color-buttontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-buttontext">6.2. 
 System Colors</a> <a href="#ref-for-valdef-system-color-buttontext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-buttonborder">
-   <b><a href="#valdef-system-color-buttonborder">#valdef-system-color-buttonborder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-buttonborder" class="dfn-panel" data-for="valdef-system-color-buttonborder" id="infopanel-for-valdef-system-color-buttonborder" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-buttonborder" style="display:none">Info about the 'ButtonBorder' definition.</span><b><a href="#valdef-system-color-buttonborder">#valdef-system-color-buttonborder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-buttonborder">6.2. 
 System Colors</a> <a href="#ref-for-valdef-system-color-buttonborder①">(2)</a>
     <li><a href="#ref-for-valdef-system-color-buttonborder②"> Appendix A: Deprecated CSS System Colors</a> <a href="#ref-for-valdef-system-color-buttonborder③">(2)</a> <a href="#ref-for-valdef-system-color-buttonborder④">(3)</a> <a href="#ref-for-valdef-system-color-buttonborder⑤">(4)</a> <a href="#ref-for-valdef-system-color-buttonborder⑥">(5)</a> <a href="#ref-for-valdef-system-color-buttonborder⑦">(6)</a> <a href="#ref-for-valdef-system-color-buttonborder⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-field">
-   <b><a href="#valdef-system-color-field">#valdef-system-color-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-field" class="dfn-panel" data-for="valdef-system-color-field" id="infopanel-for-valdef-system-color-field" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-field" style="display:none">Info about the 'Field' definition.</span><b><a href="#valdef-system-color-field">#valdef-system-color-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-field">6.2. 
 System Colors</a> <a href="#ref-for-valdef-system-color-field①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-fieldtext">
-   <b><a href="#valdef-system-color-fieldtext">#valdef-system-color-fieldtext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-fieldtext" class="dfn-panel" data-for="valdef-system-color-fieldtext" id="infopanel-for-valdef-system-color-fieldtext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-fieldtext" style="display:none">Info about the 'FieldText' definition.</span><b><a href="#valdef-system-color-fieldtext">#valdef-system-color-fieldtext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-fieldtext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-highlight">
-   <b><a href="#valdef-system-color-highlight">#valdef-system-color-highlight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-highlight" class="dfn-panel" data-for="valdef-system-color-highlight" id="infopanel-for-valdef-system-color-highlight" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-highlight" style="display:none">Info about the 'Highlight' definition.</span><b><a href="#valdef-system-color-highlight">#valdef-system-color-highlight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-highlight">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-highlighttext">
-   <b><a href="#valdef-system-color-highlighttext">#valdef-system-color-highlighttext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-highlighttext" class="dfn-panel" data-for="valdef-system-color-highlighttext" id="infopanel-for-valdef-system-color-highlighttext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-highlighttext" style="display:none">Info about the 'HighlightText' definition.</span><b><a href="#valdef-system-color-highlighttext">#valdef-system-color-highlighttext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-highlighttext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-mark">
-   <b><a href="#valdef-system-color-mark">#valdef-system-color-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-mark" class="dfn-panel" data-for="valdef-system-color-mark" id="infopanel-for-valdef-system-color-mark" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-mark" style="display:none">Info about the 'Mark' definition.</span><b><a href="#valdef-system-color-mark">#valdef-system-color-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-mark">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-marktext">
-   <b><a href="#valdef-system-color-marktext">#valdef-system-color-marktext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-marktext" class="dfn-panel" data-for="valdef-system-color-marktext" id="infopanel-for-valdef-system-color-marktext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-marktext" style="display:none">Info about the 'MarkText' definition.</span><b><a href="#valdef-system-color-marktext">#valdef-system-color-marktext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-marktext">6.2. 
 System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-color-graytext">
-   <b><a href="#valdef-system-color-graytext">#valdef-system-color-graytext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-color-graytext" class="dfn-panel" data-for="valdef-system-color-graytext" id="infopanel-for-valdef-system-color-graytext" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-color-graytext" style="display:none">Info about the 'GrayText' definition.</span><b><a href="#valdef-system-color-graytext">#valdef-system-color-graytext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-graytext">6.2. 
 System Colors</a>
     <li><a href="#ref-for-valdef-system-color-graytext①"> Appendix A: Deprecated CSS System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-transparent">
-   <b><a href="#valdef-color-transparent">#valdef-color-transparent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-transparent" class="dfn-panel" data-for="valdef-color-transparent" id="infopanel-for-valdef-color-transparent" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-transparent" style="display:none">Info about the 'transparent' definition.</span><b><a href="#valdef-color-transparent">#valdef-color-transparent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">4.6.5. Resolving other colors</a> <a href="#ref-for-valdef-color-transparent①">(2)</a>
     <li><a href="#ref-for-valdef-color-transparent②">4.7.6. Serializing other colors</a> <a href="#ref-for-valdef-color-transparent③">(2)</a>
@@ -8477,8 +8478,8 @@ Named Colors</a>
 The transparent keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-currentcolor">
-   <b><a href="#valdef-color-currentcolor">#valdef-color-currentcolor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-currentcolor" class="dfn-panel" data-for="valdef-color-currentcolor" id="infopanel-for-valdef-color-currentcolor" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' definition.</span><b><a href="#valdef-color-currentcolor">#valdef-color-currentcolor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">3. 
 Foreground Color: the color property</a> <a href="#ref-for-valdef-color-currentcolor①">(2)</a>
@@ -8492,8 +8493,8 @@ The currentcolor keyword</a> <a href="#ref-for-valdef-color-currentcolor①⓪">
 Interpolation</a> <a href="#ref-for-valdef-color-currentcolor①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hsl">
-   <b><a href="#funcdef-hsl">#funcdef-hsl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hsl" class="dfn-panel" data-for="funcdef-hsl" id="infopanel-for-funcdef-hsl" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hsl" style="display:none">Info about the 'hsl()' definition.</span><b><a href="#funcdef-hsl">#funcdef-hsl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hsl">4. 
 Representing Colors: the &lt;color> type</a>
@@ -8514,8 +8515,8 @@ Color space for interpolation</a>
     <li><a href="#ref-for-funcdef-hsl①⑤"> Changes from Colors 3</a> <a href="#ref-for-funcdef-hsl①⑥">(2)</a> <a href="#ref-for-funcdef-hsl①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hsla">
-   <b><a href="#funcdef-hsla">#funcdef-hsla</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hsla" class="dfn-panel" data-for="funcdef-hsla" id="infopanel-for-funcdef-hsla" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hsla" style="display:none">Info about the 'hsla()' definition.</span><b><a href="#funcdef-hsla">#funcdef-hsla</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hsla">4.1. The &lt;color> syntax</a> <a href="#ref-for-funcdef-hsla①">(2)</a> <a href="#ref-for-funcdef-hsla②">(3)</a>
     <li><a href="#ref-for-funcdef-hsla③">4.6.1. Resolving sRGB values</a>
@@ -8527,8 +8528,8 @@ HSL Colors: hsl() and hsla() functions</a>
     <li><a href="#ref-for-funcdef-hsla⑦"> Changes from Colors 3</a> <a href="#ref-for-funcdef-hsla⑧">(2)</a> <a href="#ref-for-funcdef-hsla⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hwb">
-   <b><a href="#funcdef-hwb">#funcdef-hwb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hwb" class="dfn-panel" data-for="funcdef-hwb" id="infopanel-for-funcdef-hwb" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hwb" style="display:none">Info about the 'hwb()' definition.</span><b><a href="#funcdef-hwb">#funcdef-hwb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hwb">4.1. The &lt;color> syntax</a> <a href="#ref-for-funcdef-hwb①">(2)</a> <a href="#ref-for-funcdef-hwb②">(3)</a>
     <li><a href="#ref-for-funcdef-hwb③">4.6.1. Resolving sRGB values</a>
@@ -8542,8 +8543,8 @@ Color space for interpolation</a>
     <li><a href="#ref-for-funcdef-hwb⑨"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-lab">
-   <b><a href="#funcdef-lab">#funcdef-lab</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-lab" class="dfn-panel" data-for="funcdef-lab" id="infopanel-for-funcdef-lab" role="dialog">
+   <span id="infopaneltitle-for-funcdef-lab" style="display:none">Info about the 'lab()' definition.</span><b><a href="#funcdef-lab">#funcdef-lab</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-lab">4.1. The &lt;color> syntax</a> <a href="#ref-for-funcdef-lab①">(2)</a>
     <li><a href="#ref-for-funcdef-lab②">4.6.2. Resolving Lab and LCH values</a>
@@ -8555,8 +8556,8 @@ Specifying Lab and LCH: the lab() and lch() functional notations</a> <a href="#r
     <li><a href="#ref-for-funcdef-lab⑨"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-lch">
-   <b><a href="#funcdef-lch">#funcdef-lch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-lch" class="dfn-panel" data-for="funcdef-lch" id="infopanel-for-funcdef-lch" role="dialog">
+   <span id="infopaneltitle-for-funcdef-lch" style="display:none">Info about the 'lch()' definition.</span><b><a href="#funcdef-lch">#funcdef-lch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-lch">4. 
 Representing Colors: the &lt;color> type</a>
@@ -8570,8 +8571,8 @@ Specifying Lab and LCH: the lab() and lch() functional notations</a>
     <li><a href="#ref-for-funcdef-lch⑨"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-color">
-   <b><a href="#funcdef-color">#funcdef-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-color" class="dfn-panel" data-for="funcdef-color" id="infopanel-for-funcdef-color" role="dialog">
+   <span id="infopaneltitle-for-funcdef-color" style="display:none">Info about the 'color()' definition.</span><b><a href="#funcdef-color">#funcdef-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color">4.1. The &lt;color> syntax</a> <a href="#ref-for-funcdef-color①">(2)</a>
     <li><a href="#ref-for-funcdef-color②">4.6.3. Resolving values of the color() function</a>
@@ -8590,34 +8591,34 @@ Working Draft of
     <li><a href="#ref-for-funcdef-color①⑦"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-color">
-   <b><a href="#invalid-color">#invalid-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-color" class="dfn-panel" data-for="invalid-color" id="infopanel-for-invalid-color" role="dialog">
+   <span id="infopaneltitle-for-invalid-color" style="display:none">Info about the 'invalid color' definition.</span><b><a href="#invalid-color">#invalid-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-color">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-invalid-color①">(2)</a> <a href="#ref-for-invalid-color②">(3)</a> <a href="#ref-for-invalid-color③">(4)</a> <a href="#ref-for-invalid-color④">(5)</a> <a href="#ref-for-invalid-color⑤">(6)</a>
     <li><a href="#ref-for-invalid-color⑥">10.3. 
 Specifying a color profile: the @color-profile at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-color">
-   <b><a href="#valid-color">#valid-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-color" class="dfn-panel" data-for="valid-color" id="infopanel-for-valid-color" role="dialog">
+   <span id="infopaneltitle-for-valid-color" style="display:none">Info about the 'valid color' definition.</span><b><a href="#valid-color">#valid-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-color">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-valid-color①">(2)</a> <a href="#ref-for-valid-color②">(3)</a> <a href="#ref-for-valid-color③">(4)</a> <a href="#ref-for-valid-color④">(5)</a> <a href="#ref-for-valid-color⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="out-of-gamut">
-   <b><a href="#out-of-gamut">#out-of-gamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-out-of-gamut" class="dfn-panel" data-for="out-of-gamut" id="infopanel-for-out-of-gamut" role="dialog">
+   <span id="infopaneltitle-for-out-of-gamut" style="display:none">Info about the 'out of gamut' definition.</span><b><a href="#out-of-gamut">#out-of-gamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-gamut">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-out-of-gamut①">(2)</a> <a href="#ref-for-out-of-gamut②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cant-be-displayed">
-   <b><a href="#cant-be-displayed">#cant-be-displayed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cant-be-displayed" class="dfn-panel" data-for="cant-be-displayed" id="infopanel-for-cant-be-displayed" role="dialog">
+   <span id="infopaneltitle-for-cant-be-displayed" style="display:none">Info about the 'can’t be displayed' definition.</span><b><a href="#cant-be-displayed">#cant-be-displayed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cant-be-displayed">10.1. Specifying profiled colors: the color() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-srgb">
-   <b><a href="#valdef-color-srgb">#valdef-color-srgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-srgb" class="dfn-panel" data-for="valdef-color-srgb" id="infopanel-for-valdef-color-srgb" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-srgb" style="display:none">Info about the 'srgb' definition.</span><b><a href="#valdef-color-srgb">#valdef-color-srgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-srgb">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-srgb①">10.2. 
@@ -8625,8 +8626,8 @@ Predefined color spaces: srgb, display-p3, a98-rgb, prophoto-rgb, rec2020,
 xyz and lab'.</a> <a href="#ref-for-valdef-color-srgb②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-display-p3">
-   <b><a href="#valdef-color-display-p3">#valdef-color-display-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-display-p3" class="dfn-panel" data-for="valdef-color-display-p3" id="infopanel-for-valdef-color-display-p3" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-display-p3" style="display:none">Info about the 'display-p3' definition.</span><b><a href="#valdef-color-display-p3">#valdef-color-display-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-display-p3">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-display-p3①">10. 
@@ -8639,8 +8640,8 @@ xyz and lab'.</a> <a href="#ref-for-valdef-color-display-p3④">(2)</a>
 Converting predefined color spaces to Lab</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-a98-rgb">
-   <b><a href="#valdef-color-a98-rgb">#valdef-color-a98-rgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-a98-rgb" class="dfn-panel" data-for="valdef-color-a98-rgb" id="infopanel-for-valdef-color-a98-rgb" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-a98-rgb" style="display:none">Info about the 'a98-rgb' definition.</span><b><a href="#valdef-color-a98-rgb">#valdef-color-a98-rgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-a98-rgb">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-a98-rgb①">10.2. 
@@ -8650,8 +8651,8 @@ xyz and lab'.</a> <a href="#ref-for-valdef-color-a98-rgb②">(2)</a>
 Converting predefined color spaces to Lab</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-prophoto-rgb">
-   <b><a href="#valdef-color-prophoto-rgb">#valdef-color-prophoto-rgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-prophoto-rgb" class="dfn-panel" data-for="valdef-color-prophoto-rgb" id="infopanel-for-valdef-color-prophoto-rgb" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-prophoto-rgb" style="display:none">Info about the 'prophoto-rgb' definition.</span><b><a href="#valdef-color-prophoto-rgb">#valdef-color-prophoto-rgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-prophoto-rgb">4.7.3. Serializing Lab and LCH values</a>
     <li><a href="#ref-for-valdef-color-prophoto-rgb①">4.7.4. Serializing values of the color() function</a>
@@ -8666,8 +8667,8 @@ Converting predefined color spaces to Lab</a>
 Converting Lab to predefined color spaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-rec2020">
-   <b><a href="#valdef-color-rec2020">#valdef-color-rec2020</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-rec2020" class="dfn-panel" data-for="valdef-color-rec2020" id="infopanel-for-valdef-color-rec2020" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-rec2020" style="display:none">Info about the 'rec2020' definition.</span><b><a href="#valdef-color-rec2020">#valdef-color-rec2020</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-rec2020">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-rec2020①">10. 
@@ -8679,8 +8680,8 @@ xyz and lab'.</a> <a href="#ref-for-valdef-color-rec2020③">(2)</a>
 Converting predefined color spaces to Lab</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-xyz">
-   <b><a href="#valdef-color-xyz">#valdef-color-xyz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-xyz" class="dfn-panel" data-for="valdef-color-xyz" id="infopanel-for-valdef-color-xyz" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-xyz" style="display:none">Info about the 'xyz' definition.</span><b><a href="#valdef-color-xyz">#valdef-color-xyz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-xyz">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-xyz①">10.2. 
@@ -8688,8 +8689,8 @@ Predefined color spaces: srgb, display-p3, a98-rgb, prophoto-rgb, rec2020,
 xyz and lab'.</a> <a href="#ref-for-valdef-color-xyz②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-lab">
-   <b><a href="#valdef-color-lab">#valdef-color-lab</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-lab" class="dfn-panel" data-for="valdef-color-lab" id="infopanel-for-valdef-color-lab" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-lab" style="display:none">Info about the 'lab' definition.</span><b><a href="#valdef-color-lab">#valdef-color-lab</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-lab">4.7.4. Serializing values of the color() function</a>
     <li><a href="#ref-for-valdef-color-lab①">10.2. 
@@ -8697,8 +8698,8 @@ Predefined color spaces: srgb, display-p3, a98-rgb, prophoto-rgb, rec2020,
 xyz and lab'.</a> <a href="#ref-for-valdef-color-lab②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-profile">
-   <b><a href="#at-ruledef-profile">#at-ruledef-profile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-profile" class="dfn-panel" data-for="at-ruledef-profile" id="infopanel-for-at-ruledef-profile" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-profile" style="display:none">Info about the '@color-profile' definition.</span><b><a href="#at-ruledef-profile">#at-ruledef-profile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-profile">10. 
 Profiled, Device-dependent Colors</a>
@@ -8715,29 +8716,29 @@ Device-dependent CMYK Colors: the device-cmyk() function</a> <a href="#ref-for-a
     <li><a href="#ref-for-at-ruledef-profile①①"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-color-profile">
-   <b><a href="#css-color-profile">#css-color-profile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-color-profile" class="dfn-panel" data-for="css-color-profile" id="infopanel-for-css-color-profile" role="dialog">
+   <span id="infopaneltitle-for-css-color-profile" style="display:none">Info about the 'color profile' definition.</span><b><a href="#css-color-profile">#css-color-profile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-color-profile">10.1. Specifying profiled colors: the color() function</a>
     <li><a href="#ref-for-css-color-profile①">10.3. 
 Specifying a color profile: the @color-profile at-rule</a> <a href="#ref-for-css-color-profile②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-color-profile-src">
-   <b><a href="#descdef-color-profile-src">#descdef-color-profile-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-color-profile-src" class="dfn-panel" data-for="descdef-color-profile-src" id="infopanel-for-descdef-color-profile-src" role="dialog">
+   <span id="infopaneltitle-for-descdef-color-profile-src" style="display:none">Info about the 'src' definition.</span><b><a href="#descdef-color-profile-src">#descdef-color-profile-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-color-profile-src">10.3. 
 Specifying a color profile: the @color-profile at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gamut-map">
-   <b><a href="#gamut-map">#gamut-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gamut-map" class="dfn-panel" data-for="gamut-map" id="infopanel-for-gamut-map" role="dialog">
+   <span id="infopaneltitle-for-gamut-map" style="display:none">Info about the 'gamut-map' definition.</span><b><a href="#gamut-map">#gamut-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gamut-map">10.1. Specifying profiled colors: the color() function</a> <a href="#ref-for-gamut-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-device-cmyk">
-   <b><a href="#funcdef-device-cmyk">#funcdef-device-cmyk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-device-cmyk" class="dfn-panel" data-for="funcdef-device-cmyk" id="infopanel-for-funcdef-device-cmyk" role="dialog">
+   <span id="infopaneltitle-for-funcdef-device-cmyk" style="display:none">Info about the 'device-cmyk()' definition.</span><b><a href="#funcdef-device-cmyk">#funcdef-device-cmyk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-device-cmyk">4.1. The &lt;color> syntax</a>
     <li><a href="#ref-for-funcdef-device-cmyk①">4.7.5. Serializing device-cmyk values</a> <a href="#ref-for-funcdef-device-cmyk②">(2)</a> <a href="#ref-for-funcdef-device-cmyk③">(3)</a>
@@ -8749,88 +8750,144 @@ Working Draft of
     <li><a href="#ref-for-funcdef-device-cmyk①①"> Changes from Colors 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-cmyk-component">
-   <b><a href="#typedef-cmyk-component">#typedef-cmyk-component</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-cmyk-component" class="dfn-panel" data-for="typedef-cmyk-component" id="infopanel-for-typedef-cmyk-component" role="dialog">
+   <span id="infopaneltitle-for-typedef-cmyk-component" style="display:none">Info about the '&lt;cmyk-component>' definition.</span><b><a href="#typedef-cmyk-component">#typedef-cmyk-component</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-cmyk-component">11. 
 Device-dependent CMYK Colors: the device-cmyk() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="naively-convert-from-cmyk-to-rgba">
-   <b><a href="#naively-convert-from-cmyk-to-rgba">#naively-convert-from-cmyk-to-rgba</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-naively-convert-from-cmyk-to-rgba" class="dfn-panel" data-for="naively-convert-from-cmyk-to-rgba" id="infopanel-for-naively-convert-from-cmyk-to-rgba" role="dialog">
+   <span id="infopaneltitle-for-naively-convert-from-cmyk-to-rgba" style="display:none">Info about the 'naively convert from CMYK to RGBA' definition.</span><b><a href="#naively-convert-from-cmyk-to-rgba">#naively-convert-from-cmyk-to-rgba</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-naively-convert-from-cmyk-to-rgba">11. 
 Device-dependent CMYK Colors: the device-cmyk() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-opacity">
-   <b><a href="#propdef-opacity">#propdef-opacity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-opacity" class="dfn-panel" data-for="propdef-opacity" id="infopanel-for-propdef-opacity" role="dialog">
+   <span id="infopaneltitle-for-propdef-opacity" style="display:none">Info about the 'opacity' definition.</span><b><a href="#propdef-opacity">#propdef-opacity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">12. 
 Transparency: the opacity property</a> <a href="#ref-for-propdef-opacity①">(2)</a> <a href="#ref-for-propdef-opacity②">(3)</a> <a href="#ref-for-propdef-opacity③">(4)</a> <a href="#ref-for-propdef-opacity④">(5)</a> <a href="#ref-for-propdef-opacity⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-deprecated-colors">
-   <b><a href="#typedef-deprecated-colors">#typedef-deprecated-colors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-deprecated-colors" class="dfn-panel" data-for="typedef-deprecated-colors" id="infopanel-for-typedef-deprecated-colors" role="dialog">
+   <span id="infopaneltitle-for-typedef-deprecated-colors" style="display:none">Info about the '&lt;deprecated-colors>' definition.</span><b><a href="#typedef-deprecated-colors">#typedef-deprecated-colors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-deprecated-colors"> Appendix A: Deprecated CSS System Colors</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-color-5/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-5/Overview.html
@@ -1813,8 +1813,8 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
    <li><a href="#valdef-hwb-w">w</a><span>, in § 5.2.3</span>
    <li><a href="#typedef-xyz-adjuster">&lt;xyz-adjuster></a><span>, in § 5.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">3. Mixing colors: the color-mix() function</a> <a href="#ref-for-typedef-color①">(2)</a>
     <li><a href="#ref-for-typedef-color②">4. Selecting the most contrasting color: the color-contrast() function</a> <a href="#ref-for-typedef-color③">(2)</a>
@@ -1827,56 +1827,56 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
     <li><a href="#ref-for-typedef-color①①">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-hue">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-hue">https://drafts.csswg.org/css-color-4/#typedef-hue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-hue" class="dfn-panel" data-for="term-for-typedef-hue" id="infopanel-for-term-for-typedef-hue" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-hue" style="display:none">Info about the '&lt;hue>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-hue">https://drafts.csswg.org/css-color-4/#typedef-hue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hue">5.2.2. Relative HSL colors</a>
     <li><a href="#ref-for-typedef-hue①">5.2.3. Relative HWB colors</a>
     <li><a href="#ref-for-typedef-hue②">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-blue">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-blue" class="dfn-panel" data-for="term-for-valdef-color-blue" id="infopanel-for-term-for-valdef-color-blue" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-blue" style="display:none">Info about the 'blue' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-blue">5.2. Relative color syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-color-space">
-   <a href="https://drafts.csswg.org/css-color-4/#color-space">https://drafts.csswg.org/css-color-4/#color-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-color-space" class="dfn-panel" data-for="term-for-color-space" id="infopanel-for-term-for-color-space" role="menu">
+   <span id="infopaneltitle-for-term-for-color-space" style="display:none">Info about the 'color space' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#color-space">https://drafts.csswg.org/css-color-4/#color-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-space">2. color spaces {#color spaces-section}</a>
     <li><a href="#ref-for-color-space①">3. Mixing colors: the color-mix() function</a> <a href="#ref-for-color-space②">(2)</a>
     <li><a href="#ref-for-color-space③">5.1. Adjusting colors: the color-adjust function</a> <a href="#ref-for-color-space④">(2)</a> <a href="#ref-for-color-space⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-darkolivegreen">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-darkolivegreen">https://drafts.csswg.org/css-color-4/#valdef-color-darkolivegreen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-darkolivegreen" class="dfn-panel" data-for="term-for-valdef-color-darkolivegreen" id="infopanel-for-term-for-valdef-color-darkolivegreen" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-darkolivegreen" style="display:none">Info about the 'darkolivegreen' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-darkolivegreen">https://drafts.csswg.org/css-color-4/#valdef-color-darkolivegreen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-darkolivegreen">5.2. Relative color syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-green">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-green">https://drafts.csswg.org/css-color-4/#valdef-color-green</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-green" class="dfn-panel" data-for="term-for-valdef-color-green" id="infopanel-for-term-for-valdef-color-green" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-green" style="display:none">Info about the 'green' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-green">https://drafts.csswg.org/css-color-4/#valdef-color-green</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-green">5.2. Relative color syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-lch-lch">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-lch-lch">https://drafts.csswg.org/css-color-4/#valdef-lch-lch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-lch-lch" class="dfn-panel" data-for="term-for-valdef-lch-lch" id="infopanel-for-term-for-valdef-lch-lch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-lch-lch" style="display:none">Info about the 'lch' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-lch-lch">https://drafts.csswg.org/css-color-4/#valdef-lch-lch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-lch-lch">2. color spaces {#color spaces-section}</a>
     <li><a href="#ref-for-valdef-lch-lch①">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-valdef-lch-lch②">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-red">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-red" class="dfn-panel" data-for="term-for-valdef-color-red" id="infopanel-for-term-for-valdef-color-red" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-red" style="display:none">Info about the 'red' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-red">https://drafts.csswg.org/css-color-4/#valdef-color-red</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">5.2. Relative color syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-alpha-value">
-   <a href="https://drafts.csswg.org/css-color-5/#typedef-alpha-value">https://drafts.csswg.org/css-color-5/#typedef-alpha-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-alpha-value" class="dfn-panel" data-for="term-for-typedef-alpha-value" id="infopanel-for-term-for-typedef-alpha-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-alpha-value" style="display:none">Info about the '&lt;alpha-value>' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#typedef-alpha-value">https://drafts.csswg.org/css-color-5/#typedef-alpha-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-alpha-value">5.2.1. Relative RGB colors</a> <a href="#ref-for-typedef-alpha-value①">(2)</a> <a href="#ref-for-typedef-alpha-value②">(3)</a>
     <li><a href="#ref-for-typedef-alpha-value③">5.2.2. Relative HSL colors</a>
@@ -1885,42 +1885,42 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
     <li><a href="#ref-for-typedef-alpha-value⑥">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-color">
-   <a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-color" class="dfn-panel" data-for="term-for-funcdef-color" id="infopanel-for-term-for-funcdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-color" style="display:none">Info about the 'color()' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color">5.2. Relative color syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-mult-comma①">4. Selecting the most contrasting color: the color-contrast() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-comb-all①">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3. Mixing colors: the color-mix() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5.2.2. Relative HSL colors</a>
     <li><a href="#ref-for-angle-value①">5.2.3. Relative HWB colors</a>
     <li><a href="#ref-for-angle-value②">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">4. Selecting the most contrasting color: the color-contrast() function</a>
     <li><a href="#ref-for-number-value①">5.2.1. Relative RGB colors</a> <a href="#ref-for-number-value②">(2)</a>
@@ -1928,8 +1928,8 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
     <li><a href="#ref-for-number-value⑥">5.2.5. Relative LCH colors</a> <a href="#ref-for-number-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-percentage-value①">5.1. Adjusting colors: the color-adjust function</a>
@@ -1940,8 +1940,8 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
     <li><a href="#ref-for-percentage-value①⑦">5.2.5. Relative LCH colors</a> <a href="#ref-for-percentage-value①⑧">(2)</a> <a href="#ref-for-percentage-value①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-mult-opt①">4. Selecting the most contrasting color: the color-contrast() function</a>
@@ -1953,20 +1953,20 @@ to WCAG 2.1 <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">section 1.4
     <li><a href="#ref-for-mult-opt①⑥">5.2.5. Relative LCH colors</a> <a href="#ref-for-mult-opt①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-math-function">
-   <a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-math-function" class="dfn-panel" data-for="term-for-math-function" id="infopanel-for-term-for-math-function" role="menu">
+   <span id="infopaneltitle-for-term-for-math-function" style="display:none">Info about the 'math function' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#math-function">https://drafts.csswg.org/css-values-4/#math-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-math-function">5.2. Relative color syntax</a> <a href="#ref-for-math-function①">(2)</a> <a href="#ref-for-math-function②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">5.2.1. Relative RGB colors</a> <a href="#ref-for-mult-num①">(2)</a> <a href="#ref-for-mult-num②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. color spaces {#color spaces-section}</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
     <li><a href="#ref-for-comb-one⑤">4. Selecting the most contrasting color: the color-contrast() function</a> <a href="#ref-for-comb-one⑥">(2)</a>
@@ -2031,70 +2031,70 @@ The CSS WG expects that the best aspects of each
 will be chosen to produce a single eventual solution. <a href="https://github.com/w3c/csswg-drafts/issues/3187">[Issue #3187]</a> <a class="issue-return" href="#issue-f41f57aa" title="Jump to section">↵</a></div>
    <div class="issue"> A future version of this specification may define a relative syntax for <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-color-5/#funcdef-color">color()</a> as well. <a class="issue-return" href="#issue-5cce798c" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="funcdef-color-mix">
-   <b><a href="#funcdef-color-mix">#funcdef-color-mix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-color-mix" class="dfn-panel" data-for="funcdef-color-mix" id="infopanel-for-funcdef-color-mix" role="dialog">
+   <span id="infopaneltitle-for-funcdef-color-mix" style="display:none">Info about the 'color-mix()' definition.</span><b><a href="#funcdef-color-mix">#funcdef-color-mix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color-mix">1. Introduction</a>
     <li><a href="#ref-for-funcdef-color-mix①">3. Mixing colors: the color-mix() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-color-contrast">
-   <b><a href="#funcdef-color-contrast">#funcdef-color-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-color-contrast" class="dfn-panel" data-for="funcdef-color-contrast" id="infopanel-for-funcdef-color-contrast" role="dialog">
+   <span id="infopaneltitle-for-funcdef-color-contrast" style="display:none">Info about the 'color-contrast()' definition.</span><b><a href="#funcdef-color-contrast">#funcdef-color-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color-contrast">1. Introduction</a>
     <li><a href="#ref-for-funcdef-color-contrast①">4. Selecting the most contrasting color: the color-contrast() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-adjuster">
-   <b><a href="#typedef-color-adjuster">#typedef-color-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-adjuster" class="dfn-panel" data-for="typedef-color-adjuster" id="infopanel-for-typedef-color-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-adjuster" style="display:none">Info about the '&lt;color-adjuster>' definition.</span><b><a href="#typedef-color-adjuster">#typedef-color-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-srgb-adjuster">
-   <b><a href="#typedef-srgb-adjuster">#typedef-srgb-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-srgb-adjuster" class="dfn-panel" data-for="typedef-srgb-adjuster" id="infopanel-for-typedef-srgb-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-srgb-adjuster" style="display:none">Info about the '&lt;srgb-adjuster>' definition.</span><b><a href="#typedef-srgb-adjuster">#typedef-srgb-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-srgb-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hsl-adjuster">
-   <b><a href="#typedef-hsl-adjuster">#typedef-hsl-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hsl-adjuster" class="dfn-panel" data-for="typedef-hsl-adjuster" id="infopanel-for-typedef-hsl-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-hsl-adjuster" style="display:none">Info about the '&lt;hsl-adjuster>' definition.</span><b><a href="#typedef-hsl-adjuster">#typedef-hsl-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hsl-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hwb-adjuster">
-   <b><a href="#typedef-hwb-adjuster">#typedef-hwb-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hwb-adjuster" class="dfn-panel" data-for="typedef-hwb-adjuster" id="infopanel-for-typedef-hwb-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-hwb-adjuster" style="display:none">Info about the '&lt;hwb-adjuster>' definition.</span><b><a href="#typedef-hwb-adjuster">#typedef-hwb-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hwb-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-xyz-adjuster">
-   <b><a href="#typedef-xyz-adjuster">#typedef-xyz-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-xyz-adjuster" class="dfn-panel" data-for="typedef-xyz-adjuster" id="infopanel-for-typedef-xyz-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-xyz-adjuster" style="display:none">Info about the '&lt;xyz-adjuster>' definition.</span><b><a href="#typedef-xyz-adjuster">#typedef-xyz-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-xyz-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-lab-adjuster">
-   <b><a href="#typedef-lab-adjuster">#typedef-lab-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-lab-adjuster" class="dfn-panel" data-for="typedef-lab-adjuster" id="infopanel-for-typedef-lab-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-lab-adjuster" style="display:none">Info about the '&lt;lab-adjuster>' definition.</span><b><a href="#typedef-lab-adjuster">#typedef-lab-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-lab-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-lch-adjuster">
-   <b><a href="#typedef-lch-adjuster">#typedef-lch-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-lch-adjuster" class="dfn-panel" data-for="typedef-lch-adjuster" id="infopanel-for-typedef-lch-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-lch-adjuster" style="display:none">Info about the '&lt;lch-adjuster>' definition.</span><b><a href="#typedef-lch-adjuster">#typedef-lch-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-lch-adjuster">5.1. Adjusting colors: the color-adjust function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hue-adjuster">
-   <b><a href="#typedef-hue-adjuster">#typedef-hue-adjuster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hue-adjuster" class="dfn-panel" data-for="typedef-hue-adjuster" id="infopanel-for-typedef-hue-adjuster" role="dialog">
+   <span id="infopaneltitle-for-typedef-hue-adjuster" style="display:none">Info about the '&lt;hue-adjuster>' definition.</span><b><a href="#typedef-hue-adjuster">#typedef-hue-adjuster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hue-adjuster">5.1. Adjusting colors: the color-adjust function</a> <a href="#ref-for-typedef-hue-adjuster①">(2)</a> <a href="#ref-for-typedef-hue-adjuster②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-color">
-   <b><a href="#relative-color">#relative-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-color" class="dfn-panel" data-for="relative-color" id="infopanel-for-relative-color" role="dialog">
+   <span id="infopaneltitle-for-relative-color" style="display:none">Info about the 'relative color' definition.</span><b><a href="#relative-color">#relative-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-color">5.2. Relative color syntax</a> <a href="#ref-for-relative-color①">(2)</a> <a href="#ref-for-relative-color②">(3)</a>
     <li><a href="#ref-for-relative-color③">5.2.1. Relative RGB colors</a>
@@ -2104,8 +2104,8 @@ will be chosen to produce a single eventual solution. <a href="https://github.co
     <li><a href="#ref-for-relative-color⑦">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-color">
-   <b><a href="#origin-color">#origin-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-color" class="dfn-panel" data-for="origin-color" id="infopanel-for-origin-color" role="dialog">
+   <span id="infopaneltitle-for-origin-color" style="display:none">Info about the 'origin color' definition.</span><b><a href="#origin-color">#origin-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-color">5.2. Relative color syntax</a> <a href="#ref-for-origin-color①">(2)</a> <a href="#ref-for-origin-color②">(3)</a> <a href="#ref-for-origin-color③">(4)</a> <a href="#ref-for-origin-color④">(5)</a> <a href="#ref-for-origin-color⑤">(6)</a> <a href="#ref-for-origin-color⑥">(7)</a> <a href="#ref-for-origin-color⑦">(8)</a> <a href="#ref-for-origin-color⑧">(9)</a> <a href="#ref-for-origin-color⑨">(10)</a> <a href="#ref-for-origin-color①⓪">(11)</a> <a href="#ref-for-origin-color①①">(12)</a>
     <li><a href="#ref-for-origin-color①②">5.2.1. Relative RGB colors</a> <a href="#ref-for-origin-color①③">(2)</a>
@@ -2115,8 +2115,8 @@ will be chosen to produce a single eventual solution. <a href="https://github.co
     <li><a href="#ref-for-origin-color②③">5.2.5. Relative LCH colors</a> <a href="#ref-for-origin-color②④">(2)</a> <a href="#ref-for-origin-color②⑤">(3)</a> <a href="#ref-for-origin-color②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="channel-keyword">
-   <b><a href="#channel-keyword">#channel-keyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-channel-keyword" class="dfn-panel" data-for="channel-keyword" id="infopanel-for-channel-keyword" role="dialog">
+   <span id="infopaneltitle-for-channel-keyword" style="display:none">Info about the 'channel keyword' definition.</span><b><a href="#channel-keyword">#channel-keyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-channel-keyword">5.2. Relative color syntax</a> <a href="#ref-for-channel-keyword①">(2)</a>
     <li><a href="#ref-for-channel-keyword②">5.2.1. Relative RGB colors</a>
@@ -2126,32 +2126,32 @@ will be chosen to produce a single eventual solution. <a href="https://github.co
     <li><a href="#ref-for-channel-keyword⑥">5.2.5. Relative LCH colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rgb">
-   <b><a href="#funcdef-rgb">#funcdef-rgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rgb" class="dfn-panel" data-for="funcdef-rgb" id="infopanel-for-funcdef-rgb" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rgb" style="display:none">Info about the 'rgb()' definition.</span><b><a href="#funcdef-rgb">#funcdef-rgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rgb">5.2.1. Relative RGB colors</a> <a href="#ref-for-funcdef-rgb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hsl">
-   <b><a href="#funcdef-hsl">#funcdef-hsl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hsl" class="dfn-panel" data-for="funcdef-hsl" id="infopanel-for-funcdef-hsl" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hsl" style="display:none">Info about the 'hsl()' definition.</span><b><a href="#funcdef-hsl">#funcdef-hsl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hsl">5.2.2. Relative HSL colors</a> <a href="#ref-for-funcdef-hsl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hwb">
-   <b><a href="#funcdef-hwb">#funcdef-hwb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hwb" class="dfn-panel" data-for="funcdef-hwb" id="infopanel-for-funcdef-hwb" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hwb" style="display:none">Info about the 'hwb()' definition.</span><b><a href="#funcdef-hwb">#funcdef-hwb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hwb">5.2.3. Relative HWB colors</a> <a href="#ref-for-funcdef-hwb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-lab">
-   <b><a href="#funcdef-lab">#funcdef-lab</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-lab" class="dfn-panel" data-for="funcdef-lab" id="infopanel-for-funcdef-lab" role="dialog">
+   <span id="infopaneltitle-for-funcdef-lab" style="display:none">Info about the 'lab()' definition.</span><b><a href="#funcdef-lab">#funcdef-lab</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-lab">5.2.4. Relative Lab colors</a> <a href="#ref-for-funcdef-lab①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-lch">
-   <b><a href="#funcdef-lch">#funcdef-lch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-lch" class="dfn-panel" data-for="funcdef-lch" id="infopanel-for-funcdef-lch" role="dialog">
+   <span id="infopaneltitle-for-funcdef-lch" style="display:none">Info about the 'lch()' definition.</span><b><a href="#funcdef-lch">#funcdef-lch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-lch">3. Mixing colors: the color-mix() function</a>
     <li><a href="#ref-for-funcdef-lch①">5.1. Adjusting colors: the color-adjust function</a>
@@ -2161,59 +2161,115 @@ will be chosen to produce a single eventual solution. <a href="https://github.co
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-color-adjust-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-adjust-1/Overview.html
@@ -1714,240 +1714,240 @@ svg|foreignObject { forced-color-adjust: auto; }
    <li><a href="#preferred-color-scheme">preferred color scheme</a><span>, in § 2</span>
    <li><a href="#used-color-scheme">used color scheme</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3.1. Properties Affected by Forced Colors Mode</a> <a href="#ref-for-propdef-background-color①">(2)</a> <a href="#ref-for-propdef-background-color②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-image-none">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-image-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-image-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-image-none" class="dfn-panel" data-for="term-for-valdef-background-image-none" id="infopanel-for-term-for-valdef-background-image-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-image-none" style="display:none">Info about the 'none (for background-image)' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-image-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-image-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-image-none">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-shadow-none">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none">https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-shadow-none" class="dfn-panel" data-for="term-for-box-shadow-none" id="infopanel-for-term-for-box-shadow-none" role="menu">
+   <span id="infopaneltitle-for-term-for-box-shadow-none" style="display:none">Info about the 'none (for box-shadow)' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none">https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-shadow-none">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-author">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-author">https://drafts.csswg.org/css-cascade-5/#cascade-origin-author</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-author" class="dfn-panel" data-for="term-for-cascade-origin-author" id="infopanel-for-term-for-cascade-origin-author" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-author" style="display:none">Info about the 'author style sheet' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-author">https://drafts.csswg.org/css-cascade-5/#cascade-origin-author</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-author">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.1. Properties Affected by Forced Colors Mode</a>
     <li><a href="#ref-for-computed-value①">7. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-revert">
-   <a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-revert" class="dfn-panel" data-for="term-for-valdef-all-revert" id="infopanel-for-term-for-valdef-all-revert" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-revert" style="display:none">Info about the 'revert' external reference.</span><a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert">7. Changes</a> <a href="#ref-for-valdef-all-revert①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">7. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-system-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-system-color">https://drafts.csswg.org/css-color-4/#typedef-system-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-system-color" class="dfn-panel" data-for="term-for-typedef-system-color" id="infopanel-for-term-for-typedef-system-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-system-color" style="display:none">Info about the '&lt;system-color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-system-color">https://drafts.csswg.org/css-color-4/#typedef-system-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-system-color">2. Preferred Color Schemes</a>
     <li><a href="#ref-for-typedef-system-color①">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-typedef-system-color②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-system-color-canvas">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas">https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-system-color-canvas" class="dfn-panel" data-for="term-for-valdef-system-color-canvas" id="infopanel-for-term-for-valdef-system-color-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-system-color-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas">https://drafts.csswg.org/css-color-4/#valdef-system-color-canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-canvas">2.2. Effects of the Used Color Scheme</a>
     <li><a href="#ref-for-valdef-system-color-canvas①">3. Forced Color Schemes</a>
     <li><a href="#ref-for-valdef-system-color-canvas②">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-system-color-canvastext">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-system-color-canvastext">https://drafts.csswg.org/css-color-4/#valdef-system-color-canvastext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-system-color-canvastext" class="dfn-panel" data-for="term-for-valdef-system-color-canvastext" id="infopanel-for-term-for-valdef-system-color-canvastext" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-system-color-canvastext" style="display:none">Info about the 'canvastext' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-system-color-canvastext">https://drafts.csswg.org/css-color-4/#valdef-system-color-canvastext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-color-canvastext">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">2.2. Effects of the Used Color Scheme</a>
     <li><a href="#ref-for-propdef-color①">3.1. Properties Affected by Forced Colors Mode</a> <a href="#ref-for-propdef-color②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-system-color-pairings">
-   <a href="https://drafts.csswg.org/css-color-4/#system-color-pairings">https://drafts.csswg.org/css-color-4/#system-color-pairings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-system-color-pairings" class="dfn-panel" data-for="term-for-system-color-pairings" id="infopanel-for-term-for-system-color-pairings" role="menu">
+   <span id="infopaneltitle-for-term-for-system-color-pairings" style="display:none">Info about the 'system color pairings' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#system-color-pairings">https://drafts.csswg.org/css-color-4/#system-color-pairings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-system-color-pairings">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-color">
-   <a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-color" class="dfn-panel" data-for="term-for-funcdef-color" id="infopanel-for-term-for-funcdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-color" style="display:none">Info about the 'color()' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-rule-color">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-rule-color" class="dfn-panel" data-for="term-for-propdef-column-rule-color" id="infopanel-for-term-for-propdef-column-rule-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-rule-color" style="display:none">Info about the 'column-rule-color' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-selection">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-selection">https://drafts.csswg.org/css-pseudo-4/#selectordef-selection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-selection" class="dfn-panel" data-for="term-for-selectordef-selection" id="infopanel-for-term-for-selectordef-selection" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-selection" style="display:none">Info about the '::selection' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-selection">https://drafts.csswg.org/css-pseudo-4/#selectordef-selection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-selection">3. Forced Color Schemes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scrollbar-color">
-   <a href="https://drafts.csswg.org/css-scrollbars-1/#propdef-scrollbar-color">https://drafts.csswg.org/css-scrollbars-1/#propdef-scrollbar-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scrollbar-color" class="dfn-panel" data-for="term-for-propdef-scrollbar-color" id="infopanel-for-term-for-propdef-scrollbar-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scrollbar-color" style="display:none">Info about the 'scrollbar-color' external reference.</span><a href="https://drafts.csswg.org/css-scrollbars-1/#propdef-scrollbar-color">https://drafts.csswg.org/css-scrollbars-1/#propdef-scrollbar-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scrollbar-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-color">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-color" class="dfn-panel" data-for="term-for-propdef-text-decoration-color" id="infopanel-for-term-for-propdef-text-decoration-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-color" style="display:none">Info about the 'text-decoration-color' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-color">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-color" class="dfn-panel" data-for="term-for-propdef-text-emphasis-color" id="infopanel-for-term-for-propdef-text-emphasis-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-color" style="display:none">Info about the 'text-emphasis-color' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-color" class="dfn-panel" data-for="term-for-propdef-outline-color" id="infopanel-for-term-for-propdef-outline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-color" style="display:none">Info about the 'outline-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a> <a href="#ref-for-identifier-value④">(5)</a> <a href="#ref-for-identifier-value⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">3.2. Opting Out of a Forced Color Scheme: the forced-color-adjust property</a>
     <li><a href="#ref-for-comb-one④">4. Performance-based Color Adjustments: the color-adjust property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://drafts.csswg.org/css2/#canvas">https://drafts.csswg.org/css2/#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://drafts.csswg.org/css2/#canvas">https://drafts.csswg.org/css2/#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">2.2. Effects of the Used Color Scheme</a> <a href="#ref-for-canvas①">(2)</a> <a href="#ref-for-canvas②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill" class="dfn-panel" data-for="term-for-propdef-fill" id="infopanel-for-term-for-propdef-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke" class="dfn-panel" data-for="term-for-propdef-stroke" id="infopanel-for-term-for-propdef-stroke" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke" style="display:none">Info about the 'stroke' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.2. Effects of the Used Color Scheme</a>
     <li><a href="#ref-for-the-iframe-element①">5. Privacy and Security Considerations</a>
     <li><a href="#ref-for-the-iframe-element②">7. Changes</a> <a href="#ref-for-the-iframe-element③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">2.2. Effects of the Used Color Scheme</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-meta" class="dfn-panel" data-for="term-for-meta" id="infopanel-for-term-for-meta" role="menu">
+   <span id="infopaneltitle-for-term-for-meta" style="display:none">Info about the 'meta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
     <li><a href="#ref-for-meta①">7. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-forced-colors">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-forced-colors">https://drafts.csswg.org/mediaqueries-5/#descdef-media-forced-colors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-forced-colors" class="dfn-panel" data-for="term-for-descdef-media-forced-colors" id="infopanel-for-term-for-descdef-media-forced-colors" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-forced-colors" style="display:none">Info about the 'forced-colors' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-forced-colors">https://drafts.csswg.org/mediaqueries-5/#descdef-media-forced-colors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-forced-colors">3. Forced Color Schemes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-prefers-color-scheme">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-scheme">https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-prefers-color-scheme" class="dfn-panel" data-for="term-for-descdef-media-prefers-color-scheme" id="infopanel-for-term-for-descdef-media-prefers-color-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-prefers-color-scheme" style="display:none">Info about the 'prefers-color-scheme' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-scheme">https://drafts.csswg.org/mediaqueries-5/#descdef-media-prefers-color-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-prefers-color-scheme">2. Preferred Color Schemes</a> <a href="#ref-for-descdef-media-prefers-color-scheme①">(2)</a>
     <li><a href="#ref-for-descdef-media-prefers-color-scheme②">3. Forced Color Schemes</a>
@@ -2153,15 +2153,15 @@ svg|foreignObject { forced-color-adjust: auto; }
    <div class="issue"> Should this property be merged with <a class="property css" data-link-type="property" href="#propdef-color-adjust">color-adjust</a> somehow? <a class="issue-return" href="#issue-aa11e0b6" title="Jump to section">↵</a></div>
    <div class="issue"> List additional MSFT / Apple / Google people here. <a class="issue-return" href="#issue-8edfffeb" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="preferred-color-scheme">
-   <b><a href="#preferred-color-scheme">#preferred-color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-color-scheme" class="dfn-panel" data-for="preferred-color-scheme" id="infopanel-for-preferred-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-preferred-color-scheme" style="display:none">Info about the 'preferred color scheme' definition.</span><b><a href="#preferred-color-scheme">#preferred-color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-color-scheme">2. Preferred Color Schemes</a> <a href="#ref-for-preferred-color-scheme①">(2)</a>
     <li><a href="#ref-for-preferred-color-scheme②">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-scheme">
-   <b><a href="#color-scheme">#color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-scheme" class="dfn-panel" data-for="color-scheme" id="infopanel-for-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-color-scheme" style="display:none">Info about the 'color scheme' definition.</span><b><a href="#color-scheme">#color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-scheme">1. Introduction</a> <a href="#ref-for-color-scheme①">(2)</a>
     <li><a href="#ref-for-color-scheme②">2. Preferred Color Schemes</a> <a href="#ref-for-color-scheme③">(2)</a> <a href="#ref-for-color-scheme④">(3)</a> <a href="#ref-for-color-scheme⑤">(4)</a> <a href="#ref-for-color-scheme⑥">(5)</a>
@@ -2170,22 +2170,22 @@ svg|foreignObject { forced-color-adjust: auto; }
     <li><a href="#ref-for-color-scheme①⑦">5. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="light-color-scheme">
-   <b><a href="#light-color-scheme">#light-color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-light-color-scheme" class="dfn-panel" data-for="light-color-scheme" id="infopanel-for-light-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-light-color-scheme" style="display:none">Info about the 'light color scheme' definition.</span><b><a href="#light-color-scheme">#light-color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-light-color-scheme">2. Preferred Color Schemes</a>
     <li><a href="#ref-for-light-color-scheme①">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-light-color-scheme②">(2)</a> <a href="#ref-for-light-color-scheme③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dark-color-scheme">
-   <b><a href="#dark-color-scheme">#dark-color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dark-color-scheme" class="dfn-panel" data-for="dark-color-scheme" id="infopanel-for-dark-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-dark-color-scheme" style="display:none">Info about the 'dark color scheme' definition.</span><b><a href="#dark-color-scheme">#dark-color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dark-color-scheme">2. Preferred Color Schemes</a>
     <li><a href="#ref-for-dark-color-scheme①">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-dark-color-scheme②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-color-scheme">
-   <b><a href="#propdef-color-scheme">#propdef-color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-color-scheme" class="dfn-panel" data-for="propdef-color-scheme" id="infopanel-for-propdef-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-propdef-color-scheme" style="display:none">Info about the 'color-scheme' definition.</span><b><a href="#propdef-color-scheme">#propdef-color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color-scheme">1. Introduction</a>
     <li><a href="#ref-for-propdef-color-scheme①">2. Preferred Color Schemes</a> <a href="#ref-for-propdef-color-scheme②">(2)</a>
@@ -2196,33 +2196,33 @@ svg|foreignObject { forced-color-adjust: auto; }
     <li><a href="#ref-for-propdef-color-scheme①②">7. Changes</a> <a href="#ref-for-propdef-color-scheme①③">(2)</a> <a href="#ref-for-propdef-color-scheme①④">(3)</a> <a href="#ref-for-propdef-color-scheme①⑤">(4)</a> <a href="#ref-for-propdef-color-scheme①⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-color-scheme">
-   <b><a href="#used-color-scheme">#used-color-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-color-scheme" class="dfn-panel" data-for="used-color-scheme" id="infopanel-for-used-color-scheme" role="dialog">
+   <span id="infopaneltitle-for-used-color-scheme" style="display:none">Info about the 'used color scheme' definition.</span><b><a href="#used-color-scheme">#used-color-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-color-scheme">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-used-color-scheme①">(2)</a> <a href="#ref-for-used-color-scheme②">(3)</a> <a href="#ref-for-used-color-scheme③">(4)</a>
     <li><a href="#ref-for-used-color-scheme④">2.2. Effects of the Used Color Scheme</a> <a href="#ref-for-used-color-scheme⑤">(2)</a> <a href="#ref-for-used-color-scheme⑥">(3)</a> <a href="#ref-for-used-color-scheme⑦">(4)</a> <a href="#ref-for-used-color-scheme⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-scheme-normal">
-   <b><a href="#valdef-color-scheme-normal">#valdef-color-scheme-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-scheme-normal" class="dfn-panel" data-for="valdef-color-scheme-normal" id="infopanel-for-valdef-color-scheme-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-scheme-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-color-scheme-normal">#valdef-color-scheme-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-scheme-normal">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a> <a href="#ref-for-valdef-color-scheme-normal①">(2)</a> <a href="#ref-for-valdef-color-scheme-normal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-scheme-light">
-   <b><a href="#valdef-color-scheme-light">#valdef-color-scheme-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-scheme-light" class="dfn-panel" data-for="valdef-color-scheme-light" id="infopanel-for-valdef-color-scheme-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-scheme-light" style="display:none">Info about the 'light' definition.</span><b><a href="#valdef-color-scheme-light">#valdef-color-scheme-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-scheme-light">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-scheme-dark">
-   <b><a href="#valdef-color-scheme-dark">#valdef-color-scheme-dark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-scheme-dark" class="dfn-panel" data-for="valdef-color-scheme-dark" id="infopanel-for-valdef-color-scheme-dark" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-scheme-dark" style="display:none">Info about the 'dark' definition.</span><b><a href="#valdef-color-scheme-dark">#valdef-color-scheme-dark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-scheme-dark">2.1. Opting Into a Preferred Color Scheme: the color-scheme property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-colors-mode">
-   <b><a href="#forced-colors-mode">#forced-colors-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-colors-mode" class="dfn-panel" data-for="forced-colors-mode" id="infopanel-for-forced-colors-mode" role="dialog">
+   <span id="infopaneltitle-for-forced-colors-mode" style="display:none">Info about the 'Forced colors mode' definition.</span><b><a href="#forced-colors-mode">#forced-colors-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-colors-mode">1. Introduction</a> <a href="#ref-for-forced-colors-mode①">(2)</a>
     <li><a href="#ref-for-forced-colors-mode②">3. Forced Color Schemes</a> <a href="#ref-for-forced-colors-mode③">(2)</a>
@@ -2232,22 +2232,22 @@ svg|foreignObject { forced-color-adjust: auto; }
     <li><a href="#ref-for-forced-colors-mode①⓪">7. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-forced-color-adjust">
-   <b><a href="#propdef-forced-color-adjust">#propdef-forced-color-adjust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-forced-color-adjust" class="dfn-panel" data-for="propdef-forced-color-adjust" id="infopanel-for-propdef-forced-color-adjust" role="dialog">
+   <span id="infopaneltitle-for-propdef-forced-color-adjust" style="display:none">Info about the 'forced-color-adjust' definition.</span><b><a href="#propdef-forced-color-adjust">#propdef-forced-color-adjust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-forced-color-adjust">1. Introduction</a>
     <li><a href="#ref-for-propdef-forced-color-adjust①">3.1. Properties Affected by Forced Colors Mode</a>
     <li><a href="#ref-for-propdef-forced-color-adjust②">3.2. Opting Out of a Forced Color Scheme: the forced-color-adjust property</a> <a href="#ref-for-propdef-forced-color-adjust③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-forced-color-adjust-auto">
-   <b><a href="#valdef-forced-color-adjust-auto">#valdef-forced-color-adjust-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-forced-color-adjust-auto" class="dfn-panel" data-for="valdef-forced-color-adjust-auto" id="infopanel-for-valdef-forced-color-adjust-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-forced-color-adjust-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-forced-color-adjust-auto">#valdef-forced-color-adjust-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-forced-color-adjust-auto">3.1. Properties Affected by Forced Colors Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-color-adjust">
-   <b><a href="#propdef-color-adjust">#propdef-color-adjust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-color-adjust" class="dfn-panel" data-for="propdef-color-adjust" id="infopanel-for-propdef-color-adjust" role="dialog">
+   <span id="infopaneltitle-for-propdef-color-adjust" style="display:none">Info about the 'color-adjust' definition.</span><b><a href="#propdef-color-adjust">#propdef-color-adjust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color-adjust">1. Introduction</a>
     <li><a href="#ref-for-propdef-color-adjust①">3.2. Opting Out of a Forced Color Scheme: the forced-color-adjust property</a>
@@ -2256,59 +2256,115 @@ svg|foreignObject { forced-color-adjust: auto; }
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-color-hdr/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-color-hdr/Overview.html
@@ -1173,8 +1173,8 @@ to account for non-reference viewing conditions.</p>
    <li><a href="#rec2100-hlg">rec2100-hlg</a><span>, in § 2.2</span>
    <li><a href="#rec2100-pq">rec2100-pq</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
@@ -1239,57 +1239,113 @@ to account for non-reference viewing conditions.</p>
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-conditional-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-conditional-3/Overview.html
@@ -1900,20 +1900,20 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
    <li><a href="#dom-css-supports">supports(property, value)</a><span>, in § 7.5</span>
    <li><a href="#dom-cssrule-supports_rule">SUPPORTS_RULE</a><span>, in § 7.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">6. Feature queries: the @supports rule</a> <a href="#ref-for-propdef-box-shadow①">(2)</a> <a href="#ref-for-propdef-box-shadow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">1.1. Background</a>
     <li><a href="#ref-for-at-ruledef-import①">3. 
@@ -1924,47 +1924,47 @@ Placement of conditional group rules</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">6.1. Definition of support</a> <a href="#ref-for-propdef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-supports" class="dfn-panel" data-for="term-for-funcdef-supports" id="infopanel-for-term-for-funcdef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-supports" style="display:none">Info about the 'supports()' external reference.</span><a href="https://drafts.csswg.org/css-conditional-5/#funcdef-supports">https://drafts.csswg.org/css-conditional-5/#funcdef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-supports">8. 
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">6. Feature queries: the @supports rule</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-qualified-name">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#css-qualified-name">https://drafts.csswg.org/css-namespaces-3/#css-qualified-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-qualified-name" class="dfn-panel" data-for="term-for-css-qualified-name" id="infopanel-for-term-for-css-qualified-name" role="menu">
+   <span id="infopaneltitle-for-term-for-css-qualified-name" style="display:none">Info about the 'css qualified name' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#css-qualified-name">https://drafts.csswg.org/css-namespaces-3/#css-qualified-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-qualified-name">3. 
 Contents of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespace-prefix">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#namespace-prefix">https://drafts.csswg.org/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespace-prefix" class="dfn-panel" data-for="term-for-namespace-prefix" id="infopanel-for-term-for-namespace-prefix" role="menu">
+   <span id="infopaneltitle-for-term-for-namespace-prefix" style="display:none">Info about the 'namespace prefix' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#namespace-prefix">https://drafts.csswg.org/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespace-prefix">3. 
 Contents of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-stylesheet">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-stylesheet" class="dfn-panel" data-for="term-for-typedef-stylesheet" id="infopanel-for-term-for-typedef-stylesheet" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-stylesheet" style="display:none">Info about the '&lt;stylesheet>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet">https://drafts.csswg.org/css-syntax-3/#typedef-stylesheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-stylesheet">3. 
 Contents of conditional group rules</a> <a href="#ref-for-typedef-stylesheet①">(2)</a>
@@ -1973,30 +1973,30 @@ Media-specific style sheets:  the @media rule</a>
     <li><a href="#ref-for-typedef-stylesheet③">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-charset">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-charset" class="dfn-panel" data-for="term-for-at-ruledef-charset" id="infopanel-for-term-for-at-ruledef-charset" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-charset" style="display:none">Info about the '@charset' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset">https://drafts.csswg.org/css-syntax-3/#at-ruledef-charset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-charset">4. 
 Placement of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">2. Processing of conditional group rules</a>
     <li><a href="#ref-for-at-rule①">4. 
 Placement of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-invalid">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-invalid" class="dfn-panel" data-for="term-for-css-invalid" id="infopanel-for-term-for-css-invalid" role="menu">
+   <span id="infopaneltitle-for-term-for-css-invalid" style="display:none">Info about the 'invalid' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-invalid">4. 
 Placement of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">7.2. 
 The CSSConditionRule interface</a>
@@ -2006,48 +2006,48 @@ The CSS namespace, and the supports() function</a> <a href="#ref-for-css-parse-s
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#style-rule">https://drafts.csswg.org/css-syntax-3/#style-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-rule" class="dfn-panel" data-for="term-for-style-rule" id="infopanel-for-term-for-style-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-style-rule" style="display:none">Info about the 'style rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#style-rule">https://drafts.csswg.org/css-syntax-3/#style-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-rule">4. 
 Placement of conditional group rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property-name-string">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string">https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property-name-string" class="dfn-panel" data-for="term-for-custom-property-name-string" id="infopanel-for-term-for-custom-property-name-string" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property-name-string" style="display:none">Info about the 'custom property name string' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string">https://drafts.css-houdini.org/css-typed-om-1/#custom-property-name-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property-name-string">7.5. 
 The CSS namespace, and the supports() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">6. Feature queries: the @supports rule</a> <a href="#ref-for-mult-zero-plus①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">6. Feature queries: the @supports rule</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">7.5. 
 The CSS namespace, and the supports() function</a> <a href="#ref-for-namespacedef-css①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssgroupingrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssgroupingrule">https://drafts.csswg.org/cssom-1/#cssgroupingrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssgroupingrule" class="dfn-panel" data-for="term-for-cssgroupingrule" id="infopanel-for-term-for-cssgroupingrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssgroupingrule" style="display:none">Info about the 'CSSGroupingRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssgroupingrule">https://drafts.csswg.org/cssom-1/#cssgroupingrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssgroupingrule">7.2. 
 The CSSConditionRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">7.2. 
 The CSSConditionRule interface</a>
@@ -2055,70 +2055,70 @@ The CSSConditionRule interface</a>
 The CSS namespace, and the supports() function</a> <a href="#ref-for-cssomstring②">(2)</a> <a href="#ref-for-cssomstring③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">7.1. 
 Extensions to the CSSRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-medialist">
-   <a href="https://drafts.csswg.org/cssom-1/#medialist">https://drafts.csswg.org/cssom-1/#medialist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-medialist" class="dfn-panel" data-for="term-for-medialist" id="infopanel-for-term-for-medialist" role="menu">
+   <span id="infopaneltitle-for-term-for-medialist" style="display:none">Info about the 'MediaList' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#medialist">https://drafts.csswg.org/cssom-1/#medialist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-medialist">7.3. 
 The CSSMediaRule interface</a> <a href="#ref-for-medialist①">(2)</a> <a href="#ref-for-medialist②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-medialist-mediatext">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-medialist-mediatext">https://drafts.csswg.org/cssom-1/#dom-medialist-mediatext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-medialist-mediatext" class="dfn-panel" data-for="term-for-dom-medialist-mediatext" id="infopanel-for-term-for-dom-medialist-mediatext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-medialist-mediatext" style="display:none">Info about the 'mediaText' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-medialist-mediatext">https://drafts.csswg.org/cssom-1/#dom-medialist-mediatext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-mediatext">7.3. 
 The CSSMediaRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">1.1. Background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">7.5. 
 The CSS namespace, and the supports() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-general-enclosed">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed">https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-general-enclosed" class="dfn-panel" data-for="term-for-typedef-general-enclosed" id="infopanel-for-term-for-typedef-general-enclosed" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-general-enclosed" style="display:none">Info about the '&lt;general-enclosed>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed">https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-general-enclosed">6. Feature queries: the @supports rule</a> <a href="#ref-for-typedef-general-enclosed①">(2)</a> <a href="#ref-for-typedef-general-enclosed②">(3)</a> <a href="#ref-for-typedef-general-enclosed③">(4)</a> <a href="#ref-for-typedef-general-enclosed④">(5)</a>
     <li><a href="#ref-for-typedef-general-enclosed⑤">7.4. 
 The CSSSupportsRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-condition">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-condition">https://drafts.csswg.org/mediaqueries-5/#typedef-media-condition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-condition" class="dfn-panel" data-for="term-for-typedef-media-condition" id="infopanel-for-term-for-typedef-media-condition" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-condition" style="display:none">Info about the '&lt;media-condition>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-condition">https://drafts.csswg.org/mediaqueries-5/#typedef-media-condition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-condition">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query-list" class="dfn-panel" data-for="term-for-typedef-media-query-list" id="infopanel-for-term-for-typedef-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">5. 
 Media-specific style sheets:  the @media rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-not">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-not">https://drafts.csswg.org/mediaqueries-5/#valdef-media-not</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-not" class="dfn-panel" data-for="term-for-valdef-media-not" id="infopanel-for-term-for-valdef-media-not" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-not" style="display:none">Info about the 'not' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-not">https://drafts.csswg.org/mediaqueries-5/#valdef-media-not</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-not">8. 
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7.2. 
 The CSSConditionRule interface</a>
@@ -2128,29 +2128,29 @@ The CSSMediaRule interface</a>
 The CSSSupportsRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">7.3. 
 The CSSMediaRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">7.3. 
 The CSSMediaRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.5. 
 The CSS namespace, and the supports() function</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">7.1. 
 Extensions to the CSSRule interface</a>
@@ -2328,15 +2328,15 @@ Extensions to the CSSRule interface</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="conditional-group-rule">
-   <b><a href="#conditional-group-rule">#conditional-group-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conditional-group-rule" class="dfn-panel" data-for="conditional-group-rule" id="infopanel-for-conditional-group-rule" role="dialog">
+   <span id="infopaneltitle-for-conditional-group-rule" style="display:none">Info about the 'conditional group rules' definition.</span><b><a href="#conditional-group-rule">#conditional-group-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conditional-group-rule">3. 
 Contents of conditional group rules</a> <a href="#ref-for-conditional-group-rule①">(2)</a> <a href="#ref-for-conditional-group-rule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-media">
-   <b><a href="#at-ruledef-media">#at-ruledef-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-media" class="dfn-panel" data-for="at-ruledef-media" id="infopanel-for-at-ruledef-media" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-media" style="display:none">Info about the '@media' definition.</span><b><a href="#at-ruledef-media">#at-ruledef-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media①">1.1. Background</a> <a href="#ref-for-at-ruledef-media②">(2)</a> <a href="#ref-for-at-ruledef-media③">(3)</a>
     <li><a href="#ref-for-at-ruledef-media④">1.2. Module Interactions</a>
@@ -2347,8 +2347,8 @@ The CSSMediaRule interface</a> <a href="#ref-for-at-ruledef-media⑨">(2)</a>
     <li><a href="#ref-for-at-ruledef-media①⓪">Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-supports">
-   <b><a href="#at-ruledef-supports">#at-ruledef-supports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-supports" class="dfn-panel" data-for="at-ruledef-supports" id="infopanel-for-at-ruledef-supports" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-supports" style="display:none">Info about the '@supports' definition.</span><b><a href="#at-ruledef-supports">#at-ruledef-supports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports①">1.1. Background</a> <a href="#ref-for-at-ruledef-supports②">(2)</a>
     <li><a href="#ref-for-at-ruledef-supports③">6. Feature queries: the @supports rule</a> <a href="#ref-for-at-ruledef-supports④">(2)</a> <a href="#ref-for-at-ruledef-supports⑤">(3)</a> <a href="#ref-for-at-ruledef-supports⑥">(4)</a> <a href="#ref-for-at-ruledef-supports⑦">(5)</a> <a href="#ref-for-at-ruledef-supports⑧">(6)</a> <a href="#ref-for-at-ruledef-supports⑨">(7)</a> <a href="#ref-for-at-ruledef-supports①⓪">(8)</a>
@@ -2362,8 +2362,8 @@ The CSSSupportsRule interface</a>
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-condition">
-   <b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-condition" class="dfn-panel" data-for="typedef-supports-condition" id="infopanel-for-typedef-supports-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-condition" style="display:none">Info about the '&lt;supports-condition>' definition.</span><b><a href="#typedef-supports-condition">#typedef-supports-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-condition">6. Feature queries: the @supports rule</a> <a href="#ref-for-typedef-supports-condition①">(2)</a> <a href="#ref-for-typedef-supports-condition②">(3)</a> <a href="#ref-for-typedef-supports-condition③">(4)</a> <a href="#ref-for-typedef-supports-condition④">(5)</a> <a href="#ref-for-typedef-supports-condition⑤">(6)</a>
     <li><a href="#ref-for-typedef-supports-condition⑥">7.2. 
@@ -2372,32 +2372,32 @@ The CSSConditionRule interface</a>
 The CSS namespace, and the supports() function</a> <a href="#ref-for-typedef-supports-condition⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-in-parens">
-   <b><a href="#typedef-supports-in-parens">#typedef-supports-in-parens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-in-parens" class="dfn-panel" data-for="typedef-supports-in-parens" id="infopanel-for-typedef-supports-in-parens" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-in-parens" style="display:none">Info about the '&lt;supports-in-parens>' definition.</span><b><a href="#typedef-supports-in-parens">#typedef-supports-in-parens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-in-parens">6. Feature queries: the @supports rule</a> <a href="#ref-for-typedef-supports-in-parens①">(2)</a> <a href="#ref-for-typedef-supports-in-parens②">(3)</a> <a href="#ref-for-typedef-supports-in-parens③">(4)</a> <a href="#ref-for-typedef-supports-in-parens④">(5)</a> <a href="#ref-for-typedef-supports-in-parens⑤">(6)</a> <a href="#ref-for-typedef-supports-in-parens⑥">(7)</a> <a href="#ref-for-typedef-supports-in-parens⑦">(8)</a> <a href="#ref-for-typedef-supports-in-parens⑧">(9)</a> <a href="#ref-for-typedef-supports-in-parens⑨">(10)</a> <a href="#ref-for-typedef-supports-in-parens①⓪">(11)</a> <a href="#ref-for-typedef-supports-in-parens①①">(12)</a> <a href="#ref-for-typedef-supports-in-parens①②">(13)</a> <a href="#ref-for-typedef-supports-in-parens①③">(14)</a> <a href="#ref-for-typedef-supports-in-parens①④">(15)</a> <a href="#ref-for-typedef-supports-in-parens①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-feature">
-   <b><a href="#typedef-supports-feature">#typedef-supports-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-feature" class="dfn-panel" data-for="typedef-supports-feature" id="infopanel-for-typedef-supports-feature" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-feature" style="display:none">Info about the '&lt;supports-feature>' definition.</span><b><a href="#typedef-supports-feature">#typedef-supports-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-feature">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-decl">
-   <b><a href="#typedef-supports-decl">#typedef-supports-decl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-decl" class="dfn-panel" data-for="typedef-supports-decl" id="infopanel-for-typedef-supports-decl" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-decl" style="display:none">Info about the '&lt;supports-decl>' definition.</span><b><a href="#typedef-supports-decl">#typedef-supports-decl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-decl">6. Feature queries: the @supports rule</a> <a href="#ref-for-typedef-supports-decl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-support">
-   <b><a href="#dfn-support">#dfn-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-support" class="dfn-panel" data-for="dfn-support" id="infopanel-for-dfn-support" role="dialog">
+   <span id="infopaneltitle-for-dfn-support" style="display:none">Info about the 'support' definition.</span><b><a href="#dfn-support">#dfn-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support">6. Feature queries: the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssconditionrule">
-   <b><a href="#cssconditionrule">#cssconditionrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssconditionrule" class="dfn-panel" data-for="cssconditionrule" id="infopanel-for-cssconditionrule" role="dialog">
+   <span id="infopaneltitle-for-cssconditionrule" style="display:none">Info about the 'CSSConditionRule' definition.</span><b><a href="#cssconditionrule">#cssconditionrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssconditionrule">7.2. 
 The CSSConditionRule interface</a>
@@ -2407,29 +2407,29 @@ The CSSMediaRule interface</a>
 The CSSSupportsRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmediarule">
-   <b><a href="#cssmediarule">#cssmediarule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmediarule" class="dfn-panel" data-for="cssmediarule" id="infopanel-for-cssmediarule" role="dialog">
+   <span id="infopaneltitle-for-cssmediarule" style="display:none">Info about the 'CSSMediaRule' definition.</span><b><a href="#cssmediarule">#cssmediarule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmediarule">7.3. 
 The CSSMediaRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csssupportsrule">
-   <b><a href="#csssupportsrule">#csssupportsrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csssupportsrule" class="dfn-panel" data-for="csssupportsrule" id="infopanel-for-csssupportsrule" role="dialog">
+   <span id="infopaneltitle-for-csssupportsrule" style="display:none">Info about the 'CSSSupportsRule' definition.</span><b><a href="#csssupportsrule">#csssupportsrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csssupportsrule">7.4. 
 The CSSSupportsRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-supports">
-   <b><a href="#dom-css-supports">#dom-css-supports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-supports" class="dfn-panel" data-for="dom-css-supports" id="infopanel-for-dom-css-supports" role="dialog">
+   <span id="infopaneltitle-for-dom-css-supports" style="display:none">Info about the 'supports' definition.</span><b><a href="#dom-css-supports">#dom-css-supports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-supports">7.5. 
 The CSS namespace, and the supports() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-supports-conditiontext">
-   <b><a href="#dom-css-supports-conditiontext">#dom-css-supports-conditiontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-supports-conditiontext" class="dfn-panel" data-for="dom-css-supports-conditiontext" id="infopanel-for-dom-css-supports-conditiontext" role="dialog">
+   <span id="infopaneltitle-for-dom-css-supports-conditiontext" style="display:none">Info about the 'supports' definition.</span><b><a href="#dom-css-supports-conditiontext">#dom-css-supports-conditiontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-supports-conditiontext">7.5. 
 The CSS namespace, and the supports() function</a>
@@ -2437,59 +2437,115 @@ The CSS namespace, and the supports() function</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-conditional-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-conditional-4/Overview.html
@@ -1175,39 +1175,39 @@ parse error), and that selector doesn’t contain <a data-link-type="dfn" href="
    <li><a href="#typedef-supports-feature">&lt;supports-feature></a><span>, in § 2</span>
    <li><a href="#typedef-supports-selector-fn">&lt;supports-selector-fn></a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-supports-decl">
-   <a href="https://drafts.csswg.org/css-conditional-3/#typedef-supports-decl">https://drafts.csswg.org/css-conditional-3/#typedef-supports-decl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-supports-decl" class="dfn-panel" data-for="term-for-typedef-supports-decl" id="infopanel-for-term-for-typedef-supports-decl" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-supports-decl" style="display:none">Info about the '&lt;supports-decl>' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#typedef-supports-decl">https://drafts.csswg.org/css-conditional-3/#typedef-supports-decl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-decl">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">Unnumbered Section</a>
     <li><a href="#ref-for-at-ruledef-supports①">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-complex-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-complex-selector">https://drafts.csswg.org/selectors-4/#typedef-complex-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-complex-selector" class="dfn-panel" data-for="term-for-typedef-complex-selector" id="infopanel-for-term-for-typedef-complex-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-complex-selector" style="display:none">Info about the '&lt;complex-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-complex-selector">https://drafts.csswg.org/selectors-4/#typedef-complex-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-complex-selector">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknown--webkit--pseudo-elements">
-   <a href="https://drafts.csswg.org/selectors-4/#unknown--webkit--pseudo-elements">https://drafts.csswg.org/selectors-4/#unknown--webkit--pseudo-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknown--webkit--pseudo-elements" class="dfn-panel" data-for="term-for-unknown--webkit--pseudo-elements" id="infopanel-for-term-for-unknown--webkit--pseudo-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-unknown--webkit--pseudo-elements" style="display:none">Info about the 'unknown -webkit- pseudo-elements' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#unknown--webkit--pseudo-elements">https://drafts.csswg.org/selectors-4/#unknown--webkit--pseudo-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknown--webkit--pseudo-elements">2.1. Extensions to the definition of support</a>
    </ul>
@@ -1256,79 +1256,135 @@ parse error), and that selector doesn’t contain <a data-link-type="dfn" href="
   <div style="counter-reset:issue">
    <div class="issue"> In the future, copy the contents of <a data-link-type="biblio" href="#biblio-css3-conditional" title="CSS Conditional Rules Module Level 3">[css3-conditional]</a> into this document. <a class="issue-return" href="#issue-58a5bc62" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-supports-feature">
-   <b><a href="#typedef-supports-feature">#typedef-supports-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-feature" class="dfn-panel" data-for="typedef-supports-feature" id="infopanel-for-typedef-supports-feature" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-feature" style="display:none">Info about the '&lt;supports-feature>' definition.</span><b><a href="#typedef-supports-feature">#typedef-supports-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-feature">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-supports-selector-fn">
-   <b><a href="#typedef-supports-selector-fn">#typedef-supports-selector-fn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-supports-selector-fn" class="dfn-panel" data-for="typedef-supports-selector-fn" id="infopanel-for-typedef-supports-selector-fn" role="dialog">
+   <span id="infopaneltitle-for-typedef-supports-selector-fn" style="display:none">Info about the '&lt;supports-selector-fn>' definition.</span><b><a href="#typedef-supports-selector-fn">#typedef-supports-selector-fn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-supports-selector-fn">2. Extensions to the @supports rule</a> <a href="#ref-for-typedef-supports-selector-fn①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-support-selector">
-   <b><a href="#dfn-support-selector">#dfn-support-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-support-selector" class="dfn-panel" data-for="dfn-support-selector" id="infopanel-for-dfn-support-selector" role="dialog">
+   <span id="infopaneltitle-for-dfn-support-selector" style="display:none">Info about the 'support a CSS selector' definition.</span><b><a href="#dfn-support-selector">#dfn-support-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-support-selector">2. Extensions to the @supports rule</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-conditional-values-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-conditional-values-1/Overview.html
@@ -934,143 +934,143 @@ As such, there are no new privacy considerations.</p>
    <li><a href="#invalid-condition">invalid condition</a><span>, in § 2.2</span>
    <li><a href="#true">'true'</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2.2. Logical comparisons: The &lt;condition> type</a>
     <li><a href="#ref-for-computed-value①">2.2.1. 
 Computed Value</a> <a href="#ref-for-computed-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">2.2.1. 
 Computed Value</a> <a href="#ref-for-used-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">3. Inline conditionals: The if() function</a> <a href="#ref-for-typedef-declaration-value①">(2)</a> <a href="#ref-for-typedef-declaration-value②">(3)</a> <a href="#ref-for-typedef-declaration-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-mult-zero-plus①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3. Inline conditionals: The if() function</a> <a href="#ref-for-comb-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension" class="dfn-panel" data-for="term-for-typedef-dimension" id="infopanel-for-term-for-typedef-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">1.2. Relation between units of the same type</a>
     <li><a href="#ref-for-length-value①">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-length-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3. Inline conditionals: The if() function</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calculation-tree">
-   <a href="https://drafts.csswg.org/css-values-4/#calculation-tree">https://drafts.csswg.org/css-values-4/#calculation-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calculation-tree" class="dfn-panel" data-for="term-for-calculation-tree" id="infopanel-for-term-for-calculation-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-calculation-tree" style="display:none">Info about the 'calculation tree' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#calculation-tree">https://drafts.csswg.org/css-values-4/#calculation-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculation-tree">2.2.1. 
 Computed Value</a> <a href="#ref-for-calculation-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canonical-unit">
-   <a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canonical-unit" class="dfn-panel" data-for="term-for-canonical-unit" id="infopanel-for-term-for-canonical-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-canonical-unit" style="display:none">Info about the 'canonical unit' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#canonical-unit">https://drafts.csswg.org/css-values-4/#canonical-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canonical-unit">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.3. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">2.2.1. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.2.1. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. Boolean constants: true and false</a>
     <li><a href="#ref-for-comb-one①">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-comb-one②">(2)</a> <a href="#ref-for-comb-one③">(3)</a> <a href="#ref-for-comb-one④">(4)</a> <a href="#ref-for-comb-one⑤">(5)</a> <a href="#ref-for-comb-one⑥">(6)</a> <a href="#ref-for-comb-one⑦">(7)</a> <a href="#ref-for-comb-one⑧">(8)</a> <a href="#ref-for-comb-one⑨">(9)</a> <a href="#ref-for-comb-one①⓪">(10)</a> <a href="#ref-for-comb-one①①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-at-computed-value-time">
-   <a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-at-computed-value-time" class="dfn-panel" data-for="term-for-invalid-at-computed-value-time" id="infopanel-for-term-for-invalid-at-computed-value-time" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-at-computed-value-time" style="display:none">Info about the 'invalid at computed-value time' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-at-computed-value-time">3. Inline conditionals: The if() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">3. Inline conditionals: The if() function</a> <a href="#ref-for-funcdef-var①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-false">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-false" class="dfn-panel" data-for="term-for-valdef-custom-media-false" id="infopanel-for-term-for-valdef-custom-media-false" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-false" style="display:none">Info about the 'false' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-false">2.1. Boolean constants: true and false</a>
     <li><a href="#ref-for-valdef-custom-media-false①">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-true">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-true" class="dfn-panel" data-for="term-for-valdef-custom-media-true" id="infopanel-for-term-for-valdef-custom-media-true" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-true" style="display:none">Info about the 'true' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-true">2.1. Boolean constants: true and false</a>
    </ul>
@@ -1165,16 +1165,16 @@ because we need to be able to interpret the values to compute the condition and 
 One way to address this would be to mandate that both <a class="production css" data-link-type="type" href="#typedef-consequent">&lt;consequent></a> and <a class="production css" data-link-type="type" href="#typedef-antecedent">&lt;antecedent></a> need to be of the same type.
 How much does that limit use cases? <a class="issue-return" href="#issue-4928eaeb" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-boolean-constant">
-   <b><a href="#typedef-boolean-constant">#typedef-boolean-constant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-boolean-constant" class="dfn-panel" data-for="typedef-boolean-constant" id="infopanel-for-typedef-boolean-constant" role="dialog">
+   <span id="infopaneltitle-for-typedef-boolean-constant" style="display:none">Info about the '&lt;boolean-constant>' definition.</span><b><a href="#typedef-boolean-constant">#typedef-boolean-constant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-boolean-constant">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-typedef-boolean-constant①">(2)</a>
     <li><a href="#ref-for-typedef-boolean-constant②">2.2.1. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-condition">
-   <b><a href="#typedef-condition">#typedef-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-condition" class="dfn-panel" data-for="typedef-condition" id="infopanel-for-typedef-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-condition" style="display:none">Info about the '&lt;condition>' definition.</span><b><a href="#typedef-condition">#typedef-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-condition">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-typedef-condition①">(2)</a> <a href="#ref-for-typedef-condition②">(3)</a> <a href="#ref-for-typedef-condition③">(4)</a> <a href="#ref-for-typedef-condition④">(5)</a> <a href="#ref-for-typedef-condition⑤">(6)</a>
     <li><a href="#ref-for-typedef-condition⑥">2.2.1. 
@@ -1182,101 +1182,157 @@ Computed Value</a> <a href="#ref-for-typedef-condition⑦">(2)</a> <a href="#ref
     <li><a href="#ref-for-typedef-condition⑨">3. Inline conditionals: The if() function</a> <a href="#ref-for-typedef-condition①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-condition-in-parens">
-   <b><a href="#typedef-condition-in-parens">#typedef-condition-in-parens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-condition-in-parens" class="dfn-panel" data-for="typedef-condition-in-parens" id="infopanel-for-typedef-condition-in-parens" role="dialog">
+   <span id="infopaneltitle-for-typedef-condition-in-parens" style="display:none">Info about the '&lt;condition-in-parens>' definition.</span><b><a href="#typedef-condition-in-parens">#typedef-condition-in-parens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-condition-in-parens">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-typedef-condition-in-parens①">(2)</a> <a href="#ref-for-typedef-condition-in-parens②">(3)</a> <a href="#ref-for-typedef-condition-in-parens③">(4)</a> <a href="#ref-for-typedef-condition-in-parens④">(5)</a> <a href="#ref-for-typedef-condition-in-parens⑤">(6)</a> <a href="#ref-for-typedef-condition-in-parens⑥">(7)</a> <a href="#ref-for-typedef-condition-in-parens⑦">(8)</a> <a href="#ref-for-typedef-condition-in-parens⑧">(9)</a> <a href="#ref-for-typedef-condition-in-parens⑨">(10)</a> <a href="#ref-for-typedef-condition-in-parens①⓪">(11)</a> <a href="#ref-for-typedef-condition-in-parens①①">(12)</a> <a href="#ref-for-typedef-condition-in-parens①②">(13)</a> <a href="#ref-for-typedef-condition-in-parens①③">(14)</a> <a href="#ref-for-typedef-condition-in-parens①④">(15)</a> <a href="#ref-for-typedef-condition-in-parens①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-atomic-condition">
-   <b><a href="#typedef-atomic-condition">#typedef-atomic-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-atomic-condition" class="dfn-panel" data-for="typedef-atomic-condition" id="infopanel-for-typedef-atomic-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-atomic-condition" style="display:none">Info about the '&lt;atomic-condition>' definition.</span><b><a href="#typedef-atomic-condition">#typedef-atomic-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-atomic-condition">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-typedef-atomic-condition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-comparison-operand">
-   <b><a href="#typedef-comparison-operand">#typedef-comparison-operand</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-comparison-operand" class="dfn-panel" data-for="typedef-comparison-operand" id="infopanel-for-typedef-comparison-operand" role="dialog">
+   <span id="infopaneltitle-for-typedef-comparison-operand" style="display:none">Info about the '&lt;comparison-operand>' definition.</span><b><a href="#typedef-comparison-operand">#typedef-comparison-operand</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-comparison-operand">2.2. Logical comparisons: The &lt;condition> type</a> <a href="#ref-for-typedef-comparison-operand①">(2)</a> <a href="#ref-for-typedef-comparison-operand②">(3)</a> <a href="#ref-for-typedef-comparison-operand③">(4)</a> <a href="#ref-for-typedef-comparison-operand④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-comparison-operator">
-   <b><a href="#typedef-comparison-operator">#typedef-comparison-operator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-comparison-operator" class="dfn-panel" data-for="typedef-comparison-operator" id="infopanel-for-typedef-comparison-operator" role="dialog">
+   <span id="infopaneltitle-for-typedef-comparison-operator" style="display:none">Info about the '&lt;comparison-operator>' definition.</span><b><a href="#typedef-comparison-operator">#typedef-comparison-operator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-comparison-operator">2.2. Logical comparisons: The &lt;condition> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-if">
-   <b><a href="#funcdef-if">#funcdef-if</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-if" class="dfn-panel" data-for="funcdef-if" id="infopanel-for-funcdef-if" role="dialog">
+   <span id="infopaneltitle-for-funcdef-if" style="display:none">Info about the 'if()' definition.</span><b><a href="#funcdef-if">#funcdef-if</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-if">3. Inline conditionals: The if() function</a> <a href="#ref-for-funcdef-if①">(2)</a> <a href="#ref-for-funcdef-if②">(3)</a> <a href="#ref-for-funcdef-if③">(4)</a> <a href="#ref-for-funcdef-if④">(5)</a> <a href="#ref-for-funcdef-if⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-consequent">
-   <b><a href="#typedef-consequent">#typedef-consequent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-consequent" class="dfn-panel" data-for="typedef-consequent" id="infopanel-for-typedef-consequent" role="dialog">
+   <span id="infopaneltitle-for-typedef-consequent" style="display:none">Info about the '&lt;consequent>' definition.</span><b><a href="#typedef-consequent">#typedef-consequent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-consequent">3. Inline conditionals: The if() function</a> <a href="#ref-for-typedef-consequent①">(2)</a> <a href="#ref-for-typedef-consequent②">(3)</a> <a href="#ref-for-typedef-consequent③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-antecedent">
-   <b><a href="#typedef-antecedent">#typedef-antecedent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-antecedent" class="dfn-panel" data-for="typedef-antecedent" id="infopanel-for-typedef-antecedent" role="dialog">
+   <span id="infopaneltitle-for-typedef-antecedent" style="display:none">Info about the '&lt;antecedent>' definition.</span><b><a href="#typedef-antecedent">#typedef-antecedent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-antecedent">3. Inline conditionals: The if() function</a> <a href="#ref-for-typedef-antecedent①">(2)</a> <a href="#ref-for-typedef-antecedent②">(3)</a> <a href="#ref-for-typedef-antecedent③">(4)</a> <a href="#ref-for-typedef-antecedent④">(5)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-1/Overview.html
@@ -2191,71 +2191,71 @@ Answers are provided below.</p>
    <li><a href="#sizing-as-if-empty">Sizing as if empty</a><span>, in § 3.1</span>
    <li><a href="#valdef-contain-strict">strict</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-corner-clipping">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">https://drafts.csswg.org/css-backgrounds-3/#corner-clipping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-corner-clipping" class="dfn-panel" data-for="term-for-corner-clipping" id="infopanel-for-term-for-corner-clipping" role="menu">
+   <span id="infopaneltitle-for-term-for-corner-clipping" style="display:none">Info about the 'corner clipping' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">https://drafts.csswg.org/css-backgrounds-3/#corner-clipping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corner-clipping">3.3. 
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-3/#forced-break">https://drafts.csswg.org/css-break-3/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#forced-break">https://drafts.csswg.org/css-break-3/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">3.2. 
 Layout Containment</a> <a href="#ref-for-forced-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation">https://drafts.csswg.org/css-break-3/#fragmentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation" class="dfn-panel" data-for="term-for-fragmentation" id="infopanel-for-term-for-fragmentation" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation" style="display:none">Info about the 'fragmentation' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation">https://drafts.csswg.org/css-break-3/#fragmentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation-container">https://drafts.csswg.org/css-break-3/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation-container">https://drafts.csswg.org/css-break-3/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmentation-container①">(2)</a> <a href="#ref-for-fragmentation-container②">(3)</a> <a href="#ref-for-fragmentation-container③">(4)</a> <a href="#ref-for-fragmentation-container④">(5)</a> <a href="#ref-for-fragmentation-container⑤">(6)</a> <a href="#ref-for-fragmentation-container⑥">(7)</a> <a href="#ref-for-fragmentation-container⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation-context">https://drafts.csswg.org/css-break-3/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation-context">https://drafts.csswg.org/css-break-3/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmentation-context①">(2)</a> <a href="#ref-for-fragmentation-context②">(3)</a> <a href="#ref-for-fragmentation-context③">(4)</a> <a href="#ref-for-fragmentation-context④">(5)</a> <a href="#ref-for-fragmentation-context⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmented-flow">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmented-flow">https://drafts.csswg.org/css-break-3/#fragmented-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmented-flow" class="dfn-panel" data-for="term-for-fragmented-flow" id="infopanel-for-term-for-fragmented-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmented-flow">https://drafts.csswg.org/css-break-3/#fragmented-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmented-flow①">(2)</a> <a href="#ref-for-fragmented-flow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monolithic">
-   <a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monolithic" class="dfn-panel" data-for="term-for-monolithic" id="infopanel-for-term-for-monolithic" role="menu">
+   <span id="infopaneltitle-for-term-for-monolithic" style="display:none">Info about the 'monolithic' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monolithic">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-containment" class="dfn-panel" data-for="term-for-style-containment" id="infopanel-for-term-for-style-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-style-containment" style="display:none">Info about the 'style containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">Changes from the
 Candidate Recommendation of 08 November 2018</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">3.1. 
 Size Containment</a>
@@ -2265,8 +2265,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-contents">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-contents" class="dfn-panel" data-for="term-for-valdef-display-contents" id="infopanel-for-term-for-valdef-display-contents" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-contents" style="display:none">Info about the 'contents' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-contents">3.2. 
 Layout Containment</a>
@@ -2274,8 +2274,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-display①">(2)</a>
@@ -2285,8 +2285,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">3.2. 
 Layout Containment</a>
@@ -2294,8 +2294,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">3.1. 
 Size Containment</a>
@@ -2305,15 +2305,15 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-ruby-box">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-ruby-box">https://drafts.csswg.org/css-display-3/#internal-ruby-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-ruby-box" class="dfn-panel" data-for="term-for-internal-ruby-box" id="infopanel-for-term-for-internal-ruby-box" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-ruby-box" style="display:none">Info about the 'internal ruby box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-ruby-box">https://drafts.csswg.org/css-display-3/#internal-ruby-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-ruby-box">3.1. 
 Size Containment</a>
@@ -2323,8 +2323,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-table-box">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-table-box">https://drafts.csswg.org/css-display-3/#internal-table-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-table-box" class="dfn-panel" data-for="term-for-internal-table-box" id="infopanel-for-term-for-internal-table-box" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-table-box" style="display:none">Info about the 'internal table box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-table-box">https://drafts.csswg.org/css-display-3/#internal-table-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-box">3.1. 
 Size Containment</a>
@@ -2334,8 +2334,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3.2. 
 Layout Containment</a>
@@ -2343,8 +2343,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">3.1. 
 Size Containment</a> <a href="#ref-for-principal-box①">(2)</a>
@@ -2354,22 +2354,22 @@ Layout Containment</a> <a href="#ref-for-principal-box③">(2)</a> <a href="#ref
 Paint Containment</a> <a href="#ref-for-principal-box⑥">(2)</a> <a href="#ref-for-principal-box⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-cell">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-cell" class="dfn-panel" data-for="term-for-valdef-display-table-cell" id="infopanel-for-term-for-valdef-display-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">3.2. 
 Layout Containment</a>
@@ -2377,43 +2377,43 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-track">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-track" class="dfn-panel" data-for="term-for-grid-track" id="infopanel-for-term-for-grid-track" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-track" style="display:none">Info about the 'grid track' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-track">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">3.1. 
 Size Containment</a> <a href="#ref-for-natural-aspect-ratio①">(2)</a> <a href="#ref-for-natural-aspect-ratio②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-height">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-height" class="dfn-panel" data-for="term-for-natural-height" id="infopanel-for-term-for-natural-height" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-height" style="display:none">Info about the 'natural height' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-clip">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-clip" class="dfn-panel" data-for="term-for-valdef-overflow-clip" id="infopanel-for-term-for-valdef-overflow-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">3.2. 
 Layout Containment</a>
@@ -2421,8 +2421,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3.2. 
 Layout Containment</a>
@@ -2430,57 +2430,57 @@ Layout Containment</a>
 Paint Containment</a> <a href="#ref-for-propdef-overflow②">(2)</a> <a href="#ref-for-propdef-overflow③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-x">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-x" class="dfn-panel" data-for="term-for-propdef-overflow-x" id="infopanel-for-term-for-propdef-overflow-x" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">3.3. 
 Paint Containment</a> <a href="#ref-for-propdef-overflow-x①">(2)</a> <a href="#ref-for-propdef-overflow-x②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-y">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-y" class="dfn-panel" data-for="term-for-propdef-overflow-y" id="infopanel-for-term-for-propdef-overflow-y" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">3.3. 
 Paint Containment</a> <a href="#ref-for-propdef-overflow-y①">(2)</a> <a href="#ref-for-propdef-overflow-y②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow" class="dfn-panel" data-for="term-for-scrollable-overflow" id="infopanel-for-term-for-scrollable-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow" style="display:none">Info about the 'scrollable overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow">3.3. 
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-nth-fragment">
-   <a href="https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment">https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-nth-fragment" class="dfn-panel" data-for="term-for-selectordef-nth-fragment" id="infopanel-for-term-for-selectordef-nth-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-nth-fragment" style="display:none">Info about the '::nth-fragment()' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment">https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-nth-fragment">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow-clip-edge">
-   <a href="https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge">https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow-clip-edge" class="dfn-panel" data-for="term-for-overflow-clip-edge" id="infopanel-for-term-for-overflow-clip-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow-clip-edge" style="display:none">Info about the 'overflow clip edge' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge">https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-clip-edge">3.3. 
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-clip-margin">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin">https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-clip-margin" class="dfn-panel" data-for="term-for-propdef-overflow-clip-margin" id="infopanel-for-term-for-propdef-overflow-clip-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-clip-margin" style="display:none">Info about the 'overflow-clip-margin' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin">https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-clip-margin">3.3. 
 Paint Containment</a> <a href="#ref-for-propdef-overflow-clip-margin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-positioning-containing-block">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block">https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-positioning-containing-block" class="dfn-panel" data-for="term-for-absolute-positioning-containing-block" id="infopanel-for-term-for-absolute-positioning-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-positioning-containing-block" style="display:none">Info about the 'absolute positioning containing block' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block">https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-positioning-containing-block">3.2. 
 Layout Containment</a>
@@ -2488,8 +2488,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fixed-positioning-containing-block">
-   <a href="https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block">https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fixed-positioning-containing-block" class="dfn-panel" data-for="term-for-fixed-positioning-containing-block" id="infopanel-for-term-for-fixed-positioning-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-fixed-positioning-containing-block" style="display:none">Info about the 'fixed positioning containing block' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block">https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-positioning-containing-block">3.2. 
 Layout Containment</a>
@@ -2497,141 +2497,141 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size" class="dfn-panel" data-for="term-for-intrinsic-size" id="infopanel-for-term-for-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">3.1. 
 Size Containment</a> <a href="#ref-for-sizing-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-aspect-ratio①">(2)</a> <a href="#ref-for-propdef-aspect-ratio②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-ui-3/#propdef-text-overflow">https://drafts.csswg.org/css-ui-3/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-ui-3/#propdef-text-overflow">https://drafts.csswg.org/css-ui-3/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">3.3. 
 Paint Containment</a> <a href="#ref-for-propdef-text-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-resize">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-resize" class="dfn-panel" data-for="term-for-propdef-resize" id="infopanel-for-term-for-propdef-resize" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-resize" style="display:none">Info about the 'resize' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-resize">3.3. 
 Paint Containment</a> <a href="#ref-for-propdef-resize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-comb-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-edge">
-   <a href="https://www.w3.org/TR/CSS2/box.html#padding-edge">https://www.w3.org/TR/CSS2/box.html#padding-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-edge" class="dfn-panel" data-for="term-for-padding-edge" id="infopanel-for-term-for-padding-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-edge" style="display:none">Info about the 'padding edge' external reference.</span><a href="https://www.w3.org/TR/CSS2/box.html#padding-edge">https://www.w3.org/TR/CSS2/box.html#padding-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">3.3. 
 Paint Containment</a> <a href="#ref-for-padding-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align">https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align">https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">3.2. 
 Layout Containment</a>
@@ -2639,8 +2639,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">2. 
 Strong Containment: the contain property</a>
@@ -2868,8 +2868,8 @@ Strong Containment: the contain property</a>
       <td>specified keyword(s)the keyword none or one or more of size, layout, paint
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-contain">
-   <b><a href="#propdef-contain">#propdef-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-contain" class="dfn-panel" data-for="propdef-contain" id="infopanel-for-propdef-contain" role="dialog">
+   <span id="infopaneltitle-for-propdef-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#propdef-contain">#propdef-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain①">1. 
 Introduction</a>
@@ -2879,50 +2879,50 @@ Strong Containment: the contain property</a> <a href="#ref-for-propdef-contain�
 Candidate Recommendation of 08 November 2018</a> <a href="#ref-for-propdef-contain①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-none">
-   <b><a href="#valdef-contain-none">#valdef-contain-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-none" class="dfn-panel" data-for="valdef-contain-none" id="infopanel-for-valdef-contain-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-contain-none">#valdef-contain-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-none">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-strict">
-   <b><a href="#valdef-contain-strict">#valdef-contain-strict</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-strict" class="dfn-panel" data-for="valdef-contain-strict" id="infopanel-for-valdef-contain-strict" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-strict" style="display:none">Info about the 'strict' definition.</span><b><a href="#valdef-contain-strict">#valdef-contain-strict</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-strict">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-content">
-   <b><a href="#valdef-contain-content">#valdef-contain-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-content" class="dfn-panel" data-for="valdef-contain-content" id="infopanel-for-valdef-contain-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-content" style="display:none">Info about the 'content' definition.</span><b><a href="#valdef-contain-content">#valdef-contain-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-content">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-size">
-   <b><a href="#valdef-contain-size">#valdef-contain-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-size" class="dfn-panel" data-for="valdef-contain-size" id="infopanel-for-valdef-contain-size" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-size" style="display:none">Info about the 'size' definition.</span><b><a href="#valdef-contain-size">#valdef-contain-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-size">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-layout">
-   <b><a href="#valdef-contain-layout">#valdef-contain-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-layout" class="dfn-panel" data-for="valdef-contain-layout" id="infopanel-for-valdef-contain-layout" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-layout" style="display:none">Info about the 'layout' definition.</span><b><a href="#valdef-contain-layout">#valdef-contain-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-layout">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-paint">
-   <b><a href="#valdef-contain-paint">#valdef-contain-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-paint" class="dfn-panel" data-for="valdef-contain-paint" id="infopanel-for-valdef-contain-paint" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-paint" style="display:none">Info about the 'paint' definition.</span><b><a href="#valdef-contain-paint">#valdef-contain-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-paint">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containment">
-   <b><a href="#containment">#containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containment" class="dfn-panel" data-for="containment" id="infopanel-for-containment" role="dialog">
+   <span id="infopaneltitle-for-containment" style="display:none">Info about the 'containment' definition.</span><b><a href="#containment">#containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containment">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-containment①">(2)</a>
@@ -2930,8 +2930,8 @@ Strong Containment: the contain property</a> <a href="#ref-for-containment①">(
 Types of Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-containment">
-   <b><a href="#size-containment">#size-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-containment" class="dfn-panel" data-for="size-containment" id="infopanel-for-size-containment" role="dialog">
+   <span id="infopaneltitle-for-size-containment" style="display:none">Info about the 'size containment' definition.</span><b><a href="#size-containment">#size-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-size-containment①">(2)</a> <a href="#ref-for-size-containment②">(3)</a>
@@ -2941,8 +2941,8 @@ Size Containment</a> <a href="#ref-for-size-containment④">(2)</a> <a href="#re
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-containment-box">
-   <b><a href="#size-containment-box">#size-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-containment-box" class="dfn-panel" data-for="size-containment-box" id="infopanel-for-size-containment-box" role="dialog">
+   <span id="infopaneltitle-for-size-containment-box" style="display:none">Info about the 'size containment box' definition.</span><b><a href="#size-containment-box">#size-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -2950,22 +2950,22 @@ Strong Containment: the contain property</a>
 Size Containment</a> <a href="#ref-for-size-containment-box②">(2)</a> <a href="#ref-for-size-containment-box③">(3)</a> <a href="#ref-for-size-containment-box④">(4)</a> <a href="#ref-for-size-containment-box⑤">(5)</a> <a href="#ref-for-size-containment-box⑥">(6)</a> <a href="#ref-for-size-containment-box⑦">(7)</a> <a href="#ref-for-size-containment-box⑧">(8)</a> <a href="#ref-for-size-containment-box⑨">(9)</a> <a href="#ref-for-size-containment-box①⓪">(10)</a> <a href="#ref-for-size-containment-box①①">(11)</a> <a href="#ref-for-size-containment-box①②">(12)</a> <a href="#ref-for-size-containment-box①③">(13)</a> <a href="#ref-for-size-containment-box①④">(14)</a> <a href="#ref-for-size-containment-box①⑤">(15)</a> <a href="#ref-for-size-containment-box①⑥">(16)</a> <a href="#ref-for-size-containment-box①⑦">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sizing-as-if-empty">
-   <b><a href="#sizing-as-if-empty">#sizing-as-if-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sizing-as-if-empty" class="dfn-panel" data-for="sizing-as-if-empty" id="infopanel-for-sizing-as-if-empty" role="dialog">
+   <span id="infopaneltitle-for-sizing-as-if-empty" style="display:none">Info about the 'Sizing as if empty' definition.</span><b><a href="#sizing-as-if-empty">#sizing-as-if-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-as-if-empty">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="laying-out-in-place">
-   <b><a href="#laying-out-in-place">#laying-out-in-place</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-laying-out-in-place" class="dfn-panel" data-for="laying-out-in-place" id="infopanel-for-laying-out-in-place" role="dialog">
+   <span id="infopaneltitle-for-laying-out-in-place" style="display:none">Info about the 'Laying out in-place' definition.</span><b><a href="#laying-out-in-place">#laying-out-in-place</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-laying-out-in-place">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-containment">
-   <b><a href="#layout-containment">#layout-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-containment" class="dfn-panel" data-for="layout-containment" id="infopanel-for-layout-containment" role="dialog">
+   <span id="infopaneltitle-for-layout-containment" style="display:none">Info about the 'layout containment' definition.</span><b><a href="#layout-containment">#layout-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment">2. 
 Strong Containment: the contain property</a>
@@ -2975,8 +2975,8 @@ Size Containment</a> <a href="#ref-for-layout-containment②">(2)</a> <a href="#
 Layout Containment</a> <a href="#ref-for-layout-containment⑤">(2)</a> <a href="#ref-for-layout-containment⑥">(3)</a> <a href="#ref-for-layout-containment⑦">(4)</a> <a href="#ref-for-layout-containment⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-containment-box">
-   <b><a href="#layout-containment-box">#layout-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-containment-box" class="dfn-panel" data-for="layout-containment-box" id="infopanel-for-layout-containment-box" role="dialog">
+   <span id="infopaneltitle-for-layout-containment-box" style="display:none">Info about the 'layout containment box' definition.</span><b><a href="#layout-containment-box">#layout-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -2984,8 +2984,8 @@ Strong Containment: the contain property</a>
 Layout Containment</a> <a href="#ref-for-layout-containment-box②">(2)</a> <a href="#ref-for-layout-containment-box③">(3)</a> <a href="#ref-for-layout-containment-box④">(4)</a> <a href="#ref-for-layout-containment-box⑤">(5)</a> <a href="#ref-for-layout-containment-box⑥">(6)</a> <a href="#ref-for-layout-containment-box⑦">(7)</a> <a href="#ref-for-layout-containment-box⑧">(8)</a> <a href="#ref-for-layout-containment-box⑨">(9)</a> <a href="#ref-for-layout-containment-box①⓪">(10)</a> <a href="#ref-for-layout-containment-box①①">(11)</a> <a href="#ref-for-layout-containment-box①②">(12)</a> <a href="#ref-for-layout-containment-box①③">(13)</a> <a href="#ref-for-layout-containment-box①④">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-containment">
-   <b><a href="#paint-containment">#paint-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-containment" class="dfn-panel" data-for="paint-containment" id="infopanel-for-paint-containment" role="dialog">
+   <span id="infopaneltitle-for-paint-containment" style="display:none">Info about the 'paint containment' definition.</span><b><a href="#paint-containment">#paint-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-containment">2. 
 Strong Containment: the contain property</a>
@@ -2993,8 +2993,8 @@ Strong Containment: the contain property</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-containment-box">
-   <b><a href="#paint-containment-box">#paint-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-containment-box" class="dfn-panel" data-for="paint-containment-box" id="infopanel-for-paint-containment-box" role="dialog">
+   <span id="infopaneltitle-for-paint-containment-box" style="display:none">Info about the 'paint containment box' definition.</span><b><a href="#paint-containment-box">#paint-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -3004,59 +3004,115 @@ Paint Containment</a> <a href="#ref-for-paint-containment-box②">(2)</a> <a hre
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-wpt */
 let wptPath = "/css/css-contain/";

--- a/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-2/Overview.html
@@ -2920,70 +2920,70 @@ Answers are provided below.</p>
    <li><a href="#style-containment">style containment</a><span>, in § 3.3</span>
    <li><a href="#valdef-content-visibility-visible">visible</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationiteration">
-   <a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationiteration" class="dfn-panel" data-for="term-for-eventdef-globaleventhandlers-animationiteration" id="infopanel-for-term-for-eventdef-globaleventhandlers-animationiteration" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-globaleventhandlers-animationiteration" style="display:none">Info about the 'animationiteration' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration">https://drafts.csswg.org/css-animations-1/#eventdef-globaleventhandlers-animationiteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-globaleventhandlers-animationiteration">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-corner-clipping">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">https://drafts.csswg.org/css-backgrounds-3/#corner-clipping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-corner-clipping" class="dfn-panel" data-for="term-for-corner-clipping" id="infopanel-for-term-for-corner-clipping" role="menu">
+   <span id="infopaneltitle-for-term-for-corner-clipping" style="display:none">Info about the 'corner clipping' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">https://drafts.csswg.org/css-backgrounds-3/#corner-clipping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corner-clipping">3.4. 
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-3/#forced-break">https://drafts.csswg.org/css-break-3/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#forced-break">https://drafts.csswg.org/css-break-3/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">3.2. 
 Layout Containment</a> <a href="#ref-for-forced-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation">https://drafts.csswg.org/css-break-3/#fragmentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation" class="dfn-panel" data-for="term-for-fragmentation" id="infopanel-for-term-for-fragmentation" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation" style="display:none">Info about the 'fragmentation' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation">https://drafts.csswg.org/css-break-3/#fragmentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation-container">https://drafts.csswg.org/css-break-3/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation-container">https://drafts.csswg.org/css-break-3/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmentation-container①">(2)</a> <a href="#ref-for-fragmentation-container②">(3)</a> <a href="#ref-for-fragmentation-container③">(4)</a> <a href="#ref-for-fragmentation-container④">(5)</a> <a href="#ref-for-fragmentation-container⑤">(6)</a> <a href="#ref-for-fragmentation-container⑥">(7)</a> <a href="#ref-for-fragmentation-container⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmentation-context">https://drafts.csswg.org/css-break-3/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmentation-context">https://drafts.csswg.org/css-break-3/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmentation-context①">(2)</a> <a href="#ref-for-fragmentation-context②">(3)</a> <a href="#ref-for-fragmentation-context③">(4)</a> <a href="#ref-for-fragmentation-context④">(5)</a> <a href="#ref-for-fragmentation-context⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmented-flow">
-   <a href="https://drafts.csswg.org/css-break-3/#fragmented-flow">https://drafts.csswg.org/css-break-3/#fragmented-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmented-flow" class="dfn-panel" data-for="term-for-fragmented-flow" id="infopanel-for-term-for-fragmented-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragmented-flow">https://drafts.csswg.org/css-break-3/#fragmented-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">3.2. 
 Layout Containment</a> <a href="#ref-for-fragmented-flow①">(2)</a> <a href="#ref-for-fragmented-flow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monolithic">
-   <a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monolithic" class="dfn-panel" data-for="term-for-monolithic" id="infopanel-for-term-for-monolithic" role="menu">
+   <span id="infopaneltitle-for-term-for-monolithic" style="display:none">Info about the 'monolithic' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monolithic">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">3.1. 
 Size Containment</a>
@@ -2993,8 +2993,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-contents">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-contents" class="dfn-panel" data-for="term-for-valdef-display-contents" id="infopanel-for-term-for-valdef-display-contents" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-contents" style="display:none">Info about the 'contents' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-contents">3.2. 
 Layout Containment</a>
@@ -3002,8 +3002,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-display①">(2)</a>
@@ -3018,8 +3018,8 @@ Using content-visibility: auto</a>
     <li><a href="#ref-for-propdef-display⑦">4.5. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">3.2. 
 Layout Containment</a>
@@ -3027,8 +3027,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">3.1. 
 Size Containment</a>
@@ -3038,15 +3038,15 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-ruby-box">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-ruby-box">https://drafts.csswg.org/css-display-3/#internal-ruby-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-ruby-box" class="dfn-panel" data-for="term-for-internal-ruby-box" id="infopanel-for-term-for-internal-ruby-box" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-ruby-box" style="display:none">Info about the 'internal ruby box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-ruby-box">https://drafts.csswg.org/css-display-3/#internal-ruby-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-ruby-box">3.1. 
 Size Containment</a>
@@ -3056,8 +3056,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-table-box">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-table-box">https://drafts.csswg.org/css-display-3/#internal-table-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-table-box" class="dfn-panel" data-for="term-for-internal-table-box" id="infopanel-for-term-for-internal-table-box" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-table-box" style="display:none">Info about the 'internal table box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-table-box">https://drafts.csswg.org/css-display-3/#internal-table-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-box">3.1. 
 Size Containment</a>
@@ -3067,8 +3067,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3.2. 
 Layout Containment</a>
@@ -3077,8 +3077,8 @@ Paint Containment</a>
     <li><a href="#ref-for-valdef-display-none②">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">3.1. 
 Size Containment</a> <a href="#ref-for-principal-box①">(2)</a>
@@ -3088,23 +3088,23 @@ Layout Containment</a> <a href="#ref-for-principal-box③">(2)</a> <a href="#ref
 Paint Containment</a> <a href="#ref-for-principal-box⑥">(2)</a> <a href="#ref-for-principal-box⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">3.1. 
 Size Containment</a>
     <li><a href="#ref-for-replaced-element①">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-cell">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-cell" class="dfn-panel" data-for="term-for-valdef-display-table-cell" id="infopanel-for-term-for-valdef-display-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">3.2. 
 Layout Containment</a>
@@ -3112,58 +3112,58 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
     <li><a href="#ref-for-propdef-visibility①">4.1. 
 Using content-visibility: hidden</a> <a href="#ref-for-propdef-visibility②">(2)</a> <a href="#ref-for-propdef-visibility③">(3)</a> <a href="#ref-for-propdef-visibility④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-track">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-track" class="dfn-panel" data-for="term-for-grid-track" id="infopanel-for-term-for-grid-track" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-track" style="display:none">Info about the 'grid track' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-track">https://drafts.csswg.org/css-grid-2/#grid-track</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-track">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">3.1. 
 Size Containment</a> <a href="#ref-for-natural-aspect-ratio①">(2)</a> <a href="#ref-for-natural-aspect-ratio②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-height">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-height" class="dfn-panel" data-for="term-for-natural-height" id="infopanel-for-term-for-natural-height" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-height" style="display:none">Info about the 'natural height' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-set">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-set">https://drafts.csswg.org/css-lists-3/#propdef-counter-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-set" class="dfn-panel" data-for="term-for-propdef-counter-set" id="infopanel-for-term-for-propdef-counter-set" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-set" style="display:none">Info about the 'counter-set' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-set">https://drafts.csswg.org/css-lists-3/#propdef-counter-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-set">3.3. 
 Style Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-clip">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-clip" class="dfn-panel" data-for="term-for-valdef-overflow-clip" id="infopanel-for-term-for-valdef-overflow-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">3.2. 
 Layout Containment</a>
@@ -3171,8 +3171,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3.2. 
 Layout Containment</a>
@@ -3180,59 +3180,59 @@ Layout Containment</a>
 Paint Containment</a> <a href="#ref-for-propdef-overflow②">(2)</a> <a href="#ref-for-propdef-overflow③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-x">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-x" class="dfn-panel" data-for="term-for-propdef-overflow-x" id="infopanel-for-term-for-propdef-overflow-x" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">3.4. 
 Paint Containment</a> <a href="#ref-for-propdef-overflow-x①">(2)</a> <a href="#ref-for-propdef-overflow-x②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-y">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-y" class="dfn-panel" data-for="term-for-propdef-overflow-y" id="infopanel-for-term-for-propdef-overflow-y" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">3.4. 
 Paint Containment</a> <a href="#ref-for-propdef-overflow-y①">(2)</a> <a href="#ref-for-propdef-overflow-y②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow" class="dfn-panel" data-for="term-for-scrollable-overflow" id="infopanel-for-term-for-scrollable-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow" style="display:none">Info about the 'scrollable overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow">3.4. 
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-nth-fragment">
-   <a href="https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment">https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-nth-fragment" class="dfn-panel" data-for="term-for-selectordef-nth-fragment" id="infopanel-for-term-for-selectordef-nth-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-nth-fragment" style="display:none">Info about the '::nth-fragment()' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment">https://drafts.csswg.org/css-overflow-4/#selectordef-nth-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-nth-fragment">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow-clip-edge">
-   <a href="https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge">https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow-clip-edge" class="dfn-panel" data-for="term-for-overflow-clip-edge" id="infopanel-for-term-for-overflow-clip-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow-clip-edge" style="display:none">Info about the 'overflow clip edge' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge">https://drafts.csswg.org/css-overflow-4/#overflow-clip-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-clip-edge">3.4. 
 Paint Containment</a>
     <li><a href="#ref-for-overflow-clip-edge①">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-clip-margin">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin">https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-clip-margin" class="dfn-panel" data-for="term-for-propdef-overflow-clip-margin" id="infopanel-for-term-for-propdef-overflow-clip-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-clip-margin" style="display:none">Info about the 'overflow-clip-margin' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin">https://drafts.csswg.org/css-overflow-4/#propdef-overflow-clip-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-clip-margin">3.4. 
 Paint Containment</a>
     <li><a href="#ref-for-propdef-overflow-clip-margin①"> Changes from 2019-11-11 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-positioning-containing-block">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block">https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-positioning-containing-block" class="dfn-panel" data-for="term-for-absolute-positioning-containing-block" id="infopanel-for-term-for-absolute-positioning-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-positioning-containing-block" style="display:none">Info about the 'absolute positioning containing block' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block">https://drafts.csswg.org/css-position-3/#absolute-positioning-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-positioning-containing-block">3.2. 
 Layout Containment</a>
@@ -3240,8 +3240,8 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fixed-positioning-containing-block">
-   <a href="https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block">https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fixed-positioning-containing-block" class="dfn-panel" data-for="term-for-fixed-positioning-containing-block" id="infopanel-for-term-for-fixed-positioning-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-fixed-positioning-containing-block" style="display:none">Info about the 'fixed positioning containing block' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block">https://drafts.csswg.org/css-position-3/#fixed-positioning-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-positioning-containing-block">3.2. 
 Layout Containment</a>
@@ -3249,216 +3249,216 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">4.1. 
 Using content-visibility: hidden</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">4.1. 
 Using content-visibility: hidden</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flat tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size" class="dfn-panel" data-for="term-for-intrinsic-size" id="infopanel-for-term-for-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">3.1. 
 Size Containment</a> <a href="#ref-for-propdef-aspect-ratio①">(2)</a> <a href="#ref-for-propdef-aspect-ratio②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size">https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain-intrinsic-size" class="dfn-panel" data-for="term-for-propdef-contain-intrinsic-size" id="infopanel-for-term-for-propdef-contain-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain-intrinsic-size" style="display:none">Info about the 'contain-intrinsic-size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size">https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain-intrinsic-size">4.2. 
 Using content-visibility: auto</a> <a href="#ref-for-propdef-contain-intrinsic-size①">(2)</a> <a href="#ref-for-propdef-contain-intrinsic-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-change-event">
-   <a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-change-event" class="dfn-panel" data-for="term-for-style-change-event" id="infopanel-for-term-for-style-change-event" role="menu">
+   <span id="infopaneltitle-for-term-for-style-change-event" style="display:none">Info about the 'style change event' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-change-event">4.3. Restrictions and Clarifications</a> <a href="#ref-for-style-change-event①">(2)</a> <a href="#ref-for-style-change-event②">(3)</a> <a href="#ref-for-style-change-event③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-ui-3/#propdef-text-overflow">https://drafts.csswg.org/css-ui-3/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-ui-3/#propdef-text-overflow">https://drafts.csswg.org/css-ui-3/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">3.4. 
 Paint Containment</a> <a href="#ref-for-propdef-text-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pointer-events">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pointer-events" class="dfn-panel" data-for="term-for-propdef-pointer-events" id="infopanel-for-term-for-propdef-pointer-events" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pointer-events" style="display:none">Info about the 'pointer-events' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pointer-events">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-resize">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-resize" class="dfn-panel" data-for="term-for-propdef-resize" id="infopanel-for-term-for-propdef-resize" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-resize" style="display:none">Info about the 'resize' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-resize">https://drafts.csswg.org/css-ui-4/#propdef-resize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-resize">3.4. 
 Paint Containment</a> <a href="#ref-for-propdef-resize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a> <a href="#ref-for-comb-one④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-close-quote">
-   <a href="https://www.w3.org/TR/CSS2/generate.html#value-def-close-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-close-quote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-close-quote" class="dfn-panel" data-for="term-for-value-def-close-quote" id="infopanel-for-term-for-value-def-close-quote" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-close-quote" style="display:none">Info about the 'close-quote' external reference.</span><a href="https://www.w3.org/TR/CSS2/generate.html#value-def-close-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-close-quote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-close-quote">3.3. 
 Style Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-no-close-quote">
-   <a href="https://www.w3.org/TR/CSS2/generate.html#value-def-no-close-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-no-close-quote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-no-close-quote" class="dfn-panel" data-for="term-for-value-def-no-close-quote" id="infopanel-for-term-for-value-def-no-close-quote" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-no-close-quote" style="display:none">Info about the 'no-close-quote' external reference.</span><a href="https://www.w3.org/TR/CSS2/generate.html#value-def-no-close-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-no-close-quote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-no-close-quote">3.3. 
 Style Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-no-open-quote">
-   <a href="https://www.w3.org/TR/CSS2/generate.html#value-def-no-open-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-no-open-quote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-no-open-quote" class="dfn-panel" data-for="term-for-value-def-no-open-quote" id="infopanel-for-term-for-value-def-no-open-quote" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-no-open-quote" style="display:none">Info about the 'no-open-quote' external reference.</span><a href="https://www.w3.org/TR/CSS2/generate.html#value-def-no-open-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-no-open-quote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-no-open-quote">3.3. 
 Style Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-open-quote">
-   <a href="https://www.w3.org/TR/CSS2/generate.html#value-def-open-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-open-quote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-open-quote" class="dfn-panel" data-for="term-for-value-def-open-quote" id="infopanel-for-term-for-value-def-open-quote" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-open-quote" style="display:none">Info about the 'open-quote' external reference.</span><a href="https://www.w3.org/TR/CSS2/generate.html#value-def-open-quote">https://www.w3.org/TR/CSS2/generate.html#value-def-open-quote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-open-quote">3.3. 
 Style Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align">https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align">https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3.2. 
 Layout Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css2/#propdef-content">https://drafts.csswg.org/css2/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-content">https://drafts.csswg.org/css2/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">3.3. 
 Style Containment</a> <a href="#ref-for-propdef-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-increment">
-   <a href="https://drafts.csswg.org/css2/#propdef-counter-increment">https://drafts.csswg.org/css2/#propdef-counter-increment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-increment" class="dfn-panel" data-for="term-for-propdef-counter-increment" id="infopanel-for-term-for-propdef-counter-increment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-counter-increment">https://drafts.csswg.org/css2/#propdef-counter-increment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">3.3. 
 Style Containment</a> <a href="#ref-for-propdef-counter-increment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">3.2. 
 Layout Containment</a>
@@ -3466,64 +3466,64 @@ Layout Containment</a>
 Paint Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">4.1. 
 Using content-visibility: hidden</a>
     <li><a href="#ref-for-dom-element-getboundingclientrect①">4.5. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-scrollintoview">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview">https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-scrollintoview" class="dfn-panel" data-for="term-for-dom-element-scrollintoview" id="infopanel-for-term-for-dom-element-scrollintoview" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-scrollintoview" style="display:none">Info about the 'scrollIntoView()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview">https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollintoview">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-focus">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-focus" class="dfn-panel" data-for="term-for-dom-window-focus" id="infopanel-for-term-for-dom-window-focus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-focus" style="display:none">Info about the 'focus()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-focus">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">4.3. Restrictions and Clarifications</a> <a href="#ref-for-the-iframe-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-innertext">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext">https://html.spec.whatwg.org/multipage/dom.html#dom-innertext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-innertext" class="dfn-panel" data-for="term-for-dom-innertext" id="infopanel-for-term-for-dom-innertext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-innertext" style="display:none">Info about the 'innerText' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext">https://html.spec.whatwg.org/multipage/dom.html#dom-innertext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-innertext">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-update-the-rendering">4.3. Restrictions and Clarifications</a> <a href="#ref-for-update-the-rendering">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intersectionobserver">
-   <a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver">https://w3c.github.io/IntersectionObserver/#intersectionobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intersectionobserver" class="dfn-panel" data-for="term-for-intersectionobserver" id="infopanel-for-term-for-intersectionobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-intersectionobserver" style="display:none">Info about the 'IntersectionObserver' external reference.</span><a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver">https://w3c.github.io/IntersectionObserver/#intersectionobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intersectionobserver-intersection-root">
-   <a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root">https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intersectionobserver-intersection-root" class="dfn-panel" data-for="term-for-intersectionobserver-intersection-root" id="infopanel-for-term-for-intersectionobserver-intersection-root" role="menu">
+   <span id="infopaneltitle-for-term-for-intersectionobserver-intersection-root" style="display:none">Info about the 'intersection root' external reference.</span><a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root">https://w3c.github.io/IntersectionObserver/#intersectionobserver-intersection-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver-intersection-root">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resizeobserver">
-   <a href="https://drafts.csswg.org/resize-observer-1/#resizeobserver">https://drafts.csswg.org/resize-observer-1/#resizeobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resizeobserver" class="dfn-panel" data-for="term-for-resizeobserver" id="infopanel-for-term-for-resizeobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-resizeobserver" style="display:none">Info about the 'ResizeObserver' external reference.</span><a href="https://drafts.csswg.org/resize-observer-1/#resizeobserver">https://drafts.csswg.org/resize-observer-1/#resizeobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resizeobserver">4.3. Restrictions and Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">2. 
 Strong Containment: the contain property</a>
@@ -3825,8 +3825,8 @@ Strong Containment: the contain property</a>
       <td>as specified
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-contain">
-   <b><a href="#propdef-contain">#propdef-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-contain" class="dfn-panel" data-for="propdef-contain" id="infopanel-for-propdef-contain" role="dialog">
+   <span id="infopaneltitle-for-propdef-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#propdef-contain">#propdef-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain②">1. 
 Introduction</a>
@@ -3835,36 +3835,36 @@ Strong Containment: the contain property</a> <a href="#ref-for-propdef-contain�
     <li><a href="#ref-for-propdef-contain①③"> Changes from 2020-06-03 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-none">
-   <b><a href="#valdef-contain-none">#valdef-contain-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-none" class="dfn-panel" data-for="valdef-contain-none" id="infopanel-for-valdef-contain-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-contain-none">#valdef-contain-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-none">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-size">
-   <b><a href="#valdef-contain-size">#valdef-contain-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-size" class="dfn-panel" data-for="valdef-contain-size" id="infopanel-for-valdef-contain-size" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-size" style="display:none">Info about the 'size' definition.</span><b><a href="#valdef-contain-size">#valdef-contain-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-size">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-layout">
-   <b><a href="#valdef-contain-layout">#valdef-contain-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-layout" class="dfn-panel" data-for="valdef-contain-layout" id="infopanel-for-valdef-contain-layout" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-layout" style="display:none">Info about the 'layout' definition.</span><b><a href="#valdef-contain-layout">#valdef-contain-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-layout">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-contain-paint">
-   <b><a href="#valdef-contain-paint">#valdef-contain-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-contain-paint" class="dfn-panel" data-for="valdef-contain-paint" id="infopanel-for-valdef-contain-paint" role="dialog">
+   <span id="infopaneltitle-for-valdef-contain-paint" style="display:none">Info about the 'paint' definition.</span><b><a href="#valdef-contain-paint">#valdef-contain-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-contain-paint">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containment">
-   <b><a href="#containment">#containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containment" class="dfn-panel" data-for="containment" id="infopanel-for-containment" role="dialog">
+   <span id="infopaneltitle-for-containment" style="display:none">Info about the 'containment' definition.</span><b><a href="#containment">#containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containment">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-containment①">(2)</a>
@@ -3877,8 +3877,8 @@ Using content-visibility: hidden</a>
 Using content-visibility: auto</a> <a href="#ref-for-containment⑧">(2)</a> <a href="#ref-for-containment⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-containment">
-   <b><a href="#size-containment">#size-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-containment" class="dfn-panel" data-for="size-containment" id="infopanel-for-size-containment" role="dialog">
+   <span id="infopaneltitle-for-size-containment" style="display:none">Info about the 'size containment' definition.</span><b><a href="#size-containment">#size-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-size-containment①">(2)</a> <a href="#ref-for-size-containment②">(3)</a>
@@ -3892,8 +3892,8 @@ Using content-visibility: auto</a>
     <li><a href="#ref-for-size-containment⑨">4.3. Restrictions and Clarifications</a> <a href="#ref-for-size-containment①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-containment-box">
-   <b><a href="#size-containment-box">#size-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-containment-box" class="dfn-panel" data-for="size-containment-box" id="infopanel-for-size-containment-box" role="dialog">
+   <span id="infopaneltitle-for-size-containment-box" style="display:none">Info about the 'size containment box' definition.</span><b><a href="#size-containment-box">#size-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -3901,22 +3901,22 @@ Strong Containment: the contain property</a>
 Size Containment</a> <a href="#ref-for-size-containment-box②">(2)</a> <a href="#ref-for-size-containment-box③">(3)</a> <a href="#ref-for-size-containment-box④">(4)</a> <a href="#ref-for-size-containment-box⑤">(5)</a> <a href="#ref-for-size-containment-box⑥">(6)</a> <a href="#ref-for-size-containment-box⑦">(7)</a> <a href="#ref-for-size-containment-box⑧">(8)</a> <a href="#ref-for-size-containment-box⑨">(9)</a> <a href="#ref-for-size-containment-box①⓪">(10)</a> <a href="#ref-for-size-containment-box①①">(11)</a> <a href="#ref-for-size-containment-box①②">(12)</a> <a href="#ref-for-size-containment-box①③">(13)</a> <a href="#ref-for-size-containment-box①④">(14)</a> <a href="#ref-for-size-containment-box①⑤">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sizing-as-if-empty">
-   <b><a href="#sizing-as-if-empty">#sizing-as-if-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sizing-as-if-empty" class="dfn-panel" data-for="sizing-as-if-empty" id="infopanel-for-sizing-as-if-empty" role="dialog">
+   <span id="infopaneltitle-for-sizing-as-if-empty" style="display:none">Info about the 'Sizing as if empty' definition.</span><b><a href="#sizing-as-if-empty">#sizing-as-if-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-as-if-empty">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="laying-out-in-place">
-   <b><a href="#laying-out-in-place">#laying-out-in-place</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-laying-out-in-place" class="dfn-panel" data-for="laying-out-in-place" id="infopanel-for-laying-out-in-place" role="dialog">
+   <span id="infopaneltitle-for-laying-out-in-place" style="display:none">Info about the 'Laying out in-place' definition.</span><b><a href="#laying-out-in-place">#laying-out-in-place</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-laying-out-in-place">3.1. 
 Size Containment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-containment">
-   <b><a href="#layout-containment">#layout-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-containment" class="dfn-panel" data-for="layout-containment" id="infopanel-for-layout-containment" role="dialog">
+   <span id="infopaneltitle-for-layout-containment" style="display:none">Info about the 'layout containment' definition.</span><b><a href="#layout-containment">#layout-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment">2. 
 Strong Containment: the contain property</a>
@@ -3927,8 +3927,8 @@ Layout Containment</a> <a href="#ref-for-layout-containment④">(2)</a> <a href=
     <li><a href="#ref-for-layout-containment⑧">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a> <a href="#ref-for-layout-containment⑨">(2)</a> <a href="#ref-for-layout-containment①⓪">(3)</a> <a href="#ref-for-layout-containment①①">(4)</a> <a href="#ref-for-layout-containment①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-containment-box">
-   <b><a href="#layout-containment-box">#layout-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-containment-box" class="dfn-panel" data-for="layout-containment-box" id="infopanel-for-layout-containment-box" role="dialog">
+   <span id="infopaneltitle-for-layout-containment-box" style="display:none">Info about the 'layout containment box' definition.</span><b><a href="#layout-containment-box">#layout-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -3936,8 +3936,8 @@ Strong Containment: the contain property</a>
 Layout Containment</a> <a href="#ref-for-layout-containment-box②">(2)</a> <a href="#ref-for-layout-containment-box③">(3)</a> <a href="#ref-for-layout-containment-box④">(4)</a> <a href="#ref-for-layout-containment-box⑤">(5)</a> <a href="#ref-for-layout-containment-box⑥">(6)</a> <a href="#ref-for-layout-containment-box⑦">(7)</a> <a href="#ref-for-layout-containment-box⑧">(8)</a> <a href="#ref-for-layout-containment-box⑨">(9)</a> <a href="#ref-for-layout-containment-box①⓪">(10)</a> <a href="#ref-for-layout-containment-box①①">(11)</a> <a href="#ref-for-layout-containment-box①②">(12)</a> <a href="#ref-for-layout-containment-box①③">(13)</a> <a href="#ref-for-layout-containment-box①④">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-containment">
-   <b><a href="#style-containment">#style-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-containment" class="dfn-panel" data-for="style-containment" id="infopanel-for-style-containment" role="dialog">
+   <span id="infopaneltitle-for-style-containment" style="display:none">Info about the 'style containment' definition.</span><b><a href="#style-containment">#style-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment①">2. 
 Strong Containment: the contain property</a> <a href="#ref-for-style-containment②">(2)</a> <a href="#ref-for-style-containment③">(3)</a>
@@ -3947,15 +3947,15 @@ Style Containment</a> <a href="#ref-for-style-containment⑤">(2)</a> <a href="#
     <li><a href="#ref-for-style-containment①②"> Changes from CSS Containment Level 1 </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="property-scoped-to-a-sub-tree">
-   <b><a href="#property-scoped-to-a-sub-tree">#property-scoped-to-a-sub-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-property-scoped-to-a-sub-tree" class="dfn-panel" data-for="property-scoped-to-a-sub-tree" id="infopanel-for-property-scoped-to-a-sub-tree" role="dialog">
+   <span id="infopaneltitle-for-property-scoped-to-a-sub-tree" style="display:none">Info about the 'scoped to a sub-tree' definition.</span><b><a href="#property-scoped-to-a-sub-tree">#property-scoped-to-a-sub-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-property-scoped-to-a-sub-tree">3.3. 
 Style Containment</a> <a href="#ref-for-property-scoped-to-a-sub-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-containment">
-   <b><a href="#paint-containment">#paint-containment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-containment" class="dfn-panel" data-for="paint-containment" id="infopanel-for-paint-containment" role="dialog">
+   <span id="infopaneltitle-for-paint-containment" style="display:none">Info about the 'paint containment' definition.</span><b><a href="#paint-containment">#paint-containment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-containment">2. 
 Strong Containment: the contain property</a>
@@ -3965,8 +3965,8 @@ Paint Containment</a> <a href="#ref-for-paint-containment②">(2)</a>
     <li><a href="#ref-for-paint-containment⑦"> Changes from 2019-11-11 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-containment-box">
-   <b><a href="#paint-containment-box">#paint-containment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-containment-box" class="dfn-panel" data-for="paint-containment-box" id="infopanel-for-paint-containment-box" role="dialog">
+   <span id="infopaneltitle-for-paint-containment-box" style="display:none">Info about the 'paint containment box' definition.</span><b><a href="#paint-containment-box">#paint-containment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-containment-box">2. 
 Strong Containment: the contain property</a>
@@ -3975,8 +3975,8 @@ Paint Containment</a> <a href="#ref-for-paint-containment-box②">(2)</a> <a hre
     <li><a href="#ref-for-paint-containment-box⑥">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-content-visibility">
-   <b><a href="#propdef-content-visibility">#propdef-content-visibility</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-content-visibility" class="dfn-panel" data-for="propdef-content-visibility" id="infopanel-for-propdef-content-visibility" role="dialog">
+   <span id="infopaneltitle-for-propdef-content-visibility" style="display:none">Info about the 'content-visibility' definition.</span><b><a href="#propdef-content-visibility">#propdef-content-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content-visibility">1. 
 Introduction</a>
@@ -3992,16 +3992,16 @@ Using content-visibility: auto</a> <a href="#ref-for-propdef-content-visibility�
     <li><a href="#ref-for-propdef-content-visibility③②"> Changes from 2019-11-11 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-visibility-hidden">
-   <b><a href="#valdef-content-visibility-hidden">#valdef-content-visibility-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-visibility-hidden" class="dfn-panel" data-for="valdef-content-visibility-hidden" id="infopanel-for-valdef-content-visibility-hidden" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-visibility-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#valdef-content-visibility-hidden">#valdef-content-visibility-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-visibility-hidden">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
     <li><a href="#ref-for-valdef-content-visibility-hidden①">4.2. 
 Using content-visibility: auto</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="skips-its-contents">
-   <b><a href="#skips-its-contents">#skips-its-contents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-skips-its-contents" class="dfn-panel" data-for="skips-its-contents" id="infopanel-for-skips-its-contents" role="dialog">
+   <span id="infopaneltitle-for-skips-its-contents" style="display:none">Info about the 'skips its contents' definition.</span><b><a href="#skips-its-contents">#skips-its-contents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skips-its-contents">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a> <a href="#ref-for-skips-its-contents①">(2)</a> <a href="#ref-for-skips-its-contents②">(3)</a> <a href="#ref-for-skips-its-contents③">(4)</a> <a href="#ref-for-skips-its-contents④">(5)</a> <a href="#ref-for-skips-its-contents⑤">(6)</a> <a href="#ref-for-skips-its-contents⑥">(7)</a> <a href="#ref-for-skips-its-contents⑦">(8)</a>
     <li><a href="#ref-for-skips-its-contents⑧">4.1. 
@@ -4013,15 +4013,15 @@ Using content-visibility: auto</a> <a href="#ref-for-skips-its-contents①②">(
     <li><a href="#ref-for-skips-its-contents④⑧">4.5. Examples</a> <a href="#ref-for-skips-its-contents④⑨">(2)</a> <a href="#ref-for-skips-its-contents⑤⓪">(3)</a> <a href="#ref-for-skips-its-contents⑤①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-contents">
-   <b><a href="#element-contents">#element-contents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-contents" class="dfn-panel" data-for="element-contents" id="infopanel-for-element-contents" role="dialog">
+   <span id="infopaneltitle-for-element-contents" style="display:none">Info about the 'contents' definition.</span><b><a href="#element-contents">#element-contents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-contents">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a> <a href="#ref-for-element-contents①">(2)</a>
     <li><a href="#ref-for-element-contents②">4.5. Examples</a> <a href="#ref-for-element-contents③">(2)</a> <a href="#ref-for-element-contents④">(3)</a> <a href="#ref-for-element-contents⑤">(4)</a> <a href="#ref-for-element-contents⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relevant-to-the-user">
-   <b><a href="#relevant-to-the-user">#relevant-to-the-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relevant-to-the-user" class="dfn-panel" data-for="relevant-to-the-user" id="infopanel-for-relevant-to-the-user" role="dialog">
+   <span id="infopaneltitle-for-relevant-to-the-user" style="display:none">Info about the 'relevant to the user' definition.</span><b><a href="#relevant-to-the-user">#relevant-to-the-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-to-the-user">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
     <li><a href="#ref-for-relevant-to-the-user①">4.2. 
@@ -4031,59 +4031,115 @@ Using content-visibility: auto</a> <a href="#ref-for-relevant-to-the-user②">(2
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-contain-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-contain-3/Overview.html
@@ -825,28 +825,28 @@ on screen, on paper, etc.
     Questions should be directed to the <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list.</p>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain">Unnumbered Section</a> <a href="#ref-for-propdef-contain①">(2)</a>
     <li><a href="#ref-for-propdef-contain②">2. 
 Strong Containment: the contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content-visibility">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility">https://drafts.csswg.org/css-contain-2/#propdef-content-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content-visibility" class="dfn-panel" data-for="term-for-propdef-content-visibility" id="infopanel-for-term-for-propdef-content-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content-visibility" style="display:none">Info about the 'content-visibility' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-content-visibility">https://drafts.csswg.org/css-contain-2/#propdef-content-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content-visibility">4. Suppressing An Element’s Contents Entirely: the content-visibility property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-containment" class="dfn-panel" data-for="term-for-style-containment" id="infopanel-for-term-for-style-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-style-containment" style="display:none">Info about the 'style containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
@@ -897,57 +897,113 @@ Value Definitions</a>
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-content-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-content-3/Overview.html
@@ -2315,15 +2315,15 @@ section section section h1 <c- p>{</c-> <c- k>bookmark-level</c-><c- p>:</c-> <c
    <li><a href="#target-text-function">target-text()</a><span>, in § 2.6.3</span>
    <li><a href="#valdef-content-text">text</a><span>, in § 2.7.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">2.4.1. 
 Specifying quotes with the quotes property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-containment" class="dfn-panel" data-for="term-for-style-containment" id="infopanel-for-term-for-style-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-style-containment" style="display:none">Info about the 'style containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">2.7.1. 
 The string-set property</a>
@@ -2331,8 +2331,8 @@ The string-set property</a>
 Bookmarks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter-style" class="dfn-panel" data-for="term-for-typedef-counter-style" id="infopanel-for-term-for-typedef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter-style" style="display:none">Info about the '&lt;counter-style>' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style">2.6.1. 
 The target-counter() function</a>
@@ -2340,15 +2340,15 @@ The target-counter() function</a>
 The target-counters() function </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a> <a href="#ref-for-typedef-image④">(5)</a> <a href="#ref-for-typedef-image⑤">(6)</a> <a href="#ref-for-typedef-image⑥">(7)</a> <a href="#ref-for-typedef-image⑦">(8)</a> <a href="#ref-for-typedef-image⑧">(9)</a>
@@ -2356,15 +2356,15 @@ Inserting and replacing content with the content property</a> <a href="#ref-for-
 &lt;image></a> <a href="#ref-for-typedef-image①⓪">(2)</a> <a href="#ref-for-typedef-image①①">(3)</a> <a href="#ref-for-typedef-image①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">1. 
 Inserting and replacing content with the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-image">
-   <a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-image" class="dfn-panel" data-for="term-for-invalid-image" id="infopanel-for-term-for-invalid-image" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-image" style="display:none">Info about the 'invalid image' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-invalid-image①">(2)</a> <a href="#ref-for-invalid-image②">(3)</a>
@@ -2372,8 +2372,8 @@ Inserting and replacing content with the content property</a> <a href="#ref-for-
 &lt;image></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-selectordef-after①">(2)</a>
@@ -2381,8 +2381,8 @@ Inserting and replacing content with the content property</a> <a href="#ref-for-
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-selectordef-before①">(2)</a>
@@ -2390,15 +2390,15 @@ Inserting and replacing content with the content property</a> <a href="#ref-for-
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">2.7.3. 
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">1. 
 Inserting and replacing content with the content property</a>
@@ -2408,29 +2408,29 @@ Element Content</a>
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">2.4.1. 
 Specifying quotes with the quotes property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">2.1. 
 String</a> <a href="#ref-for-white-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.7.1. 
 The string-set property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-mult-one-plus①">(2)</a>
@@ -2440,8 +2440,8 @@ Specifying quotes with the quotes property</a>
 The string-set property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">2.6.1. 
 The target-counter() function</a> <a href="#ref-for-comb-comma①">(2)</a>
@@ -2453,8 +2453,8 @@ The target-text() function</a>
 The string() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.6.1. 
 The target-counter() function</a>
@@ -2466,15 +2466,15 @@ The string-set property</a> <a href="#ref-for-identifier-value③">(2)</a> <a hr
 The string() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">4.1. 
 bookmark-level </a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a>
@@ -2494,8 +2494,8 @@ The target-text() function</a>
 The string-set property</a> <a href="#ref-for-string-value①⑤">(2)</a> <a href="#ref-for-string-value①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2.6.1. 
 The target-counter() function</a>
@@ -2505,8 +2505,8 @@ The target-counters() function </a>
 The target-text() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">1. 
 Inserting and replacing content with the content property</a>
@@ -2522,14 +2522,14 @@ The string() function</a>
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords"> Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a>
@@ -2559,43 +2559,43 @@ bookmark-level </a>
 bookmark-state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter">
-   <a href="https://drafts.csswg.org/css-lists-3/#typedef-counter">https://drafts.csswg.org/css-lists-3/#typedef-counter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter" class="dfn-panel" data-for="term-for-typedef-counter" id="infopanel-for-term-for-typedef-counter" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter" style="display:none">Info about the '&lt;counter>' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#typedef-counter">https://drafts.csswg.org/css-lists-3/#typedef-counter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-typedef-counter①">(2)</a> <a href="#ref-for-typedef-counter②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-increment">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-increment" class="dfn-panel" data-for="term-for-propdef-counter-increment" id="infopanel-for-term-for-propdef-counter-increment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">3. 
 Automatic counters and numbering: the counter-increment and counter-reset properties (moved)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-reset">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-reset" class="dfn-panel" data-for="term-for-propdef-counter-reset" id="infopanel-for-term-for-propdef-counter-reset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">3. 
 Automatic counters and numbering: the counter-increment and counter-reset properties (moved)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1. 
 Inserting and replacing content with the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-pseudo" class="dfn-panel" data-for="term-for-target-pseudo" id="infopanel-for-term-for-target-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-target-pseudo" style="display:none">Info about the ':target' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo">4. 
 Bookmarks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">1. 
 Inserting and replacing content with the content property</a>
@@ -2831,8 +2831,8 @@ Inserting and replacing content with the content property</a>
    <div class="issue"> Is the initial bookmark state,
 	or the bookmark state updated by the UA as appropriate? <a class="issue-return" href="#issue-be5a86f5" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-content">
-   <b><a href="#propdef-content">#propdef-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-content" class="dfn-panel" data-for="propdef-content" id="infopanel-for-propdef-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-content" style="display:none">Info about the 'content' definition.</span><b><a href="#propdef-content">#propdef-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-propdef-content①">(2)</a> <a href="#ref-for-propdef-content②">(3)</a>
@@ -2858,8 +2858,8 @@ Named strings</a>
 The string() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-normal">
-   <b><a href="#valdef-content-normal">#valdef-content-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-normal" class="dfn-panel" data-for="valdef-content-normal" id="infopanel-for-valdef-content-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-content-normal">#valdef-content-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-normal">1. 
 Inserting and replacing content with the content property</a>
@@ -2867,8 +2867,8 @@ Inserting and replacing content with the content property</a>
 Element Content</a> <a href="#ref-for-valdef-content-normal②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-none">
-   <b><a href="#valdef-content-none">#valdef-content-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-none" class="dfn-panel" data-for="valdef-content-none" id="infopanel-for-valdef-content-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-content-none">#valdef-content-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">1. 
 Inserting and replacing content with the content property</a>
@@ -2878,15 +2878,15 @@ Element Content</a> <a href="#ref-for-valdef-content-none②">(2)</a> <a href="#
 The *-quote values of the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-content-content-replacement">
-   <b><a href="#typedef-content-content-replacement">#typedef-content-content-replacement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-content-content-replacement" class="dfn-panel" data-for="typedef-content-content-replacement" id="infopanel-for-typedef-content-content-replacement" role="dialog">
+   <span id="infopaneltitle-for-typedef-content-content-replacement" style="display:none">Info about the '&lt;content-replacement>' definition.</span><b><a href="#typedef-content-content-replacement">#typedef-content-content-replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-content-replacement">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-typedef-content-content-replacement①">(2)</a> <a href="#ref-for-typedef-content-content-replacement②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-content-content-list">
-   <b><a href="#typedef-content-content-list">#typedef-content-content-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-content-content-list" class="dfn-panel" data-for="typedef-content-content-list" id="infopanel-for-typedef-content-content-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-content-content-list" style="display:none">Info about the '&lt;content-list>' definition.</span><b><a href="#typedef-content-content-list">#typedef-content-content-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-content-list">1. 
 Inserting and replacing content with the content property</a> <a href="#ref-for-typedef-content-content-list①">(2)</a> <a href="#ref-for-typedef-content-content-list②">(3)</a>
@@ -2898,8 +2898,8 @@ Alternative Text for Accessibility</a>
 bookmark-label</a> <a href="#ref-for-typedef-content-content-list⑦">(2)</a> <a href="#ref-for-typedef-content-content-list⑧">(3)</a> <a href="#ref-for-typedef-content-content-list⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-contents">
-   <b><a href="#valdef-content-contents">#valdef-content-contents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-contents" class="dfn-panel" data-for="valdef-content-contents" id="infopanel-for-valdef-content-contents" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-contents" style="display:none">Info about the 'contents' definition.</span><b><a href="#valdef-content-contents">#valdef-content-contents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-contents">1. 
 Inserting and replacing content with the content property</a>
@@ -2907,8 +2907,8 @@ Inserting and replacing content with the content property</a>
 Element Content</a> <a href="#ref-for-valdef-content-contents②">(2)</a> <a href="#ref-for-valdef-content-contents③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-quotes">
-   <b><a href="#propdef-quotes">#propdef-quotes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-quotes" class="dfn-panel" data-for="propdef-quotes" id="infopanel-for-propdef-quotes" role="dialog">
+   <span id="infopaneltitle-for-propdef-quotes" style="display:none">Info about the 'quotes' definition.</span><b><a href="#propdef-quotes">#propdef-quotes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-quotes">2.4.1. 
 Specifying quotes with the quotes property</a> <a href="#ref-for-propdef-quotes①">(2)</a>
@@ -2917,23 +2917,23 @@ The *-quote values of the content property</a> <a href="#ref-for-propdef-quotes�
     <li><a href="#ref-for-propdef-quotes⑤">5. Changes since the 2 June 2016 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-quotes-none">
-   <b><a href="#valdef-quotes-none">#valdef-quotes-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-quotes-none" class="dfn-panel" data-for="valdef-quotes-none" id="infopanel-for-valdef-quotes-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-quotes-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-quotes-none">#valdef-quotes-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-quotes-none">2.4.1. 
 Specifying quotes with the quotes property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-quotes-auto">
-   <b><a href="#valdef-quotes-auto">#valdef-quotes-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-quotes-auto" class="dfn-panel" data-for="valdef-quotes-auto" id="infopanel-for-valdef-quotes-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-quotes-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-quotes-auto">#valdef-quotes-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-quotes-auto">2.4.1. 
 Specifying quotes with the quotes property</a>
     <li><a href="#ref-for-valdef-quotes-auto①">5. Changes since the 2 June 2016 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-quote">
-   <b><a href="#typedef-quote">#typedef-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-quote" class="dfn-panel" data-for="typedef-quote" id="infopanel-for-typedef-quote" role="dialog">
+   <span id="infopaneltitle-for-typedef-quote" style="display:none">Info about the '&lt;quote>' definition.</span><b><a href="#typedef-quote">#typedef-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-quote">1. 
 Inserting and replacing content with the content property</a>
@@ -2941,8 +2941,8 @@ Inserting and replacing content with the content property</a>
 The *-quote values of the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-open-quote">
-   <b><a href="#valdef-content-open-quote">#valdef-content-open-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-open-quote" class="dfn-panel" data-for="valdef-content-open-quote" id="infopanel-for-valdef-content-open-quote" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-open-quote" style="display:none">Info about the 'open-quote' definition.</span><b><a href="#valdef-content-open-quote">#valdef-content-open-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-open-quote">2.4.1. 
 Specifying quotes with the quotes property</a> <a href="#ref-for-valdef-content-open-quote①">(2)</a>
@@ -2950,8 +2950,8 @@ Specifying quotes with the quotes property</a> <a href="#ref-for-valdef-content-
 The *-quote values of the content property</a> <a href="#ref-for-valdef-content-open-quote③">(2)</a> <a href="#ref-for-valdef-content-open-quote④">(3)</a> <a href="#ref-for-valdef-content-open-quote⑤">(4)</a> <a href="#ref-for-valdef-content-open-quote⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-close-quote">
-   <b><a href="#valdef-content-close-quote">#valdef-content-close-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-close-quote" class="dfn-panel" data-for="valdef-content-close-quote" id="infopanel-for-valdef-content-close-quote" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-close-quote" style="display:none">Info about the 'close-quote' definition.</span><b><a href="#valdef-content-close-quote">#valdef-content-close-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-close-quote">2.4.1. 
 Specifying quotes with the quotes property</a> <a href="#ref-for-valdef-content-close-quote①">(2)</a>
@@ -2959,8 +2959,8 @@ Specifying quotes with the quotes property</a> <a href="#ref-for-valdef-content-
 The *-quote values of the content property</a> <a href="#ref-for-valdef-content-close-quote③">(2)</a> <a href="#ref-for-valdef-content-close-quote④">(3)</a> <a href="#ref-for-valdef-content-close-quote⑤">(4)</a> <a href="#ref-for-valdef-content-close-quote⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-no-open-quote">
-   <b><a href="#valdef-content-no-open-quote">#valdef-content-no-open-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-no-open-quote" class="dfn-panel" data-for="valdef-content-no-open-quote" id="infopanel-for-valdef-content-no-open-quote" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-no-open-quote" style="display:none">Info about the 'no-open-quote' definition.</span><b><a href="#valdef-content-no-open-quote">#valdef-content-no-open-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-no-open-quote">2.4.1. 
 Specifying quotes with the quotes property</a>
@@ -2968,8 +2968,8 @@ Specifying quotes with the quotes property</a>
 The *-quote values of the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-no-close-quote">
-   <b><a href="#valdef-content-no-close-quote">#valdef-content-no-close-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-no-close-quote" class="dfn-panel" data-for="valdef-content-no-close-quote" id="infopanel-for-valdef-content-no-close-quote" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-no-close-quote" style="display:none">Info about the 'no-close-quote' definition.</span><b><a href="#valdef-content-no-close-quote">#valdef-content-no-close-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-no-close-quote">2.4.1. 
 Specifying quotes with the quotes property</a>
@@ -2977,15 +2977,15 @@ Specifying quotes with the quotes property</a>
 The *-quote values of the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-leader-type">
-   <b><a href="#typedef-leader-type">#typedef-leader-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-leader-type" class="dfn-panel" data-for="typedef-leader-type" id="infopanel-for-typedef-leader-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-leader-type" style="display:none">Info about the '&lt;leader-type>' definition.</span><b><a href="#typedef-leader-type">#typedef-leader-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-leader-type">2.5.1. 
 The leader() function</a> <a href="#ref-for-typedef-leader-type①">(2)</a> <a href="#ref-for-typedef-leader-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-target">
-   <b><a href="#typedef-target">#typedef-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-target" class="dfn-panel" data-for="typedef-target" id="infopanel-for-typedef-target" role="dialog">
+   <span id="infopaneltitle-for-typedef-target" style="display:none">Info about the '&lt;target>' definition.</span><b><a href="#typedef-target">#typedef-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-target">1. 
 Inserting and replacing content with the content property</a>
@@ -2993,8 +2993,8 @@ Inserting and replacing content with the content property</a>
 Cross references and the target-* functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-target-counter">
-   <b><a href="#funcdef-target-counter">#funcdef-target-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-target-counter" class="dfn-panel" data-for="funcdef-target-counter" id="infopanel-for-funcdef-target-counter" role="dialog">
+   <span id="infopaneltitle-for-funcdef-target-counter" style="display:none">Info about the 'target-counter()' definition.</span><b><a href="#funcdef-target-counter">#funcdef-target-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-target-counter">2.6. 
 Cross references and the target-* functions</a> <a href="#ref-for-funcdef-target-counter①">(2)</a>
@@ -3002,8 +3002,8 @@ Cross references and the target-* functions</a> <a href="#ref-for-funcdef-target
 The target-counter() function</a> <a href="#ref-for-funcdef-target-counter③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-target-counters">
-   <b><a href="#funcdef-target-counters">#funcdef-target-counters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-target-counters" class="dfn-panel" data-for="funcdef-target-counters" id="infopanel-for-funcdef-target-counters" role="dialog">
+   <span id="infopaneltitle-for-funcdef-target-counters" style="display:none">Info about the 'target-counters()' definition.</span><b><a href="#funcdef-target-counters">#funcdef-target-counters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-target-counters">2.6. 
 Cross references and the target-* functions</a> <a href="#ref-for-funcdef-target-counters①">(2)</a>
@@ -3011,8 +3011,8 @@ Cross references and the target-* functions</a> <a href="#ref-for-funcdef-target
 The target-counters() function </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-text-function">
-   <b><a href="#target-text-function">#target-text-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-text-function" class="dfn-panel" data-for="target-text-function" id="infopanel-for-target-text-function" role="dialog">
+   <span id="infopaneltitle-for-target-text-function" style="display:none">Info about the 'target-text()' definition.</span><b><a href="#target-text-function">#target-text-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-text-function">2.6. 
 Cross references and the target-* functions</a> <a href="#ref-for-target-text-function①">(2)</a>
@@ -3020,15 +3020,15 @@ Cross references and the target-* functions</a> <a href="#ref-for-target-text-fu
 The target-text() function</a> <a href="#ref-for-target-text-function③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="named-string">
-   <b><a href="#named-string">#named-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-named-string" class="dfn-panel" data-for="named-string" id="infopanel-for-named-string" role="dialog">
+   <span id="infopaneltitle-for-named-string" style="display:none">Info about the 'named strings' definition.</span><b><a href="#named-string">#named-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-string">2.7.2. 
 The string() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-string-set">
-   <b><a href="#propdef-string-set">#propdef-string-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-string-set" class="dfn-panel" data-for="propdef-string-set" id="infopanel-for-propdef-string-set" role="dialog">
+   <span id="infopaneltitle-for-propdef-string-set" style="display:none">Info about the 'string-set' definition.</span><b><a href="#propdef-string-set">#propdef-string-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-string-set">2.6.3. 
 The target-text() function</a>
@@ -3040,15 +3040,15 @@ The string-set property</a> <a href="#ref-for-propdef-string-set③">(2)</a>
 bookmark-label</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-string-set-none">
-   <b><a href="#valdef-string-set-none">#valdef-string-set-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-string-set-none" class="dfn-panel" data-for="valdef-string-set-none" id="infopanel-for-valdef-string-set-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-string-set-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-string-set-none">#valdef-string-set-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-string-set-none">2.7.1. 
 The string-set property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-string">
-   <b><a href="#funcdef-string">#funcdef-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-string" class="dfn-panel" data-for="funcdef-string" id="infopanel-for-funcdef-string" role="dialog">
+   <span id="infopaneltitle-for-funcdef-string" style="display:none">Info about the 'string()' definition.</span><b><a href="#funcdef-string">#funcdef-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-string">2.7.1. 
 The string-set property</a> <a href="#ref-for-funcdef-string①">(2)</a>
@@ -3056,29 +3056,29 @@ The string-set property</a> <a href="#ref-for-funcdef-string①">(2)</a>
 The string() function</a> <a href="#ref-for-funcdef-string③">(2)</a> <a href="#ref-for-funcdef-string④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-string-first">
-   <b><a href="#valdef-string-first">#valdef-string-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-string-first" class="dfn-panel" data-for="valdef-string-first" id="infopanel-for-valdef-string-first" role="dialog">
+   <span id="infopaneltitle-for-valdef-string-first" style="display:none">Info about the 'first' definition.</span><b><a href="#valdef-string-first">#valdef-string-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-string-first">2.7.2. 
 The string() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="entry-value">
-   <b><a href="#entry-value">#entry-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-entry-value" class="dfn-panel" data-for="entry-value" id="infopanel-for-entry-value" role="dialog">
+   <span id="infopaneltitle-for-entry-value" style="display:none">Info about the 'entry value' definition.</span><b><a href="#entry-value">#entry-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-value">2.7.2. 
 The string() function</a> <a href="#ref-for-entry-value①">(2)</a> <a href="#ref-for-entry-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exit-value">
-   <b><a href="#exit-value">#exit-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exit-value" class="dfn-panel" data-for="exit-value" id="infopanel-for-exit-value" role="dialog">
+   <span id="infopaneltitle-for-exit-value" style="display:none">Info about the 'exit value' definition.</span><b><a href="#exit-value">#exit-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exit-value">2.7.2. 
 The string() function</a> <a href="#ref-for-exit-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-content">
-   <b><a href="#funcdef-content">#funcdef-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-content" class="dfn-panel" data-for="funcdef-content" id="infopanel-for-funcdef-content" role="dialog">
+   <span id="infopaneltitle-for-funcdef-content" style="display:none">Info about the 'content()' definition.</span><b><a href="#funcdef-content">#funcdef-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-content">1. 
 Inserting and replacing content with the content property</a>
@@ -3086,15 +3086,15 @@ Inserting and replacing content with the content property</a>
 The content() function</a> <a href="#ref-for-funcdef-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-text">
-   <b><a href="#valdef-content-text">#valdef-content-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-text" class="dfn-panel" data-for="valdef-content-text" id="infopanel-for-valdef-content-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-content-text">#valdef-content-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-text">2.7.3. 
 The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-bookmark-level">
-   <b><a href="#propdef-bookmark-level">#propdef-bookmark-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-bookmark-level" class="dfn-panel" data-for="propdef-bookmark-level" id="infopanel-for-propdef-bookmark-level" role="dialog">
+   <span id="infopaneltitle-for-propdef-bookmark-level" style="display:none">Info about the 'bookmark-level' definition.</span><b><a href="#propdef-bookmark-level">#propdef-bookmark-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-level">4. 
 Bookmarks</a> <a href="#ref-for-propdef-bookmark-level①">(2)</a>
@@ -3104,15 +3104,15 @@ bookmark-level </a>
 bookmark-state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-bookmark-level-none">
-   <b><a href="#valdef-bookmark-level-none">#valdef-bookmark-level-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-bookmark-level-none" class="dfn-panel" data-for="valdef-bookmark-level-none" id="infopanel-for-valdef-bookmark-level-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-bookmark-level-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-bookmark-level-none">#valdef-bookmark-level-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-bookmark-level-none">4.1. 
 bookmark-level </a> <a href="#ref-for-valdef-bookmark-level-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-bookmark-label">
-   <b><a href="#propdef-bookmark-label">#propdef-bookmark-label</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-bookmark-label" class="dfn-panel" data-for="propdef-bookmark-label" id="infopanel-for-propdef-bookmark-label" role="dialog">
+   <span id="infopaneltitle-for-propdef-bookmark-label" style="display:none">Info about the 'bookmark-label' definition.</span><b><a href="#propdef-bookmark-label">#propdef-bookmark-label</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-label">4. 
 Bookmarks</a> <a href="#ref-for-propdef-bookmark-label①">(2)</a>
@@ -3120,8 +3120,8 @@ Bookmarks</a> <a href="#ref-for-propdef-bookmark-label①">(2)</a>
 bookmark-level </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-bookmark-state">
-   <b><a href="#propdef-bookmark-state">#propdef-bookmark-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-bookmark-state" class="dfn-panel" data-for="propdef-bookmark-state" id="infopanel-for-propdef-bookmark-state" role="dialog">
+   <span id="infopaneltitle-for-propdef-bookmark-state" style="display:none">Info about the 'bookmark-state' definition.</span><b><a href="#propdef-bookmark-state">#propdef-bookmark-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-state">4. 
 Bookmarks</a> <a href="#ref-for-propdef-bookmark-state①">(2)</a>
@@ -3133,59 +3133,115 @@ bookmark-state</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-counter-styles-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-counter-styles-3/Overview.html
@@ -3694,22 +3694,22 @@ the prose restrictions on negative values.</p>
    <li><a href="#use-a-negative-sign">uses a negative sign</a><span>, in § 3.2</span>
    <li><a href="#valdef-counter-style-speak-as-words">words</a><span>, in § 3.9</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">5. 
 Extending list-style-type, counter(), and counters()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">2. 
 Counter Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">Unnumbered Section</a>
     <li><a href="#ref-for-typedef-image①">3.8. 
@@ -3718,15 +3718,15 @@ Marker characters: the symbols and additive-symbols descriptors</a> <a href="#re
 Defining Anonymous Counter Styles: the symbols() function</a> <a href="#ref-for-typedef-image④">(2)</a> <a href="#ref-for-typedef-image⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3.8. 
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-counter">
-   <a href="https://drafts.csswg.org/css-lists-3/#funcdef-counter">https://drafts.csswg.org/css-lists-3/#funcdef-counter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-counter" class="dfn-panel" data-for="term-for-funcdef-counter" id="infopanel-for-term-for-funcdef-counter" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-counter" style="display:none">Info about the 'counter()' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#funcdef-counter">https://drafts.csswg.org/css-lists-3/#funcdef-counter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counter">1. 
 Introduction</a>
@@ -3740,8 +3740,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Extending list-style-type, counter(), and counters()</a> <a href="#ref-for-funcdef-counter⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-counters">
-   <a href="https://drafts.csswg.org/css-lists-3/#funcdef-counters">https://drafts.csswg.org/css-lists-3/#funcdef-counters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-counters" class="dfn-panel" data-for="term-for-funcdef-counters" id="infopanel-for-term-for-funcdef-counters" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-counters" style="display:none">Info about the 'counters()' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#funcdef-counters">https://drafts.csswg.org/css-lists-3/#funcdef-counters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counters">1. 
 Introduction</a>
@@ -3751,22 +3751,22 @@ Symbols before the marker: the prefix descriptor</a>
 Extending list-style-type, counter(), and counters()</a> <a href="#ref-for-funcdef-counters③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-list-style-position-inside">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside">https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-list-style-position-inside" class="dfn-panel" data-for="term-for-valdef-list-style-position-inside" id="infopanel-for-term-for-valdef-list-style-position-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-list-style-position-inside" style="display:none">Info about the 'inside' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside">https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-position-inside">3. 
 Defining Custom Counter Styles: the @counter-style rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style" class="dfn-panel" data-for="term-for-propdef-list-style" id="infopanel-for-term-for-propdef-list-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style" style="display:none">Info about the 'list-style' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">3. 
 Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-propdef-list-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">1. 
 Introduction</a>
@@ -3776,8 +3776,8 @@ Extending list-style-type, counter(), and counters()</a> <a href="#ref-for-propd
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">2. 
 Counter Styles</a>
@@ -3787,64 +3787,64 @@ Symbols before the marker: the prefix descriptor</a>
 Symbols after the marker: the suffix descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">3. 
 Defining Custom Counter Styles: the @counter-style rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">3.8. 
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar"> Changes since the Jun 2015 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-list-of-component-values">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-list-of-component-values" class="dfn-panel" data-for="term-for-parse-a-list-of-component-values" id="infopanel-for-term-for-parse-a-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-list-of-component-values" style="display:none">Info about the 'parse a list of component values' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-component-values">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grapheme-cluster">
-   <a href="https://drafts.csswg.org/css-text-3/#grapheme-cluster">https://drafts.csswg.org/css-text-3/#grapheme-cluster</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grapheme-cluster" class="dfn-panel" data-for="term-for-grapheme-cluster" id="infopanel-for-term-for-grapheme-cluster" role="menu">
+   <span id="infopaneltitle-for-term-for-grapheme-cluster" style="display:none">Info about the 'grapheme cluster' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#grapheme-cluster">https://drafts.csswg.org/css-text-3/#grapheme-cluster</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grapheme-cluster">3.6. 
 Zero-Padding and Constant-Width Representations: the pad descriptor</a> <a href="#ref-for-grapheme-cluster①">(2)</a> <a href="#ref-for-grapheme-cluster②">(3)</a> <a href="#ref-for-grapheme-cluster③">(4)</a> <a href="#ref-for-grapheme-cluster④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">3.9. 
 Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-content-language①">(2)</a> <a href="#ref-for-content-language②">(3)</a>
     <li><a href="#ref-for-content-language③"> Changes since the Jun 2015 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-emphasis-skip-symbols">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-emphasis-skip-symbols">https://drafts.csswg.org/css-text-decor-4/#valdef-text-emphasis-skip-symbols</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-emphasis-skip-symbols" class="dfn-panel" data-for="term-for-valdef-text-emphasis-skip-symbols" id="infopanel-for-term-for-valdef-text-emphasis-skip-symbols" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-emphasis-skip-symbols" style="display:none">Info about the 'symbols' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-emphasis-skip-symbols">https://drafts.csswg.org/css-text-decor-4/#valdef-text-emphasis-skip-symbols</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-skip-symbols">3. 
 Defining Custom Counter Styles: the @counter-style rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-3/#css-css-identifier">https://drafts.csswg.org/css-values-3/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#css-css-identifier">https://drafts.csswg.org/css-values-3/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.5. 
 Limiting the counter scope: the range descriptor</a>
@@ -3852,8 +3852,8 @@ Limiting the counter scope: the range descriptor</a>
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">3.6. 
 Zero-Padding and Constant-Width Representations: the pad descriptor</a>
@@ -3861,8 +3861,8 @@ Zero-Padding and Constant-Width Representations: the pad descriptor</a>
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">3.8. 
 Marker characters: the symbols and additive-symbols descriptors</a>
@@ -3870,8 +3870,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3. 
 Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-identifier-value①">(2)</a>
@@ -3879,8 +3879,8 @@ Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-id
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">3.1. 
 Counter algorithms: the system descriptor</a>
@@ -3892,8 +3892,8 @@ Zero-Padding and Constant-Width Representations: the pad descriptor</a> <a href=
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.8. 
 Marker characters: the symbols and additive-symbols descriptors</a>
@@ -3901,8 +3901,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Defining Anonymous Counter Styles: the symbols() function</a> <a href="#ref-for-string-value②">(2)</a> <a href="#ref-for-string-value③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.1. 
 Counter algorithms: the system descriptor</a>
@@ -3912,22 +3912,22 @@ Formatting negative values: the negative descriptor</a>
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">3. 
 Defining Custom Counter Styles: the @counter-style rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">3.5. 
 Limiting the counter scope: the range descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. 
 Counter algorithms: the system descriptor</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a>
@@ -3943,22 +3943,22 @@ Defining Anonymous Counter Styles: the symbols() function</a> <a href="#ref-for-
 Extending list-style-type, counter(), and counters()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">9.2. 
 The CSSCounterStyleRule interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a> <a href="#ref-for-cssomstring⑤">(6)</a> <a href="#ref-for-cssomstring⑥">(7)</a> <a href="#ref-for-cssomstring⑦">(8)</a> <a href="#ref-for-cssomstring⑧">(9)</a> <a href="#ref-for-cssomstring⑨">(10)</a> <a href="#ref-for-cssomstring①⓪">(11)</a> <a href="#ref-for-cssomstring①①">(12)</a> <a href="#ref-for-cssomstring①②">(13)</a> <a href="#ref-for-cssomstring①③">(14)</a> <a href="#ref-for-cssomstring①④">(15)</a> <a href="#ref-for-cssomstring①⑤">(16)</a> <a href="#ref-for-cssomstring①⑥">(17)</a> <a href="#ref-for-cssomstring①⑦">(18)</a> <a href="#ref-for-cssomstring①⑧">(19)</a> <a href="#ref-for-cssomstring①⑨">(20)</a> <a href="#ref-for-cssomstring②⓪">(21)</a> <a href="#ref-for-cssomstring②①">(22)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">9.1. 
 Extensions to the CSSRule interface</a>
@@ -3966,15 +3966,15 @@ Extensions to the CSSRule interface</a>
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-details-element">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-details-element" class="dfn-panel" data-for="term-for-the-details-element" id="infopanel-for-term-for-the-details-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-details-element" style="display:none">Info about the 'details' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-details-element">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a> <a href="#ref-for-the-details-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3. 
 Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
@@ -3982,15 +3982,15 @@ Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-as
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">9.1. 
 Extensions to the CSSRule interface</a>
@@ -4217,8 +4217,8 @@ Extensions to the CSSRule interface</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="counter-style">
-   <b><a href="#counter-style">#counter-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-counter-style" class="dfn-panel" data-for="counter-style" id="infopanel-for-counter-style" role="dialog">
+   <span id="infopaneltitle-for-counter-style" style="display:none">Info about the 'counter style' definition.</span><b><a href="#counter-style">#counter-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter-style">3. 
 Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-counter-style①">(2)</a>
@@ -4231,8 +4231,8 @@ The CSSCounterStyleRule interface</a>
     <li><a href="#ref-for-counter-style⑤"> Changes since the Jun 2015 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-counter">
-   <b><a href="#generate-a-counter">#generate-a-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-counter" class="dfn-panel" data-for="generate-a-counter" id="infopanel-for-generate-a-counter" role="dialog">
+   <span id="infopaneltitle-for-generate-a-counter" style="display:none">Info about the 'generate a counter representation' definition.</span><b><a href="#generate-a-counter">#generate-a-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-counter">2. 
 Counter Styles</a> <a href="#ref-for-generate-a-counter①">(2)</a>
@@ -4244,15 +4244,15 @@ Zero-Padding and Constant-Width Representations: the pad descriptor</a>
 Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-generate-a-counter⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-representation-for-the-counter-value">
-   <b><a href="#initial-representation-for-the-counter-value">#initial-representation-for-the-counter-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-representation-for-the-counter-value" class="dfn-panel" data-for="initial-representation-for-the-counter-value" id="infopanel-for-initial-representation-for-the-counter-value" role="dialog">
+   <span id="infopaneltitle-for-initial-representation-for-the-counter-value" style="display:none">Info about the 'initial representation for the counter value' definition.</span><b><a href="#initial-representation-for-the-counter-value">#initial-representation-for-the-counter-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-representation-for-the-counter-value">3.6. 
 Zero-Padding and Constant-Width Representations: the pad descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-counter-style">
-   <b><a href="#at-ruledef-counter-style">#at-ruledef-counter-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-counter-style" class="dfn-panel" data-for="at-ruledef-counter-style" id="infopanel-for-at-ruledef-counter-style" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-counter-style" style="display:none">Info about the '@counter-style' definition.</span><b><a href="#at-ruledef-counter-style">#at-ruledef-counter-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-counter-style①">1. 
 Introduction</a> <a href="#ref-for-at-ruledef-counter-style②">(2)</a>
@@ -4308,8 +4308,8 @@ The CSSCounterStyleRule interface</a> <a href="#ref-for-at-ruledef-counter-style
     <li><a href="#ref-for-at-ruledef-counter-style⑤①"> Changes since the Feb 2015 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-counter-style-name">
-   <b><a href="#typedef-counter-style-name">#typedef-counter-style-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-counter-style-name" class="dfn-panel" data-for="typedef-counter-style-name" id="infopanel-for-typedef-counter-style-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-counter-style-name" style="display:none">Info about the '&lt;counter-style-name>' definition.</span><b><a href="#typedef-counter-style-name">#typedef-counter-style-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style-name">3. 
 Defining Custom Counter Styles: the @counter-style rule</a> <a href="#ref-for-typedef-counter-style-name①">(2)</a>
@@ -4325,8 +4325,8 @@ Extending list-style-type, counter(), and counters()</a> <a href="#ref-for-typed
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-cyclic">
-   <b><a href="#valdef-counter-style-system-cyclic">#valdef-counter-style-system-cyclic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-cyclic" class="dfn-panel" data-for="valdef-counter-style-system-cyclic" id="infopanel-for-valdef-counter-style-system-cyclic" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-cyclic" style="display:none">Info about the 'cyclic' definition.</span><b><a href="#valdef-counter-style-system-cyclic">#valdef-counter-style-system-cyclic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-cyclic">3.1. 
 Counter algorithms: the system descriptor</a>
@@ -4340,8 +4340,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Speech Synthesis: the speak-as descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-fixed">
-   <b><a href="#valdef-counter-style-system-fixed">#valdef-counter-style-system-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-fixed" class="dfn-panel" data-for="valdef-counter-style-system-fixed" id="infopanel-for-valdef-counter-style-system-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-counter-style-system-fixed">#valdef-counter-style-system-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-fixed">3.1.2. 
 Exhaustible Symbols: the fixed system</a> <a href="#ref-for-valdef-counter-style-system-fixed①">(2)</a>
@@ -4355,8 +4355,8 @@ Defining Anonymous Counter Styles: the symbols() function</a>
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-symbol-value">
-   <b><a href="#first-symbol-value">#first-symbol-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-symbol-value" class="dfn-panel" data-for="first-symbol-value" id="infopanel-for-first-symbol-value" role="dialog">
+   <span id="infopaneltitle-for-first-symbol-value" style="display:none">Info about the 'first symbol value' definition.</span><b><a href="#first-symbol-value">#first-symbol-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-symbol-value">3.1.2. 
 Exhaustible Symbols: the fixed system</a> <a href="#ref-for-first-symbol-value①">(2)</a> <a href="#ref-for-first-symbol-value②">(3)</a>
@@ -4366,8 +4366,8 @@ Defining Anonymous Counter Styles: the symbols() function</a>
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-system-symbolic">
-   <b><a href="#valdef-system-symbolic">#valdef-system-symbolic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-system-symbolic" class="dfn-panel" data-for="valdef-system-symbolic" id="infopanel-for-valdef-system-symbolic" role="dialog">
+   <span id="infopaneltitle-for-valdef-system-symbolic" style="display:none">Info about the 'symbolic' definition.</span><b><a href="#valdef-system-symbolic">#valdef-system-symbolic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-system-symbolic">2. 
 Counter Styles</a>
@@ -4383,8 +4383,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-alphabetic">
-   <b><a href="#valdef-counter-style-system-alphabetic">#valdef-counter-style-system-alphabetic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-alphabetic" class="dfn-panel" data-for="valdef-counter-style-system-alphabetic" id="infopanel-for-valdef-counter-style-system-alphabetic" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-alphabetic" style="display:none">Info about the 'alphabetic' definition.</span><b><a href="#valdef-counter-style-system-alphabetic">#valdef-counter-style-system-alphabetic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-alphabetic">3.1.3. 
 Repeating Symbols: the symbolic system</a>
@@ -4402,8 +4402,8 @@ Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-valdef-counter-s
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-numeric">
-   <b><a href="#valdef-counter-style-system-numeric">#valdef-counter-style-system-numeric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-numeric" class="dfn-panel" data-for="valdef-counter-style-system-numeric" id="infopanel-for-valdef-counter-style-system-numeric" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-numeric" style="display:none">Info about the 'numeric' definition.</span><b><a href="#valdef-counter-style-system-numeric">#valdef-counter-style-system-numeric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-numeric">3.1. 
 Counter algorithms: the system descriptor</a>
@@ -4419,8 +4419,8 @@ Marker characters: the symbols and additive-symbols descriptors</a>
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-additive">
-   <b><a href="#valdef-counter-style-system-additive">#valdef-counter-style-system-additive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-additive" class="dfn-panel" data-for="valdef-counter-style-system-additive" id="infopanel-for-valdef-counter-style-system-additive" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-additive" style="display:none">Info about the 'additive' definition.</span><b><a href="#valdef-counter-style-system-additive">#valdef-counter-style-system-additive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-additive">2. 
 Counter Styles</a>
@@ -4434,15 +4434,15 @@ Limiting the counter scope: the range descriptor</a>
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-tuple">
-   <b><a href="#current-tuple">#current-tuple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-tuple" class="dfn-panel" data-for="current-tuple" id="infopanel-for-current-tuple" role="dialog">
+   <span id="infopaneltitle-for-current-tuple" style="display:none">Info about the 'current tuple' definition.</span><b><a href="#current-tuple">#current-tuple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-tuple">3.1.6. 
 Accumulating Numerals: the additive system</a> <a href="#ref-for-current-tuple①">(2)</a> <a href="#ref-for-current-tuple②">(3)</a> <a href="#ref-for-current-tuple③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-system-extends">
-   <b><a href="#valdef-counter-style-system-extends">#valdef-counter-style-system-extends</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-system-extends" class="dfn-panel" data-for="valdef-counter-style-system-extends" id="infopanel-for-valdef-counter-style-system-extends" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-system-extends" style="display:none">Info about the 'extends' definition.</span><b><a href="#valdef-counter-style-system-extends">#valdef-counter-style-system-extends</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-system-extends">3.1.7. 
 Building from Existing Counter Styles: the extends system </a> <a href="#ref-for-valdef-counter-style-system-extends①">(2)</a> <a href="#ref-for-valdef-counter-style-system-extends②">(3)</a> <a href="#ref-for-valdef-counter-style-system-extends③">(4)</a>
@@ -4456,15 +4456,15 @@ Speech Synthesis: the speak-as descriptor</a>
 Complex Predefined Counter Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-counter-style-negative">
-   <b><a href="#descdef-counter-style-negative">#descdef-counter-style-negative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-counter-style-negative" class="dfn-panel" data-for="descdef-counter-style-negative" id="infopanel-for-descdef-counter-style-negative" role="dialog">
+   <span id="infopaneltitle-for-descdef-counter-style-negative" style="display:none">Info about the 'negative' definition.</span><b><a href="#descdef-counter-style-negative">#descdef-counter-style-negative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-negative">3.2. 
 Formatting negative values: the negative descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="use-a-negative-sign">
-   <b><a href="#use-a-negative-sign">#use-a-negative-sign</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-use-a-negative-sign" class="dfn-panel" data-for="use-a-negative-sign" id="infopanel-for-use-a-negative-sign" role="dialog">
+   <span id="infopaneltitle-for-use-a-negative-sign" style="display:none">Info about the 'uses a negative sign' definition.</span><b><a href="#use-a-negative-sign">#use-a-negative-sign</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-use-a-negative-sign">2. 
 Counter Styles</a> <a href="#ref-for-use-a-negative-sign①">(2)</a>
@@ -4476,8 +4476,8 @@ Zero-Padding and Constant-Width Representations: the pad descriptor</a>
 Complex Predefined Counter Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-range-auto">
-   <b><a href="#valdef-counter-style-range-auto">#valdef-counter-style-range-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-range-auto" class="dfn-panel" data-for="valdef-counter-style-range-auto" id="infopanel-for-valdef-counter-style-range-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-range-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-counter-style-range-auto">#valdef-counter-style-range-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-range-auto">3.5. 
 Limiting the counter scope: the range descriptor</a>
@@ -4485,29 +4485,29 @@ Limiting the counter scope: the range descriptor</a>
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-counter-style-pad">
-   <b><a href="#descdef-counter-style-pad">#descdef-counter-style-pad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-counter-style-pad" class="dfn-panel" data-for="descdef-counter-style-pad" id="infopanel-for-descdef-counter-style-pad" role="dialog">
+   <span id="infopaneltitle-for-descdef-counter-style-pad" style="display:none">Info about the 'pad' definition.</span><b><a href="#descdef-counter-style-pad">#descdef-counter-style-pad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-pad">3.6. 
 Zero-Padding and Constant-Width Representations: the pad descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-counter-style-symbols">
-   <b><a href="#descdef-counter-style-symbols">#descdef-counter-style-symbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-counter-style-symbols" class="dfn-panel" data-for="descdef-counter-style-symbols" id="infopanel-for-descdef-counter-style-symbols" role="dialog">
+   <span id="infopaneltitle-for-descdef-counter-style-symbols" style="display:none">Info about the 'symbols' definition.</span><b><a href="#descdef-counter-style-symbols">#descdef-counter-style-symbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-symbols">3.8. 
 Marker characters: the symbols and additive-symbols descriptors</a> <a href="#ref-for-descdef-counter-style-symbols①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-counter-style-additive-symbols">
-   <b><a href="#descdef-counter-style-additive-symbols">#descdef-counter-style-additive-symbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-counter-style-additive-symbols" class="dfn-panel" data-for="descdef-counter-style-additive-symbols" id="infopanel-for-descdef-counter-style-additive-symbols" role="dialog">
+   <span id="infopaneltitle-for-descdef-counter-style-additive-symbols" style="display:none">Info about the 'additive-symbols' definition.</span><b><a href="#descdef-counter-style-additive-symbols">#descdef-counter-style-additive-symbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-additive-symbols">3.1.6. 
 Accumulating Numerals: the additive system</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-symbol">
-   <b><a href="#typedef-symbol">#typedef-symbol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-symbol" class="dfn-panel" data-for="typedef-symbol" id="infopanel-for-typedef-symbol" role="dialog">
+   <span id="infopaneltitle-for-typedef-symbol" style="display:none">Info about the '&lt;symbol>' definition.</span><b><a href="#typedef-symbol">#typedef-symbol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-symbol①">3.2. 
 Formatting negative values: the negative descriptor</a> <a href="#ref-for-typedef-symbol②">(2)</a> <a href="#ref-for-typedef-symbol③">(3)</a> <a href="#ref-for-typedef-symbol④">(4)</a>
@@ -4521,8 +4521,8 @@ Zero-Padding and Constant-Width Representations: the pad descriptor</a> <a href=
 Marker characters: the symbols and additive-symbols descriptors</a> <a href="#ref-for-typedef-symbol①⑨">(2)</a> <a href="#ref-for-typedef-symbol②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="counter-symbol">
-   <b><a href="#counter-symbol">#counter-symbol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-counter-symbol" class="dfn-panel" data-for="counter-symbol" id="infopanel-for-counter-symbol" role="dialog">
+   <span id="infopaneltitle-for-counter-symbol" style="display:none">Info about the 'counter symbol' definition.</span><b><a href="#counter-symbol">#counter-symbol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter-symbol">3.1.1. 
 Cycling Symbols: the cyclic system</a> <a href="#ref-for-counter-symbol①">(2)</a> <a href="#ref-for-counter-symbol②">(3)</a> <a href="#ref-for-counter-symbol③">(4)</a> <a href="#ref-for-counter-symbol④">(5)</a> <a href="#ref-for-counter-symbol⑤">(6)</a> <a href="#ref-for-counter-symbol⑥">(7)</a>
@@ -4540,8 +4540,8 @@ Accumulating Numerals: the additive system</a> <a href="#ref-for-counter-symbol�
 Marker characters: the symbols and additive-symbols descriptors</a> <a href="#ref-for-counter-symbol③⑤">(2)</a> <a href="#ref-for-counter-symbol③⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="additive-tuple">
-   <b><a href="#additive-tuple">#additive-tuple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-additive-tuple" class="dfn-panel" data-for="additive-tuple" id="infopanel-for-additive-tuple" role="dialog">
+   <span id="infopaneltitle-for-additive-tuple" style="display:none">Info about the 'additive tuple' definition.</span><b><a href="#additive-tuple">#additive-tuple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-additive-tuple">3.1.6. 
 Accumulating Numerals: the additive system</a> <a href="#ref-for-additive-tuple①">(2)</a> <a href="#ref-for-additive-tuple②">(3)</a> <a href="#ref-for-additive-tuple③">(4)</a>
@@ -4549,8 +4549,8 @@ Accumulating Numerals: the additive system</a> <a href="#ref-for-additive-tuple�
 Marker characters: the symbols and additive-symbols descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-counter-style-speak-as">
-   <b><a href="#descdef-counter-style-speak-as">#descdef-counter-style-speak-as</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-counter-style-speak-as" class="dfn-panel" data-for="descdef-counter-style-speak-as" id="infopanel-for-descdef-counter-style-speak-as" role="dialog">
+   <span id="infopaneltitle-for-descdef-counter-style-speak-as" style="display:none">Info about the 'speak-as' definition.</span><b><a href="#descdef-counter-style-speak-as">#descdef-counter-style-speak-as</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-speak-as">3.9. 
 Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-descdef-counter-style-speak-as①">(2)</a> <a href="#ref-for-descdef-counter-style-speak-as②">(3)</a> <a href="#ref-for-descdef-counter-style-speak-as③">(4)</a>
@@ -4560,8 +4560,8 @@ Defining Anonymous Counter Styles: the symbols() function</a>
 Complex Predefined Counter Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-speak-as-auto">
-   <b><a href="#valdef-counter-style-speak-as-auto">#valdef-counter-style-speak-as-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-speak-as-auto" class="dfn-panel" data-for="valdef-counter-style-speak-as-auto" id="infopanel-for-valdef-counter-style-speak-as-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-speak-as-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-counter-style-speak-as-auto">#valdef-counter-style-speak-as-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-speak-as-auto">3.9. 
 Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-valdef-counter-style-speak-as-auto①">(2)</a> <a href="#ref-for-valdef-counter-style-speak-as-auto②">(3)</a>
@@ -4569,15 +4569,15 @@ Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-valdef-counter-s
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-speak-as-bullets">
-   <b><a href="#valdef-counter-style-speak-as-bullets">#valdef-counter-style-speak-as-bullets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-speak-as-bullets" class="dfn-panel" data-for="valdef-counter-style-speak-as-bullets" id="infopanel-for-valdef-counter-style-speak-as-bullets" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-speak-as-bullets" style="display:none">Info about the 'bullets' definition.</span><b><a href="#valdef-counter-style-speak-as-bullets">#valdef-counter-style-speak-as-bullets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-speak-as-bullets">3.9. 
 Speech Synthesis: the speak-as descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-speak-as-numbers">
-   <b><a href="#valdef-counter-style-speak-as-numbers">#valdef-counter-style-speak-as-numbers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-speak-as-numbers" class="dfn-panel" data-for="valdef-counter-style-speak-as-numbers" id="infopanel-for-valdef-counter-style-speak-as-numbers" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-speak-as-numbers" style="display:none">Info about the 'numbers' definition.</span><b><a href="#valdef-counter-style-speak-as-numbers">#valdef-counter-style-speak-as-numbers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-speak-as-numbers">3.9. 
 Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-valdef-counter-style-speak-as-numbers①">(2)</a>
@@ -4585,15 +4585,15 @@ Speech Synthesis: the speak-as descriptor</a> <a href="#ref-for-valdef-counter-s
 Complex Predefined Counter Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-speak-as-spell-out">
-   <b><a href="#valdef-counter-style-speak-as-spell-out">#valdef-counter-style-speak-as-spell-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-speak-as-spell-out" class="dfn-panel" data-for="valdef-counter-style-speak-as-spell-out" id="infopanel-for-valdef-counter-style-speak-as-spell-out" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-speak-as-spell-out" style="display:none">Info about the 'spell-out' definition.</span><b><a href="#valdef-counter-style-speak-as-spell-out">#valdef-counter-style-speak-as-spell-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-speak-as-spell-out">3.9. 
 Speech Synthesis: the speak-as descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-symbols">
-   <b><a href="#funcdef-symbols">#funcdef-symbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-symbols" class="dfn-panel" data-for="funcdef-symbols" id="infopanel-for-funcdef-symbols" role="dialog">
+   <span id="infopaneltitle-for-funcdef-symbols" style="display:none">Info about the 'symbols()' definition.</span><b><a href="#funcdef-symbols">#funcdef-symbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-symbols">4. 
 Defining Anonymous Counter Styles: the symbols() function</a> <a href="#ref-for-funcdef-symbols①">(2)</a> <a href="#ref-for-funcdef-symbols②">(3)</a> <a href="#ref-for-funcdef-symbols③">(4)</a> <a href="#ref-for-funcdef-symbols④">(5)</a>
@@ -4601,22 +4601,22 @@ Defining Anonymous Counter Styles: the symbols() function</a> <a href="#ref-for-
 Extending list-style-type, counter(), and counters()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-symbols-type">
-   <b><a href="#typedef-symbols-type">#typedef-symbols-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-symbols-type" class="dfn-panel" data-for="typedef-symbols-type" id="infopanel-for-typedef-symbols-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-symbols-type" style="display:none">Info about the '&lt;symbols-type>' definition.</span><b><a href="#typedef-symbols-type">#typedef-symbols-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-symbols-type">4. 
 Defining Anonymous Counter Styles: the symbols() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-counter-style">
-   <b><a href="#typedef-counter-style">#typedef-counter-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-counter-style" class="dfn-panel" data-for="typedef-counter-style" id="infopanel-for-typedef-counter-style" role="dialog">
+   <span id="infopaneltitle-for-typedef-counter-style" style="display:none">Info about the '&lt;counter-style>' definition.</span><b><a href="#typedef-counter-style">#typedef-counter-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style">5. 
 Extending list-style-type, counter(), and counters()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decimal">
-   <b><a href="#decimal">#decimal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decimal" class="dfn-panel" data-for="decimal" id="infopanel-for-decimal" role="dialog">
+   <span id="infopaneltitle-for-decimal" style="display:none">Info about the 'decimal' definition.</span><b><a href="#decimal">#decimal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decimal">2. 
 Counter Styles</a>
@@ -4634,64 +4634,64 @@ Extending list-style-type, counter(), and counters()</a> <a href="#ref-for-decim
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a> <a href="#ref-for-decimal①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decimal-leading-zero">
-   <b><a href="#decimal-leading-zero">#decimal-leading-zero</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decimal-leading-zero" class="dfn-panel" data-for="decimal-leading-zero" id="infopanel-for-decimal-leading-zero" role="dialog">
+   <span id="infopaneltitle-for-decimal-leading-zero" style="display:none">Info about the 'decimal-leading-zero' definition.</span><b><a href="#decimal-leading-zero">#decimal-leading-zero</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decimal-leading-zero">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-arabic-indic">
-   <b><a href="#valdef-counter-style-name-arabic-indic">#valdef-counter-style-name-arabic-indic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-arabic-indic" class="dfn-panel" data-for="valdef-counter-style-name-arabic-indic" id="infopanel-for-valdef-counter-style-name-arabic-indic" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-arabic-indic" style="display:none">Info about the 'arabic-indic' definition.</span><b><a href="#valdef-counter-style-name-arabic-indic">#valdef-counter-style-name-arabic-indic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-arabic-indic">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="armenian">
-   <b><a href="#armenian">#armenian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-armenian" class="dfn-panel" data-for="armenian" id="infopanel-for-armenian" role="dialog">
+   <span id="infopaneltitle-for-armenian" style="display:none">Info about the 'armenian' definition.</span><b><a href="#armenian">#armenian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-armenian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-upper-armenian">
-   <b><a href="#valdef-counter-style-name-upper-armenian">#valdef-counter-style-name-upper-armenian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-upper-armenian" class="dfn-panel" data-for="valdef-counter-style-name-upper-armenian" id="infopanel-for-valdef-counter-style-name-upper-armenian" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-upper-armenian" style="display:none">Info about the 'upper-armenian' definition.</span><b><a href="#valdef-counter-style-name-upper-armenian">#valdef-counter-style-name-upper-armenian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-upper-armenian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-lower-armenian">
-   <b><a href="#valdef-counter-style-name-lower-armenian">#valdef-counter-style-name-lower-armenian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-lower-armenian" class="dfn-panel" data-for="valdef-counter-style-name-lower-armenian" id="infopanel-for-valdef-counter-style-name-lower-armenian" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-lower-armenian" style="display:none">Info about the 'lower-armenian' definition.</span><b><a href="#valdef-counter-style-name-lower-armenian">#valdef-counter-style-name-lower-armenian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-lower-armenian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-bengali">
-   <b><a href="#valdef-counter-style-name-bengali">#valdef-counter-style-name-bengali</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-bengali" class="dfn-panel" data-for="valdef-counter-style-name-bengali" id="infopanel-for-valdef-counter-style-name-bengali" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-bengali" style="display:none">Info about the 'bengali' definition.</span><b><a href="#valdef-counter-style-name-bengali">#valdef-counter-style-name-bengali</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-bengali">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-cambodian">
-   <b><a href="#valdef-counter-style-name-cambodian">#valdef-counter-style-name-cambodian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-cambodian" class="dfn-panel" data-for="valdef-counter-style-name-cambodian" id="infopanel-for-valdef-counter-style-name-cambodian" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-cambodian" style="display:none">Info about the 'cambodian' definition.</span><b><a href="#valdef-counter-style-name-cambodian">#valdef-counter-style-name-cambodian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-cambodian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-khmer">
-   <b><a href="#valdef-counter-style-name-khmer">#valdef-counter-style-name-khmer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-khmer" class="dfn-panel" data-for="valdef-counter-style-name-khmer" id="infopanel-for-valdef-counter-style-name-khmer" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-khmer" style="display:none">Info about the 'khmer' definition.</span><b><a href="#valdef-counter-style-name-khmer">#valdef-counter-style-name-khmer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-khmer">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cjk-decimal">
-   <b><a href="#cjk-decimal">#cjk-decimal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cjk-decimal" class="dfn-panel" data-for="cjk-decimal" id="infopanel-for-cjk-decimal" role="dialog">
+   <span id="infopaneltitle-for-cjk-decimal" style="display:none">Info about the 'cjk-decimal' definition.</span><b><a href="#cjk-decimal">#cjk-decimal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cjk-decimal">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
@@ -4701,135 +4701,135 @@ Longhand East Asian Counter Styles</a>
 Chinese: simp-chinese-informal, simp-chinese-formal, trad-chinese-informal, and trad-chinese-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-devanagari">
-   <b><a href="#valdef-counter-style-name-devanagari">#valdef-counter-style-name-devanagari</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-devanagari" class="dfn-panel" data-for="valdef-counter-style-name-devanagari" id="infopanel-for-valdef-counter-style-name-devanagari" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-devanagari" style="display:none">Info about the 'devanagari' definition.</span><b><a href="#valdef-counter-style-name-devanagari">#valdef-counter-style-name-devanagari</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-devanagari">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="georgian">
-   <b><a href="#georgian">#georgian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-georgian" class="dfn-panel" data-for="georgian" id="infopanel-for-georgian" role="dialog">
+   <span id="infopaneltitle-for-georgian" style="display:none">Info about the 'georgian' definition.</span><b><a href="#georgian">#georgian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-georgian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-gujarati">
-   <b><a href="#valdef-counter-style-name-gujarati">#valdef-counter-style-name-gujarati</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-gujarati" class="dfn-panel" data-for="valdef-counter-style-name-gujarati" id="infopanel-for-valdef-counter-style-name-gujarati" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-gujarati" style="display:none">Info about the 'gujarati' definition.</span><b><a href="#valdef-counter-style-name-gujarati">#valdef-counter-style-name-gujarati</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-gujarati">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-gurmukhi">
-   <b><a href="#valdef-counter-style-name-gurmukhi">#valdef-counter-style-name-gurmukhi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-gurmukhi" class="dfn-panel" data-for="valdef-counter-style-name-gurmukhi" id="infopanel-for-valdef-counter-style-name-gurmukhi" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-gurmukhi" style="display:none">Info about the 'gurmukhi' definition.</span><b><a href="#valdef-counter-style-name-gurmukhi">#valdef-counter-style-name-gurmukhi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-gurmukhi">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hebrew">
-   <b><a href="#hebrew">#hebrew</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hebrew" class="dfn-panel" data-for="hebrew" id="infopanel-for-hebrew" role="dialog">
+   <span id="infopaneltitle-for-hebrew" style="display:none">Info about the 'hebrew' definition.</span><b><a href="#hebrew">#hebrew</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hebrew">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a> <a href="#ref-for-hebrew①">(2)</a>
     <li><a href="#ref-for-hebrew②"> Changes since the Feb 2015 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-kannada">
-   <b><a href="#valdef-counter-style-name-kannada">#valdef-counter-style-name-kannada</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-kannada" class="dfn-panel" data-for="valdef-counter-style-name-kannada" id="infopanel-for-valdef-counter-style-name-kannada" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-kannada" style="display:none">Info about the 'kannada' definition.</span><b><a href="#valdef-counter-style-name-kannada">#valdef-counter-style-name-kannada</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-kannada">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-lao">
-   <b><a href="#valdef-counter-style-name-lao">#valdef-counter-style-name-lao</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-lao" class="dfn-panel" data-for="valdef-counter-style-name-lao" id="infopanel-for-valdef-counter-style-name-lao" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-lao" style="display:none">Info about the 'lao' definition.</span><b><a href="#valdef-counter-style-name-lao">#valdef-counter-style-name-lao</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-lao">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-malayalam">
-   <b><a href="#valdef-counter-style-name-malayalam">#valdef-counter-style-name-malayalam</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-malayalam" class="dfn-panel" data-for="valdef-counter-style-name-malayalam" id="infopanel-for-valdef-counter-style-name-malayalam" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-malayalam" style="display:none">Info about the 'malayalam' definition.</span><b><a href="#valdef-counter-style-name-malayalam">#valdef-counter-style-name-malayalam</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-malayalam">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-mongolian">
-   <b><a href="#valdef-counter-style-name-mongolian">#valdef-counter-style-name-mongolian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-mongolian" class="dfn-panel" data-for="valdef-counter-style-name-mongolian" id="infopanel-for-valdef-counter-style-name-mongolian" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-mongolian" style="display:none">Info about the 'mongolian' definition.</span><b><a href="#valdef-counter-style-name-mongolian">#valdef-counter-style-name-mongolian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-mongolian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-myanmar">
-   <b><a href="#valdef-counter-style-name-myanmar">#valdef-counter-style-name-myanmar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-myanmar" class="dfn-panel" data-for="valdef-counter-style-name-myanmar" id="infopanel-for-valdef-counter-style-name-myanmar" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-myanmar" style="display:none">Info about the 'myanmar' definition.</span><b><a href="#valdef-counter-style-name-myanmar">#valdef-counter-style-name-myanmar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-myanmar">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-oriya">
-   <b><a href="#valdef-counter-style-name-oriya">#valdef-counter-style-name-oriya</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-oriya" class="dfn-panel" data-for="valdef-counter-style-name-oriya" id="infopanel-for-valdef-counter-style-name-oriya" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-oriya" style="display:none">Info about the 'oriya' definition.</span><b><a href="#valdef-counter-style-name-oriya">#valdef-counter-style-name-oriya</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-oriya">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-persian">
-   <b><a href="#valdef-counter-style-name-persian">#valdef-counter-style-name-persian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-persian" class="dfn-panel" data-for="valdef-counter-style-name-persian" id="infopanel-for-valdef-counter-style-name-persian" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-persian" style="display:none">Info about the 'persian' definition.</span><b><a href="#valdef-counter-style-name-persian">#valdef-counter-style-name-persian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-persian">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lower-roman">
-   <b><a href="#lower-roman">#lower-roman</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lower-roman" class="dfn-panel" data-for="lower-roman" id="infopanel-for-lower-roman" role="dialog">
+   <span id="infopaneltitle-for-lower-roman" style="display:none">Info about the 'lower-roman' definition.</span><b><a href="#lower-roman">#lower-roman</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-roman">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upper-roman">
-   <b><a href="#upper-roman">#upper-roman</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upper-roman" class="dfn-panel" data-for="upper-roman" id="infopanel-for-upper-roman" role="dialog">
+   <span id="infopaneltitle-for-upper-roman" style="display:none">Info about the 'upper-roman' definition.</span><b><a href="#upper-roman">#upper-roman</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-roman">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-tamil">
-   <b><a href="#valdef-counter-style-name-tamil">#valdef-counter-style-name-tamil</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-tamil" class="dfn-panel" data-for="valdef-counter-style-name-tamil" id="infopanel-for-valdef-counter-style-name-tamil" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-tamil" style="display:none">Info about the 'tamil' definition.</span><b><a href="#valdef-counter-style-name-tamil">#valdef-counter-style-name-tamil</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-tamil">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-telugu">
-   <b><a href="#valdef-counter-style-name-telugu">#valdef-counter-style-name-telugu</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-telugu" class="dfn-panel" data-for="valdef-counter-style-name-telugu" id="infopanel-for-valdef-counter-style-name-telugu" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-telugu" style="display:none">Info about the 'telugu' definition.</span><b><a href="#valdef-counter-style-name-telugu">#valdef-counter-style-name-telugu</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-telugu">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-thai">
-   <b><a href="#valdef-counter-style-name-thai">#valdef-counter-style-name-thai</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-thai" class="dfn-panel" data-for="valdef-counter-style-name-thai" id="infopanel-for-valdef-counter-style-name-thai" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-thai" style="display:none">Info about the 'thai' definition.</span><b><a href="#valdef-counter-style-name-thai">#valdef-counter-style-name-thai</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-thai">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-tibetan">
-   <b><a href="#valdef-counter-style-name-tibetan">#valdef-counter-style-name-tibetan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-tibetan" class="dfn-panel" data-for="valdef-counter-style-name-tibetan" id="infopanel-for-valdef-counter-style-name-tibetan" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-tibetan" style="display:none">Info about the 'tibetan' definition.</span><b><a href="#valdef-counter-style-name-tibetan">#valdef-counter-style-name-tibetan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-tibetan">6.1. 
 Numeric: decimal, decimal-leading-zero, arabic-indic, armenian, upper-armenian, lower-armenian, bengali, cambodian, khmer, cjk-decimal, devanagari, georgian, gujarati, gurmukhi, hebrew, kannada, lao, malayalam, mongolian, myanmar, oriya, persian, lower-roman, upper-roman, tamil, telugu, thai, tibetan</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lower-alpha">
-   <b><a href="#lower-alpha">#lower-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lower-alpha" class="dfn-panel" data-for="lower-alpha" id="infopanel-for-lower-alpha" role="dialog">
+   <span id="infopaneltitle-for-lower-alpha" style="display:none">Info about the 'lower-alpha' definition.</span><b><a href="#lower-alpha">#lower-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-alpha">3.1.4. 
 Bijective Numerals: the alphabetic system</a>
@@ -4837,8 +4837,8 @@ Bijective Numerals: the alphabetic system</a>
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lower-latin">
-   <b><a href="#lower-latin">#lower-latin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lower-latin" class="dfn-panel" data-for="lower-latin" id="infopanel-for-lower-latin" role="dialog">
+   <span id="infopaneltitle-for-lower-latin" style="display:none">Info about the 'lower-latin' definition.</span><b><a href="#lower-latin">#lower-latin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-latin">3.9. 
 Speech Synthesis: the speak-as descriptor</a>
@@ -4846,8 +4846,8 @@ Speech Synthesis: the speak-as descriptor</a>
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upper-alpha">
-   <b><a href="#upper-alpha">#upper-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upper-alpha" class="dfn-panel" data-for="upper-alpha" id="infopanel-for-upper-alpha" role="dialog">
+   <span id="infopaneltitle-for-upper-alpha" style="display:none">Info about the 'upper-alpha' definition.</span><b><a href="#upper-alpha">#upper-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-alpha">3.1.3. 
 Repeating Symbols: the symbolic system</a> <a href="#ref-for-upper-alpha①">(2)</a> <a href="#ref-for-upper-alpha②">(3)</a> <a href="#ref-for-upper-alpha③">(4)</a>
@@ -4855,8 +4855,8 @@ Repeating Symbols: the symbolic system</a> <a href="#ref-for-upper-alpha①">(2)
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upper-latin">
-   <b><a href="#upper-latin">#upper-latin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upper-latin" class="dfn-panel" data-for="upper-latin" id="infopanel-for-upper-latin" role="dialog">
+   <span id="infopaneltitle-for-upper-latin" style="display:none">Info about the 'upper-latin' definition.</span><b><a href="#upper-latin">#upper-latin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-latin">3.9. 
 Speech Synthesis: the speak-as descriptor</a>
@@ -4864,8 +4864,8 @@ Speech Synthesis: the speak-as descriptor</a>
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lower-greek">
-   <b><a href="#lower-greek">#lower-greek</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lower-greek" class="dfn-panel" data-for="lower-greek" id="infopanel-for-lower-greek" role="dialog">
+   <span id="infopaneltitle-for-lower-greek" style="display:none">Info about the 'lower-greek' definition.</span><b><a href="#lower-greek">#lower-greek</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-greek">3.9. 
 Speech Synthesis: the speak-as descriptor</a>
@@ -4873,85 +4873,85 @@ Speech Synthesis: the speak-as descriptor</a>
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hiragana">
-   <b><a href="#hiragana">#hiragana</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hiragana" class="dfn-panel" data-for="hiragana" id="infopanel-for-hiragana" role="dialog">
+   <span id="infopaneltitle-for-hiragana" style="display:none">Info about the 'hiragana' definition.</span><b><a href="#hiragana">#hiragana</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hiragana">6.2. 
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hiragana-iroha">
-   <b><a href="#hiragana-iroha">#hiragana-iroha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hiragana-iroha" class="dfn-panel" data-for="hiragana-iroha" id="infopanel-for-hiragana-iroha" role="dialog">
+   <span id="infopaneltitle-for-hiragana-iroha" style="display:none">Info about the 'hiragana-iroha' definition.</span><b><a href="#hiragana-iroha">#hiragana-iroha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hiragana-iroha">6.2. 
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="katakana">
-   <b><a href="#katakana">#katakana</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-katakana" class="dfn-panel" data-for="katakana" id="infopanel-for-katakana" role="dialog">
+   <span id="infopaneltitle-for-katakana" style="display:none">Info about the 'katakana' definition.</span><b><a href="#katakana">#katakana</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-katakana">6.2. 
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="katakana-iroha">
-   <b><a href="#katakana-iroha">#katakana-iroha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-katakana-iroha" class="dfn-panel" data-for="katakana-iroha" id="infopanel-for-katakana-iroha" role="dialog">
+   <span id="infopaneltitle-for-katakana-iroha" style="display:none">Info about the 'katakana-iroha' definition.</span><b><a href="#katakana-iroha">#katakana-iroha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-katakana-iroha">6.2. 
 Alphabetic: lower-alpha, lower-latin, upper-alpha, upper-latin, lower-greek, hiragana, hiragana-iroha, katakana, katakana-iroha</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disc">
-   <b><a href="#disc">#disc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disc" class="dfn-panel" data-for="disc" id="infopanel-for-disc" role="dialog">
+   <span id="infopaneltitle-for-disc" style="display:none">Info about the 'disc' definition.</span><b><a href="#disc">#disc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disc">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a> <a href="#ref-for-disc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="circle">
-   <b><a href="#circle">#circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-circle" class="dfn-panel" data-for="circle" id="infopanel-for-circle" role="dialog">
+   <span id="infopaneltitle-for-circle" style="display:none">Info about the 'circle' definition.</span><b><a href="#circle">#circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-circle">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="square">
-   <b><a href="#square">#square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-square" class="dfn-panel" data-for="square" id="infopanel-for-square" role="dialog">
+   <span id="infopaneltitle-for-square" style="display:none">Info about the 'square' definition.</span><b><a href="#square">#square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-square">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disclosure-open">
-   <b><a href="#disclosure-open">#disclosure-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disclosure-open" class="dfn-panel" data-for="disclosure-open" id="infopanel-for-disclosure-open" role="dialog">
+   <span id="infopaneltitle-for-disclosure-open" style="display:none">Info about the 'disclosure-open' definition.</span><b><a href="#disclosure-open">#disclosure-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disclosure-open">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a> <a href="#ref-for-disclosure-open①">(2)</a> <a href="#ref-for-disclosure-open②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disclosure-closed">
-   <b><a href="#disclosure-closed">#disclosure-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disclosure-closed" class="dfn-panel" data-for="disclosure-closed" id="infopanel-for-disclosure-closed" role="dialog">
+   <span id="infopaneltitle-for-disclosure-closed" style="display:none">Info about the 'disclosure-closed' definition.</span><b><a href="#disclosure-closed">#disclosure-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disclosure-closed">6.3. 
 Symbolic: disc, circle, square, disclosure-open, disclosure-closed</a> <a href="#ref-for-disclosure-closed①">(2)</a> <a href="#ref-for-disclosure-closed②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-cjk-earthly-branch">
-   <b><a href="#valdef-counter-style-name-cjk-earthly-branch">#valdef-counter-style-name-cjk-earthly-branch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-cjk-earthly-branch" class="dfn-panel" data-for="valdef-counter-style-name-cjk-earthly-branch" id="infopanel-for-valdef-counter-style-name-cjk-earthly-branch" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-cjk-earthly-branch" style="display:none">Info about the 'cjk-earthly-branch' definition.</span><b><a href="#valdef-counter-style-name-cjk-earthly-branch">#valdef-counter-style-name-cjk-earthly-branch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-cjk-earthly-branch">6.4. 
 Fixed: cjk-earthly-branch, cjk-heavenly-stem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-cjk-heavenly-stem">
-   <b><a href="#valdef-counter-style-name-cjk-heavenly-stem">#valdef-counter-style-name-cjk-heavenly-stem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-cjk-heavenly-stem" class="dfn-panel" data-for="valdef-counter-style-name-cjk-heavenly-stem" id="infopanel-for-valdef-counter-style-name-cjk-heavenly-stem" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-cjk-heavenly-stem" style="display:none">Info about the 'cjk-heavenly-stem' definition.</span><b><a href="#valdef-counter-style-name-cjk-heavenly-stem">#valdef-counter-style-name-cjk-heavenly-stem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-cjk-heavenly-stem">6.4. 
 Fixed: cjk-earthly-branch, cjk-heavenly-stem</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="japanese-informal">
-   <b><a href="#japanese-informal">#japanese-informal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-japanese-informal" class="dfn-panel" data-for="japanese-informal" id="infopanel-for-japanese-informal" role="dialog">
+   <span id="infopaneltitle-for-japanese-informal" style="display:none">Info about the 'japanese-informal' definition.</span><b><a href="#japanese-informal">#japanese-informal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-japanese-informal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -4959,8 +4959,8 @@ Longhand East Asian Counter Styles</a>
 Japanese: japanese-informal and japanese-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="japanese-formal">
-   <b><a href="#japanese-formal">#japanese-formal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-japanese-formal" class="dfn-panel" data-for="japanese-formal" id="infopanel-for-japanese-formal" role="dialog">
+   <span id="infopaneltitle-for-japanese-formal" style="display:none">Info about the 'japanese-formal' definition.</span><b><a href="#japanese-formal">#japanese-formal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-japanese-formal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -4968,8 +4968,8 @@ Longhand East Asian Counter Styles</a>
 Japanese: japanese-informal and japanese-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="korean-hangul-formal">
-   <b><a href="#korean-hangul-formal">#korean-hangul-formal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-korean-hangul-formal" class="dfn-panel" data-for="korean-hangul-formal" id="infopanel-for-korean-hangul-formal" role="dialog">
+   <span id="infopaneltitle-for-korean-hangul-formal" style="display:none">Info about the 'korean-hangul-formal' definition.</span><b><a href="#korean-hangul-formal">#korean-hangul-formal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-korean-hangul-formal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -4977,8 +4977,8 @@ Longhand East Asian Counter Styles</a>
 Korean: korean-hangul-formal, korean-hanja-informal, and korean-hanja-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="korean-hanja-informal">
-   <b><a href="#korean-hanja-informal">#korean-hanja-informal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-korean-hanja-informal" class="dfn-panel" data-for="korean-hanja-informal" id="infopanel-for-korean-hanja-informal" role="dialog">
+   <span id="infopaneltitle-for-korean-hanja-informal" style="display:none">Info about the 'korean-hanja-informal' definition.</span><b><a href="#korean-hanja-informal">#korean-hanja-informal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-korean-hanja-informal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -4986,8 +4986,8 @@ Longhand East Asian Counter Styles</a>
 Korean: korean-hangul-formal, korean-hanja-informal, and korean-hanja-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="korean-hanja-formal">
-   <b><a href="#korean-hanja-formal">#korean-hanja-formal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-korean-hanja-formal" class="dfn-panel" data-for="korean-hanja-formal" id="infopanel-for-korean-hanja-formal" role="dialog">
+   <span id="infopaneltitle-for-korean-hanja-formal" style="display:none">Info about the 'korean-hanja-formal' definition.</span><b><a href="#korean-hanja-formal">#korean-hanja-formal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-korean-hanja-formal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -4995,8 +4995,8 @@ Longhand East Asian Counter Styles</a>
 Korean: korean-hangul-formal, korean-hanja-informal, and korean-hanja-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simp-chinese-informal">
-   <b><a href="#simp-chinese-informal">#simp-chinese-informal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simp-chinese-informal" class="dfn-panel" data-for="simp-chinese-informal" id="infopanel-for-simp-chinese-informal" role="dialog">
+   <span id="infopaneltitle-for-simp-chinese-informal" style="display:none">Info about the 'simp-chinese-informal' definition.</span><b><a href="#simp-chinese-informal">#simp-chinese-informal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simp-chinese-informal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -5004,8 +5004,8 @@ Longhand East Asian Counter Styles</a>
 Chinese: simp-chinese-informal, simp-chinese-formal, trad-chinese-informal, and trad-chinese-formal</a> <a href="#ref-for-simp-chinese-informal②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simp-chinese-formal">
-   <b><a href="#simp-chinese-formal">#simp-chinese-formal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simp-chinese-formal" class="dfn-panel" data-for="simp-chinese-formal" id="infopanel-for-simp-chinese-formal" role="dialog">
+   <span id="infopaneltitle-for-simp-chinese-formal" style="display:none">Info about the 'simp-chinese-formal' definition.</span><b><a href="#simp-chinese-formal">#simp-chinese-formal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simp-chinese-formal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -5013,8 +5013,8 @@ Longhand East Asian Counter Styles</a>
 Chinese: simp-chinese-informal, simp-chinese-formal, trad-chinese-informal, and trad-chinese-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trad-chinese-informal">
-   <b><a href="#trad-chinese-informal">#trad-chinese-informal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trad-chinese-informal" class="dfn-panel" data-for="trad-chinese-informal" id="infopanel-for-trad-chinese-informal" role="dialog">
+   <span id="infopaneltitle-for-trad-chinese-informal" style="display:none">Info about the 'trad-chinese-informal' definition.</span><b><a href="#trad-chinese-informal">#trad-chinese-informal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trad-chinese-informal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -5022,8 +5022,8 @@ Longhand East Asian Counter Styles</a>
 Chinese: simp-chinese-informal, simp-chinese-formal, trad-chinese-informal, and trad-chinese-formal</a> <a href="#ref-for-trad-chinese-informal②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trad-chinese-formal">
-   <b><a href="#trad-chinese-formal">#trad-chinese-formal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trad-chinese-formal" class="dfn-panel" data-for="trad-chinese-formal" id="infopanel-for-trad-chinese-formal" role="dialog">
+   <span id="infopaneltitle-for-trad-chinese-formal" style="display:none">Info about the 'trad-chinese-formal' definition.</span><b><a href="#trad-chinese-formal">#trad-chinese-formal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trad-chinese-formal">7.1. 
 Longhand East Asian Counter Styles</a>
@@ -5031,92 +5031,92 @@ Longhand East Asian Counter Styles</a>
 Chinese: simp-chinese-informal, simp-chinese-formal, trad-chinese-informal, and trad-chinese-formal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-style-name-ethiopic-numeric">
-   <b><a href="#valdef-counter-style-name-ethiopic-numeric">#valdef-counter-style-name-ethiopic-numeric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-style-name-ethiopic-numeric" class="dfn-panel" data-for="valdef-counter-style-name-ethiopic-numeric" id="infopanel-for-valdef-counter-style-name-ethiopic-numeric" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-style-name-ethiopic-numeric" style="display:none">Info about the 'ethiopic-numeric' definition.</span><b><a href="#valdef-counter-style-name-ethiopic-numeric">#valdef-counter-style-name-ethiopic-numeric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-style-name-ethiopic-numeric">7.2. 
 Ethiopic Numeric Counter Style: ethiopic-numeric</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csscounterstylerule">
-   <b><a href="#csscounterstylerule">#csscounterstylerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csscounterstylerule" class="dfn-panel" data-for="csscounterstylerule" id="infopanel-for-csscounterstylerule" role="dialog">
+   <span id="infopaneltitle-for-csscounterstylerule" style="display:none">Info about the 'CSSCounterStyleRule' definition.</span><b><a href="#csscounterstylerule">#csscounterstylerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csscounterstylerule">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-name">
-   <b><a href="#dom-csscounterstylerule-name">#dom-csscounterstylerule-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-name" class="dfn-panel" data-for="dom-csscounterstylerule-name" id="infopanel-for-dom-csscounterstylerule-name" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-csscounterstylerule-name">#dom-csscounterstylerule-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-name">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-system">
-   <b><a href="#dom-csscounterstylerule-system">#dom-csscounterstylerule-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-system" class="dfn-panel" data-for="dom-csscounterstylerule-system" id="infopanel-for-dom-csscounterstylerule-system" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-system" style="display:none">Info about the 'system' definition.</span><b><a href="#dom-csscounterstylerule-system">#dom-csscounterstylerule-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-system">9.2. 
 The CSSCounterStyleRule interface</a> <a href="#ref-for-dom-csscounterstylerule-system①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-symbols">
-   <b><a href="#dom-csscounterstylerule-symbols">#dom-csscounterstylerule-symbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-symbols" class="dfn-panel" data-for="dom-csscounterstylerule-symbols" id="infopanel-for-dom-csscounterstylerule-symbols" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-symbols" style="display:none">Info about the 'symbols' definition.</span><b><a href="#dom-csscounterstylerule-symbols">#dom-csscounterstylerule-symbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-symbols">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-additivesymbols">
-   <b><a href="#dom-csscounterstylerule-additivesymbols">#dom-csscounterstylerule-additivesymbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-additivesymbols" class="dfn-panel" data-for="dom-csscounterstylerule-additivesymbols" id="infopanel-for-dom-csscounterstylerule-additivesymbols" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-additivesymbols" style="display:none">Info about the 'additiveSymbols' definition.</span><b><a href="#dom-csscounterstylerule-additivesymbols">#dom-csscounterstylerule-additivesymbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-additivesymbols">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-negative">
-   <b><a href="#dom-csscounterstylerule-negative">#dom-csscounterstylerule-negative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-negative" class="dfn-panel" data-for="dom-csscounterstylerule-negative" id="infopanel-for-dom-csscounterstylerule-negative" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-negative" style="display:none">Info about the 'negative' definition.</span><b><a href="#dom-csscounterstylerule-negative">#dom-csscounterstylerule-negative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-negative">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-prefix">
-   <b><a href="#dom-csscounterstylerule-prefix">#dom-csscounterstylerule-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-prefix" class="dfn-panel" data-for="dom-csscounterstylerule-prefix" id="infopanel-for-dom-csscounterstylerule-prefix" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#dom-csscounterstylerule-prefix">#dom-csscounterstylerule-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-prefix">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-suffix">
-   <b><a href="#dom-csscounterstylerule-suffix">#dom-csscounterstylerule-suffix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-suffix" class="dfn-panel" data-for="dom-csscounterstylerule-suffix" id="infopanel-for-dom-csscounterstylerule-suffix" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-suffix" style="display:none">Info about the 'suffix' definition.</span><b><a href="#dom-csscounterstylerule-suffix">#dom-csscounterstylerule-suffix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-suffix">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-range">
-   <b><a href="#dom-csscounterstylerule-range">#dom-csscounterstylerule-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-range" class="dfn-panel" data-for="dom-csscounterstylerule-range" id="infopanel-for-dom-csscounterstylerule-range" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-range" style="display:none">Info about the 'range' definition.</span><b><a href="#dom-csscounterstylerule-range">#dom-csscounterstylerule-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-range">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-pad">
-   <b><a href="#dom-csscounterstylerule-pad">#dom-csscounterstylerule-pad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-pad" class="dfn-panel" data-for="dom-csscounterstylerule-pad" id="infopanel-for-dom-csscounterstylerule-pad" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-pad" style="display:none">Info about the 'pad' definition.</span><b><a href="#dom-csscounterstylerule-pad">#dom-csscounterstylerule-pad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-pad">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-speakas">
-   <b><a href="#dom-csscounterstylerule-speakas">#dom-csscounterstylerule-speakas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-speakas" class="dfn-panel" data-for="dom-csscounterstylerule-speakas" id="infopanel-for-dom-csscounterstylerule-speakas" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-speakas" style="display:none">Info about the 'speakAs' definition.</span><b><a href="#dom-csscounterstylerule-speakas">#dom-csscounterstylerule-speakas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-speakas">9.2. 
 The CSSCounterStyleRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csscounterstylerule-fallback">
-   <b><a href="#dom-csscounterstylerule-fallback">#dom-csscounterstylerule-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csscounterstylerule-fallback" class="dfn-panel" data-for="dom-csscounterstylerule-fallback" id="infopanel-for-dom-csscounterstylerule-fallback" role="dialog">
+   <span id="infopaneltitle-for-dom-csscounterstylerule-fallback" style="display:none">Info about the 'fallback' definition.</span><b><a href="#dom-csscounterstylerule-fallback">#dom-csscounterstylerule-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csscounterstylerule-fallback">9.2. 
 The CSSCounterStyleRule interface</a>
@@ -5124,59 +5124,115 @@ The CSSCounterStyleRule interface</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-device-adapt-1/Overview.html
@@ -2350,22 +2350,22 @@ part of a recommended UA stylesheet.</p>
      <li><a href="#valdef-user-zoom-zoom">value for user-zoom</a><span>, in § 6.8</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">5. 
 The @viewport rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">6. 
 Viewport descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-page" class="dfn-panel" data-for="term-for-at-ruledef-page" id="infopanel-for-term-for-at-ruledef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-page" style="display:none">Info about the '@page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-page">4. 
 The viewport</a> <a href="#ref-for-at-ruledef-page①">(2)</a>
@@ -2373,8 +2373,8 @@ The viewport</a> <a href="#ref-for-at-ruledef-page①">(2)</a>
 The @viewport rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">6.4. 
 The height shorthand descriptor</a>
@@ -2383,8 +2383,8 @@ and height
 properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">6.3. 
 The min-height and max-height descriptors</a>
@@ -2394,8 +2394,8 @@ and height
 properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">6.1. 
 The min-width and max-width descriptors</a> <a href="#ref-for-propdef-max-width①">(2)</a>
@@ -2407,8 +2407,8 @@ and height
 properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">6.3. 
 The min-height and max-height descriptors</a>
@@ -2418,8 +2418,8 @@ and height
 properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">6.1. 
 The min-width and max-width descriptors</a> <a href="#ref-for-propdef-min-width①">(2)</a>
@@ -2431,8 +2431,8 @@ and height
 properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">6.2. 
 The width shorthand descriptor</a>
@@ -2441,15 +2441,15 @@ and height
 properties</a> <a href="#ref-for-propdef-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">6.1. 
 The min-width and max-width descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">6.5. 
 The zoom descriptor</a> <a href="#ref-for-number-value①">(2)</a>
@@ -2459,8 +2459,8 @@ The min-zoom descriptor</a> <a href="#ref-for-number-value③">(2)</a>
 The max-zoom descriptor</a> <a href="#ref-for-number-value⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">6.1. 
 The min-width and max-width descriptors</a>
@@ -2472,36 +2472,36 @@ The min-zoom descriptor</a> <a href="#ref-for-percentage-value④">(2)</a>
 The max-zoom descriptor</a> <a href="#ref-for-percentage-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vh">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vh">https://drafts.csswg.org/css-values-4/#valdef-length-vh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vh" class="dfn-panel" data-for="term-for-valdef-length-vh" id="infopanel-for-term-for-valdef-length-vh" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vh" style="display:none">Info about the 'vh' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vh">https://drafts.csswg.org/css-values-4/#valdef-length-vh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vh">6. 
 Viewport descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vmax">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vmax">https://drafts.csswg.org/css-values-4/#valdef-length-vmax</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vmax" class="dfn-panel" data-for="term-for-valdef-length-vmax" id="infopanel-for-term-for-valdef-length-vmax" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vmax" style="display:none">Info about the 'vmax' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vmax">https://drafts.csswg.org/css-values-4/#valdef-length-vmax</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vmax">6. 
 Viewport descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vmin">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vmin">https://drafts.csswg.org/css-values-4/#valdef-length-vmin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vmin" class="dfn-panel" data-for="term-for-valdef-length-vmin" id="infopanel-for-term-for-valdef-length-vmin" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vmin" style="display:none">Info about the 'vmin' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vmin">https://drafts.csswg.org/css-values-4/#valdef-length-vmin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vmin">6. 
 Viewport descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vw">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vw">https://drafts.csswg.org/css-values-4/#valdef-length-vw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vw" class="dfn-panel" data-for="term-for-valdef-length-vw" id="infopanel-for-term-for-valdef-length-vw" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vw" style="display:none">Info about the 'vw' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vw">https://drafts.csswg.org/css-values-4/#valdef-length-vw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vw">6. 
 Viewport descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">6.2. 
 The width shorthand descriptor</a>
@@ -2509,8 +2509,8 @@ The width shorthand descriptor</a>
 The height shorthand descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">6.1. 
 The min-width and max-width descriptors</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -2526,36 +2526,36 @@ The user-zoom descriptor</a>
 The orientation descriptor</a> <a href="#ref-for-comb-one①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">4. 
 The viewport</a> <a href="#ref-for-propdef-direction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">5.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">5.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-conditional-group-rule">
-   <a href="https://drafts.csswg.org/css-conditional-3/#conditional-group-rule">https://drafts.csswg.org/css-conditional-3/#conditional-group-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-conditional-group-rule" class="dfn-panel" data-for="term-for-conditional-group-rule" id="infopanel-for-term-for-conditional-group-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-conditional-group-rule" style="display:none">Info about the 'conditional group rule' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#conditional-group-rule">https://drafts.csswg.org/css-conditional-3/#conditional-group-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conditional-group-rule">5.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">9.1. 
 Interface CSSRule</a>
@@ -2563,15 +2563,15 @@ Interface CSSRule</a>
 Interface CSSViewportRule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">9.2. 
 Interface CSSViewportRule</a> <a href="#ref-for-cssstyledeclaration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">1. 
 Introduction</a>
@@ -2579,22 +2579,22 @@ Introduction</a>
 The viewport</a> <a href="#ref-for-continuous-media②">(2)</a> <a href="#ref-for-continuous-media③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">4. 
 The viewport</a> <a href="#ref-for-paged-media①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">9.2. 
 Interface CSSViewportRule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">9.1. 
 Interface CSSRule</a>
@@ -2820,8 +2820,8 @@ behavior per default (actual viewport is initial viewport). <a class="issue-retu
    <div class="issue">min- and max- functionality can be achieved with media queries, should these be removed? <a class="issue-return" href="#issue-081c4ec9" title="Jump to section">↵</a></div>
    <div class="issue">The user-agent stylesheets recommended in the informative section don’t adequately represent current implementation behaviors.  Should there be a more explicit mechanism for switching between UA default behavior and requesting the CSS pixel? <a class="issue-return" href="#issue-7fbbd2b2" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="at-ruledef-viewport">
-   <b><a href="#at-ruledef-viewport">#at-ruledef-viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-viewport" class="dfn-panel" data-for="at-ruledef-viewport" id="infopanel-for-at-ruledef-viewport" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-viewport" style="display:none">Info about the '@viewport' definition.</span><b><a href="#at-ruledef-viewport">#at-ruledef-viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-viewport">4. 
 The viewport</a> <a href="#ref-for-at-ruledef-viewport①">(2)</a>
@@ -2868,8 +2868,8 @@ properties</a> <a href="#ref-for-at-ruledef-viewport④⓪">(2)</a>
 UA stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-viewport-length">
-   <b><a href="#typedef-viewport-length">#typedef-viewport-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-viewport-length" class="dfn-panel" data-for="typedef-viewport-length" id="infopanel-for-typedef-viewport-length" role="dialog">
+   <span id="infopaneltitle-for-typedef-viewport-length" style="display:none">Info about the '&lt;viewport-length>' definition.</span><b><a href="#typedef-viewport-length">#typedef-viewport-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-viewport-length">6.1. 
 The min-width and max-width descriptors</a> <a href="#ref-for-typedef-viewport-length①">(2)</a>
@@ -2883,8 +2883,8 @@ The height shorthand descriptor</a> <a href="#ref-for-typedef-viewport-length⑧
     <li><a href="#ref-for-typedef-viewport-length①①">Appendix A. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-viewport-length-auto">
-   <b><a href="#valdef-viewport-length-auto">#valdef-viewport-length-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-viewport-length-auto" class="dfn-panel" data-for="valdef-viewport-length-auto" id="infopanel-for-valdef-viewport-length-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-viewport-length-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-viewport-length-auto">#valdef-viewport-length-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-viewport-length-auto">7.1. 
 Definitions</a>
@@ -2899,14 +2899,14 @@ descriptors</a> <a href="#ref-for-valdef-viewport-length-auto③">(2)</a>
 Large screen UA styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-viewport-zoom">
-   <b><a href="#descdef-viewport-zoom">#descdef-viewport-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-viewport-zoom" class="dfn-panel" data-for="descdef-viewport-zoom" id="infopanel-for-descdef-viewport-zoom" role="dialog">
+   <span id="infopaneltitle-for-descdef-viewport-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#descdef-viewport-zoom">#descdef-viewport-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-viewport-zoom">Appendix A. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-zoom-auto">
-   <b><a href="#valdef-zoom-auto">#valdef-zoom-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-zoom-auto" class="dfn-panel" data-for="valdef-zoom-auto" id="infopanel-for-valdef-zoom-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-zoom-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-zoom-auto">#valdef-zoom-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-zoom-auto">6.5. 
 The zoom descriptor</a>
@@ -2928,27 +2928,27 @@ properties</a>
 Handling auto for zoom</a> <a href="#ref-for-valdef-zoom-auto①⑥">(2)</a> <a href="#ref-for-valdef-zoom-auto①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-zoom-zoom">
-   <b><a href="#valdef-user-zoom-zoom">#valdef-user-zoom-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-zoom-zoom" class="dfn-panel" data-for="valdef-user-zoom-zoom" id="infopanel-for-valdef-user-zoom-zoom" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-zoom-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#valdef-user-zoom-zoom">#valdef-user-zoom-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-zoom-zoom"> The user-scalable property</a> <a href="#ref-for-valdef-user-zoom-zoom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-zoom-fixed">
-   <b><a href="#valdef-user-zoom-fixed">#valdef-user-zoom-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-zoom-fixed" class="dfn-panel" data-for="valdef-user-zoom-fixed" id="infopanel-for-valdef-user-zoom-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-zoom-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-user-zoom-fixed">#valdef-user-zoom-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-zoom-fixed"> The user-scalable property</a> <a href="#ref-for-valdef-user-zoom-fixed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssviewportrule">
-   <b><a href="#cssviewportrule">#cssviewportrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssviewportrule" class="dfn-panel" data-for="cssviewportrule" id="infopanel-for-cssviewportrule" role="dialog">
+   <span id="infopaneltitle-for-cssviewportrule" style="display:none">Info about the 'CSSViewportRule' definition.</span><b><a href="#cssviewportrule">#cssviewportrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssviewportrule">9.2. 
 Interface CSSViewportRule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssviewportrule-style">
-   <b><a href="#dom-cssviewportrule-style">#dom-cssviewportrule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssviewportrule-style" class="dfn-panel" data-for="dom-cssviewportrule-style" id="infopanel-for-dom-cssviewportrule-style" role="dialog">
+   <span id="infopaneltitle-for-dom-cssviewportrule-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-cssviewportrule-style">#dom-cssviewportrule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssviewportrule-style">9.2. 
 Interface CSSViewportRule</a>
@@ -2956,59 +2956,115 @@ Interface CSSViewportRule</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-display-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-display-3/Overview.html
@@ -2419,41 +2419,41 @@ particularly handling of layout-internal types.
    <li><a href="#text-nodes">text node</a><span>, in § 1</span>
    <li><a href="#text-run">text run</a><span>, in § 1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-box-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#box-box-edge">https://drafts.csswg.org/css-box-4/#box-box-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-box-edge" class="dfn-panel" data-for="term-for-box-box-edge" id="infopanel-for-term-for-box-box-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-box-box-edge" style="display:none">Info about the 'box edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#box-box-edge">https://drafts.csswg.org/css-box-4/#box-box-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-box-edge"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation" class="dfn-panel" data-for="term-for-fragmentation" id="infopanel-for-term-for-fragmentation" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation" style="display:none">Info about the 'fragmentation' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">1. 
 Introduction</a> <a href="#ref-for-fragmentation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">1. 
 Introduction</a>
@@ -2462,28 +2462,28 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-computed-value②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">2.5. 
 Box Generation: the none and contents keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-property">https://drafts.csswg.org/css-cascade-5/#inherited-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-property" class="dfn-panel" data-for="term-for-inherited-property" id="infopanel-for-term-for-inherited-property" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-property" style="display:none">Info about the 'inherited property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-property">https://drafts.csswg.org/css-cascade-5/#inherited-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-property">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-grid-container①">(2)</a>
@@ -2492,83 +2492,83 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-grid-container③"> Appendix A: Glossary</a> <a href="#ref-for-grid-container④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-formatting-context">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-formatting-context">https://drafts.csswg.org/css-grid-2/#grid-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-formatting-context" class="dfn-panel" data-for="term-for-grid-formatting-context" id="infopanel-for-term-for-grid-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-formatting-context" style="display:none">Info about the 'grid formatting context' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-formatting-context">https://drafts.csswg.org/css-grid-2/#grid-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-formatting-context">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a> <a href="#ref-for-grid-formatting-context①">(2)</a>
     <li><a href="#ref-for-grid-formatting-context②"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subgrid">
-   <a href="https://drafts.csswg.org/css-grid-2/#subgrid">https://drafts.csswg.org/css-grid-2/#subgrid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subgrid" class="dfn-panel" data-for="term-for-subgrid" id="infopanel-for-term-for-subgrid" role="menu">
+   <span id="infopaneltitle-for-term-for-subgrid" style="display:none">Info about the 'subgrid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#subgrid">https://drafts.csswg.org/css-grid-2/#subgrid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subgrid"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-template-rows-subgrid">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-subgrid">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-subgrid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-template-rows-subgrid" class="dfn-panel" data-for="term-for-valdef-grid-template-rows-subgrid" id="infopanel-for-term-for-valdef-grid-template-rows-subgrid" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-template-rows-subgrid" style="display:none">Info about the 'subgrid (for grid-template-rows)' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-subgrid">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-subgrid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-rows-subgrid">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions"> Appendix A: Glossary</a> <a href="#ref-for-natural-dimensions①">(2)</a> <a href="#ref-for-natural-dimensions②">(3)</a> <a href="#ref-for-natural-dimensions③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box"> Appendix A: Glossary</a> <a href="#ref-for-root-inline-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#overflow">https://drafts.csswg.org/css-overflow-3/#overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow" class="dfn-panel" data-for="term-for-overflow" id="infopanel-for-term-for-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#overflow">https://drafts.csswg.org/css-overflow-3/#overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container"> Appendix A: Glossary</a> <a href="#ref-for-scroll-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-position">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-position" class="dfn-panel" data-for="term-for-absolute-position" id="infopanel-for-term-for-absolute-position" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-position" style="display:none">Info about the 'absolute position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position"> Appendix A: Glossary</a> <a href="#ref-for-absolute-position①">(2)</a>
     <li><a href="#ref-for-absolute-position②"> Changes</a> <a href="#ref-for-absolute-position③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-position">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-position" class="dfn-panel" data-for="term-for-absolute-position" id="infopanel-for-term-for-absolute-position①" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-position①" style="display:none">Info about the 'absolutely position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position"> Appendix A: Glossary</a> <a href="#ref-for-absolute-position①">(2)</a>
     <li><a href="#ref-for-absolute-position②"> Changes</a> <a href="#ref-for-absolute-position③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
     <li><a href="#ref-for-propdef-position①"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">2.5. 
 Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-selectordef-after①"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">2.5. 
 Box Generation: the none and contents keywords</a>
@@ -2577,8 +2577,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-selectordef-before②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">Unnumbered Section</a>
     <li><a href="#ref-for-selectordef-first-letter①">3. 
@@ -2586,14 +2586,14 @@ Run-In Layout</a>
     <li><a href="#ref-for-selectordef-first-letter②"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-selectordef-first-letter③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">2. 
 Box Layout Modes: the display property</a>
@@ -2603,15 +2603,15 @@ Generating Marker Boxes: the list-item keyword</a>
 Run-In Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-formatted-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-formatted-line" class="dfn-panel" data-for="term-for-first-formatted-line" id="infopanel-for-term-for-first-formatted-line" role="menu">
+   <span id="infopaneltitle-for-term-for-first-formatted-line" style="display:none">Info about the 'first formatted line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line">3. 
 Run-In Layout</a> <a href="#ref-for-first-formatted-line①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-grid-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-grid-box">https://drafts.csswg.org/css-tables-3/#table-grid-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-grid-box" class="dfn-panel" data-for="term-for-table-grid-box" id="infopanel-for-term-for-table-grid-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-grid-box" style="display:none">Info about the 'table grid box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-grid-box">https://drafts.csswg.org/css-tables-3/#table-grid-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-grid-box">1. 
 Introduction</a>
@@ -2622,8 +2622,8 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-table-grid-box④"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">1. 
 Introduction</a>
@@ -2634,65 +2634,65 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-table-wrapper-box④"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">3. 
 Run-In Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-comb-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a> <a href="#ref-for-comb-one①⑤">(16)</a> <a href="#ref-for-comb-one①⑥">(17)</a> <a href="#ref-for-comb-one①⑦">(18)</a> <a href="#ref-for-comb-one①⑧">(19)</a> <a href="#ref-for-comb-one①⑨">(20)</a> <a href="#ref-for-comb-one②⓪">(21)</a> <a href="#ref-for-comb-one②①">(22)</a> <a href="#ref-for-comb-one②②">(23)</a> <a href="#ref-for-comb-one②③">(24)</a> <a href="#ref-for-comb-one②④">(25)</a> <a href="#ref-for-comb-one②⑤">(26)</a> <a href="#ref-for-comb-one②⑥">(27)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2. 
 Box Layout Modes: the display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
     <li><a href="#ref-for-propdef-float①"> Appendix A: Glossary</a> <a href="#ref-for-propdef-float②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style">
-   <a href="https://drafts.csswg.org/css2/#propdef-list-style">https://drafts.csswg.org/css2/#propdef-list-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style" class="dfn-panel" data-for="term-for-propdef-list-style" id="infopanel-for-term-for-propdef-list-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style" style="display:none">Info about the 'list-style' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-list-style">https://drafts.csswg.org/css2/#propdef-list-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">2.3. 
 Generating Marker Boxes: the list-item keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
@@ -2700,15 +2700,15 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-propdef-overflow②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">1. 
 Introduction</a> <a href="#ref-for-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-flex-container①">(2)</a>
@@ -2717,28 +2717,28 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-flex-container③"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-formatting-context">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context">https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-formatting-context" class="dfn-panel" data-for="term-for-flex-formatting-context" id="infopanel-for-term-for-flex-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-formatting-context" style="display:none">Info about the 'flex formatting context' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context">https://drafts.csswg.org/css-flexbox-1/#flex-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-formatting-context">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
     <li><a href="#ref-for-flex-formatting-context①"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-layout">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-layout">https://drafts.csswg.org/css-flexbox-1/#flex-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-layout" class="dfn-panel" data-for="term-for-flex-layout" id="infopanel-for-term-for-flex-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-layout" style="display:none">Info about the 'flex layout' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-layout">https://drafts.csswg.org/css-flexbox-1/#flex-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-layout"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-container-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-container-box" class="dfn-panel" data-for="term-for-ruby-base-container-box" id="infopanel-for-term-for-ruby-base-container-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-container-box" style="display:none">Info about the 'ruby base container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-container-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-container-box"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-container">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-container" class="dfn-panel" data-for="term-for-ruby-container" id="infopanel-for-term-for-ruby-container" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-container" style="display:none">Info about the 'ruby container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-container">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-ruby-container①">(2)</a>
@@ -2749,8 +2749,8 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-ruby-container④"> Appendix A: Glossary</a> <a href="#ref-for-ruby-container⑤">(2)</a> <a href="#ref-for-ruby-container⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-formatting-context">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-formatting-context">https://drafts.csswg.org/css-ruby-1/#ruby-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-formatting-context" class="dfn-panel" data-for="term-for-ruby-formatting-context" id="infopanel-for-term-for-ruby-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-formatting-context" style="display:none">Info about the 'ruby formatting context' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-formatting-context">https://drafts.csswg.org/css-ruby-1/#ruby-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-formatting-context">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
@@ -2759,265 +2759,265 @@ Layout-Internal Display Types: the table-* and ruby-* keywords</a>
     <li><a href="#ref-for-ruby-formatting-context②"> Appendix A: Glossary</a> <a href="#ref-for-ruby-formatting-context③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audio">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audio" class="dfn-panel" data-for="term-for-audio" id="infopanel-for-term-for-audio" role="menu">
+   <span id="infopaneltitle-for-term-for-audio" style="display:none">Info about the 'audio' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-br-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-br-element" class="dfn-panel" data-for="term-for-the-br-element" id="infopanel-for-term-for-the-br-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-br-element" style="display:none">Info about the 'br' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-br-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-button-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-button-element" class="dfn-panel" data-for="term-for-the-button-element" id="infopanel-for-term-for-the-button-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-button-element" style="display:none">Info about the 'button' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-button-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-details-element">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-details-element" class="dfn-panel" data-for="term-for-the-details-element" id="infopanel-for-term-for-the-details-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-details-element" style="display:none">Info about the 'details' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-details-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-embed-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-embed-element" class="dfn-panel" data-for="term-for-the-embed-element" id="infopanel-for-term-for-the-embed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-embed-element" style="display:none">Info about the 'embed' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-embed-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-fieldset-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-fieldset-element" class="dfn-panel" data-for="term-for-the-fieldset-element" id="infopanel-for-term-for-the-fieldset-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-fieldset-element" style="display:none">Info about the 'fieldset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-fieldset-element">2.5. 
 Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-the-fieldset-element①">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame" class="dfn-panel" data-for="term-for-frame" id="infopanel-for-term-for-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-frame" style="display:none">Info about the 'frame' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frameset">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frameset">https://html.spec.whatwg.org/multipage/obsolete.html#frameset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frameset" class="dfn-panel" data-for="term-for-frameset" id="infopanel-for-term-for-frameset" role="menu">
+   <span id="infopaneltitle-for-term-for-frameset" style="display:none">Info about the 'frameset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frameset">https://html.spec.whatwg.org/multipage/obsolete.html#frameset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frameset">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element"> Appendix A: Glossary</a>
     <li><a href="#ref-for-the-img-element①"> Appendix B: Effects of display: contents on Unusual Elements</a>
     <li><a href="#ref-for-the-img-element②">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element"> Appendix B: Effects of display: contents on Unusual Elements</a>
     <li><a href="#ref-for-the-input-element①">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-legend-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-legend-element" class="dfn-panel" data-for="term-for-the-legend-element" id="infopanel-for-term-for-the-legend-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-legend-element" style="display:none">Info about the 'legend' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-legend-element">2.5. 
 Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-the-legend-element①">HTML Elements</a> <a href="#ref-for-the-legend-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-meter-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-meter-element" class="dfn-panel" data-for="term-for-the-meter-element" id="infopanel-for-term-for-the-meter-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-meter-element" style="display:none">Info about the 'meter' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-meter-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-progress-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-progress-element" class="dfn-panel" data-for="term-for-the-progress-element" id="infopanel-for-term-for-the-progress-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-progress-element" style="display:none">Info about the 'progress' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-progress-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rendered-legend">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#rendered-legend">https://html.spec.whatwg.org/multipage/rendering.html#rendered-legend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rendered-legend" class="dfn-panel" data-for="term-for-rendered-legend" id="infopanel-for-term-for-rendered-legend" role="menu">
+   <span id="infopaneltitle-for-term-for-rendered-legend" style="display:none">Info about the 'rendered legend' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#rendered-legend">https://html.spec.whatwg.org/multipage/rendering.html#rendered-legend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendered-legend">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-select-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-select-element" class="dfn-panel" data-for="term-for-the-select-element" id="infopanel-for-term-for-the-select-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-select-element" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-select-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-src">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-src" class="dfn-panel" data-for="term-for-attr-img-src" id="infopanel-for-term-for-attr-img-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-src" style="display:none">Info about the 'src' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-src"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-summary-element">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-summary-element" class="dfn-panel" data-for="term-for-the-summary-element" id="infopanel-for-term-for-the-summary-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-summary-element" style="display:none">Info about the 'summary' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-summary-element">2.5. 
 Box Generation: the none and contents keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-textarea-element" class="dfn-panel" data-for="term-for-the-textarea-element" id="infopanel-for-term-for-the-textarea-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-textarea-element" style="display:none">Info about the 'textarea' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-textarea-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-wbr-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-wbr-element" class="dfn-panel" data-for="term-for-the-wbr-element" id="infopanel-for-term-for-the-wbr-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-wbr-element" style="display:none">Info about the 'wbr' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-wbr-element">HTML Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-language">
-   <a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-language" class="dfn-panel" data-for="term-for-document-language" id="infopanel-for-term-for-document-language" role="menu">
+   <span id="infopaneltitle-for-term-for-document-language" style="display:none">Info about the 'document language' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-language">2. 
 Box Layout Modes: the display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-element" class="dfn-panel" data-for="term-for-container-element" id="infopanel-for-term-for-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-container-element" style="display:none">Info about the 'container element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-element">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermNonRenderedElement">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermNonRenderedElement">https://svgwg.org/svg2-draft/render.html#TermNonRenderedElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermNonRenderedElement" class="dfn-panel" data-for="term-for-TermNonRenderedElement" id="infopanel-for-term-for-TermNonRenderedElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermNonRenderedElement" style="display:none">Info about the 'non-rendered element' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermNonRenderedElement">https://svgwg.org/svg2-draft/render.html#TermNonRenderedElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermNonRenderedElement">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPresentationAttribute">
-   <a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPresentationAttribute" class="dfn-panel" data-for="term-for-TermPresentationAttribute" id="infopanel-for-term-for-TermPresentationAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPresentationAttribute" style="display:none">Info about the 'presentation attributes' external reference.</span><a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPresentationAttribute">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermRenderableElement">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermRenderableElement">https://svgwg.org/svg2-draft/render.html#TermRenderableElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermRenderableElement" class="dfn-panel" data-for="term-for-TermRenderableElement" id="infopanel-for-term-for-TermRenderableElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermRenderableElement" style="display:none">Info about the 'renderable element' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermRenderableElement">https://svgwg.org/svg2-draft/render.html#TermRenderableElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermRenderableElement">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermRenderedElement">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermRenderedElement">https://svgwg.org/svg2-draft/render.html#TermRenderedElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermRenderedElement" class="dfn-panel" data-for="term-for-TermRenderedElement" id="infopanel-for-term-for-TermRenderedElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermRenderedElement" style="display:none">Info about the 'rendered element' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermRenderedElement">https://svgwg.org/svg2-draft/render.html#TermRenderedElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermRenderedElement">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">SVG Elements</a> <a href="#ref-for-elementdef-svg①">(2)</a> <a href="#ref-for-elementdef-svg②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-symbol">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-symbol" class="dfn-panel" data-for="term-for-elementdef-symbol" id="infopanel-for-term-for-elementdef-symbol" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-symbol" style="display:none">Info about the 'symbol' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-symbol">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-text">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-text" class="dfn-panel" data-for="term-for-elementdef-text" id="infopanel-for-term-for-elementdef-text" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-text" style="display:none">Info about the 'text' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-text">SVG Elements</a> <a href="#ref-for-elementdef-text①">(2)</a> <a href="#ref-for-elementdef-text②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermTextContentChildElement">
-   <a href="https://svgwg.org/svg2-draft/text.html#TermTextContentChildElement">https://svgwg.org/svg2-draft/text.html#TermTextContentChildElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermTextContentChildElement" class="dfn-panel" data-for="term-for-TermTextContentChildElement" id="infopanel-for-term-for-TermTextContentChildElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermTextContentChildElement" style="display:none">Info about the 'text content child element' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TermTextContentChildElement">https://svgwg.org/svg2-draft/text.html#TermTextContentChildElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermTextContentChildElement">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-textPath">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-textPath" class="dfn-panel" data-for="term-for-elementdef-textPath" id="infopanel-for-term-for-elementdef-textPath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-textPath" style="display:none">Info about the 'textpath' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-textPath">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-tspan">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-tspan">https://svgwg.org/svg2-draft/text.html#elementdef-tspan</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-tspan" class="dfn-panel" data-for="term-for-elementdef-tspan" id="infopanel-for-term-for-elementdef-tspan" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-tspan" style="display:none">Info about the 'tspan' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-tspan">https://svgwg.org/svg2-draft/text.html#elementdef-tspan</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-tspan">SVG Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-use">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-use" class="dfn-panel" data-for="term-for-elementdef-use" id="infopanel-for-term-for-elementdef-use" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-use" style="display:none">Info about the 'use' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-use">SVG Elements</a> <a href="#ref-for-elementdef-use①">(2)</a>
    </ul>
@@ -3307,8 +3307,8 @@ Introduction</a>
       <td>see prose in a variety of specs
    </table>
   </div>
-  <aside class="dfn-panel" data-for="element-tree">
-   <b><a href="#element-tree">#element-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-tree" class="dfn-panel" data-for="element-tree" id="infopanel-for-element-tree" role="dialog">
+   <span id="infopaneltitle-for-element-tree" style="display:none">Info about the 'tree' definition.</span><b><a href="#element-tree">#element-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-tree">1. 
 Introduction</a>
@@ -3317,8 +3317,8 @@ Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-element-tree②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elements">
-   <b><a href="#elements">#elements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elements" class="dfn-panel" data-for="elements" id="infopanel-for-elements" role="dialog">
+   <span id="infopaneltitle-for-elements" style="display:none">Info about the 'elements' definition.</span><b><a href="#elements">#elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elements">1. 
 Introduction</a> <a href="#ref-for-elements①">(2)</a> <a href="#ref-for-elements②">(3)</a> <a href="#ref-for-elements③">(4)</a> <a href="#ref-for-elements④">(5)</a>
@@ -3327,8 +3327,8 @@ Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-elements⑥"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-nodes">
-   <b><a href="#text-nodes">#text-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-nodes" class="dfn-panel" data-for="text-nodes" id="infopanel-for-text-nodes" role="dialog">
+   <span id="infopaneltitle-for-text-nodes" style="display:none">Info about the 'text nodes' definition.</span><b><a href="#text-nodes">#text-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">1. 
 Introduction</a> <a href="#ref-for-text-nodes①">(2)</a> <a href="#ref-for-text-nodes②">(3)</a> <a href="#ref-for-text-nodes③">(4)</a>
@@ -3337,8 +3337,8 @@ Box Generation: the none and contents keywords</a>
     <li><a href="#ref-for-text-nodes⑤"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-tree">
-   <b><a href="#box-tree">#box-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-tree" class="dfn-panel" data-for="box-tree" id="infopanel-for-box-tree" role="dialog">
+   <span id="infopaneltitle-for-box-tree" style="display:none">Info about the 'box tree' definition.</span><b><a href="#box-tree">#box-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">1. 
 Introduction</a> <a href="#ref-for-box-tree①">(2)</a> <a href="#ref-for-box-tree②">(3)</a> <a href="#ref-for-box-tree③">(4)</a> <a href="#ref-for-box-tree④">(5)</a> <a href="#ref-for-box-tree⑤">(6)</a> <a href="#ref-for-box-tree⑥">(7)</a>
@@ -3347,8 +3347,8 @@ Box Layout Modes: the display property</a> <a href="#ref-for-box-tree⑧">(2)</a
     <li><a href="#ref-for-box-tree⑨"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box">
-   <b><a href="#box">#box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box" class="dfn-panel" data-for="box" id="infopanel-for-box" role="dialog">
+   <span id="infopaneltitle-for-box" style="display:none">Info about the 'box' definition.</span><b><a href="#box">#box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">1. 
 Introduction</a> <a href="#ref-for-box①">(2)</a> <a href="#ref-for-box②">(3)</a> <a href="#ref-for-box③">(4)</a> <a href="#ref-for-box④">(5)</a> <a href="#ref-for-box⑤">(6)</a> <a href="#ref-for-box⑥">(7)</a> <a href="#ref-for-box⑦">(8)</a> <a href="#ref-for-box⑧">(9)</a>
@@ -3357,8 +3357,8 @@ Box Generation: the none and contents keywords</a> <a href="#ref-for-box①⓪">
     <li><a href="#ref-for-box①①"> Appendix A: Glossary</a> <a href="#ref-for-box①②">(2)</a> <a href="#ref-for-box①③">(3)</a> <a href="#ref-for-box①④">(4)</a> <a href="#ref-for-box①⑤">(5)</a> <a href="#ref-for-box①⑥">(6)</a> <a href="#ref-for-box①⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-run">
-   <b><a href="#text-run">#text-run</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-run" class="dfn-panel" data-for="text-run" id="infopanel-for-text-run" role="dialog">
+   <span id="infopaneltitle-for-text-run" style="display:none">Info about the 'text run' definition.</span><b><a href="#text-run">#text-run</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">1. 
 Introduction</a> <a href="#ref-for-text-run①">(2)</a> <a href="#ref-for-text-run②">(3)</a> <a href="#ref-for-text-run③">(4)</a> <a href="#ref-for-text-run④">(5)</a>
@@ -3370,22 +3370,22 @@ Box Generation: the none and contents keywords</a> <a href="#ref-for-text-run⑦
     <li><a href="#ref-for-text-run①⓪"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-parent-box">
-   <b><a href="#css-parent-box">#css-parent-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-parent-box" class="dfn-panel" data-for="css-parent-box" id="infopanel-for-css-parent-box" role="dialog">
+   <span id="infopaneltitle-for-css-parent-box" style="display:none">Info about the 'parent box' definition.</span><b><a href="#css-parent-box">#css-parent-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parent-box"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anonymous">
-   <b><a href="#anonymous">#anonymous</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anonymous" class="dfn-panel" data-for="anonymous" id="infopanel-for-anonymous" role="dialog">
+   <span id="infopaneltitle-for-anonymous" style="display:none">Info about the 'anonymous box' definition.</span><b><a href="#anonymous">#anonymous</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">1. 
 Introduction</a> <a href="#ref-for-anonymous①">(2)</a> <a href="#ref-for-anonymous②">(3)</a>
     <li><a href="#ref-for-anonymous③"> Appendix C: Box Construction Guidelines for Spec Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-display">
-   <b><a href="#propdef-display">#propdef-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-display" class="dfn-panel" data-for="propdef-display" id="infopanel-for-propdef-display" role="dialog">
+   <span id="infopaneltitle-for-propdef-display" style="display:none">Info about the 'display' definition.</span><b><a href="#propdef-display">#propdef-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display③">1. 
 Introduction</a> <a href="#ref-for-propdef-display④">(2)</a> <a href="#ref-for-propdef-display⑤">(3)</a> <a href="#ref-for-propdef-display⑥">(4)</a> <a href="#ref-for-propdef-display⑦">(5)</a> <a href="#ref-for-propdef-display⑧">(6)</a>
@@ -3409,8 +3409,8 @@ Automatic Box Type Transformations</a> <a href="#ref-for-propdef-display②⑨">
     <li><a href="#ref-for-propdef-display⑤②"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-propdef-display⑤③">(2)</a> <a href="#ref-for-propdef-display⑤④">(3)</a> <a href="#ref-for-propdef-display⑤⑤">(4)</a> <a href="#ref-for-propdef-display⑤⑥">(5)</a> <a href="#ref-for-propdef-display⑤⑦">(6)</a> <a href="#ref-for-propdef-display⑤⑧">(7)</a> <a href="#ref-for-propdef-display⑤⑨">(8)</a> <a href="#ref-for-propdef-display⑥⓪">(9)</a> <a href="#ref-for-propdef-display⑥①">(10)</a> <a href="#ref-for-propdef-display⑥②">(11)</a> <a href="#ref-for-propdef-display⑥③">(12)</a> <a href="#ref-for-propdef-display⑥④">(13)</a> <a href="#ref-for-propdef-display⑥⑤">(14)</a> <a href="#ref-for-propdef-display⑥⑥">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="display-type">
-   <b><a href="#display-type">#display-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-display-type" class="dfn-panel" data-for="display-type" id="infopanel-for-display-type" role="dialog">
+   <span id="infopaneltitle-for-display-type" style="display:none">Info about the 'display type' definition.</span><b><a href="#display-type">#display-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">1. 
 Introduction</a>
@@ -3421,8 +3421,8 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-display-type③"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inner-display-type">
-   <b><a href="#inner-display-type">#inner-display-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inner-display-type" class="dfn-panel" data-for="inner-display-type" id="infopanel-for-inner-display-type" role="dialog">
+   <span id="infopaneltitle-for-inner-display-type" style="display:none">Info about the 'inner display type' definition.</span><b><a href="#inner-display-type">#inner-display-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">2.1. 
 Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
@@ -3442,8 +3442,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-inner-display-type①⑦"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-inner-display-type①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-display-type">
-   <b><a href="#outer-display-type">#outer-display-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-display-type" class="dfn-panel" data-for="outer-display-type" id="infopanel-for-outer-display-type" role="dialog">
+   <span id="infopaneltitle-for-outer-display-type" style="display:none">Info about the 'outer display type' definition.</span><b><a href="#outer-display-type">#outer-display-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-display-type">2.1. 
 Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
@@ -3459,8 +3459,8 @@ Box Generation: the none and contents keywords</a>
 Automatic Box Type Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-outside">
-   <b><a href="#typedef-display-outside">#typedef-display-outside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-outside" class="dfn-panel" data-for="typedef-display-outside" id="infopanel-for-typedef-display-outside" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-outside" style="display:none">Info about the '&lt;display-outside>' definition.</span><b><a href="#typedef-display-outside">#typedef-display-outside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-outside">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-typedef-display-outside①">(2)</a>
@@ -3470,8 +3470,8 @@ Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a> 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-inside">
-   <b><a href="#typedef-display-inside">#typedef-display-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-inside" class="dfn-panel" data-for="typedef-display-inside" id="infopanel-for-typedef-display-inside" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-inside" style="display:none">Info about the '&lt;display-inside>' definition.</span><b><a href="#typedef-display-inside">#typedef-display-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-inside">2. 
 Box Layout Modes: the display property</a>
@@ -3481,15 +3481,15 @@ Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a> <a href="#ref-for-typedef-display-inside③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-listitem">
-   <b><a href="#typedef-display-listitem">#typedef-display-listitem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-listitem" class="dfn-panel" data-for="typedef-display-listitem" id="infopanel-for-typedef-display-listitem" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-listitem" style="display:none">Info about the '&lt;display-listitem>' definition.</span><b><a href="#typedef-display-listitem">#typedef-display-listitem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-listitem">2. 
 Box Layout Modes: the display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-internal">
-   <b><a href="#typedef-display-internal">#typedef-display-internal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-internal" class="dfn-panel" data-for="typedef-display-internal" id="infopanel-for-typedef-display-internal" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-internal" style="display:none">Info about the '&lt;display-internal>' definition.</span><b><a href="#typedef-display-internal">#typedef-display-internal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-internal">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-typedef-display-internal①">(2)</a>
@@ -3497,8 +3497,8 @@ Box Layout Modes: the display property</a> <a href="#ref-for-typedef-display-int
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-box">
-   <b><a href="#typedef-display-box">#typedef-display-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-box" class="dfn-panel" data-for="typedef-display-box" id="infopanel-for-typedef-display-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-box" style="display:none">Info about the '&lt;display-box>' definition.</span><b><a href="#typedef-display-box">#typedef-display-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-box">2. 
 Box Layout Modes: the display property</a>
@@ -3506,8 +3506,8 @@ Box Layout Modes: the display property</a>
 Box Generation: the none and contents keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-display-legacy">
-   <b><a href="#typedef-display-legacy">#typedef-display-legacy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-display-legacy" class="dfn-panel" data-for="typedef-display-legacy" id="infopanel-for-typedef-display-legacy" role="dialog">
+   <span id="infopaneltitle-for-typedef-display-legacy" style="display:none">Info about the '&lt;display-legacy>' definition.</span><b><a href="#typedef-display-legacy">#typedef-display-legacy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-display-legacy">2. 
 Box Layout Modes: the display property</a>
@@ -3515,16 +3515,16 @@ Box Layout Modes: the display property</a>
 Precomposed Inline-level Display Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-block">
-   <b><a href="#inline-block">#inline-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-block" class="dfn-panel" data-for="inline-block" id="infopanel-for-inline-block" role="dialog">
+   <span id="infopaneltitle-for-inline-block" style="display:none">Info about the 'inline block' definition.</span><b><a href="#inline-block">#inline-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-block">2.7. 
 Automatic Box Type Transformations</a>
     <li><a href="#ref-for-inline-block①"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-block">
-   <b><a href="#valdef-display-block">#valdef-display-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-block" class="dfn-panel" data-for="valdef-display-block" id="infopanel-for-valdef-display-block" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-block" style="display:none">Info about the 'block' definition.</span><b><a href="#valdef-display-block">#valdef-display-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">2. 
 Box Layout Modes: the display property</a>
@@ -3538,14 +3538,14 @@ Generating Marker Boxes: the list-item keyword</a> <a href="#ref-for-valdef-disp
 Automatic Box Type Transformations</a> <a href="#ref-for-valdef-display-block⑥">(2)</a> <a href="#ref-for-valdef-display-block⑦">(3)</a> <a href="#ref-for-valdef-display-block⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-level-box">
-   <b><a href="#block-level-box">#block-level-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-level-box" class="dfn-panel" data-for="block-level-box" id="infopanel-for-block-level-box" role="dialog">
+   <span id="infopaneltitle-for-block-level-box" style="display:none">Info about the 'block-level' definition.</span><b><a href="#block-level-box">#block-level-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box"> Appendix A: Glossary</a> <a href="#ref-for-block-level-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline">
-   <b><a href="#valdef-display-inline">#valdef-display-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline" class="dfn-panel" data-for="valdef-display-inline" id="infopanel-for-valdef-display-inline" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#valdef-display-inline">#valdef-display-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">2. 
 Box Layout Modes: the display property</a>
@@ -3559,8 +3559,8 @@ Generating Marker Boxes: the list-item keyword</a>
 Automatic Box Type Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-level-box">
-   <b><a href="#inline-level-box">#inline-level-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-level-box" class="dfn-panel" data-for="inline-level-box" id="infopanel-for-inline-level-box" role="dialog">
+   <span id="infopaneltitle-for-inline-level-box" style="display:none">Info about the 'inline-level' definition.</span><b><a href="#inline-level-box">#inline-level-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level-box">2.1. 
 Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
@@ -3569,8 +3569,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-inline-level-box②"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-run-in">
-   <b><a href="#valdef-display-run-in">#valdef-display-run-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-run-in" class="dfn-panel" data-for="valdef-display-run-in" id="infopanel-for-valdef-display-run-in" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-run-in" style="display:none">Info about the 'run-in' definition.</span><b><a href="#valdef-display-run-in">#valdef-display-run-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-run-in">1. 
 Introduction</a>
@@ -3585,8 +3585,8 @@ Generating Marker Boxes: the list-item keyword</a>
     <li><a href="#ref-for-valdef-display-run-in⑤"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-flow">
-   <b><a href="#valdef-display-flow">#valdef-display-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-flow" class="dfn-panel" data-for="valdef-display-flow" id="infopanel-for-valdef-display-flow" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-flow" style="display:none">Info about the 'flow' definition.</span><b><a href="#valdef-display-flow">#valdef-display-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow">2.1. 
 Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
@@ -3604,8 +3604,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-valdef-display-flow⑨"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flow-layout">
-   <b><a href="#flow-layout">#flow-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flow-layout" class="dfn-panel" data-for="flow-layout" id="infopanel-for-flow-layout" role="dialog">
+   <span id="infopaneltitle-for-flow-layout" style="display:none">Info about the 'flow layout' definition.</span><b><a href="#flow-layout">#flow-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">2. 
 Box Layout Modes: the display property</a>
@@ -3618,8 +3618,8 @@ Generating Marker Boxes: the list-item keyword</a>
     <li><a href="#ref-for-flow-layout⑥"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-flow-root">
-   <b><a href="#valdef-display-flow-root">#valdef-display-flow-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-flow-root" class="dfn-panel" data-for="valdef-display-flow-root" id="infopanel-for-valdef-display-flow-root" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-flow-root" style="display:none">Info about the 'flow-root' definition.</span><b><a href="#valdef-display-flow-root">#valdef-display-flow-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow-root">2. 
 Box Layout Modes: the display property</a>
@@ -3634,8 +3634,8 @@ Automatic Box Type Transformations</a> <a href="#ref-for-valdef-display-flow-roo
     <li><a href="#ref-for-valdef-display-flow-root⑧"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-valdef-display-flow-root⑨">(2)</a> <a href="#ref-for-valdef-display-flow-root①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-table">
-   <b><a href="#valdef-display-table">#valdef-display-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-table" class="dfn-panel" data-for="valdef-display-table" id="infopanel-for-valdef-display-table" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-table" style="display:none">Info about the 'table' definition.</span><b><a href="#valdef-display-table">#valdef-display-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">2. 
 Box Layout Modes: the display property</a>
@@ -3646,8 +3646,8 @@ Layout-Internal Display Types: the table-* and ruby-* keywords</a>
     <li><a href="#ref-for-valdef-display-table③"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-flex">
-   <b><a href="#valdef-display-flex">#valdef-display-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-flex" class="dfn-panel" data-for="valdef-display-flex" id="infopanel-for-valdef-display-flex" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-flex" style="display:none">Info about the 'flex' definition.</span><b><a href="#valdef-display-flex">#valdef-display-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex">2. 
 Box Layout Modes: the display property</a>
@@ -3657,8 +3657,8 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
 Automatic Box Type Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-grid">
-   <b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-grid" class="dfn-panel" data-for="valdef-display-grid" id="infopanel-for-valdef-display-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-grid">2. 
 Box Layout Modes: the display property</a>
@@ -3668,8 +3668,8 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
 Automatic Box Type Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-ruby">
-   <b><a href="#valdef-display-ruby">#valdef-display-ruby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-ruby" class="dfn-panel" data-for="valdef-display-ruby" id="infopanel-for-valdef-display-ruby" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-ruby" style="display:none">Info about the 'ruby' definition.</span><b><a href="#valdef-display-ruby">#valdef-display-ruby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby">2. 
 Box Layout Modes: the display property</a>
@@ -3679,8 +3679,8 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-list-item">
-   <b><a href="#valdef-display-list-item">#valdef-display-list-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-list-item" class="dfn-panel" data-for="valdef-display-list-item" id="infopanel-for-valdef-display-list-item" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-list-item" style="display:none">Info about the 'list-item' definition.</span><b><a href="#valdef-display-list-item">#valdef-display-list-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-list-item">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-valdef-display-list-item①">(2)</a>
@@ -3690,59 +3690,59 @@ Generating Marker Boxes: the list-item keyword</a>
     <li><a href="#ref-for-valdef-display-list-item④"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-internal">
-   <b><a href="#layout-internal">#layout-internal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-internal" class="dfn-panel" data-for="layout-internal" id="infopanel-for-layout-internal" role="dialog">
+   <span id="infopaneltitle-for-layout-internal" style="display:none">Info about the 'layout-internal' definition.</span><b><a href="#layout-internal">#layout-internal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-internal">2.7. 
 Automatic Box Type Transformations</a> <a href="#ref-for-layout-internal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-table-row">
-   <b><a href="#valdef-display-table-row">#valdef-display-table-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-table-row" class="dfn-panel" data-for="valdef-display-table-row" id="infopanel-for-valdef-display-table-row" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-table-row" style="display:none">Info about the 'table-row' definition.</span><b><a href="#valdef-display-table-row">#valdef-display-table-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-row">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-table-cell">
-   <b><a href="#valdef-display-table-cell">#valdef-display-table-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-table-cell" class="dfn-panel" data-for="valdef-display-table-cell" id="infopanel-for-valdef-display-table-cell" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' definition.</span><b><a href="#valdef-display-table-cell">#valdef-display-table-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a> <a href="#ref-for-valdef-display-table-cell①">(2)</a>
     <li><a href="#ref-for-valdef-display-table-cell②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="internal-table-element">
-   <b><a href="#internal-table-element">#internal-table-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-internal-table-element" class="dfn-panel" data-for="internal-table-element" id="infopanel-for-internal-table-element" role="dialog">
+   <span id="infopaneltitle-for-internal-table-element" style="display:none">Info about the 'internal table element' definition.</span><b><a href="#internal-table-element">#internal-table-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-element">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-table-caption">
-   <b><a href="#valdef-display-table-caption">#valdef-display-table-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-table-caption" class="dfn-panel" data-for="valdef-display-table-caption" id="infopanel-for-valdef-display-table-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-table-caption" style="display:none">Info about the 'table-caption' definition.</span><b><a href="#valdef-display-table-caption">#valdef-display-table-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-caption">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
     <li><a href="#ref-for-valdef-display-table-caption①"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-ruby-base">
-   <b><a href="#valdef-display-ruby-base">#valdef-display-ruby-base</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-ruby-base" class="dfn-panel" data-for="valdef-display-ruby-base" id="infopanel-for-valdef-display-ruby-base" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-ruby-base" style="display:none">Info about the 'ruby-base' definition.</span><b><a href="#valdef-display-ruby-base">#valdef-display-ruby-base</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby-base">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-ruby-text">
-   <b><a href="#valdef-display-ruby-text">#valdef-display-ruby-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-ruby-text" class="dfn-panel" data-for="valdef-display-ruby-text" id="infopanel-for-valdef-display-ruby-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-ruby-text" style="display:none">Info about the 'ruby-text' definition.</span><b><a href="#valdef-display-ruby-text">#valdef-display-ruby-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby-text">2.4. 
 Layout-Internal Display Types: the table-* and ruby-* keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-contents">
-   <b><a href="#valdef-display-contents">#valdef-display-contents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-contents" class="dfn-panel" data-for="valdef-display-contents" id="infopanel-for-valdef-display-contents" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-contents" style="display:none">Info about the 'contents' definition.</span><b><a href="#valdef-display-contents">#valdef-display-contents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-contents">1. 
 Introduction</a>
@@ -3754,8 +3754,8 @@ Box Generation: the none and contents keywords</a>
 Automatic Box Type Transformations</a> <a href="#ref-for-valdef-display-contents④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-none">
-   <b><a href="#valdef-display-none">#valdef-display-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-none" class="dfn-panel" data-for="valdef-display-none" id="infopanel-for-valdef-display-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-display-none">#valdef-display-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">1. 
 Introduction</a>
@@ -3767,8 +3767,8 @@ Box Generation: the none and contents keywords</a>
 Automatic Box Type Transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-block">
-   <b><a href="#valdef-display-inline-block">#valdef-display-inline-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-block" class="dfn-panel" data-for="valdef-display-inline-block" id="infopanel-for-valdef-display-inline-block" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' definition.</span><b><a href="#valdef-display-inline-block">#valdef-display-inline-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">2. 
 Box Layout Modes: the display property</a>
@@ -3776,30 +3776,30 @@ Box Layout Modes: the display property</a>
     <li><a href="#ref-for-valdef-display-inline-block②"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-table">
-   <b><a href="#valdef-display-inline-table">#valdef-display-inline-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-table" class="dfn-panel" data-for="valdef-display-inline-table" id="infopanel-for-valdef-display-inline-table" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' definition.</span><b><a href="#valdef-display-inline-table">#valdef-display-inline-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">2. 
 Box Layout Modes: the display property</a>
     <li><a href="#ref-for-valdef-display-inline-table①"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-flex">
-   <b><a href="#valdef-display-inline-flex">#valdef-display-inline-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-flex" class="dfn-panel" data-for="valdef-display-inline-flex" id="infopanel-for-valdef-display-inline-flex" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-flex" style="display:none">Info about the 'inline-flex' definition.</span><b><a href="#valdef-display-inline-flex">#valdef-display-inline-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-flex">2. 
 Box Layout Modes: the display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-grid">
-   <b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-grid" class="dfn-panel" data-for="valdef-display-inline-grid" id="infopanel-for-valdef-display-inline-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-grid" style="display:none">Info about the 'inline-grid' definition.</span><b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-grid">2. 
 Box Layout Modes: the display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blockify">
-   <b><a href="#blockify">#blockify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blockify" class="dfn-panel" data-for="blockify" id="infopanel-for-blockify" role="dialog">
+   <span id="infopaneltitle-for-blockify" style="display:none">Info about the 'blockification' definition.</span><b><a href="#blockify">#blockify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">2.7. 
 Automatic Box Type Transformations</a> <a href="#ref-for-blockify①">(2)</a> <a href="#ref-for-blockify②">(3)</a> <a href="#ref-for-blockify③">(4)</a> <a href="#ref-for-blockify④">(5)</a> <a href="#ref-for-blockify⑤">(6)</a> <a href="#ref-for-blockify⑥">(7)</a>
@@ -3808,8 +3808,8 @@ Automatic Box Type Transformations</a> <a href="#ref-for-blockify①">(2)</a> <a
     <li><a href="#ref-for-blockify①②"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-blockify①③">(2)</a> <a href="#ref-for-blockify①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inlinify">
-   <b><a href="#inlinify">#inlinify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inlinify" class="dfn-panel" data-for="inlinify" id="infopanel-for-inlinify" role="dialog">
+   <span id="infopaneltitle-for-inlinify" style="display:none">Info about the 'inlinification' definition.</span><b><a href="#inlinify">#inlinify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inlinify">2.7. 
 Automatic Box Type Transformations</a> <a href="#ref-for-inlinify①">(2)</a> <a href="#ref-for-inlinify②">(3)</a> <a href="#ref-for-inlinify③">(4)</a> <a href="#ref-for-inlinify④">(5)</a> <a href="#ref-for-inlinify⑤">(6)</a>
@@ -3819,8 +3819,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-inlinify⑨"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-inlinify①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-in">
-   <b><a href="#run-in">#run-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-in" class="dfn-panel" data-for="run-in" id="infopanel-for-run-in" role="dialog">
+   <span id="infopaneltitle-for-run-in" style="display:none">Info about the 'run-in box' definition.</span><b><a href="#run-in">#run-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-in">2. 
 Box Layout Modes: the display property</a>
@@ -3830,15 +3830,15 @@ Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
 Run-In Layout</a> <a href="#ref-for-run-in③">(2)</a> <a href="#ref-for-run-in④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-in-sequence">
-   <b><a href="#run-in-sequence">#run-in-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-in-sequence" class="dfn-panel" data-for="run-in-sequence" id="infopanel-for-run-in-sequence" role="dialog">
+   <span id="infopaneltitle-for-run-in-sequence" style="display:none">Info about the 'run-in sequence' definition.</span><b><a href="#run-in-sequence">#run-in-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-in-sequence">3. 
 Run-In Layout</a> <a href="#ref-for-run-in-sequence①">(2)</a> <a href="#ref-for-run-in-sequence②">(3)</a> <a href="#ref-for-run-in-sequence③">(4)</a> <a href="#ref-for-run-in-sequence④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="principal-box">
-   <b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-principal-box" class="dfn-panel" data-for="principal-box" id="infopanel-for-principal-box" role="dialog">
+   <span id="infopaneltitle-for-principal-box" style="display:none">Info about the 'principal box' definition.</span><b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">1. 
 Introduction</a> <a href="#ref-for-principal-box①">(2)</a> <a href="#ref-for-principal-box②">(3)</a> <a href="#ref-for-principal-box③">(4)</a> <a href="#ref-for-principal-box④">(5)</a> <a href="#ref-for-principal-box⑤">(6)</a>
@@ -3851,8 +3851,8 @@ Outer Display Roles for Flow Layout: the block, inline, and run-in keywords</a>
     <li><a href="#ref-for-principal-box①①"> Appendix C: Box Construction Guidelines for Spec Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-level">
-   <b><a href="#inline-level">#inline-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-level" class="dfn-panel" data-for="inline-level" id="infopanel-for-inline-level" role="dialog">
+   <span id="infopaneltitle-for-inline-level" style="display:none">Info about the 'inline-level' definition.</span><b><a href="#inline-level">#inline-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-inline-level①">(2)</a> <a href="#ref-for-inline-level②">(3)</a> <a href="#ref-for-inline-level③">(4)</a> <a href="#ref-for-inline-level④">(5)</a>
@@ -3860,8 +3860,8 @@ Box Layout Modes: the display property</a> <a href="#ref-for-inline-level①">(2
     <li><a href="#ref-for-inline-level⑦"> Appendix C: Box Construction Guidelines for Spec Authors</a> <a href="#ref-for-inline-level⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-level">
-   <b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-level" class="dfn-panel" data-for="block-level" id="infopanel-for-block-level" role="dialog">
+   <span id="infopaneltitle-for-block-level" style="display:none">Info about the 'block-level' definition.</span><b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-block-level①">(2)</a> <a href="#ref-for-block-level②">(3)</a> <a href="#ref-for-block-level③">(4)</a> <a href="#ref-for-block-level④">(5)</a>
@@ -3869,8 +3869,8 @@ Box Layout Modes: the display property</a> <a href="#ref-for-block-level①">(2)
     <li><a href="#ref-for-block-level⑦"> Appendix C: Box Construction Guidelines for Spec Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-box">
-   <b><a href="#inline-box">#inline-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-box" class="dfn-panel" data-for="inline-box" id="infopanel-for-inline-box" role="dialog">
+   <span id="infopaneltitle-for-inline-box" style="display:none">Info about the 'inline box' definition.</span><b><a href="#inline-box">#inline-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">1. 
 Introduction</a>
@@ -3883,8 +3883,8 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-inline-box⑥"> Appendix A: Glossary</a> <a href="#ref-for-inline-box⑦">(2)</a> <a href="#ref-for-inline-box⑧">(3)</a> <a href="#ref-for-inline-box⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-container">
-   <b><a href="#block-container">#block-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-container" class="dfn-panel" data-for="block-container" id="infopanel-for-block-container" role="dialog">
+   <span id="infopaneltitle-for-block-container" style="display:none">Info about the 'block container' definition.</span><b><a href="#block-container">#block-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a>
@@ -3896,8 +3896,8 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-block-container①⑥"> Appendix C: Box Construction Guidelines for Spec Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-box">
-   <b><a href="#block-box">#block-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-box" class="dfn-panel" data-for="block-box" id="infopanel-for-block-box" role="dialog">
+   <span id="infopaneltitle-for-block-box" style="display:none">Info about the 'block box' definition.</span><b><a href="#block-box">#block-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">1. 
 Introduction</a>
@@ -3911,14 +3911,14 @@ Automatic Box Type Transformations</a>
     <li><a href="#ref-for-block-box⑨"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block">
-   <b><a href="#block">#block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block" class="dfn-panel" data-for="block" id="infopanel-for-block" role="dialog">
+   <span id="infopaneltitle-for-block" style="display:none">Info about the 'block' definition.</span><b><a href="#block">#block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replaced-element">
-   <b><a href="#replaced-element">#replaced-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replaced-element" class="dfn-panel" data-for="replaced-element" id="infopanel-for-replaced-element" role="dialog">
+   <span id="infopaneltitle-for-replaced-element" style="display:none">Info about the 'replaced element' definition.</span><b><a href="#replaced-element">#replaced-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2. 
 Box Layout Modes: the display property</a> <a href="#ref-for-replaced-element①">(2)</a>
@@ -3927,21 +3927,21 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-replaced-element③"> Appendix A: Glossary</a> <a href="#ref-for-replaced-element④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containing-block">
-   <b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containing-block" class="dfn-panel" data-for="containing-block" id="infopanel-for-containing-block" role="dialog">
+   <span id="infopaneltitle-for-containing-block" style="display:none">Info about the 'containing block' definition.</span><b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block"> Appendix A: Glossary</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a> <a href="#ref-for-containing-block③">(4)</a> <a href="#ref-for-containing-block④">(5)</a> <a href="#ref-for-containing-block⑤">(6)</a> <a href="#ref-for-containing-block⑥">(7)</a> <a href="#ref-for-containing-block⑦">(8)</a> <a href="#ref-for-containing-block⑧">(9)</a> <a href="#ref-for-containing-block⑨">(10)</a> <a href="#ref-for-containing-block①⓪">(11)</a>
     <li><a href="#ref-for-containing-block①①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-containing-block">
-   <b><a href="#initial-containing-block">#initial-containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-containing-block" class="dfn-panel" data-for="initial-containing-block" id="infopanel-for-initial-containing-block" role="dialog">
+   <span id="infopaneltitle-for-initial-containing-block" style="display:none">Info about the 'initial containing block' definition.</span><b><a href="#initial-containing-block">#initial-containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block"> Appendix A: Glossary</a> <a href="#ref-for-initial-containing-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formatting-context">
-   <b><a href="#formatting-context">#formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formatting-context" class="dfn-panel" data-for="formatting-context" id="infopanel-for-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-formatting-context" style="display:none">Info about the 'formatting context' definition.</span><b><a href="#formatting-context">#formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2. 
 Box Layout Modes: the display property</a>
@@ -3951,23 +3951,24 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-formatting-context①⑥"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="independent-formatting-context">
-   <b><a href="#independent-formatting-context">#independent-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-independent-formatting-context" class="dfn-panel" data-for="independent-formatting-context" id="infopanel-for-independent-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' definition.</span><b><a href="#independent-formatting-context">#independent-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context"> Appendix A: Glossary</a> <a href="#ref-for-independent-formatting-context①">(2)</a> <a href="#ref-for-independent-formatting-context②">(3)</a> <a href="#ref-for-independent-formatting-context③">(4)</a>
     <li><a href="#ref-for-independent-formatting-context④"> Appendix C: Box Construction Guidelines for Spec Authors</a> <a href="#ref-for-independent-formatting-context⑤">(2)</a>
     <li><a href="#ref-for-independent-formatting-context⑥"> Changes Prior to Candidate Recommendation Status</a> <a href="#ref-for-independent-formatting-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="establish-an-independent-formatting-context">
-   <b><a href="#establish-an-independent-formatting-context">#establish-an-independent-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="establish-an-independent-formatting-context" id="infopanel-for-establish-an-independent-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-establish-an-independent-formatting-context" style="display:none">Info about the '
+				establish an independent formatting context' definition.</span><b><a href="#establish-an-independent-formatting-context">#establish-an-independent-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context"> Appendix A: Glossary</a> <a href="#ref-for-establish-an-independent-formatting-context①">(2)</a> <a href="#ref-for-establish-an-independent-formatting-context②">(3)</a> <a href="#ref-for-establish-an-independent-formatting-context③">(4)</a> <a href="#ref-for-establish-an-independent-formatting-context④">(5)</a>
     <li><a href="#ref-for-establish-an-independent-formatting-context⑤"> Appendix C: Box Construction Guidelines for Spec Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-formatting-context">
-   <b><a href="#block-formatting-context">#block-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-formatting-context" class="dfn-panel" data-for="block-formatting-context" id="infopanel-for-block-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-block-formatting-context" style="display:none">Info about the 'block formatting context' definition.</span><b><a href="#block-formatting-context">#block-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">2. 
 Box Layout Modes: the display property</a>
@@ -3979,8 +3980,8 @@ Run-In Layout</a>
     <li><a href="#ref-for-block-formatting-context②④"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-formatting-context">
-   <b><a href="#inline-formatting-context">#inline-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-formatting-context" class="dfn-panel" data-for="inline-formatting-context" id="infopanel-for-inline-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' definition.</span><b><a href="#inline-formatting-context">#inline-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2.2. 
 Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby keywords</a>
@@ -3988,95 +3989,151 @@ Inner Display Layout Models: the flow, flow-root, table, flex, grid, and ruby ke
     <li><a href="#ref-for-inline-formatting-context⑨"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-formatting-context-root">
-   <b><a href="#block-formatting-context-root">#block-formatting-context-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-formatting-context-root" class="dfn-panel" data-for="block-formatting-context-root" id="infopanel-for-block-formatting-context-root" role="dialog">
+   <span id="infopaneltitle-for-block-formatting-context-root" style="display:none">Info about the 'block formatting context root' definition.</span><b><a href="#block-formatting-context-root">#block-formatting-context-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context-root"> Appendix A: Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bfc">
-   <b><a href="#bfc">#bfc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bfc" class="dfn-panel" data-for="bfc" id="infopanel-for-bfc" role="dialog">
+   <span id="infopaneltitle-for-bfc" style="display:none">Info about the 'BFC' definition.</span><b><a href="#bfc">#bfc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bfc">2. 
 Box Layout Modes: the display property</a>
     <li><a href="#ref-for-bfc①"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="out-of-flow">
-   <b><a href="#out-of-flow">#out-of-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-out-of-flow" class="dfn-panel" data-for="out-of-flow" id="infopanel-for-out-of-flow" role="dialog">
+   <span id="infopaneltitle-for-out-of-flow" style="display:none">Info about the 'out-of-flow' definition.</span><b><a href="#out-of-flow">#out-of-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow"> Appendix A: Glossary</a> <a href="#ref-for-out-of-flow①">(2)</a> <a href="#ref-for-out-of-flow②">(3)</a> <a href="#ref-for-out-of-flow③">(4)</a>
     <li><a href="#ref-for-out-of-flow④"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-flow">
-   <b><a href="#in-flow">#in-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-flow" class="dfn-panel" data-for="in-flow" id="infopanel-for-in-flow" role="dialog">
+   <span id="infopaneltitle-for-in-flow" style="display:none">Info about the 'in-flow' definition.</span><b><a href="#in-flow">#in-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow"> Appendix A: Glossary</a>
     <li><a href="#ref-for-in-flow①"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-order">
-   <b><a href="#document-order">#document-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-order" class="dfn-panel" data-for="document-order" id="infopanel-for-document-order" role="dialog">
+   <span id="infopaneltitle-for-document-order" style="display:none">Info about the 'document order' definition.</span><b><a href="#document-order">#document-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-order"> Changes Prior to Candidate Recommendation Status</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-easing-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-easing-1/Overview.html
@@ -1527,8 +1527,8 @@ community for their feedback and contributions.</p>
    <li><a href="#valdef-step-easing-function-step-start">step-start</a><span>, in § 2.3</span>
    <li><a href="#easing-function">timing function</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">2.2. Cubic
 Bézier easing functions:
@@ -1537,36 +1537,36 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-comb-
 step-start, step-end, steps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">2.3. Step easing functions:
 step-start, step-end, steps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">2.2. Cubic
 Bézier easing functions:
 ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a> <a href="#ref-for-number-value③">(4)</a> <a href="#ref-for-number-value④">(5)</a> <a href="#ref-for-number-value⑤">(6)</a> <a href="#ref-for-number-value⑥">(7)</a> <a href="#ref-for-number-value⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.3. Step easing functions:
 step-start, step-end, steps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-bracketed-range-notation">
-   <a href="https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation">https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-bracketed-range-notation" class="dfn-panel" data-for="term-for-css-bracketed-range-notation" id="infopanel-for-term-for-css-bracketed-range-notation" role="menu">
+   <span id="infopaneltitle-for-term-for-css-bracketed-range-notation" style="display:none">Info about the 'css bracketed range notation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation">https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-bracketed-range-notation">4. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Easing functions</a> <a href="#ref-for-comb-one①">(2)</a>
     <li><a href="#ref-for-comb-one②">2.2. Cubic
@@ -1608,8 +1608,8 @@ step-start, step-end, steps()</a> <a href="#ref-for-comb-one⑦">(2)</a> <a href
    <dt id="biblio-web-animations">[WEB-ANIMATIONS]
    <dd>Brian Birtles; et al. <a href="https://drafts.csswg.org/web-animations-1/"><cite>Web Animations</cite></a>. URL: <a href="https://drafts.csswg.org/web-animations-1/">https://drafts.csswg.org/web-animations-1/</a>
   </dl>
-  <aside class="dfn-panel" data-for="easing-function">
-   <b><a href="#easing-function">#easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-easing-function" class="dfn-panel" data-for="easing-function" id="infopanel-for-easing-function" role="dialog">
+   <span id="infopaneltitle-for-easing-function" style="display:none">Info about the 'easing function' definition.</span><b><a href="#easing-function">#easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">1. Introduction</a>
     <li><a href="#ref-for-easing-function①">2. Easing functions</a> <a href="#ref-for-easing-function②">(2)</a> <a href="#ref-for-easing-function③">(3)</a>
@@ -1620,8 +1620,8 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a>
 step-start, step-end, steps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input-progress-value">
-   <b><a href="#input-progress-value">#input-progress-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input-progress-value" class="dfn-panel" data-for="input-progress-value" id="infopanel-for-input-progress-value" role="dialog">
+   <span id="infopaneltitle-for-input-progress-value" style="display:none">Info about the 'input progress value' definition.</span><b><a href="#input-progress-value">#input-progress-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-progress-value">2. Easing functions</a> <a href="#ref-for-input-progress-value①">(2)</a>
     <li><a href="#ref-for-input-progress-value②">2.1. The linear easing function: linear</a>
@@ -1633,8 +1633,8 @@ a step easing function</a> <a href="#ref-for-input-progress-value①④">(2)</a>
     <li><a href="#ref-for-input-progress-value②③">3. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="output-progress-value">
-   <b><a href="#output-progress-value">#output-progress-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-output-progress-value" class="dfn-panel" data-for="output-progress-value" id="infopanel-for-output-progress-value" role="dialog">
+   <span id="infopaneltitle-for-output-progress-value" style="display:none">Info about the 'output progress value' definition.</span><b><a href="#output-progress-value">#output-progress-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-progress-value">2. Easing functions</a> <a href="#ref-for-output-progress-value①">(2)</a>
     <li><a href="#ref-for-output-progress-value②">2.1. The linear easing function: linear</a>
@@ -1644,36 +1644,37 @@ a step easing function</a> <a href="#ref-for-output-progress-value⑦">(2)</a> <
     <li><a href="#ref-for-output-progress-value①②">3. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-easing-function">
-   <b><a href="#linear-easing-function">#linear-easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-easing-function" class="dfn-panel" data-for="linear-easing-function" id="infopanel-for-linear-easing-function" role="dialog">
+   <span id="infopaneltitle-for-linear-easing-function" style="display:none">Info about the 'linear easing
+function' definition.</span><b><a href="#linear-easing-function">#linear-easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-easing-function">2.1. The linear easing function: linear</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-easing-function-linear">
-   <b><a href="#valdef-easing-function-linear">#valdef-easing-function-linear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-easing-function-linear" class="dfn-panel" data-for="valdef-easing-function-linear" id="infopanel-for-valdef-easing-function-linear" role="dialog">
+   <span id="infopaneltitle-for-valdef-easing-function-linear" style="display:none">Info about the 'linear' definition.</span><b><a href="#valdef-easing-function-linear">#valdef-easing-function-linear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-easing-function-linear">2. Easing functions</a>
     <li><a href="#ref-for-valdef-easing-function-linear①">2.1. The linear easing function: linear</a>
     <li><a href="#ref-for-valdef-easing-function-linear②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cubic-bzier-easing-function">
-   <b><a href="#cubic-bzier-easing-function">#cubic-bzier-easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cubic-bzier-easing-function" class="dfn-panel" data-for="cubic-bzier-easing-function" id="infopanel-for-cubic-bzier-easing-function" role="dialog">
+   <span id="infopaneltitle-for-cubic-bzier-easing-function" style="display:none">Info about the 'cubic Bézier easing function' definition.</span><b><a href="#cubic-bzier-easing-function">#cubic-bzier-easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cubic-bzier-easing-function">2.2. Cubic
 Bézier easing functions:
 ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-cubic-bzier-easing-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-cubic-bezier-easing-function">
-   <b><a href="#typedef-cubic-bezier-easing-function">#typedef-cubic-bezier-easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-cubic-bezier-easing-function" class="dfn-panel" data-for="typedef-cubic-bezier-easing-function" id="infopanel-for-typedef-cubic-bezier-easing-function" role="dialog">
+   <span id="infopaneltitle-for-typedef-cubic-bezier-easing-function" style="display:none">Info about the '&lt;cubic-bezier-easing-function>' definition.</span><b><a href="#typedef-cubic-bezier-easing-function">#typedef-cubic-bezier-easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-cubic-bezier-easing-function">2. Easing functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease">
-   <b><a href="#valdef-cubic-bezier-easing-function-ease">#valdef-cubic-bezier-easing-function-ease</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease" class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease" id="infopanel-for-valdef-cubic-bezier-easing-function-ease" role="dialog">
+   <span id="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease" style="display:none">Info about the 'ease' definition.</span><b><a href="#valdef-cubic-bezier-easing-function-ease">#valdef-cubic-bezier-easing-function-ease</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease">2.2. Cubic
 Bézier easing functions:
@@ -1681,8 +1682,8 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-valde
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-in">
-   <b><a href="#valdef-cubic-bezier-easing-function-ease-in">#valdef-cubic-bezier-easing-function-ease-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-in" class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-in" id="infopanel-for-valdef-cubic-bezier-easing-function-ease-in" role="dialog">
+   <span id="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-in" style="display:none">Info about the 'ease-in' definition.</span><b><a href="#valdef-cubic-bezier-easing-function-ease-in">#valdef-cubic-bezier-easing-function-ease-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in">2.2. Cubic
 Bézier easing functions:
@@ -1690,8 +1691,8 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-valde
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-out">
-   <b><a href="#valdef-cubic-bezier-easing-function-ease-out">#valdef-cubic-bezier-easing-function-ease-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-out" class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-out" id="infopanel-for-valdef-cubic-bezier-easing-function-ease-out" role="dialog">
+   <span id="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-out" style="display:none">Info about the 'ease-out' definition.</span><b><a href="#valdef-cubic-bezier-easing-function-ease-out">#valdef-cubic-bezier-easing-function-ease-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-out">2.2. Cubic
 Bézier easing functions:
@@ -1699,8 +1700,8 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-valde
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-out②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-in-out">
-   <b><a href="#valdef-cubic-bezier-easing-function-ease-in-out">#valdef-cubic-bezier-easing-function-ease-in-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-in-out" class="dfn-panel" data-for="valdef-cubic-bezier-easing-function-ease-in-out" id="infopanel-for-valdef-cubic-bezier-easing-function-ease-in-out" role="dialog">
+   <span id="infopaneltitle-for-valdef-cubic-bezier-easing-function-ease-in-out" style="display:none">Info about the 'ease-in-out' definition.</span><b><a href="#valdef-cubic-bezier-easing-function-ease-in-out">#valdef-cubic-bezier-easing-function-ease-in-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in-out">2.2. Cubic
 Bézier easing functions:
@@ -1708,8 +1709,8 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-valde
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in-out②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-cubic-bezier-easing-function-cubic-bezier">
-   <b><a href="#funcdef-cubic-bezier-easing-function-cubic-bezier">#funcdef-cubic-bezier-easing-function-cubic-bezier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-cubic-bezier-easing-function-cubic-bezier" class="dfn-panel" data-for="funcdef-cubic-bezier-easing-function-cubic-bezier" id="infopanel-for-funcdef-cubic-bezier-easing-function-cubic-bezier" role="dialog">
+   <span id="infopaneltitle-for-funcdef-cubic-bezier-easing-function-cubic-bezier" style="display:none">Info about the 'cubic-bezier(&lt;number [0,1]>, &lt;number>, &lt;number [0,1]>, &lt;number>)' definition.</span><b><a href="#funcdef-cubic-bezier-easing-function-cubic-bezier">#funcdef-cubic-bezier-easing-function-cubic-bezier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-cubic-bezier-easing-function-cubic-bezier">2.2. Cubic
 Bézier easing functions:
@@ -1718,22 +1719,22 @@ ease, ease-in, ease-out, ease-in-out, cubic-bezier()</a> <a href="#ref-for-funcd
     <li><a href="#ref-for-funcdef-cubic-bezier-easing-function-cubic-bezier③">4. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="step-easing-function">
-   <b><a href="#step-easing-function">#step-easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-step-easing-function" class="dfn-panel" data-for="step-easing-function" id="infopanel-for-step-easing-function" role="dialog">
+   <span id="infopaneltitle-for-step-easing-function" style="display:none">Info about the 'step easing function' definition.</span><b><a href="#step-easing-function">#step-easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-step-easing-function">2.3.1. Output of
 a step easing function</a> <a href="#ref-for-step-easing-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="steps">
-   <b><a href="#steps">#steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-steps" class="dfn-panel" data-for="steps" id="infopanel-for-steps" role="dialog">
+   <span id="infopaneltitle-for-steps" style="display:none">Info about the 'steps' definition.</span><b><a href="#steps">#steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-steps">2.3.1. Output of
 a step easing function</a> <a href="#ref-for-steps①">(2)</a> <a href="#ref-for-steps②">(3)</a> <a href="#ref-for-steps③">(4)</a> <a href="#ref-for-steps④">(5)</a> <a href="#ref-for-steps⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="step-position">
-   <b><a href="#step-position">#step-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-step-position" class="dfn-panel" data-for="step-position" id="infopanel-for-step-position" role="dialog">
+   <span id="infopaneltitle-for-step-position" style="display:none">Info about the 'step position' definition.</span><b><a href="#step-position">#step-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-step-position">2.3. Step easing functions:
 step-start, step-end, steps()</a>
@@ -1742,45 +1743,45 @@ a step easing function</a> <a href="#ref-for-step-position②">(2)</a> <a href="
     <li><a href="#ref-for-step-position⑦">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-step-easing-function">
-   <b><a href="#typedef-step-easing-function">#typedef-step-easing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-step-easing-function" class="dfn-panel" data-for="typedef-step-easing-function" id="infopanel-for-typedef-step-easing-function" role="dialog">
+   <span id="infopaneltitle-for-typedef-step-easing-function" style="display:none">Info about the '&lt;step-easing-function>' definition.</span><b><a href="#typedef-step-easing-function">#typedef-step-easing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-step-easing-function">2. Easing functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-step-position">
-   <b><a href="#typedef-step-position">#typedef-step-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-step-position" class="dfn-panel" data-for="typedef-step-position" id="infopanel-for-typedef-step-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-step-position" style="display:none">Info about the '&lt;step-position>' definition.</span><b><a href="#typedef-step-position">#typedef-step-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-step-position">2.3. Step easing functions:
 step-start, step-end, steps()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-step-easing-function-step-start">
-   <b><a href="#valdef-step-easing-function-step-start">#valdef-step-easing-function-step-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-step-easing-function-step-start" class="dfn-panel" data-for="valdef-step-easing-function-step-start" id="infopanel-for-valdef-step-easing-function-step-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-step-easing-function-step-start" style="display:none">Info about the 'step-start' definition.</span><b><a href="#valdef-step-easing-function-step-start">#valdef-step-easing-function-step-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-step-easing-function-step-start">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-step-easing-function-step-start①">(2)</a>
     <li><a href="#ref-for-valdef-step-easing-function-step-start②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-step-easing-function-step-end">
-   <b><a href="#valdef-step-easing-function-step-end">#valdef-step-easing-function-step-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-step-easing-function-step-end" class="dfn-panel" data-for="valdef-step-easing-function-step-end" id="infopanel-for-valdef-step-easing-function-step-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-step-easing-function-step-end" style="display:none">Info about the 'step-end' definition.</span><b><a href="#valdef-step-easing-function-step-end">#valdef-step-easing-function-step-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-step-easing-function-step-end">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-step-easing-function-step-end①">(2)</a>
     <li><a href="#ref-for-valdef-step-easing-function-step-end②">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-step-easing-function-steps">
-   <b><a href="#funcdef-step-easing-function-steps">#funcdef-step-easing-function-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-step-easing-function-steps" class="dfn-panel" data-for="funcdef-step-easing-function-steps" id="infopanel-for-funcdef-step-easing-function-steps" role="dialog">
+   <span id="infopaneltitle-for-funcdef-step-easing-function-steps" style="display:none">Info about the 'steps(&lt;integer>[, &lt;step-position> ]?)' definition.</span><b><a href="#funcdef-step-easing-function-steps">#funcdef-step-easing-function-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-step-easing-function-steps">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-funcdef-step-easing-function-steps①">(2)</a>
     <li><a href="#ref-for-funcdef-step-easing-function-steps②">2.4. Serialization</a> <a href="#ref-for-funcdef-step-easing-function-steps③">(2)</a> <a href="#ref-for-funcdef-step-easing-function-steps④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-jump-start">
-   <b><a href="#valdef-steps-jump-start">#valdef-steps-jump-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-jump-start" class="dfn-panel" data-for="valdef-steps-jump-start" id="infopanel-for-valdef-steps-jump-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-jump-start" style="display:none">Info about the 'jump-start' definition.</span><b><a href="#valdef-steps-jump-start">#valdef-steps-jump-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-jump-start">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-jump-start①">(2)</a>
@@ -1788,8 +1789,8 @@ step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-jump-start①">
 a step easing function</a> <a href="#ref-for-valdef-steps-jump-start③">(2)</a> <a href="#ref-for-valdef-steps-jump-start④">(3)</a> <a href="#ref-for-valdef-steps-jump-start⑤">(4)</a> <a href="#ref-for-valdef-steps-jump-start⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-jump-end">
-   <b><a href="#valdef-steps-jump-end">#valdef-steps-jump-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-jump-end" class="dfn-panel" data-for="valdef-steps-jump-end" id="infopanel-for-valdef-steps-jump-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-jump-end" style="display:none">Info about the 'jump-end' definition.</span><b><a href="#valdef-steps-jump-end">#valdef-steps-jump-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-jump-end">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-jump-end①">(2)</a>
@@ -1798,8 +1799,8 @@ a step easing function</a> <a href="#ref-for-valdef-steps-jump-end③">(2)</a> <
     <li><a href="#ref-for-valdef-steps-jump-end⑤">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-jump-none">
-   <b><a href="#valdef-steps-jump-none">#valdef-steps-jump-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-jump-none" class="dfn-panel" data-for="valdef-steps-jump-none" id="infopanel-for-valdef-steps-jump-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-jump-none" style="display:none">Info about the 'jump-none' definition.</span><b><a href="#valdef-steps-jump-none">#valdef-steps-jump-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-jump-none">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-jump-none①">(2)</a>
@@ -1807,8 +1808,8 @@ step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-jump-none①">(
 a step easing function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-jump-both">
-   <b><a href="#valdef-steps-jump-both">#valdef-steps-jump-both</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-jump-both" class="dfn-panel" data-for="valdef-steps-jump-both" id="infopanel-for-valdef-steps-jump-both" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-jump-both" style="display:none">Info about the 'jump-both' definition.</span><b><a href="#valdef-steps-jump-both">#valdef-steps-jump-both</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-jump-both">2.3. Step easing functions:
 step-start, step-end, steps()</a>
@@ -1816,8 +1817,8 @@ step-start, step-end, steps()</a>
 a step easing function</a> <a href="#ref-for-valdef-steps-jump-both②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-start">
-   <b><a href="#valdef-steps-start">#valdef-steps-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-start" class="dfn-panel" data-for="valdef-steps-start" id="infopanel-for-valdef-steps-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-steps-start">#valdef-steps-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-start">2.3. Step easing functions:
 step-start, step-end, steps()</a>
@@ -1825,8 +1826,8 @@ step-start, step-end, steps()</a>
 a step easing function</a> <a href="#ref-for-valdef-steps-start②">(2)</a> <a href="#ref-for-valdef-steps-start③">(3)</a> <a href="#ref-for-valdef-steps-start④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-steps-end">
-   <b><a href="#valdef-steps-end">#valdef-steps-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-steps-end" class="dfn-panel" data-for="valdef-steps-end" id="infopanel-for-valdef-steps-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-steps-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-steps-end">#valdef-steps-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-steps-end">2.3. Step easing functions:
 step-start, step-end, steps()</a> <a href="#ref-for-valdef-steps-end①">(2)</a>
@@ -1835,8 +1836,8 @@ a step easing function</a> <a href="#ref-for-valdef-steps-end③">(2)</a>
     <li><a href="#ref-for-valdef-steps-end④">2.4. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="before-flag">
-   <b><a href="#before-flag">#before-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-before-flag" class="dfn-panel" data-for="before-flag" id="infopanel-for-before-flag" role="dialog">
+   <span id="infopaneltitle-for-before-flag" style="display:none">Info about the 'before flag' definition.</span><b><a href="#before-flag">#before-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-flag">2. Easing functions</a>
     <li><a href="#ref-for-before-flag①">2.3.1. Output of
@@ -1845,59 +1846,115 @@ a step easing function</a> <a href="#ref-for-before-flag②">(2)</a> <a href="#r
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-egg-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-egg-1/Overview.html
@@ -1346,8 +1346,8 @@ Tim Berners-Lee (assuming the quotation by Doug correctly records what Tim said)
    <li><a href="#speech-rate-value">&lt;speech-rate></a><span>, in § 2.3</span>
    <li><a href="#tmbl">tmbl</a><span>, in § 2.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-hsl-s">
-   <a href="https://drafts.csswg.org/css-color-5/#valdef-hsl-s">https://drafts.csswg.org/css-color-5/#valdef-hsl-s</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-hsl-s" class="dfn-panel" data-for="term-for-valdef-hsl-s" id="infopanel-for-term-for-valdef-hsl-s" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-hsl-s" style="display:none">Info about the 's' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#valdef-hsl-s">https://drafts.csswg.org/css-color-5/#valdef-hsl-s</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-hsl-s">2. 
 Extended Units</a>
@@ -1355,64 +1355,64 @@ Extended Units</a>
 Traditional time units </a> <a href="#ref-for-valdef-hsl-s②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2.4.1. 
 Extension to the @media rule: The performance feature</a> <a href="#ref-for-at-ruledef-media①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-closest-corner">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-corner">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-corner</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-extent-keyword-closest-corner" class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-closest-corner" id="infopanel-for-term-for-valdef-rg-extent-keyword-closest-corner" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-extent-keyword-closest-corner" style="display:none">Info about the 'closest-corner' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-corner">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-corner</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-extent-keyword-closest-corner">3. 
 Double Rainbow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-closest-side">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-side">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-extent-keyword-closest-side" class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-closest-side" id="infopanel-for-term-for-valdef-rg-extent-keyword-closest-side" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-extent-keyword-closest-side" style="display:none">Info about the 'closest-side' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-side">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-closest-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-extent-keyword-closest-side">3. 
 Double Rainbow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-farthest-corner">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-corner">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-corner</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-extent-keyword-farthest-corner" class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-farthest-corner" id="infopanel-for-term-for-valdef-rg-extent-keyword-farthest-corner" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-extent-keyword-farthest-corner" style="display:none">Info about the 'farthest-corner' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-corner">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-corner</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-extent-keyword-farthest-corner">3. 
 Double Rainbow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-farthest-side">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-side">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-extent-keyword-farthest-side" class="dfn-panel" data-for="term-for-valdef-rg-extent-keyword-farthest-side" id="infopanel-for-term-for-valdef-rg-extent-keyword-farthest-side" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-extent-keyword-farthest-side" style="display:none">Info about the 'farthest-side' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-side">https://drafts.csswg.org/css-images-3/#valdef-rg-extent-keyword-farthest-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-extent-keyword-farthest-side">3. 
 Double Rainbow</a> <a href="#ref-for-valdef-rg-extent-keyword-farthest-side①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3. 
 Double Rainbow</a> <a href="#ref-for-length-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3. 
 Double Rainbow</a> <a href="#ref-for-percentage-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">3. 
 Double Rainbow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cm">
-   <a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cm" class="dfn-panel" data-for="term-for-cm" id="infopanel-for-term-for-cm" role="menu">
+   <span id="infopaneltitle-for-term-for-cm" style="display:none">Info about the 'cm' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">2. 
 Extended Units</a>
@@ -1420,15 +1420,15 @@ Extended Units</a>
 Astronomical units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dimension" class="dfn-panel" data-for="term-for-dimension" id="infopanel-for-term-for-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-dimension" style="display:none">Info about the 'dimension' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">2.3. 
 Speech rate</a>
@@ -1436,15 +1436,15 @@ Speech rate</a>
 Device performance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in">
-   <a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in" class="dfn-panel" data-for="term-for-in" id="infopanel-for-term-for-in" role="menu">
+   <span id="infopaneltitle-for-term-for-in" style="display:none">Info about the 'in' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">2. 
 Extended Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ms">
-   <a href="https://drafts.csswg.org/css-values-4/#ms">https://drafts.csswg.org/css-values-4/#ms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ms" class="dfn-panel" data-for="term-for-ms" id="infopanel-for-term-for-ms" role="menu">
+   <span id="infopaneltitle-for-term-for-ms" style="display:none">Info about the 'ms' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ms">https://drafts.csswg.org/css-values-4/#ms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ms">2. 
 Extended Units</a>
@@ -1452,36 +1452,36 @@ Extended Units</a>
 Traditional time units </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pc">
-   <a href="https://drafts.csswg.org/css-values-4/#pc">https://drafts.csswg.org/css-values-4/#pc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pc" class="dfn-panel" data-for="term-for-pc" id="infopanel-for-term-for-pc" role="menu">
+   <span id="infopaneltitle-for-term-for-pc" style="display:none">Info about the 'pc' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#pc">https://drafts.csswg.org/css-values-4/#pc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pc">2.1. 
 Astronomical units</a> <a href="#ref-for-pc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.1. 
 Astronomical units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.3.1. 
 Extension to the voice-rate property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.3.1. 
 Extension to the voice-rate property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">2. 
 Extended Units</a>
@@ -1489,8 +1489,8 @@ Extended Units</a>
 Traditional time units </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-length">
-   <a href="https://drafts.csswg.org/css-values-3/#absolute-length">https://drafts.csswg.org/css-values-3/#absolute-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-length" class="dfn-panel" data-for="term-for-absolute-length" id="infopanel-for-term-for-absolute-length" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-length" style="display:none">Info about the 'absolute length' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#absolute-length">https://drafts.csswg.org/css-values-3/#absolute-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-length">2. 
 Extended Units</a>
@@ -1498,15 +1498,15 @@ Extended Units</a>
 Astronomical units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-units">
-   <a href="https://drafts.csswg.org/css-values-3/#physical-units">https://drafts.csswg.org/css-values-3/#physical-units</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-units" class="dfn-panel" data-for="term-for-physical-units" id="infopanel-for-term-for-physical-units" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-units" style="display:none">Info about the 'physical units' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#physical-units">https://drafts.csswg.org/css-values-3/#physical-units</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-units">2.1. 
 Astronomical units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-voice-rate">
-   <a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-rate">https://drafts.csswg.org/css-speech-1/#propdef-voice-rate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-voice-rate" class="dfn-panel" data-for="term-for-propdef-voice-rate" id="infopanel-for-term-for-propdef-voice-rate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-voice-rate" style="display:none">Info about the 'voice-rate' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#propdef-voice-rate">https://drafts.csswg.org/css-speech-1/#propdef-voice-rate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-rate">1.1. 
 Module Interactions</a>
@@ -1514,8 +1514,8 @@ Module Interactions</a>
 Extension to the voice-rate property</a> <a href="#ref-for-propdef-voice-rate②">(2)</a> <a href="#ref-for-propdef-voice-rate③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#typedef-gradient">https://drafts.csswg.org/css-images-4/#typedef-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-gradient" class="dfn-panel" data-for="term-for-typedef-gradient" id="infopanel-for-term-for-typedef-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-gradient" style="display:none">Info about the '&lt;gradient>' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#typedef-gradient">https://drafts.csswg.org/css-images-4/#typedef-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-gradient">1.1. 
 Module Interactions</a>
@@ -1523,8 +1523,8 @@ Module Interactions</a>
 Double Rainbow</a> <a href="#ref-for-typedef-gradient②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-radial-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient">https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-radial-gradient" class="dfn-panel" data-for="term-for-funcdef-radial-gradient" id="infopanel-for-term-for-funcdef-radial-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-radial-gradient" style="display:none">Info about the 'radial-gradient()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient">https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-radial-gradient">3. 
 Double Rainbow</a>
@@ -1650,8 +1650,8 @@ at which a normal person
 can understand what’s being said in their native language</q>. <a class="issue-return" href="#issue-6104d49e" title="Jump to section">↵</a></div>
    <div class="issue"> Should negative values be allowed for <a class="production css" data-link-type="type" href="#speech-rate-value">&lt;speech-rate></a> for reversed speech? <a class="issue-return" href="#issue-670f6c64" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="speech-rate-value">
-   <b><a href="#speech-rate-value">#speech-rate-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-speech-rate-value" class="dfn-panel" data-for="speech-rate-value" id="infopanel-for-speech-rate-value" role="dialog">
+   <span id="infopaneltitle-for-speech-rate-value" style="display:none">Info about the '&lt;speech-rate>' definition.</span><b><a href="#speech-rate-value">#speech-rate-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-speech-rate-value">2.3. 
 Speech rate</a>
@@ -1659,8 +1659,8 @@ Speech rate</a>
 Extension to the voice-rate property</a> <a href="#ref-for-speech-rate-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="device-performance-value">
-   <b><a href="#device-performance-value">#device-performance-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-device-performance-value" class="dfn-panel" data-for="device-performance-value" id="infopanel-for-device-performance-value" role="dialog">
+   <span id="infopaneltitle-for-device-performance-value" style="display:none">Info about the '&lt;device-performance>' definition.</span><b><a href="#device-performance-value">#device-performance-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-performance-value">2.4. 
 Device performance</a>
@@ -1668,15 +1668,15 @@ Device performance</a>
 Extension to the @media rule: The performance feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-double-rainbow">
-   <b><a href="#funcdef-double-rainbow">#funcdef-double-rainbow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-double-rainbow" class="dfn-panel" data-for="funcdef-double-rainbow" id="infopanel-for-funcdef-double-rainbow" role="dialog">
+   <span id="infopaneltitle-for-funcdef-double-rainbow" style="display:none">Info about the 'double-rainbow()' definition.</span><b><a href="#funcdef-double-rainbow">#funcdef-double-rainbow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-double-rainbow">3. 
 Double Rainbow</a> <a href="#ref-for-funcdef-double-rainbow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-extent">
-   <b><a href="#typedef-extent">#typedef-extent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-extent" class="dfn-panel" data-for="typedef-extent" id="infopanel-for-typedef-extent" role="dialog">
+   <span id="infopaneltitle-for-typedef-extent" style="display:none">Info about the '&lt;extent>' definition.</span><b><a href="#typedef-extent">#typedef-extent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-extent">3. 
 Double Rainbow</a> <a href="#ref-for-typedef-extent①">(2)</a>
@@ -1684,57 +1684,113 @@ Double Rainbow</a> <a href="#ref-for-typedef-extent①">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-env-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-env-1/Overview.html
@@ -1233,77 +1233,77 @@ it has the same effects as defined in <a href="https://drafts.csswg.org/css-vari
    <li><a href="#substitute-an-env">substitute</a><span>, in § 3</span>
    <li><a href="#substitute-an-env">substitute an env()</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3.1. Environment Variables in Shorthand Properties</a> <a href="#ref-for-shorthand-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">2. Environment Variables</a>
     <li><a href="#ref-for-typedef-declaration-value①">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2.1. Safe area inset variables</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-at-computed-value-time">
-   <a href="https://drafts.csswg.org/css-variables-1/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-1/#invalid-at-computed-value-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-at-computed-value-time" class="dfn-panel" data-for="term-for-invalid-at-computed-value-time" id="infopanel-for-term-for-invalid-at-computed-value-time" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-at-computed-value-time" style="display:none">Info about the 'invalid at computed-value time' external reference.</span><a href="https://drafts.csswg.org/css-variables-1/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-1/#invalid-at-computed-value-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-at-computed-value-time">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-custom-property-name">
-   <a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-custom-property-name" class="dfn-panel" data-for="term-for-typedef-custom-property-name" id="infopanel-for-term-for-typedef-custom-property-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-custom-property-name" style="display:none">Info about the '&lt;custom-property-name>' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-property-name">2. Environment Variables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">1. Introduction</a> <a href="#ref-for-custom-property①">(2)</a> <a href="#ref-for-custom-property②">(3)</a>
     <li><a href="#ref-for-custom-property③">2. Environment Variables</a>
     <li><a href="#ref-for-custom-property④">3. Using Environment Variables: the env() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">Unnumbered Section</a>
     <li><a href="#ref-for-funcdef-var①">1. Introduction</a> <a href="#ref-for-funcdef-var②">(2)</a> <a href="#ref-for-funcdef-var③">(3)</a> <a href="#ref-for-funcdef-var④">(4)</a>
@@ -1311,8 +1311,8 @@ it has the same effects as defined in <a href="https://drafts.csswg.org/css-vari
     <li><a href="#ref-for-funcdef-var⑧">3.1. Environment Variables in Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Environment Variables</a>
    </ul>
@@ -1416,8 +1416,8 @@ define how/when it substitutes. <a class="issue-return" href="#issue-9806265e" t
    <div class="issue"> If <a class="css" data-link-type="maybe" href="#funcdef-env">env()</a> substitution happens during parsing,
 then this is unnecessary. <a class="issue-return" href="#issue-66b99b40" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="css-environment-variable">
-   <b><a href="#css-environment-variable">#css-environment-variable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-environment-variable" class="dfn-panel" data-for="css-environment-variable" id="infopanel-for-css-environment-variable" role="dialog">
+   <span id="infopaneltitle-for-css-environment-variable" style="display:none">Info about the 'environment variable' definition.</span><b><a href="#css-environment-variable">#css-environment-variable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-environment-variable①">1. Introduction</a> <a href="#ref-for-css-environment-variable②">(2)</a> <a href="#ref-for-css-environment-variable③">(3)</a> <a href="#ref-for-css-environment-variable④">(4)</a>
     <li><a href="#ref-for-css-environment-variable⑤">2. Environment Variables</a> <a href="#ref-for-css-environment-variable⑥">(2)</a> <a href="#ref-for-css-environment-variable⑦">(3)</a> <a href="#ref-for-css-environment-variable⑧">(4)</a> <a href="#ref-for-css-environment-variable⑨">(5)</a>
@@ -1425,75 +1425,131 @@ then this is unnecessary. <a class="issue-return" href="#issue-66b99b40" title="
     <li><a href="#ref-for-css-environment-variable①①">3. Using Environment Variables: the env() notation</a> <a href="#ref-for-css-environment-variable①②">(2)</a> <a href="#ref-for-css-environment-variable①③">(3)</a> <a href="#ref-for-css-environment-variable①④">(4)</a> <a href="#ref-for-css-environment-variable①⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-env">
-   <b><a href="#funcdef-env">#funcdef-env</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-env" class="dfn-panel" data-for="funcdef-env" id="infopanel-for-funcdef-env" role="dialog">
+   <span id="infopaneltitle-for-funcdef-env" style="display:none">Info about the 'env()' definition.</span><b><a href="#funcdef-env">#funcdef-env</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-env①">1. Introduction</a> <a href="#ref-for-funcdef-env②">(2)</a>
     <li><a href="#ref-for-funcdef-env③">3. Using Environment Variables: the env() notation</a> <a href="#ref-for-funcdef-env④">(2)</a> <a href="#ref-for-funcdef-env⑤">(3)</a> <a href="#ref-for-funcdef-env⑥">(4)</a> <a href="#ref-for-funcdef-env⑦">(5)</a> <a href="#ref-for-funcdef-env⑧">(6)</a> <a href="#ref-for-funcdef-env⑨">(7)</a> <a href="#ref-for-funcdef-env①⓪">(8)</a> <a href="#ref-for-funcdef-env①①">(9)</a> <a href="#ref-for-funcdef-env①②">(10)</a> <a href="#ref-for-funcdef-env①③">(11)</a> <a href="#ref-for-funcdef-env①④">(12)</a> <a href="#ref-for-funcdef-env①⑤">(13)</a> <a href="#ref-for-funcdef-env①⑥">(14)</a> <a href="#ref-for-funcdef-env①⑦">(15)</a> <a href="#ref-for-funcdef-env①⑧">(16)</a> <a href="#ref-for-funcdef-env①⑨">(17)</a>
     <li><a href="#ref-for-funcdef-env②⓪">3.1. Environment Variables in Shorthand Properties</a> <a href="#ref-for-funcdef-env②①">(2)</a> <a href="#ref-for-funcdef-env②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="substitute-an-env">
-   <b><a href="#substitute-an-env">#substitute-an-env</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-substitute-an-env" class="dfn-panel" data-for="substitute-an-env" id="infopanel-for-substitute-an-env" role="dialog">
+   <span id="infopaneltitle-for-substitute-an-env" style="display:none">Info about the 'substitute an env()' definition.</span><b><a href="#substitute-an-env">#substitute-an-env</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-substitute-an-env">3. Using Environment Variables: the env() notation</a> <a href="#ref-for-substitute-an-env①">(2)</a> <a href="#ref-for-substitute-an-env②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-exclusions-1/Overview.html
@@ -1526,22 +1526,22 @@ wrapping around the <a data-link-type="dfn" href="#wrapping-context" id="ref-for
    <li><a href="#wrapping-context">Wrapping context</a><span>, in § 2</span>
    <li><a href="#propdef-wrap-through">wrap-through</a><span>, in § 3.3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-style-position-outside">
-   <a href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">https://drafts.csswg.org/css-lists-3/#list-style-position-outside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-style-position-outside" class="dfn-panel" data-for="term-for-list-style-position-outside" id="infopanel-for-term-for-list-style-position-outside" role="menu">
+   <span id="infopaneltitle-for-term-for-list-style-position-outside" style="display:none">Info about the 'outside' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#list-style-position-outside">https://drafts.csswg.org/css-lists-3/#list-style-position-outside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-style-position-outside">3.3. 
 Propagation of Exclusions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-fixed">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-fixed" class="dfn-panel" data-for="term-for-valdef-position-fixed" id="infopanel-for-term-for-valdef-position-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">3.2. 
 Scope and effect of exclusions</a>
@@ -1549,8 +1549,8 @@ Scope and effect of exclusions</a>
 Step 2-A: resolve the position and size of exclusion boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">3.2. 
 Scope and effect of exclusions</a>
@@ -1558,15 +1558,15 @@ Scope and effect of exclusions</a>
 Step 2-A: resolve the position and size of exclusion boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a>
@@ -1574,8 +1574,8 @@ The wrap-flow property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-
 The wrap-through Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">3.1.1. 
 The wrap-flow property</a>
@@ -1583,8 +1583,8 @@ The wrap-flow property</a>
 Differences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-float-none">
-   <a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-float-none" class="dfn-panel" data-for="term-for-valdef-float-none" id="infopanel-for-term-for-valdef-float-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-float-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-float-none">2. 
 Terminology</a>
@@ -1592,8 +1592,8 @@ Terminology</a>
 The wrap-flow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">3. 
 Exclusions</a>
@@ -1721,8 +1721,8 @@ Exclusions order</a> <a href="#ref-for-propdef-z-index②">(2)</a>
      <a class="issue-return" href="#issue-5c31dc98" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="exclusion-box">
-   <b><a href="#exclusion-box">#exclusion-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusion-box" class="dfn-panel" data-for="exclusion-box" id="infopanel-for-exclusion-box" role="dialog">
+   <span id="infopaneltitle-for-exclusion-box" style="display:none">Info about the 'Exclusion box' definition.</span><b><a href="#exclusion-box">#exclusion-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusion-box">3.5.4. 
 Step 2-A: resolve the position and size of exclusion boxes</a> <a href="#ref-for-exclusion-box①">(2)</a> <a href="#ref-for-exclusion-box②">(3)</a> <a href="#ref-for-exclusion-box③">(4)</a> <a href="#ref-for-exclusion-box④">(5)</a>
@@ -1730,8 +1730,8 @@ Step 2-A: resolve the position and size of exclusion boxes</a> <a href="#ref-for
 Step 2-B: lay out containing block applying wrapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exclusion-area">
-   <b><a href="#exclusion-area">#exclusion-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusion-area" class="dfn-panel" data-for="exclusion-area" id="infopanel-for-exclusion-area" role="dialog">
+   <span id="infopaneltitle-for-exclusion-area" style="display:none">Info about the 'Exclusion area' definition.</span><b><a href="#exclusion-area">#exclusion-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusion-area">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-exclusion-area①">(2)</a>
@@ -1747,15 +1747,15 @@ Step 2-B: lay out containing block applying wrapping</a>
 Effect of exclusions on floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exclusion-element">
-   <b><a href="#exclusion-element">#exclusion-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusion-element" class="dfn-panel" data-for="exclusion-element" id="infopanel-for-exclusion-element" role="dialog">
+   <span id="infopaneltitle-for-exclusion-element" style="display:none">Info about the 'Exclusion element' definition.</span><b><a href="#exclusion-element">#exclusion-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusion-element">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-exclusion-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wrapping-context">
-   <b><a href="#wrapping-context">#wrapping-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wrapping-context" class="dfn-panel" data-for="wrapping-context" id="infopanel-for-wrapping-context" role="dialog">
+   <span id="infopaneltitle-for-wrapping-context" style="display:none">Info about the 'Wrapping context' definition.</span><b><a href="#wrapping-context">#wrapping-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wrapping-context">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-wrapping-context①">(2)</a>
@@ -1781,15 +1781,15 @@ Resolving RWC-1</a>
 Resolving RWC-2</a> <a href="#ref-for-wrapping-context③③">(2)</a> <a href="#ref-for-wrapping-context③④">(3)</a> <a href="#ref-for-wrapping-context③⑤">(4)</a> <a href="#ref-for-wrapping-context③⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-area">
-   <b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-area" class="dfn-panel" data-for="content-area" id="infopanel-for-content-area" role="dialog">
+   <span id="infopaneltitle-for-content-area" style="display:none">Info about the 'Content area' definition.</span><b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outside">
-   <b><a href="#outside">#outside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outside" class="dfn-panel" data-for="outside" id="infopanel-for-outside" role="dialog">
+   <span id="infopaneltitle-for-outside" style="display:none">Info about the 'Outside' definition.</span><b><a href="#outside">#outside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outside">2. 
 Terminology</a>
@@ -1799,8 +1799,8 @@ Propagation of Exclusions</a>
 The wrap-through Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inside">
-   <b><a href="#inside">#inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inside" class="dfn-panel" data-for="inside" id="infopanel-for-inside" role="dialog">
+   <span id="infopaneltitle-for-inside" style="display:none">Info about the 'inside' definition.</span><b><a href="#inside">#inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inside">2. 
 Terminology</a>
@@ -1808,8 +1808,8 @@ Terminology</a>
 The wrap-through Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-wrap-flow">
-   <b><a href="#propdef-wrap-flow">#propdef-wrap-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-wrap-flow" class="dfn-panel" data-for="propdef-wrap-flow" id="infopanel-for-propdef-wrap-flow" role="dialog">
+   <span id="infopaneltitle-for-propdef-wrap-flow" style="display:none">Info about the 'wrap-flow' definition.</span><b><a href="#propdef-wrap-flow">#propdef-wrap-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-flow">2. 
 Terminology</a>
@@ -1821,8 +1821,8 @@ The wrap-flow property</a> <a href="#ref-for-propdef-wrap-flow③">(2)</a> <a hr
 Step 1: resolve exclusion boxes belonging to each wrapping context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-auto">
-   <b><a href="#valdef-wrap-flow-auto">#valdef-wrap-flow-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-auto" class="dfn-panel" data-for="valdef-wrap-flow-auto" id="infopanel-for-valdef-wrap-flow-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-wrap-flow-auto">#valdef-wrap-flow-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-auto">2. 
 Terminology</a>
@@ -1832,50 +1832,50 @@ Declaring exclusions</a>
 The wrap-flow property</a> <a href="#ref-for-valdef-wrap-flow-auto③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-both">
-   <b><a href="#valdef-wrap-flow-both">#valdef-wrap-flow-both</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-both" class="dfn-panel" data-for="valdef-wrap-flow-both" id="infopanel-for-valdef-wrap-flow-both" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-both" style="display:none">Info about the 'both' definition.</span><b><a href="#valdef-wrap-flow-both">#valdef-wrap-flow-both</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-both">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-valdef-wrap-flow-both①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-start">
-   <b><a href="#valdef-wrap-flow-start">#valdef-wrap-flow-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-start" class="dfn-panel" data-for="valdef-wrap-flow-start" id="infopanel-for-valdef-wrap-flow-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-wrap-flow-start">#valdef-wrap-flow-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-start">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-valdef-wrap-flow-start①">(2)</a> <a href="#ref-for-valdef-wrap-flow-start②">(3)</a> <a href="#ref-for-valdef-wrap-flow-start③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-end">
-   <b><a href="#valdef-wrap-flow-end">#valdef-wrap-flow-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-end" class="dfn-panel" data-for="valdef-wrap-flow-end" id="infopanel-for-valdef-wrap-flow-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-wrap-flow-end">#valdef-wrap-flow-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-end">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-valdef-wrap-flow-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-minimum">
-   <b><a href="#valdef-wrap-flow-minimum">#valdef-wrap-flow-minimum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-minimum" class="dfn-panel" data-for="valdef-wrap-flow-minimum" id="infopanel-for-valdef-wrap-flow-minimum" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-minimum" style="display:none">Info about the 'minimum' definition.</span><b><a href="#valdef-wrap-flow-minimum">#valdef-wrap-flow-minimum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-minimum">3.1.1. 
 The wrap-flow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-maximum">
-   <b><a href="#valdef-wrap-flow-maximum">#valdef-wrap-flow-maximum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-maximum" class="dfn-panel" data-for="valdef-wrap-flow-maximum" id="infopanel-for-valdef-wrap-flow-maximum" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-maximum" style="display:none">Info about the 'maximum' definition.</span><b><a href="#valdef-wrap-flow-maximum">#valdef-wrap-flow-maximum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-maximum">3.1.1. 
 The wrap-flow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-flow-clear">
-   <b><a href="#valdef-wrap-flow-clear">#valdef-wrap-flow-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-flow-clear" class="dfn-panel" data-for="valdef-wrap-flow-clear" id="infopanel-for-valdef-wrap-flow-clear" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-flow-clear" style="display:none">Info about the 'clear' definition.</span><b><a href="#valdef-wrap-flow-clear">#valdef-wrap-flow-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-flow-clear">3.1.1. 
 The wrap-flow property</a> <a href="#ref-for-valdef-wrap-flow-clear①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-wrap-through">
-   <b><a href="#propdef-wrap-through">#propdef-wrap-through</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-wrap-through" class="dfn-panel" data-for="propdef-wrap-through" id="infopanel-for-propdef-wrap-through" role="dialog">
+   <span id="infopaneltitle-for-propdef-wrap-through" style="display:none">Info about the 'wrap-through' definition.</span><b><a href="#propdef-wrap-through">#propdef-wrap-through</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-through">2. 
 Terminology</a>
@@ -1887,8 +1887,8 @@ Propagation of Exclusions</a> <a href="#ref-for-propdef-wrap-through③">(2)</a>
 The wrap-through Property</a> <a href="#ref-for-propdef-wrap-through⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-through-none">
-   <b><a href="#valdef-wrap-through-none">#valdef-wrap-through-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-through-none" class="dfn-panel" data-for="valdef-wrap-through-none" id="infopanel-for-valdef-wrap-through-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-through-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-wrap-through-none">#valdef-wrap-through-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-through-none">3.3. 
 Propagation of Exclusions</a> <a href="#ref-for-valdef-wrap-through-none①">(2)</a>
@@ -1896,57 +1896,113 @@ Propagation of Exclusions</a> <a href="#ref-for-valdef-wrap-through-none①">(2)
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-extensions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-extensions-1/Overview.html
@@ -1012,71 +1012,71 @@ CSS.customSelector.set("_foo",
    <li><a href="#declarative-custom-selector">declarative custom selector</a><span>, in § 3</span>
    <li><a href="#typedef-extension-name">&lt;extension-name></a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">4. 
 Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-lab-a">
-   <a href="https://drafts.csswg.org/css-color-5/#valdef-lab-a">https://drafts.csswg.org/css-color-5/#valdef-lab-a</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-lab-a" class="dfn-panel" data-for="term-for-valdef-lab-a" id="infopanel-for-term-for-valdef-lab-a" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-lab-a" style="display:none">Info about the 'a' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#valdef-lab-a">https://drafts.csswg.org/css-color-5/#valdef-lab-a</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-lab-a">6. 
 Custom Selector Combinators</a> <a href="#ref-for-valdef-lab-a①">(2)</a> <a href="#ref-for-valdef-lab-a②">(3)</a> <a href="#ref-for-valdef-lab-a③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">4. 
 Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">3. 
 Custom Selectors</a> <a href="#ref-for-typedef-ident-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-3/#css-css-identifier">https://drafts.csswg.org/css-values-3/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#css-css-identifier">https://drafts.csswg.org/css-values-3/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">2. 
 Extension Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4. 
 Custom Properties</a> <a href="#ref-for-length-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3. 
 Custom Selectors</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">4. 
 Custom Properties</a>
@@ -1084,22 +1084,22 @@ Custom Properties</a>
 Custom Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-matches-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-matches-pseudo" class="dfn-panel" data-for="term-for-matches-pseudo" id="infopanel-for-term-for-matches-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-matches-pseudo" style="display:none">Info about the ':is()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-pseudo">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-selector-list">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">https://drafts.csswg.org/selectors-4/#typedef-selector-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-selector-list" class="dfn-panel" data-for="term-for-typedef-selector-list" id="infopanel-for-term-for-typedef-selector-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-selector-list" style="display:none">Info about the '&lt;selector-list>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">https://drafts.csswg.org/selectors-4/#typedef-selector-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-selector-list">3. 
 Custom Selectors</a> <a href="#ref-for-typedef-selector-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-class" class="dfn-panel" data-for="term-for-pseudo-class" id="infopanel-for-term-for-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-class" style="display:none">Info about the 'pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">3. 
 Custom Selectors</a>
@@ -1355,8 +1355,8 @@ CSS.customSelector.set("_foo",
      <a class="issue-return" href="#issue-329c3458" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-extension-name">
-   <b><a href="#typedef-extension-name">#typedef-extension-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-extension-name" class="dfn-panel" data-for="typedef-extension-name" id="infopanel-for-typedef-extension-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-extension-name" style="display:none">Info about the '&lt;extension-name>' definition.</span><b><a href="#typedef-extension-name">#typedef-extension-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-extension-name">2. 
 Extension Names</a>
@@ -1364,29 +1364,29 @@ Extension Names</a>
 Custom Selectors</a> <a href="#ref-for-typedef-extension-name②">(2)</a> <a href="#ref-for-typedef-extension-name③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-selector">
-   <b><a href="#custom-selector">#custom-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-selector" class="dfn-panel" data-for="custom-selector" id="infopanel-for-custom-selector" role="dialog">
+   <span id="infopaneltitle-for-custom-selector" style="display:none">Info about the 'Custom Selectors' definition.</span><b><a href="#custom-selector">#custom-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-selector">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-custom-selector">
-   <b><a href="#at-ruledef-custom-selector">#at-ruledef-custom-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-custom-selector" class="dfn-panel" data-for="at-ruledef-custom-selector" id="infopanel-for-at-ruledef-custom-selector" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-custom-selector" style="display:none">Info about the '@custom-selector' definition.</span><b><a href="#at-ruledef-custom-selector">#at-ruledef-custom-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-custom-selector">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-custom-selector">
-   <b><a href="#typedef-custom-selector">#typedef-custom-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-custom-selector" class="dfn-panel" data-for="typedef-custom-selector" id="infopanel-for-typedef-custom-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-custom-selector" style="display:none">Info about the '&lt;custom-selector>' definition.</span><b><a href="#typedef-custom-selector">#typedef-custom-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-selector">3. 
 Custom Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-custom-arg">
-   <b><a href="#typedef-custom-arg">#typedef-custom-arg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-custom-arg" class="dfn-panel" data-for="typedef-custom-arg" id="infopanel-for-typedef-custom-arg" role="dialog">
+   <span id="infopaneltitle-for-typedef-custom-arg" style="display:none">Info about the '&lt;custom-arg>' definition.</span><b><a href="#typedef-custom-arg">#typedef-custom-arg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-arg">3. 
 Custom Selectors</a> <a href="#ref-for-typedef-custom-arg①">(2)</a>
@@ -1394,57 +1394,113 @@ Custom Selectors</a> <a href="#ref-for-typedef-custom-arg①">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-flexbox-1/Overview.html
@@ -6050,64 +6050,64 @@ Boris Zbarsky.</p>
    <li><a href="#valdef-flex-wrap-wrap">wrap</a><span>, in § 5.2</span>
    <li><a href="#valdef-flex-wrap-wrap-reverse">wrap-reverse</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-baseline" class="dfn-panel" data-for="term-for-alignment-baseline" id="infopanel-for-term-for-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-baseline" style="display:none">Info about the 'alignment baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-baseline">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-alignment-baseline①">(2)</a> <a href="#ref-for-alignment-baseline②">(3)</a> <a href="#ref-for-alignment-baseline③">(4)</a> <a href="#ref-for-alignment-baseline④">(5)</a>
     <li><a href="#ref-for-alignment-baseline⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-alignment-baseline⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-alignment-container">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-container" class="dfn-panel" data-for="term-for-alignment-container" id="infopanel-for-term-for-alignment-container" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-container" style="display:none">Info about the 'alignment container' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-container">4.1. 
 Absolutely-Positioned Flex Children</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-alignment-context">
-   <a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-alignment-context" class="dfn-panel" data-for="term-for-shared-alignment-context" id="infopanel-for-term-for-shared-alignment-context" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-alignment-context" style="display:none">Info about the 'alignment context' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-alignment-context">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-shared-alignment-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-set" class="dfn-panel" data-for="term-for-baseline-set" id="infopanel-for-term-for-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-set" style="display:none">Info about the 'baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-set">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-baseline-set①">(2)</a>
     <li><a href="#ref-for-baseline-set②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-baseline-set③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generate-baselines">
-   <a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generate-baselines" class="dfn-panel" data-for="term-for-generate-baselines" id="infopanel-for-term-for-generate-baselines" role="menu">
+   <span id="infopaneltitle-for-term-for-generate-baselines" style="display:none">Info about the 'generate baselines' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-baselines">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-generate-baselines①">(2)</a> <a href="#ref-for-generate-baselines②">(3)</a>
     <li><a href="#ref-for-generate-baselines③"> Substantive Changes and Bugfixes</a> <a href="#ref-for-generate-baselines④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-last-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#last-baseline-alignment">https://drafts.csswg.org/css-align-3/#last-baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-last-baseline-alignment" class="dfn-panel" data-for="term-for-last-baseline-alignment" id="infopanel-for-term-for-last-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-last-baseline-alignment" style="display:none">Info about the 'last-baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#last-baseline-alignment">https://drafts.csswg.org/css-align-3/#last-baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-alignment"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start"> Substantive Changes and Bugfixes</a> <a href="#ref-for-valdef-self-position-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-synthesize-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-synthesize-baseline" class="dfn-panel" data-for="term-for-synthesize-baseline" id="infopanel-for-term-for-synthesize-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-synthesize-baseline" style="display:none">Info about the 'synthesize baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">8.3. 
 Cross-axis Alignment: the align-items and align-self properties</a>
@@ -6115,8 +6115,8 @@ Cross-axis Alignment: the align-items and align-self properties</a>
 Flex Container Baselines</a> <a href="#ref-for-synthesize-baseline②">(2)</a> <a href="#ref-for-synthesize-baseline③">(3)</a> <a href="#ref-for-synthesize-baseline④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-synthesize-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-synthesize-baseline" class="dfn-panel" data-for="term-for-synthesize-baseline" id="infopanel-for-term-for-synthesize-baseline①" role="menu">
+   <span id="infopaneltitle-for-term-for-synthesize-baseline①" style="display:none">Info about the 'synthesized baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">8.3. 
 Cross-axis Alignment: the align-items and align-self properties</a>
@@ -6124,22 +6124,22 @@ Cross-axis Alignment: the align-items and align-self properties</a>
 Flex Container Baselines</a> <a href="#ref-for-synthesize-baseline②">(2)</a> <a href="#ref-for-synthesize-baseline③">(3)</a> <a href="#ref-for-synthesize-baseline④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">10. 
 Fragmenting Flex Layout</a> <a href="#ref-for-fragmentation-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">10. 
 Fragmenting Flex Layout</a> <a href="#ref-for-fragmentation-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4. 
 Flex Items</a>
@@ -6148,15 +6148,15 @@ Fragmenting Flex Layout</a>
     <li><a href="#ref-for-computed-value②"> Changes since the 16 October 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">7.1.1. 
 Basic Values of flex</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">9.2. 
 Line Length Determination</a> <a href="#ref-for-used-value①">(2)</a>
@@ -6165,29 +6165,29 @@ Resolving Flexible Lengths</a>
     <li><a href="#ref-for-used-value③"> Changes since the 16 October 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">4. 
 Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">4.2. 
 Flex Item Margins and Paddings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">4. 
 Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">3. 
 Flex Containers: the flex and inline-flex display values</a>
@@ -6195,30 +6195,30 @@ Flex Containers: the flex and inline-flex display values</a>
 Line Length Determination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">9.4. 
 Cross Size Determination</a>
     <li><a href="#ref-for-block-level-box①"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">4. 
 Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">4.2. 
 Flex Item Margins and Paddings</a> <a href="#ref-for-containing-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">1.2. 
 Module interactions</a>
@@ -6234,45 +6234,45 @@ Collapsed Items</a>
     <li><a href="#ref-for-propdef-display②④"> Clarifications</a> <a href="#ref-for-propdef-display②⑤">(2)</a> <a href="#ref-for-propdef-display②⑥">(3)</a> <a href="#ref-for-propdef-display②⑦">(4)</a> <a href="#ref-for-propdef-display②⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">4. 
 Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-layout" class="dfn-panel" data-for="term-for-flow-layout" id="infopanel-for-term-for-flow-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-layout" style="display:none">Info about the 'flow layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">3. 
 Flex Containers: the flex and inline-flex display values</a> <a href="#ref-for-flow-layout①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">9.6. 
 Cross-Axis Alignment</a>
     <li><a href="#ref-for-formatting-context①"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">9.4. 
 Cross Size Determination</a>
     <li><a href="#ref-for-in-flow①"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">3. 
 Flex Containers: the flex and inline-flex display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">4. 
 Flex Items</a>
@@ -6281,22 +6281,22 @@ Automatic Minimum Size of Flex Items</a>
     <li><a href="#ref-for-replaced-element②"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">4. 
 Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">4. 
 Flex Items</a> <a href="#ref-for-text-run①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">4.4. 
 Collapsed Items</a> <a href="#ref-for-propdef-visibility①">(2)</a> <a href="#ref-for-propdef-visibility②">(3)</a>
@@ -6304,21 +6304,21 @@ Collapsed Items</a> <a href="#ref-for-propdef-visibility①">(2)</a> <a href="#r
 Cross Size Determination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-size">
-   <a href="https://drafts.csswg.org/css-images-3/#specified-size">https://drafts.csswg.org/css-images-3/#specified-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-size" class="dfn-panel" data-for="term-for-specified-size" id="infopanel-for-term-for-specified-size" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-size" style="display:none">Info about the 'specified size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#specified-size">https://drafts.csswg.org/css-images-3/#specified-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size"> Substantive Changes and Bugfixes</a> <a href="#ref-for-specified-size①">(2)</a> <a href="#ref-for-specified-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3. 
 Flex Containers: the flex and inline-flex display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3. 
 Flex Containers: the flex and inline-flex display values</a>
@@ -6328,67 +6328,67 @@ Flex Container Baselines</a>
     <li><a href="#ref-for-propdef-overflow③"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-overflow④">(2)</a> <a href="#ref-for-propdef-overflow⑤">(3)</a> <a href="#ref-for-propdef-overflow⑥">(4)</a> <a href="#ref-for-propdef-overflow⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-scroll-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible"> Clarifications</a>
     <li><a href="#ref-for-valdef-overflow-visible①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-valdef-overflow-visible②">(2)</a> <a href="#ref-for-valdef-overflow-visible③">(3)</a> <a href="#ref-for-valdef-overflow-visible④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">4.3. 
 Flex Item Z-Ordering</a> <a href="#ref-for-propdef-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">4.3. 
 Flex Item Z-Ordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">4.3. 
 Flex Item Z-Ordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.2. 
 Module interactions</a>
@@ -6397,8 +6397,8 @@ Flex Containers: the flex and inline-flex display values</a>
     <li><a href="#ref-for-selectordef-first-letter②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.2. 
 Module interactions</a>
@@ -6407,15 +6407,15 @@ Flex Containers: the flex and inline-flex display values</a>
     <li><a href="#ref-for-selectordef-first-line②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-formatted-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-formatted-line" class="dfn-panel" data-for="term-for-first-formatted-line" id="infopanel-for-term-for-first-formatted-line" role="menu">
+   <span id="infopaneltitle-for-term-for-first-formatted-line" style="display:none">Info about the 'first formatted line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line">3. 
 Flex Containers: the flex and inline-flex display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">4.5. 
 Automatic Minimum Size of Flex Items</a>
@@ -6438,15 +6438,15 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-valdef-width-auto①④"> Clarifications</a> <a href="#ref-for-valdef-width-auto①⑤">(2)</a> <a href="#ref-for-valdef-width-auto①⑥">(3)</a> <a href="#ref-for-valdef-width-auto②④">(4)</a> <a href="#ref-for-valdef-width-auto②⑤">(5)</a> <a href="#ref-for-valdef-width-auto②⑥">(6)</a> <a href="#ref-for-valdef-width-auto②⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-block-size">https://drafts.csswg.org/css-sizing-3/#automatic-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-block-size" class="dfn-panel" data-for="term-for-automatic-block-size" id="infopanel-for-term-for-automatic-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-block-size" style="display:none">Info about the 'automatic block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-block-size">https://drafts.csswg.org/css-sizing-3/#automatic-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-block-size">9.2. 
 Line Length Determination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-minimum-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-minimum-size" class="dfn-panel" data-for="term-for-automatic-minimum-size" id="infopanel-for-term-for-automatic-minimum-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-automatic-minimum-size①">(2)</a> <a href="#ref-for-automatic-minimum-size②">(3)</a>
@@ -6455,8 +6455,8 @@ Automatic Minimum Size of Flex Items</a> <a href="#ref-for-automatic-minimum-siz
     <li><a href="#ref-for-automatic-minimum-size⑦"> Clarifications</a> <a href="#ref-for-automatic-minimum-size⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">7.1. 
 The flex Shorthand</a>
@@ -6464,8 +6464,8 @@ The flex Shorthand</a>
 Definite and Indefinite Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">9.2. 
 Line Length Determination</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a>
@@ -6475,15 +6475,15 @@ Flex Container Intrinsic Cross Sizes</a>
     <li><a href="#ref-for-available⑥"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto" style="display:none">Info about the 'behave as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">4.5. 
 Automatic Minimum Size of Flex Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">7.2.3. 
 The flex-basis property</a>
@@ -6492,15 +6492,15 @@ Line Length Determination</a> <a href="#ref-for-propdef-box-sizing②">(2)</a>
     <li><a href="#ref-for-propdef-box-sizing③"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-box-sizing④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite①③">9.8. 
 Definite and Indefinite Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-height①">(2)</a>
@@ -6520,37 +6520,37 @@ Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-propdef-height①�
     <li><a href="#ref-for-propdef-height①⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-height①⑥">(2)</a> <a href="#ref-for-propdef-height①⑦">(3)</a> <a href="#ref-for-propdef-height①⑧">(4)</a> <a href="#ref-for-propdef-height①⑨">(5)</a> <a href="#ref-for-propdef-height②⓪">(6)</a> <a href="#ref-for-propdef-height②①">(7)</a> <a href="#ref-for-propdef-height②②">(8)</a> <a href="#ref-for-propdef-height②③">(9)</a> <a href="#ref-for-propdef-height②④">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indefinite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indefinite" class="dfn-panel" data-for="term-for-indefinite" id="infopanel-for-term-for-indefinite" role="menu">
+   <span id="infopaneltitle-for-term-for-indefinite" style="display:none">Info about the 'indefinite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">9.8. 
 Definite and Indefinite Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">9.3. 
 Main Size Determination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">4.5. 
 Automatic Minimum Size of Flex Items</a>
     <li><a href="#ref-for-intrinsic-size-contribution①"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-sizing" class="dfn-panel" data-for="term-for-intrinsic-sizing" id="infopanel-for-term-for-intrinsic-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-sizing" style="display:none">Info about the 'intrinsic sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-sizing">9.9. 
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">7.1. 
 The flex Shorthand</a>
@@ -6568,8 +6568,8 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-max-content①①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-max-content①②">(2)</a> <a href="#ref-for-max-content①③">(3)</a> <a href="#ref-for-max-content①④">(4)</a> <a href="#ref-for-max-content①⑤">(5)</a> <a href="#ref-for-max-content①⑥">(6)</a> <a href="#ref-for-max-content①⑦">(7)</a> <a href="#ref-for-max-content①⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content (for width)' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">4.5. 
 Automatic Minimum Size of Flex Items</a>
@@ -6579,8 +6579,8 @@ Line Length Determination</a>
     <li><a href="#ref-for-valdef-width-max-content④"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-constraint" class="dfn-panel" data-for="term-for-max-content-constraint" id="infopanel-for-term-for-max-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-constraint" style="display:none">Info about the 'max-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-constraint">9.2. 
 Line Length Determination</a>
@@ -6589,8 +6589,8 @@ Flex Container Intrinsic Cross Sizes</a>
     <li><a href="#ref-for-max-content-constraint②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-max-content-constraint③">(2)</a> <a href="#ref-for-max-content-constraint④">(3)</a> <a href="#ref-for-max-content-constraint⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-contribution" class="dfn-panel" data-for="term-for-max-content-contribution" id="infopanel-for-term-for-max-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-contribution" style="display:none">Info about the 'max-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-contribution">9.9.1. 
 Flex Container Intrinsic Main Sizes</a> <a href="#ref-for-max-content-contribution①">(2)</a> <a href="#ref-for-max-content-contribution②">(3)</a>
@@ -6602,8 +6602,8 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-max-content-contribution⑥"> Substantive Changes and Bugfixes</a> <a href="#ref-for-max-content-contribution⑦">(2)</a> <a href="#ref-for-max-content-contribution⑧">(3)</a> <a href="#ref-for-max-content-contribution⑨">(4)</a> <a href="#ref-for-max-content-contribution①⓪">(5)</a> <a href="#ref-for-max-content-contribution①①">(6)</a> <a href="#ref-for-max-content-contribution①②">(7)</a> <a href="#ref-for-max-content-contribution①③">(8)</a> <a href="#ref-for-max-content-contribution①④">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content①" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content①" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">7.1. 
 The flex Shorthand</a>
@@ -6621,15 +6621,15 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-max-content①①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-max-content①②">(2)</a> <a href="#ref-for-max-content①③">(3)</a> <a href="#ref-for-max-content①④">(4)</a> <a href="#ref-for-max-content①⑤">(5)</a> <a href="#ref-for-max-content①⑥">(6)</a> <a href="#ref-for-max-content①⑦">(7)</a> <a href="#ref-for-max-content①⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'maximum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-max-width①">(2)</a> <a href="#ref-for-max-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-min-content①">(2)</a>
@@ -6643,16 +6643,16 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-min-content⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-min-content①⓪">(2)</a> <a href="#ref-for-min-content①①">(3)</a> <a href="#ref-for-min-content①②">(4)</a> <a href="#ref-for-min-content①③">(5)</a> <a href="#ref-for-min-content①④">(6)</a> <a href="#ref-for-min-content①⑤">(7)</a> <a href="#ref-for-min-content①⑥">(8)</a> <a href="#ref-for-min-content①⑦">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content (for width)' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">4.5. 
 Automatic Minimum Size of Flex Items</a>
     <li><a href="#ref-for-valdef-width-min-content①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-valdef-width-min-content②">(2)</a> <a href="#ref-for-valdef-width-min-content③">(3)</a> <a href="#ref-for-valdef-width-min-content④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-constraint" class="dfn-panel" data-for="term-for-min-content-constraint" id="infopanel-for-term-for-min-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-constraint" style="display:none">Info about the 'min-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-constraint">9.2. 
 Line Length Determination</a>
@@ -6661,8 +6661,8 @@ Flex Container Intrinsic Cross Sizes</a>
     <li><a href="#ref-for-min-content-constraint②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-min-content-constraint③">(2)</a> <a href="#ref-for-min-content-constraint④">(3)</a> <a href="#ref-for-min-content-constraint⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-contribution" class="dfn-panel" data-for="term-for-min-content-contribution" id="infopanel-for-term-for-min-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">9.9.2. 
 Flex Container Intrinsic Cross Sizes</a> <a href="#ref-for-min-content-contribution①">(2)</a> <a href="#ref-for-min-content-contribution②">(3)</a>
@@ -6672,8 +6672,8 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-min-content-contribution⑥"> Substantive Changes and Bugfixes</a> <a href="#ref-for-min-content-contribution⑦">(2)</a> <a href="#ref-for-min-content-contribution⑧">(3)</a> <a href="#ref-for-min-content-contribution⑨">(4)</a> <a href="#ref-for-min-content-contribution①⓪">(5)</a> <a href="#ref-for-min-content-contribution①①">(6)</a> <a href="#ref-for-min-content-contribution①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content①" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content①" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-min-content①">(2)</a>
@@ -6687,15 +6687,15 @@ Flex Item Intrinsic Size Contributions</a>
     <li><a href="#ref-for-min-content⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-min-content①⓪">(2)</a> <a href="#ref-for-min-content①①">(3)</a> <a href="#ref-for-min-content①②">(4)</a> <a href="#ref-for-min-content①③">(5)</a> <a href="#ref-for-min-content①④">(6)</a> <a href="#ref-for-min-content①⑤">(7)</a> <a href="#ref-for-min-content①⑥">(8)</a> <a href="#ref-for-min-content①⑦">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-min-width①">(2)</a> <a href="#ref-for-min-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">9.3. 
 Main Size Determination</a>
@@ -6703,8 +6703,8 @@ Main Size Determination</a>
 Definite and Indefinite Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size" class="dfn-panel" data-for="term-for-preferred-size" id="infopanel-for-term-for-preferred-size" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size" style="display:none">Info about the 'preferred size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-preferred-size①">(2)</a>
@@ -6715,8 +6715,8 @@ Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-preferred-size④">
     <li><a href="#ref-for-preferred-size⑤"> Changes since the 16 October 2017 CR</a> <a href="#ref-for-preferred-size⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-width①">(2)</a>
@@ -6739,20 +6739,20 @@ Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-propdef-width①⑦
     <li><a href="#ref-for-propdef-width②④"> Clarifications</a> <a href="#ref-for-propdef-width②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-preferred-aspect-ratio①">(2)</a>
@@ -6765,38 +6765,38 @@ Cross Size Determination</a>
     <li><a href="#ref-for-preferred-aspect-ratio⑥"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">4. 
 Flex Items</a>
     <li><a href="#ref-for-propdef-white-space①"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">10. 
 Fragmenting Flex Layout</a>
     <li><a href="#ref-for-propdef-text-decoration①"> Changes since the 16 October 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">5.4. 
 Display Order: the order property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">7.2.3. 
 The flex-basis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">7.1. 
 The flex Shorthand</a> <a href="#ref-for-number-value①">(2)</a>
@@ -6808,28 +6808,28 @@ The flex-grow property</a> <a href="#ref-for-number-value⑤">(2)</a>
 The flex-shrink property</a> <a href="#ref-for-number-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">7.1. 
 The flex Shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-bracketed-range-notation">
-   <a href="https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation">https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-bracketed-range-notation" class="dfn-panel" data-for="term-for-css-bracketed-range-notation" id="infopanel-for-term-for-css-bracketed-range-notation" role="menu">
+   <span id="infopaneltitle-for-term-for-css-bracketed-range-notation" style="display:none">Info about the 'css bracketed range notation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation">https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-bracketed-range-notation"> Changes since the 19 November 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.3. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3. 
 Flex Containers: the flex and inline-flex display values</a>
@@ -6849,8 +6849,8 @@ Cross-axis Alignment: the align-items and align-self properties</a> <a href="#re
 Packing Flex Lines: the align-content property</a> <a href="#ref-for-comb-one②②">(2)</a> <a href="#ref-for-comb-one②③">(3)</a> <a href="#ref-for-comb-one②④">(4)</a> <a href="#ref-for-comb-one②⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">5.3. 
 Flex Direction and Wrap: the flex-flow shorthand</a>
@@ -6858,22 +6858,22 @@ Flex Direction and Wrap: the flex-flow shorthand</a>
 The flex Shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">5.1. 
 Flex Flow Direction: the flex-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">5.1. 
 Flex Flow Direction: the flex-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">4.1. 
 Absolutely-Positioned Flex Children</a>
@@ -6885,14 +6885,14 @@ Flex Line Wrapping: the flex-wrap property</a>
 Cross-Axis Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb" id="infopanel-for-term-for-valdef-writing-mode-horizontal-tb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">5.1. 
 Flex Flow Direction: the flex-direction property</a>
@@ -6900,22 +6900,22 @@ Flex Flow Direction: the flex-direction property</a>
 Flex Container Baselines</a> <a href="#ref-for-inline-axis②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">4.2. 
 Flex Item Margins and Paddings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">5.1. 
 Flex Flow Direction: the flex-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">4.1. 
 Absolutely-Positioned Flex Children</a>
@@ -6927,26 +6927,26 @@ Flex Line Wrapping: the flex-wrap property</a>
 Cross-Axis Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-direction-ltr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-rtl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-rtl" class="dfn-panel" data-for="term-for-valdef-direction-rtl" id="infopanel-for-term-for-valdef-direction-rtl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl"> Appendix A: Axis Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl" id="infopanel-for-term-for-valdef-writing-mode-vertical-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl"> Appendix A: Axis Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">2. 
 Flex Layout Box Model and Terminology</a>
@@ -6963,28 +6963,28 @@ Line Length Determination</a> <a href="#ref-for-writing-mode⑨">(2)</a>
     <li><a href="#ref-for-writing-mode①⓪"> Appendix A: Axis Mappings</a> <a href="#ref-for-writing-mode①①">(2)</a> <a href="#ref-for-writing-mode①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">5.1. 
 Flex Flow Direction: the flex-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-table-layout-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-table-layout-auto">https://drafts.csswg.org/css2/#valdef-table-layout-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-table-layout-auto" class="dfn-panel" data-for="term-for-valdef-table-layout-auto" id="infopanel-for-term-for-valdef-table-layout-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-table-layout-auto" style="display:none">Info about the 'auto (for table-layout)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-table-layout-auto">https://drafts.csswg.org/css2/#valdef-table-layout-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-table-layout-auto"> Changes since the 16 October 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto (for z-index)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">4.3. 
 Flex Item Z-Ordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">3. 
 Flex Containers: the flex and inline-flex display values</a>
@@ -6994,8 +6994,8 @@ Ordering and Orientation</a>
     <li><a href="#ref-for-propdef-clear④"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">3. 
 Flex Containers: the flex and inline-flex display values</a>
@@ -7005,15 +7005,15 @@ Ordering and Orientation</a>
     <li><a href="#ref-for-propdef-float⑤"> Clarifications</a> <a href="#ref-for-propdef-float⑥">(2)</a> <a href="#ref-for-propdef-float⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">8. 
 Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-max-height①">(2)</a>
@@ -7022,8 +7022,8 @@ Cross-axis Alignment: the align-items and align-self properties</a>
     <li><a href="#ref-for-propdef-max-height③"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-max-height④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-max-width①">(2)</a>
@@ -7031,8 +7031,8 @@ Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-max-width①
 Cross-axis Alignment: the align-items and align-self properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-min-height①">(2)</a>
@@ -7046,8 +7046,8 @@ Cross-axis Alignment: the align-items and align-self properties</a>
     <li><a href="#ref-for-propdef-min-height⑦"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-min-height⑧">(2)</a> <a href="#ref-for-propdef-min-height⑨">(3)</a> <a href="#ref-for-propdef-min-height①⓪">(4)</a> <a href="#ref-for-propdef-min-height①①">(5)</a> <a href="#ref-for-propdef-min-height①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-propdef-min-width①">(2)</a>
@@ -7061,27 +7061,27 @@ Cross-axis Alignment: the align-items and align-self properties</a>
     <li><a href="#ref-for-propdef-min-width⑧"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-min-width⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">4.3. 
 Flex Item Z-Ordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">10. 
 Fragmenting Flex Layout</a> <a href="#ref-for-propdef-break-after①">(2)</a> <a href="#ref-for-propdef-break-after②">(3)</a>
@@ -7089,8 +7089,8 @@ Fragmenting Flex Layout</a> <a href="#ref-for-propdef-break-after①">(2)</a> <a
     <li><a href="#ref-for-propdef-break-after⑤"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">10. 
 Fragmenting Flex Layout</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-for-propdef-break-before②">(3)</a> <a href="#ref-for-propdef-break-before③">(4)</a>
@@ -7098,35 +7098,35 @@ Fragmenting Flex Layout</a> <a href="#ref-for-propdef-break-before①">(2)</a> <
     <li><a href="#ref-for-propdef-break-before⑥"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.1. 
 Flex Flow Direction: the flex-direction property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">8.1. 
 Aligning with auto margins</a>
     <li><a href="#ref-for-css-end①"> Appendix A: Axis Mappings</a> <a href="#ref-for-css-end②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start"> Appendix A: Axis Mappings</a> <a href="#ref-for-css-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value"> Changes since the 16 October 2017 CR</a>
    </ul>
@@ -7522,8 +7522,8 @@ Aligning with auto margins</a>
       <td>specified integer
    </table>
   </div>
-  <aside class="dfn-panel" data-for="flex-container">
-   <b><a href="#flex-container">#flex-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-container" class="dfn-panel" data-for="flex-container" id="infopanel-for-flex-container" role="dialog">
+   <span id="infopaneltitle-for-flex-container" style="display:none">Info about the 'flex container' definition.</span><b><a href="#flex-container">#flex-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-flex-container①">(2)</a>
@@ -7572,8 +7572,8 @@ Fragmenting Flex Layout</a> <a href="#ref-for-flex-container⑥⑧">(2)</a>
     <li><a href="#ref-for-flex-container⑦⑤"> Clarifications</a> <a href="#ref-for-flex-container⑦⑥">(2)</a> <a href="#ref-for-flex-container⑨⑧">(3)</a> <a href="#ref-for-flex-container①①⓪">(4)</a> <a href="#ref-for-flex-container①①①">(5)</a> <a href="#ref-for-flex-container①①②">(6)</a> <a href="#ref-for-flex-container①①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-item">
-   <b><a href="#flex-item">#flex-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-item" class="dfn-panel" data-for="flex-item" id="infopanel-for-flex-item" role="dialog">
+   <span id="infopaneltitle-for-flex-item" style="display:none">Info about the 'flex items' definition.</span><b><a href="#flex-item">#flex-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-flex-item①">(2)</a> <a href="#ref-for-flex-item②">(3)</a> <a href="#ref-for-flex-item③">(4)</a>
@@ -7632,8 +7632,8 @@ Fragmenting Flex Layout</a>
     <li><a href="#ref-for-flex-item①④⓪"> Clarifications</a> <a href="#ref-for-flex-item①④①">(2)</a> <a href="#ref-for-flex-item①④②">(3)</a> <a href="#ref-for-flex-item①④③">(4)</a> <a href="#ref-for-flex-item①⑨②">(5)</a> <a href="#ref-for-flex-item①⑨③">(6)</a> <a href="#ref-for-flex-item①⑨④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-axis">
-   <b><a href="#main-axis">#main-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-axis" class="dfn-panel" data-for="main-axis" id="infopanel-for-main-axis" role="dialog">
+   <span id="infopaneltitle-for-main-axis" style="display:none">Info about the 'main axis' definition.</span><b><a href="#main-axis">#main-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-axis">1.1. 
 Overview</a> <a href="#ref-for-main-axis①">(2)</a>
@@ -7658,8 +7658,8 @@ Flex Container Baselines</a> <a href="#ref-for-main-axis①④">(2)</a>
     <li><a href="#ref-for-main-axis①⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-main-axis②⓪">(2)</a> <a href="#ref-for-main-axis②①">(3)</a> <a href="#ref-for-main-axis②②">(4)</a> <a href="#ref-for-main-axis②③">(5)</a> <a href="#ref-for-main-axis②④">(6)</a> <a href="#ref-for-main-axis②⑤">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-dimension">
-   <b><a href="#main-dimension">#main-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-dimension" class="dfn-panel" data-for="main-dimension" id="infopanel-for-main-dimension" role="dialog">
+   <span id="infopaneltitle-for-main-dimension" style="display:none">Info about the 'main dimension' definition.</span><b><a href="#main-dimension">#main-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-dimension">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-main-dimension①">(2)</a> <a href="#ref-for-main-dimension②">(3)</a>
@@ -7667,8 +7667,8 @@ Flex Layout Box Model and Terminology</a> <a href="#ref-for-main-dimension①">(
 Flexibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-start">
-   <b><a href="#main-start">#main-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-start" class="dfn-panel" data-for="main-start" id="infopanel-for-main-start" role="dialog">
+   <span id="infopaneltitle-for-main-start" style="display:none">Info about the 'main-start' definition.</span><b><a href="#main-start">#main-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-start">5.1. 
 Flex Flow Direction: the flex-direction property</a> <a href="#ref-for-main-start①">(2)</a> <a href="#ref-for-main-start②">(3)</a> <a href="#ref-for-main-start③">(4)</a>
@@ -7678,8 +7678,8 @@ Axis Alignment: the justify-content property</a> <a href="#ref-for-main-start⑤
     <li><a href="#ref-for-main-start①①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-main-start①②">(2)</a> <a href="#ref-for-main-start①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-end">
-   <b><a href="#main-end">#main-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-end" class="dfn-panel" data-for="main-end" id="infopanel-for-main-end" role="dialog">
+   <span id="infopaneltitle-for-main-end" style="display:none">Info about the 'main-end' definition.</span><b><a href="#main-end">#main-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-end">5.1. 
 Flex Flow Direction: the flex-direction property</a> <a href="#ref-for-main-end①">(2)</a> <a href="#ref-for-main-end②">(3)</a> <a href="#ref-for-main-end③">(4)</a>
@@ -7689,8 +7689,8 @@ Axis Alignment: the justify-content property</a> <a href="#ref-for-main-end⑤">
     <li><a href="#ref-for-main-end①①"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-size">
-   <b><a href="#main-size">#main-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-size" class="dfn-panel" data-for="main-size" id="infopanel-for-main-size" role="dialog">
+   <span id="infopaneltitle-for-main-size" style="display:none">Info about the 'main size' definition.</span><b><a href="#main-size">#main-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-size">4.4. 
 Collapsed Items</a>
@@ -7719,8 +7719,8 @@ Flex Container Intrinsic Main Sizes</a> <a href="#ref-for-main-size②⑨">(2)</
     <li><a href="#ref-for-main-size③③"> Clarifications</a> <a href="#ref-for-main-size③④">(2)</a> <a href="#ref-for-main-size③⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-size-property">
-   <b><a href="#main-size-property">#main-size-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-size-property" class="dfn-panel" data-for="main-size-property" id="infopanel-for-main-size-property" role="dialog">
+   <span id="infopaneltitle-for-main-size-property" style="display:none">Info about the 'main size property' definition.</span><b><a href="#main-size-property">#main-size-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-size-property">7.1. 
 The flex Shorthand</a> <a href="#ref-for-main-size-property①">(2)</a>
@@ -7729,22 +7729,22 @@ Basic Values of flex</a>
     <li><a href="#ref-for-main-size-property③"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-main-size-property">
-   <b><a href="#min-main-size-property">#min-main-size-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-main-size-property" class="dfn-panel" data-for="min-main-size-property" id="infopanel-for-min-main-size-property" role="dialog">
+   <span id="infopaneltitle-for-min-main-size-property" style="display:none">Info about the 'min' definition.</span><b><a href="#min-main-size-property">#min-main-size-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-main-size-property"> Changes since the 16 October 2017 CR</a> <a href="#ref-for-min-main-size-property①">(2)</a>
     <li><a href="#ref-for-min-main-size-property②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-min-main-size-property③">(2)</a> <a href="#ref-for-min-main-size-property④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-main-size-property">
-   <b><a href="#max-main-size-property">#max-main-size-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-main-size-property" class="dfn-panel" data-for="max-main-size-property" id="infopanel-for-max-main-size-property" role="dialog">
+   <span id="infopaneltitle-for-max-main-size-property" style="display:none">Info about the 'max main size properties' definition.</span><b><a href="#max-main-size-property">#max-main-size-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-main-size-property"> Changes since the 16 October 2017 CR</a> <a href="#ref-for-max-main-size-property①">(2)</a>
     <li><a href="#ref-for-max-main-size-property②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-max-main-size-property③">(2)</a> <a href="#ref-for-max-main-size-property④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-main-size">
-   <b><a href="#min-main-size">#min-main-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-main-size" class="dfn-panel" data-for="min-main-size" id="infopanel-for-min-main-size" role="dialog">
+   <span id="infopaneltitle-for-min-main-size" style="display:none">Info about the 'min' definition.</span><b><a href="#min-main-size">#min-main-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-main-size">9.9.1. 
 Flex Container Intrinsic Main Sizes</a>
@@ -7752,8 +7752,8 @@ Flex Container Intrinsic Main Sizes</a>
 Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-min-main-size②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-main-size">
-   <b><a href="#max-main-size">#max-main-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-main-size" class="dfn-panel" data-for="max-main-size" id="infopanel-for-max-main-size" role="dialog">
+   <span id="infopaneltitle-for-max-main-size" style="display:none">Info about the 'max main size' definition.</span><b><a href="#max-main-size">#max-main-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-main-size">9.9.1. 
 Flex Container Intrinsic Main Sizes</a>
@@ -7761,8 +7761,8 @@ Flex Container Intrinsic Main Sizes</a>
 Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-max-main-size②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-axis">
-   <b><a href="#cross-axis">#cross-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-axis" class="dfn-panel" data-for="cross-axis" id="infopanel-for-cross-axis" role="dialog">
+   <span id="infopaneltitle-for-cross-axis" style="display:none">Info about the 'cross axis' definition.</span><b><a href="#cross-axis">#cross-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-axis">1.1. 
 Overview</a> <a href="#ref-for-cross-axis①">(2)</a>
@@ -7786,15 +7786,15 @@ Flex Container Intrinsic Cross Sizes</a> <a href="#ref-for-cross-axis①⑥">(2)
     <li><a href="#ref-for-cross-axis②⓪"> Substantive Changes and Bugfixes</a> <a href="#ref-for-cross-axis②①">(2)</a> <a href="#ref-for-cross-axis②②">(3)</a> <a href="#ref-for-cross-axis②③">(4)</a> <a href="#ref-for-cross-axis②④">(5)</a> <a href="#ref-for-cross-axis②⑤">(6)</a> <a href="#ref-for-cross-axis②⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-dimension">
-   <b><a href="#cross-dimension">#cross-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-dimension" class="dfn-panel" data-for="cross-dimension" id="infopanel-for-cross-dimension" role="dialog">
+   <span id="infopaneltitle-for-cross-dimension" style="display:none">Info about the 'cross dimension' definition.</span><b><a href="#cross-dimension">#cross-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-dimension">2. 
 Flex Layout Box Model and Terminology</a> <a href="#ref-for-cross-dimension①">(2)</a> <a href="#ref-for-cross-dimension②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-start">
-   <b><a href="#cross-start">#cross-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-start" class="dfn-panel" data-for="cross-start" id="infopanel-for-cross-start" role="dialog">
+   <span id="infopaneltitle-for-cross-start" style="display:none">Info about the 'cross-start' definition.</span><b><a href="#cross-start">#cross-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-start">5.2. 
 Flex Line Wrapping: the flex-wrap property</a> <a href="#ref-for-cross-start①">(2)</a> <a href="#ref-for-cross-start②">(3)</a>
@@ -7806,8 +7806,8 @@ Packing Flex Lines: the align-content property</a> <a href="#ref-for-cross-start
     <li><a href="#ref-for-cross-start①⑥"> Substantive Changes and Bugfixes</a> <a href="#ref-for-cross-start①⑦">(2)</a> <a href="#ref-for-cross-start①⑧">(3)</a> <a href="#ref-for-cross-start①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-end">
-   <b><a href="#cross-end">#cross-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-end" class="dfn-panel" data-for="cross-end" id="infopanel-for-cross-end" role="dialog">
+   <span id="infopaneltitle-for-cross-end" style="display:none">Info about the 'cross-end' definition.</span><b><a href="#cross-end">#cross-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-end">5.2. 
 Flex Line Wrapping: the flex-wrap property</a> <a href="#ref-for-cross-end①">(2)</a>
@@ -7818,8 +7818,8 @@ Packing Flex Lines: the align-content property</a> <a href="#ref-for-cross-end�
     <li><a href="#ref-for-cross-end⑨"> Appendix A: Axis Mappings</a> <a href="#ref-for-cross-end①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-size">
-   <b><a href="#cross-size">#cross-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-size" class="dfn-panel" data-for="cross-size" id="infopanel-for-cross-size" role="dialog">
+   <span id="infopaneltitle-for-cross-size" style="display:none">Info about the 'cross size' definition.</span><b><a href="#cross-size">#cross-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-size">1.1. 
 Overview</a>
@@ -7848,8 +7848,8 @@ Sample Flex Fragmentation Algorithm</a>
     <li><a href="#ref-for-cross-size③⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-cross-size③⑥">(2)</a> <a href="#ref-for-cross-size③⑦">(3)</a> <a href="#ref-for-cross-size③⑧">(4)</a> <a href="#ref-for-cross-size③⑨">(5)</a> <a href="#ref-for-cross-size④⓪">(6)</a> <a href="#ref-for-cross-size④①">(7)</a> <a href="#ref-for-cross-size④②">(8)</a> <a href="#ref-for-cross-size④③">(9)</a> <a href="#ref-for-cross-size④④">(10)</a> <a href="#ref-for-cross-size④⑤">(11)</a> <a href="#ref-for-cross-size④⑥">(12)</a> <a href="#ref-for-cross-size④⑦">(13)</a> <a href="#ref-for-cross-size④⑨">(14)</a> <a href="#ref-for-cross-size⑤⓪">(15)</a> <a href="#ref-for-cross-size⑤①">(16)</a> <a href="#ref-for-cross-size⑤②">(17)</a> <a href="#ref-for-cross-size⑤③">(18)</a> <a href="#ref-for-cross-size⑤④">(19)</a> <a href="#ref-for-cross-size⑤⑤">(20)</a> <a href="#ref-for-cross-size⑤⑥">(21)</a> <a href="#ref-for-cross-size⑤⑦">(22)</a> <a href="#ref-for-cross-size⑤⑧">(23)</a> <a href="#ref-for-cross-size⑤⑨">(24)</a> <a href="#ref-for-cross-size⑥⓪">(25)</a> <a href="#ref-for-cross-size⑥①">(26)</a> <a href="#ref-for-cross-size⑥②">(27)</a> <a href="#ref-for-cross-size⑥③">(28)</a> <a href="#ref-for-cross-size⑥④">(29)</a> <a href="#ref-for-cross-size⑥⑤">(30)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-size-property">
-   <b><a href="#cross-size-property">#cross-size-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-size-property" class="dfn-panel" data-for="cross-size-property" id="infopanel-for-cross-size-property" role="dialog">
+   <span id="infopaneltitle-for-cross-size-property" style="display:none">Info about the 'cross size property' definition.</span><b><a href="#cross-size-property">#cross-size-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-size-property">8.3. 
 Cross-axis Alignment: the align-items and align-self properties</a>
@@ -7857,8 +7857,8 @@ Cross-axis Alignment: the align-items and align-self properties</a>
     <li><a href="#ref-for-cross-size-property②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-flex">
-   <b><a href="#valdef-display-flex">#valdef-display-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-flex" class="dfn-panel" data-for="valdef-display-flex" id="infopanel-for-valdef-display-flex" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-flex" style="display:none">Info about the 'flex' definition.</span><b><a href="#valdef-display-flex">#valdef-display-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex">2. 
 Flex Layout Box Model and Terminology</a>
@@ -7868,8 +7868,8 @@ Flex Containers: the flex and inline-flex display values</a> <a href="#ref-for-v
 Flex Items</a> <a href="#ref-for-valdef-display-flex⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-flex">
-   <b><a href="#valdef-display-inline-flex">#valdef-display-inline-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-flex" class="dfn-panel" data-for="valdef-display-inline-flex" id="infopanel-for-valdef-display-inline-flex" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-flex" style="display:none">Info about the 'inline-flex' definition.</span><b><a href="#valdef-display-inline-flex">#valdef-display-inline-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-flex">2. 
 Flex Layout Box Model and Terminology</a>
@@ -7879,23 +7879,23 @@ Flex Containers: the flex and inline-flex display values</a> <a href="#ref-for-v
 Flex Items</a> <a href="#ref-for-valdef-display-inline-flex⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="static-position-rectangle">
-   <b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-static-position-rectangle" class="dfn-panel" data-for="static-position-rectangle" id="infopanel-for-static-position-rectangle" role="dialog">
+   <span id="infopaneltitle-for-static-position-rectangle" style="display:none">Info about the 'static-position rectangle' definition.</span><b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position-rectangle">4.1. 
 Absolutely-Positioned Flex Children</a> <a href="#ref-for-static-position-rectangle①">(2)</a>
     <li><a href="#ref-for-static-position-rectangle②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsed-flex-item">
-   <b><a href="#collapsed-flex-item">#collapsed-flex-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsed-flex-item" class="dfn-panel" data-for="collapsed-flex-item" id="infopanel-for-collapsed-flex-item" role="dialog">
+   <span id="infopaneltitle-for-collapsed-flex-item" style="display:none">Info about the 'collapsed flex item' definition.</span><b><a href="#collapsed-flex-item">#collapsed-flex-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-flex-item">4.4. 
 Collapsed Items</a> <a href="#ref-for-collapsed-flex-item①">(2)</a> <a href="#ref-for-collapsed-flex-item②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-based-minimum-size">
-   <b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-based-minimum-size" class="dfn-panel" data-for="content-based-minimum-size" id="infopanel-for-content-based-minimum-size" role="dialog">
+   <span id="infopaneltitle-for-content-based-minimum-size" style="display:none">Info about the 'content-based minimum size' definition.</span><b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-based-minimum-size">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-content-based-minimum-size①">(2)</a> <a href="#ref-for-content-based-minimum-size②">(3)</a> <a href="#ref-for-content-based-minimum-size③">(4)</a>
@@ -7903,29 +7903,29 @@ Automatic Minimum Size of Flex Items</a> <a href="#ref-for-content-based-minimum
     <li><a href="#ref-for-content-based-minimum-size⑥"> Changes since the 16 October 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-size-suggestion">
-   <b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-size-suggestion" class="dfn-panel" data-for="specified-size-suggestion" id="infopanel-for-specified-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-specified-size-suggestion" style="display:none">Info about the 'specified size suggestion' definition.</span><b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size-suggestion">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-specified-size-suggestion①">(2)</a> <a href="#ref-for-specified-size-suggestion②">(3)</a> <a href="#ref-for-specified-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transferred-size-suggestion">
-   <b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transferred-size-suggestion" class="dfn-panel" data-for="transferred-size-suggestion" id="infopanel-for-transferred-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-transferred-size-suggestion" style="display:none">Info about the 'transferred size suggestion' definition.</span><b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transferred-size-suggestion">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-transferred-size-suggestion①">(2)</a> <a href="#ref-for-transferred-size-suggestion②">(3)</a> <a href="#ref-for-transferred-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-size-suggestion">
-   <b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-size-suggestion" class="dfn-panel" data-for="content-size-suggestion" id="infopanel-for-content-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-content-size-suggestion" style="display:none">Info about the 'content size suggestion' definition.</span><b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-size-suggestion">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-content-size-suggestion①">(2)</a> <a href="#ref-for-content-size-suggestion②">(3)</a> <a href="#ref-for-content-size-suggestion③">(4)</a> <a href="#ref-for-content-size-suggestion④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-direction">
-   <b><a href="#propdef-flex-direction">#propdef-flex-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-direction" class="dfn-panel" data-for="propdef-flex-direction" id="infopanel-for-propdef-flex-direction" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-direction" style="display:none">Info about the 'flex-direction' definition.</span><b><a href="#propdef-flex-direction">#propdef-flex-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-direction">5. 
 Ordering and Orientation</a> <a href="#ref-for-propdef-flex-direction①">(2)</a>
@@ -7938,8 +7938,8 @@ Flex Container Baselines</a>
     <li><a href="#ref-for-propdef-flex-direction⑦"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-flex-direction⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-direction-row">
-   <b><a href="#valdef-flex-direction-row">#valdef-flex-direction-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-direction-row" class="dfn-panel" data-for="valdef-flex-direction-row" id="infopanel-for-valdef-flex-direction-row" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-direction-row" style="display:none">Info about the 'row' definition.</span><b><a href="#valdef-flex-direction-row">#valdef-flex-direction-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-row">2. 
 Flex Layout Box Model and Terminology</a>
@@ -7950,30 +7950,30 @@ Flex Direction and Wrap: the flex-flow shorthand</a>
     <li><a href="#ref-for-valdef-flex-direction-row③"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-direction-row④">(2)</a> <a href="#ref-for-valdef-flex-direction-row⑤">(3)</a> <a href="#ref-for-valdef-flex-direction-row⑥">(4)</a> <a href="#ref-for-valdef-flex-direction-row⑦">(5)</a> <a href="#ref-for-valdef-flex-direction-row⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-direction-row-reverse">
-   <b><a href="#valdef-flex-direction-row-reverse">#valdef-flex-direction-row-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-direction-row-reverse" class="dfn-panel" data-for="valdef-flex-direction-row-reverse" id="infopanel-for-valdef-flex-direction-row-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-direction-row-reverse" style="display:none">Info about the 'row-reverse' definition.</span><b><a href="#valdef-flex-direction-row-reverse">#valdef-flex-direction-row-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-row-reverse">1.1. 
 Overview</a>
     <li><a href="#ref-for-valdef-flex-direction-row-reverse①"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-direction-row-reverse②">(2)</a> <a href="#ref-for-valdef-flex-direction-row-reverse③">(3)</a> <a href="#ref-for-valdef-flex-direction-row-reverse④">(4)</a> <a href="#ref-for-valdef-flex-direction-row-reverse⑤">(5)</a> <a href="#ref-for-valdef-flex-direction-row-reverse⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-direction-column">
-   <b><a href="#valdef-flex-direction-column">#valdef-flex-direction-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-direction-column" class="dfn-panel" data-for="valdef-flex-direction-column" id="infopanel-for-valdef-flex-direction-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-direction-column" style="display:none">Info about the 'column' definition.</span><b><a href="#valdef-flex-direction-column">#valdef-flex-direction-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-column">5.1. 
 Flex Flow Direction: the flex-direction property</a>
     <li><a href="#ref-for-valdef-flex-direction-column①"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-direction-column②">(2)</a> <a href="#ref-for-valdef-flex-direction-column③">(3)</a> <a href="#ref-for-valdef-flex-direction-column④">(4)</a> <a href="#ref-for-valdef-flex-direction-column⑤">(5)</a> <a href="#ref-for-valdef-flex-direction-column⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-direction-column-reverse">
-   <b><a href="#valdef-flex-direction-column-reverse">#valdef-flex-direction-column-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-direction-column-reverse" class="dfn-panel" data-for="valdef-flex-direction-column-reverse" id="infopanel-for-valdef-flex-direction-column-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-direction-column-reverse" style="display:none">Info about the 'column-reverse' definition.</span><b><a href="#valdef-flex-direction-column-reverse">#valdef-flex-direction-column-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-direction-column-reverse"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-direction-column-reverse①">(2)</a> <a href="#ref-for-valdef-flex-direction-column-reverse②">(3)</a> <a href="#ref-for-valdef-flex-direction-column-reverse③">(4)</a> <a href="#ref-for-valdef-flex-direction-column-reverse④">(5)</a> <a href="#ref-for-valdef-flex-direction-column-reverse⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-wrap">
-   <b><a href="#propdef-flex-wrap">#propdef-flex-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-wrap" class="dfn-panel" data-for="propdef-flex-wrap" id="infopanel-for-propdef-flex-wrap" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-wrap" style="display:none">Info about the 'flex-wrap' definition.</span><b><a href="#propdef-flex-wrap">#propdef-flex-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-wrap">5. 
 Ordering and Orientation</a>
@@ -7985,14 +7985,14 @@ Flex Direction and Wrap: the flex-flow shorthand</a> <a href="#ref-for-propdef-f
 Flex Lines</a> <a href="#ref-for-propdef-flex-wrap⑦">(2)</a> <a href="#ref-for-propdef-flex-wrap⑧">(3)</a> <a href="#ref-for-propdef-flex-wrap⑨">(4)</a> <a href="#ref-for-propdef-flex-wrap①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-wrap-nowrap">
-   <b><a href="#valdef-flex-wrap-nowrap">#valdef-flex-wrap-nowrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-wrap-nowrap" class="dfn-panel" data-for="valdef-flex-wrap-nowrap" id="infopanel-for-valdef-flex-wrap-nowrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-wrap-nowrap" style="display:none">Info about the 'nowrap' definition.</span><b><a href="#valdef-flex-wrap-nowrap">#valdef-flex-wrap-nowrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-wrap-nowrap"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-wrap-nowrap①">(2)</a> <a href="#ref-for-valdef-flex-wrap-nowrap②">(3)</a> <a href="#ref-for-valdef-flex-wrap-nowrap③">(4)</a> <a href="#ref-for-valdef-flex-wrap-nowrap④">(5)</a> <a href="#ref-for-valdef-flex-wrap-nowrap⑤">(6)</a> <a href="#ref-for-valdef-flex-wrap-nowrap⑥">(7)</a> <a href="#ref-for-valdef-flex-wrap-nowrap⑦">(8)</a> <a href="#ref-for-valdef-flex-wrap-nowrap⑧">(9)</a> <a href="#ref-for-valdef-flex-wrap-nowrap⑨">(10)</a> <a href="#ref-for-valdef-flex-wrap-nowrap①⓪">(11)</a> <a href="#ref-for-valdef-flex-wrap-nowrap①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-wrap-wrap">
-   <b><a href="#valdef-flex-wrap-wrap">#valdef-flex-wrap-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-wrap-wrap" class="dfn-panel" data-for="valdef-flex-wrap-wrap" id="infopanel-for-valdef-flex-wrap-wrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-wrap-wrap" style="display:none">Info about the 'wrap' definition.</span><b><a href="#valdef-flex-wrap-wrap">#valdef-flex-wrap-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-wrap-wrap">5.2. 
 Flex Line Wrapping: the flex-wrap property</a>
@@ -8001,16 +8001,16 @@ Flex Lines</a>
     <li><a href="#ref-for-valdef-flex-wrap-wrap②"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-wrap-wrap③">(2)</a> <a href="#ref-for-valdef-flex-wrap-wrap④">(3)</a> <a href="#ref-for-valdef-flex-wrap-wrap⑤">(4)</a> <a href="#ref-for-valdef-flex-wrap-wrap⑥">(5)</a> <a href="#ref-for-valdef-flex-wrap-wrap⑦">(6)</a> <a href="#ref-for-valdef-flex-wrap-wrap⑧">(7)</a> <a href="#ref-for-valdef-flex-wrap-wrap⑨">(8)</a> <a href="#ref-for-valdef-flex-wrap-wrap①⓪">(9)</a> <a href="#ref-for-valdef-flex-wrap-wrap①①">(10)</a> <a href="#ref-for-valdef-flex-wrap-wrap①②">(11)</a> <a href="#ref-for-valdef-flex-wrap-wrap①③">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-wrap-wrap-reverse">
-   <b><a href="#valdef-flex-wrap-wrap-reverse">#valdef-flex-wrap-wrap-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-wrap-wrap-reverse" class="dfn-panel" data-for="valdef-flex-wrap-wrap-reverse" id="infopanel-for-valdef-flex-wrap-wrap-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-wrap-wrap-reverse" style="display:none">Info about the 'wrap-reverse' definition.</span><b><a href="#valdef-flex-wrap-wrap-reverse">#valdef-flex-wrap-wrap-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-wrap-wrap-reverse">5.2. 
 Flex Line Wrapping: the flex-wrap property</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse①">(2)</a>
     <li><a href="#ref-for-valdef-flex-wrap-wrap-reverse②"> Appendix A: Axis Mappings</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse③">(2)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse④">(3)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse⑤">(4)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse⑥">(5)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse⑦">(6)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse⑧">(7)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse⑨">(8)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse①⓪">(9)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse①①">(10)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse①②">(11)</a> <a href="#ref-for-valdef-flex-wrap-wrap-reverse①③">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-flow">
-   <b><a href="#propdef-flex-flow">#propdef-flex-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-flow" class="dfn-panel" data-for="propdef-flex-flow" id="infopanel-for-propdef-flex-flow" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' definition.</span><b><a href="#propdef-flex-flow">#propdef-flex-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">2. 
 Flex Layout Box Model and Terminology</a>
@@ -8026,8 +8026,8 @@ Flex Container Intrinsic Cross Sizes</a>
     <li><a href="#ref-for-propdef-flex-flow①⓪"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-order">
-   <b><a href="#propdef-order">#propdef-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-order" class="dfn-panel" data-for="propdef-order" id="infopanel-for-propdef-order" role="dialog">
+   <span id="infopaneltitle-for-propdef-order" style="display:none">Info about the 'order' definition.</span><b><a href="#propdef-order">#propdef-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">1.1. 
 Overview</a>
@@ -8047,8 +8047,8 @@ Flex Container Baselines</a>
     <li><a href="#ref-for-propdef-order②⑦"> Clarifications</a> <a href="#ref-for-propdef-order②⑧">(2)</a> <a href="#ref-for-propdef-order②⑨">(3)</a> <a href="#ref-for-propdef-order③①">(4)</a> <a href="#ref-for-propdef-order③②">(5)</a> <a href="#ref-for-propdef-order③③">(6)</a> <a href="#ref-for-propdef-order③⑨">(7)</a> <a href="#ref-for-propdef-order④⓪">(8)</a> <a href="#ref-for-propdef-order④①">(9)</a> <a href="#ref-for-propdef-order④②">(10)</a> <a href="#ref-for-propdef-order④③">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="order-modified-document-order">
-   <b><a href="#order-modified-document-order">#order-modified-document-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-order-modified-document-order" class="dfn-panel" data-for="order-modified-document-order" id="infopanel-for-order-modified-document-order" role="dialog">
+   <span id="infopaneltitle-for-order-modified-document-order" style="display:none">Info about the 'order-modified document order' definition.</span><b><a href="#order-modified-document-order">#order-modified-document-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-order-modified-document-order">9. 
 Flex Layout Algorithm</a>
@@ -8057,8 +8057,8 @@ Fragmenting Flex Layout</a>
     <li><a href="#ref-for-order-modified-document-order②"> Changes since the 16 October 2017 CR</a> <a href="#ref-for-order-modified-document-order③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-line">
-   <b><a href="#flex-line">#flex-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-line" class="dfn-panel" data-for="flex-line" id="infopanel-for-flex-line" role="dialog">
+   <span id="infopaneltitle-for-flex-line" style="display:none">Info about the 'flex lines' definition.</span><b><a href="#flex-line">#flex-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-line">2. 
 Flex Layout Box Model and Terminology</a>
@@ -8076,8 +8076,8 @@ Flex Container Intrinsic Cross Sizes</a>
     <li><a href="#ref-for-flex-line⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-flex-line①⓪">(2)</a> <a href="#ref-for-flex-line①①">(3)</a> <a href="#ref-for-flex-line①②">(4)</a> <a href="#ref-for-flex-line①③">(5)</a> <a href="#ref-for-flex-line①④">(6)</a> <a href="#ref-for-flex-line①⑤">(7)</a> <a href="#ref-for-flex-line①⑥">(8)</a> <a href="#ref-for-flex-line①⑦">(9)</a> <a href="#ref-for-flex-line①⑧">(10)</a> <a href="#ref-for-flex-line①⑨">(11)</a> <a href="#ref-for-flex-line②⓪">(12)</a> <a href="#ref-for-flex-line②①">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-line-flex-container">
-   <b><a href="#single-line-flex-container">#single-line-flex-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-line-flex-container" class="dfn-panel" data-for="single-line-flex-container" id="infopanel-for-single-line-flex-container" role="dialog">
+   <span id="infopaneltitle-for-single-line-flex-container" style="display:none">Info about the 'single-line flex container' definition.</span><b><a href="#single-line-flex-container">#single-line-flex-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-line-flex-container">5.2. 
 Flex Line Wrapping: the flex-wrap property</a> <a href="#ref-for-single-line-flex-container①">(2)</a>
@@ -8100,8 +8100,8 @@ Sample Flex Fragmentation Algorithm</a> <a href="#ref-for-single-line-flex-conta
     <li><a href="#ref-for-single-line-flex-container①⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-single-line-flex-container①⑥">(2)</a> <a href="#ref-for-single-line-flex-container①⑦">(3)</a> <a href="#ref-for-single-line-flex-container①⑧">(4)</a> <a href="#ref-for-single-line-flex-container①⑨">(5)</a> <a href="#ref-for-single-line-flex-container②⓪">(6)</a> <a href="#ref-for-single-line-flex-container②①">(7)</a> <a href="#ref-for-single-line-flex-container②②">(8)</a> <a href="#ref-for-single-line-flex-container②③">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multi-line-flex-container">
-   <b><a href="#multi-line-flex-container">#multi-line-flex-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-line-flex-container" class="dfn-panel" data-for="multi-line-flex-container" id="infopanel-for-multi-line-flex-container" role="dialog">
+   <span id="infopaneltitle-for-multi-line-flex-container" style="display:none">Info about the 'multi-line flex container' definition.</span><b><a href="#multi-line-flex-container">#multi-line-flex-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-line-flex-container">5.2. 
 Flex Line Wrapping: the flex-wrap property</a> <a href="#ref-for-multi-line-flex-container①">(2)</a>
@@ -8120,8 +8120,8 @@ Sample Flex Fragmentation Algorithm</a> <a href="#ref-for-multi-line-flex-contai
     <li><a href="#ref-for-multi-line-flex-container①⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-multi-line-flex-container①⑥">(2)</a> <a href="#ref-for-multi-line-flex-container①⑦">(3)</a> <a href="#ref-for-multi-line-flex-container①⑧">(4)</a> <a href="#ref-for-multi-line-flex-container①⑨">(5)</a> <a href="#ref-for-multi-line-flex-container②⓪">(6)</a> <a href="#ref-for-multi-line-flex-container②①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fully-inflexible">
-   <b><a href="#fully-inflexible">#fully-inflexible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fully-inflexible" class="dfn-panel" data-for="fully-inflexible" id="infopanel-for-fully-inflexible" role="dialog">
+   <span id="infopaneltitle-for-fully-inflexible" style="display:none">Info about the 'fully inflexible' definition.</span><b><a href="#fully-inflexible">#fully-inflexible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-inflexible">7.1.1. 
 Basic Values of flex</a>
@@ -8130,14 +8130,14 @@ Definite and Indefinite Sizes</a>
     <li><a href="#ref-for-fully-inflexible②"> Clarifications</a> <a href="#ref-for-fully-inflexible③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible">
-   <b><a href="#flexible">#flexible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible" class="dfn-panel" data-for="flexible" id="infopanel-for-flexible" role="dialog">
+   <span id="infopaneltitle-for-flexible" style="display:none">Info about the 'flexible' definition.</span><b><a href="#flexible">#flexible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex">
-   <b><a href="#propdef-flex">#propdef-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex" class="dfn-panel" data-for="propdef-flex" id="infopanel-for-propdef-flex" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex" style="display:none">Info about the 'flex' definition.</span><b><a href="#propdef-flex">#propdef-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">4. 
 Flex Items</a>
@@ -8160,15 +8160,15 @@ The flex-basis property</a>
     <li><a href="#ref-for-propdef-flex②⑧"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-flex②⑨">(2)</a> <a href="#ref-for-propdef-flex③⓪">(3)</a> <a href="#ref-for-propdef-flex③①">(4)</a> <a href="#ref-for-propdef-flex③②">(5)</a> <a href="#ref-for-propdef-flex③③">(6)</a> <a href="#ref-for-propdef-flex③④">(7)</a> <a href="#ref-for-propdef-flex③⑤">(8)</a> <a href="#ref-for-propdef-flex③⑥">(9)</a> <a href="#ref-for-propdef-flex③⑦">(10)</a> <a href="#ref-for-propdef-flex③⑧">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-factor">
-   <b><a href="#flex-factor">#flex-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-factor" class="dfn-panel" data-for="flex-factor" id="infopanel-for-flex-factor" role="dialog">
+   <span id="infopaneltitle-for-flex-factor" style="display:none">Info about the 'flex factors' definition.</span><b><a href="#flex-factor">#flex-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-factor">9.9.1. 
 Flex Container Intrinsic Main Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-flex-grow-factor">
-   <b><a href="#flex-flex-grow-factor">#flex-flex-grow-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-flex-grow-factor" class="dfn-panel" data-for="flex-flex-grow-factor" id="infopanel-for-flex-flex-grow-factor" role="dialog">
+   <span id="infopaneltitle-for-flex-flex-grow-factor" style="display:none">Info about the 'flex grow factor' definition.</span><b><a href="#flex-flex-grow-factor">#flex-flex-grow-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-flex-grow-factor">7. 
 Flexibility</a>
@@ -8183,8 +8183,8 @@ Flex Container Intrinsic Main Sizes</a> <a href="#ref-for-flex-flex-grow-factor�
     <li><a href="#ref-for-flex-flex-grow-factor⑦"> Substantive Changes and Bugfixes</a> <a href="#ref-for-flex-flex-grow-factor⑧">(2)</a> <a href="#ref-for-flex-flex-grow-factor⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-flex-shrink-factor">
-   <b><a href="#flex-flex-shrink-factor">#flex-flex-shrink-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-flex-shrink-factor" class="dfn-panel" data-for="flex-flex-shrink-factor" id="infopanel-for-flex-flex-shrink-factor" role="dialog">
+   <span id="infopaneltitle-for-flex-flex-shrink-factor" style="display:none">Info about the 'flex shrink factor' definition.</span><b><a href="#flex-flex-shrink-factor">#flex-flex-shrink-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-flex-shrink-factor">7. 
 Flexibility</a>
@@ -8199,8 +8199,8 @@ Flex Container Intrinsic Main Sizes</a>
     <li><a href="#ref-for-flex-flex-shrink-factor⑦"> Substantive Changes and Bugfixes</a> <a href="#ref-for-flex-flex-shrink-factor⑧">(2)</a> <a href="#ref-for-flex-flex-shrink-factor⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-flex-basis">
-   <b><a href="#flex-flex-basis">#flex-flex-basis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-flex-basis" class="dfn-panel" data-for="flex-flex-basis" id="infopanel-for-flex-flex-basis" role="dialog">
+   <span id="infopaneltitle-for-flex-flex-basis" style="display:none">Info about the 'flex basis' definition.</span><b><a href="#flex-flex-basis">#flex-flex-basis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-flex-basis">7.1. 
 The flex Shorthand</a>
@@ -8216,8 +8216,8 @@ Definite and Indefinite Sizes</a>
     <li><a href="#ref-for-flex-flex-basis①⓪"> Clarifications</a> <a href="#ref-for-flex-flex-basis①①">(2)</a> <a href="#ref-for-flex-flex-basis①②">(3)</a> <a href="#ref-for-flex-flex-basis①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-basis-auto">
-   <b><a href="#valdef-flex-basis-auto">#valdef-flex-basis-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-basis-auto" class="dfn-panel" data-for="valdef-flex-basis-auto" id="infopanel-for-valdef-flex-basis-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-basis-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-flex-basis-auto">#valdef-flex-basis-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-basis-auto">7.1. 
 The flex Shorthand</a> <a href="#ref-for-valdef-flex-basis-auto①">(2)</a>
@@ -8226,8 +8226,8 @@ The flex-basis property</a>
     <li><a href="#ref-for-valdef-flex-basis-auto③"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-basis-content">
-   <b><a href="#valdef-flex-basis-content">#valdef-flex-basis-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-basis-content" class="dfn-panel" data-for="valdef-flex-basis-content" id="infopanel-for-valdef-flex-basis-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-basis-content" style="display:none">Info about the 'content' definition.</span><b><a href="#valdef-flex-basis-content">#valdef-flex-basis-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-basis-content">7.1. 
 The flex Shorthand</a> <a href="#ref-for-valdef-flex-basis-content①">(2)</a>
@@ -8239,15 +8239,15 @@ Line Length Determination</a> <a href="#ref-for-valdef-flex-basis-content⑦">(2
     <li><a href="#ref-for-valdef-flex-basis-content①⑤"> Substantive Changes and Bugfixes</a> <a href="#ref-for-valdef-flex-basis-content①⑥">(2)</a> <a href="#ref-for-valdef-flex-basis-content①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-none">
-   <b><a href="#valdef-flex-none">#valdef-flex-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-none" class="dfn-panel" data-for="valdef-flex-none" id="infopanel-for-valdef-flex-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-flex-none">#valdef-flex-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-none">7.1. 
 The flex Shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-grow">
-   <b><a href="#propdef-flex-grow">#propdef-flex-grow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-grow" class="dfn-panel" data-for="propdef-flex-grow" id="infopanel-for-propdef-flex-grow" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-grow" style="display:none">Info about the 'flex-grow' definition.</span><b><a href="#propdef-flex-grow">#propdef-flex-grow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-grow">7. 
 Flexibility</a>
@@ -8260,8 +8260,8 @@ Flex Container Intrinsic Main Sizes</a> <a href="#ref-for-propdef-flex-grow①�
     <li><a href="#ref-for-propdef-flex-grow①⑧"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-shrink">
-   <b><a href="#propdef-flex-shrink">#propdef-flex-shrink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-shrink" class="dfn-panel" data-for="propdef-flex-shrink" id="infopanel-for-propdef-flex-shrink" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-shrink" style="display:none">Info about the 'flex-shrink' definition.</span><b><a href="#propdef-flex-shrink">#propdef-flex-shrink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-shrink">7. 
 Flexibility</a>
@@ -8272,8 +8272,8 @@ The flex-shrink property</a> <a href="#ref-for-propdef-flex-shrink⑤">(2)</a> <
     <li><a href="#ref-for-propdef-flex-shrink⑦"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flex-basis">
-   <b><a href="#propdef-flex-basis">#propdef-flex-basis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flex-basis" class="dfn-panel" data-for="propdef-flex-basis" id="infopanel-for-propdef-flex-basis" role="dialog">
+   <span id="infopaneltitle-for-propdef-flex-basis" style="display:none">Info about the 'flex-basis' definition.</span><b><a href="#propdef-flex-basis">#propdef-flex-basis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-basis">7.1. 
 The flex Shorthand</a> <a href="#ref-for-propdef-flex-basis①">(2)</a> <a href="#ref-for-propdef-flex-basis②">(3)</a> <a href="#ref-for-propdef-flex-basis③">(4)</a> <a href="#ref-for-propdef-flex-basis④">(5)</a> <a href="#ref-for-propdef-flex-basis⑤">(6)</a> <a href="#ref-for-propdef-flex-basis⑥">(7)</a> <a href="#ref-for-propdef-flex-basis⑦">(8)</a>
@@ -8286,8 +8286,8 @@ Flex Container Intrinsic Main Sizes</a>
     <li><a href="#ref-for-propdef-flex-basis②②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-flex-basis②③">(2)</a> <a href="#ref-for-propdef-flex-basis②④">(3)</a> <a href="#ref-for-propdef-flex-basis②⑤">(4)</a> <a href="#ref-for-propdef-flex-basis②⑥">(5)</a> <a href="#ref-for-propdef-flex-basis②⑦">(6)</a> <a href="#ref-for-propdef-flex-basis②⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-justify-content">
-   <b><a href="#propdef-justify-content">#propdef-justify-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-justify-content" class="dfn-panel" data-for="propdef-justify-content" id="infopanel-for-propdef-justify-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-justify-content" style="display:none">Info about the 'justify-content' definition.</span><b><a href="#propdef-justify-content">#propdef-justify-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">1.2. 
 Module interactions</a>
@@ -8307,22 +8307,22 @@ Main-Axis Alignment</a>
     <li><a href="#ref-for-propdef-justify-content①⓪"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-justify-content①①">(2)</a> <a href="#ref-for-propdef-justify-content①②">(3)</a> <a href="#ref-for-propdef-justify-content①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-content-flex-start">
-   <b><a href="#valdef-justify-content-flex-start">#valdef-justify-content-flex-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-content-flex-start" class="dfn-panel" data-for="valdef-justify-content-flex-start" id="infopanel-for-valdef-justify-content-flex-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-content-flex-start" style="display:none">Info about the 'flex-start' definition.</span><b><a href="#valdef-justify-content-flex-start">#valdef-justify-content-flex-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-flex-start">8.2. 
 Axis Alignment: the justify-content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-justify-content-center">
-   <b><a href="#valdef-justify-content-center">#valdef-justify-content-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-justify-content-center" class="dfn-panel" data-for="valdef-justify-content-center" id="infopanel-for-valdef-justify-content-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-justify-content-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-justify-content-center">#valdef-justify-content-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-center">8.2. 
 Axis Alignment: the justify-content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-items">
-   <b><a href="#propdef-align-items">#propdef-align-items</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-items" class="dfn-panel" data-for="propdef-align-items" id="infopanel-for-propdef-align-items" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-items" style="display:none">Info about the 'align-items' definition.</span><b><a href="#propdef-align-items">#propdef-align-items</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">1.2. 
 Module interactions</a>
@@ -8333,8 +8333,8 @@ Cross-axis Alignment: the align-items and align-self properties</a> <a href="#re
     <li><a href="#ref-for-propdef-align-items⑦"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-align-items⑧">(2)</a> <a href="#ref-for-propdef-align-items⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-self">
-   <b><a href="#propdef-align-self">#propdef-align-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-self" class="dfn-panel" data-for="propdef-align-self" id="infopanel-for-propdef-align-self" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-self" style="display:none">Info about the 'align-self' definition.</span><b><a href="#propdef-align-self">#propdef-align-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">1.1. 
 Overview</a> <a href="#ref-for-propdef-align-self①">(2)</a> <a href="#ref-for-propdef-align-self②">(3)</a>
@@ -8360,8 +8360,8 @@ Sample Flex Fragmentation Algorithm</a> <a href="#ref-for-propdef-align-self②�
     <li><a href="#ref-for-propdef-align-self②⑨"> Clarifications</a> <a href="#ref-for-propdef-align-self③②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-items-auto">
-   <b><a href="#valdef-align-items-auto">#valdef-align-items-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-items-auto" class="dfn-panel" data-for="valdef-align-items-auto" id="infopanel-for-valdef-align-items-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-items-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-align-items-auto">#valdef-align-items-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-items-auto">7.1. 
 The flex Shorthand</a>
@@ -8370,8 +8370,8 @@ Line Length Determination</a>
     <li><a href="#ref-for-valdef-align-items-auto②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-valdef-align-items-auto③">(2)</a> <a href="#ref-for-valdef-align-items-auto④">(3)</a> <a href="#ref-for-valdef-align-items-auto⑤">(4)</a> <a href="#ref-for-valdef-align-items-auto⑥">(5)</a> <a href="#ref-for-valdef-align-items-auto⑦">(6)</a> <a href="#ref-for-valdef-align-items-auto⑧">(7)</a> <a href="#ref-for-valdef-align-items-auto⑨">(8)</a> <a href="#ref-for-valdef-align-items-auto①⓪">(9)</a> <a href="#ref-for-valdef-align-items-auto①①">(10)</a> <a href="#ref-for-valdef-align-items-auto①②">(11)</a> <a href="#ref-for-valdef-align-items-auto①③">(12)</a> <a href="#ref-for-valdef-align-items-auto①④">(13)</a> <a href="#ref-for-valdef-align-items-auto①⑤">(14)</a> <a href="#ref-for-valdef-align-items-auto①⑥">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-items-flex-start">
-   <b><a href="#valdef-align-items-flex-start">#valdef-align-items-flex-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-items-flex-start" class="dfn-panel" data-for="valdef-align-items-flex-start" id="infopanel-for-valdef-align-items-flex-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-items-flex-start" style="display:none">Info about the 'flex-start' definition.</span><b><a href="#valdef-align-items-flex-start">#valdef-align-items-flex-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-items-flex-start">4.1. 
 Absolutely-Positioned Flex Children</a>
@@ -8380,8 +8380,8 @@ Sample Flex Fragmentation Algorithm</a> <a href="#ref-for-valdef-align-items-fle
     <li><a href="#ref-for-valdef-align-items-flex-start④"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-items-baseline">
-   <b><a href="#valdef-align-items-baseline">#valdef-align-items-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-items-baseline" class="dfn-panel" data-for="valdef-align-items-baseline" id="infopanel-for-valdef-align-items-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-items-baseline" style="display:none">Info about the 'baseline' definition.</span><b><a href="#valdef-align-items-baseline">#valdef-align-items-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-items-baseline">9.4. 
 Cross Size Determination</a>
@@ -8389,16 +8389,16 @@ Cross Size Determination</a>
 Sample Flex Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-participation">
-   <b><a href="#baseline-participation">#baseline-participation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-participation" class="dfn-panel" data-for="baseline-participation" id="infopanel-for-baseline-participation" role="dialog">
+   <span id="infopaneltitle-for-baseline-participation" style="display:none">Info about the 'participates in baseline alignment' definition.</span><b><a href="#baseline-participation">#baseline-participation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-participation">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-baseline-participation">(2)</a>
     <li><a href="#ref-for-baseline-participation"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-items-stretch">
-   <b><a href="#valdef-align-items-stretch">#valdef-align-items-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-items-stretch" class="dfn-panel" data-for="valdef-align-items-stretch" id="infopanel-for-valdef-align-items-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-items-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-align-items-stretch">#valdef-align-items-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-items-stretch">4.1. 
 Absolutely-Positioned Flex Children</a>
@@ -8408,8 +8408,8 @@ Reordering and Accessibility</a>
     <li><a href="#ref-for-valdef-align-items-stretch④"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stretched">
-   <b><a href="#stretched">#stretched</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stretched" class="dfn-panel" data-for="stretched" id="infopanel-for-stretched" role="dialog">
+   <span id="infopaneltitle-for-stretched" style="display:none">Info about the 'stretched' definition.</span><b><a href="#stretched">#stretched</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretched">9.8. 
 Definite and Indefinite Sizes</a>
@@ -8417,8 +8417,8 @@ Definite and Indefinite Sizes</a>
     <li><a href="#ref-for-stretched②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-content">
-   <b><a href="#propdef-align-content">#propdef-align-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-content" class="dfn-panel" data-for="propdef-align-content" id="infopanel-for-propdef-align-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-content" style="display:none">Info about the 'align-content' definition.</span><b><a href="#propdef-align-content">#propdef-align-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">1.2. 
 Module interactions</a>
@@ -8435,46 +8435,48 @@ Sample Flex Fragmentation Algorithm</a>
     <li><a href="#ref-for-propdef-align-content⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-propdef-align-content①⓪">(2)</a> <a href="#ref-for-propdef-align-content①①">(3)</a> <a href="#ref-for-propdef-align-content①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-flex-start">
-   <b><a href="#valdef-align-content-flex-start">#valdef-align-content-flex-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-flex-start" class="dfn-panel" data-for="valdef-align-content-flex-start" id="infopanel-for-valdef-align-content-flex-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-flex-start" style="display:none">Info about the 'flex-start' definition.</span><b><a href="#valdef-align-content-flex-start">#valdef-align-content-flex-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-flex-start">8.4. 
 Packing Flex Lines: the align-content property</a> <a href="#ref-for-valdef-align-content-flex-start①">(2)</a>
     <li><a href="#ref-for-valdef-align-content-flex-start②"> Substantive Changes and Bugfixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-center">
-   <b><a href="#valdef-align-content-center">#valdef-align-content-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-center" class="dfn-panel" data-for="valdef-align-content-center" id="infopanel-for-valdef-align-content-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-align-content-center">#valdef-align-content-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-center">8.4. 
 Packing Flex Lines: the align-content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-align-content-stretch">
-   <b><a href="#valdef-align-content-stretch">#valdef-align-content-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-align-content-stretch" class="dfn-panel" data-for="valdef-align-content-stretch" id="infopanel-for-valdef-align-content-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-align-content-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-align-content-stretch">#valdef-align-content-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-stretch">9.4. 
 Cross Size Determination</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="main-axis-baseline">
-   <b><a href="#main-axis-baseline">#main-axis-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-main-axis-baseline" class="dfn-panel" data-for="main-axis-baseline" id="infopanel-for-main-axis-baseline" role="dialog">
+   <span id="infopaneltitle-for-main-axis-baseline" style="display:none">Info about the '
+		    main-axis baseline set' definition.</span><b><a href="#main-axis-baseline">#main-axis-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-axis-baseline">8.5. 
 Flex Container Baselines</a> <a href="#ref-for-main-axis-baseline①">(2)</a>
     <li><a href="#ref-for-main-axis-baseline②"> Substantive Changes and Bugfixes</a> <a href="#ref-for-main-axis-baseline③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-axis-baseline">
-   <b><a href="#cross-axis-baseline">#cross-axis-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-axis-baseline" class="dfn-panel" data-for="cross-axis-baseline" id="infopanel-for-cross-axis-baseline" role="dialog">
+   <span id="infopaneltitle-for-cross-axis-baseline" style="display:none">Info about the '
+			cross-axis baseline set' definition.</span><b><a href="#cross-axis-baseline">#cross-axis-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-axis-baseline">8.5. 
 Flex Container Baselines</a>
     <li><a href="#ref-for-cross-axis-baseline①"> Substantive Changes and Bugfixes</a> <a href="#ref-for-cross-axis-baseline②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-base-size">
-   <b><a href="#flex-base-size">#flex-base-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-base-size" class="dfn-panel" data-for="flex-base-size" id="infopanel-for-flex-base-size" role="dialog">
+   <span id="infopaneltitle-for-flex-base-size" style="display:none">Info about the 'flex base size' definition.</span><b><a href="#flex-base-size">#flex-base-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-base-size">7.1. 
 The flex Shorthand</a>
@@ -8492,8 +8494,8 @@ Flex Item Intrinsic Size Contributions</a> <a href="#ref-for-flex-base-size②�
     <li><a href="#ref-for-flex-base-size③⑥"> Clarifications</a> <a href="#ref-for-flex-base-size③⑦">(2)</a> <a href="#ref-for-flex-base-size③⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hypothetical-main-size">
-   <b><a href="#hypothetical-main-size">#hypothetical-main-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hypothetical-main-size" class="dfn-panel" data-for="hypothetical-main-size" id="infopanel-for-hypothetical-main-size" role="dialog">
+   <span id="infopaneltitle-for-hypothetical-main-size" style="display:none">Info about the 'hypothetical main size' definition.</span><b><a href="#hypothetical-main-size">#hypothetical-main-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hypothetical-main-size">9.2. 
 Line Length Determination</a>
@@ -8505,37 +8507,37 @@ Resolving Flexible Lengths</a> <a href="#ref-for-hypothetical-main-size③">(2)<
     <li><a href="#ref-for-hypothetical-main-size⑦"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hypothetical-cross-size">
-   <b><a href="#hypothetical-cross-size">#hypothetical-cross-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hypothetical-cross-size" class="dfn-panel" data-for="hypothetical-cross-size" id="infopanel-for-hypothetical-cross-size" role="dialog">
+   <span id="infopaneltitle-for-hypothetical-cross-size" style="display:none">Info about the 'hypothetical cross size' definition.</span><b><a href="#hypothetical-cross-size">#hypothetical-cross-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hypothetical-cross-size">9.4. 
 Cross Size Determination</a> <a href="#ref-for-hypothetical-cross-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-main-size">
-   <b><a href="#target-main-size">#target-main-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-main-size" class="dfn-panel" data-for="target-main-size" id="infopanel-for-target-main-size" role="dialog">
+   <span id="infopaneltitle-for-target-main-size" style="display:none">Info about the 'target main size' definition.</span><b><a href="#target-main-size">#target-main-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-main-size">9.7. 
 Resolving Flexible Lengths</a> <a href="#ref-for-target-main-size①">(2)</a> <a href="#ref-for-target-main-size②">(3)</a> <a href="#ref-for-target-main-size③">(4)</a> <a href="#ref-for-target-main-size④">(5)</a> <a href="#ref-for-target-main-size⑤">(6)</a> <a href="#ref-for-target-main-size⑥">(7)</a> <a href="#ref-for-target-main-size⑦">(8)</a> <a href="#ref-for-target-main-size⑧">(9)</a>
     <li><a href="#ref-for-target-main-size⑨"> Substantive Changes and Bugfixes</a> <a href="#ref-for-target-main-size①⓪">(2)</a> <a href="#ref-for-target-main-size①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-free-space">
-   <b><a href="#initial-free-space">#initial-free-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-free-space" class="dfn-panel" data-for="initial-free-space" id="infopanel-for-initial-free-space" role="dialog">
+   <span id="infopaneltitle-for-initial-free-space" style="display:none">Info about the 'initial free space' definition.</span><b><a href="#initial-free-space">#initial-free-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-free-space">9.7. 
 Resolving Flexible Lengths</a> <a href="#ref-for-initial-free-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remaining-free-space">
-   <b><a href="#remaining-free-space">#remaining-free-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remaining-free-space" class="dfn-panel" data-for="remaining-free-space" id="infopanel-for-remaining-free-space" role="dialog">
+   <span id="infopaneltitle-for-remaining-free-space" style="display:none">Info about the 'remaining free space' definition.</span><b><a href="#remaining-free-space">#remaining-free-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remaining-free-space">9.7. 
 Resolving Flexible Lengths</a> <a href="#ref-for-remaining-free-space①">(2)</a> <a href="#ref-for-remaining-free-space②">(3)</a> <a href="#ref-for-remaining-free-space③">(4)</a> <a href="#ref-for-remaining-free-space④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scaled-flex-shrink-factor">
-   <b><a href="#scaled-flex-shrink-factor">#scaled-flex-shrink-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scaled-flex-shrink-factor" class="dfn-panel" data-for="scaled-flex-shrink-factor" id="infopanel-for-scaled-flex-shrink-factor" role="dialog">
+   <span id="infopaneltitle-for-scaled-flex-shrink-factor" style="display:none">Info about the 'scaled flex shrink factor' definition.</span><b><a href="#scaled-flex-shrink-factor">#scaled-flex-shrink-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scaled-flex-shrink-factor">9.7. 
 Resolving Flexible Lengths</a> <a href="#ref-for-scaled-flex-shrink-factor①">(2)</a>
@@ -8544,8 +8546,8 @@ Flex Container Intrinsic Main Sizes</a> <a href="#ref-for-scaled-flex-shrink-fac
     <li><a href="#ref-for-scaled-flex-shrink-factor④"> Substantive Changes and Bugfixes</a> <a href="#ref-for-scaled-flex-shrink-factor⑤">(2)</a> <a href="#ref-for-scaled-flex-shrink-factor⑥">(3)</a> <a href="#ref-for-scaled-flex-shrink-factor⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="definite">
-   <b><a href="#definite">#definite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-definite" class="dfn-panel" data-for="definite" id="infopanel-for-definite" role="dialog">
+   <span id="infopaneltitle-for-definite" style="display:none">Info about the 'definite' definition.</span><b><a href="#definite">#definite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">4.5. 
 Automatic Minimum Size of Flex Items</a> <a href="#ref-for-definite①">(2)</a> <a href="#ref-for-definite②">(3)</a> <a href="#ref-for-definite③">(4)</a> <a href="#ref-for-definite④">(5)</a> <a href="#ref-for-definite⑤">(6)</a>
@@ -8565,59 +8567,115 @@ Definite and Indefinite Sizes</a> <a href="#ref-for-definite①⑤">(2)</a> <a h
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-font-loading-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-font-loading-3/Overview.html
@@ -2672,57 +2672,57 @@ to match with proper IDL practice.</p>
      <li><a href="#dom-fontfacedescriptors-weight">dict-member for FontFaceDescriptors</a><span>, in § 2</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-fontfacesetcheck-font">
-   <a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-font">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fontfacesetcheck-font" class="dfn-panel" data-for="term-for-dom-fontfacesetcheck-font" id="infopanel-for-term-for-dom-fontfacesetcheck-font" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fontfacesetcheck-font" style="display:none">Info about the 'font (for FontFaceSet/check())' external reference.</span><a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-font">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesetcheck-font">3.3. 
 The check() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fontfacesetload-font">
-   <a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-font">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fontfacesetload-font" class="dfn-panel" data-for="term-for-dom-fontfacesetload-font" id="infopanel-for-term-for-dom-fontfacesetload-font" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fontfacesetload-font" style="display:none">Info about the 'font (for FontFaceSet/load())' external reference.</span><a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-font">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesetload-font">3.2. 
 The load() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fontfacesetcheck-text">
-   <a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-text">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fontfacesetcheck-text" class="dfn-panel" data-for="term-for-dom-fontfacesetcheck-text" id="infopanel-for-term-for-dom-fontfacesetcheck-text" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fontfacesetcheck-text" style="display:none">Info about the 'text (for FontFaceSet/check())' external reference.</span><a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-text">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetcheck-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesetcheck-text">3.3. 
 The check() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-fontfacesetload-text">
-   <a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-text">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-fontfacesetload-text" class="dfn-panel" data-for="term-for-dom-fontfacesetload-text" id="infopanel-for-term-for-dom-fontfacesetload-text" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-fontfacesetload-text" style="display:none">Info about the 'text (for FontFaceSet/load())' external reference.</span><a href="https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-text">https://www.w3.org/TR/css-font-loading-3/#dom-fontfacesetload-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesetload-text">3.2. 
 The load() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-weight-bolder">
-   <a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bolder">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bolder</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-weight-bolder" class="dfn-panel" data-for="term-for-valdef-font-weight-bolder" id="infopanel-for-term-for-valdef-font-weight-bolder" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-weight-bolder" style="display:none">Info about the 'bolder' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bolder">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bolder</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bolder">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-weight-normal">
-   <a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-normal">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-weight-normal" class="dfn-panel" data-for="term-for-valdef-font-weight-normal" id="infopanel-for-term-for-valdef-font-weight-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-weight-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-normal">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-normal">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-font-face-rule">
-   <a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-font-face-rule" class="dfn-panel" data-for="term-for-at-font-face-rule" id="infopanel-for-term-for-at-font-face-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-font-face-rule" style="display:none">Info about the '@font-face' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-font-face-rule">1. 
 Introduction</a>
@@ -2744,8 +2744,8 @@ Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-at-font-face-rule
     <li><a href="#ref-for-at-font-face-rule③⓪"> Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">2. 
 The FontFace Interface</a> <a href="#ref-for-css-parse-something-according-to-a-css-grammar①">(2)</a>
@@ -2753,22 +2753,22 @@ The FontFace Interface</a> <a href="#ref-for-css-parse-something-according-to-a-
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2.1. 
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">2. 
 The FontFace Interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a> <a href="#ref-for-cssomstring⑤">(6)</a> <a href="#ref-for-cssomstring⑥">(7)</a> <a href="#ref-for-cssomstring⑦">(8)</a> <a href="#ref-for-cssomstring⑧">(9)</a> <a href="#ref-for-cssomstring⑨">(10)</a> <a href="#ref-for-cssomstring①⓪">(11)</a> <a href="#ref-for-cssomstring①①">(12)</a> <a href="#ref-for-cssomstring①②">(13)</a> <a href="#ref-for-cssomstring①③">(14)</a> <a href="#ref-for-cssomstring①④">(15)</a> <a href="#ref-for-cssomstring①⑤">(16)</a> <a href="#ref-for-cssomstring①⑥">(17)</a> <a href="#ref-for-cssomstring①⑦">(18)</a> <a href="#ref-for-cssomstring①⑧">(19)</a> <a href="#ref-for-cssomstring①⑨">(20)</a> <a href="#ref-for-cssomstring②⓪">(21)</a> <a href="#ref-for-cssomstring②①">(22)</a> <a href="#ref-for-cssomstring②②">(23)</a> <a href="#ref-for-cssomstring②③">(24)</a> <a href="#ref-for-cssomstring②④">(25)</a> <a href="#ref-for-cssomstring②⑤">(26)</a> <a href="#ref-for-cssomstring②⑥">(27)</a> <a href="#ref-for-cssomstring②⑦">(28)</a> <a href="#ref-for-cssomstring②⑧">(29)</a> <a href="#ref-for-cssomstring②⑨">(30)</a> <a href="#ref-for-cssomstring③⓪">(31)</a> <a href="#ref-for-cssomstring③①">(32)</a> <a href="#ref-for-cssomstring③②">(33)</a> <a href="#ref-for-cssomstring③③">(34)</a> <a href="#ref-for-cssomstring③④">(35)</a> <a href="#ref-for-cssomstring③⑤">(36)</a> <a href="#ref-for-cssomstring③⑥">(37)</a>
@@ -2778,15 +2778,15 @@ The Constructor</a> <a href="#ref-for-cssomstring③⑧">(2)</a>
 The FontFaceSet Interface</a> <a href="#ref-for-cssomstring④⓪">(2)</a> <a href="#ref-for-cssomstring④①">(3)</a> <a href="#ref-for-cssomstring④②">(4)</a> <a href="#ref-for-cssomstring④③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">
-   <a href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets">https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" class="dfn-panel" data-for="term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" id="infopanel-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" style="display:none">Info about the 'document or shadow root css style sheets' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets">https://drafts.csswg.org/cssom-1/#documentorshadowroot-document-or-shadow-root-css-style-sheets</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">4.2. 
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.5. 
 Interaction with CSS Font Loading and Matching</a>
@@ -2794,50 +2794,50 @@ Interaction with CSS Font Loading and Matching</a>
 The FontFaceSource Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-offscreencanvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas">https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-offscreencanvas" class="dfn-panel" data-for="term-for-offscreencanvas" id="infopanel-for-term-for-offscreencanvas" role="menu">
+   <span id="infopaneltitle-for-term-for-offscreencanvas" style="display:none">Info about the 'OffscreenCanvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas">https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offscreencanvas">4.1. 
 Worker FontFaceSources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4. 
 The FontFaceSource Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">2. 
 The FontFace Interface</a>
@@ -2845,8 +2845,8 @@ The FontFace Interface</a>
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ArrayBufferView">
-   <a href="https://webidl.spec.whatwg.org/#ArrayBufferView">https://webidl.spec.whatwg.org/#ArrayBufferView</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ArrayBufferView" class="dfn-panel" data-for="term-for-ArrayBufferView" id="infopanel-for-term-for-ArrayBufferView" role="menu">
+   <span id="infopaneltitle-for-term-for-ArrayBufferView" style="display:none">Info about the 'ArrayBufferView' external reference.</span><a href="https://webidl.spec.whatwg.org/#ArrayBufferView">https://webidl.spec.whatwg.org/#ArrayBufferView</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ArrayBufferView">2. 
 The FontFace Interface</a>
@@ -2854,8 +2854,8 @@ The FontFace Interface</a>
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. 
 The FontFace Interface</a>
@@ -2863,15 +2863,15 @@ The FontFace Interface</a>
 The FontFaceSet Interface</a> <a href="#ref-for-Exposed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">3. 
 The FontFaceSet Interface</a>
@@ -2879,8 +2879,8 @@ The FontFaceSet Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">1.1. 
 Values</a>
@@ -2894,43 +2894,43 @@ The FontFaceSet Interface</a> <a href="#ref-for-idl-promise⑤">(2)</a> <a href=
 The ready attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">2. 
 The FontFace Interface</a> <a href="#ref-for-syntaxerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-entries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-set-entries">https://webidl.spec.whatwg.org/#dfn-set-entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-entries" class="dfn-panel" data-for="term-for-dfn-set-entries" id="infopanel-for-term-for-dfn-set-entries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-entries" style="display:none">Info about the 'set entries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-set-entries">https://webidl.spec.whatwg.org/#dfn-set-entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-entries">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-dfn-set-entries①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. 
 The FontFaceSet Interface</a>
@@ -3145,8 +3145,8 @@ or should they use their worker url?
 Is that always defined? <a class="issue-return" href="#issue-65bdbf2d" title="Jump to section">↵</a></div>
    <div class="issue"> When a FontFace is transferred between documents, it’s no longer CSS-connected. <a class="issue-return" href="#issue-41199acf" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedefdef-binarydata">
-   <b><a href="#typedefdef-binarydata">#typedefdef-binarydata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-binarydata" class="dfn-panel" data-for="typedefdef-binarydata" id="infopanel-for-typedefdef-binarydata" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-binarydata" style="display:none">Info about the 'BinaryData' definition.</span><b><a href="#typedefdef-binarydata">#typedefdef-binarydata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-binarydata">2. 
 The FontFace Interface</a>
@@ -3154,22 +3154,22 @@ The FontFace Interface</a>
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fontfacedescriptors">
-   <b><a href="#dictdef-fontfacedescriptors">#dictdef-fontfacedescriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fontfacedescriptors" class="dfn-panel" data-for="dictdef-fontfacedescriptors" id="infopanel-for-dictdef-fontfacedescriptors" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fontfacedescriptors" style="display:none">Info about the 'FontFaceDescriptors' definition.</span><b><a href="#dictdef-fontfacedescriptors">#dictdef-fontfacedescriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fontfacedescriptors">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fontfaceloadstatus">
-   <b><a href="#enumdef-fontfaceloadstatus">#enumdef-fontfaceloadstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fontfaceloadstatus" class="dfn-panel" data-for="enumdef-fontfaceloadstatus" id="infopanel-for-enumdef-fontfaceloadstatus" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fontfaceloadstatus" style="display:none">Info about the 'FontFaceLoadStatus' definition.</span><b><a href="#enumdef-fontfaceloadstatus">#enumdef-fontfaceloadstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fontfaceloadstatus">2. 
 The FontFace Interface</a> <a href="#ref-for-enumdef-fontfaceloadstatus①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontface">
-   <b><a href="#fontface">#fontface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontface" class="dfn-panel" data-for="fontface" id="infopanel-for-fontface" role="dialog">
+   <span id="infopaneltitle-for-fontface" style="display:none">Info about the 'FontFace' definition.</span><b><a href="#fontface">#fontface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontface">1. 
 Introduction</a>
@@ -3197,29 +3197,29 @@ Worker FontFaceSources</a>
 Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-fontface④⑦">(2)</a> <a href="#ref-for-fontface④⑧">(3)</a> <a href="#ref-for-fontface④⑨">(4)</a> <a href="#ref-for-fontface⑤⓪">(5)</a> <a href="#ref-for-fontface⑤①">(6)</a> <a href="#ref-for-fontface⑤②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-family">
-   <b><a href="#dom-fontface-fontface-family-source-descriptors-family">#dom-fontface-fontface-family-source-descriptors-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-family" class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-family" id="infopanel-for-dom-fontface-fontface-family-source-descriptors-family" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-family" style="display:none">Info about the 'family' definition.</span><b><a href="#dom-fontface-fontface-family-source-descriptors-family">#dom-fontface-fontface-family-source-descriptors-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-fontface-family-source-descriptors-family">2.1. 
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-source">
-   <b><a href="#dom-fontface-fontface-family-source-descriptors-source">#dom-fontface-fontface-family-source-descriptors-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-source" class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-source" id="infopanel-for-dom-fontface-fontface-family-source-descriptors-source" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-fontface-fontface-family-source-descriptors-source">#dom-fontface-fontface-family-source-descriptors-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-fontface-family-source-descriptors-source">2.1. 
 The Constructor</a> <a href="#ref-for-dom-fontface-fontface-family-source-descriptors-source①">(2)</a> <a href="#ref-for-dom-fontface-fontface-family-source-descriptors-source②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-descriptors">
-   <b><a href="#dom-fontface-fontface-family-source-descriptors-descriptors">#dom-fontface-fontface-family-source-descriptors-descriptors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-descriptors" class="dfn-panel" data-for="dom-fontface-fontface-family-source-descriptors-descriptors" id="infopanel-for-dom-fontface-fontface-family-source-descriptors-descriptors" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-fontface-family-source-descriptors-descriptors" style="display:none">Info about the 'descriptors' definition.</span><b><a href="#dom-fontface-fontface-family-source-descriptors-descriptors">#dom-fontface-fontface-family-source-descriptors-descriptors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-fontface-family-source-descriptors-descriptors">2.1. 
 The Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-family">
-   <b><a href="#dom-fontface-family">#dom-fontface-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-family" class="dfn-panel" data-for="dom-fontface-family" id="infopanel-for-dom-fontface-family" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-family" style="display:none">Info about the 'family' definition.</span><b><a href="#dom-fontface-family">#dom-fontface-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-family">2. 
 The FontFace Interface</a>
@@ -3227,8 +3227,8 @@ The FontFace Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-style">
-   <b><a href="#dom-fontface-style">#dom-fontface-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-style" class="dfn-panel" data-for="dom-fontface-style" id="infopanel-for-dom-fontface-style" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-fontface-style">#dom-fontface-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-style">2. 
 The FontFace Interface</a> <a href="#ref-for-dom-fontface-style①">(2)</a>
@@ -3236,8 +3236,8 @@ The FontFace Interface</a> <a href="#ref-for-dom-fontface-style①">(2)</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-weight">
-   <b><a href="#dom-fontface-weight">#dom-fontface-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-weight" class="dfn-panel" data-for="dom-fontface-weight" id="infopanel-for-dom-fontface-weight" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-weight" style="display:none">Info about the 'weight' definition.</span><b><a href="#dom-fontface-weight">#dom-fontface-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-weight">2. 
 The FontFace Interface</a>
@@ -3245,8 +3245,8 @@ The FontFace Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-stretch">
-   <b><a href="#dom-fontface-stretch">#dom-fontface-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-stretch" class="dfn-panel" data-for="dom-fontface-stretch" id="infopanel-for-dom-fontface-stretch" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#dom-fontface-stretch">#dom-fontface-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-stretch">2. 
 The FontFace Interface</a>
@@ -3254,8 +3254,8 @@ The FontFace Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-unicoderange">
-   <b><a href="#dom-fontface-unicoderange">#dom-fontface-unicoderange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-unicoderange" class="dfn-panel" data-for="dom-fontface-unicoderange" id="infopanel-for-dom-fontface-unicoderange" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-unicoderange" style="display:none">Info about the 'unicodeRange' definition.</span><b><a href="#dom-fontface-unicoderange">#dom-fontface-unicoderange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-unicoderange">2. 
 The FontFace Interface</a>
@@ -3265,8 +3265,8 @@ Interaction with CSS’s @font-face Rule</a>
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-variant">
-   <b><a href="#dom-fontface-variant">#dom-fontface-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-variant" class="dfn-panel" data-for="dom-fontface-variant" id="infopanel-for-dom-fontface-variant" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-variant" style="display:none">Info about the 'variant' definition.</span><b><a href="#dom-fontface-variant">#dom-fontface-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-variant">2. 
 The FontFace Interface</a>
@@ -3274,8 +3274,8 @@ The FontFace Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-featuresettings">
-   <b><a href="#dom-fontface-featuresettings">#dom-fontface-featuresettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-featuresettings" class="dfn-panel" data-for="dom-fontface-featuresettings" id="infopanel-for-dom-fontface-featuresettings" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-featuresettings" style="display:none">Info about the 'featureSettings' definition.</span><b><a href="#dom-fontface-featuresettings">#dom-fontface-featuresettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-featuresettings">2. 
 The FontFace Interface</a>
@@ -3283,45 +3283,45 @@ The FontFace Interface</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-variationsettings">
-   <b><a href="#dom-fontface-variationsettings">#dom-fontface-variationsettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-variationsettings" class="dfn-panel" data-for="dom-fontface-variationsettings" id="infopanel-for-dom-fontface-variationsettings" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-variationsettings" style="display:none">Info about the 'variationSettings' definition.</span><b><a href="#dom-fontface-variationsettings">#dom-fontface-variationsettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-variationsettings">2. 
 The FontFace Interface</a>
     <li><a href="#ref-for-dom-fontface-variationsettings①">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-display">
-   <b><a href="#dom-fontface-display">#dom-fontface-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-display" class="dfn-panel" data-for="dom-fontface-display" id="infopanel-for-dom-fontface-display" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-display" style="display:none">Info about the 'display' definition.</span><b><a href="#dom-fontface-display">#dom-fontface-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-display">2. 
 The FontFace Interface</a>
     <li><a href="#ref-for-dom-fontface-display①">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-ascentoverride">
-   <b><a href="#dom-fontface-ascentoverride">#dom-fontface-ascentoverride</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-ascentoverride" class="dfn-panel" data-for="dom-fontface-ascentoverride" id="infopanel-for-dom-fontface-ascentoverride" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-ascentoverride" style="display:none">Info about the 'ascentOverride' definition.</span><b><a href="#dom-fontface-ascentoverride">#dom-fontface-ascentoverride</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-ascentoverride">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-descentoverride">
-   <b><a href="#dom-fontface-descentoverride">#dom-fontface-descentoverride</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-descentoverride" class="dfn-panel" data-for="dom-fontface-descentoverride" id="infopanel-for-dom-fontface-descentoverride" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-descentoverride" style="display:none">Info about the 'descentOverride' definition.</span><b><a href="#dom-fontface-descentoverride">#dom-fontface-descentoverride</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-descentoverride">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-linegapoverride">
-   <b><a href="#dom-fontface-linegapoverride">#dom-fontface-linegapoverride</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-linegapoverride" class="dfn-panel" data-for="dom-fontface-linegapoverride" id="infopanel-for-dom-fontface-linegapoverride" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-linegapoverride" style="display:none">Info about the 'lineGapOverride' definition.</span><b><a href="#dom-fontface-linegapoverride">#dom-fontface-linegapoverride</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-linegapoverride">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-status">
-   <b><a href="#dom-fontface-status">#dom-fontface-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-status" class="dfn-panel" data-for="dom-fontface-status" id="infopanel-for-dom-fontface-status" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-fontface-status">#dom-fontface-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-status">2. 
 The FontFace Interface</a>
@@ -3335,15 +3335,15 @@ The FontFaceSet Interface</a>
 The check() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-loaded">
-   <b><a href="#dom-fontface-loaded">#dom-fontface-loaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-loaded" class="dfn-panel" data-for="dom-fontface-loaded" id="infopanel-for-dom-fontface-loaded" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-loaded" style="display:none">Info about the 'loaded' definition.</span><b><a href="#dom-fontface-loaded">#dom-fontface-loaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-loaded">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-fontstatuspromise-slot">
-   <b><a href="#dom-fontface-fontstatuspromise-slot">#dom-fontface-fontstatuspromise-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-fontstatuspromise-slot" class="dfn-panel" data-for="dom-fontface-fontstatuspromise-slot" id="infopanel-for-dom-fontface-fontstatuspromise-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-fontstatuspromise-slot" style="display:none">Info about the '[[FontStatusPromise]]' definition.</span><b><a href="#dom-fontface-fontstatuspromise-slot">#dom-fontface-fontstatuspromise-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-fontstatuspromise-slot">2. 
 The FontFace Interface</a>
@@ -3355,8 +3355,8 @@ The load() method</a> <a href="#ref-for-dom-fontface-fontstatuspromise-slot⑥">
 The load() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-urls-slot">
-   <b><a href="#dom-fontface-urls-slot">#dom-fontface-urls-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-urls-slot" class="dfn-panel" data-for="dom-fontface-urls-slot" id="infopanel-for-dom-fontface-urls-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-urls-slot" style="display:none">Info about the '[[Urls]]' definition.</span><b><a href="#dom-fontface-urls-slot">#dom-fontface-urls-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-urls-slot">2.1. 
 The Constructor</a>
@@ -3366,22 +3366,22 @@ The load() method</a> <a href="#ref-for-dom-fontface-urls-slot②">(2)</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-data-slot">
-   <b><a href="#dom-fontface-data-slot">#dom-fontface-data-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-data-slot" class="dfn-panel" data-for="dom-fontface-data-slot" id="infopanel-for-dom-fontface-data-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-data-slot" style="display:none">Info about the '[[Data]]' definition.</span><b><a href="#dom-fontface-data-slot">#dom-fontface-data-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-data-slot">2.1. 
 The Constructor</a> <a href="#ref-for-dom-fontface-data-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-fontface">
-   <b><a href="#dom-fontface-fontface">#dom-fontface-fontface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-fontface" class="dfn-panel" data-for="dom-fontface-fontface" id="infopanel-for-dom-fontface-fontface" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-fontface" style="display:none">Info about the 'FontFace(family, source, descriptors)' definition.</span><b><a href="#dom-fontface-fontface">#dom-fontface-fontface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-fontface">2. 
 The FontFace Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontface-load">
-   <b><a href="#dom-fontface-load">#dom-fontface-load</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontface-load" class="dfn-panel" data-for="dom-fontface-load" id="infopanel-for-dom-fontface-load" role="dialog">
+   <span id="infopaneltitle-for-dom-fontface-load" style="display:none">Info about the 'load()' definition.</span><b><a href="#dom-fontface-load">#dom-fontface-load</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontface-load">2. 
 The FontFace Interface</a> <a href="#ref-for-dom-fontface-load①">(2)</a>
@@ -3395,8 +3395,8 @@ The ready attribute</a>
 Interaction with CSS Font Loading and Matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-connected">
-   <b><a href="#css-connected">#css-connected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-connected" class="dfn-panel" data-for="css-connected" id="infopanel-for-css-connected" role="dialog">
+   <span id="infopaneltitle-for-css-connected" style="display:none">Info about the 'CSS-connected' definition.</span><b><a href="#css-connected">#css-connected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-connected">2.3. 
 Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-css-connected①">(2)</a> <a href="#ref-for-css-connected②">(3)</a> <a href="#ref-for-css-connected③">(4)</a>
@@ -3406,37 +3406,37 @@ The FontFaceSet Interface</a> <a href="#ref-for-css-connected⑤">(2)</a> <a hre
 Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-css-connected⑨">(2)</a> <a href="#ref-for-css-connected①⓪">(3)</a> <a href="#ref-for-css-connected①①">(4)</a> <a href="#ref-for-css-connected①②">(5)</a> <a href="#ref-for-css-connected①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fontfacesetloadeventinit">
-   <b><a href="#dictdef-fontfacesetloadeventinit">#dictdef-fontfacesetloadeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fontfacesetloadeventinit" class="dfn-panel" data-for="dictdef-fontfacesetloadeventinit" id="infopanel-for-dictdef-fontfacesetloadeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fontfacesetloadeventinit" style="display:none">Info about the 'FontFaceSetLoadEventInit' definition.</span><b><a href="#dictdef-fontfacesetloadeventinit">#dictdef-fontfacesetloadeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fontfacesetloadeventinit">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfacesetloadevent">
-   <b><a href="#fontfacesetloadevent">#fontfacesetloadevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfacesetloadevent" class="dfn-panel" data-for="fontfacesetloadevent" id="infopanel-for-fontfacesetloadevent" role="dialog">
+   <span id="infopaneltitle-for-fontfacesetloadevent" style="display:none">Info about the 'FontFaceSetLoadEvent' definition.</span><b><a href="#fontfacesetloadevent">#fontfacesetloadevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfacesetloadevent">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfacesetloadevent-fontfaces">
-   <b><a href="#dom-fontfacesetloadevent-fontfaces">#dom-fontfacesetloadevent-fontfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfacesetloadevent-fontfaces" class="dfn-panel" data-for="dom-fontfacesetloadevent-fontfaces" id="infopanel-for-dom-fontfacesetloadevent-fontfaces" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfacesetloadevent-fontfaces" style="display:none">Info about the 'fontfaces' definition.</span><b><a href="#dom-fontfacesetloadevent-fontfaces">#dom-fontfacesetloadevent-fontfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesetloadevent-fontfaces">3.1. 
 Events</a>
     <li><a href="#ref-for-dom-fontfacesetloadevent-fontfaces①">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fontfacesetloadstatus">
-   <b><a href="#enumdef-fontfacesetloadstatus">#enumdef-fontfacesetloadstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fontfacesetloadstatus" class="dfn-panel" data-for="enumdef-fontfacesetloadstatus" id="infopanel-for-enumdef-fontfacesetloadstatus" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fontfacesetloadstatus" style="display:none">Info about the 'FontFaceSetLoadStatus' definition.</span><b><a href="#enumdef-fontfacesetloadstatus">#enumdef-fontfacesetloadstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fontfacesetloadstatus">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfaceset">
-   <b><a href="#fontfaceset">#fontfaceset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfaceset" class="dfn-panel" data-for="fontfaceset" id="infopanel-for-fontfaceset" role="dialog">
+   <span id="infopaneltitle-for-fontfaceset" style="display:none">Info about the 'FontFaceSet' definition.</span><b><a href="#fontfaceset">#fontfaceset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfaceset">2.1. 
 The Constructor</a> <a href="#ref-for-fontfaceset①">(2)</a> <a href="#ref-for-fontfaceset②">(3)</a> <a href="#ref-for-fontfaceset③">(4)</a> <a href="#ref-for-fontfaceset④">(5)</a> <a href="#ref-for-fontfaceset⑤">(6)</a> <a href="#ref-for-fontfaceset⑥">(7)</a> <a href="#ref-for-fontfaceset⑦">(8)</a> <a href="#ref-for-fontfaceset⑧">(9)</a>
@@ -3459,43 +3459,43 @@ Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-fontfaceset⑤③
     <li><a href="#ref-for-fontfaceset⑤④"> Privacy &amp; Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-fontfaceset-initialfaces-initialfaces">
-   <b><a href="#dom-fontfaceset-fontfaceset-initialfaces-initialfaces">#dom-fontfaceset-fontfaceset-initialfaces-initialfaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-fontfaceset-initialfaces-initialfaces" class="dfn-panel" data-for="dom-fontfaceset-fontfaceset-initialfaces-initialfaces" id="infopanel-for-dom-fontfaceset-fontfaceset-initialfaces-initialfaces" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-fontfaceset-initialfaces-initialfaces" style="display:none">Info about the 'initialFaces' definition.</span><b><a href="#dom-fontfaceset-fontfaceset-initialfaces-initialfaces">#dom-fontfaceset-fontfaceset-initialfaces-initialfaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-fontfaceset-initialfaces-initialfaces">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-onloading">
-   <b><a href="#dom-fontfaceset-onloading">#dom-fontfaceset-onloading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-onloading" class="dfn-panel" data-for="dom-fontfaceset-onloading" id="infopanel-for-dom-fontfaceset-onloading" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-onloading" style="display:none">Info about the 'onloading' definition.</span><b><a href="#dom-fontfaceset-onloading">#dom-fontfaceset-onloading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-onloading">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-onloadingdone">
-   <b><a href="#dom-fontfaceset-onloadingdone">#dom-fontfaceset-onloadingdone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-onloadingdone" class="dfn-panel" data-for="dom-fontfaceset-onloadingdone" id="infopanel-for-dom-fontfaceset-onloadingdone" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-onloadingdone" style="display:none">Info about the 'onloadingdone' definition.</span><b><a href="#dom-fontfaceset-onloadingdone">#dom-fontfaceset-onloadingdone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-onloadingdone">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-onloadingerror">
-   <b><a href="#dom-fontfaceset-onloadingerror">#dom-fontfaceset-onloadingerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-onloadingerror" class="dfn-panel" data-for="dom-fontfaceset-onloadingerror" id="infopanel-for-dom-fontfaceset-onloadingerror" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-onloadingerror" style="display:none">Info about the 'onloadingerror' definition.</span><b><a href="#dom-fontfaceset-onloadingerror">#dom-fontfaceset-onloadingerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-onloadingerror">3.1. 
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-status">
-   <b><a href="#dom-fontfaceset-status">#dom-fontfaceset-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-status" class="dfn-panel" data-for="dom-fontfaceset-status" id="infopanel-for-dom-fontfaceset-status" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-fontfaceset-status">#dom-fontfaceset-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-status">3.1. 
 Events</a> <a href="#ref-for-dom-fontfaceset-status①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-ready">
-   <b><a href="#dom-fontfaceset-ready">#dom-fontfaceset-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-ready" class="dfn-panel" data-for="dom-fontfaceset-ready" id="infopanel-for-dom-fontfaceset-ready" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#dom-fontfaceset-ready">#dom-fontfaceset-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-ready">3. 
 The FontFaceSet Interface</a>
@@ -3503,15 +3503,15 @@ The FontFaceSet Interface</a>
 The ready attribute</a> <a href="#ref-for-dom-fontfaceset-ready②">(2)</a> <a href="#ref-for-dom-fontfaceset-ready③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-fontfaceset">
-   <b><a href="#dom-fontfaceset-fontfaceset">#dom-fontfaceset-fontfaceset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-fontfaceset" class="dfn-panel" data-for="dom-fontfaceset-fontfaceset" id="infopanel-for-dom-fontfaceset-fontfaceset" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-fontfaceset" style="display:none">Info about the 'FontFaceSet(initialFaces)' definition.</span><b><a href="#dom-fontfaceset-fontfaceset">#dom-fontfaceset-fontfaceset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-fontfaceset">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfaceset-set-entries">
-   <b><a href="#fontfaceset-set-entries">#fontfaceset-set-entries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfaceset-set-entries" class="dfn-panel" data-for="fontfaceset-set-entries" id="infopanel-for-fontfaceset-set-entries" role="dialog">
+   <span id="infopaneltitle-for-fontfaceset-set-entries" style="display:none">Info about the 'set entries' definition.</span><b><a href="#fontfaceset-set-entries">#fontfaceset-set-entries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfaceset-set-entries">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-fontfaceset-set-entries①">(2)</a> <a href="#ref-for-fontfaceset-set-entries②">(3)</a> <a href="#ref-for-fontfaceset-set-entries③">(4)</a> <a href="#ref-for-fontfaceset-set-entries④">(5)</a>
@@ -3519,8 +3519,8 @@ The FontFaceSet Interface</a> <a href="#ref-for-fontfaceset-set-entries①">(2)<
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-add">
-   <b><a href="#dom-fontfaceset-add">#dom-fontfaceset-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-add" class="dfn-panel" data-for="dom-fontfaceset-add" id="infopanel-for-dom-fontfaceset-add" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-add" style="display:none">Info about the 'add(font)' definition.</span><b><a href="#dom-fontfaceset-add">#dom-fontfaceset-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-add">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-add①">(2)</a>
@@ -3528,8 +3528,8 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-add①">(2)</a>
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-delete">
-   <b><a href="#dom-fontfaceset-delete">#dom-fontfaceset-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-delete" class="dfn-panel" data-for="dom-fontfaceset-delete" id="infopanel-for-dom-fontfaceset-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-delete" style="display:none">Info about the 'delete(font)' definition.</span><b><a href="#dom-fontfaceset-delete">#dom-fontfaceset-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-delete">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-delete①">(2)</a>
@@ -3537,15 +3537,15 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-delete①">(2)</
 Interaction with CSS’s @font-face Rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-clear">
-   <b><a href="#dom-fontfaceset-clear">#dom-fontfaceset-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-clear" class="dfn-panel" data-for="dom-fontfaceset-clear" id="infopanel-for-dom-fontfaceset-clear" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-clear" style="display:none">Info about the 'clear()' definition.</span><b><a href="#dom-fontfaceset-clear">#dom-fontfaceset-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-clear">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-clear①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-loadingfonts-slot">
-   <b><a href="#dom-fontfaceset-loadingfonts-slot">#dom-fontfaceset-loadingfonts-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-loadingfonts-slot" class="dfn-panel" data-for="dom-fontfaceset-loadingfonts-slot" id="infopanel-for-dom-fontfaceset-loadingfonts-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-loadingfonts-slot" style="display:none">Info about the '[[LoadingFonts]]' definition.</span><b><a href="#dom-fontfaceset-loadingfonts-slot">#dom-fontfaceset-loadingfonts-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-loadingfonts-slot">2.1. 
 The Constructor</a> <a href="#ref-for-dom-fontfaceset-loadingfonts-slot①">(2)</a> <a href="#ref-for-dom-fontfaceset-loadingfonts-slot②">(3)</a> <a href="#ref-for-dom-fontfaceset-loadingfonts-slot③">(4)</a>
@@ -3557,8 +3557,8 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-loadingfonts-slo
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-loadedfonts-slot">
-   <b><a href="#dom-fontfaceset-loadedfonts-slot">#dom-fontfaceset-loadedfonts-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-loadedfonts-slot" class="dfn-panel" data-for="dom-fontfaceset-loadedfonts-slot" id="infopanel-for-dom-fontfaceset-loadedfonts-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-loadedfonts-slot" style="display:none">Info about the '[[LoadedFonts]]' definition.</span><b><a href="#dom-fontfaceset-loadedfonts-slot">#dom-fontfaceset-loadedfonts-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-loadedfonts-slot">2.1. 
 The Constructor</a>
@@ -3570,8 +3570,8 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-loadedfonts-slot
 Events</a> <a href="#ref-for-dom-fontfaceset-loadedfonts-slot⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-failedfonts-slot">
-   <b><a href="#dom-fontfaceset-failedfonts-slot">#dom-fontfaceset-failedfonts-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-failedfonts-slot" class="dfn-panel" data-for="dom-fontfaceset-failedfonts-slot" id="infopanel-for-dom-fontfaceset-failedfonts-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-failedfonts-slot" style="display:none">Info about the '[[FailedFonts]]' definition.</span><b><a href="#dom-fontfaceset-failedfonts-slot">#dom-fontfaceset-failedfonts-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-failedfonts-slot">2.1. 
 The Constructor</a>
@@ -3583,8 +3583,8 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-failedfonts-slot
 Events</a> <a href="#ref-for-dom-fontfaceset-failedfonts-slot⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-readypromise-slot">
-   <b><a href="#dom-fontfaceset-readypromise-slot">#dom-fontfaceset-readypromise-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-readypromise-slot" class="dfn-panel" data-for="dom-fontfaceset-readypromise-slot" id="infopanel-for-dom-fontfaceset-readypromise-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-readypromise-slot" style="display:none">Info about the '[[ReadyPromise]]' definition.</span><b><a href="#dom-fontfaceset-readypromise-slot">#dom-fontfaceset-readypromise-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-readypromise-slot">3. 
 The FontFaceSet Interface</a>
@@ -3592,8 +3592,8 @@ The FontFaceSet Interface</a>
 Events</a> <a href="#ref-for-dom-fontfaceset-readypromise-slot②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfaceset-pending-on-the-environment">
-   <b><a href="#fontfaceset-pending-on-the-environment">#fontfaceset-pending-on-the-environment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfaceset-pending-on-the-environment" class="dfn-panel" data-for="fontfaceset-pending-on-the-environment" id="infopanel-for-fontfaceset-pending-on-the-environment" role="dialog">
+   <span id="infopaneltitle-for-fontfaceset-pending-on-the-environment" style="display:none">Info about the 'pending on the environment' definition.</span><b><a href="#fontfaceset-pending-on-the-environment">#fontfaceset-pending-on-the-environment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfaceset-pending-on-the-environment">3. 
 The FontFaceSet Interface</a>
@@ -3601,15 +3601,15 @@ The FontFaceSet Interface</a>
 Events</a> <a href="#ref-for-fontfaceset-pending-on-the-environment②">(2)</a> <a href="#ref-for-fontfaceset-pending-on-the-environment③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-fontfaceset-loading">
-   <b><a href="#eventdef-fontfaceset-loading">#eventdef-fontfaceset-loading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-fontfaceset-loading" class="dfn-panel" data-for="eventdef-fontfaceset-loading" id="infopanel-for-eventdef-fontfaceset-loading" role="dialog">
+   <span id="infopaneltitle-for-eventdef-fontfaceset-loading" style="display:none">Info about the 'loading' definition.</span><b><a href="#eventdef-fontfaceset-loading">#eventdef-fontfaceset-loading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-fontfaceset-loading">3.1. 
 Events</a> <a href="#ref-for-eventdef-fontfaceset-loading①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-fontfaceset-loadingdone">
-   <b><a href="#eventdef-fontfaceset-loadingdone">#eventdef-fontfaceset-loadingdone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-fontfaceset-loadingdone" class="dfn-panel" data-for="eventdef-fontfaceset-loadingdone" id="infopanel-for-eventdef-fontfaceset-loadingdone" role="dialog">
+   <span id="infopaneltitle-for-eventdef-fontfaceset-loadingdone" style="display:none">Info about the 'loadingdone' definition.</span><b><a href="#eventdef-fontfaceset-loadingdone">#eventdef-fontfaceset-loadingdone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-fontfaceset-loadingdone">3.1. 
 Events</a> <a href="#ref-for-eventdef-fontfaceset-loadingdone①">(2)</a>
@@ -3619,22 +3619,22 @@ The ready attribute</a>
 API Examples</a> <a href="#ref-for-eventdef-fontfaceset-loadingdone④">(2)</a> <a href="#ref-for-eventdef-fontfaceset-loadingdone⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-fontfaceset-loadingerror">
-   <b><a href="#eventdef-fontfaceset-loadingerror">#eventdef-fontfaceset-loadingerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-fontfaceset-loadingerror" class="dfn-panel" data-for="eventdef-fontfaceset-loadingerror" id="infopanel-for-eventdef-fontfaceset-loadingerror" role="dialog">
+   <span id="infopaneltitle-for-eventdef-fontfaceset-loadingerror" style="display:none">Info about the 'loadingerror' definition.</span><b><a href="#eventdef-fontfaceset-loadingerror">#eventdef-fontfaceset-loadingerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-fontfaceset-loadingerror">3.1. 
 Events</a> <a href="#ref-for-eventdef-fontfaceset-loadingerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-font-load-event">
-   <b><a href="#fire-a-font-load-event">#fire-a-font-load-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-font-load-event" class="dfn-panel" data-for="fire-a-font-load-event" id="infopanel-for-fire-a-font-load-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-font-load-event" style="display:none">Info about the 'fire a font load event' definition.</span><b><a href="#fire-a-font-load-event">#fire-a-font-load-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-font-load-event">3.1. 
 Events</a> <a href="#ref-for-fire-a-font-load-event①">(2)</a> <a href="#ref-for-fire-a-font-load-event②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="switch-the-fontfaceset-to-loading">
-   <b><a href="#switch-the-fontfaceset-to-loading">#switch-the-fontfaceset-to-loading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-switch-the-fontfaceset-to-loading" class="dfn-panel" data-for="switch-the-fontfaceset-to-loading" id="infopanel-for-switch-the-fontfaceset-to-loading" role="dialog">
+   <span id="infopaneltitle-for-switch-the-fontfaceset-to-loading" style="display:none">Info about the 'switch the FontFaceSet to loading' definition.</span><b><a href="#switch-the-fontfaceset-to-loading">#switch-the-fontfaceset-to-loading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-switch-the-fontfaceset-to-loading">2.1. 
 The Constructor</a>
@@ -3642,8 +3642,8 @@ The Constructor</a>
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="switch-the-fontfaceset-to-loaded">
-   <b><a href="#switch-the-fontfaceset-to-loaded">#switch-the-fontfaceset-to-loaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-switch-the-fontfaceset-to-loaded" class="dfn-panel" data-for="switch-the-fontfaceset-to-loaded" id="infopanel-for-switch-the-fontfaceset-to-loaded" role="dialog">
+   <span id="infopaneltitle-for-switch-the-fontfaceset-to-loaded" style="display:none">Info about the 'switch the FontFaceSet to loaded' definition.</span><b><a href="#switch-the-fontfaceset-to-loaded">#switch-the-fontfaceset-to-loaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-switch-the-fontfaceset-to-loaded">2.1. 
 The Constructor</a> <a href="#ref-for-switch-the-fontfaceset-to-loaded①">(2)</a>
@@ -3655,15 +3655,15 @@ The FontFaceSet Interface</a> <a href="#ref-for-switch-the-fontfaceset-to-loaded
 Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfaceset-stuck-on-the-environment">
-   <b><a href="#fontfaceset-stuck-on-the-environment">#fontfaceset-stuck-on-the-environment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfaceset-stuck-on-the-environment" class="dfn-panel" data-for="fontfaceset-stuck-on-the-environment" id="infopanel-for-fontfaceset-stuck-on-the-environment" role="dialog">
+   <span id="infopaneltitle-for-fontfaceset-stuck-on-the-environment" style="display:none">Info about the 'stuck on the environment' definition.</span><b><a href="#fontfaceset-stuck-on-the-environment">#fontfaceset-stuck-on-the-environment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfaceset-stuck-on-the-environment">3.1. 
 Events</a> <a href="#ref-for-fontfaceset-stuck-on-the-environment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-the-matching-font-faces">
-   <b><a href="#find-the-matching-font-faces">#find-the-matching-font-faces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-the-matching-font-faces" class="dfn-panel" data-for="find-the-matching-font-faces" id="infopanel-for-find-the-matching-font-faces" role="dialog">
+   <span id="infopaneltitle-for-find-the-matching-font-faces" style="display:none">Info about the 'find the matching font faces' definition.</span><b><a href="#find-the-matching-font-faces">#find-the-matching-font-faces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-the-matching-font-faces">3.2. 
 The load() method</a>
@@ -3671,8 +3671,8 @@ The load() method</a>
 The check() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-load">
-   <b><a href="#dom-fontfaceset-load">#dom-fontfaceset-load</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-load" class="dfn-panel" data-for="dom-fontfaceset-load" id="infopanel-for-dom-fontfaceset-load" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-load" style="display:none">Info about the 'load' definition.</span><b><a href="#dom-fontfaceset-load">#dom-fontfaceset-load</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-load">3. 
 The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-load①">(2)</a>
@@ -3680,22 +3680,22 @@ The FontFaceSet Interface</a> <a href="#ref-for-dom-fontfaceset-load①">(2)</a>
 The load() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-load-font-text-font">
-   <b><a href="#dom-fontfaceset-load-font-text-font">#dom-fontfaceset-load-font-text-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-load-font-text-font" class="dfn-panel" data-for="dom-fontfaceset-load-font-text-font" id="infopanel-for-dom-fontfaceset-load-font-text-font" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-load-font-text-font" style="display:none">Info about the 'font' definition.</span><b><a href="#dom-fontfaceset-load-font-text-font">#dom-fontfaceset-load-font-text-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-load-font-text-font">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-load-font-text-text">
-   <b><a href="#dom-fontfaceset-load-font-text-text">#dom-fontfaceset-load-font-text-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-load-font-text-text" class="dfn-panel" data-for="dom-fontfaceset-load-font-text-text" id="infopanel-for-dom-fontfaceset-load-font-text-text" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-load-font-text-text" style="display:none">Info about the 'text' definition.</span><b><a href="#dom-fontfaceset-load-font-text-text">#dom-fontfaceset-load-font-text-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-load-font-text-text">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-check">
-   <b><a href="#dom-fontfaceset-check">#dom-fontfaceset-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-check" class="dfn-panel" data-for="dom-fontfaceset-check" id="infopanel-for-dom-fontfaceset-check" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-check" style="display:none">Info about the 'check' definition.</span><b><a href="#dom-fontfaceset-check">#dom-fontfaceset-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-check">3. 
 The FontFaceSet Interface</a>
@@ -3703,36 +3703,36 @@ The FontFaceSet Interface</a>
 The check() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-check-font-text-font">
-   <b><a href="#dom-fontfaceset-check-font-text-font">#dom-fontfaceset-check-font-text-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-check-font-text-font" class="dfn-panel" data-for="dom-fontfaceset-check-font-text-font" id="infopanel-for-dom-fontfaceset-check-font-text-font" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-check-font-text-font" style="display:none">Info about the 'font' definition.</span><b><a href="#dom-fontfaceset-check-font-text-font">#dom-fontfaceset-check-font-text-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-check-font-text-font">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfaceset-check-font-text-text">
-   <b><a href="#dom-fontfaceset-check-font-text-text">#dom-fontfaceset-check-font-text-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfaceset-check-font-text-text" class="dfn-panel" data-for="dom-fontfaceset-check-font-text-text" id="infopanel-for-dom-fontfaceset-check-font-text-text" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfaceset-check-font-text-text" style="display:none">Info about the 'text' definition.</span><b><a href="#dom-fontfaceset-check-font-text-text">#dom-fontfaceset-check-font-text-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfaceset-check-font-text-text">3. 
 The FontFaceSet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fontfacesource">
-   <b><a href="#fontfacesource">#fontfacesource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fontfacesource" class="dfn-panel" data-for="fontfacesource" id="infopanel-for-fontfacesource" role="dialog">
+   <span id="infopaneltitle-for-fontfacesource" style="display:none">Info about the 'FontFaceSource' definition.</span><b><a href="#fontfacesource">#fontfacesource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fontfacesource">4. 
 The FontFaceSource Mixin</a> <a href="#ref-for-fontfacesource①">(2)</a> <a href="#ref-for-fontfacesource②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-fontfacesource-fonts">
-   <b><a href="#dom-fontfacesource-fonts">#dom-fontfacesource-fonts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-fontfacesource-fonts" class="dfn-panel" data-for="dom-fontfacesource-fonts" id="infopanel-for-dom-fontfacesource-fonts" role="dialog">
+   <span id="infopaneltitle-for-dom-fontfacesource-fonts" style="display:none">Info about the 'fonts' definition.</span><b><a href="#dom-fontfacesource-fonts">#dom-fontfacesource-fonts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-fontfacesource-fonts">4. 
 The FontFaceSource Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-source">
-   <b><a href="#font-source">#font-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-source" class="dfn-panel" data-for="font-source" id="infopanel-for-font-source" role="dialog">
+   <span id="infopaneltitle-for-font-source" style="display:none">Info about the 'font source' definition.</span><b><a href="#font-source">#font-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-source">2.3. 
 Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-font-source①">(2)</a>
@@ -3748,8 +3748,8 @@ Worker FontFaceSources</a>
 Interaction with CSS’s @font-face Rule</a> <a href="#ref-for-font-source⑧">(2)</a> <a href="#ref-for-font-source⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-font-faces">
-   <b><a href="#available-font-faces">#available-font-faces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-font-faces" class="dfn-panel" data-for="available-font-faces" id="infopanel-for-available-font-faces" role="dialog">
+   <span id="infopaneltitle-for-available-font-faces" style="display:none">Info about the 'available font faces' definition.</span><b><a href="#available-font-faces">#available-font-faces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-font-faces">3.1. 
 Events</a>
@@ -3757,59 +3757,115 @@ Events</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.html
+++ b/tests/github/w3c/csswg-drafts/css-fonts-3/Overview-wip.html
@@ -5588,59 +5588,59 @@ that is <em>The Elements of Typographic Style</em>.</p>
    <li><a href="#valdef-font-size-absolute-size-xx-large">xx-large</a><span>, in § 3.5</span>
    <li><a href="#valdef-font-size-absolute-size-xx-small">xx-small</a><span>, in § 3.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">3.1. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">3.1. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-family-name-value">
-   <a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-family-name-value" class="dfn-panel" data-for="term-for-family-name-value" id="infopanel-for-term-for-family-name-value" role="menu">
+   <span id="infopaneltitle-for-term-for-family-name-value" style="display:none">Info about the '&lt;family-name>' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-family-name-value">3.1. Font family: the font-family property</a> <a href="#ref-for-family-name-value①">(2)</a>
     <li><a href="#ref-for-family-name-value②">4.2. Font family: the font-family descriptor</a>
     <li><a href="#ref-for-family-name-value③">4.3. Font reference: the src descriptor</a> <a href="#ref-for-family-name-value④">(2)</a> <a href="#ref-for-family-name-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-edge-ex">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-text-edge-ex">https://drafts.csswg.org/css-inline-3/#valdef-text-edge-ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-edge-ex" class="dfn-panel" data-for="term-for-valdef-text-edge-ex" id="infopanel-for-term-for-valdef-text-edge-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-edge-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-text-edge-ex">https://drafts.csswg.org/css-inline-3/#valdef-text-edge-ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-edge-ex">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-namedflowmap-get">
-   <a href="https://drafts.csswg.org/css-regions-1/#dom-namedflowmap-get">https://drafts.csswg.org/css-regions-1/#dom-namedflowmap-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-namedflowmap-get" class="dfn-panel" data-for="term-for-dom-namedflowmap-get" id="infopanel-for-term-for-dom-namedflowmap-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-namedflowmap-get" style="display:none">Info about the 'get()' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#dom-namedflowmap-get">https://drafts.csswg.org/css-regions-1/#dom-namedflowmap-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflowmap-get">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">6.3. Kerning: the font-kerning property</a>
     <li><a href="#ref-for-propdef-letter-spacing①">7.2. Feature precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">6.6. Capitalization: the font-variant-caps property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cursor-default">
-   <a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cursor-default" class="dfn-panel" data-for="term-for-valdef-cursor-default" id="infopanel-for-term-for-valdef-cursor-default" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cursor-default" style="display:none">Info about the 'default' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">3.1. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.1. Font family: the font-family property</a>
     <li><a href="#ref-for-mult-comma①">4.3. Font reference: the src descriptor</a> <a href="#ref-for-mult-comma②">(2)</a>
@@ -5651,79 +5651,79 @@ that is <em>The Elements of Typographic Style</em>.</p>
     <li><a href="#ref-for-mult-comma①①">6.12. Low-level font feature settings control: the font-feature-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">6.12. Low-level font feature settings control: the font-feature-settings property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.5. Font size: the font-size property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.6. Relative sizing: the font-size-adjust property</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">4.3. Font reference: the src descriptor</a>
     <li><a href="#ref-for-string-value①">6.12. Low-level font feature settings control: the font-feature-settings property</a> <a href="#ref-for-string-value②">(2)</a>
     <li><a href="#ref-for-string-value③">6.13. Font language override: the font-language-override property</a> <a href="#ref-for-string-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">4.3. Font reference: the src descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.7. Shorthand font property: the font property</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">4.3. Font reference: the src descriptor</a>
     <li><a href="#ref-for-mult-opt③">6.12. Low-level font feature settings control: the font-feature-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">3.5. Font size: the font-size property</a>
     <li><a href="#ref-for-em①">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-relative-length" class="dfn-panel" data-for="term-for-font-relative-length" id="infopanel-for-term-for-font-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'ident' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">6.9.1. Basic syntax</a> <a href="#ref-for-css-css-identifier①">(2)</a> <a href="#ref-for-css-css-identifier②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number">
-   <a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number" class="dfn-panel" data-for="term-for-number" id="infopanel-for-term-for-number" role="menu">
+   <span id="infopaneltitle-for-term-for-number" style="display:none">Info about the 'number' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number">6.9.1. Basic syntax</a> <a href="#ref-for-number①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. Font family: the font-family property</a>
     <li><a href="#ref-for-comb-one①">3.1.1. Generic font families</a> <a href="#ref-for-comb-one②">(2)</a> <a href="#ref-for-comb-one③">(3)</a> <a href="#ref-for-comb-one④">(4)</a>
@@ -5750,8 +5750,8 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-comb-one①①⑤">6.13. Font language override: the font-language-override property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.7. Shorthand font property: the font property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
     <li><a href="#ref-for-comb-any③">3.8. Controlling synthetic faces: the font-synthesis property</a>
@@ -5762,72 +5762,72 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-comb-any③⑤">6.11. Overall shorthand for font rendering: the font-variant property</a> <a href="#ref-for-comb-any③⑥">(2)</a> <a href="#ref-for-comb-any③⑦">(3)</a> <a href="#ref-for-comb-any③⑧">(4)</a> <a href="#ref-for-comb-any③⑨">(5)</a> <a href="#ref-for-comb-any④⓪">(6)</a> <a href="#ref-for-comb-any④①">(7)</a> <a href="#ref-for-comb-any④②">(8)</a> <a href="#ref-for-comb-any④③">(9)</a> <a href="#ref-for-comb-any④④">(10)</a> <a href="#ref-for-comb-any④⑤">(11)</a> <a href="#ref-for-comb-any④⑥">(12)</a> <a href="#ref-for-comb-any④⑦">(13)</a> <a href="#ref-for-comb-any④⑧">(14)</a> <a href="#ref-for-comb-any④⑨">(15)</a> <a href="#ref-for-comb-any⑤⓪">(16)</a> <a href="#ref-for-comb-any⑤①">(17)</a> <a href="#ref-for-comb-any⑤②">(18)</a> <a href="#ref-for-comb-any⑤③">(19)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3.6. Relative sizing: the font-size-adjust property</a> <a href="#ref-for-propdef-line-height①">(2)</a> <a href="#ref-for-propdef-line-height②">(3)</a>
     <li><a href="#ref-for-propdef-line-height③">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-line-height④">(2)</a> <a href="#ref-for-propdef-line-height⑤">(3)</a>
     <li><a href="#ref-for-propdef-line-height⑥"> Changes from the July 2013 CSS3 Fonts Last Call Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">8.1. The CSSFontFaceRule interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a> <a href="#ref-for-cssomstring⑤">(6)</a> <a href="#ref-for-cssomstring⑥">(7)</a> <a href="#ref-for-cssomstring⑦">(8)</a>
     <li><a href="#ref-for-cssomstring⑧">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssomstring⑨">(2)</a> <a href="#ref-for-cssomstring①⓪">(3)</a> <a href="#ref-for-cssomstring①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">8.1. The CSSFontFaceRule interface</a>
     <li><a href="#ref-for-cssrule①">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssrule②">(2)</a> <a href="#ref-for-cssrule③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-sub-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-sub-element" class="dfn-panel" data-for="term-for-the-sub-element" id="infopanel-for-term-for-the-sub-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-sub-element" style="display:none">Info about the 'sub' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-sub-element">6.5. Subscript and superscript forms: the font-variant-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-sup-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sup-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sup-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-sup-element" class="dfn-panel" data-for="term-for-the-sup-element" id="infopanel-for-term-for-the-sup-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-sup-element" style="display:none">Info about the 'sup' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sup-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sup-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-sup-element">6.5. Subscript and superscript forms: the font-variant-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-language">
-   <a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-language" class="dfn-panel" data-for="term-for-document-language" id="infopanel-for-term-for-document-language" role="menu">
+   <span id="infopaneltitle-for-term-for-document-language" style="display:none">Info about the 'document language' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-language">6.2. Language-specific display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
@@ -6290,8 +6290,8 @@ annotation(&lt;feature-value-name>) || [ small-caps | all-small-caps | petite-ca
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="propdef-font-family">
-   <b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-family" class="dfn-panel" data-for="propdef-font-family" id="infopanel-for-propdef-font-family" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-family" style="display:none">Info about the 'font-family' definition.</span><b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">3.1. Font family: the font-family property</a>
     <li><a href="#ref-for-propdef-font-family①">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-family②">(2)</a> <a href="#ref-for-propdef-font-family③">(3)</a> <a href="#ref-for-propdef-font-family④">(4)</a> <a href="#ref-for-propdef-font-family⑤">(5)</a>
@@ -6302,50 +6302,50 @@ annotation(&lt;feature-value-name>) || [ small-caps | all-small-caps | petite-ca
     <li><a href="#ref-for-propdef-font-family①③">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-generic-family">
-   <b><a href="#typedef-generic-family">#typedef-generic-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-generic-family" class="dfn-panel" data-for="typedef-generic-family" id="infopanel-for-typedef-generic-family" role="dialog">
+   <span id="infopaneltitle-for-typedef-generic-family" style="display:none">Info about the '&lt;generic-family>' definition.</span><b><a href="#typedef-generic-family">#typedef-generic-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-generic-family">3.1. Font family: the font-family property</a> <a href="#ref-for-typedef-generic-family①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-serif">
-   <b><a href="#valdef-generic-family-serif">#valdef-generic-family-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-serif" class="dfn-panel" data-for="valdef-generic-family-serif" id="infopanel-for-valdef-generic-family-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-serif" style="display:none">Info about the 'serif' definition.</span><b><a href="#valdef-generic-family-serif">#valdef-generic-family-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-serif">3.1. Font family: the font-family property</a> <a href="#ref-for-valdef-generic-family-serif①">(2)</a>
     <li><a href="#ref-for-valdef-generic-family-serif②">serif</a> <a href="#ref-for-valdef-generic-family-serif③">(2)</a> <a href="#ref-for-valdef-generic-family-serif④">(3)</a>
     <li><a href="#ref-for-valdef-generic-family-serif⑤">sans-serif</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-sans-serif">
-   <b><a href="#valdef-generic-family-sans-serif">#valdef-generic-family-sans-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-sans-serif" class="dfn-panel" data-for="valdef-generic-family-sans-serif" id="infopanel-for-valdef-generic-family-sans-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-sans-serif" style="display:none">Info about the 'sans-serif' definition.</span><b><a href="#valdef-generic-family-sans-serif">#valdef-generic-family-sans-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-sans-serif">3.1. Font family: the font-family property</a> <a href="#ref-for-valdef-generic-family-sans-serif①">(2)</a>
     <li><a href="#ref-for-valdef-generic-family-sans-serif②">serif</a>
     <li><a href="#ref-for-valdef-generic-family-sans-serif③">sans-serif</a> <a href="#ref-for-valdef-generic-family-sans-serif④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-cursive">
-   <b><a href="#valdef-generic-family-cursive">#valdef-generic-family-cursive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-cursive" class="dfn-panel" data-for="valdef-generic-family-cursive" id="infopanel-for-valdef-generic-family-cursive" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-cursive" style="display:none">Info about the 'cursive' definition.</span><b><a href="#valdef-generic-family-cursive">#valdef-generic-family-cursive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-cursive">3.1. Font family: the font-family property</a> <a href="#ref-for-valdef-generic-family-cursive①">(2)</a>
     <li><a href="#ref-for-valdef-generic-family-cursive②">cursive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-fantasy">
-   <b><a href="#valdef-generic-family-fantasy">#valdef-generic-family-fantasy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-fantasy" class="dfn-panel" data-for="valdef-generic-family-fantasy" id="infopanel-for-valdef-generic-family-fantasy" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-fantasy" style="display:none">Info about the 'fantasy' definition.</span><b><a href="#valdef-generic-family-fantasy">#valdef-generic-family-fantasy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-fantasy">3.1. Font family: the font-family property</a> <a href="#ref-for-valdef-generic-family-fantasy①">(2)</a>
     <li><a href="#ref-for-valdef-generic-family-fantasy②">3.7. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-monospace">
-   <b><a href="#valdef-generic-family-monospace">#valdef-generic-family-monospace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-monospace" class="dfn-panel" data-for="valdef-generic-family-monospace" id="infopanel-for-valdef-generic-family-monospace" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-monospace" style="display:none">Info about the 'monospace' definition.</span><b><a href="#valdef-generic-family-monospace">#valdef-generic-family-monospace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-monospace">3.1. Font family: the font-family property</a> <a href="#ref-for-valdef-generic-family-monospace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-weight">
-   <b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-weight" class="dfn-panel" data-for="propdef-font-weight" id="infopanel-for-propdef-font-weight" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-weight" style="display:none">Info about the 'font-weight' definition.</span><b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">3.2. Font weight: the font-weight property</a> <a href="#ref-for-propdef-font-weight①">(2)</a> <a href="#ref-for-propdef-font-weight②">(3)</a>
     <li><a href="#ref-for-propdef-font-weight③">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-weight④">(2)</a> <a href="#ref-for-propdef-font-weight⑤">(3)</a> <a href="#ref-for-propdef-font-weight⑥">(4)</a> <a href="#ref-for-propdef-font-weight⑦">(5)</a> <a href="#ref-for-propdef-font-weight⑧">(6)</a>
@@ -6353,56 +6353,56 @@ annotation(&lt;feature-value-name>) || [ small-caps | all-small-caps | petite-ca
     <li><a href="#ref-for-propdef-font-weight①⓪">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-weight①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-400">
-   <b><a href="#valdef-font-weight-400">#valdef-font-weight-400</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-400" class="dfn-panel" data-for="valdef-font-weight-400" id="infopanel-for-valdef-font-weight-400" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-400" style="display:none">Info about the '400' definition.</span><b><a href="#valdef-font-weight-400">#valdef-font-weight-400</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-400">3.2. Font weight: the font-weight property</a> <a href="#ref-for-valdef-font-weight-400①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-700">
-   <b><a href="#valdef-font-weight-700">#valdef-font-weight-700</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-700" class="dfn-panel" data-for="valdef-font-weight-700" id="infopanel-for-valdef-font-weight-700" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-700" style="display:none">Info about the '700' definition.</span><b><a href="#valdef-font-weight-700">#valdef-font-weight-700</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-700">3.2. Font weight: the font-weight property</a> <a href="#ref-for-valdef-font-weight-700①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bold">
-   <b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bold" class="dfn-panel" data-for="valdef-font-weight-bold" id="infopanel-for-valdef-font-weight-bold" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bold" style="display:none">Info about the 'bold' definition.</span><b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bold">3.7. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bolder">
-   <b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bolder" class="dfn-panel" data-for="valdef-font-weight-bolder" id="infopanel-for-valdef-font-weight-bolder" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bolder" style="display:none">Info about the 'bolder' definition.</span><b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bolder">3.2. Font weight: the font-weight property</a>
     <li><a href="#ref-for-valdef-font-weight-bolder①">4.4. 
 Font property descriptors: the font-style, font-weight, font-stretch descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-lighter">
-   <b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-lighter" class="dfn-panel" data-for="valdef-font-weight-lighter" id="infopanel-for-valdef-font-weight-lighter" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-lighter" style="display:none">Info about the 'lighter' definition.</span><b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-lighter">3.2. Font weight: the font-weight property</a>
     <li><a href="#ref-for-valdef-font-weight-lighter①">4.4. 
 Font property descriptors: the font-style, font-weight, font-stretch descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-stretch">
-   <b><a href="#propdef-font-stretch">#propdef-font-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-stretch" class="dfn-panel" data-for="propdef-font-stretch" id="infopanel-for-propdef-font-stretch" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' definition.</span><b><a href="#propdef-font-stretch">#propdef-font-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">3.3. Font width: the font-stretch property</a> <a href="#ref-for-propdef-font-stretch①">(2)</a>
     <li><a href="#ref-for-propdef-font-stretch②">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-stretch③">(2)</a> <a href="#ref-for-propdef-font-stretch④">(3)</a> <a href="#ref-for-propdef-font-stretch⑤">(4)</a> <a href="#ref-for-propdef-font-stretch⑥">(5)</a>
     <li><a href="#ref-for-propdef-font-stretch⑦">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-stretch⑧">(2)</a> <a href="#ref-for-propdef-font-stretch⑨">(3)</a> <a href="#ref-for-propdef-font-stretch①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-stretch-normal">
-   <b><a href="#valdef-font-stretch-normal">#valdef-font-stretch-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-stretch-normal" class="dfn-panel" data-for="valdef-font-stretch-normal" id="infopanel-for-valdef-font-stretch-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-stretch-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-stretch-normal">#valdef-font-stretch-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-stretch-normal">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-style">
-   <b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-style" class="dfn-panel" data-for="propdef-font-style" id="infopanel-for-propdef-font-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-style" style="display:none">Info about the 'font-style' definition.</span><b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">3.4. Font style: the font-style property</a> <a href="#ref-for-propdef-font-style①">(2)</a>
     <li><a href="#ref-for-propdef-font-style②">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-style③">(2)</a> <a href="#ref-for-propdef-font-style④">(3)</a> <a href="#ref-for-propdef-font-style⑤">(4)</a> <a href="#ref-for-propdef-font-style⑥">(5)</a>
@@ -6410,8 +6410,8 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-propdef-font-style⑧">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-style⑨">(2)</a> <a href="#ref-for-propdef-font-style①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-size">
-   <b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-size" class="dfn-panel" data-for="propdef-font-size" id="infopanel-for-propdef-font-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-size" style="display:none">Info about the 'font-size' definition.</span><b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">3.5. Font size: the font-size property</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a>
     <li><a href="#ref-for-propdef-font-size③">3.6. Relative sizing: the font-size-adjust property</a> <a href="#ref-for-propdef-font-size④">(2)</a> <a href="#ref-for-propdef-font-size⑤">(3)</a> <a href="#ref-for-propdef-font-size⑥">(4)</a> <a href="#ref-for-propdef-font-size⑦">(5)</a>
@@ -6419,38 +6419,38 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-propdef-font-size①③">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-size①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-font-size-absolute-size">
-   <b><a href="#typedef-font-size-absolute-size">#typedef-font-size-absolute-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-font-size-absolute-size" class="dfn-panel" data-for="typedef-font-size-absolute-size" id="infopanel-for-typedef-font-size-absolute-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-font-size-absolute-size" style="display:none">Info about the '&lt;absolute-size>' definition.</span><b><a href="#typedef-font-size-absolute-size">#typedef-font-size-absolute-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-font-size-absolute-size">3.5. Font size: the font-size property</a> <a href="#ref-for-typedef-font-size-absolute-size①">(2)</a> <a href="#ref-for-typedef-font-size-absolute-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-font-size-relative-size">
-   <b><a href="#typedef-font-size-relative-size">#typedef-font-size-relative-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-font-size-relative-size" class="dfn-panel" data-for="typedef-font-size-relative-size" id="infopanel-for-typedef-font-size-relative-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-font-size-relative-size" style="display:none">Info about the '&lt;relative-size>' definition.</span><b><a href="#typedef-font-size-relative-size">#typedef-font-size-relative-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-font-size-relative-size">3.5. Font size: the font-size property</a> <a href="#ref-for-typedef-font-size-relative-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-relative-size-font-size-larger">
-   <b><a href="#valdef-relative-size-font-size-larger">#valdef-relative-size-font-size-larger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-relative-size-font-size-larger" class="dfn-panel" data-for="valdef-relative-size-font-size-larger" id="infopanel-for-valdef-relative-size-font-size-larger" role="dialog">
+   <span id="infopaneltitle-for-valdef-relative-size-font-size-larger" style="display:none">Info about the 'larger' definition.</span><b><a href="#valdef-relative-size-font-size-larger">#valdef-relative-size-font-size-larger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-relative-size-font-size-larger">3.5. Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-size-absolute-size-medium">
-   <b><a href="#valdef-font-size-absolute-size-medium">#valdef-font-size-absolute-size-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-size-absolute-size-medium" class="dfn-panel" data-for="valdef-font-size-absolute-size-medium" id="infopanel-for-valdef-font-size-absolute-size-medium" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-size-absolute-size-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#valdef-font-size-absolute-size-medium">#valdef-font-size-absolute-size-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-size-absolute-size-medium">3.5. Font size: the font-size property</a> <a href="#ref-for-valdef-font-size-absolute-size-medium①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-size-absolute-size-large">
-   <b><a href="#valdef-font-size-absolute-size-large">#valdef-font-size-absolute-size-large</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-size-absolute-size-large" class="dfn-panel" data-for="valdef-font-size-absolute-size-large" id="infopanel-for-valdef-font-size-absolute-size-large" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-size-absolute-size-large" style="display:none">Info about the 'large' definition.</span><b><a href="#valdef-font-size-absolute-size-large">#valdef-font-size-absolute-size-large</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-size-absolute-size-large">3.5. Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-size-adjust">
-   <b><a href="#propdef-font-size-adjust">#propdef-font-size-adjust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-size-adjust" class="dfn-panel" data-for="propdef-font-size-adjust" id="infopanel-for-propdef-font-size-adjust" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' definition.</span><b><a href="#propdef-font-size-adjust">#propdef-font-size-adjust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">3.5. Font size: the font-size property</a> <a href="#ref-for-propdef-font-size-adjust①">(2)</a>
     <li><a href="#ref-for-propdef-font-size-adjust②">3.6. Relative sizing: the font-size-adjust property</a> <a href="#ref-for-propdef-font-size-adjust③">(2)</a> <a href="#ref-for-propdef-font-size-adjust④">(3)</a> <a href="#ref-for-propdef-font-size-adjust⑤">(4)</a> <a href="#ref-for-propdef-font-size-adjust⑥">(5)</a> <a href="#ref-for-propdef-font-size-adjust⑦">(6)</a> <a href="#ref-for-propdef-font-size-adjust⑧">(7)</a> <a href="#ref-for-propdef-font-size-adjust⑨">(8)</a> <a href="#ref-for-propdef-font-size-adjust①⓪">(9)</a> <a href="#ref-for-propdef-font-size-adjust①①">(10)</a> <a href="#ref-for-propdef-font-size-adjust①②">(11)</a> <a href="#ref-for-propdef-font-size-adjust①③">(12)</a>
@@ -6458,38 +6458,38 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-propdef-font-size-adjust①⑤"> Changes from the July 2013 CSS3 Fonts Last Call Working Draft</a> <a href="#ref-for-propdef-font-size-adjust①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-aspect-value">
-   <b><a href="#font-aspect-value">#font-aspect-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-aspect-value" class="dfn-panel" data-for="font-aspect-value" id="infopanel-for-font-aspect-value" role="dialog">
+   <span id="infopaneltitle-for-font-aspect-value" style="display:none">Info about the 'aspect value' definition.</span><b><a href="#font-aspect-value">#font-aspect-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-aspect-value">3.6. Relative sizing: the font-size-adjust property</a> <a href="#ref-for-font-aspect-value①">(2)</a> <a href="#ref-for-font-aspect-value②">(3)</a> <a href="#ref-for-font-aspect-value③">(4)</a> <a href="#ref-for-font-aspect-value④">(5)</a> <a href="#ref-for-font-aspect-value⑤">(6)</a> <a href="#ref-for-font-aspect-value⑥">(7)</a> <a href="#ref-for-font-aspect-value⑦">(8)</a> <a href="#ref-for-font-aspect-value⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font">
-   <b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font" class="dfn-panel" data-for="propdef-font" id="infopanel-for-propdef-font" role="dialog">
+   <span id="infopaneltitle-for-propdef-font" style="display:none">Info about the 'font' definition.</span><b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font①">(2)</a> <a href="#ref-for-propdef-font②">(3)</a> <a href="#ref-for-propdef-font③">(4)</a> <a href="#ref-for-propdef-font④">(5)</a> <a href="#ref-for-propdef-font⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-font-variant-css21">
-   <b><a href="#typedef-font-variant-css21">#typedef-font-variant-css21</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-font-variant-css21" class="dfn-panel" data-for="typedef-font-variant-css21" id="infopanel-for-typedef-font-variant-css21" role="dialog">
+   <span id="infopaneltitle-for-typedef-font-variant-css21" style="display:none">Info about the '&lt;font-variant-css21>' definition.</span><b><a href="#typedef-font-variant-css21">#typedef-font-variant-css21</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-font-variant-css21">3.7. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-caption">
-   <b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-caption" class="dfn-panel" data-for="valdef-font-caption" id="infopanel-for-valdef-font-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-caption" style="display:none">Info about the 'caption' definition.</span><b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-caption">3.7. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-small-caption">
-   <b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-small-caption" class="dfn-panel" data-for="valdef-font-small-caption" id="infopanel-for-valdef-font-small-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-small-caption" style="display:none">Info about the 'small-caption' definition.</span><b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-small-caption">3.7. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-synthesis">
-   <b><a href="#propdef-font-synthesis">#propdef-font-synthesis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-synthesis" class="dfn-panel" data-for="propdef-font-synthesis" id="infopanel-for-propdef-font-synthesis" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-synthesis" style="display:none">Info about the 'font-synthesis' definition.</span><b><a href="#propdef-font-synthesis">#propdef-font-synthesis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis">3.2. Font weight: the font-weight property</a>
     <li><a href="#ref-for-propdef-font-synthesis①">3.4. Font style: the font-style property</a>
@@ -6497,8 +6497,8 @@ Font property descriptors: the font-style, font-weight, font-stretch descriptors
     <li><a href="#ref-for-propdef-font-synthesis③">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-synthesis④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-font-face">
-   <b><a href="#at-ruledef-font-face">#at-ruledef-font-face</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-font-face" class="dfn-panel" data-for="at-ruledef-font-face" id="infopanel-for-at-ruledef-font-face" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-font-face" style="display:none">Info about the '@font-face' definition.</span><b><a href="#at-ruledef-font-face">#at-ruledef-font-face</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-face">4.1. The @font-face rule</a> <a href="#ref-for-at-ruledef-font-face①">(2)</a> <a href="#ref-for-at-ruledef-font-face②">(3)</a> <a href="#ref-for-at-ruledef-font-face③">(4)</a> <a href="#ref-for-at-ruledef-font-face④">(5)</a> <a href="#ref-for-at-ruledef-font-face⑤">(6)</a> <a href="#ref-for-at-ruledef-font-face⑥">(7)</a> <a href="#ref-for-at-ruledef-font-face⑦">(8)</a> <a href="#ref-for-at-ruledef-font-face⑧">(9)</a> <a href="#ref-for-at-ruledef-font-face⑨">(10)</a> <a href="#ref-for-at-ruledef-font-face①⓪">(11)</a>
     <li><a href="#ref-for-at-ruledef-font-face①①">4.2. Font family: the font-family descriptor</a> <a href="#ref-for-at-ruledef-font-face①②">(2)</a>
@@ -6519,54 +6519,54 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-at-ruledef-font-face⑤⑦">8.1. The CSSFontFaceRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descriptor_declaration">
-   <b><a href="#descriptor_declaration">#descriptor_declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descriptor_declaration" class="dfn-panel" data-for="descriptor_declaration" id="infopanel-for-descriptor_declaration" role="dialog">
+   <span id="infopaneltitle-for-descriptor_declaration" style="display:none">Info about the 'descriptor_declaration' definition.</span><b><a href="#descriptor_declaration">#descriptor_declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descriptor_declaration">4.1. The @font-face rule</a> <a href="#ref-for-descriptor_declaration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font_face_sym">
-   <b><a href="#font_face_sym">#font_face_sym</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font_face_sym" class="dfn-panel" data-for="font_face_sym" id="infopanel-for-font_face_sym" role="dialog">
+   <span id="infopaneltitle-for-font_face_sym" style="display:none">Info about the 'FONT_FACE_SYM' definition.</span><b><a href="#font_face_sym">#font_face_sym</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font_face_sym">4.1. The @font-face rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-font-face-src-local">
-   <b><a href="#funcdef-font-face-src-local">#funcdef-font-face-src-local</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-font-face-src-local" class="dfn-panel" data-for="funcdef-font-face-src-local" id="infopanel-for-funcdef-font-face-src-local" role="dialog">
+   <span id="infopaneltitle-for-funcdef-font-face-src-local" style="display:none">Info about the 'local()' definition.</span><b><a href="#funcdef-font-face-src-local">#funcdef-font-face-src-local</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-font-face-src-local">4.3. Font reference: the src descriptor</a> <a href="#ref-for-funcdef-font-face-src-local①">(2)</a>
     <li><a href="#ref-for-funcdef-font-face-src-local②">7.3. Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-face-font-style-normal">
-   <b><a href="#valdef-font-face-font-style-normal">#valdef-font-face-font-style-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-face-font-style-normal" class="dfn-panel" data-for="valdef-font-face-font-style-normal" id="infopanel-for-valdef-font-face-font-style-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-face-font-style-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-face-font-style-normal">#valdef-font-face-font-style-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-face-font-style-normal">3.7. Shorthand font property: the font property</a>
     <li><a href="#ref-for-valdef-font-face-font-style-normal①">3.8. Controlling synthetic faces: the font-synthesis property</a>
     <li><a href="#ref-for-valdef-font-face-font-style-normal②">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-face-font-style-italic">
-   <b><a href="#valdef-font-face-font-style-italic">#valdef-font-face-font-style-italic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-face-font-style-italic" class="dfn-panel" data-for="valdef-font-face-font-style-italic" id="infopanel-for-valdef-font-face-font-style-italic" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-face-font-style-italic" style="display:none">Info about the 'italic' definition.</span><b><a href="#valdef-font-face-font-style-italic">#valdef-font-face-font-style-italic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-face-font-style-italic">3.7. Shorthand font property: the font property</a>
     <li><a href="#ref-for-valdef-font-face-font-style-italic①">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-face-font-style-oblique">
-   <b><a href="#valdef-font-face-font-style-oblique">#valdef-font-face-font-style-oblique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-face-font-style-oblique" class="dfn-panel" data-for="valdef-font-face-font-style-oblique" id="infopanel-for-valdef-font-face-font-style-oblique" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-face-font-style-oblique" style="display:none">Info about the 'oblique' definition.</span><b><a href="#valdef-font-face-font-style-oblique">#valdef-font-face-font-style-oblique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-face-font-style-oblique">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-character-map">
-   <b><a href="#effective-character-map">#effective-character-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-character-map" class="dfn-panel" data-for="effective-character-map" id="infopanel-for-effective-character-map" role="dialog">
+   <span id="infopaneltitle-for-effective-character-map" style="display:none">Info about the 'effective character map' definition.</span><b><a href="#effective-character-map">#effective-character-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-character-map">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="character-map">
-   <b><a href="#character-map">#character-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character-map" class="dfn-panel" data-for="character-map" id="infopanel-for-character-map" role="dialog">
+   <span id="infopaneltitle-for-character-map" style="display:none">Info about the 'character map' definition.</span><b><a href="#character-map">#character-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character-map">2. Typography Background</a>
     <li><a href="#ref-for-character-map①">4.5. Character range: the unicode-range descriptor</a>
@@ -6576,39 +6576,39 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-character-map⑧">Appendix A: Mapping platform font properties to CSS properties</a> <a href="#ref-for-character-map⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="support">
-   <b><a href="#support">#support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-support" class="dfn-panel" data-for="support" id="infopanel-for-support" role="dialog">
+   <span id="infopaneltitle-for-support" style="display:none">Info about the 'support' definition.</span><b><a href="#support">#support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-support">5.3. Cluster matching</a> <a href="#ref-for-support①">(2)</a> <a href="#ref-for-support②">(3)</a> <a href="#ref-for-support③">(4)</a> <a href="#ref-for-support④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-face">
-   <b><a href="#default-face">#default-face</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-face" class="dfn-panel" data-for="default-face" id="infopanel-for-default-face" role="dialog">
+   <span id="infopaneltitle-for-default-face" style="display:none">Info about the 'default face' definition.</span><b><a href="#default-face">#default-face</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-face">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-face">
-   <b><a href="#composite-face">#composite-face</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-face" class="dfn-panel" data-for="composite-face" id="infopanel-for-composite-face" role="dialog">
+   <span id="infopaneltitle-for-composite-face" style="display:none">Info about the 'composite face' definition.</span><b><a href="#composite-face">#composite-face</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-face">5.2. Matching font styles</a> <a href="#ref-for-composite-face①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="system-font-fallback">
-   <b><a href="#system-font-fallback">#system-font-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-system-font-fallback" class="dfn-panel" data-for="system-font-fallback" id="infopanel-for-system-font-fallback" role="dialog">
+   <span id="infopaneltitle-for-system-font-fallback" style="display:none">Info about the 'system font fallback' definition.</span><b><a href="#system-font-fallback">#system-font-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-system-font-fallback">5.3. Cluster matching</a>
     <li><a href="#ref-for-system-font-fallback①">5.4. Character handling issues</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-available-font">
-   <b><a href="#first-available-font">#first-available-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-available-font" class="dfn-panel" data-for="first-available-font" id="infopanel-for-first-available-font" role="dialog">
+   <span id="infopaneltitle-for-first-available-font" style="display:none">Info about the 'first available font' definition.</span><b><a href="#first-available-font">#first-available-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-available-font">3.6. Relative sizing: the font-size-adjust property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-kerning">
-   <b><a href="#propdef-font-kerning">#propdef-font-kerning</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-kerning" class="dfn-panel" data-for="propdef-font-kerning" id="infopanel-for-propdef-font-kerning" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-kerning" style="display:none">Info about the 'font-kerning' definition.</span><b><a href="#propdef-font-kerning">#propdef-font-kerning</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-kerning">3.7. Shorthand font property: the font property</a>
     <li><a href="#ref-for-propdef-font-kerning①">6.3. Kerning: the font-kerning property</a>
@@ -6616,20 +6616,20 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-kerning③">7.2. Feature precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-kerning-auto">
-   <b><a href="#valdef-font-kerning-auto">#valdef-font-kerning-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-kerning-auto" class="dfn-panel" data-for="valdef-font-kerning-auto" id="infopanel-for-valdef-font-kerning-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-kerning-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-font-kerning-auto">#valdef-font-kerning-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-kerning-auto">6.3. Kerning: the font-kerning property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-kerning-normal">
-   <b><a href="#valdef-font-kerning-normal">#valdef-font-kerning-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-kerning-normal" class="dfn-panel" data-for="valdef-font-kerning-normal" id="infopanel-for-valdef-font-kerning-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-kerning-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-kerning-normal">#valdef-font-kerning-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-kerning-normal">6.3. Kerning: the font-kerning property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-ligatures">
-   <b><a href="#propdef-font-variant-ligatures">#propdef-font-variant-ligatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-ligatures" class="dfn-panel" data-for="propdef-font-variant-ligatures" id="infopanel-for-propdef-font-variant-ligatures" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-ligatures" style="display:none">Info about the 'font-variant-ligatures' definition.</span><b><a href="#propdef-font-variant-ligatures">#propdef-font-variant-ligatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-ligatures">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-propdef-font-variant-ligatures①">6.11. Overall shorthand for font rendering: the font-variant property</a>
@@ -6637,168 +6637,168 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-variant-ligatures③">7.3. Feature precedence examples</a> <a href="#ref-for-propdef-font-variant-ligatures④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-common-lig-values">
-   <b><a href="#typedef-common-lig-values">#typedef-common-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-common-lig-values" class="dfn-panel" data-for="typedef-common-lig-values" id="infopanel-for-typedef-common-lig-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-common-lig-values" style="display:none">Info about the '&lt;common-lig-values>' definition.</span><b><a href="#typedef-common-lig-values">#typedef-common-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-common-lig-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-common-lig-values①">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-typedef-common-lig-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-discretionary-lig-values">
-   <b><a href="#typedef-discretionary-lig-values">#typedef-discretionary-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-discretionary-lig-values" class="dfn-panel" data-for="typedef-discretionary-lig-values" id="infopanel-for-typedef-discretionary-lig-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-discretionary-lig-values" style="display:none">Info about the '&lt;discretionary-lig-values>' definition.</span><b><a href="#typedef-discretionary-lig-values">#typedef-discretionary-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-discretionary-lig-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-discretionary-lig-values①">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-typedef-discretionary-lig-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-historical-lig-values">
-   <b><a href="#typedef-historical-lig-values">#typedef-historical-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-historical-lig-values" class="dfn-panel" data-for="typedef-historical-lig-values" id="infopanel-for-typedef-historical-lig-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-historical-lig-values" style="display:none">Info about the '&lt;historical-lig-values>' definition.</span><b><a href="#typedef-historical-lig-values">#typedef-historical-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-historical-lig-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-historical-lig-values①">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-typedef-historical-lig-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-contextual-alt-values">
-   <b><a href="#typedef-contextual-alt-values">#typedef-contextual-alt-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-contextual-alt-values" class="dfn-panel" data-for="typedef-contextual-alt-values" id="infopanel-for-typedef-contextual-alt-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-contextual-alt-values" style="display:none">Info about the '&lt;contextual-alt-values>' definition.</span><b><a href="#typedef-contextual-alt-values">#typedef-contextual-alt-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-contextual-alt-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-contextual-alt-values①">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-typedef-contextual-alt-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-ligatures-none">
-   <b><a href="#valdef-font-variant-ligatures-none">#valdef-font-variant-ligatures-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-ligatures-none" class="dfn-panel" data-for="valdef-font-variant-ligatures-none" id="infopanel-for-valdef-font-variant-ligatures-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-ligatures-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-font-variant-ligatures-none">#valdef-font-variant-ligatures-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-ligatures-none">6.4. Ligatures: the font-variant-ligatures property</a>
     <li><a href="#ref-for-valdef-font-variant-ligatures-none①">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-ligatures-common-lig-values-no-common-ligatures">
-   <b><a href="#valdef-font-variant-ligatures-common-lig-values-no-common-ligatures">#valdef-font-variant-ligatures-common-lig-values-no-common-ligatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-ligatures-common-lig-values-no-common-ligatures" class="dfn-panel" data-for="valdef-font-variant-ligatures-common-lig-values-no-common-ligatures" id="infopanel-for-valdef-font-variant-ligatures-common-lig-values-no-common-ligatures" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-ligatures-common-lig-values-no-common-ligatures" style="display:none">Info about the 'no-common-ligatures' definition.</span><b><a href="#valdef-font-variant-ligatures-common-lig-values-no-common-ligatures">#valdef-font-variant-ligatures-common-lig-values-no-common-ligatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-ligatures-common-lig-values-no-common-ligatures">7.1. Default features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-position">
-   <b><a href="#propdef-font-variant-position">#propdef-font-variant-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-position" class="dfn-panel" data-for="propdef-font-variant-position" id="infopanel-for-propdef-font-variant-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-position" style="display:none">Info about the 'font-variant-position' definition.</span><b><a href="#propdef-font-variant-position">#propdef-font-variant-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-position①">6.5. Subscript and superscript forms: the font-variant-position property</a> <a href="#ref-for-propdef-font-variant-position②">(2)</a> <a href="#ref-for-propdef-font-variant-position③">(3)</a> <a href="#ref-for-propdef-font-variant-position④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-position-normal">
-   <b><a href="#valdef-font-variant-position-normal">#valdef-font-variant-position-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-position-normal" class="dfn-panel" data-for="valdef-font-variant-position-normal" id="infopanel-for-valdef-font-variant-position-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-position-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-variant-position-normal">#valdef-font-variant-position-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-position-normal">6.5. Subscript and superscript forms: the font-variant-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-position-sub">
-   <b><a href="#valdef-font-variant-position-sub">#valdef-font-variant-position-sub</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-position-sub" class="dfn-panel" data-for="valdef-font-variant-position-sub" id="infopanel-for-valdef-font-variant-position-sub" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-position-sub" style="display:none">Info about the 'sub' definition.</span><b><a href="#valdef-font-variant-position-sub">#valdef-font-variant-position-sub</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-position-sub">6.5. Subscript and superscript forms: the font-variant-position property</a> <a href="#ref-for-valdef-font-variant-position-sub①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-position-super">
-   <b><a href="#valdef-font-variant-position-super">#valdef-font-variant-position-super</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-position-super" class="dfn-panel" data-for="valdef-font-variant-position-super" id="infopanel-for-valdef-font-variant-position-super" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-position-super" style="display:none">Info about the 'super' definition.</span><b><a href="#valdef-font-variant-position-super">#valdef-font-variant-position-super</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-position-super">6.5. Subscript and superscript forms: the font-variant-position property</a> <a href="#ref-for-valdef-font-variant-position-super①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-caps">
-   <b><a href="#propdef-font-variant-caps">#propdef-font-variant-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-caps" class="dfn-panel" data-for="propdef-font-variant-caps" id="infopanel-for-propdef-font-variant-caps" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-caps" style="display:none">Info about the 'font-variant-caps' definition.</span><b><a href="#propdef-font-variant-caps">#propdef-font-variant-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-caps">6.6. Capitalization: the font-variant-caps property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-small-caps">
-   <b><a href="#valdef-font-variant-caps-small-caps">#valdef-font-variant-caps-small-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-small-caps" class="dfn-panel" data-for="valdef-font-variant-caps-small-caps" id="infopanel-for-valdef-font-variant-caps-small-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-small-caps" style="display:none">Info about the 'small-caps' definition.</span><b><a href="#valdef-font-variant-caps-small-caps">#valdef-font-variant-caps-small-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-small-caps">3.7. Shorthand font property: the font property</a>
     <li><a href="#ref-for-valdef-font-variant-caps-small-caps①">6.6. Capitalization: the font-variant-caps property</a> <a href="#ref-for-valdef-font-variant-caps-small-caps②">(2)</a> <a href="#ref-for-valdef-font-variant-caps-small-caps③">(3)</a> <a href="#ref-for-valdef-font-variant-caps-small-caps④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-all-small-caps">
-   <b><a href="#valdef-font-variant-caps-all-small-caps">#valdef-font-variant-caps-all-small-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-all-small-caps" class="dfn-panel" data-for="valdef-font-variant-caps-all-small-caps" id="infopanel-for-valdef-font-variant-caps-all-small-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-all-small-caps" style="display:none">Info about the 'all-small-caps' definition.</span><b><a href="#valdef-font-variant-caps-all-small-caps">#valdef-font-variant-caps-all-small-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-all-small-caps">6.6. Capitalization: the font-variant-caps property</a> <a href="#ref-for-valdef-font-variant-caps-all-small-caps①">(2)</a> <a href="#ref-for-valdef-font-variant-caps-all-small-caps②">(3)</a> <a href="#ref-for-valdef-font-variant-caps-all-small-caps③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-petite-caps">
-   <b><a href="#valdef-font-variant-caps-petite-caps">#valdef-font-variant-caps-petite-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-petite-caps" class="dfn-panel" data-for="valdef-font-variant-caps-petite-caps" id="infopanel-for-valdef-font-variant-caps-petite-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-petite-caps" style="display:none">Info about the 'petite-caps' definition.</span><b><a href="#valdef-font-variant-caps-petite-caps">#valdef-font-variant-caps-petite-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-petite-caps">6.6. Capitalization: the font-variant-caps property</a> <a href="#ref-for-valdef-font-variant-caps-petite-caps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-all-petite-caps">
-   <b><a href="#valdef-font-variant-caps-all-petite-caps">#valdef-font-variant-caps-all-petite-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-all-petite-caps" class="dfn-panel" data-for="valdef-font-variant-caps-all-petite-caps" id="infopanel-for-valdef-font-variant-caps-all-petite-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-all-petite-caps" style="display:none">Info about the 'all-petite-caps' definition.</span><b><a href="#valdef-font-variant-caps-all-petite-caps">#valdef-font-variant-caps-all-petite-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-all-petite-caps">6.6. Capitalization: the font-variant-caps property</a> <a href="#ref-for-valdef-font-variant-caps-all-petite-caps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-unicase">
-   <b><a href="#valdef-font-variant-caps-unicase">#valdef-font-variant-caps-unicase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-unicase" class="dfn-panel" data-for="valdef-font-variant-caps-unicase" id="infopanel-for-valdef-font-variant-caps-unicase" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-unicase" style="display:none">Info about the 'unicase' definition.</span><b><a href="#valdef-font-variant-caps-unicase">#valdef-font-variant-caps-unicase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-unicase">6.6. Capitalization: the font-variant-caps property</a> <a href="#ref-for-valdef-font-variant-caps-unicase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-titling-caps">
-   <b><a href="#valdef-font-variant-caps-titling-caps">#valdef-font-variant-caps-titling-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-titling-caps" class="dfn-panel" data-for="valdef-font-variant-caps-titling-caps" id="infopanel-for-valdef-font-variant-caps-titling-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-titling-caps" style="display:none">Info about the 'titling-caps' definition.</span><b><a href="#valdef-font-variant-caps-titling-caps">#valdef-font-variant-caps-titling-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-titling-caps">6.6. Capitalization: the font-variant-caps property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-numeric">
-   <b><a href="#propdef-font-variant-numeric">#propdef-font-variant-numeric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-numeric" class="dfn-panel" data-for="propdef-font-variant-numeric" id="infopanel-for-propdef-font-variant-numeric" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-numeric" style="display:none">Info about the 'font-variant-numeric' definition.</span><b><a href="#propdef-font-variant-numeric">#propdef-font-variant-numeric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-numeric">6.7. Numerical formatting: the font-variant-numeric property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-numeric-figure-values">
-   <b><a href="#typedef-numeric-figure-values">#typedef-numeric-figure-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-numeric-figure-values" class="dfn-panel" data-for="typedef-numeric-figure-values" id="infopanel-for-typedef-numeric-figure-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-numeric-figure-values" style="display:none">Info about the '&lt;numeric-figure-values>' definition.</span><b><a href="#typedef-numeric-figure-values">#typedef-numeric-figure-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-numeric-figure-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-numeric-figure-values①">6.7. Numerical formatting: the font-variant-numeric property</a>
     <li><a href="#ref-for-typedef-numeric-figure-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-numeric-spacing-values">
-   <b><a href="#typedef-numeric-spacing-values">#typedef-numeric-spacing-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-numeric-spacing-values" class="dfn-panel" data-for="typedef-numeric-spacing-values" id="infopanel-for-typedef-numeric-spacing-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-numeric-spacing-values" style="display:none">Info about the '&lt;numeric-spacing-values>' definition.</span><b><a href="#typedef-numeric-spacing-values">#typedef-numeric-spacing-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-numeric-spacing-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-numeric-spacing-values①">6.7. Numerical formatting: the font-variant-numeric property</a>
     <li><a href="#ref-for-typedef-numeric-spacing-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-numeric-fraction-values">
-   <b><a href="#typedef-numeric-fraction-values">#typedef-numeric-fraction-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-numeric-fraction-values" class="dfn-panel" data-for="typedef-numeric-fraction-values" id="infopanel-for-typedef-numeric-fraction-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-numeric-fraction-values" style="display:none">Info about the '&lt;numeric-fraction-values>' definition.</span><b><a href="#typedef-numeric-fraction-values">#typedef-numeric-fraction-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-numeric-fraction-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-numeric-fraction-values①">6.7. Numerical formatting: the font-variant-numeric property</a>
     <li><a href="#ref-for-typedef-numeric-fraction-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-numeric-numeric-spacing-values-proportional-nums">
-   <b><a href="#valdef-font-variant-numeric-numeric-spacing-values-proportional-nums">#valdef-font-variant-numeric-numeric-spacing-values-proportional-nums</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-numeric-numeric-spacing-values-proportional-nums" class="dfn-panel" data-for="valdef-font-variant-numeric-numeric-spacing-values-proportional-nums" id="infopanel-for-valdef-font-variant-numeric-numeric-spacing-values-proportional-nums" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-numeric-numeric-spacing-values-proportional-nums" style="display:none">Info about the 'proportional-nums' definition.</span><b><a href="#valdef-font-variant-numeric-numeric-spacing-values-proportional-nums">#valdef-font-variant-numeric-numeric-spacing-values-proportional-nums</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-numeric-numeric-spacing-values-proportional-nums">7.3. Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-numeric-numeric-spacing-values-tabular-nums">
-   <b><a href="#valdef-font-variant-numeric-numeric-spacing-values-tabular-nums">#valdef-font-variant-numeric-numeric-spacing-values-tabular-nums</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-numeric-numeric-spacing-values-tabular-nums" class="dfn-panel" data-for="valdef-font-variant-numeric-numeric-spacing-values-tabular-nums" id="infopanel-for-valdef-font-variant-numeric-numeric-spacing-values-tabular-nums" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-numeric-numeric-spacing-values-tabular-nums" style="display:none">Info about the 'tabular-nums' definition.</span><b><a href="#valdef-font-variant-numeric-numeric-spacing-values-tabular-nums">#valdef-font-variant-numeric-numeric-spacing-values-tabular-nums</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-numeric-numeric-spacing-values-tabular-nums">7.3. Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-numeric-ordinal">
-   <b><a href="#valdef-font-variant-numeric-ordinal">#valdef-font-variant-numeric-ordinal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-numeric-ordinal" class="dfn-panel" data-for="valdef-font-variant-numeric-ordinal" id="infopanel-for-valdef-font-variant-numeric-ordinal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-numeric-ordinal" style="display:none">Info about the 'ordinal' definition.</span><b><a href="#valdef-font-variant-numeric-ordinal">#valdef-font-variant-numeric-ordinal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-numeric-ordinal">6.7. Numerical formatting: the font-variant-numeric property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-alternates">
-   <b><a href="#propdef-font-variant-alternates">#propdef-font-variant-alternates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-alternates" class="dfn-panel" data-for="propdef-font-variant-alternates" id="infopanel-for-propdef-font-variant-alternates" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-alternates" style="display:none">Info about the 'font-variant-alternates' definition.</span><b><a href="#propdef-font-variant-alternates">#propdef-font-variant-alternates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-alternates">6.8. Alternates and swashes: the font-variant-alternates property</a>
     <li><a href="#ref-for-propdef-font-variant-alternates①">6.9. Defining font specific alternates: the @font-feature-values rule</a>
@@ -6807,8 +6807,8 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-variant-alternates④">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-specific">
-   <b><a href="#font-specific">#font-specific</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-specific" class="dfn-panel" data-for="font-specific" id="infopanel-for-font-specific" role="dialog">
+   <span id="infopaneltitle-for-font-specific" style="display:none">Info about the 'font specific' definition.</span><b><a href="#font-specific">#font-specific</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-specific">6.8. Alternates and swashes: the font-variant-alternates property</a> <a href="#ref-for-font-specific①">(2)</a> <a href="#ref-for-font-specific②">(3)</a> <a href="#ref-for-font-specific③">(4)</a> <a href="#ref-for-font-specific④">(5)</a> <a href="#ref-for-font-specific⑤">(6)</a>
     <li><a href="#ref-for-font-specific⑥">6.9. Defining font specific alternates: the @font-feature-values rule</a>
@@ -6817,26 +6817,26 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-font-specific⑨">7.2. Feature precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-alternates-styleset">
-   <b><a href="#valdef-font-variant-alternates-styleset">#valdef-font-variant-alternates-styleset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-alternates-styleset" class="dfn-panel" data-for="valdef-font-variant-alternates-styleset" id="infopanel-for-valdef-font-variant-alternates-styleset" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-alternates-styleset" style="display:none">Info about the 'styleset(&lt;feature-value-name>#)' definition.</span><b><a href="#valdef-font-variant-alternates-styleset">#valdef-font-variant-alternates-styleset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-alternates-styleset">6.9.2. Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-alternates-character-variant">
-   <b><a href="#valdef-font-variant-alternates-character-variant">#valdef-font-variant-alternates-character-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-alternates-character-variant" class="dfn-panel" data-for="valdef-font-variant-alternates-character-variant" id="infopanel-for-valdef-font-variant-alternates-character-variant" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-alternates-character-variant" style="display:none">Info about the 'character-variant(&lt;feature-value-name>#)' definition.</span><b><a href="#valdef-font-variant-alternates-character-variant">#valdef-font-variant-alternates-character-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-alternates-character-variant">6.9.2. Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-alternates-swash">
-   <b><a href="#valdef-font-variant-alternates-swash">#valdef-font-variant-alternates-swash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-alternates-swash" class="dfn-panel" data-for="valdef-font-variant-alternates-swash" id="infopanel-for-valdef-font-variant-alternates-swash" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-alternates-swash" style="display:none">Info about the 'swash(&lt;feature-value-name>)' definition.</span><b><a href="#valdef-font-variant-alternates-swash">#valdef-font-variant-alternates-swash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-alternates-swash">6.9.2. Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-font-feature-values">
-   <b><a href="#at-ruledef-font-feature-values">#at-ruledef-font-feature-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-font-feature-values" class="dfn-panel" data-for="at-ruledef-font-feature-values" id="infopanel-for-at-ruledef-font-feature-values" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-font-feature-values" style="display:none">Info about the '@font-feature-values' definition.</span><b><a href="#at-ruledef-font-feature-values">#at-ruledef-font-feature-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-feature-values">6.8. Alternates and swashes: the font-variant-alternates property</a>
     <li><a href="#ref-for-at-ruledef-font-feature-values①">6.9. Defining font specific alternates: the @font-feature-values rule</a>
@@ -6846,94 +6846,94 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-at-ruledef-font-feature-values⑥">Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font_family_name_list">
-   <b><a href="#font_family_name_list">#font_family_name_list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font_family_name_list" class="dfn-panel" data-for="font_family_name_list" id="infopanel-for-font_family_name_list" role="dialog">
+   <span id="infopaneltitle-for-font_family_name_list" style="display:none">Info about the 'font_family_name_list' definition.</span><b><a href="#font_family_name_list">#font_family_name_list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font_family_name_list">6.9.1. Basic syntax</a> <a href="#ref-for-font_family_name_list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font_family_name">
-   <b><a href="#font_family_name">#font_family_name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font_family_name" class="dfn-panel" data-for="font_family_name" id="infopanel-for-font_family_name" role="dialog">
+   <span id="infopaneltitle-for-font_family_name" style="display:none">Info about the 'font_family_name' definition.</span><b><a href="#font_family_name">#font_family_name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font_family_name">6.9.1. Basic syntax</a> <a href="#ref-for-font_family_name①">(2)</a> <a href="#ref-for-font_family_name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature_value_block">
-   <b><a href="#feature_value_block">#feature_value_block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature_value_block" class="dfn-panel" data-for="feature_value_block" id="infopanel-for-feature_value_block" role="dialog">
+   <span id="infopaneltitle-for-feature_value_block" style="display:none">Info about the 'feature_value_block' definition.</span><b><a href="#feature_value_block">#feature_value_block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature_value_block">6.9.1. Basic syntax</a> <a href="#ref-for-feature_value_block①">(2)</a> <a href="#ref-for-feature_value_block②">(3)</a> <a href="#ref-for-feature_value_block③">(4)</a> <a href="#ref-for-feature_value_block④">(5)</a> <a href="#ref-for-feature_value_block⑤">(6)</a>
     <li><a href="#ref-for-feature_value_block⑥">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-feature_value_block⑦">(2)</a> <a href="#ref-for-feature_value_block⑧">(3)</a> <a href="#ref-for-feature_value_block⑨">(4)</a> <a href="#ref-for-feature_value_block①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature_type">
-   <b><a href="#feature_type">#feature_type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature_type" class="dfn-panel" data-for="feature_type" id="infopanel-for-feature_type" role="dialog">
+   <span id="infopaneltitle-for-feature_type" style="display:none">Info about the 'feature_type' definition.</span><b><a href="#feature_type">#feature_type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature_type">6.9.1. Basic syntax</a> <a href="#ref-for-feature_type①">(2)</a> <a href="#ref-for-feature_type②">(3)</a> <a href="#ref-for-feature_type③">(4)</a> <a href="#ref-for-feature_type④">(5)</a> <a href="#ref-for-feature_type⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature_value_definition">
-   <b><a href="#feature_value_definition">#feature_value_definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature_value_definition" class="dfn-panel" data-for="feature_value_definition" id="infopanel-for-feature_value_definition" role="dialog">
+   <span id="infopaneltitle-for-feature_value_definition" style="display:none">Info about the 'feature_value_definition' definition.</span><b><a href="#feature_value_definition">#feature_value_definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature_value_definition">6.9.1. Basic syntax</a> <a href="#ref-for-feature_value_definition①">(2)</a> <a href="#ref-for-feature_value_definition②">(3)</a> <a href="#ref-for-feature_value_definition③">(4)</a>
     <li><a href="#ref-for-feature_value_definition④">6.9.2. Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font_feature_values_sym">
-   <b><a href="#font_feature_values_sym">#font_feature_values_sym</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font_feature_values_sym" class="dfn-panel" data-for="font_feature_values_sym" id="infopanel-for-font_feature_values_sym" role="dialog">
+   <span id="infopaneltitle-for-font_feature_values_sym" style="display:none">Info about the 'FONT_FEATURE_VALUES_SYM' definition.</span><b><a href="#font_feature_values_sym">#font_feature_values_sym</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font_feature_values_sym">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-feature-value-name">
-   <b><a href="#typedef-feature-value-name">#typedef-feature-value-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-feature-value-name" class="dfn-panel" data-for="typedef-feature-value-name" id="infopanel-for-typedef-feature-value-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-feature-value-name" style="display:none">Info about the '&lt;feature-value-name>' definition.</span><b><a href="#typedef-feature-value-name">#typedef-feature-value-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-feature-value-name">4.7. Font features: the font-variant and font-feature-settings descriptors</a> <a href="#ref-for-typedef-feature-value-name①">(2)</a> <a href="#ref-for-typedef-feature-value-name②">(3)</a> <a href="#ref-for-typedef-feature-value-name③">(4)</a> <a href="#ref-for-typedef-feature-value-name④">(5)</a> <a href="#ref-for-typedef-feature-value-name⑤">(6)</a>
     <li><a href="#ref-for-typedef-feature-value-name⑥">6.8. Alternates and swashes: the font-variant-alternates property</a> <a href="#ref-for-typedef-feature-value-name⑦">(2)</a> <a href="#ref-for-typedef-feature-value-name⑧">(3)</a> <a href="#ref-for-typedef-feature-value-name⑨">(4)</a> <a href="#ref-for-typedef-feature-value-name①⓪">(5)</a> <a href="#ref-for-typedef-feature-value-name①①">(6)</a> <a href="#ref-for-typedef-feature-value-name①②">(7)</a> <a href="#ref-for-typedef-feature-value-name①③">(8)</a> <a href="#ref-for-typedef-feature-value-name①④">(9)</a> <a href="#ref-for-typedef-feature-value-name①⑤">(10)</a> <a href="#ref-for-typedef-feature-value-name①⑥">(11)</a> <a href="#ref-for-typedef-feature-value-name①⑦">(12)</a> <a href="#ref-for-typedef-feature-value-name①⑧">(13)</a> <a href="#ref-for-typedef-feature-value-name①⑨">(14)</a> <a href="#ref-for-typedef-feature-value-name②⓪">(15)</a>
     <li><a href="#ref-for-typedef-feature-value-name②①">6.11. Overall shorthand for font rendering: the font-variant property</a> <a href="#ref-for-typedef-feature-value-name②②">(2)</a> <a href="#ref-for-typedef-feature-value-name②③">(3)</a> <a href="#ref-for-typedef-feature-value-name②④">(4)</a> <a href="#ref-for-typedef-feature-value-name②⑤">(5)</a> <a href="#ref-for-typedef-feature-value-name②⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-feature-index">
-   <b><a href="#typedef-feature-index">#typedef-feature-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-feature-index" class="dfn-panel" data-for="typedef-feature-index" id="infopanel-for-typedef-feature-index" role="dialog">
+   <span id="infopaneltitle-for-typedef-feature-index" style="display:none">Info about the '&lt;feature-index>' definition.</span><b><a href="#typedef-feature-index">#typedef-feature-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-feature-index">6.8. Alternates and swashes: the font-variant-alternates property</a> <a href="#ref-for-typedef-feature-index①">(2)</a> <a href="#ref-for-typedef-feature-index②">(3)</a> <a href="#ref-for-typedef-feature-index③">(4)</a> <a href="#ref-for-typedef-feature-index④">(5)</a> <a href="#ref-for-typedef-feature-index⑤">(6)</a> <a href="#ref-for-typedef-feature-index⑥">(7)</a> <a href="#ref-for-typedef-feature-index⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-east-asian">
-   <b><a href="#propdef-font-variant-east-asian">#propdef-font-variant-east-asian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-east-asian" class="dfn-panel" data-for="propdef-font-variant-east-asian" id="infopanel-for-propdef-font-variant-east-asian" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-east-asian" style="display:none">Info about the 'font-variant-east-asian' definition.</span><b><a href="#propdef-font-variant-east-asian">#propdef-font-variant-east-asian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-east-asian">6.10. East Asian text rendering: the font-variant-east-asian property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-east-asian-variant-values">
-   <b><a href="#typedef-east-asian-variant-values">#typedef-east-asian-variant-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-east-asian-variant-values" class="dfn-panel" data-for="typedef-east-asian-variant-values" id="infopanel-for-typedef-east-asian-variant-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-east-asian-variant-values" style="display:none">Info about the '&lt;east-asian-variant-values>' definition.</span><b><a href="#typedef-east-asian-variant-values">#typedef-east-asian-variant-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-east-asian-variant-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-east-asian-variant-values①">6.10. East Asian text rendering: the font-variant-east-asian property</a>
     <li><a href="#ref-for-typedef-east-asian-variant-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-east-asian-width-values">
-   <b><a href="#typedef-east-asian-width-values">#typedef-east-asian-width-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-east-asian-width-values" class="dfn-panel" data-for="typedef-east-asian-width-values" id="infopanel-for-typedef-east-asian-width-values" role="dialog">
+   <span id="infopaneltitle-for-typedef-east-asian-width-values" style="display:none">Info about the '&lt;east-asian-width-values>' definition.</span><b><a href="#typedef-east-asian-width-values">#typedef-east-asian-width-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-east-asian-width-values">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-east-asian-width-values①">6.10. East Asian text rendering: the font-variant-east-asian property</a>
     <li><a href="#ref-for-typedef-east-asian-width-values②">6.11. Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-east-asian-east-asian-variant-values-simplified">
-   <b><a href="#valdef-font-variant-east-asian-east-asian-variant-values-simplified">#valdef-font-variant-east-asian-east-asian-variant-values-simplified</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-east-asian-east-asian-variant-values-simplified" class="dfn-panel" data-for="valdef-font-variant-east-asian-east-asian-variant-values-simplified" id="infopanel-for-valdef-font-variant-east-asian-east-asian-variant-values-simplified" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-east-asian-east-asian-variant-values-simplified" style="display:none">Info about the 'simplified' definition.</span><b><a href="#valdef-font-variant-east-asian-east-asian-variant-values-simplified">#valdef-font-variant-east-asian-east-asian-variant-values-simplified</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-east-asian-east-asian-variant-values-simplified">6.10. East Asian text rendering: the font-variant-east-asian property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-east-asian-east-asian-variant-values-traditional">
-   <b><a href="#valdef-font-variant-east-asian-east-asian-variant-values-traditional">#valdef-font-variant-east-asian-east-asian-variant-values-traditional</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-east-asian-east-asian-variant-values-traditional" class="dfn-panel" data-for="valdef-font-variant-east-asian-east-asian-variant-values-traditional" id="infopanel-for-valdef-font-variant-east-asian-east-asian-variant-values-traditional" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-east-asian-east-asian-variant-values-traditional" style="display:none">Info about the 'traditional' definition.</span><b><a href="#valdef-font-variant-east-asian-east-asian-variant-values-traditional">#valdef-font-variant-east-asian-east-asian-variant-values-traditional</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-east-asian-east-asian-variant-values-traditional">6.10. East Asian text rendering: the font-variant-east-asian property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant">
-   <b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant" class="dfn-panel" data-for="propdef-font-variant" id="infopanel-for-propdef-font-variant" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant" style="display:none">Info about the 'font-variant' definition.</span><b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">3.7. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-variant①">(2)</a> <a href="#ref-for-propdef-font-variant②">(3)</a> <a href="#ref-for-propdef-font-variant③">(4)</a> <a href="#ref-for-propdef-font-variant④">(5)</a> <a href="#ref-for-propdef-font-variant⑤">(6)</a>
     <li><a href="#ref-for-propdef-font-variant⑥">4.7. Font features: the font-variant and font-feature-settings descriptors</a> <a href="#ref-for-propdef-font-variant⑦">(2)</a> <a href="#ref-for-propdef-font-variant⑧">(3)</a>
@@ -6949,15 +6949,15 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-variant②④">Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-normal">
-   <b><a href="#valdef-font-variant-normal">#valdef-font-variant-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-normal" class="dfn-panel" data-for="valdef-font-variant-normal" id="infopanel-for-valdef-font-variant-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-variant-normal">#valdef-font-variant-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-normal">3.7. Shorthand font property: the font property</a> <a href="#ref-for-valdef-font-variant-normal①">(2)</a>
     <li><a href="#ref-for-valdef-font-variant-normal②">7.1. Default features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-feature-settings">
-   <b><a href="#propdef-font-feature-settings">#propdef-font-feature-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-feature-settings" class="dfn-panel" data-for="propdef-font-feature-settings" id="infopanel-for-propdef-font-feature-settings" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' definition.</span><b><a href="#propdef-font-feature-settings">#propdef-font-feature-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-propdef-font-feature-settings①">6.11. Overall shorthand for font rendering: the font-variant property</a>
@@ -6969,15 +6969,15 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-feature-settings⑦">7.3. Feature precedence examples</a> <a href="#ref-for-propdef-font-feature-settings⑧">(2)</a> <a href="#ref-for-propdef-font-feature-settings⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-feature-tag-value">
-   <b><a href="#typedef-feature-tag-value">#typedef-feature-tag-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-feature-tag-value" class="dfn-panel" data-for="typedef-feature-tag-value" id="infopanel-for-typedef-feature-tag-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-feature-tag-value" style="display:none">Info about the '&lt;feature-tag-value>' definition.</span><b><a href="#typedef-feature-tag-value">#typedef-feature-tag-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-feature-tag-value">4.7. Font features: the font-variant and font-feature-settings descriptors</a>
     <li><a href="#ref-for-typedef-feature-tag-value①">6.12. Low-level font feature settings control: the font-feature-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-language-override">
-   <b><a href="#propdef-font-language-override">#propdef-font-language-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-language-override" class="dfn-panel" data-for="propdef-font-language-override" id="infopanel-for-propdef-font-language-override" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-language-override" style="display:none">Info about the 'font-language-override' definition.</span><b><a href="#propdef-font-language-override">#propdef-font-language-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-language-override①">3.7. Shorthand font property: the font property</a>
     <li><a href="#ref-for-propdef-font-language-override②">6.2. Language-specific display</a>
@@ -6985,133 +6985,189 @@ Font Feature Resolution </a>
     <li><a href="#ref-for-propdef-font-language-override④">6.13. Font language override: the font-language-override property</a> <a href="#ref-for-propdef-font-language-override⑤">(2)</a> <a href="#ref-for-propdef-font-language-override⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssfontfacerule">
-   <b><a href="#cssfontfacerule">#cssfontfacerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssfontfacerule" class="dfn-panel" data-for="cssfontfacerule" id="infopanel-for-cssfontfacerule" role="dialog">
+   <span id="infopaneltitle-for-cssfontfacerule" style="display:none">Info about the 'CSSFontFaceRule' definition.</span><b><a href="#cssfontfacerule">#cssfontfacerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfacerule">8.1. The CSSFontFaceRule interface</a> <a href="#ref-for-cssfontfacerule①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssfontfeaturevaluesrule">
-   <b><a href="#cssfontfeaturevaluesrule">#cssfontfeaturevaluesrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssfontfeaturevaluesrule" class="dfn-panel" data-for="cssfontfeaturevaluesrule" id="infopanel-for-cssfontfeaturevaluesrule" role="dialog">
+   <span id="infopaneltitle-for-cssfontfeaturevaluesrule" style="display:none">Info about the 'CSSFontFeatureValuesRule' definition.</span><b><a href="#cssfontfeaturevaluesrule">#cssfontfeaturevaluesrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfeaturevaluesrule">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssfontfeaturevaluesrule①">(2)</a> <a href="#ref-for-cssfontfeaturevaluesrule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssfontfeaturevaluesmap">
-   <b><a href="#cssfontfeaturevaluesmap">#cssfontfeaturevaluesmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssfontfeaturevaluesmap" class="dfn-panel" data-for="cssfontfeaturevaluesmap" id="infopanel-for-cssfontfeaturevaluesmap" role="dialog">
+   <span id="infopaneltitle-for-cssfontfeaturevaluesmap" style="display:none">Info about the 'CSSFontFeatureValuesMap' definition.</span><b><a href="#cssfontfeaturevaluesmap">#cssfontfeaturevaluesmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfeaturevaluesmap">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssfontfeaturevaluesmap①">(2)</a> <a href="#ref-for-cssfontfeaturevaluesmap②">(3)</a> <a href="#ref-for-cssfontfeaturevaluesmap③">(4)</a> <a href="#ref-for-cssfontfeaturevaluesmap④">(5)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑤">(6)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑥">(7)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑦">(8)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑧">(9)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑨">(10)</a> <a href="#ref-for-cssfontfeaturevaluesmap①⓪">(11)</a> <a href="#ref-for-cssfontfeaturevaluesmap①①">(12)</a> <a href="#ref-for-cssfontfeaturevaluesmap①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesmap-set">
-   <b><a href="#dom-cssfontfeaturevaluesmap-set">#dom-cssfontfeaturevaluesmap-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesmap-set" class="dfn-panel" data-for="dom-cssfontfeaturevaluesmap-set" id="infopanel-for-dom-cssfontfeaturevaluesmap-set" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesmap-set" style="display:none">Info about the 'set' definition.</span><b><a href="#dom-cssfontfeaturevaluesmap-set">#dom-cssfontfeaturevaluesmap-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesmap-set">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-dom-cssfontfeaturevaluesmap-set①">(2)</a> <a href="#ref-for-dom-cssfontfeaturevaluesmap-set②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename">
-   <b><a href="#dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename">#dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename" class="dfn-panel" data-for="dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename" id="infopanel-for-dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename" style="display:none">Info about the 'featureValueName' definition.</span><b><a href="#dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename">#dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesmap-set-featurevaluename-values-featurevaluename">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-fontfamily">
-   <b><a href="#dom-cssfontfeaturevaluesrule-fontfamily">#dom-cssfontfeaturevaluesrule-fontfamily</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-fontfamily" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-fontfamily" id="infopanel-for-dom-cssfontfeaturevaluesrule-fontfamily" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-fontfamily" style="display:none">Info about the 'fontFamily' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-fontfamily">#dom-cssfontfeaturevaluesrule-fontfamily</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-fontfamily">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-annotation">
-   <b><a href="#dom-cssfontfeaturevaluesrule-annotation">#dom-cssfontfeaturevaluesrule-annotation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-annotation" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-annotation" id="infopanel-for-dom-cssfontfeaturevaluesrule-annotation" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-annotation" style="display:none">Info about the 'annotation' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-annotation">#dom-cssfontfeaturevaluesrule-annotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-annotation">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-dom-cssfontfeaturevaluesrule-annotation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-ornaments">
-   <b><a href="#dom-cssfontfeaturevaluesrule-ornaments">#dom-cssfontfeaturevaluesrule-ornaments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-ornaments" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-ornaments" id="infopanel-for-dom-cssfontfeaturevaluesrule-ornaments" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-ornaments" style="display:none">Info about the 'ornaments' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-ornaments">#dom-cssfontfeaturevaluesrule-ornaments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-ornaments">8.2. The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-dom-cssfontfeaturevaluesrule-ornaments①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-stylistic">
-   <b><a href="#dom-cssfontfeaturevaluesrule-stylistic">#dom-cssfontfeaturevaluesrule-stylistic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-stylistic" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-stylistic" id="infopanel-for-dom-cssfontfeaturevaluesrule-stylistic" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-stylistic" style="display:none">Info about the 'stylistic' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-stylistic">#dom-cssfontfeaturevaluesrule-stylistic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-stylistic">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-swash">
-   <b><a href="#dom-cssfontfeaturevaluesrule-swash">#dom-cssfontfeaturevaluesrule-swash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-swash" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-swash" id="infopanel-for-dom-cssfontfeaturevaluesrule-swash" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-swash" style="display:none">Info about the 'swash' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-swash">#dom-cssfontfeaturevaluesrule-swash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-swash">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-charactervariant">
-   <b><a href="#dom-cssfontfeaturevaluesrule-charactervariant">#dom-cssfontfeaturevaluesrule-charactervariant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-charactervariant" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-charactervariant" id="infopanel-for-dom-cssfontfeaturevaluesrule-charactervariant" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-charactervariant" style="display:none">Info about the 'characterVariant' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-charactervariant">#dom-cssfontfeaturevaluesrule-charactervariant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-charactervariant">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-styleset">
-   <b><a href="#dom-cssfontfeaturevaluesrule-styleset">#dom-cssfontfeaturevaluesrule-styleset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssfontfeaturevaluesrule-styleset" class="dfn-panel" data-for="dom-cssfontfeaturevaluesrule-styleset" id="infopanel-for-dom-cssfontfeaturevaluesrule-styleset" role="dialog">
+   <span id="infopaneltitle-for-dom-cssfontfeaturevaluesrule-styleset" style="display:none">Info about the 'styleset' definition.</span><b><a href="#dom-cssfontfeaturevaluesrule-styleset">#dom-cssfontfeaturevaluesrule-styleset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssfontfeaturevaluesrule-styleset">8.2. The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-fonts-4/Overview.html
@@ -8291,22 +8291,22 @@ Special thanks to Ilya Grigorik and David Kuettel for their help in developing t
    <li><a href="#valdef-font-variant-emoji-unicode">unicode</a><span>, in § 9.3</span>
    <li><a href="#descdef-font-face-unicode-range">unicode-range</a><span>, in § 4.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-width-medium">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-width-medium">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-width-medium</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-width-medium" class="dfn-panel" data-for="term-for-valdef-line-width-medium" id="infopanel-for-term-for-valdef-line-width-medium" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-width-medium" style="display:none">Info about the 'medium' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-width-medium">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-width-medium</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-width-medium">2.5. 
 Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.1.1. 
 Syntax of &lt;family-name> </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">9.2.3. 
 Overriding a color from a palette: The override-color descriptor</a>
@@ -8314,68 +8314,68 @@ Overriding a color from a palette: The override-color descriptor</a>
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">4.3.3.2. @font-face requirements</a> <a href="#ref-for-propdef-color①">(2)</a>
     <li><a href="#ref-for-propdef-color②">9.1. 
 Controlling Color Font Palettes: The font-palette property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-block" class="dfn-panel" data-for="term-for-valdef-display-block" id="infopanel-for-term-for-valdef-display-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">4.9. 
 Controlling Font Display Per Font-Face: the font-display descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2.5. 
 Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascent-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#ascent-metric">https://drafts.csswg.org/css-inline-3/#ascent-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascent-metric" class="dfn-panel" data-for="term-for-ascent-metric" id="infopanel-for-term-for-ascent-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-ascent-metric" style="display:none">Info about the 'ascent metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#ascent-metric">https://drafts.csswg.org/css-inline-3/#ascent-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascent-metric">4.11. 
 Default font metrics overriding:
 the ascent-override, descent-override and line-gap-override descriptors</a> <a href="#ref-for-ascent-metric①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descent-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#descent-metric">https://drafts.csswg.org/css-inline-3/#descent-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descent-metric" class="dfn-panel" data-for="term-for-descent-metric" id="infopanel-for-term-for-descent-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-descent-metric" style="display:none">Info about the 'descent metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#descent-metric">https://drafts.csswg.org/css-inline-3/#descent-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descent-metric">4.11. 
 Default font metrics overriding:
 the ascent-override, descent-override and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-gap-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-gap-metric">https://drafts.csswg.org/css-inline-3/#line-gap-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-gap-metric" class="dfn-panel" data-for="term-for-line-gap-metric" id="infopanel-for-term-for-line-gap-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-line-gap-metric" style="display:none">Info about the 'line gap metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-gap-metric">https://drafts.csswg.org/css-inline-3/#line-gap-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-gap-metric">4.11. 
 Default font metrics overriding:
 the ascent-override, descent-override and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">2.5. 
 Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-shape-large">
-   <a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-large">https://drafts.csswg.org/css-shapes-2/#valdef-shape-large</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-shape-large" class="dfn-panel" data-for="term-for-valdef-shape-large" id="infopanel-for-term-for-valdef-shape-large" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-shape-large" style="display:none">Info about the 'large' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#valdef-shape-large">https://drafts.csswg.org/css-shapes-2/#valdef-shape-large</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-large">2.5. 
 Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">4.1. 
 The @font-face rule</a>
@@ -8384,27 +8384,27 @@ The @font-face rule</a>
 User-defined font color palettes: The @font-palette-values rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-rule-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-rule-list">https://drafts.csswg.org/css-syntax-3/#typedef-rule-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-rule-list" class="dfn-panel" data-for="term-for-typedef-rule-list" id="infopanel-for-term-for-typedef-rule-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-rule-list" style="display:none">Info about the '&lt;rule-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-rule-list">https://drafts.csswg.org/css-syntax-3/#typedef-rule-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-rule-list">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-urange">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-urange">https://drafts.csswg.org/css-syntax-3/#typedef-urange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-urange" class="dfn-panel" data-for="term-for-typedef-urange" id="infopanel-for-term-for-typedef-urange" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-urange" style="display:none">Info about the '&lt;urange>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-urange">https://drafts.csswg.org/css-syntax-3/#typedef-urange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-urange">4.5. 
 Character range: the unicode-range descriptor</a> <a href="#ref-for-typedef-urange①">(2)</a> <a href="#ref-for-typedef-urange②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-invalid">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-invalid" class="dfn-panel" data-for="term-for-css-invalid" id="infopanel-for-term-for-css-invalid" role="menu">
+   <span id="infopaneltitle-for-term-for-css-invalid" style="display:none">Info about the 'invalid' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-invalid">2.2. Font weight: the font-weight property</a>
     <li><a href="#ref-for-css-invalid①">2.3. 
@@ -8413,15 +8413,15 @@ Font width: the font-stretch property</a>
 Font style: the font-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">11.3. 
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">2.1.3. 
 Generic font families</a>
@@ -8429,8 +8429,8 @@ Generic font families</a>
 Language-specific display</a> <a href="#ref-for-content-language②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">6.3. 
 Kerning: the font-kerning property</a>
@@ -8438,22 +8438,22 @@ Kerning: the font-kerning property</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">6.6. 
 Capitalization: the font-variant-caps property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">8.1. 
 Optical sizing control: the font-optical-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.1. 
 Font family: the font-family property</a>
@@ -8474,8 +8474,8 @@ Low-level font variation settings control: the font-variation-settings property<
 Overriding a color from a palette: The override-color descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">2.4. 
 Font style: the font-style property</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a>
@@ -8484,8 +8484,8 @@ Font property descriptors: the font-style, font-weight, and
 font-stretch descriptors</a> <a href="#ref-for-angle-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.1.1. 
 Syntax of &lt;family-name> </a>
@@ -8493,15 +8493,15 @@ Syntax of &lt;family-name> </a>
 User-defined font color palettes: The @font-palette-values rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">6.8. 
 Alternates and swashes: the font-variant-alternates property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">6.9.1. Basic syntax</a> <a href="#ref-for-integer-value①">(2)</a>
     <li><a href="#ref-for-integer-value②">9.2.2. 
@@ -8510,15 +8510,15 @@ Specifying the base palette: the base-palette descriptor</a> <a href="#ref-for-i
 Overriding a color from a palette: The override-color descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">2.5. 
 Font size: the font-size property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">2.2. Font weight: the font-weight property</a> <a href="#ref-for-number-value①">(2)</a>
     <li><a href="#ref-for-number-value②">2.6. 
@@ -8529,8 +8529,8 @@ Font features and variations: the font-feature-settings and font-variation-setti
 Low-level font variation settings control: the font-variation-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.3. 
 Font width: the font-stretch property</a> <a href="#ref-for-percentage-value①">(2)</a> <a href="#ref-for-percentage-value②">(3)</a>
@@ -8539,8 +8539,8 @@ Default font metrics overriding:
 the ascent-override, descent-override and line-gap-override descriptors</a> <a href="#ref-for-percentage-value④">(2)</a> <a href="#ref-for-percentage-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2.1.1. 
 Syntax of &lt;family-name> </a>
@@ -8559,14 +8559,14 @@ Specifying the base palette: the base-palette descriptor</a>
 Overriding a color from a palette: The override-color descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">4.3.1. Parsing the src descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.4. 
 Font style: the font-style property</a>
@@ -8579,8 +8579,8 @@ font-stretch descriptors</a>
 Low-level font feature settings control: the font-feature-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
@@ -8590,51 +8590,51 @@ Syntax of &lt;family-name> </a>
 Font features and variations: the font-feature-settings and font-variation-settings descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">2.5. 
 Font size: the font-size property</a>
     <li><a href="#ref-for-em①">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-relative-length" class="dfn-panel" data-for="term-for-font-relative-length" id="infopanel-for-term-for-font-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">2.5. 
 Font size: the font-size property</a>
     <li><a href="#ref-for-font-relative-length①">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rem">
-   <a href="https://drafts.csswg.org/css-values-4/#rem">https://drafts.csswg.org/css-values-4/#rem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rem" class="dfn-panel" data-for="term-for-rem" id="infopanel-for-term-for-rem" role="menu">
+   <span id="infopaneltitle-for-term-for-rem" style="display:none">Info about the 'rem' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#rem">https://drafts.csswg.org/css-values-4/#rem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rem">2.5. 
 Font size: the font-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4.4. 
 Font property descriptors: the font-style, font-weight, and
 font-stretch descriptors</a> <a href="#ref-for-mult-num-range①">(2)</a> <a href="#ref-for-mult-num-range②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Font family: the font-family property</a>
@@ -8707,8 +8707,8 @@ Overriding a color from a palette: The override-color descriptor</a>
 Selecting the text presentation style: The font-variant-emoji property</a> <a href="#ref-for-comb-one①③⑤">(2)</a> <a href="#ref-for-comb-one①③⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
@@ -8726,50 +8726,50 @@ East Asian text rendering: the font-variant-east-asian property</a> <a href="#re
 Overall shorthand for font rendering: the font-variant property</a> <a href="#ref-for-comb-any②①">(2)</a> <a href="#ref-for-comb-any②②">(3)</a> <a href="#ref-for-comb-any②③">(4)</a> <a href="#ref-for-comb-any②④">(5)</a> <a href="#ref-for-comb-any②⑤">(6)</a> <a href="#ref-for-comb-any②⑥">(7)</a> <a href="#ref-for-comb-any②⑦">(8)</a> <a href="#ref-for-comb-any②⑧">(9)</a> <a href="#ref-for-comb-any②⑨">(10)</a> <a href="#ref-for-comb-any③⓪">(11)</a> <a href="#ref-for-comb-any③①">(12)</a> <a href="#ref-for-comb-any③②">(13)</a> <a href="#ref-for-comb-any③③">(14)</a> <a href="#ref-for-comb-any③④">(15)</a> <a href="#ref-for-comb-any③⑤">(16)</a> <a href="#ref-for-comb-any③⑥">(17)</a> <a href="#ref-for-comb-any③⑦">(18)</a> <a href="#ref-for-comb-any③⑧">(19)</a> <a href="#ref-for-comb-any③⑨">(20)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typeset-sideways">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#typeset-sideways">https://drafts.csswg.org/css-writing-modes-4/#typeset-sideways</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typeset-sideways" class="dfn-panel" data-for="term-for-typeset-sideways" id="infopanel-for-term-for-typeset-sideways" role="menu">
+   <span id="infopaneltitle-for-term-for-typeset-sideways" style="display:none">Info about the 'sideways typesetting' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#typeset-sideways">https://drafts.csswg.org/css-writing-modes-4/#typeset-sideways</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-sideways">6.3. 
 Kerning: the font-kerning property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-mode" class="dfn-panel" data-for="term-for-typographic-mode" id="infopanel-for-term-for-typographic-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-mode" style="display:none">Info about the 'typographic mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">6.3. 
 Kerning: the font-kerning property</a> <a href="#ref-for-typographic-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typeset-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#typeset-upright">https://drafts.csswg.org/css-writing-modes-4/#typeset-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typeset-upright" class="dfn-panel" data-for="term-for-typeset-upright" id="infopanel-for-term-for-typeset-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-typeset-upright" style="display:none">Info about the 'upright typesetting' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#typeset-upright">https://drafts.csswg.org/css-writing-modes-4/#typeset-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-upright">6.3. 
 Kerning: the font-kerning property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-typographic-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-typographic-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-typographic-mode" class="dfn-panel" data-for="term-for-vertical-typographic-mode" id="infopanel-for-term-for-vertical-typographic-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-typographic-mode" style="display:none">Info about the 'vertical typographic mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-typographic-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-typographic-mode">6.3. 
 Kerning: the font-kerning property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-absolute-size">
-   <a href="https://drafts.csswg.org/css2/#value-def-absolute-size">https://drafts.csswg.org/css2/#value-def-absolute-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-absolute-size" class="dfn-panel" data-for="term-for-value-def-absolute-size" id="infopanel-for-term-for-value-def-absolute-size" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-absolute-size" style="display:none">Info about the '&lt;absolute-size>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-absolute-size">https://drafts.csswg.org/css2/#value-def-absolute-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-absolute-size">2.5. 
 Font size: the font-size property</a> <a href="#ref-for-value-def-absolute-size①">(2)</a> <a href="#ref-for-value-def-absolute-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-relative-size">
-   <a href="https://drafts.csswg.org/css2/#value-def-relative-size">https://drafts.csswg.org/css2/#value-def-relative-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-relative-size" class="dfn-panel" data-for="term-for-value-def-relative-size" id="infopanel-for-term-for-value-def-relative-size" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-relative-size" style="display:none">Info about the '&lt;relative-size>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-relative-size">https://drafts.csswg.org/css2/#value-def-relative-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-relative-size">2.5. 
 Font size: the font-size property</a> <a href="#ref-for-value-def-relative-size①">(2)</a> <a href="#ref-for-value-def-relative-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">2.6. 
 Relative sizing: the font-size-adjust property</a> <a href="#ref-for-propdef-line-height①">(2)</a> <a href="#ref-for-propdef-line-height②">(3)</a>
@@ -8778,23 +8778,23 @@ Shorthand font property: the font property</a> <a href="#ref-for-propdef-line-he
     <li><a href="#ref-for-propdef-line-height⑥">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-size-medium">
-   <a href="https://drafts.csswg.org/css2/#valdef-font-size-medium">https://drafts.csswg.org/css2/#valdef-font-size-medium</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-size-medium" class="dfn-panel" data-for="term-for-valdef-font-size-medium" id="infopanel-for-term-for-valdef-font-size-medium" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-size-medium" style="display:none">Info about the 'medium' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-font-size-medium">https://drafts.csswg.org/css2/#valdef-font-size-medium</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-size-medium">2.5.1. 
     Absolute Size Keyword Mapping Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-style-oblique">
-   <a href="https://drafts.csswg.org/css2/#valdef-font-style-oblique">https://drafts.csswg.org/css2/#valdef-font-style-oblique</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-style-oblique" class="dfn-panel" data-for="term-for-valdef-font-style-oblique" id="infopanel-for-term-for-valdef-font-style-oblique" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-style-oblique" style="display:none">Info about the 'oblique' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-font-style-oblique">https://drafts.csswg.org/css2/#valdef-font-style-oblique</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-oblique">2.4. 
 Font style: the font-style property</a>
     <li><a href="#ref-for-valdef-font-style-oblique①">5.2. Matching font styles</a> <a href="#ref-for-valdef-font-style-oblique②">(2)</a> <a href="#ref-for-valdef-font-style-oblique③">(3)</a> <a href="#ref-for-valdef-font-style-oblique④">(4)</a> <a href="#ref-for-valdef-font-style-oblique⑤">(5)</a> <a href="#ref-for-valdef-font-style-oblique⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">11.2. 
 The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a>
@@ -8802,8 +8802,8 @@ The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssomstring①">(2)
 The CSSFontPaletteValuesRule interface</a> <a href="#ref-for-cssomstring④">(2)</a> <a href="#ref-for-cssomstring⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">11.1. 
 The CSSFontFaceRule interface</a>
@@ -8813,61 +8813,61 @@ The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssrule②">(2)</a>
 The CSSFontPaletteValuesRule interface</a> <a href="#ref-for-cssrule④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">11.1. 
 The CSSFontFaceRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations" id="infopanel-for-term-for-cssstyledeclaration-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">2.3. 
 Font width: the font-stretch property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">4.8.2. 
 Font fetching requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">4.8.2. 
 Font fetching requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font" class="dfn-panel" data-for="term-for-font" id="infopanel-for-term-for-font" role="menu">
+   <span id="infopaneltitle-for-term-for-font" style="display:none">Info about the 'font' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font">2.5.1. 
     Absolute Size Keyword Mapping Table</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_case_sensitive">
-   <a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_case_sensitive" class="dfn-panel" data-for="term-for-def_case_sensitive" id="infopanel-for-term-for-def_case_sensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-def_case_sensitive" style="display:none">Info about the 'case-sensitive' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_case_sensitive">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">6.9.1. Basic syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">11.1. 
 The CSSFontFaceRule interface</a>
@@ -8877,36 +8877,36 @@ The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-Exposed②">(2)</a>
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">11.3. 
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">11.2. 
 The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">11.3. 
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">11.2. 
 The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">11.2. 
 The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
@@ -8914,8 +8914,8 @@ The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-idl-unsigned-long�
 The CSSFontPaletteValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">11.2. 
 The CSSFontFeatureValuesRule interface</a>
@@ -9614,8 +9614,8 @@ comment on any bugs in this spec at <a href="https://github.com/w3c/csswg-drafts
    <div class="issue"> The threshold for preferring oblique over normal <a href="https://github.com/w3c/csswg-drafts/issues/2295">should be lower than the average angle</a>. <a class="issue-return" href="#issue-c152d461" title="Jump to section">↵</a></div>
    <div class="issue"> Add more examples and pictures. <a class="issue-return" href="#issue-6dfa50ce" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-font-family">
-   <b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-family" class="dfn-panel" data-for="propdef-font-family" id="infopanel-for-propdef-font-family" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-family" style="display:none">Info about the 'font-family' definition.</span><b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">2.1. 
 Font family: the font-family property</a>
@@ -9637,8 +9637,8 @@ Font family: the font-family descriptor</a> <a href="#ref-for-propdef-font-famil
 Preinstalled Fonts and User-Installed Fonts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="family-name-value">
-   <b><a href="#family-name-value">#family-name-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-family-name-value" class="dfn-panel" data-for="family-name-value" id="infopanel-for-family-name-value" role="dialog">
+   <span id="infopaneltitle-for-family-name-value" style="display:none">Info about the '&lt;family-name>' definition.</span><b><a href="#family-name-value">#family-name-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-family-name-value">2.1. 
 Font family: the font-family property</a> <a href="#ref-for-family-name-value①">(2)</a> <a href="#ref-for-family-name-value②">(3)</a>
@@ -9652,8 +9652,8 @@ Generic font families</a>
 Font family: the font-family descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generic-family-value">
-   <b><a href="#generic-family-value">#generic-family-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generic-family-value" class="dfn-panel" data-for="generic-family-value" id="infopanel-for-generic-family-value" role="dialog">
+   <span id="infopaneltitle-for-generic-family-value" style="display:none">Info about the '&lt;generic-family>' definition.</span><b><a href="#generic-family-value">#generic-family-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-family-value">2.1. 
 Font family: the font-family property</a> <a href="#ref-for-generic-family-value①">(2)</a> <a href="#ref-for-generic-family-value②">(3)</a> <a href="#ref-for-generic-family-value③">(4)</a> <a href="#ref-for-generic-family-value④">(5)</a> <a href="#ref-for-generic-family-value⑤">(6)</a>
@@ -9661,8 +9661,8 @@ Font family: the font-family property</a> <a href="#ref-for-generic-family-value
 Syntax of &lt;family-name> </a> <a href="#ref-for-generic-family-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-serif">
-   <b><a href="#valdef-font-family-serif">#valdef-font-family-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-serif" class="dfn-panel" data-for="valdef-font-family-serif" id="infopanel-for-valdef-font-family-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-serif" style="display:none">Info about the 'serif' definition.</span><b><a href="#valdef-font-family-serif">#valdef-font-family-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-serif">2.1.1. 
 Syntax of &lt;family-name> </a>
@@ -9670,8 +9670,8 @@ Syntax of &lt;family-name> </a>
 Generic font families</a> <a href="#ref-for-valdef-font-family-serif②">(2)</a> <a href="#ref-for-valdef-font-family-serif③">(3)</a> <a href="#ref-for-valdef-font-family-serif④">(4)</a> <a href="#ref-for-valdef-font-family-serif⑤">(5)</a> <a href="#ref-for-valdef-font-family-serif⑥">(6)</a> <a href="#ref-for-valdef-font-family-serif⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-sans-serif">
-   <b><a href="#valdef-font-family-sans-serif">#valdef-font-family-sans-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-sans-serif" class="dfn-panel" data-for="valdef-font-family-sans-serif" id="infopanel-for-valdef-font-family-sans-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-sans-serif" style="display:none">Info about the 'sans-serif' definition.</span><b><a href="#valdef-font-family-sans-serif">#valdef-font-family-sans-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-sans-serif">2.1. 
 Font family: the font-family property</a>
@@ -9679,29 +9679,29 @@ Font family: the font-family property</a>
 Generic font families</a> <a href="#ref-for-valdef-font-family-sans-serif②">(2)</a> <a href="#ref-for-valdef-font-family-sans-serif③">(3)</a> <a href="#ref-for-valdef-font-family-sans-serif④">(4)</a> <a href="#ref-for-valdef-font-family-sans-serif⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-cursive">
-   <b><a href="#valdef-font-family-cursive">#valdef-font-family-cursive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-cursive" class="dfn-panel" data-for="valdef-font-family-cursive" id="infopanel-for-valdef-font-family-cursive" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-cursive" style="display:none">Info about the 'cursive' definition.</span><b><a href="#valdef-font-family-cursive">#valdef-font-family-cursive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-cursive">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-cursive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-fantasy">
-   <b><a href="#valdef-font-family-fantasy">#valdef-font-family-fantasy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-fantasy" class="dfn-panel" data-for="valdef-font-family-fantasy" id="infopanel-for-valdef-font-family-fantasy" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-fantasy" style="display:none">Info about the 'fantasy' definition.</span><b><a href="#valdef-font-family-fantasy">#valdef-font-family-fantasy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-fantasy">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-monospace">
-   <b><a href="#valdef-font-family-monospace">#valdef-font-family-monospace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-monospace" class="dfn-panel" data-for="valdef-font-family-monospace" id="infopanel-for-valdef-font-family-monospace" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-monospace" style="display:none">Info about the 'monospace' definition.</span><b><a href="#valdef-font-family-monospace">#valdef-font-family-monospace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-monospace">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-monospace①">(2)</a> <a href="#ref-for-valdef-font-family-monospace②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-system-ui">
-   <b><a href="#valdef-font-family-system-ui">#valdef-font-family-system-ui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-system-ui" class="dfn-panel" data-for="valdef-font-family-system-ui" id="infopanel-for-valdef-font-family-system-ui" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-system-ui" style="display:none">Info about the 'system-ui' definition.</span><b><a href="#valdef-font-family-system-ui">#valdef-font-family-system-ui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-system-ui">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-system-ui①">(2)</a> <a href="#ref-for-valdef-font-family-system-ui②">(3)</a>
@@ -9710,43 +9710,43 @@ System Font</a>
     <li><a href="#ref-for-valdef-font-family-system-ui④">12.6. What information from the underlying platform, e.g. configuration data, is exposed by this specification to an origin? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-emoji">
-   <b><a href="#valdef-font-family-emoji">#valdef-font-family-emoji</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-emoji" class="dfn-panel" data-for="valdef-font-family-emoji" id="infopanel-for-valdef-font-family-emoji" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-emoji" style="display:none">Info about the 'emoji' definition.</span><b><a href="#valdef-font-family-emoji">#valdef-font-family-emoji</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-emoji">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-emoji①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-ui-serif">
-   <b><a href="#valdef-font-family-ui-serif">#valdef-font-family-ui-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-ui-serif" class="dfn-panel" data-for="valdef-font-family-ui-serif" id="infopanel-for-valdef-font-family-ui-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-ui-serif" style="display:none">Info about the 'ui-serif' definition.</span><b><a href="#valdef-font-family-ui-serif">#valdef-font-family-ui-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-ui-serif">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-ui-serif①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-ui-sans-serif">
-   <b><a href="#valdef-font-family-ui-sans-serif">#valdef-font-family-ui-sans-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-ui-sans-serif" class="dfn-panel" data-for="valdef-font-family-ui-sans-serif" id="infopanel-for-valdef-font-family-ui-sans-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-ui-sans-serif" style="display:none">Info about the 'ui-sans-serif' definition.</span><b><a href="#valdef-font-family-ui-sans-serif">#valdef-font-family-ui-sans-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-ui-sans-serif">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-ui-sans-serif①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-ui-monospace">
-   <b><a href="#valdef-font-family-ui-monospace">#valdef-font-family-ui-monospace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-ui-monospace" class="dfn-panel" data-for="valdef-font-family-ui-monospace" id="infopanel-for-valdef-font-family-ui-monospace" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-ui-monospace" style="display:none">Info about the 'ui-monospace' definition.</span><b><a href="#valdef-font-family-ui-monospace">#valdef-font-family-ui-monospace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-ui-monospace">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-ui-monospace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-family-ui-rounded">
-   <b><a href="#valdef-font-family-ui-rounded">#valdef-font-family-ui-rounded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-family-ui-rounded" class="dfn-panel" data-for="valdef-font-family-ui-rounded" id="infopanel-for-valdef-font-family-ui-rounded" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-family-ui-rounded" style="display:none">Info about the 'ui-rounded' definition.</span><b><a href="#valdef-font-family-ui-rounded">#valdef-font-family-ui-rounded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-family-ui-rounded">2.1.3. 
 Generic font families</a> <a href="#ref-for-valdef-font-family-ui-rounded①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-weight">
-   <b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-weight" class="dfn-panel" data-for="propdef-font-weight" id="infopanel-for-propdef-font-weight" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-weight" style="display:none">Info about the 'font-weight' definition.</span><b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">2.1.2. 
 Relationship Between Faces and Families </a>
@@ -9763,8 +9763,8 @@ Feature and variation precedence</a>
 Low-level font variation settings control: the font-variation-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-weight-absolute-values">
-   <b><a href="#font-weight-absolute-values">#font-weight-absolute-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-weight-absolute-values" class="dfn-panel" data-for="font-weight-absolute-values" id="infopanel-for-font-weight-absolute-values" role="dialog">
+   <span id="infopaneltitle-for-font-weight-absolute-values" style="display:none">Info about the '&lt;font-weight-absolute>' definition.</span><b><a href="#font-weight-absolute-values">#font-weight-absolute-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-weight-absolute-values">2.2. Font weight: the font-weight property</a>
     <li><a href="#ref-for-font-weight-absolute-values①">4.4. 
@@ -9772,15 +9772,15 @@ Font property descriptors: the font-style, font-weight, and
 font-stretch descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bold">
-   <b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bold" class="dfn-panel" data-for="valdef-font-weight-bold" id="infopanel-for-valdef-font-weight-bold" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bold" style="display:none">Info about the 'bold' definition.</span><b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bold">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bolder">
-   <b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bolder" class="dfn-panel" data-for="valdef-font-weight-bolder" id="infopanel-for-valdef-font-weight-bolder" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bolder" style="display:none">Info about the 'bolder' definition.</span><b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bolder">2.2.1. 
 Relative Weights</a>
@@ -9789,8 +9789,8 @@ Font property descriptors: the font-style, font-weight, and
 font-stretch descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-lighter">
-   <b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-lighter" class="dfn-panel" data-for="valdef-font-weight-lighter" id="infopanel-for-valdef-font-weight-lighter" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-lighter" style="display:none">Info about the 'lighter' definition.</span><b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-lighter">2.2.1. 
 Relative Weights</a>
@@ -9799,8 +9799,8 @@ Font property descriptors: the font-style, font-weight, and
 font-stretch descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-stretch">
-   <b><a href="#propdef-font-stretch">#propdef-font-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-stretch" class="dfn-panel" data-for="propdef-font-stretch" id="infopanel-for-propdef-font-stretch" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' definition.</span><b><a href="#propdef-font-stretch">#propdef-font-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">2.1.2. 
 Relationship Between Faces and Families </a>
@@ -9817,15 +9817,15 @@ font-stretch descriptors</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-stretch-condensed">
-   <b><a href="#valdef-font-stretch-condensed">#valdef-font-stretch-condensed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-stretch-condensed" class="dfn-panel" data-for="valdef-font-stretch-condensed" id="infopanel-for-valdef-font-stretch-condensed" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-stretch-condensed" style="display:none">Info about the 'condensed' definition.</span><b><a href="#valdef-font-stretch-condensed">#valdef-font-stretch-condensed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-stretch-condensed">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-style">
-   <b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-style" class="dfn-panel" data-for="propdef-font-style" id="infopanel-for-propdef-font-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-style" style="display:none">Info about the 'font-style' definition.</span><b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">2.1.2. 
 Relationship Between Faces and Families </a>
@@ -9841,14 +9841,14 @@ Feature and variation precedence</a> <a href="#ref-for-propdef-font-style②②"
 Low-level font variation settings control: the font-variation-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-normal">
-   <b><a href="#valdef-font-style-normal">#valdef-font-style-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-normal" class="dfn-panel" data-for="valdef-font-style-normal" id="infopanel-for-valdef-font-style-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-style-normal">#valdef-font-style-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-normal">5.2. Matching font styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-italic">
-   <b><a href="#valdef-font-style-italic">#valdef-font-style-italic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-italic" class="dfn-panel" data-for="valdef-font-style-italic" id="infopanel-for-valdef-font-style-italic" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-italic" style="display:none">Info about the 'italic' definition.</span><b><a href="#valdef-font-style-italic">#valdef-font-style-italic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-italic">2.4. 
 Font style: the font-style property</a> <a href="#ref-for-valdef-font-style-italic①">(2)</a>
@@ -9857,8 +9857,8 @@ Shorthand font property: the font property</a>
     <li><a href="#ref-for-valdef-font-style-italic③">5.2. Matching font styles</a> <a href="#ref-for-valdef-font-style-italic④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-size">
-   <b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-size" class="dfn-panel" data-for="propdef-font-size" id="infopanel-for-propdef-font-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-size" style="display:none">Info about the 'font-size' definition.</span><b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">2.5. 
 Font size: the font-size property</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a> <a href="#ref-for-propdef-font-size③">(4)</a> <a href="#ref-for-propdef-font-size④">(5)</a>
@@ -9871,8 +9871,8 @@ Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-si
 Optical sizing control: the font-optical-sizing property</a> <a href="#ref-for-propdef-font-size①⑧">(2)</a> <a href="#ref-for-propdef-font-size①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-size-adjust">
-   <b><a href="#propdef-font-size-adjust">#propdef-font-size-adjust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-size-adjust" class="dfn-panel" data-for="propdef-font-size-adjust" id="infopanel-for-propdef-font-size-adjust" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' definition.</span><b><a href="#propdef-font-size-adjust">#propdef-font-size-adjust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">2.5. 
 Font size: the font-size property</a> <a href="#ref-for-propdef-font-size-adjust①">(2)</a> <a href="#ref-for-propdef-font-size-adjust②">(3)</a>
@@ -9886,22 +9886,22 @@ Optical sizing control: the font-optical-sizing property</a>
 	Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="aspect-value">
-   <b><a href="#aspect-value">#aspect-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aspect-value" class="dfn-panel" data-for="aspect-value" id="infopanel-for-aspect-value" role="dialog">
+   <span id="infopaneltitle-for-aspect-value" style="display:none">Info about the 'aspect value' definition.</span><b><a href="#aspect-value">#aspect-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aspect-value">2.6. 
 Relative sizing: the font-size-adjust property</a> <a href="#ref-for-aspect-value①">(2)</a> <a href="#ref-for-aspect-value②">(3)</a> <a href="#ref-for-aspect-value③">(4)</a> <a href="#ref-for-aspect-value④">(5)</a> <a href="#ref-for-aspect-value⑤">(6)</a> <a href="#ref-for-aspect-value⑥">(7)</a> <a href="#ref-for-aspect-value⑦">(8)</a> <a href="#ref-for-aspect-value⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-size-adjust-none-value">
-   <b><a href="#font-size-adjust-none-value">#font-size-adjust-none-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-size-adjust-none-value" class="dfn-panel" data-for="font-size-adjust-none-value" id="infopanel-for-font-size-adjust-none-value" role="dialog">
+   <span id="infopaneltitle-for-font-size-adjust-none-value" style="display:none">Info about the 'none' definition.</span><b><a href="#font-size-adjust-none-value">#font-size-adjust-none-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-size-adjust-none-value">2.6. 
 Relative sizing: the font-size-adjust property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font">
-   <b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font" class="dfn-panel" data-for="propdef-font" id="infopanel-for-propdef-font" role="dialog">
+   <span id="infopaneltitle-for-propdef-font" style="display:none">Info about the 'font' definition.</span><b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-propdef-font①">(2)</a> <a href="#ref-for-propdef-font②">(3)</a> <a href="#ref-for-propdef-font③">(4)</a> <a href="#ref-for-propdef-font④">(5)</a> <a href="#ref-for-propdef-font⑤">(6)</a> <a href="#ref-for-propdef-font⑥">(7)</a> <a href="#ref-for-propdef-font⑦">(8)</a> <a href="#ref-for-propdef-font⑧">(9)</a> <a href="#ref-for-propdef-font⑨">(10)</a>
@@ -9909,36 +9909,36 @@ Shorthand font property: the font property</a> <a href="#ref-for-propdef-font①
 Font Feature and Variation Resolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-variant-css21-values">
-   <b><a href="#font-variant-css21-values">#font-variant-css21-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-variant-css21-values" class="dfn-panel" data-for="font-variant-css21-values" id="infopanel-for-font-variant-css21-values" role="dialog">
+   <span id="infopaneltitle-for-font-variant-css21-values" style="display:none">Info about the '&lt;font-variant-css2>' definition.</span><b><a href="#font-variant-css21-values">#font-variant-css21-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-variant-css21-values">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-font-variant-css21-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-stretch-css3-values">
-   <b><a href="#font-stretch-css3-values">#font-stretch-css3-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-stretch-css3-values" class="dfn-panel" data-for="font-stretch-css3-values" id="infopanel-for-font-stretch-css3-values" role="dialog">
+   <span id="infopaneltitle-for-font-stretch-css3-values" style="display:none">Info about the '&lt;font-stretch-css3>' definition.</span><b><a href="#font-stretch-css3-values">#font-stretch-css3-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-stretch-css3-values">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-font-stretch-css3-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-caption">
-   <b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-caption" class="dfn-panel" data-for="valdef-font-caption" id="infopanel-for-valdef-font-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-caption" style="display:none">Info about the 'caption' definition.</span><b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-caption">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-small-caption">
-   <b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-small-caption" class="dfn-panel" data-for="valdef-font-small-caption" id="infopanel-for-valdef-font-small-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-small-caption" style="display:none">Info about the 'small-caption' definition.</span><b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-small-caption">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-synthesis-weight">
-   <b><a href="#propdef-font-synthesis-weight">#propdef-font-synthesis-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-synthesis-weight" class="dfn-panel" data-for="propdef-font-synthesis-weight" id="infopanel-for-propdef-font-synthesis-weight" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-synthesis-weight" style="display:none">Info about the 'font-synthesis-weight' definition.</span><b><a href="#propdef-font-synthesis-weight">#propdef-font-synthesis-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis-weight">2.8.1. 
 Controlling synthesized bold: The font-synthesis-weight property</a>
@@ -9946,8 +9946,8 @@ Controlling synthesized bold: The font-synthesis-weight property</a>
 Controlling synthetic faces: the font-synthesis shorthand</a> <a href="#ref-for-propdef-font-synthesis-weight②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-synthesis-style">
-   <b><a href="#propdef-font-synthesis-style">#propdef-font-synthesis-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-synthesis-style" class="dfn-panel" data-for="propdef-font-synthesis-style" id="infopanel-for-propdef-font-synthesis-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-synthesis-style" style="display:none">Info about the 'font-synthesis-style' definition.</span><b><a href="#propdef-font-synthesis-style">#propdef-font-synthesis-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis-style">2.4. 
 Font style: the font-style property</a>
@@ -9958,8 +9958,8 @@ Controlling synthetic faces: the font-synthesis shorthand</a> <a href="#ref-for-
     <li><a href="#ref-for-propdef-font-synthesis-style④">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-synthesis-style⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-synthesis-small-caps">
-   <b><a href="#propdef-font-synthesis-small-caps">#propdef-font-synthesis-small-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-synthesis-small-caps" class="dfn-panel" data-for="propdef-font-synthesis-small-caps" id="infopanel-for-propdef-font-synthesis-small-caps" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-synthesis-small-caps" style="display:none">Info about the 'font-synthesis-small-caps' definition.</span><b><a href="#propdef-font-synthesis-small-caps">#propdef-font-synthesis-small-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis-small-caps">2.8.3. 
 Controlling synthesized small caps: The font-synthesis-small-caps property</a>
@@ -9967,8 +9967,8 @@ Controlling synthesized small caps: The font-synthesis-small-caps property</a>
 Controlling synthetic faces: the font-synthesis shorthand</a> <a href="#ref-for-propdef-font-synthesis-small-caps②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-synthesis">
-   <b><a href="#propdef-font-synthesis">#propdef-font-synthesis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-synthesis" class="dfn-panel" data-for="propdef-font-synthesis" id="infopanel-for-propdef-font-synthesis" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-synthesis" style="display:none">Info about the 'font-synthesis' definition.</span><b><a href="#propdef-font-synthesis">#propdef-font-synthesis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-synthesis">2.2.2. 
 Missing weights</a>
@@ -9979,8 +9979,8 @@ Controlling synthetic faces: the font-synthesis shorthand</a> <a href="#ref-for-
     <li><a href="#ref-for-propdef-font-synthesis④">5.2. Matching font styles</a> <a href="#ref-for-propdef-font-synthesis⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-block-period">
-   <b><a href="#font-block-period">#font-block-period</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-block-period" class="dfn-panel" data-for="font-block-period" id="infopanel-for-font-block-period" role="dialog">
+   <span id="infopaneltitle-for-font-block-period" style="display:none">Info about the 'font block period' definition.</span><b><a href="#font-block-period">#font-block-period</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-block-period">3.2. 
 The Font Display Timeline</a> <a href="#ref-for-font-block-period①">(2)</a> <a href="#ref-for-font-block-period②">(3)</a>
@@ -9988,8 +9988,8 @@ The Font Display Timeline</a> <a href="#ref-for-font-block-period①">(2)</a> <a
 Controlling Font Display Per Font-Face: the font-display descriptor</a> <a href="#ref-for-font-block-period④">(2)</a> <a href="#ref-for-font-block-period⑤">(3)</a> <a href="#ref-for-font-block-period⑥">(4)</a> <a href="#ref-for-font-block-period⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-swap-period">
-   <b><a href="#font-swap-period">#font-swap-period</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-swap-period" class="dfn-panel" data-for="font-swap-period" id="infopanel-for-font-swap-period" role="dialog">
+   <span id="infopaneltitle-for-font-swap-period" style="display:none">Info about the 'font swap period' definition.</span><b><a href="#font-swap-period">#font-swap-period</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-swap-period">3.2. 
 The Font Display Timeline</a> <a href="#ref-for-font-swap-period①">(2)</a> <a href="#ref-for-font-swap-period②">(3)</a>
@@ -9997,29 +9997,29 @@ The Font Display Timeline</a> <a href="#ref-for-font-swap-period①">(2)</a> <a 
 Controlling Font Display Per Font-Face: the font-display descriptor</a> <a href="#ref-for-font-swap-period④">(2)</a> <a href="#ref-for-font-swap-period⑤">(3)</a> <a href="#ref-for-font-swap-period⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-failure-period">
-   <b><a href="#font-failure-period">#font-failure-period</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-failure-period" class="dfn-panel" data-for="font-failure-period" id="infopanel-for-font-failure-period" role="dialog">
+   <span id="infopaneltitle-for-font-failure-period" style="display:none">Info about the 'font failure period' definition.</span><b><a href="#font-failure-period">#font-failure-period</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-failure-period">3.2. 
 The Font Display Timeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="render-with-a-fallback-font-face">
-   <b><a href="#render-with-a-fallback-font-face">#render-with-a-fallback-font-face</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-render-with-a-fallback-font-face" class="dfn-panel" data-for="render-with-a-fallback-font-face" id="infopanel-for-render-with-a-fallback-font-face" role="dialog">
+   <span id="infopaneltitle-for-render-with-a-fallback-font-face" style="display:none">Info about the 'render with a fallback font face' definition.</span><b><a href="#render-with-a-fallback-font-face">#render-with-a-fallback-font-face</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-render-with-a-fallback-font-face">3.2. 
 The Font Display Timeline</a> <a href="#ref-for-render-with-a-fallback-font-face①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="render-with-an-invisible-fallback-font-face">
-   <b><a href="#render-with-an-invisible-fallback-font-face">#render-with-an-invisible-fallback-font-face</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-render-with-an-invisible-fallback-font-face" class="dfn-panel" data-for="render-with-an-invisible-fallback-font-face" id="infopanel-for-render-with-an-invisible-fallback-font-face" role="dialog">
+   <span id="infopaneltitle-for-render-with-an-invisible-fallback-font-face" style="display:none">Info about the 'render with an invisible fallback font face' definition.</span><b><a href="#render-with-an-invisible-fallback-font-face">#render-with-an-invisible-fallback-font-face</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-render-with-an-invisible-fallback-font-face">3.2. 
 The Font Display Timeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-font-face-rule">
-   <b><a href="#at-font-face-rule">#at-font-face-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-font-face-rule" class="dfn-panel" data-for="at-font-face-rule" id="infopanel-for-at-font-face-rule" role="dialog">
+   <span id="infopaneltitle-for-at-font-face-rule" style="display:none">Info about the '@font-face' definition.</span><b><a href="#at-font-face-rule">#at-font-face-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-font-face-rule">3.1. 
 Introduction to Font Rendering Controls</a>
@@ -10066,43 +10066,43 @@ Object Model</a>
 The CSSFontFaceRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-family">
-   <b><a href="#descdef-font-face-font-family">#descdef-font-face-font-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-family" class="dfn-panel" data-for="descdef-font-face-font-family" id="infopanel-for-descdef-font-face-font-family" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-family" style="display:none">Info about the 'font-family' definition.</span><b><a href="#descdef-font-face-font-family">#descdef-font-face-font-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-family">4.2. Font family: the font-family descriptor</a>
     <li><a href="#ref-for-descdef-font-face-font-family①">9.2.1. 
 Font family: the font-family descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-src">
-   <b><a href="#descdef-font-face-src">#descdef-font-face-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-src" class="dfn-panel" data-for="descdef-font-face-src" id="infopanel-for-descdef-font-face-src" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-src" style="display:none">Info about the 'src' definition.</span><b><a href="#descdef-font-face-src">#descdef-font-face-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-src">4.3.1. Parsing the src descriptor</a> <a href="#ref-for-descdef-font-face-src①">(2)</a>
     <li><a href="#ref-for-descdef-font-face-src②">4.3.2. Loading an individual item in the src descriptor</a>
     <li><a href="#ref-for-descdef-font-face-src③">4.3.3. Selecting items in the src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-format-values">
-   <b><a href="#font-format-values">#font-format-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-format-values" class="dfn-panel" data-for="font-format-values" id="infopanel-for-font-format-values" role="dialog">
+   <span id="infopaneltitle-for-font-format-values" style="display:none">Info about the '&lt;font-format>' definition.</span><b><a href="#font-format-values">#font-format-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-format-values">4.3.1. Parsing the src descriptor</a>
     <li><a href="#ref-for-font-format-values①">4.3.3.1. @font-face format types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-technology-values">
-   <b><a href="#font-technology-values">#font-technology-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-technology-values" class="dfn-panel" data-for="font-technology-values" id="infopanel-for-font-technology-values" role="dialog">
+   <span id="infopaneltitle-for-font-technology-values" style="display:none">Info about the '&lt;font-technology>' definition.</span><b><a href="#font-technology-values">#font-technology-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-technology-values">4.3.1. Parsing the src descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-font-technology-values">
-   <b><a href="#color-font-technology-values">#color-font-technology-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-font-technology-values" class="dfn-panel" data-for="color-font-technology-values" id="infopanel-for-color-font-technology-values" role="dialog">
+   <span id="infopaneltitle-for-color-font-technology-values" style="display:none">Info about the '&lt;color-font-technology>' definition.</span><b><a href="#color-font-technology-values">#color-font-technology-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-font-technology-values">4.3.1. Parsing the src descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-style">
-   <b><a href="#descdef-font-face-font-style">#descdef-font-face-font-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-style" class="dfn-panel" data-for="descdef-font-face-font-style" id="infopanel-for-descdef-font-face-font-style" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-style" style="display:none">Info about the 'font-style' definition.</span><b><a href="#descdef-font-face-font-style">#descdef-font-face-font-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-style">4.4. 
 Font property descriptors: the font-style, font-weight, and
@@ -10112,8 +10112,8 @@ font-stretch descriptors</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-weight">
-   <b><a href="#descdef-font-face-font-weight">#descdef-font-face-font-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-weight" class="dfn-panel" data-for="descdef-font-face-font-weight" id="infopanel-for-descdef-font-face-font-weight" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-weight" style="display:none">Info about the 'font-weight' definition.</span><b><a href="#descdef-font-face-font-weight">#descdef-font-face-font-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-weight">4.4. 
 Font property descriptors: the font-style, font-weight, and
@@ -10122,8 +10122,8 @@ font-stretch descriptors</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-stretch">
-   <b><a href="#descdef-font-face-font-stretch">#descdef-font-face-font-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-stretch" class="dfn-panel" data-for="descdef-font-face-font-stretch" id="infopanel-for-descdef-font-face-font-stretch" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-stretch" style="display:none">Info about the 'font-stretch' definition.</span><b><a href="#descdef-font-face-font-stretch">#descdef-font-face-font-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-stretch">4.4. 
 Font property descriptors: the font-style, font-weight, and
@@ -10132,8 +10132,8 @@ font-stretch descriptors</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-feature-settings">
-   <b><a href="#descdef-font-face-font-feature-settings">#descdef-font-face-font-feature-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-feature-settings" class="dfn-panel" data-for="descdef-font-face-font-feature-settings" id="infopanel-for-descdef-font-face-font-feature-settings" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-feature-settings" style="display:none">Info about the 'font-feature-settings' definition.</span><b><a href="#descdef-font-face-font-feature-settings">#descdef-font-face-font-feature-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-feature-settings">4.6. 
 Font features and variations: the font-feature-settings and font-variation-settings descriptors</a>
@@ -10141,8 +10141,8 @@ Font features and variations: the font-feature-settings and font-variation-setti
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-variation-settings">
-   <b><a href="#descdef-font-face-font-variation-settings">#descdef-font-face-font-variation-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-variation-settings" class="dfn-panel" data-for="descdef-font-face-font-variation-settings" id="infopanel-for-descdef-font-face-font-variation-settings" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-variation-settings" style="display:none">Info about the 'font-variation-settings' definition.</span><b><a href="#descdef-font-face-font-variation-settings">#descdef-font-face-font-variation-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-variation-settings">4.6. 
 Font features and variations: the font-feature-settings and font-variation-settings descriptors</a>
@@ -10150,14 +10150,14 @@ Font features and variations: the font-feature-settings and font-variation-setti
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-named-instance">
-   <b><a href="#descdef-font-face-font-named-instance">#descdef-font-face-font-named-instance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-named-instance" class="dfn-panel" data-for="descdef-font-face-font-named-instance" id="infopanel-for-descdef-font-face-font-named-instance" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-named-instance" style="display:none">Info about the 'font-named-instance' definition.</span><b><a href="#descdef-font-face-font-named-instance">#descdef-font-face-font-named-instance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-named-instance">4.7. Using named instances from variable fonts: the font-named-instance descriptor</a> <a href="#ref-for-descdef-font-face-font-named-instance①">(2)</a> <a href="#ref-for-descdef-font-face-font-named-instance②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-display">
-   <b><a href="#descdef-font-face-font-display">#descdef-font-face-font-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-display" class="dfn-panel" data-for="descdef-font-face-font-display" id="infopanel-for-descdef-font-face-font-display" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-display" style="display:none">Info about the 'font-display' definition.</span><b><a href="#descdef-font-face-font-display">#descdef-font-face-font-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-display">4.8.1. Font loading guidelines</a>
     <li><a href="#ref-for-descdef-font-face-font-display①">4.9. 
@@ -10168,8 +10168,8 @@ Controlling Font Display Per Font-Family via @font-feature-values</a> <a href="#
 Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-face-font-display-fallback">
-   <b><a href="#valdef-font-face-font-display-fallback">#valdef-font-face-font-display-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-face-font-display-fallback" class="dfn-panel" data-for="valdef-font-face-font-display-fallback" id="infopanel-for-valdef-font-face-font-display-fallback" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-face-font-display-fallback" style="display:none">Info about the 'fallback' definition.</span><b><a href="#valdef-font-face-font-display-fallback">#valdef-font-face-font-display-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-face-font-display-fallback">3.2. 
 The Font Display Timeline</a>
@@ -10177,8 +10177,8 @@ The Font Display Timeline</a>
 Controlling Font Display Per Font-Face: the font-display descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-face-font-display-optional">
-   <b><a href="#valdef-font-face-font-display-optional">#valdef-font-face-font-display-optional</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-face-font-display-optional" class="dfn-panel" data-for="valdef-font-face-font-display-optional" id="infopanel-for-valdef-font-face-font-display-optional" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-face-font-display-optional" style="display:none">Info about the 'optional' definition.</span><b><a href="#valdef-font-face-font-display-optional">#valdef-font-face-font-display-optional</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-face-font-display-optional">3.2. 
 The Font Display Timeline</a>
@@ -10186,22 +10186,22 @@ The Font Display Timeline</a>
 Controlling Font Display Per Font-Face: the font-display descriptor</a> <a href="#ref-for-valdef-font-face-font-display-optional②">(2)</a> <a href="#ref-for-valdef-font-face-font-display-optional③">(3)</a> <a href="#ref-for-valdef-font-face-font-display-optional④">(4)</a> <a href="#ref-for-valdef-font-face-font-display-optional⑤">(5)</a> <a href="#ref-for-valdef-font-face-font-display-optional⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-feature-values-font-display">
-   <b><a href="#descdef-font-feature-values-font-display">#descdef-font-feature-values-font-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-feature-values-font-display" class="dfn-panel" data-for="descdef-font-feature-values-font-display" id="infopanel-for-descdef-font-feature-values-font-display" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-feature-values-font-display" style="display:none">Info about the 'font-display' definition.</span><b><a href="#descdef-font-feature-values-font-display">#descdef-font-feature-values-font-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-feature-values-font-display">4.9.1. 
 Controlling Font Display Per Font-Family via @font-feature-values</a> <a href="#ref-for-descdef-font-feature-values-font-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-language-override">
-   <b><a href="#descdef-font-face-font-language-override">#descdef-font-face-font-language-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-language-override" class="dfn-panel" data-for="descdef-font-face-font-language-override" id="infopanel-for-descdef-font-face-font-language-override" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-language-override" style="display:none">Info about the 'font-language-override' definition.</span><b><a href="#descdef-font-face-font-language-override">#descdef-font-face-font-language-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-language-override①">7.2. 
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="character-map">
-   <b><a href="#character-map">#character-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character-map" class="dfn-panel" data-for="character-map" id="infopanel-for-character-map" role="dialog">
+   <span id="infopaneltitle-for-character-map" style="display:none">Info about the 'character map' definition.</span><b><a href="#character-map">#character-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character-map">2.4. 
 Font style: the font-style property</a> <a href="#ref-for-character-map①">(2)</a>
@@ -10215,15 +10215,15 @@ Glyph selection and positioning</a>
     <li><a href="#ref-for-character-map①⓪"> Appendix A: Mapping platform font properties to CSS properties</a> <a href="#ref-for-character-map①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="support">
-   <b><a href="#support">#support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-support" class="dfn-panel" data-for="support" id="infopanel-for-support" role="dialog">
+   <span id="infopaneltitle-for-support" style="display:none">Info about the 'support' definition.</span><b><a href="#support">#support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-support">5.3. 
 Cluster matching</a> <a href="#ref-for-support①">(2)</a> <a href="#ref-for-support②">(3)</a> <a href="#ref-for-support③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-kerning">
-   <b><a href="#propdef-font-kerning">#propdef-font-kerning</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-kerning" class="dfn-panel" data-for="propdef-font-kerning" id="infopanel-for-propdef-font-kerning" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-kerning" style="display:none">Info about the 'font-kerning' definition.</span><b><a href="#propdef-font-kerning">#propdef-font-kerning</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-kerning">2.7. 
 Shorthand font property: the font property</a>
@@ -10235,8 +10235,8 @@ Low-level font feature settings control: the font-feature-settings property</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-ligatures">
-   <b><a href="#propdef-font-variant-ligatures">#propdef-font-variant-ligatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-ligatures" class="dfn-panel" data-for="propdef-font-variant-ligatures" id="infopanel-for-propdef-font-variant-ligatures" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-ligatures" style="display:none">Info about the 'font-variant-ligatures' definition.</span><b><a href="#propdef-font-variant-ligatures">#propdef-font-variant-ligatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-ligatures">6.4. 
 Ligatures: the font-variant-ligatures property</a>
@@ -10248,71 +10248,71 @@ Default features</a>
 Feature precedence examples</a> <a href="#ref-for-propdef-font-variant-ligatures④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="common-lig-values">
-   <b><a href="#common-lig-values">#common-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-common-lig-values" class="dfn-panel" data-for="common-lig-values" id="infopanel-for-common-lig-values" role="dialog">
+   <span id="infopaneltitle-for-common-lig-values" style="display:none">Info about the '&lt;common-lig-values>' definition.</span><b><a href="#common-lig-values">#common-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-common-lig-values">6.11. 
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discretionary-lig-values">
-   <b><a href="#discretionary-lig-values">#discretionary-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discretionary-lig-values" class="dfn-panel" data-for="discretionary-lig-values" id="infopanel-for-discretionary-lig-values" role="dialog">
+   <span id="infopaneltitle-for-discretionary-lig-values" style="display:none">Info about the '&lt;discretionary-lig-values>' definition.</span><b><a href="#discretionary-lig-values">#discretionary-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discretionary-lig-values">6.11. 
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="historical-lig-values">
-   <b><a href="#historical-lig-values">#historical-lig-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-historical-lig-values" class="dfn-panel" data-for="historical-lig-values" id="infopanel-for-historical-lig-values" role="dialog">
+   <span id="infopaneltitle-for-historical-lig-values" style="display:none">Info about the '&lt;historical-lig-values>' definition.</span><b><a href="#historical-lig-values">#historical-lig-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-historical-lig-values">6.11. 
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contextual-alt-values">
-   <b><a href="#contextual-alt-values">#contextual-alt-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contextual-alt-values" class="dfn-panel" data-for="contextual-alt-values" id="infopanel-for-contextual-alt-values" role="dialog">
+   <span id="infopaneltitle-for-contextual-alt-values" style="display:none">Info about the '&lt;contextual-alt-values>' definition.</span><b><a href="#contextual-alt-values">#contextual-alt-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contextual-alt-values">6.11. 
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-ligatures-no-discretionary-ligatures">
-   <b><a href="#valdef-font-variant-ligatures-no-discretionary-ligatures">#valdef-font-variant-ligatures-no-discretionary-ligatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-ligatures-no-discretionary-ligatures" class="dfn-panel" data-for="valdef-font-variant-ligatures-no-discretionary-ligatures" id="infopanel-for-valdef-font-variant-ligatures-no-discretionary-ligatures" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-ligatures-no-discretionary-ligatures" style="display:none">Info about the 'no-discretionary-ligatures' definition.</span><b><a href="#valdef-font-variant-ligatures-no-discretionary-ligatures">#valdef-font-variant-ligatures-no-discretionary-ligatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-ligatures-no-discretionary-ligatures">7.3. 
 Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-position">
-   <b><a href="#propdef-font-variant-position">#propdef-font-variant-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-position" class="dfn-panel" data-for="propdef-font-variant-position" id="infopanel-for-propdef-font-variant-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-position" style="display:none">Info about the 'font-variant-position' definition.</span><b><a href="#propdef-font-variant-position">#propdef-font-variant-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-position①">6.5. 
 Subscript and superscript forms: the font-variant-position property</a> <a href="#ref-for-propdef-font-variant-position②">(2)</a> <a href="#ref-for-propdef-font-variant-position③">(3)</a> <a href="#ref-for-propdef-font-variant-position④">(4)</a> <a href="#ref-for-propdef-font-variant-position⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-caps">
-   <b><a href="#propdef-font-variant-caps">#propdef-font-variant-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-caps" class="dfn-panel" data-for="propdef-font-variant-caps" id="infopanel-for-propdef-font-variant-caps" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-caps" style="display:none">Info about the 'font-variant-caps' definition.</span><b><a href="#propdef-font-variant-caps">#propdef-font-variant-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-caps">6.6. 
 Capitalization: the font-variant-caps property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-caps-small-caps">
-   <b><a href="#valdef-font-variant-caps-small-caps">#valdef-font-variant-caps-small-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-caps-small-caps" class="dfn-panel" data-for="valdef-font-variant-caps-small-caps" id="infopanel-for-valdef-font-variant-caps-small-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-caps-small-caps" style="display:none">Info about the 'small-caps' definition.</span><b><a href="#valdef-font-variant-caps-small-caps">#valdef-font-variant-caps-small-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-caps-small-caps">2.7. 
 Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-numeric">
-   <b><a href="#propdef-font-variant-numeric">#propdef-font-variant-numeric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-numeric" class="dfn-panel" data-for="propdef-font-variant-numeric" id="infopanel-for-propdef-font-variant-numeric" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-numeric" style="display:none">Info about the 'font-variant-numeric' definition.</span><b><a href="#propdef-font-variant-numeric">#propdef-font-variant-numeric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-numeric">6.7. 
 Numerical formatting: the font-variant-numeric property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="numeric-figure-values">
-   <b><a href="#numeric-figure-values">#numeric-figure-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-numeric-figure-values" class="dfn-panel" data-for="numeric-figure-values" id="infopanel-for-numeric-figure-values" role="dialog">
+   <span id="infopaneltitle-for-numeric-figure-values" style="display:none">Info about the '&lt;numeric-figure-values>' definition.</span><b><a href="#numeric-figure-values">#numeric-figure-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-numeric-figure-values">6.7. 
 Numerical formatting: the font-variant-numeric property</a>
@@ -10320,8 +10320,8 @@ Numerical formatting: the font-variant-numeric property</a>
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="numeric-spacing-values">
-   <b><a href="#numeric-spacing-values">#numeric-spacing-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-numeric-spacing-values" class="dfn-panel" data-for="numeric-spacing-values" id="infopanel-for-numeric-spacing-values" role="dialog">
+   <span id="infopaneltitle-for-numeric-spacing-values" style="display:none">Info about the '&lt;numeric-spacing-values>' definition.</span><b><a href="#numeric-spacing-values">#numeric-spacing-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-numeric-spacing-values">6.7. 
 Numerical formatting: the font-variant-numeric property</a>
@@ -10329,8 +10329,8 @@ Numerical formatting: the font-variant-numeric property</a>
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="numeric-fraction-values">
-   <b><a href="#numeric-fraction-values">#numeric-fraction-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-numeric-fraction-values" class="dfn-panel" data-for="numeric-fraction-values" id="infopanel-for-numeric-fraction-values" role="dialog">
+   <span id="infopaneltitle-for-numeric-fraction-values" style="display:none">Info about the '&lt;numeric-fraction-values>' definition.</span><b><a href="#numeric-fraction-values">#numeric-fraction-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-numeric-fraction-values">6.7. 
 Numerical formatting: the font-variant-numeric property</a>
@@ -10338,22 +10338,22 @@ Numerical formatting: the font-variant-numeric property</a>
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-numeric-proportional-nums">
-   <b><a href="#valdef-font-variant-numeric-proportional-nums">#valdef-font-variant-numeric-proportional-nums</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-numeric-proportional-nums" class="dfn-panel" data-for="valdef-font-variant-numeric-proportional-nums" id="infopanel-for-valdef-font-variant-numeric-proportional-nums" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-numeric-proportional-nums" style="display:none">Info about the 'proportional-nums' definition.</span><b><a href="#valdef-font-variant-numeric-proportional-nums">#valdef-font-variant-numeric-proportional-nums</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-numeric-proportional-nums">7.3. 
 Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-numeric-tabular-nums">
-   <b><a href="#valdef-font-variant-numeric-tabular-nums">#valdef-font-variant-numeric-tabular-nums</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-numeric-tabular-nums" class="dfn-panel" data-for="valdef-font-variant-numeric-tabular-nums" id="infopanel-for-valdef-font-variant-numeric-tabular-nums" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-numeric-tabular-nums" style="display:none">Info about the 'tabular-nums' definition.</span><b><a href="#valdef-font-variant-numeric-tabular-nums">#valdef-font-variant-numeric-tabular-nums</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-numeric-tabular-nums">7.3. 
 Feature precedence examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-alternates">
-   <b><a href="#propdef-font-variant-alternates">#propdef-font-variant-alternates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-alternates" class="dfn-panel" data-for="propdef-font-variant-alternates" id="infopanel-for-propdef-font-variant-alternates" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-alternates" style="display:none">Info about the 'font-variant-alternates' definition.</span><b><a href="#propdef-font-variant-alternates">#propdef-font-variant-alternates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-alternates">6.8. 
 Alternates and swashes: the font-variant-alternates property</a>
@@ -10365,8 +10365,8 @@ Multi-valued feature value definitions</a>
 The CSSFontFeatureValuesRule interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-value-name-value">
-   <b><a href="#feature-value-name-value">#feature-value-name-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-value-name-value" class="dfn-panel" data-for="feature-value-name-value" id="infopanel-for-feature-value-name-value" role="dialog">
+   <span id="infopaneltitle-for-feature-value-name-value" style="display:none">Info about the '&lt;feature-value-name>' definition.</span><b><a href="#feature-value-name-value">#feature-value-name-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-value-name-value">6.8. 
 Alternates and swashes: the font-variant-alternates property</a> <a href="#ref-for-feature-value-name-value①">(2)</a> <a href="#ref-for-feature-value-name-value②">(3)</a> <a href="#ref-for-feature-value-name-value③">(4)</a> <a href="#ref-for-feature-value-name-value④">(5)</a> <a href="#ref-for-feature-value-name-value⑤">(6)</a> <a href="#ref-for-feature-value-name-value⑥">(7)</a> <a href="#ref-for-feature-value-name-value⑦">(8)</a> <a href="#ref-for-feature-value-name-value⑧">(9)</a> <a href="#ref-for-feature-value-name-value⑨">(10)</a> <a href="#ref-for-feature-value-name-value①⓪">(11)</a> <a href="#ref-for-feature-value-name-value①①">(12)</a> <a href="#ref-for-feature-value-name-value①②">(13)</a> <a href="#ref-for-feature-value-name-value①③">(14)</a> <a href="#ref-for-feature-value-name-value①④">(15)</a>
@@ -10374,36 +10374,36 @@ Alternates and swashes: the font-variant-alternates property</a> <a href="#ref-f
 Overall shorthand for font rendering: the font-variant property</a> <a href="#ref-for-feature-value-name-value①⑥">(2)</a> <a href="#ref-for-feature-value-name-value①⑦">(3)</a> <a href="#ref-for-feature-value-name-value①⑧">(4)</a> <a href="#ref-for-feature-value-name-value①⑨">(5)</a> <a href="#ref-for-feature-value-name-value②⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="styleset">
-   <b><a href="#styleset">#styleset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-styleset" class="dfn-panel" data-for="styleset" id="infopanel-for-styleset" role="dialog">
+   <span id="infopaneltitle-for-styleset" style="display:none">Info about the 'styleset(&lt;feature-value-name>#)' definition.</span><b><a href="#styleset">#styleset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-styleset">6.9.2. 
 Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="character-variant">
-   <b><a href="#character-variant">#character-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character-variant" class="dfn-panel" data-for="character-variant" id="infopanel-for-character-variant" role="dialog">
+   <span id="infopaneltitle-for-character-variant" style="display:none">Info about the 'character-variant(&lt;feature-value-name>#)' definition.</span><b><a href="#character-variant">#character-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character-variant">6.9.2. 
 Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="swash">
-   <b><a href="#swash">#swash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-swash" class="dfn-panel" data-for="swash" id="infopanel-for-swash" role="dialog">
+   <span id="infopaneltitle-for-swash" style="display:none">Info about the 'swash(&lt;feature-value-name>)' definition.</span><b><a href="#swash">#swash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-swash">6.9.2. 
 Multi-valued feature value definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ornaments">
-   <b><a href="#ornaments">#ornaments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ornaments" class="dfn-panel" data-for="ornaments" id="infopanel-for-ornaments" role="dialog">
+   <span id="infopaneltitle-for-ornaments" style="display:none">Info about the 'ornaments(&lt;feature-value-name>)' definition.</span><b><a href="#ornaments">#ornaments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ornaments">6.8. 
 Alternates and swashes: the font-variant-alternates property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-font-feature-values">
-   <b><a href="#at-ruledef-font-feature-values">#at-ruledef-font-feature-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-font-feature-values" class="dfn-panel" data-for="at-ruledef-font-feature-values" id="infopanel-for-at-ruledef-font-feature-values" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-font-feature-values" style="display:none">Info about the '@font-feature-values' definition.</span><b><a href="#at-ruledef-font-feature-values">#at-ruledef-font-feature-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-feature-values">4.9.1. 
 Controlling Font Display Per Font-Family via @font-feature-values</a> <a href="#ref-for-at-ruledef-font-feature-values①">(2)</a> <a href="#ref-for-at-ruledef-font-feature-values②">(3)</a> <a href="#ref-for-at-ruledef-font-feature-values③">(4)</a>
@@ -10416,21 +10416,21 @@ Defining font specific alternates: the @font-feature-values rule</a>
 Object Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-feature-value-declaration">
-   <b><a href="#font-feature-value-declaration">#font-feature-value-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-feature-value-declaration" class="dfn-panel" data-for="font-feature-value-declaration" id="infopanel-for-font-feature-value-declaration" role="dialog">
+   <span id="infopaneltitle-for-font-feature-value-declaration" style="display:none">Info about the 'font feature value declarations' definition.</span><b><a href="#font-feature-value-declaration">#font-feature-value-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-feature-value-declaration">6.9.1. Basic syntax</a> <a href="#ref-for-font-feature-value-declaration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-east-asian">
-   <b><a href="#propdef-font-variant-east-asian">#propdef-font-variant-east-asian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-east-asian" class="dfn-panel" data-for="propdef-font-variant-east-asian" id="infopanel-for-propdef-font-variant-east-asian" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-east-asian" style="display:none">Info about the 'font-variant-east-asian' definition.</span><b><a href="#propdef-font-variant-east-asian">#propdef-font-variant-east-asian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-east-asian">6.10. 
 East Asian text rendering: the font-variant-east-asian property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="east-asian-variant-values">
-   <b><a href="#east-asian-variant-values">#east-asian-variant-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-east-asian-variant-values" class="dfn-panel" data-for="east-asian-variant-values" id="infopanel-for-east-asian-variant-values" role="dialog">
+   <span id="infopaneltitle-for-east-asian-variant-values" style="display:none">Info about the '&lt;east-asian-variant-values>' definition.</span><b><a href="#east-asian-variant-values">#east-asian-variant-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-east-asian-variant-values">6.10. 
 East Asian text rendering: the font-variant-east-asian property</a>
@@ -10438,8 +10438,8 @@ East Asian text rendering: the font-variant-east-asian property</a>
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="east-asian-width-values">
-   <b><a href="#east-asian-width-values">#east-asian-width-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-east-asian-width-values" class="dfn-panel" data-for="east-asian-width-values" id="infopanel-for-east-asian-width-values" role="dialog">
+   <span id="infopaneltitle-for-east-asian-width-values" style="display:none">Info about the '&lt;east-asian-width-values>' definition.</span><b><a href="#east-asian-width-values">#east-asian-width-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-east-asian-width-values">6.10. 
 East Asian text rendering: the font-variant-east-asian property</a>
@@ -10447,8 +10447,8 @@ East Asian text rendering: the font-variant-east-asian property</a>
 Overall shorthand for font rendering: the font-variant property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant">
-   <b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant" class="dfn-panel" data-for="propdef-font-variant" id="infopanel-for-propdef-font-variant" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant" style="display:none">Info about the 'font-variant' definition.</span><b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-variant①">(2)</a> <a href="#ref-for-propdef-font-variant②">(3)</a> <a href="#ref-for-propdef-font-variant③">(4)</a> <a href="#ref-for-propdef-font-variant④">(5)</a> <a href="#ref-for-propdef-font-variant⑤">(6)</a> <a href="#ref-for-propdef-font-variant⑥">(7)</a>
@@ -10468,15 +10468,15 @@ Default features</a>
 Feature and variation precedence</a> <a href="#ref-for-propdef-font-variant①⑧">(2)</a> <a href="#ref-for-propdef-font-variant①⑨">(3)</a> <a href="#ref-for-propdef-font-variant②⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-variant-normal-value">
-   <b><a href="#font-variant-normal-value">#font-variant-normal-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-variant-normal-value" class="dfn-panel" data-for="font-variant-normal-value" id="infopanel-for-font-variant-normal-value" role="dialog">
+   <span id="infopaneltitle-for-font-variant-normal-value" style="display:none">Info about the 'normal' definition.</span><b><a href="#font-variant-normal-value">#font-variant-normal-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-variant-normal-value">2.7. 
 Shorthand font property: the font property</a> <a href="#ref-for-font-variant-normal-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-feature-settings">
-   <b><a href="#propdef-font-feature-settings">#propdef-font-feature-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-feature-settings" class="dfn-panel" data-for="propdef-font-feature-settings" id="infopanel-for-propdef-font-feature-settings" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' definition.</span><b><a href="#propdef-font-feature-settings">#propdef-font-feature-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">2.7. 
 Shorthand font property: the font property</a>
@@ -10500,8 +10500,8 @@ Feature and variation precedence</a> <a href="#ref-for-propdef-font-feature-sett
 Feature precedence examples</a> <a href="#ref-for-propdef-font-feature-settings①②">(2)</a> <a href="#ref-for-propdef-font-feature-settings①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-language-override">
-   <b><a href="#propdef-font-language-override">#propdef-font-language-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-language-override" class="dfn-panel" data-for="propdef-font-language-override" id="infopanel-for-propdef-font-language-override" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-language-override" style="display:none">Info about the 'font-language-override' definition.</span><b><a href="#propdef-font-language-override">#propdef-font-language-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-language-override①">2.7. 
 Shorthand font property: the font property</a>
@@ -10516,8 +10516,8 @@ Overall shorthand for font rendering: the font-variant property</a>
 Feature and variation precedence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-optical-sizing">
-   <b><a href="#propdef-font-optical-sizing">#propdef-font-optical-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-optical-sizing" class="dfn-panel" data-for="propdef-font-optical-sizing" id="infopanel-for-propdef-font-optical-sizing" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-optical-sizing" style="display:none">Info about the 'font-optical-sizing' definition.</span><b><a href="#propdef-font-optical-sizing">#propdef-font-optical-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-optical-sizing">2.7. 
 Shorthand font property: the font property</a>
@@ -10529,8 +10529,8 @@ Optical sizing control: the font-optical-sizing property</a> <a href="#ref-for-p
 Low-level font variation settings control: the font-variation-settings property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variation-settings">
-   <b><a href="#propdef-font-variation-settings">#propdef-font-variation-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variation-settings" class="dfn-panel" data-for="propdef-font-variation-settings" id="infopanel-for-propdef-font-variation-settings" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variation-settings" style="display:none">Info about the 'font-variation-settings' definition.</span><b><a href="#propdef-font-variation-settings">#propdef-font-variation-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variation-settings">2.7. 
 Shorthand font property: the font property</a>
@@ -10546,8 +10546,8 @@ Feature and variation precedence</a>
 Low-level font variation settings control: the font-variation-settings property</a> <a href="#ref-for-propdef-font-variation-settings⑥">(2)</a> <a href="#ref-for-propdef-font-variation-settings⑦">(3)</a> <a href="#ref-for-propdef-font-variation-settings⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-palette">
-   <b><a href="#propdef-font-palette">#propdef-font-palette</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-palette" class="dfn-panel" data-for="propdef-font-palette" id="infopanel-for-propdef-font-palette" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-palette" style="display:none">Info about the 'font-palette' definition.</span><b><a href="#propdef-font-palette">#propdef-font-palette</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-palette①">2.7. 
 Shorthand font property: the font property</a>
@@ -10559,22 +10559,22 @@ Controlling Color Font Palettes: The font-palette property</a>
 Overriding a color from a palette: The override-color descriptor</a> <a href="#ref-for-propdef-font-palette⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-palette-normal">
-   <b><a href="#valdef-font-palette-normal">#valdef-font-palette-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-palette-normal" class="dfn-panel" data-for="valdef-font-palette-normal" id="infopanel-for-valdef-font-palette-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-palette-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-palette-normal">#valdef-font-palette-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-palette-normal">9.1. 
 Controlling Color Font Palettes: The font-palette property</a> <a href="#ref-for-valdef-font-palette-normal①">(2)</a> <a href="#ref-for-valdef-font-palette-normal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-font-palette-palette-identifier">
-   <b><a href="#typedef-font-palette-palette-identifier">#typedef-font-palette-palette-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-font-palette-palette-identifier" class="dfn-panel" data-for="typedef-font-palette-palette-identifier" id="infopanel-for-typedef-font-palette-palette-identifier" role="dialog">
+   <span id="infopaneltitle-for-typedef-font-palette-palette-identifier" style="display:none">Info about the '&lt;palette-identifier>' definition.</span><b><a href="#typedef-font-palette-palette-identifier">#typedef-font-palette-palette-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-font-palette-palette-identifier">9.1. 
 Controlling Color Font Palettes: The font-palette property</a> <a href="#ref-for-typedef-font-palette-palette-identifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-font-palette-values">
-   <b><a href="#at-ruledef-font-palette-values">#at-ruledef-font-palette-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-font-palette-values" class="dfn-panel" data-for="at-ruledef-font-palette-values" id="infopanel-for-at-ruledef-font-palette-values" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-font-palette-values" style="display:none">Info about the '@font-palette-values' definition.</span><b><a href="#at-ruledef-font-palette-values">#at-ruledef-font-palette-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-palette-values">9. 
 Color Font Support</a>
@@ -10590,29 +10590,29 @@ Specifying the base palette: the base-palette descriptor</a> <a href="#ref-for-a
 Overriding a color from a palette: The override-color descriptor</a> <a href="#ref-for-at-ruledef-font-palette-values②⑦">(2)</a> <a href="#ref-for-at-ruledef-font-palette-values②⑧">(3)</a> <a href="#ref-for-at-ruledef-font-palette-values②⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-palette-values-font-family">
-   <b><a href="#descdef-font-palette-values-font-family">#descdef-font-palette-values-font-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-palette-values-font-family" class="dfn-panel" data-for="descdef-font-palette-values-font-family" id="infopanel-for-descdef-font-palette-values-font-family" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-palette-values-font-family" style="display:none">Info about the 'font-family' definition.</span><b><a href="#descdef-font-palette-values-font-family">#descdef-font-palette-values-font-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-palette-values-font-family">9.2. 
 User-defined font color palettes: The @font-palette-values rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-palette-values-override-color">
-   <b><a href="#descdef-font-palette-values-override-color">#descdef-font-palette-values-override-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-palette-values-override-color" class="dfn-panel" data-for="descdef-font-palette-values-override-color" id="infopanel-for-descdef-font-palette-values-override-color" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-palette-values-override-color" style="display:none">Info about the 'override-color' definition.</span><b><a href="#descdef-font-palette-values-override-color">#descdef-font-palette-values-override-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-palette-values-override-color">9.2.3. 
 Overriding a color from a palette: The override-color descriptor</a> <a href="#ref-for-descdef-font-palette-values-override-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant-emoji">
-   <b><a href="#propdef-font-variant-emoji">#propdef-font-variant-emoji</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant-emoji" class="dfn-panel" data-for="propdef-font-variant-emoji" id="infopanel-for-propdef-font-variant-emoji" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant-emoji" style="display:none">Info about the 'font-variant-emoji' definition.</span><b><a href="#propdef-font-variant-emoji">#propdef-font-variant-emoji</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-emoji">9.3. 
 Selecting the text presentation style: The font-variant-emoji property</a> <a href="#ref-for-propdef-font-variant-emoji①">(2)</a> <a href="#ref-for-propdef-font-variant-emoji②">(3)</a> <a href="#ref-for-propdef-font-variant-emoji③">(4)</a> <a href="#ref-for-propdef-font-variant-emoji④">(5)</a> <a href="#ref-for-propdef-font-variant-emoji⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssfontfeaturevaluesmap">
-   <b><a href="#cssfontfeaturevaluesmap">#cssfontfeaturevaluesmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssfontfeaturevaluesmap" class="dfn-panel" data-for="cssfontfeaturevaluesmap" id="infopanel-for-cssfontfeaturevaluesmap" role="dialog">
+   <span id="infopaneltitle-for-cssfontfeaturevaluesmap" style="display:none">Info about the 'CSSFontFeatureValuesMap' definition.</span><b><a href="#cssfontfeaturevaluesmap">#cssfontfeaturevaluesmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfeaturevaluesmap">11.2. 
 The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssfontfeaturevaluesmap①">(2)</a> <a href="#ref-for-cssfontfeaturevaluesmap②">(3)</a> <a href="#ref-for-cssfontfeaturevaluesmap③">(4)</a> <a href="#ref-for-cssfontfeaturevaluesmap④">(5)</a> <a href="#ref-for-cssfontfeaturevaluesmap⑤">(6)</a>
@@ -10620,59 +10620,115 @@ The CSSFontFeatureValuesRule interface</a> <a href="#ref-for-cssfontfeaturevalue
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-fonts-5/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-fonts-5/Overview.html
@@ -1547,8 +1547,8 @@ the <a class="property css" data-link-type="property">superscript-position-overr
    <li><a href="#descdef-font-face-superscript-size-override">superscript-size-override</a><span>, in § 3.5</span>
    <li><a href="#valdef-font-family-xxx">xxx</a><span>, in § 2.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.3. 
 Glyph Size Multiplier:
@@ -1558,43 +1558,43 @@ Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">3.4. 
 Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-available-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-available-font" class="dfn-panel" data-for="term-for-first-available-font" id="infopanel-for-term-for-first-available-font" role="menu">
+   <span id="infopaneltitle-for-term-for-first-available-font" style="display:none">Info about the 'first available font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-available-font">3.1. 
 The @font-face rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">2.1. 
 Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-language-override">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-language-override" class="dfn-panel" data-for="term-for-propdef-font-language-override" id="infopanel-for-term-for-propdef-font-language-override" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-language-override" style="display:none">Info about the 'font-language-override' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-language-override">4.1. Font language override: the font-language-override property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-optical-sizing">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing">https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-optical-sizing" class="dfn-panel" data-for="term-for-propdef-font-optical-sizing" id="infopanel-for-term-for-propdef-font-optical-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-optical-sizing" style="display:none">Info about the 'font-optical-sizing' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing">https://drafts.csswg.org/css-fonts-4/#propdef-font-optical-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-optical-sizing">6.1. 
 Optical sizing control: the font-optical-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">3.3. 
 Glyph Size Multiplier:
@@ -1604,29 +1604,29 @@ Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">2.3. 
 Font style: the font-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant-position">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant-position" class="dfn-panel" data-for="term-for-propdef-font-variant-position" id="infopanel-for-term-for-propdef-font-variant-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant-position" style="display:none">Info about the 'font-variant-position' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-position">3.5. 
 Superscript and subscript metrics overrides:
 the superscript-position-override, subscript-position-override,superscript-size-override and subscript-size-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">2.2. Font weight: the font-weight property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">2.4. 
 Relative sizing: the font-size-adjust property</a> <a href="#ref-for-propdef-font-size-adjust①">(2)</a> <a href="#ref-for-propdef-font-size-adjust②">(3)</a>
@@ -1638,47 +1638,47 @@ Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a> <a href="#ref-for-propdef-font-size-adjust⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascent-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#ascent-metric">https://drafts.csswg.org/css-inline-3/#ascent-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascent-metric" class="dfn-panel" data-for="term-for-ascent-metric" id="infopanel-for-term-for-ascent-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-ascent-metric" style="display:none">Info about the 'ascent metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#ascent-metric">https://drafts.csswg.org/css-inline-3/#ascent-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascent-metric">3.4. 
 Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a> <a href="#ref-for-ascent-metric①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descent-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#descent-metric">https://drafts.csswg.org/css-inline-3/#descent-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descent-metric" class="dfn-panel" data-for="term-for-descent-metric" id="infopanel-for-term-for-descent-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-descent-metric" style="display:none">Info about the 'descent metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#descent-metric">https://drafts.csswg.org/css-inline-3/#descent-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descent-metric">3.4. 
 Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-gap-metric">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-gap-metric">https://drafts.csswg.org/css-inline-3/#line-gap-metric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-gap-metric" class="dfn-panel" data-for="term-for-line-gap-metric" id="infopanel-for-term-for-line-gap-metric" role="menu">
+   <span id="infopaneltitle-for-term-for-line-gap-metric" style="display:none">Info about the 'line gap metric' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-gap-metric">https://drafts.csswg.org/css-inline-3/#line-gap-metric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-gap-metric">3.4. 
 Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-underline-offset">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset">https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-underline-offset" class="dfn-panel" data-for="term-for-propdef-text-underline-offset" id="infopanel-for-term-for-propdef-text-underline-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-underline-offset" style="display:none">Info about the 'text-underline-offset' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset">https://drafts.csswg.org/css-text-decor-4/#propdef-text-underline-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-underline-offset">3.3. 
 Glyph Size Multiplier:
 the size-adjust descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.2. 
 Font property descriptors: the font-size </a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a> <a href="#ref-for-number-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3.3. 
 Glyph Size Multiplier:
@@ -1691,54 +1691,54 @@ Superscript and subscript metrics overrides:
 the superscript-position-override, subscript-position-override,superscript-size-override and subscript-size-override descriptors</a> <a href="#ref-for-percentage-value⑥">(2)</a> <a href="#ref-for-percentage-value⑦">(3)</a> <a href="#ref-for-percentage-value⑧">(4)</a> <a href="#ref-for-percentage-value⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">3.3. 
 Glyph Size Multiplier:
 the size-adjust descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">3.3. 
 Glyph Size Multiplier:
 the size-adjust descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">3.3. 
 Glyph Size Multiplier:
 the size-adjust descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-relative-length" class="dfn-panel" data-for="term-for-font-relative-length" id="infopanel-for-term-for-font-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">3.4. 
 Line Height Font Metrics Overrides:
 the ascent-override, descent-override, and line-gap-override descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.2. 
 Font property descriptors: the font-size </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.2. 
 Font property descriptors: the font-size </a>
@@ -1750,8 +1750,8 @@ Superscript and subscript metrics overrides:
 the superscript-position-override, subscript-position-override,superscript-size-override and subscript-size-override descriptors</a> <a href="#ref-for-comb-one⑤">(2)</a> <a href="#ref-for-comb-one⑥">(3)</a> <a href="#ref-for-comb-one⑦">(4)</a> <a href="#ref-for-comb-one⑧">(5)</a> <a href="#ref-for-comb-one⑨">(6)</a> <a href="#ref-for-comb-one①⓪">(7)</a> <a href="#ref-for-comb-one①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3.4. 
 Line Height Font Metrics Overrides:
@@ -1911,8 +1911,8 @@ the ascent-override, descent-override, and line-gap-override descriptors</a> <a 
    <div class="issue"> <a href="https://github.com/w3c/csswg-drafts/issues/5635">[Issue #5635]</a> <a class="issue-return" href="#issue-d41d8cd9①⓪" title="Jump to section">↵</a></div>
    <div class="issue"> <a href="https://github.com/w3c/csswg-drafts/issues/5466">[Issue #5466]</a> <a class="issue-return" href="#issue-d41d8cd9①①" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="at-font-face-rule">
-   <b><a href="#at-font-face-rule">#at-font-face-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-font-face-rule" class="dfn-panel" data-for="at-font-face-rule" id="infopanel-for-at-font-face-rule" role="dialog">
+   <span id="infopaneltitle-for-at-font-face-rule" style="display:none">Info about the '@font-face' definition.</span><b><a href="#at-font-face-rule">#at-font-face-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-font-face-rule">3.1. 
 The @font-face rule</a>
@@ -1929,8 +1929,8 @@ Superscript and subscript metrics overrides:
 the superscript-position-override, subscript-position-override,superscript-size-override and subscript-size-override descriptors</a> <a href="#ref-for-at-font-face-rule⑧">(2)</a> <a href="#ref-for-at-font-face-rule⑨">(3)</a> <a href="#ref-for-at-font-face-rule①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-font-face-font-size">
-   <b><a href="#descdef-font-face-font-size">#descdef-font-face-font-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-font-face-font-size" class="dfn-panel" data-for="descdef-font-face-font-size" id="infopanel-for-descdef-font-face-font-size" role="dialog">
+   <span id="infopaneltitle-for-descdef-font-face-font-size" style="display:none">Info about the 'font-size' definition.</span><b><a href="#descdef-font-face-font-size">#descdef-font-face-font-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-size">3.2. 
 Font property descriptors: the font-size </a>
@@ -1938,59 +1938,115 @@ Font property descriptors: the font-size </a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-forms-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-forms-1/Overview.html
@@ -2435,20 +2435,20 @@ especially on mobile devices where they’re a bit "weirder".</p>
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2.1. Select/Datalist Dropdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">2.1. Select/Datalist Dropdown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-option-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-option-element" class="dfn-panel" data-for="term-for-the-option-element" id="infopanel-for-term-for-the-option-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-option-element" style="display:none">Info about the 'option' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-option-element">2.1. Select/Datalist Dropdown</a>
    </ul>
@@ -2490,57 +2490,113 @@ especially on mobile devices where they’re a bit "weirder".</p>
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-3/Overview.html
@@ -1541,22 +1541,22 @@ h6 { bookmark-level: 6 }
    <li><a href="#funcdef-string">string()</a><span>, in § 1.1.2</span>
    <li><a href="#propdef-string-set">string-set</a><span>, in § 1.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">1.2.1. 
 The running() value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">1.1.1. 
 	The string-set property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">1.1.1. 
 	The string-set property </a>
@@ -1564,8 +1564,8 @@ The running() value </a>
 Page Selectors </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">1.1.2. 
 	The string() function </a>
@@ -1573,8 +1573,8 @@ Page Selectors </a>
 The element() value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">1.1.1. 
 	The string-set property </a>
@@ -1588,8 +1588,8 @@ The element() value </a>
 Page Selectors </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">1.1.2. 
 	The string() function </a>
@@ -1599,14 +1599,14 @@ The element() value </a>
 Page Selectors </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords"> Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">1.1.1. 
 	The string-set property </a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
@@ -1621,40 +1621,40 @@ The element() value </a> <a href="#ref-for-comb-one①②">(2)</a> <a href="#ref
 Rendering footnotes and footnote policy </a> <a href="#ref-for-comb-one①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">2.3. 
 	Types of footnotes </a> <a href="#ref-for-propdef-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">2.4.2. Size of the footnote area</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-content-content-list">
-   <a href="https://drafts.csswg.org/css-content-3/#typedef-content-content-list">https://drafts.csswg.org/css-content-3/#typedef-content-content-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-content-content-list" class="dfn-panel" data-for="term-for-typedef-content-content-list" id="infopanel-for-term-for-typedef-content-content-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-content-content-list" style="display:none">Info about the '&lt;content-list>' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#typedef-content-content-list">https://drafts.csswg.org/css-content-3/#typedef-content-content-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-content-list">1.1.1. 
 	The string-set property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bookmark-label">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-label">https://drafts.csswg.org/css-content-3/#propdef-bookmark-label</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bookmark-label" class="dfn-panel" data-for="term-for-propdef-bookmark-label" id="infopanel-for-term-for-propdef-bookmark-label" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bookmark-label" style="display:none">Info about the 'bookmark-label' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-label">https://drafts.csswg.org/css-content-3/#propdef-bookmark-label</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-label">Appendix C: Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bookmark-level">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-level">https://drafts.csswg.org/css-content-3/#propdef-bookmark-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bookmark-level" class="dfn-panel" data-for="term-for-propdef-bookmark-level" id="infopanel-for-term-for-propdef-bookmark-level" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bookmark-level" style="display:none">Info about the 'bookmark-level' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-bookmark-level">https://drafts.csswg.org/css-content-3/#propdef-bookmark-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bookmark-level">Appendix C: Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">1.1.2. 
 	The string() function </a>
@@ -1662,8 +1662,8 @@ Rendering footnotes and footnote policy </a> <a href="#ref-for-comb-one①⑦">(
 The element() value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page" class="dfn-panel" data-for="term-for-propdef-page" id="infopanel-for-term-for-propdef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">3.2. 
 Page groups </a>
@@ -1856,8 +1856,8 @@ letter-spacing: 1pt;
    <div class="issue"> Now described in <a data-link-type="biblio" href="#biblio-css3-content" title="CSS Generated Content Module Level 3">[CSS3-CONTENT]</a> <a class="issue-return" href="#issue-1a552eac①" title="Jump to section">↵</a></div>
    <div class="issue"> Now described in <a data-link-type="biblio" href="#biblio-css3-content" title="CSS Generated Content Module Level 3">[CSS3-CONTENT]</a> <a class="issue-return" href="#issue-1a552eac②" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-string-set">
-   <b><a href="#propdef-string-set">#propdef-string-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-string-set" class="dfn-panel" data-for="propdef-string-set" id="infopanel-for-propdef-string-set" role="dialog">
+   <span id="infopaneltitle-for-propdef-string-set" style="display:none">Info about the 'string-set' definition.</span><b><a href="#propdef-string-set">#propdef-string-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-string-set">1.1. 
 	Named strings </a>
@@ -1866,16 +1866,16 @@ letter-spacing: 1pt;
     <li><a href="#ref-for-propdef-string-set②">Appendix C: Changes</a> <a href="#ref-for-propdef-string-set③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-content">
-   <b><a href="#funcdef-content">#funcdef-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-content" class="dfn-panel" data-for="funcdef-content" id="infopanel-for-funcdef-content" role="dialog">
+   <span id="infopaneltitle-for-funcdef-content" style="display:none">Info about the 'content()' definition.</span><b><a href="#funcdef-content">#funcdef-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-content">1.1.1. 
 	The string-set property </a>
     <li><a href="#ref-for-funcdef-content①">1.1.1.1. The content() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-string">
-   <b><a href="#funcdef-string">#funcdef-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-string" class="dfn-panel" data-for="funcdef-string" id="infopanel-for-funcdef-string" role="dialog">
+   <span id="infopaneltitle-for-funcdef-string" style="display:none">Info about the 'string()' definition.</span><b><a href="#funcdef-string">#funcdef-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-string">1.1. 
 	Named strings </a> <a href="#ref-for-funcdef-string①">(2)</a>
@@ -1886,8 +1886,8 @@ letter-spacing: 1pt;
 The element() value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-running">
-   <b><a href="#funcdef-running">#funcdef-running</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-running" class="dfn-panel" data-for="funcdef-running" id="infopanel-for-funcdef-running" role="dialog">
+   <span id="infopaneltitle-for-funcdef-running" style="display:none">Info about the 'running()' definition.</span><b><a href="#funcdef-running">#funcdef-running</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-running">1.2. 
 	Running elements </a>
@@ -1897,8 +1897,8 @@ The running() value </a>
 The element() value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-element">
-   <b><a href="#funcdef-element">#funcdef-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-element" class="dfn-panel" data-for="funcdef-element" id="infopanel-for-funcdef-element" role="dialog">
+   <span id="infopaneltitle-for-funcdef-element" style="display:none">Info about the 'element()' definition.</span><b><a href="#funcdef-element">#funcdef-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-element">1.2. 
 	Running elements </a>
@@ -1908,31 +1908,31 @@ The running() value </a>
 The element() value </a> <a href="#ref-for-funcdef-element③">(2)</a> <a href="#ref-for-funcdef-element④">(3)</a> <a href="#ref-for-funcdef-element⑤">(4)</a> <a href="#ref-for-funcdef-element⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-footnote-display">
-   <b><a href="#propdef-footnote-display">#propdef-footnote-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-footnote-display" class="dfn-panel" data-for="propdef-footnote-display" id="infopanel-for-propdef-footnote-display" role="dialog">
+   <span id="infopaneltitle-for-propdef-footnote-display" style="display:none">Info about the 'footnote-display' definition.</span><b><a href="#propdef-footnote-display">#propdef-footnote-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-footnote-display">2.3. 
 	Types of footnotes </a>
     <li><a href="#ref-for-propdef-footnote-display①">Appendix C: Changes</a> <a href="#ref-for-propdef-footnote-display">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-footnote-policy">
-   <b><a href="#propdef-footnote-policy">#propdef-footnote-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-footnote-policy" class="dfn-panel" data-for="propdef-footnote-policy" id="infopanel-for-propdef-footnote-policy" role="dialog">
+   <span id="infopaneltitle-for-propdef-footnote-policy" style="display:none">Info about the 'footnote-policy' definition.</span><b><a href="#propdef-footnote-policy">#propdef-footnote-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-footnote-policy">2.8. 
 Rendering footnotes and footnote policy </a>
     <li><a href="#ref-for-propdef-footnote-policy①">Appendix C: Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="footnote-policy-line">
-   <b><a href="#footnote-policy-line">#footnote-policy-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-footnote-policy-line" class="dfn-panel" data-for="footnote-policy-line" id="infopanel-for-footnote-policy-line" role="dialog">
+   <span id="infopaneltitle-for-footnote-policy-line" style="display:none">Info about the 'line' definition.</span><b><a href="#footnote-policy-line">#footnote-policy-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-footnote-policy-line">2.8. 
 Rendering footnotes and footnote policy </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-nth">
-   <b><a href="#funcdef-nth">#funcdef-nth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-nth" class="dfn-panel" data-for="funcdef-nth" id="infopanel-for-funcdef-nth" role="dialog">
+   <span id="infopaneltitle-for-funcdef-nth" style="display:none">Info about the 'nth()' definition.</span><b><a href="#funcdef-nth">#funcdef-nth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-nth">3.1. 
 Page Selectors </a> <a href="#ref-for-funcdef-nth①">(2)</a> <a href="#ref-for-funcdef-nth②">(3)</a> <a href="#ref-for-funcdef-nth③">(4)</a>
@@ -1940,57 +1940,113 @@ Page Selectors </a> <a href="#ref-for-funcdef-nth①">(2)</a> <a href="#ref-for-
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-gcpm-4/Overview.html
@@ -1049,44 +1049,44 @@ span.reference::before {
    <li><a href="#selectordef-nth-of-page-n">:nth-of-page(n)</a><span>, in § 1.2.1</span>
    <li><a href="#selectordef-start-of-page">:start-of-page</a><span>, in § 1.2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">1.1. Copying a flow: the copy-into property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">1.1. Copying a flow: the copy-into property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">1.1. Copying a flow: the copy-into property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords"> Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">1.1. Copying a flow: the copy-into property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flow-into">
-   <a href="https://drafts.csswg.org/css-regions-1/#propdef-flow-into">https://drafts.csswg.org/css-regions-1/#propdef-flow-into</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flow-into" class="dfn-panel" data-for="term-for-propdef-flow-into" id="infopanel-for-term-for-propdef-flow-into" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flow-into" style="display:none">Info about the 'flow-into' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#propdef-flow-into">https://drafts.csswg.org/css-regions-1/#propdef-flow-into</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flow-into">1.2.1. Page selector pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">1.1. Copying a flow: the copy-into property</a>
    </ul>
@@ -1171,65 +1171,121 @@ span.reference::before {
    <div class="issue">The above HTML contains two nested spans for the footnote, as CSS has no mechanism to leave a reference object where something was removed from the flow. <a class="issue-return" href="#issue-5b376f66" title="Jump to section">↵</a></div>
    <div class="issue">Would it be possible to specify <code>flow-into: none</code> on <code>span.footnote::after</code>? <a data-link-type="biblio" href="#biblio-css3-regions" title="CSS Regions Module Level 1">[CSS3-REGIONS]</a> forbids the flow-into property on pseudo-elements, but should that be changed? <a class="issue-return" href="#issue-db66e478" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-copy-into">
-   <b><a href="#propdef-copy-into">#propdef-copy-into</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-copy-into" class="dfn-panel" data-for="propdef-copy-into" id="infopanel-for-propdef-copy-into" role="dialog">
+   <span id="infopaneltitle-for-propdef-copy-into" style="display:none">Info about the 'copy-into' definition.</span><b><a href="#propdef-copy-into">#propdef-copy-into</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-copy-into">1.1. Copying a flow: the copy-into property</a> <a href="#ref-for-propdef-copy-into①">(2)</a> <a href="#ref-for-propdef-copy-into②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-1/Overview.html
@@ -6210,8 +6210,8 @@ which we considered a better result because the first track remains sized exactl
    <li><a href="#grid-template-areas-trash-token">trash token</a><span>, in § 7.3</span>
    <li><a href="#unoccupied">unoccupied</a><span>, in § 8.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">2.3. 
 Sizing the Grid</a>
@@ -6228,15 +6228,15 @@ Grid Sizing Algorithm</a> <a href="#ref-for-propdef-align-content⑧">(2)</a> <a
     <li><a href="#ref-for-propdef-align-content①②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-items" class="dfn-panel" data-for="term-for-propdef-align-items" id="infopanel-for-term-for-propdef-align-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-items" style="display:none">Info about the 'align-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">10.4. 
 Block-axis Alignment: the align-self and align-items properties</a> <a href="#ref-for-propdef-align-items①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">6.2. 
 	Grid Item Sizing</a>
@@ -6250,24 +6250,24 @@ Alignment and Spacing</a>
 Block-axis Alignment: the align-self and align-items properties</a> <a href="#ref-for-propdef-align-self⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-baseline" class="dfn-panel" data-for="term-for-alignment-baseline" id="infopanel-for-term-for-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-baseline" style="display:none">Info about the 'alignment baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-baseline">10.6. 
 Grid Container Baselines</a> <a href="#ref-for-alignment-baseline①">(2)</a> <a href="#ref-for-alignment-baseline②">(3)</a>
     <li><a href="#ref-for-alignment-baseline③"> Minor Changes</a> <a href="#ref-for-alignment-baseline④">(2)</a> <a href="#ref-for-alignment-baseline⑤">(3)</a> <a href="#ref-for-alignment-baseline⑥">(4)</a> <a href="#ref-for-alignment-baseline⑦">(5)</a> <a href="#ref-for-alignment-baseline⑧">(6)</a> <a href="#ref-for-alignment-baseline⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-alignment-context">
-   <a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-alignment-context" class="dfn-panel" data-for="term-for-shared-alignment-context" id="infopanel-for-term-for-shared-alignment-context" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-alignment-context" style="display:none">Info about the 'alignment context' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-alignment-context">10.6. 
 Grid Container Baselines</a>
     <li><a href="#ref-for-shared-alignment-context①"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-alignment" class="dfn-panel" data-for="term-for-baseline-alignment" id="infopanel-for-term-for-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-alignment" style="display:none">Info about the 'baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment">10.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a>
@@ -6279,24 +6279,24 @@ Grid Container Baselines</a>
     <li><a href="#ref-for-baseline-alignment⑥"> Significant Adjustments and Fixes</a> <a href="#ref-for-baseline-alignment⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-set" class="dfn-panel" data-for="term-for-baseline-set" id="infopanel-for-term-for-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-set" style="display:none">Info about the 'baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-set">10.6. 
 Grid Container Baselines</a> <a href="#ref-for-baseline-set①">(2)</a>
     <li><a href="#ref-for-baseline-set②"> Minor Changes</a> <a href="#ref-for-baseline-set③">(2)</a> <a href="#ref-for-baseline-set④">(3)</a> <a href="#ref-for-baseline-set⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-sharing-group">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-sharing-group" class="dfn-panel" data-for="term-for-baseline-sharing-group" id="infopanel-for-term-for-baseline-sharing-group" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-sharing-group" style="display:none">Info about the 'baseline-sharing group' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-sharing-group">11.5. 
 Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-baseline-sharing-group①"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-alignment-properties">
-   <a href="https://drafts.csswg.org/css-align-3/#box-alignment-properties">https://drafts.csswg.org/css-align-3/#box-alignment-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-alignment-properties" class="dfn-panel" data-for="term-for-box-alignment-properties" id="infopanel-for-term-for-box-alignment-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-box-alignment-properties" style="display:none">Info about the 'box alignment properties' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#box-alignment-properties">https://drafts.csswg.org/css-align-3/#box-alignment-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-alignment-properties">2.3. 
 Sizing the Grid</a>
@@ -6306,15 +6306,15 @@ Alignment and Spacing</a>
 Aligning with auto margins</a> <a href="#ref-for-box-alignment-properties③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">7.2.1. 
 Track Sizes</a>
@@ -6323,16 +6323,16 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-propd
     <li><a href="#ref-for-propdef-column-gap③"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-distributed-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#distributed-alignment">https://drafts.csswg.org/css-align-3/#distributed-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-distributed-alignment" class="dfn-panel" data-for="term-for-distributed-alignment" id="infopanel-for-term-for-distributed-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-distributed-alignment" style="display:none">Info about the 'distributed alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#distributed-alignment">https://drafts.csswg.org/css-align-3/#distributed-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distributed-alignment">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
     <li><a href="#ref-for-distributed-alignment①"> Clarifications</a> <a href="#ref-for-distributed-alignment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fallback-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#fallback-alignment">https://drafts.csswg.org/css-align-3/#fallback-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fallback-alignment" class="dfn-panel" data-for="term-for-fallback-alignment" id="infopanel-for-term-for-fallback-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-fallback-alignment" style="display:none">Info about the 'fallback alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#fallback-alignment">https://drafts.csswg.org/css-align-3/#fallback-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback-alignment">10.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a>
@@ -6341,8 +6341,8 @@ Block-axis Alignment: the align-self and align-items properties</a>
     <li><a href="#ref-for-fallback-alignment②"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-gap" class="dfn-panel" data-for="term-for-propdef-gap" id="infopanel-for-term-for-propdef-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-gap" style="display:none">Info about the 'gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-gap">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
@@ -6354,34 +6354,34 @@ Aligning the Grid: the justify-content and align-content properties</a>
     <li><a href="#ref-for-propdef-gap⑤"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generate-baselines">
-   <a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generate-baselines" class="dfn-panel" data-for="term-for-generate-baselines" id="infopanel-for-term-for-generate-baselines" role="menu">
+   <span id="infopaneltitle-for-term-for-generate-baselines" style="display:none">Info about the 'generate baselines' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-baselines">10.6. 
 Grid Container Baselines</a> <a href="#ref-for-generate-baselines①">(2)</a>
     <li><a href="#ref-for-generate-baselines②"> Minor Changes</a> <a href="#ref-for-generate-baselines③">(2)</a> <a href="#ref-for-generate-baselines④">(3)</a> <a href="#ref-for-generate-baselines⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column-gap" class="dfn-panel" data-for="term-for-propdef-grid-column-gap" id="infopanel-for-term-for-propdef-grid-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column-gap" style="display:none">Info about the 'grid-column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-gap"> Major Changes</a> <a href="#ref-for-propdef-grid-column-gap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-gap" class="dfn-panel" data-for="term-for-propdef-grid-gap" id="infopanel-for-term-for-propdef-grid-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-gap" style="display:none">Info about the 'grid-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-gap"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row-gap" class="dfn-panel" data-for="term-for-propdef-grid-row-gap" id="infopanel-for-term-for-propdef-grid-row-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row-gap" style="display:none">Info about the 'grid-row-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap">https://drafts.csswg.org/css-align-3/#propdef-grid-row-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-gap"> Major Changes</a> <a href="#ref-for-propdef-grid-row-gap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gutter">
-   <a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gutter" class="dfn-panel" data-for="term-for-gutter" id="infopanel-for-term-for-gutter" role="menu">
+   <span id="infopaneltitle-for-term-for-gutter" style="display:none">Info about the 'gutter' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gutter">2. 
 Overview</a>
@@ -6398,8 +6398,8 @@ Initialize Track Sizes</a>
     <li><a href="#ref-for-gutter①②"> Clarifications</a> <a href="#ref-for-gutter①③">(2)</a> <a href="#ref-for-gutter①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">2.3. 
 Sizing the Grid</a>
@@ -6416,15 +6416,15 @@ Grid Sizing Algorithm</a> <a href="#ref-for-propdef-justify-content⑧">(2)</a> 
     <li><a href="#ref-for-propdef-justify-content①②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-items" class="dfn-panel" data-for="term-for-propdef-justify-items" id="infopanel-for-term-for-propdef-justify-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-items" style="display:none">Info about the 'justify-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-items">10.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a> <a href="#ref-for-propdef-justify-items①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">8. 
 Placing Grid Items</a>
@@ -6436,23 +6436,23 @@ Alignment and Spacing</a>
 Inline-axis Alignment: the justify-self and justify-items properties</a> <a href="#ref-for-propdef-justify-self④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-normal" class="dfn-panel" data-for="term-for-valdef-align-self-normal" id="infopanel-for-term-for-valdef-align-self-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-normal">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-valdef-align-self-normal①">(2)</a>
     <li><a href="#ref-for-valdef-align-self-normal②"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-content" class="dfn-panel" data-for="term-for-propdef-place-content" id="infopanel-for-term-for-propdef-place-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-content" style="display:none">Info about the 'place-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-content">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-row-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-row-gap" class="dfn-panel" data-for="term-for-propdef-row-gap" id="infopanel-for-term-for-propdef-row-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-row-gap" style="display:none">Info about the 'row-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-row-gap">7.2.1. 
 Track Sizes</a>
@@ -6461,36 +6461,36 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-propd
     <li><a href="#ref-for-propdef-row-gap③"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-around">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-around" class="dfn-panel" data-for="term-for-valdef-align-content-space-around" id="infopanel-for-term-for-valdef-align-content-space-around" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-around" style="display:none">Info about the 'space-around' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-around">10.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-between">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-between" class="dfn-panel" data-for="term-for-valdef-align-content-space-between" id="infopanel-for-term-for-valdef-align-content-space-between" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-between" style="display:none">Info about the 'space-between' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-between">10.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-evenly">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-evenly" class="dfn-panel" data-for="term-for-valdef-align-content-space-evenly" id="infopanel-for-term-for-valdef-align-content-space-evenly" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-evenly" style="display:none">Info about the 'space-evenly' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-evenly">10.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-stretch" class="dfn-panel" data-for="term-for-valdef-align-content-stretch" id="infopanel-for-term-for-valdef-align-content-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-stretch" style="display:none">Info about the 'stretch (for align-content)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-stretch">10.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
@@ -6498,8 +6498,8 @@ Aligning the Grid: the justify-content and align-content properties</a>
     <li><a href="#ref-for-valdef-align-content-stretch②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-stretch" class="dfn-panel" data-for="term-for-valdef-align-self-stretch" id="infopanel-for-term-for-valdef-align-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">4. 
 Reordering and Accessibility</a>
@@ -6507,30 +6507,30 @@ Reordering and Accessibility</a>
 	Grid Item Sizing</a> <a href="#ref-for-valdef-align-self-stretch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-self-stretch" class="dfn-panel" data-for="term-for-valdef-justify-self-stretch" id="infopanel-for-term-for-valdef-justify-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-self-stretch" style="display:none">Info about the 'stretch (for justify-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-stretch">10. 
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-synthesize-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-synthesize-baseline" class="dfn-panel" data-for="term-for-synthesize-baseline" id="infopanel-for-term-for-synthesize-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-synthesize-baseline" style="display:none">Info about the 'synthesize baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">10.6. 
 Grid Container Baselines</a> <a href="#ref-for-synthesize-baseline①">(2)</a>
     <li><a href="#ref-for-synthesize-baseline②"> Minor Changes</a> <a href="#ref-for-synthesize-baseline③">(2)</a> <a href="#ref-for-synthesize-baseline④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">12. 
 Fragmenting Grid Layout</a> <a href="#ref-for-fragmentation-container①">(2)</a>
@@ -6538,15 +6538,15 @@ Fragmenting Grid Layout</a> <a href="#ref-for-fragmentation-container①">(2)</a
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">12. 
 Fragmenting Grid Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.1. 
 	Grid Item Display</a>
@@ -6558,8 +6558,8 @@ Serialization Of Template Strings</a>
     <li><a href="#ref-for-computed-value④"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">7.1. 
 The Explicit Grid</a>
@@ -6573,37 +6573,37 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-shorthand-pro
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">7.3.1. 
 Serialization Of Template Strings</a>
     <li><a href="#ref-for-specified-value①"> Major Changes</a> <a href="#ref-for-specified-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">7.8. 
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">7.2.6. 
 Resolved Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">5.2. 
 Sizing Grid Containers</a>
@@ -6612,8 +6612,8 @@ Grid Item Margins and Paddings</a>
     <li><a href="#ref-for-block-box②"> Significant Adjustments and Fixes</a> <a href="#ref-for-block-box③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">6. 
 Grid Items</a>
@@ -6621,8 +6621,8 @@ Grid Items</a>
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -6631,8 +6631,8 @@ Sizing Grid Containers</a>
     <li><a href="#ref-for-block-formatting-context②"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -6641,16 +6641,16 @@ Sizing Grid Containers</a>
     <li><a href="#ref-for-block-level②"> Significant Adjustments and Fixes</a> <a href="#ref-for-block-level③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">6.1. 
 	Grid Item Display</a>
     <li><a href="#ref-for-blockify①"> Clarifications</a> <a href="#ref-for-blockify②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">6.4. 
 Grid Item Margins and Paddings</a> <a href="#ref-for-containing-block①">(2)</a>
@@ -6664,8 +6664,8 @@ With a Grid Container as Parent</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a> <a href="#ref-for-propdef-display③">(4)</a> <a href="#ref-for-propdef-display④">(5)</a>
@@ -6676,49 +6676,49 @@ Resolved Value of a Track Listing</a>
     <li><a href="#ref-for-propdef-display①③"> Clarifications</a> <a href="#ref-for-propdef-display①④">(2)</a> <a href="#ref-for-propdef-display①⑤">(3)</a> <a href="#ref-for-propdef-display①⑥">(4)</a> <a href="#ref-for-propdef-display①⑦">(5)</a> <a href="#ref-for-propdef-display①⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">6.1. 
 	Grid Item Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-layout" class="dfn-panel" data-for="term-for-flow-layout" id="infopanel-for-term-for-flow-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-layout" style="display:none">Info about the 'flow layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-flow-layout①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">5.2. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced"> Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-order">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-order" class="dfn-panel" data-for="term-for-propdef-order" id="infopanel-for-term-for-propdef-order" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-order" style="display:none">Info about the 'order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">4. 
 Reordering and Accessibility</a> <a href="#ref-for-propdef-order①">(2)</a> <a href="#ref-for-propdef-order②">(3)</a>
@@ -6726,8 +6726,8 @@ Reordering and Accessibility</a> <a href="#ref-for-propdef-order①">(2)</a> <a 
 Reordered Grid Items: the order property</a> <a href="#ref-for-propdef-order④">(2)</a> <a href="#ref-for-propdef-order⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-order-modified-document-order">
-   <a href="https://drafts.csswg.org/css-display-3/#order-modified-document-order">https://drafts.csswg.org/css-display-3/#order-modified-document-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-order-modified-document-order" class="dfn-panel" data-for="term-for-order-modified-document-order" id="infopanel-for-term-for-order-modified-document-order" role="menu">
+   <span id="infopaneltitle-for-term-for-order-modified-document-order" style="display:none">Info about the 'order-modified document order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#order-modified-document-order">https://drafts.csswg.org/css-display-3/#order-modified-document-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-order-modified-document-order">6.5. 
 Z-axis Ordering: the z-index property</a>
@@ -6739,8 +6739,8 @@ Grid Item Placement Algorithm</a> <a href="#ref-for-order-modified-document-orde
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">6.1. 
 	Grid Item Display</a>
@@ -6752,28 +6752,28 @@ Automatic Minimum Size of Grid Items</a>
     <li><a href="#ref-for-replaced-element④"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">6. 
 Grid Items</a> <a href="#ref-for-text-run①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flex" class="dfn-panel" data-for="term-for-valdef-display-flex" id="infopanel-for-term-for-valdef-display-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2. 
 Overview</a>
@@ -6784,8 +6784,8 @@ Grid Sizing Algorithm</a>
     <li><a href="#ref-for-flex-container③"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">2.2. 
 Placing Items</a>
@@ -6796,54 +6796,54 @@ Flexible Lengths: the fr unit</a>
     <li><a href="#ref-for-flex-item③"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">11.1. 
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-flex" class="dfn-panel" data-for="term-for-valdef-display-inline-flex" id="infopanel-for-term-for-valdef-display-inline-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-flex" style="display:none">Info about the 'inline-flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-flex"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collapsed-track">
-   <a href="https://www.w3.org/TR/css-grid-2/#collapsed-track">https://www.w3.org/TR/css-grid-2/#collapsed-track</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collapsed-track" class="dfn-panel" data-for="term-for-collapsed-track" id="infopanel-for-term-for-collapsed-track" role="menu">
+   <span id="infopaneltitle-for-term-for-collapsed-track" style="display:none">Info about the 'collapsed track' external reference.</span><a href="https://www.w3.org/TR/css-grid-2/#collapsed-track">https://www.w3.org/TR/css-grid-2/#collapsed-track</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-track⑦"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions"> Major Changes</a> <a href="#ref-for-natural-dimensions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-natural-size①">(2)</a> <a href="#ref-for-natural-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">11.1. 
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">5.3. 
 Scrollable Grid Overflow</a>
@@ -6852,8 +6852,8 @@ Grid Container Baselines</a>
     <li><a href="#ref-for-propdef-overflow②"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">5.3. 
 Scrollable Grid Overflow</a>
@@ -6862,91 +6862,91 @@ Automatic Minimum Size of Grid Items</a>
     <li><a href="#ref-for-scroll-container②"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-rectangle" class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle" id="infopanel-for-term-for-scrollable-overflow-rectangle" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-rectangle" style="display:none">Info about the 'scrollable overflow rectangle' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-rectangle">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow region' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">9.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">9.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">6.5. 
 Z-axis Ordering: the z-index property</a> <a href="#ref-for-propdef-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">9.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">9.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">6.2. 
 	Grid Item Sizing</a>
@@ -6959,8 +6959,8 @@ Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-valdef-width-auto⑥"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-minimum-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-minimum-size" class="dfn-panel" data-for="term-for-automatic-minimum-size" id="infopanel-for-term-for-automatic-minimum-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-automatic-minimum-size①">(2)</a>
@@ -6971,15 +6971,15 @@ Grid Sizing Algorithm</a>
     <li><a href="#ref-for-automatic-minimum-size⑥"> Significant Adjustments and Fixes</a> <a href="#ref-for-automatic-minimum-size⑦">(2)</a> <a href="#ref-for-automatic-minimum-size⑧">(3)</a> <a href="#ref-for-automatic-minimum-size⑨">(4)</a> <a href="#ref-for-automatic-minimum-size①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">11.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -6987,8 +6987,8 @@ Grid Sizing Algorithm</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto" style="display:none">Info about the 'behave as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -6997,8 +6997,8 @@ Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-behave-as-auto②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto①" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto①" style="display:none">Info about the 'behaves as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -7007,8 +7007,8 @@ Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-behave-as-auto②"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-definite①">(2)</a> <a href="#ref-for-definite②">(3)</a> <a href="#ref-for-definite③">(4)</a> <a href="#ref-for-definite④">(5)</a>
@@ -7026,21 +7026,21 @@ Stretch auto Tracks</a> <a href="#ref-for-definite①⑨">(2)</a>
     <li><a href="#ref-for-definite②②"> Significant Adjustments and Fixes</a> <a href="#ref-for-definite②③">(2)</a> <a href="#ref-for-definite②④">(3)</a> <a href="#ref-for-definite②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size"> Major Changes</a>
     <li><a href="#ref-for-fit-content-size①"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height"> Clarifications</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indefinite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indefinite" class="dfn-panel" data-for="term-for-indefinite" id="infopanel-for-term-for-indefinite" role="menu">
+   <span id="infopaneltitle-for-term-for-indefinite" style="display:none">Info about the 'indefinite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">7.2.4. 
 Flexible Lengths: the fr unit</a>
@@ -7061,8 +7061,8 @@ Stretch auto Tracks</a>
     <li><a href="#ref-for-indefinite⑨"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">7.2.1. 
 Track Sizes</a> <a href="#ref-for-inner-size①">(2)</a>
@@ -7072,8 +7072,8 @@ Maximize Tracks</a> <a href="#ref-for-inner-size③">(2)</a>
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -7083,8 +7083,8 @@ Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-intrinsic-size-contribution③"> Clarifications</a> <a href="#ref-for-intrinsic-size-contribution④">(2)</a> <a href="#ref-for-intrinsic-size-contribution⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-constraint" class="dfn-panel" data-for="term-for-max-content-constraint" id="infopanel-for-term-for-max-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-constraint" style="display:none">Info about the 'max-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-constraint">5.2. 
 Sizing Grid Containers</a>
@@ -7097,8 +7097,8 @@ Maximize Tracks</a>
     <li><a href="#ref-for-max-content-constraint⑥"> Significant Adjustments and Fixes</a> <a href="#ref-for-max-content-constraint⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-contribution" class="dfn-panel" data-for="term-for-max-content-contribution" id="infopanel-for-term-for-max-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-contribution" style="display:none">Info about the 'max-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-contribution">7.2.1. 
 Track Sizes</a> <a href="#ref-for-max-content-contribution①">(2)</a>
@@ -7111,22 +7111,22 @@ Expand Flexible Tracks</a>
     <li><a href="#ref-for-max-content-contribution①①"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">5.2. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'maximum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-max-width①">(2)</a> <a href="#ref-for-max-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-constraint" class="dfn-panel" data-for="term-for-min-content-constraint" id="infopanel-for-term-for-min-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-constraint" style="display:none">Info about the 'min-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-constraint">5.2. 
 Sizing Grid Containers</a>
@@ -7142,8 +7142,8 @@ Expand Flexible Tracks</a>
     <li><a href="#ref-for-min-content-constraint⑧"> Significant Adjustments and Fixes</a> <a href="#ref-for-min-content-constraint⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-contribution" class="dfn-panel" data-for="term-for-min-content-contribution" id="infopanel-for-term-for-min-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">7.2.1. 
 Track Sizes</a>
@@ -7157,8 +7157,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-min-content-contribution⑥"
     <li><a href="#ref-for-min-content-contribution①⑥"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5.2. 
 Sizing Grid Containers</a>
@@ -7166,8 +7166,8 @@ Sizing Grid Containers</a>
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-min-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-min-width①">(2)</a> <a href="#ref-for-min-width②">(3)</a>
@@ -7179,15 +7179,15 @@ Resolve Intrinsic Track Sizes</a>
     <li><a href="#ref-for-min-width⑥"> Clarifications</a> <a href="#ref-for-min-width⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">11.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-outer-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size" class="dfn-panel" data-for="term-for-preferred-size" id="infopanel-for-term-for-preferred-size" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size" style="display:none">Info about the 'preferred size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-preferred-size①">(2)</a>
@@ -7196,8 +7196,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-preferred-size③">(2)</a>
     <li><a href="#ref-for-preferred-size④"> Clarifications</a> <a href="#ref-for-preferred-size⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit" class="dfn-panel" data-for="term-for-stretch-fit" id="infopanel-for-term-for-stretch-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit" style="display:none">Info about the 'stretch fit' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -7206,31 +7206,31 @@ Grid Sizing Algorithm</a>
     <li><a href="#ref-for-stretch-fit②"> Significant Adjustments and Fixes</a> <a href="#ref-for-stretch-fit③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">6.2. 
 	Grid Item Sizing</a>
     <li><a href="#ref-for-stretch-fit-size①"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">6.6. 
 Automatic Minimum Size of Grid Items</a>
     <li><a href="#ref-for-propdef-width①"> Clarifications</a> <a href="#ref-for-propdef-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio"> Changes since the 18 December 2020 CR</a>
     <li><a href="#ref-for-propdef-aspect-ratio①"> Changes since the 18 August 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-valdef-width-fit-content①">(2)</a>
@@ -7238,8 +7238,8 @@ Automatic Minimum Size of Grid Items</a>
 Automatic Minimum Size of Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-preferred-aspect-ratio①">(2)</a>
@@ -7248,23 +7248,23 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-preferred-aspect-rati
     <li><a href="#ref-for-preferred-aspect-ratio④"> Changes since the 18 August 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-whitespace">
-   <a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-whitespace" class="dfn-panel" data-for="term-for-whitespace" id="infopanel-for-term-for-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-whitespace" style="display:none">Info about the 'whitespace' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">7.3. 
 Named Areas: the grid-template-areas property</a>
     <li><a href="#ref-for-whitespace①"> Major Changes</a> <a href="#ref-for-whitespace②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">7.8. 
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-all①">(2)</a>
@@ -7272,15 +7272,15 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-all①">
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-comb-all③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-zero-plus①">(2)</a> <a href="#ref-for-mult-zero-plus②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-one-plus①">(2)</a>
@@ -7294,8 +7294,8 @@ Explicit Grid Shorthand: the grid-template property</a>
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-comb-comma①">(2)</a> <a href="#ref-for-comb-comma②">(3)</a>
@@ -7303,8 +7303,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-comb-comma④">(2)</a> <a href="#ref-for-comb-comma⑤">(3)</a> <a href="#ref-for-comb-comma⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -7317,15 +7317,15 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
     <li><a href="#ref-for-identifier-value②②"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">7.3. 
 Named Areas: the grid-template-areas property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">7.2.3.1. 
 Syntax of repeat()</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a>
@@ -7335,8 +7335,8 @@ Computed Value of a Track Listing</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-integer-value⑤">(2)</a> <a href="#ref-for-integer-value⑥">(3)</a> <a href="#ref-for-integer-value⑦">(4)</a> <a href="#ref-for-integer-value⑧">(5)</a> <a href="#ref-for-integer-value⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a>
@@ -7346,8 +7346,8 @@ Track Sizes</a> <a href="#ref-for-typedef-length-percentage⑤">(2)</a>
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">7.2.4. 
 Flexible Lengths: the fr unit</a> <a href="#ref-for-length-value①">(2)</a>
@@ -7357,8 +7357,8 @@ Grid Sizing</a>
 Track Sizing Algorithm</a> <a href="#ref-for-length-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">7.2.1. 
 Track Sizes</a> <a href="#ref-for-percentage-value①">(2)</a>
@@ -7369,8 +7369,8 @@ Grid Sizing</a>
     <li><a href="#ref-for-percentage-value④"> Major Changes</a> <a href="#ref-for-percentage-value⑤">(2)</a> <a href="#ref-for-percentage-value⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-string-value①">(2)</a>
@@ -7382,8 +7382,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-string
     <li><a href="#ref-for-string-value⑥"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a> <a href="#ref-for-mult-opt④">(5)</a> <a href="#ref-for-mult-opt⑤">(6)</a> <a href="#ref-for-mult-opt⑥">(7)</a> <a href="#ref-for-mult-opt⑦">(8)</a>
@@ -7399,29 +7399,29 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">7.2.4. 
 Flexible Lengths: the fr unit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">8.4. 
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -7441,8 +7441,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-one②�
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-comb-one②⑦">(2)</a> <a href="#ref-for-comb-one②⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">7.7. 
 Automatic Placement: the grid-auto-flow property</a>
@@ -7450,15 +7450,15 @@ Automatic Placement: the grid-auto-flow property</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">11.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">5.2. 
 Sizing Grid Containers</a>
@@ -7468,36 +7468,36 @@ Track Sizes</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-block-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis①" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">11.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">9.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.2. 
 Sizing Grid Containers</a>
@@ -7512,43 +7512,43 @@ Grid Sizing Algorithm</a> <a href="#ref-for-inline-size⑤">(2)</a> <a href="#re
     <li><a href="#ref-for-inline-size⑦"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">11.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-inline-axis①">(2)</a> <a href="#ref-for-inline-axis②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-orthogonal-flow">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow">https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-orthogonal-flow" class="dfn-panel" data-for="term-for-establish-an-orthogonal-flow" id="infopanel-for-term-for-establish-an-orthogonal-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-orthogonal-flow" style="display:none">Info about the 'orthogonal flow' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow">https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-orthogonal-flow">11.1. 
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">9.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">6.4. 
 Grid Item Margins and Paddings</a>
@@ -7559,8 +7559,8 @@ Grid Container Baselines</a>
     <li><a href="#ref-for-writing-mode③"> Minor Changes</a> <a href="#ref-for-writing-mode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">9.1. 
 With a Grid Container as Containing Block</a>
@@ -7568,29 +7568,29 @@ With a Grid Container as Containing Block</a>
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-propdef-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">8.4. 
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
@@ -7598,8 +7598,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">11.6. 
 Maximize Tracks</a> <a href="#ref-for-propdef-max-width①">(2)</a>
@@ -7607,8 +7607,8 @@ Maximize Tracks</a> <a href="#ref-for-propdef-max-width①">(2)</a>
 Expand Flexible Tracks</a> <a href="#ref-for-propdef-max-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">6.2. 
 	Grid Item Sizing</a>
@@ -7618,8 +7618,8 @@ Track Sizes</a>
     <li><a href="#ref-for-propdef-min-height③"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">6.2. 
 	Grid Item Sizing</a>
@@ -7635,29 +7635,29 @@ Stretch auto Tracks</a>
     <li><a href="#ref-for-propdef-min-width⑦"> Significant Adjustments and Fixes</a> <a href="#ref-for-propdef-min-width⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">6.5. 
 Z-axis Ordering: the z-index property</a> <a href="#ref-for-propdef-z-index①">(2)</a> <a href="#ref-for-propdef-z-index②">(3)</a> <a href="#ref-for-propdef-z-index③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">12. 
 Fragmenting Grid Layout</a> <a href="#ref-for-propdef-break-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">12. 
 Fragmenting Grid Layout</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-for-propdef-break-before②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">10.1. 
 Gutters: the row-gap, column-gap, and gap properties</a>
@@ -7665,15 +7665,15 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">9.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">7.1. 
 The Explicit Grid</a> <a href="#ref-for-css-end①">(2)</a>
@@ -7681,8 +7681,8 @@ The Explicit Grid</a> <a href="#ref-for-css-end①">(2)</a>
 Grid Placement Conflict Handling</a> <a href="#ref-for-css-end③">(2)</a> <a href="#ref-for-css-end④">(3)</a> <a href="#ref-for-css-end⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">7.1. 
 The Explicit Grid</a> <a href="#ref-for-css-start①">(2)</a>
@@ -7690,43 +7690,43 @@ The Explicit Grid</a> <a href="#ref-for-css-start①">(2)</a>
 Grid Placement Conflict Handling</a> <a href="#ref-for-css-start③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value-special-case-property">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value-special-case-property" class="dfn-panel" data-for="term-for-resolved-value-special-case-property" id="infopanel-for-term-for-resolved-value-special-case-property" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value-special-case-property" style="display:none">Info about the 'resolved value special case property' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value-special-case-property">7.2.6. 
 Resolved Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">7.2.5. 
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">7.2.5. 
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">8.2. 
 Grid Item Placement vs. Source Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-by-computed-value">
-   <a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-by-computed-value" class="dfn-panel" data-for="term-for-by-computed-value" id="infopanel-for-term-for-by-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-by-computed-value" style="display:none">Info about the 'by computed value' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-by-computed-value">7.2.3.3. 
 Interpolation/Combination of repeat()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discrete">
-   <a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discrete" class="dfn-panel" data-for="term-for-discrete" id="infopanel-for-term-for-discrete" role="menu">
+   <span id="infopaneltitle-for-term-for-discrete" style="display:none">Info about the 'discrete' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discrete">7.2.3.3. 
 Interpolation/Combination of repeat()</a>
@@ -8300,8 +8300,8 @@ gridEl<c- p>.</c->style<c- p>.</c->gridTemplateRows <c- o>=</c-> s<c- p>.</c->gr
      <a class="issue-return" href="#issue-37995da3" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="grid">
-   <b><a href="#grid">#grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid" class="dfn-panel" data-for="grid" id="infopanel-for-grid" role="dialog">
+   <span id="infopaneltitle-for-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#grid">#grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid">2. 
 Overview</a>
@@ -8350,8 +8350,8 @@ Expand Flexible Tracks</a>
     <li><a href="#ref-for-grid②⑤"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-column">
-   <b><a href="#grid-column">#grid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-column" class="dfn-panel" data-for="grid-column" id="infopanel-for-grid-column" role="dialog">
+   <span id="infopaneltitle-for-grid-column" style="display:none">Info about the 'columns' definition.</span><b><a href="#grid-column">#grid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-column">2.1. 
 Declaring the Grid</a>
@@ -8363,8 +8363,8 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-grid-column④">(2)</a> <a href="#ref-for-grid-column⑤">(3)</a> <a href="#ref-for-grid-column⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-row">
-   <b><a href="#grid-row">#grid-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-row" class="dfn-panel" data-for="grid-row" id="infopanel-for-grid-row" role="dialog">
+   <span id="infopaneltitle-for-grid-row" style="display:none">Info about the 'rows' definition.</span><b><a href="#grid-row">#grid-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-row">2.1. 
 Declaring the Grid</a>
@@ -8376,8 +8376,8 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-grid-row④">(2)</a> <a href="#ref-for-grid-row⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-line">
-   <b><a href="#grid-line">#grid-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-line" class="dfn-panel" data-for="grid-line" id="infopanel-for-grid-line" role="dialog">
+   <span id="infopaneltitle-for-grid-line" style="display:none">Info about the 'Grid lines' definition.</span><b><a href="#grid-line">#grid-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-line">3. 
 Grid Layout Concepts and Terminology</a> <a href="#ref-for-grid-line①">(2)</a>
@@ -8408,8 +8408,8 @@ Aligning the Grid: the justify-content and align-content properties</a>
     <li><a href="#ref-for-grid-line②⑥"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-track">
-   <b><a href="#grid-track">#grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-track" class="dfn-panel" data-for="grid-track" id="infopanel-for-grid-track" role="dialog">
+   <span id="infopaneltitle-for-grid-track" style="display:none">Info about the 'Grid track' definition.</span><b><a href="#grid-track">#grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-track">2.1. 
 Declaring the Grid</a>
@@ -8450,8 +8450,8 @@ Find the Size of an fr</a> <a href="#ref-for-grid-track③③">(2)</a>
     <li><a href="#ref-for-grid-track③⑨"> Clarifications</a> <a href="#ref-for-grid-track④⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-cell">
-   <b><a href="#grid-cell">#grid-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-cell" class="dfn-panel" data-for="grid-cell" id="infopanel-for-grid-cell" role="dialog">
+   <span id="infopaneltitle-for-grid-cell" style="display:none">Info about the 'grid cell' definition.</span><b><a href="#grid-cell">#grid-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-cell">3.3. 
 Grid Areas</a>
@@ -8467,8 +8467,8 @@ Grid Item Placement Algorithm</a>
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-area">
-   <b><a href="#grid-area">#grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-area" class="dfn-panel" data-for="grid-area" id="infopanel-for-grid-area" role="dialog">
+   <span id="infopaneltitle-for-grid-area" style="display:none">Info about the 'grid area' definition.</span><b><a href="#grid-area">#grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-area">1.1. 
 Background and Motivation</a>
@@ -8510,8 +8510,8 @@ Sample Fragmentation Algorithm</a>
     <li><a href="#ref-for-grid-area③⑧"> Significant Adjustments and Fixes</a> <a href="#ref-for-grid-area③⑨">(2)</a> <a href="#ref-for-grid-area④⓪">(3)</a> <a href="#ref-for-grid-area④①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-grid">
-   <b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-grid" class="dfn-panel" data-for="valdef-display-grid" id="infopanel-for-valdef-display-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-grid">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-valdef-display-grid①">(2)</a> <a href="#ref-for-valdef-display-grid②">(3)</a>
@@ -8520,8 +8520,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a> <a hre
     <li><a href="#ref-for-valdef-display-grid⑤"> Clarifications</a> <a href="#ref-for-valdef-display-grid⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-grid">
-   <b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-grid" class="dfn-panel" data-for="valdef-display-inline-grid" id="infopanel-for-valdef-display-inline-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-grid" style="display:none">Info about the 'inline-grid' definition.</span><b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-grid">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-valdef-display-inline-grid①">(2)</a> <a href="#ref-for-valdef-display-inline-grid②">(3)</a>
@@ -8530,8 +8530,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a> <a hre
     <li><a href="#ref-for-valdef-display-inline-grid⑤"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-container">
-   <b><a href="#grid-container">#grid-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-container" class="dfn-panel" data-for="grid-container" id="infopanel-for-grid-container" role="dialog">
+   <span id="infopaneltitle-for-grid-container" style="display:none">Info about the 'grid container' definition.</span><b><a href="#grid-container">#grid-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">1.1.1. 
 Adapting Layouts to Available Space</a>
@@ -8621,23 +8621,23 @@ Fragmenting Grid Layout</a>
     <li><a href="#ref-for-grid-container①③①"> Significant Adjustments and Fixes</a> <a href="#ref-for-grid-container①③②">(2)</a> <a href="#ref-for-grid-container①③③">(3)</a> <a href="#ref-for-grid-container①③④">(4)</a> <a href="#ref-for-grid-container①③⑤">(5)</a> <a href="#ref-for-grid-container①③⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-formatting-context">
-   <b><a href="#grid-formatting-context">#grid-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-formatting-context" class="dfn-panel" data-for="grid-formatting-context" id="infopanel-for-grid-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-grid-formatting-context" style="display:none">Info about the 'grid formatting context' definition.</span><b><a href="#grid-formatting-context">#grid-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-formatting-context">6.1. 
 	Grid Item Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clamp-a-grid-area">
-   <b><a href="#clamp-a-grid-area">#clamp-a-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clamp-a-grid-area" class="dfn-panel" data-for="clamp-a-grid-area" id="infopanel-for-clamp-a-grid-area" role="dialog">
+   <span id="infopaneltitle-for-clamp-a-grid-area" style="display:none">Info about the 'clamp a grid area' definition.</span><b><a href="#clamp-a-grid-area">#clamp-a-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clamp-a-grid-area">5.4. 
 Limiting Large Grids</a>
     <li><a href="#ref-for-clamp-a-grid-area①"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-item">
-   <b><a href="#grid-item">#grid-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-item" class="dfn-panel" data-for="grid-item" id="infopanel-for-grid-item" role="dialog">
+   <span id="infopaneltitle-for-grid-item" style="display:none">Info about the 'grid items' definition.</span><b><a href="#grid-item">#grid-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">1.1.1. 
 Adapting Layouts to Available Space</a> <a href="#ref-for-grid-item①">(2)</a> <a href="#ref-for-grid-item②">(3)</a> <a href="#ref-for-grid-item③">(4)</a>
@@ -8723,8 +8723,8 @@ Fragmenting Grid Layout</a> <a href="#ref-for-grid-item①①⑤">(2)</a>
     <li><a href="#ref-for-grid-item①③②"> Significant Adjustments and Fixes</a> <a href="#ref-for-grid-item①③③">(2)</a> <a href="#ref-for-grid-item①③④">(3)</a> <a href="#ref-for-grid-item①③⑤">(4)</a> <a href="#ref-for-grid-item①③⑥">(5)</a> <a href="#ref-for-grid-item①③⑦">(6)</a> <a href="#ref-for-grid-item①③⑧">(7)</a> <a href="#ref-for-grid-item①③⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-based-minimum-size">
-   <b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-based-minimum-size" class="dfn-panel" data-for="content-based-minimum-size" id="infopanel-for-content-based-minimum-size" role="dialog">
+   <span id="infopaneltitle-for-content-based-minimum-size" style="display:none">Info about the 'content-based minimum size' definition.</span><b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-based-minimum-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-based-minimum-size①">(2)</a> <a href="#ref-for-content-based-minimum-size②">(3)</a> <a href="#ref-for-content-based-minimum-size③">(4)</a> <a href="#ref-for-content-based-minimum-size④">(5)</a>
@@ -8733,30 +8733,30 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-based-minimum
     <li><a href="#ref-for-content-based-minimum-size⑦"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-size-suggestion">
-   <b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-size-suggestion" class="dfn-panel" data-for="specified-size-suggestion" id="infopanel-for-specified-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-specified-size-suggestion" style="display:none">Info about the 'specified size suggestion' definition.</span><b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-specified-size-suggestion①">(2)</a> <a href="#ref-for-specified-size-suggestion②">(3)</a> <a href="#ref-for-specified-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transferred-size-suggestion">
-   <b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transferred-size-suggestion" class="dfn-panel" data-for="transferred-size-suggestion" id="infopanel-for-transferred-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-transferred-size-suggestion" style="display:none">Info about the 'transferred size suggestion' definition.</span><b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transferred-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-transferred-size-suggestion①">(2)</a> <a href="#ref-for-transferred-size-suggestion②">(3)</a> <a href="#ref-for-transferred-size-suggestion③">(4)</a>
     <li><a href="#ref-for-transferred-size-suggestion④"> Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-size-suggestion">
-   <b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-size-suggestion" class="dfn-panel" data-for="content-size-suggestion" id="infopanel-for-content-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-content-size-suggestion" style="display:none">Info about the 'content size suggestion' definition.</span><b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-size-suggestion①">(2)</a> <a href="#ref-for-content-size-suggestion②">(3)</a> <a href="#ref-for-content-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid">
-   <b><a href="#explicit-grid">#explicit-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid" class="dfn-panel" data-for="explicit-grid" id="infopanel-for-explicit-grid" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid" style="display:none">Info about the 'explicit grid' definition.</span><b><a href="#explicit-grid">#explicit-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid">2.1. 
 Declaring the Grid</a> <a href="#ref-for-explicit-grid①">(2)</a>
@@ -8782,16 +8782,16 @@ Aligning the Grid: the justify-content and align-content properties</a>
     <li><a href="#ref-for-explicit-grid③③"> Significant Adjustments and Fixes</a> <a href="#ref-for-explicit-grid③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid-track">
-   <b><a href="#explicit-grid-track">#explicit-grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid-track" class="dfn-panel" data-for="explicit-grid-track" id="infopanel-for-explicit-grid-track" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid-track" style="display:none">Info about the 'explicit grid tracks' definition.</span><b><a href="#explicit-grid-track">#explicit-grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid-track">7.5. 
 The Implicit Grid</a>
     <li><a href="#ref-for-explicit-grid-track①"> Clarifications</a> <a href="#ref-for-explicit-grid-track②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid-properties">
-   <b><a href="#explicit-grid-properties">#explicit-grid-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid-properties" class="dfn-panel" data-for="explicit-grid-properties" id="infopanel-for-explicit-grid-properties" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid-properties" style="display:none">Info about the 'explicit grid properties' definition.</span><b><a href="#explicit-grid-properties">#explicit-grid-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid-properties">7.5. 
 The Implicit Grid</a>
@@ -8799,8 +8799,8 @@ The Implicit Grid</a>
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-columns">
-   <b><a href="#propdef-grid-template-columns">#propdef-grid-template-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-columns" class="dfn-panel" data-for="propdef-grid-template-columns" id="infopanel-for-propdef-grid-template-columns" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-columns" style="display:none">Info about the 'grid-template-columns' definition.</span><b><a href="#propdef-grid-template-columns">#propdef-grid-template-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-columns">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-template-columns①">(2)</a> <a href="#ref-for-propdef-grid-template-columns②">(3)</a> <a href="#ref-for-propdef-grid-template-columns③">(4)</a>
@@ -8829,8 +8829,8 @@ Grid Item Placement Algorithm</a>
     <li><a href="#ref-for-propdef-grid-template-columns②⑧"> Clarifications</a> <a href="#ref-for-propdef-grid-template-columns②⑨">(2)</a> <a href="#ref-for-propdef-grid-template-columns③⓪">(3)</a> <a href="#ref-for-propdef-grid-template-columns③①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-rows">
-   <b><a href="#propdef-grid-template-rows">#propdef-grid-template-rows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-rows" class="dfn-panel" data-for="propdef-grid-template-rows" id="infopanel-for-propdef-grid-template-rows" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-rows" style="display:none">Info about the 'grid-template-rows' definition.</span><b><a href="#propdef-grid-template-rows">#propdef-grid-template-rows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-rows">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-template-rows①">(2)</a> <a href="#ref-for-propdef-grid-template-rows②">(3)</a> <a href="#ref-for-propdef-grid-template-rows③">(4)</a>
@@ -8855,8 +8855,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-
     <li><a href="#ref-for-propdef-grid-template-rows②⑦"> Clarifications</a> <a href="#ref-for-propdef-grid-template-rows②⑧">(2)</a> <a href="#ref-for-propdef-grid-template-rows②⑨">(3)</a> <a href="#ref-for-propdef-grid-template-rows③⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-list">
-   <b><a href="#track-list">#track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-list" class="dfn-panel" data-for="track-list" id="infopanel-for-track-list" role="dialog">
+   <span id="infopaneltitle-for-track-list" style="display:none">Info about the 'track list' definition.</span><b><a href="#track-list">#track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-track-list①">(2)</a> <a href="#ref-for-track-list②">(3)</a> <a href="#ref-for-track-list③">(4)</a>
@@ -8868,8 +8868,8 @@ Syntax of repeat()</a> <a href="#ref-for-track-list⑥">(2)</a> <a href="#ref-fo
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-rows-none">
-   <b><a href="#valdef-grid-template-rows-none">#valdef-grid-template-rows-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-rows-none" class="dfn-panel" data-for="valdef-grid-template-rows-none" id="infopanel-for-valdef-grid-template-rows-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-rows-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-grid-template-rows-none">#valdef-grid-template-rows-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-rows-none">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8879,8 +8879,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-valdef
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-rows-track-sizing-function">
-   <b><a href="#grid-template-rows-track-sizing-function">#grid-template-rows-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-rows-track-sizing-function" class="dfn-panel" data-for="grid-template-rows-track-sizing-function" id="infopanel-for-grid-template-rows-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-grid-template-rows-track-sizing-function" style="display:none">Info about the 'track sizing function' definition.</span><b><a href="#grid-template-rows-track-sizing-function">#grid-template-rows-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-rows-track-sizing-function">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-grid-template-rows-track-sizing-function①">(2)</a>
@@ -8898,8 +8898,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-grid-template-rows-track-siz
     <li><a href="#ref-for-grid-template-rows-track-sizing-function①⓪"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-list">
-   <b><a href="#typedef-track-list">#typedef-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-list" class="dfn-panel" data-for="typedef-track-list" id="infopanel-for-typedef-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-list" style="display:none">Info about the '&lt;track-list>' definition.</span><b><a href="#typedef-track-list">#typedef-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-list①">(2)</a>
@@ -8909,22 +8909,22 @@ Syntax of repeat()</a>
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-auto-track-list">
-   <b><a href="#typedef-auto-track-list">#typedef-auto-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-auto-track-list" class="dfn-panel" data-for="typedef-auto-track-list" id="infopanel-for-typedef-auto-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-auto-track-list" style="display:none">Info about the '&lt;auto-track-list>' definition.</span><b><a href="#typedef-auto-track-list">#typedef-auto-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-auto-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-auto-track-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-explicit-track-list">
-   <b><a href="#typedef-explicit-track-list">#typedef-explicit-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-explicit-track-list" class="dfn-panel" data-for="typedef-explicit-track-list" id="infopanel-for-typedef-explicit-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-explicit-track-list" style="display:none">Info about the '&lt;explicit-track-list>' definition.</span><b><a href="#typedef-explicit-track-list">#typedef-explicit-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-explicit-track-list">7.4. 
 Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typedef-explicit-track-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-size">
-   <b><a href="#typedef-track-size">#typedef-track-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-size" class="dfn-panel" data-for="typedef-track-size" id="infopanel-for-typedef-track-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-size" style="display:none">Info about the '&lt;track-size>' definition.</span><b><a href="#typedef-track-size">#typedef-track-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-size">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-size①">(2)</a>
@@ -8936,8 +8936,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typede
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-size">
-   <b><a href="#typedef-fixed-size">#typedef-fixed-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-size" class="dfn-panel" data-for="typedef-fixed-size" id="infopanel-for-typedef-fixed-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-size" style="display:none">Info about the '&lt;fixed-size>' definition.</span><b><a href="#typedef-fixed-size">#typedef-fixed-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-size">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-size①">(2)</a>
@@ -8945,29 +8945,29 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-fixed-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-breadth">
-   <b><a href="#typedef-track-breadth">#typedef-track-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-breadth" class="dfn-panel" data-for="typedef-track-breadth" id="infopanel-for-typedef-track-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-breadth" style="display:none">Info about the '&lt;track-breadth>' definition.</span><b><a href="#typedef-track-breadth">#typedef-track-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-breadth①">(2)</a> <a href="#ref-for-typedef-track-breadth②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-inflexible-breadth">
-   <b><a href="#typedef-inflexible-breadth">#typedef-inflexible-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-inflexible-breadth" class="dfn-panel" data-for="typedef-inflexible-breadth" id="infopanel-for-typedef-inflexible-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-inflexible-breadth" style="display:none">Info about the '&lt;inflexible-breadth>' definition.</span><b><a href="#typedef-inflexible-breadth">#typedef-inflexible-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-inflexible-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-inflexible-breadth①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-breadth">
-   <b><a href="#typedef-fixed-breadth">#typedef-fixed-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-breadth" class="dfn-panel" data-for="typedef-fixed-breadth" id="infopanel-for-typedef-fixed-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-breadth" style="display:none">Info about the '&lt;fixed-breadth>' definition.</span><b><a href="#typedef-fixed-breadth">#typedef-fixed-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-breadth①">(2)</a> <a href="#ref-for-typedef-fixed-breadth②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-line-names">
-   <b><a href="#typedef-line-names">#typedef-line-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-line-names" class="dfn-panel" data-for="typedef-line-names" id="infopanel-for-typedef-line-names" role="dialog">
+   <span id="infopaneltitle-for-typedef-line-names" style="display:none">Info about the '&lt;line-names>' definition.</span><b><a href="#typedef-line-names">#typedef-line-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-names">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-line-names①">(2)</a> <a href="#ref-for-typedef-line-names②">(3)</a> <a href="#ref-for-typedef-line-names③">(4)</a> <a href="#ref-for-typedef-line-names④">(5)</a> <a href="#ref-for-typedef-line-names⑤">(6)</a> <a href="#ref-for-typedef-line-names⑥">(7)</a> <a href="#ref-for-typedef-line-names⑦">(8)</a>
@@ -8979,8 +8979,8 @@ Syntax of repeat()</a> <a href="#ref-for-typedef-line-names①⓪">(2)</a> <a hr
 Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typedef-line-names①⑦">(2)</a> <a href="#ref-for-typedef-line-names①⑧">(3)</a> <a href="#ref-for-typedef-line-names①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-columns-flex-factor">
-   <b><a href="#grid-template-columns-flex-factor">#grid-template-columns-flex-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-columns-flex-factor" class="dfn-panel" data-for="grid-template-columns-flex-factor" id="infopanel-for-grid-template-columns-flex-factor" role="dialog">
+   <span id="infopaneltitle-for-grid-template-columns-flex-factor" style="display:none">Info about the 'flex factor' definition.</span><b><a href="#grid-template-columns-flex-factor">#grid-template-columns-flex-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-columns-flex-factor">7.2.1. 
 Track Sizes</a> <a href="#ref-for-grid-template-columns-flex-factor①">(2)</a> <a href="#ref-for-grid-template-columns-flex-factor②">(3)</a>
@@ -8993,8 +8993,8 @@ Find the Size of an fr</a> <a href="#ref-for-grid-template-columns-flex-factor�
     <li><a href="#ref-for-grid-template-columns-flex-factor①②"> Significant Adjustments and Fixes</a> <a href="#ref-for-grid-template-columns-flex-factor①③">(2)</a> <a href="#ref-for-grid-template-columns-flex-factor①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-minmax">
-   <b><a href="#valdef-grid-template-columns-minmax">#valdef-grid-template-columns-minmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-minmax" class="dfn-panel" data-for="valdef-grid-template-columns-minmax" id="infopanel-for-valdef-grid-template-columns-minmax" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-minmax" style="display:none">Info about the 'minmax(min, max)' definition.</span><b><a href="#valdef-grid-template-columns-minmax">#valdef-grid-template-columns-minmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-minmax">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -9006,8 +9006,8 @@ Computed Value of a Track Listing</a>
 Track Sizing Terminology</a> <a href="#ref-for-valdef-grid-template-columns-minmax⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-auto">
-   <b><a href="#valdef-grid-template-columns-auto">#valdef-grid-template-columns-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-auto" class="dfn-panel" data-for="valdef-grid-template-columns-auto" id="infopanel-for-valdef-grid-template-columns-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-grid-template-columns-auto">#valdef-grid-template-columns-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-auto">2.1. 
 Declaring the Grid</a> <a href="#ref-for-valdef-grid-template-columns-auto①">(2)</a>
@@ -9025,8 +9025,8 @@ Stretch auto Tracks</a>
     <li><a href="#ref-for-valdef-grid-template-columns-auto①④"> Significant Adjustments and Fixes</a> <a href="#ref-for-valdef-grid-template-columns-auto①⑤">(2)</a> <a href="#ref-for-valdef-grid-template-columns-auto①⑥">(3)</a> <a href="#ref-for-valdef-grid-template-columns-auto①⑦">(4)</a> <a href="#ref-for-valdef-grid-template-columns-auto①⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-max-content">
-   <b><a href="#valdef-grid-template-columns-max-content">#valdef-grid-template-columns-max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-max-content" class="dfn-panel" data-for="valdef-grid-template-columns-max-content" id="infopanel-for-valdef-grid-template-columns-max-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-max-content" style="display:none">Info about the 'max-content' definition.</span><b><a href="#valdef-grid-template-columns-max-content">#valdef-grid-template-columns-max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-max-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9048,8 +9048,8 @@ Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-valdef-grid
     <li><a href="#ref-for-valdef-grid-template-columns-max-content②①"> Significant Adjustments and Fixes</a> <a href="#ref-for-valdef-grid-template-columns-max-content②②">(2)</a> <a href="#ref-for-valdef-grid-template-columns-max-content②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-min-content">
-   <b><a href="#valdef-grid-template-columns-min-content">#valdef-grid-template-columns-min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-min-content" class="dfn-panel" data-for="valdef-grid-template-columns-min-content" id="infopanel-for-valdef-grid-template-columns-min-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-min-content" style="display:none">Info about the 'min-content' definition.</span><b><a href="#valdef-grid-template-columns-min-content">#valdef-grid-template-columns-min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-min-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9065,8 +9065,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-valdef-grid-template-columns
     <li><a href="#ref-for-valdef-grid-template-columns-min-content①①"> Significant Adjustments and Fixes</a> <a href="#ref-for-valdef-grid-template-columns-min-content①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-fit-content">
-   <b><a href="#valdef-grid-template-columns-fit-content">#valdef-grid-template-columns-fit-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-fit-content" class="dfn-panel" data-for="valdef-grid-template-columns-fit-content" id="infopanel-for-valdef-grid-template-columns-fit-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-fit-content" style="display:none">Info about the 'fit-content( &lt;length-percentage> )' definition.</span><b><a href="#valdef-grid-template-columns-fit-content">#valdef-grid-template-columns-fit-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-fit-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9085,8 +9085,8 @@ Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-valdef-grid
     <li><a href="#ref-for-valdef-grid-template-columns-fit-content①⑥"> Clarifications</a> <a href="#ref-for-valdef-grid-template-columns-fit-content①⑦">(2)</a> <a href="#ref-for-valdef-grid-template-columns-fit-content①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-name">
-   <b><a href="#line-name">#line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-name" class="dfn-panel" data-for="line-name" id="infopanel-for-line-name" role="dialog">
+   <span id="infopaneltitle-for-line-name" style="display:none">Info about the 'line names' definition.</span><b><a href="#line-name">#line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-name">7.2.2. 
 Naming Grid Lines: the [&lt;custom-ident>*] syntax</a> <a href="#ref-for-line-name①">(2)</a>
@@ -9098,15 +9098,15 @@ Named Lines and Spans</a> <a href="#ref-for-line-name④">(2)</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicitly-assigned-line-name">
-   <b><a href="#explicitly-assigned-line-name">#explicitly-assigned-line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicitly-assigned-line-name" class="dfn-panel" data-for="explicitly-assigned-line-name" id="infopanel-for-explicitly-assigned-line-name" role="dialog">
+   <span id="infopaneltitle-for-explicitly-assigned-line-name" style="display:none">Info about the 'explicitly assigned' definition.</span><b><a href="#explicitly-assigned-line-name">#explicitly-assigned-line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicitly-assigned-line-name">7.3.2. 
 Implicitly-Assigned Line Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeat">
-   <b><a href="#funcdef-repeat">#funcdef-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeat" class="dfn-panel" data-for="funcdef-repeat" id="infopanel-for-funcdef-repeat" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeat" style="display:none">Info about the 'repeat()' definition.</span><b><a href="#funcdef-repeat">#funcdef-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeat">7.2.3. 
 Repeating Rows and Columns: the repeat() notation</a>
@@ -9123,8 +9123,8 @@ Explicit Grid Shorthand: the grid-template property</a>
     <li><a href="#ref-for-funcdef-repeat①①"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-repeat">
-   <b><a href="#typedef-track-repeat">#typedef-track-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-repeat" class="dfn-panel" data-for="typedef-track-repeat" id="infopanel-for-typedef-track-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-repeat" style="display:none">Info about the '&lt;track-repeat>' definition.</span><b><a href="#typedef-track-repeat">#typedef-track-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -9132,8 +9132,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-track-repeat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-auto-repeat">
-   <b><a href="#typedef-auto-repeat">#typedef-auto-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-auto-repeat" class="dfn-panel" data-for="typedef-auto-repeat" id="infopanel-for-typedef-auto-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-auto-repeat" style="display:none">Info about the '&lt;auto-repeat>' definition.</span><b><a href="#typedef-auto-repeat">#typedef-auto-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-auto-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -9141,8 +9141,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-auto-repeat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-repeat">
-   <b><a href="#typedef-fixed-repeat">#typedef-fixed-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-repeat" class="dfn-panel" data-for="typedef-fixed-repeat" id="infopanel-for-typedef-fixed-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-repeat" style="display:none">Info about the '&lt;fixed-repeat>' definition.</span><b><a href="#typedef-fixed-repeat">#typedef-fixed-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-repeat①">(2)</a>
@@ -9150,8 +9150,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-fixed-repeat③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-repeat-auto-fill">
-   <b><a href="#valdef-repeat-auto-fill">#valdef-repeat-auto-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-repeat-auto-fill" class="dfn-panel" data-for="valdef-repeat-auto-fill" id="infopanel-for-valdef-repeat-auto-fill" role="dialog">
+   <span id="infopaneltitle-for-valdef-repeat-auto-fill" style="display:none">Info about the 'auto-fill' definition.</span><b><a href="#valdef-repeat-auto-fill">#valdef-repeat-auto-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-repeat-auto-fill">7.2.3.1. 
 Syntax of repeat()</a>
@@ -9160,8 +9160,8 @@ Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-valdef-
     <li><a href="#ref-for-valdef-repeat-auto-fill③"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-repeat-auto-fit">
-   <b><a href="#valdef-repeat-auto-fit">#valdef-repeat-auto-fit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-repeat-auto-fit" class="dfn-panel" data-for="valdef-repeat-auto-fit" id="infopanel-for-valdef-repeat-auto-fit" role="dialog">
+   <span id="infopaneltitle-for-valdef-repeat-auto-fit" style="display:none">Info about the 'auto-fit' definition.</span><b><a href="#valdef-repeat-auto-fit">#valdef-repeat-auto-fit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-repeat-auto-fit">7.2.3.1. 
 Syntax of repeat()</a>
@@ -9170,8 +9170,8 @@ Repeat-to-fill: auto-fill and auto-fit repetitions</a>
     <li><a href="#ref-for-valdef-repeat-auto-fit②"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsed-track">
-   <b><a href="#collapsed-track">#collapsed-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsed-track" class="dfn-panel" data-for="collapsed-track" id="infopanel-for-collapsed-track" role="dialog">
+   <span id="infopaneltitle-for-collapsed-track" style="display:none">Info about the 'collapsed track' definition.</span><b><a href="#collapsed-track">#collapsed-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-track">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-collapsed-track①">(2)</a>
@@ -9180,14 +9180,14 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-colla
     <li><a href="#ref-for-collapsed-track⑤"> Clarifications</a> <a href="#ref-for-collapsed-track⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible-length">
-   <b><a href="#flexible-length">#flexible-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible-length" class="dfn-panel" data-for="flexible-length" id="infopanel-for-flexible-length" role="dialog">
+   <span id="infopaneltitle-for-flexible-length" style="display:none">Info about the 'flexible length' definition.</span><b><a href="#flexible-length">#flexible-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible-length"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-flex">
-   <b><a href="#typedef-flex">#typedef-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-flex" class="dfn-panel" data-for="typedef-flex" id="infopanel-for-typedef-flex" role="dialog">
+   <span id="infopaneltitle-for-typedef-flex" style="display:none">Info about the '&lt;flex>' definition.</span><b><a href="#typedef-flex">#typedef-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-flex">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -9208,8 +9208,8 @@ Track Sizing Terminology</a>
     <li><a href="#ref-for-typedef-flex①⑥"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-fr">
-   <b><a href="#valdef-flex-fr">#valdef-flex-fr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-fr" class="dfn-panel" data-for="valdef-flex-fr" id="infopanel-for-valdef-flex-fr" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-fr" style="display:none">Info about the 'fr' definition.</span><b><a href="#valdef-flex-fr">#valdef-flex-fr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-fr">2.1. 
 Declaring the Grid</a> <a href="#ref-for-valdef-flex-fr①">(2)</a>
@@ -9225,8 +9225,8 @@ Find the Size of an fr</a> <a href="#ref-for-valdef-flex-fr⑧">(2)</a>
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible-tracks">
-   <b><a href="#flexible-tracks">#flexible-tracks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible-tracks" class="dfn-panel" data-for="flexible-tracks" id="infopanel-for-flexible-tracks" role="dialog">
+   <span id="infopaneltitle-for-flexible-tracks" style="display:none">Info about the 'flexible tracks' definition.</span><b><a href="#flexible-tracks">#flexible-tracks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible-tracks">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9240,16 +9240,16 @@ Find the Size of an fr</a> <a href="#ref-for-flexible-tracks⑧">(2)</a>
     <li><a href="#ref-for-flexible-tracks①⑤"> Minor Changes</a> <a href="#ref-for-flexible-tracks①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-fraction">
-   <b><a href="#flex-fraction">#flex-fraction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-fraction" class="dfn-panel" data-for="flex-fraction" id="infopanel-for-flex-fraction" role="dialog">
+   <span id="infopaneltitle-for-flex-fraction" style="display:none">Info about the 'flex fraction' definition.</span><b><a href="#flex-fraction">#flex-fraction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-fraction">11.7. 
 Expand Flexible Tracks</a> <a href="#ref-for-flex-fraction①">(2)</a> <a href="#ref-for-flex-fraction②">(3)</a> <a href="#ref-for-flex-fraction③">(4)</a> <a href="#ref-for-flex-fraction④">(5)</a> <a href="#ref-for-flex-fraction⑤">(6)</a>
     <li><a href="#ref-for-flex-fraction⑥"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-track-list">
-   <b><a href="#computed-track-list">#computed-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-track-list" class="dfn-panel" data-for="computed-track-list" id="infopanel-for-computed-track-list" role="dialog">
+   <span id="infopaneltitle-for-computed-track-list" style="display:none">Info about the 'computed track list' definition.</span><b><a href="#computed-track-list">#computed-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-computed-track-list①">(2)</a>
@@ -9259,22 +9259,22 @@ Interpolation/Combination of repeat()</a>
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-name-set">
-   <b><a href="#line-name-set">#line-name-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-name-set" class="dfn-panel" data-for="line-name-set" id="infopanel-for-line-name-set" role="dialog">
+   <span id="infopaneltitle-for-line-name-set" style="display:none">Info about the 'line name set' definition.</span><b><a href="#line-name-set">#line-name-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-name-set">7.2.5. 
 Computed Value of a Track Listing</a> <a href="#ref-for-line-name-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-section">
-   <b><a href="#track-section">#track-section</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-section" class="dfn-panel" data-for="track-section" id="infopanel-for-track-section" role="dialog">
+   <span id="infopaneltitle-for-track-section" style="display:none">Info about the 'track section' definition.</span><b><a href="#track-section">#track-section</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-section">7.2.5. 
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-areas">
-   <b><a href="#propdef-grid-template-areas">#propdef-grid-template-areas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-areas" class="dfn-panel" data-for="propdef-grid-template-areas" id="infopanel-for-propdef-grid-template-areas" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-areas" style="display:none">Info about the 'grid-template-areas' definition.</span><b><a href="#propdef-grid-template-areas">#propdef-grid-template-areas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-areas">3.3. 
 Grid Areas</a>
@@ -9307,8 +9307,8 @@ Named Areas</a>
     <li><a href="#ref-for-propdef-grid-template-areas②⑦"> Clarifications</a> <a href="#ref-for-propdef-grid-template-areas②⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="named-grid-area">
-   <b><a href="#named-grid-area">#named-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-named-grid-area" class="dfn-panel" data-for="named-grid-area" id="infopanel-for-named-grid-area" role="dialog">
+   <span id="infopaneltitle-for-named-grid-area" style="display:none">Info about the 'named grid areas' definition.</span><b><a href="#named-grid-area">#named-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-grid-area">7.2.2. 
 Naming Grid Lines: the [&lt;custom-ident>*] syntax</a>
@@ -9328,8 +9328,8 @@ Named Lines and Spans</a> <a href="#ref-for-named-grid-area①⑥">(2)</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-named-grid-area①⑧">(2)</a> <a href="#ref-for-named-grid-area①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-areas-none">
-   <b><a href="#valdef-grid-template-areas-none">#valdef-grid-template-areas-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-areas-none" class="dfn-panel" data-for="valdef-grid-template-areas-none" id="infopanel-for-valdef-grid-template-areas-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-areas-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-grid-template-areas-none">#valdef-grid-template-areas-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-areas-none">7.3. 
 Named Areas: the grid-template-areas property</a>
@@ -9337,16 +9337,16 @@ Named Areas: the grid-template-areas property</a>
 Explicit Grid Shorthand: the grid-template property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-named-cell-token">
-   <b><a href="#grid-template-areas-named-cell-token">#grid-template-areas-named-cell-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-named-cell-token" class="dfn-panel" data-for="grid-template-areas-named-cell-token" id="infopanel-for-grid-template-areas-named-cell-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-named-cell-token" style="display:none">Info about the 'named cell token' definition.</span><b><a href="#grid-template-areas-named-cell-token">#grid-template-areas-named-cell-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-named-cell-token">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-grid-template-areas-named-cell-token①">(2)</a> <a href="#ref-for-grid-template-areas-named-cell-token②">(3)</a>
     <li><a href="#ref-for-grid-template-areas-named-cell-token③"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-null-cell-token">
-   <b><a href="#grid-template-areas-null-cell-token">#grid-template-areas-null-cell-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-null-cell-token" class="dfn-panel" data-for="grid-template-areas-null-cell-token" id="infopanel-for-grid-template-areas-null-cell-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-null-cell-token" style="display:none">Info about the 'null cell token' definition.</span><b><a href="#grid-template-areas-null-cell-token">#grid-template-areas-null-cell-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-null-cell-token">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-grid-template-areas-null-cell-token①">(2)</a>
@@ -9356,15 +9356,15 @@ Serialization Of Template Strings</a>
     <li><a href="#ref-for-grid-template-areas-null-cell-token⑤"> Minor Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-trash-token">
-   <b><a href="#grid-template-areas-trash-token">#grid-template-areas-trash-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-trash-token" class="dfn-panel" data-for="grid-template-areas-trash-token" id="infopanel-for-grid-template-areas-trash-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-trash-token" style="display:none">Info about the 'trash token' definition.</span><b><a href="#grid-template-areas-trash-token">#grid-template-areas-trash-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-trash-token">7.3. 
 Named Areas: the grid-template-areas property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicitly-assigned-line-name">
-   <b><a href="#implicitly-assigned-line-name">#implicitly-assigned-line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicitly-assigned-line-name" class="dfn-panel" data-for="implicitly-assigned-line-name" id="infopanel-for-implicitly-assigned-line-name" role="dialog">
+   <span id="infopaneltitle-for-implicitly-assigned-line-name" style="display:none">Info about the 'implicitly-assigned line names' definition.</span><b><a href="#implicitly-assigned-line-name">#implicitly-assigned-line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicitly-assigned-line-name">7.2.2. 
 Naming Grid Lines: the [&lt;custom-ident>*] syntax</a>
@@ -9378,8 +9378,8 @@ Explicit Grid Shorthand: the grid-template property</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template">
-   <b><a href="#propdef-grid-template">#propdef-grid-template</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template" class="dfn-panel" data-for="propdef-grid-template" id="infopanel-for-propdef-grid-template" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template" style="display:none">Info about the 'grid-template' definition.</span><b><a href="#propdef-grid-template">#propdef-grid-template</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-template①">(2)</a>
@@ -9389,8 +9389,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-propde
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-template⑥">(2)</a> <a href="#ref-for-propdef-grid-template⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-track">
-   <b><a href="#implicit-grid-track">#implicit-grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-track" class="dfn-panel" data-for="implicit-grid-track" id="infopanel-for-implicit-grid-track" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-track" style="display:none">Info about the 'implicit grid tracks' definition.</span><b><a href="#implicit-grid-track">#implicit-grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-track">7.5. 
 The Implicit Grid</a> <a href="#ref-for-implicit-grid-track①">(2)</a>
@@ -9400,8 +9400,8 @@ Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a> <
     <li><a href="#ref-for-implicit-grid-track⑥"> Significant Adjustments and Fixes</a> <a href="#ref-for-implicit-grid-track⑦">(2)</a> <a href="#ref-for-implicit-grid-track⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-lines">
-   <b><a href="#implicit-grid-lines">#implicit-grid-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-lines" class="dfn-panel" data-for="implicit-grid-lines" id="infopanel-for-implicit-grid-lines" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-lines" style="display:none">Info about the 'implicit grid lines' definition.</span><b><a href="#implicit-grid-lines">#implicit-grid-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-lines">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-implicit-grid-lines①">(2)</a>
@@ -9409,8 +9409,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid">
-   <b><a href="#implicit-grid">#implicit-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid" class="dfn-panel" data-for="implicit-grid" id="infopanel-for-implicit-grid" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid" style="display:none">Info about the 'implicit grid' definition.</span><b><a href="#implicit-grid">#implicit-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid">5.4. 
 Limiting Large Grids</a>
@@ -9429,15 +9429,15 @@ Aligning the Grid: the justify-content and align-content properties</a>
     <li><a href="#ref-for-implicit-grid②⑥"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-properties">
-   <b><a href="#implicit-grid-properties">#implicit-grid-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-properties" class="dfn-panel" data-for="implicit-grid-properties" id="infopanel-for-implicit-grid-properties" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-properties" style="display:none">Info about the 'implicit grid properties' definition.</span><b><a href="#implicit-grid-properties">#implicit-grid-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-properties">7.8. 
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-columns">
-   <b><a href="#propdef-grid-auto-columns">#propdef-grid-auto-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-columns" class="dfn-panel" data-for="propdef-grid-auto-columns" id="infopanel-for-propdef-grid-auto-columns" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-columns" style="display:none">Info about the 'grid-auto-columns' definition.</span><b><a href="#propdef-grid-auto-columns">#propdef-grid-auto-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-columns">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-auto-columns①">(2)</a>
@@ -9454,8 +9454,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-
     <li><a href="#ref-for-propdef-grid-auto-columns①②"> Clarifications</a> <a href="#ref-for-propdef-grid-auto-columns①③">(2)</a> <a href="#ref-for-propdef-grid-auto-columns①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-rows">
-   <b><a href="#propdef-grid-auto-rows">#propdef-grid-auto-rows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-rows" class="dfn-panel" data-for="propdef-grid-auto-rows" id="infopanel-for-propdef-grid-auto-rows" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-rows" style="display:none">Info about the 'grid-auto-rows' definition.</span><b><a href="#propdef-grid-auto-rows">#propdef-grid-auto-rows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-rows">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-auto-rows①">(2)</a>
@@ -9472,8 +9472,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-
     <li><a href="#ref-for-propdef-grid-auto-rows①②"> Clarifications</a> <a href="#ref-for-propdef-grid-auto-rows①③">(2)</a> <a href="#ref-for-propdef-grid-auto-rows①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auto-placement">
-   <b><a href="#auto-placement">#auto-placement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auto-placement" class="dfn-panel" data-for="auto-placement" id="infopanel-for-auto-placement" role="dialog">
+   <span id="infopaneltitle-for-auto-placement" style="display:none">Info about the 'Automatic Placement' definition.</span><b><a href="#auto-placement">#auto-placement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auto-placement">2.2. 
 Placing Items</a>
@@ -9483,8 +9483,8 @@ Placing Grid Items</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-flow">
-   <b><a href="#propdef-grid-auto-flow">#propdef-grid-auto-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-flow" class="dfn-panel" data-for="propdef-grid-auto-flow" id="infopanel-for-propdef-grid-auto-flow" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-flow" style="display:none">Info about the 'grid-auto-flow' definition.</span><b><a href="#propdef-grid-auto-flow">#propdef-grid-auto-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-flow">7.5. 
 The Implicit Grid</a> <a href="#ref-for-propdef-grid-auto-flow①">(2)</a>
@@ -9498,8 +9498,8 @@ Auto Placement</a> <a href="#ref-for-propdef-grid-auto-flow⑧">(2)</a>
 Grid Item Placement Algorithm</a> <a href="#ref-for-propdef-grid-auto-flow①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-row">
-   <b><a href="#valdef-grid-auto-flow-row">#valdef-grid-auto-flow-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-row" class="dfn-panel" data-for="valdef-grid-auto-flow-row" id="infopanel-for-valdef-grid-auto-flow-row" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-row" style="display:none">Info about the 'row' definition.</span><b><a href="#valdef-grid-auto-flow-row">#valdef-grid-auto-flow-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-row">7.7. 
 Automatic Placement: the grid-auto-flow property</a> <a href="#ref-for-valdef-grid-auto-flow-row①">(2)</a> <a href="#ref-for-valdef-grid-auto-flow-row②">(3)</a>
@@ -9509,8 +9509,8 @@ Grid Definition Shorthand: the grid property</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-column">
-   <b><a href="#valdef-grid-auto-flow-column">#valdef-grid-auto-flow-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-column" class="dfn-panel" data-for="valdef-grid-auto-flow-column" id="infopanel-for-valdef-grid-auto-flow-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-column" style="display:none">Info about the 'column' definition.</span><b><a href="#valdef-grid-auto-flow-column">#valdef-grid-auto-flow-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-column">7.7. 
 Automatic Placement: the grid-auto-flow property</a>
@@ -9520,8 +9520,8 @@ Grid Definition Shorthand: the grid property</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-dense">
-   <b><a href="#valdef-grid-auto-flow-dense">#valdef-grid-auto-flow-dense</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-dense" class="dfn-panel" data-for="valdef-grid-auto-flow-dense" id="infopanel-for-valdef-grid-auto-flow-dense" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-dense" style="display:none">Info about the 'dense' definition.</span><b><a href="#valdef-grid-auto-flow-dense">#valdef-grid-auto-flow-dense</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-dense">7.8. 
 Grid Definition Shorthand: the grid property</a>
@@ -9531,8 +9531,8 @@ Auto Placement</a>
 Grid Item Placement Algorithm</a> <a href="#ref-for-valdef-grid-auto-flow-dense③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid">
-   <b><a href="#propdef-grid">#propdef-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid" class="dfn-panel" data-for="propdef-grid" id="infopanel-for-propdef-grid" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#propdef-grid">#propdef-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid">2.1. 
 Declaring the Grid</a>
@@ -9547,8 +9547,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid�
     <li><a href="#ref-for-propdef-grid①③"> Major Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement">
-   <b><a href="#grid-placement">#grid-placement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement" class="dfn-panel" data-for="grid-placement" id="infopanel-for-grid-placement" role="dialog">
+   <span id="infopaneltitle-for-grid-placement" style="display:none">Info about the 'placement' definition.</span><b><a href="#grid-placement">#grid-placement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement">4. 
 Reordering and Accessibility</a>
@@ -9564,29 +9564,29 @@ Grid Item Placement Algorithm</a> <a href="#ref-for-grid-placement①①">(2)</a
 With a Grid Container as Containing Block</a> <a href="#ref-for-grid-placement①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-position">
-   <b><a href="#grid-position">#grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-position" class="dfn-panel" data-for="grid-position" id="infopanel-for-grid-position" role="dialog">
+   <span id="infopaneltitle-for-grid-position" style="display:none">Info about the 'grid position' definition.</span><b><a href="#grid-position">#grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-position">8. 
 Placing Grid Items</a> <a href="#ref-for-grid-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="definite-grid-position">
-   <b><a href="#definite-grid-position">#definite-grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-definite-grid-position" class="dfn-panel" data-for="definite-grid-position" id="infopanel-for-definite-grid-position" role="dialog">
+   <span id="infopaneltitle-for-definite-grid-position" style="display:none">Info about the 'definite' definition.</span><b><a href="#definite-grid-position">#definite-grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite-grid-position">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-definite-grid-position①">(2)</a> <a href="#ref-for-definite-grid-position②">(3)</a> <a href="#ref-for-definite-grid-position③">(4)</a> <a href="#ref-for-definite-grid-position④">(5)</a> <a href="#ref-for-definite-grid-position⑤">(6)</a> <a href="#ref-for-definite-grid-position⑥">(7)</a> <a href="#ref-for-definite-grid-position⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="automatic-grid-position">
-   <b><a href="#automatic-grid-position">#automatic-grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-automatic-grid-position" class="dfn-panel" data-for="automatic-grid-position" id="infopanel-for-automatic-grid-position" role="dialog">
+   <span id="infopaneltitle-for-automatic-grid-position" style="display:none">Info about the 'automatic' definition.</span><b><a href="#automatic-grid-position">#automatic-grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-grid-position">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-automatic-grid-position①">(2)</a> <a href="#ref-for-automatic-grid-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-span">
-   <b><a href="#grid-span">#grid-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-span" class="dfn-panel" data-for="grid-span" id="infopanel-for-grid-span" role="dialog">
+   <span id="infopaneltitle-for-grid-span" style="display:none">Info about the 'grid span' definition.</span><b><a href="#grid-span">#grid-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-span">5.4. 
 Limiting Large Grids</a>
@@ -9600,8 +9600,8 @@ Grid Item Placement Algorithm</a> <a href="#ref-for-grid-span⑤">(2)</a> <a hre
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement-property">
-   <b><a href="#grid-placement-property">#grid-placement-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement-property" class="dfn-panel" data-for="grid-placement-property" id="infopanel-for-grid-placement-property" role="dialog">
+   <span id="infopaneltitle-for-grid-placement-property" style="display:none">Info about the 'grid-placement properties' definition.</span><b><a href="#grid-placement-property">#grid-placement-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-property">2.2. 
 Placing Items</a>
@@ -9629,8 +9629,8 @@ Grid Item Placement Algorithm</a>
 With a Grid Container as Containing Block</a> <a href="#ref-for-grid-placement-property①⑥">(2)</a> <a href="#ref-for-grid-placement-property①⑦">(3)</a> <a href="#ref-for-grid-placement-property①⑧">(4)</a> <a href="#ref-for-grid-placement-property①⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row-start">
-   <b><a href="#propdef-grid-row-start">#propdef-grid-row-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row-start" class="dfn-panel" data-for="propdef-grid-row-start" id="infopanel-for-propdef-grid-row-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row-start" style="display:none">Info about the 'grid-row-start' definition.</span><b><a href="#propdef-grid-row-start">#propdef-grid-row-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-start">2.2. 
 Placing Items</a>
@@ -9646,8 +9646,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column-start">
-   <b><a href="#propdef-grid-column-start">#propdef-grid-column-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column-start" class="dfn-panel" data-for="propdef-grid-column-start" id="infopanel-for-propdef-grid-column-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column-start" style="display:none">Info about the 'grid-column-start' definition.</span><b><a href="#propdef-grid-column-start">#propdef-grid-column-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-start">2.2. 
 Placing Items</a>
@@ -9661,8 +9661,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-column-start⑧">(2)</a> <a href="#ref-for-propdef-grid-column-start⑨">(3)</a> <a href="#ref-for-propdef-grid-column-start①⓪">(4)</a> <a href="#ref-for-propdef-grid-column-start①①">(5)</a> <a href="#ref-for-propdef-grid-column-start①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row-end">
-   <b><a href="#propdef-grid-row-end">#propdef-grid-row-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row-end" class="dfn-panel" data-for="propdef-grid-row-end" id="infopanel-for-propdef-grid-row-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row-end" style="display:none">Info about the 'grid-row-end' definition.</span><b><a href="#propdef-grid-row-end">#propdef-grid-row-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-end">2.2. 
 Placing Items</a>
@@ -9678,8 +9678,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column-end">
-   <b><a href="#propdef-grid-column-end">#propdef-grid-column-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column-end" class="dfn-panel" data-for="propdef-grid-column-end" id="infopanel-for-propdef-grid-column-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column-end" style="display:none">Info about the 'grid-column-end' definition.</span><b><a href="#propdef-grid-column-end">#propdef-grid-column-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-end">2.2. 
 Placing Items</a>
@@ -9693,8 +9693,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-column-end⑦">(2)</a> <a href="#ref-for-propdef-grid-column-end⑧">(3)</a> <a href="#ref-for-propdef-grid-column-end⑨">(4)</a> <a href="#ref-for-propdef-grid-column-end①⓪">(5)</a> <a href="#ref-for-propdef-grid-column-end①①">(6)</a> <a href="#ref-for-propdef-grid-column-end①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-grid-row-start-grid-line">
-   <b><a href="#typedef-grid-row-start-grid-line">#typedef-grid-row-start-grid-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-grid-row-start-grid-line" class="dfn-panel" data-for="typedef-grid-row-start-grid-line" id="infopanel-for-typedef-grid-row-start-grid-line" role="dialog">
+   <span id="infopaneltitle-for-typedef-grid-row-start-grid-line" style="display:none">Info about the '&lt;grid-line>' definition.</span><b><a href="#typedef-grid-row-start-grid-line">#typedef-grid-row-start-grid-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-grid-row-start-grid-line">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-typedef-grid-row-start-grid-line①">(2)</a>
@@ -9702,8 +9702,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-typedef-grid-row-start-grid-line③">(2)</a> <a href="#ref-for-typedef-grid-row-start-grid-line④">(3)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑤">(4)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑥">(5)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement-auto">
-   <b><a href="#grid-placement-auto">#grid-placement-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement-auto" class="dfn-panel" data-for="grid-placement-auto" id="infopanel-for-grid-placement-auto" role="dialog">
+   <span id="infopaneltitle-for-grid-placement-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#grid-placement-auto">#grid-placement-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-auto">5.2. 
 Sizing Grid Containers</a> <a href="#ref-for-grid-placement-auto①">(2)</a>
@@ -9730,8 +9730,8 @@ Sample Fragmentation Algorithm</a> <a href="#ref-for-grid-placement-auto②②">
     <li><a href="#ref-for-grid-placement-auto②⑤"> Significant Adjustments and Fixes</a> <a href="#ref-for-grid-placement-auto②⑥">(2)</a> <a href="#ref-for-grid-placement-auto②⑦">(3)</a> <a href="#ref-for-grid-placement-auto②⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row">
-   <b><a href="#propdef-grid-row">#propdef-grid-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row" class="dfn-panel" data-for="propdef-grid-row" id="infopanel-for-propdef-grid-row" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row" style="display:none">Info about the 'grid-row' definition.</span><b><a href="#propdef-grid-row">#propdef-grid-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row">2.2. 
 Placing Items</a>
@@ -9747,8 +9747,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column">
-   <b><a href="#propdef-grid-column">#propdef-grid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column" class="dfn-panel" data-for="propdef-grid-column" id="infopanel-for-propdef-grid-column" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column" style="display:none">Info about the 'grid-column' definition.</span><b><a href="#propdef-grid-column">#propdef-grid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column">2.2. 
 Placing Items</a>
@@ -9762,8 +9762,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-column⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-area">
-   <b><a href="#propdef-grid-area">#propdef-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-area" class="dfn-panel" data-for="propdef-grid-area" id="infopanel-for-propdef-grid-area" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-area" style="display:none">Info about the 'grid-area' definition.</span><b><a href="#propdef-grid-area">#propdef-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-area">2.2. 
 Placing Items</a>
@@ -9777,8 +9777,8 @@ Named Areas</a>
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-area⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-item-placement-algorithm">
-   <b><a href="#grid-item-placement-algorithm">#grid-item-placement-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-item-placement-algorithm" class="dfn-panel" data-for="grid-item-placement-algorithm" id="infopanel-for-grid-item-placement-algorithm" role="dialog">
+   <span id="infopaneltitle-for-grid-item-placement-algorithm" style="display:none">Info about the 'grid item placement algorithm' definition.</span><b><a href="#grid-item-placement-algorithm">#grid-item-placement-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item-placement-algorithm">7.6. 
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
@@ -9790,59 +9790,59 @@ Auto Placement</a> <a href="#ref-for-grid-item-placement-algorithm⑦">(2)</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="occupied">
-   <b><a href="#occupied">#occupied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-occupied" class="dfn-panel" data-for="occupied" id="infopanel-for-occupied" role="dialog">
+   <span id="infopaneltitle-for-occupied" style="display:none">Info about the 'occupied' definition.</span><b><a href="#occupied">#occupied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-occupied">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-occupied①">(2)</a> <a href="#ref-for-occupied②">(3)</a> <a href="#ref-for-occupied③">(4)</a> <a href="#ref-for-occupied④">(5)</a> <a href="#ref-for-occupied⑤">(6)</a> <a href="#ref-for-occupied⑥">(7)</a> <a href="#ref-for-occupied⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unoccupied">
-   <b><a href="#unoccupied">#unoccupied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unoccupied" class="dfn-panel" data-for="unoccupied" id="infopanel-for-unoccupied" role="dialog">
+   <span id="infopaneltitle-for-unoccupied" style="display:none">Info about the 'unoccupied' definition.</span><b><a href="#unoccupied">#unoccupied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unoccupied">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-unoccupied①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auto-placement-cursor">
-   <b><a href="#auto-placement-cursor">#auto-placement-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auto-placement-cursor" class="dfn-panel" data-for="auto-placement-cursor" id="infopanel-for-auto-placement-cursor" role="dialog">
+   <span id="infopaneltitle-for-auto-placement-cursor" style="display:none">Info about the 'auto-placement cursor' definition.</span><b><a href="#auto-placement-cursor">#auto-placement-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auto-placement-cursor">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-auto-placement-cursor①">(2)</a> <a href="#ref-for-auto-placement-cursor②">(3)</a> <a href="#ref-for-auto-placement-cursor③">(4)</a> <a href="#ref-for-auto-placement-cursor④">(5)</a> <a href="#ref-for-auto-placement-cursor⑤">(6)</a> <a href="#ref-for-auto-placement-cursor⑥">(7)</a> <a href="#ref-for-auto-placement-cursor⑦">(8)</a> <a href="#ref-for-auto-placement-cursor⑧">(9)</a> <a href="#ref-for-auto-placement-cursor⑨">(10)</a> <a href="#ref-for-auto-placement-cursor①⓪">(11)</a> <a href="#ref-for-auto-placement-cursor①①">(12)</a> <a href="#ref-for-auto-placement-cursor①②">(13)</a> <a href="#ref-for-auto-placement-cursor①③">(14)</a> <a href="#ref-for-auto-placement-cursor①④">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-grid">
-   <b><a href="#augmented-grid">#augmented-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-grid" class="dfn-panel" data-for="augmented-grid" id="infopanel-for-augmented-grid" role="dialog">
+   <span id="infopaneltitle-for-augmented-grid" style="display:none">Info about the 'augmented grid' definition.</span><b><a href="#augmented-grid">#augmented-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-grid">10.1. 
 Gutters: the row-gap, column-gap, and gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsed-gutter">
-   <b><a href="#collapsed-gutter">#collapsed-gutter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsed-gutter" class="dfn-panel" data-for="collapsed-gutter" id="infopanel-for-collapsed-gutter" role="dialog">
+   <span id="infopaneltitle-for-collapsed-gutter" style="display:none">Info about the 'collapse' definition.</span><b><a href="#collapsed-gutter">#collapsed-gutter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-gutter">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
     <li><a href="#ref-for-collapsed-gutter①"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-order">
-   <b><a href="#grid-order">#grid-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-order" class="dfn-panel" data-for="grid-order" id="infopanel-for-grid-order" role="dialog">
+   <span id="infopaneltitle-for-grid-order" style="display:none">Info about the 'Grid-modified document order (grid order)' definition.</span><b><a href="#grid-order">#grid-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-order">10.6. 
 Grid Container Baselines</a>
     <li><a href="#ref-for-grid-order①"> Minor Changes</a> <a href="#ref-for-grid-order②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-sizing-algorithm">
-   <b><a href="#grid-sizing-algorithm">#grid-sizing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-sizing-algorithm" class="dfn-panel" data-for="grid-sizing-algorithm" id="infopanel-for-grid-sizing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-grid-sizing-algorithm" style="display:none">Info about the 'grid sizing algorithm' definition.</span><b><a href="#grid-sizing-algorithm">#grid-sizing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-sizing-algorithm">11. 
 Grid Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fixed-sizing-function">
-   <b><a href="#fixed-sizing-function">#fixed-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fixed-sizing-function" class="dfn-panel" data-for="fixed-sizing-function" id="infopanel-for-fixed-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-fixed-sizing-function" style="display:none">Info about the 'fixed sizing function' definition.</span><b><a href="#fixed-sizing-function">#fixed-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-fixed-sizing-function①">(2)</a> <a href="#ref-for-fixed-sizing-function②">(3)</a>
@@ -9857,8 +9857,8 @@ Distributing Extra Space Across Spanned Tracks</a>
     <li><a href="#ref-for-fixed-sizing-function①②"> Significant Adjustments and Fixes</a> <a href="#ref-for-fixed-sizing-function①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-sizing-function">
-   <b><a href="#intrinsic-sizing-function">#intrinsic-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-sizing-function" class="dfn-panel" data-for="intrinsic-sizing-function" id="infopanel-for-intrinsic-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-sizing-function" style="display:none">Info about the 'intrinsic sizing function' definition.</span><b><a href="#intrinsic-sizing-function">#intrinsic-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-sizing-function">3.3. 
 Grid Areas</a>
@@ -9871,8 +9871,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-intrinsic-sizing-function⑤
     <li><a href="#ref-for-intrinsic-sizing-function⑥"> Minor Changes</a> <a href="#ref-for-intrinsic-sizing-function⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible-sizing-function">
-   <b><a href="#flexible-sizing-function">#flexible-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible-sizing-function" class="dfn-panel" data-for="flexible-sizing-function" id="infopanel-for-flexible-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-flexible-sizing-function" style="display:none">Info about the 'flexible sizing function' definition.</span><b><a href="#flexible-sizing-function">#flexible-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible-sizing-function">7.2.3.1. 
 Syntax of repeat()</a>
@@ -9885,8 +9885,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-flexible-sizing-function③"
     <li><a href="#ref-for-flexible-sizing-function①⑤"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-track-sizing-function">
-   <b><a href="#min-track-sizing-function">#min-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-track-sizing-function" class="dfn-panel" data-for="min-track-sizing-function" id="infopanel-for-min-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-min-track-sizing-function" style="display:none">Info about the 'min track sizing function' definition.</span><b><a href="#min-track-sizing-function">#min-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-track-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9909,8 +9909,8 @@ Distributing Extra Space Across Spanned Tracks</a>
     <li><a href="#ref-for-min-track-sizing-function②①"> Significant Adjustments and Fixes</a> <a href="#ref-for-min-track-sizing-function②②">(2)</a> <a href="#ref-for-min-track-sizing-function②③">(3)</a> <a href="#ref-for-min-track-sizing-function②④">(4)</a> <a href="#ref-for-min-track-sizing-function②⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-track-sizing-function">
-   <b><a href="#max-track-sizing-function">#max-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-track-sizing-function" class="dfn-panel" data-for="max-track-sizing-function" id="infopanel-for-max-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-max-track-sizing-function" style="display:none">Info about the 'max track sizing function' definition.</span><b><a href="#max-track-sizing-function">#max-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-track-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-max-track-sizing-function①">(2)</a> <a href="#ref-for-max-track-sizing-function②">(3)</a>
@@ -9938,8 +9938,8 @@ Stretch auto Tracks</a>
     <li><a href="#ref-for-max-track-sizing-function③③"> Significant Adjustments and Fixes</a> <a href="#ref-for-max-track-sizing-function③④">(2)</a> <a href="#ref-for-max-track-sizing-function③⑤">(3)</a> <a href="#ref-for-max-track-sizing-function③⑥">(4)</a> <a href="#ref-for-max-track-sizing-function③⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-grid-space">
-   <b><a href="#available-grid-space">#available-grid-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-grid-space" class="dfn-panel" data-for="available-grid-space" id="infopanel-for-available-grid-space" role="dialog">
+   <span id="infopaneltitle-for-available-grid-space" style="display:none">Info about the 'available grid space' definition.</span><b><a href="#available-grid-space">#available-grid-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-grid-space">11.2. 
 Track Sizing Terminology</a> <a href="#ref-for-available-grid-space①">(2)</a> <a href="#ref-for-available-grid-space②">(3)</a> <a href="#ref-for-available-grid-space③">(4)</a> <a href="#ref-for-available-grid-space④">(5)</a>
@@ -9949,8 +9949,8 @@ Maximize Tracks</a>
 Expand Flexible Tracks</a> <a href="#ref-for-available-grid-space⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="free-space">
-   <b><a href="#free-space">#free-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-free-space" class="dfn-panel" data-for="free-space" id="infopanel-for-free-space" role="dialog">
+   <span id="infopaneltitle-for-free-space" style="display:none">Info about the 'free space' definition.</span><b><a href="#free-space">#free-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-free-space">7.2.1. 
 Track Sizes</a> <a href="#ref-for-free-space①">(2)</a>
@@ -9967,8 +9967,8 @@ Stretch auto Tracks</a> <a href="#ref-for-free-space①①">(2)</a> <a href="#re
     <li><a href="#ref-for-free-space①⑦"> Clarifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-sizing-algorithm">
-   <b><a href="#track-sizing-algorithm">#track-sizing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-sizing-algorithm" class="dfn-panel" data-for="track-sizing-algorithm" id="infopanel-for-track-sizing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-track-sizing-algorithm" style="display:none">Info about the 'track sizing algorithm' definition.</span><b><a href="#track-sizing-algorithm">#track-sizing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-sizing-algorithm">7.2.1. 
 Track Sizes</a>
@@ -9981,8 +9981,8 @@ Initialize Track Sizes</a>
     <li><a href="#ref-for-track-sizing-algorithm⑤"> Clarifications</a> <a href="#ref-for-track-sizing-algorithm⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-size">
-   <b><a href="#base-size">#base-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-size" class="dfn-panel" data-for="base-size" id="infopanel-for-base-size" role="dialog">
+   <span id="infopaneltitle-for-base-size" style="display:none">Info about the 'base size' definition.</span><b><a href="#base-size">#base-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-size">11.2. 
 Track Sizing Terminology</a>
@@ -10006,8 +10006,8 @@ Find the Size of an fr</a>
     <li><a href="#ref-for-base-size③⑥"> Significant Adjustments and Fixes</a> <a href="#ref-for-base-size③⑦">(2)</a> <a href="#ref-for-base-size③⑧">(3)</a> <a href="#ref-for-base-size③⑨">(4)</a> <a href="#ref-for-base-size④⓪">(5)</a> <a href="#ref-for-base-size④①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="growth-limit">
-   <b><a href="#growth-limit">#growth-limit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-growth-limit" class="dfn-panel" data-for="growth-limit" id="infopanel-for-growth-limit" role="dialog">
+   <span id="infopaneltitle-for-growth-limit" style="display:none">Info about the 'growth limit' definition.</span><b><a href="#growth-limit">#growth-limit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-growth-limit">11.4. 
 Initialize Track Sizes</a> <a href="#ref-for-growth-limit①">(2)</a> <a href="#ref-for-growth-limit②">(3)</a> <a href="#ref-for-growth-limit③">(4)</a>
@@ -10023,15 +10023,15 @@ Maximize Tracks</a>
     <li><a href="#ref-for-growth-limit④①"> Significant Adjustments and Fixes</a> <a href="#ref-for-growth-limit④②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="limited-contribution">
-   <b><a href="#limited-contribution">#limited-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limited-contribution" class="dfn-panel" data-for="limited-contribution" id="infopanel-for-limited-contribution" role="dialog">
+   <span id="infopaneltitle-for-limited-contribution" style="display:none">Info about the 'limited min-/max-content contribution' definition.</span><b><a href="#limited-contribution">#limited-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limited-contribution">11.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-limited-contribution①">(2)</a> <a href="#ref-for-limited-contribution②">(3)</a> <a href="#ref-for-limited-contribution③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-contribution">
-   <b><a href="#minimum-contribution">#minimum-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-contribution" class="dfn-panel" data-for="minimum-contribution" id="infopanel-for-minimum-contribution" role="dialog">
+   <span id="infopaneltitle-for-minimum-contribution" style="display:none">Info about the 'minimum contribution' definition.</span><b><a href="#minimum-contribution">#minimum-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-contribution">11.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-minimum-contribution①">(2)</a> <a href="#ref-for-minimum-contribution②">(3)</a> <a href="#ref-for-minimum-contribution③">(4)</a> <a href="#ref-for-minimum-contribution④">(5)</a> <a href="#ref-for-minimum-contribution⑤">(6)</a> <a href="#ref-for-minimum-contribution⑥">(7)</a> <a href="#ref-for-minimum-contribution⑦">(8)</a> <a href="#ref-for-minimum-contribution⑧">(9)</a>
@@ -10040,8 +10040,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-minimum-contribution①">(2)
     <li><a href="#ref-for-minimum-contribution①①"> Clarifications</a> <a href="#ref-for-minimum-contribution①②">(2)</a> <a href="#ref-for-minimum-contribution①③">(3)</a> <a href="#ref-for-minimum-contribution①④">(4)</a> <a href="#ref-for-minimum-contribution①⑤">(5)</a> <a href="#ref-for-minimum-contribution①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="infinitely-growable">
-   <b><a href="#infinitely-growable">#infinitely-growable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-infinitely-growable" class="dfn-panel" data-for="infinitely-growable" id="infopanel-for-infinitely-growable" role="dialog">
+   <span id="infopaneltitle-for-infinitely-growable" style="display:none">Info about the 'infinitely growable' definition.</span><b><a href="#infinitely-growable">#infinitely-growable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-infinitely-growable">11.5. 
 Resolve Intrinsic Track Sizes</a>
@@ -10050,15 +10050,15 @@ Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-infinitely-
     <li><a href="#ref-for-infinitely-growable③"> Clarifications</a> <a href="#ref-for-infinitely-growable④">(2)</a> <a href="#ref-for-infinitely-growable⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distribute-extra-space">
-   <b><a href="#distribute-extra-space">#distribute-extra-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distribute-extra-space" class="dfn-panel" data-for="distribute-extra-space" id="infopanel-for-distribute-extra-space" role="dialog">
+   <span id="infopaneltitle-for-distribute-extra-space" style="display:none">Info about the 'distribute extra space' definition.</span><b><a href="#distribute-extra-space">#distribute-extra-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distribute-extra-space"> Major Changes</a>
     <li><a href="#ref-for-distribute-extra-space①"> Significant Adjustments and Fixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="space-to-fill">
-   <b><a href="#space-to-fill">#space-to-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-space-to-fill" class="dfn-panel" data-for="space-to-fill" id="infopanel-for-space-to-fill" role="dialog">
+   <span id="infopaneltitle-for-space-to-fill" style="display:none">Info about the 'space to fill' definition.</span><b><a href="#space-to-fill">#space-to-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-space-to-fill">11.7. 
 Expand Flexible Tracks</a> <a href="#ref-for-space-to-fill①">(2)</a>
@@ -10066,8 +10066,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-space-to-fill①">(2)</a>
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="leftover-space">
-   <b><a href="#leftover-space">#leftover-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-leftover-space" class="dfn-panel" data-for="leftover-space" id="infopanel-for-leftover-space" role="dialog">
+   <span id="infopaneltitle-for-leftover-space" style="display:none">Info about the 'leftover space' definition.</span><b><a href="#leftover-space">#leftover-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-leftover-space">7.2.1. 
 Track Sizes</a> <a href="#ref-for-leftover-space①">(2)</a>
@@ -10077,15 +10077,15 @@ Flexible Lengths: the fr unit</a> <a href="#ref-for-leftover-space③">(2)</a> <
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-factor-sum">
-   <b><a href="#flex-factor-sum">#flex-factor-sum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-factor-sum" class="dfn-panel" data-for="flex-factor-sum" id="infopanel-for-flex-factor-sum" role="dialog">
+   <span id="infopaneltitle-for-flex-factor-sum" style="display:none">Info about the 'flex factor sum' definition.</span><b><a href="#flex-factor-sum">#flex-factor-sum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-factor-sum">11.7.1. 
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hypothetical-fr-size">
-   <b><a href="#hypothetical-fr-size">#hypothetical-fr-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hypothetical-fr-size" class="dfn-panel" data-for="hypothetical-fr-size" id="infopanel-for-hypothetical-fr-size" role="dialog">
+   <span id="infopaneltitle-for-hypothetical-fr-size" style="display:none">Info about the 'hypothetical fr size' definition.</span><b><a href="#hypothetical-fr-size">#hypothetical-fr-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hypothetical-fr-size">11.7.1. 
 Find the Size of an fr</a> <a href="#ref-for-hypothetical-fr-size①">(2)</a>
@@ -10093,59 +10093,115 @@ Find the Size of an fr</a> <a href="#ref-for-hypothetical-fr-size①">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-grid-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-2/Overview.html
@@ -5721,8 +5721,8 @@ which we considered a better result because the first track remains sized exactl
    <li><a href="#grid-template-areas-trash-token">trash token</a><span>, in § 7.3</span>
    <li><a href="#unoccupied">unoccupied</a><span>, in § 8.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">2.3. 
 Sizing the Grid</a>
@@ -5738,15 +5738,15 @@ Aligning the Grid: the justify-content and align-content properties</a> <a href=
 Grid Sizing Algorithm</a> <a href="#ref-for-propdef-align-content⑨">(2)</a> <a href="#ref-for-propdef-align-content①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-items" class="dfn-panel" data-for="term-for-propdef-align-items" id="infopanel-for-term-for-propdef-align-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-items" style="display:none">Info about the 'align-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">11.4. 
 Block-axis Alignment: the align-self and align-items properties</a> <a href="#ref-for-propdef-align-items①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">6.2. 
 	Grid Item Sizing</a>
@@ -5762,22 +5762,22 @@ Alignment and Spacing</a>
 Block-axis Alignment: the align-self and align-items properties</a> <a href="#ref-for-propdef-align-self⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-baseline" class="dfn-panel" data-for="term-for-alignment-baseline" id="infopanel-for-term-for-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-baseline" style="display:none">Info about the 'alignment baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-baseline">https://drafts.csswg.org/css-align-3/#alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-baseline">11.6. 
 Grid Container Baselines</a> <a href="#ref-for-alignment-baseline①">(2)</a> <a href="#ref-for-alignment-baseline②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-alignment-context">
-   <a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-alignment-context" class="dfn-panel" data-for="term-for-shared-alignment-context" id="infopanel-for-term-for-shared-alignment-context" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-alignment-context" style="display:none">Info about the 'alignment context' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-alignment-context">11.6. 
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-alignment" class="dfn-panel" data-for="term-for-baseline-alignment" id="infopanel-for-term-for-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-alignment" style="display:none">Info about the 'baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment">11.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a>
@@ -5787,22 +5787,22 @@ Block-axis Alignment: the align-self and align-items properties</a>
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-set" class="dfn-panel" data-for="term-for-baseline-set" id="infopanel-for-term-for-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-set" style="display:none">Info about the 'baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-set">https://drafts.csswg.org/css-align-3/#baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-set">11.6. 
 Grid Container Baselines</a> <a href="#ref-for-baseline-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-sharing-group">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-sharing-group" class="dfn-panel" data-for="term-for-baseline-sharing-group" id="infopanel-for-term-for-baseline-sharing-group" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-sharing-group" style="display:none">Info about the 'baseline-sharing group' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-sharing-group">12.5. 
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-alignment-properties">
-   <a href="https://drafts.csswg.org/css-align-3/#box-alignment-properties">https://drafts.csswg.org/css-align-3/#box-alignment-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-alignment-properties" class="dfn-panel" data-for="term-for-box-alignment-properties" id="infopanel-for-term-for-box-alignment-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-box-alignment-properties" style="display:none">Info about the 'box alignment properties' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#box-alignment-properties">https://drafts.csswg.org/css-align-3/#box-alignment-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-alignment-properties">2.3. 
 Sizing the Grid</a>
@@ -5812,15 +5812,15 @@ Alignment and Spacing</a>
 Aligning with auto margins</a> <a href="#ref-for-box-alignment-properties③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">7.2.1. 
 Track Sizes</a>
@@ -5830,15 +5830,15 @@ Subgrids</a> <a href="#ref-for-propdef-column-gap②">(2)</a> <a href="#ref-for-
 Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-propdef-column-gap①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-distributed-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#distributed-alignment">https://drafts.csswg.org/css-align-3/#distributed-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-distributed-alignment" class="dfn-panel" data-for="term-for-distributed-alignment" id="infopanel-for-term-for-distributed-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-distributed-alignment" style="display:none">Info about the 'distributed alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#distributed-alignment">https://drafts.csswg.org/css-align-3/#distributed-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distributed-alignment">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fallback-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#fallback-alignment">https://drafts.csswg.org/css-align-3/#fallback-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fallback-alignment" class="dfn-panel" data-for="term-for-fallback-alignment" id="infopanel-for-term-for-fallback-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-fallback-alignment" style="display:none">Info about the 'fallback alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#fallback-alignment">https://drafts.csswg.org/css-align-3/#fallback-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback-alignment">11.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a>
@@ -5846,8 +5846,8 @@ Inline-axis Alignment: the justify-self and justify-items properties</a>
 Block-axis Alignment: the align-self and align-items properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-gap" class="dfn-panel" data-for="term-for-propdef-gap" id="infopanel-for-term-for-propdef-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-gap" style="display:none">Info about the 'gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-gap">https://drafts.csswg.org/css-align-3/#propdef-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-gap">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
@@ -5857,15 +5857,15 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-propd
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generate-baselines">
-   <a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generate-baselines" class="dfn-panel" data-for="term-for-generate-baselines" id="infopanel-for-term-for-generate-baselines" role="menu">
+   <span id="infopaneltitle-for-term-for-generate-baselines" style="display:none">Info about the 'generate baselines' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#generate-baselines">https://drafts.csswg.org/css-align-3/#generate-baselines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-baselines">11.6. 
 Grid Container Baselines</a> <a href="#ref-for-generate-baselines①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gutter">
-   <a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gutter" class="dfn-panel" data-for="term-for-gutter" id="infopanel-for-term-for-gutter" role="menu">
+   <span id="infopaneltitle-for-term-for-gutter" style="display:none">Info about the 'gutter' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gutter">2. 
 Overview</a>
@@ -5883,8 +5883,8 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-gutte
 Initialize Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">2.3. 
 Sizing the Grid</a>
@@ -5900,15 +5900,15 @@ Aligning the Grid: the justify-content and align-content properties</a> <a href=
 Grid Sizing Algorithm</a> <a href="#ref-for-propdef-justify-content⑨">(2)</a> <a href="#ref-for-propdef-justify-content①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-items" class="dfn-panel" data-for="term-for-propdef-justify-items" id="infopanel-for-term-for-propdef-justify-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-items" style="display:none">Info about the 'justify-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-items">https://drafts.csswg.org/css-align-3/#propdef-justify-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-items">11.3. 
 Inline-axis Alignment: the justify-self and justify-items properties</a> <a href="#ref-for-propdef-justify-items①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">8. 
 Placing Grid Items</a>
@@ -5922,29 +5922,29 @@ Alignment and Spacing</a>
 Inline-axis Alignment: the justify-self and justify-items properties</a> <a href="#ref-for-propdef-justify-self⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-normal" class="dfn-panel" data-for="term-for-valdef-align-self-normal" id="infopanel-for-term-for-valdef-align-self-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-normal" style="display:none">Info about the 'normal (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-normal">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-valdef-align-self-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-row-gap-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal">https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-row-gap-normal" class="dfn-panel" data-for="term-for-valdef-row-gap-normal" id="infopanel-for-term-for-valdef-row-gap-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-row-gap-normal" style="display:none">Info about the 'normal (for row-gap)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal">https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-row-gap-normal">9. 
 Subgrids</a> <a href="#ref-for-valdef-row-gap-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-content" class="dfn-panel" data-for="term-for-propdef-place-content" id="infopanel-for-term-for-propdef-place-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-content" style="display:none">Info about the 'place-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-content">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-row-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-row-gap" class="dfn-panel" data-for="term-for-propdef-row-gap" id="infopanel-for-term-for-propdef-row-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-row-gap" style="display:none">Info about the 'row-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-row-gap">https://drafts.csswg.org/css-align-3/#propdef-row-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-row-gap">7.2.1. 
 Track Sizes</a>
@@ -5954,43 +5954,43 @@ Subgrids</a>
 Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-propdef-row-gap③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-around">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-around" class="dfn-panel" data-for="term-for-valdef-align-content-space-around" id="infopanel-for-term-for-valdef-align-content-space-around" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-around" style="display:none">Info about the 'space-around' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-around">11.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-between">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-between" class="dfn-panel" data-for="term-for-valdef-align-content-space-between" id="infopanel-for-term-for-valdef-align-content-space-between" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-between" style="display:none">Info about the 'space-between' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-between">11.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-space-evenly">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-space-evenly" class="dfn-panel" data-for="term-for-valdef-align-content-space-evenly" id="infopanel-for-term-for-valdef-align-content-space-evenly" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-space-evenly" style="display:none">Info about the 'space-evenly' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-space-evenly">11.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-stretch" class="dfn-panel" data-for="term-for-valdef-align-content-stretch" id="infopanel-for-term-for-valdef-align-content-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-stretch" style="display:none">Info about the 'stretch (for align-content)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-stretch">11.5. 
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-stretch" class="dfn-panel" data-for="term-for-valdef-align-self-stretch" id="infopanel-for-term-for-valdef-align-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">4. 
 Reordering and Accessibility</a>
@@ -5998,29 +5998,29 @@ Reordering and Accessibility</a>
 	Grid Item Sizing</a> <a href="#ref-for-valdef-align-self-stretch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-self-stretch" class="dfn-panel" data-for="term-for-valdef-justify-self-stretch" id="infopanel-for-term-for-valdef-justify-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-self-stretch" style="display:none">Info about the 'stretch (for justify-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-stretch">11. 
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-synthesize-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-synthesize-baseline" class="dfn-panel" data-for="term-for-synthesize-baseline" id="infopanel-for-term-for-synthesize-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-synthesize-baseline" style="display:none">Info about the 'synthesize baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">11.6. 
 Grid Container Baselines</a> <a href="#ref-for-synthesize-baseline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">13. 
 Fragmenting Grid Layout</a> <a href="#ref-for-fragmentation-container①">(2)</a>
@@ -6028,15 +6028,15 @@ Fragmenting Grid Layout</a> <a href="#ref-for-fragmentation-container①">(2)</a
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">13. 
 Fragmenting Grid Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.1. 
 	Grid Item Display</a>
@@ -6046,8 +6046,8 @@ Resolved Value of a Standalone Track Listing</a>
 Serialization Of Template Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">7.1. 
 The Explicit Grid</a>
@@ -6061,8 +6061,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-shorthand-pro
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">7.2.6.2. 
 Resolved Value of a Subgridded Track Listing</a>
@@ -6070,15 +6070,15 @@ Resolved Value of a Subgridded Track Listing</a>
 Serialization Of Template Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">7.8. 
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">7.2.6.1. 
 Resolved Value of a Standalone Track Listing</a>
@@ -6086,15 +6086,15 @@ Resolved Value of a Standalone Track Listing</a>
 Resolved Value of a Subgridded Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">5.2. 
 Sizing Grid Containers</a>
@@ -6102,8 +6102,8 @@ Sizing Grid Containers</a>
 Grid Item Margins and Paddings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">6. 
 Grid Items</a>
@@ -6111,8 +6111,8 @@ Grid Items</a>
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -6120,8 +6120,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a>
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -6129,15 +6129,15 @@ Establishing Grid Containers: the grid and inline-grid display values</a>
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">6.1. 
 	Grid Item Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">6.4. 
 Grid Item Margins and Paddings</a> <a href="#ref-for-containing-block①">(2)</a>
@@ -6151,8 +6151,8 @@ With a Grid Container as Parent</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.4. 
 Nested vs. Subgridded Items</a>
@@ -6164,50 +6164,50 @@ Establishing Grid Containers: the grid and inline-grid display values</a> <a hre
 Resolved Value of a Standalone Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">6.1. 
 	Grid Item Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-layout" class="dfn-panel" data-for="term-for-flow-layout" id="infopanel-for-term-for-flow-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-layout" style="display:none">Info about the 'flow layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-flow-layout①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-independent-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">5.2. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">15.1. 
 Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-order">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-order" class="dfn-panel" data-for="term-for-propdef-order" id="infopanel-for-term-for-propdef-order" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-order" style="display:none">Info about the 'order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">4. 
 Reordering and Accessibility</a> <a href="#ref-for-propdef-order①">(2)</a> <a href="#ref-for-propdef-order②">(3)</a>
@@ -6215,8 +6215,8 @@ Reordering and Accessibility</a> <a href="#ref-for-propdef-order①">(2)</a> <a 
 Reordered Grid Items: the order property</a> <a href="#ref-for-propdef-order④">(2)</a> <a href="#ref-for-propdef-order⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-order-modified-document-order">
-   <a href="https://drafts.csswg.org/css-display-3/#order-modified-document-order">https://drafts.csswg.org/css-display-3/#order-modified-document-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-order-modified-document-order" class="dfn-panel" data-for="term-for-order-modified-document-order" id="infopanel-for-term-for-order-modified-document-order" role="menu">
+   <span id="infopaneltitle-for-term-for-order-modified-document-order" style="display:none">Info about the 'order-modified document order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#order-modified-document-order">https://drafts.csswg.org/css-display-3/#order-modified-document-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-order-modified-document-order">6.5. 
 Z-axis Ordering: the z-index property</a>
@@ -6228,8 +6228,8 @@ Grid Item Placement Algorithm</a> <a href="#ref-for-order-modified-document-orde
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">6.1. 
 	Grid Item Display</a>
@@ -6241,22 +6241,22 @@ Automatic Minimum Size of Grid Items</a>
 Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">6. 
 Grid Items</a> <a href="#ref-for-text-run①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">2. 
 Overview</a>
@@ -6266,8 +6266,8 @@ Flexible Lengths: the fr unit</a>
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">2.2. 
 Placing Items</a>
@@ -6277,36 +6277,36 @@ Placing Items</a>
 Flexible Lengths: the fr unit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">12.1. 
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-natural-size①">(2)</a> <a href="#ref-for-natural-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">12.1. 
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">5.3. 
 Scrollable Grid Overflow</a>
@@ -6316,8 +6316,8 @@ Subgrids</a>
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">5.3. 
 Scrollable Grid Overflow</a>
@@ -6325,85 +6325,85 @@ Scrollable Grid Overflow</a>
 Automatic Minimum Size of Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-rectangle" class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle" id="infopanel-for-term-for-scrollable-overflow-rectangle" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-rectangle" style="display:none">Info about the 'scrollable overflow rectangle' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-rectangle">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow region' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">5.3. 
 Scrollable Grid Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">10.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">10.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">6.5. 
 Z-axis Ordering: the z-index property</a> <a href="#ref-for-propdef-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">10.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">10.1. 
 With a Grid Container as Containing Block</a> <a href="#ref-for-propdef-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">6.2. 
 	Grid Item Sizing</a>
@@ -6413,22 +6413,22 @@ Track Sizes</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-minimum-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-minimum-size" class="dfn-panel" data-for="term-for-automatic-minimum-size" id="infopanel-for-term-for-automatic-minimum-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-automatic-minimum-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a>
@@ -6436,8 +6436,8 @@ Grid Sizing Algorithm</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto" style="display:none">Info about the 'behave as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -6445,8 +6445,8 @@ Automatic Minimum Size of Grid Items</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto①" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto①" style="display:none">Info about the 'behaves as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -6454,8 +6454,8 @@ Automatic Minimum Size of Grid Items</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-definite①">(2)</a> <a href="#ref-for-definite②">(3)</a> <a href="#ref-for-definite③">(4)</a> <a href="#ref-for-definite④">(5)</a>
@@ -6471,8 +6471,8 @@ Expand Flexible Tracks</a>
 Stretch auto Tracks</a> <a href="#ref-for-definite①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indefinite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indefinite" class="dfn-panel" data-for="term-for-indefinite" id="infopanel-for-term-for-indefinite" role="menu">
+   <span id="infopaneltitle-for-term-for-indefinite" style="display:none">Info about the 'indefinite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">7.2.4. 
 Flexible Lengths: the fr unit</a>
@@ -6492,8 +6492,8 @@ Expand Flexible Tracks</a>
 Stretch auto Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">7.2.1. 
 Track Sizes</a> <a href="#ref-for-inner-size①">(2)</a>
@@ -6503,8 +6503,8 @@ Maximize Tracks</a> <a href="#ref-for-inner-size③">(2)</a>
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -6514,8 +6514,8 @@ Resolve Intrinsic Track Sizes</a>
 Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-constraint" class="dfn-panel" data-for="term-for-max-content-constraint" id="infopanel-for-term-for-max-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-constraint" style="display:none">Info about the 'max-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-constraint">5.2. 
 Sizing Grid Containers</a>
@@ -6527,8 +6527,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-max-content-constraint③">(
 Maximize Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-contribution" class="dfn-panel" data-for="term-for-max-content-contribution" id="infopanel-for-term-for-max-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-contribution" style="display:none">Info about the 'max-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-contribution">https://drafts.csswg.org/css-sizing-3/#max-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-contribution">7.2.1. 
 Track Sizes</a> <a href="#ref-for-max-content-contribution①">(2)</a>
@@ -6540,22 +6540,22 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-max-content-contribution⑤"
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">5.2. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'maximum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-max-width①">(2)</a> <a href="#ref-for-max-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-constraint" class="dfn-panel" data-for="term-for-min-content-constraint" id="infopanel-for-term-for-min-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-constraint" style="display:none">Info about the 'min-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-constraint">5.2. 
 Sizing Grid Containers</a>
@@ -6569,8 +6569,8 @@ Maximize Tracks</a>
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-contribution" class="dfn-panel" data-for="term-for-min-content-contribution" id="infopanel-for-term-for-min-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">7.2.1. 
 Track Sizes</a>
@@ -6580,8 +6580,8 @@ Grid Sizing Algorithm</a> <a href="#ref-for-min-content-contribution②">(2)</a>
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-min-content-contribution⑥">(2)</a> <a href="#ref-for-min-content-contribution⑦">(3)</a> <a href="#ref-for-min-content-contribution⑧">(4)</a> <a href="#ref-for-min-content-contribution⑨">(5)</a> <a href="#ref-for-min-content-contribution①⓪">(6)</a> <a href="#ref-for-min-content-contribution①①">(7)</a> <a href="#ref-for-min-content-contribution①②">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5.2. 
 Sizing Grid Containers</a>
@@ -6589,8 +6589,8 @@ Sizing Grid Containers</a>
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-min-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-min-width①">(2)</a> <a href="#ref-for-min-width②">(3)</a>
@@ -6600,15 +6600,15 @@ Track Sizes</a>
 Resolve Intrinsic Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">12.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-outer-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size" class="dfn-panel" data-for="term-for-preferred-size" id="infopanel-for-term-for-preferred-size" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size" style="display:none">Info about the 'preferred size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-preferred-size①">(2)</a>
@@ -6616,8 +6616,8 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-preferred-size①">(2
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-preferred-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit" class="dfn-panel" data-for="term-for-stretch-fit" id="infopanel-for-term-for-stretch-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit" style="display:none">Info about the 'stretch fit' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -6625,22 +6625,22 @@ Automatic Minimum Size of Grid Items</a>
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">6.2. 
 	Grid Item Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">6.6. 
 Automatic Minimum Size of Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">15.1. 
 Changes since the 18 December 2020 CR</a>
@@ -6648,8 +6648,8 @@ Changes since the 18 December 2020 CR</a>
 Changes since the August 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-valdef-width-fit-content①">(2)</a>
@@ -6657,8 +6657,8 @@ Changes since the August 2020 CR</a>
 Automatic Minimum Size of Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">6.2. 
 	Grid Item Sizing</a> <a href="#ref-for-preferred-aspect-ratio①">(2)</a>
@@ -6668,22 +6668,22 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-preferred-aspect-rati
 Changes since the August 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-whitespace">
-   <a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-whitespace" class="dfn-panel" data-for="term-for-whitespace" id="infopanel-for-term-for-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-whitespace" style="display:none">Info about the 'whitespace' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">7.3. 
 Named Areas: the grid-template-areas property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">6. 
 Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">7.8. 
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-all①">(2)</a>
@@ -6691,15 +6691,15 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-all①">
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-comb-all③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-zero-plus①">(2)</a> <a href="#ref-for-mult-zero-plus②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-one-plus①">(2)</a> <a href="#ref-for-mult-one-plus②">(3)</a>
@@ -6713,8 +6713,8 @@ Explicit Grid Shorthand: the grid-template property</a>
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-comb-comma①">(2)</a> <a href="#ref-for-comb-comma②">(3)</a>
@@ -6722,8 +6722,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-comb-comma④">(2)</a> <a href="#ref-for-comb-comma⑤">(3)</a> <a href="#ref-for-comb-comma⑥">(4)</a> <a href="#ref-for-comb-comma⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -6735,15 +6735,15 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-identifier-value①⑥">(2)</a> <a href="#ref-for-identifier-value①⑦">(3)</a> <a href="#ref-for-identifier-value①⑧">(4)</a> <a href="#ref-for-identifier-value①⑨">(5)</a> <a href="#ref-for-identifier-value②⓪">(6)</a> <a href="#ref-for-identifier-value②①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">7.3. 
 Named Areas: the grid-template-areas property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">7.2.3.1. 
 Syntax of repeat()</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a> <a href="#ref-for-integer-value③">(4)</a>
@@ -6753,8 +6753,8 @@ Computed Value of a Track Listing</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-integer-value⑥">(2)</a> <a href="#ref-for-integer-value⑦">(3)</a> <a href="#ref-for-integer-value⑧">(4)</a> <a href="#ref-for-integer-value⑨">(5)</a> <a href="#ref-for-integer-value①⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a>
@@ -6764,8 +6764,8 @@ Track Sizes</a> <a href="#ref-for-typedef-length-percentage⑤">(2)</a>
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">7.2.4. 
 Flexible Lengths: the fr unit</a> <a href="#ref-for-length-value①">(2)</a>
@@ -6775,8 +6775,8 @@ Grid Sizing</a>
 Track Sizing Algorithm</a> <a href="#ref-for-length-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">7.2.1. 
 Track Sizes</a> <a href="#ref-for-percentage-value①">(2)</a>
@@ -6786,8 +6786,8 @@ Flexible Lengths: the fr unit</a>
 Grid Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-string-value①">(2)</a>
@@ -6797,8 +6797,8 @@ Serialization Of Template Strings</a>
 Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-string-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a> <a href="#ref-for-mult-opt④">(5)</a> <a href="#ref-for-mult-opt⑤">(6)</a> <a href="#ref-for-mult-opt⑥">(7)</a> <a href="#ref-for-mult-opt⑦">(8)</a> <a href="#ref-for-mult-opt⑧">(9)</a>
@@ -6814,29 +6814,29 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">7.2.4. 
 Flexible Lengths: the fr unit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">8.4. 
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -6856,8 +6856,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-comb-one②�
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-comb-one③⓪">(2)</a> <a href="#ref-for-comb-one③①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">7.7. 
 Automatic Placement: the grid-auto-flow property</a>
@@ -6865,15 +6865,15 @@ Automatic Placement: the grid-auto-flow property</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a> <a href="#ref-for-block-axis④">(5)</a> <a href="#ref-for-block-axis⑤">(6)</a> <a href="#ref-for-block-axis⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">5.2. 
 Sizing Grid Containers</a>
@@ -6883,43 +6883,43 @@ Track Sizes</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-block-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis①" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a> <a href="#ref-for-block-axis④">(5)</a> <a href="#ref-for-block-axis⑤">(6)</a> <a href="#ref-for-block-axis⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">10.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-inline-axis①">(2)</a> <a href="#ref-for-inline-axis②">(3)</a> <a href="#ref-for-inline-axis③">(4)</a> <a href="#ref-for-inline-axis④">(5)</a> <a href="#ref-for-inline-axis⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.2. 
 Sizing Grid Containers</a>
@@ -6933,43 +6933,43 @@ Track Sizes</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-inline-size⑤">(2)</a> <a href="#ref-for-inline-size⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis①" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-inline-axis①">(2)</a> <a href="#ref-for-inline-axis②">(3)</a> <a href="#ref-for-inline-axis③">(4)</a> <a href="#ref-for-inline-axis④">(5)</a> <a href="#ref-for-inline-axis⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-orthogonal-flow">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow">https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-orthogonal-flow" class="dfn-panel" data-for="term-for-establish-an-orthogonal-flow" id="infopanel-for-term-for-establish-an-orthogonal-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-orthogonal-flow" style="display:none">Info about the 'orthogonal flow' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow">https://drafts.csswg.org/css-writing-modes-4/#establish-an-orthogonal-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-orthogonal-flow">12.1. 
 Grid Sizing Algorithm</a> <a href="#ref-for-establish-an-orthogonal-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">10.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">6.4. 
 Grid Item Margins and Paddings</a>
@@ -6981,8 +6981,8 @@ Subgrids</a>
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">10.1. 
 With a Grid Container as Containing Block</a>
@@ -6990,29 +6990,29 @@ With a Grid Container as Containing Block</a>
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">6.5. 
 Z-axis Ordering: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-propdef-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">8.4. 
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
@@ -7020,8 +7020,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a>
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">12.6. 
 Maximize Tracks</a> <a href="#ref-for-propdef-max-width①">(2)</a>
@@ -7029,8 +7029,8 @@ Maximize Tracks</a> <a href="#ref-for-propdef-max-width①">(2)</a>
 Expand Flexible Tracks</a> <a href="#ref-for-propdef-max-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">6.2. 
 	Grid Item Sizing</a>
@@ -7038,8 +7038,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-propdef-max-width③">(2)</a>
 Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">6.2. 
 	Grid Item Sizing</a>
@@ -7053,29 +7053,29 @@ Expand Flexible Tracks</a> <a href="#ref-for-propdef-min-width④">(2)</a>
 Stretch auto Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">6.5. 
 Z-axis Ordering: the z-index property</a> <a href="#ref-for-propdef-z-index①">(2)</a> <a href="#ref-for-propdef-z-index②">(3)</a> <a href="#ref-for-propdef-z-index③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">13. 
 Fragmenting Grid Layout</a> <a href="#ref-for-propdef-break-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">13. 
 Fragmenting Grid Layout</a> <a href="#ref-for-propdef-break-before①">(2)</a> <a href="#ref-for-propdef-break-before②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">11.1. 
 Gutters: the row-gap, column-gap, and gap properties</a>
@@ -7083,15 +7083,15 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">10.1. 
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">7.1. 
 The Explicit Grid</a> <a href="#ref-for-css-end①">(2)</a>
@@ -7099,8 +7099,8 @@ The Explicit Grid</a> <a href="#ref-for-css-end①">(2)</a>
 Grid Placement Conflict Handling</a> <a href="#ref-for-css-end③">(2)</a> <a href="#ref-for-css-end④">(3)</a> <a href="#ref-for-css-end⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">7.1. 
 The Explicit Grid</a> <a href="#ref-for-css-start①">(2)</a>
@@ -7108,50 +7108,50 @@ The Explicit Grid</a> <a href="#ref-for-css-start①">(2)</a>
 Grid Placement Conflict Handling</a> <a href="#ref-for-css-start③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">7.2.6.2. 
 Resolved Value of a Subgridded Track Listing</a> <a href="#ref-for-resolved-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value-special-case-property">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value-special-case-property" class="dfn-panel" data-for="term-for-resolved-value-special-case-property" id="infopanel-for-term-for-resolved-value-special-case-property" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value-special-case-property" style="display:none">Info about the 'resolved value special case property' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value-special-case-property">7.2.6. 
 Resolved Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">7.2.5. 
 Computed Value of a Track Listing</a> <a href="#ref-for-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">7.2.5. 
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">8.2. 
 Grid Item Placement vs. Source Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-by-computed-value">
-   <a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-by-computed-value" class="dfn-panel" data-for="term-for-by-computed-value" id="infopanel-for-term-for-by-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-by-computed-value" style="display:none">Info about the 'by computed value' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#by-computed-value">https://drafts.csswg.org/web-animations-1/#by-computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-by-computed-value">7.2.3.3. 
 Interpolation/Combination of repeat()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discrete">
-   <a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discrete" class="dfn-panel" data-for="term-for-discrete" id="infopanel-for-term-for-discrete" role="menu">
+   <span id="infopaneltitle-for-term-for-discrete" style="display:none">Info about the 'discrete' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discrete">7.2.3.3. 
 Interpolation/Combination of repeat()</a>
@@ -7687,8 +7687,8 @@ gridEl<c- p>.</c->style<c- p>.</c->gridTemplateRows <c- o>=</c-> s<c- p>.</c->gr
 	for the <a data-link-type="dfn" href="#grid-placement-property">grid-placement properties</a> and is looking for feedback, especially from implementors.
 	See <a href="https://github.com/w3c/csswg-drafts/issues/2681">discussion</a>. <a class="issue-return" href="#issue-e2bc4d57" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="grid">
-   <b><a href="#grid">#grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid" class="dfn-panel" data-for="grid" id="infopanel-for-grid" role="dialog">
+   <span id="infopaneltitle-for-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#grid">#grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid">2. 
 Overview</a>
@@ -7738,8 +7738,8 @@ Grid Sizing Algorithm</a>
 Expand Flexible Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-column">
-   <b><a href="#grid-column">#grid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-column" class="dfn-panel" data-for="grid-column" id="infopanel-for-grid-column" role="dialog">
+   <span id="infopaneltitle-for-grid-column" style="display:none">Info about the 'columns' definition.</span><b><a href="#grid-column">#grid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-column">2.1. 
 Declaring the Grid</a>
@@ -7751,8 +7751,8 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-grid-column④">(2)</a> <a href="#ref-for-grid-column⑤">(3)</a> <a href="#ref-for-grid-column⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-row">
-   <b><a href="#grid-row">#grid-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-row" class="dfn-panel" data-for="grid-row" id="infopanel-for-grid-row" role="dialog">
+   <span id="infopaneltitle-for-grid-row" style="display:none">Info about the 'rows' definition.</span><b><a href="#grid-row">#grid-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-row">2.1. 
 Declaring the Grid</a>
@@ -7764,8 +7764,8 @@ Gutters: the row-gap, column-gap, and gap properties</a>
 Grid Sizing Algorithm</a> <a href="#ref-for-grid-row④">(2)</a> <a href="#ref-for-grid-row⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-line">
-   <b><a href="#grid-line">#grid-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-line" class="dfn-panel" data-for="grid-line" id="infopanel-for-grid-line" role="dialog">
+   <span id="infopaneltitle-for-grid-line" style="display:none">Info about the 'Grid lines' definition.</span><b><a href="#grid-line">#grid-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-line">3. 
 Grid Layout Concepts and Terminology</a> <a href="#ref-for-grid-line①">(2)</a>
@@ -7795,8 +7795,8 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-grid-
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-track">
-   <b><a href="#grid-track">#grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-track" class="dfn-panel" data-for="grid-track" id="infopanel-for-grid-track" role="dialog">
+   <span id="infopaneltitle-for-grid-track" style="display:none">Info about the 'Grid track' definition.</span><b><a href="#grid-track">#grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-track">2.1. 
 Declaring the Grid</a>
@@ -7836,8 +7836,8 @@ Expand Flexible Tracks</a>
 Find the Size of an fr</a> <a href="#ref-for-grid-track③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-cell">
-   <b><a href="#grid-cell">#grid-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-cell" class="dfn-panel" data-for="grid-cell" id="infopanel-for-grid-cell" role="dialog">
+   <span id="infopaneltitle-for-grid-cell" style="display:none">Info about the 'grid cell' definition.</span><b><a href="#grid-cell">#grid-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-cell">3.3. 
 Grid Areas</a>
@@ -7853,8 +7853,8 @@ Grid Item Placement Algorithm</a>
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-area">
-   <b><a href="#grid-area">#grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-area" class="dfn-panel" data-for="grid-area" id="infopanel-for-grid-area" role="dialog">
+   <span id="infopaneltitle-for-grid-area" style="display:none">Info about the 'grid area' definition.</span><b><a href="#grid-area">#grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-area">1.1. 
 Background and Motivation</a>
@@ -7896,15 +7896,15 @@ Grid Sizing Algorithm</a> <a href="#ref-for-grid-area③⑤">(2)</a> <a href="#r
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nested-grid">
-   <b><a href="#nested-grid">#nested-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nested-grid" class="dfn-panel" data-for="nested-grid" id="infopanel-for-nested-grid" role="dialog">
+   <span id="infopaneltitle-for-nested-grid" style="display:none">Info about the 'nested grid' definition.</span><b><a href="#nested-grid">#nested-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-grid">3.4. 
 Nested vs. Subgridded Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parent-grid">
-   <b><a href="#parent-grid">#parent-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parent-grid" class="dfn-panel" data-for="parent-grid" id="infopanel-for-parent-grid" role="dialog">
+   <span id="infopaneltitle-for-parent-grid" style="display:none">Info about the 'parent grid' definition.</span><b><a href="#parent-grid">#parent-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-grid">3.4. 
 Nested vs. Subgridded Items</a>
@@ -7918,8 +7918,8 @@ Subgrids</a> <a href="#ref-for-parent-grid⑨">(2)</a> <a href="#ref-for-parent-
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subgrid">
-   <b><a href="#subgrid">#subgrid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subgrid" class="dfn-panel" data-for="subgrid" id="infopanel-for-subgrid" role="dialog">
+   <span id="infopaneltitle-for-subgrid" style="display:none">Info about the 'subgrid' definition.</span><b><a href="#subgrid">#subgrid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subgrid">3.4. 
 Nested vs. Subgridded Items</a> <a href="#ref-for-subgrid①">(2)</a>
@@ -7941,8 +7941,8 @@ Subgrids</a> <a href="#ref-for-subgrid①⑥">(2)</a> <a href="#ref-for-subgrid�
 Grid Sizing Algorithm</a> <a href="#ref-for-subgrid⑤③">(2)</a> <a href="#ref-for-subgrid⑤④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-grid">
-   <b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-grid" class="dfn-panel" data-for="valdef-display-grid" id="infopanel-for-valdef-display-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#valdef-display-grid">#valdef-display-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-grid">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-valdef-display-grid①">(2)</a> <a href="#ref-for-valdef-display-grid②">(3)</a>
@@ -7950,8 +7950,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a> <a hre
 	Grid Item Display</a> <a href="#ref-for-valdef-display-grid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-inline-grid">
-   <b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-inline-grid" class="dfn-panel" data-for="valdef-display-inline-grid" id="infopanel-for-valdef-display-inline-grid" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-inline-grid" style="display:none">Info about the 'inline-grid' definition.</span><b><a href="#valdef-display-inline-grid">#valdef-display-inline-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-grid">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a> <a href="#ref-for-valdef-display-inline-grid①">(2)</a> <a href="#ref-for-valdef-display-inline-grid②">(3)</a>
@@ -7959,8 +7959,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a> <a hre
 	Grid Item Display</a> <a href="#ref-for-valdef-display-inline-grid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-container">
-   <b><a href="#grid-container">#grid-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-container" class="dfn-panel" data-for="grid-container" id="infopanel-for-grid-container" role="dialog">
+   <span id="infopaneltitle-for-grid-container" style="display:none">Info about the 'grid container' definition.</span><b><a href="#grid-container">#grid-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">1.1.1. 
 Adapting Layouts to Available Space</a>
@@ -8052,8 +8052,8 @@ Stretch auto Tracks</a>
 Fragmenting Grid Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-formatting-context">
-   <b><a href="#grid-formatting-context">#grid-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-formatting-context" class="dfn-panel" data-for="grid-formatting-context" id="infopanel-for-grid-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-grid-formatting-context" style="display:none">Info about the 'grid formatting context' definition.</span><b><a href="#grid-formatting-context">#grid-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-formatting-context">5.1. 
 Establishing Grid Containers: the grid and inline-grid display values</a>
@@ -8061,8 +8061,8 @@ Establishing Grid Containers: the grid and inline-grid display values</a>
 	Grid Item Display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clamp-a-grid-area">
-   <b><a href="#clamp-a-grid-area">#clamp-a-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clamp-a-grid-area" class="dfn-panel" data-for="clamp-a-grid-area" id="infopanel-for-clamp-a-grid-area" role="dialog">
+   <span id="infopaneltitle-for-clamp-a-grid-area" style="display:none">Info about the 'clamp a grid area' definition.</span><b><a href="#clamp-a-grid-area">#clamp-a-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clamp-a-grid-area">5.4. 
 Limiting Large Grids</a>
@@ -8070,8 +8070,8 @@ Limiting Large Grids</a>
 Subgrids</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-item">
-   <b><a href="#grid-item">#grid-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-item" class="dfn-panel" data-for="grid-item" id="infopanel-for-grid-item" role="dialog">
+   <span id="infopaneltitle-for-grid-item" style="display:none">Info about the 'grid items' definition.</span><b><a href="#grid-item">#grid-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">1.1.1. 
 Adapting Layouts to Available Space</a> <a href="#ref-for-grid-item①">(2)</a> <a href="#ref-for-grid-item②">(3)</a> <a href="#ref-for-grid-item③">(4)</a>
@@ -8157,8 +8157,8 @@ Expand Flexible Tracks</a>
 Fragmenting Grid Layout</a> <a href="#ref-for-grid-item①③①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-based-minimum-size">
-   <b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-based-minimum-size" class="dfn-panel" data-for="content-based-minimum-size" id="infopanel-for-content-based-minimum-size" role="dialog">
+   <span id="infopaneltitle-for-content-based-minimum-size" style="display:none">Info about the 'content-based minimum size' definition.</span><b><a href="#content-based-minimum-size">#content-based-minimum-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-based-minimum-size">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-based-minimum-size①">(2)</a> <a href="#ref-for-content-based-minimum-size②">(3)</a> <a href="#ref-for-content-based-minimum-size③">(4)</a> <a href="#ref-for-content-based-minimum-size④">(5)</a>
@@ -8166,15 +8166,15 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-based-minimum
 Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-size-suggestion">
-   <b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-size-suggestion" class="dfn-panel" data-for="specified-size-suggestion" id="infopanel-for-specified-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-specified-size-suggestion" style="display:none">Info about the 'specified size suggestion' definition.</span><b><a href="#specified-size-suggestion">#specified-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-specified-size-suggestion①">(2)</a> <a href="#ref-for-specified-size-suggestion②">(3)</a> <a href="#ref-for-specified-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transferred-size-suggestion">
-   <b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transferred-size-suggestion" class="dfn-panel" data-for="transferred-size-suggestion" id="infopanel-for-transferred-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-transferred-size-suggestion" style="display:none">Info about the 'transferred size suggestion' definition.</span><b><a href="#transferred-size-suggestion">#transferred-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transferred-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-transferred-size-suggestion①">(2)</a> <a href="#ref-for-transferred-size-suggestion②">(3)</a> <a href="#ref-for-transferred-size-suggestion③">(4)</a>
@@ -8182,15 +8182,15 @@ Automatic Minimum Size of Grid Items</a> <a href="#ref-for-transferred-size-sugg
 Changes since the 18 December 2020 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-size-suggestion">
-   <b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-size-suggestion" class="dfn-panel" data-for="content-size-suggestion" id="infopanel-for-content-size-suggestion" role="dialog">
+   <span id="infopaneltitle-for-content-size-suggestion" style="display:none">Info about the 'content size suggestion' definition.</span><b><a href="#content-size-suggestion">#content-size-suggestion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-size-suggestion">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-content-size-suggestion①">(2)</a> <a href="#ref-for-content-size-suggestion②">(3)</a> <a href="#ref-for-content-size-suggestion③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid">
-   <b><a href="#explicit-grid">#explicit-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid" class="dfn-panel" data-for="explicit-grid" id="infopanel-for-explicit-grid" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid" style="display:none">Info about the 'explicit grid' definition.</span><b><a href="#explicit-grid">#explicit-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid">2.1. 
 Declaring the Grid</a> <a href="#ref-for-explicit-grid①">(2)</a>
@@ -8216,15 +8216,15 @@ Subgrids</a> <a href="#ref-for-explicit-grid③②">(2)</a> <a href="#ref-for-ex
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid-track">
-   <b><a href="#explicit-grid-track">#explicit-grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid-track" class="dfn-panel" data-for="explicit-grid-track" id="infopanel-for-explicit-grid-track" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid-track" style="display:none">Info about the 'explicit grid tracks' definition.</span><b><a href="#explicit-grid-track">#explicit-grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid-track">7.5. 
 The Implicit Grid</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-grid-properties">
-   <b><a href="#explicit-grid-properties">#explicit-grid-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-grid-properties" class="dfn-panel" data-for="explicit-grid-properties" id="infopanel-for-explicit-grid-properties" role="dialog">
+   <span id="infopaneltitle-for-explicit-grid-properties" style="display:none">Info about the 'explicit grid properties' definition.</span><b><a href="#explicit-grid-properties">#explicit-grid-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-grid-properties">7.5. 
 The Implicit Grid</a>
@@ -8232,8 +8232,8 @@ The Implicit Grid</a>
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-columns">
-   <b><a href="#propdef-grid-template-columns">#propdef-grid-template-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-columns" class="dfn-panel" data-for="propdef-grid-template-columns" id="infopanel-for-propdef-grid-template-columns" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-columns" style="display:none">Info about the 'grid-template-columns' definition.</span><b><a href="#propdef-grid-template-columns">#propdef-grid-template-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-columns">3.4. 
 Nested vs. Subgridded Items</a>
@@ -8267,8 +8267,8 @@ Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-rows">
-   <b><a href="#propdef-grid-template-rows">#propdef-grid-template-rows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-rows" class="dfn-panel" data-for="propdef-grid-template-rows" id="infopanel-for-propdef-grid-template-rows" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-rows" style="display:none">Info about the 'grid-template-rows' definition.</span><b><a href="#propdef-grid-template-rows">#propdef-grid-template-rows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-rows">3.4. 
 Nested vs. Subgridded Items</a>
@@ -8298,8 +8298,8 @@ Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a> <
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-template-rows②⑥">(2)</a> <a href="#ref-for-propdef-grid-template-rows②⑦">(3)</a> <a href="#ref-for-propdef-grid-template-rows②⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-list">
-   <b><a href="#track-list">#track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-list" class="dfn-panel" data-for="track-list" id="infopanel-for-track-list" role="dialog">
+   <span id="infopaneltitle-for-track-list" style="display:none">Info about the 'track list' definition.</span><b><a href="#track-list">#track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-track-list①">(2)</a> <a href="#ref-for-track-list②">(3)</a> <a href="#ref-for-track-list③">(4)</a>
@@ -8311,8 +8311,8 @@ Syntax of repeat()</a> <a href="#ref-for-track-list⑥">(2)</a> <a href="#ref-fo
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-rows-none">
-   <b><a href="#valdef-grid-template-rows-none">#valdef-grid-template-rows-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-rows-none" class="dfn-panel" data-for="valdef-grid-template-rows-none" id="infopanel-for-valdef-grid-template-rows-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-rows-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-grid-template-rows-none">#valdef-grid-template-rows-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-rows-none">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-valdef-grid-template-rows-none①">(2)</a>
@@ -8322,8 +8322,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-valdef
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-rows-track-sizing-function">
-   <b><a href="#grid-template-rows-track-sizing-function">#grid-template-rows-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-rows-track-sizing-function" class="dfn-panel" data-for="grid-template-rows-track-sizing-function" id="infopanel-for-grid-template-rows-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-grid-template-rows-track-sizing-function" style="display:none">Info about the 'track sizing function' definition.</span><b><a href="#grid-template-rows-track-sizing-function">#grid-template-rows-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-rows-track-sizing-function">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-grid-template-rows-track-sizing-function①">(2)</a>
@@ -8339,8 +8339,8 @@ Grid Sizing</a> <a href="#ref-for-grid-template-rows-track-sizing-function⑥">(
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-grid-template-rows-track-sizing-function⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-rows-subgrid">
-   <b><a href="#valdef-grid-template-rows-subgrid">#valdef-grid-template-rows-subgrid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-rows-subgrid" class="dfn-panel" data-for="valdef-grid-template-rows-subgrid" id="infopanel-for-valdef-grid-template-rows-subgrid" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-rows-subgrid" style="display:none">Info about the 'subgrid' definition.</span><b><a href="#valdef-grid-template-rows-subgrid">#valdef-grid-template-rows-subgrid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-rows-subgrid">3.4. 
 Nested vs. Subgridded Items</a>
@@ -8354,8 +8354,8 @@ Resolved Value of a Subgridded Track Listing</a>
 Additions Since Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subgridded-axis">
-   <b><a href="#subgridded-axis">#subgridded-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subgridded-axis" class="dfn-panel" data-for="subgridded-axis" id="infopanel-for-subgridded-axis" role="dialog">
+   <span id="infopaneltitle-for-subgridded-axis" style="display:none">Info about the 'subgridded axis' definition.</span><b><a href="#subgridded-axis">#subgridded-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subgridded-axis">3.4. 
 Nested vs. Subgridded Items</a> <a href="#ref-for-subgridded-axis①">(2)</a>
@@ -8373,8 +8373,8 @@ Subgrids</a> <a href="#ref-for-subgridded-axis⑦">(2)</a> <a href="#ref-for-sub
 Grid Sizing Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="standalone-axis">
-   <b><a href="#standalone-axis">#standalone-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-standalone-axis" class="dfn-panel" data-for="standalone-axis" id="infopanel-for-standalone-axis" role="dialog">
+   <span id="infopaneltitle-for-standalone-axis" style="display:none">Info about the 'standalone axis' definition.</span><b><a href="#standalone-axis">#standalone-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-standalone-axis">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-standalone-axis①">(2)</a>
@@ -8384,8 +8384,8 @@ Computed Value of a Track Listing</a>
 Resolved Value of a Standalone Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-list">
-   <b><a href="#typedef-track-list">#typedef-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-list" class="dfn-panel" data-for="typedef-track-list" id="infopanel-for-typedef-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-list" style="display:none">Info about the '&lt;track-list>' definition.</span><b><a href="#typedef-track-list">#typedef-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-list①">(2)</a>
@@ -8395,22 +8395,22 @@ Syntax of repeat()</a>
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-auto-track-list">
-   <b><a href="#typedef-auto-track-list">#typedef-auto-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-auto-track-list" class="dfn-panel" data-for="typedef-auto-track-list" id="infopanel-for-typedef-auto-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-auto-track-list" style="display:none">Info about the '&lt;auto-track-list>' definition.</span><b><a href="#typedef-auto-track-list">#typedef-auto-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-auto-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-auto-track-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-explicit-track-list">
-   <b><a href="#typedef-explicit-track-list">#typedef-explicit-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-explicit-track-list" class="dfn-panel" data-for="typedef-explicit-track-list" id="infopanel-for-typedef-explicit-track-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-explicit-track-list" style="display:none">Info about the '&lt;explicit-track-list>' definition.</span><b><a href="#typedef-explicit-track-list">#typedef-explicit-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-explicit-track-list">7.4. 
 Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typedef-explicit-track-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-line-name-list">
-   <b><a href="#typedef-line-name-list">#typedef-line-name-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-line-name-list" class="dfn-panel" data-for="typedef-line-name-list" id="infopanel-for-typedef-line-name-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-line-name-list" style="display:none">Info about the '&lt;line-name-list>' definition.</span><b><a href="#typedef-line-name-list">#typedef-line-name-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-name-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-line-name-list①">(2)</a> <a href="#ref-for-typedef-line-name-list②">(3)</a> <a href="#ref-for-typedef-line-name-list③">(4)</a>
@@ -8420,8 +8420,8 @@ Repeat-to-fill: auto-fill and auto-fit repetitions</a>
 Placing Grid Items</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-size">
-   <b><a href="#typedef-track-size">#typedef-track-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-size" class="dfn-panel" data-for="typedef-track-size" id="infopanel-for-typedef-track-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-size" style="display:none">Info about the '&lt;track-size>' definition.</span><b><a href="#typedef-track-size">#typedef-track-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-size">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-size①">(2)</a>
@@ -8433,8 +8433,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typede
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-size">
-   <b><a href="#typedef-fixed-size">#typedef-fixed-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-size" class="dfn-panel" data-for="typedef-fixed-size" id="infopanel-for-typedef-fixed-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-size" style="display:none">Info about the '&lt;fixed-size>' definition.</span><b><a href="#typedef-fixed-size">#typedef-fixed-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-size">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-size①">(2)</a>
@@ -8442,29 +8442,29 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-fixed-size③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-breadth">
-   <b><a href="#typedef-track-breadth">#typedef-track-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-breadth" class="dfn-panel" data-for="typedef-track-breadth" id="infopanel-for-typedef-track-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-breadth" style="display:none">Info about the '&lt;track-breadth>' definition.</span><b><a href="#typedef-track-breadth">#typedef-track-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-track-breadth①">(2)</a> <a href="#ref-for-typedef-track-breadth②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-inflexible-breadth">
-   <b><a href="#typedef-inflexible-breadth">#typedef-inflexible-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-inflexible-breadth" class="dfn-panel" data-for="typedef-inflexible-breadth" id="infopanel-for-typedef-inflexible-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-inflexible-breadth" style="display:none">Info about the '&lt;inflexible-breadth>' definition.</span><b><a href="#typedef-inflexible-breadth">#typedef-inflexible-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-inflexible-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-inflexible-breadth①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-breadth">
-   <b><a href="#typedef-fixed-breadth">#typedef-fixed-breadth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-breadth" class="dfn-panel" data-for="typedef-fixed-breadth" id="infopanel-for-typedef-fixed-breadth" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-breadth" style="display:none">Info about the '&lt;fixed-breadth>' definition.</span><b><a href="#typedef-fixed-breadth">#typedef-fixed-breadth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-breadth">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-breadth①">(2)</a> <a href="#ref-for-typedef-fixed-breadth②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-line-names">
-   <b><a href="#typedef-line-names">#typedef-line-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-line-names" class="dfn-panel" data-for="typedef-line-names" id="infopanel-for-typedef-line-names" role="dialog">
+   <span id="infopaneltitle-for-typedef-line-names" style="display:none">Info about the '&lt;line-names>' definition.</span><b><a href="#typedef-line-names">#typedef-line-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-names">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-line-names①">(2)</a> <a href="#ref-for-typedef-line-names②">(3)</a> <a href="#ref-for-typedef-line-names③">(4)</a> <a href="#ref-for-typedef-line-names④">(5)</a> <a href="#ref-for-typedef-line-names⑤">(6)</a> <a href="#ref-for-typedef-line-names⑥">(7)</a> <a href="#ref-for-typedef-line-names⑦">(8)</a> <a href="#ref-for-typedef-line-names⑧">(9)</a> <a href="#ref-for-typedef-line-names⑨">(10)</a> <a href="#ref-for-typedef-line-names①⓪">(11)</a>
@@ -8476,8 +8476,8 @@ Syntax of repeat()</a> <a href="#ref-for-typedef-line-names①③">(2)</a> <a hr
 Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-typedef-line-names②①">(2)</a> <a href="#ref-for-typedef-line-names②②">(3)</a> <a href="#ref-for-typedef-line-names②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-columns-flex-factor">
-   <b><a href="#grid-template-columns-flex-factor">#grid-template-columns-flex-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-columns-flex-factor" class="dfn-panel" data-for="grid-template-columns-flex-factor" id="infopanel-for-grid-template-columns-flex-factor" role="dialog">
+   <span id="infopaneltitle-for-grid-template-columns-flex-factor" style="display:none">Info about the 'flex factor' definition.</span><b><a href="#grid-template-columns-flex-factor">#grid-template-columns-flex-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-columns-flex-factor">7.2.1. 
 Track Sizes</a> <a href="#ref-for-grid-template-columns-flex-factor①">(2)</a> <a href="#ref-for-grid-template-columns-flex-factor②">(3)</a>
@@ -8489,8 +8489,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-grid-template-columns-flex-factor�
 Find the Size of an fr</a> <a href="#ref-for-grid-template-columns-flex-factor①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-minmax">
-   <b><a href="#valdef-grid-template-columns-minmax">#valdef-grid-template-columns-minmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-minmax" class="dfn-panel" data-for="valdef-grid-template-columns-minmax" id="infopanel-for-valdef-grid-template-columns-minmax" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-minmax" style="display:none">Info about the 'minmax(min, max)' definition.</span><b><a href="#valdef-grid-template-columns-minmax">#valdef-grid-template-columns-minmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-minmax">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8502,8 +8502,8 @@ Computed Value of a Track Listing</a>
 Track Sizing Terminology</a> <a href="#ref-for-valdef-grid-template-columns-minmax⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-auto">
-   <b><a href="#valdef-grid-template-columns-auto">#valdef-grid-template-columns-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-auto" class="dfn-panel" data-for="valdef-grid-template-columns-auto" id="infopanel-for-valdef-grid-template-columns-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-grid-template-columns-auto">#valdef-grid-template-columns-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-auto">2.1. 
 Declaring the Grid</a> <a href="#ref-for-valdef-grid-template-columns-auto①">(2)</a>
@@ -8519,8 +8519,8 @@ Resolve Intrinsic Track Sizes</a>
 Stretch auto Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-max-content">
-   <b><a href="#valdef-grid-template-columns-max-content">#valdef-grid-template-columns-max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-max-content" class="dfn-panel" data-for="valdef-grid-template-columns-max-content" id="infopanel-for-valdef-grid-template-columns-max-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-max-content" style="display:none">Info about the 'max-content' definition.</span><b><a href="#valdef-grid-template-columns-max-content">#valdef-grid-template-columns-max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-max-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -8538,8 +8538,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-valdef-grid-template-columns
 Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-valdef-grid-template-columns-max-content①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-min-content">
-   <b><a href="#valdef-grid-template-columns-min-content">#valdef-grid-template-columns-min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-min-content" class="dfn-panel" data-for="valdef-grid-template-columns-min-content" id="infopanel-for-valdef-grid-template-columns-min-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-min-content" style="display:none">Info about the 'min-content' definition.</span><b><a href="#valdef-grid-template-columns-min-content">#valdef-grid-template-columns-min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-min-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -8551,8 +8551,8 @@ Grid Sizing</a>
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-valdef-grid-template-columns-min-content⑥">(2)</a> <a href="#ref-for-valdef-grid-template-columns-min-content⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-columns-fit-content">
-   <b><a href="#valdef-grid-template-columns-fit-content">#valdef-grid-template-columns-fit-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-columns-fit-content" class="dfn-panel" data-for="valdef-grid-template-columns-fit-content" id="infopanel-for-valdef-grid-template-columns-fit-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-columns-fit-content" style="display:none">Info about the 'fit-content( &lt;length-percentage> )' definition.</span><b><a href="#valdef-grid-template-columns-fit-content">#valdef-grid-template-columns-fit-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-fit-content">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -8568,8 +8568,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-valdef-grid-template-columns
 Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-valdef-grid-template-columns-fit-content①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-name">
-   <b><a href="#line-name">#line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-name" class="dfn-panel" data-for="line-name" id="infopanel-for-line-name" role="dialog">
+   <span id="infopaneltitle-for-line-name" style="display:none">Info about the 'line names' definition.</span><b><a href="#line-name">#line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-name">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-line-name①">(2)</a>
@@ -8587,8 +8587,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Subgrids</a> <a href="#ref-for-line-name①①">(2)</a> <a href="#ref-for-line-name①②">(3)</a> <a href="#ref-for-line-name①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicitly-assigned-line-name">
-   <b><a href="#explicitly-assigned-line-name">#explicitly-assigned-line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicitly-assigned-line-name" class="dfn-panel" data-for="explicitly-assigned-line-name" id="infopanel-for-explicitly-assigned-line-name" role="dialog">
+   <span id="infopaneltitle-for-explicitly-assigned-line-name" style="display:none">Info about the 'explicitly assigned' definition.</span><b><a href="#explicitly-assigned-line-name">#explicitly-assigned-line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicitly-assigned-line-name">7.3.2. 
 Implicitly-Assigned Line Names</a>
@@ -8596,8 +8596,8 @@ Implicitly-Assigned Line Names</a>
 Subgrids</a> <a href="#ref-for-explicitly-assigned-line-name②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeat">
-   <b><a href="#funcdef-repeat">#funcdef-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeat" class="dfn-panel" data-for="funcdef-repeat" id="infopanel-for-funcdef-repeat" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeat" style="display:none">Info about the 'repeat()' definition.</span><b><a href="#funcdef-repeat">#funcdef-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeat">7.2.3. 
 Repeating Rows and Columns: the repeat() notation</a>
@@ -8615,8 +8615,8 @@ Resolved Value of a Subgridded Track Listing</a>
 Explicit Grid Shorthand: the grid-template property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-track-repeat">
-   <b><a href="#typedef-track-repeat">#typedef-track-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-track-repeat" class="dfn-panel" data-for="typedef-track-repeat" id="infopanel-for-typedef-track-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-track-repeat" style="display:none">Info about the '&lt;track-repeat>' definition.</span><b><a href="#typedef-track-repeat">#typedef-track-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-track-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8624,8 +8624,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-track-repeat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-auto-repeat">
-   <b><a href="#typedef-auto-repeat">#typedef-auto-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-auto-repeat" class="dfn-panel" data-for="typedef-auto-repeat" id="infopanel-for-typedef-auto-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-auto-repeat" style="display:none">Info about the '&lt;auto-repeat>' definition.</span><b><a href="#typedef-auto-repeat">#typedef-auto-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-auto-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8633,8 +8633,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-auto-repeat②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-fixed-repeat">
-   <b><a href="#typedef-fixed-repeat">#typedef-fixed-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-fixed-repeat" class="dfn-panel" data-for="typedef-fixed-repeat" id="infopanel-for-typedef-fixed-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-fixed-repeat" style="display:none">Info about the '&lt;fixed-repeat>' definition.</span><b><a href="#typedef-fixed-repeat">#typedef-fixed-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-fixed-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-typedef-fixed-repeat①">(2)</a>
@@ -8642,8 +8642,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-fixed-repeat③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-name-repeat">
-   <b><a href="#typedef-name-repeat">#typedef-name-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-name-repeat" class="dfn-panel" data-for="typedef-name-repeat" id="infopanel-for-typedef-name-repeat" role="dialog">
+   <span id="infopaneltitle-for-typedef-name-repeat" style="display:none">Info about the '&lt;name-repeat>' definition.</span><b><a href="#typedef-name-repeat">#typedef-name-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-name-repeat">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8651,8 +8651,8 @@ Explicit Track Sizing: the grid-template-rows and grid-template-columns properti
 Syntax of repeat()</a> <a href="#ref-for-typedef-name-repeat②">(2)</a> <a href="#ref-for-typedef-name-repeat③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-repeat-auto-fill">
-   <b><a href="#valdef-repeat-auto-fill">#valdef-repeat-auto-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-repeat-auto-fill" class="dfn-panel" data-for="valdef-repeat-auto-fill" id="infopanel-for-valdef-repeat-auto-fill" role="dialog">
+   <span id="infopaneltitle-for-valdef-repeat-auto-fill" style="display:none">Info about the 'auto-fill' definition.</span><b><a href="#valdef-repeat-auto-fill">#valdef-repeat-auto-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-repeat-auto-fill">7.2.3.1. 
 Syntax of repeat()</a>
@@ -8660,8 +8660,8 @@ Syntax of repeat()</a>
 Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-valdef-repeat-auto-fill②">(2)</a> <a href="#ref-for-valdef-repeat-auto-fill③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-repeat-auto-fit">
-   <b><a href="#valdef-repeat-auto-fit">#valdef-repeat-auto-fit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-repeat-auto-fit" class="dfn-panel" data-for="valdef-repeat-auto-fit" id="infopanel-for-valdef-repeat-auto-fit" role="dialog">
+   <span id="infopaneltitle-for-valdef-repeat-auto-fit" style="display:none">Info about the 'auto-fit' definition.</span><b><a href="#valdef-repeat-auto-fit">#valdef-repeat-auto-fit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-repeat-auto-fit">7.2.3.1. 
 Syntax of repeat()</a>
@@ -8669,8 +8669,8 @@ Syntax of repeat()</a>
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsed-track">
-   <b><a href="#collapsed-track">#collapsed-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsed-track" class="dfn-panel" data-for="collapsed-track" id="infopanel-for-collapsed-track" role="dialog">
+   <span id="infopaneltitle-for-collapsed-track" style="display:none">Info about the 'collapsed track' definition.</span><b><a href="#collapsed-track">#collapsed-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-track">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-collapsed-track①">(2)</a>
@@ -8678,8 +8678,8 @@ Repeat-to-fill: auto-fill and auto-fit repetitions</a> <a href="#ref-for-collaps
 Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-collapsed-track③">(2)</a> <a href="#ref-for-collapsed-track④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-flex">
-   <b><a href="#typedef-flex">#typedef-flex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-flex" class="dfn-panel" data-for="typedef-flex" id="infopanel-for-typedef-flex" role="dialog">
+   <span id="infopaneltitle-for-typedef-flex" style="display:none">Info about the '&lt;flex>' definition.</span><b><a href="#typedef-flex">#typedef-flex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-flex">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a>
@@ -8697,8 +8697,8 @@ Grid Sizing</a>
 Track Sizing Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-flex-fr">
-   <b><a href="#valdef-flex-fr">#valdef-flex-fr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-flex-fr" class="dfn-panel" data-for="valdef-flex-fr" id="infopanel-for-valdef-flex-fr" role="dialog">
+   <span id="infopaneltitle-for-valdef-flex-fr" style="display:none">Info about the 'fr' definition.</span><b><a href="#valdef-flex-fr">#valdef-flex-fr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-fr">2.1. 
 Declaring the Grid</a> <a href="#ref-for-valdef-flex-fr①">(2)</a>
@@ -8714,8 +8714,8 @@ Find the Size of an fr</a> <a href="#ref-for-valdef-flex-fr⑧">(2)</a>
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible-tracks">
-   <b><a href="#flexible-tracks">#flexible-tracks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible-tracks" class="dfn-panel" data-for="flexible-tracks" id="infopanel-for-flexible-tracks" role="dialog">
+   <span id="infopaneltitle-for-flexible-tracks" style="display:none">Info about the 'flexible tracks' definition.</span><b><a href="#flexible-tracks">#flexible-tracks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible-tracks">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -8727,15 +8727,15 @@ Expand Flexible Tracks</a> <a href="#ref-for-flexible-tracks⑥">(2)</a>
 Find the Size of an fr</a> <a href="#ref-for-flexible-tracks⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-fraction">
-   <b><a href="#flex-fraction">#flex-fraction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-fraction" class="dfn-panel" data-for="flex-fraction" id="infopanel-for-flex-fraction" role="dialog">
+   <span id="infopaneltitle-for-flex-fraction" style="display:none">Info about the 'flex fraction' definition.</span><b><a href="#flex-fraction">#flex-fraction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-fraction">12.7. 
 Expand Flexible Tracks</a> <a href="#ref-for-flex-fraction①">(2)</a> <a href="#ref-for-flex-fraction②">(3)</a> <a href="#ref-for-flex-fraction③">(4)</a> <a href="#ref-for-flex-fraction④">(5)</a> <a href="#ref-for-flex-fraction⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-track-list">
-   <b><a href="#computed-track-list">#computed-track-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-track-list" class="dfn-panel" data-for="computed-track-list" id="infopanel-for-computed-track-list" role="dialog">
+   <span id="infopaneltitle-for-computed-track-list" style="display:none">Info about the 'computed track list' definition.</span><b><a href="#computed-track-list">#computed-track-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-track-list">7.2. 
 Explicit Track Sizing: the grid-template-rows and grid-template-columns properties</a> <a href="#ref-for-computed-track-list①">(2)</a>
@@ -8745,8 +8745,8 @@ Interpolation/Combination of repeat()</a>
 Computed Value of a Track Listing</a> <a href="#ref-for-computed-track-list④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-name-set">
-   <b><a href="#line-name-set">#line-name-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-name-set" class="dfn-panel" data-for="line-name-set" id="infopanel-for-line-name-set" role="dialog">
+   <span id="infopaneltitle-for-line-name-set" style="display:none">Info about the 'line name set' definition.</span><b><a href="#line-name-set">#line-name-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-name-set">7.2.5. 
 Computed Value of a Track Listing</a> <a href="#ref-for-line-name-set①">(2)</a> <a href="#ref-for-line-name-set②">(3)</a>
@@ -8754,15 +8754,15 @@ Computed Value of a Track Listing</a> <a href="#ref-for-line-name-set①">(2)</a
 Resolved Value of a Subgridded Track Listing</a> <a href="#ref-for-line-name-set④">(2)</a> <a href="#ref-for-line-name-set⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-section">
-   <b><a href="#track-section">#track-section</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-section" class="dfn-panel" data-for="track-section" id="infopanel-for-track-section" role="dialog">
+   <span id="infopaneltitle-for-track-section" style="display:none">Info about the 'track section' definition.</span><b><a href="#track-section">#track-section</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-section">7.2.5. 
 Computed Value of a Track Listing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template-areas">
-   <b><a href="#propdef-grid-template-areas">#propdef-grid-template-areas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template-areas" class="dfn-panel" data-for="propdef-grid-template-areas" id="infopanel-for-propdef-grid-template-areas" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template-areas" style="display:none">Info about the 'grid-template-areas' definition.</span><b><a href="#propdef-grid-template-areas">#propdef-grid-template-areas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-areas">3.3. 
 Grid Areas</a>
@@ -8794,8 +8794,8 @@ Named Areas</a>
 Subgrids</a> <a href="#ref-for-propdef-grid-template-areas②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="named-grid-area">
-   <b><a href="#named-grid-area">#named-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-named-grid-area" class="dfn-panel" data-for="named-grid-area" id="infopanel-for-named-grid-area" role="dialog">
+   <span id="infopaneltitle-for-named-grid-area" style="display:none">Info about the 'named grid areas' definition.</span><b><a href="#named-grid-area">#named-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-grid-area">7.2.2. 
 Naming Grid Lines: the [&lt;custom-ident>*] syntax</a>
@@ -8817,8 +8817,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Subgrids</a> <a href="#ref-for-named-grid-area②①">(2)</a> <a href="#ref-for-named-grid-area②②">(3)</a> <a href="#ref-for-named-grid-area②③">(4)</a> <a href="#ref-for-named-grid-area②④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-template-areas-none">
-   <b><a href="#valdef-grid-template-areas-none">#valdef-grid-template-areas-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-template-areas-none" class="dfn-panel" data-for="valdef-grid-template-areas-none" id="infopanel-for-valdef-grid-template-areas-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-template-areas-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-grid-template-areas-none">#valdef-grid-template-areas-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-areas-none">7.3. 
 Named Areas: the grid-template-areas property</a>
@@ -8826,15 +8826,15 @@ Named Areas: the grid-template-areas property</a>
 Explicit Grid Shorthand: the grid-template property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-named-cell-token">
-   <b><a href="#grid-template-areas-named-cell-token">#grid-template-areas-named-cell-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-named-cell-token" class="dfn-panel" data-for="grid-template-areas-named-cell-token" id="infopanel-for-grid-template-areas-named-cell-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-named-cell-token" style="display:none">Info about the 'named cell token' definition.</span><b><a href="#grid-template-areas-named-cell-token">#grid-template-areas-named-cell-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-named-cell-token">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-grid-template-areas-named-cell-token①">(2)</a> <a href="#ref-for-grid-template-areas-named-cell-token②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-null-cell-token">
-   <b><a href="#grid-template-areas-null-cell-token">#grid-template-areas-null-cell-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-null-cell-token" class="dfn-panel" data-for="grid-template-areas-null-cell-token" id="infopanel-for-grid-template-areas-null-cell-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-null-cell-token" style="display:none">Info about the 'null cell token' definition.</span><b><a href="#grid-template-areas-null-cell-token">#grid-template-areas-null-cell-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-null-cell-token">7.3. 
 Named Areas: the grid-template-areas property</a> <a href="#ref-for-grid-template-areas-null-cell-token①">(2)</a>
@@ -8842,15 +8842,15 @@ Named Areas: the grid-template-areas property</a> <a href="#ref-for-grid-templat
 Serialization Of Template Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-template-areas-trash-token">
-   <b><a href="#grid-template-areas-trash-token">#grid-template-areas-trash-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-template-areas-trash-token" class="dfn-panel" data-for="grid-template-areas-trash-token" id="infopanel-for-grid-template-areas-trash-token" role="dialog">
+   <span id="infopaneltitle-for-grid-template-areas-trash-token" style="display:none">Info about the 'trash token' definition.</span><b><a href="#grid-template-areas-trash-token">#grid-template-areas-trash-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-template-areas-trash-token">7.3. 
 Named Areas: the grid-template-areas property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicitly-assigned-line-name">
-   <b><a href="#implicitly-assigned-line-name">#implicitly-assigned-line-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicitly-assigned-line-name" class="dfn-panel" data-for="implicitly-assigned-line-name" id="infopanel-for-implicitly-assigned-line-name" role="dialog">
+   <span id="infopaneltitle-for-implicitly-assigned-line-name" style="display:none">Info about the 'implicitly-assigned line names' definition.</span><b><a href="#implicitly-assigned-line-name">#implicitly-assigned-line-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicitly-assigned-line-name">7.2.2. 
 Naming Grid Lines: the [&lt;custom-ident>*] syntax</a>
@@ -8866,8 +8866,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Subgrids</a> <a href="#ref-for-implicitly-assigned-line-name⑧">(2)</a> <a href="#ref-for-implicitly-assigned-line-name⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-template">
-   <b><a href="#propdef-grid-template">#propdef-grid-template</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-template" class="dfn-panel" data-for="propdef-grid-template" id="infopanel-for-propdef-grid-template" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-template" style="display:none">Info about the 'grid-template' definition.</span><b><a href="#propdef-grid-template">#propdef-grid-template</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-template①">(2)</a>
@@ -8877,8 +8877,8 @@ Explicit Grid Shorthand: the grid-template property</a> <a href="#ref-for-propde
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-template⑥">(2)</a> <a href="#ref-for-propdef-grid-template⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-track">
-   <b><a href="#implicit-grid-track">#implicit-grid-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-track" class="dfn-panel" data-for="implicit-grid-track" id="infopanel-for-implicit-grid-track" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-track" style="display:none">Info about the 'implicit grid tracks' definition.</span><b><a href="#implicit-grid-track">#implicit-grid-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-track">7.5. 
 The Implicit Grid</a> <a href="#ref-for-implicit-grid-track①">(2)</a>
@@ -8888,8 +8888,8 @@ Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a> <
 Subgrids</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-lines">
-   <b><a href="#implicit-grid-lines">#implicit-grid-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-lines" class="dfn-panel" data-for="implicit-grid-lines" id="infopanel-for-implicit-grid-lines" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-lines" style="display:none">Info about the 'implicit grid lines' definition.</span><b><a href="#implicit-grid-lines">#implicit-grid-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-lines">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-implicit-grid-lines①">(2)</a>
@@ -8899,8 +8899,8 @@ Subgrids</a>
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid">
-   <b><a href="#implicit-grid">#implicit-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid" class="dfn-panel" data-for="implicit-grid" id="infopanel-for-implicit-grid" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid" style="display:none">Info about the 'implicit grid' definition.</span><b><a href="#implicit-grid">#implicit-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid">5.4. 
 Limiting Large Grids</a>
@@ -8918,15 +8918,15 @@ Gutters: the row-gap, column-gap, and gap properties</a> <a href="#ref-for-impli
 Aligning the Grid: the justify-content and align-content properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-grid-properties">
-   <b><a href="#implicit-grid-properties">#implicit-grid-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-grid-properties" class="dfn-panel" data-for="implicit-grid-properties" id="infopanel-for-implicit-grid-properties" role="dialog">
+   <span id="infopaneltitle-for-implicit-grid-properties" style="display:none">Info about the 'implicit grid properties' definition.</span><b><a href="#implicit-grid-properties">#implicit-grid-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid-properties">7.8. 
 Grid Definition Shorthand: the grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-columns">
-   <b><a href="#propdef-grid-auto-columns">#propdef-grid-auto-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-columns" class="dfn-panel" data-for="propdef-grid-auto-columns" id="infopanel-for-propdef-grid-auto-columns" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-columns" style="display:none">Info about the 'grid-auto-columns' definition.</span><b><a href="#propdef-grid-auto-columns">#propdef-grid-auto-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-columns">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-auto-columns①">(2)</a>
@@ -8942,8 +8942,8 @@ Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a> <
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-auto-columns⑨">(2)</a> <a href="#ref-for-propdef-grid-auto-columns①⓪">(3)</a> <a href="#ref-for-propdef-grid-auto-columns①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-rows">
-   <b><a href="#propdef-grid-auto-rows">#propdef-grid-auto-rows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-rows" class="dfn-panel" data-for="propdef-grid-auto-rows" id="infopanel-for-propdef-grid-auto-rows" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-rows" style="display:none">Info about the 'grid-auto-rows' definition.</span><b><a href="#propdef-grid-auto-rows">#propdef-grid-auto-rows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-rows">7.1. 
 The Explicit Grid</a> <a href="#ref-for-propdef-grid-auto-rows①">(2)</a>
@@ -8959,8 +8959,8 @@ Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a> <
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid-auto-rows⑨">(2)</a> <a href="#ref-for-propdef-grid-auto-rows①⓪">(3)</a> <a href="#ref-for-propdef-grid-auto-rows①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auto-placement">
-   <b><a href="#auto-placement">#auto-placement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auto-placement" class="dfn-panel" data-for="auto-placement" id="infopanel-for-auto-placement" role="dialog">
+   <span id="infopaneltitle-for-auto-placement" style="display:none">Info about the 'Automatic Placement' definition.</span><b><a href="#auto-placement">#auto-placement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auto-placement">2.2. 
 Placing Items</a>
@@ -8970,8 +8970,8 @@ Placing Grid Items</a>
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-auto-flow">
-   <b><a href="#propdef-grid-auto-flow">#propdef-grid-auto-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-auto-flow" class="dfn-panel" data-for="propdef-grid-auto-flow" id="infopanel-for-propdef-grid-auto-flow" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-auto-flow" style="display:none">Info about the 'grid-auto-flow' definition.</span><b><a href="#propdef-grid-auto-flow">#propdef-grid-auto-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-auto-flow">7.5. 
 The Implicit Grid</a> <a href="#ref-for-propdef-grid-auto-flow①">(2)</a>
@@ -8985,8 +8985,8 @@ Auto Placement</a> <a href="#ref-for-propdef-grid-auto-flow⑧">(2)</a>
 Grid Item Placement Algorithm</a> <a href="#ref-for-propdef-grid-auto-flow①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-row">
-   <b><a href="#valdef-grid-auto-flow-row">#valdef-grid-auto-flow-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-row" class="dfn-panel" data-for="valdef-grid-auto-flow-row" id="infopanel-for-valdef-grid-auto-flow-row" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-row" style="display:none">Info about the 'row' definition.</span><b><a href="#valdef-grid-auto-flow-row">#valdef-grid-auto-flow-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-row">7.7. 
 Automatic Placement: the grid-auto-flow property</a> <a href="#ref-for-valdef-grid-auto-flow-row①">(2)</a> <a href="#ref-for-valdef-grid-auto-flow-row②">(3)</a>
@@ -8996,8 +8996,8 @@ Grid Definition Shorthand: the grid property</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-column">
-   <b><a href="#valdef-grid-auto-flow-column">#valdef-grid-auto-flow-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-column" class="dfn-panel" data-for="valdef-grid-auto-flow-column" id="infopanel-for-valdef-grid-auto-flow-column" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-column" style="display:none">Info about the 'column' definition.</span><b><a href="#valdef-grid-auto-flow-column">#valdef-grid-auto-flow-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-column">7.7. 
 Automatic Placement: the grid-auto-flow property</a>
@@ -9007,8 +9007,8 @@ Grid Definition Shorthand: the grid property</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-grid-auto-flow-dense">
-   <b><a href="#valdef-grid-auto-flow-dense">#valdef-grid-auto-flow-dense</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-grid-auto-flow-dense" class="dfn-panel" data-for="valdef-grid-auto-flow-dense" id="infopanel-for-valdef-grid-auto-flow-dense" role="dialog">
+   <span id="infopaneltitle-for-valdef-grid-auto-flow-dense" style="display:none">Info about the 'dense' definition.</span><b><a href="#valdef-grid-auto-flow-dense">#valdef-grid-auto-flow-dense</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-dense">7.8. 
 Grid Definition Shorthand: the grid property</a>
@@ -9018,8 +9018,8 @@ Auto Placement</a>
 Grid Item Placement Algorithm</a> <a href="#ref-for-valdef-grid-auto-flow-dense③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid">
-   <b><a href="#propdef-grid">#propdef-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid" class="dfn-panel" data-for="propdef-grid" id="infopanel-for-propdef-grid" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#propdef-grid">#propdef-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid">2.1. 
 Declaring the Grid</a>
@@ -9033,8 +9033,8 @@ The Implicit Grid</a>
 Grid Definition Shorthand: the grid property</a> <a href="#ref-for-propdef-grid⑦">(2)</a> <a href="#ref-for-propdef-grid⑧">(3)</a> <a href="#ref-for-propdef-grid⑨">(4)</a> <a href="#ref-for-propdef-grid①⓪">(5)</a> <a href="#ref-for-propdef-grid①①">(6)</a> <a href="#ref-for-propdef-grid①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement">
-   <b><a href="#grid-placement">#grid-placement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement" class="dfn-panel" data-for="grid-placement" id="infopanel-for-grid-placement" role="dialog">
+   <span id="infopaneltitle-for-grid-placement" style="display:none">Info about the 'placement' definition.</span><b><a href="#grid-placement">#grid-placement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement">4. 
 Reordering and Accessibility</a>
@@ -9050,29 +9050,29 @@ Grid Item Placement Algorithm</a> <a href="#ref-for-grid-placement①①">(2)</a
 With a Grid Container as Containing Block</a> <a href="#ref-for-grid-placement①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-position">
-   <b><a href="#grid-position">#grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-position" class="dfn-panel" data-for="grid-position" id="infopanel-for-grid-position" role="dialog">
+   <span id="infopaneltitle-for-grid-position" style="display:none">Info about the 'grid position' definition.</span><b><a href="#grid-position">#grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-position">8. 
 Placing Grid Items</a> <a href="#ref-for-grid-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="definite-grid-position">
-   <b><a href="#definite-grid-position">#definite-grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-definite-grid-position" class="dfn-panel" data-for="definite-grid-position" id="infopanel-for-definite-grid-position" role="dialog">
+   <span id="infopaneltitle-for-definite-grid-position" style="display:none">Info about the 'definite' definition.</span><b><a href="#definite-grid-position">#definite-grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite-grid-position">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-definite-grid-position①">(2)</a> <a href="#ref-for-definite-grid-position②">(3)</a> <a href="#ref-for-definite-grid-position③">(4)</a> <a href="#ref-for-definite-grid-position④">(5)</a> <a href="#ref-for-definite-grid-position⑤">(6)</a> <a href="#ref-for-definite-grid-position⑥">(7)</a> <a href="#ref-for-definite-grid-position⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="automatic-grid-position">
-   <b><a href="#automatic-grid-position">#automatic-grid-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-automatic-grid-position" class="dfn-panel" data-for="automatic-grid-position" id="infopanel-for-automatic-grid-position" role="dialog">
+   <span id="infopaneltitle-for-automatic-grid-position" style="display:none">Info about the 'automatic' definition.</span><b><a href="#automatic-grid-position">#automatic-grid-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-grid-position">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-automatic-grid-position①">(2)</a> <a href="#ref-for-automatic-grid-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-span">
-   <b><a href="#grid-span">#grid-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-span" class="dfn-panel" data-for="grid-span" id="infopanel-for-grid-span" role="dialog">
+   <span id="infopaneltitle-for-grid-span" style="display:none">Info about the 'grid span' definition.</span><b><a href="#grid-span">#grid-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-span">5.4. 
 Limiting Large Grids</a>
@@ -9090,15 +9090,15 @@ Subgrids</a> <a href="#ref-for-grid-span⑨">(2)</a> <a href="#ref-for-grid-span
 With a Grid Container as Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="indefinite-grid-span">
-   <b><a href="#indefinite-grid-span">#indefinite-grid-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-indefinite-grid-span" class="dfn-panel" data-for="indefinite-grid-span" id="infopanel-for-indefinite-grid-span" role="dialog">
+   <span id="infopaneltitle-for-indefinite-grid-span" style="display:none">Info about the 'indefinite span' definition.</span><b><a href="#indefinite-grid-span">#indefinite-grid-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite-grid-span">9. 
 Subgrids</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement-property">
-   <b><a href="#grid-placement-property">#grid-placement-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement-property" class="dfn-panel" data-for="grid-placement-property" id="infopanel-for-grid-placement-property" role="dialog">
+   <span id="infopaneltitle-for-grid-placement-property" style="display:none">Info about the 'grid-placement properties' definition.</span><b><a href="#grid-placement-property">#grid-placement-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-property">2.2. 
 Placing Items</a>
@@ -9130,8 +9130,8 @@ Subgrids</a>
 With a Grid Container as Containing Block</a> <a href="#ref-for-grid-placement-property①⑧">(2)</a> <a href="#ref-for-grid-placement-property①⑨">(3)</a> <a href="#ref-for-grid-placement-property②⓪">(4)</a> <a href="#ref-for-grid-placement-property②①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row-start">
-   <b><a href="#propdef-grid-row-start">#propdef-grid-row-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row-start" class="dfn-panel" data-for="propdef-grid-row-start" id="infopanel-for-propdef-grid-row-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row-start" style="display:none">Info about the 'grid-row-start' definition.</span><b><a href="#propdef-grid-row-start">#propdef-grid-row-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-start">2.2. 
 Placing Items</a>
@@ -9147,8 +9147,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column-start">
-   <b><a href="#propdef-grid-column-start">#propdef-grid-column-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column-start" class="dfn-panel" data-for="propdef-grid-column-start" id="infopanel-for-propdef-grid-column-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column-start" style="display:none">Info about the 'grid-column-start' definition.</span><b><a href="#propdef-grid-column-start">#propdef-grid-column-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-start">2.2. 
 Placing Items</a>
@@ -9162,8 +9162,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-column-start⑧">(2)</a> <a href="#ref-for-propdef-grid-column-start⑨">(3)</a> <a href="#ref-for-propdef-grid-column-start①⓪">(4)</a> <a href="#ref-for-propdef-grid-column-start①①">(5)</a> <a href="#ref-for-propdef-grid-column-start①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row-end">
-   <b><a href="#propdef-grid-row-end">#propdef-grid-row-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row-end" class="dfn-panel" data-for="propdef-grid-row-end" id="infopanel-for-propdef-grid-row-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row-end" style="display:none">Info about the 'grid-row-end' definition.</span><b><a href="#propdef-grid-row-end">#propdef-grid-row-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row-end">2.2. 
 Placing Items</a>
@@ -9179,8 +9179,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column-end">
-   <b><a href="#propdef-grid-column-end">#propdef-grid-column-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column-end" class="dfn-panel" data-for="propdef-grid-column-end" id="infopanel-for-propdef-grid-column-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column-end" style="display:none">Info about the 'grid-column-end' definition.</span><b><a href="#propdef-grid-column-end">#propdef-grid-column-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column-end">2.2. 
 Placing Items</a>
@@ -9194,8 +9194,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-column-end⑦">(2)</a> <a href="#ref-for-propdef-grid-column-end⑧">(3)</a> <a href="#ref-for-propdef-grid-column-end⑨">(4)</a> <a href="#ref-for-propdef-grid-column-end①⓪">(5)</a> <a href="#ref-for-propdef-grid-column-end①①">(6)</a> <a href="#ref-for-propdef-grid-column-end①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-grid-row-start-grid-line">
-   <b><a href="#typedef-grid-row-start-grid-line">#typedef-grid-row-start-grid-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-grid-row-start-grid-line" class="dfn-panel" data-for="typedef-grid-row-start-grid-line" id="infopanel-for-typedef-grid-row-start-grid-line" role="dialog">
+   <span id="infopaneltitle-for-typedef-grid-row-start-grid-line" style="display:none">Info about the '&lt;grid-line>' definition.</span><b><a href="#typedef-grid-row-start-grid-line">#typedef-grid-row-start-grid-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-grid-row-start-grid-line">8.3. 
 Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and grid-column-end properties</a> <a href="#ref-for-typedef-grid-row-start-grid-line①">(2)</a>
@@ -9203,8 +9203,8 @@ Line-based Placement: the grid-row-start, grid-column-start, grid-row-end, and g
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-typedef-grid-row-start-grid-line③">(2)</a> <a href="#ref-for-typedef-grid-row-start-grid-line④">(3)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑤">(4)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑥">(5)</a> <a href="#ref-for-typedef-grid-row-start-grid-line⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-placement-auto">
-   <b><a href="#grid-placement-auto">#grid-placement-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-placement-auto" class="dfn-panel" data-for="grid-placement-auto" id="infopanel-for-grid-placement-auto" role="dialog">
+   <span id="infopaneltitle-for-grid-placement-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#grid-placement-auto">#grid-placement-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-auto">5.2. 
 Sizing Grid Containers</a> <a href="#ref-for-grid-placement-auto①">(2)</a>
@@ -9226,8 +9226,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-grid-placement-auto①⑧">(
 Sample Fragmentation Algorithm</a> <a href="#ref-for-grid-placement-auto②⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-row">
-   <b><a href="#propdef-grid-row">#propdef-grid-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-row" class="dfn-panel" data-for="propdef-grid-row" id="infopanel-for-propdef-grid-row" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-row" style="display:none">Info about the 'grid-row' definition.</span><b><a href="#propdef-grid-row">#propdef-grid-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row">2.2. 
 Placing Items</a>
@@ -9243,8 +9243,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Sample Fragmentation Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-column">
-   <b><a href="#propdef-grid-column">#propdef-grid-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-column" class="dfn-panel" data-for="propdef-grid-column" id="infopanel-for-propdef-grid-column" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-column" style="display:none">Info about the 'grid-column' definition.</span><b><a href="#propdef-grid-column">#propdef-grid-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column">2.2. 
 Placing Items</a>
@@ -9262,8 +9262,8 @@ Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a
 Subgrids</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-grid-area">
-   <b><a href="#propdef-grid-area">#propdef-grid-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-grid-area" class="dfn-panel" data-for="propdef-grid-area" id="infopanel-for-propdef-grid-area" role="dialog">
+   <span id="infopaneltitle-for-propdef-grid-area" style="display:none">Info about the 'grid-area' definition.</span><b><a href="#propdef-grid-area">#propdef-grid-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-area">2.2. 
 Placing Items</a>
@@ -9277,8 +9277,8 @@ Named Areas</a>
 Placement Shorthands: the grid-column, grid-row, and grid-area properties</a> <a href="#ref-for-propdef-grid-area⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-item-placement-algorithm">
-   <b><a href="#grid-item-placement-algorithm">#grid-item-placement-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-item-placement-algorithm" class="dfn-panel" data-for="grid-item-placement-algorithm" id="infopanel-for-grid-item-placement-algorithm" role="dialog">
+   <span id="infopaneltitle-for-grid-item-placement-algorithm" style="display:none">Info about the 'grid item placement algorithm' definition.</span><b><a href="#grid-item-placement-algorithm">#grid-item-placement-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item-placement-algorithm">7.6. 
 Implicit Track Sizing: the grid-auto-rows and grid-auto-columns properties</a>
@@ -9290,57 +9290,57 @@ Auto Placement</a> <a href="#ref-for-grid-item-placement-algorithm⑦">(2)</a>
 Grid Item Placement Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="occupied">
-   <b><a href="#occupied">#occupied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-occupied" class="dfn-panel" data-for="occupied" id="infopanel-for-occupied" role="dialog">
+   <span id="infopaneltitle-for-occupied" style="display:none">Info about the 'occupied' definition.</span><b><a href="#occupied">#occupied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-occupied">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-occupied①">(2)</a> <a href="#ref-for-occupied②">(3)</a> <a href="#ref-for-occupied③">(4)</a> <a href="#ref-for-occupied④">(5)</a> <a href="#ref-for-occupied⑤">(6)</a> <a href="#ref-for-occupied⑥">(7)</a> <a href="#ref-for-occupied⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unoccupied">
-   <b><a href="#unoccupied">#unoccupied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unoccupied" class="dfn-panel" data-for="unoccupied" id="infopanel-for-unoccupied" role="dialog">
+   <span id="infopaneltitle-for-unoccupied" style="display:none">Info about the 'unoccupied' definition.</span><b><a href="#unoccupied">#unoccupied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unoccupied">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-unoccupied①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auto-placement-cursor">
-   <b><a href="#auto-placement-cursor">#auto-placement-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auto-placement-cursor" class="dfn-panel" data-for="auto-placement-cursor" id="infopanel-for-auto-placement-cursor" role="dialog">
+   <span id="infopaneltitle-for-auto-placement-cursor" style="display:none">Info about the 'auto-placement cursor' definition.</span><b><a href="#auto-placement-cursor">#auto-placement-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auto-placement-cursor">8.5. 
 Grid Item Placement Algorithm</a> <a href="#ref-for-auto-placement-cursor①">(2)</a> <a href="#ref-for-auto-placement-cursor②">(3)</a> <a href="#ref-for-auto-placement-cursor③">(4)</a> <a href="#ref-for-auto-placement-cursor④">(5)</a> <a href="#ref-for-auto-placement-cursor⑤">(6)</a> <a href="#ref-for-auto-placement-cursor⑥">(7)</a> <a href="#ref-for-auto-placement-cursor⑦">(8)</a> <a href="#ref-for-auto-placement-cursor⑧">(9)</a> <a href="#ref-for-auto-placement-cursor⑨">(10)</a> <a href="#ref-for-auto-placement-cursor①⓪">(11)</a> <a href="#ref-for-auto-placement-cursor①①">(12)</a> <a href="#ref-for-auto-placement-cursor①②">(13)</a> <a href="#ref-for-auto-placement-cursor①③">(14)</a> <a href="#ref-for-auto-placement-cursor①④">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="augmented-grid">
-   <b><a href="#augmented-grid">#augmented-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-augmented-grid" class="dfn-panel" data-for="augmented-grid" id="infopanel-for-augmented-grid" role="dialog">
+   <span id="infopaneltitle-for-augmented-grid" style="display:none">Info about the 'augmented grid' definition.</span><b><a href="#augmented-grid">#augmented-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-augmented-grid">11.1. 
 Gutters: the row-gap, column-gap, and gap properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsed-gutter">
-   <b><a href="#collapsed-gutter">#collapsed-gutter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsed-gutter" class="dfn-panel" data-for="collapsed-gutter" id="infopanel-for-collapsed-gutter" role="dialog">
+   <span id="infopaneltitle-for-collapsed-gutter" style="display:none">Info about the 'collapse' definition.</span><b><a href="#collapsed-gutter">#collapsed-gutter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsed-gutter">7.2.3.2. 
 Repeat-to-fill: auto-fill and auto-fit repetitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-order">
-   <b><a href="#grid-order">#grid-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-order" class="dfn-panel" data-for="grid-order" id="infopanel-for-grid-order" role="dialog">
+   <span id="infopaneltitle-for-grid-order" style="display:none">Info about the 'Grid-modified document order (grid order)' definition.</span><b><a href="#grid-order">#grid-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-order">11.6. 
 Grid Container Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-sizing-algorithm">
-   <b><a href="#grid-sizing-algorithm">#grid-sizing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-sizing-algorithm" class="dfn-panel" data-for="grid-sizing-algorithm" id="infopanel-for-grid-sizing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-grid-sizing-algorithm" style="display:none">Info about the 'grid sizing algorithm' definition.</span><b><a href="#grid-sizing-algorithm">#grid-sizing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-sizing-algorithm">12. 
 Grid Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fixed-sizing-function">
-   <b><a href="#fixed-sizing-function">#fixed-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fixed-sizing-function" class="dfn-panel" data-for="fixed-sizing-function" id="infopanel-for-fixed-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-fixed-sizing-function" style="display:none">Info about the 'fixed sizing function' definition.</span><b><a href="#fixed-sizing-function">#fixed-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-fixed-sizing-function①">(2)</a> <a href="#ref-for-fixed-sizing-function②">(3)</a>
@@ -9352,8 +9352,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-fixed-sizing-function⑥">(2
 Distributing Extra Space Across Spanned Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-sizing-function">
-   <b><a href="#intrinsic-sizing-function">#intrinsic-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-sizing-function" class="dfn-panel" data-for="intrinsic-sizing-function" id="infopanel-for-intrinsic-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-sizing-function" style="display:none">Info about the 'intrinsic sizing function' definition.</span><b><a href="#intrinsic-sizing-function">#intrinsic-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-sizing-function">3.3. 
 Grid Areas</a>
@@ -9365,8 +9365,8 @@ Initialize Track Sizes</a> <a href="#ref-for-intrinsic-sizing-function③">(2)</
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-intrinsic-sizing-function⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flexible-sizing-function">
-   <b><a href="#flexible-sizing-function">#flexible-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flexible-sizing-function" class="dfn-panel" data-for="flexible-sizing-function" id="infopanel-for-flexible-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-flexible-sizing-function" style="display:none">Info about the 'flexible sizing function' definition.</span><b><a href="#flexible-sizing-function">#flexible-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flexible-sizing-function">7.2.3.1. 
 Syntax of repeat()</a>
@@ -9376,8 +9376,8 @@ Initialize Track Sizes</a>
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-flexible-sizing-function③">(2)</a> <a href="#ref-for-flexible-sizing-function④">(3)</a> <a href="#ref-for-flexible-sizing-function⑤">(4)</a> <a href="#ref-for-flexible-sizing-function⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-track-sizing-function">
-   <b><a href="#min-track-sizing-function">#min-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-track-sizing-function" class="dfn-panel" data-for="min-track-sizing-function" id="infopanel-for-min-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-min-track-sizing-function" style="display:none">Info about the 'min track sizing function' definition.</span><b><a href="#min-track-sizing-function">#min-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-track-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a>
@@ -9397,8 +9397,8 @@ Resolve Intrinsic Track Sizes</a> <a href="#ref-for-min-track-sizing-function⑦
 Distributing Extra Space Across Spanned Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-track-sizing-function">
-   <b><a href="#max-track-sizing-function">#max-track-sizing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-track-sizing-function" class="dfn-panel" data-for="max-track-sizing-function" id="infopanel-for-max-track-sizing-function" role="dialog">
+   <span id="infopaneltitle-for-max-track-sizing-function" style="display:none">Info about the 'max track sizing function' definition.</span><b><a href="#max-track-sizing-function">#max-track-sizing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-track-sizing-function">6.6. 
 Automatic Minimum Size of Grid Items</a> <a href="#ref-for-max-track-sizing-function①">(2)</a> <a href="#ref-for-max-track-sizing-function②">(3)</a>
@@ -9422,8 +9422,8 @@ Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-max-track-s
 Stretch auto Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-grid-space">
-   <b><a href="#available-grid-space">#available-grid-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-grid-space" class="dfn-panel" data-for="available-grid-space" id="infopanel-for-available-grid-space" role="dialog">
+   <span id="infopaneltitle-for-available-grid-space" style="display:none">Info about the 'available grid space' definition.</span><b><a href="#available-grid-space">#available-grid-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-grid-space">12.2. 
 Track Sizing Terminology</a> <a href="#ref-for-available-grid-space①">(2)</a> <a href="#ref-for-available-grid-space②">(3)</a> <a href="#ref-for-available-grid-space③">(4)</a> <a href="#ref-for-available-grid-space④">(5)</a>
@@ -9433,8 +9433,8 @@ Maximize Tracks</a>
 Expand Flexible Tracks</a> <a href="#ref-for-available-grid-space⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="free-space">
-   <b><a href="#free-space">#free-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-free-space" class="dfn-panel" data-for="free-space" id="infopanel-for-free-space" role="dialog">
+   <span id="infopaneltitle-for-free-space" style="display:none">Info about the 'free space' definition.</span><b><a href="#free-space">#free-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-free-space">7.2.1. 
 Track Sizes</a> <a href="#ref-for-free-space①">(2)</a>
@@ -9448,8 +9448,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-free-space⑦">(2)</a> <a href="#re
 Stretch auto Tracks</a> <a href="#ref-for-free-space①①">(2)</a> <a href="#ref-for-free-space①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="track-sizing-algorithm">
-   <b><a href="#track-sizing-algorithm">#track-sizing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-track-sizing-algorithm" class="dfn-panel" data-for="track-sizing-algorithm" id="infopanel-for-track-sizing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-track-sizing-algorithm" style="display:none">Info about the 'track sizing algorithm' definition.</span><b><a href="#track-sizing-algorithm">#track-sizing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-sizing-algorithm">7.2.1. 
 Track Sizes</a>
@@ -9461,8 +9461,8 @@ Track Sizing Terminology</a>
 Initialize Track Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-size">
-   <b><a href="#base-size">#base-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-size" class="dfn-panel" data-for="base-size" id="infopanel-for-base-size" role="dialog">
+   <span id="infopaneltitle-for-base-size" style="display:none">Info about the 'base size' definition.</span><b><a href="#base-size">#base-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-size">12.2. 
 Track Sizing Terminology</a>
@@ -9482,8 +9482,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-base-size②⑦">(2)</a> <a href="#
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="growth-limit">
-   <b><a href="#growth-limit">#growth-limit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-growth-limit" class="dfn-panel" data-for="growth-limit" id="infopanel-for-growth-limit" role="dialog">
+   <span id="infopaneltitle-for-growth-limit" style="display:none">Info about the 'growth limit' definition.</span><b><a href="#growth-limit">#growth-limit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-growth-limit">12.4. 
 Initialize Track Sizes</a> <a href="#ref-for-growth-limit①">(2)</a> <a href="#ref-for-growth-limit②">(3)</a> <a href="#ref-for-growth-limit③">(4)</a>
@@ -9495,22 +9495,22 @@ Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-growth-limi
 Maximize Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="limited-contribution">
-   <b><a href="#limited-contribution">#limited-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limited-contribution" class="dfn-panel" data-for="limited-contribution" id="infopanel-for-limited-contribution" role="dialog">
+   <span id="infopaneltitle-for-limited-contribution" style="display:none">Info about the 'limited min-/max-content contribution' definition.</span><b><a href="#limited-contribution">#limited-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limited-contribution">12.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-limited-contribution①">(2)</a> <a href="#ref-for-limited-contribution②">(3)</a> <a href="#ref-for-limited-contribution③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimum-contribution">
-   <b><a href="#minimum-contribution">#minimum-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimum-contribution" class="dfn-panel" data-for="minimum-contribution" id="infopanel-for-minimum-contribution" role="dialog">
+   <span id="infopaneltitle-for-minimum-contribution" style="display:none">Info about the 'minimum contribution' definition.</span><b><a href="#minimum-contribution">#minimum-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimum-contribution">12.5. 
 Resolve Intrinsic Track Sizes</a> <a href="#ref-for-minimum-contribution①">(2)</a> <a href="#ref-for-minimum-contribution②">(3)</a> <a href="#ref-for-minimum-contribution③">(4)</a> <a href="#ref-for-minimum-contribution④">(5)</a> <a href="#ref-for-minimum-contribution⑤">(6)</a> <a href="#ref-for-minimum-contribution⑥">(7)</a> <a href="#ref-for-minimum-contribution⑦">(8)</a> <a href="#ref-for-minimum-contribution⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="infinitely-growable">
-   <b><a href="#infinitely-growable">#infinitely-growable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-infinitely-growable" class="dfn-panel" data-for="infinitely-growable" id="infopanel-for-infinitely-growable" role="dialog">
+   <span id="infopaneltitle-for-infinitely-growable" style="display:none">Info about the 'infinitely growable' definition.</span><b><a href="#infinitely-growable">#infinitely-growable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-infinitely-growable">12.5. 
 Resolve Intrinsic Track Sizes</a>
@@ -9518,8 +9518,8 @@ Resolve Intrinsic Track Sizes</a>
 Distributing Extra Space Across Spanned Tracks</a> <a href="#ref-for-infinitely-growable②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="space-to-fill">
-   <b><a href="#space-to-fill">#space-to-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-space-to-fill" class="dfn-panel" data-for="space-to-fill" id="infopanel-for-space-to-fill" role="dialog">
+   <span id="infopaneltitle-for-space-to-fill" style="display:none">Info about the 'space to fill' definition.</span><b><a href="#space-to-fill">#space-to-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-space-to-fill">12.7. 
 Expand Flexible Tracks</a> <a href="#ref-for-space-to-fill①">(2)</a>
@@ -9527,8 +9527,8 @@ Expand Flexible Tracks</a> <a href="#ref-for-space-to-fill①">(2)</a>
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="leftover-space">
-   <b><a href="#leftover-space">#leftover-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-leftover-space" class="dfn-panel" data-for="leftover-space" id="infopanel-for-leftover-space" role="dialog">
+   <span id="infopaneltitle-for-leftover-space" style="display:none">Info about the 'leftover space' definition.</span><b><a href="#leftover-space">#leftover-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-leftover-space">7.2.1. 
 Track Sizes</a> <a href="#ref-for-leftover-space①">(2)</a>
@@ -9538,15 +9538,15 @@ Flexible Lengths: the fr unit</a> <a href="#ref-for-leftover-space③">(2)</a> <
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-factor-sum">
-   <b><a href="#flex-factor-sum">#flex-factor-sum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-factor-sum" class="dfn-panel" data-for="flex-factor-sum" id="infopanel-for-flex-factor-sum" role="dialog">
+   <span id="infopaneltitle-for-flex-factor-sum" style="display:none">Info about the 'flex factor sum' definition.</span><b><a href="#flex-factor-sum">#flex-factor-sum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-factor-sum">12.7.1. 
 Find the Size of an fr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hypothetical-fr-size">
-   <b><a href="#hypothetical-fr-size">#hypothetical-fr-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hypothetical-fr-size" class="dfn-panel" data-for="hypothetical-fr-size" id="infopanel-for-hypothetical-fr-size" role="dialog">
+   <span id="infopaneltitle-for-hypothetical-fr-size" style="display:none">Info about the 'hypothetical fr size' definition.</span><b><a href="#hypothetical-fr-size">#hypothetical-fr-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hypothetical-fr-size">12.7.1. 
 Find the Size of an fr</a> <a href="#ref-for-hypothetical-fr-size①">(2)</a>
@@ -9554,59 +9554,115 @@ Find the Size of an fr</a> <a href="#ref-for-hypothetical-fr-size①">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-grid-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-grid-3/Overview.html
@@ -1739,15 +1739,15 @@ grid-template-columns: <c- m>150</c-><c- k>px</c-> <c- m>100</c-><c- k>px</c-> <
    <li><a href="#masonry-box">masonry box</a><span>, in § 6</span>
    <li><a href="#running-position">running position</a><span>, in § 2.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-baseline-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-baseline-position">https://drafts.csswg.org/css-align-3/#typedef-baseline-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-baseline-position" class="dfn-panel" data-for="term-for-typedef-baseline-position" id="infopanel-for-term-for-typedef-baseline-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-baseline-position" style="display:none">Info about the '&lt;baseline-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-baseline-position">https://drafts.csswg.org/css-align-3/#typedef-baseline-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-baseline-position">6.1. 
 The align-tracks and justify-tracks Properties </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-content-distribution">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-content-distribution">https://drafts.csswg.org/css-align-3/#typedef-content-distribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-content-distribution" class="dfn-panel" data-for="term-for-typedef-content-distribution" id="infopanel-for-term-for-typedef-content-distribution" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-content-distribution" style="display:none">Info about the '&lt;content-distribution>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-content-distribution">https://drafts.csswg.org/css-align-3/#typedef-content-distribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-distribution">6.1. 
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-typedef-content-distribution①">(2)</a>
@@ -1755,22 +1755,22 @@ The align-tracks and justify-tracks Properties </a> <a href="#ref-for-typedef-co
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-content-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-content-position">https://drafts.csswg.org/css-align-3/#typedef-content-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-content-position" class="dfn-panel" data-for="term-for-typedef-content-position" id="infopanel-for-term-for-typedef-content-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-content-position" style="display:none">Info about the '&lt;content-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-content-position">https://drafts.csswg.org/css-align-3/#typedef-content-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-position">6.1. 
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-typedef-content-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-overflow-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-overflow-position">https://drafts.csswg.org/css-align-3/#typedef-overflow-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-overflow-position" class="dfn-panel" data-for="term-for-typedef-overflow-position" id="infopanel-for-term-for-typedef-overflow-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-overflow-position" style="display:none">Info about the '&lt;overflow-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-overflow-position">https://drafts.csswg.org/css-align-3/#typedef-overflow-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-overflow-position">6.1. 
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-typedef-overflow-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">6. 
 Alignment and Spacing</a> <a href="#ref-for-propdef-align-content①">(2)</a>
@@ -1780,8 +1780,8 @@ The align-tracks and justify-tracks Properties </a> <a href="#ref-for-propdef-al
 Baseline Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">6.2. 
 Stretch Alignment in the Masonry Axis</a>
@@ -1789,15 +1789,15 @@ Stretch Alignment in the Masonry Axis</a>
 Baseline Alignment in the Masonry Axis</a> <a href="#ref-for-propdef-align-self②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-alignment-subject">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-subject">https://drafts.csswg.org/css-align-3/#alignment-subject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-subject" class="dfn-panel" data-for="term-for-alignment-subject" id="infopanel-for-term-for-alignment-subject" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-subject" style="display:none">Info about the 'alignment subject' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-subject">https://drafts.csswg.org/css-align-3/#alignment-subject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-subject">6. 
 Alignment and Spacing</a> <a href="#ref-for-alignment-subject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-alignment" class="dfn-panel" data-for="term-for-baseline-alignment" id="infopanel-for-term-for-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-alignment" style="display:none">Info about the 'baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment">6. 
 Alignment and Spacing</a>
@@ -1805,15 +1805,15 @@ Alignment and Spacing</a>
 Baseline Alignment in the Masonry Axis</a> <a href="#ref-for-baseline-alignment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-sharing-group">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-sharing-group" class="dfn-panel" data-for="term-for-baseline-sharing-group" id="infopanel-for-term-for-baseline-sharing-group" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-sharing-group" style="display:none">Info about the 'baseline-sharing group' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-sharing-group">https://drafts.csswg.org/css-align-3/#baseline-sharing-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-sharing-group">6.4. 
 Baseline Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">6. 
 Alignment and Spacing</a>
@@ -1821,8 +1821,8 @@ Alignment and Spacing</a>
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-end">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-end" class="dfn-panel" data-for="term-for-valdef-self-position-end" id="infopanel-for-term-for-valdef-self-position-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-end">6. 
 Alignment and Spacing</a>
@@ -1830,15 +1830,15 @@ Alignment and Spacing</a>
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#first-baseline-set">https://drafts.csswg.org/css-align-3/#first-baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-baseline-set" class="dfn-panel" data-for="term-for-first-baseline-set" id="infopanel-for-term-for-first-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-first-baseline-set" style="display:none">Info about the 'first baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#first-baseline-set">https://drafts.csswg.org/css-align-3/#first-baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-baseline-set">6.4. 
 Baseline Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">6. 
 Alignment and Spacing</a>
@@ -1846,15 +1846,15 @@ Alignment and Spacing</a>
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-propdef-justify-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-last-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#last-baseline-set">https://drafts.csswg.org/css-align-3/#last-baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-last-baseline-set" class="dfn-panel" data-for="term-for-last-baseline-set" id="infopanel-for-term-for-last-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-last-baseline-set" style="display:none">Info about the 'last baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#last-baseline-set">https://drafts.csswg.org/css-align-3/#last-baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-set">6.4. 
 Baseline Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-normal" class="dfn-panel" data-for="term-for-valdef-align-self-normal" id="infopanel-for-term-for-valdef-align-self-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-normal" style="display:none">Info about the 'normal (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-normal">6. 
 Alignment and Spacing</a>
@@ -1862,29 +1862,29 @@ Alignment and Spacing</a>
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-content-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-content-normal" class="dfn-panel" data-for="term-for-valdef-justify-content-normal" id="infopanel-for-term-for-valdef-justify-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-content-normal" style="display:none">Info about the 'normal (for justify-content)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-normal">6. 
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">6. 
 Alignment and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-content-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-content-stretch" class="dfn-panel" data-for="term-for-valdef-align-content-stretch" id="infopanel-for-term-for-valdef-align-content-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-content-stretch" style="display:none">Info about the 'stretch (for align-content)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-content-stretch">6. 
 Alignment and Spacing</a> <a href="#ref-for-valdef-align-content-stretch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-stretch" class="dfn-panel" data-for="term-for-valdef-align-self-stretch" id="infopanel-for-term-for-valdef-align-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">6.2. 
 Stretch Alignment in the Masonry Axis</a>
@@ -1892,36 +1892,36 @@ Stretch Alignment in the Masonry Axis</a>
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">7.1. 
 Fragmentation in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentainer">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentainer">https://drafts.csswg.org/css-break-4/#fragmentainer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentainer" class="dfn-panel" data-for="term-for-fragmentainer" id="infopanel-for-term-for-fragmentainer" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentainer" style="display:none">Info about the 'fragmentainer' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentainer">https://drafts.csswg.org/css-break-4/#fragmentainer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentainer">7.1. 
 Fragmentation in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">2. 
 Masonry Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3. 
 Containing Block</a>
@@ -1929,15 +1929,15 @@ Containing Block</a>
 Absolute Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-auto-flow-dense">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-auto-flow-dense">https://drafts.csswg.org/css-grid-2/#valdef-grid-auto-flow-dense</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-auto-flow-dense" class="dfn-panel" data-for="term-for-valdef-grid-auto-flow-dense" id="infopanel-for-term-for-valdef-grid-auto-flow-dense" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-auto-flow-dense" style="display:none">Info about the 'dense' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-auto-flow-dense">https://drafts.csswg.org/css-grid-2/#valdef-grid-auto-flow-dense</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-auto-flow-dense">4. 
 The Implicit Grid </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid">https://drafts.csswg.org/css-grid-2/#propdef-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid" class="dfn-panel" data-for="term-for-propdef-grid" id="infopanel-for-term-for-propdef-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid" style="display:none">Info about the 'grid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid">https://drafts.csswg.org/css-grid-2/#propdef-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid">8. 
 Subgrids</a>
@@ -1945,15 +1945,15 @@ Subgrids</a>
 Graceful Degradation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-area">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-area" class="dfn-panel" data-for="term-for-grid-area" id="infopanel-for-term-for-grid-area" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-area" style="display:none">Info about the 'grid area' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-area">3. 
 Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">2. 
 Masonry Layout</a> <a href="#ref-for-grid-container①">(2)</a> <a href="#ref-for-grid-container②">(3)</a> <a href="#ref-for-grid-container③">(4)</a> <a href="#ref-for-grid-container④">(5)</a> <a href="#ref-for-grid-container⑤">(6)</a>
@@ -1975,8 +1975,8 @@ Subgrids</a>
 Absolute Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-item">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-item" class="dfn-panel" data-for="term-for-grid-item" id="infopanel-for-term-for-grid-item" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-item" style="display:none">Info about the 'grid item' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">2. 
 Masonry Layout</a> <a href="#ref-for-grid-item①">(2)</a> <a href="#ref-for-grid-item②">(3)</a>
@@ -1990,57 +1990,57 @@ Containing Block</a>
 Fragmentation in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-position">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-position">https://drafts.csswg.org/css-grid-2/#grid-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-position" class="dfn-panel" data-for="term-for-grid-position" id="infopanel-for-term-for-grid-position" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-position" style="display:none">Info about the 'grid position' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-position">https://drafts.csswg.org/css-grid-2/#grid-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-position">9. 
 Absolute Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-column">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column">https://drafts.csswg.org/css-grid-2/#propdef-grid-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-column" class="dfn-panel" data-for="term-for-propdef-grid-column" id="infopanel-for-term-for-propdef-grid-column" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-column" style="display:none">Info about the 'grid-column' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-column">https://drafts.csswg.org/css-grid-2/#propdef-grid-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-column">2. 
 Masonry Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-row">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row">https://drafts.csswg.org/css-grid-2/#propdef-grid-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-row" class="dfn-panel" data-for="term-for-propdef-grid-row" id="infopanel-for-term-for-propdef-grid-row" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-row" style="display:none">Info about the 'grid-row' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-row">https://drafts.csswg.org/css-grid-2/#propdef-grid-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-row">2. 
 Masonry Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template">https://drafts.csswg.org/css-grid-2/#propdef-grid-template</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template" class="dfn-panel" data-for="term-for-propdef-grid-template" id="infopanel-for-term-for-propdef-grid-template" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template" style="display:none">Info about the 'grid-template' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template">https://drafts.csswg.org/css-grid-2/#propdef-grid-template</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template">11. 
 Graceful Degradation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template-columns">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template-columns" class="dfn-panel" data-for="term-for-propdef-grid-template-columns" id="infopanel-for-term-for-propdef-grid-template-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template-columns" style="display:none">Info about the 'grid-template-columns' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-columns">2. 
 Masonry Layout</a> <a href="#termref-for-propdef-grid-template-columns">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-grid-template-rows">
-   <a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-grid-template-rows" class="dfn-panel" data-for="term-for-propdef-grid-template-rows" id="infopanel-for-term-for-propdef-grid-template-rows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-grid-template-rows" style="display:none">Info about the 'grid-template-rows' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows">https://drafts.csswg.org/css-grid-2/#propdef-grid-template-rows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-grid-template-rows">2. 
 Masonry Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implicit-grid">
-   <a href="https://drafts.csswg.org/css-grid-2/#implicit-grid">https://drafts.csswg.org/css-grid-2/#implicit-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implicit-grid" class="dfn-panel" data-for="term-for-implicit-grid" id="infopanel-for-term-for-implicit-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-implicit-grid" style="display:none">Info about the 'implicit grid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#implicit-grid">https://drafts.csswg.org/css-grid-2/#implicit-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-grid">4. 
 The Implicit Grid </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-template-rows-none">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-none">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-template-rows-none" class="dfn-panel" data-for="term-for-valdef-grid-template-rows-none" id="infopanel-for-term-for-valdef-grid-template-rows-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-template-rows-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-none">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-rows-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-rows-none">2. 
 Masonry Layout</a> <a href="#ref-for-valdef-grid-template-rows-none①">(2)</a>
@@ -2050,106 +2050,106 @@ Line Name Resolution</a>
 Grid Item Placement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-subgrid">
-   <a href="https://drafts.csswg.org/css-grid-2/#subgrid">https://drafts.csswg.org/css-grid-2/#subgrid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subgrid" class="dfn-panel" data-for="term-for-subgrid" id="infopanel-for-term-for-subgrid" role="menu">
+   <span id="infopaneltitle-for-term-for-subgrid" style="display:none">Info about the 'subgrid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#subgrid">https://drafts.csswg.org/css-grid-2/#subgrid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subgrid">8. 
 Subgrids</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block">https://drafts.csswg.org/css-logical-1/#propdef-margin-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block" class="dfn-panel" data-for="term-for-propdef-margin-block" id="infopanel-for-term-for-propdef-margin-block" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block" style="display:none">Info about the 'margin-block' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block">https://drafts.csswg.org/css-logical-1/#propdef-margin-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indefinite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indefinite" class="dfn-panel" data-for="term-for-indefinite" id="infopanel-for-term-for-indefinite" role="menu">
+   <span id="infopaneltitle-for-term-for-indefinite" style="display:none">Info about the 'indefinite size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'max size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-constraint" class="dfn-panel" data-for="term-for-max-content-constraint" id="infopanel-for-term-for-max-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-constraint" style="display:none">Info about the 'max-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-constraint">https://drafts.csswg.org/css-sizing-3/#max-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-constraint">5. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">5. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">6.2. 
 Stretch Alignment in the Masonry Axis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-constraint">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-constraint" class="dfn-panel" data-for="term-for-min-content-constraint" id="infopanel-for-term-for-min-content-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-constraint" style="display:none">Info about the 'min-content constraint' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-constraint">https://drafts.csswg.org/css-sizing-3/#min-content-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-constraint">5. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5. 
 Sizing Grid Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">6.1. 
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-mult-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">6.1. 
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.5. 
 The masonry-auto-flow Property</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -2157,15 +2157,15 @@ The masonry-auto-flow Property</a> <a href="#ref-for-comb-one①">(2)</a>
 The align-tracks and justify-tracks Properties </a> <a href="#ref-for-comb-one③">(2)</a> <a href="#ref-for-comb-one④">(3)</a> <a href="#ref-for-comb-one⑤">(4)</a> <a href="#ref-for-comb-one⑥">(5)</a> <a href="#ref-for-comb-one⑦">(6)</a> <a href="#ref-for-comb-one⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.5. 
 The masonry-auto-flow Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">4. 
 The Implicit Grid </a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a>
@@ -2350,8 +2350,8 @@ The Implicit Grid </a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="
    <div class="issue"> It might be useful to define a static position in the <a data-link-type="dfn" href="#masonry-axis">masonry axis</a>. Maybe it could defined as the max (or min?) current <a data-link-type="dfn" href="#running-position">running position</a> of the <a data-link-type="dfn">grid-axis</a> tracks at that point?  Or the end of the item before it? <a class="issue-return" href="#issue-7bbe63a7" title="Jump to section">↵</a></div>
    <div class="issue"> It would also be useful to be able to align the <a data-link-type="dfn" href="#masonry-box">masonry box</a> end edge somehow, but for that we need a way to address the <a href="https://github.com/w3c/csswg-drafts/issues/2402">end line in an implicit grid</a>, or could we just use any non-auto line number other than 1 to indicate the end line given that we don’t really have any lines in this axis other than line 1? <a class="issue-return" href="#issue-b2e5048b" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="masonry-axis">
-   <b><a href="#masonry-axis">#masonry-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-masonry-axis" class="dfn-panel" data-for="masonry-axis" id="infopanel-for-masonry-axis" role="dialog">
+   <span id="infopaneltitle-for-masonry-axis" style="display:none">Info about the 'masonry axis' definition.</span><b><a href="#masonry-axis">#masonry-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-masonry-axis">2. 
 Masonry Layout</a>
@@ -2387,8 +2387,8 @@ Absolute Positioning</a> <a href="#ref-for-masonry-axis③⑤">(2)</a> <a href="
 Performance Notes</a> <a href="#ref-for-masonry-axis③⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grid-axis">
-   <b><a href="#grid-axis">#grid-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grid-axis" class="dfn-panel" data-for="grid-axis" id="infopanel-for-grid-axis" role="dialog">
+   <span id="infopaneltitle-for-grid-axis" style="display:none">Info about the 'grid axis' definition.</span><b><a href="#grid-axis">#grid-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-axis">2. 
 Masonry Layout</a> <a href="#ref-for-grid-axis①">(2)</a> <a href="#ref-for-grid-axis②">(3)</a>
@@ -2420,8 +2420,8 @@ Absolute Positioning</a>
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="running-position">
-   <b><a href="#running-position">#running-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-running-position" class="dfn-panel" data-for="running-position" id="infopanel-for-running-position" role="dialog">
+   <span id="infopaneltitle-for-running-position" style="display:none">Info about the 'running position' definition.</span><b><a href="#running-position">#running-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running-position">2.4. 
 Masonry Layout Algorithm</a> <a href="#ref-for-running-position①">(2)</a> <a href="#ref-for-running-position②">(3)</a> <a href="#ref-for-running-position③">(4)</a> <a href="#ref-for-running-position④">(5)</a>
@@ -2431,15 +2431,15 @@ Fragmentation in the Masonry Axis</a>
 Absolute Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-masonry-auto-flow">
-   <b><a href="#propdef-masonry-auto-flow">#propdef-masonry-auto-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-masonry-auto-flow" class="dfn-panel" data-for="propdef-masonry-auto-flow" id="infopanel-for-propdef-masonry-auto-flow" role="dialog">
+   <span id="infopaneltitle-for-propdef-masonry-auto-flow" style="display:none">Info about the 'masonry-auto-flow' definition.</span><b><a href="#propdef-masonry-auto-flow">#propdef-masonry-auto-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-masonry-auto-flow">2.5. 
 The masonry-auto-flow Property</a> <a href="#ref-for-propdef-masonry-auto-flow①">(2)</a> <a href="#ref-for-propdef-masonry-auto-flow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="masonry-box">
-   <b><a href="#masonry-box">#masonry-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-masonry-box" class="dfn-panel" data-for="masonry-box" id="infopanel-for-masonry-box" role="dialog">
+   <span id="infopaneltitle-for-masonry-box" style="display:none">Info about the 'masonry box' definition.</span><b><a href="#masonry-box">#masonry-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-masonry-box">6. 
 Alignment and Spacing</a> <a href="#ref-for-masonry-box①">(2)</a>
@@ -2449,8 +2449,8 @@ Baseline Alignment in the Masonry Axis</a>
 Absolute Positioning</a> <a href="#ref-for-masonry-box④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-align-tracks">
-   <b><a href="#propdef-align-tracks">#propdef-align-tracks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-align-tracks" class="dfn-panel" data-for="propdef-align-tracks" id="infopanel-for-propdef-align-tracks" role="dialog">
+   <span id="infopaneltitle-for-propdef-align-tracks" style="display:none">Info about the 'align-tracks' definition.</span><b><a href="#propdef-align-tracks">#propdef-align-tracks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-tracks">6.1. 
 The align-tracks and justify-tracks Properties </a>
@@ -2464,8 +2464,8 @@ Baseline Alignment in the Masonry Axis</a>
 Performance Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-justify-tracks">
-   <b><a href="#propdef-justify-tracks">#propdef-justify-tracks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-justify-tracks" class="dfn-panel" data-for="propdef-justify-tracks" id="infopanel-for-propdef-justify-tracks" role="dialog">
+   <span id="infopaneltitle-for-propdef-justify-tracks" style="display:none">Info about the 'justify-tracks' definition.</span><b><a href="#propdef-justify-tracks">#propdef-justify-tracks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-tracks">6.2. 
 Stretch Alignment in the Masonry Axis</a>
@@ -2477,59 +2477,115 @@ Performance Notes</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-highlight-api-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-highlight-api-1/Overview.html
@@ -1316,43 +1316,43 @@ CSS<c- p>.</c->highlights<c- p>.</c->set<c- p>(</c-><c- t>'bar'</c-><c- p>,</c->
     </ul>
    <li><a href="#registered">registered</a><span>, in § 3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">4.2.2. 
 Cascading and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">4.2.2. 
 Cascading and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-containment" class="dfn-panel" data-for="term-for-style-containment" id="infopanel-for-term-for-style-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-style-containment" style="display:none">Info about the 'style containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-selection">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-selection">https://drafts.csswg.org/css-pseudo-4/#selectordef-selection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-selection" class="dfn-panel" data-for="term-for-selectordef-selection" id="infopanel-for-term-for-selectordef-selection" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-selection" style="display:none">Info about the '::selection' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-selection">https://drafts.csswg.org/css-pseudo-4/#selectordef-selection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-selection">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-spelling-error">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-spelling-error">https://drafts.csswg.org/css-pseudo-4/#selectordef-spelling-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-spelling-error" class="dfn-panel" data-for="term-for-selectordef-spelling-error" id="infopanel-for-term-for-selectordef-spelling-error" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-spelling-error" style="display:none">Info about the '::spelling-error' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-spelling-error">https://drafts.csswg.org/css-pseudo-4/#selectordef-spelling-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-spelling-error">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-highlight-overlay">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#highlight-overlay">https://drafts.csswg.org/css-pseudo-4/#highlight-overlay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-highlight-overlay" class="dfn-panel" data-for="term-for-highlight-overlay" id="infopanel-for-term-for-highlight-overlay" role="menu">
+   <span id="infopaneltitle-for-term-for-highlight-overlay" style="display:none">Info about the 'highlight overlay' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#highlight-overlay">https://drafts.csswg.org/css-pseudo-4/#highlight-overlay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight-overlay">4.2.3. 
 Painting</a> <a href="#ref-for-highlight-overlay①">(2)</a>
@@ -1360,8 +1360,8 @@ Painting</a> <a href="#ref-for-highlight-overlay①">(2)</a>
 Priority of Overlapping Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-highlight-pseudo-element">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#highlight-pseudo-element">https://drafts.csswg.org/css-pseudo-4/#highlight-pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-highlight-pseudo-element" class="dfn-panel" data-for="term-for-highlight-pseudo-element" id="infopanel-for-term-for-highlight-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-highlight-pseudo-element" style="display:none">Info about the 'highlight pseudo-element' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#highlight-pseudo-element">https://drafts.csswg.org/css-pseudo-4/#highlight-pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight-pseudo-element">1. 
 Introduction</a>
@@ -1375,50 +1375,50 @@ Cascading and Inheritance</a>
 Painting</a> <a href="#ref-for-highlight-pseudo-element⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">4.1. 
 The Custom Highlight Pseudo-element: ::highlight()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#style-rule">https://drafts.csswg.org/css-syntax-3/#style-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-rule" class="dfn-panel" data-for="term-for-style-rule" id="infopanel-for-term-for-style-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-style-rule" style="display:none">Info about the 'style rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#style-rule">https://drafts.csswg.org/css-syntax-3/#style-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-rule">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">3.2. 
 Registering Custom Highlights</a> <a href="#ref-for-namespacedef-css①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstractrange">
-   <a href="https://dom.spec.whatwg.org/#abstractrange">https://dom.spec.whatwg.org/#abstractrange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstractrange" class="dfn-panel" data-for="term-for-abstractrange" id="infopanel-for-term-for-abstractrange" role="menu">
+   <span id="infopaneltitle-for-term-for-abstractrange" style="display:none">Info about the 'AbstractRange' external reference.</span><a href="https://dom.spec.whatwg.org/#abstractrange">https://dom.spec.whatwg.org/#abstractrange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractrange">3.1. 
 Creating Custom Highlights</a> <a href="#ref-for-abstractrange①">(2)</a> <a href="#ref-for-abstractrange②">(3)</a> <a href="#ref-for-abstractrange③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range">
-   <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range" class="dfn-panel" data-for="term-for-range" id="infopanel-for-term-for-range" role="menu">
+   <span id="infopaneltitle-for-term-for-range" style="display:none">Info about the 'Range' external reference.</span><a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">1. 
 Introduction</a>
@@ -1430,8 +1430,8 @@ Repaints</a>
 Range Updating and Invalidation</a> <a href="#ref-for-range④">(2)</a> <a href="#ref-for-range⑤">(3)</a> <a href="#ref-for-range⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-staticrange">
-   <a href="https://dom.spec.whatwg.org/#staticrange">https://dom.spec.whatwg.org/#staticrange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-staticrange" class="dfn-panel" data-for="term-for-staticrange" id="infopanel-for-term-for-staticrange" role="menu">
+   <span id="infopaneltitle-for-term-for-staticrange" style="display:none">Info about the 'StaticRange' external reference.</span><a href="https://dom.spec.whatwg.org/#staticrange">https://dom.spec.whatwg.org/#staticrange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-staticrange">3.1. 
 Creating Custom Highlights</a>
@@ -1439,8 +1439,8 @@ Creating Custom Highlights</a>
 Range Updating and Invalidation</a> <a href="#ref-for-staticrange②">(2)</a> <a href="#ref-for-staticrange③">(3)</a> <a href="#ref-for-staticrange④">(4)</a> <a href="#ref-for-staticrange⑤">(5)</a> <a href="#ref-for-staticrange⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-bp">
-   <a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-bp" class="dfn-panel" data-for="term-for-concept-range-bp" id="infopanel-for-term-for-concept-range-bp" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-bp" style="display:none">Info about the 'boundary point' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-bp">https://dom.spec.whatwg.org/#concept-range-bp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp">5.1. 
 Repaints</a>
@@ -1448,64 +1448,64 @@ Repaints</a>
 Range Updating and Invalidation</a> <a href="#ref-for-concept-range-bp②">(2)</a> <a href="#ref-for-concept-range-bp③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range-collapsed">
-   <a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range-collapsed" class="dfn-panel" data-for="term-for-range-collapsed" id="infopanel-for-term-for-range-collapsed" role="menu">
+   <span id="infopaneltitle-for-term-for-range-collapsed" style="display:none">Info about the 'collapsed' external reference.</span><a href="https://dom.spec.whatwg.org/#range-collapsed">https://dom.spec.whatwg.org/#range-collapsed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range-collapsed">4.2.3. 
 Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-contained">
-   <a href="https://dom.spec.whatwg.org/#contained">https://dom.spec.whatwg.org/#contained</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-contained" class="dfn-panel" data-for="term-for-contained" id="infopanel-for-term-for-contained" role="menu">
+   <span id="infopaneltitle-for-term-for-contained" style="display:none">Info about the 'contained' external reference.</span><a href="https://dom.spec.whatwg.org/#contained">https://dom.spec.whatwg.org/#contained</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contained">4.1. 
 The Custom Highlight Pseudo-element: ::highlight()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-end-node">
-   <a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-end-node" class="dfn-panel" data-for="term-for-concept-range-end-node" id="infopanel-for-term-for-concept-range-end-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-end-node" style="display:none">Info about the 'end node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-node">https://dom.spec.whatwg.org/#concept-range-end-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-node">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-end-offset">
-   <a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-end-offset" class="dfn-panel" data-for="term-for-concept-range-end-offset" id="infopanel-for-term-for-concept-range-end-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-end-offset" style="display:none">Info about the 'end offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-end-offset">https://dom.spec.whatwg.org/#concept-range-end-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-offset">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-a-document-tree">
-   <a href="https://dom.spec.whatwg.org/#in-a-document-tree">https://dom.spec.whatwg.org/#in-a-document-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-a-document-tree" class="dfn-panel" data-for="term-for-in-a-document-tree" id="infopanel-for-term-for-in-a-document-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-in-a-document-tree" style="display:none">Info about the 'in a document tree' external reference.</span><a href="https://dom.spec.whatwg.org/#in-a-document-tree">https://dom.spec.whatwg.org/#in-a-document-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-a-document-tree">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-length">
-   <a href="https://dom.spec.whatwg.org/#concept-node-length">https://dom.spec.whatwg.org/#concept-node-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-length" class="dfn-panel" data-for="term-for-concept-node-length" id="infopanel-for-term-for-concept-node-length" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-length" style="display:none">Info about the 'length' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-length">https://dom.spec.whatwg.org/#concept-node-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-length">5.2. 
 Range Updating and Invalidation</a> <a href="#ref-for-concept-node-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-live-range">
-   <a href="https://dom.spec.whatwg.org/#concept-live-range">https://dom.spec.whatwg.org/#concept-live-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-live-range" class="dfn-panel" data-for="term-for-concept-live-range" id="infopanel-for-term-for-concept-live-range" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-live-range" style="display:none">Info about the 'live ranges' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-live-range">https://dom.spec.whatwg.org/#concept-live-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-live-range">5.2. 
 Range Updating and Invalidation</a> <a href="#ref-for-concept-live-range①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-partially-contained">
-   <a href="https://dom.spec.whatwg.org/#partially-contained">https://dom.spec.whatwg.org/#partially-contained</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-partially-contained" class="dfn-panel" data-for="term-for-partially-contained" id="infopanel-for-term-for-partially-contained" role="menu">
+   <span id="infopaneltitle-for-term-for-partially-contained" style="display:none">Info about the 'partially contained' external reference.</span><a href="https://dom.spec.whatwg.org/#partially-contained">https://dom.spec.whatwg.org/#partially-contained</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partially-contained">4.1. 
 The Custom Highlight Pseudo-element: ::highlight()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range">
-   <a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range" class="dfn-panel" data-for="term-for-concept-range" id="infopanel-for-term-for-concept-range" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range" style="display:none">Info about the 'range' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range">https://dom.spec.whatwg.org/#concept-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range">1. 
 Introduction</a>
@@ -1521,57 +1521,57 @@ Repaints</a>
 Range Updating and Invalidation</a> <a href="#ref-for-concept-range⑨">(2)</a> <a href="#ref-for-concept-range①⓪">(3)</a> <a href="#ref-for-concept-range①①">(4)</a> <a href="#ref-for-concept-range①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start-node">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start-node" class="dfn-panel" data-for="term-for-concept-range-start-node" id="infopanel-for-term-for-concept-range-start-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start-node" style="display:none">Info about the 'start node' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-node">https://dom.spec.whatwg.org/#concept-range-start-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-node">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start-offset">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start-offset" class="dfn-panel" data-for="term-for-concept-range-start-offset" id="infopanel-for-term-for-concept-range-start-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start-offset" style="display:none">Info about the 'start offset' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start-offset">https://dom.spec.whatwg.org/#concept-range-start-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-offset">5.2. 
 Range Updating and Invalidation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">2. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specificity">
-   <a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specificity" class="dfn-panel" data-for="term-for-specificity" id="infopanel-for-term-for-specificity" role="menu">
+   <span id="infopaneltitle-for-term-for-specificity" style="display:none">Info about the 'specificity' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specificity">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. 
 Creating Custom Highlights</a>
@@ -1579,43 +1579,43 @@ Creating Custom Highlights</a>
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-idl-to-ecmascript-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value">https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-idl-to-ecmascript-value" class="dfn-panel" data-for="term-for-dfn-convert-idl-to-ecmascript-value" id="infopanel-for-term-for-dfn-convert-idl-to-ecmascript-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-idl-to-ecmascript-value" style="display:none">Info about the 'converted to an ecmascript value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value">https://webidl.spec.whatwg.org/#dfn-convert-idl-to-ecmascript-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-idl-to-ecmascript-value">3.1. 
 Creating Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">3.1. 
 Creating Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-map-entries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-map-entries" class="dfn-panel" data-for="term-for-dfn-map-entries" id="infopanel-for-term-for-dfn-map-entries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-map-entries" style="display:none">Info about the 'map entries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-map-entries">https://webidl.spec.whatwg.org/#dfn-map-entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-map-entries">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-maplike">
-   <a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-maplike" class="dfn-panel" data-for="term-for-dfn-maplike" id="infopanel-for-term-for-dfn-maplike" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-maplike" style="display:none">Info about the 'maplike' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-maplike">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-entries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-set-entries">https://webidl.spec.whatwg.org/#dfn-set-entries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-entries" class="dfn-panel" data-for="term-for-dfn-set-entries" id="infopanel-for-term-for-dfn-set-entries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-entries" style="display:none">Info about the 'set entries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-set-entries">https://webidl.spec.whatwg.org/#dfn-set-entries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-entries">3.1. 
 Creating Custom Highlights</a> <a href="#ref-for-dfn-set-entries①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-setlike">
-   <a href="https://webidl.spec.whatwg.org/#dfn-setlike">https://webidl.spec.whatwg.org/#dfn-setlike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-setlike" class="dfn-panel" data-for="term-for-dfn-setlike" id="infopanel-for-term-for-dfn-setlike" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-setlike" style="display:none">Info about the 'setlike' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-setlike">https://webidl.spec.whatwg.org/#dfn-setlike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-setlike">3.1. 
 Creating Custom Highlights</a> <a href="#ref-for-dfn-setlike①">(2)</a>
@@ -1789,8 +1789,8 @@ Creating Custom Highlights</a> <a href="#ref-for-dfn-setlike①">(2)</a>
 	or should that be added to pseudo-elements in general? <a class="issue-return" href="#issue-230bd93b" title="Jump to section">↵</a></div>
    <div class="issue"> Acknowledge people (other than editors) who deserve credit for this. <a class="issue-return" href="#issue-f0ab6bff" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="custom-highlight">
-   <b><a href="#custom-highlight">#custom-highlight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-highlight" class="dfn-panel" data-for="custom-highlight" id="infopanel-for-custom-highlight" role="dialog">
+   <span id="infopaneltitle-for-custom-highlight" style="display:none">Info about the 'custom highlight' definition.</span><b><a href="#custom-highlight">#custom-highlight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-highlight">3.1. 
 Creating Custom Highlights</a> <a href="#ref-for-custom-highlight①">(2)</a> <a href="#ref-for-custom-highlight②">(3)</a>
@@ -1808,8 +1808,8 @@ Repaints</a> <a href="#ref-for-custom-highlight①⑨">(2)</a> <a href="#ref-for
 Range Updating and Invalidation</a> <a href="#ref-for-custom-highlight②②">(2)</a> <a href="#ref-for-custom-highlight②③">(3)</a> <a href="#ref-for-custom-highlight②④">(4)</a> <a href="#ref-for-custom-highlight②⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="highlight">
-   <b><a href="#highlight">#highlight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-highlight" class="dfn-panel" data-for="highlight" id="infopanel-for-highlight" role="dialog">
+   <span id="infopaneltitle-for-highlight" style="display:none">Info about the 'Highlight' definition.</span><b><a href="#highlight">#highlight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight">1. 
 Introduction</a> <a href="#ref-for-highlight①">(2)</a>
@@ -1819,15 +1819,15 @@ Creating Custom Highlights</a> <a href="#ref-for-highlight③">(2)</a>
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-highlight-highlight-initialranges-initialranges">
-   <b><a href="#dom-highlight-highlight-initialranges-initialranges">#dom-highlight-highlight-initialranges-initialranges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-highlight-highlight-initialranges-initialranges" class="dfn-panel" data-for="dom-highlight-highlight-initialranges-initialranges" id="infopanel-for-dom-highlight-highlight-initialranges-initialranges" role="dialog">
+   <span id="infopaneltitle-for-dom-highlight-highlight-initialranges-initialranges" style="display:none">Info about the 'initialRanges' definition.</span><b><a href="#dom-highlight-highlight-initialranges-initialranges">#dom-highlight-highlight-initialranges-initialranges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-highlight-highlight-initialranges-initialranges">3.1. 
 Creating Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-highlight-priority">
-   <b><a href="#dom-highlight-priority">#dom-highlight-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-highlight-priority" class="dfn-panel" data-for="dom-highlight-priority" id="infopanel-for-dom-highlight-priority" role="dialog">
+   <span id="infopaneltitle-for-dom-highlight-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#dom-highlight-priority">#dom-highlight-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-highlight-priority">3.1. 
 Creating Custom Highlights</a> <a href="#ref-for-dom-highlight-priority①">(2)</a>
@@ -1837,15 +1837,15 @@ Priority of Overlapping Highlights</a> <a href="#ref-for-dom-highlight-priority�
 Repaints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-highlight-highlight">
-   <b><a href="#dom-highlight-highlight">#dom-highlight-highlight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-highlight-highlight" class="dfn-panel" data-for="dom-highlight-highlight" id="infopanel-for-dom-highlight-highlight" role="dialog">
+   <span id="infopaneltitle-for-dom-highlight-highlight" style="display:none">Info about the 'Highlight(AbstractRange... initialRanges)' definition.</span><b><a href="#dom-highlight-highlight">#dom-highlight-highlight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-highlight-highlight">3.1. 
 Creating Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="highlight-registry">
-   <b><a href="#highlight-registry">#highlight-registry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-highlight-registry" class="dfn-panel" data-for="highlight-registry" id="infopanel-for-highlight-registry" role="dialog">
+   <span id="infopaneltitle-for-highlight-registry" style="display:none">Info about the 'highlight registry' definition.</span><b><a href="#highlight-registry">#highlight-registry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight-registry">3.2. 
 Registering Custom Highlights</a> <a href="#ref-for-highlight-registry①">(2)</a> <a href="#ref-for-highlight-registry②">(3)</a>
@@ -1855,8 +1855,8 @@ Priority of Overlapping Highlights</a>
 Repaints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered">
-   <b><a href="#registered">#registered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered" class="dfn-panel" data-for="registered" id="infopanel-for-registered" role="dialog">
+   <span id="infopaneltitle-for-registered" style="display:none">Info about the 'registered' definition.</span><b><a href="#registered">#registered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered">3.2. 
 Registering Custom Highlights</a> <a href="#ref-for-registered①">(2)</a> <a href="#ref-for-registered②">(3)</a> <a href="#ref-for-registered③">(4)</a> <a href="#ref-for-registered④">(5)</a> <a href="#ref-for-registered⑤">(6)</a> <a href="#ref-for-registered⑥">(7)</a>
@@ -1868,15 +1868,15 @@ Priority of Overlapping Highlights</a>
 Repaints</a> <a href="#ref-for-registered①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-highlights">
-   <b><a href="#dom-css-highlights">#dom-css-highlights</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-highlights" class="dfn-panel" data-for="dom-css-highlights" id="infopanel-for-dom-css-highlights" role="dialog">
+   <span id="infopaneltitle-for-dom-css-highlights" style="display:none">Info about the 'highlights' definition.</span><b><a href="#dom-css-highlights">#dom-css-highlights</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-highlights">3.2. 
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="highlightregistry">
-   <b><a href="#highlightregistry">#highlightregistry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-highlightregistry" class="dfn-panel" data-for="highlightregistry" id="infopanel-for-highlightregistry" role="dialog">
+   <span id="infopaneltitle-for-highlightregistry" style="display:none">Info about the 'HighlightRegistry' definition.</span><b><a href="#highlightregistry">#highlightregistry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlightregistry">1. 
 Introduction</a>
@@ -1884,8 +1884,8 @@ Introduction</a>
 Registering Custom Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-highlight-name">
-   <b><a href="#custom-highlight-name">#custom-highlight-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-highlight-name" class="dfn-panel" data-for="custom-highlight-name" id="infopanel-for-custom-highlight-name" role="dialog">
+   <span id="infopaneltitle-for-custom-highlight-name" style="display:none">Info about the 'custom highlight name' definition.</span><b><a href="#custom-highlight-name">#custom-highlight-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-highlight-name">3.2. 
 Registering Custom Highlights</a> <a href="#ref-for-custom-highlight-name①">(2)</a> <a href="#ref-for-custom-highlight-name②">(3)</a>
@@ -1893,8 +1893,8 @@ Registering Custom Highlights</a> <a href="#ref-for-custom-highlight-name①">(2
 The Custom Highlight Pseudo-element: ::highlight()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-highlight-custom-highlight-name">
-   <b><a href="#selectordef-highlight-custom-highlight-name">#selectordef-highlight-custom-highlight-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-highlight-custom-highlight-name" class="dfn-panel" data-for="selectordef-highlight-custom-highlight-name" id="infopanel-for-selectordef-highlight-custom-highlight-name" role="dialog">
+   <span id="infopaneltitle-for-selectordef-highlight-custom-highlight-name" style="display:none">Info about the '::highlight(&lt;custom-highlight-name>)' definition.</span><b><a href="#selectordef-highlight-custom-highlight-name">#selectordef-highlight-custom-highlight-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-highlight-custom-highlight-name">1. 
 Introduction</a> <a href="#ref-for-selectordef-highlight-custom-highlight-name①">(2)</a>
@@ -1902,8 +1902,8 @@ Introduction</a> <a href="#ref-for-selectordef-highlight-custom-highlight-name�
 The Custom Highlight Pseudo-element: ::highlight()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-highlight-pseudo-element">
-   <b><a href="#custom-highlight-pseudo-element">#custom-highlight-pseudo-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-highlight-pseudo-element" class="dfn-panel" data-for="custom-highlight-pseudo-element" id="infopanel-for-custom-highlight-pseudo-element" role="dialog">
+   <span id="infopaneltitle-for-custom-highlight-pseudo-element" style="display:none">Info about the 'custom highlight pseudo-element' definition.</span><b><a href="#custom-highlight-pseudo-element">#custom-highlight-pseudo-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-highlight-pseudo-element">4.2.1. 
 Applicable Properties</a>
@@ -1911,15 +1911,15 @@ Applicable Properties</a>
 Cascading and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-custom-highlight-name">
-   <b><a href="#typedef-custom-highlight-name">#typedef-custom-highlight-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-custom-highlight-name" class="dfn-panel" data-for="typedef-custom-highlight-name" id="infopanel-for-typedef-custom-highlight-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-custom-highlight-name" style="display:none">Info about the '&lt;custom-highlight-name>' definition.</span><b><a href="#typedef-custom-highlight-name">#typedef-custom-highlight-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-highlight-name">4.1. 
 The Custom Highlight Pseudo-element: ::highlight()</a> <a href="#ref-for-typedef-custom-highlight-name①">(2)</a> <a href="#ref-for-typedef-custom-highlight-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="priority">
-   <b><a href="#priority">#priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-priority" class="dfn-panel" data-for="priority" id="infopanel-for-priority" role="dialog">
+   <span id="infopaneltitle-for-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#priority">#priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-priority">4.2.3. 
 Painting</a>
@@ -1929,59 +1929,115 @@ Priority of Overlapping Highlights</a> <a href="#ref-for-priority②">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-3/Overview.html
@@ -3122,33 +3122,33 @@ and editorially rewrote section on gradient color stops to better accommodate th
    <li><a href="#color-transition-hint">transition hint</a><span>, in § 3.4</span>
    <li><a href="#invalid-image">valid image</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2. Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">2. Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.4.3. 
 Color Stop “Fixup”</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2. Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-typedef-color①">3.4. Defining Gradient Color</a>
@@ -3156,27 +3156,27 @@ Color Stop “Fixup”</a>
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">2. Image Values: the &lt;image> type</a> <a href="#ref-for-valdef-color-transparent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">1.1. Module Interactions</a>
     <li><a href="#ref-for-propdef-content①">4.4. Examples of CSS Object Sizing</a> <a href="#ref-for-propdef-content②">(2)</a> <a href="#ref-for-propdef-content③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color-stop">
-   <a href="https://drafts.csswg.org/css-images-4/#typedef-color-stop">https://drafts.csswg.org/css-images-4/#typedef-color-stop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color-stop" class="dfn-panel" data-for="term-for-typedef-color-stop" id="infopanel-for-term-for-typedef-color-stop" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color-stop" style="display:none">Info about the '&lt;color-stop>' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#typedef-color-stop">https://drafts.csswg.org/css-images-4/#typedef-color-stop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-typedef-color-stop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-image">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-image" class="dfn-panel" data-for="term-for-propdef-list-style-image" id="infopanel-for-term-for-propdef-list-style-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">1.1. Module Interactions</a>
     <li><a href="#ref-for-propdef-list-style-image①">2. Image Values: the &lt;image> type</a> <a href="#ref-for-propdef-list-style-image②">(2)</a>
@@ -3185,58 +3185,58 @@ Color Stop Lists</a>
     <li><a href="#ref-for-propdef-list-style-image⑤">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">2. Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-list-style-type-none">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-list-style-type-none" class="dfn-panel" data-for="term-for-valdef-list-style-type-none" id="infopanel-for-term-for-valdef-list-style-type-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-list-style-type-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-type-none">2. Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-mask" class="dfn-panel" data-for="term-for-elementdef-mask" id="infopanel-for-term-for-elementdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-mask">2.1.1. Ambiguous Reference-or-Image URLs</a> <a href="#ref-for-elementdef-mask①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-image">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-image" class="dfn-panel" data-for="term-for-propdef-mask-image" id="infopanel-for-term-for-propdef-mask-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-image" style="display:none">Info about the 'mask-image' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">2.1.1. Ambiguous Reference-or-Image URLs</a> <a href="#ref-for-propdef-mask-image①">(2)</a> <a href="#ref-for-propdef-mask-image②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.1. Object-Sizing Terminology</a>
     <li><a href="#ref-for-propdef-height①">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size" class="dfn-panel" data-for="term-for-intrinsic-size" id="infopanel-for-term-for-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size"> Changes Since the 10 October 2019 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.1. Object-Sizing Terminology</a>
     <li><a href="#ref-for-propdef-width①">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-aspect-ratio" class="dfn-panel" data-for="term-for-preferred-aspect-ratio" id="infopanel-for-term-for-preferred-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#preferred-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">4.3.2. Cover and Contain Constraint Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">1.1. Module Interactions</a>
     <li><a href="#ref-for-propdef-cursor①">2. Image Values: the &lt;image> type</a>
@@ -3244,65 +3244,65 @@ Color Stop Lists</a>
     <li><a href="#ref-for-propdef-cursor③">5.1. Orienting an Image on the Page: the image-orientation property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.4.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">3.4.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3.1.1. linear-gradient() syntax</a>
     <li><a href="#ref-for-comb-comma①">3.4.1. 
 Color Stop Lists</a> <a href="#ref-for-comb-comma②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">3.1.1. linear-gradient() syntax</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a>
     <li><a href="#ref-for-angle-value③">5.1. Orienting an Image on the Page: the image-orientation property </a> <a href="#ref-for-angle-value④">(2)</a> <a href="#ref-for-angle-value⑤">(3)</a> <a href="#ref-for-angle-value⑥">(4)</a> <a href="#ref-for-angle-value⑦">(5)</a> <a href="#ref-for-angle-value⑧">(6)</a> <a href="#ref-for-angle-value⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
     <li><a href="#ref-for-typedef-length-percentage②">3.4.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-length-percentage③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2. Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-length-value①">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-length-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-typedef-position①">(2)</a> <a href="#ref-for-typedef-position②">(3)</a> <a href="#ref-for-typedef-position③">(4)</a> <a href="#ref-for-typedef-position④">(5)</a> <a href="#ref-for-typedef-position⑤">(6)</a> <a href="#ref-for-typedef-position⑥">(7)</a> <a href="#ref-for-typedef-position⑦">(8)</a>
     <li><a href="#ref-for-typedef-position⑧">4.6. Positioning Objects: the object-position property</a> <a href="#ref-for-typedef-position⑨">(2)</a> <a href="#ref-for-typedef-position①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">Unnumbered Section</a>
     <li><a href="#ref-for-url-value①">1.1. Module Interactions</a> <a href="#ref-for-url-value②">(2)</a> <a href="#ref-for-url-value③">(3)</a>
@@ -3310,36 +3310,36 @@ Color Stop Lists</a> <a href="#ref-for-typedef-length-percentage③">(2)</a>
     <li><a href="#ref-for-url-value⑧">2.1.1. Ambiguous Reference-or-Image URLs</a> <a href="#ref-for-url-value⑨">(2)</a> <a href="#ref-for-url-value①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.1.1. linear-gradient() syntax</a>
     <li><a href="#ref-for-mult-opt①">3.4.1. 
 Color Stop Lists</a> <a href="#ref-for-mult-opt②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-degenerate-ratio">
-   <a href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">https://drafts.csswg.org/css-values-4/#degenerate-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-degenerate-ratio" class="dfn-panel" data-for="term-for-degenerate-ratio" id="infopanel-for-term-for-degenerate-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-degenerate-ratio" style="display:none">Info about the 'degenerate ratio' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">https://drafts.csswg.org/css-values-4/#degenerate-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-degenerate-ratio">4.1. Object-Sizing Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2.1. Image References: the url() notation</a> <a href="#ref-for-funcdef-url①">(2)</a> <a href="#ref-for-funcdef-url②">(3)</a>
     <li><a href="#ref-for-funcdef-url③">2.1.1. Ambiguous Reference-or-Image URLs</a>
     <li><a href="#ref-for-funcdef-url④">4.2. CSS⇋Object Negotiation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-comb-one①">3. Gradients</a> <a href="#ref-for-comb-one②">(2)</a> <a href="#ref-for-comb-one③">(3)</a>
@@ -3349,21 +3349,21 @@ Color Stop Lists</a> <a href="#ref-for-mult-opt②">(2)</a>
     <li><a href="#ref-for-comb-one①③">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-comb-one①④">(2)</a> <a href="#ref-for-comb-one①⑤">(3)</a> <a href="#ref-for-comb-one①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.1.1. linear-gradient() syntax</a>
     <li><a href="#ref-for-comb-any①">5.1. Orienting an Image on the Page: the image-orientation property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3.1.1. linear-gradient() syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">1. Introduction</a>
     <li><a href="#ref-for-propdef-background-image①">1.1. Module Interactions</a>
@@ -3375,73 +3375,73 @@ Color Stop “Fixup”</a>
     <li><a href="#ref-for-propdef-background-image⑥">5.1. Orienting an Image on the Page: the image-orientation property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">3.2.1. radial-gradient() Syntax</a>
     <li><a href="#ref-for-propdef-background-position①">4.6. Positioning Objects: the object-position property</a> <a href="#ref-for-propdef-background-position②">(2)</a> <a href="#ref-for-propdef-background-position③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">3. Gradients</a>
     <li><a href="#ref-for-propdef-background-size①">4.1. Object-Sizing Terminology</a>
     <li><a href="#ref-for-propdef-background-size②">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">4.3.1. Default Sizing Algorithm</a>
     <li><a href="#ref-for-propdef-border-image①">4.4. Examples of CSS Object Sizing</a>
     <li><a href="#ref-for-propdef-border-image②">5.1. Orienting an Image on the Page: the image-orientation property </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-repeat" class="dfn-panel" data-for="term-for-propdef-border-image-repeat" id="infopanel-for-term-for-propdef-border-image-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-repeat" style="display:none">Info about the 'border-image-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-repeat">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-position-center">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-position-center" class="dfn-panel" data-for="term-for-valdef-background-position-center" id="infopanel-for-term-for-valdef-background-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-center">3.2.1. radial-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-repeat-round">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-repeat-round">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-repeat-round</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-repeat-round" class="dfn-panel" data-for="term-for-valdef-background-repeat-round" id="infopanel-for-term-for-valdef-background-repeat-round" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-repeat-round" style="display:none">Info about the 'round' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-repeat-round">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-repeat-round</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-repeat-round">4.4. Examples of CSS Object Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">4.1. Object-Sizing Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">4.2. CSS⇋Object Negotiation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-src">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-src" class="dfn-panel" data-for="term-for-attr-img-src" id="infopanel-for-term-for-attr-img-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-src" style="display:none">Info about the 'src' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-src">4.2. CSS⇋Object Negotiation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-pseudo" class="dfn-panel" data-for="term-for-target-pseudo" id="infopanel-for-term-for-target-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-target-pseudo" style="display:none">Info about the ':target' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo">2.1.1. Ambiguous Reference-or-Image URLs</a>
    </ul>
@@ -3659,8 +3659,8 @@ Color Stop “Fixup”</a>
   <div style="counter-reset:issue">
    <div class="issue"> Add a visual example of a color hint being used. <a class="issue-return" href="#issue-7a141efc" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-image">
-   <b><a href="#typedef-image">#typedef-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-image" class="dfn-panel" data-for="typedef-image" id="infopanel-for-typedef-image" role="dialog">
+   <span id="infopaneltitle-for-typedef-image" style="display:none">Info about the '&lt;image>' definition.</span><b><a href="#typedef-image">#typedef-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image④">1.1. Module Interactions</a> <a href="#ref-for-typedef-image⑤">(2)</a> <a href="#ref-for-typedef-image⑥">(3)</a> <a href="#ref-for-typedef-image⑦">(4)</a>
     <li><a href="#ref-for-typedef-image⑧">2. Image Values: the &lt;image> type</a> <a href="#ref-for-typedef-image⑨">(2)</a> <a href="#ref-for-typedef-image①⓪">(3)</a> <a href="#ref-for-typedef-image①①">(4)</a>
@@ -3671,40 +3671,40 @@ Color Stop “Fixup”</a>
     <li><a href="#ref-for-typedef-image①⑧"> Changes Since the 17 April 2012 Candidate Recommendation</a> <a href="#ref-for-typedef-image①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-image">
-   <b><a href="#invalid-image">#invalid-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-image" class="dfn-panel" data-for="invalid-image" id="infopanel-for-invalid-image" role="dialog">
+   <span id="infopaneltitle-for-invalid-image" style="display:none">Info about the 'invalid image' definition.</span><b><a href="#invalid-image">#invalid-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">2. Image Values: the &lt;image> type</a> <a href="#ref-for-invalid-image①">(2)</a> <a href="#ref-for-invalid-image②">(3)</a>
     <li><a href="#ref-for-invalid-image③">2.1. Image References: the url() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="loading-image">
-   <b><a href="#loading-image">#loading-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-loading-image" class="dfn-panel" data-for="loading-image" id="infopanel-for-loading-image" role="dialog">
+   <span id="infopaneltitle-for-loading-image" style="display:none">Info about the 'loading image' definition.</span><b><a href="#loading-image">#loading-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-loading-image">2. Image Values: the &lt;image> type</a> <a href="#ref-for-loading-image①">(2)</a> <a href="#ref-for-loading-image②">(3)</a> <a href="#ref-for-loading-image③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-ambiguous-image-url">
-   <b><a href="#css-ambiguous-image-url">#css-ambiguous-image-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-ambiguous-image-url" class="dfn-panel" data-for="css-ambiguous-image-url" id="infopanel-for-css-ambiguous-image-url" role="dialog">
+   <span id="infopaneltitle-for-css-ambiguous-image-url" style="display:none">Info about the 'ambiguous image URL' definition.</span><b><a href="#css-ambiguous-image-url">#css-ambiguous-image-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-ambiguous-image-url">2.1.1. Ambiguous Reference-or-Image URLs</a> <a href="#ref-for-css-ambiguous-image-url①">(2)</a> <a href="#ref-for-css-ambiguous-image-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-function">
-   <b><a href="#gradient-function">#gradient-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-function" class="dfn-panel" data-for="gradient-function" id="infopanel-for-gradient-function" role="dialog">
+   <span id="infopaneltitle-for-gradient-function" style="display:none">Info about the 'gradient functions' definition.</span><b><a href="#gradient-function">#gradient-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-function">3.4. Defining Gradient Color</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-gradient">
-   <b><a href="#typedef-gradient">#typedef-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-gradient" class="dfn-panel" data-for="typedef-gradient" id="infopanel-for-typedef-gradient" role="dialog">
+   <span id="infopaneltitle-for-typedef-gradient" style="display:none">Info about the '&lt;gradient>' definition.</span><b><a href="#typedef-gradient">#typedef-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-gradient">2. Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-typedef-gradient①">3. Gradients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-box">
-   <b><a href="#gradient-box">#gradient-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-box" class="dfn-panel" data-for="gradient-box" id="infopanel-for-gradient-box" role="dialog">
+   <span id="infopaneltitle-for-gradient-box" style="display:none">Info about the 'gradient box' definition.</span><b><a href="#gradient-box">#gradient-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-box">3. Gradients</a> <a href="#ref-for-gradient-box①">(2)</a>
     <li><a href="#ref-for-gradient-box②">3.1.1. linear-gradient() syntax</a> <a href="#ref-for-gradient-box③">(2)</a> <a href="#ref-for-gradient-box④">(3)</a>
@@ -3713,8 +3713,8 @@ Color Stop “Fixup”</a>
     <li><a href="#ref-for-gradient-box①①">3.2.3. Degenerate Radial Gradients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="starting-point">
-   <b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-starting-point" class="dfn-panel" data-for="starting-point" id="infopanel-for-starting-point" role="dialog">
+   <span id="infopaneltitle-for-starting-point" style="display:none">Info about the 'starting point' definition.</span><b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-point">3.1.1. linear-gradient() syntax</a> <a href="#ref-for-starting-point①">(2)</a>
     <li><a href="#ref-for-starting-point②">3.2.2. Placing Color Stops</a>
@@ -3723,8 +3723,8 @@ Color Stop “Fixup”</a>
 Color Stop Lists</a> <a href="#ref-for-starting-point⑤">(2)</a> <a href="#ref-for-starting-point⑥">(3)</a> <a href="#ref-for-starting-point⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ending-point">
-   <b><a href="#ending-point">#ending-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ending-point" class="dfn-panel" data-for="ending-point" id="infopanel-for-ending-point" role="dialog">
+   <span id="infopaneltitle-for-ending-point" style="display:none">Info about the 'ending point' definition.</span><b><a href="#ending-point">#ending-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ending-point">3.1.1. linear-gradient() syntax</a> <a href="#ref-for-ending-point①">(2)</a>
     <li><a href="#ref-for-ending-point②">3.2.2. Placing Color Stops</a>
@@ -3733,8 +3733,8 @@ Color Stop Lists</a> <a href="#ref-for-starting-point⑤">(2)</a> <a href="#ref-
 Color Stop Lists</a> <a href="#ref-for-ending-point⑤">(2)</a> <a href="#ref-for-ending-point⑥">(3)</a> <a href="#ref-for-ending-point⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-line">
-   <b><a href="#gradient-line">#gradient-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-line" class="dfn-panel" data-for="gradient-line" id="infopanel-for-gradient-line" role="dialog">
+   <span id="infopaneltitle-for-gradient-line" style="display:none">Info about the 'gradient line' definition.</span><b><a href="#gradient-line">#gradient-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-line">3. Gradients</a>
     <li><a href="#ref-for-gradient-line①">3.1. Linear Gradients: the linear-gradient() notation</a>
@@ -3748,8 +3748,8 @@ Color Stop Lists</a> <a href="#ref-for-gradient-line②⑦">(2)</a> <a href="#re
 Coloring the Gradient Line</a> <a href="#ref-for-gradient-line③①">(2)</a> <a href="#ref-for-gradient-line③②">(3)</a> <a href="#ref-for-gradient-line③③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-linear-gradient">
-   <b><a href="#funcdef-linear-gradient">#funcdef-linear-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-linear-gradient" class="dfn-panel" data-for="funcdef-linear-gradient" id="infopanel-for-funcdef-linear-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-linear-gradient" style="display:none">Info about the 'linear-gradient()' definition.</span><b><a href="#funcdef-linear-gradient">#funcdef-linear-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-linear-gradient">3. Gradients</a>
     <li><a href="#ref-for-funcdef-linear-gradient①">3.1. Linear Gradients: the linear-gradient() notation</a>
@@ -3759,14 +3759,14 @@ Coloring the Gradient Line</a> <a href="#ref-for-gradient-line③①">(2)</a> <a
     <li><a href="#ref-for-funcdef-linear-gradient⑤"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-side-or-corner">
-   <b><a href="#typedef-side-or-corner">#typedef-side-or-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-side-or-corner" class="dfn-panel" data-for="typedef-side-or-corner" id="infopanel-for-typedef-side-or-corner" role="dialog">
+   <span id="infopaneltitle-for-typedef-side-or-corner" style="display:none">Info about the '&lt;side-or-corner>' definition.</span><b><a href="#typedef-side-or-corner">#typedef-side-or-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-side-or-corner">3.1.1. linear-gradient() syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ending-shape">
-   <b><a href="#ending-shape">#ending-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ending-shape" class="dfn-panel" data-for="ending-shape" id="infopanel-for-ending-shape" role="dialog">
+   <span id="infopaneltitle-for-ending-shape" style="display:none">Info about the 'ending shape' definition.</span><b><a href="#ending-shape">#ending-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ending-shape">3.2. Radial Gradients: the radial-gradient() notation</a>
     <li><a href="#ref-for-ending-shape①">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-ending-shape②">(2)</a> <a href="#ref-for-ending-shape③">(3)</a> <a href="#ref-for-ending-shape④">(4)</a> <a href="#ref-for-ending-shape⑤">(5)</a> <a href="#ref-for-ending-shape⑥">(6)</a> <a href="#ref-for-ending-shape⑦">(7)</a> <a href="#ref-for-ending-shape⑧">(8)</a> <a href="#ref-for-ending-shape⑨">(9)</a>
@@ -3774,93 +3774,93 @@ Coloring the Gradient Line</a> <a href="#ref-for-gradient-line③①">(2)</a> <a
     <li><a href="#ref-for-ending-shape①①">3.2.3. Degenerate Radial Gradients</a> <a href="#ref-for-ending-shape①②">(2)</a> <a href="#ref-for-ending-shape①③">(3)</a> <a href="#ref-for-ending-shape①④">(4)</a> <a href="#ref-for-ending-shape①⑤">(5)</a> <a href="#ref-for-ending-shape①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-radial-gradient">
-   <b><a href="#funcdef-radial-gradient">#funcdef-radial-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-radial-gradient" class="dfn-panel" data-for="funcdef-radial-gradient" id="infopanel-for-funcdef-radial-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-radial-gradient" style="display:none">Info about the 'radial-gradient()' definition.</span><b><a href="#funcdef-radial-gradient">#funcdef-radial-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-radial-gradient">3. Gradients</a>
     <li><a href="#ref-for-funcdef-radial-gradient①">3.2. Radial Gradients: the radial-gradient() notation</a>
     <li><a href="#ref-for-funcdef-radial-gradient②">3.3. Repeating Gradients: the repeating-linear-gradient() and repeating-radial-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="radial-gradient-gradient-center">
-   <b><a href="#radial-gradient-gradient-center">#radial-gradient-gradient-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-radial-gradient-gradient-center" class="dfn-panel" data-for="radial-gradient-gradient-center" id="infopanel-for-radial-gradient-gradient-center" role="dialog">
+   <span id="infopaneltitle-for-radial-gradient-gradient-center" style="display:none">Info about the 'center' definition.</span><b><a href="#radial-gradient-gradient-center">#radial-gradient-gradient-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-radial-gradient-gradient-center">3.2. Radial Gradients: the radial-gradient() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ending-shape-circle">
-   <b><a href="#valdef-ending-shape-circle">#valdef-ending-shape-circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ending-shape-circle" class="dfn-panel" data-for="valdef-ending-shape-circle" id="infopanel-for-valdef-ending-shape-circle" role="dialog">
+   <span id="infopaneltitle-for-valdef-ending-shape-circle" style="display:none">Info about the 'circle' definition.</span><b><a href="#valdef-ending-shape-circle">#valdef-ending-shape-circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ending-shape-circle">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-valdef-ending-shape-circle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ending-shape-ellipse">
-   <b><a href="#valdef-ending-shape-ellipse">#valdef-ending-shape-ellipse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ending-shape-ellipse" class="dfn-panel" data-for="valdef-ending-shape-ellipse" id="infopanel-for-valdef-ending-shape-ellipse" role="dialog">
+   <span id="infopaneltitle-for-valdef-ending-shape-ellipse" style="display:none">Info about the 'ellipse' definition.</span><b><a href="#valdef-ending-shape-ellipse">#valdef-ending-shape-ellipse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ending-shape-ellipse">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-valdef-ending-shape-ellipse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-size">
-   <b><a href="#typedef-size">#typedef-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-size" class="dfn-panel" data-for="typedef-size" id="infopanel-for-typedef-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-size" style="display:none">Info about the '&lt;size>' definition.</span><b><a href="#typedef-size">#typedef-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-size">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-typedef-size①">(2)</a> <a href="#ref-for-typedef-size②">(3)</a> <a href="#ref-for-typedef-size③">(4)</a> <a href="#ref-for-typedef-size④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-size-closest-side">
-   <b><a href="#valdef-size-closest-side">#valdef-size-closest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-size-closest-side" class="dfn-panel" data-for="valdef-size-closest-side" id="infopanel-for-valdef-size-closest-side" role="dialog">
+   <span id="infopaneltitle-for-valdef-size-closest-side" style="display:none">Info about the 'closest-side' definition.</span><b><a href="#valdef-size-closest-side">#valdef-size-closest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-size-closest-side">3.2.1. radial-gradient() Syntax</a> <a href="#ref-for-valdef-size-closest-side①">(2)</a>
     <li><a href="#ref-for-valdef-size-closest-side②">3.2.3. Degenerate Radial Gradients</a>
     <li><a href="#ref-for-valdef-size-closest-side③">3.2.4. Radial Gradient Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-size-farthest-side">
-   <b><a href="#valdef-size-farthest-side">#valdef-size-farthest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-size-farthest-side" class="dfn-panel" data-for="valdef-size-farthest-side" id="infopanel-for-valdef-size-farthest-side" role="dialog">
+   <span id="infopaneltitle-for-valdef-size-farthest-side" style="display:none">Info about the 'farthest-side' definition.</span><b><a href="#valdef-size-farthest-side">#valdef-size-farthest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-size-farthest-side">3.2.1. radial-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-size-closest-corner">
-   <b><a href="#valdef-size-closest-corner">#valdef-size-closest-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-size-closest-corner" class="dfn-panel" data-for="valdef-size-closest-corner" id="infopanel-for-valdef-size-closest-corner" role="dialog">
+   <span id="infopaneltitle-for-valdef-size-closest-corner" style="display:none">Info about the 'closest-corner' definition.</span><b><a href="#valdef-size-closest-corner">#valdef-size-closest-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-size-closest-corner">3.2.1. radial-gradient() Syntax</a>
     <li><a href="#ref-for-valdef-size-closest-corner①">3.2.3. Degenerate Radial Gradients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-size-farthest-corner">
-   <b><a href="#valdef-size-farthest-corner">#valdef-size-farthest-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-size-farthest-corner" class="dfn-panel" data-for="valdef-size-farthest-corner" id="infopanel-for-valdef-size-farthest-corner" role="dialog">
+   <span id="infopaneltitle-for-valdef-size-farthest-corner" style="display:none">Info about the 'farthest-corner' definition.</span><b><a href="#valdef-size-farthest-corner">#valdef-size-farthest-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-size-farthest-corner">3.2.1. radial-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-extent-keyword">
-   <b><a href="#typedef-extent-keyword">#typedef-extent-keyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-extent-keyword" class="dfn-panel" data-for="typedef-extent-keyword" id="infopanel-for-typedef-extent-keyword" role="dialog">
+   <span id="infopaneltitle-for-typedef-extent-keyword" style="display:none">Info about the '&lt;extent-keyword>' definition.</span><b><a href="#typedef-extent-keyword">#typedef-extent-keyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-extent-keyword">3.2.1. radial-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeating-linear-gradient">
-   <b><a href="#funcdef-repeating-linear-gradient">#funcdef-repeating-linear-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeating-linear-gradient" class="dfn-panel" data-for="funcdef-repeating-linear-gradient" id="infopanel-for-funcdef-repeating-linear-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeating-linear-gradient" style="display:none">Info about the 'repeating-linear-gradient()' definition.</span><b><a href="#funcdef-repeating-linear-gradient">#funcdef-repeating-linear-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeating-linear-gradient">3. Gradients</a>
     <li><a href="#ref-for-funcdef-repeating-linear-gradient①">3.3. Repeating Gradients: the repeating-linear-gradient() and repeating-radial-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeating-radial-gradient">
-   <b><a href="#funcdef-repeating-radial-gradient">#funcdef-repeating-radial-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeating-radial-gradient" class="dfn-panel" data-for="funcdef-repeating-radial-gradient" id="infopanel-for-funcdef-repeating-radial-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeating-radial-gradient" style="display:none">Info about the 'repeating-radial-gradient()' definition.</span><b><a href="#funcdef-repeating-radial-gradient">#funcdef-repeating-radial-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeating-radial-gradient">3. Gradients</a>
     <li><a href="#ref-for-funcdef-repeating-radial-gradient①">3.3. Repeating Gradients: the repeating-linear-gradient() and repeating-radial-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-average-color">
-   <b><a href="#gradient-average-color">#gradient-average-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-average-color" class="dfn-panel" data-for="gradient-average-color" id="infopanel-for-gradient-average-color" role="dialog">
+   <span id="infopaneltitle-for-gradient-average-color" style="display:none">Info about the 'find the average color of a gradient' definition.</span><b><a href="#gradient-average-color">#gradient-average-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-average-color">3.3. Repeating Gradients: the repeating-linear-gradient() and repeating-radial-gradient() notations</a> <a href="#ref-for-gradient-average-color①">(2)</a> <a href="#ref-for-gradient-average-color②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-stop">
-   <b><a href="#color-stop">#color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-stop" class="dfn-panel" data-for="color-stop" id="infopanel-for-color-stop" role="dialog">
+   <span id="infopaneltitle-for-color-stop" style="display:none">Info about the 'color stops' definition.</span><b><a href="#color-stop">#color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-stop">3.4. Defining Gradient Color</a>
     <li><a href="#ref-for-color-stop①">3.4.1. 
@@ -3871,8 +3871,8 @@ Coloring the Gradient Line</a> <a href="#ref-for-color-stop⑦">(2)</a> <a href=
 Color Stop “Fixup”</a> <a href="#ref-for-color-stop②③">(2)</a> <a href="#ref-for-color-stop②④">(3)</a> <a href="#ref-for-color-stop②⑤">(4)</a> <a href="#ref-for-color-stop②⑥">(5)</a> <a href="#ref-for-color-stop②⑦">(6)</a> <a href="#ref-for-color-stop②⑧">(7)</a> <a href="#ref-for-color-stop②⑨">(8)</a> <a href="#ref-for-color-stop③⓪">(9)</a> <a href="#ref-for-color-stop③①">(10)</a> <a href="#ref-for-color-stop③②">(11)</a> <a href="#ref-for-color-stop③③">(12)</a> <a href="#ref-for-color-stop③④">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-transition-hint">
-   <b><a href="#color-transition-hint">#color-transition-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-transition-hint" class="dfn-panel" data-for="color-transition-hint" id="infopanel-for-color-transition-hint" role="dialog">
+   <span id="infopaneltitle-for-color-transition-hint" style="display:none">Info about the 'color transition hints' definition.</span><b><a href="#color-transition-hint">#color-transition-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-transition-hint">3.4.1. 
 Color Stop Lists</a> <a href="#ref-for-color-transition-hint①">(2)</a> <a href="#ref-for-color-transition-hint②">(3)</a>
@@ -3883,37 +3883,37 @@ Color Stop “Fixup”</a> <a href="#ref-for-color-transition-hint⑦">(2)</a> <
     <li><a href="#ref-for-color-transition-hint①⓪"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-stop-list">
-   <b><a href="#color-stop-list">#color-stop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-stop-list" class="dfn-panel" data-for="color-stop-list" id="infopanel-for-color-stop-list" role="dialog">
+   <span id="infopaneltitle-for-color-stop-list" style="display:none">Info about the 'color stop list' definition.</span><b><a href="#color-stop-list">#color-stop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-stop-list">3.4.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-stop-list">
-   <b><a href="#typedef-color-stop-list">#typedef-color-stop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-stop-list" class="dfn-panel" data-for="typedef-color-stop-list" id="infopanel-for-typedef-color-stop-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-stop-list" style="display:none">Info about the '&lt;color-stop-list>' definition.</span><b><a href="#typedef-color-stop-list">#typedef-color-stop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop-list">3.1.1. linear-gradient() syntax</a>
     <li><a href="#ref-for-typedef-color-stop-list①">3.2.1. radial-gradient() Syntax</a>
     <li><a href="#ref-for-typedef-color-stop-list②"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-linear-color-stop">
-   <b><a href="#typedef-linear-color-stop">#typedef-linear-color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-linear-color-stop" class="dfn-panel" data-for="typedef-linear-color-stop" id="infopanel-for-typedef-linear-color-stop" role="dialog">
+   <span id="infopaneltitle-for-typedef-linear-color-stop" style="display:none">Info about the '&lt;linear-color-stop>' definition.</span><b><a href="#typedef-linear-color-stop">#typedef-linear-color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-linear-color-stop">3.4.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-linear-color-stop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-linear-color-hint">
-   <b><a href="#typedef-linear-color-hint">#typedef-linear-color-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-linear-color-hint" class="dfn-panel" data-for="typedef-linear-color-hint" id="infopanel-for-typedef-linear-color-hint" role="dialog">
+   <span id="infopaneltitle-for-typedef-linear-color-hint" style="display:none">Info about the '&lt;linear-color-hint>' definition.</span><b><a href="#typedef-linear-color-hint">#typedef-linear-color-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-linear-color-hint">3.4.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="objects">
-   <b><a href="#objects">#objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-objects" class="dfn-panel" data-for="objects" id="infopanel-for-objects" role="dialog">
+   <span id="infopaneltitle-for-objects" style="display:none">Info about the 'objects' definition.</span><b><a href="#objects">#objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-objects">4.1. Object-Sizing Terminology</a> <a href="#ref-for-objects①">(2)</a> <a href="#ref-for-objects②">(3)</a> <a href="#ref-for-objects③">(4)</a> <a href="#ref-for-objects④">(5)</a> <a href="#ref-for-objects⑤">(6)</a> <a href="#ref-for-objects⑥">(7)</a>
     <li><a href="#ref-for-objects⑦">4.2. CSS⇋Object Negotiation</a> <a href="#ref-for-objects⑧">(2)</a> <a href="#ref-for-objects⑨">(3)</a> <a href="#ref-for-objects①⓪">(4)</a> <a href="#ref-for-objects①①">(5)</a> <a href="#ref-for-objects①②">(6)</a> <a href="#ref-for-objects①③">(7)</a> <a href="#ref-for-objects①④">(8)</a> <a href="#ref-for-objects①⑤">(9)</a>
@@ -3922,8 +3922,8 @@ Color Stop Lists</a>
     <li><a href="#ref-for-objects②④">4.3.2. Cover and Contain Constraint Sizing</a> <a href="#ref-for-objects②⑤">(2)</a> <a href="#ref-for-objects②⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-dimensions">
-   <b><a href="#natural-dimensions">#natural-dimensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-dimensions" class="dfn-panel" data-for="natural-dimensions" id="infopanel-for-natural-dimensions" role="dialog">
+   <span id="infopaneltitle-for-natural-dimensions" style="display:none">Info about the 'natural dimensions' definition.</span><b><a href="#natural-dimensions">#natural-dimensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">2. Image Values: the &lt;image> type</a> <a href="#ref-for-natural-dimensions①">(2)</a> <a href="#ref-for-natural-dimensions②">(3)</a>
     <li><a href="#ref-for-natural-dimensions③">3. Gradients</a>
@@ -3935,20 +3935,20 @@ Color Stop Lists</a>
     <li><a href="#ref-for-natural-dimensions②①"> Changes Since the 10 October 2019 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-height">
-   <b><a href="#natural-height">#natural-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-height" class="dfn-panel" data-for="natural-height" id="infopanel-for-natural-height" role="dialog">
+   <span id="infopaneltitle-for-natural-height" style="display:none">Info about the 'natural height' definition.</span><b><a href="#natural-height">#natural-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">4.1. Object-Sizing Terminology</a> <a href="#ref-for-natural-height①">(2)</a> <a href="#ref-for-natural-height②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-width">
-   <b><a href="#natural-width">#natural-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-width" class="dfn-panel" data-for="natural-width" id="infopanel-for-natural-width" role="dialog">
+   <span id="infopaneltitle-for-natural-width" style="display:none">Info about the 'natural width' definition.</span><b><a href="#natural-width">#natural-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-width">4.1. Object-Sizing Terminology</a> <a href="#ref-for-natural-width①">(2)</a> <a href="#ref-for-natural-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-aspect-ratio">
-   <b><a href="#natural-aspect-ratio">#natural-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-aspect-ratio" class="dfn-panel" data-for="natural-aspect-ratio" id="infopanel-for-natural-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' definition.</span><b><a href="#natural-aspect-ratio">#natural-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">4.1. Object-Sizing Terminology</a> <a href="#ref-for-natural-aspect-ratio①">(2)</a> <a href="#ref-for-natural-aspect-ratio②">(3)</a> <a href="#ref-for-natural-aspect-ratio③">(4)</a>
     <li><a href="#ref-for-natural-aspect-ratio④">4.3.1. Default Sizing Algorithm</a>
@@ -3956,8 +3956,8 @@ Color Stop Lists</a>
     <li><a href="#ref-for-natural-aspect-ratio⑧">4.5. Sizing Objects: the object-fit property</a> <a href="#ref-for-natural-aspect-ratio⑨">(2)</a> <a href="#ref-for-natural-aspect-ratio①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-size">
-   <b><a href="#specified-size">#specified-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-size" class="dfn-panel" data-for="specified-size" id="infopanel-for-specified-size" role="dialog">
+   <span id="infopaneltitle-for-specified-size" style="display:none">Info about the 'specified size' definition.</span><b><a href="#specified-size">#specified-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size">4.1. Object-Sizing Terminology</a> <a href="#ref-for-specified-size①">(2)</a>
     <li><a href="#ref-for-specified-size②">4.2. CSS⇋Object Negotiation</a>
@@ -3965,8 +3965,8 @@ Color Stop Lists</a>
     <li><a href="#ref-for-specified-size⑧">4.4. Examples of CSS Object Sizing</a> <a href="#ref-for-specified-size⑨">(2)</a> <a href="#ref-for-specified-size①⓪">(3)</a> <a href="#ref-for-specified-size①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concrete-object-size">
-   <b><a href="#concrete-object-size">#concrete-object-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concrete-object-size" class="dfn-panel" data-for="concrete-object-size" id="infopanel-for-concrete-object-size" role="dialog">
+   <span id="infopaneltitle-for-concrete-object-size" style="display:none">Info about the 'concrete object size' definition.</span><b><a href="#concrete-object-size">#concrete-object-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concrete-object-size">3. Gradients</a>
     <li><a href="#ref-for-concrete-object-size①">4.1. Object-Sizing Terminology</a> <a href="#ref-for-concrete-object-size②">(2)</a>
@@ -3978,8 +3978,8 @@ Color Stop Lists</a>
     <li><a href="#ref-for-concrete-object-size②⑧">4.6. Positioning Objects: the object-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-object-size">
-   <b><a href="#default-object-size">#default-object-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-object-size" class="dfn-panel" data-for="default-object-size" id="infopanel-for-default-object-size" role="dialog">
+   <span id="infopaneltitle-for-default-object-size" style="display:none">Info about the 'default object size' definition.</span><b><a href="#default-object-size">#default-object-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3. Gradients</a>
     <li><a href="#ref-for-default-object-size①">4.1. Object-Sizing Terminology</a> <a href="#ref-for-default-object-size②">(2)</a> <a href="#ref-for-default-object-size③">(3)</a> <a href="#ref-for-default-object-size④">(4)</a>
@@ -3989,22 +3989,22 @@ Color Stop Lists</a>
     <li><a href="#ref-for-default-object-size①③">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-size-negotiation">
-   <b><a href="#object-size-negotiation">#object-size-negotiation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-size-negotiation" class="dfn-panel" data-for="object-size-negotiation" id="infopanel-for-object-size-negotiation" role="dialog">
+   <span id="infopaneltitle-for-object-size-negotiation" style="display:none">Info about the 'object size negotiation' definition.</span><b><a href="#object-size-negotiation">#object-size-negotiation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-size-negotiation">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-sizing-algorithm">
-   <b><a href="#default-sizing-algorithm">#default-sizing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-sizing-algorithm" class="dfn-panel" data-for="default-sizing-algorithm" id="infopanel-for-default-sizing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-default-sizing-algorithm" style="display:none">Info about the 'default sizing algorithm' definition.</span><b><a href="#default-sizing-algorithm">#default-sizing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sizing-algorithm">4.3.1. Default Sizing Algorithm</a> <a href="#ref-for-default-sizing-algorithm①">(2)</a>
     <li><a href="#ref-for-default-sizing-algorithm②">4.4. Examples of CSS Object Sizing</a> <a href="#ref-for-default-sizing-algorithm③">(2)</a> <a href="#ref-for-default-sizing-algorithm④">(3)</a> <a href="#ref-for-default-sizing-algorithm⑤">(4)</a> <a href="#ref-for-default-sizing-algorithm⑥">(5)</a>
     <li><a href="#ref-for-default-sizing-algorithm⑦">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contain-constraint">
-   <b><a href="#contain-constraint">#contain-constraint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contain-constraint" class="dfn-panel" data-for="contain-constraint" id="infopanel-for-contain-constraint" role="dialog">
+   <span id="infopaneltitle-for-contain-constraint" style="display:none">Info about the 'contain constraint' definition.</span><b><a href="#contain-constraint">#contain-constraint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contain-constraint">4.1. Object-Sizing Terminology</a>
     <li><a href="#ref-for-contain-constraint①">4.3.1. Default Sizing Algorithm</a>
@@ -4013,50 +4013,50 @@ Color Stop Lists</a>
     <li><a href="#ref-for-contain-constraint④">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cover-constraint">
-   <b><a href="#cover-constraint">#cover-constraint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cover-constraint" class="dfn-panel" data-for="cover-constraint" id="infopanel-for-cover-constraint" role="dialog">
+   <span id="infopaneltitle-for-cover-constraint" style="display:none">Info about the 'cover constraint' definition.</span><b><a href="#cover-constraint">#cover-constraint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cover-constraint">4.3.2. Cover and Contain Constraint Sizing</a>
     <li><a href="#ref-for-cover-constraint①">4.4. Examples of CSS Object Sizing</a>
     <li><a href="#ref-for-cover-constraint②">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-object-fit">
-   <b><a href="#propdef-object-fit">#propdef-object-fit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-object-fit" class="dfn-panel" data-for="propdef-object-fit" id="infopanel-for-propdef-object-fit" role="dialog">
+   <span id="infopaneltitle-for-propdef-object-fit" style="display:none">Info about the 'object-fit' definition.</span><b><a href="#propdef-object-fit">#propdef-object-fit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-fit">4.4. Examples of CSS Object Sizing</a>
     <li><a href="#ref-for-propdef-object-fit①">4.5. Sizing Objects: the object-fit property</a> <a href="#ref-for-propdef-object-fit②">(2)</a> <a href="#ref-for-propdef-object-fit③">(3)</a> <a href="#ref-for-propdef-object-fit④">(4)</a>
     <li><a href="#ref-for-propdef-object-fit⑤"> Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-contain">
-   <b><a href="#valdef-object-fit-contain">#valdef-object-fit-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-contain" class="dfn-panel" data-for="valdef-object-fit-contain" id="infopanel-for-valdef-object-fit-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-object-fit-contain">#valdef-object-fit-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-contain">4.5. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-contain①">(2)</a> <a href="#ref-for-valdef-object-fit-contain②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-none">
-   <b><a href="#valdef-object-fit-none">#valdef-object-fit-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-none" class="dfn-panel" data-for="valdef-object-fit-none" id="infopanel-for-valdef-object-fit-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-object-fit-none">#valdef-object-fit-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-none">4.5. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-scale-down">
-   <b><a href="#valdef-object-fit-scale-down">#valdef-object-fit-scale-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-scale-down" class="dfn-panel" data-for="valdef-object-fit-scale-down" id="infopanel-for-valdef-object-fit-scale-down" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-scale-down" style="display:none">Info about the 'scale-down' definition.</span><b><a href="#valdef-object-fit-scale-down">#valdef-object-fit-scale-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-scale-down">4.5. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-object-position">
-   <b><a href="#propdef-object-position">#propdef-object-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-object-position" class="dfn-panel" data-for="propdef-object-position" id="infopanel-for-propdef-object-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-object-position" style="display:none">Info about the 'object-position' definition.</span><b><a href="#propdef-object-position">#propdef-object-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-position">4.5. Sizing Objects: the object-fit property</a> <a href="#ref-for-propdef-object-position①">(2)</a>
     <li><a href="#ref-for-propdef-object-position②">4.6. Positioning Objects: the object-position property</a> <a href="#ref-for-propdef-object-position③">(2)</a>
     <li><a href="#ref-for-propdef-object-position④"> Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-image-orientation">
-   <b><a href="#propdef-image-orientation">#propdef-image-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-image-orientation" class="dfn-panel" data-for="propdef-image-orientation" id="infopanel-for-propdef-image-orientation" role="dialog">
+   <span id="infopaneltitle-for-propdef-image-orientation" style="display:none">Info about the 'image-orientation' definition.</span><b><a href="#propdef-image-orientation">#propdef-image-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-orientation①">5.1. Orienting an Image on the Page: the image-orientation property </a> <a href="#ref-for-propdef-image-orientation②">(2)</a> <a href="#ref-for-propdef-image-orientation③">(3)</a>
     <li><a href="#ref-for-propdef-image-orientation④"> Acknowledgments</a>
@@ -4064,60 +4064,60 @@ Color Stop Lists</a>
     <li><a href="#ref-for-propdef-image-orientation⑥"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-orientation-none">
-   <b><a href="#valdef-image-orientation-none">#valdef-image-orientation-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-orientation-none" class="dfn-panel" data-for="valdef-image-orientation-none" id="infopanel-for-valdef-image-orientation-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-orientation-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-image-orientation-none">#valdef-image-orientation-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-orientation-none">5.1. Orienting an Image on the Page: the image-orientation property </a> <a href="#ref-for-valdef-image-orientation-none①">(2)</a> <a href="#ref-for-valdef-image-orientation-none②">(3)</a>
     <li><a href="#ref-for-valdef-image-orientation-none③"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-orientation-from-image">
-   <b><a href="#valdef-image-orientation-from-image">#valdef-image-orientation-from-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-orientation-from-image" class="dfn-panel" data-for="valdef-image-orientation-from-image" id="infopanel-for-valdef-image-orientation-from-image" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-orientation-from-image" style="display:none">Info about the 'from-image' definition.</span><b><a href="#valdef-image-orientation-from-image">#valdef-image-orientation-from-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-orientation-from-image">5.1. Orienting an Image on the Page: the image-orientation property </a> <a href="#ref-for-valdef-image-orientation-from-image①">(2)</a> <a href="#ref-for-valdef-image-orientation-from-image②">(3)</a> <a href="#ref-for-valdef-image-orientation-from-image③">(4)</a>
     <li><a href="#ref-for-valdef-image-orientation-from-image④"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-orientation-angle">
-   <b><a href="#valdef-image-orientation-angle">#valdef-image-orientation-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-orientation-angle" class="dfn-panel" data-for="valdef-image-orientation-angle" id="infopanel-for-valdef-image-orientation-angle" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-orientation-angle" style="display:none">Info about the '&lt;angle> || flip' definition.</span><b><a href="#valdef-image-orientation-angle">#valdef-image-orientation-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-orientation-angle">5.1. Orienting an Image on the Page: the image-orientation property </a> <a href="#ref-for-valdef-image-orientation-angle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-image-rendering">
-   <b><a href="#propdef-image-rendering">#propdef-image-rendering</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-image-rendering" class="dfn-panel" data-for="propdef-image-rendering" id="infopanel-for-propdef-image-rendering" role="dialog">
+   <span id="infopaneltitle-for-propdef-image-rendering" style="display:none">Info about the 'image-rendering' definition.</span><b><a href="#propdef-image-rendering">#propdef-image-rendering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-rendering">1.1. Module Interactions</a>
     <li><a href="#ref-for-propdef-image-rendering①">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-propdef-image-rendering②">(2)</a> <a href="#ref-for-propdef-image-rendering③">(3)</a> <a href="#ref-for-propdef-image-rendering④">(4)</a> <a href="#ref-for-propdef-image-rendering⑤">(5)</a>
     <li><a href="#ref-for-propdef-image-rendering⑥"> Changes Since the 17 April 2012 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-rendering-auto">
-   <b><a href="#valdef-image-rendering-auto">#valdef-image-rendering-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-rendering-auto" class="dfn-panel" data-for="valdef-image-rendering-auto" id="infopanel-for-valdef-image-rendering-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-rendering-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-image-rendering-auto">#valdef-image-rendering-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-rendering-auto">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-valdef-image-rendering-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-rendering-smooth">
-   <b><a href="#valdef-image-rendering-smooth">#valdef-image-rendering-smooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-rendering-smooth" class="dfn-panel" data-for="valdef-image-rendering-smooth" id="infopanel-for-valdef-image-rendering-smooth" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-rendering-smooth" style="display:none">Info about the 'smooth' definition.</span><b><a href="#valdef-image-rendering-smooth">#valdef-image-rendering-smooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-rendering-smooth">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-valdef-image-rendering-smooth①">(2)</a> <a href="#ref-for-valdef-image-rendering-smooth②">(3)</a> <a href="#ref-for-valdef-image-rendering-smooth③">(4)</a> <a href="#ref-for-valdef-image-rendering-smooth④">(5)</a> <a href="#ref-for-valdef-image-rendering-smooth⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-rendering-high-quality">
-   <b><a href="#valdef-image-rendering-high-quality">#valdef-image-rendering-high-quality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-rendering-high-quality" class="dfn-panel" data-for="valdef-image-rendering-high-quality" id="infopanel-for-valdef-image-rendering-high-quality" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-rendering-high-quality" style="display:none">Info about the 'high-quality' definition.</span><b><a href="#valdef-image-rendering-high-quality">#valdef-image-rendering-high-quality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-rendering-high-quality">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-valdef-image-rendering-high-quality①">(2)</a> <a href="#ref-for-valdef-image-rendering-high-quality②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-rendering-pixelated">
-   <b><a href="#valdef-image-rendering-pixelated">#valdef-image-rendering-pixelated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-rendering-pixelated" class="dfn-panel" data-for="valdef-image-rendering-pixelated" id="infopanel-for-valdef-image-rendering-pixelated" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-rendering-pixelated" style="display:none">Info about the 'pixelated' definition.</span><b><a href="#valdef-image-rendering-pixelated">#valdef-image-rendering-pixelated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-rendering-pixelated">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-valdef-image-rendering-pixelated①">(2)</a> <a href="#ref-for-valdef-image-rendering-pixelated②">(3)</a> <a href="#ref-for-valdef-image-rendering-pixelated③">(4)</a> <a href="#ref-for-valdef-image-rendering-pixelated④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-rendering-crisp-edges">
-   <b><a href="#valdef-image-rendering-crisp-edges">#valdef-image-rendering-crisp-edges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-rendering-crisp-edges" class="dfn-panel" data-for="valdef-image-rendering-crisp-edges" id="infopanel-for-valdef-image-rendering-crisp-edges" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-rendering-crisp-edges" style="display:none">Info about the 'crisp-edges' definition.</span><b><a href="#valdef-image-rendering-crisp-edges">#valdef-image-rendering-crisp-edges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-rendering-crisp-edges">5.2. Determining How To Scale an Image: the image-rendering property</a> <a href="#ref-for-valdef-image-rendering-crisp-edges①">(2)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges②">(3)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges③">(4)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges④">(5)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges⑤">(6)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges⑥">(7)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges⑦">(8)</a> <a href="#ref-for-valdef-image-rendering-crisp-edges⑧">(9)</a>
    </ul>
@@ -4139,59 +4139,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-images-4/Overview.html
@@ -3296,14 +3296,14 @@ interpolate the position and color independently.</p>
    <li><a href="#funcdef-image-set-type">type()</a><span>, in § 2.3</span>
    <li><a href="#invalid-image">valid image</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">2.4.3. Solid-color Images</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-propdef-background-image①">3.5.3. 
@@ -3311,48 +3311,48 @@ Color Stop “Fixup”</a>
     <li><a href="#ref-for-propdef-background-image②">6.1. Overriding Image Resolutions: the image-resolution property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">3.3.1. 
 conic-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">3. 
 Gradients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-position-center">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-position-center" class="dfn-panel" data-for="term-for-valdef-background-position-center" id="infopanel-for-term-for-valdef-background-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-center">3.3.1. 
 conic-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2. 2D Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">2. 2D Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.5.3. 
 Color Stop “Fixup”</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-typedef-color①">2.4. Image Fallbacks and Annotations: the image() notation</a>
@@ -3366,16 +3366,16 @@ Color Stop “Fixup”</a>
 Color Stop Lists</a> <a href="#ref-for-typedef-color①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-valdef-color-transparent①">(2)</a>
     <li><a href="#ref-for-valdef-color-transparent②">2.5. Combining images: the cross-fade() notation</a>
     <li><a href="#ref-for-valdef-color-transparent③">2.6. Using Elements as Images: the element() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-linear-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-linear-gradient" class="dfn-panel" data-for="term-for-funcdef-linear-gradient" id="infopanel-for-term-for-funcdef-linear-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-linear-gradient" style="display:none">Info about the 'linear-gradient()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-linear-gradient">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-funcdef-linear-gradient①">(2)</a>
     <li><a href="#ref-for-funcdef-linear-gradient②">3. 
@@ -3386,8 +3386,8 @@ Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(
     <li><a href="#ref-for-funcdef-linear-gradient⑤">7.3. Interpolating &lt;gradient></a> <a href="#ref-for-funcdef-linear-gradient⑥">(2)</a> <a href="#ref-for-funcdef-linear-gradient⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-radial-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient">https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-radial-gradient" class="dfn-panel" data-for="term-for-funcdef-radial-gradient" id="infopanel-for-term-for-funcdef-radial-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-radial-gradient" style="display:none">Info about the 'radial-gradient()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient">https://drafts.csswg.org/css-images-4/#funcdef-radial-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-radial-gradient">3. 
 Gradients</a>
@@ -3397,46 +3397,46 @@ Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(
     <li><a href="#ref-for-funcdef-radial-gradient③">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-stripes">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-stripes">https://drafts.csswg.org/css-images-4/#funcdef-stripes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-stripes" class="dfn-panel" data-for="term-for-funcdef-stripes" id="infopanel-for-term-for-funcdef-stripes" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-stripes" style="display:none">Info about the 'stripes()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-stripes">https://drafts.csswg.org/css-images-4/#funcdef-stripes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-stripes">4. 1D Image Values: the stripes() notation</a> <a href="#ref-for-funcdef-stripes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-image">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-image" class="dfn-panel" data-for="term-for-propdef-list-style-image" id="infopanel-for-term-for-propdef-list-style-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-propdef-list-style-image①">(2)</a>
     <li><a href="#ref-for-propdef-list-style-image②">3. 
 Gradients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">2. 2D Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-list-style-type-none">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-list-style-type-none" class="dfn-panel" data-for="term-for-valdef-list-style-type-none" id="infopanel-for-term-for-valdef-list-style-type-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-list-style-type-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-type-none">2. 2D Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">2. 2D Image Values: the &lt;image> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">2.4. Image Fallbacks and Annotations: the image() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.3. Resolution/Type Negotiation: the image-set() notation</a>
     <li><a href="#ref-for-mult-comma①">2.5. Combining images: the cross-fade() notation</a>
@@ -3444,8 +3444,8 @@ Gradients</a>
 Color Stop Lists</a> <a href="#ref-for-mult-comma③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">2.5. Combining images: the cross-fade() notation</a>
     <li><a href="#ref-for-comb-all①">3.5.1. 
@@ -3453,8 +3453,8 @@ Color Stop Lists</a> <a href="#ref-for-comb-all②">(2)</a>
     <li><a href="#ref-for-comb-all③">6.1. Overriding Image Resolutions: the image-resolution property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">2.4. Image Fallbacks and Annotations: the image() notation</a>
     <li><a href="#ref-for-comb-comma①">3.3.1. 
@@ -3463,15 +3463,15 @@ conic-gradient() Syntax</a>
 Color Stop Lists</a> <a href="#ref-for-comb-comma③">(2)</a> <a href="#ref-for-comb-comma④">(3)</a> <a href="#ref-for-comb-comma⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-angle-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-angle-percentage">https://drafts.csswg.org/css-values-4/#typedef-angle-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-angle-percentage" class="dfn-panel" data-for="term-for-typedef-angle-percentage" id="infopanel-for-term-for-typedef-angle-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-angle-percentage" style="display:none">Info about the '&lt;angle-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-angle-percentage">https://drafts.csswg.org/css-values-4/#typedef-angle-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angle-percentage">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-angle-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">3.3. 
 Conic Gradients: the conic-gradient() notation</a>
@@ -3482,22 +3482,22 @@ Color Stop Lists</a>
     <li><a href="#ref-for-angle-value⑤">7.3. Interpolating &lt;gradient></a> <a href="#ref-for-angle-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a> <a href="#ref-for-identifier-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-length-value①">3.3. 
@@ -3507,45 +3507,45 @@ Color Stop Lists</a>
     <li><a href="#ref-for-length-value③">7.3. Interpolating &lt;gradient></a> <a href="#ref-for-length-value④">(2)</a> <a href="#ref-for-length-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.5. Combining images: the cross-fade() notation</a> <a href="#ref-for-percentage-value①">(2)</a> <a href="#ref-for-percentage-value②">(3)</a>
     <li><a href="#ref-for-percentage-value③">7.3. Interpolating &lt;gradient></a> <a href="#ref-for-percentage-value④">(2)</a>
     <li><a href="#ref-for-percentage-value⑤">8. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">3.3.1. 
 conic-gradient() Syntax</a> <a href="#ref-for-typedef-position①">(2)</a> <a href="#ref-for-typedef-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-resolution-value①">(2)</a> <a href="#ref-for-resolution-value②">(3)</a>
     <li><a href="#ref-for-resolution-value③">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-resolution-value④">(2)</a> <a href="#ref-for-resolution-value⑤">(3)</a> <a href="#ref-for-resolution-value⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a> <a href="#ref-for-string-value③">(4)</a> <a href="#ref-for-string-value④">(5)</a> <a href="#ref-for-string-value⑤">(6)</a>
     <li><a href="#ref-for-string-value⑥">2.4. Image Fallbacks and Annotations: the image() notation</a> <a href="#ref-for-string-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a> <a href="#ref-for-url-value③">(4)</a>
     <li><a href="#ref-for-url-value④">2.3. Resolution/Type Negotiation: the image-set() notation</a>
     <li><a href="#ref-for-url-value⑤">2.4. Image Fallbacks and Annotations: the image() notation</a> <a href="#ref-for-url-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.4. Image Fallbacks and Annotations: the image() notation</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
     <li><a href="#ref-for-mult-opt③">2.5. Combining images: the cross-fade() notation</a>
@@ -3556,36 +3556,36 @@ Color Stop Lists</a> <a href="#ref-for-mult-opt⑦">(2)</a> <a href="#ref-for-mu
     <li><a href="#ref-for-mult-opt①⓪">6.1. Overriding Image Resolutions: the image-resolution property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.6.1. 
 Paint Sources</a>
     <li><a href="#ref-for-px①">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-px②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2.2. Image References: the url() notation</a>
     <li><a href="#ref-for-funcdef-url①">2.4.2. Image Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-mult-num-range①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
     <li><a href="#ref-for-comb-one⑤">2.3. Resolution/Type Negotiation: the image-set() notation</a>
@@ -3598,28 +3598,28 @@ Color Stop Lists</a>
     <li><a href="#ref-for-comb-one①⑤">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-comb-one①⑥">(2)</a> <a href="#ref-for-comb-one①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.3. Resolution/Type Negotiation: the image-set() notation</a>
     <li><a href="#ref-for-comb-any①">5.1. Sizing Objects: the object-fit property</a>
     <li><a href="#ref-for-comb-any②">6.1. Overriding Image Resolutions: the image-resolution property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">2.6. Using Elements as Images: the element() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-circle">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-circle">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-ending-shape-circle" class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-circle" id="infopanel-for-term-for-valdef-rg-ending-shape-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-ending-shape-circle" style="display:none">Info about the 'circle' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-circle">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-ending-shape-circle">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concrete-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concrete-object-size" class="dfn-panel" data-for="term-for-concrete-object-size" id="infopanel-for-term-for-concrete-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-concrete-object-size" style="display:none">Info about the 'concrete object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concrete-object-size">2.5.1. cross-fade() Sizing</a>
     <li><a href="#ref-for-concrete-object-size①">2.5.2. cross-fade() Painting</a>
@@ -3630,46 +3630,46 @@ Gradients</a>
     <li><a href="#ref-for-concrete-object-size⑨">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-concrete-object-size①⓪">(2)</a> <a href="#ref-for-concrete-object-size①①">(3)</a> <a href="#ref-for-concrete-object-size①②">(4)</a> <a href="#ref-for-concrete-object-size①③">(5)</a> <a href="#ref-for-concrete-object-size①④">(6)</a> <a href="#ref-for-concrete-object-size①⑤">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-contain-constraint">
-   <a href="https://drafts.csswg.org/css-images-3/#contain-constraint">https://drafts.csswg.org/css-images-3/#contain-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-contain-constraint" class="dfn-panel" data-for="term-for-contain-constraint" id="infopanel-for-term-for-contain-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-contain-constraint" style="display:none">Info about the 'contain constraint' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#contain-constraint">https://drafts.csswg.org/css-images-3/#contain-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contain-constraint">5.1. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cover-constraint">
-   <a href="https://drafts.csswg.org/css-images-3/#cover-constraint">https://drafts.csswg.org/css-images-3/#cover-constraint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cover-constraint" class="dfn-panel" data-for="term-for-cover-constraint" id="infopanel-for-term-for-cover-constraint" role="menu">
+   <span id="infopaneltitle-for-term-for-cover-constraint" style="display:none">Info about the 'cover constraint' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#cover-constraint">https://drafts.csswg.org/css-images-3/#cover-constraint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cover-constraint">5.1. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3. 
 Gradients</a>
     <li><a href="#ref-for-default-object-size①">5.1. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sizing-algorithm">
-   <a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sizing-algorithm" class="dfn-panel" data-for="term-for-default-sizing-algorithm" id="infopanel-for-term-for-default-sizing-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sizing-algorithm" style="display:none">Info about the 'default sizing algorithm' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sizing-algorithm">5.1. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-ellipse">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-ending-shape-ellipse" class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-ellipse" id="infopanel-for-term-for-valdef-rg-ending-shape-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-ending-shape-ellipse" style="display:none">Info about the 'ellipse' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-ending-shape-ellipse">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-natural-aspect-ratio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-natural-dimensions①">(2)</a> <a href="#ref-for-natural-dimensions②">(3)</a>
     <li><a href="#ref-for-natural-dimensions③">2.4.3. Solid-color Images</a>
@@ -3680,46 +3680,46 @@ Gradients</a>
     <li><a href="#ref-for-natural-dimensions⑧">6.1. Overriding Image Resolutions: the image-resolution property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-height">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-height" class="dfn-panel" data-for="term-for-natural-height" id="infopanel-for-term-for-natural-height" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-height" style="display:none">Info about the 'natural height' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">2.5.1. cross-fade() Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">2.6. Using Elements as Images: the element() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-width">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-width">https://drafts.csswg.org/css-images-3/#natural-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-width" class="dfn-panel" data-for="term-for-natural-width" id="infopanel-for-term-for-natural-width" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-width" style="display:none">Info about the 'natural width' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-width">https://drafts.csswg.org/css-images-3/#natural-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-width">2.5.1. cross-fade() Sizing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-size-negotiation">
-   <a href="https://drafts.csswg.org/css-images-3/#object-size-negotiation">https://drafts.csswg.org/css-images-3/#object-size-negotiation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-size-negotiation" class="dfn-panel" data-for="term-for-object-size-negotiation" id="infopanel-for-term-for-object-size-negotiation" role="menu">
+   <span id="infopaneltitle-for-term-for-object-size-negotiation" style="display:none">Info about the 'object size negotiation' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#object-size-negotiation">https://drafts.csswg.org/css-images-3/#object-size-negotiation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-size-negotiation">2.5.1. cross-fade() Sizing</a>
     <li><a href="#ref-for-object-size-negotiation①">5.1. Sizing Objects: the object-fit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-position">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-position" class="dfn-panel" data-for="term-for-propdef-object-position" id="infopanel-for-term-for-propdef-object-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-position" style="display:none">Info about the 'object-position' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-position">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-propdef-object-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-css">
-   <a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-css" class="dfn-panel" data-for="term-for-namespacedef-css" id="infopanel-for-term-for-namespacedef-css" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-css" style="display:none">Info about the 'CSS' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#namespacedef-css">https://drafts.csswg.org/cssom-1/#namespacedef-css</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">2.6. Using Elements as Images: the element() notation</a>
     <li><a href="#ref-for-canvas①">2.6.1. 
@@ -3728,78 +3728,78 @@ Paint Sources</a>
 Using Out-Of-Document Sources: the ElementSources interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">2.6. Using Elements as Images: the element() notation</a>
     <li><a href="#ref-for-the-img-element①">2.6.1. 
 Paint Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-p-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-p-element" class="dfn-panel" data-for="term-for-the-p-element" id="infopanel-for-term-for-the-p-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-p-element" style="display:none">Info about the 'p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-p-element">2.6. Using Elements as Images: the element() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-picture-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-picture-element" class="dfn-panel" data-for="term-for-the-picture-element" id="infopanel-for-term-for-the-picture-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-picture-element" style="display:none">Info about the 'picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-picture-element">2.3. Resolution/Type Negotiation: the image-set() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">2.6. Using Elements as Images: the element() notation</a>
     <li><a href="#ref-for-video①">2.6.1. 
 Paint Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.5.1. cross-fade() Sizing</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">2.5.2. cross-fade() Painting</a> <a href="#ref-for-list-iterate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.5.1. cross-fade() Sizing</a>
     <li><a href="#ref-for-list-item①">2.5.2. cross-fade() Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">2.5.1. cross-fade() Sizing</a>
     <li><a href="#ref-for-tuple①">2.5.2. cross-fade() Painting</a> <a href="#ref-for-tuple②">(2)</a> <a href="#ref-for-tuple③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">https://mimesniff.spec.whatwg.org/#valid-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-mime-type" class="dfn-panel" data-for="term-for-valid-mime-type" id="infopanel-for-term-for-valid-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-mime-type" style="display:none">Info about the 'valid mime type string' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">https://mimesniff.spec.whatwg.org/#valid-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-mime-type">2.3. Resolution/Type Negotiation: the image-set() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-id-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-id-selector">https://drafts.csswg.org/selectors-4/#typedef-id-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-id-selector" class="dfn-panel" data-for="term-for-typedef-id-selector" id="infopanel-for-term-for-typedef-id-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-id-selector" style="display:none">Info about the '&lt;id-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-id-selector">https://drafts.csswg.org/selectors-4/#typedef-id-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-id-selector">2.6. Using Elements as Images: the element() notation</a> <a href="#ref-for-typedef-id-selector①">(2)</a>
     <li><a href="#ref-for-typedef-id-selector②">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a>
@@ -4093,8 +4093,8 @@ Using Out-Of-Document Sources: the ElementSources interface</a>
 	between the starting and ending positions explicitly,
 	so it doesn’t grow and then shrink over a single animation. <a class="issue-return" href="#issue-f1783900" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-image">
-   <b><a href="#typedef-image">#typedef-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-image" class="dfn-panel" data-for="typedef-image" id="infopanel-for-typedef-image" role="dialog">
+   <span id="infopaneltitle-for-typedef-image" style="display:none">Info about the '&lt;image>' definition.</span><b><a href="#typedef-image">#typedef-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image②">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-typedef-image③">(2)</a> <a href="#ref-for-typedef-image④">(3)</a> <a href="#ref-for-typedef-image⑤">(4)</a>
     <li><a href="#ref-for-typedef-image⑥">2.1. Image File Formats</a> <a href="#ref-for-typedef-image⑦">(2)</a> <a href="#ref-for-typedef-image⑧">(3)</a>
@@ -4107,8 +4107,8 @@ Gradients</a>
     <li><a href="#ref-for-typedef-image①⑧">7.1. Interpolating &lt;image></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-image">
-   <b><a href="#invalid-image">#invalid-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-image" class="dfn-panel" data-for="invalid-image" id="infopanel-for-invalid-image" role="dialog">
+   <span id="infopaneltitle-for-invalid-image" style="display:none">Info about the 'invalid image' definition.</span><b><a href="#invalid-image">#invalid-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-invalid-image①">(2)</a> <a href="#ref-for-invalid-image②">(3)</a>
     <li><a href="#ref-for-invalid-image③">2.4.1. Image Fallbacks</a> <a href="#ref-for-invalid-image④">(2)</a>
@@ -4120,35 +4120,35 @@ Using Out-Of-Document Sources: the ElementSources interface</a>
 Cycle Detection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="loading-image">
-   <b><a href="#loading-image">#loading-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-loading-image" class="dfn-panel" data-for="loading-image" id="infopanel-for-loading-image" role="dialog">
+   <span id="infopaneltitle-for-loading-image" style="display:none">Info about the 'loading image' definition.</span><b><a href="#loading-image">#loading-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-loading-image">2. 2D Image Values: the &lt;image> type</a> <a href="#ref-for-loading-image①">(2)</a> <a href="#ref-for-loading-image②">(3)</a> <a href="#ref-for-loading-image③">(4)</a>
     <li><a href="#ref-for-loading-image④">2.4.1. Image Fallbacks</a> <a href="#ref-for-loading-image⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-image-set">
-   <b><a href="#funcdef-image-set">#funcdef-image-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-image-set" class="dfn-panel" data-for="funcdef-image-set" id="infopanel-for-funcdef-image-set" role="dialog">
+   <span id="infopaneltitle-for-funcdef-image-set" style="display:none">Info about the 'image-set()' definition.</span><b><a href="#funcdef-image-set">#funcdef-image-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image-set">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-funcdef-image-set①">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-funcdef-image-set②">(2)</a> <a href="#ref-for-funcdef-image-set③">(3)</a> <a href="#ref-for-funcdef-image-set④">(4)</a> <a href="#ref-for-funcdef-image-set⑤">(5)</a> <a href="#ref-for-funcdef-image-set⑥">(6)</a> <a href="#ref-for-funcdef-image-set⑦">(7)</a> <a href="#ref-for-funcdef-image-set⑧">(8)</a> <a href="#ref-for-funcdef-image-set⑨">(9)</a> <a href="#ref-for-funcdef-image-set①⓪">(10)</a> <a href="#ref-for-funcdef-image-set①①">(11)</a>
     <li><a href="#ref-for-funcdef-image-set①②">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-funcdef-image-set①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-image-set-option">
-   <b><a href="#typedef-image-set-option">#typedef-image-set-option</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-image-set-option" class="dfn-panel" data-for="typedef-image-set-option" id="infopanel-for-typedef-image-set-option" role="dialog">
+   <span id="infopaneltitle-for-typedef-image-set-option" style="display:none">Info about the '&lt;image-set-option>' definition.</span><b><a href="#typedef-image-set-option">#typedef-image-set-option</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image-set-option">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-typedef-image-set-option①">(2)</a> <a href="#ref-for-typedef-image-set-option②">(3)</a> <a href="#ref-for-typedef-image-set-option③">(4)</a> <a href="#ref-for-typedef-image-set-option④">(5)</a> <a href="#ref-for-typedef-image-set-option⑤">(6)</a> <a href="#ref-for-typedef-image-set-option⑥">(7)</a> <a href="#ref-for-typedef-image-set-option⑦">(8)</a> <a href="#ref-for-typedef-image-set-option⑧">(9)</a> <a href="#ref-for-typedef-image-set-option⑨">(10)</a> <a href="#ref-for-typedef-image-set-option①⓪">(11)</a> <a href="#ref-for-typedef-image-set-option①①">(12)</a> <a href="#ref-for-typedef-image-set-option①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-image-set-type">
-   <b><a href="#funcdef-image-set-type">#funcdef-image-set-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-image-set-type" class="dfn-panel" data-for="funcdef-image-set-type" id="infopanel-for-funcdef-image-set-type" role="dialog">
+   <span id="infopaneltitle-for-funcdef-image-set-type" style="display:none">Info about the 'type( &lt;string> )' definition.</span><b><a href="#funcdef-image-set-type">#funcdef-image-set-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image-set-type">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for-funcdef-image-set-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-image">
-   <b><a href="#funcdef-image">#funcdef-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-image" class="dfn-panel" data-for="funcdef-image" id="infopanel-for-funcdef-image" role="dialog">
+   <span id="infopaneltitle-for-funcdef-image" style="display:none">Info about the 'image()' definition.</span><b><a href="#funcdef-image">#funcdef-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image①">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-funcdef-image②">2.4. Image Fallbacks and Annotations: the image() notation</a> <a href="#ref-for-funcdef-image③">(2)</a> <a href="#ref-for-funcdef-image④">(3)</a> <a href="#ref-for-funcdef-image⑤">(4)</a> <a href="#ref-for-funcdef-image⑥">(5)</a>
@@ -4158,20 +4158,20 @@ Cycle Detection</a>
     <li><a href="#ref-for-funcdef-image①⑦"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-image-tags">
-   <b><a href="#typedef-image-tags">#typedef-image-tags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-image-tags" class="dfn-panel" data-for="typedef-image-tags" id="infopanel-for-typedef-image-tags" role="dialog">
+   <span id="infopaneltitle-for-typedef-image-tags" style="display:none">Info about the '&lt;image-tags>' definition.</span><b><a href="#typedef-image-tags">#typedef-image-tags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image-tags">2.4. Image Fallbacks and Annotations: the image() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-image-src">
-   <b><a href="#typedef-image-src">#typedef-image-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-image-src" class="dfn-panel" data-for="typedef-image-src" id="infopanel-for-typedef-image-src" role="dialog">
+   <span id="infopaneltitle-for-typedef-image-src" style="display:none">Info about the '&lt;image-src>' definition.</span><b><a href="#typedef-image-src">#typedef-image-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image-src">2.4. Image Fallbacks and Annotations: the image() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-cross-fade">
-   <b><a href="#funcdef-cross-fade">#funcdef-cross-fade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-cross-fade" class="dfn-panel" data-for="funcdef-cross-fade" id="infopanel-for-funcdef-cross-fade" role="dialog">
+   <span id="infopaneltitle-for-funcdef-cross-fade" style="display:none">Info about the 'cross-fade()' definition.</span><b><a href="#funcdef-cross-fade">#funcdef-cross-fade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-cross-fade">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-funcdef-cross-fade①">2.5. Combining images: the cross-fade() notation</a> <a href="#ref-for-funcdef-cross-fade②">(2)</a> <a href="#ref-for-funcdef-cross-fade③">(3)</a> <a href="#ref-for-funcdef-cross-fade④">(4)</a>
@@ -4183,20 +4183,20 @@ Cycle Detection</a>
     <li><a href="#ref-for-funcdef-cross-fade①⑧">8. Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-cf-image">
-   <b><a href="#typedef-cf-image">#typedef-cf-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-cf-image" class="dfn-panel" data-for="typedef-cf-image" id="infopanel-for-typedef-cf-image" role="dialog">
+   <span id="infopaneltitle-for-typedef-cf-image" style="display:none">Info about the '&lt;cf-image>' definition.</span><b><a href="#typedef-cf-image">#typedef-cf-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-cf-image">2.5. Combining images: the cross-fade() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-dimensions-of-a-cross-fade">
-   <b><a href="#natural-dimensions-of-a-cross-fade">#natural-dimensions-of-a-cross-fade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-dimensions-of-a-cross-fade" class="dfn-panel" data-for="natural-dimensions-of-a-cross-fade" id="infopanel-for-natural-dimensions-of-a-cross-fade" role="dialog">
+   <span id="infopaneltitle-for-natural-dimensions-of-a-cross-fade" style="display:none">Info about the 'natural dimensions of a cross-fade()' definition.</span><b><a href="#natural-dimensions-of-a-cross-fade">#natural-dimensions-of-a-cross-fade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions-of-a-cross-fade">2.5.2. cross-fade() Painting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-element">
-   <b><a href="#funcdef-element">#funcdef-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-element" class="dfn-panel" data-for="funcdef-element" id="infopanel-for-funcdef-element" role="dialog">
+   <span id="infopaneltitle-for-funcdef-element" style="display:none">Info about the 'element()' definition.</span><b><a href="#funcdef-element">#funcdef-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-element①">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-funcdef-element②">2.6. Using Elements as Images: the element() notation</a> <a href="#ref-for-funcdef-element③">(2)</a> <a href="#ref-for-funcdef-element④">(3)</a> <a href="#ref-for-funcdef-element⑤">(4)</a> <a href="#ref-for-funcdef-element⑥">(5)</a> <a href="#ref-for-funcdef-element⑦">(6)</a> <a href="#ref-for-funcdef-element⑧">(7)</a> <a href="#ref-for-funcdef-element⑨">(8)</a> <a href="#ref-for-funcdef-element①⓪">(9)</a> <a href="#ref-for-funcdef-element①①">(10)</a> <a href="#ref-for-funcdef-element①②">(11)</a>
@@ -4207,44 +4207,44 @@ Cycle Detection</a> <a href="#ref-for-funcdef-element①⑨">(2)</a> <a href="#r
     <li><a href="#ref-for-funcdef-element②①"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decorated-bounding-box">
-   <b><a href="#decorated-bounding-box">#decorated-bounding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decorated-bounding-box" class="dfn-panel" data-for="decorated-bounding-box" id="infopanel-for-decorated-bounding-box" role="dialog">
+   <span id="infopaneltitle-for-decorated-bounding-box" style="display:none">Info about the 'decorated bounding box' definition.</span><b><a href="#decorated-bounding-box">#decorated-bounding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decorated-bounding-box">2.6. Using Elements as Images: the element() notation</a> <a href="#ref-for-decorated-bounding-box①">(2)</a> <a href="#ref-for-decorated-bounding-box②">(3)</a> <a href="#ref-for-decorated-bounding-box③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-not-rendered">
-   <b><a href="#element-not-rendered">#element-not-rendered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-not-rendered" class="dfn-panel" data-for="element-not-rendered" id="infopanel-for-element-not-rendered" role="dialog">
+   <span id="infopaneltitle-for-element-not-rendered" style="display:none">Info about the 'not rendered' definition.</span><b><a href="#element-not-rendered">#element-not-rendered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-not-rendered">2.6. Using Elements as Images: the element() notation</a> <a href="#ref-for-element-not-rendered①">(2)</a>
     <li><a href="#ref-for-element-not-rendered②">2.6.1. 
 Paint Sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-source">
-   <b><a href="#paint-source">#paint-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-source" class="dfn-panel" data-for="paint-source" id="infopanel-for-paint-source" role="dialog">
+   <span id="infopaneltitle-for-paint-source" style="display:none">Info about the 'paint source' definition.</span><b><a href="#paint-source">#paint-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-source">2.6. Using Elements as Images: the element() notation</a> <a href="#ref-for-paint-source①">(2)</a>
     <li><a href="#ref-for-paint-source②">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a> <a href="#ref-for-paint-source③">(2)</a> <a href="#ref-for-paint-source④">(3)</a> <a href="#ref-for-paint-source⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-elementsources">
-   <b><a href="#dom-css-elementsources">#dom-css-elementsources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-elementsources" class="dfn-panel" data-for="dom-css-elementsources" id="infopanel-for-dom-css-elementsources" role="dialog">
+   <span id="infopaneltitle-for-dom-css-elementsources" style="display:none">Info about the 'elementSources' definition.</span><b><a href="#dom-css-elementsources">#dom-css-elementsources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-elementsources">2.6. Using Elements as Images: the element() notation</a>
     <li><a href="#ref-for-dom-css-elementsources①">2.6.2. 
 Using Out-Of-Document Sources: the ElementSources interface</a> <a href="#ref-for-dom-css-elementsources②">(2)</a> <a href="#ref-for-dom-css-elementsources③">(3)</a> <a href="#ref-for-dom-css-elementsources④">(4)</a> <a href="#ref-for-dom-css-elementsources⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-function">
-   <b><a href="#gradient-function">#gradient-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-function" class="dfn-panel" data-for="gradient-function" id="infopanel-for-gradient-function" role="dialog">
+   <span id="infopaneltitle-for-gradient-function" style="display:none">Info about the 'gradient functions' definition.</span><b><a href="#gradient-function">#gradient-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-function">3.5. Defining Gradient Color</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-gradient">
-   <b><a href="#typedef-gradient">#typedef-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-gradient" class="dfn-panel" data-for="typedef-gradient" id="infopanel-for-typedef-gradient" role="dialog">
+   <span id="infopaneltitle-for-typedef-gradient" style="display:none">Info about the '&lt;gradient>' definition.</span><b><a href="#typedef-gradient">#typedef-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-gradient">2. 2D Image Values: the &lt;image> type</a>
     <li><a href="#ref-for-typedef-gradient①">3. 
@@ -4252,8 +4252,8 @@ Gradients</a>
     <li><a href="#ref-for-typedef-gradient②">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-box">
-   <b><a href="#gradient-box">#gradient-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-box" class="dfn-panel" data-for="gradient-box" id="infopanel-for-gradient-box" role="dialog">
+   <span id="infopaneltitle-for-gradient-box" style="display:none">Info about the 'gradient box' definition.</span><b><a href="#gradient-box">#gradient-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-box">3. 
 Gradients</a> <a href="#ref-for-gradient-box①">(2)</a>
@@ -4261,24 +4261,24 @@ Gradients</a> <a href="#ref-for-gradient-box①">(2)</a>
 conic-gradient() Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="starting-point">
-   <b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-starting-point" class="dfn-panel" data-for="starting-point" id="infopanel-for-starting-point" role="dialog">
+   <span id="infopaneltitle-for-starting-point" style="display:none">Info about the 'starting point' definition.</span><b><a href="#starting-point">#starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-point">3.5. Defining Gradient Color</a>
     <li><a href="#ref-for-starting-point①">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-starting-point②">(2)</a> <a href="#ref-for-starting-point③">(3)</a> <a href="#ref-for-starting-point④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ending-point">
-   <b><a href="#ending-point">#ending-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ending-point" class="dfn-panel" data-for="ending-point" id="infopanel-for-ending-point" role="dialog">
+   <span id="infopaneltitle-for-ending-point" style="display:none">Info about the 'ending point' definition.</span><b><a href="#ending-point">#ending-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ending-point">3.5. Defining Gradient Color</a>
     <li><a href="#ref-for-ending-point①">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-ending-point②">(2)</a> <a href="#ref-for-ending-point③">(3)</a> <a href="#ref-for-ending-point④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gradient-line">
-   <b><a href="#gradient-line">#gradient-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gradient-line" class="dfn-panel" data-for="gradient-line" id="infopanel-for-gradient-line" role="dialog">
+   <span id="infopaneltitle-for-gradient-line" style="display:none">Info about the 'gradient line' definition.</span><b><a href="#gradient-line">#gradient-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gradient-line">3. 
 Gradients</a>
@@ -4291,8 +4291,8 @@ Color Stop Lists</a> <a href="#ref-for-gradient-line⑦">(2)</a> <a href="#ref-f
 Coloring the Gradient Line</a> <a href="#ref-for-gradient-line①①">(2)</a> <a href="#ref-for-gradient-line①②">(3)</a> <a href="#ref-for-gradient-line①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-conic-gradient">
-   <b><a href="#funcdef-conic-gradient">#funcdef-conic-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-conic-gradient" class="dfn-panel" data-for="funcdef-conic-gradient" id="infopanel-for-funcdef-conic-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-conic-gradient" style="display:none">Info about the 'conic-gradient()' definition.</span><b><a href="#funcdef-conic-gradient">#funcdef-conic-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-conic-gradient">3. 
 Gradients</a>
@@ -4306,15 +4306,15 @@ Conic Gradient Examples</a>
 Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(), and repeating-conic-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conic-gradient-gradient-center">
-   <b><a href="#conic-gradient-gradient-center">#conic-gradient-gradient-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conic-gradient-gradient-center" class="dfn-panel" data-for="conic-gradient-gradient-center" id="infopanel-for-conic-gradient-gradient-center" role="dialog">
+   <span id="infopaneltitle-for-conic-gradient-gradient-center" style="display:none">Info about the 'gradient center' definition.</span><b><a href="#conic-gradient-gradient-center">#conic-gradient-gradient-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conic-gradient-gradient-center">3.3.2. 
 Placing Color Stops</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeating-linear-gradient">
-   <b><a href="#funcdef-repeating-linear-gradient">#funcdef-repeating-linear-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeating-linear-gradient" class="dfn-panel" data-for="funcdef-repeating-linear-gradient" id="infopanel-for-funcdef-repeating-linear-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeating-linear-gradient" style="display:none">Info about the 'repeating-linear-gradient()' definition.</span><b><a href="#funcdef-repeating-linear-gradient">#funcdef-repeating-linear-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeating-linear-gradient">3. 
 Gradients</a>
@@ -4323,8 +4323,8 @@ Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(
     <li><a href="#ref-for-funcdef-repeating-linear-gradient②">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeating-radial-gradient">
-   <b><a href="#funcdef-repeating-radial-gradient">#funcdef-repeating-radial-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeating-radial-gradient" class="dfn-panel" data-for="funcdef-repeating-radial-gradient" id="infopanel-for-funcdef-repeating-radial-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeating-radial-gradient" style="display:none">Info about the 'repeating-radial-gradient()' definition.</span><b><a href="#funcdef-repeating-radial-gradient">#funcdef-repeating-radial-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeating-radial-gradient">3. 
 Gradients</a>
@@ -4332,8 +4332,8 @@ Gradients</a>
 Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(), and repeating-conic-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-repeating-conic-gradient">
-   <b><a href="#funcdef-repeating-conic-gradient">#funcdef-repeating-conic-gradient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-repeating-conic-gradient" class="dfn-panel" data-for="funcdef-repeating-conic-gradient" id="infopanel-for-funcdef-repeating-conic-gradient" role="dialog">
+   <span id="infopaneltitle-for-funcdef-repeating-conic-gradient" style="display:none">Info about the 'repeating-conic-gradient()' definition.</span><b><a href="#funcdef-repeating-conic-gradient">#funcdef-repeating-conic-gradient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-repeating-conic-gradient">3. 
 Gradients</a>
@@ -4341,8 +4341,8 @@ Gradients</a>
 Repeating Gradients: the repeating-linear-gradient(), repeating-radial-gradient(), and repeating-conic-gradient() notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-stop">
-   <b><a href="#color-stop">#color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-stop" class="dfn-panel" data-for="color-stop" id="infopanel-for-color-stop" role="dialog">
+   <span id="infopaneltitle-for-color-stop" style="display:none">Info about the 'color stops' definition.</span><b><a href="#color-stop">#color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-stop">3.5. Defining Gradient Color</a>
     <li><a href="#ref-for-color-stop①">3.5.1. 
@@ -4353,8 +4353,8 @@ Coloring the Gradient Line</a> <a href="#ref-for-color-stop⑨">(2)</a> <a href=
 Color Stop “Fixup”</a> <a href="#ref-for-color-stop②⑤">(2)</a> <a href="#ref-for-color-stop②⑥">(3)</a> <a href="#ref-for-color-stop②⑦">(4)</a> <a href="#ref-for-color-stop②⑧">(5)</a> <a href="#ref-for-color-stop②⑨">(6)</a> <a href="#ref-for-color-stop③⓪">(7)</a> <a href="#ref-for-color-stop③①">(8)</a> <a href="#ref-for-color-stop③②">(9)</a> <a href="#ref-for-color-stop③③">(10)</a> <a href="#ref-for-color-stop③④">(11)</a> <a href="#ref-for-color-stop③⑤">(12)</a> <a href="#ref-for-color-stop③⑥">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-transition-hint">
-   <b><a href="#color-transition-hint">#color-transition-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-transition-hint" class="dfn-panel" data-for="color-transition-hint" id="infopanel-for-color-transition-hint" role="dialog">
+   <span id="infopaneltitle-for-color-transition-hint" style="display:none">Info about the 'color transition hints' definition.</span><b><a href="#color-transition-hint">#color-transition-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-transition-hint">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-color-transition-hint①">(2)</a> <a href="#ref-for-color-transition-hint②">(3)</a>
@@ -4364,43 +4364,43 @@ Coloring the Gradient Line</a> <a href="#ref-for-color-transition-hint④">(2)</
 Color Stop “Fixup”</a> <a href="#ref-for-color-transition-hint⑦">(2)</a> <a href="#ref-for-color-transition-hint⑧">(3)</a> <a href="#ref-for-color-transition-hint⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-stop-list">
-   <b><a href="#color-stop-list">#color-stop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-stop-list" class="dfn-panel" data-for="color-stop-list" id="infopanel-for-color-stop-list" role="dialog">
+   <span id="infopaneltitle-for-color-stop-list" style="display:none">Info about the 'color stop list' definition.</span><b><a href="#color-stop-list">#color-stop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-stop-list">3.5.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-stop-list">
-   <b><a href="#typedef-color-stop-list">#typedef-color-stop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-stop-list" class="dfn-panel" data-for="typedef-color-stop-list" id="infopanel-for-typedef-color-stop-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-stop-list" style="display:none">Info about the '&lt;color-stop-list>' definition.</span><b><a href="#typedef-color-stop-list">#typedef-color-stop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop-list">3.5.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-linear-color-stop">
-   <b><a href="#typedef-linear-color-stop">#typedef-linear-color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-linear-color-stop" class="dfn-panel" data-for="typedef-linear-color-stop" id="infopanel-for-typedef-linear-color-stop" role="dialog">
+   <span id="infopaneltitle-for-typedef-linear-color-stop" style="display:none">Info about the '&lt;linear-color-stop>' definition.</span><b><a href="#typedef-linear-color-stop">#typedef-linear-color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-linear-color-stop">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-linear-color-stop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-linear-color-hint">
-   <b><a href="#typedef-linear-color-hint">#typedef-linear-color-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-linear-color-hint" class="dfn-panel" data-for="typedef-linear-color-hint" id="infopanel-for-typedef-linear-color-hint" role="dialog">
+   <span id="infopaneltitle-for-typedef-linear-color-hint" style="display:none">Info about the '&lt;linear-color-hint>' definition.</span><b><a href="#typedef-linear-color-hint">#typedef-linear-color-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-linear-color-hint">3.5.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-stop-length">
-   <b><a href="#typedef-color-stop-length">#typedef-color-stop-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-stop-length" class="dfn-panel" data-for="typedef-color-stop-length" id="infopanel-for-typedef-color-stop-length" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-stop-length" style="display:none">Info about the '&lt;color-stop-length>' definition.</span><b><a href="#typedef-color-stop-length">#typedef-color-stop-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop-length">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-color-stop-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-angular-color-stop-list">
-   <b><a href="#typedef-angular-color-stop-list">#typedef-angular-color-stop-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-angular-color-stop-list" class="dfn-panel" data-for="typedef-angular-color-stop-list" id="infopanel-for-typedef-angular-color-stop-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-angular-color-stop-list" style="display:none">Info about the '&lt;angular-color-stop-list>' definition.</span><b><a href="#typedef-angular-color-stop-list">#typedef-angular-color-stop-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angular-color-stop-list">3.3.1. 
 conic-gradient() Syntax</a>
@@ -4408,85 +4408,85 @@ conic-gradient() Syntax</a>
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-angular-color-stop">
-   <b><a href="#typedef-angular-color-stop">#typedef-angular-color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-angular-color-stop" class="dfn-panel" data-for="typedef-angular-color-stop" id="infopanel-for-typedef-angular-color-stop" role="dialog">
+   <span id="infopaneltitle-for-typedef-angular-color-stop" style="display:none">Info about the '&lt;angular-color-stop>' definition.</span><b><a href="#typedef-angular-color-stop">#typedef-angular-color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angular-color-stop">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-angular-color-stop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-angular-color-hint">
-   <b><a href="#typedef-angular-color-hint">#typedef-angular-color-hint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-angular-color-hint" class="dfn-panel" data-for="typedef-angular-color-hint" id="infopanel-for-typedef-angular-color-hint" role="dialog">
+   <span id="infopaneltitle-for-typedef-angular-color-hint" style="display:none">Info about the '&lt;angular-color-hint>' definition.</span><b><a href="#typedef-angular-color-hint">#typedef-angular-color-hint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angular-color-hint">3.5.1. 
 Color Stop Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-stop-angle">
-   <b><a href="#typedef-color-stop-angle">#typedef-color-stop-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-stop-angle" class="dfn-panel" data-for="typedef-color-stop-angle" id="infopanel-for-typedef-color-stop-angle" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-stop-angle" style="display:none">Info about the '&lt;color-stop-angle>' definition.</span><b><a href="#typedef-color-stop-angle">#typedef-color-stop-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop-angle">3.5.1. 
 Color Stop Lists</a> <a href="#ref-for-typedef-color-stop-angle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-color-stop">
-   <b><a href="#typedef-color-stop">#typedef-color-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-color-stop" class="dfn-panel" data-for="typedef-color-stop" id="infopanel-for-typedef-color-stop" role="dialog">
+   <span id="infopaneltitle-for-typedef-color-stop" style="display:none">Info about the '&lt;color-stop>' definition.</span><b><a href="#typedef-color-stop">#typedef-color-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color-stop">7.3. Interpolating &lt;gradient></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-object-fit">
-   <b><a href="#propdef-object-fit">#propdef-object-fit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-object-fit" class="dfn-panel" data-for="propdef-object-fit" id="infopanel-for-propdef-object-fit" role="dialog">
+   <span id="infopaneltitle-for-propdef-object-fit" style="display:none">Info about the 'object-fit' definition.</span><b><a href="#propdef-object-fit">#propdef-object-fit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-fit">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-propdef-object-fit①">(2)</a> <a href="#ref-for-propdef-object-fit②">(3)</a> <a href="#ref-for-propdef-object-fit③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-none">
-   <b><a href="#valdef-object-fit-none">#valdef-object-fit-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-none" class="dfn-panel" data-for="valdef-object-fit-none" id="infopanel-for-valdef-object-fit-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-object-fit-none">#valdef-object-fit-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-none">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-none①">(2)</a> <a href="#ref-for-valdef-object-fit-none②">(3)</a> <a href="#ref-for-valdef-object-fit-none③">(4)</a> <a href="#ref-for-valdef-object-fit-none④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-contain">
-   <b><a href="#valdef-object-fit-contain">#valdef-object-fit-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-contain" class="dfn-panel" data-for="valdef-object-fit-contain" id="infopanel-for-valdef-object-fit-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-object-fit-contain">#valdef-object-fit-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-contain">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-contain①">(2)</a> <a href="#ref-for-valdef-object-fit-contain②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-cover">
-   <b><a href="#valdef-object-fit-cover">#valdef-object-fit-cover</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-cover" class="dfn-panel" data-for="valdef-object-fit-cover" id="infopanel-for-valdef-object-fit-cover" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-cover" style="display:none">Info about the 'cover' definition.</span><b><a href="#valdef-object-fit-cover">#valdef-object-fit-cover</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-cover">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-cover①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-object-fit-scale-down">
-   <b><a href="#valdef-object-fit-scale-down">#valdef-object-fit-scale-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-object-fit-scale-down" class="dfn-panel" data-for="valdef-object-fit-scale-down" id="infopanel-for-valdef-object-fit-scale-down" role="dialog">
+   <span id="infopaneltitle-for-valdef-object-fit-scale-down" style="display:none">Info about the 'scale-down' definition.</span><b><a href="#valdef-object-fit-scale-down">#valdef-object-fit-scale-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-scale-down">5.1. Sizing Objects: the object-fit property</a> <a href="#ref-for-valdef-object-fit-scale-down①">(2)</a> <a href="#ref-for-valdef-object-fit-scale-down②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-image-resolution">
-   <b><a href="#propdef-image-resolution">#propdef-image-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-image-resolution" class="dfn-panel" data-for="propdef-image-resolution" id="infopanel-for-propdef-image-resolution" role="dialog">
+   <span id="infopaneltitle-for-propdef-image-resolution" style="display:none">Info about the 'image-resolution' definition.</span><b><a href="#propdef-image-resolution">#propdef-image-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-resolution">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-propdef-image-resolution①">(2)</a> <a href="#ref-for-propdef-image-resolution②">(3)</a> <a href="#ref-for-propdef-image-resolution③">(4)</a>
     <li><a href="#ref-for-propdef-image-resolution④"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-resolution">
-   <b><a href="#preferred-resolution">#preferred-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-resolution" class="dfn-panel" data-for="preferred-resolution" id="infopanel-for-preferred-resolution" role="dialog">
+   <span id="infopaneltitle-for-preferred-resolution" style="display:none">Info about the 'preferred resolution' definition.</span><b><a href="#preferred-resolution">#preferred-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-resolution">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-preferred-resolution①">(2)</a> <a href="#ref-for-preferred-resolution②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="--natural-resolution">
-   <b><a href="#--natural-resolution">#--natural-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for---natural-resolution" class="dfn-panel" data-for="--natural-resolution" id="infopanel-for---natural-resolution" role="dialog">
+   <span id="infopaneltitle-for---natural-resolution" style="display:none">Info about the 'natural resolution' definition.</span><b><a href="#--natural-resolution">#--natural-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for---natural-resolution">2.3. Resolution/Type Negotiation: the image-set() notation</a> <a href="#ref-for---natural-resolution①">(2)</a> <a href="#ref-for---natural-resolution②">(3)</a> <a href="#ref-for---natural-resolution③">(4)</a>
     <li><a href="#ref-for---natural-resolution④">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for---natural-resolution⑤">(2)</a> <a href="#ref-for---natural-resolution⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-image-resolution-snap">
-   <b><a href="#valdef-image-resolution-snap">#valdef-image-resolution-snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-image-resolution-snap" class="dfn-panel" data-for="valdef-image-resolution-snap" id="infopanel-for-valdef-image-resolution-snap" role="dialog">
+   <span id="infopaneltitle-for-valdef-image-resolution-snap" style="display:none">Info about the 'snap' definition.</span><b><a href="#valdef-image-resolution-snap">#valdef-image-resolution-snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-image-resolution-snap">6.1. Overriding Image Resolutions: the image-resolution property</a> <a href="#ref-for-valdef-image-resolution-snap①">(2)</a>
    </ul>
@@ -4508,59 +4508,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-inline-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-inline-3/Overview.html
@@ -3805,8 +3805,8 @@ as the <a data-link-type="dfn" href="#em-over-baseline" id="ref-for-em-over-base
    <li><a href="#x-middle-baseline">x-middle</a><span>, in § 3.2</span>
    <li><a href="#x-middle-baseline">x-middle baseline</a><span>, in § 3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">2.1. 
 Layout of Line Boxes</a>
@@ -3816,8 +3816,8 @@ Transverse Box Alignment: the vertical-align property</a>
 Alignment Within an Initial Letter Box</a> <a href="#ref-for-propdef-align-content③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shared-alignment-context">
-   <a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shared-alignment-context" class="dfn-panel" data-for="term-for-shared-alignment-context" id="infopanel-for-term-for-shared-alignment-context" role="menu">
+   <span id="infopaneltitle-for-term-for-shared-alignment-context" style="display:none">Info about the 'alignment context' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#shared-alignment-context">https://drafts.csswg.org/css-align-3/#shared-alignment-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-alignment-context">3.3. 
 Baselines of Glyphs and Boxes</a>
@@ -3829,8 +3829,8 @@ Dominant Baselines: the dominant-baseline property</a>
 Alignment Baseline Type: the alignment-baseline longhand</a> <a href="#ref-for-shared-alignment-context④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-baseline-alignment" class="dfn-panel" data-for="term-for-baseline-alignment" id="infopanel-for-term-for-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-baseline-alignment" style="display:none">Info about the 'baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#baseline-alignment">https://drafts.csswg.org/css-align-3/#baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -3838,78 +3838,78 @@ Dominant Baselines: the dominant-baseline property</a>
 Alignment Baseline Type: the alignment-baseline longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-end">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-end" class="dfn-panel" data-for="term-for-valdef-self-position-end" id="infopanel-for-term-for-valdef-self-position-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-end">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#first-baseline-set">https://drafts.csswg.org/css-align-3/#first-baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-baseline-set" class="dfn-panel" data-for="term-for-first-baseline-set" id="infopanel-for-term-for-first-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-first-baseline-set" style="display:none">Info about the 'first baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#first-baseline-set">https://drafts.csswg.org/css-align-3/#first-baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-baseline-set">4.2.1. 
 Alignment Baseline Source: the baseline-source longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#first-baseline-alignment">https://drafts.csswg.org/css-align-3/#first-baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-baseline-alignment" class="dfn-panel" data-for="term-for-first-baseline-alignment" id="infopanel-for-term-for-first-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-first-baseline-alignment" style="display:none">Info about the 'first-baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#first-baseline-alignment">https://drafts.csswg.org/css-align-3/#first-baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-baseline-alignment">4.2.1. 
 Alignment Baseline Source: the baseline-source longhand</a> <a href="#ref-for-first-baseline-alignment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-last-baseline-set">
-   <a href="https://drafts.csswg.org/css-align-3/#last-baseline-set">https://drafts.csswg.org/css-align-3/#last-baseline-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-last-baseline-set" class="dfn-panel" data-for="term-for-last-baseline-set" id="infopanel-for-term-for-last-baseline-set" role="menu">
+   <span id="infopaneltitle-for-term-for-last-baseline-set" style="display:none">Info about the 'last baseline set' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#last-baseline-set">https://drafts.csswg.org/css-align-3/#last-baseline-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-set">4.2.1. 
 Alignment Baseline Source: the baseline-source longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-last-baseline-alignment">
-   <a href="https://drafts.csswg.org/css-align-3/#last-baseline-alignment">https://drafts.csswg.org/css-align-3/#last-baseline-alignment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-last-baseline-alignment" class="dfn-panel" data-for="term-for-last-baseline-alignment" id="infopanel-for-term-for-last-baseline-alignment" role="menu">
+   <span id="infopaneltitle-for-term-for-last-baseline-alignment" style="display:none">Info about the 'last-baseline alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#last-baseline-alignment">https://drafts.csswg.org/css-align-3/#last-baseline-alignment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-baseline-alignment">4.2.1. 
 Alignment Baseline Source: the baseline-source longhand</a> <a href="#ref-for-last-baseline-alignment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-content-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-content-normal" class="dfn-panel" data-for="term-for-valdef-justify-content-normal" id="infopanel-for-term-for-valdef-justify-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-content-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-normal">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-synthesize-baseline">
-   <a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-synthesize-baseline" class="dfn-panel" data-for="term-for-synthesize-baseline" id="infopanel-for-term-for-synthesize-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-synthesize-baseline" style="display:none">Info about the 'synthesize baseline' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#synthesize-baseline">https://drafts.csswg.org/css-align-3/#synthesize-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synthesize-baseline">3.3. 
 Baselines of Glyphs and Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border">
-   <a href="https://drafts.csswg.org/css-box-4/#border">https://drafts.csswg.org/css-box-4/#border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border" class="dfn-panel" data-for="term-for-border" id="infopanel-for-term-for-border" role="menu">
+   <span id="infopaneltitle-for-term-for-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border">https://drafts.csswg.org/css-box-4/#border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border">2. 
 Inline Layout Model</a>
@@ -3925,29 +3925,29 @@ Margins, Borders, and Padding</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">7.4. 
 Alignment of Initial Letters: the initial-letter-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-box-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#box-box-edge">https://drafts.csswg.org/css-box-4/#box-box-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-box-edge" class="dfn-panel" data-for="term-for-box-box-edge" id="infopanel-for-term-for-box-box-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-box-box-edge" style="display:none">Info about the 'box edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#box-box-edge">https://drafts.csswg.org/css-box-4/#box-box-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-box-edge">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-area">
-   <a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-area" class="dfn-panel" data-for="term-for-content-area" id="infopanel-for-term-for-content-area" role="menu">
+   <span id="infopaneltitle-for-term-for-content-area" style="display:none">Info about the 'content area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">6.1. 
 Inline Box Heights: the inline-sizing property</a> <a href="#ref-for-content-area①">(2)</a> <a href="#ref-for-content-area②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">2.1. 
 Layout of Line Boxes</a>
@@ -3959,8 +3959,8 @@ Half-Leading Control: the leading-trim property</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">2. 
 Inline Layout Model</a>
@@ -3974,14 +3974,14 @@ Sizing the Initial Letter Box</a>
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">2.2. 
 Layout Within Line Boxes</a>
@@ -3997,8 +3997,8 @@ Inline Kerning</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-edge" class="dfn-panel" data-for="term-for-margin-edge" id="infopanel-for-term-for-margin-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-edge" style="display:none">Info about the 'margin edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">6.1. 
 Inline Box Heights: the inline-sizing property</a>
@@ -4011,8 +4011,8 @@ Ancestor Inlines</a>
     <li><a href="#ref-for-margin-edge⑤"> A.3: Synthesizing Baselines for Atomic Inlines</a> <a href="#ref-for-margin-edge⑥">(2)</a> <a href="#ref-for-margin-edge⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding" class="dfn-panel" data-for="term-for-padding" id="infopanel-for-term-for-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding">2. 
 Inline Layout Model</a>
@@ -4028,8 +4028,8 @@ Margins, Borders, and Padding</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 Inline Layout Model</a>
@@ -4039,22 +4039,22 @@ Layout of Line Boxes</a>
 Interaction with Fragmentation (Pagination)</a> <a href="#ref-for-fragment③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monolithic">
-   <a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monolithic" class="dfn-panel" data-for="term-for-monolithic" id="infopanel-for-term-for-monolithic" role="menu">
+   <span id="infopaneltitle-for-term-for-monolithic" style="display:none">Info about the 'monolithic' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#monolithic">https://drafts.csswg.org/css-break-3/#monolithic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monolithic">7.9.4. 
 Interaction with Fragmentation (Pagination)</a> <a href="#ref-for-monolithic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">7.9.4. 
 Interaction with Fragmentation (Pagination)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2.2. 
 Layout Within Line Boxes</a>
@@ -4064,22 +4064,22 @@ Alignment Baseline Type: the alignment-baseline longhand</a> <a href="#ref-for-b
 Logical Height Contributions of Inline Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">7.9.4. 
 Interaction with Fragmentation (Pagination)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation" class="dfn-panel" data-for="term-for-fragmentation" id="infopanel-for-term-for-fragmentation" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation" style="display:none">Info about the 'fragmentation' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">7.9.4. 
 Interaction with Fragmentation (Pagination)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">2.1. 
 Layout of Line Boxes</a>
@@ -4087,15 +4087,15 @@ Layout of Line Boxes</a>
 Interaction with Fragmentation (Pagination)</a> <a href="#ref-for-fragmentation-container②">(2)</a> <a href="#ref-for-fragmentation-container③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-widows">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-widows" class="dfn-panel" data-for="term-for-propdef-widows" id="infopanel-for-term-for-propdef-widows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-widows" style="display:none">Info about the 'widows' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">7.9.4. 
 Interaction with Fragmentation (Pagination)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">5.1. 
 Line Spacing: the line-height property</a> <a href="#ref-for-computed-value①">(2)</a>
@@ -4105,8 +4105,8 @@ Applicability</a>
 Font Sizing of Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -4114,22 +4114,22 @@ Inline Box Edge Metrics: the text-edge property</a>
 Properties Applying to Initial Letters</a> <a href="#ref-for-longhand②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">5.1. 
 Line Spacing: the line-height property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -4137,8 +4137,8 @@ Inline Box Edge Metrics: the text-edge property</a>
 Properties Applying to Initial Letters</a> <a href="#ref-for-longhand②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">7.3.1. 
 Applicability</a>
@@ -4146,21 +4146,21 @@ Applicability</a>
 Font Sizing of Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hebrew">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#hebrew">https://drafts.csswg.org/css-counter-styles-3/#hebrew</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hebrew" class="dfn-panel" data-for="term-for-hebrew" id="infopanel-for-term-for-hebrew" role="menu">
+   <span id="infopaneltitle-for-term-for-hebrew" style="display:none">Info about the 'hebrew' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#hebrew">https://drafts.csswg.org/css-counter-styles-3/#hebrew</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hebrew"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">2. 
 Inline Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2. 
 Inline Layout Model</a>
@@ -4180,8 +4180,8 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-atomic-inline⑧">(2)</a>
     <li><a href="#ref-for-atomic-inline①⓪"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline①" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline①" style="display:none">Info about the 'atomic inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2. 
 Inline Layout Model</a>
@@ -4201,15 +4201,15 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-atomic-inline⑧">(2)</a>
     <li><a href="#ref-for-atomic-inline①⓪"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-block" class="dfn-panel" data-for="term-for-valdef-display-block" id="infopanel-for-term-for-valdef-display-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">7.3.1. 
 Applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Inline Layout Model</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a> <a href="#ref-for-block-container③">(4)</a> <a href="#ref-for-block-container④">(5)</a>
@@ -4221,8 +4221,8 @@ Line Spacing: the line-height property</a>
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-block-container①⓪">(2)</a> <a href="#ref-for-block-container①①">(3)</a> <a href="#ref-for-block-container①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container①" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container①" style="display:none">Info about the 'block container box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Inline Layout Model</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a> <a href="#ref-for-block-container③">(4)</a> <a href="#ref-for-block-container④">(5)</a>
@@ -4234,8 +4234,8 @@ Line Spacing: the line-height property</a>
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-block-container①⓪">(2)</a> <a href="#ref-for-block-container①①">(3)</a> <a href="#ref-for-block-container①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">7.8. 
 Line Layout</a>
@@ -4243,8 +4243,8 @@ Line Layout</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">3.3. 
 Baselines of Glyphs and Boxes</a>
@@ -4252,15 +4252,15 @@ Baselines of Glyphs and Boxes</a>
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-tree">
-   <a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-tree" class="dfn-panel" data-for="term-for-box-tree" id="infopanel-for-term-for-box-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-box-tree" style="display:none">Info about the 'box tree' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. 
 Inline Layout Model</a>
@@ -4275,22 +4275,22 @@ Block-axis Positioning</a> <a href="#ref-for-containing-block⑧">(2)</a> <a hre
     <li><a href="#ref-for-containing-block①⓪"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">7.3.1. 
 Applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-order">
-   <a href="https://drafts.csswg.org/css-display-3/#document-order">https://drafts.csswg.org/css-display-3/#document-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-order" class="dfn-panel" data-for="term-for-document-order" id="infopanel-for-term-for-document-order" role="menu">
+   <span id="infopaneltitle-for-term-for-document-order" style="display:none">Info about the 'document order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#document-order">https://drafts.csswg.org/css-display-3/#document-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-order">2.3. 
 Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2.1. 
 Layout of Line Boxes</a>
@@ -4302,8 +4302,8 @@ Baseline Alignment</a>
 Alignment Baseline Type: the alignment-baseline longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2.1. 
 Layout of Line Boxes</a>
@@ -4317,8 +4317,8 @@ Line Layout</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">7.5. 
 Initial Letter Layout</a>
@@ -4326,15 +4326,15 @@ Initial Letter Layout</a>
 Short paragraphs with initial letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-block">https://drafts.csswg.org/css-display-3/#inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-block" class="dfn-panel" data-for="term-for-inline-block" id="infopanel-for-term-for-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-block" style="display:none">Info about the 'inline block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-block">https://drafts.csswg.org/css-display-3/#inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-block">2.2. 
 Layout Within Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2. 
 Inline Layout Model</a> <a href="#ref-for-inline-box①">(2)</a> <a href="#ref-for-inline-box②">(3)</a> <a href="#ref-for-inline-box③">(4)</a>
@@ -4372,15 +4372,15 @@ Properties Applying to Initial Letters</a>
 Ancestor Inlines</a> <a href="#ref-for-inline-box④⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">4.2.1. 
 Alignment Baseline Source: the baseline-source longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">1. 
 Introduction</a> <a href="#ref-for-inline-level①">(2)</a>
@@ -4402,8 +4402,8 @@ Inline Flow Layout: Alignment, Justification, and White Space</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level-box" class="dfn-panel" data-for="term-for-inline-level-box" id="infopanel-for-term-for-inline-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level-box" style="display:none">Info about the 'inline-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level-box">2. 
 Inline Layout Model</a> <a href="#ref-for-inline-level-box①">(2)</a> <a href="#ref-for-inline-level-box②">(3)</a> <a href="#ref-for-inline-level-box③">(4)</a>
@@ -4423,8 +4423,8 @@ Creating Initial Letters: the initial-letter property</a>
 Applicability</a> <a href="#ref-for-inline-level-box①④">(2)</a> <a href="#ref-for-inline-level-box①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level①" style="display:none">Info about the 'inline-level content' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">1. 
 Introduction</a> <a href="#ref-for-inline-level①">(2)</a>
@@ -4446,8 +4446,8 @@ Inline Flow Layout: Alignment, Justification, and White Space</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2.2. 
 Layout Within Line Boxes</a>
@@ -4456,15 +4456,15 @@ Initial Letter Layout</a>
     <li><a href="#ref-for-replaced-element②"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">2. 
 Inline Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-available-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-available-font" class="dfn-panel" data-for="term-for-first-available-font" id="infopanel-for-term-for-first-available-font" role="menu">
+   <span id="infopaneltitle-for-term-for-first-available-font" style="display:none">Info about the 'first available font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-available-font">3.3. 
 Baselines of Glyphs and Boxes</a>
@@ -4476,15 +4476,15 @@ Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-first-availab
 Inline Box Heights: the inline-sizing property</a> <a href="#ref-for-first-available-font⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-language-override">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-language-override" class="dfn-panel" data-for="term-for-propdef-font-language-override" id="infopanel-for-term-for-propdef-font-language-override" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-language-override" style="display:none">Info about the 'font-language-override' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override">https://drafts.csswg.org/css-fonts-4/#propdef-font-language-override</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-language-override">3.1. 
 Introduction to Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-propdef-font-size①">(2)</a>
@@ -4496,65 +4496,65 @@ Properties Applying to Initial Letters</a>
 Font Sizing of Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-list-style-position-inside">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside">https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-list-style-position-inside" class="dfn-panel" data-for="term-for-valdef-list-style-position-inside" id="infopanel-for-term-for-valdef-list-style-position-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-list-style-position-inside" style="display:none">Info about the 'inside' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside">https://drafts.csswg.org/css-lists-3/#valdef-list-style-position-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-position-inside">7.3.1. 
 Applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-column-box">
-   <a href="https://drafts.csswg.org/css-multicol-1/#column-box">https://drafts.csswg.org/css-multicol-1/#column-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-column-box" class="dfn-panel" data-for="term-for-column-box" id="infopanel-for-term-for-column-box" role="menu">
+   <span id="infopaneltitle-for-term-for-column-box" style="display:none">Info about the 'column box' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#column-box">https://drafts.csswg.org/css-multicol-1/#column-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-box">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-layout">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-layout">https://drafts.csswg.org/css-multicol-1/#multi-column-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-layout" class="dfn-panel" data-for="term-for-multi-column-layout" id="infopanel-for-term-for-multi-column-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-layout" style="display:none">Info about the 'multi-column layout' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-layout">https://drafts.csswg.org/css-multicol-1/#multi-column-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-layout">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-float">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-float" class="dfn-panel" data-for="term-for-float" id="infopanel-for-term-for-float" role="menu">
+   <span id="infopaneltitle-for-term-for-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-position">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-position" class="dfn-panel" data-for="term-for-absolute-position" id="infopanel-for-term-for-absolute-position" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-position" style="display:none">Info about the 'absolutely positioned box' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">7.3.1. 
 Applicability</a>
     <li><a href="#ref-for-propdef-position①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-positioned-box">
-   <a href="https://drafts.csswg.org/css-position-3/#positioned-box">https://drafts.csswg.org/css-position-3/#positioned-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-positioned-box" class="dfn-panel" data-for="term-for-positioned-box" id="infopanel-for-term-for-positioned-box" role="menu">
+   <span id="infopaneltitle-for-term-for-positioned-box" style="display:none">Info about the 'positioned box' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#positioned-box">https://drafts.csswg.org/css-position-3/#positioned-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positioned-box">2.3. 
 Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">7.3.1. 
 Applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">7.2. 
 Selecting Initial Letters</a> <a href="#ref-for-selectordef-first-letter①">(2)</a> <a href="#ref-for-selectordef-first-letter②">(3)</a> <a href="#ref-for-selectordef-first-letter③">(4)</a>
@@ -4562,71 +4562,71 @@ Selecting Initial Letters</a> <a href="#ref-for-selectordef-first-letter①">(2)
 Applicability</a> <a href="#ref-for-selectordef-first-letter⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">7.3.1. 
 Applicability</a> <a href="#ref-for-selectordef-marker①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-formatted-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-formatted-line" class="dfn-panel" data-for="term-for-first-formatted-line" id="infopanel-for-term-for-first-formatted-line" role="menu">
+   <span id="infopaneltitle-for-term-for-first-formatted-line" style="display:none">Info about the 'first formatted line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line">5.4. 
 Half-Leading Control: the leading-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-ruby-boxes">
-   <a href="https://drafts.csswg.org/css-ruby-1/#internal-ruby-boxes">https://drafts.csswg.org/css-ruby-1/#internal-ruby-boxes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-ruby-boxes" class="dfn-panel" data-for="term-for-internal-ruby-boxes" id="infopanel-for-term-for-internal-ruby-boxes" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-ruby-boxes" style="display:none">Info about the 'internal ruby boxes' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#internal-ruby-boxes">https://drafts.csswg.org/css-ruby-1/#internal-ruby-boxes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-ruby-boxes">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby">https://drafts.csswg.org/css-ruby-1/#ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby" class="dfn-panel" data-for="term-for-ruby" id="infopanel-for-term-for-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby">https://drafts.csswg.org/css-ruby-1/#ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby">7.3.1. 
 Applicability</a> <a href="#ref-for-ruby①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-box" class="dfn-panel" data-for="term-for-ruby-annotation-box" id="infopanel-for-term-for-ruby-annotation-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-box" style="display:none">Info about the 'ruby annotation' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-box">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-container">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-container" class="dfn-panel" data-for="term-for-ruby-container" id="infopanel-for-term-for-ruby-container" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-container" style="display:none">Info about the 'ruby container box' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-container">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-margin">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-margin" class="dfn-panel" data-for="term-for-propdef-shape-margin" id="infopanel-for-term-for-propdef-shape-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-margin" style="display:none">Info about the 'shape-margin' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-margin">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
     <li><a href="#ref-for-propdef-shape-margin①"> Changes</a> <a href="#ref-for-propdef-shape-margin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-outside">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside">https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-outside" class="dfn-panel" data-for="term-for-propdef-shape-outside" id="infopanel-for-term-for-propdef-shape-outside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-outside" style="display:none">Info about the 'shape-outside' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside">https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-outside"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">7.5. 
 Initial Letter Layout</a>
@@ -4638,8 +4638,8 @@ Alignment Within an Initial Letter Box</a>
 Inline Kerning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">7.5.1. 
 Properties Applying to Initial Letters</a>
@@ -4647,8 +4647,8 @@ Properties Applying to Initial Letters</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">7.5.5. 
 Sizing the Initial Letter Box</a> <a href="#ref-for-definite①">(2)</a>
@@ -4656,15 +4656,15 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-definite①">(2)</a>
 Alignment Within an Initial Letter Box</a> <a href="#ref-for-definite③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">2.1. 
 Layout of Line Boxes</a>
@@ -4672,94 +4672,94 @@ Layout of Line Boxes</a>
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'max size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'min size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#height">https://drafts.csswg.org/css-sizing-3/#height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-height" class="dfn-panel" data-for="term-for-height" id="infopanel-for-term-for-height" role="menu">
+   <span id="infopaneltitle-for-term-for-height" style="display:none">Info about the 'preferred height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#height">https://drafts.csswg.org/css-sizing-3/#height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-height">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#width">https://drafts.csswg.org/css-sizing-3/#width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-width" class="dfn-panel" data-for="term-for-width" id="infopanel-for-term-for-width" role="menu">
+   <span id="infopaneltitle-for-term-for-width" style="display:none">Info about the 'preferred width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#width">https://drafts.csswg.org/css-sizing-3/#width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-width">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">7.5.1. 
 Properties Applying to Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-line-break">
-   <a href="https://drafts.csswg.org/css-text-3/#forced-line-break">https://drafts.csswg.org/css-text-3/#forced-line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-line-break" class="dfn-panel" data-for="term-for-forced-line-break" id="infopanel-for-term-for-forced-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-line-break" style="display:none">Info about the 'forced line break' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#forced-line-break">https://drafts.csswg.org/css-text-3/#forced-line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-line-break">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hang">
-   <a href="https://drafts.csswg.org/css-text-3/#hang">https://drafts.csswg.org/css-text-3/#hang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hang" class="dfn-panel" data-for="term-for-hang" id="infopanel-for-term-for-hang" role="menu">
+   <span id="infopaneltitle-for-term-for-hang" style="display:none">Info about the 'hang' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#hang">https://drafts.csswg.org/css-text-3/#hang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hang">7.5.5. 
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">7.5.6. 
 Alignment Within an Initial Letter Box</a> <a href="#ref-for-propdef-text-align①">(2)</a>
     <li><a href="#ref-for-propdef-text-align②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">3.1. 
 Introduction to Baselines</a>
     <li><a href="#ref-for-content-language①"> A.2: Synthesizing Baselines (and Other Font Metrics) for Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'document white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">7.8.1. 
 Inline Flow Layout: Alignment, Justification, and White Space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-line-break">
-   <a href="https://drafts.csswg.org/css-text-4/#forced-line-break">https://drafts.csswg.org/css-text-4/#forced-line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-line-break" class="dfn-panel" data-for="term-for-forced-line-break" id="infopanel-for-term-for-forced-line-break①" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-line-break①" style="display:none">Info about the 'forced line break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#forced-line-break">https://drafts.csswg.org/css-text-4/#forced-line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-line-break①">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-hanging-punctuation">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation">https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-hanging-punctuation" class="dfn-panel" data-for="term-for-propdef-hanging-punctuation" id="infopanel-for-term-for-propdef-hanging-punctuation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-hanging-punctuation" style="display:none">Info about the 'hanging-punctuation' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation">https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hanging-punctuation">7.5.5. 
 Sizing the Initial Letter Box</a>
@@ -4767,15 +4767,15 @@ Sizing the Initial Letter Box</a>
 Edge Effects: Indentation and Hanging Punctuation</a> <a href="#ref-for-propdef-hanging-punctuation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-justification-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-justification-opportunity" class="dfn-panel" data-for="term-for-justification-opportunity" id="infopanel-for-term-for-justification-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-justification-opportunity" style="display:none">Info about the 'justification opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-justification-opportunity">7.8.1. 
 Inline Flow Layout: Alignment, Justification, and White Space</a> <a href="#ref-for-justification-opportunity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
@@ -4785,8 +4785,8 @@ Inline Flow Layout: Alignment, Justification, and White Space</a>
 Ancestor Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preserved-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#preserved-white-space">https://drafts.csswg.org/css-text-4/#preserved-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preserved-white-space" class="dfn-panel" data-for="term-for-preserved-white-space" id="infopanel-for-term-for-preserved-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-preserved-white-space" style="display:none">Info about the 'preserved white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#preserved-white-space">https://drafts.csswg.org/css-text-4/#preserved-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preserved-white-space">2.1. 
 Layout of Line Boxes</a>
@@ -4794,15 +4794,15 @@ Layout of Line Boxes</a>
 Logical Height Contributions of Inline Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">7.8.2. 
 Edge Effects: Indentation and Hanging Punctuation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
@@ -4810,43 +4810,43 @@ Initial Letter Wrapping: the initial-letter-wrap property</a>
 Inline Flow Layout: Alignment, Justification, and White Space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-word-separator">
-   <a href="https://drafts.csswg.org/css-text-4/#word-separator">https://drafts.csswg.org/css-text-4/#word-separator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-word-separator" class="dfn-panel" data-for="term-for-word-separator" id="infopanel-for-term-for-word-separator" role="menu">
+   <span id="infopaneltitle-for-term-for-word-separator" style="display:none">Info about the 'word separator' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#word-separator">https://drafts.csswg.org/css-text-4/#word-separator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-word-separator">7.8.1. 
 Inline Flow Layout: Alignment, Justification, and White Space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">7.8.1. 
 Inline Flow Layout: Alignment, Justification, and White Space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">7.4. 
 Alignment of Initial Letters: the initial-letter-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">7.3. 
 Creating Initial Letters: the initial-letter property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
@@ -4856,8 +4856,8 @@ Line Spacing: the line-height property</a>
 Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-typedef-length-percentage⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
@@ -4867,8 +4867,8 @@ Line Spacing: the line-height property</a> <a href="#ref-for-length-value②">(2
 Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-length-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5.1. 
 Line Spacing: the line-height property</a> <a href="#ref-for-number-value①">(2)</a>
@@ -4876,8 +4876,8 @@ Line Spacing: the line-height property</a> <a href="#ref-for-number-value①">(2
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-number-value③">(2)</a> <a href="#ref-for-number-value④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
@@ -4888,8 +4888,8 @@ Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-
     <li><a href="#ref-for-percentage-value④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -4899,22 +4899,22 @@ Creating Initial Letters: the initial-letter property</a>
 Alignment of Initial Letters: the initial-letter-align property</a> <a href="#ref-for-mult-opt③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">7.5.3. 
 Font Sizing of Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. 
 Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a>
@@ -4942,15 +4942,15 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
 Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-comb-one④④">(2)</a> <a href="#ref-for-comb-one④⑤">(3)</a> <a href="#ref-for-comb-one④⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.2. 
 Transverse Box Alignment: the vertical-align property</a> <a href="#ref-for-comb-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">1. 
 Introduction</a>
@@ -4974,8 +4974,8 @@ Alignment Within an Initial Letter Box</a> <a href="#ref-for-block-axis①⓪">(
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">5.4. 
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-block-end①">(2)</a> <a href="#ref-for-block-end②">(3)</a> <a href="#ref-for-block-end③">(4)</a>
@@ -4985,15 +4985,15 @@ Drop Initial</a>
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">2.1. 
 Layout of Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">7.5.5. 
 Sizing the Initial Letter Box</a> <a href="#ref-for-block-size①">(2)</a>
@@ -5001,8 +5001,8 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-block-size①">(2)</a>
 Alignment Within an Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis①" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">1. 
 Introduction</a>
@@ -5026,8 +5026,8 @@ Alignment Within an Initial Letter Box</a> <a href="#ref-for-block-axis①⓪">(
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end①" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end①" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">5.4. 
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-block-end①">(2)</a> <a href="#ref-for-block-end②">(3)</a> <a href="#ref-for-block-end③">(4)</a>
@@ -5037,8 +5037,8 @@ Drop Initial</a>
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">5.4. 
 Half-Leading Control: the leading-trim property</a>
@@ -5050,15 +5050,15 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-block-start③">(2)</a>
 Block-axis Positioning</a> <a href="#ref-for-block-start⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-horizontal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-horizontal-writing-mode" class="dfn-panel" data-for="term-for-horizontal-writing-mode" id="infopanel-for-term-for-horizontal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">2. 
 Inline Layout Model</a> <a href="#ref-for-inline-axis①">(2)</a>
@@ -5073,8 +5073,8 @@ Alignment Within an Initial Letter Box</a> <a href="#ref-for-inline-axis⑥">(2)
     <li><a href="#ref-for-inline-axis⑦"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">7.5.6. 
 Alignment Within an Initial Letter Box</a>
@@ -5082,8 +5082,8 @@ Alignment Within an Initial Letter Box</a>
 Inline Kerning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis①" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">2. 
 Inline Layout Model</a> <a href="#ref-for-inline-axis①">(2)</a>
@@ -5098,15 +5098,15 @@ Alignment Within an Initial Letter Box</a> <a href="#ref-for-inline-axis⑥">(2)
     <li><a href="#ref-for-inline-axis⑦"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">7.6.2. 
 Inline Kerning</a>
@@ -5114,15 +5114,15 @@ Inline Kerning</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-left" class="dfn-panel" data-for="term-for-line-left" id="infopanel-for-term-for-line-left" role="menu">
+   <span id="infopaneltitle-for-term-for-line-left" style="display:none">Info about the 'line-left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">2.1. 
 Layout of Line Boxes</a> <a href="#ref-for-line-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-over" class="dfn-panel" data-for="term-for-line-over" id="infopanel-for-term-for-line-over" role="menu">
+   <span id="infopaneltitle-for-term-for-line-over" style="display:none">Info about the 'line-over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">2.1. 
 Layout of Line Boxes</a>
@@ -5135,15 +5135,15 @@ Alignment of Initial Letters: the initial-letter-align property</a>
     <li><a href="#ref-for-line-over⑧"> A.3: Synthesizing Baselines for Atomic Inlines</a> <a href="#ref-for-line-over⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-right" class="dfn-panel" data-for="term-for-line-right" id="infopanel-for-term-for-line-right" role="menu">
+   <span id="infopaneltitle-for-term-for-line-right" style="display:none">Info about the 'line-right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">2.1. 
 Layout of Line Boxes</a> <a href="#ref-for-line-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-under" class="dfn-panel" data-for="term-for-line-under" id="infopanel-for-term-for-line-under" role="menu">
+   <span id="infopaneltitle-for-term-for-line-under" style="display:none">Info about the 'line-under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">2.1. 
 Layout of Line Boxes</a>
@@ -5158,8 +5158,8 @@ Alignment of Initial Letters: the initial-letter-align property</a>
     <li><a href="#ref-for-line-under⑧"> A.3: Synthesizing Baselines for Atomic Inlines</a> <a href="#ref-for-line-under⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-height">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-height">https://drafts.csswg.org/css-writing-modes-4/#logical-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-height" class="dfn-panel" data-for="term-for-logical-height" id="infopanel-for-term-for-logical-height" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-height" style="display:none">Info about the 'logical height' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-height">https://drafts.csswg.org/css-writing-modes-4/#logical-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-height">2.1. 
 Layout of Line Boxes</a> <a href="#ref-for-logical-height①">(2)</a>
@@ -5177,8 +5177,8 @@ Inline Box Heights: the inline-sizing property</a> <a href="#ref-for-logical-hei
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-width">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-width" class="dfn-panel" data-for="term-for-logical-width" id="infopanel-for-term-for-logical-width" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-width" style="display:none">Info about the 'logical width' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-width">2.1. 
 Layout of Line Boxes</a> <a href="#ref-for-logical-width①">(2)</a> <a href="#ref-for-logical-width②">(3)</a> <a href="#ref-for-logical-width③">(4)</a>
@@ -5186,15 +5186,15 @@ Layout of Line Boxes</a> <a href="#ref-for-logical-width①">(2)</a> <a href="#r
 Initial Letter Wrapping: the initial-letter-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-mixed">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-mixed">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-mixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-mixed" class="dfn-panel" data-for="term-for-valdef-text-orientation-mixed" id="infopanel-for-term-for-valdef-text-orientation-mixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-mixed" style="display:none">Info about the 'mixed' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-mixed">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-mixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-mixed">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-over" class="dfn-panel" data-for="term-for-over" id="infopanel-for-term-for-over" role="menu">
+   <span id="infopaneltitle-for-term-for-over" style="display:none">Info about the 'over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-over">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
@@ -5210,15 +5210,15 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-over⑧">(2)</a>
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-sideways">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-sideways">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-sideways</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-sideways" class="dfn-panel" data-for="term-for-valdef-text-orientation-sideways" id="infopanel-for-term-for-valdef-text-orientation-sideways" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-sideways" style="display:none">Info about the 'sideways' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-sideways">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-sideways</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-sideways">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">4.1. 
 Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-propdef-text-orientation①">(2)</a> <a href="#ref-for-propdef-text-orientation②">(3)</a>
@@ -5226,8 +5226,8 @@ Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-propdef
 Alignment Baseline Type: the alignment-baseline longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-mode" class="dfn-panel" data-for="term-for-typographic-mode" id="infopanel-for-term-for-typographic-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-mode" style="display:none">Info about the 'typographic mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">3.1. 
 Introduction to Baselines</a>
@@ -5235,8 +5235,8 @@ Introduction to Baselines</a>
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-under" class="dfn-panel" data-for="term-for-under" id="infopanel-for-term-for-under" role="menu">
+   <span id="infopaneltitle-for-term-for-under" style="display:none">Info about the 'under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -5248,37 +5248,37 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
 Block-axis Positioning</a> <a href="#ref-for-under⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-upright" class="dfn-panel" data-for="term-for-valdef-text-orientation-upright" id="infopanel-for-term-for-valdef-text-orientation-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">4.1. 
 Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-vertical-writing-mode①">(2)</a> <a href="#ref-for-vertical-writing-mode②">(3)</a>
     <li><a href="#ref-for-vertical-writing-mode③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr" id="infopanel-for-term-for-valdef-writing-mode-vertical-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">5.4. 
 Half-Leading Control: the leading-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">5.4. 
 Half-Leading Control: the leading-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">7.9.2. 
 Short paragraphs with initial letters</a>
@@ -5286,44 +5286,44 @@ Short paragraphs with initial letters</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">7.3.1. 
 Applicability</a>
     <li><a href="#ref-for-propdef-float①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-float-none">
-   <a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-float-none" class="dfn-panel" data-for="term-for-valdef-float-none" id="infopanel-for-term-for-valdef-float-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-float-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-float-none">7.3.1. 
 Applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">2.3. 
 Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-range-start">
-   <a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-range-start" class="dfn-panel" data-for="term-for-concept-range-start" id="infopanel-for-term-for-concept-range-start" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-range-start" style="display:none">Info about the 'start' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-range-start">https://dom.spec.whatwg.org/#concept-range-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermCurrentTextPosition">
-   <a href="https://svgwg.org/svg2-draft/text.html#TermCurrentTextPosition">https://svgwg.org/svg2-draft/text.html#TermCurrentTextPosition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermCurrentTextPosition" class="dfn-panel" data-for="term-for-TermCurrentTextPosition" id="infopanel-for-term-for-TermCurrentTextPosition" role="menu">
+   <span id="infopaneltitle-for-term-for-TermCurrentTextPosition" style="display:none">Info about the 'current text position' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TermCurrentTextPosition">https://svgwg.org/svg2-draft/text.html#TermCurrentTextPosition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermCurrentTextPosition">4.2.2. 
 Alignment Baseline Type: the alignment-baseline longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermTextContentElement">
-   <a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermTextContentElement" class="dfn-panel" data-for="term-for-TermTextContentElement" id="infopanel-for-term-for-TermTextContentElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermTextContentElement" style="display:none">Info about the 'text content element' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermTextContentElement">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -5872,8 +5872,8 @@ Line Spacing: the line-height property</a>
    <div class="issue"> Pick a default. <a class="issue-return" href="#issue-2765c39b" title="Jump to section">↵</a></div>
    <div class="issue"> Somebody sanity-check these heuristics please. <a class="issue-return" href="#issue-6c88f039" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="inline-layout">
-   <b><a href="#inline-layout">#inline-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-layout" class="dfn-panel" data-for="inline-layout" id="infopanel-for-inline-layout" role="dialog">
+   <span id="infopaneltitle-for-inline-layout" style="display:none">Info about the 'inline layout' definition.</span><b><a href="#inline-layout">#inline-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-layout">1. 
 Introduction</a>
@@ -5883,8 +5883,8 @@ Baselines and Metrics</a>
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-formatting-context">
-   <b><a href="#inline-formatting-context">#inline-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-formatting-context" class="dfn-panel" data-for="inline-formatting-context" id="infopanel-for-inline-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' definition.</span><b><a href="#inline-formatting-context">#inline-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2. 
 Inline Layout Model</a> <a href="#ref-for-inline-formatting-context①">(2)</a> <a href="#ref-for-inline-formatting-context②">(3)</a> <a href="#ref-for-inline-formatting-context③">(4)</a>
@@ -5901,8 +5901,8 @@ Initial Letter Layout</a>
     <li><a href="#ref-for-inline-formatting-context①⓪"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root-inline-box">
-   <b><a href="#root-inline-box">#root-inline-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-root-inline-box" class="dfn-panel" data-for="root-inline-box" id="infopanel-for-root-inline-box" role="dialog">
+   <span id="infopaneltitle-for-root-inline-box" style="display:none">Info about the 'root inline box' definition.</span><b><a href="#root-inline-box">#root-inline-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">2. 
 Inline Layout Model</a> <a href="#ref-for-root-inline-box①">(2)</a>
@@ -5920,8 +5920,8 @@ Alignment of Initial Letters: the initial-letter-align property</a>
 Block-axis Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-box">
-   <b><a href="#line-box">#line-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-box" class="dfn-panel" data-for="line-box" id="infopanel-for-line-box" role="dialog">
+   <span id="infopaneltitle-for-line-box" style="display:none">Info about the 'line box' definition.</span><b><a href="#line-box">#line-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">2. 
 Inline Layout Model</a> <a href="#ref-for-line-box①">(2)</a> <a href="#ref-for-line-box②">(3)</a>
@@ -5957,8 +5957,8 @@ Line Layout</a>
 Interaction with floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline">
-   <b><a href="#baseline">#baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline" class="dfn-panel" data-for="baseline" id="infopanel-for-baseline" role="dialog">
+   <span id="infopaneltitle-for-baseline" style="display:none">Info about the 'baseline' definition.</span><b><a href="#baseline">#baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline">3.1. 
 Introduction to Baselines</a> <a href="#ref-for-baseline①">(2)</a> <a href="#ref-for-baseline②">(3)</a>
@@ -5977,8 +5977,8 @@ Logical Height Contributions of Inline Boxes</a>
     <li><a href="#ref-for-baseline①⑧"> A.3: Synthesizing Baselines for Atomic Inlines</a> <a href="#ref-for-baseline①⑨">(2)</a> <a href="#ref-for-baseline②⓪">(3)</a> <a href="#ref-for-baseline②①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-table">
-   <b><a href="#baseline-table">#baseline-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-table" class="dfn-panel" data-for="baseline-table" id="infopanel-for-baseline-table" role="dialog">
+   <span id="infopaneltitle-for-baseline-table" style="display:none">Info about the 'baseline table' definition.</span><b><a href="#baseline-table">#baseline-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-table">3.1. 
 Introduction to Baselines</a> <a href="#ref-for-baseline-table①">(2)</a> <a href="#ref-for-baseline-table②">(3)</a>
@@ -5987,8 +5987,8 @@ Baselines of Glyphs and Boxes</a>
     <li><a href="#ref-for-baseline-table④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alphabetic-baseline">
-   <b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alphabetic-baseline" class="dfn-panel" data-for="alphabetic-baseline" id="infopanel-for-alphabetic-baseline" role="dialog">
+   <span id="infopaneltitle-for-alphabetic-baseline" style="display:none">Info about the 'alphabetic' definition.</span><b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alphabetic-baseline">3.2. 
 Baselines and Metrics</a>
@@ -6005,8 +6005,8 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
     <li><a href="#ref-for-alphabetic-baseline①③"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cap-height-baseline">
-   <b><a href="#cap-height-baseline">#cap-height-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cap-height-baseline" class="dfn-panel" data-for="cap-height-baseline" id="infopanel-for-cap-height-baseline" role="dialog">
+   <span id="infopaneltitle-for-cap-height-baseline" style="display:none">Info about the 'cap-height' definition.</span><b><a href="#cap-height-baseline">#cap-height-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cap-height-baseline">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -6015,8 +6015,8 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
     <li><a href="#ref-for-cap-height-baseline③"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-height-baseline">
-   <b><a href="#x-height-baseline">#x-height-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-height-baseline" class="dfn-panel" data-for="x-height-baseline" id="infopanel-for-x-height-baseline" role="dialog">
+   <span id="infopaneltitle-for-x-height-baseline" style="display:none">Info about the 'x-height' definition.</span><b><a href="#x-height-baseline">#x-height-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-height-baseline">3.2. 
 Baselines and Metrics</a>
@@ -6029,8 +6029,8 @@ Inline Box Edge Metrics: the text-edge property</a>
     <li><a href="#ref-for-x-height-baseline④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-middle-baseline">
-   <b><a href="#x-middle-baseline">#x-middle-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-middle-baseline" class="dfn-panel" data-for="x-middle-baseline" id="infopanel-for-x-middle-baseline" role="dialog">
+   <span id="infopaneltitle-for-x-middle-baseline" style="display:none">Info about the 'x-middle' definition.</span><b><a href="#x-middle-baseline">#x-middle-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-middle-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -6039,8 +6039,8 @@ Alignment Baseline Type: the alignment-baseline longhand</a>
     <li><a href="#ref-for-x-middle-baseline②"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ideographic-over-baseline">
-   <b><a href="#ideographic-over-baseline">#ideographic-over-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ideographic-over-baseline" class="dfn-panel" data-for="ideographic-over-baseline" id="infopanel-for-ideographic-over-baseline" role="dialog">
+   <span id="infopaneltitle-for-ideographic-over-baseline" style="display:none">Info about the 'ideographic-over' definition.</span><b><a href="#ideographic-over-baseline">#ideographic-over-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ideographic-over-baseline">3.2. 
 Baselines and Metrics</a>
@@ -6051,8 +6051,8 @@ Inline Box Edge Metrics: the text-edge property</a>
     <li><a href="#ref-for-ideographic-over-baseline⑦"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ideographic-under-baseline">
-   <b><a href="#ideographic-under-baseline">#ideographic-under-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ideographic-under-baseline" class="dfn-panel" data-for="ideographic-under-baseline" id="infopanel-for-ideographic-under-baseline" role="dialog">
+   <span id="infopaneltitle-for-ideographic-under-baseline" style="display:none">Info about the 'ideographic-under' definition.</span><b><a href="#ideographic-under-baseline">#ideographic-under-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ideographic-under-baseline">3.2. 
 Baselines and Metrics</a>
@@ -6065,8 +6065,8 @@ Alignment Baseline Type: the alignment-baseline longhand</a>
     <li><a href="#ref-for-ideographic-under-baseline⑧"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="central-baseline">
-   <b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-central-baseline" class="dfn-panel" data-for="central-baseline" id="infopanel-for-central-baseline" role="dialog">
+   <span id="infopaneltitle-for-central-baseline" style="display:none">Info about the 'central' definition.</span><b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-central-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-central-baseline①">(2)</a>
@@ -6078,8 +6078,8 @@ Alignment Baseline Type: the alignment-baseline longhand</a> <a href="#ref-for-c
     <li><a href="#ref-for-central-baseline①⓪"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ideographic-ink-over-baseline">
-   <b><a href="#ideographic-ink-over-baseline">#ideographic-ink-over-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ideographic-ink-over-baseline" class="dfn-panel" data-for="ideographic-ink-over-baseline" id="infopanel-for-ideographic-ink-over-baseline" role="dialog">
+   <span id="infopaneltitle-for-ideographic-ink-over-baseline" style="display:none">Info about the 'ideographic-ink-over' definition.</span><b><a href="#ideographic-ink-over-baseline">#ideographic-ink-over-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ideographic-ink-over-baseline">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -6088,8 +6088,8 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
     <li><a href="#ref-for-ideographic-ink-over-baseline③"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ideographic-ink-under-baseline">
-   <b><a href="#ideographic-ink-under-baseline">#ideographic-ink-under-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ideographic-ink-under-baseline" class="dfn-panel" data-for="ideographic-ink-under-baseline" id="infopanel-for-ideographic-ink-under-baseline" role="dialog">
+   <span id="infopaneltitle-for-ideographic-ink-under-baseline" style="display:none">Info about the 'ideographic-ink-under' definition.</span><b><a href="#ideographic-ink-under-baseline">#ideographic-ink-under-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ideographic-ink-under-baseline">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
@@ -6098,8 +6098,8 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
     <li><a href="#ref-for-ideographic-ink-under-baseline③"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hanging-baseline">
-   <b><a href="#hanging-baseline">#hanging-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hanging-baseline" class="dfn-panel" data-for="hanging-baseline" id="infopanel-for-hanging-baseline" role="dialog">
+   <span id="infopaneltitle-for-hanging-baseline" style="display:none">Info about the 'hanging' definition.</span><b><a href="#hanging-baseline">#hanging-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hanging-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -6108,8 +6108,8 @@ Alignment of Initial Letters: the initial-letter-align property</a> <a href="#re
     <li><a href="#ref-for-hanging-baseline③"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="math-baseline">
-   <b><a href="#math-baseline">#math-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-math-baseline" class="dfn-panel" data-for="math-baseline" id="infopanel-for-math-baseline" role="dialog">
+   <span id="infopaneltitle-for-math-baseline" style="display:none">Info about the 'math' definition.</span><b><a href="#math-baseline">#math-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-math-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -6118,8 +6118,8 @@ Alignment Baseline Type: the alignment-baseline longhand</a>
     <li><a href="#ref-for-math-baseline②"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-over-baseline">
-   <b><a href="#text-over-baseline">#text-over-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-over-baseline" class="dfn-panel" data-for="text-over-baseline" id="infopanel-for-text-over-baseline" role="dialog">
+   <span id="infopaneltitle-for-text-over-baseline" style="display:none">Info about the 'text-over' definition.</span><b><a href="#text-over-baseline">#text-over-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-over-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -6132,8 +6132,8 @@ Half-Leading Control: the leading-trim property</a>
     <li><a href="#ref-for-text-over-baseline④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-under-baseline">
-   <b><a href="#text-under-baseline">#text-under-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-under-baseline" class="dfn-panel" data-for="text-under-baseline" id="infopanel-for-text-under-baseline" role="dialog">
+   <span id="infopaneltitle-for-text-under-baseline" style="display:none">Info about the 'text-under' definition.</span><b><a href="#text-under-baseline">#text-under-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-under-baseline">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
@@ -6146,8 +6146,8 @@ Half-Leading Control: the leading-trim property</a>
     <li><a href="#ref-for-text-under-baseline④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="em-over-baseline">
-   <b><a href="#em-over-baseline">#em-over-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-em-over-baseline" class="dfn-panel" data-for="em-over-baseline" id="infopanel-for-em-over-baseline" role="dialog">
+   <span id="infopaneltitle-for-em-over-baseline" style="display:none">Info about the 'em-over' definition.</span><b><a href="#em-over-baseline">#em-over-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em-over-baseline">3.2. 
 Baselines and Metrics</a> <a href="#ref-for-em-over-baseline①">(2)</a>
@@ -6155,8 +6155,8 @@ Baselines and Metrics</a> <a href="#ref-for-em-over-baseline①">(2)</a>
     <li><a href="#ref-for-em-over-baseline⑧"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="em-under-baseline">
-   <b><a href="#em-under-baseline">#em-under-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-em-under-baseline" class="dfn-panel" data-for="em-under-baseline" id="infopanel-for-em-under-baseline" role="dialog">
+   <span id="infopaneltitle-for-em-under-baseline" style="display:none">Info about the 'em-under' definition.</span><b><a href="#em-under-baseline">#em-under-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em-under-baseline">3.2. 
 Baselines and Metrics</a> <a href="#ref-for-em-under-baseline①">(2)</a>
@@ -6164,8 +6164,8 @@ Baselines and Metrics</a> <a href="#ref-for-em-under-baseline①">(2)</a>
     <li><a href="#ref-for-em-under-baseline⑧"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascent-metric">
-   <b><a href="#ascent-metric">#ascent-metric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascent-metric" class="dfn-panel" data-for="ascent-metric" id="infopanel-for-ascent-metric" role="dialog">
+   <span id="infopaneltitle-for-ascent-metric" style="display:none">Info about the 'ascent metric' definition.</span><b><a href="#ascent-metric">#ascent-metric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascent-metric">3.2. 
 Baselines and Metrics</a>
@@ -6181,8 +6181,8 @@ Alignment of Initial Letters: the initial-letter-align property</a>
     <li><a href="#ref-for-ascent-metric⑦"> A.2: Synthesizing Baselines (and Other Font Metrics) for Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descent-metric">
-   <b><a href="#descent-metric">#descent-metric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descent-metric" class="dfn-panel" data-for="descent-metric" id="infopanel-for-descent-metric" role="dialog">
+   <span id="infopaneltitle-for-descent-metric" style="display:none">Info about the 'descent metric' definition.</span><b><a href="#descent-metric">#descent-metric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descent-metric">3.2. 
 Baselines and Metrics</a>
@@ -6198,8 +6198,8 @@ Alignment of Initial Letters: the initial-letter-align property</a>
     <li><a href="#ref-for-descent-metric⑦"> A.2: Synthesizing Baselines (and Other Font Metrics) for Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-gap-metric">
-   <b><a href="#line-gap-metric">#line-gap-metric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-gap-metric" class="dfn-panel" data-for="line-gap-metric" id="infopanel-for-line-gap-metric" role="dialog">
+   <span id="infopaneltitle-for-line-gap-metric" style="display:none">Info about the 'line gap metric' definition.</span><b><a href="#line-gap-metric">#line-gap-metric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-gap-metric">3.2.2. 
 Line Gap Metrics</a>
@@ -6207,8 +6207,8 @@ Line Gap Metrics</a>
 Logical Height Contributions of Inline Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-set">
-   <b><a href="#baseline-set">#baseline-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-set" class="dfn-panel" data-for="baseline-set" id="infopanel-for-baseline-set" role="dialog">
+   <span id="infopaneltitle-for-baseline-set" style="display:none">Info about the 'baseline set' definition.</span><b><a href="#baseline-set">#baseline-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-set">3.3. 
 Baselines of Glyphs and Boxes</a> <a href="#ref-for-baseline-set①">(2)</a> <a href="#ref-for-baseline-set②">(3)</a>
@@ -6217,8 +6217,8 @@ Baseline Alignment</a>
     <li><a href="#ref-for-baseline-set④"> A.3: Synthesizing Baselines for Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-dominant-baseline">
-   <b><a href="#propdef-dominant-baseline">#propdef-dominant-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-dominant-baseline" class="dfn-panel" data-for="propdef-dominant-baseline" id="infopanel-for-propdef-dominant-baseline" role="dialog">
+   <span id="infopaneltitle-for-propdef-dominant-baseline" style="display:none">Info about the 'dominant-baseline' definition.</span><b><a href="#propdef-dominant-baseline">#propdef-dominant-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-dominant-baseline">2.2. 
 Layout Within Line Boxes</a>
@@ -6231,8 +6231,8 @@ Dominant Baselines: the dominant-baseline property</a>
     <li><a href="#ref-for-propdef-dominant-baseline④"> Changes</a> <a href="#ref-for-propdef-dominant-baseline⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dominant-baseline">
-   <b><a href="#dominant-baseline">#dominant-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dominant-baseline" class="dfn-panel" data-for="dominant-baseline" id="infopanel-for-dominant-baseline" role="dialog">
+   <span id="infopaneltitle-for-dominant-baseline" style="display:none">Info about the 'dominant baseline' definition.</span><b><a href="#dominant-baseline">#dominant-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dominant-baseline">3.3. 
 Baselines of Glyphs and Boxes</a>
@@ -6246,28 +6246,28 @@ Alignment Baseline Type: the alignment-baseline longhand</a>
 Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-dominant-baseline⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-dominant-baseline-auto">
-   <b><a href="#valdef-dominant-baseline-auto">#valdef-dominant-baseline-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-dominant-baseline-auto" class="dfn-panel" data-for="valdef-dominant-baseline-auto" id="infopanel-for-valdef-dominant-baseline-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-dominant-baseline-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-dominant-baseline-auto">#valdef-dominant-baseline-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-dominant-baseline-auto"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-dominant-baseline-alphabetic">
-   <b><a href="#valdef-dominant-baseline-alphabetic">#valdef-dominant-baseline-alphabetic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-dominant-baseline-alphabetic" class="dfn-panel" data-for="valdef-dominant-baseline-alphabetic" id="infopanel-for-valdef-dominant-baseline-alphabetic" role="dialog">
+   <span id="infopaneltitle-for-valdef-dominant-baseline-alphabetic" style="display:none">Info about the 'alphabetic' definition.</span><b><a href="#valdef-dominant-baseline-alphabetic">#valdef-dominant-baseline-alphabetic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-dominant-baseline-alphabetic">4.1. 
 Dominant Baselines: the dominant-baseline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-dominant-baseline-central">
-   <b><a href="#valdef-dominant-baseline-central">#valdef-dominant-baseline-central</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-dominant-baseline-central" class="dfn-panel" data-for="valdef-dominant-baseline-central" id="infopanel-for-valdef-dominant-baseline-central" role="dialog">
+   <span id="infopaneltitle-for-valdef-dominant-baseline-central" style="display:none">Info about the 'central' definition.</span><b><a href="#valdef-dominant-baseline-central">#valdef-dominant-baseline-central</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-dominant-baseline-central">4.1. 
 Dominant Baselines: the dominant-baseline property</a> <a href="#ref-for-valdef-dominant-baseline-central①">(2)</a> <a href="#ref-for-valdef-dominant-baseline-central②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-vertical-align">
-   <b><a href="#propdef-vertical-align">#propdef-vertical-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-vertical-align" class="dfn-panel" data-for="propdef-vertical-align" id="infopanel-for-propdef-vertical-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' definition.</span><b><a href="#propdef-vertical-align">#propdef-vertical-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">2.1. 
 Layout of Line Boxes</a>
@@ -6290,8 +6290,8 @@ Properties Applying to Initial Letters</a> <a href="#ref-for-propdef-vertical-al
     <li><a href="#ref-for-propdef-vertical-align①④"> Changes</a> <a href="#ref-for-propdef-vertical-align①⑤">(2)</a> <a href="#ref-for-propdef-vertical-align①⑥">(3)</a> <a href="#ref-for-propdef-vertical-align①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-baseline-source">
-   <b><a href="#propdef-baseline-source">#propdef-baseline-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-baseline-source" class="dfn-panel" data-for="propdef-baseline-source" id="infopanel-for-propdef-baseline-source" role="dialog">
+   <span id="infopaneltitle-for-propdef-baseline-source" style="display:none">Info about the 'baseline-source' definition.</span><b><a href="#propdef-baseline-source">#propdef-baseline-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-baseline-source">3.3. 
 Baselines of Glyphs and Boxes</a>
@@ -6304,36 +6304,36 @@ Alignment Baseline Source: the baseline-source longhand</a>
     <li><a href="#ref-for-propdef-baseline-source⑤"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="baseline-alignment-preference">
-   <b><a href="#baseline-alignment-preference">#baseline-alignment-preference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-baseline-alignment-preference" class="dfn-panel" data-for="baseline-alignment-preference" id="infopanel-for-baseline-alignment-preference" role="dialog">
+   <span id="infopaneltitle-for-baseline-alignment-preference" style="display:none">Info about the 'baseline alignment preference' definition.</span><b><a href="#baseline-alignment-preference">#baseline-alignment-preference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-baseline-alignment-preference">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-source-auto">
-   <b><a href="#valdef-baseline-source-auto">#valdef-baseline-source-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-source-auto" class="dfn-panel" data-for="valdef-baseline-source-auto" id="infopanel-for-valdef-baseline-source-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-source-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-baseline-source-auto">#valdef-baseline-source-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-source-auto">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-source-first">
-   <b><a href="#valdef-baseline-source-first">#valdef-baseline-source-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-source-first" class="dfn-panel" data-for="valdef-baseline-source-first" id="infopanel-for-valdef-baseline-source-first" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-source-first" style="display:none">Info about the 'first' definition.</span><b><a href="#valdef-baseline-source-first">#valdef-baseline-source-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-source-first">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-source-last">
-   <b><a href="#valdef-baseline-source-last">#valdef-baseline-source-last</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-source-last" class="dfn-panel" data-for="valdef-baseline-source-last" id="infopanel-for-valdef-baseline-source-last" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-source-last" style="display:none">Info about the 'last' definition.</span><b><a href="#valdef-baseline-source-last">#valdef-baseline-source-last</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-source-last">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-alignment-baseline">
-   <b><a href="#propdef-alignment-baseline">#propdef-alignment-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-alignment-baseline" class="dfn-panel" data-for="propdef-alignment-baseline" id="infopanel-for-propdef-alignment-baseline" role="dialog">
+   <span id="infopaneltitle-for-propdef-alignment-baseline" style="display:none">Info about the 'alignment-baseline' definition.</span><b><a href="#propdef-alignment-baseline">#propdef-alignment-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-alignment-baseline">3.2. 
 Baselines and Metrics</a>
@@ -6350,8 +6350,8 @@ Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-propdef-
     <li><a href="#ref-for-propdef-alignment-baseline⑨"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alignment-baseline">
-   <b><a href="#alignment-baseline">#alignment-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alignment-baseline" class="dfn-panel" data-for="alignment-baseline" id="infopanel-for-alignment-baseline" role="dialog">
+   <span id="infopaneltitle-for-alignment-baseline" style="display:none">Info about the 'alignment baseline' definition.</span><b><a href="#alignment-baseline">#alignment-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-baseline">3.3. 
 Baselines of Glyphs and Boxes</a> <a href="#ref-for-alignment-baseline①">(2)</a>
@@ -6363,32 +6363,32 @@ Dominant Baselines: the dominant-baseline property</a>
 Transverse Box Alignment: the vertical-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-alignment-baseline-text-bottom">
-   <b><a href="#valdef-alignment-baseline-text-bottom">#valdef-alignment-baseline-text-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-alignment-baseline-text-bottom" class="dfn-panel" data-for="valdef-alignment-baseline-text-bottom" id="infopanel-for-valdef-alignment-baseline-text-bottom" role="dialog">
+   <span id="infopaneltitle-for-valdef-alignment-baseline-text-bottom" style="display:none">Info about the 'text-bottom' definition.</span><b><a href="#valdef-alignment-baseline-text-bottom">#valdef-alignment-baseline-text-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-text-bottom">4.2.2.1. 
 Legacy Values for SVG</a>
     <li><a href="#ref-for-valdef-alignment-baseline-text-bottom①"> Changes</a> <a href="#ref-for-valdef-alignment-baseline-text-bottom②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-alignment-baseline-middle">
-   <b><a href="#valdef-alignment-baseline-middle">#valdef-alignment-baseline-middle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-alignment-baseline-middle" class="dfn-panel" data-for="valdef-alignment-baseline-middle" id="infopanel-for-valdef-alignment-baseline-middle" role="dialog">
+   <span id="infopaneltitle-for-valdef-alignment-baseline-middle" style="display:none">Info about the 'middle' definition.</span><b><a href="#valdef-alignment-baseline-middle">#valdef-alignment-baseline-middle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-middle">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
     <li><a href="#ref-for-valdef-alignment-baseline-middle①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-alignment-baseline-text-top">
-   <b><a href="#valdef-alignment-baseline-text-top">#valdef-alignment-baseline-text-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-alignment-baseline-text-top" class="dfn-panel" data-for="valdef-alignment-baseline-text-top" id="infopanel-for-valdef-alignment-baseline-text-top" role="dialog">
+   <span id="infopaneltitle-for-valdef-alignment-baseline-text-top" style="display:none">Info about the 'text-top' definition.</span><b><a href="#valdef-alignment-baseline-text-top">#valdef-alignment-baseline-text-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-text-top">4.2.2.1. 
 Legacy Values for SVG</a>
     <li><a href="#ref-for-valdef-alignment-baseline-text-top①"> Changes</a> <a href="#ref-for-valdef-alignment-baseline-text-top②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-baseline-shift">
-   <b><a href="#propdef-baseline-shift">#propdef-baseline-shift</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-baseline-shift" class="dfn-panel" data-for="propdef-baseline-shift" id="infopanel-for-propdef-baseline-shift" role="dialog">
+   <span id="infopaneltitle-for-propdef-baseline-shift" style="display:none">Info about the 'baseline-shift' definition.</span><b><a href="#propdef-baseline-shift">#propdef-baseline-shift</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-baseline-shift">2.2. 
 Layout Within Line Boxes</a>
@@ -6399,8 +6399,8 @@ Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-propdef-
     <li><a href="#ref-for-propdef-baseline-shift⑨"> Changes</a> <a href="#ref-for-propdef-baseline-shift①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="post-alignment-shift">
-   <b><a href="#post-alignment-shift">#post-alignment-shift</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-post-alignment-shift" class="dfn-panel" data-for="post-alignment-shift" id="infopanel-for-post-alignment-shift" role="dialog">
+   <span id="infopaneltitle-for-post-alignment-shift" style="display:none">Info about the 'post-alignment shift' definition.</span><b><a href="#post-alignment-shift">#post-alignment-shift</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-post-alignment-shift">4. 
 Baseline Alignment</a>
@@ -6410,8 +6410,8 @@ Transverse Box Alignment: the vertical-align property</a>
 Alignment Baseline Type: the alignment-baseline longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-relative-shift-values">
-   <b><a href="#line-relative-shift-values">#line-relative-shift-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-relative-shift-values" class="dfn-panel" data-for="line-relative-shift-values" id="infopanel-for-line-relative-shift-values" role="dialog">
+   <span id="infopaneltitle-for-line-relative-shift-values" style="display:none">Info about the 'line-relative shift values' definition.</span><b><a href="#line-relative-shift-values">#line-relative-shift-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-relative-shift-values">2.2. 
 Layout Within Line Boxes</a>
@@ -6422,22 +6422,22 @@ Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-line-rel
     <li><a href="#ref-for-line-relative-shift-values④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-sub">
-   <b><a href="#valdef-baseline-shift-sub">#valdef-baseline-shift-sub</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-sub" class="dfn-panel" data-for="valdef-baseline-shift-sub" id="infopanel-for-valdef-baseline-shift-sub" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-sub" style="display:none">Info about the 'sub' definition.</span><b><a href="#valdef-baseline-shift-sub">#valdef-baseline-shift-sub</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-sub">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-super">
-   <b><a href="#valdef-baseline-shift-super">#valdef-baseline-shift-super</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-super" class="dfn-panel" data-for="valdef-baseline-shift-super" id="infopanel-for-valdef-baseline-shift-super" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-super" style="display:none">Info about the 'super' definition.</span><b><a href="#valdef-baseline-shift-super">#valdef-baseline-shift-super</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-super">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-top">
-   <b><a href="#valdef-baseline-shift-top">#valdef-baseline-shift-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-top" class="dfn-panel" data-for="valdef-baseline-shift-top" id="infopanel-for-valdef-baseline-shift-top" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-top" style="display:none">Info about the 'top' definition.</span><b><a href="#valdef-baseline-shift-top">#valdef-baseline-shift-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-top">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
@@ -6445,15 +6445,15 @@ Transverse Box Alignment: the vertical-align property</a>
 Post-Alignment Shift: the baseline-shift longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-center">
-   <b><a href="#valdef-baseline-shift-center">#valdef-baseline-shift-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-center" class="dfn-panel" data-for="valdef-baseline-shift-center" id="infopanel-for-valdef-baseline-shift-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-baseline-shift-center">#valdef-baseline-shift-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-center">4.2.3. 
 Post-Alignment Shift: the baseline-shift longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-bottom">
-   <b><a href="#valdef-baseline-shift-bottom">#valdef-baseline-shift-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-bottom" class="dfn-panel" data-for="valdef-baseline-shift-bottom" id="infopanel-for-valdef-baseline-shift-bottom" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-bottom" style="display:none">Info about the 'bottom' definition.</span><b><a href="#valdef-baseline-shift-bottom">#valdef-baseline-shift-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-bottom">4.2. 
 Transverse Box Alignment: the vertical-align property</a>
@@ -6461,8 +6461,8 @@ Transverse Box Alignment: the vertical-align property</a>
 Post-Alignment Shift: the baseline-shift longhand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="aligned-subtree">
-   <b><a href="#aligned-subtree">#aligned-subtree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aligned-subtree" class="dfn-panel" data-for="aligned-subtree" id="infopanel-for-aligned-subtree" role="dialog">
+   <span id="infopaneltitle-for-aligned-subtree" style="display:none">Info about the 'aligned subtree' definition.</span><b><a href="#aligned-subtree">#aligned-subtree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aligned-subtree">2.2. 
 Layout Within Line Boxes</a>
@@ -6470,15 +6470,15 @@ Layout Within Line Boxes</a>
 Post-Alignment Shift: the baseline-shift longhand</a> <a href="#ref-for-aligned-subtree②">(2)</a> <a href="#ref-for-aligned-subtree③">(3)</a> <a href="#ref-for-aligned-subtree④">(4)</a> <a href="#ref-for-aligned-subtree⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-baseline-shift-baseline">
-   <b><a href="#valdef-baseline-shift-baseline">#valdef-baseline-shift-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-baseline-shift-baseline" class="dfn-panel" data-for="valdef-baseline-shift-baseline" id="infopanel-for-valdef-baseline-shift-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-baseline-shift-baseline" style="display:none">Info about the 'baseline' definition.</span><b><a href="#valdef-baseline-shift-baseline">#valdef-baseline-shift-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-baseline">4.2.3.1. 
 Legacy Values for SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-height">
-   <b><a href="#propdef-line-height">#propdef-line-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-height" class="dfn-panel" data-for="propdef-line-height" id="infopanel-for-propdef-line-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-height" style="display:none">Info about the 'line-height' definition.</span><b><a href="#propdef-line-height">#propdef-line-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">2.1. 
 Layout of Line Boxes</a>
@@ -6505,15 +6505,15 @@ Block-axis Positioning</a>
     <li><a href="#ref-for-propdef-line-height②②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-line-height">
-   <b><a href="#preferred-line-height">#preferred-line-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-line-height" class="dfn-panel" data-for="preferred-line-height" id="infopanel-for-preferred-line-height" role="dialog">
+   <span id="infopaneltitle-for-preferred-line-height" style="display:none">Info about the 'preferred line height' definition.</span><b><a href="#preferred-line-height">#preferred-line-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-line-height">5.1. 
 Line Spacing: the line-height property</a> <a href="#ref-for-preferred-line-height①">(2)</a> <a href="#ref-for-preferred-line-height②">(3)</a> <a href="#ref-for-preferred-line-height③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-height-normal">
-   <b><a href="#valdef-line-height-normal">#valdef-line-height-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-height-normal" class="dfn-panel" data-for="valdef-line-height-normal" id="infopanel-for-valdef-line-height-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-height-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-line-height-normal">#valdef-line-height-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-height-normal">3.2.2. 
 Line Gap Metrics</a>
@@ -6525,8 +6525,8 @@ Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-valdef-line-h
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-edge">
-   <b><a href="#propdef-text-edge">#propdef-text-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-edge" class="dfn-panel" data-for="propdef-text-edge" id="infopanel-for-propdef-text-edge" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-edge" style="display:none">Info about the 'text-edge' definition.</span><b><a href="#propdef-text-edge">#propdef-text-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-edge">2.1. 
 Layout of Line Boxes</a>
@@ -6545,8 +6545,8 @@ Properties Applying to Initial Letters</a>
     <li><a href="#ref-for-propdef-text-edge②③"> Changes</a> <a href="#ref-for-propdef-text-edge②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-edge-leading">
-   <b><a href="#valdef-text-edge-leading">#valdef-text-edge-leading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-edge-leading" class="dfn-panel" data-for="valdef-text-edge-leading" id="infopanel-for-valdef-text-edge-leading" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-edge-leading" style="display:none">Info about the 'leading' definition.</span><b><a href="#valdef-text-edge-leading">#valdef-text-edge-leading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-edge-leading">5.2. 
 Inline Box Edge Metrics: the text-edge property</a> <a href="#ref-for-valdef-text-edge-leading①">(2)</a> <a href="#ref-for-valdef-text-edge-leading②">(3)</a> <a href="#ref-for-valdef-text-edge-leading③">(4)</a>
@@ -6556,8 +6556,8 @@ Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-valdef-text-e
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-valdef-text-edge-leading⑧">(2)</a> <a href="#ref-for-valdef-text-edge-leading⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-edge-text">
-   <b><a href="#valdef-text-edge-text">#valdef-text-edge-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-edge-text" class="dfn-panel" data-for="valdef-text-edge-text" id="infopanel-for-valdef-text-edge-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-edge-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-text-edge-text">#valdef-text-edge-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-edge-text">5.2. 
 Inline Box Edge Metrics: the text-edge property</a> <a href="#ref-for-valdef-text-edge-text①">(2)</a>
@@ -6565,22 +6565,22 @@ Inline Box Edge Metrics: the text-edge property</a> <a href="#ref-for-valdef-tex
 Half-Leading Control: the leading-trim property</a> <a href="#ref-for-valdef-text-edge-text③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-edge-cap">
-   <b><a href="#valdef-text-edge-cap">#valdef-text-edge-cap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-edge-cap" class="dfn-panel" data-for="valdef-text-edge-cap" id="infopanel-for-valdef-text-edge-cap" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-edge-cap" style="display:none">Info about the 'cap' definition.</span><b><a href="#valdef-text-edge-cap">#valdef-text-edge-cap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-edge-cap">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-edge-ex">
-   <b><a href="#valdef-text-edge-ex">#valdef-text-edge-ex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-edge-ex" class="dfn-panel" data-for="valdef-text-edge-ex" id="infopanel-for-valdef-text-edge-ex" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-edge-ex" style="display:none">Info about the 'ex' definition.</span><b><a href="#valdef-text-edge-ex">#valdef-text-edge-ex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-edge-ex">5.2. 
 Inline Box Edge Metrics: the text-edge property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-bounds">
-   <b><a href="#layout-bounds">#layout-bounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-bounds" class="dfn-panel" data-for="layout-bounds" id="infopanel-for-layout-bounds" role="dialog">
+   <span id="infopaneltitle-for-layout-bounds" style="display:none">Info about the 'layout bounds' definition.</span><b><a href="#layout-bounds">#layout-bounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-bounds">2.2. 
 Layout Within Line Boxes</a> <a href="#ref-for-layout-bounds①">(2)</a>
@@ -6594,15 +6594,15 @@ Inline Box Edge Metrics: the text-edge property</a>
 Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-layout-bounds⑦">(2)</a> <a href="#ref-for-layout-bounds⑧">(3)</a> <a href="#ref-for-layout-bounds⑨">(4)</a> <a href="#ref-for-layout-bounds①⓪">(5)</a> <a href="#ref-for-layout-bounds①①">(6)</a> <a href="#ref-for-layout-bounds①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="leading">
-   <b><a href="#leading">#leading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-leading" class="dfn-panel" data-for="leading" id="infopanel-for-leading" role="dialog">
+   <span id="infopaneltitle-for-leading" style="display:none">Info about the 'leading' definition.</span><b><a href="#leading">#leading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-leading">5.3. 
 Logical Height Contributions of Inline Boxes</a> <a href="#ref-for-leading①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="half-leading">
-   <b><a href="#half-leading">#half-leading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-half-leading" class="dfn-panel" data-for="half-leading" id="infopanel-for-half-leading" role="dialog">
+   <span id="infopaneltitle-for-half-leading" style="display:none">Info about the 'half-leading' definition.</span><b><a href="#half-leading">#half-leading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-half-leading">5.2. 
 Inline Box Edge Metrics: the text-edge property</a> <a href="#ref-for-half-leading①">(2)</a>
@@ -6614,8 +6614,8 @@ Half-Leading Control: the leading-trim property</a>
 Alignment of Initial Letters: the initial-letter-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-leading-trim">
-   <b><a href="#propdef-leading-trim">#propdef-leading-trim</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-leading-trim" class="dfn-panel" data-for="propdef-leading-trim" id="infopanel-for-propdef-leading-trim" role="dialog">
+   <span id="infopaneltitle-for-propdef-leading-trim" style="display:none">Info about the 'leading-trim' definition.</span><b><a href="#propdef-leading-trim">#propdef-leading-trim</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-leading-trim">2.1. 
 Layout of Line Boxes</a>
@@ -6626,22 +6626,22 @@ Half-Leading Control: the leading-trim property</a> <a href="#ref-for-propdef-le
     <li><a href="#ref-for-propdef-leading-trim⑥"> Changes</a> <a href="#ref-for-propdef-leading-trim⑦">(2)</a> <a href="#ref-for-propdef-leading-trim⑧">(3)</a> <a href="#ref-for-propdef-leading-trim⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-leading-trim-start">
-   <b><a href="#valdef-leading-trim-start">#valdef-leading-trim-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-leading-trim-start" class="dfn-panel" data-for="valdef-leading-trim-start" id="infopanel-for-valdef-leading-trim-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-leading-trim-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-leading-trim-start">#valdef-leading-trim-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-leading-trim-start">5.4. 
 Half-Leading Control: the leading-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-leading-trim-end">
-   <b><a href="#valdef-leading-trim-end">#valdef-leading-trim-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-leading-trim-end" class="dfn-panel" data-for="valdef-leading-trim-end" id="infopanel-for-valdef-leading-trim-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-leading-trim-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-leading-trim-end">#valdef-leading-trim-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-leading-trim-end">5.4. 
 Half-Leading Control: the leading-trim property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inline-sizing">
-   <b><a href="#propdef-inline-sizing">#propdef-inline-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inline-sizing" class="dfn-panel" data-for="propdef-inline-sizing" id="infopanel-for-propdef-inline-sizing" role="dialog">
+   <span id="infopaneltitle-for-propdef-inline-sizing" style="display:none">Info about the 'inline-sizing' definition.</span><b><a href="#propdef-inline-sizing">#propdef-inline-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-sizing">5.3. 
 Logical Height Contributions of Inline Boxes</a>
@@ -6651,15 +6651,15 @@ Inline Box Heights: the inline-sizing property</a>
 Properties Applying to Initial Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-inline-sizing-normal">
-   <b><a href="#valdef-inline-sizing-normal">#valdef-inline-sizing-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-inline-sizing-normal" class="dfn-panel" data-for="valdef-inline-sizing-normal" id="infopanel-for-valdef-inline-sizing-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-inline-sizing-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-inline-sizing-normal">#valdef-inline-sizing-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-inline-sizing-normal">6.1. 
 Inline Box Heights: the inline-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dropped-initial">
-   <b><a href="#dropped-initial">#dropped-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dropped-initial" class="dfn-panel" data-for="dropped-initial" id="infopanel-for-dropped-initial" role="dialog">
+   <span id="infopaneltitle-for-dropped-initial" style="display:none">Info about the 'dropped initial' definition.</span><b><a href="#dropped-initial">#dropped-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dropped-initial">7.1.1. 
 Drop Initial</a>
@@ -6668,8 +6668,8 @@ Creating Initial Letters: the initial-letter property</a>
     <li><a href="#ref-for-dropped-initial②"> Changes</a> <a href="#ref-for-dropped-initial③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sunken-initial">
-   <b><a href="#sunken-initial">#sunken-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sunken-initial" class="dfn-panel" data-for="sunken-initial" id="infopanel-for-sunken-initial" role="dialog">
+   <span id="infopaneltitle-for-sunken-initial" style="display:none">Info about the 'sunken initial' definition.</span><b><a href="#sunken-initial">#sunken-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sunken-initial">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-sunken-initial①">(2)</a>
@@ -6677,16 +6677,16 @@ Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-sunk
 Inline Flow Layout: Alignment, Justification, and White Space</a> <a href="#ref-for-sunken-initial③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="raised-initial">
-   <b><a href="#raised-initial">#raised-initial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-raised-initial" class="dfn-panel" data-for="raised-initial" id="infopanel-for-raised-initial" role="dialog">
+   <span id="infopaneltitle-for-raised-initial" style="display:none">Info about the 'raised initial' definition.</span><b><a href="#raised-initial">#raised-initial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-raised-initial">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-raised-initial①">(2)</a>
     <li><a href="#ref-for-raised-initial②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-initial-letter">
-   <b><a href="#propdef-initial-letter">#propdef-initial-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-initial-letter" class="dfn-panel" data-for="propdef-initial-letter" id="infopanel-for-propdef-initial-letter" role="dialog">
+   <span id="infopaneltitle-for-propdef-initial-letter" style="display:none">Info about the 'initial-letter' definition.</span><b><a href="#propdef-initial-letter">#propdef-initial-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter">7.2. 
 Selecting Initial Letters</a>
@@ -6707,8 +6707,8 @@ Edge Effects: Indentation and Hanging Punctuation</a>
     <li><a href="#ref-for-propdef-initial-letter②⑥"> Changes</a> <a href="#ref-for-propdef-initial-letter②⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-normal">
-   <b><a href="#valdef-initial-letter-normal">#valdef-initial-letter-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-normal" class="dfn-panel" data-for="valdef-initial-letter-normal" id="infopanel-for-valdef-initial-letter-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-initial-letter-normal">#valdef-initial-letter-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-normal">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-valdef-initial-letter-normal①">(2)</a>
@@ -6718,8 +6718,8 @@ Applicability</a> <a href="#ref-for-valdef-initial-letter-normal③">(2)</a>
 Shaping and Glyph Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-letter-initial-letter-size">
-   <b><a href="#initial-letter-initial-letter-size">#initial-letter-initial-letter-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-letter-initial-letter-size" class="dfn-panel" data-for="initial-letter-initial-letter-size" id="infopanel-for-initial-letter-initial-letter-size" role="dialog">
+   <span id="infopaneltitle-for-initial-letter-initial-letter-size" style="display:none">Info about the 'size' definition.</span><b><a href="#initial-letter-initial-letter-size">#initial-letter-initial-letter-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-letter-initial-letter-size">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-initial-letter-initial-letter-size①">(2)</a>
@@ -6729,8 +6729,8 @@ Font Sizing of Initial Letters</a>
 Block-axis Positioning</a> <a href="#ref-for-initial-letter-initial-letter-size④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-letter-initial-letter-sink">
-   <b><a href="#initial-letter-initial-letter-sink">#initial-letter-initial-letter-sink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-letter-initial-letter-sink" class="dfn-panel" data-for="initial-letter-initial-letter-sink" id="infopanel-for-initial-letter-initial-letter-sink" role="dialog">
+   <span id="infopaneltitle-for-initial-letter-initial-letter-sink" style="display:none">Info about the 'sink' definition.</span><b><a href="#initial-letter-initial-letter-sink">#initial-letter-initial-letter-sink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-letter-initial-letter-sink">7.3. 
 Creating Initial Letters: the initial-letter property</a> <a href="#ref-for-initial-letter-initial-letter-sink①">(2)</a> <a href="#ref-for-initial-letter-initial-letter-sink②">(3)</a> <a href="#ref-for-initial-letter-initial-letter-sink③">(4)</a>
@@ -6740,21 +6740,21 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-initial-letter-initial-lette
 Block-axis Positioning</a> <a href="#ref-for-initial-letter-initial-letter-sink⑦">(2)</a> <a href="#ref-for-initial-letter-initial-letter-sink⑧">(3)</a> <a href="#ref-for-initial-letter-initial-letter-sink⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-raise">
-   <b><a href="#valdef-initial-letter-raise">#valdef-initial-letter-raise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-raise" class="dfn-panel" data-for="valdef-initial-letter-raise" id="infopanel-for-valdef-initial-letter-raise" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-raise" style="display:none">Info about the 'raise' definition.</span><b><a href="#valdef-initial-letter-raise">#valdef-initial-letter-raise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-raise"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-drop">
-   <b><a href="#valdef-initial-letter-drop">#valdef-initial-letter-drop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-drop" class="dfn-panel" data-for="valdef-initial-letter-drop" id="infopanel-for-valdef-initial-letter-drop" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-drop" style="display:none">Info about the 'drop' definition.</span><b><a href="#valdef-initial-letter-drop">#valdef-initial-letter-drop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-drop">7.3. 
 Creating Initial Letters: the initial-letter property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-letter">
-   <b><a href="#initial-letter">#initial-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-letter" class="dfn-panel" data-for="initial-letter" id="infopanel-for-initial-letter" role="dialog">
+   <span id="infopaneltitle-for-initial-letter" style="display:none">Info about the 'initial letter box' definition.</span><b><a href="#initial-letter">#initial-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-letter">2.1. 
 Layout of Line Boxes</a>
@@ -6801,8 +6801,8 @@ Interaction with Fragmentation (Pagination)</a> <a href="#ref-for-initial-letter
     <li><a href="#ref-for-initial-letter⑦④"> Changes</a> <a href="#ref-for-initial-letter⑦⑤">(2)</a> <a href="#ref-for-initial-letter⑦⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-initial-letter-align">
-   <b><a href="#propdef-initial-letter-align">#propdef-initial-letter-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-initial-letter-align" class="dfn-panel" data-for="propdef-initial-letter-align" id="infopanel-for-propdef-initial-letter-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-initial-letter-align" style="display:none">Info about the 'initial-letter-align' definition.</span><b><a href="#propdef-initial-letter-align">#propdef-initial-letter-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter-align">3.2. 
 Baselines and Metrics</a>
@@ -6819,14 +6819,14 @@ Block-axis Positioning</a>
     <li><a href="#ref-for-propdef-initial-letter-align⑦"> Changes</a> <a href="#ref-for-propdef-initial-letter-align⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-align-leading">
-   <b><a href="#valdef-initial-letter-align-leading">#valdef-initial-letter-align-leading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-align-leading" class="dfn-panel" data-for="valdef-initial-letter-align-leading" id="infopanel-for-valdef-initial-letter-align-leading" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-align-leading" style="display:none">Info about the 'leading' definition.</span><b><a href="#valdef-initial-letter-align-leading">#valdef-initial-letter-align-leading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-align-leading"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-align-border-box">
-   <b><a href="#valdef-initial-letter-align-border-box">#valdef-initial-letter-align-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-align-border-box" class="dfn-panel" data-for="valdef-initial-letter-align-border-box" id="infopanel-for-valdef-initial-letter-align-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-align-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-initial-letter-align-border-box">#valdef-initial-letter-align-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-align-border-box">7.4. 
 Alignment of Initial Letters: the initial-letter-align property</a> <a href="#ref-for-valdef-initial-letter-align-border-box①">(2)</a>
@@ -6836,8 +6836,8 @@ Margins, Borders, and Padding</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-initial-letter">
-   <b><a href="#inline-initial-letter">#inline-initial-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-initial-letter" class="dfn-panel" data-for="inline-initial-letter" id="infopanel-for-inline-initial-letter" role="dialog">
+   <span id="infopaneltitle-for-inline-initial-letter" style="display:none">Info about the 'inline initial letter' definition.</span><b><a href="#inline-initial-letter">#inline-initial-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-initial-letter">7.5.1. 
 Properties Applying to Initial Letters</a>
@@ -6851,8 +6851,8 @@ Sizing the Initial Letter Box</a> <a href="#ref-for-inline-initial-letter⑤">(2
 Alignment Within an Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="atomic-initial-letter">
-   <b><a href="#atomic-initial-letter">#atomic-initial-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-atomic-initial-letter" class="dfn-panel" data-for="atomic-initial-letter" id="infopanel-for-atomic-initial-letter" role="dialog">
+   <span id="infopaneltitle-for-atomic-initial-letter" style="display:none">Info about the 'atomic initial letter' definition.</span><b><a href="#atomic-initial-letter">#atomic-initial-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-initial-letter">7.5.3. 
 Font Sizing of Initial Letters</a>
@@ -6860,8 +6860,8 @@ Font Sizing of Initial Letters</a>
 Sizing the Initial Letter Box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-initial-letter-wrap">
-   <b><a href="#propdef-initial-letter-wrap">#propdef-initial-letter-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-initial-letter-wrap" class="dfn-panel" data-for="propdef-initial-letter-wrap" id="infopanel-for-propdef-initial-letter-wrap" role="dialog">
+   <span id="infopaneltitle-for-propdef-initial-letter-wrap" style="display:none">Info about the 'initial-letter-wrap' definition.</span><b><a href="#propdef-initial-letter-wrap">#propdef-initial-letter-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter-wrap①">7.5.2. 
 Margins, Borders, and Padding</a>
@@ -6870,29 +6870,29 @@ Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-
     <li><a href="#ref-for-propdef-initial-letter-wrap④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-wrap-none">
-   <b><a href="#valdef-initial-letter-wrap-none">#valdef-initial-letter-wrap-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-wrap-none" class="dfn-panel" data-for="valdef-initial-letter-wrap-none" id="infopanel-for-valdef-initial-letter-wrap-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-wrap-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-initial-letter-wrap-none">#valdef-initial-letter-wrap-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-wrap-none">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-valdef-initial-letter-wrap-none①">(2)</a> <a href="#ref-for-valdef-initial-letter-wrap-none②">(3)</a> <a href="#ref-for-valdef-initial-letter-wrap-none③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-wrap-first">
-   <b><a href="#valdef-initial-letter-wrap-first">#valdef-initial-letter-wrap-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-wrap-first" class="dfn-panel" data-for="valdef-initial-letter-wrap-first" id="infopanel-for-valdef-initial-letter-wrap-first" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-wrap-first" style="display:none">Info about the 'first' definition.</span><b><a href="#valdef-initial-letter-wrap-first">#valdef-initial-letter-wrap-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-wrap-first">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a> <a href="#ref-for-valdef-initial-letter-wrap-first①">(2)</a> <a href="#ref-for-valdef-initial-letter-wrap-first②">(3)</a> <a href="#ref-for-valdef-initial-letter-wrap-first③">(4)</a> <a href="#ref-for-valdef-initial-letter-wrap-first④">(5)</a> <a href="#ref-for-valdef-initial-letter-wrap-first⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-initial-letter-wrap-all">
-   <b><a href="#valdef-initial-letter-wrap-all">#valdef-initial-letter-wrap-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-initial-letter-wrap-all" class="dfn-panel" data-for="valdef-initial-letter-wrap-all" id="infopanel-for-valdef-initial-letter-wrap-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-initial-letter-wrap-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-initial-letter-wrap-all">#valdef-initial-letter-wrap-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-initial-letter-wrap-all">7.7. 
 Initial Letter Wrapping: the initial-letter-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="originating-line">
-   <b><a href="#originating-line">#originating-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-originating-line" class="dfn-panel" data-for="originating-line" id="infopanel-for-originating-line" role="dialog">
+   <span id="infopaneltitle-for-originating-line" style="display:none">Info about the 'originating line box' definition.</span><b><a href="#originating-line">#originating-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-line">7.6.1. 
 Block-axis Positioning</a> <a href="#ref-for-originating-line①">(2)</a>
@@ -6906,59 +6906,115 @@ Interaction with floats</a> <a href="#ref-for-originating-line⑥">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-line-grid-1/Overview.html
@@ -1445,50 +1445,50 @@ and <a class="production" data-link-type="type" href="https://drafts.csswg.org/c
      <li><a href="#valdef-line-snap-none">value for line-snap</a><span>, in § 3.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-content-position">
-   <a href="https://drafts.csswg.org/css-align-3/#typedef-content-position">https://drafts.csswg.org/css-align-3/#typedef-content-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-content-position" class="dfn-panel" data-for="term-for-typedef-content-position" id="infopanel-for-term-for-typedef-content-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-content-position" style="display:none">Info about the '&lt;content-position>' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#typedef-content-position">https://drafts.csswg.org/css-align-3/#typedef-content-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-content-position">3.2. 
 Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-typedef-content-position①">(2)</a> <a href="#ref-for-typedef-content-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.1. 
 Snapping Line Boxes: the line-snap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height-step">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step">https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height-step" class="dfn-panel" data-for="term-for-propdef-line-height-step" id="infopanel-for-term-for-propdef-line-height-step" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height-step" style="display:none">Info about the 'line-height-step' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step">https://drafts.csswg.org/css-rhythm-1/#propdef-line-height-step</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height-step">2. 
 Defining a Line Grid: the line-grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-shape-box">
-   <a href="https://drafts.csswg.org/css-shapes-1/#typedef-shape-box">https://drafts.csswg.org/css-shapes-1/#typedef-shape-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-shape-box" class="dfn-panel" data-for="term-for-typedef-shape-box" id="infopanel-for-term-for-typedef-shape-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-shape-box" style="display:none">Info about the '&lt;shape-box>' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#typedef-shape-box">https://drafts.csswg.org/css-shapes-1/#typedef-shape-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-box">3.2. 
 Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-typedef-shape-box①">(2)</a> <a href="#ref-for-typedef-shape-box②">(3)</a> <a href="#ref-for-typedef-shape-box③">(4)</a> <a href="#ref-for-typedef-shape-box④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3.2. 
 Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-identifier-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.3. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Defining a Line Grid: the line-grid property</a>
@@ -1498,22 +1498,22 @@ Snapping Line Boxes: the line-snap property</a> <a href="#ref-for-comb-one②">(
 Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-comb-one④">(2)</a> <a href="#ref-for-comb-one⑤">(3)</a> <a href="#ref-for-comb-one⑥">(4)</a> <a href="#ref-for-comb-one⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">3.2. 
 Snapping Block Boxes: the box-snap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">2. 
 Defining a Line Grid: the line-grid property</a> <a href="#ref-for-writing-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">2. 
 Defining a Line Grid: the line-grid property</a>
@@ -1692,8 +1692,8 @@ and <a class="production" data-link-type="type" href="https://drafts.csswg.org/c
 	more than one font-size or line-height
 	in a single line box. <a class="issue-return" href="#issue-12524285" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="line-grid">
-   <b><a href="#line-grid">#line-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-grid" class="dfn-panel" data-for="line-grid" id="infopanel-for-line-grid" role="dialog">
+   <span id="infopaneltitle-for-line-grid" style="display:none">Info about the 'Line Grid' definition.</span><b><a href="#line-grid">#line-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-grid">2. 
 Defining a Line Grid: the line-grid property</a> <a href="#ref-for-line-grid①">(2)</a> <a href="#ref-for-line-grid②">(3)</a> <a href="#ref-for-line-grid③">(4)</a> <a href="#ref-for-line-grid④">(5)</a> <a href="#ref-for-line-grid⑤">(6)</a> <a href="#ref-for-line-grid⑥">(7)</a> <a href="#ref-for-line-grid⑦">(8)</a> <a href="#ref-for-line-grid⑧">(9)</a> <a href="#ref-for-line-grid⑨">(10)</a> <a href="#ref-for-line-grid①⓪">(11)</a> <a href="#ref-for-line-grid①①">(12)</a> <a href="#ref-for-line-grid①②">(13)</a> <a href="#ref-for-line-grid①③">(14)</a> <a href="#ref-for-line-grid①④">(15)</a> <a href="#ref-for-line-grid①⑤">(16)</a> <a href="#ref-for-line-grid①⑥">(17)</a> <a href="#ref-for-line-grid①⑦">(18)</a> <a href="#ref-for-line-grid①⑧">(19)</a> <a href="#ref-for-line-grid①⑨">(20)</a>
@@ -1707,8 +1707,8 @@ Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-line-grid②�
 Interacting with other alignments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-grid">
-   <b><a href="#propdef-line-grid">#propdef-line-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-grid" class="dfn-panel" data-for="propdef-line-grid" id="infopanel-for-propdef-line-grid" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-grid" style="display:none">Info about the 'line-grid' definition.</span><b><a href="#propdef-line-grid">#propdef-line-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-grid">2. 
 Defining a Line Grid: the line-grid property</a> <a href="#ref-for-propdef-line-grid①">(2)</a> <a href="#ref-for-propdef-line-grid②">(3)</a>
@@ -1716,23 +1716,23 @@ Defining a Line Grid: the line-grid property</a> <a href="#ref-for-propdef-line-
 Snapping Line Boxes: the line-snap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-grid-match-parent">
-   <b><a href="#valdef-line-grid-match-parent">#valdef-line-grid-match-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-grid-match-parent" class="dfn-panel" data-for="valdef-line-grid-match-parent" id="infopanel-for-valdef-line-grid-match-parent" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-grid-match-parent" style="display:none">Info about the 'match-parent' definition.</span><b><a href="#valdef-line-grid-match-parent">#valdef-line-grid-match-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-grid-match-parent">2. 
 Defining a Line Grid: the line-grid property</a> <a href="#ref-for-valdef-line-grid-match-parent①">(2)</a>
     <li><a href="#ref-for-valdef-line-grid-match-parent②"> Since September 16th 2014</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-grid-create">
-   <b><a href="#valdef-line-grid-create">#valdef-line-grid-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-grid-create" class="dfn-panel" data-for="valdef-line-grid-create" id="infopanel-for-valdef-line-grid-create" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-grid-create" style="display:none">Info about the 'create' definition.</span><b><a href="#valdef-line-grid-create">#valdef-line-grid-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-grid-create">2. 
 Defining a Line Grid: the line-grid property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-snap">
-   <b><a href="#propdef-line-snap">#propdef-line-snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-snap" class="dfn-panel" data-for="propdef-line-snap" id="infopanel-for-propdef-line-snap" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-snap" style="display:none">Info about the 'line-snap' definition.</span><b><a href="#propdef-line-snap">#propdef-line-snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-snap">2. 
 Defining a Line Grid: the line-grid property</a>
@@ -1742,8 +1742,8 @@ Snapping to a Grid</a>
 Snapping Line Boxes: the line-snap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-box-snap">
-   <b><a href="#propdef-box-snap">#propdef-box-snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-snap" class="dfn-panel" data-for="propdef-box-snap" id="infopanel-for-propdef-box-snap" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-snap" style="display:none">Info about the 'box-snap' definition.</span><b><a href="#propdef-box-snap">#propdef-box-snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-snap">2. 
 Defining a Line Grid: the line-grid property</a>
@@ -1755,15 +1755,15 @@ Snapping Block Boxes: the box-snap property</a> <a href="#ref-for-propdef-box-sn
 Interacting with other alignments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-snap-block-start">
-   <b><a href="#valdef-box-snap-block-start">#valdef-box-snap-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-snap-block-start" class="dfn-panel" data-for="valdef-box-snap-block-start" id="infopanel-for-valdef-box-snap-block-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-snap-block-start" style="display:none">Info about the 'block-start' definition.</span><b><a href="#valdef-box-snap-block-start">#valdef-box-snap-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-snap-block-start">3.2. 
 Snapping Block Boxes: the box-snap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-snap-block-end">
-   <b><a href="#valdef-box-snap-block-end">#valdef-box-snap-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-snap-block-end" class="dfn-panel" data-for="valdef-box-snap-block-end" id="infopanel-for-valdef-box-snap-block-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-snap-block-end" style="display:none">Info about the 'block-end' definition.</span><b><a href="#valdef-box-snap-block-end">#valdef-box-snap-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-snap-block-end">3.2. 
 Snapping Block Boxes: the box-snap property</a>
@@ -1771,57 +1771,113 @@ Snapping Block Boxes: the box-snap property</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-lists-3/Overview.html
@@ -2700,15 +2700,15 @@ li {
    <li><a href="#valdef-list-style-type-string">&lt;string></a><span>, in § 3.4</span>
    <li><a href="#css-counter-value">value</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-author">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-author">https://drafts.csswg.org/css-cascade-5/#cascade-origin-author</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-author" class="dfn-panel" data-for="term-for-cascade-origin-author" id="infopanel-for-term-for-cascade-origin-author" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-author" style="display:none">Info about the 'author origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-author">https://drafts.csswg.org/css-cascade-5/#cascade-origin-author</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-author">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.1.1. 
 Properties Applying to ::marker</a>
@@ -2716,43 +2716,43 @@ Properties Applying to ::marker</a>
 The Implicit list-item Counter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">4.4.1. 
 Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">4.6. 
 The Implicit list-item Counter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4.7. 
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-user">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-user">https://drafts.csswg.org/css-cascade-5/#cascade-origin-user</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-user" class="dfn-panel" data-for="term-for-cascade-origin-user" id="infopanel-for-term-for-cascade-origin-user" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-user" style="display:none">Info about the 'user origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-user">https://drafts.csswg.org/css-cascade-5/#cascade-origin-user</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-user">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'user-agent origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">3.1.1. 
 Properties Applying to ::marker</a>
@@ -2760,15 +2760,15 @@ Properties Applying to ::marker</a>
 Creating Counters: the counter-reset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">3.1. 
 The ::marker Pseudo-Element</a>
@@ -2786,8 +2786,8 @@ Counters in elements that do not generate boxes</a>
 The Implicit list-item Counter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-none">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-none" class="dfn-panel" data-for="term-for-valdef-content-none" id="infopanel-for-term-for-valdef-content-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">3.1. 
 The ::marker Pseudo-Element</a>
@@ -2795,8 +2795,8 @@ The ::marker Pseudo-Element</a>
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-normal">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-normal" class="dfn-panel" data-for="term-for-valdef-content-normal" id="infopanel-for-term-for-valdef-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-normal">3.2. 
 Generating Marker Contents</a>
@@ -2806,8 +2806,8 @@ Image Markers: the list-style-image property</a>
 Text-based Markers: the list-style-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter-style" class="dfn-panel" data-for="term-for-typedef-counter-style" id="infopanel-for-term-for-typedef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter-style" style="display:none">Info about the '&lt;counter-style>' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-style">3.4. 
 Text-based Markers: the list-style-type property</a> <a href="#ref-for-typedef-counter-style①">(2)</a> <a href="#ref-for-typedef-counter-style②">(3)</a> <a href="#ref-for-typedef-counter-style③">(4)</a> <a href="#ref-for-typedef-counter-style④">(5)</a> <a href="#ref-for-typedef-counter-style⑤">(6)</a> <a href="#ref-for-typedef-counter-style⑥">(7)</a>
@@ -2818,15 +2818,15 @@ Outputting Counters: the counter() and counters() functions</a> <a href="#ref-fo
     <li><a href="#ref-for-typedef-counter-style①④">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#counter-style">https://drafts.csswg.org/css-counter-styles-3/#counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-counter-style" class="dfn-panel" data-for="term-for-counter-style" id="infopanel-for-term-for-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-counter-style" style="display:none">Info about the 'counter style' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#counter-style">https://drafts.csswg.org/css-counter-styles-3/#counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter-style">4.7. 
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-counter-style①">(2)</a> <a href="#ref-for-counter-style②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decimal">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#decimal">https://drafts.csswg.org/css-counter-styles-3/#decimal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decimal" class="dfn-panel" data-for="term-for-decimal" id="infopanel-for-term-for-decimal" role="menu">
+   <span id="infopaneltitle-for-term-for-decimal" style="display:none">Info about the 'decimal' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#decimal">https://drafts.csswg.org/css-counter-styles-3/#decimal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decimal">3.4. 
 Text-based Markers: the list-style-type property</a>
@@ -2834,8 +2834,8 @@ Text-based Markers: the list-style-type property</a>
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generate-a-counter">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter">https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generate-a-counter" class="dfn-panel" data-for="term-for-generate-a-counter" id="infopanel-for-term-for-generate-a-counter" role="menu">
+   <span id="infopaneltitle-for-term-for-generate-a-counter" style="display:none">Info about the 'generate a counter representation' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter">https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-counter">3.4. 
 Text-based Markers: the list-style-type property</a>
@@ -2843,37 +2843,37 @@ Text-based Markers: the list-style-type property</a>
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-counter-style-prefix">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-prefix">https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-prefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-counter-style-prefix" class="dfn-panel" data-for="term-for-descdef-counter-style-prefix" id="infopanel-for-term-for-descdef-counter-style-prefix" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-counter-style-prefix" style="display:none">Info about the 'prefix' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-prefix">https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-prefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-prefix">3.4. 
 Text-based Markers: the list-style-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-counter-style-suffix">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-suffix">https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-suffix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-counter-style-suffix" class="dfn-panel" data-for="term-for-descdef-counter-style-suffix" id="infopanel-for-term-for-descdef-counter-style-suffix" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-counter-style-suffix" style="display:none">Info about the 'suffix' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-suffix">https://drafts.csswg.org/css-counter-styles-3/#descdef-counter-style-suffix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-counter-style-suffix">3.4. 
 Text-based Markers: the list-style-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">3.2. 
 Generating Marker Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.5. 
 Positioning Markers: The list-style-position property</a> <a href="#ref-for-block-container①">(2)</a>
     <li><a href="#ref-for-block-container②">Changes since the 17 August 2019 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Declaring a List Item</a>
@@ -2881,8 +2881,8 @@ Declaring a List Item</a>
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">1. 
 Introduction</a>
@@ -2890,69 +2890,69 @@ Introduction</a>
 Markers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-hidden">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden">https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-hidden" class="dfn-panel" data-for="term-for-valdef-visibility-hidden" id="infopanel-for-term-for-valdef-visibility-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden">https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-hidden">4.5. 
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#inline">https://drafts.csswg.org/css-display-3/#inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline" class="dfn-panel" data-for="term-for-inline" id="infopanel-for-term-for-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline">https://drafts.csswg.org/css-display-3/#inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline">3.2. 
 Generating Marker Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-list-item">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-list-item" class="dfn-panel" data-for="term-for-valdef-display-list-item" id="infopanel-for-term-for-valdef-display-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-list-item" style="display:none">Info about the 'list-item' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-list-item">2. 
 Declaring a List Item</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">4.5. 
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-order">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-order" class="dfn-panel" data-for="term-for-propdef-order" id="infopanel-for-term-for-propdef-order" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-order" style="display:none">Info about the 'order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">4.7. 
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-propdef-order①">(2)</a> <a href="#ref-for-propdef-order②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#outer-display-type">https://drafts.csswg.org/css-display-3/#outer-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-display-type" class="dfn-panel" data-for="term-for-outer-display-type" id="infopanel-for-term-for-outer-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-display-type" style="display:none">Info about the 'outer display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#outer-display-type">https://drafts.csswg.org/css-display-3/#outer-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-display-type">Changes since the 17 August 2019 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">3.2. 
 Generating Marker Contents</a>
@@ -2960,91 +2960,91 @@ Generating Marker Contents</a>
 Counters in elements that do not generate boxes</a> <a href="#ref-for-replaced-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">3.2. 
 Generating Marker Contents</a> <a href="#ref-for-text-run①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">4.5. 
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">3.3. 
 Image Markers: the list-style-image property</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a> <a href="#ref-for-typedef-image④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3.3. 
 Image Markers: the list-style-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sizing-algorithm">
-   <a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sizing-algorithm" class="dfn-panel" data-for="term-for-default-sizing-algorithm" id="infopanel-for-term-for-default-sizing-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sizing-algorithm" style="display:none">Info about the 'default sizing algorithm' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sizing-algorithm">3.3. 
 Image Markers: the list-style-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-size">
-   <a href="https://drafts.csswg.org/css-images-3/#specified-size">https://drafts.csswg.org/css-images-3/#specified-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-size" class="dfn-panel" data-for="term-for-specified-size" id="infopanel-for-term-for-specified-size" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-size" style="display:none">Info about the 'specified size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#specified-size">https://drafts.csswg.org/css-images-3/#specified-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-size">3.3. 
 Image Markers: the list-style-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-image">
-   <a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-image" class="dfn-panel" data-for="term-for-invalid-image" id="infopanel-for-term-for-invalid-image" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-image" style="display:none">Info about the 'valid image' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#invalid-image">https://drafts.csswg.org/css-images-4/#invalid-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">3.3. 
 Image Markers: the list-style-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-counter-set-none">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-counter-set-none">https://drafts.csswg.org/css-lists-3/#valdef-counter-set-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-counter-set-none" class="dfn-panel" data-for="term-for-valdef-counter-set-none" id="infopanel-for-term-for-valdef-counter-set-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-counter-set-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-counter-set-none">https://drafts.csswg.org/css-lists-3/#valdef-counter-set-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-set-none">4.6. 
 The Implicit list-item Counter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">Changes since the 20 March 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">3.1. 
 The ::marker Pseudo-Element</a>
@@ -3054,8 +3054,8 @@ Properties Applying to ::marker</a>
 Generating Marker Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">1. 
 Introduction</a>
@@ -3078,66 +3078,66 @@ The marker-side property</a> <a href="#ref-for-selectordef-marker①⑧">(2)</a>
     <li><a href="#ref-for-selectordef-marker②⑤">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-invalid">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-invalid" class="dfn-panel" data-for="term-for-css-invalid" id="infopanel-for-term-for-css-invalid" role="menu">
+   <span id="infopaneltitle-for-term-for-css-invalid" style="display:none">Info about the 'invalid' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-invalid">https://drafts.csswg.org/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-invalid">4. 
 Automatic Numbering With Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-line-break">
-   <a href="https://drafts.csswg.org/css-text-4/#forced-line-break">https://drafts.csswg.org/css-text-4/#forced-line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-line-break" class="dfn-panel" data-for="term-for-forced-line-break" id="infopanel-for-term-for-forced-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-line-break" style="display:none">Info about the 'forced line break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#forced-line-break">https://drafts.csswg.org/css-text-4/#forced-line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-line-break">3.2. 
 Generating Marker Contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-space-collapse">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-space-collapse">https://drafts.csswg.org/css-text-4/#propdef-text-space-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-space-collapse" class="dfn-panel" data-for="term-for-propdef-text-space-collapse" id="infopanel-for-term-for-propdef-text-space-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-space-collapse" style="display:none">Info about the 'text-space-collapse' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-space-collapse">https://drafts.csswg.org/css-text-4/#propdef-text-space-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-space-collapse">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-space-trim">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-space-trim">https://drafts.csswg.org/css-text-4/#propdef-text-space-trim</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-space-trim" class="dfn-panel" data-for="term-for-propdef-text-space-trim" id="infopanel-for-term-for-propdef-text-space-trim" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-space-trim" style="display:none">Info about the 'text-space-trim' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-space-trim">https://drafts.csswg.org/css-text-4/#propdef-text-space-trim</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-space-trim">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">3.1.1. 
 Properties Applying to ::marker</a>
     <li><a href="#ref-for-propdef-text-transform①">Changes since the 9 July 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">3.1.1. 
 Properties Applying to ::marker</a>
     <li><a href="#ref-for-propdef-white-space①">Changes since the 17 August 2019 WD</a> <a href="#ref-for-propdef-white-space②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">4.1. 
 Creating Counters: the counter-reset property</a>
@@ -3145,8 +3145,8 @@ Creating Counters: the counter-reset property</a>
 Manipulating Counter Values: the counter-increment and counter-set properties</a> <a href="#ref-for-mult-one-plus②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3.6. 
 Styling Markers: the list-style shorthand property</a>
@@ -3155,8 +3155,8 @@ Automatic Numbering With Counters</a>
     <li><a href="#ref-for-identifier-value②">Changes since the 20 March 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">4.1. 
 Creating Counters: the counter-reset property</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a>
@@ -3164,8 +3164,8 @@ Creating Counters: the counter-reset property</a> <a href="#ref-for-integer-valu
 Manipulating Counter Values: the counter-increment and counter-set properties</a> <a href="#ref-for-integer-value④">(2)</a> <a href="#ref-for-integer-value⑤">(3)</a> <a href="#ref-for-integer-value⑥">(4)</a> <a href="#ref-for-integer-value⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.4. 
 Text-based Markers: the list-style-type property</a> <a href="#ref-for-string-value①">(2)</a> <a href="#ref-for-string-value②">(3)</a>
@@ -3174,8 +3174,8 @@ Outputting Counters: the counter() and counters() functions</a> <a href="#ref-fo
     <li><a href="#ref-for-string-value⑤">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.1. 
 Creating Counters: the counter-reset property</a>
@@ -3183,29 +3183,29 @@ Creating Counters: the counter-reset property</a>
 Manipulating Counter Values: the counter-increment and counter-set properties</a> <a href="#ref-for-mult-opt②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">4.7. 
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-functional-notation">
-   <a href="https://drafts.csswg.org/css-values-4/#functional-notation">https://drafts.csswg.org/css-values-4/#functional-notation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-functional-notation" class="dfn-panel" data-for="term-for-functional-notation" id="infopanel-for-term-for-functional-notation" role="menu">
+   <span id="infopaneltitle-for-term-for-functional-notation" style="display:none">Info about the 'functional notation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#functional-notation">https://drafts.csswg.org/css-values-4/#functional-notation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-notation">4. 
 Automatic Numbering With Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.3. 
 Image Markers: the list-style-image property</a>
@@ -3221,22 +3221,22 @@ Creating Counters: the counter-reset property</a>
 Manipulating Counter Values: the counter-increment and counter-set properties</a> <a href="#ref-for-comb-one⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.6. 
 Styling Markers: the list-style shorthand property</a> <a href="#ref-for-comb-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">4.7. 
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.1.1. 
 Properties Applying to ::marker</a>
@@ -3244,57 +3244,57 @@ Properties Applying to ::marker</a>
 The marker-side property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-combine-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-combine-upright" class="dfn-panel" data-for="term-for-propdef-text-combine-upright" id="infopanel-for-term-for-propdef-text-combine-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">4.4.1. 
 Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">4.4.1. 
 Inheriting Counters</a> <a href="#ref-for-concept-tree-order①">(2)</a> <a href="#ref-for-concept-tree-order②">(3)</a> <a href="#ref-for-concept-tree-order③">(4)</a> <a href="#ref-for-concept-tree-order④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-li-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-li-element" class="dfn-panel" data-for="term-for-the-li-element" id="infopanel-for-term-for-the-li-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-li-element" style="display:none">Info about the 'li' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-li-element">3.6. 
 Styling Markers: the list-style shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ol-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ol-element" class="dfn-panel" data-for="term-for-the-ol-element" id="infopanel-for-term-for-the-ol-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ol-element" style="display:none">Info about the 'ol' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ol-element">3.6. 
 Styling Markers: the list-style shorthand property</a>
@@ -3302,15 +3302,15 @@ Styling Markers: the list-style shorthand property</a>
 Nested Counters and Scope</a> <a href="#ref-for-the-ol-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-option-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-option-element" class="dfn-panel" data-for="term-for-the-option-element" id="infopanel-for-term-for-the-option-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-option-element" style="display:none">Info about the 'option' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-option-element">4.5. 
 Counters in elements that do not generate boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ul-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ul-element" class="dfn-panel" data-for="term-for-the-ul-element" id="infopanel-for-term-for-the-ul-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ul-element" style="display:none">Info about the 'ul' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ul-element">3.6. 
 Styling Markers: the list-style shorthand property</a> <a href="#ref-for-the-ul-element①">(2)</a>
@@ -3318,64 +3318,64 @@ Styling Markers: the list-style shorthand property</a> <a href="#ref-for-the-ul-
 Inheriting Counters</a> <a href="#ref-for-the-ul-element③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4.4.2. 
 Instantiating Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.4.1. 
 Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.4.1. 
 Inheriting Counters</a> <a href="#ref-for-map-iterate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.4.2. 
 Instantiating Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">4.4. 
 Creating and Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.4. 
 Creating and Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">4.4. 
 Creating and Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compound">
-   <a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compound" class="dfn-panel" data-for="term-for-compound" id="infopanel-for-term-for-compound" role="menu">
+   <span id="infopaneltitle-for-term-for-compound" style="display:none">Info about the 'compound selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">3.1.1. 
 Properties Applying to ::marker</a> <a href="#ref-for-originating-element①">(2)</a>
@@ -3385,22 +3385,22 @@ Generating Marker Contents</a> <a href="#ref-for-originating-element③">(2)</a>
 The marker-side property</a> <a href="#ref-for-originating-element⑤">(2)</a> <a href="#ref-for-originating-element⑥">(3)</a> <a href="#ref-for-originating-element⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selector" class="dfn-panel" data-for="term-for-selector" id="infopanel-for-term-for-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-selector" style="display:none">Info about the 'selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector">3.1.1. 
 Properties Applying to ::marker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-rect">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-rect" class="dfn-panel" data-for="term-for-elementdef-rect" id="infopanel-for-term-for-elementdef-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-rect" style="display:none">Info about the 'rect' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-rect">4.5. 
 Counters in elements that do not generate boxes</a>
@@ -3790,8 +3790,8 @@ Counters in elements that do not generate boxes</a>
    <div class="issue"> Discussion of how to support <code>ol[reversed]</code> list numbering in CSS is ongoing.
 	See, e.g. <a href="https://github.com/w3c/csswg-drafts/issues/4181">Issue 4181</a>. <a class="issue-return" href="#issue-33887700" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="list-item">
-   <b><a href="#list-item">#list-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-item" class="dfn-panel" data-for="list-item" id="infopanel-for-list-item" role="dialog">
+   <span id="infopaneltitle-for-list-item" style="display:none">Info about the 'list item' definition.</span><b><a href="#list-item">#list-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2. 
 Declaring a List Item</a> <a href="#ref-for-list-item①">(2)</a>
@@ -3814,8 +3814,8 @@ The Implicit list-item Counter</a> <a href="#ref-for-list-item②②">(2)</a> <a
     <li><a href="#ref-for-list-item②⑨">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="marker">
-   <b><a href="#marker">#marker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-marker" class="dfn-panel" data-for="marker" id="infopanel-for-marker" role="dialog">
+   <span id="infopaneltitle-for-marker" style="display:none">Info about the 'marker' definition.</span><b><a href="#marker">#marker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker">3. 
 Markers</a> <a href="#ref-for-marker①">(2)</a> <a href="#ref-for-marker②">(3)</a>
@@ -3833,8 +3833,8 @@ Text-based Markers: the list-style-type property</a>
 The marker-side property</a> <a href="#ref-for-marker①⑥">(2)</a> <a href="#ref-for-marker①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-image">
-   <b><a href="#propdef-list-style-image">#propdef-list-style-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-image" class="dfn-panel" data-for="propdef-list-style-image" id="infopanel-for-propdef-list-style-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' definition.</span><b><a href="#propdef-list-style-image">#propdef-list-style-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">3. 
 Markers</a>
@@ -3846,8 +3846,8 @@ Image Markers: the list-style-image property</a>
 Styling Markers: the list-style shorthand property</a> <a href="#ref-for-propdef-list-style-image④">(2)</a> <a href="#ref-for-propdef-list-style-image⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="marker-image">
-   <b><a href="#marker-image">#marker-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-marker-image" class="dfn-panel" data-for="marker-image" id="infopanel-for-marker-image" role="dialog">
+   <span id="infopaneltitle-for-marker-image" style="display:none">Info about the 'marker image' definition.</span><b><a href="#marker-image">#marker-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker-image">3.2. 
 Generating Marker Contents</a> <a href="#ref-for-marker-image①">(2)</a>
@@ -3857,15 +3857,15 @@ Image Markers: the list-style-image property</a> <a href="#ref-for-marker-image�
 Text-based Markers: the list-style-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-list-style-image-none">
-   <b><a href="#valdef-list-style-image-none">#valdef-list-style-image-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-list-style-image-none" class="dfn-panel" data-for="valdef-list-style-image-none" id="infopanel-for-valdef-list-style-image-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-list-style-image-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-list-style-image-none">#valdef-list-style-image-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-image-none">3.3. 
 Image Markers: the list-style-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-type">
-   <b><a href="#propdef-list-style-type">#propdef-list-style-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-type" class="dfn-panel" data-for="propdef-list-style-type" id="infopanel-for-propdef-list-style-type" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' definition.</span><b><a href="#propdef-list-style-type">#propdef-list-style-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">3. 
 Markers</a>
@@ -3881,8 +3881,8 @@ The Implicit list-item Counter</a> <a href="#ref-for-propdef-list-style-type⑧"
     <li><a href="#ref-for-propdef-list-style-type①⓪">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="marker-string">
-   <b><a href="#marker-string">#marker-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-marker-string" class="dfn-panel" data-for="marker-string" id="infopanel-for-marker-string" role="dialog">
+   <span id="infopaneltitle-for-marker-string" style="display:none">Info about the 'marker string' definition.</span><b><a href="#marker-string">#marker-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker-string">3.2. 
 Generating Marker Contents</a> <a href="#ref-for-marker-string①">(2)</a>
@@ -3892,8 +3892,8 @@ Text-based Markers: the list-style-type property</a> <a href="#ref-for-marker-st
 The Implicit list-item Counter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-position">
-   <b><a href="#propdef-list-style-position">#propdef-list-style-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-position" class="dfn-panel" data-for="propdef-list-style-position" id="infopanel-for-propdef-list-style-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' definition.</span><b><a href="#propdef-list-style-position">#propdef-list-style-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">3.5. 
 Positioning Markers: The list-style-position property</a>
@@ -3901,15 +3901,15 @@ Positioning Markers: The list-style-position property</a>
 Styling Markers: the list-style shorthand property</a> <a href="#ref-for-propdef-list-style-position②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-list-style-position-inside">
-   <b><a href="#valdef-list-style-position-inside">#valdef-list-style-position-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-list-style-position-inside" class="dfn-panel" data-for="valdef-list-style-position-inside" id="infopanel-for-valdef-list-style-position-inside" role="dialog">
+   <span id="infopaneltitle-for-valdef-list-style-position-inside" style="display:none">Info about the 'inside' definition.</span><b><a href="#valdef-list-style-position-inside">#valdef-list-style-position-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-position-inside">3.5. 
 Positioning Markers: The list-style-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-style-position-outside">
-   <b><a href="#list-style-position-outside">#list-style-position-outside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-style-position-outside" class="dfn-panel" data-for="list-style-position-outside" id="infopanel-for-list-style-position-outside" role="dialog">
+   <span id="infopaneltitle-for-list-style-position-outside" style="display:none">Info about the 'outside' definition.</span><b><a href="#list-style-position-outside">#list-style-position-outside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-style-position-outside">3.5. 
 Positioning Markers: The list-style-position property</a>
@@ -3918,8 +3918,8 @@ The marker-side property</a>
     <li><a href="#ref-for-list-style-position-outside②">Changes since the 17 August 2019 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style">
-   <b><a href="#propdef-list-style">#propdef-list-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style" class="dfn-panel" data-for="propdef-list-style" id="infopanel-for-propdef-list-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style" style="display:none">Info about the 'list-style' definition.</span><b><a href="#propdef-list-style">#propdef-list-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">3.6. 
 Styling Markers: the list-style shorthand property</a> <a href="#ref-for-propdef-list-style①">(2)</a> <a href="#ref-for-propdef-list-style②">(3)</a> <a href="#ref-for-propdef-list-style③">(4)</a>
@@ -3928,8 +3928,8 @@ Nested Counters and Scope</a>
     <li><a href="#ref-for-propdef-list-style⑤">Changes since the 20 March 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-side">
-   <b><a href="#propdef-marker-side">#propdef-marker-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-side" class="dfn-panel" data-for="propdef-marker-side" id="infopanel-for-propdef-marker-side" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-side" style="display:none">Info about the 'marker-side' definition.</span><b><a href="#propdef-marker-side">#propdef-marker-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-side">3.5. 
 Positioning Markers: The list-style-position property</a>
@@ -3938,22 +3938,22 @@ The marker-side property</a> <a href="#ref-for-propdef-marker-side②">(2)</a> <
     <li><a href="#ref-for-propdef-marker-side④">Changes since the 20 March 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-marker-side-match-self">
-   <b><a href="#valdef-marker-side-match-self">#valdef-marker-side-match-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-marker-side-match-self" class="dfn-panel" data-for="valdef-marker-side-match-self" id="infopanel-for-valdef-marker-side-match-self" role="dialog">
+   <span id="infopaneltitle-for-valdef-marker-side-match-self" style="display:none">Info about the 'match-self' definition.</span><b><a href="#valdef-marker-side-match-self">#valdef-marker-side-match-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-marker-side-match-self">3.7. 
 The marker-side property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-marker-side-match-parent">
-   <b><a href="#valdef-marker-side-match-parent">#valdef-marker-side-match-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-marker-side-match-parent" class="dfn-panel" data-for="valdef-marker-side-match-parent" id="infopanel-for-valdef-marker-side-match-parent" role="dialog">
+   <span id="infopaneltitle-for-valdef-marker-side-match-parent" style="display:none">Info about the 'match-parent' definition.</span><b><a href="#valdef-marker-side-match-parent">#valdef-marker-side-match-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-marker-side-match-parent">3.7. 
 The marker-side property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="counter">
-   <b><a href="#counter">#counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-counter" class="dfn-panel" data-for="counter" id="infopanel-for-counter" role="dialog">
+   <span id="infopaneltitle-for-counter" style="display:none">Info about the 'counter' definition.</span><b><a href="#counter">#counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter">1. 
 Introduction</a>
@@ -3979,8 +3979,8 @@ The Implicit list-item Counter</a> <a href="#ref-for-counter①⑧">(2)</a> <a h
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-counter②④">(2)</a> <a href="#ref-for-counter②⑤">(3)</a> <a href="#ref-for-counter②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-counter-creator">
-   <b><a href="#css-counter-creator">#css-counter-creator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-counter-creator" class="dfn-panel" data-for="css-counter-creator" id="infopanel-for-css-counter-creator" role="dialog">
+   <span id="infopaneltitle-for-css-counter-creator" style="display:none">Info about the 'creator' definition.</span><b><a href="#css-counter-creator">#css-counter-creator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-counter-creator">4.4. 
 Creating and Inheriting Counters</a>
@@ -3988,8 +3988,8 @@ Creating and Inheriting Counters</a>
 Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-counter-value">
-   <b><a href="#css-counter-value">#css-counter-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-counter-value" class="dfn-panel" data-for="css-counter-value" id="infopanel-for-css-counter-value" role="dialog">
+   <span id="infopaneltitle-for-css-counter-value" style="display:none">Info about the 'value' definition.</span><b><a href="#css-counter-value">#css-counter-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-counter-value">4.4. 
 Creating and Inheriting Counters</a>
@@ -3997,8 +3997,8 @@ Creating and Inheriting Counters</a>
 Inheriting Counters</a> <a href="#ref-for-css-counter-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-counter-name">
-   <b><a href="#typedef-counter-name">#typedef-counter-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-counter-name" class="dfn-panel" data-for="typedef-counter-name" id="infopanel-for-typedef-counter-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-counter-name" style="display:none">Info about the '&lt;counter-name>' definition.</span><b><a href="#typedef-counter-name">#typedef-counter-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter-name">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-typedef-counter-name①">(2)</a> <a href="#ref-for-typedef-counter-name②">(3)</a>
@@ -4010,8 +4010,8 @@ Manipulating Counter Values: the counter-increment and counter-set properties</a
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-typedef-counter-name①②">(2)</a> <a href="#ref-for-typedef-counter-name①③">(3)</a> <a href="#ref-for-typedef-counter-name①④">(4)</a> <a href="#ref-for-typedef-counter-name①⑤">(5)</a> <a href="#ref-for-typedef-counter-name①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-counter-reset">
-   <b><a href="#propdef-counter-reset">#propdef-counter-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-counter-reset" class="dfn-panel" data-for="propdef-counter-reset" id="infopanel-for-propdef-counter-reset" role="dialog">
+   <span id="infopaneltitle-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' definition.</span><b><a href="#propdef-counter-reset">#propdef-counter-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-propdef-counter-reset①">(2)</a>
@@ -4023,8 +4023,8 @@ Nested Counters and Scope</a>
 Instantiating Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-reset-none">
-   <b><a href="#valdef-counter-reset-none">#valdef-counter-reset-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-reset-none" class="dfn-panel" data-for="valdef-counter-reset-none" id="infopanel-for-valdef-counter-reset-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-reset-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-counter-reset-none">#valdef-counter-reset-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-reset-none">4. 
 Automatic Numbering With Counters</a>
@@ -4034,8 +4034,8 @@ Creating Counters: the counter-reset property</a>
 Manipulating Counter Values: the counter-increment and counter-set properties</a> <a href="#ref-for-valdef-counter-reset-none③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-counter-increment">
-   <b><a href="#propdef-counter-increment">#propdef-counter-increment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-counter-increment" class="dfn-panel" data-for="propdef-counter-increment" id="infopanel-for-propdef-counter-increment" role="dialog">
+   <span id="infopaneltitle-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' definition.</span><b><a href="#propdef-counter-increment">#propdef-counter-increment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-propdef-counter-increment①">(2)</a>
@@ -4050,8 +4050,8 @@ The Implicit list-item Counter</a> <a href="#ref-for-propdef-counter-increment�
     <li><a href="#ref-for-propdef-counter-increment①⑤">Changes since the 20 March 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-counter-set">
-   <b><a href="#propdef-counter-set">#propdef-counter-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-counter-set" class="dfn-panel" data-for="propdef-counter-set" id="infopanel-for-propdef-counter-set" role="dialog">
+   <span id="infopaneltitle-for-propdef-counter-set" style="display:none">Info about the 'counter-set' definition.</span><b><a href="#propdef-counter-set">#propdef-counter-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-set">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-propdef-counter-set①">(2)</a>
@@ -4065,15 +4065,15 @@ Instantiating Counters</a>
     <li><a href="#ref-for-propdef-counter-set⑨">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="counter-scope">
-   <b><a href="#counter-scope">#counter-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-counter-scope" class="dfn-panel" data-for="counter-scope" id="infopanel-for-counter-scope" role="dialog">
+   <span id="infopaneltitle-for-counter-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#counter-scope">#counter-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter-scope">4.4. 
 Creating and Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-counters-set">
-   <b><a href="#css-counters-set">#css-counters-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-counters-set" class="dfn-panel" data-for="css-counters-set" id="infopanel-for-css-counters-set" role="dialog">
+   <span id="infopaneltitle-for-css-counters-set" style="display:none">Info about the 'CSS counters set' definition.</span><b><a href="#css-counters-set">#css-counters-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-counters-set">4.4.1. 
 Inheriting Counters</a> <a href="#ref-for-css-counters-set①">(2)</a> <a href="#ref-for-css-counters-set②">(3)</a> <a href="#ref-for-css-counters-set③">(4)</a> <a href="#ref-for-css-counters-set④">(5)</a> <a href="#ref-for-css-counters-set⑤">(6)</a>
@@ -4083,8 +4083,8 @@ Instantiating Counters</a>
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-css-counters-set⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="innermost">
-   <b><a href="#innermost">#innermost</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-innermost" class="dfn-panel" data-for="innermost" id="infopanel-for-innermost" role="dialog">
+   <span id="infopaneltitle-for-innermost" style="display:none">Info about the 'innermost' definition.</span><b><a href="#innermost">#innermost</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-innermost">4.3. 
 Nested Counters and Scope</a>
@@ -4092,8 +4092,8 @@ Nested Counters and Scope</a>
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-innermost②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherit-counters">
-   <b><a href="#inherit-counters">#inherit-counters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherit-counters" class="dfn-panel" data-for="inherit-counters" id="infopanel-for-inherit-counters" role="dialog">
+   <span id="infopaneltitle-for-inherit-counters" style="display:none">Info about the 'inherit counters' definition.</span><b><a href="#inherit-counters">#inherit-counters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherit-counters">4. 
 Automatic Numbering With Counters</a>
@@ -4101,8 +4101,8 @@ Automatic Numbering With Counters</a>
 Inheriting Counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="instantiate-counter">
-   <b><a href="#instantiate-counter">#instantiate-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-instantiate-counter" class="dfn-panel" data-for="instantiate-counter" id="infopanel-for-instantiate-counter" role="dialog">
+   <span id="infopaneltitle-for-instantiate-counter" style="display:none">Info about the 'instantiate a counter' definition.</span><b><a href="#instantiate-counter">#instantiate-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-instantiate-counter">4. 
 Automatic Numbering With Counters</a>
@@ -4120,8 +4120,8 @@ The Implicit list-item Counter</a>
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-counter-increment-list-item">
-   <b><a href="#valdef-counter-increment-list-item">#valdef-counter-increment-list-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-counter-increment-list-item" class="dfn-panel" data-for="valdef-counter-increment-list-item" id="infopanel-for-valdef-counter-increment-list-item" role="dialog">
+   <span id="infopaneltitle-for-valdef-counter-increment-list-item" style="display:none">Info about the 'list-item' definition.</span><b><a href="#valdef-counter-increment-list-item">#valdef-counter-increment-list-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-counter-increment-list-item">1. 
 Introduction</a>
@@ -4135,15 +4135,15 @@ The Implicit list-item Counter</a> <a href="#ref-for-valdef-counter-increment-li
     <li><a href="#ref-for-valdef-counter-increment-list-item①⑥">Changes From CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-counter">
-   <b><a href="#typedef-counter">#typedef-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-counter" class="dfn-panel" data-for="typedef-counter" id="infopanel-for-typedef-counter" role="dialog">
+   <span id="infopaneltitle-for-typedef-counter" style="display:none">Info about the '&lt;counter>' definition.</span><b><a href="#typedef-counter">#typedef-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter">4.7. 
 Outputting Counters: the counter() and counters() functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-counter">
-   <b><a href="#funcdef-counter">#funcdef-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-counter" class="dfn-panel" data-for="funcdef-counter" id="infopanel-for-funcdef-counter" role="dialog">
+   <span id="infopaneltitle-for-funcdef-counter" style="display:none">Info about the 'counter()' definition.</span><b><a href="#funcdef-counter">#funcdef-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counter">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-funcdef-counter①">(2)</a>
@@ -4155,8 +4155,8 @@ Instantiating Counters</a>
 Outputting Counters: the counter() and counters() functions</a> <a href="#ref-for-funcdef-counter⑤">(2)</a> <a href="#ref-for-funcdef-counter⑥">(3)</a> <a href="#ref-for-funcdef-counter⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-counters">
-   <b><a href="#funcdef-counters">#funcdef-counters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-counters" class="dfn-panel" data-for="funcdef-counters" id="infopanel-for-funcdef-counters" role="dialog">
+   <span id="infopaneltitle-for-funcdef-counters" style="display:none">Info about the 'counters()' definition.</span><b><a href="#funcdef-counters">#funcdef-counters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counters">4. 
 Automatic Numbering With Counters</a> <a href="#ref-for-funcdef-counters①">(2)</a>
@@ -4170,59 +4170,115 @@ Outputting Counters: the counter() and counters() functions</a> <a href="#ref-fo
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-logical-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-logical-1/Overview.html
@@ -3122,166 +3122,166 @@ blockquote <c- p>{</c->
    <li><a href="#valdef-logical-page-selector-verso">:verso</a><span>, in § 3</span>
    <li><a href="#valdef-logical-page-verso">verso</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom" class="dfn-panel" data-for="term-for-propdef-border-bottom" id="infopanel-for-term-for-propdef-border-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom" style="display:none">Info about the 'border-bottom' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-color" class="dfn-panel" data-for="term-for-propdef-border-bottom-color" id="infopanel-for-term-for-propdef-border-bottom-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-left-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-left-radius" class="dfn-panel" data-for="term-for-propdef-border-bottom-left-radius" id="infopanel-for-term-for-propdef-border-bottom-left-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-left-radius" style="display:none">Info about the 'border-bottom-left-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-left-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-right-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-right-radius" class="dfn-panel" data-for="term-for-propdef-border-bottom-right-radius" id="infopanel-for-term-for-propdef-border-bottom-right-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-right-radius" style="display:none">Info about the 'border-bottom-right-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-right-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-style" class="dfn-panel" data-for="term-for-propdef-border-bottom-style" id="infopanel-for-term-for-propdef-border-bottom-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-style" style="display:none">Info about the 'border-bottom-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-propdef-border-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left" class="dfn-panel" data-for="term-for-propdef-border-left" id="infopanel-for-term-for-propdef-border-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left" style="display:none">Info about the 'border-left' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-color" class="dfn-panel" data-for="term-for-propdef-border-left-color" id="infopanel-for-term-for-propdef-border-left-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-style" class="dfn-panel" data-for="term-for-propdef-border-left-style" id="infopanel-for-term-for-propdef-border-left-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-style" style="display:none">Info about the 'border-left-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right" class="dfn-panel" data-for="term-for-propdef-border-right" id="infopanel-for-term-for-propdef-border-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right" style="display:none">Info about the 'border-right' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-color" class="dfn-panel" data-for="term-for-propdef-border-right-color" id="infopanel-for-term-for-propdef-border-right-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-style" class="dfn-panel" data-for="term-for-propdef-border-right-style" id="infopanel-for-term-for-propdef-border-right-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-style" style="display:none">Info about the 'border-right-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-propdef-border-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top" class="dfn-panel" data-for="term-for-propdef-border-top" id="infopanel-for-term-for-propdef-border-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top" style="display:none">Info about the 'border-top' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-propdef-border-top-color①">(2)</a> <a href="#ref-for-propdef-border-top-color②">(3)</a> <a href="#ref-for-propdef-border-top-color③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-left-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-left-radius" class="dfn-panel" data-for="term-for-propdef-border-top-left-radius" id="infopanel-for-term-for-propdef-border-top-left-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-left-radius" style="display:none">Info about the 'border-top-left-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-left-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a> <a href="#ref-for-propdef-border-top-left-radius①">(2)</a> <a href="#ref-for-propdef-border-top-left-radius②">(3)</a> <a href="#ref-for-propdef-border-top-left-radius③">(4)</a> <a href="#ref-for-propdef-border-top-left-radius④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-right-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-right-radius" class="dfn-panel" data-for="term-for-propdef-border-top-right-radius" id="infopanel-for-term-for-propdef-border-top-right-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-right-radius" style="display:none">Info about the 'border-top-right-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-right-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-style" class="dfn-panel" data-for="term-for-propdef-border-top-style" id="infopanel-for-term-for-propdef-border-top-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-style" style="display:none">Info about the 'border-top-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-style">4.5.2. 
 Flow-relative Border Styles:
@@ -3291,8 +3291,8 @@ Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4.5.1. 
 Flow-relative Border Widths:
@@ -3302,15 +3302,15 @@ Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-propdef-border-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">1. 
 Introduction</a>
@@ -3325,16 +3325,16 @@ Four-Directional Shorthand Properties: the margin, padding, border-width, border
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-propdef-margin-left①">(2)</a> <a href="#ref-for-propdef-margin-left②">(3)</a> <a href="#ref-for-propdef-margin-left③">(4)</a> <a href="#ref-for-propdef-margin-left④">(5)</a> <a href="#ref-for-propdef-margin-left⑤">(6)</a>
@@ -3343,70 +3343,70 @@ Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a> <a href="#ref-for-propdef-margin-top①">(2)</a> <a href="#ref-for-propdef-margin-top②">(3)</a> <a href="#ref-for-propdef-margin-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-propdef-padding①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a> <a href="#ref-for-propdef-padding-top①">(2)</a> <a href="#ref-for-propdef-padding-top②">(3)</a> <a href="#ref-for-propdef-padding-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-propdef-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">1. 
 Introduction</a>
@@ -3414,15 +3414,15 @@ Introduction</a>
 Flow-Relative Box Model Properties</a> <a href="#ref-for-computed-value②">(2)</a> <a href="#ref-for-computed-value③">(3)</a> <a href="#ref-for-computed-value④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">4. 
 Flow-Relative Box Model Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">4. 
 Flow-Relative Box Model Properties</a>
@@ -3433,8 +3433,8 @@ the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end pro
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'longhand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">4. 
 Flow-Relative Box Model Properties</a>
@@ -3445,8 +3445,8 @@ the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end pro
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-shorthand-property①">(2)</a>
@@ -3473,8 +3473,8 @@ Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property①" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property①" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-shorthand-property①">(2)</a>
@@ -3501,15 +3501,15 @@ Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-specified-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand②" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand②" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">4. 
 Flow-Relative Box Model Properties</a>
@@ -3520,30 +3520,30 @@ the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end pro
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">1. 
 Introduction</a> <a href="#ref-for-used-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-cascade①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. 
 Flow-Relative Values: block-start, block-end, inline-start, inline-end</a>
@@ -3553,16 +3553,16 @@ Logical Values for the caption-side Property</a>
 Flow-Relative Values for the float and clear Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-bottom①">(2)</a> <a href="#ref-for-propdef-bottom②">(3)</a> <a href="#ref-for-propdef-bottom③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">3. 
 Flow-Relative Page Classifications</a> <a href="#ref-for-propdef-left①">(2)</a>
@@ -3571,8 +3571,8 @@ Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-left③">(2)</a> <a href="#ref-for-propdef-left④">(3)</a> <a href="#ref-for-propdef-left⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">3. 
 Flow-Relative Page Classifications</a> <a href="#ref-for-propdef-right①">(2)</a>
@@ -3581,30 +3581,30 @@ Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-right③">(2)</a> <a href="#ref-for-propdef-right④">(3)</a> <a href="#ref-for-propdef-right⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-top①">(2)</a> <a href="#ref-for-propdef-top②">(3)</a> <a href="#ref-for-propdef-top③">(4)</a> <a href="#ref-for-propdef-top④">(5)</a> <a href="#ref-for-propdef-top⑤">(6)</a> <a href="#ref-for-propdef-top⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-margin">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-margin" class="dfn-panel" data-for="term-for-propdef-scroll-margin" id="infopanel-for-term-for-propdef-scroll-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-margin" style="display:none">Info about the 'scroll-margin' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding" class="dfn-panel" data-for="term-for-propdef-scroll-padding" id="infopanel-for-term-for-propdef-scroll-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding" style="display:none">Info about the 'scroll-padding' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.1. 
 Logical Height and Logical Width:
@@ -3613,8 +3613,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-height①">(2)</a> <a href="#ref-for-propdef-height②">(3)</a> <a href="#ref-for-propdef-height③">(4)</a> <a href="#ref-for-propdef-height④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.1. 
 Logical Height and Logical Width:
@@ -3623,36 +3623,36 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a> <a href="#ref-for-propdef-width③">(4)</a> <a href="#ref-for-propdef-width④">(5)</a> <a href="#ref-for-propdef-width⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">2.1. 
 Logical Values for the caption-side Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">2.3. 
 Flow-Relative Values for the text-align Property</a> <a href="#ref-for-propdef-text-align①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4.2. 
 Flow-relative Margins:
@@ -3676,8 +3676,8 @@ the border-block-start-color, border-block-end-color, border-inline-start-color,
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-mult-num-range⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Logical Values for the caption-side Property</a>
@@ -3687,16 +3687,16 @@ Flow-Relative Values for the float and clear Properties</a>
 Flow-Relative Values for the text-align Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a> <a href="#ref-for-comb-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">1. 
 Introduction</a> <a href="#ref-for-propdef-direction①">(2)</a>
@@ -3728,8 +3728,8 @@ Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">4.2. 
 Flow-relative Margins:
@@ -3751,8 +3751,8 @@ Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-css-end①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-start">https://drafts.csswg.org/css-writing-modes-3/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">4.2. 
 Flow-relative Margins:
@@ -3774,22 +3774,22 @@ Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-css-start①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">2.1. 
 Logical Values for the caption-side Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">2.1. 
 Logical Values for the caption-side Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">1. 
 Introduction</a> <a href="#ref-for-flow-relative①">(2)</a> <a href="#ref-for-flow-relative②">(3)</a>
@@ -3801,22 +3801,22 @@ Flow-Relative Values for the float and clear Properties</a>
 Flow-Relative Box Model Properties</a> <a href="#ref-for-flow-relative⑧">(2)</a> <a href="#ref-for-flow-relative⑨">(3)</a> <a href="#ref-for-flow-relative①⓪">(4)</a> <a href="#ref-for-flow-relative①①">(5)</a> <a href="#ref-for-flow-relative①②">(6)</a> <a href="#ref-for-flow-relative①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb" id="infopanel-for-term-for-valdef-writing-mode-horizontal-tb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">4. 
 Flow-Relative Box Model Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">4. 
 Flow-Relative Box Model Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-relative">https://drafts.csswg.org/css-writing-modes-4/#line-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-relative" class="dfn-panel" data-for="term-for-line-relative" id="infopanel-for-term-for-line-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-line-relative" style="display:none">Info about the 'line-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-relative">https://drafts.csswg.org/css-writing-modes-4/#line-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-relative">2. 
 Flow-Relative Values: block-start, block-end, inline-start, inline-end</a>
@@ -3826,15 +3826,15 @@ Logical Values for the caption-side Property</a>
 Flow-Relative Box Model Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-valdef-direction-ltr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">2. 
 Flow-Relative Values: block-start, block-end, inline-start, inline-end</a> <a href="#ref-for-physical①">(2)</a>
@@ -3842,15 +3842,15 @@ Flow-Relative Values: block-start, block-end, inline-start, inline-end</a> <a hr
 Flow-Relative Box Model Properties</a> <a href="#ref-for-physical③">(2)</a> <a href="#ref-for-physical④">(3)</a> <a href="#ref-for-physical⑤">(4)</a> <a href="#ref-for-physical⑥">(5)</a> <a href="#ref-for-physical⑦">(6)</a> <a href="#ref-for-physical⑧">(7)</a> <a href="#ref-for-physical⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-rtl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-rtl" class="dfn-panel" data-for="term-for-valdef-direction-rtl" id="infopanel-for-term-for-valdef-direction-rtl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-valdef-direction-rtl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">1. 
 Introduction</a> <a href="#ref-for-propdef-text-orientation①">(2)</a> <a href="#ref-for-propdef-text-orientation②">(3)</a>
@@ -3882,8 +3882,8 @@ Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">1. 
 Introduction</a>
@@ -3899,8 +3899,8 @@ Flow-Relative Box Model Properties</a> <a href="#ref-for-writing-mode⑥">(2)</a
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">1. 
 Introduction</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
@@ -3937,29 +3937,29 @@ Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caption-side">
-   <a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caption-side" class="dfn-panel" data-for="term-for-propdef-caption-side" id="infopanel-for-term-for-propdef-caption-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caption-side" style="display:none">Info about the 'caption-side' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">2.1. 
 Logical Values for the caption-side Property</a> <a href="#ref-for-propdef-caption-side①">(2)</a> <a href="#ref-for-propdef-caption-side②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">2.2. 
 Flow-Relative Values for the float and clear Properties</a> <a href="#ref-for-propdef-clear①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">2.2. 
 Flow-Relative Values for the float and clear Properties</a> <a href="#ref-for-propdef-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">4.1. 
 Logical Height and Logical Width:
@@ -3968,8 +3968,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-max-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">4.1. 
 Logical Height and Logical Width:
@@ -3978,8 +3978,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-max-width①">(2)</a> <a href="#ref-for-propdef-max-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">4.1. 
 Logical Height and Logical Width:
@@ -3988,8 +3988,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-min-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">4.1. 
 Logical Height and Logical Width:
@@ -3998,15 +3998,15 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a> <a href="#ref-for-propdef-min-width①">(2)</a> <a href="#ref-for-propdef-min-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">3. 
 Flow-Relative Page Classifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3. 
 Flow-Relative Page Classifications</a>
@@ -4785,22 +4785,22 @@ Flow-Relative Page Classifications</a>
     and to specify the expected impact on the interpretation
     of whatever syntactic switch is ultimately chosen. <a class="issue-return" href="#issue-cfb9f389" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="directional-keyword">
-   <b><a href="#directional-keyword">#directional-keyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directional-keyword" class="dfn-panel" data-for="directional-keyword" id="infopanel-for-directional-keyword" role="dialog">
+   <span id="infopaneltitle-for-directional-keyword" style="display:none">Info about the 'directional keyword' definition.</span><b><a href="#directional-keyword">#directional-keyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directional-keyword">2. 
 Flow-Relative Values: block-start, block-end, inline-start, inline-end</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="logical-property-group">
-   <b><a href="#logical-property-group">#logical-property-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-logical-property-group" class="dfn-panel" data-for="logical-property-group" id="infopanel-for-logical-property-group" role="dialog">
+   <span id="infopaneltitle-for-logical-property-group" style="display:none">Info about the 'logical property group' definition.</span><b><a href="#logical-property-group">#logical-property-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-property-group">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-logical-property-group①">(2)</a> <a href="#ref-for-logical-property-group②">(3)</a> <a href="#ref-for-logical-property-group③">(4)</a> <a href="#ref-for-logical-property-group④">(5)</a> <a href="#ref-for-logical-property-group⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-size">
-   <b><a href="#propdef-block-size">#propdef-block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-size" class="dfn-panel" data-for="propdef-block-size" id="infopanel-for-propdef-block-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-size" style="display:none">Info about the 'block-size' definition.</span><b><a href="#propdef-block-size">#propdef-block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-size">4.1. 
 Logical Height and Logical Width:
@@ -4809,8 +4809,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inline-size">
-   <b><a href="#propdef-inline-size">#propdef-inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inline-size" class="dfn-panel" data-for="propdef-inline-size" id="infopanel-for-propdef-inline-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-inline-size" style="display:none">Info about the 'inline-size' definition.</span><b><a href="#propdef-inline-size">#propdef-inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-size">4.1. 
 Logical Height and Logical Width:
@@ -4819,8 +4819,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-block-size">
-   <b><a href="#propdef-min-block-size">#propdef-min-block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-block-size" class="dfn-panel" data-for="propdef-min-block-size" id="infopanel-for-propdef-min-block-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-block-size" style="display:none">Info about the 'min-block-size' definition.</span><b><a href="#propdef-min-block-size">#propdef-min-block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-block-size">4.1. 
 Logical Height and Logical Width:
@@ -4829,8 +4829,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-inline-size">
-   <b><a href="#propdef-min-inline-size">#propdef-min-inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-inline-size" class="dfn-panel" data-for="propdef-min-inline-size" id="infopanel-for-propdef-min-inline-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-inline-size" style="display:none">Info about the 'min-inline-size' definition.</span><b><a href="#propdef-min-inline-size">#propdef-min-inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-inline-size">4.1. 
 Logical Height and Logical Width:
@@ -4839,8 +4839,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-block-size">
-   <b><a href="#propdef-max-block-size">#propdef-max-block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-block-size" class="dfn-panel" data-for="propdef-max-block-size" id="infopanel-for-propdef-max-block-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-block-size" style="display:none">Info about the 'max-block-size' definition.</span><b><a href="#propdef-max-block-size">#propdef-max-block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-block-size">4.1. 
 Logical Height and Logical Width:
@@ -4849,8 +4849,8 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-inline-size">
-   <b><a href="#propdef-max-inline-size">#propdef-max-inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-inline-size" class="dfn-panel" data-for="propdef-max-inline-size" id="infopanel-for-propdef-max-inline-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-inline-size" style="display:none">Info about the 'max-inline-size' definition.</span><b><a href="#propdef-max-inline-size">#propdef-max-inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-inline-size">4.1. 
 Logical Height and Logical Width:
@@ -4859,24 +4859,24 @@ min-block-size/min-inline-size,
 and max-block-size/max-inline-size properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-block-start">
-   <b><a href="#propdef-margin-block-start">#propdef-margin-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-block-start" class="dfn-panel" data-for="propdef-margin-block-start" id="infopanel-for-propdef-margin-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-block-start" style="display:none">Info about the 'margin-block-start' definition.</span><b><a href="#propdef-margin-block-start">#propdef-margin-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-start">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a> <a href="#ref-for-propdef-margin-block-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-block-end">
-   <b><a href="#propdef-margin-block-end">#propdef-margin-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-block-end" class="dfn-panel" data-for="propdef-margin-block-end" id="infopanel-for-propdef-margin-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-block-end" style="display:none">Info about the 'margin-block-end' definition.</span><b><a href="#propdef-margin-block-end">#propdef-margin-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-end">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a> <a href="#ref-for-propdef-margin-block-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-inline-start">
-   <b><a href="#propdef-margin-inline-start">#propdef-margin-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-inline-start" class="dfn-panel" data-for="propdef-margin-inline-start" id="infopanel-for-propdef-margin-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-inline-start" style="display:none">Info about the 'margin-inline-start' definition.</span><b><a href="#propdef-margin-inline-start">#propdef-margin-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-start">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-propdef-margin-inline-start①">(2)</a> <a href="#ref-for-propdef-margin-inline-start②">(3)</a> <a href="#ref-for-propdef-margin-inline-start③">(4)</a>
@@ -4885,8 +4885,8 @@ Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a> <a href="#ref-for-propdef-margin-inline-start⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-inline-end">
-   <b><a href="#propdef-margin-inline-end">#propdef-margin-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-inline-end" class="dfn-panel" data-for="propdef-margin-inline-end" id="infopanel-for-propdef-margin-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-inline-end" style="display:none">Info about the 'margin-inline-end' definition.</span><b><a href="#propdef-margin-inline-end">#propdef-margin-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-end">4. 
 Flow-Relative Box Model Properties</a> <a href="#ref-for-propdef-margin-inline-end①">(2)</a>
@@ -4895,72 +4895,72 @@ Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a> <a href="#ref-for-propdef-margin-inline-end③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-block">
-   <b><a href="#propdef-margin-block">#propdef-margin-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-block" class="dfn-panel" data-for="propdef-margin-block" id="infopanel-for-propdef-margin-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-block" style="display:none">Info about the 'margin-block' definition.</span><b><a href="#propdef-margin-block">#propdef-margin-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-inline">
-   <b><a href="#propdef-margin-inline">#propdef-margin-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-inline" class="dfn-panel" data-for="propdef-margin-inline" id="infopanel-for-propdef-margin-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-inline" style="display:none">Info about the 'margin-inline' definition.</span><b><a href="#propdef-margin-inline">#propdef-margin-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline">4.2. 
 Flow-relative Margins:
 the margin-block-start, margin-block-end, margin-inline-start, margin-inline-end properties and margin-block and margin-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block-start">
-   <b><a href="#propdef-inset-block-start">#propdef-inset-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block-start" class="dfn-panel" data-for="propdef-inset-block-start" id="infopanel-for-propdef-inset-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block-start" style="display:none">Info about the 'inset-block-start' definition.</span><b><a href="#propdef-inset-block-start">#propdef-inset-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-start">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-block-start①">(2)</a> <a href="#ref-for-propdef-inset-block-start②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block-end">
-   <b><a href="#propdef-inset-block-end">#propdef-inset-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block-end" class="dfn-panel" data-for="propdef-inset-block-end" id="infopanel-for-propdef-inset-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block-end" style="display:none">Info about the 'inset-block-end' definition.</span><b><a href="#propdef-inset-block-end">#propdef-inset-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-end">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-block-end①">(2)</a> <a href="#ref-for-propdef-inset-block-end②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline-start">
-   <b><a href="#propdef-inset-inline-start">#propdef-inset-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline-start" class="dfn-panel" data-for="propdef-inset-inline-start" id="infopanel-for-propdef-inset-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline-start" style="display:none">Info about the 'inset-inline-start' definition.</span><b><a href="#propdef-inset-inline-start">#propdef-inset-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-start">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-inline-start①">(2)</a> <a href="#ref-for-propdef-inset-inline-start②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline-end">
-   <b><a href="#propdef-inset-inline-end">#propdef-inset-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline-end" class="dfn-panel" data-for="propdef-inset-inline-end" id="infopanel-for-propdef-inset-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline-end" style="display:none">Info about the 'inset-inline-end' definition.</span><b><a href="#propdef-inset-inline-end">#propdef-inset-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-end">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-inline-end①">(2)</a> <a href="#ref-for-propdef-inset-inline-end②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block">
-   <b><a href="#propdef-inset-block">#propdef-inset-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block" class="dfn-panel" data-for="propdef-inset-block" id="infopanel-for-propdef-inset-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block" style="display:none">Info about the 'inset-block' definition.</span><b><a href="#propdef-inset-block">#propdef-inset-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline">
-   <b><a href="#propdef-inset-inline">#propdef-inset-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline" class="dfn-panel" data-for="propdef-inset-inline" id="infopanel-for-propdef-inset-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline" style="display:none">Info about the 'inset-inline' definition.</span><b><a href="#propdef-inset-inline">#propdef-inset-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline">4.3. 
 Flow-relative Offsets:
 the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end properties and inset-block, inset-inline, and inset shorthands</a> <a href="#ref-for-propdef-inset-inline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset">
-   <b><a href="#propdef-inset">#propdef-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset" class="dfn-panel" data-for="propdef-inset" id="infopanel-for-propdef-inset" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#propdef-inset">#propdef-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset">4.3. 
 Flow-relative Offsets:
@@ -4969,280 +4969,280 @@ the inset-block-start, inset-block-end, inset-inline-start, inset-inline-end pro
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-block-start">
-   <b><a href="#propdef-padding-block-start">#propdef-padding-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-block-start" class="dfn-panel" data-for="propdef-padding-block-start" id="infopanel-for-propdef-padding-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-block-start" style="display:none">Info about the 'padding-block-start' definition.</span><b><a href="#propdef-padding-block-start">#propdef-padding-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-start">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a> <a href="#ref-for-propdef-padding-block-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-block-end">
-   <b><a href="#propdef-padding-block-end">#propdef-padding-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-block-end" class="dfn-panel" data-for="propdef-padding-block-end" id="infopanel-for-propdef-padding-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-block-end" style="display:none">Info about the 'padding-block-end' definition.</span><b><a href="#propdef-padding-block-end">#propdef-padding-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-end">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a> <a href="#ref-for-propdef-padding-block-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-inline-start">
-   <b><a href="#propdef-padding-inline-start">#propdef-padding-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-inline-start" class="dfn-panel" data-for="propdef-padding-inline-start" id="infopanel-for-propdef-padding-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-inline-start" style="display:none">Info about the 'padding-inline-start' definition.</span><b><a href="#propdef-padding-inline-start">#propdef-padding-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-start">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a> <a href="#ref-for-propdef-padding-inline-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-inline-end">
-   <b><a href="#propdef-padding-inline-end">#propdef-padding-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-inline-end" class="dfn-panel" data-for="propdef-padding-inline-end" id="infopanel-for-propdef-padding-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-inline-end" style="display:none">Info about the 'padding-inline-end' definition.</span><b><a href="#propdef-padding-inline-end">#propdef-padding-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-end">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a> <a href="#ref-for-propdef-padding-inline-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-block">
-   <b><a href="#propdef-padding-block">#propdef-padding-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-block" class="dfn-panel" data-for="propdef-padding-block" id="infopanel-for-propdef-padding-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-block" style="display:none">Info about the 'padding-block' definition.</span><b><a href="#propdef-padding-block">#propdef-padding-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-inline">
-   <b><a href="#propdef-padding-inline">#propdef-padding-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-inline" class="dfn-panel" data-for="propdef-padding-inline" id="infopanel-for-propdef-padding-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-inline" style="display:none">Info about the 'padding-inline' definition.</span><b><a href="#propdef-padding-inline">#propdef-padding-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline">4.4. 
 Flow-relative Padding:
 the padding-block-start, padding-block-end, padding-inline-start, padding-inline-end properties and padding-block and padding-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-start-width">
-   <b><a href="#propdef-border-block-start-width">#propdef-border-block-start-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-start-width" class="dfn-panel" data-for="propdef-border-block-start-width" id="infopanel-for-propdef-border-block-start-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-start-width" style="display:none">Info about the 'border-block-start-width' definition.</span><b><a href="#propdef-border-block-start-width">#propdef-border-block-start-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a> <a href="#ref-for-propdef-border-block-start-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-end-width">
-   <b><a href="#propdef-border-block-end-width">#propdef-border-block-end-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-end-width" class="dfn-panel" data-for="propdef-border-block-end-width" id="infopanel-for-propdef-border-block-end-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-end-width" style="display:none">Info about the 'border-block-end-width' definition.</span><b><a href="#propdef-border-block-end-width">#propdef-border-block-end-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a> <a href="#ref-for-propdef-border-block-end-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-start-width">
-   <b><a href="#propdef-border-inline-start-width">#propdef-border-inline-start-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-start-width" class="dfn-panel" data-for="propdef-border-inline-start-width" id="infopanel-for-propdef-border-inline-start-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-start-width" style="display:none">Info about the 'border-inline-start-width' definition.</span><b><a href="#propdef-border-inline-start-width">#propdef-border-inline-start-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a> <a href="#ref-for-propdef-border-inline-start-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-end-width">
-   <b><a href="#propdef-border-inline-end-width">#propdef-border-inline-end-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-end-width" class="dfn-panel" data-for="propdef-border-inline-end-width" id="infopanel-for-propdef-border-inline-end-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-end-width" style="display:none">Info about the 'border-inline-end-width' definition.</span><b><a href="#propdef-border-inline-end-width">#propdef-border-inline-end-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a> <a href="#ref-for-propdef-border-inline-end-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-width">
-   <b><a href="#propdef-border-block-width">#propdef-border-block-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-width" class="dfn-panel" data-for="propdef-border-block-width" id="infopanel-for-propdef-border-block-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-width" style="display:none">Info about the 'border-block-width' definition.</span><b><a href="#propdef-border-block-width">#propdef-border-block-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-width">
-   <b><a href="#propdef-border-inline-width">#propdef-border-inline-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-width" class="dfn-panel" data-for="propdef-border-inline-width" id="infopanel-for-propdef-border-inline-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-width" style="display:none">Info about the 'border-inline-width' definition.</span><b><a href="#propdef-border-inline-width">#propdef-border-inline-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-width">4.5.1. 
 Flow-relative Border Widths:
 the border-block-start-width, border-block-end-width, border-inline-start-width, border-inline-end-width properties and border-block-width and border-inline-width shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-start-style">
-   <b><a href="#propdef-border-block-start-style">#propdef-border-block-start-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-start-style" class="dfn-panel" data-for="propdef-border-block-start-style" id="infopanel-for-propdef-border-block-start-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-start-style" style="display:none">Info about the 'border-block-start-style' definition.</span><b><a href="#propdef-border-block-start-style">#propdef-border-block-start-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a> <a href="#ref-for-propdef-border-block-start-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-end-style">
-   <b><a href="#propdef-border-block-end-style">#propdef-border-block-end-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-end-style" class="dfn-panel" data-for="propdef-border-block-end-style" id="infopanel-for-propdef-border-block-end-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-end-style" style="display:none">Info about the 'border-block-end-style' definition.</span><b><a href="#propdef-border-block-end-style">#propdef-border-block-end-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a> <a href="#ref-for-propdef-border-block-end-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-start-style">
-   <b><a href="#propdef-border-inline-start-style">#propdef-border-inline-start-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-start-style" class="dfn-panel" data-for="propdef-border-inline-start-style" id="infopanel-for-propdef-border-inline-start-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-start-style" style="display:none">Info about the 'border-inline-start-style' definition.</span><b><a href="#propdef-border-inline-start-style">#propdef-border-inline-start-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a> <a href="#ref-for-propdef-border-inline-start-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-end-style">
-   <b><a href="#propdef-border-inline-end-style">#propdef-border-inline-end-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-end-style" class="dfn-panel" data-for="propdef-border-inline-end-style" id="infopanel-for-propdef-border-inline-end-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-end-style" style="display:none">Info about the 'border-inline-end-style' definition.</span><b><a href="#propdef-border-inline-end-style">#propdef-border-inline-end-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a> <a href="#ref-for-propdef-border-inline-end-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-style">
-   <b><a href="#propdef-border-block-style">#propdef-border-block-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-style" class="dfn-panel" data-for="propdef-border-block-style" id="infopanel-for-propdef-border-block-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-style" style="display:none">Info about the 'border-block-style' definition.</span><b><a href="#propdef-border-block-style">#propdef-border-block-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-style">
-   <b><a href="#propdef-border-inline-style">#propdef-border-inline-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-style" class="dfn-panel" data-for="propdef-border-inline-style" id="infopanel-for-propdef-border-inline-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-style" style="display:none">Info about the 'border-inline-style' definition.</span><b><a href="#propdef-border-inline-style">#propdef-border-inline-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-style">4.5.2. 
 Flow-relative Border Styles:
 the border-block-start-style, border-block-end-style, border-inline-start-style, border-inline-end-style properties and border-block-style and border-inline-style shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-start-color">
-   <b><a href="#propdef-border-block-start-color">#propdef-border-block-start-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-start-color" class="dfn-panel" data-for="propdef-border-block-start-color" id="infopanel-for-propdef-border-block-start-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-start-color" style="display:none">Info about the 'border-block-start-color' definition.</span><b><a href="#propdef-border-block-start-color">#propdef-border-block-start-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-propdef-border-block-start-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-end-color">
-   <b><a href="#propdef-border-block-end-color">#propdef-border-block-end-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-end-color" class="dfn-panel" data-for="propdef-border-block-end-color" id="infopanel-for-propdef-border-block-end-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-end-color" style="display:none">Info about the 'border-block-end-color' definition.</span><b><a href="#propdef-border-block-end-color">#propdef-border-block-end-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-propdef-border-block-end-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-start-color">
-   <b><a href="#propdef-border-inline-start-color">#propdef-border-inline-start-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-start-color" class="dfn-panel" data-for="propdef-border-inline-start-color" id="infopanel-for-propdef-border-inline-start-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-start-color" style="display:none">Info about the 'border-inline-start-color' definition.</span><b><a href="#propdef-border-inline-start-color">#propdef-border-inline-start-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-propdef-border-inline-start-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-end-color">
-   <b><a href="#propdef-border-inline-end-color">#propdef-border-inline-end-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-end-color" class="dfn-panel" data-for="propdef-border-inline-end-color" id="infopanel-for-propdef-border-inline-end-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-end-color" style="display:none">Info about the 'border-inline-end-color' definition.</span><b><a href="#propdef-border-inline-end-color">#propdef-border-inline-end-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a> <a href="#ref-for-propdef-border-inline-end-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-color">
-   <b><a href="#propdef-border-block-color">#propdef-border-block-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-color" class="dfn-panel" data-for="propdef-border-block-color" id="infopanel-for-propdef-border-block-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-color" style="display:none">Info about the 'border-block-color' definition.</span><b><a href="#propdef-border-block-color">#propdef-border-block-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-color">
-   <b><a href="#propdef-border-inline-color">#propdef-border-inline-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-color" class="dfn-panel" data-for="propdef-border-inline-color" id="infopanel-for-propdef-border-inline-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-color" style="display:none">Info about the 'border-inline-color' definition.</span><b><a href="#propdef-border-inline-color">#propdef-border-inline-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-color">4.5.3. 
 Flow-relative Border Colors:
 the border-block-start-color, border-block-end-color, border-inline-start-color, border-inline-end-color properties and border-block-color and border-inline-color shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-start">
-   <b><a href="#propdef-border-block-start">#propdef-border-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-start" class="dfn-panel" data-for="propdef-border-block-start" id="infopanel-for-propdef-border-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-start" style="display:none">Info about the 'border-block-start' definition.</span><b><a href="#propdef-border-block-start">#propdef-border-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a> <a href="#ref-for-propdef-border-block-start①">(2)</a> <a href="#ref-for-propdef-border-block-start②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block-end">
-   <b><a href="#propdef-border-block-end">#propdef-border-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block-end" class="dfn-panel" data-for="propdef-border-block-end" id="infopanel-for-propdef-border-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block-end" style="display:none">Info about the 'border-block-end' definition.</span><b><a href="#propdef-border-block-end">#propdef-border-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a> <a href="#ref-for-propdef-border-block-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-start">
-   <b><a href="#propdef-border-inline-start">#propdef-border-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-start" class="dfn-panel" data-for="propdef-border-inline-start" id="infopanel-for-propdef-border-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-start" style="display:none">Info about the 'border-inline-start' definition.</span><b><a href="#propdef-border-inline-start">#propdef-border-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a> <a href="#ref-for-propdef-border-inline-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline-end">
-   <b><a href="#propdef-border-inline-end">#propdef-border-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline-end" class="dfn-panel" data-for="propdef-border-inline-end" id="infopanel-for-propdef-border-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline-end" style="display:none">Info about the 'border-inline-end' definition.</span><b><a href="#propdef-border-inline-end">#propdef-border-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a> <a href="#ref-for-propdef-border-inline-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-block">
-   <b><a href="#propdef-border-block">#propdef-border-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-block" class="dfn-panel" data-for="propdef-border-block" id="infopanel-for-propdef-border-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-block" style="display:none">Info about the 'border-block' definition.</span><b><a href="#propdef-border-block">#propdef-border-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-inline">
-   <b><a href="#propdef-border-inline">#propdef-border-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-inline" class="dfn-panel" data-for="propdef-border-inline" id="infopanel-for-propdef-border-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-inline" style="display:none">Info about the 'border-inline' definition.</span><b><a href="#propdef-border-inline">#propdef-border-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline">4.5.4. 
 Flow-relative Border Shorthands:
 the border-block-start, border-block-end, border-inline-start, border-inline-end properties and border-block and border-inline shorthands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-start-start-radius">
-   <b><a href="#propdef-border-start-start-radius">#propdef-border-start-start-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-start-start-radius" class="dfn-panel" data-for="propdef-border-start-start-radius" id="infopanel-for-propdef-border-start-start-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-start-start-radius" style="display:none">Info about the 'border-start-start-radius' definition.</span><b><a href="#propdef-border-start-start-radius">#propdef-border-start-start-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-start-start-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-start-end-radius">
-   <b><a href="#propdef-border-start-end-radius">#propdef-border-start-end-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-start-end-radius" class="dfn-panel" data-for="propdef-border-start-end-radius" id="infopanel-for-propdef-border-start-end-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-start-end-radius" style="display:none">Info about the 'border-start-end-radius' definition.</span><b><a href="#propdef-border-start-end-radius">#propdef-border-start-end-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-start-end-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-end-start-radius">
-   <b><a href="#propdef-border-end-start-radius">#propdef-border-end-start-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-end-start-radius" class="dfn-panel" data-for="propdef-border-end-start-radius" id="infopanel-for-propdef-border-end-start-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-end-start-radius" style="display:none">Info about the 'border-end-start-radius' definition.</span><b><a href="#propdef-border-end-start-radius">#propdef-border-end-start-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-end-start-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-end-end-radius">
-   <b><a href="#propdef-border-end-end-radius">#propdef-border-end-end-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-end-end-radius" class="dfn-panel" data-for="propdef-border-end-end-radius" id="infopanel-for-propdef-border-end-end-radius" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-end-end-radius" style="display:none">Info about the 'border-end-end-radius' definition.</span><b><a href="#propdef-border-end-end-radius">#propdef-border-end-end-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-end-end-radius">4.6. 
 Flow-relative Corner Rounding:
 the border-start-start-radius, border-start-end-radius, border-end-start-radius, border-end-end-radius properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-margin-logical">
-   <b><a href="#valdef-margin-logical">#valdef-margin-logical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-margin-logical" class="dfn-panel" data-for="valdef-margin-logical" id="infopanel-for-valdef-margin-logical" role="dialog">
+   <span id="infopaneltitle-for-valdef-margin-logical" style="display:none">Info about the 'logical' definition.</span><b><a href="#valdef-margin-logical">#valdef-margin-logical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-margin-logical">4.7. 
 Four-Directional Shorthand Properties: the margin, padding, border-width, border-style, and border-color shorthands</a> <a href="#ref-for-valdef-margin-logical①">(2)</a>
@@ -5250,59 +5250,115 @@ Four-Directional Shorthand Properties: the margin, padding, border-width, border
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-module-bikeshed/Overview.html
@@ -1138,58 +1138,58 @@ on screen, on paper, etc.
    <li><a href="#valdef-foo-value-name">value-name</a><span>, in § 2.1</span>
    <li><a href="#variant">variant</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. Internal display model: the foo property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
     <li><a href="#ref-for-comb-one④">2.2. Shorthands and Descriptors</a> <a href="#ref-for-comb-one⑤">(2)</a> <a href="#ref-for-comb-one⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">2.1. Internal display model: the foo property</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-details-element">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-details-element" class="dfn-panel" data-for="term-for-the-details-element" id="infopanel-for-term-for-the-details-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-details-element" style="display:none">Info about the 'details' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-details-element">2. Sample section</a> <a href="#ref-for-the-details-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-dfn-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-dfn-element" class="dfn-panel" data-for="term-for-the-dfn-element" id="infopanel-for-term-for-the-dfn-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-dfn-element" style="display:none">Info about the 'dfn' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-dfn-element">2. Sample section</a>
     <li><a href="#ref-for-the-dfn-element①">2.1. Internal display model: the foo property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">2. Sample section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-dl-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-dl-element" class="dfn-panel" data-for="term-for-the-dl-element" id="infopanel-for-term-for-the-dl-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-dl-element" style="display:none">Info about the 'dl' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-dl-element">2.1. Internal display model: the foo property</a> <a href="#ref-for-the-dl-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.1. Internal display model: the foo property</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.1. Internal display model: the foo property</a>
    </ul>
@@ -1322,8 +1322,8 @@ on screen, on paper, etc.
 	for easy reference. <a class="issue-return" href="#issue-33d58da0" title="Jump to section">↵</a></div>
    <div class="issue"> Make some considerations about privacy and security. <a class="issue-return" href="#issue-2202014f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-foo">
-   <b><a href="#propdef-foo">#propdef-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-foo" class="dfn-panel" data-for="propdef-foo" id="infopanel-for-propdef-foo" role="dialog">
+   <span id="infopaneltitle-for-propdef-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#propdef-foo">#propdef-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-foo①">1. Introduction</a>
     <li><a href="#ref-for-propdef-foo②">2. Sample section</a> <a href="#ref-for-propdef-foo③">(2)</a>
@@ -1331,77 +1331,133 @@ on screen, on paper, etc.
     <li><a href="#ref-for-propdef-foo⑤">2.2. Shorthands and Descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-references">
-   <b><a href="#cross-references">#cross-references</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-references" class="dfn-panel" data-for="cross-references" id="infopanel-for-cross-references" role="dialog">
+   <span id="infopaneltitle-for-cross-references" style="display:none">Info about the 'Cross-references' definition.</span><b><a href="#cross-references">#cross-references</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-references">2.1. Internal display model: the foo property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the 'Foo' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">2.1. Internal display model: the foo property</a> <a href="#ref-for-foo①">(2)</a> <a href="#ref-for-foo②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-foodict">
-   <b><a href="#dictdef-foodict">#dictdef-foodict</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-foodict" class="dfn-panel" data-for="dictdef-foodict" id="infopanel-for-dictdef-foodict" role="dialog">
+   <span id="infopaneltitle-for-dictdef-foodict" style="display:none">Info about the 'FooDict' definition.</span><b><a href="#dictdef-foodict">#dictdef-foodict</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-foodict">2.1. Internal display model: the foo property</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-1/Overview.html
@@ -3306,90 +3306,90 @@ or security considerations beyond "implement it correctly".</p>
    <li><a href="#spanner">spanner</a><span>, in § 6.1</span>
    <li><a href="#spanning-element">spanning element</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-style" class="dfn-panel" data-for="term-for-typedef-line-style" id="infopanel-for-term-for-typedef-line-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-style" style="display:none">Info about the '&lt;line-style>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-style">4.3. The Style Of Column Rules: the column-rule-style property</a> <a href="#ref-for-typedef-line-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-width" class="dfn-panel" data-for="term-for-typedef-line-width" id="infopanel-for-term-for-typedef-line-width" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-width" style="display:none">Info about the '&lt;line-width>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-width">4.4. The Width Of Column Rules: the column-rule-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">1. 
 Introduction</a> <a href="#ref-for-propdef-border①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-hidden">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-hidden" class="dfn-panel" data-for="term-for-valdef-line-style-hidden" id="infopanel-for-term-for-valdef-line-style-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-hidden">4.4. The Width Of Column Rules: the column-rule-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-none">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-none" class="dfn-panel" data-for="term-for-valdef-line-style-none" id="infopanel-for-term-for-valdef-line-style-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-none">4.3. The Style Of Column Rules: the column-rule-style property</a>
     <li><a href="#ref-for-valdef-line-style-none①">4.4. The Width Of Column Rules: the column-rule-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#fragment">https://drafts.csswg.org/css-break-4/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragment">https://drafts.csswg.org/css-break-4/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 The Multi-Column Model</a>
     <li><a href="#ref-for-fragment①">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation" class="dfn-panel" data-for="term-for-fragmentation" id="infopanel-for-term-for-fragmentation" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation" style="display:none">Info about the 'fragmentation' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation">https://drafts.csswg.org/css-break-4/#fragmentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-widows">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-widows" class="dfn-panel" data-for="term-for-propdef-widows" id="infopanel-for-term-for-propdef-widows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-widows" style="display:none">Info about the 'widows' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">7. 
 Filling Columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">4.2. The Color of Column Rules: the 
 column-rule-color property</a> <a href="#ref-for-typedef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">2. 
 The Multi-Column Model</a> <a href="#ref-for-anonymous①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 The Multi-Column Model</a>
@@ -3399,8 +3399,8 @@ The Multi-Column Model</a>
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">2. 
 The Multi-Column Model</a> <a href="#ref-for-block-formatting-context①">(2)</a> <a href="#ref-for-block-formatting-context②">(3)</a>
@@ -3408,106 +3408,106 @@ The Multi-Column Model</a> <a href="#ref-for-block-formatting-context①">(2)</a
     <li><a href="#ref-for-block-formatting-context⑤">Changes from the Working Draft (WD) of 28 May 2018</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">2. 
 The Multi-Column Model</a> <a href="#ref-for-block-level-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. 
 The Multi-Column Model</a> <a href="#ref-for-containing-block①">(2)</a>
     <li><a href="#ref-for-containing-block②">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-containing-block③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-formatting-context①">(2)</a> <a href="#ref-for-formatting-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">2. 
 The Multi-Column Model</a> <a href="#ref-for-independent-formatting-context①">(2)</a>
     <li><a href="#ref-for-independent-formatting-context②">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-out-of-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-out-of-flow" class="dfn-panel" data-for="term-for-out-of-flow" id="infopanel-for-term-for-out-of-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-out-of-flow" style="display:none">Info about the 'out of flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-out-of-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-out-of-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-out-of-flow" class="dfn-panel" data-for="term-for-out-of-flow" id="infopanel-for-term-for-out-of-flow①" role="menu">
+   <span id="infopaneltitle-for-term-for-out-of-flow①" style="display:none">Info about the 'out-of-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-out-of-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-item">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-item" class="dfn-panel" data-for="term-for-grid-item" id="infopanel-for-term-for-grid-item" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-item" style="display:none">Info about the 'grid item' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">8.2. 
 Pagination and Overflow Outside Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-position">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-position" class="dfn-panel" data-for="term-for-absolute-position" id="infopanel-for-term-for-absolute-position" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-position" style="display:none">Info about the 'absolutely positioned box' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position">2. 
 The Multi-Column Model</a>
     <li><a href="#ref-for-absolute-position①">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">2. 
 The Multi-Column Model</a> <a href="#ref-for-propdef-position①">(2)</a> <a href="#ref-for-propdef-position②">(3)</a>
     <li><a href="#ref-for-propdef-position③">Changes from the Working Draft (WD) of 5 October 2017</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">3.1. The Inline Size of Columns: the column-width property</a>
     <li><a href="#ref-for-table-wrapper-box①">3.2. The Number of Columns: the column-count property</a>
@@ -3515,36 +3515,36 @@ The Multi-Column Model</a> <a href="#ref-for-propdef-position①">(2)</a> <a hre
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">3.2. The Number of Columns: the column-count property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">Changes from the
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.1. The Inline Size of Columns: the column-width property</a> <a href="#ref-for-length-value①">(2)</a>
     <li><a href="#ref-for-length-value②">Changes from the
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. The Inline Size of Columns: the column-width property</a>
     <li><a href="#ref-for-comb-one①">3.2. The Number of Columns: the column-count property</a>
@@ -3552,36 +3552,36 @@ Value Definitions</a>
     <li><a href="#ref-for-comb-one③">7.1. Column Balancing: the column-fill property</a> <a href="#ref-for-comb-one④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.3. The column-width and column-count Shorthand: The columns Property</a>
     <li><a href="#ref-for-comb-any①">4.5. Column Rule Shorthand: the column-rule property</a> <a href="#ref-for-comb-any②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">8.2. 
 Pagination and Overflow Outside Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">4.1. Gutters Between Columns: the column-gap property</a> <a href="#ref-for-propdef-column-gap①">(2)</a> <a href="#ref-for-propdef-column-gap②">(3)</a>
     <li><a href="#ref-for-propdef-column-gap③">Changes from the Working Draft (WD) of 28 May 2018</a> <a href="#ref-for-propdef-column-gap④">(2)</a> <a href="#ref-for-propdef-column-gap⑤">(3)</a>
@@ -3589,59 +3589,59 @@ Pagination and Overflow Outside Multicol Containers</a>
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-row-gap-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal">https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-row-gap-normal" class="dfn-panel" data-for="term-for-valdef-row-gap-normal" id="infopanel-for-term-for-valdef-row-gap-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-row-gap-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal">https://drafts.csswg.org/css-align-3/#valdef-row-gap-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-row-gap-normal">4.1. Gutters Between Columns: the column-gap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">5. 
 Column Breaks</a>
     <li><a href="#ref-for-propdef-break-after①">5.1. Controlling Fragmentation: the break-before, break-after, break-inside properties</a> <a href="#ref-for-propdef-break-after②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">5. 
 Column Breaks</a>
     <li><a href="#ref-for-propdef-break-before①">5.1. Controlling Fragmentation: the break-before, break-after, break-inside properties</a> <a href="#ref-for-propdef-break-before②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">5. 
 Column Breaks</a>
     <li><a href="#ref-for-propdef-break-inside①">5.1. Controlling Fragmentation: the break-before, break-after, break-inside properties</a> <a href="#ref-for-propdef-break-inside②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">7. 
 Filling Columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">8.2. 
 Pagination and Overflow Outside Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">3.4. The Pseudo-algorithm</a>
     <li><a href="#ref-for-paged-media①">6.1. Spanning An Element Across Columns: the column-span property</a>
@@ -3921,15 +3921,15 @@ Pagination and Overflow Outside Multicol Containers</a>
       <td>see individual properties
    </table>
   </div>
-  <aside class="dfn-panel" data-for="multi-column-layout">
-   <b><a href="#multi-column-layout">#multi-column-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-column-layout" class="dfn-panel" data-for="multi-column-layout" id="infopanel-for-multi-column-layout" role="dialog">
+   <span id="infopaneltitle-for-multi-column-layout" style="display:none">Info about the 'multi-column layout' definition.</span><b><a href="#multi-column-layout">#multi-column-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-layout">2. 
 The Multi-Column Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multi-column-container">
-   <b><a href="#multi-column-container">#multi-column-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-column-container" class="dfn-panel" data-for="multi-column-container" id="infopanel-for-multi-column-container" role="dialog">
+   <span id="infopaneltitle-for-multi-column-container" style="display:none">Info about the 'multi-column container' definition.</span><b><a href="#multi-column-container">#multi-column-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">1. 
 Introduction</a> <a href="#ref-for-multi-column-container①">(2)</a>
@@ -3940,8 +3940,8 @@ The Multi-Column Model</a> <a href="#ref-for-multi-column-container③">(2)</a> 
     <li><a href="#ref-for-multi-column-container①⑤">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-multi-column-container①⑥">(2)</a> <a href="#ref-for-multi-column-container①⑦">(3)</a> <a href="#ref-for-multi-column-container①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="column-box">
-   <b><a href="#column-box">#column-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-column-box" class="dfn-panel" data-for="column-box" id="infopanel-for-column-box" role="dialog">
+   <span id="infopaneltitle-for-column-box" style="display:none">Info about the 'column boxes' definition.</span><b><a href="#column-box">#column-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-box">2. 
 The Multi-Column Model</a> <a href="#ref-for-column-box①">(2)</a> <a href="#ref-for-column-box②">(3)</a> <a href="#ref-for-column-box③">(4)</a> <a href="#ref-for-column-box④">(5)</a> <a href="#ref-for-column-box⑤">(6)</a>
@@ -3950,8 +3950,8 @@ The Multi-Column Model</a> <a href="#ref-for-column-box①">(2)</a> <a href="#re
 Overflow Inside Multicol Containers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multi-column-line">
-   <b><a href="#multi-column-line">#multi-column-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-column-line" class="dfn-panel" data-for="multi-column-line" id="infopanel-for-multi-column-line" role="dialog">
+   <span id="infopaneltitle-for-multi-column-line" style="display:none">Info about the 'multicol lines' definition.</span><b><a href="#multi-column-line">#multi-column-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-line">2. 
 The Multi-Column Model</a> <a href="#ref-for-multi-column-line①">(2)</a> <a href="#ref-for-multi-column-line②">(3)</a> <a href="#ref-for-multi-column-line③">(4)</a>
@@ -3959,8 +3959,8 @@ The Multi-Column Model</a> <a href="#ref-for-multi-column-line①">(2)</a> <a hr
     <li><a href="#ref-for-multi-column-line⑧">7.1. Column Balancing: the column-fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="column-gap">
-   <b><a href="#column-gap">#column-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-column-gap" class="dfn-panel" data-for="column-gap" id="infopanel-for-column-gap" role="dialog">
+   <span id="infopaneltitle-for-column-gap" style="display:none">Info about the 'column gap' definition.</span><b><a href="#column-gap">#column-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-gap">1. 
 Introduction</a>
@@ -3968,8 +3968,8 @@ Introduction</a>
     <li><a href="#ref-for-column-gap②">4.5. Column Rule Shorthand: the column-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="column-rule">
-   <b><a href="#column-rule">#column-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-column-rule" class="dfn-panel" data-for="column-rule" id="infopanel-for-column-rule" role="dialog">
+   <span id="infopaneltitle-for-column-rule" style="display:none">Info about the 'column rule' definition.</span><b><a href="#column-rule">#column-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-rule">1. 
 Introduction</a>
@@ -3980,14 +3980,14 @@ column-rule-color property</a>
     <li><a href="#ref-for-column-rule⑥">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multi-column-formatting-context">
-   <b><a href="#multi-column-formatting-context">#multi-column-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-column-formatting-context" class="dfn-panel" data-for="multi-column-formatting-context" id="infopanel-for-multi-column-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-multi-column-formatting-context" style="display:none">Info about the 'multi-column formatting context' definition.</span><b><a href="#multi-column-formatting-context">#multi-column-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-formatting-context">4.1. Gutters Between Columns: the column-gap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-width">
-   <b><a href="#propdef-column-width">#propdef-column-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-width" class="dfn-panel" data-for="propdef-column-width" id="infopanel-for-propdef-column-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-width" style="display:none">Info about the 'column-width' definition.</span><b><a href="#propdef-column-width">#propdef-column-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">2. 
 The Multi-Column Model</a>
@@ -4001,16 +4001,16 @@ The Number and Width of Columns</a> <a href="#ref-for-propdef-column-width②">(
 Candidate Recommendation (CR) of 12 April 2011.</a> <a href="#ref-for-propdef-column-width①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-width-auto">
-   <b><a href="#valdef-column-width-auto">#valdef-column-width-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-width-auto" class="dfn-panel" data-for="valdef-column-width-auto" id="infopanel-for-valdef-column-width-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-width-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-column-width-auto">#valdef-column-width-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-auto">2. 
 The Multi-Column Model</a>
     <li><a href="#ref-for-valdef-column-width-auto①">3.1. The Inline Size of Columns: the column-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-count">
-   <b><a href="#propdef-column-count">#propdef-column-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-count" class="dfn-panel" data-for="propdef-column-count" id="infopanel-for-propdef-column-count" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-count" style="display:none">Info about the 'column-count' definition.</span><b><a href="#propdef-column-count">#propdef-column-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-count">2. 
 The Multi-Column Model</a>
@@ -4024,8 +4024,8 @@ The Number and Width of Columns</a> <a href="#ref-for-propdef-column-count②">(
 Candidate Recommendation (CR) of 12 April 2011.</a> <a href="#ref-for-propdef-column-count①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-columns">
-   <b><a href="#propdef-columns">#propdef-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-columns" class="dfn-panel" data-for="propdef-columns" id="infopanel-for-propdef-columns" role="dialog">
+   <span id="infopaneltitle-for-propdef-columns" style="display:none">Info about the 'columns' definition.</span><b><a href="#propdef-columns">#propdef-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-columns">1. 
 Introduction</a>
@@ -4036,23 +4036,23 @@ The Number and Width of Columns</a>
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-rule-color">
-   <b><a href="#propdef-column-rule-color">#propdef-column-rule-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-rule-color" class="dfn-panel" data-for="propdef-column-rule-color" id="infopanel-for-propdef-column-rule-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-rule-color" style="display:none">Info about the 'column-rule-color' definition.</span><b><a href="#propdef-column-rule-color">#propdef-column-rule-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-color">4.2. The Color of Column Rules: the 
 column-rule-color property</a>
     <li><a href="#ref-for-propdef-column-rule-color①">4.5. Column Rule Shorthand: the column-rule property</a> <a href="#ref-for-propdef-column-rule-color②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-rule-style">
-   <b><a href="#propdef-column-rule-style">#propdef-column-rule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-rule-style" class="dfn-panel" data-for="propdef-column-rule-style" id="infopanel-for-propdef-column-rule-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-rule-style" style="display:none">Info about the 'column-rule-style' definition.</span><b><a href="#propdef-column-rule-style">#propdef-column-rule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-style">4.3. The Style Of Column Rules: the column-rule-style property</a> <a href="#ref-for-propdef-column-rule-style①">(2)</a>
     <li><a href="#ref-for-propdef-column-rule-style②">4.5. Column Rule Shorthand: the column-rule property</a> <a href="#ref-for-propdef-column-rule-style③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-rule-width">
-   <b><a href="#propdef-column-rule-width">#propdef-column-rule-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-rule-width" class="dfn-panel" data-for="propdef-column-rule-width" id="infopanel-for-propdef-column-rule-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-rule-width" style="display:none">Info about the 'column-rule-width' definition.</span><b><a href="#propdef-column-rule-width">#propdef-column-rule-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-width">4.3. The Style Of Column Rules: the column-rule-style property</a>
     <li><a href="#ref-for-propdef-column-rule-width①">4.4. The Width Of Column Rules: the column-rule-width property</a>
@@ -4061,16 +4061,16 @@ column-rule-color property</a>
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-rule">
-   <b><a href="#propdef-column-rule">#propdef-column-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-rule" class="dfn-panel" data-for="propdef-column-rule" id="infopanel-for-propdef-column-rule" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-rule" style="display:none">Info about the 'column-rule' definition.</span><b><a href="#propdef-column-rule">#propdef-column-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule">1. 
 Introduction</a> <a href="#ref-for-propdef-column-rule①">(2)</a> <a href="#ref-for-propdef-column-rule②">(3)</a> <a href="#ref-for-propdef-column-rule③">(4)</a>
     <li><a href="#ref-for-propdef-column-rule④">4.5. Column Rule Shorthand: the column-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-span">
-   <b><a href="#propdef-column-span">#propdef-column-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-span" class="dfn-panel" data-for="propdef-column-span" id="infopanel-for-propdef-column-span" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-span" style="display:none">Info about the 'column-span' definition.</span><b><a href="#propdef-column-span">#propdef-column-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-span">1. 
 Introduction</a>
@@ -4081,20 +4081,20 @@ Spanning Columns</a>
 Candidate Recommendation (CR) of 12 April 2011.</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-span-none">
-   <b><a href="#valdef-column-span-none">#valdef-column-span-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-span-none" class="dfn-panel" data-for="valdef-column-span-none" id="infopanel-for-valdef-column-span-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-span-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-column-span-none">#valdef-column-span-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-span-none">6.1. Spanning An Element Across Columns: the column-span property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-span-all">
-   <b><a href="#valdef-column-span-all">#valdef-column-span-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-span-all" class="dfn-panel" data-for="valdef-column-span-all" id="infopanel-for-valdef-column-span-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-span-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-column-span-all">#valdef-column-span-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-span-all">6.1. Spanning An Element Across Columns: the column-span property</a> <a href="#ref-for-valdef-column-span-all①">(2)</a> <a href="#ref-for-valdef-column-span-all②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spanner">
-   <b><a href="#spanner">#spanner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spanner" class="dfn-panel" data-for="spanner" id="infopanel-for-spanner" role="dialog">
+   <span id="infopaneltitle-for-spanner" style="display:none">Info about the 'spanner' definition.</span><b><a href="#spanner">#spanner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spanner">2. 
 The Multi-Column Model</a> <a href="#ref-for-spanner①">(2)</a>
@@ -4102,8 +4102,8 @@ The Multi-Column Model</a> <a href="#ref-for-spanner①">(2)</a>
     <li><a href="#ref-for-spanner④">7.1. Column Balancing: the column-fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-column-fill">
-   <b><a href="#propdef-column-fill">#propdef-column-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-fill" class="dfn-panel" data-for="propdef-column-fill" id="infopanel-for-propdef-column-fill" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-fill" style="display:none">Info about the 'column-fill' definition.</span><b><a href="#propdef-column-fill">#propdef-column-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-fill">1. 
 Introduction</a>
@@ -4114,59 +4114,115 @@ Candidate Recommendation (CR) of 12 April 2011.</a> <a href="#ref-for-propdef-co
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-multicol-2/Overview.html
@@ -1410,8 +1410,8 @@ In addition, once final, it will replace and supersede the following:</p>
    <li><a href="#valdef-column-span-integer-1">&lt;integer [1,∞]></a><span>, in § 7.1</span>
    <li><a href="#valdef-column-span-none">none</a><span>, in § 7.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">5.1. 
 column-gap</a>
@@ -1419,29 +1419,29 @@ column-gap</a>
 column-span</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-region">
-   <a href="https://drafts.csswg.org/css-regions-1/#css-region">https://drafts.csswg.org/css-regions-1/#css-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-region" class="dfn-panel" data-for="term-for-css-region" id="infopanel-for-term-for-css-region" role="menu">
+   <span id="infopaneltitle-for-term-for-css-region" style="display:none">Info about the 'css region' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#css-region">https://drafts.csswg.org/css-regions-1/#css-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-region">6. 
 Column breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">7.1. 
 column-span</a> <a href="#ref-for-min-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">7.1. 
 column-span</a> <a href="#ref-for-outer-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">7. 
 Spanning columns</a>
@@ -1449,78 +1449,78 @@ Spanning columns</a>
 column-span</a> <a href="#ref-for-integer-value②">(2)</a> <a href="#ref-for-integer-value③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">7.1. 
 column-span</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">6.1. 
 break-before, break-after, break-inside</a> <a href="#ref-for-propdef-break-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">6.1. 
 break-before, break-after, break-inside</a> <a href="#ref-for-propdef-break-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">6.1. 
 break-before, break-after, break-inside</a> <a href="#ref-for-propdef-break-inside①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-count">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-count">https://drafts.csswg.org/css-multicol-1/#propdef-column-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-count" class="dfn-panel" data-for="term-for-propdef-column-count" id="infopanel-for-term-for-propdef-column-count" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-count" style="display:none">Info about the 'column-count' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-count">https://drafts.csswg.org/css-multicol-1/#propdef-column-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-count">4.2. 
 column-count</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-fill">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-fill">https://drafts.csswg.org/css-multicol-1/#propdef-column-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-fill" class="dfn-panel" data-for="term-for-propdef-column-fill" id="infopanel-for-term-for-propdef-column-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-fill" style="display:none">Info about the 'column-fill' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-fill">https://drafts.csswg.org/css-multicol-1/#propdef-column-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-fill">8.1. 
 column-fill</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-rule">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-rule" class="dfn-panel" data-for="term-for-propdef-column-rule" id="infopanel-for-term-for-propdef-column-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-rule" style="display:none">Info about the 'column-rule' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule">5.5. 
 column-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-rule-color">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-rule-color" class="dfn-panel" data-for="term-for-propdef-column-rule-color" id="infopanel-for-term-for-propdef-column-rule-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-rule-color" style="display:none">Info about the 'column-rule-color' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-color">5.2. 
 column-rule-color</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-rule-style">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-style">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-rule-style" class="dfn-panel" data-for="term-for-propdef-column-rule-style" id="infopanel-for-term-for-propdef-column-rule-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-rule-style" style="display:none">Info about the 'column-rule-style' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-style">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-style">5.3. 
 column-rule-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-rule-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-rule-width" class="dfn-panel" data-for="term-for-propdef-column-rule-width" id="infopanel-for-term-for-propdef-column-rule-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-rule-width" style="display:none">Info about the 'column-rule-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-rule-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-rule-width">5.4. 
 column-rule-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">4.1. 
 column-width</a>
@@ -1528,15 +1528,15 @@ column-width</a>
 column-span</a> <a href="#ref-for-propdef-column-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-columns">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-columns">https://drafts.csswg.org/css-multicol-1/#propdef-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-columns" class="dfn-panel" data-for="term-for-propdef-columns" id="infopanel-for-term-for-propdef-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-columns" style="display:none">Info about the 'columns' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-columns">https://drafts.csswg.org/css-multicol-1/#propdef-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-columns">4.3. 
 columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">7.1. 
 column-span</a>
@@ -1669,8 +1669,8 @@ column-span</a>
    <div class="issue"> Add final content from previous level <a class="issue-return" href="#issue-e0a943d4①⑧" title="Jump to section">↵</a></div>
    <div class="issue"> Add final level 1 contributor list <a class="issue-return" href="#issue-45b97b73" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-column-span">
-   <b><a href="#propdef-column-span">#propdef-column-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-column-span" class="dfn-panel" data-for="propdef-column-span" id="infopanel-for-propdef-column-span" role="dialog">
+   <span id="infopaneltitle-for-propdef-column-span" style="display:none">Info about the 'column-span' definition.</span><b><a href="#propdef-column-span">#propdef-column-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-span">7. 
 Spanning columns</a>
@@ -1680,59 +1680,115 @@ column-span</a> <a href="#ref-for-propdef-column-span②">(2)</a> <a href="#ref-
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-namespaces-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-namespaces-3/Overview.html
@@ -1010,35 +1010,35 @@ wqwname
    <li><a href="#typedef-namespace-prefix">&lt;namespace-prefix></a><span>, in § 2.1</span>
    <li><a href="#namespace-prefix">namespace prefix</a><span>, in § 2.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">2. Declaring namespaces: the @namespace rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">2.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type-selector" class="dfn-panel" data-for="term-for-type-selector" id="infopanel-for-term-for-type-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-type-selector" style="display:none">Info about the 'type selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">1.1. 
 Terminology</a>
@@ -1083,74 +1083,130 @@ Terminology</a>
    <dt id="biblio-selectors-4">[SELECTORS-4]
    <dd>Elika Etemad; Tab Atkins Jr.. <a href="https://drafts.csswg.org/selectors/"><cite>Selectors Level 4</cite></a>. URL: <a href="https://drafts.csswg.org/selectors/">https://drafts.csswg.org/selectors/</a>
   </dl>
-  <aside class="dfn-panel" data-for="typedef-namespace-prefix">
-   <b><a href="#typedef-namespace-prefix">#typedef-namespace-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-namespace-prefix" class="dfn-panel" data-for="typedef-namespace-prefix" id="infopanel-for-typedef-namespace-prefix" role="dialog">
+   <span id="infopaneltitle-for-typedef-namespace-prefix" style="display:none">Info about the '&lt;namespace-prefix>' definition.</span><b><a href="#typedef-namespace-prefix">#typedef-namespace-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-namespace-prefix">2.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-qualified-name">
-   <b><a href="#css-qualified-name">#css-qualified-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-qualified-name" class="dfn-panel" data-for="css-qualified-name" id="infopanel-for-css-qualified-name" role="dialog">
+   <span id="infopaneltitle-for-css-qualified-name" style="display:none">Info about the 'CSS qualified name' definition.</span><b><a href="#css-qualified-name">#css-qualified-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-qualified-name">2. Declaring namespaces: the @namespace rule</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-nav-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-nav-1/Overview.html
@@ -2676,8 +2676,8 @@ Answers are provided below.</p>
    <li><a href="#update-the-search-origin">updating the search origin</a><span>, in § 8.4</span>
    <li><a href="#dom-focusableareasearchmode-visible">"visible"</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">8.1. 
 Glossary</a> <a href="#ref-for-box-fragment①">(2)</a>
@@ -2685,15 +2685,15 @@ Glossary</a> <a href="#ref-for-box-fragment①">(2)</a>
 Focus Navigation Heuristics</a> <a href="#ref-for-box-fragment③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">8.1. 
 Glossary</a> <a href="#ref-for-box①">(2)</a>
@@ -2701,32 +2701,32 @@ Glossary</a> <a href="#ref-for-box①">(2)</a>
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-box">
-   <a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-box" class="dfn-panel" data-for="term-for-principal-box" id="infopanel-for-term-for-principal-box" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-box" style="display:none">Info about the 'principal box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#principal-box">https://drafts.csswg.org/css-display-3/#principal-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-hidden">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-hidden" class="dfn-panel" data-for="term-for-valdef-overflow-hidden" id="infopanel-for-term-for-valdef-overflow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">Appendix A. Scroll extensions</a> <a href="#ref-for-valdef-overflow-hidden①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-x">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-x" class="dfn-panel" data-for="term-for-propdef-overflow-x" id="infopanel-for-term-for-propdef-overflow-x" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-y">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-y" class="dfn-panel" data-for="term-for-propdef-overflow-y" id="infopanel-for-term-for-propdef-overflow-y" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">6.2.2. 
 navnotarget</a> <a href="#ref-for-scroll-container①">(2)</a>
@@ -2743,8 +2743,8 @@ Controlling the interaction with scrolling: the spatial-navigation-action proper
     <li><a href="#ref-for-scroll-container②⓪">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">3. 
 Overview</a> <a href="#ref-for-scrollport①">(2)</a> <a href="#ref-for-scrollport②">(3)</a>
@@ -2756,42 +2756,42 @@ navnotarget</a>
 Controlling the interaction with scrolling: the spatial-navigation-action property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-position">
-   <a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-position" class="dfn-panel" data-for="term-for-relative-position" id="infopanel-for-term-for-relative-position" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-position" style="display:none">Info about the 'relative position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-position">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-scroll-snap-type-mandatory">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#valdef-scroll-snap-type-mandatory">https://drafts.csswg.org/css-scroll-snap-1/#valdef-scroll-snap-type-mandatory</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-scroll-snap-type-mandatory" class="dfn-panel" data-for="term-for-valdef-scroll-snap-type-mandatory" id="infopanel-for-term-for-valdef-scroll-snap-type-mandatory" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-scroll-snap-type-mandatory" style="display:none">Info about the 'mandatory' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#valdef-scroll-snap-type-mandatory">https://drafts.csswg.org/css-scroll-snap-1/#valdef-scroll-snap-type-mandatory</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-mandatory">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-optimal-viewing-region">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region">https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-optimal-viewing-region" class="dfn-panel" data-for="term-for-optimal-viewing-region" id="infopanel-for-term-for-optimal-viewing-region" role="menu">
+   <span id="infopaneltitle-for-term-for-optimal-viewing-region" style="display:none">Info about the 'optimal viewing region' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region">https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimal-viewing-region">8.1. 
 Glossary</a> <a href="#ref-for-optimal-viewing-region①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">2.1. 
 CSS Property Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">9.1. 
 Creating additional spatial navigation containers: the spatial-navigation-contain property</a>
@@ -2801,35 +2801,35 @@ Controlling the interaction with scrolling: the spatial-navigation-action proper
 Selecting the navigation algorithm: the spatial-navigation-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x14">
-   <a href="https://drafts.csswg.org/css2/box.html#x14">https://drafts.csswg.org/css2/box.html#x14</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x14" class="dfn-panel" data-for="term-for-x14" id="infopanel-for-term-for-x14" role="menu">
+   <span id="infopaneltitle-for-term-for-x14" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css2/box.html#x14">https://drafts.csswg.org/css2/box.html#x14</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x14">8.1. 
 Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-painting-order">
-   <a href="https://drafts.csswg.org/css2/zindex.html#painting-order">https://drafts.csswg.org/css2/zindex.html#painting-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-painting-order" class="dfn-panel" data-for="term-for-painting-order" id="infopanel-for-term-for-painting-order" role="menu">
+   <span id="infopaneltitle-for-term-for-painting-order" style="display:none">Info about the 'painting order' external reference.</span><a href="https://drafts.csswg.org/css2/zindex.html#painting-order">https://drafts.csswg.org/css2/zindex.html#painting-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-painting-order">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-painting-order①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-an-element">
-   <a href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element">https://drafts.csswg.org/cssom-view-1/#scroll-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-an-element" class="dfn-panel" data-for="term-for-scroll-an-element" id="infopanel-for-term-for-scroll-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-an-element" style="display:none">Info about the 'scroll an element' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#scroll-an-element">https://drafts.csswg.org/cssom-view-1/#scroll-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-an-element">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">6.2.1. 
 navbeforefocus</a>
@@ -2837,29 +2837,29 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.1. 
 Interface NavigationEvent</a> <a href="#ref-for-eventtarget①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">5.2. 
 Low level APIs</a> <a href="#ref-for-node①">(2)</a> <a href="#ref-for-node②">(3)</a> <a href="#ref-for-node③">(4)</a> <a href="#ref-for-node④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canceled-flag">
-   <a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canceled-flag" class="dfn-panel" data-for="term-for-canceled-flag" id="infopanel-for-term-for-canceled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-canceled-flag" style="display:none">Info about the 'canceled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#canceled-flag">https://dom.spec.whatwg.org/#canceled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">4. 
 Triggering Spatial Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">5.2. 
 Low level APIs</a>
@@ -2869,22 +2869,22 @@ Glossary</a>
 Navigation</a> <a href="#ref-for-concept-document③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-element">
-   <a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-element" class="dfn-panel" data-for="term-for-document-element" id="infopanel-for-term-for-document-element" role="menu">
+   <span id="infopaneltitle-for-term-for-document-element" style="display:none">Info about the 'document element' external reference.</span><a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-element">8.3. 
 Navigation</a> <a href="#ref-for-document-element①">(2)</a> <a href="#ref-for-document-element②">(3)</a> <a href="#ref-for-document-element③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
-   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boundary-point-node" class="dfn-panel" data-for="term-for-boundary-point-node" id="infopanel-for-term-for-boundary-point-node" role="menu">
+   <span id="infopaneltitle-for-term-for-boundary-point-node" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">8.3. 
 Navigation</a> <a href="#ref-for-boundary-point-node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">6.2.1. 
 navbeforefocus</a>
@@ -2892,15 +2892,15 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
-   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-preventdefault" class="dfn-panel" data-for="term-for-dom-event-preventdefault" id="infopanel-for-term-for-dom-event-preventdefault" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-preventdefault" style="display:none">Info about the 'preventDefault()' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">3. 
 Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-target" class="dfn-panel" data-for="term-for-dom-event-target" id="infopanel-for-term-for-dom-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">6.2.1. 
 navbeforefocus</a>
@@ -2908,29 +2908,29 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-feature-policy/#default-allowlist">https://w3c.github.io/webappsec-feature-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-feature-policy/#default-allowlist">https://w3c.github.io/webappsec-feature-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">7. 
 The navigation-override policy-controlled feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-feature-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-feature-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-feature-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-feature-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">7. 
 The navigation-override policy-controlled feature</a> <a href="#ref-for-policy-controlled-feature①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">5.1. 
 Triggering Navigation Programmatically</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">6.2.1. 
 navbeforefocus</a>
@@ -2938,22 +2938,22 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-disabled">
-   <a href="https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled">https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-disabled" class="dfn-panel" data-for="term-for-concept-element-disabled" id="infopanel-for-term-for-concept-element-disabled" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-disabled" style="display:none">Info about the 'actually disabled' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled">https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-disabled">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">8.1. 
 Glossary</a>
@@ -2963,29 +2963,29 @@ Groupings of elements</a>
 Creating additional spatial navigation containers: the spatial-navigation-contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context" id="infopanel-for-term-for-currently-focused-area-of-a-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" style="display:none">Info about the 'currently focused area of a top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-anchor">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-anchor" class="dfn-panel" data-for="term-for-dom-anchor" id="infopanel-for-term-for-dom-anchor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-anchor" style="display:none">Info about the 'dom anchor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-anchor">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-dom-anchor①">(2)</a> <a href="#ref-for-dom-anchor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-expressly-inert">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#expressly-inert">https://html.spec.whatwg.org/multipage/interaction.html#expressly-inert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-expressly-inert" class="dfn-panel" data-for="term-for-expressly-inert" id="infopanel-for-term-for-expressly-inert" role="menu">
+   <span id="infopaneltitle-for-term-for-expressly-inert" style="display:none">Info about the 'expressly inert' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#expressly-inert">https://html.spec.whatwg.org/multipage/interaction.html#expressly-inert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-expressly-inert">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-focus">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-focus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-focus" class="dfn-panel" data-for="term-for-dom-focus" id="infopanel-for-term-for-dom-focus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-focus" style="display:none">Info about the 'focus(options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-focus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-focus">3. 
 Overview</a>
@@ -2995,8 +2995,8 @@ navnotarget</a>
 Controlling the interaction with scrolling: the spatial-navigation-action property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusable-area">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#focusable-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusable-area" class="dfn-panel" data-for="term-for-focusable-area" id="infopanel-for-term-for-focusable-area" role="menu">
+   <span id="infopaneltitle-for-term-for-focusable-area" style="display:none">Info about the 'focusable area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable-area">https://html.spec.whatwg.org/multipage/interaction.html#focusable-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusable-area">8.1. 
 Glossary</a> <a href="#ref-for-focusable-area①">(2)</a>
@@ -3004,15 +3004,15 @@ Glossary</a> <a href="#ref-for-focusable-area①">(2)</a>
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusing-steps">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusing-steps" class="dfn-panel" data-for="term-for-focusing-steps" id="infopanel-for-term-for-focusing-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-focusing-steps" style="display:none">Info about the 'focusing steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps">https://html.spec.whatwg.org/multipage/interaction.html#focusing-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusing-steps">8.3. 
 Navigation</a> <a href="#ref-for-focusing-steps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">6.2.1. 
 navbeforefocus</a>
@@ -3020,43 +3020,43 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nodes-are-removed">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#nodes-are-removed">https://html.spec.whatwg.org/multipage/infrastructure.html#nodes-are-removed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nodes-are-removed" class="dfn-panel" data-for="term-for-nodes-are-removed" id="infopanel-for-term-for-nodes-are-removed" role="menu">
+   <span id="infopaneltitle-for-term-for-nodes-are-removed" style="display:none">Info about the 'removed' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#nodes-are-removed">https://html.spec.whatwg.org/multipage/infrastructure.html#nodes-are-removed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodes-are-removed">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sequential-focus-navigation-order">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-order">https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sequential-focus-navigation-order" class="dfn-panel" data-for="term-for-sequential-focus-navigation-order" id="infopanel-for-term-for-sequential-focus-navigation-order" role="menu">
+   <span id="infopaneltitle-for-term-for-sequential-focus-navigation-order" style="display:none">Info about the 'sequential focus navigation order' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-order">https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequential-focus-navigation-order">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sequential-focus-navigation-starting-point">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point">https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sequential-focus-navigation-starting-point" class="dfn-panel" data-for="term-for-sequential-focus-navigation-starting-point" id="infopanel-for-term-for-sequential-focus-navigation-starting-point" role="menu">
+   <span id="infopaneltitle-for-term-for-sequential-focus-navigation-starting-point" style="display:none">Info about the 'sequential focus navigation starting point' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point">https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation-starting-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequential-focus-navigation-starting-point">8.1. 
 Glossary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-tabindex">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-tabindex" class="dfn-panel" data-for="term-for-attr-tabindex" id="infopanel-for-term-for-attr-tabindex" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-tabindex" style="display:none">Info about the 'tabindex' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-tabindex">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-attr-tabindex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-tabindex">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-tabindex" class="dfn-panel" data-for="term-for-attr-tabindex" id="infopanel-for-term-for-attr-tabindex①" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-tabindex①" style="display:none">Info about the 'tabindex (for htmlsvg-global)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex">https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-tabindex">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-attr-tabindex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element-2">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element-2" class="dfn-panel" data-for="term-for-the-body-element-2" id="infopanel-for-term-for-the-body-element-2" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element-2" style="display:none">Info about the 'the body element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element-2">6.2.1. 
 navbeforefocus</a>
@@ -3066,8 +3066,8 @@ navnotarget</a>
 Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">6.2.1. 
 navbeforefocus</a>
@@ -3081,49 +3081,49 @@ Navigation</a>
 Creating additional spatial navigation containers: the spatial-navigation-contain property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">8.3. 
 Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">8.4. 
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-boundary">
-   <a href="https://drafts.csswg.org/css-overscroll-behavior-1/#scroll-boundary">https://drafts.csswg.org/css-overscroll-behavior-1/#scroll-boundary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-boundary" class="dfn-panel" data-for="term-for-scroll-boundary" id="infopanel-for-term-for-scroll-boundary" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-boundary" style="display:none">Info about the 'scroll boundary' external reference.</span><a href="https://drafts.csswg.org/css-overscroll-behavior-1/#scroll-boundary">https://drafts.csswg.org/css-overscroll-behavior-1/#scroll-boundary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-boundary">Appendix A. Scroll extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyboardevent">
-   <a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyboardevent" class="dfn-panel" data-for="term-for-keyboardevent" id="infopanel-for-term-for-keyboardevent" role="menu">
+   <span id="infopaneltitle-for-term-for-keyboardevent" style="display:none">Info about the 'KeyboardEvent' external reference.</span><a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboardevent">6.2.1. 
 navbeforefocus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uievent">
-   <a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uievent" class="dfn-panel" data-for="term-for-uievent" id="infopanel-for-term-for-uievent" role="menu">
+   <span id="infopaneltitle-for-term-for-uievent" style="display:none">Info about the 'UIEvent' external reference.</span><a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uievent">4. 
 Triggering Spatial Navigation</a>
@@ -3131,15 +3131,15 @@ Triggering Spatial Navigation</a>
 Interface NavigationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-uieventinit">
-   <a href="https://w3c.github.io/uievents/#dictdef-uieventinit">https://w3c.github.io/uievents/#dictdef-uieventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-uieventinit" class="dfn-panel" data-for="term-for-dictdef-uieventinit" id="infopanel-for-term-for-dictdef-uieventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-uieventinit" style="display:none">Info about the 'UIEventInit' external reference.</span><a href="https://w3c.github.io/uievents/#dictdef-uieventinit">https://w3c.github.io/uievents/#dictdef-uieventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-uieventinit">6.1. 
 Interface NavigationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-target">
-   <a href="https://w3c.github.io/uievents/#event-target">https://w3c.github.io/uievents/#event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-target" class="dfn-panel" data-for="term-for-event-target" id="infopanel-for-term-for-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-event-target" style="display:none">Info about the 'event target' external reference.</span><a href="https://w3c.github.io/uievents/#event-target">https://w3c.github.io/uievents/#event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-target">6.2.1. 
 navbeforefocus</a>
@@ -3147,43 +3147,43 @@ navbeforefocus</a>
 navnotarget</a> <a href="#ref-for-event-target②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyboardevent-key">
-   <a href="https://w3c.github.io/uievents/#dom-keyboardevent-key">https://w3c.github.io/uievents/#dom-keyboardevent-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyboardevent-key" class="dfn-panel" data-for="term-for-dom-keyboardevent-key" id="infopanel-for-term-for-dom-keyboardevent-key" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyboardevent-key" style="display:none">Info about the 'key' external reference.</span><a href="https://w3c.github.io/uievents/#dom-keyboardevent-key">https://w3c.github.io/uievents/#dom-keyboardevent-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyboardevent-key">6.2.1. 
 navbeforefocus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keydown">
-   <a href="https://w3c.github.io/uievents/#keydown">https://w3c.github.io/uievents/#keydown</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keydown" class="dfn-panel" data-for="term-for-keydown" id="infopanel-for-term-for-keydown" role="menu">
+   <span id="infopaneltitle-for-term-for-keydown" style="display:none">Info about the 'keydown' external reference.</span><a href="https://w3c.github.io/uievents/#keydown">https://w3c.github.io/uievents/#keydown</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keydown">4. 
 Triggering Spatial Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">6.1. 
 Interface NavigationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. 
 Interface NavigationEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.2. 
 Low level APIs</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.1. 
 Triggering Navigation Programmatically</a>
@@ -3464,15 +3464,15 @@ Triggering Navigation Programmatically</a>
 how to perform a scroll in a given direction without an explicit position.
 Until then, we roll our own. <a href="https://github.com/w3c/csswg-drafts/issues/2323">[Issue #w3c/csswg-drafts#2323]</a> <a class="issue-return" href="#issue-00706fa4" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="spatial-navigation">
-   <b><a href="#spatial-navigation">#spatial-navigation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spatial-navigation" class="dfn-panel" data-for="spatial-navigation" id="infopanel-for-spatial-navigation" role="dialog">
+   <span id="infopaneltitle-for-spatial-navigation" style="display:none">Info about the 'spatial navigation' definition.</span><b><a href="#spatial-navigation">#spatial-navigation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spatial-navigation">1. 
 Introduction</a> <a href="#ref-for-spatial-navigation①">(2)</a> <a href="#ref-for-spatial-navigation②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-risk">
-   <b><a href="#at-risk">#at-risk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-risk" class="dfn-panel" data-for="at-risk" id="infopanel-for-at-risk" role="dialog">
+   <span id="infopaneltitle-for-at-risk" style="display:none">Info about the 'at-risk' definition.</span><b><a href="#at-risk">#at-risk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-risk">5.2. 
 Low level APIs</a>
@@ -3482,8 +3482,8 @@ Creating additional spatial navigation containers: the spatial-navigation-contai
 Controlling the interaction with scrolling: the spatial-navigation-action property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-spatialnavigationdirection">
-   <b><a href="#enumdef-spatialnavigationdirection">#enumdef-spatialnavigationdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-spatialnavigationdirection" class="dfn-panel" data-for="enumdef-spatialnavigationdirection" id="infopanel-for-enumdef-spatialnavigationdirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-spatialnavigationdirection" style="display:none">Info about the 'SpatialNavigationDirection' definition.</span><b><a href="#enumdef-spatialnavigationdirection">#enumdef-spatialnavigationdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-spatialnavigationdirection">5.1. 
 Triggering Navigation Programmatically</a>
@@ -3493,107 +3493,107 @@ Low level APIs</a>
 Interface NavigationEvent</a> <a href="#ref-for-enumdef-spatialnavigationdirection③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationdirection-up">
-   <b><a href="#dom-spatialnavigationdirection-up">#dom-spatialnavigationdirection-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationdirection-up" class="dfn-panel" data-for="dom-spatialnavigationdirection-up" id="infopanel-for-dom-spatialnavigationdirection-up" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationdirection-up" style="display:none">Info about the '"up"' definition.</span><b><a href="#dom-spatialnavigationdirection-up">#dom-spatialnavigationdirection-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationdirection-up">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-dom-spatialnavigationdirection-up①">(2)</a> <a href="#ref-for-dom-spatialnavigationdirection-up②">(3)</a> <a href="#ref-for-dom-spatialnavigationdirection-up③">(4)</a> <a href="#ref-for-dom-spatialnavigationdirection-up④">(5)</a> <a href="#ref-for-dom-spatialnavigationdirection-up⑤">(6)</a> <a href="#ref-for-dom-spatialnavigationdirection-up⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationdirection-down">
-   <b><a href="#dom-spatialnavigationdirection-down">#dom-spatialnavigationdirection-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationdirection-down" class="dfn-panel" data-for="dom-spatialnavigationdirection-down" id="infopanel-for-dom-spatialnavigationdirection-down" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationdirection-down" style="display:none">Info about the '"down"' definition.</span><b><a href="#dom-spatialnavigationdirection-down">#dom-spatialnavigationdirection-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationdirection-down">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-dom-spatialnavigationdirection-down①">(2)</a> <a href="#ref-for-dom-spatialnavigationdirection-down②">(3)</a> <a href="#ref-for-dom-spatialnavigationdirection-down③">(4)</a> <a href="#ref-for-dom-spatialnavigationdirection-down④">(5)</a> <a href="#ref-for-dom-spatialnavigationdirection-down⑤">(6)</a> <a href="#ref-for-dom-spatialnavigationdirection-down⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationdirection-left">
-   <b><a href="#dom-spatialnavigationdirection-left">#dom-spatialnavigationdirection-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationdirection-left" class="dfn-panel" data-for="dom-spatialnavigationdirection-left" id="infopanel-for-dom-spatialnavigationdirection-left" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationdirection-left" style="display:none">Info about the '"left"' definition.</span><b><a href="#dom-spatialnavigationdirection-left">#dom-spatialnavigationdirection-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationdirection-left">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-dom-spatialnavigationdirection-left①">(2)</a> <a href="#ref-for-dom-spatialnavigationdirection-left②">(3)</a> <a href="#ref-for-dom-spatialnavigationdirection-left③">(4)</a> <a href="#ref-for-dom-spatialnavigationdirection-left④">(5)</a> <a href="#ref-for-dom-spatialnavigationdirection-left⑤">(6)</a> <a href="#ref-for-dom-spatialnavigationdirection-left⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationdirection-right">
-   <b><a href="#dom-spatialnavigationdirection-right">#dom-spatialnavigationdirection-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationdirection-right" class="dfn-panel" data-for="dom-spatialnavigationdirection-right" id="infopanel-for-dom-spatialnavigationdirection-right" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationdirection-right" style="display:none">Info about the '"right"' definition.</span><b><a href="#dom-spatialnavigationdirection-right">#dom-spatialnavigationdirection-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationdirection-right">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-dom-spatialnavigationdirection-right①">(2)</a> <a href="#ref-for-dom-spatialnavigationdirection-right②">(3)</a> <a href="#ref-for-dom-spatialnavigationdirection-right③">(4)</a> <a href="#ref-for-dom-spatialnavigationdirection-right④">(5)</a> <a href="#ref-for-dom-spatialnavigationdirection-right⑤">(6)</a> <a href="#ref-for-dom-spatialnavigationdirection-right⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-navigate">
-   <b><a href="#dom-window-navigate">#dom-window-navigate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-navigate" class="dfn-panel" data-for="dom-window-navigate" id="infopanel-for-dom-window-navigate" role="dialog">
+   <span id="infopaneltitle-for-dom-window-navigate" style="display:none">Info about the 'navigate(dir)' definition.</span><b><a href="#dom-window-navigate">#dom-window-navigate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-navigate">5.1. 
 Triggering Navigation Programmatically</a> <a href="#ref-for-dom-window-navigate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-focusableareasearchmode">
-   <b><a href="#enumdef-focusableareasearchmode">#enumdef-focusableareasearchmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-focusableareasearchmode" class="dfn-panel" data-for="enumdef-focusableareasearchmode" id="infopanel-for-enumdef-focusableareasearchmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-focusableareasearchmode" style="display:none">Info about the 'FocusableAreaSearchMode' definition.</span><b><a href="#enumdef-focusableareasearchmode">#enumdef-focusableareasearchmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-focusableareasearchmode">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-focusableareasoption">
-   <b><a href="#dictdef-focusableareasoption">#dictdef-focusableareasoption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-focusableareasoption" class="dfn-panel" data-for="dictdef-focusableareasoption" id="infopanel-for-dictdef-focusableareasoption" role="dialog">
+   <span id="infopaneltitle-for-dictdef-focusableareasoption" style="display:none">Info about the 'FocusableAreasOption' definition.</span><b><a href="#dictdef-focusableareasoption">#dictdef-focusableareasoption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-focusableareasoption">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-focusableareasoption-mode">
-   <b><a href="#dom-focusableareasoption-mode">#dom-focusableareasoption-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-focusableareasoption-mode" class="dfn-panel" data-for="dom-focusableareasoption-mode" id="infopanel-for-dom-focusableareasoption-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-focusableareasoption-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-focusableareasoption-mode">#dom-focusableareasoption-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-focusableareasoption-mode">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-spatialnavigationsearchoptions">
-   <b><a href="#dictdef-spatialnavigationsearchoptions">#dictdef-spatialnavigationsearchoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-spatialnavigationsearchoptions" class="dfn-panel" data-for="dictdef-spatialnavigationsearchoptions" id="infopanel-for-dictdef-spatialnavigationsearchoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-spatialnavigationsearchoptions" style="display:none">Info about the 'SpatialNavigationSearchOptions' definition.</span><b><a href="#dictdef-spatialnavigationsearchoptions">#dictdef-spatialnavigationsearchoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-spatialnavigationsearchoptions">5.2. 
 Low level APIs</a>
     <li><a href="#ref-for-dictdef-spatialnavigationsearchoptions①">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationsearchoptions-candidates">
-   <b><a href="#dom-spatialnavigationsearchoptions-candidates">#dom-spatialnavigationsearchoptions-candidates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationsearchoptions-candidates" class="dfn-panel" data-for="dom-spatialnavigationsearchoptions-candidates" id="infopanel-for-dom-spatialnavigationsearchoptions-candidates" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationsearchoptions-candidates" style="display:none">Info about the 'candidates' definition.</span><b><a href="#dom-spatialnavigationsearchoptions-candidates">#dom-spatialnavigationsearchoptions-candidates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationsearchoptions-candidates">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-spatialnavigationsearchoptions-container">
-   <b><a href="#dom-spatialnavigationsearchoptions-container">#dom-spatialnavigationsearchoptions-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-spatialnavigationsearchoptions-container" class="dfn-panel" data-for="dom-spatialnavigationsearchoptions-container" id="infopanel-for-dom-spatialnavigationsearchoptions-container" role="dialog">
+   <span id="infopaneltitle-for-dom-spatialnavigationsearchoptions-container" style="display:none">Info about the 'container' definition.</span><b><a href="#dom-spatialnavigationsearchoptions-container">#dom-spatialnavigationsearchoptions-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-spatialnavigationsearchoptions-container">5.2. 
 Low level APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-spatialnavigationsearch">
-   <b><a href="#dom-element-spatialnavigationsearch">#dom-element-spatialnavigationsearch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-spatialnavigationsearch" class="dfn-panel" data-for="dom-element-spatialnavigationsearch" id="infopanel-for-dom-element-spatialnavigationsearch" role="dialog">
+   <span id="infopaneltitle-for-dom-element-spatialnavigationsearch" style="display:none">Info about the 'spatialNavigationSearch' definition.</span><b><a href="#dom-element-spatialnavigationsearch">#dom-element-spatialnavigationsearch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-spatialnavigationsearch">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getspatialnavigationcontainer">
-   <b><a href="#dom-element-getspatialnavigationcontainer">#dom-element-getspatialnavigationcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getspatialnavigationcontainer" class="dfn-panel" data-for="dom-element-getspatialnavigationcontainer" id="infopanel-for-dom-element-getspatialnavigationcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getspatialnavigationcontainer" style="display:none">Info about the 'getSpatialNavigationContainer()' definition.</span><b><a href="#dom-element-getspatialnavigationcontainer">#dom-element-getspatialnavigationcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getspatialnavigationcontainer①">5.2. 
 Low level APIs</a> <a href="#ref-for-dom-element-getspatialnavigationcontainer②">(2)</a> <a href="#ref-for-dom-element-getspatialnavigationcontainer③">(3)</a>
     <li><a href="#ref-for-dom-element-getspatialnavigationcontainer④">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-focusableareas">
-   <b><a href="#dom-element-focusableareas">#dom-element-focusableareas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-focusableareas" class="dfn-panel" data-for="dom-element-focusableareas" id="infopanel-for-dom-element-focusableareas" role="dialog">
+   <span id="infopaneltitle-for-dom-element-focusableareas" style="display:none">Info about the 'focusableAreas(option)' definition.</span><b><a href="#dom-element-focusableareas">#dom-element-focusableareas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-focusableareas①">5.2. 
 Low level APIs</a> <a href="#ref-for-dom-element-focusableareas②">(2)</a> <a href="#ref-for-dom-element-focusableareas③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigationevent">
-   <b><a href="#navigationevent">#navigationevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigationevent" class="dfn-panel" data-for="navigationevent" id="infopanel-for-navigationevent" role="dialog">
+   <span id="infopaneltitle-for-navigationevent" style="display:none">Info about the 'NavigationEvent' definition.</span><b><a href="#navigationevent">#navigationevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigationevent">4. 
 Triggering Spatial Navigation</a>
@@ -3605,8 +3605,8 @@ navbeforefocus</a> <a href="#ref-for-navigationevent⑤">(2)</a> <a href="#ref-f
 navnotarget</a> <a href="#ref-for-navigationevent⑧">(2)</a> <a href="#ref-for-navigationevent⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationevent-dir">
-   <b><a href="#dom-navigationevent-dir">#dom-navigationevent-dir</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationevent-dir" class="dfn-panel" data-for="dom-navigationevent-dir" id="infopanel-for-dom-navigationevent-dir" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationevent-dir" style="display:none">Info about the 'dir' definition.</span><b><a href="#dom-navigationevent-dir">#dom-navigationevent-dir</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationevent-dir">6.2.1. 
 navbeforefocus</a>
@@ -3614,8 +3614,8 @@ navbeforefocus</a>
 navnotarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigationevent-relatedtarget">
-   <b><a href="#dom-navigationevent-relatedtarget">#dom-navigationevent-relatedtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigationevent-relatedtarget" class="dfn-panel" data-for="dom-navigationevent-relatedtarget" id="infopanel-for-dom-navigationevent-relatedtarget" role="dialog">
+   <span id="infopaneltitle-for-dom-navigationevent-relatedtarget" style="display:none">Info about the 'relatedTarget' definition.</span><b><a href="#dom-navigationevent-relatedtarget">#dom-navigationevent-relatedtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigationevent-relatedtarget">6.2.1. 
 navbeforefocus</a> <a href="#ref-for-dom-navigationevent-relatedtarget①">(2)</a>
@@ -3623,29 +3623,29 @@ navbeforefocus</a> <a href="#ref-for-dom-navigationevent-relatedtarget①">(2)</
 navnotarget</a> <a href="#ref-for-dom-navigationevent-relatedtarget③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-navigationeventinit">
-   <b><a href="#dictdef-navigationeventinit">#dictdef-navigationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-navigationeventinit" class="dfn-panel" data-for="dictdef-navigationeventinit" id="infopanel-for-dictdef-navigationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-navigationeventinit" style="display:none">Info about the 'NavigationEventInit' definition.</span><b><a href="#dictdef-navigationeventinit">#dictdef-navigationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-navigationeventinit">6.1. 
 Interface NavigationEvent</a> <a href="#ref-for-dictdef-navigationeventinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-navigationevent-navbeforefocus">
-   <b><a href="#eventdef-navigationevent-navbeforefocus">#eventdef-navigationevent-navbeforefocus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-navigationevent-navbeforefocus" class="dfn-panel" data-for="eventdef-navigationevent-navbeforefocus" id="infopanel-for-eventdef-navigationevent-navbeforefocus" role="dialog">
+   <span id="infopaneltitle-for-eventdef-navigationevent-navbeforefocus" style="display:none">Info about the 'navbeforefocus' definition.</span><b><a href="#eventdef-navigationevent-navbeforefocus">#eventdef-navigationevent-navbeforefocus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-navigationevent-navbeforefocus">6.2.1. 
 navbeforefocus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dispatches-navbeforefocus-event">
-   <b><a href="#dispatches-navbeforefocus-event">#dispatches-navbeforefocus-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dispatches-navbeforefocus-event" class="dfn-panel" data-for="dispatches-navbeforefocus-event" id="infopanel-for-dispatches-navbeforefocus-event" role="dialog">
+   <span id="infopaneltitle-for-dispatches-navbeforefocus-event" style="display:none">Info about the 'dispatches navbeforefocus event' definition.</span><b><a href="#dispatches-navbeforefocus-event">#dispatches-navbeforefocus-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatches-navbeforefocus-event">8.3. 
 Navigation</a> <a href="#ref-for-dispatches-navbeforefocus-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-navigationevent-navnotarget">
-   <b><a href="#eventdef-navigationevent-navnotarget">#eventdef-navigationevent-navnotarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-navigationevent-navnotarget" class="dfn-panel" data-for="eventdef-navigationevent-navnotarget" id="infopanel-for-eventdef-navigationevent-navnotarget" role="dialog">
+   <span id="infopaneltitle-for-eventdef-navigationevent-navnotarget" style="display:none">Info about the 'navnotarget' definition.</span><b><a href="#eventdef-navigationevent-navnotarget">#eventdef-navigationevent-navnotarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-navigationevent-navnotarget">6.2.2. 
 navnotarget</a>
@@ -3653,15 +3653,15 @@ navnotarget</a>
 Controlling the interaction with scrolling: the spatial-navigation-action property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dispatches-navnotarget-event">
-   <b><a href="#dispatches-navnotarget-event">#dispatches-navnotarget-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dispatches-navnotarget-event" class="dfn-panel" data-for="dispatches-navnotarget-event" id="infopanel-for-dispatches-navnotarget-event" role="dialog">
+   <span id="infopaneltitle-for-dispatches-navnotarget-event" style="display:none">Info about the 'dispatches navnotarget event' definition.</span><b><a href="#dispatches-navnotarget-event">#dispatches-navnotarget-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatches-navnotarget-event">8.3. 
 Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigation-override">
-   <b><a href="#navigation-override">#navigation-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigation-override" class="dfn-panel" data-for="navigation-override" id="infopanel-for-navigation-override" role="dialog">
+   <span id="infopaneltitle-for-navigation-override" style="display:none">Info about the 'navigation-override' definition.</span><b><a href="#navigation-override">#navigation-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-override">6.2.1. 
 navbeforefocus</a>
@@ -3671,8 +3671,8 @@ navnotarget</a>
 The navigation-override policy-controlled feature</a> <a href="#ref-for-navigation-override③">(2)</a> <a href="#ref-for-navigation-override④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boundary-box">
-   <b><a href="#boundary-box">#boundary-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boundary-box" class="dfn-panel" data-for="boundary-box" id="infopanel-for-boundary-box" role="dialog">
+   <span id="infopaneltitle-for-boundary-box" style="display:none">Info about the 'boundary box' definition.</span><b><a href="#boundary-box">#boundary-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-box">8.1. 
 Glossary</a>
@@ -3680,8 +3680,8 @@ Glossary</a>
 Focus Navigation Heuristics</a> <a href="#ref-for-boundary-box②">(2)</a> <a href="#ref-for-boundary-box③">(3)</a> <a href="#ref-for-boundary-box④">(4)</a> <a href="#ref-for-boundary-box⑤">(5)</a> <a href="#ref-for-boundary-box⑥">(6)</a> <a href="#ref-for-boundary-box⑦">(7)</a> <a href="#ref-for-boundary-box⑧">(8)</a> <a href="#ref-for-boundary-box⑨">(9)</a> <a href="#ref-for-boundary-box①⓪">(10)</a> <a href="#ref-for-boundary-box①①">(11)</a> <a href="#ref-for-boundary-box①②">(12)</a> <a href="#ref-for-boundary-box①③">(13)</a> <a href="#ref-for-boundary-box①④">(14)</a> <a href="#ref-for-boundary-box①⑤">(15)</a> <a href="#ref-for-boundary-box①⑥">(16)</a> <a href="#ref-for-boundary-box①⑦">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inside-area">
-   <b><a href="#inside-area">#inside-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inside-area" class="dfn-panel" data-for="inside-area" id="infopanel-for-inside-area" role="dialog">
+   <span id="infopaneltitle-for-inside-area" style="display:none">Info about the 'inside area' definition.</span><b><a href="#inside-area">#inside-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inside-area">8.1. 
 Glossary</a>
@@ -3689,15 +3689,15 @@ Glossary</a>
 Focus Navigation Heuristics</a> <a href="#ref-for-inside-area②">(2)</a> <a href="#ref-for-inside-area③">(3)</a> <a href="#ref-for-inside-area④">(4)</a> <a href="#ref-for-inside-area⑤">(5)</a> <a href="#ref-for-inside-area⑥">(6)</a> <a href="#ref-for-inside-area⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="search-origin">
-   <b><a href="#search-origin">#search-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-search-origin" class="dfn-panel" data-for="search-origin" id="infopanel-for-search-origin" role="dialog">
+   <span id="infopaneltitle-for-search-origin" style="display:none">Info about the 'search origin' definition.</span><b><a href="#search-origin">#search-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-search-origin">8.4. 
 Focus Navigation Heuristics</a> <a href="#ref-for-search-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spatial-navigation-starting-point">
-   <b><a href="#spatial-navigation-starting-point">#spatial-navigation-starting-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spatial-navigation-starting-point" class="dfn-panel" data-for="spatial-navigation-starting-point" id="infopanel-for-spatial-navigation-starting-point" role="dialog">
+   <span id="infopaneltitle-for-spatial-navigation-starting-point" style="display:none">Info about the 'spatial navigation starting point' definition.</span><b><a href="#spatial-navigation-starting-point">#spatial-navigation-starting-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spatial-navigation-starting-point">8.1. 
 Glossary</a>
@@ -3705,8 +3705,8 @@ Glossary</a>
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spatial-navigation-containers">
-   <b><a href="#spatial-navigation-containers">#spatial-navigation-containers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spatial-navigation-containers" class="dfn-panel" data-for="spatial-navigation-containers" id="infopanel-for-spatial-navigation-containers" role="dialog">
+   <span id="infopaneltitle-for-spatial-navigation-containers" style="display:none">Info about the 'spatial navigation containers' definition.</span><b><a href="#spatial-navigation-containers">#spatial-navigation-containers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spatial-navigation-containers">3. 
 Overview</a> <a href="#ref-for-spatial-navigation-containers①">(2)</a> <a href="#ref-for-spatial-navigation-containers②">(3)</a> <a href="#ref-for-spatial-navigation-containers③">(4)</a> <a href="#ref-for-spatial-navigation-containers④">(5)</a> <a href="#ref-for-spatial-navigation-containers⑤">(6)</a> <a href="#ref-for-spatial-navigation-containers⑥">(7)</a> <a href="#ref-for-spatial-navigation-containers⑦">(8)</a>
@@ -3729,8 +3729,8 @@ Selecting the navigation algorithm: the spatial-navigation-function property</a>
     <li><a href="#ref-for-spatial-navigation-containers③⑥">Changes</a> <a href="#ref-for-spatial-navigation-containers③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spatial-navigation-steps">
-   <b><a href="#spatial-navigation-steps">#spatial-navigation-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spatial-navigation-steps" class="dfn-panel" data-for="spatial-navigation-steps" id="infopanel-for-spatial-navigation-steps" role="dialog">
+   <span id="infopaneltitle-for-spatial-navigation-steps" style="display:none">Info about the 'spatial navigation steps' definition.</span><b><a href="#spatial-navigation-steps">#spatial-navigation-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spatial-navigation-steps">4. 
 Triggering Spatial Navigation</a> <a href="#ref-for-spatial-navigation-steps①">(2)</a> <a href="#ref-for-spatial-navigation-steps②">(3)</a>
@@ -3738,23 +3738,23 @@ Triggering Spatial Navigation</a> <a href="#ref-for-spatial-navigation-steps①"
 Triggering Navigation Programmatically</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-search-origin">
-   <b><a href="#set-the-search-origin">#set-the-search-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-search-origin" class="dfn-panel" data-for="set-the-search-origin" id="infopanel-for-set-the-search-origin" role="dialog">
+   <span id="infopaneltitle-for-set-the-search-origin" style="display:none">Info about the 'set the search origin' definition.</span><b><a href="#set-the-search-origin">#set-the-search-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-search-origin">8.3. 
 Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-the-search-origin">
-   <b><a href="#update-the-search-origin">#update-the-search-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-the-search-origin" class="dfn-panel" data-for="update-the-search-origin" id="infopanel-for-update-the-search-origin" role="dialog">
+   <span id="infopaneltitle-for-update-the-search-origin" style="display:none">Info about the 'update the search origin' definition.</span><b><a href="#update-the-search-origin">#update-the-search-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-search-origin">8.4. 
 Focus Navigation Heuristics</a>
     <li><a href="#ref-for-update-the-search-origin①">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-focusable-areas">
-   <b><a href="#find-focusable-areas">#find-focusable-areas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-focusable-areas" class="dfn-panel" data-for="find-focusable-areas" id="infopanel-for-find-focusable-areas" role="dialog">
+   <span id="infopaneltitle-for-find-focusable-areas" style="display:none">Info about the 'find focusable areas' definition.</span><b><a href="#find-focusable-areas">#find-focusable-areas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-focusable-areas">5.2. 
 Low level APIs</a> <a href="#ref-for-find-focusable-areas①">(2)</a>
@@ -3764,8 +3764,8 @@ Navigation</a> <a href="#ref-for-find-focusable-areas③">(2)</a>
 Focus Navigation Heuristics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="select-the-best-candidate">
-   <b><a href="#select-the-best-candidate">#select-the-best-candidate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-select-the-best-candidate" class="dfn-panel" data-for="select-the-best-candidate" id="infopanel-for-select-the-best-candidate" role="dialog">
+   <span id="infopaneltitle-for-select-the-best-candidate" style="display:none">Info about the 'select the best candidate' definition.</span><b><a href="#select-the-best-candidate">#select-the-best-candidate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-select-the-best-candidate">5.2. 
 Low level APIs</a>
@@ -3775,8 +3775,8 @@ navbeforefocus</a>
 Navigation</a> <a href="#ref-for-select-the-best-candidate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-the-shortest-distance">
-   <b><a href="#find-the-shortest-distance">#find-the-shortest-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-the-shortest-distance" class="dfn-panel" data-for="find-the-shortest-distance" id="infopanel-for-find-the-shortest-distance" role="dialog">
+   <span id="infopaneltitle-for-find-the-shortest-distance" style="display:none">Info about the 'find the shortest distance' definition.</span><b><a href="#find-the-shortest-distance">#find-the-shortest-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-the-shortest-distance">8.4. 
 Focus Navigation Heuristics</a>
@@ -3784,8 +3784,8 @@ Focus Navigation Heuristics</a>
 Selecting the navigation algorithm: the spatial-navigation-function property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-spatial-navigation-contain">
-   <b><a href="#propdef-spatial-navigation-contain">#propdef-spatial-navigation-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-spatial-navigation-contain" class="dfn-panel" data-for="propdef-spatial-navigation-contain" id="infopanel-for-propdef-spatial-navigation-contain" role="dialog">
+   <span id="infopaneltitle-for-propdef-spatial-navigation-contain" style="display:none">Info about the 'spatial-navigation-contain' definition.</span><b><a href="#propdef-spatial-navigation-contain">#propdef-spatial-navigation-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-spatial-navigation-contain①">3. 
 Overview</a>
@@ -3795,8 +3795,8 @@ Groupings of elements</a>
 Creating additional spatial navigation containers: the spatial-navigation-contain property</a> <a href="#ref-for-propdef-spatial-navigation-contain④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-spatial-navigation-action">
-   <b><a href="#propdef-spatial-navigation-action">#propdef-spatial-navigation-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-spatial-navigation-action" class="dfn-panel" data-for="propdef-spatial-navigation-action" id="infopanel-for-propdef-spatial-navigation-action" role="dialog">
+   <span id="infopaneltitle-for-propdef-spatial-navigation-action" style="display:none">Info about the 'spatial-navigation-action' definition.</span><b><a href="#propdef-spatial-navigation-action">#propdef-spatial-navigation-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-spatial-navigation-action①">8.3. 
 Navigation</a> <a href="#ref-for-propdef-spatial-navigation-action②">(2)</a> <a href="#ref-for-propdef-spatial-navigation-action③">(3)</a> <a href="#ref-for-propdef-spatial-navigation-action④">(4)</a> <a href="#ref-for-propdef-spatial-navigation-action⑤">(5)</a> <a href="#ref-for-propdef-spatial-navigation-action⑥">(6)</a>
@@ -3804,8 +3804,8 @@ Navigation</a> <a href="#ref-for-propdef-spatial-navigation-action②">(2)</a> <
 Controlling the interaction with scrolling: the spatial-navigation-action property</a> <a href="#ref-for-propdef-spatial-navigation-action⑧">(2)</a> <a href="#ref-for-propdef-spatial-navigation-action⑨">(3)</a> <a href="#ref-for-propdef-spatial-navigation-action①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-spatial-navigation-action-auto">
-   <b><a href="#valdef-spatial-navigation-action-auto">#valdef-spatial-navigation-action-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-spatial-navigation-action-auto" class="dfn-panel" data-for="valdef-spatial-navigation-action-auto" id="infopanel-for-valdef-spatial-navigation-action-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-spatial-navigation-action-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-spatial-navigation-action-auto">#valdef-spatial-navigation-action-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-spatial-navigation-action-auto">8.3. 
 Navigation</a>
@@ -3813,8 +3813,8 @@ Navigation</a>
 Controlling the interaction with scrolling: the spatial-navigation-action property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-spatial-navigation-action-focus">
-   <b><a href="#valdef-spatial-navigation-action-focus">#valdef-spatial-navigation-action-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-spatial-navigation-action-focus" class="dfn-panel" data-for="valdef-spatial-navigation-action-focus" id="infopanel-for-valdef-spatial-navigation-action-focus" role="dialog">
+   <span id="infopaneltitle-for-valdef-spatial-navigation-action-focus" style="display:none">Info about the 'focus' definition.</span><b><a href="#valdef-spatial-navigation-action-focus">#valdef-spatial-navigation-action-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-spatial-navigation-action-focus">8.3. 
 Navigation</a> <a href="#ref-for-valdef-spatial-navigation-action-focus①">(2)</a> <a href="#ref-for-valdef-spatial-navigation-action-focus②">(3)</a> <a href="#ref-for-valdef-spatial-navigation-action-focus③">(4)</a>
@@ -3822,30 +3822,30 @@ Navigation</a> <a href="#ref-for-valdef-spatial-navigation-action-focus①">(2)<
 Controlling the interaction with scrolling: the spatial-navigation-action property</a> <a href="#ref-for-valdef-spatial-navigation-action-focus⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-spatial-navigation-action-scroll">
-   <b><a href="#valdef-spatial-navigation-action-scroll">#valdef-spatial-navigation-action-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-spatial-navigation-action-scroll" class="dfn-panel" data-for="valdef-spatial-navigation-action-scroll" id="infopanel-for-valdef-spatial-navigation-action-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-spatial-navigation-action-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-spatial-navigation-action-scroll">#valdef-spatial-navigation-action-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-spatial-navigation-action-scroll">8.3. 
 Navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-spatial-navigation-function">
-   <b><a href="#propdef-spatial-navigation-function">#propdef-spatial-navigation-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-spatial-navigation-function" class="dfn-panel" data-for="propdef-spatial-navigation-function" id="infopanel-for-propdef-spatial-navigation-function" role="dialog">
+   <span id="infopaneltitle-for-propdef-spatial-navigation-function" style="display:none">Info about the 'spatial-navigation-function' definition.</span><b><a href="#propdef-spatial-navigation-function">#propdef-spatial-navigation-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-spatial-navigation-function①">9.3. 
 Selecting the navigation algorithm: the spatial-navigation-function property</a>
     <li><a href="#ref-for-propdef-spatial-navigation-function②">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="can-be-manually-scrolled">
-   <b><a href="#can-be-manually-scrolled">#can-be-manually-scrolled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-can-be-manually-scrolled" class="dfn-panel" data-for="can-be-manually-scrolled" id="infopanel-for-can-be-manually-scrolled" role="dialog">
+   <span id="infopaneltitle-for-can-be-manually-scrolled" style="display:none">Info about the 'can be manually scrolled' definition.</span><b><a href="#can-be-manually-scrolled">#can-be-manually-scrolled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-can-be-manually-scrolled">8.3. 
 Navigation</a> <a href="#ref-for-can-be-manually-scrolled①">(2)</a> <a href="#ref-for-can-be-manually-scrolled②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directionally-scroll-an-element">
-   <b><a href="#directionally-scroll-an-element">#directionally-scroll-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directionally-scroll-an-element" class="dfn-panel" data-for="directionally-scroll-an-element" id="infopanel-for-directionally-scroll-an-element" role="dialog">
+   <span id="infopaneltitle-for-directionally-scroll-an-element" style="display:none">Info about the 'directionally scroll an element' definition.</span><b><a href="#directionally-scroll-an-element">#directionally-scroll-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directionally-scroll-an-element">8.3. 
 Navigation</a> <a href="#ref-for-directionally-scroll-an-element①">(2)</a> <a href="#ref-for-directionally-scroll-an-element②">(3)</a>
@@ -3855,59 +3855,115 @@ Controlling the interaction with scrolling: the spatial-navigation-action proper
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/csswg-drafts/css-nesting-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-nesting-1/Overview.html
@@ -1576,222 +1576,222 @@ return the result of the following steps:</p>
    <li><a href="#dom-cssnestingrule-selectortext">selectorText</a><span>, in § 4.2</span>
    <li><a href="#dom-cssnestingrule-style">style</a><span>, in § 4.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">3.4. Mixing Nesting Rules and Declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">2. Nesting Selector: the &amp; selector</a>
     <li><a href="#ref-for-propdef-color①">3.4. Mixing Nesting Rules and Declarations</a> <a href="#ref-for-propdef-color②">(2)</a> <a href="#ref-for-propdef-color③">(3)</a> <a href="#ref-for-propdef-color④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">3.2. The Nesting At-Rule: @nest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-cssomstring①">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-cssomstring②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrulelist">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrulelist">https://drafts.csswg.org/cssom-1/#cssrulelist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrulelist" class="dfn-panel" data-for="term-for-cssrulelist" id="infopanel-for-term-for-cssrulelist" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrulelist" style="display:none">Info about the 'CSSRuleList' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrulelist">https://drafts.csswg.org/cssom-1/#cssrulelist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrulelist">4.1. Modifications to CSSStyleRule</a> <a href="#ref-for-cssrulelist①">(2)</a>
     <li><a href="#ref-for-cssrulelist②">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-cssrulelist③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-cssstyledeclaration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstylerule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstylerule">https://drafts.csswg.org/cssom-1/#cssstylerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylerule" class="dfn-panel" data-for="term-for-cssstylerule" id="infopanel-for-term-for-cssstylerule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylerule" style="display:none">Info about the 'CSSStyleRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstylerule">https://drafts.csswg.org/cssom-1/#cssstylerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylerule">4.1. Modifications to CSSStyleRule</a> <a href="#ref-for-cssstylerule①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-rule-child-css-rules">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-rule-child-css-rules">https://drafts.csswg.org/cssom-1/#concept-css-rule-child-css-rules</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-rule-child-css-rules" class="dfn-panel" data-for="term-for-concept-css-rule-child-css-rules" id="infopanel-for-term-for-concept-css-rule-child-css-rules" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-rule-child-css-rules" style="display:none">Info about the 'child css rules' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-rule-child-css-rules">https://drafts.csswg.org/cssom-1/#concept-css-rule-child-css-rules</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-rule-child-css-rules">4.1. Modifications to CSSStyleRule</a> <a href="#ref-for-concept-css-rule-child-css-rules①">(2)</a> <a href="#ref-for-concept-css-rule-child-css-rules②">(3)</a>
     <li><a href="#ref-for-concept-css-rule-child-css-rules③">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-concept-css-rule-child-css-rules④">(2)</a> <a href="#ref-for-concept-css-rule-child-css-rules⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-computed-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-computed-flag">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-computed-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-computed-flag" class="dfn-panel" data-for="term-for-cssstyledeclaration-computed-flag" id="infopanel-for-term-for-cssstyledeclaration-computed-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-computed-flag" style="display:none">Info about the 'computed flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-computed-flag">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-computed-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-computed-flag">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-csstext">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cssstyledeclaration-csstext" class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-csstext" id="infopanel-for-term-for-dom-cssstyledeclaration-csstext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cssstyledeclaration-csstext" style="display:none">Info about the 'cssText' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-csstext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-csstext">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations" id="infopanel-for-term-for-cssstyledeclaration-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-insert-a-css-rule" class="dfn-panel" data-for="term-for-insert-a-css-rule" id="infopanel-for-term-for-insert-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-insert-a-css-rule" style="display:none">Info about the 'insert a css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-a-css-rule">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-insert-a-css-rule①">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node" id="infopanel-for-term-for-cssstyledeclaration-owner-node" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" style="display:none">Info about the 'owner node' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-owner-node">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-parent-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-parent-css-rule" class="dfn-panel" data-for="term-for-cssstyledeclaration-parent-css-rule" id="infopanel-for-term-for-cssstyledeclaration-parent-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-parent-css-rule" style="display:none">Info about the 'parent css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-parent-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-parent-css-rule">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-group-of-selectors" class="dfn-panel" data-for="term-for-parse-a-group-of-selectors" id="infopanel-for-term-for-parse-a-group-of-selectors" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-group-of-selectors" style="display:none">Info about the 'parse a group of selectors' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-group-of-selectors">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-remove-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#remove-a-css-rule">https://drafts.csswg.org/cssom-1/#remove-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-remove-a-css-rule" class="dfn-panel" data-for="term-for-remove-a-css-rule" id="infopanel-for-term-for-remove-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-remove-a-css-rule" style="display:none">Info about the 'remove a css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#remove-a-css-rule">https://drafts.csswg.org/cssom-1/#remove-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-a-css-rule">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-remove-a-css-rule①">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cssstylerule-selectortext">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-cssstylerule-selectortext">https://drafts.csswg.org/cssom-1/#dom-cssstylerule-selectortext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cssstylerule-selectortext" class="dfn-panel" data-for="term-for-dom-cssstylerule-selectortext" id="infopanel-for-term-for-dom-cssstylerule-selectortext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cssstylerule-selectortext" style="display:none">Info about the 'selectorText' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-cssstylerule-selectortext">https://drafts.csswg.org/cssom-1/#dom-cssstylerule-selectortext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-selectortext">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-css-declaration-block">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-css-declaration-block" class="dfn-panel" data-for="term-for-serialize-a-css-declaration-block" id="infopanel-for-term-for-serialize-a-css-declaration-block" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-css-declaration-block" style="display:none">Info about the 'serialize a css declaration block' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#serialize-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-declaration-block">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-rule">https://drafts.csswg.org/cssom-1/#serialize-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-css-rule" class="dfn-panel" data-for="term-for-serialize-a-css-rule" id="infopanel-for-term-for-serialize-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-css-rule" style="display:none">Info about the 'serialize a css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-rule">https://drafts.csswg.org/cssom-1/#serialize-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-rule">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-group-of-selectors">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#serialize-a-group-of-selectors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-group-of-selectors" class="dfn-panel" data-for="term-for-serialize-a-group-of-selectors" id="infopanel-for-term-for-serialize-a-group-of-selectors" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-group-of-selectors" style="display:none">Info about the 'serialize a group of selectors' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#serialize-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-group-of-selectors">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-serialize-a-group-of-selectors①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-declarations-specified-order">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order">https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-declarations-specified-order" class="dfn-panel" data-for="term-for-concept-declarations-specified-order" id="infopanel-for-term-for-concept-declarations-specified-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-declarations-specified-order" style="display:none">Info about the 'specified order' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order">https://drafts.csswg.org/cssom-1/#concept-declarations-specified-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-declarations-specified-order">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-matches-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-matches-pseudo" class="dfn-panel" data-for="term-for-matches-pseudo" id="infopanel-for-term-for-matches-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-matches-pseudo" style="display:none">Info about the ':is()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-pseudo">2. Nesting Selector: the &amp; selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-where-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#where-pseudo">https://drafts.csswg.org/selectors-4/#where-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-where-pseudo" class="dfn-panel" data-for="term-for-where-pseudo" id="infopanel-for-term-for-where-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-where-pseudo" style="display:none">Info about the ':where()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#where-pseudo">https://drafts.csswg.org/selectors-4/#where-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-where-pseudo">3.4. Mixing Nesting Rules and Declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-complex">
-   <a href="https://drafts.csswg.org/selectors-4/#complex">https://drafts.csswg.org/selectors-4/#complex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-complex" class="dfn-panel" data-for="term-for-complex" id="infopanel-for-term-for-complex" role="menu">
+   <span id="infopaneltitle-for-term-for-complex" style="display:none">Info about the 'complex selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#complex">https://drafts.csswg.org/selectors-4/#complex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complex">3.1. Direct Nesting</a>
     <li><a href="#ref-for-complex①">3.2. The Nesting At-Rule: @nest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compound">
-   <a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compound" class="dfn-panel" data-for="term-for-compound" id="infopanel-for-term-for-compound" role="menu">
+   <span id="infopaneltitle-for-term-for-compound" style="display:none">Info about the 'compound selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">2. Nesting Selector: the &amp; selector</a> <a href="#ref-for-compound①">(2)</a> <a href="#ref-for-compound②">(3)</a>
     <li><a href="#ref-for-compound③">3.1. Direct Nesting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selector-list">
-   <a href="https://drafts.csswg.org/selectors-4/#selector-list">https://drafts.csswg.org/selectors-4/#selector-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selector-list" class="dfn-panel" data-for="term-for-selector-list" id="infopanel-for-term-for-selector-list" role="menu">
+   <span id="infopaneltitle-for-term-for-selector-list" style="display:none">Info about the 'selector list' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selector-list">https://drafts.csswg.org/selectors-4/#selector-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector-list">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-selector-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-simple">
-   <a href="https://drafts.csswg.org/selectors-4/#simple">https://drafts.csswg.org/selectors-4/#simple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-simple" class="dfn-panel" data-for="term-for-simple" id="infopanel-for-term-for-simple" role="menu">
+   <span id="infopaneltitle-for-term-for-simple" style="display:none">Info about the 'simple selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#simple">https://drafts.csswg.org/selectors-4/#simple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple">3.1. Direct Nesting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specificity">
-   <a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specificity" class="dfn-panel" data-for="term-for-specificity" id="infopanel-for-term-for-specificity" role="menu">
+   <span id="infopaneltitle-for-term-for-specificity" style="display:none">Info about the 'specificity' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specificity">2. Nesting Selector: the &amp; selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type-selector" class="dfn-panel" data-for="term-for-type-selector" id="infopanel-for-term-for-type-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-type-selector" style="display:none">Info about the 'type selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">2. Nesting Selector: the &amp; selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-SameObject①">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-SameObject②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-idl-undefined①">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.1. Modifications to CSSStyleRule</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
     <li><a href="#ref-for-idl-unsigned-long③">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-idl-unsigned-long④">(2)</a> <a href="#ref-for-idl-unsigned-long⑤">(3)</a>
@@ -1901,8 +1901,8 @@ return the result of the following steps:</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="nesting-selector">
-   <b><a href="#nesting-selector">#nesting-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nesting-selector" class="dfn-panel" data-for="nesting-selector" id="infopanel-for-nesting-selector" role="dialog">
+   <span id="infopaneltitle-for-nesting-selector" style="display:none">Info about the 'nesting selector' definition.</span><b><a href="#nesting-selector">#nesting-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nesting-selector">2. Nesting Selector: the &amp; selector</a> <a href="#ref-for-nesting-selector①">(2)</a> <a href="#ref-for-nesting-selector②">(3)</a> <a href="#ref-for-nesting-selector③">(4)</a>
     <li><a href="#ref-for-nesting-selector④">3.1. Direct Nesting</a>
@@ -1911,34 +1911,34 @@ return the result of the following steps:</p>
     <li><a href="#ref-for-nesting-selector⑦">3.4. Mixing Nesting Rules and Declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-">
-   <b><a href="#selectordef-">#selectordef-</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-" class="dfn-panel" data-for="selectordef-" id="infopanel-for-selectordef-" role="dialog">
+   <span id="infopaneltitle-for-selectordef-" style="display:none">Info about the '&amp;' definition.</span><b><a href="#selectordef-">#selectordef-</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-">2. Nesting Selector: the &amp; selector</a> <a href="#ref-for-selectordef-①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nested-style-rule">
-   <b><a href="#nested-style-rule">#nested-style-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nested-style-rule" class="dfn-panel" data-for="nested-style-rule" id="infopanel-for-nested-style-rule" role="dialog">
+   <span id="infopaneltitle-for-nested-style-rule" style="display:none">Info about the 'nesting style rules' definition.</span><b><a href="#nested-style-rule">#nested-style-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-style-rule">2. Nesting Selector: the &amp; selector</a> <a href="#ref-for-nested-style-rule①">(2)</a>
     <li><a href="#ref-for-nested-style-rule②">3.4. Mixing Nesting Rules and Declarations</a> <a href="#ref-for-nested-style-rule③">(2)</a> <a href="#ref-for-nested-style-rule④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="direct-nesting">
-   <b><a href="#direct-nesting">#direct-nesting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-direct-nesting" class="dfn-panel" data-for="direct-nesting" id="infopanel-for-direct-nesting" role="dialog">
+   <span id="infopaneltitle-for-direct-nesting" style="display:none">Info about the 'directly nested' definition.</span><b><a href="#direct-nesting">#direct-nesting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-direct-nesting">3. Nesting Style Rules</a>
     <li><a href="#ref-for-direct-nesting①">3.2. The Nesting At-Rule: @nest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nest-prefixed">
-   <b><a href="#nest-prefixed">#nest-prefixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nest-prefixed" class="dfn-panel" data-for="nest-prefixed" id="infopanel-for-nest-prefixed" role="dialog">
+   <span id="infopaneltitle-for-nest-prefixed" style="display:none">Info about the 'nest-prefixed' definition.</span><b><a href="#nest-prefixed">#nest-prefixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nest-prefixed">3.1. Direct Nesting</a> <a href="#ref-for-nest-prefixed①">(2)</a> <a href="#ref-for-nest-prefixed②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-nest">
-   <b><a href="#at-ruledef-nest">#at-ruledef-nest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-nest" class="dfn-panel" data-for="at-ruledef-nest" id="infopanel-for-at-ruledef-nest" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-nest" style="display:none">Info about the '@nest' definition.</span><b><a href="#at-ruledef-nest">#at-ruledef-nest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-nest">3. Nesting Style Rules</a>
     <li><a href="#ref-for-at-ruledef-nest①">3.2. The Nesting At-Rule: @nest</a> <a href="#ref-for-at-ruledef-nest②">(2)</a> <a href="#ref-for-at-ruledef-nest③">(3)</a> <a href="#ref-for-at-ruledef-nest④">(4)</a>
@@ -1946,120 +1946,176 @@ return the result of the following steps:</p>
     <li><a href="#ref-for-at-ruledef-nest⑥">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nest-containing">
-   <b><a href="#nest-containing">#nest-containing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nest-containing" class="dfn-panel" data-for="nest-containing" id="infopanel-for-nest-containing" role="dialog">
+   <span id="infopaneltitle-for-nest-containing" style="display:none">Info about the 'nest-containing' definition.</span><b><a href="#nest-containing">#nest-containing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nest-containing">3.2. The Nesting At-Rule: @nest</a> <a href="#ref-for-nest-containing①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-cssrules">
-   <b><a href="#dom-cssstylerule-cssrules">#dom-cssstylerule-cssrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-cssrules" class="dfn-panel" data-for="dom-cssstylerule-cssrules" id="infopanel-for-dom-cssstylerule-cssrules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-cssrules" style="display:none">Info about the 'cssRules' definition.</span><b><a href="#dom-cssstylerule-cssrules">#dom-cssstylerule-cssrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-cssrules">4.1. Modifications to CSSStyleRule</a>
     <li><a href="#ref-for-dom-cssstylerule-cssrules①">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-insertrule">
-   <b><a href="#dom-cssstylerule-insertrule">#dom-cssstylerule-insertrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-insertrule" class="dfn-panel" data-for="dom-cssstylerule-insertrule" id="infopanel-for-dom-cssstylerule-insertrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-insertrule" style="display:none">Info about the 'insertRule(rule, index)' definition.</span><b><a href="#dom-cssstylerule-insertrule">#dom-cssstylerule-insertrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-insertrule">4.1. Modifications to CSSStyleRule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-deleterule">
-   <b><a href="#dom-cssstylerule-deleterule">#dom-cssstylerule-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-deleterule" class="dfn-panel" data-for="dom-cssstylerule-deleterule" id="infopanel-for-dom-cssstylerule-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-deleterule" style="display:none">Info about the 'deleteRule(index)' definition.</span><b><a href="#dom-cssstylerule-deleterule">#dom-cssstylerule-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-deleterule">4.1. Modifications to CSSStyleRule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnestingrule">
-   <b><a href="#cssnestingrule">#cssnestingrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnestingrule" class="dfn-panel" data-for="cssnestingrule" id="infopanel-for-cssnestingrule" role="dialog">
+   <span id="infopaneltitle-for-cssnestingrule" style="display:none">Info about the 'CSSNestingRule' definition.</span><b><a href="#cssnestingrule">#cssnestingrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnestingrule">4.2. The CSSNestingRule Interface</a> <a href="#ref-for-cssnestingrule①">(2)</a> <a href="#ref-for-cssnestingrule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnestingrule-selectortext">
-   <b><a href="#dom-cssnestingrule-selectortext">#dom-cssnestingrule-selectortext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnestingrule-selectortext" class="dfn-panel" data-for="dom-cssnestingrule-selectortext" id="infopanel-for-dom-cssnestingrule-selectortext" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnestingrule-selectortext" style="display:none">Info about the 'selectorText' definition.</span><b><a href="#dom-cssnestingrule-selectortext">#dom-cssnestingrule-selectortext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnestingrule-selectortext">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnestingrule-style">
-   <b><a href="#dom-cssnestingrule-style">#dom-cssnestingrule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnestingrule-style" class="dfn-panel" data-for="dom-cssnestingrule-style" id="infopanel-for-dom-cssnestingrule-style" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnestingrule-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-cssnestingrule-style">#dom-cssnestingrule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnestingrule-style">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnestingrule-cssrules">
-   <b><a href="#dom-cssnestingrule-cssrules">#dom-cssnestingrule-cssrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnestingrule-cssrules" class="dfn-panel" data-for="dom-cssnestingrule-cssrules" id="infopanel-for-dom-cssnestingrule-cssrules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnestingrule-cssrules" style="display:none">Info about the 'cssRules' definition.</span><b><a href="#dom-cssnestingrule-cssrules">#dom-cssnestingrule-cssrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnestingrule-cssrules">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnestingrule-insertrule">
-   <b><a href="#dom-cssnestingrule-insertrule">#dom-cssnestingrule-insertrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnestingrule-insertrule" class="dfn-panel" data-for="dom-cssnestingrule-insertrule" id="infopanel-for-dom-cssnestingrule-insertrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnestingrule-insertrule" style="display:none">Info about the 'insertRule(rule, index)' definition.</span><b><a href="#dom-cssnestingrule-insertrule">#dom-cssnestingrule-insertrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnestingrule-insertrule">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnestingrule-deleterule">
-   <b><a href="#dom-cssnestingrule-deleterule">#dom-cssnestingrule-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnestingrule-deleterule" class="dfn-panel" data-for="dom-cssnestingrule-deleterule" id="infopanel-for-dom-cssnestingrule-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnestingrule-deleterule" style="display:none">Info about the 'deleteRule(index)' definition.</span><b><a href="#dom-cssnestingrule-deleterule">#dom-cssnestingrule-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnestingrule-deleterule">4.2. The CSSNestingRule Interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overflow-3/Overview.html
@@ -2721,29 +2721,29 @@ but other possibilities were raised. <a href="https://github.com/w3c/csswg-draft
    <li><a href="#valdef-continue--webkit-discard">-webkit-discard</a><span>, in § 5.1.1</span>
    <li><a href="#propdef--webkit-line-clamp">-webkit-line-clamp</a><span>, in § 5.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex--webkit-box">
-   <a href="https://compat.spec.whatwg.org/#valdef-flex--webkit-box">https://compat.spec.whatwg.org/#valdef-flex--webkit-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex--webkit-box" class="dfn-panel" data-for="term-for-valdef-flex--webkit-box" id="infopanel-for-term-for-valdef-flex--webkit-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex--webkit-box" style="display:none">Info about the '-webkit-box' external reference.</span><a href="https://compat.spec.whatwg.org/#valdef-flex--webkit-box">https://compat.spec.whatwg.org/#valdef-flex--webkit-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex--webkit-box">5.1.1. 
 Legacy compatibility</a> <a href="#ref-for-valdef-flex--webkit-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef--webkit-box-orient">
-   <a href="https://compat.spec.whatwg.org/#propdef--webkit-box-orient">https://compat.spec.whatwg.org/#propdef--webkit-box-orient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef--webkit-box-orient" class="dfn-panel" data-for="term-for-propdef--webkit-box-orient" id="infopanel-for-term-for-propdef--webkit-box-orient" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef--webkit-box-orient" style="display:none">Info about the '-webkit-box-orient' external reference.</span><a href="https://compat.spec.whatwg.org/#propdef--webkit-box-orient">https://compat.spec.whatwg.org/#propdef--webkit-box-orient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-box-orient">5.1.1. 
 Legacy compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex--webkit-inline-box">
-   <a href="https://compat.spec.whatwg.org/#valdef-flex--webkit-inline-box">https://compat.spec.whatwg.org/#valdef-flex--webkit-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex--webkit-inline-box" class="dfn-panel" data-for="term-for-valdef-flex--webkit-inline-box" id="infopanel-for-term-for-valdef-flex--webkit-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex--webkit-inline-box" style="display:none">Info about the '-webkit-inline-box' external reference.</span><a href="https://compat.spec.whatwg.org/#valdef-flex--webkit-inline-box">https://compat.spec.whatwg.org/#valdef-flex--webkit-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex--webkit-inline-box">5.1.1. 
 Legacy compatibility</a> <a href="#ref-for-valdef-flex--webkit-inline-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">2.2. 
 Scrollable Overflow</a>
@@ -2751,15 +2751,15 @@ Scrollable Overflow</a>
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-distribution-properties">
-   <a href="https://drafts.csswg.org/css-align-3/#content-distribution-properties">https://drafts.csswg.org/css-align-3/#content-distribution-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-distribution-properties" class="dfn-panel" data-for="term-for-content-distribution-properties" id="infopanel-for-term-for-content-distribution-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-content-distribution-properties" style="display:none">Info about the 'content-distribution properties' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#content-distribution-properties">https://drafts.csswg.org/css-align-3/#content-distribution-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-distribution-properties">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">2.2. 
 Scrollable Overflow</a>
@@ -2767,100 +2767,100 @@ Scrollable Overflow</a>
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-content-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-content-normal" class="dfn-panel" data-for="term-for-valdef-justify-content-normal" id="infopanel-for-term-for-valdef-justify-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-content-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal">https://drafts.csswg.org/css-align-3/#valdef-justify-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-content-normal">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-place-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-place-content" class="dfn-panel" data-for="term-for-propdef-place-content" id="infopanel-for-term-for-propdef-place-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-place-content" style="display:none">Info about the 'place-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-place-content">https://drafts.csswg.org/css-align-3/#propdef-place-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-place-content">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">2.1. Ink Overflow</a>
     <li><a href="#ref-for-propdef-box-shadow①">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-clip-padding-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-padding-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-padding-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-clip-padding-box" class="dfn-panel" data-for="term-for-valdef-background-clip-padding-box" id="infopanel-for-term-for-valdef-background-clip-padding-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-clip-padding-box" style="display:none">Info about the 'padding-box' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-padding-box">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-clip-padding-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-clip-padding-box">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-visual-box">
-   <a href="https://drafts.csswg.org/css-box-4/#typedef-visual-box">https://drafts.csswg.org/css-box-4/#typedef-visual-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-visual-box" class="dfn-panel" data-for="term-for-typedef-visual-box" id="infopanel-for-term-for-typedef-visual-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-visual-box" style="display:none">Info about the '&lt;visual-box>' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#typedef-visual-box">https://drafts.csswg.org/css-box-4/#typedef-visual-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-visual-box">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a> <a href="#ref-for-typedef-visual-box①">(2)</a> <a href="#ref-for-typedef-visual-box②">(3)</a> <a href="#ref-for-typedef-visual-box③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-edge" class="dfn-panel" data-for="term-for-padding-edge" id="infopanel-for-term-for-padding-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-edge" style="display:none">Info about the 'padding edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">3.3. 
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">5.3. 
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-forced-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-break">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-break" class="dfn-panel" data-for="term-for-fragmentation-break" id="infopanel-for-term-for-fragmentation-break" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">5.3. 
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-fragmentation-break①">(2)</a> <a href="#ref-for-fragmentation-break②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-fragmentation-container①">(2)</a>
@@ -2870,29 +2870,29 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a> <a href=
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-fragmentation-container⑥">(2)</a> <a href="#ref-for-fragmentation-container⑦">(3)</a> <a href="#ref-for-fragmentation-container⑧">(4)</a> <a href="#ref-for-fragmentation-container⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-direction">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-direction">https://drafts.csswg.org/css-break-4/#fragmentation-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-direction" class="dfn-panel" data-for="term-for-fragmentation-direction" id="infopanel-for-term-for-fragmentation-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-direction" style="display:none">Info about the 'fragmentation direction' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-direction">https://drafts.csswg.org/css-break-4/#fragmentation-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-direction">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmented-flow">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmented-flow">https://drafts.csswg.org/css-break-4/#fragmented-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmented-flow" class="dfn-panel" data-for="term-for-fragmented-flow" id="infopanel-for-term-for-fragmented-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmented-flow">https://drafts.csswg.org/css-break-4/#fragmented-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">5.3. 
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-fragmented-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-region-break">
-   <a href="https://drafts.csswg.org/css-break-4/#region-break">https://drafts.csswg.org/css-break-4/#region-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-region-break" class="dfn-panel" data-for="term-for-region-break" id="infopanel-for-term-for-region-break" role="menu">
+   <span id="infopaneltitle-for-term-for-region-break" style="display:none">Info about the 'region break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#region-break">https://drafts.csswg.org/css-break-4/#region-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-break">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-region-break①">(2)</a> <a href="#ref-for-region-break②">(3)</a>
@@ -2902,43 +2902,43 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a> <a href=
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-region-break⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unforced-break">
-   <a href="https://drafts.csswg.org/css-break-4/#unforced-break">https://drafts.csswg.org/css-break-4/#unforced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unforced-break" class="dfn-panel" data-for="term-for-unforced-break" id="infopanel-for-term-for-unforced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-unforced-break" style="display:none">Info about the 'unforced break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#unforced-break">https://drafts.csswg.org/css-break-4/#unforced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unforced-break">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-widows">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-widows" class="dfn-panel" data-for="term-for-propdef-widows" id="infopanel-for-term-for-propdef-widows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-widows" style="display:none">Info about the 'widows' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.2. 
 Scrollable Overflow</a>
@@ -2950,22 +2950,22 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">2. 
 Types of Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -2977,8 +2977,8 @@ Legacy compatibility</a> <a href="#ref-for-propdef-display④">(2)</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establish an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -2988,8 +2988,8 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context①" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context①" style="display:none">Info about the 'establishes an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -2999,57 +2999,57 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a> <a href="#ref-for-independent-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-item">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-item" class="dfn-panel" data-for="term-for-grid-item" id="infopanel-for-term-for-grid-item" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-item" style="display:none">Info about the 'grid item' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">2.2. 
 Scrollable Overflow</a> <a href="#ref-for-propdef-clip①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
@@ -3057,8 +3057,8 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-multi-column-container②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container①" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container①" style="display:none">Info about the 'multicol container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
@@ -3066,31 +3066,31 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-multi-column-container②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow-columns">
-   <a href="https://drafts.csswg.org/css-multicol-1/#overflow-columns">https://drafts.csswg.org/css-multicol-1/#overflow-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow-columns" class="dfn-panel" data-for="term-for-overflow-columns" id="infopanel-for-term-for-overflow-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow-columns" style="display:none">Info about the 'overflow columns' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#overflow-columns">https://drafts.csswg.org/css-multicol-1/#overflow-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-columns">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
     <li><a href="#ref-for-selectordef-first-letter①"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
     <li><a href="#ref-for-selectordef-first-line①"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
@@ -3098,8 +3098,8 @@ Indicating Block-Axis Overflow: the block-ellipsis property</a>
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-max-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content①" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content①" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
@@ -3107,70 +3107,70 @@ Indicating Block-Axis Overflow: the block-ellipsis property</a>
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-max-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-inline-size" class="dfn-panel" data-for="term-for-min-content-inline-size" id="infopanel-for-term-for-min-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-inline-size" style="display:none">Info about the 'min-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-inline-size">5.3. 
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-min-content-inline-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-ignored">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-ignored">https://drafts.csswg.org/css-syntax-3/#css-ignored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-ignored" class="dfn-panel" data-for="term-for-css-ignored" id="infopanel-for-term-for-css-ignored" role="menu">
+   <span id="infopaneltitle-for-term-for-css-ignored" style="display:none">Info about the 'ignored' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-ignored">https://drafts.csswg.org/css-syntax-3/#css-ignored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-ignored">5.2. 
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-wrap">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap">https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-wrap" class="dfn-panel" data-for="term-for-propdef-overflow-wrap" id="infopanel-for-term-for-propdef-overflow-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-wrap" style="display:none">Info about the 'overflow-wrap' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap">https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-wrap">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-soft-wrap-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-soft-wrap-opportunity" class="dfn-panel" data-for="term-for-soft-wrap-opportunity" id="infopanel-for-term-for-soft-wrap-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-soft-wrap-opportunity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">2.1. Ink Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-3d-rendering-context">
-   <a href="https://drafts.csswg.org/css-transforms-2/#3d-rendering-context">https://drafts.csswg.org/css-transforms-2/#3d-rendering-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-3d-rendering-context" class="dfn-panel" data-for="term-for-3d-rendering-context" id="infopanel-for-term-for-3d-rendering-context" role="menu">
+   <span id="infopaneltitle-for-term-for-3d-rendering-context" style="display:none">Info about the '3d rendering context' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#3d-rendering-context">https://drafts.csswg.org/css-transforms-2/#3d-rendering-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3d-rendering-context">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-style">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-style" class="dfn-panel" data-for="term-for-propdef-transform-style" id="infopanel-for-term-for-propdef-transform-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-style" style="display:none">Info about the 'transform-style' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-style">2. 
 Types of Overflow</a> <a href="#ref-for-propdef-transform-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a>
@@ -3180,43 +3180,43 @@ Legacy compatibility</a>
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a>
@@ -3232,41 +3232,41 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">user interaction with ellipsis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-left" class="dfn-panel" data-for="term-for-physical-left" id="infopanel-for-term-for-physical-left" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-left">user interaction with ellipsis</a> <a href="#ref-for-physical-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">2.2. 
 Scrollable Overflow</a>
@@ -3274,22 +3274,22 @@ Scrollable Overflow</a>
 Scrolling Origin, Direction, and Restriction</a> <a href="#ref-for-block-start②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">4.1. 
     Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-css-end①">(2)</a> <a href="#ref-for-css-end②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">2.2. 
 Scrollable Overflow</a>
@@ -3297,15 +3297,15 @@ Scrollable Overflow</a>
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-writing-mode" class="dfn-panel" data-for="term-for-principal-writing-mode" id="infopanel-for-term-for-principal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">3.3. 
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3.3. 
 Scrolling Origin, Direction, and Restriction</a>
@@ -3313,71 +3313,71 @@ Scrolling Origin, Direction, and Restriction</a>
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">3.6. 
 Flow Relative Properties: the overflow-block and overflow-inline properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-positioned-element">
-   <a href="https://www.w3.org/TR/CSS22/visuren.html#positioned-element">https://www.w3.org/TR/CSS22/visuren.html#positioned-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-positioned-element" class="dfn-panel" data-for="term-for-positioned-element" id="infopanel-for-term-for-positioned-element" role="menu">
+   <span id="infopaneltitle-for-term-for-positioned-element" style="display:none">Info about the 'positioned' external reference.</span><a href="https://www.w3.org/TR/CSS22/visuren.html#positioned-element">https://www.w3.org/TR/CSS22/visuren.html#positioned-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positioned-element">5.3. 
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strut-element">
-   <a href="https://www.w3.org/TR/CSS22/visudet.html#strut-element">https://www.w3.org/TR/CSS22/visudet.html#strut-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strut-element" class="dfn-panel" data-for="term-for-strut-element" id="infopanel-for-term-for-strut-element" role="menu">
+   <span id="infopaneltitle-for-term-for-strut-element" style="display:none">Info about the 'strut' external reference.</span><a href="https://www.w3.org/TR/CSS22/visudet.html#strut-element">https://www.w3.org/TR/CSS22/visudet.html#strut-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strut-element">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-propdef-line-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-print">
-   <a href="https://drafts.csswg.org/css2/#valdef-media-print">https://drafts.csswg.org/css2/#valdef-media-print</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-print" class="dfn-panel" data-for="term-for-valdef-media-print" id="infopanel-for-term-for-valdef-media-print" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-print" style="display:none">Info about the 'print' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-media-print">https://drafts.csswg.org/css2/#valdef-media-print</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-print">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">2.2. 
 Scrollable Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-viewport">
-   <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-viewport">https://w3c.github.io/epub-specs/epub33/core/#dfn-viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-viewport" class="dfn-panel" data-for="term-for-dfn-viewport" id="infopanel-for-term-for-dfn-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-viewport">https://w3c.github.io/epub-specs/epub33/core/#dfn-viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-viewport">3.5. 
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">3.5. 
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-html-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-html-element" class="dfn-panel" data-for="term-for-the-html-element" id="infopanel-for-term-for-the-html-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-html-element" style="display:none">Info about the 'html' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-html-element">3.5. 
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">3.1. 
 Overflow in Print and Other Static Media</a>
@@ -3855,8 +3855,8 @@ Once it is sufficiently stable in this specification, <code>region-fragment</cod
 Discussions in the <a href="https://lists.w3.org/Archives/Public/www-style/2018Jul/0030.html">Sydney F2F meeting</a> seemed to generally converge on this,
 but other possibilities were raised. <a href="https://github.com/w3c/csswg-drafts/issues/2971">[Issue #2971]</a> <a class="issue-return" href="#issue-02656350" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="overflow">
-   <b><a href="#overflow">#overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow" class="dfn-panel" data-for="overflow" id="infopanel-for-overflow" role="dialog">
+   <span id="infopaneltitle-for-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#overflow">#overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow">2. 
 Types of Overflow</a> <a href="#ref-for-overflow①">(2)</a>
@@ -3864,8 +3864,8 @@ Types of Overflow</a> <a href="#ref-for-overflow①">(2)</a>
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a> <a href="#ref-for-overflow③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ink-overflow">
-   <b><a href="#ink-overflow">#ink-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ink-overflow" class="dfn-panel" data-for="ink-overflow" id="infopanel-for-ink-overflow" role="dialog">
+   <span id="infopaneltitle-for-ink-overflow" style="display:none">Info about the 'ink overflow' definition.</span><b><a href="#ink-overflow">#ink-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">2. 
 Types of Overflow</a>
@@ -3874,20 +3874,20 @@ Types of Overflow</a>
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ink-overflow-region">
-   <b><a href="#ink-overflow-region">#ink-overflow-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ink-overflow-region" class="dfn-panel" data-for="ink-overflow-region" id="infopanel-for-ink-overflow-region" role="dialog">
+   <span id="infopaneltitle-for-ink-overflow-region" style="display:none">Info about the 'ink overflow area' definition.</span><b><a href="#ink-overflow-region">#ink-overflow-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow-region">2.1. Ink Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ink-overflow-rectangle">
-   <b><a href="#ink-overflow-rectangle">#ink-overflow-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ink-overflow-rectangle" class="dfn-panel" data-for="ink-overflow-rectangle" id="infopanel-for-ink-overflow-rectangle" role="dialog">
+   <span id="infopaneltitle-for-ink-overflow-rectangle" style="display:none">Info about the 'ink overflow rectangle' definition.</span><b><a href="#ink-overflow-rectangle">#ink-overflow-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow-rectangle">2.1. Ink Overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrollable-overflow">
-   <b><a href="#scrollable-overflow">#scrollable-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrollable-overflow" class="dfn-panel" data-for="scrollable-overflow" id="infopanel-for-scrollable-overflow" role="dialog">
+   <span id="infopaneltitle-for-scrollable-overflow" style="display:none">Info about the 'scrollable overflow' definition.</span><b><a href="#scrollable-overflow">#scrollable-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow">2. 
 Types of Overflow</a>
@@ -3901,8 +3901,8 @@ Scrolling Origin, Direction, and Restriction</a>
 Indicating Block-Axis Overflow: the block-ellipsis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrollable-overflow-region">
-   <b><a href="#scrollable-overflow-region">#scrollable-overflow-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrollable-overflow-region" class="dfn-panel" data-for="scrollable-overflow-region" id="infopanel-for-scrollable-overflow-region" role="dialog">
+   <span id="infopaneltitle-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow area' definition.</span><b><a href="#scrollable-overflow-region">#scrollable-overflow-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">2.1. Ink Overflow</a>
     <li><a href="#ref-for-scrollable-overflow-region①">2.2. 
@@ -3913,15 +3913,15 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Scrolling Origin, Direction, and Restriction</a> <a href="#ref-for-scrollable-overflow-region⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrollable-overflow-rectangle">
-   <b><a href="#scrollable-overflow-rectangle">#scrollable-overflow-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrollable-overflow-rectangle" class="dfn-panel" data-for="scrollable-overflow-rectangle" id="infopanel-for-scrollable-overflow-rectangle" role="dialog">
+   <span id="infopaneltitle-for-scrollable-overflow-rectangle" style="display:none">Info about the 'scrollable overflow rectangle' definition.</span><b><a href="#scrollable-overflow-rectangle">#scrollable-overflow-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-rectangle">2.2. 
 Scrollable Overflow</a> <a href="#ref-for-scrollable-overflow-rectangle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-container">
-   <b><a href="#scroll-container">#scroll-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-container" class="dfn-panel" data-for="scroll-container" id="infopanel-for-scroll-container" role="dialog">
+   <span id="infopaneltitle-for-scroll-container" style="display:none">Info about the 'scroll container' definition.</span><b><a href="#scroll-container">#scroll-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">2.2. 
 Scrollable Overflow</a>
@@ -3933,15 +3933,15 @@ Overflow in Print and Other Static Media</a>
 Scrolling Origin, Direction, and Restriction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrollport">
-   <b><a href="#scrollport">#scrollport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrollport" class="dfn-panel" data-for="scrollport" id="infopanel-for-scrollport" role="dialog">
+   <span id="infopaneltitle-for-scrollport" style="display:none">Info about the 'scrollport' definition.</span><b><a href="#scrollport">#scrollport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-x">
-   <b><a href="#propdef-overflow-x">#propdef-overflow-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-x" class="dfn-panel" data-for="propdef-overflow-x" id="infopanel-for-propdef-overflow-x" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' definition.</span><b><a href="#propdef-overflow-x">#propdef-overflow-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">1. 
 Introduction</a>
@@ -3951,8 +3951,8 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Flow Relative Properties: the overflow-block and overflow-inline properties</a> <a href="#ref-for-propdef-overflow-x⑥">(2)</a> <a href="#ref-for-propdef-overflow-x⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-y">
-   <b><a href="#propdef-overflow-y">#propdef-overflow-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-y" class="dfn-panel" data-for="propdef-overflow-y" id="infopanel-for-propdef-overflow-y" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' definition.</span><b><a href="#propdef-overflow-y">#propdef-overflow-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">1. 
 Introduction</a>
@@ -3962,8 +3962,8 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Flow Relative Properties: the overflow-block and overflow-inline properties</a> <a href="#ref-for-propdef-overflow-y⑥">(2)</a> <a href="#ref-for-propdef-overflow-y⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow">
-   <b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow" class="dfn-panel" data-for="propdef-overflow" id="infopanel-for-propdef-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow③">1. 
 Introduction</a>
@@ -3985,8 +3985,8 @@ Flow Relative Properties: the overflow-block and overflow-inline properties</a>
 Fragmentation of Overflow: the continue property</a> <a href="#ref-for-propdef-overflow②①">(2)</a> <a href="#ref-for-propdef-overflow②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-visible">
-   <b><a href="#valdef-overflow-visible">#valdef-overflow-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-visible" class="dfn-panel" data-for="valdef-overflow-visible" id="infopanel-for-valdef-overflow-visible" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-visible" style="display:none">Info about the 'visible' definition.</span><b><a href="#valdef-overflow-visible">#valdef-overflow-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a> <a href="#ref-for-valdef-overflow-visible①">(2)</a> <a href="#ref-for-valdef-overflow-visible②">(3)</a> <a href="#ref-for-valdef-overflow-visible③">(4)</a>
@@ -3996,8 +3996,8 @@ Overflow Viewport Propagation</a> <a href="#ref-for-valdef-overflow-visible⑤">
     Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-hidden">
-   <b><a href="#valdef-overflow-hidden">#valdef-overflow-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-hidden" class="dfn-panel" data-for="valdef-overflow-hidden" id="infopanel-for-valdef-overflow-hidden" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#valdef-overflow-hidden">#valdef-overflow-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a> <a href="#ref-for-valdef-overflow-hidden①">(2)</a> <a href="#ref-for-valdef-overflow-hidden②">(3)</a>
@@ -4007,8 +4007,8 @@ Overflow in Print and Other Static Media</a>
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-clip">
-   <b><a href="#valdef-overflow-clip">#valdef-overflow-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-clip" class="dfn-panel" data-for="valdef-overflow-clip" id="infopanel-for-valdef-overflow-clip" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-clip" style="display:none">Info about the 'clip' definition.</span><b><a href="#valdef-overflow-clip">#valdef-overflow-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">1. 
 Introduction</a>
@@ -4018,8 +4018,8 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-scroll">
-   <b><a href="#valdef-overflow-scroll">#valdef-overflow-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-scroll" class="dfn-panel" data-for="valdef-overflow-scroll" id="infopanel-for-valdef-overflow-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-overflow-scroll">#valdef-overflow-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -4027,8 +4027,8 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Overflow in Print and Other Static Media</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-auto">
-   <b><a href="#valdef-overflow-auto">#valdef-overflow-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-auto" class="dfn-panel" data-for="valdef-overflow-auto" id="infopanel-for-valdef-overflow-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-overflow-auto">#valdef-overflow-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -4038,16 +4038,16 @@ Overflow in Print and Other Static Media</a>
 Overflow Viewport Propagation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-clip-margin">
-   <b><a href="#propdef-overflow-clip-margin">#propdef-overflow-clip-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-clip-margin" class="dfn-panel" data-for="propdef-overflow-clip-margin" id="infopanel-for-propdef-overflow-clip-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-clip-margin" style="display:none">Info about the 'overflow-clip-margin' definition.</span><b><a href="#propdef-overflow-clip-margin">#propdef-overflow-clip-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-clip-margin②">3.4. 
 Expanding Clipping Bounds: the overflow-clip-margin property</a>
     <li><a href="#ref-for-propdef-overflow-clip-margin③"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overflow-clip-edge">
-   <b><a href="#overflow-clip-edge">#overflow-clip-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow-clip-edge" class="dfn-panel" data-for="overflow-clip-edge" id="infopanel-for-overflow-clip-edge" role="dialog">
+   <span id="infopaneltitle-for-overflow-clip-edge" style="display:none">Info about the 'overflow clip edge' definition.</span><b><a href="#overflow-clip-edge">#overflow-clip-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-clip-edge">3. 
 Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow properties</a>
@@ -4055,22 +4055,22 @@ Scrolling and Clipping Overflow: the overflow-x, overflow-y, and overflow proper
 Expanding Clipping Bounds: the overflow-clip-margin property</a> <a href="#ref-for-overflow-clip-edge②">(2)</a> <a href="#ref-for-overflow-clip-edge③">(3)</a> <a href="#ref-for-overflow-clip-edge④">(4)</a> <a href="#ref-for-overflow-clip-edge⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-inline">
-   <b><a href="#propdef-overflow-inline">#propdef-overflow-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-inline" class="dfn-panel" data-for="propdef-overflow-inline" id="infopanel-for-propdef-overflow-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-inline" style="display:none">Info about the 'overflow-inline' definition.</span><b><a href="#propdef-overflow-inline">#propdef-overflow-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-inline">3.6. 
 Flow Relative Properties: the overflow-block and overflow-inline properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-block">
-   <b><a href="#propdef-overflow-block">#propdef-overflow-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-block" class="dfn-panel" data-for="propdef-overflow-block" id="infopanel-for-propdef-overflow-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-block" style="display:none">Info about the 'overflow-block' definition.</span><b><a href="#propdef-overflow-block">#propdef-overflow-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-block">3.6. 
 Flow Relative Properties: the overflow-block and overflow-inline properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-overflow">
-   <b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-overflow" class="dfn-panel" data-for="propdef-text-overflow" id="infopanel-for-propdef-text-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' definition.</span><b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow②">1. 
 Introduction</a> <a href="#ref-for-propdef-text-overflow③">(2)</a>
@@ -4083,8 +4083,8 @@ Indicating Block-Axis Overflow: the block-ellipsis property</a>
     <li><a href="#ref-for-propdef-text-overflow⑨"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-ellipsis">
-   <b><a href="#propdef-block-ellipsis">#propdef-block-ellipsis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-ellipsis" class="dfn-panel" data-for="propdef-block-ellipsis" id="infopanel-for-propdef-block-ellipsis" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-ellipsis" style="display:none">Info about the 'block-ellipsis' definition.</span><b><a href="#propdef-block-ellipsis">#propdef-block-ellipsis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-ellipsis">1. 
 Introduction</a>
@@ -4097,16 +4097,16 @@ Legacy compatibility</a> <a href="#ref-for-propdef-block-ellipsis⑨">(2)</a> <a
     <li><a href="#ref-for-propdef-block-ellipsis①①"> Changes from the 2018-07-31 Working Draft </a> <a href="#ref-for-propdef-block-ellipsis①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-overflow-ellipsis">
-   <b><a href="#block-overflow-ellipsis">#block-overflow-ellipsis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-overflow-ellipsis" class="dfn-panel" data-for="block-overflow-ellipsis" id="infopanel-for-block-overflow-ellipsis" role="dialog">
+   <span id="infopaneltitle-for-block-overflow-ellipsis" style="display:none">Info about the 'block overflow ellipsis' definition.</span><b><a href="#block-overflow-ellipsis">#block-overflow-ellipsis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-overflow-ellipsis">4.2. 
 Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-for-block-overflow-ellipsis①">(2)</a> <a href="#ref-for-block-overflow-ellipsis②">(3)</a> <a href="#ref-for-block-overflow-ellipsis③">(4)</a> <a href="#ref-for-block-overflow-ellipsis④">(5)</a> <a href="#ref-for-block-overflow-ellipsis⑤">(6)</a> <a href="#ref-for-block-overflow-ellipsis⑥">(7)</a> <a href="#ref-for-block-overflow-ellipsis⑦">(8)</a> <a href="#ref-for-block-overflow-ellipsis⑧">(9)</a> <a href="#ref-for-block-overflow-ellipsis⑨">(10)</a> <a href="#ref-for-block-overflow-ellipsis①⓪">(11)</a> <a href="#ref-for-block-overflow-ellipsis①①">(12)</a> <a href="#ref-for-block-overflow-ellipsis①②">(13)</a>
     <li><a href="#ref-for-block-overflow-ellipsis①③"> Changes from the 2018-07-31 Working Draft </a> <a href="#ref-for-block-overflow-ellipsis①④">(2)</a> <a href="#ref-for-block-overflow-ellipsis①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-ellipsis-none">
-   <b><a href="#valdef-block-ellipsis-none">#valdef-block-ellipsis-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-ellipsis-none" class="dfn-panel" data-for="valdef-block-ellipsis-none" id="infopanel-for-valdef-block-ellipsis-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-ellipsis-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-block-ellipsis-none">#valdef-block-ellipsis-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-ellipsis-none">3.5. 
 Overflow Viewport Propagation</a> <a href="#ref-for-valdef-block-ellipsis-none①">(2)</a>
@@ -4116,8 +4116,8 @@ Indicating Block-Axis Overflow: the block-ellipsis property</a> <a href="#ref-fo
 Limiting Visible Lines: the line-clamp shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-ellipsis-auto">
-   <b><a href="#valdef-block-ellipsis-auto">#valdef-block-ellipsis-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-ellipsis-auto" class="dfn-panel" data-for="valdef-block-ellipsis-auto" id="infopanel-for-valdef-block-ellipsis-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-ellipsis-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-block-ellipsis-auto">#valdef-block-ellipsis-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-ellipsis-auto">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
@@ -4125,8 +4125,8 @@ Limiting Visible Lines: the line-clamp shorthand property</a>
 Legacy compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-clamp">
-   <b><a href="#propdef-line-clamp">#propdef-line-clamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-clamp" class="dfn-panel" data-for="propdef-line-clamp" id="infopanel-for-propdef-line-clamp" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-clamp" style="display:none">Info about the 'line-clamp' definition.</span><b><a href="#propdef-line-clamp">#propdef-line-clamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-clamp②">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a> <a href="#ref-for-propdef-line-clamp③">(2)</a>
@@ -4136,30 +4136,30 @@ Legacy compatibility</a> <a href="#ref-for-propdef-line-clamp⑤">(2)</a>
 Forcing a Break After a Set Number of Lines: the max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-clamp-none">
-   <b><a href="#valdef-line-clamp-none">#valdef-line-clamp-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-clamp-none" class="dfn-panel" data-for="valdef-line-clamp-none" id="infopanel-for-valdef-line-clamp-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-clamp-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-line-clamp-none">#valdef-line-clamp-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-clamp-none">5.1.1. 
 Legacy compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef--webkit-line-clamp">
-   <b><a href="#propdef--webkit-line-clamp">#propdef--webkit-line-clamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-line-clamp" class="dfn-panel" data-for="propdef--webkit-line-clamp" id="infopanel-for-propdef--webkit-line-clamp" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-line-clamp" style="display:none">Info about the '-webkit-line-clamp' definition.</span><b><a href="#propdef--webkit-line-clamp">#propdef--webkit-line-clamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-line-clamp">5.1.1. 
 Legacy compatibility</a>
     <li><a href="#ref-for-propdef--webkit-line-clamp①"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue--webkit-discard">
-   <b><a href="#valdef-continue--webkit-discard">#valdef-continue--webkit-discard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue--webkit-discard" class="dfn-panel" data-for="valdef-continue--webkit-discard" id="infopanel-for-valdef-continue--webkit-discard" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue--webkit-discard" style="display:none">Info about the '-webkit-discard' definition.</span><b><a href="#valdef-continue--webkit-discard">#valdef-continue--webkit-discard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue--webkit-discard">5.1.1. 
 Legacy compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-lines">
-   <b><a href="#propdef-max-lines">#propdef-max-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-lines" class="dfn-panel" data-for="propdef-max-lines" id="infopanel-for-propdef-max-lines" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-lines" style="display:none">Info about the 'max-lines' definition.</span><b><a href="#propdef-max-lines">#propdef-max-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-lines①">1. 
 Introduction</a>
@@ -4173,8 +4173,8 @@ Forcing a Break After a Set Number of Lines: the max-lines property</a> <a href=
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-max-lines-none">
-   <b><a href="#valdef-max-lines-none">#valdef-max-lines-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-max-lines-none" class="dfn-panel" data-for="valdef-max-lines-none" id="infopanel-for-valdef-max-lines-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-max-lines-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-max-lines-none">#valdef-max-lines-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-lines-none">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
@@ -4182,8 +4182,8 @@ Limiting Visible Lines: the line-clamp shorthand property</a>
 Forcing a Break After a Set Number of Lines: the max-lines property</a> <a href="#ref-for-valdef-max-lines-none②">(2)</a> <a href="#ref-for-valdef-max-lines-none③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-continue">
-   <b><a href="#propdef-continue">#propdef-continue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-continue" class="dfn-panel" data-for="propdef-continue" id="infopanel-for-propdef-continue" role="dialog">
+   <span id="infopaneltitle-for-propdef-continue" style="display:none">Info about the 'continue' definition.</span><b><a href="#propdef-continue">#propdef-continue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-continue">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a> <a href="#ref-for-propdef-continue①">(2)</a> <a href="#ref-for-propdef-continue②">(3)</a>
@@ -4196,8 +4196,8 @@ Fragmentation of Overflow: the continue property</a> <a href="#ref-for-propdef-c
     <li><a href="#ref-for-propdef-continue①②"> Changes from the 2018-07-31 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-auto">
-   <b><a href="#valdef-continue-auto">#valdef-continue-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-auto" class="dfn-panel" data-for="valdef-continue-auto" id="infopanel-for-valdef-continue-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-continue-auto">#valdef-continue-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-auto">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
@@ -4205,8 +4205,8 @@ Limiting Visible Lines: the line-clamp shorthand property</a>
 Fragmentation of Overflow: the continue property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-discard">
-   <b><a href="#valdef-continue-discard">#valdef-continue-discard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-discard" class="dfn-panel" data-for="valdef-continue-discard" id="infopanel-for-valdef-continue-discard" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-discard" style="display:none">Info about the 'discard' definition.</span><b><a href="#valdef-continue-discard">#valdef-continue-discard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-discard">5.1. 
 Limiting Visible Lines: the line-clamp shorthand property</a>
@@ -4231,59 +4231,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overflow-4/Overview.html
@@ -2700,89 +2700,89 @@ Answers are provided below.</p>
    <li><a href="#valdef-scrollbar-gutter-stable">stable</a><span>, in § 4</span>
    <li><a href="#propdef-text-overflow">text-overflow</a><span>, in § 5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-subject">
-   <a href="https://drafts.csswg.org/selectors-3/#subject">https://drafts.csswg.org/selectors-3/#subject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-subject" class="dfn-panel" data-for="term-for-subject" id="infopanel-for-term-for-subject" role="menu">
+   <span id="infopaneltitle-for-term-for-subject" style="display:none">Info about the 'subject' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#subject">https://drafts.csswg.org/selectors-3/#subject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subject">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">6. Fragmentation of overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-layout-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-layout-containment" class="dfn-panel" data-for="term-for-layout-containment" id="infopanel-for-term-for-layout-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-layout-containment" style="display:none">Info about the 'layout containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment">6. Fragmentation of overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">8.1.2. Styling of fragments</a> <a href="#ref-for-propdef-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">8.1.2. Styling of fragments</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-image">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-image" class="dfn-panel" data-for="term-for-propdef-mask-image" id="infopanel-for-term-for-propdef-mask-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-image" style="display:none">Info about the 'mask-image' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-overflow-auto①">(2)</a> <a href="#ref-for-valdef-overflow-auto②">(3)</a> <a href="#ref-for-valdef-overflow-auto③">(4)</a> <a href="#ref-for-valdef-overflow-auto④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-clip">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-clip" class="dfn-panel" data-for="term-for-valdef-overflow-clip" id="infopanel-for-term-for-valdef-overflow-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-overflow-clip①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-hidden">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-hidden" class="dfn-panel" data-for="term-for-valdef-overflow-hidden" id="infopanel-for-term-for-valdef-overflow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-overflow-hidden①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">1. 
 Introduction</a>
@@ -2792,99 +2792,99 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
     <li><a href="#ref-for-propdef-overflow①⓪">6. Fragmentation of overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-scroll">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-scroll" class="dfn-panel" data-for="term-for-valdef-overflow-scroll" id="infopanel-for-term-for-valdef-overflow-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-overflow-scroll①">(2)</a> <a href="#ref-for-valdef-overflow-scroll②">(3)</a> <a href="#ref-for-valdef-overflow-scroll③">(4)</a> <a href="#ref-for-valdef-overflow-scroll④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-overflow-visible①">(2)</a>
     <li><a href="#ref-for-valdef-overflow-visible②">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">8.1.2. Styling of fragments</a>
     <li><a href="#ref-for-selectordef-first-letter①">8.1.3. Styling inside fragments</a> <a href="#ref-for-selectordef-first-letter②">(2)</a> <a href="#ref-for-selectordef-first-letter③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">8.1.3. Styling inside fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">8.2. The max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-comb-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">8.2. The max-lines property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-percentage-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">5. Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -2893,98 +2893,98 @@ Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#r
     <li><a href="#ref-for-comb-one①⓪">8.2. The max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">user interaction with ellipsis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-left" class="dfn-panel" data-for="term-for-physical-left" id="infopanel-for-term-for-physical-left" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-left">user interaction with ellipsis</a> <a href="#ref-for-physical-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-css-end①">(2)</a> <a href="#ref-for-css-end②">(3)</a>
     <li><a href="#ref-for-css-end③">ellipsis interaction with scrolling interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-inline-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-inline-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-left" class="dfn-panel" data-for="term-for-line-left" id="infopanel-for-term-for-line-left" role="menu">
+   <span id="infopaneltitle-for-term-for-line-left" style="display:none">Info about the 'line-left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-line-left①">(2)</a> <a href="#ref-for-line-left②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-right" class="dfn-panel" data-for="term-for-line-right" id="infopanel-for-term-for-line-right" role="menu">
+   <span id="infopaneltitle-for-term-for-line-right" style="display:none">Info about the 'line-right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-line-right①">(2)</a> <a href="#ref-for-line-right②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">5. Overflow Ellipsis: the text-overflow property</a>
     <li><a href="#ref-for-css-start①">ellipsis interaction with scrolling interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-region">
-   <a href="https://drafts.csswg.org/css-regions-1/#css-region">https://drafts.csswg.org/css-regions-1/#css-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-region" class="dfn-panel" data-for="term-for-css-region" id="infopanel-for-term-for-css-region" role="menu">
+   <span id="infopaneltitle-for-term-for-css-region" style="display:none">Info about the 'css region' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#css-region">https://drafts.csswg.org/css-regions-1/#css-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-region">6. Fragmentation of overflow</a> <a href="#ref-for-css-region①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-region-chain">
-   <a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-region-chain" class="dfn-panel" data-for="term-for-region-chain" id="infopanel-for-term-for-region-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-region-chain" style="display:none">Info about the 'region chain' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#region-chain">https://drafts.csswg.org/css-regions-1/#region-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-chain">6. Fragmentation of overflow</a> <a href="#ref-for-region-chain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-region-fragment">
-   <a href="https://drafts.csswg.org/css-regions-1/#propdef-region-fragment">https://drafts.csswg.org/css-regions-1/#propdef-region-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-region-fragment" class="dfn-panel" data-for="term-for-propdef-region-fragment" id="infopanel-for-term-for-propdef-region-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-region-fragment" style="display:none">Info about the 'region-fragment' external reference.</span><a href="https://drafts.csswg.org/css-regions-1/#propdef-region-fragment">https://drafts.csswg.org/css-regions-1/#propdef-region-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-region-fragment">6. Fragmentation of overflow</a> <a href="#ref-for-propdef-region-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow-columns">
-   <a href="https://drafts.csswg.org/css-multicol-1/#overflow-columns">https://drafts.csswg.org/css-multicol-1/#overflow-columns</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow-columns" class="dfn-panel" data-for="term-for-overflow-columns" id="infopanel-for-term-for-overflow-columns" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow-columns" style="display:none">Info about the 'overflow columns' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#overflow-columns">https://drafts.csswg.org/css-multicol-1/#overflow-columns</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-columns">8. Fragment overflow</a>
    </ul>
@@ -3369,65 +3369,65 @@ When applied to non fragmentainers,
 it should probably cause <a class="property css" data-link-type="property" href="#propdef-continue">continue</a> to compute to <a class="css" data-link-type="maybe" href="#valdef-continue-discard">discard</a> so that you only need to reach for one property rather than 2 to get
 that effect. <a class="issue-return" href="#issue-9eb7883d" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="scrollbar-gutter">
-   <b><a href="#scrollbar-gutter">#scrollbar-gutter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrollbar-gutter" class="dfn-panel" data-for="scrollbar-gutter" id="infopanel-for-scrollbar-gutter" role="dialog">
+   <span id="infopaneltitle-for-scrollbar-gutter" style="display:none">Info about the 'scrollbar gutter' definition.</span><b><a href="#scrollbar-gutter">#scrollbar-gutter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollbar-gutter">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-scrollbar-gutter①">(2)</a> <a href="#ref-for-scrollbar-gutter②">(3)</a> <a href="#ref-for-scrollbar-gutter③">(4)</a> <a href="#ref-for-scrollbar-gutter④">(5)</a> <a href="#ref-for-scrollbar-gutter⑤">(6)</a> <a href="#ref-for-scrollbar-gutter⑥">(7)</a> <a href="#ref-for-scrollbar-gutter⑦">(8)</a> <a href="#ref-for-scrollbar-gutter⑧">(9)</a> <a href="#ref-for-scrollbar-gutter⑨">(10)</a> <a href="#ref-for-scrollbar-gutter①⓪">(11)</a> <a href="#ref-for-scrollbar-gutter①①">(12)</a> <a href="#ref-for-scrollbar-gutter①②">(13)</a> <a href="#ref-for-scrollbar-gutter①③">(14)</a> <a href="#ref-for-scrollbar-gutter①④">(15)</a> <a href="#ref-for-scrollbar-gutter①⑤">(16)</a> <a href="#ref-for-scrollbar-gutter①⑥">(17)</a> <a href="#ref-for-scrollbar-gutter①⑦">(18)</a> <a href="#ref-for-scrollbar-gutter①⑧">(19)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scrollbar-gutter">
-   <b><a href="#propdef-scrollbar-gutter">#propdef-scrollbar-gutter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scrollbar-gutter" class="dfn-panel" data-for="propdef-scrollbar-gutter" id="infopanel-for-propdef-scrollbar-gutter" role="dialog">
+   <span id="infopaneltitle-for-propdef-scrollbar-gutter" style="display:none">Info about the 'scrollbar-gutter' definition.</span><b><a href="#propdef-scrollbar-gutter">#propdef-scrollbar-gutter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scrollbar-gutter">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-propdef-scrollbar-gutter①">(2)</a> <a href="#ref-for-propdef-scrollbar-gutter②">(3)</a> <a href="#ref-for-propdef-scrollbar-gutter③">(4)</a> <a href="#ref-for-propdef-scrollbar-gutter④">(5)</a>
     <li><a href="#ref-for-propdef-scrollbar-gutter⑤"> Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overlay-scrollbars">
-   <b><a href="#overlay-scrollbars">#overlay-scrollbars</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overlay-scrollbars" class="dfn-panel" data-for="overlay-scrollbars" id="infopanel-for-overlay-scrollbars" role="dialog">
+   <span id="infopaneltitle-for-overlay-scrollbars" style="display:none">Info about the 'overlay scrollbars' definition.</span><b><a href="#overlay-scrollbars">#overlay-scrollbars</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overlay-scrollbars">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-overlay-scrollbars①">(2)</a> <a href="#ref-for-overlay-scrollbars②">(3)</a> <a href="#ref-for-overlay-scrollbars③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="classic-scrollbars">
-   <b><a href="#classic-scrollbars">#classic-scrollbars</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-classic-scrollbars" class="dfn-panel" data-for="classic-scrollbars" id="infopanel-for-classic-scrollbars" role="dialog">
+   <span id="infopaneltitle-for-classic-scrollbars" style="display:none">Info about the 'classic scrollbars' definition.</span><b><a href="#classic-scrollbars">#classic-scrollbars</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classic-scrollbars">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-classic-scrollbars①">(2)</a> <a href="#ref-for-classic-scrollbars②">(3)</a> <a href="#ref-for-classic-scrollbars③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-gutter-auto">
-   <b><a href="#valdef-scrollbar-gutter-auto">#valdef-scrollbar-gutter-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-gutter-auto" class="dfn-panel" data-for="valdef-scrollbar-gutter-auto" id="infopanel-for-valdef-scrollbar-gutter-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-gutter-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-scrollbar-gutter-auto">#valdef-scrollbar-gutter-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-gutter-auto">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-scrollbar-gutter-auto①">(2)</a> <a href="#ref-for-valdef-scrollbar-gutter-auto②">(3)</a> <a href="#ref-for-valdef-scrollbar-gutter-auto③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-gutter-stable">
-   <b><a href="#valdef-scrollbar-gutter-stable">#valdef-scrollbar-gutter-stable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-gutter-stable" class="dfn-panel" data-for="valdef-scrollbar-gutter-stable" id="infopanel-for-valdef-scrollbar-gutter-stable" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-gutter-stable" style="display:none">Info about the 'stable' definition.</span><b><a href="#valdef-scrollbar-gutter-stable">#valdef-scrollbar-gutter-stable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-gutter-stable">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-scrollbar-gutter-stable①">(2)</a> <a href="#ref-for-valdef-scrollbar-gutter-stable②">(3)</a> <a href="#ref-for-valdef-scrollbar-gutter-stable③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-gutter-always">
-   <b><a href="#valdef-scrollbar-gutter-always">#valdef-scrollbar-gutter-always</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-gutter-always" class="dfn-panel" data-for="valdef-scrollbar-gutter-always" id="infopanel-for-valdef-scrollbar-gutter-always" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-gutter-always" style="display:none">Info about the 'always' definition.</span><b><a href="#valdef-scrollbar-gutter-always">#valdef-scrollbar-gutter-always</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-gutter-always">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-scrollbar-gutter-always①">(2)</a> <a href="#ref-for-valdef-scrollbar-gutter-always②">(3)</a> <a href="#ref-for-valdef-scrollbar-gutter-always③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-gutter-force">
-   <b><a href="#valdef-scrollbar-gutter-force">#valdef-scrollbar-gutter-force</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-gutter-force" class="dfn-panel" data-for="valdef-scrollbar-gutter-force" id="infopanel-for-valdef-scrollbar-gutter-force" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-gutter-force" style="display:none">Info about the 'force' definition.</span><b><a href="#valdef-scrollbar-gutter-force">#valdef-scrollbar-gutter-force</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-gutter-force">4. 
 Reserving space for the scrollbar: the scrollbar-gutter property</a> <a href="#ref-for-valdef-scrollbar-gutter-force①">(2)</a> <a href="#ref-for-valdef-scrollbar-gutter-force②">(3)</a> <a href="#ref-for-valdef-scrollbar-gutter-force③">(4)</a> <a href="#ref-for-valdef-scrollbar-gutter-force④">(5)</a> <a href="#ref-for-valdef-scrollbar-gutter-force⑤">(6)</a> <a href="#ref-for-valdef-scrollbar-gutter-force⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-overflow">
-   <b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-overflow" class="dfn-panel" data-for="propdef-text-overflow" id="infopanel-for-propdef-text-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' definition.</span><b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">1. 
 Introduction</a>
@@ -3436,20 +3436,20 @@ Introduction</a>
     <li><a href="#ref-for-propdef-text-overflow④">ellipsis interaction with scrolling interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overflow-ellipsis">
-   <b><a href="#overflow-ellipsis">#overflow-ellipsis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow-ellipsis" class="dfn-panel" data-for="overflow-ellipsis" id="infopanel-for-overflow-ellipsis" role="dialog">
+   <span id="infopaneltitle-for-overflow-ellipsis" style="display:none">Info about the 'ellipsis' definition.</span><b><a href="#overflow-ellipsis">#overflow-ellipsis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-ellipsis">user interaction with ellipsis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-text-overflow-fade">
-   <b><a href="#funcdef-text-overflow-fade">#funcdef-text-overflow-fade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-text-overflow-fade" class="dfn-panel" data-for="funcdef-text-overflow-fade" id="infopanel-for-funcdef-text-overflow-fade" role="dialog">
+   <span id="infopaneltitle-for-funcdef-text-overflow-fade" style="display:none">Info about the 'fade( &lt;length> | &lt;percentage> )' definition.</span><b><a href="#funcdef-text-overflow-fade">#funcdef-text-overflow-fade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-text-overflow-fade">5. Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-funcdef-text-overflow-fade①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-continue">
-   <b><a href="#propdef-continue">#propdef-continue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-continue" class="dfn-panel" data-for="propdef-continue" id="infopanel-for-propdef-continue" role="dialog">
+   <span id="infopaneltitle-for-propdef-continue" style="display:none">Info about the 'continue' definition.</span><b><a href="#propdef-continue">#propdef-continue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-continue">6. Fragmentation of overflow</a> <a href="#ref-for-propdef-continue①">(2)</a> <a href="#ref-for-propdef-continue②">(3)</a> <a href="#ref-for-propdef-continue③">(4)</a>
     <li><a href="#ref-for-propdef-continue④">7. Paginated overflow</a> <a href="#ref-for-propdef-continue⑤">(2)</a>
@@ -3458,42 +3458,42 @@ Introduction</a>
     <li><a href="#ref-for-propdef-continue①⑤">8.2. The max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-auto">
-   <b><a href="#valdef-continue-auto">#valdef-continue-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-auto" class="dfn-panel" data-for="valdef-continue-auto" id="infopanel-for-valdef-continue-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-continue-auto">#valdef-continue-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-auto">6. Fragmentation of overflow</a> <a href="#ref-for-valdef-continue-auto①">(2)</a> <a href="#ref-for-valdef-continue-auto②">(3)</a> <a href="#ref-for-valdef-continue-auto③">(4)</a> <a href="#ref-for-valdef-continue-auto④">(5)</a>
     <li><a href="#ref-for-valdef-continue-auto⑤">7. Paginated overflow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-overflow">
-   <b><a href="#valdef-continue-overflow">#valdef-continue-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-overflow" class="dfn-panel" data-for="valdef-continue-overflow" id="infopanel-for-valdef-continue-overflow" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#valdef-continue-overflow">#valdef-continue-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-overflow">6. Fragmentation of overflow</a> <a href="#ref-for-valdef-continue-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-discard">
-   <b><a href="#valdef-continue-discard">#valdef-continue-discard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-discard" class="dfn-panel" data-for="valdef-continue-discard" id="infopanel-for-valdef-continue-discard" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-discard" style="display:none">Info about the 'discard' definition.</span><b><a href="#valdef-continue-discard">#valdef-continue-discard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-discard">8.2. The max-lines property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-paginate">
-   <b><a href="#valdef-continue-paginate">#valdef-continue-paginate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-paginate" class="dfn-panel" data-for="valdef-continue-paginate" id="infopanel-for-valdef-continue-paginate" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-paginate" style="display:none">Info about the 'paginate' definition.</span><b><a href="#valdef-continue-paginate">#valdef-continue-paginate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-paginate">6. Fragmentation of overflow</a> <a href="#ref-for-valdef-continue-paginate①">(2)</a>
     <li><a href="#ref-for-valdef-continue-paginate②">7. Paginated overflow</a> <a href="#ref-for-valdef-continue-paginate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-continue-fragments">
-   <b><a href="#valdef-continue-fragments">#valdef-continue-fragments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-continue-fragments" class="dfn-panel" data-for="valdef-continue-fragments" id="infopanel-for-valdef-continue-fragments" role="dialog">
+   <span id="infopaneltitle-for-valdef-continue-fragments" style="display:none">Info about the 'fragments' definition.</span><b><a href="#valdef-continue-fragments">#valdef-continue-fragments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-continue-fragments">6. Fragmentation of overflow</a> <a href="#ref-for-valdef-continue-fragments①">(2)</a> <a href="#ref-for-valdef-continue-fragments②">(3)</a> <a href="#ref-for-valdef-continue-fragments③">(4)</a>
     <li><a href="#ref-for-valdef-continue-fragments④">8. Fragment overflow</a> <a href="#ref-for-valdef-continue-fragments⑤">(2)</a> <a href="#ref-for-valdef-continue-fragments⑥">(3)</a>
     <li><a href="#ref-for-valdef-continue-fragments⑦">8.1.2. Styling of fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-box">
-   <b><a href="#fragment-box">#fragment-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment-box" class="dfn-panel" data-for="fragment-box" id="infopanel-for-fragment-box" role="dialog">
+   <span id="infopaneltitle-for-fragment-box" style="display:none">Info about the 'fragment box' definition.</span><b><a href="#fragment-box">#fragment-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-box">6. Fragmentation of overflow</a> <a href="#ref-for-fragment-box①">(2)</a>
     <li><a href="#ref-for-fragment-box②">8. Fragment overflow</a> <a href="#ref-for-fragment-box③">(2)</a> <a href="#ref-for-fragment-box④">(3)</a> <a href="#ref-for-fragment-box⑤">(4)</a> <a href="#ref-for-fragment-box⑥">(5)</a> <a href="#ref-for-fragment-box⑦">(6)</a>
@@ -3502,8 +3502,8 @@ Introduction</a>
     <li><a href="#ref-for-fragment-box②⓪">8.1.3. Styling inside fragments</a> <a href="#ref-for-fragment-box②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-nth-fragment">
-   <b><a href="#selectordef-nth-fragment">#selectordef-nth-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-nth-fragment" class="dfn-panel" data-for="selectordef-nth-fragment" id="infopanel-for-selectordef-nth-fragment" role="dialog">
+   <span id="infopaneltitle-for-selectordef-nth-fragment" style="display:none">Info about the '::nth-fragment()' definition.</span><b><a href="#selectordef-nth-fragment">#selectordef-nth-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-nth-fragment">8. Fragment overflow</a>
     <li><a href="#ref-for-selectordef-nth-fragment①">8.1.1. The ::nth-fragment() pseudo-element</a>
@@ -3511,14 +3511,14 @@ Introduction</a>
     <li><a href="#ref-for-selectordef-nth-fragment①①">8.1.3. Styling inside fragments</a> <a href="#ref-for-selectordef-nth-fragment①②">(2)</a> <a href="#ref-for-selectordef-nth-fragment①③">(3)</a> <a href="#ref-for-selectordef-nth-fragment①④">(4)</a> <a href="#ref-for-selectordef-nth-fragment①⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-lines">
-   <b><a href="#propdef-max-lines">#propdef-max-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-lines" class="dfn-panel" data-for="propdef-max-lines" id="infopanel-for-propdef-max-lines" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-lines" style="display:none">Info about the 'max-lines' definition.</span><b><a href="#propdef-max-lines">#propdef-max-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-lines">8.2. The max-lines property</a> <a href="#ref-for-propdef-max-lines①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-max-lines-none">
-   <b><a href="#valdef-max-lines-none">#valdef-max-lines-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-max-lines-none" class="dfn-panel" data-for="valdef-max-lines-none" id="infopanel-for-valdef-max-lines-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-max-lines-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-max-lines-none">#valdef-max-lines-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-lines-none">8.2. The max-lines property</a>
    </ul>
@@ -3540,59 +3540,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-overscroll-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-overscroll-1/Overview.html
@@ -1457,42 +1457,42 @@ cause a scroll.
    <li><a href="#scroll-chain">scroll chain</a><span>, in § 3</span>
    <li><a href="#scroll-chaining">Scroll chaining</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://www.w3.org/TR/css-display-3/#containing-block-chain">https://www.w3.org/TR/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#containing-block-chain">https://www.w3.org/TR/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">1. Introduction</a>
     <li><a href="#ref-for-containing-block-chain①">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-action">
-   <a href="https://www.w3.org/TR/uievents/#default-action">https://www.w3.org/TR/uievents/#default-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-action" class="dfn-panel" data-for="term-for-default-action" id="infopanel-for-term-for-default-action" role="menu">
+   <span id="infopaneltitle-for-term-for-default-action" style="display:none">Info about the 'default action' external reference.</span><a href="https://www.w3.org/TR/uievents/#default-action">https://www.w3.org/TR/uievents/#default-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-action">1. Introduction</a> <a href="#ref-for-default-action①">(2)</a> <a href="#ref-for-default-action②">(3)</a>
     <li><a href="#ref-for-default-action③">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-action">
-   <a href="https://www.w3.org/TR/uievents/#default-action">https://www.w3.org/TR/uievents/#default-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-action" class="dfn-panel" data-for="term-for-default-action" id="infopanel-for-term-for-default-action①" role="menu">
+   <span id="infopaneltitle-for-term-for-default-action①" style="display:none">Info about the 'default actions' external reference.</span><a href="https://www.w3.org/TR/uievents/#default-action">https://www.w3.org/TR/uievents/#default-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-action">1. Introduction</a> <a href="#ref-for-default-action①">(2)</a> <a href="#ref-for-default-action②">(3)</a>
     <li><a href="#ref-for-default-action③">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener">
-   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener" id="infopanel-for-term-for-dom-eventtarget-addeventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" style="display:none">Info about the 'passive flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-preventdefault">
-   <a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-preventdefault" class="dfn-panel" data-for="term-for-dom-event-preventdefault" id="infopanel-for-term-for-dom-event-preventdefault" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-preventdefault" style="display:none">Info about the 'preventdefault' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-preventdefault">https://dom.spec.whatwg.org/#dom-event-preventdefault</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">1. Introduction</a> <a href="#ref-for-dom-event-preventdefault①">(2)</a> <a href="#ref-for-dom-event-preventdefault②">(3)</a> <a href="#ref-for-dom-event-preventdefault③">(4)</a>
     <li><a href="#ref-for-dom-event-preventdefault④">4. Overscroll Behavior Properties</a> <a href="#ref-for-dom-event-preventdefault⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">Unnumbered Section</a>
     <li><a href="#ref-for-scroll-container①">1. Introduction</a> <a href="#ref-for-scroll-container②">(2)</a> <a href="#ref-for-scroll-container③">(3)</a>
@@ -1502,8 +1502,8 @@ cause a scroll.
     <li><a href="#ref-for-scroll-container①⑥">4.2. Flow-relative Longhands for overscroll-behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container①" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container①" style="display:none">Info about the 'scroll containers' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">Unnumbered Section</a>
     <li><a href="#ref-for-scroll-container①">1. Introduction</a> <a href="#ref-for-scroll-container②">(2)</a> <a href="#ref-for-scroll-container③">(3)</a>
@@ -1513,26 +1513,26 @@ cause a scroll.
     <li><a href="#ref-for-scroll-container①⑥">4.2. Flow-relative Longhands for overscroll-behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-scrollingelement">
-   <a href="https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement">https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-scrollingelement" class="dfn-panel" data-for="term-for-dom-document-scrollingelement" id="infopanel-for-term-for-dom-document-scrollingelement" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-scrollingelement" style="display:none">Info about the 'scrollingelement' external reference.</span><a href="https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement">https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-scrollingelement">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://drafts.csswg.org/cssom-view/#viewport">https://drafts.csswg.org/cssom-view/#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://drafts.csswg.org/cssom-view/#viewport">https://drafts.csswg.org/cssom-view/#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#overflow">https://drafts.csswg.org/css-overflow-3/#overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow" class="dfn-panel" data-for="term-for-overflow" id="infopanel-for-term-for-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#overflow">https://drafts.csswg.org/css-overflow-3/#overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow">3. Scroll chaining and boundary default actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">Unnumbered Section</a>
     <li><a href="#ref-for-scrollport①">1. Introduction</a>
@@ -1540,28 +1540,28 @@ cause a scroll.
     <li><a href="#ref-for-scrollport⑤">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4. Overscroll Behavior Properties</a> <a href="#ref-for-comb-one①">(2)</a>
     <li><a href="#ref-for-comb-one②">4.1. Physical Longhands for overscroll-behavior</a> <a href="#ref-for-comb-one③">(2)</a>
     <li><a href="#ref-for-comb-one④">4.2. Flow-relative Longhands for overscroll-behavior</a> <a href="#ref-for-comb-one⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">4.2. Flow-relative Longhands for overscroll-behavior</a>
    </ul>
@@ -1689,57 +1689,57 @@ cause a scroll.
       <td>visual
    </table>
   </div>
-  <aside class="dfn-panel" data-for="scroll-chaining">
-   <b><a href="#scroll-chaining">#scroll-chaining</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-chaining" class="dfn-panel" data-for="scroll-chaining" id="infopanel-for-scroll-chaining" role="dialog">
+   <span id="infopaneltitle-for-scroll-chaining" style="display:none">Info about the 'Scroll chaining' definition.</span><b><a href="#scroll-chaining">#scroll-chaining</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-chaining">1. Introduction</a> <a href="#ref-for-scroll-chaining①">(2)</a>
     <li><a href="#ref-for-scroll-chaining②">3. Scroll chaining and boundary default actions</a>
     <li><a href="#ref-for-scroll-chaining③">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-chain">
-   <b><a href="#scroll-chain">#scroll-chain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-chain" class="dfn-panel" data-for="scroll-chain" id="infopanel-for-scroll-chain" role="dialog">
+   <span id="infopaneltitle-for-scroll-chain" style="display:none">Info about the 'scroll chain' definition.</span><b><a href="#scroll-chain">#scroll-chain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-chain">1. Introduction</a>
     <li><a href="#ref-for-scroll-chain①">3. Scroll chaining and boundary default actions</a>
     <li><a href="#ref-for-scroll-chain②">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-boundary">
-   <b><a href="#scroll-boundary">#scroll-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-boundary" class="dfn-panel" data-for="scroll-boundary" id="infopanel-for-scroll-boundary" role="dialog">
+   <span id="infopaneltitle-for-scroll-boundary" style="display:none">Info about the 'Scroll boundary' definition.</span><b><a href="#scroll-boundary">#scroll-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-boundary">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boundary-default-action">
-   <b><a href="#boundary-default-action">#boundary-default-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boundary-default-action" class="dfn-panel" data-for="boundary-default-action" id="infopanel-for-boundary-default-action" role="dialog">
+   <span id="infopaneltitle-for-boundary-default-action" style="display:none">Info about the 'Boundary default action' definition.</span><b><a href="#boundary-default-action">#boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-default-action①">1. Introduction</a> <a href="#ref-for-boundary-default-action②">(2)</a>
     <li><a href="#ref-for-boundary-default-action③">3. Scroll chaining and boundary default actions</a>
     <li><a href="#ref-for-boundary-default-action④">4. Overscroll Behavior Properties</a> <a href="#ref-for-boundary-default-action⑤">(2)</a> <a href="#ref-for-boundary-default-action⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-boundary-default-action">
-   <b><a href="#local-boundary-default-action">#local-boundary-default-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-boundary-default-action" class="dfn-panel" data-for="local-boundary-default-action" id="infopanel-for-local-boundary-default-action" role="dialog">
+   <span id="infopaneltitle-for-local-boundary-default-action" style="display:none">Info about the 'local boundary default action' definition.</span><b><a href="#local-boundary-default-action">#local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-boundary-default-action">4. Overscroll Behavior Properties</a> <a href="#ref-for-local-boundary-default-action①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-local-boundary-default-action">
-   <b><a href="#non-local-boundary-default-action">#non-local-boundary-default-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-local-boundary-default-action" class="dfn-panel" data-for="non-local-boundary-default-action" id="infopanel-for-non-local-boundary-default-action" role="dialog">
+   <span id="infopaneltitle-for-non-local-boundary-default-action" style="display:none">Info about the 'non-local boundary default action' definition.</span><b><a href="#non-local-boundary-default-action">#non-local-boundary-default-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-local-boundary-default-action">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overscroll-behavior">
-   <b><a href="#overscroll-behavior">#overscroll-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overscroll-behavior" class="dfn-panel" data-for="overscroll-behavior" id="infopanel-for-overscroll-behavior" role="dialog">
+   <span id="infopaneltitle-for-overscroll-behavior" style="display:none">Info about the 'overscroll behavior' definition.</span><b><a href="#overscroll-behavior">#overscroll-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overscroll-behavior">4. Overscroll Behavior Properties</a>
     <li><a href="#ref-for-overscroll-behavior①">4.1. Physical Longhands for overscroll-behavior</a> <a href="#ref-for-overscroll-behavior②">(2)</a> <a href="#ref-for-overscroll-behavior③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overscroll-behavior">
-   <b><a href="#propdef-overscroll-behavior">#propdef-overscroll-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overscroll-behavior" class="dfn-panel" data-for="propdef-overscroll-behavior" id="infopanel-for-propdef-overscroll-behavior" role="dialog">
+   <span id="infopaneltitle-for-propdef-overscroll-behavior" style="display:none">Info about the 'overscroll-behavior' definition.</span><b><a href="#propdef-overscroll-behavior">#propdef-overscroll-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overscroll-behavior①">1. Introduction</a>
     <li><a href="#ref-for-propdef-overscroll-behavior②">4. Overscroll Behavior Properties</a> <a href="#ref-for-propdef-overscroll-behavior③">(2)</a>
@@ -1747,29 +1747,29 @@ cause a scroll.
     <li><a href="#ref-for-propdef-overscroll-behavior⑤">4.2. Flow-relative Longhands for overscroll-behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overscroll-behavior-contain">
-   <b><a href="#valdef-overscroll-behavior-contain">#valdef-overscroll-behavior-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overscroll-behavior-contain" class="dfn-panel" data-for="valdef-overscroll-behavior-contain" id="infopanel-for-valdef-overscroll-behavior-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-overscroll-behavior-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-overscroll-behavior-contain">#valdef-overscroll-behavior-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overscroll-behavior-contain">2. Motivating Examples</a> <a href="#ref-for-valdef-overscroll-behavior-contain①">(2)</a>
     <li><a href="#ref-for-valdef-overscroll-behavior-contain②">4. Overscroll Behavior Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overscroll-behavior-none">
-   <b><a href="#valdef-overscroll-behavior-none">#valdef-overscroll-behavior-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overscroll-behavior-none" class="dfn-panel" data-for="valdef-overscroll-behavior-none" id="infopanel-for-valdef-overscroll-behavior-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-overscroll-behavior-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-overscroll-behavior-none">#valdef-overscroll-behavior-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overscroll-behavior-none">2. Motivating Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overscroll-behavior-x">
-   <b><a href="#propdef-overscroll-behavior-x">#propdef-overscroll-behavior-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overscroll-behavior-x" class="dfn-panel" data-for="propdef-overscroll-behavior-x" id="infopanel-for-propdef-overscroll-behavior-x" role="dialog">
+   <span id="infopaneltitle-for-propdef-overscroll-behavior-x" style="display:none">Info about the 'overscroll-behavior-x' definition.</span><b><a href="#propdef-overscroll-behavior-x">#propdef-overscroll-behavior-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overscroll-behavior-x">4. Overscroll Behavior Properties</a>
     <li><a href="#ref-for-propdef-overscroll-behavior-x①">4.1. Physical Longhands for overscroll-behavior</a>
     <li><a href="#ref-for-propdef-overscroll-behavior-x②">4.2. Flow-relative Longhands for overscroll-behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overscroll-behavior-y">
-   <b><a href="#propdef-overscroll-behavior-y">#propdef-overscroll-behavior-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overscroll-behavior-y" class="dfn-panel" data-for="propdef-overscroll-behavior-y" id="infopanel-for-propdef-overscroll-behavior-y" role="dialog">
+   <span id="infopaneltitle-for-propdef-overscroll-behavior-y" style="display:none">Info about the 'overscroll-behavior-y' definition.</span><b><a href="#propdef-overscroll-behavior-y">#propdef-overscroll-behavior-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overscroll-behavior-y">4. Overscroll Behavior Properties</a>
     <li><a href="#ref-for-propdef-overscroll-behavior-y①">4.1. Physical Longhands for overscroll-behavior</a>
@@ -1778,59 +1778,115 @@ cause a scroll.
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-page-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-page-3/Overview.html
@@ -3391,114 +3391,114 @@ table { page: rotated }
    <li><a href="#at-ruledef-top-right-corner">@top-right-corner</a><span>, in § 4.3</span>
    <li><a href="#valdef-page-orientation-upright">upright</a><span>, in § 7.1.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-size-height">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-size-height" class="dfn-panel" data-for="term-for-valdef-anchor-size-height" id="infopanel-for-term-for-valdef-anchor-size-height" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-size-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-size-height">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-size-width">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-size-width" class="dfn-panel" data-for="term-for-valdef-anchor-size-width" id="infopanel-for-term-for-valdef-anchor-size-width" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-size-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-size-width">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-positioning-area">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area">https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-positioning-area" class="dfn-panel" data-for="term-for-background-positioning-area" id="infopanel-for-term-for-background-positioning-area" role="menu">
+   <span id="infopaneltitle-for-term-for-background-positioning-area" style="display:none">Info about the 'background positioning area' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area">https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-positioning-area">3.1. 
 Page Backgrounds and Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">3.1. 
 Page Backgrounds and Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">3.1. 
 Page Backgrounds and Painting Order</a> <a href="#ref-for-propdef-background-clip①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">3.1. 
 Page Backgrounds and Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-border-bottom-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-border-top-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-attachment-fixed">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-attachment-fixed" class="dfn-panel" data-for="term-for-valdef-background-attachment-fixed" id="infopanel-for-term-for-valdef-background-attachment-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-attachment-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-fixed">3.1. 
 Page Backgrounds and Painting Order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-margin-bottom①">(2)</a> <a href="#ref-for-propdef-margin-bottom②">(3)</a> <a href="#ref-for-propdef-margin-bottom③">(4)</a> <a href="#ref-for-propdef-margin-bottom④">(5)</a> <a href="#ref-for-propdef-margin-bottom⑤">(6)</a> <a href="#ref-for-propdef-margin-bottom⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">5.3.2.1. Margins</a>
     <li><a href="#ref-for-propdef-margin-left①">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">5.3.2.1. Margins</a>
     <li><a href="#ref-for-propdef-margin-right①">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-margin-top①">(2)</a> <a href="#ref-for-propdef-margin-top②">(3)</a> <a href="#ref-for-propdef-margin-top③">(4)</a> <a href="#ref-for-propdef-margin-top④">(5)</a> <a href="#ref-for-propdef-margin-top⑤">(6)</a> <a href="#ref-for-propdef-margin-top⑥">(7)</a> <a href="#ref-for-propdef-margin-top⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#outer-edge">https://drafts.csswg.org/css-box-4/#outer-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-edge" class="dfn-panel" data-for="term-for-outer-edge" id="infopanel-for-term-for-outer-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-edge" style="display:none">Info about the 'outer edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#outer-edge">https://drafts.csswg.org/css-box-4/#outer-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-edge">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-padding-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-padding-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">3.2. Content outside the page box</a>
     <li><a href="#ref-for-propdef-break-before①">3.3. Page Progression</a>
@@ -3506,113 +3506,113 @@ Page-Margin Box Layout Terminology</a>
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-break-after">https://drafts.csswg.org/css-break-4/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-break-after">https://drafts.csswg.org/css-break-4/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">3.2. Content outside the page box</a>
     <li><a href="#ref-for-propdef-break-after①">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-break">
-   <a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-break" class="dfn-panel" data-for="term-for-forced-break" id="infopanel-for-term-for-forced-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-break" style="display:none">Info about the 'forced break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#forced-break">https://drafts.csswg.org/css-break-4/#forced-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-break">8.1. 
 Using named pages: page</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-left">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-left">https://drafts.csswg.org/css-break-4/#valdef-break-before-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-left" class="dfn-panel" data-for="term-for-valdef-break-before-left" id="infopanel-for-term-for-valdef-break-before-left" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-left">https://drafts.csswg.org/css-break-4/#valdef-break-before-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-left">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-recto">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-recto">https://drafts.csswg.org/css-break-4/#valdef-break-before-recto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-recto" class="dfn-panel" data-for="term-for-valdef-break-before-recto" id="infopanel-for-term-for-valdef-break-before-recto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-recto" style="display:none">Info about the 'recto' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-recto">https://drafts.csswg.org/css-break-4/#valdef-break-before-recto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-recto">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-right">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-right">https://drafts.csswg.org/css-break-4/#valdef-break-before-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-right" class="dfn-panel" data-for="term-for-valdef-break-before-right" id="infopanel-for-term-for-valdef-break-before-right" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-right">https://drafts.csswg.org/css-break-4/#valdef-break-before-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-right">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-verso">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-verso">https://drafts.csswg.org/css-break-4/#valdef-break-before-verso</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-verso" class="dfn-panel" data-for="term-for-valdef-break-before-verso" id="infopanel-for-term-for-valdef-break-before-verso" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-verso" style="display:none">Info about the 'verso' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-verso">https://drafts.csswg.org/css-break-4/#valdef-break-before-verso</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-verso">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">6. 
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">5.2. Populating page-margin boxes</a> <a href="#ref-for-propdef-content①">(2)</a>
     <li><a href="#ref-for-propdef-content②">6. 
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-none">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-none" class="dfn-panel" data-for="term-for-valdef-content-none" id="infopanel-for-term-for-valdef-content-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">5.2. Populating page-margin boxes</a> <a href="#ref-for-valdef-content-none①">(2)</a>
     <li><a href="#ref-for-valdef-content-none②">6. 
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-normal">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-normal" class="dfn-panel" data-for="term-for-valdef-content-normal" id="infopanel-for-term-for-valdef-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-normal">6. 
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-viewport">
-   <a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-viewport" class="dfn-panel" data-for="term-for-at-ruledef-viewport" id="infopanel-for-term-for-at-ruledef-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-viewport" style="display:none">Info about the '@viewport' external reference.</span><a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-viewport">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-hidden">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden">https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-hidden" class="dfn-panel" data-for="term-for-valdef-visibility-hidden" id="infopanel-for-term-for-valdef-visibility-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden">https://drafts.csswg.org/css-display-3/#valdef-visibility-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-hidden">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">6. 
 Page Properties</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a> <a href="#ref-for-propdef-font-size③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">6. 
 Page Properties</a>
@@ -3620,15 +3620,15 @@ Page Properties</a>
 Page-margin boxes and default values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">3.1. 
 Page Backgrounds and Painting Order</a> <a href="#ref-for-propdef-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">5.3.1. 
 Page-Margin Box Layout Terminology</a> <a href="#ref-for-valdef-width-auto①">(2)</a>
@@ -3636,8 +3636,8 @@ Page-Margin Box Layout Terminology</a> <a href="#ref-for-valdef-width-auto①">(
     <li><a href="#ref-for-valdef-width-auto⑥">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-valdef-width-auto⑦">(2)</a> <a href="#ref-for-valdef-width-auto⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5.3. Computing Page-margin Box Dimensions</a>
     <li><a href="#ref-for-propdef-height①">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a> <a href="#ref-for-propdef-height②">(2)</a> <a href="#ref-for-propdef-height③">(3)</a> <a href="#ref-for-propdef-height④">(4)</a> <a href="#ref-for-propdef-height⑤">(5)</a> <a href="#ref-for-propdef-height⑥">(6)</a>
@@ -3645,36 +3645,36 @@ Page-Margin Box Layout Terminology</a> <a href="#ref-for-valdef-width-auto①">(
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-block-size">https://drafts.csswg.org/css-sizing-3/#max-content-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-block-size" class="dfn-panel" data-for="term-for-max-content-block-size" id="infopanel-for-term-for-max-content-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-block-size" style="display:none">Info about the 'max-content block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-block-size">https://drafts.csswg.org/css-sizing-3/#max-content-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-block-size">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-inline-size" class="dfn-panel" data-for="term-for-max-content-inline-size" id="infopanel-for-term-for-max-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-inline-size" style="display:none">Info about the 'max-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-inline-size">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-block-size">https://drafts.csswg.org/css-sizing-3/#min-content-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-block-size" class="dfn-panel" data-for="term-for-min-content-block-size" id="infopanel-for-term-for-min-content-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-block-size" style="display:none">Info about the 'min-content block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-block-size">https://drafts.csswg.org/css-sizing-3/#min-content-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-block-size">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-inline-size" class="dfn-panel" data-for="term-for-min-content-inline-size" id="infopanel-for-term-for-min-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-inline-size" style="display:none">Info about the 'min-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-inline-size">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">5.3. Computing Page-margin Box Dimensions</a>
     <li><a href="#ref-for-propdef-width①">5.3.1. 
@@ -3686,76 +3686,76 @@ Page-Margin Box Layout Terminology</a> <a href="#ref-for-propdef-width②">(2)</
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">4.3. @page rule grammar</a> <a href="#ref-for-typedef-declaration-list①">(2)</a> <a href="#ref-for-typedef-declaration-list②">(3)</a> <a href="#ref-for-typedef-declaration-list③">(4)</a> <a href="#ref-for-typedef-declaration-list④">(5)</a> <a href="#ref-for-typedef-declaration-list⑤">(6)</a> <a href="#ref-for-typedef-declaration-list⑥">(7)</a> <a href="#ref-for-typedef-declaration-list⑦">(8)</a> <a href="#ref-for-typedef-declaration-list⑧">(9)</a> <a href="#ref-for-typedef-declaration-list⑨">(10)</a> <a href="#ref-for-typedef-declaration-list①⓪">(11)</a> <a href="#ref-for-typedef-declaration-list①①">(12)</a> <a href="#ref-for-typedef-declaration-list①②">(13)</a> <a href="#ref-for-typedef-declaration-list①③">(14)</a> <a href="#ref-for-typedef-declaration-list①④">(15)</a> <a href="#ref-for-typedef-declaration-list①⑤">(16)</a> <a href="#ref-for-typedef-declaration-list①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">5.1. At-rules for page-margin boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">6.2. 
 Page-margin boxes and default values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre" class="dfn-panel" data-for="term-for-valdef-white-space-pre" id="infopanel-for-term-for-valdef-white-space-pre" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre" style="display:none">Info about the 'pre' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">4.3. @page rule grammar</a> <a href="#ref-for-mult-zero-plus①">(2)</a> <a href="#ref-for-mult-zero-plus②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">8.1. 
 Using named pages: page</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">7.1. 
 Page size: the size property</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a>
@@ -3763,21 +3763,21 @@ Page size: the size property</a> <a href="#ref-for-length-value①">(2)</a> <a h
 Bleed Area: the bleed property</a> <a href="#ref-for-length-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.3. @page rule grammar</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">6. 
 Page Properties</a> <a href="#ref-for-em①">(2)</a>
@@ -3785,8 +3785,8 @@ Page Properties</a> <a href="#ref-for-em①">(2)</a>
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ex">
-   <a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ex" class="dfn-panel" data-for="term-for-ex" id="infopanel-for-term-for-ex" role="menu">
+   <span id="infopaneltitle-for-term-for-ex" style="display:none">Info about the 'ex' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ex">https://drafts.csswg.org/css-values-4/#ex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">6. 
 Page Properties</a> <a href="#ref-for-ex①">(2)</a>
@@ -3794,15 +3794,15 @@ Page Properties</a> <a href="#ref-for-ex①">(2)</a>
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.3. @page rule grammar</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">7.1. 
@@ -3817,8 +3817,8 @@ Bleed Area: the bleed property</a>
 Using named pages: page</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">7.1. 
 Page size: the size property</a>
@@ -3826,34 +3826,34 @@ Page size: the size property</a>
 Crop and Registration Marks: the marks property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.3. Page Progression</a>
     <li><a href="#ref-for-propdef-direction①">7.5. 
 Positioning the page box on the sheet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">3.3. Page Progression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">3.3. Page Progression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-principal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-principal-writing-mode" class="dfn-panel" data-for="term-for-principal-writing-mode" id="infopanel-for-term-for-principal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#principal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">3.3. Page Progression</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">3.3. Page Progression</a>
     <li><a href="#ref-for-propdef-writing-mode①">7.1.2. 
@@ -3862,119 +3862,119 @@ Rotating The Printed Page: the page-orientation property</a>
 Positioning the page box on the sheet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css2/#selectordef-after">https://drafts.csswg.org/css2/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the ':after' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-after">https://drafts.csswg.org/css2/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">5.2. Populating page-margin boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css2/#selectordef-before">https://drafts.csswg.org/css2/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the ':before' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-before">https://drafts.csswg.org/css2/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">5.2. Populating page-margin boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-increment">
-   <a href="https://drafts.csswg.org/css2/#propdef-counter-increment">https://drafts.csswg.org/css2/#propdef-counter-increment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-increment" class="dfn-panel" data-for="term-for-propdef-counter-increment" id="infopanel-for-term-for-propdef-counter-increment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-counter-increment">https://drafts.csswg.org/css2/#propdef-counter-increment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">6.1. 
 Page-based counters</a> <a href="#ref-for-propdef-counter-increment①">(2)</a> <a href="#ref-for-propdef-counter-increment②">(3)</a> <a href="#ref-for-propdef-counter-increment③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-reset">
-   <a href="https://drafts.csswg.org/css2/#propdef-counter-reset">https://drafts.csswg.org/css2/#propdef-counter-reset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-reset" class="dfn-panel" data-for="term-for-propdef-counter-reset" id="infopanel-for-term-for-propdef-counter-reset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-counter-reset">https://drafts.csswg.org/css2/#propdef-counter-reset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">6.1. 
 Page-based counters</a> <a href="#ref-for-propdef-counter-reset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.2. Content outside the page box</a>
     <li><a href="#ref-for-propdef-display①">5.2. Populating page-margin boxes</a> <a href="#ref-for-propdef-display②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">5.3. Computing Page-margin Box Dimensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">5.3. Computing Page-margin Box Dimensions</a>
     <li><a href="#ref-for-propdef-max-width①">5.3.2.3. Handling min-width and max-width</a> <a href="#ref-for-propdef-max-width②">(2)</a> <a href="#ref-for-propdef-max-width③">(3)</a> <a href="#ref-for-propdef-max-width④">(4)</a> <a href="#ref-for-propdef-max-width⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">5.3. Computing Page-margin Box Dimensions</a> <a href="#ref-for-propdef-min-height①">(2)</a> <a href="#ref-for-propdef-min-height②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">5.3. Computing Page-margin Box Dimensions</a> <a href="#ref-for-propdef-min-width①">(2)</a> <a href="#ref-for-propdef-min-width②">(3)</a>
     <li><a href="#ref-for-propdef-min-width③">5.3.2.3. Handling min-width and max-width</a> <a href="#ref-for-propdef-min-width④">(2)</a> <a href="#ref-for-propdef-min-width⑤">(3)</a> <a href="#ref-for-propdef-min-width⑥">(4)</a> <a href="#ref-for-propdef-min-width⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">3.2. Content outside the page box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">3.1. 
 Page Backgrounds and Painting Order</a> <a href="#ref-for-propdef-z-index①">(2)</a> <a href="#ref-for-propdef-z-index②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-painting-area">
-   <a href="https://drafts.csswg.org/css-backgrounds-4/#background-painting-area">https://drafts.csswg.org/css-backgrounds-4/#background-painting-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-painting-area" class="dfn-panel" data-for="term-for-background-painting-area" id="infopanel-for-term-for-background-painting-area" role="menu">
+   <span id="infopaneltitle-for-term-for-background-painting-area" style="display:none">Info about the 'background painting area' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-4/#background-painting-area">https://drafts.csswg.org/css-backgrounds-4/#background-painting-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-painting-area">3.1. 
 Page Backgrounds and Painting Order</a> <a href="#ref-for-background-painting-area①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">3. The Page Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-compound-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector">https://drafts.csswg.org/selectors-4/#typedef-compound-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-compound-selector" class="dfn-panel" data-for="term-for-typedef-compound-selector" id="infopanel-for-term-for-typedef-compound-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-compound-selector" style="display:none">Info about the '&lt;compound-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector">https://drafts.csswg.org/selectors-4/#typedef-compound-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-compound-selector">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4316,37 +4316,37 @@ Page Backgrounds and Painting Order</a>
      <a class="issue-return" href="#issue-59a903e8" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="page-sheet">
-   <b><a href="#page-sheet">#page-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-sheet" class="dfn-panel" data-for="page-sheet" id="infopanel-for-page-sheet" role="dialog">
+   <span id="infopaneltitle-for-page-sheet" style="display:none">Info about the 'Page sheet' definition.</span><b><a href="#page-sheet">#page-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-sheet">7.1. 
 Page size: the size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="binding-edge">
-   <b><a href="#binding-edge">#binding-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-binding-edge" class="dfn-panel" data-for="binding-edge" id="infopanel-for-binding-edge" role="dialog">
+   <span id="infopaneltitle-for-binding-edge" style="display:none">Info about the 'Binding Edge' definition.</span><b><a href="#binding-edge">#binding-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-binding-edge">5. Page-Margin Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="left-page">
-   <b><a href="#left-page">#left-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-left-page" class="dfn-panel" data-for="left-page" id="infopanel-for-left-page" role="dialog">
+   <span id="infopaneltitle-for-left-page" style="display:none">Info about the 'Left Page' definition.</span><b><a href="#left-page">#left-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-left-page">4.2.1. 
 Spread pseudo-classes: :left, :right</a>
     <li><a href="#ref-for-left-page①">5. Page-Margin Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="right-page">
-   <b><a href="#right-page">#right-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-right-page" class="dfn-panel" data-for="right-page" id="infopanel-for-right-page" role="dialog">
+   <span id="infopaneltitle-for-right-page" style="display:none">Info about the 'Right Page' definition.</span><b><a href="#right-page">#right-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-right-page">4.2.1. 
 Spread pseudo-classes: :left, :right</a>
     <li><a href="#ref-for-right-page①">5. Page-Margin Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-box">
-   <b><a href="#page-box">#page-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-box" class="dfn-panel" data-for="page-box" id="infopanel-for-page-box" role="dialog">
+   <span id="infopaneltitle-for-page-box" style="display:none">Info about the 'page box' definition.</span><b><a href="#page-box">#page-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-box">2. 
 Page Terminology</a>
@@ -4374,27 +4374,27 @@ Bleed Area: the bleed property</a>
 		Page Breaks </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-margin-boxes">
-   <b><a href="#page-margin-boxes">#page-margin-boxes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-margin-boxes" class="dfn-panel" data-for="page-margin-boxes" id="infopanel-for-page-margin-boxes" role="dialog">
+   <span id="infopaneltitle-for-page-margin-boxes" style="display:none">Info about the 'page-margin boxes' definition.</span><b><a href="#page-margin-boxes">#page-margin-boxes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-margin-boxes">3. The Page Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-empty">
-   <b><a href="#content-empty">#content-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-empty" class="dfn-panel" data-for="content-empty" id="infopanel-for-content-empty" role="dialog">
+   <span id="infopaneltitle-for-content-empty" style="display:none">Info about the 'Content-empty page' definition.</span><b><a href="#content-empty">#content-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-empty">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-progression">
-   <b><a href="#page-progression">#page-progression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-progression" class="dfn-panel" data-for="page-progression" id="infopanel-for-page-progression" role="dialog">
+   <span id="infopaneltitle-for-page-progression" style="display:none">Info about the 'page progression' definition.</span><b><a href="#page-progression">#page-progression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-progression">3.3. Page Progression</a> <a href="#ref-for-page-progression①">(2)</a> <a href="#ref-for-page-progression②">(3)</a> <a href="#ref-for-page-progression③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-page">
-   <b><a href="#at-ruledef-page">#at-ruledef-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-page" class="dfn-panel" data-for="at-ruledef-page" id="infopanel-for-at-ruledef-page" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-page" style="display:none">Info about the '@page' definition.</span><b><a href="#at-ruledef-page">#at-ruledef-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-page">3. The Page Model</a>
     <li><a href="#ref-for-at-ruledef-page①">4.1. 
@@ -4414,8 +4414,8 @@ Bleed Area: the bleed property</a>
 Using named pages: page</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-context">
-   <b><a href="#page-context">#page-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-context" class="dfn-panel" data-for="page-context" id="infopanel-for-page-context" role="dialog">
+   <span id="infopaneltitle-for-page-context" style="display:none">Info about the 'page context' definition.</span><b><a href="#page-context">#page-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-context">3. The Page Model</a> <a href="#ref-for-page-context①">(2)</a>
     <li><a href="#ref-for-page-context">5.1. At-rules for page-margin boxes</a>
@@ -4425,8 +4425,8 @@ Page Properties</a>
 Page-based counters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-selector">
-   <b><a href="#page-selector">#page-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-selector" class="dfn-panel" data-for="page-selector" id="infopanel-for-page-selector" role="dialog">
+   <span id="infopaneltitle-for-page-selector" style="display:none">Info about the 'page selector' definition.</span><b><a href="#page-selector">#page-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-selector">2. 
 Page Terminology</a> <a href="#ref-for-page-selector①">(2)</a>
@@ -4435,8 +4435,8 @@ The @page Rule</a>
     <li><a href="#ref-for-page-selector③">4.2. Page selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match">
-   <b><a href="#match">#match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match" class="dfn-panel" data-for="match" id="infopanel-for-match" role="dialog">
+   <span id="infopaneltitle-for-match" style="display:none">Info about the 'match' definition.</span><b><a href="#match">#match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match">4.1. 
 The @page Rule</a>
@@ -4449,20 +4449,20 @@ First-page pseudo-class: :first</a>
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-type-selector">
-   <b><a href="#page-type-selector">#page-type-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-type-selector" class="dfn-panel" data-for="page-type-selector" id="infopanel-for-page-type-selector" role="dialog">
+   <span id="infopaneltitle-for-page-type-selector" style="display:none">Info about the 'page type selector' definition.</span><b><a href="#page-type-selector">#page-type-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-type-selector">4.2. Page selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-pseudo-class">
-   <b><a href="#page-pseudo-class">#page-pseudo-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-pseudo-class" class="dfn-panel" data-for="page-pseudo-class" id="infopanel-for-page-pseudo-class" role="dialog">
+   <span id="infopaneltitle-for-page-pseudo-class" style="display:none">Info about the 'page pseudo-class' definition.</span><b><a href="#page-pseudo-class">#page-pseudo-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-pseudo-class">4.2. Page selectors</a> <a href="#ref-for-page-pseudo-class①">(2)</a> <a href="#ref-for-page-pseudo-class②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-left">
-   <b><a href="#valdef-page-left">#valdef-page-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-left" class="dfn-panel" data-for="valdef-page-left" id="infopanel-for-valdef-page-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-left" style="display:none">Info about the ':left' definition.</span><b><a href="#valdef-page-left">#valdef-page-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-left">2. 
 Page Terminology</a>
@@ -4470,8 +4470,8 @@ Page Terminology</a>
 Spread pseudo-classes: :left, :right</a> <a href="#ref-for-valdef-page-left②">(2)</a> <a href="#ref-for-valdef-page-left③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-right">
-   <b><a href="#valdef-page-right">#valdef-page-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-right" class="dfn-panel" data-for="valdef-page-right" id="infopanel-for-valdef-page-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-right" style="display:none">Info about the ':right' definition.</span><b><a href="#valdef-page-right">#valdef-page-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-right">2. 
 Page Terminology</a>
@@ -4479,41 +4479,41 @@ Page Terminology</a>
 Spread pseudo-classes: :left, :right</a> <a href="#ref-for-valdef-page-right②">(2)</a> <a href="#ref-for-valdef-page-right③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-first">
-   <b><a href="#valdef-page-first">#valdef-page-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-first" class="dfn-panel" data-for="valdef-page-first" id="infopanel-for-valdef-page-first" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-first" style="display:none">Info about the ':first' definition.</span><b><a href="#valdef-page-first">#valdef-page-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-first">4.2.2. 
 First-page pseudo-class: :first</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-blank">
-   <b><a href="#valdef-page-blank">#valdef-page-blank</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-blank" class="dfn-panel" data-for="valdef-page-blank" id="infopanel-for-valdef-page-blank" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-blank" style="display:none">Info about the ':blank' definition.</span><b><a href="#valdef-page-blank">#valdef-page-blank</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-blank">4.2.3. 
 Blank-page pseudo-class: :blank</a> <a href="#ref-for-valdef-page-blank①">(2)</a> <a href="#ref-for-valdef-page-blank②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-page-selector-list">
-   <b><a href="#typedef-page-selector-list">#typedef-page-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-page-selector-list" class="dfn-panel" data-for="typedef-page-selector-list" id="infopanel-for-typedef-page-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-page-selector-list" style="display:none">Info about the '&lt;page-selector-list>' definition.</span><b><a href="#typedef-page-selector-list">#typedef-page-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-page-selector-list">4.3. @page rule grammar</a> <a href="#ref-for-typedef-page-selector-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-page-selector">
-   <b><a href="#typedef-page-selector">#typedef-page-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-page-selector" class="dfn-panel" data-for="typedef-page-selector" id="infopanel-for-typedef-page-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-page-selector" style="display:none">Info about the '&lt;page-selector>' definition.</span><b><a href="#typedef-page-selector">#typedef-page-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-page-selector">4.2. Page selectors</a>
     <li><a href="#ref-for-typedef-page-selector①">4.3. @page rule grammar</a> <a href="#ref-for-typedef-page-selector②">(2)</a> <a href="#ref-for-typedef-page-selector③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-pseudo-page">
-   <b><a href="#typedef-pseudo-page">#typedef-pseudo-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-pseudo-page" class="dfn-panel" data-for="typedef-pseudo-page" id="infopanel-for-typedef-pseudo-page" role="dialog">
+   <span id="infopaneltitle-for-typedef-pseudo-page" style="display:none">Info about the '&lt;pseudo-page>' definition.</span><b><a href="#typedef-pseudo-page">#typedef-pseudo-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-page">4.3. @page rule grammar</a> <a href="#ref-for-typedef-pseudo-page①">(2)</a> <a href="#ref-for-typedef-pseudo-page②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-top-left-corner">
-   <b><a href="#at-ruledef-top-left-corner">#at-ruledef-top-left-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-top-left-corner" class="dfn-panel" data-for="at-ruledef-top-left-corner" id="infopanel-for-at-ruledef-top-left-corner" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-top-left-corner" style="display:none">Info about the '@top-left-corner' definition.</span><b><a href="#at-ruledef-top-left-corner">#at-ruledef-top-left-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-top-left-corner">3.1. 
 Page Backgrounds and Painting Order</a> <a href="#ref-for-at-ruledef-top-left-corner①">(2)</a>
@@ -4521,8 +4521,8 @@ Page Backgrounds and Painting Order</a> <a href="#ref-for-at-ruledef-top-left-co
     <li><a href="#ref-for-at-ruledef-top-left-corner③">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-top-left">
-   <b><a href="#at-ruledef-top-left">#at-ruledef-top-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-top-left" class="dfn-panel" data-for="at-ruledef-top-left" id="infopanel-for-at-ruledef-top-left" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-top-left" style="display:none">Info about the '@top-left' definition.</span><b><a href="#at-ruledef-top-left">#at-ruledef-top-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-top-left">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4534,8 +4534,8 @@ Page-Margin Box Variable Dimension Computation Rules</a>
     <li><a href="#ref-for-at-ruledef-top-left⑤">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-top-center">
-   <b><a href="#at-ruledef-top-center">#at-ruledef-top-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-top-center" class="dfn-panel" data-for="at-ruledef-top-center" id="infopanel-for-at-ruledef-top-center" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-top-center" style="display:none">Info about the '@top-center' definition.</span><b><a href="#at-ruledef-top-center">#at-ruledef-top-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-top-center">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4546,8 +4546,8 @@ Page-Margin Box Variable Dimension Computation Rules</a>
     <li><a href="#ref-for-at-ruledef-top-center④">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-top-right">
-   <b><a href="#at-ruledef-top-right">#at-ruledef-top-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-top-right" class="dfn-panel" data-for="at-ruledef-top-right" id="infopanel-for-at-ruledef-top-right" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-top-right" style="display:none">Info about the '@top-right' definition.</span><b><a href="#at-ruledef-top-right">#at-ruledef-top-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-top-right">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4558,8 +4558,8 @@ Page-Margin Box Variable Dimension Computation Rules</a>
     <li><a href="#ref-for-at-ruledef-top-right④">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-top-right-corner">
-   <b><a href="#at-ruledef-top-right-corner">#at-ruledef-top-right-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-top-right-corner" class="dfn-panel" data-for="at-ruledef-top-right-corner" id="infopanel-for-at-ruledef-top-right-corner" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-top-right-corner" style="display:none">Info about the '@top-right-corner' definition.</span><b><a href="#at-ruledef-top-right-corner">#at-ruledef-top-right-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-top-right-corner">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4567,16 +4567,16 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-top-right-corner②">5.3.3. Page-Margin Box Fixed Dimension Computation Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-bottom-left-corner">
-   <b><a href="#at-ruledef-bottom-left-corner">#at-ruledef-bottom-left-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-bottom-left-corner" class="dfn-panel" data-for="at-ruledef-bottom-left-corner" id="infopanel-for-at-ruledef-bottom-left-corner" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-bottom-left-corner" style="display:none">Info about the '@bottom-left-corner' definition.</span><b><a href="#at-ruledef-bottom-left-corner">#at-ruledef-bottom-left-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-bottom-left-corner">3.1. 
 Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-bottom-left-corner①">5. Page-Margin Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-bottom-left">
-   <b><a href="#at-ruledef-bottom-left">#at-ruledef-bottom-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-bottom-left" class="dfn-panel" data-for="at-ruledef-bottom-left" id="infopanel-for-at-ruledef-bottom-left" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-bottom-left" style="display:none">Info about the '@bottom-left' definition.</span><b><a href="#at-ruledef-bottom-left">#at-ruledef-bottom-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-bottom-left">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4584,8 +4584,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-bottom-left②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-bottom-center">
-   <b><a href="#at-ruledef-bottom-center">#at-ruledef-bottom-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-bottom-center" class="dfn-panel" data-for="at-ruledef-bottom-center" id="infopanel-for-at-ruledef-bottom-center" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-bottom-center" style="display:none">Info about the '@bottom-center' definition.</span><b><a href="#at-ruledef-bottom-center">#at-ruledef-bottom-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-bottom-center">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4593,8 +4593,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-bottom-center②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-bottom-right">
-   <b><a href="#at-ruledef-bottom-right">#at-ruledef-bottom-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-bottom-right" class="dfn-panel" data-for="at-ruledef-bottom-right" id="infopanel-for-at-ruledef-bottom-right" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-bottom-right" style="display:none">Info about the '@bottom-right' definition.</span><b><a href="#at-ruledef-bottom-right">#at-ruledef-bottom-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-bottom-right">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4602,16 +4602,16 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-bottom-right②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-bottom-right-corner">
-   <b><a href="#at-ruledef-bottom-right-corner">#at-ruledef-bottom-right-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-bottom-right-corner" class="dfn-panel" data-for="at-ruledef-bottom-right-corner" id="infopanel-for-at-ruledef-bottom-right-corner" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-bottom-right-corner" style="display:none">Info about the '@bottom-right-corner' definition.</span><b><a href="#at-ruledef-bottom-right-corner">#at-ruledef-bottom-right-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-bottom-right-corner">3.1. 
 Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-bottom-right-corner①">5. Page-Margin Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-left-top">
-   <b><a href="#at-ruledef-left-top">#at-ruledef-left-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-left-top" class="dfn-panel" data-for="at-ruledef-left-top" id="infopanel-for-at-ruledef-left-top" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-left-top" style="display:none">Info about the '@left-top' definition.</span><b><a href="#at-ruledef-left-top">#at-ruledef-left-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-left-top">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4619,8 +4619,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-left-top②">5.3.2.5. Boxes on other sides</a> <a href="#ref-for-at-ruledef-left-top③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-left-middle">
-   <b><a href="#at-ruledef-left-middle">#at-ruledef-left-middle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-left-middle" class="dfn-panel" data-for="at-ruledef-left-middle" id="infopanel-for-at-ruledef-left-middle" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-left-middle" style="display:none">Info about the '@left-middle' definition.</span><b><a href="#at-ruledef-left-middle">#at-ruledef-left-middle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-left-middle">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4628,8 +4628,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-left-middle②">5.3.2.5. Boxes on other sides</a> <a href="#ref-for-at-ruledef-left-middle③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-left-bottom">
-   <b><a href="#at-ruledef-left-bottom">#at-ruledef-left-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-left-bottom" class="dfn-panel" data-for="at-ruledef-left-bottom" id="infopanel-for-at-ruledef-left-bottom" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-left-bottom" style="display:none">Info about the '@left-bottom' definition.</span><b><a href="#at-ruledef-left-bottom">#at-ruledef-left-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-left-bottom">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4637,8 +4637,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-left-bottom②">5.3.2.5. Boxes on other sides</a> <a href="#ref-for-at-ruledef-left-bottom③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-right-top">
-   <b><a href="#at-ruledef-right-top">#at-ruledef-right-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-right-top" class="dfn-panel" data-for="at-ruledef-right-top" id="infopanel-for-at-ruledef-right-top" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-right-top" style="display:none">Info about the '@right-top' definition.</span><b><a href="#at-ruledef-right-top">#at-ruledef-right-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-right-top">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4646,8 +4646,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-right-top②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-right-middle">
-   <b><a href="#at-ruledef-right-middle">#at-ruledef-right-middle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-right-middle" class="dfn-panel" data-for="at-ruledef-right-middle" id="infopanel-for-at-ruledef-right-middle" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-right-middle" style="display:none">Info about the '@right-middle' definition.</span><b><a href="#at-ruledef-right-middle">#at-ruledef-right-middle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-right-middle">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4655,8 +4655,8 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-right-middle②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-right-bottom">
-   <b><a href="#at-ruledef-right-bottom">#at-ruledef-right-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-right-bottom" class="dfn-panel" data-for="at-ruledef-right-bottom" id="infopanel-for-at-ruledef-right-bottom" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-right-bottom" style="display:none">Info about the '@right-bottom' definition.</span><b><a href="#at-ruledef-right-bottom">#at-ruledef-right-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-right-bottom">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4664,15 +4664,15 @@ Page Backgrounds and Painting Order</a>
     <li><a href="#ref-for-at-ruledef-right-bottom②">5.3.2.5. Boxes on other sides</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specificity">
-   <b><a href="#specificity">#specificity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specificity" class="dfn-panel" data-for="specificity" id="infopanel-for-specificity" role="dialog">
+   <span id="infopaneltitle-for-specificity" style="display:none">Info about the 'specificity' definition.</span><b><a href="#specificity">#specificity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specificity">4.2.3. 
 Blank-page pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-at-rule">
-   <b><a href="#margin-at-rule">#margin-at-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-at-rule" class="dfn-panel" data-for="margin-at-rule" id="infopanel-for-margin-at-rule" role="dialog">
+   <span id="infopaneltitle-for-margin-at-rule" style="display:none">Info about the 'margin at-rule' definition.</span><b><a href="#margin-at-rule">#margin-at-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-at-rule">4.1. 
 The @page Rule</a>
@@ -4680,88 +4680,88 @@ The @page Rule</a>
     <li><a href="#ref-for-margin-at-rule③">5.1. At-rules for page-margin boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-context">
-   <b><a href="#margin-context">#margin-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-context" class="dfn-panel" data-for="margin-context" id="infopanel-for-margin-context" role="dialog">
+   <span id="infopaneltitle-for-margin-context" style="display:none">Info about the 'margin context' definition.</span><b><a href="#margin-context">#margin-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-context">3. The Page Model</a>
     <li><a href="#ref-for-margin-context①">6. 
 Page Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generated">
-   <b><a href="#generated">#generated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generated" class="dfn-panel" data-for="generated" id="infopanel-for-generated" role="dialog">
+   <span id="infopaneltitle-for-generated" style="display:none">Info about the 'generated' definition.</span><b><a href="#generated">#generated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generated">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-generated①">(2)</a> <a href="#ref-for-generated②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-width">
-   <b><a href="#available-width">#available-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-width" class="dfn-panel" data-for="available-width" id="infopanel-for-available-width" role="dialog">
+   <span id="infopaneltitle-for-available-width" style="display:none">Info about the 'available width' definition.</span><b><a href="#available-width">#available-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-width">5.3.1. 
 Page-Margin Box Layout Terminology</a>
     <li><a href="#ref-for-available-width①">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-available-width②">(2)</a> <a href="#ref-for-available-width③">(3)</a> <a href="#ref-for-available-width④">(4)</a> <a href="#ref-for-available-width⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available-height">
-   <b><a href="#available-height">#available-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available-height" class="dfn-panel" data-for="available-height" id="infopanel-for-available-height" role="dialog">
+   <span id="infopaneltitle-for-available-height" style="display:none">Info about the 'available height' definition.</span><b><a href="#available-height">#available-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available-height">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-width">
-   <b><a href="#outer-width">#outer-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-width" class="dfn-panel" data-for="outer-width" id="infopanel-for-outer-width" role="dialog">
+   <span id="infopaneltitle-for-outer-width" style="display:none">Info about the 'outer width' definition.</span><b><a href="#outer-width">#outer-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-width">5.3.1. 
 Page-Margin Box Layout Terminology</a> <a href="#ref-for-outer-width①">(2)</a>
     <li><a href="#ref-for-outer-width②">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-outer-width③">(2)</a> <a href="#ref-for-outer-width④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-width">
-   <b><a href="#min-content-width">#min-content-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-width" class="dfn-panel" data-for="min-content-width" id="infopanel-for-min-content-width" role="dialog">
+   <span id="infopaneltitle-for-min-content-width" style="display:none">Info about the 'min-content width' definition.</span><b><a href="#min-content-width">#min-content-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-width">5.3.1. 
 Page-Margin Box Layout Terminology</a>
     <li><a href="#ref-for-min-content-width①">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-min-content-width②">(2)</a> <a href="#ref-for-min-content-width③">(3)</a> <a href="#ref-for-min-content-width④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-width">
-   <b><a href="#max-content-width">#max-content-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-width" class="dfn-panel" data-for="max-content-width" id="infopanel-for-max-content-width" role="dialog">
+   <span id="infopaneltitle-for-max-content-width" style="display:none">Info about the 'max-content width' definition.</span><b><a href="#max-content-width">#max-content-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-width">5.3.1. 
 Page-Margin Box Layout Terminology</a>
     <li><a href="#ref-for-max-content-width①">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-max-content-width②">(2)</a> <a href="#ref-for-max-content-width③">(3)</a> <a href="#ref-for-max-content-width④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containing-block">
-   <b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containing-block" class="dfn-panel" data-for="containing-block" id="infopanel-for-containing-block" role="dialog">
+   <span id="infopaneltitle-for-containing-block" style="display:none">Info about the 'containing block' definition.</span><b><a href="#containing-block">#containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3. The Page Model</a> <a href="#ref-for-containing-block①">(2)</a>
     <li><a href="#ref-for-containing-block②">5.3.1. 
 Page-Margin Box Layout Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-space">
-   <b><a href="#flex-space">#flex-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-space" class="dfn-panel" data-for="flex-space" id="infopanel-for-flex-space" role="dialog">
+   <span id="infopaneltitle-for-flex-space" style="display:none">Info about the 'flex space' definition.</span><b><a href="#flex-space">#flex-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-space">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-flex-space①">(2)</a> <a href="#ref-for-flex-space②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flex-factor">
-   <b><a href="#flex-factor">#flex-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flex-factor" class="dfn-panel" data-for="flex-factor" id="infopanel-for-flex-factor" role="dialog">
+   <span id="infopaneltitle-for-flex-factor" style="display:none">Info about the 'flex factor' definition.</span><b><a href="#flex-factor">#flex-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-factor">5.3.2.2. Resolving auto widths</a> <a href="#ref-for-flex-factor①">(2)</a> <a href="#ref-for-flex-factor②">(3)</a> <a href="#ref-for-flex-factor③">(4)</a> <a href="#ref-for-flex-factor④">(5)</a> <a href="#ref-for-flex-factor⑤">(6)</a> <a href="#ref-for-flex-factor⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-page-size">
-   <b><a href="#descdef-page-size">#descdef-page-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-page-size" class="dfn-panel" data-for="descdef-page-size" id="infopanel-for-descdef-page-size" role="dialog">
+   <span id="infopaneltitle-for-descdef-page-size" style="display:none">Info about the 'size' definition.</span><b><a href="#descdef-page-size">#descdef-page-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-page-size">7.1.2. 
 Rotating The Printed Page: the page-orientation property</a> <a href="#ref-for-descdef-page-size①">(2)</a> <a href="#ref-for-descdef-page-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-size-landscape">
-   <b><a href="#valdef-page-size-landscape">#valdef-page-size-landscape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-size-landscape" class="dfn-panel" data-for="valdef-page-size-landscape" id="infopanel-for-valdef-page-size-landscape" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-size-landscape" style="display:none">Info about the 'landscape' definition.</span><b><a href="#valdef-page-size-landscape">#valdef-page-size-landscape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-size-landscape">2. 
 Page Terminology</a>
@@ -4771,8 +4771,8 @@ Page size: the size property</a>
 Rotating The Printed Page: the page-orientation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-size-portrait">
-   <b><a href="#valdef-page-size-portrait">#valdef-page-size-portrait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-size-portrait" class="dfn-panel" data-for="valdef-page-size-portrait" id="infopanel-for-valdef-page-size-portrait" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-size-portrait" style="display:none">Info about the 'portrait' definition.</span><b><a href="#valdef-page-size-portrait">#valdef-page-size-portrait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-size-portrait">2. 
 Page Terminology</a>
@@ -4782,35 +4782,35 @@ Page size: the size property</a> <a href="#ref-for-valdef-page-size-portrait②"
 Rotating The Printed Page: the page-orientation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-page-size-page-size">
-   <b><a href="#typedef-page-size-page-size">#typedef-page-size-page-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-page-size-page-size" class="dfn-panel" data-for="typedef-page-size-page-size" id="infopanel-for-typedef-page-size-page-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-page-size-page-size" style="display:none">Info about the '&lt;page-size>' definition.</span><b><a href="#typedef-page-size-page-size">#typedef-page-size-page-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-page-size-page-size">7.1. 
 Page size: the size property</a> <a href="#ref-for-typedef-page-size-page-size①">(2)</a> <a href="#ref-for-typedef-page-size-page-size②">(3)</a> <a href="#ref-for-typedef-page-size-page-size③">(4)</a> <a href="#ref-for-typedef-page-size-page-size④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-orientation-rotate-left">
-   <b><a href="#valdef-page-orientation-rotate-left">#valdef-page-orientation-rotate-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-orientation-rotate-left" class="dfn-panel" data-for="valdef-page-orientation-rotate-left" id="infopanel-for-valdef-page-orientation-rotate-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-orientation-rotate-left" style="display:none">Info about the 'rotate-left' definition.</span><b><a href="#valdef-page-orientation-rotate-left">#valdef-page-orientation-rotate-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-orientation-rotate-left">7.1.2. 
 Rotating The Printed Page: the page-orientation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-marks-none">
-   <b><a href="#valdef-page-marks-none">#valdef-page-marks-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-marks-none" class="dfn-panel" data-for="valdef-page-marks-none" id="infopanel-for-valdef-page-marks-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-marks-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-page-marks-none">#valdef-page-marks-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-marks-none"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-marks-crop">
-   <b><a href="#valdef-page-marks-crop">#valdef-page-marks-crop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-marks-crop" class="dfn-panel" data-for="valdef-page-marks-crop" id="infopanel-for-valdef-page-marks-crop" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-marks-crop" style="display:none">Info about the 'crop' definition.</span><b><a href="#valdef-page-marks-crop">#valdef-page-marks-crop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-marks-crop">7.3. 
 Bleed Area: the bleed property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bleed-area">
-   <b><a href="#bleed-area">#bleed-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bleed-area" class="dfn-panel" data-for="bleed-area" id="infopanel-for-bleed-area" role="dialog">
+   <span id="infopaneltitle-for-bleed-area" style="display:none">Info about the 'bleed area' definition.</span><b><a href="#bleed-area">#bleed-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bleed-area">3.1. 
 Page Backgrounds and Painting Order</a>
@@ -4820,101 +4820,157 @@ Crop and Registration Marks: the marks property</a>
 Bleed Area: the bleed property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-bleed-auto">
-   <b><a href="#valdef-page-bleed-auto">#valdef-page-bleed-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-bleed-auto" class="dfn-panel" data-for="valdef-page-bleed-auto" id="infopanel-for-valdef-page-bleed-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-bleed-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-page-bleed-auto">#valdef-page-bleed-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-bleed-auto"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-page">
-   <b><a href="#propdef-page">#propdef-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-page" class="dfn-panel" data-for="propdef-page" id="infopanel-for-propdef-page" role="dialog">
+   <span id="infopaneltitle-for-propdef-page" style="display:none">Info about the 'page' definition.</span><b><a href="#propdef-page">#propdef-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">4.2. Page selectors</a>
     <li><a href="#ref-for-propdef-page①">8.1. 
 Using named pages: page</a> <a href="#ref-for-propdef-page②">(2)</a> <a href="#ref-for-propdef-page③">(3)</a> <a href="#ref-for-propdef-page④">(4)</a> <a href="#ref-for-propdef-page⑤">(5)</a> <a href="#ref-for-propdef-page⑥">(6)</a> <a href="#ref-for-propdef-page⑦">(7)</a> <a href="#ref-for-propdef-page⑧">(8)</a> <a href="#ref-for-propdef-page⑨">(9)</a> <a href="#ref-for-propdef-page①⓪">(10)</a> <a href="#ref-for-propdef-page①①">(11)</a> <a href="#ref-for-propdef-page①②">(12)</a> <a href="#ref-for-propdef-page①③">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-page-value">
-   <b><a href="#start-page-value">#start-page-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-page-value" class="dfn-panel" data-for="start-page-value" id="infopanel-for-start-page-value" role="dialog">
+   <span id="infopaneltitle-for-start-page-value" style="display:none">Info about the 'start page value' definition.</span><b><a href="#start-page-value">#start-page-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-page-value">8.1. 
 Using named pages: page</a> <a href="#ref-for-start-page-value①">(2)</a> <a href="#ref-for-start-page-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-page-value">
-   <b><a href="#end-page-value">#end-page-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-page-value" class="dfn-panel" data-for="end-page-value" id="infopanel-for-end-page-value" role="dialog">
+   <span id="infopaneltitle-for-end-page-value" style="display:none">Info about the 'end page value' definition.</span><b><a href="#end-page-value">#end-page-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-page-value">8.1. 
 Using named pages: page</a> <a href="#ref-for-end-page-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-property">
-   <b><a href="#page-property">#page-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-property" class="dfn-panel" data-for="page-property" id="infopanel-for-page-property" role="dialog">
+   <span id="infopaneltitle-for-page-property" style="display:none">Info about the 'page properties' definition.</span><b><a href="#page-property">#page-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-property">4.3. @page rule grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-margin-property">
-   <b><a href="#page-margin-property">#page-margin-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-margin-property" class="dfn-panel" data-for="page-margin-property" id="infopanel-for-page-margin-property" role="dialog">
+   <span id="infopaneltitle-for-page-margin-property" style="display:none">Info about the 'page-margin properties' definition.</span><b><a href="#page-margin-property">#page-margin-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-margin-property">4.3. @page rule grammar</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-page-floats-3/Overview.html
@@ -1812,8 +1812,8 @@ canvas {
      <li><a href="#valdef-float-top">value for float</a><span>, in § 3.2</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">1. Overview</a> <a href="#ref-for-fragmentation-container①">(2)</a>
     <li><a href="#ref-for-fragmentation-container②">5. Deferring page floats</a> <a href="#ref-for-fragmentation-container③">(2)</a>
@@ -1821,53 +1821,53 @@ canvas {
     <li><a href="#ref-for-fragmentation-container①⑥">8. Page float placement</a> <a href="#ref-for-fragmentation-container①⑦">(2)</a> <a href="#ref-for-fragmentation-container①⑧">(3)</a> <a href="#ref-for-fragmentation-container①⑨">(4)</a> <a href="#ref-for-fragmentation-container②⓪">(5)</a> <a href="#ref-for-fragmentation-container②①">(6)</a> <a href="#ref-for-fragmentation-container②②">(7)</a> <a href="#ref-for-fragmentation-container②③">(8)</a> <a href="#ref-for-fragmentation-container②④">(9)</a> <a href="#ref-for-fragmentation-container②⑤">(10)</a> <a href="#ref-for-fragmentation-container②⑥">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">5.1. The float-defer property</a> <a href="#ref-for-fragmentation-context①">(2)</a> <a href="#ref-for-fragmentation-context②">(3)</a> <a href="#ref-for-fragmentation-context③">(4)</a> <a href="#ref-for-fragmentation-context④">(5)</a> <a href="#ref-for-fragmentation-context⑤">(6)</a> <a href="#ref-for-fragmentation-context⑥">(7)</a>
     <li><a href="#ref-for-fragmentation-context⑦">8. Page float placement</a> <a href="#ref-for-fragmentation-context⑧">(2)</a> <a href="#ref-for-fragmentation-context⑨">(3)</a> <a href="#ref-for-fragmentation-context①⓪">(4)</a> <a href="#ref-for-fragmentation-context①①">(5)</a> <a href="#ref-for-fragmentation-context①②">(6)</a>
     <li><a href="#ref-for-fragmentation-context①③">8.2. Rules for page float stacking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3.2. The float property</a> <a href="#ref-for-comb-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">7. The float-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.2. The float property</a> <a href="#ref-for-length-value①">(2)</a>
     <li><a href="#ref-for-length-value②">7. The float-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">7. The float-offset property</a> <a href="#ref-for-percentage-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.2. The float property</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. The float-reference property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">3.2. The float property</a> <a href="#ref-for-comb-one④">(2)</a> <a href="#ref-for-comb-one⑤">(3)</a> <a href="#ref-for-comb-one⑥">(4)</a> <a href="#ref-for-comb-one⑦">(5)</a> <a href="#ref-for-comb-one⑧">(6)</a> <a href="#ref-for-comb-one⑨">(7)</a> <a href="#ref-for-comb-one①⓪">(8)</a> <a href="#ref-for-comb-one①①">(9)</a> <a href="#ref-for-comb-one①②">(10)</a> <a href="#ref-for-comb-one①③">(11)</a> <a href="#ref-for-comb-one①④">(12)</a> <a href="#ref-for-comb-one①⑤">(13)</a> <a href="#ref-for-comb-one①⑥">(14)</a> <a href="#ref-for-comb-one①⑦">(15)</a> <a href="#ref-for-comb-one①⑧">(16)</a>
@@ -1877,42 +1877,42 @@ The clear property</a> <a href="#ref-for-comb-one②⓪">(2)</a> <a href="#ref-f
     <li><a href="#ref-for-comb-one②⑨">7. The float-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.2. The float property</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a>
     <li><a href="#ref-for-propdef-direction④">4. 
 The clear property</a> <a href="#ref-for-propdef-direction⑤">(2)</a> <a href="#ref-for-propdef-direction⑥">(3)</a> <a href="#ref-for-propdef-direction⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">3.2. The float property</a> <a href="#ref-for-inline-size①">(2)</a> <a href="#ref-for-inline-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">3.2. The float property</a> <a href="#ref-for-propdef-writing-mode①">(2)</a> <a href="#ref-for-propdef-writing-mode②">(3)</a> <a href="#ref-for-propdef-writing-mode③">(4)</a>
     <li><a href="#ref-for-propdef-writing-mode④">4. 
 The clear property</a> <a href="#ref-for-propdef-writing-mode⑤">(2)</a> <a href="#ref-for-propdef-writing-mode⑥">(3)</a> <a href="#ref-for-propdef-writing-mode⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://www.w3.org/TR/CSS22/visudet.html#propdef-max-height">https://www.w3.org/TR/CSS22/visudet.html#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://www.w3.org/TR/CSS22/visudet.html#propdef-max-height">https://www.w3.org/TR/CSS22/visudet.html#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">3.2. The float property</a> <a href="#ref-for-propdef-max-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://www.w3.org/TR/CSS22/visudet.html#propdef-max-width">https://www.w3.org/TR/CSS22/visudet.html#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://www.w3.org/TR/CSS22/visudet.html#propdef-max-width">https://www.w3.org/TR/CSS22/visudet.html#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">3.2. The float property</a> <a href="#ref-for-propdef-max-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-wrap-flow">
-   <a href="https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow">https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-wrap-flow" class="dfn-panel" data-for="term-for-propdef-wrap-flow" id="infopanel-for-term-for-propdef-wrap-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-wrap-flow" style="display:none">Info about the 'wrap-flow' external reference.</span><a href="https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow">https://drafts.csswg.org/css-exclusions-1/#propdef-wrap-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-flow">1. Overview</a>
     <li><a href="#ref-for-propdef-wrap-flow①">6. Wrapping around page floats</a> <a href="#ref-for-propdef-wrap-flow②">(2)</a>
@@ -2100,14 +2100,14 @@ And some more text&lt;/p>
   inline-end/block-end. We should augment this with the option to have a secondary
   float direction to allow basic 2D floating. <a class="issue-return" href="#issue-329c073e" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="float">
-   <b><a href="#float">#float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float" class="dfn-panel" data-for="float" id="infopanel-for-float" role="dialog">
+   <span id="infopaneltitle-for-float" style="display:none">Info about the 'Float' definition.</span><b><a href="#float">#float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float">1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-float">
-   <b><a href="#inline-float">#inline-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-float" class="dfn-panel" data-for="inline-float" id="infopanel-for-inline-float" role="dialog">
+   <span id="infopaneltitle-for-inline-float" style="display:none">Info about the 'Inline float' definition.</span><b><a href="#inline-float">#inline-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-float">3.1. The float-reference property</a>
     <li><a href="#ref-for-inline-float①">3.2. The float property</a> <a href="#ref-for-inline-float②">(2)</a>
@@ -2118,8 +2118,8 @@ The clear property</a> <a href="#ref-for-inline-float④">(2)</a> <a href="#ref-
     <li><a href="#ref-for-inline-float⑧">7. The float-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-float">
-   <b><a href="#page-float">#page-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-float" class="dfn-panel" data-for="page-float" id="infopanel-for-page-float" role="dialog">
+   <span id="infopaneltitle-for-page-float" style="display:none">Info about the 'Page float' definition.</span><b><a href="#page-float">#page-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-float">3.1. The float-reference property</a> <a href="#ref-for-page-float①">(2)</a> <a href="#ref-for-page-float②">(3)</a>
     <li><a href="#ref-for-page-float③">3.2. The float property</a> <a href="#ref-for-page-float④">(2)</a>
@@ -2130,8 +2130,8 @@ The clear property</a> <a href="#ref-for-page-float⑥">(2)</a>
     <li><a href="#ref-for-page-float⑨">7. The float-offset property</a> <a href="#ref-for-page-float①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-anchor">
-   <b><a href="#float-anchor">#float-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-anchor" class="dfn-panel" data-for="float-anchor" id="infopanel-for-float-anchor" role="dialog">
+   <span id="infopaneltitle-for-float-anchor" style="display:none">Info about the 'Float anchor' definition.</span><b><a href="#float-anchor">#float-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-anchor">3. 
 Floating to the inline-start/inline-end and block-start/block-end</a> <a href="#ref-for-float-anchor①">(2)</a>
@@ -2141,24 +2141,24 @@ Floating to the inline-start/inline-end and block-start/block-end</a> <a href="#
     <li><a href="#ref-for-float-anchor①⑧">8. Page float placement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-containing-block-formatting-context">
-   <b><a href="#float-containing-block-formatting-context">#float-containing-block-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-containing-block-formatting-context" class="dfn-panel" data-for="float-containing-block-formatting-context" id="infopanel-for-float-containing-block-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-float-containing-block-formatting-context" style="display:none">Info about the 'Float containing block formatting context' definition.</span><b><a href="#float-containing-block-formatting-context">#float-containing-block-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-containing-block-formatting-context">3.1. The float-reference property</a> <a href="#ref-for-float-containing-block-formatting-context①">(2)</a> <a href="#ref-for-float-containing-block-formatting-context②">(3)</a> <a href="#ref-for-float-containing-block-formatting-context③">(4)</a> <a href="#ref-for-float-containing-block-formatting-context④">(5)</a>
     <li><a href="#ref-for-float-containing-block-formatting-context⑤">9.1. 
 Differences between inline floats and absolutely positioned elements</a> <a href="#ref-for-float-containing-block-formatting-context⑥">(2)</a> <a href="#ref-for-float-containing-block-formatting-context⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initial-float-reference">
-   <b><a href="#initial-float-reference">#initial-float-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initial-float-reference" class="dfn-panel" data-for="initial-float-reference" id="infopanel-for-initial-float-reference" role="dialog">
+   <span id="infopaneltitle-for-initial-float-reference" style="display:none">Info about the 'Initial float reference' definition.</span><b><a href="#initial-float-reference">#initial-float-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-float-reference">5. Deferring page floats</a> <a href="#ref-for-initial-float-reference①">(2)</a>
     <li><a href="#ref-for-initial-float-reference②">5.1. The float-defer property</a> <a href="#ref-for-initial-float-reference③">(2)</a> <a href="#ref-for-initial-float-reference④">(3)</a> <a href="#ref-for-initial-float-reference⑤">(4)</a> <a href="#ref-for-initial-float-reference⑥">(5)</a> <a href="#ref-for-initial-float-reference⑦">(6)</a> <a href="#ref-for-initial-float-reference⑧">(7)</a>
     <li><a href="#ref-for-initial-float-reference⑨">8. Page float placement</a> <a href="#ref-for-initial-float-reference①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-reference">
-   <b><a href="#float-reference">#float-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-reference" class="dfn-panel" data-for="float-reference" id="infopanel-for-float-reference" role="dialog">
+   <span id="infopaneltitle-for-float-reference" style="display:none">Info about the 'Float reference' definition.</span><b><a href="#float-reference">#float-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-reference">1. Overview</a>
     <li><a href="#ref-for-float-reference①">3. 
@@ -2171,14 +2171,14 @@ The clear property</a> <a href="#ref-for-float-reference③②">(2)</a> <a href=
     <li><a href="#ref-for-float-reference④③">8.2. Rules for page float stacking</a> <a href="#ref-for-float-reference④④">(2)</a> <a href="#ref-for-float-reference④⑤">(3)</a> <a href="#ref-for-float-reference④⑥">(4)</a> <a href="#ref-for-float-reference④⑦">(5)</a> <a href="#ref-for-float-reference④⑧">(6)</a> <a href="#ref-for-float-reference④⑨">(7)</a> <a href="#ref-for-float-reference⑤⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="not-overlapping">
-   <b><a href="#not-overlapping">#not-overlapping</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-not-overlapping" class="dfn-panel" data-for="not-overlapping" id="infopanel-for-not-overlapping" role="dialog">
+   <span id="infopaneltitle-for-not-overlapping" style="display:none">Info about the 'Not overlapping' definition.</span><b><a href="#not-overlapping">#not-overlapping</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-overlapping">8.2. Rules for page float stacking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float-reference">
-   <b><a href="#propdef-float-reference">#propdef-float-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float-reference" class="dfn-panel" data-for="propdef-float-reference" id="infopanel-for-propdef-float-reference" role="dialog">
+   <span id="infopaneltitle-for-propdef-float-reference" style="display:none">Info about the 'float-reference' definition.</span><b><a href="#propdef-float-reference">#propdef-float-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float-reference">3. 
 Floating to the inline-start/inline-end and block-start/block-end</a>
@@ -2186,8 +2186,8 @@ Floating to the inline-start/inline-end and block-start/block-end</a>
     <li><a href="#ref-for-propdef-float-reference②">8. Page float placement</a> <a href="#ref-for-propdef-float-reference③">(2)</a> <a href="#ref-for-propdef-float-reference④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float">
-   <b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float" class="dfn-panel" data-for="propdef-float" id="infopanel-for-propdef-float" role="dialog">
+   <span id="infopaneltitle-for-propdef-float" style="display:none">Info about the 'float' definition.</span><b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">1. Overview</a>
     <li><a href="#ref-for-propdef-float①">3. 
@@ -2197,20 +2197,20 @@ Floating to the inline-start/inline-end and block-start/block-end</a>
     <li><a href="#ref-for-propdef-float④">8.2. Rules for page float stacking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-float-snap-block">
-   <b><a href="#funcdef-float-snap-block">#funcdef-float-snap-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-float-snap-block" class="dfn-panel" data-for="funcdef-float-snap-block" id="infopanel-for-funcdef-float-snap-block" role="dialog">
+   <span id="infopaneltitle-for-funcdef-float-snap-block" style="display:none">Info about the 'snap-block()' definition.</span><b><a href="#funcdef-float-snap-block">#funcdef-float-snap-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-float-snap-block">3.2. The float property</a> <a href="#ref-for-funcdef-float-snap-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-float-snap-inline">
-   <b><a href="#funcdef-float-snap-inline">#funcdef-float-snap-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-float-snap-inline" class="dfn-panel" data-for="funcdef-float-snap-inline" id="infopanel-for-funcdef-float-snap-inline" role="dialog">
+   <span id="infopaneltitle-for-funcdef-float-snap-inline" style="display:none">Info about the 'snap-inline()' definition.</span><b><a href="#funcdef-float-snap-inline">#funcdef-float-snap-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-float-snap-inline">3.2. The float property</a> <a href="#ref-for-funcdef-float-snap-inline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clear">
-   <b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clear" class="dfn-panel" data-for="propdef-clear" id="infopanel-for-propdef-clear" role="dialog">
+   <span id="infopaneltitle-for-propdef-clear" style="display:none">Info about the 'clear' definition.</span><b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">1. Overview</a>
     <li><a href="#ref-for-propdef-clear①">4. 
@@ -2218,16 +2218,16 @@ The clear property</a> <a href="#ref-for-propdef-clear②">(2)</a>
     <li><a href="#ref-for-propdef-clear③">8.2. Rules for page float stacking</a> <a href="#ref-for-propdef-clear④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float-defer">
-   <b><a href="#propdef-float-defer">#propdef-float-defer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float-defer" class="dfn-panel" data-for="propdef-float-defer" id="infopanel-for-propdef-float-defer" role="dialog">
+   <span id="infopaneltitle-for-propdef-float-defer" style="display:none">Info about the 'float-defer' definition.</span><b><a href="#propdef-float-defer">#propdef-float-defer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float-defer">5. Deferring page floats</a>
     <li><a href="#ref-for-propdef-float-defer①">5.1. The float-defer property</a>
     <li><a href="#ref-for-propdef-float-defer②">10. Overconstrained floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float-offset">
-   <b><a href="#propdef-float-offset">#propdef-float-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float-offset" class="dfn-panel" data-for="propdef-float-offset" id="infopanel-for-propdef-float-offset" role="dialog">
+   <span id="infopaneltitle-for-propdef-float-offset" style="display:none">Info about the 'float-offset' definition.</span><b><a href="#propdef-float-offset">#propdef-float-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float-offset">7. The float-offset property</a> <a href="#ref-for-propdef-float-offset①">(2)</a>
     <li><a href="#ref-for-propdef-float-offset②">8.2. Rules for page float stacking</a>
@@ -2235,57 +2235,113 @@ The clear property</a> <a href="#ref-for-propdef-clear②">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-position-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-position-3/Overview.html
@@ -2639,15 +2639,15 @@ that at least some of the dialog is outside the "poisoned pixels" that web conte
    <li><a href="#propdef-top">top</a><span>, in § 3.1</span>
    <li><a href="#weaker-inset">weaker inset</a><span>, in § 3.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-center">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-center" class="dfn-panel" data-for="term-for-valdef-self-position-center" id="infopanel-for-term-for-valdef-self-position-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-center">https://drafts.csswg.org/css-align-3/#valdef-self-position-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-center">3.5. 
 Absolute (and Fixed) Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-normal">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-normal" class="dfn-panel" data-for="term-for-valdef-align-self-normal" id="infopanel-for-term-for-valdef-align-self-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">https://drafts.csswg.org/css-align-3/#valdef-align-self-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-normal">3.5. 
 Absolute (and Fixed) Positioning</a>
@@ -2657,15 +2657,15 @@ Automatic Sizes of Absolutely-Positioned Boxes</a> <a href="#ref-for-valdef-alig
 Old Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-self-align">
-   <a href="https://drafts.csswg.org/css-align-3/#self-align">https://drafts.csswg.org/css-align-3/#self-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-self-align" class="dfn-panel" data-for="term-for-self-align" id="infopanel-for-term-for-self-align" role="menu">
+   <span id="infopaneltitle-for-term-for-self-align" style="display:none">Info about the 'self-alignment' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#self-align">https://drafts.csswg.org/css-align-3/#self-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-align">5. 
 Old Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-self-alignment-properties">
-   <a href="https://drafts.csswg.org/css-align-3/#self-alignment-properties">https://drafts.csswg.org/css-align-3/#self-alignment-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-self-alignment-properties" class="dfn-panel" data-for="term-for-self-alignment-properties" id="infopanel-for-term-for-self-alignment-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-self-alignment-properties" style="display:none">Info about the 'self-alignment properties' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#self-alignment-properties">https://drafts.csswg.org/css-align-3/#self-alignment-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-alignment-properties">3.5. 
 Absolute (and Fixed) Positioning</a> <a href="#ref-for-self-alignment-properties①">(2)</a>
@@ -2675,78 +2675,78 @@ Absolute Positioning Layout Model</a>
 Automatic Sizes of Absolutely-Positioned Boxes</a> <a href="#ref-for-self-alignment-properties④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-self-end">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-self-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-self-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-self-end" class="dfn-panel" data-for="term-for-valdef-self-position-self-end" id="infopanel-for-term-for-valdef-self-position-self-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-self-end" style="display:none">Info about the 'self-end' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-self-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-self-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-self-end">3.5. 
 Absolute (and Fixed) Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-self-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-self-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-self-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-self-start" class="dfn-panel" data-for="term-for-valdef-self-position-self-start" id="infopanel-for-term-for-valdef-self-position-self-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-self-start" style="display:none">Info about the 'self-start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-self-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-self-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-self-start">3.5. 
 Absolute (and Fixed) Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-stretch" class="dfn-panel" data-for="term-for-valdef-align-self-stretch" id="infopanel-for-term-for-valdef-align-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a> <a href="#ref-for-valdef-align-self-stretch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">2.1. 
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">3.4. 
 Sticky positioning</a> <a href="#ref-for-border-box①">(2)</a> <a href="#ref-for-border-box②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">3.4. 
 Sticky positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-content-edge①">(2)</a>
@@ -2754,16 +2754,16 @@ Containing Blocks of Positioned Boxes</a> <a href="#ref-for-content-edge①">(2)
 Resolving Automatic Insets</a> <a href="#ref-for-content-edge③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-propdef-margin①">(2)</a>
     <li><a href="#ref-for-propdef-margin②"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">3.4. 
 Sticky positioning</a> <a href="#ref-for-margin-box①">(2)</a>
@@ -2773,15 +2773,15 @@ Absolute (and Fixed) Positioning</a>
 Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-edge" class="dfn-panel" data-for="term-for-margin-edge" id="infopanel-for-term-for-margin-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-edge" style="display:none">Info about the 'margin edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-edge">https://drafts.csswg.org/css-box-4/#margin-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">3.4. 
 Sticky positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-margin-bottom①">(2)</a> <a href="#ref-for-propdef-margin-bottom②">(3)</a> <a href="#ref-for-propdef-margin-bottom③">(4)</a> <a href="#ref-for-propdef-margin-bottom④">(5)</a>
@@ -2789,8 +2789,8 @@ The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for
 The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-propdef-margin-bottom⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-margin-left①">(2)</a> <a href="#ref-for-propdef-margin-left②">(3)</a> <a href="#ref-for-propdef-margin-left③">(4)</a> <a href="#ref-for-propdef-margin-left④">(5)</a> <a href="#ref-for-propdef-margin-left⑤">(6)</a> <a href="#ref-for-propdef-margin-left⑥">(7)</a> <a href="#ref-for-propdef-margin-left⑦">(8)</a>
@@ -2798,8 +2798,8 @@ The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-propdef-margin-left⑨">(2)</a> <a href="#ref-for-propdef-margin-left①⓪">(3)</a> <a href="#ref-for-propdef-margin-left①①">(4)</a> <a href="#ref-for-propdef-margin-left①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-margin-right①">(2)</a> <a href="#ref-for-propdef-margin-right②">(3)</a> <a href="#ref-for-propdef-margin-right③">(4)</a> <a href="#ref-for-propdef-margin-right④">(5)</a> <a href="#ref-for-propdef-margin-right⑤">(6)</a> <a href="#ref-for-propdef-margin-right⑥">(7)</a> <a href="#ref-for-propdef-margin-right⑦">(8)</a>
@@ -2807,8 +2807,8 @@ The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-propdef-margin-right⑨">(2)</a> <a href="#ref-for-propdef-margin-right①⓪">(3)</a> <a href="#ref-for-propdef-margin-right①①">(4)</a> <a href="#ref-for-propdef-margin-right①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-margin-top①">(2)</a> <a href="#ref-for-propdef-margin-top②">(3)</a> <a href="#ref-for-propdef-margin-top③">(4)</a> <a href="#ref-for-propdef-margin-top④">(5)</a>
@@ -2816,99 +2816,99 @@ The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for
 The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-propdef-margin-top⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-edge" class="dfn-panel" data-for="term-for-padding-edge" id="infopanel-for-term-for-padding-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-edge" style="display:none">Info about the 'padding edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">2.1. 
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">5.3. 
 The Height Of Absolutely Positioned, Non-Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-box-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-break">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-break" class="dfn-panel" data-for="term-for-fragmentation-break" id="infopanel-for-term-for-fragmentation-break" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-break" style="display:none">Info about the 'fragmentation break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-break">https://drafts.csswg.org/css-break-4/#fragmentation-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-break">3.5.2. 
 Fragmenting Absolutely-positioned Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-container">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-container" class="dfn-panel" data-for="term-for-fragmentation-container" id="infopanel-for-term-for-fragmentation-container" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-container" style="display:none">Info about the 'fragmentation container' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-container">https://drafts.csswg.org/css-break-4/#fragmentation-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-container">3.5.2. 
 Fragmenting Absolutely-positioned Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmented-flow">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmented-flow">https://drafts.csswg.org/css-break-4/#fragmented-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmented-flow" class="dfn-panel" data-for="term-for-fragmented-flow" id="infopanel-for-term-for-fragmented-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmented-flow" style="display:none">Info about the 'fragmented flow' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmented-flow">https://drafts.csswg.org/css-break-4/#fragmented-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmented-flow">3.5.2. 
 Fragmenting Absolutely-positioned Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-longhand①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'longhand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-longhand①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. 
 Positioning Coordinates</a>
@@ -2916,8 +2916,8 @@ Positioning Coordinates</a>
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-shorthand-property②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property①" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property①" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3. 
 Positioning Coordinates</a>
@@ -2925,8 +2925,8 @@ Positioning Coordinates</a>
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-shorthand-property②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.3. 
 Relative Positioning</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a> <a href="#ref-for-used-value③">(4)</a>
@@ -2934,36 +2934,36 @@ Relative Positioning</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-
 Absolute (and Fixed) Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-propdef-contain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">3.5.2. 
 Fragmenting Absolutely-positioned Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blockify">
-   <a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blockify" class="dfn-panel" data-for="term-for-blockify" id="infopanel-for-term-for-blockify" role="menu">
+   <span id="infopaneltitle-for-term-for-blockify" style="display:none">Info about the 'blockify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#blockify">https://drafts.csswg.org/css-display-3/#blockify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">2. 
 Choosing A Positioning Scheme: position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-box①">(2)</a>
@@ -2973,8 +2973,8 @@ Relative Positioning</a>
 Sticky positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">1. 
 Introduction</a>
@@ -3006,15 +3006,15 @@ Normal Flow Example</a>
 Absolute Positioning Example</a> <a href="#ref-for-containing-block③④">(2)</a> <a href="#ref-for-containing-block③⑤">(3)</a> <a href="#ref-for-containing-block③⑥">(4)</a> <a href="#ref-for-containing-block③⑦">(5)</a> <a href="#ref-for-containing-block③⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-formatting-context①">(2)</a>
@@ -3022,15 +3022,15 @@ Choosing A Positioning Scheme: position property</a> <a href="#ref-for-formattin
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2. 
 Choosing A Positioning Scheme: position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-initial-containing-block①">(2)</a>
@@ -3038,29 +3038,29 @@ Containing Blocks of Positioned Boxes</a> <a href="#ref-for-initial-containing-b
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-inline-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level-box" class="dfn-panel" data-for="term-for-inline-level-box" id="infopanel-for-term-for-inline-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level-box" style="display:none">Info about the 'inline-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level-box">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-out-of-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-out-of-flow" class="dfn-panel" data-for="term-for-out-of-flow" id="infopanel-for-term-for-out-of-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-out-of-flow" style="display:none">Info about the 'out of flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow">1. 
 Introduction</a>
@@ -3070,106 +3070,106 @@ Choosing A Positioning Scheme: position property</a>
 Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-cell">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-cell" class="dfn-panel" data-for="term-for-valdef-display-table-cell" id="infopanel-for-term-for-valdef-display-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column" class="dfn-panel" data-for="term-for-valdef-display-table-column" id="infopanel-for-term-for-valdef-display-table-column" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column" style="display:none">Info about the 'table-column' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column-group" class="dfn-panel" data-for="term-for-valdef-display-table-column-group" id="infopanel-for-term-for-valdef-display-table-column-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column-group" style="display:none">Info about the 'table-column-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column-group">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-footer-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-footer-group" class="dfn-panel" data-for="term-for-valdef-display-table-footer-group" id="infopanel-for-term-for-valdef-display-table-footer-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-footer-group" style="display:none">Info about the 'table-footer-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-footer-group">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-header-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-header-group" class="dfn-panel" data-for="term-for-valdef-display-table-header-group" id="infopanel-for-term-for-valdef-display-table-header-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-header-group" style="display:none">Info about the 'table-header-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-header-group">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-row">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row">https://drafts.csswg.org/css-display-3/#valdef-display-table-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-row" class="dfn-panel" data-for="term-for-valdef-display-table-row" id="infopanel-for-term-for-valdef-display-table-row" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-row" style="display:none">Info about the 'table-row' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row">https://drafts.csswg.org/css-display-3/#valdef-display-table-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-row">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-row-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-row-group" class="dfn-panel" data-for="term-for-valdef-display-table-row-group" id="infopanel-for-term-for-valdef-display-table-row-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-row-group" style="display:none">Info about the 'table-row-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-row-group">3.3. 
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">3.5.1. 
 Resolving Automatic Insets</a> <a href="#ref-for-flex-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-area">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-area" class="dfn-panel" data-for="term-for-grid-area" id="infopanel-for-term-for-grid-area" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-area" style="display:none">Info about the 'grid area' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-area">https://drafts.csswg.org/css-grid-2/#grid-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-area">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">3.5.1. 
 Resolving Automatic Insets</a> <a href="#ref-for-grid-container①">(2)</a> <a href="#ref-for-grid-container②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-placement-property">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-placement-property">https://drafts.csswg.org/css-grid-2/#grid-placement-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-placement-property" class="dfn-panel" data-for="term-for-grid-placement-property" id="infopanel-for-term-for-grid-placement-property" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-placement-property" style="display:none">Info about the 'grid-placement property' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-placement-property">https://drafts.csswg.org/css-grid-2/#grid-placement-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-placement-property">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-scroll-position">
-   <a href="https://www.w3.org/TR/css-overflow-3/#initial-scroll-position">https://www.w3.org/TR/css-overflow-3/#initial-scroll-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-scroll-position" class="dfn-panel" data-for="term-for-initial-scroll-position" id="infopanel-for-term-for-initial-scroll-position" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-scroll-position" style="display:none">Info about the 'initial scroll position' external reference.</span><a href="https://www.w3.org/TR/css-overflow-3/#initial-scroll-position">https://www.w3.org/TR/css-overflow-3/#initial-scroll-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-scroll-position">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nearest-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#nearest-scrollport">https://drafts.csswg.org/css-overflow-3/#nearest-scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nearest-scrollport" class="dfn-panel" data-for="term-for-nearest-scrollport" id="infopanel-for-term-for-nearest-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-nearest-scrollport" style="display:none">Info about the 'nearest scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#nearest-scrollport">https://drafts.csswg.org/css-overflow-3/#nearest-scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nearest-scrollport">3.4. 
 Sticky positioning</a> <a href="#ref-for-nearest-scrollport①">(2)</a> <a href="#ref-for-nearest-scrollport②">(3)</a> <a href="#ref-for-nearest-scrollport③">(4)</a> <a href="#ref-for-nearest-scrollport④">(5)</a>
@@ -3177,8 +3177,8 @@ Sticky positioning</a> <a href="#ref-for-nearest-scrollport①">(2)</a> <a href=
 Scroll Position of Sticky-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3186,15 +3186,15 @@ Choosing A Positioning Scheme: position property</a>
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow area' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-scrollable-overflow-region①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3206,8 +3206,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Scroll Position of Sticky-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-area">
-   <a href="https://drafts.csswg.org/css-page-3/#page-area">https://drafts.csswg.org/css-page-3/#page-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-area" class="dfn-panel" data-for="term-for-page-area" id="infopanel-for-term-for-page-area" role="menu">
+   <span id="infopaneltitle-for-term-for-page-area" style="display:none">Info about the 'page area' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-area">https://drafts.csswg.org/css-page-3/#page-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-area">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3215,8 +3215,8 @@ Choosing A Positioning Scheme: position property</a>
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-page-area②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-float">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-float" class="dfn-panel" data-for="term-for-float" id="infopanel-for-term-for-float" role="menu">
+   <span id="infopaneltitle-for-term-for-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#float">https://drafts.csswg.org/css-page-floats-3/#float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float">6. 
 Informative Comparison of Normal Flow, Floats, and Positioning</a>
@@ -3224,50 +3224,50 @@ Informative Comparison of Normal Flow, Floats, and Positioning</a>
 Floating Example</a> <a href="#ref-for-float②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-valdef-width-auto①">(2)</a> <a href="#ref-for-valdef-width-auto②">(3)</a> <a href="#ref-for-valdef-width-auto③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-minimum-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-minimum-size" class="dfn-panel" data-for="term-for-automatic-minimum-size" id="infopanel-for-term-for-automatic-minimum-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a> <a href="#ref-for-automatic-size①">(2)</a> <a href="#ref-for-automatic-size②">(3)</a> <a href="#ref-for-automatic-size③">(4)</a> <a href="#ref-for-automatic-size④">(5)</a> <a href="#ref-for-automatic-size⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">4. 
 Absolute Positioning Layout Model</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">4. 
 Absolute Positioning Layout Model</a> <a href="#ref-for-definite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5.2. 
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-propdef-height①">(2)</a> <a href="#ref-for-propdef-height②">(3)</a> <a href="#ref-for-propdef-height③">(4)</a>
@@ -3277,43 +3277,43 @@ The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for
 The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-propdef-height①④">(2)</a> <a href="#ref-for-propdef-height①⑤">(3)</a> <a href="#ref-for-propdef-height①⑥">(4)</a> <a href="#ref-for-propdef-height①⑦">(5)</a> <a href="#ref-for-propdef-height①⑧">(6)</a> <a href="#ref-for-propdef-height①⑨">(7)</a> <a href="#ref-for-propdef-height②⓪">(8)</a> <a href="#ref-for-propdef-height②①">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'maximum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">4. 
 Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">4. 
 Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size" class="dfn-panel" data-for="term-for-preferred-size" id="infopanel-for-term-for-preferred-size" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size" style="display:none">Info about the 'preferred size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size">4. 
 Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a> <a href="#ref-for-propdef-width③">(4)</a> <a href="#ref-for-propdef-width④">(5)</a> <a href="#ref-for-propdef-width⑤">(6)</a> <a href="#ref-for-propdef-width⑥">(7)</a> <a href="#ref-for-propdef-width⑦">(8)</a> <a href="#ref-for-propdef-width⑧">(9)</a> <a href="#ref-for-propdef-width⑨">(10)</a>
@@ -3325,37 +3325,37 @@ The Height Of Absolutely Positioned, Replaced Elements</a>
 Floating Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-propdef-transform①">(2)</a>
     <li><a href="#ref-for-propdef-transform②"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1. 
 Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start, inset-block-end, and inset-inline-end properties </a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-mult-num-range①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
@@ -3363,15 +3363,15 @@ Choosing A Positioning Scheme: position property</a> <a href="#ref-for-comb-one�
 Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start, inset-block-end, and inset-inline-end properties </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">2.1. 
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-propdef-will-change①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a> <a href="#ref-for-propdef-direction④">(5)</a> <a href="#ref-for-propdef-direction⑤">(6)</a>
@@ -3379,22 +3379,22 @@ The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-propdef-direction⑦">(2)</a> <a href="#ref-for-propdef-direction⑧">(3)</a> <a href="#ref-for-propdef-direction⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">4.1. 
 Automatic Sizes of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">2.1. 
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-start" class="dfn-panel" data-for="term-for-block-start" id="infopanel-for-term-for-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-block-start" style="display:none">Info about the 'block-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-start">https://drafts.csswg.org/css-writing-modes-4/#block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">2.1. 
 Containing Blocks of Positioned Boxes</a>
@@ -3402,8 +3402,8 @@ Containing Blocks of Positioned Boxes</a>
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
@@ -3411,8 +3411,8 @@ Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">3. 
 Positioning Coordinates</a>
@@ -3422,22 +3422,22 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-horizontal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-horizontal-writing-mode" class="dfn-panel" data-for="term-for-horizontal-writing-mode" id="infopanel-for-term-for-horizontal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">5. 
 Old Absolute Positioning Layout Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">4.2. 
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">2.1. 
 Containing Blocks of Positioned Boxes</a>
@@ -3445,8 +3445,8 @@ Containing Blocks of Positioned Boxes</a>
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline-start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">2.1. 
 Containing Blocks of Positioned Boxes</a>
@@ -3456,22 +3456,22 @@ Resolving Automatic Insets</a>
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-over" class="dfn-panel" data-for="term-for-line-over" id="infopanel-for-term-for-line-over" role="menu">
+   <span id="infopaneltitle-for-term-for-line-over" style="display:none">Info about the 'line-over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-under" class="dfn-panel" data-for="term-for-line-under" id="infopanel-for-term-for-line-under" role="menu">
+   <span id="infopaneltitle-for-term-for-line-under" style="display:none">Info about the 'line-under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">3.5.1. 
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-ltr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-ltr" class="dfn-panel" data-for="term-for-valdef-direction-ltr" id="infopanel-for-term-for-valdef-direction-ltr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-ltr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-valdef-direction-ltr①">(2)</a> <a href="#ref-for-valdef-direction-ltr②">(3)</a> <a href="#ref-for-valdef-direction-ltr③">(4)</a> <a href="#ref-for-valdef-direction-ltr④">(5)</a>
@@ -3479,8 +3479,8 @@ The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-valdef-direction-ltr⑥">(2)</a> <a href="#ref-for-valdef-direction-ltr⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">3. 
 Positioning Coordinates</a>
@@ -3490,8 +3490,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-direction-rtl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-direction-rtl" class="dfn-panel" data-for="term-for-valdef-direction-rtl" id="infopanel-for-term-for-valdef-direction-rtl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl">https://drafts.csswg.org/css-writing-modes-4/#valdef-direction-rtl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">5.1. 
 The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-valdef-direction-rtl①">(2)</a> <a href="#ref-for-valdef-direction-rtl②">(3)</a>
@@ -3499,8 +3499,8 @@ The Width of Absolutely-Positioned, Non-Replaced Elements</a> <a href="#ref-for-
 The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-for-valdef-direction-rtl④">(2)</a> <a href="#ref-for-valdef-direction-rtl⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">3.2. 
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
@@ -3508,8 +3508,8 @@ Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
 Relative Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3.1. 
 Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start, inset-block-end, and inset-inline-end properties </a>
@@ -3517,8 +3517,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-normal-flow">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#normal-flow">https://www.w3.org/TR/CSS2/visuren.html#normal-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-normal-flow" class="dfn-panel" data-for="term-for-normal-flow" id="infopanel-for-term-for-normal-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-normal-flow" style="display:none">Info about the 'normal flow' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#normal-flow">https://www.w3.org/TR/CSS2/visuren.html#normal-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normal-flow">5.2. 
 The width of absolute or fixed positioned, replaced elements</a>
@@ -3530,22 +3530,22 @@ Normal Flow Example</a>
 Relative Positioning Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-static-position">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#static-position">https://www.w3.org/TR/CSS2/visudet.html#static-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-static-position" class="dfn-panel" data-for="term-for-static-position" id="infopanel-for-term-for-static-position" role="menu">
+   <span id="infopaneltitle-for-term-for-static-position" style="display:none">Info about the 'static position' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#static-position">https://www.w3.org/TR/CSS2/visudet.html#static-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position">3.5.1. 
 Resolving Automatic Insets</a> <a href="#ref-for-static-position①">(2)</a> <a href="#ref-for-static-position②">(3)</a> <a href="#ref-for-static-position③">(4)</a> <a href="#ref-for-static-position④">(5)</a> <a href="#ref-for-static-position⑤">(6)</a> <a href="#ref-for-static-position⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-static-position">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#static-position">https://www.w3.org/TR/CSS2/visudet.html#static-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-static-position" class="dfn-panel" data-for="term-for-static-position" id="infopanel-for-term-for-static-position①" role="menu">
+   <span id="infopaneltitle-for-term-for-static-position①" style="display:none">Info about the 'static-position containing block' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#static-position">https://www.w3.org/TR/CSS2/visudet.html#static-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position">3.5.1. 
 Resolving Automatic Insets</a> <a href="#ref-for-static-position①">(2)</a> <a href="#ref-for-static-position②">(3)</a> <a href="#ref-for-static-position③">(4)</a> <a href="#ref-for-static-position④">(5)</a> <a href="#ref-for-static-position⑤">(6)</a> <a href="#ref-for-static-position⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x1">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#x1">https://www.w3.org/TR/CSS2/visuren.html#x1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x1" class="dfn-panel" data-for="term-for-x1" id="infopanel-for-term-for-x1" role="menu">
+   <span id="infopaneltitle-for-term-for-x1" style="display:none">Info about the 'viewport' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#x1">https://www.w3.org/TR/CSS2/visuren.html#x1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x1">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-x1①">(2)</a>
@@ -3557,8 +3557,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">3.5.1. 
 Resolving Automatic Insets</a>
@@ -3566,8 +3566,8 @@ Resolving Automatic Insets</a>
 Floating Example</a> <a href="#ref-for-propdef-clear②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3575,8 +3575,8 @@ Choosing A Positioning Scheme: position property</a>
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-float-none">
-   <a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-float-none" class="dfn-panel" data-for="term-for-valdef-float-none" id="infopanel-for-term-for-valdef-float-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-float-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-float-none">https://drafts.csswg.org/css2/#valdef-float-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-float-none">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3584,15 +3584,15 @@ Choosing A Positioning Scheme: position property</a>
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">3.5. 
 Absolute (and Fixed) Positioning</a> <a href="#ref-for-resolved-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-continuous-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-continuous-media" class="dfn-panel" data-for="term-for-continuous-media" id="infopanel-for-term-for-continuous-media" role="menu">
+   <span id="infopaneltitle-for-term-for-continuous-media" style="display:none">Info about the 'continuous media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#continuous-media">https://drafts.csswg.org/mediaqueries-5/#continuous-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -3600,8 +3600,8 @@ Choosing A Positioning Scheme: position property</a>
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -4044,8 +4044,8 @@ Fragmenting Absolutely-positioned Elements</a>
 	both models should yield the same result
 	in <a data-link-type="dfn" href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">horizontal writing modes</a> when the box’s <a data-link-type="dfn" href="https://drafts.csswg.org/css-align-3/#self-align">self-alignment</a> is <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-align-3/#valdef-align-self-normal">normal</a>. <a class="issue-return" href="#issue-3a21c2a0" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-position">
-   <b><a href="#propdef-position">#propdef-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-position" class="dfn-panel" data-for="propdef-position" id="infopanel-for-propdef-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-position" style="display:none">Info about the 'position' definition.</span><b><a href="#propdef-position">#propdef-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">1. 
 Introduction</a>
@@ -4062,8 +4062,8 @@ Absolute Positioning Example</a>
     <li><a href="#ref-for-propdef-position①⓪"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="positioning-scheme">
-   <b><a href="#positioning-scheme">#positioning-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-positioning-scheme" class="dfn-panel" data-for="positioning-scheme" id="infopanel-for-positioning-scheme" role="dialog">
+   <span id="infopaneltitle-for-positioning-scheme" style="display:none">Info about the 'positioning schemes' definition.</span><b><a href="#positioning-scheme">#positioning-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positioning-scheme">1. 
 Introduction</a>
@@ -4079,8 +4079,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Informative Comparison of Normal Flow, Floats, and Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="positioned-box">
-   <b><a href="#positioned-box">#positioned-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-positioned-box" class="dfn-panel" data-for="positioned-box" id="infopanel-for-positioned-box" role="dialog">
+   <span id="infopaneltitle-for-positioned-box" style="display:none">Info about the 'positioned box' definition.</span><b><a href="#positioned-box">#positioned-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positioned-box">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -4088,8 +4088,8 @@ Choosing A Positioning Scheme: position property</a>
 Positioning Coordinates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-static">
-   <b><a href="#valdef-position-static">#valdef-position-static</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-static" class="dfn-panel" data-for="valdef-position-static" id="infopanel-for-valdef-position-static" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-static" style="display:none">Info about the 'static' definition.</span><b><a href="#valdef-position-static">#valdef-position-static</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-valdef-position-static①">(2)</a>
@@ -4099,8 +4099,8 @@ Containing Blocks of Positioned Boxes</a>
 Resolving Automatic Insets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-relative">
-   <b><a href="#valdef-position-relative">#valdef-position-relative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-relative" class="dfn-panel" data-for="valdef-position-relative" id="infopanel-for-valdef-position-relative" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-relative" style="display:none">Info about the 'relative' definition.</span><b><a href="#valdef-position-relative">#valdef-position-relative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -4110,8 +4110,8 @@ Containing Blocks of Positioned Boxes</a>
 Absolute Positioning Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-position">
-   <b><a href="#relative-position">#relative-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-position" class="dfn-panel" data-for="relative-position" id="infopanel-for-relative-position" role="dialog">
+   <span id="infopaneltitle-for-relative-position" style="display:none">Info about the 'relative positioning' definition.</span><b><a href="#relative-position">#relative-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-position①">1. 
 Introduction</a>
@@ -4127,15 +4127,15 @@ Informative Comparison of Normal Flow, Floats, and Positioning</a>
 Relative Positioning Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-sticky">
-   <b><a href="#valdef-position-sticky">#valdef-position-sticky</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-sticky" class="dfn-panel" data-for="valdef-position-sticky" id="infopanel-for-valdef-position-sticky" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-sticky" style="display:none">Info about the 'sticky' definition.</span><b><a href="#valdef-position-sticky">#valdef-position-sticky</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-sticky">2.1. 
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sticky-position">
-   <b><a href="#sticky-position">#sticky-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sticky-position" class="dfn-panel" data-for="sticky-position" id="infopanel-for-sticky-position" role="dialog">
+   <span id="infopaneltitle-for-sticky-position" style="display:none">Info about the 'sticky positioning' definition.</span><b><a href="#sticky-position">#sticky-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sticky-position①">1. 
 Introduction</a>
@@ -4149,8 +4149,8 @@ Sticky positioning</a> <a href="#ref-for-sticky-position⑤">(2)</a> <a href="#r
 Scroll Position of Sticky-Positioned Boxes</a> <a href="#ref-for-sticky-position①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-absolute">
-   <b><a href="#valdef-position-absolute">#valdef-position-absolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-absolute" class="dfn-panel" data-for="valdef-position-absolute" id="infopanel-for-valdef-position-absolute" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-absolute" style="display:none">Info about the 'absolute' definition.</span><b><a href="#valdef-position-absolute">#valdef-position-absolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-absolute">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-valdef-position-absolute①">(2)</a>
@@ -4158,8 +4158,8 @@ Choosing A Positioning Scheme: position property</a> <a href="#ref-for-valdef-po
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-position">
-   <b><a href="#absolute-position">#absolute-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-position" class="dfn-panel" data-for="absolute-position" id="infopanel-for-absolute-position" role="dialog">
+   <span id="infopaneltitle-for-absolute-position" style="display:none">Info about the 'absolute positioning' definition.</span><b><a href="#absolute-position">#absolute-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position①">1. 
 Introduction</a>
@@ -4179,8 +4179,8 @@ Automatic Sizes of Absolutely-Positioned Boxes</a>
 Informative Comparison of Normal Flow, Floats, and Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-fixed">
-   <b><a href="#valdef-position-fixed">#valdef-position-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-fixed" class="dfn-panel" data-for="valdef-position-fixed" id="infopanel-for-valdef-position-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-position-fixed">#valdef-position-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-valdef-position-fixed①">(2)</a>
@@ -4188,8 +4188,8 @@ Choosing A Positioning Scheme: position property</a> <a href="#ref-for-valdef-po
 Containing Blocks of Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fixed-position">
-   <b><a href="#fixed-position">#fixed-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fixed-position" class="dfn-panel" data-for="fixed-position" id="infopanel-for-fixed-position" role="dialog">
+   <span id="infopaneltitle-for-fixed-position" style="display:none">Info about the 'fixed positioning' definition.</span><b><a href="#fixed-position">#fixed-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-position①">1. 
 Introduction</a>
@@ -4203,8 +4203,8 @@ Resolving Automatic Insets</a>
 Fragmenting Absolutely-positioned Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-positioning-containing-block">
-   <b><a href="#absolute-positioning-containing-block">#absolute-positioning-containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-positioning-containing-block" class="dfn-panel" data-for="absolute-positioning-containing-block" id="infopanel-for-absolute-positioning-containing-block" role="dialog">
+   <span id="infopaneltitle-for-absolute-positioning-containing-block" style="display:none">Info about the 'absolute positioning containing block' definition.</span><b><a href="#absolute-positioning-containing-block">#absolute-positioning-containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-positioning-containing-block">2. 
 Choosing A Positioning Scheme: position property</a> <a href="#ref-for-absolute-positioning-containing-block①">(2)</a>
@@ -4212,8 +4212,8 @@ Choosing A Positioning Scheme: position property</a> <a href="#ref-for-absolute-
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-absolute-positioning-containing-block③">(2)</a> <a href="#ref-for-absolute-positioning-containing-block④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fixed-positioning-containing-block">
-   <b><a href="#fixed-positioning-containing-block">#fixed-positioning-containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fixed-positioning-containing-block" class="dfn-panel" data-for="fixed-positioning-containing-block" id="infopanel-for-fixed-positioning-containing-block" role="dialog">
+   <span id="infopaneltitle-for-fixed-positioning-containing-block" style="display:none">Info about the 'fixed positioning containing block' definition.</span><b><a href="#fixed-positioning-containing-block">#fixed-positioning-containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-positioning-containing-block">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -4221,8 +4221,8 @@ Choosing A Positioning Scheme: position property</a>
 Containing Blocks of Positioned Boxes</a> <a href="#ref-for-fixed-positioning-containing-block②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inset-properties">
-   <b><a href="#inset-properties">#inset-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inset-properties" class="dfn-panel" data-for="inset-properties" id="infopanel-for-inset-properties" role="dialog">
+   <span id="infopaneltitle-for-inset-properties" style="display:none">Info about the 'inset properties' definition.</span><b><a href="#inset-properties">#inset-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inset-properties">1. 
 Introduction</a>
@@ -4246,8 +4246,8 @@ Resolving Automatic Insets</a>
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-top">
-   <b><a href="#propdef-top">#propdef-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-top" class="dfn-panel" data-for="propdef-top" id="infopanel-for-propdef-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-top" style="display:none">Info about the 'top' definition.</span><b><a href="#propdef-top">#propdef-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">3. 
 Positioning Coordinates</a>
@@ -4265,8 +4265,8 @@ The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-pro
 Absolute Positioning Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-right">
-   <b><a href="#propdef-right">#propdef-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-right" class="dfn-panel" data-for="propdef-right" id="infopanel-for-propdef-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-right" style="display:none">Info about the 'right' definition.</span><b><a href="#propdef-right">#propdef-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">3. 
 Positioning Coordinates</a>
@@ -4284,8 +4284,8 @@ The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-f
 Floating Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-bottom">
-   <b><a href="#propdef-bottom">#propdef-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-bottom" class="dfn-panel" data-for="propdef-bottom" id="infopanel-for-propdef-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-bottom" style="display:none">Info about the 'bottom' definition.</span><b><a href="#propdef-bottom">#propdef-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">3. 
 Positioning Coordinates</a>
@@ -4301,8 +4301,8 @@ The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for
 The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-propdef-bottom①⑧">(2)</a> <a href="#ref-for-propdef-bottom①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-left">
-   <b><a href="#propdef-left">#propdef-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-left" class="dfn-panel" data-for="propdef-left" id="infopanel-for-propdef-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-left" style="display:none">Info about the 'left' definition.</span><b><a href="#propdef-left">#propdef-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">3. 
 Positioning Coordinates</a>
@@ -4320,8 +4320,8 @@ The width of absolute or fixed positioned, replaced elements</a> <a href="#ref-f
 Absolute Positioning Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block-start">
-   <b><a href="#propdef-inset-block-start">#propdef-inset-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block-start" class="dfn-panel" data-for="propdef-inset-block-start" id="infopanel-for-propdef-inset-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block-start" style="display:none">Info about the 'inset-block-start' definition.</span><b><a href="#propdef-inset-block-start">#propdef-inset-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-start">3. 
 Positioning Coordinates</a>
@@ -4331,8 +4331,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline-start">
-   <b><a href="#propdef-inset-inline-start">#propdef-inset-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline-start" class="dfn-panel" data-for="propdef-inset-inline-start" id="infopanel-for-propdef-inset-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline-start" style="display:none">Info about the 'inset-inline-start' definition.</span><b><a href="#propdef-inset-inline-start">#propdef-inset-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-start">3. 
 Positioning Coordinates</a>
@@ -4342,8 +4342,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block-end">
-   <b><a href="#propdef-inset-block-end">#propdef-inset-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block-end" class="dfn-panel" data-for="propdef-inset-block-end" id="infopanel-for-propdef-inset-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block-end" style="display:none">Info about the 'inset-block-end' definition.</span><b><a href="#propdef-inset-block-end">#propdef-inset-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-end">3. 
 Positioning Coordinates</a>
@@ -4353,8 +4353,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline-end">
-   <b><a href="#propdef-inset-inline-end">#propdef-inset-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline-end" class="dfn-panel" data-for="propdef-inset-inline-end" id="infopanel-for-propdef-inset-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline-end" style="display:none">Info about the 'inset-inline-end' definition.</span><b><a href="#propdef-inset-inline-end">#propdef-inset-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-end">3. 
 Positioning Coordinates</a>
@@ -4364,8 +4364,8 @@ Box Insets: the top, right, bottom, left, inset-block-start, inset-inline-start,
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-top-auto">
-   <b><a href="#valdef-top-auto">#valdef-top-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-top-auto" class="dfn-panel" data-for="valdef-top-auto" id="infopanel-for-valdef-top-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-top-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-top-auto">#valdef-top-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-top-auto">2. 
 Choosing A Positioning Scheme: position property</a>
@@ -4391,8 +4391,8 @@ The Height Of Absolutely Positioned, Non-Replaced Elements</a> <a href="#ref-for
 The Height Of Absolutely Positioned, Replaced Elements</a> <a href="#ref-for-valdef-top-auto④⑤">(2)</a> <a href="#ref-for-valdef-top-auto④⑥">(3)</a> <a href="#ref-for-valdef-top-auto④⑦">(4)</a> <a href="#ref-for-valdef-top-auto④⑧">(5)</a> <a href="#ref-for-valdef-top-auto④⑨">(6)</a> <a href="#ref-for-valdef-top-auto⑤⓪">(7)</a> <a href="#ref-for-valdef-top-auto⑤①">(8)</a> <a href="#ref-for-valdef-top-auto⑤②">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-block">
-   <b><a href="#propdef-inset-block">#propdef-inset-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-block" class="dfn-panel" data-for="propdef-inset-block" id="infopanel-for-propdef-inset-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-block" style="display:none">Info about the 'inset-block' definition.</span><b><a href="#propdef-inset-block">#propdef-inset-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block">3. 
 Positioning Coordinates</a>
@@ -4400,8 +4400,8 @@ Positioning Coordinates</a>
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-propdef-inset-block②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset-inline">
-   <b><a href="#propdef-inset-inline">#propdef-inset-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset-inline" class="dfn-panel" data-for="propdef-inset-inline" id="infopanel-for-propdef-inset-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset-inline" style="display:none">Info about the 'inset-inline' definition.</span><b><a href="#propdef-inset-inline">#propdef-inset-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline">3. 
 Positioning Coordinates</a>
@@ -4409,8 +4409,8 @@ Positioning Coordinates</a>
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-propdef-inset-inline②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-inset">
-   <b><a href="#propdef-inset">#propdef-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-inset" class="dfn-panel" data-for="propdef-inset" id="infopanel-for-propdef-inset" role="dialog">
+   <span id="infopaneltitle-for-propdef-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#propdef-inset">#propdef-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset">3. 
 Positioning Coordinates</a>
@@ -4418,29 +4418,29 @@ Positioning Coordinates</a>
 Box Insets Shorthands: the inset-block, inset-inline, and inset properties</a> <a href="#ref-for-propdef-inset②">(2)</a> <a href="#ref-for-propdef-inset③">(3)</a> <a href="#ref-for-propdef-inset④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sticky-view-rectangle">
-   <b><a href="#sticky-view-rectangle">#sticky-view-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sticky-view-rectangle" class="dfn-panel" data-for="sticky-view-rectangle" id="infopanel-for-sticky-view-rectangle" role="dialog">
+   <span id="infopaneltitle-for-sticky-view-rectangle" style="display:none">Info about the 'sticky view rectangle' definition.</span><b><a href="#sticky-view-rectangle">#sticky-view-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sticky-view-rectangle">3.4. 
 Sticky positioning</a> <a href="#ref-for-sticky-view-rectangle①">(2)</a> <a href="#ref-for-sticky-view-rectangle②">(3)</a> <a href="#ref-for-sticky-view-rectangle③">(4)</a> <a href="#ref-for-sticky-view-rectangle④">(5)</a> <a href="#ref-for-sticky-view-rectangle⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="position-box">
-   <b><a href="#position-box">#position-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-position-box" class="dfn-panel" data-for="position-box" id="infopanel-for-position-box" role="dialog">
+   <span id="infopaneltitle-for-position-box" style="display:none">Info about the 'position box' definition.</span><b><a href="#position-box">#position-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-position-box">3.4. 
 Sticky positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="weaker-inset">
-   <b><a href="#weaker-inset">#weaker-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-weaker-inset" class="dfn-panel" data-for="weaker-inset" id="infopanel-for-weaker-inset" role="dialog">
+   <span id="infopaneltitle-for-weaker-inset" style="display:none">Info about the 'weaker inset' definition.</span><b><a href="#weaker-inset">#weaker-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-weaker-inset">3.5. 
 Absolute (and Fixed) Positioning</a> <a href="#ref-for-weaker-inset①">(2)</a> <a href="#ref-for-weaker-inset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inset-modified-containing-block">
-   <b><a href="#inset-modified-containing-block">#inset-modified-containing-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inset-modified-containing-block" class="dfn-panel" data-for="inset-modified-containing-block" id="infopanel-for-inset-modified-containing-block" role="dialog">
+   <span id="infopaneltitle-for-inset-modified-containing-block" style="display:none">Info about the 'inset-modified containing block' definition.</span><b><a href="#inset-modified-containing-block">#inset-modified-containing-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inset-modified-containing-block">3.5. 
 Absolute (and Fixed) Positioning</a>
@@ -4452,8 +4452,8 @@ Automatic Sizes of Absolutely-Positioned Boxes</a>
 Auto Margins of Absolutely-Positioned Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="static-position-rectangle">
-   <b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-static-position-rectangle" class="dfn-panel" data-for="static-position-rectangle" id="infopanel-for-static-position-rectangle" role="dialog">
+   <span id="infopaneltitle-for-static-position-rectangle" style="display:none">Info about the 'static position rectangle' definition.</span><b><a href="#static-position-rectangle">#static-position-rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-static-position-rectangle">3.5. 
 Absolute (and Fixed) Positioning</a> <a href="#ref-for-static-position-rectangle①">(2)</a>
@@ -4463,59 +4463,115 @@ Resolving Automatic Insets</a> <a href="#ref-for-static-position-rectangle③">(
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-print/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-print/Overview.html
@@ -1913,516 +1913,516 @@ to express her gratitude to all those who contributed to it.</p>
     Questions should be directed to the <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list.</p>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">4. 4. Properties</a> <a href="#ref-for-propdef-background-color①">(2)</a> <a href="#ref-for-propdef-background-color②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">4. 4. Properties</a> <a href="#ref-for-propdef-background-image①">(2)</a> <a href="#ref-for-propdef-background-image②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">4. 4. Properties</a> <a href="#ref-for-propdef-background-position①">(2)</a> <a href="#ref-for-propdef-background-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">4. 4. Properties</a> <a href="#ref-for-propdef-background-repeat①">(2)</a> <a href="#ref-for-propdef-background-repeat②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom" class="dfn-panel" data-for="term-for-propdef-border-bottom" id="infopanel-for-term-for-propdef-border-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom" style="display:none">Info about the 'border-bottom' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-color" class="dfn-panel" data-for="term-for-propdef-border-bottom-color" id="infopanel-for-term-for-propdef-border-bottom-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-style" class="dfn-panel" data-for="term-for-propdef-border-bottom-style" id="infopanel-for-term-for-propdef-border-bottom-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-style" style="display:none">Info about the 'border-bottom-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left" class="dfn-panel" data-for="term-for-propdef-border-left" id="infopanel-for-term-for-propdef-border-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left" style="display:none">Info about the 'border-left' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-color" class="dfn-panel" data-for="term-for-propdef-border-left-color" id="infopanel-for-term-for-propdef-border-left-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-style" class="dfn-panel" data-for="term-for-propdef-border-left-style" id="infopanel-for-term-for-propdef-border-left-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-style" style="display:none">Info about the 'border-left-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right" class="dfn-panel" data-for="term-for-propdef-border-right" id="infopanel-for-term-for-propdef-border-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right" style="display:none">Info about the 'border-right' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-color" class="dfn-panel" data-for="term-for-propdef-border-right-color" id="infopanel-for-term-for-propdef-border-right-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-style" class="dfn-panel" data-for="term-for-propdef-border-right-style" id="infopanel-for-term-for-propdef-border-right-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-style" style="display:none">Info about the 'border-right-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top" class="dfn-panel" data-for="term-for-propdef-border-top" id="infopanel-for-term-for-propdef-border-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top" style="display:none">Info about the 'border-top' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-style" class="dfn-panel" data-for="term-for-propdef-border-top-style" id="infopanel-for-term-for-propdef-border-top-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-style" style="display:none">Info about the 'border-top-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-widows">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-widows" class="dfn-panel" data-for="term-for-propdef-widows" id="infopanel-for-term-for-propdef-widows" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-widows" style="display:none">Info about the 'widows' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-widows">https://drafts.csswg.org/css-break-4/#propdef-widows</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">4. 4. Properties</a> <a href="#ref-for-propdef-font-family①">(2)</a> <a href="#ref-for-propdef-font-family②">(3)</a> <a href="#ref-for-propdef-font-family③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">4. 4. Properties</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a> <a href="#ref-for-propdef-font-size③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">4. 4. Properties</a> <a href="#ref-for-propdef-font-style①">(2)</a> <a href="#ref-for-propdef-font-style②">(3)</a> <a href="#ref-for-propdef-font-style③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">4. 4. Properties</a> <a href="#ref-for-propdef-font-variant①">(2)</a> <a href="#ref-for-propdef-font-variant②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">4. 4. Properties</a> <a href="#ref-for-propdef-font-weight①">(2)</a> <a href="#ref-for-propdef-font-weight②">(3)</a> <a href="#ref-for-propdef-font-weight③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-fit">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-fit" class="dfn-panel" data-for="term-for-propdef-object-fit" id="infopanel-for-term-for-propdef-object-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-fit" style="display:none">Info about the 'object-fit' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-fit">Unnumbered Section</a> <a href="#ref-for-propdef-object-fit①">(2)</a>
     <li><a href="#ref-for-propdef-object-fit②">4. 4. Properties</a> <a href="#ref-for-propdef-object-fit③">(2)</a>
     <li><a href="#ref-for-propdef-object-fit④">4.1. Image Rendering Properties</a> <a href="#ref-for-propdef-object-fit⑤">(2)</a> <a href="#ref-for-propdef-object-fit⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-increment">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-increment" class="dfn-panel" data-for="term-for-propdef-counter-increment" id="infopanel-for-term-for-propdef-counter-increment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-increment">https://drafts.csswg.org/css-lists-3/#propdef-counter-increment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-counter-reset">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-counter-reset" class="dfn-panel" data-for="term-for-propdef-counter-reset" id="infopanel-for-term-for-propdef-counter-reset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset">https://drafts.csswg.org/css-lists-3/#propdef-counter-reset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style" class="dfn-panel" data-for="term-for-propdef-list-style" id="infopanel-for-term-for-propdef-list-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style" style="display:none">Info about the 'list-style' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style">https://drafts.csswg.org/css-lists-3/#propdef-list-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-image">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-image" class="dfn-panel" data-for="term-for-propdef-list-style-image" id="infopanel-for-term-for-propdef-list-style-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">4. 4. Properties</a> <a href="#ref-for-propdef-list-style-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">4. 4. Properties</a> <a href="#ref-for-propdef-list-style-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">4. 4. Properties</a> <a href="#ref-for-propdef-list-style-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-color">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-color">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">4. 4. Properties</a> <a href="#ref-for-propdef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-display">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-display">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-vertical-align">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-vertical-align">https://www.w3.org/TR/2011/REC-CSS2-20110607/colors.html#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caption-side">
-   <a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caption-side" class="dfn-panel" data-for="term-for-propdef-caption-side" id="infopanel-for-term-for-propdef-caption-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caption-side" style="display:none">Info about the 'caption-side' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">4. 4. Properties</a> <a href="#ref-for-propdef-line-height①">(2)</a> <a href="#ref-for-propdef-line-height②">(3)</a> <a href="#ref-for-propdef-line-height③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-after">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-after" class="dfn-panel" data-for="term-for-propdef-page-break-after" id="infopanel-for-term-for-propdef-page-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-after">https://drafts.csswg.org/css2/#propdef-page-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-before">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-before" class="dfn-panel" data-for="term-for-propdef-page-break-before" id="infopanel-for-term-for-propdef-page-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-before">https://drafts.csswg.org/css2/#propdef-page-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page-break-inside">
-   <a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page-break-inside" class="dfn-panel" data-for="term-for-propdef-page-break-inside" id="infopanel-for-term-for-propdef-page-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page-break-inside" style="display:none">Info about the 'page-break-inside' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-page-break-inside">https://drafts.csswg.org/css2/#propdef-page-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-inside">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-table-layout">
-   <a href="https://drafts.csswg.org/css2/#propdef-table-layout">https://drafts.csswg.org/css2/#propdef-table-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-table-layout" class="dfn-panel" data-for="term-for-propdef-table-layout" id="infopanel-for-term-for-propdef-table-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-table-layout" style="display:none">Info about the 'table-layout' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-table-layout">https://drafts.csswg.org/css2/#propdef-table-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-table-layout">4. 4. Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-object-fit-fill">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-object-fit-fill">https://drafts.csswg.org/css-images-3/#valdef-object-fit-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-object-fit-fill" class="dfn-panel" data-for="term-for-valdef-object-fit-fill" id="infopanel-for-term-for-valdef-object-fit-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-object-fit-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-object-fit-fill">https://drafts.csswg.org/css-images-3/#valdef-object-fit-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-fill">4.1. Image Rendering Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-orientation">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">https://drafts.csswg.org/css-images-3/#propdef-image-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-orientation" class="dfn-panel" data-for="term-for-propdef-image-orientation" id="infopanel-for-term-for-propdef-image-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-orientation" style="display:none">Info about the 'image-orientation' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-image-orientation">https://drafts.csswg.org/css-images-3/#propdef-image-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-orientation">4. 4. Properties</a> <a href="#ref-for-propdef-image-orientation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-position">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-position" class="dfn-panel" data-for="term-for-propdef-object-position" id="infopanel-for-term-for-propdef-object-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-position" style="display:none">Info about the 'object-position' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-position">Unnumbered Section</a> <a href="#ref-for-propdef-object-position①">(2)</a>
     <li><a href="#ref-for-propdef-object-position②">4. 4. Properties</a> <a href="#ref-for-propdef-object-position③">(2)</a>
     <li><a href="#ref-for-propdef-object-position④">4.1. Image Rendering Properties</a> <a href="#ref-for-propdef-object-position⑤">(2)</a> <a href="#ref-for-propdef-object-position⑥">(3)</a> <a href="#ref-for-propdef-object-position⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-page" class="dfn-panel" data-for="term-for-propdef-page" id="infopanel-for-term-for-propdef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-page" style="display:none">Info about the 'page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#propdef-page">https://drafts.csswg.org/css-page-3/#propdef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page">4. 4. Properties</a>
    </ul>
@@ -2654,57 +2654,113 @@ to express her gratitude to all those who contributed to it.</p>
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-pseudo-4/Overview.html
@@ -2327,8 +2327,8 @@ that would match the selector <var>type</var> with <a data-link-type="dfn" href=
    <li><a href="#tree-abiding">tree-abiding pseudo-element</a><span>, in § 4</span>
    <li><a href="#dom-csspseudoelement-type">type</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3.2. 
 Styling Highlights</a> <a href="#ref-for-propdef-background-color①">(2)</a>
@@ -2338,22 +2338,22 @@ Cascading and Per-Element Highlight Styles</a>
 Replaced Elements</a> <a href="#ref-for-propdef-background-color④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">2.2.3. 
 Styling the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2.1.3. 
 Inheritance and the ::first-line Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">2.1.3. 
 Inheritance and the ::first-line Pseudo-element</a> <a href="#ref-for-css-inheritance①">(2)</a>
@@ -2363,8 +2363,8 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 Tree-Abiding Pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-property">https://drafts.csswg.org/css-cascade-5/#inherited-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-property" class="dfn-panel" data-for="term-for-inherited-property" id="infopanel-for-term-for-inherited-property" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-property" style="display:none">Info about the 'inherited property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-property">https://drafts.csswg.org/css-cascade-5/#inherited-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-property">2.1.3. 
 Inheritance and the ::first-line Pseudo-element</a>
@@ -2372,22 +2372,22 @@ Inheritance and the ::first-line Pseudo-element</a>
 Cascading and Per-Element Highlight Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">4. 
 Tree-Abiding Pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'ua style sheet' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">3.5. 
 Cascading and Per-Element Highlight Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">2.1.2. 
 Styling the First Line Pseudo-element</a>
@@ -2395,30 +2395,30 @@ Styling the First Line Pseudo-element</a>
 Styling the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">3.6.4. 
 Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">4.1. 
 Generated Content Pseudo-elements: ::before and ::after</a> <a href="#ref-for-propdef-content①">(2)</a>
     <li><a href="#ref-for-propdef-content②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-none">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-none" class="dfn-panel" data-for="term-for-valdef-content-none" id="infopanel-for-term-for-valdef-content-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">4.1. 
 Generated Content Pseudo-elements: ::before and ::after</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.1.1. 
 Finding the First Formatted Line</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a> <a href="#ref-for-block-container③">(4)</a>
@@ -2426,8 +2426,8 @@ Finding the First Formatted Line</a> <a href="#ref-for-block-container①">(2)</
 Finding the First Letter Text</a> <a href="#ref-for-block-container⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">2.1.1. 
 Finding the First Formatted Line</a>
@@ -2435,15 +2435,15 @@ Finding the First Formatted Line</a>
 Finding the First Letter Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2.1.1. 
 Finding the First Formatted Line</a> <a href="#ref-for-block-level①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">4.1. 
 Generated Content Pseudo-elements: ::before and ::after</a>
@@ -2451,22 +2451,22 @@ Generated Content Pseudo-elements: ::before and ::after</a>
 List Markers: the ::marker pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2.1.1. 
 Finding the First Formatted Line</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">4.1. 
 Generated Content Pseudo-elements: ::before and ::after</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.2.2. 
 Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
@@ -2474,8 +2474,8 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 Styling the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2.1.1. 
 Finding the First Formatted Line</a>
@@ -2483,8 +2483,8 @@ Finding the First Formatted Line</a>
 Finding the First Letter Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.1.1. 
 Finding the First Formatted Line</a>
@@ -2492,15 +2492,15 @@ Finding the First Formatted Line</a>
 Finding the First Letter Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level-box" class="dfn-panel" data-for="term-for-inline-level-box" id="infopanel-for-term-for-inline-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level-box" style="display:none">Info about the 'inline-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level-box">https://drafts.csswg.org/css-display-3/#inline-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level-box">3.4. 
 Area of a Highlight</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level①" style="display:none">Info about the 'inline-level content' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.1.1. 
 Finding the First Formatted Line</a>
@@ -2508,15 +2508,15 @@ Finding the First Formatted Line</a>
 Finding the First Letter Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-list-item">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-list-item" class="dfn-panel" data-for="term-for-valdef-display-list-item" id="infopanel-for-term-for-valdef-display-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-list-item" style="display:none">Info about the 'list-item' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-list-item">https://drafts.csswg.org/css-display-3/#valdef-display-list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-list-item">4.2. 
 List Markers: the ::marker pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter" class="dfn-panel" data-for="term-for-propdef-initial-letter" id="infopanel-for-term-for-propdef-initial-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter" style="display:none">Info about the 'initial-letter' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter">2.2. 
 The ::first-letter pseudo-element</a>
@@ -2524,8 +2524,8 @@ The ::first-letter pseudo-element</a>
 Styling the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">2.1.1. 
 Finding the First Formatted Line</a>
@@ -2533,8 +2533,8 @@ Finding the First Formatted Line</a>
 Area of a Highlight</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://drafts.csswg.org/css-lists-3/#list-item">https://drafts.csswg.org/css-lists-3/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'list item' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#list-item">https://drafts.csswg.org/css-lists-3/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">2.2.2. 
 Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
@@ -2542,15 +2542,15 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 List Markers: the ::marker pseudo-element</a> <a href="#ref-for-list-item②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-position">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-position" class="dfn-panel" data-for="term-for-propdef-list-style-position" id="infopanel-for-term-for-propdef-list-style-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-position">https://drafts.csswg.org/css-lists-3/#propdef-list-style-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">2.2.2. 
 Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-marker">
-   <a href="https://drafts.csswg.org/css-lists-3/#marker">https://drafts.csswg.org/css-lists-3/#marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-marker" class="dfn-panel" data-for="term-for-marker" id="infopanel-for-term-for-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-marker" style="display:none">Info about the 'marker' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#marker">https://drafts.csswg.org/css-lists-3/#marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker">2.2.1. 
 Finding the First Letter Text</a>
@@ -2560,8 +2560,8 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 List Markers: the ::marker pseudo-element</a> <a href="#ref-for-marker③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-marker">
-   <a href="https://drafts.csswg.org/css-lists-3/#marker">https://drafts.csswg.org/css-lists-3/#marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-marker" class="dfn-panel" data-for="term-for-marker" id="infopanel-for-term-for-marker①" role="menu">
+   <span id="infopaneltitle-for-term-for-marker①" style="display:none">Info about the 'marker box' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#marker">https://drafts.csswg.org/css-lists-3/#marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker">2.2.1. 
 Finding the First Letter Text</a>
@@ -2571,83 +2571,83 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 List Markers: the ::marker pseudo-element</a> <a href="#ref-for-marker③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">2.1.1. 
 Finding the First Formatted Line</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-ruby-position">
-   <a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-ruby-position" class="dfn-panel" data-for="term-for-propdef-ruby-position" id="infopanel-for-term-for-propdef-ruby-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-ruby-position" style="display:none">Info about the 'ruby-position' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-position">2.1.2. 
 Styling the First Line Pseudo-element</a>
     <li><a href="#ref-for-propdef-ruby-position①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">6.2. 
 pseudo() method of the Element interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">2.1.1. 
 Finding the First Formatted Line</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">4.3. 
 Placeholder Input: the ::placeholder pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-letter-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-letter-unit" class="dfn-panel" data-for="term-for-typographic-letter-unit" id="infopanel-for-term-for-typographic-letter-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-letter-unit" style="display:none">Info about the 'typographic letter unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-letter-unit">2.2. 
 The ::first-letter pseudo-element</a> <a href="#ref-for-typographic-letter-unit①">(2)</a> <a href="#ref-for-typographic-letter-unit②">(3)</a> <a href="#ref-for-typographic-letter-unit③">(4)</a> <a href="#ref-for-typographic-letter-unit④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-decoration-line-grammar-error">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-grammar-error">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-grammar-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-decoration-line-grammar-error" class="dfn-panel" data-for="term-for-valdef-text-decoration-line-grammar-error" id="infopanel-for-term-for-valdef-text-decoration-line-grammar-error" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-decoration-line-grammar-error" style="display:none">Info about the 'grammar-error' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-grammar-error">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-grammar-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-line-grammar-error"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-decoration-line-spelling-error">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-spelling-error">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-spelling-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-decoration-line-spelling-error" class="dfn-panel" data-for="term-for-valdef-text-decoration-line-spelling-error" id="infopanel-for-term-for-valdef-text-decoration-line-spelling-error" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-decoration-line-spelling-error" style="display:none">Info about the 'spelling-error' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-spelling-error">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-spelling-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-line-spelling-error"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">3.2. 
 Styling Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis" class="dfn-panel" data-for="term-for-propdef-text-emphasis" id="infopanel-for-term-for-propdef-text-emphasis" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis" style="display:none">Info about the 'text-emphasis' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis">3.2. 
 Styling Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-position">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-position" class="dfn-panel" data-for="term-for-propdef-text-emphasis-position" id="infopanel-for-term-for-propdef-text-emphasis-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-position" style="display:none">Info about the 'text-emphasis-position' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-position"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">3.2. 
 Styling Highlights</a>
@@ -2656,69 +2656,69 @@ Shadows</a> <a href="#ref-for-propdef-text-shadow②">(2)</a>
     <li><a href="#ref-for-propdef-text-shadow③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline" class="dfn-panel" data-for="term-for-propdef-outline" id="infopanel-for-term-for-propdef-outline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline" style="display:none">Info about the 'outline' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">2.1.3. 
 Inheritance and the ::first-line Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">2.1.2. 
 Styling the First Line Pseudo-element</a>
     <li><a href="#ref-for-propdef-direction①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">3.4. 
 Area of a Highlight</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">2.1.2. 
 Styling the First Line Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">2.1.2. 
 Styling the First Line Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css2/#selectordef-after">https://drafts.csswg.org/css2/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the ':after' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-after">https://drafts.csswg.org/css2/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after③">4.1. 
 Generated Content Pseudo-elements: ::before and ::after</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">6.1. 
 CSSPseudoElement Interface</a>
@@ -2726,15 +2726,15 @@ CSSPseudoElement Interface</a>
 pseudo() method of the Element interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration" class="dfn-panel" data-for="term-for-cssstyledeclaration" id="infopanel-for-term-for-cssstyledeclaration" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration">https://drafts.csswg.org/cssom-1/#cssstyledeclaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">6.1. 
 CSSPseudoElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">6.1. 
 CSSPseudoElement Interface</a>
@@ -2742,66 +2742,66 @@ CSSPseudoElement Interface</a>
 pseudo() method of the Element interface</a> <a href="#ref-for-element②">(2)</a> <a href="#ref-for-element③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.1. 
 CSSPseudoElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill-color">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill-color" class="dfn-panel" data-for="term-for-propdef-fill-color" id="infopanel-for-term-for-propdef-fill-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill-color" style="display:none">Info about the 'fill-color' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-color">3.2. 
 Styling Highlights</a>
     <li><a href="#ref-for-propdef-fill-color①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-color">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-color" class="dfn-panel" data-for="term-for-propdef-stroke-color" id="infopanel-for-term-for-propdef-stroke-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-color" style="display:none">Info about the 'stroke-color' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-color">3.2. 
 Styling Highlights</a>
     <li><a href="#ref-for-propdef-stroke-color①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-width">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-width" class="dfn-panel" data-for="term-for-propdef-stroke-width" id="infopanel-for-term-for-propdef-stroke-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-width" style="display:none">Info about the 'stroke-width' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-width">3.2. 
 Styling Highlights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x">
-   <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x" class="dfn-panel" data-for="term-for-x" id="infopanel-for-term-for-x" role="menu">
+   <span id="infopaneltitle-for-term-for-x" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x">3.5. 
 Cascading and Per-Element Highlight Styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-placeholder-shown-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#placeholder-shown-pseudo">https://drafts.csswg.org/selectors-4/#placeholder-shown-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-placeholder-shown-pseudo" class="dfn-panel" data-for="term-for-placeholder-shown-pseudo" id="infopanel-for-term-for-placeholder-shown-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-placeholder-shown-pseudo" style="display:none">Info about the ':placeholder-shown' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#placeholder-shown-pseudo">https://drafts.csswg.org/selectors-4/#placeholder-shown-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-placeholder-shown-pseudo">4.3. 
 Placeholder Input: the ::placeholder pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-pseudo" class="dfn-panel" data-for="term-for-target-pseudo" id="infopanel-for-term-for-target-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-target-pseudo" style="display:none">Info about the ':target' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-pseudo-element-selector" class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector" id="infopanel-for-term-for-typedef-pseudo-element-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-pseudo-element-selector" style="display:none">Info about the '&lt;pseudo-element-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-element-selector">6.2. 
 pseudo() method of the Element interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">1. Introduction</a>
     <li><a href="#ref-for-originating-element①">2.1. 
@@ -2830,8 +2830,8 @@ CSSPseudoElement Interface</a>
 pseudo() method of the Element interface</a> <a href="#ref-for-originating-element①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">1. Introduction</a>
     <li><a href="#ref-for-pseudo-element①">2.1. 
@@ -2842,28 +2842,28 @@ Text and Text Decorations</a>
 pseudo() method of the Element interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selector" class="dfn-panel" data-for="term-for-selector" id="infopanel-for-term-for-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-selector" style="display:none">Info about the 'selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-concept-url-fragment①">(2)</a> <a href="#ref-for-concept-url-fragment②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. 
 CSSPseudoElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">6.2. 
 pseudo() method of the Element interface</a>
@@ -3155,8 +3155,8 @@ pseudo() method of the Element interface</a>
   of the <code class="idl"><a data-link-type="idl" href="#dom-element-pseudo">pseudo()</a></code> method is still under discussion.
   See <a href="https://github.com/w3c/csswg-drafts/issues/3607">Issue 3607</a> and <a href="https://github.com/w3c/csswg-drafts/issues/3603">Issue 3603</a>. <a class="issue-return" href="#issue-302461e7" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="selectordef-first-line">
-   <b><a href="#selectordef-first-line">#selectordef-first-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first-line" class="dfn-panel" data-for="selectordef-first-line" id="infopanel-for-selectordef-first-line" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first-line" style="display:none">Info about the '::first-line' definition.</span><b><a href="#selectordef-first-line">#selectordef-first-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1. Introduction</a>
     <li><a href="#ref-for-selectordef-first-line①">2.1.1. 
@@ -3184,8 +3184,8 @@ Compatibility Syntax</a>
     <li><a href="#ref-for-selectordef-first-line②①"> Changes</a> <a href="#ref-for-selectordef-first-line②②">(2)</a> <a href="#ref-for-selectordef-first-line②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-formatted-line">
-   <b><a href="#first-formatted-line">#first-formatted-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-formatted-line" class="dfn-panel" data-for="first-formatted-line" id="infopanel-for-first-formatted-line" role="dialog">
+   <span id="infopaneltitle-for-first-formatted-line" style="display:none">Info about the 'first formatted line' definition.</span><b><a href="#first-formatted-line">#first-formatted-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line">2.1. 
 The ::first-line pseudo-element</a>
@@ -3197,8 +3197,8 @@ The ::first-letter pseudo-element</a>
 Finding the First Letter Text</a> <a href="#ref-for-first-formatted-line⑧">(2)</a> <a href="#ref-for-first-formatted-line⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fictional-tag-sequence">
-   <b><a href="#fictional-tag-sequence">#fictional-tag-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fictional-tag-sequence" class="dfn-panel" data-for="fictional-tag-sequence" id="infopanel-for-fictional-tag-sequence" role="dialog">
+   <span id="infopaneltitle-for-fictional-tag-sequence" style="display:none">Info about the 'fictional tag sequence' definition.</span><b><a href="#fictional-tag-sequence">#fictional-tag-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fictional-tag-sequence">2.1.1. 
 Finding the First Formatted Line</a>
@@ -3210,8 +3210,8 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a>
 Overlapping Pseudo-element Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-first-letter">
-   <b><a href="#selectordef-first-letter">#selectordef-first-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first-letter" class="dfn-panel" data-for="selectordef-first-letter" id="infopanel-for-selectordef-first-letter" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' definition.</span><b><a href="#selectordef-first-letter">#selectordef-first-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">2.2. 
 The ::first-letter pseudo-element</a> <a href="#ref-for-selectordef-first-letter①">(2)</a> <a href="#ref-for-selectordef-first-letter②">(3)</a> <a href="#ref-for-selectordef-first-letter③">(4)</a>
@@ -3234,8 +3234,8 @@ Compatibility Syntax</a>
     <li><a href="#ref-for-selectordef-first-letter②⑤"> Changes</a> <a href="#ref-for-selectordef-first-letter②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-letter-text">
-   <b><a href="#first-letter-text">#first-letter-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-letter-text" class="dfn-panel" data-for="first-letter-text" id="infopanel-for-first-letter-text" role="dialog">
+   <span id="infopaneltitle-for-first-letter-text" style="display:none">Info about the 'first-letter text' definition.</span><b><a href="#first-letter-text">#first-letter-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-letter-text">2.2. 
 The ::first-letter pseudo-element</a> <a href="#ref-for-first-letter-text①">(2)</a>
@@ -3247,8 +3247,8 @@ Inheritance and Box Tree Structure of the ::first-letter Pseudo-element</a> <a h
 Styling the ::first-letter Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="highlight-pseudo-element">
-   <b><a href="#highlight-pseudo-element">#highlight-pseudo-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-highlight-pseudo-element" class="dfn-panel" data-for="highlight-pseudo-element" id="infopanel-for-highlight-pseudo-element" role="dialog">
+   <span id="infopaneltitle-for-highlight-pseudo-element" style="display:none">Info about the 'highlight pseudo-elements' definition.</span><b><a href="#highlight-pseudo-element">#highlight-pseudo-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight-pseudo-element">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-highlight-pseudo-element①">(2)</a>
@@ -3267,8 +3267,8 @@ Text and Text Decorations</a> <a href="#ref-for-highlight-pseudo-element①⓪">
     <li><a href="#ref-for-highlight-pseudo-element①③"> Changes</a> <a href="#ref-for-highlight-pseudo-element①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-selection">
-   <b><a href="#selectordef-selection">#selectordef-selection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-selection" class="dfn-panel" data-for="selectordef-selection" id="infopanel-for-selectordef-selection" role="dialog">
+   <span id="infopaneltitle-for-selectordef-selection" style="display:none">Info about the '::selection' definition.</span><b><a href="#selectordef-selection">#selectordef-selection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-selection">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-selectordef-selection①">(2)</a>
@@ -3278,8 +3278,8 @@ Cascading and Per-Element Highlight Styles</a> <a href="#ref-for-selectordef-sel
 Backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-target-text">
-   <b><a href="#selectordef-target-text">#selectordef-target-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-target-text" class="dfn-panel" data-for="selectordef-target-text" id="infopanel-for-selectordef-target-text" role="dialog">
+   <span id="infopaneltitle-for-selectordef-target-text" style="display:none">Info about the '::target-text' definition.</span><b><a href="#selectordef-target-text">#selectordef-target-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-target-text">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-selectordef-target-text①">(2)</a> <a href="#ref-for-selectordef-target-text②">(3)</a>
@@ -3288,8 +3288,8 @@ Backgrounds</a>
     <li><a href="#ref-for-selectordef-target-text④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-spelling-error">
-   <b><a href="#selectordef-spelling-error">#selectordef-spelling-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-spelling-error" class="dfn-panel" data-for="selectordef-spelling-error" id="infopanel-for-selectordef-spelling-error" role="dialog">
+   <span id="infopaneltitle-for-selectordef-spelling-error" style="display:none">Info about the '::spelling-error' definition.</span><b><a href="#selectordef-spelling-error">#selectordef-spelling-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-spelling-error">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-selectordef-spelling-error①">(2)</a>
@@ -3300,8 +3300,8 @@ Security and Privacy Considerations</a>
     <li><a href="#ref-for-selectordef-spelling-error④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-grammar-error">
-   <b><a href="#selectordef-grammar-error">#selectordef-grammar-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-grammar-error" class="dfn-panel" data-for="selectordef-grammar-error" id="infopanel-for-selectordef-grammar-error" role="dialog">
+   <span id="infopaneltitle-for-selectordef-grammar-error" style="display:none">Info about the '::grammar-error' definition.</span><b><a href="#selectordef-grammar-error">#selectordef-grammar-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-grammar-error">3.1. 
 Selecting Highlighted Content: the ::selection,  ::target-text, ::spelling-error, and ::grammar-error pseudo-elements</a> <a href="#ref-for-selectordef-grammar-error①">(2)</a>
@@ -3312,8 +3312,8 @@ Security and Privacy Considerations</a>
     <li><a href="#ref-for-selectordef-grammar-error④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="highlight-overlay">
-   <b><a href="#highlight-overlay">#highlight-overlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-highlight-overlay" class="dfn-panel" data-for="highlight-overlay" id="infopanel-for-highlight-overlay" role="dialog">
+   <span id="infopaneltitle-for-highlight-overlay" style="display:none">Info about the 'highlight overlay' definition.</span><b><a href="#highlight-overlay">#highlight-overlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-highlight-overlay">3.2. 
 Styling Highlights</a>
@@ -3327,8 +3327,8 @@ Shadows</a> <a href="#ref-for-highlight-overlay④">(2)</a> <a href="#ref-for-hi
 Text and Text Decorations</a> <a href="#ref-for-highlight-overlay⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-before">
-   <b><a href="#selectordef-before">#selectordef-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-before" class="dfn-panel" data-for="selectordef-before" id="infopanel-for-selectordef-before" role="dialog">
+   <span id="infopaneltitle-for-selectordef-before" style="display:none">Info about the '::before' definition.</span><b><a href="#selectordef-before">#selectordef-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">2.2.1. 
 Finding the First Letter Text</a>
@@ -3344,8 +3344,8 @@ CSSPseudoElement Interface</a>
 Compatibility Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-after">
-   <b><a href="#selectordef-after">#selectordef-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-after" class="dfn-panel" data-for="selectordef-after" id="infopanel-for-selectordef-after" role="dialog">
+   <span id="infopaneltitle-for-selectordef-after" style="display:none">Info about the '::after' definition.</span><b><a href="#selectordef-after">#selectordef-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">2.2.1. 
 Finding the First Letter Text</a>
@@ -3361,8 +3361,8 @@ CSSPseudoElement Interface</a>
 Compatibility Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-marker">
-   <b><a href="#selectordef-marker">#selectordef-marker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-marker" class="dfn-panel" data-for="selectordef-marker" id="infopanel-for-selectordef-marker" role="dialog">
+   <span id="infopaneltitle-for-selectordef-marker" style="display:none">Info about the '::marker' definition.</span><b><a href="#selectordef-marker">#selectordef-marker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">4.2. 
 List Markers: the ::marker pseudo-element</a> <a href="#ref-for-selectordef-marker①">(2)</a> <a href="#ref-for-selectordef-marker②">(3)</a> <a href="#ref-for-selectordef-marker③">(4)</a> <a href="#ref-for-selectordef-marker④">(5)</a>
@@ -3371,22 +3371,22 @@ CSSPseudoElement Interface</a>
     <li><a href="#ref-for-selectordef-marker⑥"> Changes</a> <a href="#ref-for-selectordef-marker⑦">(2)</a> <a href="#ref-for-selectordef-marker⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-placeholder">
-   <b><a href="#selectordef-placeholder">#selectordef-placeholder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-placeholder" class="dfn-panel" data-for="selectordef-placeholder" id="infopanel-for-selectordef-placeholder" role="dialog">
+   <span id="infopaneltitle-for-selectordef-placeholder" style="display:none">Info about the '::placeholder' definition.</span><b><a href="#selectordef-placeholder">#selectordef-placeholder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-placeholder">4.3. 
 Placeholder Input: the ::placeholder pseudo-element</a> <a href="#ref-for-selectordef-placeholder①">(2)</a> <a href="#ref-for-selectordef-placeholder②">(3)</a> <a href="#ref-for-selectordef-placeholder③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-file-selector-button">
-   <b><a href="#selectordef-file-selector-button">#selectordef-file-selector-button</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-file-selector-button" class="dfn-panel" data-for="selectordef-file-selector-button" id="infopanel-for-selectordef-file-selector-button" role="dialog">
+   <span id="infopaneltitle-for-selectordef-file-selector-button" style="display:none">Info about the '::file-selector-button' definition.</span><b><a href="#selectordef-file-selector-button">#selectordef-file-selector-button</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-file-selector-button">4.4. 
 File Selector Button: the ::file-selector-button pseudo-element</a> <a href="#ref-for-selectordef-file-selector-button①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csspseudoelement">
-   <b><a href="#csspseudoelement">#csspseudoelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csspseudoelement" class="dfn-panel" data-for="csspseudoelement" id="infopanel-for-csspseudoelement" role="dialog">
+   <span id="infopaneltitle-for-csspseudoelement" style="display:none">Info about the 'CSSPseudoElement' definition.</span><b><a href="#csspseudoelement">#csspseudoelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspseudoelement">6.1. 
 CSSPseudoElement Interface</a> <a href="#ref-for-csspseudoelement①">(2)</a>
@@ -3395,31 +3395,31 @@ pseudo() method of the Element interface</a> <a href="#ref-for-csspseudoelement�
     <li><a href="#ref-for-csspseudoelement⑥"> Changes</a> <a href="#ref-for-csspseudoelement⑦">(2)</a> <a href="#ref-for-csspseudoelement⑧">(3)</a> <a href="#ref-for-csspseudoelement⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspseudoelement-type">
-   <b><a href="#dom-csspseudoelement-type">#dom-csspseudoelement-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspseudoelement-type" class="dfn-panel" data-for="dom-csspseudoelement-type" id="infopanel-for-dom-csspseudoelement-type" role="dialog">
+   <span id="infopaneltitle-for-dom-csspseudoelement-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-csspseudoelement-type">#dom-csspseudoelement-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspseudoelement-type">6.1. 
 CSSPseudoElement Interface</a>
     <li><a href="#ref-for-dom-csspseudoelement-type①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspseudoelement-element">
-   <b><a href="#dom-csspseudoelement-element">#dom-csspseudoelement-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspseudoelement-element" class="dfn-panel" data-for="dom-csspseudoelement-element" id="infopanel-for-dom-csspseudoelement-element" role="dialog">
+   <span id="infopaneltitle-for-dom-csspseudoelement-element" style="display:none">Info about the 'element' definition.</span><b><a href="#dom-csspseudoelement-element">#dom-csspseudoelement-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspseudoelement-element">6.1. 
 CSSPseudoElement Interface</a>
     <li><a href="#ref-for-dom-csspseudoelement-element①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-pseudo-type-type">
-   <b><a href="#dom-element-pseudo-type-type">#dom-element-pseudo-type-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-pseudo-type-type" class="dfn-panel" data-for="dom-element-pseudo-type-type" id="infopanel-for-dom-element-pseudo-type-type" role="dialog">
+   <span id="infopaneltitle-for-dom-element-pseudo-type-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-element-pseudo-type-type">#dom-element-pseudo-type-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-pseudo-type-type">6.2. 
 pseudo() method of the Element interface</a> <a href="#ref-for-dom-element-pseudo-type-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-pseudo">
-   <b><a href="#dom-element-pseudo">#dom-element-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-pseudo" class="dfn-panel" data-for="dom-element-pseudo" id="infopanel-for-dom-element-pseudo" role="dialog">
+   <span id="infopaneltitle-for-dom-element-pseudo" style="display:none">Info about the 'pseudo(CSSOMString type)' definition.</span><b><a href="#dom-element-pseudo">#dom-element-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-pseudo">6.2. 
 pseudo() method of the Element interface</a> <a href="#ref-for-dom-element-pseudo①">(2)</a> <a href="#ref-for-dom-element-pseudo②">(3)</a>
@@ -3428,59 +3428,115 @@ pseudo() method of the Element interface</a> <a href="#ref-for-dom-element-pseud
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-regions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-regions-1/Overview.html
@@ -2865,71 +2865,71 @@ nav {
    <li><a href="#dom-namedflowmap-set">set()</a><span>, in § 4.1</span>
    <li><a href="#specified-flow">specified flow</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-size-height">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-size-height" class="dfn-panel" data-for="term-for-valdef-anchor-size-height" id="infopanel-for-term-for-valdef-anchor-size-height" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-size-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-size-height">7. 
 Regions visual formatting details</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-anchor-size-width">
-   <a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-anchor-size-width" class="dfn-panel" data-for="term-for-valdef-anchor-size-width" id="infopanel-for-term-for-valdef-anchor-size-width" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-anchor-size-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width">https://drafts.csswg.org/css-anchor-1/#valdef-anchor-size-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-anchor-size-width">7. 
 Regions visual formatting details</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">4.2. 
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-always">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-always">https://drafts.csswg.org/css-break-4/#valdef-break-before-always</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-always" class="dfn-panel" data-for="term-for-valdef-break-before-always" id="infopanel-for-term-for-valdef-break-before-always" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-always" style="display:none">Info about the 'always' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-always">https://drafts.csswg.org/css-break-4/#valdef-break-before-always</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-always">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-auto">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-auto">https://drafts.csswg.org/css-break-4/#valdef-break-before-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-auto" class="dfn-panel" data-for="term-for-valdef-break-before-auto" id="infopanel-for-term-for-valdef-break-before-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-auto">https://drafts.csswg.org/css-break-4/#valdef-break-before-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-auto">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-avoid">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid">https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-avoid" class="dfn-panel" data-for="term-for-valdef-break-before-avoid" id="infopanel-for-term-for-valdef-break-before-avoid" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-avoid" style="display:none">Info about the 'avoid' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid">https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-avoid-region">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid-region">https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-avoid-region" class="dfn-panel" data-for="term-for-valdef-break-before-avoid-region" id="infopanel-for-term-for-valdef-break-before-avoid-region" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-avoid-region" style="display:none">Info about the 'avoid-region' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid-region">https://drafts.csswg.org/css-break-4/#valdef-break-before-avoid-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-avoid-region">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-region">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-region">https://drafts.csswg.org/css-break-4/#valdef-break-before-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-region" class="dfn-panel" data-for="term-for-valdef-break-before-region" id="infopanel-for-term-for-valdef-break-before-region" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-region" style="display:none">Info about the 'region' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-region">https://drafts.csswg.org/css-break-4/#valdef-break-before-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-region">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-layout-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-layout-containment" class="dfn-panel" data-for="term-for-layout-containment" id="infopanel-for-term-for-layout-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-layout-containment" style="display:none">Info about the 'layout containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#layout-containment">https://drafts.csswg.org/css-contain-2/#layout-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-containment">2.3. 
 Last region</a> <a href="#ref-for-layout-containment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-property-scoped">
-   <a href="https://drafts.csswg.org/css-contain-2/#property-scoped">https://drafts.csswg.org/css-contain-2/#property-scoped</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-property-scoped" class="dfn-panel" data-for="term-for-property-scoped" id="infopanel-for-term-for-property-scoped" role="menu">
+   <span id="infopaneltitle-for-term-for-property-scoped" style="display:none">Info about the 'scoped' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#property-scoped">https://drafts.csswg.org/css-contain-2/#property-scoped</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-property-scoped">3.1. 
 The flow-into property</a>
@@ -2937,8 +2937,8 @@ The flow-into property</a>
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-containment" class="dfn-panel" data-for="term-for-style-containment" id="infopanel-for-term-for-style-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-style-containment" style="display:none">Info about the 'style containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#style-containment">https://drafts.csswg.org/css-contain-2/#style-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-containment">3.1. 
 The flow-into property</a>
@@ -2946,57 +2946,57 @@ The flow-into property</a>
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">3.2. 
 The flow-from property</a> <a href="#ref-for-propdef-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-none">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-none" class="dfn-panel" data-for="term-for-valdef-content-none" id="infopanel-for-term-for-valdef-content-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-none">https://drafts.csswg.org/css-content-3/#valdef-content-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">3.2. 
 The flow-from property</a> <a href="#ref-for-valdef-content-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-normal">
-   <a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-normal" class="dfn-panel" data-for="term-for-valdef-content-normal" id="infopanel-for-term-for-valdef-content-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#valdef-content-normal">https://drafts.csswg.org/css-content-3/#valdef-content-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-normal">3.2. 
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.2. 
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3.2. 
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3.4. 
 The region-fragment property</a> <a href="#ref-for-propdef-overflow①">(2)</a> <a href="#ref-for-propdef-overflow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-continue">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-continue">https://drafts.csswg.org/css-overflow-4/#propdef-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-continue" class="dfn-panel" data-for="term-for-propdef-continue" id="infopanel-for-term-for-propdef-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-continue">https://drafts.csswg.org/css-overflow-4/#propdef-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-continue">3.4. 
 The region-fragment property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">7.2. 
 The Region Flow Content Box (RFCB)</a>
@@ -3006,8 +3006,8 @@ Step 1 - Phase 1: Laying out RFCBs with used height of zero</a> <a href="#ref-fo
 Step 1 - Phase 2: Layout flow to compute the RFCBs' flow fragments heights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">3.2. 
 The flow-from property</a>
@@ -3029,8 +3029,8 @@ Step 2: Layout document and regions without named flows</a> <a href="#ref-for-pr
 Step 3: named flows layout</a> <a href="#ref-for-propdef-height①⑤">(2)</a> <a href="#ref-for-propdef-height①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">3.2. 
 The flow-from property</a>
@@ -3052,8 +3052,8 @@ Step 2: Layout document and regions without named flows</a>
 Step 3: named flows layout</a> <a href="#ref-for-propdef-width①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3.1. 
 The flow-into property</a>
@@ -3061,22 +3061,22 @@ The flow-into property</a>
 The flow-from property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.1. 
 The flow-into property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. 
 The flow-into property</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -3086,8 +3086,8 @@ The flow-from property</a>
 The region-fragment property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">7.3.1.2. 
 RFCB flow fragment height resolution, Phase 2</a>
@@ -3097,36 +3097,36 @@ Step 1 - Phase 2: Layout flow to compute the RFCBs' flow fragments heights</a>
 Step 2: Layout document and regions without named flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">3.3. 
 Controlling Region Flow Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-fill">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-fill">https://drafts.csswg.org/css-multicol-1/#propdef-column-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-fill" class="dfn-panel" data-for="term-for-propdef-column-fill" id="infopanel-for-term-for-propdef-column-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-fill" style="display:none">Info about the 'column-fill' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-fill">https://drafts.csswg.org/css-multicol-1/#propdef-column-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-fill">5. 
 Multi-column regions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-cssomstring①">(2)</a>
@@ -3134,64 +3134,64 @@ The NamedFlow interface</a> <a href="#ref-for-cssomstring①">(2)</a>
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">4.2. 
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range">
-   <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range" class="dfn-panel" data-for="term-for-range" id="infopanel-for-term-for-range" role="menu">
+   <span id="infopaneltitle-for-term-for-range" style="display:none">Info about the 'Range' external reference.</span><a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">4.2. 
 The Region mixin</a> <a href="#ref-for-range①">(2)</a> <a href="#ref-for-range②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">9. 
 Relation to other specifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-Exposed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
@@ -3199,8 +3199,8 @@ The NamedFlow interface</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">4.1. 
 The NamedFlow interface</a>
@@ -3467,8 +3467,8 @@ The NamedFlow interface</a>
   <div style="counter-reset:issue">
    <div class="issue"> The <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-overflow-4/#propdef-continue">continue</a> property in <a data-link-type="biblio" href="#biblio-css-overflow-3" title="CSS Overflow Module Level 3">[css-overflow-3]</a> is likely to replace this property. <a class="issue-return" href="#issue-e3598b8f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="css-region">
-   <b><a href="#css-region">#css-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-region" class="dfn-panel" data-for="css-region" id="infopanel-for-css-region" role="dialog">
+   <span id="infopaneltitle-for-css-region" style="display:none">Info about the 'CSS Region' definition.</span><b><a href="#css-region">#css-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-region">1. 
 Introduction</a> <a href="#ref-for-css-region①">(2)</a> <a href="#ref-for-css-region②">(3)</a> <a href="#ref-for-css-region③">(4)</a>
@@ -3504,8 +3504,8 @@ Relation to document events</a> <a href="#ref-for-css-region④④">(2)</a>
 Relation to other specifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="region-chain">
-   <b><a href="#region-chain">#region-chain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-region-chain" class="dfn-panel" data-for="region-chain" id="infopanel-for-region-chain" role="dialog">
+   <span id="infopaneltitle-for-region-chain" style="display:none">Info about the 'region chain' definition.</span><b><a href="#region-chain">#region-chain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region-chain">1. 
 Introduction</a> <a href="#ref-for-region-chain①">(2)</a> <a href="#ref-for-region-chain②">(3)</a> <a href="#ref-for-region-chain③">(4)</a> <a href="#ref-for-region-chain④">(5)</a>
@@ -3545,8 +3545,8 @@ Step 3: named flows layout</a>
 Step 3: named flows layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-usable-region">
-   <b><a href="#last-usable-region">#last-usable-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-usable-region" class="dfn-panel" data-for="last-usable-region" id="infopanel-for-last-usable-region" role="dialog">
+   <span id="infopaneltitle-for-last-usable-region" style="display:none">Info about the 'last usable region' definition.</span><b><a href="#last-usable-region">#last-usable-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-usable-region">2.5. 
 Regions flow breaking rules</a>
@@ -3560,8 +3560,8 @@ The Region mixin</a> <a href="#ref-for-last-usable-region⑥">(2)</a> <a href="#
 Multi-column regions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="named-flow">
-   <b><a href="#named-flow">#named-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-named-flow" class="dfn-panel" data-for="named-flow" id="infopanel-for-named-flow" role="dialog">
+   <span id="infopaneltitle-for-named-flow" style="display:none">Info about the 'named flow' definition.</span><b><a href="#named-flow">#named-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-flow">1. 
 Introduction</a> <a href="#ref-for-named-flow①">(2)</a> <a href="#ref-for-named-flow②">(3)</a> <a href="#ref-for-named-flow③">(4)</a> <a href="#ref-for-named-flow④">(5)</a> <a href="#ref-for-named-flow⑤">(6)</a>
@@ -3618,8 +3618,8 @@ Step 3: named flows layout</a> <a href="#ref-for-named-flow①⓪③">(2)</a>
 Relation to document events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flow-into">
-   <b><a href="#propdef-flow-into">#propdef-flow-into</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flow-into" class="dfn-panel" data-for="propdef-flow-into" id="infopanel-for-propdef-flow-into" role="dialog">
+   <span id="infopaneltitle-for-propdef-flow-into" style="display:none">Info about the 'flow-into' definition.</span><b><a href="#propdef-flow-into">#propdef-flow-into</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flow-into">2.4. 
 Named flows</a>
@@ -3627,8 +3627,8 @@ Named flows</a>
 The flow-into property</a> <a href="#ref-for-propdef-flow-into②">(2)</a> <a href="#ref-for-propdef-flow-into③">(3)</a> <a href="#ref-for-propdef-flow-into④">(4)</a> <a href="#ref-for-propdef-flow-into⑤">(5)</a> <a href="#ref-for-propdef-flow-into⑥">(6)</a> <a href="#ref-for-propdef-flow-into⑦">(7)</a> <a href="#ref-for-propdef-flow-into⑧">(8)</a> <a href="#ref-for-propdef-flow-into⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-flow-from">
-   <b><a href="#propdef-flow-from">#propdef-flow-from</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-flow-from" class="dfn-panel" data-for="propdef-flow-from" id="infopanel-for-propdef-flow-from" role="dialog">
+   <span id="infopaneltitle-for-propdef-flow-from" style="display:none">Info about the 'flow-from' definition.</span><b><a href="#propdef-flow-from">#propdef-flow-from</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flow-from">1. 
 Introduction</a>
@@ -3644,8 +3644,8 @@ Cycle Detection</a> <a href="#ref-for-propdef-flow-from⑨">(2)</a> <a href="#re
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nested-region-context">
-   <b><a href="#nested-region-context">#nested-region-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nested-region-context" class="dfn-panel" data-for="nested-region-context" id="infopanel-for-nested-region-context" role="dialog">
+   <span id="infopaneltitle-for-nested-region-context" style="display:none">Info about the 'nested region context' definition.</span><b><a href="#nested-region-context">#nested-region-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-region-context">7.3.1.2. 
 RFCB flow fragment height resolution, Phase 2</a>
@@ -3653,8 +3653,8 @@ RFCB flow fragment height resolution, Phase 2</a>
 Step 3: named flows layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-region-fragment">
-   <b><a href="#propdef-region-fragment">#propdef-region-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-region-fragment" class="dfn-panel" data-for="propdef-region-fragment" id="infopanel-for-propdef-region-fragment" role="dialog">
+   <span id="infopaneltitle-for-propdef-region-fragment" style="display:none">Info about the 'region-fragment' definition.</span><b><a href="#propdef-region-fragment">#propdef-region-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-region-fragment">2.5. 
 Regions flow breaking rules</a>
@@ -3664,22 +3664,22 @@ The region-fragment property</a> <a href="#ref-for-propdef-region-fragment②">(
 The Region mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-namedflows">
-   <b><a href="#dom-document-namedflows">#dom-document-namedflows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-namedflows" class="dfn-panel" data-for="dom-document-namedflows" id="infopanel-for-dom-document-namedflows" role="dialog">
+   <span id="infopaneltitle-for-dom-document-namedflows" style="display:none">Info about the 'namedFlows' definition.</span><b><a href="#dom-document-namedflows">#dom-document-namedflows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-namedflows">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="namedflowmap">
-   <b><a href="#namedflowmap">#namedflowmap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namedflowmap" class="dfn-panel" data-for="namedflowmap" id="infopanel-for-namedflowmap" role="dialog">
+   <span id="infopaneltitle-for-namedflowmap" style="display:none">Info about the 'NamedFlowMap' definition.</span><b><a href="#namedflowmap">#namedflowmap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namedflowmap">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-namedflowmap①">(2)</a> <a href="#ref-for-namedflowmap②">(3)</a> <a href="#ref-for-namedflowmap③">(4)</a> <a href="#ref-for-namedflowmap④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="namedflow">
-   <b><a href="#namedflow">#namedflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namedflow" class="dfn-panel" data-for="namedflow" id="infopanel-for-namedflow" role="dialog">
+   <span id="infopaneltitle-for-namedflow" style="display:none">Info about the 'NamedFlow' definition.</span><b><a href="#namedflow">#namedflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namedflow">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-namedflow①">(2)</a> <a href="#ref-for-namedflow②">(3)</a> <a href="#ref-for-namedflow③">(4)</a> <a href="#ref-for-namedflow④">(5)</a> <a href="#ref-for-namedflow⑤">(6)</a> <a href="#ref-for-namedflow⑥">(7)</a> <a href="#ref-for-namedflow⑦">(8)</a> <a href="#ref-for-namedflow⑧">(9)</a>
@@ -3687,43 +3687,43 @@ The NamedFlow interface</a> <a href="#ref-for-namedflow①">(2)</a> <a href="#re
 Named flow events</a> <a href="#ref-for-namedflow①⓪">(2)</a> <a href="#ref-for-namedflow①①">(3)</a> <a href="#ref-for-namedflow①②">(4)</a> <a href="#ref-for-namedflow①③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namedflow-name">
-   <b><a href="#dom-namedflow-name">#dom-namedflow-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namedflow-name" class="dfn-panel" data-for="dom-namedflow-name" id="infopanel-for-dom-namedflow-name" role="dialog">
+   <span id="infopaneltitle-for-dom-namedflow-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-namedflow-name">#dom-namedflow-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflow-name">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namedflow-overset">
-   <b><a href="#dom-namedflow-overset">#dom-namedflow-overset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namedflow-overset" class="dfn-panel" data-for="dom-namedflow-overset" id="infopanel-for-dom-namedflow-overset" role="dialog">
+   <span id="infopaneltitle-for-dom-namedflow-overset" style="display:none">Info about the 'overset' definition.</span><b><a href="#dom-namedflow-overset">#dom-namedflow-overset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflow-overset">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-dom-namedflow-overset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namedflow-getregions">
-   <b><a href="#dom-namedflow-getregions">#dom-namedflow-getregions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namedflow-getregions" class="dfn-panel" data-for="dom-namedflow-getregions" id="infopanel-for-dom-namedflow-getregions" role="dialog">
+   <span id="infopaneltitle-for-dom-namedflow-getregions" style="display:none">Info about the 'getRegions()' definition.</span><b><a href="#dom-namedflow-getregions">#dom-namedflow-getregions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflow-getregions">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namedflow-firstemptyregionindex">
-   <b><a href="#dom-namedflow-firstemptyregionindex">#dom-namedflow-firstemptyregionindex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namedflow-firstemptyregionindex" class="dfn-panel" data-for="dom-namedflow-firstemptyregionindex" id="infopanel-for-dom-namedflow-firstemptyregionindex" role="dialog">
+   <span id="infopaneltitle-for-dom-namedflow-firstemptyregionindex" style="display:none">Info about the 'firstEmptyRegionIndex' definition.</span><b><a href="#dom-namedflow-firstemptyregionindex">#dom-namedflow-firstemptyregionindex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflow-firstemptyregionindex">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namedflow-getcontent">
-   <b><a href="#dom-namedflow-getcontent">#dom-namedflow-getcontent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namedflow-getcontent" class="dfn-panel" data-for="dom-namedflow-getcontent" id="infopanel-for-dom-namedflow-getcontent" role="dialog">
+   <span id="infopaneltitle-for-dom-namedflow-getcontent" style="display:none">Info about the 'getContent()' definition.</span><b><a href="#dom-namedflow-getcontent">#dom-namedflow-getcontent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namedflow-getcontent">4.1. 
 The NamedFlow interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="region">
-   <b><a href="#region">#region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-region" class="dfn-panel" data-for="region" id="infopanel-for-region" role="dialog">
+   <span id="infopaneltitle-for-region" style="display:none">Info about the 'Region' definition.</span><b><a href="#region">#region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-region">4.1. 
 The NamedFlow interface</a> <a href="#ref-for-region①">(2)</a>
@@ -3731,15 +3731,15 @@ The NamedFlow interface</a> <a href="#ref-for-region①">(2)</a>
 The Region mixin</a> <a href="#ref-for-region③">(2)</a> <a href="#ref-for-region④">(3)</a> <a href="#ref-for-region⑤">(4)</a> <a href="#ref-for-region⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-region-regionoverset">
-   <b><a href="#dom-region-regionoverset">#dom-region-regionoverset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-region-regionoverset" class="dfn-panel" data-for="dom-region-regionoverset" id="infopanel-for-dom-region-regionoverset" role="dialog">
+   <span id="infopaneltitle-for-dom-region-regionoverset" style="display:none">Info about the 'regionOverset' definition.</span><b><a href="#dom-region-regionoverset">#dom-region-regionoverset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-region-regionoverset">4.2. 
 The Region mixin</a> <a href="#ref-for-dom-region-regionoverset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-region-getregionflowranges">
-   <b><a href="#dom-region-getregionflowranges">#dom-region-getregionflowranges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-region-getregionflowranges" class="dfn-panel" data-for="dom-region-getregionflowranges" id="infopanel-for-dom-region-getregionflowranges" role="dialog">
+   <span id="infopaneltitle-for-dom-region-getregionflowranges" style="display:none">Info about the 'getRegionFlowRanges()' definition.</span><b><a href="#dom-region-getregionflowranges">#dom-region-getregionflowranges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-region-getregionflowranges">4.2. 
 The Region mixin</a>
@@ -3747,59 +3747,115 @@ The Region mixin</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-rhythm-1/Overview.html
@@ -1656,75 +1656,75 @@ h1 <c- p>{</c->
    <li><a href="#step-unit">step unit</a><span>, in § 3</span>
    <li><a href="#valdef-block-step-align-up">up</a><span>, in § 2.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">2.3. Specifying Alignment: the block-step-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">2.2. Specifying the Spacing Type: the block-step-insert property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">2.2. Specifying the Spacing Type: the block-step-insert property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2.1. Specifying the Step Size: the block-step-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-establish-an-independent-formatting-context" class="dfn-panel" data-for="term-for-establish-an-independent-formatting-context" id="infopanel-for-term-for-establish-an-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-establish-an-independent-formatting-context" style="display:none">Info about the 'establish an independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context">https://drafts.csswg.org/css-display-3/#establish-an-independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-independent-formatting-context">2.1. Specifying the Step Size: the block-step-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3. Adjusting Line Box Heights: the line-height-step property</a> <a href="#ref-for-propdef-vertical-align①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-grid">
-   <a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid">https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-grid" class="dfn-panel" data-for="term-for-propdef-line-grid" id="infopanel-for-term-for-propdef-line-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-grid" style="display:none">Info about the 'line-grid' external reference.</span><a href="https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid">https://drafts.csswg.org/css-line-grid-1/#propdef-line-grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-grid">1.1. East Asian Casual Vertical Rhythms</a> <a href="#ref-for-propdef-line-grid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2.1. Specifying the Step Size: the block-step-size property</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a>
     <li><a href="#ref-for-length-value③">3. Adjusting Line Box Heights: the line-height-step property</a> <a href="#ref-for-length-value④">(2)</a> <a href="#ref-for-length-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. Specifying the Step Size: the block-step-size property</a>
     <li><a href="#ref-for-comb-one①">2.2. Specifying the Spacing Type: the block-step-insert property</a>
@@ -1732,50 +1732,50 @@ h1 <c- p>{</c->
     <li><a href="#ref-for-comb-one⑤">2.4. Rounding Method: the block-step-round property</a> <a href="#ref-for-comb-one⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">2.1. Specifying the Step Size: the block-step-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">2.3. Specifying Alignment: the block-step-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-over" class="dfn-panel" data-for="term-for-over" id="infopanel-for-term-for-over" role="menu">
+   <span id="infopaneltitle-for-term-for-over" style="display:none">Info about the 'over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-over">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">2.3. Specifying Alignment: the block-step-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-under" class="dfn-panel" data-for="term-for-under" id="infopanel-for-term-for-under" role="menu">
+   <span id="infopaneltitle-for-term-for-under" style="display:none">Info about the 'under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
@@ -1979,8 +1979,8 @@ h1 <c- p>{</c->
    <div class="issue">Should this be animatable?
 	There doesn’t seem to be use cases but needed for consistency? <a class="issue-return" href="#issue-27b8d19f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-block-step-size">
-   <b><a href="#propdef-block-step-size">#propdef-block-step-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-step-size" class="dfn-panel" data-for="propdef-block-step-size" id="infopanel-for-propdef-block-step-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-step-size" style="display:none">Info about the 'block-step-size' definition.</span><b><a href="#propdef-block-step-size">#propdef-block-step-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-size">2. Adjusting Block-level Box Heights</a> <a href="#ref-for-propdef-block-step-size①">(2)</a>
     <li><a href="#ref-for-propdef-block-step-size②">2.1. Specifying the Step Size: the block-step-size property</a>
@@ -1990,8 +1990,8 @@ h1 <c- p>{</c->
     <li><a href="#ref-for-propdef-block-step-size①⑤">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a> <a href="#ref-for-propdef-block-step-size①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-step-insert">
-   <b><a href="#propdef-block-step-insert">#propdef-block-step-insert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-step-insert" class="dfn-panel" data-for="propdef-block-step-insert" id="infopanel-for-propdef-block-step-insert" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-step-insert" style="display:none">Info about the 'block-step-insert' definition.</span><b><a href="#propdef-block-step-insert">#propdef-block-step-insert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-insert">2. Adjusting Block-level Box Heights</a>
     <li><a href="#ref-for-propdef-block-step-insert①">2.2. Specifying the Spacing Type: the block-step-insert property</a>
@@ -1999,40 +1999,40 @@ h1 <c- p>{</c->
     <li><a href="#ref-for-propdef-block-step-insert④">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a> <a href="#ref-for-propdef-block-step-insert⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-insert-margin">
-   <b><a href="#valdef-block-step-insert-margin">#valdef-block-step-insert-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-insert-margin" class="dfn-panel" data-for="valdef-block-step-insert-margin" id="infopanel-for-valdef-block-step-insert-margin" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-insert-margin" style="display:none">Info about the 'margin' definition.</span><b><a href="#valdef-block-step-insert-margin">#valdef-block-step-insert-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-insert-margin">2.3. Specifying Alignment: the block-step-align property</a> <a href="#ref-for-valdef-block-step-insert-margin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-step-align">
-   <b><a href="#propdef-block-step-align">#propdef-block-step-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-step-align" class="dfn-panel" data-for="propdef-block-step-align" id="infopanel-for-propdef-block-step-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-step-align" style="display:none">Info about the 'block-step-align' definition.</span><b><a href="#propdef-block-step-align">#propdef-block-step-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-align">2. Adjusting Block-level Box Heights</a>
     <li><a href="#ref-for-propdef-block-step-align①">2.3. Specifying Alignment: the block-step-align property</a> <a href="#ref-for-propdef-block-step-align②">(2)</a>
     <li><a href="#ref-for-propdef-block-step-align③">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a> <a href="#ref-for-propdef-block-step-align④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-align-center">
-   <b><a href="#valdef-block-step-align-center">#valdef-block-step-align-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-align-center" class="dfn-panel" data-for="valdef-block-step-align-center" id="infopanel-for-valdef-block-step-align-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-align-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-block-step-align-center">#valdef-block-step-align-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-align-center">2.3. Specifying Alignment: the block-step-align property</a> <a href="#ref-for-valdef-block-step-align-center①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-align-start">
-   <b><a href="#valdef-block-step-align-start">#valdef-block-step-align-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-align-start" class="dfn-panel" data-for="valdef-block-step-align-start" id="infopanel-for-valdef-block-step-align-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-align-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-block-step-align-start">#valdef-block-step-align-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-align-start">2.3. Specifying Alignment: the block-step-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-align-end">
-   <b><a href="#valdef-block-step-align-end">#valdef-block-step-align-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-align-end" class="dfn-panel" data-for="valdef-block-step-align-end" id="infopanel-for-valdef-block-step-align-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-align-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-block-step-align-end">#valdef-block-step-align-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-align-end">2.3. Specifying Alignment: the block-step-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-step-round">
-   <b><a href="#propdef-block-step-round">#propdef-block-step-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-step-round" class="dfn-panel" data-for="propdef-block-step-round" id="infopanel-for-propdef-block-step-round" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-step-round" style="display:none">Info about the 'block-step-round' definition.</span><b><a href="#propdef-block-step-round">#propdef-block-step-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-round">2. Adjusting Block-level Box Heights</a>
     <li><a href="#ref-for-propdef-block-step-round①">2.1. Specifying the Step Size: the block-step-size property</a>
@@ -2040,35 +2040,35 @@ h1 <c- p>{</c->
     <li><a href="#ref-for-propdef-block-step-round③">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a> <a href="#ref-for-propdef-block-step-round④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-align-up">
-   <b><a href="#valdef-block-step-align-up">#valdef-block-step-align-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-align-up" class="dfn-panel" data-for="valdef-block-step-align-up" id="infopanel-for-valdef-block-step-align-up" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-align-up" style="display:none">Info about the 'up' definition.</span><b><a href="#valdef-block-step-align-up">#valdef-block-step-align-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-align-up">2.4. Rounding Method: the block-step-round property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-block-step-align-down">
-   <b><a href="#valdef-block-step-align-down">#valdef-block-step-align-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-block-step-align-down" class="dfn-panel" data-for="valdef-block-step-align-down" id="infopanel-for-valdef-block-step-align-down" role="dialog">
+   <span id="infopaneltitle-for-valdef-block-step-align-down" style="display:none">Info about the 'down' definition.</span><b><a href="#valdef-block-step-align-down">#valdef-block-step-align-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-block-step-align-down">2.4. Rounding Method: the block-step-round property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-block-step">
-   <b><a href="#propdef-block-step">#propdef-block-step</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-block-step" class="dfn-panel" data-for="propdef-block-step" id="infopanel-for-propdef-block-step" role="dialog">
+   <span id="infopaneltitle-for-propdef-block-step" style="display:none">Info about the 'block-step' definition.</span><b><a href="#propdef-block-step">#propdef-block-step</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step">1.1. East Asian Casual Vertical Rhythms</a> <a href="#ref-for-propdef-block-step①">(2)</a>
     <li><a href="#ref-for-propdef-block-step②">2. Adjusting Block-level Box Heights</a> <a href="#ref-for-propdef-block-step③">(2)</a>
     <li><a href="#ref-for-propdef-block-step④">2.5. Block Step Adjustment Shorthand: the block-step shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-height-step">
-   <b><a href="#propdef-line-height-step">#propdef-line-height-step</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-height-step" class="dfn-panel" data-for="propdef-line-height-step" id="infopanel-for-propdef-line-height-step" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-height-step" style="display:none">Info about the 'line-height-step' definition.</span><b><a href="#propdef-line-height-step">#propdef-line-height-step</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height-step">1.1. East Asian Casual Vertical Rhythms</a> <a href="#ref-for-propdef-line-height-step①">(2)</a>
     <li><a href="#ref-for-propdef-line-height-step②">3. Adjusting Line Box Heights: the line-height-step property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="step-unit">
-   <b><a href="#step-unit">#step-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-step-unit" class="dfn-panel" data-for="step-unit" id="infopanel-for-step-unit" role="dialog">
+   <span id="infopaneltitle-for-step-unit" style="display:none">Info about the 'step unit' definition.</span><b><a href="#step-unit">#step-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-step-unit">2.1. Specifying the Step Size: the block-step-size property</a> <a href="#ref-for-step-unit①">(2)</a>
     <li><a href="#ref-for-step-unit②">3. Adjusting Line Box Heights: the line-height-step property</a> <a href="#ref-for-step-unit③">(2)</a> <a href="#ref-for-step-unit④">(3)</a> <a href="#ref-for-step-unit⑤">(4)</a> <a href="#ref-for-step-unit⑥">(5)</a> <a href="#ref-for-step-unit⑦">(6)</a> <a href="#ref-for-step-unit⑧">(7)</a> <a href="#ref-for-step-unit⑨">(8)</a> <a href="#ref-for-step-unit①⓪">(9)</a> <a href="#ref-for-step-unit①①">(10)</a> <a href="#ref-for-step-unit①②">(11)</a>
@@ -2076,59 +2076,115 @@ h1 <c- p>{</c->
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-round-display-1/Overview.html
@@ -1352,34 +1352,34 @@ Without using Media Queries, contents can be aligned within the display edge aut
    <li><a href="#propdef-shape-inside">shape-inside</a><span>, in § 5.1</span>
    <li><a href="#descdef-viewport-viewport-fit">viewport-fit</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">3.1. The shape media feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-viewport">
-   <a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-viewport" class="dfn-panel" data-for="term-for-at-ruledef-viewport" id="infopanel-for-term-for-at-ruledef-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-viewport" style="display:none">Info about the '@viewport' external reference.</span><a href="https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport">https://www.w3.org/TR/css-device-adapt-1/#at-ruledef-viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-viewport">4.1. The viewport-fit descriptor</a>
     <li><a href="#ref-for-at-ruledef-viewport①">8.1. 
 Changes from March 1th 2016 version</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">5.1. The shape-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. The shape media feature</a>
     <li><a href="#ref-for-comb-one①">4.1. The viewport-fit descriptor</a> <a href="#ref-for-comb-one②">(2)</a>
@@ -1387,46 +1387,46 @@ Changes from March 1th 2016 version</a>
     <li><a href="#ref-for-comb-one⑦">6.1. The border-boundary property</a> <a href="#ref-for-comb-one⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">5.1. The shape-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-uri">
-   <a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-uri" class="dfn-panel" data-for="term-for-value-def-uri" id="infopanel-for-term-for-value-def-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-uri" style="display:none">Info about the '&lt;uri>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-uri">5.1. The shape-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-false">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-false" class="dfn-panel" data-for="term-for-valdef-custom-media-false" id="infopanel-for-term-for-valdef-custom-media-false" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-false" style="display:none">Info about the 'false' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-false">3.1. The shape media feature</a> <a href="#ref-for-valdef-custom-media-false①">(2)</a> <a href="#ref-for-valdef-custom-media-false②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-true">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-true" class="dfn-panel" data-for="term-for-valdef-custom-media-true" id="infopanel-for-term-for-valdef-custom-media-true" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-true" style="display:none">Info about the 'true' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-true">3.1. The shape media feature</a> <a href="#ref-for-valdef-custom-media-true①">(2)</a> <a href="#ref-for-valdef-custom-media-true②">(3)</a> <a href="#ref-for-valdef-custom-media-true③">(4)</a> <a href="#ref-for-valdef-custom-media-true④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-distance">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-distance">https://drafts.fxtf.org/motion-1/#propdef-offset-distance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-distance" class="dfn-panel" data-for="term-for-propdef-offset-distance" id="infopanel-for-term-for-propdef-offset-distance" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-distance" style="display:none">Info about the 'offset-distance' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-distance">https://drafts.fxtf.org/motion-1/#propdef-offset-distance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-distance">8.1. 
 Changes from March 1th 2016 version</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-path">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-path">https://drafts.fxtf.org/motion-1/#propdef-offset-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-path" class="dfn-panel" data-for="term-for-propdef-offset-path" id="infopanel-for-term-for-propdef-offset-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-path" style="display:none">Info about the 'offset-path' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-path">https://drafts.fxtf.org/motion-1/#propdef-offset-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-path">8.1. 
 Changes from March 1th 2016 version</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset-position">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset-position">https://drafts.fxtf.org/motion-1/#propdef-offset-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset-position" class="dfn-panel" data-for="term-for-propdef-offset-position" id="infopanel-for-term-for-propdef-offset-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset-position" style="display:none">Info about the 'offset-position' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset-position">https://drafts.fxtf.org/motion-1/#propdef-offset-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-position">8.1. 
 Changes from March 1th 2016 version</a>
@@ -1590,47 +1590,47 @@ Changes from March 1th 2016 version</a>
   <div style="counter-reset:issue">
    <div class="issue"> What if content overflows? Clipping or scrolling? <a class="issue-return" href="#issue-8d78506c" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="descdef-media-shape">
-   <b><a href="#descdef-media-shape">#descdef-media-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-shape" class="dfn-panel" data-for="descdef-media-shape" id="infopanel-for-descdef-media-shape" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-shape" style="display:none">Info about the 'shape' definition.</span><b><a href="#descdef-media-shape">#descdef-media-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-shape">3.1. The shape media feature</a> <a href="#ref-for-descdef-media-shape①">(2)</a> <a href="#ref-for-descdef-media-shape②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-shape-rect">
-   <b><a href="#valdef-media-shape-rect">#valdef-media-shape-rect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-shape-rect" class="dfn-panel" data-for="valdef-media-shape-rect" id="infopanel-for-valdef-media-shape-rect" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-shape-rect" style="display:none">Info about the 'rect' definition.</span><b><a href="#valdef-media-shape-rect">#valdef-media-shape-rect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-shape-rect">8.1. 
 Changes from March 1th 2016 version</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-shape-round">
-   <b><a href="#valdef-media-shape-round">#valdef-media-shape-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-shape-round" class="dfn-panel" data-for="valdef-media-shape-round" id="infopanel-for-valdef-media-shape-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-shape-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-media-shape-round">#valdef-media-shape-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-shape-round">8.1. 
 Changes from March 1th 2016 version</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-viewport-fit-contain">
-   <b><a href="#valdef-viewport-fit-contain">#valdef-viewport-fit-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-viewport-fit-contain" class="dfn-panel" data-for="valdef-viewport-fit-contain" id="infopanel-for-valdef-viewport-fit-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-viewport-fit-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-viewport-fit-contain">#valdef-viewport-fit-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-viewport-fit-contain">4.1. The viewport-fit descriptor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-viewport-fit-cover">
-   <b><a href="#valdef-viewport-fit-cover">#valdef-viewport-fit-cover</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-viewport-fit-cover" class="dfn-panel" data-for="valdef-viewport-fit-cover" id="infopanel-for-valdef-viewport-fit-cover" role="dialog">
+   <span id="infopaneltitle-for-valdef-viewport-fit-cover" style="display:none">Info about the 'cover' definition.</span><b><a href="#valdef-viewport-fit-cover">#valdef-viewport-fit-cover</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-viewport-fit-cover">4.1. The viewport-fit descriptor</a> <a href="#ref-for-valdef-viewport-fit-cover">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-inside">
-   <b><a href="#propdef-shape-inside">#propdef-shape-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-inside" class="dfn-panel" data-for="propdef-shape-inside" id="infopanel-for-propdef-shape-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-inside" style="display:none">Info about the 'shape-inside' definition.</span><b><a href="#propdef-shape-inside">#propdef-shape-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-inside">1. Introduction</a>
     <li><a href="#ref-for-propdef-shape-inside①">5.1. The shape-inside property</a> <a href="#ref-for-propdef-shape-inside②">(2)</a> <a href="#ref-for-propdef-shape-inside③">(3)</a> <a href="#ref-for-propdef-shape-inside④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-boundary">
-   <b><a href="#propdef-border-boundary">#propdef-border-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-boundary" class="dfn-panel" data-for="propdef-border-boundary" id="infopanel-for-propdef-border-boundary" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-boundary" style="display:none">Info about the 'border-boundary' definition.</span><b><a href="#propdef-border-boundary">#propdef-border-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-boundary">1. Introduction</a>
     <li><a href="#ref-for-propdef-border-boundary①">6.1. The border-boundary property</a> <a href="#ref-for-propdef-border-boundary②">(2)</a> <a href="#ref-for-propdef-border-boundary③">(3)</a> <a href="#ref-for-propdef-border-boundary④">(4)</a> <a href="#ref-for-propdef-border-boundary⑤">(5)</a>
@@ -1638,57 +1638,113 @@ Changes from March 1th 2016 version</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ruby-1/Overview.html
@@ -2902,98 +2902,98 @@ rt::after  <c- p>{</c-> <c- k>content</c-><c- p>:</c-> <c- s>"）"</c-><c- p>;</
    <li><a href="#valdef-ruby-position-under">under</a><span>, in § 4.1</span>
    <li><a href="#zhuyin-fuhao">Zhuyin Fuhao</a><span>, in § 6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-border">
-   <a href="https://drafts.csswg.org/css-box-4/#border">https://drafts.csswg.org/css-box-4/#border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border" class="dfn-panel" data-for="term-for-border" id="infopanel-for-term-for-border" role="menu">
+   <span id="infopaneltitle-for-term-for-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border">https://drafts.csswg.org/css-box-4/#border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border">3.3. 
 Styling Ruby Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-area">
-   <a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-area" class="dfn-panel" data-for="term-for-content-area" id="infopanel-for-term-for-content-area" role="menu">
+   <span id="infopaneltitle-for-term-for-content-area" style="display:none">Info about the 'content area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">3.2. 
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">3.2. 
 Inter-character Ruby Layout</a> <a href="#ref-for-content-box①">(2)</a> <a href="#ref-for-content-box②">(3)</a> <a href="#ref-for-content-box③">(4)</a> <a href="#ref-for-content-box④">(5)</a> <a href="#ref-for-content-box⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin" class="dfn-panel" data-for="term-for-margin" id="infopanel-for-term-for-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">3.3. 
 Styling Ruby Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">3.2. 
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">3.6. 
 Line Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2.5. 
 White Space Collapsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-block" class="dfn-panel" data-for="term-for-valdef-display-block" id="infopanel-for-term-for-valdef-display-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-block">https://drafts.csswg.org/css-display-3/#valdef-display-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-block">2.1.2. 
 Non-Inline Ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.1.1. 
 The Ruby Formatting Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-collapse">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse">https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-collapse" class="dfn-panel" data-for="term-for-valdef-visibility-collapse" id="infopanel-for-term-for-valdef-visibility-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-collapse" style="display:none">Info about the 'collapse' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse">https://drafts.csswg.org/css-display-3/#valdef-visibility-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-collapse">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2.1.1. 
 The Ruby Formatting Context</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a> <a href="#ref-for-containing-block③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.1. 
 Ruby-specific display Values</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a> <a href="#ref-for-propdef-display③">(4)</a> <a href="#ref-for-propdef-display④">(5)</a>
@@ -3005,15 +3005,15 @@ Anonymous Ruby Box Generation</a> <a href="#ref-for-propdef-display⑧">(2)</a> 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a> <a href="#ref-for-propdef-display①④">(2)</a> <a href="#ref-for-propdef-display①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">2.1.1. 
 The Ruby Formatting Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-in-flow①">(2)</a> <a href="#ref-for-in-flow②">(3)</a> <a href="#ref-for-in-flow③">(4)</a>
@@ -3021,30 +3021,30 @@ Anonymous Ruby Box Generation</a> <a href="#ref-for-in-flow①">(2)</a> <a href=
 Block-axis Interlinear Layout</a> <a href="#ref-for-in-flow⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">2.1.1. 
 The Ruby Formatting Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">2.1.2. 
 Non-Inline Ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-block">https://drafts.csswg.org/css-display-3/#inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-block" class="dfn-panel" data-for="term-for-inline-block" id="infopanel-for-term-for-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-block" style="display:none">Info about the 'inline block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-block">https://drafts.csswg.org/css-display-3/#inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-block">3.2. 
 Inter-character Ruby Layout</a>
     <li><a href="#ref-for-inline-block①"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.1.1. 
 The Ruby Formatting Context</a> <a href="#ref-for-inline-box①">(2)</a> <a href="#ref-for-inline-box②">(3)</a> <a href="#ref-for-inline-box③">(4)</a>
@@ -3059,8 +3059,8 @@ Sharing Annotation Space: the ruby-merge property</a>
     <li><a href="#ref-for-inline-box①②"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2.1.1. 
 The Ruby Formatting Context</a> <a href="#ref-for-inline-formatting-context①">(2)</a> <a href="#ref-for-inline-formatting-context②">(3)</a> <a href="#ref-for-inline-formatting-context③">(4)</a> <a href="#ref-for-inline-formatting-context④">(5)</a>
@@ -3070,15 +3070,15 @@ Interlinear Ruby Layout</a>
 Block-axis Interlinear Layout</a> <a href="#ref-for-inline-formatting-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">2.2. 
 Anonymous Ruby Box Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.1.1. 
 The Ruby Formatting Context</a>
@@ -3086,8 +3086,8 @@ The Ruby Formatting Context</a>
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inline-level②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level①" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level①" style="display:none">Info about the 'inline-level content' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.1.1. 
 The Ruby Formatting Context</a>
@@ -3095,22 +3095,22 @@ The Ruby Formatting Context</a>
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inline-level②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inlinify">
-   <a href="https://drafts.csswg.org/css-display-3/#inlinify">https://drafts.csswg.org/css-display-3/#inlinify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inlinify" class="dfn-panel" data-for="term-for-inlinify" id="infopanel-for-term-for-inlinify" role="menu">
+   <span id="infopaneltitle-for-term-for-inlinify" style="display:none">Info about the 'inlinify' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inlinify">https://drafts.csswg.org/css-display-3/#inlinify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inlinify">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inlinify①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">2.1.2. 
 Non-Inline Ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-internal-table-element">
-   <a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-internal-table-element" class="dfn-panel" data-for="term-for-internal-table-element" id="infopanel-for-term-for-internal-table-element" role="menu">
+   <span id="infopaneltitle-for-term-for-internal-table-element" style="display:none">Info about the 'internal table element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#internal-table-element">https://drafts.csswg.org/css-display-3/#internal-table-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-table-element">2.1.1. 
 The Ruby Formatting Context</a>
@@ -3118,57 +3118,57 @@ The Ruby Formatting Context</a>
 Anonymous Ruby Box Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#outer-display-type">https://drafts.csswg.org/css-display-3/#outer-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-display-type" class="dfn-panel" data-for="term-for-outer-display-type" id="infopanel-for-term-for-outer-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-display-type" style="display:none">Info about the 'outer display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#outer-display-type">https://drafts.csswg.org/css-display-3/#outer-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-display-type">2.1.2. 
 Non-Inline Ruby</a> <a href="#ref-for-outer-display-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a> <a href="#ref-for-propdef-visibility①">(2)</a> <a href="#ref-for-propdef-visibility②">(3)</a> <a href="#ref-for-propdef-visibility③">(4)</a> <a href="#ref-for-propdef-visibility④">(5)</a> <a href="#ref-for-propdef-visibility⑤">(6)</a> <a href="#ref-for-propdef-visibility⑥">(7)</a> <a href="#ref-for-propdef-visibility⑦">(8)</a>
     <li><a href="#ref-for-propdef-visibility⑧"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-grid-template-columns-max-content">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-grid-template-columns-max-content" class="dfn-panel" data-for="term-for-valdef-grid-template-columns-max-content" id="infopanel-for-term-for-valdef-grid-template-columns-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-grid-template-columns-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content">https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-grid-template-columns-max-content"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-bottom">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-bottom" class="dfn-panel" data-for="term-for-valdef-baseline-shift-bottom" id="infopanel-for-term-for-valdef-baseline-shift-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-bottom">3.3. 
 Styling Ruby Boxes</a> <a href="#ref-for-valdef-baseline-shift-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">3.1. 
 Interlinear Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-relative-shift-values">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-relative-shift-values">https://drafts.csswg.org/css-inline-3/#line-relative-shift-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-relative-shift-values" class="dfn-panel" data-for="term-for-line-relative-shift-values" id="infopanel-for-term-for-line-relative-shift-values" role="menu">
+   <span id="infopaneltitle-for-term-for-line-relative-shift-values" style="display:none">Info about the 'line-relative shift values' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-relative-shift-values">https://drafts.csswg.org/css-inline-3/#line-relative-shift-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-relative-shift-values">3.3. 
 Styling Ruby Boxes</a> <a href="#ref-for-line-relative-shift-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-top">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-top" class="dfn-panel" data-for="term-for-valdef-baseline-shift-top" id="infopanel-for-term-for-valdef-baseline-shift-top" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-top">3.3. 
 Styling Ruby Boxes</a> <a href="#ref-for-valdef-baseline-shift-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3.1.2. 
 Block-axis Interlinear Layout</a>
@@ -3178,100 +3178,100 @@ Styling Ruby Boxes</a> <a href="#ref-for-propdef-vertical-align②">(2)</a>
 Line Spacing</a> <a href="#ref-for-propdef-vertical-align④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.2. 
 Module interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.2. 
 Module interactions</a> <a href="#ref-for-selectordef-first-line①">(2)</a>
     <li><a href="#ref-for-selectordef-first-line②"> Changes since the 5 August 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">3.2. 
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">2.2. 
 Anonymous Ruby Box Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-character">
-   <a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-character" class="dfn-panel" data-for="term-for-character" id="infopanel-for-term-for-character" role="menu">
+   <span id="infopaneltitle-for-term-for-character" style="display:none">Info about the 'character' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">4.3. 
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-character①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collapsible-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#collapsible-white-space">https://drafts.csswg.org/css-text-4/#collapsible-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collapsible-white-space" class="dfn-panel" data-for="term-for-collapsible-white-space" id="infopanel-for-term-for-collapsible-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-collapsible-white-space" style="display:none">Info about the 'collapsible white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#collapsible-white-space">https://drafts.csswg.org/css-text-4/#collapsible-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsible-white-space">2.5. 
 White Space Collapsing</a> <a href="#ref-for-collapsible-white-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-justification-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-justification-opportunity" class="dfn-panel" data-for="term-for-justification-opportunity" id="infopanel-for-term-for-justification-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-justification-opportunity" style="display:none">Info about the 'justification opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-justification-opportunity">4.3. 
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-justification-opportunity①">(2)</a> <a href="#ref-for-justification-opportunity②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-word-break-keep-all">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all">https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-word-break-keep-all" class="dfn-panel" data-for="term-for-valdef-word-break-keep-all" id="infopanel-for-term-for-valdef-word-break-keep-all" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-word-break-keep-all" style="display:none">Info about the 'keep-all' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all">https://drafts.csswg.org/css-text-4/#valdef-word-break-keep-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-break-keep-all">3.4.1. 
 Breaking Between Bases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-segment-break">
-   <a href="https://drafts.csswg.org/css-text-4/#segment-break">https://drafts.csswg.org/css-text-4/#segment-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-segment-break" class="dfn-panel" data-for="term-for-segment-break" id="infopanel-for-term-for-segment-break" role="menu">
+   <span id="infopaneltitle-for-term-for-segment-break" style="display:none">Info about the 'segment break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#segment-break">https://drafts.csswg.org/css-text-4/#segment-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-segment-break">2.5. 
 White Space Collapsing</a> <a href="#ref-for-segment-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-soft-wrap-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-soft-wrap-opportunity" class="dfn-panel" data-for="term-for-soft-wrap-opportunity" id="infopanel-for-term-for-soft-wrap-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">3.4.2. 
 Breaking Within Bases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-justify">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-justify">https://drafts.csswg.org/css-text-4/#propdef-text-justify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-justify" class="dfn-panel" data-for="term-for-propdef-text-justify" id="infopanel-for-term-for-propdef-text-justify" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-justify" style="display:none">Info about the 'text-justify' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-justify">https://drafts.csswg.org/css-text-4/#propdef-text-justify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-justify">4.3. 
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-propdef-text-justify①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-white-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">2.2. 
 Anonymous Ruby Box Generation</a>
@@ -3281,28 +3281,28 @@ Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
 Breaking Within Bases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-break">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-break">https://drafts.csswg.org/css-text-4/#propdef-word-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-break" class="dfn-panel" data-for="term-for-propdef-word-break" id="infopanel-for-term-for-propdef-word-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-break" style="display:none">Info about the 'word-break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-break">https://drafts.csswg.org/css-text-4/#propdef-word-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-break">3.4.1. 
 Breaking Between Bases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-position">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-position" class="dfn-panel" data-for="term-for-propdef-text-emphasis-position" id="infopanel-for-term-for-propdef-text-emphasis-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-position" style="display:none">Info about the 'text-emphasis-position' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-position"> Changes since the 30 June 2011 WD</a> <a href="#ref-for-propdef-text-emphasis-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.3. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Ruby-specific display Values</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
@@ -3316,92 +3316,92 @@ Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-comb-one�
 Overhanging Ruby: the ruby-overhang property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.1. 
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bidi-isolate">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bidi-isolate" class="dfn-panel" data-for="term-for-bidi-isolate" id="infopanel-for-term-for-bidi-isolate" role="menu">
+   <span id="infopaneltitle-for-term-for-bidi-isolate" style="display:none">Info about the 'bidi isolation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-isolate">4.2. 
 Sharing Annotation Space: the ruby-merge property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-bidi-override">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-bidi-override">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-bidi-override</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-bidi-override" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-bidi-override" id="infopanel-for-term-for-valdef-unicode-bidi-bidi-override" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-bidi-override" style="display:none">Info about the 'bidi-override' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-bidi-override">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-bidi-override</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-bidi-override">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-embed">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-embed">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-embed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-embed" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-embed" id="infopanel-for-term-for-valdef-unicode-bidi-embed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-embed" style="display:none">Info about the 'embed' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-embed">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-embed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-embed">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-horizontal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-horizontal-writing-mode" class="dfn-panel" data-for="term-for-horizontal-writing-mode" id="infopanel-for-term-for-horizontal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">3.2. 
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-isolate">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-isolate" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-isolate" id="infopanel-for-term-for-valdef-unicode-bidi-isolate" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-isolate" style="display:none">Info about the 'isolate' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-isolate-override">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate-override">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate-override</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-isolate-override" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-isolate-override" id="infopanel-for-term-for-valdef-unicode-bidi-isolate-override" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-isolate-override" style="display:none">Info about the 'isolate-override' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate-override">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-isolate-override</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate-override">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-over" class="dfn-panel" data-for="term-for-line-over" id="infopanel-for-term-for-line-over" role="menu">
+   <span id="infopaneltitle-for-term-for-line-over" style="display:none">Info about the 'line-over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-over">https://drafts.csswg.org/css-writing-modes-4/#line-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">4.1. 
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-under" class="dfn-panel" data-for="term-for-line-under" id="infopanel-for-term-for-line-under" role="menu">
+   <span id="infopaneltitle-for-term-for-line-under" style="display:none">Info about the 'line-under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-under">https://drafts.csswg.org/css-writing-modes-4/#line-under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">4.1. 
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-normal">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-normal">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-normal" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-normal" id="infopanel-for-term-for-valdef-unicode-bidi-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-normal">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-normal">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">4.1. 
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl" id="infopanel-for-term-for-valdef-writing-mode-vertical-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">3.2. 
 Inter-character Ruby Layout</a>
@@ -3409,15 +3409,15 @@ Inter-character Ruby Layout</a>
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">4.1. 
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">3.2. 
 Inter-character Ruby Layout</a>
@@ -3425,8 +3425,8 @@ Inter-character Ruby Layout</a>
 Ruby Positioning: the ruby-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3.3. 
 Styling Ruby Boxes</a> <a href="#ref-for-propdef-line-height①">(2)</a>
@@ -3434,34 +3434,34 @@ Styling Ruby Boxes</a> <a href="#ref-for-propdef-line-height①">(2)</a>
 Line Spacing</a> <a href="#ref-for-propdef-line-height③">(2)</a> <a href="#ref-for-propdef-line-height④">(3)</a> <a href="#ref-for-propdef-line-height⑤">(4)</a> <a href="#ref-for-propdef-line-height⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">3.5. 
 Bidi Reordering</a> <a href="#ref-for-propdef-direction①">(2)</a> <a href="#ref-for-propdef-direction②">(3)</a> <a href="#ref-for-propdef-direction③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.5. 
 Bidi Reordering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-rp-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-rp-element" class="dfn-panel" data-for="term-for-the-rp-element" id="infopanel-for-term-for-the-rp-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-rp-element" style="display:none">Info about the 'rp' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-rp-element"> Changes since the 30 June 2011 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rtc">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#rtc">https://html.spec.whatwg.org/multipage/obsolete.html#rtc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rtc" class="dfn-panel" data-for="term-for-rtc" id="infopanel-for-term-for-rtc" role="menu">
+   <span id="infopaneltitle-for-term-for-rtc" style="display:none">Info about the 'rtc' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#rtc">https://html.spec.whatwg.org/multipage/obsolete.html#rtc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtc"> Changes since the 5 August 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ruby-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ruby-element" class="dfn-panel" data-for="term-for-the-ruby-element" id="infopanel-for-term-for-the-ruby-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ruby-element" style="display:none">Info about the 'ruby' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ruby-element"> Changes since the 30 June 2011 WD</a>
    </ul>
@@ -3767,22 +3767,22 @@ Bidi Reordering</a>
    <div class="issue"> I suspect overhanging interacts with alignment in some cases;
 	might need to look into this later. <a class="issue-return" href="#issue-adc9f0e4" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="ruby">
-   <b><a href="#ruby">#ruby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby" class="dfn-panel" data-for="ruby" id="infopanel-for-ruby" role="dialog">
+   <span id="infopaneltitle-for-ruby" style="display:none">Info about the 'Ruby' definition.</span><b><a href="#ruby">#ruby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby">1.1. 
 What is ruby?</a> <a href="#ref-for-ruby①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-ruby">
-   <b><a href="#valdef-display-ruby">#valdef-display-ruby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-ruby" class="dfn-panel" data-for="valdef-display-ruby" id="infopanel-for-valdef-display-ruby" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-ruby" style="display:none">Info about the 'ruby' definition.</span><b><a href="#valdef-display-ruby">#valdef-display-ruby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby">2.1.2. 
 Non-Inline Ruby</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-container">
-   <b><a href="#ruby-container">#ruby-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-container" class="dfn-panel" data-for="ruby-container" id="infopanel-for-ruby-container" role="dialog">
+   <span id="infopaneltitle-for-ruby-container" style="display:none">Info about the 'ruby container box' definition.</span><b><a href="#ruby-container">#ruby-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-container">2.1.1. 
 The Ruby Formatting Context</a> <a href="#ref-for-ruby-container①">(2)</a> <a href="#ref-for-ruby-container②">(3)</a> <a href="#ref-for-ruby-container③">(4)</a> <a href="#ref-for-ruby-container④">(5)</a> <a href="#ref-for-ruby-container⑤">(6)</a> <a href="#ref-for-ruby-container⑥">(7)</a> <a href="#ref-for-ruby-container⑦">(8)</a> <a href="#ref-for-ruby-container⑧">(9)</a> <a href="#ref-for-ruby-container⑨">(10)</a>
@@ -3822,8 +3822,8 @@ Ruby Positioning: the ruby-position property</a>
 Overhanging Ruby: the ruby-overhang property</a> <a href="#ref-for-ruby-container④①">(2)</a> <a href="#ref-for-ruby-container④②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-base-box">
-   <b><a href="#ruby-base-box">#ruby-base-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-base-box" class="dfn-panel" data-for="ruby-base-box" id="infopanel-for-ruby-base-box" role="dialog">
+   <span id="infopaneltitle-for-ruby-base-box" style="display:none">Info about the 'ruby base box' definition.</span><b><a href="#ruby-base-box">#ruby-base-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-box">2. 
 Ruby Box Model</a> <a href="#ref-for-ruby-base-box①">(2)</a> <a href="#ref-for-ruby-base-box②">(3)</a>
@@ -3870,8 +3870,8 @@ Line-edge Alignment</a>
     <li><a href="#ref-for-ruby-base-box⑧③"> A.3 Generating Parentheses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-annotation-box">
-   <b><a href="#ruby-annotation-box">#ruby-annotation-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-annotation-box" class="dfn-panel" data-for="ruby-annotation-box" id="infopanel-for-ruby-annotation-box" role="dialog">
+   <span id="infopaneltitle-for-ruby-annotation-box" style="display:none">Info about the 'ruby annotation box' definition.</span><b><a href="#ruby-annotation-box">#ruby-annotation-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-box">2. 
 Ruby Box Model</a> <a href="#ref-for-ruby-annotation-box①">(2)</a> <a href="#ref-for-ruby-annotation-box②">(3)</a>
@@ -3919,8 +3919,8 @@ Overhanging Ruby: the ruby-overhang property</a> <a href="#ref-for-ruby-annotati
 Line-edge Alignment</a> <a href="#ref-for-ruby-annotation-box⑨⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-base-container-box">
-   <b><a href="#ruby-base-container-box">#ruby-base-container-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-base-container-box" class="dfn-panel" data-for="ruby-base-container-box" id="infopanel-for-ruby-base-container-box" role="dialog">
+   <span id="infopaneltitle-for-ruby-base-container-box" style="display:none">Info about the 'ruby base container box' definition.</span><b><a href="#ruby-base-container-box">#ruby-base-container-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-container-box">2.1.1. 
 The Ruby Formatting Context</a>
@@ -3950,8 +3950,8 @@ Line Spacing</a> <a href="#ref-for-ruby-base-container-box③⑥">(2)</a>
 Overhanging Ruby: the ruby-overhang property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-annotation-container-box">
-   <b><a href="#ruby-annotation-container-box">#ruby-annotation-container-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-annotation-container-box" class="dfn-panel" data-for="ruby-annotation-container-box" id="infopanel-for-ruby-annotation-container-box" role="dialog">
+   <span id="infopaneltitle-for-ruby-annotation-container-box" style="display:none">Info about the 'ruby annotation container box' definition.</span><b><a href="#ruby-annotation-container-box">#ruby-annotation-container-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-container-box">2.1.1. 
 The Ruby Formatting Context</a>
@@ -3987,15 +3987,15 @@ Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-ruby-annot
 Overhanging Ruby: the ruby-overhang property</a> <a href="#ref-for-ruby-annotation-container-box⑤⑥">(2)</a> <a href="#ref-for-ruby-annotation-container-box⑤⑦">(3)</a> <a href="#ref-for-ruby-annotation-container-box⑤⑧">(4)</a> <a href="#ref-for-ruby-annotation-container-box⑤⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-formatting-context">
-   <b><a href="#ruby-formatting-context">#ruby-formatting-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-formatting-context" class="dfn-panel" data-for="ruby-formatting-context" id="infopanel-for-ruby-formatting-context" role="dialog">
+   <span id="infopaneltitle-for-ruby-formatting-context" style="display:none">Info about the 'ruby formatting context' definition.</span><b><a href="#ruby-formatting-context">#ruby-formatting-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-formatting-context">2.1.1. 
 The Ruby Formatting Context</a> <a href="#ref-for-ruby-formatting-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="internal-ruby-boxes">
-   <b><a href="#internal-ruby-boxes">#internal-ruby-boxes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-internal-ruby-boxes" class="dfn-panel" data-for="internal-ruby-boxes" id="infopanel-for-internal-ruby-boxes" role="dialog">
+   <span id="infopaneltitle-for-internal-ruby-boxes" style="display:none">Info about the 'internal ruby boxes' definition.</span><b><a href="#internal-ruby-boxes">#internal-ruby-boxes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-ruby-boxes">2.1.1. 
 The Ruby Formatting Context</a>
@@ -4005,8 +4005,8 @@ Non-Inline Ruby</a>
 Bidi Reordering</a> <a href="#ref-for-internal-ruby-boxes③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intra-ruby-white-space">
-   <b><a href="#intra-ruby-white-space">#intra-ruby-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intra-ruby-white-space" class="dfn-panel" data-for="intra-ruby-white-space" id="infopanel-for-intra-ruby-white-space" role="dialog">
+   <span id="infopaneltitle-for-intra-ruby-white-space" style="display:none">Info about the 'intra-ruby white space' definition.</span><b><a href="#intra-ruby-white-space">#intra-ruby-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intra-ruby-white-space">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-intra-ruby-white-space①">(2)</a> <a href="#ref-for-intra-ruby-white-space②">(3)</a> <a href="#ref-for-intra-ruby-white-space③">(4)</a>
@@ -4014,8 +4014,8 @@ Anonymous Ruby Box Generation</a> <a href="#ref-for-intra-ruby-white-space①">(
 Unit Pairing and Spanning Annotations</a> <a href="#ref-for-intra-ruby-white-space⑤">(2)</a> <a href="#ref-for-intra-ruby-white-space⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inter-base-white-space">
-   <b><a href="#inter-base-white-space">#inter-base-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inter-base-white-space" class="dfn-panel" data-for="inter-base-white-space" id="infopanel-for-inter-base-white-space" role="dialog">
+   <span id="infopaneltitle-for-inter-base-white-space" style="display:none">Info about the 'inter-base white space' definition.</span><b><a href="#inter-base-white-space">#inter-base-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inter-base-white-space">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inter-base-white-space①">(2)</a>
@@ -4025,8 +4025,8 @@ White Space Collapsing</a>
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inter-annotation-white-space">
-   <b><a href="#inter-annotation-white-space">#inter-annotation-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inter-annotation-white-space" class="dfn-panel" data-for="inter-annotation-white-space" id="infopanel-for-inter-annotation-white-space" role="dialog">
+   <span id="infopaneltitle-for-inter-annotation-white-space" style="display:none">Info about the 'inter-annotation white space' definition.</span><b><a href="#inter-annotation-white-space">#inter-annotation-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inter-annotation-white-space">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inter-annotation-white-space①">(2)</a>
@@ -4034,8 +4034,8 @@ Anonymous Ruby Box Generation</a> <a href="#ref-for-inter-annotation-white-space
 White Space Collapsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inter-segment-white-space">
-   <b><a href="#inter-segment-white-space">#inter-segment-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inter-segment-white-space" class="dfn-panel" data-for="inter-segment-white-space" id="infopanel-for-inter-segment-white-space" role="dialog">
+   <span id="infopaneltitle-for-inter-segment-white-space" style="display:none">Info about the 'inter-segment white space' definition.</span><b><a href="#inter-segment-white-space">#inter-segment-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inter-segment-white-space">2.2. 
 Anonymous Ruby Box Generation</a> <a href="#ref-for-inter-segment-white-space①">(2)</a>
@@ -4047,8 +4047,8 @@ White Space Collapsing</a> <a href="#ref-for-inter-segment-white-space④">(2)</
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intra-level-white-space">
-   <b><a href="#intra-level-white-space">#intra-level-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intra-level-white-space" class="dfn-panel" data-for="intra-level-white-space" id="infopanel-for-intra-level-white-space" role="dialog">
+   <span id="infopaneltitle-for-intra-level-white-space" style="display:none">Info about the 'intra-level white space' definition.</span><b><a href="#intra-level-white-space">#intra-level-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intra-level-white-space">2.2. 
 Anonymous Ruby Box Generation</a>
@@ -4056,8 +4056,8 @@ Anonymous Ruby Box Generation</a>
 Unit Pairing and Spanning Annotations</a> <a href="#ref-for-intra-level-white-space②">(2)</a> <a href="#ref-for-intra-level-white-space③">(3)</a> <a href="#ref-for-intra-level-white-space④">(4)</a> <a href="#ref-for-intra-level-white-space⑤">(5)</a> <a href="#ref-for-intra-level-white-space⑥">(6)</a> <a href="#ref-for-intra-level-white-space⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pairing">
-   <b><a href="#pairing">#pairing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pairing" class="dfn-panel" data-for="pairing" id="infopanel-for-pairing" role="dialog">
+   <span id="infopaneltitle-for-pairing" style="display:none">Info about the 'pairing' definition.</span><b><a href="#pairing">#pairing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pairing">1.1. 
 What is ruby?</a>
@@ -4074,8 +4074,8 @@ Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
     <li><a href="#ref-for-pairing①⓪"> Changes since the 30 June 2011 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="span">
-   <b><a href="#span">#span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-span" class="dfn-panel" data-for="span" id="infopanel-for-span" role="dialog">
+   <span id="infopaneltitle-for-span" style="display:none">Info about the 'span' definition.</span><b><a href="#span">#span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-span">2.3. 
 Annotation Pairing</a>
@@ -4087,8 +4087,8 @@ Inline-axis Interlinear Layout</a>
 Inter-character Ruby Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spanning-annotation">
-   <b><a href="#spanning-annotation">#spanning-annotation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spanning-annotation" class="dfn-panel" data-for="spanning-annotation" id="infopanel-for-spanning-annotation" role="dialog">
+   <span id="infopaneltitle-for-spanning-annotation" style="display:none">Info about the 'spanning annotation' definition.</span><b><a href="#spanning-annotation">#spanning-annotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spanning-annotation">2.3.2. 
 Unit Pairing and Spanning Annotations</a>
@@ -4096,8 +4096,8 @@ Unit Pairing and Spanning Annotations</a>
 Inline-axis Interlinear Layout</a> <a href="#ref-for-spanning-annotation②">(2)</a> <a href="#ref-for-spanning-annotation③">(3)</a> <a href="#ref-for-spanning-annotation④">(4)</a> <a href="#ref-for-spanning-annotation⑤">(5)</a> <a href="#ref-for-spanning-annotation⑥">(6)</a> <a href="#ref-for-spanning-annotation⑦">(7)</a> <a href="#ref-for-spanning-annotation⑧">(8)</a> <a href="#ref-for-spanning-annotation⑨">(9)</a> <a href="#ref-for-spanning-annotation①⓪">(10)</a> <a href="#ref-for-spanning-annotation①①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-columns">
-   <b><a href="#ruby-columns">#ruby-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-columns" class="dfn-panel" data-for="ruby-columns" id="infopanel-for-ruby-columns" role="dialog">
+   <span id="infopaneltitle-for-ruby-columns" style="display:none">Info about the 'ruby columns' definition.</span><b><a href="#ruby-columns">#ruby-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-columns">2. 
 Ruby Box Model</a>
@@ -4113,8 +4113,8 @@ Sharing Annotation Space: the ruby-merge property</a>
 Ruby Text Decoration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-segments">
-   <b><a href="#ruby-segments">#ruby-segments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-segments" class="dfn-panel" data-for="ruby-segments" id="infopanel-for-ruby-segments" role="dialog">
+   <span id="infopaneltitle-for-ruby-segments" style="display:none">Info about the 'ruby segments' definition.</span><b><a href="#ruby-segments">#ruby-segments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-segments">2. 
 Ruby Box Model</a> <a href="#ref-for-ruby-segments①">(2)</a> <a href="#ref-for-ruby-segments②">(3)</a> <a href="#ref-for-ruby-segments③">(4)</a>
@@ -4138,8 +4138,8 @@ Sharing Annotation Space: the ruby-merge property</a>
 Ruby Text Distribution: the ruby-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="annotation-level">
-   <b><a href="#annotation-level">#annotation-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-annotation-level" class="dfn-panel" data-for="annotation-level" id="infopanel-for-annotation-level" role="dialog">
+   <span id="infopaneltitle-for-annotation-level" style="display:none">Info about the 'level' definition.</span><b><a href="#annotation-level">#annotation-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-annotation-level">2. 
 Ruby Box Model</a>
@@ -4157,8 +4157,8 @@ Inter-character Ruby Layout</a>
 Ruby Positioning: the ruby-position property</a> <a href="#ref-for-annotation-level⑨">(2)</a> <a href="#ref-for-annotation-level①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-level">
-   <b><a href="#base-level">#base-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-level" class="dfn-panel" data-for="base-level" id="infopanel-for-base-level" role="dialog">
+   <span id="infopaneltitle-for-base-level" style="display:none">Info about the 'base level' definition.</span><b><a href="#base-level">#base-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-level">2. 
 Ruby Box Model</a>
@@ -4172,8 +4172,8 @@ Breaking Between Bases</a>
 Ruby Text Decoration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hidden-annotation">
-   <b><a href="#hidden-annotation">#hidden-annotation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hidden-annotation" class="dfn-panel" data-for="hidden-annotation" id="infopanel-for-hidden-annotation" role="dialog">
+   <span id="infopaneltitle-for-hidden-annotation" style="display:none">Info about the 'hidden annotation' definition.</span><b><a href="#hidden-annotation">#hidden-annotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hidden-annotation">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a> <a href="#ref-for-hidden-annotation①">(2)</a> <a href="#ref-for-hidden-annotation②">(3)</a> <a href="#ref-for-hidden-annotation③">(4)</a> <a href="#ref-for-hidden-annotation④">(5)</a> <a href="#ref-for-hidden-annotation⑤">(6)</a> <a href="#ref-for-hidden-annotation⑥">(7)</a> <a href="#ref-for-hidden-annotation⑦">(8)</a>
@@ -4182,16 +4182,16 @@ White Space Collapsing</a>
     <li><a href="#ref-for-hidden-annotation⑨"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="auto-hidden">
-   <b><a href="#auto-hidden">#auto-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-auto-hidden" class="dfn-panel" data-for="auto-hidden" id="infopanel-for-auto-hidden" role="dialog">
+   <span id="infopaneltitle-for-auto-hidden" style="display:none">Info about the 'auto-hidden' definition.</span><b><a href="#auto-hidden">#auto-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auto-hidden">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a> <a href="#ref-for-auto-hidden①">(2)</a>
     <li><a href="#ref-for-auto-hidden②"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-ruby-position">
-   <b><a href="#propdef-ruby-position">#propdef-ruby-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-ruby-position" class="dfn-panel" data-for="propdef-ruby-position" id="infopanel-for-propdef-ruby-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-ruby-position" style="display:none">Info about the 'ruby-position' definition.</span><b><a href="#propdef-ruby-position">#propdef-ruby-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-position">1.2. 
 Module interactions</a>
@@ -4206,30 +4206,30 @@ Sharing Annotation Space: the ruby-merge property</a>
     <li><a href="#ref-for-propdef-ruby-position⑧"> Changes since the 30 June 2011 WD</a> <a href="#ref-for-propdef-ruby-position⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-position-alternate">
-   <b><a href="#valdef-ruby-position-alternate">#valdef-ruby-position-alternate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-position-alternate" class="dfn-panel" data-for="valdef-ruby-position-alternate" id="infopanel-for-valdef-ruby-position-alternate" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-position-alternate" style="display:none">Info about the 'alternate' definition.</span><b><a href="#valdef-ruby-position-alternate">#valdef-ruby-position-alternate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-position-alternate">4.1. 
 Ruby Positioning: the ruby-position property</a> <a href="#ref-for-valdef-ruby-position-alternate①">(2)</a> <a href="#ref-for-valdef-ruby-position-alternate②">(3)</a> <a href="#ref-for-valdef-ruby-position-alternate③">(4)</a>
     <li><a href="#ref-for-valdef-ruby-position-alternate④"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-position-over">
-   <b><a href="#valdef-ruby-position-over">#valdef-ruby-position-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-position-over" class="dfn-panel" data-for="valdef-ruby-position-over" id="infopanel-for-valdef-ruby-position-over" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-position-over" style="display:none">Info about the 'over' definition.</span><b><a href="#valdef-ruby-position-over">#valdef-ruby-position-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-position-over">4.1. 
 Ruby Positioning: the ruby-position property</a> <a href="#ref-for-valdef-ruby-position-over①">(2)</a> <a href="#ref-for-valdef-ruby-position-over②">(3)</a> <a href="#ref-for-valdef-ruby-position-over③">(4)</a> <a href="#ref-for-valdef-ruby-position-over④">(5)</a> <a href="#ref-for-valdef-ruby-position-over⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-position-under">
-   <b><a href="#valdef-ruby-position-under">#valdef-ruby-position-under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-position-under" class="dfn-panel" data-for="valdef-ruby-position-under" id="infopanel-for-valdef-ruby-position-under" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-position-under" style="display:none">Info about the 'under' definition.</span><b><a href="#valdef-ruby-position-under">#valdef-ruby-position-under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-position-under">4.1. 
 Ruby Positioning: the ruby-position property</a> <a href="#ref-for-valdef-ruby-position-under①">(2)</a> <a href="#ref-for-valdef-ruby-position-under②">(3)</a> <a href="#ref-for-valdef-ruby-position-under③">(4)</a> <a href="#ref-for-valdef-ruby-position-under④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-position-inter-character">
-   <b><a href="#valdef-ruby-position-inter-character">#valdef-ruby-position-inter-character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-position-inter-character" class="dfn-panel" data-for="valdef-ruby-position-inter-character" id="infopanel-for-valdef-ruby-position-inter-character" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-position-inter-character" style="display:none">Info about the 'inter-character' definition.</span><b><a href="#valdef-ruby-position-inter-character">#valdef-ruby-position-inter-character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-position-inter-character">3.2. 
 Inter-character Ruby Layout</a>
@@ -4238,8 +4238,8 @@ Breaking Across Lines</a>
     <li><a href="#ref-for-valdef-ruby-position-inter-character②"> Changes since the 30 June 2011 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ruby-position-inter-character-annotation">
-   <b><a href="#ruby-position-inter-character-annotation">#ruby-position-inter-character-annotation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ruby-position-inter-character-annotation" class="dfn-panel" data-for="ruby-position-inter-character-annotation" id="infopanel-for-ruby-position-inter-character-annotation" role="dialog">
+   <span id="infopaneltitle-for-ruby-position-inter-character-annotation" style="display:none">Info about the 'inter-character annotation' definition.</span><b><a href="#ruby-position-inter-character-annotation">#ruby-position-inter-character-annotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-position-inter-character-annotation">2.5. 
 White Space Collapsing</a>
@@ -4264,8 +4264,8 @@ Ruby Text Distribution: the ruby-align property</a>
     <li><a href="#ref-for-ruby-position-inter-character-annotation①⑨"> Changes since the 29 April 2020 WD</a> <a href="#ref-for-ruby-position-inter-character-annotation②⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interlinear-annotations">
-   <b><a href="#interlinear-annotations">#interlinear-annotations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interlinear-annotations" class="dfn-panel" data-for="interlinear-annotations" id="infopanel-for-interlinear-annotations" role="dialog">
+   <span id="infopaneltitle-for-interlinear-annotations" style="display:none">Info about the 'interlinear annotations' definition.</span><b><a href="#interlinear-annotations">#interlinear-annotations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interlinear-annotations">2.3. 
 Annotation Pairing</a>
@@ -4286,8 +4286,8 @@ Sharing Annotation Space: the ruby-merge property</a>
     <li><a href="#ref-for-interlinear-annotations⑨"> Changes since the 29 April 2020 WD</a> <a href="#ref-for-interlinear-annotations①⓪">(2)</a> <a href="#ref-for-interlinear-annotations①①">(3)</a> <a href="#ref-for-interlinear-annotations①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-ruby-merge">
-   <b><a href="#propdef-ruby-merge">#propdef-ruby-merge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-ruby-merge" class="dfn-panel" data-for="propdef-ruby-merge" id="infopanel-for-propdef-ruby-merge" role="dialog">
+   <span id="infopaneltitle-for-propdef-ruby-merge" style="display:none">Info about the 'ruby-merge' definition.</span><b><a href="#propdef-ruby-merge">#propdef-ruby-merge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-merge">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
@@ -4306,8 +4306,8 @@ Overhanging Ruby: the ruby-overhang property</a>
     <li><a href="#ref-for-propdef-ruby-merge①⑥"> Changes since the 30 June 2011 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="merged-annotation">
-   <b><a href="#merged-annotation">#merged-annotation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-merged-annotation" class="dfn-panel" data-for="merged-annotation" id="infopanel-for-merged-annotation" role="dialog">
+   <span id="infopaneltitle-for-merged-annotation" style="display:none">Info about the 'merged' definition.</span><b><a href="#merged-annotation">#merged-annotation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-merged-annotation">1.1. 
 What is ruby?</a>
@@ -4320,8 +4320,8 @@ Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-merged-ann
     <li><a href="#ref-for-merged-annotation⑦"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-merge-separate">
-   <b><a href="#valdef-ruby-merge-separate">#valdef-ruby-merge-separate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-merge-separate" class="dfn-panel" data-for="valdef-ruby-merge-separate" id="infopanel-for-valdef-ruby-merge-separate" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-merge-separate" style="display:none">Info about the 'separate' definition.</span><b><a href="#valdef-ruby-merge-separate">#valdef-ruby-merge-separate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-merge-separate">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
@@ -4331,8 +4331,8 @@ Inline-axis Interlinear Layout</a>
 Sharing Annotation Space: the ruby-merge property</a> <a href="#ref-for-valdef-ruby-merge-separate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-merge-merge">
-   <b><a href="#valdef-ruby-merge-merge">#valdef-ruby-merge-merge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-merge-merge" class="dfn-panel" data-for="valdef-ruby-merge-merge" id="infopanel-for-valdef-ruby-merge-merge" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-merge-merge" style="display:none">Info about the 'merge' definition.</span><b><a href="#valdef-ruby-merge-merge">#valdef-ruby-merge-merge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-merge-merge">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
@@ -4343,8 +4343,8 @@ Sharing Annotation Space: the ruby-merge property</a>
     <li><a href="#ref-for-valdef-ruby-merge-merge③"> Changes since the 29 April 2020 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-merge-auto">
-   <b><a href="#valdef-ruby-merge-auto">#valdef-ruby-merge-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-merge-auto" class="dfn-panel" data-for="valdef-ruby-merge-auto" id="infopanel-for-valdef-ruby-merge-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-merge-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-ruby-merge-auto">#valdef-ruby-merge-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-merge-auto">2.4. 
 Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
@@ -4352,8 +4352,8 @@ Hiding Annotations: visibility: collapse and auto-hidden ruby</a>
 Ruby Text Distribution: the ruby-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-ruby-align">
-   <b><a href="#propdef-ruby-align">#propdef-ruby-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-ruby-align" class="dfn-panel" data-for="propdef-ruby-align" id="infopanel-for-propdef-ruby-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-ruby-align" style="display:none">Info about the 'ruby-align' definition.</span><b><a href="#propdef-ruby-align">#propdef-ruby-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-align">3.1.1. 
 Inline-axis Interlinear Layout</a> <a href="#ref-for-propdef-ruby-align①">(2)</a> <a href="#ref-for-propdef-ruby-align②">(3)</a> <a href="#ref-for-propdef-ruby-align③">(4)</a> <a href="#ref-for-propdef-ruby-align④">(5)</a> <a href="#ref-for-propdef-ruby-align⑤">(6)</a>
@@ -4367,8 +4367,8 @@ Overhanging Ruby: the ruby-overhang property</a>
     <li><a href="#ref-for-propdef-ruby-align①⑥"> Changes since the 30 June 2011 WD</a> <a href="#ref-for-propdef-ruby-align①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-align-start">
-   <b><a href="#valdef-ruby-align-start">#valdef-ruby-align-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-align-start" class="dfn-panel" data-for="valdef-ruby-align-start" id="infopanel-for-valdef-ruby-align-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-align-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-ruby-align-start">#valdef-ruby-align-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-align-start">3.2. 
 Inter-character Ruby Layout</a>
@@ -4376,39 +4376,39 @@ Inter-character Ruby Layout</a>
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-valdef-ruby-align-start②">(2)</a> <a href="#ref-for-valdef-ruby-align-start③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-align-center">
-   <b><a href="#valdef-ruby-align-center">#valdef-ruby-align-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-align-center" class="dfn-panel" data-for="valdef-ruby-align-center" id="infopanel-for-valdef-ruby-align-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-align-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-ruby-align-center">#valdef-ruby-align-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-align-center">4.3. 
 Ruby Text Distribution: the ruby-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-align-space-between">
-   <b><a href="#valdef-ruby-align-space-between">#valdef-ruby-align-space-between</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-align-space-between" class="dfn-panel" data-for="valdef-ruby-align-space-between" id="infopanel-for-valdef-ruby-align-space-between" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-align-space-between" style="display:none">Info about the 'space-between' definition.</span><b><a href="#valdef-ruby-align-space-between">#valdef-ruby-align-space-between</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-align-space-between">4.3. 
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-valdef-ruby-align-space-between①">(2)</a> <a href="#ref-for-valdef-ruby-align-space-between②">(3)</a> <a href="#ref-for-valdef-ruby-align-space-between③">(4)</a>
     <li><a href="#ref-for-valdef-ruby-align-space-between④"> Changes since the 30 June 2011 WD</a> <a href="#ref-for-valdef-ruby-align-space-between⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-ruby-align-space-around">
-   <b><a href="#valdef-ruby-align-space-around">#valdef-ruby-align-space-around</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-ruby-align-space-around" class="dfn-panel" data-for="valdef-ruby-align-space-around" id="infopanel-for-valdef-ruby-align-space-around" role="dialog">
+   <span id="infopaneltitle-for-valdef-ruby-align-space-around" style="display:none">Info about the 'space-around' definition.</span><b><a href="#valdef-ruby-align-space-around">#valdef-ruby-align-space-around</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-ruby-align-space-around">4.3. 
 Ruby Text Distribution: the ruby-align property</a> <a href="#ref-for-valdef-ruby-align-space-around①">(2)</a> <a href="#ref-for-valdef-ruby-align-space-around②">(3)</a>
     <li><a href="#ref-for-valdef-ruby-align-space-around③"> Changes since the 30 June 2011 WD</a> <a href="#ref-for-valdef-ruby-align-space-around④">(2)</a> <a href="#ref-for-valdef-ruby-align-space-around⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-ruby-overhang">
-   <b><a href="#propdef-ruby-overhang">#propdef-ruby-overhang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-ruby-overhang" class="dfn-panel" data-for="propdef-ruby-overhang" id="infopanel-for-propdef-ruby-overhang" role="dialog">
+   <span id="infopaneltitle-for-propdef-ruby-overhang" style="display:none">Info about the 'ruby-overhang' definition.</span><b><a href="#propdef-ruby-overhang">#propdef-ruby-overhang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-overhang">5.1. 
 Overhanging Ruby: the ruby-overhang property</a> <a href="#ref-for-propdef-ruby-overhang①">(2)</a>
     <li><a href="#ref-for-propdef-ruby-overhang②"> Changes since the 5 August 2014 WD</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bopomofo-tone-marks">
-   <b><a href="#bopomofo-tone-marks">#bopomofo-tone-marks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bopomofo-tone-marks" class="dfn-panel" data-for="bopomofo-tone-marks" id="infopanel-for-bopomofo-tone-marks" role="dialog">
+   <span id="infopaneltitle-for-bopomofo-tone-marks" style="display:none">Info about the 'Bopomofo tone marks' definition.</span><b><a href="#bopomofo-tone-marks">#bopomofo-tone-marks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bopomofo-tone-marks">6. 
 Glossary</a>
@@ -4416,59 +4416,115 @@ Glossary</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-scoping-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scoping-1/Overview.html
@@ -1695,57 +1695,57 @@ which protect them from the things defined in this specification).</p>
    <li><a href="#css-tree-scoped-name">tree-scoped name</a><span>, in § 3.5</span>
    <li><a href="#css-tree-scoped-reference">tree-scoped reference</a><span>, in § 3.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-keyframes">
-   <a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-keyframes" class="dfn-panel" data-for="term-for-at-ruledef-keyframes" id="infopanel-for-term-for-at-ruledef-keyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-at-ruledef-keyframes①">(2)</a> <a href="#ref-for-at-ruledef-keyframes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-propdef-animation-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'ua origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">3.4.1. 
 Slots and Slotted Elements in a Shadow Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-profile">
-   <a href="https://drafts.csswg.org/css-color-5/#at-ruledef-profile">https://drafts.csswg.org/css-color-5/#at-ruledef-profile</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-profile" class="dfn-panel" data-for="term-for-at-ruledef-profile" id="infopanel-for-term-for-at-ruledef-profile" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-profile" style="display:none">Info about the '@color-profile' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#at-ruledef-profile">https://drafts.csswg.org/css-color-5/#at-ruledef-profile</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-profile">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-color">
-   <a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-color" class="dfn-panel" data-for="term-for-funcdef-color" id="infopanel-for-term-for-funcdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-color" style="display:none">Info about the 'color()' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#funcdef-color">https://drafts.csswg.org/css-color-5/#funcdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-color">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-counter-style" class="dfn-panel" data-for="term-for-at-ruledef-counter-style" id="infopanel-for-term-for-at-ruledef-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-counter-style" style="display:none">Info about the '@counter-style' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style">https://drafts.csswg.org/css-counter-styles-3/#at-ruledef-counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-counter-style">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.2.2. 
 Selecting Shadow Hosts from within a Shadow Tree</a>
@@ -1753,22 +1753,22 @@ Selecting Shadow Hosts from within a Shadow Tree</a>
 Slots and Slotted Elements in a Shadow Tree</a> <a href="#ref-for-propdef-display②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-font-feature-values">
-   <a href="https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-feature-values">https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-feature-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-font-feature-values" class="dfn-panel" data-for="term-for-at-ruledef-font-feature-values" id="infopanel-for-term-for-at-ruledef-font-feature-values" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-font-feature-values" style="display:none">Info about the '@font-feature-values' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-feature-values">https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-feature-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-feature-values">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-font-palette-values">
-   <a href="https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-palette-values">https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-palette-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-font-palette-values" class="dfn-panel" data-for="term-for-at-ruledef-font-palette-values" id="infopanel-for-term-for-at-ruledef-font-palette-values" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-font-palette-values" style="display:none">Info about the '@font-palette-values' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-palette-values">https://drafts.csswg.org/css-fonts-4/#at-ruledef-font-palette-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-font-palette-values">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-propdef-font-family①">(2)</a> <a href="#ref-for-propdef-font-family②">(3)</a>
@@ -1776,22 +1776,22 @@ Name-Defining Constructs and Inheritance</a> <a href="#ref-for-propdef-font-fami
 Serialized Tree-Scoped References</a> <a href="#ref-for-propdef-font-family④">(2)</a> <a href="#ref-for-propdef-font-family⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-font-face-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family">https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-font-face-font-family" class="dfn-panel" data-for="term-for-descdef-font-face-font-family" id="infopanel-for-term-for-descdef-font-face-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-font-face-font-family" style="display:none">Info about the 'font-family (for @font-face)' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family">https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-family">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-palette">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-palette">https://drafts.csswg.org/css-fonts-4/#propdef-font-palette</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-palette" class="dfn-panel" data-for="term-for-propdef-font-palette" id="infopanel-for-term-for-propdef-font-palette" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-palette" style="display:none">Info about the 'font-palette' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-palette">https://drafts.csswg.org/css-fonts-4/#propdef-font-palette</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-palette">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-font-face-rule">
-   <a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-font-face-rule" class="dfn-panel" data-for="term-for-at-font-face-rule" id="infopanel-for-term-for-at-font-face-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-font-face-rule" style="display:none">Info about the '@font-face' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-font-face-rule">2. 
 Default Styles for Custom Elements</a>
@@ -1801,22 +1801,22 @@ Name-Defining Constructs and Inheritance</a> <a href="#ref-for-at-font-face-rule
 Serialized Tree-Scoped References</a> <a href="#ref-for-at-font-face-rule④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">3.5. 
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-abiding">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-abiding" class="dfn-panel" data-for="term-for-tree-abiding" id="infopanel-for-term-for-tree-abiding" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-abiding" style="display:none">Info about the 'tree-abiding pseudo-element' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-abiding">3.2.4. 
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-rule" class="dfn-panel" data-for="term-for-at-rule" id="infopanel-for-term-for-at-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-rule" style="display:none">Info about the 'at-rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#at-rule">https://drafts.csswg.org/css-syntax-3/#at-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">2. 
 Default Styles for Custom Elements</a>
@@ -1824,15 +1824,15 @@ Default Styles for Custom Elements</a>
 Name-Defining Constructs and Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-reify">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#css-reify">https://drafts.css-houdini.org/css-typed-om-1/#css-reify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-reify" class="dfn-panel" data-for="term-for-css-reify" id="infopanel-for-term-for-css-reify" role="menu">
+   <span id="infopaneltitle-for-term-for-css-reify" style="display:none">Info about the 'reification' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#css-reify">https://drafts.css-houdini.org/css-typed-om-1/#css-reify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-reify">3.5.1. 
 Serialized Tree-Scoped References</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child" style="display:none">Info about the 'child' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
@@ -1842,8 +1842,8 @@ Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
 Flattening the DOM into an Element Tree</a> <a href="#ref-for-concept-tree-child③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child①" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child①" style="display:none">Info about the 'children' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
@@ -1853,8 +1853,8 @@ Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
 Flattening the DOM into an Element Tree</a> <a href="#ref-for-concept-tree-child③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">3.1. 
 Informative Explanation of Shadow DOM</a>
@@ -1862,36 +1862,36 @@ Informative Explanation of Shadow DOM</a>
 Matching Selectors Against Shadow Trees</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-element">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-element">https://dom.spec.whatwg.org/#concept-attribute-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-element" class="dfn-panel" data-for="term-for-concept-attribute-element" id="infopanel-for-term-for-concept-attribute-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-element">https://dom.spec.whatwg.org/#concept-attribute-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-element">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-concept-attribute-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-find-flattened-slotables">
-   <a href="https://dom.spec.whatwg.org/#find-flattened-slotables">https://dom.spec.whatwg.org/#find-flattened-slotables</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-find-flattened-slotables" class="dfn-panel" data-for="term-for-find-flattened-slotables" id="infopanel-for-term-for-find-flattened-slotables" role="menu">
+   <span id="infopaneltitle-for-term-for-find-flattened-slotables" style="display:none">Info about the 'find flattened slottables' external reference.</span><a href="https://dom.spec.whatwg.org/#find-flattened-slotables">https://dom.spec.whatwg.org/#find-flattened-slotables</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-flattened-slotables">3.2.4. 
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a> <a href="#ref-for-find-flattened-slotables①">(2)</a> <a href="#ref-for-find-flattened-slotables②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-find-slotables">
-   <a href="https://dom.spec.whatwg.org/#find-slotables">https://dom.spec.whatwg.org/#find-slotables</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-find-slotables" class="dfn-panel" data-for="term-for-find-slotables" id="infopanel-for-term-for-find-slotables" role="menu">
+   <span id="infopaneltitle-for-term-for-find-slotables" style="display:none">Info about the 'find slottables' external reference.</span><a href="https://dom.spec.whatwg.org/#find-slotables">https://dom.spec.whatwg.org/#find-slotables</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-slotables">3.4. 
 Flattening the DOM into an Element Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-documentfragment-host">
-   <a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-documentfragment-host" class="dfn-panel" data-for="term-for-concept-documentfragment-host" id="infopanel-for-term-for-concept-documentfragment-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-documentfragment-host" style="display:none">Info about the 'host' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">3.1. 
 Informative Explanation of Shadow DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-light-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-light-tree" class="dfn-panel" data-for="term-for-concept-light-tree" id="infopanel-for-term-for-concept-light-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-light-tree" style="display:none">Info about the 'light tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-light-tree">https://dom.spec.whatwg.org/#concept-light-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-light-tree">3.1. 
 Informative Explanation of Shadow DOM</a> <a href="#ref-for-concept-light-tree①">(2)</a>
@@ -1903,15 +1903,15 @@ Flattening the DOM into an Element Tree</a> <a href="#ref-for-concept-light-tree
 Slots and Slotted Elements in a Shadow Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-local-name">
-   <a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-local-name" class="dfn-panel" data-for="term-for-concept-element-local-name" id="infopanel-for-term-for-concept-element-local-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-local-name" style="display:none">Info about the 'local name' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-local-name">2. 
 Default Styles for Custom Elements</a> <a href="#ref-for-concept-element-local-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-node-tree">https://dom.spec.whatwg.org/#concept-node-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-tree" class="dfn-panel" data-for="term-for-concept-node-tree" id="infopanel-for-term-for-concept-node-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-tree" style="display:none">Info about the 'node tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-tree">https://dom.spec.whatwg.org/#concept-node-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-tree">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-concept-node-tree①">(2)</a>
@@ -1919,15 +1919,15 @@ Name-Defining Constructs and Inheritance</a> <a href="#ref-for-concept-node-tree
 Serialized Tree-Scoped References</a> <a href="#ref-for-concept-node-tree③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-parentnode-queryselector">
-   <a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselector">https://dom.spec.whatwg.org/#dom-parentnode-queryselector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-parentnode-queryselector" class="dfn-panel" data-for="term-for-dom-parentnode-queryselector" id="infopanel-for-term-for-dom-parentnode-queryselector" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-parentnode-queryselector" style="display:none">Info about the 'querySelector(selectors)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselector">https://dom.spec.whatwg.org/#dom-parentnode-queryselector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-queryselector">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
@@ -1939,8 +1939,8 @@ Name-Defining Constructs and Inheritance</a> <a href="#ref-for-concept-tree-root
 Serialized Tree-Scoped References</a> <a href="#ref-for-concept-tree-root⑧">(2)</a> <a href="#ref-for-concept-tree-root⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-shadow-host">
-   <a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-shadow-host" class="dfn-panel" data-for="term-for-element-shadow-host" id="infopanel-for-term-for-element-shadow-host" role="menu">
+   <span id="infopaneltitle-for-term-for-element-shadow-host" style="display:none">Info about the 'shadow host' external reference.</span><a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-shadow-host">3.1. 
 Informative Explanation of Shadow DOM</a> <a href="#ref-for-element-shadow-host①">(2)</a> <a href="#ref-for-element-shadow-host②">(3)</a>
@@ -1956,8 +1956,8 @@ Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
 Flattening the DOM into an Element Tree</a> <a href="#ref-for-element-shadow-host②⓪">(2)</a> <a href="#ref-for-element-shadow-host②①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-root" class="dfn-panel" data-for="term-for-concept-shadow-root" id="infopanel-for-term-for-concept-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">3.1. 
 Informative Explanation of Shadow DOM</a> <a href="#ref-for-concept-shadow-root①">(2)</a>
@@ -1969,8 +1969,8 @@ Selecting Shadow Hosts from within a Shadow Tree</a>
 Flattening the DOM into an Element Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">2. 
 Default Styles for Custom Elements</a> <a href="#ref-for-concept-shadow-tree①">(2)</a> <a href="#ref-for-concept-shadow-tree②">(3)</a>
@@ -1992,15 +1992,15 @@ Name-Defining Constructs and Inheritance</a> <a href="#ref-for-concept-shadow-tr
 Serialized Tree-Scoped References</a> <a href="#ref-for-concept-shadow-tree③⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-ancestor" class="dfn-panel" data-for="term-for-concept-shadow-including-ancestor" id="infopanel-for-term-for-concept-shadow-including-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-ancestor" style="display:none">Info about the 'shadow-including ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-ancestor">3.2.3. 
 Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-slot">
-   <a href="https://dom.spec.whatwg.org/#concept-slot">https://dom.spec.whatwg.org/#concept-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-slot" class="dfn-panel" data-for="term-for-concept-slot" id="infopanel-for-term-for-concept-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-slot" style="display:none">Info about the 'slot' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-slot">https://dom.spec.whatwg.org/#concept-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-slot">3.1. 
 Informative Explanation of Shadow DOM</a> <a href="#ref-for-concept-slot①">(2)</a> <a href="#ref-for-concept-slot②">(3)</a> <a href="#ref-for-concept-slot③">(4)</a> <a href="#ref-for-concept-slot④">(5)</a> <a href="#ref-for-concept-slot⑤">(6)</a> <a href="#ref-for-concept-slot⑥">(7)</a>
@@ -2012,29 +2012,29 @@ Flattening the DOM into an Element Tree</a> <a href="#ref-for-concept-slot①⑥
 Slots and Slotted Elements in a Shadow Tree</a> <a href="#ref-for-concept-slot②⓪">(2)</a> <a href="#ref-for-concept-slot②①">(3)</a> <a href="#ref-for-concept-slot②②">(4)</a> <a href="#ref-for-concept-slot②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-slotable">
-   <a href="https://dom.spec.whatwg.org/#concept-slotable">https://dom.spec.whatwg.org/#concept-slotable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-slotable" class="dfn-panel" data-for="term-for-concept-slotable" id="infopanel-for-term-for-concept-slotable" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-slotable" style="display:none">Info about the 'slottable' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-slotable">https://dom.spec.whatwg.org/#concept-slotable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-slotable">3.4. 
 Flattening the DOM into an Element Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-slot-element">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-slot-element" class="dfn-panel" data-for="term-for-the-slot-element" id="infopanel-for-term-for-the-slot-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-slot-element" style="display:none">Info about the 'slot' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-slot-element">3.1. 
 Informative Explanation of Shadow DOM</a>
@@ -2042,36 +2042,36 @@ Informative Explanation of Shadow DOM</a>
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a> <a href="#ref-for-the-slot-element②">(2)</a> <a href="#ref-for-the-slot-element③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x">
-   <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x" class="dfn-panel" data-for="term-for-x" id="infopanel-for-term-for-x" role="menu">
+   <span id="infopaneltitle-for-term-for-x" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x">3.2.4. 
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-matches-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-matches-pseudo" class="dfn-panel" data-for="term-for-matches-pseudo" id="infopanel-for-term-for-matches-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-matches-pseudo" style="display:none">Info about the ':is()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#matches-pseudo">https://drafts.csswg.org/selectors-4/#matches-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-pseudo">3.2.3. 
 Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-negation-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#negation-pseudo">https://drafts.csswg.org/selectors-4/#negation-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-negation-pseudo" class="dfn-panel" data-for="term-for-negation-pseudo" id="infopanel-for-term-for-negation-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-negation-pseudo" style="display:none">Info about the ':not()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#negation-pseudo">https://drafts.csswg.org/selectors-4/#negation-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-negation-pseudo">3.2.3. 
 Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-compound-selector-list">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector-list">https://drafts.csswg.org/selectors-4/#typedef-compound-selector-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-compound-selector-list" class="dfn-panel" data-for="term-for-typedef-compound-selector-list" id="infopanel-for-term-for-typedef-compound-selector-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-compound-selector-list" style="display:none">Info about the '&lt;compound-selector-list>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector-list">https://drafts.csswg.org/selectors-4/#typedef-compound-selector-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-compound-selector-list">4. 
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-compound-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector">https://drafts.csswg.org/selectors-4/#typedef-compound-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-compound-selector" class="dfn-panel" data-for="term-for-typedef-compound-selector" id="infopanel-for-term-for-typedef-compound-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-compound-selector" style="display:none">Info about the '&lt;compound-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-compound-selector">https://drafts.csswg.org/selectors-4/#typedef-compound-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-compound-selector">3.2.3. 
 Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes</a> <a href="#ref-for-typedef-compound-selector①">(2)</a> <a href="#ref-for-typedef-compound-selector②">(3)</a>
@@ -2079,50 +2079,50 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a> <a href="#ref-for-typedef-compound-selector④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-complex">
-   <a href="https://drafts.csswg.org/selectors-4/#complex">https://drafts.csswg.org/selectors-4/#complex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-complex" class="dfn-panel" data-for="term-for-complex" id="infopanel-for-term-for-complex" role="menu">
+   <span id="infopaneltitle-for-term-for-complex" style="display:none">Info about the 'complex selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#complex">https://drafts.csswg.org/selectors-4/#complex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complex">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compound">
-   <a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compound" class="dfn-panel" data-for="term-for-compound" id="infopanel-for-term-for-compound" role="menu">
+   <span id="infopaneltitle-for-term-for-compound" style="display:none">Info about the 'compound selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descendant-combinator">
-   <a href="https://drafts.csswg.org/selectors-4/#descendant-combinator">https://drafts.csswg.org/selectors-4/#descendant-combinator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descendant-combinator" class="dfn-panel" data-for="term-for-descendant-combinator" id="infopanel-for-term-for-descendant-combinator" role="menu">
+   <span id="infopaneltitle-for-term-for-descendant-combinator" style="display:none">Info about the 'descendant combinator' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#descendant-combinator">https://drafts.csswg.org/selectors-4/#descendant-combinator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descendant-combinator">3.1. 
 Informative Explanation of Shadow DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-featureless">
-   <a href="https://drafts.csswg.org/selectors-4/#featureless">https://drafts.csswg.org/selectors-4/#featureless</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-featureless" class="dfn-panel" data-for="term-for-featureless" id="infopanel-for-term-for-featureless" role="menu">
+   <span id="infopaneltitle-for-term-for-featureless" style="display:none">Info about the 'featureless' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#featureless">https://drafts.csswg.org/selectors-4/#featureless</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-featureless">3.2.2. 
 Selecting Shadow Hosts from within a Shadow Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-a-selector-against-a-tree">
-   <a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree">https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-a-selector-against-a-tree" class="dfn-panel" data-for="term-for-match-a-selector-against-a-tree" id="infopanel-for-term-for-match-a-selector-against-a-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-match-a-selector-against-a-tree" style="display:none">Info about the 'match a selector against a tree' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree">https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-a-tree">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-a-selector-against-an-element">
-   <a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-a-selector-against-an-element" class="dfn-panel" data-for="term-for-match-a-selector-against-an-element" id="infopanel-for-term-for-match-a-selector-against-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-match-a-selector-against-an-element" style="display:none">Info about the 'match a selector against an element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-an-element">3.2.4. 
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specificity">
-   <a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specificity" class="dfn-panel" data-for="term-for-specificity" id="infopanel-for-term-for-specificity" role="menu">
+   <span id="infopaneltitle-for-term-for-specificity" style="display:none">Info about the 'specificity' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#specificity">https://drafts.csswg.org/selectors-4/#specificity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specificity">3.2.3. 
 Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes</a> <a href="#ref-for-specificity①">(2)</a> <a href="#ref-for-specificity②">(3)</a> <a href="#ref-for-specificity③">(4)</a> <a href="#ref-for-specificity④">(5)</a>
@@ -2130,8 +2130,8 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a> <a href="#ref-for-specificity⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type-selector" class="dfn-panel" data-for="term-for-type-selector" id="infopanel-for-term-for-type-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-type-selector" style="display:none">Info about the 'type selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">2. 
 Default Styles for Custom Elements</a> <a href="#ref-for-type-selector①">(2)</a>
@@ -2341,22 +2341,22 @@ Default Styles for Custom Elements</a> <a href="#ref-for-type-selector①">(2)</
      <a class="issue-return" href="#issue-725cfdca" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="dom-window-defaultelementstylesmap-slot">
-   <b><a href="#dom-window-defaultelementstylesmap-slot">#dom-window-defaultelementstylesmap-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-defaultelementstylesmap-slot" class="dfn-panel" data-for="dom-window-defaultelementstylesmap-slot" id="infopanel-for-dom-window-defaultelementstylesmap-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-window-defaultelementstylesmap-slot" style="display:none">Info about the '[[defaultElementStylesMap]]' definition.</span><b><a href="#dom-window-defaultelementstylesmap-slot">#dom-window-defaultelementstylesmap-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-defaultelementstylesmap-slot">2. 
 Default Styles for Custom Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tree-context">
-   <b><a href="#tree-context">#tree-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tree-context" class="dfn-panel" data-for="tree-context" id="infopanel-for-tree-context" role="dialog">
+   <span id="infopaneltitle-for-tree-context" style="display:none">Info about the 'tree context' definition.</span><b><a href="#tree-context">#tree-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-context">3.2.1. 
 Matching Selectors Against Shadow Trees</a> <a href="#ref-for-tree-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-the-context-of-a-shadow-tree">
-   <b><a href="#in-the-context-of-a-shadow-tree">#in-the-context-of-a-shadow-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-the-context-of-a-shadow-tree" class="dfn-panel" data-for="in-the-context-of-a-shadow-tree" id="infopanel-for-in-the-context-of-a-shadow-tree" role="dialog">
+   <span id="infopaneltitle-for-in-the-context-of-a-shadow-tree" style="display:none">Info about the 'in the context of a shadow tree' definition.</span><b><a href="#in-the-context-of-a-shadow-tree">#in-the-context-of-a-shadow-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-the-context-of-a-shadow-tree">3.2.1. 
 Matching Selectors Against Shadow Trees</a>
@@ -2368,8 +2368,8 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-host">
-   <b><a href="#selectordef-host">#selectordef-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-host" class="dfn-panel" data-for="selectordef-host" id="infopanel-for-selectordef-host" role="dialog">
+   <span id="infopaneltitle-for-selectordef-host" style="display:none">Info about the ':host' definition.</span><b><a href="#selectordef-host">#selectordef-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-host">3.2.2. 
 Selecting Shadow Hosts from within a Shadow Tree</a> <a href="#ref-for-selectordef-host①">(2)</a>
@@ -2379,8 +2379,8 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-host-function">
-   <b><a href="#selectordef-host-function">#selectordef-host-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-host-function" class="dfn-panel" data-for="selectordef-host-function" id="infopanel-for-selectordef-host-function" role="dialog">
+   <span id="infopaneltitle-for-selectordef-host-function" style="display:none">Info about the ':host()' definition.</span><b><a href="#selectordef-host-function">#selectordef-host-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-host-function">3.2.2. 
 Selecting Shadow Hosts from within a Shadow Tree</a>
@@ -2390,8 +2390,8 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-host-context">
-   <b><a href="#selectordef-host-context">#selectordef-host-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-host-context" class="dfn-panel" data-for="selectordef-host-context" id="infopanel-for-selectordef-host-context" role="dialog">
+   <span id="infopaneltitle-for-selectordef-host-context" style="display:none">Info about the ':host-context()' definition.</span><b><a href="#selectordef-host-context">#selectordef-host-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-host-context">3.2.2. 
 Selecting Shadow Hosts from within a Shadow Tree</a>
@@ -2401,8 +2401,8 @@ Selecting Into the Light: the :host, :host(), and :host-context() pseudo-classes
 Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-slotted">
-   <b><a href="#selectordef-slotted">#selectordef-slotted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-slotted" class="dfn-panel" data-for="selectordef-slotted" id="infopanel-for-selectordef-slotted" role="dialog">
+   <span id="infopaneltitle-for-selectordef-slotted" style="display:none">Info about the '::slotted()' definition.</span><b><a href="#selectordef-slotted">#selectordef-slotted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-slotted">3.2.4. 
 Selecting Slot-Assigned Content: the ::slotted() pseudo-element</a> <a href="#ref-for-selectordef-slotted①">(2)</a> <a href="#ref-for-selectordef-slotted②">(3)</a> <a href="#ref-for-selectordef-slotted③">(4)</a> <a href="#ref-for-selectordef-slotted④">(5)</a> <a href="#ref-for-selectordef-slotted⑤">(6)</a> <a href="#ref-for-selectordef-slotted⑥">(7)</a> <a href="#ref-for-selectordef-slotted⑦">(8)</a> <a href="#ref-for-selectordef-slotted⑧">(9)</a> <a href="#ref-for-selectordef-slotted⑨">(10)</a>
@@ -2412,8 +2412,8 @@ Flattening the DOM into an Element Tree</a>
 Changes</a> <a href="#ref-for-selectordef-slotted①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flat-tree">
-   <b><a href="#flat-tree">#flat-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flat-tree" class="dfn-panel" data-for="flat-tree" id="infopanel-for-flat-tree" role="dialog">
+   <span id="infopaneltitle-for-flat-tree" style="display:none">Info about the 'flattened element tree' definition.</span><b><a href="#flat-tree">#flat-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">3.1. 
 Informative Explanation of Shadow DOM</a>
@@ -2421,15 +2421,15 @@ Informative Explanation of Shadow DOM</a>
 Flattening the DOM into an Element Tree</a> <a href="#ref-for-flat-tree②">(2)</a> <a href="#ref-for-flat-tree③">(3)</a> <a href="#ref-for-flat-tree④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-tree-scoped-name">
-   <b><a href="#css-tree-scoped-name">#css-tree-scoped-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-tree-scoped-name" class="dfn-panel" data-for="css-tree-scoped-name" id="infopanel-for-css-tree-scoped-name" role="dialog">
+   <span id="infopaneltitle-for-css-tree-scoped-name" style="display:none">Info about the 'tree-scoped name' definition.</span><b><a href="#css-tree-scoped-name">#css-tree-scoped-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-tree-scoped-name">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-css-tree-scoped-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-tree-scoped-reference">
-   <b><a href="#css-tree-scoped-reference">#css-tree-scoped-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-tree-scoped-reference" class="dfn-panel" data-for="css-tree-scoped-reference" id="infopanel-for-css-tree-scoped-reference" role="dialog">
+   <span id="infopaneltitle-for-css-tree-scoped-reference" style="display:none">Info about the 'tree-scoped reference' definition.</span><b><a href="#css-tree-scoped-reference">#css-tree-scoped-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-tree-scoped-reference">3.5. 
 Name-Defining Constructs and Inheritance</a> <a href="#ref-for-css-tree-scoped-reference①">(2)</a> <a href="#ref-for-css-tree-scoped-reference②">(3)</a> <a href="#ref-for-css-tree-scoped-reference③">(4)</a>
@@ -2439,59 +2439,115 @@ Serialized Tree-Scoped References</a> <a href="#ref-for-css-tree-scoped-referenc
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scroll-anchoring-1/Overview.html
@@ -1338,106 +1338,106 @@ introduces no new privacy or security considerations.</p>
    <li><a href="#suppression-window">suppression window</a><span>, in § 2.2.1</span>
    <li><a href="#anchor-viable-candidate">viable candidate</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-content-area">
-   <a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-area" class="dfn-panel" data-for="term-for-content-area" id="infopanel-for-term-for-content-area" role="menu">
+   <span id="infopaneltitle-for-term-for-content-area" style="display:none">Info about the 'content area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-area">https://drafts.csswg.org/css-box-4/#content-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-atomic-inline①">(2)</a> <a href="#ref-for-atomic-inline②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-containing-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">3. 
 Exclusion API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-rectangle" class="dfn-panel" data-for="term-for-scrollable-overflow-rectangle" id="infopanel-for-term-for-scrollable-overflow-rectangle" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-rectangle" style="display:none">Info about the 'scrollable overflow rectangle' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-rectangle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-rectangle">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-absolute">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-absolute" class="dfn-panel" data-for="term-for-valdef-position-absolute" id="infopanel-for-term-for-valdef-position-absolute" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-absolute" style="display:none">Info about the 'absolute' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-absolute">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-fixed">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-fixed" class="dfn-panel" data-for="term-for-valdef-position-fixed" id="infopanel-for-term-for-valdef-position-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-propdef-position①">(2)</a>
@@ -1445,191 +1445,191 @@ Anchor Node Selection</a> <a href="#ref-for-propdef-position①">(2)</a>
 Suppression Triggers</a> <a href="#ref-for-propdef-position③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-optimal-viewing-region">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region">https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-optimal-viewing-region" class="dfn-panel" data-for="term-for-optimal-viewing-region" id="infopanel-for-term-for-optimal-viewing-region" role="menu">
+   <span id="infopaneltitle-for-term-for-optimal-viewing-region" style="display:none">Info about the 'optimal viewing region' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region">https://drafts.csswg.org/css-scroll-snap-1/#optimal-viewing-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimal-viewing-region">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-optimal-viewing-region①">(2)</a> <a href="#ref-for-optimal-viewing-region②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-re-snap">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">https://drafts.csswg.org/css-scroll-snap-1/#re-snap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-re-snap" class="dfn-panel" data-for="term-for-re-snap" id="infopanel-for-term-for-re-snap" role="menu">
+   <span id="infopaneltitle-for-term-for-re-snap" style="display:none">Info about the 're-snap' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#re-snap">https://drafts.csswg.org/css-scroll-snap-1/#re-snap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-re-snap">2. 
 Description</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-snap">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap">https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-snap" class="dfn-panel" data-for="term-for-scroll-snap" id="infopanel-for-term-for-scroll-snap" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-snap" style="display:none">Info about the 'scroll snap' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap">https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snap">2. 
 Description</a>
     <li><a href="#ref-for-scroll-snap①"> Changes Since the Feb 11 2020 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-padding">
-   <a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-padding" class="dfn-panel" data-for="term-for-propdef-scroll-padding" id="infopanel-for-term-for-propdef-scroll-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-padding" style="display:none">Info about the 'scroll-padding' external reference.</span><a href="https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding">https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-height">https://drafts.csswg.org/css-sizing-3/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">2.2.2. 
 Suppression Triggers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3. 
 Exclusion API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">2.2. 
 Scroll Adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">2.2.1. 
 Suppression Window</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-document-scroll">
-   <a href="https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll">https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-document-scroll" class="dfn-panel" data-for="term-for-eventdef-document-scroll" id="infopanel-for-term-for-eventdef-document-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-document-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll">https://drafts.csswg.org/cssom-view-1/#eventdef-document-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-document-scroll">2.2. 
 Scroll Adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fip-active-match">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#fip-active-match">https://html.spec.whatwg.org/multipage/interaction.html#fip-active-match</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fip-active-match" class="dfn-panel" data-for="term-for-fip-active-match" id="infopanel-for-term-for-fip-active-match" role="menu">
+   <span id="infopaneltitle-for-term-for-fip-active-match" style="display:none">Info about the 'active match' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#fip-active-match">https://html.spec.whatwg.org/multipage/interaction.html#fip-active-match</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fip-active-match">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-anchor">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-anchor" class="dfn-panel" data-for="term-for-dom-anchor" id="infopanel-for-term-for-dom-anchor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-anchor" style="display:none">Info about the 'dom anchor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor">https://html.spec.whatwg.org/multipage/interaction.html#dom-anchor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-anchor">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-editable">
-   <a href="https://w3c.github.io/editing/docs/execCommand/index.html#editable">https://w3c.github.io/editing/docs/execCommand/index.html#editable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-editable" class="dfn-panel" data-for="term-for-editable" id="infopanel-for-term-for-editable" role="menu">
+   <span id="infopaneltitle-for-term-for-editable" style="display:none">Info about the 'editable' external reference.</span><a href="https://w3c.github.io/editing/docs/execCommand/index.html#editable">https://w3c.github.io/editing/docs/execCommand/index.html#editable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editable">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-editing-host">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#editing-host">https://html.spec.whatwg.org/multipage/interaction.html#editing-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-editing-host" class="dfn-panel" data-for="term-for-editing-host" id="infopanel-for-term-for-editing-host" role="menu">
+   <span id="infopaneltitle-for-term-for-editing-host" style="display:none">Info about the 'editing host' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#editing-host">https://html.spec.whatwg.org/multipage/interaction.html#editing-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editing-host">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focused-area-of-the-document">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document">https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focused-area-of-the-document" class="dfn-panel" data-for="term-for-focused-area-of-the-document" id="infopanel-for-term-for-focused-area-of-the-document" role="menu">
+   <span id="infopaneltitle-for-term-for-focused-area-of-the-document" style="display:none">Info about the 'focused area of the document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document">https://html.spec.whatwg.org/multipage/interaction.html#focused-area-of-the-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focused-area-of-the-document">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fe-mutable">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fe-mutable" class="dfn-panel" data-for="term-for-concept-fe-mutable" id="infopanel-for-term-for-concept-fe-mutable" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fe-mutable" style="display:none">Info about the 'mutable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fe-mutable">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-concept-fe-mutable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-textarea-element" class="dfn-panel" data-for="term-for-the-textarea-element" id="infopanel-for-term-for-the-textarea-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-textarea-element" style="display:none">Info about the 'textarea' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-textarea-element">2.1. 
 Anchor Node Selection</a>
@@ -1789,73 +1789,73 @@ Anchor Node Selection</a>
       <td>specified keyword
    </table>
   </div>
-  <aside class="dfn-panel" data-for="scroll-anchoring-anchor-node">
-   <b><a href="#scroll-anchoring-anchor-node">#scroll-anchoring-anchor-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-anchoring-anchor-node" class="dfn-panel" data-for="scroll-anchoring-anchor-node" id="infopanel-for-scroll-anchoring-anchor-node" role="dialog">
+   <span id="infopaneltitle-for-scroll-anchoring-anchor-node" style="display:none">Info about the 'anchor node' definition.</span><b><a href="#scroll-anchoring-anchor-node">#scroll-anchoring-anchor-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-anchoring-anchor-node">2.1. 
 Anchor Node Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchor-viable-candidate">
-   <b><a href="#anchor-viable-candidate">#anchor-viable-candidate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchor-viable-candidate" class="dfn-panel" data-for="anchor-viable-candidate" id="infopanel-for-anchor-viable-candidate" role="dialog">
+   <span id="infopaneltitle-for-anchor-viable-candidate" style="display:none">Info about the 'viable candidate' definition.</span><b><a href="#anchor-viable-candidate">#anchor-viable-candidate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-viable-candidate">2.1. 
 Anchor Node Selection</a>
     <li><a href="#ref-for-anchor-viable-candidate①"> Changes Since the Feb 11 2020 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchor-priority-candidates">
-   <b><a href="#anchor-priority-candidates">#anchor-priority-candidates</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchor-priority-candidates" class="dfn-panel" data-for="anchor-priority-candidates" id="infopanel-for-anchor-priority-candidates" role="dialog">
+   <span id="infopaneltitle-for-anchor-priority-candidates" style="display:none">Info about the 'priority candidates' definition.</span><b><a href="#anchor-priority-candidates">#anchor-priority-candidates</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-priority-candidates">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-anchor-priority-candidates①">(2)</a>
     <li><a href="#ref-for-anchor-priority-candidates②"> Changes Since the Feb 11 2020 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchoring-algorithm">
-   <b><a href="#anchoring-algorithm">#anchoring-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchoring-algorithm" class="dfn-panel" data-for="anchoring-algorithm" id="infopanel-for-anchoring-algorithm" role="dialog">
+   <span id="infopaneltitle-for-anchoring-algorithm" style="display:none">Info about the 'anchor node selection algorithm' definition.</span><b><a href="#anchoring-algorithm">#anchoring-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchoring-algorithm">3. 
 Exclusion API</a> <a href="#ref-for-anchoring-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-examination">
-   <b><a href="#candidate-examination">#candidate-examination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-examination" class="dfn-panel" data-for="candidate-examination" id="infopanel-for-candidate-examination" role="dialog">
+   <span id="infopaneltitle-for-candidate-examination" style="display:none">Info about the 'candidate examination algorithm' definition.</span><b><a href="#candidate-examination">#candidate-examination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-examination">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-candidate-examination①">(2)</a> <a href="#ref-for-candidate-examination②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="excluded-subtree">
-   <b><a href="#excluded-subtree">#excluded-subtree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-excluded-subtree" class="dfn-panel" data-for="excluded-subtree" id="infopanel-for-excluded-subtree" role="dialog">
+   <span id="infopaneltitle-for-excluded-subtree" style="display:none">Info about the 'excluded subtree' definition.</span><b><a href="#excluded-subtree">#excluded-subtree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-excluded-subtree">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-excluded-subtree①">(2)</a> <a href="#ref-for-excluded-subtree②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fully-visible">
-   <b><a href="#fully-visible">#fully-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fully-visible" class="dfn-panel" data-for="fully-visible" id="infopanel-for-fully-visible" role="dialog">
+   <span id="infopaneltitle-for-fully-visible" style="display:none">Info about the 'fully visible' definition.</span><b><a href="#fully-visible">#fully-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-visible">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-fully-visible①">(2)</a> <a href="#ref-for-fully-visible②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fully-clipped">
-   <b><a href="#fully-clipped">#fully-clipped</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fully-clipped" class="dfn-panel" data-for="fully-clipped" id="infopanel-for-fully-clipped" role="dialog">
+   <span id="infopaneltitle-for-fully-clipped" style="display:none">Info about the 'fully clipped' definition.</span><b><a href="#fully-clipped">#fully-clipped</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-clipped">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-fully-clipped①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partially-visible">
-   <b><a href="#partially-visible">#partially-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partially-visible" class="dfn-panel" data-for="partially-visible" id="infopanel-for-partially-visible" role="dialog">
+   <span id="infopaneltitle-for-partially-visible" style="display:none">Info about the 'partially visible' definition.</span><b><a href="#partially-visible">#partially-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partially-visible">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-partially-visible①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-anchoring-bounding-rect">
-   <b><a href="#scroll-anchoring-bounding-rect">#scroll-anchoring-bounding-rect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-anchoring-bounding-rect" class="dfn-panel" data-for="scroll-anchoring-bounding-rect" id="infopanel-for-scroll-anchoring-bounding-rect" role="dialog">
+   <span id="infopaneltitle-for-scroll-anchoring-bounding-rect" style="display:none">Info about the 'scroll anchoring bounding rect' definition.</span><b><a href="#scroll-anchoring-bounding-rect">#scroll-anchoring-bounding-rect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-anchoring-bounding-rect">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-scroll-anchoring-bounding-rect①">(2)</a>
@@ -1863,22 +1863,22 @@ Anchor Node Selection</a> <a href="#ref-for-scroll-anchoring-bounding-rect①">(
 Scroll Adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suppression-window">
-   <b><a href="#suppression-window">#suppression-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suppression-window" class="dfn-panel" data-for="suppression-window" id="infopanel-for-suppression-window" role="dialog">
+   <span id="infopaneltitle-for-suppression-window" style="display:none">Info about the 'suppression window' definition.</span><b><a href="#suppression-window">#suppression-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suppression-window">2.2. 
 Scroll Adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suppression-trigger">
-   <b><a href="#suppression-trigger">#suppression-trigger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suppression-trigger" class="dfn-panel" data-for="suppression-trigger" id="infopanel-for-suppression-trigger" role="dialog">
+   <span id="infopaneltitle-for-suppression-trigger" style="display:none">Info about the 'suppression trigger' definition.</span><b><a href="#suppression-trigger">#suppression-trigger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suppression-trigger">2.2.1. 
 Suppression Window</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-anchor">
-   <b><a href="#propdef-overflow-anchor">#propdef-overflow-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-anchor" class="dfn-panel" data-for="propdef-overflow-anchor" id="infopanel-for-propdef-overflow-anchor" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-anchor" style="display:none">Info about the 'overflow-anchor' definition.</span><b><a href="#propdef-overflow-anchor">#propdef-overflow-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-anchor">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-propdef-overflow-anchor①">(2)</a>
@@ -1886,8 +1886,8 @@ Anchor Node Selection</a> <a href="#ref-for-propdef-overflow-anchor①">(2)</a>
 Exclusion API</a> <a href="#ref-for-propdef-overflow-anchor③">(2)</a> <a href="#ref-for-propdef-overflow-anchor④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-anchor-none">
-   <b><a href="#valdef-overflow-anchor-none">#valdef-overflow-anchor-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-anchor-none" class="dfn-panel" data-for="valdef-overflow-anchor-none" id="infopanel-for-valdef-overflow-anchor-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-anchor-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-overflow-anchor-none">#valdef-overflow-anchor-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-anchor-none">2.1. 
 Anchor Node Selection</a> <a href="#ref-for-valdef-overflow-anchor-none①">(2)</a>
@@ -1895,59 +1895,115 @@ Anchor Node Selection</a> <a href="#ref-for-valdef-overflow-anchor-none①">(2)<
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scroll-snap-1/Overview.html
@@ -2908,36 +2908,36 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1" t
    <li><a href="#valdef-scroll-snap-type-x">x</a><span>, in § 4.1.1</span>
    <li><a href="#valdef-scroll-snap-type-y">y</a><span>, in § 4.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-alignment-container">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-container" class="dfn-panel" data-for="term-for-alignment-container" id="infopanel-for-term-for-alignment-container" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-container" style="display:none">Info about the 'alignment container' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-container">3. Scroll Snap Model</a>
     <li><a href="#ref-for-alignment-container①">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-alignment-container②">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-alignment-subject">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-subject">https://drafts.csswg.org/css-align-3/#alignment-subject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-subject" class="dfn-panel" data-for="term-for-alignment-subject" id="infopanel-for-term-for-alignment-subject" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-subject" style="display:none">Info about the 'alignment subject' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-subject">https://drafts.csswg.org/css-align-3/#alignment-subject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-subject">3. Scroll Snap Model</a>
     <li><a href="#ref-for-alignment-subject①">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">5.1. Scroll Snapping Area: the scroll-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-propdef-padding①">9.6. Changes Since 20 October 2016 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">Physical Longhands for scroll-padding</a>
     <li><a href="#ref-for-longhand①">Flow-relative Longhands for scroll-padding</a> <a href="#ref-for-longhand②">(2)</a>
@@ -2945,8 +2945,8 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1" t
     <li><a href="#ref-for-longhand④">Flow-relative Longhands for scroll-margin</a> <a href="#ref-for-longhand⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-shorthand-property①">5.1. Scroll Snapping Area: the scroll-margin property</a>
@@ -2954,8 +2954,8 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1" t
     <li><a href="#ref-for-shorthand-property③">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property①" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property①" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-shorthand-property①">5.1. Scroll Snapping Area: the scroll-margin property</a>
@@ -2963,31 +2963,31 @@ interact as defined in <a data-link-type="biblio" href="#biblio-css-logical-1" t
     <li><a href="#ref-for-shorthand-property③">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-chain">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-chain" class="dfn-panel" data-for="term-for-containing-block-chain" id="infopanel-for-term-for-containing-block-chain" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-chain" style="display:none">Info about the 'containing block chain' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block-chain">https://drafts.csswg.org/css-display-3/#containing-block-chain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-chain">3. Scroll Snap Model</a>
     <li><a href="#ref-for-containing-block-chain①">4.1.2. 
 Scroll Snap Strictness: the none, proximity, and mandatory values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inset-properties">
-   <a href="https://drafts.csswg.org/css-logical-1/#inset-properties">https://drafts.csswg.org/css-logical-1/#inset-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inset-properties" class="dfn-panel" data-for="term-for-inset-properties" id="infopanel-for-term-for-inset-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-inset-properties" style="display:none">Info about the 'inset properties' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#inset-properties">https://drafts.csswg.org/css-logical-1/#inset-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inset-properties">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-inset-properties①">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
     <li><a href="#ref-for-propdef-overflow①">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-propdef-overflow②">9.1. Changes Since 19 March 2019 CR</a> <a href="#ref-for-propdef-overflow③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">Unnumbered Section</a>
     <li><a href="#ref-for-scroll-container①">1. Introduction</a> <a href="#ref-for-scroll-container②">(2)</a> <a href="#ref-for-scroll-container③">(3)</a>
@@ -3017,16 +3017,16 @@ Unreachable Snap Positions</a>
     <li><a href="#ref-for-scroll-container⑤④">9.5. Changes Since 24 August 2017 CR</a> <a href="#ref-for-scroll-container⑤⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scroll-behavior">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior">https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scroll-behavior" class="dfn-panel" data-for="term-for-propdef-scroll-behavior" id="infopanel-for-term-for-propdef-scroll-behavior" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scroll-behavior" style="display:none">Info about the 'scroll-behavior' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior">https://drafts.csswg.org/css-overflow-3/#propdef-scroll-behavior</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-behavior">4.1.3. 
 Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-propdef-scroll-behavior①">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow area' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">5.1. Scroll Snapping Area: the scroll-margin property</a>
     <li><a href="#ref-for-scrollable-overflow-region①">5.2.3. 
@@ -3036,8 +3036,8 @@ Unreachable Snap Positions</a>
     <li><a href="#ref-for-scrollable-overflow-region⑤">9.5. Changes Since 24 August 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">4.2. Scroll Snapport: the scroll-padding property</a> <a href="#ref-for-scrollport①">(2)</a> <a href="#ref-for-scrollport②">(3)</a> <a href="#ref-for-scrollport③">(4)</a> <a href="#ref-for-scrollport④">(5)</a>
     <li><a href="#ref-for-scrollport⑤">5.2.1. 
@@ -3045,74 +3045,74 @@ Scoping Valid Snap Positions to Visible Boxes</a>
     <li><a href="#ref-for-scrollport⑥">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fixed-position">
-   <a href="https://drafts.csswg.org/css-position-3/#fixed-position">https://drafts.csswg.org/css-position-3/#fixed-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fixed-position" class="dfn-panel" data-for="term-for-fixed-position" id="infopanel-for-term-for-fixed-position" role="menu">
+   <span id="infopaneltitle-for-term-for-fixed-position" style="display:none">Info about the 'fixed-positioned box' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#fixed-position">https://drafts.csswg.org/css-position-3/#fixed-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fixed-position">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-fixed-position①">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset">https://drafts.csswg.org/css-position-3/#propdef-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset" class="dfn-panel" data-for="term-for-propdef-inset" id="infopanel-for-term-for-propdef-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset">https://drafts.csswg.org/css-position-3/#propdef-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">4.1.3. 
 Re-snapping After Layout Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.1. Module interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.1. Module interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.2. Scroll Snapport: the scroll-padding property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
     <li><a href="#ref-for-typedef-length-percentage③">Physical Longhands for scroll-padding</a> <a href="#ref-for-typedef-length-percentage④">(2)</a>
     <li><a href="#ref-for-typedef-length-percentage⑤">Flow-relative Longhands for scroll-padding</a> <a href="#ref-for-typedef-length-percentage⑥">(2)</a> <a href="#ref-for-typedef-length-percentage⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">5.1. Scroll Snapping Area: the scroll-margin property</a>
     <li><a href="#ref-for-length-value①">Physical Longhands for scroll-margin</a>
     <li><a href="#ref-for-length-value②">Flow-relative Longhands for scroll-margin</a> <a href="#ref-for-length-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">9.3. Changes Since 14 August 2018 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-mult-num-range①">5.1. Scroll Snapping Area: the scroll-margin property</a>
@@ -3121,8 +3121,8 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-mult-num-range④">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. Scroll Snapping Rules: the scroll-snap-type property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a>
     <li><a href="#ref-for-comb-one⑥">4.2. Scroll Snapport: the scroll-padding property</a>
@@ -3132,33 +3132,33 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-comb-one①②">Flow-relative Longhands for scroll-padding</a> <a href="#ref-for-comb-one①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
     <li><a href="#ref-for-block-axis①">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a> <a href="#ref-for-writing-mode①">(2)</a> <a href="#ref-for-writing-mode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-scrollby">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-scrollby">https://drafts.csswg.org/cssom-view-1/#dom-window-scrollby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-scrollby" class="dfn-panel" data-for="term-for-dom-window-scrollby" id="infopanel-for-term-for-dom-window-scrollby" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-scrollby" style="display:none">Info about the 'scrollBy()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-scrollby">https://drafts.csswg.org/cssom-view-1/#dom-window-scrollby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrollby">6.1. Types of Scrolling Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-scrollintoview">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview">https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-scrollintoview" class="dfn-panel" data-for="term-for-dom-element-scrollintoview" id="infopanel-for-term-for-dom-element-scrollintoview" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-scrollintoview" style="display:none">Info about the 'scrollIntoView()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview">https://drafts.csswg.org/cssom-view-1/#dom-element-scrollintoview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollintoview">5.1. Scroll Snapping Area: the scroll-margin property</a>
     <li><a href="#ref-for-dom-element-scrollintoview①">6.2. Choosing Snap Positions</a>
@@ -3166,31 +3166,31 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-dom-element-scrollintoview③">9.5. Changes Since 24 August 2017 CR</a> <a href="#ref-for-dom-element-scrollintoview④">(2)</a> <a href="#ref-for-dom-element-scrollintoview⑤">(3)</a> <a href="#ref-for-dom-element-scrollintoview⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-scrollto">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-window-scrollto">https://drafts.csswg.org/cssom-view-1/#dom-window-scrollto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-scrollto" class="dfn-panel" data-for="term-for-dom-window-scrollto" id="infopanel-for-term-for-dom-window-scrollto" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-scrollto" style="display:none">Info about the 'scrollTo()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-window-scrollto">https://drafts.csswg.org/cssom-view-1/#dom-window-scrollto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrollto">3. Scroll Snap Model</a>
     <li><a href="#ref-for-dom-window-scrollto①">6.1. Types of Scrolling Methods</a>
     <li><a href="#ref-for-dom-window-scrollto②">9.4. Changes Since 14 December 2017 CR</a> <a href="#ref-for-dom-window-scrollto③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
     <li><a href="#ref-for-the-body-element①">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-the-body-element②">9.1. Changes Since 19 March 2019 CR</a> <a href="#ref-for-the-body-element③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-section-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element">https://html.spec.whatwg.org/multipage/sections.html#the-section-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-section-element" class="dfn-panel" data-for="term-for-the-section-element" id="infopanel-for-term-for-the-section-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-section-element" style="display:none">Info about the 'section' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element">https://html.spec.whatwg.org/multipage/sections.html#the-section-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-section-element">5.2.2. 
 Snapping Boxes that Overflow the Scrollport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-pseudo" class="dfn-panel" data-for="term-for-target-pseudo" id="infopanel-for-term-for-target-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-target-pseudo" style="display:none">Info about the ':target' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#target-pseudo">https://drafts.csswg.org/selectors-4/#target-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo">5.1. Scroll Snapping Area: the scroll-margin property</a>
     <li><a href="#ref-for-target-pseudo①">6.2. Choosing Snap Positions</a>
@@ -3591,8 +3591,8 @@ Snapping Boxes that Overflow the Scrollport</a>
       <td>specified keyword(s)
    </table>
   </div>
-  <aside class="dfn-panel" data-for="scroll-snap-position">
-   <b><a href="#scroll-snap-position">#scroll-snap-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-snap-position" class="dfn-panel" data-for="scroll-snap-position" id="infopanel-for-scroll-snap-position" role="dialog">
+   <span id="infopaneltitle-for-scroll-snap-position" style="display:none">Info about the 'scroll snap positions' definition.</span><b><a href="#scroll-snap-position">#scroll-snap-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snap-position">1. Introduction</a>
     <li><a href="#ref-for-scroll-snap-position①">3. Scroll Snap Model</a> <a href="#ref-for-scroll-snap-position②">(2)</a> <a href="#ref-for-scroll-snap-position③">(3)</a> <a href="#ref-for-scroll-snap-position④">(4)</a> <a href="#ref-for-scroll-snap-position⑤">(5)</a> <a href="#ref-for-scroll-snap-position⑥">(6)</a> <a href="#ref-for-scroll-snap-position⑦">(7)</a>
@@ -3619,8 +3619,8 @@ Unreachable Snap Positions</a> <a href="#ref-for-scroll-snap-position③⑦">(2)
     <li><a href="#ref-for-scroll-snap-position⑥③">9.6. Changes Since 20 October 2016 CR</a> <a href="#ref-for-scroll-snap-position⑥④">(2)</a> <a href="#ref-for-scroll-snap-position⑥⑤">(3)</a> <a href="#ref-for-scroll-snap-position⑥⑥">(4)</a> <a href="#ref-for-scroll-snap-position⑥⑦">(5)</a> <a href="#ref-for-scroll-snap-position⑥⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-snap">
-   <b><a href="#scroll-snap">#scroll-snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-snap" class="dfn-panel" data-for="scroll-snap" id="infopanel-for-scroll-snap" role="dialog">
+   <span id="infopaneltitle-for-scroll-snap" style="display:none">Info about the 'snapping' definition.</span><b><a href="#scroll-snap">#scroll-snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snap">3. Scroll Snap Model</a>
     <li><a href="#ref-for-scroll-snap①">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
@@ -3637,8 +3637,8 @@ Scoping Valid Snap Positions to Visible Boxes</a> <a href="#ref-for-scroll-snap�
     <li><a href="#ref-for-scroll-snap②①">9.5. Changes Since 24 August 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-snap-type">
-   <b><a href="#propdef-scroll-snap-type">#propdef-scroll-snap-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-snap-type" class="dfn-panel" data-for="propdef-scroll-snap-type" id="infopanel-for-propdef-scroll-snap-type" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-snap-type" style="display:none">Info about the 'scroll-snap-type' definition.</span><b><a href="#propdef-scroll-snap-type">#propdef-scroll-snap-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-type①">3. Scroll Snap Model</a>
     <li><a href="#ref-for-propdef-scroll-snap-type②">4.1. Scroll Snapping Rules: the scroll-snap-type property</a> <a href="#ref-for-propdef-scroll-snap-type③">(2)</a> <a href="#ref-for-propdef-scroll-snap-type④">(3)</a> <a href="#ref-for-propdef-scroll-snap-type⑤">(4)</a>
@@ -3653,73 +3653,73 @@ Scoping Valid Snap Positions to Visible Boxes</a>
     <li><a href="#ref-for-propdef-scroll-snap-type①⑥">9.6. Changes Since 20 October 2016 CR</a> <a href="#ref-for-propdef-scroll-snap-type①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-x">
-   <b><a href="#valdef-scroll-snap-type-x">#valdef-scroll-snap-type-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-x" class="dfn-panel" data-for="valdef-scroll-snap-type-x" id="infopanel-for-valdef-scroll-snap-type-x" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-x" style="display:none">Info about the 'x' definition.</span><b><a href="#valdef-scroll-snap-type-x">#valdef-scroll-snap-type-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-x">4.1.1. 
 Scroll Snap Axis: the x, y, block, inline, and both values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-y">
-   <b><a href="#valdef-scroll-snap-type-y">#valdef-scroll-snap-type-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-y" class="dfn-panel" data-for="valdef-scroll-snap-type-y" id="infopanel-for-valdef-scroll-snap-type-y" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-y" style="display:none">Info about the 'y' definition.</span><b><a href="#valdef-scroll-snap-type-y">#valdef-scroll-snap-type-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-y">4.1.1. 
 Scroll Snap Axis: the x, y, block, inline, and both values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-block">
-   <b><a href="#valdef-scroll-snap-type-block">#valdef-scroll-snap-type-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-block" class="dfn-panel" data-for="valdef-scroll-snap-type-block" id="infopanel-for-valdef-scroll-snap-type-block" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-block" style="display:none">Info about the 'block' definition.</span><b><a href="#valdef-scroll-snap-type-block">#valdef-scroll-snap-type-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-block">4.1.1. 
 Scroll Snap Axis: the x, y, block, inline, and both values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-inline">
-   <b><a href="#valdef-scroll-snap-type-inline">#valdef-scroll-snap-type-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-inline" class="dfn-panel" data-for="valdef-scroll-snap-type-inline" id="infopanel-for-valdef-scroll-snap-type-inline" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#valdef-scroll-snap-type-inline">#valdef-scroll-snap-type-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-inline">4.1.1. 
 Scroll Snap Axis: the x, y, block, inline, and both values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-both">
-   <b><a href="#valdef-scroll-snap-type-both">#valdef-scroll-snap-type-both</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-both" class="dfn-panel" data-for="valdef-scroll-snap-type-both" id="infopanel-for-valdef-scroll-snap-type-both" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-both" style="display:none">Info about the 'both' definition.</span><b><a href="#valdef-scroll-snap-type-both">#valdef-scroll-snap-type-both</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-both">4.1.1. 
 Scroll Snap Axis: the x, y, block, inline, and both values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-none">
-   <b><a href="#valdef-scroll-snap-type-none">#valdef-scroll-snap-type-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-none" class="dfn-panel" data-for="valdef-scroll-snap-type-none" id="infopanel-for-valdef-scroll-snap-type-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-scroll-snap-type-none">#valdef-scroll-snap-type-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-none">4.1.2. 
 Scroll Snap Strictness: the none, proximity, and mandatory values</a> <a href="#ref-for-valdef-scroll-snap-type-none①">(2)</a> <a href="#ref-for-valdef-scroll-snap-type-none②">(3)</a> <a href="#ref-for-valdef-scroll-snap-type-none③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-mandatory">
-   <b><a href="#valdef-scroll-snap-type-mandatory">#valdef-scroll-snap-type-mandatory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-mandatory" class="dfn-panel" data-for="valdef-scroll-snap-type-mandatory" id="infopanel-for-valdef-scroll-snap-type-mandatory" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-mandatory" style="display:none">Info about the 'mandatory' definition.</span><b><a href="#valdef-scroll-snap-type-mandatory">#valdef-scroll-snap-type-mandatory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-mandatory">4.1.2. 
 Scroll Snap Strictness: the none, proximity, and mandatory values</a> <a href="#ref-for-valdef-scroll-snap-type-mandatory①">(2)</a>
     <li><a href="#ref-for-valdef-scroll-snap-type-mandatory②">6.2. Choosing Snap Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-type-proximity">
-   <b><a href="#valdef-scroll-snap-type-proximity">#valdef-scroll-snap-type-proximity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-type-proximity" class="dfn-panel" data-for="valdef-scroll-snap-type-proximity" id="infopanel-for-valdef-scroll-snap-type-proximity" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-type-proximity" style="display:none">Info about the 'proximity' definition.</span><b><a href="#valdef-scroll-snap-type-proximity">#valdef-scroll-snap-type-proximity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-type-proximity">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
     <li><a href="#ref-for-valdef-scroll-snap-type-proximity①">4.1.2. 
 Scroll Snap Strictness: the none, proximity, and mandatory values</a> <a href="#ref-for-valdef-scroll-snap-type-proximity②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="captures-snap-positions">
-   <b><a href="#captures-snap-positions">#captures-snap-positions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-captures-snap-positions" class="dfn-panel" data-for="captures-snap-positions" id="infopanel-for-captures-snap-positions" role="dialog">
+   <span id="infopaneltitle-for-captures-snap-positions" style="display:none">Info about the 'captures snap positions' definition.</span><b><a href="#captures-snap-positions">#captures-snap-positions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-captures-snap-positions①">4.1.2. 
 Scroll Snap Strictness: the none, proximity, and mandatory values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-snap-container">
-   <b><a href="#scroll-snap-container">#scroll-snap-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-snap-container" class="dfn-panel" data-for="scroll-snap-container" id="infopanel-for-scroll-snap-container" role="dialog">
+   <span id="infopaneltitle-for-scroll-snap-container" style="display:none">Info about the 'scroll snap container' definition.</span><b><a href="#scroll-snap-container">#scroll-snap-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snap-container">4.1. Scroll Snapping Rules: the scroll-snap-type property</a>
     <li><a href="#ref-for-scroll-snap-container①">4.1.2. 
@@ -3734,15 +3734,16 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-scroll-snap-container①①">9.6. Changes Since 20 October 2016 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="re-snap">
-   <b><a href="#re-snap">#re-snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-re-snap" class="dfn-panel" data-for="re-snap" id="infopanel-for-re-snap" role="dialog">
+   <span id="infopaneltitle-for-re-snap" style="display:none">Info about the '4.1.3. 
+Re-snapping After Layout Changes' definition.</span><b><a href="#re-snap">#re-snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-re-snap">4.1.3. 
 Re-snapping After Layout Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding">
-   <b><a href="#propdef-scroll-padding">#propdef-scroll-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding" class="dfn-panel" data-for="propdef-scroll-padding" id="infopanel-for-propdef-scroll-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding" style="display:none">Info about the 'scroll-padding' definition.</span><b><a href="#propdef-scroll-padding">#propdef-scroll-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding">1. Introduction</a>
     <li><a href="#ref-for-propdef-scroll-padding①">3. Scroll Snap Model</a>
@@ -3755,8 +3756,8 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-propdef-scroll-padding②⓪">9.6. Changes Since 20 October 2016 CR</a> <a href="#ref-for-propdef-scroll-padding②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optimal-viewing-region">
-   <b><a href="#optimal-viewing-region">#optimal-viewing-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optimal-viewing-region" class="dfn-panel" data-for="optimal-viewing-region" id="infopanel-for-optimal-viewing-region" role="dialog">
+   <span id="infopaneltitle-for-optimal-viewing-region" style="display:none">Info about the 'optimal viewing region' definition.</span><b><a href="#optimal-viewing-region">#optimal-viewing-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimal-viewing-region">1. Introduction</a>
     <li><a href="#ref-for-optimal-viewing-region①">4.2. Scroll Snapport: the scroll-padding property</a> <a href="#ref-for-optimal-viewing-region②">(2)</a>
@@ -3764,8 +3765,8 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-optimal-viewing-region④">9.2. Changes Since 31 January 2019 CR</a> <a href="#ref-for-optimal-viewing-region⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-padding-auto">
-   <b><a href="#valdef-scroll-padding-auto">#valdef-scroll-padding-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-padding-auto" class="dfn-panel" data-for="valdef-scroll-padding-auto" id="infopanel-for-valdef-scroll-padding-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-padding-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-scroll-padding-auto">#valdef-scroll-padding-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-padding-auto">4.2. Scroll Snapport: the scroll-padding property</a>
     <li><a href="#ref-for-valdef-scroll-padding-auto①">Physical Longhands for scroll-padding</a>
@@ -3774,8 +3775,8 @@ Re-snapping After Layout Changes</a>
     <li><a href="#ref-for-valdef-scroll-padding-auto④">9.4. Changes Since 14 December 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-snapport">
-   <b><a href="#scroll-snapport">#scroll-snapport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-snapport" class="dfn-panel" data-for="scroll-snapport" id="infopanel-for-scroll-snapport" role="dialog">
+   <span id="infopaneltitle-for-scroll-snapport" style="display:none">Info about the 'scroll snapport' definition.</span><b><a href="#scroll-snapport">#scroll-snapport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snapport">3. Scroll Snap Model</a>
     <li><a href="#ref-for-scroll-snapport①">4.1.3. 
@@ -3790,8 +3791,8 @@ Snapping Boxes that Overflow the Scrollport</a> <a href="#ref-for-scroll-snappor
     <li><a href="#ref-for-scroll-snapport①⑧">Flow-relative Longhands for scroll-padding</a> <a href="#ref-for-scroll-snapport①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-margin">
-   <b><a href="#propdef-scroll-margin">#propdef-scroll-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-margin" class="dfn-panel" data-for="propdef-scroll-margin" id="infopanel-for-propdef-scroll-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-margin" style="display:none">Info about the 'scroll-margin' definition.</span><b><a href="#propdef-scroll-margin">#propdef-scroll-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin">1. Introduction</a>
     <li><a href="#ref-for-propdef-scroll-margin①">3. Scroll Snap Model</a>
@@ -3804,8 +3805,8 @@ Snapping Boxes that Overflow the Scrollport</a> <a href="#ref-for-scroll-snappor
     <li><a href="#ref-for-propdef-scroll-margin①③">9.6. Changes Since 20 October 2016 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-snap-area">
-   <b><a href="#scroll-snap-area">#scroll-snap-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-snap-area" class="dfn-panel" data-for="scroll-snap-area" id="infopanel-for-scroll-snap-area" role="dialog">
+   <span id="infopaneltitle-for-scroll-snap-area" style="display:none">Info about the 'scroll snap area' definition.</span><b><a href="#scroll-snap-area">#scroll-snap-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-snap-area">3. Scroll Snap Model</a>
     <li><a href="#ref-for-scroll-snap-area①">4.1.3. 
@@ -3827,8 +3828,8 @@ Unreachable Snap Positions</a>
     <li><a href="#ref-for-scroll-snap-area②⑧">9.6. Changes Since 20 October 2016 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-snap-align">
-   <b><a href="#propdef-scroll-snap-align">#propdef-scroll-snap-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-snap-align" class="dfn-panel" data-for="propdef-scroll-snap-align" id="infopanel-for-propdef-scroll-snap-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-snap-align" style="display:none">Info about the 'scroll-snap-align' definition.</span><b><a href="#propdef-scroll-snap-align">#propdef-scroll-snap-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-align">3. Scroll Snap Model</a>
     <li><a href="#ref-for-propdef-scroll-snap-align①">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a> <a href="#ref-for-propdef-scroll-snap-align②">(2)</a>
@@ -3836,168 +3837,224 @@ Unreachable Snap Positions</a>
     <li><a href="#ref-for-propdef-scroll-snap-align④">9.4. Changes Since 14 December 2017 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-snap-align-start">
-   <b><a href="#valdef-scroll-snap-align-start">#valdef-scroll-snap-align-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-snap-align-start" class="dfn-panel" data-for="valdef-scroll-snap-align-start" id="infopanel-for-valdef-scroll-snap-align-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-snap-align-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-scroll-snap-align-start">#valdef-scroll-snap-align-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-snap-align-start">5.2. Scroll Snapping Alignment: the scroll-snap-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-snap-stop">
-   <b><a href="#propdef-scroll-snap-stop">#propdef-scroll-snap-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-snap-stop" class="dfn-panel" data-for="propdef-scroll-snap-stop" id="infopanel-for-propdef-scroll-snap-stop" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-snap-stop" style="display:none">Info about the 'scroll-snap-stop' definition.</span><b><a href="#propdef-scroll-snap-stop">#propdef-scroll-snap-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-snap-stop①">5.3. Scroll Snap Limits: the scroll-snap-stop property</a> <a href="#ref-for-propdef-scroll-snap-stop②">(2)</a>
     <li><a href="#ref-for-propdef-scroll-snap-stop③">9.6. Changes Since 20 October 2016 CR</a> <a href="#ref-for-propdef-scroll-snap-stop④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intended-end-position">
-   <b><a href="#intended-end-position">#intended-end-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intended-end-position" class="dfn-panel" data-for="intended-end-position" id="infopanel-for-intended-end-position" role="dialog">
+   <span id="infopaneltitle-for-intended-end-position" style="display:none">Info about the 'intended end position' definition.</span><b><a href="#intended-end-position">#intended-end-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intended-end-position">5.3. Scroll Snap Limits: the scroll-snap-stop property</a>
     <li><a href="#ref-for-intended-end-position①">6.1. Types of Scrolling Methods</a>
     <li><a href="#ref-for-intended-end-position②">6.2. Choosing Snap Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intended-direction-and-end-position">
-   <b><a href="#intended-direction-and-end-position">#intended-direction-and-end-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intended-direction-and-end-position" class="dfn-panel" data-for="intended-direction-and-end-position" id="infopanel-for-intended-direction-and-end-position" role="dialog">
+   <span id="infopaneltitle-for-intended-direction-and-end-position" style="display:none">Info about the 'intended direction and end position' definition.</span><b><a href="#intended-direction-and-end-position">#intended-direction-and-end-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intended-direction-and-end-position">6.1. Types of Scrolling Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="natural-end-point">
-   <b><a href="#natural-end-point">#natural-end-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-natural-end-point" class="dfn-panel" data-for="natural-end-point" id="infopanel-for-natural-end-point" role="dialog">
+   <span id="infopaneltitle-for-natural-end-point" style="display:none">Info about the 'natural end-point' definition.</span><b><a href="#natural-end-point">#natural-end-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-end-point">6.2. Choosing Snap Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intended-direction">
-   <b><a href="#intended-direction">#intended-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intended-direction" class="dfn-panel" data-for="intended-direction" id="infopanel-for-intended-direction" role="dialog">
+   <span id="infopaneltitle-for-intended-direction" style="display:none">Info about the 'intended direction' definition.</span><b><a href="#intended-direction">#intended-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intended-direction">6.1. Types of Scrolling Methods</a>
     <li><a href="#ref-for-intended-direction①">6.2. Choosing Snap Positions</a> <a href="#ref-for-intended-direction②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="axis-lock">
-   <b><a href="#axis-lock">#axis-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-axis-lock" class="dfn-panel" data-for="axis-lock" id="infopanel-for-axis-lock" role="dialog">
+   <span id="infopaneltitle-for-axis-lock" style="display:none">Info about the 'axis-lock' definition.</span><b><a href="#axis-lock">#axis-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-axis-lock">6.1. Types of Scrolling Methods</a>
     <li><a href="#ref-for-axis-lock①">6.2. Choosing Snap Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-inline-start">
-   <b><a href="#propdef-scroll-padding-inline-start">#propdef-scroll-padding-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-inline-start" class="dfn-panel" data-for="propdef-scroll-padding-inline-start" id="infopanel-for-propdef-scroll-padding-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-inline-start" style="display:none">Info about the 'scroll-padding-inline-start' definition.</span><b><a href="#propdef-scroll-padding-inline-start">#propdef-scroll-padding-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline-start">Flow-relative Longhands for scroll-padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-block-start">
-   <b><a href="#propdef-scroll-padding-block-start">#propdef-scroll-padding-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-block-start" class="dfn-panel" data-for="propdef-scroll-padding-block-start" id="infopanel-for-propdef-scroll-padding-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-block-start" style="display:none">Info about the 'scroll-padding-block-start' definition.</span><b><a href="#propdef-scroll-padding-block-start">#propdef-scroll-padding-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block-start">Flow-relative Longhands for scroll-padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-inline-end">
-   <b><a href="#propdef-scroll-padding-inline-end">#propdef-scroll-padding-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-inline-end" class="dfn-panel" data-for="propdef-scroll-padding-inline-end" id="infopanel-for-propdef-scroll-padding-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-inline-end" style="display:none">Info about the 'scroll-padding-inline-end' definition.</span><b><a href="#propdef-scroll-padding-inline-end">#propdef-scroll-padding-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline-end">Flow-relative Longhands for scroll-padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-block-end">
-   <b><a href="#propdef-scroll-padding-block-end">#propdef-scroll-padding-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-block-end" class="dfn-panel" data-for="propdef-scroll-padding-block-end" id="infopanel-for-propdef-scroll-padding-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-block-end" style="display:none">Info about the 'scroll-padding-block-end' definition.</span><b><a href="#propdef-scroll-padding-block-end">#propdef-scroll-padding-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block-end">Flow-relative Longhands for scroll-padding</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-block">
-   <b><a href="#propdef-scroll-padding-block">#propdef-scroll-padding-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-block" class="dfn-panel" data-for="propdef-scroll-padding-block" id="infopanel-for-propdef-scroll-padding-block" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-block" style="display:none">Info about the 'scroll-padding-block' definition.</span><b><a href="#propdef-scroll-padding-block">#propdef-scroll-padding-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-block">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-padding-inline">
-   <b><a href="#propdef-scroll-padding-inline">#propdef-scroll-padding-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-padding-inline" class="dfn-panel" data-for="propdef-scroll-padding-inline" id="infopanel-for-propdef-scroll-padding-inline" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-padding-inline" style="display:none">Info about the 'scroll-padding-inline' definition.</span><b><a href="#propdef-scroll-padding-inline">#propdef-scroll-padding-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-padding-inline">9.1. Changes Since 19 March 2019 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-margin-block-start">
-   <b><a href="#propdef-scroll-margin-block-start">#propdef-scroll-margin-block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-margin-block-start" class="dfn-panel" data-for="propdef-scroll-margin-block-start" id="infopanel-for-propdef-scroll-margin-block-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-margin-block-start" style="display:none">Info about the 'scroll-margin-block-start' definition.</span><b><a href="#propdef-scroll-margin-block-start">#propdef-scroll-margin-block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-block-start">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-margin-inline-start">
-   <b><a href="#propdef-scroll-margin-inline-start">#propdef-scroll-margin-inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-margin-inline-start" class="dfn-panel" data-for="propdef-scroll-margin-inline-start" id="infopanel-for-propdef-scroll-margin-inline-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-margin-inline-start" style="display:none">Info about the 'scroll-margin-inline-start' definition.</span><b><a href="#propdef-scroll-margin-inline-start">#propdef-scroll-margin-inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-inline-start">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-margin-block-end">
-   <b><a href="#propdef-scroll-margin-block-end">#propdef-scroll-margin-block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-margin-block-end" class="dfn-panel" data-for="propdef-scroll-margin-block-end" id="infopanel-for-propdef-scroll-margin-block-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-margin-block-end" style="display:none">Info about the 'scroll-margin-block-end' definition.</span><b><a href="#propdef-scroll-margin-block-end">#propdef-scroll-margin-block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-block-end">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-margin-inline-end">
-   <b><a href="#propdef-scroll-margin-inline-end">#propdef-scroll-margin-inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-margin-inline-end" class="dfn-panel" data-for="propdef-scroll-margin-inline-end" id="infopanel-for-propdef-scroll-margin-inline-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-margin-inline-end" style="display:none">Info about the 'scroll-margin-inline-end' definition.</span><b><a href="#propdef-scroll-margin-inline-end">#propdef-scroll-margin-inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-margin-inline-end">Flow-relative Longhands for scroll-margin</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-scrollbars-1/Overview.html
@@ -1314,34 +1314,34 @@ or on overflowing elements with scrollbars in the page.</p>
    <li><a href="#propdef-scrollbar-width">scrollbar-width</a><span>, in § 3</span>
    <li><a href="#valdef-scrollbar-width-thin">thin</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-typedef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-propdef-overflow①">(2)</a>
     <li><a href="#ref-for-propdef-overflow②">3. Scrollbar Thickness: the scrollbar-width property</a> <a href="#ref-for-propdef-overflow③">(2)</a> <a href="#ref-for-propdef-overflow④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">2. Scrollbar Colors: the scrollbar-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">3. Scrollbar Thickness: the scrollbar-width property</a> <a href="#ref-for-comb-one④">(2)</a>
@@ -1425,103 +1425,159 @@ Value Definitions</a>
       <td>specified keyword or absolute length
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-scrollbar-color">
-   <b><a href="#propdef-scrollbar-color">#propdef-scrollbar-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scrollbar-color" class="dfn-panel" data-for="propdef-scrollbar-color" id="infopanel-for-propdef-scrollbar-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-scrollbar-color" style="display:none">Info about the 'scrollbar-color' definition.</span><b><a href="#propdef-scrollbar-color">#propdef-scrollbar-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scrollbar-color">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-propdef-scrollbar-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-color-auto">
-   <b><a href="#valdef-scrollbar-color-auto">#valdef-scrollbar-color-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-color-auto" class="dfn-panel" data-for="valdef-scrollbar-color-auto" id="infopanel-for-valdef-scrollbar-color-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-color-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-scrollbar-color-auto">#valdef-scrollbar-color-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-color-auto">2. Scrollbar Colors: the scrollbar-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-color-dark">
-   <b><a href="#valdef-scrollbar-color-dark">#valdef-scrollbar-color-dark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-color-dark" class="dfn-panel" data-for="valdef-scrollbar-color-dark" id="infopanel-for-valdef-scrollbar-color-dark" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-color-dark" style="display:none">Info about the 'dark' definition.</span><b><a href="#valdef-scrollbar-color-dark">#valdef-scrollbar-color-dark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-color-dark">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-valdef-scrollbar-color-dark①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-color-light">
-   <b><a href="#valdef-scrollbar-color-light">#valdef-scrollbar-color-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-color-light" class="dfn-panel" data-for="valdef-scrollbar-color-light" id="infopanel-for-valdef-scrollbar-color-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-color-light" style="display:none">Info about the 'light' definition.</span><b><a href="#valdef-scrollbar-color-light">#valdef-scrollbar-color-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-color-light">2. Scrollbar Colors: the scrollbar-color property</a> <a href="#ref-for-valdef-scrollbar-color-light①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scrollbar-width">
-   <b><a href="#propdef-scrollbar-width">#propdef-scrollbar-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scrollbar-width" class="dfn-panel" data-for="propdef-scrollbar-width" id="infopanel-for-propdef-scrollbar-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-scrollbar-width" style="display:none">Info about the 'scrollbar-width' definition.</span><b><a href="#propdef-scrollbar-width">#propdef-scrollbar-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scrollbar-width">3. Scrollbar Thickness: the scrollbar-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-width-auto">
-   <b><a href="#valdef-scrollbar-width-auto">#valdef-scrollbar-width-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-width-auto" class="dfn-panel" data-for="valdef-scrollbar-width-auto" id="infopanel-for-valdef-scrollbar-width-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-width-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-scrollbar-width-auto">#valdef-scrollbar-width-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-width-auto">3. Scrollbar Thickness: the scrollbar-width property</a> <a href="#ref-for-valdef-scrollbar-width-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scrollbar-width-none">
-   <b><a href="#valdef-scrollbar-width-none">#valdef-scrollbar-width-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scrollbar-width-none" class="dfn-panel" data-for="valdef-scrollbar-width-none" id="infopanel-for-valdef-scrollbar-width-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-scrollbar-width-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-scrollbar-width-none">#valdef-scrollbar-width-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scrollbar-width-none">3. Scrollbar Thickness: the scrollbar-width property</a> <a href="#ref-for-valdef-scrollbar-width-none①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-shadow-parts-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shadow-parts-1/Overview.html
@@ -1529,45 +1529,45 @@ This allows clients to skip over new syntax that is not understood.</p>
    <li><a href="#valid-list-of-part-mappings">valid list of part mappings</a><span>, in § 5.2</span>
    <li><a href="#valid-part-mapping">valid part mapping</a><span>, in § 5.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3. Selecting a Shadow Element: the ::part() pseudo-element</a> <a href="#ref-for-typedef-ident①">(2)</a> <a href="#ref-for-typedef-ident②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">1. Introduction</a>
     <li><a href="#ref-for-custom-property①">1.1. Motivation</a> <a href="#ref-for-custom-property②">(2)</a> <a href="#ref-for-custom-property③">(3)</a> <a href="#ref-for-custom-property④">(4)</a> <a href="#ref-for-custom-property⑤">(5)</a> <a href="#ref-for-custom-property⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domtokenlist">
-   <a href="https://dom.spec.whatwg.org/#domtokenlist">https://dom.spec.whatwg.org/#domtokenlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domtokenlist" class="dfn-panel" data-for="term-for-domtokenlist" id="infopanel-for-term-for-domtokenlist" role="menu">
+   <span id="infopaneltitle-for-term-for-domtokenlist" style="display:none">Info about the 'DOMTokenList' external reference.</span><a href="https://dom.spec.whatwg.org/#domtokenlist">https://dom.spec.whatwg.org/#domtokenlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domtokenlist">4. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">4. Extensions to the Element Interface</a> <a href="#ref-for-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">2. Exposing a Shadow Element:</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-shadow-host">
-   <a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-shadow-host" class="dfn-panel" data-for="term-for-element-shadow-host" id="infopanel-for-term-for-element-shadow-host" role="menu">
+   <span id="infopaneltitle-for-term-for-element-shadow-host" style="display:none">Info about the 'shadow host' external reference.</span><a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-shadow-host">Unnumbered Section</a> <a href="#ref-for-element-shadow-host①">(2)</a>
     <li><a href="#ref-for-element-shadow-host②">1.1. Motivation</a>
@@ -1575,15 +1575,15 @@ This allows clients to skip over new syntax that is not understood.</p>
     <li><a href="#ref-for-element-shadow-host④">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-root" class="dfn-panel" data-for="term-for-concept-shadow-root" id="infopanel-for-term-for-concept-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">2. Exposing a Shadow Element:</a>
     <li><a href="#ref-for-concept-shadow-root①">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">Unnumbered Section</a>
     <li><a href="#ref-for-concept-shadow-tree①">1. Introduction</a>
@@ -1592,75 +1592,75 @@ This allows clients to skip over new syntax that is not understood.</p>
     <li><a href="#ref-for-concept-shadow-tree④">2.2. Forwarding a Shadow Element: the exportparts attribute</a> <a href="#ref-for-concept-shadow-tree⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domtokenlist-value">
-   <a href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">https://dom.spec.whatwg.org/#dom-domtokenlist-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domtokenlist-value" class="dfn-panel" data-for="term-for-dom-domtokenlist-value" id="infopanel-for-term-for-dom-domtokenlist-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domtokenlist-value" style="display:none">Info about the 'value' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-domtokenlist-value">https://dom.spec.whatwg.org/#dom-domtokenlist-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-value">4. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2. Exposing a Shadow Element:</a> <a href="#ref-for-list-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collect a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">5.1. Rules for parsing part mappings</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points②">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points③">(4)</a> <a href="#ref-for-collect-a-sequence-of-code-points④">(5)</a> <a href="#ref-for-collect-a-sequence-of-code-points⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2. Exposing a Shadow Element:</a>
     <li><a href="#ref-for-list①">5.2. Rules for parsing a list of part mappings</a> <a href="#ref-for-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2. Exposing a Shadow Element:</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2. Exposing a Shadow Element:</a> <a href="#ref-for-string①">(2)</a> <a href="#ref-for-string②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hover-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#hover-pseudo">https://drafts.csswg.org/selectors-4/#hover-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hover-pseudo" class="dfn-panel" data-for="term-for-hover-pseudo" id="infopanel-for-term-for-hover-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-hover-pseudo" style="display:none">Info about the ':hover' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#hover-pseudo">https://drafts.csswg.org/selectors-4/#hover-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hover-pseudo">1.1. Motivation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">3. Selecting a Shadow Element: the ::part() pseudo-element</a> <a href="#ref-for-originating-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structural-pseudo-classes">
-   <a href="https://drafts.csswg.org/selectors-4/#structural-pseudo-classes">https://drafts.csswg.org/selectors-4/#structural-pseudo-classes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structural-pseudo-classes" class="dfn-panel" data-for="term-for-structural-pseudo-classes" id="infopanel-for-term-for-structural-pseudo-classes" role="menu">
+   <span id="infopaneltitle-for-term-for-structural-pseudo-classes" style="display:none">Info about the 'structural pseudo-classes' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#structural-pseudo-classes">https://drafts.csswg.org/selectors-4/#structural-pseudo-classes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structural-pseudo-classes">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">4. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4. Extensions to the Element Interface</a>
    </ul>
@@ -1741,48 +1741,48 @@ This allows clients to skip over new syntax that is not understood.</p>
   <div style="counter-reset:issue">
    <div class="issue"> Define this as a superglobal in the DOM spec. <a href="https://github.com/w3c/csswg-drafts/issues/3424">[Issue #w3c/csswg-drafts#3424]</a> <a class="issue-return" href="#issue-853df044" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="element-part-name-list">
-   <b><a href="#element-part-name-list">#element-part-name-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-part-name-list" class="dfn-panel" data-for="element-part-name-list" id="infopanel-for-element-part-name-list" role="dialog">
+   <span id="infopaneltitle-for-element-part-name-list" style="display:none">Info about the 'part name list' definition.</span><b><a href="#element-part-name-list">#element-part-name-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-part-name-list">2. Exposing a Shadow Element:</a> <a href="#ref-for-element-part-name-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-forwarded-part-name-list">
-   <b><a href="#element-forwarded-part-name-list">#element-forwarded-part-name-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-forwarded-part-name-list" class="dfn-panel" data-for="element-forwarded-part-name-list" id="infopanel-for-element-forwarded-part-name-list" role="dialog">
+   <span id="infopaneltitle-for-element-forwarded-part-name-list" style="display:none">Info about the 'forwarded part name list' definition.</span><b><a href="#element-forwarded-part-name-list">#element-forwarded-part-name-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-forwarded-part-name-list">2. Exposing a Shadow Element:</a> <a href="#ref-for-element-forwarded-part-name-list①">(2)</a>
     <li><a href="#ref-for-element-forwarded-part-name-list②">2.2. Forwarding a Shadow Element: the exportparts attribute</a> <a href="#ref-for-element-forwarded-part-name-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadow-root-part-element-map">
-   <b><a href="#shadow-root-part-element-map">#shadow-root-part-element-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadow-root-part-element-map" class="dfn-panel" data-for="shadow-root-part-element-map" id="infopanel-for-shadow-root-part-element-map" role="dialog">
+   <span id="infopaneltitle-for-shadow-root-part-element-map" style="display:none">Info about the 'part element map' definition.</span><b><a href="#shadow-root-part-element-map">#shadow-root-part-element-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-root-part-element-map">1.1. Motivation</a>
     <li><a href="#ref-for-shadow-root-part-element-map①">2. Exposing a Shadow Element:</a> <a href="#ref-for-shadow-root-part-element-map②">(2)</a> <a href="#ref-for-shadow-root-part-element-map③">(3)</a> <a href="#ref-for-shadow-root-part-element-map④">(4)</a> <a href="#ref-for-shadow-root-part-element-map⑤">(5)</a> <a href="#ref-for-shadow-root-part-element-map⑥">(6)</a> <a href="#ref-for-shadow-root-part-element-map⑦">(7)</a>
     <li><a href="#ref-for-shadow-root-part-element-map⑧">3. Selecting a Shadow Element: the ::part() pseudo-element</a> <a href="#ref-for-shadow-root-part-element-map⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-the-part-element-map">
-   <b><a href="#calculate-the-part-element-map">#calculate-the-part-element-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculate-the-part-element-map" class="dfn-panel" data-for="calculate-the-part-element-map" id="infopanel-for-calculate-the-part-element-map" role="dialog">
+   <span id="infopaneltitle-for-calculate-the-part-element-map" style="display:none">Info about the 'calculate the part element map' definition.</span><b><a href="#calculate-the-part-element-map">#calculate-the-part-element-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-the-part-element-map">2. Exposing a Shadow Element:</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-html-global-part">
-   <b><a href="#element-attrdef-html-global-part">#element-attrdef-html-global-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-html-global-part" class="dfn-panel" data-for="element-attrdef-html-global-part" id="infopanel-for-element-attrdef-html-global-part" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-html-global-part" style="display:none">Info about the 'part' definition.</span><b><a href="#element-attrdef-html-global-part">#element-attrdef-html-global-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-html-global-part">2.1. Naming a Shadow Element: the part attribute</a>
     <li><a href="#ref-for-element-attrdef-html-global-part①">3. Selecting a Shadow Element: the ::part() pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-html-global-exportparts">
-   <b><a href="#element-attrdef-html-global-exportparts">#element-attrdef-html-global-exportparts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-html-global-exportparts" class="dfn-panel" data-for="element-attrdef-html-global-exportparts" id="infopanel-for-element-attrdef-html-global-exportparts" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-html-global-exportparts" style="display:none">Info about the 'exportparts' definition.</span><b><a href="#element-attrdef-html-global-exportparts">#element-attrdef-html-global-exportparts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-html-global-exportparts">2.2. Forwarding a Shadow Element: the exportparts attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-part">
-   <b><a href="#selectordef-part">#selectordef-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-part" class="dfn-panel" data-for="selectordef-part" id="infopanel-for-selectordef-part" role="dialog">
+   <span id="infopaneltitle-for-selectordef-part" style="display:none">Info about the '::part()' definition.</span><b><a href="#selectordef-part">#selectordef-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-part①">1. Introduction</a>
     <li><a href="#ref-for-selectordef-part②">1.1. Motivation</a> <a href="#ref-for-selectordef-part③">(2)</a> <a href="#ref-for-selectordef-part④">(3)</a>
@@ -1791,59 +1791,115 @@ This allows clients to skip over new syntax that is not understood.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shapes-1/Overview.html
@@ -2077,22 +2077,22 @@ serializes as "circle(at 95% 0%)"
    <li><a href="#wrap">wrap</a><span>, in § 1.4</span>
    <li><a href="#wrap">wrapping</a><span>, in § 1.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">1.4. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-alpha-value">
-   <a href="https://drafts.csswg.org/css-color-5/#typedef-alpha-value">https://drafts.csswg.org/css-color-5/#typedef-alpha-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-alpha-value" class="dfn-panel" data-for="term-for-typedef-alpha-value" id="infopanel-for-term-for-typedef-alpha-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-alpha-value" style="display:none">Info about the '&lt;alpha-value>' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#typedef-alpha-value">https://drafts.csswg.org/css-color-5/#typedef-alpha-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-alpha-value">6.2. 
 Choosing Image Pixels: the shape-image-threshold property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">4. 
 Shapes from Image</a>
@@ -2101,22 +2101,22 @@ Float Area Shape: the shape-outside property</a> <a href="#ref-for-typedef-image
     <li><a href="#ref-for-typedef-image⑤">7. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">3.1. 
 Supported Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-rule-evenodd">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-evenodd">https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-evenodd</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-rule-evenodd" class="dfn-panel" data-for="term-for-valdef-clip-rule-evenodd" id="infopanel-for-term-for-valdef-clip-rule-evenodd" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-rule-evenodd" style="display:none">Info about the 'evenodd' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-evenodd">https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-evenodd</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-rule-evenodd">3.1. 
 Supported Shapes</a> <a href="#ref-for-valdef-clip-rule-evenodd①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-rule-nonzero">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-nonzero">https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-nonzero</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-rule-nonzero" class="dfn-panel" data-for="term-for-valdef-clip-rule-nonzero" id="infopanel-for-term-for-valdef-clip-rule-nonzero" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-rule-nonzero" style="display:none">Info about the 'nonzero' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-nonzero">https://drafts.fxtf.org/css-masking-1/#valdef-clip-rule-nonzero</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-rule-nonzero">3.1. 
 Supported Shapes</a> <a href="#ref-for-valdef-clip-rule-nonzero①">(2)</a> <a href="#ref-for-valdef-clip-rule-nonzero②">(3)</a> <a href="#ref-for-valdef-clip-rule-nonzero③">(4)</a>
@@ -2124,8 +2124,8 @@ Supported Shapes</a> <a href="#ref-for-valdef-clip-rule-nonzero①">(2)</a> <a h
 Interpolation of Basic Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1. 
 Supported Shapes</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a>
@@ -2135,15 +2135,15 @@ Computed Values of Basic Shapes</a> <a href="#ref-for-typedef-length-percentage�
 Expanding a Shape: the shape-margin property</a> <a href="#ref-for-typedef-length-percentage⑦">(2)</a> <a href="#ref-for-typedef-length-percentage⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">6.2. 
 Choosing Image Pixels: the shape-image-threshold property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">3.1. 
 Supported Shapes</a> <a href="#ref-for-typedef-position①">(2)</a>
@@ -2153,63 +2153,63 @@ Computed Values of Basic Shapes</a>
 Serialization of Basic Shapes</a> <a href="#ref-for-typedef-position④">(2)</a> <a href="#ref-for-typedef-position⑤">(3)</a> <a href="#ref-for-typedef-position⑥">(4)</a> <a href="#ref-for-typedef-position⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.1. 
 Supported Shapes</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">6.1. 
 Float Area Shape: the shape-outside property</a> <a href="#ref-for-comb-one①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">6.1. 
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">6.3. 
 Expanding a Shape: the shape-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin">https://drafts.csswg.org/css2/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.1. 
 Supported Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-box" class="dfn-panel" data-for="term-for-typedef-box" id="infopanel-for-term-for-typedef-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-box" style="display:none">Info about the '&lt;box>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-box">5. 
 Shapes from Box Values</a> <a href="#ref-for-typedef-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">6.1. 
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">3.1. 
 Supported Shapes</a> <a href="#ref-for-propdef-border-radius①">(2)</a> <a href="#ref-for-propdef-border-radius②">(3)</a>
@@ -2217,8 +2217,8 @@ Supported Shapes</a> <a href="#ref-for-propdef-border-radius①">(2)</a> <a href
 Computed Values of Basic Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillRuleProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillRuleProperty" class="dfn-panel" data-for="term-for-FillRuleProperty" id="infopanel-for-term-for-FillRuleProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillRuleProperty" style="display:none">Info about the 'fill-rule' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillRuleProperty">3.1. 
 Supported Shapes</a> <a href="#ref-for-FillRuleProperty①">(2)</a> <a href="#ref-for-FillRuleProperty②">(3)</a> <a href="#ref-for-FillRuleProperty③">(4)</a>
@@ -2370,8 +2370,8 @@ Interpolation of Basic Shapes</a>
       <td>as defined for &lt;basic-shape> (with &lt;shape-box> following, if supplied); else the computed &lt;image>; else the keyword as specified
    </table>
   </div>
-  <aside class="dfn-panel" data-for="wrap">
-   <b><a href="#wrap">#wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wrap" class="dfn-panel" data-for="wrap" id="infopanel-for-wrap" role="dialog">
+   <span id="infopaneltitle-for-wrap" style="display:none">Info about the 'Wrap' definition.</span><b><a href="#wrap">#wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wrap①">1. 
 Introduction</a>
@@ -2383,8 +2383,8 @@ Relation to the box model and float behavior</a> <a href="#ref-for-wrap⑧">(2)<
 Expanding a Shape: the shape-margin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-area">
-   <b><a href="#float-area">#float-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-area" class="dfn-panel" data-for="float-area" id="infopanel-for-float-area" role="dialog">
+   <span id="infopaneltitle-for-float-area" style="display:none">Info about the 'Float area' definition.</span><b><a href="#float-area">#float-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-area">1. 
 Introduction</a> <a href="#ref-for-float-area①">(2)</a>
@@ -2400,8 +2400,8 @@ Declaring Shapes</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-basic-shape">
-   <b><a href="#typedef-basic-shape">#typedef-basic-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-basic-shape" class="dfn-panel" data-for="typedef-basic-shape" id="infopanel-for-typedef-basic-shape" role="dialog">
+   <span id="infopaneltitle-for-typedef-basic-shape" style="display:none">Info about the '&lt;basic-shape>' definition.</span><b><a href="#typedef-basic-shape">#typedef-basic-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-basic-shape">3. 
 Basic Shapes</a>
@@ -2415,8 +2415,8 @@ Serialization of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a> <a href="#ref-for-typedef-basic-shape⑤">(2)</a> <a href="#ref-for-typedef-basic-shape⑥">(3)</a> <a href="#ref-for-typedef-basic-shape⑦">(4)</a> <a href="#ref-for-typedef-basic-shape⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reference-box">
-   <b><a href="#reference-box">#reference-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reference-box" class="dfn-panel" data-for="reference-box" id="infopanel-for-reference-box" role="dialog">
+   <span id="infopaneltitle-for-reference-box" style="display:none">Info about the 'reference box' definition.</span><b><a href="#reference-box">#reference-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-box">3. 
 Basic Shapes</a> <a href="#ref-for-reference-box①">(2)</a>
@@ -2428,8 +2428,8 @@ Interpolation of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a> <a href="#ref-for-reference-box⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-inset">
-   <b><a href="#funcdef-inset">#funcdef-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-inset" class="dfn-panel" data-for="funcdef-inset" id="infopanel-for-funcdef-inset" role="dialog">
+   <span id="infopaneltitle-for-funcdef-inset" style="display:none">Info about the 'inset()' definition.</span><b><a href="#funcdef-inset">#funcdef-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-inset">3.2. 
 Computed Values of Basic Shapes</a>
@@ -2439,8 +2439,8 @@ Interpolation of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-circle">
-   <b><a href="#funcdef-circle">#funcdef-circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-circle" class="dfn-panel" data-for="funcdef-circle" id="infopanel-for-funcdef-circle" role="dialog">
+   <span id="infopaneltitle-for-funcdef-circle" style="display:none">Info about the 'circle()' definition.</span><b><a href="#funcdef-circle">#funcdef-circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-circle">3.2. 
 Computed Values of Basic Shapes</a>
@@ -2450,8 +2450,8 @@ Interpolation of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-ellipse">
-   <b><a href="#funcdef-ellipse">#funcdef-ellipse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-ellipse" class="dfn-panel" data-for="funcdef-ellipse" id="infopanel-for-funcdef-ellipse" role="dialog">
+   <span id="infopaneltitle-for-funcdef-ellipse" style="display:none">Info about the 'ellipse()' definition.</span><b><a href="#funcdef-ellipse">#funcdef-ellipse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-ellipse">3.2. 
 Computed Values of Basic Shapes</a>
@@ -2461,8 +2461,8 @@ Interpolation of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-polygon">
-   <b><a href="#funcdef-polygon">#funcdef-polygon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-polygon" class="dfn-panel" data-for="funcdef-polygon" id="infopanel-for-funcdef-polygon" role="dialog">
+   <span id="infopaneltitle-for-funcdef-polygon" style="display:none">Info about the 'polygon()' definition.</span><b><a href="#funcdef-polygon">#funcdef-polygon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-polygon">3.4. 
 Interpolation of Basic Shapes</a>
@@ -2470,29 +2470,29 @@ Interpolation of Basic Shapes</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-radius">
-   <b><a href="#typedef-shape-radius">#typedef-shape-radius</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-radius" class="dfn-panel" data-for="typedef-shape-radius" id="infopanel-for-typedef-shape-radius" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-radius" style="display:none">Info about the '&lt;shape-radius>' definition.</span><b><a href="#typedef-shape-radius">#typedef-shape-radius</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-radius">3.1. 
 Supported Shapes</a> <a href="#ref-for-typedef-shape-radius①">(2)</a> <a href="#ref-for-typedef-shape-radius②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="closest-side">
-   <b><a href="#closest-side">#closest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-closest-side" class="dfn-panel" data-for="closest-side" id="infopanel-for-closest-side" role="dialog">
+   <span id="infopaneltitle-for-closest-side" style="display:none">Info about the 'closest-side' definition.</span><b><a href="#closest-side">#closest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-closest-side">3.4. 
 Interpolation of Basic Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="farthest-side">
-   <b><a href="#farthest-side">#farthest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-farthest-side" class="dfn-panel" data-for="farthest-side" id="infopanel-for-farthest-side" role="dialog">
+   <span id="infopaneltitle-for-farthest-side" style="display:none">Info about the 'farthest-side' definition.</span><b><a href="#farthest-side">#farthest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-farthest-side">3.4. 
 Interpolation of Basic Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-box">
-   <b><a href="#typedef-shape-box">#typedef-shape-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-box" class="dfn-panel" data-for="typedef-shape-box" id="infopanel-for-typedef-shape-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-box" style="display:none">Info about the '&lt;shape-box>' definition.</span><b><a href="#typedef-shape-box">#typedef-shape-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-box">5. 
 Shapes from Box Values</a> <a href="#ref-for-typedef-shape-box①">(2)</a>
@@ -2500,8 +2500,8 @@ Shapes from Box Values</a> <a href="#ref-for-typedef-shape-box①">(2)</a>
 Float Area Shape: the shape-outside property</a> <a href="#ref-for-typedef-shape-box③">(2)</a> <a href="#ref-for-typedef-shape-box④">(3)</a> <a href="#ref-for-typedef-shape-box⑤">(4)</a> <a href="#ref-for-typedef-shape-box⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-box-margin-box">
-   <b><a href="#valdef-shape-box-margin-box">#valdef-shape-box-margin-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-box-margin-box" class="dfn-panel" data-for="valdef-shape-box-margin-box" id="infopanel-for-valdef-shape-box-margin-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-box-margin-box" style="display:none">Info about the 'margin-box' definition.</span><b><a href="#valdef-shape-box-margin-box">#valdef-shape-box-margin-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-box-margin-box">1.4. 
 Terminology</a>
@@ -2511,8 +2511,8 @@ Shapes from Box Values</a> <a href="#ref-for-valdef-shape-box-margin-box②">(2)
 Float Area Shape: the shape-outside property</a> <a href="#ref-for-valdef-shape-box-margin-box⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-box-border-box">
-   <b><a href="#valdef-shape-box-border-box">#valdef-shape-box-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-box-border-box" class="dfn-panel" data-for="valdef-shape-box-border-box" id="infopanel-for-valdef-shape-box-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-box-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-shape-box-border-box">#valdef-shape-box-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-box-border-box">5. 
 Shapes from Box Values</a>
@@ -2520,8 +2520,8 @@ Shapes from Box Values</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-box-padding-box">
-   <b><a href="#valdef-shape-box-padding-box">#valdef-shape-box-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-box-padding-box" class="dfn-panel" data-for="valdef-shape-box-padding-box" id="infopanel-for-valdef-shape-box-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-box-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-shape-box-padding-box">#valdef-shape-box-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-box-padding-box">5. 
 Shapes from Box Values</a>
@@ -2529,8 +2529,8 @@ Shapes from Box Values</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-box-content-box">
-   <b><a href="#valdef-shape-box-content-box">#valdef-shape-box-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-box-content-box" class="dfn-panel" data-for="valdef-shape-box-content-box" id="infopanel-for-valdef-shape-box-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-box-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-shape-box-content-box">#valdef-shape-box-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-box-content-box">5. 
 Shapes from Box Values</a>
@@ -2538,8 +2538,8 @@ Shapes from Box Values</a>
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-outside">
-   <b><a href="#propdef-shape-outside">#propdef-shape-outside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-outside" class="dfn-panel" data-for="propdef-shape-outside" id="infopanel-for-propdef-shape-outside" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-outside" style="display:none">Info about the 'shape-outside' definition.</span><b><a href="#propdef-shape-outside">#propdef-shape-outside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-outside">1. 
 Introduction</a> <a href="#ref-for-propdef-shape-outside①">(2)</a>
@@ -2560,15 +2560,15 @@ Expanding a Shape: the shape-margin property</a> <a href="#ref-for-propdef-shape
     <li><a href="#ref-for-propdef-shape-outside①⑤">7. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-outside-none">
-   <b><a href="#valdef-shape-outside-none">#valdef-shape-outside-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-outside-none" class="dfn-panel" data-for="valdef-shape-outside-none" id="infopanel-for-valdef-shape-outside-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-outside-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-shape-outside-none">#valdef-shape-outside-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-outside-none">6.1. 
 Float Area Shape: the shape-outside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-image-threshold">
-   <b><a href="#propdef-shape-image-threshold">#propdef-shape-image-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-image-threshold" class="dfn-panel" data-for="propdef-shape-image-threshold" id="infopanel-for-propdef-shape-image-threshold" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-image-threshold" style="display:none">Info about the 'shape-image-threshold' definition.</span><b><a href="#propdef-shape-image-threshold">#propdef-shape-image-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-image-threshold">4. 
 Shapes from Image</a> <a href="#ref-for-propdef-shape-image-threshold①">(2)</a> <a href="#ref-for-propdef-shape-image-threshold②">(3)</a>
@@ -2578,8 +2578,8 @@ Float Area Shape: the shape-outside property</a>
 Choosing Image Pixels: the shape-image-threshold property</a> <a href="#ref-for-propdef-shape-image-threshold⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-margin">
-   <b><a href="#propdef-shape-margin">#propdef-shape-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-margin" class="dfn-panel" data-for="propdef-shape-margin" id="infopanel-for-propdef-shape-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-margin" style="display:none">Info about the 'shape-margin' definition.</span><b><a href="#propdef-shape-margin">#propdef-shape-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-margin">4. 
 Shapes from Image</a>
@@ -2591,59 +2591,115 @@ Expanding a Shape: the shape-margin property</a> <a href="#ref-for-propdef-shape
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-shapes-2/Overview.html
@@ -1766,50 +1766,50 @@ and <a class="production css" data-link-type="type" href="#typedef-shape-arc-siz
    <li><a href="#valdef-shape-inside-url">&lt;url></a><span>, in § 8.2</span>
    <li><a href="#valdef-shape-vline">vline</a><span>, in § 4.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-basic-shape">
-   <a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-basic-shape" class="dfn-panel" data-for="term-for-typedef-basic-shape" id="infopanel-for-term-for-typedef-basic-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-basic-shape" style="display:none">Info about the '&lt;basic-shape>' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-basic-shape">8.2. 
 The shape-inside Property</a> <a href="#ref-for-typedef-basic-shape①">(2)</a> <a href="#ref-for-typedef-basic-shape②">(3)</a> <a href="#ref-for-typedef-basic-shape③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-circle">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-circle" class="dfn-panel" data-for="term-for-funcdef-basic-shape-circle" id="infopanel-for-term-for-funcdef-basic-shape-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-circle" style="display:none">Info about the 'circle()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-circle">4.1.1. 
 The shape() Function</a>
@@ -1817,22 +1817,22 @@ The shape() Function</a>
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-ellipse">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-ellipse" class="dfn-panel" data-for="term-for-funcdef-basic-shape-ellipse" id="infopanel-for-term-for-funcdef-basic-shape-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-ellipse" style="display:none">Info about the 'ellipse()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-ellipse">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-inset">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-inset" class="dfn-panel" data-for="term-for-funcdef-basic-shape-inset" id="infopanel-for-term-for-funcdef-basic-shape-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-inset" style="display:none">Info about the 'inset()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-inset">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-path">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-path" class="dfn-panel" data-for="term-for-funcdef-basic-shape-path" id="infopanel-for-term-for-funcdef-basic-shape-path" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-path" style="display:none">Info about the 'path()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-path">4.1.1. 
 The shape() Function</a> <a href="#ref-for-funcdef-basic-shape-path①">(2)</a>
@@ -1840,22 +1840,22 @@ The shape() Function</a> <a href="#ref-for-funcdef-basic-shape-path①">(2)</a>
 Interpolating the shape() Function</a> <a href="#ref-for-funcdef-basic-shape-path③">(2)</a> <a href="#ref-for-funcdef-basic-shape-path④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon" id="infopanel-for-term-for-funcdef-basic-shape-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" style="display:none">Info about the 'polygon()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-polygon">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-basic-shape-reference-box">
-   <a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-basic-shape-reference-box" class="dfn-panel" data-for="term-for-basic-shape-reference-box" id="infopanel-for-term-for-basic-shape-reference-box" role="menu">
+   <span id="infopaneltitle-for-term-for-basic-shape-reference-box" style="display:none">Info about the 'reference box' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box">https://drafts.csswg.org/css-shapes-1/#basic-shape-reference-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-shape-reference-box">4.1.1. 
 The shape() Function</a> <a href="#ref-for-basic-shape-reference-box①">(2)</a> <a href="#ref-for-basic-shape-reference-box②">(3)</a> <a href="#ref-for-basic-shape-reference-box③">(4)</a> <a href="#ref-for-basic-shape-reference-box④">(5)</a> <a href="#ref-for-basic-shape-reference-box⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-margin">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-margin" class="dfn-panel" data-for="term-for-propdef-shape-margin" id="infopanel-for-term-for-propdef-shape-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-margin" style="display:none">Info about the 'shape-margin' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-margin">8. 
 Declaring Shapes</a> <a href="#ref-for-propdef-shape-margin①">(2)</a>
@@ -1865,8 +1865,8 @@ The shape-margin property</a>
 The shape-padding Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-outside">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside">https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-outside" class="dfn-panel" data-for="term-for-propdef-shape-outside" id="infopanel-for-term-for-propdef-shape-outside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-outside" style="display:none">Info about the 'shape-outside' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside">https://drafts.csswg.org/css-shapes-1/#propdef-shape-outside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-outside">2. 
 Terminology</a> <a href="#ref-for-propdef-shape-outside①">(2)</a>
@@ -1878,106 +1878,106 @@ The shape-outside Property</a>
 The shape-image-threshold Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-rotate" class="dfn-panel" data-for="term-for-funcdef-transform-rotate" id="infopanel-for-term-for-funcdef-transform-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-rotate" style="display:none">Info about the 'rotate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-rotate">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">4.1.1. 
 The shape() Function</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a> <a href="#ref-for-angle-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a> <a href="#ref-for-typedef-length-percentage④">(5)</a> <a href="#ref-for-typedef-length-percentage⑤">(6)</a> <a href="#ref-for-typedef-length-percentage⑥">(7)</a> <a href="#ref-for-typedef-length-percentage⑦">(8)</a> <a href="#ref-for-typedef-length-percentage⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">8.6. 
 The shape-padding Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.1.1. 
 The shape() Function</a> <a href="#ref-for-percentage-value①">(2)</a> <a href="#ref-for-percentage-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">8.2. 
 The shape-inside Property</a> <a href="#ref-for-url-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.1.1. 
 The shape() Function</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation" style="display:none">Info about the 'interpolate' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">4.1.1.1. 
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4.1.1. 
 The shape() Function</a> <a href="#ref-for-mult-num-range①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1.1. 
 The shape() Function</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a>
@@ -1985,8 +1985,8 @@ The shape() Function</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-fo
 The shape-inside Property</a> <a href="#ref-for-comb-one①①">(2)</a> <a href="#ref-for-comb-one①②">(3)</a> <a href="#ref-for-comb-one①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.1.1. 
 The shape() Function</a> <a href="#ref-for-comb-any①">(2)</a>
@@ -1994,22 +1994,22 @@ The shape() Function</a> <a href="#ref-for-comb-any①">(2)</a>
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wrapping-context">
-   <a href="https://www.w3.org/TR/css3-exclusions/#wrapping-context">https://www.w3.org/TR/css3-exclusions/#wrapping-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wrapping-context" class="dfn-panel" data-for="term-for-wrapping-context" id="infopanel-for-term-for-wrapping-context" role="menu">
+   <span id="infopaneltitle-for-term-for-wrapping-context" style="display:none">Info about the 'wrapping context' external reference.</span><a href="https://www.w3.org/TR/css3-exclusions/#wrapping-context">https://www.w3.org/TR/css3-exclusions/#wrapping-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wrapping-context">8. 
 Declaring Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-path">
-   <a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-path" class="dfn-panel" data-for="term-for-elementdef-path" id="infopanel-for-term-for-elementdef-path" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-path" style="display:none">Info about the 'path' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-path">4.1.1.1. 
 Interpolating the shape() Function</a>
@@ -2165,8 +2165,8 @@ Interpolating the shape() Function</a>
    <div class="issue"> improve the illustration above,
 	using text to show overflow instead of grey boxes. <a class="issue-return" href="#issue-cb709780" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="exclusion-area">
-   <b><a href="#exclusion-area">#exclusion-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusion-area" class="dfn-panel" data-for="exclusion-area" id="infopanel-for-exclusion-area" role="dialog">
+   <span id="infopaneltitle-for-exclusion-area" style="display:none">Info about the 'exclusion area' definition.</span><b><a href="#exclusion-area">#exclusion-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusion-area">2. 
 Terminology</a> <a href="#ref-for-exclusion-area①">(2)</a> <a href="#ref-for-exclusion-area②">(3)</a>
@@ -2176,8 +2176,8 @@ Shapes</a>
 Declaring Shapes</a> <a href="#ref-for-exclusion-area⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-area">
-   <b><a href="#float-area">#float-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-area" class="dfn-panel" data-for="float-area" id="infopanel-for-float-area" role="dialog">
+   <span id="infopaneltitle-for-float-area" style="display:none">Info about the 'float area' definition.</span><b><a href="#float-area">#float-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-area">1. 
 Introduction</a>
@@ -2187,15 +2187,15 @@ Shapes</a>
 Declaring Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-area">
-   <b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-area" class="dfn-panel" data-for="content-area" id="infopanel-for-content-area" role="dialog">
+   <span id="infopaneltitle-for-content-area" style="display:none">Info about the 'content area' definition.</span><b><a href="#content-area">#content-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="direction-agnostic-size">
-   <b><a href="#direction-agnostic-size">#direction-agnostic-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-direction-agnostic-size" class="dfn-panel" data-for="direction-agnostic-size" id="infopanel-for-direction-agnostic-size" role="dialog">
+   <span id="infopaneltitle-for-direction-agnostic-size" style="display:none">Info about the 'direction-agnostic size' definition.</span><b><a href="#direction-agnostic-size">#direction-agnostic-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-direction-agnostic-size">2. 
 Terminology</a>
@@ -2203,8 +2203,8 @@ Terminology</a>
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-shape">
-   <b><a href="#funcdef-shape">#funcdef-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-shape" class="dfn-panel" data-for="funcdef-shape" id="infopanel-for-funcdef-shape" role="dialog">
+   <span id="infopaneltitle-for-funcdef-shape" style="display:none">Info about the 'shape()' definition.</span><b><a href="#funcdef-shape">#funcdef-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-shape">4.1.1. 
 The shape() Function</a> <a href="#ref-for-funcdef-shape①">(2)</a>
@@ -2212,22 +2212,22 @@ The shape() Function</a> <a href="#ref-for-funcdef-shape①">(2)</a>
 Interpolating the shape() Function</a> <a href="#ref-for-funcdef-shape③">(2)</a> <a href="#ref-for-funcdef-shape④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-command">
-   <b><a href="#typedef-shape-command">#typedef-shape-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-command" class="dfn-panel" data-for="typedef-shape-command" id="infopanel-for-typedef-shape-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-command" style="display:none">Info about the '&lt;shape-command>' definition.</span><b><a href="#typedef-shape-command">#typedef-shape-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-command①">(2)</a> <a href="#ref-for-typedef-shape-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-coordinate-pair">
-   <b><a href="#typedef-shape-coordinate-pair">#typedef-shape-coordinate-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-coordinate-pair" class="dfn-panel" data-for="typedef-shape-coordinate-pair" id="infopanel-for-typedef-shape-coordinate-pair" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-coordinate-pair" style="display:none">Info about the '&lt;coordinate-pair>' definition.</span><b><a href="#typedef-shape-coordinate-pair">#typedef-shape-coordinate-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-coordinate-pair">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-coordinate-pair①">(2)</a> <a href="#ref-for-typedef-shape-coordinate-pair②">(3)</a> <a href="#ref-for-typedef-shape-coordinate-pair③">(4)</a> <a href="#ref-for-typedef-shape-coordinate-pair④">(5)</a> <a href="#ref-for-typedef-shape-coordinate-pair⑤">(6)</a> <a href="#ref-for-typedef-shape-coordinate-pair⑥">(7)</a> <a href="#ref-for-typedef-shape-coordinate-pair⑦">(8)</a> <a href="#ref-for-typedef-shape-coordinate-pair⑧">(9)</a> <a href="#ref-for-typedef-shape-coordinate-pair⑨">(10)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⓪">(11)</a> <a href="#ref-for-typedef-shape-coordinate-pair①①">(12)</a> <a href="#ref-for-typedef-shape-coordinate-pair①②">(13)</a> <a href="#ref-for-typedef-shape-coordinate-pair①③">(14)</a> <a href="#ref-for-typedef-shape-coordinate-pair①④">(15)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⑤">(16)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⑥">(17)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⑦">(18)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⑧">(19)</a> <a href="#ref-for-typedef-shape-coordinate-pair①⑨">(20)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⓪">(21)</a> <a href="#ref-for-typedef-shape-coordinate-pair②①">(22)</a> <a href="#ref-for-typedef-shape-coordinate-pair②②">(23)</a> <a href="#ref-for-typedef-shape-coordinate-pair②③">(24)</a> <a href="#ref-for-typedef-shape-coordinate-pair②④">(25)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⑤">(26)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⑥">(27)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⑦">(28)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⑧">(29)</a> <a href="#ref-for-typedef-shape-coordinate-pair②⑨">(30)</a> <a href="#ref-for-typedef-shape-coordinate-pair③⓪">(31)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-by-to">
-   <b><a href="#typedef-shape-by-to">#typedef-shape-by-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-by-to" class="dfn-panel" data-for="typedef-shape-by-to" id="infopanel-for-typedef-shape-by-to" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-by-to" style="display:none">Info about the '&lt;by-to>' definition.</span><b><a href="#typedef-shape-by-to">#typedef-shape-by-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-by-to">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-by-to①">(2)</a> <a href="#ref-for-typedef-shape-by-to②">(3)</a> <a href="#ref-for-typedef-shape-by-to③">(4)</a> <a href="#ref-for-typedef-shape-by-to④">(5)</a> <a href="#ref-for-typedef-shape-by-to⑤">(6)</a> <a href="#ref-for-typedef-shape-by-to⑥">(7)</a> <a href="#ref-for-typedef-shape-by-to⑦">(8)</a> <a href="#ref-for-typedef-shape-by-to⑧">(9)</a> <a href="#ref-for-typedef-shape-by-to⑨">(10)</a> <a href="#ref-for-typedef-shape-by-to①⓪">(11)</a> <a href="#ref-for-typedef-shape-by-to①①">(12)</a> <a href="#ref-for-typedef-shape-by-to①②">(13)</a> <a href="#ref-for-typedef-shape-by-to①③">(14)</a> <a href="#ref-for-typedef-shape-by-to①④">(15)</a>
@@ -2235,71 +2235,71 @@ The shape() Function</a> <a href="#ref-for-typedef-shape-by-to①">(2)</a> <a hr
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-by">
-   <b><a href="#valdef-shape-by">#valdef-shape-by</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-by" class="dfn-panel" data-for="valdef-shape-by" id="infopanel-for-valdef-shape-by" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-by" style="display:none">Info about the 'by' definition.</span><b><a href="#valdef-shape-by">#valdef-shape-by</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-by">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-to">
-   <b><a href="#valdef-shape-to">#valdef-shape-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-to" class="dfn-panel" data-for="valdef-shape-to" id="infopanel-for-valdef-shape-to" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-to" style="display:none">Info about the 'to' definition.</span><b><a href="#valdef-shape-to">#valdef-shape-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-to">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-move-command">
-   <b><a href="#typedef-shape-move-command">#typedef-shape-move-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-move-command" class="dfn-panel" data-for="typedef-shape-move-command" id="infopanel-for-typedef-shape-move-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-move-command" style="display:none">Info about the '&lt;move-command>' definition.</span><b><a href="#typedef-shape-move-command">#typedef-shape-move-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-move-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-move-command①">(2)</a> <a href="#ref-for-typedef-shape-move-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-line-command">
-   <b><a href="#typedef-shape-line-command">#typedef-shape-line-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-line-command" class="dfn-panel" data-for="typedef-shape-line-command" id="infopanel-for-typedef-shape-line-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-line-command" style="display:none">Info about the '&lt;line-command>' definition.</span><b><a href="#typedef-shape-line-command">#typedef-shape-line-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-line-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-line-command①">(2)</a> <a href="#ref-for-typedef-shape-line-command②">(3)</a> <a href="#ref-for-typedef-shape-line-command③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-line">
-   <b><a href="#valdef-shape-line">#valdef-shape-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-line" class="dfn-panel" data-for="valdef-shape-line" id="infopanel-for-valdef-shape-line" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-line" style="display:none">Info about the 'line' definition.</span><b><a href="#valdef-shape-line">#valdef-shape-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-line">4.1.1. 
 The shape() Function</a> <a href="#ref-for-valdef-shape-line①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-hv-line-command">
-   <b><a href="#typedef-shape-hv-line-command">#typedef-shape-hv-line-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-hv-line-command" class="dfn-panel" data-for="typedef-shape-hv-line-command" id="infopanel-for-typedef-shape-hv-line-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-hv-line-command" style="display:none">Info about the '&lt;hv-line-command>' definition.</span><b><a href="#typedef-shape-hv-line-command">#typedef-shape-hv-line-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-hv-line-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-hv-line-command①">(2)</a> <a href="#ref-for-typedef-shape-hv-line-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-hline">
-   <b><a href="#valdef-shape-hline">#valdef-shape-hline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-hline" class="dfn-panel" data-for="valdef-shape-hline" id="infopanel-for-valdef-shape-hline" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-hline" style="display:none">Info about the 'hline' definition.</span><b><a href="#valdef-shape-hline">#valdef-shape-hline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-hline">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-vline">
-   <b><a href="#valdef-shape-vline">#valdef-shape-vline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-vline" class="dfn-panel" data-for="valdef-shape-vline" id="infopanel-for-valdef-shape-vline" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-vline" style="display:none">Info about the 'vline' definition.</span><b><a href="#valdef-shape-vline">#valdef-shape-vline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-vline">4.1.1. 
 The shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-curve-command">
-   <b><a href="#typedef-shape-curve-command">#typedef-shape-curve-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-curve-command" class="dfn-panel" data-for="typedef-shape-curve-command" id="infopanel-for-typedef-shape-curve-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-curve-command" style="display:none">Info about the '&lt;curve-command>' definition.</span><b><a href="#typedef-shape-curve-command">#typedef-shape-curve-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-curve-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-curve-command①">(2)</a> <a href="#ref-for-typedef-shape-curve-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-curve">
-   <b><a href="#valdef-shape-curve">#valdef-shape-curve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-curve" class="dfn-panel" data-for="valdef-shape-curve" id="infopanel-for-valdef-shape-curve" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-curve" style="display:none">Info about the 'curve' definition.</span><b><a href="#valdef-shape-curve">#valdef-shape-curve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-curve">4.1.1. 
 The shape() Function</a>
@@ -2307,15 +2307,15 @@ The shape() Function</a>
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-smooth-command">
-   <b><a href="#typedef-shape-smooth-command">#typedef-shape-smooth-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-smooth-command" class="dfn-panel" data-for="typedef-shape-smooth-command" id="infopanel-for-typedef-shape-smooth-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-smooth-command" style="display:none">Info about the '&lt;smooth-command>' definition.</span><b><a href="#typedef-shape-smooth-command">#typedef-shape-smooth-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-smooth-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-smooth-command①">(2)</a> <a href="#ref-for-typedef-shape-smooth-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-smooth">
-   <b><a href="#valdef-shape-smooth">#valdef-shape-smooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-smooth" class="dfn-panel" data-for="valdef-shape-smooth" id="infopanel-for-valdef-shape-smooth" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-smooth" style="display:none">Info about the 'smooth' definition.</span><b><a href="#valdef-shape-smooth">#valdef-shape-smooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-smooth">4.1.1. 
 The shape() Function</a>
@@ -2323,22 +2323,22 @@ The shape() Function</a>
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-arc-command">
-   <b><a href="#typedef-shape-arc-command">#typedef-shape-arc-command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-arc-command" class="dfn-panel" data-for="typedef-shape-arc-command" id="infopanel-for-typedef-shape-arc-command" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-arc-command" style="display:none">Info about the '&lt;arc-command>' definition.</span><b><a href="#typedef-shape-arc-command">#typedef-shape-arc-command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-arc-command">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-arc-command①">(2)</a> <a href="#ref-for-typedef-shape-arc-command②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-arc">
-   <b><a href="#valdef-shape-arc">#valdef-shape-arc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-arc" class="dfn-panel" data-for="valdef-shape-arc" id="infopanel-for-valdef-shape-arc" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-arc" style="display:none">Info about the 'arc' definition.</span><b><a href="#valdef-shape-arc">#valdef-shape-arc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-arc">4.1.1.1. 
 Interpolating the shape() Function</a> <a href="#ref-for-valdef-shape-arc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-arc-sweep">
-   <b><a href="#typedef-shape-arc-sweep">#typedef-shape-arc-sweep</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-arc-sweep" class="dfn-panel" data-for="typedef-shape-arc-sweep" id="infopanel-for-typedef-shape-arc-sweep" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-arc-sweep" style="display:none">Info about the '&lt;arc-sweep>' definition.</span><b><a href="#typedef-shape-arc-sweep">#typedef-shape-arc-sweep</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-arc-sweep">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-arc-sweep①">(2)</a> <a href="#ref-for-typedef-shape-arc-sweep②">(3)</a> <a href="#ref-for-typedef-shape-arc-sweep③">(4)</a> <a href="#ref-for-typedef-shape-arc-sweep④">(5)</a> <a href="#ref-for-typedef-shape-arc-sweep⑤">(6)</a>
@@ -2346,8 +2346,8 @@ The shape() Function</a> <a href="#ref-for-typedef-shape-arc-sweep①">(2)</a> <
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-cw">
-   <b><a href="#valdef-shape-cw">#valdef-shape-cw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-cw" class="dfn-panel" data-for="valdef-shape-cw" id="infopanel-for-valdef-shape-cw" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-cw" style="display:none">Info about the 'cw' definition.</span><b><a href="#valdef-shape-cw">#valdef-shape-cw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-cw">4.1.1. 
 The shape() Function</a>
@@ -2355,15 +2355,15 @@ The shape() Function</a>
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-ccw">
-   <b><a href="#valdef-shape-ccw">#valdef-shape-ccw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-ccw" class="dfn-panel" data-for="valdef-shape-ccw" id="infopanel-for-valdef-shape-ccw" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-ccw" style="display:none">Info about the 'ccw' definition.</span><b><a href="#valdef-shape-ccw">#valdef-shape-ccw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-ccw">4.1.1. 
 The shape() Function</a> <a href="#ref-for-valdef-shape-ccw①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-shape-arc-size">
-   <b><a href="#typedef-shape-arc-size">#typedef-shape-arc-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-shape-arc-size" class="dfn-panel" data-for="typedef-shape-arc-size" id="infopanel-for-typedef-shape-arc-size" role="dialog">
+   <span id="infopaneltitle-for-typedef-shape-arc-size" style="display:none">Info about the '&lt;arc-size>' definition.</span><b><a href="#typedef-shape-arc-size">#typedef-shape-arc-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-arc-size">4.1.1. 
 The shape() Function</a> <a href="#ref-for-typedef-shape-arc-size①">(2)</a> <a href="#ref-for-typedef-shape-arc-size②">(3)</a> <a href="#ref-for-typedef-shape-arc-size③">(4)</a> <a href="#ref-for-typedef-shape-arc-size④">(5)</a> <a href="#ref-for-typedef-shape-arc-size⑤">(6)</a>
@@ -2371,8 +2371,8 @@ The shape() Function</a> <a href="#ref-for-typedef-shape-arc-size①">(2)</a> <a
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-large">
-   <b><a href="#valdef-shape-large">#valdef-shape-large</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-large" class="dfn-panel" data-for="valdef-shape-large" id="infopanel-for-valdef-shape-large" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-large" style="display:none">Info about the 'large' definition.</span><b><a href="#valdef-shape-large">#valdef-shape-large</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-large">4.1.1. 
 The shape() Function</a>
@@ -2380,22 +2380,22 @@ The shape() Function</a>
 Interpolating the shape() Function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-small">
-   <b><a href="#valdef-shape-small">#valdef-shape-small</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-small" class="dfn-panel" data-for="valdef-shape-small" id="infopanel-for-valdef-shape-small" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-small" style="display:none">Info about the 'small' definition.</span><b><a href="#valdef-shape-small">#valdef-shape-small</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-small">4.1.1. 
 The shape() Function</a> <a href="#ref-for-valdef-shape-small①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-close">
-   <b><a href="#valdef-shape-close">#valdef-shape-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-close" class="dfn-panel" data-for="valdef-shape-close" id="infopanel-for-valdef-shape-close" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-close" style="display:none">Info about the 'close' definition.</span><b><a href="#valdef-shape-close">#valdef-shape-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-close">4.1.1. 
 The shape() Function</a> <a href="#ref-for-valdef-shape-close①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-inside">
-   <b><a href="#propdef-shape-inside">#propdef-shape-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-inside" class="dfn-panel" data-for="propdef-shape-inside" id="infopanel-for-propdef-shape-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-inside" style="display:none">Info about the 'shape-inside' definition.</span><b><a href="#propdef-shape-inside">#propdef-shape-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-inside">1. 
 Introduction</a>
@@ -2411,15 +2411,15 @@ The shape-image-threshold Property</a>
 The shape-padding Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-shape-inside-auto">
-   <b><a href="#valdef-shape-inside-auto">#valdef-shape-inside-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-shape-inside-auto" class="dfn-panel" data-for="valdef-shape-inside-auto" id="infopanel-for-valdef-shape-inside-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-shape-inside-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-shape-inside-auto">#valdef-shape-inside-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-shape-inside-auto">8.2. 
 The shape-inside Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-shape-padding">
-   <b><a href="#propdef-shape-padding">#propdef-shape-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-shape-padding" class="dfn-panel" data-for="propdef-shape-padding" id="infopanel-for-propdef-shape-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-shape-padding" style="display:none">Info about the 'shape-padding' definition.</span><b><a href="#propdef-shape-padding">#propdef-shape-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-padding">8. 
 Declaring Shapes</a> <a href="#ref-for-propdef-shape-padding①">(2)</a>
@@ -2431,59 +2431,115 @@ The shape-padding Property</a> <a href="#ref-for-propdef-shape-padding⑤">(2)</
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-size-adjust-1/Overview.html
@@ -1172,82 +1172,82 @@ this with more detail/precision.</span></p>
    <li><a href="#valdef-text-size-adjust-percentage">&lt;percentage></a><span>, in § 3</span>
    <li><a href="#propdef-text-size-adjust">text-size-adjust</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.2. Conditions that suppress adjustment</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">2.3. Calculation of default adjustment</a>
     <li><a href="#ref-for-propdef-font-size①">3. Size adjustment control: the text-size-adjust property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">2.2. Conditions that suppress adjustment</a> <a href="#ref-for-valdef-width-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-wrap-nowrap">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-nowrap">https://drafts.csswg.org/css-text-4/#valdef-text-wrap-nowrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-wrap-nowrap" class="dfn-panel" data-for="term-for-valdef-text-wrap-nowrap" id="infopanel-for-term-for-valdef-text-wrap-nowrap" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-wrap-nowrap" style="display:none">Info about the 'nowrap (for text-wrap)' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-nowrap">https://drafts.csswg.org/css-text-4/#valdef-text-wrap-nowrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-nowrap">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-nowrap">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-nowrap">https://drafts.csswg.org/css-text-4/#valdef-white-space-nowrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-nowrap" class="dfn-panel" data-for="term-for-valdef-white-space-nowrap" id="infopanel-for-term-for-valdef-white-space-nowrap" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-nowrap" style="display:none">Info about the 'nowrap (for white-space)' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-nowrap">https://drafts.csswg.org/css-text-4/#valdef-white-space-nowrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-nowrap">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre" class="dfn-panel" data-for="term-for-valdef-white-space-pre" id="infopanel-for-term-for-valdef-white-space-pre" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre" style="display:none">Info about the 'pre' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-wrap">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-wrap">https://drafts.csswg.org/css-text-4/#propdef-text-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-wrap" class="dfn-panel" data-for="term-for-propdef-text-wrap" id="infopanel-for-term-for-propdef-text-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-wrap" style="display:none">Info about the 'text-wrap' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-wrap">https://drafts.csswg.org/css-text-4/#propdef-text-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-wrap">Unnumbered Section</a>
     <li><a href="#ref-for-propdef-text-wrap①">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">2.2. Conditions that suppress adjustment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3. Size adjustment control: the text-size-adjust property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3. Size adjustment control: the text-size-adjust property</a> <a href="#ref-for-comb-one①">(2)</a>
    </ul>
@@ -1349,8 +1349,8 @@ this with more detail/precision. <a class="issue-return" href="#issue-7a854497" 
   when text size adjustment should apply. For example, in practice a
   large tablet is considered by vendors to be a small device. <a class="issue-return" href="#issue-a75ce4d0" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-text-size-adjust">
-   <b><a href="#propdef-text-size-adjust">#propdef-text-size-adjust</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-size-adjust" class="dfn-panel" data-for="propdef-text-size-adjust" id="infopanel-for-propdef-text-size-adjust" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-size-adjust" style="display:none">Info about the 'text-size-adjust' definition.</span><b><a href="#propdef-text-size-adjust">#propdef-text-size-adjust</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-size-adjust">2. Default size adjustment</a>
     <li><a href="#ref-for-propdef-text-size-adjust①">3. Size adjustment control: the text-size-adjust property</a>
@@ -1358,59 +1358,115 @@ this with more detail/precision. <a class="issue-return" href="#issue-7a854497" 
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-sizing-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-sizing-3/Overview.html
@@ -2591,22 +2591,22 @@ and a button (button-like, and thus not shrinkable).</p>
      <li><a href="#width">definition of</a><span>, in § 3.1.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-gutter">
-   <a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gutter" class="dfn-panel" data-for="term-for-gutter" id="infopanel-for-term-for-gutter" role="menu">
+   <span id="infopaneltitle-for-term-for-gutter" style="display:none">Info about the 'gutter' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#gutter">https://drafts.csswg.org/css-align-3/#gutter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gutter">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
@@ -2614,8 +2614,8 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-border-box②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">2.3. 
 Intrinsic Size Constraints</a>
@@ -2625,36 +2625,36 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-content-box③">(2)</a> <a href="#ref-for-content-box④">(3)</a> <a href="#ref-for-content-box⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin" class="dfn-panel" data-for="term-for-margin" id="infopanel-for-term-for-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-properties">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-properties">https://drafts.csswg.org/css-box-4/#margin-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-properties" class="dfn-panel" data-for="term-for-margin-properties" id="infopanel-for-term-for-margin-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-properties" style="display:none">Info about the 'margin properties' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-properties">https://drafts.csswg.org/css-box-4/#margin-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-properties">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding" class="dfn-panel" data-for="term-for-padding" id="infopanel-for-term-for-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding">https://drafts.csswg.org/css-box-4/#padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-properties">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-properties">https://drafts.csswg.org/css-box-4/#padding-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-properties" class="dfn-panel" data-for="term-for-padding-properties" id="infopanel-for-term-for-padding-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-properties" style="display:none">Info about the 'padding properties' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-properties">https://drafts.csswg.org/css-box-4/#padding-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-properties">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
@@ -2662,29 +2662,29 @@ Box Edges for Sizing: the box-sizing property</a>
 Intrinsic Sizes</a> <a href="#ref-for-computed-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-initial-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">3.2.2. 
 Containing or Excluding Floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.1. 
 Auto Box Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2. 
 Terminology</a> <a href="#ref-for-box①">(2)</a>
@@ -2692,8 +2692,8 @@ Terminology</a> <a href="#ref-for-box①">(2)</a>
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">2. 
 Terminology</a> <a href="#ref-for-containing-block①">(2)</a>
@@ -2715,29 +2715,29 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.2.2. 
 Containing or Excluding Floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">3.2.2. 
 Containing or Excluding Floats</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">2. 
 Terminology</a> <a href="#ref-for-initial-containing-block①">(2)</a>
@@ -2745,22 +2745,22 @@ Terminology</a> <a href="#ref-for-initial-containing-block①">(2)</a>
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#inline">https://drafts.csswg.org/css-display-3/#inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline" class="dfn-panel" data-for="term-for-inline" id="infopanel-for-term-for-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline">https://drafts.csswg.org/css-display-3/#inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline">3.1.1. 
 Preferred Size Properties: the width and height properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.1. 
 Auto Box Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">3.1.1. 
 Preferred Size Properties: the width and height properties</a>
@@ -2768,8 +2768,8 @@ Preferred Size Properties: the width and height properties</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-non-replaced②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2.1. 
 Auto Box Sizes</a>
@@ -2782,8 +2782,8 @@ Compressible Replaced Elements</a> <a href="#ref-for-replaced-element⑥">(2)</a
     <li><a href="#ref-for-replaced-element⑦"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element①" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element①" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2.1. 
 Auto Box Sizes</a>
@@ -2796,22 +2796,22 @@ Compressible Replaced Elements</a> <a href="#ref-for-replaced-element⑥">(2)</a
     <li><a href="#ref-for-replaced-element⑦"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">5.1. 
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-basis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-basis" class="dfn-panel" data-for="term-for-propdef-flex-basis" id="infopanel-for-term-for-propdef-flex-basis" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-basis" style="display:none">Info about the 'flex-basis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-basis">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
@@ -2819,87 +2819,87 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-item">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-item" class="dfn-panel" data-for="term-for-grid-item" id="infopanel-for-term-for-grid-item" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-item" style="display:none">Info about the 'grid item' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-item">https://drafts.csswg.org/css-grid-2/#grid-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-item">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">2.3. 
 Intrinsic Size Constraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">2.1. 
 Auto Box Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">5.1. 
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-size" class="dfn-panel" data-for="term-for-propdef-block-size" id="infopanel-for-term-for-propdef-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-size" style="display:none">Info about the 'block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-size">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-block-size" class="dfn-panel" data-for="term-for-propdef-max-block-size" id="infopanel-for-term-for-propdef-max-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-block-size" style="display:none">Info about the 'max-block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-block-size">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-page" class="dfn-panel" data-for="term-for-at-ruledef-page" id="infopanel-for-term-for-at-ruledef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-page" style="display:none">Info about the '@page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-page">3.1. 
 Sizing Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-contain">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-contain">https://drafts.csswg.org/css-sizing-4/#valdef-width-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-contain" class="dfn-panel" data-for="term-for-valdef-width-contain" id="infopanel-for-term-for-valdef-width-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-contain">https://drafts.csswg.org/css-sizing-4/#valdef-width-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-contain">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-fit-content">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-fit-content" class="dfn-panel" data-for="term-for-valdef-width-fit-content" id="infopanel-for-term-for-valdef-width-fit-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content">https://drafts.csswg.org/css-sizing-4/#valdef-width-fit-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
     <li><a href="#ref-for-valdef-width-fit-content①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-stretch">
-   <a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch">https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-stretch" class="dfn-panel" data-for="term-for-valdef-width-stretch" id="infopanel-for-term-for-valdef-width-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-stretch" style="display:none">Info about the 'stretch' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch">https://drafts.csswg.org/css-sizing-4/#valdef-width-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-stretch">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a> <a href="#ref-for-valdef-width-stretch①">(2)</a>
     <li><a href="#ref-for-valdef-width-stretch②"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-soft-wrap-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-soft-wrap-opportunity" class="dfn-panel" data-for="term-for-soft-wrap-opportunity" id="infopanel-for-term-for-soft-wrap-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">5.1. 
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1.1. 
 Preferred Size Properties: the width and height properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
@@ -2915,8 +2915,8 @@ Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-typedef-leng
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a> <a href="#ref-for-typedef-length-percentage②①">(2)</a> <a href="#ref-for-typedef-length-percentage②②">(3)</a> <a href="#ref-for-typedef-length-percentage②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2. 
 Terminology</a>
@@ -2929,8 +2929,8 @@ Intrinsic Sizes</a> <a href="#ref-for-length-value④">(2)</a> <a href="#ref-for
     <li><a href="#ref-for-length-value⑥"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2. 
 Terminology</a>
@@ -2940,15 +2940,15 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1.1. 
 Preferred Size Properties: the width and height properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
@@ -2962,15 +2962,15 @@ Box Edges for Sizing: the box-sizing property</a>
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a> <a href="#ref-for-comb-one①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">2.1. 
 Auto Box Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">2. 
 Terminology</a> <a href="#ref-for-block-size①">(2)</a>
@@ -2982,15 +2982,15 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Intrinsic Contributions of Percentage-Sized Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-relative">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-relative" class="dfn-panel" data-for="term-for-flow-relative" id="infopanel-for-term-for-flow-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-relative" style="display:none">Info about the 'flow-relative' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#flow-relative">https://drafts.csswg.org/css-writing-modes-4/#flow-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative">3.1. 
 Sizing Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">2.1. 
 Auto Box Sizes</a> <a href="#ref-for-inline-axis①">(2)</a>
@@ -2998,8 +2998,8 @@ Auto Box Sizes</a> <a href="#ref-for-inline-axis①">(2)</a>
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">2. 
 Terminology</a> <a href="#ref-for-inline-size①">(2)</a>
@@ -3011,22 +3011,22 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical" class="dfn-panel" data-for="term-for-physical" id="infopanel-for-term-for-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-physical" style="display:none">Info about the 'physical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#physical">https://drafts.csswg.org/css-writing-modes-4/#physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical">3.1.1. 
 Preferred Size Properties: the width and height properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">Unnumbered Section</a>
     <li><a href="#ref-for-propdef-column-width①">1.1. 
@@ -3035,22 +3035,22 @@ Module interactions</a>
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a> <a href="#ref-for-propdef-column-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-button-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-button-element" class="dfn-panel" data-for="term-for-the-button-element" id="infopanel-for-term-for-the-button-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-button-element" style="display:none">Info about the 'button' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-button-element">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
@@ -3058,16 +3058,16 @@ Box Edges for Sizing: the box-sizing property</a>
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">5.1. 
 Intrinsic Sizes</a>
     <li><a href="#ref-for-the-iframe-element①"> Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">5.1. 
 Intrinsic Sizes</a>
@@ -3077,29 +3077,29 @@ Intrinsic Contributions of Percentage-Sized Boxes</a>
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-meter-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-meter-element" class="dfn-panel" data-for="term-for-the-meter-element" id="infopanel-for-term-for-the-meter-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-meter-element" style="display:none">Info about the 'meter' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-meter-element">5.2.2. 
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-progress-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-progress-element" class="dfn-panel" data-for="term-for-the-progress-element" id="infopanel-for-term-for-the-progress-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-progress-element" style="display:none">Info about the 'progress' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-progress-element">5.2.2. 
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-textarea-raw-value">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-textarea-raw-value">https://html.spec.whatwg.org/multipage/form-elements.html#concept-textarea-raw-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-textarea-raw-value" class="dfn-panel" data-for="term-for-concept-textarea-raw-value" id="infopanel-for-term-for-concept-textarea-raw-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-textarea-raw-value" style="display:none">Info about the 'raw value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-textarea-raw-value">https://html.spec.whatwg.org/multipage/form-elements.html#concept-textarea-raw-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-textarea-raw-value">5.1. 
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-select-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-select-element" class="dfn-panel" data-for="term-for-the-select-element" id="infopanel-for-term-for-the-select-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-select-element" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-select-element">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a>
@@ -3107,8 +3107,8 @@ Intrinsic Contributions of Percentage-Sized Boxes</a>
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-textarea-element" class="dfn-panel" data-for="term-for-the-textarea-element" id="infopanel-for-term-for-the-textarea-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-textarea-element" style="display:none">Info about the 'textarea' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-textarea-element">5.1. 
 Intrinsic Sizes</a>
@@ -3116,8 +3116,8 @@ Intrinsic Sizes</a>
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-type">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-type" class="dfn-panel" data-for="term-for-attr-input-type" id="infopanel-for-term-for-attr-input-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-type">5.2.2. 
 Compressible Replaced Elements</a>
@@ -3419,8 +3419,8 @@ Compressible Replaced Elements</a>
 		even though CSS2 didn’t have content-dependent keywords for <a class="property css" data-link-type="property" href="#propdef-min-height">min-height</a>.
 		Since this is new, we think we could have this different behavior.) <a class="issue-return" href="#issue-9b3707fe" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="size">
-   <b><a href="#size">#size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size" class="dfn-panel" data-for="size" id="infopanel-for-size" role="dialog">
+   <span id="infopaneltitle-for-size" style="display:none">Info about the 'size' definition.</span><b><a href="#size">#size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size">2. 
 Terminology</a> <a href="#ref-for-size①">(2)</a>
@@ -3428,8 +3428,8 @@ Terminology</a> <a href="#ref-for-size①">(2)</a>
 Auto Box Sizes</a> <a href="#ref-for-size③">(2)</a> <a href="#ref-for-size④">(3)</a> <a href="#ref-for-size⑤">(4)</a> <a href="#ref-for-size⑥">(5)</a> <a href="#ref-for-size⑦">(6)</a> <a href="#ref-for-size⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inner-size">
-   <b><a href="#inner-size">#inner-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inner-size" class="dfn-panel" data-for="inner-size" id="infopanel-for-inner-size" role="dialog">
+   <span id="infopaneltitle-for-inner-size" style="display:none">Info about the 'inner size' definition.</span><b><a href="#inner-size">#inner-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
@@ -3437,8 +3437,8 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-inner-size②">(2)</a> <a href="#ref-for-inner-size③">(3)</a> <a href="#ref-for-inner-size④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-size">
-   <b><a href="#outer-size">#outer-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-size" class="dfn-panel" data-for="outer-size" id="infopanel-for-outer-size" role="dialog">
+   <span id="infopaneltitle-for-outer-size" style="display:none">Info about the 'outer size' definition.</span><b><a href="#outer-size">#outer-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">2.1. 
 Auto Box Sizes</a>
@@ -3448,8 +3448,8 @@ Intrinsic Size Contributions</a>
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="definite">
-   <b><a href="#definite">#definite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-definite" class="dfn-panel" data-for="definite" id="infopanel-for-definite" role="dialog">
+   <span id="infopaneltitle-for-definite" style="display:none">Info about the 'definite size' definition.</span><b><a href="#definite">#definite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">2. 
 Terminology</a> <a href="#ref-for-definite①">(2)</a> <a href="#ref-for-definite②">(3)</a> <a href="#ref-for-definite③">(4)</a>
@@ -3463,8 +3463,8 @@ Intrinsic Sizes</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-definite①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="indefinite">
-   <b><a href="#indefinite">#indefinite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-indefinite" class="dfn-panel" data-for="indefinite" id="infopanel-for-indefinite" role="dialog">
+   <span id="infopaneltitle-for-indefinite" style="display:none">Info about the 'indefinite size' definition.</span><b><a href="#indefinite">#indefinite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">2. 
 Terminology</a> <a href="#ref-for-indefinite①">(2)</a>
@@ -3477,8 +3477,8 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
     <li><a href="#ref-for-indefinite⑥"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="available">
-   <b><a href="#available">#available</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-available" class="dfn-panel" data-for="available" id="infopanel-for-available" role="dialog">
+   <span id="infopaneltitle-for-available" style="display:none">Info about the 'available space' definition.</span><b><a href="#available">#available</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">2. 
 Terminology</a> <a href="#ref-for-available①">(2)</a>
@@ -3490,8 +3490,8 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stretch-fit">
-   <b><a href="#stretch-fit">#stretch-fit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stretch-fit" class="dfn-panel" data-for="stretch-fit" id="infopanel-for-stretch-fit" role="dialog">
+   <span id="infopaneltitle-for-stretch-fit" style="display:none">Info about the 'stretch fit' definition.</span><b><a href="#stretch-fit">#stretch-fit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit">2. 
 Terminology</a>
@@ -3501,15 +3501,15 @@ Auto Box Sizes</a>
 Intrinsic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fallback">
-   <b><a href="#fallback">#fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fallback" class="dfn-panel" data-for="fallback" id="infopanel-for-fallback" role="dialog">
+   <span id="infopaneltitle-for-fallback" style="display:none">Info about the 'fallback size' definition.</span><b><a href="#fallback">#fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stretch-fit-size">
-   <b><a href="#stretch-fit-size">#stretch-fit-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stretch-fit-size" class="dfn-panel" data-for="stretch-fit-size" id="infopanel-for-stretch-fit-size" role="dialog">
+   <span id="infopaneltitle-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' definition.</span><b><a href="#stretch-fit-size">#stretch-fit-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">2.1. 
 Auto Box Sizes</a> <a href="#ref-for-stretch-fit-size①">(2)</a>
@@ -3517,8 +3517,8 @@ Auto Box Sizes</a> <a href="#ref-for-stretch-fit-size①">(2)</a>
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content">
-   <b><a href="#max-content">#max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content" class="dfn-panel" data-for="max-content" id="infopanel-for-max-content" role="dialog">
+   <span id="infopaneltitle-for-max-content" style="display:none">Info about the 'max-content size' definition.</span><b><a href="#max-content">#max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">2.1. 
 Auto Box Sizes</a> <a href="#ref-for-max-content①">(2)</a> <a href="#ref-for-max-content②">(3)</a> <a href="#ref-for-max-content③">(4)</a>
@@ -3533,22 +3533,22 @@ Intrinsic Sizes</a> <a href="#ref-for-max-content⑧">(2)</a> <a href="#ref-for-
     <li><a href="#ref-for-max-content①③"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-inline-size">
-   <b><a href="#max-content-inline-size">#max-content-inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-inline-size" class="dfn-panel" data-for="max-content-inline-size" id="infopanel-for-max-content-inline-size" role="dialog">
+   <span id="infopaneltitle-for-max-content-inline-size" style="display:none">Info about the 'max-content inline size' definition.</span><b><a href="#max-content-inline-size">#max-content-inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-inline-size">3.4. 
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-block-size">
-   <b><a href="#max-content-block-size">#max-content-block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-block-size" class="dfn-panel" data-for="max-content-block-size" id="infopanel-for-max-content-block-size" role="dialog">
+   <span id="infopaneltitle-for-max-content-block-size" style="display:none">Info about the 'max-content block size' definition.</span><b><a href="#max-content-block-size">#max-content-block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-block-size">2.1. 
 Auto Box Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content">
-   <b><a href="#min-content">#min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content" class="dfn-panel" data-for="min-content" id="infopanel-for-min-content" role="dialog">
+   <span id="infopaneltitle-for-min-content" style="display:none">Info about the 'min-content size' definition.</span><b><a href="#min-content">#min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">2.1. 
 Auto Box Sizes</a> <a href="#ref-for-min-content①">(2)</a> <a href="#ref-for-min-content②">(3)</a> <a href="#ref-for-min-content③">(4)</a>
@@ -3562,23 +3562,23 @@ New Column Sizing Values: the min-content, max-content, and fit-content() values
 Intrinsic Sizes</a> <a href="#ref-for-min-content⑧">(2)</a> <a href="#ref-for-min-content⑨">(3)</a> <a href="#ref-for-min-content①⓪">(4)</a> <a href="#ref-for-min-content①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-inline-size">
-   <b><a href="#min-content-inline-size">#min-content-inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-inline-size" class="dfn-panel" data-for="min-content-inline-size" id="infopanel-for-min-content-inline-size" role="dialog">
+   <span id="infopaneltitle-for-min-content-inline-size" style="display:none">Info about the 'min-content inline size' definition.</span><b><a href="#min-content-inline-size">#min-content-inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-inline-size">3.4. 
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fit-content-size">
-   <b><a href="#fit-content-size">#fit-content-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fit-content-size" class="dfn-panel" data-for="fit-content-size" id="infopanel-for-fit-content-size" role="dialog">
+   <span id="infopaneltitle-for-fit-content-size" style="display:none">Info about the 'fit-content size' definition.</span><b><a href="#fit-content-size">#fit-content-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
     <li><a href="#ref-for-fit-content-size①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-size">
-   <b><a href="#intrinsic-size">#intrinsic-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-size" class="dfn-panel" data-for="intrinsic-size" id="infopanel-for-intrinsic-size" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' definition.</span><b><a href="#intrinsic-size">#intrinsic-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size">2.1. 
 Auto Box Sizes</a>
@@ -3587,8 +3587,8 @@ Intrinsic Sizes</a> <a href="#ref-for-intrinsic-size②">(2)</a> <a href="#ref-f
     <li><a href="#ref-for-intrinsic-size⑤"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-contribution">
-   <b><a href="#max-content-contribution">#max-content-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-contribution" class="dfn-panel" data-for="max-content-contribution" id="infopanel-for-max-content-contribution" role="dialog">
+   <span id="infopaneltitle-for-max-content-contribution" style="display:none">Info about the 'max-content contribution' definition.</span><b><a href="#max-content-contribution">#max-content-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-contribution">2.2. 
 Intrinsic Size Contributions</a>
@@ -3600,8 +3600,8 @@ Intrinsic Contributions</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-max-content-contribution④">(2)</a> <a href="#ref-for-max-content-contribution⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-contribution">
-   <b><a href="#min-content-contribution">#min-content-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-contribution" class="dfn-panel" data-for="min-content-contribution" id="infopanel-for-min-content-contribution" role="dialog">
+   <span id="infopaneltitle-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' definition.</span><b><a href="#min-content-contribution">#min-content-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">2.2. 
 Intrinsic Size Contributions</a>
@@ -3615,29 +3615,30 @@ Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-min-cont
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-size-contribution">
-   <b><a href="#intrinsic-size-contribution">#intrinsic-size-contribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-size-contribution" class="dfn-panel" data-for="intrinsic-size-contribution" id="infopanel-for-intrinsic-size-contribution" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' definition.</span><b><a href="#intrinsic-size-contribution">#intrinsic-size-contribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-intrinsic-size-contribution①">(2)</a> <a href="#ref-for-intrinsic-size-contribution②">(3)</a> <a href="#ref-for-intrinsic-size-contribution③">(4)</a> <a href="#ref-for-intrinsic-size-contribution④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constraints">
-   <b><a href="#constraints">#constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constraints" class="dfn-panel" data-for="constraints" id="infopanel-for-constraints" role="dialog">
+   <span id="infopaneltitle-for-constraints" style="display:none">Info about the '2.3. 
+Intrinsic Size Constraints' definition.</span><b><a href="#constraints">#constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constraints">2.3. 
 Intrinsic Size Constraints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-constraint">
-   <b><a href="#max-content-constraint">#max-content-constraint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-constraint" class="dfn-panel" data-for="max-content-constraint" id="infopanel-for-max-content-constraint" role="dialog">
+   <span id="infopaneltitle-for-max-content-constraint" style="display:none">Info about the 'max-content constraint' definition.</span><b><a href="#max-content-constraint">#max-content-constraint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-constraint">2. 
 Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-constraint">
-   <b><a href="#min-content-constraint">#min-content-constraint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-constraint" class="dfn-panel" data-for="min-content-constraint" id="infopanel-for-min-content-constraint" role="dialog">
+   <span id="infopaneltitle-for-min-content-constraint" style="display:none">Info about the 'min-content constraint' definition.</span><b><a href="#min-content-constraint">#min-content-constraint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-constraint">2. 
 Terminology</a>
@@ -3646,8 +3647,8 @@ Auto Box Sizes</a>
     <li><a href="#ref-for-min-content-constraint②"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-aspect-ratio">
-   <b><a href="#preferred-aspect-ratio">#preferred-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-aspect-ratio" class="dfn-panel" data-for="preferred-aspect-ratio" id="infopanel-for-preferred-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' definition.</span><b><a href="#preferred-aspect-ratio">#preferred-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">2.3. 
 Intrinsic Size Constraints</a> <a href="#ref-for-preferred-aspect-ratio①">(2)</a>
@@ -3658,8 +3659,8 @@ Intrinsic Sizes</a> <a href="#ref-for-preferred-aspect-ratio④">(2)</a> <a href
     <li><a href="#ref-for-preferred-aspect-ratio⑥"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sizing-property">
-   <b><a href="#sizing-property">#sizing-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sizing-property" class="dfn-panel" data-for="sizing-property" id="infopanel-for-sizing-property" role="dialog">
+   <span id="infopaneltitle-for-sizing-property" style="display:none">Info about the 'sizing properties' definition.</span><b><a href="#sizing-property">#sizing-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">3.3. 
 Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-sizing-property①">(2)</a> <a href="#ref-for-sizing-property②">(3)</a> <a href="#ref-for-sizing-property③">(4)</a>
@@ -3668,8 +3669,9 @@ Intrinsic Sizes</a>
     <li><a href="#ref-for-sizing-property⑤"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-size-properties">
-   <b><a href="#preferred-size-properties">#preferred-size-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-size-properties" class="dfn-panel" data-for="preferred-size-properties" id="infopanel-for-preferred-size-properties" role="dialog">
+   <span id="infopaneltitle-for-preferred-size-properties" style="display:none">Info about the '3.1.1. 
+Preferred Size Properties: the width and height properties' definition.</span><b><a href="#preferred-size-properties">#preferred-size-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size-properties">3.1.1. 
 Preferred Size Properties: the width and height properties</a>
@@ -3677,8 +3679,8 @@ Preferred Size Properties: the width and height properties</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-preferred-size-properties①">(2)</a> <a href="#ref-for-preferred-size-properties②">(3)</a> <a href="#ref-for-preferred-size-properties③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-width">
-   <b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-width" class="dfn-panel" data-for="propdef-width" id="infopanel-for-propdef-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-width" style="display:none">Info about the 'width' definition.</span><b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">1. 
 Introduction</a>
@@ -3707,8 +3709,8 @@ Compressible Replaced Elements</a>
     <li><a href="#ref-for-propdef-width②⑤"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-height">
-   <b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-height" class="dfn-panel" data-for="propdef-height" id="infopanel-for-propdef-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-height" style="display:none">Info about the 'height' definition.</span><b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">1. 
 Introduction</a>
@@ -3737,8 +3739,8 @@ Compressible Replaced Elements</a>
     <li><a href="#ref-for-propdef-height②④"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="width">
-   <b><a href="#width">#width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-width" class="dfn-panel" data-for="width" id="infopanel-for-width" role="dialog">
+   <span id="infopaneltitle-for-width" style="display:none">Info about the 'width' definition.</span><b><a href="#width">#width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-width">2. 
 Terminology</a> <a href="#ref-for-width①">(2)</a>
@@ -3746,8 +3748,8 @@ Terminology</a> <a href="#ref-for-width①">(2)</a>
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="height">
-   <b><a href="#height">#height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-height" class="dfn-panel" data-for="height" id="infopanel-for-height" role="dialog">
+   <span id="infopaneltitle-for-height" style="display:none">Info about the 'height' definition.</span><b><a href="#height">#height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-height">2. 
 Terminology</a> <a href="#ref-for-height①">(2)</a>
@@ -3755,8 +3757,9 @@ Terminology</a> <a href="#ref-for-height①">(2)</a>
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-size-properties">
-   <b><a href="#min-size-properties">#min-size-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-size-properties" class="dfn-panel" data-for="min-size-properties" id="infopanel-for-min-size-properties" role="dialog">
+   <span id="infopaneltitle-for-min-size-properties" style="display:none">Info about the '3.1.2. 
+Minimum Size Properties: the min-width and min-height properties' definition.</span><b><a href="#min-size-properties">#min-size-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-size-properties">3.1.2. 
 Minimum Size Properties: the min-width and min-height properties</a>
@@ -3766,8 +3769,8 @@ Intrinsic Sizes</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-min-size-properties②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-width">
-   <b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-width" class="dfn-panel" data-for="propdef-min-width" id="infopanel-for-propdef-min-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-width" style="display:none">Info about the 'min-width' definition.</span><b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">1.1. 
 Module interactions</a>
@@ -3783,8 +3786,8 @@ Intrinsic Sizes</a> <a href="#ref-for-propdef-min-width⑥">(2)</a>
     <li><a href="#ref-for-propdef-min-width⑧"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-height">
-   <b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-height" class="dfn-panel" data-for="propdef-min-height" id="infopanel-for-propdef-min-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-height" style="display:none">Info about the 'min-height' definition.</span><b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">1.1. 
 Module interactions</a>
@@ -3802,8 +3805,8 @@ Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-propdef-
     <li><a href="#ref-for-propdef-min-height①①"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-width">
-   <b><a href="#min-width">#min-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-width" class="dfn-panel" data-for="min-width" id="infopanel-for-min-width" role="dialog">
+   <span id="infopaneltitle-for-min-width" style="display:none">Info about the 'minimum width' definition.</span><b><a href="#min-width">#min-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
@@ -3812,15 +3815,16 @@ Intrinsic Sizes</a> <a href="#ref-for-min-width②">(2)</a> <a href="#ref-for-mi
     <li><a href="#ref-for-min-width④"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-height">
-   <b><a href="#min-height">#min-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-height" class="dfn-panel" data-for="min-height" id="infopanel-for-min-height" role="dialog">
+   <span id="infopaneltitle-for-min-height" style="display:none">Info about the 'minimum height' definition.</span><b><a href="#min-height">#min-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-height">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-size-properties">
-   <b><a href="#max-size-properties">#max-size-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-size-properties" class="dfn-panel" data-for="max-size-properties" id="infopanel-for-max-size-properties" role="dialog">
+   <span id="infopaneltitle-for-max-size-properties" style="display:none">Info about the '3.1.3. 
+Maximum Size Properties: the max-width and max-height properties' definition.</span><b><a href="#max-size-properties">#max-size-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-size-properties">3.1.3. 
 Maximum Size Properties: the max-width and max-height properties</a>
@@ -3828,8 +3832,8 @@ Maximum Size Properties: the max-width and max-height properties</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-max-size-properties①">(2)</a> <a href="#ref-for-max-size-properties②">(3)</a> <a href="#ref-for-max-size-properties③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-width">
-   <b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-width" class="dfn-panel" data-for="propdef-max-width" id="infopanel-for-propdef-max-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-width" style="display:none">Info about the 'max-width' definition.</span><b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">1.1. 
 Module interactions</a>
@@ -3843,8 +3847,8 @@ Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-propdef-
 Compressible Replaced Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-height">
-   <b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-height" class="dfn-panel" data-for="propdef-max-height" id="infopanel-for-propdef-max-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-height" style="display:none">Info about the 'max-height' definition.</span><b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">1.1. 
 Module interactions</a>
@@ -3859,8 +3863,8 @@ Compressible Replaced Elements</a>
     <li><a href="#ref-for-propdef-max-height⑦"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-width">
-   <b><a href="#max-width">#max-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-width" class="dfn-panel" data-for="max-width" id="infopanel-for-max-width" role="dialog">
+   <span id="infopaneltitle-for-max-width" style="display:none">Info about the 'maximum width' definition.</span><b><a href="#max-width">#max-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
@@ -3868,15 +3872,15 @@ Box Edges for Sizing: the box-sizing property</a>
 Intrinsic Sizes</a> <a href="#ref-for-max-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-height">
-   <b><a href="#max-height">#max-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-height" class="dfn-panel" data-for="max-height" id="infopanel-for-max-height" role="dialog">
+   <span id="infopaneltitle-for-max-height" style="display:none">Info about the 'maximum height' definition.</span><b><a href="#max-height">#max-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-height">3.3. 
 Box Edges for Sizing: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-auto">
-   <b><a href="#valdef-width-auto">#valdef-width-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-auto" class="dfn-panel" data-for="valdef-width-auto" id="infopanel-for-valdef-width-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-width-auto">#valdef-width-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">2. 
 Terminology</a>
@@ -3900,8 +3904,8 @@ Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-valdef-w
     <li><a href="#ref-for-valdef-width-auto①⑨"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="automatic-size">
-   <b><a href="#automatic-size">#automatic-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-automatic-size" class="dfn-panel" data-for="automatic-size" id="infopanel-for-automatic-size" role="dialog">
+   <span id="infopaneltitle-for-automatic-size" style="display:none">Info about the 'automatic size' definition.</span><b><a href="#automatic-size">#automatic-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a> <a href="#ref-for-automatic-size①">(2)</a>
@@ -3909,22 +3913,22 @@ Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content
 “Behaving as auto”</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="automatic-minimum-size">
-   <b><a href="#automatic-minimum-size">#automatic-minimum-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-automatic-minimum-size" class="dfn-panel" data-for="automatic-minimum-size" id="infopanel-for-automatic-minimum-size" role="dialog">
+   <span id="infopaneltitle-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' definition.</span><b><a href="#automatic-minimum-size">#automatic-minimum-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-automatic-minimum-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-max-width-none">
-   <b><a href="#valdef-max-width-none">#valdef-max-width-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-max-width-none" class="dfn-panel" data-for="valdef-max-width-none" id="infopanel-for-valdef-max-width-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-max-width-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-max-width-none">#valdef-max-width-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-width-none">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-min-content">
-   <b><a href="#valdef-width-min-content">#valdef-width-min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-min-content" class="dfn-panel" data-for="valdef-width-min-content" id="infopanel-for-valdef-width-min-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-min-content" style="display:none">Info about the 'min-content' definition.</span><b><a href="#valdef-width-min-content">#valdef-width-min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a> <a href="#ref-for-valdef-width-min-content①">(2)</a> <a href="#ref-for-valdef-width-min-content②">(3)</a>
@@ -3938,8 +3942,8 @@ Intrinsic Contributions of Percentage-Sized Boxes</a>
     <li><a href="#ref-for-valdef-width-min-content⑦"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-max-content">
-   <b><a href="#valdef-width-max-content">#valdef-width-max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-max-content" class="dfn-panel" data-for="valdef-width-max-content" id="infopanel-for-valdef-width-max-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-max-content" style="display:none">Info about the 'max-content' definition.</span><b><a href="#valdef-width-max-content">#valdef-width-max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.2. 
 Sizing Values: the &lt;length-percentage>, auto | none, min-content, max-content, and fit-content() values</a> <a href="#ref-for-valdef-width-max-content①">(2)</a> <a href="#ref-for-valdef-width-max-content②">(3)</a>
@@ -3949,8 +3953,8 @@ Intrinsic Sizes</a>
     <li><a href="#ref-for-valdef-width-max-content⑤"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-fit-content-length-percentage">
-   <b><a href="#valdef-width-fit-content-length-percentage">#valdef-width-fit-content-length-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-fit-content-length-percentage" class="dfn-panel" data-for="valdef-width-fit-content-length-percentage" id="infopanel-for-valdef-width-fit-content-length-percentage" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-fit-content-length-percentage" style="display:none">Info about the 'fit-content(&lt;length-percentage>)' definition.</span><b><a href="#valdef-width-fit-content-length-percentage">#valdef-width-fit-content-length-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content-length-percentage">3.1.1. 
 Preferred Size Properties: the width and height properties</a>
@@ -3966,8 +3970,8 @@ Box Edges for Sizing: the box-sizing property</a>
     <li><a href="#ref-for-valdef-width-fit-content-length-percentage⑧"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="behave-as-auto">
-   <b><a href="#behave-as-auto">#behave-as-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-behave-as-auto" class="dfn-panel" data-for="behave-as-auto" id="infopanel-for-behave-as-auto" role="dialog">
+   <span id="infopaneltitle-for-behave-as-auto" style="display:none">Info about the 'behave as auto' definition.</span><b><a href="#behave-as-auto">#behave-as-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">3.2.1. 
 “Behaving as auto”</a>
@@ -3977,8 +3981,8 @@ Intrinsic Sizes</a> <a href="#ref-for-behave-as-auto②">(2)</a>
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-behave-as-auto④">(2)</a> <a href="#ref-for-behave-as-auto⑤">(3)</a> <a href="#ref-for-behave-as-auto⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-box-sizing">
-   <b><a href="#propdef-box-sizing">#propdef-box-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-sizing" class="dfn-panel" data-for="propdef-box-sizing" id="infopanel-for-propdef-box-sizing" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' definition.</span><b><a href="#propdef-box-sizing">#propdef-box-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">1.1. 
 Module interactions</a>
@@ -3990,36 +3994,36 @@ Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-propdef-box-
     <li><a href="#ref-for-propdef-box-sizing⑨"> Additions since CSS Level 2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-box-sizing-border-box">
-   <b><a href="#valdef-box-sizing-border-box">#valdef-box-sizing-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-box-sizing-border-box" class="dfn-panel" data-for="valdef-box-sizing-border-box" id="infopanel-for-valdef-box-sizing-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-box-sizing-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-box-sizing-border-box">#valdef-box-sizing-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-sizing-border-box">3.3. 
 Box Edges for Sizing: the box-sizing property</a> <a href="#ref-for-valdef-box-sizing-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-width-min-content">
-   <b><a href="#valdef-column-width-min-content">#valdef-column-width-min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-width-min-content" class="dfn-panel" data-for="valdef-column-width-min-content" id="infopanel-for-valdef-column-width-min-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-width-min-content" style="display:none">Info about the 'min-content' definition.</span><b><a href="#valdef-column-width-min-content">#valdef-column-width-min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-min-content">3.4. 
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-width-max-content">
-   <b><a href="#valdef-column-width-max-content">#valdef-column-width-max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-width-max-content" class="dfn-panel" data-for="valdef-column-width-max-content" id="infopanel-for-valdef-column-width-max-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-width-max-content" style="display:none">Info about the 'max-content' definition.</span><b><a href="#valdef-column-width-max-content">#valdef-column-width-max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-max-content">3.4. 
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-column-width-fit-content-length-percentage">
-   <b><a href="#valdef-column-width-fit-content-length-percentage">#valdef-column-width-fit-content-length-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-column-width-fit-content-length-percentage" class="dfn-panel" data-for="valdef-column-width-fit-content-length-percentage" id="infopanel-for-valdef-column-width-fit-content-length-percentage" role="dialog">
+   <span id="infopaneltitle-for-valdef-column-width-fit-content-length-percentage" style="display:none">Info about the 'fit-content(&lt;length-percentage>)' definition.</span><b><a href="#valdef-column-width-fit-content-length-percentage">#valdef-column-width-fit-content-length-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-fit-content-length-percentage">3.4. 
 New Column Sizing Values: the min-content, max-content, and fit-content() values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cyclic-percentage-size">
-   <b><a href="#cyclic-percentage-size">#cyclic-percentage-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cyclic-percentage-size" class="dfn-panel" data-for="cyclic-percentage-size" id="infopanel-for-cyclic-percentage-size" role="dialog">
+   <span id="infopaneltitle-for-cyclic-percentage-size" style="display:none">Info about the 'cyclic percentage size' definition.</span><b><a href="#cyclic-percentage-size">#cyclic-percentage-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cyclic-percentage-size">5.2.1. 
 Intrinsic Contributions of Percentage-Sized Boxes</a> <a href="#ref-for-cyclic-percentage-size①">(2)</a> <a href="#ref-for-cyclic-percentage-size②">(3)</a> <a href="#ref-for-cyclic-percentage-size③">(4)</a>
@@ -4043,59 +4047,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-sizing-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-sizing-4/Overview.html
@@ -2105,93 +2105,93 @@ as well as by the transferred minimum, if any.</p>
    <li><a href="#valdef-min-intrinsic-size-zero-if-extrinsic">zero-if-extrinsic</a><span>, in § 5.4</span>
    <li><a href="#valdef-min-intrinsic-size-zero-if-scroll">zero-if-scroll</a><span>, in § 5.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-alignment-container">
-   <a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-alignment-container" class="dfn-panel" data-for="term-for-alignment-container" id="infopanel-for-term-for-alignment-container" role="menu">
+   <span id="infopaneltitle-for-term-for-alignment-container" style="display:none">Info about the 'alignment container' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#alignment-container">https://drafts.csswg.org/css-align-3/#alignment-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alignment-container">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-self" class="dfn-panel" data-for="term-for-propdef-justify-self" id="infopanel-for-term-for-propdef-justify-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-self" style="display:none">Info about the 'justify-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">https://drafts.csswg.org/css-align-3/#propdef-justify-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-self">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-self-alignment-properties">
-   <a href="https://drafts.csswg.org/css-align-3/#self-alignment-properties">https://drafts.csswg.org/css-align-3/#self-alignment-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-self-alignment-properties" class="dfn-panel" data-for="term-for-self-alignment-properties" id="infopanel-for-term-for-self-alignment-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-self-alignment-properties" style="display:none">Info about the 'self-alignment properties' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#self-alignment-properties">https://drafts.csswg.org/css-align-3/#self-alignment-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-alignment-properties">6.1. 
 Stretch-fit Sizing: filling the containing block</a> <a href="#ref-for-self-alignment-properties①">(2)</a> <a href="#ref-for-self-alignment-properties②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-start">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-start" class="dfn-panel" data-for="term-for-valdef-self-position-start" id="infopanel-for-term-for-valdef-self-position-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-start">https://drafts.csswg.org/css-align-3/#valdef-self-position-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-start">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-stretch" class="dfn-panel" data-for="term-for-valdef-align-self-stretch" id="infopanel-for-term-for-valdef-align-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-stretch" style="display:none">Info about the 'stretch (for align-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-align-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-stretch">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-justify-self-stretch">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-justify-self-stretch" class="dfn-panel" data-for="term-for-valdef-justify-self-stretch" id="infopanel-for-term-for-valdef-justify-self-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-justify-self-stretch" style="display:none">Info about the 'stretch (for justify-self)' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch">https://drafts.csswg.org/css-align-3/#valdef-justify-self-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-justify-self-stretch">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">6.2. 
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-box">
-   <a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-box" class="dfn-panel" data-for="term-for-content-box" id="infopanel-for-term-for-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-content-box" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-box">https://drafts.csswg.org/css-box-4/#content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-box">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-content-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin" class="dfn-panel" data-for="term-for-margin" id="infopanel-for-term-for-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin">https://drafts.csswg.org/css-box-4/#margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin">6.1. 
 Stretch-fit Sizing: filling the containing block</a> <a href="#ref-for-margin①">(2)</a> <a href="#ref-for-margin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-margin-box">
-   <a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-margin-box" class="dfn-panel" data-for="term-for-margin-box" id="infopanel-for-term-for-margin-box" role="menu">
+   <span id="infopaneltitle-for-term-for-margin-box" style="display:none">Info about the 'margin box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#margin-box">https://drafts.csswg.org/css-box-4/#margin-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-box">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4.2.1. 
 Margin-collapsing</a>
     <li><a href="#ref-for-computed-value①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-size-containment">
-   <a href="https://drafts.csswg.org/css-contain-2/#size-containment">https://drafts.csswg.org/css-contain-2/#size-containment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-size-containment" class="dfn-panel" data-for="term-for-size-containment" id="infopanel-for-term-for-size-containment" role="menu">
+   <span id="infopaneltitle-for-term-for-size-containment" style="display:none">Info about the 'size containment' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#size-containment">https://drafts.csswg.org/css-contain-2/#size-containment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-containment">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-size-containment①">(2)</a> <a href="#ref-for-size-containment②">(3)</a> <a href="#ref-for-size-containment③">(4)</a>
@@ -2199,22 +2199,22 @@ Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a 
 Last Remembered Size</a> <a href="#ref-for-size-containment⑤">(2)</a> <a href="#ref-for-size-containment⑥">(3)</a> <a href="#ref-for-size-containment⑦">(4)</a> <a href="#ref-for-size-containment⑧">(5)</a> <a href="#ref-for-size-containment⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level-box" class="dfn-panel" data-for="term-for-block-level-box" id="infopanel-for-term-for-block-level-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level-box" style="display:none">Info about the 'block-level box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level-box">https://drafts.csswg.org/css-display-3/#block-level-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level-box">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
@@ -2222,15 +2222,15 @@ New Sizing Values: the stretch, fit-content, and contain keywords</a>
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-context" class="dfn-panel" data-for="term-for-formatting-context" id="infopanel-for-term-for-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-context" style="display:none">Info about the 'formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#formatting-context">https://drafts.csswg.org/css-display-3/#formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-context">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
@@ -2238,8 +2238,8 @@ Preferred Aspect Ratios: the aspect-ratio property</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-non-replaced①">(2)</a>
@@ -2247,8 +2247,8 @@ Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-non-rep
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">4. 
 Aspect Ratios</a>
@@ -2263,15 +2263,15 @@ Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
     <li><a href="#ref-for-replaced-element⑧"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid-container">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid-container" class="dfn-panel" data-for="term-for-grid-container" id="infopanel-for-term-for-grid-container" role="menu">
+   <span id="infopaneltitle-for-term-for-grid-container" style="display:none">Info about the 'grid container' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid-container">https://drafts.csswg.org/css-grid-2/#grid-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid-container">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">4. 
 Aspect Ratios</a>
@@ -2281,51 +2281,51 @@ Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-natural
 Effects of Preferred Aspect Ratio on Automatic Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-dimensions">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-dimensions" class="dfn-panel" data-for="term-for-natural-dimensions" id="infopanel-for-term-for-natural-dimensions" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-dimensions" style="display:none">Info about the 'natural dimension' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-dimensions">https://drafts.csswg.org/css-images-3/#natural-dimensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-dimensions">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-natural-dimensions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-height">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-height" class="dfn-panel" data-for="term-for-natural-height" id="infopanel-for-term-for-natural-height" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-height" style="display:none">Info about the 'natural height' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-height">https://drafts.csswg.org/css-images-3/#natural-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-height">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">4.2. 
 Effects of Preferred Aspect Ratio on Automatic Sizes</a>
     <li><a href="#ref-for-natural-size①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-width">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-width">https://drafts.csswg.org/css-images-3/#natural-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-width" class="dfn-panel" data-for="term-for-natural-width" id="infopanel-for-term-for-natural-width" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-width" style="display:none">Info about the 'natural width' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-width">https://drafts.csswg.org/css-images-3/#natural-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-width">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-object-fit-contain">
-   <a href="https://drafts.csswg.org/css-images-4/#valdef-object-fit-contain">https://drafts.csswg.org/css-images-4/#valdef-object-fit-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-object-fit-contain" class="dfn-panel" data-for="term-for-valdef-object-fit-contain" id="infopanel-for-term-for-valdef-object-fit-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-object-fit-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#valdef-object-fit-contain">https://drafts.csswg.org/css-images-4/#valdef-object-fit-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-object-fit-contain">6.2. 
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-fit">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-fit" class="dfn-panel" data-for="term-for-propdef-object-fit" id="infopanel-for-term-for-propdef-object-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-fit" style="display:none">Info about the 'object-fit' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-object-fit">https://drafts.csswg.org/css-images-4/#propdef-object-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-fit">6.2. 
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-size" class="dfn-panel" data-for="term-for-propdef-block-size" id="infopanel-for-term-for-propdef-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-size" style="display:none">Info about the 'block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
@@ -2334,50 +2334,50 @@ Margin-collapsing</a>
     <li><a href="#ref-for-propdef-block-size②"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inline-size" class="dfn-panel" data-for="term-for-propdef-inline-size" id="infopanel-for-term-for-propdef-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inline-size" style="display:none">Info about the 'inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-property-group">
-   <a href="https://drafts.csswg.org/css-logical-1/#logical-property-group">https://drafts.csswg.org/css-logical-1/#logical-property-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-property-group" class="dfn-panel" data-for="term-for-logical-property-group" id="infopanel-for-term-for-logical-property-group" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-property-group" style="display:none">Info about the 'logical property group' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#logical-property-group">https://drafts.csswg.org/css-logical-1/#logical-property-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-property-group">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-block-size" class="dfn-panel" data-for="term-for-propdef-max-block-size" id="infopanel-for-term-for-propdef-max-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-block-size" style="display:none">Info about the 'max-block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-max-block-size">https://drafts.csswg.org/css-logical-1/#propdef-max-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-block-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-inline-size" class="dfn-panel" data-for="term-for-propdef-max-inline-size" id="infopanel-for-term-for-propdef-max-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-inline-size" style="display:none">Info about the 'max-inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-max-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-inline-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-min-block-size">https://drafts.csswg.org/css-logical-1/#propdef-min-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-block-size" class="dfn-panel" data-for="term-for-propdef-min-block-size" id="infopanel-for-term-for-propdef-min-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-block-size" style="display:none">Info about the 'min-block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-min-block-size">https://drafts.csswg.org/css-logical-1/#propdef-min-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-block-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-inline-size" class="dfn-panel" data-for="term-for-propdef-min-inline-size" id="infopanel-for-term-for-propdef-min-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-inline-size" style="display:none">Info about the 'min-inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-min-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-inline-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4.3. 
 Automatic Content-based Minimum Sizes</a>
@@ -2385,8 +2385,8 @@ Automatic Content-based Minimum Sizes</a>
 Interaction With overflow: auto</a> <a href="#ref-for-propdef-overflow②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">4.3. 
 Automatic Content-based Minimum Sizes</a>
@@ -2394,15 +2394,15 @@ Automatic Content-based Minimum Sizes</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a> <a href="#ref-for-scroll-container②">(2)</a> <a href="#ref-for-scroll-container③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-position">
-   <a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-position" class="dfn-panel" data-for="term-for-absolute-position" id="infopanel-for-term-for-absolute-position" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-position" style="display:none">Info about the 'absolutely-positioned' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#absolute-position">https://drafts.csswg.org/css-position-3/#absolute-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-position">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
@@ -2415,15 +2415,15 @@ Stretch-fit Sizing: filling the containing block</a>
     <li><a href="#ref-for-valdef-width-auto⑤"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-minimum-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-minimum-size" class="dfn-panel" data-for="term-for-automatic-minimum-size" id="infopanel-for-term-for-automatic-minimum-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-minimum-size" style="display:none">Info about the 'automatic minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size">https://drafts.csswg.org/css-sizing-3/#automatic-minimum-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-minimum-size">4.3. 
 Automatic Content-based Minimum Sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">4.2. 
 Effects of Preferred Aspect Ratio on Automatic Sizes</a> <a href="#ref-for-automatic-size①">(2)</a> <a href="#ref-for-automatic-size②">(3)</a>
@@ -2433,8 +2433,8 @@ Min/Max Size Transfers</a>
 Stretch-fit Sizing: filling the containing block</a> <a href="#ref-for-automatic-size⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto" style="display:none">Info about the 'behave as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">4.4. 
 Min/Max Size Transfers</a>
@@ -2442,8 +2442,8 @@ Min/Max Size Transfers</a>
 Stretch-fit Sizing: filling the containing block</a> <a href="#ref-for-behave-as-auto②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto①" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto①" style="display:none">Info about the 'behaves as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">4.4. 
 Min/Max Size Transfers</a>
@@ -2451,8 +2451,8 @@ Min/Max Size Transfers</a>
 Stretch-fit Sizing: filling the containing block</a> <a href="#ref-for-behave-as-auto②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
@@ -2460,8 +2460,8 @@ Preferred Aspect Ratios: the aspect-ratio property</a>
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">4.2. 
 Effects of Preferred Aspect Ratio on Automatic Sizes</a> <a href="#ref-for-definite①">(2)</a>
@@ -2470,15 +2470,15 @@ Min/Max Size Transfers</a> <a href="#ref-for-definite③">(2)</a> <a href="#ref-
     <li><a href="#ref-for-definite⑥"> Recent Changes</a> <a href="#ref-for-definite⑦">(2)</a> <a href="#ref-for-definite⑧">(3)</a> <a href="#ref-for-definite⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extrinsic-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#extrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#extrinsic-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extrinsic-sizing" class="dfn-panel" data-for="term-for-extrinsic-sizing" id="infopanel-for-term-for-extrinsic-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-extrinsic-sizing" style="display:none">Info about the 'extrinsic sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#extrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#extrinsic-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extrinsic-sizing">5.4. 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">1.1. 
 Module interactions</a>
@@ -2492,29 +2492,29 @@ Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indefinite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indefinite" class="dfn-panel" data-for="term-for-indefinite" id="infopanel-for-term-for-indefinite" role="menu">
+   <span id="infopaneltitle-for-term-for-indefinite" style="display:none">Info about the 'indefinite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#indefinite">https://drafts.csswg.org/css-sizing-3/#indefinite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indefinite">4.4. 
 Min/Max Size Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">4.4. 
 Min/Max Size Transfers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
@@ -2522,8 +2522,8 @@ New Sizing Values: the stretch, fit-content, and contain keywords</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'maximum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">4.3. 
 Automatic Content-based Minimum Sizes</a>
@@ -2534,8 +2534,8 @@ Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
     <li><a href="#ref-for-max-width⑤"> Recent Changes</a> <a href="#ref-for-max-width⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-min-content" class="dfn-panel" data-for="term-for-valdef-width-min-content" id="infopanel-for-term-for-valdef-width-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-min-content" style="display:none">Info about the 'min-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-min-content">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
@@ -2543,15 +2543,15 @@ New Sizing Values: the stretch, fit-content, and contain keywords</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-contribution" class="dfn-panel" data-for="term-for-min-content-contribution" id="infopanel-for-term-for-min-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">5.4. 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a> <a href="#ref-for-min-content-contribution①">(2)</a> <a href="#ref-for-min-content-contribution②">(3)</a> <a href="#ref-for-min-content-contribution③">(4)</a> <a href="#ref-for-min-content-contribution④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">4.3. 
 Automatic Content-based Minimum Sizes</a>
@@ -2559,30 +2559,30 @@ Automatic Content-based Minimum Sizes</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'minimum size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">4.4. 
 Min/Max Size Transfers</a> <a href="#ref-for-min-width①">(2)</a> <a href="#ref-for-min-width②">(3)</a>
     <li><a href="#ref-for-min-width③"> Recent Changes</a> <a href="#ref-for-min-width④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-max-width-none">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-max-width-none">https://drafts.csswg.org/css-sizing-3/#valdef-max-width-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-max-width-none" class="dfn-panel" data-for="term-for-valdef-max-width-none" id="infopanel-for-term-for-valdef-max-width-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-max-width-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-max-width-none">https://drafts.csswg.org/css-sizing-3/#valdef-max-width-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-width-none">6.2. 
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-outer-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-outer-size" class="dfn-panel" data-for="term-for-outer-size" id="infopanel-for-term-for-outer-size" role="menu">
+   <span id="infopaneltitle-for-term-for-outer-size" style="display:none">Info about the 'outer height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#outer-size">https://drafts.csswg.org/css-sizing-3/#outer-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-size">6.1. 
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size" class="dfn-panel" data-for="term-for-preferred-size" id="infopanel-for-term-for-preferred-size" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size" style="display:none">Info about the 'preferred size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size">https://drafts.csswg.org/css-sizing-3/#preferred-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size">4.2. 
 Effects of Preferred Aspect Ratio on Automatic Sizes</a> <a href="#ref-for-preferred-size①">(2)</a> <a href="#ref-for-preferred-size②">(3)</a>
@@ -2593,8 +2593,8 @@ Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
     <li><a href="#ref-for-preferred-size⑦"> Recent Changes</a> <a href="#ref-for-preferred-size⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sizing-property">
-   <a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sizing-property" class="dfn-panel" data-for="term-for-sizing-property" id="infopanel-for-term-for-sizing-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sizing-property" style="display:none">Info about the 'sizing property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#sizing-property">https://drafts.csswg.org/css-sizing-3/#sizing-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-property">5.4. 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
@@ -2602,8 +2602,8 @@ Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-size" class="dfn-panel" data-for="term-for-stretch-fit-size" id="infopanel-for-term-for-stretch-fit-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-size" style="display:none">Info about the 'stretch-fit size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-size">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a> <a href="#ref-for-stretch-fit-size①">(2)</a>
@@ -2613,8 +2613,8 @@ Stretch-fit Sizing: filling the containing block</a>
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">1.1. 
 Module interactions</a>
@@ -2628,50 +2628,50 @@ Automatic Content-based Minimum Sizes</a>
 Stretch-fit Sizing: filling the containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-comb-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a> <a href="#ref-for-length-value④">(5)</a> <a href="#ref-for-length-value⑤">(6)</a> <a href="#ref-for-length-value⑥">(7)</a> <a href="#ref-for-length-value⑦">(8)</a> <a href="#ref-for-length-value⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ratio-value">
-   <a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ratio-value" class="dfn-panel" data-for="term-for-ratio-value" id="infopanel-for-term-for-ratio-value" role="menu">
+   <span id="infopaneltitle-for-term-for-ratio-value" style="display:none">Info about the '&lt;ratio>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-value">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-ratio-value①">(2)</a> <a href="#ref-for-ratio-value②">(3)</a> <a href="#ref-for-ratio-value③">(4)</a> <a href="#ref-for-ratio-value④">(5)</a> <a href="#ref-for-ratio-value⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-degenerate-ratio">
-   <a href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">https://drafts.csswg.org/css-values-4/#degenerate-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-degenerate-ratio" class="dfn-panel" data-for="term-for-degenerate-ratio" id="infopanel-for-term-for-degenerate-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-degenerate-ratio" style="display:none">Info about the 'degenerate ratio' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#degenerate-ratio">https://drafts.csswg.org/css-values-4/#degenerate-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-degenerate-ratio">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-degenerate-ratio①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -2681,8 +2681,8 @@ Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
@@ -2690,16 +2690,16 @@ Preferred Aspect Ratios: the aspect-ratio property</a>
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">4.2.1. 
 Margin-collapsing</a>
     <li><a href="#ref-for-block-axis①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">1.1. 
 Module interactions</a>
@@ -2709,8 +2709,8 @@ New Sizing Values: the stretch, fit-content, and contain keywords</a>
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">1.1. 
 Module interactions</a>
@@ -2720,8 +2720,8 @@ New Sizing Values: the stretch, fit-content, and contain keywords</a>
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">1.1. 
 Module interactions</a>
@@ -2733,8 +2733,8 @@ Automatic Content-based Minimum Sizes</a>
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">1.1. 
 Module interactions</a>
@@ -2746,15 +2746,15 @@ Automatic Content-based Minimum Sizes</a> <a href="#ref-for-propdef-min-width③
 Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">1.1. 
 Module interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a>
@@ -3087,8 +3087,8 @@ Preferred Aspect Ratios: the aspect-ratio property</a>
 	do we honor the aspect ratio or skew the image?
 	If the former, we need a step similar to #2 that applies the relevant minimums. <a class="issue-return" href="#issue-9d61aaed" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="valdef-width-stretch">
-   <b><a href="#valdef-width-stretch">#valdef-width-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-stretch" class="dfn-panel" data-for="valdef-width-stretch" id="infopanel-for-valdef-width-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-width-stretch">#valdef-width-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-stretch">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a> <a href="#ref-for-valdef-width-stretch①">(2)</a>
@@ -3097,8 +3097,8 @@ Stretch-fit Sizing: filling the containing block</a>
     <li><a href="#ref-for-valdef-width-stretch③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-fit-content">
-   <b><a href="#valdef-width-fit-content">#valdef-width-fit-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-fit-content" class="dfn-panel" data-for="valdef-width-fit-content" id="infopanel-for-valdef-width-fit-content" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-fit-content" style="display:none">Info about the 'fit-content' definition.</span><b><a href="#valdef-width-fit-content">#valdef-width-fit-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-fit-content">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
@@ -3107,16 +3107,16 @@ Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
     <li><a href="#ref-for-valdef-width-fit-content②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-contain">
-   <b><a href="#valdef-width-contain">#valdef-width-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-contain" class="dfn-panel" data-for="valdef-width-contain" id="infopanel-for-valdef-width-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-width-contain">#valdef-width-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-contain">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a>
     <li><a href="#ref-for-valdef-width-contain①"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-aspect-ratio">
-   <b><a href="#propdef-aspect-ratio">#propdef-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-aspect-ratio" class="dfn-panel" data-for="propdef-aspect-ratio" id="infopanel-for-propdef-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' definition.</span><b><a href="#propdef-aspect-ratio">#propdef-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">4. 
 Aspect Ratios</a>
@@ -3126,8 +3126,8 @@ Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-propdef
     <li><a href="#ref-for-propdef-aspect-ratio⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-aspect-ratio">
-   <b><a href="#preferred-aspect-ratio">#preferred-aspect-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-aspect-ratio" class="dfn-panel" data-for="preferred-aspect-ratio" id="infopanel-for-preferred-aspect-ratio" role="dialog">
+   <span id="infopaneltitle-for-preferred-aspect-ratio" style="display:none">Info about the 'preferred aspect ratio' definition.</span><b><a href="#preferred-aspect-ratio">#preferred-aspect-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-aspect-ratio">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a> <a href="#ref-for-preferred-aspect-ratio①">(2)</a> <a href="#ref-for-preferred-aspect-ratio②">(3)</a>
@@ -3146,15 +3146,15 @@ Contain-fit Sizing: stretching while maintaining an aspect ratio</a> <a href="#r
     <li><a href="#ref-for-preferred-aspect-ratio①⑧"> Recent Changes</a> <a href="#ref-for-preferred-aspect-ratio①⑨">(2)</a> <a href="#ref-for-preferred-aspect-ratio②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-aspect-ratio-auto">
-   <b><a href="#valdef-aspect-ratio-auto">#valdef-aspect-ratio-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-aspect-ratio-auto" class="dfn-panel" data-for="valdef-aspect-ratio-auto" id="infopanel-for-valdef-aspect-ratio-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-aspect-ratio-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-aspect-ratio-auto">#valdef-aspect-ratio-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-aspect-ratio-auto">4.1. 
 Preferred Aspect Ratios: the aspect-ratio property</a> <a href="#ref-for-valdef-aspect-ratio-auto①">(2)</a> <a href="#ref-for-valdef-aspect-ratio-auto②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ratio-dependent-axis">
-   <b><a href="#ratio-dependent-axis">#ratio-dependent-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ratio-dependent-axis" class="dfn-panel" data-for="ratio-dependent-axis" id="infopanel-for-ratio-dependent-axis" role="dialog">
+   <span id="infopaneltitle-for-ratio-dependent-axis" style="display:none">Info about the 'ratio-dependent axis' definition.</span><b><a href="#ratio-dependent-axis">#ratio-dependent-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-dependent-axis">4.2. 
 Effects of Preferred Aspect Ratio on Automatic Sizes</a>
@@ -3167,35 +3167,35 @@ Min/Max Size Transfers</a>
     <li><a href="#ref-for-ratio-dependent-axis④"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ratio-determining-axis">
-   <b><a href="#ratio-determining-axis">#ratio-determining-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ratio-determining-axis" class="dfn-panel" data-for="ratio-determining-axis" id="infopanel-for-ratio-determining-axis" role="dialog">
+   <span id="infopaneltitle-for-ratio-determining-axis" style="display:none">Info about the 'ratio-determining axis' definition.</span><b><a href="#ratio-determining-axis">#ratio-determining-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-determining-axis"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-contain-intrinsic-width">
-   <b><a href="#propdef-contain-intrinsic-width">#propdef-contain-intrinsic-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-contain-intrinsic-width" class="dfn-panel" data-for="propdef-contain-intrinsic-width" id="infopanel-for-propdef-contain-intrinsic-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-contain-intrinsic-width" style="display:none">Info about the 'contain-intrinsic-width' definition.</span><b><a href="#propdef-contain-intrinsic-width">#propdef-contain-intrinsic-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain-intrinsic-width">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-propdef-contain-intrinsic-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-contain-intrinsic-height">
-   <b><a href="#propdef-contain-intrinsic-height">#propdef-contain-intrinsic-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-contain-intrinsic-height" class="dfn-panel" data-for="propdef-contain-intrinsic-height" id="infopanel-for-propdef-contain-intrinsic-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-contain-intrinsic-height" style="display:none">Info about the 'contain-intrinsic-height' definition.</span><b><a href="#propdef-contain-intrinsic-height">#propdef-contain-intrinsic-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain-intrinsic-height">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-propdef-contain-intrinsic-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="explicit-intrinsic-inner-size">
-   <b><a href="#explicit-intrinsic-inner-size">#explicit-intrinsic-inner-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-explicit-intrinsic-inner-size" class="dfn-panel" data-for="explicit-intrinsic-inner-size" id="infopanel-for-explicit-intrinsic-inner-size" role="dialog">
+   <span id="infopaneltitle-for-explicit-intrinsic-inner-size" style="display:none">Info about the 'explicit intrinsic inner size' definition.</span><b><a href="#explicit-intrinsic-inner-size">#explicit-intrinsic-inner-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-explicit-intrinsic-inner-size">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-explicit-intrinsic-inner-size①">(2)</a> <a href="#ref-for-explicit-intrinsic-inner-size②">(3)</a> <a href="#ref-for-explicit-intrinsic-inner-size③">(4)</a> <a href="#ref-for-explicit-intrinsic-inner-size④">(5)</a> <a href="#ref-for-explicit-intrinsic-inner-size⑤">(6)</a> <a href="#ref-for-explicit-intrinsic-inner-size⑥">(7)</a> <a href="#ref-for-explicit-intrinsic-inner-size⑦">(8)</a> <a href="#ref-for-explicit-intrinsic-inner-size⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-contain-intrinsic-size">
-   <b><a href="#propdef-contain-intrinsic-size">#propdef-contain-intrinsic-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-contain-intrinsic-size" class="dfn-panel" data-for="propdef-contain-intrinsic-size" id="infopanel-for-propdef-contain-intrinsic-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-contain-intrinsic-size" style="display:none">Info about the 'contain-intrinsic-size' definition.</span><b><a href="#propdef-contain-intrinsic-size">#propdef-contain-intrinsic-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain-intrinsic-size">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a>
@@ -3207,8 +3207,9 @@ Interaction With overflow: auto</a> <a href="#ref-for-propdef-contain-intrinsic-
     <li><a href="#ref-for-propdef-contain-intrinsic-size①②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-remembered">
-   <b><a href="#last-remembered">#last-remembered</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-remembered" class="dfn-panel" data-for="last-remembered" id="infopanel-for-last-remembered" role="dialog">
+   <span id="infopaneltitle-for-last-remembered" style="display:none">Info about the '5.2.1. 
+Last Remembered Size' definition.</span><b><a href="#last-remembered">#last-remembered</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-remembered">5.2. 
 Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a href="#ref-for-last-remembered①">(2)</a>
@@ -3216,23 +3217,24 @@ Overriding Contained Intrinsic Sizes: the contain-intrinsic-* properties</a> <a 
 Last Remembered Size</a> <a href="#ref-for-last-remembered②">(2)</a> <a href="#ref-for-last-remembered③">(3)</a> <a href="#ref-for-last-remembered④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-intrinsic-sizing">
-   <b><a href="#propdef-min-intrinsic-sizing">#propdef-min-intrinsic-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-intrinsic-sizing" class="dfn-panel" data-for="propdef-min-intrinsic-sizing" id="infopanel-for-propdef-min-intrinsic-sizing" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-intrinsic-sizing" style="display:none">Info about the 'min-intrinsic-sizing' definition.</span><b><a href="#propdef-min-intrinsic-sizing">#propdef-min-intrinsic-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-intrinsic-sizing">5.4. 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
     <li><a href="#ref-for-propdef-min-intrinsic-sizing①"> Recent Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-min-intrinsic-size-zero-if-scroll">
-   <b><a href="#valdef-min-intrinsic-size-zero-if-scroll">#valdef-min-intrinsic-size-zero-if-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-min-intrinsic-size-zero-if-scroll" class="dfn-panel" data-for="valdef-min-intrinsic-size-zero-if-scroll" id="infopanel-for-valdef-min-intrinsic-size-zero-if-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-min-intrinsic-size-zero-if-scroll" style="display:none">Info about the 'zero-if-scroll' definition.</span><b><a href="#valdef-min-intrinsic-size-zero-if-scroll">#valdef-min-intrinsic-size-zero-if-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-min-intrinsic-size-zero-if-scroll">5.4. 
 Zeroing Min-Content Size Contributions: the min-intrinsic-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contain-fit-sizing">
-   <b><a href="#contain-fit-sizing">#contain-fit-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contain-fit-sizing" class="dfn-panel" data-for="contain-fit-sizing" id="infopanel-for-contain-fit-sizing" role="dialog">
+   <span id="infopaneltitle-for-contain-fit-sizing" style="display:none">Info about the '6.2. 
+Contain-fit Sizing: stretching while maintaining an aspect ratio' definition.</span><b><a href="#contain-fit-sizing">#contain-fit-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contain-fit-sizing">3.2. 
 New Sizing Values: the stretch, fit-content, and contain keywords</a> <a href="#ref-for-contain-fit-sizing">(2)</a>
@@ -3242,59 +3244,115 @@ Contain-fit Sizing: stretching while maintaining an aspect ratio</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-speech-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-speech-1/Overview.html
@@ -2677,177 +2677,177 @@ li::before { content: "List item: "; }</pre>
     </ul>
    <li><a href="#valdef-voice-family-young">young</a><span>, in § 11.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">5. 
 The aural formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">5. 
 The aural formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">5. 
 The aural formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-break-before-all">
-   <a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-all">https://drafts.csswg.org/css-break-4/#valdef-break-before-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-break-before-all" class="dfn-panel" data-for="term-for-valdef-break-before-all" id="infopanel-for-term-for-valdef-break-before-all" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-break-before-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#valdef-break-before-all">https://drafts.csswg.org/css-break-4/#valdef-break-before-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-break-before-all">2. 
 Background information, CSS 2.1</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-armenian">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#armenian">https://drafts.csswg.org/css-counter-styles-3/#armenian</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-armenian" class="dfn-panel" data-for="term-for-armenian" id="infopanel-for-term-for-armenian" role="menu">
+   <span id="infopaneltitle-for-term-for-armenian" style="display:none">Info about the 'armenian' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#armenian">https://drafts.csswg.org/css-counter-styles-3/#armenian</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-armenian">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decimal">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#decimal">https://drafts.csswg.org/css-counter-styles-3/#decimal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decimal" class="dfn-panel" data-for="term-for-decimal" id="infopanel-for-term-for-decimal" role="menu">
+   <span id="infopaneltitle-for-term-for-decimal" style="display:none">Info about the 'decimal' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#decimal">https://drafts.csswg.org/css-counter-styles-3/#decimal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decimal">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decimal-leading-zero">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#decimal-leading-zero">https://drafts.csswg.org/css-counter-styles-3/#decimal-leading-zero</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decimal-leading-zero" class="dfn-panel" data-for="term-for-decimal-leading-zero" id="infopanel-for-term-for-decimal-leading-zero" role="menu">
+   <span id="infopaneltitle-for-term-for-decimal-leading-zero" style="display:none">Info about the 'decimal-leading-zero' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#decimal-leading-zero">https://drafts.csswg.org/css-counter-styles-3/#decimal-leading-zero</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decimal-leading-zero">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-georgian">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#georgian">https://drafts.csswg.org/css-counter-styles-3/#georgian</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-georgian" class="dfn-panel" data-for="term-for-georgian" id="infopanel-for-term-for-georgian" role="menu">
+   <span id="infopaneltitle-for-term-for-georgian" style="display:none">Info about the 'georgian' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#georgian">https://drafts.csswg.org/css-counter-styles-3/#georgian</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-georgian">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-lower-alpha">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#lower-alpha">https://drafts.csswg.org/css-counter-styles-3/#lower-alpha</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-lower-alpha" class="dfn-panel" data-for="term-for-lower-alpha" id="infopanel-for-term-for-lower-alpha" role="menu">
+   <span id="infopaneltitle-for-term-for-lower-alpha" style="display:none">Info about the 'lower-alpha' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#lower-alpha">https://drafts.csswg.org/css-counter-styles-3/#lower-alpha</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-alpha">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-lower-greek">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#lower-greek">https://drafts.csswg.org/css-counter-styles-3/#lower-greek</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-lower-greek" class="dfn-panel" data-for="term-for-lower-greek" id="infopanel-for-term-for-lower-greek" role="menu">
+   <span id="infopaneltitle-for-term-for-lower-greek" style="display:none">Info about the 'lower-greek' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#lower-greek">https://drafts.csswg.org/css-counter-styles-3/#lower-greek</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-greek">13. 
 List items and counters styles</a> <a href="#ref-for-lower-greek①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-lower-latin">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#lower-latin">https://drafts.csswg.org/css-counter-styles-3/#lower-latin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-lower-latin" class="dfn-panel" data-for="term-for-lower-latin" id="infopanel-for-term-for-lower-latin" role="menu">
+   <span id="infopaneltitle-for-term-for-lower-latin" style="display:none">Info about the 'lower-latin' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#lower-latin">https://drafts.csswg.org/css-counter-styles-3/#lower-latin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-latin">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-lower-roman">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#lower-roman">https://drafts.csswg.org/css-counter-styles-3/#lower-roman</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-lower-roman" class="dfn-panel" data-for="term-for-lower-roman" id="infopanel-for-term-for-lower-roman" role="menu">
+   <span id="infopaneltitle-for-term-for-lower-roman" style="display:none">Info about the 'lower-roman' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#lower-roman">https://drafts.csswg.org/css-counter-styles-3/#lower-roman</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lower-roman">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upper-alpha">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#upper-alpha">https://drafts.csswg.org/css-counter-styles-3/#upper-alpha</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upper-alpha" class="dfn-panel" data-for="term-for-upper-alpha" id="infopanel-for-term-for-upper-alpha" role="menu">
+   <span id="infopaneltitle-for-term-for-upper-alpha" style="display:none">Info about the 'upper-alpha' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#upper-alpha">https://drafts.csswg.org/css-counter-styles-3/#upper-alpha</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-alpha">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upper-latin">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#upper-latin">https://drafts.csswg.org/css-counter-styles-3/#upper-latin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upper-latin" class="dfn-panel" data-for="term-for-upper-latin" id="infopanel-for-term-for-upper-latin" role="menu">
+   <span id="infopaneltitle-for-term-for-upper-latin" style="display:none">Info about the 'upper-latin' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#upper-latin">https://drafts.csswg.org/css-counter-styles-3/#upper-latin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-latin">13. 
 List items and counters styles</a> <a href="#ref-for-upper-latin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upper-roman">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#upper-roman">https://drafts.csswg.org/css-counter-styles-3/#upper-roman</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upper-roman" class="dfn-panel" data-for="term-for-upper-roman" id="infopanel-for-term-for-upper-roman" role="menu">
+   <span id="infopaneltitle-for-term-for-upper-roman" style="display:none">Info about the 'upper-roman' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#upper-roman">https://drafts.csswg.org/css-counter-styles-3/#upper-roman</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upper-roman">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">7.1. 
 The speak property</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a> <a href="#ref-for-propdef-display③">(4)</a> <a href="#ref-for-propdef-display④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">7.1. 
 The speak property</a> <a href="#ref-for-valdef-display-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">7.1. 
 The speak property</a>
     <li><a href="#ref-for-propdef-visibility①"> Appendix E — Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-visible">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-visible" class="dfn-panel" data-for="term-for-valdef-visibility-visible" id="infopanel-for-term-for-valdef-visibility-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-visible">7.1. 
 The speak property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-family-name-value">
-   <a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-family-name-value" class="dfn-panel" data-for="term-for-family-name-value" id="infopanel-for-term-for-family-name-value" role="menu">
+   <span id="infopaneltitle-for-term-for-family-name-value" style="display:none">Info about the '&lt;family-name>' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-family-name-value">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">11.1. 
 The voice-family property</a> <a href="#ref-for-propdef-font-family①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">6.2. 
 The voice-balance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">6.2. 
 The voice-balance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">5. 
 The aural formatting model</a>
@@ -2855,8 +2855,8 @@ The aural formatting model</a>
 Inserted and replaced content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">5. 
 The aural formatting model</a>
@@ -2864,8 +2864,8 @@ The aural formatting model</a>
 Inserted and replaced content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">11.3. 
 The voice-pitch property</a>
@@ -2873,22 +2873,22 @@ The voice-pitch property</a>
 The voice-range property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frequency-value">
-   <a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frequency-value" class="dfn-panel" data-for="term-for-frequency-value" id="infopanel-for-term-for-frequency-value" role="menu">
+   <span id="infopaneltitle-for-term-for-frequency-value" style="display:none">Info about the '&lt;frequency>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-value">11.3. 
 The voice-pitch property</a> <a href="#ref-for-frequency-value①">(2)</a> <a href="#ref-for-frequency-value②">(3)</a>
@@ -2896,22 +2896,22 @@ The voice-pitch property</a> <a href="#ref-for-frequency-value①">(2)</a> <a hr
 The voice-range property</a> <a href="#ref-for-frequency-value④">(2)</a> <a href="#ref-for-frequency-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">11.1. 
 The voice-family property</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">6.2. 
 The voice-balance property</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">11.2. 
 The voice-rate property</a> <a href="#ref-for-percentage-value①">(2)</a>
@@ -2921,8 +2921,8 @@ The voice-pitch property</a> <a href="#ref-for-percentage-value③">(2)</a>
 The voice-range property</a> <a href="#ref-for-percentage-value⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">8.1. 
 The pause-before and pause-after properties</a>
@@ -2932,8 +2932,8 @@ The rest-before and rest-after properties</a> <a href="#ref-for-time-value②">(
 The voice-duration property</a> <a href="#ref-for-time-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">8.2. 
 The pause shorthand property</a>
@@ -2945,8 +2945,8 @@ The cue-before and cue-after properties</a>
 The cue shorthand property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">3.1. 
 Value Definitions</a>
@@ -2954,8 +2954,8 @@ Value Definitions</a>
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dimension" class="dfn-panel" data-for="term-for-dimension" id="infopanel-for-term-for-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-dimension" style="display:none">Info about the 'dimension' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#dimension">https://drafts.csswg.org/css-values-4/#dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">6.1. 
 The voice-volume property</a>
@@ -2963,22 +2963,22 @@ The voice-volume property</a>
 The voice-pitch property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-css-identifier">
-   <a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-css-identifier" class="dfn-panel" data-for="term-for-css-css-identifier" id="infopanel-for-term-for-css-css-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-css-css-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-css-identifier">https://drafts.csswg.org/css-values-4/#css-css-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-css-identifier">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number">
-   <a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number" class="dfn-panel" data-for="term-for-number" id="infopanel-for-term-for-number" role="menu">
+   <span id="infopaneltitle-for-term-for-number" style="display:none">Info about the 'number' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number">6.2. 
 The voice-balance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage">https://drafts.csswg.org/css-values-4/#percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage" class="dfn-panel" data-for="term-for-percentage" id="infopanel-for-term-for-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage" style="display:none">Info about the 'percentage' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage">https://drafts.csswg.org/css-values-4/#percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage">11.2. 
 The voice-rate property</a>
@@ -2988,8 +2988,8 @@ The voice-pitch property</a>
 The voice-range property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">6.1. 
 The voice-volume property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
@@ -3019,8 +3019,8 @@ The voice-stress property</a> <a href="#ref-for-comb-one⑤⓪">(2)</a> <a href=
 The voice-duration property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">6.1. 
 The voice-volume property</a>
@@ -3034,29 +3034,29 @@ The voice-pitch property</a>
 The voice-range property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-uri">
-   <a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-uri" class="dfn-panel" data-for="term-for-value-def-uri" id="infopanel-for-term-for-value-def-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-uri" style="display:none">Info about the '&lt;uri>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-uri">https://drafts.csswg.org/css2/#value-def-uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-uri">10.1. 
 The cue-before and cue-after properties</a> <a href="#ref-for-value-def-uri①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-screen">
-   <a href="https://drafts.csswg.org/css2/#valdef-media-screen">https://drafts.csswg.org/css2/#valdef-media-screen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-screen" class="dfn-panel" data-for="term-for-valdef-media-screen" id="infopanel-for-term-for-valdef-media-screen" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-screen" style="display:none">Info about the 'screen' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-media-screen">https://drafts.csswg.org/css2/#valdef-media-screen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-screen">2. 
 Background information, CSS 2.1</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-speech">
-   <a href="https://drafts.csswg.org/css2/#valdef-media-speech">https://drafts.csswg.org/css2/#valdef-media-speech</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-speech" class="dfn-panel" data-for="term-for-valdef-media-speech" id="infopanel-for-term-for-valdef-media-speech" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-speech" style="display:none">Info about the 'speech' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-media-speech">https://drafts.csswg.org/css2/#valdef-media-speech</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-speech">2. 
 Background information, CSS 2.1</a> <a href="#ref-for-valdef-media-speech①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-content">
-   <a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-content" class="dfn-panel" data-for="term-for-propdef-content" id="infopanel-for-term-for-propdef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-content" style="display:none">Info about the 'content' external reference.</span><a href="https://drafts.csswg.org/css-content-3/#propdef-content">https://drafts.csswg.org/css-content-3/#propdef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">13. 
 List items and counters styles</a>
@@ -3064,36 +3064,36 @@ List items and counters styles</a>
 Inserted and replaced content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-image">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-image" class="dfn-panel" data-for="term-for-propdef-list-style-image" id="infopanel-for-term-for-propdef-list-style-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-image">https://drafts.csswg.org/css-lists-3/#propdef-list-style-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">13. 
 List items and counters styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-list-style-type">
-   <a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-list-style-type" class="dfn-panel" data-for="term-for-propdef-list-style-type" id="infopanel-for-term-for-propdef-list-style-type" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#propdef-list-style-type">https://drafts.csswg.org/css-lists-3/#propdef-list-style-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">13. 
 List items and counters styles</a> <a href="#ref-for-propdef-list-style-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-span-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-span-element" class="dfn-panel" data-for="term-for-the-span-element" id="infopanel-for-term-for-the-span-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-span-element" style="display:none">Info about the 'span' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-span-element">4. 
 Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-aural">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural">https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-aural" class="dfn-panel" data-for="term-for-valdef-media-aural" id="infopanel-for-term-for-valdef-media-aural" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-aural" style="display:none">Info about the 'aural' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural">https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-aural">2. 
 Background information, CSS 2.1</a>
@@ -3463,8 +3463,8 @@ offset (if any)
       <td>silent, or a keyword value and optionally also a decibel offset (if not zero)
    </table>
   </div>
-  <aside class="dfn-panel" data-for="aural-box-model">
-   <b><a href="#aural-box-model">#aural-box-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aural-box-model" class="dfn-panel" data-for="aural-box-model" id="infopanel-for-aural-box-model" role="dialog">
+   <span id="infopaneltitle-for-aural-box-model" style="display:none">Info about the 'aural “box” model' definition.</span><b><a href="#aural-box-model">#aural-box-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aural-box-model">6.1. 
 The voice-volume property</a> <a href="#ref-for-aural-box-model①">(2)</a> <a href="#ref-for-aural-box-model②">(3)</a>
@@ -3478,8 +3478,8 @@ The cue-before and cue-after properties</a> <a href="#ref-for-aural-box-model⑧
 Relation between audio cues and speech synthesis volume levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-volume">
-   <b><a href="#propdef-voice-volume">#propdef-voice-volume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-volume" class="dfn-panel" data-for="propdef-voice-volume" id="infopanel-for-propdef-voice-volume" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-volume" style="display:none">Info about the 'voice-volume' definition.</span><b><a href="#propdef-voice-volume">#propdef-voice-volume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-volume">6.1. 
 The voice-volume property</a> <a href="#ref-for-propdef-voice-volume①">(2)</a> <a href="#ref-for-propdef-voice-volume②">(3)</a> <a href="#ref-for-propdef-voice-volume③">(4)</a> <a href="#ref-for-propdef-voice-volume④">(5)</a>
@@ -3489,8 +3489,8 @@ The cue-before and cue-after properties</a> <a href="#ref-for-propdef-voice-volu
 Relation between audio cues and speech synthesis volume levels</a> <a href="#ref-for-propdef-voice-volume①②">(2)</a> <a href="#ref-for-propdef-voice-volume①③">(3)</a> <a href="#ref-for-propdef-voice-volume①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-silent">
-   <b><a href="#valdef-voice-volume-silent">#valdef-voice-volume-silent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-silent" class="dfn-panel" data-for="valdef-voice-volume-silent" id="infopanel-for-valdef-voice-volume-silent" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-silent" style="display:none">Info about the 'silent' definition.</span><b><a href="#valdef-voice-volume-silent">#valdef-voice-volume-silent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-silent">6.1. 
 The voice-volume property</a> <a href="#ref-for-valdef-voice-volume-silent①">(2)</a> <a href="#ref-for-valdef-voice-volume-silent②">(3)</a> <a href="#ref-for-valdef-voice-volume-silent③">(4)</a>
@@ -3500,43 +3500,43 @@ The cue-before and cue-after properties</a> <a href="#ref-for-valdef-voice-volum
 Relation between audio cues and speech synthesis volume levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-x-soft">
-   <b><a href="#valdef-voice-volume-x-soft">#valdef-voice-volume-x-soft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-x-soft" class="dfn-panel" data-for="valdef-voice-volume-x-soft" id="infopanel-for-valdef-voice-volume-x-soft" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-x-soft" style="display:none">Info about the 'x-soft' definition.</span><b><a href="#valdef-voice-volume-x-soft">#valdef-voice-volume-x-soft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-x-soft">6.1. 
 The voice-volume property</a> <a href="#ref-for-valdef-voice-volume-x-soft①">(2)</a> <a href="#ref-for-valdef-voice-volume-x-soft②">(3)</a> <a href="#ref-for-valdef-voice-volume-x-soft③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-soft">
-   <b><a href="#valdef-voice-volume-soft">#valdef-voice-volume-soft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-soft" class="dfn-panel" data-for="valdef-voice-volume-soft" id="infopanel-for-valdef-voice-volume-soft" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-soft" style="display:none">Info about the 'soft' definition.</span><b><a href="#valdef-voice-volume-soft">#valdef-voice-volume-soft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-soft">6.1. 
 The voice-volume property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-medium">
-   <b><a href="#valdef-voice-volume-medium">#valdef-voice-volume-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-medium" class="dfn-panel" data-for="valdef-voice-volume-medium" id="infopanel-for-valdef-voice-volume-medium" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#valdef-voice-volume-medium">#valdef-voice-volume-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-medium">6.1. 
 The voice-volume property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-loud">
-   <b><a href="#valdef-voice-volume-loud">#valdef-voice-volume-loud</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-loud" class="dfn-panel" data-for="valdef-voice-volume-loud" id="infopanel-for-valdef-voice-volume-loud" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-loud" style="display:none">Info about the 'loud' definition.</span><b><a href="#valdef-voice-volume-loud">#valdef-voice-volume-loud</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-loud">6.1. 
 The voice-volume property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-volume-x-loud">
-   <b><a href="#valdef-voice-volume-x-loud">#valdef-voice-volume-x-loud</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-volume-x-loud" class="dfn-panel" data-for="valdef-voice-volume-x-loud" id="infopanel-for-valdef-voice-volume-x-loud" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-volume-x-loud" style="display:none">Info about the 'x-loud' definition.</span><b><a href="#valdef-voice-volume-x-loud">#valdef-voice-volume-x-loud</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-volume-x-loud">6.1. 
 The voice-volume property</a> <a href="#ref-for-valdef-voice-volume-x-loud①">(2)</a> <a href="#ref-for-valdef-voice-volume-x-loud②">(3)</a> <a href="#ref-for-valdef-voice-volume-x-loud③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-voice-volume-decibel">
-   <b><a href="#typedef-voice-volume-decibel">#typedef-voice-volume-decibel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-voice-volume-decibel" class="dfn-panel" data-for="typedef-voice-volume-decibel" id="infopanel-for-typedef-voice-volume-decibel" role="dialog">
+   <span id="infopaneltitle-for-typedef-voice-volume-decibel" style="display:none">Info about the '&lt;decibel>' definition.</span><b><a href="#typedef-voice-volume-decibel">#typedef-voice-volume-decibel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-voice-volume-decibel">6.1. 
 The voice-volume property</a> <a href="#ref-for-typedef-voice-volume-decibel①">(2)</a> <a href="#ref-for-typedef-voice-volume-decibel②">(3)</a> <a href="#ref-for-typedef-voice-volume-decibel③">(4)</a>
@@ -3546,22 +3546,22 @@ The cue-before and cue-after properties</a> <a href="#ref-for-typedef-voice-volu
 Relation between audio cues and speech synthesis volume levels</a> <a href="#ref-for-typedef-voice-volume-decibel⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-balance">
-   <b><a href="#propdef-voice-balance">#propdef-voice-balance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-balance" class="dfn-panel" data-for="propdef-voice-balance" id="infopanel-for-propdef-voice-balance" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-balance" style="display:none">Info about the 'voice-balance' definition.</span><b><a href="#propdef-voice-balance">#propdef-voice-balance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-balance①">6.2. 
 The voice-balance property</a> <a href="#ref-for-propdef-voice-balance②">(2)</a> <a href="#ref-for-propdef-voice-balance③">(3)</a> <a href="#ref-for-propdef-voice-balance④">(4)</a> <a href="#ref-for-propdef-voice-balance⑤">(5)</a> <a href="#ref-for-propdef-voice-balance⑥">(6)</a> <a href="#ref-for-propdef-voice-balance⑦">(7)</a> <a href="#ref-for-propdef-voice-balance⑧">(8)</a> <a href="#ref-for-propdef-voice-balance⑨">(9)</a> <a href="#ref-for-propdef-voice-balance①⓪">(10)</a> <a href="#ref-for-propdef-voice-balance①①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-balance-center">
-   <b><a href="#valdef-voice-balance-center">#valdef-voice-balance-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-balance-center" class="dfn-panel" data-for="valdef-voice-balance-center" id="infopanel-for-valdef-voice-balance-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-balance-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-voice-balance-center">#valdef-voice-balance-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-balance-center">6.2. 
 The voice-balance property</a> <a href="#ref-for-valdef-voice-balance-center①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-speak">
-   <b><a href="#propdef-speak">#propdef-speak</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-speak" class="dfn-panel" data-for="propdef-speak" id="infopanel-for-propdef-speak" role="dialog">
+   <span id="infopaneltitle-for-propdef-speak" style="display:none">Info about the 'speak' definition.</span><b><a href="#propdef-speak">#propdef-speak</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-speak">6.1. 
 The voice-volume property</a> <a href="#ref-for-propdef-speak①">(2)</a>
@@ -3572,39 +3572,39 @@ Collapsing pauses</a>
     <li><a href="#ref-for-propdef-speak⑦"> Appendix E — Changes</a> <a href="#ref-for-propdef-speak⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-speak-auto">
-   <b><a href="#valdef-speak-auto">#valdef-speak-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-speak-auto" class="dfn-panel" data-for="valdef-speak-auto" id="infopanel-for-valdef-speak-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-speak-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-speak-auto">#valdef-speak-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-speak-auto">7.1. 
 The speak property</a> <a href="#ref-for-valdef-speak-auto①">(2)</a> <a href="#ref-for-valdef-speak-auto②">(3)</a>
     <li><a href="#ref-for-valdef-speak-auto③"> Appendix E — Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-speak-never">
-   <b><a href="#valdef-speak-never">#valdef-speak-never</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-speak-never" class="dfn-panel" data-for="valdef-speak-never" id="infopanel-for-valdef-speak-never" role="dialog">
+   <span id="infopaneltitle-for-valdef-speak-never" style="display:none">Info about the 'never' definition.</span><b><a href="#valdef-speak-never">#valdef-speak-never</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-speak-never">7.1. 
 The speak property</a> <a href="#ref-for-valdef-speak-never①">(2)</a> <a href="#ref-for-valdef-speak-never②">(3)</a>
     <li><a href="#ref-for-valdef-speak-never③"> Appendix E — Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-speak-always">
-   <b><a href="#valdef-speak-always">#valdef-speak-always</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-speak-always" class="dfn-panel" data-for="valdef-speak-always" id="infopanel-for-valdef-speak-always" role="dialog">
+   <span id="infopaneltitle-for-valdef-speak-always" style="display:none">Info about the 'always' definition.</span><b><a href="#valdef-speak-always">#valdef-speak-always</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-speak-always">7.1. 
 The speak property</a> <a href="#ref-for-valdef-speak-always①">(2)</a>
     <li><a href="#ref-for-valdef-speak-always②"> Appendix E — Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-speak-as">
-   <b><a href="#propdef-speak-as">#propdef-speak-as</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-speak-as" class="dfn-panel" data-for="propdef-speak-as" id="infopanel-for-propdef-speak-as" role="dialog">
+   <span id="infopaneltitle-for-propdef-speak-as" style="display:none">Info about the 'speak-as' definition.</span><b><a href="#propdef-speak-as">#propdef-speak-as</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-speak-as">7.2. 
 The speak-as property</a> <a href="#ref-for-propdef-speak-as①">(2)</a> <a href="#ref-for-propdef-speak-as②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-pause-before">
-   <b><a href="#propdef-pause-before">#propdef-pause-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-pause-before" class="dfn-panel" data-for="propdef-pause-before" id="infopanel-for-propdef-pause-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-pause-before" style="display:none">Info about the 'pause-before' definition.</span><b><a href="#propdef-pause-before">#propdef-pause-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause-before">8.1. 
 The pause-before and pause-after properties</a> <a href="#ref-for-propdef-pause-before①">(2)</a>
@@ -3614,8 +3614,8 @@ The pause shorthand property</a> <a href="#ref-for-propdef-pause-before③">(2)<
 Collapsing pauses</a> <a href="#ref-for-propdef-pause-before⑥">(2)</a> <a href="#ref-for-propdef-pause-before⑦">(3)</a> <a href="#ref-for-propdef-pause-before⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-pause-after">
-   <b><a href="#propdef-pause-after">#propdef-pause-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-pause-after" class="dfn-panel" data-for="propdef-pause-after" id="infopanel-for-propdef-pause-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-pause-after" style="display:none">Info about the 'pause-after' definition.</span><b><a href="#propdef-pause-after">#propdef-pause-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause-after">8.1. 
 The pause-before and pause-after properties</a> <a href="#ref-for-propdef-pause-after①">(2)</a>
@@ -3625,8 +3625,8 @@ The pause shorthand property</a> <a href="#ref-for-propdef-pause-after③">(2)</
 Collapsing pauses</a> <a href="#ref-for-propdef-pause-after⑥">(2)</a> <a href="#ref-for-propdef-pause-after⑦">(3)</a> <a href="#ref-for-propdef-pause-after⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-pause">
-   <b><a href="#propdef-pause">#propdef-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-pause" class="dfn-panel" data-for="propdef-pause" id="infopanel-for-propdef-pause" role="dialog">
+   <span id="infopaneltitle-for-propdef-pause" style="display:none">Info about the 'pause' definition.</span><b><a href="#propdef-pause">#propdef-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pause">5. 
 The aural formatting model</a>
@@ -3638,8 +3638,8 @@ The pause shorthand property</a> <a href="#ref-for-propdef-pause③">(2)</a>
 Collapsing pauses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-rest-before">
-   <b><a href="#propdef-rest-before">#propdef-rest-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-rest-before" class="dfn-panel" data-for="propdef-rest-before" id="infopanel-for-propdef-rest-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-rest-before" style="display:none">Info about the 'rest-before' definition.</span><b><a href="#propdef-rest-before">#propdef-rest-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest-before">8.3. 
 Collapsing pauses</a> <a href="#ref-for-propdef-rest-before①">(2)</a>
@@ -3649,8 +3649,8 @@ The rest-before and rest-after properties</a> <a href="#ref-for-propdef-rest-bef
 The rest shorthand property</a> <a href="#ref-for-propdef-rest-before⑤">(2)</a> <a href="#ref-for-propdef-rest-before⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-rest-after">
-   <b><a href="#propdef-rest-after">#propdef-rest-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-rest-after" class="dfn-panel" data-for="propdef-rest-after" id="infopanel-for-propdef-rest-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-rest-after" style="display:none">Info about the 'rest-after' definition.</span><b><a href="#propdef-rest-after">#propdef-rest-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest-after">8.3. 
 Collapsing pauses</a> <a href="#ref-for-propdef-rest-after①">(2)</a>
@@ -3660,8 +3660,8 @@ The rest-before and rest-after properties</a> <a href="#ref-for-propdef-rest-aft
 The rest shorthand property</a> <a href="#ref-for-propdef-rest-after⑤">(2)</a> <a href="#ref-for-propdef-rest-after⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-rest">
-   <b><a href="#propdef-rest">#propdef-rest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-rest" class="dfn-panel" data-for="propdef-rest" id="infopanel-for-propdef-rest" role="dialog">
+   <span id="infopaneltitle-for-propdef-rest" style="display:none">Info about the 'rest' definition.</span><b><a href="#propdef-rest">#propdef-rest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rest">5. 
 The aural formatting model</a> <a href="#ref-for-propdef-rest①">(2)</a>
@@ -3671,8 +3671,8 @@ The rest-before and rest-after properties</a>
 The rest shorthand property</a> <a href="#ref-for-propdef-rest④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cue-before">
-   <b><a href="#propdef-cue-before">#propdef-cue-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cue-before" class="dfn-panel" data-for="propdef-cue-before" id="infopanel-for-propdef-cue-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-cue-before" style="display:none">Info about the 'cue-before' definition.</span><b><a href="#propdef-cue-before">#propdef-cue-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue-before">8.1. 
 The pause-before and pause-after properties</a>
@@ -3686,8 +3686,8 @@ The cue-before and cue-after properties</a> <a href="#ref-for-propdef-cue-before
 The cue shorthand property</a> <a href="#ref-for-propdef-cue-before⑦">(2)</a> <a href="#ref-for-propdef-cue-before⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cue-after">
-   <b><a href="#propdef-cue-after">#propdef-cue-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cue-after" class="dfn-panel" data-for="propdef-cue-after" id="infopanel-for-propdef-cue-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-cue-after" style="display:none">Info about the 'cue-after' definition.</span><b><a href="#propdef-cue-after">#propdef-cue-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue-after">8.1. 
 The pause-before and pause-after properties</a>
@@ -3701,8 +3701,8 @@ The cue-before and cue-after properties</a> <a href="#ref-for-propdef-cue-after�
 The cue shorthand property</a> <a href="#ref-for-propdef-cue-after⑦">(2)</a> <a href="#ref-for-propdef-cue-after⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cue">
-   <b><a href="#propdef-cue">#propdef-cue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cue" class="dfn-panel" data-for="propdef-cue" id="infopanel-for-propdef-cue" role="dialog">
+   <span id="infopaneltitle-for-propdef-cue" style="display:none">Info about the 'cue' definition.</span><b><a href="#propdef-cue">#propdef-cue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cue">5. 
 The aural formatting model</a>
@@ -3712,8 +3712,8 @@ Collapsing pauses</a> <a href="#ref-for-propdef-cue②">(2)</a>
 The cue shorthand property</a> <a href="#ref-for-propdef-cue④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-family">
-   <b><a href="#propdef-voice-family">#propdef-voice-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-family" class="dfn-panel" data-for="propdef-voice-family" id="infopanel-for-propdef-voice-family" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-family" style="display:none">Info about the 'voice-family' definition.</span><b><a href="#propdef-voice-family">#propdef-voice-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-family">10.2. 
 Relation between audio cues and speech synthesis volume levels</a>
@@ -3725,71 +3725,71 @@ Voice selection, content language</a> <a href="#ref-for-propdef-voice-family⑥"
 The voice-pitch property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-generic-voice">
-   <b><a href="#typedef-generic-voice">#typedef-generic-voice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-generic-voice" class="dfn-panel" data-for="typedef-generic-voice" id="infopanel-for-typedef-generic-voice" role="dialog">
+   <span id="infopaneltitle-for-typedef-generic-voice" style="display:none">Info about the '&lt;generic-voice>' definition.</span><b><a href="#typedef-generic-voice">#typedef-generic-voice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-generic-voice">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-voice-family-age">
-   <b><a href="#typedef-voice-family-age">#typedef-voice-family-age</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-voice-family-age" class="dfn-panel" data-for="typedef-voice-family-age" id="infopanel-for-typedef-voice-family-age" role="dialog">
+   <span id="infopaneltitle-for-typedef-voice-family-age" style="display:none">Info about the '&lt;age>' definition.</span><b><a href="#typedef-voice-family-age">#typedef-voice-family-age</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-voice-family-age">11.1. 
 The voice-family property</a> <a href="#ref-for-typedef-voice-family-age①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-child">
-   <b><a href="#valdef-voice-family-child">#valdef-voice-family-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-child" class="dfn-panel" data-for="valdef-voice-family-child" id="infopanel-for-valdef-voice-family-child" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-child" style="display:none">Info about the 'child' definition.</span><b><a href="#valdef-voice-family-child">#valdef-voice-family-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-child">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-young">
-   <b><a href="#valdef-voice-family-young">#valdef-voice-family-young</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-young" class="dfn-panel" data-for="valdef-voice-family-young" id="infopanel-for-valdef-voice-family-young" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-young" style="display:none">Info about the 'young' definition.</span><b><a href="#valdef-voice-family-young">#valdef-voice-family-young</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-young">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-old">
-   <b><a href="#valdef-voice-family-old">#valdef-voice-family-old</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-old" class="dfn-panel" data-for="valdef-voice-family-old" id="infopanel-for-valdef-voice-family-old" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-old" style="display:none">Info about the 'old' definition.</span><b><a href="#valdef-voice-family-old">#valdef-voice-family-old</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-old">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-voice-family-gender">
-   <b><a href="#typedef-voice-family-gender">#typedef-voice-family-gender</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-voice-family-gender" class="dfn-panel" data-for="typedef-voice-family-gender" id="infopanel-for-typedef-voice-family-gender" role="dialog">
+   <span id="infopaneltitle-for-typedef-voice-family-gender" style="display:none">Info about the '&lt;gender>' definition.</span><b><a href="#typedef-voice-family-gender">#typedef-voice-family-gender</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-voice-family-gender">11.1. 
 The voice-family property</a> <a href="#ref-for-typedef-voice-family-gender①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-male">
-   <b><a href="#valdef-voice-family-male">#valdef-voice-family-male</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-male" class="dfn-panel" data-for="valdef-voice-family-male" id="infopanel-for-valdef-voice-family-male" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-male" style="display:none">Info about the 'male' definition.</span><b><a href="#valdef-voice-family-male">#valdef-voice-family-male</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-male">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-female">
-   <b><a href="#valdef-voice-family-female">#valdef-voice-family-female</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-female" class="dfn-panel" data-for="valdef-voice-family-female" id="infopanel-for-valdef-voice-family-female" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-female" style="display:none">Info about the 'female' definition.</span><b><a href="#valdef-voice-family-female">#valdef-voice-family-female</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-female">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-neutral">
-   <b><a href="#valdef-voice-family-neutral">#valdef-voice-family-neutral</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-neutral" class="dfn-panel" data-for="valdef-voice-family-neutral" id="infopanel-for-valdef-voice-family-neutral" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-neutral" style="display:none">Info about the 'neutral' definition.</span><b><a href="#valdef-voice-family-neutral">#valdef-voice-family-neutral</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-neutral">11.1. 
 The voice-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-family-preserve">
-   <b><a href="#valdef-voice-family-preserve">#valdef-voice-family-preserve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-family-preserve" class="dfn-panel" data-for="valdef-voice-family-preserve" id="infopanel-for-valdef-voice-family-preserve" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-family-preserve" style="display:none">Info about the 'preserve' definition.</span><b><a href="#valdef-voice-family-preserve">#valdef-voice-family-preserve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-preserve">11.1. 
 The voice-family property</a> <a href="#ref-for-valdef-voice-family-preserve①">(2)</a>
@@ -3797,8 +3797,8 @@ The voice-family property</a> <a href="#ref-for-valdef-voice-family-preserve①"
 Voice selection, content language</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-rate">
-   <b><a href="#propdef-voice-rate">#propdef-voice-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-rate" class="dfn-panel" data-for="propdef-voice-rate" id="infopanel-for-propdef-voice-rate" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-rate" style="display:none">Info about the 'voice-rate' definition.</span><b><a href="#propdef-voice-rate">#propdef-voice-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-rate">11.2. 
 The voice-rate property</a> <a href="#ref-for-propdef-voice-rate①">(2)</a>
@@ -3806,22 +3806,22 @@ The voice-rate property</a> <a href="#ref-for-propdef-voice-rate①">(2)</a>
 The voice-duration property</a> <a href="#ref-for-propdef-voice-rate③">(2)</a> <a href="#ref-for-propdef-voice-rate④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-pitch">
-   <b><a href="#propdef-voice-pitch">#propdef-voice-pitch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-pitch" class="dfn-panel" data-for="propdef-voice-pitch" id="infopanel-for-propdef-voice-pitch" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-pitch" style="display:none">Info about the 'voice-pitch' definition.</span><b><a href="#propdef-voice-pitch">#propdef-voice-pitch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-pitch①">11.3. 
 The voice-pitch property</a> <a href="#ref-for-propdef-voice-pitch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-pitch-absolute">
-   <b><a href="#valdef-voice-pitch-absolute">#valdef-voice-pitch-absolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-pitch-absolute" class="dfn-panel" data-for="valdef-voice-pitch-absolute" id="infopanel-for-valdef-voice-pitch-absolute" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-pitch-absolute" style="display:none">Info about the 'absolute' definition.</span><b><a href="#valdef-voice-pitch-absolute">#valdef-voice-pitch-absolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-pitch-absolute">11.3. 
 The voice-pitch property</a> <a href="#ref-for-valdef-voice-pitch-absolute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-voice-pitch-semitones">
-   <b><a href="#typedef-voice-pitch-semitones">#typedef-voice-pitch-semitones</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-voice-pitch-semitones" class="dfn-panel" data-for="typedef-voice-pitch-semitones" id="infopanel-for-typedef-voice-pitch-semitones" role="dialog">
+   <span id="infopaneltitle-for-typedef-voice-pitch-semitones" style="display:none">Info about the '&lt;semitones>' definition.</span><b><a href="#typedef-voice-pitch-semitones">#typedef-voice-pitch-semitones</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-voice-pitch-semitones">11.3. 
 The voice-pitch property</a> <a href="#ref-for-typedef-voice-pitch-semitones①">(2)</a> <a href="#ref-for-typedef-voice-pitch-semitones②">(3)</a>
@@ -3829,8 +3829,8 @@ The voice-pitch property</a> <a href="#ref-for-typedef-voice-pitch-semitones①"
 The voice-range property</a> <a href="#ref-for-typedef-voice-pitch-semitones④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="voice-pitch-semitone">
-   <b><a href="#voice-pitch-semitone">#voice-pitch-semitone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-voice-pitch-semitone" class="dfn-panel" data-for="voice-pitch-semitone" id="infopanel-for-voice-pitch-semitone" role="dialog">
+   <span id="infopaneltitle-for-voice-pitch-semitone" style="display:none">Info about the 'semitone' definition.</span><b><a href="#voice-pitch-semitone">#voice-pitch-semitone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-voice-pitch-semitone">11.3. 
 The voice-pitch property</a> <a href="#ref-for-voice-pitch-semitone①">(2)</a> <a href="#ref-for-voice-pitch-semitone②">(3)</a>
@@ -3838,36 +3838,36 @@ The voice-pitch property</a> <a href="#ref-for-voice-pitch-semitone①">(2)</a> 
 The voice-range property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-range">
-   <b><a href="#propdef-voice-range">#propdef-voice-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-range" class="dfn-panel" data-for="propdef-voice-range" id="infopanel-for-propdef-voice-range" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-range" style="display:none">Info about the 'voice-range' definition.</span><b><a href="#propdef-voice-range">#propdef-voice-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-range①">11.4. 
 The voice-range property</a> <a href="#ref-for-propdef-voice-range②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-range-absolute">
-   <b><a href="#valdef-voice-range-absolute">#valdef-voice-range-absolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-range-absolute" class="dfn-panel" data-for="valdef-voice-range-absolute" id="infopanel-for-valdef-voice-range-absolute" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-range-absolute" style="display:none">Info about the 'absolute' definition.</span><b><a href="#valdef-voice-range-absolute">#valdef-voice-range-absolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-range-absolute">11.4. 
 The voice-range property</a> <a href="#ref-for-valdef-voice-range-absolute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-stress">
-   <b><a href="#propdef-voice-stress">#propdef-voice-stress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-stress" class="dfn-panel" data-for="propdef-voice-stress" id="infopanel-for-propdef-voice-stress" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-stress" style="display:none">Info about the 'voice-stress' definition.</span><b><a href="#propdef-voice-stress">#propdef-voice-stress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-stress①">11.5. 
 The voice-stress property</a> <a href="#ref-for-propdef-voice-stress②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-stress-normal">
-   <b><a href="#valdef-voice-stress-normal">#valdef-voice-stress-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-stress-normal" class="dfn-panel" data-for="valdef-voice-stress-normal" id="infopanel-for-valdef-voice-stress-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-stress-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-voice-stress-normal">#valdef-voice-stress-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-stress-normal">11.5. 
 The voice-stress property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-voice-duration">
-   <b><a href="#propdef-voice-duration">#propdef-voice-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-voice-duration" class="dfn-panel" data-for="propdef-voice-duration" id="infopanel-for-propdef-voice-duration" role="dialog">
+   <span id="infopaneltitle-for-propdef-voice-duration" style="display:none">Info about the 'voice-duration' definition.</span><b><a href="#propdef-voice-duration">#propdef-voice-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-voice-duration①">8.3. 
 Collapsing pauses</a>
@@ -3875,8 +3875,8 @@ Collapsing pauses</a>
 The voice-duration property</a> <a href="#ref-for-propdef-voice-duration③">(2)</a> <a href="#ref-for-propdef-voice-duration④">(3)</a> <a href="#ref-for-propdef-voice-duration⑤">(4)</a> <a href="#ref-for-propdef-voice-duration⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-voice-duration-auto">
-   <b><a href="#valdef-voice-duration-auto">#valdef-voice-duration-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-voice-duration-auto" class="dfn-panel" data-for="valdef-voice-duration-auto" id="infopanel-for-valdef-voice-duration-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-voice-duration-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-voice-duration-auto">#valdef-voice-duration-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-duration-auto">12.1. 
 The voice-duration property</a> <a href="#ref-for-valdef-voice-duration-auto①">(2)</a>
@@ -3884,57 +3884,113 @@ The voice-duration property</a> <a href="#ref-for-valdef-voice-duration-auto①"
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-syntax-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-syntax-3/Overview.html
@@ -5516,8 +5516,8 @@ The three call-sites of the algorithm were changed to use that form.</p>
    <li><a href="#check-if-three-code-points-would-start-an-identifier">would start an identifier</a><span>, in § 4.3.9</span>
    <li><a href="#check-if-three-code-points-would-start-a-number">would start a number</a><span>, in § 4.3.10</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">2. 
 Description of CSS’s Syntax</a>
@@ -5525,8 +5525,8 @@ Description of CSS’s Syntax</a>
 The input byte stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-property">https://drafts.csswg.org/css-cascade-5/#css-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-property" class="dfn-panel" data-for="term-for-css-property" id="infopanel-for-term-for-css-property" role="menu">
+   <span id="infopaneltitle-for-term-for-css-property" style="display:none">Info about the 'property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-property">https://drafts.csswg.org/css-cascade-5/#css-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property">5. 
 Parsing</a>
@@ -5534,43 +5534,43 @@ Parsing</a>
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-important">
-   <a href="https://drafts.csswg.org/css-cascade-6/#important">https://drafts.csswg.org/css-cascade-6/#important</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-important" class="dfn-panel" data-for="term-for-important" id="infopanel-for-term-for-important" role="menu">
+   <span id="infopaneltitle-for-term-for-important" style="display:none">Info about the 'important' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#important">https://drafts.csswg.org/css-cascade-6/#important</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-important">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">5.3.1. 
 Parse something according to a CSS grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-blue">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-blue" class="dfn-panel" data-for="term-for-valdef-color-blue" id="infopanel-for-term-for-valdef-color-blue" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-blue" style="display:none">Info about the 'blue' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-blue">https://drafts.csswg.org/css-color-4/#valdef-color-blue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-blue">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-counter-style">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#counter-style">https://drafts.csswg.org/css-counter-styles-3/#counter-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-counter-style" class="dfn-panel" data-for="term-for-counter-style" id="infopanel-for-term-for-counter-style" role="menu">
+   <span id="infopaneltitle-for-term-for-counter-style" style="display:none">Info about the 'counter style' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#counter-style">https://drafts.csswg.org/css-counter-styles-3/#counter-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-counter-style">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-font-face-rule">
-   <a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-font-face-rule" class="dfn-panel" data-for="term-for-at-font-face-rule" id="infopanel-for-term-for-at-font-face-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-at-font-face-rule" style="display:none">Info about the '@font-face' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#at-font-face-rule">https://drafts.csswg.org/css-fonts-5/#at-font-face-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-font-face-rule">7. 
 The Unicode-Range microsyntax</a>
@@ -5578,15 +5578,15 @@ The Unicode-Range microsyntax</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a> <a href="#ref-for-at-font-face-rule②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-page-left">
-   <a href="https://drafts.csswg.org/css-page-3/#valdef-page-left">https://drafts.csswg.org/css-page-3/#valdef-page-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-page-left" class="dfn-panel" data-for="term-for-valdef-page-left" id="infopanel-for-term-for-valdef-page-left" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-page-left" style="display:none">Info about the ':left' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#valdef-page-left">https://drafts.csswg.org/css-page-3/#valdef-page-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-left">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-page">
-   <a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-page" class="dfn-panel" data-for="term-for-at-ruledef-page" id="infopanel-for-term-for-at-ruledef-page" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-page" style="display:none">Info about the '@page' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#at-ruledef-page">https://drafts.csswg.org/css-page-3/#at-ruledef-page</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-page">2. 
 Description of CSS’s Syntax</a>
@@ -5596,43 +5596,43 @@ Parse a list of declarations</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-curly-block">
-   <a href="https://drafts.csswg.org/css-syntax-3/#curly-block">https://drafts.csswg.org/css-syntax-3/#curly-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-curly-block" class="dfn-panel" data-for="term-for-curly-block" id="infopanel-for-term-for-curly-block" role="menu">
+   <span id="infopaneltitle-for-term-for-curly-block" style="display:none">Info about the '{}-block' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#curly-block">https://drafts.csswg.org/css-syntax-3/#curly-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-curly-block">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-decoration-line-underline">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-underline">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-underline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-decoration-line-underline" class="dfn-panel" data-for="term-for-valdef-text-decoration-line-underline" id="infopanel-for-term-for-valdef-text-decoration-line-underline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-decoration-line-underline" style="display:none">Info about the 'underline' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-underline">https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-line-underline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-line-underline">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translatex">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translatex" class="dfn-panel" data-for="term-for-funcdef-transform-translatex" id="infopanel-for-term-for-funcdef-transform-translatex" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translatex" style="display:none">Info about the 'translatex()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatex">8. 
 Defining Grammars for Rules and Other Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">7.1. 
 The &lt;urange> type</a> <a href="#ref-for-mult-zero-plus①">(2)</a> <a href="#ref-for-mult-zero-plus②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">6.2. 
 The &lt;an+b> type</a>
@@ -5640,43 +5640,43 @@ The &lt;an+b> type</a>
 The &lt;urange> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension" class="dfn-panel" data-for="term-for-typedef-dimension" id="infopanel-for-term-for-typedef-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">7.1. 
 The &lt;urange> type</a> <a href="#ref-for-typedef-dimension①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">7.1. 
 The &lt;urange> type</a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">5.3.1. 
 Parse something according to a CSS grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">6.2. 
 The &lt;an+b> type</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a> <a href="#ref-for-mult-opt④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-url">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-url" class="dfn-panel" data-for="term-for-funcdef-url" id="infopanel-for-term-for-funcdef-url" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-url" style="display:none">Info about the 'url()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-url">https://drafts.csswg.org/css-values-4/#funcdef-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">6.2. 
 The &lt;an+b> type</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a> <a href="#ref-for-comb-one①⑤">(16)</a> <a href="#ref-for-comb-one①⑥">(17)</a> <a href="#ref-for-comb-one①⑦">(18)</a> <a href="#ref-for-comb-one①⑧">(19)</a>
@@ -5684,36 +5684,36 @@ The &lt;an+b> type</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-
 The &lt;urange> type</a> <a href="#ref-for-comb-one②⓪">(2)</a> <a href="#ref-for-comb-one②①">(3)</a> <a href="#ref-for-comb-one②②">(4)</a> <a href="#ref-for-comb-one②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-attr">
-   <a href="https://drafts.csswg.org/css-values-5/#funcdef-attr">https://drafts.csswg.org/css-values-5/#funcdef-attr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-attr" class="dfn-panel" data-for="term-for-funcdef-attr" id="infopanel-for-term-for-funcdef-attr" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-attr" style="display:none">Info about the 'attr()' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#funcdef-attr">https://drafts.csswg.org/css-values-5/#funcdef-attr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-attr">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">8.2. 
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-keyframe-selector">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector">https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-keyframe-selector" class="dfn-panel" data-for="term-for-typedef-keyframe-selector" id="infopanel-for-term-for-typedef-keyframe-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-keyframe-selector" style="display:none">Info about the '&lt;keyframe-selector>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector">https://drafts.csswg.org/css-animations-1/#typedef-keyframe-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframe-selector">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-keyframes-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name">https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-keyframes-name" class="dfn-panel" data-for="term-for-typedef-keyframes-name" id="infopanel-for-term-for-typedef-keyframes-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-keyframes-name" style="display:none">Info about the '&lt;keyframes-name>' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name">https://drafts.csswg.org/css-animations-1/#typedef-keyframes-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-keyframes-name">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-keyframes">
-   <a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-keyframes" class="dfn-panel" data-for="term-for-at-ruledef-keyframes" id="infopanel-for-term-for-at-ruledef-keyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a> <a href="#ref-for-at-ruledef-keyframes①">(2)</a>
@@ -5721,15 +5721,15 @@ Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;styl
 Style rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timing-function">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timing-function" class="dfn-panel" data-for="term-for-propdef-animation-timing-function" id="infopanel-for-term-for-propdef-animation-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2. 
 Description of CSS’s Syntax</a> <a href="#ref-for-at-ruledef-media①">(2)</a>
@@ -5741,57 +5741,57 @@ Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;styl
 Style rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-namespace">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-namespace">https://dom.spec.whatwg.org/#concept-attribute-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-namespace" class="dfn-panel" data-for="term-for-concept-attribute-namespace" id="infopanel-for-term-for-concept-attribute-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-namespace" style="display:none">Info about the 'namespace' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-namespace">https://dom.spec.whatwg.org/#concept-attribute-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-namespace">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decode">
-   <a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decode" class="dfn-panel" data-for="term-for-decode" id="infopanel-for-term-for-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-decode" style="display:none">Info about the 'decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode">3.2. 
 The input byte stream</a> <a href="#ref-for-decode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-p-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-p-element" class="dfn-panel" data-for="term-for-the-p-element" id="infopanel-for-term-for-the-p-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-p-element" style="display:none">Info about the 'p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-p-element">2. 
 Description of CSS’s Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-sizes">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-sizes" class="dfn-panel" data-for="term-for-attr-img-sizes" id="infopanel-for-term-for-attr-img-sizes" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-sizes" style="display:none">Info about the 'sizes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-sizes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-sizes">5.3.2. 
 Parse A Comma-Separated List According To A CSS Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-surrogate">
-   <a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-surrogate" class="dfn-panel" data-for="term-for-dfn-surrogate" id="infopanel-for-term-for-dfn-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-surrogate" style="display:none">Info about the 'surrogates' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-surrogate">12.2. 
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.3.4. 
 Consume an ident-like token</a>
@@ -5805,8 +5805,8 @@ Defining Grammars for Rules and Other Values</a>
 Style rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">1. 
 Introduction</a>
@@ -5862,15 +5862,15 @@ Defining Grammars for Rules and Other Values</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-code-point⑨⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.3.2. 
 Parse A Comma-Separated List According To A CSS Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.3.2. 
 Parse A Comma-Separated List According To A CSS Grammar</a>
@@ -5886,22 +5886,22 @@ Consume a simple block</a>
 Consume a function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">5.4.5. 
 Consume a declaration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value">
-   <a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value" class="dfn-panel" data-for="term-for-scalar-value" id="infopanel-for-term-for-scalar-value" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value" style="display:none">Info about the 'scalar value' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value">12.2. 
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">5.3. 
 Parser Entry Points</a>
@@ -5909,8 +5909,8 @@ Parser Entry Points</a>
 Serializing &lt;an+b></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-surrogate">
-   <a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-surrogate" class="dfn-panel" data-for="term-for-surrogate" id="infopanel-for-term-for-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-surrogate" style="display:none">Info about the 'surrogate' external reference.</span><a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrogate">3.3. 
 Preprocessing the input stream</a>
@@ -5920,43 +5920,43 @@ Consume an escaped code point</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-general-enclosed">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed">https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-general-enclosed" class="dfn-panel" data-for="term-for-typedef-general-enclosed" id="infopanel-for-term-for-typedef-general-enclosed" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-general-enclosed" style="display:none">Info about the '&lt;general-enclosed>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed">https://drafts.csswg.org/mediaqueries-5/#typedef-general-enclosed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-general-enclosed">8.2. 
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-media-query-list" class="dfn-panel" data-for="term-for-typedef-media-query-list" id="infopanel-for-term-for-typedef-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list">https://drafts.csswg.org/mediaqueries-5/#typedef-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">8.1. 
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-adjacent">
-   <a href="https://drafts.csswg.org/selectors-4/#selectordef-adjacent">https://drafts.csswg.org/selectors-4/#selectordef-adjacent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-adjacent" class="dfn-panel" data-for="term-for-selectordef-adjacent" id="infopanel-for-term-for-selectordef-adjacent" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-adjacent" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selectordef-adjacent">https://drafts.csswg.org/selectors-4/#selectordef-adjacent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-adjacent">6.1. 
 Informal Syntax Description</a> <a href="#ref-for-selectordef-adjacent①">(2)</a> <a href="#ref-for-selectordef-adjacent②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nth-child-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#nth-child-pseudo">https://drafts.csswg.org/selectors-4/#nth-child-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nth-child-pseudo" class="dfn-panel" data-for="term-for-nth-child-pseudo" id="infopanel-for-term-for-nth-child-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-nth-child-pseudo" style="display:none">Info about the ':nth-child()' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#nth-child-pseudo">https://drafts.csswg.org/selectors-4/#nth-child-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-child-pseudo">6. 
 The An+B microsyntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-selector-list">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">https://drafts.csswg.org/selectors-4/#typedef-selector-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-selector-list" class="dfn-panel" data-for="term-for-typedef-selector-list" id="infopanel-for-term-for-typedef-selector-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-selector-list" style="display:none">Info about the '&lt;selector-list>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-selector-list">https://drafts.csswg.org/selectors-4/#typedef-selector-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-selector-list">9.1. 
 Style rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selector-list">
-   <a href="https://drafts.csswg.org/selectors-4/#selector-list">https://drafts.csswg.org/selectors-4/#selector-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selector-list" class="dfn-panel" data-for="term-for-selector-list" id="infopanel-for-term-for-selector-list" role="menu">
+   <span id="infopaneltitle-for-term-for-selector-list" style="display:none">Info about the 'selector list' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selector-list">https://drafts.csswg.org/selectors-4/#selector-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector-list">9.1. 
 Style rules</a>
@@ -6168,8 +6168,8 @@ Style rules</a>
    <dt id="biblio-select">[SELECT]
    <dd>Tantek Çelik; et al. <a href="https://drafts.csswg.org/selectors-3/"><cite>Selectors Level 3</cite></a>. URL: <a href="https://drafts.csswg.org/selectors-3/">https://drafts.csswg.org/selectors-3/</a>
   </dl>
-  <aside class="dfn-panel" data-for="escape-codepoint">
-   <b><a href="#escape-codepoint">#escape-codepoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-escape-codepoint" class="dfn-panel" data-for="escape-codepoint" id="infopanel-for-escape-codepoint" role="dialog">
+   <span id="infopaneltitle-for-escape-codepoint" style="display:none">Info about the 'escaping' definition.</span><b><a href="#escape-codepoint">#escape-codepoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-escape-codepoint">2. 
 Description of CSS’s Syntax</a>
@@ -6177,8 +6177,8 @@ Description of CSS’s Syntax</a>
 Defining Grammars for Rules and Other Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-invalid">
-   <b><a href="#css-invalid">#css-invalid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-invalid" class="dfn-panel" data-for="css-invalid" id="infopanel-for-css-invalid" role="dialog">
+   <span id="infopaneltitle-for-css-invalid" style="display:none">Info about the 'invalid' definition.</span><b><a href="#css-invalid">#css-invalid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-invalid">9. 
 CSS stylesheets</a>
@@ -6186,8 +6186,8 @@ CSS stylesheets</a>
 Style rules</a> <a href="#ref-for-css-invalid②">(2)</a> <a href="#ref-for-css-invalid③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-error">
-   <b><a href="#parse-error">#parse-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-error" class="dfn-panel" data-for="parse-error" id="infopanel-for-parse-error" role="dialog">
+   <span id="infopaneltitle-for-parse-error" style="display:none">Info about the 'parse errors' definition.</span><b><a href="#parse-error">#parse-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-error">4.3.1. 
 Consume a token</a>
@@ -6215,15 +6215,15 @@ Consume a function</a>
 CSS stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-decode-bytes">
-   <b><a href="#css-decode-bytes">#css-decode-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-decode-bytes" class="dfn-panel" data-for="css-decode-bytes" id="infopanel-for-css-decode-bytes" role="dialog">
+   <span id="infopaneltitle-for-css-decode-bytes" style="display:none">Info about the 'decode' definition.</span><b><a href="#css-decode-bytes">#css-decode-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-decode-bytes">5.3.3. 
 Parse a stylesheet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-fallback-encoding">
-   <b><a href="#determine-the-fallback-encoding">#determine-the-fallback-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-fallback-encoding" class="dfn-panel" data-for="determine-the-fallback-encoding" id="infopanel-for-determine-the-fallback-encoding" role="dialog">
+   <span id="infopaneltitle-for-determine-the-fallback-encoding" style="display:none">Info about the 'determine the fallback encoding' definition.</span><b><a href="#determine-the-fallback-encoding">#determine-the-fallback-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-fallback-encoding">3.2. 
 The input byte stream</a>
@@ -6233,8 +6233,8 @@ The @charset Rule</a>
 Changes from the 5 November 2013 Last Call Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-encoding">
-   <b><a href="#environment-encoding">#environment-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-environment-encoding" class="dfn-panel" data-for="environment-encoding" id="infopanel-for-environment-encoding" role="dialog">
+   <span id="infopaneltitle-for-environment-encoding" style="display:none">Info about the 'environment encoding' definition.</span><b><a href="#environment-encoding">#environment-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-encoding">3.2. 
 The input byte stream</a> <a href="#ref-for-environment-encoding①">(2)</a> <a href="#ref-for-environment-encoding②">(3)</a>
@@ -6242,15 +6242,15 @@ The input byte stream</a> <a href="#ref-for-environment-encoding①">(2)</a> <a 
 Changes from the 19 September 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input-stream">
-   <b><a href="#input-stream">#input-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input-stream" class="dfn-panel" data-for="input-stream" id="infopanel-for-input-stream" role="dialog">
+   <span id="infopaneltitle-for-input-stream" style="display:none">Info about the 'input stream' definition.</span><b><a href="#input-stream">#input-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-stream">4.2. 
 Definitions</a> <a href="#ref-for-input-stream①">(2)</a> <a href="#ref-for-input-stream②">(3)</a> <a href="#ref-for-input-stream③">(4)</a> <a href="#ref-for-input-stream④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-filter-code-points">
-   <b><a href="#css-filter-code-points">#css-filter-code-points</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-filter-code-points" class="dfn-panel" data-for="css-filter-code-points" id="infopanel-for-css-filter-code-points" role="dialog">
+   <span id="infopaneltitle-for-css-filter-code-points" style="display:none">Info about the 'filter code points' definition.</span><b><a href="#css-filter-code-points">#css-filter-code-points</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-filter-code-points">3.3. 
 Preprocessing the input stream</a>
@@ -6258,15 +6258,15 @@ Preprocessing the input stream</a>
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-tokenize">
-   <b><a href="#css-tokenize">#css-tokenize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-tokenize" class="dfn-panel" data-for="css-tokenize" id="infopanel-for-css-tokenize" role="dialog">
+   <span id="infopaneltitle-for-css-tokenize" style="display:none">Info about the 'tokenize' definition.</span><b><a href="#css-tokenize">#css-tokenize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-tokenize">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-ident-token">
-   <b><a href="#typedef-ident-token">#typedef-ident-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-ident-token" class="dfn-panel" data-for="typedef-ident-token" id="infopanel-for-typedef-ident-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' definition.</span><b><a href="#typedef-ident-token">#typedef-ident-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">4. 
 Tokenization</a>
@@ -6296,8 +6296,8 @@ Changes from the 20 February 2014 Candidate Recommendation</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-ident-token①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-function-token">
-   <b><a href="#typedef-function-token">#typedef-function-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-function-token" class="dfn-panel" data-for="typedef-function-token" id="infopanel-for-typedef-function-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' definition.</span><b><a href="#typedef-function-token">#typedef-function-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">4. 
 Tokenization</a>
@@ -6323,8 +6323,8 @@ Changes from the 20 February 2014 Candidate Recommendation</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-at-keyword-token">
-   <b><a href="#typedef-at-keyword-token">#typedef-at-keyword-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-at-keyword-token" class="dfn-panel" data-for="typedef-at-keyword-token" id="infopanel-for-typedef-at-keyword-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-at-keyword-token" style="display:none">Info about the '&lt;at-keyword-token>' definition.</span><b><a href="#typedef-at-keyword-token">#typedef-at-keyword-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-at-keyword-token">2.2. 
 Error Handling</a>
@@ -6348,8 +6348,8 @@ Defining Grammars for Rules and Other Values</a> <a href="#ref-for-typedef-at-ke
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-at-keyword-token①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-hash-token">
-   <b><a href="#typedef-hash-token">#typedef-hash-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-hash-token" class="dfn-panel" data-for="typedef-hash-token" id="infopanel-for-typedef-hash-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-hash-token" style="display:none">Info about the '&lt;hash-token>' definition.</span><b><a href="#typedef-hash-token">#typedef-hash-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hash-token">4. 
 Tokenization</a>
@@ -6363,8 +6363,8 @@ Consume a token</a> <a href="#ref-for-typedef-hash-token④">(2)</a> <a href="#r
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-string-token">
-   <b><a href="#typedef-string-token">#typedef-string-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-string-token" class="dfn-panel" data-for="typedef-string-token" id="infopanel-for-typedef-string-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-string-token" style="display:none">Info about the '&lt;string-token>' definition.</span><b><a href="#typedef-string-token">#typedef-string-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-string-token">4. 
 Tokenization</a>
@@ -6376,8 +6376,8 @@ Consume a string token</a> <a href="#ref-for-typedef-string-token③">(2)</a> <a
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bad-string-token">
-   <b><a href="#typedef-bad-string-token">#typedef-bad-string-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bad-string-token" class="dfn-panel" data-for="typedef-bad-string-token" id="infopanel-for-typedef-bad-string-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-bad-string-token" style="display:none">Info about the '&lt;bad-string-token>' definition.</span><b><a href="#typedef-bad-string-token">#typedef-bad-string-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bad-string-token">4.3.5. 
 Consume a string token</a> <a href="#ref-for-typedef-bad-string-token①">(2)</a>
@@ -6387,8 +6387,8 @@ Parsing</a>
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-url-token">
-   <b><a href="#typedef-url-token">#typedef-url-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-url-token" class="dfn-panel" data-for="typedef-url-token" id="infopanel-for-typedef-url-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-url-token" style="display:none">Info about the '&lt;url-token>' definition.</span><b><a href="#typedef-url-token">#typedef-url-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-url-token">4. 
 Tokenization</a>
@@ -6406,8 +6406,8 @@ Changes from the 20 February 2014 Candidate Recommendation</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-url-token①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-bad-url-token">
-   <b><a href="#typedef-bad-url-token">#typedef-bad-url-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-bad-url-token" class="dfn-panel" data-for="typedef-bad-url-token" id="infopanel-for-typedef-bad-url-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-bad-url-token" style="display:none">Info about the '&lt;bad-url-token>' definition.</span><b><a href="#typedef-bad-url-token">#typedef-bad-url-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bad-url-token">4.3.4. 
 Consume an ident-like token</a>
@@ -6423,8 +6423,8 @@ Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> produ
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-bad-url-token①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-delim-token">
-   <b><a href="#typedef-delim-token">#typedef-delim-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-delim-token" class="dfn-panel" data-for="typedef-delim-token" id="infopanel-for-typedef-delim-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-delim-token" style="display:none">Info about the '&lt;delim-token>' definition.</span><b><a href="#typedef-delim-token">#typedef-delim-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-delim-token">4. 
 Tokenization</a>
@@ -6444,8 +6444,8 @@ Changes from the 20 February 2014 Candidate Recommendation</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-delim-token①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-number-token">
-   <b><a href="#typedef-number-token">#typedef-number-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-number-token" class="dfn-panel" data-for="typedef-number-token" id="infopanel-for-typedef-number-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' definition.</span><b><a href="#typedef-number-token">#typedef-number-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">4. 
 Tokenization</a> <a href="#ref-for-typedef-number-token①">(2)</a>
@@ -6461,8 +6461,8 @@ The &lt;urange> type</a> <a href="#ref-for-typedef-number-token⑨">(2)</a> <a h
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-percentage-token">
-   <b><a href="#typedef-percentage-token">#typedef-percentage-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-percentage-token" class="dfn-panel" data-for="typedef-percentage-token" id="infopanel-for-typedef-percentage-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-percentage-token" style="display:none">Info about the '&lt;percentage-token>' definition.</span><b><a href="#typedef-percentage-token">#typedef-percentage-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-percentage-token">4. 
 Tokenization</a>
@@ -6474,8 +6474,8 @@ Consume a numeric token</a> <a href="#ref-for-typedef-percentage-token③">(2)</
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-dimension-token">
-   <b><a href="#typedef-dimension-token">#typedef-dimension-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-dimension-token" class="dfn-panel" data-for="typedef-dimension-token" id="infopanel-for-typedef-dimension-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' definition.</span><b><a href="#typedef-dimension-token">#typedef-dimension-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">4. 
 Tokenization</a> <a href="#ref-for-typedef-dimension-token①">(2)</a> <a href="#ref-for-typedef-dimension-token②">(3)</a>
@@ -6495,8 +6495,8 @@ Serialization</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-dimension-token①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-whitespace-token">
-   <b><a href="#typedef-whitespace-token">#typedef-whitespace-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-whitespace-token" class="dfn-panel" data-for="typedef-whitespace-token" id="infopanel-for-typedef-whitespace-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-whitespace-token" style="display:none">Info about the '&lt;whitespace-token>' definition.</span><b><a href="#typedef-whitespace-token">#typedef-whitespace-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-whitespace-token">4.1. 
 Token Railroad Diagrams</a>
@@ -6522,8 +6522,8 @@ Defining Grammars for Rules and Other Values</a> <a href="#ref-for-typedef-white
 Serialization</a> <a href="#ref-for-typedef-whitespace-token①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-cdo-token">
-   <b><a href="#typedef-cdo-token">#typedef-cdo-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-cdo-token" class="dfn-panel" data-for="typedef-cdo-token" id="infopanel-for-typedef-cdo-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-cdo-token" style="display:none">Info about the '&lt;CDO-token>' definition.</span><b><a href="#typedef-cdo-token">#typedef-cdo-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-cdo-token">4.1. 
 Token Railroad Diagrams</a>
@@ -6535,8 +6535,8 @@ Parser Entry Points</a>
 Consume a list of rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-cdc-token">
-   <b><a href="#typedef-cdc-token">#typedef-cdc-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-cdc-token" class="dfn-panel" data-for="typedef-cdc-token" id="infopanel-for-typedef-cdc-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-cdc-token" style="display:none">Info about the '&lt;CDC-token>' definition.</span><b><a href="#typedef-cdc-token">#typedef-cdc-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-cdc-token">4.1. 
 Token Railroad Diagrams</a>
@@ -6550,8 +6550,8 @@ Consume a list of rules</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-colon-token">
-   <b><a href="#typedef-colon-token">#typedef-colon-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-colon-token" class="dfn-panel" data-for="typedef-colon-token" id="infopanel-for-typedef-colon-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-colon-token" style="display:none">Info about the '&lt;colon-token>' definition.</span><b><a href="#typedef-colon-token">#typedef-colon-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-colon-token">4.3.1. 
 Consume a token</a>
@@ -6561,8 +6561,8 @@ Consume a declaration</a>
 Defining Grammars for Rules and Other Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-semicolon-token">
-   <b><a href="#typedef-semicolon-token">#typedef-semicolon-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-semicolon-token" class="dfn-panel" data-for="typedef-semicolon-token" id="infopanel-for-typedef-semicolon-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-semicolon-token" style="display:none">Info about the '&lt;semicolon-token>' definition.</span><b><a href="#typedef-semicolon-token">#typedef-semicolon-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-semicolon-token">2.2. 
 Error Handling</a>
@@ -6580,8 +6580,8 @@ Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> produ
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-typedef-semicolon-token①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-comma-token">
-   <b><a href="#typedef-comma-token">#typedef-comma-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-comma-token" class="dfn-panel" data-for="typedef-comma-token" id="infopanel-for-typedef-comma-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-comma-token" style="display:none">Info about the '&lt;comma-token>' definition.</span><b><a href="#typedef-comma-token">#typedef-comma-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-comma-token">4.3.1. 
 Consume a token</a>
@@ -6593,8 +6593,8 @@ Defining Grammars for Rules and Other Values</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-open-square">
-   <b><a href="#tokendef-open-square">#tokendef-open-square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-open-square" class="dfn-panel" data-for="tokendef-open-square" id="infopanel-for-tokendef-open-square" role="dialog">
+   <span id="infopaneltitle-for-tokendef-open-square" style="display:none">Info about the '&lt;[-token>' definition.</span><b><a href="#tokendef-open-square">#tokendef-open-square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-open-square">4.3.1. 
 Consume a token</a>
@@ -6608,8 +6608,8 @@ Consume a simple block</a> <a href="#ref-for-tokendef-open-square">(2)</a>
 Defining Grammars for Rules and Other Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-close-square">
-   <b><a href="#tokendef-close-square">#tokendef-close-square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-close-square" class="dfn-panel" data-for="tokendef-close-square" id="infopanel-for-tokendef-close-square" role="dialog">
+   <span id="infopaneltitle-for-tokendef-close-square" style="display:none">Info about the '&lt;]-token>' definition.</span><b><a href="#tokendef-close-square">#tokendef-close-square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-square">4.3.1. 
 Consume a token</a>
@@ -6623,8 +6623,8 @@ Defining Grammars for Rules and Other Values</a>
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-open-paren">
-   <b><a href="#tokendef-open-paren">#tokendef-open-paren</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-open-paren" class="dfn-panel" data-for="tokendef-open-paren" id="infopanel-for-tokendef-open-paren" role="dialog">
+   <span id="infopaneltitle-for-tokendef-open-paren" style="display:none">Info about the '&lt;(-token>' definition.</span><b><a href="#tokendef-open-paren">#tokendef-open-paren</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-open-paren">4.3.1. 
 Consume a token</a>
@@ -6640,8 +6640,8 @@ Defining Grammars for Rules and Other Values</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-close-paren">
-   <b><a href="#tokendef-close-paren">#tokendef-close-paren</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-close-paren" class="dfn-panel" data-for="tokendef-close-paren" id="infopanel-for-tokendef-close-paren" role="dialog">
+   <span id="infopaneltitle-for-tokendef-close-paren" style="display:none">Info about the '&lt;)-token>' definition.</span><b><a href="#tokendef-close-paren">#tokendef-close-paren</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-paren">4.3.1. 
 Consume a token</a>
@@ -6655,8 +6655,8 @@ Defining Grammars for Rules and Other Values</a>
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-open-curly">
-   <b><a href="#tokendef-open-curly">#tokendef-open-curly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-open-curly" class="dfn-panel" data-for="tokendef-open-curly" id="infopanel-for-tokendef-open-curly" role="dialog">
+   <span id="infopaneltitle-for-tokendef-open-curly" style="display:none">Info about the '&lt;{-token>' definition.</span><b><a href="#tokendef-open-curly">#tokendef-open-curly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-open-curly">2.2. 
 Error Handling</a>
@@ -6676,8 +6676,8 @@ Consume a simple block</a>
 Defining Grammars for Rules and Other Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tokendef-close-curly">
-   <b><a href="#tokendef-close-curly">#tokendef-close-curly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tokendef-close-curly" class="dfn-panel" data-for="tokendef-close-curly" id="infopanel-for-tokendef-close-curly" role="dialog">
+   <span id="infopaneltitle-for-tokendef-close-curly" style="display:none">Info about the '&lt;}-token>' definition.</span><b><a href="#tokendef-close-curly">#tokendef-close-curly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-curly">2.2. 
 Error Handling</a>
@@ -6693,8 +6693,8 @@ Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> produ
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-input-code-point">
-   <b><a href="#next-input-code-point">#next-input-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-input-code-point" class="dfn-panel" data-for="next-input-code-point" id="infopanel-for-next-input-code-point" role="dialog">
+   <span id="infopaneltitle-for-next-input-code-point" style="display:none">Info about the 'next input code point' definition.</span><b><a href="#next-input-code-point">#next-input-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-input-code-point">4.2. 
 Definitions</a> <a href="#ref-for-next-input-code-point①">(2)</a>
@@ -6726,8 +6726,8 @@ Consume a number</a> <a href="#ref-for-next-input-code-point②⑨">(2)</a> <a h
 Consume the remnants of a bad url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-input-code-point">
-   <b><a href="#current-input-code-point">#current-input-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-input-code-point" class="dfn-panel" data-for="current-input-code-point" id="infopanel-for-current-input-code-point" role="dialog">
+   <span id="infopaneltitle-for-current-input-code-point" style="display:none">Info about the 'current input code point' definition.</span><b><a href="#current-input-code-point">#current-input-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-input-code-point">4.2. 
 Definitions</a> <a href="#ref-for-current-input-code-point①">(2)</a>
@@ -6747,8 +6747,8 @@ Check if three code points would start an identifier</a>
 Check if three code points would start a number</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reconsume-the-current-input-code-point">
-   <b><a href="#reconsume-the-current-input-code-point">#reconsume-the-current-input-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reconsume-the-current-input-code-point" class="dfn-panel" data-for="reconsume-the-current-input-code-point" id="infopanel-for-reconsume-the-current-input-code-point" role="dialog">
+   <span id="infopaneltitle-for-reconsume-the-current-input-code-point" style="display:none">Info about the 'reconsume the current input code point' definition.</span><b><a href="#reconsume-the-current-input-code-point">#reconsume-the-current-input-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reconsume-the-current-input-code-point">4.3.1. 
 Consume a token</a> <a href="#ref-for-reconsume-the-current-input-code-point①">(2)</a> <a href="#ref-for-reconsume-the-current-input-code-point②">(3)</a> <a href="#ref-for-reconsume-the-current-input-code-point③">(4)</a> <a href="#ref-for-reconsume-the-current-input-code-point④">(5)</a> <a href="#ref-for-reconsume-the-current-input-code-point⑤">(6)</a> <a href="#ref-for-reconsume-the-current-input-code-point⑥">(7)</a>
@@ -6758,8 +6758,8 @@ Consume a string token</a>
 Consume an identifier</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="digit">
-   <b><a href="#digit">#digit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-digit" class="dfn-panel" data-for="digit" id="infopanel-for-digit" role="dialog">
+   <span id="infopaneltitle-for-digit" style="display:none">Info about the 'digit' definition.</span><b><a href="#digit">#digit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-digit">4.2. 
 Definitions</a> <a href="#ref-for-digit①">(2)</a>
@@ -6775,8 +6775,8 @@ Convert a string to a number</a> <a href="#ref-for-digit①③">(2)</a> <a href=
 The &lt;an+b> type</a> <a href="#ref-for-digit①⑥">(2)</a> <a href="#ref-for-digit①⑦">(3)</a> <a href="#ref-for-digit①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hex-digit">
-   <b><a href="#hex-digit">#hex-digit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hex-digit" class="dfn-panel" data-for="hex-digit" id="infopanel-for-hex-digit" role="dialog">
+   <span id="infopaneltitle-for-hex-digit" style="display:none">Info about the 'hex digit' definition.</span><b><a href="#hex-digit">#hex-digit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hex-digit">2.1. 
 Escaping</a> <a href="#ref-for-hex-digit①">(2)</a>
@@ -6788,29 +6788,29 @@ The Unicode-Range microsyntax</a>
 The &lt;urange> type</a> <a href="#ref-for-hex-digit⑦">(2)</a> <a href="#ref-for-hex-digit⑧">(3)</a> <a href="#ref-for-hex-digit⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uppercase-letter">
-   <b><a href="#uppercase-letter">#uppercase-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uppercase-letter" class="dfn-panel" data-for="uppercase-letter" id="infopanel-for-uppercase-letter" role="dialog">
+   <span id="infopaneltitle-for-uppercase-letter" style="display:none">Info about the 'uppercase letter' definition.</span><b><a href="#uppercase-letter">#uppercase-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uppercase-letter">4.2. 
 Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lowercase-letter">
-   <b><a href="#lowercase-letter">#lowercase-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lowercase-letter" class="dfn-panel" data-for="lowercase-letter" id="infopanel-for-lowercase-letter" role="dialog">
+   <span id="infopaneltitle-for-lowercase-letter" style="display:none">Info about the 'lowercase letter' definition.</span><b><a href="#lowercase-letter">#lowercase-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lowercase-letter">4.2. 
 Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="letter">
-   <b><a href="#letter">#letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-letter" class="dfn-panel" data-for="letter" id="infopanel-for-letter" role="dialog">
+   <span id="infopaneltitle-for-letter" style="display:none">Info about the 'letter' definition.</span><b><a href="#letter">#letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-letter">4.2. 
 Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-ascii-code-point">
-   <b><a href="#non-ascii-code-point">#non-ascii-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-ascii-code-point" class="dfn-panel" data-for="non-ascii-code-point" id="infopanel-for-non-ascii-code-point" role="dialog">
+   <span id="infopaneltitle-for-non-ascii-code-point" style="display:none">Info about the 'non-ASCII code point' definition.</span><b><a href="#non-ascii-code-point">#non-ascii-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-ascii-code-point">4.2. 
 Definitions</a>
@@ -6818,8 +6818,8 @@ Definitions</a>
 Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-non-ascii-code-point②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier-start-code-point">
-   <b><a href="#identifier-start-code-point">#identifier-start-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier-start-code-point" class="dfn-panel" data-for="identifier-start-code-point" id="infopanel-for-identifier-start-code-point" role="dialog">
+   <span id="infopaneltitle-for-identifier-start-code-point" style="display:none">Info about the 'identifier-start code point' definition.</span><b><a href="#identifier-start-code-point">#identifier-start-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-start-code-point">2. 
 Description of CSS’s Syntax</a>
@@ -6831,8 +6831,8 @@ Consume a token</a>
 Check if three code points would start an identifier</a> <a href="#ref-for-identifier-start-code-point④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier-code-point">
-   <b><a href="#identifier-code-point">#identifier-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier-code-point" class="dfn-panel" data-for="identifier-code-point" id="infopanel-for-identifier-code-point" role="dialog">
+   <span id="infopaneltitle-for-identifier-code-point" style="display:none">Info about the 'identifier code point' definition.</span><b><a href="#identifier-code-point">#identifier-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-code-point">2. 
 Description of CSS’s Syntax</a>
@@ -6844,15 +6844,15 @@ Consume an identifier</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-printable-code-point">
-   <b><a href="#non-printable-code-point">#non-printable-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-printable-code-point" class="dfn-panel" data-for="non-printable-code-point" id="infopanel-for-non-printable-code-point" role="dialog">
+   <span id="infopaneltitle-for-non-printable-code-point" style="display:none">Info about the 'non-printable code point' definition.</span><b><a href="#non-printable-code-point">#non-printable-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-printable-code-point">4.3.6. 
 Consume a url token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="newline">
-   <b><a href="#newline">#newline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-newline" class="dfn-panel" data-for="newline" id="infopanel-for-newline" role="dialog">
+   <span id="infopaneltitle-for-newline" style="display:none">Info about the 'newline' definition.</span><b><a href="#newline">#newline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-newline">2.1. 
 Escaping</a>
@@ -6866,8 +6866,8 @@ Check if two code points are a valid escape</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="whitespace">
-   <b><a href="#whitespace">#whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-whitespace" class="dfn-panel" data-for="whitespace" id="infopanel-for-whitespace" role="dialog">
+   <span id="infopaneltitle-for-whitespace" style="display:none">Info about the 'whitespace' definition.</span><b><a href="#whitespace">#whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">2.1. 
 Escaping</a>
@@ -6881,8 +6881,8 @@ Consume a url token</a> <a href="#ref-for-whitespace⑥">(2)</a> <a href="#ref-f
 Consume an escaped code point</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-allowed-code-point">
-   <b><a href="#maximum-allowed-code-point">#maximum-allowed-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-allowed-code-point" class="dfn-panel" data-for="maximum-allowed-code-point" id="infopanel-for-maximum-allowed-code-point" role="dialog">
+   <span id="infopaneltitle-for-maximum-allowed-code-point" style="display:none">Info about the 'maximum allowed code point' definition.</span><b><a href="#maximum-allowed-code-point">#maximum-allowed-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-allowed-code-point">4.3.7. 
 Consume an escaped code point</a>
@@ -6890,8 +6890,8 @@ Consume an escaped code point</a>
 The &lt;urange> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier">
-   <b><a href="#identifier">#identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier" class="dfn-panel" data-for="identifier" id="infopanel-for-identifier" role="dialog">
+   <span id="infopaneltitle-for-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#identifier">#identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier">2. 
 Description of CSS’s Syntax</a>
@@ -6903,8 +6903,8 @@ Definitions</a>
 Check if three code points would start an identifier</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="representation">
-   <b><a href="#representation">#representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-representation" class="dfn-panel" data-for="representation" id="infopanel-for-representation" role="dialog">
+   <span id="infopaneltitle-for-representation" style="display:none">Info about the 'representation' definition.</span><b><a href="#representation">#representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-representation">4.2. 
 Definitions</a> <a href="#ref-for-representation①">(2)</a> <a href="#ref-for-representation②">(3)</a>
@@ -6916,8 +6916,8 @@ The &lt;urange> type</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-token">
-   <b><a href="#consume-a-token">#consume-a-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-token" class="dfn-panel" data-for="consume-a-token" id="infopanel-for-consume-a-token" role="dialog">
+   <span id="infopaneltitle-for-consume-a-token" style="display:none">Info about the 'consume a token' definition.</span><b><a href="#consume-a-token">#consume-a-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-token">4. 
 Tokenization</a> <a href="#ref-for-consume-a-token①">(2)</a>
@@ -6927,22 +6927,22 @@ Definitions</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-comments">
-   <b><a href="#consume-comments">#consume-comments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-comments" class="dfn-panel" data-for="consume-comments" id="infopanel-for-consume-comments" role="dialog">
+   <span id="infopaneltitle-for-consume-comments" style="display:none">Info about the 'consume comments' definition.</span><b><a href="#consume-comments">#consume-comments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-comments">4.3.1. 
 Consume a token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-numeric-token">
-   <b><a href="#consume-a-numeric-token">#consume-a-numeric-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-numeric-token" class="dfn-panel" data-for="consume-a-numeric-token" id="infopanel-for-consume-a-numeric-token" role="dialog">
+   <span id="infopaneltitle-for-consume-a-numeric-token" style="display:none">Info about the 'consume a numeric token' definition.</span><b><a href="#consume-a-numeric-token">#consume-a-numeric-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-numeric-token">4.3.1. 
 Consume a token</a> <a href="#ref-for-consume-a-numeric-token①">(2)</a> <a href="#ref-for-consume-a-numeric-token②">(3)</a> <a href="#ref-for-consume-a-numeric-token③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-an-ident-like-token">
-   <b><a href="#consume-an-ident-like-token">#consume-an-ident-like-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-an-ident-like-token" class="dfn-panel" data-for="consume-an-ident-like-token" id="infopanel-for-consume-an-ident-like-token" role="dialog">
+   <span id="infopaneltitle-for-consume-an-ident-like-token" style="display:none">Info about the 'consume an ident-like token' definition.</span><b><a href="#consume-an-ident-like-token">#consume-an-ident-like-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-an-ident-like-token">4.3.1. 
 Consume a token</a> <a href="#ref-for-consume-an-ident-like-token①">(2)</a> <a href="#ref-for-consume-an-ident-like-token②">(3)</a>
@@ -6950,22 +6950,22 @@ Consume a token</a> <a href="#ref-for-consume-an-ident-like-token①">(2)</a> <a
 Consume a url token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-string-token">
-   <b><a href="#consume-a-string-token">#consume-a-string-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-string-token" class="dfn-panel" data-for="consume-a-string-token" id="infopanel-for-consume-a-string-token" role="dialog">
+   <span id="infopaneltitle-for-consume-a-string-token" style="display:none">Info about the 'consume a string token' definition.</span><b><a href="#consume-a-string-token">#consume-a-string-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-string-token">4.3.1. 
 Consume a token</a> <a href="#ref-for-consume-a-string-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-url-token">
-   <b><a href="#consume-a-url-token">#consume-a-url-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-url-token" class="dfn-panel" data-for="consume-a-url-token" id="infopanel-for-consume-a-url-token" role="dialog">
+   <span id="infopaneltitle-for-consume-a-url-token" style="display:none">Info about the 'consume a url token' definition.</span><b><a href="#consume-a-url-token">#consume-a-url-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-url-token">4.3.4. 
 Consume an ident-like token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-an-escaped-code-point">
-   <b><a href="#consume-an-escaped-code-point">#consume-an-escaped-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-an-escaped-code-point" class="dfn-panel" data-for="consume-an-escaped-code-point" id="infopanel-for-consume-an-escaped-code-point" role="dialog">
+   <span id="infopaneltitle-for-consume-an-escaped-code-point" style="display:none">Info about the 'consume an escaped code point' definition.</span><b><a href="#consume-an-escaped-code-point">#consume-an-escaped-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-an-escaped-code-point">4.3.5. 
 Consume a string token</a>
@@ -6977,8 +6977,8 @@ Consume an identifier</a>
 Consume the remnants of a bad url</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-if-two-code-points-are-a-valid-escape">
-   <b><a href="#check-if-two-code-points-are-a-valid-escape">#check-if-two-code-points-are-a-valid-escape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-if-two-code-points-are-a-valid-escape" class="dfn-panel" data-for="check-if-two-code-points-are-a-valid-escape" id="infopanel-for-check-if-two-code-points-are-a-valid-escape" role="dialog">
+   <span id="infopaneltitle-for-check-if-two-code-points-are-a-valid-escape" style="display:none">Info about the 'check if two code points are a valid escape' definition.</span><b><a href="#check-if-two-code-points-are-a-valid-escape">#check-if-two-code-points-are-a-valid-escape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-if-two-code-points-are-a-valid-escape">4.3.1. 
 Consume a token</a> <a href="#ref-for-check-if-two-code-points-are-a-valid-escape①">(2)</a>
@@ -6996,8 +6996,8 @@ Consume the remnants of a bad url</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-if-three-code-points-would-start-an-identifier">
-   <b><a href="#check-if-three-code-points-would-start-an-identifier">#check-if-three-code-points-would-start-an-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-if-three-code-points-would-start-an-identifier" class="dfn-panel" data-for="check-if-three-code-points-would-start-an-identifier" id="infopanel-for-check-if-three-code-points-would-start-an-identifier" role="dialog">
+   <span id="infopaneltitle-for-check-if-three-code-points-would-start-an-identifier" style="display:none">Info about the 'check if three code points would start an identifier' definition.</span><b><a href="#check-if-three-code-points-would-start-an-identifier">#check-if-three-code-points-would-start-an-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-if-three-code-points-would-start-an-identifier">4.3.1. 
 Consume a token</a> <a href="#ref-for-check-if-three-code-points-would-start-an-identifier①">(2)</a> <a href="#ref-for-check-if-three-code-points-would-start-an-identifier②">(3)</a>
@@ -7007,8 +7007,8 @@ Consume a numeric token</a>
 Consume an identifier</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-if-three-code-points-would-start-a-number">
-   <b><a href="#check-if-three-code-points-would-start-a-number">#check-if-three-code-points-would-start-a-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-if-three-code-points-would-start-a-number" class="dfn-panel" data-for="check-if-three-code-points-would-start-a-number" id="infopanel-for-check-if-three-code-points-would-start-a-number" role="dialog">
+   <span id="infopaneltitle-for-check-if-three-code-points-would-start-a-number" style="display:none">Info about the 'check if three code points would start a number' definition.</span><b><a href="#check-if-three-code-points-would-start-a-number">#check-if-three-code-points-would-start-a-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-if-three-code-points-would-start-a-number">4.3.1. 
 Consume a token</a> <a href="#ref-for-check-if-three-code-points-would-start-a-number①">(2)</a> <a href="#ref-for-check-if-three-code-points-would-start-a-number②">(3)</a>
@@ -7016,8 +7016,8 @@ Consume a token</a> <a href="#ref-for-check-if-three-code-points-would-start-a-n
 Consume a number</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-an-identifier">
-   <b><a href="#consume-an-identifier">#consume-an-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-an-identifier" class="dfn-panel" data-for="consume-an-identifier" id="infopanel-for-consume-an-identifier" role="dialog">
+   <span id="infopaneltitle-for-consume-an-identifier" style="display:none">Info about the 'consume an identifier' definition.</span><b><a href="#consume-an-identifier">#consume-an-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-an-identifier">4.3.1. 
 Consume a token</a> <a href="#ref-for-consume-an-identifier①">(2)</a>
@@ -7027,29 +7027,29 @@ Consume a numeric token</a>
 Consume an ident-like token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-number">
-   <b><a href="#consume-a-number">#consume-a-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-number" class="dfn-panel" data-for="consume-a-number" id="infopanel-for-consume-a-number" role="dialog">
+   <span id="infopaneltitle-for-consume-a-number" style="display:none">Info about the 'consume a number' definition.</span><b><a href="#consume-a-number">#consume-a-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-number">4.3.3. 
 Consume a numeric token</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-string-to-a-number">
-   <b><a href="#convert-a-string-to-a-number">#convert-a-string-to-a-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-string-to-a-number" class="dfn-panel" data-for="convert-a-string-to-a-number" id="infopanel-for-convert-a-string-to-a-number" role="dialog">
+   <span id="infopaneltitle-for-convert-a-string-to-a-number" style="display:none">Info about the 'convert a string to a number' definition.</span><b><a href="#convert-a-string-to-a-number">#convert-a-string-to-a-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-string-to-a-number">4.3.12. 
 Consume a number</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-the-remnants-of-a-bad-url">
-   <b><a href="#consume-the-remnants-of-a-bad-url">#consume-the-remnants-of-a-bad-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-the-remnants-of-a-bad-url" class="dfn-panel" data-for="consume-the-remnants-of-a-bad-url" id="infopanel-for-consume-the-remnants-of-a-bad-url" role="dialog">
+   <span id="infopaneltitle-for-consume-the-remnants-of-a-bad-url" style="display:none">Info about the 'consume the remnants of a bad url' definition.</span><b><a href="#consume-the-remnants-of-a-bad-url">#consume-the-remnants-of-a-bad-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-the-remnants-of-a-bad-url">4.3.6. 
 Consume a url token</a> <a href="#ref-for-consume-the-remnants-of-a-bad-url①">(2)</a> <a href="#ref-for-consume-the-remnants-of-a-bad-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-rule">
-   <b><a href="#at-rule">#at-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-rule" class="dfn-panel" data-for="at-rule" id="infopanel-for-at-rule" role="dialog">
+   <span id="infopaneltitle-for-at-rule" style="display:none">Info about the 'at-rule' definition.</span><b><a href="#at-rule">#at-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rule">2. 
 Description of CSS’s Syntax</a> <a href="#ref-for-at-rule①">(2)</a> <a href="#ref-for-at-rule②">(3)</a> <a href="#ref-for-at-rule③">(4)</a> <a href="#ref-for-at-rule④">(5)</a> <a href="#ref-for-at-rule⑤">(6)</a> <a href="#ref-for-at-rule⑥">(7)</a> <a href="#ref-for-at-rule⑦">(8)</a> <a href="#ref-for-at-rule⑧">(9)</a> <a href="#ref-for-at-rule⑨">(10)</a>
@@ -7063,8 +7063,8 @@ At-rules</a> <a href="#ref-for-at-rule①③">(2)</a> <a href="#ref-for-at-rule�
 The @charset Rule</a> <a href="#ref-for-at-rule①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="qualified-rule">
-   <b><a href="#qualified-rule">#qualified-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-qualified-rule" class="dfn-panel" data-for="qualified-rule" id="infopanel-for-qualified-rule" role="dialog">
+   <span id="infopaneltitle-for-qualified-rule" style="display:none">Info about the 'qualified rule' definition.</span><b><a href="#qualified-rule">#qualified-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-qualified-rule">2. 
 Description of CSS’s Syntax</a> <a href="#ref-for-qualified-rule①">(2)</a> <a href="#ref-for-qualified-rule②">(3)</a> <a href="#ref-for-qualified-rule③">(4)</a>
@@ -7078,36 +7078,36 @@ Style rules</a> <a href="#ref-for-qualified-rule⑦">(2)</a>
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declaration">
-   <b><a href="#declaration">#declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declaration" class="dfn-panel" data-for="declaration" id="infopanel-for-declaration" role="dialog">
+   <span id="infopaneltitle-for-declaration" style="display:none">Info about the 'declaration' definition.</span><b><a href="#declaration">#declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declaration">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-descriptor-declarations">
-   <b><a href="#css-descriptor-declarations">#css-descriptor-declarations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-descriptor-declarations" class="dfn-panel" data-for="css-descriptor-declarations" id="infopanel-for-css-descriptor-declarations" role="dialog">
+   <span id="infopaneltitle-for-css-descriptor-declarations" style="display:none">Info about the 'descriptor declarations' definition.</span><b><a href="#css-descriptor-declarations">#css-descriptor-declarations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-descriptor-declarations">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="component-value">
-   <b><a href="#component-value">#component-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-component-value" class="dfn-panel" data-for="component-value" id="infopanel-for-component-value" role="dialog">
+   <span id="infopaneltitle-for-component-value" style="display:none">Info about the 'component value' definition.</span><b><a href="#component-value">#component-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-value">5.2. 
 Definitions</a> <a href="#ref-for-component-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preserved-tokens">
-   <b><a href="#preserved-tokens">#preserved-tokens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preserved-tokens" class="dfn-panel" data-for="preserved-tokens" id="infopanel-for-preserved-tokens" role="dialog">
+   <span id="infopaneltitle-for-preserved-tokens" style="display:none">Info about the 'preserved tokens' definition.</span><b><a href="#preserved-tokens">#preserved-tokens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preserved-tokens">5. 
 Parsing</a> <a href="#ref-for-preserved-tokens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="function">
-   <b><a href="#function">#function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-function" class="dfn-panel" data-for="function" id="infopanel-for-function" role="dialog">
+   <span id="infopaneltitle-for-function" style="display:none">Info about the 'function' definition.</span><b><a href="#function">#function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-function">5. 
 Parsing</a>
@@ -7115,8 +7115,8 @@ Parsing</a>
 Parser Algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-block">
-   <b><a href="#simple-block">#simple-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-block" class="dfn-panel" data-for="simple-block" id="infopanel-for-simple-block" role="dialog">
+   <span id="infopaneltitle-for-simple-block" style="display:none">Info about the 'simple block' definition.</span><b><a href="#simple-block">#simple-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-block">5. 
 Parsing</a>
@@ -7130,8 +7130,8 @@ Consume a qualified rule</a>
 Consume a simple block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-input-token">
-   <b><a href="#current-input-token">#current-input-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-input-token" class="dfn-panel" data-for="current-input-token" id="infopanel-for-current-input-token" role="dialog">
+   <span id="infopaneltitle-for-current-input-token" style="display:none">Info about the 'current input token' definition.</span><b><a href="#current-input-token">#current-input-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-input-token">5.2. 
 Definitions</a> <a href="#ref-for-current-input-token①">(2)</a> <a href="#ref-for-current-input-token②">(3)</a> <a href="#ref-for-current-input-token③">(4)</a>
@@ -7149,8 +7149,8 @@ Consume a simple block</a> <a href="#ref-for-current-input-token①①">(2)</a> 
 Consume a function</a> <a href="#ref-for-current-input-token①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-input-token">
-   <b><a href="#next-input-token">#next-input-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-input-token" class="dfn-panel" data-for="next-input-token" id="infopanel-for-next-input-token" role="dialog">
+   <span id="infopaneltitle-for-next-input-token" style="display:none">Info about the 'next input token' definition.</span><b><a href="#next-input-token">#next-input-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-input-token">5.2. 
 Definitions</a> <a href="#ref-for-next-input-token①">(2)</a> <a href="#ref-for-next-input-token②">(3)</a> <a href="#ref-for-next-input-token③">(4)</a>
@@ -7176,8 +7176,8 @@ Consume a simple block</a>
 Consume a function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-eof-token">
-   <b><a href="#typedef-eof-token">#typedef-eof-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-eof-token" class="dfn-panel" data-for="typedef-eof-token" id="infopanel-for-typedef-eof-token" role="dialog">
+   <span id="infopaneltitle-for-typedef-eof-token" style="display:none">Info about the '&lt;EOF-token>' definition.</span><b><a href="#typedef-eof-token">#typedef-eof-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-eof-token">4. 
 Tokenization</a>
@@ -7211,8 +7211,8 @@ Consume a simple block</a>
 Consume a function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-the-next-input-token">
-   <b><a href="#consume-the-next-input-token">#consume-the-next-input-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-the-next-input-token" class="dfn-panel" data-for="consume-the-next-input-token" id="infopanel-for-consume-the-next-input-token" role="dialog">
+   <span id="infopaneltitle-for-consume-the-next-input-token" style="display:none">Info about the 'consume the next input token' definition.</span><b><a href="#consume-the-next-input-token">#consume-the-next-input-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-the-next-input-token">5.2. 
 Definitions</a>
@@ -7230,8 +7230,8 @@ Consume a declaration</a> <a href="#ref-for-consume-the-next-input-token⑧">(2)
 Consume a component value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reconsume-the-current-input-token">
-   <b><a href="#reconsume-the-current-input-token">#reconsume-the-current-input-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reconsume-the-current-input-token" class="dfn-panel" data-for="reconsume-the-current-input-token" id="infopanel-for-reconsume-the-current-input-token" role="dialog">
+   <span id="infopaneltitle-for-reconsume-the-current-input-token" style="display:none">Info about the 'reconsume the current input token' definition.</span><b><a href="#reconsume-the-current-input-token">#reconsume-the-current-input-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reconsume-the-current-input-token">5.4.1. 
 Consume a list of rules</a> <a href="#ref-for-reconsume-the-current-input-token①">(2)</a> <a href="#ref-for-reconsume-the-current-input-token②">(3)</a>
@@ -7247,8 +7247,8 @@ Consume a simple block</a>
 Consume a function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normalize-into-a-token-stream">
-   <b><a href="#normalize-into-a-token-stream">#normalize-into-a-token-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalize-into-a-token-stream" class="dfn-panel" data-for="normalize-into-a-token-stream" id="infopanel-for-normalize-into-a-token-stream" role="dialog">
+   <span id="infopaneltitle-for-normalize-into-a-token-stream" style="display:none">Info about the 'normalize into a token stream' definition.</span><b><a href="#normalize-into-a-token-stream">#normalize-into-a-token-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize-into-a-token-stream">5.3.1. 
 Parse something according to a CSS grammar</a>
@@ -7272,8 +7272,8 @@ Parse a list of component values</a>
 Parse a comma-separated list of component values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-parse-something-according-to-a-css-grammar">
-   <b><a href="#css-parse-something-according-to-a-css-grammar">#css-parse-something-according-to-a-css-grammar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="css-parse-something-according-to-a-css-grammar" id="infopanel-for-css-parse-something-according-to-a-css-grammar" role="dialog">
+   <span id="infopaneltitle-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse something according to a CSS grammar' definition.</span><b><a href="#css-parse-something-according-to-a-css-grammar">#css-parse-something-according-to-a-css-grammar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">5.3.1. 
 Parse something according to a CSS grammar</a>
@@ -7285,8 +7285,8 @@ Style rules</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-parse-a-comma-separated-list-according-to-a-css-grammar">
-   <b><a href="#css-parse-a-comma-separated-list-according-to-a-css-grammar">#css-parse-a-comma-separated-list-according-to-a-css-grammar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" class="dfn-panel" data-for="css-parse-a-comma-separated-list-according-to-a-css-grammar" id="infopanel-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" role="dialog">
+   <span id="infopaneltitle-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" style="display:none">Info about the 'parse a comma-separated list according to a CSS grammar' definition.</span><b><a href="#css-parse-a-comma-separated-list-according-to-a-css-grammar">#css-parse-a-comma-separated-list-according-to-a-css-grammar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-a-comma-separated-list-according-to-a-css-grammar">5.3.1. 
 Parse something according to a CSS grammar</a>
@@ -7294,8 +7294,8 @@ Parse something according to a CSS grammar</a>
 Parse A Comma-Separated List According To A CSS Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-stylesheet">
-   <b><a href="#parse-a-stylesheet">#parse-a-stylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-stylesheet" class="dfn-panel" data-for="parse-a-stylesheet" id="infopanel-for-parse-a-stylesheet" role="dialog">
+   <span id="infopaneltitle-for-parse-a-stylesheet" style="display:none">Info about the 'parse a stylesheet' definition.</span><b><a href="#parse-a-stylesheet">#parse-a-stylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-stylesheet">5.3. 
 Parser Entry Points</a> <a href="#ref-for-parse-a-stylesheet①">(2)</a>
@@ -7303,29 +7303,29 @@ Parser Entry Points</a> <a href="#ref-for-parse-a-stylesheet①">(2)</a>
 CSS stylesheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-list-of-rules">
-   <b><a href="#parse-a-list-of-rules">#parse-a-list-of-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-list-of-rules" class="dfn-panel" data-for="parse-a-list-of-rules" id="infopanel-for-parse-a-list-of-rules" role="dialog">
+   <span id="infopaneltitle-for-parse-a-list-of-rules" style="display:none">Info about the 'parse a list of rules' definition.</span><b><a href="#parse-a-list-of-rules">#parse-a-list-of-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-rules">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-rule">
-   <b><a href="#parse-a-rule">#parse-a-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-rule" class="dfn-panel" data-for="parse-a-rule" id="infopanel-for-parse-a-rule" role="dialog">
+   <span id="infopaneltitle-for-parse-a-rule" style="display:none">Info about the 'parse a rule' definition.</span><b><a href="#parse-a-rule">#parse-a-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-rule">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-declaration">
-   <b><a href="#parse-a-declaration">#parse-a-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-declaration" class="dfn-panel" data-for="parse-a-declaration" id="infopanel-for-parse-a-declaration" role="dialog">
+   <span id="infopaneltitle-for-parse-a-declaration" style="display:none">Info about the 'parse a declaration' definition.</span><b><a href="#parse-a-declaration">#parse-a-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-declaration">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-list-of-declarations">
-   <b><a href="#parse-a-list-of-declarations">#parse-a-list-of-declarations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-list-of-declarations" class="dfn-panel" data-for="parse-a-list-of-declarations" id="infopanel-for-parse-a-list-of-declarations" role="dialog">
+   <span id="infopaneltitle-for-parse-a-list-of-declarations" style="display:none">Info about the 'parse a list of declarations' definition.</span><b><a href="#parse-a-list-of-declarations">#parse-a-list-of-declarations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-declarations">5. 
 Parsing</a>
@@ -7337,15 +7337,15 @@ Parse a declaration</a>
 Style rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-component-value">
-   <b><a href="#parse-a-component-value">#parse-a-component-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-component-value" class="dfn-panel" data-for="parse-a-component-value" id="infopanel-for-parse-a-component-value" role="dialog">
+   <span id="infopaneltitle-for-parse-a-component-value" style="display:none">Info about the 'parse a component value' definition.</span><b><a href="#parse-a-component-value">#parse-a-component-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-component-value">5.3. 
 Parser Entry Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-list-of-component-values">
-   <b><a href="#parse-a-list-of-component-values">#parse-a-list-of-component-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-list-of-component-values" class="dfn-panel" data-for="parse-a-list-of-component-values" id="infopanel-for-parse-a-list-of-component-values" role="dialog">
+   <span id="infopaneltitle-for-parse-a-list-of-component-values" style="display:none">Info about the 'parse a list of component values' definition.</span><b><a href="#parse-a-list-of-component-values">#parse-a-list-of-component-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-component-values">5.3. 
 Parser Entry Points</a>
@@ -7353,8 +7353,8 @@ Parser Entry Points</a>
 Parse something according to a CSS grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-comma-separated-list-of-component-values">
-   <b><a href="#parse-a-comma-separated-list-of-component-values">#parse-a-comma-separated-list-of-component-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-comma-separated-list-of-component-values" class="dfn-panel" data-for="parse-a-comma-separated-list-of-component-values" id="infopanel-for-parse-a-comma-separated-list-of-component-values" role="dialog">
+   <span id="infopaneltitle-for-parse-a-comma-separated-list-of-component-values" style="display:none">Info about the 'parse a comma-separated list of component values' definition.</span><b><a href="#parse-a-comma-separated-list-of-component-values">#parse-a-comma-separated-list-of-component-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-comma-separated-list-of-component-values">5.3.2. 
 Parse A Comma-Separated List According To A CSS Grammar</a>
@@ -7362,8 +7362,8 @@ Parse A Comma-Separated List According To A CSS Grammar</a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-list-of-rules">
-   <b><a href="#consume-a-list-of-rules">#consume-a-list-of-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-list-of-rules" class="dfn-panel" data-for="consume-a-list-of-rules" id="infopanel-for-consume-a-list-of-rules" role="dialog">
+   <span id="infopaneltitle-for-consume-a-list-of-rules" style="display:none">Info about the 'consume a list of rules' definition.</span><b><a href="#consume-a-list-of-rules">#consume-a-list-of-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-list-of-rules">5.3.3. 
 Parse a stylesheet</a>
@@ -7375,8 +7375,8 @@ Consume a simple block</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-an-at-rule">
-   <b><a href="#consume-an-at-rule">#consume-an-at-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-an-at-rule" class="dfn-panel" data-for="consume-an-at-rule" id="infopanel-for-consume-an-at-rule" role="dialog">
+   <span id="infopaneltitle-for-consume-an-at-rule" style="display:none">Info about the 'consume an at-rule' definition.</span><b><a href="#consume-an-at-rule">#consume-an-at-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-an-at-rule">5.3.5. 
 Parse a rule</a>
@@ -7386,8 +7386,8 @@ Consume a list of rules</a>
 Consume a list of declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-qualified-rule">
-   <b><a href="#consume-a-qualified-rule">#consume-a-qualified-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-qualified-rule" class="dfn-panel" data-for="consume-a-qualified-rule" id="infopanel-for-consume-a-qualified-rule" role="dialog">
+   <span id="infopaneltitle-for-consume-a-qualified-rule" style="display:none">Info about the 'consume a qualified rule' definition.</span><b><a href="#consume-a-qualified-rule">#consume-a-qualified-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-qualified-rule">5.3.5. 
 Parse a rule</a>
@@ -7395,8 +7395,8 @@ Parse a rule</a>
 Consume a list of rules</a> <a href="#ref-for-consume-a-qualified-rule②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-list-of-declarations">
-   <b><a href="#consume-a-list-of-declarations">#consume-a-list-of-declarations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-list-of-declarations" class="dfn-panel" data-for="consume-a-list-of-declarations" id="infopanel-for-consume-a-list-of-declarations" role="dialog">
+   <span id="infopaneltitle-for-consume-a-list-of-declarations" style="display:none">Info about the 'consume a list of declarations' definition.</span><b><a href="#consume-a-list-of-declarations">#consume-a-list-of-declarations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-list-of-declarations">5.3.7. 
 Parse a list of declarations</a>
@@ -7406,8 +7406,8 @@ Consume a simple block</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-declaration">
-   <b><a href="#consume-a-declaration">#consume-a-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-declaration" class="dfn-panel" data-for="consume-a-declaration" id="infopanel-for-consume-a-declaration" role="dialog">
+   <span id="infopaneltitle-for-consume-a-declaration" style="display:none">Info about the 'consume a declaration' definition.</span><b><a href="#consume-a-declaration">#consume-a-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-declaration">5.3.6. 
 Parse a declaration</a>
@@ -7415,8 +7415,8 @@ Parse a declaration</a>
 Consume a list of declarations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-component-value">
-   <b><a href="#consume-a-component-value">#consume-a-component-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-component-value" class="dfn-panel" data-for="consume-a-component-value" id="infopanel-for-consume-a-component-value" role="dialog">
+   <span id="infopaneltitle-for-consume-a-component-value" style="display:none">Info about the 'consume a component value' definition.</span><b><a href="#consume-a-component-value">#consume-a-component-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-component-value">5.3.8. 
 Parse a component value</a>
@@ -7438,8 +7438,8 @@ Consume a simple block</a>
 Consume a function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-simple-block">
-   <b><a href="#consume-a-simple-block">#consume-a-simple-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-simple-block" class="dfn-panel" data-for="consume-a-simple-block" id="infopanel-for-consume-a-simple-block" role="dialog">
+   <span id="infopaneltitle-for-consume-a-simple-block" style="display:none">Info about the 'consume a simple block' definition.</span><b><a href="#consume-a-simple-block">#consume-a-simple-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-simple-block">5.4.2. 
 Consume an at-rule</a>
@@ -7449,22 +7449,22 @@ Consume a qualified rule</a>
 Consume a component value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ending-token">
-   <b><a href="#ending-token">#ending-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ending-token" class="dfn-panel" data-for="ending-token" id="infopanel-for-ending-token" role="dialog">
+   <span id="infopaneltitle-for-ending-token" style="display:none">Info about the 'ending token' definition.</span><b><a href="#ending-token">#ending-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ending-token">5.4.7. 
 Consume a simple block</a> <a href="#ref-for-ending-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-a-function">
-   <b><a href="#consume-a-function">#consume-a-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-a-function" class="dfn-panel" data-for="consume-a-function" id="infopanel-for-consume-a-function" role="dialog">
+   <span id="infopaneltitle-for-consume-a-function" style="display:none">Info about the 'consume a function' definition.</span><b><a href="#consume-a-function">#consume-a-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-function">5.4.6. 
 Consume a component value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anb-production">
-   <b><a href="#anb-production">#anb-production</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anb-production" class="dfn-panel" data-for="anb-production" id="infopanel-for-anb-production" role="dialog">
+   <span id="infopaneltitle-for-anb-production" style="display:none">Info about the '&lt;an+b>' definition.</span><b><a href="#anb-production">#anb-production</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anb-production">10.1. 
 Serializing &lt;an+b></a>
@@ -7472,8 +7472,8 @@ Serializing &lt;an+b></a>
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-urange">
-   <b><a href="#typedef-urange">#typedef-urange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-urange" class="dfn-panel" data-for="typedef-urange" id="infopanel-for-typedef-urange" role="dialog">
+   <span id="infopaneltitle-for-typedef-urange" style="display:none">Info about the '&lt;urange>' definition.</span><b><a href="#typedef-urange">#typedef-urange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-urange">4.2. 
 Definitions</a>
@@ -7487,8 +7487,8 @@ Changes from the 20 February 2014 Candidate Recommendation</a>
 Changes from CSS 2.1 and Selectors Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-declaration-list">
-   <b><a href="#typedef-declaration-list">#typedef-declaration-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-declaration-list" class="dfn-panel" data-for="typedef-declaration-list" id="infopanel-for-typedef-declaration-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' definition.</span><b><a href="#typedef-declaration-list">#typedef-declaration-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">5.4.7. 
 Consume a simple block</a>
@@ -7496,8 +7496,8 @@ Consume a simple block</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a> <a href="#ref-for-typedef-declaration-list②">(2)</a> <a href="#ref-for-typedef-declaration-list③">(3)</a> <a href="#ref-for-typedef-declaration-list④">(4)</a> <a href="#ref-for-typedef-declaration-list⑤">(5)</a> <a href="#ref-for-typedef-declaration-list⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-rule-list">
-   <b><a href="#typedef-rule-list">#typedef-rule-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-rule-list" class="dfn-panel" data-for="typedef-rule-list" id="infopanel-for-typedef-rule-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-rule-list" style="display:none">Info about the '&lt;rule-list>' definition.</span><b><a href="#typedef-rule-list">#typedef-rule-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-rule-list">5.4.7. 
 Consume a simple block</a>
@@ -7505,8 +7505,8 @@ Consume a simple block</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a> <a href="#ref-for-typedef-rule-list②">(2)</a> <a href="#ref-for-typedef-rule-list③">(3)</a> <a href="#ref-for-typedef-rule-list④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-stylesheet">
-   <b><a href="#typedef-stylesheet">#typedef-stylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-stylesheet" class="dfn-panel" data-for="typedef-stylesheet" id="infopanel-for-typedef-stylesheet" role="dialog">
+   <span id="infopaneltitle-for-typedef-stylesheet" style="display:none">Info about the '&lt;stylesheet>' definition.</span><b><a href="#typedef-stylesheet">#typedef-stylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-stylesheet">5.4.7. 
 Consume a simple block</a>
@@ -7514,8 +7514,8 @@ Consume a simple block</a>
 Defining Block Contents: the &lt;declaration-list>, &lt;rule-list>, and &lt;stylesheet> productions</a> <a href="#ref-for-typedef-stylesheet②">(2)</a> <a href="#ref-for-typedef-stylesheet③">(3)</a> <a href="#ref-for-typedef-stylesheet④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-declaration-value">
-   <b><a href="#typedef-declaration-value">#typedef-declaration-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-declaration-value" class="dfn-panel" data-for="typedef-declaration-value" id="infopanel-for-typedef-declaration-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' definition.</span><b><a href="#typedef-declaration-value">#typedef-declaration-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">8.2. 
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a> <a href="#ref-for-typedef-declaration-value①">(2)</a>
@@ -7523,8 +7523,8 @@ Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> produ
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-any-value">
-   <b><a href="#typedef-any-value">#typedef-any-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-any-value" class="dfn-panel" data-for="typedef-any-value" id="infopanel-for-typedef-any-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-any-value" style="display:none">Info about the '&lt;any-value>' definition.</span><b><a href="#typedef-any-value">#typedef-any-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-any-value">8.2. 
 Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> productions</a>
@@ -7532,8 +7532,8 @@ Defining Arbitrary Contents: the &lt;declaration-value> and &lt;any-value> produ
 Changes from the 20 February 2014 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-rule">
-   <b><a href="#style-rule">#style-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-rule" class="dfn-panel" data-for="style-rule" id="infopanel-for-style-rule" role="dialog">
+   <span id="infopaneltitle-for-style-rule" style="display:none">Info about the 'style rule' definition.</span><b><a href="#style-rule">#style-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-rule">2. 
 Description of CSS’s Syntax</a> <a href="#ref-for-style-rule①">(2)</a>
@@ -7543,22 +7543,22 @@ CSS stylesheets</a>
 At-rules</a> <a href="#ref-for-style-rule④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-at-rule">
-   <b><a href="#block-at-rule">#block-at-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-at-rule" class="dfn-panel" data-for="block-at-rule" id="infopanel-for-block-at-rule" role="dialog">
+   <span id="infopaneltitle-for-block-at-rule" style="display:none">Info about the 'block at-rules' definition.</span><b><a href="#block-at-rule">#block-at-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-at-rule">9.2. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-descriptor">
-   <b><a href="#css-descriptor">#css-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-descriptor" class="dfn-panel" data-for="css-descriptor" id="infopanel-for-css-descriptor" role="dialog">
+   <span id="infopaneltitle-for-css-descriptor" style="display:none">Info about the 'Descriptors' definition.</span><b><a href="#css-descriptor">#css-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-descriptor">5. 
 Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-charset">
-   <b><a href="#at-ruledef-charset">#at-ruledef-charset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-charset" class="dfn-panel" data-for="at-ruledef-charset" id="infopanel-for-at-ruledef-charset" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-charset" style="display:none">Info about the '@charset' definition.</span><b><a href="#at-ruledef-charset">#at-ruledef-charset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-charset">3.2. 
 The input byte stream</a> <a href="#ref-for-at-ruledef-charset①">(2)</a>
@@ -7570,59 +7570,115 @@ Changes from CSS 2.1 and Selectors Level 3</a> <a href="#ref-for-at-ruledef-char
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/csswg-drafts/css-tables-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-tables-3/Overview.html
@@ -3537,120 +3537,120 @@ caption<c- p>[</c->align=bottom i<c- p>]</c-> <c- p>{</c-> <c- k>caption-side</c
    <li><a href="#used-width-of-table">used width of a table</a><span>, in § 3.9.1</span>
    <li><a href="#visible-track">visible track</a><span>, in § 3.11</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-isolation">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-isolation" class="dfn-panel" data-for="term-for-propdef-isolation" id="infopanel-for-term-for-propdef-isolation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-isolation" style="display:none">Info about the 'isolation' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-isolation">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mix-blend-mode">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mix-blend-mode" class="dfn-panel" data-for="term-for-propdef-mix-blend-mode" id="infopanel-for-term-for-propdef-mix-blend-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mix-blend-mode" style="display:none">Info about the 'mix-blend-mode' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mix-blend-mode">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-background①">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">5.3.1.1. Changes in collapsed-borders mode</a>
     <li><a href="#ref-for-propdef-border-image①">5.3.3.1. Changes in collapsed-borders mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-source">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-source" class="dfn-panel" data-for="term-for-propdef-border-image-source" id="infopanel-for-term-for-propdef-border-image-source" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-source" style="display:none">Info about the 'border-image-source' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-source">3.7.1.1. Conflict Resolution Algorithm for Collapsed Borders</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">3.6.2. Overrides applying in collapsed-borders mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">3.7.1.3. Specificity of a border style</a> <a href="#ref-for-propdef-border-style①">(2)</a>
     <li><a href="#ref-for-propdef-border-style②">5.3.4. Border styles (collapsed-borders mode)</a> <a href="#ref-for-propdef-border-style③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">3.7.1.3. Specificity of a border style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.6.1. Overrides applying in all modes</a> <a href="#ref-for-propdef-margin①">(2)</a> <a href="#ref-for-propdef-margin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-padding①">3.6.2. Overrides applying in collapsed-borders mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-after">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-after" class="dfn-panel" data-for="term-for-propdef-break-after" id="infopanel-for-term-for-propdef-break-after" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-after" style="display:none">Info about the 'break-after' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-after">https://drafts.csswg.org/css-break-3/#propdef-break-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-after">6.1. Breaking across fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-before">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-before" class="dfn-panel" data-for="term-for-propdef-break-before" id="infopanel-for-term-for-propdef-break-before" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-before" style="display:none">Info about the 'break-before' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-before">https://drafts.csswg.org/css-break-3/#propdef-break-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-before">6.1. Breaking across fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-break-inside">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-break-inside" class="dfn-panel" data-for="term-for-propdef-break-inside" id="infopanel-for-term-for-propdef-break-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-break-inside" style="display:none">Info about the 'break-inside' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-break-inside">https://drafts.csswg.org/css-break-3/#propdef-break-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-break-inside">6.2. Repeating headers across pages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">2.2.2. Characteristics of fixup boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2.1. Table Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">4.1. 
 With a table-root as containing block</a> <a href="#ref-for-containing-block①">(2)</a>
@@ -3658,84 +3658,84 @@ With a table-root as containing block</a> <a href="#ref-for-containing-block①"
 With a table-internal as containing block</a> <a href="#ref-for-containing-block③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.1. Table Structure</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a>
     <li><a href="#ref-for-propdef-display③">2.2.1. Fixup Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flow-layout">
-   <a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flow-layout" class="dfn-panel" data-for="term-for-flow-layout" id="infopanel-for-term-for-flow-layout" role="menu">
+   <span id="infopaneltitle-for-term-for-flow-layout" style="display:none">Info about the 'flow layout' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#flow-layout">https://drafts.csswg.org/css-display-3/#flow-layout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-layout">2.1. Table Structure</a> <a href="#ref-for-flow-layout①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2.1. Table Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">2.1.1. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">2.1.1. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">3.11. Positioning of cells, captions and other internal table boxes</a>
     <li><a href="#ref-for-propdef-visibility①">4.2. 
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grid">
-   <a href="https://drafts.csswg.org/css-grid-2/#grid">https://drafts.csswg.org/css-grid-2/#grid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grid" class="dfn-panel" data-for="term-for-grid" id="infopanel-for-term-for-grid" role="menu">
+   <span id="infopaneltitle-for-term-for-grid" style="display:none">Info about the 'grid' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#grid">https://drafts.csswg.org/css-grid-2/#grid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grid">3.3. Dimensioning the row/column grid</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3.10.2. Row layout (first pass)</a> <a href="#ref-for-propdef-vertical-align①">(2)</a> <a href="#ref-for-propdef-vertical-align②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask" class="dfn-panel" data-for="term-for-propdef-mask" id="infopanel-for-term-for-propdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">3.6.1. Overrides applying in all modes</a> <a href="#ref-for-propdef-overflow①">(2)</a> <a href="#ref-for-propdef-overflow②">(3)</a>
     <li><a href="#ref-for-propdef-overflow③">3.10.2. Row layout (first pass)</a> <a href="#ref-for-propdef-overflow④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-left①">4.1. 
@@ -3744,28 +3744,28 @@ With a table-root as containing block</a>
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">2.2.1. Fixup Algorithm</a>
     <li><a href="#ref-for-propdef-position①">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-behave-as-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-behave-as-auto" class="dfn-panel" data-for="term-for-behave-as-auto" id="infopanel-for-term-for-behave-as-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-behave-as-auto" style="display:none">Info about the 'behave as auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#behave-as-auto">https://drafts.csswg.org/css-sizing-3/#behave-as-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-behave-as-auto">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">3.8.2. Computing Cell Measures</a> <a href="#ref-for-propdef-box-sizing①">(2)</a>
     <li><a href="#ref-for-propdef-box-sizing②">3.9.3.1. Changes to width distribution in fixed mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">2.2.1. Fixup Algorithm</a>
     <li><a href="#ref-for-propdef-height①">3.10.1. Computing the table height</a> <a href="#ref-for-propdef-height②">(2)</a> <a href="#ref-for-propdef-height③">(3)</a> <a href="#ref-for-propdef-height④">(4)</a> <a href="#ref-for-propdef-height⑤">(5)</a> <a href="#ref-for-propdef-height⑥">(6)</a>
@@ -3773,34 +3773,34 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-propdef-height⑧">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-max-width">https://drafts.csswg.org/css-sizing-3/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">3.8.2. Computing Cell Measures</a> <a href="#ref-for-propdef-max-width①">(2)</a> <a href="#ref-for-propdef-max-width②">(3)</a> <a href="#ref-for-propdef-max-width③">(4)</a> <a href="#ref-for-propdef-max-width④">(5)</a> <a href="#ref-for-propdef-max-width⑤">(6)</a> <a href="#ref-for-propdef-max-width⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-contribution" class="dfn-panel" data-for="term-for-min-content-contribution" id="infopanel-for-term-for-min-content-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-contribution" style="display:none">Info about the 'min-content contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-contribution">https://drafts.csswg.org/css-sizing-3/#min-content-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-contribution">3.9.1. Computing the table width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-height">https://drafts.csswg.org/css-sizing-3/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">3.8.2. Computing Cell Measures</a> <a href="#ref-for-propdef-min-width①">(2)</a> <a href="#ref-for-propdef-min-width②">(3)</a> <a href="#ref-for-propdef-min-width③">(4)</a> <a href="#ref-for-propdef-min-width④">(5)</a> <a href="#ref-for-propdef-min-width⑤">(6)</a> <a href="#ref-for-propdef-min-width⑥">(7)</a> <a href="#ref-for-propdef-min-width⑦">(8)</a> <a href="#ref-for-propdef-min-width⑧">(9)</a> <a href="#ref-for-propdef-min-width⑨">(10)</a>
     <li><a href="#ref-for-propdef-min-width①⓪">3.9.1. Computing the table width</a>
     <li><a href="#ref-for-propdef-min-width①①">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2.2.1. Fixup Algorithm</a>
     <li><a href="#ref-for-propdef-width①">3.1. Core layout principles</a>
@@ -3810,63 +3810,63 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-propdef-width①⑤">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">3.5.3. The Caption-Side property</a>
     <li><a href="#ref-for-propdef-text-align①">3.8.3. Computing Column Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">5.2. Empty cell rendering (separated-borders mode)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-perspective">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-perspective" class="dfn-panel" data-for="term-for-propdef-perspective" id="infopanel-for-term-for-propdef-perspective" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-perspective" style="display:none">Info about the 'perspective' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-style">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-style" class="dfn-panel" data-for="term-for-propdef-transform-style" id="infopanel-for-term-for-propdef-transform-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-style" style="display:none">Info about the 'transform-style' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-style">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.5.2.1. The Border-Spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.8.3. Computing Column Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">3.5.2.1. The Border-Spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.5.1. The Table-Layout property</a>
     <li><a href="#ref-for-comb-one①">3.5.2. The Border-Collapse property</a>
@@ -3874,8 +3874,8 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-comb-one③">5.2. Empty cell rendering (separated-borders mode)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-bottom①">4.1. 
@@ -3884,15 +3884,15 @@ With a table-root as containing block</a>
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">2.2.1. Fixup Algorithm</a>
     <li><a href="#ref-for-propdef-float①">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-right①">4.1. 
@@ -3901,14 +3901,14 @@ With a table-root as containing block</a>
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-border-collapse-separate">
-   <a href="https://drafts.csswg.org/css2/#valdef-border-collapse-separate">https://drafts.csswg.org/css2/#valdef-border-collapse-separate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-border-collapse-separate" class="dfn-panel" data-for="term-for-valdef-border-collapse-separate" id="infopanel-for-term-for-valdef-border-collapse-separate" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-border-collapse-separate" style="display:none">Info about the 'separate' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-border-collapse-separate">https://drafts.csswg.org/css2/#valdef-border-collapse-separate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-collapse-separate">3.5.2.1. The Border-Spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">3.6.1. Overrides applying in all modes</a>
     <li><a href="#ref-for-propdef-top①">4.1. 
@@ -3917,20 +3917,20 @@ With a table-root as containing block</a>
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-filter" class="dfn-panel" data-for="term-for-propdef-filter" id="infopanel-for-term-for-propdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-filter">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">6.2. Repeating headers across pages</a>
    </ul>
@@ -4216,8 +4216,8 @@ With a table-internal as containing block</a>
 					by saying cells only draw the backgrounds
 					of visibility:visible grouping elements? <a class="issue-return" href="#issue-2d70544e" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="table">
-   <b><a href="#table">#table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table" class="dfn-panel" data-for="table" id="infopanel-for-table" role="dialog">
+   <span id="infopaneltitle-for-table" style="display:none">Info about the 'table' definition.</span><b><a href="#table">#table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table">2.1. Table Structure</a>
     <li><a href="#ref-for-table①">2.2. Fixup</a>
@@ -4226,15 +4226,15 @@ With a table-internal as containing block</a>
 With a table-root as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-table">
-   <b><a href="#inline-table">#inline-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-table" class="dfn-panel" data-for="inline-table" id="infopanel-for-inline-table" role="dialog">
+   <span id="infopaneltitle-for-inline-table" style="display:none">Info about the 'inline-table' definition.</span><b><a href="#inline-table">#inline-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-table">2.2. Fixup</a>
     <li><a href="#ref-for-inline-table①">2.2.1. Fixup Algorithm</a> <a href="#ref-for-inline-table②">(2)</a> <a href="#ref-for-inline-table③">(3)</a> <a href="#ref-for-inline-table④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-row">
-   <b><a href="#table-row">#table-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-row" class="dfn-panel" data-for="table-row" id="infopanel-for-table-row" role="dialog">
+   <span id="infopaneltitle-for-table-row" style="display:none">Info about the 'table-row' definition.</span><b><a href="#table-row">#table-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-row">2.1. Table Structure</a>
     <li><a href="#ref-for-table-row">2.1.1. Terminology</a> <a href="#ref-for-table-row①">(2)</a> <a href="#ref-for-table-row②">(3)</a> <a href="#ref-for-table-row③">(4)</a>
@@ -4243,8 +4243,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-row①②">6.1. Breaking across fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-row-group">
-   <b><a href="#table-row-group">#table-row-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-row-group" class="dfn-panel" data-for="table-row-group" id="infopanel-for-table-row-group" role="dialog">
+   <span id="infopaneltitle-for-table-row-group" style="display:none">Info about the 'table-row-group' definition.</span><b><a href="#table-row-group">#table-row-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-row-group">2.1. Table Structure</a> <a href="#ref-for-table-row-group">(2)</a> <a href="#ref-for-table-row-group①">(3)</a> <a href="#ref-for-table-row-group②">(4)</a>
     <li><a href="#ref-for-table-row-group③">2.1.1. Terminology</a> <a href="#ref-for-table-row-group④">(2)</a>
@@ -4252,22 +4252,22 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-row-group⑧">6.1. Breaking across fragmentainers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-header-group">
-   <b><a href="#table-header-group">#table-header-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-header-group" class="dfn-panel" data-for="table-header-group" id="infopanel-for-table-header-group" role="dialog">
+   <span id="infopaneltitle-for-table-header-group" style="display:none">Info about the 'table-header-group' definition.</span><b><a href="#table-header-group">#table-header-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-header-group">2.1. Table Structure</a>
     <li><a href="#ref-for-table-header-group">6.2. Repeating headers across pages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-footer-group">
-   <b><a href="#table-footer-group">#table-footer-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-footer-group" class="dfn-panel" data-for="table-footer-group" id="infopanel-for-table-footer-group" role="dialog">
+   <span id="infopaneltitle-for-table-footer-group" style="display:none">Info about the 'table-footer-group' definition.</span><b><a href="#table-footer-group">#table-footer-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-footer-group">2.1. Table Structure</a>
     <li><a href="#ref-for-table-footer-group">6.2. Repeating headers across pages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-column">
-   <b><a href="#table-column">#table-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-column" class="dfn-panel" data-for="table-column" id="infopanel-for-table-column" role="dialog">
+   <span id="infopaneltitle-for-table-column" style="display:none">Info about the 'table-column' definition.</span><b><a href="#table-column">#table-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-column">2.1. Table Structure</a>
     <li><a href="#ref-for-table-column">2.1.1. Terminology</a> <a href="#ref-for-table-column①">(2)</a>
@@ -4275,8 +4275,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-column⑤">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-column-group">
-   <b><a href="#table-column-group">#table-column-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-column-group" class="dfn-panel" data-for="table-column-group" id="infopanel-for-table-column-group" role="dialog">
+   <span id="infopaneltitle-for-table-column-group" style="display:none">Info about the 'table-column-group' definition.</span><b><a href="#table-column-group">#table-column-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-column-group">2.1. Table Structure</a>
     <li><a href="#ref-for-table-column-group">2.1.1. Terminology</a>
@@ -4284,8 +4284,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-column-group④">3.6.1. Overrides applying in all modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-cell">
-   <b><a href="#table-cell">#table-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-cell" class="dfn-panel" data-for="table-cell" id="infopanel-for-table-cell" role="dialog">
+   <span id="infopaneltitle-for-table-cell" style="display:none">Info about the 'table-cell' definition.</span><b><a href="#table-cell">#table-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-cell">2.1. Table Structure</a>
     <li><a href="#ref-for-table-cell">2.1.1. Terminology</a> <a href="#ref-for-table-cell①">(2)</a> <a href="#ref-for-table-cell②">(3)</a> <a href="#ref-for-table-cell③">(4)</a>
@@ -4305,8 +4305,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-cell②③">5.4.1. Rendering a visibility: collapse table cell</a> <a href="#ref-for-table-cell②④">(2)</a> <a href="#ref-for-table-cell②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-caption">
-   <b><a href="#table-caption">#table-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-caption" class="dfn-panel" data-for="table-caption" id="infopanel-for-table-caption" role="dialog">
+   <span id="infopaneltitle-for-table-caption" style="display:none">Info about the 'table-caption' definition.</span><b><a href="#table-caption">#table-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-caption">2.1. Table Structure</a>
     <li><a href="#ref-for-table-caption">2.1.1. Terminology</a> <a href="#ref-for-table-caption①">(2)</a>
@@ -4315,8 +4315,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-caption">3.9.1. Computing the table width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-wrapper-box">
-   <b><a href="#table-wrapper-box">#table-wrapper-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-wrapper-box" class="dfn-panel" data-for="table-wrapper-box" id="infopanel-for-table-wrapper-box" role="dialog">
+   <span id="infopaneltitle-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' definition.</span><b><a href="#table-wrapper-box">#table-wrapper-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">2.2.1. Fixup Algorithm</a>
     <li><a href="#ref-for-table-wrapper-box①">3.6.1. Overrides applying in all modes</a>
@@ -4325,16 +4325,16 @@ With a table-root as containing block</a>
 With a table-root as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-grid-box">
-   <b><a href="#table-grid-box">#table-grid-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-grid-box" class="dfn-panel" data-for="table-grid-box" id="infopanel-for-table-grid-box" role="dialog">
+   <span id="infopaneltitle-for-table-grid-box" style="display:none">Info about the 'table grid box' definition.</span><b><a href="#table-grid-box">#table-grid-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-grid-box">3.5.1. The Table-Layout property</a>
     <li><a href="#ref-for-table-grid-box①">3.5.2. The Border-Collapse property</a>
     <li><a href="#ref-for-table-grid-box②">3.5.2.1. The Border-Spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-root-element">
-   <b><a href="#table-root-element">#table-root-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-root-element" class="dfn-panel" data-for="table-root-element" id="infopanel-for-table-root-element" role="dialog">
+   <span id="infopaneltitle-for-table-root-element" style="display:none">Info about the 'table-root' definition.</span><b><a href="#table-root-element">#table-root-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-root-element">2.1. Table Structure</a>
     <li><a href="#ref-for-table-root-element">2.1.1. Terminology</a> <a href="#ref-for-table-root-element①">(2)</a>
@@ -4351,16 +4351,16 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-root-element②⑤">5.3.1.1. Changes in collapsed-borders mode</a> <a href="#ref-for-table-root-element②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-non-root-element">
-   <b><a href="#table-non-root-element">#table-non-root-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-non-root-element" class="dfn-panel" data-for="table-non-root-element" id="infopanel-for-table-non-root-element" role="dialog">
+   <span id="infopaneltitle-for-table-non-root-element" style="display:none">Info about the 'table-non-root' definition.</span><b><a href="#table-non-root-element">#table-non-root-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-non-root-element">2.2.1. Fixup Algorithm</a> <a href="#ref-for-table-non-root-element①">(2)</a>
     <li><a href="#ref-for-table-non-root-element②">3.6.2. Overrides applying in collapsed-borders mode</a>
     <li><a href="#ref-for-table-non-root-element③">3.11. Positioning of cells, captions and other internal table boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-track">
-   <b><a href="#table-track">#table-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-track" class="dfn-panel" data-for="table-track" id="infopanel-for-table-track" role="dialog">
+   <span id="infopaneltitle-for-table-track" style="display:none">Info about the 'table-track' definition.</span><b><a href="#table-track">#table-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-track">2.1.1. Terminology</a> <a href="#ref-for-table-track①">(2)</a>
     <li><a href="#ref-for-table-track②">3.6.1. Overrides applying in all modes</a>
@@ -4371,8 +4371,8 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-track⑧">5.4.2. Rendering a visibility: collapse table-track or table-track-group</a> <a href="#ref-for-table-track⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-track-group-element">
-   <b><a href="#table-track-group-element">#table-track-group-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-track-group-element" class="dfn-panel" data-for="table-track-group-element" id="infopanel-for-table-track-group-element" role="dialog">
+   <span id="infopaneltitle-for-table-track-group-element" style="display:none">Info about the 'table-track-group' definition.</span><b><a href="#table-track-group-element">#table-track-group-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-track-group-element">2.1.1. Terminology</a> <a href="#ref-for-table-track-group-element①">(2)</a>
     <li><a href="#ref-for-table-track-group-element②">3.6.1. Overrides applying in all modes</a>
@@ -4382,41 +4382,41 @@ With a table-root as containing block</a>
     <li><a href="#ref-for-table-track-group-element⑥">5.4.2. Rendering a visibility: collapse table-track or table-track-group</a> <a href="#ref-for-table-track-group-element⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proper-table-child-element">
-   <b><a href="#proper-table-child-element">#proper-table-child-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proper-table-child-element" class="dfn-panel" data-for="proper-table-child-element" id="infopanel-for-proper-table-child-element" role="dialog">
+   <span id="infopaneltitle-for-proper-table-child-element" style="display:none">Info about the 'proper table child' definition.</span><b><a href="#proper-table-child-element">#proper-table-child-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proper-table-child-element">2.1.1. Terminology</a>
     <li><a href="#ref-for-proper-table-child-element①">2.2.1. Fixup Algorithm</a> <a href="#ref-for-proper-table-child-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proper-table-row-parent-element">
-   <b><a href="#proper-table-row-parent-element">#proper-table-row-parent-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proper-table-row-parent-element" class="dfn-panel" data-for="proper-table-row-parent-element" id="infopanel-for-proper-table-row-parent-element" role="dialog">
+   <span id="infopaneltitle-for-proper-table-row-parent-element" style="display:none">Info about the 'proper table-row parent' definition.</span><b><a href="#proper-table-row-parent-element">#proper-table-row-parent-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proper-table-row-parent-element">2.1.1. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-internal-element">
-   <b><a href="#table-internal-element">#table-internal-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-internal-element" class="dfn-panel" data-for="table-internal-element" id="infopanel-for-table-internal-element" role="dialog">
+   <span id="infopaneltitle-for-table-internal-element" style="display:none">Info about the 'table-internal' definition.</span><b><a href="#table-internal-element">#table-internal-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-internal-element">2.2. Fixup</a>
     <li><a href="#ref-for-table-internal-element①">4.2. 
 With a table-internal as containing block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tabular-container">
-   <b><a href="#tabular-container">#tabular-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tabular-container" class="dfn-panel" data-for="tabular-container" id="infopanel-for-tabular-container" role="dialog">
+   <span id="infopaneltitle-for-tabular-container" style="display:none">Info about the 'tabular container' definition.</span><b><a href="#tabular-container">#tabular-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tabular-container">2.2.1. Fixup Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-grid">
-   <b><a href="#table-grid">#table-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-grid" class="dfn-panel" data-for="table-grid" id="infopanel-for-table-grid" role="dialog">
+   <span id="infopaneltitle-for-table-grid" style="display:none">Info about the 'table grid' definition.</span><b><a href="#table-grid">#table-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-grid">2.1.1. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slot">
-   <b><a href="#slot">#slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slot" class="dfn-panel" data-for="slot" id="infopanel-for-slot" role="dialog">
+   <span id="infopaneltitle-for-slot" style="display:none">Info about the 'slot' definition.</span><b><a href="#slot">#slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slot">2.1.1. Terminology</a>
     <li><a href="#ref-for-slot①">3.2. Table layout algorithm</a> <a href="#ref-for-slot②">(2)</a>
@@ -4426,15 +4426,15 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-slot">3.8.3. Computing Column Measures</a> <a href="#ref-for-slot">(2)</a> <a href="#ref-for-slot">(3)</a> <a href="#ref-for-slot">(4)</a> <a href="#ref-for-slot">(5)</a> <a href="#ref-for-slot">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="originate">
-   <b><a href="#originate">#originate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-originate" class="dfn-panel" data-for="originate" id="infopanel-for-originate" role="dialog">
+   <span id="infopaneltitle-for-originate" style="display:none">Info about the 'originate' definition.</span><b><a href="#originate">#originate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originate">3.3.2. Track merging</a>
     <li><a href="#ref-for-originate①">3.8.3. Computing Column Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="span">
-   <b><a href="#span">#span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-span" class="dfn-panel" data-for="span" id="infopanel-for-span" role="dialog">
+   <span id="infopaneltitle-for-span" style="display:none">Info about the 'span' definition.</span><b><a href="#span">#span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-span">3.3.1. HTML Algorithm</a>
     <li><a href="#ref-for-span①">3.3.2. Track merging</a>
@@ -4443,33 +4443,33 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-span">3.11. Positioning of cells, captions and other internal table boxes</a> <a href="#ref-for-span">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-width-of-a-table">
-   <b><a href="#min-content-width-of-a-table">#min-content-width-of-a-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-width-of-a-table" class="dfn-panel" data-for="min-content-width-of-a-table" id="infopanel-for-min-content-width-of-a-table" role="dialog">
+   <span id="infopaneltitle-for-min-content-width-of-a-table" style="display:none">Info about the 'min-content width of a table' definition.</span><b><a href="#min-content-width-of-a-table">#min-content-width-of-a-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-width-of-a-table">3.1. Core layout principles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-table">
-   <b><a href="#empty-table">#empty-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-table" class="dfn-panel" data-for="empty-table" id="infopanel-for-empty-table" role="dialog">
+   <span id="infopaneltitle-for-empty-table" style="display:none">Info about the 'empty table' definition.</span><b><a href="#empty-table">#empty-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-table">5.3.1.1. Changes in collapsed-borders mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eligible-track">
-   <b><a href="#eligible-track">#eligible-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eligible-track" class="dfn-panel" data-for="eligible-track" id="infopanel-for-eligible-track" role="dialog">
+   <span id="infopaneltitle-for-eligible-track" style="display:none">Info about the 'eligible track' definition.</span><b><a href="#eligible-track">#eligible-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eligible-track">3.3.2. Track merging</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-table-layout">
-   <b><a href="#propdef-table-layout">#propdef-table-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-table-layout" class="dfn-panel" data-for="propdef-table-layout" id="infopanel-for-propdef-table-layout" role="dialog">
+   <span id="infopaneltitle-for-propdef-table-layout" style="display:none">Info about the 'table-layout' definition.</span><b><a href="#propdef-table-layout">#propdef-table-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-table-layout">3.5. Table layout modes</a>
     <li><a href="#ref-for-propdef-table-layout①">3.5.1. The Table-Layout property</a> <a href="#ref-for-propdef-table-layout②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-fixed-mode">
-   <b><a href="#in-fixed-mode">#in-fixed-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-fixed-mode" class="dfn-panel" data-for="in-fixed-mode" id="infopanel-for-in-fixed-mode" role="dialog">
+   <span id="infopaneltitle-for-in-fixed-mode" style="display:none">Info about the 'in fixed mode' definition.</span><b><a href="#in-fixed-mode">#in-fixed-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-fixed-mode">3.3.2. Track merging</a>
     <li><a href="#ref-for-in-fixed-mode①">3.5.1. The Table-Layout property</a>
@@ -4481,14 +4481,14 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-in-fixed-mode⑨">3.11. Positioning of cells, captions and other internal table boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-auto-mode">
-   <b><a href="#in-auto-mode">#in-auto-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-auto-mode" class="dfn-panel" data-for="in-auto-mode" id="infopanel-for-in-auto-mode" role="dialog">
+   <span id="infopaneltitle-for-in-auto-mode" style="display:none">Info about the 'in auto mode' definition.</span><b><a href="#in-auto-mode">#in-auto-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-auto-mode">3.3.2. Track merging</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-collapse">
-   <b><a href="#propdef-border-collapse">#propdef-border-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-collapse" class="dfn-panel" data-for="propdef-border-collapse" id="infopanel-for-propdef-border-collapse" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' definition.</span><b><a href="#propdef-border-collapse">#propdef-border-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">3.5. Table layout modes</a> <a href="#ref-for-propdef-border-collapse①">(2)</a>
     <li><a href="#ref-for-propdef-border-collapse②">3.5.2. The Border-Collapse property</a>
@@ -4496,8 +4496,8 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-propdef-border-collapse④">3.8.2. Computing Cell Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-collapsed-borders-mode">
-   <b><a href="#in-collapsed-borders-mode">#in-collapsed-borders-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-collapsed-borders-mode" class="dfn-panel" data-for="in-collapsed-borders-mode" id="infopanel-for-in-collapsed-borders-mode" role="dialog">
+   <span id="infopaneltitle-for-in-collapsed-borders-mode" style="display:none">Info about the 'in collapsed-borders mode' definition.</span><b><a href="#in-collapsed-borders-mode">#in-collapsed-borders-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-collapsed-borders-mode">3.6.2. Overrides applying in collapsed-borders mode</a>
     <li><a href="#ref-for-in-collapsed-borders-mode①">3.7.1. Conflict Resolution for Collapsed Borders</a>
@@ -4508,8 +4508,8 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-in-collapsed-borders-mode⑨">5.3.4. Border styles (collapsed-borders mode)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-separated-borders-mode">
-   <b><a href="#in-separated-borders-mode">#in-separated-borders-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-separated-borders-mode" class="dfn-panel" data-for="in-separated-borders-mode" id="infopanel-for-in-separated-borders-mode" role="dialog">
+   <span id="infopaneltitle-for-in-separated-borders-mode" style="display:none">Info about the 'in separated-borders mode' definition.</span><b><a href="#in-separated-borders-mode">#in-separated-borders-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-separated-borders-mode">3.5.2.1. The Border-Spacing property</a>
     <li><a href="#ref-for-in-separated-borders-mode①">3.8.2. Computing Cell Measures</a> <a href="#ref-for-in-separated-borders-mode②">(2)</a> <a href="#ref-for-in-separated-borders-mode③">(3)</a>
@@ -4517,8 +4517,8 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-in-separated-borders-mode⑤">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-spacing">
-   <b><a href="#propdef-border-spacing">#propdef-border-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-spacing" class="dfn-panel" data-for="propdef-border-spacing" id="infopanel-for-propdef-border-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' definition.</span><b><a href="#propdef-border-spacing">#propdef-border-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">3.5. Table layout modes</a>
     <li><a href="#ref-for-propdef-border-spacing①">3.5.2. The Border-Collapse property</a>
@@ -4527,8 +4527,8 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-propdef-border-spacing④">3.11. Positioning of cells, captions and other internal table boxes</a> <a href="#ref-for-propdef-border-spacing⑤">(2)</a> <a href="#ref-for-propdef-border-spacing⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caption-side">
-   <b><a href="#propdef-caption-side">#propdef-caption-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caption-side" class="dfn-panel" data-for="propdef-caption-side" id="infopanel-for-propdef-caption-side" role="dialog">
+   <span id="infopaneltitle-for-propdef-caption-side" style="display:none">Info about the 'caption-side' definition.</span><b><a href="#propdef-caption-side">#propdef-caption-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">3.5. Table layout modes</a>
     <li><a href="#ref-for-propdef-caption-side①">3.5.3. The Caption-Side property</a>
@@ -4536,26 +4536,26 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-propdef-caption-side③">3.11. Positioning of cells, captions and other internal table boxes</a> <a href="#ref-for-propdef-caption-side④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offsets-adjusted-width">
-   <b><a href="#offsets-adjusted-width">#offsets-adjusted-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offsets-adjusted-width" class="dfn-panel" data-for="offsets-adjusted-width" id="infopanel-for-offsets-adjusted-width" role="dialog">
+   <span id="infopaneltitle-for-offsets-adjusted-width" style="display:none">Info about the 'offsets-adjusted min-width, width, and max-width' definition.</span><b><a href="#offsets-adjusted-width">#offsets-adjusted-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offsets-adjusted-width">3.8.2. Computing Cell Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-min-content">
-   <b><a href="#outer-min-content">#outer-min-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-min-content" class="dfn-panel" data-for="outer-min-content" id="infopanel-for-outer-min-content" role="dialog">
+   <span id="infopaneltitle-for-outer-min-content" style="display:none">Info about the 'outer min-content' definition.</span><b><a href="#outer-min-content">#outer-min-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-min-content">3.8.3. Computing Column Measures</a> <a href="#ref-for-outer-min-content①">(2)</a> <a href="#ref-for-outer-min-content②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-max-content">
-   <b><a href="#outer-max-content">#outer-max-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-max-content" class="dfn-panel" data-for="outer-max-content" id="infopanel-for-outer-max-content" role="dialog">
+   <span id="infopaneltitle-for-outer-max-content" style="display:none">Info about the 'outer max-content' definition.</span><b><a href="#outer-max-content">#outer-max-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-max-content">3.8.3. Computing Column Measures</a> <a href="#ref-for-outer-max-content①">(2)</a> <a href="#ref-for-outer-max-content②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-width-of-a-column">
-   <b><a href="#min-content-width-of-a-column">#min-content-width-of-a-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-width-of-a-column" class="dfn-panel" data-for="min-content-width-of-a-column" id="infopanel-for-min-content-width-of-a-column" role="dialog">
+   <span id="infopaneltitle-for-min-content-width-of-a-column" style="display:none">Info about the 'min-content width of a column' definition.</span><b><a href="#min-content-width-of-a-column">#min-content-width-of-a-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-width-of-a-column">3.8.3. Computing Column Measures</a>
     <li><a href="#ref-for-min-content-width-of-a-column">3.9.1. Computing the table width</a>
@@ -4563,224 +4563,282 @@ With a table-internal as containing block</a>
     <li><a href="#ref-for-min-content-width-of-a-column">3.9.3.1. Changes to width distribution in fixed mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-width-of-a-column">
-   <b><a href="#max-content-width-of-a-column">#max-content-width-of-a-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-width-of-a-column" class="dfn-panel" data-for="max-content-width-of-a-column" id="infopanel-for-max-content-width-of-a-column" role="dialog">
+   <span id="infopaneltitle-for-max-content-width-of-a-column" style="display:none">Info about the 'max-content width of a column' definition.</span><b><a href="#max-content-width-of-a-column">#max-content-width-of-a-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-width-of-a-column">3.8.3. Computing Column Measures</a>
     <li><a href="#ref-for-max-content-width-of-a-column">3.9.1. Computing the table width</a>
     <li><a href="#ref-for-max-content-width-of-a-column">3.9.2.1. Rules</a> <a href="#ref-for-max-content-width-of-a-column">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-percentage-width-of-a-column">
-   <b><a href="#intrinsic-percentage-width-of-a-column">#intrinsic-percentage-width-of-a-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-percentage-width-of-a-column" class="dfn-panel" data-for="intrinsic-percentage-width-of-a-column" id="infopanel-for-intrinsic-percentage-width-of-a-column" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-percentage-width-of-a-column" style="display:none">Info about the 'intrinsic percentage width of a column' definition.</span><b><a href="#intrinsic-percentage-width-of-a-column">#intrinsic-percentage-width-of-a-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-percentage-width-of-a-column">3.8.3. Computing Column Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constrainedness">
-   <b><a href="#constrainedness">#constrainedness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constrainedness" class="dfn-panel" data-for="constrainedness" id="infopanel-for-constrainedness" role="dialog">
+   <span id="infopaneltitle-for-constrainedness" style="display:none">Info about the 'constrainedness' definition.</span><b><a href="#constrainedness">#constrainedness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constrainedness">3.8.2. Computing Cell Measures</a> <a href="#ref-for-constrainedness①">(2)</a>
     <li><a href="#ref-for-constrainedness②">3.9.3. Distribution algorithm</a>
     <li><a href="#ref-for-constrainedness③">3.9.3.2. Distributing excess width to columns</a> <a href="#ref-for-constrainedness④">(2)</a> <a href="#ref-for-constrainedness⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="capmin">
-   <b><a href="#capmin">#capmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-capmin" class="dfn-panel" data-for="capmin" id="infopanel-for-capmin" role="dialog">
+   <span id="infopaneltitle-for-capmin" style="display:none">Info about the 'caption width minimum (CAPMIN)' definition.</span><b><a href="#capmin">#capmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-capmin">3.2. Table layout algorithm</a>
     <li><a href="#ref-for-capmin">3.9.1. Computing the table width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gridmin">
-   <b><a href="#gridmin">#gridmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gridmin" class="dfn-panel" data-for="gridmin" id="infopanel-for-gridmin" role="dialog">
+   <span id="infopaneltitle-for-gridmin" style="display:none">Info about the 'row/column-grid width minimum (GRIDMIN)' definition.</span><b><a href="#gridmin">#gridmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gridmin">3.9.1. Computing the table width</a> <a href="#ref-for-gridmin">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gridmax">
-   <b><a href="#gridmax">#gridmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gridmax" class="dfn-panel" data-for="gridmax" id="infopanel-for-gridmax" role="dialog">
+   <span id="infopaneltitle-for-gridmax" style="display:none">Info about the 'row/column-grid width maximum (GRIDMAX)' definition.</span><b><a href="#gridmax">#gridmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gridmax">3.9.1. Computing the table width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-min-width-of-table">
-   <b><a href="#used-min-width-of-table">#used-min-width-of-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-min-width-of-table" class="dfn-panel" data-for="used-min-width-of-table" id="infopanel-for-used-min-width-of-table" role="dialog">
+   <span id="infopaneltitle-for-used-min-width-of-table" style="display:none">Info about the 'used min-width of a table' definition.</span><b><a href="#used-min-width-of-table">#used-min-width-of-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-min-width-of-table">3.9.1. Computing the table width</a> <a href="#ref-for-used-min-width-of-table">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-width-of-table">
-   <b><a href="#used-width-of-table">#used-width-of-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-width-of-table" class="dfn-panel" data-for="used-width-of-table" id="infopanel-for-used-width-of-table" role="dialog">
+   <span id="infopaneltitle-for-used-width-of-table" style="display:none">Info about the 'used width of a table' definition.</span><b><a href="#used-width-of-table">#used-width-of-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-width-of-table">3.9.1. Computing the table width</a> <a href="#ref-for-used-width-of-table">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolved-table-width">
-   <b><a href="#resolved-table-width">#resolved-table-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolved-table-width" class="dfn-panel" data-for="resolved-table-width" id="infopanel-for-resolved-table-width" role="dialog">
+   <span id="infopaneltitle-for-resolved-table-width" style="display:none">Info about the 'resolved-table-width' definition.</span><b><a href="#resolved-table-width">#resolved-table-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-table-width">3.9.1. Computing the table width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assignable-table-width">
-   <b><a href="#assignable-table-width">#assignable-table-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assignable-table-width" class="dfn-panel" data-for="assignable-table-width" id="infopanel-for-assignable-table-width" role="dialog">
+   <span id="infopaneltitle-for-assignable-table-width" style="display:none">Info about the 'assignable table width' definition.</span><b><a href="#assignable-table-width">#assignable-table-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assignable-table-width">3.9.2.1. Rules</a> <a href="#ref-for-assignable-table-width①">(2)</a>
     <li><a href="#ref-for-assignable-table-width②">3.9.3. Distribution algorithm</a> <a href="#ref-for-assignable-table-width③">(2)</a>
     <li><a href="#ref-for-assignable-table-width④">3.9.3.1. Changes to width distribution in fixed mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sizing-type">
-   <b><a href="#sizing-type">#sizing-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sizing-type" class="dfn-panel" data-for="sizing-type" id="infopanel-for-sizing-type" role="dialog">
+   <span id="infopaneltitle-for-sizing-type" style="display:none">Info about the 'sizing type' definition.</span><b><a href="#sizing-type">#sizing-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sizing-type">3.9.2.1. Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percent-column">
-   <b><a href="#percent-column">#percent-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percent-column" class="dfn-panel" data-for="percent-column" id="infopanel-for-percent-column" role="dialog">
+   <span id="infopaneltitle-for-percent-column" style="display:none">Info about the 'percent-column' definition.</span><b><a href="#percent-column">#percent-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-column">3.9.3. Distribution algorithm</a> <a href="#ref-for-percent-column①">(2)</a> <a href="#ref-for-percent-column②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-sizing-guess">
-   <b><a href="#min-content-sizing-guess">#min-content-sizing-guess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-sizing-guess" class="dfn-panel" data-for="min-content-sizing-guess" id="infopanel-for-min-content-sizing-guess" role="dialog">
+   <span id="infopaneltitle-for-min-content-sizing-guess" style="display:none">Info about the 'min-content sizing-guess' definition.</span><b><a href="#min-content-sizing-guess">#min-content-sizing-guess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-sizing-guess">3.9.3. Distribution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-percentage-sizing-guess">
-   <b><a href="#min-content-percentage-sizing-guess">#min-content-percentage-sizing-guess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-percentage-sizing-guess" class="dfn-panel" data-for="min-content-percentage-sizing-guess" id="infopanel-for-min-content-percentage-sizing-guess" role="dialog">
+   <span id="infopaneltitle-for-min-content-percentage-sizing-guess" style="display:none">Info about the 'min-content-percentage sizing-guess' definition.</span><b><a href="#min-content-percentage-sizing-guess">#min-content-percentage-sizing-guess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-percentage-sizing-guess">3.9.3. Distribution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-content-specified-sizing-guess">
-   <b><a href="#min-content-specified-sizing-guess">#min-content-specified-sizing-guess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-content-specified-sizing-guess" class="dfn-panel" data-for="min-content-specified-sizing-guess" id="infopanel-for-min-content-specified-sizing-guess" role="dialog">
+   <span id="infopaneltitle-for-min-content-specified-sizing-guess" style="display:none">Info about the 'min-content-specified sizing-guess' definition.</span><b><a href="#min-content-specified-sizing-guess">#min-content-specified-sizing-guess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-specified-sizing-guess">3.9.3. Distribution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-content-sizing-guess">
-   <b><a href="#max-content-sizing-guess">#max-content-sizing-guess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-content-sizing-guess" class="dfn-panel" data-for="max-content-sizing-guess" id="infopanel-for-max-content-sizing-guess" role="dialog">
+   <span id="infopaneltitle-for-max-content-sizing-guess" style="display:none">Info about the 'max-content sizing-guess' definition.</span><b><a href="#max-content-sizing-guess">#max-content-sizing-guess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-sizing-guess">3.9.3. Distribution algorithm</a> <a href="#ref-for-max-content-sizing-guess①">(2)</a> <a href="#ref-for-max-content-sizing-guess">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distributing-excess-width-to-columns">
-   <b><a href="#distributing-excess-width-to-columns">#distributing-excess-width-to-columns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distributing-excess-width-to-columns" class="dfn-panel" data-for="distributing-excess-width-to-columns" id="infopanel-for-distributing-excess-width-to-columns" role="dialog">
+   <span id="infopaneltitle-for-distributing-excess-width-to-columns" style="display:none">Info about the 'distributing excess width to columns' definition.</span><b><a href="#distributing-excess-width-to-columns">#distributing-excess-width-to-columns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distributing-excess-width-to-columns">3.9.3. Distribution algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ROWMIN">
-   <b><a href="#ROWMIN">#ROWMIN</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ROWMIN" class="dfn-panel" data-for="ROWMIN" id="infopanel-for-ROWMIN" role="dialog">
+   <span id="infopaneltitle-for-ROWMIN" style="display:none">Info about the 'ROWMIN' definition.</span><b><a href="#ROWMIN">#ROWMIN</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ROWMIN">3.10.1. Computing the table height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-cell-baseline">
-   <b><a href="#table-cell-baseline">#table-cell-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-cell-baseline" class="dfn-panel" data-for="table-cell-baseline" id="infopanel-for-table-cell-baseline" role="dialog">
+   <span id="infopaneltitle-for-table-cell-baseline" style="display:none">Info about the 'baseline of a cell' definition.</span><b><a href="#table-cell-baseline">#table-cell-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-cell-baseline">3.10.2. Row layout (first pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table-row-baseline">
-   <b><a href="#table-row-baseline">#table-row-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table-row-baseline" class="dfn-panel" data-for="table-row-baseline" id="infopanel-for-table-row-baseline" role="dialog">
+   <span id="infopaneltitle-for-table-row-baseline" style="display:none">Info about the 'baseline of the row' definition.</span><b><a href="#table-row-baseline">#table-row-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-row-baseline">3.10.2. Row layout (first pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolving-percentages-heights-in-table-cell-content">
-   <b><a href="#resolving-percentages-heights-in-table-cell-content">#resolving-percentages-heights-in-table-cell-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolving-percentages-heights-in-table-cell-content" class="dfn-panel" data-for="resolving-percentages-heights-in-table-cell-content" id="infopanel-for-resolving-percentages-heights-in-table-cell-content" role="dialog">
+   <span id="infopaneltitle-for-resolving-percentages-heights-in-table-cell-content" style="display:none">Info about the '
+			Resolve percentage heights in table-cell content:' definition.</span><b><a href="#resolving-percentages-heights-in-table-cell-content">#resolving-percentages-heights-in-table-cell-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolving-percentages-heights-in-table-cell-content">3.10.2. Row layout (first pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="appropriateness-of-child-percentage-resolution">
-   <b><a href="#appropriateness-of-child-percentage-resolution">#appropriateness-of-child-percentage-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-appropriateness-of-child-percentage-resolution" class="dfn-panel" data-for="appropriateness-of-child-percentage-resolution" id="infopanel-for-appropriateness-of-child-percentage-resolution" role="dialog">
+   <span id="infopaneltitle-for-appropriateness-of-child-percentage-resolution" style="display:none">Info about the '
+			It is appropriate to resolve percentage heights on direct children of a table-cell' definition.</span><b><a href="#appropriateness-of-child-percentage-resolution">#appropriateness-of-child-percentage-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appropriateness-of-child-percentage-resolution">3.10.2. Row layout (first pass)</a>
     <li><a href="#ref-for-appropriateness-of-child-percentage-resolution">3.10.6. Table-cell content layout (second pass)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visible-track">
-   <b><a href="#visible-track">#visible-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visible-track" class="dfn-panel" data-for="visible-track" id="infopanel-for-visible-track" role="dialog">
+   <span id="infopaneltitle-for-visible-track" style="display:none">Info about the 'visible track' definition.</span><b><a href="#visible-track">#visible-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-track">3.11. Positioning of cells, captions and other internal table boxes</a> <a href="#ref-for-visible-track">(2)</a> <a href="#ref-for-visible-track">(3)</a> <a href="#ref-for-visible-track">(4)</a> <a href="#ref-for-visible-track">(5)</a> <a href="#ref-for-visible-track">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-empty-cells">
-   <b><a href="#propdef-empty-cells">#propdef-empty-cells</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-empty-cells" class="dfn-panel" data-for="propdef-empty-cells" id="infopanel-for-propdef-empty-cells" role="dialog">
+   <span id="infopaneltitle-for-propdef-empty-cells" style="display:none">Info about the 'empty-cells' definition.</span><b><a href="#propdef-empty-cells">#propdef-empty-cells</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-empty-cells">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-cell">
-   <b><a href="#empty-cell">#empty-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-cell" class="dfn-panel" data-for="empty-cell" id="infopanel-for-empty-cell" role="dialog">
+   <span id="infopaneltitle-for-empty-cell" style="display:none">Info about the 'empty cell' definition.</span><b><a href="#empty-cell">#empty-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-cell">5.2. Empty cell rendering (separated-borders mode)</a>
     <li><a href="#ref-for-empty-cell①">5.3.2. Drawing cell backgrounds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="freely-fragmentable">
-   <b><a href="#freely-fragmentable">#freely-fragmentable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-freely-fragmentable" class="dfn-panel" data-for="freely-fragmentable" id="infopanel-for-freely-fragmentable" role="dialog">
+   <span id="infopaneltitle-for-freely-fragmentable" style="display:none">Info about the 'freely fragmentable' definition.</span><b><a href="#freely-fragmentable">#freely-fragmentable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-freely-fragmentable">6.1. Breaking across fragmentainers</a> <a href="#ref-for-freely-fragmentable①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-3/Overview.html
@@ -8193,50 +8193,50 @@ Small Kana Mappings</span><a class="self-link" href="#small-kana"></a></h2>
    <li><a href="#wrapping">wrapping</a><span>, in § 5</span>
    <li><a href="#content-writing-system">writing system</a><span>, in § 1.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-value" class="dfn-panel" data-for="term-for-inherited-value" id="infopanel-for-term-for-inherited-value" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-value" style="display:none">Info about the 'inherited value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-legacy-name-alias">
-   <a href="https://drafts.csswg.org/css-cascade-5/#legacy-name-alias">https://drafts.csswg.org/css-cascade-5/#legacy-name-alias</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-legacy-name-alias" class="dfn-panel" data-for="term-for-legacy-name-alias" id="infopanel-for-term-for-legacy-name-alias" role="menu">
+   <span id="infopaneltitle-for-term-for-legacy-name-alias" style="display:none">Info about the 'legacy name alias' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#legacy-name-alias">https://drafts.csswg.org/css-cascade-5/#legacy-name-alias</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-name-alias">5.5. 
 Overflow Wrapping: the overflow-wrap/word-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">6.1. 
 Text Alignment: the text-align shorthand</a>
@@ -8244,8 +8244,8 @@ Text Alignment: the text-align shorthand</a>
 Default Text Alignment: the text-align-all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">5.1. 
 Line Breaking Details</a>
@@ -8255,15 +8255,15 @@ Tracking: the letter-spacing property</a>
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block">
-   <a href="https://drafts.csswg.org/css-display-3/#block">https://drafts.csswg.org/css-display-3/#block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block" class="dfn-panel" data-for="term-for-block" id="infopanel-for-term-for-block" role="menu">
+   <span id="infopaneltitle-for-term-for-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block">https://drafts.csswg.org/css-display-3/#block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block"> Appendix B:
 Conversion to Plaintext</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">4.1.2. 
 Phase II: Trimming and Positioning</a>
@@ -8271,15 +8271,15 @@ Phase II: Trimming and Positioning</a>
 Tab Character Size: the tab-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">8.3. 
 Bidirectionality and Line Boxes</a> <a href="#ref-for-containing-block①">(2)</a> <a href="#ref-for-containing-block②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">8.1. 
 First Line Indentation: the text-indent property</a>
@@ -8287,15 +8287,15 @@ First Line Indentation: the text-indent property</a>
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">1.5. 
 Text Processing</a>
@@ -8305,36 +8305,36 @@ Tracking: the letter-spacing property</a>
 Hanging Glyphs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">4.1.1. 
 Phase I: Collapsing and Transformation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-out-of-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-out-of-flow" class="dfn-panel" data-for="term-for-out-of-flow" id="infopanel-for-term-for-out-of-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-out-of-flow" style="display:none">Info about the 'out-of-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#out-of-flow">https://drafts.csswg.org/css-display-3/#out-of-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-flow">1.5. 
 Text Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-feature-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-feature-settings" class="dfn-panel" data-for="term-for-propdef-font-feature-settings" id="infopanel-for-term-for-propdef-font-feature-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">7.2. 
 Tracking: the letter-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline" id="infopanel-for-term-for-valdef-alignment-baseline-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" style="display:none">Info about the 'baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-baseline">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-box" class="dfn-panel" data-for="term-for-line-box" id="infopanel-for-term-for-line-box" role="menu">
+   <span id="infopaneltitle-for-term-for-line-box" style="display:none">Info about the 'line box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#line-box">https://drafts.csswg.org/css-inline-3/#line-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">6.1. 
 Text Alignment: the text-align shorthand</a>
@@ -8342,92 +8342,92 @@ Text Alignment: the text-align shorthand</a>
 Bidirectionality and Line Boxes</a> <a href="#ref-for-line-box②">(2)</a> <a href="#ref-for-line-box③">(3)</a> <a href="#ref-for-line-box④">(4)</a> <a href="#ref-for-line-box⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">8.2. 
 Hanging Glyphs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow" class="dfn-panel" data-for="term-for-scrollable-overflow" id="infopanel-for-term-for-scrollable-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow" style="display:none">Info about the 'scrollable overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow">8.2. 
 Hanging Glyphs</a> <a href="#ref-for-scrollable-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-formatted-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-formatted-line" class="dfn-panel" data-for="term-for-first-formatted-line" id="infopanel-for-term-for-first-formatted-line" role="menu">
+   <span id="infopaneltitle-for-term-for-first-formatted-line" style="display:none">Info about the 'first formatted line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#first-formatted-line">https://drafts.csswg.org/css-pseudo-4/#first-formatted-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-formatted-line">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby">https://drafts.csswg.org/css-ruby-1/#ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby" class="dfn-panel" data-for="term-for-ruby" id="infopanel-for-term-for-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby">https://drafts.csswg.org/css-ruby-1/#ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby">2.1. 
 Case Transforms: the text-transform property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-size" class="dfn-panel" data-for="term-for-inner-size" id="infopanel-for-term-for-inner-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-size" style="display:none">Info about the 'inner size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#inner-size">https://drafts.csswg.org/css-sizing-3/#inner-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-size">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size" class="dfn-panel" data-for="term-for-intrinsic-size" id="infopanel-for-term-for-intrinsic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size" style="display:none">Info about the 'intrinsic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size">https://drafts.csswg.org/css-sizing-3/#intrinsic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size">8.2. 
 Hanging Glyphs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-size-contribution">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-size-contribution" class="dfn-panel" data-for="term-for-intrinsic-size-contribution" id="infopanel-for-term-for-intrinsic-size-contribution" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-size-contribution" style="display:none">Info about the 'intrinsic size contribution' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution">https://drafts.csswg.org/css-sizing-3/#intrinsic-size-contribution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-size-contribution">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-sizing" class="dfn-panel" data-for="term-for-intrinsic-sizing" id="infopanel-for-term-for-intrinsic-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-sizing" style="display:none">Info about the 'intrinsic sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-sizing">3. 
 White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">8.2. 
 Hanging Glyphs</a> <a href="#ref-for-max-content①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">5.4. 
 Hyphenation: the hyphens property</a>
@@ -8437,22 +8437,22 @@ Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-mi
 Hanging Glyphs</a> <a href="#ref-for-min-content④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">8.1. 
 First Line Indentation: the text-indent property</a> <a href="#ref-for-comb-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">8.1. 
 First Line Indentation: the text-indent property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.2. 
 Tab Character Size: the tab-size property</a>
@@ -8462,36 +8462,36 @@ Word Spacing: the word-spacing property</a>
 Tracking: the letter-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">4.2. 
 Tab Character Size: the tab-size property</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">8.1. 
 First Line Indentation: the text-indent property</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ch">
-   <a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ch" class="dfn-panel" data-for="term-for-ch" id="infopanel-for-term-for-ch" role="menu">
+   <span id="infopaneltitle-for-term-for-ch" style="display:none">Info about the 'ch' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ch">https://drafts.csswg.org/css-values-4/#ch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">4.1.2. 
 Phase II: Trimming and Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
@@ -8523,8 +8523,8 @@ Tracking: the letter-spacing property</a>
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-comb-one④⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-comb-any①">(2)</a>
@@ -8532,8 +8532,8 @@ Case Transforms: the text-transform property</a> <a href="#ref-for-comb-any①">
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-comb-any③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">6.1. 
 Text Alignment: the text-align shorthand</a>
@@ -8541,29 +8541,29 @@ Text Alignment: the text-align shorthand</a>
 Bidirectionality and Line Boxes</a> <a href="#ref-for-propdef-direction②">(2)</a> <a href="#ref-for-propdef-direction③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">8.3. 
 Bidirectionality and Line Boxes</a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bidi-paragraph">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-paragraph">https://drafts.csswg.org/css-writing-modes-4/#bidi-paragraph</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bidi-paragraph" class="dfn-panel" data-for="term-for-bidi-paragraph" id="infopanel-for-term-for-bidi-paragraph" role="menu">
+   <span id="infopaneltitle-for-term-for-bidi-paragraph" style="display:none">Info about the 'bidi paragraph' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-paragraph">https://drafts.csswg.org/css-writing-modes-4/#bidi-paragraph</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-paragraph">8.3. 
 Bidirectionality and Line Boxes</a> <a href="#ref-for-bidi-paragraph①">(2)</a> <a href="#ref-for-bidi-paragraph②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bidi-isolate">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bidi-isolate" class="dfn-panel" data-for="term-for-bidi-isolate" id="infopanel-for-term-for-bidi-isolate" role="menu">
+   <span id="infopaneltitle-for-term-for-bidi-isolate" style="display:none">Info about the 'bidi-isolate' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate">https://drafts.csswg.org/css-writing-modes-4/#bidi-isolate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-isolate">7.3. 
 Shaping Across Element Boundaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-end">https://drafts.csswg.org/css-writing-modes-4/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-css-end①">(2)</a> <a href="#ref-for-css-end②">(3)</a>
@@ -8571,43 +8571,43 @@ Text Alignment: the text-align shorthand</a> <a href="#ref-for-css-end①">(2)</
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">8.3. 
 Bidirectionality and Line Boxes</a> <a href="#ref-for-inline-base-direction①">(2)</a> <a href="#ref-for-inline-base-direction②">(3)</a> <a href="#ref-for-inline-base-direction③">(4)</a> <a href="#ref-for-inline-base-direction④">(5)</a> <a href="#ref-for-inline-base-direction⑤">(6)</a> <a href="#ref-for-inline-base-direction⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-left" class="dfn-panel" data-for="term-for-line-left" id="infopanel-for-term-for-line-left" role="menu">
+   <span id="infopaneltitle-for-term-for-line-left" style="display:none">Info about the 'line-left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-right" class="dfn-panel" data-for="term-for-line-right" id="infopanel-for-term-for-line-right" role="menu">
+   <span id="infopaneltitle-for-term-for-line-right" style="display:none">Info about the 'line-right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-width">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-width" class="dfn-panel" data-for="term-for-logical-width" id="infopanel-for-term-for-logical-width" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-width" style="display:none">Info about the 'logical width' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-width">https://drafts.csswg.org/css-writing-modes-4/#logical-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-width">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-start" class="dfn-panel" data-for="term-for-css-start" id="infopanel-for-term-for-css-start" role="menu">
+   <span id="infopaneltitle-for-term-for-css-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#css-start">https://drafts.csswg.org/css-writing-modes-4/#css-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-css-start①">(2)</a> <a href="#ref-for-css-start②">(3)</a>
@@ -8617,57 +8617,57 @@ First Line Indentation: the text-indent property</a>
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-upright" class="dfn-panel" data-for="term-for-valdef-text-orientation-upright" id="infopanel-for-term-for-valdef-text-orientation-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">1.4. 
 Characters and Letters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">7.2. 
 Tracking: the letter-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">7.2. 
 Tracking: the letter-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-language">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-language" class="dfn-panel" data-for="term-for-language" id="infopanel-for-term-for-language" role="menu">
+   <span id="infopaneltitle-for-term-for-language" style="display:none">Info about the 'language' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#language">https://html.spec.whatwg.org/multipage/dom.html#language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-language">1.3. 
 Languages and Typesetting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-wbr-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-wbr-element" class="dfn-panel" data-for="term-for-the-wbr-element" id="infopanel-for-term-for-the-wbr-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-wbr-element" style="display:none">Info about the 'wbr' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-wbr-element">5.2. 
 Breaking Rules for Letters: the word-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-normalize-newlines">
-   <a href="https://infra.spec.whatwg.org/#normalize-newlines">https://infra.spec.whatwg.org/#normalize-newlines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-normalize-newlines" class="dfn-panel" data-for="term-for-normalize-newlines" id="infopanel-for-term-for-normalize-newlines" role="menu">
+   <span id="infopaneltitle-for-term-for-normalize-newlines" style="display:none">Info about the 'normalize newlines' external reference.</span><a href="https://infra.spec.whatwg.org/#normalize-newlines">https://infra.spec.whatwg.org/#normalize-newlines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize-newlines">4. 
 White Space Processing &amp; Control Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-language">
-   <a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-language" class="dfn-panel" data-for="term-for-document-language" id="infopanel-for-term-for-document-language" role="menu">
+   <span id="infopaneltitle-for-term-for-document-language" style="display:none">Info about the 'document language' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#document-language">https://drafts.csswg.org/selectors-4/#document-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-language">1.3. 
 Languages and Typesetting</a> <a href="#ref-for-document-language①">(2)</a> <a href="#ref-for-document-language②">(3)</a>
@@ -9082,8 +9082,8 @@ Identifying the Content Writing System</a>
       <td>specified keyword
    </table>
   </div>
-  <aside class="dfn-panel" data-for="content-language">
-   <b><a href="#content-language">#content-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-language" class="dfn-panel" data-for="content-language" id="infopanel-for-content-language" role="dialog">
+   <span id="infopaneltitle-for-content-language" style="display:none">Info about the 'content language' definition.</span><b><a href="#content-language">#content-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">1.3. 
 Languages and Typesetting</a> <a href="#ref-for-content-language①">(2)</a> <a href="#ref-for-content-language②">(3)</a> <a href="#ref-for-content-language③">(4)</a> <a href="#ref-for-content-language④">(5)</a> <a href="#ref-for-content-language⑤">(6)</a>
@@ -9101,8 +9101,8 @@ Minimum Requirements for auto Justification</a>
 Identifying the Content Writing System</a> <a href="#ref-for-content-language①⑥">(2)</a> <a href="#ref-for-content-language①⑦">(3)</a> <a href="#ref-for-content-language①⑧">(4)</a> <a href="#ref-for-content-language①⑨">(5)</a> <a href="#ref-for-content-language②⓪">(6)</a> <a href="#ref-for-content-language②①">(7)</a> <a href="#ref-for-content-language②②">(8)</a> <a href="#ref-for-content-language②③">(9)</a> <a href="#ref-for-content-language②④">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-writing-system">
-   <b><a href="#content-writing-system">#content-writing-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-writing-system" class="dfn-panel" data-for="content-writing-system" id="infopanel-for-content-writing-system" role="dialog">
+   <span id="infopaneltitle-for-content-writing-system" style="display:none">Info about the 'content writing system' definition.</span><b><a href="#content-writing-system">#content-writing-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-writing-system">2.1.1. 
 Mapping Rules</a>
@@ -9116,8 +9116,8 @@ Scripts and Spacing</a>
 Identifying the Content Writing System</a> <a href="#ref-for-content-writing-system⑥">(2)</a> <a href="#ref-for-content-writing-system⑦">(3)</a> <a href="#ref-for-content-writing-system⑧">(4)</a> <a href="#ref-for-content-writing-system⑨">(5)</a> <a href="#ref-for-content-writing-system①⓪">(6)</a> <a href="#ref-for-content-writing-system①①">(7)</a> <a href="#ref-for-content-writing-system①②">(8)</a> <a href="#ref-for-content-writing-system①③">(9)</a> <a href="#ref-for-content-writing-system①④">(10)</a> <a href="#ref-for-content-writing-system①⑤">(11)</a> <a href="#ref-for-content-writing-system①⑥">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="character">
-   <b><a href="#character">#character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character" class="dfn-panel" data-for="character" id="infopanel-for-character" role="dialog">
+   <span id="infopaneltitle-for-character" style="display:none">Info about the 'character' definition.</span><b><a href="#character">#character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">1.4. 
 Characters and Letters</a> <a href="#ref-for-character①">(2)</a> <a href="#ref-for-character②">(3)</a> <a href="#ref-for-character③">(4)</a> <a href="#ref-for-character④">(5)</a> <a href="#ref-for-character⑤">(6)</a> <a href="#ref-for-character⑥">(7)</a> <a href="#ref-for-character⑦">(8)</a> <a href="#ref-for-character⑧">(9)</a> <a href="#ref-for-character⑨">(10)</a> <a href="#ref-for-character①⓪">(11)</a>
@@ -9125,8 +9125,8 @@ Characters and Letters</a> <a href="#ref-for-character①">(2)</a> <a href="#ref
 Overflow Wrapping: the overflow-wrap/word-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typographic-character-unit">
-   <b><a href="#typographic-character-unit">#typographic-character-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typographic-character-unit" class="dfn-panel" data-for="typographic-character-unit" id="infopanel-for-typographic-character-unit" role="dialog">
+   <span id="infopaneltitle-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' definition.</span><b><a href="#typographic-character-unit">#typographic-character-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">1.4. 
 Characters and Letters</a> <a href="#ref-for-typographic-character-unit①">(2)</a> <a href="#ref-for-typographic-character-unit②">(3)</a> <a href="#ref-for-typographic-character-unit③">(4)</a> <a href="#ref-for-typographic-character-unit④">(5)</a> <a href="#ref-for-typographic-character-unit⑤">(6)</a> <a href="#ref-for-typographic-character-unit⑥">(7)</a> <a href="#ref-for-typographic-character-unit⑦">(8)</a> <a href="#ref-for-typographic-character-unit⑧">(9)</a> <a href="#ref-for-typographic-character-unit⑨">(10)</a> <a href="#ref-for-typographic-character-unit①⓪">(11)</a> <a href="#ref-for-typographic-character-unit①①">(12)</a>
@@ -9158,8 +9158,8 @@ Scripts and Spacing</a>
 Characters and Properties</a> <a href="#ref-for-typographic-character-unit④⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grapheme-cluster">
-   <b><a href="#grapheme-cluster">#grapheme-cluster</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grapheme-cluster" class="dfn-panel" data-for="grapheme-cluster" id="infopanel-for-grapheme-cluster" role="dialog">
+   <span id="infopaneltitle-for-grapheme-cluster" style="display:none">Info about the 'grapheme cluster' definition.</span><b><a href="#grapheme-cluster">#grapheme-cluster</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grapheme-cluster">1.4. 
 Characters and Letters</a> <a href="#ref-for-grapheme-cluster①">(2)</a> <a href="#ref-for-grapheme-cluster②">(3)</a> <a href="#ref-for-grapheme-cluster③">(4)</a>
@@ -9167,8 +9167,8 @@ Characters and Letters</a> <a href="#ref-for-grapheme-cluster①">(2)</a> <a hre
 Characters and Properties</a> <a href="#ref-for-grapheme-cluster⑤">(2)</a> <a href="#ref-for-grapheme-cluster⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typographic-letter-unit">
-   <b><a href="#typographic-letter-unit">#typographic-letter-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typographic-letter-unit" class="dfn-panel" data-for="typographic-letter-unit" id="infopanel-for-typographic-letter-unit" role="dialog">
+   <span id="infopaneltitle-for-typographic-letter-unit" style="display:none">Info about the 'typographic letter unit' definition.</span><b><a href="#typographic-letter-unit">#typographic-letter-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-letter-unit">2.1. 
 Case Transforms: the text-transform property</a>
@@ -9188,8 +9188,8 @@ Cursive Scripts</a> <a href="#ref-for-typographic-letter-unit①②">(2)</a> <a 
 Cursive Scripts</a> <a href="#ref-for-typographic-letter-unit①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="letter">
-   <b><a href="#letter">#letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-letter" class="dfn-panel" data-for="letter" id="infopanel-for-letter" role="dialog">
+   <span id="infopaneltitle-for-letter" style="display:none">Info about the 'letter' definition.</span><b><a href="#letter">#letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-letter">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-letter①">(2)</a>
@@ -9199,8 +9199,8 @@ Breaking Rules for Letters: the word-break property</a>
 Minimum Requirements for auto Justification</a> <a href="#ref-for-letter④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-transform">
-   <b><a href="#propdef-text-transform">#propdef-text-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-transform" class="dfn-panel" data-for="propdef-text-transform" id="infopanel-for-propdef-text-transform" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-transform" style="display:none">Info about the 'text-transform' definition.</span><b><a href="#propdef-text-transform">#propdef-text-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform②">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-propdef-text-transform③">(2)</a> <a href="#ref-for-propdef-text-transform④">(3)</a> <a href="#ref-for-propdef-text-transform⑤">(4)</a> <a href="#ref-for-propdef-text-transform⑥">(5)</a>
@@ -9210,8 +9210,8 @@ Mapping Rules</a>
 Conversion to Plaintext</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-transform-capitalize">
-   <b><a href="#valdef-text-transform-capitalize">#valdef-text-transform-capitalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-transform-capitalize" class="dfn-panel" data-for="valdef-text-transform-capitalize" id="infopanel-for-valdef-text-transform-capitalize" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-transform-capitalize" style="display:none">Info about the 'capitalize' definition.</span><b><a href="#valdef-text-transform-capitalize">#valdef-text-transform-capitalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-transform-capitalize">2.1.1. 
 Mapping Rules</a> <a href="#ref-for-valdef-text-transform-capitalize①">(2)</a>
@@ -9219,36 +9219,36 @@ Mapping Rules</a> <a href="#ref-for-valdef-text-transform-capitalize①">(2)</a>
 Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-transform-uppercase">
-   <b><a href="#valdef-text-transform-uppercase">#valdef-text-transform-uppercase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-transform-uppercase" class="dfn-panel" data-for="valdef-text-transform-uppercase" id="infopanel-for-valdef-text-transform-uppercase" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-transform-uppercase" style="display:none">Info about the 'uppercase' definition.</span><b><a href="#valdef-text-transform-uppercase">#valdef-text-transform-uppercase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-transform-uppercase">2.1.2. 
 Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-transform-lowercase">
-   <b><a href="#valdef-text-transform-lowercase">#valdef-text-transform-lowercase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-transform-lowercase" class="dfn-panel" data-for="valdef-text-transform-lowercase" id="infopanel-for-valdef-text-transform-lowercase" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-transform-lowercase" style="display:none">Info about the 'lowercase' definition.</span><b><a href="#valdef-text-transform-lowercase">#valdef-text-transform-lowercase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-transform-lowercase">2.1.2. 
 Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-transform-full-width">
-   <b><a href="#valdef-text-transform-full-width">#valdef-text-transform-full-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-transform-full-width" class="dfn-panel" data-for="valdef-text-transform-full-width" id="infopanel-for-valdef-text-transform-full-width" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-transform-full-width" style="display:none">Info about the 'full-width' definition.</span><b><a href="#valdef-text-transform-full-width">#valdef-text-transform-full-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-transform-full-width①">2.1.2. 
 Order of Operations</a> <a href="#ref-for-valdef-text-transform-full-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-transform-full-size-kana">
-   <b><a href="#valdef-text-transform-full-size-kana">#valdef-text-transform-full-size-kana</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-transform-full-size-kana" class="dfn-panel" data-for="valdef-text-transform-full-size-kana" id="infopanel-for-valdef-text-transform-full-size-kana" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-transform-full-size-kana" style="display:none">Info about the 'full-size-kana' definition.</span><b><a href="#valdef-text-transform-full-size-kana">#valdef-text-transform-full-size-kana</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-transform-full-size-kana①">2.1.2. 
 Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="full-width">
-   <b><a href="#full-width">#full-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-full-width" class="dfn-panel" data-for="full-width" id="infopanel-for-full-width" role="dialog">
+   <span id="infopaneltitle-for-full-width" style="display:none">Info about the 'full-width' definition.</span><b><a href="#full-width">#full-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-full-width">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-full-width①">(2)</a>
@@ -9256,8 +9256,8 @@ Case Transforms: the text-transform property</a> <a href="#ref-for-full-width①
 Mapping Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-white-space">
-   <b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-white-space" class="dfn-panel" data-for="propdef-white-space" id="infopanel-for-propdef-white-space" role="dialog">
+   <span id="infopaneltitle-for-propdef-white-space" style="display:none">Info about the 'white-space' definition.</span><b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-propdef-white-space①">(2)</a>
@@ -9279,8 +9279,8 @@ Line Breaking Strictness: the line-break property</a> <a href="#ref-for-propdef-
 Overflow Wrapping: the overflow-wrap/word-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-normal">
-   <b><a href="#valdef-white-space-normal">#valdef-white-space-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-normal" class="dfn-panel" data-for="valdef-white-space-normal" id="infopanel-for-valdef-white-space-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-white-space-normal">#valdef-white-space-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-normal">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-white-space-normal①">(2)</a> <a href="#ref-for-valdef-white-space-normal②">(3)</a> <a href="#ref-for-valdef-white-space-normal③">(4)</a>
@@ -9292,8 +9292,8 @@ Phase II: Trimming and Positioning</a> <a href="#ref-for-valdef-white-space-norm
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre">
-   <b><a href="#valdef-white-space-pre">#valdef-white-space-pre</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre" class="dfn-panel" data-for="valdef-white-space-pre" id="infopanel-for-valdef-white-space-pre" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre" style="display:none">Info about the 'pre' definition.</span><b><a href="#valdef-white-space-pre">#valdef-white-space-pre</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-white-space-pre①">(2)</a> <a href="#ref-for-valdef-white-space-pre②">(3)</a>
@@ -9305,8 +9305,8 @@ Segment Break Transformation Rules</a>
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-nowrap">
-   <b><a href="#valdef-white-space-nowrap">#valdef-white-space-nowrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-nowrap" class="dfn-panel" data-for="valdef-white-space-nowrap" id="infopanel-for-valdef-white-space-nowrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-nowrap" style="display:none">Info about the 'nowrap' definition.</span><b><a href="#valdef-white-space-nowrap">#valdef-white-space-nowrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-nowrap">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9318,8 +9318,8 @@ Phase II: Trimming and Positioning</a> <a href="#ref-for-valdef-white-space-nowr
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre-wrap">
-   <b><a href="#valdef-white-space-pre-wrap">#valdef-white-space-pre-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre-wrap" class="dfn-panel" data-for="valdef-white-space-pre-wrap" id="infopanel-for-valdef-white-space-pre-wrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre-wrap" style="display:none">Info about the 'pre-wrap' definition.</span><b><a href="#valdef-white-space-pre-wrap">#valdef-white-space-pre-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-wrap">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-white-space-pre-wrap①">(2)</a>
@@ -9333,8 +9333,8 @@ Segment Break Transformation Rules</a>
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-break-spaces">
-   <b><a href="#valdef-white-space-break-spaces">#valdef-white-space-break-spaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-break-spaces" class="dfn-panel" data-for="valdef-white-space-break-spaces" id="infopanel-for-valdef-white-space-break-spaces" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-break-spaces" style="display:none">Info about the 'break-spaces' definition.</span><b><a href="#valdef-white-space-break-spaces">#valdef-white-space-break-spaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-break-spaces">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9348,8 +9348,8 @@ Segment Break Transformation Rules</a>
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-valdef-white-space-break-spaces⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre-line">
-   <b><a href="#valdef-white-space-pre-line">#valdef-white-space-pre-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre-line" class="dfn-panel" data-for="valdef-white-space-pre-line" id="infopanel-for-valdef-white-space-pre-line" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre-line" style="display:none">Info about the 'pre-line' definition.</span><b><a href="#valdef-white-space-pre-line">#valdef-white-space-pre-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-line">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9363,8 +9363,8 @@ Segment Break Transformation Rules</a>
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preserved-white-space">
-   <b><a href="#preserved-white-space">#preserved-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preserved-white-space" class="dfn-panel" data-for="preserved-white-space" id="infopanel-for-preserved-white-space" role="dialog">
+   <span id="infopaneltitle-for-preserved-white-space" style="display:none">Info about the 'preserved white space' definition.</span><b><a href="#preserved-white-space">#preserved-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preserved-white-space">2.1.2. 
 Order of Operations</a>
@@ -9382,8 +9382,8 @@ Line Breaking Details</a>
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-preserved-white-space①④">(2)</a> <a href="#ref-for-preserved-white-space①⑤">(3)</a> <a href="#ref-for-preserved-white-space①⑥">(4)</a> <a href="#ref-for-preserved-white-space①⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="segment-break">
-   <b><a href="#segment-break">#segment-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-segment-break" class="dfn-panel" data-for="segment-break" id="infopanel-for-segment-break" role="dialog">
+   <span id="infopaneltitle-for-segment-break" style="display:none">Info about the 'segment break' definition.</span><b><a href="#segment-break">#segment-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-segment-break">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-segment-break①">(2)</a>
@@ -9395,8 +9395,8 @@ Phase I: Collapsing and Transformation</a> <a href="#ref-for-segment-break⑦">(
 Segment Break Transformation Rules</a> <a href="#ref-for-segment-break⑨">(2)</a> <a href="#ref-for-segment-break①⓪">(3)</a> <a href="#ref-for-segment-break①①">(4)</a> <a href="#ref-for-segment-break①②">(5)</a> <a href="#ref-for-segment-break①③">(6)</a> <a href="#ref-for-segment-break①④">(7)</a> <a href="#ref-for-segment-break①⑤">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="white-space">
-   <b><a href="#white-space">#white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-white-space" class="dfn-panel" data-for="white-space" id="infopanel-for-white-space" role="dialog">
+   <span id="infopaneltitle-for-white-space" style="display:none">Info about the 'document white space characters' definition.</span><b><a href="#white-space">#white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">2.1.2. 
 Order of Operations</a>
@@ -9420,8 +9420,8 @@ Text Alignment: the text-align shorthand</a>
 Conversion to Plaintext</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spaces">
-   <b><a href="#spaces">#spaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spaces" class="dfn-panel" data-for="spaces" id="infopanel-for-spaces" role="dialog">
+   <span id="infopaneltitle-for-spaces" style="display:none">Info about the 'spaces' definition.</span><b><a href="#spaces">#spaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spaces">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9441,8 +9441,8 @@ Breaking Rules for Letters: the word-break property</a> <a href="#ref-for-spaces
 Cursive Scripts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tabs">
-   <b><a href="#tabs">#tabs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tabs" class="dfn-panel" data-for="tabs" id="infopanel-for-tabs" role="dialog">
+   <span id="infopaneltitle-for-tabs" style="display:none">Info about the 'tabs' definition.</span><b><a href="#tabs">#tabs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tabs">4. 
 White Space Processing &amp; Control Characters</a>
@@ -9456,8 +9456,8 @@ Segment Break Transformation Rules</a>
 Tab Character Size: the tab-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="other-space-separators">
-   <b><a href="#other-space-separators">#other-space-separators</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-other-space-separators" class="dfn-panel" data-for="other-space-separators" id="infopanel-for-other-space-separators" role="dialog">
+   <span id="infopaneltitle-for-other-space-separators" style="display:none">Info about the 'other space separators' definition.</span><b><a href="#other-space-separators">#other-space-separators</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-other-space-separators">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-other-space-separators①">(2)</a> <a href="#ref-for-other-space-separators②">(3)</a> <a href="#ref-for-other-space-separators③">(4)</a>
@@ -9467,8 +9467,8 @@ Phase II: Trimming and Positioning</a> <a href="#ref-for-other-space-separators�
 Breaking Rules for Letters: the word-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collapsible-white-space">
-   <b><a href="#collapsible-white-space">#collapsible-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collapsible-white-space" class="dfn-panel" data-for="collapsible-white-space" id="infopanel-for-collapsible-white-space" role="dialog">
+   <span id="infopaneltitle-for-collapsible-white-space" style="display:none">Info about the 'collapsible' definition.</span><b><a href="#collapsible-white-space">#collapsible-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collapsible-white-space">4. 
 White Space Processing &amp; Control Characters</a>
@@ -9484,8 +9484,8 @@ Text Alignment: the text-align shorthand</a>
 Conversion to Plaintext</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tab-stop">
-   <b><a href="#tab-stop">#tab-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tab-stop" class="dfn-panel" data-for="tab-stop" id="infopanel-for-tab-stop" role="dialog">
+   <span id="infopaneltitle-for-tab-stop" style="display:none">Info about the 'Tab stops' definition.</span><b><a href="#tab-stop">#tab-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tab-stop">4.1.2. 
 Phase II: Trimming and Positioning</a> <a href="#ref-for-tab-stop①">(2)</a>
@@ -9493,8 +9493,8 @@ Phase II: Trimming and Positioning</a> <a href="#ref-for-tab-stop①">(2)</a>
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-tab-size">
-   <b><a href="#propdef-tab-size">#propdef-tab-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-tab-size" class="dfn-panel" data-for="propdef-tab-size" id="infopanel-for-propdef-tab-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-tab-size" style="display:none">Info about the 'tab-size' definition.</span><b><a href="#propdef-tab-size">#propdef-tab-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-tab-size①">4.1.2. 
 Phase II: Trimming and Positioning</a>
@@ -9502,22 +9502,22 @@ Phase II: Trimming and Positioning</a>
 Tab Character Size: the tab-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tab-size-dfn">
-   <b><a href="#tab-size-dfn">#tab-size-dfn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tab-size-dfn" class="dfn-panel" data-for="tab-size-dfn" id="infopanel-for-tab-size-dfn" role="dialog">
+   <span id="infopaneltitle-for-tab-size-dfn" style="display:none">Info about the 'tab size' definition.</span><b><a href="#tab-size-dfn">#tab-size-dfn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tab-size-dfn">4.1.2. 
 Phase II: Trimming and Positioning</a> <a href="#ref-for-tab-size-dfn①">(2)</a> <a href="#ref-for-tab-size-dfn②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-break">
-   <b><a href="#line-break">#line-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-break" class="dfn-panel" data-for="line-break" id="infopanel-for-line-break" role="dialog">
+   <span id="infopaneltitle-for-line-break" style="display:none">Info about the 'line break' definition.</span><b><a href="#line-break">#line-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-break">5.1. 
 Line Breaking Details</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-line-break">
-   <b><a href="#forced-line-break">#forced-line-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-line-break" class="dfn-panel" data-for="forced-line-break" id="infopanel-for-forced-line-break" role="dialog">
+   <span id="infopaneltitle-for-forced-line-break" style="display:none">Info about the 'forced line break' definition.</span><b><a href="#forced-line-break">#forced-line-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-line-break">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-forced-line-break①">(2)</a> <a href="#ref-for-forced-line-break②">(3)</a>
@@ -9533,8 +9533,8 @@ First Line Indentation: the text-indent property</a>
 Conversion to Plaintext</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wrapping">
-   <b><a href="#wrapping">#wrapping</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wrapping" class="dfn-panel" data-for="wrapping" id="infopanel-for-wrapping" role="dialog">
+   <span id="infopaneltitle-for-wrapping" style="display:none">Info about the 'wrapping' definition.</span><b><a href="#wrapping">#wrapping</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wrapping">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9550,15 +9550,15 @@ Shaping Across Intra-word Breaks</a>
 Text Processing Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="soft-wrap-break">
-   <b><a href="#soft-wrap-break">#soft-wrap-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-soft-wrap-break" class="dfn-panel" data-for="soft-wrap-break" id="infopanel-for-soft-wrap-break" role="dialog">
+   <span id="infopaneltitle-for-soft-wrap-break" style="display:none">Info about the 'soft wrap break' definition.</span><b><a href="#soft-wrap-break">#soft-wrap-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-break">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-breaking-process">
-   <b><a href="#line-breaking-process">#line-breaking-process</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-breaking-process" class="dfn-panel" data-for="line-breaking-process" id="infopanel-for-line-breaking-process" role="dialog">
+   <span id="infopaneltitle-for-line-breaking-process" style="display:none">Info about the 'line breaking' definition.</span><b><a href="#line-breaking-process">#line-breaking-process</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-breaking-process">4.1.1. 
 Phase I: Collapsing and Transformation</a>
@@ -9566,8 +9566,8 @@ Phase I: Collapsing and Transformation</a>
 Line Breaking Details</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="soft-wrap-opportunity">
-   <b><a href="#soft-wrap-opportunity">#soft-wrap-opportunity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-soft-wrap-opportunity" class="dfn-panel" data-for="soft-wrap-opportunity" id="infopanel-for-soft-wrap-opportunity" role="dialog">
+   <span id="infopaneltitle-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' definition.</span><b><a href="#soft-wrap-opportunity">#soft-wrap-opportunity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">3. 
 White Space and Wrapping: the white-space property</a> <a href="#ref-for-soft-wrap-opportunity①">(2)</a>
@@ -9589,8 +9589,8 @@ Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-so
 Shaping Across Intra-word Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-word-break">
-   <b><a href="#propdef-word-break">#propdef-word-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-break" class="dfn-panel" data-for="propdef-word-break" id="infopanel-for-propdef-word-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-break" style="display:none">Info about the 'word-break' definition.</span><b><a href="#propdef-word-break">#propdef-word-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-break">5. 
 Line Breaking and Word Boundaries</a>
@@ -9606,22 +9606,22 @@ Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-pr
 Shaping Across Intra-word Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-break-normal">
-   <b><a href="#valdef-word-break-normal">#valdef-word-break-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-break-normal" class="dfn-panel" data-for="valdef-word-break-normal" id="infopanel-for-valdef-word-break-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-break-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-word-break-normal">#valdef-word-break-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-break-normal">5.2. 
 Breaking Rules for Letters: the word-break property</a> <a href="#ref-for-valdef-word-break-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-break-break-all">
-   <b><a href="#valdef-word-break-break-all">#valdef-word-break-break-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-break-break-all" class="dfn-panel" data-for="valdef-word-break-break-all" id="infopanel-for-valdef-word-break-break-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-break-break-all" style="display:none">Info about the 'break-all' definition.</span><b><a href="#valdef-word-break-break-all">#valdef-word-break-break-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-break-break-all">5.2. 
 Breaking Rules for Letters: the word-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-break">
-   <b><a href="#propdef-line-break">#propdef-line-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-break" class="dfn-panel" data-for="propdef-line-break" id="infopanel-for-propdef-line-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-break" style="display:none">Info about the 'line-break' definition.</span><b><a href="#propdef-line-break">#propdef-line-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-break">5. 
 Line Breaking and Word Boundaries</a>
@@ -9635,29 +9635,29 @@ Line Breaking Strictness: the line-break property</a> <a href="#ref-for-propdef-
 Shaping Across Intra-word Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-break-loose">
-   <b><a href="#valdef-line-break-loose">#valdef-line-break-loose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-break-loose" class="dfn-panel" data-for="valdef-line-break-loose" id="infopanel-for-valdef-line-break-loose" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-break-loose" style="display:none">Info about the 'loose' definition.</span><b><a href="#valdef-line-break-loose">#valdef-line-break-loose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-loose">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-valdef-line-break-loose①">(2)</a> <a href="#ref-for-valdef-line-break-loose②">(3)</a> <a href="#ref-for-valdef-line-break-loose③">(4)</a> <a href="#ref-for-valdef-line-break-loose④">(5)</a> <a href="#ref-for-valdef-line-break-loose⑤">(6)</a> <a href="#ref-for-valdef-line-break-loose⑥">(7)</a> <a href="#ref-for-valdef-line-break-loose⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-break-normal">
-   <b><a href="#valdef-line-break-normal">#valdef-line-break-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-break-normal" class="dfn-panel" data-for="valdef-line-break-normal" id="infopanel-for-valdef-line-break-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-break-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-line-break-normal">#valdef-line-break-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-normal">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-valdef-line-break-normal①">(2)</a> <a href="#ref-for-valdef-line-break-normal②">(3)</a> <a href="#ref-for-valdef-line-break-normal③">(4)</a> <a href="#ref-for-valdef-line-break-normal④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-break-strict">
-   <b><a href="#valdef-line-break-strict">#valdef-line-break-strict</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-break-strict" class="dfn-panel" data-for="valdef-line-break-strict" id="infopanel-for-valdef-line-break-strict" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-break-strict" style="display:none">Info about the 'strict' definition.</span><b><a href="#valdef-line-break-strict">#valdef-line-break-strict</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-strict">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-valdef-line-break-strict①">(2)</a> <a href="#ref-for-valdef-line-break-strict②">(3)</a> <a href="#ref-for-valdef-line-break-strict③">(4)</a> <a href="#ref-for-valdef-line-break-strict④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-break-anywhere">
-   <b><a href="#valdef-line-break-anywhere">#valdef-line-break-anywhere</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-break-anywhere" class="dfn-panel" data-for="valdef-line-break-anywhere" id="infopanel-for-valdef-line-break-anywhere" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-break-anywhere" style="display:none">Info about the 'anywhere' definition.</span><b><a href="#valdef-line-break-anywhere">#valdef-line-break-anywhere</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-anywhere">5.2. 
 Breaking Rules for Letters: the word-break property</a>
@@ -9665,8 +9665,8 @@ Breaking Rules for Letters: the word-break property</a>
 Line Breaking Strictness: the line-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hyphenate">
-   <b><a href="#hyphenate">#hyphenate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hyphenate" class="dfn-panel" data-for="hyphenate" id="infopanel-for-hyphenate" role="dialog">
+   <span id="infopaneltitle-for-hyphenate" style="display:none">Info about the 'Hyphenation' definition.</span><b><a href="#hyphenate">#hyphenate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hyphenate">5.4. 
 Hyphenation: the hyphens property</a> <a href="#ref-for-hyphenate①">(2)</a> <a href="#ref-for-hyphenate②">(3)</a>
@@ -9674,15 +9674,15 @@ Hyphenation: the hyphens property</a> <a href="#ref-for-hyphenate①">(2)</a> <a
 Shaping Across Intra-word Breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hyphenation-opportunity">
-   <b><a href="#hyphenation-opportunity">#hyphenation-opportunity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hyphenation-opportunity" class="dfn-panel" data-for="hyphenation-opportunity" id="infopanel-for-hyphenation-opportunity" role="dialog">
+   <span id="infopaneltitle-for-hyphenation-opportunity" style="display:none">Info about the 'hyphenation opportunity' definition.</span><b><a href="#hyphenation-opportunity">#hyphenation-opportunity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hyphenation-opportunity">5.4. 
 Hyphenation: the hyphens property</a> <a href="#ref-for-hyphenation-opportunity①">(2)</a> <a href="#ref-for-hyphenation-opportunity②">(3)</a> <a href="#ref-for-hyphenation-opportunity③">(4)</a> <a href="#ref-for-hyphenation-opportunity④">(5)</a> <a href="#ref-for-hyphenation-opportunity⑤">(6)</a> <a href="#ref-for-hyphenation-opportunity⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphens">
-   <b><a href="#propdef-hyphens">#propdef-hyphens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphens" class="dfn-panel" data-for="propdef-hyphens" id="infopanel-for-propdef-hyphens" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphens" style="display:none">Info about the 'hyphens' definition.</span><b><a href="#propdef-hyphens">#propdef-hyphens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphens">5. 
 Line Breaking and Word Boundaries</a>
@@ -9690,8 +9690,8 @@ Line Breaking and Word Boundaries</a>
 Hyphenation: the hyphens property</a> <a href="#ref-for-propdef-hyphens②">(2)</a> <a href="#ref-for-propdef-hyphens③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow-wrap">
-   <b><a href="#propdef-overflow-wrap">#propdef-overflow-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow-wrap" class="dfn-panel" data-for="propdef-overflow-wrap" id="infopanel-for-propdef-overflow-wrap" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow-wrap" style="display:none">Info about the 'overflow-wrap' definition.</span><b><a href="#propdef-overflow-wrap">#propdef-overflow-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-wrap">5. 
 Line Breaking and Word Boundaries</a>
@@ -9705,29 +9705,29 @@ Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-pr
 Shaping Across Intra-word Breaks</a> <a href="#ref-for-propdef-overflow-wrap⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-word-wrap">
-   <b><a href="#propdef-word-wrap">#propdef-word-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-wrap" class="dfn-panel" data-for="propdef-word-wrap" id="infopanel-for-propdef-word-wrap" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-wrap" style="display:none">Info about the 'word-wrap' definition.</span><b><a href="#propdef-word-wrap">#propdef-word-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-wrap">5.5. 
 Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-propdef-word-wrap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-wrap-anywhere">
-   <b><a href="#valdef-overflow-wrap-anywhere">#valdef-overflow-wrap-anywhere</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-wrap-anywhere" class="dfn-panel" data-for="valdef-overflow-wrap-anywhere" id="infopanel-for-valdef-overflow-wrap-anywhere" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-wrap-anywhere" style="display:none">Info about the 'anywhere' definition.</span><b><a href="#valdef-overflow-wrap-anywhere">#valdef-overflow-wrap-anywhere</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-wrap-anywhere">5.5. 
 Overflow Wrapping: the overflow-wrap/word-wrap property</a> <a href="#ref-for-valdef-overflow-wrap-anywhere①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-wrap-break-word">
-   <b><a href="#valdef-overflow-wrap-break-word">#valdef-overflow-wrap-break-word</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-wrap-break-word" class="dfn-panel" data-for="valdef-overflow-wrap-break-word" id="infopanel-for-valdef-overflow-wrap-break-word" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-wrap-break-word" style="display:none">Info about the 'break-word' definition.</span><b><a href="#valdef-overflow-wrap-break-word">#valdef-overflow-wrap-break-word</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-wrap-break-word">5.5. 
 Overflow Wrapping: the overflow-wrap/word-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-align">
-   <b><a href="#propdef-text-align">#propdef-text-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-align" class="dfn-panel" data-for="propdef-text-align" id="infopanel-for-propdef-text-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-align" style="display:none">Info about the 'text-align' definition.</span><b><a href="#propdef-text-align">#propdef-text-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-align①">(2)</a>
@@ -9743,8 +9743,8 @@ First Line Indentation: the text-indent property</a>
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-start">
-   <b><a href="#valdef-text-align-start">#valdef-text-align-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-start" class="dfn-panel" data-for="valdef-text-align-start" id="infopanel-for-valdef-text-align-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-start" style="display:none">Info about the 'start' definition.</span><b><a href="#valdef-text-align-start">#valdef-text-align-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-start">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-valdef-text-align-start①">(2)</a>
@@ -9754,22 +9754,22 @@ Last Line Alignment: the text-align-last property</a>
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-end">
-   <b><a href="#valdef-text-align-end">#valdef-text-align-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-end" class="dfn-panel" data-for="valdef-text-align-end" id="infopanel-for-valdef-text-align-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-end" style="display:none">Info about the 'end' definition.</span><b><a href="#valdef-text-align-end">#valdef-text-align-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-end">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-center">
-   <b><a href="#valdef-text-align-center">#valdef-text-align-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-center" class="dfn-panel" data-for="valdef-text-align-center" id="infopanel-for-valdef-text-align-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-text-align-center">#valdef-text-align-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">6.4.3. 
 Unexpandable Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-justify">
-   <b><a href="#valdef-text-align-justify">#valdef-text-align-justify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-justify" class="dfn-panel" data-for="valdef-text-align-justify" id="infopanel-for-valdef-text-align-justify" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-justify" style="display:none">Info about the 'justify' definition.</span><b><a href="#valdef-text-align-justify">#valdef-text-align-justify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-justify">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-valdef-text-align-justify①">(2)</a>
@@ -9783,15 +9783,15 @@ Expanding and Compressing Text</a>
 Unexpandable Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-justify-all">
-   <b><a href="#valdef-text-align-justify-all">#valdef-text-align-justify-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-justify-all" class="dfn-panel" data-for="valdef-text-align-justify-all" id="infopanel-for-valdef-text-align-justify-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-justify-all" style="display:none">Info about the 'justify-all' definition.</span><b><a href="#valdef-text-align-justify-all">#valdef-text-align-justify-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-justify-all">6.1. 
 Text Alignment: the text-align shorthand</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-match-parent">
-   <b><a href="#valdef-text-align-match-parent">#valdef-text-align-match-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-match-parent" class="dfn-panel" data-for="valdef-text-align-match-parent" id="infopanel-for-valdef-text-align-match-parent" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-match-parent" style="display:none">Info about the 'match-parent' definition.</span><b><a href="#valdef-text-align-match-parent">#valdef-text-align-match-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-match-parent">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-valdef-text-align-match-parent①">(2)</a>
@@ -9799,8 +9799,8 @@ Text Alignment: the text-align shorthand</a> <a href="#ref-for-valdef-text-align
 Default Text Alignment: the text-align-all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-align-all">
-   <b><a href="#propdef-text-align-all">#propdef-text-align-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-align-all" class="dfn-panel" data-for="propdef-text-align-all" id="infopanel-for-propdef-text-align-all" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-align-all" style="display:none">Info about the 'text-align-all' definition.</span><b><a href="#propdef-text-align-all">#propdef-text-align-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align-all">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-align-all①">(2)</a> <a href="#ref-for-propdef-text-align-all②">(3)</a> <a href="#ref-for-propdef-text-align-all③">(4)</a>
@@ -9812,8 +9812,8 @@ Last Line Alignment: the text-align-last property</a> <a href="#ref-for-propdef-
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-align-last">
-   <b><a href="#propdef-text-align-last">#propdef-text-align-last</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-align-last" class="dfn-panel" data-for="propdef-text-align-last" id="infopanel-for-propdef-text-align-last" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-align-last" style="display:none">Info about the 'text-align-last' definition.</span><b><a href="#propdef-text-align-last">#propdef-text-align-last</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align-last">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-align-last①">(2)</a> <a href="#ref-for-propdef-text-align-last②">(3)</a> <a href="#ref-for-propdef-text-align-last③">(4)</a> <a href="#ref-for-propdef-text-align-last④">(5)</a>
@@ -9827,8 +9827,8 @@ Unexpandable Text</a> <a href="#ref-for-propdef-text-align-last⑧">(2)</a>
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-last-auto">
-   <b><a href="#valdef-text-align-last-auto">#valdef-text-align-last-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-last-auto" class="dfn-panel" data-for="valdef-text-align-last-auto" id="infopanel-for-valdef-text-align-last-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-last-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-text-align-last-auto">#valdef-text-align-last-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-last-auto">6.1. 
 Text Alignment: the text-align shorthand</a>
@@ -9836,8 +9836,8 @@ Text Alignment: the text-align shorthand</a>
 Default Text Alignment: the text-align-all property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-justify">
-   <b><a href="#propdef-text-justify">#propdef-text-justify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-justify" class="dfn-panel" data-for="propdef-text-justify" id="infopanel-for-propdef-text-justify" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-justify" style="display:none">Info about the 'text-justify' definition.</span><b><a href="#propdef-text-justify">#propdef-text-justify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-justify①">6.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-justify②">(2)</a>
@@ -9847,29 +9847,29 @@ Justification Method: the text-justify property</a> <a href="#ref-for-propdef-te
 Expanding and Compressing Text</a> <a href="#ref-for-propdef-text-justify⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-justify-auto">
-   <b><a href="#valdef-text-justify-auto">#valdef-text-justify-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-justify-auto" class="dfn-panel" data-for="valdef-text-justify-auto" id="infopanel-for-valdef-text-justify-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-justify-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-text-justify-auto">#valdef-text-justify-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-justify-auto">6.4.5. 
 Minimum Requirements for auto Justification</a> <a href="#ref-for-valdef-text-justify-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-justify-inter-word">
-   <b><a href="#valdef-text-justify-inter-word">#valdef-text-justify-inter-word</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-justify-inter-word" class="dfn-panel" data-for="valdef-text-justify-inter-word" id="infopanel-for-valdef-text-justify-inter-word" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-justify-inter-word" style="display:none">Info about the 'inter-word' definition.</span><b><a href="#valdef-text-justify-inter-word">#valdef-text-justify-inter-word</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-justify-inter-word">6.4. 
 Justification Method: the text-justify property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-justify-inter-character">
-   <b><a href="#valdef-text-justify-inter-character">#valdef-text-justify-inter-character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-justify-inter-character" class="dfn-panel" data-for="valdef-text-justify-inter-character" id="infopanel-for-valdef-text-justify-inter-character" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-justify-inter-character" style="display:none">Info about the 'inter-character' definition.</span><b><a href="#valdef-text-justify-inter-character">#valdef-text-justify-inter-character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-justify-inter-character">6.4.1. 
 Expanding and Compressing Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="justification-opportunity">
-   <b><a href="#justification-opportunity">#justification-opportunity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-justification-opportunity" class="dfn-panel" data-for="justification-opportunity" id="infopanel-for-justification-opportunity" role="dialog">
+   <span id="infopaneltitle-for-justification-opportunity" style="display:none">Info about the 'justification opportunity' definition.</span><b><a href="#justification-opportunity">#justification-opportunity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-justification-opportunity">6.1. 
 Text Alignment: the text-align shorthand</a>
@@ -9887,8 +9887,8 @@ Minimum Requirements for auto Justification</a> <a href="#ref-for-justification-
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-word-spacing">
-   <b><a href="#propdef-word-spacing">#propdef-word-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-spacing" class="dfn-panel" data-for="propdef-word-spacing" id="infopanel-for-propdef-word-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' definition.</span><b><a href="#propdef-word-spacing">#propdef-word-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">4.2. 
 Tab Character Size: the tab-size property</a>
@@ -9906,8 +9906,8 @@ Tracking: the letter-spacing property</a>
 Text Processing Order of Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="word-separator">
-   <b><a href="#word-separator">#word-separator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-word-separator" class="dfn-panel" data-for="word-separator" id="infopanel-for-word-separator" role="dialog">
+   <span id="infopaneltitle-for-word-separator" style="display:none">Info about the 'Word-separator characters' definition.</span><b><a href="#word-separator">#word-separator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-word-separator">5.1. 
 Line Breaking Details</a> <a href="#ref-for-word-separator①">(2)</a> <a href="#ref-for-word-separator②">(3)</a> <a href="#ref-for-word-separator③">(4)</a>
@@ -9925,8 +9925,8 @@ Spacing</a>
 Word Spacing: the word-spacing property</a> <a href="#ref-for-word-separator①②">(2)</a> <a href="#ref-for-word-separator①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-letter-spacing">
-   <b><a href="#propdef-letter-spacing">#propdef-letter-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-letter-spacing" class="dfn-panel" data-for="propdef-letter-spacing" id="infopanel-for-propdef-letter-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' definition.</span><b><a href="#propdef-letter-spacing">#propdef-letter-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">4.2. 
 Tab Character Size: the tab-size property</a>
@@ -9946,15 +9946,15 @@ Text Processing Order of Operations</a>
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-letter-spacing-normal">
-   <b><a href="#valdef-letter-spacing-normal">#valdef-letter-spacing-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-letter-spacing-normal" class="dfn-panel" data-for="valdef-letter-spacing-normal" id="infopanel-for-valdef-letter-spacing-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-letter-spacing-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-letter-spacing-normal">#valdef-letter-spacing-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-letter-spacing-normal">7.2. 
 Tracking: the letter-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-indent">
-   <b><a href="#propdef-text-indent">#propdef-text-indent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-indent" class="dfn-panel" data-for="propdef-text-indent" id="infopanel-for-propdef-text-indent" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-indent" style="display:none">Info about the 'text-indent' definition.</span><b><a href="#propdef-text-indent">#propdef-text-indent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">8. 
 Edge Effects</a>
@@ -9964,22 +9964,22 @@ First Line Indentation: the text-indent property</a> <a href="#ref-for-propdef-t
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-indent-each-line">
-   <b><a href="#valdef-text-indent-each-line">#valdef-text-indent-each-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-indent-each-line" class="dfn-panel" data-for="valdef-text-indent-each-line" id="infopanel-for-valdef-text-indent-each-line" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-indent-each-line" style="display:none">Info about the 'each-line' definition.</span><b><a href="#valdef-text-indent-each-line">#valdef-text-indent-each-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-indent-each-line">8.1. 
 First Line Indentation: the text-indent property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-indent-hanging">
-   <b><a href="#valdef-text-indent-hanging">#valdef-text-indent-hanging</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-indent-hanging" class="dfn-panel" data-for="valdef-text-indent-hanging" id="infopanel-for-valdef-text-indent-hanging" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-indent-hanging" style="display:none">Info about the 'hanging' definition.</span><b><a href="#valdef-text-indent-hanging">#valdef-text-indent-hanging</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-indent-hanging">8.1. 
 First Line Indentation: the text-indent property</a> <a href="#ref-for-valdef-text-indent-hanging①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hang">
-   <b><a href="#hang">#hang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hang" class="dfn-panel" data-for="hang" id="infopanel-for-hang" role="dialog">
+   <span id="infopaneltitle-for-hang" style="display:none">Info about the 'hangs' definition.</span><b><a href="#hang">#hang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hang">3. 
 White Space and Wrapping: the white-space property</a>
@@ -9993,15 +9993,15 @@ Hanging Glyphs</a> <a href="#ref-for-hang①①">(2)</a> <a href="#ref-for-hang�
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-hang①⑨">(2)</a> <a href="#ref-for-hang②⓪">(3)</a> <a href="#ref-for-hang②①">(4)</a> <a href="#ref-for-hang②②">(5)</a> <a href="#ref-for-hang②③">(6)</a> <a href="#ref-for-hang②④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hanging-glyph">
-   <b><a href="#hanging-glyph">#hanging-glyph</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hanging-glyph" class="dfn-panel" data-for="hanging-glyph" id="infopanel-for-hanging-glyph" role="dialog">
+   <span id="infopaneltitle-for-hanging-glyph" style="display:none">Info about the 'hanging glyph' definition.</span><b><a href="#hanging-glyph">#hanging-glyph</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hanging-glyph">8.2. 
 Hanging Glyphs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conditionally-hang">
-   <b><a href="#conditionally-hang">#conditionally-hang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conditionally-hang" class="dfn-panel" data-for="conditionally-hang" id="infopanel-for-conditionally-hang" role="dialog">
+   <span id="infopaneltitle-for-conditionally-hang" style="display:none">Info about the 'conditionally hang' definition.</span><b><a href="#conditionally-hang">#conditionally-hang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conditionally-hang">4.1.2. 
 Phase II: Trimming and Positioning</a> <a href="#ref-for-conditionally-hang①">(2)</a> <a href="#ref-for-conditionally-hang②">(3)</a> <a href="#ref-for-conditionally-hang③">(4)</a> <a href="#ref-for-conditionally-hang④">(5)</a> <a href="#ref-for-conditionally-hang⑤">(6)</a>
@@ -10011,8 +10011,8 @@ Hanging Glyphs</a>
 Hanging Punctuation: the hanging-punctuation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hanging-punctuation">
-   <b><a href="#propdef-hanging-punctuation">#propdef-hanging-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hanging-punctuation" class="dfn-panel" data-for="propdef-hanging-punctuation" id="infopanel-for-propdef-hanging-punctuation" role="dialog">
+   <span id="infopaneltitle-for-propdef-hanging-punctuation" style="display:none">Info about the 'hanging-punctuation' definition.</span><b><a href="#propdef-hanging-punctuation">#propdef-hanging-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hanging-punctuation①">8. 
 Edge Effects</a>
@@ -10022,43 +10022,43 @@ Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-prop
 Bidirectionality and Line Boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-hanging-punctuation-force-end">
-   <b><a href="#valdef-hanging-punctuation-force-end">#valdef-hanging-punctuation-force-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-hanging-punctuation-force-end" class="dfn-panel" data-for="valdef-hanging-punctuation-force-end" id="infopanel-for-valdef-hanging-punctuation-force-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-hanging-punctuation-force-end" style="display:none">Info about the 'force-end' definition.</span><b><a href="#valdef-hanging-punctuation-force-end">#valdef-hanging-punctuation-force-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-hanging-punctuation-force-end">8.2.1. 
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-valdef-hanging-punctuation-force-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-hanging-punctuation-allow-end">
-   <b><a href="#valdef-hanging-punctuation-allow-end">#valdef-hanging-punctuation-allow-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-hanging-punctuation-allow-end" class="dfn-panel" data-for="valdef-hanging-punctuation-allow-end" id="infopanel-for-valdef-hanging-punctuation-allow-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-hanging-punctuation-allow-end" style="display:none">Info about the 'allow-end' definition.</span><b><a href="#valdef-hanging-punctuation-allow-end">#valdef-hanging-punctuation-allow-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-hanging-punctuation-allow-end">8.2.1. 
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-valdef-hanging-punctuation-allow-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stop-or-comma">
-   <b><a href="#stop-or-comma">#stop-or-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stop-or-comma" class="dfn-panel" data-for="stop-or-comma" id="infopanel-for-stop-or-comma" role="dialog">
+   <span id="infopaneltitle-for-stop-or-comma" style="display:none">Info about the 'Stops and commas' definition.</span><b><a href="#stop-or-comma">#stop-or-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-or-comma">8.2.1. 
 Hanging Punctuation: the hanging-punctuation property</a> <a href="#ref-for-stop-or-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-scripts">
-   <b><a href="#block-scripts">#block-scripts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-scripts" class="dfn-panel" data-for="block-scripts" id="infopanel-for-block-scripts" role="dialog">
+   <span id="infopaneltitle-for-block-scripts" style="display:none">Info about the 'block scripts' definition.</span><b><a href="#block-scripts">#block-scripts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-scripts">6.4.5. 
 Minimum Requirements for auto Justification</a> <a href="#ref-for-block-scripts①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clustered-scripts">
-   <b><a href="#clustered-scripts">#clustered-scripts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clustered-scripts" class="dfn-panel" data-for="clustered-scripts" id="infopanel-for-clustered-scripts" role="dialog">
+   <span id="infopaneltitle-for-clustered-scripts" style="display:none">Info about the 'clustered scripts' definition.</span><b><a href="#clustered-scripts">#clustered-scripts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clustered-scripts">6.4.5. 
 Minimum Requirements for auto Justification</a> <a href="#ref-for-clustered-scripts①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cursive-script">
-   <b><a href="#cursive-script">#cursive-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cursive-script" class="dfn-panel" data-for="cursive-script" id="infopanel-for-cursive-script" role="dialog">
+   <span id="infopaneltitle-for-cursive-script" style="display:none">Info about the 'cursive scripts' definition.</span><b><a href="#cursive-script">#cursive-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cursive-script">6.4.4. 
 Cursive Scripts</a> <a href="#ref-for-cursive-script①">(2)</a>
@@ -10068,8 +10068,8 @@ Cursive Scripts</a> <a href="#ref-for-cursive-script③">(2)</a>
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unicode-east-asian-width">
-   <b><a href="#unicode-east-asian-width">#unicode-east-asian-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unicode-east-asian-width" class="dfn-panel" data-for="unicode-east-asian-width" id="infopanel-for-unicode-east-asian-width" role="dialog">
+   <span id="infopaneltitle-for-unicode-east-asian-width" style="display:none">Info about the 'East Asian width property' definition.</span><b><a href="#unicode-east-asian-width">#unicode-east-asian-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicode-east-asian-width">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-unicode-east-asian-width①">(2)</a>
@@ -10077,8 +10077,8 @@ Line Breaking Strictness: the line-break property</a> <a href="#ref-for-unicode-
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unicode-general-category">
-   <b><a href="#unicode-general-category">#unicode-general-category</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unicode-general-category" class="dfn-panel" data-for="unicode-general-category" id="infopanel-for-unicode-general-category" role="dialog">
+   <span id="infopaneltitle-for-unicode-general-category" style="display:none">Info about the 'general category' definition.</span><b><a href="#unicode-general-category">#unicode-general-category</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicode-general-category">1.4. 
 Characters and Letters</a>
@@ -10088,8 +10088,8 @@ White Space Processing &amp; Control Characters</a> <a href="#ref-for-unicode-ge
 The White Space Processing Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unicode-script">
-   <b><a href="#unicode-script">#unicode-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unicode-script" class="dfn-panel" data-for="unicode-script" id="infopanel-for-unicode-script" role="dialog">
+   <span id="infopaneltitle-for-unicode-script" style="display:none">Info about the 'script property' definition.</span><b><a href="#unicode-script">#unicode-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicode-script">4. 
 White Space Processing &amp; Control Characters</a>
@@ -10097,8 +10097,8 @@ White Space Processing &amp; Control Characters</a>
 Scripts and Spacing</a> <a href="#ref-for-unicode-script②">(2)</a> <a href="#ref-for-unicode-script③">(3)</a> <a href="#ref-for-unicode-script④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writing-system-chinese">
-   <b><a href="#writing-system-chinese">#writing-system-chinese</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writing-system-chinese" class="dfn-panel" data-for="writing-system-chinese" id="infopanel-for-writing-system-chinese" role="dialog">
+   <span id="infopaneltitle-for-writing-system-chinese" style="display:none">Info about the 'Chinese' definition.</span><b><a href="#writing-system-chinese">#writing-system-chinese</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-system-chinese">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-writing-system-chinese①">(2)</a> <a href="#ref-for-writing-system-chinese②">(3)</a>
@@ -10106,8 +10106,8 @@ Line Breaking Strictness: the line-break property</a> <a href="#ref-for-writing-
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writing-system-japanese">
-   <b><a href="#writing-system-japanese">#writing-system-japanese</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writing-system-japanese" class="dfn-panel" data-for="writing-system-japanese" id="infopanel-for-writing-system-japanese" role="dialog">
+   <span id="infopaneltitle-for-writing-system-japanese" style="display:none">Info about the 'Japanese' definition.</span><b><a href="#writing-system-japanese">#writing-system-japanese</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-system-japanese">5.3. 
 Line Breaking Strictness: the line-break property</a> <a href="#ref-for-writing-system-japanese①">(2)</a> <a href="#ref-for-writing-system-japanese②">(3)</a>
@@ -10115,15 +10115,15 @@ Line Breaking Strictness: the line-break property</a> <a href="#ref-for-writing-
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writing-system-korean">
-   <b><a href="#writing-system-korean">#writing-system-korean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writing-system-korean" class="dfn-panel" data-for="writing-system-korean" id="infopanel-for-writing-system-korean" role="dialog">
+   <span id="infopaneltitle-for-writing-system-korean" style="display:none">Info about the 'Korean' definition.</span><b><a href="#writing-system-korean">#writing-system-korean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-system-korean"> Appendix D:
 Scripts and Spacing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="kana-small">
-   <b><a href="#kana-small">#kana-small</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-kana-small" class="dfn-panel" data-for="kana-small" id="infopanel-for-kana-small" role="dialog">
+   <span id="infopaneltitle-for-kana-small" style="display:none">Info about the 'Small' definition.</span><b><a href="#kana-small">#kana-small</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kana-small">2.1. 
 Case Transforms: the text-transform property</a> <a href="#ref-for-kana-small①">(2)</a> <a href="#ref-for-kana-small②">(3)</a>
@@ -10131,8 +10131,8 @@ Case Transforms: the text-transform property</a> <a href="#ref-for-kana-small①
 Mapping Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="kana-full-size">
-   <b><a href="#kana-full-size">#kana-full-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-kana-full-size" class="dfn-panel" data-for="kana-full-size" id="infopanel-for-kana-full-size" role="dialog">
+   <span id="infopaneltitle-for-kana-full-size" style="display:none">Info about the 'Full-size' definition.</span><b><a href="#kana-full-size">#kana-full-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kana-full-size">2.1. 
 Case Transforms: the text-transform property</a>
@@ -10157,59 +10157,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-4/Overview.html
@@ -3522,43 +3522,43 @@ em   { background: green; color: white; }
    <li><a href="#propdef-wrap-before">wrap-before</a><span>, in § 5.2</span>
    <li><a href="#propdef-wrap-inside">wrap-inside</a><span>, in § 5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">2.2.2. 
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">2.2.2. 
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">2.2.2. 
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragmentation-context">
-   <a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragmentation-context" class="dfn-panel" data-for="term-for-fragmentation-context" id="infopanel-for-term-for-fragmentation-context" role="menu">
+   <span id="infopaneltitle-for-term-for-fragmentation-context" style="display:none">Info about the 'fragmentation context' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#fragmentation-context">https://drafts.csswg.org/css-break-4/#fragmentation-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragmentation-context">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-declared-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#declared-value">https://drafts.csswg.org/css-cascade-5/#declared-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-declared-value" class="dfn-panel" data-for="term-for-declared-value" id="infopanel-for-term-for-declared-value" role="menu">
+   <span id="infopaneltitle-for-term-for-declared-value" style="display:none">Info about the 'declared value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#declared-value">https://drafts.csswg.org/css-cascade-5/#declared-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-value">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-used-value①">(2)</a>
@@ -3566,43 +3566,43 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Hyphens: the hyphenate-character property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-user">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-user">https://drafts.csswg.org/css-cascade-5/#cascade-origin-user</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-user" class="dfn-panel" data-for="term-for-cascade-origin-user" id="infopanel-for-term-for-cascade-origin-user" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-user" style="display:none">Info about the 'user origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-user">https://drafts.csswg.org/css-cascade-5/#cascade-origin-user</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-user">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-cascade-origin-user①">(2)</a> <a href="#ref-for-cascade-origin-user②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'user-agent origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-cascade-origin-ua①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">10.1. 
 Line Start/End Padding: the line-padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-box">
-   <a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-box" class="dfn-panel" data-for="term-for-block-box" id="infopanel-for-term-for-block-box" role="menu">
+   <span id="infopaneltitle-for-term-for-block-box" style="display:none">Info about the 'block box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-box">https://drafts.csswg.org/css-display-3/#block-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-box">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">5.1. 
 Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-block-container①">(2)</a> <a href="#ref-for-block-container②">(3)</a> <a href="#ref-for-block-container③">(4)</a>
@@ -3614,36 +3614,36 @@ Hyphenation Line Limits: the hyphenate-limit-lines and hyphenate-limit-last prop
 Aligning a block of text within its container: the text-group-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">9.3. 
 Aligning a block of text within its container: the text-group-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">9.3. 
 Aligning a block of text within its container: the text-group-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">9.3. 
 Aligning a block of text within its container: the text-group-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -3659,15 +3659,15 @@ Line breaks within boxes: the wrap-inside property</a>
 Line Start/End Padding: the line-padding property</a> <a href="#ref-for-inline-box⑥">(2)</a> <a href="#ref-for-inline-box⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">5.1. 
 Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-inline-formatting-context①">(2)</a> <a href="#ref-for-inline-formatting-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a> <a href="#ref-for-inline-level①">(2)</a> <a href="#ref-for-inline-level②">(3)</a>
@@ -3675,8 +3675,8 @@ Inline breaks between boxes: the wrap-before/wrap-after properties</a> <a href="
 Line Start/End Padding: the line-padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-run">
-   <a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-run" class="dfn-panel" data-for="term-for-text-run" id="infopanel-for-term-for-text-run" role="menu">
+   <span id="infopaneltitle-for-term-for-text-run" style="display:none">Info about the 'text run' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-run">https://drafts.csswg.org/css-display-3/#text-run</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-run">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -3684,15 +3684,15 @@ Detecting Word Boundaries: the word-boundary-detection property</a>
 Makig Word Boundaries Visible: the word-boundary-expansion property</a> <a href="#ref-for-text-run②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">10.2.1. 
 Fullwidth Punctuation Collapsing</a> <a href="#ref-for-propdef-font-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intrinsic-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intrinsic-sizing" class="dfn-panel" data-for="term-for-intrinsic-sizing" id="infopanel-for-term-for-intrinsic-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-intrinsic-sizing" style="display:none">Info about the 'intrinsic sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing">https://drafts.csswg.org/css-sizing-3/#intrinsic-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-sizing">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -3700,22 +3700,22 @@ Detecting Word Boundaries: the word-boundary-detection property</a>
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-break-anywhere">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-anywhere">https://drafts.csswg.org/css-text-4/#valdef-line-break-anywhere</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-break-anywhere" class="dfn-panel" data-for="term-for-valdef-line-break-anywhere" id="infopanel-for-term-for-valdef-line-break-anywhere" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-break-anywhere" style="display:none">Info about the 'anywhere' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-anywhere">https://drafts.csswg.org/css-text-4/#valdef-line-break-anywhere</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-anywhere">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-center">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-center" class="dfn-panel" data-for="term-for-valdef-text-align-center" id="infopanel-for-term-for-valdef-text-align-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">9.2. 
 Character-based Alignment in a Table Column</a> <a href="#ref-for-valdef-text-align-center①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-content-language①">(2)</a> <a href="#ref-for-content-language②">(3)</a>
@@ -3723,36 +3723,36 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Hyphens: the hyphenate-character property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-end">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-end">https://drafts.csswg.org/css-text-4/#valdef-text-align-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-end" class="dfn-panel" data-for="term-for-valdef-text-align-end" id="infopanel-for-term-for-valdef-text-align-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-end">https://drafts.csswg.org/css-text-4/#valdef-text-align-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-end">9.2. 
 Character-based Alignment in a Table Column</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-hanging-punctuation">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation">https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-hanging-punctuation" class="dfn-panel" data-for="term-for-propdef-hanging-punctuation" id="infopanel-for-term-for-propdef-hanging-punctuation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-hanging-punctuation" style="display:none">Info about the 'hanging-punctuation' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation">https://drafts.csswg.org/css-text-4/#propdef-hanging-punctuation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hanging-punctuation">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef-hanging-punctuation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-justification-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-justification-opportunity" class="dfn-panel" data-for="term-for-justification-opportunity" id="infopanel-for-term-for-justification-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-justification-opportunity" style="display:none">Info about the 'justification opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#justification-opportunity">https://drafts.csswg.org/css-text-4/#justification-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-justification-opportunity">10.1. 
 Line Start/End Padding: the line-padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-left">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-left">https://drafts.csswg.org/css-text-4/#valdef-text-align-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-left" class="dfn-panel" data-for="term-for-valdef-text-align-left" id="infopanel-for-term-for-valdef-text-align-left" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-left">https://drafts.csswg.org/css-text-4/#valdef-text-align-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-left">9.2. 
 Character-based Alignment in a Table Column</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-breaking-process">
-   <a href="https://drafts.csswg.org/css-text-4/#line-breaking-process">https://drafts.csswg.org/css-text-4/#line-breaking-process</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-breaking-process" class="dfn-panel" data-for="term-for-line-breaking-process" id="infopanel-for-term-for-line-breaking-process" role="menu">
+   <span id="infopaneltitle-for-term-for-line-breaking-process" style="display:none">Info about the 'line breaking' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#line-breaking-process">https://drafts.csswg.org/css-text-4/#line-breaking-process</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-breaking-process">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -3760,64 +3760,64 @@ Detecting Word Boundaries: the word-boundary-detection property</a>
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-break">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-line-break">https://drafts.csswg.org/css-text-4/#propdef-line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-break" class="dfn-panel" data-for="term-for-propdef-line-break" id="infopanel-for-term-for-propdef-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-break" style="display:none">Info about the 'line-break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-line-break">https://drafts.csswg.org/css-text-4/#propdef-line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-break">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-propdef-line-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-break-loose">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-loose">https://drafts.csswg.org/css-text-4/#valdef-line-break-loose</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-break-loose" class="dfn-panel" data-for="term-for-valdef-line-break-loose" id="infopanel-for-term-for-valdef-line-break-loose" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-break-loose" style="display:none">Info about the 'loose' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-loose">https://drafts.csswg.org/css-text-4/#valdef-line-break-loose</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-loose">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-break-normal">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-normal">https://drafts.csswg.org/css-text-4/#valdef-line-break-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-break-normal" class="dfn-panel" data-for="term-for-valdef-line-break-normal" id="infopanel-for-term-for-valdef-line-break-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-break-normal" style="display:none">Info about the 'normal (for line-break)' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-normal">https://drafts.csswg.org/css-text-4/#valdef-line-break-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-normal">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-normal">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-normal">https://drafts.csswg.org/css-text-4/#valdef-white-space-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-normal" class="dfn-panel" data-for="term-for-valdef-white-space-normal" id="infopanel-for-term-for-valdef-white-space-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-normal" style="display:none">Info about the 'normal (for white-space)' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-normal">https://drafts.csswg.org/css-text-4/#valdef-white-space-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-normal">7. 
 Shorthand for White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre" class="dfn-panel" data-for="term-for-valdef-white-space-pre" id="infopanel-for-term-for-valdef-white-space-pre" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre" style="display:none">Info about the 'pre' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre">7. 
 Shorthand for White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre-line">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre-line" class="dfn-panel" data-for="term-for-valdef-white-space-pre-line" id="infopanel-for-term-for-valdef-white-space-pre-line" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre-line" style="display:none">Info about the 'pre-line' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-line">7. 
 Shorthand for White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre-wrap">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-wrap">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre-wrap" class="dfn-panel" data-for="term-for-valdef-white-space-pre-wrap" id="infopanel-for-term-for-valdef-white-space-pre-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre-wrap" style="display:none">Info about the 'pre-wrap' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-wrap">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-wrap">7. 
 Shorthand for White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-right">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-right">https://drafts.csswg.org/css-text-4/#valdef-text-align-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-right" class="dfn-panel" data-for="term-for-valdef-text-align-right" id="infopanel-for-term-for-valdef-text-align-right" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-right">https://drafts.csswg.org/css-text-4/#valdef-text-align-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-right">9.2. 
 Character-based Alignment in a Table Column</a> <a href="#ref-for-valdef-text-align-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-segment-break">
-   <a href="https://drafts.csswg.org/css-text-4/#segment-break">https://drafts.csswg.org/css-text-4/#segment-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-segment-break" class="dfn-panel" data-for="term-for-segment-break" id="infopanel-for-term-for-segment-break" role="menu">
+   <span id="infopaneltitle-for-term-for-segment-break" style="display:none">Info about the 'segment break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#segment-break">https://drafts.csswg.org/css-text-4/#segment-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-segment-break">3.1. 
 White Space Collapsing: the text-space-collapse property</a> <a href="#ref-for-segment-break①">(2)</a> <a href="#ref-for-segment-break②">(3)</a>
@@ -3825,8 +3825,8 @@ White Space Collapsing: the text-space-collapse property</a> <a href="#ref-for-s
 White Space Trimming: the text-space-trim property</a> <a href="#ref-for-segment-break④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-soft-wrap-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-soft-wrap-opportunity" class="dfn-panel" data-for="term-for-soft-wrap-opportunity" id="infopanel-for-term-for-soft-wrap-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-soft-wrap-opportunity①">(2)</a> <a href="#ref-for-soft-wrap-opportunity②">(3)</a> <a href="#ref-for-soft-wrap-opportunity③">(4)</a> <a href="#ref-for-soft-wrap-opportunity④">(5)</a>
@@ -3834,29 +3834,29 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Text Wrap Settings: the text-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-start">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-start">https://drafts.csswg.org/css-text-4/#valdef-text-align-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-start" class="dfn-panel" data-for="term-for-valdef-text-align-start" id="infopanel-for-term-for-valdef-text-align-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-start">https://drafts.csswg.org/css-text-4/#valdef-text-align-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-start">9.2. 
 Character-based Alignment in a Table Column</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-break-strict">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-strict">https://drafts.csswg.org/css-text-4/#valdef-line-break-strict</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-break-strict" class="dfn-panel" data-for="term-for-valdef-line-break-strict" id="infopanel-for-term-for-valdef-line-break-strict" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-break-strict" style="display:none">Info about the 'strict' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-line-break-strict">https://drafts.csswg.org/css-text-4/#valdef-line-break-strict</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-break-strict">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef-text-indent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">2.1. 
 Case Transforms: the text-transform property</a>
@@ -3864,8 +3864,8 @@ Case Transforms: the text-transform property</a>
 Makig Word Boundaries Visible: the word-boundary-expansion property</a> <a href="#ref-for-propdef-text-transform②">(2)</a> <a href="#ref-for-propdef-text-transform③">(3)</a> <a href="#ref-for-propdef-text-transform④">(4)</a> <a href="#ref-for-propdef-text-transform⑤">(5)</a> <a href="#ref-for-propdef-text-transform⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-typographic-character-unit①">(2)</a> <a href="#ref-for-typographic-character-unit②">(3)</a> <a href="#ref-for-typographic-character-unit③">(4)</a> <a href="#ref-for-typographic-character-unit④">(5)</a> <a href="#ref-for-typographic-character-unit⑤">(6)</a> <a href="#ref-for-typographic-character-unit⑥">(7)</a> <a href="#ref-for-typographic-character-unit⑦">(8)</a>
@@ -3873,8 +3873,8 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Hyphens: the hyphenate-character property</a> <a href="#ref-for-typographic-character-unit⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-letter-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-letter-unit" class="dfn-panel" data-for="term-for-typographic-letter-unit" id="infopanel-for-term-for-typographic-letter-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-letter-unit" style="display:none">Info about the 'typographic letter unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-letter-unit">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-typographic-letter-unit①">(2)</a> <a href="#ref-for-typographic-letter-unit②">(3)</a> <a href="#ref-for-typographic-letter-unit③">(4)</a> <a href="#ref-for-typographic-letter-unit④">(5)</a> <a href="#ref-for-typographic-letter-unit⑤">(6)</a>
@@ -3882,22 +3882,22 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Line Start/End Padding: the line-padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-break">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-break">https://drafts.csswg.org/css-text-4/#propdef-word-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-break" class="dfn-panel" data-for="term-for-propdef-word-break" id="infopanel-for-term-for-propdef-word-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-break" style="display:none">Info about the 'word-break' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-break">https://drafts.csswg.org/css-text-4/#propdef-word-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-break">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-propdef-word-break①">(2)</a> <a href="#ref-for-propdef-word-break②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">6. 
 Last Line Minimum Length</a>
@@ -3907,15 +3907,15 @@ Hyphenation Character Limits: the hyphenate-limit-chars property</a>
 Hyphenation Line Limits: the hyphenate-limit-lines and hyphenate-limit-last properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">8.2. 
 Hyphenation Size Limit: the hyphenate-limit-zone property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">6. 
 Last Line Minimum Length</a>
@@ -3923,15 +3923,15 @@ Last Line Minimum Length</a>
 Line Start/End Padding: the line-padding property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">6. 
 Last Line Minimum Length</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -3944,15 +3944,15 @@ Character-based Alignment in a Table Column</a> <a href="#ref-for-string-value�
     <li><a href="#ref-for-string-value⑦"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">8.3. 
 Hyphenation Character Limits: the hyphenate-limit-chars property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-comb-one①">(2)</a>
@@ -3982,8 +3982,8 @@ Aligning a block of text within its container: the text-group-align property</a>
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-comb-one③⑥">(2)</a> <a href="#ref-for-comb-one③⑦">(3)</a> <a href="#ref-for-comb-one③⑧">(4)</a> <a href="#ref-for-comb-one③⑨">(5)</a> <a href="#ref-for-comb-one④⓪">(6)</a> <a href="#ref-for-comb-one④①">(7)</a> <a href="#ref-for-comb-one④②">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.2. 
 White Space Trimming: the text-space-trim property</a> <a href="#ref-for-comb-any①">(2)</a>
@@ -3991,98 +3991,98 @@ White Space Trimming: the text-space-trim property</a> <a href="#ref-for-comb-an
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-comb-any③">(2)</a> <a href="#ref-for-comb-any④">(3)</a> <a href="#ref-for-comb-any⑤">(4)</a> <a href="#ref-for-comb-any⑥">(5)</a> <a href="#ref-for-comb-any⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">9.3. 
 Aligning a block of text within its container: the text-group-align property</a> <a href="#ref-for-inline-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-start">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-start" class="dfn-panel" data-for="term-for-inline-start" id="infopanel-for-term-for-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-start" style="display:none">Info about the 'inline start' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-start">https://drafts.csswg.org/css-writing-modes-4/#inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">9.3. 
 Aligning a block of text within its container: the text-group-align property</a> <a href="#ref-for-inline-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">5.1. 
 Text Wrap Settings: the text-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline-size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">5.1. 
 Text Wrap Settings: the text-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-left" class="dfn-panel" data-for="term-for-line-left" id="infopanel-for-term-for-line-left" role="menu">
+   <span id="infopaneltitle-for-term-for-line-left" style="display:none">Info about the 'line-left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-left">https://drafts.csswg.org/css-writing-modes-4/#line-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">9.3. 
 Aligning a block of text within its container: the text-group-align property</a> <a href="#ref-for-line-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-line-right">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-line-right" class="dfn-panel" data-for="term-for-line-right" id="infopanel-for-term-for-line-right" role="menu">
+   <span id="infopaneltitle-for-term-for-line-right" style="display:none">Info about the 'line-right' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#line-right">https://drafts.csswg.org/css-writing-modes-4/#line-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">9.3. 
 Aligning a block of text within its container: the text-group-align property</a> <a href="#ref-for-line-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-combine-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-combine-upright" class="dfn-panel" data-for="term-for-propdef-text-combine-upright" id="infopanel-for-term-for-propdef-text-combine-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright">10.2.2. 
 Text Spacing Character Classes</a> <a href="#ref-for-propdef-text-combine-upright①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">10.2.2. 
 Text Spacing Character Classes</a> <a href="#ref-for-propdef-text-orientation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-lang">
-   <a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-lang" class="dfn-panel" data-for="term-for-selectordef-lang" id="infopanel-for-term-for-selectordef-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-lang" style="display:none">Info about the ':lang()' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a> <a href="#ref-for-flex-item①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-line">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-line">https://drafts.csswg.org/css-flexbox-1/#flex-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-line" class="dfn-panel" data-for="term-for-flex-line" id="infopanel-for-term-for-flex-line" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-line" style="display:none">Info about the 'flex line' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-line">https://drafts.csswg.org/css-flexbox-1/#flex-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-line">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a> <a href="#ref-for-flex-line①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-wrap">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-wrap" class="dfn-panel" data-for="term-for-propdef-flex-wrap" id="infopanel-for-term-for-propdef-flex-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-wrap" style="display:none">Info about the 'flex-wrap' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-wrap"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-line-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container">https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-line-flex-container" class="dfn-panel" data-for="term-for-multi-line-flex-container" id="infopanel-for-term-for-multi-line-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-line-flex-container" style="display:none">Info about the 'multi-line flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container">https://drafts.csswg.org/css-flexbox-1/#multi-line-flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-line-flex-container">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-line-break">
-   <a href="https://drafts.csswg.org/css-text-3/#forced-line-break">https://drafts.csswg.org/css-text-3/#forced-line-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-line-break" class="dfn-panel" data-for="term-for-forced-line-break" id="infopanel-for-term-for-forced-line-break" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-line-break" style="display:none">Info about the 'forced line break' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#forced-line-break">https://drafts.csswg.org/css-text-3/#forced-line-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-line-break">2.2.2. 
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
@@ -4090,8 +4090,8 @@ Makig Word Boundaries Visible: the word-boundary-expansion property</a>
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">10.1. 
 Line Start/End Padding: the line-padding property</a>
@@ -4099,15 +4099,15 @@ Line Start/End Padding: the line-padding property</a>
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef-letter-spacing②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-other-space-separators">
-   <a href="https://drafts.csswg.org/css-text-3/#other-space-separators">https://drafts.csswg.org/css-text-3/#other-space-separators</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-other-space-separators" class="dfn-panel" data-for="term-for-other-space-separators" id="infopanel-for-term-for-other-space-separators" role="menu">
+   <span id="infopaneltitle-for-term-for-other-space-separators" style="display:none">Info about the 'other space separators' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#other-space-separators">https://drafts.csswg.org/css-text-3/#other-space-separators</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-other-space-separators">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">9.1. 
 Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-align①">(2)</a>
@@ -4115,15 +4115,15 @@ Text Alignment: the text-align shorthand</a> <a href="#ref-for-propdef-text-alig
 Character-based Alignment in a Table Column</a> <a href="#ref-for-propdef-text-align③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-word-separator">
-   <a href="https://drafts.csswg.org/css-text-3/#word-separator">https://drafts.csswg.org/css-text-3/#word-separator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-word-separator" class="dfn-panel" data-for="term-for-word-separator" id="infopanel-for-term-for-word-separator" role="menu">
+   <span id="infopaneltitle-for-term-for-word-separator" style="display:none">Info about the 'word-separator character' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#word-separator">https://drafts.csswg.org/css-text-3/#word-separator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-word-separator">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-word-spacing">https://drafts.csswg.org/css-text-3/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-word-spacing">https://drafts.csswg.org/css-text-3/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -4131,8 +4131,8 @@ Detecting Word Boundaries: the word-boundary-detection property</a>
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef-word-spacing②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-wbr-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-wbr-element" class="dfn-panel" data-for="term-for-the-wbr-element" id="infopanel-for-term-for-the-wbr-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-wbr-element" style="display:none">Info about the 'wbr' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-wbr-element">2.2. 
 Word Boundaries</a>
@@ -4142,8 +4142,8 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Makig Word Boundaries Visible: the word-boundary-expansion property</a> <a href="#ref-for-the-wbr-element④">(2)</a> <a href="#ref-for-the-wbr-element⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selector" class="dfn-panel" data-for="term-for-selector" id="infopanel-for-term-for-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-selector" style="display:none">Info about the 'selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selector">https://drafts.csswg.org/selectors-4/#selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
@@ -4675,8 +4675,8 @@ no-compress || ideograph-alpha || ideograph-numeric || punctuation
    <div class="issue"> It was requested to add a value for doubling the space after periods. <a class="issue-return" href="#issue-2d794e33" title="Jump to section">↵</a></div>
    <div class="issue"> Classes and Unicode code points need to be reviewed. <a class="issue-return" href="#issue-2a3b8c81" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-word-boundary-detection">
-   <b><a href="#propdef-word-boundary-detection">#propdef-word-boundary-detection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-boundary-detection" class="dfn-panel" data-for="propdef-word-boundary-detection" id="infopanel-for-propdef-word-boundary-detection" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-boundary-detection" style="display:none">Info about the 'word-boundary-detection' definition.</span><b><a href="#propdef-word-boundary-detection">#propdef-word-boundary-detection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-boundary-detection">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-propdef-word-boundary-detection①">(2)</a> <a href="#ref-for-propdef-word-boundary-detection②">(3)</a>
@@ -4684,8 +4684,8 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="virtual-word-boundary">
-   <b><a href="#virtual-word-boundary">#virtual-word-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-virtual-word-boundary" class="dfn-panel" data-for="virtual-word-boundary" id="infopanel-for-virtual-word-boundary" role="dialog">
+   <span id="infopaneltitle-for-virtual-word-boundary" style="display:none">Info about the 'virtual word boundary' definition.</span><b><a href="#virtual-word-boundary">#virtual-word-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-virtual-word-boundary">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-virtual-word-boundary①">(2)</a> <a href="#ref-for-virtual-word-boundary②">(3)</a> <a href="#ref-for-virtual-word-boundary③">(4)</a> <a href="#ref-for-virtual-word-boundary④">(5)</a> <a href="#ref-for-virtual-word-boundary⑤">(6)</a> <a href="#ref-for-virtual-word-boundary⑥">(7)</a> <a href="#ref-for-virtual-word-boundary⑦">(8)</a> <a href="#ref-for-virtual-word-boundary⑧">(9)</a> <a href="#ref-for-virtual-word-boundary⑨">(10)</a> <a href="#ref-for-virtual-word-boundary①⓪">(11)</a> <a href="#ref-for-virtual-word-boundary①①">(12)</a> <a href="#ref-for-virtual-word-boundary①②">(13)</a> <a href="#ref-for-virtual-word-boundary①③">(14)</a>
@@ -4693,36 +4693,36 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-boundary-detection-manual">
-   <b><a href="#valdef-word-boundary-detection-manual">#valdef-word-boundary-detection-manual</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-boundary-detection-manual" class="dfn-panel" data-for="valdef-word-boundary-detection-manual" id="infopanel-for-valdef-word-boundary-detection-manual" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-boundary-detection-manual" style="display:none">Info about the 'manual' definition.</span><b><a href="#valdef-word-boundary-detection-manual">#valdef-word-boundary-detection-manual</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-boundary-detection-manual">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-valdef-word-boundary-detection-manual①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-boundary-detection-normal">
-   <b><a href="#valdef-word-boundary-detection-normal">#valdef-word-boundary-detection-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-boundary-detection-normal" class="dfn-panel" data-for="valdef-word-boundary-detection-normal" id="infopanel-for-valdef-word-boundary-detection-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-boundary-detection-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-word-boundary-detection-normal">#valdef-word-boundary-detection-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-boundary-detection-normal">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-boundary-detection-auto-lang">
-   <b><a href="#valdef-word-boundary-detection-auto-lang">#valdef-word-boundary-detection-auto-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-boundary-detection-auto-lang" class="dfn-panel" data-for="valdef-word-boundary-detection-auto-lang" id="infopanel-for-valdef-word-boundary-detection-auto-lang" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-boundary-detection-auto-lang" style="display:none">Info about the 'auto(&lt;lang>)' definition.</span><b><a href="#valdef-word-boundary-detection-auto-lang">#valdef-word-boundary-detection-auto-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-boundary-detection-auto-lang">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-word-boundary-detection-lang">
-   <b><a href="#typedef-word-boundary-detection-lang">#typedef-word-boundary-detection-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-word-boundary-detection-lang" class="dfn-panel" data-for="typedef-word-boundary-detection-lang" id="infopanel-for-typedef-word-boundary-detection-lang" role="dialog">
+   <span id="infopaneltitle-for-typedef-word-boundary-detection-lang" style="display:none">Info about the '&lt;lang>' definition.</span><b><a href="#typedef-word-boundary-detection-lang">#typedef-word-boundary-detection-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-word-boundary-detection-lang">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-typedef-word-boundary-detection-lang①">(2)</a> <a href="#ref-for-typedef-word-boundary-detection-lang②">(3)</a> <a href="#ref-for-typedef-word-boundary-detection-lang③">(4)</a> <a href="#ref-for-typedef-word-boundary-detection-lang④">(5)</a> <a href="#ref-for-typedef-word-boundary-detection-lang⑤">(6)</a> <a href="#ref-for-typedef-word-boundary-detection-lang⑥">(7)</a> <a href="#ref-for-typedef-word-boundary-detection-lang⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-word-boundary-expansion">
-   <b><a href="#propdef-word-boundary-expansion">#propdef-word-boundary-expansion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-boundary-expansion" class="dfn-panel" data-for="propdef-word-boundary-expansion" id="infopanel-for-propdef-word-boundary-expansion" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-boundary-expansion" style="display:none">Info about the 'word-boundary-expansion' definition.</span><b><a href="#propdef-word-boundary-expansion">#propdef-word-boundary-expansion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-boundary-expansion">2.2.1. 
 Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#ref-for-propdef-word-boundary-expansion①">(2)</a>
@@ -4730,8 +4730,8 @@ Detecting Word Boundaries: the word-boundary-detection property</a> <a href="#re
 Makig Word Boundaries Visible: the word-boundary-expansion property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-space-collapse">
-   <b><a href="#propdef-text-space-collapse">#propdef-text-space-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-space-collapse" class="dfn-panel" data-for="propdef-text-space-collapse" id="infopanel-for-propdef-text-space-collapse" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-space-collapse" style="display:none">Info about the 'text-space-collapse' definition.</span><b><a href="#propdef-text-space-collapse">#propdef-text-space-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-space-collapse">3.1. 
 White Space Collapsing: the text-space-collapse property</a>
@@ -4740,8 +4740,8 @@ Shorthand for White Space and Wrapping: the white-space property</a> <a href="#r
     <li><a href="#ref-for-propdef-text-space-collapse③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-space-collapse-collapse">
-   <b><a href="#valdef-text-space-collapse-collapse">#valdef-text-space-collapse-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-space-collapse-collapse" class="dfn-panel" data-for="valdef-text-space-collapse-collapse" id="infopanel-for-valdef-text-space-collapse-collapse" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-space-collapse-collapse" style="display:none">Info about the 'collapse' definition.</span><b><a href="#valdef-text-space-collapse-collapse">#valdef-text-space-collapse-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-space-collapse-collapse">3.1. 
 White Space Collapsing: the text-space-collapse property</a>
@@ -4749,22 +4749,22 @@ White Space Collapsing: the text-space-collapse property</a>
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-text-space-collapse-collapse②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-space-collapse-preserve">
-   <b><a href="#valdef-text-space-collapse-preserve">#valdef-text-space-collapse-preserve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-space-collapse-preserve" class="dfn-panel" data-for="valdef-text-space-collapse-preserve" id="infopanel-for-valdef-text-space-collapse-preserve" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-space-collapse-preserve" style="display:none">Info about the 'preserve' definition.</span><b><a href="#valdef-text-space-collapse-preserve">#valdef-text-space-collapse-preserve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-space-collapse-preserve">7. 
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-text-space-collapse-preserve①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-space-collapse-preserve-breaks">
-   <b><a href="#valdef-text-space-collapse-preserve-breaks">#valdef-text-space-collapse-preserve-breaks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-space-collapse-preserve-breaks" class="dfn-panel" data-for="valdef-text-space-collapse-preserve-breaks" id="infopanel-for-valdef-text-space-collapse-preserve-breaks" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-space-collapse-preserve-breaks" style="display:none">Info about the 'preserve-breaks' definition.</span><b><a href="#valdef-text-space-collapse-preserve-breaks">#valdef-text-space-collapse-preserve-breaks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-space-collapse-preserve-breaks">7. 
 Shorthand for White Space and Wrapping: the white-space property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-space-trim">
-   <b><a href="#propdef-text-space-trim">#propdef-text-space-trim</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-space-trim" class="dfn-panel" data-for="propdef-text-space-trim" id="infopanel-for-propdef-text-space-trim" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-space-trim" style="display:none">Info about the 'text-space-trim' definition.</span><b><a href="#propdef-text-space-trim">#propdef-text-space-trim</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-space-trim">3.2. 
 White Space Trimming: the text-space-trim property</a>
@@ -4772,8 +4772,8 @@ White Space Trimming: the text-space-trim property</a>
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-propdef-text-space-trim②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-wrap">
-   <b><a href="#propdef-text-wrap">#propdef-text-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-wrap" class="dfn-panel" data-for="propdef-text-wrap" id="infopanel-for-propdef-text-wrap" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-wrap" style="display:none">Info about the 'text-wrap' definition.</span><b><a href="#propdef-text-wrap">#propdef-text-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-wrap">5. 
 Text Wrapping</a>
@@ -4784,8 +4784,8 @@ Shorthand for White Space and Wrapping: the white-space property</a> <a href="#r
     <li><a href="#ref-for-propdef-text-wrap⑦"> Changes</a> <a href="#ref-for-propdef-text-wrap⑧">(2)</a> <a href="#ref-for-propdef-text-wrap⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-wrap-wrap">
-   <b><a href="#valdef-text-wrap-wrap">#valdef-text-wrap-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-wrap-wrap" class="dfn-panel" data-for="valdef-text-wrap-wrap" id="infopanel-for-valdef-text-wrap-wrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-wrap-wrap" style="display:none">Info about the 'wrap' definition.</span><b><a href="#valdef-text-wrap-wrap">#valdef-text-wrap-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-wrap">5.1. 
 Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-valdef-text-wrap-wrap①">(2)</a> <a href="#ref-for-valdef-text-wrap-wrap②">(3)</a> <a href="#ref-for-valdef-text-wrap-wrap③">(4)</a> <a href="#ref-for-valdef-text-wrap-wrap④">(5)</a> <a href="#ref-for-valdef-text-wrap-wrap⑤">(6)</a> <a href="#ref-for-valdef-text-wrap-wrap⑥">(7)</a>
@@ -4793,36 +4793,36 @@ Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-valdef-text-wra
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-text-wrap-wrap⑧">(2)</a> <a href="#ref-for-valdef-text-wrap-wrap⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-wrap-nowrap">
-   <b><a href="#valdef-text-wrap-nowrap">#valdef-text-wrap-nowrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-wrap-nowrap" class="dfn-panel" data-for="valdef-text-wrap-nowrap" id="infopanel-for-valdef-text-wrap-nowrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-wrap-nowrap" style="display:none">Info about the 'nowrap' definition.</span><b><a href="#valdef-text-wrap-nowrap">#valdef-text-wrap-nowrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-nowrap">7. 
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-valdef-text-wrap-nowrap①">(2)</a> <a href="#ref-for-valdef-text-wrap-nowrap②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-wrap-balance">
-   <b><a href="#valdef-text-wrap-balance">#valdef-text-wrap-balance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-wrap-balance" class="dfn-panel" data-for="valdef-text-wrap-balance" id="infopanel-for-valdef-text-wrap-balance" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-wrap-balance" style="display:none">Info about the 'balance' definition.</span><b><a href="#valdef-text-wrap-balance">#valdef-text-wrap-balance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-balance">5.1. 
 Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-valdef-text-wrap-balance①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-wrap-stable">
-   <b><a href="#valdef-text-wrap-stable">#valdef-text-wrap-stable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-wrap-stable" class="dfn-panel" data-for="valdef-text-wrap-stable" id="infopanel-for-valdef-text-wrap-stable" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-wrap-stable" style="display:none">Info about the 'stable' definition.</span><b><a href="#valdef-text-wrap-stable">#valdef-text-wrap-stable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-stable">5.1. 
 Text Wrap Settings: the text-wrap property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-wrap-pretty">
-   <b><a href="#valdef-text-wrap-pretty">#valdef-text-wrap-pretty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-wrap-pretty" class="dfn-panel" data-for="valdef-text-wrap-pretty" id="infopanel-for-valdef-text-wrap-pretty" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-wrap-pretty" style="display:none">Info about the 'pretty' definition.</span><b><a href="#valdef-text-wrap-pretty">#valdef-text-wrap-pretty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-pretty">5.1. 
 Text Wrap Settings: the text-wrap property</a> <a href="#ref-for-valdef-text-wrap-pretty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-wrap-before">
-   <b><a href="#propdef-wrap-before">#propdef-wrap-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-wrap-before" class="dfn-panel" data-for="propdef-wrap-before" id="infopanel-for-propdef-wrap-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-wrap-before" style="display:none">Info about the 'wrap-before' definition.</span><b><a href="#propdef-wrap-before">#propdef-wrap-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-before">5. 
 Text Wrapping</a>
@@ -4830,8 +4830,8 @@ Text Wrapping</a>
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-wrap-after">
-   <b><a href="#propdef-wrap-after">#propdef-wrap-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-wrap-after" class="dfn-panel" data-for="propdef-wrap-after" id="infopanel-for-propdef-wrap-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-wrap-after" style="display:none">Info about the 'wrap-after' definition.</span><b><a href="#propdef-wrap-after">#propdef-wrap-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-after">5. 
 Text Wrapping</a>
@@ -4839,22 +4839,22 @@ Text Wrapping</a>
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-before-auto">
-   <b><a href="#valdef-wrap-before-auto">#valdef-wrap-before-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-before-auto" class="dfn-panel" data-for="valdef-wrap-before-auto" id="infopanel-for-valdef-wrap-before-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-before-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-wrap-before-auto">#valdef-wrap-before-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-before-auto">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-before-avoid">
-   <b><a href="#valdef-wrap-before-avoid">#valdef-wrap-before-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-before-avoid" class="dfn-panel" data-for="valdef-wrap-before-avoid" id="infopanel-for-valdef-wrap-before-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-before-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-wrap-before-avoid">#valdef-wrap-before-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-before-avoid">5.2. 
 Inline breaks between boxes: the wrap-before/wrap-after properties</a> <a href="#ref-for-valdef-wrap-before-avoid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-wrap-inside">
-   <b><a href="#propdef-wrap-inside">#propdef-wrap-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-wrap-inside" class="dfn-panel" data-for="propdef-wrap-inside" id="infopanel-for-propdef-wrap-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-wrap-inside" style="display:none">Info about the 'wrap-inside' definition.</span><b><a href="#propdef-wrap-inside">#propdef-wrap-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-wrap-inside">5. 
 Text Wrapping</a>
@@ -4862,102 +4862,102 @@ Text Wrapping</a>
 Line breaks within boxes: the wrap-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-inside-auto">
-   <b><a href="#valdef-wrap-inside-auto">#valdef-wrap-inside-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-inside-auto" class="dfn-panel" data-for="valdef-wrap-inside-auto" id="infopanel-for-valdef-wrap-inside-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-inside-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-wrap-inside-auto">#valdef-wrap-inside-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-inside-auto">5.3. 
 Line breaks within boxes: the wrap-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-wrap-inside-avoid">
-   <b><a href="#valdef-wrap-inside-avoid">#valdef-wrap-inside-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-wrap-inside-avoid" class="dfn-panel" data-for="valdef-wrap-inside-avoid" id="infopanel-for-valdef-wrap-inside-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-wrap-inside-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-wrap-inside-avoid">#valdef-wrap-inside-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-wrap-inside-avoid">5.3. 
 Line breaks within boxes: the wrap-inside property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-white-space">
-   <b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-white-space" class="dfn-panel" data-for="propdef-white-space" id="infopanel-for-propdef-white-space" role="dialog">
+   <span id="infopaneltitle-for-propdef-white-space" style="display:none">Info about the 'white-space' definition.</span><b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">7. 
 Shorthand for White Space and Wrapping: the white-space property</a> <a href="#ref-for-propdef-white-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphenate-character">
-   <b><a href="#propdef-hyphenate-character">#propdef-hyphenate-character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphenate-character" class="dfn-panel" data-for="propdef-hyphenate-character" id="infopanel-for-propdef-hyphenate-character" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphenate-character" style="display:none">Info about the 'hyphenate-character' definition.</span><b><a href="#propdef-hyphenate-character">#propdef-hyphenate-character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphenate-character">8.1. 
 Hyphens: the hyphenate-character property</a> <a href="#ref-for-propdef-hyphenate-character①">(2)</a> <a href="#ref-for-propdef-hyphenate-character②">(3)</a>
     <li><a href="#ref-for-propdef-hyphenate-character③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-hyphenate-character-auto">
-   <b><a href="#valdef-hyphenate-character-auto">#valdef-hyphenate-character-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-hyphenate-character-auto" class="dfn-panel" data-for="valdef-hyphenate-character-auto" id="infopanel-for-valdef-hyphenate-character-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-hyphenate-character-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-hyphenate-character-auto">#valdef-hyphenate-character-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-hyphenate-character-auto">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphenate-limit-zone">
-   <b><a href="#propdef-hyphenate-limit-zone">#propdef-hyphenate-limit-zone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphenate-limit-zone" class="dfn-panel" data-for="propdef-hyphenate-limit-zone" id="infopanel-for-propdef-hyphenate-limit-zone" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphenate-limit-zone" style="display:none">Info about the 'hyphenate-limit-zone' definition.</span><b><a href="#propdef-hyphenate-limit-zone">#propdef-hyphenate-limit-zone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphenate-limit-zone">8.2. 
 Hyphenation Size Limit: the hyphenate-limit-zone property</a> <a href="#ref-for-propdef-hyphenate-limit-zone①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphenate-limit-chars">
-   <b><a href="#propdef-hyphenate-limit-chars">#propdef-hyphenate-limit-chars</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphenate-limit-chars" class="dfn-panel" data-for="propdef-hyphenate-limit-chars" id="infopanel-for-propdef-hyphenate-limit-chars" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphenate-limit-chars" style="display:none">Info about the 'hyphenate-limit-chars' definition.</span><b><a href="#propdef-hyphenate-limit-chars">#propdef-hyphenate-limit-chars</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphenate-limit-chars">8.3. 
 Hyphenation Character Limits: the hyphenate-limit-chars property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-hyphenate-limit-chars-auto">
-   <b><a href="#valdef-hyphenate-limit-chars-auto">#valdef-hyphenate-limit-chars-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-hyphenate-limit-chars-auto" class="dfn-panel" data-for="valdef-hyphenate-limit-chars-auto" id="infopanel-for-valdef-hyphenate-limit-chars-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-hyphenate-limit-chars-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-hyphenate-limit-chars-auto">#valdef-hyphenate-limit-chars-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-hyphenate-limit-chars-auto">8.3. 
 Hyphenation Character Limits: the hyphenate-limit-chars property</a> <a href="#ref-for-valdef-hyphenate-limit-chars-auto①">(2)</a> <a href="#ref-for-valdef-hyphenate-limit-chars-auto②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphenate-limit-lines">
-   <b><a href="#propdef-hyphenate-limit-lines">#propdef-hyphenate-limit-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphenate-limit-lines" class="dfn-panel" data-for="propdef-hyphenate-limit-lines" id="infopanel-for-propdef-hyphenate-limit-lines" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphenate-limit-lines" style="display:none">Info about the 'hyphenate-limit-lines' definition.</span><b><a href="#propdef-hyphenate-limit-lines">#propdef-hyphenate-limit-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphenate-limit-lines">8.4. 
 Hyphenation Line Limits: the hyphenate-limit-lines and hyphenate-limit-last properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-hyphenate-limit-last">
-   <b><a href="#propdef-hyphenate-limit-last">#propdef-hyphenate-limit-last</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-hyphenate-limit-last" class="dfn-panel" data-for="propdef-hyphenate-limit-last" id="infopanel-for-propdef-hyphenate-limit-last" role="dialog">
+   <span id="infopaneltitle-for-propdef-hyphenate-limit-last" style="display:none">Info about the 'hyphenate-limit-last' definition.</span><b><a href="#propdef-hyphenate-limit-last">#propdef-hyphenate-limit-last</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-hyphenate-limit-last">8.4. 
 Hyphenation Line Limits: the hyphenate-limit-lines and hyphenate-limit-last properties</a> <a href="#ref-for-propdef-hyphenate-limit-last①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-group-align">
-   <b><a href="#propdef-text-group-align">#propdef-text-group-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-group-align" class="dfn-panel" data-for="propdef-text-group-align" id="infopanel-for-propdef-text-group-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-group-align" style="display:none">Info about the 'text-group-align' definition.</span><b><a href="#propdef-text-group-align">#propdef-text-group-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-group-align">9.3. 
 Aligning a block of text within its container: the text-group-align property</a>
     <li><a href="#ref-for-propdef-text-group-align①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="group-alignment">
-   <b><a href="#group-alignment">#group-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-group-alignment" class="dfn-panel" data-for="group-alignment" id="infopanel-for-group-alignment" role="dialog">
+   <span id="infopaneltitle-for-group-alignment" style="display:none">Info about the 'Group alignment' definition.</span><b><a href="#group-alignment">#group-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group-alignment">9.3. 
 Aligning a block of text within its container: the text-group-align property</a> <a href="#ref-for-group-alignment①">(2)</a> <a href="#ref-for-group-alignment②">(3)</a> <a href="#ref-for-group-alignment③">(4)</a> <a href="#ref-for-group-alignment④">(5)</a> <a href="#ref-for-group-alignment⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-padding">
-   <b><a href="#propdef-line-padding">#propdef-line-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-padding" class="dfn-panel" data-for="propdef-line-padding" id="infopanel-for-propdef-line-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-padding" style="display:none">Info about the 'line-padding' definition.</span><b><a href="#propdef-line-padding">#propdef-line-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-padding">10.1. 
 Line Start/End Padding: the line-padding property</a>
     <li><a href="#ref-for-propdef-line-padding①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-spacing">
-   <b><a href="#propdef-text-spacing">#propdef-text-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-spacing" class="dfn-panel" data-for="propdef-text-spacing" id="infopanel-for-propdef-text-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-spacing" style="display:none">Info about the 'text-spacing' definition.</span><b><a href="#propdef-text-spacing">#propdef-text-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-spacing">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-propdef-text-spacing①">(2)</a> <a href="#ref-for-propdef-text-spacing②">(3)</a>
@@ -4966,15 +4966,15 @@ Fullwidth Punctuation Collapsing</a> <a href="#ref-for-propdef-text-spacing④">
     <li><a href="#ref-for-propdef-text-spacing⑤"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-normal">
-   <b><a href="#valdef-text-spacing-normal">#valdef-text-spacing-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-normal" class="dfn-panel" data-for="valdef-text-spacing-normal" id="infopanel-for-valdef-text-spacing-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-text-spacing-normal">#valdef-text-spacing-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-normal">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-none">
-   <b><a href="#valdef-text-spacing-none">#valdef-text-spacing-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-none" class="dfn-panel" data-for="valdef-text-spacing-none" id="infopanel-for-valdef-text-spacing-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-spacing-none">#valdef-text-spacing-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-none">10.2. 
 Character Class Spacing: the text-spacing property</a>
@@ -4982,50 +4982,50 @@ Character Class Spacing: the text-spacing property</a>
 Fullwidth Punctuation Collapsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-space-start">
-   <b><a href="#valdef-text-spacing-space-start">#valdef-text-spacing-space-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-space-start" class="dfn-panel" data-for="valdef-text-spacing-space-start" id="infopanel-for-valdef-text-spacing-space-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-space-start" style="display:none">Info about the 'space-start' definition.</span><b><a href="#valdef-text-spacing-space-start">#valdef-text-spacing-space-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-space-start">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-trim-start">
-   <b><a href="#valdef-text-spacing-trim-start">#valdef-text-spacing-trim-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-trim-start" class="dfn-panel" data-for="valdef-text-spacing-trim-start" id="infopanel-for-valdef-text-spacing-trim-start" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-trim-start" style="display:none">Info about the 'trim-start' definition.</span><b><a href="#valdef-text-spacing-trim-start">#valdef-text-spacing-trim-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-trim-start">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-valdef-text-spacing-trim-start①">(2)</a> <a href="#ref-for-valdef-text-spacing-trim-start②">(3)</a> <a href="#ref-for-valdef-text-spacing-trim-start③">(4)</a> <a href="#ref-for-valdef-text-spacing-trim-start④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-space-first">
-   <b><a href="#valdef-text-spacing-space-first">#valdef-text-spacing-space-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-space-first" class="dfn-panel" data-for="valdef-text-spacing-space-first" id="infopanel-for-valdef-text-spacing-space-first" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-space-first" style="display:none">Info about the 'space-first' definition.</span><b><a href="#valdef-text-spacing-space-first">#valdef-text-spacing-space-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-space-first">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-space-end">
-   <b><a href="#valdef-text-spacing-space-end">#valdef-text-spacing-space-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-space-end" class="dfn-panel" data-for="valdef-text-spacing-space-end" id="infopanel-for-valdef-text-spacing-space-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-space-end" style="display:none">Info about the 'space-end' definition.</span><b><a href="#valdef-text-spacing-space-end">#valdef-text-spacing-space-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-space-end">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-trim-end">
-   <b><a href="#valdef-text-spacing-trim-end">#valdef-text-spacing-trim-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-trim-end" class="dfn-panel" data-for="valdef-text-spacing-trim-end" id="infopanel-for-valdef-text-spacing-trim-end" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-trim-end" style="display:none">Info about the 'trim-end' definition.</span><b><a href="#valdef-text-spacing-trim-end">#valdef-text-spacing-trim-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-trim-end">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-spacing-space-adjacent">
-   <b><a href="#valdef-text-spacing-space-adjacent">#valdef-text-spacing-space-adjacent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-spacing-space-adjacent" class="dfn-panel" data-for="valdef-text-spacing-space-adjacent" id="infopanel-for-valdef-text-spacing-space-adjacent" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-spacing-space-adjacent" style="display:none">Info about the 'space-adjacent' definition.</span><b><a href="#valdef-text-spacing-space-adjacent">#valdef-text-spacing-space-adjacent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-spacing-space-adjacent">10.2.1. 
 Fullwidth Punctuation Collapsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ideographs">
-   <b><a href="#ideographs">#ideographs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ideographs" class="dfn-panel" data-for="ideographs" id="infopanel-for-ideographs" role="dialog">
+   <span id="infopaneltitle-for-ideographs" style="display:none">Info about the 'ideographs' definition.</span><b><a href="#ideographs">#ideographs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ideographs">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-ideographs①">(2)</a>
@@ -5033,22 +5033,22 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-ideogra
 Text Spacing Character Classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-ideographic-letters">
-   <b><a href="#non-ideographic-letters">#non-ideographic-letters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-ideographic-letters" class="dfn-panel" data-for="non-ideographic-letters" id="infopanel-for-non-ideographic-letters" role="dialog">
+   <span id="infopaneltitle-for-non-ideographic-letters" style="display:none">Info about the 'non-ideographic letters' definition.</span><b><a href="#non-ideographic-letters">#non-ideographic-letters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-ideographic-letters">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-ideographic-numerals">
-   <b><a href="#non-ideographic-numerals">#non-ideographic-numerals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-ideographic-numerals" class="dfn-panel" data-for="non-ideographic-numerals" id="infopanel-for-non-ideographic-numerals" role="dialog">
+   <span id="infopaneltitle-for-non-ideographic-numerals" style="display:none">Info about the 'non-ideographic numerals' definition.</span><b><a href="#non-ideographic-numerals">#non-ideographic-numerals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-ideographic-numerals">10.2. 
 Character Class Spacing: the text-spacing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullwidth-opening-punctuation">
-   <b><a href="#fullwidth-opening-punctuation">#fullwidth-opening-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullwidth-opening-punctuation" class="dfn-panel" data-for="fullwidth-opening-punctuation" id="infopanel-for-fullwidth-opening-punctuation" role="dialog">
+   <span id="infopaneltitle-for-fullwidth-opening-punctuation" style="display:none">Info about the 'fullwidth opening punctuation' definition.</span><b><a href="#fullwidth-opening-punctuation">#fullwidth-opening-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullwidth-opening-punctuation">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-fullwidth-opening-punctuation①">(2)</a> <a href="#ref-for-fullwidth-opening-punctuation②">(3)</a>
@@ -5056,8 +5056,8 @@ Character Class Spacing: the text-spacing property</a> <a href="#ref-for-fullwid
 Fullwidth Punctuation Collapsing</a> <a href="#ref-for-fullwidth-opening-punctuation④">(2)</a> <a href="#ref-for-fullwidth-opening-punctuation⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullwidth-closing-punctuation">
-   <b><a href="#fullwidth-closing-punctuation">#fullwidth-closing-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullwidth-closing-punctuation" class="dfn-panel" data-for="fullwidth-closing-punctuation" id="infopanel-for-fullwidth-closing-punctuation" role="dialog">
+   <span id="infopaneltitle-for-fullwidth-closing-punctuation" style="display:none">Info about the 'fullwidth closing punctuation' definition.</span><b><a href="#fullwidth-closing-punctuation">#fullwidth-closing-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullwidth-closing-punctuation">10.2. 
 Character Class Spacing: the text-spacing property</a> <a href="#ref-for-fullwidth-closing-punctuation①">(2)</a> <a href="#ref-for-fullwidth-closing-punctuation②">(3)</a> <a href="#ref-for-fullwidth-closing-punctuation③">(4)</a>
@@ -5067,8 +5067,8 @@ Fullwidth Punctuation Collapsing</a> <a href="#ref-for-fullwidth-closing-punctua
 Text Spacing Character Classes</a> <a href="#ref-for-fullwidth-closing-punctuation⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullwidth-middle-dot-punctuation">
-   <b><a href="#fullwidth-middle-dot-punctuation">#fullwidth-middle-dot-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullwidth-middle-dot-punctuation" class="dfn-panel" data-for="fullwidth-middle-dot-punctuation" id="infopanel-for-fullwidth-middle-dot-punctuation" role="dialog">
+   <span id="infopaneltitle-for-fullwidth-middle-dot-punctuation" style="display:none">Info about the 'fullwidth middle dot punctuation' definition.</span><b><a href="#fullwidth-middle-dot-punctuation">#fullwidth-middle-dot-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullwidth-middle-dot-punctuation">10.2.1. 
 Fullwidth Punctuation Collapsing</a> <a href="#ref-for-fullwidth-middle-dot-punctuation①">(2)</a>
@@ -5076,15 +5076,15 @@ Fullwidth Punctuation Collapsing</a> <a href="#ref-for-fullwidth-middle-dot-punc
 Text Spacing Character Classes</a> <a href="#ref-for-fullwidth-middle-dot-punctuation③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullwidth-colon-punctuation">
-   <b><a href="#fullwidth-colon-punctuation">#fullwidth-colon-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullwidth-colon-punctuation" class="dfn-panel" data-for="fullwidth-colon-punctuation" id="infopanel-for-fullwidth-colon-punctuation" role="dialog">
+   <span id="infopaneltitle-for-fullwidth-colon-punctuation" style="display:none">Info about the 'fullwidth colon punctuation' definition.</span><b><a href="#fullwidth-colon-punctuation">#fullwidth-colon-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullwidth-colon-punctuation">10.2.2. 
 Text Spacing Character Classes</a> <a href="#ref-for-fullwidth-colon-punctuation①">(2)</a> <a href="#ref-for-fullwidth-colon-punctuation②">(3)</a> <a href="#ref-for-fullwidth-colon-punctuation③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullwidth-dot-punctuation">
-   <b><a href="#fullwidth-dot-punctuation">#fullwidth-dot-punctuation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullwidth-dot-punctuation" class="dfn-panel" data-for="fullwidth-dot-punctuation" id="infopanel-for-fullwidth-dot-punctuation" role="dialog">
+   <span id="infopaneltitle-for-fullwidth-dot-punctuation" style="display:none">Info about the 'fullwidth dot punctuation' definition.</span><b><a href="#fullwidth-dot-punctuation">#fullwidth-dot-punctuation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullwidth-dot-punctuation">10.2.2. 
 Text Spacing Character Classes</a> <a href="#ref-for-fullwidth-dot-punctuation①">(2)</a> <a href="#ref-for-fullwidth-dot-punctuation②">(3)</a> <a href="#ref-for-fullwidth-dot-punctuation③">(4)</a>
@@ -5092,59 +5092,115 @@ Text Spacing Character Classes</a> <a href="#ref-for-fullwidth-dot-punctuation�
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-text-decor-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-decor-3/Overview.html
@@ -1603,36 +1603,36 @@ Changes</span><a class="self-link" href="#changes"></a></h2>
     </ul>
    <li><a href="#valdef-text-decoration-line-underline">underline</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-box-shadow">https://www.w3.org/TR/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-box-shadow">https://www.w3.org/TR/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">4. 
 Text Shadows: the text-shadow property</a> <a href="#ref-for-propdef-box-shadow①">(2)</a> <a href="#ref-for-propdef-box-shadow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadow-inset">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#shadow-inset">https://www.w3.org/TR/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadow-inset" class="dfn-panel" data-for="term-for-shadow-inset" id="infopanel-for-term-for-shadow-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-shadow-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#shadow-inset">https://www.w3.org/TR/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-inset">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-shadow-none">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#box-shadow-none">https://www.w3.org/TR/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-shadow-none" class="dfn-panel" data-for="term-for-box-shadow-none" id="infopanel-for-term-for-box-shadow-none" role="menu">
+   <span id="infopaneltitle-for-term-for-box-shadow-none" style="display:none">Info about the 'none' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#box-shadow-none">https://www.w3.org/TR/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-shadow-none">4. 
 Text Shadows: the text-shadow property</a> <a href="#ref-for-box-shadow-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://www.w3.org/TR/css-break-3/#fragment">https://www.w3.org/TR/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://www.w3.org/TR/css-break-3/#fragment">https://www.w3.org/TR/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2.3. 
 Text Decoration Color: the text-decoration-color property</a>
@@ -1642,8 +1642,8 @@ Emphasis Mark Color: the text-emphasis-color property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">3.2. 
 Emphasis Mark Color: the text-emphasis-color property</a>
@@ -1651,36 +1651,36 @@ Emphasis Mark Color: the text-emphasis-color property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://www.w3.org/TR/css-display-3/#anonymous">https://www.w3.org/TR/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#anonymous">https://www.w3.org/TR/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://www.w3.org/TR/css-display-3/#atomic-inline">https://www.w3.org/TR/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#atomic-inline">https://www.w3.org/TR/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://www.w3.org/TR/css-display-3/#block-container">https://www.w3.org/TR/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#block-container">https://www.w3.org/TR/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-block-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://www.w3.org/TR/css-display-3/#block-level">https://www.w3.org/TR/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#block-level">https://www.w3.org/TR/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://www.w3.org/TR/css-display-3/#box">https://www.w3.org/TR/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#box">https://www.w3.org/TR/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
@@ -1688,94 +1688,94 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
 Overflow of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://www.w3.org/TR/css-display-3/#propdef-display">https://www.w3.org/TR/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#propdef-display">https://www.w3.org/TR/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://www.w3.org/TR/css-display-3/#in-flow">https://www.w3.org/TR/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#in-flow">https://www.w3.org/TR/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-in-flow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://www.w3.org/TR/css-display-3/#inline-box">https://www.w3.org/TR/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#inline-box">https://www.w3.org/TR/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-inline-box①">(2)</a> <a href="#ref-for-inline-box②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://www.w3.org/TR/css-display-3/#inline-formatting-context">https://www.w3.org/TR/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#inline-formatting-context">https://www.w3.org/TR/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://www.w3.org/TR/css-display-3/#inline-level">https://www.w3.org/TR/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#inline-level">https://www.w3.org/TR/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://www.w3.org/TR/css-display-3/#non-replaced">https://www.w3.org/TR/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#non-replaced">https://www.w3.org/TR/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://www.w3.org/TR/css-display-3/#propdef-visibility">https://www.w3.org/TR/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#propdef-visibility">https://www.w3.org/TR/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant-position">
-   <a href="https://www.w3.org/TR/css-fonts-4/#propdef-font-variant-position">https://www.w3.org/TR/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant-position" class="dfn-panel" data-for="term-for-propdef-font-variant-position" id="infopanel-for-term-for-propdef-font-variant-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant-position" style="display:none">Info about the 'font-variant-position' external reference.</span><a href="https://www.w3.org/TR/css-fonts-4/#propdef-font-variant-position">https://www.w3.org/TR/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-position">2.5. 
 Text Underline Position: the text-underline-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-variant-east-asian-ruby">
-   <a href="https://www.w3.org/TR/css-fonts-4/#valdef-font-variant-east-asian-ruby">https://www.w3.org/TR/css-fonts-4/#valdef-font-variant-east-asian-ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-variant-east-asian-ruby" class="dfn-panel" data-for="term-for-valdef-font-variant-east-asian-ruby" id="infopanel-for-term-for-valdef-font-variant-east-asian-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-variant-east-asian-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://www.w3.org/TR/css-fonts-4/#valdef-font-variant-east-asian-ruby">https://www.w3.org/TR/css-fonts-4/#valdef-font-variant-east-asian-ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-east-asian-ruby">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
     <li><a href="#ref-for-valdef-font-variant-east-asian-ruby①"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline">
-   <a href="https://www.w3.org/TR/css-inline-3/#valdef-alignment-baseline-baseline">https://www.w3.org/TR/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline" id="infopanel-for-term-for-valdef-alignment-baseline-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" style="display:none">Info about the 'baseline' external reference.</span><a href="https://www.w3.org/TR/css-inline-3/#valdef-alignment-baseline-baseline">https://www.w3.org/TR/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-baseline">2.5. 
 Text Underline Position: the text-underline-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://www.w3.org/TR/css-inline-3/#propdef-vertical-align">https://www.w3.org/TR/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://www.w3.org/TR/css-inline-3/#propdef-vertical-align">https://www.w3.org/TR/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">2.5. 
 Text Underline Position: the text-underline-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://www.w3.org/TR/css-overflow-3/#ink-overflow">https://www.w3.org/TR/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://www.w3.org/TR/css-overflow-3/#ink-overflow">https://www.w3.org/TR/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">5.2. 
 Overflow of Text Decorations</a>
     <li><a href="#ref-for-ink-overflow①"> Changes since the July 2018 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://www.w3.org/TR/css-overflow-3/#scrollable-overflow-region">https://www.w3.org/TR/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow area' external reference.</span><a href="https://www.w3.org/TR/css-overflow-3/#scrollable-overflow-region">https://www.w3.org/TR/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">4. 
 Text Shadows: the text-shadow property</a>
@@ -1783,51 +1783,51 @@ Text Shadows: the text-shadow property</a>
 Overflow of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-box">
-   <a href="https://www.w3.org/TR/css-ruby-1/#ruby-annotation-box">https://www.w3.org/TR/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-box" class="dfn-panel" data-for="term-for-ruby-annotation-box" id="infopanel-for-term-for-ruby-annotation-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-box" style="display:none">Info about the 'ruby annotation' external reference.</span><a href="https://www.w3.org/TR/css-ruby-1/#ruby-annotation-box">https://www.w3.org/TR/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-box">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
     <li><a href="#ref-for-ruby-annotation-box①"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-box">
-   <a href="https://www.w3.org/TR/css-ruby-1/#ruby-base-box">https://www.w3.org/TR/css-ruby-1/#ruby-base-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-box" class="dfn-panel" data-for="term-for-ruby-base-box" id="infopanel-for-term-for-ruby-base-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-box" style="display:none">Info about the 'ruby base' external reference.</span><a href="https://www.w3.org/TR/css-ruby-1/#ruby-base-box">https://www.w3.org/TR/css-ruby-1/#ruby-base-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-container">
-   <a href="https://www.w3.org/TR/css-ruby-1/#ruby-container">https://www.w3.org/TR/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-container" class="dfn-panel" data-for="term-for-ruby-container" id="infopanel-for-term-for-ruby-container" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-container" style="display:none">Info about the 'ruby container' external reference.</span><a href="https://www.w3.org/TR/css-ruby-1/#ruby-container">https://www.w3.org/TR/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-container">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://www.w3.org/TR/css-text-4/#typographic-character-unit">https://www.w3.org/TR/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://www.w3.org/TR/css-text-4/#typographic-character-unit">https://www.w3.org/TR/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-decoration-style-wavy">
-   <a href="https://www.w3.org/TR/css-text-decor-4/#valdef-text-decoration-style-wavy">https://www.w3.org/TR/css-text-decor-4/#valdef-text-decoration-style-wavy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-decoration-style-wavy" class="dfn-panel" data-for="term-for-valdef-text-decoration-style-wavy" id="infopanel-for-term-for-valdef-text-decoration-style-wavy" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-decoration-style-wavy" style="display:none">Info about the 'wavy' external reference.</span><a href="https://www.w3.org/TR/css-text-decor-4/#valdef-text-decoration-style-wavy">https://www.w3.org/TR/css-text-decor-4/#valdef-text-decoration-style-wavy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-style-wavy">2.2. 
 Text Decoration Style: the text-decoration-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-comma">https://www.w3.org/TR/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-comma">https://www.w3.org/TR/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-all">https://www.w3.org/TR/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-all">https://www.w3.org/TR/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
@@ -1835,22 +1835,22 @@ Emphasis Mark Position: the text-emphasis-position property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://www.w3.org/TR/css-values-4/#string-value">https://www.w3.org/TR/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#string-value">https://www.w3.org/TR/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
@@ -1858,22 +1858,22 @@ Emphasis Mark Position: the text-emphasis-position property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-num-range">https://www.w3.org/TR/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-num-range">https://www.w3.org/TR/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -1889,8 +1889,8 @@ Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-fo
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
@@ -1904,20 +1904,20 @@ Emphasis Mark Style: the text-emphasis-style property</a>
 Emphasis Mark Shorthand: the text-emphasis property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr" id="infopanel-for-term-for-valdef-writing-mode-sideways-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" style="display:none">Info about the 'sideways-lr' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-lr"> Changes since the August 2013 Candidate Recommendation</a> <a href="#ref-for-valdef-writing-mode-sideways-lr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-rl">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-rl">https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-sideways-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-rl" id="infopanel-for-term-for-valdef-writing-mode-sideways-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-sideways-rl" style="display:none">Info about the 'sideways-rl' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-rl">https://www.w3.org/TR/css-writing-modes-4/#valdef-writing-mode-sideways-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-rl"> Changes since the August 2013 Candidate Recommendation</a> <a href="#ref-for-valdef-writing-mode-sideways-rl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-mode">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#typographic-mode">https://www.w3.org/TR/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-mode" class="dfn-panel" data-for="term-for-typographic-mode" id="infopanel-for-term-for-typographic-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-mode" style="display:none">Info about the 'typographic mode' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#typographic-mode">https://www.w3.org/TR/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">2.5. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-typographic-mode①">(2)</a> <a href="#ref-for-typographic-mode②">(3)</a> <a href="#ref-for-typographic-mode③">(4)</a> <a href="#ref-for-typographic-mode④">(5)</a>
@@ -1928,42 +1928,42 @@ Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-fo
     <li><a href="#ref-for-typographic-mode①③"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-under">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#under">https://www.w3.org/TR/css-writing-modes-4/#under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-under" class="dfn-panel" data-for="term-for-under" id="infopanel-for-term-for-under" role="menu">
+   <span id="infopaneltitle-for-term-for-under" style="display:none">Info about the 'under' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#under">https://www.w3.org/TR/css-writing-modes-4/#under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">2.5. 
 Text Underline Position: the text-underline-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#vertical-writing-mode">https://www.w3.org/TR/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#vertical-writing-mode">https://www.w3.org/TR/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#writing-mode">https://www.w3.org/TR/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#writing-mode">https://www.w3.org/TR/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#propdef-writing-mode">https://www.w3.org/TR/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#propdef-writing-mode">https://www.w3.org/TR/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-del-element">
-   <a href="https://html.spec.whatwg.org/multipage/edits.html#the-del-element">https://html.spec.whatwg.org/multipage/edits.html#the-del-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-del-element" class="dfn-panel" data-for="term-for-the-del-element" id="infopanel-for-term-for-the-del-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-del-element" style="display:none">Info about the 'del' external reference.</span><a href="https://html.spec.whatwg.org/multipage/edits.html#the-del-element">https://html.spec.whatwg.org/multipage/edits.html#the-del-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-del-element">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ins-element">
-   <a href="https://html.spec.whatwg.org/multipage/edits.html#the-ins-element">https://html.spec.whatwg.org/multipage/edits.html#the-ins-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ins-element" class="dfn-panel" data-for="term-for-the-ins-element" id="infopanel-for-term-for-the-ins-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ins-element" style="display:none">Info about the 'ins' external reference.</span><a href="https://html.spec.whatwg.org/multipage/edits.html#the-ins-element">https://html.spec.whatwg.org/multipage/edits.html#the-ins-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ins-element">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
@@ -2246,15 +2246,15 @@ plus a computed color
    <div class="issue"> If you find any issues, recommendations to add, or corrections,
 		please send the information to <a href="mailto:www-style@w3.org">www-style@w3.org</a> with <kbd>[css-text-decor]</kbd> in the subject line. <a class="issue-return" href="#issue-4a420eee" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="character">
-   <b><a href="#character">#character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character" class="dfn-panel" data-for="character" id="infopanel-for-character" role="dialog">
+   <span id="infopaneltitle-for-character" style="display:none">Info about the 'character' definition.</span><b><a href="#character">#character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-character①">(2)</a> <a href="#ref-for-character②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decorating-box">
-   <b><a href="#decorating-box">#decorating-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decorating-box" class="dfn-panel" data-for="decorating-box" id="infopanel-for-decorating-box" role="dialog">
+   <span id="infopaneltitle-for-decorating-box" style="display:none">Info about the 'decorating box' definition.</span><b><a href="#decorating-box">#decorating-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decorating-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-decorating-box①">(2)</a> <a href="#ref-for-decorating-box②">(3)</a>
@@ -2262,8 +2262,8 @@ Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-d
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-decorating-box④">(2)</a> <a href="#ref-for-decorating-box⑤">(3)</a> <a href="#ref-for-decorating-box⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-line">
-   <b><a href="#propdef-text-decoration-line">#propdef-text-decoration-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-line" class="dfn-panel" data-for="propdef-text-decoration-line" id="infopanel-for-propdef-text-decoration-line" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-line" style="display:none">Info about the 'text-decoration-line' definition.</span><b><a href="#propdef-text-decoration-line">#propdef-text-decoration-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-line">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -2274,8 +2274,8 @@ Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-pr
     <li><a href="#ref-for-propdef-text-decoration-line④"> Appendix B: Default UA Stylesheet</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-style">
-   <b><a href="#propdef-text-decoration-style">#propdef-text-decoration-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-style" class="dfn-panel" data-for="propdef-text-decoration-style" id="infopanel-for-propdef-text-decoration-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-style" style="display:none">Info about the 'text-decoration-style' definition.</span><b><a href="#propdef-text-decoration-style">#propdef-text-decoration-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-style">2.2. 
 Text Decoration Style: the text-decoration-style property</a>
@@ -2283,8 +2283,8 @@ Text Decoration Style: the text-decoration-style property</a>
 Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-propdef-text-decoration-style②">(2)</a> <a href="#ref-for-propdef-text-decoration-style③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-color">
-   <b><a href="#propdef-text-decoration-color">#propdef-text-decoration-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-color" class="dfn-panel" data-for="propdef-text-decoration-color" id="infopanel-for-propdef-text-decoration-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-color" style="display:none">Info about the 'text-decoration-color' definition.</span><b><a href="#propdef-text-decoration-color">#propdef-text-decoration-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-color">2.3. 
 Text Decoration Color: the text-decoration-color property</a>
@@ -2292,8 +2292,8 @@ Text Decoration Color: the text-decoration-color property</a>
 Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-propdef-text-decoration-color②">(2)</a> <a href="#ref-for-propdef-text-decoration-color③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration">
-   <b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration" class="dfn-panel" data-for="propdef-text-decoration" id="infopanel-for-propdef-text-decoration" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' definition.</span><b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">2.4. 
 Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-propdef-text-decoration①">(2)</a> <a href="#ref-for-propdef-text-decoration②">(3)</a>
@@ -2303,8 +2303,8 @@ Text Underline Position: the text-underline-position property</a>
 Painting Order of Text Decorations</a> <a href="#ref-for-propdef-text-decoration⑤">(2)</a> <a href="#ref-for-propdef-text-decoration⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-underline-position">
-   <b><a href="#propdef-text-underline-position">#propdef-text-underline-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-underline-position" class="dfn-panel" data-for="propdef-text-underline-position" id="infopanel-for-propdef-text-underline-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-underline-position" style="display:none">Info about the 'text-underline-position' definition.</span><b><a href="#propdef-text-underline-position">#propdef-text-underline-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-underline-position">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -2316,40 +2316,40 @@ Text Underline Position: the text-underline-position property</a> <a href="#ref-
     <li><a href="#ref-for-propdef-text-underline-position⑦"> Changes since the August 2013 Candidate Recommendation</a> <a href="#ref-for-propdef-text-underline-position⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-auto">
-   <b><a href="#underline-auto">#underline-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-auto" class="dfn-panel" data-for="underline-auto" id="infopanel-for-underline-auto" role="dialog">
+   <span id="infopaneltitle-for-underline-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#underline-auto">#underline-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-auto">2.5. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-auto①">(2)</a>
     <li><a href="#ref-for-underline-auto②"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-under">
-   <b><a href="#underline-under">#underline-under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-under" class="dfn-panel" data-for="underline-under" id="infopanel-for-underline-under" role="dialog">
+   <span id="infopaneltitle-for-underline-under" style="display:none">Info about the 'under' definition.</span><b><a href="#underline-under">#underline-under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-under">2.5. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-under①">(2)</a> <a href="#ref-for-underline-under②">(3)</a> <a href="#ref-for-underline-under③">(4)</a>
     <li><a href="#ref-for-underline-under④"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-left">
-   <b><a href="#underline-left">#underline-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-left" class="dfn-panel" data-for="underline-left" id="infopanel-for-underline-left" role="dialog">
+   <span id="infopaneltitle-for-underline-left" style="display:none">Info about the 'left' definition.</span><b><a href="#underline-left">#underline-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-left">2.5. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-left①">(2)</a> <a href="#ref-for-underline-left②">(3)</a> <a href="#ref-for-underline-left③">(4)</a>
     <li><a href="#ref-for-underline-left④"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-right">
-   <b><a href="#underline-right">#underline-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-right" class="dfn-panel" data-for="underline-right" id="infopanel-for-underline-right" role="dialog">
+   <span id="infopaneltitle-for-underline-right" style="display:none">Info about the 'right' definition.</span><b><a href="#underline-right">#underline-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-right">2.5. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-right①">(2)</a> <a href="#ref-for-underline-right②">(3)</a> <a href="#ref-for-underline-right③">(4)</a>
     <li><a href="#ref-for-underline-right④"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-style">
-   <b><a href="#propdef-text-emphasis-style">#propdef-text-emphasis-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-style" class="dfn-panel" data-for="propdef-text-emphasis-style" id="infopanel-for-propdef-text-emphasis-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-style" style="display:none">Info about the 'text-emphasis-style' definition.</span><b><a href="#propdef-text-emphasis-style">#propdef-text-emphasis-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-style">3. 
 Emphasis Marks</a>
@@ -2359,43 +2359,43 @@ Emphasis Mark Style: the text-emphasis-style property</a>
 Emphasis Mark Shorthand: the text-emphasis property</a> <a href="#ref-for-propdef-text-emphasis-style③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-none">
-   <b><a href="#valdef-text-emphasis-style-none">#valdef-text-emphasis-style-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-none" class="dfn-panel" data-for="valdef-text-emphasis-style-none" id="infopanel-for-valdef-text-emphasis-style-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-emphasis-style-none">#valdef-text-emphasis-style-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-none">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-filled">
-   <b><a href="#valdef-text-emphasis-style-filled">#valdef-text-emphasis-style-filled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-filled" class="dfn-panel" data-for="valdef-text-emphasis-style-filled" id="infopanel-for-valdef-text-emphasis-style-filled" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-filled" style="display:none">Info about the 'filled' definition.</span><b><a href="#valdef-text-emphasis-style-filled">#valdef-text-emphasis-style-filled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-filled">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-valdef-text-emphasis-style-filled①">(2)</a> <a href="#ref-for-valdef-text-emphasis-style-filled②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-text-emphasis-open">
-   <b><a href="#valdef-text-text-emphasis-open">#valdef-text-text-emphasis-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-text-emphasis-open" class="dfn-panel" data-for="valdef-text-text-emphasis-open" id="infopanel-for-valdef-text-text-emphasis-open" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-text-emphasis-open" style="display:none">Info about the 'open' definition.</span><b><a href="#valdef-text-text-emphasis-open">#valdef-text-text-emphasis-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-text-emphasis-open">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-valdef-text-text-emphasis-open①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-circle">
-   <b><a href="#valdef-text-emphasis-style-circle">#valdef-text-emphasis-style-circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-circle" class="dfn-panel" data-for="valdef-text-emphasis-style-circle" id="infopanel-for-valdef-text-emphasis-style-circle" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-circle" style="display:none">Info about the 'circle' definition.</span><b><a href="#valdef-text-emphasis-style-circle">#valdef-text-emphasis-style-circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-circle">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-sesame">
-   <b><a href="#valdef-text-emphasis-style-sesame">#valdef-text-emphasis-style-sesame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-sesame" class="dfn-panel" data-for="valdef-text-emphasis-style-sesame" id="infopanel-for-valdef-text-emphasis-style-sesame" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-sesame" style="display:none">Info about the 'sesame' definition.</span><b><a href="#valdef-text-emphasis-style-sesame">#valdef-text-emphasis-style-sesame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-sesame">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-color">
-   <b><a href="#propdef-text-emphasis-color">#propdef-text-emphasis-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-color" class="dfn-panel" data-for="propdef-text-emphasis-color" id="infopanel-for-propdef-text-emphasis-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-color" style="display:none">Info about the 'text-emphasis-color' definition.</span><b><a href="#propdef-text-emphasis-color">#propdef-text-emphasis-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-color">3. 
 Emphasis Marks</a>
@@ -2405,8 +2405,8 @@ Emphasis Mark Color: the text-emphasis-color property</a> <a href="#ref-for-prop
 Emphasis Mark Shorthand: the text-emphasis property</a> <a href="#ref-for-propdef-text-emphasis-color④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis">
-   <b><a href="#propdef-text-emphasis">#propdef-text-emphasis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis" class="dfn-panel" data-for="propdef-text-emphasis" id="infopanel-for-propdef-text-emphasis" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis" style="display:none">Info about the 'text-emphasis' definition.</span><b><a href="#propdef-text-emphasis">#propdef-text-emphasis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis">3. 
 Emphasis Marks</a>
@@ -2417,8 +2417,8 @@ Painting Order of Text Decorations</a>
     <li><a href="#ref-for-propdef-text-emphasis③"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-position">
-   <b><a href="#propdef-text-emphasis-position">#propdef-text-emphasis-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-position" class="dfn-panel" data-for="propdef-text-emphasis-position" id="infopanel-for-propdef-text-emphasis-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-position" style="display:none">Info about the 'text-emphasis-position' definition.</span><b><a href="#propdef-text-emphasis-position">#propdef-text-emphasis-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-position">3. 
 Emphasis Marks</a>
@@ -2429,16 +2429,16 @@ Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-fo
     <li><a href="#ref-for-propdef-text-emphasis-position④"> Changes since the August 2013 Candidate Recommendation</a> <a href="#ref-for-propdef-text-emphasis-position⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-position-right">
-   <b><a href="#valdef-text-emphasis-position-right">#valdef-text-emphasis-position-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-position-right" class="dfn-panel" data-for="valdef-text-emphasis-position-right" id="infopanel-for-valdef-text-emphasis-position-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-position-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-text-emphasis-position-right">#valdef-text-emphasis-position-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-position-right">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
     <li><a href="#ref-for-valdef-text-emphasis-position-right①"> Changes since the August 2013 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-shadow">
-   <b><a href="#propdef-text-shadow">#propdef-text-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-shadow" class="dfn-panel" data-for="propdef-text-shadow" id="infopanel-for-propdef-text-shadow" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' definition.</span><b><a href="#propdef-text-shadow">#propdef-text-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
@@ -2451,57 +2451,113 @@ Painting Order of Text Decorations</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-text-decor-4/Overview.html
@@ -3168,36 +3168,36 @@ Changes</span><a class="self-link" href="#changes"></a></h2>
    <li><a href="#valdef-text-decoration-style-wavy">wavy</a><span>, in § 2.2</span>
    <li><a href="#underline-zero-position">zero position</a><span>, in § 2.8.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">4. 
 Text Shadows: the text-shadow property</a> <a href="#ref-for-propdef-box-shadow①">(2)</a> <a href="#ref-for-propdef-box-shadow②">(3)</a> <a href="#ref-for-propdef-box-shadow③">(4)</a> <a href="#ref-for-propdef-box-shadow④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadow-inset">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#shadow-inset">https://drafts.csswg.org/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadow-inset" class="dfn-panel" data-for="term-for-shadow-inset" id="infopanel-for-term-for-shadow-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-shadow-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#shadow-inset">https://drafts.csswg.org/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-inset">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-shadow-none">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none">https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-shadow-none" class="dfn-panel" data-for="term-for-box-shadow-none" id="infopanel-for-term-for-box-shadow-none" role="menu">
+   <span id="infopaneltitle-for-term-for-box-shadow-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none">https://drafts.csswg.org/css-backgrounds-3/#box-shadow-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-shadow-none">4. 
 Text Shadows: the text-shadow property</a> <a href="#ref-for-box-shadow-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
@@ -3213,15 +3213,15 @@ Text Underline Position: the text-underline-position property</a>
 Text Underline Offset: the text-underline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand①" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand①" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-longhand①">(2)</a> <a href="#ref-for-longhand②">(3)</a>
@@ -3237,15 +3237,15 @@ Text Underline Position: the text-underline-position property</a>
 Text Underline Offset: the text-underline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2.3. 
 Text Decoration Color: the text-decoration-color property</a>
@@ -3255,8 +3255,8 @@ Emphasis Mark Color: the text-emphasis-color property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">3.2. 
 Emphasis Mark Color: the text-emphasis-color property</a>
@@ -3264,36 +3264,36 @@ Emphasis Mark Color: the text-emphasis-color property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous">
-   <a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous" class="dfn-panel" data-for="term-for-anonymous" id="infopanel-for-term-for-anonymous" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous" style="display:none">Info about the 'anonymous' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#anonymous">https://drafts.csswg.org/css-display-3/#anonymous</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-atomic-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-atomic-inline" class="dfn-panel" data-for="term-for-atomic-inline" id="infopanel-for-term-for-atomic-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-atomic-inline" style="display:none">Info about the 'atomic inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#atomic-inline">https://drafts.csswg.org/css-display-3/#atomic-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-inline">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-atomic-inline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-block-container①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
@@ -3301,57 +3301,57 @@ Line Decoration: Underline, Overline, and Strike-Through</a>
 Overflow of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-in-flow①">(2)</a> <a href="#ref-for-in-flow②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-inline-box①">(2)</a> <a href="#ref-for-inline-box②">(3)</a> <a href="#ref-for-inline-box③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-replaced">
-   <a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-replaced" class="dfn-panel" data-for="term-for-non-replaced" id="infopanel-for-term-for-non-replaced" role="menu">
+   <span id="infopaneltitle-for-term-for-non-replaced" style="display:none">Info about the 'non-replaced' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#non-replaced">https://drafts.csswg.org/css-display-3/#non-replaced</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-replaced">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-non-replaced①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-available-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-available-font" class="dfn-panel" data-for="term-for-first-available-font" id="infopanel-for-term-for-first-available-font" role="menu">
+   <span id="infopaneltitle-for-term-for-first-available-font" style="display:none">Info about the 'first available font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#first-available-font">https://drafts.csswg.org/css-fonts-4/#first-available-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-available-font">2.4. 
 Text Decoration Line Thickness: the text-decoration-thickness property</a>
@@ -3359,29 +3359,29 @@ Text Decoration Line Thickness: the text-decoration-thickness property</a>
 Text Underline Position: the text-underline-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-propdef-font-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant-position">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant-position" class="dfn-panel" data-for="term-for-propdef-font-variant-position" id="infopanel-for-term-for-propdef-font-variant-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant-position" style="display:none">Info about the 'font-variant-position' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant-position">2.9. 
 Text Decoration Line Uniformity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-variant-east-asian-ruby">
-   <a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-variant-east-asian-ruby">https://drafts.csswg.org/css-fonts-4/#valdef-font-variant-east-asian-ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-variant-east-asian-ruby" class="dfn-panel" data-for="term-for-valdef-font-variant-east-asian-ruby" id="infopanel-for-term-for-valdef-font-variant-east-asian-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-variant-east-asian-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-variant-east-asian-ruby">https://drafts.csswg.org/css-fonts-4/#valdef-font-variant-east-asian-ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-east-asian-ruby">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline" id="infopanel-for-term-for-valdef-alignment-baseline-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" style="display:none">Info about the 'baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-baseline">2.5. 
 Determining the Position and Thickness of Line Decorations</a>
@@ -3389,8 +3389,8 @@ Determining the Position and Thickness of Line Decorations</a>
 Text Decoration Line Uniformity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-propdef-vertical-align①">(2)</a>
@@ -3398,15 +3398,15 @@ Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for
 Text Decoration Line Uniformity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ink-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ink-overflow" class="dfn-panel" data-for="term-for-ink-overflow" id="infopanel-for-term-for-ink-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-ink-overflow" style="display:none">Info about the 'ink overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#ink-overflow">https://drafts.csswg.org/css-overflow-3/#ink-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ink-overflow">5.2. 
 Overflow of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollable-overflow-region">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollable-overflow-region" class="dfn-panel" data-for="term-for-scrollable-overflow-region" id="infopanel-for-term-for-scrollable-overflow-region" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollable-overflow-region" style="display:none">Info about the 'scrollable overflow region' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region">https://drafts.csswg.org/css-overflow-3/#scrollable-overflow-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollable-overflow-region">4. 
 Text Shadows: the text-shadow property</a>
@@ -3414,69 +3414,69 @@ Text Shadows: the text-shadow property</a>
 Overflow of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-position">
-   <a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-position" class="dfn-panel" data-for="term-for-relative-position" id="infopanel-for-term-for-relative-position" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-position" style="display:none">Info about the 'relatively position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#relative-position">https://drafts.csswg.org/css-position-3/#relative-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-position">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-annotation-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-annotation-box" class="dfn-panel" data-for="term-for-ruby-annotation-box" id="infopanel-for-term-for-ruby-annotation-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-annotation-box" style="display:none">Info about the 'ruby annotation' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box">https://drafts.csswg.org/css-ruby-1/#ruby-annotation-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-annotation-box">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-base-box">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-base-box" class="dfn-panel" data-for="term-for-ruby-base-box" id="infopanel-for-term-for-ruby-base-box" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-base-box" style="display:none">Info about the 'ruby base' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-base-box">https://drafts.csswg.org/css-ruby-1/#ruby-base-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-base-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ruby-container">
-   <a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ruby-container" class="dfn-panel" data-for="term-for-ruby-container" id="infopanel-for-term-for-ruby-container" role="menu">
+   <span id="infopaneltitle-for-term-for-ruby-container" style="display:none">Info about the 'ruby container' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#ruby-container">https://drafts.csswg.org/css-ruby-1/#ruby-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ruby-container">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-letter">
-   <a href="https://drafts.csswg.org/css-syntax-3/#letter">https://drafts.csswg.org/css-syntax-3/#letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-letter" class="dfn-panel" data-for="term-for-letter" id="infopanel-for-term-for-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-letter" style="display:none">Info about the 'letter' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#letter">https://drafts.csswg.org/css-syntax-3/#letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-letter">1.3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">1.3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">2.10.4. 
 Skipping Spaces: the text-decoration-skip-spaces property</a> <a href="#ref-for-propdef-letter-spacing①">(2)</a> <a href="#ref-for-propdef-letter-spacing②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">1.3. Terminology</a>
     <li><a href="#ref-for-typographic-character-unit①">2.10.4. 
@@ -3487,28 +3487,28 @@ Emphasis Mark Style: the text-emphasis-style property</a>
 Emphasis Mark Skip: the text-emphasis-skip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-letter-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-letter-unit" class="dfn-panel" data-for="term-for-typographic-letter-unit" id="infopanel-for-term-for-typographic-letter-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-letter-unit" style="display:none">Info about the 'typographic letter unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-letter-unit">https://drafts.csswg.org/css-text-4/#typographic-letter-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-letter-unit">1.3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">2.10.4. 
 Skipping Spaces: the text-decoration-skip-spaces property</a> <a href="#ref-for-propdef-word-spacing①">(2)</a> <a href="#ref-for-propdef-word-spacing②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
@@ -3516,8 +3516,8 @@ Emphasis Mark Position: the text-emphasis-position property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2.4. 
 Text Decoration Line Thickness: the text-decoration-thickness property</a> <a href="#ref-for-length-value①">(2)</a>
@@ -3527,8 +3527,8 @@ Text Underline Offset: the text-underline-offset property</a> <a href="#ref-for-
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.4. 
 Text Decoration Line Thickness: the text-decoration-thickness property</a> <a href="#ref-for-percentage-value①">(2)</a>
@@ -3537,15 +3537,15 @@ Text Underline Offset: the text-underline-offset property</a> <a href="#ref-for-
     <li><a href="#ref-for-percentage-value④"> Changes since the 13 March 2018 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
@@ -3553,22 +3553,22 @@ Emphasis Mark Position: the text-emphasis-position property</a>
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">4. 
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
@@ -3600,8 +3600,8 @@ Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-fo
 Text Shadows: the text-shadow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
@@ -3619,8 +3619,8 @@ Emphasis Mark Shorthand: the text-emphasis property</a>
 Emphasis Mark Skip: the text-emphasis-skip property</a> <a href="#ref-for-comb-any①①">(2)</a> <a href="#ref-for-comb-any①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-over">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-over" class="dfn-panel" data-for="term-for-over" id="infopanel-for-term-for-over" role="menu">
+   <span id="infopaneltitle-for-term-for-over" style="display:none">Info about the 'over' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#over">https://drafts.csswg.org/css-writing-modes-4/#over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-over">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-over①">(2)</a> <a href="#ref-for-over②">(3)</a> <a href="#ref-for-over③">(4)</a>
@@ -3628,8 +3628,8 @@ Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for
 Underline Offset Origin (Zero Position)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-mode" class="dfn-panel" data-for="term-for-typographic-mode" id="infopanel-for-term-for-typographic-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-mode" style="display:none">Info about the 'typographic mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#typographic-mode">https://drafts.csswg.org/css-writing-modes-4/#typographic-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">2.7. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-typographic-mode①">(2)</a> <a href="#ref-for-typographic-mode②">(3)</a> <a href="#ref-for-typographic-mode③">(4)</a> <a href="#ref-for-typographic-mode④">(5)</a>
@@ -3639,8 +3639,8 @@ Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-typo
 Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-for-typographic-mode①⓪">(2)</a> <a href="#ref-for-typographic-mode①①">(3)</a> <a href="#ref-for-typographic-mode①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-under" class="dfn-panel" data-for="term-for-under" id="infopanel-for-term-for-under" role="menu">
+   <span id="infopaneltitle-for-term-for-under" style="display:none">Info about the 'under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-under①">(2)</a> <a href="#ref-for-under②">(3)</a> <a href="#ref-for-under③">(4)</a>
@@ -3648,36 +3648,36 @@ Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for
 Underline Offset Origin (Zero Position)</a> <a href="#ref-for-under⑤">(2)</a> <a href="#ref-for-under⑥">(3)</a> <a href="#ref-for-under⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill" class="dfn-panel" data-for="term-for-propdef-fill" id="infopanel-for-term-for-propdef-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke" class="dfn-panel" data-for="term-for-propdef-stroke" id="infopanel-for-term-for-propdef-stroke" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke" style="display:none">Info about the 'stroke' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">1.1. 
 Module Interactions</a>
@@ -4145,8 +4145,8 @@ plus a computed color
    <div class="issue"> If you find any issues, recommendations to add, or corrections,
 		please send the information to <a href="mailto:www-style@w3.org">www-style@w3.org</a> with <kbd>[css-text-decor]</kbd> in the subject line. <a class="issue-return" href="#issue-4a420eee" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="character">
-   <b><a href="#character">#character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character" class="dfn-panel" data-for="character" id="infopanel-for-character" role="dialog">
+   <span id="infopaneltitle-for-character" style="display:none">Info about the 'character' definition.</span><b><a href="#character">#character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-character①">(2)</a>
@@ -4154,8 +4154,8 @@ Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-char
 Emphasis Mark Skip: the text-emphasis-skip property</a> <a href="#ref-for-character③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decorating-box">
-   <b><a href="#decorating-box">#decorating-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decorating-box" class="dfn-panel" data-for="decorating-box" id="infopanel-for-decorating-box" role="dialog">
+   <span id="infopaneltitle-for-decorating-box" style="display:none">Info about the 'decorating box' definition.</span><b><a href="#decorating-box">#decorating-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decorating-box">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a> <a href="#ref-for-decorating-box①">(2)</a> <a href="#ref-for-decorating-box②">(3)</a>
@@ -4171,8 +4171,8 @@ Skipping Spaces: the text-decoration-skip-box property</a> <a href="#ref-for-dec
 Inset Edges: the text-decoration-skip-inset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-line">
-   <b><a href="#propdef-text-decoration-line">#propdef-text-decoration-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-line" class="dfn-panel" data-for="propdef-text-decoration-line" id="infopanel-for-propdef-text-decoration-line" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-line" style="display:none">Info about the 'text-decoration-line' definition.</span><b><a href="#propdef-text-decoration-line">#propdef-text-decoration-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-line">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -4192,8 +4192,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
     <li><a href="#ref-for-propdef-text-decoration-line⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-line-spelling-error">
-   <b><a href="#valdef-text-decoration-line-spelling-error">#valdef-text-decoration-line-spelling-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-line-spelling-error" class="dfn-panel" data-for="valdef-text-decoration-line-spelling-error" id="infopanel-for-valdef-text-decoration-line-spelling-error" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-line-spelling-error" style="display:none">Info about the 'spelling-error' definition.</span><b><a href="#valdef-text-decoration-line-spelling-error">#valdef-text-decoration-line-spelling-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-line-spelling-error">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -4204,8 +4204,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
     <li><a href="#ref-for-valdef-text-decoration-line-spelling-error③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-line-grammar-error">
-   <b><a href="#valdef-text-decoration-line-grammar-error">#valdef-text-decoration-line-grammar-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-line-grammar-error" class="dfn-panel" data-for="valdef-text-decoration-line-grammar-error" id="infopanel-for-valdef-text-decoration-line-grammar-error" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-line-grammar-error" style="display:none">Info about the 'grammar-error' definition.</span><b><a href="#valdef-text-decoration-line-grammar-error">#valdef-text-decoration-line-grammar-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-line-grammar-error">2.1. 
 Text Decoration Lines: the text-decoration-line property</a>
@@ -4216,8 +4216,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
     <li><a href="#ref-for-valdef-text-decoration-line-grammar-error③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-style">
-   <b><a href="#propdef-text-decoration-style">#propdef-text-decoration-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-style" class="dfn-panel" data-for="propdef-text-decoration-style" id="infopanel-for-propdef-text-decoration-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-style" style="display:none">Info about the 'text-decoration-style' definition.</span><b><a href="#propdef-text-decoration-style">#propdef-text-decoration-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-style">2.2. 
 Text Decoration Style: the text-decoration-style property</a>
@@ -4225,8 +4225,8 @@ Text Decoration Style: the text-decoration-style property</a>
 Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-propdef-text-decoration-style②">(2)</a> <a href="#ref-for-propdef-text-decoration-style③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-color">
-   <b><a href="#propdef-text-decoration-color">#propdef-text-decoration-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-color" class="dfn-panel" data-for="propdef-text-decoration-color" id="infopanel-for-propdef-text-decoration-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-color" style="display:none">Info about the 'text-decoration-color' definition.</span><b><a href="#propdef-text-decoration-color">#propdef-text-decoration-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-color">2.3. 
 Text Decoration Color: the text-decoration-color property</a>
@@ -4234,8 +4234,8 @@ Text Decoration Color: the text-decoration-color property</a>
 Text Decoration Shorthand: the text-decoration property</a> <a href="#ref-for-propdef-text-decoration-color②">(2)</a> <a href="#ref-for-propdef-text-decoration-color③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-thickness">
-   <b><a href="#propdef-text-decoration-thickness">#propdef-text-decoration-thickness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-thickness" class="dfn-panel" data-for="propdef-text-decoration-thickness" id="infopanel-for-propdef-text-decoration-thickness" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-thickness" style="display:none">Info about the 'text-decoration-thickness' definition.</span><b><a href="#propdef-text-decoration-thickness">#propdef-text-decoration-thickness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-thickness">2.4. 
 Text Decoration Line Thickness: the text-decoration-thickness property</a>
@@ -4249,8 +4249,8 @@ Text Decoration Line Uniformity</a>
     <li><a href="#ref-for-propdef-text-decoration-thickness⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-thickness-auto">
-   <b><a href="#valdef-text-decoration-thickness-auto">#valdef-text-decoration-thickness-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-thickness-auto" class="dfn-panel" data-for="valdef-text-decoration-thickness-auto" id="infopanel-for-valdef-text-decoration-thickness-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-thickness-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-text-decoration-thickness-auto">#valdef-text-decoration-thickness-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-thickness-auto">2.4. 
 Text Decoration Line Thickness: the text-decoration-thickness property</a>
@@ -4258,15 +4258,15 @@ Text Decoration Line Thickness: the text-decoration-thickness property</a>
 Automatic Thickness of Text Decoration Lines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="considered-text">
-   <b><a href="#considered-text">#considered-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-considered-text" class="dfn-panel" data-for="considered-text" id="infopanel-for-considered-text" role="dialog">
+   <span id="infopaneltitle-for-considered-text" style="display:none">Info about the 'considered text' definition.</span><b><a href="#considered-text">#considered-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-considered-text">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-considered-text①">(2)</a> <a href="#ref-for-considered-text②">(3)</a> <a href="#ref-for-considered-text③">(4)</a> <a href="#ref-for-considered-text④">(5)</a> <a href="#ref-for-considered-text⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration">
-   <b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration" class="dfn-panel" data-for="propdef-text-decoration" id="infopanel-for-propdef-text-decoration" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' definition.</span><b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-propdef-text-decoration①">(2)</a> <a href="#ref-for-propdef-text-decoration②">(3)</a>
@@ -4286,8 +4286,8 @@ Text Underline Offset: the text-underline-offset property</a>
 Painting Order of Text Decorations</a> <a href="#ref-for-propdef-text-decoration①③">(2)</a> <a href="#ref-for-propdef-text-decoration①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-underline-position">
-   <b><a href="#propdef-text-underline-position">#propdef-text-underline-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-underline-position" class="dfn-panel" data-for="propdef-text-underline-position" id="infopanel-for-propdef-text-underline-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-underline-position" style="display:none">Info about the 'text-underline-position' definition.</span><b><a href="#propdef-text-underline-position">#propdef-text-underline-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-underline-position">2.1. 
 Text Decoration Lines: the text-decoration-line property</a> <a href="#ref-for-propdef-text-underline-position①">(2)</a>
@@ -4309,8 +4309,8 @@ Skipping Glyphs: the text-decoration-skip-ink property</a>
     <li><a href="#ref-for-propdef-text-underline-position①⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-auto">
-   <b><a href="#underline-auto">#underline-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-auto" class="dfn-panel" data-for="underline-auto" id="infopanel-for-underline-auto" role="dialog">
+   <span id="infopaneltitle-for-underline-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#underline-auto">#underline-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-auto">2.7. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-auto①">(2)</a>
@@ -4318,8 +4318,8 @@ Text Underline Position: the text-underline-position property</a> <a href="#ref-
 Underline Offset Origin (Zero Position)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-underline-position-from-font">
-   <b><a href="#valdef-text-underline-position-from-font">#valdef-text-underline-position-from-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-underline-position-from-font" class="dfn-panel" data-for="valdef-text-underline-position-from-font" id="infopanel-for-valdef-text-underline-position-from-font" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-underline-position-from-font" style="display:none">Info about the 'from-font' definition.</span><b><a href="#valdef-text-underline-position-from-font">#valdef-text-underline-position-from-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-underline-position-from-font">2.8. 
 Text Underline Offset: the text-underline-offset property</a>
@@ -4331,8 +4331,8 @@ Using Font Metrics for Automatic Positioning</a>
     <li><a href="#ref-for-valdef-text-underline-position-from-font④"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-under">
-   <b><a href="#underline-under">#underline-under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-under" class="dfn-panel" data-for="underline-under" id="infopanel-for-underline-under" role="dialog">
+   <span id="infopaneltitle-for-underline-under" style="display:none">Info about the 'under' definition.</span><b><a href="#underline-under">#underline-under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-under">2.7. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-under①">(2)</a> <a href="#ref-for-underline-under②">(3)</a> <a href="#ref-for-underline-under③">(4)</a>
@@ -4340,8 +4340,8 @@ Text Underline Position: the text-underline-position property</a> <a href="#ref-
 Underline Offset Origin (Zero Position)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-left">
-   <b><a href="#underline-left">#underline-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-left" class="dfn-panel" data-for="underline-left" id="infopanel-for-underline-left" role="dialog">
+   <span id="infopaneltitle-for-underline-left" style="display:none">Info about the 'left' definition.</span><b><a href="#underline-left">#underline-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-left">2.7. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-left①">(2)</a> <a href="#ref-for-underline-left②">(3)</a> <a href="#ref-for-underline-left③">(4)</a>
@@ -4349,8 +4349,8 @@ Text Underline Position: the text-underline-position property</a> <a href="#ref-
 Underline Offset Origin (Zero Position)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-right">
-   <b><a href="#underline-right">#underline-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-right" class="dfn-panel" data-for="underline-right" id="infopanel-for-underline-right" role="dialog">
+   <span id="infopaneltitle-for-underline-right" style="display:none">Info about the 'right' definition.</span><b><a href="#underline-right">#underline-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-right">2.7. 
 Text Underline Position: the text-underline-position property</a> <a href="#ref-for-underline-right①">(2)</a> <a href="#ref-for-underline-right②">(3)</a> <a href="#ref-for-underline-right③">(4)</a>
@@ -4358,8 +4358,8 @@ Text Underline Position: the text-underline-position property</a> <a href="#ref-
 Underline Offset Origin (Zero Position)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-underline-offset">
-   <b><a href="#propdef-text-underline-offset">#propdef-text-underline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-underline-offset" class="dfn-panel" data-for="propdef-text-underline-offset" id="infopanel-for-propdef-text-underline-offset" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-underline-offset" style="display:none">Info about the 'text-underline-offset' definition.</span><b><a href="#propdef-text-underline-offset">#propdef-text-underline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-underline-offset">2.5. 
 Determining the Position and Thickness of Line Decorations</a>
@@ -4377,8 +4377,8 @@ Skipping Glyphs: the text-decoration-skip-ink property</a>
     <li><a href="#ref-for-propdef-text-underline-offset①⓪"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-underline-offset-auto">
-   <b><a href="#valdef-text-underline-offset-auto">#valdef-text-underline-offset-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-underline-offset-auto" class="dfn-panel" data-for="valdef-text-underline-offset-auto" id="infopanel-for-valdef-text-underline-offset-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-underline-offset-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-text-underline-offset-auto">#valdef-text-underline-offset-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-underline-offset-auto">2.7. 
 Text Underline Position: the text-underline-position property</a>
@@ -4386,8 +4386,8 @@ Text Underline Position: the text-underline-position property</a>
 Using Font Metrics for Automatic Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underline-zero-position">
-   <b><a href="#underline-zero-position">#underline-zero-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underline-zero-position" class="dfn-panel" data-for="underline-zero-position" id="infopanel-for-underline-zero-position" role="dialog">
+   <span id="infopaneltitle-for-underline-zero-position" style="display:none">Info about the 'zero position' definition.</span><b><a href="#underline-zero-position">#underline-zero-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underline-zero-position">2.7. 
 Text Underline Position: the text-underline-position property</a>
@@ -4395,8 +4395,8 @@ Text Underline Position: the text-underline-position property</a>
 Text Underline Offset: the text-underline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip">
-   <b><a href="#propdef-text-decoration-skip">#propdef-text-decoration-skip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip" class="dfn-panel" data-for="propdef-text-decoration-skip" id="infopanel-for-propdef-text-decoration-skip" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip" style="display:none">Info about the 'text-decoration-skip' definition.</span><b><a href="#propdef-text-decoration-skip">#propdef-text-decoration-skip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip">2.5. 
 Determining the Position and Thickness of Line Decorations</a> <a href="#ref-for-propdef-text-decoration-skip①">(2)</a>
@@ -4412,15 +4412,15 @@ Inset Edges: the text-decoration-skip-inset property</a> <a href="#ref-for-propd
     <li><a href="#ref-for-propdef-text-decoration-skip⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-skip-none">
-   <b><a href="#valdef-text-decoration-skip-none">#valdef-text-decoration-skip-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-skip-none" class="dfn-panel" data-for="valdef-text-decoration-skip-none" id="infopanel-for-valdef-text-decoration-skip-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-skip-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-decoration-skip-none">#valdef-text-decoration-skip-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-skip-none">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a> <a href="#ref-for-valdef-text-decoration-skip-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip-self">
-   <b><a href="#propdef-text-decoration-skip-self">#propdef-text-decoration-skip-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip-self" class="dfn-panel" data-for="propdef-text-decoration-skip-self" id="infopanel-for-propdef-text-decoration-skip-self" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip-self" style="display:none">Info about the 'text-decoration-skip-self' definition.</span><b><a href="#propdef-text-decoration-skip-self">#propdef-text-decoration-skip-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-self">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a>
@@ -4428,8 +4428,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
 Skipping Spaces: the text-decoration-skip-self property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip-box">
-   <b><a href="#propdef-text-decoration-skip-box">#propdef-text-decoration-skip-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip-box" class="dfn-panel" data-for="propdef-text-decoration-skip-box" id="infopanel-for-propdef-text-decoration-skip-box" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip-box" style="display:none">Info about the 'text-decoration-skip-box' definition.</span><b><a href="#propdef-text-decoration-skip-box">#propdef-text-decoration-skip-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-box">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a>
@@ -4437,8 +4437,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
 Skipping Spaces: the text-decoration-skip-box property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip-inset">
-   <b><a href="#propdef-text-decoration-skip-inset">#propdef-text-decoration-skip-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip-inset" class="dfn-panel" data-for="propdef-text-decoration-skip-inset" id="infopanel-for-propdef-text-decoration-skip-inset" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip-inset" style="display:none">Info about the 'text-decoration-skip-inset' definition.</span><b><a href="#propdef-text-decoration-skip-inset">#propdef-text-decoration-skip-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-inset">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a>
@@ -4446,8 +4446,8 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
 Inset Edges: the text-decoration-skip-inset property</a> <a href="#ref-for-propdef-text-decoration-skip-inset②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip-spaces">
-   <b><a href="#propdef-text-decoration-skip-spaces">#propdef-text-decoration-skip-spaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip-spaces" class="dfn-panel" data-for="propdef-text-decoration-skip-spaces" id="infopanel-for-propdef-text-decoration-skip-spaces" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip-spaces" style="display:none">Info about the 'text-decoration-skip-spaces' definition.</span><b><a href="#propdef-text-decoration-skip-spaces">#propdef-text-decoration-skip-spaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-spaces">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a>
@@ -4455,22 +4455,22 @@ Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-
 Skipping Spaces: the text-decoration-skip-spaces property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-skip-spaces-none">
-   <b><a href="#valdef-text-decoration-skip-spaces-none">#valdef-text-decoration-skip-spaces-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-skip-spaces-none" class="dfn-panel" data-for="valdef-text-decoration-skip-spaces-none" id="infopanel-for-valdef-text-decoration-skip-spaces-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-skip-spaces-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-decoration-skip-spaces-none">#valdef-text-decoration-skip-spaces-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-skip-spaces-none">2.10.4. 
 Skipping Spaces: the text-decoration-skip-spaces property</a> <a href="#ref-for-valdef-text-decoration-skip-spaces-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spacer">
-   <b><a href="#spacer">#spacer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spacer" class="dfn-panel" data-for="spacer" id="infopanel-for-spacer" role="dialog">
+   <span id="infopaneltitle-for-spacer" style="display:none">Info about the 'spacer' definition.</span><b><a href="#spacer">#spacer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spacer">2.10.4. 
 Skipping Spaces: the text-decoration-skip-spaces property</a> <a href="#ref-for-spacer①">(2)</a> <a href="#ref-for-spacer②">(3)</a> <a href="#ref-for-spacer③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration-skip-ink">
-   <b><a href="#propdef-text-decoration-skip-ink">#propdef-text-decoration-skip-ink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration-skip-ink" class="dfn-panel" data-for="propdef-text-decoration-skip-ink" id="infopanel-for-propdef-text-decoration-skip-ink" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration-skip-ink" style="display:none">Info about the 'text-decoration-skip-ink' definition.</span><b><a href="#propdef-text-decoration-skip-ink">#propdef-text-decoration-skip-ink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-skip-ink">2.10. 
 Text Decoration Line Continuity: the text-decoration-skip shorthand and its sub-properties</a> <a href="#ref-for-propdef-text-decoration-skip-ink①">(2)</a>
@@ -4479,21 +4479,21 @@ Skipping Glyphs: the text-decoration-skip-ink property</a>
     <li><a href="#ref-for-propdef-text-decoration-skip-ink③"> Changes since the 13 March 2018 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-skip-ink-auto">
-   <b><a href="#valdef-text-decoration-skip-ink-auto">#valdef-text-decoration-skip-ink-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-skip-ink-auto" class="dfn-panel" data-for="valdef-text-decoration-skip-ink-auto" id="infopanel-for-valdef-text-decoration-skip-ink-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-skip-ink-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-text-decoration-skip-ink-auto">#valdef-text-decoration-skip-ink-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-skip-ink-auto">2.10.5. 
 Skipping Glyphs: the text-decoration-skip-ink property</a> <a href="#ref-for-valdef-text-decoration-skip-ink-auto①">(2)</a> <a href="#ref-for-valdef-text-decoration-skip-ink-auto②">(3)</a> <a href="#ref-for-valdef-text-decoration-skip-ink-auto③">(4)</a> <a href="#ref-for-valdef-text-decoration-skip-ink-auto④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-decoration-skip-ink-all">
-   <b><a href="#valdef-text-decoration-skip-ink-all">#valdef-text-decoration-skip-ink-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-decoration-skip-ink-all" class="dfn-panel" data-for="valdef-text-decoration-skip-ink-all" id="infopanel-for-valdef-text-decoration-skip-ink-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-decoration-skip-ink-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-text-decoration-skip-ink-all">#valdef-text-decoration-skip-ink-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-skip-ink-all"> Changes since the 13 March 2018 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-style">
-   <b><a href="#propdef-text-emphasis-style">#propdef-text-emphasis-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-style" class="dfn-panel" data-for="propdef-text-emphasis-style" id="infopanel-for-propdef-text-emphasis-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-style" style="display:none">Info about the 'text-emphasis-style' definition.</span><b><a href="#propdef-text-emphasis-style">#propdef-text-emphasis-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-style">3. 
 Additional Controls for Emphasis Marks</a>
@@ -4503,43 +4503,43 @@ Emphasis Mark Style: the text-emphasis-style property</a>
 Emphasis Mark Shorthand: the text-emphasis property</a> <a href="#ref-for-propdef-text-emphasis-style③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-none">
-   <b><a href="#valdef-text-emphasis-style-none">#valdef-text-emphasis-style-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-none" class="dfn-panel" data-for="valdef-text-emphasis-style-none" id="infopanel-for-valdef-text-emphasis-style-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-emphasis-style-none">#valdef-text-emphasis-style-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-none">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-filled">
-   <b><a href="#valdef-text-emphasis-style-filled">#valdef-text-emphasis-style-filled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-filled" class="dfn-panel" data-for="valdef-text-emphasis-style-filled" id="infopanel-for-valdef-text-emphasis-style-filled" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-filled" style="display:none">Info about the 'filled' definition.</span><b><a href="#valdef-text-emphasis-style-filled">#valdef-text-emphasis-style-filled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-filled">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-valdef-text-emphasis-style-filled①">(2)</a> <a href="#ref-for-valdef-text-emphasis-style-filled②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-text-emphasis-open">
-   <b><a href="#valdef-text-text-emphasis-open">#valdef-text-text-emphasis-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-text-emphasis-open" class="dfn-panel" data-for="valdef-text-text-emphasis-open" id="infopanel-for-valdef-text-text-emphasis-open" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-text-emphasis-open" style="display:none">Info about the 'open' definition.</span><b><a href="#valdef-text-text-emphasis-open">#valdef-text-text-emphasis-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-text-emphasis-open">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a> <a href="#ref-for-valdef-text-text-emphasis-open①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-circle">
-   <b><a href="#valdef-text-emphasis-style-circle">#valdef-text-emphasis-style-circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-circle" class="dfn-panel" data-for="valdef-text-emphasis-style-circle" id="infopanel-for-valdef-text-emphasis-style-circle" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-circle" style="display:none">Info about the 'circle' definition.</span><b><a href="#valdef-text-emphasis-style-circle">#valdef-text-emphasis-style-circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-circle">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-style-sesame">
-   <b><a href="#valdef-text-emphasis-style-sesame">#valdef-text-emphasis-style-sesame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-style-sesame" class="dfn-panel" data-for="valdef-text-emphasis-style-sesame" id="infopanel-for-valdef-text-emphasis-style-sesame" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-style-sesame" style="display:none">Info about the 'sesame' definition.</span><b><a href="#valdef-text-emphasis-style-sesame">#valdef-text-emphasis-style-sesame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-style-sesame">3.1. 
 Emphasis Mark Style: the text-emphasis-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-color">
-   <b><a href="#propdef-text-emphasis-color">#propdef-text-emphasis-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-color" class="dfn-panel" data-for="propdef-text-emphasis-color" id="infopanel-for-propdef-text-emphasis-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-color" style="display:none">Info about the 'text-emphasis-color' definition.</span><b><a href="#propdef-text-emphasis-color">#propdef-text-emphasis-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-color">3. 
 Additional Controls for Emphasis Marks</a>
@@ -4549,8 +4549,8 @@ Emphasis Mark Color: the text-emphasis-color property</a> <a href="#ref-for-prop
 Emphasis Mark Shorthand: the text-emphasis property</a> <a href="#ref-for-propdef-text-emphasis-color④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis">
-   <b><a href="#propdef-text-emphasis">#propdef-text-emphasis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis" class="dfn-panel" data-for="propdef-text-emphasis" id="infopanel-for-propdef-text-emphasis" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis" style="display:none">Info about the 'text-emphasis' definition.</span><b><a href="#propdef-text-emphasis">#propdef-text-emphasis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis">3. 
 Additional Controls for Emphasis Marks</a>
@@ -4560,8 +4560,8 @@ Emphasis Mark Shorthand: the text-emphasis property</a>
 Painting Order of Text Decorations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-position">
-   <b><a href="#propdef-text-emphasis-position">#propdef-text-emphasis-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-position" class="dfn-panel" data-for="propdef-text-emphasis-position" id="infopanel-for-propdef-text-emphasis-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-position" style="display:none">Info about the 'text-emphasis-position' definition.</span><b><a href="#propdef-text-emphasis-position">#propdef-text-emphasis-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-position">3. 
 Additional Controls for Emphasis Marks</a>
@@ -4571,15 +4571,15 @@ Emphasis Mark Shorthand: the text-emphasis property</a>
 Emphasis Mark Position: the text-emphasis-position property</a> <a href="#ref-for-propdef-text-emphasis-position③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-position-right">
-   <b><a href="#valdef-text-emphasis-position-right">#valdef-text-emphasis-position-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-position-right" class="dfn-panel" data-for="valdef-text-emphasis-position-right" id="infopanel-for-valdef-text-emphasis-position-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-position-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-text-emphasis-position-right">#valdef-text-emphasis-position-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-position-right">3.4. 
 Emphasis Mark Position: the text-emphasis-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-emphasis-skip">
-   <b><a href="#propdef-text-emphasis-skip">#propdef-text-emphasis-skip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-emphasis-skip" class="dfn-panel" data-for="propdef-text-emphasis-skip" id="infopanel-for-propdef-text-emphasis-skip" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-emphasis-skip" style="display:none">Info about the 'text-emphasis-skip' definition.</span><b><a href="#propdef-text-emphasis-skip">#propdef-text-emphasis-skip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-skip">3.5. 
 Emphasis Mark Skip: the text-emphasis-skip property</a>
@@ -4587,15 +4587,15 @@ Emphasis Mark Skip: the text-emphasis-skip property</a>
     <li><a href="#ref-for-propdef-text-emphasis-skip②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-emphasis-skip-symbols">
-   <b><a href="#valdef-text-emphasis-skip-symbols">#valdef-text-emphasis-skip-symbols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-emphasis-skip-symbols" class="dfn-panel" data-for="valdef-text-emphasis-skip-symbols" id="infopanel-for-valdef-text-emphasis-skip-symbols" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-emphasis-skip-symbols" style="display:none">Info about the 'symbols' definition.</span><b><a href="#valdef-text-emphasis-skip-symbols">#valdef-text-emphasis-skip-symbols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-emphasis-skip-symbols">3.5. 
 Emphasis Mark Skip: the text-emphasis-skip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-shadow">
-   <b><a href="#propdef-text-shadow">#propdef-text-shadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-shadow" class="dfn-panel" data-for="propdef-text-shadow" id="infopanel-for-propdef-text-shadow" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' definition.</span><b><a href="#propdef-text-shadow">#propdef-text-shadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">2. 
 Line Decoration: Underline, Overline, and Strike-Through</a>
@@ -4608,59 +4608,115 @@ Painting Order of Text Decorations</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transforms-1/Overview.html
@@ -4123,15 +4123,15 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
    <li><a href="#user-coordinate-system">user coordinate system</a><span>, in § 1.2</span>
    <li><a href="#valdef-transform-box-view-box">view-box</a><span>, in § 5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4. The transform-origin Property</a>
     <li><a href="#ref-for-used-value①">5. Transform reference box: the transform-box property</a> <a href="#ref-for-used-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-clippath">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-clippath" class="dfn-panel" data-for="term-for-elementdef-clippath" id="infopanel-for-term-for-elementdef-clippath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-clippath" style="display:none">Info about the 'clippath' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-clippath">1.2. CSS Values</a>
     <li><a href="#ref-for-elementdef-clippath①">5. Transform reference box: the transform-box property</a>
@@ -4139,158 +4139,158 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-elementdef-clippath③">Since the 30 November 2017 Working Draft </a> <a href="#ref-for-elementdef-clippath④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-attrdef-clippath-clippathunits">
-   <a href="https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits">https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-attrdef-clippath-clippathunits" class="dfn-panel" data-for="term-for-element-attrdef-clippath-clippathunits" id="infopanel-for-term-for-element-attrdef-clippath-clippathunits" role="menu">
+   <span id="infopaneltitle-for-term-for-element-attrdef-clippath-clippathunits" style="display:none">Info about the 'clippathunits' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits">https://drafts.fxtf.org/css-masking-1/#element-attrdef-clippath-clippathunits</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-clippath-clippathunits">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-element-attrdef-clippath-clippathunits①">6.4. User coordinate space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-scroll">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-scroll" class="dfn-panel" data-for="term-for-valdef-overflow-scroll" id="infopanel-for-term-for-valdef-overflow-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4. The transform-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-number-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-number-token" class="dfn-panel" data-for="term-for-typedef-number-token" id="infopanel-for-term-for-typedef-number-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">6.2. Syntax of the SVG transform attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-letter">
-   <a href="https://drafts.csswg.org/css-syntax-3/#letter">https://drafts.csswg.org/css-syntax-3/#letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-letter" class="dfn-panel" data-for="term-for-letter" id="infopanel-for-term-for-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-letter" style="display:none">Info about the 'letter' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#letter">https://drafts.csswg.org/css-syntax-3/#letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-letter">6.2. Syntax of the SVG transform attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-translate3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-translate3d" class="dfn-panel" data-for="term-for-funcdef-translate3d" id="infopanel-for-term-for-funcdef-translate3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-translate3d" style="display:none">Info about the 'translate3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d">https://drafts.csswg.org/css-transforms-2/#funcdef-translate3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-translate3d">10. Interpolation of primitives and derived transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">7.1. 2D Transform Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">4. The transform-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">3. The transform Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">7.1. 2D Transform Functions</a> <a href="#ref-for-comb-comma①">(2)</a> <a href="#ref-for-comb-comma②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">6.3. SVG transform functions</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a> <a href="#ref-for-angle-value③">(4)</a>
     <li><a href="#ref-for-angle-value④">7.1. 2D Transform Functions</a> <a href="#ref-for-angle-value⑤">(2)</a> <a href="#ref-for-angle-value⑥">(3)</a> <a href="#ref-for-angle-value⑦">(4)</a> <a href="#ref-for-angle-value⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4. The transform-origin Property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a>
     <li><a href="#ref-for-typedef-length-percentage④">7.1. 2D Transform Functions</a> <a href="#ref-for-typedef-length-percentage⑤">(2)</a> <a href="#ref-for-typedef-length-percentage⑥">(3)</a> <a href="#ref-for-typedef-length-percentage⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4. The transform-origin Property</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a>
     <li><a href="#ref-for-length-value④">6.3. SVG transform functions</a> <a href="#ref-for-length-value⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">7.1. 2D Transform Functions</a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a> <a href="#ref-for-number-value③">(4)</a> <a href="#ref-for-number-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-zero-value">
-   <a href="https://drafts.csswg.org/css-values-4/#zero-value">https://drafts.csswg.org/css-values-4/#zero-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-zero-value" class="dfn-panel" data-for="term-for-zero-value" id="infopanel-for-term-for-zero-value" role="menu">
+   <span id="infopaneltitle-for-term-for-zero-value" style="display:none">Info about the '&lt;zero>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#zero-value">https://drafts.csswg.org/css-values-4/#zero-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-zero-value">7. The Transform Functions</a>
     <li><a href="#ref-for-zero-value①">7.1. 2D Transform Functions</a> <a href="#ref-for-zero-value②">(2)</a> <a href="#ref-for-zero-value③">(3)</a> <a href="#ref-for-zero-value④">(4)</a> <a href="#ref-for-zero-value⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4. The transform-origin Property</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">7.1. 2D Transform Functions</a> <a href="#ref-for-mult-opt③">(2)</a> <a href="#ref-for-mult-opt④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">3.1. Serialization of &lt;transform-function>s</a> <a href="#ref-for-funcdef-calc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deg">
-   <a href="https://drafts.csswg.org/css-values-4/#deg">https://drafts.csswg.org/css-values-4/#deg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deg" class="dfn-panel" data-for="term-for-deg" id="infopanel-for-term-for-deg" role="menu">
+   <span id="infopaneltitle-for-term-for-deg" style="display:none">Info about the 'deg' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#deg">https://drafts.csswg.org/css-values-4/#deg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deg">6.3. SVG transform functions</a> <a href="#ref-for-deg①">(2)</a> <a href="#ref-for-deg②">(3)</a> <a href="#ref-for-deg③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation" style="display:none">Info about the 'interpolate' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">9. Interpolation of Transforms</a> <a href="#ref-for-interpolation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation①" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation①" style="display:none">Info about the 'interpolation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">9. Interpolation of Transforms</a> <a href="#ref-for-interpolation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">6.3. SVG transform functions</a> <a href="#ref-for-px①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3. The transform Property</a>
     <li><a href="#ref-for-comb-one①">4. The transform-origin Property</a> <a href="#ref-for-comb-one②">(2)</a> <a href="#ref-for-comb-one③">(3)</a> <a href="#ref-for-comb-one④">(4)</a> <a href="#ref-for-comb-one⑤">(5)</a> <a href="#ref-for-comb-one⑥">(6)</a> <a href="#ref-for-comb-one⑦">(7)</a> <a href="#ref-for-comb-one⑧">(8)</a> <a href="#ref-for-comb-one⑨">(9)</a> <a href="#ref-for-comb-one①⓪">(10)</a> <a href="#ref-for-comb-one①①">(11)</a> <a href="#ref-for-comb-one①②">(12)</a> <a href="#ref-for-comb-one①③">(13)</a> <a href="#ref-for-comb-one①④">(14)</a> <a href="#ref-for-comb-one①⑤">(15)</a> <a href="#ref-for-comb-one①⑥">(16)</a> <a href="#ref-for-comb-one①⑦">(17)</a>
@@ -4298,70 +4298,70 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-comb-one②②">7.1. 2D Transform Functions</a> <a href="#ref-for-comb-one②③">(2)</a> <a href="#ref-for-comb-one②④">(3)</a> <a href="#ref-for-comb-one②⑤">(4)</a> <a href="#ref-for-comb-one②⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-z-index-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-z-index-auto" class="dfn-panel" data-for="term-for-valdef-z-index-auto" id="infopanel-for-term-for-valdef-z-index-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-z-index-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-z-index-auto">https://drafts.csswg.org/css2/#valdef-z-index-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">2. The Transform Rendering Model</a> <a href="#ref-for-propdef-z-index①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">1.1. Module Interactions</a>
     <li><a href="#ref-for-propdef-background-attachment①">2. The Transform Rendering Model</a> <a href="#ref-for-propdef-background-attachment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">4. The transform-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-attachment-fixed">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-attachment-fixed" class="dfn-panel" data-for="term-for-valdef-background-attachment-fixed" id="infopanel-for-term-for-valdef-background-attachment-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-attachment-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-fixed">1.1. Module Interactions</a>
     <li><a href="#ref-for-valdef-background-attachment-fixed①">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-attachment-scroll" class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll" id="infopanel-for-term-for-valdef-background-attachment-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-attachment-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-scroll">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value-special-case-property">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value-special-case-property" class="dfn-panel" data-for="term-for-resolved-value-special-case-property" id="infopanel-for-term-for-resolved-value-special-case-property" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value-special-case-property" style="display:none">Info about the 'resolved value special case property' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value-special-case-property">4. The transform-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">2. The Transform Rendering Model</a> <a href="#ref-for-the-div-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-animate">
-   <a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-animate" class="dfn-panel" data-for="term-for-elementdef-animate" id="infopanel-for-term-for-elementdef-animate" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-animate" style="display:none">Info about the 'animate' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-animate">Since the 14 February 2019 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-set">
-   <a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-set" class="dfn-panel" data-for="term-for-elementdef-set" id="infopanel-for-term-for-elementdef-set" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-set" style="display:none">Info about the 'set' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-set">Since the 14 February 2019 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LinearGradientElementGradientTransformAttribute">
-   <a href="https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementGradientTransformAttribute">https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementGradientTransformAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LinearGradientElementGradientTransformAttribute" class="dfn-panel" data-for="term-for-LinearGradientElementGradientTransformAttribute" id="infopanel-for-term-for-LinearGradientElementGradientTransformAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-LinearGradientElementGradientTransformAttribute" style="display:none">Info about the 'gradienttransform' external reference.</span><a href="https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementGradientTransformAttribute">https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementGradientTransformAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LinearGradientElementGradientTransformAttribute">6.1. SVG presentation attributes</a>
     <li><a href="#ref-for-LinearGradientElementGradientTransformAttribute①">6.2. Syntax of the SVG transform attribute</a> <a href="#ref-for-LinearGradientElementGradientTransformAttribute②">(2)</a> <a href="#ref-for-LinearGradientElementGradientTransformAttribute③">(3)</a>
@@ -4371,15 +4371,15 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-LinearGradientElementGradientTransformAttribute⑧">Since the 30 November 2017 Working Draft </a> <a href="#ref-for-LinearGradientElementGradientTransformAttribute⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LinearGradientElementGradientUnitsAttribute">
-   <a href="https://www.w3.org/TR/SVG/pservers.html#LinearGradientElementGradientUnitsAttribute">https://www.w3.org/TR/SVG/pservers.html#LinearGradientElementGradientUnitsAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LinearGradientElementGradientUnitsAttribute" class="dfn-panel" data-for="term-for-LinearGradientElementGradientUnitsAttribute" id="infopanel-for-term-for-LinearGradientElementGradientUnitsAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-LinearGradientElementGradientUnitsAttribute" style="display:none">Info about the 'gradientunits' external reference.</span><a href="https://www.w3.org/TR/SVG/pservers.html#LinearGradientElementGradientUnitsAttribute">https://www.w3.org/TR/SVG/pservers.html#LinearGradientElementGradientUnitsAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LinearGradientElementGradientUnitsAttribute">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-LinearGradientElementGradientUnitsAttribute①">6.4. User coordinate space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PatternElementPatternTransformAttribute">
-   <a href="https://www.w3.org/TR/SVG11/pservers.html#PatternElementPatternTransformAttribute">https://www.w3.org/TR/SVG11/pservers.html#PatternElementPatternTransformAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PatternElementPatternTransformAttribute" class="dfn-panel" data-for="term-for-PatternElementPatternTransformAttribute" id="infopanel-for-term-for-PatternElementPatternTransformAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-PatternElementPatternTransformAttribute" style="display:none">Info about the 'patterntransform' external reference.</span><a href="https://www.w3.org/TR/SVG11/pservers.html#PatternElementPatternTransformAttribute">https://www.w3.org/TR/SVG11/pservers.html#PatternElementPatternTransformAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PatternElementPatternTransformAttribute">6.1. SVG presentation attributes</a>
     <li><a href="#ref-for-PatternElementPatternTransformAttribute①">6.2. Syntax of the SVG transform attribute</a> <a href="#ref-for-PatternElementPatternTransformAttribute②">(2)</a> <a href="#ref-for-PatternElementPatternTransformAttribute③">(3)</a>
@@ -4389,15 +4389,15 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-PatternElementPatternTransformAttribute⑧">Since the 30 November 2017 Working Draft </a> <a href="#ref-for-PatternElementPatternTransformAttribute⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PatternElementPatternUnitsAttribute">
-   <a href="https://www.w3.org/TR/SVG/pservers.html#PatternElementPatternUnitsAttribute">https://www.w3.org/TR/SVG/pservers.html#PatternElementPatternUnitsAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PatternElementPatternUnitsAttribute" class="dfn-panel" data-for="term-for-PatternElementPatternUnitsAttribute" id="infopanel-for-term-for-PatternElementPatternUnitsAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-PatternElementPatternUnitsAttribute" style="display:none">Info about the 'patternunits' external reference.</span><a href="https://www.w3.org/TR/SVG/pservers.html#PatternElementPatternUnitsAttribute">https://www.w3.org/TR/SVG/pservers.html#PatternElementPatternUnitsAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PatternElementPatternUnitsAttribute">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-PatternElementPatternUnitsAttribute①">6.4. User coordinate space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TransformAttribute">
-   <a href="https://www.w3.org/TR/SVG11/coords.html#TransformAttribute">https://www.w3.org/TR/SVG11/coords.html#TransformAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TransformAttribute" class="dfn-panel" data-for="term-for-TransformAttribute" id="infopanel-for-term-for-TransformAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-TransformAttribute" style="display:none">Info about the 'transform' external reference.</span><a href="https://www.w3.org/TR/SVG11/coords.html#TransformAttribute">https://www.w3.org/TR/SVG11/coords.html#TransformAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TransformAttribute">6. The SVG transform Attribute</a>
     <li><a href="#ref-for-TransformAttribute①">6.1. SVG presentation attributes</a> <a href="#ref-for-TransformAttribute②">(2)</a> <a href="#ref-for-TransformAttribute③">(3)</a>
@@ -4409,99 +4409,99 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-TransformAttribute①⑧">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-__svg__SVGAnimatedPreserveAspectRatio__animVal">
-   <a href="https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal">https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__animVal" class="dfn-panel" data-for="term-for-__svg__SVGAnimatedPreserveAspectRatio__animVal" id="infopanel-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__animVal" role="menu">
+   <span id="infopaneltitle-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__animVal" style="display:none">Info about the 'animVal' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal">https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-__svg__SVGAnimatedPreserveAspectRatio__animVal">6.5. SVG DOM interface for the transform attribute</a> <a href="#ref-for-__svg__SVGAnimatedPreserveAspectRatio__animVal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal">
-   <a href="https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal">https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal" class="dfn-panel" data-for="term-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal" id="infopanel-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal" role="menu">
+   <span id="infopaneltitle-for-term-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal" style="display:none">Info about the 'baseVal' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal">https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal">6.5. SVG DOM interface for the transform attribute</a> <a href="#ref-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal①">(2)</a> <a href="#ref-for-__svg__SVGAnimatedPreserveAspectRatio__baseVal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-linearGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-linearGradient" class="dfn-panel" data-for="term-for-elementdef-linearGradient" id="infopanel-for-term-for-elementdef-linearGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-linearGradient" style="display:none">Info about the 'lineargradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-linearGradient">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-elementdef-linearGradient①">6.4. User coordinate space</a>
     <li><a href="#ref-for-elementdef-linearGradient②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermObjectBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermObjectBoundingBox" class="dfn-panel" data-for="term-for-TermObjectBoundingBox" id="infopanel-for-term-for-TermObjectBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermObjectBoundingBox" style="display:none">Info about the 'object bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermObjectBoundingBox">5. Transform reference box: the transform-box property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPaintServerElement">
-   <a href="https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement">https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPaintServerElement" class="dfn-panel" data-for="term-for-TermPaintServerElement" id="infopanel-for-term-for-TermPaintServerElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPaintServerElement" style="display:none">Info about the 'paint server element' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement">https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPaintServerElement">1.2. CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-elementdef-pattern①">6.4. User coordinate space</a> <a href="#ref-for-elementdef-pattern②">(2)</a> <a href="#ref-for-elementdef-pattern③">(3)</a>
     <li><a href="#ref-for-elementdef-pattern④">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPresentationAttribute">
-   <a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPresentationAttribute" class="dfn-panel" data-for="term-for-TermPresentationAttribute" id="infopanel-for-term-for-TermPresentationAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPresentationAttribute" style="display:none">Info about the 'presentation attributes' external reference.</span><a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPresentationAttribute">6.1. SVG presentation attributes</a> <a href="#ref-for-TermPresentationAttribute①">(2)</a> <a href="#ref-for-TermPresentationAttribute②">(3)</a> <a href="#ref-for-TermPresentationAttribute③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-radialGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-radialGradient" class="dfn-panel" data-for="term-for-elementdef-radialGradient" id="infopanel-for-term-for-elementdef-radialGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-radialGradient" style="display:none">Info about the 'radialgradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-radialGradient">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-elementdef-radialGradient①">6.4. User coordinate space</a>
     <li><a href="#ref-for-elementdef-radialGradient②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-rect">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-rect" class="dfn-panel" data-for="term-for-elementdef-rect" id="infopanel-for-term-for-elementdef-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-rect" style="display:none">Info about the 'rect' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-rect">2. The Transform Rendering Model</a> <a href="#ref-for-elementdef-rect①">(2)</a>
     <li><a href="#ref-for-elementdef-rect②">6.4. User coordinate space</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermRenderableElement">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermRenderableElement">https://svgwg.org/svg2-draft/render.html#TermRenderableElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermRenderableElement" class="dfn-panel" data-for="term-for-TermRenderableElement" id="infopanel-for-term-for-TermRenderableElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermRenderableElement" style="display:none">Info about the 'renderable element' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermRenderableElement">https://svgwg.org/svg2-draft/render.html#TermRenderableElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermRenderableElement">1.2. CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">1.1. Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStrokeBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStrokeBoundingBox" class="dfn-panel" data-for="term-for-TermStrokeBoundingBox" id="infopanel-for-term-for-TermStrokeBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStrokeBoundingBox" style="display:none">Info about the 'stroke bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStrokeBoundingBox">5. Transform reference box: the transform-box property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermTextContentElement">
-   <a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermTextContentElement" class="dfn-panel" data-for="term-for-TermTextContentElement" id="infopanel-for-term-for-TermTextContentElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermTextContentElement" style="display:none">Info about the 'text content element' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermTextContentElement">1.2. CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-__svg__SVGFitToViewBox__viewBox">
-   <a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox">https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-__svg__SVGFitToViewBox__viewBox" class="dfn-panel" data-for="term-for-__svg__SVGFitToViewBox__viewBox" id="infopanel-for-term-for-__svg__SVGFitToViewBox__viewBox" role="menu">
+   <span id="infopaneltitle-for-term-for-__svg__SVGFitToViewBox__viewBox" style="display:none">Info about the 'viewBox' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox">https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-__svg__SVGFitToViewBox__viewBox">5. Transform reference box: the transform-box property</a> <a href="#ref-for-__svg__SVGFitToViewBox__viewBox①">(2)</a> <a href="#ref-for-__svg__SVGFitToViewBox__viewBox②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermViewportCoordinateSystem">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermViewportCoordinateSystem">https://svgwg.org/svg2-draft/coords.html#TermViewportCoordinateSystem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermViewportCoordinateSystem" class="dfn-panel" data-for="term-for-TermViewportCoordinateSystem" id="infopanel-for-term-for-TermViewportCoordinateSystem" role="menu">
+   <span id="infopaneltitle-for-term-for-TermViewportCoordinateSystem" style="display:none">Info about the 'viewport coordinate system' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermViewportCoordinateSystem">https://svgwg.org/svg2-draft/coords.html#TermViewportCoordinateSystem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermViewportCoordinateSystem">1.2. CSS Values</a>
     <li><a href="#ref-for-TermViewportCoordinateSystem①">2. The Transform Rendering Model</a> <a href="#ref-for-TermViewportCoordinateSystem②">(2)</a> <a href="#ref-for-TermViewportCoordinateSystem③">(3)</a>
@@ -4711,8 +4711,8 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
       <td>see background-position
    </table>
   </div>
-  <aside class="dfn-panel" data-for="transformable-element">
-   <b><a href="#transformable-element">#transformable-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformable-element" class="dfn-panel" data-for="transformable-element" id="infopanel-for-transformable-element" role="dialog">
+   <span id="infopaneltitle-for-transformable-element" style="display:none">Info about the 'transformable element' definition.</span><b><a href="#transformable-element">#transformable-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformable-element">2. The Transform Rendering Model</a>
     <li><a href="#ref-for-transformable-element①">3. The transform Property</a>
@@ -4722,75 +4722,75 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-transformable-element⑤">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-coordinate-system">
-   <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-coordinate-system" class="dfn-panel" data-for="local-coordinate-system" id="infopanel-for-local-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' definition.</span><b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">1.2. CSS Values</a>
     <li><a href="#ref-for-local-coordinate-system①">2. The Transform Rendering Model</a> <a href="#ref-for-local-coordinate-system②">(2)</a> <a href="#ref-for-local-coordinate-system③">(3)</a> <a href="#ref-for-local-coordinate-system④">(4)</a>
     <li><a href="#ref-for-local-coordinate-system⑤">8. The Transform Function Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformation-matrix">
-   <b><a href="#transformation-matrix">#transformation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformation-matrix" class="dfn-panel" data-for="transformation-matrix" id="infopanel-for-transformation-matrix" role="dialog">
+   <span id="infopaneltitle-for-transformation-matrix" style="display:none">Info about the 'transformation matrix' definition.</span><b><a href="#transformation-matrix">#transformation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformation-matrix">2. The Transform Rendering Model</a> <a href="#ref-for-transformation-matrix①">(2)</a> <a href="#ref-for-transformation-matrix②">(3)</a> <a href="#ref-for-transformation-matrix③">(4)</a> <a href="#ref-for-transformation-matrix④">(5)</a> <a href="#ref-for-transformation-matrix⑤">(6)</a>
     <li><a href="#ref-for-transformation-matrix⑥">4. The transform-origin Property</a>
     <li><a href="#ref-for-transformation-matrix⑦">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-transformation-matrix">
-   <b><a href="#current-transformation-matrix">#current-transformation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-transformation-matrix" class="dfn-panel" data-for="current-transformation-matrix" id="infopanel-for-current-transformation-matrix" role="dialog">
+   <span id="infopaneltitle-for-current-transformation-matrix" style="display:none">Info about the 'current transformation matrix' definition.</span><b><a href="#current-transformation-matrix">#current-transformation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-transformation-matrix">2. The Transform Rendering Model</a> <a href="#ref-for-current-transformation-matrix①">(2)</a> <a href="#ref-for-current-transformation-matrix②">(3)</a>
     <li><a href="#ref-for-current-transformation-matrix③">8. The Transform Function Lists</a>
     <li><a href="#ref-for-current-transformation-matrix④">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="2d-matrix">
-   <b><a href="#2d-matrix">#2d-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-2d-matrix" class="dfn-panel" data-for="2d-matrix" id="infopanel-for-2d-matrix" role="dialog">
+   <span id="infopaneltitle-for-2d-matrix" style="display:none">Info about the '2D matrix' definition.</span><b><a href="#2d-matrix">#2d-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-2d-matrix">11. Interpolation of Matrices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identity-transform-function">
-   <b><a href="#identity-transform-function">#identity-transform-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identity-transform-function" class="dfn-panel" data-for="identity-transform-function" id="infopanel-for-identity-transform-function" role="dialog">
+   <span id="infopaneltitle-for-identity-transform-function" style="display:none">Info about the 'identity transform function' definition.</span><b><a href="#identity-transform-function">#identity-transform-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform-function">9. Interpolation of Transforms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="post-multiply">
-   <b><a href="#post-multiply">#post-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-post-multiply" class="dfn-panel" data-for="post-multiply" id="infopanel-for-post-multiply" role="dialog">
+   <span id="infopaneltitle-for-post-multiply" style="display:none">Info about the 'post-multiply' definition.</span><b><a href="#post-multiply">#post-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-post-multiply">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="post-multiplied">
-   <b><a href="#post-multiplied">#post-multiplied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-post-multiplied" class="dfn-panel" data-for="post-multiplied" id="infopanel-for-post-multiplied" role="dialog">
+   <span id="infopaneltitle-for-post-multiplied" style="display:none">Info about the 'post-multiplied' definition.</span><b><a href="#post-multiplied">#post-multiplied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-post-multiplied">2. The Transform Rendering Model</a> <a href="#ref-for-post-multiplied①">(2)</a>
     <li><a href="#ref-for-post-multiplied②">6.3. SVG transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pre-multiply">
-   <b><a href="#pre-multiply">#pre-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pre-multiply" class="dfn-panel" data-for="pre-multiply" id="infopanel-for-pre-multiply" role="dialog">
+   <span id="infopaneltitle-for-pre-multiply" style="display:none">Info about the 'pre-multiply' definition.</span><b><a href="#pre-multiply">#pre-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pre-multiply">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pre-multiplied">
-   <b><a href="#pre-multiplied">#pre-multiplied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pre-multiplied" class="dfn-panel" data-for="pre-multiplied" id="infopanel-for-pre-multiplied" role="dialog">
+   <span id="infopaneltitle-for-pre-multiplied" style="display:none">Info about the 'pre-multiplied' definition.</span><b><a href="#pre-multiplied">#pre-multiplied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pre-multiplied">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="containing-block-for-all-descendants">
-   <b><a href="#containing-block-for-all-descendants">#containing-block-for-all-descendants</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-containing-block-for-all-descendants" class="dfn-panel" data-for="containing-block-for-all-descendants" id="infopanel-for-containing-block-for-all-descendants" role="dialog">
+   <span id="infopaneltitle-for-containing-block-for-all-descendants" style="display:none">Info about the 'containing block for all descendants' definition.</span><b><a href="#containing-block-for-all-descendants">#containing-block-for-all-descendants</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-for-all-descendants">2. The Transform Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transform">
-   <b><a href="#propdef-transform">#propdef-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transform" class="dfn-panel" data-for="propdef-transform" id="infopanel-for-propdef-transform" role="dialog">
+   <span id="infopaneltitle-for-propdef-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#propdef-transform">#propdef-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">1. Introduction</a>
     <li><a href="#ref-for-propdef-transform①">1.2. CSS Values</a> <a href="#ref-for-propdef-transform②">(2)</a>
@@ -4807,8 +4807,8 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-propdef-transform②⑦">Since the 30 November 2017 Working Draft </a> <a href="#ref-for-propdef-transform②⑧">(2)</a> <a href="#ref-for-propdef-transform②⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-transform-list">
-   <b><a href="#typedef-transform-list">#typedef-transform-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-transform-list" class="dfn-panel" data-for="typedef-transform-list" id="infopanel-for-typedef-transform-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' definition.</span><b><a href="#typedef-transform-list">#typedef-transform-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">3. The transform Property</a>
     <li><a href="#ref-for-typedef-transform-list①">3.2. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-typedef-transform-list②">(2)</a> <a href="#ref-for-typedef-transform-list③">(3)</a>
@@ -4816,8 +4816,8 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-typedef-transform-list⑤">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transform-origin">
-   <b><a href="#propdef-transform-origin">#propdef-transform-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transform-origin" class="dfn-panel" data-for="propdef-transform-origin" id="infopanel-for-propdef-transform-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' definition.</span><b><a href="#propdef-transform-origin">#propdef-transform-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">1.2. CSS Values</a>
     <li><a href="#ref-for-propdef-transform-origin①">2. The Transform Rendering Model</a> <a href="#ref-for-propdef-transform-origin②">(2)</a> <a href="#ref-for-propdef-transform-origin③">(3)</a> <a href="#ref-for-propdef-transform-origin④">(4)</a> <a href="#ref-for-propdef-transform-origin⑤">(5)</a>
@@ -4828,22 +4828,22 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-propdef-transform-origin①④">7.1. 2D Transform Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-origin-center">
-   <b><a href="#valdef-transform-origin-center">#valdef-transform-origin-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-origin-center" class="dfn-panel" data-for="valdef-transform-origin-center" id="infopanel-for-valdef-transform-origin-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-origin-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-transform-origin-center">#valdef-transform-origin-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-origin-center">4. The transform-origin Property</a> <a href="#ref-for-valdef-transform-origin-center①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transform-box">
-   <b><a href="#propdef-transform-box">#propdef-transform-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transform-box" class="dfn-panel" data-for="propdef-transform-box" id="infopanel-for-propdef-transform-box" role="dialog">
+   <span id="infopaneltitle-for-propdef-transform-box" style="display:none">Info about the 'transform-box' definition.</span><b><a href="#propdef-transform-box">#propdef-transform-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-box">1.2. CSS Values</a>
     <li><a href="#ref-for-propdef-transform-box①">5. Transform reference box: the transform-box property</a>
     <li><a href="#ref-for-propdef-transform-box②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reference-box">
-   <b><a href="#reference-box">#reference-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reference-box" class="dfn-panel" data-for="reference-box" id="infopanel-for-reference-box" role="dialog">
+   <span id="infopaneltitle-for-reference-box" style="display:none">Info about the 'reference box' definition.</span><b><a href="#reference-box">#reference-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-box">1.2. CSS Values</a>
     <li><a href="#ref-for-reference-box①">3. The transform Property</a>
@@ -4853,40 +4853,40 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-reference-box①⓪">7. The Transform Functions</a> <a href="#ref-for-reference-box①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-box-content-box">
-   <b><a href="#valdef-transform-box-content-box">#valdef-transform-box-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-box-content-box" class="dfn-panel" data-for="valdef-transform-box-content-box" id="infopanel-for-valdef-transform-box-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-box-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-transform-box-content-box">#valdef-transform-box-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-box-content-box">5. Transform reference box: the transform-box property</a> <a href="#ref-for-valdef-transform-box-content-box①">(2)</a>
     <li><a href="#ref-for-valdef-transform-box-content-box②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-box-border-box">
-   <b><a href="#valdef-transform-box-border-box">#valdef-transform-box-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-box-border-box" class="dfn-panel" data-for="valdef-transform-box-border-box" id="infopanel-for-valdef-transform-box-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-box-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-transform-box-border-box">#valdef-transform-box-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-box-border-box">5. Transform reference box: the transform-box property</a> <a href="#ref-for-valdef-transform-box-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-box-fill-box">
-   <b><a href="#valdef-transform-box-fill-box">#valdef-transform-box-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-box-fill-box" class="dfn-panel" data-for="valdef-transform-box-fill-box" id="infopanel-for-valdef-transform-box-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-box-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-transform-box-fill-box">#valdef-transform-box-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-box-fill-box">5. Transform reference box: the transform-box property</a> <a href="#ref-for-valdef-transform-box-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-box-stroke-box">
-   <b><a href="#valdef-transform-box-stroke-box">#valdef-transform-box-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-box-stroke-box" class="dfn-panel" data-for="valdef-transform-box-stroke-box" id="infopanel-for-valdef-transform-box-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-box-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-transform-box-stroke-box">#valdef-transform-box-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-box-stroke-box">5. Transform reference box: the transform-box property</a> <a href="#ref-for-valdef-transform-box-stroke-box①">(2)</a>
     <li><a href="#ref-for-valdef-transform-box-stroke-box②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transform-box-view-box">
-   <b><a href="#valdef-transform-box-view-box">#valdef-transform-box-view-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transform-box-view-box" class="dfn-panel" data-for="valdef-transform-box-view-box" id="infopanel-for-valdef-transform-box-view-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-transform-box-view-box" style="display:none">Info about the 'view-box' definition.</span><b><a href="#valdef-transform-box-view-box">#valdef-transform-box-view-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transform-box-view-box">5. Transform reference box: the transform-box property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-transform-function">
-   <b><a href="#typedef-transform-function">#typedef-transform-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-transform-function" class="dfn-panel" data-for="typedef-transform-function" id="infopanel-for-typedef-transform-function" role="dialog">
+   <span id="infopaneltitle-for-typedef-transform-function" style="display:none">Info about the '&lt;transform-function>' definition.</span><b><a href="#typedef-transform-function">#typedef-transform-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-function">2. The Transform Rendering Model</a> <a href="#ref-for-typedef-transform-function①">(2)</a>
     <li><a href="#ref-for-typedef-transform-function②">3. The transform Property</a>
@@ -4897,16 +4897,16 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-typedef-transform-function①①">8. The Transform Function Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-matrix">
-   <b><a href="#funcdef-transform-matrix">#funcdef-transform-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-matrix" class="dfn-panel" data-for="funcdef-transform-matrix" id="infopanel-for-funcdef-transform-matrix" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-matrix" style="display:none">Info about the 'matrix()' definition.</span><b><a href="#funcdef-transform-matrix">#funcdef-transform-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-matrix">3.2. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-funcdef-transform-matrix①">(2)</a>
     <li><a href="#ref-for-funcdef-transform-matrix②">6.3. SVG transform functions</a> <a href="#ref-for-funcdef-transform-matrix③">(2)</a>
     <li><a href="#ref-for-funcdef-transform-matrix④">10. Interpolation of primitives and derived transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-translate">
-   <b><a href="#funcdef-transform-translate">#funcdef-transform-translate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-translate" class="dfn-panel" data-for="funcdef-transform-translate" id="infopanel-for-funcdef-transform-translate" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-translate" style="display:none">Info about the 'translate()' definition.</span><b><a href="#funcdef-transform-translate">#funcdef-transform-translate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translate">2. The Transform Rendering Model</a>
     <li><a href="#ref-for-funcdef-transform-translate①">6.3. SVG transform functions</a>
@@ -4914,66 +4914,66 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
     <li><a href="#ref-for-funcdef-transform-translate④">10. Interpolation of primitives and derived transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-translatex">
-   <b><a href="#funcdef-transform-translatex">#funcdef-transform-translatex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-translatex" class="dfn-panel" data-for="funcdef-transform-translatex" id="infopanel-for-funcdef-transform-translatex" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-translatex" style="display:none">Info about the 'translateX()' definition.</span><b><a href="#funcdef-transform-translatex">#funcdef-transform-translatex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatex">6.2. Syntax of the SVG transform attribute</a>
     <li><a href="#ref-for-funcdef-transform-translatex①">7.2. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-translatey">
-   <b><a href="#funcdef-transform-translatey">#funcdef-transform-translatey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-translatey" class="dfn-panel" data-for="funcdef-transform-translatey" id="infopanel-for-funcdef-transform-translatey" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-translatey" style="display:none">Info about the 'translateY()' definition.</span><b><a href="#funcdef-transform-translatey">#funcdef-transform-translatey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatey">6.2. Syntax of the SVG transform attribute</a>
     <li><a href="#ref-for-funcdef-transform-translatey①">7.2. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-scale">
-   <b><a href="#funcdef-transform-scale">#funcdef-transform-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-scale" class="dfn-panel" data-for="funcdef-transform-scale" id="infopanel-for-funcdef-transform-scale" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-scale" style="display:none">Info about the 'scale()' definition.</span><b><a href="#funcdef-transform-scale">#funcdef-transform-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-scale">2. The Transform Rendering Model</a>
     <li><a href="#ref-for-funcdef-transform-scale①">6.3. SVG transform functions</a>
     <li><a href="#ref-for-funcdef-transform-scale②">7.2. Transform function primitives and derivatives</a> <a href="#ref-for-funcdef-transform-scale③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-scalex">
-   <b><a href="#funcdef-transform-scalex">#funcdef-transform-scalex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-scalex" class="dfn-panel" data-for="funcdef-transform-scalex" id="infopanel-for-funcdef-transform-scalex" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-scalex" style="display:none">Info about the 'scaleX()' definition.</span><b><a href="#funcdef-transform-scalex">#funcdef-transform-scalex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-scalex">6.2. Syntax of the SVG transform attribute</a>
     <li><a href="#ref-for-funcdef-transform-scalex①">7.2. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-scaley">
-   <b><a href="#funcdef-transform-scaley">#funcdef-transform-scaley</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-scaley" class="dfn-panel" data-for="funcdef-transform-scaley" id="infopanel-for-funcdef-transform-scaley" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-scaley" style="display:none">Info about the 'scaleY()' definition.</span><b><a href="#funcdef-transform-scaley">#funcdef-transform-scaley</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-scaley">6.2. Syntax of the SVG transform attribute</a>
     <li><a href="#ref-for-funcdef-transform-scaley①">7.2. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-rotate">
-   <b><a href="#funcdef-transform-rotate">#funcdef-transform-rotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-rotate" class="dfn-panel" data-for="funcdef-transform-rotate" id="infopanel-for-funcdef-transform-rotate" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-rotate" style="display:none">Info about the 'rotate()' definition.</span><b><a href="#funcdef-transform-rotate">#funcdef-transform-rotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-rotate">2. The Transform Rendering Model</a>
     <li><a href="#ref-for-funcdef-transform-rotate①">6.3. SVG transform functions</a>
     <li><a href="#ref-for-funcdef-transform-rotate②">Since the 30 November 2017 Working Draft </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-skew">
-   <b><a href="#funcdef-transform-skew">#funcdef-transform-skew</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-skew" class="dfn-panel" data-for="funcdef-transform-skew" id="infopanel-for-funcdef-transform-skew" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-skew" style="display:none">Info about the 'skew()' definition.</span><b><a href="#funcdef-transform-skew">#funcdef-transform-skew</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skew">6.2. Syntax of the SVG transform attribute</a>
     <li><a href="#ref-for-funcdef-transform-skew①">7.1. 2D Transform Functions</a> <a href="#ref-for-funcdef-transform-skew②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-skewx">
-   <b><a href="#funcdef-transform-skewx">#funcdef-transform-skewx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-skewx" class="dfn-panel" data-for="funcdef-transform-skewx" id="infopanel-for-funcdef-transform-skewx" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-skewx" style="display:none">Info about the 'skewX()' definition.</span><b><a href="#funcdef-transform-skewx">#funcdef-transform-skewx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skewx">6.3. SVG transform functions</a>
     <li><a href="#ref-for-funcdef-transform-skewx①">7.1. 2D Transform Functions</a> <a href="#ref-for-funcdef-transform-skewx②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-transform-skewy">
-   <b><a href="#funcdef-transform-skewy">#funcdef-transform-skewy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-transform-skewy" class="dfn-panel" data-for="funcdef-transform-skewy" id="infopanel-for-funcdef-transform-skewy" role="dialog">
+   <span id="infopaneltitle-for-funcdef-transform-skewy" style="display:none">Info about the 'skewY()' definition.</span><b><a href="#funcdef-transform-skewy">#funcdef-transform-skewy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-skewy">6.3. SVG transform functions</a>
     <li><a href="#ref-for-funcdef-transform-skewy①">7.1. 2D Transform Functions</a> <a href="#ref-for-funcdef-transform-skewy②">(2)</a>
@@ -4981,59 +4981,115 @@ avoid matrix interpolation for the common prefix of the two lists.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transforms-2/Overview.html
@@ -2766,106 +2766,106 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
    <li><a href="#valdef-rotate-y">y</a><span>, in § 5</span>
    <li><a href="#valdef-rotate-z">z</a><span>, in § 5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-isolation">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-isolation" class="dfn-panel" data-for="term-for-propdef-isolation" id="infopanel-for-term-for-propdef-isolation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-isolation" style="display:none">Info about the 'isolation' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-isolation">https://drafts.fxtf.org/compositing-2/#propdef-isolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-isolation">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mix-blend-mode">
-   <a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mix-blend-mode" class="dfn-panel" data-for="term-for-propdef-mix-blend-mode" id="infopanel-for-term-for-propdef-mix-blend-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mix-blend-mode" style="display:none">Info about the 'mix-blend-mode' external reference.</span><a href="https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode">https://drafts.fxtf.org/compositing-2/#propdef-mix-blend-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mix-blend-mode">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">9. The perspective-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2.1. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-computed-value①">(2)</a>
     <li><a href="#ref-for-computed-value②">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-clippath">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-clippath" class="dfn-panel" data-for="term-for-elementdef-clippath" id="infopanel-for-term-for-elementdef-clippath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-clippath" style="display:none">Info about the 'clippath' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-clippath">11. SVG and 3D transform functions</a> <a href="#ref-for-elementdef-clippath①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-mask" class="dfn-panel" data-for="term-for-elementdef-mask" id="infopanel-for-term-for-elementdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-mask">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-source">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-source" class="dfn-panel" data-for="term-for-propdef-mask-border-source" id="infopanel-for-term-for-propdef-mask-border-source" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-source" style="display:none">Info about the 'mask-border-source' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-source">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-image">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-image" class="dfn-panel" data-for="term-for-propdef-mask-image" id="infopanel-for-term-for-propdef-mask-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-image" style="display:none">Info about the 'mask-image' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-clip">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-clip" class="dfn-panel" data-for="term-for-valdef-overflow-clip" id="infopanel-for-term-for-valdef-overflow-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-2d-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#2d-matrix">https://drafts.csswg.org/css-transforms-1/#2d-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-2d-matrix" class="dfn-panel" data-for="term-for-2d-matrix" id="infopanel-for-term-for-2d-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-2d-matrix" style="display:none">Info about the '2d matrix' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#2d-matrix">https://drafts.csswg.org/css-transforms-1/#2d-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-2d-matrix">2. Terminology</a>
     <li><a href="#ref-for-2d-matrix①">2.1. Serialization of the computed value of &lt;transform-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-list">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-list" class="dfn-panel" data-for="term-for-typedef-transform-list" id="infopanel-for-term-for-typedef-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">2.1. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-typedef-transform-list①">(2)</a> <a href="#ref-for-typedef-transform-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block-for-all-descendants">
-   <a href="https://drafts.csswg.org/css-transforms-1/#containing-block-for-all-descendants">https://drafts.csswg.org/css-transforms-1/#containing-block-for-all-descendants</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block-for-all-descendants" class="dfn-panel" data-for="term-for-containing-block-for-all-descendants" id="infopanel-for-term-for-containing-block-for-all-descendants" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block-for-all-descendants" style="display:none">Info about the 'containing block for all descendants' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#containing-block-for-all-descendants">https://drafts.csswg.org/css-transforms-1/#containing-block-for-all-descendants</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block-for-all-descendants">1.1. Module Interactions</a>
     <li><a href="#ref-for-containing-block-for-all-descendants①">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-containing-block-for-all-descendants②">(2)</a>
@@ -2873,31 +2873,31 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-containing-block-for-all-descendants④">8. The perspective Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-matrix" class="dfn-panel" data-for="term-for-funcdef-transform-matrix" id="infopanel-for-term-for-funcdef-transform-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-matrix" style="display:none">Info about the 'matrix()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-matrix">2.1. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-funcdef-transform-matrix①">(2)</a> <a href="#ref-for-funcdef-transform-matrix②">(3)</a>
     <li><a href="#ref-for-funcdef-transform-matrix③">14. Interpolation of primitives and derived transform functions</a> <a href="#ref-for-funcdef-transform-matrix④">(2)</a>
     <li><a href="#ref-for-funcdef-transform-matrix⑤">15.1. Neutral element for addition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reference-box">
-   <a href="https://drafts.csswg.org/css-transforms-1/#reference-box">https://drafts.csswg.org/css-transforms-1/#reference-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reference-box" class="dfn-panel" data-for="term-for-reference-box" id="infopanel-for-term-for-reference-box" role="menu">
+   <span id="infopaneltitle-for-term-for-reference-box" style="display:none">Info about the 'reference box' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#reference-box">https://drafts.csswg.org/css-transforms-1/#reference-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-box">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-reference-box①">9. The perspective-origin Property</a> <a href="#ref-for-reference-box②">(2)</a> <a href="#ref-for-reference-box③">(3)</a> <a href="#ref-for-reference-box④">(4)</a> <a href="#ref-for-reference-box⑤">(5)</a> <a href="#ref-for-reference-box⑥">(6)</a>
     <li><a href="#ref-for-reference-box⑦">12. The Transform Functions</a> <a href="#ref-for-reference-box⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-rotate" class="dfn-panel" data-for="term-for-funcdef-transform-rotate" id="infopanel-for-term-for-funcdef-transform-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-rotate" style="display:none">Info about the 'rotate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-rotate">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-funcdef-transform-rotate①">(2)</a>
     <li><a href="#ref-for-funcdef-transform-rotate②">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">1. Introduction</a> <a href="#ref-for-propdef-transform①">(2)</a>
     <li><a href="#ref-for-propdef-transform②">1.1. Module Interactions</a>
@@ -2912,16 +2912,16 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-transform①③">17. The SVG transform Attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-origin">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-origin" class="dfn-panel" data-for="term-for-propdef-transform-origin" id="infopanel-for-term-for-propdef-transform-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">4. The Transform Rendering Model</a> <a href="#ref-for-propdef-transform-origin①">(2)</a> <a href="#ref-for-propdef-transform-origin②">(3)</a> <a href="#ref-for-propdef-transform-origin③">(4)</a> <a href="#ref-for-propdef-transform-origin④">(5)</a>
     <li><a href="#ref-for-propdef-transform-origin⑤">6. Current Transformation Matrix</a> <a href="#ref-for-propdef-transform-origin⑥">(2)</a> <a href="#ref-for-propdef-transform-origin⑦">(3)</a>
     <li><a href="#ref-for-propdef-transform-origin⑧">17. The SVG transform Attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformable-element">
-   <a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">https://drafts.csswg.org/css-transforms-1/#transformable-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformable-element" class="dfn-panel" data-for="term-for-transformable-element" id="infopanel-for-term-for-transformable-element" role="menu">
+   <span id="infopaneltitle-for-term-for-transformable-element" style="display:none">Info about the 'transformable element' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#transformable-element">https://drafts.csswg.org/css-transforms-1/#transformable-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformable-element">4.1.2. 3D Rendering Contexts</a>
     <li><a href="#ref-for-transformable-element①">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-transformable-element②">(2)</a> <a href="#ref-for-transformable-element③">(3)</a>
@@ -2931,60 +2931,60 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-transformable-element⑦">10. The backface-visibility Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformation-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#transformation-matrix">https://drafts.csswg.org/css-transforms-1/#transformation-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformation-matrix" class="dfn-panel" data-for="term-for-transformation-matrix" id="infopanel-for-term-for-transformation-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-transformation-matrix" style="display:none">Info about the 'transformation matrix' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#transformation-matrix">https://drafts.csswg.org/css-transforms-1/#transformation-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformation-matrix">4. The Transform Rendering Model</a>
     <li><a href="#ref-for-transformation-matrix①">4.1.4. Accumulated 3D Transformation Matrix Computation</a>
     <li><a href="#ref-for-transformation-matrix②">6. Current Transformation Matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformed-element">
-   <a href="https://drafts.csswg.org/css-transforms-1/#transformed-element">https://drafts.csswg.org/css-transforms-1/#transformed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformed-element" class="dfn-panel" data-for="term-for-transformed-element" id="infopanel-for-term-for-transformed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-transformed-element" style="display:none">Info about the 'transformed element' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#transformed-element">https://drafts.csswg.org/css-transforms-1/#transformed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-element">4.1.3. Transformed element hierarchies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translate" class="dfn-panel" data-for="term-for-funcdef-transform-translate" id="infopanel-for-term-for-funcdef-transform-translate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translate" style="display:none">Info about the 'translate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translate">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-funcdef-transform-translate①">(2)</a>
     <li><a href="#ref-for-funcdef-transform-translate②">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translatex">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translatex" class="dfn-panel" data-for="term-for-funcdef-transform-translatex" id="infopanel-for-term-for-funcdef-transform-translatex" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translatex" style="display:none">Info about the 'translatex()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatex">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-translatey">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-translatey" class="dfn-panel" data-for="term-for-funcdef-transform-translatey" id="infopanel-for-term-for-funcdef-transform-translatey" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-translatey" style="display:none">Info about the 'translatey()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-translatey</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-translatey">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">12.1. 2D Transform Functions</a>
     <li><a href="#ref-for-mult-comma①">12.2. 3D Transform Functions</a> <a href="#ref-for-mult-comma②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">12.2. 3D Transform Functions</a> <a href="#ref-for-comb-comma①">(2)</a> <a href="#ref-for-comb-comma②">(3)</a> <a href="#ref-for-comb-comma③">(4)</a> <a href="#ref-for-comb-comma④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a> <a href="#ref-for-angle-value③">(4)</a>
     <li><a href="#ref-for-angle-value④">5.1. Serialization</a>
@@ -2993,15 +2993,15 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-angle-value⑦">12.2. 3D Transform Functions</a> <a href="#ref-for-angle-value⑧">(2)</a> <a href="#ref-for-angle-value⑨">(3)</a> <a href="#ref-for-angle-value①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
     <li><a href="#ref-for-typedef-length-percentage③">12.2. 3D Transform Functions</a> <a href="#ref-for-typedef-length-percentage④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-length-value①">8. The perspective Property</a> <a href="#ref-for-length-value②">(2)</a> <a href="#ref-for-length-value③">(3)</a> <a href="#ref-for-length-value④">(4)</a>
@@ -3009,8 +3009,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-length-value⑥">12.2. 3D Transform Functions</a> <a href="#ref-for-length-value⑦">(2)</a> <a href="#ref-for-length-value⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a> <a href="#ref-for-number-value③">(4)</a> <a href="#ref-for-number-value④">(5)</a>
     <li><a href="#ref-for-number-value⑤">12. The Transform Functions</a>
@@ -3018,8 +3018,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-number-value⑨">12.2. 3D Transform Functions</a> <a href="#ref-for-number-value①⓪">(2)</a> <a href="#ref-for-number-value①①">(3)</a> <a href="#ref-for-number-value①②">(4)</a> <a href="#ref-for-number-value①③">(5)</a> <a href="#ref-for-number-value①④">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-percentage-value①">(2)</a>
     <li><a href="#ref-for-percentage-value②">9. The perspective-origin Property</a>
@@ -3027,56 +3027,56 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-percentage-value⑥">12.2. 3D Transform Functions</a> <a href="#ref-for-percentage-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">9. The perspective-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-zero-value">
-   <a href="https://drafts.csswg.org/css-values-4/#zero-value">https://drafts.csswg.org/css-values-4/#zero-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-zero-value" class="dfn-panel" data-for="term-for-zero-value" id="infopanel-for-term-for-zero-value" role="menu">
+   <span id="infopaneltitle-for-term-for-zero-value" style="display:none">Info about the '&lt;zero>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#zero-value">https://drafts.csswg.org/css-values-4/#zero-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-zero-value">12.2. 3D Transform Functions</a> <a href="#ref-for-zero-value①">(2)</a> <a href="#ref-for-zero-value②">(3)</a> <a href="#ref-for-zero-value③">(4)</a> <a href="#ref-for-zero-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-mult-opt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accumulation">
-   <a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accumulation" class="dfn-panel" data-for="term-for-accumulation" id="infopanel-for-term-for-accumulation" role="menu">
+   <span id="infopaneltitle-for-term-for-accumulation" style="display:none">Info about the 'value accumulation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accumulation">15. Addition and accumulation of transform lists</a> <a href="#ref-for-accumulation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-addition">
-   <a href="https://drafts.csswg.org/css-values-4/#addition">https://drafts.csswg.org/css-values-4/#addition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-addition" class="dfn-panel" data-for="term-for-addition" id="infopanel-for-term-for-addition" role="menu">
+   <span id="infopaneltitle-for-term-for-addition" style="display:none">Info about the 'value addition' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#addition">https://drafts.csswg.org/css-values-4/#addition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-addition">15. Addition and accumulation of transform lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a>
     <li><a href="#ref-for-comb-one⑧">7. The transform-style Property</a>
@@ -3086,134 +3086,134 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-comb-one①④">12.2. 3D Transform Functions</a> <a href="#ref-for-comb-one①⑤">(2)</a> <a href="#ref-for-comb-one①⑥">(3)</a> <a href="#ref-for-comb-one①⑦">(4)</a> <a href="#ref-for-comb-one①⑧">(5)</a> <a href="#ref-for-comb-one①⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-clip-auto">https://drafts.csswg.org/css2/#valdef-clip-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-auto" class="dfn-panel" data-for="term-for-valdef-clip-auto" id="infopanel-for-term-for-valdef-clip-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-clip-auto">https://drafts.csswg.org/css2/#valdef-clip-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-auto">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">1.1. Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value-special-case-property-like-height">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property-like-height">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property-like-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value-special-case-property-like-height" class="dfn-panel" data-for="term-for-resolved-value-special-case-property-like-height" id="infopanel-for-term-for-resolved-value-special-case-property-like-height" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value-special-case-property-like-height" style="display:none">Info about the 'resolved value special case property like height' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property-like-height">https://drafts.csswg.org/cssom-1/#resolved-value-special-case-property-like-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value-special-case-property-like-height">9. The perspective-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-filter" class="dfn-panel" data-for="term-for-propdef-filter" id="infopanel-for-term-for-propdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-filter">7.1. Grouping property values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">15. Addition and accumulation of transform lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">15. Addition and accumulation of transform lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset" class="dfn-panel" data-for="term-for-propdef-offset" id="infopanel-for-term-for-propdef-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset" style="display:none">Info about the 'offset' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset">6. Current Transformation Matrix</a> <a href="#ref-for-propdef-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-animate">
-   <a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-animate" class="dfn-panel" data-for="term-for-elementdef-animate" id="infopanel-for-term-for-elementdef-animate" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-animate" style="display:none">Info about the 'animate' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-animate">18.1. The animate and set element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-set">
-   <a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-set" class="dfn-panel" data-for="term-for-elementdef-set" id="infopanel-for-term-for-elementdef-set" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-set" style="display:none">Info about the 'set' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-set">18.1. The animate and set element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-element" class="dfn-panel" data-for="term-for-container-element" id="infopanel-for-term-for-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-container-element" style="display:none">Info about the 'container element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-element">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-foreignObject">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-foreignObject" class="dfn-panel" data-for="term-for-elementdef-foreignObject" id="infopanel-for-term-for-elementdef-foreignObject" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-foreignObject" style="display:none">Info about the 'foreignobject' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-foreignObject">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-g">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-g" class="dfn-panel" data-for="term-for-elementdef-g" id="infopanel-for-term-for-elementdef-g" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-g" style="display:none">Info about the 'g' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-g">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-graphics-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-graphics-element" class="dfn-panel" data-for="term-for-graphics-element" id="infopanel-for-term-for-graphics-element" role="menu">
+   <span id="infopaneltitle-for-term-for-graphics-element" style="display:none">Info about the 'graphics element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-graphics-element">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-graphics-referencing-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#graphics-referencing-element">https://svgwg.org/svg2-draft/struct.html#graphics-referencing-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-graphics-referencing-element" class="dfn-panel" data-for="term-for-graphics-referencing-element" id="infopanel-for-term-for-graphics-referencing-element" role="menu">
+   <span id="infopaneltitle-for-term-for-graphics-referencing-element" style="display:none">Info about the 'graphics referencing element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#graphics-referencing-element">https://svgwg.org/svg2-draft/struct.html#graphics-referencing-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-graphics-referencing-element">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-linearGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-linearGradient" class="dfn-panel" data-for="term-for-elementdef-linearGradient" id="infopanel-for-term-for-elementdef-linearGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-linearGradient" style="display:none">Info about the 'lineargradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-linearGradient">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">11. SVG and 3D transform functions</a> <a href="#ref-for-elementdef-pattern①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-radialGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-radialGradient" class="dfn-panel" data-for="term-for-elementdef-radialGradient" id="infopanel-for-term-for-elementdef-radialGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-radialGradient" style="display:none">Info about the 'radialgradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-radialGradient">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VectorEffectProperty">
-   <a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VectorEffectProperty" class="dfn-panel" data-for="term-for-VectorEffectProperty" id="infopanel-for-term-for-VectorEffectProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-VectorEffectProperty" style="display:none">Info about the 'vector-effect' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VectorEffectProperty">11. SVG and 3D transform functions</a>
    </ul>
@@ -3512,26 +3512,26 @@ the WG resolved to add a formula for decomposing a transform into a unified "sca
 (the spec already defines how to decompose it into scaleX/Y/Z),
 for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/Specifying_decomposition_of_scale">Formula is defined here.</a> <a class="issue-return" href="#issue-b3f9db98" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="3d-transformed-element">
-   <b><a href="#3d-transformed-element">#3d-transformed-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-3d-transformed-element" class="dfn-panel" data-for="3d-transformed-element" id="infopanel-for-3d-transformed-element" role="dialog">
+   <span id="infopaneltitle-for-3d-transformed-element" style="display:none">Info about the '3D transformed element' definition.</span><b><a href="#3d-transformed-element">#3d-transformed-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3d-transformed-element">4.1.2. 3D Rendering Contexts</a> <a href="#ref-for-3d-transformed-element①">(2)</a> <a href="#ref-for-3d-transformed-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="3d-matrix">
-   <b><a href="#3d-matrix">#3d-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-3d-matrix" class="dfn-panel" data-for="3d-matrix" id="infopanel-for-3d-matrix" role="dialog">
+   <span id="infopaneltitle-for-3d-matrix" style="display:none">Info about the '3D matrix' definition.</span><b><a href="#3d-matrix">#3d-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3d-matrix">13. Interpolation of Matrices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identity-transform-function">
-   <b><a href="#identity-transform-function">#identity-transform-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identity-transform-function" class="dfn-panel" data-for="identity-transform-function" id="infopanel-for-identity-transform-function" role="dialog">
+   <span id="infopaneltitle-for-identity-transform-function" style="display:none">Info about the 'identity transform function' definition.</span><b><a href="#identity-transform-function">#identity-transform-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform-function">15. Addition and accumulation of transform lists</a> <a href="#ref-for-identity-transform-function①">(2)</a> <a href="#ref-for-identity-transform-function②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="perspective-matrix">
-   <b><a href="#perspective-matrix">#perspective-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-perspective-matrix" class="dfn-panel" data-for="perspective-matrix" id="infopanel-for-perspective-matrix" role="dialog">
+   <span id="infopaneltitle-for-perspective-matrix" style="display:none">Info about the 'perspective matrix' definition.</span><b><a href="#perspective-matrix">#perspective-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perspective-matrix">4.1.1. Perspective</a>
     <li><a href="#ref-for-perspective-matrix①">4.1.4. Accumulated 3D Transformation Matrix Computation</a>
@@ -3539,8 +3539,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-perspective-matrix③">9. The perspective-origin Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accumulated-3d-transformation-matrix">
-   <b><a href="#accumulated-3d-transformation-matrix">#accumulated-3d-transformation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accumulated-3d-transformation-matrix" class="dfn-panel" data-for="accumulated-3d-transformation-matrix" id="infopanel-for-accumulated-3d-transformation-matrix" role="dialog">
+   <span id="infopaneltitle-for-accumulated-3d-transformation-matrix" style="display:none">Info about the 'accumulated 3D transformation matrix' definition.</span><b><a href="#accumulated-3d-transformation-matrix">#accumulated-3d-transformation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accumulated-3d-transformation-matrix">4.1.4. Accumulated 3D Transformation Matrix Computation</a> <a href="#ref-for-accumulated-3d-transformation-matrix①">(2)</a>
     <li><a href="#ref-for-accumulated-3d-transformation-matrix②">4.1.5. Backface Visibility</a>
@@ -3548,8 +3548,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-accumulated-3d-transformation-matrix⑤">10. The backface-visibility Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="3d-rendering-context">
-   <b><a href="#3d-rendering-context">#3d-rendering-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-3d-rendering-context" class="dfn-panel" data-for="3d-rendering-context" id="infopanel-for-3d-rendering-context" role="dialog">
+   <span id="infopaneltitle-for-3d-rendering-context" style="display:none">Info about the '3D rendering context' definition.</span><b><a href="#3d-rendering-context">#3d-rendering-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3d-rendering-context">2. Terminology</a>
     <li><a href="#ref-for-3d-rendering-context①">4.1. 3D Transform Rendering</a>
@@ -3561,8 +3561,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-3d-rendering-context①⑤">11. SVG and 3D transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-translate">
-   <b><a href="#propdef-translate">#propdef-translate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-translate" class="dfn-panel" data-for="propdef-translate" id="infopanel-for-propdef-translate" role="dialog">
+   <span id="infopaneltitle-for-propdef-translate" style="display:none">Info about the 'translate' definition.</span><b><a href="#propdef-translate">#propdef-translate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-translate">1. Introduction</a>
     <li><a href="#ref-for-propdef-translate①">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-propdef-translate②">(2)</a> <a href="#ref-for-propdef-translate③">(3)</a> <a href="#ref-for-propdef-translate④">(4)</a> <a href="#ref-for-propdef-translate⑤">(5)</a> <a href="#ref-for-propdef-translate⑥">(6)</a>
@@ -3570,8 +3570,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-translate⑧">6. Current Transformation Matrix</a> <a href="#ref-for-propdef-translate⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-rotate">
-   <b><a href="#propdef-rotate">#propdef-rotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-rotate" class="dfn-panel" data-for="propdef-rotate" id="infopanel-for-propdef-rotate" role="dialog">
+   <span id="infopaneltitle-for-propdef-rotate" style="display:none">Info about the 'rotate' definition.</span><b><a href="#propdef-rotate">#propdef-rotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rotate">1. Introduction</a>
     <li><a href="#ref-for-propdef-rotate①">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-propdef-rotate②">(2)</a> <a href="#ref-for-propdef-rotate③">(3)</a> <a href="#ref-for-propdef-rotate④">(4)</a> <a href="#ref-for-propdef-rotate⑤">(5)</a> <a href="#ref-for-propdef-rotate⑥">(6)</a> <a href="#ref-for-propdef-rotate⑦">(7)</a>
@@ -3579,14 +3579,14 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-rotate⑨">6. Current Transformation Matrix</a> <a href="#ref-for-propdef-rotate①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-rotate-z">
-   <b><a href="#valdef-rotate-z">#valdef-rotate-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-rotate-z" class="dfn-panel" data-for="valdef-rotate-z" id="infopanel-for-valdef-rotate-z" role="dialog">
+   <span id="infopaneltitle-for-valdef-rotate-z" style="display:none">Info about the 'z' definition.</span><b><a href="#valdef-rotate-z">#valdef-rotate-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rotate-z">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scale">
-   <b><a href="#propdef-scale">#propdef-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scale" class="dfn-panel" data-for="propdef-scale" id="infopanel-for-propdef-scale" role="dialog">
+   <span id="infopaneltitle-for-propdef-scale" style="display:none">Info about the 'scale' definition.</span><b><a href="#propdef-scale">#propdef-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scale">1. Introduction</a>
     <li><a href="#ref-for-propdef-scale①">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-propdef-scale②">(2)</a> <a href="#ref-for-propdef-scale③">(3)</a> <a href="#ref-for-propdef-scale④">(4)</a> <a href="#ref-for-propdef-scale⑤">(5)</a> <a href="#ref-for-propdef-scale⑥">(6)</a>
@@ -3594,15 +3594,15 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-scale⑧">6. Current Transformation Matrix</a> <a href="#ref-for-propdef-scale⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-translate-none">
-   <b><a href="#valdef-translate-none">#valdef-translate-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-translate-none" class="dfn-panel" data-for="valdef-translate-none" id="infopanel-for-valdef-translate-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-translate-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-translate-none">#valdef-translate-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-translate-none">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-valdef-translate-none①">(2)</a> <a href="#ref-for-valdef-translate-none②">(3)</a> <a href="#ref-for-valdef-translate-none③">(4)</a> <a href="#ref-for-valdef-translate-none④">(5)</a> <a href="#ref-for-valdef-translate-none⑤">(6)</a> <a href="#ref-for-valdef-translate-none⑥">(7)</a> <a href="#ref-for-valdef-translate-none⑦">(8)</a>
     <li><a href="#ref-for-valdef-translate-none⑧">5.1. Serialization</a> <a href="#ref-for-valdef-translate-none⑨">(2)</a> <a href="#ref-for-valdef-translate-none①⓪">(3)</a> <a href="#ref-for-valdef-translate-none①①">(4)</a> <a href="#ref-for-valdef-translate-none①②">(5)</a> <a href="#ref-for-valdef-translate-none①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transform-style">
-   <b><a href="#propdef-transform-style">#propdef-transform-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transform-style" class="dfn-panel" data-for="propdef-transform-style" id="infopanel-for-propdef-transform-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-transform-style" style="display:none">Info about the 'transform-style' definition.</span><b><a href="#propdef-transform-style">#propdef-transform-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-style">1. Introduction</a>
     <li><a href="#ref-for-propdef-transform-style①">1.1. Module Interactions</a>
@@ -3615,8 +3615,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-transform-style①①">18.1. The animate and set element</a> <a href="#ref-for-propdef-transform-style①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-perspective">
-   <b><a href="#propdef-perspective">#propdef-perspective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-perspective" class="dfn-panel" data-for="propdef-perspective" id="infopanel-for-propdef-perspective" role="dialog">
+   <span id="infopaneltitle-for-propdef-perspective" style="display:none">Info about the 'perspective' definition.</span><b><a href="#propdef-perspective">#propdef-perspective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective">1. Introduction</a>
     <li><a href="#ref-for-propdef-perspective①">1.1. Module Interactions</a>
@@ -3632,15 +3632,15 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-perspective①⑦">18.1. The animate and set element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-perspective-none">
-   <b><a href="#valdef-perspective-none">#valdef-perspective-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-perspective-none" class="dfn-panel" data-for="valdef-perspective-none" id="infopanel-for-valdef-perspective-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-perspective-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-perspective-none">#valdef-perspective-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-perspective-none">4.1.4. Accumulated 3D Transformation Matrix Computation</a>
     <li><a href="#ref-for-valdef-perspective-none①">8. The perspective Property</a> <a href="#ref-for-valdef-perspective-none②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-perspective-origin">
-   <b><a href="#propdef-perspective-origin">#propdef-perspective-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-perspective-origin" class="dfn-panel" data-for="propdef-perspective-origin" id="infopanel-for-propdef-perspective-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-perspective-origin" style="display:none">Info about the 'perspective-origin' definition.</span><b><a href="#propdef-perspective-origin">#propdef-perspective-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective-origin">1. Introduction</a>
     <li><a href="#ref-for-propdef-perspective-origin①">2. Terminology</a>
@@ -3653,8 +3653,8 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-perspective-origin①⑤">18.1. The animate and set element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-backface-visibility">
-   <b><a href="#propdef-backface-visibility">#propdef-backface-visibility</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-backface-visibility" class="dfn-panel" data-for="propdef-backface-visibility" id="infopanel-for-propdef-backface-visibility" role="dialog">
+   <span id="infopaneltitle-for-propdef-backface-visibility" style="display:none">Info about the 'backface-visibility' definition.</span><b><a href="#propdef-backface-visibility">#propdef-backface-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-backface-visibility">1. Introduction</a>
     <li><a href="#ref-for-propdef-backface-visibility①">1.1. Module Interactions</a>
@@ -3666,103 +3666,103 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
     <li><a href="#ref-for-propdef-backface-visibility⑨">18.1. The animate and set element</a> <a href="#ref-for-propdef-backface-visibility①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-transform-function">
-   <b><a href="#typedef-transform-function">#typedef-transform-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-transform-function" class="dfn-panel" data-for="typedef-transform-function" id="infopanel-for-typedef-transform-function" role="dialog">
+   <span id="infopaneltitle-for-typedef-transform-function" style="display:none">Info about the '&lt;transform-function>' definition.</span><b><a href="#typedef-transform-function">#typedef-transform-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-function">2.1. Serialization of the computed value of &lt;transform-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-scale">
-   <b><a href="#funcdef-scale">#funcdef-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-scale" class="dfn-panel" data-for="funcdef-scale" id="infopanel-for-funcdef-scale" role="dialog">
+   <span id="infopaneltitle-for-funcdef-scale" style="display:none">Info about the 'scale()' definition.</span><b><a href="#funcdef-scale">#funcdef-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scale">5. Individual Transform Properties: the translate, scale, and rotate properties</a> <a href="#ref-for-funcdef-scale①">(2)</a>
     <li><a href="#ref-for-funcdef-scale②">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-scalex">
-   <b><a href="#funcdef-scalex">#funcdef-scalex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-scalex" class="dfn-panel" data-for="funcdef-scalex" id="infopanel-for-funcdef-scalex" role="dialog">
+   <span id="infopaneltitle-for-funcdef-scalex" style="display:none">Info about the 'scaleX()' definition.</span><b><a href="#funcdef-scalex">#funcdef-scalex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scalex">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-scaley">
-   <b><a href="#funcdef-scaley">#funcdef-scaley</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-scaley" class="dfn-panel" data-for="funcdef-scaley" id="infopanel-for-funcdef-scaley" role="dialog">
+   <span id="infopaneltitle-for-funcdef-scaley" style="display:none">Info about the 'scaleY()' definition.</span><b><a href="#funcdef-scaley">#funcdef-scaley</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scaley">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="3d-transform-functions">
-   <b><a href="#3d-transform-functions">#3d-transform-functions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-3d-transform-functions" class="dfn-panel" data-for="3d-transform-functions" id="infopanel-for-3d-transform-functions" role="dialog">
+   <span id="infopaneltitle-for-3d-transform-functions" style="display:none">Info about the '3d transform functions' definition.</span><b><a href="#3d-transform-functions">#3d-transform-functions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-3d-transform-functions">1.1. Module Interactions</a>
     <li><a href="#ref-for-3d-transform-functions①">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-matrix3d">
-   <b><a href="#funcdef-matrix3d">#funcdef-matrix3d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-matrix3d" class="dfn-panel" data-for="funcdef-matrix3d" id="infopanel-for-funcdef-matrix3d" role="dialog">
+   <span id="infopaneltitle-for-funcdef-matrix3d" style="display:none">Info about the 'matrix3d()' definition.</span><b><a href="#funcdef-matrix3d">#funcdef-matrix3d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-matrix3d">2.1. Serialization of the computed value of &lt;transform-list></a> <a href="#ref-for-funcdef-matrix3d①">(2)</a> <a href="#ref-for-funcdef-matrix3d②">(3)</a>
     <li><a href="#ref-for-funcdef-matrix3d③">14. Interpolation of primitives and derived transform functions</a> <a href="#ref-for-funcdef-matrix3d④">(2)</a>
     <li><a href="#ref-for-funcdef-matrix3d⑤">15.1. Neutral element for addition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-translate3d">
-   <b><a href="#funcdef-translate3d">#funcdef-translate3d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-translate3d" class="dfn-panel" data-for="funcdef-translate3d" id="infopanel-for-funcdef-translate3d" role="dialog">
+   <span id="infopaneltitle-for-funcdef-translate3d" style="display:none">Info about the 'translate3d()' definition.</span><b><a href="#funcdef-translate3d">#funcdef-translate3d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-translate3d">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-translate3d①">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-translatez">
-   <b><a href="#funcdef-translatez">#funcdef-translatez</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-translatez" class="dfn-panel" data-for="funcdef-translatez" id="infopanel-for-funcdef-translatez" role="dialog">
+   <span id="infopaneltitle-for-funcdef-translatez" style="display:none">Info about the 'translateZ()' definition.</span><b><a href="#funcdef-translatez">#funcdef-translatez</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-translatez">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-scale3d">
-   <b><a href="#funcdef-scale3d">#funcdef-scale3d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-scale3d" class="dfn-panel" data-for="funcdef-scale3d" id="infopanel-for-funcdef-scale3d" role="dialog">
+   <span id="infopaneltitle-for-funcdef-scale3d" style="display:none">Info about the 'scale3d()' definition.</span><b><a href="#funcdef-scale3d">#funcdef-scale3d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scale3d">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-scale3d①">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-scalez">
-   <b><a href="#funcdef-scalez">#funcdef-scalez</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-scalez" class="dfn-panel" data-for="funcdef-scalez" id="infopanel-for-funcdef-scalez" role="dialog">
+   <span id="infopaneltitle-for-funcdef-scalez" style="display:none">Info about the 'scaleZ()' definition.</span><b><a href="#funcdef-scalez">#funcdef-scalez</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-scalez">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rotate3d">
-   <b><a href="#funcdef-rotate3d">#funcdef-rotate3d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rotate3d" class="dfn-panel" data-for="funcdef-rotate3d" id="infopanel-for-funcdef-rotate3d" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rotate3d" style="display:none">Info about the 'rotate3d()' definition.</span><b><a href="#funcdef-rotate3d">#funcdef-rotate3d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotate3d">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-rotate3d①">12.3. Transform function primitives and derivatives</a>
     <li><a href="#ref-for-funcdef-rotate3d②">14. Interpolation of primitives and derived transform functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rotatex">
-   <b><a href="#funcdef-rotatex">#funcdef-rotatex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rotatex" class="dfn-panel" data-for="funcdef-rotatex" id="infopanel-for-funcdef-rotatex" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rotatex" style="display:none">Info about the 'rotateX()' definition.</span><b><a href="#funcdef-rotatex">#funcdef-rotatex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatex">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-rotatex①">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rotatey">
-   <b><a href="#funcdef-rotatey">#funcdef-rotatey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rotatey" class="dfn-panel" data-for="funcdef-rotatey" id="infopanel-for-funcdef-rotatey" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rotatey" style="display:none">Info about the 'rotateY()' definition.</span><b><a href="#funcdef-rotatey">#funcdef-rotatey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatey">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-rotatey①">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rotatez">
-   <b><a href="#funcdef-rotatez">#funcdef-rotatez</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rotatez" class="dfn-panel" data-for="funcdef-rotatez" id="infopanel-for-funcdef-rotatez" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rotatez" style="display:none">Info about the 'rotateZ()' definition.</span><b><a href="#funcdef-rotatez">#funcdef-rotatez</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rotatez">5. Individual Transform Properties: the translate, scale, and rotate properties</a>
     <li><a href="#ref-for-funcdef-rotatez①">12.3. Transform function primitives and derivatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-perspective">
-   <b><a href="#funcdef-perspective">#funcdef-perspective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-perspective" class="dfn-panel" data-for="funcdef-perspective" id="infopanel-for-funcdef-perspective" role="dialog">
+   <span id="infopaneltitle-for-funcdef-perspective" style="display:none">Info about the 'perspective()' definition.</span><b><a href="#funcdef-perspective">#funcdef-perspective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-perspective">4.1.1. Perspective</a> <a href="#ref-for-funcdef-perspective①">(2)</a>
     <li><a href="#ref-for-funcdef-perspective②">14. Interpolation of primitives and derived transform functions</a> <a href="#ref-for-funcdef-perspective③">(2)</a>
@@ -3771,59 +3771,115 @@ for use by things like SVG’s non-scaling stroke spec. <a href="https://www.w3.
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transitions-1/Overview.html
@@ -2456,96 +2456,96 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
    <li><a href="#transitionstart">transitionstart</a><span>, in § 6.2</span>
    <li><a href="#propdef-transition-timing-function">transition-timing-function</a><span>, in § 2.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-constructing-events">
-   <a href="http://w3c.github.io/dom/#constructing-events">http://w3c.github.io/dom/#constructing-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructing-events" class="dfn-panel" data-for="term-for-constructing-events" id="infopanel-for-term-for-constructing-events" role="menu">
+   <span id="infopaneltitle-for-term-for-constructing-events" style="display:none">Info about the 'event constructor' external reference.</span><a href="http://w3c.github.io/dom/#constructing-events">http://w3c.github.io/dom/#constructing-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructing-events">6.1.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadow-inset">
-   <a href="https://www.w3.org/TR/css3-background/#shadow-inset">https://www.w3.org/TR/css3-background/#shadow-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadow-inset" class="dfn-panel" data-for="term-for-shadow-inset" id="infopanel-for-term-for-shadow-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-shadow-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://www.w3.org/TR/css3-background/#shadow-inset">https://www.w3.org/TR/css3-background/#shadow-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-inset">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">2. Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">2.1. The transition-property Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">2. Transitions</a> <a href="#ref-for-computed-value①">(2)</a>
     <li><a href="#ref-for-computed-value②">3. Starting of transitions</a> <a href="#ref-for-computed-value③">(2)</a> <a href="#ref-for-computed-value④">(3)</a> <a href="#ref-for-computed-value⑤">(4)</a> <a href="#ref-for-computed-value⑥">(5)</a> <a href="#ref-for-computed-value⑦">(6)</a> <a href="#ref-for-computed-value⑧">(7)</a> <a href="#ref-for-computed-value⑨">(8)</a> <a href="#ref-for-computed-value①⓪">(9)</a> <a href="#ref-for-computed-value①①">(10)</a> <a href="#ref-for-computed-value①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.1. The transition-property Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">2.1. The transition-property Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">10.2. Cascade</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">2.3. The transition-timing-function Property</a>
     <li><a href="#ref-for-typedef-easing-function①">2.5. The transition Shorthand Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-input-progress-value">
-   <a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-input-progress-value" class="dfn-panel" data-for="term-for-input-progress-value" id="infopanel-for-term-for-input-progress-value" role="menu">
+   <span id="infopaneltitle-for-term-for-input-progress-value" style="display:none">Info about the 'input progress value' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-progress-value">2.3. The transition-timing-function Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-output-progress-value">
-   <a href="https://drafts.csswg.org/css-easing-2/#output-progress-value">https://drafts.csswg.org/css-easing-2/#output-progress-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-output-progress-value" class="dfn-panel" data-for="term-for-output-progress-value" id="infopanel-for-term-for-output-progress-value" role="menu">
+   <span id="infopaneltitle-for-term-for-output-progress-value" style="display:none">Info about the 'output progress value' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#output-progress-value">https://drafts.csswg.org/css-easing-2/#output-progress-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-output-progress-value">2.3. The transition-timing-function Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">8. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#time-value">https://drafts.csswg.org/css-values-3/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">2.2. The transition-duration Property</a>
     <li><a href="#ref-for-time-value①">2.4. The transition-delay Property</a>
     <li><a href="#ref-for-time-value②">2.5. The transition Shorthand Property</a> <a href="#ref-for-time-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.1. The transition-property Property</a>
     <li><a href="#ref-for-mult-comma①">2.2. The transition-duration Property</a>
@@ -2554,190 +2554,190 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
     <li><a href="#ref-for-mult-comma④">2.5. The transition Shorthand Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.1. The transition-property Property</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation" style="display:none">Info about the 'interpolate' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">2.3. The transition-timing-function Property</a>
     <li><a href="#ref-for-interpolation①">4. Application of transitions</a> <a href="#ref-for-interpolation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation①" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation①" style="display:none">Info about the 'interpolation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">2.3. The transition-timing-function Property</a>
     <li><a href="#ref-for-interpolation①">4. Application of transitions</a> <a href="#ref-for-interpolation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. The transition-property Property</a> <a href="#ref-for-comb-one①">(2)</a>
     <li><a href="#ref-for-comb-one②">2.5. The transition Shorthand Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">2.5. The transition Shorthand Property</a> <a href="#ref-for-comb-any①">(2)</a> <a href="#ref-for-comb-any②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css2/#propdef-background-color">https://drafts.csswg.org/css2/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-background-color">https://drafts.csswg.org/css2/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">2. Transitions</a> <a href="#ref-for-propdef-background-color①">(2)</a>
     <li><a href="#ref-for-propdef-background-color②">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">2. Transitions</a> <a href="#ref-for-propdef-left①">(2)</a> <a href="#ref-for-propdef-left②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">2. Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-width">https://drafts.csswg.org/css2/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-width">https://drafts.csswg.org/css2/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">2. Transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationevent-elapsedtime">
-   <a href="https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime">https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationevent-elapsedtime" class="dfn-panel" data-for="term-for-dom-animationevent-elapsedtime" id="infopanel-for-term-for-dom-animationevent-elapsedtime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationevent-elapsedtime" style="display:none">Info about the 'elapsedTime' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime">https://drafts.csswg.org/css-animations-1/#dom-animationevent-elapsedtime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationevent-elapsedtime">6.2. Types of TransitionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">6.1.1. IDL Definition</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a>
     <li><a href="#ref-for-cssomstring⑤">6.1.2. Attributes</a> <a href="#ref-for-cssomstring⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://html.spec.whatwg.org/#document">https://html.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://html.spec.whatwg.org/#document">https://html.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">7.1. IDL Definition</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-globaleventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-globaleventhandlers" class="dfn-panel" data-for="term-for-globaleventhandlers" id="infopanel-for-term-for-globaleventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-globaleventhandlers" style="display:none">Info about the 'GlobalEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-globaleventhandlers">7. DOM Interfaces</a>
     <li><a href="#ref-for-globaleventhandlers①">7.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-dispatch">https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-dispatch">https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">6. Transition Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-content-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-content-attributes" class="dfn-panel" data-for="term-for-event-handler-content-attributes" id="infopanel-for-term-for-event-handler-content-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-content-attributes" style="display:none">Info about the 'event handler content attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-content-attributes">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">6.3. Event handlers on elements, Document objects, and Window objects</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">6.3. Event handlers on elements, Document objects, and Window objects</a> <a href="#ref-for-event-handler-idl-attributes①">(2)</a>
     <li><a href="#ref-for-event-handler-idl-attributes②">7. DOM Interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">6.3. Event handlers on elements, Document objects, and Window objects</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-elements">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-elements" class="dfn-panel" data-for="term-for-html-elements" id="infopanel-for-term-for-html-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-html-elements" style="display:none">Info about the 'html elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-elements">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-type">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-type">https://drafts.csswg.org/web-animations-1/#animation-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-type" class="dfn-panel" data-for="term-for-animation-type" id="infopanel-for-term-for-animation-type" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-type" style="display:none">Info about the 'animation type' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-type">https://drafts.csswg.org/web-animations-1/#animation-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-type">3. Starting of transitions</a> <a href="#ref-for-animation-type①">(2)</a> <a href="#ref-for-animation-type②">(3)</a> <a href="#ref-for-animation-type③">(4)</a>
     <li><a href="#ref-for-animation-type④">4. Application of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-combining-shadow-lists">
-   <a href="https://drafts.csswg.org/web-animations-1/#combining-shadow-lists">https://drafts.csswg.org/web-animations-1/#combining-shadow-lists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-combining-shadow-lists" class="dfn-panel" data-for="term-for-combining-shadow-lists" id="infopanel-for-term-for-combining-shadow-lists" role="menu">
+   <span id="infopaneltitle-for-term-for-combining-shadow-lists" style="display:none">Info about the 'combining shadow lists' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#combining-shadow-lists">https://drafts.csswg.org/web-animations-1/#combining-shadow-lists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-combining-shadow-lists">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discrete">
-   <a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discrete" class="dfn-panel" data-for="term-for-discrete" id="infopanel-for-term-for-discrete" role="menu">
+   <span id="infopaneltitle-for-term-for-discrete" style="display:none">Info about the 'discrete' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discrete">3. Starting of transitions</a> <a href="#ref-for-discrete①">(2)</a> <a href="#ref-for-discrete②">(3)</a> <a href="#ref-for-discrete③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-not-animatable">
-   <a href="https://drafts.csswg.org/web-animations-1/#not-animatable">https://drafts.csswg.org/web-animations-1/#not-animatable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-not-animatable" class="dfn-panel" data-for="term-for-not-animatable" id="infopanel-for-term-for-not-animatable" role="menu">
+   <span id="infopaneltitle-for-term-for-not-animatable" style="display:none">Info about the 'not animatable' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#not-animatable">https://drafts.csswg.org/web-animations-1/#not-animatable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-animatable">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.1.1. IDL Definition</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">6.1.2. Attributes</a>
@@ -2996,8 +2996,8 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="propdef-transition-property">
-   <b><a href="#propdef-transition-property">#propdef-transition-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transition-property" class="dfn-panel" data-for="propdef-transition-property" id="infopanel-for-propdef-transition-property" role="dialog">
+   <span id="infopaneltitle-for-propdef-transition-property" style="display:none">Info about the 'transition-property' definition.</span><b><a href="#propdef-transition-property">#propdef-transition-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-property">2. Transitions</a> <a href="#ref-for-propdef-transition-property①">(2)</a> <a href="#ref-for-propdef-transition-property②">(3)</a>
     <li><a href="#ref-for-propdef-transition-property③">2.1. The transition-property Property</a> <a href="#ref-for-propdef-transition-property④">(2)</a> <a href="#ref-for-propdef-transition-property⑤">(3)</a> <a href="#ref-for-propdef-transition-property⑥">(4)</a>
@@ -3006,28 +3006,28 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
     <li><a href="#ref-for-propdef-transition-property①①">6.2. Types of TransitionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-transition-property">
-   <b><a href="#single-transition-property">#single-transition-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-transition-property" class="dfn-panel" data-for="single-transition-property" id="infopanel-for-single-transition-property" role="dialog">
+   <span id="infopaneltitle-for-single-transition-property" style="display:none">Info about the '&lt;single-transition-property>' definition.</span><b><a href="#single-transition-property">#single-transition-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-transition-property">2.1. The transition-property Property</a> <a href="#ref-for-single-transition-property①">(2)</a>
     <li><a href="#ref-for-single-transition-property②">2.5. The transition Shorthand Property</a> <a href="#ref-for-single-transition-property③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transition-property-none">
-   <b><a href="#valdef-transition-property-none">#valdef-transition-property-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transition-property-none" class="dfn-panel" data-for="valdef-transition-property-none" id="infopanel-for-valdef-transition-property-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-transition-property-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-transition-property-none">#valdef-transition-property-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transition-property-none">2.1. The transition-property Property</a> <a href="#ref-for-valdef-transition-property-none①">(2)</a> <a href="#ref-for-valdef-transition-property-none②">(3)</a>
     <li><a href="#ref-for-valdef-transition-property-none③">2.5. The transition Shorthand Property</a> <a href="#ref-for-valdef-transition-property-none④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-transition-property-all">
-   <b><a href="#valdef-transition-property-all">#valdef-transition-property-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-transition-property-all" class="dfn-panel" data-for="valdef-transition-property-all" id="infopanel-for-valdef-transition-property-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-transition-property-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-transition-property-all">#valdef-transition-property-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transition-property-all">2.1. The transition-property Property</a> <a href="#ref-for-valdef-transition-property-all①">(2)</a> <a href="#ref-for-valdef-transition-property-all②">(3)</a> <a href="#ref-for-valdef-transition-property-all③">(4)</a> <a href="#ref-for-valdef-transition-property-all④">(5)</a> <a href="#ref-for-valdef-transition-property-all⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transition-duration">
-   <b><a href="#propdef-transition-duration">#propdef-transition-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transition-duration" class="dfn-panel" data-for="propdef-transition-duration" id="infopanel-for-propdef-transition-duration" role="dialog">
+   <span id="infopaneltitle-for-propdef-transition-duration" style="display:none">Info about the 'transition-duration' definition.</span><b><a href="#propdef-transition-duration">#propdef-transition-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-duration">2.1. The transition-property Property</a>
     <li><a href="#ref-for-propdef-transition-duration①">2.2. The transition-duration Property</a> <a href="#ref-for-propdef-transition-duration②">(2)</a> <a href="#ref-for-propdef-transition-duration③">(3)</a>
@@ -3035,16 +3035,16 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
     <li><a href="#ref-for-propdef-transition-duration⑨">6.2. Types of TransitionEvent</a> <a href="#ref-for-propdef-transition-duration①⓪">(2)</a> <a href="#ref-for-propdef-transition-duration①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transition-timing-function">
-   <b><a href="#propdef-transition-timing-function">#propdef-transition-timing-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transition-timing-function" class="dfn-panel" data-for="propdef-transition-timing-function" id="infopanel-for-propdef-transition-timing-function" role="dialog">
+   <span id="infopaneltitle-for-propdef-transition-timing-function" style="display:none">Info about the 'transition-timing-function' definition.</span><b><a href="#propdef-transition-timing-function">#propdef-transition-timing-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-timing-function">2.1. The transition-property Property</a>
     <li><a href="#ref-for-propdef-transition-timing-function①">2.3. The transition-timing-function Property</a> <a href="#ref-for-propdef-transition-timing-function②">(2)</a>
     <li><a href="#ref-for-propdef-transition-timing-function③">3. Starting of transitions</a> <a href="#ref-for-propdef-transition-timing-function④">(2)</a> <a href="#ref-for-propdef-transition-timing-function⑤">(3)</a> <a href="#ref-for-propdef-transition-timing-function⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transition-delay">
-   <b><a href="#propdef-transition-delay">#propdef-transition-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transition-delay" class="dfn-panel" data-for="propdef-transition-delay" id="infopanel-for-propdef-transition-delay" role="dialog">
+   <span id="infopaneltitle-for-propdef-transition-delay" style="display:none">Info about the 'transition-delay' definition.</span><b><a href="#propdef-transition-delay">#propdef-transition-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-delay">2.1. The transition-property Property</a>
     <li><a href="#ref-for-propdef-transition-delay①">2.4. The transition-delay Property</a> <a href="#ref-for-propdef-transition-delay②">(2)</a> <a href="#ref-for-propdef-transition-delay③">(3)</a> <a href="#ref-for-propdef-transition-delay④">(4)</a> <a href="#ref-for-propdef-transition-delay⑤">(5)</a>
@@ -3052,277 +3052,333 @@ and all the rest of the <a href="http://lists.w3.org/Archives/Public/www-style/"
     <li><a href="#ref-for-propdef-transition-delay①⓪">6.2. Types of TransitionEvent</a> <a href="#ref-for-propdef-transition-delay①①">(2)</a> <a href="#ref-for-propdef-transition-delay①②">(3)</a> <a href="#ref-for-propdef-transition-delay①③">(4)</a> <a href="#ref-for-propdef-transition-delay①④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-transition">
-   <b><a href="#propdef-transition">#propdef-transition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-transition" class="dfn-panel" data-for="propdef-transition" id="infopanel-for-propdef-transition" role="dialog">
+   <span id="infopaneltitle-for-propdef-transition" style="display:none">Info about the 'transition' definition.</span><b><a href="#propdef-transition">#propdef-transition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition">2.5. The transition Shorthand Property</a> <a href="#ref-for-propdef-transition①">(2)</a>
     <li><a href="#ref-for-propdef-transition②">3. Starting of transitions</a> <a href="#ref-for-propdef-transition③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-transition">
-   <b><a href="#single-transition">#single-transition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-transition" class="dfn-panel" data-for="single-transition" id="infopanel-for-single-transition" role="dialog">
+   <span id="infopaneltitle-for-single-transition" style="display:none">Info about the '&lt;single-transition>' definition.</span><b><a href="#single-transition">#single-transition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-transition">2.5. The transition Shorthand Property</a> <a href="#ref-for-single-transition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="running-transition">
-   <b><a href="#running-transition">#running-transition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-running-transition" class="dfn-panel" data-for="running-transition" id="infopanel-for-running-transition" role="dialog">
+   <span id="infopaneltitle-for-running-transition" style="display:none">Info about the 'running transitions' definition.</span><b><a href="#running-transition">#running-transition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running-transition">3. Starting of transitions</a> <a href="#ref-for-running-transition①">(2)</a> <a href="#ref-for-running-transition②">(3)</a> <a href="#ref-for-running-transition③">(4)</a> <a href="#ref-for-running-transition④">(5)</a> <a href="#ref-for-running-transition⑤">(6)</a> <a href="#ref-for-running-transition⑥">(7)</a> <a href="#ref-for-running-transition⑦">(8)</a> <a href="#ref-for-running-transition⑧">(9)</a> <a href="#ref-for-running-transition⑨">(10)</a> <a href="#ref-for-running-transition①⓪">(11)</a> <a href="#ref-for-running-transition①①">(12)</a> <a href="#ref-for-running-transition①②">(13)</a> <a href="#ref-for-running-transition①③">(14)</a> <a href="#ref-for-running-transition①④">(15)</a> <a href="#ref-for-running-transition①⑤">(16)</a> <a href="#ref-for-running-transition①⑥">(17)</a> <a href="#ref-for-running-transition①⑦">(18)</a>
     <li><a href="#ref-for-running-transition①⑧">5. Completion of transitions</a> <a href="#ref-for-running-transition①⑨">(2)</a> <a href="#ref-for-running-transition②⓪">(3)</a>
     <li><a href="#ref-for-running-transition②①">6.2. Types of TransitionEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-start-time">
-   <b><a href="#transition-start-time">#transition-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-start-time" class="dfn-panel" data-for="transition-start-time" id="infopanel-for-transition-start-time" role="dialog">
+   <span id="infopaneltitle-for-transition-start-time" style="display:none">Info about the 'start time' definition.</span><b><a href="#transition-start-time">#transition-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-start-time">3. Starting of transitions</a> <a href="#ref-for-transition-start-time①">(2)</a> <a href="#ref-for-transition-start-time②">(3)</a> <a href="#ref-for-transition-start-time③">(4)</a> <a href="#ref-for-transition-start-time④">(5)</a> <a href="#ref-for-transition-start-time⑤">(6)</a>
     <li><a href="#ref-for-transition-start-time⑥">4. Application of transitions</a> <a href="#ref-for-transition-start-time⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-end-time">
-   <b><a href="#transition-end-time">#transition-end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-end-time" class="dfn-panel" data-for="transition-end-time" id="infopanel-for-transition-end-time" role="dialog">
+   <span id="infopaneltitle-for-transition-end-time" style="display:none">Info about the 'end time' definition.</span><b><a href="#transition-end-time">#transition-end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-end-time">3. Starting of transitions</a> <a href="#ref-for-transition-end-time①">(2)</a> <a href="#ref-for-transition-end-time②">(3)</a>
     <li><a href="#ref-for-transition-end-time③">4. Application of transitions</a>
     <li><a href="#ref-for-transition-end-time④">5. Completion of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-start-value">
-   <b><a href="#transition-start-value">#transition-start-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-start-value" class="dfn-panel" data-for="transition-start-value" id="infopanel-for-transition-start-value" role="dialog">
+   <span id="infopaneltitle-for-transition-start-value" style="display:none">Info about the 'start value' definition.</span><b><a href="#transition-start-value">#transition-start-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-start-value">3. Starting of transitions</a> <a href="#ref-for-transition-start-value①">(2)</a> <a href="#ref-for-transition-start-value②">(3)</a> <a href="#ref-for-transition-start-value③">(4)</a> <a href="#ref-for-transition-start-value④">(5)</a>
     <li><a href="#ref-for-transition-start-value⑤">4. Application of transitions</a> <a href="#ref-for-transition-start-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-end-value">
-   <b><a href="#transition-end-value">#transition-end-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-end-value" class="dfn-panel" data-for="transition-end-value" id="infopanel-for-transition-end-value" role="dialog">
+   <span id="infopaneltitle-for-transition-end-value" style="display:none">Info about the 'end value' definition.</span><b><a href="#transition-end-value">#transition-end-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-end-value">3. Starting of transitions</a> <a href="#ref-for-transition-end-value①">(2)</a> <a href="#ref-for-transition-end-value②">(3)</a> <a href="#ref-for-transition-end-value③">(4)</a> <a href="#ref-for-transition-end-value④">(5)</a> <a href="#ref-for-transition-end-value⑤">(6)</a> <a href="#ref-for-transition-end-value⑥">(7)</a> <a href="#ref-for-transition-end-value⑦">(8)</a>
     <li><a href="#ref-for-transition-end-value⑧">4. Application of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-reversing-adjusted-start-value">
-   <b><a href="#transition-reversing-adjusted-start-value">#transition-reversing-adjusted-start-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-reversing-adjusted-start-value" class="dfn-panel" data-for="transition-reversing-adjusted-start-value" id="infopanel-for-transition-reversing-adjusted-start-value" role="dialog">
+   <span id="infopaneltitle-for-transition-reversing-adjusted-start-value" style="display:none">Info about the 'reversing-adjusted start value' definition.</span><b><a href="#transition-reversing-adjusted-start-value">#transition-reversing-adjusted-start-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-reversing-adjusted-start-value">3. Starting of transitions</a> <a href="#ref-for-transition-reversing-adjusted-start-value①">(2)</a> <a href="#ref-for-transition-reversing-adjusted-start-value②">(3)</a> <a href="#ref-for-transition-reversing-adjusted-start-value③">(4)</a> <a href="#ref-for-transition-reversing-adjusted-start-value④">(5)</a> <a href="#ref-for-transition-reversing-adjusted-start-value⑤">(6)</a>
     <li><a href="#ref-for-transition-reversing-adjusted-start-value⑥">3.1. Faster reversing of interrupted transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-reversing-shortening-factor">
-   <b><a href="#transition-reversing-shortening-factor">#transition-reversing-shortening-factor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-reversing-shortening-factor" class="dfn-panel" data-for="transition-reversing-shortening-factor" id="infopanel-for-transition-reversing-shortening-factor" role="dialog">
+   <span id="infopaneltitle-for-transition-reversing-shortening-factor" style="display:none">Info about the 'reversing shortening factor' definition.</span><b><a href="#transition-reversing-shortening-factor">#transition-reversing-shortening-factor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-reversing-shortening-factor">3. Starting of transitions</a> <a href="#ref-for-transition-reversing-shortening-factor①">(2)</a> <a href="#ref-for-transition-reversing-shortening-factor②">(3)</a> <a href="#ref-for-transition-reversing-shortening-factor③">(4)</a> <a href="#ref-for-transition-reversing-shortening-factor④">(5)</a> <a href="#ref-for-transition-reversing-shortening-factor⑤">(6)</a> <a href="#ref-for-transition-reversing-shortening-factor⑥">(7)</a> <a href="#ref-for-transition-reversing-shortening-factor⑦">(8)</a>
     <li><a href="#ref-for-transition-reversing-shortening-factor⑧">3.1. Faster reversing of interrupted transitions</a> <a href="#ref-for-transition-reversing-shortening-factor⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="completed-transition">
-   <b><a href="#completed-transition">#completed-transition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-completed-transition" class="dfn-panel" data-for="completed-transition" id="infopanel-for-completed-transition" role="dialog">
+   <span id="infopaneltitle-for-completed-transition" style="display:none">Info about the 'completed transitions' definition.</span><b><a href="#completed-transition">#completed-transition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-completed-transition">3. Starting of transitions</a> <a href="#ref-for-completed-transition①">(2)</a> <a href="#ref-for-completed-transition②">(3)</a> <a href="#ref-for-completed-transition③">(4)</a> <a href="#ref-for-completed-transition④">(5)</a> <a href="#ref-for-completed-transition⑤">(6)</a> <a href="#ref-for-completed-transition⑥">(7)</a> <a href="#ref-for-completed-transition⑦">(8)</a> <a href="#ref-for-completed-transition⑧">(9)</a> <a href="#ref-for-completed-transition⑨">(10)</a> <a href="#ref-for-completed-transition①⓪">(11)</a> <a href="#ref-for-completed-transition①①">(12)</a>
     <li><a href="#ref-for-completed-transition①②">5. Completion of transitions</a> <a href="#ref-for-completed-transition①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-change-event">
-   <b><a href="#style-change-event">#style-change-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-change-event" class="dfn-panel" data-for="style-change-event" id="infopanel-for-style-change-event" role="dialog">
+   <span id="infopaneltitle-for-style-change-event" style="display:none">Info about the 'style change event' definition.</span><b><a href="#style-change-event">#style-change-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-change-event">3. Starting of transitions</a> <a href="#ref-for-style-change-event①">(2)</a> <a href="#ref-for-style-change-event②">(3)</a> <a href="#ref-for-style-change-event③">(4)</a> <a href="#ref-for-style-change-event④">(5)</a> <a href="#ref-for-style-change-event⑤">(6)</a> <a href="#ref-for-style-change-event⑥">(7)</a> <a href="#ref-for-style-change-event⑦">(8)</a> <a href="#ref-for-style-change-event⑧">(9)</a>
     <li><a href="#ref-for-style-change-event⑨">5. Completion of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="before-change-style">
-   <b><a href="#before-change-style">#before-change-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-before-change-style" class="dfn-panel" data-for="before-change-style" id="infopanel-for-before-change-style" role="dialog">
+   <span id="infopaneltitle-for-before-change-style" style="display:none">Info about the 'before-change style' definition.</span><b><a href="#before-change-style">#before-change-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-change-style">3. Starting of transitions</a> <a href="#ref-for-before-change-style①">(2)</a> <a href="#ref-for-before-change-style②">(3)</a> <a href="#ref-for-before-change-style③">(4)</a> <a href="#ref-for-before-change-style④">(5)</a> <a href="#ref-for-before-change-style⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="after-change-style">
-   <b><a href="#after-change-style">#after-change-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-after-change-style" class="dfn-panel" data-for="after-change-style" id="infopanel-for-after-change-style" role="dialog">
+   <span id="infopaneltitle-for-after-change-style" style="display:none">Info about the 'after-change style' definition.</span><b><a href="#after-change-style">#after-change-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-after-change-style">3. Starting of transitions</a> <a href="#ref-for-after-change-style①">(2)</a> <a href="#ref-for-after-change-style②">(3)</a> <a href="#ref-for-after-change-style③">(4)</a> <a href="#ref-for-after-change-style④">(5)</a> <a href="#ref-for-after-change-style⑤">(6)</a> <a href="#ref-for-after-change-style⑥">(7)</a> <a href="#ref-for-after-change-style⑦">(8)</a> <a href="#ref-for-after-change-style⑧">(9)</a> <a href="#ref-for-after-change-style⑨">(10)</a> <a href="#ref-for-after-change-style①⓪">(11)</a> <a href="#ref-for-after-change-style①①">(12)</a> <a href="#ref-for-after-change-style①②">(13)</a> <a href="#ref-for-after-change-style①③">(14)</a> <a href="#ref-for-after-change-style①④">(15)</a> <a href="#ref-for-after-change-style①⑤">(16)</a> <a href="#ref-for-after-change-style①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matching-transition-property-value">
-   <b><a href="#matching-transition-property-value">#matching-transition-property-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matching-transition-property-value" class="dfn-panel" data-for="matching-transition-property-value" id="infopanel-for-matching-transition-property-value" role="dialog">
+   <span id="infopaneltitle-for-matching-transition-property-value" style="display:none">Info about the 'matching transition-property value' definition.</span><b><a href="#matching-transition-property-value">#matching-transition-property-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matching-transition-property-value">3. Starting of transitions</a> <a href="#ref-for-matching-transition-property-value①">(2)</a> <a href="#ref-for-matching-transition-property-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matching-transition-duration">
-   <b><a href="#matching-transition-duration">#matching-transition-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matching-transition-duration" class="dfn-panel" data-for="matching-transition-duration" id="infopanel-for-matching-transition-duration" role="dialog">
+   <span id="infopaneltitle-for-matching-transition-duration" style="display:none">Info about the 'matching transition duration' definition.</span><b><a href="#matching-transition-duration">#matching-transition-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matching-transition-duration">3. Starting of transitions</a> <a href="#ref-for-matching-transition-duration①">(2)</a> <a href="#ref-for-matching-transition-duration②">(3)</a> <a href="#ref-for-matching-transition-duration③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matching-transition-delay">
-   <b><a href="#matching-transition-delay">#matching-transition-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matching-transition-delay" class="dfn-panel" data-for="matching-transition-delay" id="infopanel-for-matching-transition-delay" role="dialog">
+   <span id="infopaneltitle-for-matching-transition-delay" style="display:none">Info about the 'matching transition delay' definition.</span><b><a href="#matching-transition-delay">#matching-transition-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matching-transition-delay">3. Starting of transitions</a> <a href="#ref-for-matching-transition-delay①">(2)</a> <a href="#ref-for-matching-transition-delay②">(3)</a> <a href="#ref-for-matching-transition-delay③">(4)</a> <a href="#ref-for-matching-transition-delay④">(5)</a> <a href="#ref-for-matching-transition-delay⑤">(6)</a> <a href="#ref-for-matching-transition-delay⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-combined-duration">
-   <b><a href="#transition-combined-duration">#transition-combined-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-combined-duration" class="dfn-panel" data-for="transition-combined-duration" id="infopanel-for-transition-combined-duration" role="dialog">
+   <span id="infopaneltitle-for-transition-combined-duration" style="display:none">Info about the 'combined duration' definition.</span><b><a href="#transition-combined-duration">#transition-combined-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-combined-duration">3. Starting of transitions</a> <a href="#ref-for-transition-combined-duration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitionable">
-   <b><a href="#transitionable">#transitionable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitionable" class="dfn-panel" data-for="transitionable" id="infopanel-for-transitionable" role="dialog">
+   <span id="infopaneltitle-for-transitionable" style="display:none">Info about the 'transitionable' definition.</span><b><a href="#transitionable">#transitionable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionable">3. Starting of transitions</a> <a href="#ref-for-transitionable①">(2)</a> <a href="#ref-for-transitionable②">(3)</a> <a href="#ref-for-transitionable③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-value">
-   <b><a href="#current-value">#current-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-value" class="dfn-panel" data-for="current-value" id="infopanel-for-current-value" role="dialog">
+   <span id="infopaneltitle-for-current-value" style="display:none">Info about the 'current value' definition.</span><b><a href="#current-value">#current-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-value">3. Starting of transitions</a> <a href="#ref-for-current-value①">(2)</a> <a href="#ref-for-current-value②">(3)</a> <a href="#ref-for-current-value③">(4)</a>
     <li><a href="#ref-for-current-value④">4. Application of transitions</a> <a href="#ref-for-current-value⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitionevent">
-   <b><a href="#transitionevent">#transitionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitionevent" class="dfn-panel" data-for="transitionevent" id="infopanel-for-transitionevent" role="dialog">
+   <span id="infopaneltitle-for-transitionevent" style="display:none">Info about the 'TransitionEvent' definition.</span><b><a href="#transitionevent">#transitionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionevent">6.1. Interface TransitionEvent</a> <a href="#ref-for-transitionevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-transitioneventinit">
-   <b><a href="#dictdef-transitioneventinit">#dictdef-transitioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-transitioneventinit" class="dfn-panel" data-for="dictdef-transitioneventinit" id="infopanel-for-dictdef-transitioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-transitioneventinit" style="display:none">Info about the 'TransitionEventInit' definition.</span><b><a href="#dictdef-transitioneventinit">#dictdef-transitioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-transitioneventinit">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Events-TransitionEvent-propertyName">
-   <b><a href="#Events-TransitionEvent-propertyName">#Events-TransitionEvent-propertyName</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Events-TransitionEvent-propertyName" class="dfn-panel" data-for="Events-TransitionEvent-propertyName" id="infopanel-for-Events-TransitionEvent-propertyName" role="dialog">
+   <span id="infopaneltitle-for-Events-TransitionEvent-propertyName" style="display:none">Info about the 'propertyName' definition.</span><b><a href="#Events-TransitionEvent-propertyName">#Events-TransitionEvent-propertyName</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Events-TransitionEvent-propertyName">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Events-TransitionEvent-elapsedTime">
-   <b><a href="#Events-TransitionEvent-elapsedTime">#Events-TransitionEvent-elapsedTime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Events-TransitionEvent-elapsedTime" class="dfn-panel" data-for="Events-TransitionEvent-elapsedTime" id="infopanel-for-Events-TransitionEvent-elapsedTime" role="dialog">
+   <span id="infopaneltitle-for-Events-TransitionEvent-elapsedTime" style="display:none">Info about the 'elapsedTime' definition.</span><b><a href="#Events-TransitionEvent-elapsedTime">#Events-TransitionEvent-elapsedTime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Events-TransitionEvent-elapsedTime">6.1.1. IDL Definition</a>
     <li><a href="#ref-for-Events-TransitionEvent-elapsedTime①">6.2. Types of TransitionEvent</a> <a href="#ref-for-Events-TransitionEvent-elapsedTime②">(2)</a> <a href="#ref-for-Events-TransitionEvent-elapsedTime③">(3)</a> <a href="#ref-for-Events-TransitionEvent-elapsedTime④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Events-TransitionEvent-pseudoElement">
-   <b><a href="#Events-TransitionEvent-pseudoElement">#Events-TransitionEvent-pseudoElement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Events-TransitionEvent-pseudoElement" class="dfn-panel" data-for="Events-TransitionEvent-pseudoElement" id="infopanel-for-Events-TransitionEvent-pseudoElement" role="dialog">
+   <span id="infopaneltitle-for-Events-TransitionEvent-pseudoElement" style="display:none">Info about the 'pseudoElement' definition.</span><b><a href="#Events-TransitionEvent-pseudoElement">#Events-TransitionEvent-pseudoElement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Events-TransitionEvent-pseudoElement">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transitionevent-transitionevent">
-   <b><a href="#dom-transitionevent-transitionevent">#dom-transitionevent-transitionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transitionevent-transitionevent" class="dfn-panel" data-for="dom-transitionevent-transitionevent" id="infopanel-for-dom-transitionevent-transitionevent" role="dialog">
+   <span id="infopaneltitle-for-dom-transitionevent-transitionevent" style="display:none">Info about the 'TransitionEvent(type, transitionEventInitDict)' definition.</span><b><a href="#dom-transitionevent-transitionevent">#dom-transitionevent-transitionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transitionevent-transitionevent">6.1.1. IDL Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitionrun">
-   <b><a href="#transitionrun">#transitionrun</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitionrun" class="dfn-panel" data-for="transitionrun" id="infopanel-for-transitionrun" role="dialog">
+   <span id="infopaneltitle-for-transitionrun" style="display:none">Info about the 'transitionrun' definition.</span><b><a href="#transitionrun">#transitionrun</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionrun">6.2. Types of TransitionEvent</a> <a href="#ref-for-transitionrun①">(2)</a>
     <li><a href="#ref-for-transitionrun②">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitionstart">
-   <b><a href="#transitionstart">#transitionstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitionstart" class="dfn-panel" data-for="transitionstart" id="infopanel-for-transitionstart" role="dialog">
+   <span id="infopaneltitle-for-transitionstart" style="display:none">Info about the 'transitionstart' definition.</span><b><a href="#transitionstart">#transitionstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionstart">6.2. Types of TransitionEvent</a> <a href="#ref-for-transitionstart①">(2)</a>
     <li><a href="#ref-for-transitionstart②">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitionend">
-   <b><a href="#transitionend">#transitionend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitionend" class="dfn-panel" data-for="transitionend" id="infopanel-for-transitionend" role="dialog">
+   <span id="infopaneltitle-for-transitionend" style="display:none">Info about the 'transitionend' definition.</span><b><a href="#transitionend">#transitionend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionend">6.2. Types of TransitionEvent</a>
     <li><a href="#ref-for-transitionend①">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transitioncancel">
-   <b><a href="#transitioncancel">#transitioncancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transitioncancel" class="dfn-panel" data-for="transitioncancel" id="infopanel-for-transitioncancel" role="dialog">
+   <span id="infopaneltitle-for-transitioncancel" style="display:none">Info about the 'transitioncancel' definition.</span><b><a href="#transitioncancel">#transitioncancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitioncancel">6.2. Types of TransitionEvent</a> <a href="#ref-for-transitioncancel①">(2)</a>
     <li><a href="#ref-for-transitioncancel②">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionrun">
-   <b><a href="#dom-globaleventhandlers-ontransitionrun">#dom-globaleventhandlers-ontransitionrun</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-globaleventhandlers-ontransitionrun" class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionrun" id="infopanel-for-dom-globaleventhandlers-ontransitionrun" role="dialog">
+   <span id="infopaneltitle-for-dom-globaleventhandlers-ontransitionrun" style="display:none">Info about the 'ontransitionrun' definition.</span><b><a href="#dom-globaleventhandlers-ontransitionrun">#dom-globaleventhandlers-ontransitionrun</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-globaleventhandlers-ontransitionrun">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionstart">
-   <b><a href="#dom-globaleventhandlers-ontransitionstart">#dom-globaleventhandlers-ontransitionstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-globaleventhandlers-ontransitionstart" class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionstart" id="infopanel-for-dom-globaleventhandlers-ontransitionstart" role="dialog">
+   <span id="infopaneltitle-for-dom-globaleventhandlers-ontransitionstart" style="display:none">Info about the 'ontransitionstart' definition.</span><b><a href="#dom-globaleventhandlers-ontransitionstart">#dom-globaleventhandlers-ontransitionstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-globaleventhandlers-ontransitionstart">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionend">
-   <b><a href="#dom-globaleventhandlers-ontransitionend">#dom-globaleventhandlers-ontransitionend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-globaleventhandlers-ontransitionend" class="dfn-panel" data-for="dom-globaleventhandlers-ontransitionend" id="infopanel-for-dom-globaleventhandlers-ontransitionend" role="dialog">
+   <span id="infopaneltitle-for-dom-globaleventhandlers-ontransitionend" style="display:none">Info about the 'ontransitionend' definition.</span><b><a href="#dom-globaleventhandlers-ontransitionend">#dom-globaleventhandlers-ontransitionend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-globaleventhandlers-ontransitionend">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-globaleventhandlers-ontransitioncancel">
-   <b><a href="#dom-globaleventhandlers-ontransitioncancel">#dom-globaleventhandlers-ontransitioncancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-globaleventhandlers-ontransitioncancel" class="dfn-panel" data-for="dom-globaleventhandlers-ontransitioncancel" id="infopanel-for-dom-globaleventhandlers-ontransitioncancel" role="dialog">
+   <span id="infopaneltitle-for-dom-globaleventhandlers-ontransitioncancel" style="display:none">Info about the 'ontransitioncancel' definition.</span><b><a href="#dom-globaleventhandlers-ontransitioncancel">#dom-globaleventhandlers-ontransitioncancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-globaleventhandlers-ontransitioncancel">6.3. Event handlers on elements, Document objects, and Window objects</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-transitions-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-transitions-2/Overview.html
@@ -1540,199 +1540,199 @@ elem<c- p>.</c->getAnimations<c- p>()[</c-><c- mf>0</c-><c- p>].</c->transitionP
    <li><a href="#transition-phase">transition phase</a><span>, in § 5.1</span>
    <li><a href="#dom-csstransition-transitionproperty">transitionProperty</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">2.1. The transition-property Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">6.2. Requirements on pending style changes</a> <a href="#ref-for-propdef-opacity①">(2)</a> <a href="#ref-for-propdef-opacity②">(3)</a> <a href="#ref-for-propdef-opacity③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">2.3. The transition-timing-function Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitionevent">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transitionevent">https://drafts.csswg.org/css-transitions-1/#transitionevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitionevent" class="dfn-panel" data-for="term-for-transitionevent" id="infopanel-for-term-for-transitionevent" role="menu">
+   <span id="infopaneltitle-for-term-for-transitionevent" style="display:none">Info about the 'TransitionEvent' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transitionevent">https://drafts.csswg.org/css-transitions-1/#transitionevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionevent">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-transition-property-all">
-   <a href="https://drafts.csswg.org/css-transitions-1/#valdef-transition-property-all">https://drafts.csswg.org/css-transitions-1/#valdef-transition-property-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-transition-property-all" class="dfn-panel" data-for="term-for-valdef-transition-property-all" id="infopanel-for-term-for-valdef-transition-property-all" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-transition-property-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#valdef-transition-property-all">https://drafts.csswg.org/css-transitions-1/#valdef-transition-property-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-transition-property-all">2.1. The transition-property Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-cancel">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transition-cancel">https://drafts.csswg.org/css-transitions-1/#transition-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-cancel" class="dfn-panel" data-for="term-for-transition-cancel" id="infopanel-for-term-for-transition-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-cancel" style="display:none">Info about the 'cancel' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transition-cancel">https://drafts.csswg.org/css-transitions-1/#transition-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-cancel">3. Starting of transitions</a> <a href="#ref-for-transition-cancel①">(2)</a> <a href="#ref-for-transition-cancel②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-completed-transition">
-   <a href="https://drafts.csswg.org/css-transitions-1/#completed-transition">https://drafts.csswg.org/css-transitions-1/#completed-transition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-completed-transition" class="dfn-panel" data-for="term-for-completed-transition" id="infopanel-for-term-for-completed-transition" role="menu">
+   <span id="infopaneltitle-for-term-for-completed-transition" style="display:none">Info about the 'completed transition' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#completed-transition">https://drafts.csswg.org/css-transitions-1/#completed-transition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-completed-transition">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Events-TransitionEvent-elapsedTime">
-   <a href="https://drafts.csswg.org/css-transitions-1/#Events-TransitionEvent-elapsedTime">https://drafts.csswg.org/css-transitions-1/#Events-TransitionEvent-elapsedTime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Events-TransitionEvent-elapsedTime" class="dfn-panel" data-for="term-for-Events-TransitionEvent-elapsedTime" id="infopanel-for-term-for-Events-TransitionEvent-elapsedTime" role="menu">
+   <span id="infopaneltitle-for-term-for-Events-TransitionEvent-elapsedTime" style="display:none">Info about the 'elapsedTime' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#Events-TransitionEvent-elapsedTime">https://drafts.csswg.org/css-transitions-1/#Events-TransitionEvent-elapsedTime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Events-TransitionEvent-elapsedTime">5.1. Event dispatch</a> <a href="#ref-for-Events-TransitionEvent-elapsedTime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-reversing-shortening-factor">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transition-reversing-shortening-factor">https://drafts.csswg.org/css-transitions-1/#transition-reversing-shortening-factor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-reversing-shortening-factor" class="dfn-panel" data-for="term-for-transition-reversing-shortening-factor" id="infopanel-for-term-for-transition-reversing-shortening-factor" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-reversing-shortening-factor" style="display:none">Info about the 'reversing shortening factor' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transition-reversing-shortening-factor">https://drafts.csswg.org/css-transitions-1/#transition-reversing-shortening-factor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-reversing-shortening-factor">3.1. Faster reversing of interrupted transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-reversing-adjusted-start-value">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transition-reversing-adjusted-start-value">https://drafts.csswg.org/css-transitions-1/#transition-reversing-adjusted-start-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-reversing-adjusted-start-value" class="dfn-panel" data-for="term-for-transition-reversing-adjusted-start-value" id="infopanel-for-term-for-transition-reversing-adjusted-start-value" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-reversing-adjusted-start-value" style="display:none">Info about the 'reversing-adjusted start value' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transition-reversing-adjusted-start-value">https://drafts.csswg.org/css-transitions-1/#transition-reversing-adjusted-start-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-reversing-adjusted-start-value">3.1. Faster reversing of interrupted transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-running-transition">
-   <a href="https://drafts.csswg.org/css-transitions-1/#running-transition">https://drafts.csswg.org/css-transitions-1/#running-transition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-running-transition" class="dfn-panel" data-for="term-for-running-transition" id="infopanel-for-term-for-running-transition" role="menu">
+   <span id="infopaneltitle-for-term-for-running-transition" style="display:none">Info about the 'running transition' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#running-transition">https://drafts.csswg.org/css-transitions-1/#running-transition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running-transition">3. Starting of transitions</a> <a href="#ref-for-running-transition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-change-event">
-   <a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-change-event" class="dfn-panel" data-for="term-for-style-change-event" id="infopanel-for-term-for-style-change-event" role="menu">
+   <span id="infopaneltitle-for-term-for-style-change-event" style="display:none">Info about the 'style change event' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-change-event">3.2. The current transition generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-delay">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-delay" class="dfn-panel" data-for="term-for-propdef-transition-delay" id="infopanel-for-term-for-propdef-transition-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-delay" style="display:none">Info about the 'transition-delay' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-delay">2.4. The transition-delay Property</a> <a href="#ref-for-propdef-transition-delay①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-duration">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-duration" class="dfn-panel" data-for="term-for-propdef-transition-duration" id="infopanel-for-term-for-propdef-transition-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-duration" style="display:none">Info about the 'transition-duration' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-duration">2.2. The transition-duration Property</a> <a href="#ref-for-propdef-transition-duration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-property">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-property" class="dfn-panel" data-for="term-for-propdef-transition-property" id="infopanel-for-term-for-propdef-transition-property" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-property" style="display:none">Info about the 'transition-property' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-property">2.1. The transition-property Property</a> <a href="#ref-for-propdef-transition-property①">(2)</a>
     <li><a href="#ref-for-propdef-transition-property②">3. Starting of transitions</a>
     <li><a href="#ref-for-propdef-transition-property③">8. Issues deferred from previous levels of the spec</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-timing-function">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-timing-function" class="dfn-panel" data-for="term-for-propdef-transition-timing-function" id="infopanel-for-term-for-propdef-transition-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-timing-function" style="display:none">Info about the 'transition-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-timing-function">2.3. The transition-timing-function Property</a> <a href="#ref-for-propdef-transition-timing-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitioncancel">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transitioncancel">https://drafts.csswg.org/css-transitions-1/#transitioncancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitioncancel" class="dfn-panel" data-for="term-for-transitioncancel" id="infopanel-for-term-for-transitioncancel" role="menu">
+   <span id="infopaneltitle-for-term-for-transitioncancel" style="display:none">Info about the 'transitioncancel' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transitioncancel">https://drafts.csswg.org/css-transitions-1/#transitioncancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitioncancel">5.1. Event dispatch</a> <a href="#ref-for-transitioncancel①">(2)</a> <a href="#ref-for-transitioncancel②">(3)</a> <a href="#ref-for-transitioncancel③">(4)</a> <a href="#ref-for-transitioncancel④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitionend">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transitionend">https://drafts.csswg.org/css-transitions-1/#transitionend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitionend" class="dfn-panel" data-for="term-for-transitionend" id="infopanel-for-term-for-transitionend" role="menu">
+   <span id="infopaneltitle-for-term-for-transitionend" style="display:none">Info about the 'transitionend' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transitionend">https://drafts.csswg.org/css-transitions-1/#transitionend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionend">5.1. Event dispatch</a> <a href="#ref-for-transitionend①">(2)</a> <a href="#ref-for-transitionend②">(3)</a> <a href="#ref-for-transitionend③">(4)</a> <a href="#ref-for-transitionend④">(5)</a> <a href="#ref-for-transitionend⑤">(6)</a> <a href="#ref-for-transitionend⑥">(7)</a> <a href="#ref-for-transitionend⑦">(8)</a> <a href="#ref-for-transitionend⑧">(9)</a> <a href="#ref-for-transitionend⑨">(10)</a> <a href="#ref-for-transitionend①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitionrun">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transitionrun">https://drafts.csswg.org/css-transitions-1/#transitionrun</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitionrun" class="dfn-panel" data-for="term-for-transitionrun" id="infopanel-for-term-for-transitionrun" role="menu">
+   <span id="infopaneltitle-for-term-for-transitionrun" style="display:none">Info about the 'transitionrun' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transitionrun">https://drafts.csswg.org/css-transitions-1/#transitionrun</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionrun">5.1. Event dispatch</a> <a href="#ref-for-transitionrun①">(2)</a> <a href="#ref-for-transitionrun②">(3)</a> <a href="#ref-for-transitionrun③">(4)</a> <a href="#ref-for-transitionrun④">(5)</a> <a href="#ref-for-transitionrun⑤">(6)</a> <a href="#ref-for-transitionrun⑥">(7)</a> <a href="#ref-for-transitionrun⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitionstart">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transitionstart">https://drafts.csswg.org/css-transitions-1/#transitionstart</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitionstart" class="dfn-panel" data-for="term-for-transitionstart" id="infopanel-for-term-for-transitionstart" role="menu">
+   <span id="infopaneltitle-for-term-for-transitionstart" style="display:none">Info about the 'transitionstart' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transitionstart">https://drafts.csswg.org/css-transitions-1/#transitionstart</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionstart">5.1. Event dispatch</a> <a href="#ref-for-transitionstart①">(2)</a> <a href="#ref-for-transitionstart②">(3)</a> <a href="#ref-for-transitionstart③">(4)</a> <a href="#ref-for-transitionstart④">(5)</a> <a href="#ref-for-transitionstart⑤">(6)</a> <a href="#ref-for-transitionstart⑥">(7)</a> <a href="#ref-for-transitionstart⑦">(8)</a> <a href="#ref-for-transitionstart⑧">(9)</a> <a href="#ref-for-transitionstart⑨">(10)</a> <a href="#ref-for-transitionstart①⓪">(11)</a> <a href="#ref-for-transitionstart①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">6.1. The CSSTransition interface</a> <a href="#ref-for-cssomstring①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">6.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">4.1. Animation composite order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#being-rendered">https://html.spec.whatwg.org/multipage/browsers.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#being-rendered">https://html.spec.whatwg.org/multipage/browsers.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations/#animation">https://drafts.csswg.org/web-animations/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-animation" style="display:none">Info about the 'Animation' external reference.</span><a href="https://drafts.csswg.org/web-animations/#animation">https://drafts.csswg.org/web-animations/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">4.1. Animation composite order</a>
     <li><a href="#ref-for-animation①">6.1. The CSSTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-duration">
-   <a href="https://drafts.csswg.org/web-animations/#active-duration">https://drafts.csswg.org/web-animations/#active-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-duration" class="dfn-panel" data-for="term-for-active-duration" id="infopanel-for-term-for-active-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-active-duration" style="display:none">Info about the 'active duration' external reference.</span><a href="https://drafts.csswg.org/web-animations/#active-duration">https://drafts.csswg.org/web-animations/#active-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-duration">5.1. Event dispatch</a> <a href="#ref-for-active-duration①">(2)</a> <a href="#ref-for-active-duration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-time">
-   <a href="https://drafts.csswg.org/web-animations/#active-time">https://drafts.csswg.org/web-animations/#active-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-time" class="dfn-panel" data-for="term-for-active-time" id="infopanel-for-term-for-active-time" role="menu">
+   <span id="infopaneltitle-for-term-for-active-time" style="display:none">Info about the 'active time' external reference.</span><a href="https://drafts.csswg.org/web-animations/#active-time">https://drafts.csswg.org/web-animations/#active-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-time">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations/#animation">https://drafts.csswg.org/web-animations/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation①" role="menu">
+   <span id="infopaneltitle-for-term-for-animation①" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/web-animations/#animation">https://drafts.csswg.org/web-animations/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">4.1. Animation composite order</a>
     <li><a href="#ref-for-animation①">6.1. The CSSTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-class">
-   <a href="https://drafts.csswg.org/web-animations/#animation-class">https://drafts.csswg.org/web-animations/#animation-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-class" class="dfn-panel" data-for="term-for-animation-class" id="infopanel-for-term-for-animation-class" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-class" style="display:none">Info about the 'animation class' external reference.</span><a href="https://drafts.csswg.org/web-animations/#animation-class">https://drafts.csswg.org/web-animations/#animation-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-class">4.1. Animation composite order</a> <a href="#ref-for-animation-class①">(2)</a>
     <li><a href="#ref-for-animation-class②">4.2. Animation cascade level</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations/#animation-effect">https://drafts.csswg.org/web-animations/#animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-effect" class="dfn-panel" data-for="term-for-animation-effect" id="infopanel-for-term-for-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-effect" style="display:none">Info about the 'animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations/#animation-effect">https://drafts.csswg.org/web-animations/#animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect">2.2. The transition-duration Property</a>
     <li><a href="#ref-for-animation-effect①">2.3. The transition-timing-function Property</a>
@@ -1740,112 +1740,112 @@ elem<c- p>.</c->getAnimations<c- p>()[</c-><c- mf>0</c-><c- p>].</c->transitionP
     <li><a href="#ref-for-animation-effect③">3.1. Faster reversing of interrupted transitions</a> <a href="#ref-for-animation-effect④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cancel-an-animation">
-   <a href="https://drafts.csswg.org/web-animations/#cancel-an-animation">https://drafts.csswg.org/web-animations/#cancel-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cancel-an-animation" class="dfn-panel" data-for="term-for-cancel-an-animation" id="infopanel-for-term-for-cancel-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-cancel-an-animation" style="display:none">Info about the 'cancel an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations/#cancel-an-animation">https://drafts.csswg.org/web-animations/#cancel-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-an-animation">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-cancel">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-cancel">https://drafts.csswg.org/web-animations-1/#dom-animation-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-cancel" class="dfn-panel" data-for="term-for-dom-animation-cancel" id="infopanel-for-term-for-dom-animation-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-cancel" style="display:none">Info about the 'cancel()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-cancel">https://drafts.csswg.org/web-animations-1/#dom-animation-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-cancel">3. Starting of transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-iteration">
-   <a href="https://drafts.csswg.org/web-animations/#current-iteration">https://drafts.csswg.org/web-animations/#current-iteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-iteration" class="dfn-panel" data-for="term-for-current-iteration" id="infopanel-for-term-for-current-iteration" role="menu">
+   <span id="infopaneltitle-for-term-for-current-iteration" style="display:none">Info about the 'current iteration' external reference.</span><a href="https://drafts.csswg.org/web-animations/#current-iteration">https://drafts.csswg.org/web-animations/#current-iteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-iteration">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-time">
-   <a href="https://drafts.csswg.org/web-animations/#current-time">https://drafts.csswg.org/web-animations/#current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-time" class="dfn-panel" data-for="term-for-current-time" id="infopanel-for-term-for-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-current-time" style="display:none">Info about the 'current time' external reference.</span><a href="https://drafts.csswg.org/web-animations/#current-time">https://drafts.csswg.org/web-animations/#current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">5.1. Event dispatch</a> <a href="#ref-for-current-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fill-mode">
-   <a href="https://drafts.csswg.org/web-animations/#fill-mode">https://drafts.csswg.org/web-animations/#fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fill-mode" class="dfn-panel" data-for="term-for-fill-mode" id="infopanel-for-term-for-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-fill-mode" style="display:none">Info about the 'fill mode' external reference.</span><a href="https://drafts.csswg.org/web-animations/#fill-mode">https://drafts.csswg.org/web-animations/#fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-mode">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-animation-list">
-   <a href="https://drafts.csswg.org/web-animations/#global-animation-list">https://drafts.csswg.org/web-animations/#global-animation-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-animation-list" class="dfn-panel" data-for="term-for-global-animation-list" id="infopanel-for-term-for-global-animation-list" role="menu">
+   <span id="infopaneltitle-for-term-for-global-animation-list" style="display:none">Info about the 'global animation list' external reference.</span><a href="https://drafts.csswg.org/web-animations/#global-animation-list">https://drafts.csswg.org/web-animations/#global-animation-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-animation-list">4.1. Animation composite order</a> <a href="#ref-for-global-animation-list①">(2)</a> <a href="#ref-for-global-animation-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idle-play-state">
-   <a href="https://drafts.csswg.org/web-animations/#idle-play-state">https://drafts.csswg.org/web-animations/#idle-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idle-play-state" class="dfn-panel" data-for="term-for-idle-play-state" id="infopanel-for-term-for-idle-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-idle-play-state" style="display:none">Info about the 'idle play state' external reference.</span><a href="https://drafts.csswg.org/web-animations/#idle-play-state">https://drafts.csswg.org/web-animations/#idle-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle-play-state">4.1. Animation composite order</a> <a href="#ref-for-idle-play-state①">(2)</a> <a href="#ref-for-idle-play-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-duration">
-   <a href="https://drafts.csswg.org/web-animations/#iteration-duration">https://drafts.csswg.org/web-animations/#iteration-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-duration" class="dfn-panel" data-for="term-for-iteration-duration" id="infopanel-for-term-for-iteration-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-duration" style="display:none">Info about the 'iteration duration' external reference.</span><a href="https://drafts.csswg.org/web-animations/#iteration-duration">https://drafts.csswg.org/web-animations/#iteration-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-duration">2.2. The transition-duration Property</a>
     <li><a href="#ref-for-iteration-duration①">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-start">
-   <a href="https://drafts.csswg.org/web-animations/#iteration-start">https://drafts.csswg.org/web-animations/#iteration-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-start" class="dfn-panel" data-for="term-for-iteration-start" id="infopanel-for-term-for-iteration-start" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-start" style="display:none">Info about the 'iteration start' external reference.</span><a href="https://drafts.csswg.org/web-animations/#iteration-start">https://drafts.csswg.org/web-animations/#iteration-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-start">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pending-play-state">
-   <a href="https://drafts.csswg.org/web-animations/#pending-play-state">https://drafts.csswg.org/web-animations/#pending-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pending-play-state" class="dfn-panel" data-for="term-for-pending-play-state" id="infopanel-for-term-for-pending-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-pending-play-state" style="display:none">Info about the 'pending play state' external reference.</span><a href="https://drafts.csswg.org/web-animations/#pending-play-state">https://drafts.csswg.org/web-animations/#pending-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-play-state">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sampling">
-   <a href="https://drafts.csswg.org/web-animations/#sampling">https://drafts.csswg.org/web-animations/#sampling</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sampling" class="dfn-panel" data-for="term-for-sampling" id="infopanel-for-term-for-sampling" role="menu">
+   <span id="infopaneltitle-for-term-for-sampling" style="display:none">Info about the 'sampling' external reference.</span><a href="https://drafts.csswg.org/web-animations/#sampling">https://drafts.csswg.org/web-animations/#sampling</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sampling">5.1. Event dispatch</a> <a href="#ref-for-sampling①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-start-delay">
-   <a href="https://drafts.csswg.org/web-animations/#start-delay">https://drafts.csswg.org/web-animations/#start-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-start-delay" class="dfn-panel" data-for="term-for-start-delay" id="infopanel-for-term-for-start-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-start-delay" style="display:none">Info about the 'start delay' external reference.</span><a href="https://drafts.csswg.org/web-animations/#start-delay">https://drafts.csswg.org/web-animations/#start-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">2.4. The transition-delay Property</a>
     <li><a href="#ref-for-start-delay①">5.1. Event dispatch</a> <a href="#ref-for-start-delay②">(2)</a> <a href="#ref-for-start-delay③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect">
-   <a href="https://drafts.csswg.org/web-animations/#target-effect">https://drafts.csswg.org/web-animations/#target-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect" class="dfn-panel" data-for="term-for-target-effect" id="infopanel-for-term-for-target-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect" style="display:none">Info about the 'target effect' external reference.</span><a href="https://drafts.csswg.org/web-animations/#target-effect">https://drafts.csswg.org/web-animations/#target-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect">5.1. Event dispatch</a> <a href="#ref-for-target-effect①">(2)</a> <a href="#ref-for-target-effect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect-end">
-   <a href="https://drafts.csswg.org/web-animations/#target-effect-end">https://drafts.csswg.org/web-animations/#target-effect-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect-end" class="dfn-panel" data-for="term-for-target-effect-end" id="infopanel-for-term-for-target-effect-end" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect-end" style="display:none">Info about the 'target effect end' external reference.</span><a href="https://drafts.csswg.org/web-animations/#target-effect-end">https://drafts.csswg.org/web-animations/#target-effect-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect-end">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformed-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#transformed-progress">https://drafts.csswg.org/web-animations-1/#transformed-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformed-progress" class="dfn-panel" data-for="term-for-transformed-progress" id="infopanel-for-term-for-transformed-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-transformed-progress" style="display:none">Info about the 'transformed progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#transformed-progress">https://drafts.csswg.org/web-animations-1/#transformed-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-progress">2.3. The transition-timing-function Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unresolved">
-   <a href="https://drafts.csswg.org/web-animations/#unresolved">https://drafts.csswg.org/web-animations/#unresolved</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unresolved" class="dfn-panel" data-for="term-for-unresolved" id="infopanel-for-term-for-unresolved" role="menu">
+   <span id="infopaneltitle-for-term-for-unresolved" style="display:none">Info about the 'unresolved' external reference.</span><a href="https://drafts.csswg.org/web-animations/#unresolved">https://drafts.csswg.org/web-animations/#unresolved</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unresolved">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animatable-getanimations">
-   <a href="https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations">https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animatable-getanimations" class="dfn-panel" data-for="term-for-dom-animatable-getanimations" id="infopanel-for-term-for-dom-animatable-getanimations" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animatable-getanimations" style="display:none">Info about the 'getAnimations()' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations">https://drafts.csswg.org/web-animations-2/#dom-animatable-getanimations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-getanimations">6.2. Requirements on pending style changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. The CSSTransition interface</a>
    </ul>
@@ -2013,125 +2013,183 @@ elem<c- p>.</c->getAnimations<c- p>()[</c-><c- mf>0</c-><c- p>].</c->transitionP
 		a different transition
 		than the color of a shadow. <a class="issue-return" href="#issue-5a3a5638" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="expanded-transition-property-name">
-   <b><a href="#expanded-transition-property-name">#expanded-transition-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-expanded-transition-property-name" class="dfn-panel" data-for="expanded-transition-property-name" id="infopanel-for-expanded-transition-property-name" role="dialog">
+   <span id="infopaneltitle-for-expanded-transition-property-name" style="display:none">Info about the 'expanded transition property
+name' definition.</span><b><a href="#expanded-transition-property-name">#expanded-transition-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-expanded-transition-property-name">4.1. Animation composite order</a>
     <li><a href="#ref-for-expanded-transition-property-name①">6.1. The CSSTransition interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="owning-element">
-   <b><a href="#owning-element">#owning-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-owning-element" class="dfn-panel" data-for="owning-element" id="infopanel-for-owning-element" role="dialog">
+   <span id="infopaneltitle-for-owning-element" style="display:none">Info about the 'owning element' definition.</span><b><a href="#owning-element">#owning-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-owning-element">3. Starting of transitions</a> <a href="#ref-for-owning-element①">(2)</a> <a href="#ref-for-owning-element②">(3)</a> <a href="#ref-for-owning-element③">(4)</a> <a href="#ref-for-owning-element④">(5)</a>
     <li><a href="#ref-for-owning-element⑤">4.1. Animation composite order</a> <a href="#ref-for-owning-element⑥">(2)</a> <a href="#ref-for-owning-element⑦">(3)</a> <a href="#ref-for-owning-element⑧">(4)</a> <a href="#ref-for-owning-element⑨">(5)</a> <a href="#ref-for-owning-element①⓪">(6)</a> <a href="#ref-for-owning-element①①">(7)</a> <a href="#ref-for-owning-element①②">(8)</a>
     <li><a href="#ref-for-owning-element①③">4.2. Animation cascade level</a> <a href="#ref-for-owning-element①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-transition-generation">
-   <b><a href="#current-transition-generation">#current-transition-generation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-transition-generation" class="dfn-panel" data-for="current-transition-generation" id="infopanel-for-current-transition-generation" role="dialog">
+   <span id="infopaneltitle-for-current-transition-generation" style="display:none">Info about the 'current transition
+generation' definition.</span><b><a href="#current-transition-generation">#current-transition-generation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-transition-generation">3.2. The current transition generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-generation">
-   <b><a href="#transition-generation">#transition-generation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-generation" class="dfn-panel" data-for="transition-generation" id="infopanel-for-transition-generation" role="dialog">
+   <span id="infopaneltitle-for-transition-generation" style="display:none">Info about the 'transition generation' definition.</span><b><a href="#transition-generation">#transition-generation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-generation">4.1. Animation composite order</a> <a href="#ref-for-transition-generation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transition-phase">
-   <b><a href="#transition-phase">#transition-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transition-phase" class="dfn-panel" data-for="transition-phase" id="infopanel-for-transition-phase" role="dialog">
+   <span id="infopaneltitle-for-transition-phase" style="display:none">Info about the 'transition phase' definition.</span><b><a href="#transition-phase">#transition-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-phase">5.1. Event dispatch</a> <a href="#ref-for-transition-phase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interval-start">
-   <b><a href="#interval-start">#interval-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interval-start" class="dfn-panel" data-for="interval-start" id="infopanel-for-interval-start" role="dialog">
+   <span id="infopaneltitle-for-interval-start" style="display:none">Info about the 'interval start' definition.</span><b><a href="#interval-start">#interval-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interval-start">5.1. Event dispatch</a> <a href="#ref-for-interval-start①">(2)</a> <a href="#ref-for-interval-start②">(3)</a> <a href="#ref-for-interval-start③">(4)</a> <a href="#ref-for-interval-start④">(5)</a> <a href="#ref-for-interval-start⑤">(6)</a> <a href="#ref-for-interval-start⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interval-end">
-   <b><a href="#interval-end">#interval-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interval-end" class="dfn-panel" data-for="interval-end" id="infopanel-for-interval-end" role="dialog">
+   <span id="infopaneltitle-for-interval-end" style="display:none">Info about the 'interval end' definition.</span><b><a href="#interval-end">#interval-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interval-end">5.1. Event dispatch</a> <a href="#ref-for-interval-end①">(2)</a> <a href="#ref-for-interval-end②">(3)</a> <a href="#ref-for-interval-end③">(4)</a> <a href="#ref-for-interval-end④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elapsed-time">
-   <b><a href="#elapsed-time">#elapsed-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elapsed-time" class="dfn-panel" data-for="elapsed-time" id="infopanel-for-elapsed-time" role="dialog">
+   <span id="infopaneltitle-for-elapsed-time" style="display:none">Info about the 'Elapsed time' definition.</span><b><a href="#elapsed-time">#elapsed-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elapsed-time">5.1. Event dispatch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csstransition">
-   <b><a href="#csstransition">#csstransition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csstransition" class="dfn-panel" data-for="csstransition" id="infopanel-for-csstransition" role="dialog">
+   <span id="infopaneltitle-for-csstransition" style="display:none">Info about the 'CSSTransition' definition.</span><b><a href="#csstransition">#csstransition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csstransition">3. Starting of transitions</a>
     <li><a href="#ref-for-csstransition①">6.2. Requirements on pending style changes</a> <a href="#ref-for-csstransition②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csstransition-transitionproperty">
-   <b><a href="#dom-csstransition-transitionproperty">#dom-csstransition-transitionproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csstransition-transitionproperty" class="dfn-panel" data-for="dom-csstransition-transitionproperty" id="infopanel-for-dom-csstransition-transitionproperty" role="dialog">
+   <span id="infopaneltitle-for-dom-csstransition-transitionproperty" style="display:none">Info about the 'transitionProperty' definition.</span><b><a href="#dom-csstransition-transitionproperty">#dom-csstransition-transitionproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csstransition-transitionproperty">6.1. The CSSTransition interface</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-ui-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ui-3/Overview.html
@@ -1960,126 +1960,126 @@ option<c- p>[</c->selected<c- p>]</c->::before
    <li><a href="#valdef-cursor-zoom-in">zoom-in</a><span>, in § 7.1.1</span>
    <li><a href="#valdef-cursor-zoom-out">zoom-out</a><span>, in § 7.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-width">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-line-width">https://www.w3.org/TR/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-width" class="dfn-panel" data-for="term-for-typedef-line-width" id="infopanel-for-term-for-typedef-line-width" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-width" style="display:none">Info about the '&lt;line-width>' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-line-width">https://www.w3.org/TR/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-width">5.2. Outline Thickness: the outline-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-border-radius">https://www.w3.org/TR/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-border-radius">https://www.w3.org/TR/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">5.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-propdef-border-radius①">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-none">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#valdef-line-style-none">https://www.w3.org/TR/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-none" class="dfn-panel" data-for="term-for-valdef-line-style-none" id="infopanel-for-term-for-valdef-line-style-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-none" style="display:none">Info about the 'none' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#valdef-line-style-none">https://www.w3.org/TR/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-none">5.2. Outline Thickness: the outline-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">5.4. Outline Colors: the outline-color property</a> <a href="#ref-for-typedef-color①">(2)</a>
     <li><a href="#ref-for-typedef-color②">7.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-typedef-color③">(2)</a> <a href="#ref-for-typedef-color④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor">https://www.w3.org/TR/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">5.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-valdef-color-currentcolor①">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a>
     <li><a href="#ref-for-typedef-image④">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concrete-object-size">
-   <a href="https://www.w3.org/TR/css-images-3/#concrete-object-size">https://www.w3.org/TR/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concrete-object-size" class="dfn-panel" data-for="term-for-concrete-object-size" id="infopanel-for-term-for-concrete-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-concrete-object-size" style="display:none">Info about the 'concrete object size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#concrete-object-size">https://www.w3.org/TR/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concrete-object-size">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://www.w3.org/TR/css-images-3/#default-object-size">https://www.w3.org/TR/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#default-object-size">https://www.w3.org/TR/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sizing-algorithm">
-   <a href="https://www.w3.org/TR/css-images-3/#default-sizing-algorithm">https://www.w3.org/TR/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sizing-algorithm" class="dfn-panel" data-for="term-for-default-sizing-algorithm" id="infopanel-for-term-for-default-sizing-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sizing-algorithm" style="display:none">Info about the 'default sizing algorithm' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#default-sizing-algorithm">https://www.w3.org/TR/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sizing-algorithm">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-aspect-ratio">https://www.w3.org/TR/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-aspect-ratio">https://www.w3.org/TR/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://www.w3.org/TR/css-images-3/#natural-size">https://www.w3.org/TR/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#natural-size">https://www.w3.org/TR/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-natural-size①">(2)</a> <a href="#ref-for-natural-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csspseudoelement">
-   <a href="https://www.w3.org/TR/css-pseudo-4/#csspseudoelement">https://www.w3.org/TR/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csspseudoelement" class="dfn-panel" data-for="term-for-csspseudoelement" id="infopanel-for-term-for-csspseudoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-csspseudoelement" style="display:none">Info about the 'CSSPseudoElement' external reference.</span><a href="https://www.w3.org/TR/css-pseudo-4/#csspseudoelement">https://www.w3.org/TR/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspseudoelement">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-zero-plus">https://www.w3.org/TR/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-zero-plus">https://www.w3.org/TR/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-comma">https://www.w3.org/TR/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-comma">https://www.w3.org/TR/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">5.5. Offsetting the Outline: the outline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://www.w3.org/TR/css-values-4/#url-value">https://www.w3.org/TR/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#url-value">https://www.w3.org/TR/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#css-wide-keywords">https://www.w3.org/TR/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">3. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. Changing the Box Model: the box-sizing property</a>
     <li><a href="#ref-for-comb-one①">5.3. Outline Patterns: the outline-style property</a>
@@ -2091,271 +2091,271 @@ option<c- p>[</c->selected<c- p>]</c->::before
     <li><a href="#ref-for-comb-one④②">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">5.1. Outlines Shorthand: the outline property</a> <a href="#ref-for-comb-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">user interaction with ellipsis</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-end" class="dfn-panel" data-for="term-for-css-end" id="infopanel-for-term-for-css-end" role="menu">
+   <span id="infopaneltitle-for-term-for-css-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#css-end">https://drafts.csswg.org/css-writing-modes-3/#css-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">6.2. 
     Overflow Ellipsis: the text-overflow property</a> <a href="#ref-for-css-end①">(2)</a> <a href="#ref-for-css-end②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-physical-left">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-physical-left" class="dfn-panel" data-for="term-for-physical-left" id="infopanel-for-term-for-physical-left" role="menu">
+   <span id="infopaneltitle-for-term-for-physical-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#physical-left">https://drafts.csswg.org/css-writing-modes-3/#physical-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-left">user interaction with ellipsis</a> <a href="#ref-for-physical-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-width-property">
-   <a href="https://www.w3.org/TR/CSS2/visudet.html#the-width-property">https://www.w3.org/TR/CSS2/visudet.html#the-width-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-width-property" class="dfn-panel" data-for="term-for-the-width-property" id="infopanel-for-term-for-the-width-property" role="menu">
+   <span id="infopaneltitle-for-term-for-the-width-property" style="display:none">Info about the 'auto' external reference.</span><a href="https://www.w3.org/TR/CSS2/visudet.html#the-width-property">https://www.w3.org/TR/CSS2/visudet.html#the-width-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-the-width-property">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-the-width-property">(2)</a> <a href="#ref-for-the-width-property①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://www.w3.org/TR/CSS2/box.html#border-edge">https://www.w3.org/TR/CSS2/box.html#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border edge' external reference.</span><a href="https://www.w3.org/TR/CSS2/box.html#border-edge">https://www.w3.org/TR/CSS2/box.html#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">5.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-border-edge①">5.5. Offsetting the Outline: the outline-offset property</a> <a href="#ref-for-border-edge②">(2)</a> <a href="#ref-for-border-edge③">(3)</a>
     <li><a href="#ref-for-border-edge④">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-border-edge⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-position-props">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-position-props" class="dfn-panel" data-for="term-for-position-props" id="infopanel-for-term-for-position-props" role="menu">
+   <span id="infopaneltitle-for-term-for-position-props" style="display:none">Info about the 'bottom' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-position-props">4.1. Changing the Box Model: the box-sizing property</a>
     <li><a href="#ref-for-position-props①">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-position-props②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-position-props">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-position-props" class="dfn-panel" data-for="term-for-position-props" id="infopanel-for-term-for-position-props①" role="menu">
+   <span id="infopaneltitle-for-term-for-position-props①" style="display:none">Info about the 'right' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-position-props">4.1. Changing the Box Model: the box-sizing property</a>
     <li><a href="#ref-for-position-props①">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-position-props②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-position-props">
-   <a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-position-props" class="dfn-panel" data-for="term-for-position-props" id="infopanel-for-term-for-position-props②" role="menu">
+   <span id="infopaneltitle-for-term-for-position-props②" style="display:none">Info about the 'top' external reference.</span><a href="https://www.w3.org/TR/CSS2/visuren.html#position-props">https://www.w3.org/TR/CSS2/visuren.html#position-props</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-position-props">4.1. Changing the Box Model: the box-sizing property</a>
     <li><a href="#ref-for-position-props①">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-position-props②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://www.w3.org/TR/CSS2/visufx.html#propdef-overflow">https://www.w3.org/TR/CSS2/visufx.html#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'visible' external reference.</span><a href="https://www.w3.org/TR/CSS2/visufx.html#propdef-overflow">https://www.w3.org/TR/CSS2/visufx.html#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow③">6.1. Resizing Boxes: the resize property</a>
     <li><a href="#ref-for-propdef-overflow⑥">6.2. 
     Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css2/#propdef-background-image">https://drafts.csswg.org/css2/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-background-image">https://drafts.csswg.org/css2/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-propdef-background-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-bottom-width">https://drafts.csswg.org/css2/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-bottom-width">https://drafts.csswg.org/css2/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-border-bottom-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-left-width">https://drafts.csswg.org/css2/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-left-width">https://drafts.csswg.org/css2/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-border-left-width①">(2)</a> <a href="#ref-for-propdef-border-left-width②">(3)</a> <a href="#ref-for-propdef-border-left-width③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-right-width">https://drafts.csswg.org/css2/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-right-width">https://drafts.csswg.org/css2/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-border-right-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-style">https://drafts.csswg.org/css2/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-style">https://drafts.csswg.org/css2/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">5.3. Outline Patterns: the outline-style property</a>
     <li><a href="#ref-for-propdef-border-style①">5.4. Outline Colors: the outline-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-top-width">https://drafts.csswg.org/css2/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-top-width">https://drafts.csswg.org/css2/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-border-top-width①">(2)</a> <a href="#ref-for-propdef-border-top-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-width">https://drafts.csswg.org/css2/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-width">https://drafts.csswg.org/css2/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">5.4. Outline Colors: the outline-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-height">
-   <a href="https://drafts.csswg.org/css2/#content-height">https://drafts.csswg.org/css2/#content-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-height" class="dfn-panel" data-for="term-for-content-height" id="infopanel-for-term-for-content-height" role="menu">
+   <span id="infopaneltitle-for-term-for-content-height" style="display:none">Info about the 'content height' external reference.</span><a href="https://drafts.csswg.org/css2/#content-height">https://drafts.csswg.org/css2/#content-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-content-height①">(2)</a> <a href="#ref-for-content-height②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-width">
-   <a href="https://drafts.csswg.org/css2/#content-width">https://drafts.csswg.org/css2/#content-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-width" class="dfn-panel" data-for="term-for-content-width" id="infopanel-for-term-for-content-width" role="menu">
+   <span id="infopaneltitle-for-term-for-content-width" style="display:none">Info about the 'content width' external reference.</span><a href="https://drafts.csswg.org/css2/#content-width">https://drafts.csswg.org/css2/#content-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-content-width①">(2)</a> <a href="#ref-for-content-width②">(3)</a> <a href="#ref-for-content-width③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">7.1.1.1. Cursor of the canvas</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-height">https://drafts.csswg.org/css2/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-height">https://drafts.csswg.org/css2/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-height①">(2)</a> <a href="#ref-for-propdef-height②">(3)</a> <a href="#ref-for-propdef-height③">(4)</a> <a href="#ref-for-propdef-height④">(5)</a>
     <li><a href="#ref-for-propdef-height⑤">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-height⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">4.1. Changing the Box Model: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin-left">https://drafts.csswg.org/css2/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin-left">https://drafts.csswg.org/css2/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">4.1. Changing the Box Model: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-margin-top">https://drafts.csswg.org/css2/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-margin-top">https://drafts.csswg.org/css2/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">4.1. Changing the Box Model: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-max-height①">(2)</a> <a href="#ref-for-propdef-max-height②">(3)</a> <a href="#ref-for-propdef-max-height③">(4)</a>
     <li><a href="#ref-for-propdef-max-height④">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-max-width①">(2)</a> <a href="#ref-for-propdef-max-width②">(3)</a> <a href="#ref-for-propdef-max-width③">(4)</a>
     <li><a href="#ref-for-propdef-max-width④">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-min-height①">(2)</a> <a href="#ref-for-propdef-min-height②">(3)</a> <a href="#ref-for-propdef-min-height③">(4)</a>
     <li><a href="#ref-for-propdef-min-height④">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-min-width①">(2)</a> <a href="#ref-for-propdef-min-width②">(3)</a> <a href="#ref-for-propdef-min-width③">(4)</a>
     <li><a href="#ref-for-propdef-min-width④">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow①" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow①" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-overflow">https://drafts.csswg.org/css2/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-overflow①">(2)</a> <a href="#ref-for-propdef-overflow②">(3)</a> <a href="#ref-for-propdef-overflow④">(4)</a>
     <li><a href="#ref-for-propdef-overflow⑤">6.2. 
     Overflow Ellipsis: the text-overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css2/#propdef-padding-bottom">https://drafts.csswg.org/css2/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-padding-bottom">https://drafts.csswg.org/css2/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-padding-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-padding-left">https://drafts.csswg.org/css2/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-padding-left">https://drafts.csswg.org/css2/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-padding-left①">(2)</a> <a href="#ref-for-propdef-padding-left②">(3)</a> <a href="#ref-for-propdef-padding-left③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css2/#propdef-padding-right">https://drafts.csswg.org/css2/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-padding-right">https://drafts.csswg.org/css2/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-padding-right①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-padding-top">https://drafts.csswg.org/css2/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-padding-top">https://drafts.csswg.org/css2/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-padding-top①">(2)</a> <a href="#ref-for-propdef-padding-top②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css2/#propdef-visibility">https://drafts.csswg.org/css2/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-visibility">https://drafts.csswg.org/css2/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">7.1.1.1. Cursor of the canvas</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-width">https://drafts.csswg.org/css2/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-width">https://drafts.csswg.org/css2/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a> <a href="#ref-for-propdef-width③">(4)</a> <a href="#ref-for-propdef-width④">(5)</a> <a href="#ref-for-propdef-width⑤">(6)</a> <a href="#ref-for-propdef-width⑥">(7)</a> <a href="#ref-for-propdef-width⑦">(8)</a>
     <li><a href="#ref-for-propdef-width⑧">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-width⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-picture-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-picture-element" class="dfn-panel" data-for="term-for-the-picture-element" id="infopanel-for-term-for-the-picture-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-picture-element" style="display:none">Info about the 'picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-picture-element">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">6.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://www.w3.org/TR/SVG2/struct.html#elementdef-svg">https://www.w3.org/TR/SVG2/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://www.w3.org/TR/SVG2/struct.html#elementdef-svg">https://www.w3.org/TR/SVG2/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">6.1. Resizing Boxes: the resize property</a>
    </ul>
@@ -2642,48 +2642,48 @@ and optionally replaced elements such as images, videos, and iframes
       <td>specified keyword
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-box-sizing">
-   <b><a href="#propdef-box-sizing">#propdef-box-sizing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-box-sizing" class="dfn-panel" data-for="propdef-box-sizing" id="infopanel-for-propdef-box-sizing" role="dialog">
+   <span id="infopaneltitle-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' definition.</span><b><a href="#propdef-box-sizing">#propdef-box-sizing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-propdef-box-sizing①">(2)</a> <a href="#ref-for-propdef-box-sizing②">(3)</a> <a href="#ref-for-propdef-box-sizing③">(4)</a> <a href="#ref-for-propdef-box-sizing④">(5)</a> <a href="#ref-for-propdef-box-sizing⑤">(6)</a> <a href="#ref-for-propdef-box-sizing⑥">(7)</a>
     <li><a href="#ref-for-propdef-box-sizing⑦">Using box-sizing to evenly share space</a>
     <li><a href="#ref-for-propdef-box-sizing⑧">Appendix A. Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-inner-width">
-   <b><a href="#min-inner-width">#min-inner-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-inner-width" class="dfn-panel" data-for="min-inner-width" id="infopanel-for-min-inner-width" role="dialog">
+   <span id="infopaneltitle-for-min-inner-width" style="display:none">Info about the 'min inner width' definition.</span><b><a href="#min-inner-width">#min-inner-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-inner-width">4.1. Changing the Box Model: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-inner-width">
-   <b><a href="#max-inner-width">#max-inner-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-inner-width" class="dfn-panel" data-for="max-inner-width" id="infopanel-for-max-inner-width" role="dialog">
+   <span id="infopaneltitle-for-max-inner-width" style="display:none">Info about the 'max inner width' definition.</span><b><a href="#max-inner-width">#max-inner-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-inner-width">4.1. Changing the Box Model: the box-sizing property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="min-inner-height">
-   <b><a href="#min-inner-height">#min-inner-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-min-inner-height" class="dfn-panel" data-for="min-inner-height" id="infopanel-for-min-inner-height" role="dialog">
+   <span id="infopaneltitle-for-min-inner-height" style="display:none">Info about the 'min inner height' definition.</span><b><a href="#min-inner-height">#min-inner-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-inner-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-min-inner-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-inner-height">
-   <b><a href="#max-inner-height">#max-inner-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-inner-height" class="dfn-panel" data-for="max-inner-height" id="infopanel-for-max-inner-height" role="dialog">
+   <span id="infopaneltitle-for-max-inner-height" style="display:none">Info about the 'max inner height' definition.</span><b><a href="#max-inner-height">#max-inner-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-inner-height">4.1. Changing the Box Model: the box-sizing property</a> <a href="#ref-for-max-inner-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline">
-   <b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline" class="dfn-panel" data-for="propdef-outline" id="infopanel-for-propdef-outline" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline" style="display:none">Info about the 'outline' definition.</span><b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">5.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline①">5.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-propdef-outline②">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-width">
-   <b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-width" class="dfn-panel" data-for="propdef-outline-width" id="infopanel-for-propdef-outline-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-width" style="display:none">Info about the 'outline-width' definition.</span><b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-width">5.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-width①">5.2. Outline Thickness: the outline-width property</a>
@@ -2691,8 +2691,8 @@ and optionally replaced elements such as images, videos, and iframes
     <li><a href="#ref-for-propdef-outline-width④">5.5. Offsetting the Outline: the outline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-style">
-   <b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-style" class="dfn-panel" data-for="propdef-outline-style" id="infopanel-for-propdef-outline-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-style" style="display:none">Info about the 'outline-style' definition.</span><b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-style">5.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-style①">5.3. Outline Patterns: the outline-style property</a>
@@ -2700,33 +2700,33 @@ and optionally replaced elements such as images, videos, and iframes
     <li><a href="#ref-for-propdef-outline-style⑤">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-color">
-   <b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-color" class="dfn-panel" data-for="propdef-outline-color" id="infopanel-for-propdef-outline-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-color" style="display:none">Info about the 'outline-color' definition.</span><b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">5.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-color①">5.4. Outline Colors: the outline-color property</a> <a href="#ref-for-propdef-outline-color②">(2)</a> <a href="#ref-for-propdef-outline-color③">(3)</a> <a href="#ref-for-propdef-outline-color④">(4)</a> <a href="#ref-for-propdef-outline-color⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-outline-color-invert">
-   <b><a href="#valdef-outline-color-invert">#valdef-outline-color-invert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-outline-color-invert" class="dfn-panel" data-for="valdef-outline-color-invert" id="infopanel-for-valdef-outline-color-invert" role="dialog">
+   <span id="infopaneltitle-for-valdef-outline-color-invert" style="display:none">Info about the 'invert' definition.</span><b><a href="#valdef-outline-color-invert">#valdef-outline-color-invert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-outline-color-invert">5.4. Outline Colors: the outline-color property</a> <a href="#ref-for-valdef-outline-color-invert①">(2)</a> <a href="#ref-for-valdef-outline-color-invert②">(3)</a> <a href="#ref-for-valdef-outline-color-invert③">(4)</a> <a href="#ref-for-valdef-outline-color-invert④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-offset">
-   <b><a href="#propdef-outline-offset">#propdef-outline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-offset" class="dfn-panel" data-for="propdef-outline-offset" id="infopanel-for-propdef-outline-offset" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-offset" style="display:none">Info about the 'outline-offset' definition.</span><b><a href="#propdef-outline-offset">#propdef-outline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-offset">5.5. Offsetting the Outline: the outline-offset property</a> <a href="#ref-for-propdef-outline-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-resize">
-   <b><a href="#propdef-resize">#propdef-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-resize" class="dfn-panel" data-for="propdef-resize" id="infopanel-for-propdef-resize" role="dialog">
+   <span id="infopaneltitle-for-propdef-resize" style="display:none">Info about the 'resize' definition.</span><b><a href="#propdef-resize">#propdef-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-resize">6.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-resize①">(2)</a> <a href="#ref-for-propdef-resize②">(3)</a> <a href="#ref-for-propdef-resize③">(4)</a> <a href="#ref-for-propdef-resize④">(5)</a> <a href="#ref-for-propdef-resize⑤">(6)</a> <a href="#ref-for-propdef-resize⑥">(7)</a> <a href="#ref-for-propdef-resize⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-overflow">
-   <b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-overflow" class="dfn-panel" data-for="propdef-text-overflow" id="infopanel-for-propdef-text-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' definition.</span><b><a href="#propdef-text-overflow">#propdef-text-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">6.2. 
     Overflow Ellipsis: the text-overflow property</a>
@@ -2734,8 +2734,8 @@ and optionally replaced elements such as images, videos, and iframes
     <li><a href="#ref-for-propdef-text-overflow②">user interaction with ellipsis</a> <a href="#ref-for-propdef-text-overflow③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cursor">
-   <b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cursor" class="dfn-panel" data-for="propdef-cursor" id="infopanel-for-propdef-cursor" role="dialog">
+   <span id="infopaneltitle-for-propdef-cursor" style="display:none">Info about the 'cursor' definition.</span><b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">7.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-propdef-cursor①">(2)</a>
     <li><a href="#ref-for-propdef-cursor②">7.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-propdef-cursor③">(2)</a>
@@ -2743,129 +2743,185 @@ and optionally replaced elements such as images, videos, and iframes
     <li><a href="#ref-for-propdef-cursor⑥">Appendix C. Considerations for Security and Privacy</a> <a href="#ref-for-propdef-cursor⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-auto">
-   <b><a href="#valdef-cursor-auto">#valdef-cursor-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-auto" class="dfn-panel" data-for="valdef-cursor-auto" id="infopanel-for-valdef-cursor-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-cursor-auto">#valdef-cursor-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-auto">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-default">
-   <b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-default" class="dfn-panel" data-for="valdef-cursor-default" id="infopanel-for-valdef-cursor-default" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-default" style="display:none">Info about the 'default' definition.</span><b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-pointer">
-   <b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-pointer" class="dfn-panel" data-for="valdef-cursor-pointer" id="infopanel-for-valdef-cursor-pointer" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-pointer">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-wait">
-   <b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-wait" class="dfn-panel" data-for="valdef-cursor-wait" id="infopanel-for-valdef-cursor-wait" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-wait" style="display:none">Info about the 'wait' definition.</span><b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-wait">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-text">
-   <b><a href="#valdef-cursor-text">#valdef-cursor-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-text" class="dfn-panel" data-for="valdef-cursor-text" id="infopanel-for-valdef-cursor-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-cursor-text">#valdef-cursor-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-text">7.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-valdef-cursor-text①">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
     <li><a href="#ref-for-valdef-cursor-text②">Appendix B. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-vertical-text">
-   <b><a href="#valdef-cursor-vertical-text">#valdef-cursor-vertical-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-vertical-text" class="dfn-panel" data-for="valdef-cursor-vertical-text" id="infopanel-for-valdef-cursor-vertical-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-vertical-text" style="display:none">Info about the 'vertical-text' definition.</span><b><a href="#valdef-cursor-vertical-text">#valdef-cursor-vertical-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-vertical-text">7.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-valdef-cursor-vertical-text①">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-se-resize">
-   <b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-se-resize" class="dfn-panel" data-for="valdef-cursor-se-resize" id="infopanel-for-valdef-cursor-se-resize" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-se-resize" style="display:none">Info about the 'se-resize' definition.</span><b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-se-resize">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-zoom-in">
-   <b><a href="#valdef-cursor-zoom-in">#valdef-cursor-zoom-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-zoom-in" class="dfn-panel" data-for="valdef-cursor-zoom-in" id="infopanel-for-valdef-cursor-zoom-in" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-zoom-in" style="display:none">Info about the 'zoom-in' definition.</span><b><a href="#valdef-cursor-zoom-in">#valdef-cursor-zoom-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-zoom-in">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-zoom-out">
-   <b><a href="#valdef-cursor-zoom-out">#valdef-cursor-zoom-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-zoom-out" class="dfn-panel" data-for="valdef-cursor-zoom-out" id="infopanel-for-valdef-cursor-zoom-out" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-zoom-out" style="display:none">Info about the 'zoom-out' definition.</span><b><a href="#valdef-cursor-zoom-out">#valdef-cursor-zoom-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-zoom-out">7.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caret-color">
-   <b><a href="#propdef-caret-color">#propdef-caret-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caret-color" class="dfn-panel" data-for="propdef-caret-color" id="infopanel-for-propdef-caret-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-caret-color" style="display:none">Info about the 'caret-color' definition.</span><b><a href="#propdef-caret-color">#propdef-caret-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-color">7.2.1. Coloring the Insertion Caret: the caret-color property</a>
     <li><a href="#ref-for-propdef-caret-color①">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-caret-color-auto">
-   <b><a href="#valdef-caret-color-auto">#valdef-caret-color-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-caret-color-auto" class="dfn-panel" data-for="valdef-caret-color-auto" id="infopanel-for-valdef-caret-color-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-caret-color-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-caret-color-auto">#valdef-caret-color-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-color-auto">7.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-valdef-caret-color-auto①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/css-ui-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-ui-4/Overview.html
@@ -3683,210 +3683,210 @@ option<c- p>[</c->selected<c- p>]</c->::before <c- p>{</c->
    <li><a href="#valdef-cursor-zoom-in">zoom-in</a><span>, in § 5.1.1</span>
    <li><a href="#valdef-cursor-zoom-out">zoom-out</a><span>, in § 5.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-style" class="dfn-panel" data-for="term-for-typedef-line-style" id="infopanel-for-term-for-typedef-line-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-style" style="display:none">Info about the '&lt;line-style>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-style">3.4. Outline Colors: the outline-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-width" class="dfn-panel" data-for="term-for-typedef-line-width" id="infopanel-for-term-for-typedef-line-width" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-width" style="display:none">Info about the '&lt;line-width>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-width">3.2. Outline Thickness: the outline-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">7.1. Widget Accent Colors: the accent-color property</a>
     <li><a href="#ref-for-propdef-background-color①">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-propdef-background-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border" class="dfn-panel" data-for="term-for-propdef-border" id="infopanel-for-term-for-propdef-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border" style="display:none">Info about the 'border' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border">https://drafts.csswg.org/css-backgrounds-3/#propdef-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">7.2. Switching appearance: the appearance property</a>
     <li><a href="#ref-for-propdef-border①">7.3. 
 Control Specific Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">3.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-propdef-border-radius①">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">3.4. Outline Colors: the outline-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-style-none">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-style-none" class="dfn-panel" data-for="term-for-valdef-line-style-none" id="infopanel-for-term-for-valdef-line-style-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-style-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none">https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-style-none">3.2. Outline Thickness: the outline-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-edge">https://drafts.csswg.org/css-box-4/#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">3.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-border-edge①">3.5. Offsetting the Outline: the outline-offset property</a> <a href="#ref-for-border-edge②">(2)</a> <a href="#ref-for-border-edge③">(3)</a>
     <li><a href="#ref-for-border-edge④">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-border-edge⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#content-edge">https://drafts.csswg.org/css-box-4/#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">7.3.1. 
 Single-Line Text Input Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-edge">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-edge" class="dfn-panel" data-for="term-for-padding-edge" id="infopanel-for-term-for-padding-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-edge" style="display:none">Info about the 'padding edge' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-edge">https://drafts.csswg.org/css-box-4/#padding-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">7.3.1. 
 Single-Line Text Input Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">7.2.1. 
 Effects of appearance on Decorative Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">6.1. Controlling content selection</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-legacy-name-alias">
-   <a href="https://drafts.csswg.org/css-cascade-5/#legacy-name-alias">https://drafts.csswg.org/css-cascade-5/#legacy-name-alias</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-legacy-name-alias" class="dfn-panel" data-for="term-for-legacy-name-alias" id="infopanel-for-term-for-legacy-name-alias" role="menu">
+   <span id="infopaneltitle-for-term-for-legacy-name-alias" style="display:none">Info about the 'legacy name alias' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#legacy-name-alias">https://drafts.csswg.org/css-cascade-5/#legacy-name-alias</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-name-alias">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'sub-property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">6.1. Controlling content selection</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a> <a href="#ref-for-used-value③">(4)</a> <a href="#ref-for-used-value④">(5)</a> <a href="#ref-for-used-value⑤">(6)</a> <a href="#ref-for-used-value⑥">(7)</a> <a href="#ref-for-used-value⑦">(8)</a> <a href="#ref-for-used-value⑧">(9)</a> <a href="#ref-for-used-value⑨">(10)</a> <a href="#ref-for-used-value①⓪">(11)</a> <a href="#ref-for-used-value①①">(12)</a> <a href="#ref-for-used-value①②">(13)</a> <a href="#ref-for-used-value①③">(14)</a> <a href="#ref-for-used-value①④">(15)</a> <a href="#ref-for-used-value①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'user-agent origin' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">3.4. Outline Colors: the outline-color property</a> <a href="#ref-for-typedef-color①">(2)</a>
     <li><a href="#ref-for-typedef-color②">5.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-typedef-color③">(2)</a> <a href="#ref-for-typedef-color④">(3)</a>
     <li><a href="#ref-for-typedef-color⑤">7.1. Widget Accent Colors: the accent-color property</a> <a href="#ref-for-typedef-color⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">7.1. Widget Accent Colors: the accent-color property</a>
     <li><a href="#ref-for-propdef-color①">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">5.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-valdef-color-currentcolor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">5.1.1.1. Cursor of the canvas</a> <a href="#ref-for-propdef-display①">(2)</a>
     <li><a href="#ref-for-propdef-display②">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a>
     <li><a href="#ref-for-typedef-image④">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concrete-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concrete-object-size" class="dfn-panel" data-for="term-for-concrete-object-size" id="infopanel-for-term-for-concrete-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-concrete-object-size" style="display:none">Info about the 'concrete object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#concrete-object-size">https://drafts.csswg.org/css-images-3/#concrete-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concrete-object-size">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sizing-algorithm">
-   <a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sizing-algorithm" class="dfn-panel" data-for="term-for-default-sizing-algorithm" id="infopanel-for-term-for-default-sizing-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sizing-algorithm" style="display:none">Info about the 'default sizing algorithm' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-sizing-algorithm">https://drafts.csswg.org/css-images-3/#default-sizing-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sizing-algorithm">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-aspect-ratio" class="dfn-panel" data-for="term-for-natural-aspect-ratio" id="infopanel-for-term-for-natural-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-aspect-ratio" style="display:none">Info about the 'natural aspect ratio' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-aspect-ratio">https://drafts.csswg.org/css-images-3/#natural-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-aspect-ratio">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-natural-size">
-   <a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-natural-size" class="dfn-panel" data-for="term-for-natural-size" id="infopanel-for-term-for-natural-size" role="menu">
+   <span id="infopaneltitle-for-term-for-natural-size" style="display:none">Info about the 'natural size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#natural-size">https://drafts.csswg.org/css-images-3/#natural-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-natural-size">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-natural-size①">(2)</a> <a href="#ref-for-natural-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">4.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-overflow①">(2)</a> <a href="#ref-for-propdef-overflow②">(3)</a> <a href="#ref-for-propdef-overflow③">(4)</a>
     <li><a href="#ref-for-propdef-overflow④">7.3.1. 
 Single-Line Text Input Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">2. Module Interactions</a>
     <li><a href="#ref-for-propdef-text-overflow①">7.3.1. 
@@ -3895,133 +3895,133 @@ Single-Line Text Input Controls</a>
 22 December 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-margin-boxes">
-   <a href="https://drafts.csswg.org/css-page-3/#page-margin-boxes">https://drafts.csswg.org/css-page-3/#page-margin-boxes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-margin-boxes" class="dfn-panel" data-for="term-for-page-margin-boxes" id="infopanel-for-term-for-page-margin-boxes" role="menu">
+   <span id="infopaneltitle-for-term-for-page-margin-boxes" style="display:none">Info about the 'page-margin boxes' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-margin-boxes">https://drafts.csswg.org/css-page-3/#page-margin-boxes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-margin-boxes">6.1. Controlling content selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">Unnumbered Section</a>
     <li><a href="#ref-for-selectordef-after①">6.1. Controlling content selection</a> <a href="#ref-for-selectordef-after②">(2)</a> <a href="#ref-for-selectordef-after③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">Unnumbered Section</a>
     <li><a href="#ref-for-selectordef-before①">6.1. Controlling content selection</a> <a href="#ref-for-selectordef-before②">(2)</a> <a href="#ref-for-selectordef-before③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">6.1. Controlling content selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">6.1. Controlling content selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-marker">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-marker" class="dfn-panel" data-for="term-for-selectordef-marker" id="infopanel-for-term-for-selectordef-marker" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-marker" style="display:none">Info about the '::marker' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-marker">https://drafts.csswg.org/css-pseudo-4/#selectordef-marker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-marker">6.1. Controlling content selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">2. Module Interactions</a>
     <li><a href="#ref-for-propdef-box-sizing①">Changes from the
 22 December 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">4.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-caret-color-auto">
-   <a href="https://drafts.csswg.org/css-ui-3/#valdef-caret-color-auto">https://drafts.csswg.org/css-ui-3/#valdef-caret-color-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-caret-color-auto" class="dfn-panel" data-for="term-for-valdef-caret-color-auto" id="infopanel-for-term-for-valdef-caret-color-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-caret-color-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-ui-3/#valdef-caret-color-auto">https://drafts.csswg.org/css-ui-3/#valdef-caret-color-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-color-auto">5.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-valdef-caret-color-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.5. Offsetting the Outline: the outline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">5.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-mult-opt①">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">2.1. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.3. Outline Patterns: the outline-style property</a>
     <li><a href="#ref-for-comb-one①">3.4. Outline Colors: the outline-color property</a>
@@ -4035,196 +4035,196 @@ Single-Line Text Input Controls</a>
     <li><a href="#ref-for-comb-one⑤④">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-comb-one⑤⑤">(2)</a> <a href="#ref-for-comb-one⑤⑥">(3)</a> <a href="#ref-for-comb-one⑤⑦">(4)</a> <a href="#ref-for-comb-one⑤⑧">(5)</a> <a href="#ref-for-comb-one⑤⑨">(6)</a> <a href="#ref-for-comb-one⑥⓪">(7)</a> <a href="#ref-for-comb-one⑥①">(8)</a> <a href="#ref-for-comb-one⑥②">(9)</a> <a href="#ref-for-comb-one⑥③">(10)</a> <a href="#ref-for-comb-one⑥④">(11)</a> <a href="#ref-for-comb-one⑥⑤">(12)</a> <a href="#ref-for-comb-one⑥⑥">(13)</a> <a href="#ref-for-comb-one⑥⑦">(14)</a> <a href="#ref-for-comb-one⑥⑧">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.1. Outlines Shorthand: the outline property</a> <a href="#ref-for-comb-any①">(2)</a>
     <li><a href="#ref-for-comb-any②">5.2.3. Insertion caret shorthand: caret</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-size" class="dfn-panel" data-for="term-for-block-size" id="infopanel-for-term-for-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-block-size" style="display:none">Info about the 'block size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-size">https://drafts.csswg.org/css-writing-modes-4/#block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-size">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-size" class="dfn-panel" data-for="term-for-inline-size" id="infopanel-for-term-for-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-size" style="display:none">Info about the 'inline size' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-size">https://drafts.csswg.org/css-writing-modes-4/#inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline-axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-under">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-under" class="dfn-panel" data-for="term-for-under" id="infopanel-for-term-for-under" role="menu">
+   <span id="infopaneltitle-for-term-for-under" style="display:none">Info about the 'under' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#under">https://drafts.csswg.org/css-writing-modes-4/#under</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">5.2.2. Shape of the insertion caret: caret-shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writing-mode" class="dfn-panel" data-for="term-for-writing-mode" id="infopanel-for-term-for-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-writing-mode" style="display:none">Info about the 'writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#writing-mode">https://drafts.csswg.org/css-writing-modes-4/#writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-writing-mode①">(2)</a> <a href="#ref-for-writing-mode②">(3)</a>
     <li><a href="#ref-for-writing-mode③">5.2.2. Shape of the insertion caret: caret-shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">4.1. Resizing Boxes: the resize property</a>
     <li><a href="#ref-for-propdef-bottom①">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">4.1. Resizing Boxes: the resize property</a>
     <li><a href="#ref-for-propdef-right①">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css2/#propdef-visibility">https://drafts.csswg.org/css2/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-visibility">https://drafts.csswg.org/css2/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">5.1.1.1. Cursor of the canvas</a>
     <li><a href="#ref-for-propdef-visibility①">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-z-index">
-   <a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-z-index" class="dfn-panel" data-for="term-for-propdef-z-index" id="infopanel-for-term-for-propdef-z-index" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-z-index" style="display:none">Info about the 'z-index' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-z-index">https://drafts.csswg.org/css2/#propdef-z-index</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">7.2.2. 
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-drop-down-box">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#drop-down-box">https://html.spec.whatwg.org/multipage/rendering.html#drop-down-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-drop-down-box" class="dfn-panel" data-for="term-for-drop-down-box" id="infopanel-for-term-for-drop-down-box" role="menu">
+   <span id="infopaneltitle-for-term-for-drop-down-box" style="display:none">Info about the 'drop-down box' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#drop-down-box">https://html.spec.whatwg.org/multipage/rendering.html#drop-down-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-drop-down-box">7.2. Switching appearance: the appearance property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">6.1. Controlling content selection</a>
     <li><a href="#ref-for-the-input-element①">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-the-input-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fe-mutable">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fe-mutable" class="dfn-panel" data-for="term-for-concept-fe-mutable" id="infopanel-for-term-for-concept-fe-mutable" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fe-mutable" style="display:none">Info about the 'mutable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fe-mutable">6.1. Controlling content selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-option-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-option-element" class="dfn-panel" data-for="term-for-the-option-element" id="infopanel-for-term-for-the-option-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-option-element" style="display:none">Info about the 'option' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-option-element">7.2.2. 
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-picture-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-picture-element" class="dfn-panel" data-for="term-for-the-picture-element" id="infopanel-for-term-for-the-picture-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-picture-element" style="display:none">Info about the 'picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-picture-element">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-select-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-select-element" class="dfn-panel" data-for="term-for-the-select-element" id="infopanel-for-term-for-the-select-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-select-element" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-select-element">7.2. Switching appearance: the appearance property</a>
     <li><a href="#ref-for-the-select-element①">7.2.1. 
@@ -4233,71 +4233,71 @@ Effects of appearance on Decorative Aspects of Elements</a> <a href="#ref-for-th
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-textarea-element" class="dfn-panel" data-for="term-for-the-textarea-element" id="infopanel-for-term-for-the-textarea-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-textarea-element" style="display:none">Info about the 'textarea' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-textarea-element">6.1. Controlling content selection</a> <a href="#ref-for-the-textarea-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-type">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-type" class="dfn-panel" data-for="term-for-attr-input-type" id="infopanel-for-term-for-attr-input-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-type">https://html.spec.whatwg.org/multipage/input.html#attr-input-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-type">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-attr-input-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-scroll-root">
-   <a href="https://drafts.csswg.org/scroll-animations-1/#valdef-scroll-root">https://drafts.csswg.org/scroll-animations-1/#valdef-scroll-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-scroll-root" class="dfn-panel" data-for="term-for-valdef-scroll-root" id="infopanel-for-term-for-valdef-scroll-root" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-scroll-root" style="display:none">Info about the 'root' external reference.</span><a href="https://drafts.csswg.org/scroll-animations-1/#valdef-scroll-root">https://drafts.csswg.org/scroll-animations-1/#valdef-scroll-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-root">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a> <a href="#ref-for-valdef-scroll-root①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-checked-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#checked-pseudo">https://drafts.csswg.org/selectors-4/#checked-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-checked-pseudo" class="dfn-panel" data-for="term-for-checked-pseudo" id="infopanel-for-term-for-checked-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-checked-pseudo" style="display:none">Info about the ':checked' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#checked-pseudo">https://drafts.csswg.org/selectors-4/#checked-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-checked-pseudo">7.2.2. 
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-disabled-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#disabled-pseudo">https://drafts.csswg.org/selectors-4/#disabled-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-disabled-pseudo" class="dfn-panel" data-for="term-for-disabled-pseudo" id="infopanel-for-term-for-disabled-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-disabled-pseudo" style="display:none">Info about the ':disabled' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#disabled-pseudo">https://drafts.csswg.org/selectors-4/#disabled-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disabled-pseudo">7.2.2. 
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enabled-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#enabled-pseudo">https://drafts.csswg.org/selectors-4/#enabled-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enabled-pseudo" class="dfn-panel" data-for="term-for-enabled-pseudo" id="infopanel-for-term-for-enabled-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-enabled-pseudo" style="display:none">Info about the ':enabled' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#enabled-pseudo">https://drafts.csswg.org/selectors-4/#enabled-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enabled-pseudo">7.2.2. 
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focus-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#focus-pseudo">https://drafts.csswg.org/selectors-4/#focus-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focus-pseudo" class="dfn-panel" data-for="term-for-focus-pseudo" id="infopanel-for-term-for-focus-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-focus-pseudo" style="display:none">Info about the ':focus' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#focus-pseudo">https://drafts.csswg.org/selectors-4/#focus-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-pseudo">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focus-visible-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#focus-visible-pseudo">https://drafts.csswg.org/selectors-4/#focus-visible-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focus-visible-pseudo" class="dfn-panel" data-for="term-for-focus-visible-pseudo" id="infopanel-for-term-for-focus-visible-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-focus-visible-pseudo" style="display:none">Info about the ':focus-visible' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#focus-visible-pseudo">https://drafts.csswg.org/selectors-4/#focus-visible-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-visible-pseudo">3. Outline properties</a> <a href="#ref-for-focus-visible-pseudo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">4.1. Resizing Boxes: the resize property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-textPath">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-textPath" class="dfn-panel" data-for="term-for-elementdef-textPath" id="infopanel-for-term-for-elementdef-textPath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-textPath" style="display:none">Info about the 'textpath' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-textPath">5.2.2. Shape of the insertion caret: caret-shape</a>
    </ul>
@@ -4805,16 +4805,16 @@ which properties on which elements
 have this effect. <a class="issue-return" href="#issue-a6172891" title="Jump to section">↵</a></div>
    <div class="issue"> Documenting what UAs need to put in their UA stylesheet would be good. <a class="issue-return" href="#issue-b9172b39" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-outline">
-   <b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline" class="dfn-panel" data-for="propdef-outline" id="infopanel-for-propdef-outline" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline" style="display:none">Info about the 'outline' definition.</span><b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">3.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline①">3.4. Outline Colors: the outline-color property</a>
     <li><a href="#ref-for-propdef-outline②">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-width">
-   <b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-width" class="dfn-panel" data-for="propdef-outline-width" id="infopanel-for-propdef-outline-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-width" style="display:none">Info about the 'outline-width' definition.</span><b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-width">3.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-width①">3.2. Outline Thickness: the outline-width property</a>
@@ -4822,8 +4822,8 @@ have this effect. <a class="issue-return" href="#issue-a6172891" title="Jump to 
     <li><a href="#ref-for-propdef-outline-width⑤">3.5. Offsetting the Outline: the outline-offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-style">
-   <b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-style" class="dfn-panel" data-for="propdef-outline-style" id="infopanel-for-propdef-outline-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-style" style="display:none">Info about the 'outline-style' definition.</span><b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-style">3.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-style①">3.3. Outline Patterns: the outline-style property</a>
@@ -4831,42 +4831,42 @@ have this effect. <a class="issue-return" href="#issue-a6172891" title="Jump to 
     <li><a href="#ref-for-propdef-outline-style④">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-color">
-   <b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-color" class="dfn-panel" data-for="propdef-outline-color" id="infopanel-for-propdef-outline-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-color" style="display:none">Info about the 'outline-color' definition.</span><b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">3.1. Outlines Shorthand: the outline property</a>
     <li><a href="#ref-for-propdef-outline-color①">3.4. Outline Colors: the outline-color property</a> <a href="#ref-for-propdef-outline-color②">(2)</a> <a href="#ref-for-propdef-outline-color③">(3)</a> <a href="#ref-for-propdef-outline-color④">(4)</a> <a href="#ref-for-propdef-outline-color⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-outline-line-style">
-   <b><a href="#typedef-outline-line-style">#typedef-outline-line-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-outline-line-style" class="dfn-panel" data-for="typedef-outline-line-style" id="infopanel-for-typedef-outline-line-style" role="dialog">
+   <span id="infopaneltitle-for-typedef-outline-line-style" style="display:none">Info about the '&lt;outline-line-style>' definition.</span><b><a href="#typedef-outline-line-style">#typedef-outline-line-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-outline-line-style">3.3. Outline Patterns: the outline-style property</a>
     <li><a href="#ref-for-typedef-outline-line-style①">3.4. Outline Colors: the outline-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-outline-color-invert">
-   <b><a href="#valdef-outline-color-invert">#valdef-outline-color-invert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-outline-color-invert" class="dfn-panel" data-for="valdef-outline-color-invert" id="infopanel-for-valdef-outline-color-invert" role="dialog">
+   <span id="infopaneltitle-for-valdef-outline-color-invert" style="display:none">Info about the 'invert' definition.</span><b><a href="#valdef-outline-color-invert">#valdef-outline-color-invert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-outline-color-invert">3.4. Outline Colors: the outline-color property</a> <a href="#ref-for-valdef-outline-color-invert①">(2)</a> <a href="#ref-for-valdef-outline-color-invert②">(3)</a> <a href="#ref-for-valdef-outline-color-invert③">(4)</a> <a href="#ref-for-valdef-outline-color-invert④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-offset">
-   <b><a href="#propdef-outline-offset">#propdef-outline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-offset" class="dfn-panel" data-for="propdef-outline-offset" id="infopanel-for-propdef-outline-offset" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-offset" style="display:none">Info about the 'outline-offset' definition.</span><b><a href="#propdef-outline-offset">#propdef-outline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-offset">3.5. Offsetting the Outline: the outline-offset property</a> <a href="#ref-for-propdef-outline-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-resize">
-   <b><a href="#propdef-resize">#propdef-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-resize" class="dfn-panel" data-for="propdef-resize" id="infopanel-for-propdef-resize" role="dialog">
+   <span id="infopaneltitle-for-propdef-resize" style="display:none">Info about the 'resize' definition.</span><b><a href="#propdef-resize">#propdef-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-resize">4.1. Resizing Boxes: the resize property</a> <a href="#ref-for-propdef-resize①">(2)</a> <a href="#ref-for-propdef-resize②">(3)</a> <a href="#ref-for-propdef-resize③">(4)</a> <a href="#ref-for-propdef-resize④">(5)</a> <a href="#ref-for-propdef-resize⑤">(6)</a> <a href="#ref-for-propdef-resize⑥">(7)</a> <a href="#ref-for-propdef-resize⑦">(8)</a>
     <li><a href="#ref-for-propdef-resize⑧">Changes from the
 24 January 2020 Working Draft</a> <a href="#ref-for-propdef-resize⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cursor">
-   <b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cursor" class="dfn-panel" data-for="propdef-cursor" id="infopanel-for-propdef-cursor" role="dialog">
+   <span id="infopaneltitle-for-propdef-cursor" style="display:none">Info about the 'cursor' definition.</span><b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-propdef-cursor①">(2)</a> <a href="#ref-for-propdef-cursor②">(3)</a> <a href="#ref-for-propdef-cursor③">(4)</a>
     <li><a href="#ref-for-propdef-cursor④">5.2.1. Coloring the Insertion Caret: the caret-color property</a> <a href="#ref-for-propdef-cursor⑤">(2)</a>
@@ -4876,35 +4876,35 @@ have this effect. <a class="issue-return" href="#issue-a6172891" title="Jump to 
     <li><a href="#ref-for-propdef-cursor⑧">Appendix C. Considerations for Security and Privacy</a> <a href="#ref-for-propdef-cursor⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-auto">
-   <b><a href="#valdef-cursor-auto">#valdef-cursor-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-auto" class="dfn-panel" data-for="valdef-cursor-auto" id="infopanel-for-valdef-cursor-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-cursor-auto">#valdef-cursor-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-auto">5.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-valdef-cursor-auto①">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-default">
-   <b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-default" class="dfn-panel" data-for="valdef-cursor-default" id="infopanel-for-valdef-cursor-default" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-default" style="display:none">Info about the 'default' definition.</span><b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-pointer">
-   <b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-pointer" class="dfn-panel" data-for="valdef-cursor-pointer" id="infopanel-for-valdef-cursor-pointer" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-pointer">5.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-valdef-cursor-pointer①">Changes from the
 22 December 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-wait">
-   <b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-wait" class="dfn-panel" data-for="valdef-cursor-wait" id="infopanel-for-valdef-cursor-wait" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-wait" style="display:none">Info about the 'wait' definition.</span><b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-wait">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-text">
-   <b><a href="#valdef-cursor-text">#valdef-cursor-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-text" class="dfn-panel" data-for="valdef-cursor-text" id="infopanel-for-valdef-cursor-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-cursor-text">#valdef-cursor-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-text">5.1.1. Styling the Cursor: the cursor property</a> <a href="#ref-for-valdef-cursor-text①">(2)</a>
     <li><a href="#ref-for-valdef-cursor-text②">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
@@ -4912,192 +4912,192 @@ have this effect. <a class="issue-return" href="#issue-a6172891" title="Jump to 
 22 December 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-vertical-text">
-   <b><a href="#valdef-cursor-vertical-text">#valdef-cursor-vertical-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-vertical-text" class="dfn-panel" data-for="valdef-cursor-vertical-text" id="infopanel-for-valdef-cursor-vertical-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-vertical-text" style="display:none">Info about the 'vertical-text' definition.</span><b><a href="#valdef-cursor-vertical-text">#valdef-cursor-vertical-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-vertical-text">5.1.1. Styling the Cursor: the cursor property</a>
     <li><a href="#ref-for-valdef-cursor-vertical-text①">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-se-resize">
-   <b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-se-resize" class="dfn-panel" data-for="valdef-cursor-se-resize" id="infopanel-for-valdef-cursor-se-resize" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-se-resize" style="display:none">Info about the 'se-resize' definition.</span><b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-se-resize">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-zoom-in">
-   <b><a href="#valdef-cursor-zoom-in">#valdef-cursor-zoom-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-zoom-in" class="dfn-panel" data-for="valdef-cursor-zoom-in" id="infopanel-for-valdef-cursor-zoom-in" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-zoom-in" style="display:none">Info about the 'zoom-in' definition.</span><b><a href="#valdef-cursor-zoom-in">#valdef-cursor-zoom-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-zoom-in">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-zoom-out">
-   <b><a href="#valdef-cursor-zoom-out">#valdef-cursor-zoom-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-zoom-out" class="dfn-panel" data-for="valdef-cursor-zoom-out" id="infopanel-for-valdef-cursor-zoom-out" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-zoom-out" style="display:none">Info about the 'zoom-out' definition.</span><b><a href="#valdef-cursor-zoom-out">#valdef-cursor-zoom-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-zoom-out">5.1.1. Styling the Cursor: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caret-color">
-   <b><a href="#propdef-caret-color">#propdef-caret-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caret-color" class="dfn-panel" data-for="propdef-caret-color" id="infopanel-for-propdef-caret-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-caret-color" style="display:none">Info about the 'caret-color' definition.</span><b><a href="#propdef-caret-color">#propdef-caret-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-color">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
     <li><a href="#ref-for-propdef-caret-color①">5.2.3. Insertion caret shorthand: caret</a> <a href="#ref-for-propdef-caret-color②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caret-shape">
-   <b><a href="#propdef-caret-shape">#propdef-caret-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caret-shape" class="dfn-panel" data-for="propdef-caret-shape" id="infopanel-for-propdef-caret-shape" role="dialog">
+   <span id="infopaneltitle-for-propdef-caret-shape" style="display:none">Info about the 'caret-shape' definition.</span><b><a href="#propdef-caret-shape">#propdef-caret-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-shape">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
     <li><a href="#ref-for-propdef-caret-shape①">5.2.2. Shape of the insertion caret: caret-shape</a> <a href="#ref-for-propdef-caret-shape②">(2)</a>
     <li><a href="#ref-for-propdef-caret-shape③">5.2.3. Insertion caret shorthand: caret</a> <a href="#ref-for-propdef-caret-shape④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="character">
-   <b><a href="#character">#character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-character" class="dfn-panel" data-for="character" id="infopanel-for-character" role="dialog">
+   <span id="infopaneltitle-for-character" style="display:none">Info about the 'character' definition.</span><b><a href="#character">#character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">5.2.2. Shape of the insertion caret: caret-shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visible-character">
-   <b><a href="#visible-character">#visible-character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visible-character" class="dfn-panel" data-for="visible-character" id="infopanel-for-visible-character" role="dialog">
+   <span id="infopaneltitle-for-visible-character" style="display:none">Info about the 'visible character' definition.</span><b><a href="#visible-character">#visible-character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-character">5.2.2. Shape of the insertion caret: caret-shape</a> <a href="#ref-for-visible-character①">(2)</a> <a href="#ref-for-visible-character②">(3)</a> <a href="#ref-for-visible-character③">(4)</a> <a href="#ref-for-visible-character④">(5)</a> <a href="#ref-for-visible-character⑤">(6)</a> <a href="#ref-for-visible-character⑥">(7)</a> <a href="#ref-for-visible-character⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-caret-shape-auto">
-   <b><a href="#valdef-caret-shape-auto">#valdef-caret-shape-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-caret-shape-auto" class="dfn-panel" data-for="valdef-caret-shape-auto" id="infopanel-for-valdef-caret-shape-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-caret-shape-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-caret-shape-auto">#valdef-caret-shape-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-shape-auto">5.2.2. Shape of the insertion caret: caret-shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-caret-shape-bar">
-   <b><a href="#valdef-caret-shape-bar">#valdef-caret-shape-bar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-caret-shape-bar" class="dfn-panel" data-for="valdef-caret-shape-bar" id="infopanel-for-valdef-caret-shape-bar" role="dialog">
+   <span id="infopaneltitle-for-valdef-caret-shape-bar" style="display:none">Info about the 'bar' definition.</span><b><a href="#valdef-caret-shape-bar">#valdef-caret-shape-bar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-shape-bar">5.2.2. Shape of the insertion caret: caret-shape</a> <a href="#ref-for-valdef-caret-shape-bar①">(2)</a> <a href="#ref-for-valdef-caret-shape-bar②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-caret-shape-block">
-   <b><a href="#valdef-caret-shape-block">#valdef-caret-shape-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-caret-shape-block" class="dfn-panel" data-for="valdef-caret-shape-block" id="infopanel-for-valdef-caret-shape-block" role="dialog">
+   <span id="infopaneltitle-for-valdef-caret-shape-block" style="display:none">Info about the 'block' definition.</span><b><a href="#valdef-caret-shape-block">#valdef-caret-shape-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-shape-block">5.2.1. Coloring the Insertion Caret: the caret-color property</a>
     <li><a href="#ref-for-valdef-caret-shape-block①">5.2.2. Shape of the insertion caret: caret-shape</a> <a href="#ref-for-valdef-caret-shape-block②">(2)</a> <a href="#ref-for-valdef-caret-shape-block③">(3)</a> <a href="#ref-for-valdef-caret-shape-block④">(4)</a> <a href="#ref-for-valdef-caret-shape-block⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-caret-shape-underscore">
-   <b><a href="#valdef-caret-shape-underscore">#valdef-caret-shape-underscore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-caret-shape-underscore" class="dfn-panel" data-for="valdef-caret-shape-underscore" id="infopanel-for-valdef-caret-shape-underscore" role="dialog">
+   <span id="infopaneltitle-for-valdef-caret-shape-underscore" style="display:none">Info about the 'underscore' definition.</span><b><a href="#valdef-caret-shape-underscore">#valdef-caret-shape-underscore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caret-shape-underscore">5.2.2. Shape of the insertion caret: caret-shape</a> <a href="#ref-for-valdef-caret-shape-underscore①">(2)</a> <a href="#ref-for-valdef-caret-shape-underscore②">(3)</a> <a href="#ref-for-valdef-caret-shape-underscore③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caret">
-   <b><a href="#propdef-caret">#propdef-caret</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caret" class="dfn-panel" data-for="propdef-caret" id="infopanel-for-propdef-caret" role="dialog">
+   <span id="infopaneltitle-for-propdef-caret" style="display:none">Info about the 'caret' definition.</span><b><a href="#propdef-caret">#propdef-caret</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret">5.2.3. Insertion caret shorthand: caret</a>
     <li><a href="#ref-for-propdef-caret①">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-nav-up">
-   <b><a href="#propdef-nav-up">#propdef-nav-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-nav-up" class="dfn-panel" data-for="propdef-nav-up" id="infopanel-for-propdef-nav-up" role="dialog">
+   <span id="infopaneltitle-for-propdef-nav-up" style="display:none">Info about the 'nav-up' definition.</span><b><a href="#propdef-nav-up">#propdef-nav-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-up">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-nav-right">
-   <b><a href="#propdef-nav-right">#propdef-nav-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-nav-right" class="dfn-panel" data-for="propdef-nav-right" id="infopanel-for-propdef-nav-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-nav-right" style="display:none">Info about the 'nav-right' definition.</span><b><a href="#propdef-nav-right">#propdef-nav-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-right">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-nav-down">
-   <b><a href="#propdef-nav-down">#propdef-nav-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-nav-down" class="dfn-panel" data-for="propdef-nav-down" id="infopanel-for-propdef-nav-down" role="dialog">
+   <span id="infopaneltitle-for-propdef-nav-down" style="display:none">Info about the 'nav-down' definition.</span><b><a href="#propdef-nav-down">#propdef-nav-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-down">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-nav-left">
-   <b><a href="#propdef-nav-left">#propdef-nav-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-nav-left" class="dfn-panel" data-for="propdef-nav-left" id="infopanel-for-propdef-nav-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-nav-left" style="display:none">Info about the 'nav-left' definition.</span><b><a href="#propdef-nav-left">#propdef-nav-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-nav-left">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-id">
-   <b><a href="#typedef-id">#typedef-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-id" class="dfn-panel" data-for="typedef-id" id="infopanel-for-typedef-id" role="dialog">
+   <span id="infopaneltitle-for-typedef-id" style="display:none">Info about the '&lt;id>' definition.</span><b><a href="#typedef-id">#typedef-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-id">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a> <a href="#ref-for-typedef-id①">(2)</a> <a href="#ref-for-typedef-id②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-target-name">
-   <b><a href="#typedef-target-name">#typedef-target-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-target-name" class="dfn-panel" data-for="typedef-target-name" id="infopanel-for-typedef-target-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-target-name" style="display:none">Info about the '&lt;target-name>' definition.</span><b><a href="#typedef-target-name">#typedef-target-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-target-name">5.3.1. Directional Focus Navigation: the nav-up, nav-right, nav-down, nav-left properties</a> <a href="#ref-for-typedef-target-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-user-select">
-   <b><a href="#propdef-user-select">#propdef-user-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-user-select" class="dfn-panel" data-for="propdef-user-select" id="infopanel-for-propdef-user-select" role="dialog">
+   <span id="infopaneltitle-for-propdef-user-select" style="display:none">Info about the 'user-select' definition.</span><b><a href="#propdef-user-select">#propdef-user-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-user-select①">6.1. Controlling content selection</a> <a href="#ref-for-propdef-user-select②">(2)</a> <a href="#ref-for-propdef-user-select③">(3)</a> <a href="#ref-for-propdef-user-select④">(4)</a> <a href="#ref-for-propdef-user-select⑤">(5)</a> <a href="#ref-for-propdef-user-select⑥">(6)</a> <a href="#ref-for-propdef-user-select⑦">(7)</a> <a href="#ref-for-propdef-user-select⑧">(8)</a> <a href="#ref-for-propdef-user-select⑨">(9)</a> <a href="#ref-for-propdef-user-select①⓪">(10)</a> <a href="#ref-for-propdef-user-select①①">(11)</a> <a href="#ref-for-propdef-user-select①②">(12)</a> <a href="#ref-for-propdef-user-select①③">(13)</a> <a href="#ref-for-propdef-user-select①④">(14)</a> <a href="#ref-for-propdef-user-select①⑤">(15)</a> <a href="#ref-for-propdef-user-select①⑥">(16)</a> <a href="#ref-for-propdef-user-select①⑦">(17)</a>
     <li><a href="#ref-for-propdef-user-select①⑧">Changes from the
 22 December 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="editable-element">
-   <b><a href="#editable-element">#editable-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editable-element" class="dfn-panel" data-for="editable-element" id="infopanel-for-editable-element" role="dialog">
+   <span id="infopaneltitle-for-editable-element" style="display:none">Info about the 'editable element' definition.</span><b><a href="#editable-element">#editable-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editable-element">6.1. Controlling content selection</a> <a href="#ref-for-editable-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-select-auto">
-   <b><a href="#valdef-user-select-auto">#valdef-user-select-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-select-auto" class="dfn-panel" data-for="valdef-user-select-auto" id="infopanel-for-valdef-user-select-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-select-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-user-select-auto">#valdef-user-select-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-select-auto">6.1. Controlling content selection</a> <a href="#ref-for-valdef-user-select-auto①">(2)</a> <a href="#ref-for-valdef-user-select-auto②">(3)</a> <a href="#ref-for-valdef-user-select-auto③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-select-text">
-   <b><a href="#valdef-user-select-text">#valdef-user-select-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-select-text" class="dfn-panel" data-for="valdef-user-select-text" id="infopanel-for-valdef-user-select-text" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-select-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef-user-select-text">#valdef-user-select-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-select-text">6.1. Controlling content selection</a> <a href="#ref-for-valdef-user-select-text①">(2)</a> <a href="#ref-for-valdef-user-select-text②">(3)</a> <a href="#ref-for-valdef-user-select-text③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-select-none">
-   <b><a href="#valdef-user-select-none">#valdef-user-select-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-select-none" class="dfn-panel" data-for="valdef-user-select-none" id="infopanel-for-valdef-user-select-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-select-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-user-select-none">#valdef-user-select-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-select-none">6.1. Controlling content selection</a> <a href="#ref-for-valdef-user-select-none①">(2)</a> <a href="#ref-for-valdef-user-select-none②">(3)</a> <a href="#ref-for-valdef-user-select-none③">(4)</a> <a href="#ref-for-valdef-user-select-none④">(5)</a> <a href="#ref-for-valdef-user-select-none⑤">(6)</a> <a href="#ref-for-valdef-user-select-none⑥">(7)</a> <a href="#ref-for-valdef-user-select-none⑦">(8)</a> <a href="#ref-for-valdef-user-select-none⑧">(9)</a> <a href="#ref-for-valdef-user-select-none⑨">(10)</a> <a href="#ref-for-valdef-user-select-none①⓪">(11)</a> <a href="#ref-for-valdef-user-select-none①①">(12)</a> <a href="#ref-for-valdef-user-select-none①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-select-contain">
-   <b><a href="#valdef-user-select-contain">#valdef-user-select-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-select-contain" class="dfn-panel" data-for="valdef-user-select-contain" id="infopanel-for-valdef-user-select-contain" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-select-contain" style="display:none">Info about the 'contain' definition.</span><b><a href="#valdef-user-select-contain">#valdef-user-select-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-select-contain">6.1. Controlling content selection</a> <a href="#ref-for-valdef-user-select-contain①">(2)</a> <a href="#ref-for-valdef-user-select-contain②">(3)</a> <a href="#ref-for-valdef-user-select-contain③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-user-select-all">
-   <b><a href="#valdef-user-select-all">#valdef-user-select-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-user-select-all" class="dfn-panel" data-for="valdef-user-select-all" id="infopanel-for-valdef-user-select-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-user-select-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-user-select-all">#valdef-user-select-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-user-select-all">6.1. Controlling content selection</a> <a href="#ref-for-valdef-user-select-all①">(2)</a> <a href="#ref-for-valdef-user-select-all②">(3)</a> <a href="#ref-for-valdef-user-select-all③">(4)</a> <a href="#ref-for-valdef-user-select-all④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-accent-color">
-   <b><a href="#propdef-accent-color">#propdef-accent-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-accent-color" class="dfn-panel" data-for="propdef-accent-color" id="infopanel-for-propdef-accent-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-accent-color" style="display:none">Info about the 'accent-color' definition.</span><b><a href="#propdef-accent-color">#propdef-accent-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-accent-color">7.1. Widget Accent Colors: the accent-color property</a> <a href="#ref-for-propdef-accent-color①">(2)</a> <a href="#ref-for-propdef-accent-color②">(3)</a> <a href="#ref-for-propdef-accent-color③">(4)</a> <a href="#ref-for-propdef-accent-color④">(5)</a> <a href="#ref-for-propdef-accent-color⑤">(6)</a>
     <li><a href="#ref-for-propdef-accent-color⑥">Changes from the
 24 January 2020 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accent-color">
-   <b><a href="#accent-color">#accent-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accent-color" class="dfn-panel" data-for="accent-color" id="infopanel-for-accent-color" role="dialog">
+   <span id="infopaneltitle-for-accent-color" style="display:none">Info about the 'accent color' definition.</span><b><a href="#accent-color">#accent-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accent-color">7.1. Widget Accent Colors: the accent-color property</a> <a href="#ref-for-accent-color①">(2)</a> <a href="#ref-for-accent-color②">(3)</a> <a href="#ref-for-accent-color③">(4)</a> <a href="#ref-for-accent-color④">(5)</a> <a href="#ref-for-accent-color⑤">(6)</a> <a href="#ref-for-accent-color⑥">(7)</a> <a href="#ref-for-accent-color⑦">(8)</a> <a href="#ref-for-accent-color⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-accent-color-auto">
-   <b><a href="#valdef-accent-color-auto">#valdef-accent-color-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-accent-color-auto" class="dfn-panel" data-for="valdef-accent-color-auto" id="infopanel-for-valdef-accent-color-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-accent-color-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-accent-color-auto">#valdef-accent-color-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-accent-color-auto">7.1. Widget Accent Colors: the accent-color property</a> <a href="#ref-for-valdef-accent-color-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-appearance">
-   <b><a href="#propdef-appearance">#propdef-appearance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-appearance" class="dfn-panel" data-for="propdef-appearance" id="infopanel-for-propdef-appearance" role="dialog">
+   <span id="infopaneltitle-for-propdef-appearance" style="display:none">Info about the 'appearance' definition.</span><b><a href="#propdef-appearance">#propdef-appearance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-appearance">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-propdef-appearance①">(2)</a> <a href="#ref-for-propdef-appearance②">(3)</a> <a href="#ref-for-propdef-appearance③">(4)</a> <a href="#ref-for-propdef-appearance④">(5)</a>
     <li><a href="#ref-for-propdef-appearance⑤">7.2.1. 
@@ -5113,8 +5113,8 @@ Single-Line Text Input Controls</a>
     <li><a href="#ref-for-propdef-appearance①⑨">Appendix C. Considerations for Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="widget">
-   <b><a href="#widget">#widget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-widget" class="dfn-panel" data-for="widget" id="infopanel-for-widget" role="dialog">
+   <span id="infopaneltitle-for-widget" style="display:none">Info about the 'widget' definition.</span><b><a href="#widget">#widget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widget">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-widget①">(2)</a> <a href="#ref-for-widget②">(3)</a> <a href="#ref-for-widget③">(4)</a> <a href="#ref-for-widget④">(5)</a> <a href="#ref-for-widget⑤">(6)</a> <a href="#ref-for-widget⑥">(7)</a> <a href="#ref-for-widget⑦">(8)</a> <a href="#ref-for-widget⑧">(9)</a>
     <li><a href="#ref-for-widget⑨">7.2.1. 
@@ -5123,14 +5123,14 @@ Effects of appearance on Decorative Aspects of Elements</a> <a href="#ref-for-wi
 Effects of appearance on Semantic Aspects of Elements</a> <a href="#ref-for-widget①③">(2)</a> <a href="#ref-for-widget①④">(3)</a> <a href="#ref-for-widget①⑤">(4)</a> <a href="#ref-for-widget①⑥">(5)</a> <a href="#ref-for-widget①⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="native-appearance">
-   <b><a href="#native-appearance">#native-appearance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-native-appearance" class="dfn-panel" data-for="native-appearance" id="infopanel-for-native-appearance" role="dialog">
+   <span id="infopaneltitle-for-native-appearance" style="display:none">Info about the 'native appearance' definition.</span><b><a href="#native-appearance">#native-appearance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-native-appearance">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-native-appearance①">(2)</a> <a href="#ref-for-native-appearance②">(3)</a> <a href="#ref-for-native-appearance③">(4)</a> <a href="#ref-for-native-appearance④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-appearance-none">
-   <b><a href="#valdef-appearance-none">#valdef-appearance-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-appearance-none" class="dfn-panel" data-for="valdef-appearance-none" id="infopanel-for-valdef-appearance-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-appearance-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-appearance-none">#valdef-appearance-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-appearance-none">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-valdef-appearance-none①">(2)</a> <a href="#ref-for-valdef-appearance-none②">(3)</a>
     <li><a href="#ref-for-valdef-appearance-none③">7.2.1. 
@@ -5139,8 +5139,8 @@ Effects of appearance on Decorative Aspects of Elements</a> <a href="#ref-for-va
 Effects of appearance on Semantic Aspects of Elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-appearance-auto">
-   <b><a href="#valdef-appearance-auto">#valdef-appearance-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-appearance-auto" class="dfn-panel" data-for="valdef-appearance-auto" id="infopanel-for-valdef-appearance-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-appearance-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-appearance-auto">#valdef-appearance-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-appearance-auto">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-valdef-appearance-auto①">(2)</a> <a href="#ref-for-valdef-appearance-auto②">(3)</a> <a href="#ref-for-valdef-appearance-auto③">(4)</a> <a href="#ref-for-valdef-appearance-auto④">(5)</a> <a href="#ref-for-valdef-appearance-auto⑤">(6)</a> <a href="#ref-for-valdef-appearance-auto⑥">(7)</a>
     <li><a href="#ref-for-valdef-appearance-auto⑦">7.3. 
@@ -5149,20 +5149,20 @@ Control Specific Rules</a> <a href="#ref-for-valdef-appearance-auto⑧">(2)</a>
 Single-Line Text Input Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-appearance-textfield">
-   <b><a href="#valdef-appearance-textfield">#valdef-appearance-textfield</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-appearance-textfield" class="dfn-panel" data-for="valdef-appearance-textfield" id="infopanel-for-valdef-appearance-textfield" role="dialog">
+   <span id="infopaneltitle-for-valdef-appearance-textfield" style="display:none">Info about the 'textfield' definition.</span><b><a href="#valdef-appearance-textfield">#valdef-appearance-textfield</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-appearance-textfield">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-valdef-appearance-textfield①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-appearance-menulist-button">
-   <b><a href="#valdef-appearance-menulist-button">#valdef-appearance-menulist-button</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-appearance-menulist-button" class="dfn-panel" data-for="valdef-appearance-menulist-button" id="infopanel-for-valdef-appearance-menulist-button" role="dialog">
+   <span id="infopaneltitle-for-valdef-appearance-menulist-button" style="display:none">Info about the 'menulist-button' definition.</span><b><a href="#valdef-appearance-menulist-button">#valdef-appearance-menulist-button</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-appearance-menulist-button">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-valdef-appearance-menulist-button①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-appearance-compat-auto">
-   <b><a href="#typedef-appearance-compat-auto">#typedef-appearance-compat-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-appearance-compat-auto" class="dfn-panel" data-for="typedef-appearance-compat-auto" id="infopanel-for-typedef-appearance-compat-auto" role="dialog">
+   <span id="infopaneltitle-for-typedef-appearance-compat-auto" style="display:none">Info about the '&lt;compat-auto>' definition.</span><b><a href="#typedef-appearance-compat-auto">#typedef-appearance-compat-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-appearance-compat-auto">7.2. Switching appearance: the appearance property</a> <a href="#ref-for-typedef-appearance-compat-auto①">(2)</a> <a href="#ref-for-typedef-appearance-compat-auto②">(3)</a>
    </ul>
@@ -5184,59 +5184,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-3/Overview.html
@@ -3400,57 +3400,57 @@ color: <c- nf>attr</c-><c- p>(</c->color<c- p>);</c-> <c- c>/* 'color' doesn’t
    <li><a href="#vmin">vmin</a><span>, in § 5.1.2</span>
    <li><a href="#vw">vw</a><span>, in § 5.1.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timing-function">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timing-function" class="dfn-panel" data-for="term-for-propdef-animation-timing-function" id="infopanel-for-term-for-propdef-animation-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a> <a href="#ref-for-propdef-animation-timing-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">3.4. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-actual-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-actual-value" class="dfn-panel" data-for="term-for-actual-value" id="infopanel-for-term-for-actual-value" role="menu">
+   <span id="infopaneltitle-for-term-for-actual-value" style="display:none">Info about the 'actual value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">5. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">4. 
 Numeric Data Types</a>
@@ -3464,8 +3464,8 @@ Computed Value</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.1. 
 Component Value Types</a>
@@ -3473,15 +3473,15 @@ Component Value Types</a>
 CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-inherit②">(2)</a> <a href="#ref-for-valdef-all-inherit③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">3.1.1. 
 CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-initial①">(2)</a> <a href="#ref-for-valdef-all-initial②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">4. 
 Numeric Data Types</a>
@@ -3489,15 +3489,15 @@ Numeric Data Types</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-unset">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-unset" class="dfn-panel" data-for="term-for-valdef-all-unset" id="infopanel-for-term-for-valdef-all-unset" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-unset" style="display:none">Info about the 'unset' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">3.1.1. 
 CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-unset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4.4.1. 
 Compatible Units</a> <a href="#ref-for-used-value①">(2)</a>
@@ -3507,8 +3507,8 @@ Distance Units: the &lt;length> type</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">7.1. 
 Colors: the &lt;color> type</a> <a href="#ref-for-typedef-color①">(2)</a> <a href="#ref-for-typedef-color②">(3)</a>
@@ -3516,85 +3516,85 @@ Colors: the &lt;color> type</a> <a href="#ref-for-typedef-color①">(2)</a> <a h
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">8.1.2. 
 Type Checking</a> <a href="#ref-for-propdef-opacity①">(2)</a> <a href="#ref-for-propdef-opacity②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rgba">
-   <a href="https://drafts.csswg.org/css-color-4/#funcdef-rgba">https://drafts.csswg.org/css-color-4/#funcdef-rgba</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rgba" class="dfn-panel" data-for="term-for-funcdef-rgba" id="infopanel-for-term-for-funcdef-rgba" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rgba" style="display:none">Info about the 'rgba()' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#funcdef-rgba">https://drafts.csswg.org/css-color-4/#funcdef-rgba</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rgba">8. 
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-hsl">
-   <a href="https://drafts.csswg.org/css-color-5/#funcdef-hsl">https://drafts.csswg.org/css-color-5/#funcdef-hsl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-hsl" class="dfn-panel" data-for="term-for-funcdef-hsl" id="infopanel-for-term-for-funcdef-hsl" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-hsl" style="display:none">Info about the 'hsl()' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#funcdef-hsl">https://drafts.csswg.org/css-color-5/#funcdef-hsl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hsl">4.6. 
 Mixing Percentages and Dimensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-disc">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#disc">https://drafts.csswg.org/css-counter-styles-3/#disc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-disc" class="dfn-panel" data-for="term-for-disc" id="infopanel-for-term-for-disc" role="menu">
+   <span id="infopaneltitle-for-term-for-disc" style="display:none">Info about the 'disc' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#disc">https://drafts.csswg.org/css-counter-styles-3/#disc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disc">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">4.5. 
 Percentages: the &lt;percentage> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-in" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" style="display:none">Info about the 'ease-in' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-out" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" style="display:none">Info about the 'ease-out' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-out">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a> <a href="#ref-for-propdef-font①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">4.4.1. 
 Compatible Units</a>
@@ -3606,48 +3606,48 @@ Mathematical Expressions: calc()</a>
 Computed Value</a> <a href="#ref-for-propdef-font-size⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-fr">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-fr" class="dfn-panel" data-for="term-for-valdef-flex-fr" id="infopanel-for-term-for-valdef-flex-fr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-fr" style="display:none">Info about the 'fr' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-fr">4. 
 Numeric Data Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-resolution">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-resolution" class="dfn-panel" data-for="term-for-propdef-image-resolution" id="infopanel-for-term-for-propdef-image-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-resolution" style="display:none">Info about the 'image-resolution' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-resolution">6.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-propdef-image-resolution①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-linear-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-linear-gradient" class="dfn-panel" data-for="term-for-funcdef-linear-gradient" id="infopanel-for-term-for-funcdef-linear-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-linear-gradient" style="display:none">Info about the 'linear-gradient()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-linear-gradient">6.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">8.1.3. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">4.6. 
 Mixing Percentages and Dimensions</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a> <a href="#ref-for-propdef-width③">(4)</a> <a href="#ref-for-propdef-width④">(5)</a> <a href="#ref-for-propdef-width⑤">(6)</a> <a href="#ref-for-propdef-width⑥">(7)</a>
@@ -3659,8 +3659,8 @@ Range Checking</a> <a href="#ref-for-propdef-width①②">(2)</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension-token" class="dfn-panel" data-for="term-for-typedef-dimension-token" id="infopanel-for-term-for-typedef-dimension-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">2.5. 
 Component Values and White Space</a>
@@ -3672,22 +3672,22 @@ Type Checking</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-function-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-function-token" class="dfn-panel" data-for="term-for-typedef-function-token" id="infopanel-for-term-for-typedef-function-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">8. 
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-hash-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-hash-token" class="dfn-panel" data-for="term-for-typedef-hash-token" id="infopanel-for-term-for-typedef-hash-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-hash-token" style="display:none">Info about the '&lt;hash-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hash-token">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">3. 
 Textual Data Types</a>
@@ -3695,8 +3695,8 @@ Textual Data Types</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-number-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-number-token" class="dfn-panel" data-for="term-for-typedef-number-token" id="infopanel-for-term-for-typedef-number-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">4.2. 
 Integers: the &lt;integer> type</a>
@@ -3708,8 +3708,8 @@ Type Checking</a> <a href="#ref-for-typedef-number-token③">(2)</a>
 Attribute References: attr()</a> <a href="#ref-for-typedef-number-token⑤">(2)</a> <a href="#ref-for-typedef-number-token⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-percentage-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-percentage-token" class="dfn-panel" data-for="term-for-typedef-percentage-token" id="infopanel-for-term-for-typedef-percentage-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-percentage-token" style="display:none">Info about the '&lt;percentage-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-percentage-token">4.5. 
 Percentages: the &lt;percentage> type</a>
@@ -3717,22 +3717,22 @@ Percentages: the &lt;percentage> type</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-string-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-string-token" class="dfn-panel" data-for="term-for-typedef-string-token" id="infopanel-for-term-for-typedef-string-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-string-token" style="display:none">Info about the '&lt;string-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-string-token">3.3. 
 Quoted Strings: the &lt;string> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-url-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-url-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-url-token" class="dfn-panel" data-for="term-for-typedef-url-token" id="infopanel-for-term-for-typedef-url-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-url-token" style="display:none">Info about the '&lt;url-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-url-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-url-token">3.4. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-component-value" class="dfn-panel" data-for="term-for-component-value" id="infopanel-for-term-for-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-component-value" style="display:none">Info about the 'component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-value">2.4. 
 Combinator and Multiplier Patterns</a>
@@ -3740,177 +3740,177 @@ Combinator and Multiplier Patterns</a>
 Mixing Percentages and Dimensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-consume-a-url-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#consume-a-url-token">https://drafts.csswg.org/css-syntax-3/#consume-a-url-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-consume-a-url-token" class="dfn-panel" data-for="term-for-consume-a-url-token" id="infopanel-for-term-for-consume-a-url-token" role="menu">
+   <span id="infopaneltitle-for-term-for-consume-a-url-token" style="display:none">Info about the 'consume a url token' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#consume-a-url-token">https://drafts.csswg.org/css-syntax-3/#consume-a-url-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-url-token">3.4. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-center">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-center" class="dfn-panel" data-for="term-for-valdef-text-align-center" id="infopanel-for-term-for-valdef-text-align-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-tab-size">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-tab-size">https://drafts.csswg.org/css-text-4/#propdef-tab-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-tab-size" class="dfn-panel" data-for="term-for-propdef-tab-size" id="infopanel-for-term-for-propdef-tab-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-tab-size" style="display:none">Info about the 'tab-size' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-tab-size">https://drafts.csswg.org/css-text-4/#propdef-tab-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-tab-size">8.1.2. 
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-origin">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-origin" class="dfn-panel" data-for="term-for-propdef-transform-origin" id="infopanel-for-term-for-propdef-transform-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">7.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cursor-default">
-   <a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cursor-default" class="dfn-panel" data-for="term-for-valdef-cursor-default" id="infopanel-for-term-for-valdef-cursor-default" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cursor-default" style="display:none">Info about the 'default' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-color" class="dfn-panel" data-for="term-for-propdef-outline-color" id="infopanel-for-term-for-propdef-outline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-color" style="display:none">Info about the 'outline-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-angle">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-angle">https://drafts.csswg.org/css-values-5/#valdef-attr-angle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-angle" class="dfn-panel" data-for="term-for-valdef-attr-angle" id="infopanel-for-term-for-valdef-attr-angle" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-angle" style="display:none">Info about the 'angle' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-angle">https://drafts.csswg.org/css-values-5/#valdef-attr-angle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-angle">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-color">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-color">https://drafts.csswg.org/css-values-5/#valdef-attr-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-color" class="dfn-panel" data-for="term-for-valdef-attr-color" id="infopanel-for-term-for-valdef-attr-color" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-color">https://drafts.csswg.org/css-values-5/#valdef-attr-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-color">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-frequency">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-frequency">https://drafts.csswg.org/css-values-5/#valdef-attr-frequency</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-frequency" class="dfn-panel" data-for="term-for-valdef-attr-frequency" id="infopanel-for-term-for-valdef-attr-frequency" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-frequency" style="display:none">Info about the 'frequency' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-frequency">https://drafts.csswg.org/css-values-5/#valdef-attr-frequency</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-frequency">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-length">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-length">https://drafts.csswg.org/css-values-5/#valdef-attr-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-length" class="dfn-panel" data-for="term-for-valdef-attr-length" id="infopanel-for-term-for-valdef-attr-length" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-length" style="display:none">Info about the 'length' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-length">https://drafts.csswg.org/css-values-5/#valdef-attr-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-length">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-number">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-number">https://drafts.csswg.org/css-values-5/#valdef-attr-number</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-number" class="dfn-panel" data-for="term-for-valdef-attr-number" id="infopanel-for-term-for-valdef-attr-number" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-number" style="display:none">Info about the 'number' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-number">https://drafts.csswg.org/css-values-5/#valdef-attr-number</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-number">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-string">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-string">https://drafts.csswg.org/css-values-5/#valdef-attr-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-string" class="dfn-panel" data-for="term-for-valdef-attr-string" id="infopanel-for-term-for-valdef-attr-string" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-string" style="display:none">Info about the 'string' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-string">https://drafts.csswg.org/css-values-5/#valdef-attr-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-string">8.2. 
 Attribute References: attr()</a> <a href="#ref-for-valdef-attr-string①">(2)</a> <a href="#ref-for-valdef-attr-string②">(3)</a>
     <li><a href="#ref-for-valdef-attr-string③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-time">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-time">https://drafts.csswg.org/css-values-5/#valdef-attr-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-time" class="dfn-panel" data-for="term-for-valdef-attr-time" id="infopanel-for-term-for-valdef-attr-time" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-time" style="display:none">Info about the 'time' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-time">https://drafts.csswg.org/css-values-5/#valdef-attr-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-time">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-toggle">
-   <a href="https://drafts.csswg.org/css-values-5/#funcdef-toggle">https://drafts.csswg.org/css-values-5/#funcdef-toggle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-toggle" class="dfn-panel" data-for="term-for-funcdef-toggle" id="infopanel-for-term-for-funcdef-toggle" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-toggle" style="display:none">Info about the 'toggle()' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#funcdef-toggle">https://drafts.csswg.org/css-values-5/#funcdef-toggle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-toggle"> Changes</a> <a href="#ref-for-funcdef-toggle①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-attr-url">
-   <a href="https://drafts.csswg.org/css-values-5/#valdef-attr-url">https://drafts.csswg.org/css-values-5/#valdef-attr-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-attr-url" class="dfn-panel" data-for="term-for-valdef-attr-url" id="infopanel-for-term-for-valdef-attr-url" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-attr-url" style="display:none">Info about the 'url' external reference.</span><a href="https://drafts.csswg.org/css-values-5/#valdef-attr-url">https://drafts.csswg.org/css-values-5/#valdef-attr-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-url">8.2. 
 Attribute References: attr()</a>
     <li><a href="#ref-for-valdef-attr-url①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-upright" class="dfn-panel" data-for="term-for-valdef-text-orientation-upright" id="infopanel-for-term-for-valdef-text-orientation-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr" id="infopanel-for-term-for-valdef-writing-mode-vertical-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl" id="infopanel-for-term-for-valdef-writing-mode-vertical-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-border-width">
-   <a href="https://drafts.csswg.org/css2/#value-def-border-width">https://drafts.csswg.org/css2/#value-def-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-border-width" class="dfn-panel" data-for="term-for-value-def-border-width" id="infopanel-for-term-for-value-def-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-border-width" style="display:none">Info about the '&lt;border-width>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-border-width">https://drafts.csswg.org/css2/#value-def-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-border-width">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">3.1. 
 Pre-defined Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">5. 
 Distance Units: the &lt;length> type</a>
@@ -3918,22 +3918,22 @@ Distance Units: the &lt;length> type</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">7.3. 
 2D Positioning: the &lt;position> type</a> <a href="#ref-for-propdef-background-position①">(2)</a>
@@ -3942,15 +3942,15 @@ Computed Value</a> <a href="#ref-for-propdef-background-position③">(2)</a>
     <li><a href="#ref-for-propdef-background-position④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">2.1. 
 Component Value Types</a> <a href="#ref-for-propdef-border-width①">(2)</a> <a href="#ref-for-propdef-border-width②">(3)</a>
@@ -3958,8 +3958,8 @@ Component Value Types</a> <a href="#ref-for-propdef-border-width①">(2)</a> <a 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">2.6. 
 Property Value Examples</a>
@@ -3967,42 +3967,42 @@ Property Value Examples</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadow-inset">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#shadow-inset">https://drafts.csswg.org/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadow-inset" class="dfn-panel" data-for="term-for-shadow-inset" id="infopanel-for-term-for-shadow-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-shadow-inset" style="display:none">Info about the 'inset' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#shadow-inset">https://drafts.csswg.org/css-backgrounds-3/#shadow-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-inset">8.2. 
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">7.2. 
 Images: the &lt;image> type</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-object-position">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-object-position" class="dfn-panel" data-for="term-for-propdef-object-position" id="infopanel-for-term-for-propdef-object-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-object-position" style="display:none">Info about the 'object-position' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-object-position">https://drafts.csswg.org/css-images-3/#propdef-object-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-object-position"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-base-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-base-element" class="dfn-panel" data-for="term-for-the-base-element" id="infopanel-for-term-for-the-base-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-base-element" style="display:none">Info about the 'base' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-base-element">3.4.1.1. 
 Fragment URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-history-pushstate">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-history-pushstate" class="dfn-panel" data-for="term-for-dom-history-pushstate" id="infopanel-for-term-for-dom-history-pushstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-history-pushstate" style="display:none">Info about the 'pushState(data, unused, url)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-history-pushstate">3.4.1.1. 
 Fragment URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.1. 
 Pre-defined Keywords</a>
@@ -4016,30 +4016,30 @@ Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a>
 Frequency Units: the &lt;frequency> type and Hz, kHz units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3.3. 
 Quoted Strings: the &lt;string> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">5.1.1. 
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">5.1.2. 
 Viewport-percentage Lengths: the vw, vh, vmin, vmax units</a>
     <li><a href="#ref-for-paged-media①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x">
-   <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x" class="dfn-panel" data-for="term-for-x" id="infopanel-for-term-for-x" role="menu">
+   <span id="infopaneltitle-for-term-for-x" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x">8.1. 
 Mathematical Expressions: calc()</a>
@@ -4049,8 +4049,8 @@ Syntax</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-adjacent">
-   <a href="https://drafts.csswg.org/selectors-4/#selectordef-adjacent">https://drafts.csswg.org/selectors-4/#selectordef-adjacent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-adjacent" class="dfn-panel" data-for="term-for-selectordef-adjacent" id="infopanel-for-term-for-selectordef-adjacent" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-adjacent" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#selectordef-adjacent">https://drafts.csswg.org/selectors-4/#selectordef-adjacent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-adjacent">8.1. 
 Mathematical Expressions: calc()</a>
@@ -4358,35 +4358,35 @@ Type Checking</a>
    <dt id="biblio-rfc6694">[RFC6694]
    <dd>S. Moonesamy, Ed.. <a href="https://www.rfc-editor.org/rfc/rfc6694"><cite>The "about" URI Scheme</cite></a>. August 2012. Informational. URL: <a href="https://www.rfc-editor.org/rfc/rfc6694">https://www.rfc-editor.org/rfc/rfc6694</a>
   </dl>
-  <aside class="dfn-panel" data-for="css-value-definition-syntax">
-   <b><a href="#css-value-definition-syntax">#css-value-definition-syntax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-value-definition-syntax" class="dfn-panel" data-for="css-value-definition-syntax" id="infopanel-for-css-value-definition-syntax" role="dialog">
+   <span id="infopaneltitle-for-css-value-definition-syntax" style="display:none">Info about the 'value definition syntax' definition.</span><b><a href="#css-value-definition-syntax">#css-value-definition-syntax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-value-definition-syntax"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-comma">
-   <b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-comma" class="dfn-panel" data-for="comb-comma" id="infopanel-for-comb-comma" role="dialog">
+   <span id="infopaneltitle-for-comb-comma" style="display:none">Info about the 'Commas' definition.</span><b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">2.1. 
 Component Value Types</a> <a href="#ref-for-comb-comma①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-all">
-   <b><a href="#comb-all">#comb-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-all" class="dfn-panel" data-for="comb-all" id="infopanel-for-comb-all" role="dialog">
+   <span id="infopaneltitle-for-comb-all" style="display:none">Info about the '&amp;&amp;' definition.</span><b><a href="#comb-all">#comb-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">7.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-any">
-   <b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-any" class="dfn-panel" data-for="comb-any" id="infopanel-for-comb-any" role="dialog">
+   <span id="infopaneltitle-for-comb-any" style="display:none">Info about the '||' definition.</span><b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">7.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-one">
-   <b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-one" class="dfn-panel" data-for="comb-one" id="infopanel-for-comb-one" role="dialog">
+   <span id="infopaneltitle-for-comb-one" style="display:none">Info about the '|' definition.</span><b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.6. 
 Mixing Percentages and Dimensions</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a>
@@ -4396,8 +4396,8 @@ Mixing Percentages and Dimensions</a> <a href="#ref-for-comb-one①">(2)</a> <a 
 Syntax</a> <a href="#ref-for-comb-one①⑨">(2)</a> <a href="#ref-for-comb-one②⓪">(3)</a> <a href="#ref-for-comb-one②①">(4)</a> <a href="#ref-for-comb-one②②">(5)</a> <a href="#ref-for-comb-one②③">(6)</a> <a href="#ref-for-comb-one②④">(7)</a> <a href="#ref-for-comb-one②⑤">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-zero-plus">
-   <b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-zero-plus" class="dfn-panel" data-for="mult-zero-plus" id="infopanel-for-mult-zero-plus" role="dialog">
+   <span id="infopaneltitle-for-mult-zero-plus" style="display:none">Info about the '*' definition.</span><b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">3.4. 
 Resource Locators: the &lt;url> type</a>
@@ -4405,8 +4405,8 @@ Resource Locators: the &lt;url> type</a>
 Syntax</a> <a href="#ref-for-mult-zero-plus②">(2)</a> <a href="#ref-for-mult-zero-plus③">(3)</a> <a href="#ref-for-mult-zero-plus④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-opt">
-   <b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-opt" class="dfn-panel" data-for="mult-opt" id="infopanel-for-mult-opt" role="dialog">
+   <span id="infopaneltitle-for-mult-opt" style="display:none">Info about the '?' definition.</span><b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.1. 
 Component Value Types</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
@@ -4414,15 +4414,15 @@ Component Value Types</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-f
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-comma">
-   <b><a href="#mult-comma">#mult-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-comma" class="dfn-panel" data-for="mult-comma" id="infopanel-for-mult-comma" role="dialog">
+   <span id="infopaneltitle-for-mult-comma" style="display:none">Info about the '#' definition.</span><b><a href="#mult-comma">#mult-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-identifier">
-   <b><a href="#css-identifier">#css-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-identifier" class="dfn-panel" data-for="css-identifier" id="infopanel-for-css-identifier" role="dialog">
+   <span id="infopaneltitle-for-css-identifier" style="display:none">Info about the 'identifiers' definition.</span><b><a href="#css-identifier">#css-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-identifier">3. 
 Textual Data Types</a>
@@ -4435,8 +4435,8 @@ Numbers with Units: dimension values</a>
     <li><a href="#ref-for-css-identifier④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-ident">
-   <b><a href="#typedef-ident">#typedef-ident</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-ident" class="dfn-panel" data-for="typedef-ident" id="infopanel-for-typedef-ident" role="dialog">
+   <span id="infopaneltitle-for-typedef-ident" style="display:none">Info about the '&lt;ident>' definition.</span><b><a href="#typedef-ident">#typedef-ident</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3. 
 Textual Data Types</a>
@@ -4445,16 +4445,16 @@ URL Modifiers</a>
     <li><a href="#ref-for-typedef-ident②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-wide-keywords">
-   <b><a href="#css-wide-keywords">#css-wide-keywords</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-wide-keywords" class="dfn-panel" data-for="css-wide-keywords" id="infopanel-for-css-wide-keywords" role="dialog">
+   <span id="infopaneltitle-for-css-wide-keywords" style="display:none">Info about the 'CSS-wide keywords' definition.</span><b><a href="#css-wide-keywords">#css-wide-keywords</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">3.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
     <li><a href="#ref-for-css-wide-keywords①"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier-value">
-   <b><a href="#identifier-value">#identifier-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier-value" class="dfn-panel" data-for="identifier-value" id="infopanel-for-identifier-value" role="dialog">
+   <span id="infopaneltitle-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' definition.</span><b><a href="#identifier-value">#identifier-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.1. 
 Component Value Types</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a>
@@ -4465,8 +4465,8 @@ Author-defined Identifiers: the &lt;custom-ident> type</a> <a href="#ref-for-ide
     <li><a href="#ref-for-identifier-value①③"> Changes</a> <a href="#ref-for-identifier-value①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-value">
-   <b><a href="#string-value">#string-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-value" class="dfn-panel" data-for="string-value" id="infopanel-for-string-value" role="dialog">
+   <span id="infopaneltitle-for-string-value" style="display:none">Info about the '&lt;string>' definition.</span><b><a href="#string-value">#string-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3. 
 Textual Data Types</a>
@@ -4479,8 +4479,8 @@ Attribute References: attr()</a> <a href="#ref-for-string-value⑥">(2)</a>
     <li><a href="#ref-for-string-value⑦"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-url">
-   <b><a href="#funcdef-url">#funcdef-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-url" class="dfn-panel" data-for="funcdef-url" id="infopanel-for-funcdef-url" role="dialog">
+   <span id="infopaneltitle-for-funcdef-url" style="display:none">Info about the 'url()' definition.</span><b><a href="#funcdef-url">#funcdef-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">3.4. 
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-funcdef-url①">(2)</a> <a href="#ref-for-funcdef-url②">(3)</a>
@@ -4495,8 +4495,8 @@ Attribute References: attr()</a>
     <li><a href="#ref-for-funcdef-url①④"> Changes</a> <a href="#ref-for-funcdef-url①⑤">(2)</a> <a href="#ref-for-funcdef-url①⑥">(3)</a> <a href="#ref-for-funcdef-url①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-value">
-   <b><a href="#url-value">#url-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-value" class="dfn-panel" data-for="url-value" id="infopanel-for-url-value" role="dialog">
+   <span id="infopaneltitle-for-url-value" style="display:none">Info about the '&lt;url>' definition.</span><b><a href="#url-value">#url-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">3. 
 Textual Data Types</a>
@@ -4511,15 +4511,15 @@ Images: the &lt;image> type</a>
     <li><a href="#ref-for-url-value⑨"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-local-url-flag">
-   <b><a href="#url-local-url-flag">#url-local-url-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-local-url-flag" class="dfn-panel" data-for="url-local-url-flag" id="infopanel-for-url-local-url-flag" role="dialog">
+   <span id="infopaneltitle-for-url-local-url-flag" style="display:none">Info about the 'local url flag' definition.</span><b><a href="#url-local-url-flag">#url-local-url-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-local-url-flag">3.4.1.1. 
 Fragment URLs</a> <a href="#ref-for-url-local-url-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-url-modifier">
-   <b><a href="#typedef-url-modifier">#typedef-url-modifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-url-modifier" class="dfn-panel" data-for="typedef-url-modifier" id="infopanel-for-typedef-url-modifier" role="dialog">
+   <span id="infopaneltitle-for-typedef-url-modifier" style="display:none">Info about the '&lt;url-modifier>' definition.</span><b><a href="#typedef-url-modifier">#typedef-url-modifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-url-modifier">3.4. 
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-typedef-url-modifier①">(2)</a>
@@ -4527,23 +4527,23 @@ Resource Locators: the &lt;url> type</a> <a href="#ref-for-typedef-url-modifier�
 URL Modifiers</a> <a href="#ref-for-typedef-url-modifier③">(2)</a> <a href="#ref-for-typedef-url-modifier④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="numeric-data-types">
-   <b><a href="#numeric-data-types">#numeric-data-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-numeric-data-types" class="dfn-panel" data-for="numeric-data-types" id="infopanel-for-numeric-data-types" role="dialog">
+   <span id="infopaneltitle-for-numeric-data-types" style="display:none">Info about the 'numeric data types' definition.</span><b><a href="#numeric-data-types">#numeric-data-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-numeric-data-types">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-bracketed-range-notation">
-   <b><a href="#css-bracketed-range-notation">#css-bracketed-range-notation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-bracketed-range-notation" class="dfn-panel" data-for="css-bracketed-range-notation" id="infopanel-for-css-bracketed-range-notation" role="dialog">
+   <span id="infopaneltitle-for-css-bracketed-range-notation" style="display:none">Info about the 'CSS bracketed range notation' definition.</span><b><a href="#css-bracketed-range-notation">#css-bracketed-range-notation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-bracketed-range-notation">4.1. 
 Range Restrictions and Range Definition Notation</a> <a href="#ref-for-css-bracketed-range-notation①">(2)</a>
     <li><a href="#ref-for-css-bracketed-range-notation②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="integer-value">
-   <b><a href="#integer-value">#integer-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-integer-value" class="dfn-panel" data-for="integer-value" id="infopanel-for-integer-value" role="dialog">
+   <span id="infopaneltitle-for-integer-value" style="display:none">Info about the '&lt;integer>' definition.</span><b><a href="#integer-value">#integer-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">2.1. 
 Component Value Types</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a>
@@ -4561,15 +4561,15 @@ Type Checking</a> <a href="#ref-for-integer-value⑧">(2)</a> <a href="#ref-for-
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="integer">
-   <b><a href="#integer">#integer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-integer" class="dfn-panel" data-for="integer" id="infopanel-for-integer" role="dialog">
+   <span id="infopaneltitle-for-integer" style="display:none">Info about the 'integer' definition.</span><b><a href="#integer">#integer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer">4.3. 
 Real Numbers: the &lt;number> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="number-value">
-   <b><a href="#number-value">#number-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-number-value" class="dfn-panel" data-for="number-value" id="infopanel-for-number-value" role="dialog">
+   <span id="infopaneltitle-for-number-value" style="display:none">Info about the '&lt;number>' definition.</span><b><a href="#number-value">#number-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">4. 
 Numeric Data Types</a>
@@ -4590,8 +4590,8 @@ Attribute References: attr()</a>
     <li><a href="#ref-for-number-value②④"> Changes</a> <a href="#ref-for-number-value②⑤">(2)</a> <a href="#ref-for-number-value②⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="number">
-   <b><a href="#number">#number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-number" class="dfn-panel" data-for="number" id="infopanel-for-number" role="dialog">
+   <span id="infopaneltitle-for-number" style="display:none">Info about the 'number' definition.</span><b><a href="#number">#number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number">4.4. 
 Numbers with Units: dimension values</a>
@@ -4599,8 +4599,8 @@ Numbers with Units: dimension values</a>
 Percentages: the &lt;percentage> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dimension">
-   <b><a href="#dimension">#dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dimension" class="dfn-panel" data-for="dimension" id="infopanel-for-dimension" role="dialog">
+   <span id="infopaneltitle-for-dimension" style="display:none">Info about the 'dimension' definition.</span><b><a href="#dimension">#dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">4. 
 Numeric Data Types</a> <a href="#ref-for-dimension①">(2)</a>
@@ -4622,8 +4622,8 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-dimension">
-   <b><a href="#typedef-dimension">#typedef-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-dimension" class="dfn-panel" data-for="typedef-dimension" id="infopanel-for-typedef-dimension" role="dialog">
+   <span id="infopaneltitle-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' definition.</span><b><a href="#typedef-dimension">#typedef-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">4.4. 
 Numbers with Units: dimension values</a>
@@ -4635,8 +4635,8 @@ Syntax</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compatible-units">
-   <b><a href="#compatible-units">#compatible-units</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compatible-units" class="dfn-panel" data-for="compatible-units" id="infopanel-for-compatible-units" role="dialog">
+   <span id="infopaneltitle-for-compatible-units" style="display:none">Info about the 'compatible units' definition.</span><b><a href="#compatible-units">#compatible-units</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compatible-units">4.4.1. 
 Compatible Units</a> <a href="#ref-for-compatible-units①">(2)</a>
@@ -4655,8 +4655,8 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
     <li><a href="#ref-for-compatible-units⑧"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canonical-unit">
-   <b><a href="#canonical-unit">#canonical-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canonical-unit" class="dfn-panel" data-for="canonical-unit" id="infopanel-for-canonical-unit" role="dialog">
+   <span id="infopaneltitle-for-canonical-unit" style="display:none">Info about the 'canonical unit' definition.</span><b><a href="#canonical-unit">#canonical-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canonical-unit">4.4.1. 
 Compatible Units</a>
@@ -4673,8 +4673,8 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
     <li><a href="#ref-for-canonical-unit⑥"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percentage-value">
-   <b><a href="#percentage-value">#percentage-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percentage-value" class="dfn-panel" data-for="percentage-value" id="infopanel-for-percentage-value" role="dialog">
+   <span id="infopaneltitle-for-percentage-value" style="display:none">Info about the '&lt;percentage>' definition.</span><b><a href="#percentage-value">#percentage-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.1. 
 Component Value Types</a>
@@ -4695,16 +4695,16 @@ Type Checking</a> <a href="#ref-for-percentage-value②⓪">(2)</a> <a href="#re
     <li><a href="#ref-for-percentage-value②③"> Changes</a> <a href="#ref-for-percentage-value②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-length-percentage">
-   <b><a href="#typedef-length-percentage">#typedef-length-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-length-percentage" class="dfn-panel" data-for="typedef-length-percentage" id="infopanel-for-typedef-length-percentage" role="dialog">
+   <span id="infopaneltitle-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' definition.</span><b><a href="#typedef-length-percentage">#typedef-length-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">7.3. 
 2D Positioning: the &lt;position> type</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a> <a href="#ref-for-typedef-length-percentage③">(4)</a>
     <li><a href="#ref-for-typedef-length-percentage④"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="length-value">
-   <b><a href="#length-value">#length-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-length-value" class="dfn-panel" data-for="length-value" id="infopanel-for-length-value" role="dialog">
+   <span id="infopaneltitle-for-length-value" style="display:none">Info about the '&lt;length>' definition.</span><b><a href="#length-value">#length-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">1. 
 Introduction</a>
@@ -4731,22 +4731,22 @@ Attribute References: attr()</a>
     <li><a href="#ref-for-length-value②⓪"> Changes</a> <a href="#ref-for-length-value②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-length">
-   <b><a href="#relative-length">#relative-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-length" class="dfn-panel" data-for="relative-length" id="infopanel-for-relative-length" role="dialog">
+   <span id="infopaneltitle-for-relative-length" style="display:none">Info about the 'Relative length units' definition.</span><b><a href="#relative-length">#relative-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-length">5. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-relative-length">
-   <b><a href="#font-relative-length">#font-relative-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-relative-length" class="dfn-panel" data-for="font-relative-length" id="infopanel-for-font-relative-length" role="dialog">
+   <span id="infopaneltitle-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' definition.</span><b><a href="#font-relative-length">#font-relative-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">8.1.3. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="em">
-   <b><a href="#em">#em</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-em" class="dfn-panel" data-for="em" id="infopanel-for-em" role="dialog">
+   <span id="infopaneltitle-for-em" style="display:none">Info about the 'em unit' definition.</span><b><a href="#em">#em</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">4.4.1. 
 Compatible Units</a>
@@ -4756,8 +4756,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, ch, rem units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ex">
-   <b><a href="#ex">#ex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ex" class="dfn-panel" data-for="ex" id="infopanel-for-ex" role="dialog">
+   <span id="infopaneltitle-for-ex" style="display:none">Info about the 'ex unit' definition.</span><b><a href="#ex">#ex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">5.1. 
 Relative Lengths</a>
@@ -4766,8 +4766,8 @@ Font-relative Lengths: the em, ex, ch, rem units</a> <a href="#ref-for-ex②">(2
     <li><a href="#ref-for-ex③"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ch">
-   <b><a href="#ch">#ch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ch" class="dfn-panel" data-for="ch" id="infopanel-for-ch" role="dialog">
+   <span id="infopaneltitle-for-ch" style="display:none">Info about the 'ch unit' definition.</span><b><a href="#ch">#ch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">5.1. 
 Relative Lengths</a>
@@ -4775,8 +4775,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, ch, rem units</a> <a href="#ref-for-ch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="length-advance-measure">
-   <b><a href="#length-advance-measure">#length-advance-measure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-length-advance-measure" class="dfn-panel" data-for="length-advance-measure" id="infopanel-for-length-advance-measure" role="dialog">
+   <span id="infopaneltitle-for-length-advance-measure" style="display:none">Info about the 'advance measure' definition.</span><b><a href="#length-advance-measure">#length-advance-measure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-advance-measure">5.1. 
 Relative Lengths</a>
@@ -4784,8 +4784,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, ch, rem units</a> <a href="#ref-for-length-advance-measure②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rem">
-   <b><a href="#rem">#rem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rem" class="dfn-panel" data-for="rem" id="infopanel-for-rem" role="dialog">
+   <span id="infopaneltitle-for-rem" style="display:none">Info about the 'rem unit' definition.</span><b><a href="#rem">#rem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rem">5.1. 
 Relative Lengths</a>
@@ -4795,8 +4795,8 @@ Font-relative Lengths: the em, ex, ch, rem units</a> <a href="#ref-for-rem②">(
 Mathematical Expressions: calc()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vw">
-   <b><a href="#vw">#vw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vw" class="dfn-panel" data-for="vw" id="infopanel-for-vw" role="dialog">
+   <span id="infopaneltitle-for-vw" style="display:none">Info about the 'vw unit' definition.</span><b><a href="#vw">#vw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vw">5.1. 
 Relative Lengths</a>
@@ -4804,8 +4804,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vmin, vmax units</a> <a href="#ref-for-vw②">(2)</a> <a href="#ref-for-vw③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vh">
-   <b><a href="#vh">#vh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vh" class="dfn-panel" data-for="vh" id="infopanel-for-vh" role="dialog">
+   <span id="infopaneltitle-for-vh" style="display:none">Info about the 'vh unit' definition.</span><b><a href="#vh">#vh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vh">5.1. 
 Relative Lengths</a>
@@ -4813,8 +4813,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vmin, vmax units</a> <a href="#ref-for-vh②">(2)</a> <a href="#ref-for-vh③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vmin">
-   <b><a href="#vmin">#vmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vmin" class="dfn-panel" data-for="vmin" id="infopanel-for-vmin" role="dialog">
+   <span id="infopaneltitle-for-vmin" style="display:none">Info about the 'vmin unit' definition.</span><b><a href="#vmin">#vmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vmin">5.1. 
 Relative Lengths</a>
@@ -4822,8 +4822,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vmax">
-   <b><a href="#vmax">#vmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vmax" class="dfn-panel" data-for="vmax" id="infopanel-for-vmax" role="dialog">
+   <span id="infopaneltitle-for-vmax" style="display:none">Info about the 'vmax unit' definition.</span><b><a href="#vmax">#vmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vmax">5.1. 
 Relative Lengths</a>
@@ -4831,29 +4831,29 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-length">
-   <b><a href="#absolute-length">#absolute-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-length" class="dfn-panel" data-for="absolute-length" id="infopanel-for-absolute-length" role="dialog">
+   <span id="infopaneltitle-for-absolute-length" style="display:none">Info about the 'absolute length units' definition.</span><b><a href="#absolute-length">#absolute-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-length">5. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="physical-units">
-   <b><a href="#physical-units">#physical-units</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-physical-units" class="dfn-panel" data-for="physical-units" id="infopanel-for-physical-units" role="dialog">
+   <span id="infopaneltitle-for-physical-units" style="display:none">Info about the 'physical units' definition.</span><b><a href="#physical-units">#physical-units</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-units">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-physical-units①">(2)</a> <a href="#ref-for-physical-units②">(3)</a> <a href="#ref-for-physical-units③">(4)</a> <a href="#ref-for-physical-units④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visual-angle-unit">
-   <b><a href="#visual-angle-unit">#visual-angle-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visual-angle-unit" class="dfn-panel" data-for="visual-angle-unit" id="infopanel-for-visual-angle-unit" role="dialog">
+   <span id="infopaneltitle-for-visual-angle-unit" style="display:none">Info about the 'visual angle unit (pixel unit)' definition.</span><b><a href="#visual-angle-unit">#visual-angle-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visual-angle-unit">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-visual-angle-unit①">(2)</a> <a href="#ref-for-visual-angle-unit②">(3)</a> <a href="#ref-for-visual-angle-unit③">(4)</a> <a href="#ref-for-visual-angle-unit④">(5)</a> <a href="#ref-for-visual-angle-unit⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cm">
-   <b><a href="#cm">#cm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cm" class="dfn-panel" data-for="cm" id="infopanel-for-cm" role="dialog">
+   <span id="infopaneltitle-for-cm" style="display:none">Info about the 'cm' definition.</span><b><a href="#cm">#cm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-cm①">(2)</a>
@@ -4863,23 +4863,23 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mm">
-   <b><a href="#mm">#mm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mm" class="dfn-panel" data-for="mm" id="infopanel-for-mm" role="dialog">
+   <span id="infopaneltitle-for-mm" style="display:none">Info about the 'mm' definition.</span><b><a href="#mm">#mm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mm">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-mm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Q">
-   <b><a href="#Q">#Q</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Q" class="dfn-panel" data-for="Q" id="infopanel-for-Q" role="dialog">
+   <span id="infopaneltitle-for-Q" style="display:none">Info about the 'Q' definition.</span><b><a href="#Q">#Q</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Q">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-Q①">(2)</a>
     <li><a href="#ref-for-Q②"> Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in">
-   <b><a href="#in">#in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in" class="dfn-panel" data-for="in" id="infopanel-for-in" role="dialog">
+   <span id="infopaneltitle-for-in" style="display:none">Info about the 'in' definition.</span><b><a href="#in">#in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">4.4.1. 
 Compatible Units</a>
@@ -4889,22 +4889,22 @@ Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-in�
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-in④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pc">
-   <b><a href="#pc">#pc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pc" class="dfn-panel" data-for="pc" id="infopanel-for-pc" role="dialog">
+   <span id="infopaneltitle-for-pc" style="display:none">Info about the 'pc' definition.</span><b><a href="#pc">#pc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pc">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-pc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pt">
-   <b><a href="#pt">#pt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pt" class="dfn-panel" data-for="pt" id="infopanel-for-pt" role="dialog">
+   <span id="infopaneltitle-for-pt" style="display:none">Info about the 'pt' definition.</span><b><a href="#pt">#pt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pt">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-pt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="px">
-   <b><a href="#px">#px</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-px" class="dfn-panel" data-for="px" id="infopanel-for-px" role="dialog">
+   <span id="infopaneltitle-for-px" style="display:none">Info about the 'px' definition.</span><b><a href="#px">#px</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">4.4.1. 
 Compatible Units</a> <a href="#ref-for-px①">(2)</a>
@@ -4916,22 +4916,22 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href
 Attribute References: attr()</a> <a href="#ref-for-px①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchor-unit">
-   <b><a href="#anchor-unit">#anchor-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchor-unit" class="dfn-panel" data-for="anchor-unit" id="infopanel-for-anchor-unit" role="dialog">
+   <span id="infopaneltitle-for-anchor-unit" style="display:none">Info about the 'anchored' definition.</span><b><a href="#anchor-unit">#anchor-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-unit">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-anchor-unit①">(2)</a> <a href="#ref-for-anchor-unit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reference-pixel">
-   <b><a href="#reference-pixel">#reference-pixel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reference-pixel" class="dfn-panel" data-for="reference-pixel" id="infopanel-for-reference-pixel" role="dialog">
+   <span id="infopaneltitle-for-reference-pixel" style="display:none">Info about the 'reference pixel' definition.</span><b><a href="#reference-pixel">#reference-pixel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-pixel">5.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="angle-value">
-   <b><a href="#angle-value">#angle-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-angle-value" class="dfn-panel" data-for="angle-value" id="infopanel-for-angle-value" role="dialog">
+   <span id="infopaneltitle-for-angle-value" style="display:none">Info about the '&lt;angle>' definition.</span><b><a href="#angle-value">#angle-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">4. 
 Numeric Data Types</a>
@@ -4947,8 +4947,8 @@ Type Checking</a> <a href="#ref-for-angle-value①⓪">(2)</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deg">
-   <b><a href="#deg">#deg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deg" class="dfn-panel" data-for="deg" id="infopanel-for-deg" role="dialog">
+   <span id="infopaneltitle-for-deg" style="display:none">Info about the 'deg' definition.</span><b><a href="#deg">#deg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deg">6.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a> <a href="#ref-for-deg①">(2)</a>
@@ -4956,29 +4956,29 @@ Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a> <a href="#re
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grad">
-   <b><a href="#grad">#grad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grad" class="dfn-panel" data-for="grad" id="infopanel-for-grad" role="dialog">
+   <span id="infopaneltitle-for-grad" style="display:none">Info about the 'grad' definition.</span><b><a href="#grad">#grad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grad">6.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rad">
-   <b><a href="#rad">#rad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rad" class="dfn-panel" data-for="rad" id="infopanel-for-rad" role="dialog">
+   <span id="infopaneltitle-for-rad" style="display:none">Info about the 'rad' definition.</span><b><a href="#rad">#rad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rad">6.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="turn">
-   <b><a href="#turn">#turn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-turn" class="dfn-panel" data-for="turn" id="infopanel-for-turn" role="dialog">
+   <span id="infopaneltitle-for-turn" style="display:none">Info about the 'turn' definition.</span><b><a href="#turn">#turn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-turn">6.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="time-value">
-   <b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-time-value" class="dfn-panel" data-for="time-value" id="infopanel-for-time-value" role="dialog">
+   <span id="infopaneltitle-for-time-value" style="display:none">Info about the '&lt;time>' definition.</span><b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">4. 
 Numeric Data Types</a>
@@ -4996,22 +4996,22 @@ Type Checking</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="s">
-   <b><a href="#s">#s</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-s" class="dfn-panel" data-for="s" id="infopanel-for-s" role="dialog">
+   <span id="infopaneltitle-for-s" style="display:none">Info about the 's' definition.</span><b><a href="#s">#s</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-s">6.2. 
 Duration Units: the &lt;time> type and s, ms units</a> <a href="#ref-for-s①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ms">
-   <b><a href="#ms">#ms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ms" class="dfn-panel" data-for="ms" id="infopanel-for-ms" role="dialog">
+   <span id="infopaneltitle-for-ms" style="display:none">Info about the 'ms' definition.</span><b><a href="#ms">#ms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ms">6.2. 
 Duration Units: the &lt;time> type and s, ms units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frequency-value">
-   <b><a href="#frequency-value">#frequency-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frequency-value" class="dfn-panel" data-for="frequency-value" id="infopanel-for-frequency-value" role="dialog">
+   <span id="infopaneltitle-for-frequency-value" style="display:none">Info about the '&lt;frequency>' definition.</span><b><a href="#frequency-value">#frequency-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-value">4. 
 Numeric Data Types</a>
@@ -5029,22 +5029,22 @@ Type Checking</a>
 Attribute References: attr()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Hz">
-   <b><a href="#Hz">#Hz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Hz" class="dfn-panel" data-for="Hz" id="infopanel-for-Hz" role="dialog">
+   <span id="infopaneltitle-for-Hz" style="display:none">Info about the 'Hz' definition.</span><b><a href="#Hz">#Hz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Hz">6.3. 
 Frequency Units: the &lt;frequency> type and Hz, kHz units</a> <a href="#ref-for-Hz①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="kHz">
-   <b><a href="#kHz">#kHz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-kHz" class="dfn-panel" data-for="kHz" id="infopanel-for-kHz" role="dialog">
+   <span id="infopaneltitle-for-kHz" style="display:none">Info about the 'kHz' definition.</span><b><a href="#kHz">#kHz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kHz">6.3. 
 Frequency Units: the &lt;frequency> type and Hz, kHz units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolution-value">
-   <b><a href="#resolution-value">#resolution-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolution-value" class="dfn-panel" data-for="resolution-value" id="infopanel-for-resolution-value" role="dialog">
+   <span id="infopaneltitle-for-resolution-value" style="display:none">Info about the '&lt;resolution>' definition.</span><b><a href="#resolution-value">#resolution-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">4. 
 Numeric Data Types</a>
@@ -5054,37 +5054,37 @@ Numbers with Units: dimension values</a>
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-resolution-value③">(2)</a> <a href="#ref-for-resolution-value④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dpi">
-   <b><a href="#dpi">#dpi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dpi" class="dfn-panel" data-for="dpi" id="infopanel-for-dpi" role="dialog">
+   <span id="infopaneltitle-for-dpi" style="display:none">Info about the 'dpi' definition.</span><b><a href="#dpi">#dpi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dpi">6.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dpcm">
-   <b><a href="#dpcm">#dpcm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dpcm" class="dfn-panel" data-for="dpcm" id="infopanel-for-dpcm" role="dialog">
+   <span id="infopaneltitle-for-dpcm" style="display:none">Info about the 'dpcm' definition.</span><b><a href="#dpcm">#dpcm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dpcm">6.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dppx">
-   <b><a href="#dppx">#dppx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dppx" class="dfn-panel" data-for="dppx" id="infopanel-for-dppx" role="dialog">
+   <span id="infopaneltitle-for-dppx" style="display:none">Info about the 'dppx' definition.</span><b><a href="#dppx">#dppx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dppx">6.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-dppx①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-position">
-   <b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-position" class="dfn-panel" data-for="typedef-position" id="infopanel-for-typedef-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-position" style="display:none">Info about the '&lt;position>' definition.</span><b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">7.3. 
 2D Positioning: the &lt;position> type</a> <a href="#ref-for-typedef-position①">(2)</a> <a href="#ref-for-typedef-position②">(3)</a> <a href="#ref-for-typedef-position③">(4)</a> <a href="#ref-for-typedef-position④">(5)</a> <a href="#ref-for-typedef-position⑤">(6)</a> <a href="#ref-for-typedef-position⑥">(7)</a>
     <li><a href="#ref-for-typedef-position⑦"> Changes</a> <a href="#ref-for-typedef-position⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="functional-notation">
-   <b><a href="#functional-notation">#functional-notation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-functional-notation" class="dfn-panel" data-for="functional-notation" id="infopanel-for-functional-notation" role="dialog">
+   <span id="infopaneltitle-for-functional-notation" style="display:none">Info about the 'functional notation' definition.</span><b><a href="#functional-notation">#functional-notation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-notation">3.4. 
 Resource Locators: the &lt;url> type</a>
@@ -5094,8 +5094,8 @@ URL Modifiers</a>
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-calc">
-   <b><a href="#funcdef-calc">#funcdef-calc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-calc" class="dfn-panel" data-for="funcdef-calc" id="infopanel-for-funcdef-calc" role="dialog">
+   <span id="infopaneltitle-for-funcdef-calc" style="display:none">Info about the 'calc()' definition.</span><b><a href="#funcdef-calc">#funcdef-calc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">4.6. 
 Mixing Percentages and Dimensions</a> <a href="#ref-for-funcdef-calc①">(2)</a> <a href="#ref-for-funcdef-calc②">(3)</a>
@@ -5114,57 +5114,57 @@ Serialization</a>
     <li><a href="#ref-for-funcdef-calc②⑤"> Changes</a> <a href="#ref-for-funcdef-calc②⑥">(2)</a> <a href="#ref-for-funcdef-calc②⑦">(3)</a> <a href="#ref-for-funcdef-calc②⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-sum">
-   <b><a href="#typedef-calc-sum">#typedef-calc-sum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-sum" class="dfn-panel" data-for="typedef-calc-sum" id="infopanel-for-typedef-calc-sum" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-sum" style="display:none">Info about the '&lt;calc-sum>' definition.</span><b><a href="#typedef-calc-sum">#typedef-calc-sum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-sum">8.1.1. 
 Syntax</a> <a href="#ref-for-typedef-calc-sum①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-product">
-   <b><a href="#typedef-calc-product">#typedef-calc-product</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-product" class="dfn-panel" data-for="typedef-calc-product" id="infopanel-for-typedef-calc-product" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-product" style="display:none">Info about the '&lt;calc-product>' definition.</span><b><a href="#typedef-calc-product">#typedef-calc-product</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-product">8.1.1. 
 Syntax</a> <a href="#ref-for-typedef-calc-product①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-value">
-   <b><a href="#typedef-calc-value">#typedef-calc-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-value" class="dfn-panel" data-for="typedef-calc-value" id="infopanel-for-typedef-calc-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-value" style="display:none">Info about the '&lt;calc-value>' definition.</span><b><a href="#typedef-calc-value">#typedef-calc-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-value">8.1.1. 
 Syntax</a> <a href="#ref-for-typedef-calc-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-number-sum">
-   <b><a href="#typedef-calc-number-sum">#typedef-calc-number-sum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-number-sum" class="dfn-panel" data-for="typedef-calc-number-sum" id="infopanel-for-typedef-calc-number-sum" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-number-sum" style="display:none">Info about the '&lt;calc-number-sum>' definition.</span><b><a href="#typedef-calc-number-sum">#typedef-calc-number-sum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-number-sum">8.1.1. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-number-product">
-   <b><a href="#typedef-calc-number-product">#typedef-calc-number-product</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-number-product" class="dfn-panel" data-for="typedef-calc-number-product" id="infopanel-for-typedef-calc-number-product" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-number-product" style="display:none">Info about the '&lt;calc-number-product>' definition.</span><b><a href="#typedef-calc-number-product">#typedef-calc-number-product</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-number-product">8.1.1. 
 Syntax</a> <a href="#ref-for-typedef-calc-number-product①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-number-value">
-   <b><a href="#typedef-calc-number-value">#typedef-calc-number-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-number-value" class="dfn-panel" data-for="typedef-calc-number-value" id="infopanel-for-typedef-calc-number-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-number-value" style="display:none">Info about the '&lt;calc-number-value>' definition.</span><b><a href="#typedef-calc-number-value">#typedef-calc-number-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-number-value">8.1.1. 
 Syntax</a> <a href="#ref-for-typedef-calc-number-value①">(2)</a> <a href="#ref-for-typedef-calc-number-value②">(3)</a> <a href="#ref-for-typedef-calc-number-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolved-type">
-   <b><a href="#resolved-type">#resolved-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolved-type" class="dfn-panel" data-for="resolved-type" id="infopanel-for-resolved-type" role="dialog">
+   <span id="infopaneltitle-for-resolved-type" style="display:none">Info about the 'resolved type' definition.</span><b><a href="#resolved-type">#resolved-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-type">8.1.2. 
 Type Checking</a> <a href="#ref-for-resolved-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-attr">
-   <b><a href="#funcdef-attr">#funcdef-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-attr" class="dfn-panel" data-for="funcdef-attr" id="infopanel-for-funcdef-attr" role="dialog">
+   <span id="infopaneltitle-for-funcdef-attr" style="display:none">Info about the 'attr()' definition.</span><b><a href="#funcdef-attr">#funcdef-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-attr①">8.1. 
 Mathematical Expressions: calc()</a>
@@ -5175,15 +5175,15 @@ Attribute References: attr()</a> <a href="#ref-for-funcdef-attr④">(2)</a> <a h
     <li><a href="#ref-for-funcdef-attr①②"> Changes</a> <a href="#ref-for-funcdef-attr①③">(2)</a> <a href="#ref-for-funcdef-attr①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attr-name">
-   <b><a href="#typedef-attr-name">#typedef-attr-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attr-name" class="dfn-panel" data-for="typedef-attr-name" id="infopanel-for-typedef-attr-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-attr-name" style="display:none">Info about the '&lt;attr-name>' definition.</span><b><a href="#typedef-attr-name">#typedef-attr-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attr-name">8.2. 
 Attribute References: attr()</a> <a href="#ref-for-typedef-attr-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-type-or-unit">
-   <b><a href="#typedef-type-or-unit">#typedef-type-or-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-type-or-unit" class="dfn-panel" data-for="typedef-type-or-unit" id="infopanel-for-typedef-type-or-unit" role="dialog">
+   <span id="infopaneltitle-for-typedef-type-or-unit" style="display:none">Info about the '&lt;type-or-unit>' definition.</span><b><a href="#typedef-type-or-unit">#typedef-type-or-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-type-or-unit">8.1.2. 
 Type Checking</a>
@@ -5191,8 +5191,8 @@ Type Checking</a>
 Attribute References: attr()</a> <a href="#ref-for-typedef-type-or-unit②">(2)</a> <a href="#ref-for-typedef-type-or-unit③">(3)</a> <a href="#ref-for-typedef-type-or-unit④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attr-fallback">
-   <b><a href="#typedef-attr-fallback">#typedef-attr-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attr-fallback" class="dfn-panel" data-for="typedef-attr-fallback" id="infopanel-for-typedef-attr-fallback" role="dialog">
+   <span id="infopaneltitle-for-typedef-attr-fallback" style="display:none">Info about the '&lt;attr-fallback>' definition.</span><b><a href="#typedef-attr-fallback">#typedef-attr-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attr-fallback">8.2. 
 Attribute References: attr()</a> <a href="#ref-for-typedef-attr-fallback①">(2)</a> <a href="#ref-for-typedef-attr-fallback②">(3)</a> <a href="#ref-for-typedef-attr-fallback③">(4)</a>
@@ -5200,59 +5200,115 @@ Attribute References: attr()</a> <a href="#ref-for-typedef-attr-fallback①">(2)
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-values-4/Overview.html
@@ -5574,22 +5574,22 @@ append them to <var>ret</var> in the same order.</p>
    <li><a href="#x">x</a><span>, in § 7.4</span>
    <li><a href="#zero-value">&lt;zero></a><span>, in § 5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-iteration-count">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-iteration-count" class="dfn-panel" data-for="term-for-propdef-animation-iteration-count" id="infopanel-for-term-for-propdef-animation-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-iteration-count" style="display:none">Info about the 'animation-iteration-count' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-iteration-count">11.12. 
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
@@ -5597,43 +5597,43 @@ Author-defined Identifiers: the &lt;custom-ident> type</a>
 Numeric Constants: e, pi</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timing-function">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timing-function" class="dfn-panel" data-for="term-for-propdef-animation-timing-function" id="infopanel-for-term-for-propdef-animation-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a> <a href="#ref-for-propdef-animation-timing-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-orphans">
-   <a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-orphans" class="dfn-panel" data-for="term-for-propdef-orphans" id="infopanel-for-term-for-propdef-orphans" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-orphans" style="display:none">Info about the 'orphans' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#propdef-orphans">https://drafts.csswg.org/css-break-3/#propdef-orphans</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">4.5. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-actual-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-actual-value" class="dfn-panel" data-for="term-for-actual-value" id="infopanel-for-term-for-actual-value" role="menu">
+   <span id="infopaneltitle-for-term-for-actual-value" style="display:none">Info about the 'actual value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">6. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
@@ -5653,8 +5653,8 @@ Range Checking</a> <a href="#ref-for-computed-value①①">(2)</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.1. 
 Component Value Types</a>
@@ -5664,36 +5664,36 @@ CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-i
 Toggling Between Values: toggle()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inherited-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inherited-value" class="dfn-panel" data-for="term-for-inherited-value" id="infopanel-for-term-for-inherited-value" role="menu">
+   <span id="infopaneltitle-for-term-for-inherited-value" style="display:none">Info about the 'inherited value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#inherited-value">https://drafts.csswg.org/css-cascade-5/#inherited-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-value">9.1. 
 Toggling Between Values: toggle()</a> <a href="#ref-for-inherited-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">4.1.1. 
 CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-initial①">(2)</a> <a href="#ref-for-valdef-all-initial②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">9.1. 
 Toggling Between Values: toggle()</a> <a href="#ref-for-shorthand-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property①" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property①" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">9.1. 
 Toggling Between Values: toggle()</a> <a href="#ref-for-shorthand-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-specified-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-specified-value" class="dfn-panel" data-for="term-for-specified-value" id="infopanel-for-term-for-specified-value" role="menu">
+   <span id="infopaneltitle-for-term-for-specified-value" style="display:none">Info about the 'specified value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#specified-value">https://drafts.csswg.org/css-cascade-5/#specified-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">4. 
 Textual Data Types</a>
@@ -5703,15 +5703,15 @@ Numeric Data Types</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-unset">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-unset" class="dfn-panel" data-for="term-for-valdef-all-unset" id="infopanel-for-term-for-valdef-all-unset" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-unset" style="display:none">Info about the 'unset' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">4.1.1. 
 CSS-wide keywords: initial, inherit and unset</a> <a href="#ref-for-valdef-all-unset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">5.4.1. 
 Compatible Units</a> <a href="#ref-for-used-value①">(2)</a>
@@ -5725,8 +5725,8 @@ Computed Value</a> <a href="#ref-for-used-value⑤">(2)</a>
 Range Checking</a> <a href="#ref-for-used-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">8.1. 
 Colors: the &lt;color> type</a> <a href="#ref-for-typedef-color①">(2)</a> <a href="#ref-for-typedef-color②">(3)</a>
@@ -5736,92 +5736,92 @@ Combination of &lt;color></a> <a href="#ref-for-typedef-color④">(2)</a> <a hre
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-hex-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-hex-color">https://drafts.csswg.org/css-color-4/#typedef-hex-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-hex-color" class="dfn-panel" data-for="term-for-typedef-hex-color" id="infopanel-for-term-for-typedef-hex-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-hex-color" style="display:none">Info about the '&lt;hex-color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-hex-color">https://drafts.csswg.org/css-color-4/#typedef-hex-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hex-color">10.1. 
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">8.1.1. 
 Combination of &lt;color></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-named-color">
-   <a href="https://drafts.csswg.org/css-color-4/#named-color">https://drafts.csswg.org/css-color-4/#named-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-named-color" class="dfn-panel" data-for="term-for-named-color" id="infopanel-for-term-for-named-color" role="menu">
+   <span id="infopaneltitle-for-term-for-named-color" style="display:none">Info about the 'named color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#named-color">https://drafts.csswg.org/css-color-4/#named-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-named-color">10.1. 
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">11.9. 
 Type Checking</a> <a href="#ref-for-propdef-opacity①">(2)</a> <a href="#ref-for-propdef-opacity②">(3)</a> <a href="#ref-for-propdef-opacity③">(4)</a> <a href="#ref-for-propdef-opacity④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-rgba">
-   <a href="https://drafts.csswg.org/css-color-4/#funcdef-rgba">https://drafts.csswg.org/css-color-4/#funcdef-rgba</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-rgba" class="dfn-panel" data-for="term-for-funcdef-rgba" id="infopanel-for-term-for-funcdef-rgba" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-rgba" style="display:none">Info about the 'rgba()' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#funcdef-rgba">https://drafts.csswg.org/css-color-4/#funcdef-rgba</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rgba">9. 
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-profile">
-   <a href="https://drafts.csswg.org/css-color-5/#at-ruledef-profile">https://drafts.csswg.org/css-color-5/#at-ruledef-profile</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-profile" class="dfn-panel" data-for="term-for-at-ruledef-profile" id="infopanel-for-term-for-at-ruledef-profile" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-profile" style="display:none">Info about the '@color-profile' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#at-ruledef-profile">https://drafts.csswg.org/css-color-5/#at-ruledef-profile</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-profile">4.3. 
 Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-hsl">
-   <a href="https://drafts.csswg.org/css-color-5/#funcdef-hsl">https://drafts.csswg.org/css-color-5/#funcdef-hsl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-hsl" class="dfn-panel" data-for="term-for-funcdef-hsl" id="infopanel-for-term-for-funcdef-hsl" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-hsl" style="display:none">Info about the 'hsl()' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#funcdef-hsl">https://drafts.csswg.org/css-color-5/#funcdef-hsl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hsl">5.6. 
 Mixing Percentages and Dimensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-disc">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#disc">https://drafts.csswg.org/css-counter-styles-3/#disc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-disc" class="dfn-panel" data-for="term-for-disc" id="infopanel-for-term-for-disc" role="menu">
+   <span id="infopaneltitle-for-term-for-disc" style="display:none">Info about the 'disc' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#disc">https://drafts.csswg.org/css-counter-styles-3/#disc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disc">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">5.5. 
 Percentages: the &lt;percentage> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-in" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-in" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-in" style="display:none">Info about the 'ease-in' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-in">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out">
-   <a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" class="dfn-panel" data-for="term-for-valdef-cubic-bezier-easing-function-ease-out" id="infopanel-for-term-for-valdef-cubic-bezier-easing-function-ease-out" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cubic-bezier-easing-function-ease-out" style="display:none">Info about the 'ease-out' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out">https://drafts.csswg.org/css-easing-2/#valdef-cubic-bezier-easing-function-ease-out</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cubic-bezier-easing-function-ease-out">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function" style="display:none">Info about the 'easing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a>
@@ -5829,8 +5829,8 @@ Combining Values: Interpolation, Addition, and Accumulation</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function①" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function①" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a>
@@ -5838,22 +5838,22 @@ Combining Values: Interpolation, Addition, and Accumulation</a>
 Range Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-propdef-font①">(2)</a> <a href="#ref-for-propdef-font②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">5.4.1. 
 Compatible Units</a>
@@ -5867,15 +5867,15 @@ Comparison Functions: min(), max(), and clamp()</a>
 Computed Value</a> <a href="#ref-for-propdef-font-size⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-font-face-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-5/#descdef-font-face-font-size">https://drafts.csswg.org/css-fonts-5/#descdef-font-face-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-font-face-font-size" class="dfn-panel" data-for="term-for-descdef-font-face-font-size" id="infopanel-for-term-for-descdef-font-face-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-font-face-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#descdef-font-face-font-size">https://drafts.csswg.org/css-fonts-5/#descdef-font-face-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-font-face-font-size">11.1. 
 Basic Arithmetic: calc()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-flex">
-   <a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-flex" class="dfn-panel" data-for="term-for-typedef-flex" id="infopanel-for-term-for-typedef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-flex" style="display:none">Info about the '&lt;flex>' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#typedef-flex">https://drafts.csswg.org/css-grid-2/#typedef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-flex">10. 
 Attribute References: the attr() function</a>
@@ -5885,92 +5885,92 @@ Mathematical Expressions</a>
 Type Checking</a> <a href="#ref-for-typedef-flex③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-flex-fr">
-   <a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-flex-fr" class="dfn-panel" data-for="term-for-valdef-flex-fr" id="infopanel-for-term-for-valdef-flex-fr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-flex-fr" style="display:none">Info about the 'fr' external reference.</span><a href="https://drafts.csswg.org/css-grid-2/#valdef-flex-fr">https://drafts.csswg.org/css-grid-2/#valdef-flex-fr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-flex-fr">5. 
 Numeric Data Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-resolution">
-   <a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-resolution" class="dfn-panel" data-for="term-for-propdef-image-resolution" id="infopanel-for-term-for-propdef-image-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-resolution" style="display:none">Info about the 'image-resolution' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#propdef-image-resolution">https://drafts.csswg.org/css-images-4/#propdef-image-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-resolution">7.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-propdef-image-resolution①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-linear-gradient">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-linear-gradient" class="dfn-panel" data-for="term-for-funcdef-linear-gradient" id="infopanel-for-term-for-funcdef-linear-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-linear-gradient" style="display:none">Info about the 'linear-gradient()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient">https://drafts.csswg.org/css-images-4/#funcdef-linear-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-linear-gradient">7.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-line-height-normal">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-line-height-normal">https://drafts.csswg.org/css-inline-3/#valdef-line-height-normal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-line-height-normal" class="dfn-panel" data-for="term-for-valdef-line-height-normal" id="infopanel-for-term-for-valdef-line-height-normal" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-line-height-normal" style="display:none">Info about the 'normal' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-line-height-normal">https://drafts.csswg.org/css-inline-3/#valdef-line-height-normal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-height-normal">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-valdef-line-height-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">6.1.2. 
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">6.1.2. 
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-lines">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-max-lines">https://drafts.csswg.org/css-overflow-4/#propdef-max-lines</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-lines" class="dfn-panel" data-for="term-for-propdef-max-lines" id="infopanel-for-term-for-propdef-max-lines" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-lines" style="display:none">Info about the 'max-lines' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-max-lines">https://drafts.csswg.org/css-overflow-4/#propdef-max-lines</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-lines">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-step-size">
-   <a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-step-size" class="dfn-panel" data-for="term-for-propdef-block-step-size" id="infopanel-for-term-for-propdef-block-step-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-step-size" style="display:none">Info about the 'block-step-size' external reference.</span><a href="https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size">https://drafts.csswg.org/css-rhythm-1/#propdef-block-step-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-step-size">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-propdef-block-step-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">11.11. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">11.1. 
 Basic Arithmetic: calc()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-min-width">https://drafts.csswg.org/css-sizing-3/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">11.2. 
 Comparison Functions: min(), max(), and clamp()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">5.6. 
 Mixing Percentages and Dimensions</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a> <a href="#ref-for-propdef-width③">(4)</a> <a href="#ref-for-propdef-width④">(5)</a> <a href="#ref-for-propdef-width⑤">(6)</a> <a href="#ref-for-propdef-width⑥">(7)</a>
@@ -5984,15 +5984,15 @@ Type Checking</a> <a href="#ref-for-propdef-width①⓪">(2)</a> <a href="#ref-f
 Range Checking</a> <a href="#ref-for-propdef-width①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">10. 
 Attribute References: the attr() function</a> <a href="#ref-for-typedef-declaration-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-delim-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-delim-token" class="dfn-panel" data-for="term-for-typedef-delim-token" id="infopanel-for-term-for-typedef-delim-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-delim-token" style="display:none">Info about the '&lt;delim-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-delim-token">10. 
 Attribute References: the attr() function</a>
@@ -6000,8 +6000,8 @@ Attribute References: the attr() function</a>
 Internal Representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension-token" class="dfn-panel" data-for="term-for-typedef-dimension-token" id="infopanel-for-term-for-typedef-dimension-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">2.5. 
 Component Values and White Space</a>
@@ -6011,22 +6011,22 @@ Numbers with Units: dimension values</a>
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-function-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-function-token" class="dfn-panel" data-for="term-for-typedef-function-token" id="infopanel-for-term-for-typedef-function-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">9. 
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">4. 
 Textual Data Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-number-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-number-token" class="dfn-panel" data-for="term-for-typedef-number-token" id="infopanel-for-term-for-typedef-number-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">5.2. 
 Integers: the &lt;integer> type</a>
@@ -6038,8 +6038,8 @@ attr() Types</a> <a href="#ref-for-typedef-number-token④">(2)</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-percentage-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-percentage-token" class="dfn-panel" data-for="term-for-typedef-percentage-token" id="infopanel-for-term-for-typedef-percentage-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-percentage-token" style="display:none">Info about the '&lt;percentage-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token">https://drafts.csswg.org/css-syntax-3/#typedef-percentage-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-percentage-token">5.5. 
 Percentages: the &lt;percentage> type</a>
@@ -6047,29 +6047,29 @@ Percentages: the &lt;percentage> type</a>
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-string-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-string-token" class="dfn-panel" data-for="term-for-typedef-string-token" id="infopanel-for-term-for-typedef-string-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-string-token" style="display:none">Info about the '&lt;string-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-string-token">4.4. 
 Quoted Strings: the &lt;string> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-url-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-url-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-url-token" class="dfn-panel" data-for="term-for-typedef-url-token" id="infopanel-for-term-for-typedef-url-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-url-token" style="display:none">Info about the '&lt;url-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-url-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-url-token">4.5. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-whitespace-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token">https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-whitespace-token" class="dfn-panel" data-for="term-for-typedef-whitespace-token" id="infopanel-for-term-for-typedef-whitespace-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-whitespace-token" style="display:none">Info about the '&lt;whitespace-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token">https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-whitespace-token">11.10. 
 Internal Representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-component-value" class="dfn-panel" data-for="term-for-component-value" id="infopanel-for-term-for-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-component-value" style="display:none">Info about the 'component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-value">2.4. 
 Combinator and Multiplier Patterns</a>
@@ -6079,85 +6079,85 @@ Mixing Percentages and Dimensions</a>
 Internal Representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-consume-a-url-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#consume-a-url-token">https://drafts.csswg.org/css-syntax-3/#consume-a-url-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-consume-a-url-token" class="dfn-panel" data-for="term-for-consume-a-url-token" id="infopanel-for-term-for-consume-a-url-token" role="menu">
+   <span id="infopaneltitle-for-term-for-consume-a-url-token" style="display:none">Info about the 'consume a url token' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#consume-a-url-token">https://drafts.csswg.org/css-syntax-3/#consume-a-url-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-a-url-token">4.5. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-component-value">https://drafts.csswg.org/css-syntax-3/#parse-a-component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-component-value" class="dfn-panel" data-for="term-for-parse-a-component-value" id="infopanel-for-term-for-parse-a-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-component-value" style="display:none">Info about the 'parse a component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-component-value">https://drafts.csswg.org/css-syntax-3/#parse-a-component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-component-value">10.1. 
 attr() Types</a> <a href="#ref-for-parse-a-component-value①">(2)</a> <a href="#ref-for-parse-a-component-value②">(3)</a> <a href="#ref-for-parse-a-component-value③">(4)</a> <a href="#ref-for-parse-a-component-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-simple-block">
-   <a href="https://drafts.csswg.org/css-syntax-3/#simple-block">https://drafts.csswg.org/css-syntax-3/#simple-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-simple-block" class="dfn-panel" data-for="term-for-simple-block" id="infopanel-for-term-for-simple-block" role="menu">
+   <span id="infopaneltitle-for-term-for-simple-block" style="display:none">Info about the 'simple block' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#simple-block">https://drafts.csswg.org/css-syntax-3/#simple-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-block">11.10. 
 Internal Representation</a> <a href="#ref-for-simple-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-whitespace">
-   <a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-whitespace" class="dfn-panel" data-for="term-for-whitespace" id="infopanel-for-term-for-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-whitespace" style="display:none">Info about the 'whitespace' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#whitespace">https://drafts.csswg.org/css-syntax-3/#whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">11.8. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-center">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-center" class="dfn-panel" data-for="term-for-valdef-text-align-center" id="infopanel-for-term-for-valdef-text-align-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-tab-size">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-tab-size">https://drafts.csswg.org/css-text-4/#propdef-tab-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-tab-size" class="dfn-panel" data-for="term-for-propdef-tab-size" id="infopanel-for-term-for-propdef-tab-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-tab-size" style="display:none">Info about the 'tab-size' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-tab-size">https://drafts.csswg.org/css-text-4/#propdef-tab-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-tab-size">11.9. 
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-emphasis-color">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-emphasis-color" class="dfn-panel" data-for="term-for-propdef-text-emphasis-color" id="infopanel-for-term-for-propdef-text-emphasis-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-emphasis-color" style="display:none">Info about the 'text-emphasis-color' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-emphasis-color">8.1.1. 
 Combination of &lt;color></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-origin">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-origin" class="dfn-panel" data-for="term-for-propdef-transform-origin" id="infopanel-for-term-for-propdef-transform-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">8.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-add-two-types">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-add-two-types" class="dfn-panel" data-for="term-for-cssnumericvalue-add-two-types" id="infopanel-for-term-for-cssnumericvalue-add-two-types" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-add-two-types" style="display:none">Info about the 'add two types' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-add-two-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-add-two-types">11.9. 
 Type Checking</a> <a href="#ref-for-cssnumericvalue-add-two-types①">(2)</a> <a href="#ref-for-cssnumericvalue-add-two-types②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-internal-representation">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#css-internal-representation">https://drafts.css-houdini.org/css-typed-om-1/#css-internal-representation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-internal-representation" class="dfn-panel" data-for="term-for-css-internal-representation" id="infopanel-for-term-for-css-internal-representation" role="menu">
+   <span id="infopaneltitle-for-term-for-css-internal-representation" style="display:none">Info about the 'internal representation' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#css-internal-representation">https://drafts.css-houdini.org/css-typed-om-1/#css-internal-representation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-internal-representation">11.10. 
 Internal Representation</a> <a href="#ref-for-css-internal-representation①">(2)</a> <a href="#ref-for-css-internal-representation②">(3)</a> <a href="#ref-for-css-internal-representation③">(4)</a>
@@ -6165,8 +6165,8 @@ Internal Representation</a> <a href="#ref-for-css-internal-representation①">(2
 Simplification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-invert-a-type">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-invert-a-type">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-invert-a-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-invert-a-type" class="dfn-panel" data-for="term-for-cssnumericvalue-invert-a-type" id="infopanel-for-term-for-cssnumericvalue-invert-a-type" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-invert-a-type" style="display:none">Info about the 'invert a type' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-invert-a-type">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-invert-a-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-invert-a-type">11.9. 
 Type Checking</a>
@@ -6174,8 +6174,8 @@ Type Checking</a>
 Simplification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-match">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-match" class="dfn-panel" data-for="term-for-cssnumericvalue-match" id="infopanel-for-term-for-cssnumericvalue-match" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-match" style="display:none">Info about the 'match' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-match">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-cssnumericvalue-match①">(2)</a>
@@ -6185,8 +6185,8 @@ Type Checking</a> <a href="#ref-for-cssnumericvalue-match③">(2)</a>
 Simplification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-multiply-two-types">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-multiply-two-types" class="dfn-panel" data-for="term-for-cssnumericvalue-multiply-two-types" id="infopanel-for-term-for-cssnumericvalue-multiply-two-types" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-multiply-two-types" style="display:none">Info about the 'multiply two types' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-multiply-two-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-multiply-two-types">11.9. 
 Type Checking</a> <a href="#ref-for-cssnumericvalue-multiply-two-types①">(2)</a>
@@ -6194,15 +6194,15 @@ Type Checking</a> <a href="#ref-for-cssnumericvalue-multiply-two-types①">(2)</
 Simplification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-percent-hint">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-percent-hint">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-percent-hint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-percent-hint" class="dfn-panel" data-for="term-for-cssnumericvalue-percent-hint" id="infopanel-for-term-for-cssnumericvalue-percent-hint" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-percent-hint" style="display:none">Info about the 'percent hint' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-percent-hint">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-percent-hint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-percent-hint">11.9. 
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue-type">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-type">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue-type" class="dfn-panel" data-for="term-for-cssnumericvalue-type" id="infopanel-for-term-for-cssnumericvalue-type" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue-type" style="display:none">Info about the 'type' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-type">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue-type">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-cssnumericvalue-type①">(2)</a>
@@ -6216,22 +6216,22 @@ Type Checking</a> <a href="#ref-for-cssnumericvalue-type⑦">(2)</a> <a href="#r
 Serialization</a> <a href="#ref-for-cssnumericvalue-type③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-cursor-default">
-   <a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-cursor-default" class="dfn-panel" data-for="term-for-valdef-cursor-default" id="infopanel-for-term-for-valdef-cursor-default" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-cursor-default" style="display:none">Info about the 'default' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#valdef-cursor-default">https://drafts.csswg.org/css-ui-4/#valdef-cursor-default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-color" class="dfn-panel" data-for="term-for-propdef-outline-color" id="infopanel-for-term-for-propdef-outline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-color" style="display:none">Info about the 'outline-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">4.3. 
 Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a> <a href="#ref-for-custom-property①">(2)</a>
@@ -6239,29 +6239,29 @@ Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a> <a href="#
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-guaranteed-invalid-value">
-   <a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-guaranteed-invalid-value" class="dfn-panel" data-for="term-for-guaranteed-invalid-value" id="infopanel-for-term-for-guaranteed-invalid-value" role="menu">
+   <span id="infopaneltitle-for-term-for-guaranteed-invalid-value" style="display:none">Info about the 'guaranteed-invalid value' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-guaranteed-invalid-value">10. 
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-at-computed-value-time">
-   <a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-at-computed-value-time" class="dfn-panel" data-for="term-for-invalid-at-computed-value-time" id="infopanel-for-term-for-invalid-at-computed-value-time" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-at-computed-value-time" style="display:none">Info about the 'invalid at computed-value time' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time">https://drafts.csswg.org/css-variables-2/#invalid-at-computed-value-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-at-computed-value-time">10.2. 
 attr() Substitution</a> <a href="#ref-for-invalid-at-computed-value-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-substitute-a-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#substitute-a-var">https://drafts.csswg.org/css-variables-2/#substitute-a-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-substitute-a-var" class="dfn-panel" data-for="term-for-substitute-a-var" id="infopanel-for-term-for-substitute-a-var" role="menu">
+   <span id="infopaneltitle-for-term-for-substitute-a-var" style="display:none">Info about the 'substitute a var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#substitute-a-var">https://drafts.csswg.org/css-variables-2/#substitute-a-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-substitute-a-var">10.2. 
 attr() Substitution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">4.5. 
 Resource Locators: the &lt;url> type</a>
@@ -6273,50 +6273,50 @@ attr() Substitution</a>
 Basic Arithmetic: calc()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">6.1. 
 Relative Lengths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">6.1. 
 Relative Lengths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-orientation-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-orientation-upright" class="dfn-panel" data-for="term-for-valdef-text-orientation-upright" id="infopanel-for-term-for-valdef-text-orientation-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright">https://drafts.csswg.org/css-writing-modes-4/#valdef-text-orientation-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-lr" id="infopanel-for-term-for-valdef-writing-mode-vertical-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="term-for-valdef-writing-mode-vertical-rl" id="infopanel-for-term-for-valdef-writing-mode-vertical-rl" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-vertical-rl</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
@@ -6324,43 +6324,43 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-border-width">
-   <a href="https://drafts.csswg.org/css2/#value-def-border-width">https://drafts.csswg.org/css2/#value-def-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-border-width" class="dfn-panel" data-for="term-for-value-def-border-width" id="infopanel-for-term-for-value-def-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-border-width" style="display:none">Info about the '&lt;border-width>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-border-width">https://drafts.csswg.org/css2/#value-def-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-border-width">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css2/#propdef-background-position">https://drafts.csswg.org/css2/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-background-position">https://drafts.csswg.org/css2/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position②">9.1. 
 Toggling Between Values: toggle()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-collapse">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-collapse" class="dfn-panel" data-for="term-for-propdef-border-collapse" id="infopanel-for-term-for-propdef-border-collapse" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-collapse">https://drafts.csswg.org/css2/#propdef-border-collapse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">4.1. 
 Pre-defined Keywords</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-circle">
-   <a href="https://drafts.csswg.org/css2/#value-def-circle">https://drafts.csswg.org/css2/#value-def-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-circle" class="dfn-panel" data-for="term-for-value-def-circle" id="infopanel-for-term-for-value-def-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-circle" style="display:none">Info about the 'circle' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-circle">https://drafts.csswg.org/css2/#value-def-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-circle">9.1. 
 Toggling Between Values: toggle()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-disc">
-   <a href="https://drafts.csswg.org/css2/#value-def-disc">https://drafts.csswg.org/css2/#value-def-disc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-disc" class="dfn-panel" data-for="term-for-value-def-disc" id="infopanel-for-term-for-value-def-disc" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-disc" style="display:none">Info about the 'disc' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-disc">https://drafts.csswg.org/css2/#value-def-disc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-disc">9.1. 
 Toggling Between Values: toggle()</a> <a href="#ref-for-value-def-disc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">6. 
 Distance Units: the &lt;length> type</a>
@@ -6372,29 +6372,29 @@ Numeric Constants: e, pi</a> <a href="#ref-for-propdef-line-height①⓪">(2)</a
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-square">
-   <a href="https://drafts.csswg.org/css2/#value-def-square">https://drafts.csswg.org/css2/#value-def-square</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-square" class="dfn-panel" data-for="term-for-value-def-square" id="infopanel-for-term-for-value-def-square" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-square" style="display:none">Info about the 'square' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-square">https://drafts.csswg.org/css2/#value-def-square</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-square">9.1. 
 Toggling Between Values: toggle()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-attachment">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-attachment" class="dfn-panel" data-for="term-for-propdef-background-attachment" id="infopanel-for-term-for-propdef-background-attachment" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-attachment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position①" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position①" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">8.3. 
 2D Positioning: the &lt;position> type</a> <a href="#ref-for-propdef-background-position①">(2)</a>
@@ -6406,15 +6406,15 @@ Sign-Related Functions: abs(), sign()</a>
 Computed Value</a> <a href="#ref-for-propdef-background-position⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">2.1. 
 Component Value Types</a> <a href="#ref-for-propdef-border-width①">(2)</a> <a href="#ref-for-propdef-border-width②">(3)</a>
@@ -6422,15 +6422,15 @@ Component Value Types</a> <a href="#ref-for-propdef-border-width①">(2)</a> <a 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">2.6. 
 Property Value Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">8.2. 
 Images: the &lt;image> type</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a> <a href="#ref-for-typedef-image③">(4)</a>
@@ -6438,36 +6438,36 @@ Images: the &lt;image> type</a> <a href="#ref-for-typedef-image①">(2)</a> <a h
 Combination of &lt;image></a> <a href="#ref-for-typedef-image⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute" class="dfn-panel" data-for="term-for-concept-attribute" id="infopanel-for-term-for-concept-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute" style="display:none">Info about the 'attribute' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute">10. 
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">10. 
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-base-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-base-element" class="dfn-panel" data-for="term-for-the-base-element" id="infopanel-for-term-for-the-base-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-base-element" style="display:none">Info about the 'base' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-base-element">4.5.1.1. 
 Fragment URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-history-pushstate">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-history-pushstate" class="dfn-panel" data-for="term-for-dom-history-pushstate" id="infopanel-for-term-for-dom-history-pushstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-history-pushstate" style="display:none">Info about the 'pushState(data, unused, url)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-history-pushstate">4.5.1.1. 
 Fragment URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.1. 
 Pre-defined Keywords</a>
@@ -6485,15 +6485,15 @@ Degenerate Numeric Constants: infinity, -infinity, NaN</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenate' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">11.13. 
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">11.10.1. 
 Simplification</a>
@@ -6501,15 +6501,15 @@ Simplification</a>
 Serialization</a> <a href="#ref-for-list-iterate②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'identical to' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.4. 
 Quoted Strings: the &lt;string> type</a>
@@ -6517,15 +6517,15 @@ Quoted Strings: the &lt;string> type</a>
 Serialization</a> <a href="#ref-for-string②">(2)</a> <a href="#ref-for-string③">(3)</a> <a href="#ref-for-string④">(4)</a> <a href="#ref-for-string⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">10.1. 
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">6.1.1. 
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
@@ -6533,43 +6533,43 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">6.1.2. 
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-wq-name">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-wq-name">https://drafts.csswg.org/selectors-4/#typedef-wq-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-wq-name" class="dfn-panel" data-for="term-for-typedef-wq-name" id="infopanel-for-term-for-typedef-wq-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-wq-name" style="display:none">Info about the '&lt;wq-name>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-wq-name">https://drafts.csswg.org/selectors-4/#typedef-wq-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-wq-name">10. 
 Attribute References: the attr() function</a> <a href="#ref-for-typedef-wq-name①">(2)</a> <a href="#ref-for-typedef-wq-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attribute-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attribute-selector" class="dfn-panel" data-for="term-for-attribute-selector" id="infopanel-for-term-for-attribute-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-attribute-selector" style="display:none">Info about the 'attribute selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-selector">10. 
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">10. 
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">4.5. 
 Resource Locators: the &lt;url> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-discrete">
-   <a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-discrete" class="dfn-panel" data-for="term-for-discrete" id="infopanel-for-term-for-discrete" role="menu">
+   <span id="infopaneltitle-for-term-for-discrete" style="display:none">Info about the 'discrete' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#discrete">https://drafts.csswg.org/web-animations-1/#discrete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discrete">4. 
 Textual Data Types</a>
@@ -6981,8 +6981,8 @@ Textual Data Types</a>
 	What behavior should be used? <a href="https://github.com/w3c/csswg-drafts/issues/5689">[Issue #5689]</a> <a class="issue-return" href="#issue-1a929fd0" title="Jump to section">↵</a></div>
    <div class="issue"> This section is still <a href="https://lists.w3.org/Archives/Member/w3c-css-wg/2016AprJun/0239.html">under discussion</a>. <a class="issue-return" href="#issue-f5bc4b00" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="comb-comma">
-   <b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-comma" class="dfn-panel" data-for="comb-comma" id="infopanel-for-comb-comma" role="dialog">
+   <span id="infopaneltitle-for-comb-comma" style="display:none">Info about the 'Commas' definition.</span><b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">2.1. 
 Component Value Types</a> <a href="#ref-for-comb-comma①">(2)</a>
@@ -6992,22 +6992,22 @@ Attribute References: the attr() function</a>
 Syntax</a> <a href="#ref-for-comb-comma④">(2)</a> <a href="#ref-for-comb-comma⑤">(3)</a> <a href="#ref-for-comb-comma⑥">(4)</a> <a href="#ref-for-comb-comma⑦">(5)</a> <a href="#ref-for-comb-comma⑧">(6)</a> <a href="#ref-for-comb-comma⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-all">
-   <b><a href="#comb-all">#comb-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-all" class="dfn-panel" data-for="comb-all" id="infopanel-for-comb-all" role="dialog">
+   <span id="infopaneltitle-for-comb-all" style="display:none">Info about the '&amp;&amp;' definition.</span><b><a href="#comb-all">#comb-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">8.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-any">
-   <b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-any" class="dfn-panel" data-for="comb-any" id="infopanel-for-comb-any" role="dialog">
+   <span id="infopaneltitle-for-comb-any" style="display:none">Info about the '||' definition.</span><b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">8.3. 
 2D Positioning: the &lt;position> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-one">
-   <b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-one" class="dfn-panel" data-for="comb-one" id="infopanel-for-comb-one" role="dialog">
+   <span id="infopaneltitle-for-comb-one" style="display:none">Info about the '|' definition.</span><b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.5. 
 Resource Locators: the &lt;url> type</a>
@@ -7021,8 +7021,8 @@ Attribute References: the attr() function</a> <a href="#ref-for-comb-one②⓪">
 Syntax</a> <a href="#ref-for-comb-one③①">(2)</a> <a href="#ref-for-comb-one③②">(3)</a> <a href="#ref-for-comb-one③③">(4)</a> <a href="#ref-for-comb-one③④">(5)</a> <a href="#ref-for-comb-one③⑤">(6)</a> <a href="#ref-for-comb-one③⑥">(7)</a> <a href="#ref-for-comb-one③⑦">(8)</a> <a href="#ref-for-comb-one③⑧">(9)</a> <a href="#ref-for-comb-one③⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-zero-plus">
-   <b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-zero-plus" class="dfn-panel" data-for="mult-zero-plus" id="infopanel-for-mult-zero-plus" role="dialog">
+   <span id="infopaneltitle-for-mult-zero-plus" style="display:none">Info about the '*' definition.</span><b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">4.5. 
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-mult-zero-plus①">(2)</a>
@@ -7030,8 +7030,8 @@ Resource Locators: the &lt;url> type</a> <a href="#ref-for-mult-zero-plus①">(2
 Syntax</a> <a href="#ref-for-mult-zero-plus③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-opt">
-   <b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-opt" class="dfn-panel" data-for="mult-opt" id="infopanel-for-mult-opt" role="dialog">
+   <span id="infopaneltitle-for-mult-opt" style="display:none">Info about the '?' definition.</span><b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.1. 
 Component Value Types</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
@@ -7045,8 +7045,8 @@ Attribute References: the attr() function</a> <a href="#ref-for-mult-opt⑥">(2)
 Syntax</a> <a href="#ref-for-mult-opt⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-comma">
-   <b><a href="#mult-comma">#mult-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-comma" class="dfn-panel" data-for="mult-comma" id="infopanel-for-mult-comma" role="dialog">
+   <span id="infopaneltitle-for-mult-comma" style="display:none">Info about the '#' definition.</span><b><a href="#mult-comma">#mult-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2.1. 
 Component Value Types</a>
@@ -7054,8 +7054,8 @@ Component Value Types</a>
 Syntax</a> <a href="#ref-for-mult-comma①">(2)</a> <a href="#ref-for-mult-comma②">(3)</a> <a href="#ref-for-mult-comma③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interpolation">
-   <b><a href="#interpolation">#interpolation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interpolation" class="dfn-panel" data-for="interpolation" id="infopanel-for-interpolation" role="dialog">
+   <span id="infopaneltitle-for-interpolation" style="display:none">Info about the 'interpolation' definition.</span><b><a href="#interpolation">#interpolation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a>
@@ -7079,8 +7079,8 @@ Combination of &lt;position></a>
 Combination of Math Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="addition">
-   <b><a href="#addition">#addition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-addition" class="dfn-panel" data-for="addition" id="infopanel-for-addition" role="dialog">
+   <span id="infopaneltitle-for-addition" style="display:none">Info about the 'addition' definition.</span><b><a href="#addition">#addition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-addition">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a> <a href="#ref-for-addition①">(2)</a> <a href="#ref-for-addition②">(3)</a> <a href="#ref-for-addition③">(4)</a> <a href="#ref-for-addition④">(5)</a> <a href="#ref-for-addition⑤">(6)</a> <a href="#ref-for-addition⑥">(7)</a>
@@ -7102,15 +7102,15 @@ Combination of &lt;position></a> <a href="#ref-for-addition①⑥">(2)</a>
 Combination of Math Functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accumulation">
-   <b><a href="#accumulation">#accumulation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accumulation" class="dfn-panel" data-for="accumulation" id="infopanel-for-accumulation" role="dialog">
+   <span id="infopaneltitle-for-accumulation" style="display:none">Info about the 'accumulation' definition.</span><b><a href="#accumulation">#accumulation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accumulation">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a> <a href="#ref-for-accumulation①">(2)</a> <a href="#ref-for-accumulation②">(3)</a> <a href="#ref-for-accumulation③">(4)</a> <a href="#ref-for-accumulation④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="not-additive">
-   <b><a href="#not-additive">#not-additive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-not-additive" class="dfn-panel" data-for="not-additive" id="infopanel-for-not-additive" role="dialog">
+   <span id="infopaneltitle-for-not-additive" style="display:none">Info about the 'not additive' definition.</span><b><a href="#not-additive">#not-additive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-additive">4. 
 Textual Data Types</a>
@@ -7118,8 +7118,8 @@ Textual Data Types</a>
 Combination of &lt;image></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-identifier">
-   <b><a href="#css-identifier">#css-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-identifier" class="dfn-panel" data-for="css-identifier" id="infopanel-for-css-identifier" role="dialog">
+   <span id="infopaneltitle-for-css-identifier" style="display:none">Info about the 'identifiers' definition.</span><b><a href="#css-identifier">#css-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-identifier">4. 
 Textual Data Types</a>
@@ -7131,8 +7131,8 @@ Author-defined Identifiers: the &lt;custom-ident> type</a>
 Numbers with Units: dimension values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-ident">
-   <b><a href="#typedef-ident">#typedef-ident</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-ident" class="dfn-panel" data-for="typedef-ident" id="infopanel-for-typedef-ident" role="dialog">
+   <span id="infopaneltitle-for-typedef-ident" style="display:none">Info about the '&lt;ident>' definition.</span><b><a href="#typedef-ident">#typedef-ident</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">4. 
 Textual Data Types</a>
@@ -7140,8 +7140,8 @@ Textual Data Types</a>
 URL Modifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-wide-keywords">
-   <b><a href="#css-wide-keywords">#css-wide-keywords</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-wide-keywords" class="dfn-panel" data-for="css-wide-keywords" id="infopanel-for-css-wide-keywords" role="dialog">
+   <span id="infopaneltitle-for-css-wide-keywords" style="display:none">Info about the 'CSS-wide keywords' definition.</span><b><a href="#css-wide-keywords">#css-wide-keywords</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">4.2. 
 Author-defined Identifiers: the &lt;custom-ident> type</a>
@@ -7149,8 +7149,8 @@ Author-defined Identifiers: the &lt;custom-ident> type</a>
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identifier-value">
-   <b><a href="#identifier-value">#identifier-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identifier-value" class="dfn-panel" data-for="identifier-value" id="infopanel-for-identifier-value" role="dialog">
+   <span id="infopaneltitle-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' definition.</span><b><a href="#identifier-value">#identifier-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2.1. 
 Component Value Types</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a>
@@ -7164,8 +7164,8 @@ Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a>
 attr() Types</a> <a href="#ref-for-identifier-value①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-dashed-ident">
-   <b><a href="#typedef-dashed-ident">#typedef-dashed-ident</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-dashed-ident" class="dfn-panel" data-for="typedef-dashed-ident" id="infopanel-for-typedef-dashed-ident" role="dialog">
+   <span id="infopaneltitle-for-typedef-dashed-ident" style="display:none">Info about the '&lt;dashed-ident>' definition.</span><b><a href="#typedef-dashed-ident">#typedef-dashed-ident</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dashed-ident">4.3. 
 Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a> <a href="#ref-for-typedef-dashed-ident①">(2)</a> <a href="#ref-for-typedef-dashed-ident②">(3)</a> <a href="#ref-for-typedef-dashed-ident③">(4)</a> <a href="#ref-for-typedef-dashed-ident④">(5)</a> <a href="#ref-for-typedef-dashed-ident⑤">(6)</a> <a href="#ref-for-typedef-dashed-ident⑥">(7)</a> <a href="#ref-for-typedef-dashed-ident⑦">(8)</a> <a href="#ref-for-typedef-dashed-ident⑧">(9)</a>
@@ -7173,8 +7173,8 @@ Explicitly Author-defined Identifiers: the &lt;dashed-ident> type</a> <a href="#
     <li><a href="#ref-for-typedef-dashed-ident①⓪"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-value">
-   <b><a href="#string-value">#string-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-value" class="dfn-panel" data-for="string-value" id="infopanel-for-string-value" role="dialog">
+   <span id="infopaneltitle-for-string-value" style="display:none">Info about the '&lt;string>' definition.</span><b><a href="#string-value">#string-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">4. 
 Textual Data Types</a>
@@ -7184,8 +7184,8 @@ Quoted Strings: the &lt;string> type</a>
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-string-value③">(2)</a> <a href="#ref-for-string-value④">(3)</a> <a href="#ref-for-string-value⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-url">
-   <b><a href="#funcdef-url">#funcdef-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-url" class="dfn-panel" data-for="funcdef-url" id="infopanel-for-funcdef-url" role="dialog">
+   <span id="infopaneltitle-for-funcdef-url" style="display:none">Info about the 'url()' definition.</span><b><a href="#funcdef-url">#funcdef-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-url">4.5. 
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-funcdef-url①">(2)</a> <a href="#ref-for-funcdef-url②">(3)</a> <a href="#ref-for-funcdef-url③">(4)</a> <a href="#ref-for-funcdef-url④">(5)</a> <a href="#ref-for-funcdef-url⑤">(6)</a>
@@ -7199,8 +7199,8 @@ URL Modifiers</a> <a href="#ref-for-funcdef-url①⑤">(2)</a>
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-src">
-   <b><a href="#funcdef-src">#funcdef-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-src" class="dfn-panel" data-for="funcdef-src" id="infopanel-for-funcdef-src" role="dialog">
+   <span id="infopaneltitle-for-funcdef-src" style="display:none">Info about the 'src()' definition.</span><b><a href="#funcdef-src">#funcdef-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-src">4.5. 
 Resource Locators: the &lt;url> type</a>
@@ -7208,8 +7208,8 @@ Resource Locators: the &lt;url> type</a>
     <li><a href="#ref-for-funcdef-src②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-value">
-   <b><a href="#url-value">#url-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-value" class="dfn-panel" data-for="url-value" id="infopanel-for-url-value" role="dialog">
+   <span id="infopaneltitle-for-url-value" style="display:none">Info about the '&lt;url>' definition.</span><b><a href="#url-value">#url-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">4. 
 Textual Data Types</a>
@@ -7227,15 +7227,15 @@ attr() Types</a>
     <li><a href="#ref-for-url-value①⓪"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-local-url-flag">
-   <b><a href="#url-local-url-flag">#url-local-url-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-local-url-flag" class="dfn-panel" data-for="url-local-url-flag" id="infopanel-for-url-local-url-flag" role="dialog">
+   <span id="infopaneltitle-for-url-local-url-flag" style="display:none">Info about the 'local url flag' definition.</span><b><a href="#url-local-url-flag">#url-local-url-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-local-url-flag">4.5.1.1. 
 Fragment URLs</a> <a href="#ref-for-url-local-url-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-url-modifier">
-   <b><a href="#typedef-url-modifier">#typedef-url-modifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-url-modifier" class="dfn-panel" data-for="typedef-url-modifier" id="infopanel-for-typedef-url-modifier" role="dialog">
+   <span id="infopaneltitle-for-typedef-url-modifier" style="display:none">Info about the '&lt;url-modifier>' definition.</span><b><a href="#typedef-url-modifier">#typedef-url-modifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-url-modifier">4.5. 
 Resource Locators: the &lt;url> type</a> <a href="#ref-for-typedef-url-modifier①">(2)</a> <a href="#ref-for-typedef-url-modifier②">(3)</a>
@@ -7243,22 +7243,22 @@ Resource Locators: the &lt;url> type</a> <a href="#ref-for-typedef-url-modifier�
 URL Modifiers</a> <a href="#ref-for-typedef-url-modifier④">(2)</a> <a href="#ref-for-typedef-url-modifier⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="numeric-data-types">
-   <b><a href="#numeric-data-types">#numeric-data-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-numeric-data-types" class="dfn-panel" data-for="numeric-data-types" id="infopanel-for-numeric-data-types" role="dialog">
+   <span id="infopaneltitle-for-numeric-data-types" style="display:none">Info about the 'numeric data types' definition.</span><b><a href="#numeric-data-types">#numeric-data-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-numeric-data-types">2.1. 
 Component Value Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-bracketed-range-notation">
-   <b><a href="#css-bracketed-range-notation">#css-bracketed-range-notation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-bracketed-range-notation" class="dfn-panel" data-for="css-bracketed-range-notation" id="infopanel-for-css-bracketed-range-notation" role="dialog">
+   <span id="infopaneltitle-for-css-bracketed-range-notation" style="display:none">Info about the 'CSS bracketed range notation' definition.</span><b><a href="#css-bracketed-range-notation">#css-bracketed-range-notation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-bracketed-range-notation">5.1. 
 Range Restrictions and Range Definition Notation</a> <a href="#ref-for-css-bracketed-range-notation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="integer-value">
-   <b><a href="#integer-value">#integer-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-integer-value" class="dfn-panel" data-for="integer-value" id="infopanel-for-integer-value" role="dialog">
+   <span id="infopaneltitle-for-integer-value" style="display:none">Info about the '&lt;integer>' definition.</span><b><a href="#integer-value">#integer-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">2.1. 
 Component Value Types</a> <a href="#ref-for-integer-value①">(2)</a> <a href="#ref-for-integer-value②">(3)</a>
@@ -7279,15 +7279,15 @@ Range Checking</a>
     <li><a href="#ref-for-integer-value①⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="integer">
-   <b><a href="#integer">#integer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-integer" class="dfn-panel" data-for="integer" id="infopanel-for-integer" role="dialog">
+   <span id="infopaneltitle-for-integer" style="display:none">Info about the 'integer' definition.</span><b><a href="#integer">#integer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer">5.3. 
 Real Numbers: the &lt;number> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="number-value">
-   <b><a href="#number-value">#number-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-number-value" class="dfn-panel" data-for="number-value" id="infopanel-for-number-value" role="dialog">
+   <span id="infopaneltitle-for-number-value" style="display:none">Info about the '&lt;number>' definition.</span><b><a href="#number-value">#number-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">5. 
 Numeric Data Types</a>
@@ -7323,8 +7323,8 @@ Range Checking</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="number">
-   <b><a href="#number">#number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-number" class="dfn-panel" data-for="number" id="infopanel-for-number" role="dialog">
+   <span id="infopaneltitle-for-number" style="display:none">Info about the 'number' definition.</span><b><a href="#number">#number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number">5.3. 
 Real Numbers: the &lt;number> type</a>
@@ -7334,15 +7334,15 @@ Numbers with Units: dimension values</a>
 Percentages: the &lt;percentage> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="zero-value">
-   <b><a href="#zero-value">#zero-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-zero-value" class="dfn-panel" data-for="zero-value" id="infopanel-for-zero-value" role="dialog">
+   <span id="infopaneltitle-for-zero-value" style="display:none">Info about the '&lt;zero>' definition.</span><b><a href="#zero-value">#zero-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-zero-value">5.3. 
 Real Numbers: the &lt;number> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dimension">
-   <b><a href="#dimension">#dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dimension" class="dfn-panel" data-for="dimension" id="infopanel-for-dimension" role="dialog">
+   <span id="infopaneltitle-for-dimension" style="display:none">Info about the 'dimension' definition.</span><b><a href="#dimension">#dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dimension">5. 
 Numeric Data Types</a> <a href="#ref-for-dimension①">(2)</a>
@@ -7365,8 +7365,8 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
     <li><a href="#ref-for-dimension①②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-dimension">
-   <b><a href="#typedef-dimension">#typedef-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-dimension" class="dfn-panel" data-for="typedef-dimension" id="infopanel-for-typedef-dimension" role="dialog">
+   <span id="infopaneltitle-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' definition.</span><b><a href="#typedef-dimension">#typedef-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">5.4. 
 Numbers with Units: dimension values</a>
@@ -7384,8 +7384,8 @@ Syntax</a>
 Type Checking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compatible-units">
-   <b><a href="#compatible-units">#compatible-units</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compatible-units" class="dfn-panel" data-for="compatible-units" id="infopanel-for-compatible-units" role="dialog">
+   <span id="infopaneltitle-for-compatible-units" style="display:none">Info about the 'compatible units' definition.</span><b><a href="#compatible-units">#compatible-units</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compatible-units">5.4.1. 
 Compatible Units</a> <a href="#ref-for-compatible-units①">(2)</a>
@@ -7405,8 +7405,8 @@ Frequency Units: the &lt;frequency> type and Hz, kHz units</a>
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canonical-unit">
-   <b><a href="#canonical-unit">#canonical-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canonical-unit" class="dfn-panel" data-for="canonical-unit" id="infopanel-for-canonical-unit" role="dialog">
+   <span id="infopaneltitle-for-canonical-unit" style="display:none">Info about the 'canonical unit' definition.</span><b><a href="#canonical-unit">#canonical-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canonical-unit">3. 
 Combining Values: Interpolation, Addition, and Accumulation</a>
@@ -7430,8 +7430,8 @@ Simplification</a> <a href="#ref-for-canonical-unit⑨">(2)</a> <a href="#ref-fo
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percentage-value">
-   <b><a href="#percentage-value">#percentage-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percentage-value" class="dfn-panel" data-for="percentage-value" id="infopanel-for-percentage-value" role="dialog">
+   <span id="infopaneltitle-for-percentage-value" style="display:none">Info about the '&lt;percentage>' definition.</span><b><a href="#percentage-value">#percentage-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2.1. 
 Component Value Types</a>
@@ -7461,8 +7461,8 @@ Syntax</a>
 Type Checking</a> <a href="#ref-for-percentage-value③①">(2)</a> <a href="#ref-for-percentage-value③②">(3)</a> <a href="#ref-for-percentage-value③③">(4)</a> <a href="#ref-for-percentage-value③④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-length-percentage">
-   <b><a href="#typedef-length-percentage">#typedef-length-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-length-percentage" class="dfn-panel" data-for="typedef-length-percentage" id="infopanel-for-typedef-length-percentage" role="dialog">
+   <span id="infopaneltitle-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' definition.</span><b><a href="#typedef-length-percentage">#typedef-length-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">5.6.1. 
 Combination of Percentage and Dimension Mixes</a>
@@ -7474,29 +7474,29 @@ Combination of &lt;position></a> <a href="#ref-for-typedef-length-percentage⑥"
 Mathematical Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-frequency-percentage">
-   <b><a href="#typedef-frequency-percentage">#typedef-frequency-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-frequency-percentage" class="dfn-panel" data-for="typedef-frequency-percentage" id="infopanel-for-typedef-frequency-percentage" role="dialog">
+   <span id="infopaneltitle-for-typedef-frequency-percentage" style="display:none">Info about the '&lt;frequency-percentage>' definition.</span><b><a href="#typedef-frequency-percentage">#typedef-frequency-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-frequency-percentage">5.6.1. 
 Combination of Percentage and Dimension Mixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-angle-percentage">
-   <b><a href="#typedef-angle-percentage">#typedef-angle-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-angle-percentage" class="dfn-panel" data-for="typedef-angle-percentage" id="infopanel-for-typedef-angle-percentage" role="dialog">
+   <span id="infopaneltitle-for-typedef-angle-percentage" style="display:none">Info about the '&lt;angle-percentage>' definition.</span><b><a href="#typedef-angle-percentage">#typedef-angle-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-angle-percentage">5.6.1. 
 Combination of Percentage and Dimension Mixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-time-percentage">
-   <b><a href="#typedef-time-percentage">#typedef-time-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-time-percentage" class="dfn-panel" data-for="typedef-time-percentage" id="infopanel-for-typedef-time-percentage" role="dialog">
+   <span id="infopaneltitle-for-typedef-time-percentage" style="display:none">Info about the '&lt;time-percentage>' definition.</span><b><a href="#typedef-time-percentage">#typedef-time-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-time-percentage">5.6.1. 
 Combination of Percentage and Dimension Mixes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ratio-value">
-   <b><a href="#ratio-value">#ratio-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ratio-value" class="dfn-panel" data-for="ratio-value" id="infopanel-for-ratio-value" role="dialog">
+   <span id="infopaneltitle-for-ratio-value" style="display:none">Info about the '&lt;ratio>' definition.</span><b><a href="#ratio-value">#ratio-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-value">5.7. 
 Ratios: the &lt;ratio> type</a> <a href="#ref-for-ratio-value①">(2)</a> <a href="#ref-for-ratio-value②">(3)</a> <a href="#ref-for-ratio-value③">(4)</a> <a href="#ref-for-ratio-value④">(5)</a> <a href="#ref-for-ratio-value⑤">(6)</a>
@@ -7506,15 +7506,15 @@ Combination of &lt;ratio></a> <a href="#ref-for-ratio-value⑦">(2)</a> <a href=
     <li><a href="#ref-for-ratio-value①④"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="degenerate-ratio">
-   <b><a href="#degenerate-ratio">#degenerate-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-degenerate-ratio" class="dfn-panel" data-for="degenerate-ratio" id="infopanel-for-degenerate-ratio" role="dialog">
+   <span id="infopaneltitle-for-degenerate-ratio" style="display:none">Info about the 'degenerate ratio' definition.</span><b><a href="#degenerate-ratio">#degenerate-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-degenerate-ratio">5.7.1. 
 Combination of &lt;ratio></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="length-value">
-   <b><a href="#length-value">#length-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-length-value" class="dfn-panel" data-for="length-value" id="infopanel-for-length-value" role="dialog">
+   <span id="infopaneltitle-for-length-value" style="display:none">Info about the '&lt;length>' definition.</span><b><a href="#length-value">#length-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">1. 
 Introduction</a>
@@ -7552,22 +7552,22 @@ Type Checking</a> <a href="#ref-for-length-value②⑥">(2)</a> <a href="#ref-fo
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-length">
-   <b><a href="#relative-length">#relative-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-length" class="dfn-panel" data-for="relative-length" id="infopanel-for-relative-length" role="dialog">
+   <span id="infopaneltitle-for-relative-length" style="display:none">Info about the 'Relative length units' definition.</span><b><a href="#relative-length">#relative-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-length">6. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-relative-length">
-   <b><a href="#font-relative-length">#font-relative-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-relative-length" class="dfn-panel" data-for="font-relative-length" id="infopanel-for-font-relative-length" role="dialog">
+   <span id="infopaneltitle-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' definition.</span><b><a href="#font-relative-length">#font-relative-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">11.11. 
 Computed Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="em">
-   <b><a href="#em">#em</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-em" class="dfn-panel" data-for="em" id="infopanel-for-em" role="dialog">
+   <span id="infopaneltitle-for-em" style="display:none">Info about the 'em unit' definition.</span><b><a href="#em">#em</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">5.4.1. 
 Compatible Units</a>
@@ -7581,8 +7581,8 @@ Computed Value</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ex">
-   <b><a href="#ex">#ex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ex" class="dfn-panel" data-for="ex" id="infopanel-for-ex" role="dialog">
+   <span id="infopaneltitle-for-ex" style="display:none">Info about the 'ex unit' definition.</span><b><a href="#ex">#ex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">6.1. 
 Relative Lengths</a>
@@ -7590,8 +7590,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-ex②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cap">
-   <b><a href="#cap">#cap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cap" class="dfn-panel" data-for="cap" id="infopanel-for-cap" role="dialog">
+   <span id="infopaneltitle-for-cap" style="display:none">Info about the 'cap unit' definition.</span><b><a href="#cap">#cap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cap">6.1. 
 Relative Lengths</a>
@@ -7600,8 +7600,8 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="
     <li><a href="#ref-for-cap③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ch">
-   <b><a href="#ch">#ch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ch" class="dfn-panel" data-for="ch" id="infopanel-for-ch" role="dialog">
+   <span id="infopaneltitle-for-ch" style="display:none">Info about the 'ch unit' definition.</span><b><a href="#ch">#ch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ch">6.1. 
 Relative Lengths</a>
@@ -7609,8 +7609,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-ch②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="length-advance-measure">
-   <b><a href="#length-advance-measure">#length-advance-measure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-length-advance-measure" class="dfn-panel" data-for="length-advance-measure" id="infopanel-for-length-advance-measure" role="dialog">
+   <span id="infopaneltitle-for-length-advance-measure" style="display:none">Info about the 'advance measure' definition.</span><b><a href="#length-advance-measure">#length-advance-measure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-advance-measure">6.1. 
 Relative Lengths</a> <a href="#ref-for-length-advance-measure①">(2)</a>
@@ -7618,8 +7618,8 @@ Relative Lengths</a> <a href="#ref-for-length-advance-measure①">(2)</a>
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-length-advance-measure③">(2)</a> <a href="#ref-for-length-advance-measure④">(3)</a> <a href="#ref-for-length-advance-measure⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ic">
-   <b><a href="#ic">#ic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ic" class="dfn-panel" data-for="ic" id="infopanel-for-ic" role="dialog">
+   <span id="infopaneltitle-for-ic" style="display:none">Info about the 'ic unit' definition.</span><b><a href="#ic">#ic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ic">6.1. 
 Relative Lengths</a>
@@ -7628,8 +7628,8 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a>
     <li><a href="#ref-for-ic②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rem">
-   <b><a href="#rem">#rem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rem" class="dfn-panel" data-for="rem" id="infopanel-for-rem" role="dialog">
+   <span id="infopaneltitle-for-rem" style="display:none">Info about the 'rem unit' definition.</span><b><a href="#rem">#rem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rem">6.1. 
 Relative Lengths</a>
@@ -7637,8 +7637,8 @@ Relative Lengths</a>
 Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="#ref-for-rem②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lh">
-   <b><a href="#lh">#lh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lh" class="dfn-panel" data-for="lh" id="infopanel-for-lh" role="dialog">
+   <span id="infopaneltitle-for-lh" style="display:none">Info about the 'lh unit' definition.</span><b><a href="#lh">#lh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lh">6.1. 
 Relative Lengths</a>
@@ -7647,8 +7647,8 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="
     <li><a href="#ref-for-lh④"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rlh">
-   <b><a href="#rlh">#rlh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rlh" class="dfn-panel" data-for="rlh" id="infopanel-for-rlh" role="dialog">
+   <span id="infopaneltitle-for-rlh" style="display:none">Info about the 'rlh unit' definition.</span><b><a href="#rlh">#rlh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rlh">6.1. 
 Relative Lengths</a>
@@ -7657,8 +7657,8 @@ Font-relative Lengths: the em, ex, cap, ch, ic, rem, lh, rlh units</a> <a href="
     <li><a href="#ref-for-rlh⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vw">
-   <b><a href="#vw">#vw</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vw" class="dfn-panel" data-for="vw" id="infopanel-for-vw" role="dialog">
+   <span id="infopaneltitle-for-vw" style="display:none">Info about the 'vw unit' definition.</span><b><a href="#vw">#vw</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vw">6.1. 
 Relative Lengths</a>
@@ -7666,8 +7666,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a> <a href="#ref-for-vw②">(2)</a> <a href="#ref-for-vw③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vh">
-   <b><a href="#vh">#vh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vh" class="dfn-panel" data-for="vh" id="infopanel-for-vh" role="dialog">
+   <span id="infopaneltitle-for-vh" style="display:none">Info about the 'vh unit' definition.</span><b><a href="#vh">#vh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vh">6.1. 
 Relative Lengths</a>
@@ -7675,8 +7675,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a> <a href="#ref-for-vh②">(2)</a> <a href="#ref-for-vh③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-length-vi">
-   <b><a href="#valdef-length-vi">#valdef-length-vi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-length-vi" class="dfn-panel" data-for="valdef-length-vi" id="infopanel-for-valdef-length-vi" role="dialog">
+   <span id="infopaneltitle-for-valdef-length-vi" style="display:none">Info about the 'vi unit' definition.</span><b><a href="#valdef-length-vi">#valdef-length-vi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vi">6.1. 
 Relative Lengths</a>
@@ -7685,8 +7685,8 @@ Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a> <a href="#
     <li><a href="#ref-for-valdef-length-vi③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-length-vb">
-   <b><a href="#valdef-length-vb">#valdef-length-vb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-length-vb" class="dfn-panel" data-for="valdef-length-vb" id="infopanel-for-valdef-length-vb" role="dialog">
+   <span id="infopaneltitle-for-valdef-length-vb" style="display:none">Info about the 'vb unit' definition.</span><b><a href="#valdef-length-vb">#valdef-length-vb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vb">6.1. 
 Relative Lengths</a>
@@ -7695,8 +7695,8 @@ Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a> <a href="#
     <li><a href="#ref-for-valdef-length-vb③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vmin">
-   <b><a href="#vmin">#vmin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vmin" class="dfn-panel" data-for="vmin" id="infopanel-for-vmin" role="dialog">
+   <span id="infopaneltitle-for-vmin" style="display:none">Info about the 'vmin unit' definition.</span><b><a href="#vmin">#vmin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vmin">6.1. 
 Relative Lengths</a>
@@ -7704,8 +7704,8 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vmax">
-   <b><a href="#vmax">#vmax</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vmax" class="dfn-panel" data-for="vmax" id="infopanel-for-vmax" role="dialog">
+   <span id="infopaneltitle-for-vmax" style="display:none">Info about the 'vmax unit' definition.</span><b><a href="#vmax">#vmax</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vmax">6.1. 
 Relative Lengths</a>
@@ -7713,29 +7713,29 @@ Relative Lengths</a>
 Viewport-percentage Lengths: the vw, vh, vi, vb, vmin, vmax units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-length">
-   <b><a href="#absolute-length">#absolute-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-length" class="dfn-panel" data-for="absolute-length" id="infopanel-for-absolute-length" role="dialog">
+   <span id="infopaneltitle-for-absolute-length" style="display:none">Info about the 'absolute length units' definition.</span><b><a href="#absolute-length">#absolute-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-length">6. 
 Distance Units: the &lt;length> type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="physical-unit">
-   <b><a href="#physical-unit">#physical-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-physical-unit" class="dfn-panel" data-for="physical-unit" id="infopanel-for-physical-unit" role="dialog">
+   <span id="infopaneltitle-for-physical-unit" style="display:none">Info about the 'physical units' definition.</span><b><a href="#physical-unit">#physical-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-unit">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-physical-unit①">(2)</a> <a href="#ref-for-physical-unit②">(3)</a> <a href="#ref-for-physical-unit③">(4)</a> <a href="#ref-for-physical-unit④">(5)</a> <a href="#ref-for-physical-unit⑤">(6)</a> <a href="#ref-for-physical-unit⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visual-angle-unit">
-   <b><a href="#visual-angle-unit">#visual-angle-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visual-angle-unit" class="dfn-panel" data-for="visual-angle-unit" id="infopanel-for-visual-angle-unit" role="dialog">
+   <span id="infopaneltitle-for-visual-angle-unit" style="display:none">Info about the 'visual angle unit (pixel unit)' definition.</span><b><a href="#visual-angle-unit">#visual-angle-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visual-angle-unit">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-visual-angle-unit①">(2)</a> <a href="#ref-for-visual-angle-unit②">(3)</a> <a href="#ref-for-visual-angle-unit③">(4)</a> <a href="#ref-for-visual-angle-unit④">(5)</a> <a href="#ref-for-visual-angle-unit⑤">(6)</a> <a href="#ref-for-visual-angle-unit⑥">(7)</a> <a href="#ref-for-visual-angle-unit⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cm">
-   <b><a href="#cm">#cm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cm" class="dfn-panel" data-for="cm" id="infopanel-for-cm" role="dialog">
+   <span id="infopaneltitle-for-cm" style="display:none">Info about the 'cm' definition.</span><b><a href="#cm">#cm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-cm①">(2)</a>
@@ -7743,22 +7743,22 @@ Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-cm�
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mm">
-   <b><a href="#mm">#mm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mm" class="dfn-panel" data-for="mm" id="infopanel-for-mm" role="dialog">
+   <span id="infopaneltitle-for-mm" style="display:none">Info about the 'mm' definition.</span><b><a href="#mm">#mm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mm">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-mm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Q">
-   <b><a href="#Q">#Q</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Q" class="dfn-panel" data-for="Q" id="infopanel-for-Q" role="dialog">
+   <span id="infopaneltitle-for-Q" style="display:none">Info about the 'Q' definition.</span><b><a href="#Q">#Q</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Q">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-Q①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in">
-   <b><a href="#in">#in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in" class="dfn-panel" data-for="in" id="infopanel-for-in" role="dialog">
+   <span id="infopaneltitle-for-in" style="display:none">Info about the 'in' definition.</span><b><a href="#in">#in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">5.4.1. 
 Compatible Units</a>
@@ -7768,22 +7768,22 @@ Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-in�
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-in④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pc">
-   <b><a href="#pc">#pc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pc" class="dfn-panel" data-for="pc" id="infopanel-for-pc" role="dialog">
+   <span id="infopaneltitle-for-pc" style="display:none">Info about the 'pc' definition.</span><b><a href="#pc">#pc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pc">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-pc①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pt">
-   <b><a href="#pt">#pt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pt" class="dfn-panel" data-for="pt" id="infopanel-for-pt" role="dialog">
+   <span id="infopaneltitle-for-pt" style="display:none">Info about the 'pt' definition.</span><b><a href="#pt">#pt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pt">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-pt①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="px">
-   <b><a href="#px">#px</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-px" class="dfn-panel" data-for="px" id="infopanel-for-px" role="dialog">
+   <span id="infopaneltitle-for-px" style="display:none">Info about the 'px' definition.</span><b><a href="#px">#px</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">5.4.1. 
 Compatible Units</a> <a href="#ref-for-px①">(2)</a>
@@ -7801,22 +7801,22 @@ Computed Value</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchor-unit">
-   <b><a href="#anchor-unit">#anchor-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchor-unit" class="dfn-panel" data-for="anchor-unit" id="infopanel-for-anchor-unit" role="dialog">
+   <span id="infopaneltitle-for-anchor-unit" style="display:none">Info about the 'anchored' definition.</span><b><a href="#anchor-unit">#anchor-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-unit">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a> <a href="#ref-for-anchor-unit①">(2)</a> <a href="#ref-for-anchor-unit②">(3)</a> <a href="#ref-for-anchor-unit③">(4)</a> <a href="#ref-for-anchor-unit④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reference-pixel">
-   <b><a href="#reference-pixel">#reference-pixel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reference-pixel" class="dfn-panel" data-for="reference-pixel" id="infopanel-for-reference-pixel" role="dialog">
+   <span id="infopaneltitle-for-reference-pixel" style="display:none">Info about the 'reference pixel' definition.</span><b><a href="#reference-pixel">#reference-pixel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reference-pixel">6.2. 
 Absolute Lengths: the cm, mm, Q, in, pt, pc, px units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="angle-value">
-   <b><a href="#angle-value">#angle-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-angle-value" class="dfn-panel" data-for="angle-value" id="infopanel-for-angle-value" role="dialog">
+   <span id="infopaneltitle-for-angle-value" style="display:none">Info about the '&lt;angle>' definition.</span><b><a href="#angle-value">#angle-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5. 
 Numeric Data Types</a> <a href="#ref-for-angle-value①">(2)</a>
@@ -7836,8 +7836,8 @@ Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2(
 Type Checking</a> <a href="#ref-for-angle-value①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deg">
-   <b><a href="#deg">#deg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deg" class="dfn-panel" data-for="deg" id="infopanel-for-deg" role="dialog">
+   <span id="infopaneltitle-for-deg" style="display:none">Info about the 'deg' definition.</span><b><a href="#deg">#deg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deg">7.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a> <a href="#ref-for-deg①">(2)</a>
@@ -7845,8 +7845,8 @@ Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a> <a href="#re
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grad">
-   <b><a href="#grad">#grad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grad" class="dfn-panel" data-for="grad" id="infopanel-for-grad" role="dialog">
+   <span id="infopaneltitle-for-grad" style="display:none">Info about the 'grad' definition.</span><b><a href="#grad">#grad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grad">7.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
@@ -7854,8 +7854,8 @@ Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rad">
-   <b><a href="#rad">#rad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rad" class="dfn-panel" data-for="rad" id="infopanel-for-rad" role="dialog">
+   <span id="infopaneltitle-for-rad" style="display:none">Info about the 'rad' definition.</span><b><a href="#rad">#rad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rad">7.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
@@ -7863,15 +7863,15 @@ Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="turn">
-   <b><a href="#turn">#turn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-turn" class="dfn-panel" data-for="turn" id="infopanel-for-turn" role="dialog">
+   <span id="infopaneltitle-for-turn" style="display:none">Info about the 'turn' definition.</span><b><a href="#turn">#turn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-turn">7.1. 
 Angle Units: the &lt;angle> type and deg, grad, rad, turn units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="time-value">
-   <b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-time-value" class="dfn-panel" data-for="time-value" id="infopanel-for-time-value" role="dialog">
+   <span id="infopaneltitle-for-time-value" style="display:none">Info about the '&lt;time>' definition.</span><b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">5. 
 Numeric Data Types</a>
@@ -7891,15 +7891,15 @@ Mathematical Expressions</a>
 Type Checking</a> <a href="#ref-for-time-value①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="s">
-   <b><a href="#s">#s</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-s" class="dfn-panel" data-for="s" id="infopanel-for-s" role="dialog">
+   <span id="infopaneltitle-for-s" style="display:none">Info about the 's' definition.</span><b><a href="#s">#s</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-s">7.2. 
 Duration Units: the &lt;time> type and s, ms units</a> <a href="#ref-for-s①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ms">
-   <b><a href="#ms">#ms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ms" class="dfn-panel" data-for="ms" id="infopanel-for-ms" role="dialog">
+   <span id="infopaneltitle-for-ms" style="display:none">Info about the 'ms' definition.</span><b><a href="#ms">#ms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ms">7.2. 
 Duration Units: the &lt;time> type and s, ms units</a>
@@ -7907,8 +7907,8 @@ Duration Units: the &lt;time> type and s, ms units</a>
 Attribute References: the attr() function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frequency-value">
-   <b><a href="#frequency-value">#frequency-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frequency-value" class="dfn-panel" data-for="frequency-value" id="infopanel-for-frequency-value" role="dialog">
+   <span id="infopaneltitle-for-frequency-value" style="display:none">Info about the '&lt;frequency>' definition.</span><b><a href="#frequency-value">#frequency-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-value">5. 
 Numeric Data Types</a>
@@ -7928,22 +7928,22 @@ Mathematical Expressions</a>
 Type Checking</a> <a href="#ref-for-frequency-value①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Hz">
-   <b><a href="#Hz">#Hz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Hz" class="dfn-panel" data-for="Hz" id="infopanel-for-Hz" role="dialog">
+   <span id="infopaneltitle-for-Hz" style="display:none">Info about the 'Hz' definition.</span><b><a href="#Hz">#Hz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Hz">7.3. 
 Frequency Units: the &lt;frequency> type and Hz, kHz units</a> <a href="#ref-for-Hz①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="kHz">
-   <b><a href="#kHz">#kHz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-kHz" class="dfn-panel" data-for="kHz" id="infopanel-for-kHz" role="dialog">
+   <span id="infopaneltitle-for-kHz" style="display:none">Info about the 'kHz' definition.</span><b><a href="#kHz">#kHz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-kHz">7.3. 
 Frequency Units: the &lt;frequency> type and Hz, kHz units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolution-value">
-   <b><a href="#resolution-value">#resolution-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolution-value" class="dfn-panel" data-for="resolution-value" id="infopanel-for-resolution-value" role="dialog">
+   <span id="infopaneltitle-for-resolution-value" style="display:none">Info about the '&lt;resolution>' definition.</span><b><a href="#resolution-value">#resolution-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">5. 
 Numeric Data Types</a>
@@ -7957,36 +7957,36 @@ Mathematical Expressions</a>
 Type Checking</a> <a href="#ref-for-resolution-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dpi">
-   <b><a href="#dpi">#dpi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dpi" class="dfn-panel" data-for="dpi" id="infopanel-for-dpi" role="dialog">
+   <span id="infopaneltitle-for-dpi" style="display:none">Info about the 'dpi' definition.</span><b><a href="#dpi">#dpi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dpi">7.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dpcm">
-   <b><a href="#dpcm">#dpcm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dpcm" class="dfn-panel" data-for="dpcm" id="infopanel-for-dpcm" role="dialog">
+   <span id="infopaneltitle-for-dpcm" style="display:none">Info about the 'dpcm' definition.</span><b><a href="#dpcm">#dpcm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dpcm">7.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dppx">
-   <b><a href="#dppx">#dppx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dppx" class="dfn-panel" data-for="dppx" id="infopanel-for-dppx" role="dialog">
+   <span id="infopaneltitle-for-dppx" style="display:none">Info about the 'dppx' definition.</span><b><a href="#dppx">#dppx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dppx">7.4. 
 Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href="#ref-for-dppx①">(2)</a>
     <li><a href="#ref-for-dppx②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x">
-   <b><a href="#x">#x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x" class="dfn-panel" data-for="x" id="infopanel-for-x" role="dialog">
+   <span id="infopaneltitle-for-x" style="display:none">Info about the 'x' definition.</span><b><a href="#x">#x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-position">
-   <b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-position" class="dfn-panel" data-for="typedef-position" id="infopanel-for-typedef-position" role="dialog">
+   <span id="infopaneltitle-for-typedef-position" style="display:none">Info about the '&lt;position>' definition.</span><b><a href="#typedef-position">#typedef-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">8.3. 
 2D Positioning: the &lt;position> type</a> <a href="#ref-for-typedef-position①">(2)</a> <a href="#ref-for-typedef-position②">(3)</a> <a href="#ref-for-typedef-position③">(4)</a> <a href="#ref-for-typedef-position④">(5)</a> <a href="#ref-for-typedef-position⑤">(6)</a> <a href="#ref-for-typedef-position⑥">(7)</a>
@@ -7994,8 +7994,8 @@ Resolution Units: the &lt;resolution> type and dpi, dpcm, dppx units</a> <a href
 Combination of &lt;position></a> <a href="#ref-for-typedef-position⑧">(2)</a> <a href="#ref-for-typedef-position⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="functional-notation">
-   <b><a href="#functional-notation">#functional-notation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-functional-notation" class="dfn-panel" data-for="functional-notation" id="infopanel-for-functional-notation" role="dialog">
+   <span id="infopaneltitle-for-functional-notation" style="display:none">Info about the 'functional notation' definition.</span><b><a href="#functional-notation">#functional-notation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-notation">4.5. 
 Resource Locators: the &lt;url> type</a>
@@ -8005,23 +8005,23 @@ URL Modifiers</a>
 Functional Notations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-toggle">
-   <b><a href="#funcdef-toggle">#funcdef-toggle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-toggle" class="dfn-panel" data-for="funcdef-toggle" id="infopanel-for-funcdef-toggle" role="dialog">
+   <span id="infopaneltitle-for-funcdef-toggle" style="display:none">Info about the 'toggle()' definition.</span><b><a href="#funcdef-toggle">#funcdef-toggle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-toggle①">9.1. 
 Toggling Between Values: toggle()</a> <a href="#ref-for-funcdef-toggle②">(2)</a> <a href="#ref-for-funcdef-toggle③">(3)</a> <a href="#ref-for-funcdef-toggle④">(4)</a> <a href="#ref-for-funcdef-toggle⑤">(5)</a> <a href="#ref-for-funcdef-toggle⑥">(6)</a> <a href="#ref-for-funcdef-toggle⑦">(7)</a> <a href="#ref-for-funcdef-toggle⑧">(8)</a> <a href="#ref-for-funcdef-toggle⑨">(9)</a> <a href="#ref-for-funcdef-toggle①⓪">(10)</a> <a href="#ref-for-funcdef-toggle①①">(11)</a> <a href="#ref-for-funcdef-toggle①②">(12)</a> <a href="#ref-for-funcdef-toggle①③">(13)</a> <a href="#ref-for-funcdef-toggle①④">(14)</a> <a href="#ref-for-funcdef-toggle①⑤">(15)</a> <a href="#ref-for-funcdef-toggle①⑥">(16)</a>
     <li><a href="#ref-for-funcdef-toggle①⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-toggle-value">
-   <b><a href="#typedef-toggle-value">#typedef-toggle-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-toggle-value" class="dfn-panel" data-for="typedef-toggle-value" id="infopanel-for-typedef-toggle-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-toggle-value" style="display:none">Info about the '&lt;toggle-value>' definition.</span><b><a href="#typedef-toggle-value">#typedef-toggle-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-toggle-value">9.1. 
 Toggling Between Values: toggle()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-attr">
-   <b><a href="#funcdef-attr">#funcdef-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-attr" class="dfn-panel" data-for="funcdef-attr" id="infopanel-for-funcdef-attr" role="dialog">
+   <span id="infopaneltitle-for-funcdef-attr" style="display:none">Info about the 'attr()' definition.</span><b><a href="#funcdef-attr">#funcdef-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-attr①">9.1. 
 Toggling Between Values: toggle()</a>
@@ -8036,8 +8036,8 @@ Basic Arithmetic: calc()</a>
     <li><a href="#ref-for-funcdef-attr②②"> Changes Since the Jan 13 2019 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attr-type">
-   <b><a href="#typedef-attr-type">#typedef-attr-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attr-type" class="dfn-panel" data-for="typedef-attr-type" id="infopanel-for-typedef-attr-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-attr-type" style="display:none">Info about the '&lt;attr-type>' definition.</span><b><a href="#typedef-attr-type">#typedef-attr-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attr-type">10. 
 Attribute References: the attr() function</a> <a href="#ref-for-typedef-attr-type①">(2)</a> <a href="#ref-for-typedef-attr-type②">(3)</a>
@@ -8045,8 +8045,8 @@ Attribute References: the attr() function</a> <a href="#ref-for-typedef-attr-typ
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-dimension-unit">
-   <b><a href="#typedef-dimension-unit">#typedef-dimension-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-dimension-unit" class="dfn-panel" data-for="typedef-dimension-unit" id="infopanel-for-typedef-dimension-unit" role="dialog">
+   <span id="infopaneltitle-for-typedef-dimension-unit" style="display:none">Info about the '&lt;dimension-unit>' definition.</span><b><a href="#typedef-dimension-unit">#typedef-dimension-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-unit">10. 
 Attribute References: the attr() function</a>
@@ -8054,8 +8054,8 @@ Attribute References: the attr() function</a>
 attr() Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr-substitution-value">
-   <b><a href="#attr-substitution-value">#attr-substitution-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr-substitution-value" class="dfn-panel" data-for="attr-substitution-value" id="infopanel-for-attr-substitution-value" role="dialog">
+   <span id="infopaneltitle-for-attr-substitution-value" style="display:none">Info about the 'substitution value' definition.</span><b><a href="#attr-substitution-value">#attr-substitution-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-substitution-value">10.1. 
 attr() Types</a> <a href="#ref-for-attr-substitution-value①">(2)</a> <a href="#ref-for-attr-substitution-value②">(3)</a> <a href="#ref-for-attr-substitution-value③">(4)</a> <a href="#ref-for-attr-substitution-value④">(5)</a> <a href="#ref-for-attr-substitution-value⑤">(6)</a> <a href="#ref-for-attr-substitution-value⑥">(7)</a> <a href="#ref-for-attr-substitution-value⑦">(8)</a> <a href="#ref-for-attr-substitution-value⑧">(9)</a> <a href="#ref-for-attr-substitution-value⑨">(10)</a> <a href="#ref-for-attr-substitution-value①⓪">(11)</a> <a href="#ref-for-attr-substitution-value①①">(12)</a> <a href="#ref-for-attr-substitution-value①②">(13)</a> <a href="#ref-for-attr-substitution-value①③">(14)</a> <a href="#ref-for-attr-substitution-value①④">(15)</a>
@@ -8063,15 +8063,15 @@ attr() Types</a> <a href="#ref-for-attr-substitution-value①">(2)</a> <a href="
 attr() Substitution</a> <a href="#ref-for-attr-substitution-value①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-attr-string">
-   <b><a href="#valdef-attr-string">#valdef-attr-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-attr-string" class="dfn-panel" data-for="valdef-attr-string" id="infopanel-for-valdef-attr-string" role="dialog">
+   <span id="infopaneltitle-for-valdef-attr-string" style="display:none">Info about the 'string' definition.</span><b><a href="#valdef-attr-string">#valdef-attr-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-attr-string">10. 
 Attribute References: the attr() function</a> <a href="#ref-for-valdef-attr-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="substitute-an-attr">
-   <b><a href="#substitute-an-attr">#substitute-an-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-substitute-an-attr" class="dfn-panel" data-for="substitute-an-attr" id="infopanel-for-substitute-an-attr" role="dialog">
+   <span id="infopaneltitle-for-substitute-an-attr" style="display:none">Info about the 'substitute an attr()' definition.</span><b><a href="#substitute-an-attr">#substitute-an-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-substitute-an-attr">10. 
 Attribute References: the attr() function</a>
@@ -8079,8 +8079,8 @@ Attribute References: the attr() function</a>
 attr() Substitution</a> <a href="#ref-for-substitute-an-attr②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="math-function">
-   <b><a href="#math-function">#math-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-math-function" class="dfn-panel" data-for="math-function" id="infopanel-for-math-function" role="dialog">
+   <span id="infopaneltitle-for-math-function" style="display:none">Info about the 'math functions' definition.</span><b><a href="#math-function">#math-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-math-function">3.1. 
 Range Checking</a>
@@ -8120,8 +8120,8 @@ Combination of Math Functions</a> <a href="#ref-for-math-function④⑧">(2)</a>
     <li><a href="#ref-for-math-function⑤⓪"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-calc">
-   <b><a href="#funcdef-calc">#funcdef-calc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-calc" class="dfn-panel" data-for="funcdef-calc" id="infopanel-for-funcdef-calc" role="dialog">
+   <span id="infopaneltitle-for-funcdef-calc" style="display:none">Info about the 'calc()' definition.</span><b><a href="#funcdef-calc">#funcdef-calc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">5.6. 
 Mixing Percentages and Dimensions</a> <a href="#ref-for-funcdef-calc①">(2)</a> <a href="#ref-for-funcdef-calc②">(3)</a>
@@ -8151,8 +8151,8 @@ Serialization</a> <a href="#ref-for-funcdef-calc②①">(2)</a>
     <li><a href="#ref-for-funcdef-calc②③"> Additions Since Level 3</a> <a href="#ref-for-funcdef-calc②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calc-calculation">
-   <b><a href="#calc-calculation">#calc-calculation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calc-calculation" class="dfn-panel" data-for="calc-calculation" id="infopanel-for-calc-calculation" role="dialog">
+   <span id="infopaneltitle-for-calc-calculation" style="display:none">Info about the 'calculation' definition.</span><b><a href="#calc-calculation">#calc-calculation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calc-calculation">11.1. 
 Basic Arithmetic: calc()</a> <a href="#ref-for-calc-calculation①">(2)</a>
@@ -8180,8 +8180,8 @@ Internal Representation</a> <a href="#ref-for-calc-calculation③⑥">(2)</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-min">
-   <b><a href="#funcdef-min">#funcdef-min</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-min" class="dfn-panel" data-for="funcdef-min" id="infopanel-for-funcdef-min" role="dialog">
+   <span id="infopaneltitle-for-funcdef-min" style="display:none">Info about the 'min()' definition.</span><b><a href="#funcdef-min">#funcdef-min</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-min">11.2. 
 Comparison Functions: min(), max(), and clamp()</a> <a href="#ref-for-funcdef-min①">(2)</a> <a href="#ref-for-funcdef-min②">(3)</a> <a href="#ref-for-funcdef-min③">(4)</a> <a href="#ref-for-funcdef-min④">(5)</a> <a href="#ref-for-funcdef-min⑤">(6)</a> <a href="#ref-for-funcdef-min⑥">(7)</a>
@@ -8192,8 +8192,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-min⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-max">
-   <b><a href="#funcdef-max">#funcdef-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-max" class="dfn-panel" data-for="funcdef-max" id="infopanel-for-funcdef-max" role="dialog">
+   <span id="infopaneltitle-for-funcdef-max" style="display:none">Info about the 'max()' definition.</span><b><a href="#funcdef-max">#funcdef-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-max">11.2. 
 Comparison Functions: min(), max(), and clamp()</a> <a href="#ref-for-funcdef-max①">(2)</a> <a href="#ref-for-funcdef-max②">(3)</a> <a href="#ref-for-funcdef-max③">(4)</a> <a href="#ref-for-funcdef-max④">(5)</a> <a href="#ref-for-funcdef-max⑤">(6)</a> <a href="#ref-for-funcdef-max⑥">(7)</a>
@@ -8204,8 +8204,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-max⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-clamp">
-   <b><a href="#funcdef-clamp">#funcdef-clamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-clamp" class="dfn-panel" data-for="funcdef-clamp" id="infopanel-for-funcdef-clamp" role="dialog">
+   <span id="infopaneltitle-for-funcdef-clamp" style="display:none">Info about the 'clamp()' definition.</span><b><a href="#funcdef-clamp">#funcdef-clamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-clamp">11. 
 Mathematical Expressions</a>
@@ -8218,8 +8218,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-clamp①⓪"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-round">
-   <b><a href="#funcdef-round">#funcdef-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-round" class="dfn-panel" data-for="funcdef-round" id="infopanel-for-funcdef-round" role="dialog">
+   <span id="infopaneltitle-for-funcdef-round" style="display:none">Info about the 'round(&lt;rounding-strategy>?, A, B)' definition.</span><b><a href="#funcdef-round">#funcdef-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-round">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-funcdef-round①">(2)</a> <a href="#ref-for-funcdef-round②">(3)</a>
@@ -8231,8 +8231,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-round⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-rounding-strategy">
-   <b><a href="#typedef-rounding-strategy">#typedef-rounding-strategy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-rounding-strategy" class="dfn-panel" data-for="typedef-rounding-strategy" id="infopanel-for-typedef-rounding-strategy" role="dialog">
+   <span id="infopaneltitle-for-typedef-rounding-strategy" style="display:none">Info about the '&lt;rounding-strategy>' definition.</span><b><a href="#typedef-rounding-strategy">#typedef-rounding-strategy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-rounding-strategy">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-typedef-rounding-strategy①">(2)</a> <a href="#ref-for-typedef-rounding-strategy②">(3)</a> <a href="#ref-for-typedef-rounding-strategy③">(4)</a>
@@ -8242,8 +8242,8 @@ Argument Ranges</a>
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-rounding-strategy-nearest">
-   <b><a href="#valdef-rounding-strategy-nearest">#valdef-rounding-strategy-nearest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-rounding-strategy-nearest" class="dfn-panel" data-for="valdef-rounding-strategy-nearest" id="infopanel-for-valdef-rounding-strategy-nearest" role="dialog">
+   <span id="infopaneltitle-for-valdef-rounding-strategy-nearest" style="display:none">Info about the 'nearest' definition.</span><b><a href="#valdef-rounding-strategy-nearest">#valdef-rounding-strategy-nearest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rounding-strategy-nearest">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a>
@@ -8251,15 +8251,15 @@ Stepped Value Functions: round(), mod(), and rem()</a>
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-rounding-strategy-up">
-   <b><a href="#valdef-rounding-strategy-up">#valdef-rounding-strategy-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-rounding-strategy-up" class="dfn-panel" data-for="valdef-rounding-strategy-up" id="infopanel-for-valdef-rounding-strategy-up" role="dialog">
+   <span id="infopaneltitle-for-valdef-rounding-strategy-up" style="display:none">Info about the 'up' definition.</span><b><a href="#valdef-rounding-strategy-up">#valdef-rounding-strategy-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rounding-strategy-up">11.3.1. 
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-rounding-strategy-down">
-   <b><a href="#valdef-rounding-strategy-down">#valdef-rounding-strategy-down</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-rounding-strategy-down" class="dfn-panel" data-for="valdef-rounding-strategy-down" id="infopanel-for-valdef-rounding-strategy-down" role="dialog">
+   <span id="infopaneltitle-for-valdef-rounding-strategy-down" style="display:none">Info about the 'down' definition.</span><b><a href="#valdef-rounding-strategy-down">#valdef-rounding-strategy-down</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rounding-strategy-down">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a>
@@ -8267,8 +8267,8 @@ Stepped Value Functions: round(), mod(), and rem()</a>
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-rounding-strategy-to-zero">
-   <b><a href="#valdef-rounding-strategy-to-zero">#valdef-rounding-strategy-to-zero</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-rounding-strategy-to-zero" class="dfn-panel" data-for="valdef-rounding-strategy-to-zero" id="infopanel-for-valdef-rounding-strategy-to-zero" role="dialog">
+   <span id="infopaneltitle-for-valdef-rounding-strategy-to-zero" style="display:none">Info about the 'to-zero' definition.</span><b><a href="#valdef-rounding-strategy-to-zero">#valdef-rounding-strategy-to-zero</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rounding-strategy-to-zero">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-valdef-rounding-strategy-to-zero①">(2)</a>
@@ -8276,8 +8276,8 @@ Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-valdef-
 Argument Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-mod">
-   <b><a href="#funcdef-mod">#funcdef-mod</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-mod" class="dfn-panel" data-for="funcdef-mod" id="infopanel-for-funcdef-mod" role="dialog">
+   <span id="infopaneltitle-for-funcdef-mod" style="display:none">Info about the 'mod(A, B)' definition.</span><b><a href="#funcdef-mod">#funcdef-mod</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-mod">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-funcdef-mod①">(2)</a> <a href="#ref-for-funcdef-mod②">(3)</a> <a href="#ref-for-funcdef-mod③">(4)</a> <a href="#ref-for-funcdef-mod④">(5)</a> <a href="#ref-for-funcdef-mod⑤">(6)</a>
@@ -8289,8 +8289,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-mod⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-rem">
-   <b><a href="#funcdef-rem">#funcdef-rem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-rem" class="dfn-panel" data-for="funcdef-rem" id="infopanel-for-funcdef-rem" role="dialog">
+   <span id="infopaneltitle-for-funcdef-rem" style="display:none">Info about the 'rem(A, B)' definition.</span><b><a href="#funcdef-rem">#funcdef-rem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-rem">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-funcdef-rem①">(2)</a> <a href="#ref-for-funcdef-rem②">(3)</a> <a href="#ref-for-funcdef-rem③">(4)</a> <a href="#ref-for-funcdef-rem④">(5)</a> <a href="#ref-for-funcdef-rem⑤">(6)</a> <a href="#ref-for-funcdef-rem⑥">(7)</a> <a href="#ref-for-funcdef-rem⑦">(8)</a> <a href="#ref-for-funcdef-rem⑧">(9)</a>
@@ -8302,15 +8302,15 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-rem①②"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="between-zero-and-b">
-   <b><a href="#between-zero-and-b">#between-zero-and-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-between-zero-and-b" class="dfn-panel" data-for="between-zero-and-b" id="infopanel-for-between-zero-and-b" role="dialog">
+   <span id="infopaneltitle-for-between-zero-and-b" style="display:none">Info about the 'between zero and B' definition.</span><b><a href="#between-zero-and-b">#between-zero-and-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-between-zero-and-b">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-between-zero-and-b①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-sin">
-   <b><a href="#funcdef-sin">#funcdef-sin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-sin" class="dfn-panel" data-for="funcdef-sin" id="infopanel-for-funcdef-sin" role="dialog">
+   <span id="infopaneltitle-for-funcdef-sin" style="display:none">Info about the 'sin(A)' definition.</span><b><a href="#funcdef-sin">#funcdef-sin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-sin">11. 
 Mathematical Expressions</a>
@@ -8324,8 +8324,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-sin⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-cos">
-   <b><a href="#funcdef-cos">#funcdef-cos</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-cos" class="dfn-panel" data-for="funcdef-cos" id="infopanel-for-funcdef-cos" role="dialog">
+   <span id="infopaneltitle-for-funcdef-cos" style="display:none">Info about the 'cos(A)' definition.</span><b><a href="#funcdef-cos">#funcdef-cos</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-cos">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-cos①">(2)</a> <a href="#ref-for-funcdef-cos②">(3)</a>
@@ -8337,8 +8337,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-cos⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-tan">
-   <b><a href="#funcdef-tan">#funcdef-tan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-tan" class="dfn-panel" data-for="funcdef-tan" id="infopanel-for-funcdef-tan" role="dialog">
+   <span id="infopaneltitle-for-funcdef-tan" style="display:none">Info about the 'tan(A)' definition.</span><b><a href="#funcdef-tan">#funcdef-tan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-tan">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-tan①">(2)</a> <a href="#ref-for-funcdef-tan②">(3)</a>
@@ -8350,8 +8350,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-tan⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-asin">
-   <b><a href="#funcdef-asin">#funcdef-asin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-asin" class="dfn-panel" data-for="funcdef-asin" id="infopanel-for-funcdef-asin" role="dialog">
+   <span id="infopaneltitle-for-funcdef-asin" style="display:none">Info about the 'asin(A)' definition.</span><b><a href="#funcdef-asin">#funcdef-asin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-asin">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-asin①">(2)</a> <a href="#ref-for-funcdef-asin②">(3)</a>
@@ -8363,8 +8363,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-asin⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-acos">
-   <b><a href="#funcdef-acos">#funcdef-acos</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-acos" class="dfn-panel" data-for="funcdef-acos" id="infopanel-for-funcdef-acos" role="dialog">
+   <span id="infopaneltitle-for-funcdef-acos" style="display:none">Info about the 'acos(A)' definition.</span><b><a href="#funcdef-acos">#funcdef-acos</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-acos">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-acos①">(2)</a> <a href="#ref-for-funcdef-acos②">(3)</a>
@@ -8376,8 +8376,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-acos⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-atan">
-   <b><a href="#funcdef-atan">#funcdef-atan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-atan" class="dfn-panel" data-for="funcdef-atan" id="infopanel-for-funcdef-atan" role="dialog">
+   <span id="infopaneltitle-for-funcdef-atan" style="display:none">Info about the 'atan(A)' definition.</span><b><a href="#funcdef-atan">#funcdef-atan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-atan">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-atan①">(2)</a> <a href="#ref-for-funcdef-atan②">(3)</a>
@@ -8389,8 +8389,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-atan⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-atan2">
-   <b><a href="#funcdef-atan2">#funcdef-atan2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-atan2" class="dfn-panel" data-for="funcdef-atan2" id="infopanel-for-funcdef-atan2" role="dialog">
+   <span id="infopaneltitle-for-funcdef-atan2" style="display:none">Info about the 'atan2(A, B)' definition.</span><b><a href="#funcdef-atan2">#funcdef-atan2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-atan2">11.4. 
 Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2()</a> <a href="#ref-for-funcdef-atan2①">(2)</a>
@@ -8402,8 +8402,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-atan2⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-pow">
-   <b><a href="#funcdef-pow">#funcdef-pow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-pow" class="dfn-panel" data-for="funcdef-pow" id="infopanel-for-funcdef-pow" role="dialog">
+   <span id="infopaneltitle-for-funcdef-pow" style="display:none">Info about the 'pow(A, B)' definition.</span><b><a href="#funcdef-pow">#funcdef-pow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-pow">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-funcdef-pow①">(2)</a> <a href="#ref-for-funcdef-pow②">(3)</a> <a href="#ref-for-funcdef-pow③">(4)</a>
@@ -8415,8 +8415,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-pow⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-sqrt">
-   <b><a href="#funcdef-sqrt">#funcdef-sqrt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-sqrt" class="dfn-panel" data-for="funcdef-sqrt" id="infopanel-for-funcdef-sqrt" role="dialog">
+   <span id="infopaneltitle-for-funcdef-sqrt" style="display:none">Info about the 'sqrt(A)' definition.</span><b><a href="#funcdef-sqrt">#funcdef-sqrt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-sqrt">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-funcdef-sqrt①">(2)</a> <a href="#ref-for-funcdef-sqrt②">(3)</a> <a href="#ref-for-funcdef-sqrt③">(4)</a>
@@ -8428,8 +8428,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-sqrt⑦"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-hypot">
-   <b><a href="#funcdef-hypot">#funcdef-hypot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-hypot" class="dfn-panel" data-for="funcdef-hypot" id="infopanel-for-funcdef-hypot" role="dialog">
+   <span id="infopaneltitle-for-funcdef-hypot" style="display:none">Info about the 'hypot(A, …)' definition.</span><b><a href="#funcdef-hypot">#funcdef-hypot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-hypot">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-funcdef-hypot①">(2)</a> <a href="#ref-for-funcdef-hypot②">(3)</a> <a href="#ref-for-funcdef-hypot③">(4)</a> <a href="#ref-for-funcdef-hypot④">(5)</a> <a href="#ref-for-funcdef-hypot⑤">(6)</a>
@@ -8441,8 +8441,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-hypot⑨"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-log">
-   <b><a href="#funcdef-log">#funcdef-log</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-log" class="dfn-panel" data-for="funcdef-log" id="infopanel-for-funcdef-log" role="dialog">
+   <span id="infopaneltitle-for-funcdef-log" style="display:none">Info about the 'log(A, B?)' definition.</span><b><a href="#funcdef-log">#funcdef-log</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-log">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-funcdef-log①">(2)</a> <a href="#ref-for-funcdef-log②">(3)</a>
@@ -8454,8 +8454,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-log⑥"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-exp">
-   <b><a href="#funcdef-exp">#funcdef-exp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-exp" class="dfn-panel" data-for="funcdef-exp" id="infopanel-for-funcdef-exp" role="dialog">
+   <span id="infopaneltitle-for-funcdef-exp" style="display:none">Info about the 'exp(A)' definition.</span><b><a href="#funcdef-exp">#funcdef-exp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-exp">11.5. 
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a> <a href="#ref-for-funcdef-exp①">(2)</a>
@@ -8467,8 +8467,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-exp⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-abs">
-   <b><a href="#funcdef-abs">#funcdef-abs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-abs" class="dfn-panel" data-for="funcdef-abs" id="infopanel-for-funcdef-abs" role="dialog">
+   <span id="infopaneltitle-for-funcdef-abs" style="display:none">Info about the 'abs(A)' definition.</span><b><a href="#funcdef-abs">#funcdef-abs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-abs">11.6. 
 Sign-Related Functions: abs(), sign()</a> <a href="#ref-for-funcdef-abs①">(2)</a>
@@ -8480,8 +8480,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-abs⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-sign">
-   <b><a href="#funcdef-sign">#funcdef-sign</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-sign" class="dfn-panel" data-for="funcdef-sign" id="infopanel-for-funcdef-sign" role="dialog">
+   <span id="infopaneltitle-for-funcdef-sign" style="display:none">Info about the 'sign(A)' definition.</span><b><a href="#funcdef-sign">#funcdef-sign</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-sign">11.6. 
 Sign-Related Functions: abs(), sign()</a> <a href="#ref-for-funcdef-sign①">(2)</a>
@@ -8493,8 +8493,8 @@ Type Checking</a>
     <li><a href="#ref-for-funcdef-sign⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-calc-e">
-   <b><a href="#valdef-calc-e">#valdef-calc-e</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-calc-e" class="dfn-panel" data-for="valdef-calc-e" id="infopanel-for-valdef-calc-e" role="dialog">
+   <span id="infopaneltitle-for-valdef-calc-e" style="display:none">Info about the 'e' definition.</span><b><a href="#valdef-calc-e">#valdef-calc-e</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-e">11.7. 
 Numeric Constants: e, pi</a>
@@ -8504,8 +8504,8 @@ Degenerate Numeric Constants: infinity, -infinity, NaN</a>
     <li><a href="#ref-for-valdef-calc-e③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-calc-pi">
-   <b><a href="#valdef-calc-pi">#valdef-calc-pi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-calc-pi" class="dfn-panel" data-for="valdef-calc-pi" id="infopanel-for-valdef-calc-pi" role="dialog">
+   <span id="infopaneltitle-for-valdef-calc-pi" style="display:none">Info about the 'pi' definition.</span><b><a href="#valdef-calc-pi">#valdef-calc-pi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-pi">11.7. 
 Numeric Constants: e, pi</a>
@@ -8515,8 +8515,8 @@ Degenerate Numeric Constants: infinity, -infinity, NaN</a>
     <li><a href="#ref-for-valdef-calc-pi③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-calc-infinity">
-   <b><a href="#valdef-calc-infinity">#valdef-calc-infinity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-calc-infinity" class="dfn-panel" data-for="valdef-calc-infinity" id="infopanel-for-valdef-calc-infinity" role="dialog">
+   <span id="infopaneltitle-for-valdef-calc-infinity" style="display:none">Info about the 'infinity' definition.</span><b><a href="#valdef-calc-infinity">#valdef-calc-infinity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-infinity">11.7.1. 
 Degenerate Numeric Constants: infinity, -infinity, NaN</a> <a href="#ref-for-valdef-calc-infinity①">(2)</a>
@@ -8528,8 +8528,8 @@ Serialization</a>
     <li><a href="#ref-for-valdef-calc-infinity⑤"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-calc--infinity">
-   <b><a href="#valdef-calc--infinity">#valdef-calc--infinity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-calc--infinity" class="dfn-panel" data-for="valdef-calc--infinity" id="infopanel-for-valdef-calc--infinity" role="dialog">
+   <span id="infopaneltitle-for-valdef-calc--infinity" style="display:none">Info about the '-infinity' definition.</span><b><a href="#valdef-calc--infinity">#valdef-calc--infinity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc--infinity">11.7.1. 
 Degenerate Numeric Constants: infinity, -infinity, NaN</a>
@@ -8539,8 +8539,8 @@ Serialization</a>
     <li><a href="#ref-for-valdef-calc--infinity③"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-calc-nan">
-   <b><a href="#valdef-calc-nan">#valdef-calc-nan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-calc-nan" class="dfn-panel" data-for="valdef-calc-nan" id="infopanel-for-valdef-calc-nan" role="dialog">
+   <span id="infopaneltitle-for-valdef-calc-nan" style="display:none">Info about the 'NaN' definition.</span><b><a href="#valdef-calc-nan">#valdef-calc-nan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-nan">11.7.1. 
 Degenerate Numeric Constants: infinity, -infinity, NaN</a> <a href="#ref-for-valdef-calc-nan①">(2)</a>
@@ -8550,8 +8550,8 @@ Serialization</a>
     <li><a href="#ref-for-valdef-calc-nan④"> Additions Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-sum">
-   <b><a href="#typedef-calc-sum">#typedef-calc-sum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-sum" class="dfn-panel" data-for="typedef-calc-sum" id="infopanel-for-typedef-calc-sum" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-sum" style="display:none">Info about the '&lt;calc-sum>' definition.</span><b><a href="#typedef-calc-sum">#typedef-calc-sum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-sum">11.1. 
 Basic Arithmetic: calc()</a>
@@ -8559,22 +8559,22 @@ Basic Arithmetic: calc()</a>
 Syntax</a> <a href="#ref-for-typedef-calc-sum②">(2)</a> <a href="#ref-for-typedef-calc-sum③">(3)</a> <a href="#ref-for-typedef-calc-sum④">(4)</a> <a href="#ref-for-typedef-calc-sum⑤">(5)</a> <a href="#ref-for-typedef-calc-sum⑥">(6)</a> <a href="#ref-for-typedef-calc-sum⑦">(7)</a> <a href="#ref-for-typedef-calc-sum⑧">(8)</a> <a href="#ref-for-typedef-calc-sum⑨">(9)</a> <a href="#ref-for-typedef-calc-sum①⓪">(10)</a> <a href="#ref-for-typedef-calc-sum①①">(11)</a> <a href="#ref-for-typedef-calc-sum①②">(12)</a> <a href="#ref-for-typedef-calc-sum①③">(13)</a> <a href="#ref-for-typedef-calc-sum①④">(14)</a> <a href="#ref-for-typedef-calc-sum①⑤">(15)</a> <a href="#ref-for-typedef-calc-sum①⑥">(16)</a> <a href="#ref-for-typedef-calc-sum①⑦">(17)</a> <a href="#ref-for-typedef-calc-sum①⑧">(18)</a> <a href="#ref-for-typedef-calc-sum①⑨">(19)</a> <a href="#ref-for-typedef-calc-sum②⓪">(20)</a> <a href="#ref-for-typedef-calc-sum②①">(21)</a> <a href="#ref-for-typedef-calc-sum②②">(22)</a> <a href="#ref-for-typedef-calc-sum②③">(23)</a> <a href="#ref-for-typedef-calc-sum②④">(24)</a> <a href="#ref-for-typedef-calc-sum②⑤">(25)</a> <a href="#ref-for-typedef-calc-sum②⑥">(26)</a> <a href="#ref-for-typedef-calc-sum②⑦">(27)</a> <a href="#ref-for-typedef-calc-sum②⑧">(28)</a> <a href="#ref-for-typedef-calc-sum②⑨">(29)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-product">
-   <b><a href="#typedef-calc-product">#typedef-calc-product</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-product" class="dfn-panel" data-for="typedef-calc-product" id="infopanel-for-typedef-calc-product" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-product" style="display:none">Info about the '&lt;calc-product>' definition.</span><b><a href="#typedef-calc-product">#typedef-calc-product</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-product">11.8. 
 Syntax</a> <a href="#ref-for-typedef-calc-product①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-value">
-   <b><a href="#typedef-calc-value">#typedef-calc-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-value" class="dfn-panel" data-for="typedef-calc-value" id="infopanel-for-typedef-calc-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-value" style="display:none">Info about the '&lt;calc-value>' definition.</span><b><a href="#typedef-calc-value">#typedef-calc-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-value">11.8. 
 Syntax</a> <a href="#ref-for-typedef-calc-value①">(2)</a> <a href="#ref-for-typedef-calc-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-calc-constant">
-   <b><a href="#typedef-calc-constant">#typedef-calc-constant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-calc-constant" class="dfn-panel" data-for="typedef-calc-constant" id="infopanel-for-typedef-calc-constant" role="dialog">
+   <span id="infopaneltitle-for-typedef-calc-constant" style="display:none">Info about the '&lt;calc-constant>' definition.</span><b><a href="#typedef-calc-constant">#typedef-calc-constant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-calc-constant">11.8. 
 Syntax</a>
@@ -8584,8 +8584,8 @@ Type Checking</a>
 Simplification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-type-of-a-calculation">
-   <b><a href="#determine-the-type-of-a-calculation">#determine-the-type-of-a-calculation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-type-of-a-calculation" class="dfn-panel" data-for="determine-the-type-of-a-calculation" id="infopanel-for-determine-the-type-of-a-calculation" role="dialog">
+   <span id="infopaneltitle-for-determine-the-type-of-a-calculation" style="display:none">Info about the 'determine the type of a calculation' definition.</span><b><a href="#determine-the-type-of-a-calculation">#determine-the-type-of-a-calculation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-type-of-a-calculation">11.3. 
 Stepped Value Functions: round(), mod(), and rem()</a> <a href="#ref-for-determine-the-type-of-a-calculation①">(2)</a>
@@ -8595,15 +8595,15 @@ Trigonometric Functions: sin(), cos(), tan(), asin(), acos(), atan(), and atan2(
 Exponential  Functions: pow(), sqrt(), hypot(), log(), exp()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="top-level-calculation">
-   <b><a href="#top-level-calculation">#top-level-calculation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-top-level-calculation" class="dfn-panel" data-for="top-level-calculation" id="infopanel-for-top-level-calculation" role="dialog">
+   <span id="infopaneltitle-for-top-level-calculation" style="display:none">Info about the 'top-level calculation' definition.</span><b><a href="#top-level-calculation">#top-level-calculation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-calculation">11.9. 
 Type Checking</a> <a href="#ref-for-top-level-calculation①">(2)</a> <a href="#ref-for-top-level-calculation②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculation-tree">
-   <b><a href="#calculation-tree">#calculation-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculation-tree" class="dfn-panel" data-for="calculation-tree" id="infopanel-for-calculation-tree" role="dialog">
+   <span id="infopaneltitle-for-calculation-tree" style="display:none">Info about the 'calculation tree' definition.</span><b><a href="#calculation-tree">#calculation-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculation-tree">11.10. 
 Internal Representation</a> <a href="#ref-for-calculation-tree①">(2)</a>
@@ -8613,8 +8613,8 @@ Computed Value</a> <a href="#ref-for-calculation-tree③">(2)</a>
 Serialization</a> <a href="#ref-for-calculation-tree⑤">(2)</a> <a href="#ref-for-calculation-tree⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculation-tree-operator-nodes">
-   <b><a href="#calculation-tree-operator-nodes">#calculation-tree-operator-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculation-tree-operator-nodes" class="dfn-panel" data-for="calculation-tree-operator-nodes" id="infopanel-for-calculation-tree-operator-nodes" role="dialog">
+   <span id="infopaneltitle-for-calculation-tree-operator-nodes" style="display:none">Info about the 'operator nodes' definition.</span><b><a href="#calculation-tree-operator-nodes">#calculation-tree-operator-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculation-tree-operator-nodes">11.10. 
 Internal Representation</a>
@@ -8622,8 +8622,8 @@ Internal Representation</a>
 Simplification</a> <a href="#ref-for-calculation-tree-operator-nodes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculation-tree-calc-operator-nodes">
-   <b><a href="#calculation-tree-calc-operator-nodes">#calculation-tree-calc-operator-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculation-tree-calc-operator-nodes" class="dfn-panel" data-for="calculation-tree-calc-operator-nodes" id="infopanel-for-calculation-tree-calc-operator-nodes" role="dialog">
+   <span id="infopaneltitle-for-calculation-tree-calc-operator-nodes" style="display:none">Info about the 'calc-operator nodes' definition.</span><b><a href="#calculation-tree-calc-operator-nodes">#calculation-tree-calc-operator-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculation-tree-calc-operator-nodes">11.10.1. 
 Simplification</a>
@@ -8631,15 +8631,15 @@ Simplification</a>
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-calculation">
-   <b><a href="#parse-a-calculation">#parse-a-calculation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-calculation" class="dfn-panel" data-for="parse-a-calculation" id="infopanel-for-parse-a-calculation" role="dialog">
+   <span id="infopaneltitle-for-parse-a-calculation" style="display:none">Info about the 'parse a calculation' definition.</span><b><a href="#parse-a-calculation">#parse-a-calculation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-calculation">11.10. 
 Internal Representation</a> <a href="#ref-for-parse-a-calculation①">(2)</a> <a href="#ref-for-parse-a-calculation②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simplify-a-calculation-tree">
-   <b><a href="#simplify-a-calculation-tree">#simplify-a-calculation-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simplify-a-calculation-tree" class="dfn-panel" data-for="simplify-a-calculation-tree" id="infopanel-for-simplify-a-calculation-tree" role="dialog">
+   <span id="infopaneltitle-for-simplify-a-calculation-tree" style="display:none">Info about the 'simplify a calculation tree' definition.</span><b><a href="#simplify-a-calculation-tree">#simplify-a-calculation-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simplify-a-calculation-tree">11.10. 
 Internal Representation</a>
@@ -8651,22 +8651,22 @@ Computed Value</a>
 Combination of Math Functions</a> <a href="#ref-for-simplify-a-calculation-tree④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-math-function">
-   <b><a href="#serialize-a-math-function">#serialize-a-math-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-math-function" class="dfn-panel" data-for="serialize-a-math-function" id="infopanel-for-serialize-a-math-function" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-math-function" style="display:none">Info about the 'serialize a math function' definition.</span><b><a href="#serialize-a-math-function">#serialize-a-math-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-math-function">11.13. 
 Serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-calculation-tree">
-   <b><a href="#serialize-a-calculation-tree">#serialize-a-calculation-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-calculation-tree" class="dfn-panel" data-for="serialize-a-calculation-tree" id="infopanel-for-serialize-a-calculation-tree" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-calculation-tree" style="display:none">Info about the 'serialize a calculation tree' definition.</span><b><a href="#serialize-a-calculation-tree">#serialize-a-calculation-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-calculation-tree">11.13. 
 Serialization</a> <a href="#ref-for-serialize-a-calculation-tree①">(2)</a> <a href="#ref-for-serialize-a-calculation-tree②">(3)</a> <a href="#ref-for-serialize-a-calculation-tree③">(4)</a> <a href="#ref-for-serialize-a-calculation-tree④">(5)</a> <a href="#ref-for-serialize-a-calculation-tree⑤">(6)</a> <a href="#ref-for-serialize-a-calculation-tree⑥">(7)</a> <a href="#ref-for-serialize-a-calculation-tree⑦">(8)</a> <a href="#ref-for-serialize-a-calculation-tree⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sort-a-calculations-children">
-   <b><a href="#sort-a-calculations-children">#sort-a-calculations-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sort-a-calculations-children" class="dfn-panel" data-for="sort-a-calculations-children" id="infopanel-for-sort-a-calculations-children" role="dialog">
+   <span id="infopaneltitle-for-sort-a-calculations-children" style="display:none">Info about the 'sort a calculation’s children' definition.</span><b><a href="#sort-a-calculations-children">#sort-a-calculations-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sort-a-calculations-children">11.13. 
 Serialization</a> <a href="#ref-for-sort-a-calculations-children①">(2)</a>
@@ -8674,59 +8674,115 @@ Serialization</a> <a href="#ref-for-sort-a-calculations-children①">(2)</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-variables-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-variables-1/Overview.html
@@ -1778,22 +1778,22 @@ and mandates a defense against that attack.</p>
    <li><a href="#funcdef-var">var()</a><span>, in § 3</span>
    <li><a href="#substitute-a-var">var() substitution</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-keyframes">
-   <a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-keyframes" class="dfn-panel" data-for="term-for-at-ruledef-keyframes" id="infopanel-for-term-for-at-ruledef-keyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">2. 
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">2. 
 Defining Custom Properties: the --* family of properties</a>
@@ -1803,141 +1803,141 @@ Using Cascading Variables: the var() notation</a> <a href="#ref-for-propdef-back
 Invalid Variables</a> <a href="#ref-for-propdef-background-color④">(2)</a> <a href="#ref-for-propdef-background-color⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">3. 
 Using Cascading Variables: the var() notation</a> <a href="#ref-for-propdef-margin-top①">(2)</a> <a href="#ref-for-propdef-margin-top②">(3)</a> <a href="#ref-for-propdef-margin-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">2. 
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">2.2. 
 Guaranteed-Invalid Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-longhand">
-   <a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-longhand" class="dfn-panel" data-for="term-for-longhand" id="infopanel-for-term-for-longhand" role="menu">
+   <span id="infopaneltitle-for-term-for-longhand" style="display:none">Info about the 'longhand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#longhand">https://drafts.csswg.org/css-cascade-5/#longhand</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-longhand">3.2. 
 Variables in Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand property' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#shorthand-property">https://drafts.csswg.org/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3.2. 
 Variables in Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-unset">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-unset" class="dfn-panel" data-for="term-for-valdef-all-unset" id="infopanel-for-term-for-valdef-all-unset" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-unset" style="display:none">Info about the 'unset' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">3.1. 
 Invalid Variables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">3.2. 
 Variables in Shorthand Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">2. 
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-contents">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-contents" class="dfn-panel" data-for="term-for-valdef-display-contents" id="infopanel-for-term-for-valdef-display-contents" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-contents" style="display:none">Info about the 'contents' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-contents">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">2.3. 
 Resolving Dependency Cycles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-registered-custom-property">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#registered-custom-property">https://drafts.css-houdini.org/css-properties-values-api-1/#registered-custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-registered-custom-property" class="dfn-panel" data-for="term-for-registered-custom-property" id="infopanel-for-term-for-registered-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-registered-custom-property" style="display:none">Info about the 'registered custom property' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#registered-custom-property">https://drafts.css-houdini.org/css-properties-values-api-1/#registered-custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-custom-property">3.1. 
 Invalid Variables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tokendef-close-paren">
-   <a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-paren">https://drafts.csswg.org/css-syntax-3/#tokendef-close-paren</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tokendef-close-paren" class="dfn-panel" data-for="term-for-tokendef-close-paren" id="infopanel-for-term-for-tokendef-close-paren" role="menu">
+   <span id="infopaneltitle-for-term-for-tokendef-close-paren" style="display:none">Info about the '&lt;)-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-paren">https://drafts.csswg.org/css-syntax-3/#tokendef-close-paren</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-paren">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tokendef-close-square">
-   <a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-square">https://drafts.csswg.org/css-syntax-3/#tokendef-close-square</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tokendef-close-square" class="dfn-panel" data-for="term-for-tokendef-close-square" id="infopanel-for-term-for-tokendef-close-square" role="menu">
+   <span id="infopaneltitle-for-term-for-tokendef-close-square" style="display:none">Info about the '&lt;]-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-square">https://drafts.csswg.org/css-syntax-3/#tokendef-close-square</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-square">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-bad-string-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-bad-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-bad-string-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-bad-string-token" class="dfn-panel" data-for="term-for-typedef-bad-string-token" id="infopanel-for-term-for-typedef-bad-string-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-bad-string-token" style="display:none">Info about the '&lt;bad-string-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-bad-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-bad-string-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bad-string-token">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-bad-url-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-bad-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-bad-url-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-bad-url-token" class="dfn-panel" data-for="term-for-typedef-bad-url-token" id="infopanel-for-term-for-typedef-bad-url-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-bad-url-token" style="display:none">Info about the '&lt;bad-url-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-bad-url-token">https://drafts.csswg.org/css-syntax-3/#typedef-bad-url-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bad-url-token">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-value" class="dfn-panel" data-for="term-for-typedef-declaration-value" id="infopanel-for-term-for-typedef-declaration-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-value" style="display:none">Info about the '&lt;declaration-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-value">2. 
 Defining Custom Properties: the --* family of properties</a>
@@ -1949,43 +1949,43 @@ Using Cascading Variables: the var() notation</a>
 Changes Since the 03 December 2015 CR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-delim-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-delim-token" class="dfn-panel" data-for="term-for-typedef-delim-token" id="infopanel-for-term-for-typedef-delim-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-delim-token" style="display:none">Info about the '&lt;delim-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-delim-token">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-semicolon-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-semicolon-token">https://drafts.csswg.org/css-syntax-3/#typedef-semicolon-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-semicolon-token" class="dfn-panel" data-for="term-for-typedef-semicolon-token" id="infopanel-for-term-for-typedef-semicolon-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-semicolon-token" style="display:none">Info about the '&lt;semicolon-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-semicolon-token">https://drafts.csswg.org/css-syntax-3/#typedef-semicolon-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-semicolon-token">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tokendef-close-curly">
-   <a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-curly">https://drafts.csswg.org/css-syntax-3/#tokendef-close-curly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tokendef-close-curly" class="dfn-panel" data-for="term-for-tokendef-close-curly" id="infopanel-for-term-for-tokendef-close-curly" role="menu">
+   <span id="infopaneltitle-for-term-for-tokendef-close-curly" style="display:none">Info about the '&lt;}-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#tokendef-close-curly">https://drafts.csswg.org/css-syntax-3/#tokendef-close-curly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tokendef-close-curly">2.1. 
 Custom Property Value Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-comma" class="dfn-panel" data-for="term-for-comb-comma" id="infopanel-for-term-for-comb-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-comma" style="display:none">Info about the ',' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-comma">https://drafts.csswg.org/css-values-4/#comb-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dashed-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dashed-ident" class="dfn-panel" data-for="term-for-typedef-dashed-ident" id="infopanel-for-term-for-typedef-dashed-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dashed-ident" style="display:none">Info about the '&lt;dashed-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dashed-ident">https://drafts.csswg.org/css-values-4/#typedef-dashed-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dashed-ident">2. 
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2. 
 Defining Custom Properties: the --* family of properties</a>
@@ -1993,15 +1993,15 @@ Defining Custom Properties: the --* family of properties</a>
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
@@ -2009,50 +2009,50 @@ Value Definitions</a>
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">2.3. 
 Resolving Dependency Cycles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-lang">
-   <a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-lang" class="dfn-panel" data-for="term-for-selectordef-lang" id="infopanel-for-term-for-selectordef-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-lang" style="display:none">Info about the ':lang()' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">5.2. 
 Changes since the May 6 2014 Last Call Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-declaration-case-sensitive-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#css-declaration-case-sensitive-flag">https://drafts.csswg.org/cssom-1/#css-declaration-case-sensitive-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-declaration-case-sensitive-flag" class="dfn-panel" data-for="term-for-css-declaration-case-sensitive-flag" id="infopanel-for-term-for-css-declaration-case-sensitive-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-css-declaration-case-sensitive-flag" style="display:none">Info about the 'case-sensitive flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#css-declaration-case-sensitive-flag">https://drafts.csswg.org/cssom-1/#css-declaration-case-sensitive-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-case-sensitive-flag">4. 
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="term-for-cssstyledeclaration-declarations" id="infopanel-for-term-for-cssstyledeclaration-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">4. 
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-getpropertyvalue">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-getpropertyvalue">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-getpropertyvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cssstyledeclaration-getpropertyvalue" class="dfn-panel" data-for="term-for-dom-cssstyledeclaration-getpropertyvalue" id="infopanel-for-term-for-dom-cssstyledeclaration-getpropertyvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cssstyledeclaration-getpropertyvalue" style="display:none">Info about the 'getPropertyValue(property)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-getpropertyvalue">https://drafts.csswg.org/cssom-1/#dom-cssstyledeclaration-getpropertyvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue">4. 
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_case_sensitive">
-   <a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_case_sensitive" class="dfn-panel" data-for="term-for-def_case_sensitive" id="infopanel-for-term-for-def_case_sensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-def_case_sensitive" style="display:none">Info about the 'case-sensitive' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_case_sensitive">2. 
 Defining Custom Properties: the --* family of properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">2.1. 
 Custom Property Value Syntax</a>
@@ -2239,8 +2239,8 @@ Serializing Custom Properties</a>
       <td>specified value with variables substituted, or the guaranteed-invalid value
    </table>
   </div>
-  <aside class="dfn-panel" data-for="custom-property">
-   <b><a href="#custom-property">#custom-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-property" class="dfn-panel" data-for="custom-property" id="infopanel-for-custom-property" role="dialog">
+   <span id="infopaneltitle-for-custom-property" style="display:none">Info about the 'custom property' definition.</span><b><a href="#custom-property">#custom-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">1. 
 Introduction</a> <a href="#ref-for-custom-property①">(2)</a>
@@ -2260,22 +2260,22 @@ Invalid Variables</a> <a href="#ref-for-custom-property②⑨">(2)</a> <a href="
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-custom-property-name">
-   <b><a href="#typedef-custom-property-name">#typedef-custom-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-custom-property-name" class="dfn-panel" data-for="typedef-custom-property-name" id="infopanel-for-typedef-custom-property-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-custom-property-name" style="display:none">Info about the '&lt;custom-property-name>' definition.</span><b><a href="#typedef-custom-property-name">#typedef-custom-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-property-name">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-tainted">
-   <b><a href="#animation-tainted">#animation-tainted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-tainted" class="dfn-panel" data-for="animation-tainted" id="infopanel-for-animation-tainted" role="dialog">
+   <span id="infopaneltitle-for-animation-tainted" style="display:none">Info about the 'animation-tainted' definition.</span><b><a href="#animation-tainted">#animation-tainted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-tainted">3. 
 Using Cascading Variables: the var() notation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="guaranteed-invalid-value">
-   <b><a href="#guaranteed-invalid-value">#guaranteed-invalid-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-guaranteed-invalid-value" class="dfn-panel" data-for="guaranteed-invalid-value" id="infopanel-for-guaranteed-invalid-value" role="dialog">
+   <span id="infopaneltitle-for-guaranteed-invalid-value" style="display:none">Info about the 'guaranteed-invalid value' definition.</span><b><a href="#guaranteed-invalid-value">#guaranteed-invalid-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-guaranteed-invalid-value">2. 
 Defining Custom Properties: the --* family of properties</a> <a href="#ref-for-guaranteed-invalid-value①">(2)</a>
@@ -2289,8 +2289,8 @@ Using Cascading Variables: the var() notation</a>
 Invalid Variables</a> <a href="#ref-for-guaranteed-invalid-value⑧">(2)</a> <a href="#ref-for-guaranteed-invalid-value⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-var">
-   <b><a href="#funcdef-var">#funcdef-var</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-var" class="dfn-panel" data-for="funcdef-var" id="infopanel-for-funcdef-var" role="dialog">
+   <span id="infopaneltitle-for-funcdef-var" style="display:none">Info about the 'var()' definition.</span><b><a href="#funcdef-var">#funcdef-var</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">1. 
 Introduction</a>
@@ -2315,8 +2315,8 @@ Changes since the May 6 2014 Last Call Working Draft</a> <a href="#ref-for-funcd
     <li><a href="#ref-for-funcdef-var④⑧">7. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="substitute-a-var">
-   <b><a href="#substitute-a-var">#substitute-a-var</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-substitute-a-var" class="dfn-panel" data-for="substitute-a-var" id="infopanel-for-substitute-a-var" role="dialog">
+   <span id="infopaneltitle-for-substitute-a-var" style="display:none">Info about the 'substitute a var()' definition.</span><b><a href="#substitute-a-var">#substitute-a-var</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-substitute-a-var">2. 
 Defining Custom Properties: the --* family of properties</a>
@@ -2324,8 +2324,8 @@ Defining Custom Properties: the --* family of properties</a>
 Using Cascading Variables: the var() notation</a> <a href="#ref-for-substitute-a-var②">(2)</a> <a href="#ref-for-substitute-a-var③">(3)</a> <a href="#ref-for-substitute-a-var④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-at-computed-value-time">
-   <b><a href="#invalid-at-computed-value-time">#invalid-at-computed-value-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-at-computed-value-time" class="dfn-panel" data-for="invalid-at-computed-value-time" id="infopanel-for-invalid-at-computed-value-time" role="dialog">
+   <span id="infopaneltitle-for-invalid-at-computed-value-time" style="display:none">Info about the 'invalid at computed-value time' definition.</span><b><a href="#invalid-at-computed-value-time">#invalid-at-computed-value-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-at-computed-value-time">2.2. 
 Guaranteed-Invalid Values</a>
@@ -2339,8 +2339,8 @@ Invalid Variables</a> <a href="#ref-for-invalid-at-computed-value-time⑧">(2)</
 Safely Handling Overly-Long Variables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-substitution-value">
-   <b><a href="#pending-substitution-value">#pending-substitution-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-substitution-value" class="dfn-panel" data-for="pending-substitution-value" id="infopanel-for-pending-substitution-value" role="dialog">
+   <span id="infopaneltitle-for-pending-substitution-value" style="display:none">Info about the 'pending-substitution value' definition.</span><b><a href="#pending-substitution-value">#pending-substitution-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-substitution-value">3.2. 
 Variables in Shorthand Properties</a> <a href="#ref-for-pending-substitution-value①">(2)</a>
@@ -2348,59 +2348,115 @@ Variables in Shorthand Properties</a> <a href="#ref-for-pending-substitution-val
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-will-change-1/Overview.html
@@ -1283,22 +1283,22 @@ and doing a lot of the initial design work.</p>
    <li><a href="#valdef-will-change-scroll-position">scroll-position</a><span>, in § 2</span>
    <li><a href="#propdef-will-change">will-change</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">2. 
 Hinting at Future Behavior: the will-change property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">2. 
 Hinting at Future Behavior: the will-change property</a> <a href="#ref-for-propdef-opacity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">1. 
 Introduction</a>
@@ -1306,36 +1306,36 @@ Introduction</a>
 Hinting at Future Behavior: the will-change property</a> <a href="#ref-for-propdef-transform②">(2)</a> <a href="#ref-for-propdef-transform③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">2. 
 Hinting at Future Behavior: the will-change property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">2. 
 Hinting at Future Behavior: the will-change property</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a> <a href="#ref-for-identifier-value③">(4)</a> <a href="#ref-for-identifier-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.1. 
 Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. 
 Hinting at Future Behavior: the will-change property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">2. 
 Hinting at Future Behavior: the will-change property</a>
@@ -1422,8 +1422,8 @@ Hinting at Future Behavior: the will-change property</a>
       <td>specified value
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-will-change">
-   <b><a href="#propdef-will-change">#propdef-will-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-will-change" class="dfn-panel" data-for="propdef-will-change" id="infopanel-for-propdef-will-change" role="dialog">
+   <span id="infopaneltitle-for-propdef-will-change" style="display:none">Info about the 'will-change' definition.</span><b><a href="#propdef-will-change">#propdef-will-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change①">1. 
 Introduction</a>
@@ -1438,29 +1438,29 @@ Hinting at Future Behavior: the will-change property</a> <a href="#ref-for-propd
     <li><a href="#ref-for-propdef-will-change③④">4. Changes since the April 29 2014 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-animateable-feature">
-   <b><a href="#typedef-animateable-feature">#typedef-animateable-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-animateable-feature" class="dfn-panel" data-for="typedef-animateable-feature" id="infopanel-for-typedef-animateable-feature" role="dialog">
+   <span id="infopaneltitle-for-typedef-animateable-feature" style="display:none">Info about the '&lt;animateable-feature>' definition.</span><b><a href="#typedef-animateable-feature">#typedef-animateable-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-animateable-feature">2. 
 Hinting at Future Behavior: the will-change property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-will-change-auto">
-   <b><a href="#valdef-will-change-auto">#valdef-will-change-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-will-change-auto" class="dfn-panel" data-for="valdef-will-change-auto" id="infopanel-for-valdef-will-change-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-will-change-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-will-change-auto">#valdef-will-change-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-will-change-auto">2. 
 Hinting at Future Behavior: the will-change property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-will-change-scroll-position">
-   <b><a href="#valdef-will-change-scroll-position">#valdef-will-change-scroll-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-will-change-scroll-position" class="dfn-panel" data-for="valdef-will-change-scroll-position" id="infopanel-for-valdef-will-change-scroll-position" role="dialog">
+   <span id="infopaneltitle-for-valdef-will-change-scroll-position" style="display:none">Info about the 'scroll-position' definition.</span><b><a href="#valdef-will-change-scroll-position">#valdef-will-change-scroll-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-will-change-scroll-position">2. 
 Hinting at Future Behavior: the will-change property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-will-change-contents">
-   <b><a href="#valdef-will-change-contents">#valdef-will-change-contents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-will-change-contents" class="dfn-panel" data-for="valdef-will-change-contents" id="infopanel-for-valdef-will-change-contents" role="dialog">
+   <span id="infopaneltitle-for-valdef-will-change-contents" style="display:none">Info about the 'contents' definition.</span><b><a href="#valdef-will-change-contents">#valdef-will-change-contents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-will-change-contents">2. 
 Hinting at Future Behavior: the will-change property</a>
@@ -1468,59 +1468,115 @@ Hinting at Future Behavior: the will-change property</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-3/Overview.html
@@ -3516,43 +3516,43 @@ Vertical Scripts in Unicode</span><a class="self-link" href="#script-orientation
    <li><a href="#x-axis">x-axis</a><span>, in § 6</span>
    <li><a href="#y-axis">y-axis</a><span>, in § 6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">7.1. 
 Principles of Layout in Vertical Writing Modes</a> <a href="#ref-for-propdef-margin-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">7.1. 
 Principles of Layout in Vertical Writing Modes</a> <a href="#ref-for-propdef-margin-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2.4.5. 
 Reordering-induced Box Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">1.1. 
 Module Interactions</a>
@@ -3562,22 +3562,22 @@ Orienting Text: the text-orientation property</a>
 The Principal Writing Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">8. 
 The Principal Writing Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-used-value①">(2)</a>
@@ -3587,8 +3587,8 @@ Abstract-to-Physical Mappings</a>
 The Principal Writing Mode</a> <a href="#ref-for-used-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-block-container①">(2)</a>
@@ -3598,71 +3598,71 @@ Block Flow Direction: the writing-mode property</a>
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-level">
-   <a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-level" class="dfn-panel" data-for="term-for-block-level" id="infopanel-for-term-for-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-block-level" style="display:none">Info about the 'block-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-level">https://drafts.csswg.org/css-display-3/#block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-display-type" class="dfn-panel" data-for="term-for-display-type" id="infopanel-for-term-for-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-display-type" style="display:none">Info about the 'display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#display-type">https://drafts.csswg.org/css-display-3/#display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-type">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow">https://drafts.csswg.org/css-display-3/#valdef-display-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flow" class="dfn-panel" data-for="term-for-valdef-display-flow" id="infopanel-for-term-for-valdef-display-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flow" style="display:none">Info about the 'flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow">https://drafts.csswg.org/css-display-3/#valdef-display-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flow-root">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flow-root" class="dfn-panel" data-for="term-for-valdef-display-flow-root" id="infopanel-for-term-for-valdef-display-flow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flow-root" style="display:none">Info about the 'flow-root' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow-root">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">8.1. 
 Propagation to the Initial Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -3670,15 +3670,15 @@ Embeddings and Overrides: the unicode-bidi property</a>
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.4.5. 
 Reordering-induced Box Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">3.2. 
 Block Flow Direction: the writing-mode property</a>
@@ -3686,15 +3686,15 @@ Block Flow Direction: the writing-mode property</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">3.2. 
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-inner-display-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2.4.3. 
 Bidi Treatment of Atomic Inlines</a>
@@ -3702,57 +3702,57 @@ Bidi Treatment of Atomic Inlines</a>
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-feature-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-feature-settings" class="dfn-panel" data-for="term-for-propdef-font-feature-settings" id="infopanel-for-term-for-propdef-font-feature-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">9.1.3.1. 
 Full-width Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">9.1.3.1. 
 Full-width Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline" id="infopanel-for-term-for-valdef-alignment-baseline-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" style="display:none">Info about the 'baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-baseline">4.4. 
 Baseline Alignment</a> <a href="#ref-for-valdef-alignment-baseline-baseline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-sub">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-sub" class="dfn-panel" data-for="term-for-valdef-baseline-shift-sub" id="infopanel-for-term-for-valdef-baseline-shift-sub" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-sub" style="display:none">Info about the 'sub' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-sub">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-super">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-super" class="dfn-panel" data-for="term-for-valdef-baseline-shift-super" id="infopanel-for-term-for-valdef-baseline-shift-super" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-super" style="display:none">Info about the 'super' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-super">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">4. 
 Inline-level Alignment</a> <a href="#ref-for-propdef-vertical-align①">(2)</a>
@@ -3768,22 +3768,22 @@ Line-Relative Mappings</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">7.3.1. 
 Available Space of Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-rect" class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect" id="infopanel-for-term-for-funcdef-basic-shape-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-rect" style="display:none">Info about the 'rect()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-rect">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">7.3.1. 
 Available Space of Orthogonal Flows</a>
@@ -3791,15 +3791,15 @@ Available Space of Orthogonal Flows</a>
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automatic-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automatic-size" class="dfn-panel" data-for="term-for-automatic-size" id="infopanel-for-term-for-automatic-size" role="menu">
+   <span id="infopaneltitle-for-term-for-automatic-size" style="display:none">Info about the 'automatic size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#automatic-size">https://drafts.csswg.org/css-sizing-3/#automatic-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automatic-size">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a> <a href="#ref-for-automatic-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available block space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -3807,8 +3807,8 @@ Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available①" role="menu">
+   <span id="infopaneltitle-for-term-for-available①" style="display:none">Info about the 'available inline space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -3816,8 +3816,8 @@ Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available②" role="menu">
+   <span id="infopaneltitle-for-term-for-available②" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -3825,15 +3825,15 @@ Available Space of Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fallback">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fallback">https://drafts.csswg.org/css-sizing-3/#fallback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fallback" class="dfn-panel" data-for="term-for-fallback" id="infopanel-for-term-for-fallback" role="menu">
+   <span id="infopaneltitle-for-term-for-fallback" style="display:none">Info about the 'fallback size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fallback">https://drafts.csswg.org/css-sizing-3/#fallback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback">7.3.1. 
 Available Space of Orthogonal Flows</a>
@@ -3841,99 +3841,99 @@ Available Space of Orthogonal Flows</a>
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fit-content-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fit-content-size" class="dfn-panel" data-for="term-for-fit-content-size" id="infopanel-for-term-for-fit-content-size" role="menu">
+   <span id="infopaneltitle-for-term-for-fit-content-size" style="display:none">Info about the 'fit-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fit-content-size">https://drafts.csswg.org/css-sizing-3/#fit-content-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fit-content-size">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'max size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">7.3.1. 
 Available Space of Orthogonal Flows</a> <a href="#ref-for-max-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-inline-size" class="dfn-panel" data-for="term-for-max-content-inline-size" id="infopanel-for-term-for-max-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-inline-size" style="display:none">Info about the 'max-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-inline-size">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">7.3. 
 Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'min size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">7.3.1. 
 Available Space of Orthogonal Flows</a> <a href="#ref-for-min-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-inline-size" class="dfn-panel" data-for="term-for-min-content-inline-size" id="infopanel-for-term-for-min-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-inline-size" style="display:none">Info about the 'min-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-inline-size">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">7.3. 
 Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-preferred-size-properties">
-   <a href="https://drafts.csswg.org/css-sizing-3/#preferred-size-properties">https://drafts.csswg.org/css-sizing-3/#preferred-size-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-preferred-size-properties" class="dfn-panel" data-for="term-for-preferred-size-properties" id="infopanel-for-term-for-preferred-size-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-preferred-size-properties" style="display:none">Info about the 'preferred size property' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#preferred-size-properties">https://drafts.csswg.org/css-sizing-3/#preferred-size-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-size-properties">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-inline-size" class="dfn-panel" data-for="term-for-stretch-fit-inline-size" id="infopanel-for-term-for-stretch-fit-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-inline-size" style="display:none">Info about the 'stretch-fit inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-inline-size">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a> <a href="#ref-for-stretch-fit-inline-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-character">
-   <a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-character" class="dfn-panel" data-for="term-for-character" id="infopanel-for-term-for-character" role="menu">
+   <span id="infopaneltitle-for-term-for-character" style="display:none">Info about the 'character' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">5.1.1. 
 Vertical Typesetting and Font Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">9.1.2. 
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">6.3. 
 Line-relative Directions</a>
@@ -3945,29 +3945,29 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'document white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">9.1.2. 
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">9.1.3.1. 
 Full-width Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typographic-character-unit①">(2)</a> <a href="#ref-for-typographic-character-unit②">(3)</a> <a href="#ref-for-typographic-character-unit③">(4)</a>
@@ -3987,57 +3987,57 @@ Compression Rules</a> <a href="#ref-for-typographic-character-unit①⑤">(2)</a
 Full-width Characters</a> <a href="#ref-for-typographic-character-unit②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-relative-length" class="dfn-panel" data-for="term-for-font-relative-length" id="infopanel-for-term-for-font-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Specifying Directionality: the direction property</a>
@@ -4053,8 +4053,8 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-c
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" class="dfn-panel" data-for="term-for-valdef-writing-mode-sideways-lr" id="infopanel-for-term-for-valdef-writing-mode-sideways-lr" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-sideways-lr" style="display:none">Info about the 'sideways-lr' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-sideways-lr</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-lr">5.1.2. 
 Mixed Vertical Orientations</a>
@@ -4062,29 +4062,29 @@ Mixed Vertical Orientations</a>
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-caption-side-bottom">
-   <a href="https://drafts.csswg.org/css2/#valdef-caption-side-bottom">https://drafts.csswg.org/css2/#valdef-caption-side-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-caption-side-bottom" class="dfn-panel" data-for="term-for-valdef-caption-side-bottom" id="infopanel-for-term-for-valdef-caption-side-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-caption-side-bottom" style="display:none">Info about the 'bottom (for caption-side)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-caption-side-bottom">https://drafts.csswg.org/css2/#valdef-caption-side-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caption-side-bottom">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caption-side">
-   <a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caption-side" class="dfn-panel" data-for="term-for-propdef-caption-side" id="infopanel-for-term-for-propdef-caption-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caption-side" style="display:none">Info about the 'caption-side' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">7.4. 
 Flow-Relative Mappings</a> <a href="#ref-for-propdef-caption-side①">(2)</a>
@@ -4092,8 +4092,8 @@ Flow-Relative Mappings</a> <a href="#ref-for-propdef-caption-side①">(2)</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">7.4. 
 Flow-Relative Mappings</a>
@@ -4101,15 +4101,15 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.csswg.org/css2/#propdef-clip">https://drafts.csswg.org/css2/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clip">https://drafts.csswg.org/css2/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-propdef-display①">(2)</a>
@@ -4123,8 +4123,8 @@ The Principal Writing Mode</a> <a href="#ref-for-propdef-display⑦">(2)</a>
   2019 CSS Writing Modes Module Level 4 Recommendation</a> <a href="#ref-for-propdef-display⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">7.4. 
 Flow-Relative Mappings</a>
@@ -4132,15 +4132,15 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">7.2. 
 Dimensional Mapping</a>
@@ -4148,78 +4148,78 @@ Dimensional Mapping</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-caption-side-top">
-   <a href="https://drafts.csswg.org/css2/#valdef-caption-side-top">https://drafts.csswg.org/css2/#valdef-caption-side-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-caption-side-top" class="dfn-panel" data-for="term-for-valdef-caption-side-top" id="infopanel-for-term-for-valdef-caption-side-top" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-caption-side-top" style="display:none">Info about the 'top (for caption-side)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-caption-side-top">https://drafts.csswg.org/css2/#valdef-caption-side-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caption-side-top">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">7.5. 
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multi-column-container">
-   <a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multi-column-container" class="dfn-panel" data-for="term-for-multi-column-container" id="infopanel-for-term-for-multi-column-container" role="menu">
+   <span id="infopaneltitle-for-term-for-multi-column-container" style="display:none">Info about the 'multi-column container' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#multi-column-container">https://drafts.csswg.org/css-multicol-1/#multi-column-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-column-container">7.3.2. 
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-progression">
-   <a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-progression" class="dfn-panel" data-for="term-for-page-progression" id="infopanel-for-term-for-page-progression" role="menu">
+   <span id="infopaneltitle-for-term-for-page-progression" style="display:none">Info about the 'page progression' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-progression">8. 
 The Principal Writing Mode</a>
@@ -4227,8 +4227,8 @@ The Principal Writing Mode</a>
 Page Flow: the page progression direction</a> <a href="#ref-for-page-progression②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">8. 
 The Principal Writing Mode</a> <a href="#ref-for-the-body-element①">(2)</a>
@@ -4236,8 +4236,8 @@ The Principal Writing Mode</a> <a href="#ref-for-the-body-element①">(2)</a>
   2019 CSS Writing Modes Module Level 4 Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">8.2. 
 Page Flow: the page progression direction</a>
@@ -4594,8 +4594,8 @@ Page Flow: the page progression direction</a>
       <td>specified value
    </table>
   </div>
-  <aside class="dfn-panel" data-for="writing-mode">
-   <b><a href="#writing-mode">#writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writing-mode" class="dfn-panel" data-for="writing-mode" id="infopanel-for-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-writing-mode" style="display:none">Info about the 'writing mode' definition.</span><b><a href="#writing-mode">#writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">1.1. 
 Module Interactions</a> <a href="#ref-for-writing-mode①">(2)</a>
@@ -4603,8 +4603,8 @@ Module Interactions</a> <a href="#ref-for-writing-mode①">(2)</a>
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-writing-mode③">(2)</a> <a href="#ref-for-writing-mode④">(3)</a> <a href="#ref-for-writing-mode⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-base-direction">
-   <b><a href="#inline-base-direction">#inline-base-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-base-direction" class="dfn-panel" data-for="inline-base-direction" id="infopanel-for-inline-base-direction" role="dialog">
+   <span id="infopaneltitle-for-inline-base-direction" style="display:none">Info about the 'inline base direction' definition.</span><b><a href="#inline-base-direction">#inline-base-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">1. 
 Introduction to Writing Modes</a>
@@ -4612,8 +4612,8 @@ Introduction to Writing Modes</a>
 Specifying Directionality: the direction property</a> <a href="#ref-for-inline-base-direction②">(2)</a> <a href="#ref-for-inline-base-direction③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-flow-direction">
-   <b><a href="#block-flow-direction">#block-flow-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-flow-direction" class="dfn-panel" data-for="block-flow-direction" id="infopanel-for-block-flow-direction" role="dialog">
+   <span id="infopaneltitle-for-block-flow-direction" style="display:none">Info about the 'block flow direction' definition.</span><b><a href="#block-flow-direction">#block-flow-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">1. 
 Introduction to Writing Modes</a>
@@ -4623,8 +4623,8 @@ Block Flow Direction: the writing-mode property</a> <a href="#ref-for-block-flow
 Flow-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typographic-mode">
-   <b><a href="#typographic-mode">#typographic-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typographic-mode" class="dfn-panel" data-for="typographic-mode" id="infopanel-for-typographic-mode" role="dialog">
+   <span id="infopaneltitle-for-typographic-mode" style="display:none">Info about the 'typographic mode' definition.</span><b><a href="#typographic-mode">#typographic-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">3.2. 
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-typographic-mode①">(2)</a> <a href="#ref-for-typographic-mode②">(3)</a>
@@ -4638,8 +4638,8 @@ Baseline Alignment</a>
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typographic-mode⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-writing-mode">
-   <b><a href="#horizontal-writing-mode">#horizontal-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-writing-mode" class="dfn-panel" data-for="horizontal-writing-mode" id="infopanel-for-horizontal-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' definition.</span><b><a href="#horizontal-writing-mode">#horizontal-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">5.1. 
 Orienting Text: the text-orientation property</a>
@@ -4647,15 +4647,15 @@ Orienting Text: the text-orientation property</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-writing-mode">
-   <b><a href="#vertical-writing-mode">#vertical-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-writing-mode" class="dfn-panel" data-for="vertical-writing-mode" id="infopanel-for-vertical-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' definition.</span><b><a href="#vertical-writing-mode">#vertical-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">6.4. 
 Abstract-to-Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-direction">
-   <b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-direction" class="dfn-panel" data-for="propdef-direction" id="infopanel-for-propdef-direction" role="dialog">
+   <span id="infopaneltitle-for-propdef-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-direction①">(2)</a>
@@ -4687,8 +4687,8 @@ Principles of Layout in Vertical Writing Modes</a>
 The Principal Writing Mode</a> <a href="#ref-for-propdef-direction③④">(2)</a> <a href="#ref-for-propdef-direction③⑤">(3)</a> <a href="#ref-for-propdef-direction③⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-ltr">
-   <b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-ltr" class="dfn-panel" data-for="valdef-direction-ltr" id="infopanel-for-valdef-direction-ltr" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' definition.</span><b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -4704,8 +4704,8 @@ Abstract-to-Physical Mappings</a> <a href="#ref-for-valdef-direction-ltr⑤">(2)
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-rtl">
-   <b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-rtl" class="dfn-panel" data-for="valdef-direction-rtl" id="infopanel-for-valdef-direction-rtl" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' definition.</span><b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -4723,8 +4723,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-unicode-bidi">
-   <b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-unicode-bidi" class="dfn-panel" data-for="propdef-unicode-bidi" id="infopanel-for-propdef-unicode-bidi" role="dialog">
+   <span id="infopaneltitle-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' definition.</span><b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">1. 
 Introduction to Writing Modes</a>
@@ -4750,8 +4750,8 @@ Paragraph Breaks Within Embeddings and Isolates</a>
 Orienting Text: the text-orientation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-normal">
-   <b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-normal" class="dfn-panel" data-for="valdef-unicode-bidi-normal" id="infopanel-for-valdef-unicode-bidi-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-normal">2.1. 
 Specifying Directionality: the direction property</a>
@@ -4761,8 +4761,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Example of Bidirectional Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-embed">
-   <b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-embed" class="dfn-panel" data-for="valdef-unicode-bidi-embed" id="infopanel-for-valdef-unicode-bidi-embed" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-embed" style="display:none">Info about the 'embed' definition.</span><b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-embed">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-embed①">(2)</a>
@@ -4770,22 +4770,22 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Treatment of Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directional-embedding">
-   <b><a href="#directional-embedding">#directional-embedding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directional-embedding" class="dfn-panel" data-for="directional-embedding" id="infopanel-for-directional-embedding" role="dialog">
+   <span id="infopaneltitle-for-directional-embedding" style="display:none">Info about the 'directional embedding' definition.</span><b><a href="#directional-embedding">#directional-embedding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directional-embedding">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-isolate">
-   <b><a href="#valdef-unicode-bidi-isolate">#valdef-unicode-bidi-isolate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-isolate" class="dfn-panel" data-for="valdef-unicode-bidi-isolate" id="infopanel-for-valdef-unicode-bidi-isolate" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-isolate" style="display:none">Info about the 'isolate' definition.</span><b><a href="#valdef-unicode-bidi-isolate">#valdef-unicode-bidi-isolate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-isolate①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-isolate②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-isolate③">(4)</a> <a href="#ref-for-valdef-unicode-bidi-isolate④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidi-isolate">
-   <b><a href="#bidi-isolate">#bidi-isolate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidi-isolate" class="dfn-panel" data-for="bidi-isolate" id="infopanel-for-bidi-isolate" role="dialog">
+   <span id="infopaneltitle-for-bidi-isolate" style="display:none">Info about the 'bidi-isolates' definition.</span><b><a href="#bidi-isolate">#bidi-isolate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-isolate">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -4793,8 +4793,8 @@ Embeddings and Overrides: the unicode-bidi property</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isolated-sequence">
-   <b><a href="#isolated-sequence">#isolated-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isolated-sequence" class="dfn-panel" data-for="isolated-sequence" id="infopanel-for-isolated-sequence" role="dialog">
+   <span id="infopaneltitle-for-isolated-sequence" style="display:none">Info about the 'isolated sequence' definition.</span><b><a href="#isolated-sequence">#isolated-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isolated-sequence">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-isolated-sequence①">(2)</a>
@@ -4802,8 +4802,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-isolat
 Example of Bidirectional Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-bidi-override">
-   <b><a href="#valdef-unicode-bidi-bidi-override">#valdef-unicode-bidi-bidi-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-bidi-override" class="dfn-panel" data-for="valdef-unicode-bidi-bidi-override" id="infopanel-for-valdef-unicode-bidi-bidi-override" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-bidi-override" style="display:none">Info about the 'bidi-override' definition.</span><b><a href="#valdef-unicode-bidi-bidi-override">#valdef-unicode-bidi-bidi-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-bidi-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override③">(4)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override④">(5)</a>
@@ -4811,22 +4811,22 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Treatment of Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directional-override">
-   <b><a href="#directional-override">#directional-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directional-override" class="dfn-panel" data-for="directional-override" id="infopanel-for-directional-override" role="dialog">
+   <span id="infopaneltitle-for-directional-override" style="display:none">Info about the 'directional override' definition.</span><b><a href="#directional-override">#directional-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directional-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-directional-override①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-isolate-override">
-   <b><a href="#valdef-unicode-bidi-isolate-override">#valdef-unicode-bidi-isolate-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-isolate-override" class="dfn-panel" data-for="valdef-unicode-bidi-isolate-override" id="infopanel-for-valdef-unicode-bidi-isolate-override" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-isolate-override" style="display:none">Info about the 'isolate-override' definition.</span><b><a href="#valdef-unicode-bidi-isolate-override">#valdef-unicode-bidi-isolate-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-isolate-override①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-plaintext">
-   <b><a href="#valdef-unicode-bidi-plaintext">#valdef-unicode-bidi-plaintext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-plaintext" class="dfn-panel" data-for="valdef-unicode-bidi-plaintext" id="infopanel-for-valdef-unicode-bidi-plaintext" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-plaintext" style="display:none">Info about the 'plaintext' definition.</span><b><a href="#valdef-unicode-bidi-plaintext">#valdef-unicode-bidi-plaintext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-plaintext">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-plaintext①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-plaintext②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-plaintext③">(4)</a>
@@ -4834,8 +4834,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Paragraph Embedding Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-paragraph-break">
-   <b><a href="#forced-paragraph-break">#forced-paragraph-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-paragraph-break" class="dfn-panel" data-for="forced-paragraph-break" id="infopanel-for-forced-paragraph-break" role="dialog">
+   <span id="infopaneltitle-for-forced-paragraph-break" style="display:none">Info about the 'forced paragraph break' definition.</span><b><a href="#forced-paragraph-break">#forced-paragraph-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-paragraph-break">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-forced-paragraph-break①">(2)</a>
@@ -4843,8 +4843,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-forced
 Paragraph Breaks Within Embeddings and Isolates</a> <a href="#ref-for-forced-paragraph-break③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidi-paragraph">
-   <b><a href="#bidi-paragraph">#bidi-paragraph</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidi-paragraph" class="dfn-panel" data-for="bidi-paragraph" id="infopanel-for-bidi-paragraph" role="dialog">
+   <span id="infopaneltitle-for-bidi-paragraph" style="display:none">Info about the 'paragraph' definition.</span><b><a href="#bidi-paragraph">#bidi-paragraph</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-paragraph">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -4854,8 +4854,8 @@ CSS–Unicode Bidi Control Translation, Text Reordering</a>
 Paragraph Breaks Within Embeddings and Isolates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-writing-mode">
-   <b><a href="#propdef-writing-mode">#propdef-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-writing-mode" class="dfn-panel" data-for="propdef-writing-mode" id="infopanel-for-propdef-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' definition.</span><b><a href="#propdef-writing-mode">#propdef-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
@@ -4885,8 +4885,8 @@ Orthogonal Flows</a>
 The Principal Writing Mode</a> <a href="#ref-for-propdef-writing-mode②④">(2)</a> <a href="#ref-for-propdef-writing-mode②⑤">(3)</a> <a href="#ref-for-propdef-writing-mode②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-horizontal-tb">
-   <b><a href="#valdef-writing-mode-horizontal-tb">#valdef-writing-mode-horizontal-tb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="valdef-writing-mode-horizontal-tb" id="infopanel-for-valdef-writing-mode-horizontal-tb" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' definition.</span><b><a href="#valdef-writing-mode-horizontal-tb">#valdef-writing-mode-horizontal-tb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">2.4.5. 
 Reordering-induced Box Fragmentation</a>
@@ -4908,8 +4908,8 @@ Line-Relative Mappings</a>
 Page Flow: the page progression direction</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-vertical-rl">
-   <b><a href="#valdef-writing-mode-vertical-rl">#valdef-writing-mode-vertical-rl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="valdef-writing-mode-vertical-rl" id="infopanel-for-valdef-writing-mode-vertical-rl" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' definition.</span><b><a href="#valdef-writing-mode-vertical-rl">#valdef-writing-mode-vertical-rl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">3.2. 
 Block Flow Direction: the writing-mode property</a>
@@ -4933,8 +4933,8 @@ Orthogonal Flows</a> <a href="#ref-for-valdef-writing-mode-vertical-rl①①">(2
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-vertical-lr">
-   <b><a href="#valdef-writing-mode-vertical-lr">#valdef-writing-mode-vertical-lr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="valdef-writing-mode-vertical-lr" id="infopanel-for-valdef-writing-mode-vertical-lr" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' definition.</span><b><a href="#valdef-writing-mode-vertical-lr">#valdef-writing-mode-vertical-lr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">3.2.1.1. 
 Supporting SVG1.1 writing-mode values in CSS syntax</a>
@@ -4952,22 +4952,22 @@ Orthogonal Flows</a>
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alphabetic-baseline">
-   <b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alphabetic-baseline" class="dfn-panel" data-for="alphabetic-baseline" id="infopanel-for-alphabetic-baseline" role="dialog">
+   <span id="infopaneltitle-for-alphabetic-baseline" style="display:none">Info about the 'alphabetic baseline' definition.</span><b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alphabetic-baseline">4.2. 
 Text Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="central-baseline">
-   <b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-central-baseline" class="dfn-panel" data-for="central-baseline" id="infopanel-for-central-baseline" role="dialog">
+   <span id="infopaneltitle-for-central-baseline" style="display:none">Info about the 'central baseline' definition.</span><b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-central-baseline">4.2. 
 Text Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-only">
-   <b><a href="#horizontal-only">#horizontal-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-only" class="dfn-panel" data-for="horizontal-only" id="infopanel-for-horizontal-only" role="dialog">
+   <span id="infopaneltitle-for-horizontal-only" style="display:none">Info about the 'horizontal-only' definition.</span><b><a href="#horizontal-only">#horizontal-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-only">5. 
 Introduction to Vertical Text Layout</a> <a href="#ref-for-horizontal-only①">(2)</a>
@@ -4975,8 +4975,8 @@ Introduction to Vertical Text Layout</a> <a href="#ref-for-horizontal-only①">(
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-only">
-   <b><a href="#vertical-only">#vertical-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-only" class="dfn-panel" data-for="vertical-only" id="infopanel-for-vertical-only" role="dialog">
+   <span id="infopaneltitle-for-vertical-only" style="display:none">Info about the 'vertical-only' definition.</span><b><a href="#vertical-only">#vertical-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-only">5. 
 Introduction to Vertical Text Layout</a>
@@ -4984,8 +4984,8 @@ Introduction to Vertical Text Layout</a>
 Vertical Scripts in Unicode</a> <a href="#ref-for-vertical-only②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bi-orientational">
-   <b><a href="#bi-orientational">#bi-orientational</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bi-orientational" class="dfn-panel" data-for="bi-orientational" id="infopanel-for-bi-orientational" role="dialog">
+   <span id="infopaneltitle-for-bi-orientational" style="display:none">Info about the 'bi-orientational' definition.</span><b><a href="#bi-orientational">#bi-orientational</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bi-orientational">5. 
 Introduction to Vertical Text Layout</a> <a href="#ref-for-bi-orientational①">(2)</a>
@@ -4993,29 +4993,30 @@ Introduction to Vertical Text Layout</a> <a href="#ref-for-bi-orientational①">
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-script">
-   <b><a href="#vertical-script">#vertical-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-script" class="dfn-panel" data-for="vertical-script" id="infopanel-for-vertical-script" role="dialog">
+   <span id="infopaneltitle-for-vertical-script" style="display:none">Info about the 'vertical script' definition.</span><b><a href="#vertical-script">#vertical-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-script">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-vertical-script①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-script">
-   <b><a href="#horizontal-script">#horizontal-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-script" class="dfn-panel" data-for="horizontal-script" id="infopanel-for-horizontal-script" role="dialog">
+   <span id="infopaneltitle-for-horizontal-script" style="display:none">Info about the 'horizontal script' definition.</span><b><a href="#horizontal-script">#horizontal-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-script">Appendix A:
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bi-orientational-transform">
-   <b><a href="#bi-orientational-transform">#bi-orientational-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bi-orientational-transform" class="dfn-panel" data-for="bi-orientational-transform" id="infopanel-for-bi-orientational-transform" role="dialog">
+   <span id="infopaneltitle-for-bi-orientational-transform" style="display:none">Info about the 'bi-orientational
+    transform' definition.</span><b><a href="#bi-orientational-transform">#bi-orientational-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bi-orientational-transform">5. 
 Introduction to Vertical Text Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-orientation">
-   <b><a href="#propdef-text-orientation">#propdef-text-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-orientation" class="dfn-panel" data-for="propdef-text-orientation" id="infopanel-for-propdef-text-orientation" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' definition.</span><b><a href="#propdef-text-orientation">#propdef-text-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-text-orientation①">(2)</a>
@@ -5043,8 +5044,8 @@ The Principal Writing Mode</a> <a href="#ref-for-propdef-text-orientation①⑤"
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-mixed">
-   <b><a href="#valdef-text-orientation-mixed">#valdef-text-orientation-mixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-mixed" class="dfn-panel" data-for="valdef-text-orientation-mixed" id="infopanel-for-valdef-text-orientation-mixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-mixed" style="display:none">Info about the 'mixed' definition.</span><b><a href="#valdef-text-orientation-mixed">#valdef-text-orientation-mixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-mixed">4.2. 
 Text Baselines</a>
@@ -5064,8 +5065,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-upright">
-   <b><a href="#valdef-text-orientation-upright">#valdef-text-orientation-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-upright" class="dfn-panel" data-for="valdef-text-orientation-upright" id="infopanel-for-valdef-text-orientation-upright" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' definition.</span><b><a href="#valdef-text-orientation-upright">#valdef-text-orientation-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">4.2. 
 Text Baselines</a>
@@ -5079,8 +5080,8 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-v
 Abstract-to-Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-sideways">
-   <b><a href="#valdef-text-orientation-sideways">#valdef-text-orientation-sideways</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-sideways" class="dfn-panel" data-for="valdef-text-orientation-sideways" id="infopanel-for-valdef-text-orientation-sideways" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-sideways" style="display:none">Info about the 'sideways' definition.</span><b><a href="#valdef-text-orientation-sideways">#valdef-text-orientation-sideways</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-sideways">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-valdef-text-orientation-sideways①">(2)</a>
@@ -5090,8 +5091,8 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-v
 Line-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typeset-upright">
-   <b><a href="#typeset-upright">#typeset-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typeset-upright" class="dfn-panel" data-for="typeset-upright" id="infopanel-for-typeset-upright" role="dialog">
+   <span id="infopaneltitle-for-typeset-upright" style="display:none">Info about the 'upright typesetting' definition.</span><b><a href="#typeset-upright">#typeset-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-upright">5.1. 
 Orienting Text: the text-orientation property</a>
@@ -5099,8 +5100,9 @@ Orienting Text: the text-orientation property</a>
 Mixed Vertical Orientations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typeset-sideways">
-   <b><a href="#typeset-sideways">#typeset-sideways</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typeset-sideways" class="dfn-panel" data-for="typeset-sideways" id="infopanel-for-typeset-sideways" role="dialog">
+   <span id="infopaneltitle-for-typeset-sideways" style="display:none">Info about the 'sideways typesetting
+    ' definition.</span><b><a href="#typeset-sideways">#typeset-sideways</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-sideways">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typeset-sideways">(2)</a>
@@ -5110,50 +5112,50 @@ Vertical Typesetting and Font Features</a>
 Mixed Vertical Orientations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-glyph-orientation-vertical">
-   <b><a href="#propdef-glyph-orientation-vertical">#propdef-glyph-orientation-vertical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-glyph-orientation-vertical" class="dfn-panel" data-for="propdef-glyph-orientation-vertical" id="infopanel-for-propdef-glyph-orientation-vertical" role="dialog">
+   <span id="infopaneltitle-for-propdef-glyph-orientation-vertical" style="display:none">Info about the 'glyph-orientation-vertical' definition.</span><b><a href="#propdef-glyph-orientation-vertical">#propdef-glyph-orientation-vertical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-propdef-glyph-orientation-vertical①">(2)</a> <a href="#ref-for-propdef-glyph-orientation-vertical②">(3)</a> <a href="#ref-for-propdef-glyph-orientation-vertical③">(4)</a> <a href="#ref-for-propdef-glyph-orientation-vertical④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-axis">
-   <b><a href="#x-axis">#x-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-axis" class="dfn-panel" data-for="x-axis" id="infopanel-for-x-axis" role="dialog">
+   <span id="infopaneltitle-for-x-axis" style="display:none">Info about the 'x-axis' definition.</span><b><a href="#x-axis">#x-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-axis">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-x-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-dimension">
-   <b><a href="#horizontal-dimension">#horizontal-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-dimension" class="dfn-panel" data-for="horizontal-dimension" id="infopanel-for-horizontal-dimension" role="dialog">
+   <span id="infopaneltitle-for-horizontal-dimension" style="display:none">Info about the 'horizontal dimension' definition.</span><b><a href="#horizontal-dimension">#horizontal-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-dimension">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-horizontal-dimension①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="y-axis">
-   <b><a href="#y-axis">#y-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-y-axis" class="dfn-panel" data-for="y-axis" id="infopanel-for-y-axis" role="dialog">
+   <span id="infopaneltitle-for-y-axis" style="display:none">Info about the 'y-axis' definition.</span><b><a href="#y-axis">#y-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-y-axis">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-y-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-dimension">
-   <b><a href="#vertical-dimension">#vertical-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-dimension" class="dfn-panel" data-for="vertical-dimension" id="infopanel-for-vertical-dimension" role="dialog">
+   <span id="infopaneltitle-for-vertical-dimension" style="display:none">Info about the 'vertical dimension' definition.</span><b><a href="#vertical-dimension">#vertical-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-dimension">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-vertical-dimension①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-axis">
-   <b><a href="#block-axis">#block-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-axis" class="dfn-panel" data-for="block-axis" id="infopanel-for-block-axis" role="dialog">
+   <span id="infopaneltitle-for-block-axis" style="display:none">Info about the 'block axis' definition.</span><b><a href="#block-axis">#block-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">7.3. 
 Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-axis">
-   <b><a href="#inline-axis">#inline-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-axis" class="dfn-panel" data-for="inline-axis" id="infopanel-for-inline-axis" role="dialog">
+   <span id="infopaneltitle-for-inline-axis" style="display:none">Info about the 'inline axis' definition.</span><b><a href="#inline-axis">#inline-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">4.1. 
 Introduction to Baselines</a>
@@ -5167,8 +5169,8 @@ Available Space of Orthogonal Flows</a>
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-size">
-   <b><a href="#block-size">#block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-size" class="dfn-panel" data-for="block-size" id="infopanel-for-block-size" role="dialog">
+   <span id="infopaneltitle-for-block-size" style="display:none">Info about the 'block size' definition.</span><b><a href="#block-size">#block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">7.2. 
 Dimensional Mapping</a>
@@ -5178,8 +5180,8 @@ Orthogonal Flows</a> <a href="#ref-for-block-size②">(2)</a> <a href="#ref-for-
 Available Space of Orthogonal Flows</a> <a href="#ref-for-block-size⑥">(2)</a> <a href="#ref-for-block-size⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-size">
-   <b><a href="#inline-size">#inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-size" class="dfn-panel" data-for="inline-size" id="infopanel-for-inline-size" role="dialog">
+   <span id="infopaneltitle-for-inline-size" style="display:none">Info about the 'inline size' definition.</span><b><a href="#inline-size">#inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">7.2. 
 Dimensional Mapping</a> <a href="#ref-for-inline-size①">(2)</a>
@@ -5189,15 +5191,15 @@ Orthogonal Flows</a> <a href="#ref-for-inline-size③">(2)</a> <a href="#ref-for
 Available Space of Orthogonal Flows</a> <a href="#ref-for-inline-size⑨">(2)</a> <a href="#ref-for-inline-size①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flow-relative-direction">
-   <b><a href="#flow-relative-direction">#flow-relative-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flow-relative-direction" class="dfn-panel" data-for="flow-relative-direction" id="infopanel-for-flow-relative-direction" role="dialog">
+   <span id="infopaneltitle-for-flow-relative-direction" style="display:none">Info about the 'flow-relative directions' definition.</span><b><a href="#flow-relative-direction">#flow-relative-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative-direction">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-start">
-   <b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-start" class="dfn-panel" data-for="block-start" id="infopanel-for-block-start" role="dialog">
+   <span id="infopaneltitle-for-block-start" style="display:none">Info about the 'block-start' definition.</span><b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">6. 
 Abstract Box Terminology</a>
@@ -5213,8 +5215,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a> <a href="#ref-for-block-start⑨">(2)</a> <a href="#ref-for-block-start①⓪">(3)</a> <a href="#ref-for-block-start①①">(4)</a> <a href="#ref-for-block-start①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-end">
-   <b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-end" class="dfn-panel" data-for="block-end" id="infopanel-for-block-end" role="dialog">
+   <span id="infopaneltitle-for-block-end" style="display:none">Info about the 'block-end' definition.</span><b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">6. 
 Abstract Box Terminology</a>
@@ -5228,8 +5230,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a> <a href="#ref-for-block-end⑦">(2)</a> <a href="#ref-for-block-end⑧">(3)</a> <a href="#ref-for-block-end⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-start">
-   <b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-start" class="dfn-panel" data-for="inline-start" id="infopanel-for-inline-start" role="dialog">
+   <span id="infopaneltitle-for-inline-start" style="display:none">Info about the 'inline-start' definition.</span><b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">6. 
 Abstract Box Terminology</a>
@@ -5243,8 +5245,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-end">
-   <b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-end" class="dfn-panel" data-for="inline-end" id="infopanel-for-inline-end" role="dialog">
+   <span id="infopaneltitle-for-inline-end" style="display:none">Info about the 'inline-end' definition.</span><b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">6. 
 Abstract Box Terminology</a>
@@ -5254,8 +5256,8 @@ Flow-relative Directions</a> <a href="#ref-for-inline-end②">(2)</a> <a href="#
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-start">
-   <b><a href="#css-start">#css-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-start" class="dfn-panel" data-for="css-start" id="infopanel-for-css-start" role="dialog">
+   <span id="infopaneltitle-for-css-start" style="display:none">Info about the 'start' definition.</span><b><a href="#css-start">#css-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">2.4.5. 
 Reordering-induced Box Fragmentation</a> <a href="#ref-for-css-start①">(2)</a>
@@ -5269,8 +5271,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Flow-Relative Mappings</a> <a href="#ref-for-css-start⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-end">
-   <b><a href="#css-end">#css-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-end" class="dfn-panel" data-for="css-end" id="infopanel-for-css-end" role="dialog">
+   <span id="infopaneltitle-for-css-end" style="display:none">Info about the 'end' definition.</span><b><a href="#css-end">#css-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">2.4.5. 
 Reordering-induced Box Fragmentation</a>
@@ -5280,22 +5282,22 @@ Abstract Box Terminology</a>
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-orientation">
-   <b><a href="#line-orientation">#line-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-orientation" class="dfn-panel" data-for="line-orientation" id="infopanel-for-line-orientation" role="dialog">
+   <span id="infopaneltitle-for-line-orientation" style="display:none">Info about the 'line orientation' definition.</span><b><a href="#line-orientation">#line-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-orientation">6.3. 
 Line-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-relative-direction">
-   <b><a href="#line-relative-direction">#line-relative-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-relative-direction" class="dfn-panel" data-for="line-relative-direction" id="infopanel-for-line-relative-direction" role="dialog">
+   <span id="infopaneltitle-for-line-relative-direction" style="display:none">Info about the 'line-relative directions' definition.</span><b><a href="#line-relative-direction">#line-relative-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-relative-direction">7.5. 
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="over">
-   <b><a href="#over">#over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-over" class="dfn-panel" data-for="over" id="infopanel-for-over" role="dialog">
+   <span id="infopaneltitle-for-over" style="display:none">Info about the 'over' definition.</span><b><a href="#over">#over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-over">4.2. 
 Text Baselines</a>
@@ -5307,8 +5309,8 @@ Line-relative Directions</a>
 Line-Relative Mappings</a> <a href="#ref-for-over④">(2)</a> <a href="#ref-for-over⑤">(3)</a> <a href="#ref-for-over⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-over">
-   <b><a href="#line-over">#line-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-over" class="dfn-panel" data-for="line-over" id="infopanel-for-line-over" role="dialog">
+   <span id="infopaneltitle-for-line-over" style="display:none">Info about the 'line-over' definition.</span><b><a href="#line-over">#line-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">6. 
 Abstract Box Terminology</a>
@@ -5320,8 +5322,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="under">
-   <b><a href="#under">#under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-under" class="dfn-panel" data-for="under" id="infopanel-for-under" role="dialog">
+   <span id="infopaneltitle-for-under" style="display:none">Info about the 'under' definition.</span><b><a href="#under">#under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">4.2. 
 Text Baselines</a>
@@ -5331,8 +5333,8 @@ Atomic Inline Baselines</a> <a href="#ref-for-under②">(2)</a>
 Line-Relative Mappings</a> <a href="#ref-for-under④">(2)</a> <a href="#ref-for-under⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-under">
-   <b><a href="#line-under">#line-under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-under" class="dfn-panel" data-for="line-under" id="infopanel-for-line-under" role="dialog">
+   <span id="infopaneltitle-for-line-under" style="display:none">Info about the 'line-under' definition.</span><b><a href="#line-under">#line-under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">6. 
 Abstract Box Terminology</a>
@@ -5342,8 +5344,8 @@ Line-relative Directions</a>
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-left">
-   <b><a href="#line-left">#line-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-left" class="dfn-panel" data-for="line-left" id="infopanel-for-line-left" role="dialog">
+   <span id="infopaneltitle-for-line-left" style="display:none">Info about the 'line-left' definition.</span><b><a href="#line-left">#line-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">2.1. 
 Specifying Directionality: the direction property</a> <a href="#ref-for-line-left①">(2)</a>
@@ -5359,8 +5361,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a> <a href="#ref-for-line-left⑦">(2)</a> <a href="#ref-for-line-left⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-right">
-   <b><a href="#line-right">#line-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-right" class="dfn-panel" data-for="line-right" id="infopanel-for-line-right" role="dialog">
+   <span id="infopaneltitle-for-line-right" style="display:none">Info about the 'line-right' definition.</span><b><a href="#line-right">#line-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">2.1. 
 Specifying Directionality: the direction property</a> <a href="#ref-for-line-right①">(2)</a>
@@ -5374,8 +5376,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a> <a href="#ref-for-line-right⑥">(2)</a> <a href="#ref-for-line-right⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="establish-an-orthogonal-flow">
-   <b><a href="#establish-an-orthogonal-flow">#establish-an-orthogonal-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-establish-an-orthogonal-flow" class="dfn-panel" data-for="establish-an-orthogonal-flow" id="infopanel-for-establish-an-orthogonal-flow" role="dialog">
+   <span id="infopaneltitle-for-establish-an-orthogonal-flow" style="display:none">Info about the 'orthogonal flow' definition.</span><b><a href="#establish-an-orthogonal-flow">#establish-an-orthogonal-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-orthogonal-flow">7.3. 
 Orthogonal Flows</a> <a href="#ref-for-establish-an-orthogonal-flow①">(2)</a> <a href="#ref-for-establish-an-orthogonal-flow②">(3)</a>
@@ -5385,8 +5387,8 @@ Available Space of Orthogonal Flows</a>
 Auto-sizing Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="principal-writing-mode">
-   <b><a href="#principal-writing-mode">#principal-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-principal-writing-mode" class="dfn-panel" data-for="principal-writing-mode" id="infopanel-for-principal-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' definition.</span><b><a href="#principal-writing-mode">#principal-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">8. 
 The Principal Writing Mode</a>
@@ -5398,8 +5400,8 @@ Page Flow: the page progression direction</a> <a href="#ref-for-principal-writin
   2019 CSS Writing Modes Module Level 4 Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-combine-upright">
-   <b><a href="#propdef-text-combine-upright">#propdef-text-combine-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-combine-upright" class="dfn-panel" data-for="propdef-text-combine-upright" id="infopanel-for-propdef-text-combine-upright" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' definition.</span><b><a href="#propdef-text-combine-upright">#propdef-text-combine-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright">9.1. 
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
@@ -5413,8 +5415,8 @@ Full-width Characters</a>
   2019 CSS Writing Modes Module Level 4 Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-combine-upright-none">
-   <b><a href="#valdef-text-combine-upright-none">#valdef-text-combine-upright-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-combine-upright-none" class="dfn-panel" data-for="valdef-text-combine-upright-none" id="infopanel-for-valdef-text-combine-upright-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-combine-upright-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-combine-upright-none">#valdef-text-combine-upright-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-combine-upright-none">8. 
 The Principal Writing Mode</a>
@@ -5424,59 +5426,115 @@ Text Run Rules</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css-writing-modes-4/Overview.html
@@ -3782,64 +3782,64 @@ Vertical Scripts in Unicode</span><a class="self-link" href="#script-orientation
    <li><a href="#x-axis">x-axis</a><span>, in § 6</span>
    <li><a href="#y-axis">y-axis</a><span>, in § 6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-gap">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-gap" class="dfn-panel" data-for="term-for-propdef-column-gap" id="infopanel-for-term-for-propdef-column-gap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-gap" style="display:none">Info about the 'column-gap' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-column-gap">https://drafts.csswg.org/css-align-3/#propdef-column-gap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-gap">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-propdef-column-gap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">7.1. 
 Principles of Layout in Vertical Writing Modes</a> <a href="#ref-for-propdef-margin-bottom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">7.1. 
 Principles of Layout in Vertical Writing Modes</a> <a href="#ref-for-propdef-margin-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-3/#fragment">https://drafts.csswg.org/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">2.4.5.1. 
 Conditions of Reordering-induced Box Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">2.4.5.1. 
 Conditions of Reordering-induced Box Fragmentation</a> <a href="#ref-for-box-fragment①">(2)</a> <a href="#ref-for-box-fragment②">(3)</a> <a href="#ref-for-box-fragment③">(4)</a> <a href="#ref-for-box-fragment④">(5)</a> <a href="#ref-for-box-fragment⑤">(6)</a> <a href="#ref-for-box-fragment⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">2.4.5.2. 
 Box Model of Reordering-induced Box Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">1.1. 
 Module Interactions</a>
@@ -3849,22 +3849,22 @@ Orienting Text: the text-orientation property</a>
 The Principal Writing Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inheritance' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">8. 
 The Principal Writing Mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-used-value①">(2)</a>
@@ -3874,8 +3874,8 @@ Abstract-to-Physical Mappings</a>
 The Principal Writing Mode</a> <a href="#ref-for-used-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-block-container①">(2)</a>
@@ -3885,50 +3885,50 @@ Block Flow Direction: the writing-mode property</a>
 Auto-sizing Other Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-formatting-context" class="dfn-panel" data-for="term-for-block-formatting-context" id="infopanel-for-term-for-block-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-block-formatting-context" style="display:none">Info about the 'block formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-formatting-context">https://drafts.csswg.org/css-display-3/#block-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-formatting-context">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow">https://drafts.csswg.org/css-display-3/#valdef-display-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flow" class="dfn-panel" data-for="term-for-valdef-display-flow" id="infopanel-for-term-for-valdef-display-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flow" style="display:none">Info about the 'flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow">https://drafts.csswg.org/css-display-3/#valdef-display-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flow-root">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flow-root" class="dfn-panel" data-for="term-for-valdef-display-flow-root" id="infopanel-for-term-for-valdef-display-flow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flow-root" style="display:none">Info about the 'flow-root' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">https://drafts.csswg.org/css-display-3/#valdef-display-flow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flow-root">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-flow">
-   <a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-flow" class="dfn-panel" data-for="term-for-in-flow" id="infopanel-for-term-for-in-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-in-flow" style="display:none">Info about the 'in-flow' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#in-flow">https://drafts.csswg.org/css-display-3/#in-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-flow">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-independent-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-independent-formatting-context" class="dfn-panel" data-for="term-for-independent-formatting-context" id="infopanel-for-term-for-independent-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-independent-formatting-context" style="display:none">Info about the 'independent formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#independent-formatting-context">https://drafts.csswg.org/css-display-3/#independent-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-independent-formatting-context">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">8.1. 
 Propagation to the Initial Containing Block</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -3936,8 +3936,8 @@ Embeddings and Overrides: the unicode-bidi property</a>
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-box">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-box" class="dfn-panel" data-for="term-for-inline-box" id="infopanel-for-term-for-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-box" style="display:none">Info about the 'inline box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-box">https://drafts.csswg.org/css-display-3/#inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-box">2.4.5. 
 Reordering-induced Box Fragmentation</a>
@@ -3947,8 +3947,8 @@ Conditions of Reordering-induced Box Fragmentation</a> <a href="#ref-for-inline-
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-block">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-block" class="dfn-panel" data-for="term-for-valdef-display-inline-block" id="infopanel-for-term-for-valdef-display-inline-block" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-block" style="display:none">Info about the 'inline-block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-block">https://drafts.csswg.org/css-display-3/#valdef-display-inline-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-block">3.2. 
 Block Flow Direction: the writing-mode property</a>
@@ -3958,15 +3958,15 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inner-display-type">
-   <a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inner-display-type" class="dfn-panel" data-for="term-for-inner-display-type" id="infopanel-for-term-for-inner-display-type" role="menu">
+   <span id="infopaneltitle-for-term-for-inner-display-type" style="display:none">Info about the 'inner display type' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inner-display-type">https://drafts.csswg.org/css-display-3/#inner-display-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-display-type">3.2. 
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-inner-display-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#replaced-element">https://drafts.csswg.org/css-display-3/#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">2.4.3. 
 Bidi Treatment of Atomic Inlines</a>
@@ -3974,71 +3974,71 @@ Bidi Treatment of Atomic Inlines</a>
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">7.3.3. 
 Auto-sizing Other Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flex-item">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-item" class="dfn-panel" data-for="term-for-flex-item" id="infopanel-for-term-for-flex-item" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-item" style="display:none">Info about the 'flex item' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-item">https://drafts.csswg.org/css-flexbox-1/#flex-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-item">7.3.3. 
 Auto-sizing Other Orthogonal Flow Roots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-feature-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-feature-settings" class="dfn-panel" data-for="term-for-propdef-font-feature-settings" id="infopanel-for-term-for-propdef-font-feature-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">9.1.3.1. 
 Full-width Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">9.1.3.1. 
 Full-width Characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-object-size">
-   <a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-object-size" class="dfn-panel" data-for="term-for-default-object-size" id="infopanel-for-term-for-default-object-size" role="menu">
+   <span id="infopaneltitle-for-term-for-default-object-size" style="display:none">Info about the 'default object size' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#default-object-size">https://drafts.csswg.org/css-images-3/#default-object-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-object-size">3.2. 
 Block Flow Direction: the writing-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" class="dfn-panel" data-for="term-for-valdef-alignment-baseline-baseline" id="infopanel-for-term-for-valdef-alignment-baseline-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-alignment-baseline-baseline" style="display:none">Info about the 'baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline">https://drafts.csswg.org/css-inline-3/#valdef-alignment-baseline-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-alignment-baseline-baseline">4.4. 
 Baseline Alignment</a> <a href="#ref-for-valdef-alignment-baseline-baseline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-root-inline-box">
-   <a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-root-inline-box" class="dfn-panel" data-for="term-for-root-inline-box" id="infopanel-for-term-for-root-inline-box" role="menu">
+   <span id="infopaneltitle-for-term-for-root-inline-box" style="display:none">Info about the 'root inline box' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#root-inline-box">https://drafts.csswg.org/css-inline-3/#root-inline-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-inline-box">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-sub">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-sub" class="dfn-panel" data-for="term-for-valdef-baseline-shift-sub" id="infopanel-for-term-for-valdef-baseline-shift-sub" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-sub" style="display:none">Info about the 'sub' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-sub</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-sub">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-baseline-shift-super">
-   <a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-baseline-shift-super" class="dfn-panel" data-for="term-for-valdef-baseline-shift-super" id="infopanel-for-term-for-valdef-baseline-shift-super" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-baseline-shift-super" style="display:none">Info about the 'super' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super">https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-super</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-baseline-shift-super">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">4. 
 Inline-level Alignment</a> <a href="#ref-for-propdef-vertical-align①">(2)</a>
@@ -4054,8 +4054,8 @@ Line-Relative Mappings</a>
 Layout Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">7.3.1. 
 Available Space in Orthogonal Flows</a>
@@ -4063,15 +4063,15 @@ Available Space in Orthogonal Flows</a>
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-rect" class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect" id="infopanel-for-term-for-funcdef-basic-shape-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-rect" style="display:none">Info about the 'rect()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-rect">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-speak-as-digits">
-   <a href="https://drafts.csswg.org/css-speech-1/#valdef-speak-as-digits">https://drafts.csswg.org/css-speech-1/#valdef-speak-as-digits</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-speak-as-digits" class="dfn-panel" data-for="term-for-valdef-speak-as-digits" id="infopanel-for-term-for-valdef-speak-as-digits" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-speak-as-digits" style="display:none">Info about the 'digits' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#valdef-speak-as-digits">https://drafts.csswg.org/css-speech-1/#valdef-speak-as-digits</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-speak-as-digits">9.1. 
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
@@ -4080,15 +4080,15 @@ Text Run Rules</a>
     <li><a href="#ref-for-valdef-speak-as-digits②"> New in Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-character">
-   <a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-character" class="dfn-panel" data-for="term-for-character" id="infopanel-for-term-for-character" role="menu">
+   <span id="infopaneltitle-for-term-for-character" style="display:none">Info about the 'character' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#character">https://drafts.csswg.org/css-text-3/#character</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-character">5.1.1. 
 Vertical Typesetting and Font Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-letter-spacing">https://drafts.csswg.org/css-text-3/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">9.1.2. 
 Layout Rules</a>
@@ -4096,8 +4096,8 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">6.3. 
 Line-relative Directions</a>
@@ -4109,8 +4109,8 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'document white space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">9.1.2. 
 Layout Rules</a>
@@ -4118,29 +4118,29 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-transform">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-transform" class="dfn-panel" data-for="term-for-propdef-text-transform" id="infopanel-for-term-for-propdef-text-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-transform" style="display:none">Info about the 'text-transform' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-transform">https://drafts.csswg.org/css-text-4/#propdef-text-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">9.1.3.1. 
 Full-width Characters</a> <a href="#ref-for-propdef-text-transform①">(2)</a> <a href="#ref-for-propdef-text-transform②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tracking">
-   <a href="https://drafts.csswg.org/css-text-4/#tracking">https://drafts.csswg.org/css-text-4/#tracking</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tracking" class="dfn-panel" data-for="term-for-tracking" id="infopanel-for-term-for-tracking" role="menu">
+   <span id="infopaneltitle-for-term-for-tracking" style="display:none">Info about the 'tracking' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#tracking">https://drafts.csswg.org/css-text-4/#tracking</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tracking">2.4.5.1. 
 Conditions of Reordering-induced Box Fragmentation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typographic-character-unit①">(2)</a> <a href="#ref-for-typographic-character-unit②">(3)</a> <a href="#ref-for-typographic-character-unit③">(4)</a>
@@ -4160,22 +4160,22 @@ Compression Rules</a> <a href="#ref-for-typographic-character-unit①⑦">(2)</a
 Full-width Characters</a> <a href="#ref-for-typographic-character-unit②③">(2)</a> <a href="#ref-for-typographic-character-unit②④">(3)</a> <a href="#ref-for-typographic-character-unit②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a>
@@ -4183,43 +4183,43 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a>
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.4. 
 Baseline Alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">9.1. 
 Horizontal-in-Vertical Composition: the text-combine-upright property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.2. 
 Value Definitions and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font-relative-length" class="dfn-panel" data-for="term-for-font-relative-length" id="infopanel-for-term-for-font-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-font-relative-length" style="display:none">Info about the 'font-relative lengths' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#font-relative-length">https://drafts.csswg.org/css-values-4/#font-relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-relative-length">1.1. 
 Module Interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Specifying Directionality: the direction property</a>
@@ -4235,29 +4235,29 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-c
 Horizontal-in-Vertical Composition: the text-combine-upright property</a> <a href="#ref-for-comb-one①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-border-spacing">https://drafts.csswg.org/css2/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-bottom">https://drafts.csswg.org/css2/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-caption-side-bottom">
-   <a href="https://drafts.csswg.org/css2/#valdef-caption-side-bottom">https://drafts.csswg.org/css2/#valdef-caption-side-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-caption-side-bottom" class="dfn-panel" data-for="term-for-valdef-caption-side-bottom" id="infopanel-for-term-for-valdef-caption-side-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-caption-side-bottom" style="display:none">Info about the 'bottom (for caption-side)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-caption-side-bottom">https://drafts.csswg.org/css2/#valdef-caption-side-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caption-side-bottom">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caption-side">
-   <a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caption-side" class="dfn-panel" data-for="term-for-propdef-caption-side" id="infopanel-for-term-for-propdef-caption-side" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caption-side" style="display:none">Info about the 'caption-side' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-caption-side">https://drafts.csswg.org/css2/#propdef-caption-side</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">7.4. 
 Flow-Relative Mappings</a> <a href="#ref-for-propdef-caption-side①">(2)</a>
@@ -4265,8 +4265,8 @@ Flow-Relative Mappings</a> <a href="#ref-for-propdef-caption-side①">(2)</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clear">
-   <a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clear" class="dfn-panel" data-for="term-for-propdef-clear" id="infopanel-for-term-for-propdef-clear" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clear" style="display:none">Info about the 'clear' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clear">https://drafts.csswg.org/css2/#propdef-clear</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">7.4. 
 Flow-Relative Mappings</a>
@@ -4274,15 +4274,15 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.csswg.org/css2/#propdef-clip">https://drafts.csswg.org/css2/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-clip">https://drafts.csswg.org/css2/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-display">https://drafts.csswg.org/css2/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-propdef-display①">(2)</a>
@@ -4296,8 +4296,8 @@ The Principal Writing Mode</a>
 2019 CSS Writing Modes Module Level 4 Candidate Recommendation</a> <a href="#ref-for-propdef-display⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">7.4. 
 Flow-Relative Mappings</a>
@@ -4305,15 +4305,15 @@ Flow-Relative Mappings</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-left">https://drafts.csswg.org/css2/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">7.2. 
 Dimensional Mapping</a>
@@ -4323,57 +4323,57 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-right">https://drafts.csswg.org/css2/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-top">https://drafts.csswg.org/css2/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-caption-side-top">
-   <a href="https://drafts.csswg.org/css2/#valdef-caption-side-top">https://drafts.csswg.org/css2/#valdef-caption-side-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-caption-side-top" class="dfn-panel" data-for="term-for-valdef-caption-side-top" id="infopanel-for-term-for-valdef-caption-side-top" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-caption-side-top" style="display:none">Info about the 'top (for caption-side)' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-caption-side-top">https://drafts.csswg.org/css2/#valdef-caption-side-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-caption-side-top">7.4. 
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">7.3.1. 
 Available Space in Orthogonal Flows</a>
@@ -4381,8 +4381,8 @@ Available Space in Orthogonal Flows</a>
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-valdef-width-auto②">(2)</a> <a href="#ref-for-valdef-width-auto③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available" role="menu">
+   <span id="infopaneltitle-for-term-for-available" style="display:none">Info about the 'available block space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space in Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -4392,8 +4392,8 @@ Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-available
 Auto-sizing Other Orthogonal Flow Roots</a> <a href="#ref-for-available⑨">(2)</a> <a href="#ref-for-available①⓪">(3)</a> <a href="#ref-for-available①①">(4)</a> <a href="#ref-for-available①②">(5)</a> <a href="#ref-for-available①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available①" role="menu">
+   <span id="infopaneltitle-for-term-for-available①" style="display:none">Info about the 'available inline space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space in Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -4403,8 +4403,8 @@ Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-available
 Auto-sizing Other Orthogonal Flow Roots</a> <a href="#ref-for-available⑨">(2)</a> <a href="#ref-for-available①⓪">(3)</a> <a href="#ref-for-available①①">(4)</a> <a href="#ref-for-available①②">(5)</a> <a href="#ref-for-available①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-available">
-   <a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-available" class="dfn-panel" data-for="term-for-available" id="infopanel-for-term-for-available②" role="menu">
+   <span id="infopaneltitle-for-term-for-available②" style="display:none">Info about the 'available space' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#available">https://drafts.csswg.org/css-sizing-3/#available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-available">7.3.1. 
 Available Space in Orthogonal Flows</a> <a href="#ref-for-available①">(2)</a> <a href="#ref-for-available②">(3)</a> <a href="#ref-for-available③">(4)</a> <a href="#ref-for-available④">(5)</a> <a href="#ref-for-available⑤">(6)</a>
@@ -4414,29 +4414,29 @@ Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-available
 Auto-sizing Other Orthogonal Flow Roots</a> <a href="#ref-for-available⑨">(2)</a> <a href="#ref-for-available①⓪">(3)</a> <a href="#ref-for-available①①">(4)</a> <a href="#ref-for-available①②">(5)</a> <a href="#ref-for-available①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-definite">
-   <a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-definite" class="dfn-panel" data-for="term-for-definite" id="infopanel-for-term-for-definite" role="menu">
+   <span id="infopaneltitle-for-term-for-definite" style="display:none">Info about the 'definite' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#definite">https://drafts.csswg.org/css-sizing-3/#definite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-definite">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-definite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fallback">
-   <a href="https://drafts.csswg.org/css-sizing-3/#fallback">https://drafts.csswg.org/css-sizing-3/#fallback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fallback" class="dfn-panel" data-for="term-for-fallback" id="infopanel-for-term-for-fallback" role="menu">
+   <span id="infopaneltitle-for-term-for-fallback" style="display:none">Info about the 'fallback' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#fallback">https://drafts.csswg.org/css-sizing-3/#fallback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fallback">7.3.1. 
 Available Space in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-width" class="dfn-panel" data-for="term-for-max-width" id="infopanel-for-term-for-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-max-width" style="display:none">Info about the 'max size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-width">https://drafts.csswg.org/css-sizing-3/#max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-width">7.3.1. 
 Available Space in Orthogonal Flows</a> <a href="#ref-for-max-width①">(2)</a>
@@ -4444,29 +4444,29 @@ Available Space in Orthogonal Flows</a> <a href="#ref-for-max-width①">(2)</a>
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-max-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-max-content" class="dfn-panel" data-for="term-for-valdef-width-max-content" id="infopanel-for-term-for-valdef-width-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-max-content" style="display:none">Info about the 'max-content' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-max-content">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-block-size">https://drafts.csswg.org/css-sizing-3/#max-content-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-block-size" class="dfn-panel" data-for="term-for-max-content-block-size" id="infopanel-for-term-for-max-content-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-block-size" style="display:none">Info about the 'max-content block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-block-size">https://drafts.csswg.org/css-sizing-3/#max-content-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-block-size">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-max-content-block-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content-inline-size" class="dfn-panel" data-for="term-for-max-content-inline-size" id="infopanel-for-term-for-max-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content-inline-size" style="display:none">Info about the 'max-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content-inline-size">https://drafts.csswg.org/css-sizing-3/#max-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content-inline-size">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-max-content-inline-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-max-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-max-content" class="dfn-panel" data-for="term-for-max-content" id="infopanel-for-term-for-max-content" role="menu">
+   <span id="infopaneltitle-for-term-for-max-content" style="display:none">Info about the 'max-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#max-content">https://drafts.csswg.org/css-sizing-3/#max-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-content">7.3. 
 Orthogonal Flows</a>
@@ -4474,8 +4474,8 @@ Orthogonal Flows</a>
 Auto-sizing Other Orthogonal Flow Roots</a> <a href="#ref-for-max-content②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-width" class="dfn-panel" data-for="term-for-min-width" id="infopanel-for-term-for-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-min-width" style="display:none">Info about the 'min size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-width">https://drafts.csswg.org/css-sizing-3/#min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-width">7.3.1. 
 Available Space in Orthogonal Flows</a> <a href="#ref-for-min-width①">(2)</a>
@@ -4483,92 +4483,92 @@ Available Space in Orthogonal Flows</a> <a href="#ref-for-min-width①">(2)</a>
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-min-width③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-block-size">https://drafts.csswg.org/css-sizing-3/#min-content-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-block-size" class="dfn-panel" data-for="term-for-min-content-block-size" id="infopanel-for-term-for-min-content-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-block-size" style="display:none">Info about the 'min-content block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-block-size">https://drafts.csswg.org/css-sizing-3/#min-content-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-block-size">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content-inline-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content-inline-size" class="dfn-panel" data-for="term-for-min-content-inline-size" id="infopanel-for-term-for-min-content-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content-inline-size" style="display:none">Info about the 'min-content inline size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content-inline-size">https://drafts.csswg.org/css-sizing-3/#min-content-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content-inline-size">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-min-content">
-   <a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-min-content" class="dfn-panel" data-for="term-for-min-content" id="infopanel-for-term-for-min-content" role="menu">
+   <span id="infopaneltitle-for-term-for-min-content" style="display:none">Info about the 'min-content size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#min-content">https://drafts.csswg.org/css-sizing-3/#min-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-min-content">7.3. 
 Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit" class="dfn-panel" data-for="term-for-stretch-fit" id="infopanel-for-term-for-stretch-fit" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit" style="display:none">Info about the 'stretch fit' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit">https://drafts.csswg.org/css-sizing-3/#stretch-fit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stretch-fit-block-size">
-   <a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-block-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stretch-fit-block-size" class="dfn-panel" data-for="term-for-stretch-fit-block-size" id="infopanel-for-term-for-stretch-fit-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-stretch-fit-block-size" style="display:none">Info about the 'stretch-fit block size' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#stretch-fit-block-size">https://drafts.csswg.org/css-sizing-3/#stretch-fit-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stretch-fit-block-size">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">7.2. 
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-3/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">7.5. 
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">7.6. 
 Purely Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-column-count-auto">
-   <a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-count-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-count-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-column-count-auto" class="dfn-panel" data-for="term-for-valdef-column-count-auto" id="infopanel-for-term-for-valdef-column-count-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-column-count-auto" style="display:none">Info about the 'auto (for column-count)' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-count-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-count-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-count-auto">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-valdef-column-count-auto①">(2)</a> <a href="#ref-for-valdef-column-count-auto②">(3)</a> <a href="#ref-for-valdef-column-count-auto③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-column-width-auto">
-   <a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-column-width-auto" class="dfn-panel" data-for="term-for-valdef-column-width-auto" id="infopanel-for-term-for-valdef-column-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-column-width-auto" style="display:none">Info about the 'auto (for column-width)' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto">https://drafts.csswg.org/css-multicol-1/#valdef-column-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-column-width-auto">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-valdef-column-width-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-count">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-count">https://drafts.csswg.org/css-multicol-1/#propdef-column-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-count" class="dfn-panel" data-for="term-for-propdef-column-count" id="infopanel-for-term-for-propdef-column-count" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-count" style="display:none">Info about the 'column-count' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-count">https://drafts.csswg.org/css-multicol-1/#propdef-column-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-count">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-propdef-column-count①">(2)</a> <a href="#ref-for-propdef-column-count②">(3)</a> <a href="#ref-for-propdef-column-count③">(4)</a> <a href="#ref-for-propdef-column-count④">(5)</a> <a href="#ref-for-propdef-column-count⑤">(6)</a> <a href="#ref-for-propdef-column-count⑥">(7)</a> <a href="#ref-for-propdef-column-count⑦">(8)</a> <a href="#ref-for-propdef-column-count⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-column-width">
-   <a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-column-width" class="dfn-panel" data-for="term-for-propdef-column-width" id="infopanel-for-term-for-propdef-column-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-column-width" style="display:none">Info about the 'column-width' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#propdef-column-width">https://drafts.csswg.org/css-multicol-1/#propdef-column-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-column-width">7.3.2. 
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-propdef-column-width①">(2)</a> <a href="#ref-for-propdef-column-width②">(3)</a> <a href="#ref-for-propdef-column-width③">(4)</a> <a href="#ref-for-propdef-column-width④">(5)</a> <a href="#ref-for-propdef-column-width⑤">(6)</a> <a href="#ref-for-propdef-column-width⑥">(7)</a> <a href="#ref-for-propdef-column-width⑦">(8)</a> <a href="#ref-for-propdef-column-width⑧">(9)</a> <a href="#ref-for-propdef-column-width⑨">(10)</a> <a href="#ref-for-propdef-column-width①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-progression">
-   <a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-progression" class="dfn-panel" data-for="term-for-page-progression" id="infopanel-for-term-for-page-progression" role="menu">
+   <span id="infopaneltitle-for-term-for-page-progression" style="display:none">Info about the 'page progression' external reference.</span><a href="https://drafts.csswg.org/css-page-3/#page-progression">https://drafts.csswg.org/css-page-3/#page-progression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-progression">8. 
 The Principal Writing Mode</a>
@@ -4576,8 +4576,8 @@ The Principal Writing Mode</a>
 Page Flow: the page progression direction</a> <a href="#ref-for-page-progression②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">8. 
 The Principal Writing Mode</a>
@@ -4585,8 +4585,8 @@ The Principal Writing Mode</a>
 2019 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paged-media">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paged-media" class="dfn-panel" data-for="term-for-paged-media" id="infopanel-for-term-for-paged-media" role="menu">
+   <span id="infopaneltitle-for-term-for-paged-media" style="display:none">Info about the 'paged media' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#paged-media">https://drafts.csswg.org/mediaqueries-5/#paged-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">8.2. 
 Page Flow: the page progression direction</a>
@@ -4972,8 +4972,8 @@ Page Flow: the page progression direction</a>
         but cause the box to overflow the containing block? <a class="issue-return" href="#issue-fae7187e" title="Jump to section">↵</a></div>
    <div class="issue"> Does it also propagate to @page boxes? <a class="issue-return" href="#issue-80e9901b" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="writing-mode">
-   <b><a href="#writing-mode">#writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writing-mode" class="dfn-panel" data-for="writing-mode" id="infopanel-for-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-writing-mode" style="display:none">Info about the 'writing mode' definition.</span><b><a href="#writing-mode">#writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writing-mode">1.1. 
 Module Interactions</a> <a href="#ref-for-writing-mode①">(2)</a>
@@ -4981,8 +4981,8 @@ Module Interactions</a> <a href="#ref-for-writing-mode①">(2)</a>
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-writing-mode③">(2)</a> <a href="#ref-for-writing-mode④">(3)</a> <a href="#ref-for-writing-mode⑤">(4)</a> <a href="#ref-for-writing-mode⑥">(5)</a> <a href="#ref-for-writing-mode⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-base-direction">
-   <b><a href="#inline-base-direction">#inline-base-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-base-direction" class="dfn-panel" data-for="inline-base-direction" id="infopanel-for-inline-base-direction" role="dialog">
+   <span id="infopaneltitle-for-inline-base-direction" style="display:none">Info about the 'inline base direction' definition.</span><b><a href="#inline-base-direction">#inline-base-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">1. 
 Introduction to Writing Modes</a>
@@ -4990,8 +4990,8 @@ Introduction to Writing Modes</a>
 Specifying Directionality: the direction property</a> <a href="#ref-for-inline-base-direction②">(2)</a> <a href="#ref-for-inline-base-direction③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-flow-direction">
-   <b><a href="#block-flow-direction">#block-flow-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-flow-direction" class="dfn-panel" data-for="block-flow-direction" id="infopanel-for-block-flow-direction" role="dialog">
+   <span id="infopaneltitle-for-block-flow-direction" style="display:none">Info about the 'block flow direction' definition.</span><b><a href="#block-flow-direction">#block-flow-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">1. 
 Introduction to Writing Modes</a>
@@ -5001,8 +5001,8 @@ Block Flow Direction: the writing-mode property</a> <a href="#ref-for-block-flow
 Flow-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typographic-mode">
-   <b><a href="#typographic-mode">#typographic-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typographic-mode" class="dfn-panel" data-for="typographic-mode" id="infopanel-for-typographic-mode" role="dialog">
+   <span id="infopaneltitle-for-typographic-mode" style="display:none">Info about the 'typographic mode' definition.</span><b><a href="#typographic-mode">#typographic-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-mode">3.2. 
 Block Flow Direction: the writing-mode property</a> <a href="#ref-for-typographic-mode①">(2)</a> <a href="#ref-for-typographic-mode②">(3)</a> <a href="#ref-for-typographic-mode③">(4)</a> <a href="#ref-for-typographic-mode④">(5)</a>
@@ -5016,8 +5016,8 @@ Baseline Alignment</a>
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typographic-mode⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-writing-mode">
-   <b><a href="#horizontal-writing-mode">#horizontal-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-writing-mode" class="dfn-panel" data-for="horizontal-writing-mode" id="infopanel-for-horizontal-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' definition.</span><b><a href="#horizontal-writing-mode">#horizontal-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">5.1. 
 Orienting Text: the text-orientation property</a>
@@ -5027,15 +5027,15 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-writing-mode">
-   <b><a href="#vertical-writing-mode">#vertical-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-writing-mode" class="dfn-panel" data-for="vertical-writing-mode" id="infopanel-for-vertical-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' definition.</span><b><a href="#vertical-writing-mode">#vertical-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">6.4. 
 Abstract-to-Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-direction">
-   <b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-direction" class="dfn-panel" data-for="propdef-direction" id="infopanel-for-propdef-direction" role="dialog">
+   <span id="infopaneltitle-for-propdef-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-direction①">(2)</a>
@@ -5067,8 +5067,8 @@ Principles of Layout in Vertical Writing Modes</a>
 The Principal Writing Mode</a> <a href="#ref-for-propdef-direction③④">(2)</a> <a href="#ref-for-propdef-direction③⑤">(3)</a> <a href="#ref-for-propdef-direction③⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-ltr">
-   <b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-ltr" class="dfn-panel" data-for="valdef-direction-ltr" id="infopanel-for-valdef-direction-ltr" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' definition.</span><b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -5084,8 +5084,8 @@ Abstract-to-Physical Mappings</a> <a href="#ref-for-valdef-direction-ltr⑤">(2)
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-rtl">
-   <b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-rtl" class="dfn-panel" data-for="valdef-direction-rtl" id="infopanel-for-valdef-direction-rtl" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' definition.</span><b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -5103,8 +5103,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-unicode-bidi">
-   <b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-unicode-bidi" class="dfn-panel" data-for="propdef-unicode-bidi" id="infopanel-for-propdef-unicode-bidi" role="dialog">
+   <span id="infopaneltitle-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' definition.</span><b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">1. 
 Introduction to Writing Modes</a>
@@ -5130,8 +5130,8 @@ Paragraph Breaks Within Embeddings and Isolates</a>
 Orienting Text: the text-orientation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-normal">
-   <b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-normal" class="dfn-panel" data-for="valdef-unicode-bidi-normal" id="infopanel-for-valdef-unicode-bidi-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-normal">2.1. 
 Specifying Directionality: the direction property</a>
@@ -5141,8 +5141,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Example of Bidirectional Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-embed">
-   <b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-embed" class="dfn-panel" data-for="valdef-unicode-bidi-embed" id="infopanel-for-valdef-unicode-bidi-embed" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-embed" style="display:none">Info about the 'embed' definition.</span><b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-embed">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-embed①">(2)</a>
@@ -5150,22 +5150,22 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Treatment of Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directional-embedding">
-   <b><a href="#directional-embedding">#directional-embedding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directional-embedding" class="dfn-panel" data-for="directional-embedding" id="infopanel-for-directional-embedding" role="dialog">
+   <span id="infopaneltitle-for-directional-embedding" style="display:none">Info about the 'directional embedding' definition.</span><b><a href="#directional-embedding">#directional-embedding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directional-embedding">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-isolate">
-   <b><a href="#valdef-unicode-bidi-isolate">#valdef-unicode-bidi-isolate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-isolate" class="dfn-panel" data-for="valdef-unicode-bidi-isolate" id="infopanel-for-valdef-unicode-bidi-isolate" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-isolate" style="display:none">Info about the 'isolate' definition.</span><b><a href="#valdef-unicode-bidi-isolate">#valdef-unicode-bidi-isolate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-isolate①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-isolate②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-isolate③">(4)</a> <a href="#ref-for-valdef-unicode-bidi-isolate④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidi-isolate">
-   <b><a href="#bidi-isolate">#bidi-isolate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidi-isolate" class="dfn-panel" data-for="bidi-isolate" id="infopanel-for-bidi-isolate" role="dialog">
+   <span id="infopaneltitle-for-bidi-isolate" style="display:none">Info about the 'bidi-isolates' definition.</span><b><a href="#bidi-isolate">#bidi-isolate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-isolate">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -5175,8 +5175,8 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isolated-sequence">
-   <b><a href="#isolated-sequence">#isolated-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isolated-sequence" class="dfn-panel" data-for="isolated-sequence" id="infopanel-for-isolated-sequence" role="dialog">
+   <span id="infopaneltitle-for-isolated-sequence" style="display:none">Info about the 'isolated sequence' definition.</span><b><a href="#isolated-sequence">#isolated-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isolated-sequence">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-isolated-sequence①">(2)</a>
@@ -5184,8 +5184,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-isolat
 Example of Bidirectional Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-bidi-override">
-   <b><a href="#valdef-unicode-bidi-bidi-override">#valdef-unicode-bidi-bidi-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-bidi-override" class="dfn-panel" data-for="valdef-unicode-bidi-bidi-override" id="infopanel-for-valdef-unicode-bidi-bidi-override" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-bidi-override" style="display:none">Info about the 'bidi-override' definition.</span><b><a href="#valdef-unicode-bidi-bidi-override">#valdef-unicode-bidi-bidi-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-bidi-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override③">(4)</a> <a href="#ref-for-valdef-unicode-bidi-bidi-override④">(5)</a>
@@ -5193,22 +5193,22 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Treatment of Atomic Inlines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directional-override">
-   <b><a href="#directional-override">#directional-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directional-override" class="dfn-panel" data-for="directional-override" id="infopanel-for-directional-override" role="dialog">
+   <span id="infopaneltitle-for-directional-override" style="display:none">Info about the 'directional override' definition.</span><b><a href="#directional-override">#directional-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directional-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-directional-override①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-isolate-override">
-   <b><a href="#valdef-unicode-bidi-isolate-override">#valdef-unicode-bidi-isolate-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-isolate-override" class="dfn-panel" data-for="valdef-unicode-bidi-isolate-override" id="infopanel-for-valdef-unicode-bidi-isolate-override" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-isolate-override" style="display:none">Info about the 'isolate-override' definition.</span><b><a href="#valdef-unicode-bidi-isolate-override">#valdef-unicode-bidi-isolate-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-isolate-override">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-isolate-override①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-plaintext">
-   <b><a href="#valdef-unicode-bidi-plaintext">#valdef-unicode-bidi-plaintext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-plaintext" class="dfn-panel" data-for="valdef-unicode-bidi-plaintext" id="infopanel-for-valdef-unicode-bidi-plaintext" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-plaintext" style="display:none">Info about the 'plaintext' definition.</span><b><a href="#valdef-unicode-bidi-plaintext">#valdef-unicode-bidi-plaintext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-plaintext">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef-unicode-bidi-plaintext①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-plaintext②">(3)</a> <a href="#ref-for-valdef-unicode-bidi-plaintext③">(4)</a>
@@ -5216,8 +5216,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-valdef
 Bidi Paragraph Embedding Levels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forced-paragraph-break">
-   <b><a href="#forced-paragraph-break">#forced-paragraph-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forced-paragraph-break" class="dfn-panel" data-for="forced-paragraph-break" id="infopanel-for-forced-paragraph-break" role="dialog">
+   <span id="infopaneltitle-for-forced-paragraph-break" style="display:none">Info about the 'forced paragraph break' definition.</span><b><a href="#forced-paragraph-break">#forced-paragraph-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-paragraph-break">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-forced-paragraph-break①">(2)</a>
@@ -5225,8 +5225,8 @@ Embeddings and Overrides: the unicode-bidi property</a> <a href="#ref-for-forced
 Paragraph Breaks Within Embeddings and Isolates</a> <a href="#ref-for-forced-paragraph-break③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidi-paragraph">
-   <b><a href="#bidi-paragraph">#bidi-paragraph</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidi-paragraph" class="dfn-panel" data-for="bidi-paragraph" id="infopanel-for-bidi-paragraph" role="dialog">
+   <span id="infopaneltitle-for-bidi-paragraph" style="display:none">Info about the 'paragraph' definition.</span><b><a href="#bidi-paragraph">#bidi-paragraph</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidi-paragraph">2.2. 
 Embeddings and Overrides: the unicode-bidi property</a>
@@ -5236,8 +5236,8 @@ CSS–Unicode Bidi Control Translation, Text Reordering</a>
 Paragraph Breaks Within Embeddings and Isolates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-writing-mode">
-   <b><a href="#propdef-writing-mode">#propdef-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-writing-mode" class="dfn-panel" data-for="propdef-writing-mode" id="infopanel-for-propdef-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' definition.</span><b><a href="#propdef-writing-mode">#propdef-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
@@ -5268,8 +5268,8 @@ The Principal Writing Mode</a> <a href="#ref-for-propdef-writing-mode②④">(2)
     <li><a href="#ref-for-propdef-writing-mode②⑦"> New in Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-horizontal-tb">
-   <b><a href="#valdef-writing-mode-horizontal-tb">#valdef-writing-mode-horizontal-tb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="valdef-writing-mode-horizontal-tb" id="infopanel-for-valdef-writing-mode-horizontal-tb" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' definition.</span><b><a href="#valdef-writing-mode-horizontal-tb">#valdef-writing-mode-horizontal-tb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">2.4.5.2. 
 Box Model of Reordering-induced Box Fragments</a>
@@ -5291,8 +5291,8 @@ Line-Relative Mappings</a>
 Page Flow: the page progression direction</a> <a href="#ref-for-valdef-writing-mode-horizontal-tb①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-vertical-rl">
-   <b><a href="#valdef-writing-mode-vertical-rl">#valdef-writing-mode-vertical-rl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-vertical-rl" class="dfn-panel" data-for="valdef-writing-mode-vertical-rl" id="infopanel-for-valdef-writing-mode-vertical-rl" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-vertical-rl" style="display:none">Info about the 'vertical-rl' definition.</span><b><a href="#valdef-writing-mode-vertical-rl">#valdef-writing-mode-vertical-rl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-rl">3.2. 
 Block Flow Direction: the writing-mode property</a>
@@ -5316,8 +5316,8 @@ Orthogonal Flows</a> <a href="#ref-for-valdef-writing-mode-vertical-rl①①">(2
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-vertical-lr">
-   <b><a href="#valdef-writing-mode-vertical-lr">#valdef-writing-mode-vertical-lr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-vertical-lr" class="dfn-panel" data-for="valdef-writing-mode-vertical-lr" id="infopanel-for-valdef-writing-mode-vertical-lr" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-vertical-lr" style="display:none">Info about the 'vertical-lr' definition.</span><b><a href="#valdef-writing-mode-vertical-lr">#valdef-writing-mode-vertical-lr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-vertical-lr">3.2.1.1. 
 Supporting SVG1.1 writing-mode values in CSS syntax</a>
@@ -5335,8 +5335,8 @@ Orthogonal Flows</a>
 Page Flow: the page progression direction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-sideways-rl">
-   <b><a href="#valdef-writing-mode-sideways-rl">#valdef-writing-mode-sideways-rl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-sideways-rl" class="dfn-panel" data-for="valdef-writing-mode-sideways-rl" id="infopanel-for-valdef-writing-mode-sideways-rl" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-sideways-rl" style="display:none">Info about the 'sideways-rl' definition.</span><b><a href="#valdef-writing-mode-sideways-rl">#valdef-writing-mode-sideways-rl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-rl">6.3. 
 Line-relative Directions</a>
@@ -5347,8 +5347,8 @@ Page Flow: the page progression direction</a>
     <li><a href="#ref-for-valdef-writing-mode-sideways-rl③"> New in Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-writing-mode-sideways-lr">
-   <b><a href="#valdef-writing-mode-sideways-lr">#valdef-writing-mode-sideways-lr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-writing-mode-sideways-lr" class="dfn-panel" data-for="valdef-writing-mode-sideways-lr" id="infopanel-for-valdef-writing-mode-sideways-lr" role="dialog">
+   <span id="infopaneltitle-for-valdef-writing-mode-sideways-lr" style="display:none">Info about the 'sideways-lr' definition.</span><b><a href="#valdef-writing-mode-sideways-lr">#valdef-writing-mode-sideways-lr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-sideways-lr">5.1.2. 
 Mixed Vertical Orientations</a>
@@ -5363,15 +5363,15 @@ Page Flow: the page progression direction</a>
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alphabetic-baseline">
-   <b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alphabetic-baseline" class="dfn-panel" data-for="alphabetic-baseline" id="infopanel-for-alphabetic-baseline" role="dialog">
+   <span id="infopaneltitle-for-alphabetic-baseline" style="display:none">Info about the 'alphabetic baseline' definition.</span><b><a href="#alphabetic-baseline">#alphabetic-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alphabetic-baseline">4.2. 
 Text Baselines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="central-baseline">
-   <b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-central-baseline" class="dfn-panel" data-for="central-baseline" id="infopanel-for-central-baseline" role="dialog">
+   <span id="infopaneltitle-for-central-baseline" style="display:none">Info about the 'central baseline' definition.</span><b><a href="#central-baseline">#central-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-central-baseline">4.2. 
 Text Baselines</a>
@@ -5379,8 +5379,8 @@ Text Baselines</a>
 2019 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-only">
-   <b><a href="#horizontal-only">#horizontal-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-only" class="dfn-panel" data-for="horizontal-only" id="infopanel-for-horizontal-only" role="dialog">
+   <span id="infopaneltitle-for-horizontal-only" style="display:none">Info about the 'horizontal-only' definition.</span><b><a href="#horizontal-only">#horizontal-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-only">5. 
 Introduction to Vertical Text Layout</a> <a href="#ref-for-horizontal-only①">(2)</a>
@@ -5388,8 +5388,8 @@ Introduction to Vertical Text Layout</a> <a href="#ref-for-horizontal-only①">(
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-only">
-   <b><a href="#vertical-only">#vertical-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-only" class="dfn-panel" data-for="vertical-only" id="infopanel-for-vertical-only" role="dialog">
+   <span id="infopaneltitle-for-vertical-only" style="display:none">Info about the 'vertical-only' definition.</span><b><a href="#vertical-only">#vertical-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-only">5. 
 Introduction to Vertical Text Layout</a>
@@ -5397,8 +5397,8 @@ Introduction to Vertical Text Layout</a>
 Vertical Scripts in Unicode</a> <a href="#ref-for-vertical-only②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bi-orientational">
-   <b><a href="#bi-orientational">#bi-orientational</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bi-orientational" class="dfn-panel" data-for="bi-orientational" id="infopanel-for-bi-orientational" role="dialog">
+   <span id="infopaneltitle-for-bi-orientational" style="display:none">Info about the 'bi-orientational' definition.</span><b><a href="#bi-orientational">#bi-orientational</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bi-orientational">5. 
 Introduction to Vertical Text Layout</a> <a href="#ref-for-bi-orientational①">(2)</a>
@@ -5406,29 +5406,30 @@ Introduction to Vertical Text Layout</a> <a href="#ref-for-bi-orientational①">
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-script">
-   <b><a href="#vertical-script">#vertical-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-script" class="dfn-panel" data-for="vertical-script" id="infopanel-for-vertical-script" role="dialog">
+   <span id="infopaneltitle-for-vertical-script" style="display:none">Info about the 'vertical script' definition.</span><b><a href="#vertical-script">#vertical-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-script">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-vertical-script①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-script">
-   <b><a href="#horizontal-script">#horizontal-script</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-script" class="dfn-panel" data-for="horizontal-script" id="infopanel-for-horizontal-script" role="dialog">
+   <span id="infopaneltitle-for-horizontal-script" style="display:none">Info about the 'horizontal script' definition.</span><b><a href="#horizontal-script">#horizontal-script</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-script">Appendix A:
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bi-orientational-transform">
-   <b><a href="#bi-orientational-transform">#bi-orientational-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bi-orientational-transform" class="dfn-panel" data-for="bi-orientational-transform" id="infopanel-for-bi-orientational-transform" role="dialog">
+   <span id="infopaneltitle-for-bi-orientational-transform" style="display:none">Info about the 'bi-orientational
+    transform' definition.</span><b><a href="#bi-orientational-transform">#bi-orientational-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bi-orientational-transform">5. 
 Introduction to Vertical Text Layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-orientation">
-   <b><a href="#propdef-text-orientation">#propdef-text-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-orientation" class="dfn-panel" data-for="propdef-text-orientation" id="infopanel-for-propdef-text-orientation" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' definition.</span><b><a href="#propdef-text-orientation">#propdef-text-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">1. 
 Introduction to Writing Modes</a> <a href="#ref-for-propdef-text-orientation①">(2)</a>
@@ -5458,8 +5459,8 @@ Layout Rules</a>
 2018 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-mixed">
-   <b><a href="#valdef-text-orientation-mixed">#valdef-text-orientation-mixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-mixed" class="dfn-panel" data-for="valdef-text-orientation-mixed" id="infopanel-for-valdef-text-orientation-mixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-mixed" style="display:none">Info about the 'mixed' definition.</span><b><a href="#valdef-text-orientation-mixed">#valdef-text-orientation-mixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-mixed">4.2. 
 Text Baselines</a>
@@ -5479,8 +5480,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Vertical Scripts in Unicode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-upright">
-   <b><a href="#valdef-text-orientation-upright">#valdef-text-orientation-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-upright" class="dfn-panel" data-for="valdef-text-orientation-upright" id="infopanel-for-valdef-text-orientation-upright" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-upright" style="display:none">Info about the 'upright' definition.</span><b><a href="#valdef-text-orientation-upright">#valdef-text-orientation-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-upright">4.2. 
 Text Baselines</a>
@@ -5494,8 +5495,8 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-v
 Abstract-to-Physical Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-orientation-sideways">
-   <b><a href="#valdef-text-orientation-sideways">#valdef-text-orientation-sideways</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-orientation-sideways" class="dfn-panel" data-for="valdef-text-orientation-sideways" id="infopanel-for-valdef-text-orientation-sideways" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-orientation-sideways" style="display:none">Info about the 'sideways' definition.</span><b><a href="#valdef-text-orientation-sideways">#valdef-text-orientation-sideways</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-orientation-sideways">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-valdef-text-orientation-sideways①">(2)</a>
@@ -5505,8 +5506,8 @@ Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-v
 Line-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typeset-upright">
-   <b><a href="#typeset-upright">#typeset-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typeset-upright" class="dfn-panel" data-for="typeset-upright" id="infopanel-for-typeset-upright" role="dialog">
+   <span id="infopaneltitle-for-typeset-upright" style="display:none">Info about the 'upright typesetting' definition.</span><b><a href="#typeset-upright">#typeset-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-upright">5.1. 
 Orienting Text: the text-orientation property</a>
@@ -5514,8 +5515,9 @@ Orienting Text: the text-orientation property</a>
 Mixed Vertical Orientations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typeset-sideways">
-   <b><a href="#typeset-sideways">#typeset-sideways</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typeset-sideways" class="dfn-panel" data-for="typeset-sideways" id="infopanel-for-typeset-sideways" role="dialog">
+   <span id="infopaneltitle-for-typeset-sideways" style="display:none">Info about the 'sideways typesetting
+    ' definition.</span><b><a href="#typeset-sideways">#typeset-sideways</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typeset-sideways">5.1. 
 Orienting Text: the text-orientation property</a> <a href="#ref-for-typeset-sideways">(2)</a>
@@ -5525,50 +5527,50 @@ Vertical Typesetting and Font Features</a>
 Mixed Vertical Orientations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-glyph-orientation-vertical">
-   <b><a href="#propdef-glyph-orientation-vertical">#propdef-glyph-orientation-vertical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-glyph-orientation-vertical" class="dfn-panel" data-for="propdef-glyph-orientation-vertical" id="infopanel-for-propdef-glyph-orientation-vertical" role="dialog">
+   <span id="infopaneltitle-for-propdef-glyph-orientation-vertical" style="display:none">Info about the 'glyph-orientation-vertical' definition.</span><b><a href="#propdef-glyph-orientation-vertical">#propdef-glyph-orientation-vertical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical">5.1.3. 
 Obsolete: the SVG1.1 glyph-orientation-vertical property</a> <a href="#ref-for-propdef-glyph-orientation-vertical①">(2)</a> <a href="#ref-for-propdef-glyph-orientation-vertical②">(3)</a> <a href="#ref-for-propdef-glyph-orientation-vertical③">(4)</a> <a href="#ref-for-propdef-glyph-orientation-vertical④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-axis">
-   <b><a href="#x-axis">#x-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-axis" class="dfn-panel" data-for="x-axis" id="infopanel-for-x-axis" role="dialog">
+   <span id="infopaneltitle-for-x-axis" style="display:none">Info about the 'x-axis' definition.</span><b><a href="#x-axis">#x-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-axis">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-x-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="horizontal-dimension">
-   <b><a href="#horizontal-dimension">#horizontal-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-horizontal-dimension" class="dfn-panel" data-for="horizontal-dimension" id="infopanel-for-horizontal-dimension" role="dialog">
+   <span id="infopaneltitle-for-horizontal-dimension" style="display:none">Info about the 'horizontal dimension' definition.</span><b><a href="#horizontal-dimension">#horizontal-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-dimension">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-horizontal-dimension①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="y-axis">
-   <b><a href="#y-axis">#y-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-y-axis" class="dfn-panel" data-for="y-axis" id="infopanel-for-y-axis" role="dialog">
+   <span id="infopaneltitle-for-y-axis" style="display:none">Info about the 'y-axis' definition.</span><b><a href="#y-axis">#y-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-y-axis">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-y-axis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertical-dimension">
-   <b><a href="#vertical-dimension">#vertical-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertical-dimension" class="dfn-panel" data-for="vertical-dimension" id="infopanel-for-vertical-dimension" role="dialog">
+   <span id="infopaneltitle-for-vertical-dimension" style="display:none">Info about the 'vertical dimension' definition.</span><b><a href="#vertical-dimension">#vertical-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-dimension">6.1. 
 Abstract Dimensions</a> <a href="#ref-for-vertical-dimension①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-axis">
-   <b><a href="#block-axis">#block-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-axis" class="dfn-panel" data-for="block-axis" id="infopanel-for-block-axis" role="dialog">
+   <span id="infopaneltitle-for-block-axis" style="display:none">Info about the 'block axis' definition.</span><b><a href="#block-axis">#block-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">7.3. 
 Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-axis">
-   <b><a href="#inline-axis">#inline-axis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-axis" class="dfn-panel" data-for="inline-axis" id="infopanel-for-inline-axis" role="dialog">
+   <span id="infopaneltitle-for-inline-axis" style="display:none">Info about the 'inline axis' definition.</span><b><a href="#inline-axis">#inline-axis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">4.1. 
 Introduction to Baselines</a>
@@ -5582,8 +5584,8 @@ Available Space in Orthogonal Flows</a>
 Auto-sizing Block Containers in Orthogonal Flows</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-size">
-   <b><a href="#block-size">#block-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-size" class="dfn-panel" data-for="block-size" id="infopanel-for-block-size" role="dialog">
+   <span id="infopaneltitle-for-block-size" style="display:none">Info about the 'block size' definition.</span><b><a href="#block-size">#block-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-size">7.2. 
 Dimensional Mapping</a>
@@ -5595,8 +5597,8 @@ Available Space in Orthogonal Flows</a> <a href="#ref-for-block-size⑥">(2)</a>
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-block-size⑨">(2)</a> <a href="#ref-for-block-size①⓪">(3)</a> <a href="#ref-for-block-size①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-size">
-   <b><a href="#inline-size">#inline-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-size" class="dfn-panel" data-for="inline-size" id="infopanel-for-inline-size" role="dialog">
+   <span id="infopaneltitle-for-inline-size" style="display:none">Info about the 'inline size' definition.</span><b><a href="#inline-size">#inline-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-size">7.2. 
 Dimensional Mapping</a> <a href="#ref-for-inline-size①">(2)</a>
@@ -5608,15 +5610,15 @@ Available Space in Orthogonal Flows</a> <a href="#ref-for-inline-size⑨">(2)</a
 Auto-sizing Block Containers in Orthogonal Flows</a> <a href="#ref-for-inline-size①②">(2)</a> <a href="#ref-for-inline-size①③">(3)</a> <a href="#ref-for-inline-size①④">(4)</a> <a href="#ref-for-inline-size①⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flow-relative-direction">
-   <b><a href="#flow-relative-direction">#flow-relative-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flow-relative-direction" class="dfn-panel" data-for="flow-relative-direction" id="infopanel-for-flow-relative-direction" role="dialog">
+   <span id="infopaneltitle-for-flow-relative-direction" style="display:none">Info about the 'flow-relative directions' definition.</span><b><a href="#flow-relative-direction">#flow-relative-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flow-relative-direction">7.1. 
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-start">
-   <b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-start" class="dfn-panel" data-for="block-start" id="infopanel-for-block-start" role="dialog">
+   <span id="infopaneltitle-for-block-start" style="display:none">Info about the 'block-start' definition.</span><b><a href="#block-start">#block-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-start">6. 
 Abstract Box Terminology</a>
@@ -5632,8 +5634,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a> <a href="#ref-for-block-start⑨">(2)</a> <a href="#ref-for-block-start①⓪">(3)</a> <a href="#ref-for-block-start①①">(4)</a> <a href="#ref-for-block-start①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-end">
-   <b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-end" class="dfn-panel" data-for="block-end" id="infopanel-for-block-end" role="dialog">
+   <span id="infopaneltitle-for-block-end" style="display:none">Info about the 'block-end' definition.</span><b><a href="#block-end">#block-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">6. 
 Abstract Box Terminology</a>
@@ -5647,8 +5649,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a> <a href="#ref-for-block-end⑦">(2)</a> <a href="#ref-for-block-end⑧">(3)</a> <a href="#ref-for-block-end⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-start">
-   <b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-start" class="dfn-panel" data-for="inline-start" id="infopanel-for-inline-start" role="dialog">
+   <span id="infopaneltitle-for-inline-start" style="display:none">Info about the 'inline-start' definition.</span><b><a href="#inline-start">#inline-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-start">6. 
 Abstract Box Terminology</a>
@@ -5662,8 +5664,8 @@ Dimensional Mapping</a>
 Flow-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-end">
-   <b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-end" class="dfn-panel" data-for="inline-end" id="infopanel-for-inline-end" role="dialog">
+   <span id="infopaneltitle-for-inline-end" style="display:none">Info about the 'inline-end' definition.</span><b><a href="#inline-end">#inline-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">6. 
 Abstract Box Terminology</a>
@@ -5673,8 +5675,8 @@ Flow-relative Directions</a> <a href="#ref-for-inline-end②">(2)</a> <a href="#
 Dimensional Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-start">
-   <b><a href="#css-start">#css-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-start" class="dfn-panel" data-for="css-start" id="infopanel-for-css-start" role="dialog">
+   <span id="infopaneltitle-for-css-start" style="display:none">Info about the 'start' definition.</span><b><a href="#css-start">#css-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-start">2.4.5.2. 
 Box Model of Reordering-induced Box Fragments</a> <a href="#ref-for-css-start①">(2)</a>
@@ -5688,8 +5690,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Flow-Relative Mappings</a> <a href="#ref-for-css-start⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-end">
-   <b><a href="#css-end">#css-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-end" class="dfn-panel" data-for="css-end" id="infopanel-for-css-end" role="dialog">
+   <span id="infopaneltitle-for-css-end" style="display:none">Info about the 'end' definition.</span><b><a href="#css-end">#css-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-end">2.4.5.2. 
 Box Model of Reordering-induced Box Fragments</a>
@@ -5699,22 +5701,22 @@ Abstract Box Terminology</a>
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-orientation">
-   <b><a href="#line-orientation">#line-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-orientation" class="dfn-panel" data-for="line-orientation" id="infopanel-for-line-orientation" role="dialog">
+   <span id="infopaneltitle-for-line-orientation" style="display:none">Info about the 'line orientation' definition.</span><b><a href="#line-orientation">#line-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-orientation">6.3. 
 Line-relative Directions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-relative-direction">
-   <b><a href="#line-relative-direction">#line-relative-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-relative-direction" class="dfn-panel" data-for="line-relative-direction" id="infopanel-for-line-relative-direction" role="dialog">
+   <span id="infopaneltitle-for-line-relative-direction" style="display:none">Info about the 'line-relative directions' definition.</span><b><a href="#line-relative-direction">#line-relative-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-relative-direction">7.5. 
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="over">
-   <b><a href="#over">#over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-over" class="dfn-panel" data-for="over" id="infopanel-for-over" role="dialog">
+   <span id="infopaneltitle-for-over" style="display:none">Info about the 'over' definition.</span><b><a href="#over">#over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-over">4.2. 
 Text Baselines</a>
@@ -5726,8 +5728,8 @@ Line-relative Directions</a>
 Line-Relative Mappings</a> <a href="#ref-for-over④">(2)</a> <a href="#ref-for-over⑤">(3)</a> <a href="#ref-for-over⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-over">
-   <b><a href="#line-over">#line-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-over" class="dfn-panel" data-for="line-over" id="infopanel-for-line-over" role="dialog">
+   <span id="infopaneltitle-for-line-over" style="display:none">Info about the 'line-over' definition.</span><b><a href="#line-over">#line-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-over">6. 
 Abstract Box Terminology</a>
@@ -5739,8 +5741,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="under">
-   <b><a href="#under">#under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-under" class="dfn-panel" data-for="under" id="infopanel-for-under" role="dialog">
+   <span id="infopaneltitle-for-under" style="display:none">Info about the 'under' definition.</span><b><a href="#under">#under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-under">4.2. 
 Text Baselines</a>
@@ -5750,8 +5752,8 @@ Atomic Inline Baselines</a> <a href="#ref-for-under②">(2)</a>
 Line-Relative Mappings</a> <a href="#ref-for-under④">(2)</a> <a href="#ref-for-under⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-under">
-   <b><a href="#line-under">#line-under</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-under" class="dfn-panel" data-for="line-under" id="infopanel-for-line-under" role="dialog">
+   <span id="infopaneltitle-for-line-under" style="display:none">Info about the 'line-under' definition.</span><b><a href="#line-under">#line-under</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-under">6. 
 Abstract Box Terminology</a>
@@ -5761,8 +5763,8 @@ Line-relative Directions</a>
 Principles of Layout in Vertical Writing Modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-left">
-   <b><a href="#line-left">#line-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-left" class="dfn-panel" data-for="line-left" id="infopanel-for-line-left" role="dialog">
+   <span id="infopaneltitle-for-line-left" style="display:none">Info about the 'line-left' definition.</span><b><a href="#line-left">#line-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-left">2.1. 
 Specifying Directionality: the direction property</a> <a href="#ref-for-line-left①">(2)</a>
@@ -5778,8 +5780,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a> <a href="#ref-for-line-left⑦">(2)</a> <a href="#ref-for-line-left⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-right">
-   <b><a href="#line-right">#line-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-right" class="dfn-panel" data-for="line-right" id="infopanel-for-line-right" role="dialog">
+   <span id="infopaneltitle-for-line-right" style="display:none">Info about the 'line-right' definition.</span><b><a href="#line-right">#line-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-right">2.1. 
 Specifying Directionality: the direction property</a> <a href="#ref-for-line-right①">(2)</a>
@@ -5793,8 +5795,8 @@ Principles of Layout in Vertical Writing Modes</a>
 Line-Relative Mappings</a> <a href="#ref-for-line-right⑥">(2)</a> <a href="#ref-for-line-right⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="establish-an-orthogonal-flow">
-   <b><a href="#establish-an-orthogonal-flow">#establish-an-orthogonal-flow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-establish-an-orthogonal-flow" class="dfn-panel" data-for="establish-an-orthogonal-flow" id="infopanel-for-establish-an-orthogonal-flow" role="dialog">
+   <span id="infopaneltitle-for-establish-an-orthogonal-flow" style="display:none">Info about the 'orthogonal flow' definition.</span><b><a href="#establish-an-orthogonal-flow">#establish-an-orthogonal-flow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-establish-an-orthogonal-flow">7.3. 
 Orthogonal Flows</a> <a href="#ref-for-establish-an-orthogonal-flow①">(2)</a> <a href="#ref-for-establish-an-orthogonal-flow②">(3)</a>
@@ -5806,8 +5808,8 @@ Auto-sizing Block Containers in Orthogonal Flows</a>
 Auto-sizing Other Orthogonal Flow Roots</a> <a href="#ref-for-establish-an-orthogonal-flow⑥">(2)</a> <a href="#ref-for-establish-an-orthogonal-flow⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="principal-writing-mode">
-   <b><a href="#principal-writing-mode">#principal-writing-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-principal-writing-mode" class="dfn-panel" data-for="principal-writing-mode" id="infopanel-for-principal-writing-mode" role="dialog">
+   <span id="infopaneltitle-for-principal-writing-mode" style="display:none">Info about the 'principal writing mode' definition.</span><b><a href="#principal-writing-mode">#principal-writing-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-writing-mode">8.1. 
 Propagation to the Initial Containing Block</a>
@@ -5817,8 +5819,8 @@ Page Flow: the page progression direction</a> <a href="#ref-for-principal-writin
 2019 CSS Writing Modes Module Level 4 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-combine-upright">
-   <b><a href="#propdef-text-combine-upright">#propdef-text-combine-upright</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-combine-upright" class="dfn-panel" data-for="propdef-text-combine-upright" id="infopanel-for-propdef-text-combine-upright" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' definition.</span><b><a href="#propdef-text-combine-upright">#propdef-text-combine-upright</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright①">9.1. 
 Horizontal-in-Vertical Composition: the text-combine-upright property</a> <a href="#ref-for-propdef-text-combine-upright②">(2)</a>
@@ -5835,8 +5837,8 @@ Full-width Characters</a> <a href="#ref-for-propdef-text-combine-upright①⓪">
     <li><a href="#ref-for-propdef-text-combine-upright①④"> New in Level 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-combine-upright-none">
-   <b><a href="#valdef-text-combine-upright-none">#valdef-text-combine-upright-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-combine-upright-none" class="dfn-panel" data-for="valdef-text-combine-upright-none" id="infopanel-for-valdef-text-combine-upright-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-combine-upright-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-text-combine-upright-none">#valdef-text-combine-upright-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-combine-upright-none">8. 
 The Principal Writing Mode</a>
@@ -5844,8 +5846,8 @@ The Principal Writing Mode</a>
 Text Run Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-combine-upright-all">
-   <b><a href="#valdef-text-combine-upright-all">#valdef-text-combine-upright-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-combine-upright-all" class="dfn-panel" data-for="valdef-text-combine-upright-all" id="infopanel-for-valdef-text-combine-upright-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-combine-upright-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-text-combine-upright-all">#valdef-text-combine-upright-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-combine-upright-all">9.1.1. 
 Text Run Rules</a>
@@ -5853,59 +5855,115 @@ Text Run Rules</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/css2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/css2/Overview.html
@@ -17429,65 +17429,65 @@ u\+[0-9a-f?]{1,6}/- return UNICODE_RANGE;
     can be found from on the CSS Working Group’s website at <a href="http://www.w3.org/Style/CSS/Test/">http://www.w3.org/Style/CSS/Test/</a>.
     Questions should be directed to the <a href="http://lists.w3.org/Archives/Public/public-css-testsuite">public-css-testsuite@w3.org</a> mailing list.</p>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-b">
-   <a href="https://drafts.csswg.org/css-color-5/#valdef-color-b">https://drafts.csswg.org/css-color-5/#valdef-color-b</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-b" class="dfn-panel" data-for="term-for-valdef-color-b" id="infopanel-for-term-for-valdef-color-b" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-b" style="display:none">Info about the 'b' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#valdef-color-b">https://drafts.csswg.org/css-color-5/#valdef-color-b</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-b">6.4.4. Precedence of non-CSS presentational hints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block">
-   <a href="https://drafts.csswg.org/css-display-3/#block">https://drafts.csswg.org/css-display-3/#block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block" class="dfn-panel" data-for="term-for-block" id="infopanel-for-term-for-block" role="menu">
+   <span id="infopaneltitle-for-term-for-block" style="display:none">Info about the 'block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block">https://drafts.csswg.org/css-display-3/#block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block">4.1.6. Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-run-in">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-run-in">https://drafts.csswg.org/css-display-3/#valdef-display-run-in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-run-in" class="dfn-panel" data-for="term-for-valdef-display-run-in" id="infopanel-for-term-for-valdef-display-run-in" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-run-in" style="display:none">Info about the 'run-in' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-run-in">https://drafts.csswg.org/css-display-3/#valdef-display-run-in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-run-in">4.3.8. Unsupported Values</a> <a href="#ref-for-valdef-display-run-in①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-newline">
-   <a href="https://drafts.csswg.org/css-syntax-3/#newline">https://drafts.csswg.org/css-syntax-3/#newline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-newline" class="dfn-panel" data-for="term-for-newline" id="infopanel-for-term-for-newline" role="menu">
+   <span id="infopaneltitle-for-term-for-newline" style="display:none">Info about the 'newline' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#newline">https://drafts.csswg.org/css-syntax-3/#newline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-newline">4.3.7. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-list-style-image-none">
-   <a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-image-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-image-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-list-style-image-none" class="dfn-panel" data-for="term-for-valdef-list-style-image-none" id="infopanel-for-term-for-valdef-list-style-image-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-list-style-image-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-image-none">https://drafts.csswg.org/css-lists-3/#valdef-list-style-image-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-image-none">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a> <a href="#ref-for-valdef-list-style-image-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.1.6. Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-aural">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural">https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-aural" class="dfn-panel" data-for="term-for-valdef-media-aural" id="infopanel-for-term-for-valdef-media-aural" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-aural" style="display:none">Info about the 'aural' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural">https://drafts.csswg.org/mediaqueries-5/#valdef-media-aural</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-aural">7.3. Recognized media types</a>
     <li><a href="#ref-for-valdef-media-aural①">Appendix A: Aural style sheets</a> <a href="#ref-for-valdef-media-aural②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-property-name">
-   <b><a href="#propdef-property-name">#propdef-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-property-name" class="dfn-panel" data-for="propdef-property-name" id="infopanel-for-propdef-property-name" role="dialog">
+   <span id="infopaneltitle-for-propdef-property-name" style="display:none">Info about the 'property-name' definition.</span><b><a href="#propdef-property-name">#propdef-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-property-name">1.4.2.1. Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-comma">
-   <b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-comma" class="dfn-panel" data-for="comb-comma" id="infopanel-for-comb-comma" role="dialog">
+   <span id="infopaneltitle-for-comb-comma" style="display:none">Info about the ',' definition.</span><b><a href="#comb-comma">#comb-comma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-comma">15.3. Font family: the font-family property</a>
     <li><a href="#ref-for-comb-comma①">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-one">
-   <b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-one" class="dfn-panel" data-for="comb-one" id="infopanel-for-comb-one" role="dialog">
+   <span id="infopaneltitle-for-comb-one" style="display:none">Info about the '|' definition.</span><b><a href="#comb-one">#comb-one</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">8.3. Margin properties:
 margin-top,
@@ -17584,8 +17584,8 @@ property</a> <a href="#ref-for-comb-one②③①">(2)</a>
     <li><a href="#ref-for-comb-one②⑤④">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-comb-one②⑤⑤">(2)</a> <a href="#ref-for-comb-one②⑤⑥">(3)</a> <a href="#ref-for-comb-one②⑤⑦">(4)</a> <a href="#ref-for-comb-one②⑤⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comb-any">
-   <b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comb-any" class="dfn-panel" data-for="comb-any" id="infopanel-for-comb-any" role="dialog">
+   <span id="infopaneltitle-for-comb-any" style="display:none">Info about the '||' definition.</span><b><a href="#comb-any">#comb-any</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">8.5.4. Border shorthand properties:
 border-top,
@@ -17605,15 +17605,15 @@ property</a> <a href="#ref-for-comb-any①④">(2)</a> <a href="#ref-for-comb-an
     <li><a href="#ref-for-comb-any①⑥">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-comb-any①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-zero-plus">
-   <b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-zero-plus" class="dfn-panel" data-for="mult-zero-plus" id="infopanel-for-mult-zero-plus" role="dialog">
+   <span id="infopaneltitle-for-mult-zero-plus" style="display:none">Info about the '*' definition.</span><b><a href="#mult-zero-plus">#mult-zero-plus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">15.3. Font family: the font-family property</a>
     <li><a href="#ref-for-mult-zero-plus①">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-one-plus">
-   <b><a href="#mult-one-plus">#mult-one-plus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-one-plus" class="dfn-panel" data-for="mult-one-plus" id="infopanel-for-mult-one-plus" role="dialog">
+   <span id="infopaneltitle-for-mult-one-plus" style="display:none">Info about the '+' definition.</span><b><a href="#mult-one-plus">#mult-one-plus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">1.4.2.1. Value</a>
     <li><a href="#ref-for-mult-one-plus">12.2. The content property</a>
@@ -17621,8 +17621,8 @@ property</a> <a href="#ref-for-comb-any①④">(2)</a> <a href="#ref-for-comb-an
     <li><a href="#ref-for-mult-one-plus②">12.4. Automatic counters and numbering</a> <a href="#ref-for-mult-one-plus③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-opt">
-   <b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-opt" class="dfn-panel" data-for="mult-opt" id="infopanel-for-mult-opt" role="dialog">
+   <span id="infopaneltitle-for-mult-opt" style="display:none">Info about the '?' definition.</span><b><a href="#mult-opt">#mult-opt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">12.4. Automatic counters and numbering</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -17632,8 +17632,8 @@ background </a>
     <li><a href="#ref-for-mult-opt⑤">17.6.1. The separated borders model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mult-num-range">
-   <b><a href="#mult-num-range">#mult-num-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mult-num-range" class="dfn-panel" data-for="mult-num-range" id="infopanel-for-mult-num-range" role="dialog">
+   <span id="infopaneltitle-for-mult-num-range" style="display:none">Info about the '{A,B}' definition.</span><b><a href="#mult-num-range">#mult-num-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">1.4.2.1. Value</a>
     <li><a href="#ref-for-mult-num-range">8.3. Margin properties:
@@ -17665,78 +17665,86 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shorthand-properties">
-   <b><a href="#shorthand-properties">#shorthand-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shorthand-properties" class="dfn-panel" data-for="shorthand-properties" id="infopanel-for-shorthand-properties" role="dialog">
+   <span id="infopaneltitle-for-shorthand-properties" style="display:none">Info about the 'shorthand properties' definition.</span><b><a href="#shorthand-properties">#shorthand-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-properties">6.4.2. !important rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formatting-structure">
-   <b><a href="#formatting-structure">#formatting-structure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formatting-structure" class="dfn-panel" data-for="formatting-structure" id="infopanel-for-formatting-structure" role="dialog">
+   <span id="infopaneltitle-for-formatting-structure" style="display:none">Info about the '
+formatting
+structure' definition.</span><b><a href="#formatting-structure">#formatting-structure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-structure">9.2.4. The display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canvas">
-   <b><a href="#canvas">#canvas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canvas" class="dfn-panel" data-for="canvas" id="infopanel-for-canvas" role="dialog">
+   <span id="infopaneltitle-for-canvas" style="display:none">Info about the ' canvas' definition.</span><b><a href="#canvas">#canvas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">2.3.2. CSS 2 addressing model</a>
     <li><a href="#ref-for-canvas">9.1.1. The viewport</a>
     <li><a href="#ref-for-canvas">14.2. The background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-style-sheet">
-   <b><a href="#valid-style-sheet">#valid-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-style-sheet" class="dfn-panel" data-for="valid-style-sheet" id="infopanel-for-valid-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-valid-style-sheet" style="display:none">Info about the 'Valid style
+sheet' definition.</span><b><a href="#valid-style-sheet">#valid-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-style-sheet">3.2. UA Conformance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="doclanguage">
-   <b><a href="#doclanguage">#doclanguage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-doclanguage" class="dfn-panel" data-for="doclanguage" id="infopanel-for-doclanguage" role="dialog">
+   <span id="infopaneltitle-for-doclanguage" style="display:none">Info about the 'Document language' definition.</span><b><a href="#doclanguage">#doclanguage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-doclanguage">17.1. Introduction to tables</a>
     <li><a href="#ref-for-doclanguage">17.2. The CSS table model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element">
-   <b><a href="#element">#element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element" class="dfn-panel" data-for="element" id="infopanel-for-element" role="dialog">
+   <span id="infopaneltitle-for-element" style="display:none">Info about the 'Element' definition.</span><b><a href="#element">#element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replaced-element">
-   <b><a href="#replaced-element">#replaced-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replaced-element" class="dfn-panel" data-for="replaced-element" id="infopanel-for-replaced-element" role="dialog">
+   <span id="infopaneltitle-for-replaced-element" style="display:none">Info about the '
+Replaced
+element' definition.</span><b><a href="#replaced-element">#replaced-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">Appendix D: Default style sheet for HTML 4</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic">
-   <b><a href="#intrinsic">#intrinsic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic" class="dfn-panel" data-for="intrinsic" id="infopanel-for-intrinsic" role="dialog">
+   <span id="infopaneltitle-for-intrinsic" style="display:none">Info about the 'Intrinsic dimensions' definition.</span><b><a href="#intrinsic">#intrinsic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic">9.1. Introduction to the visual formatting model</a>
     <li><a href="#ref-for-intrinsic">10.6.5. Absolutely positioned, replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute">
-   <b><a href="#attribute">#attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute" class="dfn-panel" data-for="attribute" id="infopanel-for-attribute" role="dialog">
+   <span id="infopaneltitle-for-attribute" style="display:none">Info about the 'Attribute' definition.</span><b><a href="#attribute">#attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute">3.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content">
-   <b><a href="#content">#content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content" class="dfn-panel" data-for="content" id="infopanel-for-content" role="dialog">
+   <span id="infopaneltitle-for-content" style="display:none">Info about the 'Content' definition.</span><b><a href="#content">#content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content">3.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rendered-content">
-   <b><a href="#rendered-content">#rendered-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rendered-content" class="dfn-panel" data-for="rendered-content" id="infopanel-for-rendered-content" role="dialog">
+   <span id="infopaneltitle-for-rendered-content" style="display:none">Info about the 'Rendered
+content' definition.</span><b><a href="#rendered-content">#rendered-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rendered-content">8.1. Box dimensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="doctree">
-   <b><a href="#doctree">#doctree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-doctree" class="dfn-panel" data-for="doctree" id="infopanel-for-doctree" role="dialog">
+   <span id="infopaneltitle-for-doctree" style="display:none">Info about the '
+Document
+tree' definition.</span><b><a href="#doctree">#doctree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-doctree">2.3. The CSS 2 processing model</a>
     <li><a href="#ref-for-doctree">3.2. UA Conformance</a>
@@ -17761,8 +17769,8 @@ pseudo-elements</a>
     <li><a href="#ref-for-doctree">13.3. Page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root">
-   <b><a href="#root">#root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-root" class="dfn-panel" data-for="root" id="infopanel-for-root" role="dialog">
+   <span id="infopaneltitle-for-root" style="display:none">Info about the 'root' definition.</span><b><a href="#root">#root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root">4.3.3.  Percentages</a>
     <li><a href="#ref-for-root">10.1. Definition of "containing
@@ -17770,32 +17778,33 @@ block"</a>
     <li><a href="#ref-for-root">10.5. Content height: the height property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="author">
-   <b><a href="#author">#author</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-author" class="dfn-panel" data-for="author" id="infopanel-for-author" role="dialog">
+   <span id="infopaneltitle-for-author" style="display:none">Info about the 'Author' definition.</span><b><a href="#author">#author</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-author">3.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user">
-   <b><a href="#user">#user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user" class="dfn-panel" data-for="user" id="infopanel-for-user" role="dialog">
+   <span id="infopaneltitle-for-user" style="display:none">Info about the 'User' definition.</span><b><a href="#user">#user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user">3.1. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent">
-   <b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent" class="dfn-panel" data-for="user-agent" id="infopanel-for-user-agent" role="dialog">
+   <span id="infopaneltitle-for-user-agent" style="display:none">Info about the 'User agent
+(UA)' definition.</span><b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">3.1. Definitions</a> <a href="#ref-for-user-agent">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="property">
-   <b><a href="#property">#property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-property" class="dfn-panel" data-for="property" id="infopanel-for-property" role="dialog">
+   <span id="infopaneltitle-for-property" style="display:none">Info about the 'Property' definition.</span><b><a href="#property">#property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-property">4.1.8. Declarations and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-identifier">
-   <b><a href="#value-def-identifier">#value-def-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-identifier" class="dfn-panel" data-for="value-def-identifier" id="infopanel-for-value-def-identifier" role="dialog">
+   <span id="infopaneltitle-for-value-def-identifier" style="display:none">Info about the 'identifiers' definition.</span><b><a href="#value-def-identifier">#value-def-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-identifier">4.1.2. Keywords</a>
     <li><a href="#ref-for-value-def-identifier">4.1.3. Characters and case</a>
@@ -17807,8 +17816,9 @@ At-rules</a>
     <li><a href="#ref-for-value-def-identifier">15.3. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="escaped-characters">
-   <b><a href="#escaped-characters">#escaped-characters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-escaped-characters" class="dfn-panel" data-for="escaped-characters" id="infopanel-for-escaped-characters" role="dialog">
+   <span id="infopaneltitle-for-escaped-characters" style="display:none">Info about the ' character
+    escape.' definition.</span><b><a href="#escaped-characters">#escaped-characters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-escaped-characters">4.1.6. Blocks</a>
     <li><a href="#ref-for-escaped-characters">4.1.8. Declarations and properties</a>
@@ -17818,41 +17828,42 @@ At-rules</a>
 CSS1</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-rules-dfn">
-   <b><a href="#at-rules-dfn">#at-rules-dfn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-rules-dfn" class="dfn-panel" data-for="at-rules-dfn" id="infopanel-for-at-rules-dfn" role="dialog">
+   <span id="infopaneltitle-for-at-rules-dfn" style="display:none">Info about the '
+At-rules' definition.</span><b><a href="#at-rules-dfn">#at-rules-dfn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-rules-dfn">4.1.4. Statements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rule-sets-dfn">
-   <b><a href="#rule-sets-dfn">#rule-sets-dfn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rule-sets-dfn" class="dfn-panel" data-for="rule-sets-dfn" id="infopanel-for-rule-sets-dfn" role="dialog">
+   <span id="infopaneltitle-for-rule-sets-dfn" style="display:none">Info about the 'rule set' definition.</span><b><a href="#rule-sets-dfn">#rule-sets-dfn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rule-sets-dfn">4.1.4. Statements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ignore①">
-   <b><a href="#ignore①">#ignore①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ignore①" class="dfn-panel" data-for="ignore①" id="infopanel-for-ignore①" role="dialog">
+   <span id="infopaneltitle-for-ignore①" style="display:none">Info about the 'ignore' definition.</span><b><a href="#ignore①">#ignore①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ignore①">3.2. UA Conformance</a> <a href="#ref-for-ignore①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-integer">
-   <b><a href="#value-def-integer">#value-def-integer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-integer" class="dfn-panel" data-for="value-def-integer" id="infopanel-for-value-def-integer" role="dialog">
+   <span id="infopaneltitle-for-value-def-integer" style="display:none">Info about the '&lt;integer>' definition.</span><b><a href="#value-def-integer">#value-def-integer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-integer">9.9.1. Specifying the stack level: the z-index property</a> <a href="#ref-for-value-def-integer①">(2)</a>
     <li><a href="#ref-for-value-def-integer②">12.4. Automatic counters and numbering</a> <a href="#ref-for-value-def-integer③">(2)</a>
     <li><a href="#ref-for-value-def-integer④">13.3.2. Breaks inside elements: orphans, widows</a> <a href="#ref-for-value-def-integer⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-number">
-   <b><a href="#value-def-number">#value-def-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-number" class="dfn-panel" data-for="value-def-number" id="infopanel-for-value-def-number" role="dialog">
+   <span id="infopaneltitle-for-value-def-number" style="display:none">Info about the '&lt;number>' definition.</span><b><a href="#value-def-number">#value-def-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-number">4.3.3.  Percentages</a>
     <li><a href="#ref-for-value-def-number①">10.8.1. Leading and half-leading</a> <a href="#ref-for-value-def-number②">(2)</a> <a href="#ref-for-value-def-number③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-length">
-   <b><a href="#value-def-length">#value-def-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-length" class="dfn-panel" data-for="value-def-length" id="infopanel-for-value-def-length" role="dialog">
+   <span id="infopaneltitle-for-value-def-length" style="display:none">Info about the '&lt;length>' definition.</span><b><a href="#value-def-length">#value-def-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-length">1.4.2.1. Value</a> <a href="#ref-for-value-def-length①">(2)</a> <a href="#ref-for-value-def-length②">(3)</a>
     <li><a href="#ref-for-value-def-length③">8.3. Margin properties:
@@ -17888,8 +17899,8 @@ property</a>
     <li><a href="#ref-for-value-def-length④①">17.6.1. The separated borders model</a> <a href="#ref-for-value-def-length④②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="em-width">
-   <b><a href="#em-width">#em-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-em-width" class="dfn-panel" data-for="em-width" id="infopanel-for-em-width" role="dialog">
+   <span id="infopaneltitle-for-em-width" style="display:none">Info about the 'em' definition.</span><b><a href="#em-width">#em-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em-width">4.3.2. Lengths</a> <a href="#ref-for-em-width①">(2)</a>
     <li><a href="#ref-for-em-width②">6.1.2. 
@@ -17906,8 +17917,8 @@ padding </a>
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ex">
-   <b><a href="#ex">#ex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ex" class="dfn-panel" data-for="ex" id="infopanel-for-ex" role="dialog">
+   <span id="infopaneltitle-for-ex" style="display:none">Info about the 'ex' definition.</span><b><a href="#ex">#ex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ex">4.3.2. Lengths</a> <a href="#ref-for-ex①">(2)</a> <a href="#ref-for-ex②">(3)</a> <a href="#ref-for-ex③">(4)</a>
     <li><a href="#ref-for-ex④">6.1.2. 
@@ -17917,8 +17928,8 @@ Computed values</a>
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-percentage">
-   <b><a href="#value-def-percentage">#value-def-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-percentage" class="dfn-panel" data-for="value-def-percentage" id="infopanel-for-value-def-percentage" role="dialog">
+   <span id="infopaneltitle-for-value-def-percentage" style="display:none">Info about the '&lt;percentage>' definition.</span><b><a href="#value-def-percentage">#value-def-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-percentage">1.4.2.1. Value</a>
     <li><a href="#ref-for-value-def-percentage①">8.3. Margin properties:
@@ -17948,8 +17959,8 @@ property</a>
     <li><a href="#ref-for-value-def-percentage③②">17.5.3. Table height algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-uri">
-   <b><a href="#value-def-uri">#value-def-uri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-uri" class="dfn-panel" data-for="value-def-uri" id="infopanel-for-value-def-uri" role="dialog">
+   <span id="infopaneltitle-for-value-def-uri" style="display:none">Info about the '&lt;uri>' definition.</span><b><a href="#value-def-uri">#value-def-uri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-uri">1.4.2.1. Value</a> <a href="#ref-for-value-def-uri①">(2)</a>
     <li><a href="#ref-for-value-def-uri②">12.2. The content property</a> <a href="#ref-for-value-def-uri③">(2)</a>
@@ -17961,27 +17972,28 @@ background </a> <a href="#ref-for-value-def-uri⑥">(2)</a>
     <li><a href="#ref-for-value-def-uri⑦">18.1. Cursors: the cursor property</a> <a href="#ref-for-value-def-uri⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-counter">
-   <b><a href="#value-def-counter">#value-def-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-counter" class="dfn-panel" data-for="value-def-counter" id="infopanel-for-value-def-counter" role="dialog">
+   <span id="infopaneltitle-for-value-def-counter" style="display:none">Info about the 'Counters' definition.</span><b><a href="#value-def-counter">#value-def-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-counter">12.2. The content property</a> <a href="#ref-for-value-def-counter①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-counter">
-   <b><a href="#funcdef-counter">#funcdef-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-counter" class="dfn-panel" data-for="funcdef-counter" id="infopanel-for-funcdef-counter" role="dialog">
+   <span id="infopaneltitle-for-funcdef-counter" style="display:none">Info about the '
+counter(&lt;identifier>)' definition.</span><b><a href="#funcdef-counter">#funcdef-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counter">12.2. The content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-counters">
-   <b><a href="#funcdef-counters">#funcdef-counters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-counters" class="dfn-panel" data-for="funcdef-counters" id="infopanel-for-funcdef-counters" role="dialog">
+   <span id="infopaneltitle-for-funcdef-counters" style="display:none">Info about the 'counters(&lt;identifier>, &lt;string>)' definition.</span><b><a href="#funcdef-counters">#funcdef-counters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-counters">12.2. The content property</a>
     <li><a href="#ref-for-funcdef-counters①">12.4.1. Nested counters and scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-color">
-   <b><a href="#value-def-color">#value-def-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-color" class="dfn-panel" data-for="value-def-color" id="infopanel-for-value-def-color" role="dialog">
+   <span id="infopaneltitle-for-value-def-color" style="display:none">Info about the '&lt;color>' definition.</span><b><a href="#value-def-color">#value-def-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-color">8.5.2. Border color:
 border-top-color,
@@ -17996,22 +18008,22 @@ background </a> <a href="#ref-for-value-def-color⑤">(2)</a>
     <li><a href="#ref-for-value-def-color⑥">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-blue">
-   <b><a href="#valdef-color-blue">#valdef-color-blue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-blue" class="dfn-panel" data-for="valdef-color-blue" id="infopanel-for-valdef-color-blue" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-blue" style="display:none">Info about the 'blue' definition.</span><b><a href="#valdef-color-blue">#valdef-color-blue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-blue">5.12.2. The :first-letter pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-red">
-   <b><a href="#valdef-color-red">#valdef-color-red</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-red" class="dfn-panel" data-for="valdef-color-red" id="infopanel-for-valdef-color-red" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-red" style="display:none">Info about the 'red' definition.</span><b><a href="#valdef-color-red">#valdef-color-red</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-red">2.1. A brief CSS 2 tutorial for HTML</a>
     <li><a href="#ref-for-valdef-color-red①">3.1. Definitions</a>
     <li><a href="#ref-for-valdef-color-red②">5.12.2. The :first-letter pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-color-silver">
-   <b><a href="#valdef-color-silver">#valdef-color-silver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-color-silver" class="dfn-panel" data-for="valdef-color-silver" id="infopanel-for-valdef-color-silver" role="dialog">
+   <span id="infopaneltitle-for-valdef-color-silver" style="display:none">Info about the 'silver' definition.</span><b><a href="#valdef-color-silver">#valdef-color-silver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-silver">8.5.3. Border style:
 border-top-style,
@@ -18021,97 +18033,100 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-string">
-   <b><a href="#value-def-string">#value-def-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-string" class="dfn-panel" data-for="value-def-string" id="infopanel-for-value-def-string" role="dialog">
+   <span id="infopaneltitle-for-value-def-string" style="display:none">Info about the 'Strings' definition.</span><b><a href="#value-def-string">#value-def-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-string">12.2. The content property</a> <a href="#ref-for-value-def-string①">(2)</a>
     <li><a href="#ref-for-value-def-string②">12.3.1. Specifying quotes with the quotes property</a> <a href="#ref-for-value-def-string③">(2)</a> <a href="#ref-for-value-def-string④">(3)</a> <a href="#ref-for-value-def-string⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-selector">
-   <b><a href="#simple-selector">#simple-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-selector" class="dfn-panel" data-for="simple-selector" id="infopanel-for-simple-selector" role="dialog">
+   <span id="infopaneltitle-for-simple-selector" style="display:none">Info about the 'simple selector' definition.</span><b><a href="#simple-selector">#simple-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-selector">5.3. Universal selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selector①">
-   <b><a href="#selector①">#selector①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selector①" class="dfn-panel" data-for="selector①" id="infopanel-for-selector①" role="dialog">
+   <span id="infopaneltitle-for-selector①" style="display:none">Info about the 'selector' definition.</span><b><a href="#selector①">#selector①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector①">4.1.7. Rule sets, declaration blocks, and selectors</a>
     <li><a href="#ref-for-selector①①">5.1. Pattern matching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-first-child">
-   <b><a href="#selectordef-first-child">#selectordef-first-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first-child" class="dfn-panel" data-for="selectordef-first-child" id="infopanel-for-selectordef-first-child" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first-child" style="display:none">Info about the ':first-child' definition.</span><b><a href="#selectordef-first-child">#selectordef-first-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-child">5.10. Pseudo-elements and pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-link">
-   <b><a href="#selectordef-link">#selectordef-link</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-link" class="dfn-panel" data-for="selectordef-link" id="infopanel-for-selectordef-link" role="dialog">
+   <span id="infopaneltitle-for-selectordef-link" style="display:none">Info about the ':link' definition.</span><b><a href="#selectordef-link">#selectordef-link</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-link">5.11.2. The link pseudo-classes: :link and :visited</a> <a href="#ref-for-selectordef-link①">(2)</a>
     <li><a href="#ref-for-selectordef-link②">5.11.3. The dynamic pseudo-classes:
 :hover, :active, and :focus</a> <a href="#ref-for-selectordef-link③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-visited">
-   <b><a href="#selectordef-visited">#selectordef-visited</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-visited" class="dfn-panel" data-for="selectordef-visited" id="infopanel-for-selectordef-visited" role="dialog">
+   <span id="infopaneltitle-for-selectordef-visited" style="display:none">Info about the ':visited' definition.</span><b><a href="#selectordef-visited">#selectordef-visited</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-visited">5.11.2. The link pseudo-classes: :link and :visited</a>
     <li><a href="#ref-for-selectordef-visited①">5.11.3. The dynamic pseudo-classes:
 :hover, :active, and :focus</a> <a href="#ref-for-selectordef-visited②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-hover">
-   <b><a href="#selectordef-hover">#selectordef-hover</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-hover" class="dfn-panel" data-for="selectordef-hover" id="infopanel-for-selectordef-hover" role="dialog">
+   <span id="infopaneltitle-for-selectordef-hover" style="display:none">Info about the ':hover' definition.</span><b><a href="#selectordef-hover">#selectordef-hover</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-hover">5.11.3. The dynamic pseudo-classes:
 :hover, :active, and :focus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-active">
-   <b><a href="#selectordef-active">#selectordef-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-active" class="dfn-panel" data-for="selectordef-active" id="infopanel-for-selectordef-active" role="dialog">
+   <span id="infopaneltitle-for-selectordef-active" style="display:none">Info about the ':active' definition.</span><b><a href="#selectordef-active">#selectordef-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-active">5.11.3. The dynamic pseudo-classes:
 :hover, :active, and :focus</a> <a href="#ref-for-selectordef-active①">(2)</a> <a href="#ref-for-selectordef-active②">(3)</a> <a href="#ref-for-selectordef-active③">(4)</a> <a href="#ref-for-selectordef-active④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-lang">
-   <b><a href="#selectordef-lang">#selectordef-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-lang" class="dfn-panel" data-for="selectordef-lang" id="infopanel-for-selectordef-lang" role="dialog">
+   <span id="infopaneltitle-for-selectordef-lang" style="display:none">Info about the ':lang' definition.</span><b><a href="#selectordef-lang">#selectordef-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">5.10. Pseudo-elements and pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-first-line">
-   <b><a href="#selectordef-first-line">#selectordef-first-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first-line" class="dfn-panel" data-for="selectordef-first-line" id="infopanel-for-selectordef-first-line" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first-line" style="display:none">Info about the ':first-line' definition.</span><b><a href="#selectordef-first-line">#selectordef-first-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">5.12. Pseudo-elements</a>
     <li><a href="#ref-for-selectordef-first-line①">5.12.1. The :first-line pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fictional-tag-sequence">
-   <b><a href="#fictional-tag-sequence">#fictional-tag-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fictional-tag-sequence" class="dfn-panel" data-for="fictional-tag-sequence" id="infopanel-for-fictional-tag-sequence" role="dialog">
+   <span id="infopaneltitle-for-fictional-tag-sequence" style="display:none">Info about the 'fictional tag
+sequence' definition.</span><b><a href="#fictional-tag-sequence">#fictional-tag-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fictional-tag-sequence">5.12.2. The :first-letter pseudo-element</a> <a href="#ref-for-fictional-tag-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-first-letter">
-   <b><a href="#selectordef-first-letter">#selectordef-first-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first-letter" class="dfn-panel" data-for="selectordef-first-letter" id="infopanel-for-selectordef-first-letter" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first-letter" style="display:none">Info about the ':first-letter' definition.</span><b><a href="#selectordef-first-letter">#selectordef-first-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">5.12. Pseudo-elements</a>
     <li><a href="#ref-for-selectordef-first-letter①">5.12.2. The :first-letter pseudo-element</a> <a href="#ref-for-selectordef-first-letter②">(2)</a> <a href="#ref-for-selectordef-first-letter③">(3)</a> <a href="#ref-for-selectordef-first-letter④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specified-value">
-   <b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specified-value" class="dfn-panel" data-for="specified-value" id="infopanel-for-specified-value" role="dialog">
+   <span id="infopaneltitle-for-specified-value" style="display:none">Info about the '
+Specified values' definition.</span><b><a href="#specified-value">#specified-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specified-value">6.2. Inheritance</a>
     <li><a href="#ref-for-specified-value">Specified value of inherit</a> <a href="#ref-for-specified-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-value">
-   <b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-value" class="dfn-panel" data-for="computed-value" id="infopanel-for-computed-value" role="dialog">
+   <span id="infopaneltitle-for-computed-value" style="display:none">Info about the '
+Computed values' definition.</span><b><a href="#computed-value">#computed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">1.4.2.7. Computed value</a>
     <li><a href="#ref-for-computed-value">4.3.2. Lengths</a>
@@ -18128,29 +18143,31 @@ border-color </a>
     <li><a href="#ref-for-computed-value">Specified value of inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-value">
-   <b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-value" class="dfn-panel" data-for="used-value" id="infopanel-for-used-value" role="dialog">
+   <span id="infopaneltitle-for-used-value" style="display:none">Info about the '
+Used values' definition.</span><b><a href="#used-value">#used-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">13.3.3. Allowed page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="usedValue">
-   <b><a href="#usedValue">#usedValue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-usedValue" class="dfn-panel" data-for="usedValue" id="infopanel-for-usedValue" role="dialog">
+   <span id="infopaneltitle-for-usedValue" style="display:none">Info about the 'used value' definition.</span><b><a href="#usedValue">#usedValue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usedValue">4.3.2. Lengths</a>
     <li><a href="#ref-for-usedValue">10.3. Calculating widths and
 margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-value">
-   <b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-value" class="dfn-panel" data-for="actual-value" id="infopanel-for-actual-value" role="dialog">
+   <span id="infopaneltitle-for-actual-value" style="display:none">Info about the '
+Actual values' definition.</span><b><a href="#actual-value">#actual-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">3.2. UA Conformance</a>
     <li><a href="#ref-for-actual-value">4.3.2. Lengths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-all-inherit">
-   <b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-all-inherit" class="dfn-panel" data-for="valdef-all-inherit" id="infopanel-for-valdef-all-inherit" role="dialog">
+   <span id="infopaneltitle-for-valdef-all-inherit" style="display:none">Info about the 'inherit' definition.</span><b><a href="#valdef-all-inherit">#valdef-all-inherit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">1.4.2.1. Value</a>
     <li><a href="#ref-for-valdef-all-inherit①">2.4. CSS design principles</a>
@@ -18165,8 +18182,8 @@ value</a> <a href="#ref-for-valdef-all-inherit⑤">(2)</a> <a href="#ref-for-val
     <li><a href="#ref-for-valdef-all-inherit⑨">Specified value of inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-import">
-   <b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-import" class="dfn-panel" data-for="at-ruledef-import" id="infopanel-for-at-ruledef-import" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-import" style="display:none">Info about the '@import' definition.</span><b><a href="#at-ruledef-import">#at-ruledef-import</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">4.1.5. 
 At-rules</a> <a href="#ref-for-at-ruledef-import①">(2)</a> <a href="#ref-for-at-ruledef-import②">(3)</a> <a href="#ref-for-at-ruledef-import③">(4)</a>
@@ -18174,14 +18191,14 @@ At-rules</a> <a href="#ref-for-at-ruledef-import①">(2)</a> <a href="#ref-for-a
     <li><a href="#ref-for-at-ruledef-import⑦">7.2. Specifying media-dependent style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-style-sheet">
-   <b><a href="#default-style-sheet">#default-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-style-sheet" class="dfn-panel" data-for="default-style-sheet" id="infopanel-for-default-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-default-style-sheet" style="display:none">Info about the 'default style sheet' definition.</span><b><a href="#default-style-sheet">#default-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-style-sheet">9.2.4. The display property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-media">
-   <b><a href="#at-ruledef-media">#at-ruledef-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-media" class="dfn-panel" data-for="at-ruledef-media" id="infopanel-for-at-ruledef-media" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-media" style="display:none">Info about the '@media' definition.</span><b><a href="#at-ruledef-media">#at-ruledef-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">4.1.5. 
 At-rules</a>
@@ -18189,14 +18206,14 @@ At-rules</a>
     <li><a href="#ref-for-at-ruledef-media②">7.2.1. The @media rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-all">
-   <b><a href="#valdef-media-all">#valdef-media-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-all" class="dfn-panel" data-for="valdef-media-all" id="infopanel-for-valdef-media-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-media-all">#valdef-media-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-all">6.3. The @import rule</a> <a href="#ref-for-valdef-media-all①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-print">
-   <b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-print" class="dfn-panel" data-for="valdef-media-print" id="infopanel-for-valdef-media-print" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-print" style="display:none">Info about the 'print' definition.</span><b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-print">4.1.5. 
 At-rules</a>
@@ -18204,20 +18221,20 @@ At-rules</a>
     <li><a href="#ref-for-valdef-media-print②">11.1.1. Overflow: the overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-screen">
-   <b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-screen" class="dfn-panel" data-for="valdef-media-screen" id="infopanel-for-valdef-media-screen" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-screen">7.3. Recognized media types</a> <a href="#ref-for-valdef-media-screen①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-tv">
-   <b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-tv" class="dfn-panel" data-for="valdef-media-tv" id="infopanel-for-valdef-media-tv" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-tv" style="display:none">Info about the 'tv' definition.</span><b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-tv">7.3. Recognized media types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="continuous-media-group">
-   <b><a href="#continuous-media-group">#continuous-media-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-continuous-media-group" class="dfn-panel" data-for="continuous-media-group" id="infopanel-for-continuous-media-group" role="dialog">
+   <span id="infopaneltitle-for-continuous-media-group" style="display:none">Info about the 'continuous' definition.</span><b><a href="#continuous-media-group">#continuous-media-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media-group">9.1. Introduction to the visual formatting model</a>
     <li><a href="#ref-for-continuous-media-group">9.1.1. The viewport</a>
@@ -18225,22 +18242,23 @@ At-rules</a>
     <li><a href="#ref-for-continuous-media-group">13.1. Introduction to paged media</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paged-media-group">
-   <b><a href="#paged-media-group">#paged-media-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paged-media-group" class="dfn-panel" data-for="paged-media-group" id="infopanel-for-paged-media-group" role="dialog">
+   <span id="infopaneltitle-for-paged-media-group" style="display:none">Info about the 'paged' definition.</span><b><a href="#paged-media-group">#paged-media-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media-group">9.1. Introduction to the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interactive-media-group">
-   <b><a href="#interactive-media-group">#interactive-media-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interactive-media-group" class="dfn-panel" data-for="interactive-media-group" id="infopanel-for-interactive-media-group" role="dialog">
+   <span id="infopaneltitle-for-interactive-media-group" style="display:none">Info about the 'interactive' definition.</span><b><a href="#interactive-media-group">#interactive-media-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interactive-media-group">5.11.3. The dynamic pseudo-classes:
 :hover, :active, and :focus</a> <a href="#ref-for-interactive-media-group">(2)</a>
     <li><a href="#ref-for-interactive-media-group">18.4.1. Outlines and the focus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-content-area">
-   <b><a href="#box-content-area">#box-content-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-content-area" class="dfn-panel" data-for="box-content-area" id="infopanel-for-box-content-area" role="dialog">
+   <span id="infopaneltitle-for-box-content-area" style="display:none">Info about the '
+content area' definition.</span><b><a href="#box-content-area">#box-content-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-content-area">14.2. The background</a>
     <li><a href="#ref-for-box-content-area">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -18248,8 +18266,9 @@ background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-padding-area">
-   <b><a href="#box-padding-area">#box-padding-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-padding-area" class="dfn-panel" data-for="box-padding-area" id="infopanel-for-box-padding-area" role="dialog">
+   <span id="infopaneltitle-for-box-padding-area" style="display:none">Info about the '
+padding' definition.</span><b><a href="#box-padding-area">#box-padding-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-padding-area">8.4. Padding properties:
 padding-top,
@@ -18263,8 +18282,9 @@ background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-border-area">
-   <b><a href="#box-border-area">#box-border-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-border-area" class="dfn-panel" data-for="box-border-area" id="infopanel-for-box-border-area" role="dialog">
+   <span id="infopaneltitle-for-box-border-area" style="display:none">Info about the '
+border' definition.</span><b><a href="#box-border-area">#box-border-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-border-area">8.5. Border properties</a>
     <li><a href="#ref-for-box-border-area">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
@@ -18276,8 +18296,9 @@ background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="box-margin-area">
-   <b><a href="#box-margin-area">#box-margin-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-box-margin-area" class="dfn-panel" data-for="box-margin-area" id="infopanel-for-box-margin-area" role="dialog">
+   <span id="infopaneltitle-for-box-margin-area" style="display:none">Info about the '
+margin' definition.</span><b><a href="#box-margin-area">#box-margin-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-margin-area">8.3. Margin properties:
 margin-top,
@@ -18287,22 +18308,23 @@ margin-left, and
 margin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-edge">
-   <b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-edge" class="dfn-panel" data-for="padding-edge" id="infopanel-for-padding-edge" role="dialog">
+   <span id="infopaneltitle-for-padding-edge" style="display:none">Info about the 'padding edge' definition.</span><b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">10.1. Definition of "containing
 block"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-edge">
-   <b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-edge" class="dfn-panel" data-for="border-edge" id="infopanel-for-border-edge" role="dialog">
+   <span id="infopaneltitle-for-border-edge" style="display:none">Info about the 'border edge' definition.</span><b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">17.5. Visual layout of table contents</a>
     <li><a href="#ref-for-border-edge">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outer-edge">
-   <b><a href="#outer-edge">#outer-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outer-edge" class="dfn-panel" data-for="outer-edge" id="infopanel-for-outer-edge" role="dialog">
+   <span id="infopaneltitle-for-outer-edge" style="display:none">Info about the 'outer
+edge' definition.</span><b><a href="#outer-edge">#outer-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outer-edge">9.5.1. Positioning the float: the
 float property</a> <a href="#ref-for-outer-edge">(2)</a> <a href="#ref-for-outer-edge">(3)</a> <a href="#ref-for-outer-edge">(4)</a> <a href="#ref-for-outer-edge">(5)</a> <a href="#ref-for-outer-edge">(6)</a> <a href="#ref-for-outer-edge">(7)</a> <a href="#ref-for-outer-edge">(8)</a>
@@ -18310,22 +18332,22 @@ float property</a> <a href="#ref-for-outer-edge">(2)</a> <a href="#ref-for-outer
 the clear property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-width">
-   <b><a href="#content-width">#content-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-width" class="dfn-panel" data-for="content-width" id="infopanel-for-content-width" role="dialog">
+   <span id="infopaneltitle-for-content-width" style="display:none">Info about the 'content width' definition.</span><b><a href="#content-width">#content-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-width">8.2. Example of margins, padding, and borders</a>
     <li><a href="#ref-for-content-width">10.2. Content width: the width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-height">
-   <b><a href="#content-height">#content-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-height" class="dfn-panel" data-for="content-height" id="infopanel-for-content-height" role="dialog">
+   <span id="infopaneltitle-for-content-height" style="display:none">Info about the 'content height' definition.</span><b><a href="#content-height">#content-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-height">8.2. Example of margins, padding, and borders</a>
     <li><a href="#ref-for-content-height">10.5. Content height: the height property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-margin-width">
-   <b><a href="#value-def-margin-width">#value-def-margin-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-margin-width" class="dfn-panel" data-for="value-def-margin-width" id="infopanel-for-value-def-margin-width" role="dialog">
+   <span id="infopaneltitle-for-value-def-margin-width" style="display:none">Info about the '&lt;margin-width>' definition.</span><b><a href="#value-def-margin-width">#value-def-margin-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-margin-width">8.3. Margin properties:
 margin-top,
@@ -18335,8 +18357,8 @@ margin-left, and
 margin</a> <a href="#ref-for-value-def-margin-width①">(2)</a> <a href="#ref-for-value-def-margin-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-top">
-   <b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-top" class="dfn-panel" data-for="propdef-margin-top" id="infopanel-for-propdef-margin-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-top" style="display:none">Info about the 'margin-top' definition.</span><b><a href="#propdef-margin-top">#propdef-margin-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">8.3. Margin properties:
 margin-top,
@@ -18358,8 +18380,8 @@ flow when overflow computes to visible</a>
     <li><a href="#ref-for-propdef-margin-top②⓪">13.3.3. Allowed page breaks</a> <a href="#ref-for-propdef-margin-top②①">(2)</a> <a href="#ref-for-propdef-margin-top②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-bottom">
-   <b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-bottom" class="dfn-panel" data-for="propdef-margin-bottom" id="infopanel-for-propdef-margin-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' definition.</span><b><a href="#propdef-margin-bottom">#propdef-margin-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">8.3. Margin properties:
 margin-top,
@@ -18381,8 +18403,8 @@ flow when overflow computes to visible</a>
     <li><a href="#ref-for-propdef-margin-bottom②⓪">13.3.3. Allowed page breaks</a> <a href="#ref-for-propdef-margin-bottom②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-right">
-   <b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-right" class="dfn-panel" data-for="propdef-margin-right" id="infopanel-for-propdef-margin-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-right" style="display:none">Info about the 'margin-right' definition.</span><b><a href="#propdef-margin-right">#propdef-margin-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">8.3. Margin properties:
 margin-top,
@@ -18404,8 +18426,8 @@ flow</a> <a href="#ref-for-propdef-margin-right⑥">(2)</a> <a href="#ref-for-pr
     <li><a href="#ref-for-propdef-margin-right②⑥">13.2.1. Page margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin-left">
-   <b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin-left" class="dfn-panel" data-for="propdef-margin-left" id="infopanel-for-propdef-margin-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin-left" style="display:none">Info about the 'margin-left' definition.</span><b><a href="#propdef-margin-left">#propdef-margin-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">8.3. Margin properties:
 margin-top,
@@ -18427,8 +18449,8 @@ flow</a> <a href="#ref-for-propdef-margin-left⑥">(2)</a> <a href="#ref-for-pro
     <li><a href="#ref-for-propdef-margin-left②⑥">13.2.1. Page margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-margin">
-   <b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-margin" class="dfn-panel" data-for="propdef-margin" id="infopanel-for-propdef-margin" role="dialog">
+   <span id="infopaneltitle-for-propdef-margin" style="display:none">Info about the 'margin' definition.</span><b><a href="#propdef-margin">#propdef-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">8.3. Margin properties:
 margin-top,
@@ -18446,8 +18468,9 @@ border</a>
     <li><a href="#ref-for-propdef-margin⑤">13.2.1. Page margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-padding-width">
-   <b><a href="#value-def-padding-width">#value-def-padding-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-padding-width" class="dfn-panel" data-for="value-def-padding-width" id="infopanel-for-value-def-padding-width" role="dialog">
+   <span id="infopaneltitle-for-value-def-padding-width" style="display:none">Info about the '&lt;padding-width>
+' definition.</span><b><a href="#value-def-padding-width">#value-def-padding-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-padding-width">8.4. Padding properties:
 padding-top,
@@ -18457,8 +18480,8 @@ padding-left, and
 padding </a> <a href="#ref-for-value-def-padding-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-top">
-   <b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-top" class="dfn-panel" data-for="propdef-padding-top" id="infopanel-for-propdef-padding-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-top" style="display:none">Info about the 'padding-top' definition.</span><b><a href="#propdef-padding-top">#propdef-padding-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">8.4. Padding properties:
 padding-top,
@@ -18469,8 +18492,8 @@ padding </a> <a href="#ref-for-propdef-padding-top①">(2)</a> <a href="#ref-for
     <li><a href="#ref-for-propdef-padding-top④">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-right">
-   <b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-right" class="dfn-panel" data-for="propdef-padding-right" id="infopanel-for-propdef-padding-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-right" style="display:none">Info about the 'padding-right' definition.</span><b><a href="#propdef-padding-right">#propdef-padding-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">8.4. Padding properties:
 padding-top,
@@ -18484,8 +18507,8 @@ flow</a> <a href="#ref-for-propdef-padding-right④">(2)</a>
     <li><a href="#ref-for-propdef-padding-right⑥">10.3.7. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-bottom">
-   <b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-bottom" class="dfn-panel" data-for="propdef-padding-bottom" id="infopanel-for-propdef-padding-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' definition.</span><b><a href="#propdef-padding-bottom">#propdef-padding-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">8.4. Padding properties:
 padding-top,
@@ -18496,8 +18519,8 @@ padding </a> <a href="#ref-for-propdef-padding-bottom①">(2)</a> <a href="#ref-
     <li><a href="#ref-for-propdef-padding-bottom④">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding-left">
-   <b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding-left" class="dfn-panel" data-for="propdef-padding-left" id="infopanel-for-propdef-padding-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding-left" style="display:none">Info about the 'padding-left' definition.</span><b><a href="#propdef-padding-left">#propdef-padding-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">8.4. Padding properties:
 padding-top,
@@ -18511,8 +18534,8 @@ flow</a> <a href="#ref-for-propdef-padding-left④">(2)</a>
     <li><a href="#ref-for-propdef-padding-left⑥">10.3.7. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-padding">
-   <b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-padding" class="dfn-panel" data-for="propdef-padding" id="infopanel-for-propdef-padding" role="dialog">
+   <span id="infopaneltitle-for-propdef-padding" style="display:none">Info about the 'padding' definition.</span><b><a href="#propdef-padding">#propdef-padding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">8.2. Example of margins, padding, and borders</a>
     <li><a href="#ref-for-propdef-padding①">8.4. Padding properties:
@@ -18529,8 +18552,8 @@ border-left, and
 border</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-border-width">
-   <b><a href="#value-def-border-width">#value-def-border-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-border-width" class="dfn-panel" data-for="value-def-border-width" id="infopanel-for-value-def-border-width" role="dialog">
+   <span id="infopaneltitle-for-value-def-border-width" style="display:none">Info about the '&lt;border-width>' definition.</span><b><a href="#value-def-border-width">#value-def-border-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-border-width">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18544,16 +18567,16 @@ border</a> <a href="#ref-for-value-def-border-width③">(2)</a>
     <li><a href="#ref-for-value-def-border-width④">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-width-thin">
-   <b><a href="#valdef-border-width-thin">#valdef-border-width-thin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-width-thin" class="dfn-panel" data-for="valdef-border-width-thin" id="infopanel-for-valdef-border-width-thin" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-width-thin" style="display:none">Info about the 'thin' definition.</span><b><a href="#valdef-border-width-thin">#valdef-border-width-thin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-width-thin">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
 border-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-width-medium">
-   <b><a href="#valdef-border-width-medium">#valdef-border-width-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-width-medium" class="dfn-panel" data-for="valdef-border-width-medium" id="infopanel-for-valdef-border-width-medium" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-width-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#valdef-border-width-medium">#valdef-border-width-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-width-medium">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18562,16 +18585,16 @@ border-width</a>
 property</a> <a href="#ref-for-valdef-border-width-medium②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-width-thick">
-   <b><a href="#valdef-border-width-thick">#valdef-border-width-thick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-width-thick" class="dfn-panel" data-for="valdef-border-width-thick" id="infopanel-for-valdef-border-width-thick" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-width-thick" style="display:none">Info about the 'thick' definition.</span><b><a href="#valdef-border-width-thick">#valdef-border-width-thick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-width-thick">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
 border-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-width">
-   <b><a href="#propdef-border-top-width">#propdef-border-top-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-width" class="dfn-panel" data-for="propdef-border-top-width" id="infopanel-for-propdef-border-top-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' definition.</span><b><a href="#propdef-border-top-width">#propdef-border-top-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18579,8 +18602,8 @@ border-width</a> <a href="#ref-for-propdef-border-top-width①">(2)</a>
     <li><a href="#ref-for-propdef-border-top-width②">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-width">
-   <b><a href="#propdef-border-right-width">#propdef-border-right-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-width" class="dfn-panel" data-for="propdef-border-right-width" id="infopanel-for-propdef-border-right-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' definition.</span><b><a href="#propdef-border-right-width">#propdef-border-right-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18591,8 +18614,8 @@ flow</a> <a href="#ref-for-propdef-border-right-width③">(2)</a>
     <li><a href="#ref-for-propdef-border-right-width⑤">10.3.7. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-width">
-   <b><a href="#propdef-border-bottom-width">#propdef-border-bottom-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-width" class="dfn-panel" data-for="propdef-border-bottom-width" id="infopanel-for-propdef-border-bottom-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' definition.</span><b><a href="#propdef-border-bottom-width">#propdef-border-bottom-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18600,8 +18623,8 @@ border-width</a> <a href="#ref-for-propdef-border-bottom-width①">(2)</a>
     <li><a href="#ref-for-propdef-border-bottom-width②">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-width">
-   <b><a href="#propdef-border-left-width">#propdef-border-left-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-width" class="dfn-panel" data-for="propdef-border-left-width" id="infopanel-for-propdef-border-left-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' definition.</span><b><a href="#propdef-border-left-width">#propdef-border-left-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18612,8 +18635,8 @@ flow</a> <a href="#ref-for-propdef-border-left-width③">(2)</a>
     <li><a href="#ref-for-propdef-border-left-width⑤">10.3.7. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-width">
-   <b><a href="#propdef-border-width">#propdef-border-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-width" class="dfn-panel" data-for="propdef-border-width" id="infopanel-for-propdef-border-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-width" style="display:none">Info about the 'border-width' definition.</span><b><a href="#propdef-border-width">#propdef-border-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">1.4.2.1. Value</a> <a href="#ref-for-propdef-border-width①">(2)</a> <a href="#ref-for-propdef-border-width②">(3)</a>
     <li><a href="#ref-for-propdef-border-width③">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
@@ -18636,8 +18659,8 @@ border-style</a> <a href="#ref-for-propdef-border-width⑥">(2)</a>
     <li><a href="#ref-for-propdef-border-width⑨">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-color">
-   <b><a href="#propdef-border-top-color">#propdef-border-top-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-color" class="dfn-panel" data-for="propdef-border-top-color" id="infopanel-for-propdef-border-top-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' definition.</span><b><a href="#propdef-border-top-color">#propdef-border-top-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">8.5.2. Border color:
 border-top-color,
@@ -18654,8 +18677,8 @@ border</a> <a href="#ref-for-propdef-border-top-color②">(2)</a>
     <li><a href="#ref-for-propdef-border-top-color③">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-color">
-   <b><a href="#propdef-border-right-color">#propdef-border-right-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-color" class="dfn-panel" data-for="propdef-border-right-color" id="infopanel-for-propdef-border-right-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' definition.</span><b><a href="#propdef-border-right-color">#propdef-border-right-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">8.5.2. Border color:
 border-top-color,
@@ -18665,8 +18688,8 @@ border-left-color, and
 border-color </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-color">
-   <b><a href="#propdef-border-bottom-color">#propdef-border-bottom-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-color" class="dfn-panel" data-for="propdef-border-bottom-color" id="infopanel-for-propdef-border-bottom-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' definition.</span><b><a href="#propdef-border-bottom-color">#propdef-border-bottom-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">8.5.2. Border color:
 border-top-color,
@@ -18676,8 +18699,8 @@ border-left-color, and
 border-color </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-color">
-   <b><a href="#propdef-border-left-color">#propdef-border-left-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-color" class="dfn-panel" data-for="propdef-border-left-color" id="infopanel-for-propdef-border-left-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' definition.</span><b><a href="#propdef-border-left-color">#propdef-border-left-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">8.5.2. Border color:
 border-top-color,
@@ -18687,8 +18710,8 @@ border-left-color, and
 border-color </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-color">
-   <b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-color" class="dfn-panel" data-for="propdef-border-color" id="infopanel-for-propdef-border-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-color" style="display:none">Info about the 'border-color' definition.</span><b><a href="#propdef-border-color">#propdef-border-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">8.5.2. Border color:
 border-top-color,
@@ -18704,8 +18727,8 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-color-transparent">
-   <b><a href="#valdef-border-color-transparent">#valdef-border-color-transparent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-color-transparent" class="dfn-panel" data-for="valdef-border-color-transparent" id="infopanel-for-valdef-border-color-transparent" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-color-transparent" style="display:none">Info about the 'transparent' definition.</span><b><a href="#valdef-border-color-transparent">#valdef-border-color-transparent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-color-transparent">14.2. The background</a>
     <li><a href="#ref-for-valdef-border-color-transparent①">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -18713,8 +18736,8 @@ background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-border-style">
-   <b><a href="#value-def-border-style">#value-def-border-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-border-style" class="dfn-panel" data-for="value-def-border-style" id="infopanel-for-value-def-border-style" role="dialog">
+   <span id="infopaneltitle-for-value-def-border-style" style="display:none">Info about the '&lt;border-style>' definition.</span><b><a href="#value-def-border-style">#value-def-border-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-border-style">8.5.3. Border style:
 border-top-style,
@@ -18732,8 +18755,8 @@ border</a> <a href="#ref-for-value-def-border-style③">(2)</a>
     <li><a href="#ref-for-value-def-border-style⑥">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-bo-none">
-   <b><a href="#value-def-bo-none">#value-def-bo-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-bo-none" class="dfn-panel" data-for="value-def-bo-none" id="infopanel-for-value-def-bo-none" role="dialog">
+   <span id="infopaneltitle-for-value-def-bo-none" style="display:none">Info about the 'none' definition.</span><b><a href="#value-def-bo-none">#value-def-bo-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-bo-none">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18749,8 +18772,8 @@ border-style</a> <a href="#ref-for-value-def-bo-none②">(2)</a>
     <li><a href="#ref-for-value-def-bo-none⑨">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-hidden">
-   <b><a href="#value-def-hidden">#value-def-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-hidden" class="dfn-panel" data-for="value-def-hidden" id="infopanel-for-value-def-hidden" role="dialog">
+   <span id="infopaneltitle-for-value-def-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#value-def-hidden">#value-def-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-hidden">8.5.1. Border width: border-top-width, border-right-width, border-bottom-width,
 border-left-width, and
@@ -18760,8 +18783,8 @@ border-width</a>
     <li><a href="#ref-for-value-def-hidden⑤">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-dotted">
-   <b><a href="#value-def-dotted">#value-def-dotted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-dotted" class="dfn-panel" data-for="value-def-dotted" id="infopanel-for-value-def-dotted" role="dialog">
+   <span id="infopaneltitle-for-value-def-dotted" style="display:none">Info about the 'dotted' definition.</span><b><a href="#value-def-dotted">#value-def-dotted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-dotted">3.1. Definitions</a>
     <li><a href="#ref-for-value-def-dotted①">8.5.3. Border style:
@@ -18774,15 +18797,15 @@ border-style</a>
     <li><a href="#ref-for-value-def-dotted③">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-dashed">
-   <b><a href="#value-def-dashed">#value-def-dashed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-dashed" class="dfn-panel" data-for="value-def-dashed" id="infopanel-for-value-def-dashed" role="dialog">
+   <span id="infopaneltitle-for-value-def-dashed" style="display:none">Info about the 'dashed' definition.</span><b><a href="#value-def-dashed">#value-def-dashed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-dashed">17.6.2.1. Border conflict resolution</a>
     <li><a href="#ref-for-value-def-dashed①">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-solid">
-   <b><a href="#value-def-solid">#value-def-solid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-solid" class="dfn-panel" data-for="value-def-solid" id="infopanel-for-value-def-solid" role="dialog">
+   <span id="infopaneltitle-for-value-def-solid" style="display:none">Info about the 'solid' definition.</span><b><a href="#value-def-solid">#value-def-solid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-solid">8.5.3. Border style:
 border-top-style,
@@ -18794,15 +18817,15 @@ border-style</a>
     <li><a href="#ref-for-value-def-solid②">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-double">
-   <b><a href="#value-def-double">#value-def-double</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-double" class="dfn-panel" data-for="value-def-double" id="infopanel-for-value-def-double" role="dialog">
+   <span id="infopaneltitle-for-value-def-double" style="display:none">Info about the 'double' definition.</span><b><a href="#value-def-double">#value-def-double</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-double">17.6.2.1. Border conflict resolution</a>
     <li><a href="#ref-for-value-def-double①">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-groove">
-   <b><a href="#value-def-groove">#value-def-groove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-groove" class="dfn-panel" data-for="value-def-groove" id="infopanel-for-value-def-groove" role="dialog">
+   <span id="infopaneltitle-for-value-def-groove" style="display:none">Info about the 'groove' definition.</span><b><a href="#value-def-groove">#value-def-groove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-groove">8.5.3. Border style:
 border-top-style,
@@ -18814,8 +18837,8 @@ border-style</a> <a href="#ref-for-value-def-groove①">(2)</a>
     <li><a href="#ref-for-value-def-groove③">17.6.3. Border styles</a> <a href="#ref-for-value-def-groove④">(2)</a> <a href="#ref-for-value-def-groove⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-ridge">
-   <b><a href="#value-def-ridge">#value-def-ridge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-ridge" class="dfn-panel" data-for="value-def-ridge" id="infopanel-for-value-def-ridge" role="dialog">
+   <span id="infopaneltitle-for-value-def-ridge" style="display:none">Info about the 'ridge' definition.</span><b><a href="#value-def-ridge">#value-def-ridge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-ridge">8.5.3. Border style:
 border-top-style,
@@ -18827,8 +18850,8 @@ border-style</a>
     <li><a href="#ref-for-value-def-ridge②">17.6.3. Border styles</a> <a href="#ref-for-value-def-ridge③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-inset">
-   <b><a href="#value-def-inset">#value-def-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-inset" class="dfn-panel" data-for="value-def-inset" id="infopanel-for-value-def-inset" role="dialog">
+   <span id="infopaneltitle-for-value-def-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#value-def-inset">#value-def-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-inset">8.5.3. Border style:
 border-top-style,
@@ -18840,8 +18863,8 @@ border-style</a> <a href="#ref-for-value-def-inset①">(2)</a>
     <li><a href="#ref-for-value-def-inset③">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-outset">
-   <b><a href="#value-def-outset">#value-def-outset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-outset" class="dfn-panel" data-for="value-def-outset" id="infopanel-for-value-def-outset" role="dialog">
+   <span id="infopaneltitle-for-value-def-outset" style="display:none">Info about the 'outset' definition.</span><b><a href="#value-def-outset">#value-def-outset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-outset">8.5.3. Border style:
 border-top-style,
@@ -18853,8 +18876,8 @@ border-style</a>
     <li><a href="#ref-for-value-def-outset②">17.6.3. Border styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top-style">
-   <b><a href="#propdef-border-top-style">#propdef-border-top-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top-style" class="dfn-panel" data-for="propdef-border-top-style" id="infopanel-for-propdef-border-top-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top-style" style="display:none">Info about the 'border-top-style' definition.</span><b><a href="#propdef-border-top-style">#propdef-border-top-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-style">8.5.3. Border style:
 border-top-style,
@@ -18864,8 +18887,8 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right-style">
-   <b><a href="#propdef-border-right-style">#propdef-border-right-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right-style" class="dfn-panel" data-for="propdef-border-right-style" id="infopanel-for-propdef-border-right-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right-style" style="display:none">Info about the 'border-right-style' definition.</span><b><a href="#propdef-border-right-style">#propdef-border-right-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-style">8.5.3. Border style:
 border-top-style,
@@ -18875,8 +18898,8 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom-style">
-   <b><a href="#propdef-border-bottom-style">#propdef-border-bottom-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom-style" class="dfn-panel" data-for="propdef-border-bottom-style" id="infopanel-for-propdef-border-bottom-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom-style" style="display:none">Info about the 'border-bottom-style' definition.</span><b><a href="#propdef-border-bottom-style">#propdef-border-bottom-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-style">8.5.3. Border style:
 border-top-style,
@@ -18886,8 +18909,8 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left-style">
-   <b><a href="#propdef-border-left-style">#propdef-border-left-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left-style" class="dfn-panel" data-for="propdef-border-left-style" id="infopanel-for-propdef-border-left-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left-style" style="display:none">Info about the 'border-left-style' definition.</span><b><a href="#propdef-border-left-style">#propdef-border-left-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-style">8.5.3. Border style:
 border-top-style,
@@ -18897,8 +18920,8 @@ border-left-style, and
 border-style</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-style">
-   <b><a href="#propdef-border-style">#propdef-border-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-style" class="dfn-panel" data-for="propdef-border-style" id="infopanel-for-propdef-border-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-style" style="display:none">Info about the 'border-style' definition.</span><b><a href="#propdef-border-style">#propdef-border-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">8.2. Example of margins, padding, and borders</a>
     <li><a href="#ref-for-propdef-border-style①">8.5.3. Border style:
@@ -18911,8 +18934,8 @@ border-style</a> <a href="#ref-for-propdef-border-style②">(2)</a>
     <li><a href="#ref-for-propdef-border-style④">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-top">
-   <b><a href="#propdef-border-top">#propdef-border-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-top" class="dfn-panel" data-for="propdef-border-top" id="infopanel-for-propdef-border-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-top" style="display:none">Info about the 'border-top' definition.</span><b><a href="#propdef-border-top">#propdef-border-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">8.5.4. Border shorthand properties:
 border-top,
@@ -18922,8 +18945,8 @@ border-left, and
 border</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-right">
-   <b><a href="#propdef-border-right">#propdef-border-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-right" class="dfn-panel" data-for="propdef-border-right" id="infopanel-for-propdef-border-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-right" style="display:none">Info about the 'border-right' definition.</span><b><a href="#propdef-border-right">#propdef-border-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right">8.5.4. Border shorthand properties:
 border-top,
@@ -18933,8 +18956,8 @@ border-left, and
 border</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-bottom">
-   <b><a href="#propdef-border-bottom">#propdef-border-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-bottom" class="dfn-panel" data-for="propdef-border-bottom" id="infopanel-for-propdef-border-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-bottom" style="display:none">Info about the 'border-bottom' definition.</span><b><a href="#propdef-border-bottom">#propdef-border-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom">8.5.4. Border shorthand properties:
 border-top,
@@ -18944,8 +18967,8 @@ border-left, and
 border</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-left">
-   <b><a href="#propdef-border-left">#propdef-border-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-left" class="dfn-panel" data-for="propdef-border-left" id="infopanel-for-propdef-border-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-left" style="display:none">Info about the 'border-left' definition.</span><b><a href="#propdef-border-left">#propdef-border-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left">8.5.4. Border shorthand properties:
 border-top,
@@ -18955,8 +18978,8 @@ border-left, and
 border</a> <a href="#ref-for-propdef-border-left①">(2)</a> <a href="#ref-for-propdef-border-left②">(3)</a> <a href="#ref-for-propdef-border-left③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border">
-   <b><a href="#propdef-border">#propdef-border</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border" class="dfn-panel" data-for="propdef-border" id="infopanel-for-propdef-border" role="dialog">
+   <span id="infopaneltitle-for-propdef-border" style="display:none">Info about the 'border' definition.</span><b><a href="#propdef-border">#propdef-border</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border">8.5.4. Border shorthand properties:
 border-top,
@@ -18967,30 +18990,33 @@ border</a> <a href="#ref-for-propdef-border①">(2)</a> <a href="#ref-for-propde
     <li><a href="#ref-for-propdef-border③">17.3. Columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-level">
-   <b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-level" class="dfn-panel" data-for="block-level" id="infopanel-for-block-level" role="dialog">
+   <span id="infopaneltitle-for-block-level" style="display:none">Info about the 'Block-level elements' definition.</span><b><a href="#block-level">#block-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-level">9.4. Normal flow</a>
     <li><a href="#ref-for-block-level">17.2. The CSS table model</a>
     <li><a href="#ref-for-block-level">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="principal-box">
-   <b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-principal-box" class="dfn-panel" data-for="principal-box" id="infopanel-for-principal-box" role="dialog">
+   <span id="infopaneltitle-for-principal-box" style="display:none">Info about the 'principal block-level
+box' definition.</span><b><a href="#principal-box">#principal-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-principal-box">12.5. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anonymous">
-   <b><a href="#anonymous">#anonymous</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anonymous" class="dfn-panel" data-for="anonymous" id="infopanel-for-anonymous" role="dialog">
+   <span id="infopaneltitle-for-anonymous" style="display:none">Info about the 'anonymous block box' definition.</span><b><a href="#anonymous">#anonymous</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous">5.11.1. :first-child pseudo-class</a>
     <li><a href="#ref-for-anonymous">9.8.1. Normal flow</a>
     <li><a href="#ref-for-anonymous">17.2.1. Anonymous table objects</a> <a href="#ref-for-anonymous">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inline-level">
-   <b><a href="#inline-level">#inline-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inline-level" class="dfn-panel" data-for="inline-level" id="infopanel-for-inline-level" role="dialog">
+   <span id="infopaneltitle-for-inline-level" style="display:none">Info about the '
+Inline-level
+elements' definition.</span><b><a href="#inline-level">#inline-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">9.4. Normal flow</a>
     <li><a href="#ref-for-inline-level">10.8.1. Leading and half-leading</a>
@@ -18998,8 +19024,8 @@ border</a> <a href="#ref-for-propdef-border①">(2)</a> <a href="#ref-for-propde
     <li><a href="#ref-for-inline-level">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-display">
-   <b><a href="#propdef-display">#propdef-display</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-display" class="dfn-panel" data-for="propdef-display" id="infopanel-for-propdef-display" role="dialog">
+   <span id="infopaneltitle-for-propdef-display" style="display:none">Info about the 'display' definition.</span><b><a href="#propdef-display">#propdef-display</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2.3. The CSS 2 processing model</a>
     <li><a href="#ref-for-propdef-display①">4.3.8. Unsupported Values</a>
@@ -19023,8 +19049,8 @@ pseudo-elements</a> <a href="#ref-for-propdef-display②①">(2)</a>
     <li><a href="#ref-for-propdef-display②⑤">17.2. The CSS table model</a> <a href="#ref-for-propdef-display②⑥">(2)</a> <a href="#ref-for-propdef-display②⑦">(3)</a> <a href="#ref-for-propdef-display②⑧">(4)</a> <a href="#ref-for-propdef-display②⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-block">
-   <b><a href="#value-def-block">#value-def-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-block" class="dfn-panel" data-for="value-def-block" id="infopanel-for-value-def-block" role="dialog">
+   <span id="infopaneltitle-for-value-def-block" style="display:none">Info about the 'block' definition.</span><b><a href="#value-def-block">#value-def-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-block">9.2.1. Block-level elements and block boxes</a>
     <li><a href="#ref-for-value-def-block①">9.7. Relationships between display, position,
@@ -19034,8 +19060,8 @@ pseudo-elements</a>
     <li><a href="#ref-for-value-def-block③">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-inline-block">
-   <b><a href="#value-def-inline-block">#value-def-inline-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-inline-block" class="dfn-panel" data-for="value-def-inline-block" id="infopanel-for-value-def-inline-block" role="dialog">
+   <span id="infopaneltitle-for-value-def-inline-block" style="display:none">Info about the 'inline-block' definition.</span><b><a href="#value-def-inline-block">#value-def-inline-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-inline-block">9.2.2. Inline-level elements and inline boxes</a>
     <li><a href="#ref-for-value-def-inline-block①">10.3. Calculating widths and
@@ -19052,8 +19078,8 @@ elements in normal flow and floating replaced elements</a>
     <li><a href="#ref-for-value-def-inline-block①①">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-inline">
-   <b><a href="#value-def-inline">#value-def-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-inline" class="dfn-panel" data-for="value-def-inline" id="infopanel-for-value-def-inline" role="dialog">
+   <span id="infopaneltitle-for-value-def-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#value-def-inline">#value-def-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-inline">9.2.2. Inline-level elements and inline boxes</a> <a href="#ref-for-value-def-inline①">(2)</a>
     <li><a href="#ref-for-value-def-inline②">9.2.4. The display property</a>
@@ -19062,8 +19088,8 @@ pseudo-elements</a>
     <li><a href="#ref-for-value-def-inline④">17.2.1. Anonymous table objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-list-item">
-   <b><a href="#value-def-list-item">#value-def-list-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-list-item" class="dfn-panel" data-for="value-def-list-item" id="infopanel-for-value-def-list-item" role="dialog">
+   <span id="infopaneltitle-for-value-def-list-item" style="display:none">Info about the 'list-item' definition.</span><b><a href="#value-def-list-item">#value-def-list-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-list-item">9.2.1. Block-level elements and block boxes</a> <a href="#ref-for-value-def-list-item①">(2)</a>
     <li><a href="#ref-for-value-def-list-item②">9.7. Relationships between display, position,
@@ -19073,8 +19099,8 @@ Generated content, automatic numbering,
 and lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-display-none">
-   <b><a href="#valdef-display-none">#valdef-display-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-display-none" class="dfn-panel" data-for="valdef-display-none" id="infopanel-for-valdef-display-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-display-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-display-none">#valdef-display-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">2.3. The CSS 2 processing model</a>
     <li><a href="#ref-for-valdef-display-none①">9.2.4. The display property</a>
@@ -19084,8 +19110,8 @@ and float</a>
     <li><a href="#ref-for-valdef-display-none④">12.4.3. Counters in elements with 'display: none'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table">
-   <b><a href="#value-def-table">#value-def-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table" class="dfn-panel" data-for="value-def-table" id="infopanel-for-value-def-table" role="dialog">
+   <span id="infopaneltitle-for-value-def-table" style="display:none">Info about the 'table' definition.</span><b><a href="#value-def-table">#value-def-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table">9.2.1. Block-level elements and block boxes</a>
     <li><a href="#ref-for-value-def-table①">17.2. The CSS table model</a>
@@ -19099,8 +19125,8 @@ property</a>
     <li><a href="#ref-for-value-def-table①⑦">17.6.1. The separated borders model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-inline-table">
-   <b><a href="#value-def-inline-table">#value-def-inline-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-inline-table" class="dfn-panel" data-for="value-def-inline-table" id="infopanel-for-value-def-inline-table" role="dialog">
+   <span id="infopaneltitle-for-value-def-inline-table" style="display:none">Info about the 'inline-table' definition.</span><b><a href="#value-def-inline-table">#value-def-inline-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-inline-table">9.2.2. Inline-level elements and inline boxes</a>
     <li><a href="#ref-for-value-def-inline-table①">10.8.1. Leading and half-leading</a>
@@ -19116,43 +19142,43 @@ property</a>
     <li><a href="#ref-for-value-def-inline-table①⑧">17.6.1. The separated borders model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-row-group">
-   <b><a href="#value-def-table-row-group">#value-def-table-row-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-row-group" class="dfn-panel" data-for="value-def-table-row-group" id="infopanel-for-value-def-table-row-group" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-row-group" style="display:none">Info about the 'table-row-group' definition.</span><b><a href="#value-def-table-row-group">#value-def-table-row-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-row-group">17.2. The CSS table model</a> <a href="#ref-for-value-def-table-row-group①">(2)</a> <a href="#ref-for-value-def-table-row-group②">(3)</a>
     <li><a href="#ref-for-value-def-table-row-group③">17.2.1. Anonymous table objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-column">
-   <b><a href="#value-def-table-column">#value-def-table-column</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-column" class="dfn-panel" data-for="value-def-table-column" id="infopanel-for-value-def-table-column" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-column" style="display:none">Info about the 'table-column' definition.</span><b><a href="#value-def-table-column">#value-def-table-column</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-column">17.2. The CSS table model</a> <a href="#ref-for-value-def-table-column①">(2)</a>
     <li><a href="#ref-for-value-def-table-column②">17.2.1. Anonymous table objects</a> <a href="#ref-for-value-def-table-column③">(2)</a> <a href="#ref-for-value-def-table-column④">(3)</a> <a href="#ref-for-value-def-table-column⑤">(4)</a> <a href="#ref-for-value-def-table-column⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-column-group">
-   <b><a href="#value-def-table-column-group">#value-def-table-column-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-column-group" class="dfn-panel" data-for="value-def-table-column-group" id="infopanel-for-value-def-table-column-group" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-column-group" style="display:none">Info about the 'table-column-group' definition.</span><b><a href="#value-def-table-column-group">#value-def-table-column-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-column-group">17.2. The CSS table model</a> <a href="#ref-for-value-def-table-column-group①">(2)</a>
     <li><a href="#ref-for-value-def-table-column-group②">17.2.1. Anonymous table objects</a> <a href="#ref-for-value-def-table-column-group③">(2)</a> <a href="#ref-for-value-def-table-column-group④">(3)</a> <a href="#ref-for-value-def-table-column-group⑤">(4)</a> <a href="#ref-for-value-def-table-column-group⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-header-group">
-   <b><a href="#value-def-table-header-group">#value-def-table-header-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-header-group" class="dfn-panel" data-for="value-def-table-header-group" id="infopanel-for-value-def-table-header-group" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-header-group" style="display:none">Info about the 'table-header-group' definition.</span><b><a href="#value-def-table-header-group">#value-def-table-header-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-header-group">17.2. The CSS table model</a>
     <li><a href="#ref-for-value-def-table-header-group①">17.2.1. Anonymous table objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-footer-group">
-   <b><a href="#value-def-table-footer-group">#value-def-table-footer-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-footer-group" class="dfn-panel" data-for="value-def-table-footer-group" id="infopanel-for-value-def-table-footer-group" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-footer-group" style="display:none">Info about the 'table-footer-group' definition.</span><b><a href="#value-def-table-footer-group">#value-def-table-footer-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-footer-group">17.2. The CSS table model</a>
     <li><a href="#ref-for-value-def-table-footer-group①">17.2.1. Anonymous table objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-row">
-   <b><a href="#value-def-table-row">#value-def-table-row</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-row" class="dfn-panel" data-for="value-def-table-row" id="infopanel-for-value-def-table-row" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-row" style="display:none">Info about the 'table-row' definition.</span><b><a href="#value-def-table-row">#value-def-table-row</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-row">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -19162,8 +19188,8 @@ page-break-inside </a>
     <li><a href="#ref-for-value-def-table-row①④">17.5.3. Table height algorithms</a> <a href="#ref-for-value-def-table-row①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-cell">
-   <b><a href="#value-def-table-cell">#value-def-table-cell</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-cell" class="dfn-panel" data-for="value-def-table-cell" id="infopanel-for-value-def-table-cell" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-cell" style="display:none">Info about the 'table-cell' definition.</span><b><a href="#value-def-table-cell">#value-def-table-cell</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-cell">10.8.1. Leading and half-leading</a>
     <li><a href="#ref-for-value-def-table-cell①">17.2. The CSS table model</a>
@@ -19171,16 +19197,16 @@ page-break-inside </a>
     <li><a href="#ref-for-value-def-table-cell①⓪">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-table-caption">
-   <b><a href="#value-def-table-caption">#value-def-table-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-table-caption" class="dfn-panel" data-for="value-def-table-caption" id="infopanel-for-value-def-table-caption" role="dialog">
+   <span id="infopaneltitle-for-value-def-table-caption" style="display:none">Info about the 'table-caption' definition.</span><b><a href="#value-def-table-caption">#value-def-table-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-table-caption">17.2. The CSS table model</a>
     <li><a href="#ref-for-value-def-table-caption①">17.2.1. Anonymous table objects</a> <a href="#ref-for-value-def-table-caption②">(2)</a> <a href="#ref-for-value-def-table-caption③">(3)</a> <a href="#ref-for-value-def-table-caption④">(4)</a> <a href="#ref-for-value-def-table-caption⑤">(5)</a>
     <li><a href="#ref-for-value-def-table-caption⑥">17.4.1. Caption position and alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-position">
-   <b><a href="#propdef-position">#propdef-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-position" class="dfn-panel" data-for="propdef-position" id="infopanel-for-propdef-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-position" style="display:none">Info about the 'position' definition.</span><b><a href="#propdef-position">#propdef-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-propdef-position①">(2)</a>
     <li><a href="#ref-for-propdef-position②">9.3.2. Box offsets: top, right, bottom, left</a>
@@ -19195,8 +19221,8 @@ block"</a>
     <li><a href="#ref-for-propdef-position①③">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-static">
-   <b><a href="#valdef-position-static">#valdef-position-static</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-static" class="dfn-panel" data-for="valdef-position-static" id="infopanel-for-valdef-position-static" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-static" style="display:none">Info about the 'static' definition.</span><b><a href="#valdef-position-static">#valdef-position-static</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">9.3.1. Choosing a positioning scheme: position property</a>
     <li><a href="#ref-for-valdef-position-static①">9.3.2. Box offsets: top, right, bottom, left</a>
@@ -19206,16 +19232,16 @@ block"</a>
     <li><a href="#ref-for-valdef-position-static⑤">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-relative">
-   <b><a href="#valdef-position-relative">#valdef-position-relative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-relative" class="dfn-panel" data-for="valdef-position-relative" id="infopanel-for-valdef-position-relative" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-relative" style="display:none">Info about the 'relative' definition.</span><b><a href="#valdef-position-relative">#valdef-position-relative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">9.8.4. Absolute positioning</a>
     <li><a href="#ref-for-valdef-position-relative①">10.1. Definition of "containing
 block"</a> <a href="#ref-for-valdef-position-relative②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-absolute">
-   <b><a href="#valdef-position-absolute">#valdef-position-absolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-absolute" class="dfn-panel" data-for="valdef-position-absolute" id="infopanel-for-valdef-position-absolute" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-absolute" style="display:none">Info about the 'absolute' definition.</span><b><a href="#valdef-position-absolute">#valdef-position-absolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-absolute">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-valdef-position-absolute①">(2)</a>
     <li><a href="#ref-for-valdef-position-absolute②">9.6. Absolute positioning</a>
@@ -19225,8 +19251,8 @@ and float</a>
 block"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-position-fixed">
-   <b><a href="#valdef-position-fixed">#valdef-position-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-position-fixed" class="dfn-panel" data-for="valdef-position-fixed" id="infopanel-for-valdef-position-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-position-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-position-fixed">#valdef-position-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">9.3.1. Choosing a positioning scheme: position property</a>
     <li><a href="#ref-for-valdef-position-fixed①">9.6. Absolute positioning</a>
@@ -19236,8 +19262,8 @@ and float</a>
 block"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-top">
-   <b><a href="#propdef-top">#propdef-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-top" class="dfn-panel" data-for="propdef-top" id="infopanel-for-propdef-top" role="dialog">
+   <span id="infopaneltitle-for-propdef-top" style="display:none">Info about the 'top' definition.</span><b><a href="#propdef-top">#propdef-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-propdef-top①">(2)</a>
     <li><a href="#ref-for-propdef-top②">9.3.2. Box offsets: top, right, bottom, left</a> <a href="#ref-for-propdef-top③">(2)</a> <a href="#ref-for-propdef-top④">(3)</a> <a href="#ref-for-propdef-top⑤">(4)</a> <a href="#ref-for-propdef-top⑥">(5)</a>
@@ -19255,8 +19281,8 @@ properties</a>
     <li><a href="#ref-for-propdef-top③②">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-right">
-   <b><a href="#propdef-right">#propdef-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-right" class="dfn-panel" data-for="propdef-right" id="infopanel-for-propdef-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-right" style="display:none">Info about the 'right' definition.</span><b><a href="#propdef-right">#propdef-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-propdef-right①">(2)</a>
     <li><a href="#ref-for-propdef-right②">9.3.2. Box offsets: top, right, bottom, left</a> <a href="#ref-for-propdef-right③">(2)</a>
@@ -19277,8 +19303,8 @@ page-break-inside </a> <a href="#ref-for-propdef-right③⑨">(2)</a>
     <li><a href="#ref-for-propdef-right④④">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-bottom">
-   <b><a href="#propdef-bottom">#propdef-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-bottom" class="dfn-panel" data-for="propdef-bottom" id="infopanel-for-propdef-bottom" role="dialog">
+   <span id="infopaneltitle-for-propdef-bottom" style="display:none">Info about the 'bottom' definition.</span><b><a href="#propdef-bottom">#propdef-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-propdef-bottom①">(2)</a>
     <li><a href="#ref-for-propdef-bottom②">9.3.2. Box offsets: top, right, bottom, left</a> <a href="#ref-for-propdef-bottom③">(2)</a>
@@ -19295,8 +19321,8 @@ properties</a>
     <li><a href="#ref-for-propdef-bottom②⑨">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-left">
-   <b><a href="#propdef-left">#propdef-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-left" class="dfn-panel" data-for="propdef-left" id="infopanel-for-propdef-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-left" style="display:none">Info about the 'left' definition.</span><b><a href="#propdef-left">#propdef-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">9.3.1. Choosing a positioning scheme: position property</a> <a href="#ref-for-propdef-left①">(2)</a>
     <li><a href="#ref-for-propdef-left②">9.3.2. Box offsets: top, right, bottom, left</a> <a href="#ref-for-propdef-left③">(2)</a>
@@ -19319,15 +19345,15 @@ page-break-inside </a> <a href="#ref-for-propdef-left④⓪">(2)</a>
     <li><a href="#ref-for-propdef-left④⑤">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-top-auto">
-   <b><a href="#valdef-top-auto">#valdef-top-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-top-auto" class="dfn-panel" data-for="valdef-top-auto" id="infopanel-for-valdef-top-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-top-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-top-auto">#valdef-top-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-top-auto">9.3.2. Box offsets: top, right, bottom, left</a> <a href="#ref-for-valdef-top-auto①">(2)</a> <a href="#ref-for-valdef-top-auto②">(3)</a> <a href="#ref-for-valdef-top-auto③">(4)</a>
     <li><a href="#ref-for-valdef-top-auto④">9.4.3. Relative positioning</a> <a href="#ref-for-valdef-top-auto⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-box">
-   <b><a href="#line-box">#line-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-box" class="dfn-panel" data-for="line-box" id="infopanel-for-line-box" role="dialog">
+   <span id="infopaneltitle-for-line-box" style="display:none">Info about the 'line box' definition.</span><b><a href="#line-box">#line-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-box">9.5.1. Positioning the float: the
 float property</a>
@@ -19342,8 +19368,8 @@ properties</a>
     <li><a href="#ref-for-line-box">17.5.3. Table height algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-float">
-   <b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-float" class="dfn-panel" data-for="propdef-float" id="infopanel-for-propdef-float" role="dialog">
+   <span id="infopaneltitle-for-propdef-float" style="display:none">Info about the 'float' definition.</span><b><a href="#propdef-float">#propdef-float</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">5.12.2. The :first-letter pseudo-element</a> <a href="#ref-for-propdef-float①">(2)</a> <a href="#ref-for-propdef-float②">(3)</a>
     <li><a href="#ref-for-propdef-float③">9.3.1. Choosing a positioning scheme: position property</a>
@@ -19357,8 +19383,8 @@ and float</a> <a href="#ref-for-propdef-float⑦">(2)</a> <a href="#ref-for-prop
     <li><a href="#ref-for-propdef-float①④">17.4. Tables in the visual formatting model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-float-none">
-   <b><a href="#valdef-float-none">#valdef-float-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-float-none" class="dfn-panel" data-for="valdef-float-none" id="infopanel-for-valdef-float-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-float-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-float-none">#valdef-float-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-float-none">5.12.2. The :first-letter pseudo-element</a> <a href="#ref-for-valdef-float-none①">(2)</a>
     <li><a href="#ref-for-valdef-float-none②">9.5.1. Positioning the float: the
@@ -19369,16 +19395,16 @@ and float</a> <a href="#ref-for-valdef-float-none④">(2)</a>
     <li><a href="#ref-for-valdef-float-none⑦">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="float-rules">
-   <b><a href="#float-rules">#float-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-float-rules" class="dfn-panel" data-for="float-rules" id="infopanel-for-float-rules" role="dialog">
+   <span id="infopaneltitle-for-float-rules" style="display:none">Info about the 'Here are the precise rules' definition.</span><b><a href="#float-rules">#float-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-float-rules">9.5. Floats</a>
     <li><a href="#ref-for-float-rules">9.5.2. Controlling flow next to floats:
 the clear property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clear">
-   <b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clear" class="dfn-panel" data-for="propdef-clear" id="infopanel-for-propdef-clear" role="dialog">
+   <span id="infopaneltitle-for-propdef-clear" style="display:none">Info about the 'clear' definition.</span><b><a href="#propdef-clear">#propdef-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clear">1.4.2.3. Applies to</a>
     <li><a href="#ref-for-propdef-clear①">9.5. Floats</a> <a href="#ref-for-propdef-clear②">(2)</a> <a href="#ref-for-propdef-clear③">(3)</a>
@@ -19390,29 +19416,31 @@ the clear property</a> <a href="#ref-for-propdef-clear⑥">(2)</a> <a href="#ref
     <li><a href="#ref-for-propdef-clear①⑥">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clear-both">
-   <b><a href="#valdef-clear-both">#valdef-clear-both</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clear-both" class="dfn-panel" data-for="valdef-clear-both" id="infopanel-for-valdef-clear-both" role="dialog">
+   <span id="infopaneltitle-for-valdef-clear-both" style="display:none">Info about the 'both' definition.</span><b><a href="#valdef-clear-both">#valdef-clear-both</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clear-both">9.5.2. Controlling flow next to floats:
 the clear property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clear-none">
-   <b><a href="#valdef-clear-none">#valdef-clear-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clear-none" class="dfn-panel" data-for="valdef-clear-none" id="infopanel-for-valdef-clear-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-clear-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-clear-none">#valdef-clear-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clear-none">9.5.2. Controlling flow next to floats:
 the clear property</a> <a href="#ref-for-valdef-clear-none①">(2)</a>
     <li><a href="#ref-for-valdef-clear-none②">10.6.4. Absolutely positioned, non-replaced elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clearance">
-   <b><a href="#clearance">#clearance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clearance" class="dfn-panel" data-for="clearance" id="infopanel-for-clearance" role="dialog">
+   <span id="infopaneltitle-for-clearance" style="display:none">Info about the 'clearance' definition.</span><b><a href="#clearance">#clearance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clearance">8.3.1. Collapsing margins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolutely-positioned">
-   <b><a href="#absolutely-positioned">#absolutely-positioned</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolutely-positioned" class="dfn-panel" data-for="absolutely-positioned" id="infopanel-for-absolutely-positioned" role="dialog">
+   <span id="infopaneltitle-for-absolutely-positioned" style="display:none">Info about the '
+absolutely positioned
+element' definition.</span><b><a href="#absolutely-positioned">#absolutely-positioned</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolutely-positioned">8.3.1. Collapsing margins</a>
     <li><a href="#ref-for-absolutely-positioned">9.3.1. Choosing a positioning scheme: position property</a>
@@ -19421,28 +19449,29 @@ the clear property</a> <a href="#ref-for-valdef-clear-none①">(2)</a>
 float property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-z-index">
-   <b><a href="#propdef-z-index">#propdef-z-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-z-index" class="dfn-panel" data-for="propdef-z-index" id="infopanel-for-propdef-z-index" role="dialog">
+   <span id="infopaneltitle-for-propdef-z-index" style="display:none">Info about the 'z-index' definition.</span><b><a href="#propdef-z-index">#propdef-z-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-z-index">9.9.1. Specifying the stack level: the z-index property</a> <a href="#ref-for-propdef-z-index①">(2)</a> <a href="#ref-for-propdef-z-index②">(3)</a> <a href="#ref-for-propdef-z-index③">(4)</a>
     <li><a href="#ref-for-propdef-z-index④">14.2. The background</a>
     <li><a href="#ref-for-propdef-z-index⑤">Painting order</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-z-index-auto">
-   <b><a href="#valdef-z-index-auto">#valdef-z-index-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-z-index-auto" class="dfn-panel" data-for="valdef-z-index-auto" id="infopanel-for-valdef-z-index-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-z-index-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-z-index-auto">#valdef-z-index-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-z-index-auto">9.9.1. Specifying the stack level: the z-index property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stack-level">
-   <b><a href="#stack-level">#stack-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stack-level" class="dfn-panel" data-for="stack-level" id="infopanel-for-stack-level" role="dialog">
+   <span id="infopaneltitle-for-stack-level" style="display:none">Info about the 'stack
+level' definition.</span><b><a href="#stack-level">#stack-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-level">9.6. Absolute positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-direction">
-   <b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-direction" class="dfn-panel" data-for="propdef-direction" id="infopanel-for-propdef-direction" role="dialog">
+   <span id="infopaneltitle-for-propdef-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#propdef-direction">#propdef-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">8.6. The box model for inline elements in bidirectional context</a> <a href="#ref-for-propdef-direction①">(2)</a>
     <li><a href="#ref-for-propdef-direction②">9.4.3. Relative positioning</a> <a href="#ref-for-propdef-direction③">(2)</a>
@@ -19463,8 +19492,8 @@ list-style properties</a> <a href="#ref-for-propdef-direction②⑥">(2)</a>
     <li><a href="#ref-for-propdef-direction③②">17.6.2.1. Border conflict resolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-ltr">
-   <b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-ltr" class="dfn-panel" data-for="valdef-direction-ltr" id="infopanel-for-valdef-direction-ltr" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-ltr" style="display:none">Info about the 'ltr' definition.</span><b><a href="#valdef-direction-ltr">#valdef-direction-ltr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-ltr">8.6. The box model for inline elements in bidirectional context</a>
     <li><a href="#ref-for-valdef-direction-ltr①">9.4.3. Relative positioning</a>
@@ -19479,8 +19508,8 @@ list-style properties</a>
     <li><a href="#ref-for-valdef-direction-ltr①④">17.6.2.1. Border conflict resolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-direction-rtl">
-   <b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-direction-rtl" class="dfn-panel" data-for="valdef-direction-rtl" id="infopanel-for-valdef-direction-rtl" role="dialog">
+   <span id="infopaneltitle-for-valdef-direction-rtl" style="display:none">Info about the 'rtl' definition.</span><b><a href="#valdef-direction-rtl">#valdef-direction-rtl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-direction-rtl">8.6. The box model for inline elements in bidirectional context</a>
     <li><a href="#ref-for-valdef-direction-rtl①">9.4.3. Relative positioning</a>
@@ -19495,8 +19524,8 @@ list-style properties</a>
     <li><a href="#ref-for-valdef-direction-rtl①②">17.6.2.1. Border conflict resolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-unicode-bidi">
-   <b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-unicode-bidi" class="dfn-panel" data-for="propdef-unicode-bidi" id="infopanel-for-propdef-unicode-bidi" role="dialog">
+   <span id="infopaneltitle-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' definition.</span><b><a href="#propdef-unicode-bidi">#propdef-unicode-bidi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">9.10. Text direction:
 the direction
@@ -19504,8 +19533,8 @@ and unicode-bidi
 properties </a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a> <a href="#ref-for-propdef-unicode-bidi②">(3)</a> <a href="#ref-for-propdef-unicode-bidi③">(4)</a> <a href="#ref-for-propdef-unicode-bidi④">(5)</a> <a href="#ref-for-propdef-unicode-bidi⑤">(6)</a> <a href="#ref-for-propdef-unicode-bidi⑥">(7)</a> <a href="#ref-for-propdef-unicode-bidi⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-normal">
-   <b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-normal" class="dfn-panel" data-for="valdef-unicode-bidi-normal" id="infopanel-for-valdef-unicode-bidi-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-unicode-bidi-normal">#valdef-unicode-bidi-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-normal">9.10. Text direction:
 the direction
@@ -19513,8 +19542,8 @@ and unicode-bidi
 properties </a> <a href="#ref-for-valdef-unicode-bidi-normal①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-normal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-unicode-bidi-embed">
-   <b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-unicode-bidi-embed" class="dfn-panel" data-for="valdef-unicode-bidi-embed" id="infopanel-for-valdef-unicode-bidi-embed" role="dialog">
+   <span id="infopaneltitle-for-valdef-unicode-bidi-embed" style="display:none">Info about the 'embed' definition.</span><b><a href="#valdef-unicode-bidi-embed">#valdef-unicode-bidi-embed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-embed">9.10. Text direction:
 the direction
@@ -19522,8 +19551,8 @@ and unicode-bidi
 properties </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-width">
-   <b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-width" class="dfn-panel" data-for="propdef-width" id="infopanel-for-propdef-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-width" style="display:none">Info about the 'width' definition.</span><b><a href="#propdef-width">#propdef-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">8.1. Box dimensions</a>
     <li><a href="#ref-for-propdef-width①">9.8.3. Floating a box</a>
@@ -19555,8 +19584,8 @@ property</a>
     <li><a href="#ref-for-propdef-width⑤⑥">17.5.2.2. Automatic table layout</a> <a href="#ref-for-propdef-width⑤⑦">(2)</a> <a href="#ref-for-propdef-width⑤⑧">(3)</a> <a href="#ref-for-propdef-width⑤⑨">(4)</a> <a href="#ref-for-propdef-width⑥⓪">(5)</a> <a href="#ref-for-propdef-width⑥①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-width-auto">
-   <b><a href="#valdef-width-auto">#valdef-width-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-width-auto" class="dfn-panel" data-for="valdef-width-auto" id="infopanel-for-valdef-width-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-width-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-width-auto">#valdef-width-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">10.2. Content width: the width property</a>
     <li><a href="#ref-for-valdef-width-auto①">10.3.2. Inline, replaced elements</a> <a href="#ref-for-valdef-width-auto②">(2)</a> <a href="#ref-for-valdef-width-auto③">(3)</a>
@@ -19570,30 +19599,31 @@ property</a>
     <li><a href="#ref-for-valdef-width-auto①③">17.5.2.2. Automatic table layout</a> <a href="#ref-for-valdef-width-auto①④">(2)</a> <a href="#ref-for-valdef-width-auto①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-width">
-   <b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-width" class="dfn-panel" data-for="propdef-min-width" id="infopanel-for-propdef-min-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-width" style="display:none">Info about the 'min-width' definition.</span><b><a href="#propdef-min-width">#propdef-min-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">10.3. Calculating widths and
 margins</a>
     <li><a href="#ref-for-propdef-min-width①">10.4. Minimum and maximum widths: min-width and max-width</a> <a href="#ref-for-propdef-min-width②">(2)</a> <a href="#ref-for-propdef-min-width③">(3)</a> <a href="#ref-for-propdef-min-width④">(4)</a> <a href="#ref-for-propdef-min-width⑤">(5)</a> <a href="#ref-for-propdef-min-width⑥">(6)</a> <a href="#ref-for-propdef-min-width⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-width">
-   <b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-width" class="dfn-panel" data-for="propdef-max-width" id="infopanel-for-propdef-max-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-width" style="display:none">Info about the 'max-width' definition.</span><b><a href="#propdef-max-width">#propdef-max-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">10.3. Calculating widths and
 margins</a>
     <li><a href="#ref-for-propdef-max-width①">10.4. Minimum and maximum widths: min-width and max-width</a> <a href="#ref-for-propdef-max-width②">(2)</a> <a href="#ref-for-propdef-max-width③">(3)</a> <a href="#ref-for-propdef-max-width④">(4)</a> <a href="#ref-for-propdef-max-width⑤">(5)</a> <a href="#ref-for-propdef-max-width⑥">(6)</a> <a href="#ref-for-propdef-max-width⑦">(7)</a> <a href="#ref-for-propdef-max-width⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-max-width-none">
-   <b><a href="#valdef-max-width-none">#valdef-max-width-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-max-width-none" class="dfn-panel" data-for="valdef-max-width-none" id="infopanel-for-valdef-max-width-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-max-width-none" style="display:none">Info about the 'none
+' definition.</span><b><a href="#valdef-max-width-none">#valdef-max-width-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-width-none">10.4. Minimum and maximum widths: min-width and max-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-height">
-   <b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-height" class="dfn-panel" data-for="propdef-height" id="infopanel-for-propdef-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-height" style="display:none">Info about the 'height' definition.</span><b><a href="#propdef-height">#propdef-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">8.1. Box dimensions</a>
     <li><a href="#ref-for-propdef-height①">8.3.1. Collapsing margins</a> <a href="#ref-for-propdef-height②">(2)</a> <a href="#ref-for-propdef-height③">(3)</a>
@@ -19617,8 +19647,8 @@ flow when overflow computes to visible</a>
     <li><a href="#ref-for-propdef-height④①">17.5.3. Table height algorithms</a> <a href="#ref-for-propdef-height④②">(2)</a> <a href="#ref-for-propdef-height④③">(3)</a> <a href="#ref-for-propdef-height④④">(4)</a> <a href="#ref-for-propdef-height④⑤">(5)</a> <a href="#ref-for-propdef-height④⑥">(6)</a> <a href="#ref-for-propdef-height④⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-height-auto">
-   <b><a href="#valdef-height-auto">#valdef-height-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-height-auto" class="dfn-panel" data-for="valdef-height-auto" id="infopanel-for-valdef-height-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-height-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-height-auto">#valdef-height-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-height-auto">8.3.1. Collapsing margins</a> <a href="#ref-for-valdef-height-auto①">(2)</a> <a href="#ref-for-valdef-height-auto②">(3)</a> <a href="#ref-for-valdef-height-auto③">(4)</a>
     <li><a href="#ref-for-valdef-height-auto④">10.5. Content height: the height property</a> <a href="#ref-for-valdef-height-auto⑤">(2)</a>
@@ -19630,8 +19660,8 @@ flow when overflow computes to visible</a>
     <li><a href="#ref-for-valdef-height-auto①⓪">17.5.3. Table height algorithms</a> <a href="#ref-for-valdef-height-auto①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-min-height">
-   <b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-min-height" class="dfn-panel" data-for="propdef-min-height" id="infopanel-for-propdef-min-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-min-height" style="display:none">Info about the 'min-height' definition.</span><b><a href="#propdef-min-height">#propdef-min-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">8.3.1. Collapsing margins</a> <a href="#ref-for-propdef-min-height①">(2)</a> <a href="#ref-for-propdef-min-height②">(3)</a>
     <li><a href="#ref-for-propdef-min-height③">10.4. Minimum and maximum widths: min-width and max-width</a>
@@ -19640,8 +19670,8 @@ margins</a>
     <li><a href="#ref-for-propdef-min-height⑤">10.7. Minimum and maximum heights: min-height and max-height</a> <a href="#ref-for-propdef-min-height⑥">(2)</a> <a href="#ref-for-propdef-min-height⑦">(3)</a> <a href="#ref-for-propdef-min-height⑧">(4)</a> <a href="#ref-for-propdef-min-height⑨">(5)</a> <a href="#ref-for-propdef-min-height①⓪">(6)</a> <a href="#ref-for-propdef-min-height①①">(7)</a> <a href="#ref-for-propdef-min-height①②">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-max-height">
-   <b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-max-height" class="dfn-panel" data-for="propdef-max-height" id="infopanel-for-propdef-max-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-max-height" style="display:none">Info about the 'max-height' definition.</span><b><a href="#propdef-max-height">#propdef-max-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">10.4. Minimum and maximum widths: min-width and max-width</a>
     <li><a href="#ref-for-propdef-max-height①">10.6. Calculating heights and
@@ -19649,14 +19679,14 @@ margins</a>
     <li><a href="#ref-for-propdef-max-height②">10.7. Minimum and maximum heights: min-height and max-height</a> <a href="#ref-for-propdef-max-height③">(2)</a> <a href="#ref-for-propdef-max-height④">(3)</a> <a href="#ref-for-propdef-max-height⑤">(4)</a> <a href="#ref-for-propdef-max-height⑥">(5)</a> <a href="#ref-for-propdef-max-height⑦">(6)</a> <a href="#ref-for-propdef-max-height⑧">(7)</a> <a href="#ref-for-propdef-max-height⑨">(8)</a> <a href="#ref-for-propdef-max-height①⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-max-height-none">
-   <b><a href="#valdef-max-height-none">#valdef-max-height-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-max-height-none" class="dfn-panel" data-for="valdef-max-height-none" id="infopanel-for-valdef-max-height-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-max-height-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-max-height-none">#valdef-max-height-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-max-height-none">10.7. Minimum and maximum heights: min-height and max-height</a> <a href="#ref-for-valdef-max-height-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-line-height">
-   <b><a href="#propdef-line-height">#propdef-line-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-line-height" class="dfn-panel" data-for="propdef-line-height" id="infopanel-for-propdef-line-height" role="dialog">
+   <span id="infopaneltitle-for-propdef-line-height" style="display:none">Info about the 'line-height' definition.</span><b><a href="#propdef-line-height">#propdef-line-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">1.4.3. Shorthand properties</a>
     <li><a href="#ref-for-propdef-line-height①">4.3.3.  Percentages</a>
@@ -19669,14 +19699,14 @@ properties</a> <a href="#ref-for-propdef-line-height⑨">(2)</a> <a href="#ref-f
     <li><a href="#ref-for-propdef-line-height②②">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-line-height②③">(2)</a> <a href="#ref-for-propdef-line-height②④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-line-height-normal">
-   <b><a href="#valdef-line-height-normal">#valdef-line-height-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-line-height-normal" class="dfn-panel" data-for="valdef-line-height-normal" id="infopanel-for-valdef-line-height-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-line-height-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-line-height-normal">#valdef-line-height-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-line-height-normal">10.8.1. Leading and half-leading</a> <a href="#ref-for-valdef-line-height-normal①">(2)</a> <a href="#ref-for-valdef-line-height-normal②">(3)</a> <a href="#ref-for-valdef-line-height-normal③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-vertical-align">
-   <b><a href="#propdef-vertical-align">#propdef-vertical-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-vertical-align" class="dfn-panel" data-for="propdef-vertical-align" id="infopanel-for-propdef-vertical-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' definition.</span><b><a href="#propdef-vertical-align">#propdef-vertical-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">5.12.2. The :first-letter pseudo-element</a>
     <li><a href="#ref-for-propdef-vertical-align①">9.4.2. Inline formatting contexts</a>
@@ -19686,14 +19716,14 @@ properties</a> <a href="#ref-for-propdef-vertical-align③">(2)</a>
     <li><a href="#ref-for-propdef-vertical-align⑤">17.5.3. Table height algorithms</a> <a href="#ref-for-propdef-vertical-align⑥">(2)</a> <a href="#ref-for-propdef-vertical-align⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-vertical-align-baseline">
-   <b><a href="#valdef-vertical-align-baseline">#valdef-vertical-align-baseline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-vertical-align-baseline" class="dfn-panel" data-for="valdef-vertical-align-baseline" id="infopanel-for-valdef-vertical-align-baseline" role="dialog">
+   <span id="infopaneltitle-for-valdef-vertical-align-baseline" style="display:none">Info about the 'baseline' definition.</span><b><a href="#valdef-vertical-align-baseline">#valdef-vertical-align-baseline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-vertical-align-baseline">10.8.1. Leading and half-leading</a> <a href="#ref-for-valdef-vertical-align-baseline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overflow">
-   <b><a href="#overflow">#overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow" class="dfn-panel" data-for="overflow" id="infopanel-for-overflow" role="dialog">
+   <span id="infopaneltitle-for-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#overflow">#overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow">9.1.2. 
 Containing blocks </a>
@@ -19704,8 +19734,8 @@ properties </a>
     <li><a href="#ref-for-overflow">10.5. Content height: the height property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-overflow">
-   <b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-overflow" class="dfn-panel" data-for="propdef-overflow" id="infopanel-for-propdef-overflow" role="dialog">
+   <span id="infopaneltitle-for-propdef-overflow" style="display:none">Info about the 'overflow' definition.</span><b><a href="#propdef-overflow">#propdef-overflow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">8.3.1. Collapsing margins</a>
     <li><a href="#ref-for-propdef-overflow①">9.4.1. Block formatting contexts</a>
@@ -19729,8 +19759,8 @@ background </a>
     <li><a href="#ref-for-propdef-overflow②③">17.6.2. The collapsing border model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-visible">
-   <b><a href="#valdef-overflow-visible">#valdef-overflow-visible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-visible" class="dfn-panel" data-for="valdef-overflow-visible" id="infopanel-for-valdef-overflow-visible" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-visible" style="display:none">Info about the 'visible' definition.</span><b><a href="#valdef-overflow-visible">#valdef-overflow-visible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">8.3.1. Collapsing margins</a>
     <li><a href="#ref-for-valdef-overflow-visible①">9.4.1. Block formatting contexts</a>
@@ -19745,44 +19775,44 @@ flow when overflow computes to visible</a> <a href="#ref-for-valdef-overflow-vis
 list-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-hidden">
-   <b><a href="#valdef-overflow-hidden">#valdef-overflow-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-hidden" class="dfn-panel" data-for="valdef-overflow-hidden" id="infopanel-for-valdef-overflow-hidden" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#valdef-overflow-hidden">#valdef-overflow-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">11.1.1. Overflow: the overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-scroll">
-   <b><a href="#valdef-overflow-scroll">#valdef-overflow-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-scroll" class="dfn-panel" data-for="valdef-overflow-scroll" id="infopanel-for-valdef-overflow-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-overflow-scroll">#valdef-overflow-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-scroll">11.1.1. Overflow: the overflow property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-overflow-auto">
-   <b><a href="#valdef-overflow-auto">#valdef-overflow-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-overflow-auto" class="dfn-panel" data-for="valdef-overflow-auto" id="infopanel-for-valdef-overflow-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-overflow-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-overflow-auto">#valdef-overflow-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">11.1.1. Overflow: the overflow property</a> <a href="#ref-for-valdef-overflow-auto①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clip">
-   <b><a href="#propdef-clip">#propdef-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clip" class="dfn-panel" data-for="propdef-clip" id="infopanel-for-propdef-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-clip" style="display:none">Info about the 'clip' definition.</span><b><a href="#propdef-clip">#propdef-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">11.1.2. Clipping: the clip property</a> <a href="#ref-for-propdef-clip①">(2)</a> <a href="#ref-for-propdef-clip②">(3)</a> <a href="#ref-for-propdef-clip③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-auto">
-   <b><a href="#valdef-clip-auto">#valdef-clip-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-auto" class="dfn-panel" data-for="valdef-clip-auto" id="infopanel-for-valdef-clip-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-clip-auto">#valdef-clip-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-auto">11.1.2. Clipping: the clip property</a> <a href="#ref-for-valdef-clip-auto①">(2)</a> <a href="#ref-for-valdef-clip-auto②">(3)</a> <a href="#ref-for-valdef-clip-auto③">(4)</a> <a href="#ref-for-valdef-clip-auto④">(5)</a> <a href="#ref-for-valdef-clip-auto⑤">(6)</a> <a href="#ref-for-valdef-clip-auto⑥">(7)</a> <a href="#ref-for-valdef-clip-auto⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-shape">
-   <b><a href="#value-def-shape">#value-def-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-shape" class="dfn-panel" data-for="value-def-shape" id="infopanel-for-value-def-shape" role="dialog">
+   <span id="infopaneltitle-for-value-def-shape" style="display:none">Info about the '&lt;shape>' definition.</span><b><a href="#value-def-shape">#value-def-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-shape">11.1.2. Clipping: the clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-visibility">
-   <b><a href="#propdef-visibility">#propdef-visibility</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-visibility" class="dfn-panel" data-for="propdef-visibility" id="infopanel-for-propdef-visibility" role="dialog">
+   <span id="infopaneltitle-for-propdef-visibility" style="display:none">Info about the 'visibility' definition.</span><b><a href="#propdef-visibility">#propdef-visibility</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">9.4.3. Relative positioning</a>
     <li><a href="#ref-for-propdef-visibility①">11.2. Visibility: the visibility property</a> <a href="#ref-for-propdef-visibility②">(2)</a>
@@ -19792,24 +19822,24 @@ list-style properties</a>
     <li><a href="#ref-for-propdef-visibility⑧">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-visibility-hidden">
-   <b><a href="#valdef-visibility-hidden">#valdef-visibility-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-visibility-hidden" class="dfn-panel" data-for="valdef-visibility-hidden" id="infopanel-for-valdef-visibility-hidden" role="dialog">
+   <span id="infopaneltitle-for-valdef-visibility-hidden" style="display:none">Info about the 'hidden' definition.</span><b><a href="#valdef-visibility-hidden">#valdef-visibility-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-hidden">11.2. Visibility: the visibility property</a>
     <li><a href="#ref-for-valdef-visibility-hidden①">12.4.3. Counters in elements with 'display: none'</a>
     <li><a href="#ref-for-valdef-visibility-hidden②">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-visibility-collapse">
-   <b><a href="#valdef-visibility-collapse">#valdef-visibility-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-visibility-collapse" class="dfn-panel" data-for="valdef-visibility-collapse" id="infopanel-for-valdef-visibility-collapse" role="dialog">
+   <span id="infopaneltitle-for-valdef-visibility-collapse" style="display:none">Info about the 'collapse' definition.</span><b><a href="#valdef-visibility-collapse">#valdef-visibility-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-collapse">11.2. Visibility: the visibility property</a>
     <li><a href="#ref-for-valdef-visibility-collapse①">17.3. Columns</a>
     <li><a href="#ref-for-valdef-visibility-collapse②">17.5.5. Dynamic row and column effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-before">
-   <b><a href="#selectordef-before">#selectordef-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-before" class="dfn-panel" data-for="selectordef-before" id="infopanel-for-selectordef-before" role="dialog">
+   <span id="infopaneltitle-for-selectordef-before" style="display:none">Info about the ':before' definition.</span><b><a href="#selectordef-before">#selectordef-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">5.12.2. The :first-letter pseudo-element</a>
     <li><a href="#ref-for-selectordef-before①">5.12.3. The :before and :after
@@ -19817,16 +19847,16 @@ pseudo-elements</a>
     <li><a href="#ref-for-selectordef-before②">Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-after">
-   <b><a href="#selectordef-after">#selectordef-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-after" class="dfn-panel" data-for="selectordef-after" id="infopanel-for-selectordef-after" role="dialog">
+   <span id="infopaneltitle-for-selectordef-after" style="display:none">Info about the ':after' definition.</span><b><a href="#selectordef-after">#selectordef-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">5.12.2. The :first-letter pseudo-element</a>
     <li><a href="#ref-for-selectordef-after①">5.12.3. The :before and :after
 pseudo-elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-content">
-   <b><a href="#propdef-content">#propdef-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-content" class="dfn-panel" data-for="propdef-content" id="infopanel-for-propdef-content" role="dialog">
+   <span id="infopaneltitle-for-propdef-content" style="display:none">Info about the 'content' definition.</span><b><a href="#propdef-content">#propdef-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-content">4.3.5. Counters</a> <a href="#ref-for-propdef-content①">(2)</a>
     <li><a href="#ref-for-propdef-content②">4.3.7. Strings</a>
@@ -19843,40 +19873,40 @@ pseudo-elements</a>
     <li><a href="#ref-for-propdef-content①⑤">12.4.1. Nested counters and scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-none">
-   <b><a href="#valdef-content-none">#valdef-content-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-none" class="dfn-panel" data-for="valdef-content-none" id="infopanel-for-valdef-content-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-content-none">#valdef-content-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-none">12.2. The content property</a> <a href="#ref-for-valdef-content-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-content-normal">
-   <b><a href="#valdef-content-normal">#valdef-content-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-content-normal" class="dfn-panel" data-for="valdef-content-normal" id="infopanel-for-valdef-content-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-content-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-content-normal">#valdef-content-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-normal">12.2. The content property</a> <a href="#ref-for-valdef-content-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-open-quote">
-   <b><a href="#value-def-open-quote">#value-def-open-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-open-quote" class="dfn-panel" data-for="value-def-open-quote" id="infopanel-for-value-def-open-quote" role="dialog">
+   <span id="infopaneltitle-for-value-def-open-quote" style="display:none">Info about the 'open-quote' definition.</span><b><a href="#value-def-open-quote">#value-def-open-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-open-quote">12.3.1. Specifying quotes with the quotes property</a> <a href="#ref-for-value-def-open-quote①">(2)</a>
     <li><a href="#ref-for-value-def-open-quote②">12.3.2. Inserting quotes with the content property</a> <a href="#ref-for-value-def-open-quote③">(2)</a> <a href="#ref-for-value-def-open-quote④">(3)</a> <a href="#ref-for-value-def-open-quote⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-close-quote">
-   <b><a href="#value-def-close-quote">#value-def-close-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-close-quote" class="dfn-panel" data-for="value-def-close-quote" id="infopanel-for-value-def-close-quote" role="dialog">
+   <span id="infopaneltitle-for-value-def-close-quote" style="display:none">Info about the 'close-quote' definition.</span><b><a href="#value-def-close-quote">#value-def-close-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-close-quote">12.3.1. Specifying quotes with the quotes property</a> <a href="#ref-for-value-def-close-quote①">(2)</a>
     <li><a href="#ref-for-value-def-close-quote②">12.3.2. Inserting quotes with the content property</a> <a href="#ref-for-value-def-close-quote③">(2)</a> <a href="#ref-for-value-def-close-quote④">(3)</a> <a href="#ref-for-value-def-close-quote⑤">(4)</a> <a href="#ref-for-value-def-close-quote⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-no-close-quote">
-   <b><a href="#value-def-no-close-quote">#value-def-no-close-quote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-no-close-quote" class="dfn-panel" data-for="value-def-no-close-quote" id="infopanel-for-value-def-no-close-quote" role="dialog">
+   <span id="infopaneltitle-for-value-def-no-close-quote" style="display:none">Info about the 'no-close-quote' definition.</span><b><a href="#value-def-no-close-quote">#value-def-no-close-quote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-no-close-quote">12.3.2. Inserting quotes with the content property</a> <a href="#ref-for-value-def-no-close-quote①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-quotes">
-   <b><a href="#propdef-quotes">#propdef-quotes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-quotes" class="dfn-panel" data-for="propdef-quotes" id="infopanel-for-propdef-quotes" role="dialog">
+   <span id="infopaneltitle-for-propdef-quotes" style="display:none">Info about the 'quotes' definition.</span><b><a href="#propdef-quotes">#propdef-quotes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-quotes">5.11.4. The language pseudo-class: :lang</a>
     <li><a href="#ref-for-propdef-quotes①">12.2. The content property</a>
@@ -19885,24 +19915,24 @@ pseudo-elements</a>
     <li><a href="#ref-for-propdef-quotes⑤">12.3.2. Inserting quotes with the content property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-counter-reset">
-   <b><a href="#propdef-counter-reset">#propdef-counter-reset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-counter-reset" class="dfn-panel" data-for="propdef-counter-reset" id="infopanel-for-propdef-counter-reset" role="dialog">
+   <span id="infopaneltitle-for-propdef-counter-reset" style="display:none">Info about the 'counter-reset' definition.</span><b><a href="#propdef-counter-reset">#propdef-counter-reset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-reset">4.3.5. Counters</a>
     <li><a href="#ref-for-propdef-counter-reset①">12.4. Automatic counters and numbering</a> <a href="#ref-for-propdef-counter-reset②">(2)</a> <a href="#ref-for-propdef-counter-reset③">(3)</a> <a href="#ref-for-propdef-counter-reset④">(4)</a>
     <li><a href="#ref-for-propdef-counter-reset⑤">12.4.1. Nested counters and scope</a> <a href="#ref-for-propdef-counter-reset⑥">(2)</a> <a href="#ref-for-propdef-counter-reset⑦">(3)</a> <a href="#ref-for-propdef-counter-reset⑧">(4)</a> <a href="#ref-for-propdef-counter-reset⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-counter-increment">
-   <b><a href="#propdef-counter-increment">#propdef-counter-increment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-counter-increment" class="dfn-panel" data-for="propdef-counter-increment" id="infopanel-for-propdef-counter-increment" role="dialog">
+   <span id="infopaneltitle-for-propdef-counter-increment" style="display:none">Info about the 'counter-increment' definition.</span><b><a href="#propdef-counter-increment">#propdef-counter-increment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-counter-increment">4.3.5. Counters</a>
     <li><a href="#ref-for-propdef-counter-increment①">12.4. Automatic counters and numbering</a> <a href="#ref-for-propdef-counter-increment②">(2)</a> <a href="#ref-for-propdef-counter-increment③">(3)</a>
     <li><a href="#ref-for-propdef-counter-increment④">12.4.1. Nested counters and scope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-type">
-   <b><a href="#propdef-list-style-type">#propdef-list-style-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-type" class="dfn-panel" data-for="propdef-list-style-type" id="infopanel-for-propdef-list-style-type" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-type" style="display:none">Info about the 'list-style-type' definition.</span><b><a href="#propdef-list-style-type">#propdef-list-style-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-type">4.3.5. Counters</a>
     <li><a href="#ref-for-propdef-list-style-type①">12.4.2. Counter styles</a>
@@ -19911,111 +19941,112 @@ pseudo-elements</a>
 list-style properties</a> <a href="#ref-for-propdef-list-style-type④">(2)</a> <a href="#ref-for-propdef-list-style-type⑤">(3)</a> <a href="#ref-for-propdef-list-style-type⑥">(4)</a> <a href="#ref-for-propdef-list-style-type⑦">(5)</a> <a href="#ref-for-propdef-list-style-type⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-list-style-type-none">
-   <b><a href="#valdef-list-style-type-none">#valdef-list-style-type-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-list-style-type-none" class="dfn-panel" data-for="valdef-list-style-type-none" id="infopanel-for-valdef-list-style-type-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-list-style-type-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-list-style-type-none">#valdef-list-style-type-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-type-none">12.4.2. Counter styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-disc">
-   <b><a href="#value-def-disc">#value-def-disc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-disc" class="dfn-panel" data-for="value-def-disc" id="infopanel-for-value-def-disc" role="dialog">
+   <span id="infopaneltitle-for-value-def-disc" style="display:none">Info about the 'disc' definition.</span><b><a href="#value-def-disc">#value-def-disc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-disc">12.4.2. Counter styles</a>
     <li><a href="#ref-for-value-def-disc①">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a> <a href="#ref-for-value-def-disc②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-circle">
-   <b><a href="#value-def-circle">#value-def-circle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-circle" class="dfn-panel" data-for="value-def-circle" id="infopanel-for-value-def-circle" role="dialog">
+   <span id="infopaneltitle-for-value-def-circle" style="display:none">Info about the 'circle' definition.</span><b><a href="#value-def-circle">#value-def-circle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-circle">12.4.2. Counter styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-square">
-   <b><a href="#value-def-square">#value-def-square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-square" class="dfn-panel" data-for="value-def-square" id="infopanel-for-value-def-square" role="dialog">
+   <span id="infopaneltitle-for-value-def-square" style="display:none">Info about the 'square' definition.</span><b><a href="#value-def-square">#value-def-square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-square">12.4.2. Counter styles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-decimal">
-   <b><a href="#value-def-decimal">#value-def-decimal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-decimal" class="dfn-panel" data-for="value-def-decimal" id="infopanel-for-value-def-decimal" role="dialog">
+   <span id="infopaneltitle-for-value-def-decimal" style="display:none">Info about the 'decimal' definition.</span><b><a href="#value-def-decimal">#value-def-decimal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-decimal">4.3.5. Counters</a>
     <li><a href="#ref-for-value-def-decimal①">12.2. The content property</a> <a href="#ref-for-value-def-decimal②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-lower-latin">
-   <b><a href="#value-def-lower-latin">#value-def-lower-latin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-lower-latin" class="dfn-panel" data-for="value-def-lower-latin" id="infopanel-for-value-def-lower-latin" role="dialog">
+   <span id="infopaneltitle-for-value-def-lower-latin" style="display:none">Info about the 'lower-latin' definition.</span><b><a href="#value-def-lower-latin">#value-def-lower-latin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-lower-latin">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="velue-def-lower-alpha">
-   <b><a href="#velue-def-lower-alpha">#velue-def-lower-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-velue-def-lower-alpha" class="dfn-panel" data-for="velue-def-lower-alpha" id="infopanel-for-velue-def-lower-alpha" role="dialog">
+   <span id="infopaneltitle-for-velue-def-lower-alpha" style="display:none">Info about the 'lower-alpha' definition.</span><b><a href="#velue-def-lower-alpha">#velue-def-lower-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-velue-def-lower-alpha">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-image">
-   <b><a href="#propdef-list-style-image">#propdef-list-style-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-image" class="dfn-panel" data-for="propdef-list-style-image" id="infopanel-for-propdef-list-style-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-image" style="display:none">Info about the 'list-style-image' definition.</span><b><a href="#propdef-list-style-image">#propdef-list-style-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-image">12.5. Lists</a>
     <li><a href="#ref-for-propdef-list-style-image①">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a> <a href="#ref-for-propdef-list-style-image②">(2)</a> <a href="#ref-for-propdef-list-style-image③">(3)</a> <a href="#ref-for-propdef-list-style-image④">(4)</a> <a href="#ref-for-propdef-list-style-image⑤">(5)</a> <a href="#ref-for-propdef-list-style-image⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style-position">
-   <b><a href="#propdef-list-style-position">#propdef-list-style-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style-position" class="dfn-panel" data-for="propdef-list-style-position" id="infopanel-for-propdef-list-style-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style-position" style="display:none">Info about the 'list-style-position' definition.</span><b><a href="#propdef-list-style-position">#propdef-list-style-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style-position">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a> <a href="#ref-for-propdef-list-style-position①">(2)</a> <a href="#ref-for-propdef-list-style-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-list-style-position-outside">
-   <b><a href="#valdef-list-style-position-outside">#valdef-list-style-position-outside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-list-style-position-outside" class="dfn-panel" data-for="valdef-list-style-position-outside" id="infopanel-for-valdef-list-style-position-outside" role="dialog">
+   <span id="infopaneltitle-for-valdef-list-style-position-outside" style="display:none">Info about the 'outside' definition.</span><b><a href="#valdef-list-style-position-outside">#valdef-list-style-position-outside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-list-style-position-outside">12.5. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-list-style">
-   <b><a href="#propdef-list-style">#propdef-list-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-list-style" class="dfn-panel" data-for="propdef-list-style" id="infopanel-for-propdef-list-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-list-style" style="display:none">Info about the 'list-style' definition.</span><b><a href="#propdef-list-style">#propdef-list-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-list-style">12.5.1. Lists: the list-style-type, list-style-image, list-style-position, and
 list-style properties</a> <a href="#ref-for-propdef-list-style①">(2)</a> <a href="#ref-for-propdef-list-style②">(3)</a> <a href="#ref-for-propdef-list-style③">(4)</a> <a href="#ref-for-propdef-list-style④">(5)</a> <a href="#ref-for-propdef-list-style⑤">(6)</a> <a href="#ref-for-propdef-list-style⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-area">
-   <b><a href="#page-area">#page-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-area" class="dfn-panel" data-for="page-area" id="infopanel-for-page-area" role="dialog">
+   <span id="infopaneltitle-for-page-area" style="display:none">Info about the 'page area' definition.</span><b><a href="#page-area">#page-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-area">10.1. Definition of "containing
 block"</a>
     <li><a href="#ref-for-page-area">13.2.2. Page selectors: selecting left, right, and first pages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-page">
-   <b><a href="#at-ruledef-page">#at-ruledef-page</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-page" class="dfn-panel" data-for="at-ruledef-page" id="infopanel-for-at-ruledef-page" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-page" style="display:none">Info about the '@page' definition.</span><b><a href="#at-ruledef-page">#at-ruledef-page</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-page">4.1.5. 
 At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-context">
-   <b><a href="#page-context">#page-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-context" class="dfn-panel" data-for="page-context" id="infopanel-for-page-context" role="dialog">
+   <span id="infopaneltitle-for-page-context" style="display:none">Info about the 'page
+context' definition.</span><b><a href="#page-context">#page-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-context">13.2.1. Page margins</a> <a href="#ref-for-page-context">(2)</a>
     <li><a href="#ref-for-page-context">13.4. Cascading in the page context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-first">
-   <b><a href="#selectordef-first">#selectordef-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-first" class="dfn-panel" data-for="selectordef-first" id="infopanel-for-selectordef-first" role="dialog">
+   <span id="infopaneltitle-for-selectordef-first" style="display:none">Info about the ':first' definition.</span><b><a href="#selectordef-first">#selectordef-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first">13.2.2. Page selectors: selecting left, right, and first pages</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-page-break-before">
-   <b><a href="#propdef-page-break-before">#propdef-page-break-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-page-break-before" class="dfn-panel" data-for="propdef-page-break-before" id="infopanel-for-propdef-page-break-before" role="dialog">
+   <span id="infopaneltitle-for-propdef-page-break-before" style="display:none">Info about the 'page-break-before' definition.</span><b><a href="#propdef-page-break-before">#propdef-page-break-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-before">7.1. Introduction to media types</a>
     <li><a href="#ref-for-propdef-page-break-before①">13.3.1. Page break properties: page-break-before,
@@ -20025,8 +20056,8 @@ page-break-inside </a> <a href="#ref-for-propdef-page-break-before②">(2)</a>
     <li><a href="#ref-for-propdef-page-break-before④">13.3.4. Forced page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-page-break-after">
-   <b><a href="#propdef-page-break-after">#propdef-page-break-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-page-break-after" class="dfn-panel" data-for="propdef-page-break-after" id="infopanel-for-propdef-page-break-after" role="dialog">
+   <span id="infopaneltitle-for-propdef-page-break-after" style="display:none">Info about the 'page-break-after' definition.</span><b><a href="#propdef-page-break-after">#propdef-page-break-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-after">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -20035,8 +20066,8 @@ page-break-inside </a> <a href="#ref-for-propdef-page-break-after①">(2)</a>
     <li><a href="#ref-for-propdef-page-break-after③">13.3.4. Forced page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-page-break-inside">
-   <b><a href="#propdef-page-break-inside">#propdef-page-break-inside</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-page-break-inside" class="dfn-panel" data-for="propdef-page-break-inside" id="infopanel-for-propdef-page-break-inside" role="dialog">
+   <span id="infopaneltitle-for-propdef-page-break-inside" style="display:none">Info about the 'page-break-inside' definition.</span><b><a href="#propdef-page-break-inside">#propdef-page-break-inside</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-page-break-inside">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -20044,8 +20075,8 @@ page-break-inside </a> <a href="#ref-for-propdef-page-break-inside①">(2)</a>
     <li><a href="#ref-for-propdef-page-break-inside②">13.3.3. Allowed page breaks</a> <a href="#ref-for-propdef-page-break-inside③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-break-auto">
-   <b><a href="#valdef-page-break-auto">#valdef-page-break-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-break-auto" class="dfn-panel" data-for="valdef-page-break-auto" id="infopanel-for-valdef-page-break-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-break-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-page-break-auto">#valdef-page-break-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-break-auto">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -20053,8 +20084,8 @@ page-break-inside </a>
     <li><a href="#ref-for-valdef-page-break-auto①">13.3.3. Allowed page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-break-always">
-   <b><a href="#valdef-page-break-always">#valdef-page-break-always</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-break-always" class="dfn-panel" data-for="valdef-page-break-always" id="infopanel-for-valdef-page-break-always" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-break-always" style="display:none">Info about the 'always' definition.</span><b><a href="#valdef-page-break-always">#valdef-page-break-always</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-break-always">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -20063,8 +20094,8 @@ page-break-inside </a> <a href="#ref-for-valdef-page-break-always①">(2)</a>
     <li><a href="#ref-for-valdef-page-break-always③">13.3.4. Forced page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-page-break-avoid">
-   <b><a href="#valdef-page-break-avoid">#valdef-page-break-avoid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-page-break-avoid" class="dfn-panel" data-for="valdef-page-break-avoid" id="infopanel-for-valdef-page-break-avoid" role="dialog">
+   <span id="infopaneltitle-for-valdef-page-break-avoid" style="display:none">Info about the 'avoid' definition.</span><b><a href="#valdef-page-break-avoid">#valdef-page-break-avoid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-page-break-avoid">13.3.1. Page break properties: page-break-before,
 page-break-after,
@@ -20072,24 +20103,24 @@ page-break-inside </a>
     <li><a href="#ref-for-valdef-page-break-avoid①">13.3.3. Allowed page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-orphans">
-   <b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-orphans" class="dfn-panel" data-for="propdef-orphans" id="infopanel-for-propdef-orphans" role="dialog">
+   <span id="infopaneltitle-for-propdef-orphans" style="display:none">Info about the 'orphans' definition.</span><b><a href="#propdef-orphans">#propdef-orphans</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-orphans">13.3.2. Breaks inside elements: orphans, widows</a> <a href="#ref-for-propdef-orphans①">(2)</a>
     <li><a href="#ref-for-propdef-orphans②">13.3.3. Allowed page breaks</a>
     <li><a href="#ref-for-propdef-orphans③">13.3.5. "Best" page breaks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-widows">
-   <b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-widows" class="dfn-panel" data-for="propdef-widows" id="infopanel-for-propdef-widows" role="dialog">
+   <span id="infopaneltitle-for-propdef-widows" style="display:none">Info about the 'widows' definition.</span><b><a href="#propdef-widows">#propdef-widows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-widows">13.3.2. Breaks inside elements: orphans, widows</a> <a href="#ref-for-propdef-widows①">(2)</a>
     <li><a href="#ref-for-propdef-widows②">13.3.3. Allowed page breaks</a>
     <li><a href="#ref-for-propdef-widows③">13.3.5. "Best" page breaks</a> <a href="#ref-for-propdef-widows④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-color">
-   <b><a href="#propdef-color">#propdef-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-color" class="dfn-panel" data-for="propdef-color" id="infopanel-for-propdef-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-color" style="display:none">Info about the 'color' definition.</span><b><a href="#propdef-color">#propdef-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">2.1. A brief CSS 2 tutorial for HTML</a> <a href="#ref-for-propdef-color①">(2)</a>
     <li><a href="#ref-for-propdef-color②">2.4. CSS design principles</a>
@@ -20118,8 +20149,8 @@ property</a> <a href="#ref-for-propdef-color①⑥">(2)</a>
     <li><a href="#ref-for-propdef-color①⑧">18.4. Dynamic outlines: the outline property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-color">
-   <b><a href="#propdef-background-color">#propdef-background-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-color" class="dfn-panel" data-for="propdef-background-color" id="infopanel-for-propdef-background-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-color" style="display:none">Info about the 'background-color' definition.</span><b><a href="#propdef-background-color">#propdef-background-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">14.2. The background</a> <a href="#ref-for-propdef-background-color①">(2)</a>
     <li><a href="#ref-for-propdef-background-color②">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -20128,8 +20159,8 @@ background </a> <a href="#ref-for-propdef-background-color③">(2)</a> <a href="
     <li><a href="#ref-for-propdef-background-color⑥">18.2. System Colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-image">
-   <b><a href="#propdef-background-image">#propdef-background-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-image" class="dfn-panel" data-for="propdef-background-image" id="infopanel-for-propdef-background-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-image" style="display:none">Info about the 'background-image' definition.</span><b><a href="#propdef-background-image">#propdef-background-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">14.2. The background</a>
     <li><a href="#ref-for-propdef-background-image①">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -20138,22 +20169,22 @@ background </a> <a href="#ref-for-propdef-background-image②">(2)</a> <a href="
     <li><a href="#ref-for-propdef-background-image④">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-image-none">
-   <b><a href="#valdef-background-image-none">#valdef-background-image-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-image-none" class="dfn-panel" data-for="valdef-background-image-none" id="infopanel-for-valdef-background-image-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-image-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-background-image-none">#valdef-background-image-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-image-none">14.2. The background</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-repeat">
-   <b><a href="#propdef-background-repeat">#propdef-background-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-repeat" class="dfn-panel" data-for="propdef-background-repeat" id="infopanel-for-propdef-background-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' definition.</span><b><a href="#propdef-background-repeat">#propdef-background-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
 background-position, and
 background </a> <a href="#ref-for-propdef-background-repeat①">(2)</a> <a href="#ref-for-propdef-background-repeat②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-attachment">
-   <b><a href="#propdef-background-attachment">#propdef-background-attachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-attachment" class="dfn-panel" data-for="propdef-background-attachment" id="infopanel-for-propdef-background-attachment" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-attachment" style="display:none">Info about the 'background-attachment' definition.</span><b><a href="#propdef-background-attachment">#propdef-background-attachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-attachment">1.4.2.1. Value</a>
     <li><a href="#ref-for-propdef-background-attachment①">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -20161,24 +20192,24 @@ background-position, and
 background </a> <a href="#ref-for-propdef-background-attachment②">(2)</a> <a href="#ref-for-propdef-background-attachment③">(3)</a> <a href="#ref-for-propdef-background-attachment④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-attachment-fixed">
-   <b><a href="#valdef-background-attachment-fixed">#valdef-background-attachment-fixed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-attachment-fixed" class="dfn-panel" data-for="valdef-background-attachment-fixed" id="infopanel-for-valdef-background-attachment-fixed" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-attachment-fixed" style="display:none">Info about the 'fixed' definition.</span><b><a href="#valdef-background-attachment-fixed">#valdef-background-attachment-fixed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-fixed">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
 background-position, and
 background </a> <a href="#ref-for-valdef-background-attachment-fixed①">(2)</a> <a href="#ref-for-valdef-background-attachment-fixed②">(3)</a> <a href="#ref-for-valdef-background-attachment-fixed③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-attachment-scroll">
-   <b><a href="#valdef-background-attachment-scroll">#valdef-background-attachment-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-attachment-scroll" class="dfn-panel" data-for="valdef-background-attachment-scroll" id="infopanel-for-valdef-background-attachment-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-attachment-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-background-attachment-scroll">#valdef-background-attachment-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-scroll">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
 background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-position">
-   <b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-position" class="dfn-panel" data-for="propdef-background-position" id="infopanel-for-propdef-background-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-position" style="display:none">Info about the 'background-position' definition.</span><b><a href="#propdef-background-position">#propdef-background-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">14.2. The background</a>
     <li><a href="#ref-for-propdef-background-position①">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
@@ -20186,16 +20217,16 @@ background-position, and
 background </a> <a href="#ref-for-propdef-background-position②">(2)</a> <a href="#ref-for-propdef-background-position③">(3)</a> <a href="#ref-for-propdef-background-position④">(4)</a> <a href="#ref-for-propdef-background-position⑤">(5)</a> <a href="#ref-for-propdef-background-position⑥">(6)</a> <a href="#ref-for-propdef-background-position⑦">(7)</a> <a href="#ref-for-propdef-background-position⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-background-position-center">
-   <b><a href="#valdef-background-position-center">#valdef-background-position-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-background-position-center" class="dfn-panel" data-for="valdef-background-position-center" id="infopanel-for-valdef-background-position-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-background-position-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-background-position-center">#valdef-background-position-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-position-center">14.2.1. Background properties: background-color, background-image, background-repeat, background-attachment,
 background-position, and
 background </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background">
-   <b><a href="#propdef-background">#propdef-background</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background" class="dfn-panel" data-for="propdef-background" id="infopanel-for-propdef-background" role="dialog">
+   <span id="infopaneltitle-for-propdef-background" style="display:none">Info about the 'background' definition.</span><b><a href="#propdef-background">#propdef-background</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">6.2.1. The inherit
 value</a>
@@ -20213,8 +20244,8 @@ background </a> <a href="#ref-for-propdef-background⑤">(2)</a> <a href="#ref-f
     <li><a href="#ref-for-propdef-background⑦">17.3. Columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-family">
-   <b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-family" class="dfn-panel" data-for="propdef-font-family" id="infopanel-for-propdef-font-family" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-family" style="display:none">Info about the 'font-family' definition.</span><b><a href="#propdef-font-family">#propdef-font-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">1.4.3. Shorthand properties</a>
     <li><a href="#ref-for-propdef-font-family①">2.1. A brief CSS 2 tutorial for HTML</a>
@@ -20225,20 +20256,20 @@ errors</a>
     <li><a href="#ref-for-propdef-font-family①①">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-family①②">(2)</a> <a href="#ref-for-propdef-font-family①③">(3)</a> <a href="#ref-for-propdef-font-family①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-family-name">
-   <b><a href="#value-def-family-name">#value-def-family-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-family-name" class="dfn-panel" data-for="value-def-family-name" id="infopanel-for-value-def-family-name" role="dialog">
+   <span id="infopaneltitle-for-value-def-family-name" style="display:none">Info about the '&lt;family-name>' definition.</span><b><a href="#value-def-family-name">#value-def-family-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-family-name">15.3. Font family: the font-family property</a> <a href="#ref-for-value-def-family-name①">(2)</a> <a href="#ref-for-value-def-family-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-generic-family">
-   <b><a href="#value-def-generic-family">#value-def-generic-family</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-generic-family" class="dfn-panel" data-for="value-def-generic-family" id="infopanel-for-value-def-generic-family" role="dialog">
+   <span id="infopaneltitle-for-value-def-generic-family" style="display:none">Info about the '&lt;generic-family>' definition.</span><b><a href="#value-def-generic-family">#value-def-generic-family</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-generic-family">15.3. Font family: the font-family property</a> <a href="#ref-for-value-def-generic-family①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-serif">
-   <b><a href="#valdef-generic-family-serif">#valdef-generic-family-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-serif" class="dfn-panel" data-for="valdef-generic-family-serif" id="infopanel-for-valdef-generic-family-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-serif" style="display:none">Info about the 'serif' definition.</span><b><a href="#valdef-generic-family-serif">#valdef-generic-family-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-serif">15.3. Font family: the font-family property</a>
     <li><a href="#ref-for-valdef-generic-family-serif①">15.3.1.1. serif</a> <a href="#ref-for-valdef-generic-family-serif②">(2)</a>
@@ -20246,8 +20277,8 @@ errors</a>
 sans-serif</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-sans-serif">
-   <b><a href="#valdef-generic-family-sans-serif">#valdef-generic-family-sans-serif</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-sans-serif" class="dfn-panel" data-for="valdef-generic-family-sans-serif" id="infopanel-for-valdef-generic-family-sans-serif" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-sans-serif" style="display:none">Info about the 'sans-serif' definition.</span><b><a href="#valdef-generic-family-sans-serif">#valdef-generic-family-sans-serif</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-sans-serif">2.1. A brief CSS 2 tutorial for HTML</a>
     <li><a href="#ref-for-valdef-generic-family-sans-serif①">15.3. Font family: the font-family property</a>
@@ -20256,29 +20287,29 @@ sans-serif</a>
 sans-serif</a> <a href="#ref-for-valdef-generic-family-sans-serif④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-cursive">
-   <b><a href="#valdef-generic-family-cursive">#valdef-generic-family-cursive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-cursive" class="dfn-panel" data-for="valdef-generic-family-cursive" id="infopanel-for-valdef-generic-family-cursive" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-cursive" style="display:none">Info about the 'cursive' definition.</span><b><a href="#valdef-generic-family-cursive">#valdef-generic-family-cursive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-cursive">15.3. Font family: the font-family property</a>
     <li><a href="#ref-for-valdef-generic-family-cursive①">15.3.1.3. 
 cursive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-fantasy">
-   <b><a href="#valdef-generic-family-fantasy">#valdef-generic-family-fantasy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-fantasy" class="dfn-panel" data-for="valdef-generic-family-fantasy" id="infopanel-for-valdef-generic-family-fantasy" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-fantasy" style="display:none">Info about the 'fantasy' definition.</span><b><a href="#valdef-generic-family-fantasy">#valdef-generic-family-fantasy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-fantasy">15.3. Font family: the font-family property</a>
     <li><a href="#ref-for-valdef-generic-family-fantasy①">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-generic-family-monospace">
-   <b><a href="#valdef-generic-family-monospace">#valdef-generic-family-monospace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-generic-family-monospace" class="dfn-panel" data-for="valdef-generic-family-monospace" id="infopanel-for-valdef-generic-family-monospace" role="dialog">
+   <span id="infopaneltitle-for-valdef-generic-family-monospace" style="display:none">Info about the 'monospace' definition.</span><b><a href="#valdef-generic-family-monospace">#valdef-generic-family-monospace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-generic-family-monospace">15.3. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-style">
-   <b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-style" class="dfn-panel" data-for="propdef-font-style" id="infopanel-for-propdef-font-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-style" style="display:none">Info about the 'font-style' definition.</span><b><a href="#propdef-font-style">#propdef-font-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">1.4.3. Shorthand properties</a> <a href="#ref-for-propdef-font-style①">(2)</a>
     <li><a href="#ref-for-propdef-font-style②">15.2. Font matching algorithm</a>
@@ -20287,23 +20318,23 @@ font-style property</a> <a href="#ref-for-propdef-font-style④">(2)</a>
     <li><a href="#ref-for-propdef-font-style⑤">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-style⑥">(2)</a> <a href="#ref-for-propdef-font-style⑦">(3)</a> <a href="#ref-for-propdef-font-style⑧">(4)</a> <a href="#ref-for-propdef-font-style⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-normal">
-   <b><a href="#valdef-font-style-normal">#valdef-font-style-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-normal" class="dfn-panel" data-for="valdef-font-style-normal" id="infopanel-for-valdef-font-style-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-style-normal">#valdef-font-style-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-normal">15.4. Font styling: the
 font-style property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-oblique">
-   <b><a href="#valdef-font-style-oblique">#valdef-font-style-oblique</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-oblique" class="dfn-panel" data-for="valdef-font-style-oblique" id="infopanel-for-valdef-font-style-oblique" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-oblique" style="display:none">Info about the 'oblique' definition.</span><b><a href="#valdef-font-style-oblique">#valdef-font-style-oblique</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-oblique">15.2. Font matching algorithm</a>
     <li><a href="#ref-for-valdef-font-style-oblique①">15.4. Font styling: the
 font-style property</a> <a href="#ref-for-valdef-font-style-oblique②">(2)</a> <a href="#ref-for-valdef-font-style-oblique③">(3)</a> <a href="#ref-for-valdef-font-style-oblique④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-italic">
-   <b><a href="#valdef-font-style-italic">#valdef-font-style-italic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-italic" class="dfn-panel" data-for="valdef-font-style-italic" id="infopanel-for-valdef-font-style-italic" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-italic" style="display:none">Info about the 'italic' definition.</span><b><a href="#valdef-font-style-italic">#valdef-font-style-italic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-italic">15.1. Introduction</a>
     <li><a href="#ref-for-valdef-font-style-italic①">15.2. Font matching algorithm</a> <a href="#ref-for-valdef-font-style-italic②">(2)</a>
@@ -20312,8 +20343,8 @@ font-style property</a> <a href="#ref-for-valdef-font-style-italic④">(2)</a>
     <li><a href="#ref-for-valdef-font-style-italic⑤">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-variant">
-   <b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-variant" class="dfn-panel" data-for="propdef-font-variant" id="infopanel-for-propdef-font-variant" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-variant" style="display:none">Info about the 'font-variant' definition.</span><b><a href="#propdef-font-variant">#propdef-font-variant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">1.4.3. Shorthand properties</a> <a href="#ref-for-propdef-font-variant①">(2)</a>
     <li><a href="#ref-for-propdef-font-variant②">15.2. Font matching algorithm</a>
@@ -20322,22 +20353,22 @@ font-variant property</a> <a href="#ref-for-propdef-font-variant④">(2)</a>
     <li><a href="#ref-for-propdef-font-variant⑤">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-variant⑥">(2)</a> <a href="#ref-for-propdef-font-variant⑦">(3)</a> <a href="#ref-for-propdef-font-variant⑧">(4)</a> <a href="#ref-for-propdef-font-variant⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-variant-normal">
-   <b><a href="#valdef-font-variant-normal">#valdef-font-variant-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-variant-normal" class="dfn-panel" data-for="valdef-font-variant-normal" id="infopanel-for-valdef-font-variant-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-variant-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-variant-normal">#valdef-font-variant-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-variant-normal">15.2. Font matching algorithm</a> <a href="#ref-for-valdef-font-variant-normal①">(2)</a>
     <li><a href="#ref-for-valdef-font-variant-normal②">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-style-small-caps">
-   <b><a href="#valdef-font-style-small-caps">#valdef-font-style-small-caps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-style-small-caps" class="dfn-panel" data-for="valdef-font-style-small-caps" id="infopanel-for-valdef-font-style-small-caps" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-style-small-caps" style="display:none">Info about the 'small-caps' definition.</span><b><a href="#valdef-font-style-small-caps">#valdef-font-style-small-caps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-small-caps">15.2. Font matching algorithm</a> <a href="#ref-for-valdef-font-style-small-caps①">(2)</a> <a href="#ref-for-valdef-font-style-small-caps②">(3)</a>
     <li><a href="#ref-for-valdef-font-style-small-caps③">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-weight">
-   <b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-weight" class="dfn-panel" data-for="propdef-font-weight" id="infopanel-for-propdef-font-weight" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-weight" style="display:none">Info about the 'font-weight' definition.</span><b><a href="#propdef-font-weight">#propdef-font-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">1.4.3. Shorthand properties</a>
     <li><a href="#ref-for-propdef-font-weight①">15.2. Font matching algorithm</a> <a href="#ref-for-propdef-font-weight②">(2)</a>
@@ -20346,15 +20377,15 @@ font-weight property</a> <a href="#ref-for-propdef-font-weight④">(2)</a> <a hr
     <li><a href="#ref-for-propdef-font-weight⑥">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-weight⑦">(2)</a> <a href="#ref-for-propdef-font-weight⑧">(3)</a> <a href="#ref-for-propdef-font-weight⑨">(4)</a> <a href="#ref-for-propdef-font-weight①⓪">(5)</a> <a href="#ref-for-propdef-font-weight①①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-normal">
-   <b><a href="#valdef-font-weight-normal">#valdef-font-weight-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-normal" class="dfn-panel" data-for="valdef-font-weight-normal" id="infopanel-for-valdef-font-weight-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-font-weight-normal">#valdef-font-weight-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-normal">15.6. Font boldness: the
 font-weight property</a> <a href="#ref-for-valdef-font-weight-normal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bold">
-   <b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bold" class="dfn-panel" data-for="valdef-font-weight-bold" id="infopanel-for-valdef-font-weight-bold" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bold" style="display:none">Info about the 'bold' definition.</span><b><a href="#valdef-font-weight-bold">#valdef-font-weight-bold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bold">5.11.1. :first-child pseudo-class</a>
     <li><a href="#ref-for-valdef-font-weight-bold①">15.6. Font boldness: the
@@ -20362,22 +20393,22 @@ font-weight property</a>
     <li><a href="#ref-for-valdef-font-weight-bold②">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-bolder">
-   <b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-bolder" class="dfn-panel" data-for="valdef-font-weight-bolder" id="infopanel-for-valdef-font-weight-bolder" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-bolder" style="display:none">Info about the 'bolder' definition.</span><b><a href="#valdef-font-weight-bolder">#valdef-font-weight-bolder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bolder">15.6. Font boldness: the
 font-weight property</a> <a href="#ref-for-valdef-font-weight-bolder①">(2)</a> <a href="#ref-for-valdef-font-weight-bolder②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-weight-lighter">
-   <b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-weight-lighter" class="dfn-panel" data-for="valdef-font-weight-lighter" id="infopanel-for-valdef-font-weight-lighter" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-weight-lighter" style="display:none">Info about the 'lighter' definition.</span><b><a href="#valdef-font-weight-lighter">#valdef-font-weight-lighter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-lighter">15.6. Font boldness: the
 font-weight property</a> <a href="#ref-for-valdef-font-weight-lighter①">(2)</a> <a href="#ref-for-valdef-font-weight-lighter②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font-size">
-   <b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font-size" class="dfn-panel" data-for="propdef-font-size" id="infopanel-for-propdef-font-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-font-size" style="display:none">Info about the 'font-size' definition.</span><b><a href="#propdef-font-size">#propdef-font-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">1.4.3. Shorthand properties</a>
     <li><a href="#ref-for-propdef-font-size①">4.3.2. Lengths</a> <a href="#ref-for-propdef-font-size②">(2)</a> <a href="#ref-for-propdef-font-size③">(3)</a> <a href="#ref-for-propdef-font-size④">(4)</a>
@@ -20391,36 +20422,36 @@ property</a> <a href="#ref-for-propdef-font-size①③">(2)</a>
     <li><a href="#ref-for-propdef-font-size①④">15.8. Shorthand font property: the font property</a> <a href="#ref-for-propdef-font-size①⑤">(2)</a> <a href="#ref-for-propdef-font-size①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-absolute-size">
-   <b><a href="#value-def-absolute-size">#value-def-absolute-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-absolute-size" class="dfn-panel" data-for="value-def-absolute-size" id="infopanel-for-value-def-absolute-size" role="dialog">
+   <span id="infopaneltitle-for-value-def-absolute-size" style="display:none">Info about the '&lt;absolute-size>' definition.</span><b><a href="#value-def-absolute-size">#value-def-absolute-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-absolute-size">15.7. Font size: the font-size
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-size-medium">
-   <b><a href="#valdef-font-size-medium">#valdef-font-size-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-size-medium" class="dfn-panel" data-for="valdef-font-size-medium" id="infopanel-for-valdef-font-size-medium" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-size-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#valdef-font-size-medium">#valdef-font-size-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-size-medium">15.7. Font size: the font-size
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-size-large">
-   <b><a href="#valdef-font-size-large">#valdef-font-size-large</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-size-large" class="dfn-panel" data-for="valdef-font-size-large" id="infopanel-for-valdef-font-size-large" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-size-large" style="display:none">Info about the 'large' definition.</span><b><a href="#valdef-font-size-large">#valdef-font-size-large</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-size-large">15.7. Font size: the font-size
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-relative-size">
-   <b><a href="#value-def-relative-size">#value-def-relative-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-relative-size" class="dfn-panel" data-for="value-def-relative-size" id="infopanel-for-value-def-relative-size" role="dialog">
+   <span id="infopaneltitle-for-value-def-relative-size" style="display:none">Info about the '&lt;relative-size>' definition.</span><b><a href="#value-def-relative-size">#value-def-relative-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-relative-size">15.7. Font size: the font-size
 property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-font">
-   <b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-font" class="dfn-panel" data-for="propdef-font" id="infopanel-for-propdef-font" role="dialog">
+   <span id="infopaneltitle-for-propdef-font" style="display:none">Info about the 'font' definition.</span><b><a href="#propdef-font">#propdef-font</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">1.4.3. Shorthand properties</a>
     <li><a href="#ref-for-propdef-font①">3.1. Definitions</a>
@@ -20429,28 +20460,28 @@ property</a>
     <li><a href="#ref-for-propdef-font⑨">18.3. User preferences for fonts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-caption">
-   <b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-caption" class="dfn-panel" data-for="valdef-font-caption" id="infopanel-for-valdef-font-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-caption" style="display:none">Info about the 'caption' definition.</span><b><a href="#valdef-font-caption">#valdef-font-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-caption">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-font-small-caption">
-   <b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-font-small-caption" class="dfn-panel" data-for="valdef-font-small-caption" id="infopanel-for-valdef-font-small-caption" role="dialog">
+   <span id="infopaneltitle-for-valdef-font-small-caption" style="display:none">Info about the 'small-caption' definition.</span><b><a href="#valdef-font-small-caption">#valdef-font-small-caption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-small-caption">15.8. Shorthand font property: the font property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-indent">
-   <b><a href="#propdef-text-indent">#propdef-text-indent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-indent" class="dfn-panel" data-for="propdef-text-indent" id="infopanel-for-propdef-text-indent" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-indent" style="display:none">Info about the 'text-indent' definition.</span><b><a href="#propdef-text-indent">#propdef-text-indent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">4.3.2. Lengths</a>
     <li><a href="#ref-for-propdef-text-indent①">11.1. Overflow and clipping</a>
     <li><a href="#ref-for-propdef-text-indent②">16.1. Indentation: the text-indent property</a> <a href="#ref-for-propdef-text-indent③">(2)</a> <a href="#ref-for-propdef-text-indent④">(3)</a> <a href="#ref-for-propdef-text-indent⑤">(4)</a> <a href="#ref-for-propdef-text-indent⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-align">
-   <b><a href="#propdef-text-align">#propdef-text-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-align" class="dfn-panel" data-for="propdef-text-align" id="infopanel-for-propdef-text-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-align" style="display:none">Info about the 'text-align' definition.</span><b><a href="#propdef-text-align">#propdef-text-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">9.4.2. Inline formatting contexts</a>
     <li><a href="#ref-for-propdef-text-align①">16.2. Alignment: the text-align property</a> <a href="#ref-for-propdef-text-align②">(2)</a>
@@ -20459,33 +20490,33 @@ property</a>
     <li><a href="#ref-for-propdef-text-align⑤">17.5.4. Horizontal alignment in a column</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-left">
-   <b><a href="#valdef-text-align-left">#valdef-text-align-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-left" class="dfn-panel" data-for="valdef-text-align-left" id="infopanel-for-valdef-text-align-left" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-left" style="display:none">Info about the 'left' definition.</span><b><a href="#valdef-text-align-left">#valdef-text-align-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-left">16.2. Alignment: the text-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-right">
-   <b><a href="#valdef-text-align-right">#valdef-text-align-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-right" class="dfn-panel" data-for="valdef-text-align-right" id="infopanel-for-valdef-text-align-right" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-right" style="display:none">Info about the 'right' definition.</span><b><a href="#valdef-text-align-right">#valdef-text-align-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-right">16.2. Alignment: the text-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-center">
-   <b><a href="#valdef-text-align-center">#valdef-text-align-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-center" class="dfn-panel" data-for="valdef-text-align-center" id="infopanel-for-valdef-text-align-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-text-align-center">#valdef-text-align-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">16.2. Alignment: the text-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-text-align-justify">
-   <b><a href="#valdef-text-align-justify">#valdef-text-align-justify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-text-align-justify" class="dfn-panel" data-for="valdef-text-align-justify" id="infopanel-for-valdef-text-align-justify" role="dialog">
+   <span id="infopaneltitle-for-valdef-text-align-justify" style="display:none">Info about the 'justify' definition.</span><b><a href="#valdef-text-align-justify">#valdef-text-align-justify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-justify">9.4.2. Inline formatting contexts</a>
     <li><a href="#ref-for-valdef-text-align-justify①">16.2. Alignment: the text-align property</a> <a href="#ref-for-valdef-text-align-justify②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-decoration">
-   <b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-decoration" class="dfn-panel" data-for="propdef-text-decoration" id="infopanel-for-propdef-text-decoration" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' definition.</span><b><a href="#propdef-text-decoration">#propdef-text-decoration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">5.12.1. The :first-line pseudo-element</a>
     <li><a href="#ref-for-propdef-text-decoration①">5.12.2. The :first-letter pseudo-element</a>
@@ -20494,8 +20525,8 @@ blinking: the text-decoration
 property</a> <a href="#ref-for-propdef-text-decoration③">(2)</a> <a href="#ref-for-propdef-text-decoration④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-letter-spacing">
-   <b><a href="#propdef-letter-spacing">#propdef-letter-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-letter-spacing" class="dfn-panel" data-for="propdef-letter-spacing" id="infopanel-for-propdef-letter-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' definition.</span><b><a href="#propdef-letter-spacing">#propdef-letter-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">5.12.1. The :first-line pseudo-element</a>
     <li><a href="#ref-for-propdef-letter-spacing①">5.12.2. The :first-letter pseudo-element</a>
@@ -20503,14 +20534,14 @@ property</a> <a href="#ref-for-propdef-text-decoration③">(2)</a> <a href="#ref
     <li><a href="#ref-for-propdef-letter-spacing③">16.4. Letter and word spacing: the letter-spacing and word-spacing properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-letter-spacing-normal">
-   <b><a href="#valdef-letter-spacing-normal">#valdef-letter-spacing-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-letter-spacing-normal" class="dfn-panel" data-for="valdef-letter-spacing-normal" id="infopanel-for-valdef-letter-spacing-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-letter-spacing-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-letter-spacing-normal">#valdef-letter-spacing-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-letter-spacing-normal">16.4. Letter and word spacing: the letter-spacing and word-spacing properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-word-spacing">
-   <b><a href="#propdef-word-spacing">#propdef-word-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-word-spacing" class="dfn-panel" data-for="propdef-word-spacing" id="infopanel-for-propdef-word-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' definition.</span><b><a href="#propdef-word-spacing">#propdef-word-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">5.12.1. The :first-line pseudo-element</a>
     <li><a href="#ref-for-propdef-word-spacing①">5.12.2. The :first-letter pseudo-element</a>
@@ -20518,14 +20549,14 @@ property</a> <a href="#ref-for-propdef-text-decoration③">(2)</a> <a href="#ref
     <li><a href="#ref-for-propdef-word-spacing③">16.4. Letter and word spacing: the letter-spacing and word-spacing properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-word-spacing-normal">
-   <b><a href="#valdef-word-spacing-normal">#valdef-word-spacing-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-word-spacing-normal" class="dfn-panel" data-for="valdef-word-spacing-normal" id="infopanel-for-valdef-word-spacing-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-word-spacing-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-word-spacing-normal">#valdef-word-spacing-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-word-spacing-normal">16.4. Letter and word spacing: the letter-spacing and word-spacing properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-text-transform">
-   <b><a href="#propdef-text-transform">#propdef-text-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-text-transform" class="dfn-panel" data-for="propdef-text-transform" id="infopanel-for-propdef-text-transform" role="dialog">
+   <span id="infopaneltitle-for-propdef-text-transform" style="display:none">Info about the 'text-transform' definition.</span><b><a href="#propdef-text-transform">#propdef-text-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-transform">5.12.1. The :first-line pseudo-element</a>
     <li><a href="#ref-for-propdef-text-transform①">5.12.2. The :first-letter pseudo-element</a>
@@ -20534,8 +20565,8 @@ font-variant property</a>
     <li><a href="#ref-for-propdef-text-transform③">16.5. Capitalization: the text-transform property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-white-space">
-   <b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-white-space" class="dfn-panel" data-for="propdef-white-space" id="infopanel-for-propdef-white-space" role="dialog">
+   <span id="infopaneltitle-for-propdef-white-space" style="display:none">Info about the 'white-space' definition.</span><b><a href="#propdef-white-space">#propdef-white-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">9.2.2.1. Anonymous inline boxes</a>
     <li><a href="#ref-for-propdef-white-space①">12.2. The content property</a>
@@ -20547,62 +20578,63 @@ font-variant property</a>
     <li><a href="#ref-for-propdef-white-space①⑦">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-normal">
-   <b><a href="#valdef-white-space-normal">#valdef-white-space-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-normal" class="dfn-panel" data-for="valdef-white-space-normal" id="infopanel-for-valdef-white-space-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-white-space-normal">#valdef-white-space-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-normal">16.6. White space: the white-space property</a>
     <li><a href="#ref-for-valdef-white-space-normal①">16.6.1. The white-space processing model</a> <a href="#ref-for-valdef-white-space-normal②">(2)</a> <a href="#ref-for-valdef-white-space-normal③">(3)</a> <a href="#ref-for-valdef-white-space-normal④">(4)</a> <a href="#ref-for-valdef-white-space-normal⑤">(5)</a> <a href="#ref-for-valdef-white-space-normal⑥">(6)</a>
     <li><a href="#ref-for-valdef-white-space-normal⑦">16.6.2. Example of bidirectionality with white space collapsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre">
-   <b><a href="#valdef-white-space-pre">#valdef-white-space-pre</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre" class="dfn-panel" data-for="valdef-white-space-pre" id="infopanel-for-valdef-white-space-pre" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre" style="display:none">Info about the 'pre' definition.</span><b><a href="#valdef-white-space-pre">#valdef-white-space-pre</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre">13.2.3.  Content outside the page box</a>
     <li><a href="#ref-for-valdef-white-space-pre①">16.2. Alignment: the text-align property</a>
     <li><a href="#ref-for-valdef-white-space-pre②">16.6.1. The white-space processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-nowrap">
-   <b><a href="#valdef-white-space-nowrap">#valdef-white-space-nowrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-nowrap" class="dfn-panel" data-for="valdef-white-space-nowrap" id="infopanel-for-valdef-white-space-nowrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-nowrap" style="display:none">Info about the 'nowrap' definition.</span><b><a href="#valdef-white-space-nowrap">#valdef-white-space-nowrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-nowrap">16.6.1. The white-space processing model</a> <a href="#ref-for-valdef-white-space-nowrap①">(2)</a> <a href="#ref-for-valdef-white-space-nowrap②">(3)</a> <a href="#ref-for-valdef-white-space-nowrap③">(4)</a> <a href="#ref-for-valdef-white-space-nowrap④">(5)</a> <a href="#ref-for-valdef-white-space-nowrap⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre-wrap">
-   <b><a href="#valdef-white-space-pre-wrap">#valdef-white-space-pre-wrap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre-wrap" class="dfn-panel" data-for="valdef-white-space-pre-wrap" id="infopanel-for-valdef-white-space-pre-wrap" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre-wrap" style="display:none">Info about the 'pre-wrap' definition.</span><b><a href="#valdef-white-space-pre-wrap">#valdef-white-space-pre-wrap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-wrap">16.2. Alignment: the text-align property</a>
     <li><a href="#ref-for-valdef-white-space-pre-wrap①">16.6.1. The white-space processing model</a> <a href="#ref-for-valdef-white-space-pre-wrap②">(2)</a> <a href="#ref-for-valdef-white-space-pre-wrap③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-white-space-pre-line">
-   <b><a href="#valdef-white-space-pre-line">#valdef-white-space-pre-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-white-space-pre-line" class="dfn-panel" data-for="valdef-white-space-pre-line" id="infopanel-for-valdef-white-space-pre-line" role="dialog">
+   <span id="infopaneltitle-for-valdef-white-space-pre-line" style="display:none">Info about the 'pre-line' definition.</span><b><a href="#valdef-white-space-pre-line">#valdef-white-space-pre-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-line">16.6.1. The white-space processing model</a> <a href="#ref-for-valdef-white-space-pre-line①">(2)</a> <a href="#ref-for-valdef-white-space-pre-line②">(3)</a> <a href="#ref-for-valdef-white-space-pre-line③">(4)</a> <a href="#ref-for-valdef-white-space-pre-line④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-document-language-elements-to-table-elements">
-   <b><a href="#map-document-language-elements-to-table-elements">#map-document-language-elements-to-table-elements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-document-language-elements-to-table-elements" class="dfn-panel" data-for="map-document-language-elements-to-table-elements" id="infopanel-for-map-document-language-elements-to-table-elements" role="dialog">
+   <span id="infopaneltitle-for-map-document-language-elements-to-table-elements" style="display:none">Info about the 'map document language elements to table
+elements' definition.</span><b><a href="#map-document-language-elements-to-table-elements">#map-document-language-elements-to-table-elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-document-language-elements-to-table-elements">17.1. Introduction to tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rules-on-anonymous-table-objects">
-   <b><a href="#rules-on-anonymous-table-objects">#rules-on-anonymous-table-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rules-on-anonymous-table-objects" class="dfn-panel" data-for="rules-on-anonymous-table-objects" id="infopanel-for-rules-on-anonymous-table-objects" role="dialog">
+   <span id="infopaneltitle-for-rules-on-anonymous-table-objects" style="display:none">Info about the 'rules' definition.</span><b><a href="#rules-on-anonymous-table-objects">#rules-on-anonymous-table-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-on-anonymous-table-objects">17.5. Visual layout of table contents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-caption-side">
-   <b><a href="#propdef-caption-side">#propdef-caption-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-caption-side" class="dfn-panel" data-for="propdef-caption-side" id="infopanel-for-propdef-caption-side" role="dialog">
+   <span id="infopaneltitle-for-propdef-caption-side" style="display:none">Info about the 'caption-side' definition.</span><b><a href="#propdef-caption-side">#propdef-caption-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caption-side">17.4. Tables in the visual formatting model</a>
     <li><a href="#ref-for-propdef-caption-side①">17.4.1. Caption position and alignment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-table-layout">
-   <b><a href="#propdef-table-layout">#propdef-table-layout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-table-layout" class="dfn-panel" data-for="propdef-table-layout" id="infopanel-for-propdef-table-layout" role="dialog">
+   <span id="infopaneltitle-for-propdef-table-layout" style="display:none">Info about the 'table-layout' definition.</span><b><a href="#propdef-table-layout">#propdef-table-layout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-table-layout">17.5.2. Table width algorithms:
 the table-layout
@@ -20610,33 +20642,33 @@ property</a> <a href="#ref-for-propdef-table-layout①">(2)</a>
     <li><a href="#ref-for-propdef-table-layout②">17.5.2.2. Automatic table layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-table-layout-auto">
-   <b><a href="#valdef-table-layout-auto">#valdef-table-layout-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-table-layout-auto" class="dfn-panel" data-for="valdef-table-layout-auto" id="infopanel-for-valdef-table-layout-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-table-layout-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-table-layout-auto">#valdef-table-layout-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-table-layout-auto">17.5.2.2. Automatic table layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-collapse">
-   <b><a href="#propdef-border-collapse">#propdef-border-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-collapse" class="dfn-panel" data-for="propdef-border-collapse" id="infopanel-for-propdef-border-collapse" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-collapse" style="display:none">Info about the 'border-collapse' definition.</span><b><a href="#propdef-border-collapse">#propdef-border-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-collapse">17.3. Columns</a>
     <li><a href="#ref-for-propdef-border-collapse①">17.5.1. Table layers and transparency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-collapse-separate">
-   <b><a href="#valdef-border-collapse-separate">#valdef-border-collapse-separate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-collapse-separate" class="dfn-panel" data-for="valdef-border-collapse-separate" id="infopanel-for-valdef-border-collapse-separate" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-collapse-separate" style="display:none">Info about the 'separate' definition.</span><b><a href="#valdef-border-collapse-separate">#valdef-border-collapse-separate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-collapse-separate">17.5.1. Table layers and transparency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-border-collapse-collapse">
-   <b><a href="#valdef-border-collapse-collapse">#valdef-border-collapse-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-border-collapse-collapse" class="dfn-panel" data-for="valdef-border-collapse-collapse" id="infopanel-for-valdef-border-collapse-collapse" role="dialog">
+   <span id="infopaneltitle-for-valdef-border-collapse-collapse" style="display:none">Info about the 'collapse' definition.</span><b><a href="#valdef-border-collapse-collapse">#valdef-border-collapse-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-border-collapse-collapse">17.3. Columns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="separated-borders-model">
-   <b><a href="#separated-borders-model">#separated-borders-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-separated-borders-model" class="dfn-panel" data-for="separated-borders-model" id="infopanel-for-separated-borders-model" role="dialog">
+   <span id="infopaneltitle-for-separated-borders-model" style="display:none">Info about the 'separated borders model' definition.</span><b><a href="#separated-borders-model">#separated-borders-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-separated-borders-model">17.5. Visual layout of table contents</a>
     <li><a href="#ref-for-separated-borders-model①">17.5.1. Table layers and transparency</a> <a href="#ref-for-separated-borders-model②">(2)</a>
@@ -20644,143 +20676,199 @@ property</a> <a href="#ref-for-propdef-table-layout①">(2)</a>
     <li><a href="#ref-for-separated-borders-model④">17.6.3. Border styles</a> <a href="#ref-for-separated-borders-model⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-border-spacing">
-   <b><a href="#propdef-border-spacing">#propdef-border-spacing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-border-spacing" class="dfn-panel" data-for="propdef-border-spacing" id="infopanel-for-propdef-border-spacing" role="dialog">
+   <span id="infopaneltitle-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' definition.</span><b><a href="#propdef-border-spacing">#propdef-border-spacing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">17.5. Visual layout of table contents</a>
     <li><a href="#ref-for-propdef-border-spacing①">17.5.1. Table layers and transparency</a>
     <li><a href="#ref-for-propdef-border-spacing②">17.6.1. The separated borders model</a> <a href="#ref-for-propdef-border-spacing③">(2)</a> <a href="#ref-for-propdef-border-spacing④">(3)</a> <a href="#ref-for-propdef-border-spacing⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-empty-cells">
-   <b><a href="#propdef-empty-cells">#propdef-empty-cells</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-empty-cells" class="dfn-panel" data-for="propdef-empty-cells" id="infopanel-for-propdef-empty-cells" role="dialog">
+   <span id="infopaneltitle-for-propdef-empty-cells" style="display:none">Info about the 'empty-cells' definition.</span><b><a href="#propdef-empty-cells">#propdef-empty-cells</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-empty-cells">17.5.1. Table layers and transparency</a>
     <li><a href="#ref-for-propdef-empty-cells①">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-empty-cells-hide">
-   <b><a href="#valdef-empty-cells-hide">#valdef-empty-cells-hide</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-empty-cells-hide" class="dfn-panel" data-for="valdef-empty-cells-hide" id="infopanel-for-valdef-empty-cells-hide" role="dialog">
+   <span id="infopaneltitle-for-valdef-empty-cells-hide" style="display:none">Info about the 'hide' definition.</span><b><a href="#valdef-empty-cells-hide">#valdef-empty-cells-hide</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-empty-cells-hide">17.5.1. Table layers and transparency</a>
     <li><a href="#ref-for-valdef-empty-cells-hide①">17.6.1.1. Borders and Backgrounds around empty cells: the empty-cells property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-cursor">
-   <b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-cursor" class="dfn-panel" data-for="propdef-cursor" id="infopanel-for-propdef-cursor" role="dialog">
+   <span id="infopaneltitle-for-propdef-cursor" style="display:none">Info about the 'cursor' definition.</span><b><a href="#propdef-cursor">#propdef-cursor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-default">
-   <b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-default" class="dfn-panel" data-for="valdef-cursor-default" id="infopanel-for-valdef-cursor-default" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-default" style="display:none">Info about the 'default' definition.</span><b><a href="#valdef-cursor-default">#valdef-cursor-default</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-default">15.3. Font family: the font-family property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-pointer">
-   <b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-pointer" class="dfn-panel" data-for="valdef-cursor-pointer" id="infopanel-for-valdef-cursor-pointer" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#valdef-cursor-pointer">#valdef-cursor-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-pointer">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-se-resize">
-   <b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-se-resize" class="dfn-panel" data-for="valdef-cursor-se-resize" id="infopanel-for-valdef-cursor-se-resize" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-se-resize" style="display:none">Info about the 'se-resize' definition.</span><b><a href="#valdef-cursor-se-resize">#valdef-cursor-se-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-se-resize">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-cursor-wait">
-   <b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-cursor-wait" class="dfn-panel" data-for="valdef-cursor-wait" id="infopanel-for-valdef-cursor-wait" role="dialog">
+   <span id="infopaneltitle-for-valdef-cursor-wait" style="display:none">Info about the 'wait' definition.</span><b><a href="#valdef-cursor-wait">#valdef-cursor-wait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-cursor-wait">18.1. Cursors: the cursor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline">
-   <b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline" class="dfn-panel" data-for="propdef-outline" id="infopanel-for-propdef-outline" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline" style="display:none">Info about the 'outline' definition.</span><b><a href="#propdef-outline">#propdef-outline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-propdef-outline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-width">
-   <b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-width" class="dfn-panel" data-for="propdef-outline-width" id="infopanel-for-propdef-outline-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-width" style="display:none">Info about the 'outline-width' definition.</span><b><a href="#propdef-outline-width">#propdef-outline-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-width">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-propdef-outline-width①">(2)</a> <a href="#ref-for-propdef-outline-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-style">
-   <b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-style" class="dfn-panel" data-for="propdef-outline-style" id="infopanel-for-propdef-outline-style" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-style" style="display:none">Info about the 'outline-style' definition.</span><b><a href="#propdef-outline-style">#propdef-outline-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-style">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-propdef-outline-style①">(2)</a> <a href="#ref-for-propdef-outline-style②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-outline-color">
-   <b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-outline-color" class="dfn-panel" data-for="propdef-outline-color" id="infopanel-for-propdef-outline-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-outline-color" style="display:none">Info about the 'outline-color' definition.</span><b><a href="#propdef-outline-color">#propdef-outline-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-propdef-outline-color①">(2)</a> <a href="#ref-for-propdef-outline-color②">(3)</a> <a href="#ref-for-propdef-outline-color③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-def-invert">
-   <b><a href="#value-def-invert">#value-def-invert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-def-invert" class="dfn-panel" data-for="value-def-invert" id="infopanel-for-value-def-invert" role="dialog">
+   <span id="infopaneltitle-for-value-def-invert" style="display:none">Info about the 'invert' definition.</span><b><a href="#value-def-invert">#value-def-invert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-invert">18.4. Dynamic outlines: the outline property</a> <a href="#ref-for-value-def-invert①">(2)</a> <a href="#ref-for-value-def-invert②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/cssom-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/cssom-1/Overview.html
@@ -4496,122 +4496,122 @@ initial version of the alternative style sheets API and canonicalization
    <li><a href="#dom-cssstyledeclaration-webkit-cased-attribute">webkit-cased attribute</a><span>, in § 6.6.1</span>
    <li><a href="#dom-cssstyledeclaration-webkit_cased_attribute">webkit_cased_attribute</a><span>, in § 6.6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-a-style-sheet-that-is-blocking-scripts">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#a-style-sheet-that-is-blocking-scripts">https://html.spec.whatwg.org/multipage/semantics.html#a-style-sheet-that-is-blocking-scripts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-style-sheet-that-is-blocking-scripts" class="dfn-panel" data-for="term-for-a-style-sheet-that-is-blocking-scripts" id="infopanel-for-term-for-a-style-sheet-that-is-blocking-scripts" role="menu">
+   <span id="infopaneltitle-for-term-for-a-style-sheet-that-is-blocking-scripts" style="display:none">Info about the 'a style sheet that is blocking scripts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#a-style-sheet-that-is-blocking-scripts">https://html.spec.whatwg.org/multipage/semantics.html#a-style-sheet-that-is-blocking-scripts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-style-sheet-that-is-blocking-scripts">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-a-style-sheet-that-is-blocking-scripts①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-type">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#content-type">https://html.spec.whatwg.org/multipage/infrastructure.html#content-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-type" class="dfn-panel" data-for="term-for-content-type" id="infopanel-for-term-for-content-type" role="menu">
+   <span id="infopaneltitle-for-term-for-content-type" style="display:none">Info about the 'content-type metadata' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#content-type">https://html.spec.whatwg.org/multipage/infrastructure.html#content-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-type">6.3.1. Fetching CSS style sheets</a> <a href="#ref-for-content-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-base-url" class="dfn-panel" data-for="term-for-document-base-url" id="infopanel-for-term-for-document-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-document-base-url" style="display:none">Info about the 'document base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url">https://html.spec.whatwg.org/multipage/infrastructure.html#document-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-base-url">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-document-base-url①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'document url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-concept-document-url①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">6.3.1. Fetching CSS style sheets</a>
     <li><a href="#ref-for-concept-fetch①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-elements">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-elements" class="dfn-panel" data-for="term-for-html-elements" id="infopanel-for-term-for-html-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-html-elements" style="display:none">Info about the 'html elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-elements">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="http://heycam.github.io/webidl/#idl-long">http://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="http://heycam.github.io/webidl/#idl-long">http://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">6.3.1. Fetching CSS style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-concept-node-document①">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">6.3.1. Fetching CSS style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dt-pseudo-attribute">
-   <a href="https://www.w3.org/TR/xml-stylesheet/#dt-pseudo-attribute">https://www.w3.org/TR/xml-stylesheet/#dt-pseudo-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dt-pseudo-attribute" class="dfn-panel" data-for="term-for-dt-pseudo-attribute" id="infopanel-for-term-for-dt-pseudo-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dt-pseudo-attribute" style="display:none">Info about the 'pseudo-attribute' external reference.</span><a href="https://www.w3.org/TR/xml-stylesheet/#dt-pseudo-attribute">https://www.w3.org/TR/xml-stylesheet/#dt-pseudo-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dt-pseudo-attribute">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-dt-pseudo-attribute①">(2)</a> <a href="#ref-for-dt-pseudo-attribute②">(3)</a> <a href="#ref-for-dt-pseudo-attribute③">(4)</a> <a href="#ref-for-dt-pseudo-attribute④">(5)</a> <a href="#ref-for-dt-pseudo-attribute⑤">(6)</a> <a href="#ref-for-dt-pseudo-attribute⑥">(7)</a> <a href="#ref-for-dt-pseudo-attribute⑦">(8)</a> <a href="#ref-for-dt-pseudo-attribute⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">6.3.1. Fetching CSS style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer" class="dfn-panel" data-for="term-for-concept-request-referrer" id="infopanel-for-term-for-concept-request-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer" style="display:none">Info about the 'referrer' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer">6.3.1. Fetching CSS style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">6.3.1. Fetching CSS style sheets</a> <a href="#ref-for-concept-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-sheet-ready">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#style-sheet-ready">https://html.spec.whatwg.org/multipage/semantics.html#style-sheet-ready</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-sheet-ready" class="dfn-panel" data-for="term-for-style-sheet-ready" id="infopanel-for-term-for-style-sheet-ready" role="menu">
+   <span id="infopaneltitle-for-term-for-style-sheet-ready" style="display:none">Info about the 'style sheet ready' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#style-sheet-ready">https://html.spec.whatwg.org/multipage/semantics.html#style-sheet-ready</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-sheet-ready">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-style-sheet-ready①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-supported-property-indices">
-   <a href="http://heycam.github.io/webidl/#dfn-supported-property-indices">http://heycam.github.io/webidl/#dfn-supported-property-indices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-supported-property-indices" class="dfn-panel" data-for="term-for-dfn-supported-property-indices" id="infopanel-for-term-for-dfn-supported-property-indices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-supported-property-indices" style="display:none">Info about the 'supported property indices' external reference.</span><a href="http://heycam.github.io/webidl/#dfn-supported-property-indices">http://heycam.github.io/webidl/#dfn-supported-property-indices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices">4.4. The MediaList Interface</a> <a href="#ref-for-dfn-supported-property-indices①">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-indices②">6.2.2. The StyleSheetList Interface</a> <a href="#ref-for-dfn-supported-property-indices③">(2)</a>
@@ -4619,8 +4619,8 @@ initial version of the alternative style sheets API and canonicalization
     <li><a href="#ref-for-dfn-supported-property-indices⑥">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-dfn-supported-property-indices⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="http://heycam.github.io/webidl/#dfn-throw">http://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="http://heycam.github.io/webidl/#dfn-throw">http://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.4. The MediaList Interface</a>
     <li><a href="#ref-for-dfn-throw①">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-dfn-throw②">(2)</a> <a href="#ref-for-dfn-throw③">(3)</a>
@@ -4629,682 +4629,682 @@ initial version of the alternative style sheets API and canonicalization
     <li><a href="#ref-for-dfn-throw①③">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-order">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#tree-order">https://html.spec.whatwg.org/multipage/infrastructure.html#tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-order" class="dfn-panel" data-for="term-for-tree-order" id="infopanel-for-term-for-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#tree-order">https://html.spec.whatwg.org/multipage/infrastructure.html#tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-order">6.2. CSS Style Sheet Collections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">6.4.4. The CSSImportRule Interface</a> <a href="#ref-for-concept-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">6.3.1. Fetching CSS style sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-concept-url-parser①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-concept-url-serializer①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-parser">
-   <a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser">https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-parser" class="dfn-panel" data-for="term-for-xml-parser" id="infopanel-for-term-for-xml-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-parser" style="display:none">Info about the 'xml parser' external reference.</span><a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser">https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-parser">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dt-xml-stylesheet-processing-instruction">
-   <a href="https://www.w3.org/TR/xml-stylesheet/#dt-xml-stylesheet-processing-instruction">https://www.w3.org/TR/xml-stylesheet/#dt-xml-stylesheet-processing-instruction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dt-xml-stylesheet-processing-instruction" class="dfn-panel" data-for="term-for-dt-xml-stylesheet-processing-instruction" id="infopanel-for-term-for-dt-xml-stylesheet-processing-instruction" role="menu">
+   <span id="infopaneltitle-for-term-for-dt-xml-stylesheet-processing-instruction" style="display:none">Info about the 'xml-stylesheet processing instruction' external reference.</span><a href="https://www.w3.org/TR/xml-stylesheet/#dt-xml-stylesheet-processing-instruction">https://www.w3.org/TR/xml-stylesheet/#dt-xml-stylesheet-processing-instruction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dt-xml-stylesheet-processing-instruction">6.3. Style Sheet Association</a>
     <li><a href="#ref-for-dt-xml-stylesheet-processing-instruction①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-dt-xml-stylesheet-processing-instruction②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef--webkit-transform">
-   <a href="https://compat.spec.whatwg.org/#propdef--webkit-transform">https://compat.spec.whatwg.org/#propdef--webkit-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef--webkit-transform" class="dfn-panel" data-for="term-for-propdef--webkit-transform" id="infopanel-for-term-for-propdef--webkit-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef--webkit-transform" style="display:none">Info about the '-webkit-transform' external reference.</span><a href="https://compat.spec.whatwg.org/#propdef--webkit-transform">https://compat.spec.whatwg.org/#propdef--webkit-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-transform">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csskeyframerule">
-   <a href="https://drafts.csswg.org/css-animations-1/#csskeyframerule">https://drafts.csswg.org/css-animations-1/#csskeyframerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csskeyframerule" class="dfn-panel" data-for="term-for-csskeyframerule" id="infopanel-for-term-for-csskeyframerule" role="menu">
+   <span id="infopaneltitle-for-term-for-csskeyframerule" style="display:none">Info about the 'CSSKeyframeRule' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#csskeyframerule">https://drafts.csswg.org/css-animations-1/#csskeyframerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeyframerule">6.4. CSS Rules</a>
     <li><a href="#ref-for-csskeyframerule①">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csskeyframesrule">
-   <a href="https://drafts.csswg.org/css-animations-1/#csskeyframesrule">https://drafts.csswg.org/css-animations-1/#csskeyframesrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csskeyframesrule" class="dfn-panel" data-for="term-for-csskeyframesrule" id="infopanel-for-term-for-csskeyframesrule" role="menu">
+   <span id="infopaneltitle-for-term-for-csskeyframesrule" style="display:none">Info about the 'CSSKeyframesRule' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#csskeyframesrule">https://drafts.csswg.org/css-animations-1/#csskeyframesrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeyframesrule">6.4. CSS Rules</a>
     <li><a href="#ref-for-csskeyframesrule①">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-csskeyframesrule-cssrules">
-   <a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-cssrules">https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-cssrules</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-csskeyframesrule-cssrules" class="dfn-panel" data-for="term-for-dom-csskeyframesrule-cssrules" id="infopanel-for-term-for-dom-csskeyframesrule-cssrules" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-csskeyframesrule-cssrules" style="display:none">Info about the 'cssRules' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-cssrules">https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-cssrules</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-cssrules">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-csskeyframerule-keytext">
-   <a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframerule-keytext">https://drafts.csswg.org/css-animations-1/#dom-csskeyframerule-keytext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-csskeyframerule-keytext" class="dfn-panel" data-for="term-for-dom-csskeyframerule-keytext" id="infopanel-for-term-for-dom-csskeyframerule-keytext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-csskeyframerule-keytext" style="display:none">Info about the 'keyText' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframerule-keytext">https://drafts.csswg.org/css-animations-1/#dom-csskeyframerule-keytext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframerule-keytext">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-csskeyframesrule-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-name">https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-csskeyframesrule-name" class="dfn-panel" data-for="term-for-dom-csskeyframesrule-name" id="infopanel-for-term-for-dom-csskeyframesrule-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-csskeyframesrule-name" style="display:none">Info about the 'name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-name">https://drafts.csswg.org/css-animations-1/#dom-csskeyframesrule-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csskeyframesrule-name">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-color" class="dfn-panel" data-for="term-for-propdef-border-bottom-color" id="infopanel-for-term-for-propdef-border-bottom-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-color" class="dfn-panel" data-for="term-for-propdef-border-left-color" id="infopanel-for-term-for-propdef-border-left-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-color" class="dfn-panel" data-for="term-for-propdef-border-right-color" id="infopanel-for-term-for-propdef-border-right-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">7.2. Extensions to the Window Interface</a>
     <li><a href="#ref-for-computed-value①">9. Resolved Values</a> <a href="#ref-for-computed-value②">(2)</a> <a href="#ref-for-computed-value③">(3)</a> <a href="#ref-for-computed-value④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">9. Resolved Values</a> <a href="#ref-for-used-value①">(2)</a> <a href="#ref-for-used-value②">(3)</a> <a href="#ref-for-used-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">6.7.2. Serializing CSS Values</a> <a href="#ref-for-typedef-color①">(2)</a>
     <li><a href="#ref-for-typedef-color②">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">9. Resolved Values</a> <a href="#ref-for-propdef-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csscounterstylerule">
-   <a href="https://drafts.csswg.org/css-counter-styles-3/#csscounterstylerule">https://drafts.csswg.org/css-counter-styles-3/#csscounterstylerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csscounterstylerule" class="dfn-panel" data-for="term-for-csscounterstylerule" id="infopanel-for-term-for-csscounterstylerule" role="menu">
+   <span id="infopaneltitle-for-term-for-csscounterstylerule" style="display:none">Info about the 'CSSCounterStyleRule' external reference.</span><a href="https://drafts.csswg.org/css-counter-styles-3/#csscounterstylerule">https://drafts.csswg.org/css-counter-styles-3/#csscounterstylerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csscounterstylerule">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssviewportrule">
-   <a href="https://www.w3.org/TR/css-device-adapt-1/#cssviewportrule">https://www.w3.org/TR/css-device-adapt-1/#cssviewportrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssviewportrule" class="dfn-panel" data-for="term-for-cssviewportrule" id="infopanel-for-term-for-cssviewportrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssviewportrule" style="display:none">Info about the 'CSSViewportRule' external reference.</span><a href="https://www.w3.org/TR/css-device-adapt-1/#cssviewportrule">https://www.w3.org/TR/css-device-adapt-1/#cssviewportrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssviewportrule">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-contents">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-contents" class="dfn-panel" data-for="term-for-valdef-display-contents" id="infopanel-for-term-for-valdef-display-contents" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-contents" style="display:none">Info about the 'contents' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">https://drafts.csswg.org/css-display-3/#valdef-display-contents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-contents">9. Resolved Values</a> <a href="#ref-for-valdef-display-contents①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">9. Resolved Values</a> <a href="#ref-for-propdef-display①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">9. Resolved Values</a> <a href="#ref-for-valdef-display-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-family-name-value">
-   <a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-family-name-value" class="dfn-panel" data-for="term-for-family-name-value" id="infopanel-for-term-for-family-name-value" role="menu">
+   <span id="infopaneltitle-for-term-for-family-name-value" style="display:none">Info about the '&lt;family-name>' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#family-name-value">https://drafts.csswg.org/css-fonts-4/#family-name-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-family-name-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssfontfacerule">
-   <a href="https://drafts.csswg.org/css-fonts-4/#cssfontfacerule">https://drafts.csswg.org/css-fonts-4/#cssfontfacerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssfontfacerule" class="dfn-panel" data-for="term-for-cssfontfacerule" id="infopanel-for-term-for-cssfontfacerule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssfontfacerule" style="display:none">Info about the 'CSSFontFaceRule' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#cssfontfacerule">https://drafts.csswg.org/css-fonts-4/#cssfontfacerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfacerule">6.4. CSS Rules</a> <a href="#ref-for-cssfontfacerule①">(2)</a>
     <li><a href="#ref-for-cssfontfacerule②">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssfontfeaturevaluesrule">
-   <a href="https://drafts.csswg.org/css-fonts-4/#cssfontfeaturevaluesrule">https://drafts.csswg.org/css-fonts-4/#cssfontfeaturevaluesrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssfontfeaturevaluesrule" class="dfn-panel" data-for="term-for-cssfontfeaturevaluesrule" id="infopanel-for-term-for-cssfontfeaturevaluesrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssfontfeaturevaluesrule" style="display:none">Info about the 'CSSFontFeatureValuesRule' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#cssfontfeaturevaluesrule">https://drafts.csswg.org/css-fonts-4/#cssfontfeaturevaluesrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssfontfeaturevaluesrule">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-feature-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-feature-settings" class="dfn-panel" data-for="term-for-propdef-font-feature-settings" id="infopanel-for-term-for-propdef-font-feature-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">6.4. CSS Rules</a> <a href="#ref-for-propdef-font-feature-settings①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-propdef-font-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-stretch">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-stretch" class="dfn-panel" data-for="term-for-propdef-font-stretch" id="infopanel-for-term-for-propdef-font-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">6.4. CSS Rules</a> <a href="#ref-for-propdef-font-stretch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">6.4. CSS Rules</a> <a href="#ref-for-propdef-font-style①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">6.4. CSS Rules</a> <a href="#ref-for-propdef-font-variant①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">6.4. CSS Rules</a> <a href="#ref-for-propdef-font-weight①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-counter">
-   <a href="https://drafts.csswg.org/css-lists-3/#typedef-counter">https://drafts.csswg.org/css-lists-3/#typedef-counter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-counter" class="dfn-panel" data-for="term-for-typedef-counter" id="infopanel-for-term-for-typedef-counter" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-counter" style="display:none">Info about the '&lt;counter>' external reference.</span><a href="https://drafts.csswg.org/css-lists-3/#typedef-counter">https://drafts.csswg.org/css-lists-3/#typedef-counter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-counter">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-block-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-block-size" class="dfn-panel" data-for="term-for-propdef-block-size" id="infopanel-for-term-for-propdef-block-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-block-size" style="display:none">Info about the 'block-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-block-size">https://drafts.csswg.org/css-logical-1/#propdef-block-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-block-size">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-end-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-end-color" class="dfn-panel" data-for="term-for-propdef-border-block-end-color" id="infopanel-for-term-for-propdef-border-block-end-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-end-color" style="display:none">Info about the 'border-block-end-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-end-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-end-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-block-start-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-block-start-color" class="dfn-panel" data-for="term-for-propdef-border-block-start-color" id="infopanel-for-term-for-propdef-border-block-start-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-block-start-color" style="display:none">Info about the 'border-block-start-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-block-start-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-block-start-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-end-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-end-color" class="dfn-panel" data-for="term-for-propdef-border-inline-end-color" id="infopanel-for-term-for-propdef-border-inline-end-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-end-color" style="display:none">Info about the 'border-inline-end-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-end-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-end-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-inline-start-color">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-inline-start-color" class="dfn-panel" data-for="term-for-propdef-border-inline-start-color" id="infopanel-for-term-for-propdef-border-inline-start-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-inline-start-color" style="display:none">Info about the 'border-inline-start-color' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color">https://drafts.csswg.org/css-logical-1/#propdef-border-inline-start-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-inline-start-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inline-size" class="dfn-panel" data-for="term-for-propdef-inline-size" id="infopanel-for-term-for-propdef-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inline-size" style="display:none">Info about the 'inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-size">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-property-group">
-   <a href="https://drafts.csswg.org/css-logical-1/#logical-property-group">https://drafts.csswg.org/css-logical-1/#logical-property-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-property-group" class="dfn-panel" data-for="term-for-logical-property-group" id="infopanel-for-term-for-logical-property-group" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-property-group" style="display:none">Info about the 'logical property group' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#logical-property-group">https://drafts.csswg.org/css-logical-1/#logical-property-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-property-group">6.6. CSS Declaration Blocks</a>
     <li><a href="#ref-for-logical-property-group①">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-logical-property-group②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mapping-logic">
-   <a href="https://drafts.csswg.org/css-logical-1/#mapping-logic">https://drafts.csswg.org/css-logical-1/#mapping-logic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mapping-logic" class="dfn-panel" data-for="term-for-mapping-logic" id="infopanel-for-term-for-mapping-logic" role="menu">
+   <span id="infopaneltitle-for-term-for-mapping-logic" style="display:none">Info about the 'mapping logic' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#mapping-logic">https://drafts.csswg.org/css-logical-1/#mapping-logic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mapping-logic">6.6. CSS Declaration Blocks</a>
     <li><a href="#ref-for-mapping-logic①">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-mapping-logic②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block-end" class="dfn-panel" data-for="term-for-propdef-margin-block-end" id="infopanel-for-term-for-propdef-margin-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block-end" style="display:none">Info about the 'margin-block-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-block-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-block-start" class="dfn-panel" data-for="term-for-propdef-margin-block-start" id="infopanel-for-term-for-propdef-margin-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-block-start" style="display:none">Info about the 'margin-block-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-block-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-inline-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-inline-end" class="dfn-panel" data-for="term-for-propdef-margin-inline-end" id="infopanel-for-term-for-propdef-margin-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-inline-end" style="display:none">Info about the 'margin-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-inline-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-inline-start" class="dfn-panel" data-for="term-for-propdef-margin-inline-start" id="infopanel-for-term-for-propdef-margin-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-inline-start" style="display:none">Info about the 'margin-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-margin-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-inline-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-block-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-block-end" class="dfn-panel" data-for="term-for-propdef-padding-block-end" id="infopanel-for-term-for-propdef-padding-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-block-end" style="display:none">Info about the 'padding-block-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-block-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-block-start" class="dfn-panel" data-for="term-for-propdef-padding-block-start" id="infopanel-for-term-for-propdef-padding-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-block-start" style="display:none">Info about the 'padding-block-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-block-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-inline-end">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-inline-end" class="dfn-panel" data-for="term-for-propdef-padding-inline-end" id="infopanel-for-term-for-propdef-padding-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-inline-end" style="display:none">Info about the 'padding-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-inline-start">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-inline-start" class="dfn-panel" data-for="term-for-propdef-padding-inline-start" id="infopanel-for-term-for-propdef-padding-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-inline-start" style="display:none">Info about the 'padding-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start">https://drafts.csswg.org/css-logical-1/#propdef-padding-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-inline-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-namespace">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#default-namespace">https://drafts.csswg.org/css-namespaces-3/#default-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-namespace" class="dfn-panel" data-for="term-for-default-namespace" id="infopanel-for-term-for-default-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-default-namespace" style="display:none">Info about the 'default namespace' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#default-namespace">https://drafts.csswg.org/css-namespaces-3/#default-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-namespace">5.2. Serializing Selectors</a> <a href="#ref-for-default-namespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespace-prefix">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#namespace-prefix">https://drafts.csswg.org/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespace-prefix" class="dfn-panel" data-for="term-for-namespace-prefix" id="infopanel-for-term-for-namespace-prefix" role="menu">
+   <span id="infopaneltitle-for-term-for-namespace-prefix" style="display:none">Info about the 'namespace prefix' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#namespace-prefix">https://drafts.csswg.org/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespace-prefix">5.2. Serializing Selectors</a> <a href="#ref-for-namespace-prefix①">(2)</a> <a href="#ref-for-namespace-prefix②">(3)</a> <a href="#ref-for-namespace-prefix③">(4)</a> <a href="#ref-for-namespace-prefix④">(5)</a> <a href="#ref-for-namespace-prefix⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-block-end">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-end">https://drafts.csswg.org/css-position-3/#propdef-inset-block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-block-end" class="dfn-panel" data-for="term-for-propdef-inset-block-end" id="infopanel-for-term-for-propdef-inset-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-block-end" style="display:none">Info about the 'inset-block-end' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-end">https://drafts.csswg.org/css-position-3/#propdef-inset-block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-block-start">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-start">https://drafts.csswg.org/css-position-3/#propdef-inset-block-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-block-start" class="dfn-panel" data-for="term-for-propdef-inset-block-start" id="infopanel-for-term-for-propdef-inset-block-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-block-start" style="display:none">Info about the 'inset-block-start' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-block-start">https://drafts.csswg.org/css-position-3/#propdef-inset-block-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-block-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-inline-end">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-inline-end" class="dfn-panel" data-for="term-for-propdef-inset-inline-end" id="infopanel-for-term-for-propdef-inset-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-inline-end" style="display:none">Info about the 'inset-inline-end' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-end">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inset-inline-start">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inset-inline-start" class="dfn-panel" data-for="term-for-propdef-inset-inline-start" id="infopanel-for-term-for-propdef-inset-inline-start" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inset-inline-start" style="display:none">Info about the 'inset-inline-start' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start">https://drafts.csswg.org/css-position-3/#propdef-inset-inline-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inset-inline-start">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">9. Resolved Values</a> <a href="#ref-for-propdef-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-slotted">
-   <a href="https://drafts.csswg.org/css-scoping-1/#selectordef-slotted">https://drafts.csswg.org/css-scoping-1/#selectordef-slotted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-slotted" class="dfn-panel" data-for="term-for-selectordef-slotted" id="infopanel-for-term-for-selectordef-slotted" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-slotted" style="display:none">Info about the '::slotted()' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#selectordef-slotted">https://drafts.csswg.org/css-scoping-1/#selectordef-slotted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-slotted">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flat tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-part">
-   <a href="https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part">https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-part" class="dfn-panel" data-for="term-for-selectordef-part" id="infopanel-for-term-for-selectordef-part" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-part" style="display:none">Info about the '::part()' external reference.</span><a href="https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part">https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-part">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">9. Resolved Values</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-caret-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-color">https://drafts.csswg.org/css-ui-4/#propdef-caret-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-caret-color" class="dfn-panel" data-for="term-for-propdef-caret-color" id="infopanel-for-term-for-propdef-caret-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-caret-color" style="display:none">Info about the 'caret-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-caret-color">https://drafts.csswg.org/css-ui-4/#propdef-caret-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-caret-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline-color">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline-color" class="dfn-panel" data-for="term-for-propdef-outline-color" id="infopanel-for-term-for-propdef-outline-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline-color" style="display:none">Info about the 'outline-color' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline-color">https://drafts.csswg.org/css-ui-4/#propdef-outline-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline-color">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frequency-value">
-   <a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frequency-value" class="dfn-panel" data-for="term-for-frequency-value" id="infopanel-for-term-for-frequency-value" role="menu">
+   <span id="infopaneltitle-for-term-for-frequency-value" style="display:none">Info about the '&lt;frequency>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#frequency-value">https://drafts.csswg.org/css-values-4/#frequency-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frequency-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">6.7.2. Serializing CSS Values</a>
     <li><a href="#ref-for-number-value①">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ratio-value">
-   <a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ratio-value" class="dfn-panel" data-for="term-for-ratio-value" id="infopanel-for-term-for-ratio-value" role="menu">
+   <span id="infopaneltitle-for-term-for-ratio-value" style="display:none">Info about the '&lt;ratio>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">6.7.2. Serializing CSS Values</a> <a href="#ref-for-url-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-1/#custom-property">https://drafts.csswg.org/css-variables-1/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-1/#custom-property">https://drafts.csswg.org/css-variables-1/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">2. Terminology</a>
     <li><a href="#ref-for-custom-property①">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-custom-property②">(2)</a> <a href="#ref-for-custom-property③">(3)</a> <a href="#ref-for-custom-property④">(4)</a>
     <li><a href="#ref-for-custom-property⑤">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-guaranteed-invalid-value">
-   <a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-guaranteed-invalid-value" class="dfn-panel" data-for="term-for-guaranteed-invalid-value" id="infopanel-for-term-for-guaranteed-invalid-value" role="menu">
+   <span id="infopaneltitle-for-term-for-guaranteed-invalid-value" style="display:none">Info about the 'guaranteed-invalid value' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value">https://drafts.csswg.org/css-variables-2/#guaranteed-invalid-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-guaranteed-invalid-value">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-identifier">
-   <a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-identifier" class="dfn-panel" data-for="term-for-value-def-identifier" id="infopanel-for-term-for-value-def-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-identifier" style="display:none">Info about the '&lt;identifier>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-identifier">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-shape">
-   <a href="https://drafts.csswg.org/css2/#value-def-shape">https://drafts.csswg.org/css2/#value-def-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-shape" class="dfn-panel" data-for="term-for-value-def-shape" id="infopanel-for-term-for-value-def-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-shape" style="display:none">Info about the '&lt;shape>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-shape">https://drafts.csswg.org/css2/#value-def-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-shape">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">9. Resolved Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssmediarule">
-   <a href="https://drafts.csswg.org/css-conditional-3/#cssmediarule">https://drafts.csswg.org/css-conditional-3/#cssmediarule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssmediarule" class="dfn-panel" data-for="term-for-cssmediarule" id="infopanel-for-term-for-cssmediarule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssmediarule" style="display:none">Info about the 'CSSMediaRule' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#cssmediarule">https://drafts.csswg.org/css-conditional-3/#cssmediarule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmediarule">6.4. CSS Rules</a>
     <li><a href="#ref-for-cssmediarule①">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-cssmediarule②">6.4.6. The CSSMediaRule Interface</a> <a href="#ref-for-cssmediarule③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csssupportsrule">
-   <a href="https://drafts.csswg.org/css-conditional-3/#csssupportsrule">https://drafts.csswg.org/css-conditional-3/#csssupportsrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csssupportsrule" class="dfn-panel" data-for="term-for-csssupportsrule" id="infopanel-for-term-for-csssupportsrule" role="menu">
+   <span id="infopaneltitle-for-term-for-csssupportsrule" style="display:none">Info about the 'CSSSupportsRule' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#csssupportsrule">https://drafts.csswg.org/css-conditional-3/#csssupportsrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csssupportsrule">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-whitespace-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token">https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-whitespace-token" class="dfn-panel" data-for="term-for-typedef-whitespace-token" id="infopanel-for-term-for-typedef-whitespace-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-whitespace-token" style="display:none">Info about the '&lt;whitespace-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token">https://drafts.csswg.org/css-syntax-3/#typedef-whitespace-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-whitespace-token">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-encoding">
-   <a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-encoding" class="dfn-panel" data-for="term-for-environment-encoding" id="infopanel-for-term-for-environment-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-encoding" style="display:none">Info about the 'environment encoding' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#environment-encoding">https://drafts.csswg.org/css-syntax-3/#environment-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-encoding">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">6.7.2. Serializing CSS Values</a>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar①">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-list-of-component-values">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-list-of-component-values" class="dfn-panel" data-for="term-for-parse-a-list-of-component-values" id="infopanel-for-term-for-parse-a-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-list-of-component-values" style="display:none">Info about the 'parse a list of component values' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-component-values">6.7.1. Parsing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-list-of-declarations">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-declarations">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-declarations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-list-of-declarations" class="dfn-panel" data-for="term-for-parse-a-list-of-declarations" id="infopanel-for-term-for-parse-a-list-of-declarations" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-list-of-declarations" style="display:none">Info about the 'parse a list of declarations' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-declarations">https://drafts.csswg.org/css-syntax-3/#parse-a-list-of-declarations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-declarations">6.6. CSS Declaration Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-rule">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-rule">https://drafts.csswg.org/css-syntax-3/#parse-a-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-rule" class="dfn-panel" data-for="term-for-parse-a-rule" id="infopanel-for-term-for-parse-a-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-rule" style="display:none">Info about the 'parse a rule' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-rule">https://drafts.csswg.org/css-syntax-3/#parse-a-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-rule">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-an-anb-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value">https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-an-anb-value" class="dfn-panel" data-for="term-for-serialize-an-anb-value" id="infopanel-for-term-for-serialize-an-anb-value" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-an-anb-value" style="display:none">Info about the 'serialize an &lt;an+b> value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value">https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-anb-value">5.2. Serializing Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-document③">11.1. Changes From 5 December 2013</a> <a href="#ref-for-document④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-documentorshadowroot①">(2)</a> <a href="#ref-for-documentorshadowroot②">(3)</a>
     <li><a href="#ref-for-documentorshadowroot③">6.2.3. Extensions to the DocumentOrShadowRoot Interface Mixin</a> <a href="#ref-for-documentorshadowroot④">(2)</a>
     <li><a href="#ref-for-documentorshadowroot⑤">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-element①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
@@ -5313,73 +5313,73 @@ initial version of the alternative style sheets API and canonicalization
     <li><a href="#ref-for-element④">11.1. Changes From 5 December 2013</a> <a href="#ref-for-element⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-processinginstruction">
-   <a href="https://dom.spec.whatwg.org/#processinginstruction">https://dom.spec.whatwg.org/#processinginstruction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-processinginstruction" class="dfn-panel" data-for="term-for-processinginstruction" id="infopanel-for-term-for-processinginstruction" role="menu">
+   <span id="infopaneltitle-for-term-for-processinginstruction" style="display:none">Info about the 'ProcessingInstruction' external reference.</span><a href="https://dom.spec.whatwg.org/#processinginstruction">https://dom.spec.whatwg.org/#processinginstruction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processinginstruction">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-processinginstruction①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attributes-change-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attributes-change-ext">https://dom.spec.whatwg.org/#concept-element-attributes-change-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attributes-change-ext" class="dfn-panel" data-for="term-for-concept-element-attributes-change-ext" id="infopanel-for-term-for-concept-element-attributes-change-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attributes-change-ext" style="display:none">Info about the 'attribute change steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attributes-change-ext">https://dom.spec.whatwg.org/#concept-element-attributes-change-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-change-ext">6.6. CSS Declaration Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-encoding">
-   <a href="https://dom.spec.whatwg.org/#concept-document-encoding">https://dom.spec.whatwg.org/#concept-document-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-encoding" class="dfn-panel" data-for="term-for-concept-document-encoding" id="infopanel-for-term-for-concept-document-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-encoding" style="display:none">Info about the 'encoding' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-encoding">https://dom.spec.whatwg.org/#concept-document-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-encoding">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-a-document-tree">
-   <a href="https://dom.spec.whatwg.org/#in-a-document-tree">https://dom.spec.whatwg.org/#in-a-document-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-a-document-tree" class="dfn-panel" data-for="term-for-in-a-document-tree" id="infopanel-for-term-for-in-a-document-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-in-a-document-tree" style="display:none">Info about the 'in a document tree' external reference.</span><a href="https://dom.spec.whatwg.org/#in-a-document-tree">https://dom.spec.whatwg.org/#in-a-document-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-a-document-tree">6.1. CSS Style Sheets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
-   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boundary-point-node" class="dfn-panel" data-for="term-for-boundary-point-node" id="infopanel-for-term-for-boundary-point-node" role="menu">
+   <span id="infopaneltitle-for-term-for-boundary-point-node" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-boundary-point-node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attributes-set-value">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attributes-set-value">https://dom.spec.whatwg.org/#concept-element-attributes-set-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attributes-set-value" class="dfn-panel" data-for="term-for-concept-element-attributes-set-value" id="infopanel-for-term-for-concept-element-attributes-set-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attributes-set-value" style="display:none">Info about the 'set an attribute value' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attributes-set-value">https://dom.spec.whatwg.org/#concept-element-attributes-set-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-set-value">6.6. CSS Declaration Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document①" role="menu">
+   <span id="infopaneltitle-for-term-for-document①" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-document③">11.1. Changes From 5 December 2013</a> <a href="#ref-for-document④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot①" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot①" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-documentorshadowroot①">(2)</a> <a href="#ref-for-documentorshadowroot②">(3)</a>
     <li><a href="#ref-for-documentorshadowroot③">6.2.3. Extensions to the DocumentOrShadowRoot Interface Mixin</a> <a href="#ref-for-documentorshadowroot④">(2)</a>
     <li><a href="#ref-for-documentorshadowroot⑤">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element①" role="menu">
+   <span id="infopaneltitle-for-term-for-element①" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-element①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
@@ -5388,273 +5388,273 @@ initial version of the alternative style sheets API and canonicalization
     <li><a href="#ref-for-element④">11.1. Changes From 5 December 2013</a> <a href="#ref-for-element⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-cd-data">
-   <a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-cd-data" class="dfn-panel" data-for="term-for-concept-cd-data" id="infopanel-for-term-for-concept-cd-data" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-cd-data" style="display:none">Info about the 'data' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-cd-data">https://dom.spec.whatwg.org/#concept-cd-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-data">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document①" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document①" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-following">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-following" class="dfn-panel" data-for="term-for-concept-tree-following" id="infopanel-for-term-for-concept-tree-following" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-following" style="display:none">Info about the 'following' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-following">https://dom.spec.whatwg.org/#concept-tree-following</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-following">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attributes-get-by-namespace">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace">https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attributes-get-by-namespace" class="dfn-panel" data-for="term-for-concept-element-attributes-get-by-namespace" id="infopanel-for-term-for-concept-element-attributes-get-by-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attributes-get-by-namespace" style="display:none">Info about the 'get an attribute by namespace and local name' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace">https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-get-by-namespace">6.6. CSS Declaration Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node">
-   <a href="https://dom.spec.whatwg.org/#concept-node">https://dom.spec.whatwg.org/#concept-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node" class="dfn-panel" data-for="term-for-concept-node" id="infopanel-for-term-for-concept-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node" style="display:none">Info about the 'nodes' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node">https://dom.spec.whatwg.org/#concept-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-root" class="dfn-panel" data-for="term-for-concept-shadow-including-root" id="infopanel-for-term-for-concept-shadow-including-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-root" style="display:none">Info about the 'shadow-including root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-root">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-encoding-get">
-   <a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-encoding-get" class="dfn-panel" data-for="term-for-concept-encoding-get" id="infopanel-for-term-for-concept-encoding-get" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-encoding-get" style="display:none">Info about the 'get an encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-get">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-cereactions①">(2)</a> <a href="#ref-for-cereactions②">(3)</a> <a href="#ref-for-cereactions③">(4)</a> <a href="#ref-for-cereactions④">(5)</a> <a href="#ref-for-cereactions⑤">(6)</a> <a href="#ref-for-cereactions⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlelement" class="dfn-panel" data-for="term-for-htmlelement" id="infopanel-for-term-for-htmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlelement" style="display:none">Info about the 'HTMLElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlelement">7.1. 
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">7.2. Extensions to the Window Interface</a> <a href="#ref-for-window①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">8.1. The CSS.escape() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-same-origin" class="dfn-panel" data-for="term-for-cors-same-origin" id="infopanel-for-term-for-cors-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-same-origin" style="display:none">Info about the 'cors-same-origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-same-origin">6.3.1. Fetching CSS style sheets</a>
     <li><a href="#ref-for-cors-same-origin①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-cors-same-origin②">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">8.1. The CSS.escape() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">6.3.1. Fetching CSS style sheets</a>
     <li><a href="#ref-for-concept-origin①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">6.3.2. The LinkStyle Interface</a> <a href="#ref-for-the-style-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_code_unit">
-   <a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_code_unit" class="dfn-panel" data-for="term-for-def_code_unit" id="infopanel-for-term-for-def_code_unit" role="menu">
+   <span id="infopaneltitle-for-term-for-def_code_unit" style="display:none">Info about the 'code units' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_code_unit">3. CSSOMString</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.2. Serializing Media Queries</a> <a href="#ref-for-ascii-lowercase①">(2)</a>
     <li><a href="#ref-for-ascii-lowercase②">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-ascii-lowercase③">(2)</a> <a href="#ref-for-ascii-lowercase④">(3)</a> <a href="#ref-for-ascii-lowercase⑤">(4)</a> <a href="#ref-for-ascii-lowercase⑥">(5)</a>
     <li><a href="#ref-for-ascii-lowercase⑦">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-uppercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-uppercase">https://infra.spec.whatwg.org/#ascii-uppercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-uppercase" class="dfn-panel" data-for="term-for-ascii-uppercase" id="infopanel-for-term-for-ascii-uppercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-uppercase" style="display:none">Info about the 'ascii uppercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-uppercase">https://infra.spec.whatwg.org/#ascii-uppercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-uppercase">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">6.7.2. Serializing CSS Values</a> <a href="#ref-for-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-surrogate">
-   <a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-surrogate" class="dfn-panel" data-for="term-for-surrogate" id="infopanel-for-term-for-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-surrogate" style="display:none">Info about the 'surrogate' external reference.</span><a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrogate">3. CSSOMString</a> <a href="#ref-for-surrogate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mathmlelement">
-   <a href="https://w3c.github.io/mathml-core/#dom-mathmlelement">https://w3c.github.io/mathml-core/#dom-mathmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mathmlelement" class="dfn-panel" data-for="term-for-dom-mathmlelement" id="infopanel-for-term-for-dom-mathmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mathmlelement" style="display:none">Info about the 'MathMLElement' external reference.</span><a href="https://w3c.github.io/mathml-core/#dom-mathmlelement">https://w3c.github.io/mathml-core/#dom-mathmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mathmlelement">7.1. 
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-color">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-color">https://drafts.csswg.org/mediaqueries-4/#descdef-media-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-color" class="dfn-panel" data-for="term-for-descdef-media-color" id="infopanel-for-term-for-descdef-media-color" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-color">https://drafts.csswg.org/mediaqueries-4/#descdef-media-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color">4.2.1. Serializing Media Feature Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-scan-interlace">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-interlace">https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-interlace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-scan-interlace" class="dfn-panel" data-for="term-for-valdef-media-scan-interlace" id="infopanel-for-term-for-valdef-media-scan-interlace" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-scan-interlace" style="display:none">Info about the 'interlace' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-interlace">https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-interlace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-scan-interlace">4.2.1. Serializing Media Feature Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-orientation-landscape">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-landscape">https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-landscape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-orientation-landscape" class="dfn-panel" data-for="term-for-valdef-media-orientation-landscape" id="infopanel-for-term-for-valdef-media-orientation-landscape" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-orientation-landscape" style="display:none">Info about the 'landscape' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-landscape">https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-landscape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-landscape">4.2.1. Serializing Media Feature Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-orientation-portrait">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-portrait">https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-portrait</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-orientation-portrait" class="dfn-panel" data-for="term-for-valdef-media-orientation-portrait" id="infopanel-for-term-for-valdef-media-orientation-portrait" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-orientation-portrait" style="display:none">Info about the 'portrait' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-portrait">https://drafts.csswg.org/mediaqueries-4/#valdef-media-orientation-portrait</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-portrait">4.2.1. Serializing Media Feature Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-scan-progressive">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-progressive">https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-progressive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-scan-progressive" class="dfn-panel" data-for="term-for-valdef-media-scan-progressive" id="infopanel-for-term-for-valdef-media-scan-progressive" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-scan-progressive" style="display:none">Info about the 'progressive' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-progressive">https://drafts.csswg.org/mediaqueries-4/#valdef-media-scan-progressive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-scan-progressive">4.2.1. Serializing Media Feature Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-feature">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-feature">https://drafts.csswg.org/mediaqueries-5/#media-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-feature" class="dfn-panel" data-for="term-for-media-feature" id="infopanel-for-term-for-media-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-media-feature" style="display:none">Info about the 'media feature' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-feature">https://drafts.csswg.org/mediaqueries-5/#media-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-feature">4.2. Serializing Media Queries</a> <a href="#ref-for-media-feature①">(2)</a> <a href="#ref-for-media-feature②">(3)</a> <a href="#ref-for-media-feature③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query" class="dfn-panel" data-for="term-for-media-query" id="infopanel-for-term-for-media-query" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query" style="display:none">Info about the 'media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query">https://drafts.csswg.org/mediaqueries-5/#media-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query">4. Media Queries</a> <a href="#ref-for-media-query①">(2)</a>
     <li><a href="#ref-for-media-query②">4.2. Serializing Media Queries</a> <a href="#ref-for-media-query③">(2)</a> <a href="#ref-for-media-query④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-query-list">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-query-list">https://drafts.csswg.org/mediaqueries-5/#media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-query-list" class="dfn-panel" data-for="term-for-media-query-list" id="infopanel-for-term-for-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-media-query-list" style="display:none">Info about the 'media query list' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-query-list">https://drafts.csswg.org/mediaqueries-5/#media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-list">4.1. Parsing Media Queries</a>
     <li><a href="#ref-for-media-query-list①">4.2. Serializing Media Queries</a> <a href="#ref-for-media-query-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-type">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#media-type">https://drafts.csswg.org/mediaqueries-5/#media-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-type" class="dfn-panel" data-for="term-for-media-type" id="infopanel-for-term-for-media-type" role="menu">
+   <span id="infopaneltitle-for-term-for-media-type" style="display:none">Info about the 'media type' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#media-type">https://drafts.csswg.org/mediaqueries-5/#media-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-type">4.2. Serializing Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sel-after">
-   <a href="https://drafts.csswg.org/selectors-3/#sel-after">https://drafts.csswg.org/selectors-3/#sel-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sel-after" class="dfn-panel" data-for="term-for-sel-after" id="infopanel-for-term-for-sel-after" role="menu">
+   <span id="infopaneltitle-for-term-for-sel-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#sel-after">https://drafts.csswg.org/selectors-3/#sel-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sel-after">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sel-before">
-   <a href="https://drafts.csswg.org/selectors-3/#sel-before">https://drafts.csswg.org/selectors-3/#sel-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sel-before" class="dfn-panel" data-for="term-for-sel-before" id="infopanel-for-term-for-sel-before" role="menu">
+   <span id="infopaneltitle-for-term-for-sel-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#sel-before">https://drafts.csswg.org/selectors-3/#sel-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sel-before">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-pseudo-element-selector" class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector" id="infopanel-for-term-for-typedef-pseudo-element-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-pseudo-element-selector" style="display:none">Info about the '&lt;pseudo-element-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-element-selector">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compound">
-   <a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compound" class="dfn-panel" data-for="term-for-compound" id="infopanel-for-term-for-compound" role="menu">
+   <span id="infopaneltitle-for-term-for-compound" style="display:none">Info about the 'compound selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">5.2. Serializing Selectors</a> <a href="#ref-for-compound①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-simple">
-   <a href="https://drafts.csswg.org/selectors-4/#simple">https://drafts.csswg.org/selectors-4/#simple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-simple" class="dfn-panel" data-for="term-for-simple" id="infopanel-for-term-for-simple" role="menu">
+   <span id="infopaneltitle-for-term-for-simple" style="display:none">Info about the 'simple selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#simple">https://drafts.csswg.org/selectors-4/#simple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple">5.2. Serializing Selectors</a> <a href="#ref-for-simple①">(2)</a> <a href="#ref-for-simple②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-universal-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#universal-selector">https://drafts.csswg.org/selectors-4/#universal-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-universal-selector" class="dfn-panel" data-for="term-for-universal-selector" id="infopanel-for-term-for-universal-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-universal-selector" style="display:none">Info about the 'universal selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#universal-selector">https://drafts.csswg.org/selectors-4/#universal-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-universal-selector">5.2. Serializing Selectors</a> <a href="#ref-for-universal-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGElement">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGElement" class="dfn-panel" data-for="term-for-InterfaceSVGElement" id="infopanel-for-term-for-InterfaceSVGElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGElement" style="display:none">Info about the 'SVGElement' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGElement">7.1. 
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-url-string">
-   <a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-url-string" class="dfn-panel" data-for="term-for-absolute-url-string" id="infopanel-for-term-for-absolute-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-url-string" style="display:none">Info about the 'absolute-url string' external reference.</span><a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-string">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-absolute-url-string①">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. CSSOMString</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-idl-DOMString③">6.1.2.1. Deprecated CSSStyleSheet members</a> <a href="#ref-for-idl-DOMString④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.4. The MediaList Interface</a>
     <li><a href="#ref-for-Exposed①">6.1.1. The StyleSheet Interface</a>
@@ -5672,51 +5672,51 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-Exposed①③">8.1. The CSS.escape() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hierarchyrequesterror">
-   <a href="https://webidl.spec.whatwg.org/#hierarchyrequesterror">https://webidl.spec.whatwg.org/#hierarchyrequesterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hierarchyrequesterror" class="dfn-panel" data-for="term-for-hierarchyrequesterror" id="infopanel-for-term-for-hierarchyrequesterror" role="menu">
+   <span id="infopaneltitle-for-term-for-hierarchyrequesterror" style="display:none">Info about the 'HierarchyRequestError' external reference.</span><a href="https://webidl.spec.whatwg.org/#hierarchyrequesterror">https://webidl.spec.whatwg.org/#hierarchyrequesterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hierarchyrequesterror">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indexsizeerror">
-   <a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indexsizeerror" class="dfn-panel" data-for="term-for-indexsizeerror" id="infopanel-for-term-for-indexsizeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-indexsizeerror" style="display:none">Info about the 'IndexSizeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indexsizeerror">6.4. CSS Rules</a> <a href="#ref-for-indexsizeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6.4. CSS Rules</a> <a href="#ref-for-invalidstateerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyNullToEmptyString">
-   <a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyNullToEmptyString" class="dfn-panel" data-for="term-for-LegacyNullToEmptyString" id="infopanel-for-term-for-LegacyNullToEmptyString" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyNullToEmptyString" style="display:none">Info about the 'LegacyNullToEmptyString' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNullToEmptyString">4.4. The MediaList Interface</a>
     <li><a href="#ref-for-LegacyNullToEmptyString①">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-LegacyNullToEmptyString②">(2)</a> <a href="#ref-for-LegacyNullToEmptyString③">(3)</a> <a href="#ref-for-LegacyNullToEmptyString④">(4)</a> <a href="#ref-for-LegacyNullToEmptyString⑤">(5)</a> <a href="#ref-for-LegacyNullToEmptyString⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
-   <a href="https://webidl.spec.whatwg.org/#nomodificationallowederror">https://webidl.spec.whatwg.org/#nomodificationallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nomodificationallowederror" class="dfn-panel" data-for="term-for-nomodificationallowederror" id="infopanel-for-term-for-nomodificationallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-nomodificationallowederror" style="display:none">Info about the 'NoModificationAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#nomodificationallowederror">https://webidl.spec.whatwg.org/#nomodificationallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nomodificationallowederror">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-nomodificationallowederror①">(2)</a> <a href="#ref-for-nomodificationallowederror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-PutForwards①">6.4.3. The CSSStyleRule Interface</a>
@@ -5727,8 +5727,8 @@ The ElementCSSInlineStyle Mixin</a>
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-SameObject①">6.1.2. The CSSStyleSheet Interface</a>
@@ -5743,40 +5743,40 @@ The ElementCSSInlineStyle Mixin</a>
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. CSSOMString</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a>
     <li><a href="#ref-for-idl-USVString③">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-idl-USVString④">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.4. The MediaList Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">6.1.2. The CSSStyleSheet Interface</a>
@@ -5785,8 +5785,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-idl-undefined⑤">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.4. The MediaList Interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-idl-unsigned-long③">(2)</a> <a href="#ref-for-idl-unsigned-long④">(3)</a>
@@ -5797,8 +5797,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-idl-unsigned-long①④">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-idl-unsigned-long①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">6.4.2. The CSSRule Interface</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a> <a href="#ref-for-idl-unsigned-short③">(4)</a> <a href="#ref-for-idl-unsigned-short④">(5)</a> <a href="#ref-for-idl-unsigned-short⑤">(6)</a> <a href="#ref-for-idl-unsigned-short⑥">(7)</a> <a href="#ref-for-idl-unsigned-short⑦">(8)</a> <a href="#ref-for-idl-unsigned-short⑧">(9)</a>
    </ul>
@@ -6447,47 +6447,47 @@ so it’s expected that there won’t be any compat concerns.
 If any are discovered, please report
 so we can consider reverting this change. <a class="issue-return" href="#issue-24739c22" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="set">
-   <b><a href="#set">#set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set" class="dfn-panel" data-for="set" id="infopanel-for-set" role="dialog">
+   <span id="infopaneltitle-for-set" style="display:none">Info about the 'set' definition.</span><b><a href="#set">#set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unset">
-   <b><a href="#unset">#unset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unset" class="dfn-panel" data-for="unset" id="infopanel-for-unset" role="dialog">
+   <span id="infopaneltitle-for-unset" style="display:none">Info about the 'unset' definition.</span><b><a href="#unset">#unset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unset">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-styling-language">
-   <b><a href="#supported-styling-language">#supported-styling-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-styling-language" class="dfn-panel" data-for="supported-styling-language" id="infopanel-for-supported-styling-language" role="dialog">
+   <span id="infopaneltitle-for-supported-styling-language" style="display:none">Info about the 'supported styling language' definition.</span><b><a href="#supported-styling-language">#supported-styling-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-styling-language">6.3.1. Fetching CSS style sheets</a> <a href="#ref-for-supported-styling-language①">(2)</a>
     <li><a href="#ref-for-supported-styling-language②">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-css-property">
-   <b><a href="#supported-css-property">#supported-css-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-css-property" class="dfn-panel" data-for="supported-css-property" id="infopanel-for-supported-css-property" role="dialog">
+   <span id="infopaneltitle-for-supported-css-property" style="display:none">Info about the 'supported CSS property' definition.</span><b><a href="#supported-css-property">#supported-css-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-css-property">2. Terminology</a>
     <li><a href="#ref-for-supported-css-property①">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-supported-css-property②">(2)</a> <a href="#ref-for-supported-css-property③">(3)</a> <a href="#ref-for-supported-css-property④">(4)</a>
     <li><a href="#ref-for-supported-css-property⑤">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="escape-a-character">
-   <b><a href="#escape-a-character">#escape-a-character</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-escape-a-character" class="dfn-panel" data-for="escape-a-character" id="infopanel-for-escape-a-character" role="dialog">
+   <span id="infopaneltitle-for-escape-a-character" style="display:none">Info about the 'escape a character' definition.</span><b><a href="#escape-a-character">#escape-a-character</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-escape-a-character">2.1. Common Serializing Idioms</a> <a href="#ref-for-escape-a-character①">(2)</a> <a href="#ref-for-escape-a-character②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="escape-a-character-as-code-point">
-   <b><a href="#escape-a-character-as-code-point">#escape-a-character-as-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-escape-a-character-as-code-point" class="dfn-panel" data-for="escape-a-character-as-code-point" id="infopanel-for-escape-a-character-as-code-point" role="dialog">
+   <span id="infopaneltitle-for-escape-a-character-as-code-point" style="display:none">Info about the 'escape a character as code point' definition.</span><b><a href="#escape-a-character-as-code-point">#escape-a-character-as-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-escape-a-character-as-code-point">2.1. Common Serializing Idioms</a> <a href="#ref-for-escape-a-character-as-code-point①">(2)</a> <a href="#ref-for-escape-a-character-as-code-point②">(3)</a> <a href="#ref-for-escape-a-character-as-code-point③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-an-identifier">
-   <b><a href="#serialize-an-identifier">#serialize-an-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-an-identifier" class="dfn-panel" data-for="serialize-an-identifier" id="infopanel-for-serialize-an-identifier" role="dialog">
+   <span id="infopaneltitle-for-serialize-an-identifier" style="display:none">Info about the 'serialize an identifier' definition.</span><b><a href="#serialize-an-identifier">#serialize-an-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-identifier">4.2. Serializing Media Queries</a>
     <li><a href="#ref-for-serialize-an-identifier①">5.2. Serializing Selectors</a> <a href="#ref-for-serialize-an-identifier②">(2)</a> <a href="#ref-for-serialize-an-identifier③">(3)</a> <a href="#ref-for-serialize-an-identifier④">(4)</a> <a href="#ref-for-serialize-an-identifier⑤">(5)</a> <a href="#ref-for-serialize-an-identifier⑥">(6)</a>
@@ -6496,8 +6496,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-serialize-an-identifier①⓪">8.1. The CSS.escape() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-string">
-   <b><a href="#serialize-a-string">#serialize-a-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-string" class="dfn-panel" data-for="serialize-a-string" id="infopanel-for-serialize-a-string" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-string" style="display:none">Info about the 'serialize a string' definition.</span><b><a href="#serialize-a-string">#serialize-a-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-string">2.1. Common Serializing Idioms</a> <a href="#ref-for-serialize-a-string①">(2)</a>
     <li><a href="#ref-for-serialize-a-string②">5.2. Serializing Selectors</a> <a href="#ref-for-serialize-a-string③">(2)</a>
@@ -6505,21 +6505,21 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-serialize-a-string⑤">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-url">
-   <b><a href="#serialize-a-url">#serialize-a-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-url" class="dfn-panel" data-for="serialize-a-url" id="infopanel-for-serialize-a-url" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-url" style="display:none">Info about the 'serialize a URL' definition.</span><b><a href="#serialize-a-url">#serialize-a-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-url">6.4. CSS Rules</a> <a href="#ref-for-serialize-a-url①">(2)</a> <a href="#ref-for-serialize-a-url②">(3)</a>
     <li><a href="#ref-for-serialize-a-url③">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-local">
-   <b><a href="#serialize-a-local">#serialize-a-local</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-local" class="dfn-panel" data-for="serialize-a-local" id="infopanel-for-serialize-a-local" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-local" style="display:none">Info about the 'serialize a LOCAL' definition.</span><b><a href="#serialize-a-local">#serialize-a-local</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-local">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-comma-separated-list">
-   <b><a href="#serialize-a-comma-separated-list">#serialize-a-comma-separated-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-comma-separated-list" class="dfn-panel" data-for="serialize-a-comma-separated-list" id="infopanel-for-serialize-a-comma-separated-list" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-comma-separated-list" style="display:none">Info about the 'serialize a comma-separated list' definition.</span><b><a href="#serialize-a-comma-separated-list">#serialize-a-comma-separated-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-comma-separated-list">4.2. Serializing Media Queries</a>
     <li><a href="#ref-for-serialize-a-comma-separated-list①">5.2. Serializing Selectors</a> <a href="#ref-for-serialize-a-comma-separated-list②">(2)</a>
@@ -6527,8 +6527,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-serialize-a-comma-separated-list④">6.7.2. Serializing CSS Values</a> <a href="#ref-for-serialize-a-comma-separated-list⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssomstring">
-   <b><a href="#cssomstring">#cssomstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssomstring" class="dfn-panel" data-for="cssomstring" id="infopanel-for-cssomstring" role="dialog">
+   <span id="infopaneltitle-for-cssomstring" style="display:none">Info about the 'CSSOMString' definition.</span><b><a href="#cssomstring">#cssomstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">4.4. The MediaList Interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a>
     <li><a href="#ref-for-cssomstring④">6.1.1. The StyleSheet Interface</a>
@@ -6544,54 +6544,54 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-cssomstring②⑨">8.1. The CSS.escape() Method</a> <a href="#ref-for-cssomstring③⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-media-query-list">
-   <b><a href="#parse-a-media-query-list">#parse-a-media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-media-query-list" class="dfn-panel" data-for="parse-a-media-query-list" id="infopanel-for-parse-a-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-parse-a-media-query-list" style="display:none">Info about the 'parse a media query list' definition.</span><b><a href="#parse-a-media-query-list">#parse-a-media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-media-query-list">4.1. Parsing Media Queries</a>
     <li><a href="#ref-for-parse-a-media-query-list①">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-media-query">
-   <b><a href="#parse-a-media-query">#parse-a-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-media-query" class="dfn-panel" data-for="parse-a-media-query" id="infopanel-for-parse-a-media-query" role="dialog">
+   <span id="infopaneltitle-for-parse-a-media-query" style="display:none">Info about the 'parse a media query' definition.</span><b><a href="#parse-a-media-query">#parse-a-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-media-query">4.4. The MediaList Interface</a> <a href="#ref-for-parse-a-media-query①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-media-query-list">
-   <b><a href="#serialize-a-media-query-list">#serialize-a-media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-media-query-list" class="dfn-panel" data-for="serialize-a-media-query-list" id="infopanel-for-serialize-a-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-media-query-list" style="display:none">Info about the 'serialize a media query list' definition.</span><b><a href="#serialize-a-media-query-list">#serialize-a-media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-media-query-list">4.4. The MediaList Interface</a>
     <li><a href="#ref-for-serialize-a-media-query-list①">6.4. CSS Rules</a> <a href="#ref-for-serialize-a-media-query-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-media-query">
-   <b><a href="#serialize-a-media-query">#serialize-a-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-media-query" class="dfn-panel" data-for="serialize-a-media-query" id="infopanel-for-serialize-a-media-query" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-media-query" style="display:none">Info about the 'serialize a media query' definition.</span><b><a href="#serialize-a-media-query">#serialize-a-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-media-query">4.2. Serializing Media Queries</a>
     <li><a href="#ref-for-serialize-a-media-query①">4.3. Comparing Media Queries</a>
     <li><a href="#ref-for-serialize-a-media-query②">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-media-feature-value">
-   <b><a href="#serialize-a-media-feature-value">#serialize-a-media-feature-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-media-feature-value" class="dfn-panel" data-for="serialize-a-media-feature-value" id="infopanel-for-serialize-a-media-feature-value" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-media-feature-value" style="display:none">Info about the 'serialize a media feature value' definition.</span><b><a href="#serialize-a-media-feature-value">#serialize-a-media-feature-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-media-feature-value">4.2. Serializing Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compare-media-queries">
-   <b><a href="#compare-media-queries">#compare-media-queries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compare-media-queries" class="dfn-panel" data-for="compare-media-queries" id="infopanel-for-compare-media-queries" role="dialog">
+   <span id="infopaneltitle-for-compare-media-queries" style="display:none">Info about the 'compare media queries' definition.</span><b><a href="#compare-media-queries">#compare-media-queries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compare-media-queries">4.4. The MediaList Interface</a> <a href="#ref-for-compare-media-queries①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="medialist-collection-of-media-queries">
-   <b><a href="#medialist-collection-of-media-queries">#medialist-collection-of-media-queries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-medialist-collection-of-media-queries" class="dfn-panel" data-for="medialist-collection-of-media-queries" id="infopanel-for-medialist-collection-of-media-queries" role="dialog">
+   <span id="infopaneltitle-for-medialist-collection-of-media-queries" style="display:none">Info about the 'collection of media queries' definition.</span><b><a href="#medialist-collection-of-media-queries">#medialist-collection-of-media-queries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-medialist-collection-of-media-queries">4.4. The MediaList Interface</a> <a href="#ref-for-medialist-collection-of-media-queries①">(2)</a> <a href="#ref-for-medialist-collection-of-media-queries②">(3)</a> <a href="#ref-for-medialist-collection-of-media-queries③">(4)</a> <a href="#ref-for-medialist-collection-of-media-queries④">(5)</a> <a href="#ref-for-medialist-collection-of-media-queries⑤">(6)</a> <a href="#ref-for-medialist-collection-of-media-queries⑥">(7)</a> <a href="#ref-for-medialist-collection-of-media-queries⑦">(8)</a> <a href="#ref-for-medialist-collection-of-media-queries⑧">(9)</a> <a href="#ref-for-medialist-collection-of-media-queries⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="medialist">
-   <b><a href="#medialist">#medialist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-medialist" class="dfn-panel" data-for="medialist" id="infopanel-for-medialist" role="dialog">
+   <span id="infopaneltitle-for-medialist" style="display:none">Info about the 'MediaList' definition.</span><b><a href="#medialist">#medialist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-medialist">4.4. The MediaList Interface</a>
     <li><a href="#ref-for-medialist①">6.1. CSS Style Sheets</a>
@@ -6599,14 +6599,14 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-medialist③">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-medialist-object">
-   <b><a href="#create-a-medialist-object">#create-a-medialist-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-medialist-object" class="dfn-panel" data-for="create-a-medialist-object" id="infopanel-for-create-a-medialist-object" role="dialog">
+   <span id="infopaneltitle-for-create-a-medialist-object" style="display:none">Info about the 'create a MediaList object' definition.</span><b><a href="#create-a-medialist-object">#create-a-medialist-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-medialist-object">6.1. CSS Style Sheets</a> <a href="#ref-for-create-a-medialist-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-medialist-mediatext">
-   <b><a href="#dom-medialist-mediatext">#dom-medialist-mediatext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-medialist-mediatext" class="dfn-panel" data-for="dom-medialist-mediatext" id="infopanel-for-dom-medialist-mediatext" role="dialog">
+   <span id="infopaneltitle-for-dom-medialist-mediatext" style="display:none">Info about the 'mediaText' definition.</span><b><a href="#dom-medialist-mediatext">#dom-medialist-mediatext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-mediatext">4.4. The MediaList Interface</a> <a href="#ref-for-dom-medialist-mediatext①">(2)</a> <a href="#ref-for-dom-medialist-mediatext②">(3)</a>
     <li><a href="#ref-for-dom-medialist-mediatext③">6.1. CSS Style Sheets</a> <a href="#ref-for-dom-medialist-mediatext④">(2)</a>
@@ -6614,58 +6614,58 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-dom-medialist-mediatext⑥">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-medialist-item">
-   <b><a href="#dom-medialist-item">#dom-medialist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-medialist-item" class="dfn-panel" data-for="dom-medialist-item" id="infopanel-for-dom-medialist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-medialist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-medialist-item">#dom-medialist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-item">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-medialist-length">
-   <b><a href="#dom-medialist-length">#dom-medialist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-medialist-length" class="dfn-panel" data-for="dom-medialist-length" id="infopanel-for-dom-medialist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-medialist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-medialist-length">#dom-medialist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-length">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-medialist-appendmedium">
-   <b><a href="#dom-medialist-appendmedium">#dom-medialist-appendmedium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-medialist-appendmedium" class="dfn-panel" data-for="dom-medialist-appendmedium" id="infopanel-for-dom-medialist-appendmedium" role="dialog">
+   <span id="infopaneltitle-for-dom-medialist-appendmedium" style="display:none">Info about the 'appendMedium(medium)' definition.</span><b><a href="#dom-medialist-appendmedium">#dom-medialist-appendmedium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-appendmedium">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-medialist-deletemedium">
-   <b><a href="#dom-medialist-deletemedium">#dom-medialist-deletemedium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-medialist-deletemedium" class="dfn-panel" data-for="dom-medialist-deletemedium" id="infopanel-for-dom-medialist-deletemedium" role="dialog">
+   <span id="infopaneltitle-for-dom-medialist-deletemedium" style="display:none">Info about the 'deleteMedium(medium)' definition.</span><b><a href="#dom-medialist-deletemedium">#dom-medialist-deletemedium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-medialist-deletemedium">4.4. The MediaList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-group-of-selectors">
-   <b><a href="#parse-a-group-of-selectors">#parse-a-group-of-selectors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-group-of-selectors" class="dfn-panel" data-for="parse-a-group-of-selectors" id="infopanel-for-parse-a-group-of-selectors" role="dialog">
+   <span id="infopaneltitle-for-parse-a-group-of-selectors" style="display:none">Info about the 'parse a group of selectors' definition.</span><b><a href="#parse-a-group-of-selectors">#parse-a-group-of-selectors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-group-of-selectors">6.4.3. The CSSStyleRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-group-of-selectors">
-   <b><a href="#serialize-a-group-of-selectors">#serialize-a-group-of-selectors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-group-of-selectors" class="dfn-panel" data-for="serialize-a-group-of-selectors" id="infopanel-for-serialize-a-group-of-selectors" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-group-of-selectors" style="display:none">Info about the 'serialize a group of selectors' definition.</span><b><a href="#serialize-a-group-of-selectors">#serialize-a-group-of-selectors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-group-of-selectors">5.2. Serializing Selectors</a>
     <li><a href="#ref-for-serialize-a-group-of-selectors①">6.4. CSS Rules</a>
     <li><a href="#ref-for-serialize-a-group-of-selectors②">6.4.3. The CSSStyleRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-selector">
-   <b><a href="#serialize-a-selector">#serialize-a-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-selector" class="dfn-panel" data-for="serialize-a-selector" id="infopanel-for-serialize-a-selector" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-selector" style="display:none">Info about the 'serialize a selector' definition.</span><b><a href="#serialize-a-selector">#serialize-a-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-selector">5.2. Serializing Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-simple-selector">
-   <b><a href="#serialize-a-simple-selector">#serialize-a-simple-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-simple-selector" class="dfn-panel" data-for="serialize-a-simple-selector" id="infopanel-for-serialize-a-simple-selector" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-simple-selector" style="display:none">Info about the 'serialize a simple selector' definition.</span><b><a href="#serialize-a-simple-selector">#serialize-a-simple-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-simple-selector">5.2. Serializing Selectors</a> <a href="#ref-for-serialize-a-simple-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-style-sheet">
-   <b><a href="#css-style-sheet">#css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-style-sheet" class="dfn-panel" data-for="css-style-sheet" id="infopanel-for-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-css-style-sheet" style="display:none">Info about the 'CSS style sheet' definition.</span><b><a href="#css-style-sheet">#css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-style-sheet">6.1. CSS Style Sheets</a> <a href="#ref-for-css-style-sheet①">(2)</a> <a href="#ref-for-css-style-sheet②">(3)</a> <a href="#ref-for-css-style-sheet③">(4)</a> <a href="#ref-for-css-style-sheet④">(5)</a> <a href="#ref-for-css-style-sheet⑤">(6)</a> <a href="#ref-for-css-style-sheet⑥">(7)</a> <a href="#ref-for-css-style-sheet⑦">(8)</a> <a href="#ref-for-css-style-sheet⑧">(9)</a> <a href="#ref-for-css-style-sheet⑨">(10)</a> <a href="#ref-for-css-style-sheet①⓪">(11)</a> <a href="#ref-for-css-style-sheet①①">(12)</a> <a href="#ref-for-css-style-sheet①②">(13)</a> <a href="#ref-for-css-style-sheet①③">(14)</a> <a href="#ref-for-css-style-sheet①④">(15)</a> <a href="#ref-for-css-style-sheet①⑤">(16)</a> <a href="#ref-for-css-style-sheet①⑥">(17)</a>
     <li><a href="#ref-for-css-style-sheet①⑦">6.1.2. The CSSStyleSheet Interface</a>
@@ -6679,22 +6679,22 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-css-style-sheet④⑥">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-type">
-   <b><a href="#concept-css-style-sheet-type">#concept-css-style-sheet-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-type" class="dfn-panel" data-for="concept-css-style-sheet-type" id="infopanel-for-concept-css-style-sheet-type" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-type" style="display:none">Info about the 'type' definition.</span><b><a href="#concept-css-style-sheet-type">#concept-css-style-sheet-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-type">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-location">
-   <b><a href="#concept-css-style-sheet-location">#concept-css-style-sheet-location</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-location" class="dfn-panel" data-for="concept-css-style-sheet-location" id="infopanel-for-concept-css-style-sheet-location" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-location" style="display:none">Info about the 'location' definition.</span><b><a href="#concept-css-style-sheet-location">#concept-css-style-sheet-location</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-location">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-concept-css-style-sheet-location①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-concept-css-style-sheet-location②">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-parent-css-style-sheet">
-   <b><a href="#concept-css-style-sheet-parent-css-style-sheet">#concept-css-style-sheet-parent-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-parent-css-style-sheet" class="dfn-panel" data-for="concept-css-style-sheet-parent-css-style-sheet" id="infopanel-for-concept-css-style-sheet-parent-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-parent-css-style-sheet" style="display:none">Info about the 'parent CSS style sheet' definition.</span><b><a href="#concept-css-style-sheet-parent-css-style-sheet">#concept-css-style-sheet-parent-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet①">6.1.1. The StyleSheet Interface</a>
@@ -6703,8 +6703,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet④">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-owner-node">
-   <b><a href="#concept-css-style-sheet-owner-node">#concept-css-style-sheet-owner-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-owner-node" class="dfn-panel" data-for="concept-css-style-sheet-owner-node" id="infopanel-for-concept-css-style-sheet-owner-node" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-owner-node" style="display:none">Info about the 'owner node' definition.</span><b><a href="#concept-css-style-sheet-owner-node">#concept-css-style-sheet-owner-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-node">6.1. CSS Style Sheets</a> <a href="#ref-for-concept-css-style-sheet-owner-node①">(2)</a> <a href="#ref-for-concept-css-style-sheet-owner-node②">(3)</a> <a href="#ref-for-concept-css-style-sheet-owner-node③">(4)</a> <a href="#ref-for-concept-css-style-sheet-owner-node④">(5)</a>
     <li><a href="#ref-for-concept-css-style-sheet-owner-node⑤">6.1.1. The StyleSheet Interface</a>
@@ -6715,8 +6715,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-owner-node①⓪">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-owner-css-rule">
-   <b><a href="#concept-css-style-sheet-owner-css-rule">#concept-css-style-sheet-owner-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-owner-css-rule" class="dfn-panel" data-for="concept-css-style-sheet-owner-css-rule" id="infopanel-for-concept-css-style-sheet-owner-css-rule" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-owner-css-rule" style="display:none">Info about the 'owner CSS rule' definition.</span><b><a href="#concept-css-style-sheet-owner-css-rule">#concept-css-style-sheet-owner-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-css-rule">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-concept-css-style-sheet-owner-css-rule①">6.2. CSS Style Sheet Collections</a>
@@ -6724,8 +6724,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-owner-css-rule③">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-media">
-   <b><a href="#concept-css-style-sheet-media">#concept-css-style-sheet-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-media" class="dfn-panel" data-for="concept-css-style-sheet-media" id="infopanel-for-concept-css-style-sheet-media" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-media" style="display:none">Info about the 'media' definition.</span><b><a href="#concept-css-style-sheet-media">#concept-css-style-sheet-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-media">6.1. CSS Style Sheets</a> <a href="#ref-for-concept-css-style-sheet-media①">(2)</a> <a href="#ref-for-concept-css-style-sheet-media②">(3)</a> <a href="#ref-for-concept-css-style-sheet-media③">(4)</a>
     <li><a href="#ref-for-concept-css-style-sheet-media④">6.1.1. The StyleSheet Interface</a>
@@ -6733,8 +6733,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-media⑥">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-title">
-   <b><a href="#concept-css-style-sheet-title">#concept-css-style-sheet-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-title" class="dfn-panel" data-for="concept-css-style-sheet-title" id="infopanel-for-concept-css-style-sheet-title" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-title" style="display:none">Info about the 'title' definition.</span><b><a href="#concept-css-style-sheet-title">#concept-css-style-sheet-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-title">6.1. CSS Style Sheets</a> <a href="#ref-for-concept-css-style-sheet-title①">(2)</a> <a href="#ref-for-concept-css-style-sheet-title②">(3)</a> <a href="#ref-for-concept-css-style-sheet-title③">(4)</a>
     <li><a href="#ref-for-concept-css-style-sheet-title④">6.1.1. The StyleSheet Interface</a> <a href="#ref-for-concept-css-style-sheet-title⑤">(2)</a>
@@ -6743,8 +6743,8 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-title①⑤">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-alternate-flag">
-   <b><a href="#concept-css-style-sheet-alternate-flag">#concept-css-style-sheet-alternate-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-alternate-flag" class="dfn-panel" data-for="concept-css-style-sheet-alternate-flag" id="infopanel-for-concept-css-style-sheet-alternate-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-alternate-flag" style="display:none">Info about the 'alternate flag' definition.</span><b><a href="#concept-css-style-sheet-alternate-flag">#concept-css-style-sheet-alternate-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-alternate-flag">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-concept-css-style-sheet-alternate-flag①">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-concept-css-style-sheet-alternate-flag②">(2)</a>
@@ -6752,23 +6752,23 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-alternate-flag④">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-disabled-flag">
-   <b><a href="#concept-css-style-sheet-disabled-flag">#concept-css-style-sheet-disabled-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-disabled-flag" class="dfn-panel" data-for="concept-css-style-sheet-disabled-flag" id="infopanel-for-concept-css-style-sheet-disabled-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-disabled-flag" style="display:none">Info about the 'disabled flag' definition.</span><b><a href="#concept-css-style-sheet-disabled-flag">#concept-css-style-sheet-disabled-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-disabled-flag">6.1.1. The StyleSheet Interface</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag①">(2)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag②">(3)</a>
     <li><a href="#ref-for-concept-css-style-sheet-disabled-flag③">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag④">(2)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag⑤">(3)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag⑥">(4)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag⑦">(5)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag⑧">(6)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag⑨">(7)</a> <a href="#ref-for-concept-css-style-sheet-disabled-flag①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-css-rules">
-   <b><a href="#concept-css-style-sheet-css-rules">#concept-css-style-sheet-css-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-css-rules" class="dfn-panel" data-for="concept-css-style-sheet-css-rules" id="infopanel-for-concept-css-style-sheet-css-rules" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-css-rules" style="display:none">Info about the 'CSS rules' definition.</span><b><a href="#concept-css-style-sheet-css-rules">#concept-css-style-sheet-css-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-css-rules">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-concept-css-style-sheet-css-rules①">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-concept-css-style-sheet-css-rules②">(2)</a> <a href="#ref-for-concept-css-style-sheet-css-rules③">(3)</a>
     <li><a href="#ref-for-concept-css-style-sheet-css-rules④">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-style-sheet-origin-clean-flag">
-   <b><a href="#concept-css-style-sheet-origin-clean-flag">#concept-css-style-sheet-origin-clean-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-style-sheet-origin-clean-flag" class="dfn-panel" data-for="concept-css-style-sheet-origin-clean-flag" id="infopanel-for-concept-css-style-sheet-origin-clean-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-css-style-sheet-origin-clean-flag" style="display:none">Info about the 'origin-clean flag' definition.</span><b><a href="#concept-css-style-sheet-origin-clean-flag">#concept-css-style-sheet-origin-clean-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-concept-css-style-sheet-origin-clean-flag①">(2)</a> <a href="#ref-for-concept-css-style-sheet-origin-clean-flag②">(3)</a>
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag③">6.2. CSS Style Sheet Collections</a>
@@ -6777,60 +6777,60 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag⑥">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stylesheet">
-   <b><a href="#stylesheet">#stylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stylesheet" class="dfn-panel" data-for="stylesheet" id="infopanel-for-stylesheet" role="dialog">
+   <span id="infopaneltitle-for-stylesheet" style="display:none">Info about the 'StyleSheet' definition.</span><b><a href="#stylesheet">#stylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylesheet">6.1.1. The StyleSheet Interface</a> <a href="#ref-for-stylesheet①">(2)</a>
     <li><a href="#ref-for-stylesheet②">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-stylesheet③">6.3.2. The LinkStyle Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-type">
-   <b><a href="#dom-stylesheet-type">#dom-stylesheet-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-type" class="dfn-panel" data-for="dom-stylesheet-type" id="infopanel-for-dom-stylesheet-type" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-stylesheet-type">#dom-stylesheet-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-type">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-href">
-   <b><a href="#dom-stylesheet-href">#dom-stylesheet-href</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-href" class="dfn-panel" data-for="dom-stylesheet-href" id="infopanel-for-dom-stylesheet-href" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-href" style="display:none">Info about the 'href' definition.</span><b><a href="#dom-stylesheet-href">#dom-stylesheet-href</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-href">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-dom-stylesheet-href①">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-ownernode">
-   <b><a href="#dom-stylesheet-ownernode">#dom-stylesheet-ownernode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-ownernode" class="dfn-panel" data-for="dom-stylesheet-ownernode" id="infopanel-for-dom-stylesheet-ownernode" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-ownernode" style="display:none">Info about the 'ownerNode' definition.</span><b><a href="#dom-stylesheet-ownernode">#dom-stylesheet-ownernode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-ownernode">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-parentstylesheet">
-   <b><a href="#dom-stylesheet-parentstylesheet">#dom-stylesheet-parentstylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-parentstylesheet" class="dfn-panel" data-for="dom-stylesheet-parentstylesheet" id="infopanel-for-dom-stylesheet-parentstylesheet" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-parentstylesheet" style="display:none">Info about the 'parentStyleSheet' definition.</span><b><a href="#dom-stylesheet-parentstylesheet">#dom-stylesheet-parentstylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-parentstylesheet">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-title">
-   <b><a href="#dom-stylesheet-title">#dom-stylesheet-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-title" class="dfn-panel" data-for="dom-stylesheet-title" id="infopanel-for-dom-stylesheet-title" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-stylesheet-title">#dom-stylesheet-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-title">6.1.1. The StyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-media">
-   <b><a href="#dom-stylesheet-media">#dom-stylesheet-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-media" class="dfn-panel" data-for="dom-stylesheet-media" id="infopanel-for-dom-stylesheet-media" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-media" style="display:none">Info about the 'media' definition.</span><b><a href="#dom-stylesheet-media">#dom-stylesheet-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-media">6.1.1. The StyleSheet Interface</a>
     <li><a href="#ref-for-dom-stylesheet-media①">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheet-disabled">
-   <b><a href="#dom-stylesheet-disabled">#dom-stylesheet-disabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheet-disabled" class="dfn-panel" data-for="dom-stylesheet-disabled" id="infopanel-for-dom-stylesheet-disabled" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheet-disabled" style="display:none">Info about the 'disabled' definition.</span><b><a href="#dom-stylesheet-disabled">#dom-stylesheet-disabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheet-disabled">6.1.1. The StyleSheet Interface</a> <a href="#ref-for-dom-stylesheet-disabled①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylesheet">
-   <b><a href="#cssstylesheet">#cssstylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylesheet" class="dfn-panel" data-for="cssstylesheet" id="infopanel-for-cssstylesheet" role="dialog">
+   <span id="infopaneltitle-for-cssstylesheet" style="display:none">Info about the 'CSSStyleSheet' definition.</span><b><a href="#cssstylesheet">#cssstylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylesheet">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-cssstylesheet①">6.1.1. The StyleSheet Interface</a>
@@ -6842,194 +6842,194 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-cssstylesheet⑨">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-ownerrule">
-   <b><a href="#dom-cssstylesheet-ownerrule">#dom-cssstylesheet-ownerrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-ownerrule" class="dfn-panel" data-for="dom-cssstylesheet-ownerrule" id="infopanel-for-dom-cssstylesheet-ownerrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-ownerrule" style="display:none">Info about the 'ownerRule' definition.</span><b><a href="#dom-cssstylesheet-ownerrule">#dom-cssstylesheet-ownerrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-ownerrule">6.1.2. The CSSStyleSheet Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-cssrules">
-   <b><a href="#dom-cssstylesheet-cssrules">#dom-cssstylesheet-cssrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-cssrules" class="dfn-panel" data-for="dom-cssstylesheet-cssrules" id="infopanel-for-dom-cssstylesheet-cssrules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-cssrules" style="display:none">Info about the 'cssRules' definition.</span><b><a href="#dom-cssstylesheet-cssrules">#dom-cssstylesheet-cssrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-cssrules">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-dom-cssstylesheet-cssrules①">6.1.2.1. Deprecated CSSStyleSheet members</a> <a href="#ref-for-dom-cssstylesheet-cssrules②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-insertrule">
-   <b><a href="#dom-cssstylesheet-insertrule">#dom-cssstylesheet-insertrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-insertrule" class="dfn-panel" data-for="dom-cssstylesheet-insertrule" id="infopanel-for-dom-cssstylesheet-insertrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-insertrule" style="display:none">Info about the 'insertRule(rule, index)' definition.</span><b><a href="#dom-cssstylesheet-insertrule">#dom-cssstylesheet-insertrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-insertrule">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-dom-cssstylesheet-insertrule①">(2)</a>
     <li><a href="#ref-for-dom-cssstylesheet-insertrule②">6.1.2.1. Deprecated CSSStyleSheet members</a>
     <li><a href="#ref-for-dom-cssstylesheet-insertrule③">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-deleterule">
-   <b><a href="#dom-cssstylesheet-deleterule">#dom-cssstylesheet-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-deleterule" class="dfn-panel" data-for="dom-cssstylesheet-deleterule" id="infopanel-for-dom-cssstylesheet-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-deleterule" style="display:none">Info about the 'deleteRule(index)' definition.</span><b><a href="#dom-cssstylesheet-deleterule">#dom-cssstylesheet-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-deleterule">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-dom-cssstylesheet-deleterule①">(2)</a>
     <li><a href="#ref-for-dom-cssstylesheet-deleterule②">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-rules">
-   <b><a href="#dom-cssstylesheet-rules">#dom-cssstylesheet-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-rules" class="dfn-panel" data-for="dom-cssstylesheet-rules" id="infopanel-for-dom-cssstylesheet-rules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-rules" style="display:none">Info about the 'rules' definition.</span><b><a href="#dom-cssstylesheet-rules">#dom-cssstylesheet-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-rules">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-removerule">
-   <b><a href="#dom-cssstylesheet-removerule">#dom-cssstylesheet-removerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-removerule" class="dfn-panel" data-for="dom-cssstylesheet-removerule" id="infopanel-for-dom-cssstylesheet-removerule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-removerule" style="display:none">Info about the 'removeRule(index)' definition.</span><b><a href="#dom-cssstylesheet-removerule">#dom-cssstylesheet-removerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-removerule">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylesheet-addrule">
-   <b><a href="#dom-cssstylesheet-addrule">#dom-cssstylesheet-addrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylesheet-addrule" class="dfn-panel" data-for="dom-cssstylesheet-addrule" id="infopanel-for-dom-cssstylesheet-addrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylesheet-addrule" style="display:none">Info about the 'addRule(selector, block, optionalIndex)' definition.</span><b><a href="#dom-cssstylesheet-addrule">#dom-cssstylesheet-addrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylesheet-addrule">6.1.2.1. Deprecated CSSStyleSheet members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="documentorshadowroot-document-or-shadow-root-css-style-sheets">
-   <b><a href="#documentorshadowroot-document-or-shadow-root-css-style-sheets">#documentorshadowroot-document-or-shadow-root-css-style-sheets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" class="dfn-panel" data-for="documentorshadowroot-document-or-shadow-root-css-style-sheets" id="infopanel-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" role="dialog">
+   <span id="infopaneltitle-for-documentorshadowroot-document-or-shadow-root-css-style-sheets" style="display:none">Info about the 'document or shadow root CSS style sheets' definition.</span><b><a href="#documentorshadowroot-document-or-shadow-root-css-style-sheets">#documentorshadowroot-document-or-shadow-root-css-style-sheets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets①">(2)</a> <a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets②">(3)</a> <a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets③">(4)</a>
     <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets④">6.2.3. Extensions to the DocumentOrShadowRoot Interface Mixin</a>
     <li><a href="#ref-for-documentorshadowroot-document-or-shadow-root-css-style-sheets⑤">6.3.2. The LinkStyle Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-css-style-sheet">
-   <b><a href="#create-a-css-style-sheet">#create-a-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-css-style-sheet" class="dfn-panel" data-for="create-a-css-style-sheet" id="infopanel-for-create-a-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-create-a-css-style-sheet" style="display:none">Info about the 'create a CSS style sheet' definition.</span><b><a href="#create-a-css-style-sheet">#create-a-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-css-style-sheet">6.3.3. Requirements on specifications</a>
     <li><a href="#ref-for-create-a-css-style-sheet①">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-create-a-css-style-sheet②">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-a-css-style-sheet">
-   <b><a href="#add-a-css-style-sheet">#add-a-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-a-css-style-sheet" class="dfn-panel" data-for="add-a-css-style-sheet" id="infopanel-for-add-a-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-add-a-css-style-sheet" style="display:none">Info about the 'add a CSS style sheet' definition.</span><b><a href="#add-a-css-style-sheet">#add-a-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-a-css-style-sheet">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-add-a-css-style-sheet①">6.2. CSS Style Sheet Collections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-a-css-style-sheet">
-   <b><a href="#remove-a-css-style-sheet">#remove-a-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-a-css-style-sheet" class="dfn-panel" data-for="remove-a-css-style-sheet" id="infopanel-for-remove-a-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-remove-a-css-style-sheet" style="display:none">Info about the 'remove a CSS style sheet' definition.</span><b><a href="#remove-a-css-style-sheet">#remove-a-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-a-css-style-sheet">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-style-sheet-set">
-   <b><a href="#css-style-sheet-set">#css-style-sheet-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-style-sheet-set" class="dfn-panel" data-for="css-style-sheet-set" id="infopanel-for-css-style-sheet-set" role="dialog">
+   <span id="infopaneltitle-for-css-style-sheet-set" style="display:none">Info about the 'CSS style sheet set' definition.</span><b><a href="#css-style-sheet-set">#css-style-sheet-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-style-sheet-set">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-css-style-sheet-set①">(2)</a> <a href="#ref-for-css-style-sheet-set②">(3)</a> <a href="#ref-for-css-style-sheet-set③">(4)</a> <a href="#ref-for-css-style-sheet-set④">(5)</a> <a href="#ref-for-css-style-sheet-set⑤">(6)</a>
     <li><a href="#ref-for-css-style-sheet-set⑥">6.2.1. The HTTP Default-Style Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-style-sheet-set-name">
-   <b><a href="#css-style-sheet-set-name">#css-style-sheet-set-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-style-sheet-set-name" class="dfn-panel" data-for="css-style-sheet-set-name" id="infopanel-for-css-style-sheet-set-name" role="dialog">
+   <span id="infopaneltitle-for-css-style-sheet-set-name" style="display:none">Info about the 'CSS style sheet set name' definition.</span><b><a href="#css-style-sheet-set-name">#css-style-sheet-set-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-style-sheet-set-name">6.2. CSS Style Sheet Collections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enabled-css-style-sheet-set">
-   <b><a href="#enabled-css-style-sheet-set">#enabled-css-style-sheet-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enabled-css-style-sheet-set" class="dfn-panel" data-for="enabled-css-style-sheet-set" id="infopanel-for-enabled-css-style-sheet-set" role="dialog">
+   <span id="infopaneltitle-for-enabled-css-style-sheet-set" style="display:none">Info about the 'enabled CSS style sheet set' definition.</span><b><a href="#enabled-css-style-sheet-set">#enabled-css-style-sheet-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enabled-css-style-sheet-set">6.2.1. The HTTP Default-Style Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enable-a-css-style-sheet-set">
-   <b><a href="#enable-a-css-style-sheet-set">#enable-a-css-style-sheet-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enable-a-css-style-sheet-set" class="dfn-panel" data-for="enable-a-css-style-sheet-set" id="infopanel-for-enable-a-css-style-sheet-set" role="dialog">
+   <span id="infopaneltitle-for-enable-a-css-style-sheet-set" style="display:none">Info about the 'enable a CSS style sheet set' definition.</span><b><a href="#enable-a-css-style-sheet-set">#enable-a-css-style-sheet-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enable-a-css-style-sheet-set">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-enable-a-css-style-sheet-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="select-a-css-style-sheet-set">
-   <b><a href="#select-a-css-style-sheet-set">#select-a-css-style-sheet-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-select-a-css-style-sheet-set" class="dfn-panel" data-for="select-a-css-style-sheet-set" id="infopanel-for-select-a-css-style-sheet-set" role="dialog">
+   <span id="infopaneltitle-for-select-a-css-style-sheet-set" style="display:none">Info about the 'select a CSS style sheet set' definition.</span><b><a href="#select-a-css-style-sheet-set">#select-a-css-style-sheet-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-select-a-css-style-sheet-set">6.2. CSS Style Sheet Collections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-css-style-sheet-set-name">
-   <b><a href="#last-css-style-sheet-set-name">#last-css-style-sheet-set-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-css-style-sheet-set-name" class="dfn-panel" data-for="last-css-style-sheet-set-name" id="infopanel-for-last-css-style-sheet-set-name" role="dialog">
+   <span id="infopaneltitle-for-last-css-style-sheet-set-name" style="display:none">Info about the 'last CSS style sheet set name' definition.</span><b><a href="#last-css-style-sheet-set-name">#last-css-style-sheet-set-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-css-style-sheet-set-name">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-last-css-style-sheet-set-name①">(2)</a> <a href="#ref-for-last-css-style-sheet-set-name②">(3)</a> <a href="#ref-for-last-css-style-sheet-set-name③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-css-style-sheet-set-name">
-   <b><a href="#preferred-css-style-sheet-set-name">#preferred-css-style-sheet-set-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-css-style-sheet-set-name" class="dfn-panel" data-for="preferred-css-style-sheet-set-name" id="infopanel-for-preferred-css-style-sheet-set-name" role="dialog">
+   <span id="infopaneltitle-for-preferred-css-style-sheet-set-name" style="display:none">Info about the 'preferred CSS style sheet set name' definition.</span><b><a href="#preferred-css-style-sheet-set-name">#preferred-css-style-sheet-set-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-css-style-sheet-set-name">6.2. CSS Style Sheet Collections</a> <a href="#ref-for-preferred-css-style-sheet-set-name①">(2)</a> <a href="#ref-for-preferred-css-style-sheet-set-name②">(3)</a> <a href="#ref-for-preferred-css-style-sheet-set-name③">(4)</a>
     <li><a href="#ref-for-preferred-css-style-sheet-set-name④">6.2.1. The HTTP Default-Style Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="change-the-preferred-css-style-sheet-set-name">
-   <b><a href="#change-the-preferred-css-style-sheet-set-name">#change-the-preferred-css-style-sheet-set-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-change-the-preferred-css-style-sheet-set-name" class="dfn-panel" data-for="change-the-preferred-css-style-sheet-set-name" id="infopanel-for-change-the-preferred-css-style-sheet-set-name" role="dialog">
+   <span id="infopaneltitle-for-change-the-preferred-css-style-sheet-set-name" style="display:none">Info about the 'change the preferred CSS style sheet set name' definition.</span><b><a href="#change-the-preferred-css-style-sheet-set-name">#change-the-preferred-css-style-sheet-set-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-change-the-preferred-css-style-sheet-set-name">6.2. CSS Style Sheet Collections</a>
     <li><a href="#ref-for-change-the-preferred-css-style-sheet-set-name①">6.2.1. The HTTP Default-Style Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stylesheetlist">
-   <b><a href="#stylesheetlist">#stylesheetlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stylesheetlist" class="dfn-panel" data-for="stylesheetlist" id="infopanel-for-stylesheetlist" role="dialog">
+   <span id="infopaneltitle-for-stylesheetlist" style="display:none">Info about the 'StyleSheetList' definition.</span><b><a href="#stylesheetlist">#stylesheetlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stylesheetlist">6.2.2. The StyleSheetList Interface</a> <a href="#ref-for-stylesheetlist①">(2)</a>
     <li><a href="#ref-for-stylesheetlist②">6.2.3. Extensions to the DocumentOrShadowRoot Interface Mixin</a> <a href="#ref-for-stylesheetlist③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheetlist-item">
-   <b><a href="#dom-stylesheetlist-item">#dom-stylesheetlist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheetlist-item" class="dfn-panel" data-for="dom-stylesheetlist-item" id="infopanel-for-dom-stylesheetlist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheetlist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-stylesheetlist-item">#dom-stylesheetlist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheetlist-item">6.2.2. The StyleSheetList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-stylesheetlist-length">
-   <b><a href="#dom-stylesheetlist-length">#dom-stylesheetlist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-stylesheetlist-length" class="dfn-panel" data-for="dom-stylesheetlist-length" id="infopanel-for-dom-stylesheetlist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-stylesheetlist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-stylesheetlist-length">#dom-stylesheetlist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-stylesheetlist-length">6.2.2. The StyleSheetList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documentorshadowroot-stylesheets">
-   <b><a href="#dom-documentorshadowroot-stylesheets">#dom-documentorshadowroot-stylesheets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documentorshadowroot-stylesheets" class="dfn-panel" data-for="dom-documentorshadowroot-stylesheets" id="infopanel-for-dom-documentorshadowroot-stylesheets" role="dialog">
+   <span id="infopaneltitle-for-dom-documentorshadowroot-stylesheets" style="display:none">Info about the 'styleSheets' definition.</span><b><a href="#dom-documentorshadowroot-stylesheets">#dom-documentorshadowroot-stylesheets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentorshadowroot-stylesheets">6.2.3. Extensions to the DocumentOrShadowRoot Interface Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-a-css-style-sheet">
-   <b><a href="#fetch-a-css-style-sheet">#fetch-a-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-a-css-style-sheet" class="dfn-panel" data-for="fetch-a-css-style-sheet" id="infopanel-for-fetch-a-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-fetch-a-css-style-sheet" style="display:none">Info about the 'fetch a CSS style sheet' definition.</span><b><a href="#fetch-a-css-style-sheet">#fetch-a-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-a-css-style-sheet">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
     <li><a href="#ref-for-fetch-a-css-style-sheet①">6.3.5. Requirements on user agents Implementing the HTTP Link Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-css-style-sheet">
-   <b><a href="#associated-css-style-sheet">#associated-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-css-style-sheet" class="dfn-panel" data-for="associated-css-style-sheet" id="infopanel-for-associated-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-associated-css-style-sheet" style="display:none">Info about the 'associated CSS style sheet' definition.</span><b><a href="#associated-css-style-sheet">#associated-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-css-style-sheet">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-associated-css-style-sheet①">6.3.2. The LinkStyle Interface</a> <a href="#ref-for-associated-css-style-sheet②">(2)</a>
     <li><a href="#ref-for-associated-css-style-sheet③">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linkstyle">
-   <b><a href="#linkstyle">#linkstyle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linkstyle" class="dfn-panel" data-for="linkstyle" id="infopanel-for-linkstyle" role="dialog">
+   <span id="infopaneltitle-for-linkstyle" style="display:none">Info about the 'LinkStyle' definition.</span><b><a href="#linkstyle">#linkstyle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linkstyle">6.3.2. The LinkStyle Interface</a> <a href="#ref-for-linkstyle①">(2)</a>
     <li><a href="#ref-for-linkstyle②">6.3.3. Requirements on specifications</a>
     <li><a href="#ref-for-linkstyle③">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-linkstyle-sheet">
-   <b><a href="#dom-linkstyle-sheet">#dom-linkstyle-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-linkstyle-sheet" class="dfn-panel" data-for="dom-linkstyle-sheet" id="infopanel-for-dom-linkstyle-sheet" role="dialog">
+   <span id="infopaneltitle-for-dom-linkstyle-sheet" style="display:none">Info about the 'sheet' definition.</span><b><a href="#dom-linkstyle-sheet">#dom-linkstyle-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-linkstyle-sheet">6.3.2. The LinkStyle Interface</a> <a href="#ref-for-dom-linkstyle-sheet①">(2)</a> <a href="#ref-for-dom-linkstyle-sheet②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="prolog">
-   <b><a href="#prolog">#prolog</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-prolog" class="dfn-panel" data-for="prolog" id="infopanel-for-prolog" role="dialog">
+   <span id="infopaneltitle-for-prolog" style="display:none">Info about the 'prolog' definition.</span><b><a href="#prolog">#prolog</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prolog">6.3.4. Requirements on user agents Implementing the xml-stylesheet processing instruction</a> <a href="#ref-for-prolog①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-rule">
-   <b><a href="#css-rule">#css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-rule" class="dfn-panel" data-for="css-rule" id="infopanel-for-css-rule" role="dialog">
+   <span id="infopaneltitle-for-css-rule" style="display:none">Info about the 'CSS rule' definition.</span><b><a href="#css-rule">#css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-rule">6.1. CSS Style Sheets</a>
     <li><a href="#ref-for-css-rule①">6.4. CSS Rules</a> <a href="#ref-for-css-rule②">(2)</a> <a href="#ref-for-css-rule③">(3)</a> <a href="#ref-for-css-rule④">(4)</a> <a href="#ref-for-css-rule⑤">(5)</a>
@@ -7037,62 +7037,62 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-css-rule⑦">6.6. CSS Declaration Blocks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-rule-type">
-   <b><a href="#concept-css-rule-type">#concept-css-rule-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-rule-type" class="dfn-panel" data-for="concept-css-rule-type" id="infopanel-for-concept-css-rule-type" role="dialog">
+   <span id="infopaneltitle-for-concept-css-rule-type" style="display:none">Info about the 'type' definition.</span><b><a href="#concept-css-rule-type">#concept-css-rule-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-rule-type">6.4. CSS Rules</a> <a href="#ref-for-concept-css-rule-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-rule-parent-css-rule">
-   <b><a href="#concept-css-rule-parent-css-rule">#concept-css-rule-parent-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-rule-parent-css-rule" class="dfn-panel" data-for="concept-css-rule-parent-css-rule" id="infopanel-for-concept-css-rule-parent-css-rule" role="dialog">
+   <span id="infopaneltitle-for-concept-css-rule-parent-css-rule" style="display:none">Info about the 'parent CSS rule' definition.</span><b><a href="#concept-css-rule-parent-css-rule">#concept-css-rule-parent-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-rule-parent-css-rule">6.4. CSS Rules</a>
     <li><a href="#ref-for-concept-css-rule-parent-css-rule①">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-rule-parent-css-style-sheet">
-   <b><a href="#concept-css-rule-parent-css-style-sheet">#concept-css-rule-parent-css-style-sheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-rule-parent-css-style-sheet" class="dfn-panel" data-for="concept-css-rule-parent-css-style-sheet" id="infopanel-for-concept-css-rule-parent-css-style-sheet" role="dialog">
+   <span id="infopaneltitle-for-concept-css-rule-parent-css-style-sheet" style="display:none">Info about the 'parent CSS style sheet' definition.</span><b><a href="#concept-css-rule-parent-css-style-sheet">#concept-css-rule-parent-css-style-sheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-rule-parent-css-style-sheet">6.4. CSS Rules</a>
     <li><a href="#ref-for-concept-css-rule-parent-css-style-sheet①">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-css-rule-child-css-rules">
-   <b><a href="#concept-css-rule-child-css-rules">#concept-css-rule-child-css-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-css-rule-child-css-rules" class="dfn-panel" data-for="concept-css-rule-child-css-rules" id="infopanel-for-concept-css-rule-child-css-rules" role="dialog">
+   <span id="infopaneltitle-for-concept-css-rule-child-css-rules" style="display:none">Info about the 'child CSS rules' definition.</span><b><a href="#concept-css-rule-child-css-rules">#concept-css-rule-child-css-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-rule-child-css-rules">6.4.5. The CSSGroupingRule Interface</a> <a href="#ref-for-concept-css-rule-child-css-rules①">(2)</a> <a href="#ref-for-concept-css-rule-child-css-rules②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-css-rule">
-   <b><a href="#parse-a-css-rule">#parse-a-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-css-rule" class="dfn-panel" data-for="parse-a-css-rule" id="infopanel-for-parse-a-css-rule" role="dialog">
+   <span id="infopaneltitle-for-parse-a-css-rule" style="display:none">Info about the 'parse a CSS rule' definition.</span><b><a href="#parse-a-css-rule">#parse-a-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-rule">6.4. CSS Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-css-rule">
-   <b><a href="#serialize-a-css-rule">#serialize-a-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-css-rule" class="dfn-panel" data-for="serialize-a-css-rule" id="infopanel-for-serialize-a-css-rule" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-css-rule" style="display:none">Info about the 'serialize a CSS rule' definition.</span><b><a href="#serialize-a-css-rule">#serialize-a-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-rule">6.4. CSS Rules</a> <a href="#ref-for-serialize-a-css-rule①">(2)</a>
     <li><a href="#ref-for-serialize-a-css-rule②">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="insert-a-css-rule">
-   <b><a href="#insert-a-css-rule">#insert-a-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-insert-a-css-rule" class="dfn-panel" data-for="insert-a-css-rule" id="infopanel-for-insert-a-css-rule" role="dialog">
+   <span id="infopaneltitle-for-insert-a-css-rule" style="display:none">Info about the 'insert a CSS rule' definition.</span><b><a href="#insert-a-css-rule">#insert-a-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-a-css-rule">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-insert-a-css-rule①">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-a-css-rule">
-   <b><a href="#remove-a-css-rule">#remove-a-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-a-css-rule" class="dfn-panel" data-for="remove-a-css-rule" id="infopanel-for-remove-a-css-rule" role="dialog">
+   <span id="infopaneltitle-for-remove-a-css-rule" style="display:none">Info about the 'remove a CSS rule' definition.</span><b><a href="#remove-a-css-rule">#remove-a-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-a-css-rule">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-remove-a-css-rule①">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-remove-a-css-rule②">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssrulelist">
-   <b><a href="#cssrulelist">#cssrulelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssrulelist" class="dfn-panel" data-for="cssrulelist" id="infopanel-for-cssrulelist" role="dialog">
+   <span id="infopaneltitle-for-cssrulelist" style="display:none">Info about the 'CSSRuleList' definition.</span><b><a href="#cssrulelist">#cssrulelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrulelist">6.1.2. The CSSStyleSheet Interface</a> <a href="#ref-for-cssrulelist①">(2)</a> <a href="#ref-for-cssrulelist②">(3)</a>
     <li><a href="#ref-for-cssrulelist③">6.1.2.1. Deprecated CSSStyleSheet members</a>
@@ -7100,20 +7100,20 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-cssrulelist⑥">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrulelist-item">
-   <b><a href="#dom-cssrulelist-item">#dom-cssrulelist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrulelist-item" class="dfn-panel" data-for="dom-cssrulelist-item" id="infopanel-for-dom-cssrulelist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrulelist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-cssrulelist-item">#dom-cssrulelist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrulelist-item">6.4.1. The CSSRuleList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrulelist-length">
-   <b><a href="#dom-cssrulelist-length">#dom-cssrulelist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrulelist-length" class="dfn-panel" data-for="dom-cssrulelist-length" id="infopanel-for-dom-cssrulelist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrulelist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-cssrulelist-length">#dom-cssrulelist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrulelist-length">6.4.1. The CSSRuleList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssrule">
-   <b><a href="#cssrule">#cssrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssrule" class="dfn-panel" data-for="cssrule" id="infopanel-for-cssrule" role="dialog">
+   <span id="infopaneltitle-for-cssrule" style="display:none">Info about the 'CSSRule' definition.</span><b><a href="#cssrule">#cssrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">6.1.2. The CSSStyleSheet Interface</a>
     <li><a href="#ref-for-cssrule①">6.4. CSS Rules</a>
@@ -7128,53 +7128,53 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-cssrule①⑥">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrule-csstext">
-   <b><a href="#dom-cssrule-csstext">#dom-cssrule-csstext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrule-csstext" class="dfn-panel" data-for="dom-cssrule-csstext" id="infopanel-for-dom-cssrule-csstext" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrule-csstext" style="display:none">Info about the 'cssText' definition.</span><b><a href="#dom-cssrule-csstext">#dom-cssrule-csstext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrule-csstext">6.4.2. The CSSRule Interface</a> <a href="#ref-for-dom-cssrule-csstext①">(2)</a>
     <li><a href="#ref-for-dom-cssrule-csstext②">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrule-parentrule">
-   <b><a href="#dom-cssrule-parentrule">#dom-cssrule-parentrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrule-parentrule" class="dfn-panel" data-for="dom-cssrule-parentrule" id="infopanel-for-dom-cssrule-parentrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrule-parentrule" style="display:none">Info about the 'parentRule' definition.</span><b><a href="#dom-cssrule-parentrule">#dom-cssrule-parentrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrule-parentrule">6.4.2. The CSSRule Interface</a> <a href="#ref-for-dom-cssrule-parentrule①">(2)</a> <a href="#ref-for-dom-cssrule-parentrule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrule-parentstylesheet">
-   <b><a href="#dom-cssrule-parentstylesheet">#dom-cssrule-parentstylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrule-parentstylesheet" class="dfn-panel" data-for="dom-cssrule-parentstylesheet" id="infopanel-for-dom-cssrule-parentstylesheet" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrule-parentstylesheet" style="display:none">Info about the 'parentStyleSheet' definition.</span><b><a href="#dom-cssrule-parentstylesheet">#dom-cssrule-parentstylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrule-parentstylesheet">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssrule-type">
-   <b><a href="#dom-cssrule-type">#dom-cssrule-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssrule-type" class="dfn-panel" data-for="dom-cssrule-type" id="infopanel-for-dom-cssrule-type" role="dialog">
+   <span id="infopaneltitle-for-dom-cssrule-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-cssrule-type">#dom-cssrule-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssrule-type">6.4.2. The CSSRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstylerule">
-   <b><a href="#cssstylerule">#cssstylerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstylerule" class="dfn-panel" data-for="cssstylerule" id="infopanel-for-cssstylerule" role="dialog">
+   <span id="infopaneltitle-for-cssstylerule" style="display:none">Info about the 'CSSStyleRule' definition.</span><b><a href="#cssstylerule">#cssstylerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylerule">6.4. CSS Rules</a>
     <li><a href="#ref-for-cssstylerule①">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-cssstylerule②">6.4.3. The CSSStyleRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-selectortext">
-   <b><a href="#dom-cssstylerule-selectortext">#dom-cssstylerule-selectortext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-selectortext" class="dfn-panel" data-for="dom-cssstylerule-selectortext" id="infopanel-for-dom-cssstylerule-selectortext" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-selectortext" style="display:none">Info about the 'selectorText' definition.</span><b><a href="#dom-cssstylerule-selectortext">#dom-cssstylerule-selectortext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-selectortext">6.4.3. The CSSStyleRule Interface</a> <a href="#ref-for-dom-cssstylerule-selectortext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstylerule-style">
-   <b><a href="#dom-cssstylerule-style">#dom-cssstylerule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstylerule-style" class="dfn-panel" data-for="dom-cssstylerule-style" id="infopanel-for-dom-cssstylerule-style" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstylerule-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-cssstylerule-style">#dom-cssstylerule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstylerule-style">6.4.3. The CSSStyleRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-declarations-specified-order">
-   <b><a href="#concept-declarations-specified-order">#concept-declarations-specified-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-declarations-specified-order" class="dfn-panel" data-for="concept-declarations-specified-order" id="infopanel-for-concept-declarations-specified-order" role="dialog">
+   <span id="infopaneltitle-for-concept-declarations-specified-order" style="display:none">Info about the 'specified order' definition.</span><b><a href="#concept-declarations-specified-order">#concept-declarations-specified-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-declarations-specified-order">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-concept-declarations-specified-order①">6.4.7. The CSSPageRule Interface</a>
@@ -7182,106 +7182,106 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-concept-declarations-specified-order③">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssimportrule">
-   <b><a href="#cssimportrule">#cssimportrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssimportrule" class="dfn-panel" data-for="cssimportrule" id="infopanel-for-cssimportrule" role="dialog">
+   <span id="infopaneltitle-for-cssimportrule" style="display:none">Info about the 'CSSImportRule' definition.</span><b><a href="#cssimportrule">#cssimportrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssimportrule">6.4. CSS Rules</a>
     <li><a href="#ref-for-cssimportrule①">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-cssimportrule②">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssimportrule-href">
-   <b><a href="#dom-cssimportrule-href">#dom-cssimportrule-href</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssimportrule-href" class="dfn-panel" data-for="dom-cssimportrule-href" id="infopanel-for-dom-cssimportrule-href" role="dialog">
+   <span id="infopaneltitle-for-dom-cssimportrule-href" style="display:none">Info about the 'href' definition.</span><b><a href="#dom-cssimportrule-href">#dom-cssimportrule-href</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssimportrule-href">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssimportrule-media">
-   <b><a href="#dom-cssimportrule-media">#dom-cssimportrule-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssimportrule-media" class="dfn-panel" data-for="dom-cssimportrule-media" id="infopanel-for-dom-cssimportrule-media" role="dialog">
+   <span id="infopaneltitle-for-dom-cssimportrule-media" style="display:none">Info about the 'media' definition.</span><b><a href="#dom-cssimportrule-media">#dom-cssimportrule-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssimportrule-media">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssimportrule-stylesheet">
-   <b><a href="#dom-cssimportrule-stylesheet">#dom-cssimportrule-stylesheet</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssimportrule-stylesheet" class="dfn-panel" data-for="dom-cssimportrule-stylesheet" id="infopanel-for-dom-cssimportrule-stylesheet" role="dialog">
+   <span id="infopaneltitle-for-dom-cssimportrule-stylesheet" style="display:none">Info about the 'styleSheet' definition.</span><b><a href="#dom-cssimportrule-stylesheet">#dom-cssimportrule-stylesheet</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssimportrule-stylesheet">6.4.4. The CSSImportRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssgroupingrule">
-   <b><a href="#cssgroupingrule">#cssgroupingrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssgroupingrule" class="dfn-panel" data-for="cssgroupingrule" id="infopanel-for-cssgroupingrule" role="dialog">
+   <span id="infopaneltitle-for-cssgroupingrule" style="display:none">Info about the 'CSSGroupingRule' definition.</span><b><a href="#cssgroupingrule">#cssgroupingrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssgroupingrule">6.1.2.1. Deprecated CSSStyleSheet members</a>
     <li><a href="#ref-for-cssgroupingrule①">6.4.5. The CSSGroupingRule Interface</a>
     <li><a href="#ref-for-cssgroupingrule②">6.4.7. The CSSPageRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssgroupingrule-cssrules">
-   <b><a href="#dom-cssgroupingrule-cssrules">#dom-cssgroupingrule-cssrules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssgroupingrule-cssrules" class="dfn-panel" data-for="dom-cssgroupingrule-cssrules" id="infopanel-for-dom-cssgroupingrule-cssrules" role="dialog">
+   <span id="infopaneltitle-for-dom-cssgroupingrule-cssrules" style="display:none">Info about the 'cssRules' definition.</span><b><a href="#dom-cssgroupingrule-cssrules">#dom-cssgroupingrule-cssrules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssgroupingrule-cssrules">6.4. CSS Rules</a>
     <li><a href="#ref-for-dom-cssgroupingrule-cssrules①">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssgroupingrule-insertrule">
-   <b><a href="#dom-cssgroupingrule-insertrule">#dom-cssgroupingrule-insertrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssgroupingrule-insertrule" class="dfn-panel" data-for="dom-cssgroupingrule-insertrule" id="infopanel-for-dom-cssgroupingrule-insertrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssgroupingrule-insertrule" style="display:none">Info about the 'insertRule(rule, index)' definition.</span><b><a href="#dom-cssgroupingrule-insertrule">#dom-cssgroupingrule-insertrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssgroupingrule-insertrule">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssgroupingrule-deleterule">
-   <b><a href="#dom-cssgroupingrule-deleterule">#dom-cssgroupingrule-deleterule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssgroupingrule-deleterule" class="dfn-panel" data-for="dom-cssgroupingrule-deleterule" id="infopanel-for-dom-cssgroupingrule-deleterule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssgroupingrule-deleterule" style="display:none">Info about the 'deleteRule(index)' definition.</span><b><a href="#dom-cssgroupingrule-deleterule">#dom-cssgroupingrule-deleterule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssgroupingrule-deleterule">6.4.5. The CSSGroupingRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-list-of-css-page-selectors">
-   <b><a href="#parse-a-list-of-css-page-selectors">#parse-a-list-of-css-page-selectors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-list-of-css-page-selectors" class="dfn-panel" data-for="parse-a-list-of-css-page-selectors" id="infopanel-for-parse-a-list-of-css-page-selectors" role="dialog">
+   <span id="infopaneltitle-for-parse-a-list-of-css-page-selectors" style="display:none">Info about the 'parse a list of CSS page selectors' definition.</span><b><a href="#parse-a-list-of-css-page-selectors">#parse-a-list-of-css-page-selectors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-list-of-css-page-selectors">6.4.7. The CSSPageRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-list-of-css-page-selectors">
-   <b><a href="#serialize-a-list-of-css-page-selectors">#serialize-a-list-of-css-page-selectors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-list-of-css-page-selectors" class="dfn-panel" data-for="serialize-a-list-of-css-page-selectors" id="infopanel-for-serialize-a-list-of-css-page-selectors" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-list-of-css-page-selectors" style="display:none">Info about the 'serialize a list of CSS page selectors' definition.</span><b><a href="#serialize-a-list-of-css-page-selectors">#serialize-a-list-of-css-page-selectors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-list-of-css-page-selectors">6.4.7. The CSSPageRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csspagerule">
-   <b><a href="#csspagerule">#csspagerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csspagerule" class="dfn-panel" data-for="csspagerule" id="infopanel-for-csspagerule" role="dialog">
+   <span id="infopaneltitle-for-csspagerule" style="display:none">Info about the 'CSSPageRule' definition.</span><b><a href="#csspagerule">#csspagerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspagerule">6.4. CSS Rules</a> <a href="#ref-for-csspagerule①">(2)</a>
     <li><a href="#ref-for-csspagerule②">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-csspagerule③">6.4.7. The CSSPageRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-csspagerule-selectortext">
-   <b><a href="#dom-csspagerule-selectortext">#dom-csspagerule-selectortext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-csspagerule-selectortext" class="dfn-panel" data-for="dom-csspagerule-selectortext" id="infopanel-for-dom-csspagerule-selectortext" role="dialog">
+   <span id="infopaneltitle-for-dom-csspagerule-selectortext" style="display:none">Info about the 'selectorText' definition.</span><b><a href="#dom-csspagerule-selectortext">#dom-csspagerule-selectortext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-csspagerule-selectortext">6.4.7. The CSSPageRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssmarginrule">
-   <b><a href="#cssmarginrule">#cssmarginrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssmarginrule" class="dfn-panel" data-for="cssmarginrule" id="infopanel-for-cssmarginrule" role="dialog">
+   <span id="infopaneltitle-for-cssmarginrule" style="display:none">Info about the 'CSSMarginRule' definition.</span><b><a href="#cssmarginrule">#cssmarginrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssmarginrule">6.4.2. The CSSRule Interface</a>
     <li><a href="#ref-for-cssmarginrule①">6.4.8. The CSSMarginRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmarginrule-name">
-   <b><a href="#dom-cssmarginrule-name">#dom-cssmarginrule-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmarginrule-name" class="dfn-panel" data-for="dom-cssmarginrule-name" id="infopanel-for-dom-cssmarginrule-name" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmarginrule-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-cssmarginrule-name">#dom-cssmarginrule-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmarginrule-name">6.4.8. The CSSMarginRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssmarginrule-style">
-   <b><a href="#dom-cssmarginrule-style">#dom-cssmarginrule-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssmarginrule-style" class="dfn-panel" data-for="dom-cssmarginrule-style" id="infopanel-for-dom-cssmarginrule-style" role="dialog">
+   <span id="infopaneltitle-for-dom-cssmarginrule-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-cssmarginrule-style">#dom-cssmarginrule-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssmarginrule-style">6.4.8. The CSSMarginRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssnamespacerule">
-   <b><a href="#cssnamespacerule">#cssnamespacerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssnamespacerule" class="dfn-panel" data-for="cssnamespacerule" id="infopanel-for-cssnamespacerule" role="dialog">
+   <span id="infopaneltitle-for-cssnamespacerule" style="display:none">Info about the 'CSSNamespaceRule' definition.</span><b><a href="#cssnamespacerule">#cssnamespacerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnamespacerule">6.4. CSS Rules</a>
     <li><a href="#ref-for-cssnamespacerule①">6.4.2. The CSSRule Interface</a>
@@ -7289,22 +7289,22 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-cssnamespacerule③">11.1. Changes From 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnamespacerule-namespaceuri">
-   <b><a href="#dom-cssnamespacerule-namespaceuri">#dom-cssnamespacerule-namespaceuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnamespacerule-namespaceuri" class="dfn-panel" data-for="dom-cssnamespacerule-namespaceuri" id="infopanel-for-dom-cssnamespacerule-namespaceuri" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnamespacerule-namespaceuri" style="display:none">Info about the 'namespaceURI' definition.</span><b><a href="#dom-cssnamespacerule-namespaceuri">#dom-cssnamespacerule-namespaceuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnamespacerule-namespaceuri">6.4. CSS Rules</a>
     <li><a href="#ref-for-dom-cssnamespacerule-namespaceuri①">6.4.9. The CSSNamespaceRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssnamespacerule-prefix">
-   <b><a href="#dom-cssnamespacerule-prefix">#dom-cssnamespacerule-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssnamespacerule-prefix" class="dfn-panel" data-for="dom-cssnamespacerule-prefix" id="infopanel-for-dom-cssnamespacerule-prefix" role="dialog">
+   <span id="infopaneltitle-for-dom-cssnamespacerule-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#dom-cssnamespacerule-prefix">#dom-cssnamespacerule-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssnamespacerule-prefix">6.4. CSS Rules</a>
     <li><a href="#ref-for-dom-cssnamespacerule-prefix①">6.4.9. The CSSNamespaceRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-declaration">
-   <b><a href="#css-declaration">#css-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-declaration" class="dfn-panel" data-for="css-declaration" id="infopanel-for-css-declaration" role="dialog">
+   <span id="infopaneltitle-for-css-declaration" style="display:none">Info about the 'CSS declaration' definition.</span><b><a href="#css-declaration">#css-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration">6.5. CSS Declarations</a>
     <li><a href="#ref-for-css-declaration①">6.6. CSS Declaration Blocks</a> <a href="#ref-for-css-declaration②">(2)</a> <a href="#ref-for-css-declaration③">(3)</a> <a href="#ref-for-css-declaration④">(4)</a> <a href="#ref-for-css-declaration⑤">(5)</a> <a href="#ref-for-css-declaration⑥">(6)</a> <a href="#ref-for-css-declaration⑦">(7)</a>
@@ -7313,29 +7313,29 @@ so we can consider reverting this change. <a class="issue-return" href="#issue-2
     <li><a href="#ref-for-css-declaration②⑨">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-declaration-property-name">
-   <b><a href="#css-declaration-property-name">#css-declaration-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-declaration-property-name" class="dfn-panel" data-for="css-declaration-property-name" id="infopanel-for-css-declaration-property-name" role="dialog">
+   <span id="infopaneltitle-for-css-declaration-property-name" style="display:none">Info about the 'property name' definition.</span><b><a href="#css-declaration-property-name">#css-declaration-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-property-name">6.5. CSS Declarations</a>
     <li><a href="#ref-for-css-declaration-property-name①">6.6. CSS Declaration Blocks</a> <a href="#ref-for-css-declaration-property-name②">(2)</a> <a href="#ref-for-css-declaration-property-name③">(3)</a>
     <li><a href="#ref-for-css-declaration-property-name④">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-css-declaration-property-name⑤">(2)</a> <a href="#ref-for-css-declaration-property-name⑥">(3)</a> <a href="#ref-for-css-declaration-property-name⑦">(4)</a> <a href="#ref-for-css-declaration-property-name⑧">(5)</a> <a href="#ref-for-css-declaration-property-name⑨">(6)</a> <a href="#ref-for-css-declaration-property-name①⓪">(7)</a> <a href="#ref-for-css-declaration-property-name①①">(8)</a> <a href="#ref-for-css-declaration-property-name①②">(9)</a> <a href="#ref-for-css-declaration-property-name①③">(10)</a> <a href="#ref-for-css-declaration-property-name①④">(11)</a> <a href="#ref-for-css-declaration-property-name①⑤">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-declaration-value">
-   <b><a href="#css-declaration-value">#css-declaration-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-declaration-value" class="dfn-panel" data-for="css-declaration-value" id="infopanel-for-css-declaration-value" role="dialog">
+   <span id="infopaneltitle-for-css-declaration-value" style="display:none">Info about the 'value' definition.</span><b><a href="#css-declaration-value">#css-declaration-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-value">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-css-declaration-value①">(2)</a> <a href="#ref-for-css-declaration-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-declaration-important-flag">
-   <b><a href="#css-declaration-important-flag">#css-declaration-important-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-declaration-important-flag" class="dfn-panel" data-for="css-declaration-important-flag" id="infopanel-for-css-declaration-important-flag" role="dialog">
+   <span id="infopaneltitle-for-css-declaration-important-flag" style="display:none">Info about the 'important flag' definition.</span><b><a href="#css-declaration-important-flag">#css-declaration-important-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-important-flag">6.6. CSS Declaration Blocks</a> <a href="#ref-for-css-declaration-important-flag①">(2)</a> <a href="#ref-for-css-declaration-important-flag②">(3)</a>
     <li><a href="#ref-for-css-declaration-important-flag③">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-css-declaration-important-flag④">(2)</a> <a href="#ref-for-css-declaration-important-flag⑤">(3)</a> <a href="#ref-for-css-declaration-important-flag⑥">(4)</a> <a href="#ref-for-css-declaration-important-flag⑦">(5)</a> <a href="#ref-for-css-declaration-important-flag⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-declaration-block">
-   <b><a href="#css-declaration-block">#css-declaration-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-declaration-block" class="dfn-panel" data-for="css-declaration-block" id="infopanel-for-css-declaration-block" role="dialog">
+   <span id="infopaneltitle-for-css-declaration-block" style="display:none">Info about the 'CSS declaration block' definition.</span><b><a href="#css-declaration-block">#css-declaration-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-block">6.6. CSS Declaration Blocks</a> <a href="#ref-for-css-declaration-block①">(2)</a> <a href="#ref-for-css-declaration-block②">(3)</a> <a href="#ref-for-css-declaration-block③">(4)</a> <a href="#ref-for-css-declaration-block④">(5)</a> <a href="#ref-for-css-declaration-block⑤">(6)</a> <a href="#ref-for-css-declaration-block⑥">(7)</a>
     <li><a href="#ref-for-css-declaration-block⑦">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-css-declaration-block⑧">(2)</a> <a href="#ref-for-css-declaration-block⑨">(3)</a> <a href="#ref-for-css-declaration-block①⓪">(4)</a>
@@ -7344,8 +7344,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-css-declaration-block①②">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration-computed-flag">
-   <b><a href="#cssstyledeclaration-computed-flag">#cssstyledeclaration-computed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration-computed-flag" class="dfn-panel" data-for="cssstyledeclaration-computed-flag" id="infopanel-for-cssstyledeclaration-computed-flag" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration-computed-flag" style="display:none">Info about the 'computed flag' definition.</span><b><a href="#cssstyledeclaration-computed-flag">#cssstyledeclaration-computed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-computed-flag">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-cssstyledeclaration-computed-flag①">6.4.7. The CSSPageRule Interface</a>
@@ -7357,8 +7357,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-cssstyledeclaration-computed-flag①①">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration-declarations">
-   <b><a href="#cssstyledeclaration-declarations">#cssstyledeclaration-declarations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration-declarations" class="dfn-panel" data-for="cssstyledeclaration-declarations" id="infopanel-for-cssstyledeclaration-declarations" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration-declarations" style="display:none">Info about the 'declarations' definition.</span><b><a href="#cssstyledeclaration-declarations">#cssstyledeclaration-declarations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-declarations">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-cssstyledeclaration-declarations①">6.4.7. The CSSPageRule Interface</a>
@@ -7368,8 +7368,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-cssstyledeclaration-declarations②⓪">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration-parent-css-rule">
-   <b><a href="#cssstyledeclaration-parent-css-rule">#cssstyledeclaration-parent-css-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration-parent-css-rule" class="dfn-panel" data-for="cssstyledeclaration-parent-css-rule" id="infopanel-for-cssstyledeclaration-parent-css-rule" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration-parent-css-rule" style="display:none">Info about the 'parent CSS rule' definition.</span><b><a href="#cssstyledeclaration-parent-css-rule">#cssstyledeclaration-parent-css-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-parent-css-rule">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-cssstyledeclaration-parent-css-rule①">6.4.7. The CSSPageRule Interface</a>
@@ -7380,8 +7380,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-cssstyledeclaration-parent-css-rule⑤">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration-owner-node">
-   <b><a href="#cssstyledeclaration-owner-node">#cssstyledeclaration-owner-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration-owner-node" class="dfn-panel" data-for="cssstyledeclaration-owner-node" id="infopanel-for-cssstyledeclaration-owner-node" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration-owner-node" style="display:none">Info about the 'owner node' definition.</span><b><a href="#cssstyledeclaration-owner-node">#cssstyledeclaration-owner-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-owner-node">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-cssstyledeclaration-owner-node①">6.4.7. The CSSPageRule Interface</a>
@@ -7392,28 +7392,28 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-cssstyledeclaration-owner-node⑧">7.2. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration-updating-flag">
-   <b><a href="#cssstyledeclaration-updating-flag">#cssstyledeclaration-updating-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration-updating-flag" class="dfn-panel" data-for="cssstyledeclaration-updating-flag" id="infopanel-for-cssstyledeclaration-updating-flag" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration-updating-flag" style="display:none">Info about the 'updating flag' definition.</span><b><a href="#cssstyledeclaration-updating-flag">#cssstyledeclaration-updating-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-updating-flag">6.6. CSS Declaration Blocks</a> <a href="#ref-for-cssstyledeclaration-updating-flag①">(2)</a> <a href="#ref-for-cssstyledeclaration-updating-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-css-declaration-block">
-   <b><a href="#parse-a-css-declaration-block">#parse-a-css-declaration-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-css-declaration-block" class="dfn-panel" data-for="parse-a-css-declaration-block" id="infopanel-for-parse-a-css-declaration-block" role="dialog">
+   <span id="infopaneltitle-for-parse-a-css-declaration-block" style="display:none">Info about the 'parse a CSS declaration block' definition.</span><b><a href="#parse-a-css-declaration-block">#parse-a-css-declaration-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-declaration-block">6.6. CSS Declaration Blocks</a> <a href="#ref-for-parse-a-css-declaration-block①">(2)</a>
     <li><a href="#ref-for-parse-a-css-declaration-block②">6.6.1. The CSSStyleDeclaration Interface</a>
     <li><a href="#ref-for-parse-a-css-declaration-block③">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-css-declaration">
-   <b><a href="#serialize-a-css-declaration">#serialize-a-css-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-css-declaration" class="dfn-panel" data-for="serialize-a-css-declaration" id="infopanel-for-serialize-a-css-declaration" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-css-declaration" style="display:none">Info about the 'serialize a CSS declaration' definition.</span><b><a href="#serialize-a-css-declaration">#serialize-a-css-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-declaration">6.6. CSS Declaration Blocks</a> <a href="#ref-for-serialize-a-css-declaration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-css-declaration-block">
-   <b><a href="#serialize-a-css-declaration-block">#serialize-a-css-declaration-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-css-declaration-block" class="dfn-panel" data-for="serialize-a-css-declaration-block" id="infopanel-for-serialize-a-css-declaration-block" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-css-declaration-block" style="display:none">Info about the 'serialize a CSS declaration block' definition.</span><b><a href="#serialize-a-css-declaration-block">#serialize-a-css-declaration-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-declaration-block">6.4. CSS Rules</a> <a href="#ref-for-serialize-a-css-declaration-block①">(2)</a>
     <li><a href="#ref-for-serialize-a-css-declaration-block②">6.6. CSS Declaration Blocks</a>
@@ -7421,21 +7421,21 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-serialize-a-css-declaration-block④">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-style-attribute-for">
-   <b><a href="#update-style-attribute-for">#update-style-attribute-for</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-style-attribute-for" class="dfn-panel" data-for="update-style-attribute-for" id="infopanel-for-update-style-attribute-for" role="dialog">
+   <span id="infopaneltitle-for-update-style-attribute-for" style="display:none">Info about the 'update style attribute for' definition.</span><b><a href="#update-style-attribute-for">#update-style-attribute-for</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-style-attribute-for">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-update-style-attribute-for①">(2)</a> <a href="#ref-for-update-style-attribute-for②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shorthands-preferred-order">
-   <b><a href="#concept-shorthands-preferred-order">#concept-shorthands-preferred-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shorthands-preferred-order" class="dfn-panel" data-for="concept-shorthands-preferred-order" id="infopanel-for-concept-shorthands-preferred-order" role="dialog">
+   <span id="infopaneltitle-for-concept-shorthands-preferred-order" style="display:none">Info about the 'preferred order' definition.</span><b><a href="#concept-shorthands-preferred-order">#concept-shorthands-preferred-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shorthands-preferred-order">6.6. CSS Declaration Blocks</a>
     <li><a href="#ref-for-concept-shorthands-preferred-order①">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssstyledeclaration">
-   <b><a href="#cssstyledeclaration">#cssstyledeclaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssstyledeclaration" class="dfn-panel" data-for="cssstyledeclaration" id="infopanel-for-cssstyledeclaration" role="dialog">
+   <span id="infopaneltitle-for-cssstyledeclaration" style="display:none">Info about the 'CSSStyleDeclaration' definition.</span><b><a href="#cssstyledeclaration">#cssstyledeclaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-cssstyledeclaration①">6.4.7. The CSSPageRule Interface</a>
@@ -7448,8 +7448,8 @@ The ElementCSSInlineStyle Mixin</a>
     <li><a href="#ref-for-cssstyledeclaration①②">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-csstext">
-   <b><a href="#dom-cssstyledeclaration-csstext">#dom-cssstyledeclaration-csstext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-csstext" class="dfn-panel" data-for="dom-cssstyledeclaration-csstext" id="infopanel-for-dom-cssstyledeclaration-csstext" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-csstext" style="display:none">Info about the 'cssText' definition.</span><b><a href="#dom-cssstyledeclaration-csstext">#dom-cssstyledeclaration-csstext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-csstext">6.4.3. The CSSStyleRule Interface</a>
     <li><a href="#ref-for-dom-cssstyledeclaration-csstext①">6.4.7. The CSSPageRule Interface</a>
@@ -7459,216 +7459,272 @@ The ElementCSSInlineStyle Mixin</a>
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-length">
-   <b><a href="#dom-cssstyledeclaration-length">#dom-cssstyledeclaration-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-length" class="dfn-panel" data-for="dom-cssstyledeclaration-length" id="infopanel-for-dom-cssstyledeclaration-length" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-cssstyledeclaration-length">#dom-cssstyledeclaration-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-length">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-item">
-   <b><a href="#dom-cssstyledeclaration-item">#dom-cssstyledeclaration-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-item" class="dfn-panel" data-for="dom-cssstyledeclaration-item" id="infopanel-for-dom-cssstyledeclaration-item" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-cssstyledeclaration-item">#dom-cssstyledeclaration-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-item">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-getpropertyvalue">
-   <b><a href="#dom-cssstyledeclaration-getpropertyvalue">#dom-cssstyledeclaration-getpropertyvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-getpropertyvalue" class="dfn-panel" data-for="dom-cssstyledeclaration-getpropertyvalue" id="infopanel-for-dom-cssstyledeclaration-getpropertyvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-getpropertyvalue" style="display:none">Info about the 'getPropertyValue(property)' definition.</span><b><a href="#dom-cssstyledeclaration-getpropertyvalue">#dom-cssstyledeclaration-getpropertyvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue①">(2)</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue②">(3)</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue③">(4)</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue④">(5)</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue⑤">(6)</a>
     <li><a href="#ref-for-dom-cssstyledeclaration-getpropertyvalue⑥">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-getpropertypriority">
-   <b><a href="#dom-cssstyledeclaration-getpropertypriority">#dom-cssstyledeclaration-getpropertypriority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-getpropertypriority" class="dfn-panel" data-for="dom-cssstyledeclaration-getpropertypriority" id="infopanel-for-dom-cssstyledeclaration-getpropertypriority" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-getpropertypriority" style="display:none">Info about the 'getPropertyPriority(property)' definition.</span><b><a href="#dom-cssstyledeclaration-getpropertypriority">#dom-cssstyledeclaration-getpropertypriority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-getpropertypriority">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-dom-cssstyledeclaration-getpropertypriority①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-setproperty">
-   <b><a href="#dom-cssstyledeclaration-setproperty">#dom-cssstyledeclaration-setproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-setproperty" class="dfn-panel" data-for="dom-cssstyledeclaration-setproperty" id="infopanel-for-dom-cssstyledeclaration-setproperty" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-setproperty" style="display:none">Info about the 'setProperty(property, value, priority)' definition.</span><b><a href="#dom-cssstyledeclaration-setproperty">#dom-cssstyledeclaration-setproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-setproperty">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-dom-cssstyledeclaration-setproperty①">(2)</a> <a href="#ref-for-dom-cssstyledeclaration-setproperty②">(3)</a> <a href="#ref-for-dom-cssstyledeclaration-setproperty③">(4)</a> <a href="#ref-for-dom-cssstyledeclaration-setproperty④">(5)</a>
     <li><a href="#ref-for-dom-cssstyledeclaration-setproperty⑤">11.1. Changes From 5 December 2013</a>
     <li><a href="#ref-for-dom-cssstyledeclaration-setproperty⑥">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-a-css-declaration">
-   <b><a href="#set-a-css-declaration">#set-a-css-declaration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-a-css-declaration" class="dfn-panel" data-for="set-a-css-declaration" id="infopanel-for-set-a-css-declaration" role="dialog">
+   <span id="infopaneltitle-for-set-a-css-declaration" style="display:none">Info about the 'set a CSS declaration' definition.</span><b><a href="#set-a-css-declaration">#set-a-css-declaration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-a-css-declaration">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-set-a-css-declaration①">(2)</a> <a href="#ref-for-set-a-css-declaration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-removeproperty">
-   <b><a href="#dom-cssstyledeclaration-removeproperty">#dom-cssstyledeclaration-removeproperty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-removeproperty" class="dfn-panel" data-for="dom-cssstyledeclaration-removeproperty" id="infopanel-for-dom-cssstyledeclaration-removeproperty" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-removeproperty" style="display:none">Info about the 'removeProperty(property)' definition.</span><b><a href="#dom-cssstyledeclaration-removeproperty">#dom-cssstyledeclaration-removeproperty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-removeproperty">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-dom-cssstyledeclaration-removeproperty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-parentrule">
-   <b><a href="#dom-cssstyledeclaration-parentrule">#dom-cssstyledeclaration-parentrule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-parentrule" class="dfn-panel" data-for="dom-cssstyledeclaration-parentrule" id="infopanel-for-dom-cssstyledeclaration-parentrule" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-parentrule" style="display:none">Info about the 'parentRule' definition.</span><b><a href="#dom-cssstyledeclaration-parentrule">#dom-cssstyledeclaration-parentrule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-parentrule">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-cssfloat">
-   <b><a href="#dom-cssstyledeclaration-cssfloat">#dom-cssstyledeclaration-cssfloat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-cssfloat" class="dfn-panel" data-for="dom-cssstyledeclaration-cssfloat" id="infopanel-for-dom-cssstyledeclaration-cssfloat" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-cssfloat" style="display:none">Info about the 'cssFloat' definition.</span><b><a href="#dom-cssstyledeclaration-cssfloat">#dom-cssstyledeclaration-cssfloat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-cssfloat">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-camel-cased-attribute">
-   <b><a href="#dom-cssstyledeclaration-camel-cased-attribute">#dom-cssstyledeclaration-camel-cased-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-camel-cased-attribute" class="dfn-panel" data-for="dom-cssstyledeclaration-camel-cased-attribute" id="infopanel-for-dom-cssstyledeclaration-camel-cased-attribute" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-camel-cased-attribute" style="display:none">Info about the 'camel-cased attribute' definition.</span><b><a href="#dom-cssstyledeclaration-camel-cased-attribute">#dom-cssstyledeclaration-camel-cased-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-camel-cased-attribute">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-webkit-cased-attribute">
-   <b><a href="#dom-cssstyledeclaration-webkit-cased-attribute">#dom-cssstyledeclaration-webkit-cased-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-webkit-cased-attribute" class="dfn-panel" data-for="dom-cssstyledeclaration-webkit-cased-attribute" id="infopanel-for-dom-cssstyledeclaration-webkit-cased-attribute" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-webkit-cased-attribute" style="display:none">Info about the 'webkit-cased attribute' definition.</span><b><a href="#dom-cssstyledeclaration-webkit-cased-attribute">#dom-cssstyledeclaration-webkit-cased-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-webkit-cased-attribute">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssstyledeclaration-dashed-attribute">
-   <b><a href="#dom-cssstyledeclaration-dashed-attribute">#dom-cssstyledeclaration-dashed-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssstyledeclaration-dashed-attribute" class="dfn-panel" data-for="dom-cssstyledeclaration-dashed-attribute" id="infopanel-for-dom-cssstyledeclaration-dashed-attribute" role="dialog">
+   <span id="infopaneltitle-for-dom-cssstyledeclaration-dashed-attribute" style="display:none">Info about the 'dashed attribute' definition.</span><b><a href="#dom-cssstyledeclaration-dashed-attribute">#dom-cssstyledeclaration-dashed-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssstyledeclaration-dashed-attribute">6.6.1. The CSSStyleDeclaration Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-property-to-idl-attribute">
-   <b><a href="#css-property-to-idl-attribute">#css-property-to-idl-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-property-to-idl-attribute" class="dfn-panel" data-for="css-property-to-idl-attribute" id="infopanel-for-css-property-to-idl-attribute" role="dialog">
+   <span id="infopaneltitle-for-css-property-to-idl-attribute" style="display:none">Info about the 'CSS property to IDL attribute' definition.</span><b><a href="#css-property-to-idl-attribute">#css-property-to-idl-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property-to-idl-attribute">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-css-property-to-idl-attribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-attribute-to-css-property">
-   <b><a href="#idl-attribute-to-css-property">#idl-attribute-to-css-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-attribute-to-css-property" class="dfn-panel" data-for="idl-attribute-to-css-property" id="infopanel-for-idl-attribute-to-css-property" role="dialog">
+   <span id="infopaneltitle-for-idl-attribute-to-css-property" style="display:none">Info about the 'IDL attribute to CSS property' definition.</span><b><a href="#idl-attribute-to-css-property">#idl-attribute-to-css-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-attribute-to-css-property">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-idl-attribute-to-css-property①">(2)</a> <a href="#ref-for-idl-attribute-to-css-property②">(3)</a> <a href="#ref-for-idl-attribute-to-css-property③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-css-value">
-   <b><a href="#parse-a-css-value">#parse-a-css-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-css-value" class="dfn-panel" data-for="parse-a-css-value" id="infopanel-for-parse-a-css-value" role="dialog">
+   <span id="infopaneltitle-for-parse-a-css-value" style="display:none">Info about the 'parse a CSS value' definition.</span><b><a href="#parse-a-css-value">#parse-a-css-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-value">6.6.1. The CSSStyleDeclaration Interface</a>
     <li><a href="#ref-for-parse-a-css-value①">6.7.1. Parsing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-css-value">
-   <b><a href="#serialize-a-css-value">#serialize-a-css-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-css-value" class="dfn-panel" data-for="serialize-a-css-value" id="infopanel-for-serialize-a-css-value" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-css-value" style="display:none">Info about the 'serialize a CSS value' definition.</span><b><a href="#serialize-a-css-value">#serialize-a-css-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-value">6.6. CSS Declaration Blocks</a> <a href="#ref-for-serialize-a-css-value①">(2)</a>
     <li><a href="#ref-for-serialize-a-css-value②">6.6.1. The CSSStyleDeclaration Interface</a> <a href="#ref-for-serialize-a-css-value③">(2)</a>
     <li><a href="#ref-for-serialize-a-css-value④">6.7.2. Serializing CSS Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-css-component-value">
-   <b><a href="#serialize-a-css-component-value">#serialize-a-css-component-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-css-component-value" class="dfn-panel" data-for="serialize-a-css-component-value" id="infopanel-for-serialize-a-css-component-value" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-css-component-value" style="display:none">Info about the 'serialize a CSS component value' definition.</span><b><a href="#serialize-a-css-component-value">#serialize-a-css-component-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-component-value">6.7.2. Serializing CSS Values</a> <a href="#ref-for-serialize-a-css-component-value①">(2)</a> <a href="#ref-for-serialize-a-css-component-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementcssinlinestyle">
-   <b><a href="#elementcssinlinestyle">#elementcssinlinestyle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementcssinlinestyle" class="dfn-panel" data-for="elementcssinlinestyle" id="infopanel-for-elementcssinlinestyle" role="dialog">
+   <span id="infopaneltitle-for-elementcssinlinestyle" style="display:none">Info about the 'ElementCSSInlineStyle' definition.</span><b><a href="#elementcssinlinestyle">#elementcssinlinestyle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementcssinlinestyle">7.1. 
 The ElementCSSInlineStyle Mixin</a> <a href="#ref-for-elementcssinlinestyle①">(2)</a> <a href="#ref-for-elementcssinlinestyle②">(3)</a> <a href="#ref-for-elementcssinlinestyle③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementcssinlinestyle-style">
-   <b><a href="#dom-elementcssinlinestyle-style">#dom-elementcssinlinestyle-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementcssinlinestyle-style" class="dfn-panel" data-for="dom-elementcssinlinestyle-style" id="infopanel-for-dom-elementcssinlinestyle-style" role="dialog">
+   <span id="infopaneltitle-for-dom-elementcssinlinestyle-style" style="display:none">Info about the 'style' definition.</span><b><a href="#dom-elementcssinlinestyle-style">#dom-elementcssinlinestyle-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementcssinlinestyle-style">7.1. 
 The ElementCSSInlineStyle Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-getcomputedstyle">
-   <b><a href="#dom-window-getcomputedstyle">#dom-window-getcomputedstyle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="dom-window-getcomputedstyle" id="infopanel-for-dom-window-getcomputedstyle" role="dialog">
+   <span id="infopaneltitle-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt, pseudoElt)' definition.</span><b><a href="#dom-window-getcomputedstyle">#dom-window-getcomputedstyle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">7.2. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-getcomputedstyle①">(2)</a>
     <li><a href="#ref-for-dom-window-getcomputedstyle②">9. Resolved Values</a> <a href="#ref-for-dom-window-getcomputedstyle③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="namespacedef-css">
-   <b><a href="#namespacedef-css">#namespacedef-css</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namespacedef-css" class="dfn-panel" data-for="namespacedef-css" id="infopanel-for-namespacedef-css" role="dialog">
+   <span id="infopaneltitle-for-namespacedef-css" style="display:none">Info about the 'CSS' definition.</span><b><a href="#namespacedef-css">#namespacedef-css</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-css">8.1. The CSS.escape() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-css-escape">
-   <b><a href="#dom-css-escape">#dom-css-escape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-css-escape" class="dfn-panel" data-for="dom-css-escape" id="infopanel-for-dom-css-escape" role="dialog">
+   <span id="infopaneltitle-for-dom-css-escape" style="display:none">Info about the 'escape(ident)' definition.</span><b><a href="#dom-css-escape">#dom-css-escape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-escape">8.1. The CSS.escape() Method</a> <a href="#ref-for-dom-css-escape①">(2)</a> <a href="#ref-for-dom-css-escape②">(3)</a>
     <li><a href="#ref-for-dom-css-escape③">11.2. Changes From 12 July 2011 To 5 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolved-value">
-   <b><a href="#resolved-value">#resolved-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolved-value" class="dfn-panel" data-for="resolved-value" id="infopanel-for-resolved-value" role="dialog">
+   <span id="infopaneltitle-for-resolved-value" style="display:none">Info about the 'resolved value' definition.</span><b><a href="#resolved-value">#resolved-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">7.2. Extensions to the Window Interface</a>
     <li><a href="#ref-for-resolved-value①">9. Resolved Values</a> <a href="#ref-for-resolved-value②">(2)</a> <a href="#ref-for-resolved-value③">(3)</a> <a href="#ref-for-resolved-value④">(4)</a> <a href="#ref-for-resolved-value⑤">(5)</a> <a href="#ref-for-resolved-value⑥">(6)</a> <a href="#ref-for-resolved-value⑦">(7)</a> <a href="#ref-for-resolved-value⑧">(8)</a> <a href="#ref-for-resolved-value⑨">(9)</a> <a href="#ref-for-resolved-value①⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-default-style">
-   <b><a href="#http-default-style">#http-default-style</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-default-style" class="dfn-panel" data-for="http-default-style" id="infopanel-for-http-default-style" role="dialog">
+   <span id="infopaneltitle-for-http-default-style" style="display:none">Info about the 'Default-Style' definition.</span><b><a href="#http-default-style">#http-default-style</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-default-style">6.2.1. The HTTP Default-Style Header</a> <a href="#ref-for-http-default-style①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/cssom-view-1/Overview.html
@@ -4785,76 +4785,76 @@ the Windows Internet Explorer browser.</p>
      <li><a href="#dom-mouseevent-y">attribute for MouseEvent</a><span>, in § 10</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-interface-MouseEvent">
-   <a href="https://www.w3.org/TR/DOM-Level-3-Events/#interface-MouseEvent">https://www.w3.org/TR/DOM-Level-3-Events/#interface-MouseEvent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-MouseEvent" class="dfn-panel" data-for="term-for-interface-MouseEvent" id="infopanel-for-term-for-interface-MouseEvent" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-MouseEvent" style="display:none">Info about the 'MouseEvent' external reference.</span><a href="https://www.w3.org/TR/DOM-Level-3-Events/#interface-MouseEvent">https://www.w3.org/TR/DOM-Level-3-Events/#interface-MouseEvent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-MouseEvent">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-interface-MouseEvent①">(2)</a>
     <li><a href="#ref-for-interface-MouseEvent②">14. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windowproxy">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">https://html.spec.whatwg.org/multipage/browsers.html#windowproxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windowproxy" class="dfn-panel" data-for="term-for-windowproxy" id="infopanel-for-term-for-windowproxy" role="menu">
+   <span id="infopaneltitle-for-term-for-windowproxy" style="display:none">Info about the 'WindowProxy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#windowproxy">https://html.spec.whatwg.org/multipage/browsers.html#windowproxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowproxy">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-document" class="dfn-panel" data-for="term-for-active-document" id="infopanel-for-term-for-active-document" role="menu">
+   <span id="infopaneltitle-for-term-for-active-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-document">6. Extensions to the Element Interface</a> <a href="#ref-for-active-document①">(2)</a> <a href="#ref-for-active-document②">(3)</a> <a href="#ref-for-active-document③">(4)</a> <a href="#ref-for-active-document④">(5)</a> <a href="#ref-for-active-document⑤">(6)</a> <a href="#ref-for-active-document⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anonymous-block-level">
-   <a href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anonymous-block-level" class="dfn-panel" data-for="term-for-anonymous-block-level" id="infopanel-for-term-for-anonymous-block-level" role="menu">
+   <span id="infopaneltitle-for-term-for-anonymous-block-level" style="display:none">Info about the 'anonymous block box' external reference.</span><a href="https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level">https://www.w3.org/TR/CSS21/visuren.html#anonymous-block-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymous-block-level">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#auxiliary-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4. Extensions to the Window Interface</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a> <a href="#ref-for-browsing-context③">(4)</a> <a href="#ref-for-browsing-context④">(5)</a> <a href="#ref-for-browsing-context⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mf-colors">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#mf-colors">https://drafts.csswg.org/mediaqueries-4/#mf-colors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mf-colors" class="dfn-panel" data-for="term-for-mf-colors" id="infopanel-for-term-for-mf-colors" role="menu">
+   <span id="infopaneltitle-for-term-for-mf-colors" style="display:none">Info about the 'color media query' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#mf-colors">https://drafts.csswg.org/mediaqueries-4/#mf-colors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mf-colors">4.3. The Screen Interface</a> <a href="#ref-for-mf-colors①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-context-object">
-   <a href="https://dom.spec.whatwg.org/#context-object">https://dom.spec.whatwg.org/#context-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-context-object" class="dfn-panel" data-for="term-for-context-object" id="infopanel-for-term-for-context-object" role="menu">
+   <span id="infopaneltitle-for-term-for-context-object" style="display:none">Info about the 'context object' external reference.</span><a href="https://dom.spec.whatwg.org/#context-object">https://dom.spec.whatwg.org/#context-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-context-object">4. Extensions to the Window Interface</a> <a href="#ref-for-context-object①">(2)</a> <a href="#ref-for-context-object②">(3)</a> <a href="#ref-for-context-object③">(4)</a> <a href="#ref-for-context-object④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="http://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value">http://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="http://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value">http://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">4. Extensions to the Window Interface</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">(2)</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value②">6. Extensions to the Element Interface</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatch-flag">
-   <a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatch-flag" class="dfn-panel" data-for="term-for-dispatch-flag" id="infopanel-for-term-for-dispatch-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatch-flag">https://dom.spec.whatwg.org/#dispatch-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-dispatch-flag①">(2)</a> <a href="#ref-for-dispatch-flag②">(3)</a> <a href="#ref-for-dispatch-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="http://heycam.github.io/webidl/#idl-double">http://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="http://heycam.github.io/webidl/#idl-double">http://heycam.github.io/webidl/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4. Extensions to the Window Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a>
     <li><a href="#ref-for-idl-double⑤">5. Extensions to the Document Interface</a> <a href="#ref-for-idl-double⑥">(2)</a> <a href="#ref-for-idl-double⑦">(3)</a> <a href="#ref-for-idl-double⑧">(4)</a> <a href="#ref-for-idl-double⑨">(5)</a> <a href="#ref-for-idl-double①⓪">(6)</a>
@@ -4862,65 +4862,65 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-idl-double②⑤">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.2. The MediaQueryList Interface</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attributes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">4.2. The MediaQueryList Interface</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">4.2. The MediaQueryList Interface</a> <a href="#ref-for-concept-event-listener①">(2)</a> <a href="#ref-for-concept-event-listener②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-familiar-with">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#familiar-with">https://html.spec.whatwg.org/multipage/browsers.html#familiar-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-familiar-with" class="dfn-panel" data-for="term-for-familiar-with" id="infopanel-for-term-for-familiar-with" role="menu">
+   <span id="infopaneltitle-for-term-for-familiar-with" style="display:none">Info about the 'familiar with' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#familiar-with">https://html.spec.whatwg.org/multipage/browsers.html#familiar-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-familiar-with">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">4.2. The MediaQueryList Interface</a>
     <li><a href="#ref-for-concept-event-fire①">12.1. Resizing viewports</a>
     <li><a href="#ref-for-concept-event-fire②">12.2. Scrolling</a> <a href="#ref-for-concept-event-fire③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-elements">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-elements" class="dfn-panel" data-for="term-for-html-elements" id="infopanel-for-term-for-html-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-html-elements" style="display:none">Info about the 'html elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-elements">2. Terminology</a> <a href="#ref-for-html-elements①">(2)</a>
     <li><a href="#ref-for-html-elements②">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-incumbent-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-incumbent-settings-object" class="dfn-panel" data-for="term-for-incumbent-settings-object" id="infopanel-for-term-for-incumbent-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-incumbent-settings-object" style="display:none">Info about the 'incumbent settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incumbent-settings-object">4. Extensions to the Window Interface</a> <a href="#ref-for-incumbent-settings-object①">(2)</a> <a href="#ref-for-incumbent-settings-object②">(3)</a> <a href="#ref-for-incumbent-settings-object③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-istrusted">
-   <a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-istrusted" class="dfn-panel" data-for="term-for-dom-event-istrusted" id="infopanel-for-term-for-dom-event-istrusted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-istrusted">https://dom.spec.whatwg.org/#dom-event-istrusted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="http://heycam.github.io/webidl/#idl-long">http://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="http://heycam.github.io/webidl/#idl-long">http://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">4. Extensions to the Window Interface</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a> <a href="#ref-for-idl-long④">(5)</a> <a href="#ref-for-idl-long⑤">(6)</a> <a href="#ref-for-idl-long⑥">(7)</a> <a href="#ref-for-idl-long⑦">(8)</a> <a href="#ref-for-idl-long⑧">(9)</a> <a href="#ref-for-idl-long⑨">(10)</a> <a href="#ref-for-idl-long①⓪">(11)</a> <a href="#ref-for-idl-long①①">(12)</a> <a href="#ref-for-idl-long①②">(13)</a> <a href="#ref-for-idl-long①③">(14)</a> <a href="#ref-for-idl-long①④">(15)</a> <a href="#ref-for-idl-long①⑤">(16)</a>
     <li><a href="#ref-for-idl-long①⑥">4.3. The Screen Interface</a> <a href="#ref-for-idl-long①⑦">(2)</a> <a href="#ref-for-idl-long①⑧">(3)</a> <a href="#ref-for-idl-long①⑨">(4)</a>
@@ -4930,95 +4930,95 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-idl-long③②">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">6. Extensions to the Element Interface</a> <a href="#ref-for-concept-node-document①">(2)</a> <a href="#ref-for-concept-node-document②">(3)</a> <a href="#ref-for-concept-node-document③">(4)</a> <a href="#ref-for-concept-node-document④">(5)</a> <a href="#ref-for-concept-node-document⑤">(6)</a> <a href="#ref-for-concept-node-document⑥">(7)</a> <a href="#ref-for-concept-node-document⑦">(8)</a> <a href="#ref-for-concept-node-document⑧">(9)</a> <a href="#ref-for-concept-node-document⑨">(10)</a> <a href="#ref-for-concept-node-document①⓪">(11)</a>
     <li><a href="#ref-for-concept-node-document①①">12.2. Scrolling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-media-query-list">
-   <a href="https://drafts.csswg.org/cssom/#parse-a-media-query-list">https://drafts.csswg.org/cssom/#parse-a-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-media-query-list" class="dfn-panel" data-for="term-for-parse-a-media-query-list" id="infopanel-for-term-for-parse-a-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-media-query-list" style="display:none">Info about the 'parse a media query list' external reference.</span><a href="https://drafts.csswg.org/cssom/#parse-a-media-query-list">https://drafts.csswg.org/cssom/#parse-a-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-media-query-list">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">5. Extensions to the Document Interface</a> <a href="#ref-for-concept-document-quirks①">(2)</a>
     <li><a href="#ref-for-concept-document-quirks②">6. Extensions to the Element Interface</a> <a href="#ref-for-concept-document-quirks③">(2)</a> <a href="#ref-for-concept-document-quirks④">(3)</a> <a href="#ref-for-concept-document-quirks⑤">(4)</a> <a href="#ref-for-concept-document-quirks⑥">(5)</a> <a href="#ref-for-concept-document-quirks⑦">(6)</a> <a href="#ref-for-concept-document-quirks⑧">(7)</a> <a href="#ref-for-concept-document-quirks⑨">(8)</a> <a href="#ref-for-concept-document-quirks①⓪">(9)</a> <a href="#ref-for-concept-document-quirks①①">(10)</a> <a href="#ref-for-concept-document-quirks①②">(11)</a> <a href="#ref-for-concept-document-quirks①③">(12)</a> <a href="#ref-for-concept-document-quirks①④">(13)</a> <a href="#ref-for-concept-document-quirks①⑤">(14)</a> <a href="#ref-for-concept-document-quirks①⑥">(15)</a> <a href="#ref-for-concept-document-quirks①⑦">(16)</a> <a href="#ref-for-concept-document-quirks①⑧">(17)</a> <a href="#ref-for-concept-document-quirks①⑨">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-browsing-context" class="dfn-panel" data-for="term-for-responsible-browsing-context" id="infopanel-for-term-for-responsible-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-browsing-context" style="display:none">Info about the 'responsible browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-browsing-context">4. Extensions to the Window Interface</a> <a href="#ref-for-responsible-browsing-context①">(2)</a> <a href="#ref-for-responsible-browsing-context②">(3)</a> <a href="#ref-for-responsible-browsing-context③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rules-for-parsing-integers">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#rules-for-parsing-integers">https://html.spec.whatwg.org/multipage/infrastructure.html#rules-for-parsing-integers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rules-for-parsing-integers" class="dfn-panel" data-for="term-for-rules-for-parsing-integers" id="infopanel-for-term-for-rules-for-parsing-integers" role="menu">
+   <span id="infopaneltitle-for-term-for-rules-for-parsing-integers" style="display:none">Info about the 'rules for parsing integers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#rules-for-parsing-integers">https://html.spec.whatwg.org/multipage/infrastructure.html#rules-for-parsing-integers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-parsing-integers">4.1. The features argument to the open() method</a> <a href="#ref-for-rules-for-parsing-integers①">(2)</a> <a href="#ref-for-rules-for-parsing-integers②">(3)</a> <a href="#ref-for-rules-for-parsing-integers③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">6.1. Element Scrolling Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-media-query-list">
-   <a href="https://drafts.csswg.org/cssom/#serialize-a-media-query-list">https://drafts.csswg.org/cssom/#serialize-a-media-query-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-media-query-list" class="dfn-panel" data-for="term-for-serialize-a-media-query-list" id="infopanel-for-term-for-serialize-a-media-query-list" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-media-query-list" style="display:none">Info about the 'serialize a media query list' external reference.</span><a href="https://drafts.csswg.org/cssom/#serialize-a-media-query-list">https://drafts.csswg.org/cssom/#serialize-a-media-query-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-media-query-list">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-range-startcontainer">
-   <a href="https://dom.spec.whatwg.org/#dom-range-startcontainer">https://dom.spec.whatwg.org/#dom-range-startcontainer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-range-startcontainer" class="dfn-panel" data-for="term-for-dom-range-startcontainer" id="infopanel-for-term-for-dom-range-startcontainer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-range-startcontainer" style="display:none">Info about the 'startContainer' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-range-startcontainer">https://dom.spec.whatwg.org/#dom-range-startcontainer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-startcontainer">5. Extensions to the Document Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-range-startoffset">
-   <a href="https://dom.spec.whatwg.org/#dom-range-startoffset">https://dom.spec.whatwg.org/#dom-range-startoffset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-range-startoffset" class="dfn-panel" data-for="term-for-dom-range-startoffset" id="infopanel-for-term-for-dom-range-startoffset" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-range-startoffset" style="display:none">Info about the 'startOffset' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-range-startoffset">https://dom.spec.whatwg.org/#dom-range-startoffset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-startoffset">5. Extensions to the Document Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-fragment">
-   <a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-fragment" class="dfn-panel" data-for="term-for-box-fragment" id="infopanel-for-term-for-box-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-box-fragment" style="display:none">Info about the 'box fragment' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#box-fragment">https://drafts.csswg.org/css-break-4/#box-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-fragment">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. Terminology</a>
     <li><a href="#ref-for-propdef-display①">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">2. Terminology</a> <a href="#ref-for-initial-containing-block①">(2)</a> <a href="#ref-for-initial-containing-block②">(3)</a> <a href="#ref-for-initial-containing-block③">(4)</a> <a href="#ref-for-initial-containing-block④">(5)</a> <a href="#ref-for-initial-containing-block⑤">(6)</a> <a href="#ref-for-initial-containing-block⑥">(7)</a> <a href="#ref-for-initial-containing-block⑦">(8)</a> <a href="#ref-for-initial-containing-block⑧">(9)</a> <a href="#ref-for-initial-containing-block⑨">(10)</a> <a href="#ref-for-initial-containing-block①⓪">(11)</a> <a href="#ref-for-initial-containing-block①①">(12)</a> <a href="#ref-for-initial-containing-block①②">(13)</a> <a href="#ref-for-initial-containing-block①③">(14)</a> <a href="#ref-for-initial-containing-block①④">(15)</a> <a href="#ref-for-initial-containing-block①⑤">(16)</a> <a href="#ref-for-initial-containing-block①⑥">(17)</a>
     <li><a href="#ref-for-initial-containing-block①⑦">4. Extensions to the Window Interface</a> <a href="#ref-for-initial-containing-block①⑧">(2)</a>
@@ -5027,116 +5027,116 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-initial-containing-block②⑤">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-initial-containing-block②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-table" class="dfn-panel" data-for="term-for-valdef-display-inline-table" id="infopanel-for-term-for-valdef-display-inline-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-table" style="display:none">Info about the 'inline-table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline-table">https://drafts.csswg.org/css-display-3/#valdef-display-inline-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-table">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column" class="dfn-panel" data-for="term-for-valdef-display-table-column" id="infopanel-for-term-for-valdef-display-table-column" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column" style="display:none">Info about the 'table-column' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column-group" class="dfn-panel" data-for="term-for-valdef-display-table-column-group" id="infopanel-for-term-for-valdef-display-table-column-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column-group" style="display:none">Info about the 'table-column-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column-group">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-auto">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-auto" class="dfn-panel" data-for="term-for-valdef-overflow-auto" id="infopanel-for-term-for-valdef-overflow-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-auto">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-clip">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-clip" class="dfn-panel" data-for="term-for-valdef-overflow-clip" id="infopanel-for-term-for-valdef-overflow-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-clip">2. Terminology</a> <a href="#ref-for-valdef-overflow-clip①">(2)</a> <a href="#ref-for-valdef-overflow-clip②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-hidden">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-hidden" class="dfn-panel" data-for="term-for-valdef-overflow-hidden" id="infopanel-for-term-for-valdef-overflow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-x">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-x" class="dfn-panel" data-for="term-for-propdef-overflow-x" id="infopanel-for-term-for-propdef-overflow-x" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-x" style="display:none">Info about the 'overflow-x' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-x">2. Terminology</a> <a href="#ref-for-propdef-overflow-x①">(2)</a> <a href="#ref-for-propdef-overflow-x②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-y">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-y" class="dfn-panel" data-for="term-for-propdef-overflow-y" id="infopanel-for-term-for-propdef-overflow-y" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-y" style="display:none">Info about the 'overflow-y' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y">https://drafts.csswg.org/css-overflow-3/#propdef-overflow-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-y">2. Terminology</a> <a href="#ref-for-propdef-overflow-y①">(2)</a> <a href="#ref-for-propdef-overflow-y②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-visible">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-visible" class="dfn-panel" data-for="term-for-valdef-overflow-visible" id="infopanel-for-term-for-valdef-overflow-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-visible">2. Terminology</a> <a href="#ref-for-valdef-overflow-visible①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-fixed">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-fixed" class="dfn-panel" data-for="term-for-valdef-position-fixed" id="infopanel-for-term-for-valdef-position-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-valdef-position-fixed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-propdef-position①">(2)</a> <a href="#ref-for-propdef-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csspseudoelement">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#csspseudoelement">https://drafts.csswg.org/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csspseudoelement" class="dfn-panel" data-for="term-for-csspseudoelement" id="infopanel-for-term-for-csspseudoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-csspseudoelement" style="display:none">Info about the 'CSSPseudoElement' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#csspseudoelement">https://drafts.csswg.org/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspseudoelement">11.1. The GeometryUtils Interface</a> <a href="#ref-for-csspseudoelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flat tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-flat-tree①">(2)</a> <a href="#ref-for-flat-tree②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-character-unit">
-   <a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-character-unit" class="dfn-panel" data-for="term-for-typographic-character-unit" id="infopanel-for-term-for-typographic-character-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-character-unit" style="display:none">Info about the 'typographic character unit' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#typographic-character-unit">https://drafts.csswg.org/css-text-4/#typographic-character-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-character-unit">9. Extensions to the Range Interface</a> <a href="#ref-for-typographic-character-unit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pointer-events">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pointer-events" class="dfn-panel" data-for="term-for-propdef-pointer-events" id="infopanel-for-term-for-propdef-pointer-events" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pointer-events" style="display:none">Info about the 'pointer-events' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pointer-events">5. Extensions to the Document Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">2.1. CSS pixels</a>
     <li><a href="#ref-for-px①">2.3. Web-exposed screen information</a> <a href="#ref-for-px②">(2)</a> <a href="#ref-for-px③">(3)</a> <a href="#ref-for-px④">(4)</a> <a href="#ref-for-px⑤">(5)</a>
@@ -5144,45 +5144,45 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-px①⑥">4.1. The features argument to the open() method</a> <a href="#ref-for-px①⑦">(2)</a> <a href="#ref-for-px①⑧">(3)</a> <a href="#ref-for-px①⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">13.1. Smooth Scrolling: The scroll-behavior Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">6.1. Element Scrolling Members</a> <a href="#ref-for-block-flow-direction①">(2)</a> <a href="#ref-for-block-flow-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-end" class="dfn-panel" data-for="term-for-block-end" id="infopanel-for-term-for-block-end" role="menu">
+   <span id="infopaneltitle-for-term-for-block-end" style="display:none">Info about the 'block-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-end">https://drafts.csswg.org/css-writing-modes-4/#block-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-end">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-base-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-base-direction" class="dfn-panel" data-for="term-for-inline-base-direction" id="infopanel-for-term-for-inline-base-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-base-direction" style="display:none">Info about the 'inline base direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction">https://drafts.csswg.org/css-writing-modes-4/#inline-base-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-base-direction">6.1. Element Scrolling Members</a> <a href="#ref-for-inline-base-direction①">(2)</a> <a href="#ref-for-inline-base-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-end">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-end" class="dfn-panel" data-for="term-for-inline-end" id="infopanel-for-term-for-inline-end" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-end" style="display:none">Info about the 'inline-end' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-end">https://drafts.csswg.org/css-writing-modes-4/#inline-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-end">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-cssomstring①">4.2. The MediaQueryList Interface</a> <a href="#ref-for-cssomstring②">(2)</a> <a href="#ref-for-cssomstring③">(3)</a> <a href="#ref-for-cssomstring④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4. Extensions to the Window Interface</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">4.2. The MediaQueryList Interface</a>
@@ -5195,8 +5195,8 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-document①⑧">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">5. Extensions to the Document Interface</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a>
     <li><a href="#ref-for-element③">6. Extensions to the Element Interface</a> <a href="#ref-for-element④">(2)</a>
@@ -5207,144 +5207,144 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-element①④">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.2. The MediaQueryList Interface</a>
     <li><a href="#ref-for-event①">4.2.1. Event summary</a>
     <li><a href="#ref-for-event②">12.3. Event summary</a> <a href="#ref-for-event③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-callbackdef-eventlistener">
-   <a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-callbackdef-eventlistener" class="dfn-panel" data-for="term-for-callbackdef-eventlistener" id="infopanel-for-term-for-callbackdef-eventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-callbackdef-eventlistener" style="display:none">Info about the 'EventListener' external reference.</span><a href="https://dom.spec.whatwg.org/#callbackdef-eventlistener">https://dom.spec.whatwg.org/#callbackdef-eventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-eventlistener">4.2. The MediaQueryList Interface</a> <a href="#ref-for-callbackdef-eventlistener①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range">
-   <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range" class="dfn-panel" data-for="term-for-range" id="infopanel-for-term-for-range" role="menu">
+   <span id="infopaneltitle-for-term-for-range" style="display:none">Info about the 'Range' external reference.</span><a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-range①">9. Extensions to the Range Interface</a> <a href="#ref-for-range②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text">
-   <a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text" class="dfn-panel" data-for="term-for-text" id="infopanel-for-term-for-text" role="menu">
+   <span id="infopaneltitle-for-term-for-text" style="display:none">Info about the 'Text' external reference.</span><a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text">9. Extensions to the Range Interface</a>
     <li><a href="#ref-for-text①">11.1. The GeometryUtils Interface</a> <a href="#ref-for-text②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-add-an-event-listener">
-   <a href="https://dom.spec.whatwg.org/#add-an-event-listener">https://dom.spec.whatwg.org/#add-an-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-add-an-event-listener" class="dfn-panel" data-for="term-for-add-an-event-listener" id="infopanel-for-term-for-add-an-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-add-an-event-listener" style="display:none">Info about the 'add an event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#add-an-event-listener">https://dom.spec.whatwg.org/#add-an-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-an-event-listener">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener">
-   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener" id="infopanel-for-term-for-dom-eventtarget-addeventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" style="display:none">Info about the 'addEventListener(type, callback)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-listener-callback">
-   <a href="https://dom.spec.whatwg.org/#event-listener-callback">https://dom.spec.whatwg.org/#event-listener-callback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-listener-callback" class="dfn-panel" data-for="term-for-event-listener-callback" id="infopanel-for-term-for-event-listener-callback" role="menu">
+   <span id="infopaneltitle-for-term-for-event-listener-callback" style="display:none">Info about the 'callback' external reference.</span><a href="https://dom.spec.whatwg.org/#event-listener-callback">https://dom.spec.whatwg.org/#event-listener-callback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-callback">4.2. The MediaQueryList Interface</a> <a href="#ref-for-event-listener-callback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-listener-capture">
-   <a href="https://dom.spec.whatwg.org/#event-listener-capture">https://dom.spec.whatwg.org/#event-listener-capture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-listener-capture" class="dfn-panel" data-for="term-for-event-listener-capture" id="infopanel-for-term-for-event-listener-capture" role="menu">
+   <span id="infopaneltitle-for-term-for-event-listener-capture" style="display:none">Info about the 'capture' external reference.</span><a href="https://dom.spec.whatwg.org/#event-listener-capture">https://dom.spec.whatwg.org/#event-listener-capture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-capture">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-closed-shadow-hidden">
-   <a href="https://dom.spec.whatwg.org/#concept-closed-shadow-hidden">https://dom.spec.whatwg.org/#concept-closed-shadow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-closed-shadow-hidden" class="dfn-panel" data-for="term-for-concept-closed-shadow-hidden" id="infopanel-for-term-for-concept-closed-shadow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-closed-shadow-hidden" style="display:none">Info about the 'closed-shadow-hidden' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-closed-shadow-hidden">https://dom.spec.whatwg.org/#concept-closed-shadow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-closed-shadow-hidden">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-concept-closed-shadow-hidden①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener①" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener①" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">4.2. The MediaQueryList Interface</a> <a href="#ref-for-concept-event-listener①">(2)</a> <a href="#ref-for-concept-event-listener②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget-event-listener-list">
-   <a href="https://dom.spec.whatwg.org/#eventtarget-event-listener-list">https://dom.spec.whatwg.org/#eventtarget-event-listener-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget-event-listener-list" class="dfn-panel" data-for="term-for-eventtarget-event-listener-list" id="infopanel-for-term-for-eventtarget-event-listener-list" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget-event-listener-list" style="display:none">Info about the 'event listener list' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget-event-listener-list">https://dom.spec.whatwg.org/#eventtarget-event-listener-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-event-listener-list">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parent-element">
-   <a href="https://dom.spec.whatwg.org/#parent-element">https://dom.spec.whatwg.org/#parent-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parent-element" class="dfn-panel" data-for="term-for-parent-element" id="infopanel-for-term-for-parent-element" role="menu">
+   <span id="infopaneltitle-for-term-for-parent-element" style="display:none">Info about the 'parent element' external reference.</span><a href="https://dom.spec.whatwg.org/#parent-element">https://dom.spec.whatwg.org/#parent-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-remove-an-event-listener">
-   <a href="https://dom.spec.whatwg.org/#remove-an-event-listener">https://dom.spec.whatwg.org/#remove-an-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-remove-an-event-listener" class="dfn-panel" data-for="term-for-remove-an-event-listener" id="infopanel-for-term-for-remove-an-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-remove-an-event-listener" style="display:none">Info about the 'remove an event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#remove-an-event-listener">https://dom.spec.whatwg.org/#remove-an-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-an-event-listener">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-removeeventlistener">
-   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-eventtarget-removeeventlistener" class="dfn-panel" data-for="term-for-dom-eventtarget-removeeventlistener" id="infopanel-for-term-for-dom-eventtarget-removeeventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-eventtarget-removeeventlistener" style="display:none">Info about the 'removeEventListener(type, callback)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-removeeventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-removeeventlistener">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-listener-type">
-   <a href="https://dom.spec.whatwg.org/#event-listener-type">https://dom.spec.whatwg.org/#event-listener-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-listener-type" class="dfn-panel" data-for="term-for-event-listener-type" id="infopanel-for-term-for-event-listener-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-listener-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#event-listener-type">https://dom.spec.whatwg.org/#event-listener-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-type">4.2. The MediaQueryList Interface</a> <a href="#ref-for-event-listener-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dompoint">
-   <a href="https://drafts.fxtf.org/geometry-1/#dompoint">https://drafts.fxtf.org/geometry-1/#dompoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dompoint" class="dfn-panel" data-for="term-for-dompoint" id="infopanel-for-term-for-dompoint" role="menu">
+   <span id="infopaneltitle-for-term-for-dompoint" style="display:none">Info about the 'DOMPoint' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dompoint">https://drafts.fxtf.org/geometry-1/#dompoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompoint">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-dompointinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-dompointinit" class="dfn-panel" data-for="term-for-dictdef-dompointinit" id="infopanel-for-term-for-dictdef-dompointinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit">https://drafts.fxtf.org/geometry-1/#dictdef-dompointinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domquad">
-   <a href="https://drafts.fxtf.org/geometry-1/#domquad">https://drafts.fxtf.org/geometry-1/#domquad</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domquad" class="dfn-panel" data-for="term-for-domquad" id="infopanel-for-term-for-domquad" role="menu">
+   <span id="infopaneltitle-for-term-for-domquad" style="display:none">Info about the 'DOMQuad' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domquad">https://drafts.fxtf.org/geometry-1/#domquad</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domquad">11.1. The GeometryUtils Interface</a> <a href="#ref-for-domquad①">(2)</a> <a href="#ref-for-domquad②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-domquadinit">
-   <a href="https://drafts.fxtf.org/geometry-1/#dictdef-domquadinit">https://drafts.fxtf.org/geometry-1/#dictdef-domquadinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-domquadinit" class="dfn-panel" data-for="term-for-dictdef-domquadinit" id="infopanel-for-term-for-dictdef-domquadinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-domquadinit" style="display:none">Info about the 'DOMQuadInit' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dictdef-domquadinit">https://drafts.fxtf.org/geometry-1/#dictdef-domquadinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-domquadinit">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrect">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrect" class="dfn-panel" data-for="term-for-domrect" id="infopanel-for-term-for-domrect" role="menu">
+   <span id="infopaneltitle-for-term-for-domrect" style="display:none">Info about the 'DOMRect' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrect">https://drafts.fxtf.org/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">5.1. The CaretPosition Interface</a> <a href="#ref-for-domrect①">(2)</a> <a href="#ref-for-domrect②">(3)</a> <a href="#ref-for-domrect③">(4)</a>
     <li><a href="#ref-for-domrect④">6. Extensions to the Element Interface</a> <a href="#ref-for-domrect⑤">(2)</a> <a href="#ref-for-domrect⑥">(3)</a> <a href="#ref-for-domrect⑦">(4)</a> <a href="#ref-for-domrect⑧">(5)</a> <a href="#ref-for-domrect⑨">(6)</a> <a href="#ref-for-domrect①⓪">(7)</a>
@@ -5352,67 +5352,67 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-domrect②⓪">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectlist">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectlist">https://drafts.fxtf.org/geometry-1/#domrectlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectlist" class="dfn-panel" data-for="term-for-domrectlist" id="infopanel-for-term-for-domrectlist" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectlist" style="display:none">Info about the 'DOMRectList' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectlist">https://drafts.fxtf.org/geometry-1/#domrectlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectlist">6. Extensions to the Element Interface</a> <a href="#ref-for-domrectlist①">(2)</a> <a href="#ref-for-domrectlist②">(3)</a> <a href="#ref-for-domrectlist③">(4)</a>
     <li><a href="#ref-for-domrectlist④">9. Extensions to the Range Interface</a> <a href="#ref-for-domrectlist⑤">(2)</a> <a href="#ref-for-domrectlist⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrect-height">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-height">https://drafts.fxtf.org/geometry-1/#dom-domrect-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrect-height" class="dfn-panel" data-for="term-for-dom-domrect-height" id="infopanel-for-term-for-dom-domrect-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrect-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-height">https://drafts.fxtf.org/geometry-1/#dom-domrect-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-height">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-domrect-height①">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrect-width">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-width">https://drafts.fxtf.org/geometry-1/#dom-domrect-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrect-width" class="dfn-panel" data-for="term-for-dom-domrect-width" id="infopanel-for-term-for-dom-domrect-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrect-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-width">https://drafts.fxtf.org/geometry-1/#dom-domrect-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-width">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-domrect-width①">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrect-x">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-x">https://drafts.fxtf.org/geometry-1/#dom-domrect-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrect-x" class="dfn-panel" data-for="term-for-dom-domrect-x" id="infopanel-for-term-for-dom-domrect-x" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrect-x" style="display:none">Info about the 'x' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-x">https://drafts.fxtf.org/geometry-1/#dom-domrect-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-x">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-domrect-x①">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domrect-y">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-y">https://drafts.fxtf.org/geometry-1/#dom-domrect-y</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domrect-y" class="dfn-panel" data-for="term-for-dom-domrect-y" id="infopanel-for-term-for-dom-domrect-y" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domrect-y" style="display:none">Info about the 'y' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-domrect-y">https://drafts.fxtf.org/geometry-1/#dom-domrect-y</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-y">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-domrect-y①">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlelement" class="dfn-panel" data-for="term-for-htmlelement" id="infopanel-for-term-for-htmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlelement" style="display:none">Info about the 'HTMLElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlelement">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-htmlelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">8. Extensions to the HTMLImageElement Interface</a> <a href="#ref-for-htmlimageelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4. Extensions to the Window Interface</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a>
     <li><a href="#ref-for-window③">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-window④">(2)</a>
@@ -5421,20 +5421,20 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-window⑧">Changes From 17 December 2013 To 31 January 2020</a> <a href="#ref-for-window⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-defaultview">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-defaultview" class="dfn-panel" data-for="term-for-dom-document-defaultview" id="infopanel-for-term-for-dom-document-defaultview" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-defaultview" style="display:none">Info about the 'defaultView' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-defaultview">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-document-defaultview①">(2)</a> <a href="#ref-for-dom-document-defaultview②">(3)</a> <a href="#ref-for-dom-document-defaultview③">(4)</a> <a href="#ref-for-dom-document-defaultview④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-agent-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-agent-event-loop" class="dfn-panel" data-for="term-for-concept-agent-event-loop" id="infopanel-for-term-for-concept-agent-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-agent-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#concept-agent-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-agent-event-loop">4.2. The MediaQueryList Interface</a>
     <li><a href="#ref-for-concept-agent-event-loop①">12.1. Resizing viewports</a>
@@ -5442,55 +5442,55 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-concept-agent-event-loop③">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-live">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#live">https://html.spec.whatwg.org/multipage/infrastructure.html#live</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-live" class="dfn-panel" data-for="term-for-live" id="infopanel-for-term-for-live" role="menu">
+   <span id="infopaneltitle-for-term-for-live" style="display:none">Info about the 'live' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#live">https://html.spec.whatwg.org/multipage/infrastructure.html#live</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-live">5.1. The CaretPosition Interface</a>
     <li><a href="#ref-for-live①">6. Extensions to the Element Interface</a> <a href="#ref-for-live②">(2)</a>
     <li><a href="#ref-for-live③">9. Extensions to the Range Interface</a> <a href="#ref-for-live④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-open">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-open" class="dfn-panel" data-for="term-for-dom-open" id="infopanel-for-term-for-dom-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-open" style="display:none">Info about the 'open(url, target, features)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-open">4.1. The features argument to the open() method</a> <a href="#ref-for-dom-open①">(2)</a>
     <li><a href="#ref-for-dom-open②">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.1. The features argument to the open() method</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4.1. The features argument to the open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-mouseeventinit">
-   <a href="https://w3c.github.io/uievents/#dictdef-mouseeventinit">https://w3c.github.io/uievents/#dictdef-mouseeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-mouseeventinit" class="dfn-panel" data-for="term-for-dictdef-mouseeventinit" id="infopanel-for-term-for-dictdef-mouseeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-mouseeventinit" style="display:none">Info about the 'MouseEventInit' external reference.</span><a href="https://w3c.github.io/uievents/#dictdef-mouseeventinit">https://w3c.github.io/uievents/#dictdef-mouseeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mouseeventinit">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.2. The MediaQueryList Interface</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">4.3. The Screen Interface</a>
     <li><a href="#ref-for-Exposed③">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-NewObject①">5.1. The CaretPosition Interface</a>
@@ -5498,49 +5498,49 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-NewObject③">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Replaceable">
-   <a href="https://webidl.spec.whatwg.org/#Replaceable">https://webidl.spec.whatwg.org/#Replaceable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Replaceable" class="dfn-panel" data-for="term-for-Replaceable" id="infopanel-for-term-for-Replaceable" role="menu">
+   <span id="infopaneltitle-for-term-for-Replaceable" style="display:none">Info about the 'Replaceable' external reference.</span><a href="https://webidl.spec.whatwg.org/#Replaceable">https://webidl.spec.whatwg.org/#Replaceable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Replaceable">4. Extensions to the Window Interface</a> <a href="#ref-for-Replaceable①">(2)</a> <a href="#ref-for-Replaceable②">(3)</a> <a href="#ref-for-Replaceable③">(4)</a> <a href="#ref-for-Replaceable④">(5)</a> <a href="#ref-for-Replaceable⑤">(6)</a> <a href="#ref-for-Replaceable⑥">(7)</a> <a href="#ref-for-Replaceable⑦">(8)</a> <a href="#ref-for-Replaceable⑧">(9)</a> <a href="#ref-for-Replaceable⑨">(10)</a> <a href="#ref-for-Replaceable①⓪">(11)</a> <a href="#ref-for-Replaceable①①">(12)</a> <a href="#ref-for-Replaceable①②">(13)</a> <a href="#ref-for-Replaceable①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.2. The MediaQueryList Interface</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
     <li><a href="#ref-for-idl-boolean③">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-idl-sequence①">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4. Extensions to the Window Interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a> <a href="#ref-for-idl-undefined⑤">(6)</a> <a href="#ref-for-idl-undefined⑥">(7)</a> <a href="#ref-for-idl-undefined⑦">(8)</a> <a href="#ref-for-idl-undefined⑧">(9)</a> <a href="#ref-for-idl-undefined⑨">(10)</a>
     <li><a href="#ref-for-idl-undefined①⓪">4.2. The MediaQueryList Interface</a> <a href="#ref-for-idl-undefined①①">(2)</a>
     <li><a href="#ref-for-idl-undefined①②">6. Extensions to the Element Interface</a> <a href="#ref-for-idl-undefined①③">(2)</a> <a href="#ref-for-idl-undefined①④">(3)</a> <a href="#ref-for-idl-undefined①⑤">(4)</a> <a href="#ref-for-idl-undefined①⑥">(5)</a> <a href="#ref-for-idl-undefined①⑦">(6)</a> <a href="#ref-for-idl-undefined①⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">4. Extensions to the Window Interface</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a> <a href="#ref-for-idl-unrestricted-double②">(3)</a> <a href="#ref-for-idl-unrestricted-double③">(4)</a> <a href="#ref-for-idl-unrestricted-double④">(5)</a> <a href="#ref-for-idl-unrestricted-double⑤">(6)</a> <a href="#ref-for-idl-unrestricted-double⑥">(7)</a> <a href="#ref-for-idl-unrestricted-double⑦">(8)</a>
     <li><a href="#ref-for-idl-unrestricted-double⑧">6. Extensions to the Element Interface</a> <a href="#ref-for-idl-unrestricted-double⑨">(2)</a> <a href="#ref-for-idl-unrestricted-double①⓪">(3)</a> <a href="#ref-for-idl-unrestricted-double①①">(4)</a> <a href="#ref-for-idl-unrestricted-double①②">(5)</a> <a href="#ref-for-idl-unrestricted-double①③">(6)</a> <a href="#ref-for-idl-unrestricted-double①④">(7)</a> <a href="#ref-for-idl-unrestricted-double①⑤">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.3. The Screen Interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">5.1. The CaretPosition Interface</a>
@@ -6028,8 +6028,8 @@ the Windows Internet Explorer browser.</p>
    <div class="issue">... <a class="issue-return" href="#issue-2f43b42f②" title="Jump to section">↵</a></div>
    <div class="issue"> The features in this section should be moved to some other specification. <a class="issue-return" href="#issue-e12d69d6" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="the-html-body-element">
-   <b><a href="#the-html-body-element">#the-html-body-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-html-body-element" class="dfn-panel" data-for="the-html-body-element" id="infopanel-for-the-html-body-element" role="dialog">
+   <span id="infopaneltitle-for-the-html-body-element" style="display:none">Info about the 'The HTML body element' definition.</span><b><a href="#the-html-body-element">#the-html-body-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-html-body-element">2. Terminology</a>
     <li><a href="#ref-for-the-html-body-element①">5. Extensions to the Document Interface</a> <a href="#ref-for-the-html-body-element②">(2)</a> <a href="#ref-for-the-html-body-element③">(3)</a> <a href="#ref-for-the-html-body-element④">(4)</a> <a href="#ref-for-the-html-body-element⑤">(5)</a>
@@ -6037,8 +6037,8 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-the-html-body-element①⑤">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-the-html-body-element①⑥">(2)</a> <a href="#ref-for-the-html-body-element①⑦">(3)</a> <a href="#ref-for-the-html-body-element①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="padding-edge">
-   <b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-padding-edge" class="dfn-panel" data-for="padding-edge" id="infopanel-for-padding-edge" role="dialog">
+   <span id="infopaneltitle-for-padding-edge" style="display:none">Info about the 'padding edge' definition.</span><b><a href="#padding-edge">#padding-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-edge">2. Terminology</a> <a href="#ref-for-padding-edge①">(2)</a> <a href="#ref-for-padding-edge②">(3)</a> <a href="#ref-for-padding-edge③">(4)</a> <a href="#ref-for-padding-edge④">(5)</a> <a href="#ref-for-padding-edge⑤">(6)</a> <a href="#ref-for-padding-edge⑥">(7)</a> <a href="#ref-for-padding-edge⑦">(8)</a> <a href="#ref-for-padding-edge⑧">(9)</a> <a href="#ref-for-padding-edge⑨">(10)</a> <a href="#ref-for-padding-edge①⓪">(11)</a> <a href="#ref-for-padding-edge①①">(12)</a> <a href="#ref-for-padding-edge①②">(13)</a> <a href="#ref-for-padding-edge①③">(14)</a> <a href="#ref-for-padding-edge①④">(15)</a> <a href="#ref-for-padding-edge①⑤">(16)</a>
     <li><a href="#ref-for-padding-edge①⑥">6. Extensions to the Element Interface</a> <a href="#ref-for-padding-edge①⑦">(2)</a> <a href="#ref-for-padding-edge①⑧">(3)</a> <a href="#ref-for-padding-edge①⑨">(4)</a> <a href="#ref-for-padding-edge②⓪">(5)</a> <a href="#ref-for-padding-edge②①">(6)</a> <a href="#ref-for-padding-edge②②">(7)</a> <a href="#ref-for-padding-edge②③">(8)</a>
@@ -6047,22 +6047,22 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-padding-edge③⓪">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-padding-edge③①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="border-edge">
-   <b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-border-edge" class="dfn-panel" data-for="border-edge" id="infopanel-for-border-edge" role="dialog">
+   <span id="infopaneltitle-for-border-edge" style="display:none">Info about the 'border edge' definition.</span><b><a href="#border-edge">#border-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">6. Extensions to the Element Interface</a> <a href="#ref-for-border-edge①">(2)</a> <a href="#ref-for-border-edge②">(3)</a> <a href="#ref-for-border-edge③">(4)</a>
     <li><a href="#ref-for-border-edge④">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-border-edge⑤">(2)</a> <a href="#ref-for-border-edge⑥">(3)</a> <a href="#ref-for-border-edge⑦">(4)</a> <a href="#ref-for-border-edge⑧">(5)</a> <a href="#ref-for-border-edge⑨">(6)</a>
     <li><a href="#ref-for-border-edge①⓪">8. Extensions to the HTMLImageElement Interface</a> <a href="#ref-for-border-edge①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="margin-edge">
-   <b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-margin-edge" class="dfn-panel" data-for="margin-edge" id="infopanel-for-margin-edge" role="dialog">
+   <span id="infopaneltitle-for-margin-edge" style="display:none">Info about the 'margin edge' definition.</span><b><a href="#margin-edge">#margin-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-margin-edge">2. Terminology</a> <a href="#ref-for-margin-edge①">(2)</a> <a href="#ref-for-margin-edge②">(3)</a> <a href="#ref-for-margin-edge③">(4)</a> <a href="#ref-for-margin-edge④">(5)</a> <a href="#ref-for-margin-edge⑤">(6)</a> <a href="#ref-for-margin-edge⑥">(7)</a> <a href="#ref-for-margin-edge⑦">(8)</a> <a href="#ref-for-margin-edge⑧">(9)</a> <a href="#ref-for-margin-edge⑨">(10)</a> <a href="#ref-for-margin-edge①⓪">(11)</a> <a href="#ref-for-margin-edge①①">(12)</a> <a href="#ref-for-margin-edge①②">(13)</a> <a href="#ref-for-margin-edge①③">(14)</a> <a href="#ref-for-margin-edge①④">(15)</a> <a href="#ref-for-margin-edge①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="viewport">
-   <b><a href="#viewport">#viewport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-viewport" class="dfn-panel" data-for="viewport" id="infopanel-for-viewport" role="dialog">
+   <span id="infopaneltitle-for-viewport" style="display:none">Info about the 'viewport' definition.</span><b><a href="#viewport">#viewport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">2. Terminology</a> <a href="#ref-for-viewport①">(2)</a> <a href="#ref-for-viewport②">(3)</a> <a href="#ref-for-viewport③">(4)</a> <a href="#ref-for-viewport④">(5)</a> <a href="#ref-for-viewport⑤">(6)</a> <a href="#ref-for-viewport⑥">(7)</a> <a href="#ref-for-viewport⑦">(8)</a> <a href="#ref-for-viewport⑧">(9)</a> <a href="#ref-for-viewport⑨">(10)</a> <a href="#ref-for-viewport①⓪">(11)</a> <a href="#ref-for-viewport①①">(12)</a> <a href="#ref-for-viewport①②">(13)</a> <a href="#ref-for-viewport①③">(14)</a>
     <li><a href="#ref-for-viewport①④">2.3. Web-exposed screen information</a> <a href="#ref-for-viewport①⑤">(2)</a>
@@ -6078,8 +6078,8 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-viewport⑧⑥">13.1. Smooth Scrolling: The scroll-behavior Property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrolling-box">
-   <b><a href="#scrolling-box">#scrolling-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrolling-box" class="dfn-panel" data-for="scrolling-box" id="infopanel-for-scrolling-box" role="dialog">
+   <span id="infopaneltitle-for-scrolling-box" style="display:none">Info about the 'scrolling box' definition.</span><b><a href="#scrolling-box">#scrolling-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrolling-box">2. Terminology</a> <a href="#ref-for-scrolling-box①">(2)</a> <a href="#ref-for-scrolling-box②">(3)</a>
     <li><a href="#ref-for-scrolling-box③">3.1. Scrolling</a> <a href="#ref-for-scrolling-box④">(2)</a> <a href="#ref-for-scrolling-box⑤">(3)</a>
@@ -6088,24 +6088,24 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-scrolling-box①②">13.1. Smooth Scrolling: The scroll-behavior Property</a> <a href="#ref-for-scrolling-box①③">(2)</a> <a href="#ref-for-scrolling-box①④">(3)</a> <a href="#ref-for-scrolling-box①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="potentially-scrollable">
-   <b><a href="#potentially-scrollable">#potentially-scrollable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-potentially-scrollable" class="dfn-panel" data-for="potentially-scrollable" id="infopanel-for-potentially-scrollable" role="dialog">
+   <span id="infopaneltitle-for-potentially-scrollable" style="display:none">Info about the 'potentially scrollable' definition.</span><b><a href="#potentially-scrollable">#potentially-scrollable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-scrollable">2. Terminology</a>
     <li><a href="#ref-for-potentially-scrollable①">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-potentially-scrollable②">6. Extensions to the Element Interface</a> <a href="#ref-for-potentially-scrollable③">(2)</a> <a href="#ref-for-potentially-scrollable④">(3)</a> <a href="#ref-for-potentially-scrollable⑤">(4)</a> <a href="#ref-for-potentially-scrollable⑥">(5)</a> <a href="#ref-for-potentially-scrollable⑦">(6)</a> <a href="#ref-for-potentially-scrollable⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overflow-directions">
-   <b><a href="#overflow-directions">#overflow-directions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overflow-directions" class="dfn-panel" data-for="overflow-directions" id="infopanel-for-overflow-directions" role="dialog">
+   <span id="infopaneltitle-for-overflow-directions" style="display:none">Info about the 'overflow directions' definition.</span><b><a href="#overflow-directions">#overflow-directions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-directions">2. Terminology</a> <a href="#ref-for-overflow-directions①">(2)</a> <a href="#ref-for-overflow-directions②">(3)</a> <a href="#ref-for-overflow-directions③">(4)</a> <a href="#ref-for-overflow-directions④">(5)</a> <a href="#ref-for-overflow-directions⑤">(6)</a> <a href="#ref-for-overflow-directions⑥">(7)</a> <a href="#ref-for-overflow-directions⑦">(8)</a> <a href="#ref-for-overflow-directions⑧">(9)</a> <a href="#ref-for-overflow-directions⑨">(10)</a>
     <li><a href="#ref-for-overflow-directions①⓪">4. Extensions to the Window Interface</a> <a href="#ref-for-overflow-directions①①">(2)</a> <a href="#ref-for-overflow-directions①②">(3)</a> <a href="#ref-for-overflow-directions①③">(4)</a>
     <li><a href="#ref-for-overflow-directions①④">6.1. Element Scrolling Members</a> <a href="#ref-for-overflow-directions①⑤">(2)</a> <a href="#ref-for-overflow-directions①⑥">(3)</a> <a href="#ref-for-overflow-directions①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrolling-area">
-   <b><a href="#scrolling-area">#scrolling-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrolling-area" class="dfn-panel" data-for="scrolling-area" id="infopanel-for-scrolling-area" role="dialog">
+   <span id="infopaneltitle-for-scrolling-area" style="display:none">Info about the 'scrolling area' definition.</span><b><a href="#scrolling-area">#scrolling-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrolling-area">2. Terminology</a> <a href="#ref-for-scrolling-area①">(2)</a>
     <li><a href="#ref-for-scrolling-area②">3.1. Scrolling</a>
@@ -6114,21 +6114,21 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-scrolling-area①⑦">6.1. Element Scrolling Members</a> <a href="#ref-for-scrolling-area①⑧">(2)</a> <a href="#ref-for-scrolling-area①⑨">(3)</a> <a href="#ref-for-scrolling-area②⓪">(4)</a> <a href="#ref-for-scrolling-area②①">(5)</a> <a href="#ref-for-scrolling-area②②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="beginning-edges">
-   <b><a href="#beginning-edges">#beginning-edges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-beginning-edges" class="dfn-panel" data-for="beginning-edges" id="infopanel-for-beginning-edges" role="dialog">
+   <span id="infopaneltitle-for-beginning-edges" style="display:none">Info about the 'beginning edges' definition.</span><b><a href="#beginning-edges">#beginning-edges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-beginning-edges">3.1. Scrolling</a> <a href="#ref-for-beginning-edges①">(2)</a>
     <li><a href="#ref-for-beginning-edges②">6.1. Element Scrolling Members</a> <a href="#ref-for-beginning-edges③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ending-edges">
-   <b><a href="#ending-edges">#ending-edges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ending-edges" class="dfn-panel" data-for="ending-edges" id="infopanel-for-ending-edges" role="dialog">
+   <span id="infopaneltitle-for-ending-edges" style="display:none">Info about the 'ending edges' definition.</span><b><a href="#ending-edges">#ending-edges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ending-edges">6.1. Element Scrolling Members</a> <a href="#ref-for-ending-edges①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-layout-box">
-   <b><a href="#css-layout-box">#css-layout-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-layout-box" class="dfn-panel" data-for="css-layout-box" id="infopanel-for-css-layout-box" role="dialog">
+   <span id="infopaneltitle-for-css-layout-box" style="display:none">Info about the 'CSS layout box' definition.</span><b><a href="#css-layout-box">#css-layout-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-layout-box">2. Terminology</a> <a href="#ref-for-css-layout-box①">(2)</a> <a href="#ref-for-css-layout-box②">(3)</a> <a href="#ref-for-css-layout-box③">(4)</a>
     <li><a href="#ref-for-css-layout-box④">6. Extensions to the Element Interface</a> <a href="#ref-for-css-layout-box⑤">(2)</a> <a href="#ref-for-css-layout-box⑥">(3)</a> <a href="#ref-for-css-layout-box⑦">(4)</a> <a href="#ref-for-css-layout-box⑧">(5)</a> <a href="#ref-for-css-layout-box⑨">(6)</a> <a href="#ref-for-css-layout-box①⓪">(7)</a> <a href="#ref-for-css-layout-box①①">(8)</a> <a href="#ref-for-css-layout-box①②">(9)</a> <a href="#ref-for-css-layout-box①③">(10)</a> <a href="#ref-for-css-layout-box①④">(11)</a> <a href="#ref-for-css-layout-box①⑤">(12)</a> <a href="#ref-for-css-layout-box①⑥">(13)</a> <a href="#ref-for-css-layout-box①⑦">(14)</a> <a href="#ref-for-css-layout-box①⑧">(15)</a>
@@ -6136,22 +6136,22 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-css-layout-box③③">8. Extensions to the HTMLImageElement Interface</a> <a href="#ref-for-css-layout-box③④">(2)</a> <a href="#ref-for-css-layout-box③⑤">(3)</a> <a href="#ref-for-css-layout-box③⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svg-layout-box">
-   <b><a href="#svg-layout-box">#svg-layout-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svg-layout-box" class="dfn-panel" data-for="svg-layout-box" id="infopanel-for-svg-layout-box" role="dialog">
+   <span id="infopaneltitle-for-svg-layout-box" style="display:none">Info about the 'SVG layout box' definition.</span><b><a href="#svg-layout-box">#svg-layout-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svg-layout-box">2. Terminology</a> <a href="#ref-for-svg-layout-box①">(2)</a>
     <li><a href="#ref-for-svg-layout-box②">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-box">
-   <b><a href="#layout-box">#layout-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-box" class="dfn-panel" data-for="layout-box" id="infopanel-for-layout-box" role="dialog">
+   <span id="infopaneltitle-for-layout-box" style="display:none">Info about the 'layout box' definition.</span><b><a href="#layout-box">#layout-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-box">5. Extensions to the Document Interface</a> <a href="#ref-for-layout-box①">(2)</a>
     <li><a href="#ref-for-layout-box②">6. Extensions to the Element Interface</a> <a href="#ref-for-layout-box③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transforms">
-   <b><a href="#transforms">#transforms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transforms" class="dfn-panel" data-for="transforms" id="infopanel-for-transforms" role="dialog">
+   <span id="infopaneltitle-for-transforms" style="display:none">Info about the 'transforms' definition.</span><b><a href="#transforms">#transforms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transforms">5. Extensions to the Document Interface</a> <a href="#ref-for-transforms①">(2)</a> <a href="#ref-for-transforms②">(3)</a> <a href="#ref-for-transforms③">(4)</a> <a href="#ref-for-transforms④">(5)</a>
     <li><a href="#ref-for-transforms⑤">5.1. The CaretPosition Interface</a>
@@ -6163,22 +6163,22 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-transforms②③">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="page-zoom">
-   <b><a href="#page-zoom">#page-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-page-zoom" class="dfn-panel" data-for="page-zoom" id="infopanel-for-page-zoom" role="dialog">
+   <span id="infopaneltitle-for-page-zoom" style="display:none">Info about the 'page zoom' definition.</span><b><a href="#page-zoom">#page-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-zoom">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-page-zoom①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pinch-zoom">
-   <b><a href="#pinch-zoom">#pinch-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pinch-zoom" class="dfn-panel" data-for="pinch-zoom" id="infopanel-for-pinch-zoom" role="dialog">
+   <span id="infopaneltitle-for-pinch-zoom" style="display:none">Info about the 'pinch zoom' definition.</span><b><a href="#pinch-zoom">#pinch-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinch-zoom">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-pinch-zoom①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-exposed-screen-area">
-   <b><a href="#web-exposed-screen-area">#web-exposed-screen-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-exposed-screen-area" class="dfn-panel" data-for="web-exposed-screen-area" id="infopanel-for-web-exposed-screen-area" role="dialog">
+   <span id="infopaneltitle-for-web-exposed-screen-area" style="display:none">Info about the 'Web-exposed screen area' definition.</span><b><a href="#web-exposed-screen-area">#web-exposed-screen-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-exposed-screen-area">4. Extensions to the Window Interface</a> <a href="#ref-for-web-exposed-screen-area①">(2)</a>
     <li><a href="#ref-for-web-exposed-screen-area②">4.1. The features argument to the open() method</a> <a href="#ref-for-web-exposed-screen-area③">(2)</a>
@@ -6186,296 +6186,296 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-web-exposed-screen-area⑥">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-web-exposed-screen-area⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-exposed-available-screen-area">
-   <b><a href="#web-exposed-available-screen-area">#web-exposed-available-screen-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-exposed-available-screen-area" class="dfn-panel" data-for="web-exposed-available-screen-area" id="infopanel-for-web-exposed-available-screen-area" role="dialog">
+   <span id="infopaneltitle-for-web-exposed-available-screen-area" style="display:none">Info about the 'Web-exposed available screen area' definition.</span><b><a href="#web-exposed-available-screen-area">#web-exposed-available-screen-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-exposed-available-screen-area">4.1. The features argument to the open() method</a> <a href="#ref-for-web-exposed-available-screen-area①">(2)</a> <a href="#ref-for-web-exposed-available-screen-area②">(3)</a> <a href="#ref-for-web-exposed-available-screen-area③">(4)</a> <a href="#ref-for-web-exposed-available-screen-area④">(5)</a> <a href="#ref-for-web-exposed-available-screen-area⑤">(6)</a>
     <li><a href="#ref-for-web-exposed-available-screen-area⑥">4.3. The Screen Interface</a> <a href="#ref-for-web-exposed-available-screen-area⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="perform-a-scroll">
-   <b><a href="#perform-a-scroll">#perform-a-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-perform-a-scroll" class="dfn-panel" data-for="perform-a-scroll" id="infopanel-for-perform-a-scroll" role="dialog">
+   <span id="infopaneltitle-for-perform-a-scroll" style="display:none">Info about the 'perform a scroll' definition.</span><b><a href="#perform-a-scroll">#perform-a-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-scroll">3.1. Scrolling</a>
     <li><a href="#ref-for-perform-a-scroll①">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-perform-a-scroll②">6.1. Element Scrolling Members</a> <a href="#ref-for-perform-a-scroll③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-smooth-scroll">
-   <b><a href="#concept-smooth-scroll">#concept-smooth-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-smooth-scroll" class="dfn-panel" data-for="concept-smooth-scroll" id="infopanel-for-concept-smooth-scroll" role="dialog">
+   <span id="infopaneltitle-for-concept-smooth-scroll" style="display:none">Info about the 'smooth scroll' definition.</span><b><a href="#concept-smooth-scroll">#concept-smooth-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-smooth-scroll">3.1. Scrolling</a> <a href="#ref-for-concept-smooth-scroll①">(2)</a> <a href="#ref-for-concept-smooth-scroll②">(3)</a>
     <li><a href="#ref-for-concept-smooth-scroll③">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-concept-smooth-scroll④">6.1. Element Scrolling Members</a> <a href="#ref-for-concept-smooth-scroll⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="smooth-scroll-aborted">
-   <b><a href="#smooth-scroll-aborted">#smooth-scroll-aborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-smooth-scroll-aborted" class="dfn-panel" data-for="smooth-scroll-aborted" id="infopanel-for-smooth-scroll-aborted" role="dialog">
+   <span id="infopaneltitle-for-smooth-scroll-aborted" style="display:none">Info about the 'aborted' definition.</span><b><a href="#smooth-scroll-aborted">#smooth-scroll-aborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-smooth-scroll-aborted">3.1. Scrolling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-instant-scroll">
-   <b><a href="#concept-instant-scroll">#concept-instant-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-instant-scroll" class="dfn-panel" data-for="concept-instant-scroll" id="infopanel-for-concept-instant-scroll" role="dialog">
+   <span id="infopaneltitle-for-concept-instant-scroll" style="display:none">Info about the 'instant scroll' definition.</span><b><a href="#concept-instant-scroll">#concept-instant-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-instant-scroll">3.1. Scrolling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normalize-non-finite-values">
-   <b><a href="#normalize-non-finite-values">#normalize-non-finite-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalize-non-finite-values" class="dfn-panel" data-for="normalize-non-finite-values" id="infopanel-for-normalize-non-finite-values" role="dialog">
+   <span id="infopaneltitle-for-normalize-non-finite-values" style="display:none">Info about the 'normalize non-finite values' definition.</span><b><a href="#normalize-non-finite-values">#normalize-non-finite-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalize-non-finite-values">4. Extensions to the Window Interface</a> <a href="#ref-for-normalize-non-finite-values①">(2)</a>
     <li><a href="#ref-for-normalize-non-finite-values②">6. Extensions to the Element Interface</a> <a href="#ref-for-normalize-non-finite-values③">(2)</a> <a href="#ref-for-normalize-non-finite-values④">(3)</a> <a href="#ref-for-normalize-non-finite-values⑤">(4)</a> <a href="#ref-for-normalize-non-finite-values⑥">(5)</a> <a href="#ref-for-normalize-non-finite-values⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-scrollbehavior">
-   <b><a href="#enumdef-scrollbehavior">#enumdef-scrollbehavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-scrollbehavior" class="dfn-panel" data-for="enumdef-scrollbehavior" id="infopanel-for-enumdef-scrollbehavior" role="dialog">
+   <span id="infopaneltitle-for-enumdef-scrollbehavior" style="display:none">Info about the 'ScrollBehavior' definition.</span><b><a href="#enumdef-scrollbehavior">#enumdef-scrollbehavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-scrollbehavior">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-scrolloptions">
-   <b><a href="#dictdef-scrolloptions">#dictdef-scrolloptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-scrolloptions" class="dfn-panel" data-for="dictdef-scrolloptions" id="infopanel-for-dictdef-scrolloptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-scrolloptions" style="display:none">Info about the 'ScrollOptions' definition.</span><b><a href="#dictdef-scrolloptions">#dictdef-scrolloptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-scrolloptions">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dictdef-scrolloptions①">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolloptions-behavior">
-   <b><a href="#dom-scrolloptions-behavior">#dom-scrolloptions-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolloptions-behavior" class="dfn-panel" data-for="dom-scrolloptions-behavior" id="infopanel-for-dom-scrolloptions-behavior" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolloptions-behavior" style="display:none">Info about the 'behavior' definition.</span><b><a href="#dom-scrolloptions-behavior">#dom-scrolloptions-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolloptions-behavior">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-scrolloptions-behavior①">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-scrolloptions-behavior②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-scrolltooptions">
-   <b><a href="#dictdef-scrolltooptions">#dictdef-scrolltooptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-scrolltooptions" class="dfn-panel" data-for="dictdef-scrolltooptions" id="infopanel-for-dictdef-scrolltooptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-scrolltooptions" style="display:none">Info about the 'ScrollToOptions' definition.</span><b><a href="#dictdef-scrolltooptions">#dictdef-scrolltooptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-scrolltooptions">4. Extensions to the Window Interface</a> <a href="#ref-for-dictdef-scrolltooptions①">(2)</a> <a href="#ref-for-dictdef-scrolltooptions②">(3)</a> <a href="#ref-for-dictdef-scrolltooptions③">(4)</a> <a href="#ref-for-dictdef-scrolltooptions④">(5)</a>
     <li><a href="#ref-for-dictdef-scrolltooptions⑤">6. Extensions to the Element Interface</a> <a href="#ref-for-dictdef-scrolltooptions⑥">(2)</a> <a href="#ref-for-dictdef-scrolltooptions⑦">(3)</a> <a href="#ref-for-dictdef-scrolltooptions⑧">(4)</a> <a href="#ref-for-dictdef-scrolltooptions⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltooptions-left">
-   <b><a href="#dom-scrolltooptions-left">#dom-scrolltooptions-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltooptions-left" class="dfn-panel" data-for="dom-scrolltooptions-left" id="infopanel-for-dom-scrolltooptions-left" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltooptions-left" style="display:none">Info about the 'left' definition.</span><b><a href="#dom-scrolltooptions-left">#dom-scrolltooptions-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltooptions-left">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-scrolltooptions-left①">(2)</a> <a href="#ref-for-dom-scrolltooptions-left②">(3)</a> <a href="#ref-for-dom-scrolltooptions-left③">(4)</a>
     <li><a href="#ref-for-dom-scrolltooptions-left④">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-scrolltooptions-left⑤">(2)</a> <a href="#ref-for-dom-scrolltooptions-left⑥">(3)</a> <a href="#ref-for-dom-scrolltooptions-left⑦">(4)</a> <a href="#ref-for-dom-scrolltooptions-left⑧">(5)</a> <a href="#ref-for-dom-scrolltooptions-left⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltooptions-top">
-   <b><a href="#dom-scrolltooptions-top">#dom-scrolltooptions-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltooptions-top" class="dfn-panel" data-for="dom-scrolltooptions-top" id="infopanel-for-dom-scrolltooptions-top" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltooptions-top" style="display:none">Info about the 'top' definition.</span><b><a href="#dom-scrolltooptions-top">#dom-scrolltooptions-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltooptions-top">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-scrolltooptions-top①">(2)</a> <a href="#ref-for-dom-scrolltooptions-top②">(3)</a> <a href="#ref-for-dom-scrolltooptions-top③">(4)</a>
     <li><a href="#ref-for-dom-scrolltooptions-top④">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-scrolltooptions-top⑤">(2)</a> <a href="#ref-for-dom-scrolltooptions-top⑥">(3)</a> <a href="#ref-for-dom-scrolltooptions-top⑦">(4)</a> <a href="#ref-for-dom-scrolltooptions-top⑧">(5)</a> <a href="#ref-for-dom-scrolltooptions-top⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-matchmedia">
-   <b><a href="#dom-window-matchmedia">#dom-window-matchmedia</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-matchmedia" class="dfn-panel" data-for="dom-window-matchmedia" id="infopanel-for-dom-window-matchmedia" role="dialog">
+   <span id="infopaneltitle-for-dom-window-matchmedia" style="display:none">Info about the 'matchMedia(query)' definition.</span><b><a href="#dom-window-matchmedia">#dom-window-matchmedia</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-matchmedia">2.1. CSS pixels</a>
     <li><a href="#ref-for-dom-window-matchmedia①">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-screen">
-   <b><a href="#dom-window-screen">#dom-window-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-screen" class="dfn-panel" data-for="dom-window-screen" id="infopanel-for-dom-window-screen" role="dialog">
+   <span id="infopaneltitle-for-dom-window-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#dom-window-screen">#dom-window-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-screen">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-screen①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-moveto">
-   <b><a href="#dom-window-moveto">#dom-window-moveto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-moveto" class="dfn-panel" data-for="dom-window-moveto" id="infopanel-for-dom-window-moveto" role="dialog">
+   <span id="infopaneltitle-for-dom-window-moveto" style="display:none">Info about the 'moveTo(x, y)' definition.</span><b><a href="#dom-window-moveto">#dom-window-moveto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-moveto">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-moveto①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-moveby">
-   <b><a href="#dom-window-moveby">#dom-window-moveby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-moveby" class="dfn-panel" data-for="dom-window-moveby" id="infopanel-for-dom-window-moveby" role="dialog">
+   <span id="infopaneltitle-for-dom-window-moveby" style="display:none">Info about the 'moveBy(x, y)' definition.</span><b><a href="#dom-window-moveby">#dom-window-moveby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-moveby">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-moveby①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-resizeto">
-   <b><a href="#dom-window-resizeto">#dom-window-resizeto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-resizeto" class="dfn-panel" data-for="dom-window-resizeto" id="infopanel-for-dom-window-resizeto" role="dialog">
+   <span id="infopaneltitle-for-dom-window-resizeto" style="display:none">Info about the 'resizeTo(width, height)' definition.</span><b><a href="#dom-window-resizeto">#dom-window-resizeto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-resizeto">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-resizeto①">Changes From 31 January 2020</a>
     <li><a href="#ref-for-dom-window-resizeto②">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-resizeby">
-   <b><a href="#dom-window-resizeby">#dom-window-resizeby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-resizeby" class="dfn-panel" data-for="dom-window-resizeby" id="infopanel-for-dom-window-resizeby" role="dialog">
+   <span id="infopaneltitle-for-dom-window-resizeby" style="display:none">Info about the 'resizeBy(x, y)' definition.</span><b><a href="#dom-window-resizeby">#dom-window-resizeby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-resizeby">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-resizeby①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-to-resize-and-move">
-   <b><a href="#allowed-to-resize-and-move">#allowed-to-resize-and-move</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-to-resize-and-move" class="dfn-panel" data-for="allowed-to-resize-and-move" id="infopanel-for-allowed-to-resize-and-move" role="dialog">
+   <span id="infopaneltitle-for-allowed-to-resize-and-move" style="display:none">Info about the 'allowed to resize and move' definition.</span><b><a href="#allowed-to-resize-and-move">#allowed-to-resize-and-move</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-resize-and-move">4. Extensions to the Window Interface</a> <a href="#ref-for-allowed-to-resize-and-move①">(2)</a> <a href="#ref-for-allowed-to-resize-and-move②">(3)</a> <a href="#ref-for-allowed-to-resize-and-move③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-innerwidth">
-   <b><a href="#dom-window-innerwidth">#dom-window-innerwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-innerwidth" class="dfn-panel" data-for="dom-window-innerwidth" id="infopanel-for-dom-window-innerwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-window-innerwidth" style="display:none">Info about the 'innerWidth' definition.</span><b><a href="#dom-window-innerwidth">#dom-window-innerwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-innerwidth">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-innerwidth①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-innerheight">
-   <b><a href="#dom-window-innerheight">#dom-window-innerheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-innerheight" class="dfn-panel" data-for="dom-window-innerheight" id="infopanel-for-dom-window-innerheight" role="dialog">
+   <span id="infopaneltitle-for-dom-window-innerheight" style="display:none">Info about the 'innerHeight' definition.</span><b><a href="#dom-window-innerheight">#dom-window-innerheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-innerheight">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-scrollx">
-   <b><a href="#dom-window-scrollx">#dom-window-scrollx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-scrollx" class="dfn-panel" data-for="dom-window-scrollx" id="infopanel-for-dom-window-scrollx" role="dialog">
+   <span id="infopaneltitle-for-dom-window-scrollx" style="display:none">Info about the 'scrollX' definition.</span><b><a href="#dom-window-scrollx">#dom-window-scrollx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrollx">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-scrollx①">(2)</a> <a href="#ref-for-dom-window-scrollx②">(3)</a>
     <li><a href="#ref-for-dom-window-scrollx③">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-window-scrollx④">(2)</a> <a href="#ref-for-dom-window-scrollx⑤">(3)</a> <a href="#ref-for-dom-window-scrollx⑥">(4)</a> <a href="#ref-for-dom-window-scrollx⑦">(5)</a>
     <li><a href="#ref-for-dom-window-scrollx⑧">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-pagexoffset">
-   <b><a href="#dom-window-pagexoffset">#dom-window-pagexoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-pagexoffset" class="dfn-panel" data-for="dom-window-pagexoffset" id="infopanel-for-dom-window-pagexoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-window-pagexoffset" style="display:none">Info about the 'pageXOffset' definition.</span><b><a href="#dom-window-pagexoffset">#dom-window-pagexoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-pagexoffset">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-scrolly">
-   <b><a href="#dom-window-scrolly">#dom-window-scrolly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-scrolly" class="dfn-panel" data-for="dom-window-scrolly" id="infopanel-for-dom-window-scrolly" role="dialog">
+   <span id="infopaneltitle-for-dom-window-scrolly" style="display:none">Info about the 'scrollY' definition.</span><b><a href="#dom-window-scrolly">#dom-window-scrolly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrolly">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-scrolly①">(2)</a> <a href="#ref-for-dom-window-scrolly②">(3)</a>
     <li><a href="#ref-for-dom-window-scrolly③">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-window-scrolly④">(2)</a> <a href="#ref-for-dom-window-scrolly⑤">(3)</a> <a href="#ref-for-dom-window-scrolly⑥">(4)</a>
     <li><a href="#ref-for-dom-window-scrolly⑦">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-pageyoffset">
-   <b><a href="#dom-window-pageyoffset">#dom-window-pageyoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-pageyoffset" class="dfn-panel" data-for="dom-window-pageyoffset" id="infopanel-for-dom-window-pageyoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-window-pageyoffset" style="display:none">Info about the 'pageYOffset' definition.</span><b><a href="#dom-window-pageyoffset">#dom-window-pageyoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-pageyoffset">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-scroll">
-   <b><a href="#dom-window-scroll">#dom-window-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-scroll" class="dfn-panel" data-for="dom-window-scroll" id="infopanel-for-dom-window-scroll" role="dialog">
+   <span id="infopaneltitle-for-dom-window-scroll" style="display:none">Info about the 'scroll()' definition.</span><b><a href="#dom-window-scroll">#dom-window-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scroll">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-scroll①">(2)</a> <a href="#ref-for-dom-window-scroll②">(3)</a> <a href="#ref-for-dom-window-scroll③">(4)</a>
     <li><a href="#ref-for-dom-window-scroll④">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-window-scroll⑤">(2)</a> <a href="#ref-for-dom-window-scroll⑥">(3)</a> <a href="#ref-for-dom-window-scroll⑦">(4)</a> <a href="#ref-for-dom-window-scroll⑧">(5)</a> <a href="#ref-for-dom-window-scroll⑨">(6)</a>
     <li><a href="#ref-for-dom-window-scroll①⓪">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-scrollto">
-   <b><a href="#dom-window-scrollto">#dom-window-scrollto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-scrollto" class="dfn-panel" data-for="dom-window-scrollto" id="infopanel-for-dom-window-scrollto" role="dialog">
+   <span id="infopaneltitle-for-dom-window-scrollto" style="display:none">Info about the 'scrollTo()' definition.</span><b><a href="#dom-window-scrollto">#dom-window-scrollto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrollto">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-scrollto①">(2)</a>
     <li><a href="#ref-for-dom-window-scrollto②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-scrollby">
-   <b><a href="#dom-window-scrollby">#dom-window-scrollby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-scrollby" class="dfn-panel" data-for="dom-window-scrollby" id="infopanel-for-dom-window-scrollby" role="dialog">
+   <span id="infopaneltitle-for-dom-window-scrollby" style="display:none">Info about the 'scrollBy()' definition.</span><b><a href="#dom-window-scrollby">#dom-window-scrollby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-scrollby">4. Extensions to the Window Interface</a> <a href="#ref-for-dom-window-scrollby①">(2)</a>
     <li><a href="#ref-for-dom-window-scrollby②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-screenx">
-   <b><a href="#dom-window-screenx">#dom-window-screenx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-screenx" class="dfn-panel" data-for="dom-window-screenx" id="infopanel-for-dom-window-screenx" role="dialog">
+   <span id="infopaneltitle-for-dom-window-screenx" style="display:none">Info about the 'screenX' definition.</span><b><a href="#dom-window-screenx">#dom-window-screenx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-screenx">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-screenleft">
-   <b><a href="#dom-window-screenleft">#dom-window-screenleft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-screenleft" class="dfn-panel" data-for="dom-window-screenleft" id="infopanel-for-dom-window-screenleft" role="dialog">
+   <span id="infopaneltitle-for-dom-window-screenleft" style="display:none">Info about the 'screenLeft' definition.</span><b><a href="#dom-window-screenleft">#dom-window-screenleft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-screenleft">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-screeny">
-   <b><a href="#dom-window-screeny">#dom-window-screeny</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-screeny" class="dfn-panel" data-for="dom-window-screeny" id="infopanel-for-dom-window-screeny" role="dialog">
+   <span id="infopaneltitle-for-dom-window-screeny" style="display:none">Info about the 'screenY' definition.</span><b><a href="#dom-window-screeny">#dom-window-screeny</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-screeny">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-screentop">
-   <b><a href="#dom-window-screentop">#dom-window-screentop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-screentop" class="dfn-panel" data-for="dom-window-screentop" id="infopanel-for-dom-window-screentop" role="dialog">
+   <span id="infopaneltitle-for-dom-window-screentop" style="display:none">Info about the 'screenTop' definition.</span><b><a href="#dom-window-screentop">#dom-window-screentop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-screentop">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-outerwidth">
-   <b><a href="#dom-window-outerwidth">#dom-window-outerwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-outerwidth" class="dfn-panel" data-for="dom-window-outerwidth" id="infopanel-for-dom-window-outerwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-window-outerwidth" style="display:none">Info about the 'outerWidth' definition.</span><b><a href="#dom-window-outerwidth">#dom-window-outerwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-outerwidth">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-outerheight">
-   <b><a href="#dom-window-outerheight">#dom-window-outerheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-outerheight" class="dfn-panel" data-for="dom-window-outerheight" id="infopanel-for-dom-window-outerheight" role="dialog">
+   <span id="infopaneltitle-for-dom-window-outerheight" style="display:none">Info about the 'outerHeight' definition.</span><b><a href="#dom-window-outerheight">#dom-window-outerheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-outerheight">4. Extensions to the Window Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-devicepixelratio">
-   <b><a href="#dom-window-devicepixelratio">#dom-window-devicepixelratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-devicepixelratio" class="dfn-panel" data-for="dom-window-devicepixelratio" id="infopanel-for-dom-window-devicepixelratio" role="dialog">
+   <span id="infopaneltitle-for-dom-window-devicepixelratio" style="display:none">Info about the 'devicePixelRatio' definition.</span><b><a href="#dom-window-devicepixelratio">#dom-window-devicepixelratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-devicepixelratio">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-dom-window-devicepixelratio①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-open-feature-name-width">
-   <b><a href="#supported-open-feature-name-width">#supported-open-feature-name-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-open-feature-name-width" class="dfn-panel" data-for="supported-open-feature-name-width" id="infopanel-for-supported-open-feature-name-width" role="dialog">
+   <span id="infopaneltitle-for-supported-open-feature-name-width" style="display:none">Info about the 'width' definition.</span><b><a href="#supported-open-feature-name-width">#supported-open-feature-name-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-open-feature-name-width">4.1. The features argument to the open() method</a> <a href="#ref-for-supported-open-feature-name-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-open-feature-name-height">
-   <b><a href="#supported-open-feature-name-height">#supported-open-feature-name-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-open-feature-name-height" class="dfn-panel" data-for="supported-open-feature-name-height" id="infopanel-for-supported-open-feature-name-height" role="dialog">
+   <span id="infopaneltitle-for-supported-open-feature-name-height" style="display:none">Info about the 'height' definition.</span><b><a href="#supported-open-feature-name-height">#supported-open-feature-name-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-open-feature-name-height">4.1. The features argument to the open() method</a> <a href="#ref-for-supported-open-feature-name-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-open-feature-name-left">
-   <b><a href="#supported-open-feature-name-left">#supported-open-feature-name-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-open-feature-name-left" class="dfn-panel" data-for="supported-open-feature-name-left" id="infopanel-for-supported-open-feature-name-left" role="dialog">
+   <span id="infopaneltitle-for-supported-open-feature-name-left" style="display:none">Info about the 'left' definition.</span><b><a href="#supported-open-feature-name-left">#supported-open-feature-name-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-open-feature-name-left">4.1. The features argument to the open() method</a> <a href="#ref-for-supported-open-feature-name-left①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-open-feature-name-top">
-   <b><a href="#supported-open-feature-name-top">#supported-open-feature-name-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-open-feature-name-top" class="dfn-panel" data-for="supported-open-feature-name-top" id="infopanel-for-supported-open-feature-name-top" role="dialog">
+   <span id="infopaneltitle-for-supported-open-feature-name-top" style="display:none">Info about the 'top' definition.</span><b><a href="#supported-open-feature-name-top">#supported-open-feature-name-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-open-feature-name-top">4.1. The features argument to the open() method</a> <a href="#ref-for-supported-open-feature-name-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-query-list">
-   <b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query-list" class="dfn-panel" data-for="media-query-list" id="infopanel-for-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-media-query-list" style="display:none">Info about the 'media query list' definition.</span><b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-list">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-media-query-list①">4.2. The MediaQueryList Interface</a> <a href="#ref-for-media-query-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaquerylist-document">
-   <b><a href="#mediaquerylist-document">#mediaquerylist-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaquerylist-document" class="dfn-panel" data-for="mediaquerylist-document" id="infopanel-for-mediaquerylist-document" role="dialog">
+   <span id="infopaneltitle-for-mediaquerylist-document" style="display:none">Info about the 'document' definition.</span><b><a href="#mediaquerylist-document">#mediaquerylist-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaquerylist-document">4. Extensions to the Window Interface</a>
     <li><a href="#ref-for-mediaquerylist-document①">4.2. The MediaQueryList Interface</a> <a href="#ref-for-mediaquerylist-document②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaquerylist-media">
-   <b><a href="#mediaquerylist-media">#mediaquerylist-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaquerylist-media" class="dfn-panel" data-for="mediaquerylist-media" id="infopanel-for-mediaquerylist-media" role="dialog">
+   <span id="infopaneltitle-for-mediaquerylist-media" style="display:none">Info about the 'media' definition.</span><b><a href="#mediaquerylist-media">#mediaquerylist-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaquerylist-media">4.2. The MediaQueryList Interface</a> <a href="#ref-for-mediaquerylist-media①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaquerylist-matches-state">
-   <b><a href="#mediaquerylist-matches-state">#mediaquerylist-matches-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaquerylist-matches-state" class="dfn-panel" data-for="mediaquerylist-matches-state" id="infopanel-for-mediaquerylist-matches-state" role="dialog">
+   <span id="infopaneltitle-for-mediaquerylist-matches-state" style="display:none">Info about the 'matches state' definition.</span><b><a href="#mediaquerylist-matches-state">#mediaquerylist-matches-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaquerylist-matches-state">4.2. The MediaQueryList Interface</a> <a href="#ref-for-mediaquerylist-matches-state①">(2)</a> <a href="#ref-for-mediaquerylist-matches-state②">(3)</a>
     <li><a href="#ref-for-mediaquerylist-matches-state③">4.2.1. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaquerylist">
-   <b><a href="#mediaquerylist">#mediaquerylist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaquerylist" class="dfn-panel" data-for="mediaquerylist" id="infopanel-for-mediaquerylist" role="dialog">
+   <span id="infopaneltitle-for-mediaquerylist" style="display:none">Info about the 'MediaQueryList' definition.</span><b><a href="#mediaquerylist">#mediaquerylist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaquerylist">4. Extensions to the Window Interface</a> <a href="#ref-for-mediaquerylist①">(2)</a>
     <li><a href="#ref-for-mediaquerylist②">4.2. The MediaQueryList Interface</a> <a href="#ref-for-mediaquerylist③">(2)</a> <a href="#ref-for-mediaquerylist④">(3)</a> <a href="#ref-for-mediaquerylist⑤">(4)</a> <a href="#ref-for-mediaquerylist⑥">(5)</a> <a href="#ref-for-mediaquerylist⑦">(6)</a> <a href="#ref-for-mediaquerylist⑧">(7)</a>
@@ -6483,69 +6483,69 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-mediaquerylist①①">Changes From 17 December 2013 To 31 January 2020</a> <a href="#ref-for-mediaquerylist①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylist-media">
-   <b><a href="#dom-mediaquerylist-media">#dom-mediaquerylist-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylist-media" class="dfn-panel" data-for="dom-mediaquerylist-media" id="infopanel-for-dom-mediaquerylist-media" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylist-media" style="display:none">Info about the 'media' definition.</span><b><a href="#dom-mediaquerylist-media">#dom-mediaquerylist-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylist-media">4.2. The MediaQueryList Interface</a> <a href="#ref-for-dom-mediaquerylist-media①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylist-matches">
-   <b><a href="#dom-mediaquerylist-matches">#dom-mediaquerylist-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylist-matches" class="dfn-panel" data-for="dom-mediaquerylist-matches" id="infopanel-for-dom-mediaquerylist-matches" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylist-matches" style="display:none">Info about the 'matches' definition.</span><b><a href="#dom-mediaquerylist-matches">#dom-mediaquerylist-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylist-matches">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylist-addlistener">
-   <b><a href="#dom-mediaquerylist-addlistener">#dom-mediaquerylist-addlistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylist-addlistener" class="dfn-panel" data-for="dom-mediaquerylist-addlistener" id="infopanel-for-dom-mediaquerylist-addlistener" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylist-addlistener" style="display:none">Info about the 'addListener(callback)' definition.</span><b><a href="#dom-mediaquerylist-addlistener">#dom-mediaquerylist-addlistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylist-addlistener">4.2. The MediaQueryList Interface</a> <a href="#ref-for-dom-mediaquerylist-addlistener①">(2)</a> <a href="#ref-for-dom-mediaquerylist-addlistener②">(3)</a>
     <li><a href="#ref-for-dom-mediaquerylist-addlistener③">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylist-removelistener">
-   <b><a href="#dom-mediaquerylist-removelistener">#dom-mediaquerylist-removelistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylist-removelistener" class="dfn-panel" data-for="dom-mediaquerylist-removelistener" id="infopanel-for-dom-mediaquerylist-removelistener" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylist-removelistener" style="display:none">Info about the 'removeListener(callback)' definition.</span><b><a href="#dom-mediaquerylist-removelistener">#dom-mediaquerylist-removelistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylist-removelistener">4.2. The MediaQueryList Interface</a> <a href="#ref-for-dom-mediaquerylist-removelistener①">(2)</a> <a href="#ref-for-dom-mediaquerylist-removelistener②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylist-onchange">
-   <b><a href="#dom-mediaquerylist-onchange">#dom-mediaquerylist-onchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylist-onchange" class="dfn-panel" data-for="dom-mediaquerylist-onchange" id="infopanel-for-dom-mediaquerylist-onchange" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylist-onchange" style="display:none">Info about the 'onchange' definition.</span><b><a href="#dom-mediaquerylist-onchange">#dom-mediaquerylist-onchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylist-onchange">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediaquerylistevent">
-   <b><a href="#mediaquerylistevent">#mediaquerylistevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediaquerylistevent" class="dfn-panel" data-for="mediaquerylistevent" id="infopanel-for-mediaquerylistevent" role="dialog">
+   <span id="infopaneltitle-for-mediaquerylistevent" style="display:none">Info about the 'MediaQueryListEvent' definition.</span><b><a href="#mediaquerylistevent">#mediaquerylistevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediaquerylistevent">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediaquerylisteventinit">
-   <b><a href="#dictdef-mediaquerylisteventinit">#dictdef-mediaquerylisteventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediaquerylisteventinit" class="dfn-panel" data-for="dictdef-mediaquerylisteventinit" id="infopanel-for-dictdef-mediaquerylisteventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediaquerylisteventinit" style="display:none">Info about the 'MediaQueryListEventInit' definition.</span><b><a href="#dictdef-mediaquerylisteventinit">#dictdef-mediaquerylisteventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediaquerylisteventinit">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylistevent-media">
-   <b><a href="#dom-mediaquerylistevent-media">#dom-mediaquerylistevent-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylistevent-media" class="dfn-panel" data-for="dom-mediaquerylistevent-media" id="infopanel-for-dom-mediaquerylistevent-media" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylistevent-media" style="display:none">Info about the 'media' definition.</span><b><a href="#dom-mediaquerylistevent-media">#dom-mediaquerylistevent-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylistevent-media">4.2. The MediaQueryList Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaquerylistevent-matches">
-   <b><a href="#dom-mediaquerylistevent-matches">#dom-mediaquerylistevent-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaquerylistevent-matches" class="dfn-panel" data-for="dom-mediaquerylistevent-matches" id="infopanel-for-dom-mediaquerylistevent-matches" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaquerylistevent-matches" style="display:none">Info about the 'matches' definition.</span><b><a href="#dom-mediaquerylistevent-matches">#dom-mediaquerylistevent-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaquerylistevent-matches">4.2. The MediaQueryList Interface</a> <a href="#ref-for-dom-mediaquerylistevent-matches①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediaquerylist-change">
-   <b><a href="#eventdef-mediaquerylist-change">#eventdef-mediaquerylist-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediaquerylist-change" class="dfn-panel" data-for="eventdef-mediaquerylist-change" id="infopanel-for-eventdef-mediaquerylist-change" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediaquerylist-change" style="display:none">Info about the 'change' definition.</span><b><a href="#eventdef-mediaquerylist-change">#eventdef-mediaquerylist-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediaquerylist-change">4.2. The MediaQueryList Interface</a> <a href="#ref-for-eventdef-mediaquerylist-change①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="screen">
-   <b><a href="#screen">#screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-screen" class="dfn-panel" data-for="screen" id="infopanel-for-screen" role="dialog">
+   <span id="infopaneltitle-for-screen" style="display:none">Info about the 'Screen' definition.</span><b><a href="#screen">#screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screen">4. Extensions to the Window Interface</a> <a href="#ref-for-screen①">(2)</a>
     <li><a href="#ref-for-screen②">4.3. The Screen Interface</a> <a href="#ref-for-screen③">(2)</a>
@@ -6553,449 +6553,449 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-screen⑤">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-availwidth">
-   <b><a href="#dom-screen-availwidth">#dom-screen-availwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-availwidth" class="dfn-panel" data-for="dom-screen-availwidth" id="infopanel-for-dom-screen-availwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-availwidth" style="display:none">Info about the 'availWidth' definition.</span><b><a href="#dom-screen-availwidth">#dom-screen-availwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-availwidth">4.3. The Screen Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-availheight">
-   <b><a href="#dom-screen-availheight">#dom-screen-availheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-availheight" class="dfn-panel" data-for="dom-screen-availheight" id="infopanel-for-dom-screen-availheight" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-availheight" style="display:none">Info about the 'availHeight' definition.</span><b><a href="#dom-screen-availheight">#dom-screen-availheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-availheight">4.3. The Screen Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-width">
-   <b><a href="#dom-screen-width">#dom-screen-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-width" class="dfn-panel" data-for="dom-screen-width" id="infopanel-for-dom-screen-width" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-screen-width">#dom-screen-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-width">4.3. The Screen Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-height">
-   <b><a href="#dom-screen-height">#dom-screen-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-height" class="dfn-panel" data-for="dom-screen-height" id="infopanel-for-dom-screen-height" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-screen-height">#dom-screen-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-height">4.3. The Screen Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-colordepth">
-   <b><a href="#dom-screen-colordepth">#dom-screen-colordepth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-colordepth" class="dfn-panel" data-for="dom-screen-colordepth" id="infopanel-for-dom-screen-colordepth" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-colordepth" style="display:none">Info about the 'colorDepth' definition.</span><b><a href="#dom-screen-colordepth">#dom-screen-colordepth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-colordepth">4.3. The Screen Interface</a> <a href="#ref-for-dom-screen-colordepth①">(2)</a>
     <li><a href="#ref-for-dom-screen-colordepth②">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-screen-pixeldepth">
-   <b><a href="#dom-screen-pixeldepth">#dom-screen-pixeldepth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-screen-pixeldepth" class="dfn-panel" data-for="dom-screen-pixeldepth" id="infopanel-for-dom-screen-pixeldepth" role="dialog">
+   <span id="infopaneltitle-for-dom-screen-pixeldepth" style="display:none">Info about the 'pixelDepth' definition.</span><b><a href="#dom-screen-pixeldepth">#dom-screen-pixeldepth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-screen-pixeldepth">4.3. The Screen Interface</a> <a href="#ref-for-dom-screen-pixeldepth①">(2)</a>
     <li><a href="#ref-for-dom-screen-pixeldepth②">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-elementfrompoint">
-   <b><a href="#dom-document-elementfrompoint">#dom-document-elementfrompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-elementfrompoint" class="dfn-panel" data-for="dom-document-elementfrompoint" id="infopanel-for-dom-document-elementfrompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-document-elementfrompoint" style="display:none">Info about the 'elementFromPoint(x, y)' definition.</span><b><a href="#dom-document-elementfrompoint">#dom-document-elementfrompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-elementfrompoint">5. Extensions to the Document Interface</a> <a href="#ref-for-dom-document-elementfrompoint①">(2)</a> <a href="#ref-for-dom-document-elementfrompoint②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-elementsfrompoint">
-   <b><a href="#dom-document-elementsfrompoint">#dom-document-elementsfrompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-elementsfrompoint" class="dfn-panel" data-for="dom-document-elementsfrompoint" id="infopanel-for-dom-document-elementsfrompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-document-elementsfrompoint" style="display:none">Info about the 'elementsFromPoint(x, y)' definition.</span><b><a href="#dom-document-elementsfrompoint">#dom-document-elementsfrompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-elementsfrompoint">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-dom-document-elementsfrompoint①">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-caretpositionfrompoint">
-   <b><a href="#dom-document-caretpositionfrompoint">#dom-document-caretpositionfrompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-caretpositionfrompoint" class="dfn-panel" data-for="dom-document-caretpositionfrompoint" id="infopanel-for-dom-document-caretpositionfrompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-document-caretpositionfrompoint" style="display:none">Info about the 'caretPositionFromPoint(x, y)' definition.</span><b><a href="#dom-document-caretpositionfrompoint">#dom-document-caretpositionfrompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-caretpositionfrompoint">5. Extensions to the Document Interface</a> <a href="#ref-for-dom-document-caretpositionfrompoint①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-scrollingelement">
-   <b><a href="#dom-document-scrollingelement">#dom-document-scrollingelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-scrollingelement" class="dfn-panel" data-for="dom-document-scrollingelement" id="infopanel-for-dom-document-scrollingelement" role="dialog">
+   <span id="infopaneltitle-for-dom-document-scrollingelement" style="display:none">Info about the 'scrollingElement' definition.</span><b><a href="#dom-document-scrollingelement">#dom-document-scrollingelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-scrollingelement">5. Extensions to the Document Interface</a> <a href="#ref-for-dom-document-scrollingelement①">(2)</a>
     <li><a href="#ref-for-dom-document-scrollingelement②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="caret-position">
-   <b><a href="#caret-position">#caret-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-caret-position" class="dfn-panel" data-for="caret-position" id="infopanel-for-caret-position" role="dialog">
+   <span id="infopaneltitle-for-caret-position" style="display:none">Info about the 'caret position' definition.</span><b><a href="#caret-position">#caret-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-caret-position">5. Extensions to the Document Interface</a> <a href="#ref-for-caret-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="caret-node">
-   <b><a href="#caret-node">#caret-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-caret-node" class="dfn-panel" data-for="caret-node" id="infopanel-for-caret-node" role="dialog">
+   <span id="infopaneltitle-for-caret-node" style="display:none">Info about the 'caret node' definition.</span><b><a href="#caret-node">#caret-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-caret-node">5. Extensions to the Document Interface</a> <a href="#ref-for-caret-node①">(2)</a>
     <li><a href="#ref-for-caret-node②">5.1. The CaretPosition Interface</a> <a href="#ref-for-caret-node③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="caret-offset">
-   <b><a href="#caret-offset">#caret-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-caret-offset" class="dfn-panel" data-for="caret-offset" id="infopanel-for-caret-offset" role="dialog">
+   <span id="infopaneltitle-for-caret-offset" style="display:none">Info about the 'caret offset' definition.</span><b><a href="#caret-offset">#caret-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-caret-offset">5. Extensions to the Document Interface</a> <a href="#ref-for-caret-offset①">(2)</a>
     <li><a href="#ref-for-caret-offset②">5.1. The CaretPosition Interface</a> <a href="#ref-for-caret-offset③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="caret-range">
-   <b><a href="#caret-range">#caret-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-caret-range" class="dfn-panel" data-for="caret-range" id="infopanel-for-caret-range" role="dialog">
+   <span id="infopaneltitle-for-caret-range" style="display:none">Info about the 'caret range' definition.</span><b><a href="#caret-range">#caret-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-caret-range">5. Extensions to the Document Interface</a> <a href="#ref-for-caret-range①">(2)</a> <a href="#ref-for-caret-range②">(3)</a> <a href="#ref-for-caret-range③">(4)</a>
     <li><a href="#ref-for-caret-range④">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="caretposition">
-   <b><a href="#caretposition">#caretposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-caretposition" class="dfn-panel" data-for="caretposition" id="infopanel-for-caretposition" role="dialog">
+   <span id="infopaneltitle-for-caretposition" style="display:none">Info about the 'CaretPosition' definition.</span><b><a href="#caretposition">#caretposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-caretposition">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-caretposition①">5.1. The CaretPosition Interface</a> <a href="#ref-for-caretposition②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-caretposition-offsetnode">
-   <b><a href="#dom-caretposition-offsetnode">#dom-caretposition-offsetnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-caretposition-offsetnode" class="dfn-panel" data-for="dom-caretposition-offsetnode" id="infopanel-for-dom-caretposition-offsetnode" role="dialog">
+   <span id="infopaneltitle-for-dom-caretposition-offsetnode" style="display:none">Info about the 'offsetNode' definition.</span><b><a href="#dom-caretposition-offsetnode">#dom-caretposition-offsetnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-caretposition-offsetnode">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-caretposition-offset">
-   <b><a href="#dom-caretposition-offset">#dom-caretposition-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-caretposition-offset" class="dfn-panel" data-for="dom-caretposition-offset" id="infopanel-for-dom-caretposition-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-caretposition-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-caretposition-offset">#dom-caretposition-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-caretposition-offset">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-caretposition-getclientrect">
-   <b><a href="#dom-caretposition-getclientrect">#dom-caretposition-getclientrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-caretposition-getclientrect" class="dfn-panel" data-for="dom-caretposition-getclientrect" id="infopanel-for-dom-caretposition-getclientrect" role="dialog">
+   <span id="infopaneltitle-for-dom-caretposition-getclientrect" style="display:none">Info about the 'getClientRect()' definition.</span><b><a href="#dom-caretposition-getclientrect">#dom-caretposition-getclientrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-caretposition-getclientrect">5.1. The CaretPosition Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-scrolllogicalposition">
-   <b><a href="#enumdef-scrolllogicalposition">#enumdef-scrolllogicalposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-scrolllogicalposition" class="dfn-panel" data-for="enumdef-scrolllogicalposition" id="infopanel-for-enumdef-scrolllogicalposition" role="dialog">
+   <span id="infopaneltitle-for-enumdef-scrolllogicalposition" style="display:none">Info about the 'ScrollLogicalPosition' definition.</span><b><a href="#enumdef-scrolllogicalposition">#enumdef-scrolllogicalposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-scrolllogicalposition">6. Extensions to the Element Interface</a> <a href="#ref-for-enumdef-scrolllogicalposition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-scrollintoviewoptions">
-   <b><a href="#dictdef-scrollintoviewoptions">#dictdef-scrollintoviewoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-scrollintoviewoptions" class="dfn-panel" data-for="dictdef-scrollintoviewoptions" id="infopanel-for-dictdef-scrollintoviewoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-scrollintoviewoptions" style="display:none">Info about the 'ScrollIntoViewOptions' definition.</span><b><a href="#dictdef-scrollintoviewoptions">#dictdef-scrollintoviewoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-scrollintoviewoptions">6. Extensions to the Element Interface</a> <a href="#ref-for-dictdef-scrollintoviewoptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrollintoviewoptions-block">
-   <b><a href="#dom-scrollintoviewoptions-block">#dom-scrollintoviewoptions-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrollintoviewoptions-block" class="dfn-panel" data-for="dom-scrollintoviewoptions-block" id="infopanel-for-dom-scrollintoviewoptions-block" role="dialog">
+   <span id="infopaneltitle-for-dom-scrollintoviewoptions-block" style="display:none">Info about the 'block' definition.</span><b><a href="#dom-scrollintoviewoptions-block">#dom-scrollintoviewoptions-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrollintoviewoptions-block">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrollintoviewoptions-inline">
-   <b><a href="#dom-scrollintoviewoptions-inline">#dom-scrollintoviewoptions-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrollintoviewoptions-inline" class="dfn-panel" data-for="dom-scrollintoviewoptions-inline" id="infopanel-for-dom-scrollintoviewoptions-inline" role="dialog">
+   <span id="infopaneltitle-for-dom-scrollintoviewoptions-inline" style="display:none">Info about the 'inline' definition.</span><b><a href="#dom-scrollintoviewoptions-inline">#dom-scrollintoviewoptions-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrollintoviewoptions-inline">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getclientrects">
-   <b><a href="#dom-element-getclientrects">#dom-element-getclientrects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getclientrects" class="dfn-panel" data-for="dom-element-getclientrects" id="infopanel-for-dom-element-getclientrects" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getclientrects" style="display:none">Info about the 'getClientRects()' definition.</span><b><a href="#dom-element-getclientrects">#dom-element-getclientrects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getclientrects">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-getclientrects①">(2)</a> <a href="#ref-for-dom-element-getclientrects②">(3)</a>
     <li><a href="#ref-for-dom-element-getclientrects③">9. Extensions to the Range Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getboundingclientrect">
-   <b><a href="#dom-element-getboundingclientrect">#dom-element-getboundingclientrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="dom-element-getboundingclientrect" id="infopanel-for-dom-element-getboundingclientrect" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' definition.</span><b><a href="#dom-element-getboundingclientrect">#dom-element-getboundingclientrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-getboundingclientrect①">(2)</a>
     <li><a href="#ref-for-dom-element-getboundingclientrect②">6.1. Element Scrolling Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollintoview">
-   <b><a href="#dom-element-scrollintoview">#dom-element-scrollintoview</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollintoview" class="dfn-panel" data-for="dom-element-scrollintoview" id="infopanel-for-dom-element-scrollintoview" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollintoview" style="display:none">Info about the 'scrollIntoView(arg)' definition.</span><b><a href="#dom-element-scrollintoview">#dom-element-scrollintoview</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollintoview">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-scrollintoview①">Changes From 17 December 2013 To 31 January 2020</a> <a href="#ref-for-dom-element-scrollintoview②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scroll">
-   <b><a href="#dom-element-scroll">#dom-element-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scroll" class="dfn-panel" data-for="dom-element-scroll" id="infopanel-for-dom-element-scroll" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scroll" style="display:none">Info about the 'scroll()' definition.</span><b><a href="#dom-element-scroll">#dom-element-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scroll">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-scroll①">(2)</a> <a href="#ref-for-dom-element-scroll②">(3)</a> <a href="#ref-for-dom-element-scroll③">(4)</a>
     <li><a href="#ref-for-dom-element-scroll④">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollto">
-   <b><a href="#dom-element-scrollto">#dom-element-scrollto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollto" class="dfn-panel" data-for="dom-element-scrollto" id="infopanel-for-dom-element-scrollto" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollto" style="display:none">Info about the 'scrollTo()' definition.</span><b><a href="#dom-element-scrollto">#dom-element-scrollto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollto">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-scrollto①">(2)</a>
     <li><a href="#ref-for-dom-element-scrollto②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollby">
-   <b><a href="#dom-element-scrollby">#dom-element-scrollby</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollby" class="dfn-panel" data-for="dom-element-scrollby" id="infopanel-for-dom-element-scrollby" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollby" style="display:none">Info about the 'scrollBy()' definition.</span><b><a href="#dom-element-scrollby">#dom-element-scrollby</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollby">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-scrollby①">(2)</a>
     <li><a href="#ref-for-dom-element-scrollby②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrolltop">
-   <b><a href="#dom-element-scrolltop">#dom-element-scrolltop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrolltop" class="dfn-panel" data-for="dom-element-scrolltop" id="infopanel-for-dom-element-scrolltop" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrolltop" style="display:none">Info about the 'scrollTop' definition.</span><b><a href="#dom-element-scrolltop">#dom-element-scrolltop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrolltop">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-dom-element-scrolltop①">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-scrolltop②">(2)</a> <a href="#ref-for-dom-element-scrolltop③">(3)</a> <a href="#ref-for-dom-element-scrolltop④">(4)</a>
     <li><a href="#ref-for-dom-element-scrolltop⑤">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollleft">
-   <b><a href="#dom-element-scrollleft">#dom-element-scrollleft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollleft" class="dfn-panel" data-for="dom-element-scrollleft" id="infopanel-for-dom-element-scrollleft" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollleft" style="display:none">Info about the 'scrollLeft' definition.</span><b><a href="#dom-element-scrollleft">#dom-element-scrollleft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollleft">5. Extensions to the Document Interface</a>
     <li><a href="#ref-for-dom-element-scrollleft①">6. Extensions to the Element Interface</a> <a href="#ref-for-dom-element-scrollleft②">(2)</a> <a href="#ref-for-dom-element-scrollleft③">(3)</a> <a href="#ref-for-dom-element-scrollleft④">(4)</a>
     <li><a href="#ref-for-dom-element-scrollleft⑤">Changes From 17 December 2013 To 31 January 2020</a> <a href="#ref-for-dom-element-scrollleft⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollwidth">
-   <b><a href="#dom-element-scrollwidth">#dom-element-scrollwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollwidth" class="dfn-panel" data-for="dom-element-scrollwidth" id="infopanel-for-dom-element-scrollwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollwidth" style="display:none">Info about the 'scrollWidth' definition.</span><b><a href="#dom-element-scrollwidth">#dom-element-scrollwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollwidth">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-scrollwidth①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-scrollheight">
-   <b><a href="#dom-element-scrollheight">#dom-element-scrollheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-scrollheight" class="dfn-panel" data-for="dom-element-scrollheight" id="infopanel-for-dom-element-scrollheight" role="dialog">
+   <span id="infopaneltitle-for-dom-element-scrollheight" style="display:none">Info about the 'scrollHeight' definition.</span><b><a href="#dom-element-scrollheight">#dom-element-scrollheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-scrollheight">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-scrollheight①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-clienttop">
-   <b><a href="#dom-element-clienttop">#dom-element-clienttop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-clienttop" class="dfn-panel" data-for="dom-element-clienttop" id="infopanel-for-dom-element-clienttop" role="dialog">
+   <span id="infopaneltitle-for-dom-element-clienttop" style="display:none">Info about the 'clientTop' definition.</span><b><a href="#dom-element-clienttop">#dom-element-clienttop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-clienttop">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-clienttop①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-clientleft">
-   <b><a href="#dom-element-clientleft">#dom-element-clientleft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-clientleft" class="dfn-panel" data-for="dom-element-clientleft" id="infopanel-for-dom-element-clientleft" role="dialog">
+   <span id="infopaneltitle-for-dom-element-clientleft" style="display:none">Info about the 'clientLeft' definition.</span><b><a href="#dom-element-clientleft">#dom-element-clientleft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-clientleft">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-clientleft①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-clientwidth">
-   <b><a href="#dom-element-clientwidth">#dom-element-clientwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-clientwidth" class="dfn-panel" data-for="dom-element-clientwidth" id="infopanel-for-dom-element-clientwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-element-clientwidth" style="display:none">Info about the 'clientWidth' definition.</span><b><a href="#dom-element-clientwidth">#dom-element-clientwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-clientwidth">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-clientwidth①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-clientheight">
-   <b><a href="#dom-element-clientheight">#dom-element-clientheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-clientheight" class="dfn-panel" data-for="dom-element-clientheight" id="infopanel-for-dom-element-clientheight" role="dialog">
+   <span id="infopaneltitle-for-dom-element-clientheight" style="display:none">Info about the 'clientHeight' definition.</span><b><a href="#dom-element-clientheight">#dom-element-clientheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-clientheight">6. Extensions to the Element Interface</a>
     <li><a href="#ref-for-dom-element-clientheight①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-an-element-into-view">
-   <b><a href="#scroll-an-element-into-view">#scroll-an-element-into-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-an-element-into-view" class="dfn-panel" data-for="scroll-an-element-into-view" id="infopanel-for-scroll-an-element-into-view" role="dialog">
+   <span id="infopaneltitle-for-scroll-an-element-into-view" style="display:none">Info about the 'scroll an element into view' definition.</span><b><a href="#scroll-an-element-into-view">#scroll-an-element-into-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-an-element-into-view">6. Extensions to the Element Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-an-element">
-   <b><a href="#scroll-an-element">#scroll-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-an-element" class="dfn-panel" data-for="scroll-an-element" id="infopanel-for-scroll-an-element" role="dialog">
+   <span id="infopaneltitle-for-scroll-an-element" style="display:none">Info about the 'scroll an element' definition.</span><b><a href="#scroll-an-element">#scroll-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-an-element">6. Extensions to the Element Interface</a> <a href="#ref-for-scroll-an-element①">(2)</a> <a href="#ref-for-scroll-an-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlelement-offsetparent">
-   <b><a href="#dom-htmlelement-offsetparent">#dom-htmlelement-offsetparent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlelement-offsetparent" class="dfn-panel" data-for="dom-htmlelement-offsetparent" id="infopanel-for-dom-htmlelement-offsetparent" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlelement-offsetparent" style="display:none">Info about the 'offsetParent' definition.</span><b><a href="#dom-htmlelement-offsetparent">#dom-htmlelement-offsetparent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsetparent">7. Extensions to the HTMLElement Interface</a> <a href="#ref-for-dom-htmlelement-offsetparent①">(2)</a> <a href="#ref-for-dom-htmlelement-offsetparent②">(3)</a> <a href="#ref-for-dom-htmlelement-offsetparent③">(4)</a> <a href="#ref-for-dom-htmlelement-offsetparent④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlelement-offsettop">
-   <b><a href="#dom-htmlelement-offsettop">#dom-htmlelement-offsettop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlelement-offsettop" class="dfn-panel" data-for="dom-htmlelement-offsettop" id="infopanel-for-dom-htmlelement-offsettop" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlelement-offsettop" style="display:none">Info about the 'offsetTop' definition.</span><b><a href="#dom-htmlelement-offsettop">#dom-htmlelement-offsettop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsettop">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlelement-offsetleft">
-   <b><a href="#dom-htmlelement-offsetleft">#dom-htmlelement-offsetleft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlelement-offsetleft" class="dfn-panel" data-for="dom-htmlelement-offsetleft" id="infopanel-for-dom-htmlelement-offsetleft" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlelement-offsetleft" style="display:none">Info about the 'offsetLeft' definition.</span><b><a href="#dom-htmlelement-offsetleft">#dom-htmlelement-offsetleft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsetleft">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlelement-offsetwidth">
-   <b><a href="#dom-htmlelement-offsetwidth">#dom-htmlelement-offsetwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlelement-offsetwidth" class="dfn-panel" data-for="dom-htmlelement-offsetwidth" id="infopanel-for-dom-htmlelement-offsetwidth" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlelement-offsetwidth" style="display:none">Info about the 'offsetWidth' definition.</span><b><a href="#dom-htmlelement-offsetwidth">#dom-htmlelement-offsetwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsetwidth">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlelement-offsetheight">
-   <b><a href="#dom-htmlelement-offsetheight">#dom-htmlelement-offsetheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlelement-offsetheight" class="dfn-panel" data-for="dom-htmlelement-offsetheight" id="infopanel-for-dom-htmlelement-offsetheight" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlelement-offsetheight" style="display:none">Info about the 'offsetHeight' definition.</span><b><a href="#dom-htmlelement-offsetheight">#dom-htmlelement-offsetheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsetheight">7. Extensions to the HTMLElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlimageelement-x">
-   <b><a href="#dom-htmlimageelement-x">#dom-htmlimageelement-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlimageelement-x" class="dfn-panel" data-for="dom-htmlimageelement-x" id="infopanel-for-dom-htmlimageelement-x" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlimageelement-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-htmlimageelement-x">#dom-htmlimageelement-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlimageelement-x">8. Extensions to the HTMLImageElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlimageelement-y">
-   <b><a href="#dom-htmlimageelement-y">#dom-htmlimageelement-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlimageelement-y" class="dfn-panel" data-for="dom-htmlimageelement-y" id="infopanel-for-dom-htmlimageelement-y" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlimageelement-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-htmlimageelement-y">#dom-htmlimageelement-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlimageelement-y">8. Extensions to the HTMLImageElement Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-getclientrects">
-   <b><a href="#dom-range-getclientrects">#dom-range-getclientrects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-getclientrects" class="dfn-panel" data-for="dom-range-getclientrects" id="infopanel-for-dom-range-getclientrects" role="dialog">
+   <span id="infopaneltitle-for-dom-range-getclientrects" style="display:none">Info about the 'getClientRects()' definition.</span><b><a href="#dom-range-getclientrects">#dom-range-getclientrects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-getclientrects">5.1. The CaretPosition Interface</a>
     <li><a href="#ref-for-dom-range-getclientrects①">9. Extensions to the Range Interface</a> <a href="#ref-for-dom-range-getclientrects②">(2)</a> <a href="#ref-for-dom-range-getclientrects③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-getboundingclientrect">
-   <b><a href="#dom-range-getboundingclientrect">#dom-range-getboundingclientrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-getboundingclientrect" class="dfn-panel" data-for="dom-range-getboundingclientrect" id="infopanel-for-dom-range-getboundingclientrect" role="dialog">
+   <span id="infopaneltitle-for-dom-range-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' definition.</span><b><a href="#dom-range-getboundingclientrect">#dom-range-getboundingclientrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-getboundingclientrect">9. Extensions to the Range Interface</a> <a href="#ref-for-dom-range-getboundingclientrect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-screenx">
-   <b><a href="#dom-mouseevent-screenx">#dom-mouseevent-screenx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-screenx" class="dfn-panel" data-for="dom-mouseevent-screenx" id="infopanel-for-dom-mouseevent-screenx" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-screenx" style="display:none">Info about the 'screenX' definition.</span><b><a href="#dom-mouseevent-screenx">#dom-mouseevent-screenx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-screenx">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-screeny">
-   <b><a href="#dom-mouseevent-screeny">#dom-mouseevent-screeny</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-screeny" class="dfn-panel" data-for="dom-mouseevent-screeny" id="infopanel-for-dom-mouseevent-screeny" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-screeny" style="display:none">Info about the 'screenY' definition.</span><b><a href="#dom-mouseevent-screeny">#dom-mouseevent-screeny</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-screeny">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-pagex">
-   <b><a href="#dom-mouseevent-pagex">#dom-mouseevent-pagex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-pagex" class="dfn-panel" data-for="dom-mouseevent-pagex" id="infopanel-for-dom-mouseevent-pagex" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-pagex" style="display:none">Info about the 'pageX' definition.</span><b><a href="#dom-mouseevent-pagex">#dom-mouseevent-pagex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-pagex">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-dom-mouseevent-pagex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-pagey">
-   <b><a href="#dom-mouseevent-pagey">#dom-mouseevent-pagey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-pagey" class="dfn-panel" data-for="dom-mouseevent-pagey" id="infopanel-for-dom-mouseevent-pagey" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-pagey" style="display:none">Info about the 'pageY' definition.</span><b><a href="#dom-mouseevent-pagey">#dom-mouseevent-pagey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-pagey">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-dom-mouseevent-pagey①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-clientx">
-   <b><a href="#dom-mouseevent-clientx">#dom-mouseevent-clientx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-clientx" class="dfn-panel" data-for="dom-mouseevent-clientx" id="infopanel-for-dom-mouseevent-clientx" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-clientx" style="display:none">Info about the 'clientX' definition.</span><b><a href="#dom-mouseevent-clientx">#dom-mouseevent-clientx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-clientx">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-dom-mouseevent-clientx①">(2)</a> <a href="#ref-for-dom-mouseevent-clientx②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-clienty">
-   <b><a href="#dom-mouseevent-clienty">#dom-mouseevent-clienty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-clienty" class="dfn-panel" data-for="dom-mouseevent-clienty" id="infopanel-for-dom-mouseevent-clienty" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-clienty" style="display:none">Info about the 'clientY' definition.</span><b><a href="#dom-mouseevent-clienty">#dom-mouseevent-clienty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-clienty">10. Extensions to the MouseEvent Interface</a> <a href="#ref-for-dom-mouseevent-clienty①">(2)</a> <a href="#ref-for-dom-mouseevent-clienty②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-x">
-   <b><a href="#dom-mouseevent-x">#dom-mouseevent-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-x" class="dfn-panel" data-for="dom-mouseevent-x" id="infopanel-for-dom-mouseevent-x" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-mouseevent-x">#dom-mouseevent-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-x">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-y">
-   <b><a href="#dom-mouseevent-y">#dom-mouseevent-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-y" class="dfn-panel" data-for="dom-mouseevent-y" id="infopanel-for-dom-mouseevent-y" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-mouseevent-y">#dom-mouseevent-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-y">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-offsetx">
-   <b><a href="#dom-mouseevent-offsetx">#dom-mouseevent-offsetx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-offsetx" class="dfn-panel" data-for="dom-mouseevent-offsetx" id="infopanel-for-dom-mouseevent-offsetx" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-offsetx" style="display:none">Info about the 'offsetX' definition.</span><b><a href="#dom-mouseevent-offsetx">#dom-mouseevent-offsetx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-offsetx">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mouseevent-offsety">
-   <b><a href="#dom-mouseevent-offsety">#dom-mouseevent-offsety</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mouseevent-offsety" class="dfn-panel" data-for="dom-mouseevent-offsety" id="infopanel-for-dom-mouseevent-offsety" role="dialog">
+   <span id="infopaneltitle-for-dom-mouseevent-offsety" style="display:none">Info about the 'offsetY' definition.</span><b><a href="#dom-mouseevent-offsety">#dom-mouseevent-offsety</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mouseevent-offsety">10. Extensions to the MouseEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-cssboxtype">
-   <b><a href="#enumdef-cssboxtype">#enumdef-cssboxtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-cssboxtype" class="dfn-panel" data-for="enumdef-cssboxtype" id="infopanel-for-enumdef-cssboxtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-cssboxtype" style="display:none">Info about the 'CSSBoxType' definition.</span><b><a href="#enumdef-cssboxtype">#enumdef-cssboxtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-cssboxtype">11.1. The GeometryUtils Interface</a> <a href="#ref-for-enumdef-cssboxtype①">(2)</a> <a href="#ref-for-enumdef-cssboxtype②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-boxquadoptions">
-   <b><a href="#dictdef-boxquadoptions">#dictdef-boxquadoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-boxquadoptions" class="dfn-panel" data-for="dictdef-boxquadoptions" id="infopanel-for-dictdef-boxquadoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-boxquadoptions" style="display:none">Info about the 'BoxQuadOptions' definition.</span><b><a href="#dictdef-boxquadoptions">#dictdef-boxquadoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-boxquadoptions">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-convertcoordinateoptions">
-   <b><a href="#dictdef-convertcoordinateoptions">#dictdef-convertcoordinateoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-convertcoordinateoptions" class="dfn-panel" data-for="dictdef-convertcoordinateoptions" id="infopanel-for-dictdef-convertcoordinateoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-convertcoordinateoptions" style="display:none">Info about the 'ConvertCoordinateOptions' definition.</span><b><a href="#dictdef-convertcoordinateoptions">#dictdef-convertcoordinateoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-convertcoordinateoptions">11.1. The GeometryUtils Interface</a> <a href="#ref-for-dictdef-convertcoordinateoptions①">(2)</a> <a href="#ref-for-dictdef-convertcoordinateoptions②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geometryutils">
-   <b><a href="#geometryutils">#geometryutils</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geometryutils" class="dfn-panel" data-for="geometryutils" id="infopanel-for-geometryutils" role="dialog">
+   <span id="infopaneltitle-for-geometryutils" style="display:none">Info about the 'GeometryUtils' definition.</span><b><a href="#geometryutils">#geometryutils</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geometryutils">11.1. The GeometryUtils Interface</a> <a href="#ref-for-geometryutils①">(2)</a> <a href="#ref-for-geometryutils②">(3)</a> <a href="#ref-for-geometryutils③">(4)</a> <a href="#ref-for-geometryutils④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-geometrynode">
-   <b><a href="#typedefdef-geometrynode">#typedefdef-geometrynode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-geometrynode" class="dfn-panel" data-for="typedefdef-geometrynode" id="infopanel-for-typedefdef-geometrynode" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-geometrynode" style="display:none">Info about the 'GeometryNode' definition.</span><b><a href="#typedefdef-geometrynode">#typedefdef-geometrynode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-geometrynode">11.1. The GeometryUtils Interface</a> <a href="#ref-for-typedefdef-geometrynode①">(2)</a> <a href="#ref-for-typedefdef-geometrynode②">(3)</a> <a href="#ref-for-typedefdef-geometrynode③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geometryutils-getboxquads">
-   <b><a href="#dom-geometryutils-getboxquads">#dom-geometryutils-getboxquads</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geometryutils-getboxquads" class="dfn-panel" data-for="dom-geometryutils-getboxquads" id="infopanel-for-dom-geometryutils-getboxquads" role="dialog">
+   <span id="infopaneltitle-for-dom-geometryutils-getboxquads" style="display:none">Info about the 'getBoxQuads(options)' definition.</span><b><a href="#dom-geometryutils-getboxquads">#dom-geometryutils-getboxquads</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geometryutils-getboxquads">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geometryutils-convertquadfromnode">
-   <b><a href="#dom-geometryutils-convertquadfromnode">#dom-geometryutils-convertquadfromnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geometryutils-convertquadfromnode" class="dfn-panel" data-for="dom-geometryutils-convertquadfromnode" id="infopanel-for-dom-geometryutils-convertquadfromnode" role="dialog">
+   <span id="infopaneltitle-for-dom-geometryutils-convertquadfromnode" style="display:none">Info about the 'convertQuadFromNode(quad, from, options)' definition.</span><b><a href="#dom-geometryutils-convertquadfromnode">#dom-geometryutils-convertquadfromnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geometryutils-convertquadfromnode">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geometryutils-convertrectfromnode">
-   <b><a href="#dom-geometryutils-convertrectfromnode">#dom-geometryutils-convertrectfromnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geometryutils-convertrectfromnode" class="dfn-panel" data-for="dom-geometryutils-convertrectfromnode" id="infopanel-for-dom-geometryutils-convertrectfromnode" role="dialog">
+   <span id="infopaneltitle-for-dom-geometryutils-convertrectfromnode" style="display:none">Info about the 'convertRectFromNode(rect, from, options)' definition.</span><b><a href="#dom-geometryutils-convertrectfromnode">#dom-geometryutils-convertrectfromnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geometryutils-convertrectfromnode">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geometryutils-convertpointfromnode">
-   <b><a href="#dom-geometryutils-convertpointfromnode">#dom-geometryutils-convertpointfromnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geometryutils-convertpointfromnode" class="dfn-panel" data-for="dom-geometryutils-convertpointfromnode" id="infopanel-for-dom-geometryutils-convertpointfromnode" role="dialog">
+   <span id="infopaneltitle-for-dom-geometryutils-convertpointfromnode" style="display:none">Info about the 'convertPointFromNode(point, from, options)' definition.</span><b><a href="#dom-geometryutils-convertpointfromnode">#dom-geometryutils-convertpointfromnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geometryutils-convertpointfromnode">11.1. The GeometryUtils Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-scroll-event-targets">
-   <b><a href="#pending-scroll-event-targets">#pending-scroll-event-targets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-scroll-event-targets" class="dfn-panel" data-for="pending-scroll-event-targets" id="infopanel-for-pending-scroll-event-targets" role="dialog">
+   <span id="infopaneltitle-for-pending-scroll-event-targets" style="display:none">Info about the 'pending scroll event targets' definition.</span><b><a href="#pending-scroll-event-targets">#pending-scroll-event-targets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-scroll-event-targets">12.2. Scrolling</a> <a href="#ref-for-pending-scroll-event-targets①">(2)</a> <a href="#ref-for-pending-scroll-event-targets②">(3)</a> <a href="#ref-for-pending-scroll-event-targets③">(4)</a> <a href="#ref-for-pending-scroll-event-targets④">(5)</a> <a href="#ref-for-pending-scroll-event-targets⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-window-resize">
-   <b><a href="#eventdef-window-resize">#eventdef-window-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-window-resize" class="dfn-panel" data-for="eventdef-window-resize" id="infopanel-for-eventdef-window-resize" role="dialog">
+   <span id="infopaneltitle-for-eventdef-window-resize" style="display:none">Info about the 'resize' definition.</span><b><a href="#eventdef-window-resize">#eventdef-window-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-window-resize">12.1. Resizing viewports</a>
     <li><a href="#ref-for-eventdef-window-resize①">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-document-scroll">
-   <b><a href="#eventdef-document-scroll">#eventdef-document-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-document-scroll" class="dfn-panel" data-for="eventdef-document-scroll" id="infopanel-for-eventdef-document-scroll" role="dialog">
+   <span id="infopaneltitle-for-eventdef-document-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#eventdef-document-scroll">#eventdef-document-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-document-scroll">12.2. Scrolling</a> <a href="#ref-for-eventdef-document-scroll①">(2)</a>
     <li><a href="#ref-for-eventdef-document-scroll②">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-scroll-behavior">
-   <b><a href="#propdef-scroll-behavior">#propdef-scroll-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-scroll-behavior" class="dfn-panel" data-for="propdef-scroll-behavior" id="infopanel-for-propdef-scroll-behavior" role="dialog">
+   <span id="infopaneltitle-for-propdef-scroll-behavior" style="display:none">Info about the 'scroll-behavior' definition.</span><b><a href="#propdef-scroll-behavior">#propdef-scroll-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scroll-behavior">3.1. Scrolling</a> <a href="#ref-for-propdef-scroll-behavior①">(2)</a>
     <li><a href="#ref-for-propdef-scroll-behavior②">13.1. Smooth Scrolling: The scroll-behavior Property</a> <a href="#ref-for-propdef-scroll-behavior③">(2)</a> <a href="#ref-for-propdef-scroll-behavior④">(3)</a>
@@ -7003,14 +7003,14 @@ the Windows Internet Explorer browser.</p>
     <li><a href="#ref-for-propdef-scroll-behavior⑥">Changes From 4 August 2011 To 17 December 2013</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-behavior-auto">
-   <b><a href="#valdef-scroll-behavior-auto">#valdef-scroll-behavior-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-behavior-auto" class="dfn-panel" data-for="valdef-scroll-behavior-auto" id="infopanel-for-valdef-scroll-behavior-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-behavior-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-scroll-behavior-auto">#valdef-scroll-behavior-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-behavior-auto">Changes From 17 December 2013 To 31 January 2020</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-scroll-behavior-smooth">
-   <b><a href="#valdef-scroll-behavior-smooth">#valdef-scroll-behavior-smooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-scroll-behavior-smooth" class="dfn-panel" data-for="valdef-scroll-behavior-smooth" id="infopanel-for-valdef-scroll-behavior-smooth" role="dialog">
+   <span id="infopaneltitle-for-valdef-scroll-behavior-smooth" style="display:none">Info about the 'smooth' definition.</span><b><a href="#valdef-scroll-behavior-smooth">#valdef-scroll-behavior-smooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-scroll-behavior-smooth">3.1. Scrolling</a>
    </ul>
@@ -7032,59 +7032,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/mediaqueries-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/mediaqueries-4/Overview.html
@@ -3464,15 +3464,15 @@ Answers are provided below.</p>
    <li><a href="#descdef-media-update">update</a><span>, in § 5.4</span>
    <li><a href="#descdef-media-width">width</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">1. 
 Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">1.3. 
 Units</a> <a href="#ref-for-initial-value①">(2)</a>
@@ -3480,8 +3480,8 @@ Units</a> <a href="#ref-for-initial-value①">(2)</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">1. 
 Introduction</a>
@@ -3527,8 +3527,8 @@ All Available Interaction Capabilities: the any-pointer and any-hover features</
     <li><a href="#ref-for-at-ruledef-media②③"> device-aspect-ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">1.3. 
 Units</a>
@@ -3536,44 +3536,44 @@ Units</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">4.3. 
 Aspect-Ratio: the aspect-ratio feature</a> <a href="#ref-for-propdef-aspect-ratio①">(2)</a>
     <li><a href="#ref-for-propdef-aspect-ratio②"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-any-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-any-value" class="dfn-panel" data-for="term-for-typedef-any-value" id="infopanel-for-term-for-typedef-any-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-any-value" style="display:none">Info about the '&lt;any-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-any-value">3. 
 Syntax</a> <a href="#ref-for-typedef-any-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-delim-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-delim-token" class="dfn-panel" data-for="term-for-typedef-delim-token" id="infopanel-for-term-for-typedef-delim-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-delim-token" style="display:none">Info about the '&lt;delim-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-delim-token">3. 
 Syntax</a> <a href="#ref-for-typedef-delim-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-function-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-function-token" class="dfn-panel" data-for="term-for-typedef-function-token" id="infopanel-for-term-for-typedef-function-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">3. 
 Syntax</a> <a href="#ref-for-typedef-function-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-comma-separated-list-of-component-values">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-comma-separated-list-of-component-values" class="dfn-panel" data-for="term-for-parse-a-comma-separated-list-of-component-values" id="infopanel-for-term-for-parse-a-comma-separated-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-comma-separated-list-of-component-values" style="display:none">Info about the 'parse a comma-separated list of component values' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-comma-separated-list-of-component-values">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-dimension">https://drafts.csswg.org/css-values-3/#typedef-dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension" class="dfn-panel" data-for="term-for-typedef-dimension" id="infopanel-for-term-for-typedef-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-dimension">https://drafts.csswg.org/css-values-3/#typedef-dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
@@ -3581,28 +3581,28 @@ Evaluating Media Features in a Boolean Context</a>
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-3/#typedef-ident">https://drafts.csswg.org/css-values-3/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#typedef-ident">https://drafts.csswg.org/css-values-3/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3. 
 Syntax</a> <a href="#ref-for-typedef-ident①">(2)</a> <a href="#ref-for-typedef-ident②">(3)</a> <a href="#ref-for-typedef-ident③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#mult-opt">https://drafts.csswg.org/css-values-3/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt"> Changes since the 5 September 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cm">
-   <a href="https://drafts.csswg.org/css-values-3/#cm">https://drafts.csswg.org/css-values-3/#cm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cm" class="dfn-panel" data-for="term-for-cm" id="infopanel-for-term-for-cm" role="menu">
+   <span id="infopaneltitle-for-term-for-cm" style="display:none">Info about the 'cm' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#cm">https://drafts.csswg.org/css-values-3/#cm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#em">https://drafts.csswg.org/css-values-3/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">1.3. 
 Units</a>
@@ -3610,15 +3610,15 @@ Units</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in">
-   <a href="https://drafts.csswg.org/css-values-3/#in">https://drafts.csswg.org/css-values-3/#in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in" class="dfn-panel" data-for="term-for-in" id="infopanel-for-term-for-in" role="menu">
+   <span id="infopaneltitle-for-term-for-in" style="display:none">Info about the 'in' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#in">https://drafts.csswg.org/css-values-3/#in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-3/#px">https://drafts.csswg.org/css-values-3/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#px">https://drafts.csswg.org/css-values-3/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">5.1. 
 Display Resolution: the resolution feature</a>
@@ -3626,15 +3626,15 @@ Display Resolution: the resolution feature</a>
     <li><a href="#ref-for-px②"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-length">
-   <a href="https://drafts.csswg.org/css-values-3/#relative-length">https://drafts.csswg.org/css-values-3/#relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-length" class="dfn-panel" data-for="term-for-relative-length" id="infopanel-for-term-for-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-length" style="display:none">Info about the 'relative length' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#relative-length">https://drafts.csswg.org/css-values-3/#relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-length">1.3. 
 Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#comb-one">https://drafts.csswg.org/css-values-3/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.4. 
 Orientation: the orientation feature</a>
@@ -3658,8 +3658,8 @@ Hover Capability: the hover feature</a>
 All Available Interaction Capabilities: the any-pointer and any-hover features</a> <a href="#ref-for-comb-one①④">(2)</a> <a href="#ref-for-comb-one①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">1.2. 
 Values</a>
@@ -3674,8 +3674,8 @@ Monochrome Screens: the monochrome feature</a>
     <li><a href="#ref-for-integer-value⑤"> Changes since the 5 September 2017 Candidate Recommendation</a> <a href="#ref-for-integer-value⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.1. 
 Width: the width feature</a> <a href="#ref-for-length-value①">(2)</a>
@@ -3685,8 +3685,8 @@ Height: the height feature</a> <a href="#ref-for-length-value③">(2)</a>
     <li><a href="#ref-for-length-value⑤"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">1.2. 
 Values</a>
@@ -3695,8 +3695,8 @@ Syntax</a>
     <li><a href="#ref-for-number-value②"> Changes since the 5 September 2017 Candidate Recommendation</a> <a href="#ref-for-number-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ratio-value">
-   <a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ratio-value" class="dfn-panel" data-for="term-for-ratio-value" id="infopanel-for-term-for-ratio-value" role="menu">
+   <span id="infopaneltitle-for-term-for-ratio-value" style="display:none">Info about the '&lt;ratio>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-value">3. 
 Syntax</a>
@@ -3706,8 +3706,8 @@ Aspect-Ratio: the aspect-ratio feature</a>
     <li><a href="#ref-for-ratio-value③"> Changes since the 5 September 2017 Candidate Recommendation</a> <a href="#ref-for-ratio-value④">(2)</a> <a href="#ref-for-ratio-value⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">1.2. 
 Values</a>
@@ -3715,44 +3715,44 @@ Values</a>
 Display Resolution: the resolution feature</a> <a href="#ref-for-resolution-value②">(2)</a> <a href="#ref-for-resolution-value③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#block-axis">https://www.w3.org/TR/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#block-axis">https://www.w3.org/TR/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">5.5. 
 Block-Axis Overflow: the overflow-block feature</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#inline-axis">https://www.w3.org/TR/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#inline-axis">https://www.w3.org/TR/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">5.6. 
 Inline-Axis Overflow: the overflow-inline feature</a> <a href="#ref-for-inline-axis①">(2)</a> <a href="#ref-for-inline-axis②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-zoom">
-   <a href="https://drafts.csswg.org/cssom-view-1/#page-zoom">https://drafts.csswg.org/cssom-view-1/#page-zoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-zoom" class="dfn-panel" data-for="term-for-page-zoom" id="infopanel-for-term-for-page-zoom" role="menu">
+   <span id="infopaneltitle-for-term-for-page-zoom" style="display:none">Info about the 'page zoom' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#page-zoom">https://drafts.csswg.org/cssom-view-1/#page-zoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-zoom">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pinch-zoom">
-   <a href="https://www.w3.org/TR/cssom-view-1/#pinch-zoom">https://www.w3.org/TR/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pinch-zoom" class="dfn-panel" data-for="term-for-pinch-zoom" id="infopanel-for-term-for-pinch-zoom" role="menu">
+   <span id="infopaneltitle-for-term-for-pinch-zoom" style="display:none">Info about the 'pinch zoom' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#pinch-zoom">https://www.w3.org/TR/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinch-zoom">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-web-exposed-screen-area">
-   <a href="https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area">https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-web-exposed-screen-area" class="dfn-panel" data-for="term-for-web-exposed-screen-area" id="infopanel-for-term-for-web-exposed-screen-area" role="menu">
+   <span id="infopaneltitle-for-term-for-web-exposed-screen-area" style="display:none">Info about the 'web-exposed screen area' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area">https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-exposed-screen-area"> device-width</a>
     <li><a href="#ref-for-web-exposed-screen-area①"> device-height</a>
     <li><a href="#ref-for-web-exposed-screen-area②"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3. 
 Syntax</a>
@@ -3998,8 +3998,8 @@ Syntax</a>
       <td>range
    </table>
   </div>
-  <aside class="dfn-panel" data-for="media-query">
-   <b><a href="#media-query">#media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query" class="dfn-panel" data-for="media-query" id="infopanel-for-media-query" role="dialog">
+   <span id="infopaneltitle-for-media-query" style="display:none">Info about the 'media query' definition.</span><b><a href="#media-query">#media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query①">1. 
 Introduction</a>
@@ -4022,8 +4022,8 @@ Evaluating Media Features in a Range Context</a>
 Error Handling</a> <a href="#ref-for-media-query②⑧">(2)</a> <a href="#ref-for-media-query②⑨">(3)</a> <a href="#ref-for-media-query③⓪">(4)</a> <a href="#ref-for-media-query③①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-query-list">
-   <b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query-list" class="dfn-panel" data-for="media-query-list" id="infopanel-for-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-media-query-list" style="display:none">Info about the 'media query list' definition.</span><b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-list">2.1. 
 Combining Media Queries</a> <a href="#ref-for-media-query-list①">(2)</a> <a href="#ref-for-media-query-list②">(3)</a>
@@ -4033,8 +4033,8 @@ Syntax</a>
 Error Handling</a> <a href="#ref-for-media-query-list⑤">(2)</a> <a href="#ref-for-media-query-list⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-query-modifier">
-   <b><a href="#media-query-modifier">#media-query-modifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query-modifier" class="dfn-panel" data-for="media-query-modifier" id="infopanel-for-media-query-modifier" role="dialog">
+   <span id="infopaneltitle-for-media-query-modifier" style="display:none">Info about the 'media query modifier' definition.</span><b><a href="#media-query-modifier">#media-query-modifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-modifier">2. 
 Media Queries</a>
@@ -4042,8 +4042,8 @@ Media Queries</a>
 Hiding a Media Query From Legacy user agents: the only keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-not">
-   <b><a href="#valdef-media-not">#valdef-media-not</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-not" class="dfn-panel" data-for="valdef-media-not" id="infopanel-for-valdef-media-not" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-not" style="display:none">Info about the 'not' definition.</span><b><a href="#valdef-media-not">#valdef-media-not</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-not">2.2.1. 
 Negating a Media Query: the not keyword</a> <a href="#ref-for-valdef-media-not①">(2)</a>
@@ -4057,8 +4057,8 @@ Error Handling</a>
     <li><a href="#ref-for-valdef-media-not⑧"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-only">
-   <b><a href="#valdef-media-only">#valdef-media-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-only" class="dfn-panel" data-for="valdef-media-only" id="infopanel-for-valdef-media-only" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-only" style="display:none">Info about the 'only' definition.</span><b><a href="#valdef-media-only">#valdef-media-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-only">2.2.2. 
 Hiding a Media Query From Legacy user agents: the only keyword</a> <a href="#ref-for-valdef-media-only①">(2)</a> <a href="#ref-for-valdef-media-only②">(3)</a> <a href="#ref-for-valdef-media-only③">(4)</a>
@@ -4067,8 +4067,8 @@ Syntax</a>
     <li><a href="#ref-for-valdef-media-only⑤"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-type">
-   <b><a href="#media-type">#media-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-type" class="dfn-panel" data-for="media-type" id="infopanel-for-media-type" role="dialog">
+   <span id="infopaneltitle-for-media-type" style="display:none">Info about the 'media type' definition.</span><b><a href="#media-type">#media-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-type">1. 
 Introduction</a> <a href="#ref-for-media-type①">(2)</a>
@@ -4088,22 +4088,22 @@ Media Features</a>
 Error Handling</a> <a href="#ref-for-media-type②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-all">
-   <b><a href="#valdef-media-all">#valdef-media-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-all" class="dfn-panel" data-for="valdef-media-all" id="infopanel-for-valdef-media-all" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-all" style="display:none">Info about the 'all' definition.</span><b><a href="#valdef-media-all">#valdef-media-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-all"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-print">
-   <b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-print" class="dfn-panel" data-for="valdef-media-print" id="infopanel-for-valdef-media-print" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-print" style="display:none">Info about the 'print' definition.</span><b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-print">2.3. 
 Media Types</a>
     <li><a href="#ref-for-valdef-media-print①"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-screen">
-   <b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-screen" class="dfn-panel" data-for="valdef-media-screen" id="infopanel-for-valdef-media-screen" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-screen">2. 
 Media Queries</a>
@@ -4117,36 +4117,36 @@ Media Types</a>
     <li><a href="#ref-for-valdef-media-screen⑥"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-tty">
-   <b><a href="#valdef-media-tty">#valdef-media-tty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-tty" class="dfn-panel" data-for="valdef-media-tty" id="infopanel-for-valdef-media-tty" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-tty" style="display:none">Info about the 'tty' definition.</span><b><a href="#valdef-media-tty">#valdef-media-tty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-tty">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-tv">
-   <b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-tv" class="dfn-panel" data-for="valdef-media-tv" id="infopanel-for-valdef-media-tv" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-tv" style="display:none">Info about the 'tv' definition.</span><b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-tv">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-projection">
-   <b><a href="#valdef-media-projection">#valdef-media-projection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-projection" class="dfn-panel" data-for="valdef-media-projection" id="infopanel-for-valdef-media-projection" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-projection" style="display:none">Info about the 'projection' definition.</span><b><a href="#valdef-media-projection">#valdef-media-projection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-projection">2.1. 
 Combining Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-handheld">
-   <b><a href="#valdef-media-handheld">#valdef-media-handheld</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-handheld" class="dfn-panel" data-for="valdef-media-handheld" id="infopanel-for-valdef-media-handheld" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-handheld" style="display:none">Info about the 'handheld' definition.</span><b><a href="#valdef-media-handheld">#valdef-media-handheld</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-handheld">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-speech">
-   <b><a href="#valdef-media-speech">#valdef-media-speech</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-speech" class="dfn-panel" data-for="valdef-media-speech" id="infopanel-for-valdef-media-speech" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-speech" style="display:none">Info about the 'speech' definition.</span><b><a href="#valdef-media-speech">#valdef-media-speech</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-speech">2.4. 
 Media Features</a>
@@ -4156,8 +4156,8 @@ Error Handling</a>
     <li><a href="#ref-for-valdef-media-speech③"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-feature">
-   <b><a href="#media-feature">#media-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-feature" class="dfn-panel" data-for="media-feature" id="infopanel-for-media-feature" role="dialog">
+   <span id="infopaneltitle-for-media-feature" style="display:none">Info about the 'media feature' definition.</span><b><a href="#media-feature">#media-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-feature">2. 
 Media Queries</a>
@@ -4184,8 +4184,8 @@ Hover Capability: the hover feature</a>
     <li><a href="#ref-for-media-feature③⑦"> Changes Since Media Queries Level 3</a> <a href="#ref-for-media-feature③⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean-context">
-   <b><a href="#boolean-context">#boolean-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean-context" class="dfn-panel" data-for="boolean-context" id="infopanel-for-boolean-context" role="dialog">
+   <span id="infopaneltitle-for-boolean-context" style="display:none">Info about the 'boolean context' definition.</span><b><a href="#boolean-context">#boolean-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean-context">2.4. 
 Media Features</a>
@@ -4195,8 +4195,8 @@ Evaluating Media Features in a Boolean Context</a> <a href="#ref-for-boolean-con
 Using “min-” and “max-” Prefixes On Range Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="range-context">
-   <b><a href="#range-context">#range-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-range-context" class="dfn-panel" data-for="range-context" id="infopanel-for-range-context" role="dialog">
+   <span id="infopaneltitle-for-range-context" style="display:none">Info about the 'range context' definition.</span><b><a href="#range-context">#range-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range-context">2.4. 
 Media Features</a>
@@ -4208,8 +4208,8 @@ Using “min-” and “max-” Prefixes On Range Features</a> <a href="#ref-for
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="false-in-the-negative-range">
-   <b><a href="#false-in-the-negative-range">#false-in-the-negative-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-false-in-the-negative-range" class="dfn-panel" data-for="false-in-the-negative-range" id="infopanel-for-false-in-the-negative-range" role="dialog">
+   <span id="infopaneltitle-for-false-in-the-negative-range" style="display:none">Info about the 'false in the negative range' definition.</span><b><a href="#false-in-the-negative-range">#false-in-the-negative-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-false-in-the-negative-range">4.1. 
 Width: the width feature</a>
@@ -4228,23 +4228,23 @@ Monochrome Screens: the monochrome feature</a>
     <li><a href="#ref-for-false-in-the-negative-range⑧"> Changes since the 19 May 2017 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-condition">
-   <b><a href="#media-condition">#media-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-condition" class="dfn-panel" data-for="media-condition" id="infopanel-for-media-condition" role="dialog">
+   <span id="infopaneltitle-for-media-condition" style="display:none">Info about the 'media condition' definition.</span><b><a href="#media-condition">#media-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-condition">2. 
 Media Queries</a>
     <li><a href="#ref-for-media-condition①">2.5. Combining Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query-list">
-   <b><a href="#typedef-media-query-list">#typedef-media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query-list" class="dfn-panel" data-for="typedef-media-query-list" id="infopanel-for-typedef-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' definition.</span><b><a href="#typedef-media-query-list">#typedef-media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">3. 
 Syntax</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query">
-   <b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query" class="dfn-panel" data-for="typedef-media-query" id="infopanel-for-typedef-media-query" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query" style="display:none">Info about the '&lt;media-query>' definition.</span><b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query">3. 
 Syntax</a> <a href="#ref-for-typedef-media-query①">(2)</a>
@@ -4252,8 +4252,8 @@ Syntax</a> <a href="#ref-for-typedef-media-query①">(2)</a>
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-type">
-   <b><a href="#typedef-media-type">#typedef-media-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-type" class="dfn-panel" data-for="typedef-media-type" id="infopanel-for-typedef-media-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-type" style="display:none">Info about the '&lt;media-type>' definition.</span><b><a href="#typedef-media-type">#typedef-media-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-type">3. 
 Syntax</a> <a href="#ref-for-typedef-media-type①">(2)</a>
@@ -4261,85 +4261,85 @@ Syntax</a> <a href="#ref-for-typedef-media-type①">(2)</a>
 Error Handling</a> <a href="#ref-for-typedef-media-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-condition">
-   <b><a href="#typedef-media-condition">#typedef-media-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-condition" class="dfn-panel" data-for="typedef-media-condition" id="infopanel-for-typedef-media-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-condition" style="display:none">Info about the '&lt;media-condition>' definition.</span><b><a href="#typedef-media-condition">#typedef-media-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-condition">3. 
 Syntax</a> <a href="#ref-for-typedef-media-condition①">(2)</a>
     <li><a href="#ref-for-typedef-media-condition②">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-media-condition③">(2)</a> <a href="#ref-for-typedef-media-condition④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-condition-without-or">
-   <b><a href="#typedef-media-condition-without-or">#typedef-media-condition-without-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-condition-without-or" class="dfn-panel" data-for="typedef-media-condition-without-or" id="infopanel-for-typedef-media-condition-without-or" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-condition-without-or" style="display:none">Info about the '&lt;media-condition-without-or>' definition.</span><b><a href="#typedef-media-condition-without-or">#typedef-media-condition-without-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-condition-without-or">3. 
 Syntax</a>
     <li><a href="#ref-for-typedef-media-condition-without-or①">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-media-condition-without-or②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-not">
-   <b><a href="#typedef-media-not">#typedef-media-not</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-not" class="dfn-panel" data-for="typedef-media-not" id="infopanel-for-typedef-media-not" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-not" style="display:none">Info about the '&lt;media-not>' definition.</span><b><a href="#typedef-media-not">#typedef-media-not</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-not">3. 
 Syntax</a> <a href="#ref-for-typedef-media-not①">(2)</a>
     <li><a href="#ref-for-typedef-media-not②">3.1. Evaluating Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-and">
-   <b><a href="#typedef-media-and">#typedef-media-and</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-and" class="dfn-panel" data-for="typedef-media-and" id="infopanel-for-typedef-media-and" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-and" style="display:none">Info about the '&lt;media-and>' definition.</span><b><a href="#typedef-media-and">#typedef-media-and</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-and">3. 
 Syntax</a> <a href="#ref-for-typedef-media-and①">(2)</a>
     <li><a href="#ref-for-typedef-media-and②">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-media-and③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-or">
-   <b><a href="#typedef-media-or">#typedef-media-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-or" class="dfn-panel" data-for="typedef-media-or" id="infopanel-for-typedef-media-or" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-or" style="display:none">Info about the '&lt;media-or>' definition.</span><b><a href="#typedef-media-or">#typedef-media-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-or">3. 
 Syntax</a>
     <li><a href="#ref-for-typedef-media-or①">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-media-or②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-in-parens">
-   <b><a href="#typedef-media-in-parens">#typedef-media-in-parens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-in-parens" class="dfn-panel" data-for="typedef-media-in-parens" id="infopanel-for-typedef-media-in-parens" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-in-parens" style="display:none">Info about the '&lt;media-in-parens>' definition.</span><b><a href="#typedef-media-in-parens">#typedef-media-in-parens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-in-parens">3. 
 Syntax</a> <a href="#ref-for-typedef-media-in-parens①">(2)</a> <a href="#ref-for-typedef-media-in-parens②">(3)</a> <a href="#ref-for-typedef-media-in-parens③">(4)</a> <a href="#ref-for-typedef-media-in-parens④">(5)</a> <a href="#ref-for-typedef-media-in-parens⑤">(6)</a>
     <li><a href="#ref-for-typedef-media-in-parens⑥">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-media-in-parens⑦">(2)</a> <a href="#ref-for-typedef-media-in-parens⑧">(3)</a> <a href="#ref-for-typedef-media-in-parens⑨">(4)</a> <a href="#ref-for-typedef-media-in-parens①⓪">(5)</a> <a href="#ref-for-typedef-media-in-parens①①">(6)</a> <a href="#ref-for-typedef-media-in-parens①②">(7)</a> <a href="#ref-for-typedef-media-in-parens①③">(8)</a> <a href="#ref-for-typedef-media-in-parens①④">(9)</a> <a href="#ref-for-typedef-media-in-parens①⑤">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-feature">
-   <b><a href="#typedef-media-feature">#typedef-media-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-feature" class="dfn-panel" data-for="typedef-media-feature" id="infopanel-for-typedef-media-feature" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-feature" style="display:none">Info about the '&lt;media-feature>' definition.</span><b><a href="#typedef-media-feature">#typedef-media-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-feature">3. 
 Syntax</a>
     <li><a href="#ref-for-typedef-media-feature①">3.1. Evaluating Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-plain">
-   <b><a href="#typedef-mf-plain">#typedef-mf-plain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-plain" class="dfn-panel" data-for="typedef-mf-plain" id="infopanel-for-typedef-mf-plain" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-plain" style="display:none">Info about the '&lt;mf-plain>' definition.</span><b><a href="#typedef-mf-plain">#typedef-mf-plain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-plain">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-boolean">
-   <b><a href="#typedef-mf-boolean">#typedef-mf-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-boolean" class="dfn-panel" data-for="typedef-mf-boolean" id="infopanel-for-typedef-mf-boolean" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-boolean" style="display:none">Info about the '&lt;mf-boolean>' definition.</span><b><a href="#typedef-mf-boolean">#typedef-mf-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-boolean">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-range">
-   <b><a href="#typedef-mf-range">#typedef-mf-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-range" class="dfn-panel" data-for="typedef-mf-range" id="infopanel-for-typedef-mf-range" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-range" style="display:none">Info about the '&lt;mf-range>' definition.</span><b><a href="#typedef-mf-range">#typedef-mf-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-range">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-name">
-   <b><a href="#typedef-mf-name">#typedef-mf-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-name" class="dfn-panel" data-for="typedef-mf-name" id="infopanel-for-typedef-mf-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-name" style="display:none">Info about the '&lt;mf-name>' definition.</span><b><a href="#typedef-mf-name">#typedef-mf-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-name">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-name①">(2)</a> <a href="#ref-for-typedef-mf-name②">(3)</a> <a href="#ref-for-typedef-mf-name③">(4)</a> <a href="#ref-for-typedef-mf-name④">(5)</a> <a href="#ref-for-typedef-mf-name⑤">(6)</a>
@@ -4347,8 +4347,8 @@ Syntax</a> <a href="#ref-for-typedef-mf-name①">(2)</a> <a href="#ref-for-typed
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-value">
-   <b><a href="#typedef-mf-value">#typedef-mf-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-value" class="dfn-panel" data-for="typedef-mf-value" id="infopanel-for-typedef-mf-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-value" style="display:none">Info about the '&lt;mf-value>' definition.</span><b><a href="#typedef-mf-value">#typedef-mf-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-value">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-value①">(2)</a> <a href="#ref-for-typedef-mf-value②">(3)</a> <a href="#ref-for-typedef-mf-value③">(4)</a> <a href="#ref-for-typedef-mf-value④">(5)</a> <a href="#ref-for-typedef-mf-value⑤">(6)</a> <a href="#ref-for-typedef-mf-value⑥">(7)</a>
@@ -4356,44 +4356,44 @@ Syntax</a> <a href="#ref-for-typedef-mf-value①">(2)</a> <a href="#ref-for-type
 Error Handling</a> <a href="#ref-for-typedef-mf-value⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-lt">
-   <b><a href="#typedef-mf-lt">#typedef-mf-lt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-lt" class="dfn-panel" data-for="typedef-mf-lt" id="infopanel-for-typedef-mf-lt" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-lt" style="display:none">Info about the '&lt;mf-lt>' definition.</span><b><a href="#typedef-mf-lt">#typedef-mf-lt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-lt">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-lt①">(2)</a> <a href="#ref-for-typedef-mf-lt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-gt">
-   <b><a href="#typedef-mf-gt">#typedef-mf-gt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-gt" class="dfn-panel" data-for="typedef-mf-gt" id="infopanel-for-typedef-mf-gt" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-gt" style="display:none">Info about the '&lt;mf-gt>' definition.</span><b><a href="#typedef-mf-gt">#typedef-mf-gt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-gt">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-gt①">(2)</a> <a href="#ref-for-typedef-mf-gt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-eq">
-   <b><a href="#typedef-mf-eq">#typedef-mf-eq</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-eq" class="dfn-panel" data-for="typedef-mf-eq" id="infopanel-for-typedef-mf-eq" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-eq" style="display:none">Info about the '&lt;mf-eq>' definition.</span><b><a href="#typedef-mf-eq">#typedef-mf-eq</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-eq">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-comparison">
-   <b><a href="#typedef-mf-comparison">#typedef-mf-comparison</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-comparison" class="dfn-panel" data-for="typedef-mf-comparison" id="infopanel-for-typedef-mf-comparison" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-comparison" style="display:none">Info about the '&lt;mf-comparison>' definition.</span><b><a href="#typedef-mf-comparison">#typedef-mf-comparison</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-comparison">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-comparison①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-general-enclosed">
-   <b><a href="#typedef-general-enclosed">#typedef-general-enclosed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-general-enclosed" class="dfn-panel" data-for="typedef-general-enclosed" id="infopanel-for-typedef-general-enclosed" role="dialog">
+   <span id="infopaneltitle-for-typedef-general-enclosed" style="display:none">Info about the '&lt;general-enclosed>' definition.</span><b><a href="#typedef-general-enclosed">#typedef-general-enclosed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-general-enclosed">3. 
 Syntax</a> <a href="#ref-for-typedef-general-enclosed①">(2)</a> <a href="#ref-for-typedef-general-enclosed②">(3)</a>
     <li><a href="#ref-for-typedef-general-enclosed③">3.1. Evaluating Media Queries</a> <a href="#ref-for-typedef-general-enclosed④">(2)</a> <a href="#ref-for-typedef-general-enclosed⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-width">
-   <b><a href="#descdef-media-width">#descdef-media-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-width" class="dfn-panel" data-for="descdef-media-width" id="infopanel-for-descdef-media-width" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-width" style="display:none">Info about the 'width' definition.</span><b><a href="#descdef-media-width">#descdef-media-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-width">2.4.1. 
 Media Feature Types: “range” and “discrete”</a>
@@ -4410,8 +4410,8 @@ Orientation: the orientation feature</a>
     <li><a href="#ref-for-descdef-media-width⑧"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-height">
-   <b><a href="#descdef-media-height">#descdef-media-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-height" class="dfn-panel" data-for="descdef-media-height" id="infopanel-for-descdef-media-height" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-height" style="display:none">Info about the 'height' definition.</span><b><a href="#descdef-media-height">#descdef-media-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-height">4.2. 
 Height: the height feature</a> <a href="#ref-for-descdef-media-height①">(2)</a> <a href="#ref-for-descdef-media-height②">(3)</a>
@@ -4422,43 +4422,43 @@ Orientation: the orientation feature</a>
     <li><a href="#ref-for-descdef-media-height⑤"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-orientation-portrait">
-   <b><a href="#valdef-media-orientation-portrait">#valdef-media-orientation-portrait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-orientation-portrait" class="dfn-panel" data-for="valdef-media-orientation-portrait" id="infopanel-for-valdef-media-orientation-portrait" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-orientation-portrait" style="display:none">Info about the 'portrait' definition.</span><b><a href="#valdef-media-orientation-portrait">#valdef-media-orientation-portrait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-portrait">4.4. 
 Orientation: the orientation feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-orientation-landscape">
-   <b><a href="#valdef-media-orientation-landscape">#valdef-media-orientation-landscape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-orientation-landscape" class="dfn-panel" data-for="valdef-media-orientation-landscape" id="infopanel-for-valdef-media-orientation-landscape" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-orientation-landscape" style="display:none">Info about the 'landscape' definition.</span><b><a href="#valdef-media-orientation-landscape">#valdef-media-orientation-landscape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-landscape">4.4. 
 Orientation: the orientation feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-resolution">
-   <b><a href="#descdef-media-resolution">#descdef-media-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-resolution" class="dfn-panel" data-for="descdef-media-resolution" id="infopanel-for-descdef-media-resolution" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-resolution" style="display:none">Info about the 'resolution' definition.</span><b><a href="#descdef-media-resolution">#descdef-media-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-resolution">2.4.3. 
 Evaluating Media Features in a Range Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-resolution-infinite">
-   <b><a href="#valdef-media-resolution-infinite">#valdef-media-resolution-infinite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-resolution-infinite" class="dfn-panel" data-for="valdef-media-resolution-infinite" id="infopanel-for-valdef-media-resolution-infinite" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-resolution-infinite" style="display:none">Info about the 'infinite' definition.</span><b><a href="#valdef-media-resolution-infinite">#valdef-media-resolution-infinite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-resolution-infinite">5.1. 
 Display Resolution: the resolution feature</a> <a href="#ref-for-valdef-media-resolution-infinite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-scan">
-   <b><a href="#descdef-media-scan">#descdef-media-scan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-scan" class="dfn-panel" data-for="descdef-media-scan" id="infopanel-for-descdef-media-scan" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-scan" style="display:none">Info about the 'scan' definition.</span><b><a href="#descdef-media-scan">#descdef-media-scan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-scan">5.2. 
 Display Type: the scan feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-grid">
-   <b><a href="#descdef-media-grid">#descdef-media-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-grid" class="dfn-panel" data-for="descdef-media-grid" id="infopanel-for-descdef-media-grid" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#descdef-media-grid">#descdef-media-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-grid">2.3. 
 Media Types</a>
@@ -4468,28 +4468,28 @@ Using “min-” and “max-” Prefixes On Range Features</a> <a href="#ref-for
 Detecting Console Displays: the grid feature</a> <a href="#ref-for-descdef-media-grid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mq-boolean">
-   <b><a href="#typedef-mq-boolean">#typedef-mq-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mq-boolean" class="dfn-panel" data-for="typedef-mq-boolean" id="infopanel-for-typedef-mq-boolean" role="dialog">
+   <span id="infopaneltitle-for-typedef-mq-boolean" style="display:none">Info about the '&lt;mq-boolean>' definition.</span><b><a href="#typedef-mq-boolean">#typedef-mq-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mq-boolean">5.3. 
 Detecting Console Displays: the grid feature</a> <a href="#ref-for-typedef-mq-boolean①">(2)</a> <a href="#ref-for-typedef-mq-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-update">
-   <b><a href="#descdef-media-update">#descdef-media-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-update" class="dfn-panel" data-for="descdef-media-update" id="infopanel-for-descdef-media-update" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-update" style="display:none">Info about the 'update' definition.</span><b><a href="#descdef-media-update">#descdef-media-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-update①"> Changes since the 5 September 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-update-none">
-   <b><a href="#valdef-media-update-none">#valdef-media-update-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-update-none" class="dfn-panel" data-for="valdef-media-update-none" id="infopanel-for-valdef-media-update-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-update-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-update-none">#valdef-media-update-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-update-none">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-overflow-block">
-   <b><a href="#descdef-media-overflow-block">#descdef-media-overflow-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-overflow-block" class="dfn-panel" data-for="descdef-media-overflow-block" id="infopanel-for-descdef-media-overflow-block" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-overflow-block" style="display:none">Info about the 'overflow-block' definition.</span><b><a href="#descdef-media-overflow-block">#descdef-media-overflow-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-overflow-block">5.5. 
 Block-Axis Overflow: the overflow-block feature</a> <a href="#ref-for-descdef-media-overflow-block①">(2)</a>
@@ -4497,22 +4497,22 @@ Block-Axis Overflow: the overflow-block feature</a> <a href="#ref-for-descdef-me
     <li><a href="#ref-for-descdef-media-overflow-block③"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-none">
-   <b><a href="#valdef-media-overflow-block-none">#valdef-media-overflow-block-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-none" class="dfn-panel" data-for="valdef-media-overflow-block-none" id="infopanel-for-valdef-media-overflow-block-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-overflow-block-none">#valdef-media-overflow-block-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-none">5.5. 
 Block-Axis Overflow: the overflow-block feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-scroll">
-   <b><a href="#valdef-media-overflow-block-scroll">#valdef-media-overflow-block-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-scroll" class="dfn-panel" data-for="valdef-media-overflow-block-scroll" id="infopanel-for-valdef-media-overflow-block-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-media-overflow-block-scroll">#valdef-media-overflow-block-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-scroll">5.5. 
 Block-Axis Overflow: the overflow-block feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-paged">
-   <b><a href="#valdef-media-overflow-block-paged">#valdef-media-overflow-block-paged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-paged" class="dfn-panel" data-for="valdef-media-overflow-block-paged" id="infopanel-for-valdef-media-overflow-block-paged" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-paged" style="display:none">Info about the 'paged' definition.</span><b><a href="#valdef-media-overflow-block-paged">#valdef-media-overflow-block-paged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-paged">5.5. 
 Block-Axis Overflow: the overflow-block feature</a>
@@ -4520,8 +4520,8 @@ Block-Axis Overflow: the overflow-block feature</a>
 Inline-Axis Overflow: the overflow-inline feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="continuous-media">
-   <b><a href="#continuous-media">#continuous-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-continuous-media" class="dfn-panel" data-for="continuous-media" id="infopanel-for-continuous-media" role="dialog">
+   <span id="infopaneltitle-for-continuous-media" style="display:none">Info about the 'continuous media' definition.</span><b><a href="#continuous-media">#continuous-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">4.1. 
 Width: the width feature</a>
@@ -4534,8 +4534,8 @@ Block-Axis Overflow: the overflow-block feature</a>
     <li><a href="#ref-for-continuous-media⑤"> Changes since the 5 September 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paged-media">
-   <b><a href="#paged-media">#paged-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paged-media" class="dfn-panel" data-for="paged-media" id="infopanel-for-paged-media" role="dialog">
+   <span id="infopaneltitle-for-paged-media" style="display:none">Info about the 'paged media' definition.</span><b><a href="#paged-media">#paged-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">4.1. 
 Width: the width feature</a>
@@ -4548,16 +4548,16 @@ Block-Axis Overflow: the overflow-block feature</a>
     <li><a href="#ref-for-paged-media⑤"> Changes since the 5 September 2017 Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-overflow-inline">
-   <b><a href="#descdef-media-overflow-inline">#descdef-media-overflow-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-overflow-inline" class="dfn-panel" data-for="descdef-media-overflow-inline" id="infopanel-for-descdef-media-overflow-inline" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-overflow-inline" style="display:none">Info about the 'overflow-inline' definition.</span><b><a href="#descdef-media-overflow-inline">#descdef-media-overflow-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-overflow-inline">5.6. 
 Inline-Axis Overflow: the overflow-inline feature</a> <a href="#ref-for-descdef-media-overflow-inline①">(2)</a> <a href="#ref-for-descdef-media-overflow-inline②">(3)</a>
     <li><a href="#ref-for-descdef-media-overflow-inline③"> Changes Since Media Queries Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color">
-   <b><a href="#descdef-media-color">#descdef-media-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color" class="dfn-panel" data-for="descdef-media-color" id="infopanel-for-descdef-media-color" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color" style="display:none">Info about the 'color' definition.</span><b><a href="#descdef-media-color">#descdef-media-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color">2.4. 
 Media Features</a>
@@ -4569,57 +4569,57 @@ Error Handling</a>
 Color Depth: the color feature</a> <a href="#ref-for-descdef-media-color④">(2)</a> <a href="#ref-for-descdef-media-color⑤">(3)</a> <a href="#ref-for-descdef-media-color⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color-index">
-   <b><a href="#descdef-media-color-index">#descdef-media-color-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color-index" class="dfn-panel" data-for="descdef-media-color-index" id="infopanel-for-descdef-media-color-index" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color-index" style="display:none">Info about the 'color-index' definition.</span><b><a href="#descdef-media-color-index">#descdef-media-color-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color-index">6.2. 
 Paletted Color Screens: the color-index feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-monochrome">
-   <b><a href="#descdef-media-monochrome">#descdef-media-monochrome</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-monochrome" class="dfn-panel" data-for="descdef-media-monochrome" id="infopanel-for-descdef-media-monochrome" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-monochrome" style="display:none">Info about the 'monochrome' definition.</span><b><a href="#descdef-media-monochrome">#descdef-media-monochrome</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-monochrome">6.3. 
 Monochrome Screens: the monochrome feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color-gamut">
-   <b><a href="#descdef-media-color-gamut">#descdef-media-color-gamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color-gamut" class="dfn-panel" data-for="descdef-media-color-gamut" id="infopanel-for-descdef-media-color-gamut" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color-gamut" style="display:none">Info about the 'color-gamut' definition.</span><b><a href="#descdef-media-color-gamut">#descdef-media-color-gamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color-gamut">6.1. 
 Color Depth: the color feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-srgb">
-   <b><a href="#valdef-media-color-gamut-srgb">#valdef-media-color-gamut-srgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-srgb" class="dfn-panel" data-for="valdef-media-color-gamut-srgb" id="infopanel-for-valdef-media-color-gamut-srgb" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-srgb" style="display:none">Info about the 'srgb' definition.</span><b><a href="#valdef-media-color-gamut-srgb">#valdef-media-color-gamut-srgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-srgb">6.4. 
 Color Display Quality: the color-gamut feature</a> <a href="#ref-for-valdef-media-color-gamut-srgb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-p3">
-   <b><a href="#valdef-media-color-gamut-p3">#valdef-media-color-gamut-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-p3" class="dfn-panel" data-for="valdef-media-color-gamut-p3" id="infopanel-for-valdef-media-color-gamut-p3" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-p3" style="display:none">Info about the 'p3' definition.</span><b><a href="#valdef-media-color-gamut-p3">#valdef-media-color-gamut-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-p3">6.4. 
 Color Display Quality: the color-gamut feature</a> <a href="#ref-for-valdef-media-color-gamut-p3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-rec2020">
-   <b><a href="#valdef-media-color-gamut-rec2020">#valdef-media-color-gamut-rec2020</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-rec2020" class="dfn-panel" data-for="valdef-media-color-gamut-rec2020" id="infopanel-for-valdef-media-color-gamut-rec2020" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-rec2020" style="display:none">Info about the 'rec2020' definition.</span><b><a href="#valdef-media-color-gamut-rec2020">#valdef-media-color-gamut-rec2020</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-rec2020">6.4. 
 Color Display Quality: the color-gamut feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-pointer">
-   <b><a href="#descdef-media-pointer">#descdef-media-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-pointer" class="dfn-panel" data-for="descdef-media-pointer" id="infopanel-for-descdef-media-pointer" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#descdef-media-pointer">#descdef-media-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-pointer">7. 
 Interaction Media Features</a> <a href="#ref-for-descdef-media-pointer①">(2)</a> <a href="#ref-for-descdef-media-pointer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-none">
-   <b><a href="#valdef-media-pointer-none">#valdef-media-pointer-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-none" class="dfn-panel" data-for="valdef-media-pointer-none" id="infopanel-for-valdef-media-pointer-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-pointer-none">#valdef-media-pointer-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-none">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
@@ -4629,8 +4629,8 @@ Pointing Device Quality: the pointer feature</a>
 All Available Interaction Capabilities: the any-pointer and any-hover features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-coarse">
-   <b><a href="#valdef-media-pointer-coarse">#valdef-media-pointer-coarse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-coarse" class="dfn-panel" data-for="valdef-media-pointer-coarse" id="infopanel-for-valdef-media-pointer-coarse" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-coarse" style="display:none">Info about the 'coarse' definition.</span><b><a href="#valdef-media-pointer-coarse">#valdef-media-pointer-coarse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-coarse">7.1. 
 Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-pointer-coarse①">(2)</a> <a href="#ref-for-valdef-media-pointer-coarse②">(3)</a> <a href="#ref-for-valdef-media-pointer-coarse③">(4)</a> <a href="#ref-for-valdef-media-pointer-coarse④">(5)</a> <a href="#ref-for-valdef-media-pointer-coarse⑤">(6)</a> <a href="#ref-for-valdef-media-pointer-coarse⑥">(7)</a>
@@ -4638,8 +4638,8 @@ Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-
 All Available Interaction Capabilities: the any-pointer and any-hover features</a> <a href="#ref-for-valdef-media-pointer-coarse⑧">(2)</a> <a href="#ref-for-valdef-media-pointer-coarse⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-fine">
-   <b><a href="#valdef-media-pointer-fine">#valdef-media-pointer-fine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-fine" class="dfn-panel" data-for="valdef-media-pointer-fine" id="infopanel-for-valdef-media-pointer-fine" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-fine" style="display:none">Info about the 'fine' definition.</span><b><a href="#valdef-media-pointer-fine">#valdef-media-pointer-fine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-fine">7.1. 
 Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-pointer-fine①">(2)</a> <a href="#ref-for-valdef-media-pointer-fine②">(3)</a>
@@ -4647,8 +4647,8 @@ Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-
 All Available Interaction Capabilities: the any-pointer and any-hover features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-hover">
-   <b><a href="#descdef-media-hover">#descdef-media-hover</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-hover" class="dfn-panel" data-for="descdef-media-hover" id="infopanel-for-descdef-media-hover" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-hover" style="display:none">Info about the 'hover' definition.</span><b><a href="#descdef-media-hover">#descdef-media-hover</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-hover">7. 
 Interaction Media Features</a> <a href="#ref-for-descdef-media-hover①">(2)</a>
@@ -4656,14 +4656,14 @@ Interaction Media Features</a> <a href="#ref-for-descdef-media-hover①">(2)</a>
 Hover Capability: the hover feature</a> <a href="#ref-for-descdef-media-hover③">(2)</a> <a href="#ref-for-descdef-media-hover④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-device-width">
-   <b><a href="#descdef-media-device-width">#descdef-media-device-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-device-width" class="dfn-panel" data-for="descdef-media-device-width" id="infopanel-for-descdef-media-device-width" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-device-width" style="display:none">Info about the 'device-width' definition.</span><b><a href="#descdef-media-device-width">#descdef-media-device-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-device-width"> device-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-device-height">
-   <b><a href="#descdef-media-device-height">#descdef-media-device-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-device-height" class="dfn-panel" data-for="descdef-media-device-height" id="infopanel-for-descdef-media-device-height" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-device-height" style="display:none">Info about the 'device-height' definition.</span><b><a href="#descdef-media-device-height">#descdef-media-device-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-device-height"> device-height</a>
    </ul>
@@ -4685,57 +4685,113 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/mediaqueries-5/Overview.html
+++ b/tests/github/w3c/csswg-drafts/mediaqueries-5/Overview.html
@@ -4293,8 +4293,8 @@ improved this specification.</p>
    <li><a href="#descdef-media-video-width">video-width</a><span>, in § 8.3</span>
    <li><a href="#descdef-media-width">width</a><span>, in § 4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">1. 
 Introduction</a>
@@ -4302,8 +4302,8 @@ Introduction</a>
 Custom Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-value" class="dfn-panel" data-for="term-for-initial-value" id="infopanel-for-term-for-initial-value" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-value" style="display:none">Info about the 'initial value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#initial-value">https://drafts.csswg.org/css-cascade-5/#initial-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-value">1.3. 
 Units</a> <a href="#ref-for-initial-value①">(2)</a>
@@ -4311,22 +4311,22 @@ Units</a> <a href="#ref-for-initial-value①">(2)</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade-origin-ua">
-   <a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade-origin-ua" class="dfn-panel" data-for="term-for-cascade-origin-ua" id="infopanel-for-term-for-cascade-origin-ua" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade-origin-ua" style="display:none">Info about the 'ua style sheet' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua">https://drafts.csswg.org/css-cascade-5/#cascade-origin-ua</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade-origin-ua">6.6. 
 Detecting inverted colors on the display: the inverted-colors feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forced-colors-mode">
-   <a href="https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode">https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forced-colors-mode" class="dfn-panel" data-for="term-for-forced-colors-mode" id="infopanel-for-term-for-forced-colors-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-forced-colors-mode" style="display:none">Info about the 'forced colors mode' external reference.</span><a href="https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode">https://drafts.csswg.org/css-color-adjust-1/#forced-colors-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forced-colors-mode">11.4. 
 Detecting Forced Colors Mode: the forced-colors feature</a> <a href="#ref-for-forced-colors-mode①">(2)</a> <a href="#ref-for-forced-colors-mode②">(3)</a> <a href="#ref-for-forced-colors-mode③">(4)</a> <a href="#ref-for-forced-colors-mode④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">1. 
 Introduction</a>
@@ -4403,15 +4403,15 @@ Detecting the desire for reduced data usage when loading a page: the prefers-red
     <li><a href="#ref-for-at-ruledef-media③⑧"> device-aspect-ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-extension-name">
-   <a href="https://drafts.csswg.org/css-extensions-1/#typedef-extension-name">https://drafts.csswg.org/css-extensions-1/#typedef-extension-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-extension-name" class="dfn-panel" data-for="term-for-typedef-extension-name" id="infopanel-for-term-for-typedef-extension-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-extension-name" style="display:none">Info about the '&lt;extension-name>' external reference.</span><a href="https://drafts.csswg.org/css-extensions-1/#typedef-extension-name">https://drafts.csswg.org/css-extensions-1/#typedef-extension-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-extension-name">10. 
 Custom Media Queries</a> <a href="#ref-for-typedef-extension-name①">(2)</a> <a href="#ref-for-typedef-extension-name②">(3)</a> <a href="#ref-for-typedef-extension-name③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">1.3. 
 Units</a>
@@ -4419,44 +4419,44 @@ Units</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-aspect-ratio">
-   <a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-aspect-ratio" class="dfn-panel" data-for="term-for-propdef-aspect-ratio" id="infopanel-for-term-for-propdef-aspect-ratio" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-aspect-ratio" style="display:none">Info about the 'aspect-ratio' external reference.</span><a href="https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio">https://drafts.csswg.org/css-sizing-4/#propdef-aspect-ratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-aspect-ratio">4.3. 
 Aspect-Ratio: the aspect-ratio feature</a> <a href="#ref-for-propdef-aspect-ratio①">(2)</a>
     <li><a href="#ref-for-propdef-aspect-ratio②"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-any-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-any-value" class="dfn-panel" data-for="term-for-typedef-any-value" id="infopanel-for-term-for-typedef-any-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-any-value" style="display:none">Info about the '&lt;any-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-any-value">3. 
 Syntax</a> <a href="#ref-for-typedef-any-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-delim-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-delim-token" class="dfn-panel" data-for="term-for-typedef-delim-token" id="infopanel-for-term-for-typedef-delim-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-delim-token" style="display:none">Info about the '&lt;delim-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-delim-token">https://drafts.csswg.org/css-syntax-3/#typedef-delim-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-delim-token">3. 
 Syntax</a> <a href="#ref-for-typedef-delim-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-function-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-function-token" class="dfn-panel" data-for="term-for-typedef-function-token" id="infopanel-for-term-for-typedef-function-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">3. 
 Syntax</a> <a href="#ref-for-typedef-function-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-comma-separated-list-of-component-values">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-comma-separated-list-of-component-values" class="dfn-panel" data-for="term-for-parse-a-comma-separated-list-of-component-values" id="infopanel-for-term-for-parse-a-comma-separated-list-of-component-values" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-comma-separated-list-of-component-values" style="display:none">Info about the 'parse a comma-separated list of component values' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values">https://drafts.csswg.org/css-syntax-3/#parse-a-comma-separated-list-of-component-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-comma-separated-list-of-component-values">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension" class="dfn-panel" data-for="term-for-typedef-dimension" id="infopanel-for-term-for-typedef-dimension" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension" style="display:none">Info about the '&lt;dimension>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-dimension">https://drafts.csswg.org/css-values-4/#typedef-dimension</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
@@ -4464,15 +4464,15 @@ Evaluating Media Features in a Boolean Context</a>
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">3. 
 Syntax</a> <a href="#ref-for-typedef-ident①">(2)</a> <a href="#ref-for-typedef-ident②">(3)</a> <a href="#ref-for-typedef-ident③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#integer-value">https://drafts.csswg.org/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">1.2. 
 Values</a>
@@ -4486,8 +4486,8 @@ Paletted Color Screens: the color-index feature</a>
 Monochrome Screens: the monochrome feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.1. 
 Width: the width feature</a> <a href="#ref-for-length-value①">(2)</a>
@@ -4501,8 +4501,8 @@ Video-Height: the video-height feature</a> <a href="#ref-for-length-value⑦">(2
     <li><a href="#ref-for-length-value⑨"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">1.2. 
 Values</a>
@@ -4510,8 +4510,8 @@ Values</a>
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ratio-value">
-   <a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ratio-value" class="dfn-panel" data-for="term-for-ratio-value" id="infopanel-for-term-for-ratio-value" role="menu">
+   <span id="infopaneltitle-for-term-for-ratio-value" style="display:none">Info about the '&lt;ratio>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#ratio-value">https://drafts.csswg.org/css-values-4/#ratio-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ratio-value">3. 
 Syntax</a>
@@ -4520,8 +4520,8 @@ Aspect-Ratio: the aspect-ratio feature</a>
     <li><a href="#ref-for-ratio-value②"> device-aspect-ratio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolution-value">
-   <a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolution-value" class="dfn-panel" data-for="term-for-resolution-value" id="infopanel-for-term-for-resolution-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolution-value" style="display:none">Info about the '&lt;resolution>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#resolution-value">https://drafts.csswg.org/css-values-4/#resolution-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolution-value">1.2. 
 Values</a>
@@ -4531,15 +4531,15 @@ Display Resolution: the resolution feature</a> <a href="#ref-for-resolution-valu
 Video Display Resolution: the video-resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cm">
-   <a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cm" class="dfn-panel" data-for="term-for-cm" id="infopanel-for-term-for-cm" role="menu">
+   <span id="infopaneltitle-for-term-for-cm" style="display:none">Info about the 'cm' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-em">
-   <a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-em" class="dfn-panel" data-for="term-for-em" id="infopanel-for-term-for-em" role="menu">
+   <span id="infopaneltitle-for-term-for-em" style="display:none">Info about the 'em' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#em">https://drafts.csswg.org/css-values-4/#em</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-em">1.3. 
 Units</a>
@@ -4547,15 +4547,15 @@ Units</a>
 Width: the width feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in">
-   <a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in" class="dfn-panel" data-for="term-for-in" id="infopanel-for-term-for-in" role="menu">
+   <span id="infopaneltitle-for-term-for-in" style="display:none">Info about the 'in' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">5.1. 
 Display Resolution: the resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">5.1. 
 Display Resolution: the resolution feature</a>
@@ -4563,15 +4563,15 @@ Display Resolution: the resolution feature</a>
     <li><a href="#ref-for-px②"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-length">
-   <a href="https://drafts.csswg.org/css-values-4/#relative-length">https://drafts.csswg.org/css-values-4/#relative-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-length" class="dfn-panel" data-for="term-for-relative-length" id="infopanel-for-term-for-relative-length" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-length" style="display:none">Info about the 'relative length' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#relative-length">https://drafts.csswg.org/css-values-4/#relative-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-length">1.3. 
 Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.4. 
 Orientation: the orientation feature</a>
@@ -4623,22 +4623,22 @@ Detecting the desire for light or dark color schemes: the prefers-color-scheme f
 Detecting the desire for reduced data usage when loading a page: the prefers-reduced-data feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#block-axis">https://www.w3.org/TR/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#block-axis">https://www.w3.org/TR/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">4.5. 
 Block-Axis Overflow: the overflow-block feature</a> <a href="#ref-for-block-axis①">(2)</a> <a href="#ref-for-block-axis②">(3)</a> <a href="#ref-for-block-axis③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://www.w3.org/TR/css-writing-modes-4/#inline-axis">https://www.w3.org/TR/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://www.w3.org/TR/css-writing-modes-4/#inline-axis">https://www.w3.org/TR/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">4.6. 
 Inline-Axis Overflow: the overflow-inline feature</a> <a href="#ref-for-inline-axis①">(2)</a> <a href="#ref-for-inline-axis②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-zoom">
-   <a href="https://drafts.csswg.org/cssom-view-1/#page-zoom">https://drafts.csswg.org/cssom-view-1/#page-zoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-zoom" class="dfn-panel" data-for="term-for-page-zoom" id="infopanel-for-term-for-page-zoom" role="menu">
+   <span id="infopaneltitle-for-term-for-page-zoom" style="display:none">Info about the 'page zoom' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#page-zoom">https://drafts.csswg.org/cssom-view-1/#page-zoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-zoom">5.1. 
 Display Resolution: the resolution feature</a>
@@ -4646,8 +4646,8 @@ Display Resolution: the resolution feature</a>
 Video Display Resolution: the video-resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pinch-zoom">
-   <a href="https://www.w3.org/TR/cssom-view-1/#pinch-zoom">https://www.w3.org/TR/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pinch-zoom" class="dfn-panel" data-for="term-for-pinch-zoom" id="infopanel-for-term-for-pinch-zoom" role="menu">
+   <span id="infopaneltitle-for-term-for-pinch-zoom" style="display:none">Info about the 'pinch zoom' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#pinch-zoom">https://www.w3.org/TR/cssom-view-1/#pinch-zoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinch-zoom">5.1. 
 Display Resolution: the resolution feature</a>
@@ -4655,15 +4655,15 @@ Display Resolution: the resolution feature</a>
 Video Display Resolution: the video-resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-web-exposed-screen-area">
-   <a href="https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area">https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-web-exposed-screen-area" class="dfn-panel" data-for="term-for-web-exposed-screen-area" id="infopanel-for-term-for-web-exposed-screen-area" role="menu">
+   <span id="infopaneltitle-for-term-for-web-exposed-screen-area" style="display:none">Info about the 'web-exposed screen area' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area">https://drafts.csswg.org/cssom-view-1/#web-exposed-screen-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-exposed-screen-area"> device-width</a>
     <li><a href="#ref-for-web-exposed-screen-area①"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3. 
 Syntax</a>
@@ -5090,8 +5090,8 @@ CSS.customMedia.set('--foo', 5);
    <div class="issue"> This feature is an early draft,
 	and the CSS-WG does not consider it ready for shipping in production. <a href="https://github.com/w3c/csswg-drafts/issues/4834">[Issue #4834]</a> <a class="issue-return" href="#issue-e89a5833" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="media-query">
-   <b><a href="#media-query">#media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query" class="dfn-panel" data-for="media-query" id="infopanel-for-media-query" role="dialog">
+   <span id="infopaneltitle-for-media-query" style="display:none">Info about the 'media query' definition.</span><b><a href="#media-query">#media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query①">1. 
 Introduction</a>
@@ -5115,8 +5115,8 @@ Evaluating Media Queries</a> <a href="#ref-for-media-query②⑥">(2)</a>
 Error Handling</a> <a href="#ref-for-media-query②⑧">(2)</a> <a href="#ref-for-media-query②⑨">(3)</a> <a href="#ref-for-media-query③⓪">(4)</a> <a href="#ref-for-media-query③①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-query-list">
-   <b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query-list" class="dfn-panel" data-for="media-query-list" id="infopanel-for-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-media-query-list" style="display:none">Info about the 'media query list' definition.</span><b><a href="#media-query-list">#media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-list">2.1. 
 Combining Media Queries</a> <a href="#ref-for-media-query-list①">(2)</a> <a href="#ref-for-media-query-list②">(3)</a>
@@ -5126,8 +5126,8 @@ Syntax</a>
 Error Handling</a> <a href="#ref-for-media-query-list⑤">(2)</a> <a href="#ref-for-media-query-list⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-query-modifier">
-   <b><a href="#media-query-modifier">#media-query-modifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-query-modifier" class="dfn-panel" data-for="media-query-modifier" id="infopanel-for-media-query-modifier" role="dialog">
+   <span id="infopaneltitle-for-media-query-modifier" style="display:none">Info about the 'media query modifier' definition.</span><b><a href="#media-query-modifier">#media-query-modifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-query-modifier">2. 
 Media Queries</a>
@@ -5135,8 +5135,8 @@ Media Queries</a>
 Hiding a Media Query From Legacy user agents: the only keyword</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-not">
-   <b><a href="#valdef-media-not">#valdef-media-not</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-not" class="dfn-panel" data-for="valdef-media-not" id="infopanel-for-valdef-media-not" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-not" style="display:none">Info about the 'not' definition.</span><b><a href="#valdef-media-not">#valdef-media-not</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-not">2.2.1. 
 Negating a Media Query: the not keyword</a> <a href="#ref-for-valdef-media-not①">(2)</a>
@@ -5150,8 +5150,8 @@ Syntax</a> <a href="#ref-for-valdef-media-not⑥">(2)</a>
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-only">
-   <b><a href="#valdef-media-only">#valdef-media-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-only" class="dfn-panel" data-for="valdef-media-only" id="infopanel-for-valdef-media-only" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-only" style="display:none">Info about the 'only' definition.</span><b><a href="#valdef-media-only">#valdef-media-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-only">2.2.2. 
 Hiding a Media Query From Legacy user agents: the only keyword</a> <a href="#ref-for-valdef-media-only①">(2)</a> <a href="#ref-for-valdef-media-only②">(3)</a> <a href="#ref-for-valdef-media-only③">(4)</a>
@@ -5159,8 +5159,8 @@ Hiding a Media Query From Legacy user agents: the only keyword</a> <a href="#ref
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-type">
-   <b><a href="#media-type">#media-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-type" class="dfn-panel" data-for="media-type" id="infopanel-for-media-type" role="dialog">
+   <span id="infopaneltitle-for-media-type" style="display:none">Info about the 'media type' definition.</span><b><a href="#media-type">#media-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-type">1. 
 Introduction</a> <a href="#ref-for-media-type①">(2)</a>
@@ -5180,15 +5180,15 @@ Media Features</a>
 Error Handling</a> <a href="#ref-for-media-type②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-print">
-   <b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-print" class="dfn-panel" data-for="valdef-media-print" id="infopanel-for-valdef-media-print" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-print" style="display:none">Info about the 'print' definition.</span><b><a href="#valdef-media-print">#valdef-media-print</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-print">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-screen">
-   <b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-screen" class="dfn-panel" data-for="valdef-media-screen" id="infopanel-for-valdef-media-screen" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#valdef-media-screen">#valdef-media-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-screen">2. 
 Media Queries</a>
@@ -5200,36 +5200,36 @@ Hiding a Media Query From Legacy user agents: the only keyword</a> <a href="#ref
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-tty">
-   <b><a href="#valdef-media-tty">#valdef-media-tty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-tty" class="dfn-panel" data-for="valdef-media-tty" id="infopanel-for-valdef-media-tty" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-tty" style="display:none">Info about the 'tty' definition.</span><b><a href="#valdef-media-tty">#valdef-media-tty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-tty">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-tv">
-   <b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-tv" class="dfn-panel" data-for="valdef-media-tv" id="infopanel-for-valdef-media-tv" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-tv" style="display:none">Info about the 'tv' definition.</span><b><a href="#valdef-media-tv">#valdef-media-tv</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-tv">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-projection">
-   <b><a href="#valdef-media-projection">#valdef-media-projection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-projection" class="dfn-panel" data-for="valdef-media-projection" id="infopanel-for-valdef-media-projection" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-projection" style="display:none">Info about the 'projection' definition.</span><b><a href="#valdef-media-projection">#valdef-media-projection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-projection">2.1. 
 Combining Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-handheld">
-   <b><a href="#valdef-media-handheld">#valdef-media-handheld</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-handheld" class="dfn-panel" data-for="valdef-media-handheld" id="infopanel-for-valdef-media-handheld" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-handheld" style="display:none">Info about the 'handheld' definition.</span><b><a href="#valdef-media-handheld">#valdef-media-handheld</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-handheld">2.3. 
 Media Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-speech">
-   <b><a href="#valdef-media-speech">#valdef-media-speech</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-speech" class="dfn-panel" data-for="valdef-media-speech" id="infopanel-for-valdef-media-speech" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-speech" style="display:none">Info about the 'speech' definition.</span><b><a href="#valdef-media-speech">#valdef-media-speech</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-speech">2.4. 
 Media Features</a>
@@ -5237,8 +5237,8 @@ Media Features</a>
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-feature">
-   <b><a href="#media-feature">#media-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-feature" class="dfn-panel" data-for="media-feature" id="infopanel-for-media-feature" role="dialog">
+   <span id="infopaneltitle-for-media-feature" style="display:none">Info about the 'media feature' definition.</span><b><a href="#media-feature">#media-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-feature">2. 
 Media Queries</a>
@@ -5267,8 +5267,8 @@ Custom Media Queries</a> <a href="#ref-for-media-feature③④">(2)</a> <a href=
     <li><a href="#ref-for-media-feature③⑥"> Appendix A: Deprecated Media Features</a> <a href="#ref-for-media-feature③⑦">(2)</a> <a href="#ref-for-media-feature③⑧">(3)</a> <a href="#ref-for-media-feature③⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean-context">
-   <b><a href="#boolean-context">#boolean-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean-context" class="dfn-panel" data-for="boolean-context" id="infopanel-for-boolean-context" role="dialog">
+   <span id="infopaneltitle-for-boolean-context" style="display:none">Info about the 'boolean context' definition.</span><b><a href="#boolean-context">#boolean-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean-context">2.4. 
 Media Features</a>
@@ -5288,8 +5288,8 @@ Detecting the desire for increased or decreased color contrast from elements on 
 Detecting the desire for reduced data usage when loading a page: the prefers-reduced-data feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="range-context">
-   <b><a href="#range-context">#range-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-range-context" class="dfn-panel" data-for="range-context" id="infopanel-for-range-context" role="dialog">
+   <span id="infopaneltitle-for-range-context" style="display:none">Info about the 'range context' definition.</span><b><a href="#range-context">#range-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range-context">2.4. 
 Media Features</a>
@@ -5303,8 +5303,8 @@ Display Resolution: the resolution feature</a>
 Custom Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="false-in-the-negative-range">
-   <b><a href="#false-in-the-negative-range">#false-in-the-negative-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-false-in-the-negative-range" class="dfn-panel" data-for="false-in-the-negative-range" id="infopanel-for-false-in-the-negative-range" role="dialog">
+   <span id="infopaneltitle-for-false-in-the-negative-range" style="display:none">Info about the 'false in the negative range' definition.</span><b><a href="#false-in-the-negative-range">#false-in-the-negative-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-false-in-the-negative-range">4.1. 
 Width: the width feature</a>
@@ -5328,8 +5328,8 @@ Video Display Resolution: the video-resolution feature</a>
     <li><a href="#ref-for-false-in-the-negative-range①⓪"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-condition">
-   <b><a href="#media-condition">#media-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-condition" class="dfn-panel" data-for="media-condition" id="infopanel-for-media-condition" role="dialog">
+   <span id="infopaneltitle-for-media-condition" style="display:none">Info about the 'media condition' definition.</span><b><a href="#media-condition">#media-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-condition">2. 
 Media Queries</a>
@@ -5337,8 +5337,8 @@ Media Queries</a>
 Combining Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query-list">
-   <b><a href="#typedef-media-query-list">#typedef-media-query-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query-list" class="dfn-panel" data-for="typedef-media-query-list" id="infopanel-for-typedef-media-query-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query-list" style="display:none">Info about the '&lt;media-query-list>' definition.</span><b><a href="#typedef-media-query-list">#typedef-media-query-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query-list">3. 
 Syntax</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
@@ -5346,8 +5346,8 @@ Syntax</a> <a href="#ref-for-typedef-media-query-list①">(2)</a>
 Custom Media Queries</a> <a href="#ref-for-typedef-media-query-list③">(2)</a> <a href="#ref-for-typedef-media-query-list④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-query">
-   <b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-query" class="dfn-panel" data-for="typedef-media-query" id="infopanel-for-typedef-media-query" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-query" style="display:none">Info about the '&lt;media-query>' definition.</span><b><a href="#typedef-media-query">#typedef-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-query">3. 
 Syntax</a> <a href="#ref-for-typedef-media-query①">(2)</a>
@@ -5355,8 +5355,8 @@ Syntax</a> <a href="#ref-for-typedef-media-query①">(2)</a>
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-type">
-   <b><a href="#typedef-media-type">#typedef-media-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-type" class="dfn-panel" data-for="typedef-media-type" id="infopanel-for-typedef-media-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-type" style="display:none">Info about the '&lt;media-type>' definition.</span><b><a href="#typedef-media-type">#typedef-media-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-type">3. 
 Syntax</a> <a href="#ref-for-typedef-media-type①">(2)</a>
@@ -5364,8 +5364,8 @@ Syntax</a> <a href="#ref-for-typedef-media-type①">(2)</a>
 Error Handling</a> <a href="#ref-for-typedef-media-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-condition">
-   <b><a href="#typedef-media-condition">#typedef-media-condition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-condition" class="dfn-panel" data-for="typedef-media-condition" id="infopanel-for-typedef-media-condition" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-condition" style="display:none">Info about the '&lt;media-condition>' definition.</span><b><a href="#typedef-media-condition">#typedef-media-condition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-condition">3. 
 Syntax</a> <a href="#ref-for-typedef-media-condition①">(2)</a>
@@ -5373,8 +5373,8 @@ Syntax</a> <a href="#ref-for-typedef-media-condition①">(2)</a>
 Evaluating Media Queries</a> <a href="#ref-for-typedef-media-condition③">(2)</a> <a href="#ref-for-typedef-media-condition④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-condition-without-or">
-   <b><a href="#typedef-media-condition-without-or">#typedef-media-condition-without-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-condition-without-or" class="dfn-panel" data-for="typedef-media-condition-without-or" id="infopanel-for-typedef-media-condition-without-or" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-condition-without-or" style="display:none">Info about the '&lt;media-condition-without-or>' definition.</span><b><a href="#typedef-media-condition-without-or">#typedef-media-condition-without-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-condition-without-or">3. 
 Syntax</a>
@@ -5382,8 +5382,8 @@ Syntax</a>
 Evaluating Media Queries</a> <a href="#ref-for-typedef-media-condition-without-or②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-not">
-   <b><a href="#typedef-media-not">#typedef-media-not</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-not" class="dfn-panel" data-for="typedef-media-not" id="infopanel-for-typedef-media-not" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-not" style="display:none">Info about the '&lt;media-not>' definition.</span><b><a href="#typedef-media-not">#typedef-media-not</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-not">3. 
 Syntax</a> <a href="#ref-for-typedef-media-not①">(2)</a>
@@ -5391,8 +5391,8 @@ Syntax</a> <a href="#ref-for-typedef-media-not①">(2)</a>
 Evaluating Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-and">
-   <b><a href="#typedef-media-and">#typedef-media-and</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-and" class="dfn-panel" data-for="typedef-media-and" id="infopanel-for-typedef-media-and" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-and" style="display:none">Info about the '&lt;media-and>' definition.</span><b><a href="#typedef-media-and">#typedef-media-and</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-and">3. 
 Syntax</a> <a href="#ref-for-typedef-media-and①">(2)</a>
@@ -5400,8 +5400,8 @@ Syntax</a> <a href="#ref-for-typedef-media-and①">(2)</a>
 Evaluating Media Queries</a> <a href="#ref-for-typedef-media-and③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-or">
-   <b><a href="#typedef-media-or">#typedef-media-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-or" class="dfn-panel" data-for="typedef-media-or" id="infopanel-for-typedef-media-or" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-or" style="display:none">Info about the '&lt;media-or>' definition.</span><b><a href="#typedef-media-or">#typedef-media-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-or">3. 
 Syntax</a>
@@ -5409,8 +5409,8 @@ Syntax</a>
 Evaluating Media Queries</a> <a href="#ref-for-typedef-media-or②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-in-parens">
-   <b><a href="#typedef-media-in-parens">#typedef-media-in-parens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-in-parens" class="dfn-panel" data-for="typedef-media-in-parens" id="infopanel-for-typedef-media-in-parens" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-in-parens" style="display:none">Info about the '&lt;media-in-parens>' definition.</span><b><a href="#typedef-media-in-parens">#typedef-media-in-parens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-in-parens">3. 
 Syntax</a> <a href="#ref-for-typedef-media-in-parens①">(2)</a> <a href="#ref-for-typedef-media-in-parens②">(3)</a> <a href="#ref-for-typedef-media-in-parens③">(4)</a> <a href="#ref-for-typedef-media-in-parens④">(5)</a> <a href="#ref-for-typedef-media-in-parens⑤">(6)</a>
@@ -5418,8 +5418,8 @@ Syntax</a> <a href="#ref-for-typedef-media-in-parens①">(2)</a> <a href="#ref-f
 Evaluating Media Queries</a> <a href="#ref-for-typedef-media-in-parens⑦">(2)</a> <a href="#ref-for-typedef-media-in-parens⑧">(3)</a> <a href="#ref-for-typedef-media-in-parens⑨">(4)</a> <a href="#ref-for-typedef-media-in-parens①⓪">(5)</a> <a href="#ref-for-typedef-media-in-parens①①">(6)</a> <a href="#ref-for-typedef-media-in-parens①②">(7)</a> <a href="#ref-for-typedef-media-in-parens①③">(8)</a> <a href="#ref-for-typedef-media-in-parens①④">(9)</a> <a href="#ref-for-typedef-media-in-parens①⑤">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-media-feature">
-   <b><a href="#typedef-media-feature">#typedef-media-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-media-feature" class="dfn-panel" data-for="typedef-media-feature" id="infopanel-for-typedef-media-feature" role="dialog">
+   <span id="infopaneltitle-for-typedef-media-feature" style="display:none">Info about the '&lt;media-feature>' definition.</span><b><a href="#typedef-media-feature">#typedef-media-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-media-feature">3. 
 Syntax</a>
@@ -5427,29 +5427,29 @@ Syntax</a>
 Evaluating Media Queries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-plain">
-   <b><a href="#typedef-mf-plain">#typedef-mf-plain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-plain" class="dfn-panel" data-for="typedef-mf-plain" id="infopanel-for-typedef-mf-plain" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-plain" style="display:none">Info about the '&lt;mf-plain>' definition.</span><b><a href="#typedef-mf-plain">#typedef-mf-plain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-plain">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-boolean">
-   <b><a href="#typedef-mf-boolean">#typedef-mf-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-boolean" class="dfn-panel" data-for="typedef-mf-boolean" id="infopanel-for-typedef-mf-boolean" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-boolean" style="display:none">Info about the '&lt;mf-boolean>' definition.</span><b><a href="#typedef-mf-boolean">#typedef-mf-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-boolean">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-range">
-   <b><a href="#typedef-mf-range">#typedef-mf-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-range" class="dfn-panel" data-for="typedef-mf-range" id="infopanel-for-typedef-mf-range" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-range" style="display:none">Info about the '&lt;mf-range>' definition.</span><b><a href="#typedef-mf-range">#typedef-mf-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-range">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-name">
-   <b><a href="#typedef-mf-name">#typedef-mf-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-name" class="dfn-panel" data-for="typedef-mf-name" id="infopanel-for-typedef-mf-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-name" style="display:none">Info about the '&lt;mf-name>' definition.</span><b><a href="#typedef-mf-name">#typedef-mf-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-name">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-name①">(2)</a> <a href="#ref-for-typedef-mf-name②">(3)</a> <a href="#ref-for-typedef-mf-name③">(4)</a> <a href="#ref-for-typedef-mf-name④">(5)</a> <a href="#ref-for-typedef-mf-name⑤">(6)</a>
@@ -5457,8 +5457,8 @@ Syntax</a> <a href="#ref-for-typedef-mf-name①">(2)</a> <a href="#ref-for-typed
 Error Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-value">
-   <b><a href="#typedef-mf-value">#typedef-mf-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-value" class="dfn-panel" data-for="typedef-mf-value" id="infopanel-for-typedef-mf-value" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-value" style="display:none">Info about the '&lt;mf-value>' definition.</span><b><a href="#typedef-mf-value">#typedef-mf-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-value">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-value①">(2)</a> <a href="#ref-for-typedef-mf-value②">(3)</a> <a href="#ref-for-typedef-mf-value③">(4)</a> <a href="#ref-for-typedef-mf-value④">(5)</a> <a href="#ref-for-typedef-mf-value⑤">(6)</a> <a href="#ref-for-typedef-mf-value⑥">(7)</a>
@@ -5466,36 +5466,36 @@ Syntax</a> <a href="#ref-for-typedef-mf-value①">(2)</a> <a href="#ref-for-type
 Error Handling</a> <a href="#ref-for-typedef-mf-value⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-lt">
-   <b><a href="#typedef-mf-lt">#typedef-mf-lt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-lt" class="dfn-panel" data-for="typedef-mf-lt" id="infopanel-for-typedef-mf-lt" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-lt" style="display:none">Info about the '&lt;mf-lt>' definition.</span><b><a href="#typedef-mf-lt">#typedef-mf-lt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-lt">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-lt①">(2)</a> <a href="#ref-for-typedef-mf-lt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-gt">
-   <b><a href="#typedef-mf-gt">#typedef-mf-gt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-gt" class="dfn-panel" data-for="typedef-mf-gt" id="infopanel-for-typedef-mf-gt" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-gt" style="display:none">Info about the '&lt;mf-gt>' definition.</span><b><a href="#typedef-mf-gt">#typedef-mf-gt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-gt">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-gt①">(2)</a> <a href="#ref-for-typedef-mf-gt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-eq">
-   <b><a href="#typedef-mf-eq">#typedef-mf-eq</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-eq" class="dfn-panel" data-for="typedef-mf-eq" id="infopanel-for-typedef-mf-eq" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-eq" style="display:none">Info about the '&lt;mf-eq>' definition.</span><b><a href="#typedef-mf-eq">#typedef-mf-eq</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-eq">3. 
 Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mf-comparison">
-   <b><a href="#typedef-mf-comparison">#typedef-mf-comparison</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mf-comparison" class="dfn-panel" data-for="typedef-mf-comparison" id="infopanel-for-typedef-mf-comparison" role="dialog">
+   <span id="infopaneltitle-for-typedef-mf-comparison" style="display:none">Info about the '&lt;mf-comparison>' definition.</span><b><a href="#typedef-mf-comparison">#typedef-mf-comparison</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mf-comparison">3. 
 Syntax</a> <a href="#ref-for-typedef-mf-comparison①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-general-enclosed">
-   <b><a href="#typedef-general-enclosed">#typedef-general-enclosed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-general-enclosed" class="dfn-panel" data-for="typedef-general-enclosed" id="infopanel-for-typedef-general-enclosed" role="dialog">
+   <span id="infopaneltitle-for-typedef-general-enclosed" style="display:none">Info about the '&lt;general-enclosed>' definition.</span><b><a href="#typedef-general-enclosed">#typedef-general-enclosed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-general-enclosed">3. 
 Syntax</a> <a href="#ref-for-typedef-general-enclosed①">(2)</a> <a href="#ref-for-typedef-general-enclosed②">(3)</a>
@@ -5503,8 +5503,8 @@ Syntax</a> <a href="#ref-for-typedef-general-enclosed①">(2)</a> <a href="#ref-
 Evaluating Media Queries</a> <a href="#ref-for-typedef-general-enclosed④">(2)</a> <a href="#ref-for-typedef-general-enclosed⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-width">
-   <b><a href="#descdef-media-width">#descdef-media-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-width" class="dfn-panel" data-for="descdef-media-width" id="infopanel-for-descdef-media-width" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-width" style="display:none">Info about the 'width' definition.</span><b><a href="#descdef-media-width">#descdef-media-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-width">2.4.1. 
 Media Feature Types: “range” and “discrete”</a>
@@ -5521,8 +5521,8 @@ Orientation: the orientation feature</a>
     <li><a href="#ref-for-descdef-media-width⑧"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-height">
-   <b><a href="#descdef-media-height">#descdef-media-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-height" class="dfn-panel" data-for="descdef-media-height" id="infopanel-for-descdef-media-height" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-height" style="display:none">Info about the 'height' definition.</span><b><a href="#descdef-media-height">#descdef-media-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-height">4.2. 
 Height: the height feature</a> <a href="#ref-for-descdef-media-height①">(2)</a> <a href="#ref-for-descdef-media-height②">(3)</a>
@@ -5533,43 +5533,43 @@ Orientation: the orientation feature</a>
     <li><a href="#ref-for-descdef-media-height⑤"> Appendix A: Deprecated Media Features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-orientation-portrait">
-   <b><a href="#valdef-media-orientation-portrait">#valdef-media-orientation-portrait</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-orientation-portrait" class="dfn-panel" data-for="valdef-media-orientation-portrait" id="infopanel-for-valdef-media-orientation-portrait" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-orientation-portrait" style="display:none">Info about the 'portrait' definition.</span><b><a href="#valdef-media-orientation-portrait">#valdef-media-orientation-portrait</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-portrait">4.4. 
 Orientation: the orientation feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-orientation-landscape">
-   <b><a href="#valdef-media-orientation-landscape">#valdef-media-orientation-landscape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-orientation-landscape" class="dfn-panel" data-for="valdef-media-orientation-landscape" id="infopanel-for-valdef-media-orientation-landscape" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-orientation-landscape" style="display:none">Info about the 'landscape' definition.</span><b><a href="#valdef-media-orientation-landscape">#valdef-media-orientation-landscape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-orientation-landscape">4.4. 
 Orientation: the orientation feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-overflow-block">
-   <b><a href="#descdef-media-overflow-block">#descdef-media-overflow-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-overflow-block" class="dfn-panel" data-for="descdef-media-overflow-block" id="infopanel-for-descdef-media-overflow-block" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-overflow-block" style="display:none">Info about the 'overflow-block' definition.</span><b><a href="#descdef-media-overflow-block">#descdef-media-overflow-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-overflow-block">4.5. 
 Block-Axis Overflow: the overflow-block feature</a> <a href="#ref-for-descdef-media-overflow-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-none">
-   <b><a href="#valdef-media-overflow-block-none">#valdef-media-overflow-block-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-none" class="dfn-panel" data-for="valdef-media-overflow-block-none" id="infopanel-for-valdef-media-overflow-block-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-overflow-block-none">#valdef-media-overflow-block-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-none">4.5. 
 Block-Axis Overflow: the overflow-block feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-scroll">
-   <b><a href="#valdef-media-overflow-block-scroll">#valdef-media-overflow-block-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-scroll" class="dfn-panel" data-for="valdef-media-overflow-block-scroll" id="infopanel-for-valdef-media-overflow-block-scroll" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#valdef-media-overflow-block-scroll">#valdef-media-overflow-block-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-scroll">4.5. 
 Block-Axis Overflow: the overflow-block feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-overflow-block-paged">
-   <b><a href="#valdef-media-overflow-block-paged">#valdef-media-overflow-block-paged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-overflow-block-paged" class="dfn-panel" data-for="valdef-media-overflow-block-paged" id="infopanel-for-valdef-media-overflow-block-paged" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-overflow-block-paged" style="display:none">Info about the 'paged' definition.</span><b><a href="#valdef-media-overflow-block-paged">#valdef-media-overflow-block-paged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-overflow-block-paged">4.5. 
 Block-Axis Overflow: the overflow-block feature</a>
@@ -5577,8 +5577,8 @@ Block-Axis Overflow: the overflow-block feature</a>
 Inline-Axis Overflow: the overflow-inline feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="continuous-media">
-   <b><a href="#continuous-media">#continuous-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-continuous-media" class="dfn-panel" data-for="continuous-media" id="infopanel-for-continuous-media" role="dialog">
+   <span id="infopaneltitle-for-continuous-media" style="display:none">Info about the 'continuous media' definition.</span><b><a href="#continuous-media">#continuous-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continuous-media">4.1. 
 Width: the width feature</a>
@@ -5594,8 +5594,8 @@ Video-Height: the video-height feature</a>
     <li><a href="#ref-for-continuous-media⑥"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paged-media">
-   <b><a href="#paged-media">#paged-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paged-media" class="dfn-panel" data-for="paged-media" id="infopanel-for-paged-media" role="dialog">
+   <span id="infopaneltitle-for-paged-media" style="display:none">Info about the 'paged media' definition.</span><b><a href="#paged-media">#paged-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paged-media">4.1. 
 Width: the width feature</a>
@@ -5611,36 +5611,36 @@ Video-Height: the video-height feature</a>
     <li><a href="#ref-for-paged-media⑥"> device-height</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-overflow-inline">
-   <b><a href="#descdef-media-overflow-inline">#descdef-media-overflow-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-overflow-inline" class="dfn-panel" data-for="descdef-media-overflow-inline" id="infopanel-for-descdef-media-overflow-inline" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-overflow-inline" style="display:none">Info about the 'overflow-inline' definition.</span><b><a href="#descdef-media-overflow-inline">#descdef-media-overflow-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-overflow-inline">4.6. 
 Inline-Axis Overflow: the overflow-inline feature</a> <a href="#ref-for-descdef-media-overflow-inline①">(2)</a> <a href="#ref-for-descdef-media-overflow-inline②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-resolution">
-   <b><a href="#descdef-media-resolution">#descdef-media-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-resolution" class="dfn-panel" data-for="descdef-media-resolution" id="infopanel-for-descdef-media-resolution" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-resolution" style="display:none">Info about the 'resolution' definition.</span><b><a href="#descdef-media-resolution">#descdef-media-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-resolution">2.4.3. 
 Evaluating Media Features in a Range Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-resolution-infinite">
-   <b><a href="#valdef-media-resolution-infinite">#valdef-media-resolution-infinite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-resolution-infinite" class="dfn-panel" data-for="valdef-media-resolution-infinite" id="infopanel-for-valdef-media-resolution-infinite" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-resolution-infinite" style="display:none">Info about the 'infinite' definition.</span><b><a href="#valdef-media-resolution-infinite">#valdef-media-resolution-infinite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-resolution-infinite">5.1. 
 Display Resolution: the resolution feature</a> <a href="#ref-for-valdef-media-resolution-infinite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-scan">
-   <b><a href="#descdef-media-scan">#descdef-media-scan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-scan" class="dfn-panel" data-for="descdef-media-scan" id="infopanel-for-descdef-media-scan" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-scan" style="display:none">Info about the 'scan' definition.</span><b><a href="#descdef-media-scan">#descdef-media-scan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-scan">5.2. 
 Display Type: the scan feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-grid">
-   <b><a href="#descdef-media-grid">#descdef-media-grid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-grid" class="dfn-panel" data-for="descdef-media-grid" id="infopanel-for-descdef-media-grid" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-grid" style="display:none">Info about the 'grid' definition.</span><b><a href="#descdef-media-grid">#descdef-media-grid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-grid">2.3. 
 Media Types</a>
@@ -5650,29 +5650,29 @@ Using “min-” and “max-” Prefixes On Range Features</a> <a href="#ref-for
 Detecting Console Displays: the grid feature</a> <a href="#ref-for-descdef-media-grid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mq-boolean">
-   <b><a href="#typedef-mq-boolean">#typedef-mq-boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mq-boolean" class="dfn-panel" data-for="typedef-mq-boolean" id="infopanel-for-typedef-mq-boolean" role="dialog">
+   <span id="infopaneltitle-for-typedef-mq-boolean" style="display:none">Info about the '&lt;mq-boolean>' definition.</span><b><a href="#typedef-mq-boolean">#typedef-mq-boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mq-boolean">5.3. 
 Detecting Console Displays: the grid feature</a> <a href="#ref-for-typedef-mq-boolean①">(2)</a> <a href="#ref-for-typedef-mq-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-update-none">
-   <b><a href="#valdef-media-update-none">#valdef-media-update-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-update-none" class="dfn-panel" data-for="valdef-media-update-none" id="infopanel-for-valdef-media-update-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-update-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-update-none">#valdef-media-update-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-update-none">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-environment-blending-subtractive">
-   <b><a href="#valdef-media-environment-blending-subtractive">#valdef-media-environment-blending-subtractive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-environment-blending-subtractive" class="dfn-panel" data-for="valdef-media-environment-blending-subtractive" id="infopanel-for-valdef-media-environment-blending-subtractive" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-environment-blending-subtractive" style="display:none">Info about the 'subtractive' definition.</span><b><a href="#valdef-media-environment-blending-subtractive">#valdef-media-environment-blending-subtractive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-environment-blending-subtractive">5.5. 
 Detecting the display technology: the environment-blending feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color">
-   <b><a href="#descdef-media-color">#descdef-media-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color" class="dfn-panel" data-for="descdef-media-color" id="infopanel-for-descdef-media-color" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color" style="display:none">Info about the 'color' definition.</span><b><a href="#descdef-media-color">#descdef-media-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color">2.4. 
 Media Features</a>
@@ -5684,50 +5684,50 @@ Error Handling</a>
 Color Depth: the color feature</a> <a href="#ref-for-descdef-media-color④">(2)</a> <a href="#ref-for-descdef-media-color⑤">(3)</a> <a href="#ref-for-descdef-media-color⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color-index">
-   <b><a href="#descdef-media-color-index">#descdef-media-color-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color-index" class="dfn-panel" data-for="descdef-media-color-index" id="infopanel-for-descdef-media-color-index" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color-index" style="display:none">Info about the 'color-index' definition.</span><b><a href="#descdef-media-color-index">#descdef-media-color-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color-index">6.2. 
 Paletted Color Screens: the color-index feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-monochrome">
-   <b><a href="#descdef-media-monochrome">#descdef-media-monochrome</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-monochrome" class="dfn-panel" data-for="descdef-media-monochrome" id="infopanel-for-descdef-media-monochrome" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-monochrome" style="display:none">Info about the 'monochrome' definition.</span><b><a href="#descdef-media-monochrome">#descdef-media-monochrome</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-monochrome">6.3. 
 Monochrome Screens: the monochrome feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-color-gamut">
-   <b><a href="#descdef-media-color-gamut">#descdef-media-color-gamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-color-gamut" class="dfn-panel" data-for="descdef-media-color-gamut" id="infopanel-for-descdef-media-color-gamut" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-color-gamut" style="display:none">Info about the 'color-gamut' definition.</span><b><a href="#descdef-media-color-gamut">#descdef-media-color-gamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-color-gamut">6.1. 
 Color Depth: the color feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-srgb">
-   <b><a href="#valdef-media-color-gamut-srgb">#valdef-media-color-gamut-srgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-srgb" class="dfn-panel" data-for="valdef-media-color-gamut-srgb" id="infopanel-for-valdef-media-color-gamut-srgb" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-srgb" style="display:none">Info about the 'srgb' definition.</span><b><a href="#valdef-media-color-gamut-srgb">#valdef-media-color-gamut-srgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-srgb">6.4. 
 Color Display Quality: the color-gamut feature</a> <a href="#ref-for-valdef-media-color-gamut-srgb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-p3">
-   <b><a href="#valdef-media-color-gamut-p3">#valdef-media-color-gamut-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-p3" class="dfn-panel" data-for="valdef-media-color-gamut-p3" id="infopanel-for-valdef-media-color-gamut-p3" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-p3" style="display:none">Info about the 'p3' definition.</span><b><a href="#valdef-media-color-gamut-p3">#valdef-media-color-gamut-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-p3">6.4. 
 Color Display Quality: the color-gamut feature</a> <a href="#ref-for-valdef-media-color-gamut-p3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-color-gamut-rec2020">
-   <b><a href="#valdef-media-color-gamut-rec2020">#valdef-media-color-gamut-rec2020</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-color-gamut-rec2020" class="dfn-panel" data-for="valdef-media-color-gamut-rec2020" id="infopanel-for-valdef-media-color-gamut-rec2020" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-color-gamut-rec2020" style="display:none">Info about the 'rec2020' definition.</span><b><a href="#valdef-media-color-gamut-rec2020">#valdef-media-color-gamut-rec2020</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-color-gamut-rec2020">6.4. 
 Color Display Quality: the color-gamut feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-dynamic-range">
-   <b><a href="#descdef-media-dynamic-range">#descdef-media-dynamic-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-dynamic-range" class="dfn-panel" data-for="descdef-media-dynamic-range" id="infopanel-for-descdef-media-dynamic-range" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-dynamic-range" style="display:none">Info about the 'dynamic-range' definition.</span><b><a href="#descdef-media-dynamic-range">#descdef-media-dynamic-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-dynamic-range">6.5. 
 Dynamic Range: the dynamic-range feature</a>
@@ -5735,29 +5735,29 @@ Dynamic Range: the dynamic-range feature</a>
 	Determining contrast and brightness of display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-dynamic-range-high">
-   <b><a href="#valdef-media-dynamic-range-high">#valdef-media-dynamic-range-high</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-dynamic-range-high" class="dfn-panel" data-for="valdef-media-dynamic-range-high" id="infopanel-for-valdef-media-dynamic-range-high" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-dynamic-range-high" style="display:none">Info about the 'high' definition.</span><b><a href="#valdef-media-dynamic-range-high">#valdef-media-dynamic-range-high</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-dynamic-range-high">6.5. 
 Dynamic Range: the dynamic-range feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="peak-brightness">
-   <b><a href="#peak-brightness">#peak-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-peak-brightness" class="dfn-panel" data-for="peak-brightness" id="infopanel-for-peak-brightness" role="dialog">
+   <span id="infopaneltitle-for-peak-brightness" style="display:none">Info about the 'Peak brightness' definition.</span><b><a href="#peak-brightness">#peak-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-peak-brightness">6.5.1. 
 	Determining contrast and brightness of display</a> <a href="#ref-for-peak-brightness①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contrast-ratio">
-   <b><a href="#contrast-ratio">#contrast-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contrast-ratio" class="dfn-panel" data-for="contrast-ratio" id="infopanel-for-contrast-ratio" role="dialog">
+   <span id="infopaneltitle-for-contrast-ratio" style="display:none">Info about the 'contrast ratio' definition.</span><b><a href="#contrast-ratio">#contrast-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contrast-ratio">6.5.1. 
 	Determining contrast and brightness of display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contrast-ratio-high-contrast-ratio">
-   <b><a href="#contrast-ratio-high-contrast-ratio">#contrast-ratio-high-contrast-ratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contrast-ratio-high-contrast-ratio" class="dfn-panel" data-for="contrast-ratio-high-contrast-ratio" id="infopanel-for-contrast-ratio-high-contrast-ratio" role="dialog">
+   <span id="infopaneltitle-for-contrast-ratio-high-contrast-ratio" style="display:none">Info about the 'high' definition.</span><b><a href="#contrast-ratio-high-contrast-ratio">#contrast-ratio-high-contrast-ratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contrast-ratio-high-contrast-ratio">6.5. 
 Dynamic Range: the dynamic-range feature</a>
@@ -5765,8 +5765,8 @@ Dynamic Range: the dynamic-range feature</a>
 	Determining contrast and brightness of display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="peak-brightness-high-peak-brightness">
-   <b><a href="#peak-brightness-high-peak-brightness">#peak-brightness-high-peak-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-peak-brightness-high-peak-brightness" class="dfn-panel" data-for="peak-brightness-high-peak-brightness" id="infopanel-for-peak-brightness-high-peak-brightness" role="dialog">
+   <span id="infopaneltitle-for-peak-brightness-high-peak-brightness" style="display:none">Info about the 'high' definition.</span><b><a href="#peak-brightness-high-peak-brightness">#peak-brightness-high-peak-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-peak-brightness-high-peak-brightness">6.5. 
 Dynamic Range: the dynamic-range feature</a>
@@ -5774,15 +5774,15 @@ Dynamic Range: the dynamic-range feature</a>
 	Determining contrast and brightness of display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-pointer">
-   <b><a href="#descdef-media-pointer">#descdef-media-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-pointer" class="dfn-panel" data-for="descdef-media-pointer" id="infopanel-for-descdef-media-pointer" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#descdef-media-pointer">#descdef-media-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-pointer">7. 
 Interaction Media Features</a> <a href="#ref-for-descdef-media-pointer①">(2)</a> <a href="#ref-for-descdef-media-pointer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-none">
-   <b><a href="#valdef-media-pointer-none">#valdef-media-pointer-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-none" class="dfn-panel" data-for="valdef-media-pointer-none" id="infopanel-for-valdef-media-pointer-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-pointer-none">#valdef-media-pointer-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-none">2.4.2. 
 Evaluating Media Features in a Boolean Context</a>
@@ -5792,8 +5792,8 @@ Pointing Device Quality: the pointer feature</a>
 All Available Interaction Capabilities: the any-pointer and any-hover features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-coarse">
-   <b><a href="#valdef-media-pointer-coarse">#valdef-media-pointer-coarse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-coarse" class="dfn-panel" data-for="valdef-media-pointer-coarse" id="infopanel-for-valdef-media-pointer-coarse" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-coarse" style="display:none">Info about the 'coarse' definition.</span><b><a href="#valdef-media-pointer-coarse">#valdef-media-pointer-coarse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-coarse">7.1. 
 Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-pointer-coarse①">(2)</a> <a href="#ref-for-valdef-media-pointer-coarse②">(3)</a> <a href="#ref-for-valdef-media-pointer-coarse③">(4)</a> <a href="#ref-for-valdef-media-pointer-coarse④">(5)</a> <a href="#ref-for-valdef-media-pointer-coarse⑤">(6)</a> <a href="#ref-for-valdef-media-pointer-coarse⑥">(7)</a>
@@ -5801,8 +5801,8 @@ Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-
 All Available Interaction Capabilities: the any-pointer and any-hover features</a> <a href="#ref-for-valdef-media-pointer-coarse⑧">(2)</a> <a href="#ref-for-valdef-media-pointer-coarse⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-pointer-fine">
-   <b><a href="#valdef-media-pointer-fine">#valdef-media-pointer-fine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-pointer-fine" class="dfn-panel" data-for="valdef-media-pointer-fine" id="infopanel-for-valdef-media-pointer-fine" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-pointer-fine" style="display:none">Info about the 'fine' definition.</span><b><a href="#valdef-media-pointer-fine">#valdef-media-pointer-fine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-pointer-fine">7.1. 
 Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-pointer-fine①">(2)</a> <a href="#ref-for-valdef-media-pointer-fine②">(3)</a>
@@ -5810,8 +5810,8 @@ Pointing Device Quality: the pointer feature</a> <a href="#ref-for-valdef-media-
 All Available Interaction Capabilities: the any-pointer and any-hover features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-hover">
-   <b><a href="#descdef-media-hover">#descdef-media-hover</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-hover" class="dfn-panel" data-for="descdef-media-hover" id="infopanel-for-descdef-media-hover" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-hover" style="display:none">Info about the 'hover' definition.</span><b><a href="#descdef-media-hover">#descdef-media-hover</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-hover">7. 
 Interaction Media Features</a> <a href="#ref-for-descdef-media-hover①">(2)</a>
@@ -5819,16 +5819,16 @@ Interaction Media Features</a> <a href="#ref-for-descdef-media-hover①">(2)</a>
 Hover Capability: the hover feature</a> <a href="#ref-for-descdef-media-hover③">(2)</a> <a href="#ref-for-descdef-media-hover④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-video-color-gamut">
-   <b><a href="#descdef-media-video-color-gamut">#descdef-media-video-color-gamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-video-color-gamut" class="dfn-panel" data-for="descdef-media-video-color-gamut" id="infopanel-for-descdef-media-video-color-gamut" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-video-color-gamut" style="display:none">Info about the 'video-color-gamut' definition.</span><b><a href="#descdef-media-video-color-gamut">#descdef-media-video-color-gamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-video-color-gamut">8. Video Prefixed Features</a>
     <li><a href="#ref-for-descdef-media-video-color-gamut①">8.1. 
 Video Color Display Quality: the video-color-gamut feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-video-dynamic-range">
-   <b><a href="#descdef-media-video-dynamic-range">#descdef-media-video-dynamic-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-video-dynamic-range" class="dfn-panel" data-for="descdef-media-video-dynamic-range" id="infopanel-for-descdef-media-video-dynamic-range" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-video-dynamic-range" style="display:none">Info about the 'video-dynamic-range' definition.</span><b><a href="#descdef-media-video-dynamic-range">#descdef-media-video-dynamic-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-video-dynamic-range">6.5.1. 
 	Determining contrast and brightness of display</a>
@@ -5837,8 +5837,8 @@ Video Color Display Quality: the video-color-gamut feature</a>
 Video Dynamic Range: the video-dynamic-range feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-video-width">
-   <b><a href="#descdef-media-video-width">#descdef-media-video-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-video-width" class="dfn-panel" data-for="descdef-media-video-width" id="infopanel-for-descdef-media-video-width" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-video-width" style="display:none">Info about the 'video-width' definition.</span><b><a href="#descdef-media-video-width">#descdef-media-video-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-video-width">8. Video Prefixed Features</a> <a href="#ref-for-descdef-media-video-width①">(2)</a>
     <li><a href="#ref-for-descdef-media-video-width②">8.3. 
@@ -5849,8 +5849,8 @@ Video-Height: the video-height feature</a>
 Video Display Resolution: the video-resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-video-height">
-   <b><a href="#descdef-media-video-height">#descdef-media-video-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-video-height" class="dfn-panel" data-for="descdef-media-video-height" id="infopanel-for-descdef-media-video-height" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-video-height" style="display:none">Info about the 'video-height' definition.</span><b><a href="#descdef-media-video-height">#descdef-media-video-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-video-height">8. Video Prefixed Features</a> <a href="#ref-for-descdef-media-video-height①">(2)</a>
     <li><a href="#ref-for-descdef-media-video-height②">8.3. 
@@ -5861,8 +5861,8 @@ Video-Height: the video-height feature</a> <a href="#ref-for-descdef-media-video
 Video Display Resolution: the video-resolution feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-video-resolution">
-   <b><a href="#descdef-media-video-resolution">#descdef-media-video-resolution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-video-resolution" class="dfn-panel" data-for="descdef-media-video-resolution" id="infopanel-for-descdef-media-video-resolution" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-video-resolution" style="display:none">Info about the 'video-resolution' definition.</span><b><a href="#descdef-media-video-resolution">#descdef-media-video-resolution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-video-resolution">8. Video Prefixed Features</a> <a href="#ref-for-descdef-media-video-resolution①">(2)</a>
     <li><a href="#ref-for-descdef-media-video-resolution②">8.3. 
@@ -5873,43 +5873,43 @@ Video-Height: the video-height feature</a>
 Video Display Resolution: the video-resolution feature</a> <a href="#ref-for-descdef-media-video-resolution⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-scripting-enabled">
-   <b><a href="#valdef-media-scripting-enabled">#valdef-media-scripting-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-scripting-enabled" class="dfn-panel" data-for="valdef-media-scripting-enabled" id="infopanel-for-valdef-media-scripting-enabled" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-scripting-enabled" style="display:none">Info about the 'enabled' definition.</span><b><a href="#valdef-media-scripting-enabled">#valdef-media-scripting-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-scripting-enabled">9.1. 
 Scripting Support: the scripting feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-scripting-initial-only">
-   <b><a href="#valdef-media-scripting-initial-only">#valdef-media-scripting-initial-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-scripting-initial-only" class="dfn-panel" data-for="valdef-media-scripting-initial-only" id="infopanel-for-valdef-media-scripting-initial-only" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-scripting-initial-only" style="display:none">Info about the 'initial-only' definition.</span><b><a href="#valdef-media-scripting-initial-only">#valdef-media-scripting-initial-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-scripting-initial-only">9.1. 
 Scripting Support: the scripting feature</a> <a href="#ref-for-valdef-media-scripting-initial-only①">(2)</a> <a href="#ref-for-valdef-media-scripting-initial-only②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-scripting-none">
-   <b><a href="#valdef-media-scripting-none">#valdef-media-scripting-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-scripting-none" class="dfn-panel" data-for="valdef-media-scripting-none" id="infopanel-for-valdef-media-scripting-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-scripting-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-media-scripting-none">#valdef-media-scripting-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-scripting-none">9.1. 
 Scripting Support: the scripting feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-media-query">
-   <b><a href="#custom-media-query">#custom-media-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-media-query" class="dfn-panel" data-for="custom-media-query" id="infopanel-for-custom-media-query" role="dialog">
+   <span id="infopaneltitle-for-custom-media-query" style="display:none">Info about the 'custom media query' definition.</span><b><a href="#custom-media-query">#custom-media-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-media-query">10. 
 Custom Media Queries</a> <a href="#ref-for-custom-media-query①">(2)</a> <a href="#ref-for-custom-media-query②">(3)</a> <a href="#ref-for-custom-media-query③">(4)</a> <a href="#ref-for-custom-media-query④">(5)</a> <a href="#ref-for-custom-media-query⑤">(6)</a> <a href="#ref-for-custom-media-query⑥">(7)</a> <a href="#ref-for-custom-media-query⑦">(8)</a> <a href="#ref-for-custom-media-query⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-custom-media">
-   <b><a href="#at-ruledef-custom-media">#at-ruledef-custom-media</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-custom-media" class="dfn-panel" data-for="at-ruledef-custom-media" id="infopanel-for-at-ruledef-custom-media" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-custom-media" style="display:none">Info about the '@custom-media' definition.</span><b><a href="#at-ruledef-custom-media">#at-ruledef-custom-media</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-custom-media">10. 
 Custom Media Queries</a> <a href="#ref-for-at-ruledef-custom-media①">(2)</a> <a href="#ref-for-at-ruledef-custom-media②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-prefers-contrast">
-   <b><a href="#descdef-media-prefers-contrast">#descdef-media-prefers-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-prefers-contrast" class="dfn-panel" data-for="descdef-media-prefers-contrast" id="infopanel-for-descdef-media-prefers-contrast" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-prefers-contrast" style="display:none">Info about the 'prefers-contrast' definition.</span><b><a href="#descdef-media-prefers-contrast">#descdef-media-prefers-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-prefers-contrast">11.3. 
 Detecting the desire for increased or decreased color contrast from elements on the page: the prefers-contrast feature</a> <a href="#ref-for-descdef-media-prefers-contrast①">(2)</a>
@@ -5918,8 +5918,8 @@ Detecting Forced Colors Mode: the forced-colors feature</a> <a href="#ref-for-de
     <li><a href="#ref-for-descdef-media-prefers-contrast④"> Changes Since the 2020-07-15 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-prefers-contrast-less">
-   <b><a href="#valdef-media-prefers-contrast-less">#valdef-media-prefers-contrast-less</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-prefers-contrast-less" class="dfn-panel" data-for="valdef-media-prefers-contrast-less" id="infopanel-for-valdef-media-prefers-contrast-less" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-prefers-contrast-less" style="display:none">Info about the 'less' definition.</span><b><a href="#valdef-media-prefers-contrast-less">#valdef-media-prefers-contrast-less</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-prefers-contrast-less">11.3. 
 Detecting the desire for increased or decreased color contrast from elements on the page: the prefers-contrast feature</a>
@@ -5927,8 +5927,8 @@ Detecting the desire for increased or decreased color contrast from elements on 
 Automatic handling of User Preferences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-prefers-contrast-more">
-   <b><a href="#valdef-media-prefers-contrast-more">#valdef-media-prefers-contrast-more</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-prefers-contrast-more" class="dfn-panel" data-for="valdef-media-prefers-contrast-more" id="infopanel-for-valdef-media-prefers-contrast-more" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-prefers-contrast-more" style="display:none">Info about the 'more' definition.</span><b><a href="#valdef-media-prefers-contrast-more">#valdef-media-prefers-contrast-more</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-prefers-contrast-more">11.3. 
 Detecting the desire for increased or decreased color contrast from elements on the page: the prefers-contrast feature</a>
@@ -5936,15 +5936,15 @@ Detecting the desire for increased or decreased color contrast from elements on 
 Automatic handling of User Preferences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-forced-colors">
-   <b><a href="#descdef-media-forced-colors">#descdef-media-forced-colors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-forced-colors" class="dfn-panel" data-for="descdef-media-forced-colors" id="infopanel-for-descdef-media-forced-colors" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-forced-colors" style="display:none">Info about the 'forced-colors' definition.</span><b><a href="#descdef-media-forced-colors">#descdef-media-forced-colors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-forced-colors">11.4. 
 Detecting Forced Colors Mode: the forced-colors feature</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-prefers-color-scheme-light">
-   <b><a href="#valdef-media-prefers-color-scheme-light">#valdef-media-prefers-color-scheme-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-prefers-color-scheme-light" class="dfn-panel" data-for="valdef-media-prefers-color-scheme-light" id="infopanel-for-valdef-media-prefers-color-scheme-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-prefers-color-scheme-light" style="display:none">Info about the 'light' definition.</span><b><a href="#valdef-media-prefers-color-scheme-light">#valdef-media-prefers-color-scheme-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-prefers-color-scheme-light">11.5. 
 Detecting the desire for light or dark color schemes: the prefers-color-scheme feature</a>
@@ -5952,35 +5952,35 @@ Detecting the desire for light or dark color schemes: the prefers-color-scheme f
 Automatic handling of User Preferences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-prefers-color-scheme-dark">
-   <b><a href="#valdef-media-prefers-color-scheme-dark">#valdef-media-prefers-color-scheme-dark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-prefers-color-scheme-dark" class="dfn-panel" data-for="valdef-media-prefers-color-scheme-dark" id="infopanel-for-valdef-media-prefers-color-scheme-dark" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-prefers-color-scheme-dark" style="display:none">Info about the 'dark' definition.</span><b><a href="#valdef-media-prefers-color-scheme-dark">#valdef-media-prefers-color-scheme-dark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-prefers-color-scheme-dark">11.7. 
 Automatic handling of User Preferences</a> <a href="#ref-for-valdef-media-prefers-color-scheme-dark①">(2)</a> <a href="#ref-for-valdef-media-prefers-color-scheme-dark②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-prefers-reduced-data">
-   <b><a href="#descdef-media-prefers-reduced-data">#descdef-media-prefers-reduced-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-prefers-reduced-data" class="dfn-panel" data-for="descdef-media-prefers-reduced-data" id="infopanel-for-descdef-media-prefers-reduced-data" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-prefers-reduced-data" style="display:none">Info about the 'prefers-reduced-data' definition.</span><b><a href="#descdef-media-prefers-reduced-data">#descdef-media-prefers-reduced-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-prefers-reduced-data">11.7. 
 Automatic handling of User Preferences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-media-prefers-reduced-data-reduce">
-   <b><a href="#valdef-media-prefers-reduced-data-reduce">#valdef-media-prefers-reduced-data-reduce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-media-prefers-reduced-data-reduce" class="dfn-panel" data-for="valdef-media-prefers-reduced-data-reduce" id="infopanel-for-valdef-media-prefers-reduced-data-reduce" role="dialog">
+   <span id="infopaneltitle-for-valdef-media-prefers-reduced-data-reduce" style="display:none">Info about the 'reduce' definition.</span><b><a href="#valdef-media-prefers-reduced-data-reduce">#valdef-media-prefers-reduced-data-reduce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-prefers-reduced-data-reduce">11.7. 
 Automatic handling of User Preferences</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-device-width">
-   <b><a href="#descdef-media-device-width">#descdef-media-device-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-device-width" class="dfn-panel" data-for="descdef-media-device-width" id="infopanel-for-descdef-media-device-width" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-device-width" style="display:none">Info about the 'device-width' definition.</span><b><a href="#descdef-media-device-width">#descdef-media-device-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-device-width"> device-width</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-media-device-height">
-   <b><a href="#descdef-media-device-height">#descdef-media-device-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-media-device-height" class="dfn-panel" data-for="descdef-media-device-height" id="infopanel-for-descdef-media-device-height" role="dialog">
+   <span id="infopaneltitle-for-descdef-media-device-height" style="display:none">Info about the 'device-height' definition.</span><b><a href="#descdef-media-device-height">#descdef-media-device-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-device-height"> device-height</a>
    </ul>
@@ -6002,57 +6002,113 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/resize-observer-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/resize-observer-1/Overview.html
@@ -2006,117 +2006,117 @@ will be considered for delivery in the next loop.</p>
     </ul>
    <li><a href="#dom-resizeobserver-unobserve">unobserve(target)</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-intersection-observer-interface">
-   <a href="https://www.w3.org/TR/intersection-observer/#intersection-observer-interface">https://www.w3.org/TR/intersection-observer/#intersection-observer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intersection-observer-interface" class="dfn-panel" data-for="term-for-intersection-observer-interface" id="infopanel-for-term-for-intersection-observer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-intersection-observer-interface" style="display:none">Info about the 'IntersectionObserver' external reference.</span><a href="https://www.w3.org/TR/intersection-observer/#intersection-observer-interface">https://www.w3.org/TR/intersection-observer/#intersection-observer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersection-observer-interface">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BoundingBoxes">
-   <a href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BoundingBoxes" class="dfn-panel" data-for="term-for-BoundingBoxes" id="infopanel-for-term-for-BoundingBoxes" role="menu">
+   <span id="infopaneltitle-for-term-for-BoundingBoxes" style="display:none">Info about the 'bounding box' external reference.</span><a href="https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes">https://www.w3.org/TR/SVG2/coords.html#BoundingBoxes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BoundingBoxes">3.3.1. content rect</a> <a href="#ref-for-BoundingBoxes①">(2)</a> <a href="#ref-for-BoundingBoxes②">(3)</a>
     <li><a href="#ref-for-BoundingBoxes③">3.4.8. Calculate box size, given target and observed box</a> <a href="#ref-for-BoundingBoxes④">(2)</a> <a href="#ref-for-BoundingBoxes⑤">(3)</a> <a href="#ref-for-BoundingBoxes⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-border-area">
-   <a href="https://www.w3.org/TR/CSS21/box.html#box-border-area">https://www.w3.org/TR/CSS21/box.html#box-border-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-border-area" class="dfn-panel" data-for="term-for-box-border-area" id="infopanel-for-term-for-box-border-area" role="menu">
+   <span id="infopaneltitle-for-term-for-box-border-area" style="display:none">Info about the 'box border area' external reference.</span><a href="https://www.w3.org/TR/CSS21/box.html#box-border-area">https://www.w3.org/TR/CSS21/box.html#box-border-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-border-area">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-area">
-   <a href="https://drafts.csswg.org/css-box-3/#content-area">https://drafts.csswg.org/css-box-3/#content-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-area" class="dfn-panel" data-for="term-for-content-area" id="infopanel-for-term-for-content-area" role="menu">
+   <span id="infopaneltitle-for-term-for-content-area" style="display:none">Info about the 'content area' external reference.</span><a href="https://drafts.csswg.org/css-box-3/#content-area">https://drafts.csswg.org/css-box-3/#content-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-area">2.1. ResizeObserver interface</a> <a href="#ref-for-content-area①">(2)</a>
     <li><a href="#ref-for-content-area②">3.4.8. Calculate box size, given target and observed box</a> <a href="#ref-for-content-area③">(2)</a> <a href="#ref-for-content-area④">(3)</a> <a href="#ref-for-content-area⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-height">
-   <a href="https://www.w3.org/TR/CSS2/box.html#content-height">https://www.w3.org/TR/CSS2/box.html#content-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-height" class="dfn-panel" data-for="term-for-content-height" id="infopanel-for-term-for-content-height" role="menu">
+   <span id="infopaneltitle-for-term-for-content-height" style="display:none">Info about the 'content height' external reference.</span><a href="https://www.w3.org/TR/CSS2/box.html#content-height">https://www.w3.org/TR/CSS2/box.html#content-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-height">3.3.1. content rect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-width">
-   <a href="https://www.w3.org/TR/CSS2/box.html#content-width">https://www.w3.org/TR/CSS2/box.html#content-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-width" class="dfn-panel" data-for="term-for-content-width" id="infopanel-for-term-for-content-width" role="menu">
+   <span id="infopaneltitle-for-term-for-content-width" style="display:none">Info about the 'content width' external reference.</span><a href="https://www.w3.org/TR/CSS2/box.html#content-width">https://www.w3.org/TR/CSS2/box.html#content-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-width">3.3.1. content rect</a> <a href="#ref-for-content-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-devicepixelratio">
-   <a href="https://www.w3.org/TR/cssom-view-1/#dom-window-devicepixelratio">https://www.w3.org/TR/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-devicepixelratio" class="dfn-panel" data-for="term-for-dom-window-devicepixelratio" id="infopanel-for-term-for-dom-window-devicepixelratio" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-devicepixelratio" style="display:none">Info about the 'devicepixelratio' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#dom-window-devicepixelratio">https://www.w3.org/TR/cssom-view-1/#dom-window-devicepixelratio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-devicepixelratio">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://www.w3.org/TR/css-display-3/#propdef-display">https://www.w3.org/TR/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#propdef-display">https://www.w3.org/TR/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-processing-model-8">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8">https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-processing-model-8" class="dfn-panel" data-for="term-for-processing-model-8" id="infopanel-for-term-for-processing-model-8" role="menu">
+   <span id="infopaneltitle-for-term-for-processing-model-8" style="display:none">Info about the 'html processing model' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8">https://html.spec.whatwg.org/multipage/webappapis.html#processing-model-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processing-model-8">3.6.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://www.w3.org/TR/css3-multicol/#">https://www.w3.org/TR/css3-multicol/#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'multi-column' external reference.</span><a href="https://www.w3.org/TR/css3-multicol/#">https://www.w3.org/TR/css3-multicol/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.3. ResizeObserverEntry</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">3.3.1. content rect</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-physical">
-   <a href="https://drafts.csswg.org/css-box-3/#padding-physical">https://drafts.csswg.org/css-box-3/#padding-physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-physical" class="dfn-panel" data-for="term-for-padding-physical" id="infopanel-for-term-for-padding-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-physical" style="display:none">Info about the 'padding left' external reference.</span><a href="https://drafts.csswg.org/css-box-3/#padding-physical">https://drafts.csswg.org/css-box-3/#padding-physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-physical">3.3.1. content rect</a> <a href="#ref-for-padding-physical①">(2)</a>
     <li><a href="#ref-for-padding-physical②">3.4.4. 
 Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physical③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-physical">
-   <a href="https://drafts.csswg.org/css-box-3/#padding-physical">https://drafts.csswg.org/css-box-3/#padding-physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-physical" class="dfn-panel" data-for="term-for-padding-physical" id="infopanel-for-term-for-padding-physical①" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-physical①" style="display:none">Info about the 'padding top' external reference.</span><a href="https://drafts.csswg.org/css-box-3/#padding-physical">https://drafts.csswg.org/css-box-3/#padding-physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-physical">3.3.1. content rect</a> <a href="#ref-for-padding-physical①">(2)</a>
     <li><a href="#ref-for-padding-physical②">3.4.4. 
 Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physical③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGGraphicsElement">
-   <a href="https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGraphicsElement">https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGraphicsElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGGraphicsElement" class="dfn-panel" data-for="term-for-InterfaceSVGGraphicsElement" id="infopanel-for-term-for-InterfaceSVGGraphicsElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGGraphicsElement" style="display:none">Info about the 'svggraphicselement' external reference.</span><a href="https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGraphicsElement">https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGraphicsElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGGraphicsElement">3.3.1. content rect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-viewport">
-   <a href="https://www.w3.org/TR/css3-positioning/#viewport">https://www.w3.org/TR/css3-positioning/#viewport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-viewport" class="dfn-panel" data-for="term-for-viewport" id="infopanel-for-term-for-viewport" role="menu">
+   <span id="infopaneltitle-for-term-for-viewport" style="display:none">Info about the 'viewport' external reference.</span><a href="https://www.w3.org/TR/css3-positioning/#viewport">https://www.w3.org/TR/css3-positioning/#viewport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-viewport">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-area">
-   <a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-area" class="dfn-panel" data-for="term-for-border-area" id="infopanel-for-term-for-border-area" role="menu">
+   <span id="infopaneltitle-for-term-for-border-area" style="display:none">Info about the 'border area' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-area">https://drafts.csswg.org/css-box-4/#border-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-area">3.4.8. Calculate box size, given target and observed box</a> <a href="#ref-for-border-area①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-box">
-   <a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-box" class="dfn-panel" data-for="term-for-border-box" id="infopanel-for-term-for-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-border-box" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#border-box">https://drafts.csswg.org/css-box-4/#border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-box">2.3. ResizeObserverEntry</a> <a href="#ref-for-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-window-resize">
-   <a href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-window-resize" class="dfn-panel" data-for="term-for-eventdef-window-resize" id="infopanel-for-term-for-eventdef-window-resize" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-window-resize" style="display:none">Info about the 'resize' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize">https://drafts.csswg.org/cssom-view-1/#eventdef-window-resize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-window-resize">1. Introduction</a> <a href="#ref-for-eventdef-window-resize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-document①">3.4.2. Has active observations</a>
@@ -2124,8 +2124,8 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physica
     <li><a href="#ref-for-document③">3.6.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-document④">(2)</a> <a href="#ref-for-document⑤">(3)</a> <a href="#ref-for-document⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">1. Introduction</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a> <a href="#ref-for-element④">(5)</a>
     <li><a href="#ref-for-element⑤">2.1. ResizeObserver interface</a> <a href="#ref-for-element⑥">(2)</a> <a href="#ref-for-element⑦">(3)</a>
@@ -2135,65 +2135,65 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physica
     <li><a href="#ref-for-element②①">3.4.8. Calculate box size, given target and observed box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mutationobserver">
-   <a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mutationobserver" class="dfn-panel" data-for="term-for-mutationobserver" id="infopanel-for-term-for-mutationobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-mutationobserver" style="display:none">Info about the 'MutationObserver' external reference.</span><a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationobserver">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.2.1. Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#domrectreadonly">https://drafts.fxtf.org/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">2.3. ResizeObserverEntry</a> <a href="#ref-for-domrectreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-errorevent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-errorevent" class="dfn-panel" data-for="term-for-errorevent" id="infopanel-for-term-for-errorevent" role="menu">
+   <span id="infopaneltitle-for-term-for-errorevent" style="display:none">Info about the 'ErrorEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-errorevent">3.4.6. Deliver Resize Loop Error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGGraphicsElement">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGGraphicsElement" class="dfn-panel" data-for="term-for-InterfaceSVGGraphicsElement" id="infopanel-for-term-for-InterfaceSVGGraphicsElement①" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGGraphicsElement①" style="display:none">Info about the 'SVGGraphicsElement' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGGraphicsElement①">3.4.8. Calculate box size, given target and observed box</a> <a href="#ref-for-InterfaceSVGGraphicsElement②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-Exposed①">2.3. ResizeObserverEntry</a> <a href="#ref-for-Exposed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">2.3. ResizeObserverEntry</a> <a href="#ref-for-idl-frozen-array①">(2)</a> <a href="#ref-for-idl-frozen-array②">(3)</a> <a href="#ref-for-idl-frozen-array③">(4)</a> <a href="#ref-for-idl-frozen-array④">(5)</a> <a href="#ref-for-idl-frozen-array⑤">(6)</a> <a href="#ref-for-idl-frozen-array⑥">(7)</a> <a href="#ref-for-idl-frozen-array⑦">(8)</a> <a href="#ref-for-idl-frozen-array⑧">(9)</a>
     <li><a href="#ref-for-idl-frozen-array⑨">3.1. ResizeObservation example struct</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. ResizeObserverCallback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.1. ResizeObserver interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a>
     <li><a href="#ref-for-idl-undefined③">2.2. ResizeObserverCallback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">2.3. ResizeObserverEntry</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a>
    </ul>
@@ -2317,40 +2317,40 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physica
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-resizeobserverboxoptions">
-   <b><a href="#enumdef-resizeobserverboxoptions">#enumdef-resizeobserverboxoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-resizeobserverboxoptions" class="dfn-panel" data-for="enumdef-resizeobserverboxoptions" id="infopanel-for-enumdef-resizeobserverboxoptions" role="dialog">
+   <span id="infopaneltitle-for-enumdef-resizeobserverboxoptions" style="display:none">Info about the 'ResizeObserverBoxOptions' definition.</span><b><a href="#enumdef-resizeobserverboxoptions">#enumdef-resizeobserverboxoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-resizeobserverboxoptions">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-enumdef-resizeobserverboxoptions①">3.1. ResizeObservation example struct</a> <a href="#ref-for-enumdef-resizeobserverboxoptions②">(2)</a>
     <li><a href="#ref-for-enumdef-resizeobserverboxoptions③">3.4.8. Calculate box size, given target and observed box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverboxoptions-border-box">
-   <b><a href="#dom-resizeobserverboxoptions-border-box">#dom-resizeobserverboxoptions-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverboxoptions-border-box" class="dfn-panel" data-for="dom-resizeobserverboxoptions-border-box" id="infopanel-for-dom-resizeobserverboxoptions-border-box" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverboxoptions-border-box" style="display:none">Info about the '"border-box"' definition.</span><b><a href="#dom-resizeobserverboxoptions-border-box">#dom-resizeobserverboxoptions-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverboxoptions-border-box">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverboxoptions-content-box">
-   <b><a href="#dom-resizeobserverboxoptions-content-box">#dom-resizeobserverboxoptions-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverboxoptions-content-box" class="dfn-panel" data-for="dom-resizeobserverboxoptions-content-box" id="infopanel-for-dom-resizeobserverboxoptions-content-box" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverboxoptions-content-box" style="display:none">Info about the '"content-box"' definition.</span><b><a href="#dom-resizeobserverboxoptions-content-box">#dom-resizeobserverboxoptions-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverboxoptions-content-box">2.1. ResizeObserver interface</a> <a href="#ref-for-dom-resizeobserverboxoptions-content-box①">(2)</a> <a href="#ref-for-dom-resizeobserverboxoptions-content-box②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverboxoptions-device-pixel-content-box">
-   <b><a href="#dom-resizeobserverboxoptions-device-pixel-content-box">#dom-resizeobserverboxoptions-device-pixel-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverboxoptions-device-pixel-content-box" class="dfn-panel" data-for="dom-resizeobserverboxoptions-device-pixel-content-box" id="infopanel-for-dom-resizeobserverboxoptions-device-pixel-content-box" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverboxoptions-device-pixel-content-box" style="display:none">Info about the '"device-pixel-content-box"' definition.</span><b><a href="#dom-resizeobserverboxoptions-device-pixel-content-box">#dom-resizeobserverboxoptions-device-pixel-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverboxoptions-device-pixel-content-box">2.1. ResizeObserver interface</a> <a href="#ref-for-dom-resizeobserverboxoptions-device-pixel-content-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-resizeobserveroptions">
-   <b><a href="#dictdef-resizeobserveroptions">#dictdef-resizeobserveroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-resizeobserveroptions" class="dfn-panel" data-for="dictdef-resizeobserveroptions" id="infopanel-for-dictdef-resizeobserveroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-resizeobserveroptions" style="display:none">Info about the 'ResizeObserverOptions' definition.</span><b><a href="#dictdef-resizeobserveroptions">#dictdef-resizeobserveroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-resizeobserveroptions">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resizeobserver">
-   <b><a href="#resizeobserver">#resizeobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resizeobserver" class="dfn-panel" data-for="resizeobserver" id="infopanel-for-resizeobserver" role="dialog">
+   <span id="infopaneltitle-for-resizeobserver" style="display:none">Info about the 'ResizeObserver' definition.</span><b><a href="#resizeobserver">#resizeobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resizeobserver">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-resizeobserver①">2.2. ResizeObserverCallback</a> <a href="#ref-for-resizeobserver②">(2)</a>
@@ -2360,39 +2360,39 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-padding-physica
     <li><a href="#ref-for-resizeobserver⑨">3.6.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-resizeobserver①⓪">(2)</a> <a href="#ref-for-resizeobserver①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-resizeobserver">
-   <b><a href="#dom-resizeobserver-resizeobserver">#dom-resizeobserver-resizeobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-resizeobserver" class="dfn-panel" data-for="dom-resizeobserver-resizeobserver" id="infopanel-for-dom-resizeobserver-resizeobserver" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-resizeobserver" style="display:none">Info about the 'new ResizeObserver(callback)' definition.</span><b><a href="#dom-resizeobserver-resizeobserver">#dom-resizeobserver-resizeobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-resizeobserver">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-observe">
-   <b><a href="#dom-resizeobserver-observe">#dom-resizeobserver-observe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-observe" class="dfn-panel" data-for="dom-resizeobserver-observe" id="infopanel-for-dom-resizeobserver-observe" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-observe" style="display:none">Info about the 'observe(target, options)' definition.</span><b><a href="#dom-resizeobserver-observe">#dom-resizeobserver-observe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-observe">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-unobserve">
-   <b><a href="#dom-resizeobserver-unobserve">#dom-resizeobserver-unobserve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-unobserve" class="dfn-panel" data-for="dom-resizeobserver-unobserve" id="infopanel-for-dom-resizeobserver-unobserve" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-unobserve" style="display:none">Info about the 'unobserve(target)' definition.</span><b><a href="#dom-resizeobserver-unobserve">#dom-resizeobserver-unobserve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-unobserve">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-disconnect">
-   <b><a href="#dom-resizeobserver-disconnect">#dom-resizeobserver-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-disconnect" class="dfn-panel" data-for="dom-resizeobserver-disconnect" id="infopanel-for-dom-resizeobserver-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-resizeobserver-disconnect">#dom-resizeobserver-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-disconnect">2.1. ResizeObserver interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-resizeobservercallback">
-   <b><a href="#callbackdef-resizeobservercallback">#callbackdef-resizeobservercallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-resizeobservercallback" class="dfn-panel" data-for="callbackdef-resizeobservercallback" id="infopanel-for-callbackdef-resizeobservercallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-resizeobservercallback" style="display:none">Info about the 'ResizeObserverCallback' definition.</span><b><a href="#callbackdef-resizeobservercallback">#callbackdef-resizeobservercallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-resizeobservercallback">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-callbackdef-resizeobservercallback①">2.3. ResizeObserverEntry</a> <a href="#ref-for-callbackdef-resizeobservercallback②">(2)</a> <a href="#ref-for-callbackdef-resizeobservercallback③">(3)</a> <a href="#ref-for-callbackdef-resizeobservercallback④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resizeobserverentry">
-   <b><a href="#resizeobserverentry">#resizeobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resizeobserverentry" class="dfn-panel" data-for="resizeobserverentry" id="infopanel-for-resizeobserverentry" role="dialog">
+   <span id="infopaneltitle-for-resizeobserverentry" style="display:none">Info about the 'ResizeObserverEntry' definition.</span><b><a href="#resizeobserverentry">#resizeobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resizeobserverentry">2.2. ResizeObserverCallback</a>
     <li><a href="#ref-for-resizeobserverentry①">3.4.4. 
@@ -2400,24 +2400,24 @@ Create and populate a ResizeObserverEntry </a>
     <li><a href="#ref-for-resizeobserverentry②">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverentry-target">
-   <b><a href="#dom-resizeobserverentry-target">#dom-resizeobserverentry-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverentry-target" class="dfn-panel" data-for="dom-resizeobserverentry-target" id="infopanel-for-dom-resizeobserverentry-target" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverentry-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-resizeobserverentry-target">#dom-resizeobserverentry-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverentry-target">2.3. ResizeObserverEntry</a>
     <li><a href="#ref-for-dom-resizeobserverentry-target①">3.4.4. 
 Create and populate a ResizeObserverEntry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverentry-contentrect">
-   <b><a href="#dom-resizeobserverentry-contentrect">#dom-resizeobserverentry-contentrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverentry-contentrect" class="dfn-panel" data-for="dom-resizeobserverentry-contentrect" id="infopanel-for-dom-resizeobserverentry-contentrect" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverentry-contentrect" style="display:none">Info about the 'contentRect' definition.</span><b><a href="#dom-resizeobserverentry-contentrect">#dom-resizeobserverentry-contentrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverentry-contentrect">2.3. ResizeObserverEntry</a>
     <li><a href="#ref-for-dom-resizeobserverentry-contentrect①">3.4.4. 
 Create and populate a ResizeObserverEntry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverentry-borderboxsize">
-   <b><a href="#dom-resizeobserverentry-borderboxsize">#dom-resizeobserverentry-borderboxsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverentry-borderboxsize" class="dfn-panel" data-for="dom-resizeobserverentry-borderboxsize" id="infopanel-for-dom-resizeobserverentry-borderboxsize" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverentry-borderboxsize" style="display:none">Info about the 'borderBoxSize' definition.</span><b><a href="#dom-resizeobserverentry-borderboxsize">#dom-resizeobserverentry-borderboxsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverentry-borderboxsize">2.3. ResizeObserverEntry</a>
     <li><a href="#ref-for-dom-resizeobserverentry-borderboxsize①">3.4.4. 
@@ -2425,8 +2425,8 @@ Create and populate a ResizeObserverEntry </a>
     <li><a href="#ref-for-dom-resizeobserverentry-borderboxsize②">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverentry-contentboxsize">
-   <b><a href="#dom-resizeobserverentry-contentboxsize">#dom-resizeobserverentry-contentboxsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverentry-contentboxsize" class="dfn-panel" data-for="dom-resizeobserverentry-contentboxsize" id="infopanel-for-dom-resizeobserverentry-contentboxsize" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverentry-contentboxsize" style="display:none">Info about the 'contentBoxSize' definition.</span><b><a href="#dom-resizeobserverentry-contentboxsize">#dom-resizeobserverentry-contentboxsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverentry-contentboxsize">2.3. ResizeObserverEntry</a>
     <li><a href="#ref-for-dom-resizeobserverentry-contentboxsize①">3.4.4. 
@@ -2434,8 +2434,8 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-dom-resizeobser
     <li><a href="#ref-for-dom-resizeobserverentry-contentboxsize③">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserverentry-devicepixelcontentboxsize">
-   <b><a href="#dom-resizeobserverentry-devicepixelcontentboxsize">#dom-resizeobserverentry-devicepixelcontentboxsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserverentry-devicepixelcontentboxsize" class="dfn-panel" data-for="dom-resizeobserverentry-devicepixelcontentboxsize" id="infopanel-for-dom-resizeobserverentry-devicepixelcontentboxsize" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserverentry-devicepixelcontentboxsize" style="display:none">Info about the 'devicePixelContentBoxSize' definition.</span><b><a href="#dom-resizeobserverentry-devicepixelcontentboxsize">#dom-resizeobserverentry-devicepixelcontentboxsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserverentry-devicepixelcontentboxsize">2.3. ResizeObserverEntry</a>
     <li><a href="#ref-for-dom-resizeobserverentry-devicepixelcontentboxsize①">3.4.4. 
@@ -2443,51 +2443,51 @@ Create and populate a ResizeObserverEntry </a>
     <li><a href="#ref-for-dom-resizeobserverentry-devicepixelcontentboxsize②">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resizeobserversize">
-   <b><a href="#resizeobserversize">#resizeobserversize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resizeobserversize" class="dfn-panel" data-for="resizeobserversize" id="infopanel-for-resizeobserversize" role="dialog">
+   <span id="infopaneltitle-for-resizeobserversize" style="display:none">Info about the 'ResizeObserverSize' definition.</span><b><a href="#resizeobserversize">#resizeobserversize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resizeobserversize">2.3. ResizeObserverEntry</a> <a href="#ref-for-resizeobserversize①">(2)</a> <a href="#ref-for-resizeobserversize②">(3)</a> <a href="#ref-for-resizeobserversize③">(4)</a> <a href="#ref-for-resizeobserversize④">(5)</a> <a href="#ref-for-resizeobserversize⑤">(6)</a>
     <li><a href="#ref-for-resizeobserversize⑥">3.1. ResizeObservation example struct</a> <a href="#ref-for-resizeobserversize⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resizeobservation">
-   <b><a href="#resizeobservation">#resizeobservation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resizeobservation" class="dfn-panel" data-for="resizeobservation" id="infopanel-for-resizeobservation" role="dialog">
+   <span id="infopaneltitle-for-resizeobservation" style="display:none">Info about the 'ResizeObservation' definition.</span><b><a href="#resizeobservation">#resizeobservation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resizeobservation">2.1. ResizeObserver interface</a> <a href="#ref-for-resizeobservation①">(2)</a>
     <li><a href="#ref-for-resizeobservation②">3.1. ResizeObservation example struct</a>
     <li><a href="#ref-for-resizeobservation③">3.2.2. ResizeObserver</a> <a href="#ref-for-resizeobservation④">(2)</a> <a href="#ref-for-resizeobservation⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobservation-target">
-   <b><a href="#dom-resizeobservation-target">#dom-resizeobservation-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobservation-target" class="dfn-panel" data-for="dom-resizeobservation-target" id="infopanel-for-dom-resizeobservation-target" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobservation-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-resizeobservation-target">#dom-resizeobservation-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobservation-target">3.1. ResizeObservation example struct</a> <a href="#ref-for-dom-resizeobservation-target①">(2)</a>
     <li><a href="#ref-for-dom-resizeobservation-target②">3.4.1. Gather active observations at depth</a>
     <li><a href="#ref-for-dom-resizeobservation-target③">3.4.5. Broadcast active observations</a> <a href="#ref-for-dom-resizeobservation-target④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobservation-observedbox">
-   <b><a href="#dom-resizeobservation-observedbox">#dom-resizeobservation-observedbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobservation-observedbox" class="dfn-panel" data-for="dom-resizeobservation-observedbox" id="infopanel-for-dom-resizeobservation-observedbox" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobservation-observedbox" style="display:none">Info about the 'observedBox' definition.</span><b><a href="#dom-resizeobservation-observedbox">#dom-resizeobservation-observedbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobservation-observedbox">3.1. ResizeObservation example struct</a> <a href="#ref-for-dom-resizeobservation-observedbox①">(2)</a>
     <li><a href="#ref-for-dom-resizeobservation-observedbox②">3.4.5. Broadcast active observations</a> <a href="#ref-for-dom-resizeobservation-observedbox③">(2)</a> <a href="#ref-for-dom-resizeobservation-observedbox④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobservation-lastreportedsizes">
-   <b><a href="#dom-resizeobservation-lastreportedsizes">#dom-resizeobservation-lastreportedsizes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobservation-lastreportedsizes" class="dfn-panel" data-for="dom-resizeobservation-lastreportedsizes" id="infopanel-for-dom-resizeobservation-lastreportedsizes" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobservation-lastreportedsizes" style="display:none">Info about the 'lastReportedSizes' definition.</span><b><a href="#dom-resizeobservation-lastreportedsizes">#dom-resizeobservation-lastreportedsizes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobservation-lastreportedsizes">3.1. ResizeObservation example struct</a> <a href="#ref-for-dom-resizeobservation-lastreportedsizes①">(2)</a> <a href="#ref-for-dom-resizeobservation-lastreportedsizes②">(3)</a>
     <li><a href="#ref-for-dom-resizeobservation-lastreportedsizes③">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobservation-isactive">
-   <b><a href="#dom-resizeobservation-isactive">#dom-resizeobservation-isactive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobservation-isactive" class="dfn-panel" data-for="dom-resizeobservation-isactive" id="infopanel-for-dom-resizeobservation-isactive" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobservation-isactive" style="display:none">Info about the 'isActive()' definition.</span><b><a href="#dom-resizeobservation-isactive">#dom-resizeobservation-isactive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobservation-isactive">3.4.1. Gather active observations at depth</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-resizeobservers-slot">
-   <b><a href="#dom-document-resizeobservers-slot">#dom-document-resizeobservers-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-resizeobservers-slot" class="dfn-panel" data-for="dom-document-resizeobservers-slot" id="infopanel-for-dom-document-resizeobservers-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-document-resizeobservers-slot" style="display:none">Info about the '[[resizeObservers]]' definition.</span><b><a href="#dom-document-resizeobservers-slot">#dom-document-resizeobservers-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-resizeobservers-slot">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-dom-document-resizeobservers-slot①">3.4.1. Gather active observations at depth</a>
@@ -2496,22 +2496,22 @@ Create and populate a ResizeObserverEntry </a>
     <li><a href="#ref-for-dom-document-resizeobservers-slot④">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-callback-slot">
-   <b><a href="#dom-resizeobserver-callback-slot">#dom-resizeobserver-callback-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-callback-slot" class="dfn-panel" data-for="dom-resizeobserver-callback-slot" id="infopanel-for-dom-resizeobserver-callback-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-callback-slot" style="display:none">Info about the '[[callback]]' definition.</span><b><a href="#dom-resizeobserver-callback-slot">#dom-resizeobserver-callback-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-callback-slot">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-dom-resizeobserver-callback-slot①">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-observationtargets-slot">
-   <b><a href="#dom-resizeobserver-observationtargets-slot">#dom-resizeobserver-observationtargets-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-observationtargets-slot" class="dfn-panel" data-for="dom-resizeobserver-observationtargets-slot" id="infopanel-for-dom-resizeobserver-observationtargets-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-observationtargets-slot" style="display:none">Info about the '[[observationTargets]]' definition.</span><b><a href="#dom-resizeobserver-observationtargets-slot">#dom-resizeobserver-observationtargets-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-observationtargets-slot">2.1. ResizeObserver interface</a> <a href="#ref-for-dom-resizeobserver-observationtargets-slot①">(2)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-slot②">(3)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-slot③">(4)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-slot④">(5)</a> <a href="#ref-for-dom-resizeobserver-observationtargets-slot⑤">(6)</a>
     <li><a href="#ref-for-dom-resizeobserver-observationtargets-slot⑥">3.4.1. Gather active observations at depth</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-activetargets-slot">
-   <b><a href="#dom-resizeobserver-activetargets-slot">#dom-resizeobserver-activetargets-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-activetargets-slot" class="dfn-panel" data-for="dom-resizeobserver-activetargets-slot" id="infopanel-for-dom-resizeobserver-activetargets-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-activetargets-slot" style="display:none">Info about the '[[activeTargets]]' definition.</span><b><a href="#dom-resizeobserver-activetargets-slot">#dom-resizeobserver-activetargets-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-activetargets-slot">2.1. ResizeObserver interface</a>
     <li><a href="#ref-for-dom-resizeobserver-activetargets-slot①">3.4.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-activetargets-slot②">(2)</a>
@@ -2519,65 +2519,65 @@ Create and populate a ResizeObserverEntry </a>
     <li><a href="#ref-for-dom-resizeobserver-activetargets-slot④">3.4.5. Broadcast active observations</a> <a href="#ref-for-dom-resizeobserver-activetargets-slot⑤">(2)</a> <a href="#ref-for-dom-resizeobserver-activetargets-slot⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-resizeobserver-skippedtargets-slot">
-   <b><a href="#dom-resizeobserver-skippedtargets-slot">#dom-resizeobserver-skippedtargets-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-resizeobserver-skippedtargets-slot" class="dfn-panel" data-for="dom-resizeobserver-skippedtargets-slot" id="infopanel-for-dom-resizeobserver-skippedtargets-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-resizeobserver-skippedtargets-slot" style="display:none">Info about the '[[skippedTargets]]' definition.</span><b><a href="#dom-resizeobserver-skippedtargets-slot">#dom-resizeobserver-skippedtargets-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-resizeobserver-skippedtargets-slot">3.4.1. Gather active observations at depth</a> <a href="#ref-for-dom-resizeobserver-skippedtargets-slot①">(2)</a>
     <li><a href="#ref-for-dom-resizeobserver-skippedtargets-slot②">3.4.3. Has skipped observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-rect">
-   <b><a href="#content-rect">#content-rect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-rect" class="dfn-panel" data-for="content-rect" id="infopanel-for-content-rect" role="dialog">
+   <span id="infopaneltitle-for-content-rect" style="display:none">Info about the 'content rect' definition.</span><b><a href="#content-rect">#content-rect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-rect">2.3. ResizeObserverEntry</a> <a href="#ref-for-content-rect①">(2)</a> <a href="#ref-for-content-rect②">(3)</a> <a href="#ref-for-content-rect③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gather-active-observations-at-depth">
-   <b><a href="#gather-active-observations-at-depth">#gather-active-observations-at-depth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gather-active-observations-at-depth" class="dfn-panel" data-for="gather-active-observations-at-depth" id="infopanel-for-gather-active-observations-at-depth" role="dialog">
+   <span id="infopaneltitle-for-gather-active-observations-at-depth" style="display:none">Info about the 'gather active observations at depth' definition.</span><b><a href="#gather-active-observations-at-depth">#gather-active-observations-at-depth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gather-active-observations-at-depth">3.6.1.  HTML Processing Model: Event Loop</a> <a href="#ref-for-gather-active-observations-at-depth①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-active-observations">
-   <b><a href="#has-active-observations">#has-active-observations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-active-observations" class="dfn-panel" data-for="has-active-observations" id="infopanel-for-has-active-observations" role="dialog">
+   <span id="infopaneltitle-for-has-active-observations" style="display:none">Info about the 'has active observations' definition.</span><b><a href="#has-active-observations">#has-active-observations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-active-observations">3.6.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-skipped-observations">
-   <b><a href="#has-skipped-observations">#has-skipped-observations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-skipped-observations" class="dfn-panel" data-for="has-skipped-observations" id="infopanel-for-has-skipped-observations" role="dialog">
+   <span id="infopaneltitle-for-has-skipped-observations" style="display:none">Info about the 'has skipped observations' definition.</span><b><a href="#has-skipped-observations">#has-skipped-observations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-skipped-observations">3.6.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-and-populate-a-resizeobserverentry">
-   <b><a href="#create-and-populate-a-resizeobserverentry">#create-and-populate-a-resizeobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-and-populate-a-resizeobserverentry" class="dfn-panel" data-for="create-and-populate-a-resizeobserverentry" id="infopanel-for-create-and-populate-a-resizeobserverentry" role="dialog">
+   <span id="infopaneltitle-for-create-and-populate-a-resizeobserverentry" style="display:none">Info about the 'create and populate a ResizeObserverEntry' definition.</span><b><a href="#create-and-populate-a-resizeobserverentry">#create-and-populate-a-resizeobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-and-populate-a-resizeobserverentry">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="broadcast-active-observations">
-   <b><a href="#broadcast-active-observations">#broadcast-active-observations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-broadcast-active-observations" class="dfn-panel" data-for="broadcast-active-observations" id="infopanel-for-broadcast-active-observations" role="dialog">
+   <span id="infopaneltitle-for-broadcast-active-observations" style="display:none">Info about the 'broadcast active observations' definition.</span><b><a href="#broadcast-active-observations">#broadcast-active-observations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-broadcast-active-observations">2.2. ResizeObserverCallback</a>
     <li><a href="#ref-for-broadcast-active-observations①">3.6.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deliver-resize-loop-error-notification">
-   <b><a href="#deliver-resize-loop-error-notification">#deliver-resize-loop-error-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deliver-resize-loop-error-notification" class="dfn-panel" data-for="deliver-resize-loop-error-notification" id="infopanel-for-deliver-resize-loop-error-notification" role="dialog">
+   <span id="infopaneltitle-for-deliver-resize-loop-error-notification" style="display:none">Info about the 'deliver resize loop error notification' definition.</span><b><a href="#deliver-resize-loop-error-notification">#deliver-resize-loop-error-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deliver-resize-loop-error-notification">3.6.1.  HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-depth-for-node">
-   <b><a href="#calculate-depth-for-node">#calculate-depth-for-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculate-depth-for-node" class="dfn-panel" data-for="calculate-depth-for-node" id="infopanel-for-calculate-depth-for-node" role="dialog">
+   <span id="infopaneltitle-for-calculate-depth-for-node" style="display:none">Info about the 'calculate depth for node' definition.</span><b><a href="#calculate-depth-for-node">#calculate-depth-for-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-depth-for-node">3.4.1. Gather active observations at depth</a>
     <li><a href="#ref-for-calculate-depth-for-node①">3.4.5. Broadcast active observations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-box-size">
-   <b><a href="#calculate-box-size">#calculate-box-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculate-box-size" class="dfn-panel" data-for="calculate-box-size" id="infopanel-for-calculate-box-size" role="dialog">
+   <span id="infopaneltitle-for-calculate-box-size" style="display:none">Info about the 'calculate box size' definition.</span><b><a href="#calculate-box-size">#calculate-box-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-box-size">3.1. ResizeObservation example struct</a>
     <li><a href="#ref-for-calculate-box-size">3.4.4. 
@@ -2586,59 +2586,115 @@ Create and populate a ResizeObserverEntry </a> <a href="#ref-for-calculate-box-s
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/scroll-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/scroll-animations-1/Overview.html
@@ -2182,22 +2182,22 @@ in an "incognito" mode using scroll-linked animations.</p>
     </ul>
    <li><a href="#dom-scrolldirection-vertical">"vertical"</a><span>, in § 3.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timeline">
-   <a href="https://drafts.csswg.org/css-animations-2/#propdef-animation-timeline">https://drafts.csswg.org/css-animations-2/#propdef-animation-timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timeline" class="dfn-panel" data-for="term-for-propdef-animation-timeline" id="infopanel-for-term-for-propdef-animation-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timeline" style="display:none">Info about the 'animation-timeline' external reference.</span><a href="https://drafts.csswg.org/css-animations-2/#propdef-animation-timeline">https://drafts.csswg.org/css-animations-2/#propdef-animation-timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timeline">2.2. The content progress bar</a>
     <li><a href="#ref-for-propdef-animation-timeline①">3.2. The '@scroll-timeline' at-rule</a>
     <li><a href="#ref-for-propdef-animation-timeline②">3.3. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-padding-box">
-   <a href="https://drafts.csswg.org/css-box-4/#padding-box">https://drafts.csswg.org/css-box-4/#padding-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-padding-box" class="dfn-panel" data-for="term-for-padding-box" id="infopanel-for-term-for-padding-box" role="menu">
+   <span id="infopaneltitle-for-term-for-padding-box" style="display:none">Info about the 'padding box' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#padding-box">https://drafts.csswg.org/css-box-4/#padding-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-padding-box">3.1.3.1. Container-based Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scroll-container">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scroll-container" class="dfn-panel" data-for="term-for-scroll-container" id="infopanel-for-term-for-scroll-container" role="menu">
+   <span id="infopaneltitle-for-term-for-scroll-container" style="display:none">Info about the 'scroll container' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scroll-container">https://drafts.csswg.org/css-overflow-3/#scroll-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-container">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-scroll-container①">3.1.3. Scroll Timeline Offset</a>
@@ -2208,175 +2208,175 @@ in an "incognito" mode using scroll-linked animations.</p>
     <li><a href="#ref-for-scroll-container⑨">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrollport">
-   <a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrollport" class="dfn-panel" data-for="term-for-scrollport" id="infopanel-for-term-for-scrollport" role="menu">
+   <span id="infopaneltitle-for-term-for-scrollport" style="display:none">Info about the 'scrollport' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#scrollport">https://drafts.csswg.org/css-overflow-3/#scrollport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrollport">3.1.3.2. Element-based Offset</a> <a href="#ref-for-scrollport①">(2)</a> <a href="#ref-for-scrollport②">(3)</a> <a href="#ref-for-scrollport③">(4)</a> <a href="#ref-for-scrollport④">(5)</a> <a href="#ref-for-scrollport⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-declaration-list">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-declaration-list" class="dfn-panel" data-for="term-for-typedef-declaration-list" id="infopanel-for-term-for-typedef-declaration-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-declaration-list" style="display:none">Info about the '&lt;declaration-list>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list">https://drafts.csswg.org/css-syntax-3/#typedef-declaration-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-declaration-list">3.2. The '@scroll-timeline' at-rule</a> <a href="#ref-for-typedef-declaration-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csskeywordvalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#csskeywordvalue">https://drafts.css-houdini.org/css-typed-om-1/#csskeywordvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csskeywordvalue" class="dfn-panel" data-for="term-for-csskeywordvalue" id="infopanel-for-term-for-csskeywordvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-csskeywordvalue" style="display:none">Info about the 'CSSKeywordValue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#csskeywordvalue">https://drafts.css-houdini.org/css-typed-om-1/#csskeywordvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeywordvalue">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-csskeywordvalue①">3.1.3.1. Container-based Offset</a> <a href="#ref-for-csskeywordvalue②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedefdef-csskeywordish">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-csskeywordish">https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-csskeywordish</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedefdef-csskeywordish" class="dfn-panel" data-for="term-for-typedefdef-csskeywordish" id="infopanel-for-term-for-typedefdef-csskeywordish" role="menu">
+   <span id="infopaneltitle-for-term-for-typedefdef-csskeywordish" style="display:none">Info about the 'CSSKeywordish' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-csskeywordish">https://drafts.css-houdini.org/css-typed-om-1/#typedefdef-csskeywordish</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-csskeywordish">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssnumericvalue">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssnumericvalue" class="dfn-panel" data-for="term-for-cssnumericvalue" id="infopanel-for-term-for-cssnumericvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-cssnumericvalue" style="display:none">Info about the 'CSSNumericValue' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue">https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssnumericvalue">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-cssnumericvalue①">(2)</a>
     <li><a href="#ref-for-cssnumericvalue②">3.1.3.1. Container-based Offset</a> <a href="#ref-for-cssnumericvalue③">(2)</a> <a href="#ref-for-cssnumericvalue④">(3)</a> <a href="#ref-for-cssnumericvalue⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstylevalue-match-a-grammar">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstylevalue-match-a-grammar" class="dfn-panel" data-for="term-for-cssstylevalue-match-a-grammar" id="infopanel-for-term-for-cssstylevalue-match-a-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstylevalue-match-a-grammar" style="display:none">Info about the 'match the grammar' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar">https://drafts.css-houdini.org/css-typed-om-1/#cssstylevalue-match-a-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstylevalue-match-a-grammar">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-cssstylevalue-match-a-grammar①">(2)</a>
     <li><a href="#ref-for-cssstylevalue-match-a-grammar②">3.1.3.1. Container-based Offset</a> <a href="#ref-for-cssstylevalue-match-a-grammar③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rectify-a-keywordish-value">
-   <a href="https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-keywordish-value">https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-keywordish-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rectify-a-keywordish-value" class="dfn-panel" data-for="term-for-rectify-a-keywordish-value" id="infopanel-for-term-for-rectify-a-keywordish-value" role="menu">
+   <span id="infopaneltitle-for-term-for-rectify-a-keywordish-value" style="display:none">Info about the 'rectify a keywordish value' external reference.</span><a href="https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-keywordish-value">https://drafts.css-houdini.org/css-typed-om-1/#rectify-a-keywordish-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectify-a-keywordish-value">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identifier-value">
-   <a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identifier-value" class="dfn-panel" data-for="term-for-identifier-value" id="infopanel-for-term-for-identifier-value" role="menu">
+   <span id="infopaneltitle-for-term-for-identifier-value" style="display:none">Info about the '&lt;custom-ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#identifier-value">https://drafts.csswg.org/css-values-4/#identifier-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identifier-value">3.2. The '@scroll-timeline' at-rule</a> <a href="#ref-for-identifier-value①">(2)</a> <a href="#ref-for-identifier-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-typedef-length-percentage①">3.1.3.1. Container-based Offset</a>
     <li><a href="#ref-for-typedef-length-percentage②">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-typedef-length-percentage③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.1.3.1. Container-based Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">3.2. The '@scroll-timeline' at-rule</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the '&lt;time>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#time-value">https://drafts.csswg.org/css-values-4/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">3.1.3.1. Container-based Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-wide-keywords">
-   <a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-wide-keywords" class="dfn-panel" data-for="term-for-css-wide-keywords" id="infopanel-for-term-for-css-wide-keywords" role="menu">
+   <span id="infopaneltitle-for-term-for-css-wide-keywords" style="display:none">Info about the 'css-wide keywords' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#css-wide-keywords">https://drafts.csswg.org/css-values-4/#css-wide-keywords</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-wide-keywords">1.3. Value Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-axis" class="dfn-panel" data-for="term-for-block-axis" id="infopanel-for-term-for-block-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-block-axis" style="display:none">Info about the 'block axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-axis">https://drafts.csswg.org/css-writing-modes-4/#block-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-axis">3.1.1. The ScrollDirection enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-axis">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-axis" class="dfn-panel" data-for="term-for-inline-axis" id="infopanel-for-term-for-inline-axis" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-axis" style="display:none">Info about the 'inline axis' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#inline-axis">https://drafts.csswg.org/css-writing-modes-4/#inline-axis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-axis">3.1.1. The ScrollDirection enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">2.2. The content progress bar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csskeyframerule">
-   <a href="https://drafts.csswg.org/css-animations-1/#csskeyframerule">https://drafts.csswg.org/css-animations-1/#csskeyframerule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csskeyframerule" class="dfn-panel" data-for="term-for-csskeyframerule" id="infopanel-for-term-for-csskeyframerule" role="menu">
+   <span id="infopaneltitle-for-term-for-csskeyframerule" style="display:none">Info about the 'csskeyframerule' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#csskeyframerule">https://drafts.csswg.org/css-animations-1/#csskeyframerule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csskeyframerule">3.1.6. The progress of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-csskeyframesrule-findrule">
-   <a href="https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule">https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-csskeyframesrule-findrule" class="dfn-panel" data-for="term-for-interface-csskeyframesrule-findrule" id="infopanel-for-term-for-interface-csskeyframesrule-findrule" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-csskeyframesrule-findrule" style="display:none">Info about the 'findrule' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule">https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-csskeyframesrule-findrule">3.1.6. The progress of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-cssomstring①">(2)</a> <a href="#ref-for-cssomstring②">(3)</a> <a href="#ref-for-cssomstring③">(4)</a> <a href="#ref-for-cssomstring④">(5)</a> <a href="#ref-for-cssomstring⑤">(6)</a> <a href="#ref-for-cssomstring⑥">(7)</a> <a href="#ref-for-cssomstring⑦">(8)</a> <a href="#ref-for-cssomstring⑧">(9)</a> <a href="#ref-for-cssomstring⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssrule">
-   <a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssrule" class="dfn-panel" data-for="term-for-cssrule" id="infopanel-for-term-for-cssrule" role="menu">
+   <span id="infopaneltitle-for-term-for-cssrule" style="display:none">Info about the 'CSSRule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssrule">https://drafts.csswg.org/cssom-1/#cssrule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssrule">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-css-component-value">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-component-value">https://drafts.csswg.org/cssom-1/#serialize-a-css-component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-css-component-value" class="dfn-panel" data-for="term-for-serialize-a-css-component-value" id="infopanel-for-term-for-serialize-a-css-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-css-component-value" style="display:none">Info about the 'serialize a css component value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-css-component-value">https://drafts.csswg.org/cssom-1/#serialize-a-css-component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-component-value">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-serialize-a-css-component-value①">(2)</a> <a href="#ref-for-serialize-a-css-component-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-selector">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-a-selector">https://drafts.csswg.org/cssom-1/#serialize-a-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-selector" class="dfn-panel" data-for="term-for-serialize-a-selector" id="infopanel-for-term-for-serialize-a-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-selector" style="display:none">Info about the 'serialize a selector' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-a-selector">https://drafts.csswg.org/cssom-1/#serialize-a-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-selector">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-an-identifier">
-   <a href="https://drafts.csswg.org/cssom-1/#serialize-an-identifier">https://drafts.csswg.org/cssom-1/#serialize-an-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-an-identifier" class="dfn-panel" data-for="term-for-serialize-an-identifier" id="infopanel-for-term-for-serialize-an-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-an-identifier" style="display:none">Info about the 'serialize an identifier' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#serialize-an-identifier">https://drafts.csswg.org/cssom-1/#serialize-an-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-identifier">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-serialize-an-identifier①">(2)</a> <a href="#ref-for-serialize-an-identifier②">(3)</a> <a href="#ref-for-serialize-an-identifier③">(4)</a> <a href="#ref-for-serialize-an-identifier④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-layout-box">
-   <a href="https://drafts.csswg.org/cssom-view/#css-layout-box">https://drafts.csswg.org/cssom-view/#css-layout-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-layout-box" class="dfn-panel" data-for="term-for-css-layout-box" id="infopanel-for-term-for-css-layout-box" role="menu">
+   <span id="infopaneltitle-for-term-for-css-layout-box" style="display:none">Info about the 'css layout box' external reference.</span><a href="https://drafts.csswg.org/cssom-view/#css-layout-box">https://drafts.csswg.org/cssom-view/#css-layout-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-layout-box">3.1.3.1. Container-based Offset</a>
     <li><a href="#ref-for-css-layout-box①">3.1.3.2. Element-based Offset</a> <a href="#ref-for-css-layout-box②">(2)</a>
@@ -2384,185 +2384,185 @@ in an "incognito" mode using scroll-linked animations.</p>
     <li><a href="#ref-for-css-layout-box④">3.1.8. The current time of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overflow-directions">
-   <a href="https://drafts.csswg.org/cssom-view/#overflow-directions">https://drafts.csswg.org/cssom-view/#overflow-directions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overflow-directions" class="dfn-panel" data-for="term-for-overflow-directions" id="infopanel-for-term-for-overflow-directions" role="menu">
+   <span id="infopaneltitle-for-term-for-overflow-directions" style="display:none">Info about the 'overflow direction' external reference.</span><a href="https://drafts.csswg.org/cssom-view/#overflow-directions">https://drafts.csswg.org/cssom-view/#overflow-directions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overflow-directions">3.1.3.1. Container-based Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-scrollingelement">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-document-scrollingelement">https://drafts.csswg.org/cssom-view-1/#dom-document-scrollingelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-scrollingelement" class="dfn-panel" data-for="term-for-dom-document-scrollingelement" id="infopanel-for-term-for-dom-document-scrollingelement" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-scrollingelement" style="display:none">Info about the 'scrollingElement' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-document-scrollingelement">https://drafts.csswg.org/cssom-view-1/#dom-document-scrollingelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-scrollingelement">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-dom-document-scrollingelement①">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-document①">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a>
     <li><a href="#ref-for-element③">3.1.3.2. Element-based Offset</a> <a href="#ref-for-element④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">3.2. The '@scroll-timeline' at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-window①">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-current-global-object①">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'document associated with a window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-concept-document-window①">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" class="dfn-panel" data-for="term-for-dom-animationframeprovider-requestanimationframe" id="infopanel-for-term-for-dom-animationframeprovider-requestanimationframe" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animationframeprovider-requestanimationframe" style="display:none">Info about the 'requestAnimationFrame(callback)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-animationframeprovider-requestanimationframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationframeprovider-requestanimationframe">4. Avoiding cycles with layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-id-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-id-selector">https://drafts.csswg.org/selectors-4/#typedef-id-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-id-selector" class="dfn-panel" data-for="term-for-typedef-id-selector" id="infopanel-for-term-for-typedef-id-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-id-selector" style="display:none">Info about the '&lt;id-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-id-selector">https://drafts.csswg.org/selectors-4/#typedef-id-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-id-selector">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-typedef-id-selector①">(2)</a> <a href="#ref-for-typedef-id-selector②">(3)</a> <a href="#ref-for-typedef-id-selector③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationtimeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationtimeline" class="dfn-panel" data-for="term-for-animationtimeline" id="infopanel-for-term-for-animationtimeline" role="menu">
+   <span id="infopaneltitle-for-term-for-animationtimeline" style="display:none">Info about the 'AnimationTimeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationtimeline">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-animationtimeline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-active-phase">
-   <a href="https://w3c.github.io/web-animations/#timeline-active-phase">https://w3c.github.io/web-animations/#timeline-active-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-active-phase" class="dfn-panel" data-for="term-for-timeline-active-phase" id="infopanel-for-term-for-timeline-active-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-active-phase" style="display:none">Info about the 'active phase' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline-active-phase">https://w3c.github.io/web-animations/#timeline-active-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-active-phase">3.1.7. The phase of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-after-phase">
-   <a href="https://w3c.github.io/web-animations/#timeline-after-phase">https://w3c.github.io/web-animations/#timeline-after-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-after-phase" class="dfn-panel" data-for="term-for-timeline-after-phase" id="infopanel-for-term-for-timeline-after-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-after-phase" style="display:none">Info about the 'after phase' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline-after-phase">https://w3c.github.io/web-animations/#timeline-after-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-after-phase">3.1.7. The phase of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-animation">
-   <a href="https://w3c.github.io/web-animations/#concept-animation">https://w3c.github.io/web-animations/#concept-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-animation" class="dfn-panel" data-for="term-for-concept-animation" id="infopanel-for-term-for-concept-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://w3c.github.io/web-animations/#concept-animation">https://w3c.github.io/web-animations/#concept-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-animation">1.1. Relationship to other specifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-before-phase">
-   <a href="https://w3c.github.io/web-animations/#timeline-before-phase">https://w3c.github.io/web-animations/#timeline-before-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-before-phase" class="dfn-panel" data-for="term-for-timeline-before-phase" id="infopanel-for-term-for-timeline-before-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-before-phase" style="display:none">Info about the 'before phase' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline-before-phase">https://w3c.github.io/web-animations/#timeline-before-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-before-phase">3.1.7. The phase of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-time">
-   <a href="https://w3c.github.io/web-animations/#current-time">https://w3c.github.io/web-animations/#current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-time" class="dfn-panel" data-for="term-for-current-time" id="infopanel-for-term-for-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-current-time" style="display:none">Info about the 'current time' external reference.</span><a href="https://w3c.github.io/web-animations/#current-time">https://w3c.github.io/web-animations/#current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">3.1.6. The progress of a ScrollTimeline</a>
     <li><a href="#ref-for-current-time①">3.1.8. The current time of a ScrollTimeline</a> <a href="#ref-for-current-time②">(2)</a> <a href="#ref-for-current-time③">(3)</a> <a href="#ref-for-current-time④">(4)</a> <a href="#ref-for-current-time⑤">(5)</a> <a href="#ref-for-current-time⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-duration">
-   <a href="https://w3c.github.io/web-animations/#duration">https://w3c.github.io/web-animations/#duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-duration" class="dfn-panel" data-for="term-for-duration" id="infopanel-for-term-for-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/web-animations/#duration">https://w3c.github.io/web-animations/#duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-duration">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-inactive-phase">
-   <a href="https://w3c.github.io/web-animations/#timeline-inactive-phase">https://w3c.github.io/web-animations/#timeline-inactive-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-inactive-phase" class="dfn-panel" data-for="term-for-timeline-inactive-phase" id="infopanel-for-term-for-timeline-inactive-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-inactive-phase" style="display:none">Info about the 'inactive phase' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline-inactive-phase">https://w3c.github.io/web-animations/#timeline-inactive-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-inactive-phase">3.1.7. The phase of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-phase">
-   <a href="https://w3c.github.io/web-animations/#timeline-phase">https://w3c.github.io/web-animations/#timeline-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-phase" class="dfn-panel" data-for="term-for-timeline-phase" id="infopanel-for-term-for-timeline-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-phase" style="display:none">Info about the 'phase' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline-phase">https://w3c.github.io/web-animations/#timeline-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-phase">3.1.7. The phase of a ScrollTimeline</a> <a href="#ref-for-timeline-phase①">(2)</a> <a href="#ref-for-timeline-phase②">(3)</a> <a href="#ref-for-timeline-phase③">(4)</a> <a href="#ref-for-timeline-phase④">(5)</a> <a href="#ref-for-timeline-phase⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-start-delay">
-   <a href="https://w3c.github.io/web-animations/#start-delay">https://w3c.github.io/web-animations/#start-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-start-delay" class="dfn-panel" data-for="term-for-start-delay" id="infopanel-for-term-for-start-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-start-delay" style="display:none">Info about the 'start delay' external reference.</span><a href="https://w3c.github.io/web-animations/#start-delay">https://w3c.github.io/web-animations/#start-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect-end">
-   <a href="https://w3c.github.io/web-animations/#target-effect-end">https://w3c.github.io/web-animations/#target-effect-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect-end" class="dfn-panel" data-for="term-for-target-effect-end" id="infopanel-for-term-for-target-effect-end" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect-end" style="display:none">Info about the 'target effect end' external reference.</span><a href="https://w3c.github.io/web-animations/#target-effect-end">https://w3c.github.io/web-animations/#target-effect-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect-end">3.1.4. The effective time range of a ScrollTimeline</a> <a href="#ref-for-target-effect-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline">
-   <a href="https://w3c.github.io/web-animations/#timeline">https://w3c.github.io/web-animations/#timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline" class="dfn-panel" data-for="term-for-timeline" id="infopanel-for-term-for-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline" style="display:none">Info about the 'timeline' external reference.</span><a href="https://w3c.github.io/web-animations/#timeline">https://w3c.github.io/web-animations/#timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline">1.1. Relationship to other specifications</a> <a href="#ref-for-timeline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-Exposed①">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">3.1.3.2. Element-based Offset</a> <a href="#ref-for-idl-double③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1.2. The ScrollTimeline interface</a>
    </ul>
@@ -2821,39 +2821,39 @@ checked anywhere. <a href="https://github.com/w3c/csswg-drafts/issues/5203">[Iss
    <div class="issue"> Consider choosing animation target’s nearest scrollable ancestor
 instead of document’s scrolling Element for <code>auto</code>. <a href="https://github.com/w3c/csswg-drafts/issues/4338">[Issue #4338]</a> <a class="issue-return" href="#issue-62b2910f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="enumdef-scrolldirection">
-   <b><a href="#enumdef-scrolldirection">#enumdef-scrolldirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-scrolldirection" class="dfn-panel" data-for="enumdef-scrolldirection" id="infopanel-for-enumdef-scrolldirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-scrolldirection" style="display:none">Info about the 'ScrollDirection' definition.</span><b><a href="#enumdef-scrolldirection">#enumdef-scrolldirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-scrolldirection">3.1.1. The ScrollDirection enumeration</a> <a href="#ref-for-enumdef-scrolldirection①">(2)</a>
     <li><a href="#ref-for-enumdef-scrolldirection②">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-enumdef-scrolldirection③">(2)</a> <a href="#ref-for-enumdef-scrolldirection④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-scrolltimelineautokeyword">
-   <b><a href="#enumdef-scrolltimelineautokeyword">#enumdef-scrolltimelineautokeyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-scrolltimelineautokeyword" class="dfn-panel" data-for="enumdef-scrolltimelineautokeyword" id="infopanel-for-enumdef-scrolltimelineautokeyword" role="dialog">
+   <span id="infopaneltitle-for-enumdef-scrolltimelineautokeyword" style="display:none">Info about the 'ScrollTimelineAutoKeyword' definition.</span><b><a href="#enumdef-scrolltimelineautokeyword">#enumdef-scrolltimelineautokeyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-scrolltimelineautokeyword">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-enumdef-scrolltimelineautokeyword①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-containerbasedoffset">
-   <b><a href="#typedefdef-containerbasedoffset">#typedefdef-containerbasedoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-containerbasedoffset" class="dfn-panel" data-for="typedefdef-containerbasedoffset" id="infopanel-for-typedefdef-containerbasedoffset" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-containerbasedoffset" style="display:none">Info about the 'ContainerBasedOffset' definition.</span><b><a href="#typedefdef-containerbasedoffset">#typedefdef-containerbasedoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-containerbasedoffset">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-scrolltimelineoffset">
-   <b><a href="#typedefdef-scrolltimelineoffset">#typedefdef-scrolltimelineoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-scrolltimelineoffset" class="dfn-panel" data-for="typedefdef-scrolltimelineoffset" id="infopanel-for-typedefdef-scrolltimelineoffset" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-scrolltimelineoffset" style="display:none">Info about the 'ScrollTimelineOffset' definition.</span><b><a href="#typedefdef-scrolltimelineoffset">#typedefdef-scrolltimelineoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-scrolltimelineoffset">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-typedefdef-scrolltimelineoffset①">(2)</a> <a href="#ref-for-typedefdef-scrolltimelineoffset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-scrolltimelineoptions">
-   <b><a href="#dictdef-scrolltimelineoptions">#dictdef-scrolltimelineoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-scrolltimelineoptions" class="dfn-panel" data-for="dictdef-scrolltimelineoptions" id="infopanel-for-dictdef-scrolltimelineoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-scrolltimelineoptions" style="display:none">Info about the 'ScrollTimelineOptions' definition.</span><b><a href="#dictdef-scrolltimelineoptions">#dictdef-scrolltimelineoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-scrolltimelineoptions">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scrolltimeline">
-   <b><a href="#scrolltimeline">#scrolltimeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scrolltimeline" class="dfn-panel" data-for="scrolltimeline" id="infopanel-for-scrolltimeline" role="dialog">
+   <span id="infopaneltitle-for-scrolltimeline" style="display:none">Info about the 'ScrollTimeline' definition.</span><b><a href="#scrolltimeline">#scrolltimeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrolltimeline">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-scrolltimeline①">(2)</a> <a href="#ref-for-scrolltimeline②">(3)</a>
     <li><a href="#ref-for-scrolltimeline③">3.1.4. The effective time range of a ScrollTimeline</a> <a href="#ref-for-scrolltimeline④">(2)</a> <a href="#ref-for-scrolltimeline⑤">(3)</a>
@@ -2864,21 +2864,21 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-scrolltimeline①②">4. Avoiding cycles with layout</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-timeline">
-   <b><a href="#scroll-timeline">#scroll-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-timeline" class="dfn-panel" data-for="scroll-timeline" id="infopanel-for-scroll-timeline" role="dialog">
+   <span id="infopaneltitle-for-scroll-timeline" style="display:none">Info about the 'scroll timeline' definition.</span><b><a href="#scroll-timeline">#scroll-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-timeline">1.1. Relationship to other specifications</a>
     <li><a href="#ref-for-scroll-timeline①">3.2. The '@scroll-timeline' at-rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltimeline-scrolltimeline">
-   <b><a href="#dom-scrolltimeline-scrolltimeline">#dom-scrolltimeline-scrolltimeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltimeline-scrolltimeline" class="dfn-panel" data-for="dom-scrolltimeline-scrolltimeline" id="infopanel-for-dom-scrolltimeline-scrolltimeline" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltimeline-scrolltimeline" style="display:none">Info about the 'ScrollTimeline(options)' definition.</span><b><a href="#dom-scrolltimeline-scrolltimeline">#dom-scrolltimeline-scrolltimeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltimeline-scrolltimeline">3.1.2. The ScrollTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltimeline-source">
-   <b><a href="#dom-scrolltimeline-source">#dom-scrolltimeline-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltimeline-source" class="dfn-panel" data-for="dom-scrolltimeline-source" id="infopanel-for-dom-scrolltimeline-source" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltimeline-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-scrolltimeline-source">#dom-scrolltimeline-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltimeline-source">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-scrolltimeline-source①">(2)</a>
     <li><a href="#ref-for-dom-scrolltimeline-source②">3.1.3. Scroll Timeline Offset</a>
@@ -2889,8 +2889,8 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-dom-scrolltimeline-source③①">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-dom-scrolltimeline-source③②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltimeline-orientation">
-   <b><a href="#dom-scrolltimeline-orientation">#dom-scrolltimeline-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltimeline-orientation" class="dfn-panel" data-for="dom-scrolltimeline-orientation" id="infopanel-for-dom-scrolltimeline-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltimeline-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-scrolltimeline-orientation">#dom-scrolltimeline-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltimeline-orientation">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-scrolltimeline-orientation①">(2)</a> <a href="#ref-for-dom-scrolltimeline-orientation②">(3)</a>
     <li><a href="#ref-for-dom-scrolltimeline-orientation③">3.1.3. Scroll Timeline Offset</a>
@@ -2901,8 +2901,8 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-dom-scrolltimeline-orientation①④">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltimeline-scrolloffsets">
-   <b><a href="#dom-scrolltimeline-scrolloffsets">#dom-scrolltimeline-scrolloffsets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltimeline-scrolloffsets" class="dfn-panel" data-for="dom-scrolltimeline-scrolloffsets" id="infopanel-for-dom-scrolltimeline-scrolloffsets" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltimeline-scrolloffsets" style="display:none">Info about the 'scrollOffsets' definition.</span><b><a href="#dom-scrolltimeline-scrolloffsets">#dom-scrolltimeline-scrolloffsets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltimeline-scrolloffsets">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets①">(2)</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets②">(3)</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets③">(4)</a>
     <li><a href="#ref-for-dom-scrolltimeline-scrolloffsets④">3.1.5. The effective scroll offsets of a ScrollTimeline</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets⑤">(2)</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets⑥">(3)</a> <a href="#ref-for-dom-scrolltimeline-scrolloffsets⑦">(4)</a>
@@ -2910,16 +2910,16 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-dom-scrolltimeline-scrolloffsets⑨">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-scrolltimeline-timerange">
-   <b><a href="#dom-scrolltimeline-timerange">#dom-scrolltimeline-timerange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-scrolltimeline-timerange" class="dfn-panel" data-for="dom-scrolltimeline-timerange" id="infopanel-for-dom-scrolltimeline-timerange" role="dialog">
+   <span id="infopaneltitle-for-dom-scrolltimeline-timerange" style="display:none">Info about the 'timeRange' definition.</span><b><a href="#dom-scrolltimeline-timerange">#dom-scrolltimeline-timerange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-scrolltimeline-timerange">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-scrolltimeline-timerange①">(2)</a> <a href="#ref-for-dom-scrolltimeline-timerange②">(3)</a> <a href="#ref-for-dom-scrolltimeline-timerange③">(4)</a>
     <li><a href="#ref-for-dom-scrolltimeline-timerange④">3.1.4. The effective time range of a ScrollTimeline</a> <a href="#ref-for-dom-scrolltimeline-timerange⑤">(2)</a>
     <li><a href="#ref-for-dom-scrolltimeline-timerange⑥">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-scroll-offset">
-   <b><a href="#effective-scroll-offset">#effective-scroll-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-scroll-offset" class="dfn-panel" data-for="effective-scroll-offset" id="infopanel-for-effective-scroll-offset" role="dialog">
+   <span id="infopaneltitle-for-effective-scroll-offset" style="display:none">Info about the 'effective scroll offset' definition.</span><b><a href="#effective-scroll-offset">#effective-scroll-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-scroll-offset">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-effective-scroll-offset①">3.1.3. Scroll Timeline Offset</a> <a href="#ref-for-effective-scroll-offset②">(2)</a>
@@ -2928,121 +2928,121 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-effective-scroll-offset⑨">3.1.5. The effective scroll offsets of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scroll-timeline-offset">
-   <b><a href="#scroll-timeline-offset">#scroll-timeline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scroll-timeline-offset" class="dfn-panel" data-for="scroll-timeline-offset" id="infopanel-for-scroll-timeline-offset" role="dialog">
+   <span id="infopaneltitle-for-scroll-timeline-offset" style="display:none">Info about the 'scroll timeline offset' definition.</span><b><a href="#scroll-timeline-offset">#scroll-timeline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scroll-timeline-offset">3.1.2. The ScrollTimeline interface</a>
     <li><a href="#ref-for-scroll-timeline-offset①">3.1.3. Scroll Timeline Offset</a>
     <li><a href="#ref-for-scroll-timeline-offset②">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-scroll-timeline-offset③">(2)</a> <a href="#ref-for-scroll-timeline-offset④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-a-scroll-timeline-offset">
-   <b><a href="#resolve-a-scroll-timeline-offset">#resolve-a-scroll-timeline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-a-scroll-timeline-offset" class="dfn-panel" data-for="resolve-a-scroll-timeline-offset" id="infopanel-for-resolve-a-scroll-timeline-offset" role="dialog">
+   <span id="infopaneltitle-for-resolve-a-scroll-timeline-offset" style="display:none">Info about the 'resolve a scroll timeline offset' definition.</span><b><a href="#resolve-a-scroll-timeline-offset">#resolve-a-scroll-timeline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-scroll-timeline-offset">3.1.5. The effective scroll offsets of a ScrollTimeline</a> <a href="#ref-for-resolve-a-scroll-timeline-offset①">(2)</a> <a href="#ref-for-resolve-a-scroll-timeline-offset②">(3)</a> <a href="#ref-for-resolve-a-scroll-timeline-offset③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-start-offset">
-   <b><a href="#effective-start-offset">#effective-start-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-start-offset" class="dfn-panel" data-for="effective-start-offset" id="infopanel-for-effective-start-offset" role="dialog">
+   <span id="infopaneltitle-for-effective-start-offset" style="display:none">Info about the 'effective start offset' definition.</span><b><a href="#effective-start-offset">#effective-start-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-start-offset">3.1.7. The phase of a ScrollTimeline</a>
     <li><a href="#ref-for-effective-start-offset①">3.1.8. The current time of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-end-offset">
-   <b><a href="#effective-end-offset">#effective-end-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-end-offset" class="dfn-panel" data-for="effective-end-offset" id="infopanel-for-effective-end-offset" role="dialog">
+   <span id="infopaneltitle-for-effective-end-offset" style="display:none">Info about the 'effective end offset' definition.</span><b><a href="#effective-end-offset">#effective-end-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-end-offset">3.1.7. The phase of a ScrollTimeline</a> <a href="#ref-for-effective-end-offset①">(2)</a>
     <li><a href="#ref-for-effective-end-offset②">3.1.8. The current time of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="container-based-offset">
-   <b><a href="#container-based-offset">#container-based-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-container-based-offset" class="dfn-panel" data-for="container-based-offset" id="infopanel-for-container-based-offset" role="dialog">
+   <span id="infopaneltitle-for-container-based-offset" style="display:none">Info about the 'container-based offset' definition.</span><b><a href="#container-based-offset">#container-based-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-based-offset">3.1.3. Scroll Timeline Offset</a>
     <li><a href="#ref-for-container-based-offset①">3.1.3.1. Container-based Offset</a>
     <li><a href="#ref-for-container-based-offset②">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-a-container-based-offset">
-   <b><a href="#resolve-a-container-based-offset">#resolve-a-container-based-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-a-container-based-offset" class="dfn-panel" data-for="resolve-a-container-based-offset" id="infopanel-for-resolve-a-container-based-offset" role="dialog">
+   <span id="infopaneltitle-for-resolve-a-container-based-offset" style="display:none">Info about the 'resolve a container-based offset' definition.</span><b><a href="#resolve-a-container-based-offset">#resolve-a-container-based-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-container-based-offset">3.1.3. Scroll Timeline Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-based-offset">
-   <b><a href="#element-based-offset">#element-based-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-based-offset" class="dfn-panel" data-for="element-based-offset" id="infopanel-for-element-based-offset" role="dialog">
+   <span id="infopaneltitle-for-element-based-offset" style="display:none">Info about the 'element-based offset' definition.</span><b><a href="#element-based-offset">#element-based-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-based-offset">3.1.3. Scroll Timeline Offset</a>
     <li><a href="#ref-for-element-based-offset①">3.1.3.2. Element-based Offset</a>
     <li><a href="#ref-for-element-based-offset②">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-edge">
-   <b><a href="#enumdef-edge">#enumdef-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-edge" class="dfn-panel" data-for="enumdef-edge" id="infopanel-for-enumdef-edge" role="dialog">
+   <span id="infopaneltitle-for-enumdef-edge" style="display:none">Info about the 'Edge' definition.</span><b><a href="#enumdef-edge">#enumdef-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-edge">3.1.3.2. Element-based Offset</a> <a href="#ref-for-enumdef-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-edge-start">
-   <b><a href="#dom-edge-start">#dom-edge-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-edge-start" class="dfn-panel" data-for="dom-edge-start" id="infopanel-for-dom-edge-start" role="dialog">
+   <span id="infopaneltitle-for-dom-edge-start" style="display:none">Info about the '"start"' definition.</span><b><a href="#dom-edge-start">#dom-edge-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-edge-start">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-edge-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-edge-end">
-   <b><a href="#dom-edge-end">#dom-edge-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-edge-end" class="dfn-panel" data-for="dom-edge-end" id="infopanel-for-dom-edge-end" role="dialog">
+   <span id="infopaneltitle-for-dom-edge-end" style="display:none">Info about the '"end"' definition.</span><b><a href="#dom-edge-end">#dom-edge-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-edge-end">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dom-edge-end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-elementbasedoffset">
-   <b><a href="#dictdef-elementbasedoffset">#dictdef-elementbasedoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-elementbasedoffset" class="dfn-panel" data-for="dictdef-elementbasedoffset" id="infopanel-for-dictdef-elementbasedoffset" role="dialog">
+   <span id="infopaneltitle-for-dictdef-elementbasedoffset" style="display:none">Info about the 'ElementBasedOffset' definition.</span><b><a href="#dictdef-elementbasedoffset">#dictdef-elementbasedoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-elementbasedoffset">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-dictdef-elementbasedoffset①">(2)</a>
     <li><a href="#ref-for-dictdef-elementbasedoffset②">3.1.3.2. Element-based Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementbasedoffset-target">
-   <b><a href="#dom-elementbasedoffset-target">#dom-elementbasedoffset-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementbasedoffset-target" class="dfn-panel" data-for="dom-elementbasedoffset-target" id="infopanel-for-dom-elementbasedoffset-target" role="dialog">
+   <span id="infopaneltitle-for-dom-elementbasedoffset-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-elementbasedoffset-target">#dom-elementbasedoffset-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementbasedoffset-target">3.1.3.2. Element-based Offset</a> <a href="#ref-for-dom-elementbasedoffset-target①">(2)</a> <a href="#ref-for-dom-elementbasedoffset-target②">(3)</a>
     <li><a href="#ref-for-dom-elementbasedoffset-target③">3.1.8. The current time of a ScrollTimeline</a>
     <li><a href="#ref-for-dom-elementbasedoffset-target④">3.2.1. Scroll Timeline descriptors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementbasedoffset-edge">
-   <b><a href="#dom-elementbasedoffset-edge">#dom-elementbasedoffset-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementbasedoffset-edge" class="dfn-panel" data-for="dom-elementbasedoffset-edge" id="infopanel-for-dom-elementbasedoffset-edge" role="dialog">
+   <span id="infopaneltitle-for-dom-elementbasedoffset-edge" style="display:none">Info about the 'edge' definition.</span><b><a href="#dom-elementbasedoffset-edge">#dom-elementbasedoffset-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementbasedoffset-edge">3.1.3.2. Element-based Offset</a> <a href="#ref-for-dom-elementbasedoffset-edge①">(2)</a> <a href="#ref-for-dom-elementbasedoffset-edge②">(3)</a> <a href="#ref-for-dom-elementbasedoffset-edge③">(4)</a> <a href="#ref-for-dom-elementbasedoffset-edge④">(5)</a>
     <li><a href="#ref-for-dom-elementbasedoffset-edge⑤">3.2.1. Scroll Timeline descriptors</a>
     <li><a href="#ref-for-dom-elementbasedoffset-edge⑥">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementbasedoffset-threshold">
-   <b><a href="#dom-elementbasedoffset-threshold">#dom-elementbasedoffset-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementbasedoffset-threshold" class="dfn-panel" data-for="dom-elementbasedoffset-threshold" id="infopanel-for-dom-elementbasedoffset-threshold" role="dialog">
+   <span id="infopaneltitle-for-dom-elementbasedoffset-threshold" style="display:none">Info about the 'threshold' definition.</span><b><a href="#dom-elementbasedoffset-threshold">#dom-elementbasedoffset-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementbasedoffset-threshold">3.1.3.2. Element-based Offset</a> <a href="#ref-for-dom-elementbasedoffset-threshold①">(2)</a>
     <li><a href="#ref-for-dom-elementbasedoffset-threshold②">3.2.1. Scroll Timeline descriptors</a>
     <li><a href="#ref-for-dom-elementbasedoffset-threshold③">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-an-element-based-offset">
-   <b><a href="#resolve-an-element-based-offset">#resolve-an-element-based-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-an-element-based-offset" class="dfn-panel" data-for="resolve-an-element-based-offset" id="infopanel-for-resolve-an-element-based-offset" role="dialog">
+   <span id="infopaneltitle-for-resolve-an-element-based-offset" style="display:none">Info about the 'resolve an element-based offset' definition.</span><b><a href="#resolve-an-element-based-offset">#resolve-an-element-based-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-an-element-based-offset">3.1.3. Scroll Timeline Offset</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-time-range">
-   <b><a href="#effective-time-range">#effective-time-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-time-range" class="dfn-panel" data-for="effective-time-range" id="infopanel-for-effective-time-range" role="dialog">
+   <span id="infopaneltitle-for-effective-time-range" style="display:none">Info about the 'effective time range' definition.</span><b><a href="#effective-time-range">#effective-time-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-time-range">3.1.2. The ScrollTimeline interface</a> <a href="#ref-for-effective-time-range①">(2)</a>
     <li><a href="#ref-for-effective-time-range②">3.1.4. The effective time range of a ScrollTimeline</a> <a href="#ref-for-effective-time-range③">(2)</a> <a href="#ref-for-effective-time-range④">(3)</a>
     <li><a href="#ref-for-effective-time-range⑤">3.1.8. The current time of a ScrollTimeline</a> <a href="#ref-for-effective-time-range⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-scroll-offsets">
-   <b><a href="#effective-scroll-offsets">#effective-scroll-offsets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-scroll-offsets" class="dfn-panel" data-for="effective-scroll-offsets" id="infopanel-for-effective-scroll-offsets" role="dialog">
+   <span id="infopaneltitle-for-effective-scroll-offsets" style="display:none">Info about the 'effective scroll offsets' definition.</span><b><a href="#effective-scroll-offsets">#effective-scroll-offsets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-scroll-offsets">3.1.3. Scroll Timeline Offset</a> <a href="#ref-for-effective-scroll-offsets①">(2)</a>
     <li><a href="#ref-for-effective-scroll-offsets②">3.1.3.1. Container-based Offset</a>
@@ -3051,151 +3051,207 @@ instead of document’s scrolling Element for <code>auto</code>. <a href="https:
     <li><a href="#ref-for-effective-scroll-offsets⑤">3.1.8. The current time of a ScrollTimeline</a> <a href="#ref-for-effective-scroll-offsets⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-scroll-timeline-offsets">
-   <b><a href="#resolve-scroll-timeline-offsets">#resolve-scroll-timeline-offsets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-scroll-timeline-offsets" class="dfn-panel" data-for="resolve-scroll-timeline-offsets" id="infopanel-for-resolve-scroll-timeline-offsets" role="dialog">
+   <span id="infopaneltitle-for-resolve-scroll-timeline-offsets" style="display:none">Info about the 'resolve scroll timeline offsets' definition.</span><b><a href="#resolve-scroll-timeline-offsets">#resolve-scroll-timeline-offsets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-scroll-timeline-offsets">3.1.6. The progress of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calculate-scroll-timeline-progress">
-   <b><a href="#calculate-scroll-timeline-progress">#calculate-scroll-timeline-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calculate-scroll-timeline-progress" class="dfn-panel" data-for="calculate-scroll-timeline-progress" id="infopanel-for-calculate-scroll-timeline-progress" role="dialog">
+   <span id="infopaneltitle-for-calculate-scroll-timeline-progress" style="display:none">Info about the 'calculate scroll timeline progress' definition.</span><b><a href="#calculate-scroll-timeline-progress">#calculate-scroll-timeline-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calculate-scroll-timeline-progress">3.1.8. The current time of a ScrollTimeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-scroll-timeline">
-   <b><a href="#at-ruledef-scroll-timeline">#at-ruledef-scroll-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-scroll-timeline" class="dfn-panel" data-for="at-ruledef-scroll-timeline" id="infopanel-for-at-ruledef-scroll-timeline" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-scroll-timeline" style="display:none">Info about the '@scroll-timeline' definition.</span><b><a href="#at-ruledef-scroll-timeline">#at-ruledef-scroll-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-scroll-timeline">3.2. The '@scroll-timeline' at-rule</a> <a href="#ref-for-at-ruledef-scroll-timeline①">(2)</a> <a href="#ref-for-at-ruledef-scroll-timeline②">(3)</a>
     <li><a href="#ref-for-at-ruledef-scroll-timeline③">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-at-ruledef-scroll-timeline④">(2)</a> <a href="#ref-for-at-ruledef-scroll-timeline⑤">(3)</a> <a href="#ref-for-at-ruledef-scroll-timeline⑥">(4)</a>
     <li><a href="#ref-for-at-ruledef-scroll-timeline⑦">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-at-ruledef-scroll-timeline⑧">(2)</a> <a href="#ref-for-at-ruledef-scroll-timeline⑨">(3)</a> <a href="#ref-for-at-ruledef-scroll-timeline①⓪">(4)</a> <a href="#ref-for-at-ruledef-scroll-timeline①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-scroll-timeline-offset">
-   <b><a href="#typedef-scroll-timeline-offset">#typedef-scroll-timeline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-scroll-timeline-offset" class="dfn-panel" data-for="typedef-scroll-timeline-offset" id="infopanel-for-typedef-scroll-timeline-offset" role="dialog">
+   <span id="infopaneltitle-for-typedef-scroll-timeline-offset" style="display:none">Info about the '&lt;scroll-timeline-offset>' definition.</span><b><a href="#typedef-scroll-timeline-offset">#typedef-scroll-timeline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-scroll-timeline-offset">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-typedef-scroll-timeline-offset①">(2)</a> <a href="#ref-for-typedef-scroll-timeline-offset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-element-offset">
-   <b><a href="#typedef-element-offset">#typedef-element-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-element-offset" class="dfn-panel" data-for="typedef-element-offset" id="infopanel-for-typedef-element-offset" role="dialog">
+   <span id="infopaneltitle-for-typedef-element-offset" style="display:none">Info about the '&lt;element-offset>' definition.</span><b><a href="#typedef-element-offset">#typedef-element-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-element-offset">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-typedef-element-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-element-offset-edge">
-   <b><a href="#typedef-element-offset-edge">#typedef-element-offset-edge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-element-offset-edge" class="dfn-panel" data-for="typedef-element-offset-edge" id="infopanel-for-typedef-element-offset-edge" role="dialog">
+   <span id="infopaneltitle-for-typedef-element-offset-edge" style="display:none">Info about the '&lt;element-offset-edge>' definition.</span><b><a href="#typedef-element-offset-edge">#typedef-element-offset-edge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-element-offset-edge">3.2.1. Scroll Timeline descriptors</a> <a href="#ref-for-typedef-element-offset-edge①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cssscrolltimelinerule">
-   <b><a href="#cssscrolltimelinerule">#cssscrolltimelinerule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cssscrolltimelinerule" class="dfn-panel" data-for="cssscrolltimelinerule" id="infopanel-for-cssscrolltimelinerule" role="dialog">
+   <span id="infopaneltitle-for-cssscrolltimelinerule" style="display:none">Info about the 'CSSScrollTimelineRule' definition.</span><b><a href="#cssscrolltimelinerule">#cssscrolltimelinerule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssscrolltimelinerule">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscrolltimelinerule-name">
-   <b><a href="#dom-cssscrolltimelinerule-name">#dom-cssscrolltimelinerule-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscrolltimelinerule-name" class="dfn-panel" data-for="dom-cssscrolltimelinerule-name" id="infopanel-for-dom-cssscrolltimelinerule-name" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscrolltimelinerule-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-cssscrolltimelinerule-name">#dom-cssscrolltimelinerule-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscrolltimelinerule-name">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-dom-cssscrolltimelinerule-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscrolltimelinerule-source">
-   <b><a href="#dom-cssscrolltimelinerule-source">#dom-cssscrolltimelinerule-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscrolltimelinerule-source" class="dfn-panel" data-for="dom-cssscrolltimelinerule-source" id="infopanel-for-dom-cssscrolltimelinerule-source" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscrolltimelinerule-source" style="display:none">Info about the 'source' definition.</span><b><a href="#dom-cssscrolltimelinerule-source">#dom-cssscrolltimelinerule-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscrolltimelinerule-source">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscrolltimelinerule-orientation">
-   <b><a href="#dom-cssscrolltimelinerule-orientation">#dom-cssscrolltimelinerule-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscrolltimelinerule-orientation" class="dfn-panel" data-for="dom-cssscrolltimelinerule-orientation" id="infopanel-for-dom-cssscrolltimelinerule-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscrolltimelinerule-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-cssscrolltimelinerule-orientation">#dom-cssscrolltimelinerule-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscrolltimelinerule-orientation">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscrolltimelinerule-scrolloffsets">
-   <b><a href="#dom-cssscrolltimelinerule-scrolloffsets">#dom-cssscrolltimelinerule-scrolloffsets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscrolltimelinerule-scrolloffsets" class="dfn-panel" data-for="dom-cssscrolltimelinerule-scrolloffsets" id="infopanel-for-dom-cssscrolltimelinerule-scrolloffsets" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscrolltimelinerule-scrolloffsets" style="display:none">Info about the 'scrollOffsets' definition.</span><b><a href="#dom-cssscrolltimelinerule-scrolloffsets">#dom-cssscrolltimelinerule-scrolloffsets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscrolltimelinerule-scrolloffsets">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cssscrolltimelinerule-timerange">
-   <b><a href="#dom-cssscrolltimelinerule-timerange">#dom-cssscrolltimelinerule-timerange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cssscrolltimelinerule-timerange" class="dfn-panel" data-for="dom-cssscrolltimelinerule-timerange" id="infopanel-for-dom-cssscrolltimelinerule-timerange" role="dialog">
+   <span id="infopaneltitle-for-dom-cssscrolltimelinerule-timerange" style="display:none">Info about the 'timeRange' definition.</span><b><a href="#dom-cssscrolltimelinerule-timerange">#dom-cssscrolltimelinerule-timerange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cssscrolltimelinerule-timerange">3.2.2. The CSSScrollTimelineRule Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-scroll-timeline-offset">
-   <b><a href="#serialize-a-scroll-timeline-offset">#serialize-a-scroll-timeline-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-scroll-timeline-offset" class="dfn-panel" data-for="serialize-a-scroll-timeline-offset" id="infopanel-for-serialize-a-scroll-timeline-offset" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-scroll-timeline-offset" style="display:none">Info about the 'serialize a scroll timeline offset' definition.</span><b><a href="#serialize-a-scroll-timeline-offset">#serialize-a-scroll-timeline-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-scroll-timeline-offset">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-serialize-a-scroll-timeline-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-selector-function">
-   <b><a href="#serialize-a-selector-function">#serialize-a-selector-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-selector-function" class="dfn-panel" data-for="serialize-a-selector-function" id="infopanel-for-serialize-a-selector-function" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-selector-function" style="display:none">Info about the 'serialize a selector() function' definition.</span><b><a href="#serialize-a-selector-function">#serialize-a-selector-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-selector-function">3.2.2. The CSSScrollTimelineRule Interface</a> <a href="#ref-for-serialize-a-selector-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="layout-cycles">
-   <b><a href="#layout-cycles">#layout-cycles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-layout-cycles" class="dfn-panel" data-for="layout-cycles" id="infopanel-for-layout-cycles" role="dialog">
+   <span id="infopaneltitle-for-layout-cycles" style="display:none">Info about the 'layout cycles' definition.</span><b><a href="#layout-cycles">#layout-cycles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-layout-cycles">4. Avoiding cycles with layout</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/selectors-4/Overview.html
+++ b/tests/github/w3c/csswg-drafts/selectors-4/Overview.html
@@ -5301,36 +5301,36 @@ as selectors do not provide any ability not already possible by walking the DOM 
    <li><a href="#whitespace">White space</a><span>, in § 3.7</span>
    <li><a href="#typedef-wq-name">&lt;wq-name></a><span>, in § 17</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-valdef-lab-a">
-   <a href="https://drafts.csswg.org/css-color-5/#valdef-lab-a">https://drafts.csswg.org/css-color-5/#valdef-lab-a</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-lab-a" class="dfn-panel" data-for="term-for-valdef-lab-a" id="infopanel-for-term-for-valdef-lab-a" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-lab-a" style="display:none">Info about the 'a' external reference.</span><a href="https://drafts.csswg.org/css-color-5/#valdef-lab-a">https://drafts.csswg.org/css-color-5/#valdef-lab-a</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-lab-a">3.6.2. 
 Binding to the Document Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box-tree">
-   <a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box-tree" class="dfn-panel" data-for="term-for-box-tree" id="infopanel-for-term-for-box-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-box-tree" style="display:none">Info about the 'box tree' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box-tree">https://drafts.csswg.org/css-display-3/#box-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box-tree">3.6.4. 
 Internal Structure</a> <a href="#ref-for-box-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">12.1.1. 
 The :enabled and :disabled Pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">12.1.1. 
 The :enabled and :disabled Pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-after">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-after" class="dfn-panel" data-for="term-for-selectordef-after" id="infopanel-for-term-for-selectordef-after" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-after">https://drafts.csswg.org/css-pseudo-4/#selectordef-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-after">3.6. Pseudo-elements</a>
     <li><a href="#ref-for-selectordef-after①">3.6.1. 
@@ -5341,8 +5341,8 @@ Grammar</a>
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-before">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-before" class="dfn-panel" data-for="term-for-selectordef-before" id="infopanel-for-term-for-selectordef-before" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-before">https://drafts.csswg.org/css-pseudo-4/#selectordef-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-before">3.6. Pseudo-elements</a>
     <li><a href="#ref-for-selectordef-before①">3.6.1. 
@@ -5355,8 +5355,8 @@ Grammar</a>
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-letter">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-letter" class="dfn-panel" data-for="term-for-selectordef-first-letter" id="infopanel-for-term-for-selectordef-first-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-letter" style="display:none">Info about the '::first-letter' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-letter">3.6. Pseudo-elements</a>
     <li><a href="#ref-for-selectordef-first-letter①">3.6.1. 
@@ -5365,8 +5365,8 @@ Syntax</a>
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-first-line">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-first-line" class="dfn-panel" data-for="term-for-selectordef-first-line" id="infopanel-for-term-for-selectordef-first-line" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-first-line" style="display:none">Info about the '::first-line' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line">https://drafts.csswg.org/css-pseudo-4/#selectordef-first-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-first-line">3.2. 
 Data Model</a> <a href="#ref-for-selectordef-first-line①">(2)</a>
@@ -5381,50 +5381,50 @@ Pseudo-classing Pseudo-elements</a> <a href="#ref-for-selectordef-first-line⑧"
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tree-abiding">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tree-abiding" class="dfn-panel" data-for="term-for-tree-abiding" id="infopanel-for-term-for-tree-abiding" role="menu">
+   <span id="infopaneltitle-for-term-for-tree-abiding" style="display:none">Info about the 'tree-abiding pseudo-element' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#tree-abiding">https://drafts.csswg.org/css-pseudo-4/#tree-abiding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-abiding">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-content">
-   <a href="https://www.w3.org/TR/css-scoping-1/#selectordef-content">https://www.w3.org/TR/css-scoping-1/#selectordef-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-content" class="dfn-panel" data-for="term-for-selectordef-content" id="infopanel-for-term-for-selectordef-content" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-content" style="display:none">Info about the '::content' external reference.</span><a href="https://www.w3.org/TR/css-scoping-1/#selectordef-content">https://www.w3.org/TR/css-scoping-1/#selectordef-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-content">3.6.4. 
 Internal Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-shadow">
-   <a href="https://www.w3.org/TR/css-scoping-1/#selectordef-shadow">https://www.w3.org/TR/css-scoping-1/#selectordef-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-shadow" class="dfn-panel" data-for="term-for-selectordef-shadow" id="infopanel-for-term-for-selectordef-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-shadow" style="display:none">Info about the '::shadow' external reference.</span><a href="https://www.w3.org/TR/css-scoping-1/#selectordef-shadow">https://www.w3.org/TR/css-scoping-1/#selectordef-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-shadow">3.6.4. 
 Internal Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-slotted">
-   <a href="https://drafts.csswg.org/css-scoping-1/#selectordef-slotted">https://drafts.csswg.org/css-scoping-1/#selectordef-slotted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-slotted" class="dfn-panel" data-for="term-for-selectordef-slotted" id="infopanel-for-term-for-selectordef-slotted" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-slotted" style="display:none">Info about the '::slotted()' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#selectordef-slotted">https://drafts.csswg.org/css-scoping-1/#selectordef-slotted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-slotted">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-host">
-   <a href="https://drafts.csswg.org/css-scoping-1/#selectordef-host">https://drafts.csswg.org/css-scoping-1/#selectordef-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-host" class="dfn-panel" data-for="term-for-selectordef-host" id="infopanel-for-term-for-selectordef-host" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-host" style="display:none">Info about the ':host' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#selectordef-host">https://drafts.csswg.org/css-scoping-1/#selectordef-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-host">3.2. 
 Data Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-host-context">
-   <a href="https://drafts.csswg.org/css-scoping-1/#selectordef-host-context">https://drafts.csswg.org/css-scoping-1/#selectordef-host-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-host-context" class="dfn-panel" data-for="term-for-selectordef-host-context" id="infopanel-for-term-for-selectordef-host-context" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-host-context" style="display:none">Info about the ':host-context()' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#selectordef-host-context">https://drafts.csswg.org/css-scoping-1/#selectordef-host-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-host-context">3.2. 
 Data Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-flat-tree">
-   <a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flat-tree" class="dfn-panel" data-for="term-for-flat-tree" id="infopanel-for-term-for-flat-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-flat-tree" style="display:none">Info about the 'flat tree' external reference.</span><a href="https://drafts.csswg.org/css-scoping-1/#flat-tree">https://drafts.csswg.org/css-scoping-1/#flat-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flat-tree">8.5. 
 The Target Container Pseudo-class: :target-within</a>
@@ -5436,78 +5436,78 @@ The Activation Pseudo-class: :active</a>
 The Focus Container Pseudo-class: :focus-within</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-language">
-   <a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-language" class="dfn-panel" data-for="term-for-content-language" id="infopanel-for-term-for-content-language" role="menu">
+   <span id="infopaneltitle-for-term-for-content-language" style="display:none">Info about the 'content language' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#content-language">https://drafts.csswg.org/css-text-4/#content-language</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-language">7.2. 
 The Language Pseudo-class: :lang()</a> <a href="#ref-for-content-language①">(2)</a> <a href="#ref-for-content-language②">(3)</a> <a href="#ref-for-content-language③">(4)</a> <a href="#ref-for-content-language④">(5)</a> <a href="#ref-for-content-language⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'document white space characters' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">13.2. 
 :empty pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">17. 
 Grammar</a> <a href="#ref-for-mult-comma①">(2)</a> <a href="#ref-for-mult-comma②">(3)</a> <a href="#ref-for-mult-comma③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">17. 
 Grammar</a> <a href="#ref-for-mult-zero-plus①">(2)</a> <a href="#ref-for-mult-zero-plus②">(3)</a> <a href="#ref-for-mult-zero-plus③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-ident">https://drafts.csswg.org/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">7.2. 
 The Language Pseudo-class: :lang()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">7.2. 
 The Language Pseudo-class: :lang()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">17. 
 Grammar</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a> <a href="#ref-for-mult-opt③">(4)</a> <a href="#ref-for-mult-opt④">(5)</a> <a href="#ref-for-mult-opt⑤">(6)</a> <a href="#ref-for-mult-opt⑥">(7)</a> <a href="#ref-for-mult-opt⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">17. 
 Grammar</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a> <a href="#ref-for-comb-one①⑤">(16)</a> <a href="#ref-for-comb-one①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">7.1. 
 The Directionality Pseudo-class: :dir()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-qualified-name">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#css-qualified-name">https://drafts.csswg.org/css-namespaces-3/#css-qualified-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-qualified-name" class="dfn-panel" data-for="term-for-css-qualified-name" id="infopanel-for-term-for-css-qualified-name" role="menu">
+   <span id="infopaneltitle-for-term-for-css-qualified-name" style="display:none">Info about the 'css qualified name' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#css-qualified-name">https://drafts.csswg.org/css-namespaces-3/#css-qualified-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-qualified-name">5.1. 
 Type (tag name) selector</a>
@@ -5517,15 +5517,15 @@ Universal selector </a>
 Attribute selectors and namespaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-namespace">
-   <a href="https://drafts.csswg.org/css-namespaces-3/#default-namespace">https://drafts.csswg.org/css-namespaces-3/#default-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-namespace" class="dfn-panel" data-for="term-for-default-namespace" id="infopanel-for-term-for-default-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-default-namespace" style="display:none">Info about the 'default namespace' external reference.</span><a href="https://drafts.csswg.org/css-namespaces-3/#default-namespace">https://drafts.csswg.org/css-namespaces-3/#default-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-namespace">5.3. 
 Namespaces in Elemental Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anb-production">
-   <a href="https://drafts.csswg.org/css-syntax-3/#anb-production">https://drafts.csswg.org/css-syntax-3/#anb-production</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anb-production" class="dfn-panel" data-for="term-for-anb-production" id="infopanel-for-term-for-anb-production" role="menu">
+   <span id="infopaneltitle-for-term-for-anb-production" style="display:none">Info about the '&lt;an+b>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#anb-production">https://drafts.csswg.org/css-syntax-3/#anb-production</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anb-production">19.3. 
 Changes since the 2 May 2013 Working Draft</a>
@@ -5533,8 +5533,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes since the 23 August 2012 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-any-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-any-value" class="dfn-panel" data-for="term-for-typedef-any-value" id="infopanel-for-term-for-typedef-any-value" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-any-value" style="display:none">Info about the '&lt;any-value>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-any-value">17. 
 Grammar</a>
@@ -5542,22 +5542,22 @@ Grammar</a>
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-function-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-function-token" class="dfn-panel" data-for="term-for-typedef-function-token" id="infopanel-for-term-for-typedef-function-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-function-token" style="display:none">Info about the '&lt;function-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-function-token">https://drafts.csswg.org/css-syntax-3/#typedef-function-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-function-token">17. 
 Grammar</a> <a href="#ref-for-typedef-function-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-hash-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-hash-token" class="dfn-panel" data-for="term-for-typedef-hash-token" id="infopanel-for-term-for-typedef-hash-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-hash-token" style="display:none">Info about the '&lt;hash-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-hash-token">https://drafts.csswg.org/css-syntax-3/#typedef-hash-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-hash-token">17. 
 Grammar</a> <a href="#ref-for-typedef-hash-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">6.1. 
 Attribute presence and value selectors</a>
@@ -5567,8 +5567,8 @@ Substring matching attribute selectors</a>
 Grammar</a> <a href="#ref-for-typedef-ident-token③">(2)</a> <a href="#ref-for-typedef-ident-token④">(3)</a> <a href="#ref-for-typedef-ident-token⑤">(4)</a> <a href="#ref-for-typedef-ident-token⑥">(5)</a> <a href="#ref-for-typedef-ident-token⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-string-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-string-token" class="dfn-panel" data-for="term-for-typedef-string-token" id="infopanel-for-term-for-typedef-string-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-string-token" style="display:none">Info about the '&lt;string-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-string-token">https://drafts.csswg.org/css-syntax-3/#typedef-string-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-string-token">6.1. 
 Attribute presence and value selectors</a>
@@ -5578,8 +5578,8 @@ Substring matching attribute selectors</a>
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">17. 
 Grammar</a>
@@ -5589,36 +5589,36 @@ Parse A Selector</a>
 Parse A Relative Selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-a-comma-separated-list-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-a-comma-separated-list-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-a-comma-separated-list-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-a-comma-separated-list-according-to-a-css-grammar" style="display:none">Info about the 'parse a list' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-a-comma-separated-list-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-a-comma-separated-list-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-a-comma-separated-list-according-to-a-css-grammar">17.1. 
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">13.1. 
 :root pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentfragment">
-   <a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentfragment" class="dfn-panel" data-for="term-for-documentfragment" id="infopanel-for-term-for-documentfragment" role="menu">
+   <span id="infopaneltitle-for-term-for-documentfragment" style="display:none">Info about the 'DocumentFragment' external reference.</span><a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentfragment">3.3. 
 Scoped Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">18.5. 
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-inclusive-sibling">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-sibling">https://dom.spec.whatwg.org/#concept-tree-inclusive-sibling</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-inclusive-sibling" class="dfn-panel" data-for="term-for-concept-tree-inclusive-sibling" id="infopanel-for-term-for-concept-tree-inclusive-sibling" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-inclusive-sibling" style="display:none">Info about the 'inclusive sibling' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-sibling">https://dom.spec.whatwg.org/#concept-tree-inclusive-sibling</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-inclusive-sibling">13.3. 
 Child-indexed Pseudo-classes</a>
@@ -5632,8 +5632,8 @@ Child-indexed Pseudo-classes</a>
 :last-child pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">6.6. 
 Class selectors</a>
@@ -5641,43 +5641,43 @@ Class selectors</a>
 ID selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">18.5. 
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-shadow-host">
-   <a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-shadow-host" class="dfn-panel" data-for="term-for-element-shadow-host" id="infopanel-for-term-for-element-shadow-host" role="menu">
+   <span id="infopaneltitle-for-term-for-element-shadow-host" style="display:none">Info about the 'shadow host' external reference.</span><a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-shadow-host">3.2. 
 Data Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-tree" class="dfn-panel" data-for="term-for-concept-shadow-tree" id="infopanel-for-term-for-concept-shadow-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-tree">https://dom.spec.whatwg.org/#concept-shadow-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">3.2. 
 Data Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">18.5. 
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree" class="dfn-panel" data-for="term-for-concept-tree" id="infopanel-for-term-for-concept-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree" style="display:none">Info about the 'tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree">18.5. 
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">3.3. 
 Scoped Selectors</a> <a href="#ref-for-the-a-element①">(2)</a>
@@ -5691,29 +5691,29 @@ The Hyperlink Pseudo-class: :any-link</a>
 User Action Pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-area-element">
-   <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-area-element" class="dfn-panel" data-for="term-for-the-area-element" id="infopanel-for-term-for-the-area-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-area-element" style="display:none">Info about the 'area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-area-element">8.1. 
 The Hyperlink Pseudo-class: :any-link</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-button-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-button-element" class="dfn-panel" data-for="term-for-the-button-element" id="infopanel-for-term-for-the-button-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-button-element" style="display:none">Info about the 'button' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-button-element">4.3. 
 The Negation (Matches-None) Pseudo-class: :not()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">5.4. 
 The Defined Pseudo-class: :defined</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-div-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-div-element" class="dfn-panel" data-for="term-for-the-div-element" id="infopanel-for-term-for-the-div-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-div-element" style="display:none">Info about the 'div' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-div-element">6.6. 
 Class selectors</a>
@@ -5723,22 +5723,22 @@ Class selectors</a>
 Descendant combinator ( )</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-definition">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-definition" class="dfn-panel" data-for="term-for-element-definition" id="infopanel-for-term-for-element-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-element-definition" style="display:none">Info about the 'element definition' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#element-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-definition">5.4. 
 The Defined Pseudo-class: :defined</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-em-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-em-element" class="dfn-panel" data-for="term-for-the-em-element" id="infopanel-for-term-for-the-em-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-em-element" style="display:none">Info about the 'em' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-em-element">14.1. 
 Descendant combinator ( )</a> <a href="#ref-for-the-em-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-h1-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element">https://html.spec.whatwg.org/multipage/sections.html#the-h1-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-h1-element" class="dfn-panel" data-for="term-for-the-h1-element" id="infopanel-for-term-for-the-h1-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-h1-element" style="display:none">Info about the 'h1' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-h1-element">https://html.spec.whatwg.org/multipage/sections.html#the-h1-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-h1-element">5.1. 
 Type (tag name) selector</a>
@@ -5754,15 +5754,15 @@ Descendant combinator ( )</a> <a href="#ref-for-the-h1-element⑦">(2)</a>
 Next-sibling combinator (+)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-html-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-html-element" class="dfn-panel" data-for="term-for-the-html-element" id="infopanel-for-term-for-the-html-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-html-element" style="display:none">Info about the 'html' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-html-element">13.1. 
 :root pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">13.4.1. 
 :nth-of-type() pseudo-class</a>
@@ -5770,8 +5770,8 @@ Next-sibling combinator (+)</a>
 :nth-last-of-type() pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">9.4. 
 The Focus-Indicated Pseudo-class: :focus-visible</a>
@@ -5784,8 +5784,8 @@ The Empty-Value Pseudo-class: :blank</a>
     <li><a href="#ref-for-the-input-element④"> Appendix B: Obsolete but Required Parsing Quirks for Web Compat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-label-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-label-element">https://html.spec.whatwg.org/multipage/forms.html#the-label-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-label-element" class="dfn-panel" data-for="term-for-the-label-element" id="infopanel-for-term-for-the-label-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-label-element" style="display:none">Info about the 'label' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-label-element">https://html.spec.whatwg.org/multipage/forms.html#the-label-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-label-element">9.1. 
 The Pointer Hover Pseudo-class: :hover</a>
@@ -5793,29 +5793,29 @@ The Pointer Hover Pseudo-class: :hover</a>
 The Input Focus Pseudo-class: :focus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-li-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-li-element" class="dfn-panel" data-for="term-for-the-li-element" id="infopanel-for-term-for-the-li-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-li-element" style="display:none">Info about the 'li' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-li-element">14.2. 
 Child combinator (>)</a> <a href="#ref-for-the-li-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-meta" class="dfn-panel" data-for="term-for-meta" id="infopanel-for-term-for-meta" role="menu">
+   <span id="infopaneltitle-for-term-for-meta" style="display:none">Info about the 'meta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">7.2. 
 The Language Pseudo-class: :lang()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">6.2. 
 Substring matching attribute selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ol-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ol-element" class="dfn-panel" data-for="term-for-the-ol-element" id="infopanel-for-term-for-the-ol-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ol-element" style="display:none">Info about the 'ol' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ol-element">4.2. 
 The Matches-Any Pseudo-class: :is()</a>
@@ -5823,15 +5823,15 @@ The Matches-Any Pseudo-class: :is()</a>
 Child combinator (>)</a> <a href="#ref-for-the-ol-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-option-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-option-element" class="dfn-panel" data-for="term-for-the-option-element" id="infopanel-for-term-for-the-option-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-option-element" style="display:none">Info about the 'option' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-option-element">12.1.3. 
 The Placeholder-shown Pseudo-class: :placeholder-shown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-p-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-p-element" class="dfn-panel" data-for="term-for-the-p-element" id="infopanel-for-term-for-the-p-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-p-element" style="display:none">Info about the 'p' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-p-element">6.6. 
 Class selectors</a>
@@ -5851,36 +5851,36 @@ Child combinator (>)</a> <a href="#ref-for-the-p-element⑦">(2)</a>
 Next-sibling combinator (+)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-placeholder">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder">https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-placeholder" class="dfn-panel" data-for="term-for-attr-input-placeholder" id="infopanel-for-term-for-attr-input-placeholder" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-placeholder" style="display:none">Info about the 'placeholder' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder">https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-placeholder">12.1.3. 
 The Placeholder-shown Pseudo-class: :placeholder-shown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-pre-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-pre-element" class="dfn-panel" data-for="term-for-the-pre-element" id="infopanel-for-term-for-the-pre-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-pre-element" style="display:none">Info about the 'pre' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-pre-element">14.4. 
 Subsequent-sibling combinator (~)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-q-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-q-element" class="dfn-panel" data-for="term-for-the-q-element" id="infopanel-for-term-for-the-q-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-q-element" style="display:none">Info about the 'q' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-q-element">7.2. 
 The Language Pseudo-class: :lang()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-select-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-select-element" class="dfn-panel" data-for="term-for-the-select-element" id="infopanel-for-term-for-the-select-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-select-element" style="display:none">Info about the 'select' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-select-element">12.1.3. 
 The Placeholder-shown Pseudo-class: :placeholder-shown</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-span-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-span-element" class="dfn-panel" data-for="term-for-the-span-element" id="infopanel-for-term-for-the-span-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-span-element" style="display:none">Info about the 'span' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-span-element">6.1. 
 Attribute presence and value selectors</a> <a href="#ref-for-the-span-element①">(2)</a>
@@ -5888,22 +5888,22 @@ Attribute presence and value selectors</a> <a href="#ref-for-the-span-element①
 Class selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-textarea-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-textarea-element" class="dfn-panel" data-for="term-for-the-textarea-element" id="infopanel-for-term-for-the-textarea-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-textarea-element" style="display:none">Info about the 'textarea' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-textarea-element">12.3.1. 
 The Empty-Value Pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-value">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-value">https://html.spec.whatwg.org/multipage/input.html#attr-input-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-value" class="dfn-panel" data-for="term-for-attr-input-value" id="infopanel-for-term-for-attr-input-value" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-value" style="display:none">Info about the 'value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-value">https://html.spec.whatwg.org/multipage/input.html#attr-input-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-value">12.3.1. 
 The Empty-Value Pseudo-class: :blank</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.5. 
 Pseudo-classes</a>
@@ -5922,8 +5922,8 @@ The Language Pseudo-class: :lang()</a>
     <li><a href="#ref-for-ascii-case-insensitive⑨"> Appendix B: Obsolete but Required Parsing Quirks for Web Compat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'identical to' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">2. 
 Selectors Overview</a>
@@ -5935,22 +5935,22 @@ Class selectors</a>
 ID selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-math">
-   <a href="https://w3c.github.io/mathml-core/#dfn-math">https://w3c.github.io/mathml-core/#dfn-math</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-math" class="dfn-panel" data-for="term-for-dfn-math" id="infopanel-for-term-for-dfn-math" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-math" style="display:none">Info about the 'math' external reference.</span><a href="https://w3c.github.io/mathml-core/#dfn-math">https://w3c.github.io/mathml-core/#dfn-math</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-math">14.3. 
 Next-sibling combinator (+)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-x">
-   <a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-x" class="dfn-panel" data-for="term-for-x" id="infopanel-for-term-for-x" role="menu">
+   <span id="infopaneltitle-for-term-for-x" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#x">https://drafts.csswg.org/selectors-3/#x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x">3.6.2. 
 Binding to the Document Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">8.4. 
 The Target Pseudo-class: :target</a>
@@ -6195,8 +6195,8 @@ The Target Pseudo-class: :target</a>
    <div class="issue"> Semantic definition should probably move back here. <a class="issue-return" href="#issue-fb60ae39" title="Jump to section">↵</a></div>
    <div class="issue"> Need to define tree for XML. <a class="issue-return" href="#issue-4ca3978c" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="selector">
-   <b><a href="#selector">#selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selector" class="dfn-panel" data-for="selector" id="infopanel-for-selector" role="dialog">
+   <span id="infopaneltitle-for-selector" style="display:none">Info about the 'selector' definition.</span><b><a href="#selector">#selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector①">1. 
 Introduction</a>
@@ -6204,8 +6204,8 @@ Introduction</a>
 Structure and Terminology</a> <a href="#ref-for-selector③">(2)</a> <a href="#ref-for-selector④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match">
-   <b><a href="#match">#match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match" class="dfn-panel" data-for="match" id="infopanel-for-match" role="dialog">
+   <span id="infopaneltitle-for-match" style="display:none">Info about the 'matching' definition.</span><b><a href="#match">#match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match">3.1. 
 Structure and Terminology</a> <a href="#ref-for-match①">(2)</a> <a href="#ref-for-match②">(3)</a> <a href="#ref-for-match③">(4)</a> <a href="#ref-for-match④">(5)</a>
@@ -6213,8 +6213,8 @@ Structure and Terminology</a> <a href="#ref-for-match①">(2)</a> <a href="#ref-
 API Hooks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple">
-   <b><a href="#simple">#simple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple" class="dfn-panel" data-for="simple" id="infopanel-for-simple" role="dialog">
+   <span id="infopaneltitle-for-simple" style="display:none">Info about the 'simple selector' definition.</span><b><a href="#simple">#simple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple">3.1. 
 Structure and Terminology</a> <a href="#ref-for-simple①">(2)</a> <a href="#ref-for-simple②">(3)</a> <a href="#ref-for-simple③">(4)</a> <a href="#ref-for-simple④">(5)</a> <a href="#ref-for-simple⑤">(6)</a> <a href="#ref-for-simple⑥">(7)</a> <a href="#ref-for-simple⑦">(8)</a> <a href="#ref-for-simple⑧">(9)</a>
@@ -6228,8 +6228,8 @@ Universal selector </a>
 Match a Selector Against a Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compound">
-   <b><a href="#compound">#compound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compound" class="dfn-panel" data-for="compound" id="infopanel-for-compound" role="dialog">
+   <span id="infopaneltitle-for-compound" style="display:none">Info about the 'compound selector' definition.</span><b><a href="#compound">#compound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">2. 
 Selectors Overview</a> <a href="#ref-for-compound①">(2)</a> <a href="#ref-for-compound②">(3)</a> <a href="#ref-for-compound③">(4)</a> <a href="#ref-for-compound④">(5)</a> <a href="#ref-for-compound⑤">(6)</a>
@@ -6265,8 +6265,8 @@ Subsequent-sibling combinator (~)</a> <a href="#ref-for-compound③⑦">(2)</a>
 Match a Selector Against an Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selector-combinator">
-   <b><a href="#selector-combinator">#selector-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selector-combinator" class="dfn-panel" data-for="selector-combinator" id="infopanel-for-selector-combinator" role="dialog">
+   <span id="infopaneltitle-for-selector-combinator" style="display:none">Info about the 'combinator' definition.</span><b><a href="#selector-combinator">#selector-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector-combinator">3.1. 
 Structure and Terminology</a> <a href="#ref-for-selector-combinator①">(2)</a> <a href="#ref-for-selector-combinator②">(3)</a> <a href="#ref-for-selector-combinator③">(4)</a> <a href="#ref-for-selector-combinator④">(5)</a> <a href="#ref-for-selector-combinator⑤">(6)</a>
@@ -6280,8 +6280,8 @@ Internal Structure</a>
 Match a Selector Against an Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complex">
-   <b><a href="#complex">#complex</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complex" class="dfn-panel" data-for="complex" id="infopanel-for-complex" role="dialog">
+   <span id="infopaneltitle-for-complex" style="display:none">Info about the 'complex selector' definition.</span><b><a href="#complex">#complex</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complex">3.1. 
 Structure and Terminology</a> <a href="#ref-for-complex①">(2)</a> <a href="#ref-for-complex②">(3)</a> <a href="#ref-for-complex③">(4)</a> <a href="#ref-for-complex④">(5)</a>
@@ -6297,8 +6297,8 @@ Match a Selector Against an Element</a>
 Match a Selector Against a Pseudo-element</a> <a href="#ref-for-complex①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-simple-selectors">
-   <b><a href="#list-of-simple-selectors">#list-of-simple-selectors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-simple-selectors" class="dfn-panel" data-for="list-of-simple-selectors" id="infopanel-for-list-of-simple-selectors" role="dialog">
+   <span id="infopaneltitle-for-list-of-simple-selectors" style="display:none">Info about the 'list of simple/compound/complex selectors' definition.</span><b><a href="#list-of-simple-selectors">#list-of-simple-selectors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-simple-selectors">3.1. 
 Structure and Terminology</a>
@@ -6306,8 +6306,8 @@ Structure and Terminology</a>
 Match a Selector Against an Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selector-list">
-   <b><a href="#selector-list">#selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selector-list" class="dfn-panel" data-for="selector-list" id="infopanel-for-selector-list" role="dialog">
+   <span id="infopaneltitle-for-selector-list" style="display:none">Info about the 'selector list' definition.</span><b><a href="#selector-list">#selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selector-list">3.1. 
 Structure and Terminology</a> <a href="#ref-for-selector-list①">(2)</a> <a href="#ref-for-selector-list②">(3)</a> <a href="#ref-for-selector-list③">(4)</a>
@@ -6325,8 +6325,8 @@ Calculating a selector’s specificity</a> <a href="#ref-for-selector-list①⓪
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="featureless">
-   <b><a href="#featureless">#featureless</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-featureless" class="dfn-panel" data-for="featureless" id="infopanel-for-featureless" role="dialog">
+   <span id="infopaneltitle-for-featureless" style="display:none">Info about the 'featureless' definition.</span><b><a href="#featureless">#featureless</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-featureless">3.2. 
 Data Model</a> <a href="#ref-for-featureless①">(2)</a> <a href="#ref-for-featureless②">(3)</a>
@@ -6336,8 +6336,8 @@ Syntax</a>
 Universal selector </a> <a href="#ref-for-featureless⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-language">
-   <b><a href="#document-language">#document-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-language" class="dfn-panel" data-for="document-language" id="infopanel-for-document-language" role="dialog">
+   <span id="infopaneltitle-for-document-language" style="display:none">Info about the 'document language' definition.</span><b><a href="#document-language">#document-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-language">3.1. 
 Structure and Terminology</a>
@@ -6347,15 +6347,15 @@ Data Model</a>
 The Directionality Pseudo-class: :dir()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-language">
-   <b><a href="#host-language">#host-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-language" class="dfn-panel" data-for="host-language" id="infopanel-for-host-language" role="dialog">
+   <span id="infopaneltitle-for-host-language" style="display:none">Info about the 'host language' definition.</span><b><a href="#host-language">#host-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-language">3.2. 
 Data Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scoped-selector">
-   <b><a href="#scoped-selector">#scoped-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scoped-selector" class="dfn-panel" data-for="scoped-selector" id="infopanel-for-scoped-selector" role="dialog">
+   <span id="infopaneltitle-for-scoped-selector" style="display:none">Info about the 'scope' definition.</span><b><a href="#scoped-selector">#scoped-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scoped-selector">3.3. 
 Scoped Selectors</a> <a href="#ref-for-scoped-selector①">(2)</a>
@@ -6371,8 +6371,8 @@ Match a Selector Against a Tree</a> <a href="#ref-for-scoped-selector⑦">(2)</a
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scoping-root">
-   <b><a href="#scoping-root">#scoping-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scoping-root" class="dfn-panel" data-for="scoping-root" id="infopanel-for-scoping-root" role="dialog">
+   <span id="infopaneltitle-for-scoping-root" style="display:none">Info about the 'scoping root' definition.</span><b><a href="#scoping-root">#scoping-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scoping-root">3.3. 
 Scoped Selectors</a> <a href="#ref-for-scoping-root①">(2)</a>
@@ -6382,15 +6382,15 @@ The Reference Element Pseudo-class: :scope</a> <a href="#ref-for-scoping-root③
 Match a Selector Against a Tree</a> <a href="#ref-for-scoping-root⑥">(2)</a> <a href="#ref-for-scoping-root⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="virtual-scoping-root">
-   <b><a href="#virtual-scoping-root">#virtual-scoping-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-virtual-scoping-root" class="dfn-panel" data-for="virtual-scoping-root" id="infopanel-for-virtual-scoping-root" role="dialog">
+   <span id="infopaneltitle-for-virtual-scoping-root" style="display:none">Info about the 'virtual' definition.</span><b><a href="#virtual-scoping-root">#virtual-scoping-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-virtual-scoping-root">3.4.1. 
 Absolutizing a Relative Selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-selector">
-   <b><a href="#relative-selector">#relative-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-selector" class="dfn-panel" data-for="relative-selector" id="infopanel-for-relative-selector" role="dialog">
+   <span id="infopaneltitle-for-relative-selector" style="display:none">Info about the 'relative selectors' definition.</span><b><a href="#relative-selector">#relative-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-selector">2. 
 Selectors Overview</a>
@@ -6406,8 +6406,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes since the 23 August 2012 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolutize">
-   <b><a href="#absolutize">#absolutize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolutize" class="dfn-panel" data-for="absolutize" id="infopanel-for-absolutize" role="dialog">
+   <span id="infopaneltitle-for-absolutize" style="display:none">Info about the 'absolutize a relative selector' definition.</span><b><a href="#absolutize">#absolutize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolutize">3.4. 
 Relative Selectors</a>
@@ -6415,15 +6415,15 @@ Relative Selectors</a>
 The Relational Pseudo-class: :has()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolutize-list">
-   <b><a href="#absolutize-list">#absolutize-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolutize-list" class="dfn-panel" data-for="absolutize-list" id="infopanel-for-absolutize-list" role="dialog">
+   <span id="infopaneltitle-for-absolutize-list" style="display:none">Info about the 'absolutize a relative selector list' definition.</span><b><a href="#absolutize-list">#absolutize-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolutize-list">18.2. 
 Parse A Relative Selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pseudo-class">
-   <b><a href="#pseudo-class">#pseudo-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pseudo-class" class="dfn-panel" data-for="pseudo-class" id="infopanel-for-pseudo-class" role="dialog">
+   <span id="infopaneltitle-for-pseudo-class" style="display:none">Info about the 'Pseudo-classes' definition.</span><b><a href="#pseudo-class">#pseudo-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">3.1. 
 Structure and Terminology</a>
@@ -6444,15 +6444,15 @@ The Focus-Indicated Pseudo-class: :focus-visible</a> <a href="#ref-for-pseudo-cl
 :nth-last-of-type() pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="functional-pseudo-class">
-   <b><a href="#functional-pseudo-class">#functional-pseudo-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-functional-pseudo-class" class="dfn-panel" data-for="functional-pseudo-class" id="infopanel-for-functional-pseudo-class" role="dialog">
+   <span id="infopaneltitle-for-functional-pseudo-class" style="display:none">Info about the 'functional pseudo-class' definition.</span><b><a href="#functional-pseudo-class">#functional-pseudo-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-pseudo-class">3.5. 
 Pseudo-classes</a> <a href="#ref-for-functional-pseudo-class①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pseudo-element">
-   <b><a href="#pseudo-element">#pseudo-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pseudo-element" class="dfn-panel" data-for="pseudo-element" id="infopanel-for-pseudo-element" role="dialog">
+   <span id="infopaneltitle-for-pseudo-element" style="display:none">Info about the 'pseudo-element' definition.</span><b><a href="#pseudo-element">#pseudo-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">3.6. Pseudo-elements</a> <a href="#ref-for-pseudo-element①">(2)</a> <a href="#ref-for-pseudo-element②">(3)</a>
     <li><a href="#ref-for-pseudo-element③">3.6.1. 
@@ -6472,16 +6472,16 @@ Match a Selector Against a Tree</a>
     <li><a href="#ref-for-pseudo-element②⑦"> Appendix B: Obsolete but Required Parsing Quirks for Web Compat</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="originating-element">
-   <b><a href="#originating-element">#originating-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-originating-element" class="dfn-panel" data-for="originating-element" id="infopanel-for-originating-element" role="dialog">
+   <span id="infopaneltitle-for-originating-element" style="display:none">Info about the 'originating element' definition.</span><b><a href="#originating-element">#originating-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">3.6. Pseudo-elements</a>
     <li><a href="#ref-for-originating-element①">3.6.2. 
 Binding to the Document Tree</a> <a href="#ref-for-originating-element②">(2)</a> <a href="#ref-for-originating-element③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="whitespace">
-   <b><a href="#whitespace">#whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-whitespace" class="dfn-panel" data-for="whitespace" id="infopanel-for-whitespace" role="dialog">
+   <span id="infopaneltitle-for-whitespace" style="display:none">Info about the 'White space' definition.</span><b><a href="#whitespace">#whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace">3.5. 
 Pseudo-classes</a> <a href="#ref-for-whitespace①">(2)</a>
@@ -6493,8 +6493,8 @@ Attribute presence and value selectors</a>
 Class selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nsdecl">
-   <b><a href="#nsdecl">#nsdecl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nsdecl" class="dfn-panel" data-for="nsdecl" id="infopanel-for-nsdecl" role="dialog">
+   <span id="infopaneltitle-for-nsdecl" style="display:none">Info about the 'declared' definition.</span><b><a href="#nsdecl">#nsdecl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nsdecl">5.3. 
 Namespaces in Elemental Selectors</a> <a href="#ref-for-nsdecl">(2)</a> <a href="#ref-for-nsdecl">(3)</a>
@@ -6502,8 +6502,8 @@ Namespaces in Elemental Selectors</a> <a href="#ref-for-nsdecl">(2)</a> <a href=
 Attribute selectors and namespaces</a> <a href="#ref-for-nsdecl①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-selector">
-   <b><a href="#invalid-selector">#invalid-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-selector" class="dfn-panel" data-for="invalid-selector" id="infopanel-for-invalid-selector" role="dialog">
+   <span id="infopaneltitle-for-invalid-selector" style="display:none">Info about the 'invalid selectors' definition.</span><b><a href="#invalid-selector">#invalid-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-selector">3.9. 
 Invalid Selectors and Error Handling</a> <a href="#ref-for-invalid-selector①">(2)</a>
@@ -6517,8 +6517,8 @@ API Hooks</a>
 Parse A Selector</a> <a href="#ref-for-invalid-selector⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-pseudo">
-   <b><a href="#matches-pseudo">#matches-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-pseudo" class="dfn-panel" data-for="matches-pseudo" id="infopanel-for-matches-pseudo" role="dialog">
+   <span id="infopaneltitle-for-matches-pseudo" style="display:none">Info about the ':is()' definition.</span><b><a href="#matches-pseudo">#matches-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-pseudo">3.6.3. 
 Pseudo-classing Pseudo-elements</a>
@@ -6541,8 +6541,8 @@ Changes since the 2 February 2018 Working Draft</a> <a href="#ref-for-matches-ps
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-matches">
-   <b><a href="#selectordef-matches">#selectordef-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-matches" class="dfn-panel" data-for="selectordef-matches" id="infopanel-for-selectordef-matches" role="dialog">
+   <span id="infopaneltitle-for-selectordef-matches" style="display:none">Info about the ':matches()' definition.</span><b><a href="#selectordef-matches">#selectordef-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-matches">19.2. 
 Changes since the 2 February 2018 Working Draft</a>
@@ -6552,8 +6552,8 @@ Changes since the 2 May 2013 Working Draft</a> <a href="#ref-for-selectordef-mat
 Changes since the 23 August 2012 Working Draft</a> <a href="#ref-for-selectordef-matches④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="negation-pseudo">
-   <b><a href="#negation-pseudo">#negation-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-negation-pseudo" class="dfn-panel" data-for="negation-pseudo" id="infopanel-for-negation-pseudo" role="dialog">
+   <span id="infopaneltitle-for-negation-pseudo" style="display:none">Info about the ':not()' definition.</span><b><a href="#negation-pseudo">#negation-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-negation-pseudo">3.6.3. 
 Pseudo-classing Pseudo-elements</a>
@@ -6571,8 +6571,8 @@ Changes since the 23 August 2012 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="where-pseudo">
-   <b><a href="#where-pseudo">#where-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-where-pseudo" class="dfn-panel" data-for="where-pseudo" id="infopanel-for-where-pseudo" role="dialog">
+   <span id="infopaneltitle-for-where-pseudo" style="display:none">Info about the ':where()' definition.</span><b><a href="#where-pseudo">#where-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-where-pseudo">4.4. 
 The Specificity-adjustment Pseudo-class: :where()</a> <a href="#ref-for-where-pseudo①">(2)</a> <a href="#ref-for-where-pseudo②">(3)</a>
@@ -6584,8 +6584,8 @@ Changes since the 2 February 2018 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="has-pseudo">
-   <b><a href="#has-pseudo">#has-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-has-pseudo" class="dfn-panel" data-for="has-pseudo" id="infopanel-for-has-pseudo" role="dialog">
+   <span id="infopaneltitle-for-has-pseudo" style="display:none">Info about the ':has()' definition.</span><b><a href="#has-pseudo">#has-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-has-pseudo①">4.5. 
 The Relational Pseudo-class: :has()</a> <a href="#ref-for-has-pseudo②">(2)</a>
@@ -6602,8 +6602,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="type-selector">
-   <b><a href="#type-selector">#type-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-type-selector" class="dfn-panel" data-for="type-selector" id="infopanel-for-type-selector" role="dialog">
+   <span id="infopaneltitle-for-type-selector" style="display:none">Info about the 'type selector' definition.</span><b><a href="#type-selector">#type-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">3.1. 
 Structure and Terminology</a> <a href="#ref-for-type-selector①">(2)</a>
@@ -6625,8 +6625,8 @@ Namespaces in Elemental Selectors</a> <a href="#ref-for-type-selector①⓪">(2)
 :nth-last-of-type() pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="universal-selector">
-   <b><a href="#universal-selector">#universal-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-universal-selector" class="dfn-panel" data-for="universal-selector" id="infopanel-for-universal-selector" role="dialog">
+   <span id="infopaneltitle-for-universal-selector" style="display:none">Info about the 'universal selector' definition.</span><b><a href="#universal-selector">#universal-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-universal-selector">3.1. 
 Structure and Terminology</a> <a href="#ref-for-universal-selector①">(2)</a>
@@ -6644,36 +6644,36 @@ Universal selector </a> <a href="#ref-for-universal-selector⑦">(2)</a> <a href
 Namespaces in Elemental Selectors</a> <a href="#ref-for-universal-selector①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="defined-pseudo">
-   <b><a href="#defined-pseudo">#defined-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-defined-pseudo" class="dfn-panel" data-for="defined-pseudo" id="infopanel-for-defined-pseudo" role="dialog">
+   <span id="infopaneltitle-for-defined-pseudo" style="display:none">Info about the ':defined' definition.</span><b><a href="#defined-pseudo">#defined-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-defined-pseudo">5.4. 
 The Defined Pseudo-class: :defined</a> <a href="#ref-for-defined-pseudo①">(2)</a> <a href="#ref-for-defined-pseudo②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribute-selector">
-   <b><a href="#attribute-selector">#attribute-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-selector" class="dfn-panel" data-for="attribute-selector" id="infopanel-for-attribute-selector" role="dialog">
+   <span id="infopaneltitle-for-attribute-selector" style="display:none">Info about the 'attribute selector' definition.</span><b><a href="#attribute-selector">#attribute-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-selector">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="class-selector">
-   <b><a href="#class-selector">#class-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-class-selector" class="dfn-panel" data-for="class-selector" id="infopanel-for-class-selector" role="dialog">
+   <span id="infopaneltitle-for-class-selector" style="display:none">Info about the 'class selector' definition.</span><b><a href="#class-selector">#class-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-class-selector">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="id-selector">
-   <b><a href="#id-selector">#id-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-id-selector" class="dfn-panel" data-for="id-selector" id="infopanel-for-id-selector" role="dialog">
+   <span id="infopaneltitle-for-id-selector" style="display:none">Info about the 'ID selector' definition.</span><b><a href="#id-selector">#id-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-id-selector">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dir-pseudo">
-   <b><a href="#dir-pseudo">#dir-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dir-pseudo" class="dfn-panel" data-for="dir-pseudo" id="infopanel-for-dir-pseudo" role="dialog">
+   <span id="infopaneltitle-for-dir-pseudo" style="display:none">Info about the ':dir()' definition.</span><b><a href="#dir-pseudo">#dir-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dir-pseudo">7.1. 
 The Directionality Pseudo-class: :dir()</a> <a href="#ref-for-dir-pseudo①">(2)</a> <a href="#ref-for-dir-pseudo②">(3)</a>
@@ -6681,8 +6681,8 @@ The Directionality Pseudo-class: :dir()</a> <a href="#ref-for-dir-pseudo①">(2)
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lang-pseudo">
-   <b><a href="#lang-pseudo">#lang-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lang-pseudo" class="dfn-panel" data-for="lang-pseudo" id="infopanel-for-lang-pseudo" role="dialog">
+   <span id="infopaneltitle-for-lang-pseudo" style="display:none">Info about the ':lang()' definition.</span><b><a href="#lang-pseudo">#lang-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lang-pseudo">3.2. 
 Data Model</a>
@@ -6700,8 +6700,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="language-range">
-   <b><a href="#language-range">#language-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-language-range" class="dfn-panel" data-for="language-range" id="infopanel-for-language-range" role="dialog">
+   <span id="infopaneltitle-for-language-range" style="display:none">Info about the 'language range' definition.</span><b><a href="#language-range">#language-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-language-range">3.7. 
 Characters and case sensitivity</a>
@@ -6709,8 +6709,8 @@ Characters and case sensitivity</a>
 The Language Pseudo-class: :lang()</a> <a href="#ref-for-language-range②">(2)</a> <a href="#ref-for-language-range③">(3)</a> <a href="#ref-for-language-range④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="any-link-pseudo">
-   <b><a href="#any-link-pseudo">#any-link-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-any-link-pseudo" class="dfn-panel" data-for="any-link-pseudo" id="infopanel-for-any-link-pseudo" role="dialog">
+   <span id="infopaneltitle-for-any-link-pseudo" style="display:none">Info about the ':any-link' definition.</span><b><a href="#any-link-pseudo">#any-link-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-any-link-pseudo">8.1. 
 The Hyperlink Pseudo-class: :any-link</a>
@@ -6718,8 +6718,8 @@ The Hyperlink Pseudo-class: :any-link</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="link-pseudo">
-   <b><a href="#link-pseudo">#link-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-link-pseudo" class="dfn-panel" data-for="link-pseudo" id="infopanel-for-link-pseudo" role="dialog">
+   <span id="infopaneltitle-for-link-pseudo" style="display:none">Info about the ':link' definition.</span><b><a href="#link-pseudo">#link-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-pseudo">8.1. 
 The Hyperlink Pseudo-class: :any-link</a>
@@ -6729,8 +6729,8 @@ The Link History Pseudo-classes: :link and :visited</a> <a href="#ref-for-link-p
 The Activation Pseudo-class: :active</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visited-pseudo">
-   <b><a href="#visited-pseudo">#visited-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visited-pseudo" class="dfn-panel" data-for="visited-pseudo" id="infopanel-for-visited-pseudo" role="dialog">
+   <span id="infopaneltitle-for-visited-pseudo" style="display:none">Info about the ':visited' definition.</span><b><a href="#visited-pseudo">#visited-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visited-pseudo">8.1. 
 The Hyperlink Pseudo-class: :any-link</a>
@@ -6740,8 +6740,8 @@ The Link History Pseudo-classes: :link and :visited</a> <a href="#ref-for-visite
 The Activation Pseudo-class: :active</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-link-pseudo">
-   <b><a href="#local-link-pseudo">#local-link-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-link-pseudo" class="dfn-panel" data-for="local-link-pseudo" id="infopanel-for-local-link-pseudo" role="dialog">
+   <span id="infopaneltitle-for-local-link-pseudo" style="display:none">Info about the ':local-link' definition.</span><b><a href="#local-link-pseudo">#local-link-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-link-pseudo">8.3. 
 The Local Link Pseudo-class: :local-link</a> <a href="#ref-for-local-link-pseudo①">(2)</a>
@@ -6749,8 +6749,8 @@ The Local Link Pseudo-class: :local-link</a> <a href="#ref-for-local-link-pseudo
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-pseudo">
-   <b><a href="#target-pseudo">#target-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-pseudo" class="dfn-panel" data-for="target-pseudo" id="infopanel-for-target-pseudo" role="dialog">
+   <span id="infopaneltitle-for-target-pseudo" style="display:none">Info about the ':target' definition.</span><b><a href="#target-pseudo">#target-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo">8.3. 
 The Local Link Pseudo-class: :local-link</a>
@@ -6760,8 +6760,8 @@ The Target Pseudo-class: :target</a> <a href="#ref-for-target-pseudo②">(2)</a>
 The Target Container Pseudo-class: :target-within</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-within-pseudo">
-   <b><a href="#target-within-pseudo">#target-within-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-within-pseudo" class="dfn-panel" data-for="target-within-pseudo" id="infopanel-for-target-within-pseudo" role="dialog">
+   <span id="infopaneltitle-for-target-within-pseudo" style="display:none">Info about the ':target-within' definition.</span><b><a href="#target-within-pseudo">#target-within-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-within-pseudo">8.3. 
 The Local Link Pseudo-class: :local-link</a>
@@ -6773,8 +6773,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scope-element">
-   <b><a href="#scope-element">#scope-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scope-element" class="dfn-panel" data-for="scope-element" id="infopanel-for-scope-element" role="dialog">
+   <span id="infopaneltitle-for-scope-element" style="display:none">Info about the ':scope elements' definition.</span><b><a href="#scope-element">#scope-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scope-element">2. 
 Selectors Overview</a>
@@ -6796,8 +6796,8 @@ Match a Selector Against an Element</a> <a href="#ref-for-scope-element①②">(
 Match a Selector Against a Tree</a> <a href="#ref-for-scope-element①④">(2)</a> <a href="#ref-for-scope-element①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scope-pseudo">
-   <b><a href="#scope-pseudo">#scope-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scope-pseudo" class="dfn-panel" data-for="scope-pseudo" id="infopanel-for-scope-pseudo" role="dialog">
+   <span id="infopaneltitle-for-scope-pseudo" style="display:none">Info about the ':scope' definition.</span><b><a href="#scope-pseudo">#scope-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scope-pseudo">3.4. 
 Relative Selectors</a> <a href="#ref-for-scope-pseudo①">(2)</a> <a href="#ref-for-scope-pseudo②">(3)</a>
@@ -6813,15 +6813,15 @@ Match a Selector Against a Tree</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-action-pseudo-class">
-   <b><a href="#user-action-pseudo-class">#user-action-pseudo-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-action-pseudo-class" class="dfn-panel" data-for="user-action-pseudo-class" id="infopanel-for-user-action-pseudo-class" role="dialog">
+   <span id="infopaneltitle-for-user-action-pseudo-class" style="display:none">Info about the 'user action pseudo-classes' definition.</span><b><a href="#user-action-pseudo-class">#user-action-pseudo-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-action-pseudo-class">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hover-pseudo">
-   <b><a href="#hover-pseudo">#hover-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hover-pseudo" class="dfn-panel" data-for="hover-pseudo" id="infopanel-for-hover-pseudo" role="dialog">
+   <span id="infopaneltitle-for-hover-pseudo" style="display:none">Info about the ':hover' definition.</span><b><a href="#hover-pseudo">#hover-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hover-pseudo">3.6.3. 
 Pseudo-classing Pseudo-elements</a>
@@ -6829,15 +6829,15 @@ Pseudo-classing Pseudo-elements</a>
 The Pointer Hover Pseudo-class: :hover</a> <a href="#ref-for-hover-pseudo②">(2)</a> <a href="#ref-for-hover-pseudo③">(3)</a> <a href="#ref-for-hover-pseudo④">(4)</a> <a href="#ref-for-hover-pseudo⑤">(5)</a> <a href="#ref-for-hover-pseudo⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-pseudo">
-   <b><a href="#active-pseudo">#active-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-pseudo" class="dfn-panel" data-for="active-pseudo" id="infopanel-for-active-pseudo" role="dialog">
+   <span id="infopaneltitle-for-active-pseudo" style="display:none">Info about the ':active' definition.</span><b><a href="#active-pseudo">#active-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-pseudo">9.2. 
 The Activation Pseudo-class: :active</a> <a href="#ref-for-active-pseudo①">(2)</a> <a href="#ref-for-active-pseudo②">(3)</a> <a href="#ref-for-active-pseudo③">(4)</a> <a href="#ref-for-active-pseudo④">(5)</a> <a href="#ref-for-active-pseudo⑤">(6)</a> <a href="#ref-for-active-pseudo⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="focus-pseudo">
-   <b><a href="#focus-pseudo">#focus-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-focus-pseudo" class="dfn-panel" data-for="focus-pseudo" id="infopanel-for-focus-pseudo" role="dialog">
+   <span id="infopaneltitle-for-focus-pseudo" style="display:none">Info about the ':focus' definition.</span><b><a href="#focus-pseudo">#focus-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-pseudo">3.6.3. 
 Pseudo-classing Pseudo-elements</a> <a href="#ref-for-focus-pseudo①">(2)</a>
@@ -6849,15 +6849,15 @@ The Focus-Indicated Pseudo-class: :focus-visible</a> <a href="#ref-for-focus-pse
 The Focus Container Pseudo-class: :focus-within</a> <a href="#ref-for-focus-pseudo①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="indicate-focus">
-   <b><a href="#indicate-focus">#indicate-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-indicate-focus" class="dfn-panel" data-for="indicate-focus" id="infopanel-for-indicate-focus" role="dialog">
+   <span id="infopaneltitle-for-indicate-focus" style="display:none">Info about the 'indicate focus' definition.</span><b><a href="#indicate-focus">#indicate-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indicate-focus">9.4. 
 The Focus-Indicated Pseudo-class: :focus-visible</a> <a href="#ref-for-indicate-focus①">(2)</a> <a href="#ref-for-indicate-focus②">(3)</a> <a href="#ref-for-indicate-focus③">(4)</a> <a href="#ref-for-indicate-focus④">(5)</a> <a href="#ref-for-indicate-focus⑤">(6)</a> <a href="#ref-for-indicate-focus⑥">(7)</a> <a href="#ref-for-indicate-focus⑦">(8)</a> <a href="#ref-for-indicate-focus⑧">(9)</a> <a href="#ref-for-indicate-focus⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="focus-visible-pseudo">
-   <b><a href="#focus-visible-pseudo">#focus-visible-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-focus-visible-pseudo" class="dfn-panel" data-for="focus-visible-pseudo" id="infopanel-for-focus-visible-pseudo" role="dialog">
+   <span id="infopaneltitle-for-focus-visible-pseudo" style="display:none">Info about the ':focus-visible' definition.</span><b><a href="#focus-visible-pseudo">#focus-visible-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-visible-pseudo">9.4. 
 The Focus-Indicated Pseudo-class: :focus-visible</a> <a href="#ref-for-focus-visible-pseudo①">(2)</a> <a href="#ref-for-focus-visible-pseudo②">(3)</a> <a href="#ref-for-focus-visible-pseudo③">(4)</a> <a href="#ref-for-focus-visible-pseudo④">(5)</a>
@@ -6869,8 +6869,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="focus-within-pseudo">
-   <b><a href="#focus-within-pseudo">#focus-within-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-focus-within-pseudo" class="dfn-panel" data-for="focus-within-pseudo" id="infopanel-for-focus-within-pseudo" role="dialog">
+   <span id="infopaneltitle-for-focus-within-pseudo" style="display:none">Info about the ':focus-within' definition.</span><b><a href="#focus-within-pseudo">#focus-within-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-within-pseudo">9.3. 
 The Input Focus Pseudo-class: :focus</a>
@@ -6882,8 +6882,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-pseudo">
-   <b><a href="#current-pseudo">#current-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-pseudo" class="dfn-panel" data-for="current-pseudo" id="infopanel-for-current-pseudo" role="dialog">
+   <span id="infopaneltitle-for-current-pseudo" style="display:none">Info about the ':current' definition.</span><b><a href="#current-pseudo">#current-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-pseudo">2. 
 Selectors Overview</a>
@@ -6897,8 +6897,8 @@ The Past-element Pseudo-class: :past</a> <a href="#ref-for-current-pseudo⑨">(2
 The Future-element Pseudo-class: :future</a> <a href="#ref-for-current-pseudo①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="past-pseudo">
-   <b><a href="#past-pseudo">#past-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-past-pseudo" class="dfn-panel" data-for="past-pseudo" id="infopanel-for-past-pseudo" role="dialog">
+   <span id="infopaneltitle-for-past-pseudo" style="display:none">Info about the ':past' definition.</span><b><a href="#past-pseudo">#past-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-past-pseudo">10. 
 Time-dimensional Pseudo-classes</a> <a href="#ref-for-past-pseudo①">(2)</a> <a href="#ref-for-past-pseudo②">(3)</a>
@@ -6906,8 +6906,8 @@ Time-dimensional Pseudo-classes</a> <a href="#ref-for-past-pseudo①">(2)</a> <a
 The Past-element Pseudo-class: :past</a> <a href="#ref-for-past-pseudo④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="future-pseudo">
-   <b><a href="#future-pseudo">#future-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-future-pseudo" class="dfn-panel" data-for="future-pseudo" id="infopanel-for-future-pseudo" role="dialog">
+   <span id="infopaneltitle-for-future-pseudo" style="display:none">Info about the ':future' definition.</span><b><a href="#future-pseudo">#future-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-future-pseudo">10. 
 Time-dimensional Pseudo-classes</a> <a href="#ref-for-future-pseudo①">(2)</a> <a href="#ref-for-future-pseudo②">(3)</a>
@@ -6915,8 +6915,8 @@ Time-dimensional Pseudo-classes</a> <a href="#ref-for-future-pseudo①">(2)</a> 
 The Future-element Pseudo-class: :future</a> <a href="#ref-for-future-pseudo④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-playing">
-   <b><a href="#selectordef-playing">#selectordef-playing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-playing" class="dfn-panel" data-for="selectordef-playing" id="infopanel-for-selectordef-playing" role="dialog">
+   <span id="infopaneltitle-for-selectordef-playing" style="display:none">Info about the ':playing' definition.</span><b><a href="#selectordef-playing">#selectordef-playing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-playing">11.1. 
 Video/Audio Play State: the :playing and :paused pseudo-classes</a>
@@ -6924,8 +6924,8 @@ Video/Audio Play State: the :playing and :paused pseudo-classes</a>
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="selectordef-paused">
-   <b><a href="#selectordef-paused">#selectordef-paused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-selectordef-paused" class="dfn-panel" data-for="selectordef-paused" id="infopanel-for-selectordef-paused" role="dialog">
+   <span id="infopaneltitle-for-selectordef-paused" style="display:none">Info about the ':paused' definition.</span><b><a href="#selectordef-paused">#selectordef-paused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-paused">11.1. 
 Video/Audio Play State: the :playing and :paused pseudo-classes</a>
@@ -6933,36 +6933,36 @@ Video/Audio Play State: the :playing and :paused pseudo-classes</a>
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enabled-pseudo">
-   <b><a href="#enabled-pseudo">#enabled-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enabled-pseudo" class="dfn-panel" data-for="enabled-pseudo" id="infopanel-for-enabled-pseudo" role="dialog">
+   <span id="infopaneltitle-for-enabled-pseudo" style="display:none">Info about the ':enabled' definition.</span><b><a href="#enabled-pseudo">#enabled-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enabled-pseudo">12.1.1. 
 The :enabled and :disabled Pseudo-classes</a> <a href="#ref-for-enabled-pseudo①">(2)</a> <a href="#ref-for-enabled-pseudo②">(3)</a> <a href="#ref-for-enabled-pseudo③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="disabled-pseudo">
-   <b><a href="#disabled-pseudo">#disabled-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-disabled-pseudo" class="dfn-panel" data-for="disabled-pseudo" id="infopanel-for-disabled-pseudo" role="dialog">
+   <span id="infopaneltitle-for-disabled-pseudo" style="display:none">Info about the ':disabled' definition.</span><b><a href="#disabled-pseudo">#disabled-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-disabled-pseudo">12.1.1. 
 The :enabled and :disabled Pseudo-classes</a> <a href="#ref-for-disabled-pseudo①">(2)</a> <a href="#ref-for-disabled-pseudo②">(3)</a> <a href="#ref-for-disabled-pseudo③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-write-pseudo">
-   <b><a href="#read-write-pseudo">#read-write-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-write-pseudo" class="dfn-panel" data-for="read-write-pseudo" id="infopanel-for-read-write-pseudo" role="dialog">
+   <span id="infopaneltitle-for-read-write-pseudo" style="display:none">Info about the ':read-write' definition.</span><b><a href="#read-write-pseudo">#read-write-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-write-pseudo①">12.1.2. 
 The Mutability Pseudo-classes: :read-only and :read-write</a> <a href="#ref-for-read-write-pseudo②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-only-pseudo">
-   <b><a href="#read-only-pseudo">#read-only-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-only-pseudo" class="dfn-panel" data-for="read-only-pseudo" id="infopanel-for-read-only-pseudo" role="dialog">
+   <span id="infopaneltitle-for-read-only-pseudo" style="display:none">Info about the ':read-only' definition.</span><b><a href="#read-only-pseudo">#read-only-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-only-pseudo">12.1.2. 
 The Mutability Pseudo-classes: :read-only and :read-write</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="placeholder-shown-pseudo">
-   <b><a href="#placeholder-shown-pseudo">#placeholder-shown-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-placeholder-shown-pseudo" class="dfn-panel" data-for="placeholder-shown-pseudo" id="infopanel-for-placeholder-shown-pseudo" role="dialog">
+   <span id="infopaneltitle-for-placeholder-shown-pseudo" style="display:none">Info about the ':placeholder-shown' definition.</span><b><a href="#placeholder-shown-pseudo">#placeholder-shown-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-placeholder-shown-pseudo">12.1.3. 
 The Placeholder-shown Pseudo-class: :placeholder-shown</a> <a href="#ref-for-placeholder-shown-pseudo①">(2)</a>
@@ -6970,15 +6970,15 @@ The Placeholder-shown Pseudo-class: :placeholder-shown</a> <a href="#ref-for-pla
 Changes since the 23 August 2012 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-pseudo">
-   <b><a href="#default-pseudo">#default-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-pseudo" class="dfn-panel" data-for="default-pseudo" id="infopanel-for-default-pseudo" role="dialog">
+   <span id="infopaneltitle-for-default-pseudo" style="display:none">Info about the ':default' definition.</span><b><a href="#default-pseudo">#default-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-pseudo">12.1.4. 
 The Default-option Pseudo-class: :default</a> <a href="#ref-for-default-pseudo①">(2)</a> <a href="#ref-for-default-pseudo②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="checked-pseudo">
-   <b><a href="#checked-pseudo">#checked-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-checked-pseudo" class="dfn-panel" data-for="checked-pseudo" id="infopanel-for-checked-pseudo" role="dialog">
+   <span id="infopaneltitle-for-checked-pseudo" style="display:none">Info about the ':checked' definition.</span><b><a href="#checked-pseudo">#checked-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-checked-pseudo">12.2.1. 
 The Selected-option Pseudo-class: :checked</a> <a href="#ref-for-checked-pseudo①">(2)</a> <a href="#ref-for-checked-pseudo②">(3)</a>
@@ -6986,8 +6986,8 @@ The Selected-option Pseudo-class: :checked</a> <a href="#ref-for-checked-pseudo�
 The Indeterminate-value Pseudo-class: :indeterminate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="indeterminate-pseudo">
-   <b><a href="#indeterminate-pseudo">#indeterminate-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-indeterminate-pseudo" class="dfn-panel" data-for="indeterminate-pseudo" id="infopanel-for-indeterminate-pseudo" role="dialog">
+   <span id="infopaneltitle-for-indeterminate-pseudo" style="display:none">Info about the ':indeterminate' definition.</span><b><a href="#indeterminate-pseudo">#indeterminate-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indeterminate-pseudo">12.2.2. 
 The Indeterminate-value Pseudo-class: :indeterminate</a> <a href="#ref-for-indeterminate-pseudo①">(2)</a> <a href="#ref-for-indeterminate-pseudo②">(3)</a> <a href="#ref-for-indeterminate-pseudo③">(4)</a>
@@ -6995,8 +6995,8 @@ The Indeterminate-value Pseudo-class: :indeterminate</a> <a href="#ref-for-indet
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blank-pseudo">
-   <b><a href="#blank-pseudo">#blank-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blank-pseudo" class="dfn-panel" data-for="blank-pseudo" id="infopanel-for-blank-pseudo" role="dialog">
+   <span id="infopaneltitle-for-blank-pseudo" style="display:none">Info about the ':blank' definition.</span><b><a href="#blank-pseudo">#blank-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blank-pseudo">12.3.1. 
 The Empty-Value Pseudo-class: :blank</a> <a href="#ref-for-blank-pseudo①">(2)</a>
@@ -7006,8 +7006,8 @@ Changes since the 2 February 2018 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-pseudo">
-   <b><a href="#valid-pseudo">#valid-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-pseudo" class="dfn-panel" data-for="valid-pseudo" id="infopanel-for-valid-pseudo" role="dialog">
+   <span id="infopaneltitle-for-valid-pseudo" style="display:none">Info about the ':valid' definition.</span><b><a href="#valid-pseudo">#valid-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-pseudo">3.5. 
 Pseudo-classes</a>
@@ -7017,8 +7017,8 @@ The Validity Pseudo-classes: :valid and :invalid</a> <a href="#ref-for-valid-pse
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a> <a href="#ref-for-valid-pseudo⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invalid-pseudo">
-   <b><a href="#invalid-pseudo">#invalid-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invalid-pseudo" class="dfn-panel" data-for="invalid-pseudo" id="infopanel-for-invalid-pseudo" role="dialog">
+   <span id="infopaneltitle-for-invalid-pseudo" style="display:none">Info about the ':invalid' definition.</span><b><a href="#invalid-pseudo">#invalid-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-pseudo">12.3.2. 
 The Validity Pseudo-classes: :valid and :invalid</a> <a href="#ref-for-invalid-pseudo①">(2)</a> <a href="#ref-for-invalid-pseudo②">(3)</a>
@@ -7026,15 +7026,15 @@ The Validity Pseudo-classes: :valid and :invalid</a> <a href="#ref-for-invalid-p
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a> <a href="#ref-for-invalid-pseudo④">(2)</a> <a href="#ref-for-invalid-pseudo⑤">(3)</a> <a href="#ref-for-invalid-pseudo⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-range-pseudo">
-   <b><a href="#in-range-pseudo">#in-range-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-range-pseudo" class="dfn-panel" data-for="in-range-pseudo" id="infopanel-for-in-range-pseudo" role="dialog">
+   <span id="infopaneltitle-for-in-range-pseudo" style="display:none">Info about the ':in-range' definition.</span><b><a href="#in-range-pseudo">#in-range-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-range-pseudo">12.3.3. 
 The Range Pseudo-classes: :in-range and :out-of-range</a> <a href="#ref-for-in-range-pseudo①">(2)</a> <a href="#ref-for-in-range-pseudo②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="out-of-range-pseudo">
-   <b><a href="#out-of-range-pseudo">#out-of-range-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-out-of-range-pseudo" class="dfn-panel" data-for="out-of-range-pseudo" id="infopanel-for-out-of-range-pseudo" role="dialog">
+   <span id="infopaneltitle-for-out-of-range-pseudo" style="display:none">Info about the ':out-of-range' definition.</span><b><a href="#out-of-range-pseudo">#out-of-range-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-out-of-range-pseudo">12.3.3. 
 The Range Pseudo-classes: :in-range and :out-of-range</a> <a href="#ref-for-out-of-range-pseudo①">(2)</a> <a href="#ref-for-out-of-range-pseudo②">(3)</a>
@@ -7042,8 +7042,8 @@ The Range Pseudo-classes: :in-range and :out-of-range</a> <a href="#ref-for-out-
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="required-pseudo">
-   <b><a href="#required-pseudo">#required-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-required-pseudo" class="dfn-panel" data-for="required-pseudo" id="infopanel-for-required-pseudo" role="dialog">
+   <span id="infopaneltitle-for-required-pseudo" style="display:none">Info about the ':required' definition.</span><b><a href="#required-pseudo">#required-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-required-pseudo">12.3.4. 
 The Optionality Pseudo-classes: :required and :optional</a>
@@ -7051,15 +7051,15 @@ The Optionality Pseudo-classes: :required and :optional</a>
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optional-pseudo">
-   <b><a href="#optional-pseudo">#optional-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optional-pseudo" class="dfn-panel" data-for="optional-pseudo" id="infopanel-for-optional-pseudo" role="dialog">
+   <span id="infopaneltitle-for-optional-pseudo" style="display:none">Info about the ':optional' definition.</span><b><a href="#optional-pseudo">#optional-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optional-pseudo">12.3.4. 
 The Optionality Pseudo-classes: :required and :optional</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-invalid-pseudo">
-   <b><a href="#user-invalid-pseudo">#user-invalid-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-invalid-pseudo" class="dfn-panel" data-for="user-invalid-pseudo" id="infopanel-for-user-invalid-pseudo" role="dialog">
+   <span id="infopaneltitle-for-user-invalid-pseudo" style="display:none">Info about the ':user-invalid' definition.</span><b><a href="#user-invalid-pseudo">#user-invalid-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-invalid-pseudo">12.3.5. 
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a> <a href="#ref-for-user-invalid-pseudo①">(2)</a> <a href="#ref-for-user-invalid-pseudo②">(3)</a> <a href="#ref-for-user-invalid-pseudo③">(4)</a>
@@ -7071,23 +7071,23 @@ Changes since the 29 September 2011 Working Draft</a>
 Changes Since Level 3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-valid-pseudo">
-   <b><a href="#user-valid-pseudo">#user-valid-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-valid-pseudo" class="dfn-panel" data-for="user-valid-pseudo" id="infopanel-for-user-valid-pseudo" role="dialog">
+   <span id="infopaneltitle-for-user-valid-pseudo" style="display:none">Info about the ':user-valid' definition.</span><b><a href="#user-valid-pseudo">#user-valid-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-valid-pseudo">12.3.5. 
 The User-interaction Pseudo-classes: :user-valid and :user-invalid</a> <a href="#ref-for-user-valid-pseudo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="structural-pseudo-classes">
-   <b><a href="#structural-pseudo-classes">#structural-pseudo-classes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-structural-pseudo-classes" class="dfn-panel" data-for="structural-pseudo-classes" id="infopanel-for-structural-pseudo-classes" role="dialog">
+   <span id="infopaneltitle-for-structural-pseudo-classes" style="display:none">Info about the 'structural pseudo-classes' definition.</span><b><a href="#structural-pseudo-classes">#structural-pseudo-classes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structural-pseudo-classes">3.6. Pseudo-elements</a>
     <li><a href="#ref-for-structural-pseudo-classes①">13. 
 Tree-Structural pseudo-classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root-pseudo">
-   <b><a href="#root-pseudo">#root-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-root-pseudo" class="dfn-panel" data-for="root-pseudo" id="infopanel-for-root-pseudo" role="dialog">
+   <span id="infopaneltitle-for-root-pseudo" style="display:none">Info about the ':root' definition.</span><b><a href="#root-pseudo">#root-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root-pseudo">8.6. 
 The Reference Element Pseudo-class: :scope</a>
@@ -7096,8 +7096,8 @@ The Reference Element Pseudo-class: :scope</a>
     <li><a href="#ref-for-root-pseudo③"> Appendix A: Guidance on Mapping Source Documents &amp; Data to an Element Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-pseudo">
-   <b><a href="#empty-pseudo">#empty-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-pseudo" class="dfn-panel" data-for="empty-pseudo" id="infopanel-for-empty-pseudo" role="dialog">
+   <span id="infopaneltitle-for-empty-pseudo" style="display:none">Info about the ':empty' definition.</span><b><a href="#empty-pseudo">#empty-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-pseudo">13.2. 
 :empty pseudo-class</a> <a href="#ref-for-empty-pseudo①">(2)</a>
@@ -7105,8 +7105,8 @@ The Reference Element Pseudo-class: :scope</a>
 Changes since the 2 February 2018 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-child-pseudo">
-   <b><a href="#nth-child-pseudo">#nth-child-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-child-pseudo" class="dfn-panel" data-for="nth-child-pseudo" id="infopanel-for-nth-child-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-child-pseudo" style="display:none">Info about the ':nth-child(An+B [of S]? )' definition.</span><b><a href="#nth-child-pseudo">#nth-child-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-child-pseudo">13.3.1. 
 :nth-child() pseudo-class</a> <a href="#ref-for-nth-child-pseudo①">(2)</a>
@@ -7121,8 +7121,8 @@ Calculating a selector’s specificity</a>
 Changes since the 2 February 2018 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-last-child-pseudo">
-   <b><a href="#nth-last-child-pseudo">#nth-last-child-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-last-child-pseudo" class="dfn-panel" data-for="nth-last-child-pseudo" id="infopanel-for-nth-last-child-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-last-child-pseudo" style="display:none">Info about the ':nth-last-child(An+B [of S]? )' definition.</span><b><a href="#nth-last-child-pseudo">#nth-last-child-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-last-child-pseudo">13.3.2. 
 :nth-last-child() pseudo-class</a> <a href="#ref-for-nth-last-child-pseudo①">(2)</a>
@@ -7130,8 +7130,8 @@ Changes since the 2 February 2018 Working Draft</a>
 Calculating a selector’s specificity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-child-pseudo">
-   <b><a href="#first-child-pseudo">#first-child-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-child-pseudo" class="dfn-panel" data-for="first-child-pseudo" id="infopanel-for-first-child-pseudo" role="dialog">
+   <span id="infopaneltitle-for-first-child-pseudo" style="display:none">Info about the ':first-child' definition.</span><b><a href="#first-child-pseudo">#first-child-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-child-pseudo">13.3.3. 
 :first-child pseudo-class</a>
@@ -7140,57 +7140,57 @@ Child combinator (>)</a>
     <li><a href="#ref-for-first-child-pseudo②"> Appendix A: Guidance on Mapping Source Documents &amp; Data to an Element Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-child-pseudo">
-   <b><a href="#last-child-pseudo">#last-child-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-child-pseudo" class="dfn-panel" data-for="last-child-pseudo" id="infopanel-for-last-child-pseudo" role="dialog">
+   <span id="infopaneltitle-for-last-child-pseudo" style="display:none">Info about the ':last-child' definition.</span><b><a href="#last-child-pseudo">#last-child-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-child-pseudo">13.3.4. 
 :last-child pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="only-child-pseudo">
-   <b><a href="#only-child-pseudo">#only-child-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-only-child-pseudo" class="dfn-panel" data-for="only-child-pseudo" id="infopanel-for-only-child-pseudo" role="dialog">
+   <span id="infopaneltitle-for-only-child-pseudo" style="display:none">Info about the ':only-child' definition.</span><b><a href="#only-child-pseudo">#only-child-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-only-child-pseudo">13.3.5. 
 :only-child pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-of-type-pseudo">
-   <b><a href="#nth-of-type-pseudo">#nth-of-type-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-of-type-pseudo" class="dfn-panel" data-for="nth-of-type-pseudo" id="infopanel-for-nth-of-type-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-of-type-pseudo" style="display:none">Info about the ':nth-of-type(An+B)' definition.</span><b><a href="#nth-of-type-pseudo">#nth-of-type-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-of-type-pseudo">13.4.1. 
 :nth-of-type() pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-last-of-type-pseudo">
-   <b><a href="#nth-last-of-type-pseudo">#nth-last-of-type-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-last-of-type-pseudo" class="dfn-panel" data-for="nth-last-of-type-pseudo" id="infopanel-for-nth-last-of-type-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-last-of-type-pseudo" style="display:none">Info about the ':nth-last-of-type(An+B)' definition.</span><b><a href="#nth-last-of-type-pseudo">#nth-last-of-type-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-last-of-type-pseudo">13.4.2. 
 :nth-last-of-type() pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-of-type-pseudo">
-   <b><a href="#first-of-type-pseudo">#first-of-type-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-of-type-pseudo" class="dfn-panel" data-for="first-of-type-pseudo" id="infopanel-for-first-of-type-pseudo" role="dialog">
+   <span id="infopaneltitle-for-first-of-type-pseudo" style="display:none">Info about the ':first-of-type' definition.</span><b><a href="#first-of-type-pseudo">#first-of-type-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-of-type-pseudo">13.4.3. 
 :first-of-type pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-of-type-pseudo">
-   <b><a href="#last-of-type-pseudo">#last-of-type-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-of-type-pseudo" class="dfn-panel" data-for="last-of-type-pseudo" id="infopanel-for-last-of-type-pseudo" role="dialog">
+   <span id="infopaneltitle-for-last-of-type-pseudo" style="display:none">Info about the ':last-of-type' definition.</span><b><a href="#last-of-type-pseudo">#last-of-type-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-of-type-pseudo">13.4.4. 
 :last-of-type pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="only-of-type-pseudo">
-   <b><a href="#only-of-type-pseudo">#only-of-type-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-only-of-type-pseudo" class="dfn-panel" data-for="only-of-type-pseudo" id="infopanel-for-only-of-type-pseudo" role="dialog">
+   <span id="infopaneltitle-for-only-of-type-pseudo" style="display:none">Info about the ':only-of-type' definition.</span><b><a href="#only-of-type-pseudo">#only-of-type-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-only-of-type-pseudo">13.4.5. 
 :only-of-type pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descendant-combinator">
-   <b><a href="#descendant-combinator">#descendant-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descendant-combinator" class="dfn-panel" data-for="descendant-combinator" id="infopanel-for-descendant-combinator" role="dialog">
+   <span id="infopaneltitle-for-descendant-combinator" style="display:none">Info about the 'descendant combinator' definition.</span><b><a href="#descendant-combinator">#descendant-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descendant-combinator">3.1. 
 Structure and Terminology</a> <a href="#ref-for-descendant-combinator①">(2)</a>
@@ -7200,29 +7200,29 @@ Absolutizing a Relative Selector</a> <a href="#ref-for-descendant-combinator③"
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="child-combinator">
-   <b><a href="#child-combinator">#child-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-child-combinator" class="dfn-panel" data-for="child-combinator" id="infopanel-for-child-combinator" role="dialog">
+   <span id="infopaneltitle-for-child-combinator" style="display:none">Info about the 'child combinator' definition.</span><b><a href="#child-combinator">#child-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-combinator">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-sibling-combinator">
-   <b><a href="#next-sibling-combinator">#next-sibling-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-sibling-combinator" class="dfn-panel" data-for="next-sibling-combinator" id="infopanel-for-next-sibling-combinator" role="dialog">
+   <span id="infopaneltitle-for-next-sibling-combinator" style="display:none">Info about the 'next-sibling combinator' definition.</span><b><a href="#next-sibling-combinator">#next-sibling-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-sibling-combinator">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subsequent-sibling-combinator">
-   <b><a href="#subsequent-sibling-combinator">#subsequent-sibling-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subsequent-sibling-combinator" class="dfn-panel" data-for="subsequent-sibling-combinator" id="infopanel-for-subsequent-sibling-combinator" role="dialog">
+   <span id="infopaneltitle-for-subsequent-sibling-combinator" style="display:none">Info about the 'subsequent-sibling combinator' definition.</span><b><a href="#subsequent-sibling-combinator">#subsequent-sibling-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subsequent-sibling-combinator">3.1. 
 Structure and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="column-combinator">
-   <b><a href="#column-combinator">#column-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-column-combinator" class="dfn-panel" data-for="column-combinator" id="infopanel-for-column-combinator" role="dialog">
+   <span id="infopaneltitle-for-column-combinator" style="display:none">Info about the 'column combinator' definition.</span><b><a href="#column-combinator">#column-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-column-combinator">15. 
 Grid-Structural Selectors</a>
@@ -7230,8 +7230,8 @@ Grid-Structural Selectors</a>
 Changes since the 29 September 2011 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-col-pseudo">
-   <b><a href="#nth-col-pseudo">#nth-col-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-col-pseudo" class="dfn-panel" data-for="nth-col-pseudo" id="infopanel-for-nth-col-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-col-pseudo" style="display:none">Info about the ':nth-col(An+B)' definition.</span><b><a href="#nth-col-pseudo">#nth-col-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-col-pseudo">15. 
 Grid-Structural Selectors</a>
@@ -7241,8 +7241,8 @@ Grid-Structural Selectors</a>
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nth-last-col-pseudo">
-   <b><a href="#nth-last-col-pseudo">#nth-last-col-pseudo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nth-last-col-pseudo" class="dfn-panel" data-for="nth-last-col-pseudo" id="infopanel-for-nth-last-col-pseudo" role="dialog">
+   <span id="infopaneltitle-for-nth-last-col-pseudo" style="display:none">Info about the ':nth-last-col(An+B)' definition.</span><b><a href="#nth-last-col-pseudo">#nth-last-col-pseudo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nth-last-col-pseudo">15. 
 Grid-Structural Selectors</a>
@@ -7252,8 +7252,8 @@ Grid-Structural Selectors</a>
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="specificity">
-   <b><a href="#specificity">#specificity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-specificity" class="dfn-panel" data-for="specificity" id="infopanel-for-specificity" role="dialog">
+   <span id="infopaneltitle-for-specificity" style="display:none">Info about the 'specificity' definition.</span><b><a href="#specificity">#specificity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-specificity">19.3. 
 Changes since the 2 May 2013 Working Draft</a>
@@ -7261,8 +7261,8 @@ Changes since the 2 May 2013 Working Draft</a>
 Changes since the 23 August 2012 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-selector-list">
-   <b><a href="#typedef-selector-list">#typedef-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-selector-list" class="dfn-panel" data-for="typedef-selector-list" id="infopanel-for-typedef-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-selector-list" style="display:none">Info about the '&lt;selector-list>' definition.</span><b><a href="#typedef-selector-list">#typedef-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-selector-list">17.1. 
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a>
@@ -7270,22 +7270,22 @@ Changes since the 23 August 2012 Working Draft</a>
 Parse A Selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-complex-selector-list">
-   <b><a href="#typedef-complex-selector-list">#typedef-complex-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-complex-selector-list" class="dfn-panel" data-for="typedef-complex-selector-list" id="infopanel-for-typedef-complex-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-complex-selector-list" style="display:none">Info about the '&lt;complex-selector-list>' definition.</span><b><a href="#typedef-complex-selector-list">#typedef-complex-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-complex-selector-list">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-relative-selector-list">
-   <b><a href="#typedef-relative-selector-list">#typedef-relative-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-relative-selector-list" class="dfn-panel" data-for="typedef-relative-selector-list" id="infopanel-for-typedef-relative-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-relative-selector-list" style="display:none">Info about the '&lt;relative-selector-list>' definition.</span><b><a href="#typedef-relative-selector-list">#typedef-relative-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-relative-selector-list">18.2. 
 Parse A Relative Selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-complex-selector">
-   <b><a href="#typedef-complex-selector">#typedef-complex-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-complex-selector" class="dfn-panel" data-for="typedef-complex-selector" id="infopanel-for-typedef-complex-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-complex-selector" style="display:none">Info about the '&lt;complex-selector>' definition.</span><b><a href="#typedef-complex-selector">#typedef-complex-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-complex-selector">3.1. 
 Structure and Terminology</a>
@@ -7295,8 +7295,8 @@ Grammar</a> <a href="#ref-for-typedef-complex-selector②">(2)</a> <a href="#ref
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a> <a href="#ref-for-typedef-complex-selector⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-relative-selector">
-   <b><a href="#typedef-relative-selector">#typedef-relative-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-relative-selector" class="dfn-panel" data-for="typedef-relative-selector" id="infopanel-for-typedef-relative-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-relative-selector" style="display:none">Info about the '&lt;relative-selector>' definition.</span><b><a href="#typedef-relative-selector">#typedef-relative-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-relative-selector">3.4. 
 Relative Selectors</a>
@@ -7306,8 +7306,8 @@ Grammar</a>
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-compound-selector">
-   <b><a href="#typedef-compound-selector">#typedef-compound-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-compound-selector" class="dfn-panel" data-for="typedef-compound-selector" id="infopanel-for-typedef-compound-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-compound-selector" style="display:none">Info about the '&lt;compound-selector>' definition.</span><b><a href="#typedef-compound-selector">#typedef-compound-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-compound-selector">3.1. 
 Structure and Terminology</a>
@@ -7315,8 +7315,8 @@ Structure and Terminology</a>
 Grammar</a> <a href="#ref-for-typedef-compound-selector②">(2)</a> <a href="#ref-for-typedef-compound-selector③">(3)</a> <a href="#ref-for-typedef-compound-selector④">(4)</a> <a href="#ref-for-typedef-compound-selector⑤">(5)</a> <a href="#ref-for-typedef-compound-selector⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-simple-selector">
-   <b><a href="#typedef-simple-selector">#typedef-simple-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-simple-selector" class="dfn-panel" data-for="typedef-simple-selector" id="infopanel-for-typedef-simple-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-simple-selector" style="display:none">Info about the '&lt;simple-selector>' definition.</span><b><a href="#typedef-simple-selector">#typedef-simple-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-simple-selector">3.1. 
 Structure and Terminology</a>
@@ -7324,92 +7324,92 @@ Structure and Terminology</a>
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-combinator">
-   <b><a href="#typedef-combinator">#typedef-combinator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-combinator" class="dfn-panel" data-for="typedef-combinator" id="infopanel-for-typedef-combinator" role="dialog">
+   <span id="infopaneltitle-for-typedef-combinator" style="display:none">Info about the '&lt;combinator>' definition.</span><b><a href="#typedef-combinator">#typedef-combinator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-combinator">17. 
 Grammar</a> <a href="#ref-for-typedef-combinator①">(2)</a> <a href="#ref-for-typedef-combinator②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-type-selector">
-   <b><a href="#typedef-type-selector">#typedef-type-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-type-selector" class="dfn-panel" data-for="typedef-type-selector" id="infopanel-for-typedef-type-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-type-selector" style="display:none">Info about the '&lt;type-selector>' definition.</span><b><a href="#typedef-type-selector">#typedef-type-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-type-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-type-selector①">(2)</a> <a href="#ref-for-typedef-type-selector②">(3)</a> <a href="#ref-for-typedef-type-selector③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-ns-prefix">
-   <b><a href="#typedef-ns-prefix">#typedef-ns-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-ns-prefix" class="dfn-panel" data-for="typedef-ns-prefix" id="infopanel-for-typedef-ns-prefix" role="dialog">
+   <span id="infopaneltitle-for-typedef-ns-prefix" style="display:none">Info about the '&lt;ns-prefix>' definition.</span><b><a href="#typedef-ns-prefix">#typedef-ns-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ns-prefix">17. 
 Grammar</a> <a href="#ref-for-typedef-ns-prefix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-wq-name">
-   <b><a href="#typedef-wq-name">#typedef-wq-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-wq-name" class="dfn-panel" data-for="typedef-wq-name" id="infopanel-for-typedef-wq-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-wq-name" style="display:none">Info about the '&lt;wq-name>' definition.</span><b><a href="#typedef-wq-name">#typedef-wq-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-wq-name">17. 
 Grammar</a> <a href="#ref-for-typedef-wq-name①">(2)</a> <a href="#ref-for-typedef-wq-name②">(3)</a> <a href="#ref-for-typedef-wq-name③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-subclass-selector">
-   <b><a href="#typedef-subclass-selector">#typedef-subclass-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-subclass-selector" class="dfn-panel" data-for="typedef-subclass-selector" id="infopanel-for-typedef-subclass-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-subclass-selector" style="display:none">Info about the '&lt;subclass-selector>' definition.</span><b><a href="#typedef-subclass-selector">#typedef-subclass-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-subclass-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-subclass-selector①">(2)</a> <a href="#ref-for-typedef-subclass-selector②">(3)</a> <a href="#ref-for-typedef-subclass-selector③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-id-selector">
-   <b><a href="#typedef-id-selector">#typedef-id-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-id-selector" class="dfn-panel" data-for="typedef-id-selector" id="infopanel-for-typedef-id-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-id-selector" style="display:none">Info about the '&lt;id-selector>' definition.</span><b><a href="#typedef-id-selector">#typedef-id-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-id-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-id-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-class-selector">
-   <b><a href="#typedef-class-selector">#typedef-class-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-class-selector" class="dfn-panel" data-for="typedef-class-selector" id="infopanel-for-typedef-class-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-class-selector" style="display:none">Info about the '&lt;class-selector>' definition.</span><b><a href="#typedef-class-selector">#typedef-class-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-class-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-class-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attribute-selector">
-   <b><a href="#typedef-attribute-selector">#typedef-attribute-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attribute-selector" class="dfn-panel" data-for="typedef-attribute-selector" id="infopanel-for-typedef-attribute-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-attribute-selector" style="display:none">Info about the '&lt;attribute-selector>' definition.</span><b><a href="#typedef-attribute-selector">#typedef-attribute-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attribute-selector">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attr-matcher">
-   <b><a href="#typedef-attr-matcher">#typedef-attr-matcher</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attr-matcher" class="dfn-panel" data-for="typedef-attr-matcher" id="infopanel-for-typedef-attr-matcher" role="dialog">
+   <span id="infopaneltitle-for-typedef-attr-matcher" style="display:none">Info about the '&lt;attr-matcher>' definition.</span><b><a href="#typedef-attr-matcher">#typedef-attr-matcher</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attr-matcher">17. 
 Grammar</a> <a href="#ref-for-typedef-attr-matcher①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-attr-modifier">
-   <b><a href="#typedef-attr-modifier">#typedef-attr-modifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-attr-modifier" class="dfn-panel" data-for="typedef-attr-modifier" id="infopanel-for-typedef-attr-modifier" role="dialog">
+   <span id="infopaneltitle-for-typedef-attr-modifier" style="display:none">Info about the '&lt;attr-modifier>' definition.</span><b><a href="#typedef-attr-modifier">#typedef-attr-modifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-attr-modifier">17. 
 Grammar</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-pseudo-class-selector">
-   <b><a href="#typedef-pseudo-class-selector">#typedef-pseudo-class-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-pseudo-class-selector" class="dfn-panel" data-for="typedef-pseudo-class-selector" id="infopanel-for-typedef-pseudo-class-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-pseudo-class-selector" style="display:none">Info about the '&lt;pseudo-class-selector>' definition.</span><b><a href="#typedef-pseudo-class-selector">#typedef-pseudo-class-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-class-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-pseudo-class-selector①">(2)</a> <a href="#ref-for-typedef-pseudo-class-selector②">(3)</a> <a href="#ref-for-typedef-pseudo-class-selector③">(4)</a> <a href="#ref-for-typedef-pseudo-class-selector④">(5)</a> <a href="#ref-for-typedef-pseudo-class-selector⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-pseudo-element-selector">
-   <b><a href="#typedef-pseudo-element-selector">#typedef-pseudo-element-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-pseudo-element-selector" class="dfn-panel" data-for="typedef-pseudo-element-selector" id="infopanel-for-typedef-pseudo-element-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-pseudo-element-selector" style="display:none">Info about the '&lt;pseudo-element-selector>' definition.</span><b><a href="#typedef-pseudo-element-selector">#typedef-pseudo-element-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-element-selector">17. 
 Grammar</a> <a href="#ref-for-typedef-pseudo-element-selector①">(2)</a> <a href="#ref-for-typedef-pseudo-element-selector②">(3)</a> <a href="#ref-for-typedef-pseudo-element-selector③">(4)</a> <a href="#ref-for-typedef-pseudo-element-selector④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-forgiving-selector-list">
-   <b><a href="#typedef-forgiving-selector-list">#typedef-forgiving-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-forgiving-selector-list" class="dfn-panel" data-for="typedef-forgiving-selector-list" id="infopanel-for-typedef-forgiving-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-forgiving-selector-list" style="display:none">Info about the '&lt;forgiving-selector-list>' definition.</span><b><a href="#typedef-forgiving-selector-list">#typedef-forgiving-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-forgiving-selector-list">4.2. 
 The Matches-Any Pseudo-class: :is()</a>
@@ -7417,15 +7417,15 @@ The Matches-Any Pseudo-class: :is()</a>
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a> <a href="#ref-for-typedef-forgiving-selector-list②">(2)</a> <a href="#ref-for-typedef-forgiving-selector-list③">(3)</a> <a href="#ref-for-typedef-forgiving-selector-list④">(4)</a> <a href="#ref-for-typedef-forgiving-selector-list⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-as-a-forgiving-selector-list">
-   <b><a href="#parse-as-a-forgiving-selector-list">#parse-as-a-forgiving-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-as-a-forgiving-selector-list" class="dfn-panel" data-for="parse-as-a-forgiving-selector-list" id="infopanel-for-parse-as-a-forgiving-selector-list" role="dialog">
+   <span id="infopaneltitle-for-parse-as-a-forgiving-selector-list" style="display:none">Info about the 'parse as a forgiving selector list' definition.</span><b><a href="#parse-as-a-forgiving-selector-list">#parse-as-a-forgiving-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-as-a-forgiving-selector-list">17.1. 
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-forgiving-relative-selector-list">
-   <b><a href="#typedef-forgiving-relative-selector-list">#typedef-forgiving-relative-selector-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-forgiving-relative-selector-list" class="dfn-panel" data-for="typedef-forgiving-relative-selector-list" id="infopanel-for-typedef-forgiving-relative-selector-list" role="dialog">
+   <span id="infopaneltitle-for-typedef-forgiving-relative-selector-list" style="display:none">Info about the '&lt;forgiving-relative-selector-list>' definition.</span><b><a href="#typedef-forgiving-relative-selector-list">#typedef-forgiving-relative-selector-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-forgiving-relative-selector-list">4.5. 
 The Relational Pseudo-class: :has()</a>
@@ -7433,8 +7433,8 @@ The Relational Pseudo-class: :has()</a>
 &lt;forgiving-selector-list> and &lt;forgiving-relative-selector-list></a> <a href="#ref-for-typedef-forgiving-relative-selector-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-selector-against-an-element">
-   <b><a href="#match-a-selector-against-an-element">#match-a-selector-against-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-selector-against-an-element" class="dfn-panel" data-for="match-a-selector-against-an-element" id="infopanel-for-match-a-selector-against-an-element" role="dialog">
+   <span id="infopaneltitle-for-match-a-selector-against-an-element" style="display:none">Info about the 'match a selector against an element' definition.</span><b><a href="#match-a-selector-against-an-element">#match-a-selector-against-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-an-element">18.4. 
 Match a Selector Against a Pseudo-element</a>
@@ -7442,88 +7442,144 @@ Match a Selector Against a Pseudo-element</a>
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-complex-selector-against-an-element">
-   <b><a href="#match-a-complex-selector-against-an-element">#match-a-complex-selector-against-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-complex-selector-against-an-element" class="dfn-panel" data-for="match-a-complex-selector-against-an-element" id="infopanel-for-match-a-complex-selector-against-an-element" role="dialog">
+   <span id="infopaneltitle-for-match-a-complex-selector-against-an-element" style="display:none">Info about the 'match a complex selector against an element' definition.</span><b><a href="#match-a-complex-selector-against-an-element">#match-a-complex-selector-against-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-complex-selector-against-an-element">18.4. 
 Match a Selector Against a Pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-selector-against-a-pseudo-element">
-   <b><a href="#match-a-selector-against-a-pseudo-element">#match-a-selector-against-a-pseudo-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-selector-against-a-pseudo-element" class="dfn-panel" data-for="match-a-selector-against-a-pseudo-element" id="infopanel-for-match-a-selector-against-a-pseudo-element" role="dialog">
+   <span id="infopaneltitle-for-match-a-selector-against-a-pseudo-element" style="display:none">Info about the 'match a selector against a pseudo-element' definition.</span><b><a href="#match-a-selector-against-a-pseudo-element">#match-a-selector-against-a-pseudo-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-a-pseudo-element">18.5. 
 Match a Selector Against a Tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-selector-against-a-tree">
-   <b><a href="#match-a-selector-against-a-tree">#match-a-selector-against-a-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-selector-against-a-tree" class="dfn-panel" data-for="match-a-selector-against-a-tree" id="infopanel-for-match-a-selector-against-a-tree" role="dialog">
+   <span id="infopaneltitle-for-match-a-selector-against-a-tree" style="display:none">Info about the 'match a selector against a tree' definition.</span><b><a href="#match-a-selector-against-a-tree">#match-a-selector-against-a-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-a-tree">19.3. 
 Changes since the 2 May 2013 Working Draft</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unknown--webkit--pseudo-elements">
-   <b><a href="#unknown--webkit--pseudo-elements">#unknown--webkit--pseudo-elements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unknown--webkit--pseudo-elements" class="dfn-panel" data-for="unknown--webkit--pseudo-elements" id="infopanel-for-unknown--webkit--pseudo-elements" role="dialog">
+   <span id="infopaneltitle-for-unknown--webkit--pseudo-elements" style="display:none">Info about the 'unknown -webkit- pseudo-elements' definition.</span><b><a href="#unknown--webkit--pseudo-elements">#unknown--webkit--pseudo-elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknown--webkit--pseudo-elements"> Appendix B: Obsolete but Required Parsing Quirks for Web Compat</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/csswg-drafts/selectors-nonelement-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/selectors-nonelement-1/Overview.html
@@ -463,43 +463,43 @@ on screen, on paper, etc.
    <li><a href="#typedef-na-name">&lt;na-name></a><span>, in § 2.1</span>
    <li><a href="#typedef-na-prefix">&lt;na-prefix></a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-namespace-prefix">
-   <a href="https://www.w3.org/TR/css-namespaces-3/#namespace-prefix">https://www.w3.org/TR/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespace-prefix" class="dfn-panel" data-for="term-for-namespace-prefix" id="infopanel-for-term-for-namespace-prefix" role="menu">
+   <span id="infopaneltitle-for-term-for-namespace-prefix" style="display:none">Info about the 'namespace prefix' external reference.</span><a href="https://www.w3.org/TR/css-namespaces-3/#namespace-prefix">https://www.w3.org/TR/css-namespaces-3/#namespace-prefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespace-prefix">2.1. 
 Attribute node selector</a> <a href="#ref-for-namespace-prefix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident">
-   <a href="https://www.w3.org/TR/css-values-4/#typedef-ident">https://www.w3.org/TR/css-values-4/#typedef-ident</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident" class="dfn-panel" data-for="term-for-typedef-ident" id="infopanel-for-term-for-typedef-ident" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident" style="display:none">Info about the '&lt;ident>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#typedef-ident">https://www.w3.org/TR/css-values-4/#typedef-ident</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident">2.1. 
 Attribute node selector</a> <a href="#ref-for-typedef-ident①">(2)</a> <a href="#ref-for-typedef-ident②">(3)</a> <a href="#ref-for-typedef-ident③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-opt">https://www.w3.org/TR/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">2.1. 
 Attribute node selector</a> <a href="#ref-for-mult-opt①">(2)</a> <a href="#ref-for-mult-opt②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2.1. 
 Attribute node selector</a> <a href="#ref-for-comb-one①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://www.w3.org/TR/selectors-4/#originating-element">https://www.w3.org/TR/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://www.w3.org/TR/selectors-4/#originating-element">https://www.w3.org/TR/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">2.1. 
 Attribute node selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://www.w3.org/TR/selectors-4/#pseudo-element">https://www.w3.org/TR/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://www.w3.org/TR/selectors-4/#pseudo-element">https://www.w3.org/TR/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">2.1. 
 Attribute node selector</a>
@@ -545,29 +545,29 @@ Attribute node selector</a>
    <dt id="biblio-selectors-api">[SELECTORS-API]
    <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/"><cite>DOM Standard</cite></a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
   </dl>
-  <aside class="dfn-panel" data-for="attribute-node-selector">
-   <b><a href="#attribute-node-selector">#attribute-node-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribute-node-selector" class="dfn-panel" data-for="attribute-node-selector" id="infopanel-for-attribute-node-selector" role="dialog">
+   <span id="infopaneltitle-for-attribute-node-selector" style="display:none">Info about the 'attribute node selector' definition.</span><b><a href="#attribute-node-selector">#attribute-node-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-node-selector">2.1. 
 Attribute node selector</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-namespace-attr">
-   <b><a href="#typedef-namespace-attr">#typedef-namespace-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-namespace-attr" class="dfn-panel" data-for="typedef-namespace-attr" id="infopanel-for-typedef-namespace-attr" role="dialog">
+   <span id="infopaneltitle-for-typedef-namespace-attr" style="display:none">Info about the '&lt;namespace-attr>' definition.</span><b><a href="#typedef-namespace-attr">#typedef-namespace-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-namespace-attr">2.1. 
 Attribute node selector</a> <a href="#ref-for-typedef-namespace-attr①">(2)</a> <a href="#ref-for-typedef-namespace-attr②">(3)</a> <a href="#ref-for-typedef-namespace-attr③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-na-prefix">
-   <b><a href="#typedef-na-prefix">#typedef-na-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-na-prefix" class="dfn-panel" data-for="typedef-na-prefix" id="infopanel-for-typedef-na-prefix" role="dialog">
+   <span id="infopaneltitle-for-typedef-na-prefix" style="display:none">Info about the '&lt;na-prefix>' definition.</span><b><a href="#typedef-na-prefix">#typedef-na-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-na-prefix">2.1. 
 Attribute node selector</a> <a href="#ref-for-typedef-na-prefix①">(2)</a> <a href="#ref-for-typedef-na-prefix②">(3)</a> <a href="#ref-for-typedef-na-prefix③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-na-name">
-   <b><a href="#typedef-na-name">#typedef-na-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-na-name" class="dfn-panel" data-for="typedef-na-name" id="infopanel-for-typedef-na-name" role="dialog">
+   <span id="infopaneltitle-for-typedef-na-name" style="display:none">Info about the '&lt;na-name>' definition.</span><b><a href="#typedef-na-name">#typedef-na-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-na-name">2.1. 
 Attribute node selector</a> <a href="#ref-for-typedef-na-name①">(2)</a> <a href="#ref-for-typedef-na-name②">(3)</a>
@@ -575,57 +575,113 @@ Attribute node selector</a> <a href="#ref-for-typedef-na-name①">(2)</a> <a hre
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
+++ b/tests/github/w3c/csswg-drafts/web-animations-1/Overview.html
@@ -6666,104 +6666,104 @@ according to its type, or falling back to <a data-link-type="dfn" href="#discret
    <li><a href="#dom-animationeffect-updatetiming">updateTiming()</a><span>, in § 6.5</span>
    <li><a href="#dom-animationeffect-updatetiming">updateTiming(timing)</a><span>, in § 6.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-fill-mode">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-fill-mode" class="dfn-panel" data-for="term-for-propdef-animation-fill-mode" id="infopanel-for-term-for-propdef-animation-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-fill-mode" style="display:none">Info about the 'animation-fill-mode' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-fill-mode">4.6. Fill behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">5.4.1. Animation classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-events">
-   <a href="https://drafts.csswg.org/css-animations/#events">https://drafts.csswg.org/css-animations/#events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-events" class="dfn-panel" data-for="term-for-events" id="infopanel-for-term-for-events" role="menu">
+   <span id="infopaneltitle-for-term-for-events" style="display:none">Info about the 'events from css animations' external reference.</span><a href="https://drafts.csswg.org/css-animations/#events">https://drafts.csswg.org/css-animations/#events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-events">4.4.18. Animation events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssanimation">
-   <a href="https://drafts.csswg.org/css-animations-2/#cssanimation">https://drafts.csswg.org/css-animations-2/#cssanimation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssanimation" class="dfn-panel" data-for="term-for-cssanimation" id="infopanel-for-term-for-cssanimation" role="menu">
+   <span id="infopaneltitle-for-term-for-cssanimation" style="display:none">Info about the 'CSSAnimation' external reference.</span><a href="https://drafts.csswg.org/css-animations-2/#cssanimation">https://drafts.csswg.org/css-animations-2/#cssanimation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssanimation">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-owning-element">
-   <a href="https://drafts.csswg.org/css-animations-2/#owning-element">https://drafts.csswg.org/css-animations-2/#owning-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-owning-element" class="dfn-panel" data-for="term-for-owning-element" id="infopanel-for-term-for-owning-element" role="menu">
+   <span id="infopaneltitle-for-term-for-owning-element" style="display:none">Info about the 'owning element (animation)' external reference.</span><a href="https://drafts.csswg.org/css-animations-2/#owning-element">https://drafts.csswg.org/css-animations-2/#owning-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-owning-element">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">5.2. Animating properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">5.2. Animating properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top" class="dfn-panel" data-for="term-for-propdef-border-top" id="infopanel-for-term-for-propdef-border-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top" style="display:none">Info about the 'border-top' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-propdef-border-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-propdef-border-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">Animation of box-shadow</a> <a href="#ref-for-propdef-box-shadow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">5.2. Animating properties</a>
     <li><a href="#ref-for-computed-value①">5.2.1. Custom Properties</a>
@@ -6771,57 +6771,57 @@ according to its type, or falling back to <a data-link-type="dfn" href="#discret
     <li><a href="#ref-for-computed-value⑥">5.3.4. The effect value of a keyframe effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">6.4. The Animation interface</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">Animation of visibility</a> <a href="#ref-for-propdef-visibility①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-visibility-visible">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-visibility-visible" class="dfn-panel" data-for="term-for-valdef-visibility-visible" id="infopanel-for-term-for-valdef-visibility-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-visibility-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-visibility-visible">https://drafts.csswg.org/css-display-3/#valdef-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-visibility-visible">Animation of visibility</a> <a href="#ref-for-valdef-visibility-visible①">(2)</a> <a href="#ref-for-valdef-visibility-visible②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linear-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-1/#linear-easing-function">https://drafts.csswg.org/css-easing-1/#linear-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linear-easing-function" class="dfn-panel" data-for="term-for-linear-easing-function" id="infopanel-for-term-for-linear-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-linear-easing-function" style="display:none">Info about the 'linear timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-1/#linear-easing-function">https://drafts.csswg.org/css-easing-1/#linear-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-easing-function">4.10. Time transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-easing-function" class="dfn-panel" data-for="term-for-typedef-easing-function" id="infopanel-for-term-for-typedef-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-easing-function" style="display:none">Info about the '&lt;easing-function>' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#typedef-easing-function">https://drafts.csswg.org/css-easing-2/#typedef-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-easing-function">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-typedef-easing-function①">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-before-flag">
-   <a href="https://drafts.csswg.org/css-easing-2/#before-flag">https://drafts.csswg.org/css-easing-2/#before-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-before-flag" class="dfn-panel" data-for="term-for-before-flag" id="infopanel-for-term-for-before-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-before-flag" style="display:none">Info about the 'before flag' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#before-flag">https://drafts.csswg.org/css-easing-2/#before-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-flag">4.10.1. Calculating the transformed progress</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-input-progress-value">
-   <a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-input-progress-value" class="dfn-panel" data-for="term-for-input-progress-value" id="infopanel-for-term-for-input-progress-value" role="menu">
+   <span id="infopaneltitle-for-term-for-input-progress-value" style="display:none">Info about the 'input progress value' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#input-progress-value">https://drafts.csswg.org/css-easing-2/#input-progress-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-progress-value">4.10.1. Calculating the transformed progress</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">4.8.3.3. Calculating the simple iteration progress</a>
     <li><a href="#ref-for-easing-function①">4.10. Time transformations</a> <a href="#ref-for-easing-function②">(2)</a> <a href="#ref-for-easing-function③">(3)</a>
@@ -6835,75 +6835,75 @@ according to its type, or falling back to <a data-link-type="dfn" href="#discret
 argument</a> <a href="#ref-for-easing-function①④">(2)</a> <a href="#ref-for-easing-function①⑤">(3)</a> <a href="#ref-for-easing-function①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">5.3.2. Computing property values</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a>
     <li><a href="#ref-for-propdef-font-size③">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-propdef-font-size④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">Animation of font-weight</a> <a href="#ref-for-propdef-font-weight①">(2)</a> <a href="#ref-for-propdef-font-weight②">(3)</a> <a href="#ref-for-propdef-font-weight③">(4)</a> <a href="#ref-for-propdef-font-weight④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-css-registerproperty">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty">https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-css-registerproperty" class="dfn-panel" data-for="term-for-dom-css-registerproperty" id="infopanel-for-term-for-dom-css-registerproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-css-registerproperty" style="display:none">Info about the 'registerProperty(definition)' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty">https://drafts.css-houdini.org/css-properties-values-api-1/#dom-css-registerproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-registerproperty">5.2.1. Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntax-definition">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntax-definition" class="dfn-panel" data-for="term-for-syntax-definition" id="infopanel-for-term-for-syntax-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-syntax-definition" style="display:none">Info about the 'syntax definition' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#syntax-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-definition">5.2.1. Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-universal-syntax-definition">
-   <a href="https://drafts.css-houdini.org/css-properties-values-api-1/#universal-syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#universal-syntax-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-universal-syntax-definition" class="dfn-panel" data-for="term-for-universal-syntax-definition" id="infopanel-for-term-for-universal-syntax-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-universal-syntax-definition" style="display:none">Info about the 'universal syntax definition' external reference.</span><a href="https://drafts.css-houdini.org/css-properties-values-api-1/#universal-syntax-definition">https://drafts.css-houdini.org/css-properties-values-api-1/#universal-syntax-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-universal-syntax-definition">5.2.1. Custom Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-part">
-   <a href="https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part">https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-part" class="dfn-panel" data-for="term-for-selectordef-part" id="infopanel-for-term-for-selectordef-part" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-part" style="display:none">Info about the '::part()' external reference.</span><a href="https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part">https://drafts.csswg.org/css-shadow-parts-1/#selectordef-part</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-part">5.3. Keyframe effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-attribute">
-   <a href="https://drafts.csswg.org/css-style-attr/#style-attribute">https://drafts.csswg.org/css-style-attr/#style-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-attribute" class="dfn-panel" data-for="term-for-style-attribute" id="infopanel-for-term-for-style-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-style-attribute" style="display:none">Info about the 'style attribute' external reference.</span><a href="https://drafts.csswg.org/css-style-attr/#style-attribute">https://drafts.csswg.org/css-style-attr/#style-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-attribute">6.4. The Animation interface</a> <a href="#ref-for-style-attribute①">(2)</a> <a href="#ref-for-style-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-after-change-style">
-   <a href="https://drafts.csswg.org/css-transitions-1/#after-change-style">https://drafts.csswg.org/css-transitions-1/#after-change-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-after-change-style" class="dfn-panel" data-for="term-for-after-change-style" id="infopanel-for-term-for-after-change-style" role="menu">
+   <span id="infopaneltitle-for-term-for-after-change-style" style="display:none">Info about the 'after-change style' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#after-change-style">https://drafts.csswg.org/css-transitions-1/#after-change-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-after-change-style">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-before-change-style">
-   <a href="https://drafts.csswg.org/css-transitions-1/#before-change-style">https://drafts.csswg.org/css-transitions-1/#before-change-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-before-change-style" class="dfn-panel" data-for="term-for-before-change-style" id="infopanel-for-term-for-before-change-style" role="menu">
+   <span id="infopaneltitle-for-term-for-before-change-style" style="display:none">Info about the 'before-change style' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#before-change-style">https://drafts.csswg.org/css-transitions-1/#before-change-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-change-style">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-events">
-   <a href="https://drafts.csswg.org/css-transitions/#transition-events">https://drafts.csswg.org/css-transitions/#transition-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-events" class="dfn-panel" data-for="term-for-transition-events" id="infopanel-for-term-for-transition-events" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-events" style="display:none">Info about the 'events from css transitions' external reference.</span><a href="https://drafts.csswg.org/css-transitions/#transition-events">https://drafts.csswg.org/css-transitions/#transition-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-events">4.4.18. Animation events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-style-change-event">
-   <a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-style-change-event" class="dfn-panel" data-for="term-for-style-change-event" id="infopanel-for-term-for-style-change-event" role="menu">
+   <span id="infopaneltitle-for-term-for-style-change-event" style="display:none">Info about the 'style change event' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#style-change-event">https://drafts.csswg.org/css-transitions-1/#style-change-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-change-event">6.4. The Animation interface</a>
     <li><a href="#ref-for-style-change-event①">6.8. The Animatable interface mixin</a>
@@ -6911,26 +6911,26 @@ argument</a> <a href="#ref-for-easing-function①④">(2)</a> <a href="#ref-for-
     <li><a href="#ref-for-style-change-event③">6.13. Model liveness</a> <a href="#ref-for-style-change-event④">(2)</a> <a href="#ref-for-style-change-event⑤">(3)</a> <a href="#ref-for-style-change-event⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transitionend">
-   <a href="https://drafts.csswg.org/css-transitions/#transitionend">https://drafts.csswg.org/css-transitions/#transitionend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transitionend" class="dfn-panel" data-for="term-for-transitionend" id="infopanel-for-term-for-transitionend" role="menu">
+   <span id="infopaneltitle-for-term-for-transitionend" style="display:none">Info about the 'transitionend' external reference.</span><a href="https://drafts.csswg.org/css-transitions/#transitionend">https://drafts.csswg.org/css-transitions/#transitionend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transitionend">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-owning-element">
-   <a href="https://drafts.csswg.org/css-transitions-2/#owning-element">https://drafts.csswg.org/css-transitions-2/#owning-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-owning-element" class="dfn-panel" data-for="term-for-owning-element" id="infopanel-for-term-for-owning-element①" role="menu">
+   <span id="infopaneltitle-for-term-for-owning-element①" style="display:none">Info about the 'owning element (transition)' external reference.</span><a href="https://drafts.csswg.org/css-transitions-2/#owning-element">https://drafts.csswg.org/css-transitions-2/#owning-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-owning-element①">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">Animation of font-weight</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation" style="display:none">Info about the 'interpolate' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">5.2. Animating properties</a>
     <li><a href="#ref-for-interpolation①">5.3.4. The effect value of a keyframe effect</a>
@@ -6938,8 +6938,8 @@ argument</a> <a href="#ref-for-easing-function①④">(2)</a> <a href="#ref-for-
     <li><a href="#ref-for-interpolation③">Animation of visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interpolation">
-   <a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interpolation" class="dfn-panel" data-for="term-for-interpolation" id="infopanel-for-term-for-interpolation①" role="menu">
+   <span id="infopaneltitle-for-term-for-interpolation①" style="display:none">Info about the 'interpolation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#interpolation">https://drafts.csswg.org/css-values-4/#interpolation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interpolation">5.2. Animating properties</a>
     <li><a href="#ref-for-interpolation①">5.3.4. The effect value of a keyframe effect</a>
@@ -6947,22 +6947,22 @@ argument</a> <a href="#ref-for-easing-function①④">(2)</a> <a href="#ref-for-
     <li><a href="#ref-for-interpolation③">Animation of visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-not-additive">
-   <a href="https://drafts.csswg.org/css-values-4/#not-additive">https://drafts.csswg.org/css-values-4/#not-additive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-not-additive" class="dfn-panel" data-for="term-for-not-additive" id="infopanel-for-term-for-not-additive" role="menu">
+   <span id="infopaneltitle-for-term-for-not-additive" style="display:none">Info about the 'not additive' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#not-additive">https://drafts.csswg.org/css-values-4/#not-additive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-additive">5.2. Animating properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accumulation">
-   <a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accumulation" class="dfn-panel" data-for="term-for-accumulation" id="infopanel-for-term-for-accumulation" role="menu">
+   <span id="infopaneltitle-for-term-for-accumulation" style="display:none">Info about the 'value accumulation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accumulation">5.4.4. Effect composition</a> <a href="#ref-for-accumulation①">(2)</a>
     <li><a href="#ref-for-accumulation②">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
     <li><a href="#ref-for-accumulation③">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-addition">
-   <a href="https://drafts.csswg.org/css-values-4/#addition">https://drafts.csswg.org/css-values-4/#addition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-addition" class="dfn-panel" data-for="term-for-addition" id="infopanel-for-term-for-addition" role="menu">
+   <span id="infopaneltitle-for-term-for-addition" style="display:none">Info about the 'value addition' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#addition">https://drafts.csswg.org/css-values-4/#addition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-addition">5.4.4. Effect composition</a> <a href="#ref-for-addition①">(2)</a>
     <li><a href="#ref-for-addition②">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
@@ -6970,109 +6970,109 @@ argument</a> <a href="#ref-for-easing-function①④">(2)</a> <a href="#ref-for-
     <li><a href="#ref-for-addition④">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-custom-property-name">
-   <a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-custom-property-name" class="dfn-panel" data-for="term-for-typedef-custom-property-name" id="infopanel-for-term-for-typedef-custom-property-name" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-custom-property-name" style="display:none">Info about the '&lt;custom-property-name>' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name">https://drafts.csswg.org/css-variables-2/#typedef-custom-property-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-custom-property-name">6.6.2. Property names and IDL names</a> <a href="#ref-for-typedef-custom-property-name①">(2)</a>
     <li><a href="#ref-for-typedef-custom-property-name②">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-property">
-   <a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-property" class="dfn-panel" data-for="term-for-custom-property" id="infopanel-for-term-for-custom-property" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-property" style="display:none">Info about the 'custom property' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#custom-property">https://drafts.csswg.org/css-variables-2/#custom-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-property">5.2.1. Custom Properties</a> <a href="#ref-for-custom-property①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-logical-to-physical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical">https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-logical-to-physical" class="dfn-panel" data-for="term-for-logical-to-physical" id="infopanel-for-term-for-logical-to-physical" role="menu">
+   <span id="infopaneltitle-for-term-for-logical-to-physical" style="display:none">Info about the 'equivalent physical property' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical">https://drafts.csswg.org/css-writing-modes-4/#logical-to-physical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logical-to-physical">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">5.3.3. Calculating computed keyframes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">6.6.2. Property names and IDL names</a> <a href="#ref-for-propdef-float①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssomstring">
-   <a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssomstring" class="dfn-panel" data-for="term-for-cssomstring" id="infopanel-for-term-for-cssomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-cssomstring" style="display:none">Info about the 'CSSOMString' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssomstring">https://drafts.csswg.org/cssom-1/#cssomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssomstring">6.6. The KeyframeEffect interface</a> <a href="#ref-for-cssomstring①">(2)</a>
     <li><a href="#ref-for-cssomstring②">6.6.4. The KeyframeEffectOptions dictionary</a> <a href="#ref-for-cssomstring③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-declaration-block">
-   <a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">https://drafts.csswg.org/cssom-1/#css-declaration-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-declaration-block" class="dfn-panel" data-for="term-for-css-declaration-block" id="infopanel-for-term-for-css-declaration-block" role="menu">
+   <span id="infopaneltitle-for-term-for-css-declaration-block" style="display:none">Info about the 'css declaration block' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#css-declaration-block">https://drafts.csswg.org/cssom-1/#css-declaration-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-declaration-block">6.4. The Animation interface</a> <a href="#ref-for-css-declaration-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-property-to-idl-attribute">
-   <a href="https://drafts.csswg.org/cssom/#css-property-to-idl-attribute">https://drafts.csswg.org/cssom/#css-property-to-idl-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-property-to-idl-attribute" class="dfn-panel" data-for="term-for-css-property-to-idl-attribute" id="infopanel-for-term-for-css-property-to-idl-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-css-property-to-idl-attribute" style="display:none">Info about the 'css property to idl attribute' external reference.</span><a href="https://drafts.csswg.org/cssom/#css-property-to-idl-attribute">https://drafts.csswg.org/cssom/#css-property-to-idl-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-property-to-idl-attribute">5.3.3. Calculating computed keyframes</a>
     <li><a href="#ref-for-css-property-to-idl-attribute①">6.6.2. Property names and IDL names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-attribute-to-css-property">
-   <a href="https://drafts.csswg.org/cssom/#idl-attribute-to-css-property">https://drafts.csswg.org/cssom/#idl-attribute-to-css-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-attribute-to-css-property" class="dfn-panel" data-for="term-for-idl-attribute-to-css-property" id="infopanel-for-term-for-idl-attribute-to-css-property" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-attribute-to-css-property" style="display:none">Info about the 'idl attribute to css property' external reference.</span><a href="https://drafts.csswg.org/cssom/#idl-attribute-to-css-property">https://drafts.csswg.org/cssom/#idl-attribute-to-css-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-attribute-to-css-property">6.6.2. Property names and IDL names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node">
-   <a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" class="dfn-panel" data-for="term-for-cssstyledeclaration-owner-node" id="infopanel-for-term-for-cssstyledeclaration-owner-node" role="menu">
+   <span id="infopaneltitle-for-term-for-cssstyledeclaration-owner-node" style="display:none">Info about the 'owner node' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node">https://drafts.csswg.org/cssom-1/#cssstyledeclaration-owner-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cssstyledeclaration-owner-node">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-css-value">
-   <a href="https://drafts.csswg.org/cssom/#serialize-a-css-value">https://drafts.csswg.org/cssom/#serialize-a-css-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-css-value" class="dfn-panel" data-for="term-for-serialize-a-css-value" id="infopanel-for-term-for-serialize-a-css-value" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-css-value" style="display:none">Info about the 'serialize a css value' external reference.</span><a href="https://drafts.csswg.org/cssom/#serialize-a-css-value">https://drafts.csswg.org/cssom/#serialize-a-css-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-css-value">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-a-css-declaration">
-   <a href="https://drafts.csswg.org/cssom-1/#set-a-css-declaration">https://drafts.csswg.org/cssom-1/#set-a-css-declaration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-a-css-declaration" class="dfn-panel" data-for="term-for-set-a-css-declaration" id="infopanel-for-term-for-set-a-css-declaration" role="menu">
+   <span id="infopaneltitle-for-term-for-set-a-css-declaration" style="display:none">Info about the 'set a css declaration' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#set-a-css-declaration">https://drafts.csswg.org/cssom-1/#set-a-css-declaration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-a-css-declaration">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-style-attribute-for">
-   <a href="https://drafts.csswg.org/cssom-1/#update-style-attribute-for">https://drafts.csswg.org/cssom-1/#update-style-attribute-for</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-style-attribute-for" class="dfn-panel" data-for="term-for-update-style-attribute-for" id="infopanel-for-term-for-update-style-attribute-for" role="menu">
+   <span id="infopaneltitle-for-term-for-update-style-attribute-for" style="display:none">Info about the 'update style attribute for' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#update-style-attribute-for">https://drafts.csswg.org/cssom-1/#update-style-attribute-for</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-style-attribute-for">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a> <a href="#ref-for-documentorshadowroot①">(2)</a>
     <li><a href="#ref-for-documentorshadowroot②">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">5.3. Keyframe effects</a> <a href="#ref-for-element①">(2)</a>
     <li><a href="#ref-for-element②">5.3.2. Computing property values</a>
@@ -7080,66 +7080,66 @@ argument</a>
     <li><a href="#ref-for-element⑧">6.11. Extensions to the Element interface</a> <a href="#ref-for-element⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadowroot">
-   <a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadowroot" class="dfn-panel" data-for="term-for-shadowroot" id="infopanel-for-term-for-shadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-shadowroot" style="display:none">Info about the 'ShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child" style="display:none">Info about the 'child' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constructing-events">
-   <a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructing-events" class="dfn-panel" data-for="term-for-constructing-events" id="infopanel-for-term-for-constructing-events" role="menu">
+   <span id="infopaneltitle-for-term-for-constructing-events" style="display:none">Info about the 'constructing events' external reference.</span><a href="https://dom.spec.whatwg.org/#constructing-events">https://dom.spec.whatwg.org/#constructing-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructing-events">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'create an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-concept-event-create①">4.4.14. Canceling an animation</a>
     <li><a href="#ref-for-concept-event-create②">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-descendant" class="dfn-panel" data-for="term-for-concept-tree-descendant" id="infopanel-for-term-for-concept-tree-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-descendant" style="display:none">Info about the 'descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-descendant">https://dom.spec.whatwg.org/#concept-tree-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">5.5.2. Removing replaced animations</a>
     <li><a href="#ref-for-concept-tree-descendant①">6.8. The Animatable interface mixin</a>
     <li><a href="#ref-for-concept-tree-descendant②">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">4.3. Timelines</a>
     <li><a href="#ref-for-concept-event-dispatch①">4.4.12. Updating the finished state</a>
@@ -7147,135 +7147,135 @@ argument</a>
     <li><a href="#ref-for-concept-event-dispatch③">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attribute-has">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attribute-has">https://dom.spec.whatwg.org/#concept-element-attribute-has</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attribute-has" class="dfn-panel" data-for="term-for-concept-element-attribute-has" id="infopanel-for-term-for-concept-element-attribute-has" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attribute-has" style="display:none">Info about the 'has an attribute' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attribute-has">https://dom.spec.whatwg.org/#concept-element-attribute-has</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute-has">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-inclusive-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant">https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-inclusive-descendant" class="dfn-panel" data-for="term-for-concept-tree-inclusive-descendant" id="infopanel-for-term-for-concept-tree-inclusive-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-inclusive-descendant" style="display:none">Info about the 'inclusive descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant">https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-inclusive-descendant">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-root" class="dfn-panel" data-for="term-for-concept-shadow-root" id="infopanel-for-term-for-concept-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-dom-event-type①">4.4.14. Canceling an animation</a>
     <li><a href="#ref-for-dom-event-type②">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc" style="display:none">Info about the '[[defineownproperty]]' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver" style="display:none">Info about the '[[get]]' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">http://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-completion-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'completion record specification type' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-completion-record-specification-type">http://www.ecma-international.org/ecma-262/6.0/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-sec-completion-record-specification-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-enumerableownnames">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-enumerableownnames">http://www.ecma-international.org/ecma-262/6.0/#sec-enumerableownnames</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-enumerableownnames" class="dfn-panel" data-for="term-for-sec-enumerableownnames" id="infopanel-for-term-for-sec-enumerableownnames" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-enumerableownnames" style="display:none">Info about the 'enumerableownnames' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-enumerableownnames">http://www.ecma-international.org/ecma-262/6.0/#sec-enumerableownnames</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-enumerableownnames">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getiterator">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-getiterator">http://www.ecma-international.org/ecma-262/6.0/#sec-getiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getiterator" class="dfn-panel" data-for="term-for-sec-getiterator" id="infopanel-for-term-for-sec-getiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getiterator" style="display:none">Info about the 'getiterator' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-getiterator">http://www.ecma-international.org/ecma-262/6.0/#sec-getiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getiterator">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getmethod">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getmethod" class="dfn-panel" data-for="term-for-sec-getmethod" id="infopanel-for-term-for-sec-getmethod" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getmethod" style="display:none">Info about the 'getmethod' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod">http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getmethod">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iteratorstep">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorstep">http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorstep</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iteratorstep" class="dfn-panel" data-for="term-for-sec-iteratorstep" id="infopanel-for-term-for-sec-iteratorstep" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iteratorstep" style="display:none">Info about the 'iteratorstep' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorstep">http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorstep</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iteratorstep">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iteratorvalue">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorvalue">http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorvalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iteratorvalue" class="dfn-panel" data-for="term-for-sec-iteratorvalue" id="infopanel-for-term-for-sec-iteratorvalue" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iteratorvalue" style="display:none">Info about the 'iteratorvalue' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorvalue">http://www.ecma-international.org/ecma-262/6.0/#sec-iteratorvalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iteratorvalue">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'promise' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">4.4.7. The current ready promise</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a>
     <li><a href="#ref-for-sec-promise-objects③">4.4.11. The current finished promise</a> <a href="#ref-for-sec-promise-objects④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects①" style="display:none">Info about the 'promise object' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">4.4.7. The current ready promise</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a>
     <li><a href="#ref-for-sec-promise-objects③">4.4.11. The current finished promise</a> <a href="#ref-for-sec-promise-objects④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'type' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-well-known-symbols">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-well-known-symbols" class="dfn-panel" data-for="term-for-sec-well-known-symbols" id="infopanel-for-term-for-sec-well-known-symbols" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-well-known-symbols" style="display:none">Info about the 'well known symbols' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols">http://www.ecma-international.org/ecma-262/6.0/#sec-well-known-symbols</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-well-known-symbols">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#domhighrestimestamp">https://w3c.github.io/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domhighrestimestamp" class="dfn-panel" data-for="term-for-domhighrestimestamp" id="infopanel-for-term-for-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#domhighrestimestamp">https://w3c.github.io/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domhighrestimestamp">6.3. The DocumentTimeline interface</a> <a href="#ref-for-domhighrestimestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-origin">
-   <a href="https://w3c.github.io/hr-time/#time-origin">https://w3c.github.io/hr-time/#time-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-origin" class="dfn-panel" data-for="term-for-time-origin" id="infopanel-for-term-for-time-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-time-origin" style="display:none">Info about the 'time origin' external reference.</span><a href="https://w3c.github.io/hr-time/#time-origin">https://w3c.github.io/hr-time/#time-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-origin">4.3.2. Document timelines</a>
     <li><a href="#ref-for-time-origin①">4.3.3. The default document timeline</a>
@@ -7283,8 +7283,8 @@ argument</a>
     <li><a href="#ref-for-time-origin④">6.3. The DocumentTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://html.spec.whatwg.org/#document">https://html.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://html.spec.whatwg.org/#document">https://html.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.3. Timelines</a>
     <li><a href="#ref-for-document①">4.3.3. The default document timeline</a>
@@ -7298,45 +7298,45 @@ argument</a>
     <li><a href="#ref-for-document①②">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">6.4. The Animation interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">6.3. The DocumentTimeline interface</a>
     <li><a href="#ref-for-window①">6.4. The Animation interface</a> <a href="#ref-for-window②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-document" class="dfn-panel" data-for="term-for-active-document" id="infopanel-for-term-for-active-document" role="menu">
+   <span id="infopaneltitle-for-term-for-active-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-document">4.3.2. Document timelines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-an-entry-with-persisted-user-state">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#an-entry-with-persisted-user-state">https://html.spec.whatwg.org/multipage/browsers.html#an-entry-with-persisted-user-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-an-entry-with-persisted-user-state" class="dfn-panel" data-for="term-for-an-entry-with-persisted-user-state" id="infopanel-for-term-for-an-entry-with-persisted-user-state" role="menu">
+   <span id="infopaneltitle-for-term-for-an-entry-with-persisted-user-state" style="display:none">Info about the 'an entry with persisted user state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#an-entry-with-persisted-user-state">https://html.spec.whatwg.org/multipage/browsers.html#an-entry-with-persisted-user-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-an-entry-with-persisted-user-state">8. Interaction with page display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-frames">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#animation-frames">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#animation-frames</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-frames" class="dfn-panel" data-for="term-for-animation-frames" id="infopanel-for-term-for-animation-frames" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-frames" style="display:none">Info about the 'animation frame callbacks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#animation-frames">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#animation-frames</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-frames">1.2. Relationship to other specifications</a> <a href="#ref-for-animation-frames①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#being-rendered">https://html.spec.whatwg.org/multipage/browsers.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#being-rendered">https://html.spec.whatwg.org/multipage/browsers.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">6.4. The Animation interface</a> <a href="#ref-for-being-rendered①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4.7.3. Iteration time space</a>
     <li><a href="#ref-for-current-global-object①">5.2.1. Custom Properties</a>
@@ -7344,64 +7344,64 @@ argument</a>
     <li><a href="#ref-for-current-global-object③">6.4. The Animation interface</a> <a href="#ref-for-current-global-object④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'document associated with a window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window">https://html.spec.whatwg.org/multipage/browsers.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">6.3. The DocumentTimeline interface</a>
     <li><a href="#ref-for-concept-document-window①">6.4. The Animation interface</a> <a href="#ref-for-concept-document-window②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-open">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open">https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-open" class="dfn-panel" data-for="term-for-dom-document-open" id="infopanel-for-term-for-dom-document-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-open" style="display:none">Info about the 'document.open()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open">https://html.spec.whatwg.org/multipage/webappapis.html#dom-document-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-open">4.3.3. The default document timeline</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-dom-manipulation-task-source①">4.4.14. Canceling an animation</a>
     <li><a href="#ref-for-dom-manipulation-task-source②">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop-processing-model">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop-processing-model" class="dfn-panel" data-for="term-for-event-loop-processing-model" id="infopanel-for-term-for-event-loop-processing-model" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop-processing-model" style="display:none">Info about the 'event loop processing model' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop-processing-model">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">https://html.spec.whatwg.org/multipage/embedded-content.html#media-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element" class="dfn-panel" data-for="term-for-media-element" id="infopanel-for-term-for-media-element" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element" style="display:none">Info about the 'media element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">https://html.spec.whatwg.org/multipage/embedded-content.html#media-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element">4.4.10. Reaching the end</a>
     <li><a href="#ref-for-media-element①">8. Interaction with page display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">4.3. Timelines</a>
     <li><a href="#ref-for-perform-a-microtask-checkpoint①">4.4.8. Playing an animation</a>
     <li><a href="#ref-for-perform-a-microtask-checkpoint②">4.4.9. Pausing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">4.4.12. Updating the finished state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-queue-a-task①">4.4.14. Canceling an animation</a>
     <li><a href="#ref-for-queue-a-task②">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.4.2. Setting the associated effect of an animation</a>
     <li><a href="#ref-for-concept-relevant-realm①">4.4.7. The current ready promise</a>
@@ -7412,103 +7412,103 @@ argument</a>
     <li><a href="#ref-for-concept-relevant-realm⑥">6.8. The Animatable interface mixin</a> <a href="#ref-for-concept-relevant-realm⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" class="dfn-panel" data-for="term-for-run-the-animation-frame-callbacks" id="infopanel-for-term-for-run-the-animation-frame-callbacks" role="menu">
+   <span id="infopaneltitle-for-term-for-run-the-animation-frame-callbacks" style="display:none">Info about the 'run the animation frame callbacks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#run-the-animation-frame-callbacks">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html.html#run-the-animation-frame-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-animation-frame-callbacks">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session-history-entry">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#session-history-entry">https://html.spec.whatwg.org/multipage/browsers.html#session-history-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session-history-entry" class="dfn-panel" data-for="term-for-session-history-entry" id="infopanel-for-term-for-session-history-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-session-history-entry" style="display:none">Info about the 'session history entry' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#session-history-entry">https://html.spec.whatwg.org/multipage/browsers.html#session-history-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history-entry">8. Interaction with page display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-extend">
-   <a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-extend" class="dfn-panel" data-for="term-for-list-extend" id="infopanel-for-term-for-list-extend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-extend" style="display:none">Info about the 'extend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-extend">https://infra.spec.whatwg.org/#list-extend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-extend">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'iterate' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">6.4. The Animation interface</a> <a href="#ref-for-ordered-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-offset">
-   <a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-offset" class="dfn-panel" data-for="term-for-propdef-offset" id="infopanel-for-term-for-propdef-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-offset" style="display:none">Info about the 'offset' external reference.</span><a href="https://drafts.fxtf.org/motion-1/#propdef-offset">https://drafts.fxtf.org/motion-1/#propdef-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset">6.6.2. Property names and IDL names</a> <a href="#ref-for-propdef-offset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-pseudo-element-selector" class="dfn-panel" data-for="term-for-typedef-pseudo-element-selector" id="infopanel-for-term-for-typedef-pseudo-element-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-pseudo-element-selector" style="display:none">Info about the '&lt;pseudo-element-selector>' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector">https://drafts.csswg.org/selectors-4/#typedef-pseudo-element-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-pseudo-element-selector">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#invalid-selector">https://drafts.csswg.org/selectors-4/#invalid-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-selector" class="dfn-panel" data-for="term-for-invalid-selector" id="infopanel-for-term-for-invalid-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-selector" style="display:none">Info about the 'invalid selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#invalid-selector">https://drafts.csswg.org/selectors-4/#invalid-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-selector">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">5.3. Keyframe effects</a>
     <li><a href="#ref-for-originating-element①">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-originating-element②">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">5.3. Keyframe effects</a> <a href="#ref-for-pseudo-element①">(2)</a> <a href="#ref-for-pseudo-element②">(3)</a> <a href="#ref-for-pseudo-element③">(4)</a>
     <li><a href="#ref-for-pseudo-element④">6.6.4. The KeyframeEffectOptions dictionary</a>
     <li><a href="#ref-for-pseudo-element⑤">6.8. The Animatable interface mixin</a> <a href="#ref-for-pseudo-element⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-registration">
-   <a href="https://svgwg.org/svg2-draft/mimereg.html#mime-registration">https://svgwg.org/svg2-draft/mimereg.html#mime-registration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-registration" class="dfn-panel" data-for="term-for-mime-registration" id="infopanel-for-term-for-mime-registration" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-registration" style="display:none">Info about the 'svg mime type' external reference.</span><a href="https://svgwg.org/svg2-draft/mimereg.html#mime-registration">https://svgwg.org/svg2-draft/mimereg.html#mime-registration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-registration">7. Integration with Media Fragments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-composite-operation">
-   <a href="https://drafts.csswg.org/web-animations-2/#iteration-composite-operation">https://drafts.csswg.org/web-animations-2/#iteration-composite-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-composite-operation" class="dfn-panel" data-for="term-for-iteration-composite-operation" id="infopanel-for-term-for-iteration-composite-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-composite-operation" style="display:none">Info about the 'iteration composite operation' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#iteration-composite-operation">https://drafts.csswg.org/web-animations-2/#iteration-composite-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-composite-operation">4.7.2. Controlling iteration</a>
     <li><a href="#ref-for-iteration-composite-operation①">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-composite-operation-accumulate">
-   <a href="https://drafts.csswg.org/web-animations-2/#iteration-composite-operation-accumulate">https://drafts.csswg.org/web-animations-2/#iteration-composite-operation-accumulate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-composite-operation-accumulate" class="dfn-panel" data-for="term-for-iteration-composite-operation-accumulate" id="infopanel-for-term-for-iteration-composite-operation-accumulate" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-composite-operation-accumulate" style="display:none">Info about the 'iteration composite operation accumulate' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#iteration-composite-operation-accumulate">https://drafts.csswg.org/web-animations-2/#iteration-composite-operation-accumulate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-composite-operation-accumulate">4.7.2. Controlling iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.4.8. Playing an animation</a>
     <li><a href="#ref-for-idl-DOMException①">4.4.9. Pausing an animation</a>
@@ -7518,8 +7518,8 @@ argument</a>
     <li><a href="#ref-for-idl-DOMException⑥">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">6.4. The Animation interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a> <a href="#ref-for-idl-DOMString⑤">(4)</a> <a href="#ref-for-idl-DOMString⑥">(5)</a>
@@ -7530,8 +7530,8 @@ argument</a> <a href="#ref-for-idl-DOMString⑨">(2)</a> <a href="#ref-for-idl-D
     <li><a href="#ref-for-idl-DOMString①③">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.2. The AnimationTimeline interface</a>
     <li><a href="#ref-for-Exposed①">6.3. The DocumentTimeline interface</a>
@@ -7541,8 +7541,8 @@ argument</a> <a href="#ref-for-idl-DOMString⑨">(2)</a> <a href="#ref-for-idl-D
     <li><a href="#ref-for-Exposed⑤">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.4.8. Playing an animation</a>
     <li><a href="#ref-for-invalidstateerror①">4.4.9. Pausing an animation</a>
@@ -7551,32 +7551,32 @@ argument</a> <a href="#ref-for-idl-DOMString⑨">(2)</a> <a href="#ref-for-idl-D
     <li><a href="#ref-for-invalidstateerror④">6.4. The Animation interface</a> <a href="#ref-for-invalidstateerror⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nomodificationallowederror">
-   <a href="https://webidl.spec.whatwg.org/#nomodificationallowederror">https://webidl.spec.whatwg.org/#nomodificationallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nomodificationallowederror" class="dfn-panel" data-for="term-for-nomodificationallowederror" id="infopanel-for-term-for-nomodificationallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-nomodificationallowederror" style="display:none">Info about the 'NoModificationAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#nomodificationallowederror">https://webidl.spec.whatwg.org/#nomodificationallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nomodificationallowederror">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">6.4. The Animation interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://heycam.github.io/webidl/#EnforceRange">https://heycam.github.io/webidl/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the '[enforcerange]' external reference.</span><a href="https://heycam.github.io/webidl/#EnforceRange">https://heycam.github.io/webidl/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://heycam.github.io/webidl/#a-new-promise">https://heycam.github.io/webidl/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://heycam.github.io/webidl/#a-new-promise">https://heycam.github.io/webidl/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.4.8. Playing an animation</a>
     <li><a href="#ref-for-a-new-promise①">4.4.9. Pausing an animation</a>
@@ -7584,35 +7584,35 @@ argument</a> <a href="#ref-for-idl-DOMString⑨">(2)</a> <a href="#ref-for-idl-D
     <li><a href="#ref-for-a-new-promise③">4.4.14. Canceling an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6.4. The Animation interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">6.8. The Animatable interface mixin</a> <a href="#ref-for-idl-boolean③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value">https://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'convert ecmascript to idl value' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value">https://heycam.github.io/webidl/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://heycam.github.io/webidl/#a-promise-resolved-with">https://heycam.github.io/webidl/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'create a new resolved promise' external reference.</span><a href="https://heycam.github.io/webidl/#a-promise-resolved-with">https://heycam.github.io/webidl/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">4.4.2. Setting the associated effect of an animation</a>
     <li><a href="#ref-for-a-promise-resolved-with①">4.4.7. The current ready promise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-DOMString-to-es">
-   <a href="https://heycam.github.io/webidl/#DOMString-to-es">https://heycam.github.io/webidl/#DOMString-to-es</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-DOMString-to-es" class="dfn-panel" data-for="term-for-DOMString-to-es" id="infopanel-for-term-for-DOMString-to-es" role="menu">
+   <span id="infopaneltitle-for-term-for-DOMString-to-es" style="display:none">Info about the 'domstring to es' external reference.</span><a href="https://heycam.github.io/webidl/#DOMString-to-es">https://heycam.github.io/webidl/#DOMString-to-es</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DOMString-to-es">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.2. The AnimationTimeline interface</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">6.4. The Animation interface</a> <a href="#ref-for-idl-double③">(2)</a> <a href="#ref-for-idl-double④">(3)</a> <a href="#ref-for-idl-double⑤">(4)</a> <a href="#ref-for-idl-double⑥">(5)</a> <a href="#ref-for-idl-double⑦">(6)</a> <a href="#ref-for-idl-double⑧">(7)</a>
@@ -7624,51 +7624,51 @@ argument</a> <a href="#ref-for-idl-double②⑤">(2)</a> <a href="#ref-for-idl-d
     <li><a href="#ref-for-idl-double②⑦">6.12. The AnimationPlaybackEvent interface</a> <a href="#ref-for-idl-double②⑧">(2)</a> <a href="#ref-for-idl-double②⑨">(3)</a> <a href="#ref-for-idl-double③⓪">(4)</a> <a href="#ref-for-idl-double③①">(5)</a> <a href="#ref-for-idl-double③②">(6)</a> <a href="#ref-for-idl-double③③">(7)</a> <a href="#ref-for-idl-double③④">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-es-to-dictionary">
-   <a href="https://heycam.github.io/webidl/#es-to-dictionary">https://heycam.github.io/webidl/#es-to-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-es-to-dictionary" class="dfn-panel" data-for="term-for-es-to-dictionary" id="infopanel-for-term-for-es-to-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-es-to-dictionary" style="display:none">Info about the 'es to dictionary' external reference.</span><a href="https://heycam.github.io/webidl/#es-to-dictionary">https://heycam.github.io/webidl/#es-to-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-es-to-dictionary">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-es-to-DOMString">
-   <a href="https://heycam.github.io/webidl/#es-to-DOMString">https://heycam.github.io/webidl/#es-to-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-es-to-DOMString" class="dfn-panel" data-for="term-for-es-to-DOMString" id="infopanel-for-term-for-es-to-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-es-to-DOMString" style="display:none">Info about the 'es to domstring' external reference.</span><a href="https://heycam.github.io/webidl/#es-to-DOMString">https://heycam.github.io/webidl/#es-to-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-es-to-DOMString">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-nullable-type">
-   <a href="https://heycam.github.io/webidl/#dfn-nullable-type">https://heycam.github.io/webidl/#dfn-nullable-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-nullable-type" class="dfn-panel" data-for="term-for-dfn-nullable-type" id="infopanel-for-term-for-dfn-nullable-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-nullable-type" style="display:none">Info about the 'nullable' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-nullable-type">https://heycam.github.io/webidl/#dfn-nullable-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-nullable-type">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">6.6. The KeyframeEffect interface</a> <a href="#ref-for-idl-object①">(2)</a> <a href="#ref-for-idl-object②">(3)</a>
     <li><a href="#ref-for-idl-object③">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-present">
-   <a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-present" class="dfn-panel" data-for="term-for-dfn-present" id="infopanel-for-term-for-dfn-present" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-present" style="display:none">Info about the 'present' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-present">https://heycam.github.io/webidl/#dfn-present</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-present">6.5. The AnimationEffect interface</a>
     <li><a href="#ref-for-dfn-present①">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dfn-present②">6.5.4. Updating the timing of an AnimationEffect</a> <a href="#ref-for-dfn-present③">(2)</a> <a href="#ref-for-dfn-present④">(3)</a> <a href="#ref-for-dfn-present⑤">(4)</a> <a href="#ref-for-dfn-present⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://heycam.github.io/webidl/#reject">https://heycam.github.io/webidl/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject a promise' external reference.</span><a href="https://heycam.github.io/webidl/#reject">https://heycam.github.io/webidl/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.4.2. Setting the associated effect of an animation</a>
     <li><a href="#ref-for-reject①">4.4.14. Canceling an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://heycam.github.io/webidl/#resolve">https://heycam.github.io/webidl/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve a promise' external reference.</span><a href="https://heycam.github.io/webidl/#resolve">https://heycam.github.io/webidl/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.4.4. Setting the current time of an animation</a>
     <li><a href="#ref-for-resolve①">4.4.5. Setting the start time of an animation</a>
@@ -7678,8 +7678,8 @@ argument</a>
     <li><a href="#ref-for-resolve⑤">4.4.13. Finishing an animation</a> <a href="#ref-for-resolve⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-idl-sequence①">6.6.3. Processing a keyframes
@@ -7688,8 +7688,8 @@ argument</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-se
     <li><a href="#ref-for-idl-sequence⑤">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">4.4.4. Setting the current time of an animation</a>
     <li><a href="#ref-for-dfn-throw①">4.4.8. Playing an animation</a>
@@ -7703,16 +7703,16 @@ argument</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-se
 argument</a> <a href="#ref-for-dfn-throw①④">(2)</a> <a href="#ref-for-dfn-throw①⑤">(3)</a> <a href="#ref-for-dfn-throw①⑥">(4)</a> <a href="#ref-for-dfn-throw①⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6.4. The Animation interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a> <a href="#ref-for-idl-undefined⑤">(6)</a> <a href="#ref-for-idl-undefined⑥">(7)</a> <a href="#ref-for-idl-undefined⑦">(8)</a>
     <li><a href="#ref-for-idl-undefined⑧">6.5. The AnimationEffect interface</a>
     <li><a href="#ref-for-idl-undefined⑨">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a> <a href="#ref-for-idl-unrestricted-double②">(3)</a> <a href="#ref-for-idl-unrestricted-double③">(4)</a> <a href="#ref-for-idl-unrestricted-double④">(5)</a>
     <li><a href="#ref-for-idl-unrestricted-double⑤">6.5.5. The ComputedEffectTiming dictionary</a> <a href="#ref-for-idl-unrestricted-double⑥">(2)</a> <a href="#ref-for-idl-unrestricted-double⑦">(3)</a> <a href="#ref-for-idl-unrestricted-double⑧">(4)</a> <a href="#ref-for-idl-unrestricted-double⑨">(5)</a> <a href="#ref-for-idl-unrestricted-double①⓪">(6)</a>
@@ -8300,8 +8300,8 @@ define it simply as removing the animation effect from its animation? <a href="h
    <div class="issue"> What should we do if the [[type]] is <span class="esvalue">break</span>, <span class="esvalue">continue</span>, or <span class="esvalue">return</span>? Can it be? <a class="issue-return" href="#issue-47a68024" title="Jump to section">↵</a></div>
    <div class="issue"> Is this at odds with those <a data-link-type="dfn" href="#time-value">time values</a> being relative to <code>navigationStart</code> and with <code>requestAnimationFrame</code> using the same time as <code>document.timeline.currentTime</code>? <a href="https://github.com/w3c/csswg-drafts/issues/2083">[Issue #2083]</a> <a class="issue-return" href="#issue-a128cfff" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="time-value">
-   <b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-time-value" class="dfn-panel" data-for="time-value" id="infopanel-for-time-value" role="dialog">
+   <span id="infopaneltitle-for-time-value" style="display:none">Info about the 'time value' definition.</span><b><a href="#time-value">#time-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">4.2. Time values</a> <a href="#ref-for-time-value①">(2)</a> <a href="#ref-for-time-value②">(3)</a> <a href="#ref-for-time-value③">(4)</a>
     <li><a href="#ref-for-time-value④">4.3. Timelines</a> <a href="#ref-for-time-value⑤">(2)</a> <a href="#ref-for-time-value⑥">(3)</a> <a href="#ref-for-time-value⑦">(4)</a>
@@ -8329,8 +8329,8 @@ define it simply as removing the animation effect from its animation? <a href="h
     <li><a href="#ref-for-time-value④⑥">9.1. Precision of time values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unresolved">
-   <b><a href="#unresolved">#unresolved</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unresolved" class="dfn-panel" data-for="unresolved" id="infopanel-for-unresolved" role="dialog">
+   <span id="infopaneltitle-for-unresolved" style="display:none">Info about the 'unresolved' definition.</span><b><a href="#unresolved">#unresolved</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unresolved">2. Specification conventions</a>
     <li><a href="#ref-for-unresolved①">4.3. Timelines</a> <a href="#ref-for-unresolved②">(2)</a>
@@ -8367,8 +8367,8 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-unresolved①⓪⑧">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline">
-   <b><a href="#timeline">#timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline" class="dfn-panel" data-for="timeline" id="infopanel-for-timeline" role="dialog">
+   <span id="infopaneltitle-for-timeline" style="display:none">Info about the 'timeline' definition.</span><b><a href="#timeline">#timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline">4.3. Timelines</a> <a href="#ref-for-timeline①">(2)</a> <a href="#ref-for-timeline②">(3)</a> <a href="#ref-for-timeline③">(4)</a> <a href="#ref-for-timeline④">(5)</a>
     <li><a href="#ref-for-timeline⑤">4.3.1. Timeline Phase</a> <a href="#ref-for-timeline⑥">(2)</a>
@@ -8399,8 +8399,8 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-timeline⑤⑨">8. Interaction with page display</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-current-time">
-   <b><a href="#timeline-current-time">#timeline-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-current-time" class="dfn-panel" data-for="timeline-current-time" id="infopanel-for-timeline-current-time" role="dialog">
+   <span id="infopaneltitle-for-timeline-current-time" style="display:none">Info about the 'current time' definition.</span><b><a href="#timeline-current-time">#timeline-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-current-time">4.3. Timelines</a> <a href="#ref-for-timeline-current-time①">(2)</a> <a href="#ref-for-timeline-current-time②">(3)</a> <a href="#ref-for-timeline-current-time③">(4)</a>
     <li><a href="#ref-for-timeline-current-time④">4.3.1. Timeline Phase</a>
@@ -8412,8 +8412,8 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-timeline-current-time①①">6.13. Model liveness</a> <a href="#ref-for-timeline-current-time①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="monotonically-increasing-timeline">
-   <b><a href="#monotonically-increasing-timeline">#monotonically-increasing-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-monotonically-increasing-timeline" class="dfn-panel" data-for="monotonically-increasing-timeline" id="infopanel-for-monotonically-increasing-timeline" role="dialog">
+   <span id="infopaneltitle-for-monotonically-increasing-timeline" style="display:none">Info about the 'monotonically increasing' definition.</span><b><a href="#monotonically-increasing-timeline">#monotonically-increasing-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monotonically-increasing-timeline">4.3.2. Document timelines</a>
     <li><a href="#ref-for-monotonically-increasing-timeline①">4.4.8. Playing an animation</a>
@@ -8422,8 +8422,9 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-monotonically-increasing-timeline④">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-time-to-origin-relative-time">
-   <b><a href="#timeline-time-to-origin-relative-time">#timeline-time-to-origin-relative-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-time-to-origin-relative-time" class="dfn-panel" data-for="timeline-time-to-origin-relative-time" id="infopanel-for-timeline-time-to-origin-relative-time" role="dialog">
+   <span id="infopaneltitle-for-timeline-time-to-origin-relative-time" style="display:none">Info about the 'convert a timeline time to an
+origin-relative time' definition.</span><b><a href="#timeline-time-to-origin-relative-time">#timeline-time-to-origin-relative-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-time-to-origin-relative-time">4.3.2. Document timelines</a>
     <li><a href="#ref-for-timeline-time-to-origin-relative-time①">4.4.14. Canceling an animation</a>
@@ -8431,16 +8432,16 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-timeline-time-to-origin-relative-time④">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-associated-with-a-document">
-   <b><a href="#timeline-associated-with-a-document">#timeline-associated-with-a-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-associated-with-a-document" class="dfn-panel" data-for="timeline-associated-with-a-document" id="infopanel-for-timeline-associated-with-a-document" role="dialog">
+   <span id="infopaneltitle-for-timeline-associated-with-a-document" style="display:none">Info about the 'associated with a document' definition.</span><b><a href="#timeline-associated-with-a-document">#timeline-associated-with-a-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-associated-with-a-document">4.3. Timelines</a>
     <li><a href="#ref-for-timeline-associated-with-a-document①">4.3.2. Document timelines</a>
     <li><a href="#ref-for-timeline-associated-with-a-document②">4.4. Animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-animations-and-send-events">
-   <b><a href="#update-animations-and-send-events">#update-animations-and-send-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-animations-and-send-events" class="dfn-panel" data-for="update-animations-and-send-events" id="infopanel-for-update-animations-and-send-events" role="dialog">
+   <span id="infopaneltitle-for-update-animations-and-send-events" style="display:none">Info about the 'update animations and send events' definition.</span><b><a href="#update-animations-and-send-events">#update-animations-and-send-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-animations-and-send-events">4.3.2. Document timelines</a>
     <li><a href="#ref-for-update-animations-and-send-events①">4.3.3. The default document timeline</a>
@@ -8449,8 +8450,8 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
     <li><a href="#ref-for-update-animations-and-send-events④">6.13. Model liveness</a> <a href="#ref-for-update-animations-and-send-events⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-frame">
-   <b><a href="#animation-frame">#animation-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-frame" class="dfn-panel" data-for="animation-frame" id="infopanel-for-animation-frame" role="dialog">
+   <span id="infopaneltitle-for-animation-frame" style="display:none">Info about the 'animation frame' definition.</span><b><a href="#animation-frame">#animation-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-frame">4.3. Timelines</a> <a href="#ref-for-animation-frame①">(2)</a>
     <li><a href="#ref-for-animation-frame②">4.4.17. Play states</a>
@@ -8458,42 +8459,42 @@ states</a> <a href="#ref-for-unresolved⑧⑦">(2)</a> <a href="#ref-for-unresol
 states</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-phase">
-   <b><a href="#timeline-phase">#timeline-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-phase" class="dfn-panel" data-for="timeline-phase" id="infopanel-for-timeline-phase" role="dialog">
+   <span id="infopaneltitle-for-timeline-phase" style="display:none">Info about the 'phases' definition.</span><b><a href="#timeline-phase">#timeline-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-phase">4.3.2. Document timelines</a> <a href="#ref-for-timeline-phase①">(2)</a>
     <li><a href="#ref-for-timeline-phase②">6.2. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-inactive-phase">
-   <b><a href="#timeline-inactive-phase">#timeline-inactive-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-inactive-phase" class="dfn-panel" data-for="timeline-inactive-phase" id="infopanel-for-timeline-inactive-phase" role="dialog">
+   <span id="infopaneltitle-for-timeline-inactive-phase" style="display:none">Info about the 'inactive' definition.</span><b><a href="#timeline-inactive-phase">#timeline-inactive-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-inactive-phase">4.3.1. Timeline Phase</a>
     <li><a href="#ref-for-timeline-inactive-phase①">4.3.2. Document timelines</a>
     <li><a href="#ref-for-timeline-inactive-phase②">6.4.3. The TimelinePhase enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-before-phase">
-   <b><a href="#timeline-before-phase">#timeline-before-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-before-phase" class="dfn-panel" data-for="timeline-before-phase" id="infopanel-for-timeline-before-phase" role="dialog">
+   <span id="infopaneltitle-for-timeline-before-phase" style="display:none">Info about the 'before' definition.</span><b><a href="#timeline-before-phase">#timeline-before-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-before-phase">6.4.3. The TimelinePhase enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-active-phase">
-   <b><a href="#timeline-active-phase">#timeline-active-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-active-phase" class="dfn-panel" data-for="timeline-active-phase" id="infopanel-for-timeline-active-phase" role="dialog">
+   <span id="infopaneltitle-for-timeline-active-phase" style="display:none">Info about the 'active' definition.</span><b><a href="#timeline-active-phase">#timeline-active-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-active-phase">4.3.2. Document timelines</a>
     <li><a href="#ref-for-timeline-active-phase①">6.4.3. The TimelinePhase enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeline-after-phase">
-   <b><a href="#timeline-after-phase">#timeline-after-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeline-after-phase" class="dfn-panel" data-for="timeline-after-phase" id="infopanel-for-timeline-after-phase" role="dialog">
+   <span id="infopaneltitle-for-timeline-after-phase" style="display:none">Info about the 'after' definition.</span><b><a href="#timeline-after-phase">#timeline-after-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-after-phase">6.4.3. The TimelinePhase enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inactive-timeline">
-   <b><a href="#inactive-timeline">#inactive-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inactive-timeline" class="dfn-panel" data-for="inactive-timeline" id="infopanel-for-inactive-timeline" role="dialog">
+   <span id="infopaneltitle-for-inactive-timeline" style="display:none">Info about the 'inactive timeline' definition.</span><b><a href="#inactive-timeline">#inactive-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inactive-timeline">4.3.1. Timeline Phase</a>
     <li><a href="#ref-for-inactive-timeline①">4.3.2. Document timelines</a>
@@ -8513,8 +8514,8 @@ states</a>
     <li><a href="#ref-for-inactive-timeline①⑧">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-timeline">
-   <b><a href="#document-timeline">#document-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-timeline" class="dfn-panel" data-for="document-timeline" id="infopanel-for-document-timeline" role="dialog">
+   <span id="infopaneltitle-for-document-timeline" style="display:none">Info about the 'document timeline' definition.</span><b><a href="#document-timeline">#document-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-timeline">4.3.2. Document timelines</a> <a href="#ref-for-document-timeline①">(2)</a>
     <li><a href="#ref-for-document-timeline②">4.3.3. The default document timeline</a> <a href="#ref-for-document-timeline③">(2)</a>
@@ -8522,16 +8523,17 @@ states</a>
     <li><a href="#ref-for-document-timeline⑤">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-time">
-   <b><a href="#origin-time">#origin-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-time" class="dfn-panel" data-for="origin-time" id="infopanel-for-origin-time" role="dialog">
+   <span id="infopaneltitle-for-origin-time" style="display:none">Info about the 'origin
+time' definition.</span><b><a href="#origin-time">#origin-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-time">4.3.2. Document timelines</a>
     <li><a href="#ref-for-origin-time①">4.3.3. The default document timeline</a>
     <li><a href="#ref-for-origin-time②">6.3. The DocumentTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-document-timeline">
-   <b><a href="#default-document-timeline">#default-document-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-document-timeline" class="dfn-panel" data-for="default-document-timeline" id="infopanel-for-default-document-timeline" role="dialog">
+   <span id="infopaneltitle-for-default-document-timeline" style="display:none">Info about the 'default document timeline' definition.</span><b><a href="#default-document-timeline">#default-document-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-document-timeline">4.3.3. The default document timeline</a> <a href="#ref-for-default-document-timeline①">(2)</a> <a href="#ref-for-default-document-timeline②">(3)</a>
     <li><a href="#ref-for-default-document-timeline③">4.7.3. Iteration time space</a>
@@ -8542,8 +8544,8 @@ states</a>
     <li><a href="#ref-for-default-document-timeline⑨">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-animation">
-   <b><a href="#concept-animation">#concept-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-animation" class="dfn-panel" data-for="concept-animation" id="infopanel-for-concept-animation" role="dialog">
+   <span id="infopaneltitle-for-concept-animation" style="display:none">Info about the 'animation' definition.</span><b><a href="#concept-animation">#concept-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-animation">2. Specification conventions</a>
     <li><a href="#ref-for-concept-animation①">4.3. Timelines</a> <a href="#ref-for-concept-animation②">(2)</a>
@@ -8587,8 +8589,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-concept-animation⑦⑧">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-effect">
-   <b><a href="#associated-effect">#associated-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-effect" class="dfn-panel" data-for="associated-effect" id="infopanel-for-associated-effect" role="dialog">
+   <span id="infopaneltitle-for-associated-effect" style="display:none">Info about the 'associated effect' definition.</span><b><a href="#associated-effect">#associated-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-effect">4.1.1. Stateless</a>
     <li><a href="#ref-for-associated-effect①">4.4. Animations</a> <a href="#ref-for-associated-effect②">(2)</a>
@@ -8610,8 +8612,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-associated-effect③②">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-for-timing">
-   <b><a href="#document-for-timing">#document-for-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-for-timing" class="dfn-panel" data-for="document-for-timing" id="infopanel-for-document-for-timing" role="dialog">
+   <span id="infopaneltitle-for-document-for-timing" style="display:none">Info about the 'document for timing' definition.</span><b><a href="#document-for-timing">#document-for-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-for-timing">4.4. Animations</a>
     <li><a href="#ref-for-document-for-timing①">4.4.12. Updating the finished state</a> <a href="#ref-for-document-for-timing②">(2)</a>
@@ -8619,8 +8621,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-document-for-timing⑤">5.5.2. Removing replaced animations</a> <a href="#ref-for-document-for-timing⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-time">
-   <b><a href="#start-time">#start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-time" class="dfn-panel" data-for="start-time" id="infopanel-for-start-time" role="dialog">
+   <span id="infopaneltitle-for-start-time" style="display:none">Info about the 'start time' definition.</span><b><a href="#start-time">#start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-time">2. Specification conventions</a>
     <li><a href="#ref-for-start-time①">4.4.1. Setting the timeline of an animation</a>
@@ -8642,8 +8644,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-start-time⑤⓪">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hold-time">
-   <b><a href="#hold-time">#hold-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hold-time" class="dfn-panel" data-for="hold-time" id="infopanel-for-hold-time" role="dialog">
+   <span id="infopaneltitle-for-hold-time" style="display:none">Info about the 'hold time' definition.</span><b><a href="#hold-time">#hold-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hold-time">4.4. Animations</a>
     <li><a href="#ref-for-hold-time①">4.4.1. Setting the timeline of an animation</a>
@@ -8658,33 +8660,33 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-hold-time④⓪">4.4.15.2. Seamlessly updating the playback rate of an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-animation-list">
-   <b><a href="#global-animation-list">#global-animation-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-animation-list" class="dfn-panel" data-for="global-animation-list" id="infopanel-for-global-animation-list" role="dialog">
+   <span id="infopaneltitle-for-global-animation-list" style="display:none">Info about the 'global animation list' definition.</span><b><a href="#global-animation-list">#global-animation-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-animation-list">5.4.2. The effect stack</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-timeline-of-an-animation">
-   <b><a href="#set-the-timeline-of-an-animation">#set-the-timeline-of-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-timeline-of-an-animation" class="dfn-panel" data-for="set-the-timeline-of-an-animation" id="infopanel-for-set-the-timeline-of-an-animation" role="dialog">
+   <span id="infopaneltitle-for-set-the-timeline-of-an-animation" style="display:none">Info about the 'set the timeline of an animation' definition.</span><b><a href="#set-the-timeline-of-an-animation">#set-the-timeline-of-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-timeline-of-an-animation">6.4. The Animation interface</a> <a href="#ref-for-set-the-timeline-of-an-animation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-associated-effect-of-an-animation">
-   <b><a href="#set-the-associated-effect-of-an-animation">#set-the-associated-effect-of-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-associated-effect-of-an-animation" class="dfn-panel" data-for="set-the-associated-effect-of-an-animation" id="infopanel-for-set-the-associated-effect-of-an-animation" role="dialog">
+   <span id="infopaneltitle-for-set-the-associated-effect-of-an-animation" style="display:none">Info about the 'set the associated effect of an animation' definition.</span><b><a href="#set-the-associated-effect-of-an-animation">#set-the-associated-effect-of-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-associated-effect-of-an-animation">4.4.2. Setting the associated effect of an animation</a>
     <li><a href="#ref-for-set-the-associated-effect-of-an-animation①">6.4. The Animation interface</a> <a href="#ref-for-set-the-associated-effect-of-an-animation②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reset-an-animations-pending-tasks">
-   <b><a href="#reset-an-animations-pending-tasks">#reset-an-animations-pending-tasks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reset-an-animations-pending-tasks" class="dfn-panel" data-for="reset-an-animations-pending-tasks" id="infopanel-for-reset-an-animations-pending-tasks" role="dialog">
+   <span id="infopaneltitle-for-reset-an-animations-pending-tasks" style="display:none">Info about the 'reset an animation’s pending tasks' definition.</span><b><a href="#reset-an-animations-pending-tasks">#reset-an-animations-pending-tasks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-an-animations-pending-tasks">4.4.14. Canceling an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-time">
-   <b><a href="#current-time">#current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-time" class="dfn-panel" data-for="current-time" id="infopanel-for-current-time" role="dialog">
+   <span id="infopaneltitle-for-current-time" style="display:none">Info about the 'current time' definition.</span><b><a href="#current-time">#current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">4.3. Timelines</a> <a href="#ref-for-current-time①">(2)</a>
     <li><a href="#ref-for-current-time②">4.4. Animations</a>
@@ -8707,38 +8709,38 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-current-time⑤⑧">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="silently-set-the-current-time">
-   <b><a href="#silently-set-the-current-time">#silently-set-the-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-silently-set-the-current-time" class="dfn-panel" data-for="silently-set-the-current-time" id="infopanel-for-silently-set-the-current-time" role="dialog">
+   <span id="infopaneltitle-for-silently-set-the-current-time" style="display:none">Info about the 'silently set the current time' definition.</span><b><a href="#silently-set-the-current-time">#silently-set-the-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-silently-set-the-current-time">4.4.4. Setting the current time of an animation</a>
     <li><a href="#ref-for-silently-set-the-current-time①">4.4.13. Finishing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-current-time">
-   <b><a href="#set-the-current-time">#set-the-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-current-time" class="dfn-panel" data-for="set-the-current-time" id="infopanel-for-set-the-current-time" role="dialog">
+   <span id="infopaneltitle-for-set-the-current-time" style="display:none">Info about the 'set the current time' definition.</span><b><a href="#set-the-current-time">#set-the-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-current-time">4.4.12. Updating the finished state</a> <a href="#ref-for-set-the-current-time①">(2)</a>
     <li><a href="#ref-for-set-the-current-time②">4.4.15.1. Setting the playback rate of an animation</a>
     <li><a href="#ref-for-set-the-current-time③">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-start-time">
-   <b><a href="#set-the-start-time">#set-the-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-start-time" class="dfn-panel" data-for="set-the-start-time" id="infopanel-for-set-the-start-time" role="dialog">
+   <span id="infopaneltitle-for-set-the-start-time" style="display:none">Info about the 'set the start time' definition.</span><b><a href="#set-the-start-time">#set-the-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-start-time">2. Specification conventions</a>
     <li><a href="#ref-for-set-the-start-time①">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ready">
-   <b><a href="#ready">#ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ready" class="dfn-panel" data-for="ready" id="infopanel-for-ready" role="dialog">
+   <span id="infopaneltitle-for-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#ready">#ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ready">4.4.2. Setting the associated effect of an animation</a> <a href="#ref-for-ready①">(2)</a>
     <li><a href="#ref-for-ready②">4.4.6. Waiting for the associated effect</a>
     <li><a href="#ref-for-ready③">4.4.8. Playing an animation</a> <a href="#ref-for-ready④">(2)</a> <a href="#ref-for-ready⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-ready-promise">
-   <b><a href="#current-ready-promise">#current-ready-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-ready-promise" class="dfn-panel" data-for="current-ready-promise" id="infopanel-for-current-ready-promise" role="dialog">
+   <span id="infopaneltitle-for-current-ready-promise" style="display:none">Info about the 'current ready promise' definition.</span><b><a href="#current-ready-promise">#current-ready-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-ready-promise">4.4.2. Setting the associated effect of an animation</a> <a href="#ref-for-current-ready-promise①">(2)</a> <a href="#ref-for-current-ready-promise②">(3)</a>
     <li><a href="#ref-for-current-ready-promise③">4.4.4. Setting the current time of an animation</a>
@@ -8751,8 +8753,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-current-ready-promise①⑦">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="play-an-animation">
-   <b><a href="#play-an-animation">#play-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-play-an-animation" class="dfn-panel" data-for="play-an-animation" id="infopanel-for-play-an-animation" role="dialog">
+   <span id="infopaneltitle-for-play-an-animation" style="display:none">Info about the 'play an animation' definition.</span><b><a href="#play-an-animation">#play-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-an-animation">4.4.9. Pausing an animation</a>
     <li><a href="#ref-for-play-an-animation①">4.4.15.2. Seamlessly updating the playback rate of an animation</a>
@@ -8761,8 +8763,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-play-an-animation⑤">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-play-task">
-   <b><a href="#pending-play-task">#pending-play-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-play-task" class="dfn-panel" data-for="pending-play-task" id="infopanel-for-pending-play-task" role="dialog">
+   <span id="infopaneltitle-for-pending-play-task" style="display:none">Info about the 'pending play task' definition.</span><b><a href="#pending-play-task">#pending-play-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-play-task">4.4.2. Setting the associated effect of an animation</a> <a href="#ref-for-pending-play-task①">(2)</a> <a href="#ref-for-pending-play-task②">(3)</a>
     <li><a href="#ref-for-pending-play-task③">4.4.5. Setting the start time of an animation</a>
@@ -8776,14 +8778,14 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-pending-play-task①⑧">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pause-an-animation">
-   <b><a href="#pause-an-animation">#pause-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pause-an-animation" class="dfn-panel" data-for="pause-an-animation" id="infopanel-for-pause-an-animation" role="dialog">
+   <span id="infopaneltitle-for-pause-an-animation" style="display:none">Info about the 'pause an animation' definition.</span><b><a href="#pause-an-animation">#pause-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pause-an-animation">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-pause-task">
-   <b><a href="#pending-pause-task">#pending-pause-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-pause-task" class="dfn-panel" data-for="pending-pause-task" id="infopanel-for-pending-pause-task" role="dialog">
+   <span id="infopaneltitle-for-pending-pause-task" style="display:none">Info about the 'pending pause task' definition.</span><b><a href="#pending-pause-task">#pending-pause-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-pause-task">4.4.2. Setting the associated effect of an animation</a> <a href="#ref-for-pending-pause-task①">(2)</a> <a href="#ref-for-pending-pause-task②">(3)</a>
     <li><a href="#ref-for-pending-pause-task③">4.4.4. Setting the current time of an animation</a> <a href="#ref-for-pending-pause-task④">(2)</a>
@@ -8798,8 +8800,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-pending-pause-task①⑧">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-finished-promise">
-   <b><a href="#current-finished-promise">#current-finished-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-finished-promise" class="dfn-panel" data-for="current-finished-promise" id="infopanel-for-current-finished-promise" role="dialog">
+   <span id="infopaneltitle-for-current-finished-promise" style="display:none">Info about the 'current finished promise' definition.</span><b><a href="#current-finished-promise">#current-finished-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-finished-promise">4.4.8. Playing an animation</a>
     <li><a href="#ref-for-current-finished-promise①">4.4.11. The current finished promise</a>
@@ -8809,8 +8811,8 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-current-finished-promise①②">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-effect-end">
-   <b><a href="#associated-effect-end">#associated-effect-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-effect-end" class="dfn-panel" data-for="associated-effect-end" id="infopanel-for-associated-effect-end" role="dialog">
+   <span id="infopaneltitle-for-associated-effect-end" style="display:none">Info about the 'associated effect end' definition.</span><b><a href="#associated-effect-end">#associated-effect-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-effect-end">4.4.8. Playing an animation</a> <a href="#ref-for-associated-effect-end①">(2)</a> <a href="#ref-for-associated-effect-end②">(3)</a> <a href="#ref-for-associated-effect-end③">(4)</a>
     <li><a href="#ref-for-associated-effect-end④">4.4.9. Pausing an animation</a> <a href="#ref-for-associated-effect-end⑤">(2)</a>
@@ -8820,15 +8822,16 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-associated-effect-end①⑤">6.4. The Animation interface</a> <a href="#ref-for-associated-effect-end①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-current-time">
-   <b><a href="#previous-current-time">#previous-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-current-time" class="dfn-panel" data-for="previous-current-time" id="infopanel-for-previous-current-time" role="dialog">
+   <span id="infopaneltitle-for-previous-current-time" style="display:none">Info about the 'previous current
+time' definition.</span><b><a href="#previous-current-time">#previous-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-current-time">4.4.4. Setting the current time of an animation</a>
     <li><a href="#ref-for-previous-current-time①">4.4.12. Updating the finished state</a> <a href="#ref-for-previous-current-time②">(2)</a> <a href="#ref-for-previous-current-time③">(3)</a> <a href="#ref-for-previous-current-time④">(4)</a> <a href="#ref-for-previous-current-time⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-an-animations-finished-state">
-   <b><a href="#update-an-animations-finished-state">#update-an-animations-finished-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-an-animations-finished-state" class="dfn-panel" data-for="update-an-animations-finished-state" id="infopanel-for-update-an-animations-finished-state" role="dialog">
+   <span id="infopaneltitle-for-update-an-animations-finished-state" style="display:none">Info about the 'update an animation’s finished state' definition.</span><b><a href="#update-an-animations-finished-state">#update-an-animations-finished-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-an-animations-finished-state">4.3. Timelines</a>
     <li><a href="#ref-for-update-an-animations-finished-state①">4.4.1. Setting the timeline of an animation</a>
@@ -8842,28 +8845,28 @@ states</a> <a href="#ref-for-concept-animation④⓪">(2)</a>
     <li><a href="#ref-for-update-an-animations-finished-state①①">4.4.15.2. Seamlessly updating the playback rate of an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finish-notification-steps">
-   <b><a href="#finish-notification-steps">#finish-notification-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finish-notification-steps" class="dfn-panel" data-for="finish-notification-steps" id="infopanel-for-finish-notification-steps" role="dialog">
+   <span id="infopaneltitle-for-finish-notification-steps" style="display:none">Info about the 'finish notification steps' definition.</span><b><a href="#finish-notification-steps">#finish-notification-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finish-notification-steps">4.4.12. Updating the finished state</a> <a href="#ref-for-finish-notification-steps①">(2)</a> <a href="#ref-for-finish-notification-steps②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finish-an-animation">
-   <b><a href="#finish-an-animation">#finish-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finish-an-animation" class="dfn-panel" data-for="finish-an-animation" id="infopanel-for-finish-an-animation" role="dialog">
+   <span id="infopaneltitle-for-finish-an-animation" style="display:none">Info about the 'finish an animation' definition.</span><b><a href="#finish-an-animation">#finish-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finish-an-animation">4.4.12. Updating the finished state</a> <a href="#ref-for-finish-an-animation①">(2)</a>
     <li><a href="#ref-for-finish-an-animation②">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cancel-an-animation">
-   <b><a href="#cancel-an-animation">#cancel-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cancel-an-animation" class="dfn-panel" data-for="cancel-an-animation" id="infopanel-for-cancel-an-animation" role="dialog">
+   <span id="infopaneltitle-for-cancel-an-animation" style="display:none">Info about the 'cancel an animation' definition.</span><b><a href="#cancel-an-animation">#cancel-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-an-animation">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-cancel-an-animation①">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="playback-rate">
-   <b><a href="#playback-rate">#playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-playback-rate" class="dfn-panel" data-for="playback-rate" id="infopanel-for-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-playback-rate" style="display:none">Info about the 'playback rate' definition.</span><b><a href="#playback-rate">#playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-rate">2. Specification conventions</a>
     <li><a href="#ref-for-playback-rate①">4.4.3. The current time of an animation</a> <a href="#ref-for-playback-rate②">(2)</a>
@@ -8885,16 +8888,16 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-playback-rate④⑥">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-playback-rate">
-   <b><a href="#set-the-playback-rate">#set-the-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-playback-rate" class="dfn-panel" data-for="set-the-playback-rate" id="infopanel-for-set-the-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-set-the-playback-rate" style="display:none">Info about the 'set the playback rate' definition.</span><b><a href="#set-the-playback-rate">#set-the-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-playback-rate">2. Specification conventions</a>
     <li><a href="#ref-for-set-the-playback-rate①">4.4.15.2. Seamlessly updating the playback rate of an animation</a>
     <li><a href="#ref-for-set-the-playback-rate②">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-playback-rate">
-   <b><a href="#pending-playback-rate">#pending-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-playback-rate" class="dfn-panel" data-for="pending-playback-rate" id="infopanel-for-pending-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-pending-playback-rate" style="display:none">Info about the 'pending playback rate' definition.</span><b><a href="#pending-playback-rate">#pending-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-playback-rate">4.4.8. Playing an animation</a> <a href="#ref-for-pending-playback-rate①">(2)</a>
     <li><a href="#ref-for-pending-playback-rate②">4.4.15.1. Setting the playback rate of an animation</a>
@@ -8902,8 +8905,8 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-pending-playback-rate①④">4.4.16. Reversing an animation</a> <a href="#ref-for-pending-playback-rate①⑤">(2)</a> <a href="#ref-for-pending-playback-rate①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-playback-rate">
-   <b><a href="#effective-playback-rate">#effective-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-playback-rate" class="dfn-panel" data-for="effective-playback-rate" id="infopanel-for-effective-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-effective-playback-rate" style="display:none">Info about the 'effective playback rate' definition.</span><b><a href="#effective-playback-rate">#effective-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-playback-rate">4.4.8. Playing an animation</a> <a href="#ref-for-effective-playback-rate①">(2)</a> <a href="#ref-for-effective-playback-rate②">(3)</a>
     <li><a href="#ref-for-effective-playback-rate③">4.4.13. Finishing an animation</a> <a href="#ref-for-effective-playback-rate④">(2)</a>
@@ -8912,8 +8915,9 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-effective-playback-rate⑧">4.4.17. Play states</a> <a href="#ref-for-effective-playback-rate⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply-any-pending-playback-rate">
-   <b><a href="#apply-any-pending-playback-rate">#apply-any-pending-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply-any-pending-playback-rate" class="dfn-panel" data-for="apply-any-pending-playback-rate" id="infopanel-for-apply-any-pending-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-apply-any-pending-playback-rate" style="display:none">Info about the 'apply any pending playback
+rate' definition.</span><b><a href="#apply-any-pending-playback-rate">#apply-any-pending-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply-any-pending-playback-rate">4.4.2. Setting the associated effect of an animation</a>
     <li><a href="#ref-for-apply-any-pending-playback-rate①">4.4.4. Setting the current time of an animation</a>
@@ -8924,20 +8928,20 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-apply-any-pending-playback-rate⑧">4.4.15.2. Seamlessly updating the playback rate of an animation</a> <a href="#ref-for-apply-any-pending-playback-rate⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="seamlessly-update-the-playback-rate">
-   <b><a href="#seamlessly-update-the-playback-rate">#seamlessly-update-the-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-seamlessly-update-the-playback-rate" class="dfn-panel" data-for="seamlessly-update-the-playback-rate" id="infopanel-for-seamlessly-update-the-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-seamlessly-update-the-playback-rate" style="display:none">Info about the 'seamlessly update the playback rate' definition.</span><b><a href="#seamlessly-update-the-playback-rate">#seamlessly-update-the-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-seamlessly-update-the-playback-rate">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reverse-an-animation">
-   <b><a href="#reverse-an-animation">#reverse-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reverse-an-animation" class="dfn-panel" data-for="reverse-an-animation" id="infopanel-for-reverse-an-animation" role="dialog">
+   <span id="infopaneltitle-for-reverse-an-animation" style="display:none">Info about the 'reverse an animation' definition.</span><b><a href="#reverse-an-animation">#reverse-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reverse-an-animation">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="play-state">
-   <b><a href="#play-state">#play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-play-state" class="dfn-panel" data-for="play-state" id="infopanel-for-play-state" role="dialog">
+   <span id="infopaneltitle-for-play-state" style="display:none">Info about the 'play states' definition.</span><b><a href="#play-state">#play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-state">4.4.9. Pausing an animation</a>
     <li><a href="#ref-for-play-state①">4.4.12. Updating the finished state</a> <a href="#ref-for-play-state②">(2)</a>
@@ -8949,8 +8953,8 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-play-state⑧">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idle-play-state">
-   <b><a href="#idle-play-state">#idle-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idle-play-state" class="dfn-panel" data-for="idle-play-state" id="infopanel-for-idle-play-state" role="dialog">
+   <span id="infopaneltitle-for-idle-play-state" style="display:none">Info about the 'idle' definition.</span><b><a href="#idle-play-state">#idle-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idle-play-state">4.4.13. Finishing an animation</a>
     <li><a href="#ref-for-idle-play-state①">4.4.14. Canceling an animation</a>
@@ -8961,8 +8965,8 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-idle-play-state⑥">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paused-play-state">
-   <b><a href="#paused-play-state">#paused-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paused-play-state" class="dfn-panel" data-for="paused-play-state" id="infopanel-for-paused-play-state" role="dialog">
+   <span id="infopaneltitle-for-paused-play-state" style="display:none">Info about the 'paused' definition.</span><b><a href="#paused-play-state">#paused-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paused-play-state">4.4.9. Pausing an animation</a> <a href="#ref-for-paused-play-state①">(2)</a>
     <li><a href="#ref-for-paused-play-state②">4.4.15. Speed control</a>
@@ -8971,8 +8975,8 @@ states</a> <a href="#ref-for-playback-rate③⑥">(2)</a> <a href="#ref-for-play
     <li><a href="#ref-for-paused-play-state⑦">6.4.1. The AnimationPlayState enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finished-play-state">
-   <b><a href="#finished-play-state">#finished-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finished-play-state" class="dfn-panel" data-for="finished-play-state" id="infopanel-for-finished-play-state" role="dialog">
+   <span id="infopaneltitle-for-finished-play-state" style="display:none">Info about the 'finished' definition.</span><b><a href="#finished-play-state">#finished-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finished-play-state">4.4.1. Setting the timeline of an animation</a>
     <li><a href="#ref-for-finished-play-state①">4.4.9. Pausing an animation</a>
@@ -8987,23 +8991,23 @@ states</a>
     <li><a href="#ref-for-finished-play-state①⑤">6.4.1. The AnimationPlayState enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="running-play-state">
-   <b><a href="#running-play-state">#running-play-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-running-play-state" class="dfn-panel" data-for="running-play-state" id="infopanel-for-running-play-state" role="dialog">
+   <span id="infopaneltitle-for-running-play-state" style="display:none">Info about the 'running' definition.</span><b><a href="#running-play-state">#running-play-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running-play-state">4.4.7. The current ready promise</a>
     <li><a href="#ref-for-running-play-state①">4.4.17. Play states</a>
     <li><a href="#ref-for-running-play-state②">6.4.1. The AnimationPlayState enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-events">
-   <b><a href="#animation-events">#animation-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-events" class="dfn-panel" data-for="animation-events" id="infopanel-for-animation-events" role="dialog">
+   <span id="infopaneltitle-for-animation-events" style="display:none">Info about the 'Animation events' definition.</span><b><a href="#animation-events">#animation-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-events">4.3. Timelines</a> <a href="#ref-for-animation-events①">(2)</a>
     <li><a href="#ref-for-animation-events②">4.4.18. Animation events</a> <a href="#ref-for-animation-events③">(2)</a> <a href="#ref-for-animation-events④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-animation-event-queue">
-   <b><a href="#pending-animation-event-queue">#pending-animation-event-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-animation-event-queue" class="dfn-panel" data-for="pending-animation-event-queue" id="infopanel-for-pending-animation-event-queue" role="dialog">
+   <span id="infopaneltitle-for-pending-animation-event-queue" style="display:none">Info about the 'pending animation event queue' definition.</span><b><a href="#pending-animation-event-queue">#pending-animation-event-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-animation-event-queue">4.3. Timelines</a> <a href="#ref-for-pending-animation-event-queue①">(2)</a>
     <li><a href="#ref-for-pending-animation-event-queue②">4.4.12. Updating the finished state</a>
@@ -9011,8 +9015,8 @@ states</a>
     <li><a href="#ref-for-pending-animation-event-queue④">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheduled-event-time">
-   <b><a href="#scheduled-event-time">#scheduled-event-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheduled-event-time" class="dfn-panel" data-for="scheduled-event-time" id="infopanel-for-scheduled-event-time" role="dialog">
+   <span id="infopaneltitle-for-scheduled-event-time" style="display:none">Info about the 'scheduled event time' definition.</span><b><a href="#scheduled-event-time">#scheduled-event-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheduled-event-time">4.3. Timelines</a> <a href="#ref-for-scheduled-event-time①">(2)</a>
     <li><a href="#ref-for-scheduled-event-time②">4.4.12. Updating the finished state</a>
@@ -9021,35 +9025,38 @@ states</a>
     <li><a href="#ref-for-scheduled-event-time⑥">5.5.2. Removing replaced animations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-time-to-timeline-time">
-   <b><a href="#animation-time-to-timeline-time">#animation-time-to-timeline-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-time-to-timeline-time" class="dfn-panel" data-for="animation-time-to-timeline-time" id="infopanel-for-animation-time-to-timeline-time" role="dialog">
+   <span id="infopaneltitle-for-animation-time-to-timeline-time" style="display:none">Info about the 'convert an animation time to
+timeline time a time value, time, that is relative to the start
+time of an animation, animation, perform the following steps:' definition.</span><b><a href="#animation-time-to-timeline-time">#animation-time-to-timeline-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-time-to-timeline-time">4.4.18.1. Sorting animation events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-time-to-origin-relative-time">
-   <b><a href="#animation-time-to-origin-relative-time">#animation-time-to-origin-relative-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-time-to-origin-relative-time" class="dfn-panel" data-for="animation-time-to-origin-relative-time" id="infopanel-for-animation-time-to-origin-relative-time" role="dialog">
+   <span id="infopaneltitle-for-animation-time-to-origin-relative-time" style="display:none">Info about the 'convert a timeline time to
+an origin-relative time' definition.</span><b><a href="#animation-time-to-origin-relative-time">#animation-time-to-origin-relative-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-time-to-origin-relative-time">4.4.12. Updating the finished state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-playback-events">
-   <b><a href="#animation-playback-events">#animation-playback-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-playback-events" class="dfn-panel" data-for="animation-playback-events" id="infopanel-for-animation-playback-events" role="dialog">
+   <span id="infopaneltitle-for-animation-playback-events" style="display:none">Info about the 'animation playback events' definition.</span><b><a href="#animation-playback-events">#animation-playback-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-playback-events">4.4.18. Animation events</a>
     <li><a href="#ref-for-animation-playback-events①">4.4.18.2. Animation playback events</a>
     <li><a href="#ref-for-animation-playback-events②">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finish-event">
-   <b><a href="#finish-event">#finish-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finish-event" class="dfn-panel" data-for="finish-event" id="infopanel-for-finish-event" role="dialog">
+   <span id="infopaneltitle-for-finish-event" style="display:none">Info about the 'finish' definition.</span><b><a href="#finish-event">#finish-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finish-event">4.4.12. Updating the finished state</a> <a href="#ref-for-finish-event①">(2)</a>
     <li><a href="#ref-for-finish-event②">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cancel-event">
-   <b><a href="#cancel-event">#cancel-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cancel-event" class="dfn-panel" data-for="cancel-event" id="infopanel-for-cancel-event" role="dialog">
+   <span id="infopaneltitle-for-cancel-event" style="display:none">Info about the 'cancel' definition.</span><b><a href="#cancel-event">#cancel-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-event">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-cancel-event①">4.4.14. Canceling an animation</a>
@@ -9057,16 +9064,16 @@ states</a>
     <li><a href="#ref-for-cancel-event③">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-event">
-   <b><a href="#remove-event">#remove-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-event" class="dfn-panel" data-for="remove-event" id="infopanel-for-remove-event" role="dialog">
+   <span id="infopaneltitle-for-remove-event" style="display:none">Info about the 'remove' definition.</span><b><a href="#remove-event">#remove-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-event">5.5.2. Removing replaced animations</a>
     <li><a href="#ref-for-remove-event①">6.4. The Animation interface</a>
     <li><a href="#ref-for-remove-event②">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-effect">
-   <b><a href="#animation-effect">#animation-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-effect" class="dfn-panel" data-for="animation-effect" id="infopanel-for-animation-effect" role="dialog">
+   <span id="infopaneltitle-for-animation-effect" style="display:none">Info about the 'animation effect' definition.</span><b><a href="#animation-effect">#animation-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect">2. Specification conventions</a>
     <li><a href="#ref-for-animation-effect①">4.3. Timelines</a>
@@ -9106,8 +9113,8 @@ states</a> <a href="#ref-for-animation-effect②④">(2)</a> <a href="#ref-for-a
     <li><a href="#ref-for-animation-effect①①③">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-with-an-animation">
-   <b><a href="#associated-with-an-animation">#associated-with-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-with-an-animation" class="dfn-panel" data-for="associated-with-an-animation" id="infopanel-for-associated-with-an-animation" role="dialog">
+   <span id="infopaneltitle-for-associated-with-an-animation" style="display:none">Info about the 'associated' definition.</span><b><a href="#associated-with-an-animation">#associated-with-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-with-an-animation">4.5.1. Relationship between animation effects
   and animations</a> <a href="#ref-for-associated-with-an-animation①">(2)</a>
@@ -9120,14 +9127,15 @@ states</a> <a href="#ref-for-associated-with-an-animation④">(2)</a> <a href="#
     <li><a href="#ref-for-associated-with-an-animation①④">6.5.5. The ComputedEffectTiming dictionary</a> <a href="#ref-for-associated-with-an-animation①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-with-a-timeline">
-   <b><a href="#associated-with-a-timeline">#associated-with-a-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-with-a-timeline" class="dfn-panel" data-for="associated-with-a-timeline" id="infopanel-for-associated-with-a-timeline" role="dialog">
+   <span id="infopaneltitle-for-associated-with-a-timeline" style="display:none">Info about the 'associated with
+a timeline' definition.</span><b><a href="#associated-with-a-timeline">#associated-with-a-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-with-a-timeline">4.3. Timelines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-interval">
-   <b><a href="#active-interval">#active-interval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-interval" class="dfn-panel" data-for="active-interval" id="infopanel-for-active-interval" role="dialog">
+   <span id="infopaneltitle-for-active-interval" style="display:none">Info about the 'active interval' definition.</span><b><a href="#active-interval">#active-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-interval">4.5.3. The active interval</a> <a href="#ref-for-active-interval①">(2)</a> <a href="#ref-for-active-interval②">(3)</a> <a href="#ref-for-active-interval③">(4)</a> <a href="#ref-for-active-interval④">(5)</a> <a href="#ref-for-active-interval⑤">(6)</a> <a href="#ref-for-active-interval⑥">(7)</a> <a href="#ref-for-active-interval⑦">(8)</a> <a href="#ref-for-active-interval⑧">(9)</a>
     <li><a href="#ref-for-active-interval⑨">4.5.5. Animation effect phases and
@@ -9138,8 +9146,8 @@ states</a> <a href="#ref-for-active-interval①⓪">(2)</a> <a href="#ref-for-ac
     <li><a href="#ref-for-active-interval①⑥">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-active-interval①⑦">(2)</a> <a href="#ref-for-active-interval①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-delay">
-   <b><a href="#start-delay">#start-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-delay" class="dfn-panel" data-for="start-delay" id="infopanel-for-start-delay" role="dialog">
+   <span id="infopaneltitle-for-start-delay" style="display:none">Info about the 'start delay' definition.</span><b><a href="#start-delay">#start-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">4.5.3. The active interval</a> <a href="#ref-for-start-delay①">(2)</a> <a href="#ref-for-start-delay②">(3)</a> <a href="#ref-for-start-delay③">(4)</a> <a href="#ref-for-start-delay④">(5)</a> <a href="#ref-for-start-delay⑤">(6)</a>
     <li><a href="#ref-for-start-delay⑥">4.5.5. Animation effect phases and
@@ -9152,8 +9160,8 @@ states</a> <a href="#ref-for-start-delay⑦">(2)</a> <a href="#ref-for-start-del
     <li><a href="#ref-for-start-delay①⑨">6.6.1. Creating a new KeyframeEffect object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-delay">
-   <b><a href="#end-delay">#end-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-delay" class="dfn-panel" data-for="end-delay" id="infopanel-for-end-delay" role="dialog">
+   <span id="infopaneltitle-for-end-delay" style="display:none">Info about the 'end delay' definition.</span><b><a href="#end-delay">#end-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-delay">4.5.3. The active interval</a> <a href="#ref-for-end-delay①">(2)</a>
     <li><a href="#ref-for-end-delay②">4.5.5. Animation effect phases and
@@ -9164,8 +9172,8 @@ states</a> <a href="#ref-for-end-delay③">(2)</a>
     <li><a href="#ref-for-end-delay⑦">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-time">
-   <b><a href="#end-time">#end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-time" class="dfn-panel" data-for="end-time" id="infopanel-for-end-time" role="dialog">
+   <span id="infopaneltitle-for-end-time" style="display:none">Info about the 'end time' definition.</span><b><a href="#end-time">#end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-time">4.4.10. Reaching the end</a> <a href="#ref-for-end-time①">(2)</a>
     <li><a href="#ref-for-end-time②">4.4.12. Updating the finished state</a>
@@ -9176,8 +9184,8 @@ states</a> <a href="#ref-for-end-time⑤">(2)</a> <a href="#ref-for-end-time⑥"
     <li><a href="#ref-for-end-time⑨">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-time">
-   <b><a href="#local-time">#local-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-time" class="dfn-panel" data-for="local-time" id="infopanel-for-local-time" role="dialog">
+   <span id="infopaneltitle-for-local-time" style="display:none">Info about the 'local time' definition.</span><b><a href="#local-time">#local-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-time">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-local-time①">(2)</a> <a href="#ref-for-local-time②">(3)</a> <a href="#ref-for-local-time③">(4)</a> <a href="#ref-for-local-time④">(5)</a> <a href="#ref-for-local-time⑤">(6)</a> <a href="#ref-for-local-time⑥">(7)</a> <a href="#ref-for-local-time⑦">(8)</a> <a href="#ref-for-local-time⑧">(9)</a> <a href="#ref-for-local-time⑨">(10)</a> <a href="#ref-for-local-time①⓪">(11)</a>
@@ -9186,29 +9194,29 @@ states</a> <a href="#ref-for-local-time①">(2)</a> <a href="#ref-for-local-time
     <li><a href="#ref-for-local-time②①">6.5.5. The ComputedEffectTiming dictionary</a> <a href="#ref-for-local-time②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-direction">
-   <b><a href="#animation-direction">#animation-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-direction" class="dfn-panel" data-for="animation-direction" id="infopanel-for-animation-direction" role="dialog">
+   <span id="infopaneltitle-for-animation-direction" style="display:none">Info about the 'animation direction' definition.</span><b><a href="#animation-direction">#animation-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-direction">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-animation-direction①">(2)</a> <a href="#ref-for-animation-direction②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="before-active-boundary-time">
-   <b><a href="#before-active-boundary-time">#before-active-boundary-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-before-active-boundary-time" class="dfn-panel" data-for="before-active-boundary-time" id="infopanel-for-before-active-boundary-time" role="dialog">
+   <span id="infopaneltitle-for-before-active-boundary-time" style="display:none">Info about the 'before-active boundary time' definition.</span><b><a href="#before-active-boundary-time">#before-active-boundary-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-active-boundary-time">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-before-active-boundary-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-after-boundary-time">
-   <b><a href="#active-after-boundary-time">#active-after-boundary-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-after-boundary-time" class="dfn-panel" data-for="active-after-boundary-time" id="infopanel-for-active-after-boundary-time" role="dialog">
+   <span id="infopaneltitle-for-active-after-boundary-time" style="display:none">Info about the 'active-after boundary time' definition.</span><b><a href="#active-after-boundary-time">#active-after-boundary-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-after-boundary-time">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-active-after-boundary-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="before-phase">
-   <b><a href="#before-phase">#before-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-before-phase" class="dfn-panel" data-for="before-phase" id="infopanel-for-before-phase" role="dialog">
+   <span id="infopaneltitle-for-before-phase" style="display:none">Info about the 'before phase' definition.</span><b><a href="#before-phase">#before-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-phase">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-before-phase①">(2)</a> <a href="#ref-for-before-phase②">(3)</a>
@@ -9219,8 +9227,8 @@ states</a> <a href="#ref-for-before-phase①">(2)</a> <a href="#ref-for-before-p
     <li><a href="#ref-for-before-phase⑧">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="after-phase">
-   <b><a href="#after-phase">#after-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-after-phase" class="dfn-panel" data-for="after-phase" id="infopanel-for-after-phase" role="dialog">
+   <span id="infopaneltitle-for-after-phase" style="display:none">Info about the 'after phase' definition.</span><b><a href="#after-phase">#after-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-after-phase">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-after-phase①">(2)</a> <a href="#ref-for-after-phase②">(3)</a>
@@ -9232,8 +9240,8 @@ states</a> <a href="#ref-for-after-phase①">(2)</a> <a href="#ref-for-after-pha
     <li><a href="#ref-for-after-phase⑨">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-phase">
-   <b><a href="#active-phase">#active-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-phase" class="dfn-panel" data-for="active-phase" id="infopanel-for-active-phase" role="dialog">
+   <span id="infopaneltitle-for-active-phase" style="display:none">Info about the 'active phase' definition.</span><b><a href="#active-phase">#active-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-phase">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-phase②">(3)</a> <a href="#ref-for-active-phase③">(4)</a>
@@ -9243,8 +9251,8 @@ states</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-p
     <li><a href="#ref-for-active-phase⑦">5.6. Side effects of animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-play">
-   <b><a href="#in-play">#in-play</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-play" class="dfn-panel" data-for="in-play" id="infopanel-for-in-play" role="dialog">
+   <span id="infopaneltitle-for-in-play" style="display:none">Info about the 'in play' definition.</span><b><a href="#in-play">#in-play</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-play">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-in-play①">(2)</a> <a href="#ref-for-in-play②">(3)</a> <a href="#ref-for-in-play③">(4)</a>
@@ -9253,8 +9261,8 @@ states</a> <a href="#ref-for-in-play①">(2)</a> <a href="#ref-for-in-play②">(
     <li><a href="#ref-for-in-play①⓪">4.7.4. Interval timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current">
-   <b><a href="#current">#current</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current" class="dfn-panel" data-for="current" id="infopanel-for-current" role="dialog">
+   <span id="infopaneltitle-for-current" style="display:none">Info about the 'current' definition.</span><b><a href="#current">#current</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current">4.5.5. Animation effect phases and
 states</a>
@@ -9263,8 +9271,8 @@ states</a>
     <li><a href="#ref-for-current③">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-effect">
-   <b><a href="#in-effect">#in-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-effect" class="dfn-panel" data-for="in-effect" id="infopanel-for-in-effect" role="dialog">
+   <span id="infopaneltitle-for-in-effect" style="display:none">Info about the 'in effect' definition.</span><b><a href="#in-effect">#in-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-effect">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-in-effect①">(2)</a>
@@ -9274,8 +9282,8 @@ states</a> <a href="#ref-for-in-effect①">(2)</a>
     <li><a href="#ref-for-in-effect⑥">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fill-mode">
-   <b><a href="#fill-mode">#fill-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fill-mode" class="dfn-panel" data-for="fill-mode" id="infopanel-for-fill-mode" role="dialog">
+   <span id="infopaneltitle-for-fill-mode" style="display:none">Info about the 'fill mode' definition.</span><b><a href="#fill-mode">#fill-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-mode">4.5.3. The active interval</a>
     <li><a href="#ref-for-fill-mode①">4.5.5. Animation effect phases and
@@ -9289,16 +9297,17 @@ states</a>
     <li><a href="#ref-for-fill-mode①⑤">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-interval">
-   <b><a href="#iteration-interval">#iteration-interval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-interval" class="dfn-panel" data-for="iteration-interval" id="infopanel-for-iteration-interval" role="dialog">
+   <span id="infopaneltitle-for-iteration-interval" style="display:none">Info about the 'iteration interval' definition.</span><b><a href="#iteration-interval">#iteration-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-interval">4.7.1. Iteration intervals</a>
     <li><a href="#ref-for-iteration-interval①">4.7.2. Controlling iteration</a>
     <li><a href="#ref-for-iteration-interval②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-duration">
-   <b><a href="#iteration-duration">#iteration-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-duration" class="dfn-panel" data-for="iteration-duration" id="infopanel-for-iteration-duration" role="dialog">
+   <span id="infopaneltitle-for-iteration-duration" style="display:none">Info about the 'iteration
+duration' definition.</span><b><a href="#iteration-duration">#iteration-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-duration">2. Specification conventions</a>
     <li><a href="#ref-for-iteration-duration①">4.7.1. Iteration intervals</a> <a href="#ref-for-iteration-duration②">(2)</a> <a href="#ref-for-iteration-duration③">(3)</a> <a href="#ref-for-iteration-duration④">(4)</a> <a href="#ref-for-iteration-duration⑤">(5)</a> <a href="#ref-for-iteration-duration⑥">(6)</a>
@@ -9314,8 +9323,8 @@ states</a>
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-count">
-   <b><a href="#iteration-count">#iteration-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-count" class="dfn-panel" data-for="iteration-count" id="infopanel-for-iteration-count" role="dialog">
+   <span id="infopaneltitle-for-iteration-count" style="display:none">Info about the 'iteration count' definition.</span><b><a href="#iteration-count">#iteration-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-count">4.7.1. Iteration intervals</a>
     <li><a href="#ref-for-iteration-count①">4.7.2. Controlling iteration</a> <a href="#ref-for-iteration-count②">(2)</a> <a href="#ref-for-iteration-count③">(3)</a> <a href="#ref-for-iteration-count④">(4)</a> <a href="#ref-for-iteration-count⑤">(5)</a> <a href="#ref-for-iteration-count⑥">(6)</a> <a href="#ref-for-iteration-count⑦">(7)</a>
@@ -9329,8 +9338,8 @@ argument</a>
     <li><a href="#ref-for-iteration-count①⑦">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-start">
-   <b><a href="#iteration-start">#iteration-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-start" class="dfn-panel" data-for="iteration-start" id="infopanel-for-iteration-start" role="dialog">
+   <span id="infopaneltitle-for-iteration-start" style="display:none">Info about the 'iteration start' definition.</span><b><a href="#iteration-start">#iteration-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-start">4.7.2. Controlling iteration</a> <a href="#ref-for-iteration-start①">(2)</a> <a href="#ref-for-iteration-start②">(3)</a> <a href="#ref-for-iteration-start③">(4)</a> <a href="#ref-for-iteration-start④">(5)</a> <a href="#ref-for-iteration-start⑤">(6)</a>
     <li><a href="#ref-for-iteration-start⑥">4.8.1. Overview</a>
@@ -9341,8 +9350,8 @@ argument</a>
     <li><a href="#ref-for-iteration-start①①">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-duration">
-   <b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-duration" class="dfn-panel" data-for="active-duration" id="infopanel-for-active-duration" role="dialog">
+   <span id="infopaneltitle-for-active-duration" style="display:none">Info about the 'active duration' definition.</span><b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-duration">4.5.3. The active interval</a> <a href="#ref-for-active-duration①">(2)</a> <a href="#ref-for-active-duration②">(3)</a> <a href="#ref-for-active-duration③">(4)</a>
     <li><a href="#ref-for-active-duration④">4.5.5. Animation effect phases and
@@ -9356,8 +9365,8 @@ states</a>
     <li><a href="#ref-for-active-duration①⑧">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-time">
-   <b><a href="#active-time">#active-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-time" class="dfn-panel" data-for="active-time" id="infopanel-for-active-time" role="dialog">
+   <span id="infopaneltitle-for-active-time" style="display:none">Info about the 'active time' definition.</span><b><a href="#active-time">#active-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-time">4.5.5. Animation effect phases and
 states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-time②">(3)</a> <a href="#ref-for-active-time③">(4)</a>
@@ -9370,24 +9379,24 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-active-time①④">4.8.4. Calculating the current iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="overall-progress">
-   <b><a href="#overall-progress">#overall-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-overall-progress" class="dfn-panel" data-for="overall-progress" id="infopanel-for-overall-progress" role="dialog">
+   <span id="infopaneltitle-for-overall-progress" style="display:none">Info about the 'overall progress' definition.</span><b><a href="#overall-progress">#overall-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overall-progress">4.8.1. Overview</a> <a href="#ref-for-overall-progress①">(2)</a>
     <li><a href="#ref-for-overall-progress②">4.8.3.3. Calculating the simple iteration progress</a> <a href="#ref-for-overall-progress③">(2)</a> <a href="#ref-for-overall-progress④">(3)</a>
     <li><a href="#ref-for-overall-progress⑤">4.8.4. Calculating the current iteration</a> <a href="#ref-for-overall-progress⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-iteration-progress">
-   <b><a href="#simple-iteration-progress">#simple-iteration-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-iteration-progress" class="dfn-panel" data-for="simple-iteration-progress" id="infopanel-for-simple-iteration-progress" role="dialog">
+   <span id="infopaneltitle-for-simple-iteration-progress" style="display:none">Info about the 'simple iteration progress' definition.</span><b><a href="#simple-iteration-progress">#simple-iteration-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-iteration-progress">4.8.1. Overview</a> <a href="#ref-for-simple-iteration-progress①">(2)</a>
     <li><a href="#ref-for-simple-iteration-progress②">4.8.4. Calculating the current iteration</a>
     <li><a href="#ref-for-simple-iteration-progress③">4.9.1. Calculating the directed progress</a> <a href="#ref-for-simple-iteration-progress④">(2)</a> <a href="#ref-for-simple-iteration-progress⑤">(3)</a> <a href="#ref-for-simple-iteration-progress⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-iteration">
-   <b><a href="#current-iteration">#current-iteration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-iteration" class="dfn-panel" data-for="current-iteration" id="infopanel-for-current-iteration" role="dialog">
+   <span id="infopaneltitle-for-current-iteration" style="display:none">Info about the 'current iteration' definition.</span><b><a href="#current-iteration">#current-iteration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-iteration">4.7.1. Iteration intervals</a>
     <li><a href="#ref-for-current-iteration①">4.9.1. Calculating the directed progress</a>
@@ -9397,8 +9406,9 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-current-iteration⑤">6.5.5. The ComputedEffectTiming dictionary</a> <a href="#ref-for-current-iteration⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="playback-direction">
-   <b><a href="#playback-direction">#playback-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-playback-direction" class="dfn-panel" data-for="playback-direction" id="infopanel-for-playback-direction" role="dialog">
+   <span id="infopaneltitle-for-playback-direction" style="display:none">Info about the 'playback
+direction' definition.</span><b><a href="#playback-direction">#playback-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-direction">4.8.1. Overview</a>
     <li><a href="#ref-for-playback-direction①">4.8.3.3. Calculating the simple iteration progress</a>
@@ -9408,23 +9418,23 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-playback-direction⑦">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directed-progress">
-   <b><a href="#directed-progress">#directed-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directed-progress" class="dfn-panel" data-for="directed-progress" id="infopanel-for-directed-progress" role="dialog">
+   <span id="infopaneltitle-for-directed-progress" style="display:none">Info about the 'directed progress' definition.</span><b><a href="#directed-progress">#directed-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directed-progress">4.8.1. Overview</a> <a href="#ref-for-directed-progress①">(2)</a>
     <li><a href="#ref-for-directed-progress②">4.9. Direction control</a>
     <li><a href="#ref-for-directed-progress③">4.10.1. Calculating the transformed progress</a> <a href="#ref-for-directed-progress④">(2)</a> <a href="#ref-for-directed-progress⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformed-progress">
-   <b><a href="#transformed-progress">#transformed-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformed-progress" class="dfn-panel" data-for="transformed-progress" id="infopanel-for-transformed-progress" role="dialog">
+   <span id="infopaneltitle-for-transformed-progress" style="display:none">Info about the 'transformed progress' definition.</span><b><a href="#transformed-progress">#transformed-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-progress">4.8.1. Overview</a> <a href="#ref-for-transformed-progress①">(2)</a>
     <li><a href="#ref-for-transformed-progress②">4.11. The iteration progress</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-progress">
-   <b><a href="#iteration-progress">#iteration-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-progress" class="dfn-panel" data-for="iteration-progress" id="infopanel-for-iteration-progress" role="dialog">
+   <span id="infopaneltitle-for-iteration-progress" style="display:none">Info about the 'iteration progress' definition.</span><b><a href="#iteration-progress">#iteration-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-progress">4.6.1. Fill modes</a> <a href="#ref-for-iteration-progress①">(2)</a> <a href="#ref-for-iteration-progress②">(3)</a>
     <li><a href="#ref-for-iteration-progress③">4.7.3. Iteration time space</a>
@@ -9436,8 +9446,9 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-iteration-progress①②">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-property">
-   <b><a href="#target-property">#target-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-property" class="dfn-panel" data-for="target-property" id="infopanel-for-target-property" role="dialog">
+   <span id="infopaneltitle-for-target-property" style="display:none">Info about the 'target
+properties' definition.</span><b><a href="#target-property">#target-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-property">5.1. Introduction</a>
     <li><a href="#ref-for-target-property①">5.3.4. The effect value of a keyframe effect</a>
@@ -9449,8 +9460,8 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-target-property①②">6.4. The Animation interface</a> <a href="#ref-for-target-property①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effect-value">
-   <b><a href="#effect-value">#effect-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effect-value" class="dfn-panel" data-for="effect-value" id="infopanel-for-effect-value" role="dialog">
+   <span id="infopaneltitle-for-effect-value" style="display:none">Info about the 'effect value' definition.</span><b><a href="#effect-value">#effect-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-value">5.3.1. Keyframes</a>
     <li><a href="#ref-for-effect-value①">5.3.2. Computing property values</a>
@@ -9462,14 +9473,14 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-effect-value②②">6.4. The Animation interface</a> <a href="#ref-for-effect-value②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-animatable">
-   <b><a href="#concept-animatable">#concept-animatable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-animatable" class="dfn-panel" data-for="concept-animatable" id="infopanel-for-concept-animatable" role="dialog">
+   <span id="infopaneltitle-for-concept-animatable" style="display:none">Info about the 'animatable' definition.</span><b><a href="#concept-animatable">#concept-animatable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-animatable">5.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-type">
-   <b><a href="#animation-type">#animation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-type" class="dfn-panel" data-for="animation-type" id="infopanel-for-animation-type" role="dialog">
+   <span id="infopaneltitle-for-animation-type" style="display:none">Info about the 'Animation type' definition.</span><b><a href="#animation-type">#animation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-type">5.1. Introduction</a>
     <li><a href="#ref-for-animation-type①">5.2. Animating properties</a> <a href="#ref-for-animation-type②">(2)</a>
@@ -9480,15 +9491,15 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-animation-type①③">Animation of font-weight</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="not-animatable">
-   <b><a href="#not-animatable">#not-animatable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-not-animatable" class="dfn-panel" data-for="not-animatable" id="infopanel-for-not-animatable" role="dialog">
+   <span id="infopaneltitle-for-not-animatable" style="display:none">Info about the 'not animatable' definition.</span><b><a href="#not-animatable">#not-animatable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-animatable">5.2. Animating properties</a> <a href="#ref-for-not-animatable①">(2)</a>
     <li><a href="#ref-for-not-animatable②">5.3.4. The effect value of a keyframe effect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discrete">
-   <b><a href="#discrete">#discrete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discrete" class="dfn-panel" data-for="discrete" id="infopanel-for-discrete" role="dialog">
+   <span id="infopaneltitle-for-discrete" style="display:none">Info about the 'discrete' definition.</span><b><a href="#discrete">#discrete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discrete">5.2. Animating properties</a> <a href="#ref-for-discrete①">(2)</a> <a href="#ref-for-discrete②">(3)</a> <a href="#ref-for-discrete③">(4)</a>
     <li><a href="#ref-for-discrete④">5.2.1. Custom Properties</a>
@@ -9496,8 +9507,8 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-discrete⑥">Animation of box-shadow</a> <a href="#ref-for-discrete⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="by-computed-value">
-   <b><a href="#by-computed-value">#by-computed-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-by-computed-value" class="dfn-panel" data-for="by-computed-value" id="infopanel-for-by-computed-value" role="dialog">
+   <span id="infopaneltitle-for-by-computed-value" style="display:none">Info about the 'by computed value' definition.</span><b><a href="#by-computed-value">#by-computed-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-by-computed-value">5.2. Animating properties</a> <a href="#ref-for-by-computed-value①">(2)</a>
     <li><a href="#ref-for-by-computed-value②">5.2.1. Custom Properties</a>
@@ -9506,8 +9517,8 @@ states</a> <a href="#ref-for-active-time①">(2)</a> <a href="#ref-for-active-ti
     <li><a href="#ref-for-by-computed-value⑤">Animation of box-shadow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyframe-effect">
-   <b><a href="#keyframe-effect">#keyframe-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyframe-effect" class="dfn-panel" data-for="keyframe-effect" id="infopanel-for-keyframe-effect" role="dialog">
+   <span id="infopaneltitle-for-keyframe-effect" style="display:none">Info about the 'Keyframe effects' definition.</span><b><a href="#keyframe-effect">#keyframe-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe-effect">4.4.6. Waiting for the associated effect</a>
     <li><a href="#ref-for-keyframe-effect①">4.5.2. Types of animation effects</a>
@@ -9525,8 +9536,8 @@ argument</a> <a href="#ref-for-keyframe-effect④⓪">(2)</a>
     <li><a href="#ref-for-keyframe-effect④①">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-keyframe-effect④②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effect-target">
-   <b><a href="#effect-target">#effect-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effect-target" class="dfn-panel" data-for="effect-target" id="infopanel-for-effect-target" role="dialog">
+   <span id="infopaneltitle-for-effect-target" style="display:none">Info about the 'effect target' definition.</span><b><a href="#effect-target">#effect-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-target">5.3. Keyframe effects</a> <a href="#ref-for-effect-target①">(2)</a> <a href="#ref-for-effect-target②">(3)</a> <a href="#ref-for-effect-target③">(4)</a>
     <li><a href="#ref-for-effect-target④">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-effect-target⑤">(2)</a>
@@ -9539,8 +9550,8 @@ argument</a> <a href="#ref-for-keyframe-effect④⓪">(2)</a>
     <li><a href="#ref-for-effect-target②②">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-element">
-   <b><a href="#target-element">#target-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-element" class="dfn-panel" data-for="target-element" id="infopanel-for-target-element" role="dialog">
+   <span id="infopaneltitle-for-target-element" style="display:none">Info about the 'target element' definition.</span><b><a href="#target-element">#target-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-element">5.3. Keyframe effects</a> <a href="#ref-for-target-element①">(2)</a>
     <li><a href="#ref-for-target-element②">5.3.2. Computing property values</a>
@@ -9551,15 +9562,15 @@ argument</a> <a href="#ref-for-keyframe-effect④⓪">(2)</a>
     <li><a href="#ref-for-target-element①⓪">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="target-pseudo-selector">
-   <b><a href="#target-pseudo-selector">#target-pseudo-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-target-pseudo-selector" class="dfn-panel" data-for="target-pseudo-selector" id="infopanel-for-target-pseudo-selector" role="dialog">
+   <span id="infopaneltitle-for-target-pseudo-selector" style="display:none">Info about the 'target pseudo-selector' definition.</span><b><a href="#target-pseudo-selector">#target-pseudo-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-pseudo-selector">5.3. Keyframe effects</a> <a href="#ref-for-target-pseudo-selector①">(2)</a>
     <li><a href="#ref-for-target-pseudo-selector②">6.6. The KeyframeEffect interface</a> <a href="#ref-for-target-pseudo-selector③">(2)</a> <a href="#ref-for-target-pseudo-selector④">(3)</a> <a href="#ref-for-target-pseudo-selector⑤">(4)</a> <a href="#ref-for-target-pseudo-selector⑥">(5)</a> <a href="#ref-for-target-pseudo-selector⑦">(6)</a> <a href="#ref-for-target-pseudo-selector⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyframe">
-   <b><a href="#keyframe">#keyframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyframe" class="dfn-panel" data-for="keyframe" id="infopanel-for-keyframe" role="dialog">
+   <span id="infopaneltitle-for-keyframe" style="display:none">Info about the 'keyframe' definition.</span><b><a href="#keyframe">#keyframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe">5.3.1. Keyframes</a> <a href="#ref-for-keyframe①">(2)</a> <a href="#ref-for-keyframe②">(3)</a> <a href="#ref-for-keyframe③">(4)</a> <a href="#ref-for-keyframe④">(5)</a> <a href="#ref-for-keyframe⑤">(6)</a> <a href="#ref-for-keyframe⑥">(7)</a>
     <li><a href="#ref-for-keyframe⑦">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-keyframe⑧">(2)</a> <a href="#ref-for-keyframe⑨">(3)</a> <a href="#ref-for-keyframe①⓪">(4)</a> <a href="#ref-for-keyframe①①">(5)</a> <a href="#ref-for-keyframe①②">(6)</a> <a href="#ref-for-keyframe①③">(7)</a> <a href="#ref-for-keyframe①④">(8)</a> <a href="#ref-for-keyframe①⑤">(9)</a> <a href="#ref-for-keyframe①⑥">(10)</a> <a href="#ref-for-keyframe①⑦">(11)</a> <a href="#ref-for-keyframe①⑧">(12)</a> <a href="#ref-for-keyframe①⑨">(13)</a> <a href="#ref-for-keyframe②⓪">(14)</a> <a href="#ref-for-keyframe②①">(15)</a> <a href="#ref-for-keyframe②②">(16)</a>
@@ -9572,8 +9583,8 @@ argument</a> <a href="#ref-for-keyframe⑤⑦">(2)</a> <a href="#ref-for-keyfram
     <li><a href="#ref-for-keyframe⑦①">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyframe-offset">
-   <b><a href="#keyframe-offset">#keyframe-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyframe-offset" class="dfn-panel" data-for="keyframe-offset" id="infopanel-for-keyframe-offset" role="dialog">
+   <span id="infopaneltitle-for-keyframe-offset" style="display:none">Info about the 'offset of a keyframe' definition.</span><b><a href="#keyframe-offset">#keyframe-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe-offset">5.3.1. Keyframes</a> <a href="#ref-for-keyframe-offset①">(2)</a>
     <li><a href="#ref-for-keyframe-offset②">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-keyframe-offset③">(2)</a> <a href="#ref-for-keyframe-offset④">(3)</a> <a href="#ref-for-keyframe-offset⑤">(4)</a>
@@ -9582,15 +9593,16 @@ argument</a> <a href="#ref-for-keyframe⑤⑦">(2)</a> <a href="#ref-for-keyfram
 argument</a> <a href="#ref-for-keyframe-offset⑨">(2)</a> <a href="#ref-for-keyframe-offset①⓪">(3)</a> <a href="#ref-for-keyframe-offset①①">(4)</a> <a href="#ref-for-keyframe-offset①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="loosely-sorted-by-offset">
-   <b><a href="#loosely-sorted-by-offset">#loosely-sorted-by-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-loosely-sorted-by-offset" class="dfn-panel" data-for="loosely-sorted-by-offset" id="infopanel-for-loosely-sorted-by-offset" role="dialog">
+   <span id="infopaneltitle-for-loosely-sorted-by-offset" style="display:none">Info about the 'loosely sorted by offset' definition.</span><b><a href="#loosely-sorted-by-offset">#loosely-sorted-by-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-loosely-sorted-by-offset">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyframe-specific-composite-operation">
-   <b><a href="#keyframe-specific-composite-operation">#keyframe-specific-composite-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyframe-specific-composite-operation" class="dfn-panel" data-for="keyframe-specific-composite-operation" id="infopanel-for-keyframe-specific-composite-operation" role="dialog">
+   <span id="infopaneltitle-for-keyframe-specific-composite-operation" style="display:none">Info about the 'keyframe-specific composite
+operation' definition.</span><b><a href="#keyframe-specific-composite-operation">#keyframe-specific-composite-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe-specific-composite-operation">5.3.1. Keyframes</a>
     <li><a href="#ref-for-keyframe-specific-composite-operation①">6.6. The KeyframeEffect interface</a> <a href="#ref-for-keyframe-specific-composite-operation②">(2)</a>
@@ -9599,15 +9611,15 @@ argument</a> <a href="#ref-for-keyframe-specific-composite-operation④">(2)</a>
     <li><a href="#ref-for-keyframe-specific-composite-operation⑥">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-a-property-value">
-   <b><a href="#compute-a-property-value">#compute-a-property-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-a-property-value" class="dfn-panel" data-for="compute-a-property-value" id="infopanel-for-compute-a-property-value" role="dialog">
+   <span id="infopaneltitle-for-compute-a-property-value" style="display:none">Info about the 'compute a property value' definition.</span><b><a href="#compute-a-property-value">#compute-a-property-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-a-property-value">5.3.2. Computing property values</a> <a href="#ref-for-compute-a-property-value①">(2)</a>
     <li><a href="#ref-for-compute-a-property-value②">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-compute-a-property-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-keyframes">
-   <b><a href="#computed-keyframes">#computed-keyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-keyframes" class="dfn-panel" data-for="computed-keyframes" id="infopanel-for-computed-keyframes" role="dialog">
+   <span id="infopaneltitle-for-computed-keyframes" style="display:none">Info about the 'computed keyframes' definition.</span><b><a href="#computed-keyframes">#computed-keyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-keyframes">5.3.3. Calculating computed keyframes</a>
     <li><a href="#ref-for-computed-keyframes①">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-computed-keyframes②">(2)</a> <a href="#ref-for-computed-keyframes③">(3)</a>
@@ -9615,8 +9627,8 @@ argument</a> <a href="#ref-for-keyframe-specific-composite-operation④">(2)</a>
     <li><a href="#ref-for-computed-keyframes⑥">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-keyframe-offset">
-   <b><a href="#computed-keyframe-offset">#computed-keyframe-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-keyframe-offset" class="dfn-panel" data-for="computed-keyframe-offset" id="infopanel-for-computed-keyframe-offset" role="dialog">
+   <span id="infopaneltitle-for-computed-keyframe-offset" style="display:none">Info about the 'computed keyframe offsets.' definition.</span><b><a href="#computed-keyframe-offset">#computed-keyframe-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-keyframe-offset">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-computed-keyframe-offset①">(2)</a> <a href="#ref-for-computed-keyframe-offset②">(3)</a> <a href="#ref-for-computed-keyframe-offset③">(4)</a> <a href="#ref-for-computed-keyframe-offset④">(5)</a> <a href="#ref-for-computed-keyframe-offset⑤">(6)</a> <a href="#ref-for-computed-keyframe-offset⑥">(7)</a> <a href="#ref-for-computed-keyframe-offset⑦">(8)</a> <a href="#ref-for-computed-keyframe-offset⑧">(9)</a> <a href="#ref-for-computed-keyframe-offset⑨">(10)</a> <a href="#ref-for-computed-keyframe-offset①⓪">(11)</a>
     <li><a href="#ref-for-computed-keyframe-offset①①">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-computed-keyframe-offset①②">(2)</a> <a href="#ref-for-computed-keyframe-offset①③">(3)</a> <a href="#ref-for-computed-keyframe-offset①④">(4)</a> <a href="#ref-for-computed-keyframe-offset①⑤">(5)</a> <a href="#ref-for-computed-keyframe-offset①⑥">(6)</a> <a href="#ref-for-computed-keyframe-offset①⑦">(7)</a> <a href="#ref-for-computed-keyframe-offset①⑧">(8)</a> <a href="#ref-for-computed-keyframe-offset①⑨">(9)</a> <a href="#ref-for-computed-keyframe-offset②⓪">(10)</a> <a href="#ref-for-computed-keyframe-offset②①">(11)</a> <a href="#ref-for-computed-keyframe-offset②②">(12)</a>
@@ -9625,8 +9637,8 @@ argument</a> <a href="#ref-for-keyframe-specific-composite-operation④">(2)</a>
 argument</a> <a href="#ref-for-computed-keyframe-offset②⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-missing-keyframe-offsets">
-   <b><a href="#compute-missing-keyframe-offsets">#compute-missing-keyframe-offsets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-missing-keyframe-offsets" class="dfn-panel" data-for="compute-missing-keyframe-offsets" id="infopanel-for-compute-missing-keyframe-offsets" role="dialog">
+   <span id="infopaneltitle-for-compute-missing-keyframe-offsets" style="display:none">Info about the 'compute missing keyframe offsets' definition.</span><b><a href="#compute-missing-keyframe-offsets">#compute-missing-keyframe-offsets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-missing-keyframe-offsets">5.3.3. Calculating computed keyframes</a>
     <li><a href="#ref-for-compute-missing-keyframe-offsets①">6.6. The KeyframeEffect interface</a> <a href="#ref-for-compute-missing-keyframe-offsets②">(2)</a>
@@ -9634,26 +9646,26 @@ argument</a> <a href="#ref-for-computed-keyframe-offset②⑦">(2)</a>
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offsetk">
-   <b><a href="#offsetk">#offsetk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offsetk" class="dfn-panel" data-for="offsetk" id="infopanel-for-offsetk" role="dialog">
+   <span id="infopaneltitle-for-offsetk" style="display:none">Info about the 'offsetk' definition.</span><b><a href="#offsetk">#offsetk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offsetk">5.3.3. Calculating computed keyframes</a> <a href="#ref-for-offsetk①">(2)</a> <a href="#ref-for-offsetk②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="neutral-value-for-composition">
-   <b><a href="#neutral-value-for-composition">#neutral-value-for-composition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-neutral-value-for-composition" class="dfn-panel" data-for="neutral-value-for-composition" id="infopanel-for-neutral-value-for-composition" role="dialog">
+   <span id="infopaneltitle-for-neutral-value-for-composition" style="display:none">Info about the 'neutral value for composition' definition.</span><b><a href="#neutral-value-for-composition">#neutral-value-for-composition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-neutral-value-for-composition">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-neutral-value-for-composition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite">
-   <b><a href="#composite">#composite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite" class="dfn-panel" data-for="composite" id="infopanel-for-composite" role="dialog">
+   <span id="infopaneltitle-for-composite" style="display:none">Info about the 'compositing' definition.</span><b><a href="#composite">#composite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite">5.4. Combining effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-class">
-   <b><a href="#animation-class">#animation-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-class" class="dfn-panel" data-for="animation-class" id="infopanel-for-animation-class" role="dialog">
+   <span id="infopaneltitle-for-animation-class" style="display:none">Info about the 'animation class' definition.</span><b><a href="#animation-class">#animation-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-class">4.4. Animations</a>
     <li><a href="#ref-for-animation-class①">5.4.1. Animation classes</a>
@@ -9661,8 +9673,9 @@ argument</a>
     <li><a href="#ref-for-animation-class④">5.4.5. Applying the composited result</a> <a href="#ref-for-animation-class⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effect-stack">
-   <b><a href="#effect-stack">#effect-stack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effect-stack" class="dfn-panel" data-for="effect-stack" id="infopanel-for-effect-stack" role="dialog">
+   <span id="infopaneltitle-for-effect-stack" style="display:none">Info about the 'effect
+stack' definition.</span><b><a href="#effect-stack">#effect-stack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-stack">5. Animation model</a>
     <li><a href="#ref-for-effect-stack①">5.4. Combining effects</a> <a href="#ref-for-effect-stack②">(2)</a> <a href="#ref-for-effect-stack③">(3)</a>
@@ -9675,22 +9688,22 @@ argument</a>
     <li><a href="#ref-for-effect-stack①⑥">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-composite-order">
-   <b><a href="#animation-composite-order">#animation-composite-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-composite-order" class="dfn-panel" data-for="animation-composite-order" id="infopanel-for-animation-composite-order" role="dialog">
+   <span id="infopaneltitle-for-animation-composite-order" style="display:none">Info about the 'composite order' definition.</span><b><a href="#animation-composite-order">#animation-composite-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-composite-order">4.3. Timelines</a>
     <li><a href="#ref-for-animation-composite-order①">5.5.2. Removing replaced animations</a>
     <li><a href="#ref-for-animation-composite-order②">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-animation-of-an-animation-effect">
-   <b><a href="#associated-animation-of-an-animation-effect">#associated-animation-of-an-animation-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-animation-of-an-animation-effect" class="dfn-panel" data-for="associated-animation-of-an-animation-effect" id="infopanel-for-associated-animation-of-an-animation-effect" role="dialog">
+   <span id="infopaneltitle-for-associated-animation-of-an-animation-effect" style="display:none">Info about the 'associated animation of an animation effect' definition.</span><b><a href="#associated-animation-of-an-animation-effect">#associated-animation-of-an-animation-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-animation-of-an-animation-effect">5.4.5. Applying the composited result</a> <a href="#ref-for-associated-animation-of-an-animation-effect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underlying-value">
-   <b><a href="#underlying-value">#underlying-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underlying-value" class="dfn-panel" data-for="underlying-value" id="infopanel-for-underlying-value" role="dialog">
+   <span id="infopaneltitle-for-underlying-value" style="display:none">Info about the 'underlying value' definition.</span><b><a href="#underlying-value">#underlying-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underlying-value">5.1. Introduction</a>
     <li><a href="#ref-for-underlying-value①">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-underlying-value②">(2)</a>
@@ -9703,14 +9716,14 @@ argument</a>
     <li><a href="#ref-for-underlying-value①⑤">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-underlying-value①⑥">(2)</a> <a href="#ref-for-underlying-value①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composited-value">
-   <b><a href="#composited-value">#composited-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composited-value" class="dfn-panel" data-for="composited-value" id="infopanel-for-composited-value" role="dialog">
+   <span id="infopaneltitle-for-composited-value" style="display:none">Info about the 'composited value' definition.</span><b><a href="#composited-value">#composited-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composited-value">5.4.5. Applying the composited result</a> <a href="#ref-for-composited-value①">(2)</a> <a href="#ref-for-composited-value②">(3)</a> <a href="#ref-for-composited-value③">(4)</a> <a href="#ref-for-composited-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-operation">
-   <b><a href="#composite-operation">#composite-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-operation" class="dfn-panel" data-for="composite-operation" id="infopanel-for-composite-operation" role="dialog">
+   <span id="infopaneltitle-for-composite-operation" style="display:none">Info about the 'composite operation' definition.</span><b><a href="#composite-operation">#composite-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-operation">5.3.1. Keyframes</a> <a href="#ref-for-composite-operation①">(2)</a>
     <li><a href="#ref-for-composite-operation②">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-composite-operation③">(2)</a> <a href="#ref-for-composite-operation④">(3)</a> <a href="#ref-for-composite-operation⑤">(4)</a> <a href="#ref-for-composite-operation⑥">(5)</a> <a href="#ref-for-composite-operation⑦">(6)</a> <a href="#ref-for-composite-operation⑧">(7)</a> <a href="#ref-for-composite-operation⑨">(8)</a>
@@ -9723,28 +9736,28 @@ argument</a>
     <li><a href="#ref-for-composite-operation①⑧">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-composite-operation①⑨">(2)</a> <a href="#ref-for-composite-operation②⓪">(3)</a> <a href="#ref-for-composite-operation②①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-operation-replace">
-   <b><a href="#composite-operation-replace">#composite-operation-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-operation-replace" class="dfn-panel" data-for="composite-operation-replace" id="infopanel-for-composite-operation-replace" role="dialog">
+   <span id="infopaneltitle-for-composite-operation-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#composite-operation-replace">#composite-operation-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-operation-replace">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-composite-operation-replace①">(2)</a>
     <li><a href="#ref-for-composite-operation-replace②">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-operation-add">
-   <b><a href="#composite-operation-add">#composite-operation-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-operation-add" class="dfn-panel" data-for="composite-operation-add" id="infopanel-for-composite-operation-add" role="dialog">
+   <span id="infopaneltitle-for-composite-operation-add" style="display:none">Info about the 'add' definition.</span><b><a href="#composite-operation-add">#composite-operation-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-operation-add">5.3.4. The effect value of a keyframe effect</a> <a href="#ref-for-composite-operation-add①">(2)</a> <a href="#ref-for-composite-operation-add②">(3)</a>
     <li><a href="#ref-for-composite-operation-add③">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-operation-accumulate">
-   <b><a href="#composite-operation-accumulate">#composite-operation-accumulate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-operation-accumulate" class="dfn-panel" data-for="composite-operation-accumulate" id="infopanel-for-composite-operation-accumulate" role="dialog">
+   <span id="infopaneltitle-for-composite-operation-accumulate" style="display:none">Info about the 'accumulate' definition.</span><b><a href="#composite-operation-accumulate">#composite-operation-accumulate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-operation-accumulate">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replace-state">
-   <b><a href="#replace-state">#replace-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replace-state" class="dfn-panel" data-for="replace-state" id="infopanel-for-replace-state" role="dialog">
+   <span id="infopaneltitle-for-replace-state" style="display:none">Info about the 'replace state' definition.</span><b><a href="#replace-state">#replace-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replace-state">5.5.1. Replace state</a> <a href="#ref-for-replace-state①">(2)</a>
     <li><a href="#ref-for-replace-state②">5.5.2. Removing replaced animations</a> <a href="#ref-for-replace-state③">(2)</a> <a href="#ref-for-replace-state④">(3)</a>
@@ -9753,16 +9766,16 @@ argument</a>
     <li><a href="#ref-for-replace-state⑨">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-replace-state">
-   <b><a href="#active-replace-state">#active-replace-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-replace-state" class="dfn-panel" data-for="active-replace-state" id="infopanel-for-active-replace-state" role="dialog">
+   <span id="infopaneltitle-for-active-replace-state" style="display:none">Info about the 'active' definition.</span><b><a href="#active-replace-state">#active-replace-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-replace-state">5.5.1. Replace state</a>
     <li><a href="#ref-for-active-replace-state①">5.5.2. Removing replaced animations</a>
     <li><a href="#ref-for-active-replace-state②">6.4.2. The AnimationReplaceState enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="removed-replace-state">
-   <b><a href="#removed-replace-state">#removed-replace-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-removed-replace-state" class="dfn-panel" data-for="removed-replace-state" id="infopanel-for-removed-replace-state" role="dialog">
+   <span id="infopaneltitle-for-removed-replace-state" style="display:none">Info about the 'removed' definition.</span><b><a href="#removed-replace-state">#removed-replace-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-removed-replace-state">5.5.1. Replace state</a>
     <li><a href="#ref-for-removed-replace-state①">5.5.2. Removing replaced animations</a> <a href="#ref-for-removed-replace-state②">(2)</a>
@@ -9772,27 +9785,27 @@ argument</a>
     <li><a href="#ref-for-removed-replace-state⑦">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="persisted-replace-state">
-   <b><a href="#persisted-replace-state">#persisted-replace-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-persisted-replace-state" class="dfn-panel" data-for="persisted-replace-state" id="infopanel-for-persisted-replace-state" role="dialog">
+   <span id="infopaneltitle-for-persisted-replace-state" style="display:none">Info about the 'persisted' definition.</span><b><a href="#persisted-replace-state">#persisted-replace-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-persisted-replace-state">6.4. The Animation interface</a>
     <li><a href="#ref-for-persisted-replace-state①">6.4.2. The AnimationReplaceState enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replaceable-animation">
-   <b><a href="#replaceable-animation">#replaceable-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replaceable-animation" class="dfn-panel" data-for="replaceable-animation" id="infopanel-for-replaceable-animation" role="dialog">
+   <span id="infopaneltitle-for-replaceable-animation" style="display:none">Info about the 'replaceable' definition.</span><b><a href="#replaceable-animation">#replaceable-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaceable-animation">5.5.2. Removing replaced animations</a> <a href="#ref-for-replaceable-animation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-replaced-animations">
-   <b><a href="#remove-replaced-animations">#remove-replaced-animations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-replaced-animations" class="dfn-panel" data-for="remove-replaced-animations" id="infopanel-for-remove-replaced-animations" role="dialog">
+   <span id="infopaneltitle-for-remove-replaced-animations" style="display:none">Info about the 'remove replaced animations' definition.</span><b><a href="#remove-replaced-animations">#remove-replaced-animations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-replaced-animations">4.3. Timelines</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationtimeline">
-   <b><a href="#animationtimeline">#animationtimeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animationtimeline" class="dfn-panel" data-for="animationtimeline" id="infopanel-for-animationtimeline" role="dialog">
+   <span id="infopaneltitle-for-animationtimeline" style="display:none">Info about the 'AnimationTimeline' definition.</span><b><a href="#animationtimeline">#animationtimeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationtimeline">6.2. The AnimationTimeline interface</a>
     <li><a href="#ref-for-animationtimeline①">6.3. The DocumentTimeline interface</a>
@@ -9800,51 +9813,51 @@ argument</a>
     <li><a href="#ref-for-animationtimeline⑤">6.8. The Animatable interface mixin</a> <a href="#ref-for-animationtimeline⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationtimeline-currenttime">
-   <b><a href="#dom-animationtimeline-currenttime">#dom-animationtimeline-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationtimeline-currenttime" class="dfn-panel" data-for="dom-animationtimeline-currenttime" id="infopanel-for-dom-animationtimeline-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationtimeline-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-animationtimeline-currenttime">#dom-animationtimeline-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationtimeline-currenttime">6.2. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationtimeline-phase">
-   <b><a href="#dom-animationtimeline-phase">#dom-animationtimeline-phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationtimeline-phase" class="dfn-panel" data-for="dom-animationtimeline-phase" id="infopanel-for-dom-animationtimeline-phase" role="dialog">
+   <span id="infopaneltitle-for-dom-animationtimeline-phase" style="display:none">Info about the 'phase' definition.</span><b><a href="#dom-animationtimeline-phase">#dom-animationtimeline-phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationtimeline-phase">6.2. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-documenttimelineoptions">
-   <b><a href="#dictdef-documenttimelineoptions">#dictdef-documenttimelineoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-documenttimelineoptions" class="dfn-panel" data-for="dictdef-documenttimelineoptions" id="infopanel-for-dictdef-documenttimelineoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-documenttimelineoptions" style="display:none">Info about the 'DocumentTimelineOptions' definition.</span><b><a href="#dictdef-documenttimelineoptions">#dictdef-documenttimelineoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-documenttimelineoptions">6.3. The DocumentTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="documenttimeline">
-   <b><a href="#documenttimeline">#documenttimeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documenttimeline" class="dfn-panel" data-for="documenttimeline" id="infopanel-for-documenttimeline" role="dialog">
+   <span id="infopaneltitle-for-documenttimeline" style="display:none">Info about the 'DocumentTimeline' definition.</span><b><a href="#documenttimeline">#documenttimeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documenttimeline">6.3. The DocumentTimeline interface</a> <a href="#ref-for-documenttimeline①">(2)</a>
     <li><a href="#ref-for-documenttimeline②">6.9. Extensions to the Document interface</a> <a href="#ref-for-documenttimeline③">(2)</a> <a href="#ref-for-documenttimeline④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttimelineoptions-origintime">
-   <b><a href="#dom-documenttimelineoptions-origintime">#dom-documenttimelineoptions-origintime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttimelineoptions-origintime" class="dfn-panel" data-for="dom-documenttimelineoptions-origintime" id="infopanel-for-dom-documenttimelineoptions-origintime" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttimelineoptions-origintime" style="display:none">Info about the 'originTime' definition.</span><b><a href="#dom-documenttimelineoptions-origintime">#dom-documenttimelineoptions-origintime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttimelineoptions-origintime">6.3. The DocumentTimeline interface</a> <a href="#ref-for-dom-documenttimelineoptions-origintime①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttimeline-documenttimeline">
-   <b><a href="#dom-documenttimeline-documenttimeline">#dom-documenttimeline-documenttimeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttimeline-documenttimeline" class="dfn-panel" data-for="dom-documenttimeline-documenttimeline" id="infopanel-for-dom-documenttimeline-documenttimeline" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttimeline-documenttimeline" style="display:none">Info about the 'DocumentTimeline (options)' definition.</span><b><a href="#dom-documenttimeline-documenttimeline">#dom-documenttimeline-documenttimeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttimeline-documenttimeline">6.3. The DocumentTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttimeline-documenttimeline-options-options">
-   <b><a href="#dom-documenttimeline-documenttimeline-options-options">#dom-documenttimeline-documenttimeline-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttimeline-documenttimeline-options-options" class="dfn-panel" data-for="dom-documenttimeline-documenttimeline-options-options" id="infopanel-for-dom-documenttimeline-documenttimeline-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttimeline-documenttimeline-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-documenttimeline-documenttimeline-options-options">#dom-documenttimeline-documenttimeline-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttimeline-documenttimeline-options-options">6.3. The DocumentTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation">
-   <b><a href="#animation">#animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation" class="dfn-panel" data-for="animation" id="infopanel-for-animation" role="dialog">
+   <span id="infopaneltitle-for-animation" style="display:none">Info about the 'Animation' definition.</span><b><a href="#animation">#animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">6.4. The Animation interface</a> <a href="#ref-for-animation①">(2)</a> <a href="#ref-for-animation②">(3)</a> <a href="#ref-for-animation③">(4)</a> <a href="#ref-for-animation④">(5)</a> <a href="#ref-for-animation⑤">(6)</a> <a href="#ref-for-animation⑥">(7)</a>
     <li><a href="#ref-for-animation⑦">6.6.1. Creating a new KeyframeEffect object</a>
@@ -9854,195 +9867,195 @@ argument</a>
     <li><a href="#ref-for-animation①⑧">11. Changes since last publication</a> <a href="#ref-for-animation①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-animation">
-   <b><a href="#dom-animation-animation">#dom-animation-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-animation" class="dfn-panel" data-for="dom-animation-animation" id="infopanel-for-dom-animation-animation" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-animation" style="display:none">Info about the 'Animation (effect, timeline)' definition.</span><b><a href="#dom-animation-animation">#dom-animation-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-animation">6.4. The Animation interface</a>
     <li><a href="#ref-for-dom-animation-animation①">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-animation-effect-timeline-effect">
-   <b><a href="#dom-animation-animation-effect-timeline-effect">#dom-animation-animation-effect-timeline-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-animation-effect-timeline-effect" class="dfn-panel" data-for="dom-animation-animation-effect-timeline-effect" id="infopanel-for-dom-animation-animation-effect-timeline-effect" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-animation-effect-timeline-effect" style="display:none">Info about the 'effect' definition.</span><b><a href="#dom-animation-animation-effect-timeline-effect">#dom-animation-animation-effect-timeline-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-animation-effect-timeline-effect">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-animation-effect-timeline-timeline">
-   <b><a href="#dom-animation-animation-effect-timeline-timeline">#dom-animation-animation-effect-timeline-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-animation-effect-timeline-timeline" class="dfn-panel" data-for="dom-animation-animation-effect-timeline-timeline" id="infopanel-for-dom-animation-animation-effect-timeline-timeline" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-animation-effect-timeline-timeline" style="display:none">Info about the 'timeline' definition.</span><b><a href="#dom-animation-animation-effect-timeline-timeline">#dom-animation-animation-effect-timeline-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-animation-effect-timeline-timeline">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-id">
-   <b><a href="#dom-animation-id">#dom-animation-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-id" class="dfn-panel" data-for="dom-animation-id" id="infopanel-for-dom-animation-id" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-animation-id">#dom-animation-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-id">6.4. The Animation interface</a>
     <li><a href="#ref-for-dom-animation-id①">6.8. The Animatable interface mixin</a> <a href="#ref-for-dom-animation-id②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-effect">
-   <b><a href="#dom-animation-effect">#dom-animation-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-effect" class="dfn-panel" data-for="dom-animation-effect" id="infopanel-for-dom-animation-effect" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-effect" style="display:none">Info about the 'effect' definition.</span><b><a href="#dom-animation-effect">#dom-animation-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-effect">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-timeline">
-   <b><a href="#dom-animation-timeline">#dom-animation-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-timeline" class="dfn-panel" data-for="dom-animation-timeline" id="infopanel-for-dom-animation-timeline" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-timeline" style="display:none">Info about the 'timeline' definition.</span><b><a href="#dom-animation-timeline">#dom-animation-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-timeline">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-starttime">
-   <b><a href="#dom-animation-starttime">#dom-animation-starttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-starttime" class="dfn-panel" data-for="dom-animation-starttime" id="infopanel-for-dom-animation-starttime" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-starttime" style="display:none">Info about the 'startTime' definition.</span><b><a href="#dom-animation-starttime">#dom-animation-starttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-starttime">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-currenttime">
-   <b><a href="#dom-animation-currenttime">#dom-animation-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-currenttime" class="dfn-panel" data-for="dom-animation-currenttime" id="infopanel-for-dom-animation-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-animation-currenttime">#dom-animation-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-currenttime">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-playbackrate">
-   <b><a href="#dom-animation-playbackrate">#dom-animation-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-playbackrate" class="dfn-panel" data-for="dom-animation-playbackrate" id="infopanel-for-dom-animation-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-animation-playbackrate">#dom-animation-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-playbackrate">6.4. The Animation interface</a> <a href="#ref-for-dom-animation-playbackrate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-playstate">
-   <b><a href="#dom-animation-playstate">#dom-animation-playstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-playstate" class="dfn-panel" data-for="dom-animation-playstate" id="infopanel-for-dom-animation-playstate" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-playstate" style="display:none">Info about the 'playState' definition.</span><b><a href="#dom-animation-playstate">#dom-animation-playstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-playstate">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-replacestate">
-   <b><a href="#dom-animation-replacestate">#dom-animation-replacestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-replacestate" class="dfn-panel" data-for="dom-animation-replacestate" id="infopanel-for-dom-animation-replacestate" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-replacestate" style="display:none">Info about the 'replaceState' definition.</span><b><a href="#dom-animation-replacestate">#dom-animation-replacestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-replacestate">6.4. The Animation interface</a>
     <li><a href="#ref-for-dom-animation-replacestate①">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-pending">
-   <b><a href="#dom-animation-pending">#dom-animation-pending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-pending" class="dfn-panel" data-for="dom-animation-pending" id="infopanel-for-dom-animation-pending" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-pending" style="display:none">Info about the 'pending' definition.</span><b><a href="#dom-animation-pending">#dom-animation-pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-pending">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-ready">
-   <b><a href="#dom-animation-ready">#dom-animation-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-ready" class="dfn-panel" data-for="dom-animation-ready" id="infopanel-for-dom-animation-ready" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#dom-animation-ready">#dom-animation-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-ready">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-finished">
-   <b><a href="#dom-animation-finished">#dom-animation-finished</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-finished" class="dfn-panel" data-for="dom-animation-finished" id="infopanel-for-dom-animation-finished" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-finished" style="display:none">Info about the 'finished' definition.</span><b><a href="#dom-animation-finished">#dom-animation-finished</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-finished">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-onfinish">
-   <b><a href="#dom-animation-onfinish">#dom-animation-onfinish</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-onfinish" class="dfn-panel" data-for="dom-animation-onfinish" id="infopanel-for-dom-animation-onfinish" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-onfinish" style="display:none">Info about the 'onfinish' definition.</span><b><a href="#dom-animation-onfinish">#dom-animation-onfinish</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-onfinish">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-oncancel">
-   <b><a href="#dom-animation-oncancel">#dom-animation-oncancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-oncancel" class="dfn-panel" data-for="dom-animation-oncancel" id="infopanel-for-dom-animation-oncancel" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-oncancel" style="display:none">Info about the 'oncancel' definition.</span><b><a href="#dom-animation-oncancel">#dom-animation-oncancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-oncancel">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-onremove">
-   <b><a href="#dom-animation-onremove">#dom-animation-onremove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-onremove" class="dfn-panel" data-for="dom-animation-onremove" id="infopanel-for-dom-animation-onremove" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-onremove" style="display:none">Info about the 'onremove' definition.</span><b><a href="#dom-animation-onremove">#dom-animation-onremove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-onremove">6.4. The Animation interface</a>
     <li><a href="#ref-for-dom-animation-onremove①">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-cancel">
-   <b><a href="#dom-animation-cancel">#dom-animation-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-cancel" class="dfn-panel" data-for="dom-animation-cancel" id="infopanel-for-dom-animation-cancel" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-cancel" style="display:none">Info about the 'void cancel()' definition.</span><b><a href="#dom-animation-cancel">#dom-animation-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-cancel">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-finish">
-   <b><a href="#dom-animation-finish">#dom-animation-finish</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-finish" class="dfn-panel" data-for="dom-animation-finish" id="infopanel-for-dom-animation-finish" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-finish" style="display:none">Info about the 'void finish()' definition.</span><b><a href="#dom-animation-finish">#dom-animation-finish</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-finish">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-dom-animation-finish①">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-play">
-   <b><a href="#dom-animation-play">#dom-animation-play</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-play" class="dfn-panel" data-for="dom-animation-play" id="infopanel-for-dom-animation-play" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-play" style="display:none">Info about the 'void play()' definition.</span><b><a href="#dom-animation-play">#dom-animation-play</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-play">6.4. The Animation interface</a> <a href="#ref-for-dom-animation-play①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-pause">
-   <b><a href="#dom-animation-pause">#dom-animation-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-pause" class="dfn-panel" data-for="dom-animation-pause" id="infopanel-for-dom-animation-pause" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-pause" style="display:none">Info about the 'void pause()' definition.</span><b><a href="#dom-animation-pause">#dom-animation-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-pause">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-updateplaybackrate">
-   <b><a href="#dom-animation-updateplaybackrate">#dom-animation-updateplaybackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-updateplaybackrate" class="dfn-panel" data-for="dom-animation-updateplaybackrate" id="infopanel-for-dom-animation-updateplaybackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-updateplaybackrate" style="display:none">Info about the 'void updatePlaybackRate(playbackRate)' definition.</span><b><a href="#dom-animation-updateplaybackrate">#dom-animation-updateplaybackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-updateplaybackrate">6.4. The Animation interface</a> <a href="#ref-for-dom-animation-updateplaybackrate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-updateplaybackrate-playbackrate-playbackrate">
-   <b><a href="#dom-animation-updateplaybackrate-playbackrate-playbackrate">#dom-animation-updateplaybackrate-playbackrate-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-updateplaybackrate-playbackrate-playbackrate" class="dfn-panel" data-for="dom-animation-updateplaybackrate-playbackrate-playbackrate" id="infopanel-for-dom-animation-updateplaybackrate-playbackrate-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-updateplaybackrate-playbackrate-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-animation-updateplaybackrate-playbackrate-playbackrate">#dom-animation-updateplaybackrate-playbackrate-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-updateplaybackrate-playbackrate-playbackrate">6.4. The Animation interface</a> <a href="#ref-for-dom-animation-updateplaybackrate-playbackrate-playbackrate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-reverse">
-   <b><a href="#dom-animation-reverse">#dom-animation-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-reverse" class="dfn-panel" data-for="dom-animation-reverse" id="infopanel-for-dom-animation-reverse" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-reverse" style="display:none">Info about the 'void reverse()' definition.</span><b><a href="#dom-animation-reverse">#dom-animation-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-reverse">6.4. The Animation interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-persist">
-   <b><a href="#dom-animation-persist">#dom-animation-persist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-persist" class="dfn-panel" data-for="dom-animation-persist" id="infopanel-for-dom-animation-persist" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-persist" style="display:none">Info about the 'void persist()' definition.</span><b><a href="#dom-animation-persist">#dom-animation-persist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-persist">6.4. The Animation interface</a> <a href="#ref-for-dom-animation-persist①">(2)</a>
     <li><a href="#ref-for-dom-animation-persist②">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animation-commitstyles">
-   <b><a href="#dom-animation-commitstyles">#dom-animation-commitstyles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animation-commitstyles" class="dfn-panel" data-for="dom-animation-commitstyles" id="infopanel-for-dom-animation-commitstyles" role="dialog">
+   <span id="infopaneltitle-for-dom-animation-commitstyles" style="display:none">Info about the 'void commitStyles()' definition.</span><b><a href="#dom-animation-commitstyles">#dom-animation-commitstyles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-commitstyles">6.4. The Animation interface</a>
     <li><a href="#ref-for-dom-animation-commitstyles①">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="commit-computed-styles">
-   <b><a href="#commit-computed-styles">#commit-computed-styles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-commit-computed-styles" class="dfn-panel" data-for="commit-computed-styles" id="infopanel-for-commit-computed-styles" role="dialog">
+   <span id="infopaneltitle-for-commit-computed-styles" style="display:none">Info about the 'commit computed styles' definition.</span><b><a href="#commit-computed-styles">#commit-computed-styles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-commit-computed-styles">6.4. The Animation interface</a> <a href="#ref-for-commit-computed-styles①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-animationplaystate">
-   <b><a href="#enumdef-animationplaystate">#enumdef-animationplaystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-animationplaystate" class="dfn-panel" data-for="enumdef-animationplaystate" id="infopanel-for-enumdef-animationplaystate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-animationplaystate" style="display:none">Info about the 'AnimationPlayState' definition.</span><b><a href="#enumdef-animationplaystate">#enumdef-animationplaystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-animationplaystate">6.4. The Animation interface</a> <a href="#ref-for-enumdef-animationplaystate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-animationreplacestate">
-   <b><a href="#enumdef-animationreplacestate">#enumdef-animationreplacestate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-animationreplacestate" class="dfn-panel" data-for="enumdef-animationreplacestate" id="infopanel-for-enumdef-animationreplacestate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-animationreplacestate" style="display:none">Info about the 'AnimationReplaceState' definition.</span><b><a href="#enumdef-animationreplacestate">#enumdef-animationreplacestate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-animationreplacestate">6.4. The Animation interface</a> <a href="#ref-for-enumdef-animationreplacestate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-timelinephase">
-   <b><a href="#enumdef-timelinephase">#enumdef-timelinephase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-timelinephase" class="dfn-panel" data-for="enumdef-timelinephase" id="infopanel-for-enumdef-timelinephase" role="dialog">
+   <span id="infopaneltitle-for-enumdef-timelinephase" style="display:none">Info about the 'TimelinePhase' definition.</span><b><a href="#enumdef-timelinephase">#enumdef-timelinephase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-timelinephase">6.2. The AnimationTimeline interface</a> <a href="#ref-for-enumdef-timelinephase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationeffect">
-   <b><a href="#animationeffect">#animationeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animationeffect" class="dfn-panel" data-for="animationeffect" id="infopanel-for-animationeffect" role="dialog">
+   <span id="infopaneltitle-for-animationeffect" style="display:none">Info about the 'AnimationEffect' definition.</span><b><a href="#animationeffect">#animationeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationeffect">6.4. The Animation interface</a> <a href="#ref-for-animationeffect①">(2)</a> <a href="#ref-for-animationeffect②">(3)</a>
     <li><a href="#ref-for-animationeffect③">6.5. The AnimationEffect interface</a>
@@ -10050,35 +10063,35 @@ argument</a>
     <li><a href="#ref-for-animationeffect⑥">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-gettiming">
-   <b><a href="#dom-animationeffect-gettiming">#dom-animationeffect-gettiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-gettiming" class="dfn-panel" data-for="dom-animationeffect-gettiming" id="infopanel-for-dom-animationeffect-gettiming" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-gettiming" style="display:none">Info about the 'getTiming()' definition.</span><b><a href="#dom-animationeffect-gettiming">#dom-animationeffect-gettiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-gettiming">6.5. The AnimationEffect interface</a> <a href="#ref-for-dom-animationeffect-gettiming①">(2)</a> <a href="#ref-for-dom-animationeffect-gettiming②">(3)</a> <a href="#ref-for-dom-animationeffect-gettiming③">(4)</a> <a href="#ref-for-dom-animationeffect-gettiming④">(5)</a>
     <li><a href="#ref-for-dom-animationeffect-gettiming⑤">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-getcomputedtiming">
-   <b><a href="#dom-animationeffect-getcomputedtiming">#dom-animationeffect-getcomputedtiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-getcomputedtiming" class="dfn-panel" data-for="dom-animationeffect-getcomputedtiming" id="infopanel-for-dom-animationeffect-getcomputedtiming" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-getcomputedtiming" style="display:none">Info about the 'getComputedTiming()' definition.</span><b><a href="#dom-animationeffect-getcomputedtiming">#dom-animationeffect-getcomputedtiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-getcomputedtiming">6.5. The AnimationEffect interface</a> <a href="#ref-for-dom-animationeffect-getcomputedtiming①">(2)</a> <a href="#ref-for-dom-animationeffect-getcomputedtiming②">(3)</a> <a href="#ref-for-dom-animationeffect-getcomputedtiming③">(4)</a> <a href="#ref-for-dom-animationeffect-getcomputedtiming④">(5)</a> <a href="#ref-for-dom-animationeffect-getcomputedtiming⑤">(6)</a>
     <li><a href="#ref-for-dom-animationeffect-getcomputedtiming⑥">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-updatetiming">
-   <b><a href="#dom-animationeffect-updatetiming">#dom-animationeffect-updatetiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-updatetiming" class="dfn-panel" data-for="dom-animationeffect-updatetiming" id="infopanel-for-dom-animationeffect-updatetiming" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-updatetiming" style="display:none">Info about the 'updateTiming(timing)' definition.</span><b><a href="#dom-animationeffect-updatetiming">#dom-animationeffect-updatetiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-updatetiming">6.5. The AnimationEffect interface</a>
     <li><a href="#ref-for-dom-animationeffect-updatetiming①">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-updatetiming-timing-timing">
-   <b><a href="#dom-animationeffect-updatetiming-timing-timing">#dom-animationeffect-updatetiming-timing-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-updatetiming-timing-timing" class="dfn-panel" data-for="dom-animationeffect-updatetiming-timing-timing" id="infopanel-for-dom-animationeffect-updatetiming-timing-timing" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-updatetiming-timing-timing" style="display:none">Info about the 'optional OptionalEffectTiming timing' definition.</span><b><a href="#dom-animationeffect-updatetiming-timing-timing">#dom-animationeffect-updatetiming-timing-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-updatetiming-timing-timing">6.5. The AnimationEffect interface</a> <a href="#ref-for-dom-animationeffect-updatetiming-timing-timing①">(2)</a> <a href="#ref-for-dom-animationeffect-updatetiming-timing-timing②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-effecttiming">
-   <b><a href="#dictdef-effecttiming">#dictdef-effecttiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-effecttiming" class="dfn-panel" data-for="dictdef-effecttiming" id="infopanel-for-dictdef-effecttiming" role="dialog">
+   <span id="infopaneltitle-for-dictdef-effecttiming" style="display:none">Info about the 'EffectTiming' definition.</span><b><a href="#dictdef-effecttiming">#dictdef-effecttiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-effecttiming">6.5. The AnimationEffect interface</a> <a href="#ref-for-dictdef-effecttiming①">(2)</a> <a href="#ref-for-dictdef-effecttiming②">(3)</a> <a href="#ref-for-dictdef-effecttiming③">(4)</a> <a href="#ref-for-dictdef-effecttiming④">(5)</a>
     <li><a href="#ref-for-dictdef-effecttiming⑤">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-dictdef-effecttiming⑥">(2)</a>
@@ -10091,82 +10104,82 @@ argument</a> <a href="#ref-for-dictdef-effecttiming①②">(2)</a> <a href="#ref
     <li><a href="#ref-for-dictdef-effecttiming①④">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-optionaleffecttiming">
-   <b><a href="#dictdef-optionaleffecttiming">#dictdef-optionaleffecttiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-optionaleffecttiming" class="dfn-panel" data-for="dictdef-optionaleffecttiming" id="infopanel-for-dictdef-optionaleffecttiming" role="dialog">
+   <span id="infopaneltitle-for-dictdef-optionaleffecttiming" style="display:none">Info about the 'OptionalEffectTiming' definition.</span><b><a href="#dictdef-optionaleffecttiming">#dictdef-optionaleffecttiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-optionaleffecttiming">6.5. The AnimationEffect interface</a> <a href="#ref-for-dictdef-optionaleffecttiming①">(2)</a>
     <li><a href="#ref-for-dictdef-optionaleffecttiming②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dictdef-optionaleffecttiming③">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-delay">
-   <b><a href="#dom-effecttiming-delay">#dom-effecttiming-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-delay" class="dfn-panel" data-for="dom-effecttiming-delay" id="infopanel-for-dom-effecttiming-delay" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-delay" style="display:none">Info about the 'delay' definition.</span><b><a href="#dom-effecttiming-delay">#dom-effecttiming-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-delay">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dom-effecttiming-delay①">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-delay">
-   <b><a href="#dom-optionaleffecttiming-delay">#dom-optionaleffecttiming-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-delay" class="dfn-panel" data-for="dom-optionaleffecttiming-delay" id="infopanel-for-dom-optionaleffecttiming-delay" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-delay" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-delay">#dom-optionaleffecttiming-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-delay">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-enddelay">
-   <b><a href="#dom-effecttiming-enddelay">#dom-effecttiming-enddelay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-enddelay" class="dfn-panel" data-for="dom-effecttiming-enddelay" id="infopanel-for-dom-effecttiming-enddelay" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-enddelay" style="display:none">Info about the 'endDelay' definition.</span><b><a href="#dom-effecttiming-enddelay">#dom-effecttiming-enddelay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-enddelay">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dom-effecttiming-enddelay①">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-enddelay">
-   <b><a href="#dom-optionaleffecttiming-enddelay">#dom-optionaleffecttiming-enddelay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-enddelay" class="dfn-panel" data-for="dom-optionaleffecttiming-enddelay" id="infopanel-for-dom-optionaleffecttiming-enddelay" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-enddelay" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-enddelay">#dom-optionaleffecttiming-enddelay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-enddelay">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-fill">
-   <b><a href="#dom-effecttiming-fill">#dom-effecttiming-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-fill" class="dfn-panel" data-for="dom-effecttiming-fill" id="infopanel-for-dom-effecttiming-fill" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#dom-effecttiming-fill">#dom-effecttiming-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-fill">6.5. The AnimationEffect interface</a> <a href="#ref-for-dom-effecttiming-fill①">(2)</a>
     <li><a href="#ref-for-dom-effecttiming-fill②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dom-effecttiming-fill③">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-fill">
-   <b><a href="#dom-optionaleffecttiming-fill">#dom-optionaleffecttiming-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-fill" class="dfn-panel" data-for="dom-optionaleffecttiming-fill" id="infopanel-for-dom-optionaleffecttiming-fill" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-fill" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-fill">#dom-optionaleffecttiming-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-fill">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-iterationstart">
-   <b><a href="#dom-effecttiming-iterationstart">#dom-effecttiming-iterationstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-iterationstart" class="dfn-panel" data-for="dom-effecttiming-iterationstart" id="infopanel-for-dom-effecttiming-iterationstart" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-iterationstart" style="display:none">Info about the 'iterationStart' definition.</span><b><a href="#dom-effecttiming-iterationstart">#dom-effecttiming-iterationstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-iterationstart">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-dom-effecttiming-iterationstart①">(2)</a> <a href="#ref-for-dom-effecttiming-iterationstart②">(3)</a> <a href="#ref-for-dom-effecttiming-iterationstart③">(4)</a>
     <li><a href="#ref-for-dom-effecttiming-iterationstart④">6.5.4. Updating the timing of an AnimationEffect</a> <a href="#ref-for-dom-effecttiming-iterationstart⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-iterationstart">
-   <b><a href="#dom-optionaleffecttiming-iterationstart">#dom-optionaleffecttiming-iterationstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-iterationstart" class="dfn-panel" data-for="dom-optionaleffecttiming-iterationstart" id="infopanel-for-dom-optionaleffecttiming-iterationstart" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-iterationstart" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-iterationstart">#dom-optionaleffecttiming-iterationstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-iterationstart">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-iterations">
-   <b><a href="#dom-effecttiming-iterations">#dom-effecttiming-iterations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-iterations" class="dfn-panel" data-for="dom-effecttiming-iterations" id="infopanel-for-dom-effecttiming-iterations" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-iterations" style="display:none">Info about the 'iterations' definition.</span><b><a href="#dom-effecttiming-iterations">#dom-effecttiming-iterations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-iterations">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-dom-effecttiming-iterations①">(2)</a> <a href="#ref-for-dom-effecttiming-iterations②">(3)</a>
     <li><a href="#ref-for-dom-effecttiming-iterations③">6.5.4. Updating the timing of an AnimationEffect</a> <a href="#ref-for-dom-effecttiming-iterations④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-iterations">
-   <b><a href="#dom-optionaleffecttiming-iterations">#dom-optionaleffecttiming-iterations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-iterations" class="dfn-panel" data-for="dom-optionaleffecttiming-iterations" id="infopanel-for-dom-optionaleffecttiming-iterations" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-iterations" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-iterations">#dom-optionaleffecttiming-iterations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-iterations">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-duration">
-   <b><a href="#dom-effecttiming-duration">#dom-effecttiming-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-duration" class="dfn-panel" data-for="dom-effecttiming-duration" id="infopanel-for-dom-effecttiming-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#dom-effecttiming-duration">#dom-effecttiming-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-duration">6.5. The AnimationEffect interface</a> <a href="#ref-for-dom-effecttiming-duration①">(2)</a>
     <li><a href="#ref-for-dom-effecttiming-duration②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-dom-effecttiming-duration③">(2)</a> <a href="#ref-for-dom-effecttiming-duration④">(3)</a>
@@ -10174,27 +10187,27 @@ argument</a> <a href="#ref-for-dictdef-effecttiming①②">(2)</a> <a href="#ref
     <li><a href="#ref-for-dom-effecttiming-duration⑦">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-duration">
-   <b><a href="#dom-optionaleffecttiming-duration">#dom-optionaleffecttiming-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-duration" class="dfn-panel" data-for="dom-optionaleffecttiming-duration" id="infopanel-for-dom-optionaleffecttiming-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-duration" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-duration">#dom-optionaleffecttiming-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-duration">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-direction">
-   <b><a href="#dom-effecttiming-direction">#dom-effecttiming-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-direction" class="dfn-panel" data-for="dom-effecttiming-direction" id="infopanel-for-dom-effecttiming-direction" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#dom-effecttiming-direction">#dom-effecttiming-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-direction">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dom-effecttiming-direction①">6.5.4. Updating the timing of an AnimationEffect</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-direction">
-   <b><a href="#dom-optionaleffecttiming-direction">#dom-optionaleffecttiming-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-direction" class="dfn-panel" data-for="dom-optionaleffecttiming-direction" id="infopanel-for-dom-optionaleffecttiming-direction" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-direction" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-direction">#dom-optionaleffecttiming-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-direction">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-easing">
-   <b><a href="#dom-effecttiming-easing">#dom-effecttiming-easing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-easing" class="dfn-panel" data-for="dom-effecttiming-easing" id="infopanel-for-dom-effecttiming-easing" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-easing" style="display:none">Info about the 'easing' definition.</span><b><a href="#dom-effecttiming-easing">#dom-effecttiming-easing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-easing">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dom-effecttiming-easing①">6.5.4. Updating the timing of an AnimationEffect</a> <a href="#ref-for-dom-effecttiming-easing②">(2)</a>
@@ -10202,71 +10215,71 @@ argument</a> <a href="#ref-for-dictdef-effecttiming①②">(2)</a> <a href="#ref
 argument</a> <a href="#ref-for-dom-effecttiming-easing④">(2)</a> <a href="#ref-for-dom-effecttiming-easing⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-optionaleffecttiming-easing">
-   <b><a href="#dom-optionaleffecttiming-easing">#dom-optionaleffecttiming-easing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-optionaleffecttiming-easing" class="dfn-panel" data-for="dom-optionaleffecttiming-easing" id="infopanel-for-dom-optionaleffecttiming-easing" role="dialog">
+   <span id="infopaneltitle-for-dom-optionaleffecttiming-easing" style="display:none">Info about the '' definition.</span><b><a href="#dom-optionaleffecttiming-easing">#dom-optionaleffecttiming-easing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-optionaleffecttiming-easing">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fillmode">
-   <b><a href="#enumdef-fillmode">#enumdef-fillmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fillmode" class="dfn-panel" data-for="enumdef-fillmode" id="infopanel-for-enumdef-fillmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fillmode" style="display:none">Info about the 'FillMode' definition.</span><b><a href="#enumdef-fillmode">#enumdef-fillmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fillmode">6.5. The AnimationEffect interface</a> <a href="#ref-for-enumdef-fillmode①">(2)</a>
     <li><a href="#ref-for-enumdef-fillmode②">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-enumdef-fillmode③">(2)</a> <a href="#ref-for-enumdef-fillmode④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-playbackdirection">
-   <b><a href="#enumdef-playbackdirection">#enumdef-playbackdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-playbackdirection" class="dfn-panel" data-for="enumdef-playbackdirection" id="infopanel-for-enumdef-playbackdirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-playbackdirection" style="display:none">Info about the 'PlaybackDirection' definition.</span><b><a href="#enumdef-playbackdirection">#enumdef-playbackdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-playbackdirection">6.5.1. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-enumdef-playbackdirection①">(2)</a> <a href="#ref-for-enumdef-playbackdirection②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-the-timing-properties-of-an-animation-effect">
-   <b><a href="#update-the-timing-properties-of-an-animation-effect">#update-the-timing-properties-of-an-animation-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-the-timing-properties-of-an-animation-effect" class="dfn-panel" data-for="update-the-timing-properties-of-an-animation-effect" id="infopanel-for-update-the-timing-properties-of-an-animation-effect" role="dialog">
+   <span id="infopaneltitle-for-update-the-timing-properties-of-an-animation-effect" style="display:none">Info about the 'update the timing properties of an animation effect' definition.</span><b><a href="#update-the-timing-properties-of-an-animation-effect">#update-the-timing-properties-of-an-animation-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-timing-properties-of-an-animation-effect">6.5. The AnimationEffect interface</a>
     <li><a href="#ref-for-update-the-timing-properties-of-an-animation-effect①">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-computedeffecttiming">
-   <b><a href="#dictdef-computedeffecttiming">#dictdef-computedeffecttiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-computedeffecttiming" class="dfn-panel" data-for="dictdef-computedeffecttiming" id="infopanel-for-dictdef-computedeffecttiming" role="dialog">
+   <span id="infopaneltitle-for-dictdef-computedeffecttiming" style="display:none">Info about the 'ComputedEffectTiming' definition.</span><b><a href="#dictdef-computedeffecttiming">#dictdef-computedeffecttiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-computedeffecttiming">6.5. The AnimationEffect interface</a> <a href="#ref-for-dictdef-computedeffecttiming①">(2)</a>
     <li><a href="#ref-for-dictdef-computedeffecttiming②">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-endtime">
-   <b><a href="#dom-computedeffecttiming-endtime">#dom-computedeffecttiming-endtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-endtime" class="dfn-panel" data-for="dom-computedeffecttiming-endtime" id="infopanel-for-dom-computedeffecttiming-endtime" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-endtime" style="display:none">Info about the 'endTime' definition.</span><b><a href="#dom-computedeffecttiming-endtime">#dom-computedeffecttiming-endtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-endtime">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-activeduration">
-   <b><a href="#dom-computedeffecttiming-activeduration">#dom-computedeffecttiming-activeduration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-activeduration" class="dfn-panel" data-for="dom-computedeffecttiming-activeduration" id="infopanel-for-dom-computedeffecttiming-activeduration" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-activeduration" style="display:none">Info about the 'activeDuration' definition.</span><b><a href="#dom-computedeffecttiming-activeduration">#dom-computedeffecttiming-activeduration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-activeduration">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-localtime">
-   <b><a href="#dom-computedeffecttiming-localtime">#dom-computedeffecttiming-localtime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-localtime" class="dfn-panel" data-for="dom-computedeffecttiming-localtime" id="infopanel-for-dom-computedeffecttiming-localtime" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-localtime" style="display:none">Info about the 'localTime' definition.</span><b><a href="#dom-computedeffecttiming-localtime">#dom-computedeffecttiming-localtime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-localtime">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-progress">
-   <b><a href="#dom-computedeffecttiming-progress">#dom-computedeffecttiming-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-progress" class="dfn-panel" data-for="dom-computedeffecttiming-progress" id="infopanel-for-dom-computedeffecttiming-progress" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-progress" style="display:none">Info about the 'progress' definition.</span><b><a href="#dom-computedeffecttiming-progress">#dom-computedeffecttiming-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-progress">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-currentiteration">
-   <b><a href="#dom-computedeffecttiming-currentiteration">#dom-computedeffecttiming-currentiteration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-currentiteration" class="dfn-panel" data-for="dom-computedeffecttiming-currentiteration" id="infopanel-for-dom-computedeffecttiming-currentiteration" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-currentiteration" style="display:none">Info about the 'currentIteration' definition.</span><b><a href="#dom-computedeffecttiming-currentiteration">#dom-computedeffecttiming-currentiteration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-currentiteration">6.5.5. The ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyframeeffect">
-   <b><a href="#keyframeeffect">#keyframeeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyframeeffect" class="dfn-panel" data-for="keyframeeffect" id="infopanel-for-keyframeeffect" role="dialog">
+   <span id="infopaneltitle-for-keyframeeffect" style="display:none">Info about the 'KeyframeEffect' definition.</span><b><a href="#keyframeeffect">#keyframeeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframeeffect">6.6. The KeyframeEffect interface</a> <a href="#ref-for-keyframeeffect①">(2)</a> <a href="#ref-for-keyframeeffect②">(3)</a> <a href="#ref-for-keyframeeffect③">(4)</a> <a href="#ref-for-keyframeeffect④">(5)</a> <a href="#ref-for-keyframeeffect⑤">(6)</a> <a href="#ref-for-keyframeeffect⑥">(7)</a> <a href="#ref-for-keyframeeffect⑦">(8)</a>
     <li><a href="#ref-for-keyframeeffect⑧">6.6.1. Creating a new KeyframeEffect object</a> <a href="#ref-for-keyframeeffect⑨">(2)</a> <a href="#ref-for-keyframeeffect①⓪">(3)</a>
@@ -10276,8 +10289,9 @@ argument</a>
     <li><a href="#ref-for-keyframeeffect①⑤">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect">
-   <b><a href="#dom-keyframeeffect-keyframeeffect">#dom-keyframeeffect-keyframeeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect" id="infopanel-for-dom-keyframeeffect-keyframeeffect" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect" style="display:none">Info about the '
+KeyframeEffect (target, keyframes, options)' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect">#dom-keyframeeffect-keyframeeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffect-keyframeeffect①">(2)</a>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect②">6.6.1. Creating a new KeyframeEffect object</a>
@@ -10287,133 +10301,135 @@ argument</a>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect⑤">6.8. The Animatable interface mixin</a> <a href="#ref-for-dom-keyframeeffect-keyframeeffect⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-target">
-   <b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-target">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-target" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-target" id="infopanel-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-target" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-target" style="display:none">Info about the 'Element? target' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-target">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-target">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes">
-   <b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes" id="infopanel-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes" style="display:none">Info about the 'object? keyframes' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-keyframes">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-options">
-   <b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-options">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-options" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-target-keyframes-options-options" id="infopanel-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-options" style="display:none">Info about the 'optional KeyframeEffectOptions options' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect-target-keyframes-options-options">#dom-keyframeeffect-keyframeeffect-target-keyframes-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-target-keyframes-options-options">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-source">
-   <b><a href="#dom-keyframeeffect-keyframeeffect-source">#dom-keyframeeffect-keyframeeffect-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-source" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-source" id="infopanel-for-dom-keyframeeffect-keyframeeffect-source" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-source" style="display:none">Info about the 'KeyframeEffect (source)' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect-source">#dom-keyframeeffect-keyframeeffect-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-source">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-source-source">
-   <b><a href="#dom-keyframeeffect-keyframeeffect-source-source">#dom-keyframeeffect-keyframeeffect-source-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-source-source" class="dfn-panel" data-for="dom-keyframeeffect-keyframeeffect-source-source" id="infopanel-for-dom-keyframeeffect-keyframeeffect-source-source" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-keyframeeffect-source-source" style="display:none">Info about the 'KeyframeEffect source' definition.</span><b><a href="#dom-keyframeeffect-keyframeeffect-source-source">#dom-keyframeeffect-keyframeeffect-source-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-source-source">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffect-keyframeeffect-source-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-target">
-   <b><a href="#dom-keyframeeffect-target">#dom-keyframeeffect-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-target" class="dfn-panel" data-for="dom-keyframeeffect-target" id="infopanel-for-dom-keyframeeffect-target" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-keyframeeffect-target">#dom-keyframeeffect-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-target">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-pseudoelement">
-   <b><a href="#dom-keyframeeffect-pseudoelement">#dom-keyframeeffect-pseudoelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-pseudoelement" class="dfn-panel" data-for="dom-keyframeeffect-pseudoelement" id="infopanel-for-dom-keyframeeffect-pseudoelement" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-pseudoelement" style="display:none">Info about the 'pseudoElement' definition.</span><b><a href="#dom-keyframeeffect-pseudoelement">#dom-keyframeeffect-pseudoelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-pseudoelement">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffect-pseudoelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-composite">
-   <b><a href="#dom-keyframeeffect-composite">#dom-keyframeeffect-composite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-composite" class="dfn-panel" data-for="dom-keyframeeffect-composite" id="infopanel-for-dom-keyframeeffect-composite" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-composite" style="display:none">Info about the 'composite' definition.</span><b><a href="#dom-keyframeeffect-composite">#dom-keyframeeffect-composite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-composite">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffect-composite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-getkeyframes">
-   <b><a href="#dom-keyframeeffect-getkeyframes">#dom-keyframeeffect-getkeyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-getkeyframes" class="dfn-panel" data-for="dom-keyframeeffect-getkeyframes" id="infopanel-for-dom-keyframeeffect-getkeyframes" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-getkeyframes" style="display:none">Info about the '
+sequence&lt;object> getKeyframes()' definition.</span><b><a href="#dom-keyframeeffect-getkeyframes">#dom-keyframeeffect-getkeyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-getkeyframes">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-dom-keyframeeffect-getkeyframes①">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-basecomputedkeyframe-offset">
-   <b><a href="#dom-basecomputedkeyframe-offset">#dom-basecomputedkeyframe-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-basecomputedkeyframe-offset" class="dfn-panel" data-for="dom-basecomputedkeyframe-offset" id="infopanel-for-dom-basecomputedkeyframe-offset" role="dialog">
+   <span id="infopaneltitle-for-dom-basecomputedkeyframe-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#dom-basecomputedkeyframe-offset">#dom-basecomputedkeyframe-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-basecomputedkeyframe-offset">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-basecomputedkeyframe-computedoffset">
-   <b><a href="#dom-basecomputedkeyframe-computedoffset">#dom-basecomputedkeyframe-computedoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-basecomputedkeyframe-computedoffset" class="dfn-panel" data-for="dom-basecomputedkeyframe-computedoffset" id="infopanel-for-dom-basecomputedkeyframe-computedoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-basecomputedkeyframe-computedoffset" style="display:none">Info about the 'computedOffset' definition.</span><b><a href="#dom-basecomputedkeyframe-computedoffset">#dom-basecomputedkeyframe-computedoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-basecomputedkeyframe-computedoffset">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-basecomputedkeyframe-easing">
-   <b><a href="#dom-basecomputedkeyframe-easing">#dom-basecomputedkeyframe-easing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-basecomputedkeyframe-easing" class="dfn-panel" data-for="dom-basecomputedkeyframe-easing" id="infopanel-for-dom-basecomputedkeyframe-easing" role="dialog">
+   <span id="infopaneltitle-for-dom-basecomputedkeyframe-easing" style="display:none">Info about the 'easing' definition.</span><b><a href="#dom-basecomputedkeyframe-easing">#dom-basecomputedkeyframe-easing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-basecomputedkeyframe-easing">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-basecomputedkeyframe-composite">
-   <b><a href="#dom-basecomputedkeyframe-composite">#dom-basecomputedkeyframe-composite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-basecomputedkeyframe-composite" class="dfn-panel" data-for="dom-basecomputedkeyframe-composite" id="infopanel-for-dom-basecomputedkeyframe-composite" role="dialog">
+   <span id="infopaneltitle-for-dom-basecomputedkeyframe-composite" style="display:none">Info about the 'composite' definition.</span><b><a href="#dom-basecomputedkeyframe-composite">#dom-basecomputedkeyframe-composite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-basecomputedkeyframe-composite">6.6. The KeyframeEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-setkeyframes">
-   <b><a href="#dom-keyframeeffect-setkeyframes">#dom-keyframeeffect-setkeyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-setkeyframes" class="dfn-panel" data-for="dom-keyframeeffect-setkeyframes" id="infopanel-for-dom-keyframeeffect-setkeyframes" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-setkeyframes" style="display:none">Info about the '
+void setKeyframes(object? keyframes)' definition.</span><b><a href="#dom-keyframeeffect-setkeyframes">#dom-keyframeeffect-setkeyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-setkeyframes">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffect-setkeyframes①">(2)</a> <a href="#ref-for-dom-keyframeeffect-setkeyframes②">(3)</a>
     <li><a href="#ref-for-dom-keyframeeffect-setkeyframes③">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-property-name-to-idl-attribute-name">
-   <b><a href="#animation-property-name-to-idl-attribute-name">#animation-property-name-to-idl-attribute-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-property-name-to-idl-attribute-name" class="dfn-panel" data-for="animation-property-name-to-idl-attribute-name" id="infopanel-for-animation-property-name-to-idl-attribute-name" role="dialog">
+   <span id="infopaneltitle-for-animation-property-name-to-idl-attribute-name" style="display:none">Info about the 'animation property name to IDL attribute name' definition.</span><b><a href="#animation-property-name-to-idl-attribute-name">#animation-property-name-to-idl-attribute-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-property-name-to-idl-attribute-name">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-animation-property-name-to-idl-attribute-name①">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="idl-attribute-name-to-animation-property-name">
-   <b><a href="#idl-attribute-name-to-animation-property-name">#idl-attribute-name-to-animation-property-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-idl-attribute-name-to-animation-property-name" class="dfn-panel" data-for="idl-attribute-name-to-animation-property-name" id="infopanel-for-idl-attribute-name-to-animation-property-name" role="dialog">
+   <span id="infopaneltitle-for-idl-attribute-name-to-animation-property-name" style="display:none">Info about the 'IDL attribute name to animation property name' definition.</span><b><a href="#idl-attribute-name-to-animation-property-name">#idl-attribute-name-to-animation-property-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-attribute-name-to-animation-property-name">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-the-completion-record">
-   <b><a href="#check-the-completion-record">#check-the-completion-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-the-completion-record" class="dfn-panel" data-for="check-the-completion-record" id="infopanel-for-check-the-completion-record" role="dialog">
+   <span id="infopaneltitle-for-check-the-completion-record" style="display:none">Info about the 'check the completion record' definition.</span><b><a href="#check-the-completion-record">#check-the-completion-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-the-completion-record">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-check-the-completion-record①">(2)</a> <a href="#ref-for-check-the-completion-record②">(3)</a> <a href="#ref-for-check-the-completion-record③">(4)</a> <a href="#ref-for-check-the-completion-record④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-a-keyframe-like-object">
-   <b><a href="#process-a-keyframe-like-object">#process-a-keyframe-like-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-a-keyframe-like-object" class="dfn-panel" data-for="process-a-keyframe-like-object" id="infopanel-for-process-a-keyframe-like-object" role="dialog">
+   <span id="infopaneltitle-for-process-a-keyframe-like-object" style="display:none">Info about the 'process a keyframe-like object' definition.</span><b><a href="#process-a-keyframe-like-object">#process-a-keyframe-like-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-a-keyframe-like-object">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-process-a-keyframe-like-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-a-keyframes-argument">
-   <b><a href="#process-a-keyframes-argument">#process-a-keyframes-argument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-a-keyframes-argument" class="dfn-panel" data-for="process-a-keyframes-argument" id="infopanel-for-process-a-keyframes-argument" role="dialog">
+   <span id="infopaneltitle-for-process-a-keyframes-argument" style="display:none">Info about the 'process a keyframes argument' definition.</span><b><a href="#process-a-keyframes-argument">#process-a-keyframes-argument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-a-keyframes-argument">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-process-a-keyframes-argument①">6.6.3. Processing a keyframes
 argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-keyframeeffectoptions">
-   <b><a href="#dictdef-keyframeeffectoptions">#dictdef-keyframeeffectoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-keyframeeffectoptions" class="dfn-panel" data-for="dictdef-keyframeeffectoptions" id="infopanel-for-dictdef-keyframeeffectoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-keyframeeffectoptions" style="display:none">Info about the 'KeyframeEffectOptions' definition.</span><b><a href="#dictdef-keyframeeffectoptions">#dictdef-keyframeeffectoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-keyframeeffectoptions">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dictdef-keyframeeffectoptions①">(2)</a> <a href="#ref-for-dictdef-keyframeeffectoptions②">(3)</a> <a href="#ref-for-dictdef-keyframeeffectoptions③">(4)</a> <a href="#ref-for-dictdef-keyframeeffectoptions④">(5)</a>
     <li><a href="#ref-for-dictdef-keyframeeffectoptions⑤">6.6.3. Processing a keyframes
@@ -10422,62 +10438,62 @@ argument</a>
     <li><a href="#ref-for-dictdef-keyframeeffectoptions⑦">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffectoptions-composite">
-   <b><a href="#dom-keyframeeffectoptions-composite">#dom-keyframeeffectoptions-composite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffectoptions-composite" class="dfn-panel" data-for="dom-keyframeeffectoptions-composite" id="infopanel-for-dom-keyframeeffectoptions-composite" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffectoptions-composite" style="display:none">Info about the 'composite' definition.</span><b><a href="#dom-keyframeeffectoptions-composite">#dom-keyframeeffectoptions-composite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffectoptions-composite">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffectoptions-pseudoelement">
-   <b><a href="#dom-keyframeeffectoptions-pseudoelement">#dom-keyframeeffectoptions-pseudoelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffectoptions-pseudoelement" class="dfn-panel" data-for="dom-keyframeeffectoptions-pseudoelement" id="infopanel-for-dom-keyframeeffectoptions-pseudoelement" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffectoptions-pseudoelement" style="display:none">Info about the 'pseudoElement' definition.</span><b><a href="#dom-keyframeeffectoptions-pseudoelement">#dom-keyframeeffectoptions-pseudoelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffectoptions-pseudoelement">6.6. The KeyframeEffect interface</a> <a href="#ref-for-dom-keyframeeffectoptions-pseudoelement①">(2)</a>
     <li><a href="#ref-for-dom-keyframeeffectoptions-pseudoelement②">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compositeoperation">
-   <b><a href="#compositeoperation">#compositeoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compositeoperation" class="dfn-panel" data-for="compositeoperation" id="infopanel-for-compositeoperation" role="dialog">
+   <span id="infopaneltitle-for-compositeoperation" style="display:none">Info about the 'CompositeOperation' definition.</span><b><a href="#compositeoperation">#compositeoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compositeoperation">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-compositeoperation①">6.6.4. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-compositeoperation">
-   <b><a href="#enumdef-compositeoperation">#enumdef-compositeoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-compositeoperation" class="dfn-panel" data-for="enumdef-compositeoperation" id="infopanel-for-enumdef-compositeoperation" role="dialog">
+   <span id="infopaneltitle-for-enumdef-compositeoperation" style="display:none">Info about the 'CompositeOperation' definition.</span><b><a href="#enumdef-compositeoperation">#enumdef-compositeoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-compositeoperation">6.6. The KeyframeEffect interface</a> <a href="#ref-for-enumdef-compositeoperation①">(2)</a>
     <li><a href="#ref-for-enumdef-compositeoperation②">6.6.4. The KeyframeEffectOptions dictionary</a> <a href="#ref-for-enumdef-compositeoperation③">(2)</a>
     <li><a href="#ref-for-enumdef-compositeoperation④">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-compositeoperation-replace">
-   <b><a href="#dom-compositeoperation-replace">#dom-compositeoperation-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-compositeoperation-replace" class="dfn-panel" data-for="dom-compositeoperation-replace" id="infopanel-for-dom-compositeoperation-replace" role="dialog">
+   <span id="infopaneltitle-for-dom-compositeoperation-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#dom-compositeoperation-replace">#dom-compositeoperation-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-compositeoperation-replace">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-dom-compositeoperation-replace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-compositeoperation-add">
-   <b><a href="#dom-compositeoperation-add">#dom-compositeoperation-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-compositeoperation-add" class="dfn-panel" data-for="dom-compositeoperation-add" id="infopanel-for-dom-compositeoperation-add" role="dialog">
+   <span id="infopaneltitle-for-dom-compositeoperation-add" style="display:none">Info about the 'add' definition.</span><b><a href="#dom-compositeoperation-add">#dom-compositeoperation-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-compositeoperation-add">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-dom-compositeoperation-add①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-compositeoperation-accumulate">
-   <b><a href="#dom-compositeoperation-accumulate">#dom-compositeoperation-accumulate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-compositeoperation-accumulate" class="dfn-panel" data-for="dom-compositeoperation-accumulate" id="infopanel-for-dom-compositeoperation-accumulate" role="dialog">
+   <span id="infopaneltitle-for-dom-compositeoperation-accumulate" style="display:none">Info about the 'accumulate' definition.</span><b><a href="#dom-compositeoperation-accumulate">#dom-compositeoperation-accumulate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-compositeoperation-accumulate">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-dom-compositeoperation-accumulate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-compositeoperationorauto">
-   <b><a href="#enumdef-compositeoperationorauto">#enumdef-compositeoperationorauto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-compositeoperationorauto" class="dfn-panel" data-for="enumdef-compositeoperationorauto" id="infopanel-for-enumdef-compositeoperationorauto" role="dialog">
+   <span id="infopaneltitle-for-enumdef-compositeoperationorauto" style="display:none">Info about the 'CompositeOperationOrAuto' definition.</span><b><a href="#enumdef-compositeoperationorauto">#enumdef-compositeoperationorauto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-compositeoperationorauto">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-enumdef-compositeoperationorauto①">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-enumdef-compositeoperationorauto②">(2)</a> <a href="#ref-for-enumdef-compositeoperationorauto③">(3)</a> <a href="#ref-for-enumdef-compositeoperationorauto④">(4)</a> <a href="#ref-for-enumdef-compositeoperationorauto⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-compositeoperationorauto-auto">
-   <b><a href="#dom-compositeoperationorauto-auto">#dom-compositeoperationorauto-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-compositeoperationorauto-auto" class="dfn-panel" data-for="dom-compositeoperationorauto-auto" id="infopanel-for-dom-compositeoperationorauto-auto" role="dialog">
+   <span id="infopaneltitle-for-dom-compositeoperationorauto-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#dom-compositeoperationorauto-auto">#dom-compositeoperationorauto-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-compositeoperationorauto-auto">6.6. The KeyframeEffect interface</a>
     <li><a href="#ref-for-dom-compositeoperationorauto-auto①">6.6.3. Processing a keyframes
@@ -10486,8 +10502,8 @@ argument</a> <a href="#ref-for-dom-compositeoperationorauto-auto②">(2)</a>
     <li><a href="#ref-for-dom-compositeoperationorauto-auto④">6.7. The CompositeOperation and CompositeOperationOrAuto enumerations</a> <a href="#ref-for-dom-compositeoperationorauto-auto⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animatable">
-   <b><a href="#animatable">#animatable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animatable" class="dfn-panel" data-for="animatable" id="infopanel-for-animatable" role="dialog">
+   <span id="infopaneltitle-for-animatable" style="display:none">Info about the 'Animatable' definition.</span><b><a href="#animatable">#animatable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animatable">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-animatable①">(2)</a>
@@ -10496,22 +10512,22 @@ argument</a> <a href="#ref-for-animatable①">(2)</a>
     <li><a href="#ref-for-animatable④">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-keyframeanimationoptions">
-   <b><a href="#dictdef-keyframeanimationoptions">#dictdef-keyframeanimationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-keyframeanimationoptions" class="dfn-panel" data-for="dictdef-keyframeanimationoptions" id="infopanel-for-dictdef-keyframeanimationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-keyframeanimationoptions" style="display:none">Info about the 'KeyframeAnimationOptions' definition.</span><b><a href="#dictdef-keyframeanimationoptions">#dictdef-keyframeanimationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-keyframeanimationoptions">6.6.3. Processing a keyframes
 argument</a>
     <li><a href="#ref-for-dictdef-keyframeanimationoptions①">6.8. The Animatable interface mixin</a> <a href="#ref-for-dictdef-keyframeanimationoptions②">(2)</a> <a href="#ref-for-dictdef-keyframeanimationoptions③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-getanimationsoptions">
-   <b><a href="#dictdef-getanimationsoptions">#dictdef-getanimationsoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-getanimationsoptions" class="dfn-panel" data-for="dictdef-getanimationsoptions" id="infopanel-for-dictdef-getanimationsoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-getanimationsoptions" style="display:none">Info about the 'GetAnimationsOptions' definition.</span><b><a href="#dictdef-getanimationsoptions">#dictdef-getanimationsoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-getanimationsoptions">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animatable-animate">
-   <b><a href="#dom-animatable-animate">#dom-animatable-animate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animatable-animate" class="dfn-panel" data-for="dom-animatable-animate" id="infopanel-for-dom-animatable-animate" role="dialog">
+   <span id="infopaneltitle-for-dom-animatable-animate" style="display:none">Info about the 'Animation animate(keyframes, options)' definition.</span><b><a href="#dom-animatable-animate">#dom-animatable-animate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-animate">6.6.3. Processing a keyframes
 argument</a> <a href="#ref-for-dom-animatable-animate①">(2)</a>
@@ -10519,72 +10535,74 @@ argument</a> <a href="#ref-for-dom-animatable-animate①">(2)</a>
     <li><a href="#ref-for-dom-animatable-animate③">6.13. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animatable-animate-keyframes-options-keyframes">
-   <b><a href="#dom-animatable-animate-keyframes-options-keyframes">#dom-animatable-animate-keyframes-options-keyframes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animatable-animate-keyframes-options-keyframes" class="dfn-panel" data-for="dom-animatable-animate-keyframes-options-keyframes" id="infopanel-for-dom-animatable-animate-keyframes-options-keyframes" role="dialog">
+   <span id="infopaneltitle-for-dom-animatable-animate-keyframes-options-keyframes" style="display:none">Info about the 'keyframes' definition.</span><b><a href="#dom-animatable-animate-keyframes-options-keyframes">#dom-animatable-animate-keyframes-options-keyframes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-animate-keyframes-options-keyframes">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animatable-animate-keyframes-options-options">
-   <b><a href="#dom-animatable-animate-keyframes-options-options">#dom-animatable-animate-keyframes-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animatable-animate-keyframes-options-options" class="dfn-panel" data-for="dom-animatable-animate-keyframes-options-options" id="infopanel-for-dom-animatable-animate-keyframes-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-animatable-animate-keyframes-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-animatable-animate-keyframes-options-options">#dom-animatable-animate-keyframes-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-animate-keyframes-options-options">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animatable-getanimations">
-   <b><a href="#dom-animatable-getanimations">#dom-animatable-getanimations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animatable-getanimations" class="dfn-panel" data-for="dom-animatable-getanimations" id="infopanel-for-dom-animatable-getanimations" role="dialog">
+   <span id="infopaneltitle-for-dom-animatable-getanimations" style="display:none">Info about the '
+sequence&lt;Animation> getAnimations(options)' definition.</span><b><a href="#dom-animatable-getanimations">#dom-animatable-getanimations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-getanimations">6.8. The Animatable interface mixin</a> <a href="#ref-for-dom-animatable-getanimations①">(2)</a> <a href="#ref-for-dom-animatable-getanimations②">(3)</a>
     <li><a href="#ref-for-dom-animatable-getanimations③">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relevant-animation">
-   <b><a href="#relevant-animation">#relevant-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relevant-animation" class="dfn-panel" data-for="relevant-animation" id="infopanel-for-relevant-animation" role="dialog">
+   <span id="infopaneltitle-for-relevant-animation" style="display:none">Info about the 'relevant' definition.</span><b><a href="#relevant-animation">#relevant-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-animation">6.8. The Animatable interface mixin</a>
     <li><a href="#ref-for-relevant-animation①">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animatable-getanimations-options-options">
-   <b><a href="#dom-animatable-getanimations-options-options">#dom-animatable-getanimations-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animatable-getanimations-options-options" class="dfn-panel" data-for="dom-animatable-getanimations-options-options" id="infopanel-for-dom-animatable-getanimations-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-animatable-getanimations-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-animatable-getanimations-options-options">#dom-animatable-getanimations-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animatable-getanimations-options-options">6.8. The Animatable interface mixin</a> <a href="#ref-for-dom-animatable-getanimations-options-options①">(2)</a>
     <li><a href="#ref-for-dom-animatable-getanimations-options-options②">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeanimationoptions-id">
-   <b><a href="#dom-keyframeanimationoptions-id">#dom-keyframeanimationoptions-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeanimationoptions-id" class="dfn-panel" data-for="dom-keyframeanimationoptions-id" id="infopanel-for-dom-keyframeanimationoptions-id" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeanimationoptions-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-keyframeanimationoptions-id">#dom-keyframeanimationoptions-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeanimationoptions-id">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeanimationoptions-timeline">
-   <b><a href="#dom-keyframeanimationoptions-timeline">#dom-keyframeanimationoptions-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeanimationoptions-timeline" class="dfn-panel" data-for="dom-keyframeanimationoptions-timeline" id="infopanel-for-dom-keyframeanimationoptions-timeline" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeanimationoptions-timeline" style="display:none">Info about the 'timeline' definition.</span><b><a href="#dom-keyframeanimationoptions-timeline">#dom-keyframeanimationoptions-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeanimationoptions-timeline">6.8. The Animatable interface mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-getanimationsoptions-subtree">
-   <b><a href="#dom-getanimationsoptions-subtree">#dom-getanimationsoptions-subtree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-getanimationsoptions-subtree" class="dfn-panel" data-for="dom-getanimationsoptions-subtree" id="infopanel-for-dom-getanimationsoptions-subtree" role="dialog">
+   <span id="infopaneltitle-for-dom-getanimationsoptions-subtree" style="display:none">Info about the 'subtree' definition.</span><b><a href="#dom-getanimationsoptions-subtree">#dom-getanimationsoptions-subtree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-getanimationsoptions-subtree">6.8. The Animatable interface mixin</a> <a href="#ref-for-dom-getanimationsoptions-subtree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-timeline">
-   <b><a href="#dom-document-timeline">#dom-document-timeline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-timeline" class="dfn-panel" data-for="dom-document-timeline" id="infopanel-for-dom-document-timeline" role="dialog">
+   <span id="infopaneltitle-for-dom-document-timeline" style="display:none">Info about the 'timeline' definition.</span><b><a href="#dom-document-timeline">#dom-document-timeline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-timeline">6.9. Extensions to the Document interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documentorshadowroot-getanimations">
-   <b><a href="#dom-documentorshadowroot-getanimations">#dom-documentorshadowroot-getanimations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documentorshadowroot-getanimations" class="dfn-panel" data-for="dom-documentorshadowroot-getanimations" id="infopanel-for-dom-documentorshadowroot-getanimations" role="dialog">
+   <span id="infopaneltitle-for-dom-documentorshadowroot-getanimations" style="display:none">Info about the '
+sequence&lt;Animation> getAnimations()' definition.</span><b><a href="#dom-documentorshadowroot-getanimations">#dom-documentorshadowroot-getanimations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentorshadowroot-getanimations">6.10. Extensions to the DocumentOrShadowRoot interface mixin</a>
     <li><a href="#ref-for-dom-documentorshadowroot-getanimations①">11. Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationplaybackevent">
-   <b><a href="#animationplaybackevent">#animationplaybackevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animationplaybackevent" class="dfn-panel" data-for="animationplaybackevent" id="infopanel-for-animationplaybackevent" role="dialog">
+   <span id="infopaneltitle-for-animationplaybackevent" style="display:none">Info about the 'AnimationPlaybackEvent' definition.</span><b><a href="#animationplaybackevent">#animationplaybackevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationplaybackevent">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-animationplaybackevent①">4.4.14. Canceling an animation</a>
@@ -10592,20 +10610,21 @@ argument</a> <a href="#ref-for-dom-animatable-animate①">(2)</a>
     <li><a href="#ref-for-animationplaybackevent③">6.12. The AnimationPlaybackEvent interface</a> <a href="#ref-for-animationplaybackevent④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-animationplaybackeventinit">
-   <b><a href="#dictdef-animationplaybackeventinit">#dictdef-animationplaybackeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-animationplaybackeventinit" class="dfn-panel" data-for="dictdef-animationplaybackeventinit" id="infopanel-for-dictdef-animationplaybackeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-animationplaybackeventinit" style="display:none">Info about the 'AnimationPlaybackEventInit' definition.</span><b><a href="#dictdef-animationplaybackeventinit">#dictdef-animationplaybackeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-animationplaybackeventinit">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationplaybackevent-animationplaybackevent">
-   <b><a href="#dom-animationplaybackevent-animationplaybackevent">#dom-animationplaybackevent-animationplaybackevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationplaybackevent-animationplaybackevent" class="dfn-panel" data-for="dom-animationplaybackevent-animationplaybackevent" id="infopanel-for-dom-animationplaybackevent-animationplaybackevent" role="dialog">
+   <span id="infopaneltitle-for-dom-animationplaybackevent-animationplaybackevent" style="display:none">Info about the '
+AnimationPlaybackEvent(type, eventInitDict)' definition.</span><b><a href="#dom-animationplaybackevent-animationplaybackevent">#dom-animationplaybackevent-animationplaybackevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationplaybackevent-animationplaybackevent">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationplaybackevent-currenttime">
-   <b><a href="#dom-animationplaybackevent-currenttime">#dom-animationplaybackevent-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationplaybackevent-currenttime" class="dfn-panel" data-for="dom-animationplaybackevent-currenttime" id="infopanel-for-dom-animationplaybackevent-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationplaybackevent-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-animationplaybackevent-currenttime">#dom-animationplaybackevent-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationplaybackevent-currenttime">4.4.12. Updating the finished state</a>
     <li><a href="#ref-for-dom-animationplaybackevent-currenttime①">4.4.14. Canceling an animation</a>
@@ -10613,8 +10632,8 @@ argument</a> <a href="#ref-for-dom-animatable-animate①">(2)</a>
     <li><a href="#ref-for-dom-animationplaybackevent-currenttime③">6.12. The AnimationPlaybackEvent interface</a> <a href="#ref-for-dom-animationplaybackevent-currenttime④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationplaybackevent-timelinetime">
-   <b><a href="#dom-animationplaybackevent-timelinetime">#dom-animationplaybackevent-timelinetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationplaybackevent-timelinetime" class="dfn-panel" data-for="dom-animationplaybackevent-timelinetime" id="infopanel-for-dom-animationplaybackevent-timelinetime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationplaybackevent-timelinetime" style="display:none">Info about the 'timelineTime' definition.</span><b><a href="#dom-animationplaybackevent-timelinetime">#dom-animationplaybackevent-timelinetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationplaybackevent-timelinetime">4.4.12. Updating the finished state</a> <a href="#ref-for-dom-animationplaybackevent-timelinetime①">(2)</a>
     <li><a href="#ref-for-dom-animationplaybackevent-timelinetime②">4.4.14. Canceling an animation</a>
@@ -10622,79 +10641,135 @@ argument</a> <a href="#ref-for-dom-animatable-animate①">(2)</a>
     <li><a href="#ref-for-dom-animationplaybackevent-timelinetime④">6.12. The AnimationPlaybackEvent interface</a> <a href="#ref-for-dom-animationplaybackevent-timelinetime⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationplaybackeventinit-currenttime">
-   <b><a href="#dom-animationplaybackeventinit-currenttime">#dom-animationplaybackeventinit-currenttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationplaybackeventinit-currenttime" class="dfn-panel" data-for="dom-animationplaybackeventinit-currenttime" id="infopanel-for-dom-animationplaybackeventinit-currenttime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationplaybackeventinit-currenttime" style="display:none">Info about the 'currentTime' definition.</span><b><a href="#dom-animationplaybackeventinit-currenttime">#dom-animationplaybackeventinit-currenttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationplaybackeventinit-currenttime">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationplaybackeventinit-timelinetime">
-   <b><a href="#dom-animationplaybackeventinit-timelinetime">#dom-animationplaybackeventinit-timelinetime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationplaybackeventinit-timelinetime" class="dfn-panel" data-for="dom-animationplaybackeventinit-timelinetime" id="infopanel-for-dom-animationplaybackeventinit-timelinetime" role="dialog">
+   <span id="infopaneltitle-for-dom-animationplaybackeventinit-timelinetime" style="display:none">Info about the 'timelineTime' definition.</span><b><a href="#dom-animationplaybackeventinit-timelinetime">#dom-animationplaybackeventinit-timelinetime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationplaybackeventinit-timelinetime">6.12. The AnimationPlaybackEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="combining-shadow-lists">
-   <b><a href="#combining-shadow-lists">#combining-shadow-lists</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-combining-shadow-lists" class="dfn-panel" data-for="combining-shadow-lists" id="infopanel-for-combining-shadow-lists" role="dialog">
+   <span id="infopaneltitle-for-combining-shadow-lists" style="display:none">Info about the 'shadow lists' definition.</span><b><a href="#combining-shadow-lists">#combining-shadow-lists</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-combining-shadow-lists">Animation of box-shadow</a> <a href="#ref-for-combining-shadow-lists①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/csswg-drafts/web-animations-2/Overview.html
+++ b/tests/github/w3c/csswg-drafts/web-animations-2/Overview.html
@@ -3096,40 +3096,40 @@ alert<c- p>(</c->timesCalled<c- p>);</c-> <c- c1>// Displays ‘0’</c-></pre>
    <li><a href="#transformed-time">transformed time</a><span>, in § 3.7.2</span>
    <li><a href="#tree-order">tree order</a><span>, in § 3.8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">5.8.1. Creating a new KeyframeEffect object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linear-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-1/#linear-easing-function">https://drafts.csswg.org/css-easing-1/#linear-easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linear-easing-function" class="dfn-panel" data-for="term-for-linear-easing-function" id="infopanel-for-term-for-linear-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-linear-easing-function" style="display:none">Info about the 'linear timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-1/#linear-easing-function">https://drafts.csswg.org/css-easing-1/#linear-easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-easing-function">3.7. Time transformations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-easing-function">
-   <a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-easing-function" class="dfn-panel" data-for="term-for-easing-function" id="infopanel-for-term-for-easing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-easing-function" style="display:none">Info about the 'timing function' external reference.</span><a href="https://drafts.csswg.org/css-easing-2/#easing-function">https://drafts.csswg.org/css-easing-2/#easing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-easing-function">3.3.5. Fill modes</a>
     <li><a href="#ref-for-easing-function①">3.7. Time transformations</a>
     <li><a href="#ref-for-easing-function②">3.8.1. Relationship of group time to child time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-running">
-   <a href="https://drafts.csswg.org/css-gcpm-3/#propdef-running">https://drafts.csswg.org/css-gcpm-3/#propdef-running</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-running" class="dfn-panel" data-for="term-for-propdef-running" id="infopanel-for-term-for-propdef-running" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-running" style="display:none">Info about the 'running' external reference.</span><a href="https://drafts.csswg.org/css-gcpm-3/#propdef-running">https://drafts.csswg.org/css-gcpm-3/#propdef-running</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-running">3.2.1. Setting the timeline of an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-csspseudoelement">
-   <a href="https://drafts.csswg.org/css-pseudo-4/#csspseudoelement">https://drafts.csswg.org/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-csspseudoelement" class="dfn-panel" data-for="term-for-csspseudoelement" id="infopanel-for-term-for-csspseudoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-csspseudoelement" style="display:none">Info about the 'CSSPseudoElement' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4/#csspseudoelement">https://drafts.csswg.org/css-pseudo-4/#csspseudoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csspseudoelement">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transition-start-time">
-   <a href="https://drafts.csswg.org/css-transitions-1/#transition-start-time">https://drafts.csswg.org/css-transitions-1/#transition-start-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transition-start-time" class="dfn-panel" data-for="term-for-transition-start-time" id="infopanel-for-term-for-transition-start-time" role="menu">
+   <span id="infopaneltitle-for-term-for-transition-start-time" style="display:none">Info about the 'start time' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#transition-start-time">https://drafts.csswg.org/css-transitions-1/#transition-start-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transition-start-time">3.2.1. Setting the timeline of an animation</a> <a href="#ref-for-transition-start-time①">(2)</a> <a href="#ref-for-transition-start-time②">(3)</a> <a href="#ref-for-transition-start-time③">(4)</a> <a href="#ref-for-transition-start-time④">(5)</a>
     <li><a href="#ref-for-transition-start-time⑤">3.2.4. Setting the current time of an
@@ -3139,33 +3139,33 @@ Animation</a> <a href="#ref-for-transition-start-time①②">(2)</a>
     <li><a href="#ref-for-transition-start-time①③">3.2.6. Playing an animation</a> <a href="#ref-for-transition-start-time①④">(2)</a> <a href="#ref-for-transition-start-time①⑤">(3)</a> <a href="#ref-for-transition-start-time①⑥">(4)</a> <a href="#ref-for-transition-start-time①⑦">(5)</a> <a href="#ref-for-transition-start-time①⑧">(6)</a> <a href="#ref-for-transition-start-time①⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accumulation">
-   <a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accumulation" class="dfn-panel" data-for="term-for-accumulation" id="infopanel-for-term-for-accumulation" role="menu">
+   <span id="infopaneltitle-for-term-for-accumulation" style="display:none">Info about the 'value accumulation' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#accumulation">https://drafts.csswg.org/css-values-4/#accumulation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accumulation">4.2.1. The effect value of a keyframe effect</a>
     <li><a href="#ref-for-accumulation①">4.4. Effect accumulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-animation" style="display:none">Info about the 'Animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">3.2.5. Setting the start time of an
 Animation</a>
@@ -3182,14 +3182,14 @@ Animation</a>
     <li><a href="#ref-for-animation②⑤">5.11. The Animatable interface</a> <a href="#ref-for-animation②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-animation-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-animation-animation">https://drafts.csswg.org/web-animations-1/#dom-animation-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-animation-animation" class="dfn-panel" data-for="term-for-dom-animation-animation" id="infopanel-for-term-for-dom-animation-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-animation-animation" style="display:none">Info about the 'Animation()' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-animation-animation">https://drafts.csswg.org/web-animations-1/#dom-animation-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animation-animation">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationeffect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationeffect" class="dfn-panel" data-for="term-for-animationeffect" id="infopanel-for-term-for-animationeffect" role="menu">
+   <span id="infopaneltitle-for-term-for-animationeffect" style="display:none">Info about the 'AnimationEffect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationeffect">https://drafts.csswg.org/web-animations-1/#animationeffect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationeffect">5.1. The AnimationTimeline interface</a>
     <li><a href="#ref-for-animationeffect①">5.2. The AnimationEffect interface</a> <a href="#ref-for-animationeffect②">(2)</a> <a href="#ref-for-animationeffect③">(3)</a> <a href="#ref-for-animationeffect④">(4)</a> <a href="#ref-for-animationeffect⑤">(5)</a> <a href="#ref-for-animationeffect⑥">(6)</a> <a href="#ref-for-animationeffect⑦">(7)</a> <a href="#ref-for-animationeffect⑧">(8)</a> <a href="#ref-for-animationeffect⑨">(9)</a>
@@ -3198,21 +3198,21 @@ Animation</a>
     <li><a href="#ref-for-animationeffect①⑨">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animationtimeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animationtimeline" class="dfn-panel" data-for="term-for-animationtimeline" id="infopanel-for-term-for-animationtimeline" role="menu">
+   <span id="infopaneltitle-for-term-for-animationtimeline" style="display:none">Info about the 'AnimationTimeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animationtimeline">https://drafts.csswg.org/web-animations-1/#animationtimeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationtimeline">5.1. The AnimationTimeline interface</a> <a href="#ref-for-animationtimeline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-computedeffecttiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-computedeffecttiming" class="dfn-panel" data-for="term-for-dictdef-computedeffecttiming" id="infopanel-for-term-for-dictdef-computedeffecttiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-computedeffecttiming" style="display:none">Info about the 'ComputedEffectTiming' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-computedeffecttiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-computedeffecttiming">5.4. The
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-effecttiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-effecttiming" class="dfn-panel" data-for="term-for-dictdef-effecttiming" id="infopanel-for-term-for-dictdef-effecttiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-effecttiming" style="display:none">Info about the 'EffectTiming' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-effecttiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-effecttiming">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a>
     <li><a href="#ref-for-dictdef-effecttiming①">5.4. The
@@ -3222,29 +3222,29 @@ Animation</a>
     <li><a href="#ref-for-dictdef-effecttiming①①">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyframeeffect">
-   <a href="https://drafts.csswg.org/web-animations-1/#keyframeeffect">https://drafts.csswg.org/web-animations-1/#keyframeeffect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyframeeffect" class="dfn-panel" data-for="term-for-keyframeeffect" id="infopanel-for-term-for-keyframeeffect" role="menu">
+   <span id="infopaneltitle-for-term-for-keyframeeffect" style="display:none">Info about the 'KeyframeEffect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#keyframeeffect">https://drafts.csswg.org/web-animations-1/#keyframeeffect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframeeffect">5.4.1. The FillMode enumeration</a>
     <li><a href="#ref-for-keyframeeffect①">5.8. The KeyframeEffect interfaces</a> <a href="#ref-for-keyframeeffect②">(2)</a> <a href="#ref-for-keyframeeffect③">(3)</a> <a href="#ref-for-keyframeeffect④">(4)</a> <a href="#ref-for-keyframeeffect⑤">(5)</a>
     <li><a href="#ref-for-keyframeeffect⑥">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-keyframeeffectoptions">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions">https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-keyframeeffectoptions" class="dfn-panel" data-for="term-for-dictdef-keyframeeffectoptions" id="infopanel-for-term-for-dictdef-keyframeeffectoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-keyframeeffectoptions" style="display:none">Info about the 'KeyframeEffectOptions' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions">https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-keyframeeffectoptions">5.8. The KeyframeEffect interfaces</a>
     <li><a href="#ref-for-dictdef-keyframeeffectoptions①">5.8.2. The KeyframeEffectOptions dictionary</a> <a href="#ref-for-dictdef-keyframeeffectoptions②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-optionaleffecttiming">
-   <a href="https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-optionaleffecttiming" class="dfn-panel" data-for="term-for-dictdef-optionaleffecttiming" id="infopanel-for-term-for-dictdef-optionaleffecttiming" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-optionaleffecttiming" style="display:none">Info about the 'OptionalEffectTiming' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming">https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-optionaleffecttiming">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-interval">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-interval">https://drafts.csswg.org/web-animations-1/#active-interval</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-interval" class="dfn-panel" data-for="term-for-active-interval" id="infopanel-for-term-for-active-interval" role="menu">
+   <span id="infopaneltitle-for-term-for-active-interval" style="display:none">Info about the 'active interval' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-interval">https://drafts.csswg.org/web-animations-1/#active-interval</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-interval">3.3.2. The active interval</a>
     <li><a href="#ref-for-active-interval①">3.2. Animations</a> <a href="#ref-for-active-interval②">(2)</a>
@@ -3261,8 +3261,8 @@ states</a>
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-phase">https://drafts.csswg.org/web-animations-1/#active-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-phase" class="dfn-panel" data-for="term-for-active-phase" id="infopanel-for-term-for-active-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-active-phase" style="display:none">Info about the 'active phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-phase">https://drafts.csswg.org/web-animations-1/#active-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-phase">3.3.4. Animation effect phases and
 states</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-phase②">(3)</a>
@@ -3270,8 +3270,8 @@ states</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-p
     <li><a href="#ref-for-active-phase⑤">3.6.3.1. Calculating the active time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-time">
-   <a href="https://drafts.csswg.org/web-animations-1/#active-time">https://drafts.csswg.org/web-animations-1/#active-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-time" class="dfn-panel" data-for="term-for-active-time" id="infopanel-for-term-for-active-time" role="menu">
+   <span id="infopaneltitle-for-term-for-active-time" style="display:none">Info about the 'active time' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#active-time">https://drafts.csswg.org/web-animations-1/#active-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-time">3.2. Animations</a>
     <li><a href="#ref-for-active-time①">3.6.1. Overview</a> <a href="#ref-for-active-time②">(2)</a>
@@ -3279,15 +3279,15 @@ states</a> <a href="#ref-for-active-phase①">(2)</a> <a href="#ref-for-active-p
     <li><a href="#ref-for-active-time④">3.6.3.2. Calculating the overall progress</a> <a href="#ref-for-active-time⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-after-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#after-phase">https://drafts.csswg.org/web-animations-1/#after-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-after-phase" class="dfn-panel" data-for="term-for-after-phase" id="infopanel-for-term-for-after-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-after-phase" style="display:none">Info about the 'after phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#after-phase">https://drafts.csswg.org/web-animations-1/#after-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-after-phase">3.3.5. Fill modes</a> <a href="#ref-for-after-phase①">(2)</a> <a href="#ref-for-after-phase②">(3)</a>
     <li><a href="#ref-for-after-phase③">3.6.3.1. Calculating the active time</a> <a href="#ref-for-after-phase④">(2)</a> <a href="#ref-for-after-phase⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation" class="dfn-panel" data-for="term-for-animation" id="infopanel-for-term-for-animation①" role="menu">
+   <span id="infopaneltitle-for-term-for-animation①" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation">https://drafts.csswg.org/web-animations-1/#animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation">3.2.5. Setting the start time of an
 Animation</a>
@@ -3304,8 +3304,8 @@ Animation</a>
     <li><a href="#ref-for-animation②⑤">5.11. The Animatable interface</a> <a href="#ref-for-animation②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-effect">https://drafts.csswg.org/web-animations-1/#animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-effect" class="dfn-panel" data-for="term-for-animation-effect" id="infopanel-for-term-for-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-effect" style="display:none">Info about the 'animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-effect">https://drafts.csswg.org/web-animations-1/#animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect">2. Changes since level 1</a>
     <li><a href="#ref-for-animation-effect①">3.2.3. Waiting for the target effect</a>
@@ -3343,26 +3343,26 @@ states</a> <a href="#ref-for-animation-effect②⑧">(2)</a> <a href="#ref-for-a
     <li><a href="#ref-for-animation-effect①②③">5.11. The Animatable interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-playback-rate">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-playback-rate">https://drafts.csswg.org/web-animations-1/#animation-playback-rate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-playback-rate" class="dfn-panel" data-for="term-for-animation-playback-rate" id="infopanel-for-term-for-animation-playback-rate" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-playback-rate" style="display:none">Info about the 'animation playback rate' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-playback-rate">https://drafts.csswg.org/web-animations-1/#animation-playback-rate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-playback-rate">3.5. Animation effect speed control</a> <a href="#ref-for-animation-playback-rate①">(2)</a> <a href="#ref-for-animation-playback-rate②">(3)</a> <a href="#ref-for-animation-playback-rate③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-associated-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-associated-effect">https://drafts.csswg.org/web-animations-1/#animation-associated-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-associated-effect" class="dfn-panel" data-for="term-for-animation-associated-effect" id="infopanel-for-term-for-animation-associated-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-associated-effect" style="display:none">Info about the 'associated effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-associated-effect">https://drafts.csswg.org/web-animations-1/#animation-associated-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-associated-effect">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-before-flag">
-   <a href="https://drafts.csswg.org/web-animations-1/#before-flag">https://drafts.csswg.org/web-animations-1/#before-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-before-flag" class="dfn-panel" data-for="term-for-before-flag" id="infopanel-for-term-for-before-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-before-flag" style="display:none">Info about the 'before flag' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#before-flag">https://drafts.csswg.org/web-animations-1/#before-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-flag">3.7.1. Calculating the transformed progress</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-before-phase">
-   <a href="https://drafts.csswg.org/web-animations-1/#before-phase">https://drafts.csswg.org/web-animations-1/#before-phase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-before-phase" class="dfn-panel" data-for="term-for-before-phase" id="infopanel-for-term-for-before-phase" role="menu">
+   <span id="infopaneltitle-for-term-for-before-phase" style="display:none">Info about the 'before phase' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#before-phase">https://drafts.csswg.org/web-animations-1/#before-phase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-before-phase">3.3.4. Animation effect phases and
 states</a>
@@ -3370,35 +3370,35 @@ states</a>
     <li><a href="#ref-for-before-phase④">3.6.3.1. Calculating the active time</a> <a href="#ref-for-before-phase⑤">(2)</a> <a href="#ref-for-before-phase⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cancel-an-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#cancel-an-animation">https://drafts.csswg.org/web-animations-1/#cancel-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cancel-an-animation" class="dfn-panel" data-for="term-for-cancel-an-animation" id="infopanel-for-term-for-cancel-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-cancel-an-animation" style="display:none">Info about the 'cancel an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#cancel-an-animation">https://drafts.csswg.org/web-animations-1/#cancel-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-an-animation">3.2.8. Canceling an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyframeeffect-composite">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-composite">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-composite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyframeeffect-composite" class="dfn-panel" data-for="term-for-dom-keyframeeffect-composite" id="infopanel-for-term-for-dom-keyframeeffect-composite" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyframeeffect-composite" style="display:none">Info about the 'composite' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-composite">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-composite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-composite">5.8. The KeyframeEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-finished-promise">
-   <a href="https://drafts.csswg.org/web-animations-1/#current-finished-promise">https://drafts.csswg.org/web-animations-1/#current-finished-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-finished-promise" class="dfn-panel" data-for="term-for-current-finished-promise" id="infopanel-for-term-for-current-finished-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-current-finished-promise" style="display:none">Info about the 'current finished promise' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#current-finished-promise">https://drafts.csswg.org/web-animations-1/#current-finished-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-finished-promise">3.2.6. Playing an animation</a>
     <li><a href="#ref-for-current-finished-promise①">4.1.1. Not animatable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-iteration">
-   <a href="https://drafts.csswg.org/web-animations-1/#current-iteration">https://drafts.csswg.org/web-animations-1/#current-iteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-iteration" class="dfn-panel" data-for="term-for-current-iteration" id="infopanel-for-term-for-current-iteration" role="menu">
+   <span id="infopaneltitle-for-term-for-current-iteration" style="display:none">Info about the 'current iteration' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#current-iteration">https://drafts.csswg.org/web-animations-1/#current-iteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-iteration">4.5. Custom effects</a>
     <li><a href="#ref-for-current-iteration①">4.5.1. Sampling custom effects</a>
     <li><a href="#ref-for-current-iteration②">5.9. The IterationCompositeOperation enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-time">
-   <a href="https://drafts.csswg.org/web-animations-1/#current-time">https://drafts.csswg.org/web-animations-1/#current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-time" class="dfn-panel" data-for="term-for-current-time" id="infopanel-for-term-for-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-current-time" style="display:none">Info about the 'current time' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#current-time">https://drafts.csswg.org/web-animations-1/#current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-time">3.2.1. Setting the timeline of an animation</a> <a href="#ref-for-current-time①">(2)</a> <a href="#ref-for-current-time②">(3)</a>
     <li><a href="#ref-for-current-time③">3.2.4. Setting the current time of an
@@ -3409,22 +3409,22 @@ Animation</a> <a href="#ref-for-current-time⑦">(2)</a> <a href="#ref-for-curre
     <li><a href="#ref-for-current-time①②">3.3.3. Local time and inherited time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directed-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#directed-progress">https://drafts.csswg.org/web-animations-1/#directed-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directed-progress" class="dfn-panel" data-for="term-for-directed-progress" id="infopanel-for-term-for-directed-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-directed-progress" style="display:none">Info about the 'directed progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#directed-progress">https://drafts.csswg.org/web-animations-1/#directed-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directed-progress">3.6.1. Overview</a> <a href="#ref-for-directed-progress①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-effect-value">
-   <a href="https://drafts.csswg.org/web-animations-1/#effect-value">https://drafts.csswg.org/web-animations-1/#effect-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-effect-value" class="dfn-panel" data-for="term-for-effect-value" id="infopanel-for-term-for-effect-value" role="menu">
+   <span id="infopaneltitle-for-term-for-effect-value" style="display:none">Info about the 'effect value' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#effect-value">https://drafts.csswg.org/web-animations-1/#effect-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effect-value">4.2.1. The effect value of a keyframe effect</a>
     <li><a href="#ref-for-effect-value①">4.4. Effect accumulation</a> <a href="#ref-for-effect-value②">(2)</a>
     <li><a href="#ref-for-effect-value③">5.9. The IterationCompositeOperation enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-end-delay">
-   <a href="https://drafts.csswg.org/web-animations-1/#end-delay">https://drafts.csswg.org/web-animations-1/#end-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-end-delay" class="dfn-panel" data-for="term-for-end-delay" id="infopanel-for-term-for-end-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-end-delay" style="display:none">Info about the 'end delay' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#end-delay">https://drafts.csswg.org/web-animations-1/#end-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-delay">3.3.2. The active interval</a> <a href="#ref-for-end-delay①">(2)</a>
     <li><a href="#ref-for-end-delay②">3.2. Animations</a>
@@ -3433,8 +3433,8 @@ Animation</a> <a href="#ref-for-current-time⑦">(2)</a> <a href="#ref-for-curre
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fill-mode">
-   <a href="https://drafts.csswg.org/web-animations-1/#fill-mode">https://drafts.csswg.org/web-animations-1/#fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fill-mode" class="dfn-panel" data-for="term-for-fill-mode" id="infopanel-for-term-for-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-fill-mode" style="display:none">Info about the 'fill mode' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#fill-mode">https://drafts.csswg.org/web-animations-1/#fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-mode">3.3.4. Animation effect phases and
 states</a>
@@ -3442,16 +3442,16 @@ states</a>
     <li><a href="#ref-for-fill-mode②">3.6.3.1. Calculating the active time</a> <a href="#ref-for-fill-mode③">(2)</a> <a href="#ref-for-fill-mode④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-finished-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#finished-play-state">https://drafts.csswg.org/web-animations-1/#finished-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-finished-play-state" class="dfn-panel" data-for="term-for-finished-play-state" id="infopanel-for-term-for-finished-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-finished-play-state" style="display:none">Info about the 'finished play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#finished-play-state">https://drafts.csswg.org/web-animations-1/#finished-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finished-play-state">3.2.1. Setting the timeline of an animation</a>
     <li><a href="#ref-for-finished-play-state①">3.3.4. Animation effect phases and
 states</a> <a href="#ref-for-finished-play-state②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-hold-time">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-hold-time">https://drafts.csswg.org/web-animations-1/#animation-hold-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-hold-time" class="dfn-panel" data-for="term-for-animation-hold-time" id="infopanel-for-term-for-animation-hold-time" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-hold-time" style="display:none">Info about the 'hold time' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-hold-time">https://drafts.csswg.org/web-animations-1/#animation-hold-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-hold-time">3.2.1. Setting the timeline of an animation</a> <a href="#ref-for-animation-hold-time①">(2)</a>
     <li><a href="#ref-for-animation-hold-time②">3.2.4. Setting the current time of an
@@ -3461,16 +3461,16 @@ Animation</a> <a href="#ref-for-animation-hold-time⑦">(2)</a> <a href="#ref-fo
     <li><a href="#ref-for-animation-hold-time①⓪">3.2.6. Playing an animation</a> <a href="#ref-for-animation-hold-time①①">(2)</a> <a href="#ref-for-animation-hold-time①②">(3)</a> <a href="#ref-for-animation-hold-time①③">(4)</a> <a href="#ref-for-animation-hold-time①④">(5)</a> <a href="#ref-for-animation-hold-time①⑤">(6)</a> <a href="#ref-for-animation-hold-time①⑥">(7)</a> <a href="#ref-for-animation-hold-time①⑦">(8)</a> <a href="#ref-for-animation-hold-time①⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#in-effect">https://drafts.csswg.org/web-animations-1/#in-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-effect" class="dfn-panel" data-for="term-for-in-effect" id="infopanel-for-term-for-in-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-in-effect" style="display:none">Info about the 'in effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#in-effect">https://drafts.csswg.org/web-animations-1/#in-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-effect">4.5.1. Sampling custom effects</a> <a href="#ref-for-in-effect①">(2)</a> <a href="#ref-for-in-effect②">(3)</a> <a href="#ref-for-in-effect③">(4)</a> <a href="#ref-for-in-effect④">(5)</a> <a href="#ref-for-in-effect⑤">(6)</a>
     <li><a href="#ref-for-in-effect⑥">5.4. The
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inactive-timeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#inactive-timeline">https://drafts.csswg.org/web-animations-1/#inactive-timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inactive-timeline" class="dfn-panel" data-for="term-for-inactive-timeline" id="infopanel-for-term-for-inactive-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-inactive-timeline" style="display:none">Info about the 'inactive timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#inactive-timeline">https://drafts.csswg.org/web-animations-1/#inactive-timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inactive-timeline">3.2.4. Setting the current time of an
 Animation</a> <a href="#ref-for-inactive-timeline①">(2)</a>
@@ -3478,16 +3478,16 @@ Animation</a> <a href="#ref-for-inactive-timeline①">(2)</a>
 Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-count">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-count">https://drafts.csswg.org/web-animations-1/#iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-count" class="dfn-panel" data-for="term-for-iteration-count" id="infopanel-for-term-for-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-count" style="display:none">Info about the 'iteration count' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-count">https://drafts.csswg.org/web-animations-1/#iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-count">3.6.1. Overview</a>
     <li><a href="#ref-for-iteration-count①">3.6.2. Calculating the active duration</a> <a href="#ref-for-iteration-count②">(2)</a>
     <li><a href="#ref-for-iteration-count③">3.8.1. Relationship of group time to child time</a> <a href="#ref-for-iteration-count④">(2)</a> <a href="#ref-for-iteration-count⑤">(3)</a> <a href="#ref-for-iteration-count⑥">(4)</a> <a href="#ref-for-iteration-count⑦">(5)</a> <a href="#ref-for-iteration-count⑧">(6)</a> <a href="#ref-for-iteration-count⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-duration">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-duration">https://drafts.csswg.org/web-animations-1/#iteration-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-duration" class="dfn-panel" data-for="term-for-iteration-duration" id="infopanel-for-term-for-iteration-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-duration" style="display:none">Info about the 'iteration duration' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-duration">https://drafts.csswg.org/web-animations-1/#iteration-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-duration">3.4.1. Iteration intervals</a> <a href="#ref-for-iteration-duration①">(2)</a>
     <li><a href="#ref-for-iteration-duration②">3.6.1. Overview</a> <a href="#ref-for-iteration-duration③">(2)</a>
@@ -3499,8 +3499,8 @@ Animation</a>
     <li><a href="#ref-for-iteration-duration①②">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-progress">https://drafts.csswg.org/web-animations-1/#iteration-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-progress" class="dfn-panel" data-for="term-for-iteration-progress" id="infopanel-for-term-for-iteration-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-progress" style="display:none">Info about the 'iteration progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-progress">https://drafts.csswg.org/web-animations-1/#iteration-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-progress">3.2.1. Setting the timeline of an animation</a>
     <li><a href="#ref-for-iteration-progress①">3.2.2. Setting the target effect of an
@@ -3511,14 +3511,14 @@ Animation</a>
     <li><a href="#ref-for-iteration-progress①①">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-start">
-   <a href="https://drafts.csswg.org/web-animations-1/#iteration-start">https://drafts.csswg.org/web-animations-1/#iteration-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-start" class="dfn-panel" data-for="term-for-iteration-start" id="infopanel-for-term-for-iteration-start" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-start" style="display:none">Info about the 'iteration start' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#iteration-start">https://drafts.csswg.org/web-animations-1/#iteration-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-start">3.6.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyframe-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#keyframe-effect">https://drafts.csswg.org/web-animations-1/#keyframe-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyframe-effect" class="dfn-panel" data-for="term-for-keyframe-effect" id="infopanel-for-term-for-keyframe-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-keyframe-effect" style="display:none">Info about the 'keyframe effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#keyframe-effect">https://drafts.csswg.org/web-animations-1/#keyframe-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyframe-effect">3.2.3. Waiting for the target effect</a>
     <li><a href="#ref-for-keyframe-effect①">3.3.1. Types of animation effects</a>
@@ -3528,59 +3528,59 @@ Animation</a>
     <li><a href="#ref-for-keyframe-effect⑥">5.8.1. Creating a new KeyframeEffect object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-not-animatable">
-   <a href="https://drafts.csswg.org/web-animations-1/#not-animatable">https://drafts.csswg.org/web-animations-1/#not-animatable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-not-animatable" class="dfn-panel" data-for="term-for-not-animatable" id="infopanel-for-term-for-not-animatable" role="menu">
+   <span id="infopaneltitle-for-term-for-not-animatable" style="display:none">Info about the 'not animatable' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#not-animatable">https://drafts.csswg.org/web-animations-1/#not-animatable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-not-animatable">4.1.1. Not animatable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-overall-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#overall-progress">https://drafts.csswg.org/web-animations-1/#overall-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-overall-progress" class="dfn-panel" data-for="term-for-overall-progress" id="infopanel-for-term-for-overall-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-overall-progress" style="display:none">Info about the 'overall progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#overall-progress">https://drafts.csswg.org/web-animations-1/#overall-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-overall-progress">3.6.1. Overview</a> <a href="#ref-for-overall-progress①">(2)</a>
     <li><a href="#ref-for-overall-progress②">3.6.3.2. Calculating the overall progress</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pause-an-animation">
-   <a href="https://drafts.csswg.org/web-animations-1/#pause-an-animation">https://drafts.csswg.org/web-animations-1/#pause-an-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pause-an-animation" class="dfn-panel" data-for="term-for-pause-an-animation" id="infopanel-for-term-for-pause-an-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-pause-an-animation" style="display:none">Info about the 'pause an animation' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#pause-an-animation">https://drafts.csswg.org/web-animations-1/#pause-an-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pause-an-animation">3.2.7. Pausing an animation</a> <a href="#ref-for-pause-an-animation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animation-play-state">
-   <a href="https://drafts.csswg.org/web-animations-1/#animation-play-state">https://drafts.csswg.org/web-animations-1/#animation-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animation-play-state" class="dfn-panel" data-for="term-for-animation-play-state" id="infopanel-for-term-for-animation-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-animation-play-state" style="display:none">Info about the 'play state' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#animation-play-state">https://drafts.csswg.org/web-animations-1/#animation-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-play-state">3.2.1. Setting the timeline of an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-playback-direction">
-   <a href="https://drafts.csswg.org/web-animations-1/#playback-direction">https://drafts.csswg.org/web-animations-1/#playback-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-playback-direction" class="dfn-panel" data-for="term-for-playback-direction" id="infopanel-for-term-for-playback-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-playback-direction" style="display:none">Info about the 'playback direction' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#playback-direction">https://drafts.csswg.org/web-animations-1/#playback-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-direction">3.6.1. Overview</a>
     <li><a href="#ref-for-playback-direction①">3.8.1. Relationship of group time to child time</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ready">
-   <a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ready" class="dfn-panel" data-for="term-for-ready" id="infopanel-for-term-for-ready" role="menu">
+   <span id="infopaneltitle-for-term-for-ready" style="display:none">Info about the 'ready' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#ready">https://drafts.csswg.org/web-animations-1/#ready</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ready">3.2.6. Playing an animation</a> <a href="#ref-for-ready①">(2)</a> <a href="#ref-for-ready②">(3)</a>
     <li><a href="#ref-for-ready③">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-simple-iteration-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#simple-iteration-progress">https://drafts.csswg.org/web-animations-1/#simple-iteration-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-simple-iteration-progress" class="dfn-panel" data-for="term-for-simple-iteration-progress" id="infopanel-for-term-for-simple-iteration-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-simple-iteration-progress" style="display:none">Info about the 'simple iteration progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#simple-iteration-progress">https://drafts.csswg.org/web-animations-1/#simple-iteration-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-iteration-progress">3.6.1. Overview</a> <a href="#ref-for-simple-iteration-progress①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-keyframeeffect-keyframeeffect-source-source">
-   <a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect-source-source">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect-source-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-keyframeeffect-keyframeeffect-source-source" class="dfn-panel" data-for="term-for-dom-keyframeeffect-keyframeeffect-source-source" id="infopanel-for-term-for-dom-keyframeeffect-keyframeeffect-source-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-keyframeeffect-keyframeeffect-source-source" style="display:none">Info about the 'source' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect-source-source">https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-keyframeeffect-source-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-keyframeeffect-source-source">5.8. The KeyframeEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-effect">https://drafts.csswg.org/web-animations-1/#target-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-effect" class="dfn-panel" data-for="term-for-target-effect" id="infopanel-for-term-for-target-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-target-effect" style="display:none">Info about the 'target effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-effect">https://drafts.csswg.org/web-animations-1/#target-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-effect">3.2.2. Setting the target effect of an
   animation</a>
@@ -3592,23 +3592,23 @@ Animation</a>
     <li><a href="#ref-for-target-effect⑧">5.1. The AnimationTimeline interface</a> <a href="#ref-for-target-effect⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-element">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-element">https://drafts.csswg.org/web-animations-1/#target-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-element" class="dfn-panel" data-for="term-for-target-element" id="infopanel-for-term-for-target-element" role="menu">
+   <span id="infopaneltitle-for-term-for-target-element" style="display:none">Info about the 'target element' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-element">https://drafts.csswg.org/web-animations-1/#target-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-element">4.5.1. Sampling custom effects</a> <a href="#ref-for-target-element①">(2)</a> <a href="#ref-for-target-element②">(3)</a> <a href="#ref-for-target-element③">(4)</a> <a href="#ref-for-target-element④">(5)</a>
     <li><a href="#ref-for-target-element⑤">5.10. The EffectCallback callback function</a> <a href="#ref-for-target-element⑥">(2)</a> <a href="#ref-for-target-element⑦">(3)</a> <a href="#ref-for-target-element⑧">(4)</a> <a href="#ref-for-target-element⑨">(5)</a>
     <li><a href="#ref-for-target-element①⓪">5.11. The Animatable interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-target-property">
-   <a href="https://drafts.csswg.org/web-animations-1/#target-property">https://drafts.csswg.org/web-animations-1/#target-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-target-property" class="dfn-panel" data-for="term-for-target-property" id="infopanel-for-term-for-target-property" role="menu">
+   <span id="infopaneltitle-for-term-for-target-property" style="display:none">Info about the 'target property' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#target-property">https://drafts.csswg.org/web-animations-1/#target-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-target-property">4.2.1. The effect value of a keyframe effect</a>
     <li><a href="#ref-for-target-property①">4.5.2. Execution order of custom effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-time-value">
-   <a href="https://drafts.csswg.org/web-animations-1/#time-value">https://drafts.csswg.org/web-animations-1/#time-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-time-value" class="dfn-panel" data-for="term-for-time-value" id="infopanel-for-term-for-time-value" role="menu">
+   <span id="infopaneltitle-for-term-for-time-value" style="display:none">Info about the 'time value' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#time-value">https://drafts.csswg.org/web-animations-1/#time-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-value">3.2.4. Setting the current time of an
 Animation</a>
@@ -3619,8 +3619,8 @@ Animation</a>
     <li><a href="#ref-for-time-value⑥">3.6.3.1. Calculating the active time</a> <a href="#ref-for-time-value⑦">(2)</a> <a href="#ref-for-time-value⑧">(3)</a> <a href="#ref-for-time-value⑨">(4)</a> <a href="#ref-for-time-value①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline">
-   <a href="https://drafts.csswg.org/web-animations-1/#timeline">https://drafts.csswg.org/web-animations-1/#timeline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline" class="dfn-panel" data-for="term-for-timeline" id="infopanel-for-term-for-timeline" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline" style="display:none">Info about the 'timeline' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#timeline">https://drafts.csswg.org/web-animations-1/#timeline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline">3.2.1. Setting the timeline of an animation</a> <a href="#ref-for-timeline①">(2)</a>
     <li><a href="#ref-for-timeline②">3.2.4. Setting the current time of an
@@ -3631,15 +3631,15 @@ Animation</a> <a href="#ref-for-timeline⑧">(2)</a>
     <li><a href="#ref-for-timeline①①">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformed-progress">
-   <a href="https://drafts.csswg.org/web-animations-1/#transformed-progress">https://drafts.csswg.org/web-animations-1/#transformed-progress</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformed-progress" class="dfn-panel" data-for="term-for-transformed-progress" id="infopanel-for-term-for-transformed-progress" role="menu">
+   <span id="infopaneltitle-for-term-for-transformed-progress" style="display:none">Info about the 'transformed progress' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#transformed-progress">https://drafts.csswg.org/web-animations-1/#transformed-progress</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-progress">3.6.1. Overview</a> <a href="#ref-for-transformed-progress①">(2)</a> <a href="#ref-for-transformed-progress②">(3)</a>
     <li><a href="#ref-for-transformed-progress③">3.7.2. Calculating the transformed time</a> <a href="#ref-for-transformed-progress④">(2)</a> <a href="#ref-for-transformed-progress⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unresolved">
-   <a href="https://drafts.csswg.org/web-animations-1/#unresolved">https://drafts.csswg.org/web-animations-1/#unresolved</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unresolved" class="dfn-panel" data-for="term-for-unresolved" id="infopanel-for-term-for-unresolved" role="menu">
+   <span id="infopaneltitle-for-term-for-unresolved" style="display:none">Info about the 'unresolved' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#unresolved">https://drafts.csswg.org/web-animations-1/#unresolved</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unresolved">3.2.1. Setting the timeline of an animation</a> <a href="#ref-for-unresolved①">(2)</a> <a href="#ref-for-unresolved②">(3)</a>
     <li><a href="#ref-for-unresolved③">3.2.2. Setting the target effect of an
@@ -3656,34 +3656,34 @@ Animation</a> <a href="#ref-for-unresolved①③">(2)</a> <a href="#ref-for-unre
     <li><a href="#ref-for-unresolved④⑥">4.5.1. Sampling custom effects</a> <a href="#ref-for-unresolved④⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-animations-and-send-events">
-   <a href="https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events">https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-animations-and-send-events" class="dfn-panel" data-for="term-for-update-animations-and-send-events" id="infopanel-for-term-for-update-animations-and-send-events" role="menu">
+   <span id="infopaneltitle-for-term-for-update-animations-and-send-events" style="display:none">Info about the 'update animations and send events' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events">https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-animations-and-send-events">4.5. Custom effects</a>
     <li><a href="#ref-for-update-animations-and-send-events①">4.5.1. Sampling custom effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-timing-properties-of-an-animation-effect">
-   <a href="https://drafts.csswg.org/web-animations-1/#update-the-timing-properties-of-an-animation-effect">https://drafts.csswg.org/web-animations-1/#update-the-timing-properties-of-an-animation-effect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-timing-properties-of-an-animation-effect" class="dfn-panel" data-for="term-for-update-the-timing-properties-of-an-animation-effect" id="infopanel-for-term-for-update-the-timing-properties-of-an-animation-effect" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-timing-properties-of-an-animation-effect" style="display:none">Info about the 'update the timing properties of an animation effect' external reference.</span><a href="https://drafts.csswg.org/web-animations-1/#update-the-timing-properties-of-an-animation-effect">https://drafts.csswg.org/web-animations-1/#update-the-timing-properties-of-an-animation-effect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-timing-properties-of-an-animation-effect">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-effecttiming-duration">
-   <a href="https://drafts.csswg.org/web-animations-2/#dom-effecttiming-duration">https://drafts.csswg.org/web-animations-2/#dom-effecttiming-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-effecttiming-duration" class="dfn-panel" data-for="term-for-dom-effecttiming-duration" id="infopanel-for-term-for-dom-effecttiming-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-effecttiming-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://drafts.csswg.org/web-animations-2/#dom-effecttiming-duration">https://drafts.csswg.org/web-animations-2/#dom-effecttiming-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-duration">5.5. The GroupEffect interface</a>
     <li><a href="#ref-for-dom-effecttiming-duration①">5.5.1. Processing a timing argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The AnimationTimeline interface</a>
     <li><a href="#ref-for-Exposed①">5.2. The AnimationEffect interface</a>
@@ -3692,20 +3692,20 @@ Animation</a> <a href="#ref-for-unresolved①③">(2)</a> <a href="#ref-for-unre
     <li><a href="#ref-for-Exposed④">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.2.6. Playing an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
     <li><a href="#ref-for-idl-double③">5.4. The
@@ -3713,15 +3713,15 @@ Animation</a> <a href="#ref-for-unresolved①③">(2)</a> <a href="#ref-for-unre
     <li><a href="#ref-for-idl-double⑤">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.5. The GroupEffect interface</a>
     <li><a href="#ref-for-idl-sequence①">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://heycam.github.io/webidl/#dfn-throw">https://heycam.github.io/webidl/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.2.4. Setting the current time of an
 Animation</a>
@@ -3731,15 +3731,15 @@ Animation</a>
     <li><a href="#ref-for-dfn-throw⑦">5.8. The KeyframeEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">5.5. The GroupEffect interface</a>
     <li><a href="#ref-for-idl-unrestricted-double①">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">5.6. The AnimationNodeList interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
    </ul>
@@ -4076,28 +4076,28 @@ feedback</a>). <a class="issue-return" href="#issue-6fb09aae" title="Jump to sec
 either its parent group or animation. Should we keep it in level 1 and define it
 simply as removing the animation from its animation? <a class="issue-return" href="#issue-49ccd991" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="silently-set-the-current-time">
-   <b><a href="#silently-set-the-current-time">#silently-set-the-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-silently-set-the-current-time" class="dfn-panel" data-for="silently-set-the-current-time" id="infopanel-for-silently-set-the-current-time" role="dialog">
+   <span id="infopaneltitle-for-silently-set-the-current-time" style="display:none">Info about the 'silently set the current time' definition.</span><b><a href="#silently-set-the-current-time">#silently-set-the-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-silently-set-the-current-time">3.2.4. Setting the current time of an
 Animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-current-time">
-   <b><a href="#set-the-current-time">#set-the-current-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-current-time" class="dfn-panel" data-for="set-the-current-time" id="infopanel-for-set-the-current-time" role="dialog">
+   <span id="infopaneltitle-for-set-the-current-time" style="display:none">Info about the 'set the current time' definition.</span><b><a href="#set-the-current-time">#set-the-current-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-current-time">3.2.1. Setting the timeline of an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="play-an-animation">
-   <b><a href="#play-an-animation">#play-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-play-an-animation" class="dfn-panel" data-for="play-an-animation" id="infopanel-for-play-an-animation" role="dialog">
+   <span id="infopaneltitle-for-play-an-animation" style="display:none">Info about the 'play an animation' definition.</span><b><a href="#play-an-animation">#play-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-play-an-animation">3.2.6. Playing an animation</a>
     <li><a href="#ref-for-play-an-animation①">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-play-task">
-   <b><a href="#pending-play-task">#pending-play-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-play-task" class="dfn-panel" data-for="pending-play-task" id="infopanel-for-pending-play-task" role="dialog">
+   <span id="infopaneltitle-for-pending-play-task" style="display:none">Info about the 'pending play task' definition.</span><b><a href="#pending-play-task">#pending-play-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-play-task">3.2.2. Setting the target effect of an
   animation</a>
@@ -4106,8 +4106,8 @@ Animation</a>
     <li><a href="#ref-for-pending-play-task②">3.2.6. Playing an animation</a> <a href="#ref-for-pending-play-task③">(2)</a> <a href="#ref-for-pending-play-task④">(3)</a> <a href="#ref-for-pending-play-task⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directly-associated-with-an-animation">
-   <b><a href="#directly-associated-with-an-animation">#directly-associated-with-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directly-associated-with-an-animation" class="dfn-panel" data-for="directly-associated-with-an-animation" id="infopanel-for-directly-associated-with-an-animation" role="dialog">
+   <span id="infopaneltitle-for-directly-associated-with-an-animation" style="display:none">Info about the 'directly associated' definition.</span><b><a href="#directly-associated-with-an-animation">#directly-associated-with-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directly-associated-with-an-animation">3.3. Animation effects</a> <a href="#ref-for-directly-associated-with-an-animation①">(2)</a> <a href="#ref-for-directly-associated-with-an-animation②">(3)</a>
     <li><a href="#ref-for-directly-associated-with-an-animation③">3.3.3. Local time and inherited time</a>
@@ -4117,8 +4117,8 @@ states</a>
     <li><a href="#ref-for-directly-associated-with-an-animation⑦">5.5.2. Definitions for manipulating hierarchies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-with-an-animation">
-   <b><a href="#associated-with-an-animation">#associated-with-an-animation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-with-an-animation" class="dfn-panel" data-for="associated-with-an-animation" id="infopanel-for-associated-with-an-animation" role="dialog">
+   <span id="infopaneltitle-for-associated-with-an-animation" style="display:none">Info about the 'associated with an animation' definition.</span><b><a href="#associated-with-an-animation">#associated-with-an-animation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-with-an-animation">3.3.4. Animation effect phases and
 states</a>
@@ -4126,8 +4126,8 @@ states</a>
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-effect-start-time">
-   <b><a href="#animation-effect-start-time">#animation-effect-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-effect-start-time" class="dfn-panel" data-for="animation-effect-start-time" id="infopanel-for-animation-effect-start-time" role="dialog">
+   <span id="infopaneltitle-for-animation-effect-start-time" style="display:none">Info about the 'start time' definition.</span><b><a href="#animation-effect-start-time">#animation-effect-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect-start-time">3.3.2. The active interval</a>
     <li><a href="#ref-for-animation-effect-start-time①">3.2. Animations</a> <a href="#ref-for-animation-effect-start-time②">(2)</a> <a href="#ref-for-animation-effect-start-time③">(3)</a> <a href="#ref-for-animation-effect-start-time④">(4)</a> <a href="#ref-for-animation-effect-start-time⑤">(5)</a> <a href="#ref-for-animation-effect-start-time⑥">(6)</a> <a href="#ref-for-animation-effect-start-time⑦">(7)</a> <a href="#ref-for-animation-effect-start-time⑧">(8)</a>
@@ -4145,8 +4145,8 @@ states</a>
   ComputedEffectTiming dictionary</a> <a href="#ref-for-animation-effect-start-time②⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-delay">
-   <b><a href="#start-delay">#start-delay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-delay" class="dfn-panel" data-for="start-delay" id="infopanel-for-start-delay" role="dialog">
+   <span id="infopaneltitle-for-start-delay" style="display:none">Info about the 'start delay' definition.</span><b><a href="#start-delay">#start-delay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-delay">3.3.2. The active interval</a>
     <li><a href="#ref-for-start-delay①">3.2. Animations</a> <a href="#ref-for-start-delay②">(2)</a> <a href="#ref-for-start-delay③">(3)</a> <a href="#ref-for-start-delay④">(4)</a>
@@ -4161,8 +4161,8 @@ states</a>
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-time">
-   <b><a href="#end-time">#end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-time" class="dfn-panel" data-for="end-time" id="infopanel-for-end-time" role="dialog">
+   <span id="infopaneltitle-for-end-time" style="display:none">Info about the 'end time' definition.</span><b><a href="#end-time">#end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-time">3.2. Animations</a>
     <li><a href="#ref-for-end-time①">3.8.3. The intrinsic
@@ -4173,8 +4173,8 @@ states</a>
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-time">
-   <b><a href="#inherited-time">#inherited-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-time" class="dfn-panel" data-for="inherited-time" id="infopanel-for-inherited-time" role="dialog">
+   <span id="infopaneltitle-for-inherited-time" style="display:none">Info about the 'inherited time' definition.</span><b><a href="#inherited-time">#inherited-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-time">3.2. Animations</a> <a href="#ref-for-inherited-time①">(2)</a>
     <li><a href="#ref-for-inherited-time②">3.3.3. Local time and inherited time</a> <a href="#ref-for-inherited-time③">(2)</a> <a href="#ref-for-inherited-time④">(3)</a> <a href="#ref-for-inherited-time⑤">(4)</a>
@@ -4185,8 +4185,8 @@ states</a>
   ComputedEffectTiming dictionary</a> <a href="#ref-for-inherited-time①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-time">
-   <b><a href="#local-time">#local-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-time" class="dfn-panel" data-for="local-time" id="infopanel-for-local-time" role="dialog">
+   <span id="infopaneltitle-for-local-time" style="display:none">Info about the 'local time' definition.</span><b><a href="#local-time">#local-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-time">3.2. Animations</a>
     <li><a href="#ref-for-local-time①">3.3.3. Local time and inherited time</a> <a href="#ref-for-local-time②">(2)</a> <a href="#ref-for-local-time③">(3)</a> <a href="#ref-for-local-time④">(4)</a>
@@ -4197,23 +4197,23 @@ states</a>
     <li><a href="#ref-for-local-time①⑦">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-play">
-   <b><a href="#in-play">#in-play</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-play" class="dfn-panel" data-for="in-play" id="infopanel-for-in-play" role="dialog">
+   <span id="infopaneltitle-for-in-play" style="display:none">Info about the 'in play' definition.</span><b><a href="#in-play">#in-play</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-play">3.3.4. Animation effect phases and
 states</a> <a href="#ref-for-in-play①">(2)</a> <a href="#ref-for-in-play②">(3)</a> <a href="#ref-for-in-play③">(4)</a> <a href="#ref-for-in-play④">(5)</a> <a href="#ref-for-in-play⑤">(6)</a>
     <li><a href="#ref-for-in-play⑥">3.4.3. Interval timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current">
-   <b><a href="#current">#current</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current" class="dfn-panel" data-for="current" id="infopanel-for-current" role="dialog">
+   <span id="infopaneltitle-for-current" style="display:none">Info about the 'current' definition.</span><b><a href="#current">#current</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current">3.3.4. Animation effect phases and
 states</a> <a href="#ref-for-current①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="intrinsic-iteration-duration">
-   <b><a href="#intrinsic-iteration-duration">#intrinsic-iteration-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-intrinsic-iteration-duration" class="dfn-panel" data-for="intrinsic-iteration-duration" id="infopanel-for-intrinsic-iteration-duration" role="dialog">
+   <span id="infopaneltitle-for-intrinsic-iteration-duration" style="display:none">Info about the 'intrinsic iteration duration' definition.</span><b><a href="#intrinsic-iteration-duration">#intrinsic-iteration-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intrinsic-iteration-duration">3.4.1. Iteration intervals</a> <a href="#ref-for-intrinsic-iteration-duration①">(2)</a>
     <li><a href="#ref-for-intrinsic-iteration-duration②">3.8.3. The intrinsic
@@ -4225,8 +4225,8 @@ states</a> <a href="#ref-for-current①">(2)</a>
     <li><a href="#ref-for-intrinsic-iteration-duration①①">5.8.1. Creating a new KeyframeEffect object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animation-effect-playback-rate">
-   <b><a href="#animation-effect-playback-rate">#animation-effect-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animation-effect-playback-rate" class="dfn-panel" data-for="animation-effect-playback-rate" id="infopanel-for-animation-effect-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-animation-effect-playback-rate" style="display:none">Info about the 'playback rate' definition.</span><b><a href="#animation-effect-playback-rate">#animation-effect-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animation-effect-playback-rate">2. Changes since level 1</a>
     <li><a href="#ref-for-animation-effect-playback-rate①">3.2.9. Speed control</a>
@@ -4239,14 +4239,14 @@ states</a> <a href="#ref-for-current①">(2)</a>
     <li><a href="#ref-for-animation-effect-playback-rate②⓪">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="repeated-duration">
-   <b><a href="#repeated-duration">#repeated-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-repeated-duration" class="dfn-panel" data-for="repeated-duration" id="infopanel-for-repeated-duration" role="dialog">
+   <span id="infopaneltitle-for-repeated-duration" style="display:none">Info about the 'repeated duration' definition.</span><b><a href="#repeated-duration">#repeated-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-repeated-duration">3.6.2. Calculating the active duration</a> <a href="#ref-for-repeated-duration①">(2)</a> <a href="#ref-for-repeated-duration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-duration">
-   <b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-duration" class="dfn-panel" data-for="active-duration" id="infopanel-for-active-duration" role="dialog">
+   <span id="infopaneltitle-for-active-duration" style="display:none">Info about the 'active duration' definition.</span><b><a href="#active-duration">#active-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-duration">3.2. Animations</a>
     <li><a href="#ref-for-active-duration①">3.5. Animation effect speed control</a> <a href="#ref-for-active-duration②">(2)</a> <a href="#ref-for-active-duration③">(3)</a>
@@ -4257,8 +4257,8 @@ states</a> <a href="#ref-for-current①">(2)</a>
   children of a sequence effect</a> <a href="#ref-for-active-duration①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformed-time">
-   <b><a href="#transformed-time">#transformed-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformed-time" class="dfn-panel" data-for="transformed-time" id="infopanel-for-transformed-time" role="dialog">
+   <span id="infopaneltitle-for-transformed-time" style="display:none">Info about the 'transformed time' definition.</span><b><a href="#transformed-time">#transformed-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformed-time">3.3.3. Local time and inherited time</a>
     <li><a href="#ref-for-transformed-time①">3.5. Animation effect speed control</a>
@@ -4268,8 +4268,8 @@ states</a> <a href="#ref-for-current①">(2)</a>
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="group-effect">
-   <b><a href="#group-effect">#group-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-group-effect" class="dfn-panel" data-for="group-effect" id="infopanel-for-group-effect" role="dialog">
+   <span id="infopaneltitle-for-group-effect" style="display:none">Info about the 'group effect' definition.</span><b><a href="#group-effect">#group-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group-effect">2. Changes since level 1</a>
     <li><a href="#ref-for-group-effect①">3.3. Animation effects</a> <a href="#ref-for-group-effect②">(2)</a>
@@ -4287,8 +4287,8 @@ states</a> <a href="#ref-for-current①">(2)</a>
     <li><a href="#ref-for-group-effect③⑤">5.5. The GroupEffect interface</a> <a href="#ref-for-group-effect③⑥">(2)</a> <a href="#ref-for-group-effect③⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="child-effect">
-   <b><a href="#child-effect">#child-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-child-effect" class="dfn-panel" data-for="child-effect" id="infopanel-for-child-effect" role="dialog">
+   <span id="infopaneltitle-for-child-effect" style="display:none">Info about the 'child effects' definition.</span><b><a href="#child-effect">#child-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-effect">3.8. Grouping and synchronization</a> <a href="#ref-for-child-effect①">(2)</a> <a href="#ref-for-child-effect②">(3)</a>
     <li><a href="#ref-for-child-effect③">3.8.2. The start time of
@@ -4304,8 +4304,8 @@ states</a> <a href="#ref-for-current①">(2)</a>
     <li><a href="#ref-for-child-effect①④">5.5.2. Definitions for manipulating hierarchies</a> <a href="#ref-for-child-effect①⑤">(2)</a> <a href="#ref-for-child-effect①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parent-group">
-   <b><a href="#parent-group">#parent-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parent-group" class="dfn-panel" data-for="parent-group" id="infopanel-for-parent-group" role="dialog">
+   <span id="infopaneltitle-for-parent-group" style="display:none">Info about the 'parent group' definition.</span><b><a href="#parent-group">#parent-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-group">3.2.2. Setting the target effect of an
   animation</a> <a href="#ref-for-parent-group①">(2)</a>
@@ -4322,40 +4322,46 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-parent-group③③">5.5.2. Definitions for manipulating hierarchies</a> <a href="#ref-for-parent-group③④">(2)</a> <a href="#ref-for-parent-group③⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tree-order">
-   <b><a href="#tree-order">#tree-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tree-order" class="dfn-panel" data-for="tree-order" id="infopanel-for-tree-order" role="dialog">
+   <span id="infopaneltitle-for-tree-order" style="display:none">Info about the '
+tree order' definition.</span><b><a href="#tree-order">#tree-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tree-order">4.3.1. The effect stack</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="root">
-   <b><a href="#root">#root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-root" class="dfn-panel" data-for="root" id="infopanel-for-root" role="dialog">
+   <span id="infopaneltitle-for-root" style="display:none">Info about the '
+root' definition.</span><b><a href="#root">#root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-root">3.3. Animation effects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ancestor">
-   <b><a href="#ancestor">#ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ancestor" class="dfn-panel" data-for="ancestor" id="infopanel-for-ancestor" role="dialog">
+   <span id="infopaneltitle-for-ancestor" style="display:none">Info about the '
+ancestor' definition.</span><b><a href="#ancestor">#ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ancestor">3.3. Animation effects</a>
     <li><a href="#ref-for-ancestor①">3.3.5. Fill modes</a> <a href="#ref-for-ancestor②">(2)</a> <a href="#ref-for-ancestor③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descendant">
-   <b><a href="#descendant">#descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descendant" class="dfn-panel" data-for="descendant" id="infopanel-for-descendant" role="dialog">
+   <span id="infopaneltitle-for-descendant" style="display:none">Info about the '
+descendant' definition.</span><b><a href="#descendant">#descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descendant">3.1.1. Hierarchical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inclusive-ancestor">
-   <b><a href="#inclusive-ancestor">#inclusive-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inclusive-ancestor" class="dfn-panel" data-for="inclusive-ancestor" id="infopanel-for-inclusive-ancestor" role="dialog">
+   <span id="infopaneltitle-for-inclusive-ancestor" style="display:none">Info about the '
+inclusive ancestor' definition.</span><b><a href="#inclusive-ancestor">#inclusive-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inclusive-ancestor">5.2. The AnimationEffect interface</a> <a href="#ref-for-inclusive-ancestor①">(2)</a> <a href="#ref-for-inclusive-ancestor②">(3)</a> <a href="#ref-for-inclusive-ancestor③">(4)</a>
     <li><a href="#ref-for-inclusive-ancestor④">5.5. The GroupEffect interface</a> <a href="#ref-for-inclusive-ancestor⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inclusive-descendant">
-   <b><a href="#inclusive-descendant">#inclusive-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inclusive-descendant" class="dfn-panel" data-for="inclusive-descendant" id="infopanel-for-inclusive-descendant" role="dialog">
+   <span id="infopaneltitle-for-inclusive-descendant" style="display:none">Info about the '
+inclusive descendant' definition.</span><b><a href="#inclusive-descendant">#inclusive-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inclusive-descendant">3.2.2. Setting the target effect of an
   animation</a>
@@ -4363,35 +4369,39 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-inclusive-descendant②">3.2.8. Canceling an animation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-sibling">
-   <b><a href="#next-sibling">#next-sibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-sibling" class="dfn-panel" data-for="next-sibling" id="infopanel-for-next-sibling" role="dialog">
+   <span id="infopaneltitle-for-next-sibling" style="display:none">Info about the '
+next sibling' definition.</span><b><a href="#next-sibling">#next-sibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-sibling">5.2. The AnimationEffect interface</a>
     <li><a href="#ref-for-next-sibling①">5.5.2. Definitions for manipulating hierarchies</a> <a href="#ref-for-next-sibling②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previous-sibling">
-   <b><a href="#previous-sibling">#previous-sibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previous-sibling" class="dfn-panel" data-for="previous-sibling" id="infopanel-for-previous-sibling" role="dialog">
+   <span id="infopaneltitle-for-previous-sibling" style="display:none">Info about the '
+previous sibling' definition.</span><b><a href="#previous-sibling">#previous-sibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previous-sibling">3.8.4.1. The start time of
   children of a sequence effect</a> <a href="#ref-for-previous-sibling①">(2)</a>
     <li><a href="#ref-for-previous-sibling②">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-child">
-   <b><a href="#first-child">#first-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-child" class="dfn-panel" data-for="first-child" id="infopanel-for-first-child" role="dialog">
+   <span id="infopaneltitle-for-first-child" style="display:none">Info about the '
+first child' definition.</span><b><a href="#first-child">#first-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-child">5.5. The GroupEffect interface</a> <a href="#ref-for-first-child①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-child">
-   <b><a href="#last-child">#last-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-child" class="dfn-panel" data-for="last-child" id="infopanel-for-last-child" role="dialog">
+   <span id="infopaneltitle-for-last-child" style="display:none">Info about the '
+last child' definition.</span><b><a href="#last-child">#last-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-child">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sequence-effect">
-   <b><a href="#sequence-effect">#sequence-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sequence-effect" class="dfn-panel" data-for="sequence-effect" id="infopanel-for-sequence-effect" role="dialog">
+   <span id="infopaneltitle-for-sequence-effect" style="display:none">Info about the 'sequence effect' definition.</span><b><a href="#sequence-effect">#sequence-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequence-effect">2. Changes since level 1</a>
     <li><a href="#ref-for-sequence-effect①">3.3.2. The active interval</a>
@@ -4407,8 +4417,8 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-sequence-effect①⑧">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-composite-operation">
-   <b><a href="#iteration-composite-operation">#iteration-composite-operation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-composite-operation" class="dfn-panel" data-for="iteration-composite-operation" id="infopanel-for-iteration-composite-operation" role="dialog">
+   <span id="infopaneltitle-for-iteration-composite-operation" style="display:none">Info about the 'iteration composite operation' definition.</span><b><a href="#iteration-composite-operation">#iteration-composite-operation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-composite-operation">4.2.1. The effect value of a keyframe effect</a>
     <li><a href="#ref-for-iteration-composite-operation①">4.4. Effect accumulation</a> <a href="#ref-for-iteration-composite-operation②">(2)</a>
@@ -4417,21 +4427,21 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-iteration-composite-operation⑦">5.9. The IterationCompositeOperation enumeration</a> <a href="#ref-for-iteration-composite-operation⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-composite-operation-replace">
-   <b><a href="#iteration-composite-operation-replace">#iteration-composite-operation-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-composite-operation-replace" class="dfn-panel" data-for="iteration-composite-operation-replace" id="infopanel-for-iteration-composite-operation-replace" role="dialog">
+   <span id="infopaneltitle-for-iteration-composite-operation-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#iteration-composite-operation-replace">#iteration-composite-operation-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-composite-operation-replace">5.9. The IterationCompositeOperation enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-composite-operation-accumulate">
-   <b><a href="#iteration-composite-operation-accumulate">#iteration-composite-operation-accumulate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-composite-operation-accumulate" class="dfn-panel" data-for="iteration-composite-operation-accumulate" id="infopanel-for-iteration-composite-operation-accumulate" role="dialog">
+   <span id="infopaneltitle-for-iteration-composite-operation-accumulate" style="display:none">Info about the 'accumulate' definition.</span><b><a href="#iteration-composite-operation-accumulate">#iteration-composite-operation-accumulate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-composite-operation-accumulate">4.2.1. The effect value of a keyframe effect</a>
     <li><a href="#ref-for-iteration-composite-operation-accumulate①">5.9. The IterationCompositeOperation enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-effect">
-   <b><a href="#custom-effect">#custom-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-effect" class="dfn-panel" data-for="custom-effect" id="infopanel-for-custom-effect" role="dialog">
+   <span id="infopaneltitle-for-custom-effect" style="display:none">Info about the 'custom effect' definition.</span><b><a href="#custom-effect">#custom-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-effect">2. Changes since level 1</a>
     <li><a href="#ref-for-custom-effect①">3.2.1. Setting the timeline of an animation</a>
@@ -4447,75 +4457,79 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-custom-effect①⑥">5.10. The EffectCallback callback function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationtimeline-play">
-   <b><a href="#dom-animationtimeline-play">#dom-animationtimeline-play</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationtimeline-play" class="dfn-panel" data-for="dom-animationtimeline-play" id="infopanel-for-dom-animationtimeline-play" role="dialog">
+   <span id="infopaneltitle-for-dom-animationtimeline-play" style="display:none">Info about the '
+Animation play(optional AnimationEffect? effect = null)' definition.</span><b><a href="#dom-animationtimeline-play">#dom-animationtimeline-play</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationtimeline-play">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationtimeline-play-effect-effect">
-   <b><a href="#dom-animationtimeline-play-effect-effect">#dom-animationtimeline-play-effect-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationtimeline-play-effect-effect" class="dfn-panel" data-for="dom-animationtimeline-play-effect-effect" id="infopanel-for-dom-animationtimeline-play-effect-effect" role="dialog">
+   <span id="infopaneltitle-for-dom-animationtimeline-play-effect-effect" style="display:none">Info about the 'effect' definition.</span><b><a href="#dom-animationtimeline-play-effect-effect">#dom-animationtimeline-play-effect-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationtimeline-play-effect-effect">5.1. The AnimationTimeline interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-parent">
-   <b><a href="#dom-animationeffect-parent">#dom-animationeffect-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-parent" class="dfn-panel" data-for="dom-animationeffect-parent" id="infopanel-for-dom-animationeffect-parent" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-parent" style="display:none">Info about the 'parent' definition.</span><b><a href="#dom-animationeffect-parent">#dom-animationeffect-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-parent">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-previoussibling">
-   <b><a href="#dom-animationeffect-previoussibling">#dom-animationeffect-previoussibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-previoussibling" class="dfn-panel" data-for="dom-animationeffect-previoussibling" id="infopanel-for-dom-animationeffect-previoussibling" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-previoussibling" style="display:none">Info about the 'previousSibling' definition.</span><b><a href="#dom-animationeffect-previoussibling">#dom-animationeffect-previoussibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-previoussibling">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-nextsibling">
-   <b><a href="#dom-animationeffect-nextsibling">#dom-animationeffect-nextsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-nextsibling" class="dfn-panel" data-for="dom-animationeffect-nextsibling" id="infopanel-for-dom-animationeffect-nextsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-nextsibling" style="display:none">Info about the 'nextSibling' definition.</span><b><a href="#dom-animationeffect-nextsibling">#dom-animationeffect-nextsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-nextsibling">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-before">
-   <b><a href="#dom-animationeffect-before">#dom-animationeffect-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-before" class="dfn-panel" data-for="dom-animationeffect-before" id="infopanel-for-dom-animationeffect-before" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-before" style="display:none">Info about the '
+void before (AnimationEffect... effects)' definition.</span><b><a href="#dom-animationeffect-before">#dom-animationeffect-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-before">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-after">
-   <b><a href="#dom-animationeffect-after">#dom-animationeffect-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-after" class="dfn-panel" data-for="dom-animationeffect-after" id="infopanel-for-dom-animationeffect-after" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-after" style="display:none">Info about the '
+void after(AnimationEffect... effects)' definition.</span><b><a href="#dom-animationeffect-after">#dom-animationeffect-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-after">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-replace">
-   <b><a href="#dom-animationeffect-replace">#dom-animationeffect-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-replace" class="dfn-panel" data-for="dom-animationeffect-replace" id="infopanel-for-dom-animationeffect-replace" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-replace" style="display:none">Info about the '
+void replace(AnimationEffect... effects)' definition.</span><b><a href="#dom-animationeffect-replace">#dom-animationeffect-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-replace">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationeffect-remove">
-   <b><a href="#dom-animationeffect-remove">#dom-animationeffect-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationeffect-remove" class="dfn-panel" data-for="dom-animationeffect-remove" id="infopanel-for-dom-animationeffect-remove" role="dialog">
+   <span id="infopaneltitle-for-dom-animationeffect-remove" style="display:none">Info about the 'void remove()' definition.</span><b><a href="#dom-animationeffect-remove">#dom-animationeffect-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationeffect-remove">5.2. The AnimationEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-effecttiming-playbackrate">
-   <b><a href="#dom-effecttiming-playbackrate">#dom-effecttiming-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-effecttiming-playbackrate" class="dfn-panel" data-for="dom-effecttiming-playbackrate" id="infopanel-for-dom-effecttiming-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-effecttiming-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-effecttiming-playbackrate">#dom-effecttiming-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-effecttiming-playbackrate">5.3. The EffectTiming and OptionalEffectTiming dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-computedeffecttiming-starttime">
-   <b><a href="#dom-computedeffecttiming-starttime">#dom-computedeffecttiming-starttime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-computedeffecttiming-starttime" class="dfn-panel" data-for="dom-computedeffecttiming-starttime" id="infopanel-for-dom-computedeffecttiming-starttime" role="dialog">
+   <span id="infopaneltitle-for-dom-computedeffecttiming-starttime" style="display:none">Info about the 'startTime' definition.</span><b><a href="#dom-computedeffecttiming-starttime">#dom-computedeffecttiming-starttime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-computedeffecttiming-starttime">5.4. The
   ComputedEffectTiming dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="groupeffect">
-   <b><a href="#groupeffect">#groupeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-groupeffect" class="dfn-panel" data-for="groupeffect" id="infopanel-for-groupeffect" role="dialog">
+   <span id="infopaneltitle-for-groupeffect" style="display:none">Info about the 'GroupEffect' definition.</span><b><a href="#groupeffect">#groupeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-groupeffect">5.2. The AnimationEffect interface</a> <a href="#ref-for-groupeffect①">(2)</a>
     <li><a href="#ref-for-groupeffect②">5.4.1. The FillMode enumeration</a>
@@ -4524,77 +4538,80 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-groupeffect①③">5.12. Model liveness</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-groupeffect">
-   <b><a href="#dom-groupeffect-groupeffect">#dom-groupeffect-groupeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-groupeffect" class="dfn-panel" data-for="dom-groupeffect-groupeffect" id="infopanel-for-dom-groupeffect-groupeffect" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-groupeffect" style="display:none">Info about the 'GroupEffect ()' definition.</span><b><a href="#dom-groupeffect-groupeffect">#dom-groupeffect-groupeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-groupeffect">5.5. The GroupEffect interface</a> <a href="#ref-for-dom-groupeffect-groupeffect①">(2)</a>
     <li><a href="#ref-for-dom-groupeffect-groupeffect②">5.5.1. Processing a timing argument</a>
     <li><a href="#ref-for-dom-groupeffect-groupeffect③">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-groupeffect-children-timing-children">
-   <b><a href="#dom-groupeffect-groupeffect-children-timing-children">#dom-groupeffect-groupeffect-children-timing-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-groupeffect-children-timing-children" class="dfn-panel" data-for="dom-groupeffect-groupeffect-children-timing-children" id="infopanel-for-dom-groupeffect-groupeffect-children-timing-children" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-groupeffect-children-timing-children" style="display:none">Info about the 'children' definition.</span><b><a href="#dom-groupeffect-groupeffect-children-timing-children">#dom-groupeffect-groupeffect-children-timing-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-groupeffect-children-timing-children">5.5. The GroupEffect interface</a> <a href="#ref-for-dom-groupeffect-groupeffect-children-timing-children①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-groupeffect-children-timing-timing">
-   <b><a href="#dom-groupeffect-groupeffect-children-timing-timing">#dom-groupeffect-groupeffect-children-timing-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-groupeffect-children-timing-timing" class="dfn-panel" data-for="dom-groupeffect-groupeffect-children-timing-timing" id="infopanel-for-dom-groupeffect-groupeffect-children-timing-timing" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-groupeffect-children-timing-timing" style="display:none">Info about the 'timing' definition.</span><b><a href="#dom-groupeffect-groupeffect-children-timing-timing">#dom-groupeffect-groupeffect-children-timing-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-groupeffect-children-timing-timing">5.5. The GroupEffect interface</a> <a href="#ref-for-dom-groupeffect-groupeffect-children-timing-timing①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-children">
-   <b><a href="#dom-groupeffect-children">#dom-groupeffect-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-children" class="dfn-panel" data-for="dom-groupeffect-children" id="infopanel-for-dom-groupeffect-children" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-children" style="display:none">Info about the 'children' definition.</span><b><a href="#dom-groupeffect-children">#dom-groupeffect-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-children">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-firstchild">
-   <b><a href="#dom-groupeffect-firstchild">#dom-groupeffect-firstchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-firstchild" class="dfn-panel" data-for="dom-groupeffect-firstchild" id="infopanel-for-dom-groupeffect-firstchild" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-firstchild" style="display:none">Info about the 'firstChild' definition.</span><b><a href="#dom-groupeffect-firstchild">#dom-groupeffect-firstchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-firstchild">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-lastchild">
-   <b><a href="#dom-groupeffect-lastchild">#dom-groupeffect-lastchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-lastchild" class="dfn-panel" data-for="dom-groupeffect-lastchild" id="infopanel-for-dom-groupeffect-lastchild" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-lastchild" style="display:none">Info about the 'lastChild' definition.</span><b><a href="#dom-groupeffect-lastchild">#dom-groupeffect-lastchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-lastchild">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-prepend">
-   <b><a href="#dom-groupeffect-prepend">#dom-groupeffect-prepend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-prepend" class="dfn-panel" data-for="dom-groupeffect-prepend" id="infopanel-for-dom-groupeffect-prepend" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-prepend" style="display:none">Info about the '' definition.</span><b><a href="#dom-groupeffect-prepend">#dom-groupeffect-prepend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-prepend">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-append">
-   <b><a href="#dom-groupeffect-append">#dom-groupeffect-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-append" class="dfn-panel" data-for="dom-groupeffect-append" id="infopanel-for-dom-groupeffect-append" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-append" style="display:none">Info about the '
+void append (AnimationEffect... effects)' definition.</span><b><a href="#dom-groupeffect-append">#dom-groupeffect-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-append">5.5. The GroupEffect interface</a> <a href="#ref-for-dom-groupeffect-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-groupeffect-clone">
-   <b><a href="#dom-groupeffect-clone">#dom-groupeffect-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-groupeffect-clone" class="dfn-panel" data-for="dom-groupeffect-clone" id="infopanel-for-dom-groupeffect-clone" role="dialog">
+   <span id="infopaneltitle-for-dom-groupeffect-clone" style="display:none">Info about the '
+GroupEffect clone ()' definition.</span><b><a href="#dom-groupeffect-clone">#dom-groupeffect-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-groupeffect-clone">5.5. The GroupEffect interface</a>
     <li><a href="#ref-for-dom-groupeffect-clone①">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-a-timing-argument">
-   <b><a href="#process-a-timing-argument">#process-a-timing-argument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-a-timing-argument" class="dfn-panel" data-for="process-a-timing-argument" id="infopanel-for-process-a-timing-argument" role="dialog">
+   <span id="infopaneltitle-for-process-a-timing-argument" style="display:none">Info about the 'process a timing argument' definition.</span><b><a href="#process-a-timing-argument">#process-a-timing-argument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-a-timing-argument">5.5. The GroupEffect interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="next-sibling-not-included">
-   <b><a href="#next-sibling-not-included">#next-sibling-not-included</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-next-sibling-not-included" class="dfn-panel" data-for="next-sibling-not-included" id="infopanel-for-next-sibling-not-included" role="dialog">
+   <span id="infopaneltitle-for-next-sibling-not-included" style="display:none">Info about the 'next sibling of
+effect not included' definition.</span><b><a href="#next-sibling-not-included">#next-sibling-not-included</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-next-sibling-not-included">5.2. The AnimationEffect interface</a> <a href="#ref-for-next-sibling-not-included①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-an-animation-effect">
-   <b><a href="#remove-an-animation-effect">#remove-an-animation-effect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-an-animation-effect" class="dfn-panel" data-for="remove-an-animation-effect" id="infopanel-for-remove-an-animation-effect" role="dialog">
+   <span id="infopaneltitle-for-remove-an-animation-effect" style="display:none">Info about the 'remove' definition.</span><b><a href="#remove-an-animation-effect">#remove-an-animation-effect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-an-animation-effect">3.2.2. Setting the target effect of an
   animation</a>
@@ -4602,77 +4619,79 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
     <li><a href="#ref-for-remove-an-animation-effect③">5.5.2. Definitions for manipulating hierarchies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="insert-children">
-   <b><a href="#insert-children">#insert-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-insert-children" class="dfn-panel" data-for="insert-children" id="infopanel-for-insert-children" role="dialog">
+   <span id="infopaneltitle-for-insert-children" style="display:none">Info about the 'insert' definition.</span><b><a href="#insert-children">#insert-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-children">5.2. The AnimationEffect interface</a> <a href="#ref-for-insert-children①">(2)</a> <a href="#ref-for-insert-children②">(3)</a>
     <li><a href="#ref-for-insert-children③">5.5. The GroupEffect interface</a> <a href="#ref-for-insert-children④">(2)</a> <a href="#ref-for-insert-children⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="animationnodelist">
-   <b><a href="#animationnodelist">#animationnodelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-animationnodelist" class="dfn-panel" data-for="animationnodelist" id="infopanel-for-animationnodelist" role="dialog">
+   <span id="infopaneltitle-for-animationnodelist" style="display:none">Info about the 'AnimationNodeList' definition.</span><b><a href="#animationnodelist">#animationnodelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animationnodelist">5.5. The GroupEffect interface</a> <a href="#ref-for-animationnodelist①">(2)</a>
     <li><a href="#ref-for-animationnodelist②">5.6. The AnimationNodeList interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationnodelist-length">
-   <b><a href="#dom-animationnodelist-length">#dom-animationnodelist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationnodelist-length" class="dfn-panel" data-for="dom-animationnodelist-length" id="infopanel-for-dom-animationnodelist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-animationnodelist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-animationnodelist-length">#dom-animationnodelist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationnodelist-length">5.6. The AnimationNodeList interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-animationnodelist-item">
-   <b><a href="#dom-animationnodelist-item">#dom-animationnodelist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-animationnodelist-item" class="dfn-panel" data-for="dom-animationnodelist-item" id="infopanel-for-dom-animationnodelist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-animationnodelist-item" style="display:none">Info about the '
+getter AnimationEffect? item(unsigned long index)' definition.</span><b><a href="#dom-animationnodelist-item">#dom-animationnodelist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-animationnodelist-item">5.6. The AnimationNodeList interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sequenceeffect">
-   <b><a href="#sequenceeffect">#sequenceeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sequenceeffect" class="dfn-panel" data-for="sequenceeffect" id="infopanel-for-sequenceeffect" role="dialog">
+   <span id="infopaneltitle-for-sequenceeffect" style="display:none">Info about the 'SequenceEffect' definition.</span><b><a href="#sequenceeffect">#sequenceeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequenceeffect">5.7. The SequenceEffect interfaces</a> <a href="#ref-for-sequenceeffect①">(2)</a> <a href="#ref-for-sequenceeffect②">(3)</a> <a href="#ref-for-sequenceeffect③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sequenceeffect-sequenceeffect">
-   <b><a href="#dom-sequenceeffect-sequenceeffect">#dom-sequenceeffect-sequenceeffect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sequenceeffect-sequenceeffect" class="dfn-panel" data-for="dom-sequenceeffect-sequenceeffect" id="infopanel-for-dom-sequenceeffect-sequenceeffect" role="dialog">
+   <span id="infopaneltitle-for-dom-sequenceeffect-sequenceeffect" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-sequenceeffect-sequenceeffect">#dom-sequenceeffect-sequenceeffect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sequenceeffect-sequenceeffect">5.5.1. Processing a timing argument</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sequenceeffect-clone">
-   <b><a href="#dom-sequenceeffect-clone">#dom-sequenceeffect-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sequenceeffect-clone" class="dfn-panel" data-for="dom-sequenceeffect-clone" id="infopanel-for-dom-sequenceeffect-clone" role="dialog">
+   <span id="infopaneltitle-for-dom-sequenceeffect-clone" style="display:none">Info about the '
+SequenceEffect clone ()' definition.</span><b><a href="#dom-sequenceeffect-clone">#dom-sequenceeffect-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sequenceeffect-clone">5.7. The SequenceEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffect-iterationcomposite">
-   <b><a href="#dom-keyframeeffect-iterationcomposite">#dom-keyframeeffect-iterationcomposite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffect-iterationcomposite" class="dfn-panel" data-for="dom-keyframeeffect-iterationcomposite" id="infopanel-for-dom-keyframeeffect-iterationcomposite" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffect-iterationcomposite" style="display:none">Info about the 'iterationComposite' definition.</span><b><a href="#dom-keyframeeffect-iterationcomposite">#dom-keyframeeffect-iterationcomposite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffect-iterationcomposite">5.8. The KeyframeEffect interfaces</a> <a href="#ref-for-dom-keyframeeffect-iterationcomposite①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keyframeeffectoptions-iterationcomposite">
-   <b><a href="#dom-keyframeeffectoptions-iterationcomposite">#dom-keyframeeffectoptions-iterationcomposite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keyframeeffectoptions-iterationcomposite" class="dfn-panel" data-for="dom-keyframeeffectoptions-iterationcomposite" id="infopanel-for-dom-keyframeeffectoptions-iterationcomposite" role="dialog">
+   <span id="infopaneltitle-for-dom-keyframeeffectoptions-iterationcomposite" style="display:none">Info about the 'iterationComposite' definition.</span><b><a href="#dom-keyframeeffectoptions-iterationcomposite">#dom-keyframeeffectoptions-iterationcomposite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keyframeeffectoptions-iterationcomposite">5.8.2. The KeyframeEffectOptions dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iterationcompositeoperation">
-   <b><a href="#iterationcompositeoperation">#iterationcompositeoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iterationcompositeoperation" class="dfn-panel" data-for="iterationcompositeoperation" id="infopanel-for-iterationcompositeoperation" role="dialog">
+   <span id="infopaneltitle-for-iterationcompositeoperation" style="display:none">Info about the 'IterationCompositeOperation' definition.</span><b><a href="#iterationcompositeoperation">#iterationcompositeoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iterationcompositeoperation">5.8. The KeyframeEffect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-iterationcompositeoperation">
-   <b><a href="#enumdef-iterationcompositeoperation">#enumdef-iterationcompositeoperation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-iterationcompositeoperation" class="dfn-panel" data-for="enumdef-iterationcompositeoperation" id="infopanel-for-enumdef-iterationcompositeoperation" role="dialog">
+   <span id="infopaneltitle-for-enumdef-iterationcompositeoperation" style="display:none">Info about the 'IterationCompositeOperation' definition.</span><b><a href="#enumdef-iterationcompositeoperation">#enumdef-iterationcompositeoperation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-iterationcompositeoperation">5.8. The KeyframeEffect interfaces</a> <a href="#ref-for-enumdef-iterationcompositeoperation①">(2)</a>
     <li><a href="#ref-for-enumdef-iterationcompositeoperation②">5.8.2. The KeyframeEffectOptions dictionary</a> <a href="#ref-for-enumdef-iterationcompositeoperation③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-effectcallback">
-   <b><a href="#callbackdef-effectcallback">#callbackdef-effectcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-effectcallback" class="dfn-panel" data-for="callbackdef-effectcallback" id="infopanel-for-callbackdef-effectcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-effectcallback" style="display:none">Info about the 'EffectCallback' definition.</span><b><a href="#callbackdef-effectcallback">#callbackdef-effectcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-effectcallback">5.10. The EffectCallback callback function</a> <a href="#ref-for-callbackdef-effectcallback①">(2)</a>
     <li><a href="#ref-for-callbackdef-effectcallback②">5.12. Model liveness</a>
@@ -4680,57 +4699,113 @@ states</a> <a href="#ref-for-parent-group①①">(2)</a> <a href="#ref-for-paren
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/device-memory/index.html
+++ b/tests/github/w3c/device-memory/index.html
@@ -771,50 +771,50 @@ specification.</p>
    <li><a href="#examples">Examples</a><span>, in § 2.1</span>
    <li><a href="#navigatordevicememory">NavigatorDeviceMemory</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">3. Device Memory JS API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">3. Device Memory JS API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-name-decimals">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-decimals">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-decimals</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-name-decimals" class="dfn-panel" data-for="term-for-name-decimals" id="infopanel-for-term-for-name-decimals" role="menu">
+   <span id="infopaneltitle-for-term-for-name-decimals" style="display:none">Info about the 'decimal' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-decimals">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-decimals</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name-decimals">2. Device Memory (Client Hint) Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-name-items">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-items">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-name-items" class="dfn-panel" data-for="term-for-name-items" id="infopanel-for-term-for-name-items" role="menu">
+   <span id="infopaneltitle-for-term-for-name-items" style="display:none">Info about the 'item' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-items">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#name-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name-items">2. Device Memory (Client Hint) Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'structured header value' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2. Device Memory (Client Hint) Header Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Device Memory JS API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">3. Device Memory JS API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3. Device Memory JS API</a>
    </ul>
@@ -868,78 +868,134 @@ specification.</p>
 <a data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator"><c- n>WorkerNavigator</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="#navigatordevicememory"><c- n>NavigatorDeviceMemory</c-></a>;
 
 </pre>
-  <aside class="dfn-panel" data-for="computing-device-memory-value">
-   <b><a href="#computing-device-memory-value">#computing-device-memory-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computing-device-memory-value" class="dfn-panel" data-for="computing-device-memory-value" id="infopanel-for-computing-device-memory-value" role="dialog">
+   <span id="infopaneltitle-for-computing-device-memory-value" style="display:none">Info about the '2.1. Computing Device Memory Value' definition.</span><b><a href="#computing-device-memory-value">#computing-device-memory-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computing-device-memory-value">2.1. Computing Device Memory Value</a>
     <li><a href="#ref-for-computing-device-memory-value">3. Device Memory JS API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="examples">
-   <b><a href="#examples">#examples</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-examples" class="dfn-panel" data-for="examples" id="infopanel-for-examples" role="dialog">
+   <span id="infopaneltitle-for-examples" style="display:none">Info about the '2.2. Examples' definition.</span><b><a href="#examples">#examples</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-examples">2.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatordevicememory">
-   <b><a href="#navigatordevicememory">#navigatordevicememory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatordevicememory" class="dfn-panel" data-for="navigatordevicememory" id="infopanel-for-navigatordevicememory" role="dialog">
+   <span id="infopaneltitle-for-navigatordevicememory" style="display:none">Info about the 'NavigatorDeviceMemory' definition.</span><b><a href="#navigatordevicememory">#navigatordevicememory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatordevicememory">3. Device Memory JS API</a> <a href="#ref-for-navigatordevicememory①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/deviceorientation/index.html
+++ b/tests/github/w3c/deviceorientation/index.html
@@ -1317,54 +1317,54 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
      <li><a href="#dom-devicemotioneventaccelerationinit-z">dict-member for DeviceMotionEventAccelerationInit</a><span>, in § 4.4</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.1. deviceorientation Event</a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
     <li><a href="#ref-for-relevant-settings-object③">4.4. devicemotion Event</a> <a href="#ref-for-relevant-settings-object④">(2)</a> <a href="#ref-for-relevant-settings-object⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-triggered-by-user-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-triggered-by-user-activation" class="dfn-panel" data-for="term-for-triggered-by-user-activation" id="infopanel-for-term-for-triggered-by-user-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-triggered-by-user-activation" style="display:none">Info about the 'triggered by user activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-triggered-by-user-activation">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-triggered-by-user-activation①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-orientationchange">
-   <a href="https://compat.spec.whatwg.org/#event-orientationchange">https://compat.spec.whatwg.org/#event-orientationchange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-orientationchange" class="dfn-panel" data-for="term-for-event-orientationchange" id="infopanel-for-term-for-event-orientationchange" role="menu">
+   <span id="infopaneltitle-for-term-for-event-orientationchange" style="display:none">Info about the 'orientationchange' external reference.</span><a href="https://compat.spec.whatwg.org/#event-orientationchange">https://compat.spec.whatwg.org/#event-orientationchange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-orientationchange">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-event①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-dictdef-eventinit①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dommatrixreadonly-rotate">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotate">https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dommatrixreadonly-rotate" class="dfn-panel" data-for="term-for-dom-dommatrixreadonly-rotate" id="infopanel-for-term-for-dom-dommatrixreadonly-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dommatrixreadonly-rotate" style="display:none">Info about the 'rotate()' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotate">https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-rotate">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dommatrix-rotateself">
-   <a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateself">https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateself</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dommatrix-rotateself" class="dfn-panel" data-for="term-for-dom-dommatrix-rotateself" id="infopanel-for-term-for-dom-dommatrix-rotateself" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dommatrix-rotateself" style="display:none">Info about the 'rotateSelf()' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateself">https://drafts.fxtf.org/geometry-1/#dom-dommatrix-rotateself</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-rotateself">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-eventhandler①">4.2. deviceorientationabsolute Event</a>
@@ -1372,8 +1372,8 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-eventhandler③">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-window①">4.2. deviceorientationabsolute Event</a>
@@ -1381,55 +1381,55 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-window③">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">5. Security and privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-event-handler-event-type①">4.2. deviceorientationabsolute Event</a>
     <li><a href="#ref-for-event-handler-event-type②">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-in-parallel①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">4.5. Permission model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.1. deviceorientation Event</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a> <a href="#ref-for-concept-settings-object-origin②">(3)</a>
     <li><a href="#ref-for-concept-settings-object-origin③">4.4. devicemotion Event</a> <a href="#ref-for-concept-settings-object-origin④">(2)</a> <a href="#ref-for-concept-settings-object-origin⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-queue-a-task①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">5. Security and privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window" class="dfn-panel" data-for="term-for-dom-window" id="infopanel-for-term-for-dom-window" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window" style="display:none">Info about the 'window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window">4.1. deviceorientation Event</a> <a href="#ref-for-dom-window①">(2)</a>
     <li><a href="#ref-for-dom-window②">4.2. deviceorientationabsolute Event</a> <a href="#ref-for-dom-window③">(2)</a>
@@ -1437,63 +1437,63 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-dom-window⑥">4.4. devicemotion Event</a> <a href="#ref-for-dom-window⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate-visible">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate-visible">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visibilitystate-visible" class="dfn-panel" data-for="term-for-dom-visibilitystate-visible" id="infopanel-for-term-for-dom-visibilitystate-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visibilitystate-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate-visible">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilitystate-visible">5. Security and privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-idl-DOMException①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-idl-DOMString①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-Exposed①">4.4. devicemotion Event</a> <a href="#ref-for-Exposed②">(2)</a> <a href="#ref-for-Exposed③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-notallowederror①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-idl-promise①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">4.1. deviceorientation Event</a> <a href="#ref-for-SecureContext①">(2)</a>
     <li><a href="#ref-for-SecureContext②">4.2. deviceorientationabsolute Event</a>
     <li><a href="#ref-for-SecureContext③">4.4. devicemotion Event</a> <a href="#ref-for-SecureContext④">(2)</a> <a href="#ref-for-SecureContext⑤">(3)</a> <a href="#ref-for-SecureContext⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.1. deviceorientation Event</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">4.1. deviceorientation Event</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a> <a href="#ref-for-idl-double⑤">(6)</a>
     <li><a href="#ref-for-idl-double⑥">4.4. devicemotion Event</a> <a href="#ref-for-idl-double⑦">(2)</a> <a href="#ref-for-idl-double⑧">(3)</a> <a href="#ref-for-idl-double⑨">(4)</a> <a href="#ref-for-idl-double①⓪">(5)</a> <a href="#ref-for-idl-double①①">(6)</a> <a href="#ref-for-idl-double①②">(7)</a> <a href="#ref-for-idl-double①③">(8)</a> <a href="#ref-for-idl-double①④">(9)</a> <a href="#ref-for-idl-double①⑤">(10)</a> <a href="#ref-for-idl-double①⑥">(11)</a> <a href="#ref-for-idl-double①⑦">(12)</a> <a href="#ref-for-idl-double①⑧">(13)</a> <a href="#ref-for-idl-double①⑨">(14)</a>
@@ -1680,8 +1680,8 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="def-deviceorientation">
-   <b><a href="#def-deviceorientation">#def-deviceorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-deviceorientation" class="dfn-panel" data-for="def-deviceorientation" id="infopanel-for-def-deviceorientation" role="dialog">
+   <span id="infopaneltitle-for-def-deviceorientation" style="display:none">Info about the 'deviceorientation' definition.</span><b><a href="#def-deviceorientation">#def-deviceorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-deviceorientation">2. Introduction</a> <a href="#ref-for-def-deviceorientation①">(2)</a>
     <li><a href="#ref-for-def-deviceorientation②">4.1. deviceorientation Event</a> <a href="#ref-for-def-deviceorientation③">(2)</a> <a href="#ref-for-def-deviceorientation④">(3)</a>
@@ -1689,21 +1689,21 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-def-deviceorientation⑥">4.3. compassneedscalibration Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-ondeviceorientation">
-   <b><a href="#dom-window-ondeviceorientation">#dom-window-ondeviceorientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-ondeviceorientation" class="dfn-panel" data-for="dom-window-ondeviceorientation" id="infopanel-for-dom-window-ondeviceorientation" role="dialog">
+   <span id="infopaneltitle-for-dom-window-ondeviceorientation" style="display:none">Info about the 'ondeviceorientation' definition.</span><b><a href="#dom-window-ondeviceorientation">#dom-window-ondeviceorientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-ondeviceorientation">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deviceorientationevent">
-   <b><a href="#deviceorientationevent">#deviceorientationevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deviceorientationevent" class="dfn-panel" data-for="deviceorientationevent" id="infopanel-for-deviceorientationevent" role="dialog">
+   <span id="infopaneltitle-for-deviceorientationevent" style="display:none">Info about the 'DeviceOrientationEvent' definition.</span><b><a href="#deviceorientationevent">#deviceorientationevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deviceorientationevent">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-deviceorientationevent①">4.2. deviceorientationabsolute Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-deviceorientationevent-alpha">
-   <b><a href="#dom-deviceorientationevent-alpha">#dom-deviceorientationevent-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-deviceorientationevent-alpha" class="dfn-panel" data-for="dom-deviceorientationevent-alpha" id="infopanel-for-dom-deviceorientationevent-alpha" role="dialog">
+   <span id="infopaneltitle-for-dom-deviceorientationevent-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#dom-deviceorientationevent-alpha">#dom-deviceorientationevent-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-deviceorientationevent-alpha">2. Introduction</a> <a href="#ref-for-dom-deviceorientationevent-alpha①">(2)</a>
     <li><a href="#ref-for-dom-deviceorientationevent-alpha②">4.1. deviceorientation Event</a> <a href="#ref-for-dom-deviceorientationevent-alpha③">(2)</a> <a href="#ref-for-dom-deviceorientationevent-alpha④">(3)</a> <a href="#ref-for-dom-deviceorientationevent-alpha⑤">(4)</a> <a href="#ref-for-dom-deviceorientationevent-alpha⑥">(5)</a> <a href="#ref-for-dom-deviceorientationevent-alpha⑦">(6)</a> <a href="#ref-for-dom-deviceorientationevent-alpha⑧">(7)</a>
@@ -1711,8 +1711,8 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-dom-deviceorientationevent-alpha①⓪">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-deviceorientationevent-beta">
-   <b><a href="#dom-deviceorientationevent-beta">#dom-deviceorientationevent-beta</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-deviceorientationevent-beta" class="dfn-panel" data-for="dom-deviceorientationevent-beta" id="infopanel-for-dom-deviceorientationevent-beta" role="dialog">
+   <span id="infopaneltitle-for-dom-deviceorientationevent-beta" style="display:none">Info about the 'beta' definition.</span><b><a href="#dom-deviceorientationevent-beta">#dom-deviceorientationevent-beta</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-deviceorientationevent-beta">2. Introduction</a>
     <li><a href="#ref-for-dom-deviceorientationevent-beta①">4.1. deviceorientation Event</a> <a href="#ref-for-dom-deviceorientationevent-beta②">(2)</a> <a href="#ref-for-dom-deviceorientationevent-beta③">(3)</a> <a href="#ref-for-dom-deviceorientationevent-beta④">(4)</a> <a href="#ref-for-dom-deviceorientationevent-beta⑤">(5)</a> <a href="#ref-for-dom-deviceorientationevent-beta⑥">(6)</a> <a href="#ref-for-dom-deviceorientationevent-beta⑦">(7)</a>
@@ -1720,8 +1720,8 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-dom-deviceorientationevent-beta⑨">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-deviceorientationevent-gamma">
-   <b><a href="#dom-deviceorientationevent-gamma">#dom-deviceorientationevent-gamma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-deviceorientationevent-gamma" class="dfn-panel" data-for="dom-deviceorientationevent-gamma" id="infopanel-for-dom-deviceorientationevent-gamma" role="dialog">
+   <span id="infopaneltitle-for-dom-deviceorientationevent-gamma" style="display:none">Info about the 'gamma' definition.</span><b><a href="#dom-deviceorientationevent-gamma">#dom-deviceorientationevent-gamma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-deviceorientationevent-gamma">2. Introduction</a>
     <li><a href="#ref-for-dom-deviceorientationevent-gamma①">4.1. deviceorientation Event</a> <a href="#ref-for-dom-deviceorientationevent-gamma②">(2)</a> <a href="#ref-for-dom-deviceorientationevent-gamma③">(3)</a> <a href="#ref-for-dom-deviceorientationevent-gamma④">(4)</a> <a href="#ref-for-dom-deviceorientationevent-gamma⑤">(5)</a> <a href="#ref-for-dom-deviceorientationevent-gamma⑥">(6)</a> <a href="#ref-for-dom-deviceorientationevent-gamma⑦">(7)</a>
@@ -1729,8 +1729,8 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-dom-deviceorientationevent-gamma⑨">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-deviceorientationevent-absolute">
-   <b><a href="#dom-deviceorientationevent-absolute">#dom-deviceorientationevent-absolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-deviceorientationevent-absolute" class="dfn-panel" data-for="dom-deviceorientationevent-absolute" id="infopanel-for-dom-deviceorientationevent-absolute" role="dialog">
+   <span id="infopaneltitle-for-dom-deviceorientationevent-absolute" style="display:none">Info about the 'absolute' definition.</span><b><a href="#dom-deviceorientationevent-absolute">#dom-deviceorientationevent-absolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-deviceorientationevent-absolute">4.1. deviceorientation Event</a> <a href="#ref-for-dom-deviceorientationevent-absolute①">(2)</a> <a href="#ref-for-dom-deviceorientationevent-absolute②">(3)</a>
     <li><a href="#ref-for-dom-deviceorientationevent-absolute③">4.2. deviceorientationabsolute Event</a>
@@ -1738,140 +1738,140 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
     <li><a href="#ref-for-dom-deviceorientationevent-absolute⑤">A.2 Alternate device orientation representations</a> <a href="#ref-for-dom-deviceorientationevent-absolute⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-deviceorientationevent-requestpermission">
-   <b><a href="#dom-deviceorientationevent-requestpermission">#dom-deviceorientationevent-requestpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-deviceorientationevent-requestpermission" class="dfn-panel" data-for="dom-deviceorientationevent-requestpermission" id="infopanel-for-dom-deviceorientationevent-requestpermission" role="dialog">
+   <span id="infopaneltitle-for-dom-deviceorientationevent-requestpermission" style="display:none">Info about the 'requestPermission' definition.</span><b><a href="#dom-deviceorientationevent-requestpermission">#dom-deviceorientationevent-requestpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-deviceorientationevent-requestpermission">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-deviceorientationeventinit">
-   <b><a href="#dictdef-deviceorientationeventinit">#dictdef-deviceorientationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-deviceorientationeventinit" class="dfn-panel" data-for="dictdef-deviceorientationeventinit" id="infopanel-for-dictdef-deviceorientationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-deviceorientationeventinit" style="display:none">Info about the 'DeviceOrientationEventInit' definition.</span><b><a href="#dictdef-deviceorientationeventinit">#dictdef-deviceorientationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-deviceorientationeventinit">4.1. deviceorientation Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-permissionstate">
-   <b><a href="#enumdef-permissionstate">#enumdef-permissionstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-permissionstate" class="dfn-panel" data-for="enumdef-permissionstate" id="infopanel-for-enumdef-permissionstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-permissionstate" style="display:none">Info about the 'PermissionState' definition.</span><b><a href="#enumdef-permissionstate">#enumdef-permissionstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-permissionstate">4.1. deviceorientation Event</a>
     <li><a href="#ref-for-enumdef-permissionstate①">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-deviceorientationabsolute">
-   <b><a href="#def-deviceorientationabsolute">#def-deviceorientationabsolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-deviceorientationabsolute" class="dfn-panel" data-for="def-deviceorientationabsolute" id="infopanel-for-def-deviceorientationabsolute" role="dialog">
+   <span id="infopaneltitle-for-def-deviceorientationabsolute" style="display:none">Info about the 'deviceorientationabsolute' definition.</span><b><a href="#def-deviceorientationabsolute">#def-deviceorientationabsolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-deviceorientationabsolute">4.2. deviceorientationabsolute Event</a> <a href="#ref-for-def-deviceorientationabsolute①">(2)</a> <a href="#ref-for-def-deviceorientationabsolute②">(3)</a> <a href="#ref-for-def-deviceorientationabsolute③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-ondeviceorientationabsolute">
-   <b><a href="#dom-window-ondeviceorientationabsolute">#dom-window-ondeviceorientationabsolute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-ondeviceorientationabsolute" class="dfn-panel" data-for="dom-window-ondeviceorientationabsolute" id="infopanel-for-dom-window-ondeviceorientationabsolute" role="dialog">
+   <span id="infopaneltitle-for-dom-window-ondeviceorientationabsolute" style="display:none">Info about the 'ondeviceorientationabsolute' definition.</span><b><a href="#dom-window-ondeviceorientationabsolute">#dom-window-ondeviceorientationabsolute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-ondeviceorientationabsolute">4.2. deviceorientationabsolute Event</a> <a href="#ref-for-dom-window-ondeviceorientationabsolute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-compassneedscalibration">
-   <b><a href="#def-compassneedscalibration">#def-compassneedscalibration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-compassneedscalibration" class="dfn-panel" data-for="def-compassneedscalibration" id="infopanel-for-def-compassneedscalibration" role="dialog">
+   <span id="infopaneltitle-for-def-compassneedscalibration" style="display:none">Info about the 'compassneedscalibration' definition.</span><b><a href="#def-compassneedscalibration">#def-compassneedscalibration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-compassneedscalibration">2. Introduction</a>
     <li><a href="#ref-for-def-compassneedscalibration①">4.3. compassneedscalibration Event</a> <a href="#ref-for-def-compassneedscalibration②">(2)</a> <a href="#ref-for-def-compassneedscalibration③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-oncompassneedscalibration">
-   <b><a href="#dom-window-oncompassneedscalibration">#dom-window-oncompassneedscalibration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-oncompassneedscalibration" class="dfn-panel" data-for="dom-window-oncompassneedscalibration" id="infopanel-for-dom-window-oncompassneedscalibration" role="dialog">
+   <span id="infopaneltitle-for-dom-window-oncompassneedscalibration" style="display:none">Info about the 'oncompassneedscalibration' definition.</span><b><a href="#dom-window-oncompassneedscalibration">#dom-window-oncompassneedscalibration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-oncompassneedscalibration">4.3. compassneedscalibration Event</a> <a href="#ref-for-dom-window-oncompassneedscalibration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-devicemotion">
-   <b><a href="#def-devicemotion">#def-devicemotion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-devicemotion" class="dfn-panel" data-for="def-devicemotion" id="infopanel-for-def-devicemotion" role="dialog">
+   <span id="infopaneltitle-for-def-devicemotion" style="display:none">Info about the 'devicemotion' definition.</span><b><a href="#def-devicemotion">#def-devicemotion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-devicemotion">2. Introduction</a> <a href="#ref-for-def-devicemotion①">(2)</a>
     <li><a href="#ref-for-def-devicemotion②">4.4. devicemotion Event</a> <a href="#ref-for-def-devicemotion③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-ondevicemotion">
-   <b><a href="#dom-window-ondevicemotion">#dom-window-ondevicemotion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-ondevicemotion" class="dfn-panel" data-for="dom-window-ondevicemotion" id="infopanel-for-dom-window-ondevicemotion" role="dialog">
+   <span id="infopaneltitle-for-dom-window-ondevicemotion" style="display:none">Info about the 'ondevicemotion' definition.</span><b><a href="#dom-window-ondevicemotion">#dom-window-ondevicemotion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-ondevicemotion">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="devicemotioneventacceleration">
-   <b><a href="#devicemotioneventacceleration">#devicemotioneventacceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-devicemotioneventacceleration" class="dfn-panel" data-for="devicemotioneventacceleration" id="infopanel-for-devicemotioneventacceleration" role="dialog">
+   <span id="infopaneltitle-for-devicemotioneventacceleration" style="display:none">Info about the 'DeviceMotionEventAcceleration' definition.</span><b><a href="#devicemotioneventacceleration">#devicemotioneventacceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicemotioneventacceleration">4.4. devicemotion Event</a> <a href="#ref-for-devicemotioneventacceleration①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="devicemotioneventrotationrate">
-   <b><a href="#devicemotioneventrotationrate">#devicemotioneventrotationrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-devicemotioneventrotationrate" class="dfn-panel" data-for="devicemotioneventrotationrate" id="infopanel-for-devicemotioneventrotationrate" role="dialog">
+   <span id="infopaneltitle-for-devicemotioneventrotationrate" style="display:none">Info about the 'DeviceMotionEventRotationRate' definition.</span><b><a href="#devicemotioneventrotationrate">#devicemotioneventrotationrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicemotioneventrotationrate">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotioneventrotationrate-gamma">
-   <b><a href="#dom-devicemotioneventrotationrate-gamma">#dom-devicemotioneventrotationrate-gamma</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotioneventrotationrate-gamma" class="dfn-panel" data-for="dom-devicemotioneventrotationrate-gamma" id="infopanel-for-dom-devicemotioneventrotationrate-gamma" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotioneventrotationrate-gamma" style="display:none">Info about the 'gamma' definition.</span><b><a href="#dom-devicemotioneventrotationrate-gamma">#dom-devicemotioneventrotationrate-gamma</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotioneventrotationrate-gamma">2. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="devicemotionevent">
-   <b><a href="#devicemotionevent">#devicemotionevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-devicemotionevent" class="dfn-panel" data-for="devicemotionevent" id="infopanel-for-devicemotionevent" role="dialog">
+   <span id="infopaneltitle-for-devicemotionevent" style="display:none">Info about the 'DeviceMotionEvent' definition.</span><b><a href="#devicemotionevent">#devicemotionevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicemotionevent">4.4. devicemotion Event</a> <a href="#ref-for-devicemotionevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotionevent-acceleration">
-   <b><a href="#dom-devicemotionevent-acceleration">#dom-devicemotionevent-acceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotionevent-acceleration" class="dfn-panel" data-for="dom-devicemotionevent-acceleration" id="infopanel-for-dom-devicemotionevent-acceleration" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotionevent-acceleration" style="display:none">Info about the 'acceleration' definition.</span><b><a href="#dom-devicemotionevent-acceleration">#dom-devicemotionevent-acceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotionevent-acceleration">2. Introduction</a> <a href="#ref-for-dom-devicemotionevent-acceleration①">(2)</a>
     <li><a href="#ref-for-dom-devicemotionevent-acceleration②">4.4. devicemotion Event</a> <a href="#ref-for-dom-devicemotionevent-acceleration③">(2)</a> <a href="#ref-for-dom-devicemotionevent-acceleration④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotionevent-accelerationincludinggravity">
-   <b><a href="#dom-devicemotionevent-accelerationincludinggravity">#dom-devicemotionevent-accelerationincludinggravity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotionevent-accelerationincludinggravity" class="dfn-panel" data-for="dom-devicemotionevent-accelerationincludinggravity" id="infopanel-for-dom-devicemotionevent-accelerationincludinggravity" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotionevent-accelerationincludinggravity" style="display:none">Info about the 'accelerationIncludingGravity' definition.</span><b><a href="#dom-devicemotionevent-accelerationincludinggravity">#dom-devicemotionevent-accelerationincludinggravity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity">2. Introduction</a> <a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity①">(2)</a> <a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity②">(3)</a>
     <li><a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity③">4.4. devicemotion Event</a> <a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity④">(2)</a> <a href="#ref-for-dom-devicemotionevent-accelerationincludinggravity⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotionevent-rotationrate">
-   <b><a href="#dom-devicemotionevent-rotationrate">#dom-devicemotionevent-rotationrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotionevent-rotationrate" class="dfn-panel" data-for="dom-devicemotionevent-rotationrate" id="infopanel-for-dom-devicemotionevent-rotationrate" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotionevent-rotationrate" style="display:none">Info about the 'rotationRate' definition.</span><b><a href="#dom-devicemotionevent-rotationrate">#dom-devicemotionevent-rotationrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotionevent-rotationrate">2. Introduction</a>
     <li><a href="#ref-for-dom-devicemotionevent-rotationrate①">4.4. devicemotion Event</a> <a href="#ref-for-dom-devicemotionevent-rotationrate②">(2)</a> <a href="#ref-for-dom-devicemotionevent-rotationrate③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotionevent-interval">
-   <b><a href="#dom-devicemotionevent-interval">#dom-devicemotionevent-interval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotionevent-interval" class="dfn-panel" data-for="dom-devicemotionevent-interval" id="infopanel-for-dom-devicemotionevent-interval" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotionevent-interval" style="display:none">Info about the 'interval' definition.</span><b><a href="#dom-devicemotionevent-interval">#dom-devicemotionevent-interval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotionevent-interval">4.4. devicemotion Event</a> <a href="#ref-for-dom-devicemotionevent-interval①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicemotionevent-requestpermission">
-   <b><a href="#dom-devicemotionevent-requestpermission">#dom-devicemotionevent-requestpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicemotionevent-requestpermission" class="dfn-panel" data-for="dom-devicemotionevent-requestpermission" id="infopanel-for-dom-devicemotionevent-requestpermission" role="dialog">
+   <span id="infopaneltitle-for-dom-devicemotionevent-requestpermission" style="display:none">Info about the 'requestPermission' definition.</span><b><a href="#dom-devicemotionevent-requestpermission">#dom-devicemotionevent-requestpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicemotionevent-requestpermission">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-devicemotioneventaccelerationinit">
-   <b><a href="#dictdef-devicemotioneventaccelerationinit">#dictdef-devicemotioneventaccelerationinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-devicemotioneventaccelerationinit" class="dfn-panel" data-for="dictdef-devicemotioneventaccelerationinit" id="infopanel-for-dictdef-devicemotioneventaccelerationinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-devicemotioneventaccelerationinit" style="display:none">Info about the 'DeviceMotionEventAccelerationInit' definition.</span><b><a href="#dictdef-devicemotioneventaccelerationinit">#dictdef-devicemotioneventaccelerationinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-devicemotioneventaccelerationinit">4.4. devicemotion Event</a> <a href="#ref-for-dictdef-devicemotioneventaccelerationinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-devicemotioneventrotationrateinit">
-   <b><a href="#dictdef-devicemotioneventrotationrateinit">#dictdef-devicemotioneventrotationrateinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-devicemotioneventrotationrateinit" class="dfn-panel" data-for="dictdef-devicemotioneventrotationrateinit" id="infopanel-for-dictdef-devicemotioneventrotationrateinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-devicemotioneventrotationrateinit" style="display:none">Info about the 'DeviceMotionEventRotationRateInit' definition.</span><b><a href="#dictdef-devicemotioneventrotationrateinit">#dictdef-devicemotioneventrotationrateinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-devicemotioneventrotationrateinit">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-devicemotioneventinit">
-   <b><a href="#dictdef-devicemotioneventinit">#dictdef-devicemotioneventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-devicemotioneventinit" class="dfn-panel" data-for="dictdef-devicemotioneventinit" id="infopanel-for-dictdef-devicemotioneventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-devicemotioneventinit" style="display:none">Info about the 'DeviceMotionEventInit' definition.</span><b><a href="#dictdef-devicemotioneventinit">#dictdef-devicemotioneventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-devicemotioneventinit">4.4. devicemotion Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission">
-   <b><a href="#permission">#permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission" class="dfn-panel" data-for="permission" id="infopanel-for-permission" role="dialog">
+   <span id="infopaneltitle-for-permission" style="display:none">Info about the 'permission' definition.</span><b><a href="#permission">#permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission">4.1. deviceorientation Event</a> <a href="#ref-for-permission①">(2)</a>
     <li><a href="#ref-for-permission②">4.4. devicemotion Event</a> <a href="#ref-for-permission③">(2)</a>
@@ -1880,57 +1880,113 @@ for the application to ask for <a data-link-type="dfn" href="#permission" id="re
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/fxtf-drafts/compositing-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/compositing-1/Overview.html
@@ -2119,62 +2119,62 @@ Draft of 2013-06-25</a>:</p>
    <li><a href="#valdef-blend-mode-screen">screen</a><span>, in § 10.1.3</span>
    <li><a href="#valdef-blend-mode-soft-light">soft-light</a><span>, in § 10.1.10</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a>
     <li><a href="#ref-for-comb-one①⑤">3.4.2. The isolation property</a>
     <li><a href="#ref-for-comb-one①⑥">4. Specifying Compositing and Blending in Canvas 2D</a> <a href="#ref-for-comb-one①⑦">(2)</a> <a href="#ref-for-comb-one①⑧">(3)</a> <a href="#ref-for-comb-one①⑨">(4)</a> <a href="#ref-for-comb-one②⓪">(5)</a> <a href="#ref-for-comb-one②①">(6)</a> <a href="#ref-for-comb-one②②">(7)</a> <a href="#ref-for-comb-one②③">(8)</a> <a href="#ref-for-comb-one②④">(9)</a> <a href="#ref-for-comb-one②⑤">(10)</a> <a href="#ref-for-comb-one②⑥">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">2.1. Module interactions</a>
     <li><a href="#ref-for-stacking-context①">3.2. Behavior specific to HTML</a>
     <li><a href="#ref-for-stacking-context②">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-stacking-context③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-context-2d-globalcompositeoperation">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-context-2d-globalcompositeoperation" class="dfn-panel" data-for="term-for-dom-context-2d-globalcompositeoperation" id="infopanel-for-term-for-dom-context-2d-globalcompositeoperation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-context-2d-globalcompositeoperation" style="display:none">Info about the 'globalCompositeOperation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation">Unnumbered Section</a>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation①">2.1. Module interactions</a>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation②">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">3.4.2. The isolation property</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
@@ -2287,48 +2287,48 @@ Draft of 2013-06-25</a>:</p>
       <td>visual
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-mix-blend-mode">
-   <b><a href="#propdef-mix-blend-mode">#propdef-mix-blend-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mix-blend-mode" class="dfn-panel" data-for="propdef-mix-blend-mode" id="infopanel-for-propdef-mix-blend-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-mix-blend-mode" style="display:none">Info about the 'mix-blend-mode' definition.</span><b><a href="#propdef-mix-blend-mode">#propdef-mix-blend-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mix-blend-mode">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ltblendmodegt">
-   <b><a href="#ltblendmodegt">#ltblendmodegt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ltblendmodegt" class="dfn-panel" data-for="ltblendmodegt" id="infopanel-for-ltblendmodegt" role="dialog">
+   <span id="infopaneltitle-for-ltblendmodegt" style="display:none">Info about the '&lt;blend-mode>' definition.</span><b><a href="#ltblendmodegt">#ltblendmodegt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltblendmodegt">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-ltblendmodegt①">(2)</a>
     <li><a href="#ref-for-ltblendmodegt②">3.4.3. The background-blend-mode property</a>
     <li><a href="#ref-for-ltblendmodegt③">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-isolation">
-   <b><a href="#propdef-isolation">#propdef-isolation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-isolation" class="dfn-panel" data-for="propdef-isolation" id="infopanel-for-propdef-isolation" role="dialog">
+   <span id="infopaneltitle-for-propdef-isolation" style="display:none">Info about the 'isolation' definition.</span><b><a href="#propdef-isolation">#propdef-isolation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-isolation">3.4.2. The isolation property</a> <a href="#ref-for-propdef-isolation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isolated-propid">
-   <b><a href="#isolated-propid">#isolated-propid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isolated-propid" class="dfn-panel" data-for="isolated-propid" id="infopanel-for-isolated-propid" role="dialog">
+   <span id="infopaneltitle-for-isolated-propid" style="display:none">Info about the '&lt;isolation-mode>' definition.</span><b><a href="#isolated-propid">#isolated-propid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isolated-propid">3.4.2. The isolation property</a> <a href="#ref-for-isolated-propid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-blend-mode">
-   <b><a href="#propdef-background-blend-mode">#propdef-background-blend-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-blend-mode" class="dfn-panel" data-for="propdef-background-blend-mode" id="infopanel-for-propdef-background-blend-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-blend-mode" style="display:none">Info about the 'background-blend-mode' definition.</span><b><a href="#propdef-background-blend-mode">#propdef-background-blend-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-blend-mode">2.1. Module interactions</a>
     <li><a href="#ref-for-propdef-background-blend-mode①">3.4.3. The background-blend-mode property</a> <a href="#ref-for-propdef-background-blend-mode②">(2)</a> <a href="#ref-for-propdef-background-blend-mode③">(3)</a> <a href="#ref-for-propdef-background-blend-mode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compositemode">
-   <b><a href="#compositemode">#compositemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compositemode" class="dfn-panel" data-for="compositemode" id="infopanel-for-compositemode" role="dialog">
+   <span id="infopaneltitle-for-compositemode" style="display:none">Info about the '&lt;composite-mode>' definition.</span><b><a href="#compositemode">#compositemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compositemode">4. Specifying Compositing and Blending in Canvas 2D</a> <a href="#ref-for-compositemode①">(2)</a>
     <li><a href="#ref-for-compositemode②">12. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backdrop">
-   <b><a href="#backdrop">#backdrop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backdrop" class="dfn-panel" data-for="backdrop" id="infopanel-for-backdrop" role="dialog">
+   <span id="infopaneltitle-for-backdrop" style="display:none">Info about the 'backdrop' definition.</span><b><a href="#backdrop">#backdrop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backdrop①">5. Introduction to compositing</a> <a href="#ref-for-backdrop②">(2)</a>
     <li><a href="#ref-for-backdrop③">5.1. Simple alpha compositing</a> <a href="#ref-for-backdrop④">(2)</a> <a href="#ref-for-backdrop⑤">(3)</a>
@@ -2352,161 +2352,217 @@ Draft of 2013-06-25</a>:</p>
     <li><a href="#ref-for-backdrop③⑥">10.2.4. luminosity blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-normal">
-   <b><a href="#valdef-blend-mode-normal">#valdef-blend-mode-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-normal" class="dfn-panel" data-for="valdef-blend-mode-normal" id="infopanel-for-valdef-blend-mode-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-blend-mode-normal">#valdef-blend-mode-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-normal">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-valdef-blend-mode-normal①">(2)</a>
     <li><a href="#ref-for-valdef-blend-mode-normal②">8.1. Group invariance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-multiply">
-   <b><a href="#valdef-blend-mode-multiply">#valdef-blend-mode-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-multiply" class="dfn-panel" data-for="valdef-blend-mode-multiply" id="infopanel-for-valdef-blend-mode-multiply" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-multiply" style="display:none">Info about the 'multiply' definition.</span><b><a href="#valdef-blend-mode-multiply">#valdef-blend-mode-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-multiply">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-multiply①">10.1.9. hard-light blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-screen">
-   <b><a href="#valdef-blend-mode-screen">#valdef-blend-mode-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-screen" class="dfn-panel" data-for="valdef-blend-mode-screen" id="infopanel-for-valdef-blend-mode-screen" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#valdef-blend-mode-screen">#valdef-blend-mode-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-screen">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-screen①">10.1.9. hard-light blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-overlay">
-   <b><a href="#valdef-blend-mode-overlay">#valdef-blend-mode-overlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-overlay" class="dfn-panel" data-for="valdef-blend-mode-overlay" id="infopanel-for-valdef-blend-mode-overlay" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-overlay" style="display:none">Info about the 'overlay' definition.</span><b><a href="#valdef-blend-mode-overlay">#valdef-blend-mode-overlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-overlay">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-valdef-blend-mode-overlay①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-darken">
-   <b><a href="#valdef-blend-mode-darken">#valdef-blend-mode-darken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-darken" class="dfn-panel" data-for="valdef-blend-mode-darken" id="infopanel-for-valdef-blend-mode-darken" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-darken" style="display:none">Info about the 'darken' definition.</span><b><a href="#valdef-blend-mode-darken">#valdef-blend-mode-darken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-darken">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-lighten">
-   <b><a href="#valdef-blend-mode-lighten">#valdef-blend-mode-lighten</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-lighten" class="dfn-panel" data-for="valdef-blend-mode-lighten" id="infopanel-for-valdef-blend-mode-lighten" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-lighten" style="display:none">Info about the 'lighten' definition.</span><b><a href="#valdef-blend-mode-lighten">#valdef-blend-mode-lighten</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-lighten">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color-dodge">
-   <b><a href="#valdef-blend-mode-color-dodge">#valdef-blend-mode-color-dodge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color-dodge" class="dfn-panel" data-for="valdef-blend-mode-color-dodge" id="infopanel-for-valdef-blend-mode-color-dodge" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color-dodge" style="display:none">Info about the 'color-dodge' definition.</span><b><a href="#valdef-blend-mode-color-dodge">#valdef-blend-mode-color-dodge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color-dodge">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color-burn">
-   <b><a href="#valdef-blend-mode-color-burn">#valdef-blend-mode-color-burn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color-burn" class="dfn-panel" data-for="valdef-blend-mode-color-burn" id="infopanel-for-valdef-blend-mode-color-burn" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color-burn" style="display:none">Info about the 'color-burn' definition.</span><b><a href="#valdef-blend-mode-color-burn">#valdef-blend-mode-color-burn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color-burn">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-hard-light">
-   <b><a href="#valdef-blend-mode-hard-light">#valdef-blend-mode-hard-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-hard-light" class="dfn-panel" data-for="valdef-blend-mode-hard-light" id="infopanel-for-valdef-blend-mode-hard-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-hard-light" style="display:none">Info about the 'hard-light' definition.</span><b><a href="#valdef-blend-mode-hard-light">#valdef-blend-mode-hard-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-hard-light">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-hard-light①">10.1.4. overlay blend mode</a> <a href="#ref-for-valdef-blend-mode-hard-light②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-soft-light">
-   <b><a href="#valdef-blend-mode-soft-light">#valdef-blend-mode-soft-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-soft-light" class="dfn-panel" data-for="valdef-blend-mode-soft-light" id="infopanel-for-valdef-blend-mode-soft-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-soft-light" style="display:none">Info about the 'soft-light' definition.</span><b><a href="#valdef-blend-mode-soft-light">#valdef-blend-mode-soft-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-soft-light">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-difference">
-   <b><a href="#valdef-blend-mode-difference">#valdef-blend-mode-difference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-difference" class="dfn-panel" data-for="valdef-blend-mode-difference" id="infopanel-for-valdef-blend-mode-difference" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-difference" style="display:none">Info about the 'difference' definition.</span><b><a href="#valdef-blend-mode-difference">#valdef-blend-mode-difference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-difference">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-exclusion">
-   <b><a href="#valdef-blend-mode-exclusion">#valdef-blend-mode-exclusion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-exclusion" class="dfn-panel" data-for="valdef-blend-mode-exclusion" id="infopanel-for-valdef-blend-mode-exclusion" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-exclusion" style="display:none">Info about the 'exclusion' definition.</span><b><a href="#valdef-blend-mode-exclusion">#valdef-blend-mode-exclusion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-exclusion">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-hue">
-   <b><a href="#valdef-blend-mode-hue">#valdef-blend-mode-hue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-hue" class="dfn-panel" data-for="valdef-blend-mode-hue" id="infopanel-for-valdef-blend-mode-hue" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-hue" style="display:none">Info about the 'hue' definition.</span><b><a href="#valdef-blend-mode-hue">#valdef-blend-mode-hue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-hue">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-saturation">
-   <b><a href="#valdef-blend-mode-saturation">#valdef-blend-mode-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-saturation" class="dfn-panel" data-for="valdef-blend-mode-saturation" id="infopanel-for-valdef-blend-mode-saturation" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#valdef-blend-mode-saturation">#valdef-blend-mode-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-saturation">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color">
-   <b><a href="#valdef-blend-mode-color">#valdef-blend-mode-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color" class="dfn-panel" data-for="valdef-blend-mode-color" id="infopanel-for-valdef-blend-mode-color" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color" style="display:none">Info about the 'color' definition.</span><b><a href="#valdef-blend-mode-color">#valdef-blend-mode-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-luminosity">
-   <b><a href="#valdef-blend-mode-luminosity">#valdef-blend-mode-luminosity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-luminosity" class="dfn-panel" data-for="valdef-blend-mode-luminosity" id="infopanel-for-valdef-blend-mode-luminosity" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-luminosity" style="display:none">Info about the 'luminosity' definition.</span><b><a href="#valdef-blend-mode-luminosity">#valdef-blend-mode-luminosity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-luminosity">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/fxtf-drafts/compositing-2/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/compositing-2/Overview.html
@@ -2144,34 +2144,34 @@ Draft of 2013-06-25</a>:</p>
    <li><a href="#source-over">source-over</a><span>, in § 9.1.4</span>
    <li><a href="#xor">xor</a><span>, in § 9.1.12</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-3/#css-inheritance">https://drafts.csswg.org/css-cascade-3/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-3/#css-inheritance">https://drafts.csswg.org/css-cascade-3/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">2.2. Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a> <a href="#ref-for-comb-one⑤">(6)</a> <a href="#ref-for-comb-one⑥">(7)</a> <a href="#ref-for-comb-one⑦">(8)</a> <a href="#ref-for-comb-one⑧">(9)</a> <a href="#ref-for-comb-one⑨">(10)</a> <a href="#ref-for-comb-one①⓪">(11)</a> <a href="#ref-for-comb-one①①">(12)</a> <a href="#ref-for-comb-one①②">(13)</a> <a href="#ref-for-comb-one①③">(14)</a> <a href="#ref-for-comb-one①④">(15)</a>
     <li><a href="#ref-for-comb-one①⑤">3.4.2. The isolation property</a>
     <li><a href="#ref-for-comb-one①⑥">4. Specifying Compositing and Blending in Canvas 2D</a> <a href="#ref-for-comb-one①⑦">(2)</a> <a href="#ref-for-comb-one①⑧">(3)</a> <a href="#ref-for-comb-one①⑨">(4)</a> <a href="#ref-for-comb-one②⓪">(5)</a> <a href="#ref-for-comb-one②①">(6)</a> <a href="#ref-for-comb-one②②">(7)</a> <a href="#ref-for-comb-one②③">(8)</a> <a href="#ref-for-comb-one②④">(9)</a> <a href="#ref-for-comb-one②⑤">(10)</a> <a href="#ref-for-comb-one②⑥">(11)</a> <a href="#ref-for-comb-one②⑦">(12)</a> <a href="#ref-for-comb-one②⑧">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stacking-context">
-   <a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stacking-context" class="dfn-panel" data-for="term-for-stacking-context" id="infopanel-for-term-for-stacking-context" role="menu">
+   <span id="infopaneltitle-for-term-for-stacking-context" style="display:none">Info about the 'stacking context' external reference.</span><a href="https://drafts.csswg.org/css2/#stacking-context">https://drafts.csswg.org/css2/#stacking-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stacking-context">2.1. Module interactions</a>
     <li><a href="#ref-for-stacking-context①">3.2. Behavior specific to HTML</a> <a href="#ref-for-stacking-context②">(2)</a>
@@ -2179,34 +2179,34 @@ Draft of 2013-06-25</a>:</p>
     <li><a href="#ref-for-stacking-context⑤">3.4.2. The isolation property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">3.4.3. The background-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-context-2d-globalcompositeoperation">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-context-2d-globalcompositeoperation" class="dfn-panel" data-for="term-for-dom-context-2d-globalcompositeoperation" id="infopanel-for-term-for-dom-context-2d-globalcompositeoperation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-context-2d-globalcompositeoperation" style="display:none">Info about the 'globalCompositeOperation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation">https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-globalcompositeoperation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation">Unnumbered Section</a>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation①">2.1. Module interactions</a>
     <li><a href="#ref-for-dom-context-2d-globalcompositeoperation②">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">3.4.2. The isolation property</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
@@ -2328,48 +2328,48 @@ Draft of 2013-06-25</a>:</p>
       <td>visual
    </table>
   </div>
-  <aside class="dfn-panel" data-for="propdef-mix-blend-mode">
-   <b><a href="#propdef-mix-blend-mode">#propdef-mix-blend-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mix-blend-mode" class="dfn-panel" data-for="propdef-mix-blend-mode" id="infopanel-for-propdef-mix-blend-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-mix-blend-mode" style="display:none">Info about the 'mix-blend-mode' definition.</span><b><a href="#propdef-mix-blend-mode">#propdef-mix-blend-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mix-blend-mode">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ltblendmodegt">
-   <b><a href="#ltblendmodegt">#ltblendmodegt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ltblendmodegt" class="dfn-panel" data-for="ltblendmodegt" id="infopanel-for-ltblendmodegt" role="dialog">
+   <span id="infopaneltitle-for-ltblendmodegt" style="display:none">Info about the '&lt;blend-mode>' definition.</span><b><a href="#ltblendmodegt">#ltblendmodegt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltblendmodegt">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-ltblendmodegt①">(2)</a>
     <li><a href="#ref-for-ltblendmodegt②">3.4.3. The background-blend-mode property</a>
     <li><a href="#ref-for-ltblendmodegt③">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-isolation">
-   <b><a href="#propdef-isolation">#propdef-isolation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-isolation" class="dfn-panel" data-for="propdef-isolation" id="infopanel-for-propdef-isolation" role="dialog">
+   <span id="infopaneltitle-for-propdef-isolation" style="display:none">Info about the 'isolation' definition.</span><b><a href="#propdef-isolation">#propdef-isolation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-isolation">3.4.2. The isolation property</a> <a href="#ref-for-propdef-isolation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isolated-propid">
-   <b><a href="#isolated-propid">#isolated-propid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isolated-propid" class="dfn-panel" data-for="isolated-propid" id="infopanel-for-isolated-propid" role="dialog">
+   <span id="infopaneltitle-for-isolated-propid" style="display:none">Info about the '&lt;isolation-mode>' definition.</span><b><a href="#isolated-propid">#isolated-propid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isolated-propid">3.4.2. The isolation property</a> <a href="#ref-for-isolated-propid①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-background-blend-mode">
-   <b><a href="#propdef-background-blend-mode">#propdef-background-blend-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-background-blend-mode" class="dfn-panel" data-for="propdef-background-blend-mode" id="infopanel-for-propdef-background-blend-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-background-blend-mode" style="display:none">Info about the 'background-blend-mode' definition.</span><b><a href="#propdef-background-blend-mode">#propdef-background-blend-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-blend-mode">2.1. Module interactions</a>
     <li><a href="#ref-for-propdef-background-blend-mode①">3.4.3. The background-blend-mode property</a> <a href="#ref-for-propdef-background-blend-mode②">(2)</a> <a href="#ref-for-propdef-background-blend-mode③">(3)</a> <a href="#ref-for-propdef-background-blend-mode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compositemode">
-   <b><a href="#compositemode">#compositemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compositemode" class="dfn-panel" data-for="compositemode" id="infopanel-for-compositemode" role="dialog">
+   <span id="infopaneltitle-for-compositemode" style="display:none">Info about the '&lt;composite-mode>' definition.</span><b><a href="#compositemode">#compositemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compositemode">4. Specifying Compositing and Blending in Canvas 2D</a> <a href="#ref-for-compositemode①">(2)</a>
     <li><a href="#ref-for-compositemode②">12. Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backdrop">
-   <b><a href="#backdrop">#backdrop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backdrop" class="dfn-panel" data-for="backdrop" id="infopanel-for-backdrop" role="dialog">
+   <span id="infopaneltitle-for-backdrop" style="display:none">Info about the 'backdrop' definition.</span><b><a href="#backdrop">#backdrop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backdrop①">5. Introduction to compositing</a> <a href="#ref-for-backdrop②">(2)</a>
     <li><a href="#ref-for-backdrop③">5.1. Simple alpha compositing</a> <a href="#ref-for-backdrop④">(2)</a> <a href="#ref-for-backdrop⑤">(3)</a>
@@ -2393,257 +2393,313 @@ Draft of 2013-06-25</a>:</p>
     <li><a href="#ref-for-backdrop③⑥">10.2.4. luminosity blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clear">
-   <b><a href="#clear">#clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clear" class="dfn-panel" data-for="clear" id="infopanel-for-clear" role="dialog">
+   <span id="infopaneltitle-for-clear" style="display:none">Info about the 'clear' definition.</span><b><a href="#clear">#clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="copy">
-   <b><a href="#copy">#copy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-copy" class="dfn-panel" data-for="copy" id="infopanel-for-copy" role="dialog">
+   <span id="infopaneltitle-for-copy" style="display:none">Info about the 'copy' definition.</span><b><a href="#copy">#copy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-copy">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination">
-   <b><a href="#destination">#destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination" class="dfn-panel" data-for="destination" id="infopanel-for-destination" role="dialog">
+   <span id="infopaneltitle-for-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#destination">#destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination">9.2. Group compositing behavior with Porter Duff modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-over">
-   <b><a href="#source-over">#source-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-over" class="dfn-panel" data-for="source-over" id="infopanel-for-source-over" role="dialog">
+   <span id="infopaneltitle-for-source-over" style="display:none">Info about the 'source-over' definition.</span><b><a href="#source-over">#source-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-over">4. Specifying Compositing and Blending in Canvas 2D</a>
     <li><a href="#ref-for-source-over①">9. Advanced compositing features</a>
     <li><a href="#ref-for-source-over②">10.1. Separable blend modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination-over">
-   <b><a href="#destination-over">#destination-over</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination-over" class="dfn-panel" data-for="destination-over" id="infopanel-for-destination-over" role="dialog">
+   <span id="infopaneltitle-for-destination-over" style="display:none">Info about the 'destination-over' definition.</span><b><a href="#destination-over">#destination-over</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination-over">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-in">
-   <b><a href="#source-in">#source-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-in" class="dfn-panel" data-for="source-in" id="infopanel-for-source-in" role="dialog">
+   <span id="infopaneltitle-for-source-in" style="display:none">Info about the 'source-in' definition.</span><b><a href="#source-in">#source-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-in">4. Specifying Compositing and Blending in Canvas 2D</a>
     <li><a href="#ref-for-source-in①">9.2. Group compositing behavior with Porter Duff modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination-in">
-   <b><a href="#destination-in">#destination-in</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination-in" class="dfn-panel" data-for="destination-in" id="infopanel-for-destination-in" role="dialog">
+   <span id="infopaneltitle-for-destination-in" style="display:none">Info about the 'destination-in' definition.</span><b><a href="#destination-in">#destination-in</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination-in">4. Specifying Compositing and Blending in Canvas 2D</a>
     <li><a href="#ref-for-destination-in①">9.2. Group compositing behavior with Porter Duff modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-out">
-   <b><a href="#source-out">#source-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-out" class="dfn-panel" data-for="source-out" id="infopanel-for-source-out" role="dialog">
+   <span id="infopaneltitle-for-source-out" style="display:none">Info about the 'source-out' definition.</span><b><a href="#source-out">#source-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-out">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination-out">
-   <b><a href="#destination-out">#destination-out</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination-out" class="dfn-panel" data-for="destination-out" id="infopanel-for-destination-out" role="dialog">
+   <span id="infopaneltitle-for-destination-out" style="display:none">Info about the 'destination-out' definition.</span><b><a href="#destination-out">#destination-out</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination-out">4. Specifying Compositing and Blending in Canvas 2D</a>
     <li><a href="#ref-for-destination-out①">9.2. Group compositing behavior with Porter Duff modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-atop">
-   <b><a href="#source-atop">#source-atop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-atop" class="dfn-panel" data-for="source-atop" id="infopanel-for-source-atop" role="dialog">
+   <span id="infopaneltitle-for-source-atop" style="display:none">Info about the 'source-atop' definition.</span><b><a href="#source-atop">#source-atop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-atop">4. Specifying Compositing and Blending in Canvas 2D</a>
     <li><a href="#ref-for-source-atop①">9.2. Group compositing behavior with Porter Duff modes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination-atop">
-   <b><a href="#destination-atop">#destination-atop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination-atop" class="dfn-panel" data-for="destination-atop" id="infopanel-for-destination-atop" role="dialog">
+   <span id="infopaneltitle-for-destination-atop" style="display:none">Info about the 'destination-atop' definition.</span><b><a href="#destination-atop">#destination-atop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination-atop">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xor">
-   <b><a href="#xor">#xor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xor" class="dfn-panel" data-for="xor" id="infopanel-for-xor" role="dialog">
+   <span id="infopaneltitle-for-xor" style="display:none">Info about the 'xor' definition.</span><b><a href="#xor">#xor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xor">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lighter">
-   <b><a href="#lighter">#lighter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lighter" class="dfn-panel" data-for="lighter" id="infopanel-for-lighter" role="dialog">
+   <span id="infopaneltitle-for-lighter" style="display:none">Info about the 'lighter' definition.</span><b><a href="#lighter">#lighter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lighter">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="plus-darker">
-   <b><a href="#plus-darker">#plus-darker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-plus-darker" class="dfn-panel" data-for="plus-darker" id="infopanel-for-plus-darker" role="dialog">
+   <span id="infopaneltitle-for-plus-darker" style="display:none">Info about the 'plus-darker' definition.</span><b><a href="#plus-darker">#plus-darker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plus-darker">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="plus-lighter">
-   <b><a href="#plus-lighter">#plus-lighter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-plus-lighter" class="dfn-panel" data-for="plus-lighter" id="infopanel-for-plus-lighter" role="dialog">
+   <span id="infopaneltitle-for-plus-lighter" style="display:none">Info about the 'plus-lighter' definition.</span><b><a href="#plus-lighter">#plus-lighter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plus-lighter">4. Specifying Compositing and Blending in Canvas 2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-normal">
-   <b><a href="#valdef-blend-mode-normal">#valdef-blend-mode-normal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-normal" class="dfn-panel" data-for="valdef-blend-mode-normal" id="infopanel-for-valdef-blend-mode-normal" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-normal" style="display:none">Info about the 'normal' definition.</span><b><a href="#valdef-blend-mode-normal">#valdef-blend-mode-normal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-normal">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-valdef-blend-mode-normal①">(2)</a>
     <li><a href="#ref-for-valdef-blend-mode-normal②">8.1. Group invariance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-multiply">
-   <b><a href="#valdef-blend-mode-multiply">#valdef-blend-mode-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-multiply" class="dfn-panel" data-for="valdef-blend-mode-multiply" id="infopanel-for-valdef-blend-mode-multiply" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-multiply" style="display:none">Info about the 'multiply' definition.</span><b><a href="#valdef-blend-mode-multiply">#valdef-blend-mode-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-multiply">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-multiply①">10.1.9. hard-light blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-screen">
-   <b><a href="#valdef-blend-mode-screen">#valdef-blend-mode-screen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-screen" class="dfn-panel" data-for="valdef-blend-mode-screen" id="infopanel-for-valdef-blend-mode-screen" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-screen" style="display:none">Info about the 'screen' definition.</span><b><a href="#valdef-blend-mode-screen">#valdef-blend-mode-screen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-screen">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-screen①">10.1.9. hard-light blend mode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-overlay">
-   <b><a href="#valdef-blend-mode-overlay">#valdef-blend-mode-overlay</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-overlay" class="dfn-panel" data-for="valdef-blend-mode-overlay" id="infopanel-for-valdef-blend-mode-overlay" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-overlay" style="display:none">Info about the 'overlay' definition.</span><b><a href="#valdef-blend-mode-overlay">#valdef-blend-mode-overlay</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-overlay">3.4.1. The mix-blend-mode property</a> <a href="#ref-for-valdef-blend-mode-overlay①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-darken">
-   <b><a href="#valdef-blend-mode-darken">#valdef-blend-mode-darken</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-darken" class="dfn-panel" data-for="valdef-blend-mode-darken" id="infopanel-for-valdef-blend-mode-darken" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-darken" style="display:none">Info about the 'darken' definition.</span><b><a href="#valdef-blend-mode-darken">#valdef-blend-mode-darken</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-darken">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-lighten">
-   <b><a href="#valdef-blend-mode-lighten">#valdef-blend-mode-lighten</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-lighten" class="dfn-panel" data-for="valdef-blend-mode-lighten" id="infopanel-for-valdef-blend-mode-lighten" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-lighten" style="display:none">Info about the 'lighten' definition.</span><b><a href="#valdef-blend-mode-lighten">#valdef-blend-mode-lighten</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-lighten">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color-dodge">
-   <b><a href="#valdef-blend-mode-color-dodge">#valdef-blend-mode-color-dodge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color-dodge" class="dfn-panel" data-for="valdef-blend-mode-color-dodge" id="infopanel-for-valdef-blend-mode-color-dodge" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color-dodge" style="display:none">Info about the 'color-dodge' definition.</span><b><a href="#valdef-blend-mode-color-dodge">#valdef-blend-mode-color-dodge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color-dodge">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color-burn">
-   <b><a href="#valdef-blend-mode-color-burn">#valdef-blend-mode-color-burn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color-burn" class="dfn-panel" data-for="valdef-blend-mode-color-burn" id="infopanel-for-valdef-blend-mode-color-burn" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color-burn" style="display:none">Info about the 'color-burn' definition.</span><b><a href="#valdef-blend-mode-color-burn">#valdef-blend-mode-color-burn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color-burn">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-hard-light">
-   <b><a href="#valdef-blend-mode-hard-light">#valdef-blend-mode-hard-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-hard-light" class="dfn-panel" data-for="valdef-blend-mode-hard-light" id="infopanel-for-valdef-blend-mode-hard-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-hard-light" style="display:none">Info about the 'hard-light' definition.</span><b><a href="#valdef-blend-mode-hard-light">#valdef-blend-mode-hard-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-hard-light">3.4.1. The mix-blend-mode property</a>
     <li><a href="#ref-for-valdef-blend-mode-hard-light①">10.1.4. overlay blend mode</a> <a href="#ref-for-valdef-blend-mode-hard-light②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-soft-light">
-   <b><a href="#valdef-blend-mode-soft-light">#valdef-blend-mode-soft-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-soft-light" class="dfn-panel" data-for="valdef-blend-mode-soft-light" id="infopanel-for-valdef-blend-mode-soft-light" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-soft-light" style="display:none">Info about the 'soft-light' definition.</span><b><a href="#valdef-blend-mode-soft-light">#valdef-blend-mode-soft-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-soft-light">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-difference">
-   <b><a href="#valdef-blend-mode-difference">#valdef-blend-mode-difference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-difference" class="dfn-panel" data-for="valdef-blend-mode-difference" id="infopanel-for-valdef-blend-mode-difference" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-difference" style="display:none">Info about the 'difference' definition.</span><b><a href="#valdef-blend-mode-difference">#valdef-blend-mode-difference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-difference">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-exclusion">
-   <b><a href="#valdef-blend-mode-exclusion">#valdef-blend-mode-exclusion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-exclusion" class="dfn-panel" data-for="valdef-blend-mode-exclusion" id="infopanel-for-valdef-blend-mode-exclusion" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-exclusion" style="display:none">Info about the 'exclusion' definition.</span><b><a href="#valdef-blend-mode-exclusion">#valdef-blend-mode-exclusion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-exclusion">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-hue">
-   <b><a href="#valdef-blend-mode-hue">#valdef-blend-mode-hue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-hue" class="dfn-panel" data-for="valdef-blend-mode-hue" id="infopanel-for-valdef-blend-mode-hue" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-hue" style="display:none">Info about the 'hue' definition.</span><b><a href="#valdef-blend-mode-hue">#valdef-blend-mode-hue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-hue">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-saturation">
-   <b><a href="#valdef-blend-mode-saturation">#valdef-blend-mode-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-saturation" class="dfn-panel" data-for="valdef-blend-mode-saturation" id="infopanel-for-valdef-blend-mode-saturation" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#valdef-blend-mode-saturation">#valdef-blend-mode-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-saturation">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-color">
-   <b><a href="#valdef-blend-mode-color">#valdef-blend-mode-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-color" class="dfn-panel" data-for="valdef-blend-mode-color" id="infopanel-for-valdef-blend-mode-color" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-color" style="display:none">Info about the 'color' definition.</span><b><a href="#valdef-blend-mode-color">#valdef-blend-mode-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-color">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-blend-mode-luminosity">
-   <b><a href="#valdef-blend-mode-luminosity">#valdef-blend-mode-luminosity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-blend-mode-luminosity" class="dfn-panel" data-for="valdef-blend-mode-luminosity" id="infopanel-for-valdef-blend-mode-luminosity" role="dialog">
+   <span id="infopaneltitle-for-valdef-blend-mode-luminosity" style="display:none">Info about the 'luminosity' definition.</span><b><a href="#valdef-blend-mode-luminosity">#valdef-blend-mode-luminosity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-blend-mode-luminosity">3.4.1. The mix-blend-mode property</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/css-masking-1/Overview.html
@@ -3337,14 +3337,14 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
      <li><a href="#element-attrdef-mask-y">element-attr for mask</a><span>, in § 9.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break">https://drafts.csswg.org/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">7.6. Positioning Area: the mask-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-used-value①">(2)</a>
     <li><a href="#ref-for-used-value②">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-used-value③">(2)</a>
@@ -3354,15 +3354,15 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-used-value⑦">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-color①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-propdef-opacity①">6.1. The clipPath element</a>
@@ -3373,91 +3373,91 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-opacity⑥">9.1. The mask element</a> <a href="#ref-for-propdef-opacity⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-content-visibility-visible">
-   <a href="https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible">https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-content-visibility-visible" class="dfn-panel" data-for="term-for-valdef-content-visibility-visible" id="infopanel-for-term-for-valdef-content-visibility-visible" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-content-visibility-visible" style="display:none">Info about the 'visible' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible">https://drafts.csswg.org/css-contain-2/#valdef-content-visibility-visible</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-content-visibility-visible">5. Clipping Paths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">6.1. The clipPath element</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a> <a href="#ref-for-propdef-display③">(4)</a> <a href="#ref-for-propdef-display④">(5)</a>
     <li><a href="#ref-for-propdef-display⑤">9.1. The mask element</a> <a href="#ref-for-propdef-display⑥">(2)</a> <a href="#ref-for-propdef-display⑦">(3)</a> <a href="#ref-for-propdef-display⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">6.1. The clipPath element</a> <a href="#ref-for-valdef-display-none①">(2)</a>
     <li><a href="#ref-for-valdef-display-none②">9.1. The mask element</a> <a href="#ref-for-valdef-display-none③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">6.1. The clipPath element</a> <a href="#ref-for-propdef-visibility①">(2)</a>
     <li><a href="#ref-for-propdef-visibility②">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-family①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-size①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-stretch">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-stretch" class="dfn-panel" data-for="term-for-propdef-font-stretch" id="infopanel-for-term-for-propdef-font-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-stretch①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-style①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-variant①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-weight①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-font-size-adjust①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#typedef-image">https://drafts.csswg.org/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-typedef-image①">(2)</a> <a href="#ref-for-typedef-image②">(3)</a>
     <li><a href="#ref-for-typedef-image③">7.2. Mask Image Interpretation: the mask-mode property</a>
@@ -3466,105 +3466,105 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-typedef-image⑦">10. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-image-rendering">
-   <a href="https://drafts.csswg.org/css-images-3/#propdef-image-rendering">https://drafts.csswg.org/css-images-3/#propdef-image-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-image-rendering" class="dfn-panel" data-for="term-for-propdef-image-rendering" id="infopanel-for-term-for-propdef-image-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-image-rendering" style="display:none">Info about the 'image-rendering' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#propdef-image-rendering">https://drafts.csswg.org/css-images-3/#propdef-image-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-image-rendering">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-image-rendering①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-alignment-baseline" class="dfn-panel" data-for="term-for-propdef-alignment-baseline" id="infopanel-for-term-for-propdef-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-alignment-baseline" style="display:none">Info about the 'alignment-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-alignment-baseline">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-alignment-baseline①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-baseline-shift">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-baseline-shift" class="dfn-panel" data-for="term-for-propdef-baseline-shift" id="infopanel-for-term-for-propdef-baseline-shift" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-baseline-shift" style="display:none">Info about the 'baseline-shift' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-baseline-shift">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-baseline-shift①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-dominant-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-dominant-baseline" class="dfn-panel" data-for="term-for-propdef-dominant-baseline" id="infopanel-for-term-for-propdef-dominant-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-dominant-baseline" style="display:none">Info about the 'dominant-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-dominant-baseline">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-dominant-baseline①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">5. Clipping Paths</a>
     <li><a href="#ref-for-propdef-overflow①">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-overflow②">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-basic-shape">
-   <a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-basic-shape" class="dfn-panel" data-for="term-for-typedef-basic-shape" id="infopanel-for-term-for-typedef-basic-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-basic-shape" style="display:none">Info about the '&lt;basic-shape>' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-basic-shape">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-typedef-basic-shape①">(2)</a> <a href="#ref-for-typedef-basic-shape②">(3)</a> <a href="#ref-for-typedef-basic-shape③">(4)</a>
     <li><a href="#ref-for-typedef-basic-shape④">6.2. Winding Rules: the clip-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-shape-box">
-   <a href="https://drafts.csswg.org/css-shapes-1/#typedef-shape-box">https://drafts.csswg.org/css-shapes-1/#typedef-shape-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-shape-box" class="dfn-panel" data-for="term-for-typedef-shape-box" id="infopanel-for-term-for-typedef-shape-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-shape-box" style="display:none">Info about the '&lt;shape-box>' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#typedef-shape-box">https://drafts.csswg.org/css-shapes-1/#typedef-shape-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-shape-box">5.1. Clipping Shape: the clip-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon" id="infopanel-for-term-for-funcdef-basic-shape-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" style="display:none">Info about the 'polygon()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-polygon">5.1. Clipping Shape: the clip-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-voice-family-child">
-   <a href="https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child">https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-voice-family-child" class="dfn-panel" data-for="term-for-valdef-voice-family-child" id="infopanel-for-term-for-valdef-voice-family-child" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-voice-family-child" style="display:none">Info about the 'child' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child">https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-child">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-letter-spacing①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-word-spacing①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-text-decoration①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-cursor">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-cursor" class="dfn-panel" data-for="term-for-propdef-cursor" id="infopanel-for-term-for-propdef-cursor" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-cursor" style="display:none">Info about the 'cursor' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-cursor">https://drafts.csswg.org/css-ui-4/#propdef-cursor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-cursor">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-cursor①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pointer-events">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pointer-events" class="dfn-panel" data-for="term-for-propdef-pointer-events" id="infopanel-for-term-for-propdef-pointer-events" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pointer-events" style="display:none">Info about the 'pointer-events' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pointer-events">5. Clipping Paths</a>
     <li><a href="#ref-for-propdef-pointer-events①">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-pointer-events②">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-comma">https://drafts.csswg.org/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">7.1. Mask Image Source: the mask-image property</a>
     <li><a href="#ref-for-mult-comma①">7.2. Mask Image Interpretation: the mask-mode property</a>
@@ -3577,15 +3577,15 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mult-comma⑧">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">8.4. Masking Areas: the mask-border-width property</a>
     <li><a href="#ref-for-typedef-length-percentage①">9.1. The mask element</a> <a href="#ref-for-typedef-length-percentage②">(2)</a> <a href="#ref-for-typedef-length-percentage③">(3)</a> <a href="#ref-for-typedef-length-percentage④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">7.4. Positioning Mask Images: the mask-position property</a>
     <li><a href="#ref-for-length-value①">8.4. Masking Areas: the mask-border-width property</a>
@@ -3593,44 +3593,44 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-length-value④">Appendix A: The deprecated clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">8.4. Masking Areas: the mask-border-width property</a>
     <li><a href="#ref-for-number-value①">8.5. Edge Overhang: the mask-border-outset property</a> <a href="#ref-for-number-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">7.4. Positioning Mask Images: the mask-position property</a>
     <li><a href="#ref-for-typedef-position①">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-url-value①">(2)</a>
     <li><a href="#ref-for-url-value②">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-url-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">7.9. Mask Shorthand: the mask property</a>
     <li><a href="#ref-for-mult-opt①">8.3. Mask Border Image Slicing: the mask-border-slice property</a>
     <li><a href="#ref-for-mult-opt②">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-mult-opt③">(2)</a> <a href="#ref-for-mult-opt④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">6.1. The clipPath element</a>
     <li><a href="#ref-for-px①">9.1. The mask element</a> <a href="#ref-for-px②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">8.3. Mask Border Image Slicing: the mask-border-slice property</a>
     <li><a href="#ref-for-mult-num-range①">8.4. Masking Areas: the mask-border-width property</a>
@@ -3638,8 +3638,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mult-num-range③">8.6. Mask Border Image Tiling: the mask-border-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
     <li><a href="#ref-for-comb-one⑤">6.2. Winding Rules: the clip-rule property</a>
@@ -3657,308 +3657,308 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-comb-one②④">Appendix A: The deprecated clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-comb-any①">7.9. Mask Shorthand: the mask property</a> <a href="#ref-for-comb-any②">(2)</a> <a href="#ref-for-comb-any③">(3)</a> <a href="#ref-for-comb-any④">(4)</a> <a href="#ref-for-comb-any⑤">(5)</a> <a href="#ref-for-comb-any⑥">(6)</a>
     <li><a href="#ref-for-comb-any⑦">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-comb-any⑧">(2)</a> <a href="#ref-for-comb-any⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-direction①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-unicode-bidi①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical" id="infopanel-for-term-for-propdef-glyph-orientation-vertical" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" style="display:none">Info about the 'glyph-orientation-vertical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-writing-mode①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-auto">
-   <a href="https://drafts.csswg.org/css2/#valdef-clip-auto">https://drafts.csswg.org/css2/#valdef-clip-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-auto" class="dfn-panel" data-for="term-for-valdef-clip-auto" id="infopanel-for-term-for-valdef-clip-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-clip-auto">https://drafts.csswg.org/css2/#valdef-clip-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-auto">Appendix A: The deprecated clip property</a> <a href="#ref-for-valdef-clip-auto①">(2)</a> <a href="#ref-for-valdef-clip-auto②">(3)</a> <a href="#ref-for-valdef-clip-auto③">(4)</a> <a href="#ref-for-valdef-clip-auto④">(5)</a> <a href="#ref-for-valdef-clip-auto⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">Interface SVGClipPathElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-coordinate-system">
-   <a href="https://drafts.csswg.org/css-transforms-1/#user-coordinate-system">https://drafts.csswg.org/css-transforms-1/#user-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-coordinate-system" class="dfn-panel" data-for="term-for-user-coordinate-system" id="infopanel-for-term-for-user-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-user-coordinate-system" style="display:none">Info about the 'user coordinate system' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#user-coordinate-system">https://drafts.csswg.org/css-transforms-1/#user-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-coordinate-system">6.1. The clipPath element</a> <a href="#ref-for-user-coordinate-system①">(2)</a>
     <li><a href="#ref-for-user-coordinate-system②">9.1. The mask element</a> <a href="#ref-for-user-coordinate-system③">(2)</a> <a href="#ref-for-user-coordinate-system④">(3)</a> <a href="#ref-for-user-coordinate-system⑤">(4)</a> <a href="#ref-for-user-coordinate-system⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-bg-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-bg-size">https://drafts.csswg.org/css-backgrounds-3/#typedef-bg-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-bg-size" class="dfn-panel" data-for="term-for-typedef-bg-size" id="infopanel-for-term-for-typedef-bg-size" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-bg-size" style="display:none">Info about the '&lt;bg-size>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-bg-size">https://drafts.csswg.org/css-backgrounds-3/#typedef-bg-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-size">7.7. Sizing Mask Images: the mask-size property</a>
     <li><a href="#ref-for-typedef-bg-size①">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-repeat-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-repeat-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-repeat-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-repeat-style" class="dfn-panel" data-for="term-for-typedef-repeat-style" id="infopanel-for-term-for-typedef-repeat-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-repeat-style" style="display:none">Info about the '&lt;repeat-style>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-repeat-style">https://drafts.csswg.org/css-backgrounds-3/#typedef-repeat-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-repeat-style">7.3. Tiling Mask Images: the mask-repeat property</a>
     <li><a href="#ref-for-typedef-repeat-style①">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">Changes since last publication</a> <a href="#ref-for-propdef-background①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-painting-area">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#background-painting-area">https://drafts.csswg.org/css-backgrounds-3/#background-painting-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-painting-area" class="dfn-panel" data-for="term-for-background-painting-area" id="infopanel-for-term-for-background-painting-area" role="menu">
+   <span id="infopaneltitle-for-term-for-background-painting-area" style="display:none">Info about the 'background painting area' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#background-painting-area">https://drafts.csswg.org/css-backgrounds-3/#background-painting-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-painting-area">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-positioning-area">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area">https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-positioning-area" class="dfn-panel" data-for="term-for-background-positioning-area" id="infopanel-for-term-for-background-positioning-area" role="menu">
+   <span id="infopaneltitle-for-term-for-background-positioning-area" style="display:none">Info about the 'background positioning area' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area">https://drafts.csswg.org/css-backgrounds-3/#background-positioning-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-positioning-area">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">7.6. Positioning Area: the mask-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">7.4. Positioning Mask Images: the mask-position property</a> <a href="#ref-for-propdef-background-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">7.3. Tiling Mask Images: the mask-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">7.7. Sizing Mask Images: the mask-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-image-area">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-area">https://drafts.csswg.org/css-backgrounds-3/#border-image-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-image-area" class="dfn-panel" data-for="term-for-border-image-area" id="infopanel-for-term-for-border-image-area" role="menu">
+   <span id="infopaneltitle-for-term-for-border-image-area" style="display:none">Info about the 'border image area' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#border-image-area">https://drafts.csswg.org/css-backgrounds-3/#border-image-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-image-area">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">8. Border-Box Mask</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-repeat">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-repeat" class="dfn-panel" data-for="term-for-propdef-border-image-repeat" id="infopanel-for-term-for-propdef-border-image-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-repeat" style="display:none">Info about the 'border-image-repeat' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-repeat">8.6. Mask Border Image Tiling: the mask-border-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-slice">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-slice" class="dfn-panel" data-for="term-for-propdef-border-image-slice" id="infopanel-for-term-for-propdef-border-image-slice" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-slice" style="display:none">Info about the 'border-image-slice' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-slice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-slice">8.3. Mask Border Image Slicing: the mask-border-slice property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image-width" class="dfn-panel" data-for="term-for-propdef-border-image-width" id="infopanel-for-term-for-propdef-border-image-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image-width" style="display:none">Info about the 'border-image-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image-width">8.4. Masking Areas: the mask-border-width property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">5.1. Clipping Shape: the clip-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">8.4. Masking Areas: the mask-border-width property</a>
     <li><a href="#ref-for-propdef-border-width①">8.5. Edge Overhang: the mask-border-outset property</a> <a href="#ref-for-propdef-border-width②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-stroke-linejoin-miter">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linejoin-miter">https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linejoin-miter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-stroke-linejoin-miter" class="dfn-panel" data-for="term-for-valdef-stroke-linejoin-miter" id="infopanel-for-term-for-valdef-stroke-linejoin-miter" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-stroke-linejoin-miter" style="display:none">Info about the 'miter' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linejoin-miter">https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linejoin-miter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-miter">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-stroke-linecap-square">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linecap-square">https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linecap-square</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-stroke-linecap-square" class="dfn-panel" data-for="term-for-valdef-stroke-linecap-square" id="infopanel-for-term-for-valdef-stroke-linecap-square" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-stroke-linecap-square" style="display:none">Info about the 'square' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linecap-square">https://drafts.fxtf.org/fill-stroke-3/#valdef-stroke-linecap-square</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linecap-square">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-valdef-stroke-linecap-square①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color-interpolation-filters">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-color-interpolation-filters">https://drafts.fxtf.org/filter-effects-1/#propdef-color-interpolation-filters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color-interpolation-filters" class="dfn-panel" data-for="term-for-propdef-color-interpolation-filters" id="infopanel-for-term-for-propdef-color-interpolation-filters" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color-interpolation-filters" style="display:none">Info about the 'color-interpolation-filters' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-color-interpolation-filters">https://drafts.fxtf.org/filter-effects-1/#propdef-color-interpolation-filters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color-interpolation-filters">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-color-interpolation-filters①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-fecolormatrix">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#elementdef-fecolormatrix">https://drafts.fxtf.org/filter-effects-1/#elementdef-fecolormatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-fecolormatrix" class="dfn-panel" data-for="term-for-elementdef-fecolormatrix" id="infopanel-for-term-for-elementdef-fecolormatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-fecolormatrix" style="display:none">Info about the 'fecolormatrix' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#elementdef-fecolormatrix">https://drafts.fxtf.org/filter-effects-1/#elementdef-fecolormatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-fecolormatrix">7.10.1. Mask processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-filter" class="dfn-panel" data-for="term-for-propdef-filter" id="infopanel-for-term-for-propdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-filter">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-filter①">9.1. The mask element</a> <a href="#ref-for-propdef-filter②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flood-color">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flood-color" class="dfn-panel" data-for="term-for-propdef-flood-color" id="infopanel-for-term-for-propdef-flood-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flood-color" style="display:none">Info about the 'flood-color' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flood-color">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-flood-color①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flood-opacity">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-opacity">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flood-opacity" class="dfn-panel" data-for="term-for-propdef-flood-opacity" id="infopanel-for-term-for-propdef-flood-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flood-opacity" style="display:none">Info about the 'flood-opacity' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-opacity">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flood-opacity">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-flood-opacity①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-lighting-color">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color">https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-lighting-color" class="dfn-panel" data-for="term-for-propdef-lighting-color" id="infopanel-for-term-for-propdef-lighting-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-lighting-color" style="display:none">Info about the 'lighting-color' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color">https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-lighting-color">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-lighting-color①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-interpolation-filters-linearrgb">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#valdef-color-interpolation-filters-linearrgb">https://drafts.fxtf.org/filter-effects-1/#valdef-color-interpolation-filters-linearrgb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-interpolation-filters-linearrgb" class="dfn-panel" data-for="term-for-valdef-color-interpolation-filters-linearrgb" id="infopanel-for-term-for-valdef-color-interpolation-filters-linearrgb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-interpolation-filters-linearrgb" style="display:none">Info about the 'linearrgb' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#valdef-color-interpolation-filters-linearrgb">https://drafts.fxtf.org/filter-effects-1/#valdef-color-interpolation-filters-linearrgb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-interpolation-filters-linearrgb">7.10.1. Mask processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font" class="dfn-panel" data-for="term-for-font" id="infopanel-for-term-for-font" role="menu">
+   <span id="infopaneltitle-for-term-for-font" style="display:none">Info about the 'font' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-animate">
-   <a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-animate" class="dfn-panel" data-for="term-for-elementdef-animate" id="infopanel-for-term-for-elementdef-animate" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-animate" style="display:none">Info about the 'animate' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-animate">https://svgwg.org/specs/animations/#elementdef-animate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-animate">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-animate①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-animateMotion">
-   <a href="https://svgwg.org/specs/animations/#elementdef-animateMotion">https://svgwg.org/specs/animations/#elementdef-animateMotion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-animateMotion" class="dfn-panel" data-for="term-for-elementdef-animateMotion" id="infopanel-for-term-for-elementdef-animateMotion" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-animateMotion" style="display:none">Info about the 'animatemotion' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-animateMotion">https://svgwg.org/specs/animations/#elementdef-animateMotion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-animateMotion">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-animateMotion①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-animateTransform">
-   <a href="https://svgwg.org/specs/animations/#elementdef-animateTransform">https://svgwg.org/specs/animations/#elementdef-animateTransform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-animateTransform" class="dfn-panel" data-for="term-for-elementdef-animateTransform" id="infopanel-for-term-for-elementdef-animateTransform" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-animateTransform" style="display:none">Info about the 'animatetransform' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-animateTransform">https://svgwg.org/specs/animations/#elementdef-animateTransform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-animateTransform">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-animateTransform①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-set">
-   <a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-set" class="dfn-panel" data-for="term-for-elementdef-set" id="infopanel-for-term-for-elementdef-set" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-set" style="display:none">Info about the 'set' external reference.</span><a href="https://svgwg.org/specs/animations/#elementdef-set">https://svgwg.org/specs/animations/#elementdef-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-set">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-set①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedEnumeration">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGAnimatedEnumeration" class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedEnumeration" id="infopanel-for-term-for-InterfaceSVGAnimatedEnumeration" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGAnimatedEnumeration" style="display:none">Info about the 'SVGAnimatedEnumeration' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGAnimatedEnumeration">Interface SVGClipPathElement</a> <a href="#ref-for-InterfaceSVGAnimatedEnumeration①">(2)</a>
     <li><a href="#ref-for-InterfaceSVGAnimatedEnumeration②">Interface SVGMaskElement</a> <a href="#ref-for-InterfaceSVGAnimatedEnumeration③">(2)</a> <a href="#ref-for-InterfaceSVGAnimatedEnumeration④">(3)</a> <a href="#ref-for-InterfaceSVGAnimatedEnumeration⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedLength">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGAnimatedLength" class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedLength" id="infopanel-for-term-for-InterfaceSVGAnimatedLength" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGAnimatedLength" style="display:none">Info about the 'SVGAnimatedLength' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGAnimatedLength">Interface SVGMaskElement</a> <a href="#ref-for-InterfaceSVGAnimatedLength①">(2)</a> <a href="#ref-for-InterfaceSVGAnimatedLength②">(3)</a> <a href="#ref-for-InterfaceSVGAnimatedLength③">(4)</a> <a href="#ref-for-InterfaceSVGAnimatedLength④">(5)</a> <a href="#ref-for-InterfaceSVGAnimatedLength⑤">(6)</a> <a href="#ref-for-InterfaceSVGAnimatedLength⑥">(7)</a> <a href="#ref-for-InterfaceSVGAnimatedLength⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedTransformList">
-   <a href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList">https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGAnimatedTransformList" class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedTransformList" id="infopanel-for-term-for-InterfaceSVGAnimatedTransformList" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGAnimatedTransformList" style="display:none">Info about the 'SVGAnimatedTransformList' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList">https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGAnimatedTransformList">Interface SVGClipPathElement</a> <a href="#ref-for-InterfaceSVGAnimatedTransformList①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGElement">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGElement" class="dfn-panel" data-for="term-for-InterfaceSVGElement" id="infopanel-for-term-for-InterfaceSVGElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGElement" style="display:none">Info about the 'SVGElement' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement">https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGElement">Interface SVGClipPathElement</a>
     <li><a href="#ref-for-InterfaceSVGElement①">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGUnitTypes">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGUnitTypes">https://svgwg.org/svg2-draft/types.html#InterfaceSVGUnitTypes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGUnitTypes" class="dfn-panel" data-for="term-for-InterfaceSVGUnitTypes" id="infopanel-for-term-for-InterfaceSVGUnitTypes" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGUnitTypes" style="display:none">Info about the 'SVGUnitTypes' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGUnitTypes">https://svgwg.org/svg2-draft/types.html#InterfaceSVGUnitTypes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGUnitTypes">Interface SVGClipPathElement</a>
     <li><a href="#ref-for-InterfaceSVGUnitTypes①">Interface SVGMaskElement</a> <a href="#ref-for-InterfaceSVGUnitTypes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-a">
-   <a href="https://svgwg.org/svg2-draft/linking.html#elementdef-a">https://svgwg.org/svg2-draft/linking.html#elementdef-a</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-a" class="dfn-panel" data-for="term-for-elementdef-a" id="infopanel-for-term-for-elementdef-a" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-a" style="display:none">Info about the 'a' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#elementdef-a">https://svgwg.org/svg2-draft/linking.html#elementdef-a</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-a">9.1. The mask element</a>
     <li><a href="#ref-for-elementdef-a①">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-basic-shape">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#basic-shape">https://svgwg.org/svg2-draft/shapes.html#basic-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-basic-shape" class="dfn-panel" data-for="term-for-basic-shape" id="infopanel-for-term-for-basic-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-basic-shape" style="display:none">Info about the 'basic shape' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#basic-shape">https://svgwg.org/svg2-draft/shapes.html#basic-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-shape">6.1. The clipPath element</a> <a href="#ref-for-basic-shape①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bounding-box">
-   <a href="https://svgwg.org/svg2-draft/coords.html#bounding-box">https://svgwg.org/svg2-draft/coords.html#bounding-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bounding-box" class="dfn-panel" data-for="term-for-bounding-box" id="infopanel-for-term-for-bounding-box" role="menu">
+   <span id="infopaneltitle-for-term-for-bounding-box" style="display:none">Info about the 'bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#bounding-box">https://svgwg.org/svg2-draft/coords.html#bounding-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bounding-box">6.1. The clipPath element</a> <a href="#ref-for-bounding-box①">(2)</a>
     <li><a href="#ref-for-bounding-box②">9.1. The mask element</a> <a href="#ref-for-bounding-box③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-circle">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-circle">https://svgwg.org/svg2-draft/shapes.html#elementdef-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-circle" class="dfn-panel" data-for="term-for-elementdef-circle" id="infopanel-for-term-for-elementdef-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-circle" style="display:none">Info about the 'circle' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-circle">https://svgwg.org/svg2-draft/shapes.html#elementdef-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-circle">6.1. The clipPath element</a> <a href="#ref-for-elementdef-circle①">(2)</a>
     <li><a href="#ref-for-elementdef-circle②">7.10.1. Mask processing</a>
@@ -3966,23 +3966,23 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-elementdef-circle④">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorInterpolationProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorInterpolationProperty" class="dfn-panel" data-for="term-for-ColorInterpolationProperty" id="infopanel-for-term-for-ColorInterpolationProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorInterpolationProperty" style="display:none">Info about the 'color-interpolation' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorInterpolationProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-ColorInterpolationProperty①">7.10.1. Mask processing</a>
     <li><a href="#ref-for-ColorInterpolationProperty②">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorRenderingProperty">
-   <a href="https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty">https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorRenderingProperty" class="dfn-panel" data-for="term-for-ColorRenderingProperty" id="infopanel-for-term-for-ColorRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorRenderingProperty" style="display:none">Info about the 'color-rendering' external reference.</span><a href="https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty">https://www.w3.org/TR/SVG2/painting.html#ColorRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorRenderingProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-ColorRenderingProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-element" class="dfn-panel" data-for="term-for-container-element" id="infopanel-for-term-for-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-container-element" style="display:none">Info about the 'container element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-element">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-container-element①">6.1. The clipPath element</a>
@@ -4005,8 +4005,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-container-element①⑧">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-container-element①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-defs">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-defs">https://svgwg.org/svg2-draft/struct.html#elementdef-defs</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-defs" class="dfn-panel" data-for="term-for-elementdef-defs" id="infopanel-for-term-for-elementdef-defs" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-defs" style="display:none">Info about the 'defs' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-defs">https://svgwg.org/svg2-draft/struct.html#elementdef-defs</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-defs">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-elementdef-defs①">7.1. Mask Image Source: the mask-image property</a>
@@ -4027,57 +4027,57 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-elementdef-defs①⑥">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-desc">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-desc">https://svgwg.org/svg2-draft/struct.html#elementdef-desc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-desc" class="dfn-panel" data-for="term-for-elementdef-desc" id="infopanel-for-term-for-elementdef-desc" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-desc" style="display:none">Info about the 'desc' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-desc">https://svgwg.org/svg2-draft/struct.html#elementdef-desc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-desc">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-desc①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-ellipse">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse">https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-ellipse" class="dfn-panel" data-for="term-for-elementdef-ellipse" id="infopanel-for-term-for-elementdef-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-ellipse" style="display:none">Info about the 'ellipse' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse">https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-ellipse">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-ellipse①">9.1. The mask element</a>
     <li><a href="#ref-for-elementdef-ellipse②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillProperty">https://svgwg.org/svg2-draft/painting.html#FillProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillProperty" class="dfn-panel" data-for="term-for-FillProperty" id="infopanel-for-term-for-FillProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillProperty" style="display:none">Info about the 'fill' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillProperty">https://svgwg.org/svg2-draft/painting.html#FillProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillProperty">6.1. The clipPath element</a> <a href="#ref-for-FillProperty①">(2)</a>
     <li><a href="#ref-for-FillProperty②">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty">https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillOpacityProperty" class="dfn-panel" data-for="term-for-FillOpacityProperty" id="infopanel-for-term-for-FillOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillOpacityProperty" style="display:none">Info about the 'fill-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty">https://svgwg.org/svg2-draft/painting.html#FillOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillOpacityProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-FillOpacityProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-FillRuleProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-FillRuleProperty" class="dfn-panel" data-for="term-for-FillRuleProperty" id="infopanel-for-term-for-FillRuleProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-FillRuleProperty" style="display:none">Info about the 'fill-rule' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#FillRuleProperty">https://svgwg.org/svg2-draft/painting.html#FillRuleProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FillRuleProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-FillRuleProperty①">6.2. Winding Rules: the clip-rule property</a> <a href="#ref-for-FillRuleProperty②">(2)</a> <a href="#ref-for-FillRuleProperty③">(3)</a>
     <li><a href="#ref-for-FillRuleProperty④">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-foreignObject">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-foreignObject" class="dfn-panel" data-for="term-for-elementdef-foreignObject" id="infopanel-for-term-for-elementdef-foreignObject" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-foreignObject" style="display:none">Info about the 'foreignobject' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-foreignObject">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-g">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-g" class="dfn-panel" data-for="term-for-elementdef-g" id="infopanel-for-term-for-elementdef-g" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-g" style="display:none">Info about the 'g' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-g">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-graphics-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-graphics-element" class="dfn-panel" data-for="term-for-graphics-element" id="infopanel-for-term-for-graphics-element" role="menu">
+   <span id="infopaneltitle-for-term-for-graphics-element" style="display:none">Info about the 'graphics element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#graphics-element">https://svgwg.org/svg2-draft/struct.html#graphics-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-graphics-element">1.1. Clipping</a>
     <li><a href="#ref-for-graphics-element①">5.1. Clipping Shape: the clip-path property</a>
@@ -4102,70 +4102,70 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-graphics-element②②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-image">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-image" class="dfn-panel" data-for="term-for-elementdef-image" id="infopanel-for-term-for-elementdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-image" style="display:none">Info about the 'image' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-image">9.1. The mask element</a>
     <li><a href="#ref-for-elementdef-image①">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-elementdef-image②">(2)</a> <a href="#ref-for-elementdef-image③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-line">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-line" class="dfn-panel" data-for="term-for-elementdef-line" id="infopanel-for-term-for-elementdef-line" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-line" style="display:none">Info about the 'line' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-line">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-line①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-linearGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-linearGradient" class="dfn-panel" data-for="term-for-elementdef-linearGradient" id="infopanel-for-term-for-elementdef-linearGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-linearGradient" style="display:none">Info about the 'lineargradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-linearGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-linearGradient">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerProperty" class="dfn-panel" data-for="term-for-MarkerProperty" id="infopanel-for-term-for-MarkerProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerProperty" style="display:none">Info about the 'marker' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-MarkerProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerEndProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerEndProperty" class="dfn-panel" data-for="term-for-MarkerEndProperty" id="infopanel-for-term-for-MarkerEndProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerEndProperty" style="display:none">Info about the 'marker-end' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerEndProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-MarkerEndProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerMidProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerMidProperty" class="dfn-panel" data-for="term-for-MarkerMidProperty" id="infopanel-for-term-for-MarkerMidProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerMidProperty" style="display:none">Info about the 'marker-mid' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerMidProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-MarkerMidProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerStartProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerStartProperty" class="dfn-panel" data-for="term-for-MarkerStartProperty" id="infopanel-for-term-for-MarkerStartProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerStartProperty" style="display:none">Info about the 'marker-start' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerStartProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-MarkerStartProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-metadata">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-metadata" class="dfn-panel" data-for="term-for-elementdef-metadata" id="infopanel-for-term-for-elementdef-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-metadata" style="display:none">Info about the 'metadata' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-metadata">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-metadata①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermNeverRenderedElement">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement">https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermNeverRenderedElement" class="dfn-panel" data-for="term-for-TermNeverRenderedElement" id="infopanel-for-term-for-TermNeverRenderedElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermNeverRenderedElement" style="display:none">Info about the 'never-rendered element' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement">https://svgwg.org/svg2-draft/render.html#TermNeverRenderedElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermNeverRenderedElement">6.1. The clipPath element</a>
     <li><a href="#ref-for-TermNeverRenderedElement①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermObjectBoundingBox">
-   <a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermObjectBoundingBox" class="dfn-panel" data-for="term-for-TermObjectBoundingBox" id="infopanel-for-term-for-TermObjectBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermObjectBoundingBox" style="display:none">Info about the 'object bounding box' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox">https://svgwg.org/svg2-draft/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermObjectBoundingBox">2. Module interactions</a>
     <li><a href="#ref-for-TermObjectBoundingBox①">5.1. Clipping Shape: the clip-path property</a>
@@ -4175,65 +4175,65 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-TermObjectBoundingBox⑤">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-TermObjectBoundingBox⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-path">
-   <a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-path" class="dfn-panel" data-for="term-for-elementdef-path" id="infopanel-for-term-for-elementdef-path" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-path" style="display:none">Info about the 'path' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-path">6.1. The clipPath element</a> <a href="#ref-for-elementdef-path①">(2)</a> <a href="#ref-for-elementdef-path②">(3)</a>
     <li><a href="#ref-for-elementdef-path③">6.2. Winding Rules: the clip-rule property</a>
     <li><a href="#ref-for-elementdef-path④">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">9.1. The mask element</a>
     <li><a href="#ref-for-elementdef-pattern①">Appendix A: The deprecated clip property</a> <a href="#ref-for-elementdef-pattern②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polygon">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polygon" class="dfn-panel" data-for="term-for-elementdef-polygon" id="infopanel-for-term-for-elementdef-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polygon" style="display:none">Info about the 'polygon' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polygon">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-polygon①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polyline">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polyline" class="dfn-panel" data-for="term-for-elementdef-polyline" id="infopanel-for-term-for-elementdef-polyline" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polyline" style="display:none">Info about the 'polyline' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polyline">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-polyline①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-radialGradient">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-radialGradient" class="dfn-panel" data-for="term-for-elementdef-radialGradient" id="infopanel-for-term-for-elementdef-radialGradient" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-radialGradient" style="display:none">Info about the 'radialgradient' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient">https://svgwg.org/svg2-draft/pservers.html#elementdef-radialGradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-radialGradient">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-rect">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-rect" class="dfn-panel" data-for="term-for-elementdef-rect" id="infopanel-for-term-for-elementdef-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-rect" style="display:none">Info about the 'rect' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-rect">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-rect①">9.1. The mask element</a>
     <li><a href="#ref-for-elementdef-rect②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-script">
-   <a href="https://svgwg.org/svg2-draft/interact.html#elementdef-script">https://svgwg.org/svg2-draft/interact.html#elementdef-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-script" class="dfn-panel" data-for="term-for-elementdef-script" id="infopanel-for-term-for-elementdef-script" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-script" style="display:none">Info about the 'script' external reference.</span><a href="https://svgwg.org/svg2-draft/interact.html#elementdef-script">https://svgwg.org/svg2-draft/interact.html#elementdef-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-script">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-script①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ShapeRenderingProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty">https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ShapeRenderingProperty" class="dfn-panel" data-for="term-for-ShapeRenderingProperty" id="infopanel-for-term-for-ShapeRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ShapeRenderingProperty" style="display:none">Info about the 'shape-rendering' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty">https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ShapeRenderingProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-ShapeRenderingProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">2. Module interactions</a>
     <li><a href="#ref-for-TermStackingContext①">5.1. Clipping Shape: the clip-path property</a>
@@ -4243,145 +4243,145 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-TermStackingContext⑤">8.8. Masking with the mask border image</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StopColorProperty">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StopColorProperty" class="dfn-panel" data-for="term-for-StopColorProperty" id="infopanel-for-term-for-StopColorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StopColorProperty" style="display:none">Info about the 'stop-color' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StopColorProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StopColorProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StopOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty">https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StopOpacityProperty" class="dfn-panel" data-for="term-for-StopOpacityProperty" id="infopanel-for-term-for-StopOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StopOpacityProperty" style="display:none">Info about the 'stop-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty">https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StopOpacityProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StopOpacityProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">https://svgwg.org/svg2-draft/painting.html#StrokeProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeProperty" class="dfn-panel" data-for="term-for-StrokeProperty" id="infopanel-for-term-for-StrokeProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeProperty" style="display:none">Info about the 'stroke' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">https://svgwg.org/svg2-draft/painting.html#StrokeProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeProperty">6.1. The clipPath element</a> <a href="#ref-for-StrokeProperty①">(2)</a>
     <li><a href="#ref-for-StrokeProperty②">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeProperty③">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeDasharrayProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeDasharrayProperty" class="dfn-panel" data-for="term-for-StrokeDasharrayProperty" id="infopanel-for-term-for-StrokeDasharrayProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeDasharrayProperty" style="display:none">Info about the 'stroke-dasharray' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeDasharrayProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeDasharrayProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeDasharrayProperty②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeDashoffsetProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeDashoffsetProperty" class="dfn-panel" data-for="term-for-StrokeDashoffsetProperty" id="infopanel-for-term-for-StrokeDashoffsetProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeDashoffsetProperty" style="display:none">Info about the 'stroke-dashoffset' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty">https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeDashoffsetProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeDashoffsetProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeDashoffsetProperty②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeLinecapProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeLinecapProperty" class="dfn-panel" data-for="term-for-StrokeLinecapProperty" id="infopanel-for-term-for-StrokeLinecapProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeLinecapProperty" style="display:none">Info about the 'stroke-linecap' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinecapProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeLinecapProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeLinecapProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeLinecapProperty②">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-StrokeLinecapProperty③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeLinejoinProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeLinejoinProperty" class="dfn-panel" data-for="term-for-StrokeLinejoinProperty" id="infopanel-for-term-for-StrokeLinejoinProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeLinejoinProperty" style="display:none">Info about the 'stroke-linejoin' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty">https://svgwg.org/svg2-draft/painting.html#StrokeLinejoinProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeLinejoinProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeLinejoinProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeLinejoinProperty②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeMiterlimitProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeMiterlimitProperty" class="dfn-panel" data-for="term-for-StrokeMiterlimitProperty" id="infopanel-for-term-for-StrokeMiterlimitProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeMiterlimitProperty" style="display:none">Info about the 'stroke-miterlimit' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty">https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeMiterlimitProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeMiterlimitProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeMiterlimitProperty②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeOpacityProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty">https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeOpacityProperty" class="dfn-panel" data-for="term-for-StrokeOpacityProperty" id="infopanel-for-term-for-StrokeOpacityProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeOpacityProperty" style="display:none">Info about the 'stroke-opacity' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty">https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeOpacityProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-StrokeOpacityProperty①">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeOpacityProperty②">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StrokeWidthProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StrokeWidthProperty" class="dfn-panel" data-for="term-for-StrokeWidthProperty" id="infopanel-for-term-for-StrokeWidthProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StrokeWidthProperty" style="display:none">Info about the 'stroke-width' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StrokeWidthProperty">6.1. The clipPath element</a> <a href="#ref-for-StrokeWidthProperty①">(2)</a>
     <li><a href="#ref-for-StrokeWidthProperty②">9.1. The mask element</a>
     <li><a href="#ref-for-StrokeWidthProperty③">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-StrokeWidthProperty④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-style">
-   <a href="https://svgwg.org/svg2-draft/styling.html#elementdef-style">https://svgwg.org/svg2-draft/styling.html#elementdef-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-style" class="dfn-panel" data-for="term-for-elementdef-style" id="infopanel-for-term-for-elementdef-style" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-style" style="display:none">Info about the 'style' external reference.</span><a href="https://svgwg.org/svg2-draft/styling.html#elementdef-style">https://svgwg.org/svg2-draft/styling.html#elementdef-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-style">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-switch">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-switch" class="dfn-panel" data-for="term-for-elementdef-switch" id="infopanel-for-term-for-elementdef-switch" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-switch" style="display:none">Info about the 'switch' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-switch">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-symbol">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-symbol" class="dfn-panel" data-for="term-for-elementdef-symbol" id="infopanel-for-term-for-elementdef-symbol" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-symbol" style="display:none">Info about the 'symbol' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-symbol">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-text">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-text" class="dfn-panel" data-for="term-for-elementdef-text" id="infopanel-for-term-for-elementdef-text" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-text" style="display:none">Info about the 'text' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-text">6.1. The clipPath element</a> <a href="#ref-for-elementdef-text①">(2)</a> <a href="#ref-for-elementdef-text②">(3)</a>
     <li><a href="#ref-for-elementdef-text③">7.10.1. Mask processing</a>
     <li><a href="#ref-for-elementdef-text④">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermTextContentElement">
-   <a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermTextContentElement" class="dfn-panel" data-for="term-for-TermTextContentElement" id="infopanel-for-term-for-TermTextContentElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermTextContentElement" style="display:none">Info about the 'text content element' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TermTextContentElement">https://svgwg.org/svg2-draft/text.html#TermTextContentElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermTextContentElement">Appendix B: Compute stroke bounding box</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextAnchorProperty">
-   <a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextAnchorProperty" class="dfn-panel" data-for="term-for-TextAnchorProperty" id="infopanel-for-term-for-TextAnchorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextAnchorProperty" style="display:none">Info about the 'text-anchor' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextAnchorProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-TextAnchorProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextRenderingProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextRenderingProperty" class="dfn-panel" data-for="term-for-TextRenderingProperty" id="infopanel-for-term-for-TextRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextRenderingProperty" style="display:none">Info about the 'text-rendering' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextRenderingProperty">6.1. The clipPath element</a>
     <li><a href="#ref-for-TextRenderingProperty①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-title">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-title">https://svgwg.org/svg2-draft/struct.html#elementdef-title</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-title" class="dfn-panel" data-for="term-for-elementdef-title" id="infopanel-for-term-for-elementdef-title" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-title" style="display:none">Info about the 'title' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-title">https://svgwg.org/svg2-draft/struct.html#elementdef-title</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-title">6.1. The clipPath element</a>
     <li><a href="#ref-for-elementdef-title①">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-use">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-use" class="dfn-panel" data-for="term-for-elementdef-use" id="infopanel-for-term-for-elementdef-use" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-use" style="display:none">Info about the 'use' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-use">5. Clipping Paths</a>
     <li><a href="#ref-for-elementdef-use①">5.1. Clipping Shape: the clip-path property</a>
@@ -4404,22 +4404,22 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-elementdef-use②⓪">Appendix B: Compute stroke bounding box</a> <a href="#ref-for-elementdef-use②①">(2)</a> <a href="#ref-for-elementdef-use②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-view">
-   <a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-view" class="dfn-panel" data-for="term-for-elementdef-view" id="infopanel-for-term-for-elementdef-view" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-view" style="display:none">Info about the 'view' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-view">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ViewBoxAttribute">
-   <a href="https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute">https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ViewBoxAttribute" class="dfn-panel" data-for="term-for-ViewBoxAttribute" id="infopanel-for-term-for-ViewBoxAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-ViewBoxAttribute" style="display:none">Info about the 'viewbox' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute">https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ViewBoxAttribute">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-ViewBoxAttribute①">(2)</a> <a href="#ref-for-ViewBoxAttribute②">(3)</a>
     <li><a href="#ref-for-ViewBoxAttribute③">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-ViewBoxAttribute④">(2)</a> <a href="#ref-for-ViewBoxAttribute⑤">(3)</a>
     <li><a href="#ref-for-ViewBoxAttribute⑥">7.6. Positioning Area: the mask-origin property</a> <a href="#ref-for-ViewBoxAttribute⑦">(2)</a> <a href="#ref-for-ViewBoxAttribute⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">Interface SVGClipPathElement</a>
     <li><a href="#ref-for-Exposed①">Interface SVGMaskElement</a>
@@ -5035,21 +5035,21 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
    <div class="issue"> Firefox disables rendering of elements referencing clipPaths with violated content model. No browser ignores clipPath on use with indirect reference. <a href="https://github.com/w3c/fxtf-drafts/issues/17">[Issue #17]</a> <a class="issue-return" href="#issue-d0c561ed" title="Jump to section">↵</a></div>
    <div class="issue"> Define raw geometry with regards to CSS properties that affect it. Especially on text. <a href="https://github.com/w3c/fxtf-drafts/issues/170">[Issue #170]</a> <a class="issue-return" href="#issue-1eaffdcc" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="clipping-path">
-   <b><a href="#clipping-path">#clipping-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipping-path" class="dfn-panel" data-for="clipping-path" id="infopanel-for-clipping-path" role="dialog">
+   <span id="infopaneltitle-for-clipping-path" style="display:none">Info about the 'clipping path' definition.</span><b><a href="#clipping-path">#clipping-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipping-path">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-clipping-path①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clipping-region">
-   <b><a href="#clipping-region">#clipping-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clipping-region" class="dfn-panel" data-for="clipping-region" id="infopanel-for-clipping-region" role="dialog">
+   <span id="infopaneltitle-for-clipping-region" style="display:none">Info about the 'clipping region' definition.</span><b><a href="#clipping-region">#clipping-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipping-region">5. Clipping Paths</a>
     <li><a href="#ref-for-clipping-region①">6.2. Winding Rules: the clip-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clip-path">
-   <b><a href="#propdef-clip-path">#propdef-clip-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clip-path" class="dfn-panel" data-for="propdef-clip-path" id="infopanel-for-propdef-clip-path" role="dialog">
+   <span id="infopaneltitle-for-propdef-clip-path" style="display:none">Info about the 'clip-path' definition.</span><b><a href="#propdef-clip-path">#propdef-clip-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">1.1. Clipping</a>
     <li><a href="#ref-for-propdef-clip-path①">5. Clipping Paths</a> <a href="#ref-for-propdef-clip-path②">(2)</a>
@@ -5060,15 +5060,15 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-clip-path①⑦">Appendix A: The deprecated clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-clip-source">
-   <b><a href="#typedef-clip-source">#typedef-clip-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-clip-source" class="dfn-panel" data-for="typedef-clip-source" id="infopanel-for-typedef-clip-source" role="dialog">
+   <span id="infopaneltitle-for-typedef-clip-source" style="display:none">Info about the '&lt;clip-source>' definition.</span><b><a href="#typedef-clip-source">#typedef-clip-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-clip-source">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-typedef-clip-source①">10. Privacy and Security Considerations</a> <a href="#ref-for-typedef-clip-source②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-geometry-box">
-   <b><a href="#typedef-geometry-box">#typedef-geometry-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-geometry-box" class="dfn-panel" data-for="typedef-geometry-box" id="infopanel-for-typedef-geometry-box" role="dialog">
+   <span id="infopaneltitle-for-typedef-geometry-box" style="display:none">Info about the '&lt;geometry-box>' definition.</span><b><a href="#typedef-geometry-box">#typedef-geometry-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-geometry-box">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-typedef-geometry-box①">(2)</a>
     <li><a href="#ref-for-typedef-geometry-box②">7.5. Masking Area: the mask-clip property</a>
@@ -5077,28 +5077,28 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-typedef-geometry-box①①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-path-fill-box">
-   <b><a href="#valdef-clip-path-fill-box">#valdef-clip-path-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-path-fill-box" class="dfn-panel" data-for="valdef-clip-path-fill-box" id="infopanel-for-valdef-clip-path-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-path-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-clip-path-fill-box">#valdef-clip-path-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-fill-box">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-valdef-clip-path-fill-box①">(2)</a>
     <li><a href="#ref-for-valdef-clip-path-fill-box②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-path-stroke-box">
-   <b><a href="#valdef-clip-path-stroke-box">#valdef-clip-path-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-path-stroke-box" class="dfn-panel" data-for="valdef-clip-path-stroke-box" id="infopanel-for-valdef-clip-path-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-path-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-clip-path-stroke-box">#valdef-clip-path-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-stroke-box">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-valdef-clip-path-stroke-box①">(2)</a>
     <li><a href="#ref-for-valdef-clip-path-stroke-box②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-path-view-box">
-   <b><a href="#valdef-clip-path-view-box">#valdef-clip-path-view-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-path-view-box" class="dfn-panel" data-for="valdef-clip-path-view-box" id="infopanel-for-valdef-clip-path-view-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-path-view-box" style="display:none">Info about the 'view-box' definition.</span><b><a href="#valdef-clip-path-view-box">#valdef-clip-path-view-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-view-box">5.1. Clipping Shape: the clip-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-clippath">
-   <b><a href="#elementdef-clippath">#elementdef-clippath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-clippath" class="dfn-panel" data-for="elementdef-clippath" id="infopanel-for-elementdef-clippath" role="dialog">
+   <span id="infopaneltitle-for-elementdef-clippath" style="display:none">Info about the 'clipPath' definition.</span><b><a href="#elementdef-clippath">#elementdef-clippath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-clippath">1.1. Clipping</a>
     <li><a href="#ref-for-elementdef-clippath①">5. Clipping Paths</a>
@@ -5110,27 +5110,27 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-elementdef-clippath③③">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-clippath-clippathunits">
-   <b><a href="#element-attrdef-clippath-clippathunits">#element-attrdef-clippath-clippathunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-clippath-clippathunits" class="dfn-panel" data-for="element-attrdef-clippath-clippathunits" id="infopanel-for-element-attrdef-clippath-clippathunits" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-clippath-clippathunits" style="display:none">Info about the 'clipPathUnits' definition.</span><b><a href="#element-attrdef-clippath-clippathunits">#element-attrdef-clippath-clippathunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-clippath-clippathunits">6.1. The clipPath element</a> <a href="#ref-for-element-attrdef-clippath-clippathunits①">(2)</a>
     <li><a href="#ref-for-element-attrdef-clippath-clippathunits②">Interface SVGClipPathElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clippathunits-userspaceonuse">
-   <b><a href="#valdef-clippathunits-userspaceonuse">#valdef-clippathunits-userspaceonuse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clippathunits-userspaceonuse" class="dfn-panel" data-for="valdef-clippathunits-userspaceonuse" id="infopanel-for-valdef-clippathunits-userspaceonuse" role="dialog">
+   <span id="infopaneltitle-for-valdef-clippathunits-userspaceonuse" style="display:none">Info about the 'userSpaceOnUse' definition.</span><b><a href="#valdef-clippathunits-userspaceonuse">#valdef-clippathunits-userspaceonuse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clippathunits-userspaceonuse">6.1. The clipPath element</a> <a href="#ref-for-valdef-clippathunits-userspaceonuse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clippathunits-objectboundingbox">
-   <b><a href="#valdef-clippathunits-objectboundingbox">#valdef-clippathunits-objectboundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clippathunits-objectboundingbox" class="dfn-panel" data-for="valdef-clippathunits-objectboundingbox" id="infopanel-for-valdef-clippathunits-objectboundingbox" role="dialog">
+   <span id="infopaneltitle-for-valdef-clippathunits-objectboundingbox" style="display:none">Info about the 'objectBoundingBox' definition.</span><b><a href="#valdef-clippathunits-objectboundingbox">#valdef-clippathunits-objectboundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clippathunits-objectboundingbox">6.1. The clipPath element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clip-rule">
-   <b><a href="#propdef-clip-rule">#propdef-clip-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clip-rule" class="dfn-panel" data-for="propdef-clip-rule" id="infopanel-for-propdef-clip-rule" role="dialog">
+   <span id="infopaneltitle-for-propdef-clip-rule" style="display:none">Info about the 'clip-rule' definition.</span><b><a href="#propdef-clip-rule">#propdef-clip-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-rule">6.1. The clipPath element</a>
     <li><a href="#ref-for-propdef-clip-rule①">6.2. Winding Rules: the clip-rule property</a> <a href="#ref-for-propdef-clip-rule②">(2)</a> <a href="#ref-for-propdef-clip-rule③">(3)</a> <a href="#ref-for-propdef-clip-rule④">(4)</a> <a href="#ref-for-propdef-clip-rule⑤">(5)</a> <a href="#ref-for-propdef-clip-rule⑥">(6)</a> <a href="#ref-for-propdef-clip-rule⑦">(7)</a> <a href="#ref-for-propdef-clip-rule⑧">(8)</a>
@@ -5138,20 +5138,20 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-clip-rule①⓪">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-rule-nonzero">
-   <b><a href="#valdef-clip-rule-nonzero">#valdef-clip-rule-nonzero</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-rule-nonzero" class="dfn-panel" data-for="valdef-clip-rule-nonzero" id="infopanel-for-valdef-clip-rule-nonzero" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-rule-nonzero" style="display:none">Info about the 'nonzero' definition.</span><b><a href="#valdef-clip-rule-nonzero">#valdef-clip-rule-nonzero</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-rule-nonzero">6.2. Winding Rules: the clip-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-clip-rule-evenodd">
-   <b><a href="#valdef-clip-rule-evenodd">#valdef-clip-rule-evenodd</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-clip-rule-evenodd" class="dfn-panel" data-for="valdef-clip-rule-evenodd" id="infopanel-for-valdef-clip-rule-evenodd" role="dialog">
+   <span id="infopaneltitle-for-valdef-clip-rule-evenodd" style="display:none">Info about the 'evenodd' definition.</span><b><a href="#valdef-clip-rule-evenodd">#valdef-clip-rule-evenodd</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-rule-evenodd">6.2. Winding Rules: the clip-rule property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-image">
-   <b><a href="#propdef-mask-image">#propdef-mask-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-image" class="dfn-panel" data-for="propdef-mask-image" id="infopanel-for-propdef-mask-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-image" style="display:none">Info about the 'mask-image' definition.</span><b><a href="#propdef-mask-image">#propdef-mask-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">1.2. Masking</a> <a href="#ref-for-propdef-mask-image①">(2)</a> <a href="#ref-for-propdef-mask-image②">(3)</a> <a href="#ref-for-propdef-mask-image③">(4)</a>
     <li><a href="#ref-for-propdef-mask-image④">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-propdef-mask-image⑤">(2)</a> <a href="#ref-for-propdef-mask-image⑥">(3)</a>
@@ -5164,8 +5164,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-image①⑦">Changes since last publication</a> <a href="#ref-for-propdef-mask-image①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-layer-image">
-   <b><a href="#mask-layer-image">#mask-layer-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-layer-image" class="dfn-panel" data-for="mask-layer-image" id="infopanel-for-mask-layer-image" role="dialog">
+   <span id="infopaneltitle-for-mask-layer-image" style="display:none">Info about the 'mask layer image' definition.</span><b><a href="#mask-layer-image">#mask-layer-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-layer-image">4. Terminology</a>
     <li><a href="#ref-for-mask-layer-image①">7.1. Mask Image Source: the mask-image property</a>
@@ -5183,8 +5183,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mask-layer-image①⑨">Changes since last publication</a> <a href="#ref-for-mask-layer-image②⓪">(2)</a> <a href="#ref-for-mask-layer-image②①">(3)</a> <a href="#ref-for-mask-layer-image②②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mask-reference">
-   <b><a href="#typedef-mask-reference">#typedef-mask-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mask-reference" class="dfn-panel" data-for="typedef-mask-reference" id="infopanel-for-typedef-mask-reference" role="dialog">
+   <span id="infopaneltitle-for-typedef-mask-reference" style="display:none">Info about the '&lt;mask-reference>' definition.</span><b><a href="#typedef-mask-reference">#typedef-mask-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mask-reference">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-typedef-mask-reference①">(2)</a> <a href="#ref-for-typedef-mask-reference②">(3)</a>
     <li><a href="#ref-for-typedef-mask-reference③">7.2. Mask Image Interpretation: the mask-mode property</a> <a href="#ref-for-typedef-mask-reference④">(2)</a> <a href="#ref-for-typedef-mask-reference⑤">(3)</a>
@@ -5192,8 +5192,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-typedef-mask-reference⑧">7.10.2. Layering Multiple Mask Images</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mask-source">
-   <b><a href="#typedef-mask-source">#typedef-mask-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mask-source" class="dfn-panel" data-for="typedef-mask-source" id="infopanel-for-typedef-mask-source" role="dialog">
+   <span id="infopaneltitle-for-typedef-mask-source" style="display:none">Info about the '&lt;mask-source>' definition.</span><b><a href="#typedef-mask-source">#typedef-mask-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mask-source">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-typedef-mask-source①">(2)</a> <a href="#ref-for-typedef-mask-source②">(3)</a>
     <li><a href="#ref-for-typedef-mask-source③">7.2. Mask Image Interpretation: the mask-mode property</a>
@@ -5201,8 +5201,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-typedef-mask-source⑥">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-mode">
-   <b><a href="#propdef-mask-mode">#propdef-mask-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-mode" class="dfn-panel" data-for="propdef-mask-mode" id="infopanel-for-propdef-mask-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-mode" style="display:none">Info about the 'mask-mode' definition.</span><b><a href="#propdef-mask-mode">#propdef-mask-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-mode">7.2. Mask Image Interpretation: the mask-mode property</a> <a href="#ref-for-propdef-mask-mode①">(2)</a> <a href="#ref-for-propdef-mask-mode②">(3)</a> <a href="#ref-for-propdef-mask-mode③">(4)</a> <a href="#ref-for-propdef-mask-mode④">(5)</a> <a href="#ref-for-propdef-mask-mode⑤">(6)</a>
     <li><a href="#ref-for-propdef-mask-mode⑥">7.10.2. Layering Multiple Mask Images</a>
@@ -5211,43 +5211,43 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-mode①①">Changes since last publication</a> <a href="#ref-for-propdef-mask-mode①②">(2)</a> <a href="#ref-for-propdef-mask-mode①③">(3)</a> <a href="#ref-for-propdef-mask-mode①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-masking-mode">
-   <b><a href="#typedef-masking-mode">#typedef-masking-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-masking-mode" class="dfn-panel" data-for="typedef-masking-mode" id="infopanel-for-typedef-masking-mode" role="dialog">
+   <span id="infopaneltitle-for-typedef-masking-mode" style="display:none">Info about the '&lt;masking-mode>' definition.</span><b><a href="#typedef-masking-mode">#typedef-masking-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-masking-mode">7.2. Mask Image Interpretation: the mask-mode property</a>
     <li><a href="#ref-for-typedef-masking-mode①">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-mode-alpha">
-   <b><a href="#valdef-mask-mode-alpha">#valdef-mask-mode-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-mode-alpha" class="dfn-panel" data-for="valdef-mask-mode-alpha" id="infopanel-for-valdef-mask-mode-alpha" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-mode-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#valdef-mask-mode-alpha">#valdef-mask-mode-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-mode-alpha">7.2. Mask Image Interpretation: the mask-mode property</a>
     <li><a href="#ref-for-valdef-mask-mode-alpha①">9.2. Mask Source Interpretation: the mask-type property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-mode-luminance">
-   <b><a href="#valdef-mask-mode-luminance">#valdef-mask-mode-luminance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-mode-luminance" class="dfn-panel" data-for="valdef-mask-mode-luminance" id="infopanel-for-valdef-mask-mode-luminance" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-mode-luminance" style="display:none">Info about the 'luminance' definition.</span><b><a href="#valdef-mask-mode-luminance">#valdef-mask-mode-luminance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-mode-luminance">7.2. Mask Image Interpretation: the mask-mode property</a> <a href="#ref-for-valdef-mask-mode-luminance①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-mode-match-source">
-   <b><a href="#valdef-mask-mode-match-source">#valdef-mask-mode-match-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-mode-match-source" class="dfn-panel" data-for="valdef-mask-mode-match-source" id="infopanel-for-valdef-mask-mode-match-source" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-mode-match-source" style="display:none">Info about the 'match-source' definition.</span><b><a href="#valdef-mask-mode-match-source">#valdef-mask-mode-match-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-mode-match-source">9.2. Mask Source Interpretation: the mask-type property</a> <a href="#ref-for-valdef-mask-mode-match-source①">(2)</a>
     <li><a href="#ref-for-valdef-mask-mode-match-source②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-repeat">
-   <b><a href="#propdef-mask-repeat">#propdef-mask-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-repeat" class="dfn-panel" data-for="propdef-mask-repeat" id="infopanel-for-propdef-mask-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-repeat" style="display:none">Info about the 'mask-repeat' definition.</span><b><a href="#propdef-mask-repeat">#propdef-mask-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-repeat">7.3. Tiling Mask Images: the mask-repeat property</a> <a href="#ref-for-propdef-mask-repeat①">(2)</a>
     <li><a href="#ref-for-propdef-mask-repeat②">7.9. Mask Shorthand: the mask property</a>
     <li><a href="#ref-for-propdef-mask-repeat③">Changes since last publication</a> <a href="#ref-for-propdef-mask-repeat④">(2)</a> <a href="#ref-for-propdef-mask-repeat⑤">(3)</a> <a href="#ref-for-propdef-mask-repeat⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-position">
-   <b><a href="#propdef-mask-position">#propdef-mask-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-position" class="dfn-panel" data-for="propdef-mask-position" id="infopanel-for-propdef-mask-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-position" style="display:none">Info about the 'mask-position' definition.</span><b><a href="#propdef-mask-position">#propdef-mask-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-position">1.2. Masking</a>
     <li><a href="#ref-for-propdef-mask-position①">7.4. Positioning Mask Images: the mask-position property</a> <a href="#ref-for-propdef-mask-position②">(2)</a>
@@ -5256,8 +5256,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-position⑤">Changes since last publication</a> <a href="#ref-for-propdef-mask-position⑥">(2)</a> <a href="#ref-for-propdef-mask-position⑦">(3)</a> <a href="#ref-for-propdef-mask-position⑧">(4)</a> <a href="#ref-for-propdef-mask-position⑨">(5)</a> <a href="#ref-for-propdef-mask-position①⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-clip">
-   <b><a href="#propdef-mask-clip">#propdef-mask-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-clip" class="dfn-panel" data-for="propdef-mask-clip" id="infopanel-for-propdef-mask-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-clip" style="display:none">Info about the 'mask-clip' definition.</span><b><a href="#propdef-mask-clip">#propdef-mask-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-clip">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-propdef-mask-clip①">(2)</a> <a href="#ref-for-propdef-mask-clip②">(3)</a> <a href="#ref-for-propdef-mask-clip③">(4)</a>
     <li><a href="#ref-for-propdef-mask-clip④">7.6. Positioning Area: the mask-origin property</a>
@@ -5265,8 +5265,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-clip⑨">Changes since last publication</a> <a href="#ref-for-propdef-mask-clip①⓪">(2)</a> <a href="#ref-for-propdef-mask-clip①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-painting-area">
-   <b><a href="#mask-painting-area">#mask-painting-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-painting-area" class="dfn-panel" data-for="mask-painting-area" id="infopanel-for-mask-painting-area" role="dialog">
+   <span id="infopaneltitle-for-mask-painting-area" style="display:none">Info about the 'mask painting area' definition.</span><b><a href="#mask-painting-area">#mask-painting-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-painting-area">4. Terminology</a>
     <li><a href="#ref-for-mask-painting-area①">7.3. Tiling Mask Images: the mask-repeat property</a>
@@ -5274,105 +5274,105 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mask-painting-area③">7.5. Masking Area: the mask-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-content-box">
-   <b><a href="#valdef-mask-clip-content-box">#valdef-mask-clip-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-content-box" class="dfn-panel" data-for="valdef-mask-clip-content-box" id="infopanel-for-valdef-mask-clip-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-mask-clip-content-box">#valdef-mask-clip-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-content-box">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-valdef-mask-clip-content-box①">(2)</a>
     <li><a href="#ref-for-valdef-mask-clip-content-box②">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-valdef-mask-clip-content-box③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-padding-box">
-   <b><a href="#valdef-mask-clip-padding-box">#valdef-mask-clip-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-padding-box" class="dfn-panel" data-for="valdef-mask-clip-padding-box" id="infopanel-for-valdef-mask-clip-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-mask-clip-padding-box">#valdef-mask-clip-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-padding-box">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-valdef-mask-clip-padding-box①">7.5. Masking Area: the mask-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-border-box">
-   <b><a href="#valdef-mask-clip-border-box">#valdef-mask-clip-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-border-box" class="dfn-panel" data-for="valdef-mask-clip-border-box" id="infopanel-for-valdef-mask-clip-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-mask-clip-border-box">#valdef-mask-clip-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-border-box">5.1. Clipping Shape: the clip-path property</a> <a href="#ref-for-valdef-mask-clip-border-box①">(2)</a> <a href="#ref-for-valdef-mask-clip-border-box②">(3)</a>
     <li><a href="#ref-for-valdef-mask-clip-border-box③">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-valdef-mask-clip-border-box④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-fill-box">
-   <b><a href="#valdef-mask-clip-fill-box">#valdef-mask-clip-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-fill-box" class="dfn-panel" data-for="valdef-mask-clip-fill-box" id="infopanel-for-valdef-mask-clip-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-mask-clip-fill-box">#valdef-mask-clip-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-fill-box">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-valdef-mask-clip-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-stroke-box">
-   <b><a href="#valdef-mask-clip-stroke-box">#valdef-mask-clip-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-stroke-box" class="dfn-panel" data-for="valdef-mask-clip-stroke-box" id="infopanel-for-valdef-mask-clip-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-mask-clip-stroke-box">#valdef-mask-clip-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-stroke-box">7.5. Masking Area: the mask-clip property</a> <a href="#ref-for-valdef-mask-clip-stroke-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-view-box">
-   <b><a href="#valdef-mask-clip-view-box">#valdef-mask-clip-view-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-view-box" class="dfn-panel" data-for="valdef-mask-clip-view-box" id="infopanel-for-valdef-mask-clip-view-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-view-box" style="display:none">Info about the 'view-box' definition.</span><b><a href="#valdef-mask-clip-view-box">#valdef-mask-clip-view-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-view-box">7.5. Masking Area: the mask-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-clip-no-clip">
-   <b><a href="#valdef-mask-clip-no-clip">#valdef-mask-clip-no-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-clip-no-clip" class="dfn-panel" data-for="valdef-mask-clip-no-clip" id="infopanel-for-valdef-mask-clip-no-clip" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-clip-no-clip" style="display:none">Info about the 'no-clip' definition.</span><b><a href="#valdef-mask-clip-no-clip">#valdef-mask-clip-no-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-no-clip">7.9. Mask Shorthand: the mask property</a> <a href="#ref-for-valdef-mask-clip-no-clip①">(2)</a> <a href="#ref-for-valdef-mask-clip-no-clip②">(3)</a>
     <li><a href="#ref-for-valdef-mask-clip-no-clip③">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-origin">
-   <b><a href="#propdef-mask-origin">#propdef-mask-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-origin" class="dfn-panel" data-for="propdef-mask-origin" id="infopanel-for-propdef-mask-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-origin" style="display:none">Info about the 'mask-origin' definition.</span><b><a href="#propdef-mask-origin">#propdef-mask-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-origin">7.6. Positioning Area: the mask-origin property</a> <a href="#ref-for-propdef-mask-origin①">(2)</a> <a href="#ref-for-propdef-mask-origin②">(3)</a> <a href="#ref-for-propdef-mask-origin③">(4)</a> <a href="#ref-for-propdef-mask-origin④">(5)</a>
     <li><a href="#ref-for-propdef-mask-origin⑤">7.9. Mask Shorthand: the mask property</a> <a href="#ref-for-propdef-mask-origin⑥">(2)</a> <a href="#ref-for-propdef-mask-origin⑦">(3)</a> <a href="#ref-for-propdef-mask-origin⑧">(4)</a>
     <li><a href="#ref-for-propdef-mask-origin⑨">Changes since last publication</a> <a href="#ref-for-propdef-mask-origin①⓪">(2)</a> <a href="#ref-for-propdef-mask-origin①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-positioning-area">
-   <b><a href="#mask-positioning-area">#mask-positioning-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-positioning-area" class="dfn-panel" data-for="mask-positioning-area" id="infopanel-for-mask-positioning-area" role="dialog">
+   <span id="infopaneltitle-for-mask-positioning-area" style="display:none">Info about the 'mask positioning area' definition.</span><b><a href="#mask-positioning-area">#mask-positioning-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-positioning-area">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-content-box">
-   <b><a href="#valdef-mask-origin-content-box">#valdef-mask-origin-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-content-box" class="dfn-panel" data-for="valdef-mask-origin-content-box" id="infopanel-for-valdef-mask-origin-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-mask-origin-content-box">#valdef-mask-origin-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-content-box">7.6. Positioning Area: the mask-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-padding-box">
-   <b><a href="#valdef-mask-origin-padding-box">#valdef-mask-origin-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-padding-box" class="dfn-panel" data-for="valdef-mask-origin-padding-box" id="infopanel-for-valdef-mask-origin-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-mask-origin-padding-box">#valdef-mask-origin-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-padding-box">7.6. Positioning Area: the mask-origin property</a> <a href="#ref-for-valdef-mask-origin-padding-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-border-box">
-   <b><a href="#valdef-mask-origin-border-box">#valdef-mask-origin-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-border-box" class="dfn-panel" data-for="valdef-mask-origin-border-box" id="infopanel-for-valdef-mask-origin-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-mask-origin-border-box">#valdef-mask-origin-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-border-box">7.6. Positioning Area: the mask-origin property</a> <a href="#ref-for-valdef-mask-origin-border-box①">(2)</a>
     <li><a href="#ref-for-valdef-mask-origin-border-box②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-fill-box">
-   <b><a href="#valdef-mask-origin-fill-box">#valdef-mask-origin-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-fill-box" class="dfn-panel" data-for="valdef-mask-origin-fill-box" id="infopanel-for-valdef-mask-origin-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-mask-origin-fill-box">#valdef-mask-origin-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-fill-box">7.6. Positioning Area: the mask-origin property</a> <a href="#ref-for-valdef-mask-origin-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-stroke-box">
-   <b><a href="#valdef-mask-origin-stroke-box">#valdef-mask-origin-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-stroke-box" class="dfn-panel" data-for="valdef-mask-origin-stroke-box" id="infopanel-for-valdef-mask-origin-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-mask-origin-stroke-box">#valdef-mask-origin-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-stroke-box">7.6. Positioning Area: the mask-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-origin-view-box">
-   <b><a href="#valdef-mask-origin-view-box">#valdef-mask-origin-view-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-origin-view-box" class="dfn-panel" data-for="valdef-mask-origin-view-box" id="infopanel-for-valdef-mask-origin-view-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-origin-view-box" style="display:none">Info about the 'view-box' definition.</span><b><a href="#valdef-mask-origin-view-box">#valdef-mask-origin-view-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-origin-view-box">7.6. Positioning Area: the mask-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-size">
-   <b><a href="#propdef-mask-size">#propdef-mask-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-size" class="dfn-panel" data-for="propdef-mask-size" id="infopanel-for-propdef-mask-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-size" style="display:none">Info about the 'mask-size' definition.</span><b><a href="#propdef-mask-size">#propdef-mask-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-size">1.2. Masking</a>
     <li><a href="#ref-for-propdef-mask-size①">7.7. Sizing Mask Images: the mask-size property</a> <a href="#ref-for-propdef-mask-size②">(2)</a>
@@ -5380,8 +5380,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-size④">Changes since last publication</a> <a href="#ref-for-propdef-mask-size⑤">(2)</a> <a href="#ref-for-propdef-mask-size⑥">(3)</a> <a href="#ref-for-propdef-mask-size⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-composite">
-   <b><a href="#propdef-mask-composite">#propdef-mask-composite</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-composite" class="dfn-panel" data-for="propdef-mask-composite" id="infopanel-for-propdef-mask-composite" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-composite" style="display:none">Info about the 'mask-composite' definition.</span><b><a href="#propdef-mask-composite">#propdef-mask-composite</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-composite">7.1. Mask Image Source: the mask-image property</a>
     <li><a href="#ref-for-propdef-mask-composite①">7.8. Compositing mask layers: the mask-composite property</a> <a href="#ref-for-propdef-mask-composite②">(2)</a> <a href="#ref-for-propdef-mask-composite③">(3)</a>
@@ -5389,55 +5389,55 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-composite⑥">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-compositing-operator">
-   <b><a href="#typedef-compositing-operator">#typedef-compositing-operator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-compositing-operator" class="dfn-panel" data-for="typedef-compositing-operator" id="infopanel-for-typedef-compositing-operator" role="dialog">
+   <span id="infopaneltitle-for-typedef-compositing-operator" style="display:none">Info about the '&lt;compositing-operator>' definition.</span><b><a href="#typedef-compositing-operator">#typedef-compositing-operator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-compositing-operator">7.8. Compositing mask layers: the mask-composite property</a>
     <li><a href="#ref-for-typedef-compositing-operator①">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source">
-   <b><a href="#source">#source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source" class="dfn-panel" data-for="source" id="infopanel-for-source" role="dialog">
+   <span id="infopaneltitle-for-source" style="display:none">Info about the 'source' definition.</span><b><a href="#source">#source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source">7.8. Compositing mask layers: the mask-composite property</a> <a href="#ref-for-source①">(2)</a> <a href="#ref-for-source②">(3)</a> <a href="#ref-for-source③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="destination">
-   <b><a href="#destination">#destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-destination" class="dfn-panel" data-for="destination" id="infopanel-for-destination" role="dialog">
+   <span id="infopaneltitle-for-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#destination">#destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-destination">7.8. Compositing mask layers: the mask-composite property</a> <a href="#ref-for-destination①">(2)</a> <a href="#ref-for-destination②">(3)</a> <a href="#ref-for-destination③">(4)</a> <a href="#ref-for-destination④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-composite-add">
-   <b><a href="#valdef-mask-composite-add">#valdef-mask-composite-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-composite-add" class="dfn-panel" data-for="valdef-mask-composite-add" id="infopanel-for-valdef-mask-composite-add" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-composite-add" style="display:none">Info about the 'add' definition.</span><b><a href="#valdef-mask-composite-add">#valdef-mask-composite-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-composite-add">7.8. Compositing mask layers: the mask-composite property</a> <a href="#ref-for-valdef-mask-composite-add①">(2)</a>
     <li><a href="#ref-for-valdef-mask-composite-add②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-composite-subtract">
-   <b><a href="#valdef-mask-composite-subtract">#valdef-mask-composite-subtract</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-composite-subtract" class="dfn-panel" data-for="valdef-mask-composite-subtract" id="infopanel-for-valdef-mask-composite-subtract" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-composite-subtract" style="display:none">Info about the 'subtract' definition.</span><b><a href="#valdef-mask-composite-subtract">#valdef-mask-composite-subtract</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-composite-subtract">7.8. Compositing mask layers: the mask-composite property</a>
     <li><a href="#ref-for-valdef-mask-composite-subtract①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-composite-intersect">
-   <b><a href="#valdef-mask-composite-intersect">#valdef-mask-composite-intersect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-composite-intersect" class="dfn-panel" data-for="valdef-mask-composite-intersect" id="infopanel-for-valdef-mask-composite-intersect" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-composite-intersect" style="display:none">Info about the 'intersect' definition.</span><b><a href="#valdef-mask-composite-intersect">#valdef-mask-composite-intersect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-composite-intersect">7.8. Compositing mask layers: the mask-composite property</a>
     <li><a href="#ref-for-valdef-mask-composite-intersect①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-composite-exclude">
-   <b><a href="#valdef-mask-composite-exclude">#valdef-mask-composite-exclude</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-composite-exclude" class="dfn-panel" data-for="valdef-mask-composite-exclude" id="infopanel-for-valdef-mask-composite-exclude" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-composite-exclude" style="display:none">Info about the 'exclude' definition.</span><b><a href="#valdef-mask-composite-exclude">#valdef-mask-composite-exclude</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-composite-exclude">7.8. Compositing mask layers: the mask-composite property</a> <a href="#ref-for-valdef-mask-composite-exclude①">(2)</a> <a href="#ref-for-valdef-mask-composite-exclude②">(3)</a>
     <li><a href="#ref-for-valdef-mask-composite-exclude③">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask">
-   <b><a href="#propdef-mask">#propdef-mask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask" class="dfn-panel" data-for="propdef-mask" id="infopanel-for-propdef-mask" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask" style="display:none">Info about the 'mask' definition.</span><b><a href="#propdef-mask">#propdef-mask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask">1.2. Masking</a>
     <li><a href="#ref-for-propdef-mask①">6.1. The clipPath element</a>
@@ -5448,20 +5448,20 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask①①">Changes since last publication</a> <a href="#ref-for-propdef-mask①②">(2)</a> <a href="#ref-for-propdef-mask①③">(3)</a> <a href="#ref-for-propdef-mask①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-mask-layer">
-   <b><a href="#typedef-mask-layer">#typedef-mask-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-mask-layer" class="dfn-panel" data-for="typedef-mask-layer" id="infopanel-for-typedef-mask-layer" role="dialog">
+   <span id="infopaneltitle-for-typedef-mask-layer" style="display:none">Info about the '&lt;mask-layer>' definition.</span><b><a href="#typedef-mask-layer">#typedef-mask-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mask-layer">7.9. Mask Shorthand: the mask property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-image">
-   <b><a href="#mask-image">#mask-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-image" class="dfn-panel" data-for="mask-image" id="infopanel-for-mask-image" role="dialog">
+   <span id="infopaneltitle-for-mask-image" style="display:none">Info about the 'mask image' definition.</span><b><a href="#mask-image">#mask-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-image">7.10.1. Mask processing</a> <a href="#ref-for-mask-image①">(2)</a> <a href="#ref-for-mask-image②">(3)</a> <a href="#ref-for-mask-image③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-source">
-   <b><a href="#propdef-mask-border-source">#propdef-mask-border-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-source" class="dfn-panel" data-for="propdef-mask-border-source" id="infopanel-for-propdef-mask-border-source" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-source" style="display:none">Info about the 'mask-border-source' definition.</span><b><a href="#propdef-mask-border-source">#propdef-mask-border-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-source">1.2. Masking</a> <a href="#ref-for-propdef-mask-border-source①">(2)</a> <a href="#ref-for-propdef-mask-border-source②">(3)</a>
     <li><a href="#ref-for-propdef-mask-border-source③">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-propdef-mask-border-source④">(2)</a>
@@ -5473,8 +5473,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-border-source①⑥">10. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-border-image">
-   <b><a href="#mask-border-image">#mask-border-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-border-image" class="dfn-panel" data-for="mask-border-image" id="infopanel-for-mask-border-image" role="dialog">
+   <span id="infopaneltitle-for-mask-border-image" style="display:none">Info about the 'mask border image' definition.</span><b><a href="#mask-border-image">#mask-border-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-border-image">4. Terminology</a>
     <li><a href="#ref-for-mask-border-image①">7.10.1. Mask processing</a>
@@ -5488,27 +5488,27 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mask-border-image①⑥">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-mode">
-   <b><a href="#propdef-mask-border-mode">#propdef-mask-border-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-mode" class="dfn-panel" data-for="propdef-mask-border-mode" id="infopanel-for-propdef-mask-border-mode" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-mode" style="display:none">Info about the 'mask-border-mode' definition.</span><b><a href="#propdef-mask-border-mode">#propdef-mask-border-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-mode">8.2. Mask Border Image Interpretation: the mask-border-mode property</a> <a href="#ref-for-propdef-mask-border-mode①">(2)</a>
     <li><a href="#ref-for-propdef-mask-border-mode②">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border-mode③">(2)</a> <a href="#ref-for-propdef-mask-border-mode④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-border-mode-alpha">
-   <b><a href="#valdef-mask-border-mode-alpha">#valdef-mask-border-mode-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-border-mode-alpha" class="dfn-panel" data-for="valdef-mask-border-mode-alpha" id="infopanel-for-valdef-mask-border-mode-alpha" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-border-mode-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#valdef-mask-border-mode-alpha">#valdef-mask-border-mode-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-border-mode-alpha">8.2. Mask Border Image Interpretation: the mask-border-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-border-mode-luminance">
-   <b><a href="#valdef-mask-border-mode-luminance">#valdef-mask-border-mode-luminance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-border-mode-luminance" class="dfn-panel" data-for="valdef-mask-border-mode-luminance" id="infopanel-for-valdef-mask-border-mode-luminance" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-border-mode-luminance" style="display:none">Info about the 'luminance' definition.</span><b><a href="#valdef-mask-border-mode-luminance">#valdef-mask-border-mode-luminance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-border-mode-luminance">8.2. Mask Border Image Interpretation: the mask-border-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-slice">
-   <b><a href="#propdef-mask-border-slice">#propdef-mask-border-slice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-slice" class="dfn-panel" data-for="propdef-mask-border-slice" id="infopanel-for-propdef-mask-border-slice" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-slice" style="display:none">Info about the 'mask-border-slice' definition.</span><b><a href="#propdef-mask-border-slice">#propdef-mask-border-slice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-slice">8.3. Mask Border Image Slicing: the mask-border-slice property</a>
     <li><a href="#ref-for-propdef-mask-border-slice①">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border-slice②">(2)</a> <a href="#ref-for-propdef-mask-border-slice③">(3)</a>
@@ -5516,22 +5516,22 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-border-slice⑤">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-border-slice-fill">
-   <b><a href="#valdef-mask-border-slice-fill">#valdef-mask-border-slice-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-border-slice-fill" class="dfn-panel" data-for="valdef-mask-border-slice-fill" id="infopanel-for-valdef-mask-border-slice-fill" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-border-slice-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#valdef-mask-border-slice-fill">#valdef-mask-border-slice-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-border-slice-fill">Changes since last publication</a> <a href="#ref-for-valdef-mask-border-slice-fill①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-width">
-   <b><a href="#propdef-mask-border-width">#propdef-mask-border-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-width" class="dfn-panel" data-for="propdef-mask-border-width" id="infopanel-for-propdef-mask-border-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-width" style="display:none">Info about the 'mask-border-width' definition.</span><b><a href="#propdef-mask-border-width">#propdef-mask-border-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-width">8.4. Masking Areas: the mask-border-width property</a>
     <li><a href="#ref-for-propdef-mask-border-width①">8.5. Edge Overhang: the mask-border-outset property</a>
     <li><a href="#ref-for-propdef-mask-border-width②">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border-width③">(2)</a> <a href="#ref-for-propdef-mask-border-width④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mask-border-image-area">
-   <b><a href="#mask-border-image-area">#mask-border-image-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mask-border-image-area" class="dfn-panel" data-for="mask-border-image-area" id="infopanel-for-mask-border-image-area" role="dialog">
+   <span id="infopaneltitle-for-mask-border-image-area" style="display:none">Info about the 'mask border image area' definition.</span><b><a href="#mask-border-image-area">#mask-border-image-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mask-border-image-area">1.2. Masking</a>
     <li><a href="#ref-for-mask-border-image-area①">4. Terminology</a>
@@ -5540,23 +5540,23 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-mask-border-image-area④">8.5. Edge Overhang: the mask-border-outset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-outset">
-   <b><a href="#propdef-mask-border-outset">#propdef-mask-border-outset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-outset" class="dfn-panel" data-for="propdef-mask-border-outset" id="infopanel-for-propdef-mask-border-outset" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-outset" style="display:none">Info about the 'mask-border-outset' definition.</span><b><a href="#propdef-mask-border-outset">#propdef-mask-border-outset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-outset">8.4. Masking Areas: the mask-border-width property</a>
     <li><a href="#ref-for-propdef-mask-border-outset①">8.5. Edge Overhang: the mask-border-outset property</a> <a href="#ref-for-propdef-mask-border-outset②">(2)</a>
     <li><a href="#ref-for-propdef-mask-border-outset③">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border-outset④">(2)</a> <a href="#ref-for-propdef-mask-border-outset⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border-repeat">
-   <b><a href="#propdef-mask-border-repeat">#propdef-mask-border-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border-repeat" class="dfn-panel" data-for="propdef-mask-border-repeat" id="infopanel-for-propdef-mask-border-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border-repeat" style="display:none">Info about the 'mask-border-repeat' definition.</span><b><a href="#propdef-mask-border-repeat">#propdef-mask-border-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-repeat">8.6. Mask Border Image Tiling: the mask-border-repeat property</a>
     <li><a href="#ref-for-propdef-mask-border-repeat①">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border-repeat②">(2)</a> <a href="#ref-for-propdef-mask-border-repeat③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-border">
-   <b><a href="#propdef-mask-border">#propdef-mask-border</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-border" class="dfn-panel" data-for="propdef-mask-border" id="infopanel-for-propdef-mask-border" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-border" style="display:none">Info about the 'mask-border' definition.</span><b><a href="#propdef-mask-border">#propdef-mask-border</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border">1.2. Masking</a> <a href="#ref-for-propdef-mask-border①">(2)</a>
     <li><a href="#ref-for-propdef-mask-border②">7.9. Mask Shorthand: the mask property</a> <a href="#ref-for-propdef-mask-border③">(2)</a>
@@ -5564,8 +5564,8 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-border⑦">8.7. Mask Border Image Shorthand: the mask-border property</a> <a href="#ref-for-propdef-mask-border⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-mask">
-   <b><a href="#elementdef-mask">#elementdef-mask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-mask" class="dfn-panel" data-for="elementdef-mask" id="infopanel-for-elementdef-mask" role="dialog">
+   <span id="infopaneltitle-for-elementdef-mask" style="display:none">Info about the 'mask' definition.</span><b><a href="#elementdef-mask">#elementdef-mask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-mask">1.2. Masking</a> <a href="#ref-for-elementdef-mask①">(2)</a> <a href="#ref-for-elementdef-mask②">(3)</a>
     <li><a href="#ref-for-elementdef-mask③">7.1. Mask Image Source: the mask-image property</a> <a href="#ref-for-elementdef-mask④">(2)</a>
@@ -5580,79 +5580,79 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-elementdef-mask④②">Changes since last publication</a> <a href="#ref-for-elementdef-mask④③">(2)</a> <a href="#ref-for-elementdef-mask④④">(3)</a> <a href="#ref-for-elementdef-mask④⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-maskunits">
-   <b><a href="#element-attrdef-mask-maskunits">#element-attrdef-mask-maskunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-maskunits" class="dfn-panel" data-for="element-attrdef-mask-maskunits" id="infopanel-for-element-attrdef-mask-maskunits" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-maskunits" style="display:none">Info about the 'maskUnits' definition.</span><b><a href="#element-attrdef-mask-maskunits">#element-attrdef-mask-maskunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-maskunits">7.5. Masking Area: the mask-clip property</a>
     <li><a href="#ref-for-element-attrdef-mask-maskunits①">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-maskunits②">(2)</a>
     <li><a href="#ref-for-element-attrdef-mask-maskunits③">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-maskunits-userspaceonuse">
-   <b><a href="#valdef-maskunits-userspaceonuse">#valdef-maskunits-userspaceonuse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-maskunits-userspaceonuse" class="dfn-panel" data-for="valdef-maskunits-userspaceonuse" id="infopanel-for-valdef-maskunits-userspaceonuse" role="dialog">
+   <span id="infopaneltitle-for-valdef-maskunits-userspaceonuse" style="display:none">Info about the 'userSpaceOnUse' definition.</span><b><a href="#valdef-maskunits-userspaceonuse">#valdef-maskunits-userspaceonuse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-maskunits-userspaceonuse">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-maskunits-objectboundingbox">
-   <b><a href="#valdef-maskunits-objectboundingbox">#valdef-maskunits-objectboundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-maskunits-objectboundingbox" class="dfn-panel" data-for="valdef-maskunits-objectboundingbox" id="infopanel-for-valdef-maskunits-objectboundingbox" role="dialog">
+   <span id="infopaneltitle-for-valdef-maskunits-objectboundingbox" style="display:none">Info about the 'objectBoundingBox' definition.</span><b><a href="#valdef-maskunits-objectboundingbox">#valdef-maskunits-objectboundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-maskunits-objectboundingbox">9.1. The mask element</a> <a href="#ref-for-valdef-maskunits-objectboundingbox①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-maskcontentunits">
-   <b><a href="#element-attrdef-mask-maskcontentunits">#element-attrdef-mask-maskcontentunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-maskcontentunits" class="dfn-panel" data-for="element-attrdef-mask-maskcontentunits" id="infopanel-for-element-attrdef-mask-maskcontentunits" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-maskcontentunits" style="display:none">Info about the 'maskContentUnits' definition.</span><b><a href="#element-attrdef-mask-maskcontentunits">#element-attrdef-mask-maskcontentunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-maskcontentunits">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-maskcontentunits①">(2)</a>
     <li><a href="#ref-for-element-attrdef-mask-maskcontentunits②">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-maskcontentunits-userspaceonuse">
-   <b><a href="#valdef-maskcontentunits-userspaceonuse">#valdef-maskcontentunits-userspaceonuse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-maskcontentunits-userspaceonuse" class="dfn-panel" data-for="valdef-maskcontentunits-userspaceonuse" id="infopanel-for-valdef-maskcontentunits-userspaceonuse" role="dialog">
+   <span id="infopaneltitle-for-valdef-maskcontentunits-userspaceonuse" style="display:none">Info about the 'userSpaceOnUse' definition.</span><b><a href="#valdef-maskcontentunits-userspaceonuse">#valdef-maskcontentunits-userspaceonuse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-maskcontentunits-userspaceonuse">9.1. The mask element</a> <a href="#ref-for-valdef-maskcontentunits-userspaceonuse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-maskcontentunits-objectboundingbox">
-   <b><a href="#valdef-maskcontentunits-objectboundingbox">#valdef-maskcontentunits-objectboundingbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-maskcontentunits-objectboundingbox" class="dfn-panel" data-for="valdef-maskcontentunits-objectboundingbox" id="infopanel-for-valdef-maskcontentunits-objectboundingbox" role="dialog">
+   <span id="infopaneltitle-for-valdef-maskcontentunits-objectboundingbox" style="display:none">Info about the 'objectBoundingBox' definition.</span><b><a href="#valdef-maskcontentunits-objectboundingbox">#valdef-maskcontentunits-objectboundingbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-maskcontentunits-objectboundingbox">9.1. The mask element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-x">
-   <b><a href="#element-attrdef-mask-x">#element-attrdef-mask-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-x" class="dfn-panel" data-for="element-attrdef-mask-x" id="infopanel-for-element-attrdef-mask-x" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-x" style="display:none">Info about the 'x' definition.</span><b><a href="#element-attrdef-mask-x">#element-attrdef-mask-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-x">7.5. Masking Area: the mask-clip property</a>
     <li><a href="#ref-for-element-attrdef-mask-x①">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-x②">(2)</a> <a href="#ref-for-element-attrdef-mask-x③">(3)</a> <a href="#ref-for-element-attrdef-mask-x④">(4)</a> <a href="#ref-for-element-attrdef-mask-x⑤">(5)</a> <a href="#ref-for-element-attrdef-mask-x⑥">(6)</a> <a href="#ref-for-element-attrdef-mask-x⑦">(7)</a> <a href="#ref-for-element-attrdef-mask-x⑧">(8)</a> <a href="#ref-for-element-attrdef-mask-x⑨">(9)</a>
     <li><a href="#ref-for-element-attrdef-mask-x①⓪">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-y">
-   <b><a href="#element-attrdef-mask-y">#element-attrdef-mask-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-y" class="dfn-panel" data-for="element-attrdef-mask-y" id="infopanel-for-element-attrdef-mask-y" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-y" style="display:none">Info about the 'y' definition.</span><b><a href="#element-attrdef-mask-y">#element-attrdef-mask-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-y">7.5. Masking Area: the mask-clip property</a>
     <li><a href="#ref-for-element-attrdef-mask-y①">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-y②">(2)</a> <a href="#ref-for-element-attrdef-mask-y③">(3)</a> <a href="#ref-for-element-attrdef-mask-y④">(4)</a> <a href="#ref-for-element-attrdef-mask-y⑤">(5)</a> <a href="#ref-for-element-attrdef-mask-y⑥">(6)</a> <a href="#ref-for-element-attrdef-mask-y⑦">(7)</a> <a href="#ref-for-element-attrdef-mask-y⑧">(8)</a> <a href="#ref-for-element-attrdef-mask-y⑨">(9)</a>
     <li><a href="#ref-for-element-attrdef-mask-y①⓪">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-width">
-   <b><a href="#element-attrdef-mask-width">#element-attrdef-mask-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-width" class="dfn-panel" data-for="element-attrdef-mask-width" id="infopanel-for-element-attrdef-mask-width" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-width" style="display:none">Info about the 'width' definition.</span><b><a href="#element-attrdef-mask-width">#element-attrdef-mask-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-width">7.5. Masking Area: the mask-clip property</a>
     <li><a href="#ref-for-element-attrdef-mask-width①">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-width②">(2)</a> <a href="#ref-for-element-attrdef-mask-width③">(3)</a> <a href="#ref-for-element-attrdef-mask-width④">(4)</a> <a href="#ref-for-element-attrdef-mask-width⑤">(5)</a> <a href="#ref-for-element-attrdef-mask-width⑥">(6)</a> <a href="#ref-for-element-attrdef-mask-width⑦">(7)</a> <a href="#ref-for-element-attrdef-mask-width⑧">(8)</a> <a href="#ref-for-element-attrdef-mask-width⑨">(9)</a>
     <li><a href="#ref-for-element-attrdef-mask-width①⓪">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-mask-height">
-   <b><a href="#element-attrdef-mask-height">#element-attrdef-mask-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-mask-height" class="dfn-panel" data-for="element-attrdef-mask-height" id="infopanel-for-element-attrdef-mask-height" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-mask-height" style="display:none">Info about the 'height' definition.</span><b><a href="#element-attrdef-mask-height">#element-attrdef-mask-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-mask-height">7.5. Masking Area: the mask-clip property</a>
     <li><a href="#ref-for-element-attrdef-mask-height①">9.1. The mask element</a> <a href="#ref-for-element-attrdef-mask-height②">(2)</a> <a href="#ref-for-element-attrdef-mask-height③">(3)</a> <a href="#ref-for-element-attrdef-mask-height④">(4)</a> <a href="#ref-for-element-attrdef-mask-height⑤">(5)</a> <a href="#ref-for-element-attrdef-mask-height⑥">(6)</a> <a href="#ref-for-element-attrdef-mask-height⑦">(7)</a> <a href="#ref-for-element-attrdef-mask-height⑧">(8)</a> <a href="#ref-for-element-attrdef-mask-height⑨">(9)</a>
     <li><a href="#ref-for-element-attrdef-mask-height①⓪">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-mask-type">
-   <b><a href="#propdef-mask-type">#propdef-mask-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-mask-type" class="dfn-panel" data-for="propdef-mask-type" id="infopanel-for-propdef-mask-type" role="dialog">
+   <span id="infopaneltitle-for-propdef-mask-type" style="display:none">Info about the 'mask-type' definition.</span><b><a href="#propdef-mask-type">#propdef-mask-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-type">7.2. Mask Image Interpretation: the mask-mode property</a> <a href="#ref-for-propdef-mask-type①">(2)</a> <a href="#ref-for-propdef-mask-type②">(3)</a>
     <li><a href="#ref-for-propdef-mask-type③">8.2. Mask Border Image Interpretation: the mask-border-mode property</a>
@@ -5660,21 +5660,21 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-mask-type⑨">Changes since last publication</a> <a href="#ref-for-propdef-mask-type①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-type-luminance">
-   <b><a href="#valdef-mask-type-luminance">#valdef-mask-type-luminance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-type-luminance" class="dfn-panel" data-for="valdef-mask-type-luminance" id="infopanel-for-valdef-mask-type-luminance" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-type-luminance" style="display:none">Info about the 'luminance' definition.</span><b><a href="#valdef-mask-type-luminance">#valdef-mask-type-luminance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-type-luminance">7.2. Mask Image Interpretation: the mask-mode property</a>
     <li><a href="#ref-for-valdef-mask-type-luminance①">9.2. Mask Source Interpretation: the mask-type property</a> <a href="#ref-for-valdef-mask-type-luminance②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-mask-type-alpha">
-   <b><a href="#valdef-mask-type-alpha">#valdef-mask-type-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-mask-type-alpha" class="dfn-panel" data-for="valdef-mask-type-alpha" id="infopanel-for-valdef-mask-type-alpha" role="dialog">
+   <span id="infopaneltitle-for-valdef-mask-type-alpha" style="display:none">Info about the 'alpha' definition.</span><b><a href="#valdef-mask-type-alpha">#valdef-mask-type-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-type-alpha">7.2. Mask Image Interpretation: the mask-mode property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-clip">
-   <b><a href="#propdef-clip">#propdef-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-clip" class="dfn-panel" data-for="propdef-clip" id="infopanel-for-propdef-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef-clip" style="display:none">Info about the 'clip' definition.</span><b><a href="#propdef-clip">#propdef-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">5. Clipping Paths</a>
     <li><a href="#ref-for-propdef-clip①">6.1. The clipPath element</a>
@@ -5682,38 +5682,38 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-propdef-clip③">Appendix A: The deprecated clip property</a> <a href="#ref-for-propdef-clip④">(2)</a> <a href="#ref-for-propdef-clip⑤">(3)</a> <a href="#ref-for-propdef-clip⑥">(4)</a> <a href="#ref-for-propdef-clip⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-clip-rect">
-   <b><a href="#funcdef-clip-rect">#funcdef-clip-rect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-clip-rect" class="dfn-panel" data-for="funcdef-clip-rect" id="infopanel-for-funcdef-clip-rect" role="dialog">
+   <span id="infopaneltitle-for-funcdef-clip-rect" style="display:none">Info about the 'rect()' definition.</span><b><a href="#funcdef-clip-rect">#funcdef-clip-rect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-clip-rect">Appendix A: The deprecated clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-clip-top">
-   <b><a href="#typedef-clip-top">#typedef-clip-top</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-clip-top" class="dfn-panel" data-for="typedef-clip-top" id="infopanel-for-typedef-clip-top" role="dialog">
+   <span id="infopaneltitle-for-typedef-clip-top" style="display:none">Info about the '&lt;top>' definition.</span><b><a href="#typedef-clip-top">#typedef-clip-top</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-clip-top">Appendix A: The deprecated clip property</a> <a href="#ref-for-typedef-clip-top①">(2)</a> <a href="#ref-for-typedef-clip-top②">(3)</a> <a href="#ref-for-typedef-clip-top③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-clip-right">
-   <b><a href="#typedef-clip-right">#typedef-clip-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-clip-right" class="dfn-panel" data-for="typedef-clip-right" id="infopanel-for-typedef-clip-right" role="dialog">
+   <span id="infopaneltitle-for-typedef-clip-right" style="display:none">Info about the '&lt;right>' definition.</span><b><a href="#typedef-clip-right">#typedef-clip-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-clip-right">Appendix A: The deprecated clip property</a> <a href="#ref-for-typedef-clip-right①">(2)</a> <a href="#ref-for-typedef-clip-right②">(3)</a> <a href="#ref-for-typedef-clip-right③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-clip-bottom">
-   <b><a href="#typedef-clip-bottom">#typedef-clip-bottom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-clip-bottom" class="dfn-panel" data-for="typedef-clip-bottom" id="infopanel-for-typedef-clip-bottom" role="dialog">
+   <span id="infopaneltitle-for-typedef-clip-bottom" style="display:none">Info about the '&lt;bottom>' definition.</span><b><a href="#typedef-clip-bottom">#typedef-clip-bottom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-clip-bottom">Appendix A: The deprecated clip property</a> <a href="#ref-for-typedef-clip-bottom①">(2)</a> <a href="#ref-for-typedef-clip-bottom②">(3)</a> <a href="#ref-for-typedef-clip-bottom③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-clip-left">
-   <b><a href="#typedef-clip-left">#typedef-clip-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-clip-left" class="dfn-panel" data-for="typedef-clip-left" id="infopanel-for-typedef-clip-left" role="dialog">
+   <span id="infopaneltitle-for-typedef-clip-left" style="display:none">Info about the '&lt;left>' definition.</span><b><a href="#typedef-clip-left">#typedef-clip-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-clip-left">Appendix A: The deprecated clip property</a> <a href="#ref-for-typedef-clip-left①">(2)</a> <a href="#ref-for-typedef-clip-left②">(3)</a> <a href="#ref-for-typedef-clip-left③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stroke-bounding-box">
-   <b><a href="#stroke-bounding-box">#stroke-bounding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stroke-bounding-box" class="dfn-panel" data-for="stroke-bounding-box" id="infopanel-for-stroke-bounding-box" role="dialog">
+   <span id="infopaneltitle-for-stroke-bounding-box" style="display:none">Info about the 'stroke bounding box' definition.</span><b><a href="#stroke-bounding-box">#stroke-bounding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stroke-bounding-box">5.1. Clipping Shape: the clip-path property</a>
     <li><a href="#ref-for-stroke-bounding-box①">7.5. Masking Area: the mask-clip property</a>
@@ -5721,121 +5721,177 @@ p#two <c- p>{</c-> <c- k>clip</c-><c- p>:</c-> <c- nf>rect</c-><c- p>(</c-><c- m
     <li><a href="#ref-for-stroke-bounding-box③">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgclippathelement">
-   <b><a href="#svgclippathelement">#svgclippathelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgclippathelement" class="dfn-panel" data-for="svgclippathelement" id="infopanel-for-svgclippathelement" role="dialog">
+   <span id="infopaneltitle-for-svgclippathelement" style="display:none">Info about the 'SVGClipPathElement' definition.</span><b><a href="#svgclippathelement">#svgclippathelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgclippathelement">Interface SVGClipPathElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgclippathelement-clippathunits">
-   <b><a href="#dom-svgclippathelement-clippathunits">#dom-svgclippathelement-clippathunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgclippathelement-clippathunits" class="dfn-panel" data-for="dom-svgclippathelement-clippathunits" id="infopanel-for-dom-svgclippathelement-clippathunits" role="dialog">
+   <span id="infopaneltitle-for-dom-svgclippathelement-clippathunits" style="display:none">Info about the 'clipPathUnits' definition.</span><b><a href="#dom-svgclippathelement-clippathunits">#dom-svgclippathelement-clippathunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgclippathelement-clippathunits">Interface SVGClipPathElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgclippathelement-transform">
-   <b><a href="#dom-svgclippathelement-transform">#dom-svgclippathelement-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgclippathelement-transform" class="dfn-panel" data-for="dom-svgclippathelement-transform" id="infopanel-for-dom-svgclippathelement-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-svgclippathelement-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-svgclippathelement-transform">#dom-svgclippathelement-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgclippathelement-transform">Interface SVGClipPathElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgmaskelement">
-   <b><a href="#svgmaskelement">#svgmaskelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgmaskelement" class="dfn-panel" data-for="svgmaskelement" id="infopanel-for-svgmaskelement" role="dialog">
+   <span id="infopaneltitle-for-svgmaskelement" style="display:none">Info about the 'SVGMaskElement' definition.</span><b><a href="#svgmaskelement">#svgmaskelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgmaskelement">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-maskunits">
-   <b><a href="#dom-svgmaskelement-maskunits">#dom-svgmaskelement-maskunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-maskunits" class="dfn-panel" data-for="dom-svgmaskelement-maskunits" id="infopanel-for-dom-svgmaskelement-maskunits" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-maskunits" style="display:none">Info about the 'maskUnits' definition.</span><b><a href="#dom-svgmaskelement-maskunits">#dom-svgmaskelement-maskunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-maskunits">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-maskcontentunits">
-   <b><a href="#dom-svgmaskelement-maskcontentunits">#dom-svgmaskelement-maskcontentunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-maskcontentunits" class="dfn-panel" data-for="dom-svgmaskelement-maskcontentunits" id="infopanel-for-dom-svgmaskelement-maskcontentunits" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-maskcontentunits" style="display:none">Info about the 'maskContentUnits' definition.</span><b><a href="#dom-svgmaskelement-maskcontentunits">#dom-svgmaskelement-maskcontentunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-maskcontentunits">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-x">
-   <b><a href="#dom-svgmaskelement-x">#dom-svgmaskelement-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-x" class="dfn-panel" data-for="dom-svgmaskelement-x" id="infopanel-for-dom-svgmaskelement-x" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-svgmaskelement-x">#dom-svgmaskelement-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-x">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-y">
-   <b><a href="#dom-svgmaskelement-y">#dom-svgmaskelement-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-y" class="dfn-panel" data-for="dom-svgmaskelement-y" id="infopanel-for-dom-svgmaskelement-y" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-svgmaskelement-y">#dom-svgmaskelement-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-y">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-width">
-   <b><a href="#dom-svgmaskelement-width">#dom-svgmaskelement-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-width" class="dfn-panel" data-for="dom-svgmaskelement-width" id="infopanel-for-dom-svgmaskelement-width" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-svgmaskelement-width">#dom-svgmaskelement-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-width">Interface SVGMaskElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svgmaskelement-height">
-   <b><a href="#dom-svgmaskelement-height">#dom-svgmaskelement-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svgmaskelement-height" class="dfn-panel" data-for="dom-svgmaskelement-height" id="infopanel-for-dom-svgmaskelement-height" role="dialog">
+   <span id="infopaneltitle-for-dom-svgmaskelement-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-svgmaskelement-height">#dom-svgmaskelement-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svgmaskelement-height">Interface SVGMaskElement</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/fill-stroke/Overview.html
@@ -3266,99 +3266,99 @@ which takes the value from the element’s corresponding <a class="property css"
    <li><a href="#propdef-stroke-width">stroke-width</a><span>, in § 4.2.1</span>
    <li><a href="#typedef-svg-paint">&lt;svg-paint></a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-fragment">
-   <a href="https://www.w3.org/TR/css-break-3/#fragment">https://www.w3.org/TR/css-break-3/#fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fragment" class="dfn-panel" data-for="term-for-fragment" id="infopanel-for-term-for-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://www.w3.org/TR/css-break-3/#fragment">https://www.w3.org/TR/css-break-3/#fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment">3.2.2. Fragmented Fills: the fill-break property</a>
     <li><a href="#ref-for-fragment①">4.2.6. Fragmented Strokes: the stroke-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-decoration-break">
-   <a href="https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break">https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-decoration-break" class="dfn-panel" data-for="term-for-propdef-box-decoration-break" id="infopanel-for-term-for-propdef-box-decoration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-decoration-break" style="display:none">Info about the 'box-decoration-break' external reference.</span><a href="https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break">https://www.w3.org/TR/css-break-4/#propdef-box-decoration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-decoration-break">3. Fills</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shorthand-property">
-   <a href="https://www.w3.org/TR/css-cascade-5/#shorthand-property">https://www.w3.org/TR/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shorthand-property" class="dfn-panel" data-for="term-for-shorthand-property" id="infopanel-for-term-for-shorthand-property" role="menu">
+   <span id="infopaneltitle-for-term-for-shorthand-property" style="display:none">Info about the 'shorthand' external reference.</span><a href="https://www.w3.org/TR/css-cascade-5/#shorthand-property">https://www.w3.org/TR/css-cascade-5/#shorthand-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorthand-property">3.3.7. Fill Shorthand: the fill property</a>
     <li><a href="#ref-for-shorthand-property①">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#typedef-color">https://www.w3.org/TR/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">2. Paint</a>
     <li><a href="#ref-for-typedef-color①">3.3.1. Fill Color: the fill-color property</a>
     <li><a href="#ref-for-typedef-color②">4.4.1. Stroke Color: the stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://www.w3.org/TR/css-color-4/#propdef-color">https://www.w3.org/TR/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#propdef-color">https://www.w3.org/TR/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3.3.1. Fill Color: the fill-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://www.w3.org/TR/css-color-4/#propdef-opacity">https://www.w3.org/TR/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#propdef-opacity">https://www.w3.org/TR/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">3.4.1. Fill Opacity: the fill-opacity property</a> <a href="#ref-for-propdef-opacity①">(2)</a>
     <li><a href="#ref-for-propdef-opacity②">4.5.1. Stroke Opacity: the stroke-opacity property</a> <a href="#ref-for-propdef-opacity③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://www.w3.org/TR/css-color-4/#valdef-color-transparent">https://www.w3.org/TR/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://www.w3.org/TR/css-color-4/#valdef-color-transparent">https://www.w3.org/TR/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">3.3.7. Fill Shorthand: the fill property</a>
     <li><a href="#ref-for-valdef-color-transparent①">4.1. Layering Multiple Strokes</a> <a href="#ref-for-valdef-color-transparent②">(2)</a>
     <li><a href="#ref-for-valdef-color-transparent③">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://www.w3.org/TR/css-display-3/#initial-containing-block">https://www.w3.org/TR/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://www.w3.org/TR/css-display-3/#initial-containing-block">https://www.w3.org/TR/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">3.3.3. Fill Positioning Area: the fill-origin property</a>
     <li><a href="#ref-for-initial-containing-block①">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-image">
-   <a href="https://www.w3.org/TR/css-images-4/#funcdef-image">https://www.w3.org/TR/css-images-4/#funcdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-image" class="dfn-panel" data-for="term-for-funcdef-image" id="infopanel-for-term-for-funcdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-image" style="display:none">Info about the 'image()' external reference.</span><a href="https://www.w3.org/TR/css-images-4/#funcdef-image">https://www.w3.org/TR/css-images-4/#funcdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image">3.3.1. Fill Color: the fill-color property</a>
     <li><a href="#ref-for-funcdef-image①">4.4.1. Stroke Color: the stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-image">
-   <a href="https://www.w3.org/TR/css-images-4/#invalid-image">https://www.w3.org/TR/css-images-4/#invalid-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-image" class="dfn-panel" data-for="term-for-invalid-image" id="infopanel-for-term-for-invalid-image" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-image" style="display:none">Info about the 'invalid image' external reference.</span><a href="https://www.w3.org/TR/css-images-4/#invalid-image">https://www.w3.org/TR/css-images-4/#invalid-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">3.3.1. Fill Color: the fill-color property</a> <a href="#ref-for-invalid-image①">(2)</a>
     <li><a href="#ref-for-invalid-image②">3.3.7. Fill Shorthand: the fill property</a>
     <li><a href="#ref-for-invalid-image③">4.4.1. Stroke Color: the stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalid-image">
-   <a href="https://www.w3.org/TR/css-images-4/#invalid-image">https://www.w3.org/TR/css-images-4/#invalid-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalid-image" class="dfn-panel" data-for="term-for-invalid-image" id="infopanel-for-term-for-invalid-image①" role="menu">
+   <span id="infopaneltitle-for-term-for-invalid-image①" style="display:none">Info about the 'valid image' external reference.</span><a href="https://www.w3.org/TR/css-images-4/#invalid-image">https://www.w3.org/TR/css-images-4/#invalid-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalid-image">3.3.1. Fill Color: the fill-color property</a> <a href="#ref-for-invalid-image①">(2)</a>
     <li><a href="#ref-for-invalid-image②">3.3.7. Fill Shorthand: the fill property</a>
     <li><a href="#ref-for-invalid-image③">4.4.1. Stroke Color: the stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-invalid">
-   <a href="https://www.w3.org/TR/css-syntax-3/#css-invalid">https://www.w3.org/TR/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-invalid" class="dfn-panel" data-for="term-for-css-invalid" id="infopanel-for-term-for-css-invalid" role="menu">
+   <span id="infopaneltitle-for-term-for-css-invalid" style="display:none">Info about the 'invalid' external reference.</span><a href="https://www.w3.org/TR/css-syntax-3/#css-invalid">https://www.w3.org/TR/css-syntax-3/#css-invalid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-invalid">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://www.w3.org/TR/css-text-decor-4/#propdef-text-decoration">https://www.w3.org/TR/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://www.w3.org/TR/css-text-decor-4/#propdef-text-decoration">https://www.w3.org/TR/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">5. Text Decoration Fills and Strokes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-comma">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-comma">https://www.w3.org/TR/css-values-4/#mult-comma</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-comma" class="dfn-panel" data-for="term-for-mult-comma" id="infopanel-for-term-for-mult-comma" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-comma" style="display:none">Info about the '#' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-comma">https://www.w3.org/TR/css-values-4/#mult-comma</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-comma">3.3.2. Fill Image Sources: the fill-image property</a>
     <li><a href="#ref-for-mult-comma①">3.3.4. Positioning Fill Images: the fill-position property</a>
@@ -3373,61 +3373,61 @@ which takes the value from the element’s corresponding <a class="property css"
     <li><a href="#ref-for-mult-comma①⓪">4.4.6. Tiling Stroke Images: the stroke-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://www.w3.org/TR/css-values-4/#mult-one-plus">https://www.w3.org/TR/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#mult-one-plus">https://www.w3.org/TR/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">4.3.1. Stroke Dash Patterns: the stroke-dasharray property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integer-value">
-   <a href="https://www.w3.org/TR/css-values-4/#integer-value">https://www.w3.org/TR/css-values-4/#integer-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integer-value" class="dfn-panel" data-for="term-for-integer-value" id="infopanel-for-term-for-integer-value" role="menu">
+   <span id="infopaneltitle-for-term-for-integer-value" style="display:none">Info about the '&lt;integer>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#integer-value">https://www.w3.org/TR/css-values-4/#integer-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integer-value">2.1. SVG-Specific Paints</a> <a href="#ref-for-integer-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://www.w3.org/TR/css-values-4/#typedef-length-percentage">https://www.w3.org/TR/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#typedef-length-percentage">https://www.w3.org/TR/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.2.1. Stroke Thickness: the stroke-width property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a>
     <li><a href="#ref-for-typedef-length-percentage②">4.3.1. Stroke Dash Patterns: the stroke-dasharray property</a> <a href="#ref-for-typedef-length-percentage③">(2)</a> <a href="#ref-for-typedef-length-percentage④">(3)</a>
     <li><a href="#ref-for-typedef-length-percentage⑤">4.3.2. Stroke Dash Start Position: the stroke-dashoffset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#length-value">https://www.w3.org/TR/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#number-value">https://www.w3.org/TR/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.4.1. Fill Opacity: the fill-opacity property</a>
     <li><a href="#ref-for-number-value①">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a> <a href="#ref-for-number-value②">(2)</a>
     <li><a href="#ref-for-number-value③">4.5.1. Stroke Opacity: the stroke-opacity property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://www.w3.org/TR/css-values-4/#typedef-position">https://www.w3.org/TR/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#typedef-position">https://www.w3.org/TR/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">3.3.4. Positioning Fill Images: the fill-position property</a>
     <li><a href="#ref-for-typedef-position①">4.4.4. Positioning Stroke Images: the stroke-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://www.w3.org/TR/css-values-4/#url-value">https://www.w3.org/TR/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#url-value">https://www.w3.org/TR/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-functional-notation">
-   <a href="https://www.w3.org/TR/css-values-4/#functional-notation">https://www.w3.org/TR/css-values-4/#functional-notation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-functional-notation" class="dfn-panel" data-for="term-for-functional-notation" id="infopanel-for-term-for-functional-notation" role="menu">
+   <span id="infopaneltitle-for-term-for-functional-notation" style="display:none">Info about the 'functional notation' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#functional-notation">https://www.w3.org/TR/css-values-4/#functional-notation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-notation">2.1. SVG-Specific Paints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-one">https://www.w3.org/TR/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Paint</a> <a href="#ref-for-comb-one①">(2)</a>
     <li><a href="#ref-for-comb-one②">2.1. SVG-Specific Paints</a>
@@ -3443,117 +3443,117 @@ which takes the value from the element’s corresponding <a class="property css"
     <li><a href="#ref-for-comb-one②⑤">4.4.3. Stroke Positioning Area: the stroke-origin property</a> <a href="#ref-for-comb-one②⑥">(2)</a> <a href="#ref-for-comb-one②⑦">(3)</a> <a href="#ref-for-comb-one②⑧">(4)</a> <a href="#ref-for-comb-one②⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://www.w3.org/TR/css-values-4/#comb-any">https://www.w3.org/TR/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a>
     <li><a href="#ref-for-comb-any①">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-comb-any②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the '&lt;image>' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">2. Paint</a> <a href="#ref-for-typedef-image①">(2)</a>
     <li><a href="#ref-for-typedef-image②">3.3.2. Fill Image Sources: the fill-image property</a>
     <li><a href="#ref-for-typedef-image③">4.4.2. Stroke Image Sources: the stroke-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-ambiguous-image-url">
-   <a href="https://www.w3.org/TR/css-images-3/#css-ambiguous-image-url">https://www.w3.org/TR/css-images-3/#css-ambiguous-image-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-ambiguous-image-url" class="dfn-panel" data-for="term-for-css-ambiguous-image-url" id="infopanel-for-term-for-css-ambiguous-image-url" role="menu">
+   <span id="infopaneltitle-for-term-for-css-ambiguous-image-url" style="display:none">Info about the 'ambiguous image url' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#css-ambiguous-image-url">https://www.w3.org/TR/css-images-3/#css-ambiguous-image-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-ambiguous-image-url">2. Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-bg-size">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-bg-size">https://www.w3.org/TR/css-backgrounds-3/#typedef-bg-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-bg-size" class="dfn-panel" data-for="term-for-typedef-bg-size" id="infopanel-for-term-for-typedef-bg-size" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-bg-size" style="display:none">Info about the '&lt;bg-size>' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-bg-size">https://www.w3.org/TR/css-backgrounds-3/#typedef-bg-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-bg-size">3.3.5. Sizing Fill Images: the fill-size property</a>
     <li><a href="#ref-for-typedef-bg-size①">4.4.5. Sizing Stroke Images: the stroke-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-repeat-style">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-repeat-style">https://www.w3.org/TR/css-backgrounds-3/#typedef-repeat-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-repeat-style" class="dfn-panel" data-for="term-for-typedef-repeat-style" id="infopanel-for-term-for-typedef-repeat-style" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-repeat-style" style="display:none">Info about the '&lt;repeat-style>' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#typedef-repeat-style">https://www.w3.org/TR/css-backgrounds-3/#typedef-repeat-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-repeat-style">3.3.6. Tiling Fill Images: the fill-repeat property</a>
     <li><a href="#ref-for-typedef-repeat-style①">4.4.6. Tiling Stroke Images: the stroke-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-size-auto">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#valdef-background-size-auto">https://www.w3.org/TR/css-backgrounds-3/#valdef-background-size-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-size-auto" class="dfn-panel" data-for="term-for-valdef-background-size-auto" id="infopanel-for-term-for-valdef-background-size-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-size-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#valdef-background-size-auto">https://www.w3.org/TR/css-backgrounds-3/#valdef-background-size-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-size-auto">3.3.5. Sizing Fill Images: the fill-size property</a>
     <li><a href="#ref-for-valdef-background-size-auto①">4.4.5. Sizing Stroke Images: the stroke-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background">https://www.w3.org/TR/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background">https://www.w3.org/TR/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">3.3.7. Fill Shorthand: the fill property</a> <a href="#ref-for-propdef-background①">(2)</a> <a href="#ref-for-propdef-background②">(3)</a>
     <li><a href="#ref-for-propdef-background③">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-color">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-color">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3.3.1. Fill Color: the fill-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.3.2. Fill Image Sources: the fill-image property</a>
     <li><a href="#ref-for-propdef-background-image①">4.4.2. Stroke Image Sources: the stroke-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-position">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-position">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">3.3.4. Positioning Fill Images: the fill-position property</a>
     <li><a href="#ref-for-propdef-background-position①">4.4.4. Positioning Stroke Images: the stroke-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-repeat">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-repeat">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-repeat" class="dfn-panel" data-for="term-for-propdef-background-repeat" id="infopanel-for-term-for-propdef-background-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-repeat" style="display:none">Info about the 'background-repeat' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-repeat">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-repeat">3.3.6. Tiling Fill Images: the fill-repeat property</a>
     <li><a href="#ref-for-propdef-background-repeat①">4.4.6. Tiling Stroke Images: the stroke-repeat property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-size">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-size">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">3.3.5. Sizing Fill Images: the fill-size property</a>
     <li><a href="#ref-for-propdef-background-size①">4.4.5. Sizing Stroke Images: the stroke-size property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermEquivalentPath">
-   <a href="https://www.w3.org/TR/SVG2/paths.html#TermEquivalentPath">https://www.w3.org/TR/SVG2/paths.html#TermEquivalentPath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermEquivalentPath" class="dfn-panel" data-for="term-for-TermEquivalentPath" id="infopanel-for-term-for-TermEquivalentPath" role="menu">
+   <span id="infopaneltitle-for-term-for-TermEquivalentPath" style="display:none">Info about the 'equivalent path' external reference.</span><a href="https://www.w3.org/TR/SVG2/paths.html#TermEquivalentPath">https://www.w3.org/TR/SVG2/paths.html#TermEquivalentPath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermEquivalentPath">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a>
     <li><a href="#ref-for-TermEquivalentPath①">4.6.2. Stroke Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermObjectBoundingBox">
-   <a href="https://www.w3.org/TR/SVG2/coords.html#TermObjectBoundingBox">https://www.w3.org/TR/SVG2/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermObjectBoundingBox" class="dfn-panel" data-for="term-for-TermObjectBoundingBox" id="infopanel-for-term-for-TermObjectBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermObjectBoundingBox" style="display:none">Info about the 'object bounding box' external reference.</span><a href="https://www.w3.org/TR/SVG2/coords.html#TermObjectBoundingBox">https://www.w3.org/TR/SVG2/coords.html#TermObjectBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermObjectBoundingBox">3.3.3. Fill Positioning Area: the fill-origin property</a>
     <li><a href="#ref-for-TermObjectBoundingBox①">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPaintServerElement">
-   <a href="https://www.w3.org/TR/SVG2/painting.html#TermPaintServerElement">https://www.w3.org/TR/SVG2/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPaintServerElement" class="dfn-panel" data-for="term-for-TermPaintServerElement" id="infopanel-for-term-for-TermPaintServerElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPaintServerElement" style="display:none">Info about the 'paint server element' external reference.</span><a href="https://www.w3.org/TR/SVG2/painting.html#TermPaintServerElement">https://www.w3.org/TR/SVG2/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPaintServerElement">2.1. SVG-Specific Paints</a> <a href="#ref-for-TermPaintServerElement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PaintOrderProperty">
-   <a href="https://www.w3.org/TR/SVG2/painting.html#PaintOrderProperty">https://www.w3.org/TR/SVG2/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PaintOrderProperty" class="dfn-panel" data-for="term-for-PaintOrderProperty" id="infopanel-for-term-for-PaintOrderProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-PaintOrderProperty" style="display:none">Info about the 'paint-order' external reference.</span><a href="https://www.w3.org/TR/SVG2/painting.html#PaintOrderProperty">https://www.w3.org/TR/SVG2/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PaintOrderProperty">4. Strokes (Outlines)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-path">
-   <a href="https://www.w3.org/TR/SVG2/paths.html#elementdef-path">https://www.w3.org/TR/SVG2/paths.html#elementdef-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-path" class="dfn-panel" data-for="term-for-elementdef-path" id="infopanel-for-term-for-elementdef-path" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-path" style="display:none">Info about the 'path' external reference.</span><a href="https://www.w3.org/TR/SVG2/paths.html#elementdef-path">https://www.w3.org/TR/SVG2/paths.html#elementdef-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-path">1. Introduction</a>
     <li><a href="#ref-for-elementdef-path①">4.2.3. Stroke End Shapes: the stroke-linecap property</a>
@@ -3562,27 +3562,27 @@ which takes the value from the element’s corresponding <a class="property css"
     <li><a href="#ref-for-elementdef-path⑤">4.6.3. Dash Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://www.w3.org/TR/SVG2/pservers.html#elementdef-pattern">https://www.w3.org/TR/SVG2/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://www.w3.org/TR/SVG2/pservers.html#elementdef-pattern">https://www.w3.org/TR/SVG2/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">4.6.1. Stroke Paths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-rect">
-   <a href="https://www.w3.org/TR/SVG2/shapes.html#elementdef-rect">https://www.w3.org/TR/SVG2/shapes.html#elementdef-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-rect" class="dfn-panel" data-for="term-for-elementdef-rect" id="infopanel-for-term-for-elementdef-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-rect" style="display:none">Info about the 'rect' external reference.</span><a href="https://www.w3.org/TR/SVG2/shapes.html#elementdef-rect">https://www.w3.org/TR/SVG2/shapes.html#elementdef-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-rect">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStrokeBoundingBox">
-   <a href="https://www.w3.org/TR/SVG2/coords.html#TermStrokeBoundingBox">https://www.w3.org/TR/SVG2/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStrokeBoundingBox" class="dfn-panel" data-for="term-for-TermStrokeBoundingBox" id="infopanel-for-term-for-TermStrokeBoundingBox" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStrokeBoundingBox" style="display:none">Info about the 'stroke bounding box' external reference.</span><a href="https://www.w3.org/TR/SVG2/coords.html#TermStrokeBoundingBox">https://www.w3.org/TR/SVG2/coords.html#TermStrokeBoundingBox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStrokeBoundingBox">3.3.3. Fill Positioning Area: the fill-origin property</a>
     <li><a href="#ref-for-TermStrokeBoundingBox①">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-repeatable-list">
-   <a href="https://www.w3.org/TR/web-animations-1/#repeatable-list">https://www.w3.org/TR/web-animations-1/#repeatable-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-repeatable-list" class="dfn-panel" data-for="term-for-repeatable-list" id="infopanel-for-term-for-repeatable-list" role="menu">
+   <span id="infopaneltitle-for-term-for-repeatable-list" style="display:none">Info about the 'repeatable list' external reference.</span><a href="https://www.w3.org/TR/web-animations-1/#repeatable-list">https://www.w3.org/TR/web-animations-1/#repeatable-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-repeatable-list">3.3.4. Positioning Fill Images: the fill-position property</a>
     <li><a href="#ref-for-repeatable-list①">3.3.5. Sizing Fill Images: the fill-size property</a>
@@ -4217,8 +4217,8 @@ Light gray represents dash pattern based on center of inset path.</p>
    <div class="issue"> These should definitely be at-risk,
 	possibly deferred to the next level. <a class="issue-return" href="#issue-c8b0ec40" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="typedef-paint">
-   <b><a href="#typedef-paint">#typedef-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-paint" class="dfn-panel" data-for="typedef-paint" id="infopanel-for-typedef-paint" role="dialog">
+   <span id="infopaneltitle-for-typedef-paint" style="display:none">Info about the '&lt;paint>' definition.</span><b><a href="#typedef-paint">#typedef-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-paint">2. Paint</a>
     <li><a href="#ref-for-typedef-paint①">2.1. SVG-Specific Paints</a>
@@ -4226,20 +4226,20 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-typedef-paint③">4.4.2. Stroke Image Sources: the stroke-image property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-paint-none">
-   <b><a href="#valdef-paint-none">#valdef-paint-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-paint-none" class="dfn-panel" data-for="valdef-paint-none" id="infopanel-for-valdef-paint-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-paint-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-paint-none">#valdef-paint-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-paint-none">2.1. SVG-Specific Paints</a> <a href="#ref-for-valdef-paint-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-svg-paint">
-   <b><a href="#typedef-svg-paint">#typedef-svg-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-svg-paint" class="dfn-panel" data-for="typedef-svg-paint" id="infopanel-for-typedef-svg-paint" role="dialog">
+   <span id="infopaneltitle-for-typedef-svg-paint" style="display:none">Info about the '&lt;svg-paint>' definition.</span><b><a href="#typedef-svg-paint">#typedef-svg-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-svg-paint">2. Paint</a> <a href="#ref-for-typedef-svg-paint①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fill">
-   <b><a href="#fill">#fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fill" class="dfn-panel" data-for="fill" id="infopanel-for-fill" role="dialog">
+   <span id="infopaneltitle-for-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#fill">#fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill">3. Fills</a> <a href="#ref-for-fill①">(2)</a>
     <li><a href="#ref-for-fill②">3.2.2. Fragmented Fills: the fill-break property</a>
@@ -4247,41 +4247,41 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-fill④">4. Strokes (Outlines)</a> <a href="#ref-for-fill⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-rule">
-   <b><a href="#propdef-fill-rule">#propdef-fill-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-rule" class="dfn-panel" data-for="propdef-fill-rule" id="infopanel-for-propdef-fill-rule" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-rule" style="display:none">Info about the 'fill-rule' definition.</span><b><a href="#propdef-fill-rule">#propdef-fill-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-rule">3.2.1. Winding Rule for SVG shapes: the fill-rule property</a> <a href="#ref-for-propdef-fill-rule①">(2)</a> <a href="#ref-for-propdef-fill-rule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-rule-nonzero">
-   <b><a href="#valdef-fill-rule-nonzero">#valdef-fill-rule-nonzero</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-rule-nonzero" class="dfn-panel" data-for="valdef-fill-rule-nonzero" id="infopanel-for-valdef-fill-rule-nonzero" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-rule-nonzero" style="display:none">Info about the 'nonzero' definition.</span><b><a href="#valdef-fill-rule-nonzero">#valdef-fill-rule-nonzero</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-rule-nonzero">4.2.2. Stroke Positioning: the stroke-align property</a> <a href="#ref-for-valdef-fill-rule-nonzero①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-rule-evenodd">
-   <b><a href="#valdef-fill-rule-evenodd">#valdef-fill-rule-evenodd</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-rule-evenodd" class="dfn-panel" data-for="valdef-fill-rule-evenodd" id="infopanel-for-valdef-fill-rule-evenodd" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-rule-evenodd" style="display:none">Info about the 'evenodd' definition.</span><b><a href="#valdef-fill-rule-evenodd">#valdef-fill-rule-evenodd</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-rule-evenodd">4.2.2. Stroke Positioning: the stroke-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-break">
-   <b><a href="#propdef-fill-break">#propdef-fill-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-break" class="dfn-panel" data-for="propdef-fill-break" id="infopanel-for-propdef-fill-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-break" style="display:none">Info about the 'fill-break' definition.</span><b><a href="#propdef-fill-break">#propdef-fill-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-break">3. Fills</a>
     <li><a href="#ref-for-propdef-fill-break①">3.2.2. Fragmented Fills: the fill-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-color">
-   <b><a href="#propdef-fill-color">#propdef-fill-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-color" class="dfn-panel" data-for="propdef-fill-color" id="infopanel-for-propdef-fill-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-color" style="display:none">Info about the 'fill-color' definition.</span><b><a href="#propdef-fill-color">#propdef-fill-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-color">3. Fills</a>
     <li><a href="#ref-for-propdef-fill-color①">3.3.1. Fill Color: the fill-color property</a> <a href="#ref-for-propdef-fill-color②">(2)</a> <a href="#ref-for-propdef-fill-color③">(3)</a>
     <li><a href="#ref-for-propdef-fill-color④">3.3.7. Fill Shorthand: the fill property</a> <a href="#ref-for-propdef-fill-color⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-image">
-   <b><a href="#propdef-fill-image">#propdef-fill-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-image" class="dfn-panel" data-for="propdef-fill-image" id="infopanel-for-propdef-fill-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-image" style="display:none">Info about the 'fill-image' definition.</span><b><a href="#propdef-fill-image">#propdef-fill-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-image">3. Fills</a>
     <li><a href="#ref-for-propdef-fill-image①">3.1. Layering Multiple Fills</a>
@@ -4290,80 +4290,80 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-fill-image④">3.3.7. Fill Shorthand: the fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-origin">
-   <b><a href="#propdef-fill-origin">#propdef-fill-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-origin" class="dfn-panel" data-for="propdef-fill-origin" id="infopanel-for-propdef-fill-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-origin" style="display:none">Info about the 'fill-origin' definition.</span><b><a href="#propdef-fill-origin">#propdef-fill-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-origin">3.3.3. Fill Positioning Area: the fill-origin property</a>
     <li><a href="#ref-for-propdef-fill-origin①">3.3.7. Fill Shorthand: the fill property</a> <a href="#ref-for-propdef-fill-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fill-positioning-area">
-   <b><a href="#fill-positioning-area">#fill-positioning-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fill-positioning-area" class="dfn-panel" data-for="fill-positioning-area" id="infopanel-for-fill-positioning-area" role="dialog">
+   <span id="infopaneltitle-for-fill-positioning-area" style="display:none">Info about the 'fill positioning area' definition.</span><b><a href="#fill-positioning-area">#fill-positioning-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-positioning-area">3.3.3. Fill Positioning Area: the fill-origin property</a> <a href="#ref-for-fill-positioning-area①">(2)</a>
     <li><a href="#ref-for-fill-positioning-area②">3.3.4. Positioning Fill Images: the fill-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-match-parent">
-   <b><a href="#valdef-fill-origin-match-parent">#valdef-fill-origin-match-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-match-parent" class="dfn-panel" data-for="valdef-fill-origin-match-parent" id="infopanel-for-valdef-fill-origin-match-parent" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-match-parent" style="display:none">Info about the 'match-parent' definition.</span><b><a href="#valdef-fill-origin-match-parent">#valdef-fill-origin-match-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-match-parent">3.3.3. Fill Positioning Area: the fill-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-content-box">
-   <b><a href="#valdef-fill-origin-content-box">#valdef-fill-origin-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-content-box" class="dfn-panel" data-for="valdef-fill-origin-content-box" id="infopanel-for-valdef-fill-origin-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-fill-origin-content-box">#valdef-fill-origin-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-content-box">3.3.3. Fill Positioning Area: the fill-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-padding-box">
-   <b><a href="#valdef-fill-origin-padding-box">#valdef-fill-origin-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-padding-box" class="dfn-panel" data-for="valdef-fill-origin-padding-box" id="infopanel-for-valdef-fill-origin-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-fill-origin-padding-box">#valdef-fill-origin-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-padding-box">3.3.3. Fill Positioning Area: the fill-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-border-box">
-   <b><a href="#valdef-fill-origin-border-box">#valdef-fill-origin-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-border-box" class="dfn-panel" data-for="valdef-fill-origin-border-box" id="infopanel-for-valdef-fill-origin-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-fill-origin-border-box">#valdef-fill-origin-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-border-box">3.3.3. Fill Positioning Area: the fill-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-fill-box">
-   <b><a href="#valdef-fill-origin-fill-box">#valdef-fill-origin-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-fill-box" class="dfn-panel" data-for="valdef-fill-origin-fill-box" id="infopanel-for-valdef-fill-origin-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-fill-origin-fill-box">#valdef-fill-origin-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-fill-box">3.3.3. Fill Positioning Area: the fill-origin property</a>
     <li><a href="#ref-for-valdef-fill-origin-fill-box①">3.3.7. Fill Shorthand: the fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-fill-origin-stroke-box">
-   <b><a href="#valdef-fill-origin-stroke-box">#valdef-fill-origin-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-fill-origin-stroke-box" class="dfn-panel" data-for="valdef-fill-origin-stroke-box" id="infopanel-for-valdef-fill-origin-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-fill-origin-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-fill-origin-stroke-box">#valdef-fill-origin-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-fill-origin-stroke-box">3.3.3. Fill Positioning Area: the fill-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-position">
-   <b><a href="#propdef-fill-position">#propdef-fill-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-position" class="dfn-panel" data-for="propdef-fill-position" id="infopanel-for-propdef-fill-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-position" style="display:none">Info about the 'fill-position' definition.</span><b><a href="#propdef-fill-position">#propdef-fill-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-position">3.3.4. Positioning Fill Images: the fill-position property</a>
     <li><a href="#ref-for-propdef-fill-position①">3.3.7. Fill Shorthand: the fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-size">
-   <b><a href="#propdef-fill-size">#propdef-fill-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-size" class="dfn-panel" data-for="propdef-fill-size" id="infopanel-for-propdef-fill-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-size" style="display:none">Info about the 'fill-size' definition.</span><b><a href="#propdef-fill-size">#propdef-fill-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-size">3.3.5. Sizing Fill Images: the fill-size property</a>
     <li><a href="#ref-for-propdef-fill-size①">3.3.7. Fill Shorthand: the fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-repeat">
-   <b><a href="#propdef-fill-repeat">#propdef-fill-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-repeat" class="dfn-panel" data-for="propdef-fill-repeat" id="infopanel-for-propdef-fill-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-repeat" style="display:none">Info about the 'fill-repeat' definition.</span><b><a href="#propdef-fill-repeat">#propdef-fill-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-repeat">3.3.6. Tiling Fill Images: the fill-repeat property</a>
     <li><a href="#ref-for-propdef-fill-repeat①">3.3.7. Fill Shorthand: the fill property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill">
-   <b><a href="#propdef-fill">#propdef-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill" class="dfn-panel" data-for="propdef-fill" id="infopanel-for-propdef-fill" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#propdef-fill">#propdef-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill">2.1. SVG-Specific Paints</a>
     <li><a href="#ref-for-propdef-fill①">3. Fills</a>
@@ -4372,14 +4372,14 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-fill⑦">5. Text Decoration Fills and Strokes</a> <a href="#ref-for-propdef-fill⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-fill-opacity">
-   <b><a href="#propdef-fill-opacity">#propdef-fill-opacity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-fill-opacity" class="dfn-panel" data-for="propdef-fill-opacity" id="infopanel-for-propdef-fill-opacity" role="dialog">
+   <span id="infopaneltitle-for-propdef-fill-opacity" style="display:none">Info about the 'fill-opacity' definition.</span><b><a href="#propdef-fill-opacity">#propdef-fill-opacity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill-opacity">3.4.1. Fill Opacity: the fill-opacity property</a> <a href="#ref-for-propdef-fill-opacity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stroke">
-   <b><a href="#stroke">#stroke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stroke" class="dfn-panel" data-for="stroke" id="infopanel-for-stroke" role="dialog">
+   <span id="infopaneltitle-for-stroke" style="display:none">Info about the 'stroke' definition.</span><b><a href="#stroke">#stroke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stroke">4. Strokes (Outlines)</a> <a href="#ref-for-stroke①">(2)</a> <a href="#ref-for-stroke②">(3)</a>
     <li><a href="#ref-for-stroke③">4.2.2. Stroke Positioning: the stroke-align property</a>
@@ -4387,8 +4387,8 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-stroke⑤">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-width">
-   <b><a href="#propdef-stroke-width">#propdef-stroke-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-width" class="dfn-panel" data-for="propdef-stroke-width" id="infopanel-for-propdef-stroke-width" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-width" style="display:none">Info about the 'stroke-width' definition.</span><b><a href="#propdef-stroke-width">#propdef-stroke-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-width">4.2. Stroke Geometry</a>
     <li><a href="#ref-for-propdef-stroke-width①">4.2.1. Stroke Thickness: the stroke-width property</a>
@@ -4399,140 +4399,140 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-stroke-width①③">4.6.6. Arcs Linejoin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scaled-viewport-size">
-   <b><a href="#scaled-viewport-size">#scaled-viewport-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scaled-viewport-size" class="dfn-panel" data-for="scaled-viewport-size" id="infopanel-for-scaled-viewport-size" role="dialog">
+   <span id="infopaneltitle-for-scaled-viewport-size" style="display:none">Info about the 'scaled viewport size' definition.</span><b><a href="#scaled-viewport-size">#scaled-viewport-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scaled-viewport-size">4.2.1. Stroke Thickness: the stroke-width property</a>
     <li><a href="#ref-for-scaled-viewport-size①">4.3.1. Stroke Dash Patterns: the stroke-dasharray property</a>
     <li><a href="#ref-for-scaled-viewport-size②">4.3.2. Stroke Dash Start Position: the stroke-dashoffset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-align">
-   <b><a href="#propdef-stroke-align">#propdef-stroke-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-align" class="dfn-panel" data-for="propdef-stroke-align" id="infopanel-for-propdef-stroke-align" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-align" style="display:none">Info about the 'stroke-align' definition.</span><b><a href="#propdef-stroke-align">#propdef-stroke-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-align">4.2.2. Stroke Positioning: the stroke-align property</a> <a href="#ref-for-propdef-stroke-align①">(2)</a> <a href="#ref-for-propdef-stroke-align②">(3)</a> <a href="#ref-for-propdef-stroke-align③">(4)</a> <a href="#ref-for-propdef-stroke-align④">(5)</a> <a href="#ref-for-propdef-stroke-align⑤">(6)</a> <a href="#ref-for-propdef-stroke-align⑥">(7)</a>
     <li><a href="#ref-for-propdef-stroke-align⑦">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-align-center">
-   <b><a href="#valdef-stroke-align-center">#valdef-stroke-align-center</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-align-center" class="dfn-panel" data-for="valdef-stroke-align-center" id="infopanel-for-valdef-stroke-align-center" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-align-center" style="display:none">Info about the 'center' definition.</span><b><a href="#valdef-stroke-align-center">#valdef-stroke-align-center</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-align-center">4.2.2. Stroke Positioning: the stroke-align property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-align-inset">
-   <b><a href="#valdef-stroke-align-inset">#valdef-stroke-align-inset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-align-inset" class="dfn-panel" data-for="valdef-stroke-align-inset" id="infopanel-for-valdef-stroke-align-inset" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-align-inset" style="display:none">Info about the 'inset' definition.</span><b><a href="#valdef-stroke-align-inset">#valdef-stroke-align-inset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-align-inset">4.2.2. Stroke Positioning: the stroke-align property</a> <a href="#ref-for-valdef-stroke-align-inset①">(2)</a> <a href="#ref-for-valdef-stroke-align-inset②">(3)</a>
     <li><a href="#ref-for-valdef-stroke-align-inset③">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-align-outset">
-   <b><a href="#valdef-stroke-align-outset">#valdef-stroke-align-outset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-align-outset" class="dfn-panel" data-for="valdef-stroke-align-outset" id="infopanel-for-valdef-stroke-align-outset" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-align-outset" style="display:none">Info about the 'outset' definition.</span><b><a href="#valdef-stroke-align-outset">#valdef-stroke-align-outset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-align-outset">4.2.2. Stroke Positioning: the stroke-align property</a> <a href="#ref-for-valdef-stroke-align-outset①">(2)</a> <a href="#ref-for-valdef-stroke-align-outset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-linecap">
-   <b><a href="#propdef-stroke-linecap">#propdef-stroke-linecap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-linecap" class="dfn-panel" data-for="propdef-stroke-linecap" id="infopanel-for-propdef-stroke-linecap" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-linecap" style="display:none">Info about the 'stroke-linecap' definition.</span><b><a href="#propdef-stroke-linecap">#propdef-stroke-linecap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-linecap">4.2.3. Stroke End Shapes: the stroke-linecap property</a> <a href="#ref-for-propdef-stroke-linecap①">(2)</a>
     <li><a href="#ref-for-propdef-stroke-linecap②">4.6.1. Stroke Paths</a> <a href="#ref-for-propdef-stroke-linecap③">(2)</a>
     <li><a href="#ref-for-propdef-stroke-linecap④">4.6.4. Cap Shapes</a> <a href="#ref-for-propdef-stroke-linecap⑤">(2)</a> <a href="#ref-for-propdef-stroke-linecap⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linecap-butt">
-   <b><a href="#valdef-stroke-linecap-butt">#valdef-stroke-linecap-butt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linecap-butt" class="dfn-panel" data-for="valdef-stroke-linecap-butt" id="infopanel-for-valdef-stroke-linecap-butt" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linecap-butt" style="display:none">Info about the 'butt' definition.</span><b><a href="#valdef-stroke-linecap-butt">#valdef-stroke-linecap-butt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linecap-butt">4.6.1. Stroke Paths</a>
     <li><a href="#ref-for-valdef-stroke-linecap-butt①">4.6.4. Cap Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linecap-round">
-   <b><a href="#valdef-stroke-linecap-round">#valdef-stroke-linecap-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linecap-round" class="dfn-panel" data-for="valdef-stroke-linecap-round" id="infopanel-for-valdef-stroke-linecap-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linecap-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-stroke-linecap-round">#valdef-stroke-linecap-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linecap-round">4.6.1. Stroke Paths</a>
     <li><a href="#ref-for-valdef-stroke-linecap-round①">4.6.4. Cap Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linecap-square">
-   <b><a href="#valdef-stroke-linecap-square">#valdef-stroke-linecap-square</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linecap-square" class="dfn-panel" data-for="valdef-stroke-linecap-square" id="infopanel-for-valdef-stroke-linecap-square" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linecap-square" style="display:none">Info about the 'square' definition.</span><b><a href="#valdef-stroke-linecap-square">#valdef-stroke-linecap-square</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linecap-square">4.6.1. Stroke Paths</a>
     <li><a href="#ref-for-valdef-stroke-linecap-square①">4.6.4. Cap Shapes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-linejoin">
-   <b><a href="#propdef-stroke-linejoin">#propdef-stroke-linejoin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-linejoin" class="dfn-panel" data-for="propdef-stroke-linejoin" id="infopanel-for-propdef-stroke-linejoin" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-linejoin" style="display:none">Info about the 'stroke-linejoin' definition.</span><b><a href="#propdef-stroke-linejoin">#propdef-stroke-linejoin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-linejoin">4.2.2. Stroke Positioning: the stroke-align property</a> <a href="#ref-for-propdef-stroke-linejoin①">(2)</a>
     <li><a href="#ref-for-propdef-stroke-linejoin②">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a> <a href="#ref-for-propdef-stroke-linejoin③">(2)</a>
     <li><a href="#ref-for-propdef-stroke-linejoin④">4.6.5. Line Join Shape</a> <a href="#ref-for-propdef-stroke-linejoin⑤">(2)</a> <a href="#ref-for-propdef-stroke-linejoin⑥">(3)</a> <a href="#ref-for-propdef-stroke-linejoin⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-crop">
-   <b><a href="#valdef-stroke-linejoin-crop">#valdef-stroke-linejoin-crop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-crop" class="dfn-panel" data-for="valdef-stroke-linejoin-crop" id="infopanel-for-valdef-stroke-linejoin-crop" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-crop" style="display:none">Info about the 'crop' definition.</span><b><a href="#valdef-stroke-linejoin-crop">#valdef-stroke-linejoin-crop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-crop">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-miter">
-   <b><a href="#valdef-stroke-linejoin-miter">#valdef-stroke-linejoin-miter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-miter" class="dfn-panel" data-for="valdef-stroke-linejoin-miter" id="infopanel-for-valdef-stroke-linejoin-miter" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-miter" style="display:none">Info about the 'miter' definition.</span><b><a href="#valdef-stroke-linejoin-miter">#valdef-stroke-linejoin-miter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-miter">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a>
     <li><a href="#ref-for-valdef-stroke-linejoin-miter①">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a> <a href="#ref-for-valdef-stroke-linejoin-miter②">(2)</a>
     <li><a href="#ref-for-valdef-stroke-linejoin-miter③">4.6.5. Line Join Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-arcs">
-   <b><a href="#valdef-stroke-linejoin-arcs">#valdef-stroke-linejoin-arcs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-arcs" class="dfn-panel" data-for="valdef-stroke-linejoin-arcs" id="infopanel-for-valdef-stroke-linejoin-arcs" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-arcs" style="display:none">Info about the 'arcs' definition.</span><b><a href="#valdef-stroke-linejoin-arcs">#valdef-stroke-linejoin-arcs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-arcs">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a> <a href="#ref-for-valdef-stroke-linejoin-arcs①">(2)</a>
     <li><a href="#ref-for-valdef-stroke-linejoin-arcs②">4.6.5. Line Join Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-bevel">
-   <b><a href="#valdef-stroke-linejoin-bevel">#valdef-stroke-linejoin-bevel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-bevel" class="dfn-panel" data-for="valdef-stroke-linejoin-bevel" id="infopanel-for-valdef-stroke-linejoin-bevel" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-bevel" style="display:none">Info about the 'bevel' definition.</span><b><a href="#valdef-stroke-linejoin-bevel">#valdef-stroke-linejoin-bevel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-bevel">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-round">
-   <b><a href="#valdef-stroke-linejoin-round">#valdef-stroke-linejoin-round</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-round" class="dfn-panel" data-for="valdef-stroke-linejoin-round" id="infopanel-for-valdef-stroke-linejoin-round" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-round" style="display:none">Info about the 'round' definition.</span><b><a href="#valdef-stroke-linejoin-round">#valdef-stroke-linejoin-round</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-round">4.6.5. Line Join Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-linejoin-fallback">
-   <b><a href="#valdef-stroke-linejoin-fallback">#valdef-stroke-linejoin-fallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-linejoin-fallback" class="dfn-panel" data-for="valdef-stroke-linejoin-fallback" id="infopanel-for-valdef-stroke-linejoin-fallback" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-linejoin-fallback" style="display:none">Info about the 'fallback' definition.</span><b><a href="#valdef-stroke-linejoin-fallback">#valdef-stroke-linejoin-fallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-linejoin-fallback">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a> <a href="#ref-for-valdef-stroke-linejoin-fallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-miterlimit">
-   <b><a href="#propdef-stroke-miterlimit">#propdef-stroke-miterlimit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-miterlimit" class="dfn-panel" data-for="propdef-stroke-miterlimit" id="infopanel-for-propdef-stroke-miterlimit" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-miterlimit" style="display:none">Info about the 'stroke-miterlimit' definition.</span><b><a href="#propdef-stroke-miterlimit">#propdef-stroke-miterlimit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-miterlimit">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a> <a href="#ref-for-propdef-stroke-miterlimit①">(2)</a> <a href="#ref-for-propdef-stroke-miterlimit②">(3)</a> <a href="#ref-for-propdef-stroke-miterlimit③">(4)</a>
     <li><a href="#ref-for-propdef-stroke-miterlimit④">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a>
     <li><a href="#ref-for-propdef-stroke-miterlimit⑤">4.6.5. Line Join Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="--corner-diagonal">
-   <b><a href="#--corner-diagonal">#--corner-diagonal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for---corner-diagonal" class="dfn-panel" data-for="--corner-diagonal" id="infopanel-for---corner-diagonal" role="dialog">
+   <span id="infopaneltitle-for---corner-diagonal" style="display:none">Info about the 'diagonal' definition.</span><b><a href="#--corner-diagonal">#--corner-diagonal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for---corner-diagonal">4.2.4. Stroke Corner Shapes: the stroke-linejoin property</a>
     <li><a href="#ref-for---corner-diagonal①">4.2.5. Stroke Corner Limits: the stroke-miterlimit property</a> <a href="#ref-for---corner-diagonal②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-break">
-   <b><a href="#propdef-stroke-break">#propdef-stroke-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-break" class="dfn-panel" data-for="propdef-stroke-break" id="infopanel-for-propdef-stroke-break" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-break" style="display:none">Info about the 'stroke-break' definition.</span><b><a href="#propdef-stroke-break">#propdef-stroke-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-break">3. Fills</a>
     <li><a href="#ref-for-propdef-stroke-break①">4.2.6. Fragmented Strokes: the stroke-break property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-dasharray">
-   <b><a href="#propdef-stroke-dasharray">#propdef-stroke-dasharray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-dasharray" class="dfn-panel" data-for="propdef-stroke-dasharray" id="infopanel-for-propdef-stroke-dasharray" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-dasharray" style="display:none">Info about the 'stroke-dasharray' definition.</span><b><a href="#propdef-stroke-dasharray">#propdef-stroke-dasharray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dasharray">4.2. Stroke Geometry</a>
     <li><a href="#ref-for-propdef-stroke-dasharray①">4.3.1. Stroke Dash Patterns: the stroke-dasharray property</a>
@@ -4540,65 +4540,65 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-stroke-dasharray③">4.6.3. Dash Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dasharray-none">
-   <b><a href="#valdef-stroke-dasharray-none">#valdef-stroke-dasharray-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dasharray-none" class="dfn-panel" data-for="valdef-stroke-dasharray-none" id="infopanel-for-valdef-stroke-dasharray-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dasharray-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-stroke-dasharray-none">#valdef-stroke-dasharray-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dasharray-none">4.3.1. Stroke Dash Patterns: the stroke-dasharray property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-dashoffset">
-   <b><a href="#propdef-stroke-dashoffset">#propdef-stroke-dashoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-dashoffset" class="dfn-panel" data-for="propdef-stroke-dashoffset" id="infopanel-for-propdef-stroke-dashoffset" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-dashoffset" style="display:none">Info about the 'stroke-dashoffset' definition.</span><b><a href="#propdef-stroke-dashoffset">#propdef-stroke-dashoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dashoffset">4.3.2. Stroke Dash Start Position: the stroke-dashoffset property</a>
     <li><a href="#ref-for-propdef-stroke-dashoffset①">4.6.3. Dash Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-dash-corner">
-   <b><a href="#propdef-stroke-dash-corner">#propdef-stroke-dash-corner</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-dash-corner" class="dfn-panel" data-for="propdef-stroke-dash-corner" id="infopanel-for-propdef-stroke-dash-corner" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-dash-corner" style="display:none">Info about the 'stroke-dash-corner' definition.</span><b><a href="#propdef-stroke-dash-corner">#propdef-stroke-dash-corner</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dash-corner">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-propdef-stroke-dash-corner①">(2)</a> <a href="#ref-for-propdef-stroke-dash-corner②">(3)</a> <a href="#ref-for-propdef-stroke-dash-corner③">(4)</a> <a href="#ref-for-propdef-stroke-dash-corner④">(5)</a> <a href="#ref-for-propdef-stroke-dash-corner⑤">(6)</a>
     <li><a href="#ref-for-propdef-stroke-dash-corner⑥">4.6.3. Dash Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dash-corner-none">
-   <b><a href="#valdef-stroke-dash-corner-none">#valdef-stroke-dash-corner-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dash-corner-none" class="dfn-panel" data-for="valdef-stroke-dash-corner-none" id="infopanel-for-valdef-stroke-dash-corner-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dash-corner-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-stroke-dash-corner-none">#valdef-stroke-dash-corner-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dash-corner-none">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-valdef-stroke-dash-corner-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-dash-justify">
-   <b><a href="#propdef-stroke-dash-justify">#propdef-stroke-dash-justify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-dash-justify" class="dfn-panel" data-for="propdef-stroke-dash-justify" id="infopanel-for-propdef-stroke-dash-justify" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-dash-justify" style="display:none">Info about the 'stroke-dash-justify' definition.</span><b><a href="#propdef-stroke-dash-justify">#propdef-stroke-dash-justify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-dash-justify">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-propdef-stroke-dash-justify①">(2)</a>
     <li><a href="#ref-for-propdef-stroke-dash-justify②">4.6.3. Dash Positions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dash-justify-stretch">
-   <b><a href="#valdef-stroke-dash-justify-stretch">#valdef-stroke-dash-justify-stretch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dash-justify-stretch" class="dfn-panel" data-for="valdef-stroke-dash-justify-stretch" id="infopanel-for-valdef-stroke-dash-justify-stretch" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dash-justify-stretch" style="display:none">Info about the 'stretch' definition.</span><b><a href="#valdef-stroke-dash-justify-stretch">#valdef-stroke-dash-justify-stretch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dash-justify-stretch">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-valdef-stroke-dash-justify-stretch①">(2)</a> <a href="#ref-for-valdef-stroke-dash-justify-stretch②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dash-justify-compress">
-   <b><a href="#valdef-stroke-dash-justify-compress">#valdef-stroke-dash-justify-compress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dash-justify-compress" class="dfn-panel" data-for="valdef-stroke-dash-justify-compress" id="infopanel-for-valdef-stroke-dash-justify-compress" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dash-justify-compress" style="display:none">Info about the 'compress' definition.</span><b><a href="#valdef-stroke-dash-justify-compress">#valdef-stroke-dash-justify-compress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dash-justify-compress">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a> <a href="#ref-for-valdef-stroke-dash-justify-compress①">(2)</a> <a href="#ref-for-valdef-stroke-dash-justify-compress②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dash-justify-dashes">
-   <b><a href="#valdef-stroke-dash-justify-dashes">#valdef-stroke-dash-justify-dashes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dash-justify-dashes" class="dfn-panel" data-for="valdef-stroke-dash-justify-dashes" id="infopanel-for-valdef-stroke-dash-justify-dashes" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dash-justify-dashes" style="display:none">Info about the 'dashes' definition.</span><b><a href="#valdef-stroke-dash-justify-dashes">#valdef-stroke-dash-justify-dashes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dash-justify-dashes">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-dash-justify-gaps">
-   <b><a href="#valdef-stroke-dash-justify-gaps">#valdef-stroke-dash-justify-gaps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-dash-justify-gaps" class="dfn-panel" data-for="valdef-stroke-dash-justify-gaps" id="infopanel-for-valdef-stroke-dash-justify-gaps" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-dash-justify-gaps" style="display:none">Info about the 'gaps' definition.</span><b><a href="#valdef-stroke-dash-justify-gaps">#valdef-stroke-dash-justify-gaps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-dash-justify-gaps">4.3.3. Corner Control: the stroke-dash-corner and stroke-dash-justify properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-color">
-   <b><a href="#propdef-stroke-color">#propdef-stroke-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-color" class="dfn-panel" data-for="propdef-stroke-color" id="infopanel-for-propdef-stroke-color" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-color" style="display:none">Info about the 'stroke-color' definition.</span><b><a href="#propdef-stroke-color">#propdef-stroke-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-color">3.3.1. Fill Color: the fill-color property</a>
     <li><a href="#ref-for-propdef-stroke-color①">4. Strokes (Outlines)</a>
@@ -4607,8 +4607,8 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-stroke-color⑥">4.4.7. Stroke Shorthand: the stroke property</a> <a href="#ref-for-propdef-stroke-color⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-image">
-   <b><a href="#propdef-stroke-image">#propdef-stroke-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-image" class="dfn-panel" data-for="propdef-stroke-image" id="infopanel-for-propdef-stroke-image" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-image" style="display:none">Info about the 'stroke-image' definition.</span><b><a href="#propdef-stroke-image">#propdef-stroke-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-image">4. Strokes (Outlines)</a>
     <li><a href="#ref-for-propdef-stroke-image①">4.1. Layering Multiple Strokes</a> <a href="#ref-for-propdef-stroke-image②">(2)</a>
@@ -4617,80 +4617,80 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-stroke-image⑥">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-origin">
-   <b><a href="#propdef-stroke-origin">#propdef-stroke-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-origin" class="dfn-panel" data-for="propdef-stroke-origin" id="infopanel-for-propdef-stroke-origin" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-origin" style="display:none">Info about the 'stroke-origin' definition.</span><b><a href="#propdef-stroke-origin">#propdef-stroke-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-origin">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
     <li><a href="#ref-for-propdef-stroke-origin①">4.4.7. Stroke Shorthand: the stroke property</a> <a href="#ref-for-propdef-stroke-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stroke-positioning-area">
-   <b><a href="#stroke-positioning-area">#stroke-positioning-area</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stroke-positioning-area" class="dfn-panel" data-for="stroke-positioning-area" id="infopanel-for-stroke-positioning-area" role="dialog">
+   <span id="infopaneltitle-for-stroke-positioning-area" style="display:none">Info about the 'stroke positioning area' definition.</span><b><a href="#stroke-positioning-area">#stroke-positioning-area</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stroke-positioning-area">4.4.3. Stroke Positioning Area: the stroke-origin property</a> <a href="#ref-for-stroke-positioning-area①">(2)</a>
     <li><a href="#ref-for-stroke-positioning-area②">4.4.4. Positioning Stroke Images: the stroke-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-match-parent">
-   <b><a href="#valdef-stroke-origin-match-parent">#valdef-stroke-origin-match-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-match-parent" class="dfn-panel" data-for="valdef-stroke-origin-match-parent" id="infopanel-for-valdef-stroke-origin-match-parent" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-match-parent" style="display:none">Info about the 'match-parent' definition.</span><b><a href="#valdef-stroke-origin-match-parent">#valdef-stroke-origin-match-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-match-parent">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-content-box">
-   <b><a href="#valdef-stroke-origin-content-box">#valdef-stroke-origin-content-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-content-box" class="dfn-panel" data-for="valdef-stroke-origin-content-box" id="infopanel-for-valdef-stroke-origin-content-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-content-box" style="display:none">Info about the 'content-box' definition.</span><b><a href="#valdef-stroke-origin-content-box">#valdef-stroke-origin-content-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-content-box">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-padding-box">
-   <b><a href="#valdef-stroke-origin-padding-box">#valdef-stroke-origin-padding-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-padding-box" class="dfn-panel" data-for="valdef-stroke-origin-padding-box" id="infopanel-for-valdef-stroke-origin-padding-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-padding-box" style="display:none">Info about the 'padding-box' definition.</span><b><a href="#valdef-stroke-origin-padding-box">#valdef-stroke-origin-padding-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-padding-box">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-border-box">
-   <b><a href="#valdef-stroke-origin-border-box">#valdef-stroke-origin-border-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-border-box" class="dfn-panel" data-for="valdef-stroke-origin-border-box" id="infopanel-for-valdef-stroke-origin-border-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-border-box" style="display:none">Info about the 'border-box' definition.</span><b><a href="#valdef-stroke-origin-border-box">#valdef-stroke-origin-border-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-border-box">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-fill-box">
-   <b><a href="#valdef-stroke-origin-fill-box">#valdef-stroke-origin-fill-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-fill-box" class="dfn-panel" data-for="valdef-stroke-origin-fill-box" id="infopanel-for-valdef-stroke-origin-fill-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-fill-box" style="display:none">Info about the 'fill-box' definition.</span><b><a href="#valdef-stroke-origin-fill-box">#valdef-stroke-origin-fill-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-fill-box">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-stroke-origin-stroke-box">
-   <b><a href="#valdef-stroke-origin-stroke-box">#valdef-stroke-origin-stroke-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-stroke-origin-stroke-box" class="dfn-panel" data-for="valdef-stroke-origin-stroke-box" id="infopanel-for-valdef-stroke-origin-stroke-box" role="dialog">
+   <span id="infopaneltitle-for-valdef-stroke-origin-stroke-box" style="display:none">Info about the 'stroke-box' definition.</span><b><a href="#valdef-stroke-origin-stroke-box">#valdef-stroke-origin-stroke-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-stroke-origin-stroke-box">4.4.3. Stroke Positioning Area: the stroke-origin property</a>
     <li><a href="#ref-for-valdef-stroke-origin-stroke-box①">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-position">
-   <b><a href="#propdef-stroke-position">#propdef-stroke-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-position" class="dfn-panel" data-for="propdef-stroke-position" id="infopanel-for-propdef-stroke-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-position" style="display:none">Info about the 'stroke-position' definition.</span><b><a href="#propdef-stroke-position">#propdef-stroke-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-position">4.4.4. Positioning Stroke Images: the stroke-position property</a>
     <li><a href="#ref-for-propdef-stroke-position①">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-size">
-   <b><a href="#propdef-stroke-size">#propdef-stroke-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-size" class="dfn-panel" data-for="propdef-stroke-size" id="infopanel-for-propdef-stroke-size" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-size" style="display:none">Info about the 'stroke-size' definition.</span><b><a href="#propdef-stroke-size">#propdef-stroke-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-size">4.4.5. Sizing Stroke Images: the stroke-size property</a>
     <li><a href="#ref-for-propdef-stroke-size①">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-repeat">
-   <b><a href="#propdef-stroke-repeat">#propdef-stroke-repeat</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-repeat" class="dfn-panel" data-for="propdef-stroke-repeat" id="infopanel-for-propdef-stroke-repeat" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-repeat" style="display:none">Info about the 'stroke-repeat' definition.</span><b><a href="#propdef-stroke-repeat">#propdef-stroke-repeat</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-repeat">4.4.6. Tiling Stroke Images: the stroke-repeat property</a>
     <li><a href="#ref-for-propdef-stroke-repeat①">4.4.7. Stroke Shorthand: the stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke">
-   <b><a href="#propdef-stroke">#propdef-stroke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke" class="dfn-panel" data-for="propdef-stroke" id="infopanel-for-propdef-stroke" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke" style="display:none">Info about the 'stroke' definition.</span><b><a href="#propdef-stroke">#propdef-stroke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke">2.1. SVG-Specific Paints</a>
     <li><a href="#ref-for-propdef-stroke①">4. Strokes (Outlines)</a>
@@ -4701,86 +4701,142 @@ Light gray represents dash pattern based on center of inset path.</p>
     <li><a href="#ref-for-propdef-stroke⑥">5. Text Decoration Fills and Strokes</a> <a href="#ref-for-propdef-stroke⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-stroke-opacity">
-   <b><a href="#propdef-stroke-opacity">#propdef-stroke-opacity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-stroke-opacity" class="dfn-panel" data-for="propdef-stroke-opacity" id="infopanel-for-propdef-stroke-opacity" role="dialog">
+   <span id="infopaneltitle-for-propdef-stroke-opacity" style="display:none">Info about the 'stroke-opacity' definition.</span><b><a href="#propdef-stroke-opacity">#propdef-stroke-opacity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-opacity">4.5.1. Stroke Opacity: the stroke-opacity property</a> <a href="#ref-for-propdef-stroke-opacity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dash-positions">
-   <b><a href="#dash-positions">#dash-positions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dash-positions" class="dfn-panel" data-for="dash-positions" id="infopanel-for-dash-positions" role="dialog">
+   <span id="infopaneltitle-for-dash-positions" style="display:none">Info about the 'dash positions' definition.</span><b><a href="#dash-positions">#dash-positions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dash-positions">4.6.2. Stroke Shape</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cap-shapes">
-   <b><a href="#cap-shapes">#cap-shapes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cap-shapes" class="dfn-panel" data-for="cap-shapes" id="infopanel-for-cap-shapes" role="dialog">
+   <span id="infopaneltitle-for-cap-shapes" style="display:none">Info about the 'cap shapes' definition.</span><b><a href="#cap-shapes">#cap-shapes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cap-shapes">4.2.3. Stroke End Shapes: the stroke-linecap property</a>
     <li><a href="#ref-for-cap-shapes①">4.6.2. Stroke Shape</a> <a href="#ref-for-cap-shapes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="line-join-shape">
-   <b><a href="#line-join-shape">#line-join-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-line-join-shape" class="dfn-panel" data-for="line-join-shape" id="infopanel-for-line-join-shape" role="dialog">
+   <span id="infopaneltitle-for-line-join-shape" style="display:none">Info about the 'line join shape' definition.</span><b><a href="#line-join-shape">#line-join-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-line-join-shape">4.6.2. Stroke Shape</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/filter-effects-2/Overview.html
@@ -1349,33 +1349,33 @@ See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 5
    <li><a href="#backdrop-root">Backdrop Root</a><span>, in § 3</span>
    <li><a href="#backdrop-root-image">Backdrop Root Image</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">2. Backdrop filters: the backdrop-filter property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-filter-value-list">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#typedef-filter-value-list">https://drafts.fxtf.org/filter-effects-1/#typedef-filter-value-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-filter-value-list" class="dfn-panel" data-for="term-for-typedef-filter-value-list" id="infopanel-for-term-for-typedef-filter-value-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-filter-value-list" style="display:none">Info about the '&lt;filter-value-list>' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#typedef-filter-value-list">https://drafts.fxtf.org/filter-effects-1/#typedef-filter-value-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-filter-value-list">2. Backdrop filters: the backdrop-filter property</a>
     <li><a href="#ref-for-typedef-filter-value-list①">2.1. Filtering and Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-filter" class="dfn-panel" data-for="term-for-propdef-filter" id="infopanel-for-term-for-propdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-filter">2.1. Filtering and Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.1. Filtering and Clipping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-element" class="dfn-panel" data-for="term-for-container-element" id="infopanel-for-term-for-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-container-element" style="display:none">Info about the 'container element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-element">2. Backdrop filters: the backdrop-filter property</a>
    </ul>
@@ -1458,79 +1458,135 @@ See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 5
    <div class="issue"> This specification does not yet have Working Group consensus, specifically on the definition of Backdrop Root.
 See <a href="https://github.com/w3c/fxtf-drafts/issues/53">discussion in issue 53</a>. <a class="issue-return" href="#issue-ade95eb0①" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-backdrop-filter">
-   <b><a href="#propdef-backdrop-filter">#propdef-backdrop-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-backdrop-filter" class="dfn-panel" data-for="propdef-backdrop-filter" id="infopanel-for-propdef-backdrop-filter" role="dialog">
+   <span id="infopaneltitle-for-propdef-backdrop-filter" style="display:none">Info about the 'backdrop-filter' definition.</span><b><a href="#propdef-backdrop-filter">#propdef-backdrop-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-backdrop-filter">2. Backdrop filters: the backdrop-filter property</a> <a href="#ref-for-propdef-backdrop-filter①">(2)</a> <a href="#ref-for-propdef-backdrop-filter②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backdrop-root-image">
-   <b><a href="#backdrop-root-image">#backdrop-root-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backdrop-root-image" class="dfn-panel" data-for="backdrop-root-image" id="infopanel-for-backdrop-root-image" role="dialog">
+   <span id="infopaneltitle-for-backdrop-root-image" style="display:none">Info about the 'Backdrop Root Image' definition.</span><b><a href="#backdrop-root-image">#backdrop-root-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backdrop-root-image">2.1. Filtering and Clipping</a> <a href="#ref-for-backdrop-root-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backdrop-root">
-   <b><a href="#backdrop-root">#backdrop-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backdrop-root" class="dfn-panel" data-for="backdrop-root" id="infopanel-for-backdrop-root" role="dialog">
+   <span id="infopaneltitle-for-backdrop-root" style="display:none">Info about the 'Backdrop Root' definition.</span><b><a href="#backdrop-root">#backdrop-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backdrop-root">3. Backdrop Root</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/fxtf-drafts/geometry/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/geometry/Overview.html
@@ -4233,95 +4233,95 @@ for their careful reviews, comments, and corrections.</p>
     </ul>
    <li><a href="#point-z-coordinate">z coordinate</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-function">
-   <a href="https://drafts.csswg.org/css-transforms-2/#typedef-transform-function">https://drafts.csswg.org/css-transforms-2/#typedef-transform-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-function" class="dfn-panel" data-for="term-for-typedef-transform-function" id="infopanel-for-term-for-typedef-transform-function" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-function" style="display:none">Info about the '&lt;transform-function>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#typedef-transform-function">https://drafts.csswg.org/css-transforms-2/#typedef-transform-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-function">6.2. Parsing a string into an abstract matrix</a> <a href="#ref-for-typedef-transform-function①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-matrix3d">
-   <a href="https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d">https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-matrix3d" class="dfn-panel" data-for="term-for-funcdef-matrix3d" id="infopanel-for-term-for-funcdef-matrix3d" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-matrix3d" style="display:none">Info about the 'matrix3d()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d">https://drafts.csswg.org/css-transforms-2/#funcdef-matrix3d</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-matrix3d">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">6.2. Parsing a string into an abstract matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-length">
-   <a href="https://drafts.csswg.org/css-values-4/#absolute-length">https://drafts.csswg.org/css-values-4/#absolute-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-length" class="dfn-panel" data-for="term-for-absolute-length" id="infopanel-for-term-for-absolute-length" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-length" style="display:none">Info about the 'absolute length' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#absolute-length">https://drafts.csswg.org/css-values-4/#absolute-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-length">6.2. Parsing a string into an abstract matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-calc-infinity">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-calc-infinity">https://drafts.csswg.org/css-values-4/#valdef-calc-infinity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-calc-infinity" class="dfn-panel" data-for="term-for-valdef-calc-infinity" id="infopanel-for-term-for-valdef-calc-infinity" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-calc-infinity" style="display:none">Info about the 'infinity' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-calc-infinity">https://drafts.csswg.org/css-values-4/#valdef-calc-infinity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-infinity">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-calc-nan">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-calc-nan">https://drafts.csswg.org/css-values-4/#valdef-calc-nan</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-calc-nan" class="dfn-panel" data-for="term-for-valdef-calc-nan" id="infopanel-for-term-for-valdef-calc-nan" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-calc-nan" style="display:none">Info about the 'nan' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-calc-nan">https://drafts.csswg.org/css-values-4/#valdef-calc-nan</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-calc-nan">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a>
     <li><a href="#ref-for-valdef-calc-nan①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-valdef-calc-nan②">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar">
-   <a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" class="dfn-panel" data-for="term-for-css-parse-something-according-to-a-css-grammar" id="infopanel-for-term-for-css-parse-something-according-to-a-css-grammar" role="menu">
+   <span id="infopaneltitle-for-term-for-css-parse-something-according-to-a-css-grammar" style="display:none">Info about the 'parse' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar">https://drafts.csswg.org/css-syntax-3/#css-parse-something-according-to-a-css-grammar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-parse-something-according-to-a-css-grammar">6.2. Parsing a string into an abstract matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-list">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-list" class="dfn-panel" data-for="term-for-typedef-transform-list" id="infopanel-for-term-for-typedef-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">6.2. Parsing a string into an abstract matrix</a> <a href="#ref-for-typedef-transform-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-matrix">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-matrix" class="dfn-panel" data-for="term-for-funcdef-transform-matrix" id="infopanel-for-term-for-funcdef-transform-matrix" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-matrix" style="display:none">Info about the 'matrix()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-matrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-matrix">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">6.2. Parsing a string into an abstract matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">8. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions">
-   <a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions" class="dfn-panel" data-for="term-for-sec-algorithm-conventions" id="infopanel-for-term-for-sec-algorithm-conventions" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions" style="display:none">Info about the '!' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-algorithm-conventions">https://tc39.github.io/ecma262/#sec-algorithm-conventions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions">6.5. Immutable transformation methods</a> <a href="#ref-for-sec-algorithm-conventions①">(2)</a> <a href="#ref-for-sec-algorithm-conventions②">(3)</a> <a href="#ref-for-sec-algorithm-conventions③">(4)</a> <a href="#ref-for-sec-algorithm-conventions④">(5)</a> <a href="#ref-for-sec-algorithm-conventions⑤">(6)</a> <a href="#ref-for-sec-algorithm-conventions⑥">(7)</a> <a href="#ref-for-sec-algorithm-conventions⑦">(8)</a> <a href="#ref-for-sec-algorithm-conventions⑧">(9)</a> <a href="#ref-for-sec-algorithm-conventions⑨">(10)</a> <a href="#ref-for-sec-algorithm-conventions①⓪">(11)</a> <a href="#ref-for-sec-algorithm-conventions①①">(12)</a> <a href="#ref-for-sec-algorithm-conventions①②">(13)</a> <a href="#ref-for-sec-algorithm-conventions①③">(14)</a> <a href="#ref-for-sec-algorithm-conventions①④">(15)</a> <a href="#ref-for-sec-algorithm-conventions①⑤">(16)</a> <a href="#ref-for-sec-algorithm-conventions①⑥">(17)</a> <a href="#ref-for-sec-algorithm-conventions①⑦">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-samevaluezero">
-   <a href="https://tc39.github.io/ecma262/#sec-samevaluezero">https://tc39.github.io/ecma262/#sec-samevaluezero</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-samevaluezero" class="dfn-panel" data-for="term-for-sec-samevaluezero" id="infopanel-for-term-for-sec-samevaluezero" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-samevaluezero" style="display:none">Info about the 'samevaluezero' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-samevaluezero">https://tc39.github.io/ecma262/#sec-samevaluezero</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-samevaluezero">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-sec-samevaluezero①">(2)</a> <a href="#ref-for-sec-samevaluezero②">(3)</a> <a href="#ref-for-sec-samevaluezero③">(4)</a> <a href="#ref-for-sec-samevaluezero④">(5)</a> <a href="#ref-for-sec-samevaluezero⑤">(6)</a> <a href="#ref-for-sec-samevaluezero⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'tostring' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">6.5. Immutable transformation methods</a> <a href="#ref-for-sec-tostring①">(2)</a> <a href="#ref-for-sec-tostring②">(3)</a> <a href="#ref-for-sec-tostring③">(4)</a> <a href="#ref-for-sec-tostring④">(5)</a> <a href="#ref-for-sec-tostring⑤">(6)</a> <a href="#ref-for-sec-tostring⑥">(7)</a> <a href="#ref-for-sec-tostring⑦">(8)</a> <a href="#ref-for-sec-tostring⑧">(9)</a> <a href="#ref-for-sec-tostring⑨">(10)</a> <a href="#ref-for-sec-tostring①⓪">(11)</a> <a href="#ref-for-sec-tostring①①">(12)</a> <a href="#ref-for-sec-tostring①②">(13)</a> <a href="#ref-for-sec-tostring①③">(14)</a> <a href="#ref-for-sec-tostring①④">(15)</a> <a href="#ref-for-sec-tostring①⑤">(16)</a> <a href="#ref-for-sec-tostring①⑥">(17)</a> <a href="#ref-for-sec-tostring①⑦">(18)</a>
     <li><a href="#ref-for-sec-tostring①⑧">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serializable">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serializable" class="dfn-panel" data-for="term-for-serializable" id="infopanel-for-term-for-serializable" role="menu">
+   <span id="infopaneltitle-for-term-for-serializable" style="display:none">Info about the 'Serializable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serializable">https://html.spec.whatwg.org/multipage/structured-data.html#serializable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializable">2. The DOMPoint interfaces</a> <a href="#ref-for-serializable①">(2)</a>
     <li><a href="#ref-for-serializable②">3. The DOMRect interfaces</a> <a href="#ref-for-serializable③">(2)</a>
@@ -4329,67 +4329,67 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-serializable⑤">6. The DOMMatrix interfaces</a> <a href="#ref-for-serializable⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-window①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deserialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deserialization-steps" class="dfn-panel" data-for="term-for-deserialization-steps" id="infopanel-for-term-for-deserialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-deserialization-steps" style="display:none">Info about the 'deserialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#deserialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deserialization-steps">7. Structured serialization</a> <a href="#ref-for-deserialization-steps①">(2)</a> <a href="#ref-for-deserialization-steps②">(3)</a> <a href="#ref-for-deserialization-steps③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialization-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialization-steps" class="dfn-panel" data-for="term-for-serialization-steps" id="infopanel-for-term-for-serialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-serialization-steps" style="display:none">Info about the 'serialization steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps">https://html.spec.whatwg.org/multipage/structured-data.html#serialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialization-steps">7. Structured serialization</a> <a href="#ref-for-serialization-steps①">(2)</a> <a href="#ref-for-serialization-steps②">(3)</a> <a href="#ref-for-serialization-steps③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sub-deserialization">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sub-deserialization" class="dfn-panel" data-for="term-for-sub-deserialization" id="infopanel-for-term-for-sub-deserialization" role="menu">
+   <span id="infopaneltitle-for-term-for-sub-deserialization" style="display:none">Info about the 'sub-deserialization' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-deserialization</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sub-deserialization">7. Structured serialization</a> <a href="#ref-for-sub-deserialization①">(2)</a> <a href="#ref-for-sub-deserialization②">(3)</a> <a href="#ref-for-sub-deserialization③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sub-serialization">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sub-serialization" class="dfn-panel" data-for="term-for-sub-serialization" id="infopanel-for-term-for-sub-serialization" role="menu">
+   <span id="infopaneltitle-for-term-for-sub-serialization" style="display:none">Info about the 'sub-serialization' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization">https://html.spec.whatwg.org/multipage/structured-data.html#sub-serialization</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sub-serialization">7. Structured serialization</a> <a href="#ref-for-sub-serialization①">(2)</a> <a href="#ref-for-sub-serialization②">(3)</a> <a href="#ref-for-sub-serialization③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-idl-DOMException①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-idl-DOMException②">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">6. The DOMMatrix interfaces</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-idl-DOMString④">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-Default①">3. The DOMRect interfaces</a>
@@ -4397,8 +4397,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-Default③">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. The DOMPoint interfaces</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">3. The DOMRect interfaces</a> <a href="#ref-for-Exposed③">(2)</a>
@@ -4407,42 +4407,42 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-Exposed⑥">6. The DOMMatrix interfaces</a> <a href="#ref-for-Exposed⑦">(2)</a> <a href="#ref-for-Exposed⑧">(3)</a> <a href="#ref-for-Exposed⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">6. The DOMMatrix interfaces</a> <a href="#ref-for-idl-Float32Array①">(2)</a> <a href="#ref-for-idl-Float32Array②">(3)</a>
     <li><a href="#ref-for-idl-Float32Array③">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float64Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float64Array" class="dfn-panel" data-for="term-for-idl-Float64Array" id="infopanel-for-term-for-idl-Float64Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float64Array" style="display:none">Info about the 'Float64Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float64Array">6. The DOMMatrix interfaces</a> <a href="#ref-for-idl-Float64Array①">(2)</a> <a href="#ref-for-idl-Float64Array②">(3)</a>
     <li><a href="#ref-for-idl-Float64Array③">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indexsizeerror">
-   <a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indexsizeerror" class="dfn-panel" data-for="term-for-indexsizeerror" id="infopanel-for-term-for-indexsizeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-indexsizeerror" style="display:none">Info about the 'IndexSizeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indexsizeerror">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyWindowAlias">
-   <a href="https://webidl.spec.whatwg.org/#LegacyWindowAlias">https://webidl.spec.whatwg.org/#LegacyWindowAlias</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyWindowAlias" class="dfn-panel" data-for="term-for-LegacyWindowAlias" id="infopanel-for-term-for-LegacyWindowAlias" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyWindowAlias" style="display:none">Info about the 'LegacyWindowAlias' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyWindowAlias">https://webidl.spec.whatwg.org/#LegacyWindowAlias</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyWindowAlias">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-LegacyWindowAlias①">3. The DOMRect interfaces</a>
     <li><a href="#ref-for-LegacyWindowAlias②">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">2. The DOMPoint interfaces</a> <a href="#ref-for-NewObject①">(2)</a> <a href="#ref-for-NewObject②">(3)</a>
     <li><a href="#ref-for-NewObject③">3. The DOMRect interfaces</a> <a href="#ref-for-NewObject④">(2)</a>
@@ -4450,35 +4450,35 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-NewObject⑧">6. The DOMMatrix interfaces</a> <a href="#ref-for-NewObject⑨">(2)</a> <a href="#ref-for-NewObject①⓪">(3)</a> <a href="#ref-for-NewObject①①">(4)</a> <a href="#ref-for-NewObject①②">(5)</a> <a href="#ref-for-NewObject①③">(6)</a> <a href="#ref-for-NewObject①④">(7)</a> <a href="#ref-for-NewObject①⑤">(8)</a> <a href="#ref-for-NewObject①⑥">(9)</a> <a href="#ref-for-NewObject①⑦">(10)</a> <a href="#ref-for-NewObject①⑧">(11)</a> <a href="#ref-for-NewObject①⑨">(12)</a> <a href="#ref-for-NewObject②⓪">(13)</a> <a href="#ref-for-NewObject②①">(14)</a> <a href="#ref-for-NewObject②②">(15)</a> <a href="#ref-for-NewObject②③">(16)</a> <a href="#ref-for-NewObject②④">(17)</a> <a href="#ref-for-NewObject②⑤">(18)</a> <a href="#ref-for-NewObject②⑥">(19)</a> <a href="#ref-for-NewObject②⑦">(20)</a> <a href="#ref-for-NewObject②⑧">(21)</a> <a href="#ref-for-NewObject②⑨">(22)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5. The DOMQuad interface</a> <a href="#ref-for-SameObject①">(2)</a> <a href="#ref-for-SameObject②">(3)</a> <a href="#ref-for-SameObject③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-syntaxerror①">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a> <a href="#ref-for-exceptiondef-typeerror④">(3)</a> <a href="#ref-for-exceptiondef-typeerror⑤">(4)</a>
     <li><a href="#ref-for-exceptiondef-typeerror⑥">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6. The DOMMatrix interfaces</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-idl-object①">3. The DOMRect interfaces</a>
@@ -4486,14 +4486,14 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-idl-object③">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">6. The DOMMatrix interfaces</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">2. The DOMPoint interfaces</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a> <a href="#ref-for-idl-unrestricted-double②">(3)</a> <a href="#ref-for-idl-unrestricted-double③">(4)</a> <a href="#ref-for-idl-unrestricted-double④">(5)</a> <a href="#ref-for-idl-unrestricted-double⑤">(6)</a> <a href="#ref-for-idl-unrestricted-double⑥">(7)</a> <a href="#ref-for-idl-unrestricted-double⑦">(8)</a> <a href="#ref-for-idl-unrestricted-double⑧">(9)</a> <a href="#ref-for-idl-unrestricted-double⑨">(10)</a> <a href="#ref-for-idl-unrestricted-double①⓪">(11)</a> <a href="#ref-for-idl-unrestricted-double①①">(12)</a> <a href="#ref-for-idl-unrestricted-double①②">(13)</a> <a href="#ref-for-idl-unrestricted-double①③">(14)</a> <a href="#ref-for-idl-unrestricted-double①④">(15)</a> <a href="#ref-for-idl-unrestricted-double①⑤">(16)</a> <a href="#ref-for-idl-unrestricted-double①⑥">(17)</a> <a href="#ref-for-idl-unrestricted-double①⑦">(18)</a> <a href="#ref-for-idl-unrestricted-double①⑧">(19)</a> <a href="#ref-for-idl-unrestricted-double①⑨">(20)</a>
     <li><a href="#ref-for-idl-unrestricted-double②⓪">3. The DOMRect interfaces</a> <a href="#ref-for-idl-unrestricted-double②①">(2)</a> <a href="#ref-for-idl-unrestricted-double②②">(3)</a> <a href="#ref-for-idl-unrestricted-double②③">(4)</a> <a href="#ref-for-idl-unrestricted-double②④">(5)</a> <a href="#ref-for-idl-unrestricted-double②⑤">(6)</a> <a href="#ref-for-idl-unrestricted-double②⑥">(7)</a> <a href="#ref-for-idl-unrestricted-double②⑦">(8)</a> <a href="#ref-for-idl-unrestricted-double②⑧">(9)</a> <a href="#ref-for-idl-unrestricted-double②⑨">(10)</a> <a href="#ref-for-idl-unrestricted-double③⓪">(11)</a> <a href="#ref-for-idl-unrestricted-double③①">(12)</a> <a href="#ref-for-idl-unrestricted-double③②">(13)</a> <a href="#ref-for-idl-unrestricted-double③③">(14)</a> <a href="#ref-for-idl-unrestricted-double③④">(15)</a> <a href="#ref-for-idl-unrestricted-double③⑤">(16)</a> <a href="#ref-for-idl-unrestricted-double③⑥">(17)</a> <a href="#ref-for-idl-unrestricted-double③⑦">(18)</a> <a href="#ref-for-idl-unrestricted-double③⑧">(19)</a> <a href="#ref-for-idl-unrestricted-double③⑨">(20)</a> <a href="#ref-for-idl-unrestricted-double④⓪">(21)</a> <a href="#ref-for-idl-unrestricted-double④①">(22)</a> <a href="#ref-for-idl-unrestricted-double④②">(23)</a> <a href="#ref-for-idl-unrestricted-double④③">(24)</a>
@@ -4501,8 +4501,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-idl-unrestricted-double①⑥②">Document conventions</a> <a href="#ref-for-idl-unrestricted-double①⑥③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4. The DOMRectList interface</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
@@ -4897,14 +4897,14 @@ for their careful reviews, comments, and corrections.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="point">
-   <b><a href="#point">#point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-point" class="dfn-panel" data-for="point" id="infopanel-for-point" role="dialog">
+   <span id="infopaneltitle-for-point" style="display:none">Info about the 'point' definition.</span><b><a href="#point">#point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-point">2.1. Transforming a point with a matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dompointreadonly">
-   <b><a href="#dompointreadonly">#dompointreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dompointreadonly" class="dfn-panel" data-for="dompointreadonly" id="infopanel-for-dompointreadonly" role="dialog">
+   <span id="infopaneltitle-for-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly' definition.</span><b><a href="#dompointreadonly">#dompointreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompointreadonly">2. The DOMPoint interfaces</a> <a href="#ref-for-dompointreadonly①">(2)</a> <a href="#ref-for-dompointreadonly②">(3)</a> <a href="#ref-for-dompointreadonly③">(4)</a> <a href="#ref-for-dompointreadonly④">(5)</a> <a href="#ref-for-dompointreadonly⑤">(6)</a> <a href="#ref-for-dompointreadonly⑥">(7)</a> <a href="#ref-for-dompointreadonly⑦">(8)</a>
     <li><a href="#ref-for-dompointreadonly⑧">5. The DOMQuad interface</a>
@@ -4912,15 +4912,15 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dompointreadonly①①">Changes since last publication</a> <a href="#ref-for-dompointreadonly①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgpoint">
-   <b><a href="#svgpoint">#svgpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgpoint" class="dfn-panel" data-for="svgpoint" id="infopanel-for-svgpoint" role="dialog">
+   <span id="infopaneltitle-for-svgpoint" style="display:none">Info about the 'SVGPoint' definition.</span><b><a href="#svgpoint">#svgpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgpoint">1. Introduction</a>
     <li><a href="#ref-for-svgpoint①">9.2. SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dompoint">
-   <b><a href="#dompoint">#dompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dompoint" class="dfn-panel" data-for="dompoint" id="infopanel-for-dompoint" role="dialog">
+   <span id="infopaneltitle-for-dompoint" style="display:none">Info about the 'DOMPoint' definition.</span><b><a href="#dompoint">#dompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dompoint">2. The DOMPoint interfaces</a> <a href="#ref-for-dompoint①">(2)</a> <a href="#ref-for-dompoint②">(3)</a> <a href="#ref-for-dompoint③">(4)</a> <a href="#ref-for-dompoint④">(5)</a> <a href="#ref-for-dompoint⑤">(6)</a> <a href="#ref-for-dompoint⑥">(7)</a> <a href="#ref-for-dompoint⑦">(8)</a> <a href="#ref-for-dompoint⑧">(9)</a> <a href="#ref-for-dompoint⑨">(10)</a> <a href="#ref-for-dompoint①⓪">(11)</a> <a href="#ref-for-dompoint①①">(12)</a> <a href="#ref-for-dompoint①②">(13)</a>
     <li><a href="#ref-for-dompoint①③">2.1. Transforming a point with a matrix</a>
@@ -4931,40 +4931,40 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dompoint③⑤">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-dompointinit">
-   <b><a href="#dictdef-dompointinit">#dictdef-dompointinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dompointinit" class="dfn-panel" data-for="dictdef-dompointinit" id="infopanel-for-dictdef-dompointinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dompointinit" style="display:none">Info about the 'DOMPointInit' definition.</span><b><a href="#dictdef-dompointinit">#dictdef-dompointinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dompointinit">2. The DOMPoint interfaces</a> <a href="#ref-for-dictdef-dompointinit①">(2)</a>
     <li><a href="#ref-for-dictdef-dompointinit②">5. The DOMQuad interface</a> <a href="#ref-for-dictdef-dompointinit③">(2)</a> <a href="#ref-for-dictdef-dompointinit④">(3)</a> <a href="#ref-for-dictdef-dompointinit⑤">(4)</a> <a href="#ref-for-dictdef-dompointinit⑥">(5)</a> <a href="#ref-for-dictdef-dompointinit⑦">(6)</a> <a href="#ref-for-dictdef-dompointinit⑧">(7)</a> <a href="#ref-for-dictdef-dompointinit⑨">(8)</a> <a href="#ref-for-dictdef-dompointinit①⓪">(9)</a>
     <li><a href="#ref-for-dictdef-dompointinit①①">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointinit-x">
-   <b><a href="#dom-dompointinit-x">#dom-dompointinit-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointinit-x" class="dfn-panel" data-for="dom-dompointinit-x" id="infopanel-for-dom-dompointinit-x" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointinit-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-dompointinit-x">#dom-dompointinit-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-x">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointinit-y">
-   <b><a href="#dom-dompointinit-y">#dom-dompointinit-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointinit-y" class="dfn-panel" data-for="dom-dompointinit-y" id="infopanel-for-dom-dompointinit-y" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointinit-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-dompointinit-y">#dom-dompointinit-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-y">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointinit-z">
-   <b><a href="#dom-dompointinit-z">#dom-dompointinit-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointinit-z" class="dfn-panel" data-for="dom-dompointinit-z" id="infopanel-for-dom-dompointinit-z" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointinit-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-dompointinit-z">#dom-dompointinit-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-z">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointinit-w">
-   <b><a href="#dom-dompointinit-w">#dom-dompointinit-w</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointinit-w" class="dfn-panel" data-for="dom-dompointinit-w" id="infopanel-for-dom-dompointinit-w" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointinit-w" style="display:none">Info about the 'w' definition.</span><b><a href="#dom-dompointinit-w">#dom-dompointinit-w</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointinit-w">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="point-x-coordinate">
-   <b><a href="#point-x-coordinate">#point-x-coordinate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-point-x-coordinate" class="dfn-panel" data-for="point-x-coordinate" id="infopanel-for-point-x-coordinate" role="dialog">
+   <span id="infopaneltitle-for-point-x-coordinate" style="display:none">Info about the 'x coordinate' definition.</span><b><a href="#point-x-coordinate">#point-x-coordinate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-point-x-coordinate">2. The DOMPoint interfaces</a> <a href="#ref-for-point-x-coordinate①">(2)</a> <a href="#ref-for-point-x-coordinate②">(3)</a> <a href="#ref-for-point-x-coordinate③">(4)</a> <a href="#ref-for-point-x-coordinate④">(5)</a> <a href="#ref-for-point-x-coordinate⑤">(6)</a>
     <li><a href="#ref-for-point-x-coordinate⑥">2.1. Transforming a point with a matrix</a> <a href="#ref-for-point-x-coordinate⑦">(2)</a>
@@ -4972,8 +4972,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-point-x-coordinate②⓪">7. Structured serialization</a> <a href="#ref-for-point-x-coordinate②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="point-y-coordinate">
-   <b><a href="#point-y-coordinate">#point-y-coordinate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-point-y-coordinate" class="dfn-panel" data-for="point-y-coordinate" id="infopanel-for-point-y-coordinate" role="dialog">
+   <span id="infopaneltitle-for-point-y-coordinate" style="display:none">Info about the 'y coordinate' definition.</span><b><a href="#point-y-coordinate">#point-y-coordinate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-point-y-coordinate">2. The DOMPoint interfaces</a> <a href="#ref-for-point-y-coordinate①">(2)</a> <a href="#ref-for-point-y-coordinate②">(3)</a> <a href="#ref-for-point-y-coordinate③">(4)</a> <a href="#ref-for-point-y-coordinate④">(5)</a> <a href="#ref-for-point-y-coordinate⑤">(6)</a>
     <li><a href="#ref-for-point-y-coordinate⑥">2.1. Transforming a point with a matrix</a> <a href="#ref-for-point-y-coordinate⑦">(2)</a>
@@ -4981,8 +4981,9 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-point-y-coordinate②⓪">7. Structured serialization</a> <a href="#ref-for-point-y-coordinate②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="point-z-coordinate">
-   <b><a href="#point-z-coordinate">#point-z-coordinate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-point-z-coordinate" class="dfn-panel" data-for="point-z-coordinate" id="infopanel-for-point-z-coordinate" role="dialog">
+   <span id="infopaneltitle-for-point-z-coordinate" style="display:none">Info about the 'z
+coordinate' definition.</span><b><a href="#point-z-coordinate">#point-z-coordinate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-point-z-coordinate">2. The DOMPoint interfaces</a> <a href="#ref-for-point-z-coordinate①">(2)</a> <a href="#ref-for-point-z-coordinate②">(3)</a> <a href="#ref-for-point-z-coordinate③">(4)</a>
     <li><a href="#ref-for-point-z-coordinate④">2.1. Transforming a point with a matrix</a> <a href="#ref-for-point-z-coordinate⑤">(2)</a> <a href="#ref-for-point-z-coordinate⑥">(3)</a>
@@ -4990,8 +4991,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-point-z-coordinate①①">7. Structured serialization</a> <a href="#ref-for-point-z-coordinate①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="point-w-perspective">
-   <b><a href="#point-w-perspective">#point-w-perspective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-point-w-perspective" class="dfn-panel" data-for="point-w-perspective" id="infopanel-for-point-w-perspective" role="dialog">
+   <span id="infopaneltitle-for-point-w-perspective" style="display:none">Info about the 'w perspective' definition.</span><b><a href="#point-w-perspective">#point-w-perspective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-point-w-perspective">2. The DOMPoint interfaces</a> <a href="#ref-for-point-w-perspective①">(2)</a> <a href="#ref-for-point-w-perspective②">(3)</a> <a href="#ref-for-point-w-perspective③">(4)</a>
     <li><a href="#ref-for-point-w-perspective④">2.1. Transforming a point with a matrix</a> <a href="#ref-for-point-w-perspective⑤">(2)</a> <a href="#ref-for-point-w-perspective⑥">(3)</a>
@@ -4999,142 +5000,144 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-point-w-perspective①①">7. Structured serialization</a> <a href="#ref-for-point-w-perspective①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-dompointreadonly">
-   <b><a href="#dom-dompointreadonly-dompointreadonly">#dom-dompointreadonly-dompointreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-dompointreadonly" class="dfn-panel" data-for="dom-dompointreadonly-dompointreadonly" id="infopanel-for-dom-dompointreadonly-dompointreadonly" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-dompointreadonly" style="display:none">Info about the 'DOMPointReadOnly(x,
+y, z, w)' definition.</span><b><a href="#dom-dompointreadonly-dompointreadonly">#dom-dompointreadonly-dompointreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-dompointreadonly">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompoint-dompoint">
-   <b><a href="#dom-dompoint-dompoint">#dom-dompoint-dompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompoint-dompoint" class="dfn-panel" data-for="dom-dompoint-dompoint" id="infopanel-for-dom-dompoint-dompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-dompoint-dompoint" style="display:none">Info about the 'DOMPoint(x, y, z, w)' definition.</span><b><a href="#dom-dompoint-dompoint">#dom-dompoint-dompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompoint-dompoint">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-frompoint">
-   <b><a href="#dom-dompointreadonly-frompoint">#dom-dompointreadonly-frompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-frompoint" class="dfn-panel" data-for="dom-dompointreadonly-frompoint" id="infopanel-for-dom-dompointreadonly-frompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-frompoint" style="display:none">Info about the 'fromPoint(other)' definition.</span><b><a href="#dom-dompointreadonly-frompoint">#dom-dompointreadonly-frompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-frompoint">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompoint-frompoint">
-   <b><a href="#dom-dompoint-frompoint">#dom-dompoint-frompoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompoint-frompoint" class="dfn-panel" data-for="dom-dompoint-frompoint" id="infopanel-for-dom-dompoint-frompoint" role="dialog">
+   <span id="infopaneltitle-for-dom-dompoint-frompoint" style="display:none">Info about the 'fromPoint(other)' definition.</span><b><a href="#dom-dompoint-frompoint">#dom-dompoint-frompoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompoint-frompoint">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-dompointreadonly-from-the-dictionary">
-   <b><a href="#create-a-dompointreadonly-from-the-dictionary">#create-a-dompointreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-dompointreadonly-from-the-dictionary" class="dfn-panel" data-for="create-a-dompointreadonly-from-the-dictionary" id="infopanel-for-create-a-dompointreadonly-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-dompointreadonly-from-the-dictionary" style="display:none">Info about the 'create a DOMPointReadOnly
+from a dictionary' definition.</span><b><a href="#create-a-dompointreadonly-from-the-dictionary">#create-a-dompointreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-dompointreadonly-from-the-dictionary">2. The DOMPoint interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-dompoint-from-the-dictionary">
-   <b><a href="#create-a-dompoint-from-the-dictionary">#create-a-dompoint-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-dompoint-from-the-dictionary" class="dfn-panel" data-for="create-a-dompoint-from-the-dictionary" id="infopanel-for-create-a-dompoint-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-dompoint-from-the-dictionary" style="display:none">Info about the 'create a DOMPoint from a dictionary' definition.</span><b><a href="#create-a-dompoint-from-the-dictionary">#create-a-dompoint-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-dompoint-from-the-dictionary">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-create-a-dompoint-from-the-dictionary①">5. The DOMQuad interface</a> <a href="#ref-for-create-a-dompoint-from-the-dictionary②">(2)</a> <a href="#ref-for-create-a-dompoint-from-the-dictionary③">(3)</a> <a href="#ref-for-create-a-dompoint-from-the-dictionary④">(4)</a>
     <li><a href="#ref-for-create-a-dompoint-from-the-dictionary⑤">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-x">
-   <b><a href="#dom-dompointreadonly-x">#dom-dompointreadonly-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-x" class="dfn-panel" data-for="dom-dompointreadonly-x" id="infopanel-for-dom-dompointreadonly-x" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-dompointreadonly-x">#dom-dompointreadonly-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-x">2. The DOMPoint interfaces</a> <a href="#ref-for-dom-dompointreadonly-x①">(2)</a> <a href="#ref-for-dom-dompointreadonly-x②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-y">
-   <b><a href="#dom-dompointreadonly-y">#dom-dompointreadonly-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-y" class="dfn-panel" data-for="dom-dompointreadonly-y" id="infopanel-for-dom-dompointreadonly-y" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-dompointreadonly-y">#dom-dompointreadonly-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-y">2. The DOMPoint interfaces</a> <a href="#ref-for-dom-dompointreadonly-y①">(2)</a> <a href="#ref-for-dom-dompointreadonly-y②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-z">
-   <b><a href="#dom-dompointreadonly-z">#dom-dompointreadonly-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-z" class="dfn-panel" data-for="dom-dompointreadonly-z" id="infopanel-for-dom-dompointreadonly-z" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-dompointreadonly-z">#dom-dompointreadonly-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-z">2. The DOMPoint interfaces</a> <a href="#ref-for-dom-dompointreadonly-z①">(2)</a> <a href="#ref-for-dom-dompointreadonly-z②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-w">
-   <b><a href="#dom-dompointreadonly-w">#dom-dompointreadonly-w</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-w" class="dfn-panel" data-for="dom-dompointreadonly-w" id="infopanel-for-dom-dompointreadonly-w" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-w" style="display:none">Info about the 'w' definition.</span><b><a href="#dom-dompointreadonly-w">#dom-dompointreadonly-w</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-w">2. The DOMPoint interfaces</a> <a href="#ref-for-dom-dompointreadonly-w①">(2)</a> <a href="#ref-for-dom-dompointreadonly-w②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dompointreadonly-matrixtransform">
-   <b><a href="#dom-dompointreadonly-matrixtransform">#dom-dompointreadonly-matrixtransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dompointreadonly-matrixtransform" class="dfn-panel" data-for="dom-dompointreadonly-matrixtransform" id="infopanel-for-dom-dompointreadonly-matrixtransform" role="dialog">
+   <span id="infopaneltitle-for-dom-dompointreadonly-matrixtransform" style="display:none">Info about the 'matrixTransform(matrix)' definition.</span><b><a href="#dom-dompointreadonly-matrixtransform">#dom-dompointreadonly-matrixtransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dompointreadonly-matrixtransform">2. The DOMPoint interfaces</a> <a href="#ref-for-dom-dompointreadonly-matrixtransform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-a-point-with-a-matrix">
-   <b><a href="#transform-a-point-with-a-matrix">#transform-a-point-with-a-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-a-point-with-a-matrix" class="dfn-panel" data-for="transform-a-point-with-a-matrix" id="infopanel-for-transform-a-point-with-a-matrix" role="dialog">
+   <span id="infopaneltitle-for-transform-a-point-with-a-matrix" style="display:none">Info about the 'transform a point with a matrix' definition.</span><b><a href="#transform-a-point-with-a-matrix">#transform-a-point-with-a-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-a-point-with-a-matrix">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-transform-a-point-with-a-matrix①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle">
-   <b><a href="#rectangle">#rectangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle" class="dfn-panel" data-for="rectangle" id="infopanel-for-rectangle" role="dialog">
+   <span id="infopaneltitle-for-rectangle" style="display:none">Info about the 'rectangle' definition.</span><b><a href="#rectangle">#rectangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle-origin">
-   <b><a href="#rectangle-origin">#rectangle-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle-origin" class="dfn-panel" data-for="rectangle-origin" id="infopanel-for-rectangle-origin" role="dialog">
+   <span id="infopaneltitle-for-rectangle-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#rectangle-origin">#rectangle-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle-origin">3. The DOMRect interfaces</a> <a href="#ref-for-rectangle-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle-x-coordinate">
-   <b><a href="#rectangle-x-coordinate">#rectangle-x-coordinate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle-x-coordinate" class="dfn-panel" data-for="rectangle-x-coordinate" id="infopanel-for-rectangle-x-coordinate" role="dialog">
+   <span id="infopaneltitle-for-rectangle-x-coordinate" style="display:none">Info about the 'x coordinate' definition.</span><b><a href="#rectangle-x-coordinate">#rectangle-x-coordinate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle-x-coordinate">3. The DOMRect interfaces</a> <a href="#ref-for-rectangle-x-coordinate①">(2)</a> <a href="#ref-for-rectangle-x-coordinate②">(3)</a> <a href="#ref-for-rectangle-x-coordinate③">(4)</a> <a href="#ref-for-rectangle-x-coordinate④">(5)</a> <a href="#ref-for-rectangle-x-coordinate⑤">(6)</a> <a href="#ref-for-rectangle-x-coordinate⑥">(7)</a> <a href="#ref-for-rectangle-x-coordinate⑦">(8)</a> <a href="#ref-for-rectangle-x-coordinate⑧">(9)</a>
     <li><a href="#ref-for-rectangle-x-coordinate⑨">5. The DOMQuad interface</a>
     <li><a href="#ref-for-rectangle-x-coordinate①⓪">7. Structured serialization</a> <a href="#ref-for-rectangle-x-coordinate①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle-y-coordinate">
-   <b><a href="#rectangle-y-coordinate">#rectangle-y-coordinate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle-y-coordinate" class="dfn-panel" data-for="rectangle-y-coordinate" id="infopanel-for-rectangle-y-coordinate" role="dialog">
+   <span id="infopaneltitle-for-rectangle-y-coordinate" style="display:none">Info about the 'y coordinate' definition.</span><b><a href="#rectangle-y-coordinate">#rectangle-y-coordinate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle-y-coordinate">3. The DOMRect interfaces</a> <a href="#ref-for-rectangle-y-coordinate①">(2)</a> <a href="#ref-for-rectangle-y-coordinate②">(3)</a> <a href="#ref-for-rectangle-y-coordinate③">(4)</a> <a href="#ref-for-rectangle-y-coordinate④">(5)</a> <a href="#ref-for-rectangle-y-coordinate⑤">(6)</a> <a href="#ref-for-rectangle-y-coordinate⑥">(7)</a> <a href="#ref-for-rectangle-y-coordinate⑦">(8)</a> <a href="#ref-for-rectangle-y-coordinate⑧">(9)</a>
     <li><a href="#ref-for-rectangle-y-coordinate⑨">5. The DOMQuad interface</a>
     <li><a href="#ref-for-rectangle-y-coordinate①⓪">7. Structured serialization</a> <a href="#ref-for-rectangle-y-coordinate①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle-width-dimension">
-   <b><a href="#rectangle-width-dimension">#rectangle-width-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle-width-dimension" class="dfn-panel" data-for="rectangle-width-dimension" id="infopanel-for-rectangle-width-dimension" role="dialog">
+   <span id="infopaneltitle-for-rectangle-width-dimension" style="display:none">Info about the 'width dimension' definition.</span><b><a href="#rectangle-width-dimension">#rectangle-width-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle-width-dimension">3. The DOMRect interfaces</a> <a href="#ref-for-rectangle-width-dimension①">(2)</a> <a href="#ref-for-rectangle-width-dimension②">(3)</a> <a href="#ref-for-rectangle-width-dimension③">(4)</a> <a href="#ref-for-rectangle-width-dimension④">(5)</a> <a href="#ref-for-rectangle-width-dimension⑤">(6)</a> <a href="#ref-for-rectangle-width-dimension⑥">(7)</a> <a href="#ref-for-rectangle-width-dimension⑦">(8)</a>
     <li><a href="#ref-for-rectangle-width-dimension⑧">5. The DOMQuad interface</a>
     <li><a href="#ref-for-rectangle-width-dimension⑨">7. Structured serialization</a> <a href="#ref-for-rectangle-width-dimension①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rectangle-height-dimension">
-   <b><a href="#rectangle-height-dimension">#rectangle-height-dimension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rectangle-height-dimension" class="dfn-panel" data-for="rectangle-height-dimension" id="infopanel-for-rectangle-height-dimension" role="dialog">
+   <span id="infopaneltitle-for-rectangle-height-dimension" style="display:none">Info about the 'height dimension' definition.</span><b><a href="#rectangle-height-dimension">#rectangle-height-dimension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rectangle-height-dimension">3. The DOMRect interfaces</a> <a href="#ref-for-rectangle-height-dimension①">(2)</a> <a href="#ref-for-rectangle-height-dimension②">(3)</a> <a href="#ref-for-rectangle-height-dimension③">(4)</a> <a href="#ref-for-rectangle-height-dimension④">(5)</a> <a href="#ref-for-rectangle-height-dimension⑤">(6)</a> <a href="#ref-for-rectangle-height-dimension⑥">(7)</a> <a href="#ref-for-rectangle-height-dimension⑦">(8)</a>
     <li><a href="#ref-for-rectangle-height-dimension⑧">5. The DOMQuad interface</a>
     <li><a href="#ref-for-rectangle-height-dimension⑨">7. Structured serialization</a> <a href="#ref-for-rectangle-height-dimension①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domrectreadonly">
-   <b><a href="#domrectreadonly">#domrectreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domrectreadonly" class="dfn-panel" data-for="domrectreadonly" id="infopanel-for-domrectreadonly" role="dialog">
+   <span id="infopaneltitle-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' definition.</span><b><a href="#domrectreadonly">#domrectreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">3. The DOMRect interfaces</a> <a href="#ref-for-domrectreadonly①">(2)</a> <a href="#ref-for-domrectreadonly②">(3)</a> <a href="#ref-for-domrectreadonly③">(4)</a> <a href="#ref-for-domrectreadonly④">(5)</a> <a href="#ref-for-domrectreadonly⑤">(6)</a> <a href="#ref-for-domrectreadonly⑥">(7)</a> <a href="#ref-for-domrectreadonly⑦">(8)</a> <a href="#ref-for-domrectreadonly⑧">(9)</a>
     <li><a href="#ref-for-domrectreadonly⑨">7. Structured serialization</a> <a href="#ref-for-domrectreadonly①⓪">(2)</a>
     <li><a href="#ref-for-domrectreadonly①①">Changes since last publication</a> <a href="#ref-for-domrectreadonly①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgrect">
-   <b><a href="#svgrect">#svgrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgrect" class="dfn-panel" data-for="svgrect" id="infopanel-for-svgrect" role="dialog">
+   <span id="infopaneltitle-for-svgrect" style="display:none">Info about the 'SVGRect' definition.</span><b><a href="#svgrect">#svgrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgrect">1. Introduction</a>
     <li><a href="#ref-for-svgrect①">9.2. SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domrect">
-   <b><a href="#domrect">#domrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domrect" class="dfn-panel" data-for="domrect" id="infopanel-for-domrect" role="dialog">
+   <span id="infopaneltitle-for-domrect" style="display:none">Info about the 'DOMRect' definition.</span><b><a href="#domrect">#domrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">3. The DOMRect interfaces</a> <a href="#ref-for-domrect①">(2)</a> <a href="#ref-for-domrect②">(3)</a> <a href="#ref-for-domrect③">(4)</a> <a href="#ref-for-domrect④">(5)</a> <a href="#ref-for-domrect⑤">(6)</a> <a href="#ref-for-domrect⑥">(7)</a> <a href="#ref-for-domrect⑦">(8)</a> <a href="#ref-for-domrect⑧">(9)</a>
     <li><a href="#ref-for-domrect⑨">4. The DOMRectList interface</a> <a href="#ref-for-domrect①⓪">(2)</a> <a href="#ref-for-domrect①①">(3)</a> <a href="#ref-for-domrect①②">(4)</a>
@@ -5146,275 +5149,282 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-domrect②⓪">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-x">
-   <b><a href="#dom-domrect-x">#dom-domrect-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-x" class="dfn-panel" data-for="dom-domrect-x" id="infopanel-for-dom-domrect-x" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-domrect-x">#dom-domrect-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-x">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-y">
-   <b><a href="#dom-domrect-y">#dom-domrect-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-y" class="dfn-panel" data-for="dom-domrect-y" id="infopanel-for-dom-domrect-y" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-domrect-y">#dom-domrect-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-y">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-width">
-   <b><a href="#dom-domrect-width">#dom-domrect-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-width" class="dfn-panel" data-for="dom-domrect-width" id="infopanel-for-dom-domrect-width" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-domrect-width">#dom-domrect-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-width">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-height">
-   <b><a href="#dom-domrect-height">#dom-domrect-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-height" class="dfn-panel" data-for="dom-domrect-height" id="infopanel-for-dom-domrect-height" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-domrect-height">#dom-domrect-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-height">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-domrectinit">
-   <b><a href="#dictdef-domrectinit">#dictdef-domrectinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-domrectinit" class="dfn-panel" data-for="dictdef-domrectinit" id="infopanel-for-dictdef-domrectinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-domrectinit" style="display:none">Info about the 'DOMRectInit' definition.</span><b><a href="#dictdef-domrectinit">#dictdef-domrectinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-domrectinit">3. The DOMRect interfaces</a> <a href="#ref-for-dictdef-domrectinit①">(2)</a>
     <li><a href="#ref-for-dictdef-domrectinit②">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectinit-x">
-   <b><a href="#dom-domrectinit-x">#dom-domrectinit-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectinit-x" class="dfn-panel" data-for="dom-domrectinit-x" id="infopanel-for-dom-domrectinit-x" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectinit-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-domrectinit-x">#dom-domrectinit-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectinit-x">3. The DOMRect interfaces</a>
     <li><a href="#ref-for-dom-domrectinit-x①">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectinit-y">
-   <b><a href="#dom-domrectinit-y">#dom-domrectinit-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectinit-y" class="dfn-panel" data-for="dom-domrectinit-y" id="infopanel-for-dom-domrectinit-y" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectinit-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-domrectinit-y">#dom-domrectinit-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectinit-y">3. The DOMRect interfaces</a>
     <li><a href="#ref-for-dom-domrectinit-y①">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectinit-width">
-   <b><a href="#dom-domrectinit-width">#dom-domrectinit-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectinit-width" class="dfn-panel" data-for="dom-domrectinit-width" id="infopanel-for-dom-domrectinit-width" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectinit-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-domrectinit-width">#dom-domrectinit-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectinit-width">3. The DOMRect interfaces</a>
     <li><a href="#ref-for-dom-domrectinit-width①">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectinit-height">
-   <b><a href="#dom-domrectinit-height">#dom-domrectinit-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectinit-height" class="dfn-panel" data-for="dom-domrectinit-height" id="infopanel-for-dom-domrectinit-height" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectinit-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-domrectinit-height">#dom-domrectinit-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectinit-height">3. The DOMRect interfaces</a>
     <li><a href="#ref-for-dom-domrectinit-height①">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectreadonly-domrectreadonly">
-   <b><a href="#dom-domrectreadonly-domrectreadonly">#dom-domrectreadonly-domrectreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectreadonly-domrectreadonly" class="dfn-panel" data-for="dom-domrectreadonly-domrectreadonly" id="infopanel-for-dom-domrectreadonly-domrectreadonly" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectreadonly-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly(x,
+y, width, height)' definition.</span><b><a href="#dom-domrectreadonly-domrectreadonly">#dom-domrectreadonly-domrectreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectreadonly-domrectreadonly">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-domrect">
-   <b><a href="#dom-domrect-domrect">#dom-domrect-domrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-domrect" class="dfn-panel" data-for="dom-domrect-domrect" id="infopanel-for-dom-domrect-domrect" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-domrect" style="display:none">Info about the 'DOMRect(x, y, width,
+height)' definition.</span><b><a href="#dom-domrect-domrect">#dom-domrect-domrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-domrect">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectreadonly-fromrect">
-   <b><a href="#dom-domrectreadonly-fromrect">#dom-domrectreadonly-fromrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectreadonly-fromrect" class="dfn-panel" data-for="dom-domrectreadonly-fromrect" id="infopanel-for-dom-domrectreadonly-fromrect" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectreadonly-fromrect" style="display:none">Info about the 'fromRect(other)' definition.</span><b><a href="#dom-domrectreadonly-fromrect">#dom-domrectreadonly-fromrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectreadonly-fromrect">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrect-fromrect">
-   <b><a href="#dom-domrect-fromrect">#dom-domrect-fromrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrect-fromrect" class="dfn-panel" data-for="dom-domrect-fromrect" id="infopanel-for-dom-domrect-fromrect" role="dialog">
+   <span id="infopaneltitle-for-dom-domrect-fromrect" style="display:none">Info about the 'fromRect(other)' definition.</span><b><a href="#dom-domrect-fromrect">#dom-domrect-fromrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrect-fromrect">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-domrectreadonly-from-the-dictionary">
-   <b><a href="#create-a-domrectreadonly-from-the-dictionary">#create-a-domrectreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-domrectreadonly-from-the-dictionary" class="dfn-panel" data-for="create-a-domrectreadonly-from-the-dictionary" id="infopanel-for-create-a-domrectreadonly-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-domrectreadonly-from-the-dictionary" style="display:none">Info about the 'create a DOMRectReadOnly
+from a dictionary' definition.</span><b><a href="#create-a-domrectreadonly-from-the-dictionary">#create-a-domrectreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-domrectreadonly-from-the-dictionary">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-domrect-from-the-dictionary">
-   <b><a href="#create-a-domrect-from-the-dictionary">#create-a-domrect-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-domrect-from-the-dictionary" class="dfn-panel" data-for="create-a-domrect-from-the-dictionary" id="infopanel-for-create-a-domrect-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-domrect-from-the-dictionary" style="display:none">Info about the 'create a DOMRect from a dictionary' definition.</span><b><a href="#create-a-domrect-from-the-dictionary">#create-a-domrect-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-domrect-from-the-dictionary">3. The DOMRect interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domrectlist">
-   <b><a href="#domrectlist">#domrectlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domrectlist" class="dfn-panel" data-for="domrectlist" id="infopanel-for-domrectlist" role="dialog">
+   <span id="infopaneltitle-for-domrectlist" style="display:none">Info about the 'DOMRectList' definition.</span><b><a href="#domrectlist">#domrectlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectlist">4. The DOMRectList interface</a> <a href="#ref-for-domrectlist①">(2)</a> <a href="#ref-for-domrectlist②">(3)</a>
     <li><a href="#ref-for-domrectlist③">Changes since last publication</a> <a href="#ref-for-domrectlist④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectlist-length">
-   <b><a href="#dom-domrectlist-length">#dom-domrectlist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectlist-length" class="dfn-panel" data-for="dom-domrectlist-length" id="infopanel-for-dom-domrectlist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectlist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-domrectlist-length">#dom-domrectlist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectlist-length">4. The DOMRectList interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domrectlist-item">
-   <b><a href="#dom-domrectlist-item">#dom-domrectlist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domrectlist-item" class="dfn-panel" data-for="dom-domrectlist-item" id="infopanel-for-dom-domrectlist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-domrectlist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-domrectlist-item">#dom-domrectlist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domrectlist-item">4. The DOMRectList interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domquad">
-   <b><a href="#domquad">#domquad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domquad" class="dfn-panel" data-for="domquad" id="infopanel-for-domquad" role="dialog">
+   <span id="infopaneltitle-for-domquad" style="display:none">Info about the 'DOMQuad' definition.</span><b><a href="#domquad">#domquad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domquad">5. The DOMQuad interface</a> <a href="#ref-for-domquad①">(2)</a> <a href="#ref-for-domquad②">(3)</a> <a href="#ref-for-domquad③">(4)</a> <a href="#ref-for-domquad④">(5)</a> <a href="#ref-for-domquad⑤">(6)</a> <a href="#ref-for-domquad⑥">(7)</a> <a href="#ref-for-domquad⑦">(8)</a> <a href="#ref-for-domquad⑧">(9)</a> <a href="#ref-for-domquad⑨">(10)</a> <a href="#ref-for-domquad①⓪">(11)</a> <a href="#ref-for-domquad①①">(12)</a> <a href="#ref-for-domquad①②">(13)</a> <a href="#ref-for-domquad①③">(14)</a> <a href="#ref-for-domquad①④">(15)</a> <a href="#ref-for-domquad①⑤">(16)</a>
     <li><a href="#ref-for-domquad①⑥">7. Structured serialization</a> <a href="#ref-for-domquad①⑦">(2)</a>
     <li><a href="#ref-for-domquad①⑧">Changes since last publication</a> <a href="#ref-for-domquad①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-domquadinit">
-   <b><a href="#dictdef-domquadinit">#dictdef-domquadinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-domquadinit" class="dfn-panel" data-for="dictdef-domquadinit" id="infopanel-for-dictdef-domquadinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-domquadinit" style="display:none">Info about the 'DOMQuadInit' definition.</span><b><a href="#dictdef-domquadinit">#dictdef-domquadinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-domquadinit">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquadinit-p1">
-   <b><a href="#dom-domquadinit-p1">#dom-domquadinit-p1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquadinit-p1" class="dfn-panel" data-for="dom-domquadinit-p1" id="infopanel-for-dom-domquadinit-p1" role="dialog">
+   <span id="infopaneltitle-for-dom-domquadinit-p1" style="display:none">Info about the 'p1' definition.</span><b><a href="#dom-domquadinit-p1">#dom-domquadinit-p1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquadinit-p1">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquadinit-p2">
-   <b><a href="#dom-domquadinit-p2">#dom-domquadinit-p2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquadinit-p2" class="dfn-panel" data-for="dom-domquadinit-p2" id="infopanel-for-dom-domquadinit-p2" role="dialog">
+   <span id="infopaneltitle-for-dom-domquadinit-p2" style="display:none">Info about the 'p2' definition.</span><b><a href="#dom-domquadinit-p2">#dom-domquadinit-p2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquadinit-p2">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquadinit-p3">
-   <b><a href="#dom-domquadinit-p3">#dom-domquadinit-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquadinit-p3" class="dfn-panel" data-for="dom-domquadinit-p3" id="infopanel-for-dom-domquadinit-p3" role="dialog">
+   <span id="infopaneltitle-for-dom-domquadinit-p3" style="display:none">Info about the 'p3' definition.</span><b><a href="#dom-domquadinit-p3">#dom-domquadinit-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquadinit-p3">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquadinit-p4">
-   <b><a href="#dom-domquadinit-p4">#dom-domquadinit-p4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquadinit-p4" class="dfn-panel" data-for="dom-domquadinit-p4" id="infopanel-for-dom-domquadinit-p4" role="dialog">
+   <span id="infopaneltitle-for-dom-domquadinit-p4" style="display:none">Info about the 'p4' definition.</span><b><a href="#dom-domquadinit-p4">#dom-domquadinit-p4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquadinit-p4">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quadrilateral-point-1">
-   <b><a href="#quadrilateral-point-1">#quadrilateral-point-1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quadrilateral-point-1" class="dfn-panel" data-for="quadrilateral-point-1" id="infopanel-for-quadrilateral-point-1" role="dialog">
+   <span id="infopaneltitle-for-quadrilateral-point-1" style="display:none">Info about the 'point 1' definition.</span><b><a href="#quadrilateral-point-1">#quadrilateral-point-1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quadrilateral-point-1">5. The DOMQuad interface</a> <a href="#ref-for-quadrilateral-point-1①">(2)</a> <a href="#ref-for-quadrilateral-point-1②">(3)</a> <a href="#ref-for-quadrilateral-point-1③">(4)</a> <a href="#ref-for-quadrilateral-point-1④">(5)</a> <a href="#ref-for-quadrilateral-point-1⑤">(6)</a> <a href="#ref-for-quadrilateral-point-1⑥">(7)</a> <a href="#ref-for-quadrilateral-point-1⑦">(8)</a>
     <li><a href="#ref-for-quadrilateral-point-1⑧">7. Structured serialization</a> <a href="#ref-for-quadrilateral-point-1⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quadrilateral-point-2">
-   <b><a href="#quadrilateral-point-2">#quadrilateral-point-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quadrilateral-point-2" class="dfn-panel" data-for="quadrilateral-point-2" id="infopanel-for-quadrilateral-point-2" role="dialog">
+   <span id="infopaneltitle-for-quadrilateral-point-2" style="display:none">Info about the 'point 2' definition.</span><b><a href="#quadrilateral-point-2">#quadrilateral-point-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quadrilateral-point-2">5. The DOMQuad interface</a> <a href="#ref-for-quadrilateral-point-2①">(2)</a> <a href="#ref-for-quadrilateral-point-2②">(3)</a> <a href="#ref-for-quadrilateral-point-2③">(4)</a> <a href="#ref-for-quadrilateral-point-2④">(5)</a> <a href="#ref-for-quadrilateral-point-2⑤">(6)</a> <a href="#ref-for-quadrilateral-point-2⑥">(7)</a> <a href="#ref-for-quadrilateral-point-2⑦">(8)</a>
     <li><a href="#ref-for-quadrilateral-point-2⑧">7. Structured serialization</a> <a href="#ref-for-quadrilateral-point-2⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quadrilateral-point-3">
-   <b><a href="#quadrilateral-point-3">#quadrilateral-point-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quadrilateral-point-3" class="dfn-panel" data-for="quadrilateral-point-3" id="infopanel-for-quadrilateral-point-3" role="dialog">
+   <span id="infopaneltitle-for-quadrilateral-point-3" style="display:none">Info about the 'point
+3' definition.</span><b><a href="#quadrilateral-point-3">#quadrilateral-point-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quadrilateral-point-3">5. The DOMQuad interface</a> <a href="#ref-for-quadrilateral-point-3①">(2)</a> <a href="#ref-for-quadrilateral-point-3②">(3)</a> <a href="#ref-for-quadrilateral-point-3③">(4)</a> <a href="#ref-for-quadrilateral-point-3④">(5)</a> <a href="#ref-for-quadrilateral-point-3⑤">(6)</a> <a href="#ref-for-quadrilateral-point-3⑥">(7)</a> <a href="#ref-for-quadrilateral-point-3⑦">(8)</a>
     <li><a href="#ref-for-quadrilateral-point-3⑧">7. Structured serialization</a> <a href="#ref-for-quadrilateral-point-3⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quadrilateral-point-4">
-   <b><a href="#quadrilateral-point-4">#quadrilateral-point-4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quadrilateral-point-4" class="dfn-panel" data-for="quadrilateral-point-4" id="infopanel-for-quadrilateral-point-4" role="dialog">
+   <span id="infopaneltitle-for-quadrilateral-point-4" style="display:none">Info about the 'point 4' definition.</span><b><a href="#quadrilateral-point-4">#quadrilateral-point-4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quadrilateral-point-4">5. The DOMQuad interface</a> <a href="#ref-for-quadrilateral-point-4①">(2)</a> <a href="#ref-for-quadrilateral-point-4②">(3)</a> <a href="#ref-for-quadrilateral-point-4③">(4)</a> <a href="#ref-for-quadrilateral-point-4④">(5)</a> <a href="#ref-for-quadrilateral-point-4⑤">(6)</a> <a href="#ref-for-quadrilateral-point-4⑥">(7)</a> <a href="#ref-for-quadrilateral-point-4⑦">(8)</a>
     <li><a href="#ref-for-quadrilateral-point-4⑧">7. Structured serialization</a> <a href="#ref-for-quadrilateral-point-4⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-domquad">
-   <b><a href="#dom-domquad-domquad">#dom-domquad-domquad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-domquad" class="dfn-panel" data-for="dom-domquad-domquad" id="infopanel-for-dom-domquad-domquad" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-domquad" style="display:none">Info about the 'DOMQuad(p1, p2,
+p3, p4)' definition.</span><b><a href="#dom-domquad-domquad">#dom-domquad-domquad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-domquad">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-fromrect">
-   <b><a href="#dom-domquad-fromrect">#dom-domquad-fromrect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-fromrect" class="dfn-panel" data-for="dom-domquad-fromrect" id="infopanel-for-dom-domquad-fromrect" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-fromrect" style="display:none">Info about the 'fromRect(other)' definition.</span><b><a href="#dom-domquad-fromrect">#dom-domquad-fromrect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-fromrect">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-domquad-from-the-domrectinit-dictionary">
-   <b><a href="#create-a-domquad-from-the-domrectinit-dictionary">#create-a-domquad-from-the-domrectinit-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-domquad-from-the-domrectinit-dictionary" class="dfn-panel" data-for="create-a-domquad-from-the-domrectinit-dictionary" id="infopanel-for-create-a-domquad-from-the-domrectinit-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-domquad-from-the-domrectinit-dictionary" style="display:none">Info about the 'create a DOMQuad from
+a DOMRectInit dictionary' definition.</span><b><a href="#create-a-domquad-from-the-domrectinit-dictionary">#create-a-domquad-from-the-domrectinit-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-domquad-from-the-domrectinit-dictionary">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-fromquad">
-   <b><a href="#dom-domquad-fromquad">#dom-domquad-fromquad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-fromquad" class="dfn-panel" data-for="dom-domquad-fromquad" id="infopanel-for-dom-domquad-fromquad" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-fromquad" style="display:none">Info about the 'fromQuad(other)' definition.</span><b><a href="#dom-domquad-fromquad">#dom-domquad-fromquad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-fromquad">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-domquad-from-the-domquadinit-dictionary">
-   <b><a href="#create-a-domquad-from-the-domquadinit-dictionary">#create-a-domquad-from-the-domquadinit-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-domquad-from-the-domquadinit-dictionary" class="dfn-panel" data-for="create-a-domquad-from-the-domquadinit-dictionary" id="infopanel-for-create-a-domquad-from-the-domquadinit-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-domquad-from-the-domquadinit-dictionary" style="display:none">Info about the 'create a DOMQuad from
+a DOMQuadInit dictionary' definition.</span><b><a href="#create-a-domquad-from-the-domquadinit-dictionary">#create-a-domquad-from-the-domquadinit-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-domquad-from-the-domquadinit-dictionary">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-p1">
-   <b><a href="#dom-domquad-p1">#dom-domquad-p1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-p1" class="dfn-panel" data-for="dom-domquad-p1" id="infopanel-for-dom-domquad-p1" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-p1" style="display:none">Info about the 'p1' definition.</span><b><a href="#dom-domquad-p1">#dom-domquad-p1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-p1">5. The DOMQuad interface</a> <a href="#ref-for-dom-domquad-p1①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-p2">
-   <b><a href="#dom-domquad-p2">#dom-domquad-p2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-p2" class="dfn-panel" data-for="dom-domquad-p2" id="infopanel-for-dom-domquad-p2" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-p2" style="display:none">Info about the 'p2' definition.</span><b><a href="#dom-domquad-p2">#dom-domquad-p2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-p2">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-p3">
-   <b><a href="#dom-domquad-p3">#dom-domquad-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-p3" class="dfn-panel" data-for="dom-domquad-p3" id="infopanel-for-dom-domquad-p3" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-p3" style="display:none">Info about the 'p3' definition.</span><b><a href="#dom-domquad-p3">#dom-domquad-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-p3">5. The DOMQuad interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-p4">
-   <b><a href="#dom-domquad-p4">#dom-domquad-p4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-p4" class="dfn-panel" data-for="dom-domquad-p4" id="infopanel-for-dom-domquad-p4" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-p4" style="display:none">Info about the 'p4' definition.</span><b><a href="#dom-domquad-p4">#dom-domquad-p4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-p4">5. The DOMQuad interface</a> <a href="#ref-for-dom-domquad-p4①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domquad-getbounds">
-   <b><a href="#dom-domquad-getbounds">#dom-domquad-getbounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domquad-getbounds" class="dfn-panel" data-for="dom-domquad-getbounds" id="infopanel-for-dom-domquad-getbounds" role="dialog">
+   <span id="infopaneltitle-for-dom-domquad-getbounds" style="display:none">Info about the 'getBounds()' definition.</span><b><a href="#dom-domquad-getbounds">#dom-domquad-getbounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domquad-getbounds">5. The DOMQuad interface</a> <a href="#ref-for-dom-domquad-getbounds①">(2)</a>
     <li><a href="#ref-for-dom-domquad-getbounds②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix">
-   <b><a href="#matrix">#matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix" class="dfn-panel" data-for="matrix" id="infopanel-for-matrix" role="dialog">
+   <span id="infopaneltitle-for-matrix" style="display:none">Info about the 'matrix' definition.</span><b><a href="#matrix">#matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix">2.1. Transforming a point with a matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="4x4-abstract-matrix">
-   <b><a href="#4x4-abstract-matrix">#4x4-abstract-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-4x4-abstract-matrix" class="dfn-panel" data-for="4x4-abstract-matrix" id="infopanel-for-4x4-abstract-matrix" role="dialog">
+   <span id="infopaneltitle-for-4x4-abstract-matrix" style="display:none">Info about the '4x4 abstract matrix' definition.</span><b><a href="#4x4-abstract-matrix">#4x4-abstract-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-4x4-abstract-matrix">6.2. Parsing a string into an abstract matrix</a> <a href="#ref-for-4x4-abstract-matrix①">(2)</a> <a href="#ref-for-4x4-abstract-matrix②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="post-multiply">
-   <b><a href="#post-multiply">#post-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-post-multiply" class="dfn-panel" data-for="post-multiply" id="infopanel-for-post-multiply" role="dialog">
+   <span id="infopaneltitle-for-post-multiply" style="display:none">Info about the 'post-multiply' definition.</span><b><a href="#post-multiply">#post-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-post-multiply">6.2. Parsing a string into an abstract matrix</a>
     <li><a href="#ref-for-post-multiply①">6.5. Immutable transformation methods</a> <a href="#ref-for-post-multiply②">(2)</a>
     <li><a href="#ref-for-post-multiply③">6.6. Mutable transformation methods</a> <a href="#ref-for-post-multiply④">(2)</a> <a href="#ref-for-post-multiply⑤">(3)</a> <a href="#ref-for-post-multiply⑥">(4)</a> <a href="#ref-for-post-multiply⑦">(5)</a> <a href="#ref-for-post-multiply⑧">(6)</a> <a href="#ref-for-post-multiply⑨">(7)</a> <a href="#ref-for-post-multiply①⓪">(8)</a> <a href="#ref-for-post-multiply①①">(9)</a> <a href="#ref-for-post-multiply①②">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pre-multiply">
-   <b><a href="#pre-multiply">#pre-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pre-multiply" class="dfn-panel" data-for="pre-multiply" id="infopanel-for-pre-multiply" role="dialog">
+   <span id="infopaneltitle-for-pre-multiply" style="display:none">Info about the 'pre-multiply' definition.</span><b><a href="#pre-multiply">#pre-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pre-multiply">2.1. Transforming a point with a matrix</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dommatrixreadonly">
-   <b><a href="#dommatrixreadonly">#dommatrixreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dommatrixreadonly" class="dfn-panel" data-for="dommatrixreadonly" id="infopanel-for-dommatrixreadonly" role="dialog">
+   <span id="infopaneltitle-for-dommatrixreadonly" style="display:none">Info about the 'DOMMatrixReadOnly' definition.</span><b><a href="#dommatrixreadonly">#dommatrixreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrixreadonly">6. The DOMMatrix interfaces</a> <a href="#ref-for-dommatrixreadonly①">(2)</a> <a href="#ref-for-dommatrixreadonly②">(3)</a> <a href="#ref-for-dommatrixreadonly③">(4)</a> <a href="#ref-for-dommatrixreadonly④">(5)</a> <a href="#ref-for-dommatrixreadonly⑤">(6)</a> <a href="#ref-for-dommatrixreadonly⑥">(7)</a> <a href="#ref-for-dommatrixreadonly⑦">(8)</a> <a href="#ref-for-dommatrixreadonly⑧">(9)</a>
     <li><a href="#ref-for-dommatrixreadonly⑨">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dommatrixreadonly①⓪">(2)</a> <a href="#ref-for-dommatrixreadonly①①">(3)</a> <a href="#ref-for-dommatrixreadonly①②">(4)</a> <a href="#ref-for-dommatrixreadonly①③">(5)</a> <a href="#ref-for-dommatrixreadonly①④">(6)</a> <a href="#ref-for-dommatrixreadonly①⑤">(7)</a> <a href="#ref-for-dommatrixreadonly①⑥">(8)</a> <a href="#ref-for-dommatrixreadonly①⑦">(9)</a> <a href="#ref-for-dommatrixreadonly①⑧">(10)</a> <a href="#ref-for-dommatrixreadonly①⑨">(11)</a> <a href="#ref-for-dommatrixreadonly②⓪">(12)</a> <a href="#ref-for-dommatrixreadonly②①">(13)</a> <a href="#ref-for-dommatrixreadonly②②">(14)</a> <a href="#ref-for-dommatrixreadonly②③">(15)</a> <a href="#ref-for-dommatrixreadonly②④">(16)</a> <a href="#ref-for-dommatrixreadonly②⑤">(17)</a>
@@ -5424,23 +5434,23 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dommatrixreadonly③②">Changes since last publication</a> <a href="#ref-for-dommatrixreadonly③③">(2)</a> <a href="#ref-for-dommatrixreadonly③④">(3)</a> <a href="#ref-for-dommatrixreadonly③⑤">(4)</a> <a href="#ref-for-dommatrixreadonly③⑥">(5)</a> <a href="#ref-for-dommatrixreadonly③⑦">(6)</a> <a href="#ref-for-dommatrixreadonly③⑧">(7)</a> <a href="#ref-for-dommatrixreadonly③⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="svgmatrix">
-   <b><a href="#svgmatrix">#svgmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgmatrix" class="dfn-panel" data-for="svgmatrix" id="infopanel-for-svgmatrix" role="dialog">
+   <span id="infopaneltitle-for-svgmatrix" style="display:none">Info about the 'SVGMatrix' definition.</span><b><a href="#svgmatrix">#svgmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgmatrix">1. Introduction</a>
     <li><a href="#ref-for-svgmatrix①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-svgmatrix②">9.2. SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webkitcssmatrix">
-   <b><a href="#webkitcssmatrix">#webkitcssmatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webkitcssmatrix" class="dfn-panel" data-for="webkitcssmatrix" id="infopanel-for-webkitcssmatrix" role="dialog">
+   <span id="infopaneltitle-for-webkitcssmatrix" style="display:none">Info about the 'WebKitCSSMatrix' definition.</span><b><a href="#webkitcssmatrix">#webkitcssmatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webkitcssmatrix">9.3. Non-standard</a>
     <li><a href="#ref-for-webkitcssmatrix①">Changes since last publication</a> <a href="#ref-for-webkitcssmatrix②">(2)</a> <a href="#ref-for-webkitcssmatrix③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dommatrix">
-   <b><a href="#dommatrix">#dommatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dommatrix" class="dfn-panel" data-for="dommatrix" id="infopanel-for-dommatrix" role="dialog">
+   <span id="infopaneltitle-for-dommatrix" style="display:none">Info about the 'DOMMatrix' definition.</span><b><a href="#dommatrix">#dommatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrix">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-dommatrix①">6. The DOMMatrix interfaces</a> <a href="#ref-for-dommatrix②">(2)</a> <a href="#ref-for-dommatrix③">(3)</a> <a href="#ref-for-dommatrix④">(4)</a> <a href="#ref-for-dommatrix⑤">(5)</a> <a href="#ref-for-dommatrix⑥">(6)</a> <a href="#ref-for-dommatrix⑦">(7)</a> <a href="#ref-for-dommatrix⑧">(8)</a> <a href="#ref-for-dommatrix⑨">(9)</a> <a href="#ref-for-dommatrix①⓪">(10)</a> <a href="#ref-for-dommatrix①①">(11)</a> <a href="#ref-for-dommatrix①②">(12)</a> <a href="#ref-for-dommatrix①③">(13)</a> <a href="#ref-for-dommatrix①④">(14)</a> <a href="#ref-for-dommatrix①⑤">(15)</a> <a href="#ref-for-dommatrix①⑥">(16)</a> <a href="#ref-for-dommatrix①⑦">(17)</a> <a href="#ref-for-dommatrix①⑧">(18)</a> <a href="#ref-for-dommatrix①⑨">(19)</a> <a href="#ref-for-dommatrix②⓪">(20)</a> <a href="#ref-for-dommatrix②①">(21)</a> <a href="#ref-for-dommatrix②②">(22)</a> <a href="#ref-for-dommatrix②③">(23)</a> <a href="#ref-for-dommatrix②④">(24)</a> <a href="#ref-for-dommatrix②⑤">(25)</a> <a href="#ref-for-dommatrix②⑥">(26)</a> <a href="#ref-for-dommatrix②⑦">(27)</a> <a href="#ref-for-dommatrix②⑧">(28)</a> <a href="#ref-for-dommatrix②⑨">(29)</a> <a href="#ref-for-dommatrix③⓪">(30)</a> <a href="#ref-for-dommatrix③①">(31)</a>
@@ -5455,93 +5465,93 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dommatrix⑦④">Changes since last publication</a> <a href="#ref-for-dommatrix⑦⑤">(2)</a> <a href="#ref-for-dommatrix⑦⑥">(3)</a> <a href="#ref-for-dommatrix⑦⑦">(4)</a> <a href="#ref-for-dommatrix⑦⑧">(5)</a> <a href="#ref-for-dommatrix⑦⑨">(6)</a> <a href="#ref-for-dommatrix⑧⓪">(7)</a> <a href="#ref-for-dommatrix⑧①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-dommatrix2dinit">
-   <b><a href="#dictdef-dommatrix2dinit">#dictdef-dommatrix2dinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dommatrix2dinit" class="dfn-panel" data-for="dictdef-dommatrix2dinit" id="infopanel-for-dictdef-dommatrix2dinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dommatrix2dinit" style="display:none">Info about the 'DOMMatrix2DInit' definition.</span><b><a href="#dictdef-dommatrix2dinit">#dictdef-dommatrix2dinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dommatrix2dinit">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dictdef-dommatrix2dinit①">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-a">
-   <b><a href="#dom-dommatrix2dinit-a">#dom-dommatrix2dinit-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-a" class="dfn-panel" data-for="dom-dommatrix2dinit-a" id="infopanel-for-dom-dommatrix2dinit-a" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-a" style="display:none">Info about the 'a' definition.</span><b><a href="#dom-dommatrix2dinit-a">#dom-dommatrix2dinit-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-a">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-a①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-a②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-a③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-b">
-   <b><a href="#dom-dommatrix2dinit-b">#dom-dommatrix2dinit-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-b" class="dfn-panel" data-for="dom-dommatrix2dinit-b" id="infopanel-for-dom-dommatrix2dinit-b" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-b" style="display:none">Info about the 'b' definition.</span><b><a href="#dom-dommatrix2dinit-b">#dom-dommatrix2dinit-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-b">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-b①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-b②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-b③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-c">
-   <b><a href="#dom-dommatrix2dinit-c">#dom-dommatrix2dinit-c</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-c" class="dfn-panel" data-for="dom-dommatrix2dinit-c" id="infopanel-for-dom-dommatrix2dinit-c" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-c" style="display:none">Info about the 'c' definition.</span><b><a href="#dom-dommatrix2dinit-c">#dom-dommatrix2dinit-c</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-c">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-c①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-c②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-c③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-d">
-   <b><a href="#dom-dommatrix2dinit-d">#dom-dommatrix2dinit-d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-d" class="dfn-panel" data-for="dom-dommatrix2dinit-d" id="infopanel-for-dom-dommatrix2dinit-d" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-d" style="display:none">Info about the 'd' definition.</span><b><a href="#dom-dommatrix2dinit-d">#dom-dommatrix2dinit-d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-d">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-d①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-d②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-d③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-e">
-   <b><a href="#dom-dommatrix2dinit-e">#dom-dommatrix2dinit-e</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-e" class="dfn-panel" data-for="dom-dommatrix2dinit-e" id="infopanel-for-dom-dommatrix2dinit-e" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-e" style="display:none">Info about the 'e' definition.</span><b><a href="#dom-dommatrix2dinit-e">#dom-dommatrix2dinit-e</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-e">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-e①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-e②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-e③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-f">
-   <b><a href="#dom-dommatrix2dinit-f">#dom-dommatrix2dinit-f</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-f" class="dfn-panel" data-for="dom-dommatrix2dinit-f" id="infopanel-for-dom-dommatrix2dinit-f" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-f" style="display:none">Info about the 'f' definition.</span><b><a href="#dom-dommatrix2dinit-f">#dom-dommatrix2dinit-f</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-f">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-f①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-f②">(3)</a> <a href="#ref-for-dom-dommatrix2dinit-f③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m11">
-   <b><a href="#dom-dommatrix2dinit-m11">#dom-dommatrix2dinit-m11</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m11" class="dfn-panel" data-for="dom-dommatrix2dinit-m11" id="infopanel-for-dom-dommatrix2dinit-m11" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m11" style="display:none">Info about the 'm11' definition.</span><b><a href="#dom-dommatrix2dinit-m11">#dom-dommatrix2dinit-m11</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m11">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m11①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m11②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m11③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m11④">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m11⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m12">
-   <b><a href="#dom-dommatrix2dinit-m12">#dom-dommatrix2dinit-m12</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m12" class="dfn-panel" data-for="dom-dommatrix2dinit-m12" id="infopanel-for-dom-dommatrix2dinit-m12" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m12" style="display:none">Info about the 'm12' definition.</span><b><a href="#dom-dommatrix2dinit-m12">#dom-dommatrix2dinit-m12</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m12">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m12①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m12②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m12③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m12④">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m12⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m21">
-   <b><a href="#dom-dommatrix2dinit-m21">#dom-dommatrix2dinit-m21</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m21" class="dfn-panel" data-for="dom-dommatrix2dinit-m21" id="infopanel-for-dom-dommatrix2dinit-m21" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m21" style="display:none">Info about the 'm21' definition.</span><b><a href="#dom-dommatrix2dinit-m21">#dom-dommatrix2dinit-m21</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m21">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m21①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m21②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m21③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m21④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m22">
-   <b><a href="#dom-dommatrix2dinit-m22">#dom-dommatrix2dinit-m22</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m22" class="dfn-panel" data-for="dom-dommatrix2dinit-m22" id="infopanel-for-dom-dommatrix2dinit-m22" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m22" style="display:none">Info about the 'm22' definition.</span><b><a href="#dom-dommatrix2dinit-m22">#dom-dommatrix2dinit-m22</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m22">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m22①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m22②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m22③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m22④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m41">
-   <b><a href="#dom-dommatrix2dinit-m41">#dom-dommatrix2dinit-m41</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m41" class="dfn-panel" data-for="dom-dommatrix2dinit-m41" id="infopanel-for-dom-dommatrix2dinit-m41" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m41" style="display:none">Info about the 'm41' definition.</span><b><a href="#dom-dommatrix2dinit-m41">#dom-dommatrix2dinit-m41</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m41">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m41①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m41②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m41③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m41④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix2dinit-m42">
-   <b><a href="#dom-dommatrix2dinit-m42">#dom-dommatrix2dinit-m42</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix2dinit-m42" class="dfn-panel" data-for="dom-dommatrix2dinit-m42" id="infopanel-for-dom-dommatrix2dinit-m42" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix2dinit-m42" style="display:none">Info about the 'm42' definition.</span><b><a href="#dom-dommatrix2dinit-m42">#dom-dommatrix2dinit-m42</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix2dinit-m42">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrix2dinit-m42①">(2)</a> <a href="#ref-for-dom-dommatrix2dinit-m42②">(3)</a>
     <li><a href="#ref-for-dom-dommatrix2dinit-m42③">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-dom-dommatrix2dinit-m42④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-dommatrixinit">
-   <b><a href="#dictdef-dommatrixinit">#dictdef-dommatrixinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dommatrixinit" class="dfn-panel" data-for="dictdef-dommatrixinit" id="infopanel-for-dictdef-dommatrixinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dommatrixinit" style="display:none">Info about the 'DOMMatrixInit' definition.</span><b><a href="#dictdef-dommatrixinit">#dictdef-dommatrixinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dommatrixinit">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-dictdef-dommatrixinit①">6. The DOMMatrix interfaces</a> <a href="#ref-for-dictdef-dommatrixinit②">(2)</a> <a href="#ref-for-dictdef-dommatrixinit③">(3)</a> <a href="#ref-for-dictdef-dommatrixinit④">(4)</a> <a href="#ref-for-dictdef-dommatrixinit⑤">(5)</a>
@@ -5549,77 +5559,77 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dictdef-dommatrixinit⑧">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m13">
-   <b><a href="#dom-dommatrixinit-m13">#dom-dommatrixinit-m13</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m13" class="dfn-panel" data-for="dom-dommatrixinit-m13" id="infopanel-for-dom-dommatrixinit-m13" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m13" style="display:none">Info about the 'm13' definition.</span><b><a href="#dom-dommatrixinit-m13">#dom-dommatrixinit-m13</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m13">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m13①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixinit-m13②">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m14">
-   <b><a href="#dom-dommatrixinit-m14">#dom-dommatrixinit-m14</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m14" class="dfn-panel" data-for="dom-dommatrixinit-m14" id="infopanel-for-dom-dommatrixinit-m14" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m14" style="display:none">Info about the 'm14' definition.</span><b><a href="#dom-dommatrixinit-m14">#dom-dommatrixinit-m14</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m14">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m14①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m23">
-   <b><a href="#dom-dommatrixinit-m23">#dom-dommatrixinit-m23</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m23" class="dfn-panel" data-for="dom-dommatrixinit-m23" id="infopanel-for-dom-dommatrixinit-m23" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m23" style="display:none">Info about the 'm23' definition.</span><b><a href="#dom-dommatrixinit-m23">#dom-dommatrixinit-m23</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m23">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m23①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m24">
-   <b><a href="#dom-dommatrixinit-m24">#dom-dommatrixinit-m24</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m24" class="dfn-panel" data-for="dom-dommatrixinit-m24" id="infopanel-for-dom-dommatrixinit-m24" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m24" style="display:none">Info about the 'm24' definition.</span><b><a href="#dom-dommatrixinit-m24">#dom-dommatrixinit-m24</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m24">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m24①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m31">
-   <b><a href="#dom-dommatrixinit-m31">#dom-dommatrixinit-m31</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m31" class="dfn-panel" data-for="dom-dommatrixinit-m31" id="infopanel-for-dom-dommatrixinit-m31" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m31" style="display:none">Info about the 'm31' definition.</span><b><a href="#dom-dommatrixinit-m31">#dom-dommatrixinit-m31</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m31">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m31①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m32">
-   <b><a href="#dom-dommatrixinit-m32">#dom-dommatrixinit-m32</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m32" class="dfn-panel" data-for="dom-dommatrixinit-m32" id="infopanel-for-dom-dommatrixinit-m32" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m32" style="display:none">Info about the 'm32' definition.</span><b><a href="#dom-dommatrixinit-m32">#dom-dommatrixinit-m32</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m32">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m32①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m33">
-   <b><a href="#dom-dommatrixinit-m33">#dom-dommatrixinit-m33</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m33" class="dfn-panel" data-for="dom-dommatrixinit-m33" id="infopanel-for-dom-dommatrixinit-m33" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m33" style="display:none">Info about the 'm33' definition.</span><b><a href="#dom-dommatrixinit-m33">#dom-dommatrixinit-m33</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m33">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m33①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m34">
-   <b><a href="#dom-dommatrixinit-m34">#dom-dommatrixinit-m34</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m34" class="dfn-panel" data-for="dom-dommatrixinit-m34" id="infopanel-for-dom-dommatrixinit-m34" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m34" style="display:none">Info about the 'm34' definition.</span><b><a href="#dom-dommatrixinit-m34">#dom-dommatrixinit-m34</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m34">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m34①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m43">
-   <b><a href="#dom-dommatrixinit-m43">#dom-dommatrixinit-m43</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m43" class="dfn-panel" data-for="dom-dommatrixinit-m43" id="infopanel-for-dom-dommatrixinit-m43" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m43" style="display:none">Info about the 'm43' definition.</span><b><a href="#dom-dommatrixinit-m43">#dom-dommatrixinit-m43</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m43">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m43①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-m44">
-   <b><a href="#dom-dommatrixinit-m44">#dom-dommatrixinit-m44</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-m44" class="dfn-panel" data-for="dom-dommatrixinit-m44" id="infopanel-for-dom-dommatrixinit-m44" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-m44" style="display:none">Info about the 'm44' definition.</span><b><a href="#dom-dommatrixinit-m44">#dom-dommatrixinit-m44</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-m44">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-m44①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixinit-m44②">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixinit-is2d">
-   <b><a href="#dom-dommatrixinit-is2d">#dom-dommatrixinit-is2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixinit-is2d" class="dfn-panel" data-for="dom-dommatrixinit-is2d" id="infopanel-for-dom-dommatrixinit-is2d" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixinit-is2d" style="display:none">Info about the 'is2D' definition.</span><b><a href="#dom-dommatrixinit-is2d">#dom-dommatrixinit-is2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixinit-is2d">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a> <a href="#ref-for-dom-dommatrixinit-is2d①">(2)</a> <a href="#ref-for-dom-dommatrixinit-is2d②">(3)</a> <a href="#ref-for-dom-dommatrixinit-is2d③">(4)</a>
     <li><a href="#ref-for-dom-dommatrixinit-is2d④">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m11-element">
-   <b><a href="#matrix-m11-element">#matrix-m11-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m11-element" class="dfn-panel" data-for="matrix-m11-element" id="infopanel-for-matrix-m11-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m11-element" style="display:none">Info about the 'm11 element' definition.</span><b><a href="#matrix-m11-element">#matrix-m11-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m11-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-matrix-m11-element①">(2)</a>
     <li><a href="#ref-for-matrix-m11-element②">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m11-element③">(2)</a> <a href="#ref-for-matrix-m11-element④">(3)</a>
@@ -5628,8 +5638,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m11-element⑨">7. Structured serialization</a> <a href="#ref-for-matrix-m11-element①⓪">(2)</a> <a href="#ref-for-matrix-m11-element①①">(3)</a> <a href="#ref-for-matrix-m11-element①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m12-element">
-   <b><a href="#matrix-m12-element">#matrix-m12-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m12-element" class="dfn-panel" data-for="matrix-m12-element" id="infopanel-for-matrix-m12-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m12-element" style="display:none">Info about the 'm12 element' definition.</span><b><a href="#matrix-m12-element">#matrix-m12-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m12-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m12-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m12-element②">(2)</a> <a href="#ref-for-matrix-m12-element③">(3)</a>
@@ -5637,8 +5647,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m12-element⑥">7. Structured serialization</a> <a href="#ref-for-matrix-m12-element⑦">(2)</a> <a href="#ref-for-matrix-m12-element⑧">(3)</a> <a href="#ref-for-matrix-m12-element⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m13-element">
-   <b><a href="#matrix-m13-element">#matrix-m13-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m13-element" class="dfn-panel" data-for="matrix-m13-element" id="infopanel-for-matrix-m13-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m13-element" style="display:none">Info about the 'm13 element' definition.</span><b><a href="#matrix-m13-element">#matrix-m13-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m13-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m13-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m13-element②">(2)</a> <a href="#ref-for-matrix-m13-element③">(3)</a>
@@ -5646,8 +5656,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m13-element⑤">7. Structured serialization</a> <a href="#ref-for-matrix-m13-element⑥">(2)</a> <a href="#ref-for-matrix-m13-element⑦">(3)</a> <a href="#ref-for-matrix-m13-element⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m14-element">
-   <b><a href="#matrix-m14-element">#matrix-m14-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m14-element" class="dfn-panel" data-for="matrix-m14-element" id="infopanel-for-matrix-m14-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m14-element" style="display:none">Info about the 'm14 element' definition.</span><b><a href="#matrix-m14-element">#matrix-m14-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m14-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m14-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m14-element②">(2)</a> <a href="#ref-for-matrix-m14-element③">(3)</a>
@@ -5655,8 +5665,9 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m14-element⑤">7. Structured serialization</a> <a href="#ref-for-matrix-m14-element⑥">(2)</a> <a href="#ref-for-matrix-m14-element⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m21-element">
-   <b><a href="#matrix-m21-element">#matrix-m21-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m21-element" class="dfn-panel" data-for="matrix-m21-element" id="infopanel-for-matrix-m21-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m21-element" style="display:none">Info about the 'm21
+element' definition.</span><b><a href="#matrix-m21-element">#matrix-m21-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m21-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m21-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m21-element②">(2)</a> <a href="#ref-for-matrix-m21-element③">(3)</a>
@@ -5664,8 +5675,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m21-element⑥">7. Structured serialization</a> <a href="#ref-for-matrix-m21-element⑦">(2)</a> <a href="#ref-for-matrix-m21-element⑧">(3)</a> <a href="#ref-for-matrix-m21-element⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m22-element">
-   <b><a href="#matrix-m22-element">#matrix-m22-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m22-element" class="dfn-panel" data-for="matrix-m22-element" id="infopanel-for-matrix-m22-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m22-element" style="display:none">Info about the 'm22 element' definition.</span><b><a href="#matrix-m22-element">#matrix-m22-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m22-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m22-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m22-element②">(2)</a> <a href="#ref-for-matrix-m22-element③">(3)</a>
@@ -5673,8 +5684,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m22-element⑥">7. Structured serialization</a> <a href="#ref-for-matrix-m22-element⑦">(2)</a> <a href="#ref-for-matrix-m22-element⑧">(3)</a> <a href="#ref-for-matrix-m22-element⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m23-element">
-   <b><a href="#matrix-m23-element">#matrix-m23-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m23-element" class="dfn-panel" data-for="matrix-m23-element" id="infopanel-for-matrix-m23-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m23-element" style="display:none">Info about the 'm23 element' definition.</span><b><a href="#matrix-m23-element">#matrix-m23-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m23-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m23-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m23-element②">(2)</a> <a href="#ref-for-matrix-m23-element③">(3)</a>
@@ -5682,8 +5693,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m23-element⑤">7. Structured serialization</a> <a href="#ref-for-matrix-m23-element⑥">(2)</a> <a href="#ref-for-matrix-m23-element⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m24-element">
-   <b><a href="#matrix-m24-element">#matrix-m24-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m24-element" class="dfn-panel" data-for="matrix-m24-element" id="infopanel-for-matrix-m24-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m24-element" style="display:none">Info about the 'm24 element' definition.</span><b><a href="#matrix-m24-element">#matrix-m24-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m24-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m24-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m24-element②">(2)</a> <a href="#ref-for-matrix-m24-element③">(3)</a>
@@ -5691,40 +5702,41 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m24-element⑤">7. Structured serialization</a> <a href="#ref-for-matrix-m24-element⑥">(2)</a> <a href="#ref-for-matrix-m24-element⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m31-element">
-   <b><a href="#matrix-m31-element">#matrix-m31-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m31-element" class="dfn-panel" data-for="matrix-m31-element" id="infopanel-for-matrix-m31-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m31-element" style="display:none">Info about the 'm31 element' definition.</span><b><a href="#matrix-m31-element">#matrix-m31-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m31-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m31-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m31-element②">(2)</a> <a href="#ref-for-matrix-m31-element③">(3)</a>
     <li><a href="#ref-for-matrix-m31-element④">7. Structured serialization</a> <a href="#ref-for-matrix-m31-element⑤">(2)</a> <a href="#ref-for-matrix-m31-element⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m32-element">
-   <b><a href="#matrix-m32-element">#matrix-m32-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m32-element" class="dfn-panel" data-for="matrix-m32-element" id="infopanel-for-matrix-m32-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m32-element" style="display:none">Info about the 'm32
+element' definition.</span><b><a href="#matrix-m32-element">#matrix-m32-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m32-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m32-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m32-element②">(2)</a> <a href="#ref-for-matrix-m32-element③">(3)</a>
     <li><a href="#ref-for-matrix-m32-element④">7. Structured serialization</a> <a href="#ref-for-matrix-m32-element⑤">(2)</a> <a href="#ref-for-matrix-m32-element⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m33-element">
-   <b><a href="#matrix-m33-element">#matrix-m33-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m33-element" class="dfn-panel" data-for="matrix-m33-element" id="infopanel-for-matrix-m33-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m33-element" style="display:none">Info about the 'm33 element' definition.</span><b><a href="#matrix-m33-element">#matrix-m33-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m33-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m33-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m33-element②">(2)</a> <a href="#ref-for-matrix-m33-element③">(3)</a>
     <li><a href="#ref-for-matrix-m33-element④">7. Structured serialization</a> <a href="#ref-for-matrix-m33-element⑤">(2)</a> <a href="#ref-for-matrix-m33-element⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m34-element">
-   <b><a href="#matrix-m34-element">#matrix-m34-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m34-element" class="dfn-panel" data-for="matrix-m34-element" id="infopanel-for-matrix-m34-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m34-element" style="display:none">Info about the 'm34 element' definition.</span><b><a href="#matrix-m34-element">#matrix-m34-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m34-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m34-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m34-element②">(2)</a> <a href="#ref-for-matrix-m34-element③">(3)</a>
     <li><a href="#ref-for-matrix-m34-element④">7. Structured serialization</a> <a href="#ref-for-matrix-m34-element⑤">(2)</a> <a href="#ref-for-matrix-m34-element⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m41-element">
-   <b><a href="#matrix-m41-element">#matrix-m41-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m41-element" class="dfn-panel" data-for="matrix-m41-element" id="infopanel-for-matrix-m41-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m41-element" style="display:none">Info about the 'm41 element' definition.</span><b><a href="#matrix-m41-element">#matrix-m41-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m41-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m41-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m41-element②">(2)</a> <a href="#ref-for-matrix-m41-element③">(3)</a>
@@ -5732,8 +5744,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m41-element⑥">7. Structured serialization</a> <a href="#ref-for-matrix-m41-element⑦">(2)</a> <a href="#ref-for-matrix-m41-element⑧">(3)</a> <a href="#ref-for-matrix-m41-element⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m42-element">
-   <b><a href="#matrix-m42-element">#matrix-m42-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m42-element" class="dfn-panel" data-for="matrix-m42-element" id="infopanel-for-matrix-m42-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m42-element" style="display:none">Info about the 'm42 element' definition.</span><b><a href="#matrix-m42-element">#matrix-m42-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m42-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m42-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m42-element②">(2)</a> <a href="#ref-for-matrix-m42-element③">(3)</a>
@@ -5741,8 +5753,9 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m42-element⑥">7. Structured serialization</a> <a href="#ref-for-matrix-m42-element⑦">(2)</a> <a href="#ref-for-matrix-m42-element⑧">(3)</a> <a href="#ref-for-matrix-m42-element⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m43-element">
-   <b><a href="#matrix-m43-element">#matrix-m43-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m43-element" class="dfn-panel" data-for="matrix-m43-element" id="infopanel-for-matrix-m43-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m43-element" style="display:none">Info about the 'm43
+element' definition.</span><b><a href="#matrix-m43-element">#matrix-m43-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m43-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-matrix-m43-element①">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m43-element②">(2)</a> <a href="#ref-for-matrix-m43-element③">(3)</a>
@@ -5750,8 +5763,8 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m43-element⑤">7. Structured serialization</a> <a href="#ref-for-matrix-m43-element⑥">(2)</a> <a href="#ref-for-matrix-m43-element⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-m44-element">
-   <b><a href="#matrix-m44-element">#matrix-m44-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-m44-element" class="dfn-panel" data-for="matrix-m44-element" id="infopanel-for-matrix-m44-element" role="dialog">
+   <span id="infopaneltitle-for-matrix-m44-element" style="display:none">Info about the 'm44 element' definition.</span><b><a href="#matrix-m44-element">#matrix-m44-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-m44-element">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-matrix-m44-element①">(2)</a>
     <li><a href="#ref-for-matrix-m44-element②">6.4. DOMMatrix attributes</a> <a href="#ref-for-matrix-m44-element③">(2)</a> <a href="#ref-for-matrix-m44-element④">(3)</a>
@@ -5760,102 +5773,103 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-m44-element⑧">7. Structured serialization</a> <a href="#ref-for-matrix-m44-element⑨">(2)</a> <a href="#ref-for-matrix-m44-element①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-validate-and-fixup-2d">
-   <b><a href="#matrix-validate-and-fixup-2d">#matrix-validate-and-fixup-2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-validate-and-fixup-2d" class="dfn-panel" data-for="matrix-validate-and-fixup-2d" id="infopanel-for-matrix-validate-and-fixup-2d" role="dialog">
+   <span id="infopaneltitle-for-matrix-validate-and-fixup-2d" style="display:none">Info about the 'validate and fixup (2D)' definition.</span><b><a href="#matrix-validate-and-fixup-2d">#matrix-validate-and-fixup-2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-validate-and-fixup-2d">6.1. DOMMatrix2DInit and DOMMatrixInit dictionaries</a>
     <li><a href="#ref-for-matrix-validate-and-fixup-2d①">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-validate-and-fixup">
-   <b><a href="#matrix-validate-and-fixup">#matrix-validate-and-fixup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-validate-and-fixup" class="dfn-panel" data-for="matrix-validate-and-fixup" id="infopanel-for-matrix-validate-and-fixup" role="dialog">
+   <span id="infopaneltitle-for-matrix-validate-and-fixup" style="display:none">Info about the 'validate and fixup' definition.</span><b><a href="#matrix-validate-and-fixup">#matrix-validate-and-fixup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-validate-and-fixup">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-string-into-an-abstract-matrix">
-   <b><a href="#parse-a-string-into-an-abstract-matrix">#parse-a-string-into-an-abstract-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-string-into-an-abstract-matrix" class="dfn-panel" data-for="parse-a-string-into-an-abstract-matrix" id="infopanel-for-parse-a-string-into-an-abstract-matrix" role="dialog">
+   <span id="infopaneltitle-for-parse-a-string-into-an-abstract-matrix" style="display:none">Info about the 'parse a string into an abstract matrix' definition.</span><b><a href="#parse-a-string-into-an-abstract-matrix">#parse-a-string-into-an-abstract-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-string-into-an-abstract-matrix">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-parse-a-string-into-an-abstract-matrix①">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-2d-matrix">
-   <b><a href="#create-a-2d-matrix">#create-a-2d-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-2d-matrix" class="dfn-panel" data-for="create-a-2d-matrix" id="infopanel-for-create-a-2d-matrix" role="dialog">
+   <span id="infopaneltitle-for-create-a-2d-matrix" style="display:none">Info about the 'create a 2d matrix' definition.</span><b><a href="#create-a-2d-matrix">#create-a-2d-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-2d-matrix">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-create-a-2d-matrix①">(2)</a> <a href="#ref-for-create-a-2d-matrix②">(3)</a> <a href="#ref-for-create-a-2d-matrix③">(4)</a> <a href="#ref-for-create-a-2d-matrix④">(5)</a> <a href="#ref-for-create-a-2d-matrix⑤">(6)</a> <a href="#ref-for-create-a-2d-matrix⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-3d-matrix">
-   <b><a href="#create-a-3d-matrix">#create-a-3d-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-3d-matrix" class="dfn-panel" data-for="create-a-3d-matrix" id="infopanel-for-create-a-3d-matrix" role="dialog">
+   <span id="infopaneltitle-for-create-a-3d-matrix" style="display:none">Info about the 'create a 3d matrix' definition.</span><b><a href="#create-a-3d-matrix">#create-a-3d-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-3d-matrix">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a> <a href="#ref-for-create-a-3d-matrix①">(2)</a> <a href="#ref-for-create-a-3d-matrix②">(3)</a> <a href="#ref-for-create-a-3d-matrix③">(4)</a> <a href="#ref-for-create-a-3d-matrix④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-dommatrixreadonly">
-   <b><a href="#dom-dommatrixreadonly-dommatrixreadonly">#dom-dommatrixreadonly-dommatrixreadonly</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-dommatrixreadonly" class="dfn-panel" data-for="dom-dommatrixreadonly-dommatrixreadonly" id="infopanel-for-dom-dommatrixreadonly-dommatrixreadonly" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-dommatrixreadonly" style="display:none">Info about the 'DOMMatrixReadOnly(init)' definition.</span><b><a href="#dom-dommatrixreadonly-dommatrixreadonly">#dom-dommatrixreadonly-dommatrixreadonly</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-dommatrixreadonly">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-dommatrix">
-   <b><a href="#dom-dommatrix-dommatrix">#dom-dommatrix-dommatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-dommatrix" class="dfn-panel" data-for="dom-dommatrix-dommatrix" id="infopanel-for-dom-dommatrix-dommatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-dommatrix" style="display:none">Info about the 'DOMMatrix(init)' definition.</span><b><a href="#dom-dommatrix-dommatrix">#dom-dommatrix-dommatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-dommatrix">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-frommatrix">
-   <b><a href="#dom-dommatrixreadonly-frommatrix">#dom-dommatrixreadonly-frommatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-frommatrix" class="dfn-panel" data-for="dom-dommatrixreadonly-frommatrix" id="infopanel-for-dom-dommatrixreadonly-frommatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-frommatrix" style="display:none">Info about the 'fromMatrix(other)' definition.</span><b><a href="#dom-dommatrixreadonly-frommatrix">#dom-dommatrixreadonly-frommatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-frommatrix">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-frommatrix">
-   <b><a href="#dom-dommatrix-frommatrix">#dom-dommatrix-frommatrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-frommatrix" class="dfn-panel" data-for="dom-dommatrix-frommatrix" id="infopanel-for-dom-dommatrix-frommatrix" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-frommatrix" style="display:none">Info about the 'fromMatrix(other)' definition.</span><b><a href="#dom-dommatrix-frommatrix">#dom-dommatrix-frommatrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-frommatrix">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-dommatrixreadonly-from-the-dictionary">
-   <b><a href="#create-a-dommatrixreadonly-from-the-dictionary">#create-a-dommatrixreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-dommatrixreadonly-from-the-dictionary" class="dfn-panel" data-for="create-a-dommatrixreadonly-from-the-dictionary" id="infopanel-for-create-a-dommatrixreadonly-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-dommatrixreadonly-from-the-dictionary" style="display:none">Info about the 'create a
+DOMMatrixReadOnly from a dictionary' definition.</span><b><a href="#create-a-dommatrixreadonly-from-the-dictionary">#create-a-dommatrixreadonly-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-dommatrixreadonly-from-the-dictionary">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-dommatrix-from-the-dictionary">
-   <b><a href="#create-a-dommatrix-from-the-dictionary">#create-a-dommatrix-from-the-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-dommatrix-from-the-dictionary" class="dfn-panel" data-for="create-a-dommatrix-from-the-dictionary" id="infopanel-for-create-a-dommatrix-from-the-dictionary" role="dialog">
+   <span id="infopaneltitle-for-create-a-dommatrix-from-the-dictionary" style="display:none">Info about the 'create a DOMMatrix from a dictionary' definition.</span><b><a href="#create-a-dommatrix-from-the-dictionary">#create-a-dommatrix-from-the-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-dommatrix-from-the-dictionary">2. The DOMPoint interfaces</a>
     <li><a href="#ref-for-create-a-dommatrix-from-the-dictionary①">6.3. Creating DOMMatrixReadOnly and DOMMatrix objects</a>
     <li><a href="#ref-for-create-a-dommatrix-from-the-dictionary②">6.6. Mutable transformation methods</a> <a href="#ref-for-create-a-dommatrix-from-the-dictionary③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-fromfloat32array">
-   <b><a href="#dom-dommatrixreadonly-fromfloat32array">#dom-dommatrixreadonly-fromfloat32array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-fromfloat32array" class="dfn-panel" data-for="dom-dommatrixreadonly-fromfloat32array" id="infopanel-for-dom-dommatrixreadonly-fromfloat32array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-fromfloat32array" style="display:none">Info about the 'fromFloat32Array(array32)' definition.</span><b><a href="#dom-dommatrixreadonly-fromfloat32array">#dom-dommatrixreadonly-fromfloat32array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-fromfloat32array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-fromfloat32array">
-   <b><a href="#dom-dommatrix-fromfloat32array">#dom-dommatrix-fromfloat32array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-fromfloat32array" class="dfn-panel" data-for="dom-dommatrix-fromfloat32array" id="infopanel-for-dom-dommatrix-fromfloat32array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-fromfloat32array" style="display:none">Info about the 'fromFloat32Array(array32)' definition.</span><b><a href="#dom-dommatrix-fromfloat32array">#dom-dommatrix-fromfloat32array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-fromfloat32array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-fromfloat64array">
-   <b><a href="#dom-dommatrixreadonly-fromfloat64array">#dom-dommatrixreadonly-fromfloat64array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-fromfloat64array" class="dfn-panel" data-for="dom-dommatrixreadonly-fromfloat64array" id="infopanel-for-dom-dommatrixreadonly-fromfloat64array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-fromfloat64array" style="display:none">Info about the 'fromFloat64Array(array64)' definition.</span><b><a href="#dom-dommatrixreadonly-fromfloat64array">#dom-dommatrixreadonly-fromfloat64array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-fromfloat64array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-fromfloat64array">
-   <b><a href="#dom-dommatrix-fromfloat64array">#dom-dommatrix-fromfloat64array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-fromfloat64array" class="dfn-panel" data-for="dom-dommatrix-fromfloat64array" id="infopanel-for-dom-dommatrix-fromfloat64array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-fromfloat64array" style="display:none">Info about the 'fromFloat64Array(array64)' definition.</span><b><a href="#dom-dommatrix-fromfloat64array">#dom-dommatrix-fromfloat64array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-fromfloat64array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m11">
-   <b><a href="#dom-dommatrixreadonly-m11">#dom-dommatrixreadonly-m11</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m11" class="dfn-panel" data-for="dom-dommatrixreadonly-m11" id="infopanel-for-dom-dommatrixreadonly-m11" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m11" style="display:none">Info about the 'm11' definition.</span><b><a href="#dom-dommatrixreadonly-m11">#dom-dommatrixreadonly-m11</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m11">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m11①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m11②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m11③">(2)</a> <a href="#ref-for-dom-dommatrixreadonly-m11④">(3)</a>
@@ -5863,172 +5877,172 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dom-dommatrixreadonly-m11⑦">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-a">
-   <b><a href="#dom-dommatrixreadonly-a">#dom-dommatrixreadonly-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-a" class="dfn-panel" data-for="dom-dommatrixreadonly-a" id="infopanel-for-dom-dommatrixreadonly-a" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-a" style="display:none">Info about the 'a' definition.</span><b><a href="#dom-dommatrixreadonly-a">#dom-dommatrixreadonly-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-a">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-a①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-a②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-a③">(2)</a> <a href="#ref-for-dom-dommatrixreadonly-a④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m12">
-   <b><a href="#dom-dommatrixreadonly-m12">#dom-dommatrixreadonly-m12</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m12" class="dfn-panel" data-for="dom-dommatrixreadonly-m12" id="infopanel-for-dom-dommatrixreadonly-m12" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m12" style="display:none">Info about the 'm12' definition.</span><b><a href="#dom-dommatrixreadonly-m12">#dom-dommatrixreadonly-m12</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m12">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m12①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m12②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m12③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-b">
-   <b><a href="#dom-dommatrixreadonly-b">#dom-dommatrixreadonly-b</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-b" class="dfn-panel" data-for="dom-dommatrixreadonly-b" id="infopanel-for-dom-dommatrixreadonly-b" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-b" style="display:none">Info about the 'b' definition.</span><b><a href="#dom-dommatrixreadonly-b">#dom-dommatrixreadonly-b</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-b">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-b①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-b②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-b③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m13">
-   <b><a href="#dom-dommatrixreadonly-m13">#dom-dommatrixreadonly-m13</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m13" class="dfn-panel" data-for="dom-dommatrixreadonly-m13" id="infopanel-for-dom-dommatrixreadonly-m13" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m13" style="display:none">Info about the 'm13' definition.</span><b><a href="#dom-dommatrixreadonly-m13">#dom-dommatrixreadonly-m13</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m13">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m13①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m13②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m14">
-   <b><a href="#dom-dommatrixreadonly-m14">#dom-dommatrixreadonly-m14</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m14" class="dfn-panel" data-for="dom-dommatrixreadonly-m14" id="infopanel-for-dom-dommatrixreadonly-m14" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m14" style="display:none">Info about the 'm14' definition.</span><b><a href="#dom-dommatrixreadonly-m14">#dom-dommatrixreadonly-m14</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m14">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m14①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m14②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m21">
-   <b><a href="#dom-dommatrixreadonly-m21">#dom-dommatrixreadonly-m21</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m21" class="dfn-panel" data-for="dom-dommatrixreadonly-m21" id="infopanel-for-dom-dommatrixreadonly-m21" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m21" style="display:none">Info about the 'm21' definition.</span><b><a href="#dom-dommatrixreadonly-m21">#dom-dommatrixreadonly-m21</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m21">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m21①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m21②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m21③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-c">
-   <b><a href="#dom-dommatrixreadonly-c">#dom-dommatrixreadonly-c</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-c" class="dfn-panel" data-for="dom-dommatrixreadonly-c" id="infopanel-for-dom-dommatrixreadonly-c" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-c" style="display:none">Info about the 'c' definition.</span><b><a href="#dom-dommatrixreadonly-c">#dom-dommatrixreadonly-c</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-c">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-c①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-c②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-c③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m22">
-   <b><a href="#dom-dommatrixreadonly-m22">#dom-dommatrixreadonly-m22</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m22" class="dfn-panel" data-for="dom-dommatrixreadonly-m22" id="infopanel-for-dom-dommatrixreadonly-m22" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m22" style="display:none">Info about the 'm22' definition.</span><b><a href="#dom-dommatrixreadonly-m22">#dom-dommatrixreadonly-m22</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m22">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m22①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m22②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m22③">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m22④">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-d">
-   <b><a href="#dom-dommatrixreadonly-d">#dom-dommatrixreadonly-d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-d" class="dfn-panel" data-for="dom-dommatrixreadonly-d" id="infopanel-for-dom-dommatrixreadonly-d" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-d" style="display:none">Info about the 'd' definition.</span><b><a href="#dom-dommatrixreadonly-d">#dom-dommatrixreadonly-d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-d">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-d①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-d②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-d③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m23">
-   <b><a href="#dom-dommatrixreadonly-m23">#dom-dommatrixreadonly-m23</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m23" class="dfn-panel" data-for="dom-dommatrixreadonly-m23" id="infopanel-for-dom-dommatrixreadonly-m23" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m23" style="display:none">Info about the 'm23' definition.</span><b><a href="#dom-dommatrixreadonly-m23">#dom-dommatrixreadonly-m23</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m23">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m23①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m23②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m24">
-   <b><a href="#dom-dommatrixreadonly-m24">#dom-dommatrixreadonly-m24</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m24" class="dfn-panel" data-for="dom-dommatrixreadonly-m24" id="infopanel-for-dom-dommatrixreadonly-m24" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m24" style="display:none">Info about the 'm24' definition.</span><b><a href="#dom-dommatrixreadonly-m24">#dom-dommatrixreadonly-m24</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m24">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m24①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m24②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m31">
-   <b><a href="#dom-dommatrixreadonly-m31">#dom-dommatrixreadonly-m31</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m31" class="dfn-panel" data-for="dom-dommatrixreadonly-m31" id="infopanel-for-dom-dommatrixreadonly-m31" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m31" style="display:none">Info about the 'm31' definition.</span><b><a href="#dom-dommatrixreadonly-m31">#dom-dommatrixreadonly-m31</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m31">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m31①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m31②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m32">
-   <b><a href="#dom-dommatrixreadonly-m32">#dom-dommatrixreadonly-m32</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m32" class="dfn-panel" data-for="dom-dommatrixreadonly-m32" id="infopanel-for-dom-dommatrixreadonly-m32" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m32" style="display:none">Info about the 'm32' definition.</span><b><a href="#dom-dommatrixreadonly-m32">#dom-dommatrixreadonly-m32</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m32">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m32①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m32②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m33">
-   <b><a href="#dom-dommatrixreadonly-m33">#dom-dommatrixreadonly-m33</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m33" class="dfn-panel" data-for="dom-dommatrixreadonly-m33" id="infopanel-for-dom-dommatrixreadonly-m33" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m33" style="display:none">Info about the 'm33' definition.</span><b><a href="#dom-dommatrixreadonly-m33">#dom-dommatrixreadonly-m33</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m33">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m33①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m33②">6.4. DOMMatrix attributes</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m33③">6.6. Mutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m34">
-   <b><a href="#dom-dommatrixreadonly-m34">#dom-dommatrixreadonly-m34</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m34" class="dfn-panel" data-for="dom-dommatrixreadonly-m34" id="infopanel-for-dom-dommatrixreadonly-m34" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m34" style="display:none">Info about the 'm34' definition.</span><b><a href="#dom-dommatrixreadonly-m34">#dom-dommatrixreadonly-m34</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m34">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m34①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m34②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m41">
-   <b><a href="#dom-dommatrixreadonly-m41">#dom-dommatrixreadonly-m41</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m41" class="dfn-panel" data-for="dom-dommatrixreadonly-m41" id="infopanel-for-dom-dommatrixreadonly-m41" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m41" style="display:none">Info about the 'm41' definition.</span><b><a href="#dom-dommatrixreadonly-m41">#dom-dommatrixreadonly-m41</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m41">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m41①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m41②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m41③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-e">
-   <b><a href="#dom-dommatrixreadonly-e">#dom-dommatrixreadonly-e</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-e" class="dfn-panel" data-for="dom-dommatrixreadonly-e" id="infopanel-for-dom-dommatrixreadonly-e" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-e" style="display:none">Info about the 'e' definition.</span><b><a href="#dom-dommatrixreadonly-e">#dom-dommatrixreadonly-e</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-e">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-e①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-e②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-e③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m42">
-   <b><a href="#dom-dommatrixreadonly-m42">#dom-dommatrixreadonly-m42</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m42" class="dfn-panel" data-for="dom-dommatrixreadonly-m42" id="infopanel-for-dom-dommatrixreadonly-m42" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m42" style="display:none">Info about the 'm42' definition.</span><b><a href="#dom-dommatrixreadonly-m42">#dom-dommatrixreadonly-m42</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m42">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m42①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m42②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m42③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-f">
-   <b><a href="#dom-dommatrixreadonly-f">#dom-dommatrixreadonly-f</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-f" class="dfn-panel" data-for="dom-dommatrixreadonly-f" id="infopanel-for-dom-dommatrixreadonly-f" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-f" style="display:none">Info about the 'f' definition.</span><b><a href="#dom-dommatrixreadonly-f">#dom-dommatrixreadonly-f</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-f">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-f①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-f②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-f③">(2)</a> <a href="#ref-for-dom-dommatrixreadonly-f④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m43">
-   <b><a href="#dom-dommatrixreadonly-m43">#dom-dommatrixreadonly-m43</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m43" class="dfn-panel" data-for="dom-dommatrixreadonly-m43" id="infopanel-for-dom-dommatrixreadonly-m43" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m43" style="display:none">Info about the 'm43' definition.</span><b><a href="#dom-dommatrixreadonly-m43">#dom-dommatrixreadonly-m43</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m43">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m43①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m43②">6.4. DOMMatrix attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-m44">
-   <b><a href="#dom-dommatrixreadonly-m44">#dom-dommatrixreadonly-m44</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-m44" class="dfn-panel" data-for="dom-dommatrixreadonly-m44" id="infopanel-for-dom-dommatrixreadonly-m44" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-m44" style="display:none">Info about the 'm44' definition.</span><b><a href="#dom-dommatrixreadonly-m44">#dom-dommatrixreadonly-m44</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-m44">6. The DOMMatrix interfaces</a> <a href="#ref-for-dom-dommatrixreadonly-m44①">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m44②">6.4. DOMMatrix attributes</a> <a href="#ref-for-dom-dommatrixreadonly-m44③">(2)</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-m44④">6.5. Immutable transformation methods</a> <a href="#ref-for-dom-dommatrixreadonly-m44⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-is2d">
-   <b><a href="#dom-dommatrixreadonly-is2d">#dom-dommatrixreadonly-is2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-is2d" class="dfn-panel" data-for="dom-dommatrixreadonly-is2d" id="infopanel-for-dom-dommatrixreadonly-is2d" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-is2d" style="display:none">Info about the 'is2D' definition.</span><b><a href="#dom-dommatrixreadonly-is2d">#dom-dommatrixreadonly-is2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-is2d">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-is2d①">Changes since last publication</a> <a href="#ref-for-dom-dommatrixreadonly-is2d②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-isidentity">
-   <b><a href="#dom-dommatrixreadonly-isidentity">#dom-dommatrixreadonly-isidentity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-isidentity" class="dfn-panel" data-for="dom-dommatrixreadonly-isidentity" id="infopanel-for-dom-dommatrixreadonly-isidentity" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-isidentity" style="display:none">Info about the 'isIdentity' definition.</span><b><a href="#dom-dommatrixreadonly-isidentity">#dom-dommatrixreadonly-isidentity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-isidentity">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-isidentity①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matrix-is-2d">
-   <b><a href="#matrix-is-2d">#matrix-is-2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matrix-is-2d" class="dfn-panel" data-for="matrix-is-2d" id="infopanel-for-matrix-is-2d" role="dialog">
+   <span id="infopaneltitle-for-matrix-is-2d" style="display:none">Info about the 'is 2D' definition.</span><b><a href="#matrix-is-2d">#matrix-is-2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matrix-is-2d">2.1. Transforming a point with a matrix</a>
     <li><a href="#ref-for-matrix-is-2d①">6. The DOMMatrix interfaces</a>
@@ -6039,127 +6053,128 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-matrix-is-2d②⑨">7. Structured serialization</a> <a href="#ref-for-matrix-is-2d③⓪">(2)</a> <a href="#ref-for-matrix-is-2d③①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-translate">
-   <b><a href="#dom-dommatrixreadonly-translate">#dom-dommatrixreadonly-translate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-translate" class="dfn-panel" data-for="dom-dommatrixreadonly-translate" id="infopanel-for-dom-dommatrixreadonly-translate" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-translate" style="display:none">Info about the 'translate(tx, ty, tz)' definition.</span><b><a href="#dom-dommatrixreadonly-translate">#dom-dommatrixreadonly-translate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-translate">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-scale">
-   <b><a href="#dom-dommatrixreadonly-scale">#dom-dommatrixreadonly-scale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-scale" class="dfn-panel" data-for="dom-dommatrixreadonly-scale" id="infopanel-for-dom-dommatrixreadonly-scale" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-scale" style="display:none">Info about the 'scale(scaleX, scaleY, scaleZ, originX,
+originY, originZ)' definition.</span><b><a href="#dom-dommatrixreadonly-scale">#dom-dommatrixreadonly-scale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-scale">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-scale①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-scale②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-scalenonuniform">
-   <b><a href="#dom-dommatrixreadonly-scalenonuniform">#dom-dommatrixreadonly-scalenonuniform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-scalenonuniform" class="dfn-panel" data-for="dom-dommatrixreadonly-scalenonuniform" id="infopanel-for-dom-dommatrixreadonly-scalenonuniform" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-scalenonuniform" style="display:none">Info about the 'scaleNonUniform(scaleX, scaleY)' definition.</span><b><a href="#dom-dommatrixreadonly-scalenonuniform">#dom-dommatrixreadonly-scalenonuniform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-scalenonuniform">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-scale3d">
-   <b><a href="#dom-dommatrixreadonly-scale3d">#dom-dommatrixreadonly-scale3d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-scale3d" class="dfn-panel" data-for="dom-dommatrixreadonly-scale3d" id="infopanel-for-dom-dommatrixreadonly-scale3d" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-scale3d" style="display:none">Info about the 'scale3d(scale, originX, originY, originZ)' definition.</span><b><a href="#dom-dommatrixreadonly-scale3d">#dom-dommatrixreadonly-scale3d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-scale3d">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-rotate">
-   <b><a href="#dom-dommatrixreadonly-rotate">#dom-dommatrixreadonly-rotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-rotate" class="dfn-panel" data-for="dom-dommatrixreadonly-rotate" id="infopanel-for-dom-dommatrixreadonly-rotate" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-rotate" style="display:none">Info about the 'rotate(rotX, rotY, rotZ)' definition.</span><b><a href="#dom-dommatrixreadonly-rotate">#dom-dommatrixreadonly-rotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-rotate">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-rotate①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-rotatefromvector">
-   <b><a href="#dom-dommatrixreadonly-rotatefromvector">#dom-dommatrixreadonly-rotatefromvector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-rotatefromvector" class="dfn-panel" data-for="dom-dommatrixreadonly-rotatefromvector" id="infopanel-for-dom-dommatrixreadonly-rotatefromvector" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-rotatefromvector" style="display:none">Info about the 'rotateFromVector(x, y)' definition.</span><b><a href="#dom-dommatrixreadonly-rotatefromvector">#dom-dommatrixreadonly-rotatefromvector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-rotatefromvector">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-rotateaxisangle">
-   <b><a href="#dom-dommatrixreadonly-rotateaxisangle">#dom-dommatrixreadonly-rotateaxisangle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-rotateaxisangle" class="dfn-panel" data-for="dom-dommatrixreadonly-rotateaxisangle" id="infopanel-for-dom-dommatrixreadonly-rotateaxisangle" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-rotateaxisangle" style="display:none">Info about the 'rotateAxisAngle(x, y, z, angle)' definition.</span><b><a href="#dom-dommatrixreadonly-rotateaxisangle">#dom-dommatrixreadonly-rotateaxisangle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-rotateaxisangle">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-skewx">
-   <b><a href="#dom-dommatrixreadonly-skewx">#dom-dommatrixreadonly-skewx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-skewx" class="dfn-panel" data-for="dom-dommatrixreadonly-skewx" id="infopanel-for-dom-dommatrixreadonly-skewx" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-skewx" style="display:none">Info about the 'skewX(sx)' definition.</span><b><a href="#dom-dommatrixreadonly-skewx">#dom-dommatrixreadonly-skewx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-skewx">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-skewy">
-   <b><a href="#dom-dommatrixreadonly-skewy">#dom-dommatrixreadonly-skewy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-skewy" class="dfn-panel" data-for="dom-dommatrixreadonly-skewy" id="infopanel-for-dom-dommatrixreadonly-skewy" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-skewy" style="display:none">Info about the 'skewY(sy)' definition.</span><b><a href="#dom-dommatrixreadonly-skewy">#dom-dommatrixreadonly-skewy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-skewy">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-multiply">
-   <b><a href="#dom-dommatrixreadonly-multiply">#dom-dommatrixreadonly-multiply</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-multiply" class="dfn-panel" data-for="dom-dommatrixreadonly-multiply" id="infopanel-for-dom-dommatrixreadonly-multiply" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-multiply" style="display:none">Info about the 'multiply(other)' definition.</span><b><a href="#dom-dommatrixreadonly-multiply">#dom-dommatrixreadonly-multiply</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-multiply">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-flipx">
-   <b><a href="#dom-dommatrixreadonly-flipx">#dom-dommatrixreadonly-flipx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-flipx" class="dfn-panel" data-for="dom-dommatrixreadonly-flipx" id="infopanel-for-dom-dommatrixreadonly-flipx" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-flipx" style="display:none">Info about the 'flipX()' definition.</span><b><a href="#dom-dommatrixreadonly-flipx">#dom-dommatrixreadonly-flipx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-flipx">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-flipy">
-   <b><a href="#dom-dommatrixreadonly-flipy">#dom-dommatrixreadonly-flipy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-flipy" class="dfn-panel" data-for="dom-dommatrixreadonly-flipy" id="infopanel-for-dom-dommatrixreadonly-flipy" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-flipy" style="display:none">Info about the 'flipY()' definition.</span><b><a href="#dom-dommatrixreadonly-flipy">#dom-dommatrixreadonly-flipy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-flipy">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-inverse">
-   <b><a href="#dom-dommatrixreadonly-inverse">#dom-dommatrixreadonly-inverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-inverse" class="dfn-panel" data-for="dom-dommatrixreadonly-inverse" id="infopanel-for-dom-dommatrixreadonly-inverse" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-inverse" style="display:none">Info about the 'inverse()' definition.</span><b><a href="#dom-dommatrixreadonly-inverse">#dom-dommatrixreadonly-inverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-inverse">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrixreadonly-inverse①">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-transformpoint">
-   <b><a href="#dom-dommatrixreadonly-transformpoint">#dom-dommatrixreadonly-transformpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-transformpoint" class="dfn-panel" data-for="dom-dommatrixreadonly-transformpoint" id="infopanel-for-dom-dommatrixreadonly-transformpoint" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-transformpoint" style="display:none">Info about the 'transformPoint(point)' definition.</span><b><a href="#dom-dommatrixreadonly-transformpoint">#dom-dommatrixreadonly-transformpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-transformpoint">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-tofloat32array">
-   <b><a href="#dom-dommatrixreadonly-tofloat32array">#dom-dommatrixreadonly-tofloat32array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-tofloat32array" class="dfn-panel" data-for="dom-dommatrixreadonly-tofloat32array" id="infopanel-for-dom-dommatrixreadonly-tofloat32array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-tofloat32array" style="display:none">Info about the 'toFloat32Array()' definition.</span><b><a href="#dom-dommatrixreadonly-tofloat32array">#dom-dommatrixreadonly-tofloat32array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-tofloat32array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrixreadonly-tofloat64array">
-   <b><a href="#dom-dommatrixreadonly-tofloat64array">#dom-dommatrixreadonly-tofloat64array</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrixreadonly-tofloat64array" class="dfn-panel" data-for="dom-dommatrixreadonly-tofloat64array" id="infopanel-for-dom-dommatrixreadonly-tofloat64array" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrixreadonly-tofloat64array" style="display:none">Info about the 'toFloat64Array()' definition.</span><b><a href="#dom-dommatrixreadonly-tofloat64array">#dom-dommatrixreadonly-tofloat64array</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrixreadonly-tofloat64array">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dommatrixreadonly-stringification-behavior">
-   <b><a href="#dommatrixreadonly-stringification-behavior">#dommatrixreadonly-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dommatrixreadonly-stringification-behavior" class="dfn-panel" data-for="dommatrixreadonly-stringification-behavior" id="infopanel-for-dommatrixreadonly-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-dommatrixreadonly-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#dommatrixreadonly-stringification-behavior">#dommatrixreadonly-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrixreadonly-stringification-behavior">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-multiplyself">
-   <b><a href="#dom-dommatrix-multiplyself">#dom-dommatrix-multiplyself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-multiplyself" class="dfn-panel" data-for="dom-dommatrix-multiplyself" id="infopanel-for-dom-dommatrix-multiplyself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-multiplyself" style="display:none">Info about the 'multiplySelf(other)' definition.</span><b><a href="#dom-dommatrix-multiplyself">#dom-dommatrix-multiplyself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-multiplyself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-multiplyself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-premultiplyself">
-   <b><a href="#dom-dommatrix-premultiplyself">#dom-dommatrix-premultiplyself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-premultiplyself" class="dfn-panel" data-for="dom-dommatrix-premultiplyself" id="infopanel-for-dom-dommatrix-premultiplyself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-premultiplyself" style="display:none">Info about the 'preMultiplySelf(other)' definition.</span><b><a href="#dom-dommatrix-premultiplyself">#dom-dommatrix-premultiplyself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-premultiplyself">6. The DOMMatrix interfaces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-translateself">
-   <b><a href="#dom-dommatrix-translateself">#dom-dommatrix-translateself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-translateself" class="dfn-panel" data-for="dom-dommatrix-translateself" id="infopanel-for-dom-dommatrix-translateself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-translateself" style="display:none">Info about the 'translateSelf(tx, ty, tz)' definition.</span><b><a href="#dom-dommatrix-translateself">#dom-dommatrix-translateself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-translateself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-translateself①">6.5. Immutable transformation methods</a>
@@ -6167,82 +6182,84 @@ for their careful reviews, comments, and corrections.</p>
     <li><a href="#ref-for-dom-dommatrix-translateself⑥">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-scaleself">
-   <b><a href="#dom-dommatrix-scaleself">#dom-dommatrix-scaleself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-scaleself" class="dfn-panel" data-for="dom-dommatrix-scaleself" id="infopanel-for-dom-dommatrix-scaleself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-scaleself" style="display:none">Info about the 'scaleSelf(scaleX, scaleY, scaleZ, originX,
+originY, originZ)' definition.</span><b><a href="#dom-dommatrix-scaleself">#dom-dommatrix-scaleself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-scaleself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-scaleself①">6.5. Immutable transformation methods</a> <a href="#ref-for-dom-dommatrix-scaleself②">(2)</a>
     <li><a href="#ref-for-dom-dommatrix-scaleself③">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-scale3dself">
-   <b><a href="#dom-dommatrix-scale3dself">#dom-dommatrix-scale3dself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-scale3dself" class="dfn-panel" data-for="dom-dommatrix-scale3dself" id="infopanel-for-dom-dommatrix-scale3dself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-scale3dself" style="display:none">Info about the 'scale3dSelf(scale, originX, originY,
+originZ)' definition.</span><b><a href="#dom-dommatrix-scale3dself">#dom-dommatrix-scale3dself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-scale3dself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-scale3dself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-rotateself">
-   <b><a href="#dom-dommatrix-rotateself">#dom-dommatrix-rotateself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-rotateself" class="dfn-panel" data-for="dom-dommatrix-rotateself" id="infopanel-for-dom-dommatrix-rotateself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-rotateself" style="display:none">Info about the 'rotateSelf(rotX, rotY, rotZ)' definition.</span><b><a href="#dom-dommatrix-rotateself">#dom-dommatrix-rotateself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-rotateself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-rotateself①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-dom-dommatrix-rotateself②">Changes since last publication</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-rotatefromvectorself">
-   <b><a href="#dom-dommatrix-rotatefromvectorself">#dom-dommatrix-rotatefromvectorself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-rotatefromvectorself" class="dfn-panel" data-for="dom-dommatrix-rotatefromvectorself" id="infopanel-for-dom-dommatrix-rotatefromvectorself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-rotatefromvectorself" style="display:none">Info about the 'rotateFromVectorSelf(x, y)' definition.</span><b><a href="#dom-dommatrix-rotatefromvectorself">#dom-dommatrix-rotatefromvectorself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-rotatefromvectorself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-rotatefromvectorself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-rotateaxisangleself">
-   <b><a href="#dom-dommatrix-rotateaxisangleself">#dom-dommatrix-rotateaxisangleself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-rotateaxisangleself" class="dfn-panel" data-for="dom-dommatrix-rotateaxisangleself" id="infopanel-for-dom-dommatrix-rotateaxisangleself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-rotateaxisangleself" style="display:none">Info about the 'rotateAxisAngleSelf(x, y, z, angle)' definition.</span><b><a href="#dom-dommatrix-rotateaxisangleself">#dom-dommatrix-rotateaxisangleself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-rotateaxisangleself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-rotateaxisangleself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-skewxself">
-   <b><a href="#dom-dommatrix-skewxself">#dom-dommatrix-skewxself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-skewxself" class="dfn-panel" data-for="dom-dommatrix-skewxself" id="infopanel-for-dom-dommatrix-skewxself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-skewxself" style="display:none">Info about the 'skewXSelf(sx)' definition.</span><b><a href="#dom-dommatrix-skewxself">#dom-dommatrix-skewxself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-skewxself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-skewxself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-skewyself">
-   <b><a href="#dom-dommatrix-skewyself">#dom-dommatrix-skewyself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-skewyself" class="dfn-panel" data-for="dom-dommatrix-skewyself" id="infopanel-for-dom-dommatrix-skewyself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-skewyself" style="display:none">Info about the 'skewYSelf(sy)' definition.</span><b><a href="#dom-dommatrix-skewyself">#dom-dommatrix-skewyself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-skewyself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-skewyself①">6.5. Immutable transformation methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-invertself">
-   <b><a href="#dom-dommatrix-invertself">#dom-dommatrix-invertself</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-invertself" class="dfn-panel" data-for="dom-dommatrix-invertself" id="infopanel-for-dom-dommatrix-invertself" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-invertself" style="display:none">Info about the 'invertSelf()' definition.</span><b><a href="#dom-dommatrix-invertself">#dom-dommatrix-invertself</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-invertself">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-invertself①">6.5. Immutable transformation methods</a>
     <li><a href="#ref-for-dom-dommatrix-invertself②">Changes since last publication</a> <a href="#ref-for-dom-dommatrix-invertself③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-dommatrix-setmatrixvalue">
-   <b><a href="#dom-dommatrix-setmatrixvalue">#dom-dommatrix-setmatrixvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-dommatrix-setmatrixvalue" class="dfn-panel" data-for="dom-dommatrix-setmatrixvalue" id="infopanel-for-dom-dommatrix-setmatrixvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-dommatrix-setmatrixvalue" style="display:none">Info about the 'setMatrixValue(transformList)' definition.</span><b><a href="#dom-dommatrix-setmatrixvalue">#dom-dommatrix-setmatrixvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dommatrix-setmatrixvalue">6. The DOMMatrix interfaces</a>
     <li><a href="#ref-for-dom-dommatrix-setmatrixvalue①">6.4. DOMMatrix attributes</a>
     <li><a href="#ref-for-dom-dommatrix-setmatrixvalue②">Changes since last publication</a> <a href="#ref-for-dom-dommatrix-setmatrixvalue③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nan-safe-minimum">
-   <b><a href="#nan-safe-minimum">#nan-safe-minimum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nan-safe-minimum" class="dfn-panel" data-for="nan-safe-minimum" id="infopanel-for-nan-safe-minimum" role="dialog">
+   <span id="infopaneltitle-for-nan-safe-minimum" style="display:none">Info about the 'NaN-safe minimum' definition.</span><b><a href="#nan-safe-minimum">#nan-safe-minimum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nan-safe-minimum">3. The DOMRect interfaces</a> <a href="#ref-for-nan-safe-minimum①">(2)</a>
     <li><a href="#ref-for-nan-safe-minimum②">5. The DOMQuad interface</a> <a href="#ref-for-nan-safe-minimum③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nan-safe-maximum">
-   <b><a href="#nan-safe-maximum">#nan-safe-maximum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nan-safe-maximum" class="dfn-panel" data-for="nan-safe-maximum" id="infopanel-for-nan-safe-maximum" role="dialog">
+   <span id="infopaneltitle-for-nan-safe-maximum" style="display:none">Info about the 'NaN-safe maximum' definition.</span><b><a href="#nan-safe-maximum">#nan-safe-maximum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nan-safe-maximum">3. The DOMRect interfaces</a> <a href="#ref-for-nan-safe-maximum①">(2)</a>
     <li><a href="#ref-for-nan-safe-maximum②">5. The DOMQuad interface</a> <a href="#ref-for-nan-safe-maximum③">(2)</a>
@@ -6265,59 +6282,115 @@ document.body.addEventListener("click", function(e) {
 });</script>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/fxtf-drafts/motion-1/Overview.html
+++ b/tests/github/w3c/fxtf-drafts/motion-1/Overview.html
@@ -2354,157 +2354,157 @@ for their reviews, comments, and corrections.</p>
    <li><a href="#total-length">total length</a><span>, in § 4.2.1</span>
    <li><a href="#used-offset-distance">used offset distance</a><span>, in § 4.2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">4.4. Define an anchor point: The offset-anchor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-border-radius①">(2)</a>
     <li><a href="#ref-for-propdef-border-radius②">4.1.3. Examples of &lt;coord-box> Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-coord-box">
-   <a href="https://drafts.csswg.org/css-box-4/#typedef-coord-box">https://drafts.csswg.org/css-box-4/#typedef-coord-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-coord-box" class="dfn-panel" data-for="term-for-typedef-coord-box" id="infopanel-for-term-for-typedef-coord-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-coord-box" style="display:none">Info about the '&lt;coord-box>' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#typedef-coord-box">https://drafts.csswg.org/css-box-4/#typedef-coord-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-coord-box">4.1. Define a path: The offset-path property</a> <a href="#ref-for-typedef-coord-box①">(2)</a> <a href="#ref-for-typedef-coord-box②">(3)</a> <a href="#ref-for-typedef-coord-box③">(4)</a> <a href="#ref-for-typedef-coord-box④">(5)</a>
     <li><a href="#ref-for-typedef-coord-box⑤">4.1.3. Examples of &lt;coord-box> Positioning</a> <a href="#ref-for-typedef-coord-box⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">4.1. Define a path: The offset-path property</a> <a href="#ref-for-used-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-contain">
-   <a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-contain" class="dfn-panel" data-for="term-for-propdef-contain" id="infopanel-for-term-for-propdef-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://drafts.csswg.org/css-contain-2/#propdef-contain">https://drafts.csswg.org/css-contain-2/#propdef-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-contain">4.1.1. Examples Of ray() Positioning</a> <a href="#ref-for-propdef-contain①">(2)</a> <a href="#ref-for-propdef-contain②">(3)</a>
     <li><a href="#ref-for-propdef-contain③">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-size">
-   <a href="https://www.w3.org/TR/css-images-3/#typedef-size">https://www.w3.org/TR/css-images-3/#typedef-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-size" class="dfn-panel" data-for="term-for-typedef-size" id="infopanel-for-term-for-typedef-size" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-size" style="display:none">Info about the '&lt;size>' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#typedef-size">https://www.w3.org/TR/css-images-3/#typedef-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-size">4.1. Define a path: The offset-path property</a> <a href="#ref-for-typedef-size①">(2)</a>
     <li><a href="#ref-for-typedef-size②">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-geometry-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-geometry-box" class="dfn-panel" data-for="term-for-typedef-geometry-box" id="infopanel-for-term-for-typedef-geometry-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-geometry-box" style="display:none">Info about the '&lt;geometry-box>' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box">https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-geometry-box">4.3. Define the starting point of the path: The offset-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-mask-clip-border-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-mask-clip-border-box" class="dfn-panel" data-for="term-for-valdef-mask-clip-border-box" id="infopanel-for-term-for-valdef-mask-clip-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-mask-clip-border-box" style="display:none">Info about the 'border-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-border-box">4.1. Define a path: The offset-path property</a> <a href="#ref-for-valdef-mask-clip-border-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-mask-clip-content-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-mask-clip-content-box" class="dfn-panel" data-for="term-for-valdef-mask-clip-content-box" id="infopanel-for-term-for-valdef-mask-clip-content-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-mask-clip-content-box" style="display:none">Info about the 'content-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-content-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-content-box">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-path-fill-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-path-fill-box" class="dfn-panel" data-for="term-for-valdef-clip-path-fill-box" id="infopanel-for-term-for-valdef-clip-path-fill-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-path-fill-box" style="display:none">Info about the 'fill-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-fill-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-fill-box">4.1. Define a path: The offset-path property</a> <a href="#ref-for-valdef-clip-path-fill-box①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-mask-clip-padding-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-mask-clip-padding-box" class="dfn-panel" data-for="term-for-valdef-mask-clip-padding-box" id="infopanel-for-term-for-valdef-mask-clip-padding-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-mask-clip-padding-box" style="display:none">Info about the 'padding-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box">https://drafts.fxtf.org/css-masking-1/#valdef-mask-clip-padding-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-mask-clip-padding-box">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-path-stroke-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-path-stroke-box" class="dfn-panel" data-for="term-for-valdef-clip-path-stroke-box" id="infopanel-for-term-for-valdef-clip-path-stroke-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-path-stroke-box" style="display:none">Info about the 'stroke-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-stroke-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-stroke-box">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clip-path-view-box">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clip-path-view-box" class="dfn-panel" data-for="term-for-valdef-clip-path-view-box" id="infopanel-for-term-for-valdef-clip-path-view-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clip-path-view-box" style="display:none">Info about the 'view-box' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box">https://drafts.fxtf.org/css-masking-1/#valdef-clip-path-view-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clip-path-view-box">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">4.3. Define the starting point of the path: The offset-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">4.3. Define the starting point of the path: The offset-position property</a> <a href="#ref-for-propdef-position①">(2)</a> <a href="#ref-for-propdef-position②">(3)</a> <a href="#ref-for-propdef-position③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">4.3. Define the starting point of the path: The offset-position property</a> <a href="#ref-for-valdef-position-static①">(2)</a> <a href="#ref-for-valdef-position-static②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">4.3. Define the starting point of the path: The offset-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-basic-shape">
-   <a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-basic-shape" class="dfn-panel" data-for="term-for-typedef-basic-shape" id="infopanel-for-term-for-typedef-basic-shape" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-basic-shape" style="display:none">Info about the '&lt;basic-shape>' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape">https://drafts.csswg.org/css-shapes-1/#typedef-basic-shape</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-basic-shape">4.1. Define a path: The offset-path property</a> <a href="#ref-for-typedef-basic-shape①">(2)</a> <a href="#ref-for-typedef-basic-shape②">(3)</a> <a href="#ref-for-typedef-basic-shape③">(4)</a>
     <li><a href="#ref-for-typedef-basic-shape④">4.1.2. Examples Of &lt;basic-shape> Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-circle">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-circle" class="dfn-panel" data-for="term-for-funcdef-basic-shape-circle" id="infopanel-for-term-for-funcdef-basic-shape-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-circle" style="display:none">Info about the 'circle()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-circle">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-ellipse">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-ellipse" class="dfn-panel" data-for="term-for-funcdef-basic-shape-ellipse" id="infopanel-for-term-for-funcdef-basic-shape-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-ellipse" style="display:none">Info about the 'ellipse()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-ellipse">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-inset">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-inset" class="dfn-panel" data-for="term-for-funcdef-basic-shape-inset" id="infopanel-for-term-for-funcdef-basic-shape-inset" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-inset" style="display:none">Info about the 'inset()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-inset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-inset">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" class="dfn-panel" data-for="term-for-funcdef-basic-shape-polygon" id="infopanel-for-term-for-funcdef-basic-shape-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-polygon" style="display:none">Info about the 'polygon()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-polygon">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">https://drafts.csswg.org/css-transforms-1/#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#local-coordinate-system">https://drafts.csswg.org/css-transforms-1/#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-transform-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-transform-rotate" class="dfn-panel" data-for="term-for-funcdef-transform-rotate" id="infopanel-for-term-for-funcdef-transform-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-transform-rotate" style="display:none">Info about the 'rotate()' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-transform-rotate">4.5.1. Calculating the path transform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">2. Module interactions</a>
     <li><a href="#termref-for-propdef-transform">4.1. Define a path: The offset-path property</a>
@@ -2512,46 +2512,46 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-transform②">4.5. Rotation at point: The offset-rotate property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-origin">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-origin" class="dfn-panel" data-for="term-for-propdef-transform-origin" id="infopanel-for-term-for-propdef-transform-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">4.4. Define an anchor point: The offset-anchor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-rotate">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">https://drafts.csswg.org/css-transforms-2/#propdef-rotate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-rotate" class="dfn-panel" data-for="term-for-propdef-rotate" id="infopanel-for-term-for-propdef-rotate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-rotate" style="display:none">Info about the 'rotate' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-rotate">https://drafts.csswg.org/css-transforms-2/#propdef-rotate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-rotate">2. Module interactions</a>
     <li><a href="#ref-for-propdef-rotate①">4.3. Define the starting point of the path: The offset-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-scale">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-scale" class="dfn-panel" data-for="term-for-propdef-scale" id="infopanel-for-term-for-propdef-scale" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-scale" style="display:none">Info about the 'scale' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-scale">https://drafts.csswg.org/css-transforms-2/#propdef-scale</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-scale">2. Module interactions</a>
     <li><a href="#ref-for-propdef-scale①">4.3. Define the starting point of the path: The offset-position property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-translate">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">https://drafts.csswg.org/css-transforms-2/#propdef-translate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-translate" class="dfn-panel" data-for="term-for-propdef-translate" id="infopanel-for-term-for-propdef-translate" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-translate" style="display:none">Info about the 'translate' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-translate">https://drafts.csswg.org/css-transforms-2/#propdef-translate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-translate">2. Module interactions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-req">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-req" class="dfn-panel" data-for="term-for-mult-req" id="infopanel-for-term-for-mult-req" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-req" style="display:none">Info about the '!' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-req">https://drafts.csswg.org/css-values-4/#mult-req</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-req">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-all">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-all" class="dfn-panel" data-for="term-for-comb-all" id="infopanel-for-term-for-comb-all" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-all" style="display:none">Info about the '&amp;&amp;' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-all">https://drafts.csswg.org/css-values-4/#comb-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-all">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">4.1. Define a path: The offset-path property</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a> <a href="#ref-for-angle-value③">(4)</a> <a href="#ref-for-angle-value④">(5)</a>
     <li><a href="#ref-for-angle-value⑤">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-angle-value⑥">(2)</a> <a href="#ref-for-angle-value⑦">(3)</a>
@@ -2559,53 +2559,53 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-angle-value①⑧">Changes</a> <a href="#ref-for-angle-value①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-length-percentage">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-length-percentage" class="dfn-panel" data-for="term-for-typedef-length-percentage" id="infopanel-for-term-for-typedef-length-percentage" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-length-percentage" style="display:none">Info about the '&lt;length-percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-length-percentage">https://drafts.csswg.org/css-values-4/#typedef-length-percentage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-length-percentage">4.2. Position on the path: The offset-distance property</a> <a href="#ref-for-typedef-length-percentage①">(2)</a> <a href="#ref-for-typedef-length-percentage②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">4.3. Define the starting point of the path: The offset-position property</a>
     <li><a href="#ref-for-length-value①">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-length-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">4.4. Define an anchor point: The offset-anchor property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-position">
-   <a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-position" class="dfn-panel" data-for="term-for-typedef-position" id="infopanel-for-term-for-typedef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-position" style="display:none">Info about the '&lt;position>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#typedef-position">https://drafts.csswg.org/css-values-4/#typedef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-position">4.3. Define the starting point of the path: The offset-position property</a> <a href="#ref-for-typedef-position①">(2)</a>
     <li><a href="#ref-for-typedef-position②">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-typedef-position③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-value">
-   <a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-value" class="dfn-panel" data-for="term-for-string-value" id="infopanel-for-term-for-string-value" role="menu">
+   <span id="infopaneltitle-for-term-for-string-value" style="display:none">Info about the '&lt;string>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#string-value">https://drafts.csswg.org/css-values-4/#string-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-value">4.1. Define a path: The offset-path property</a> <a href="#ref-for-string-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">4.1. Define a path: The offset-path property</a> <a href="#ref-for-url-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">4.1. Define a path: The offset-path property</a>
     <li><a href="#ref-for-mult-opt①">4.6. Offset shorthand: The offset property</a> <a href="#ref-for-mult-opt②">(2)</a> <a href="#ref-for-mult-opt③">(3)</a> <a href="#ref-for-mult-opt④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4.1. Define a path: The offset-path property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a> <a href="#ref-for-comb-one③">(4)</a> <a href="#ref-for-comb-one④">(5)</a>
     <li><a href="#ref-for-comb-one⑤">4.3. Define the starting point of the path: The offset-position property</a>
@@ -2613,27 +2613,27 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-comb-one⑦">4.5. Rotation at point: The offset-rotate property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">4.5. Rotation at point: The offset-rotate property</a>
     <li><a href="#ref-for-comb-any①">4.6. Offset shorthand: The offset property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPathDirection">
-   <a href="https://svgwg.org/svg2-draft/paths.html#TermPathDirection">https://svgwg.org/svg2-draft/paths.html#TermPathDirection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPathDirection" class="dfn-panel" data-for="term-for-TermPathDirection" id="infopanel-for-term-for-TermPathDirection" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPathDirection" style="display:none">Info about the 'direction of a path' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#TermPathDirection">https://svgwg.org/svg2-draft/paths.html#TermPathDirection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPathDirection">4.5. Rotation at point: The offset-rotate property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermShapeElement">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">https://svgwg.org/svg2-draft/shapes.html#TermShapeElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermShapeElement" class="dfn-panel" data-for="term-for-TermShapeElement" id="infopanel-for-term-for-TermShapeElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermShapeElement" style="display:none">Info about the 'shape elements' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">https://svgwg.org/svg2-draft/shapes.html#TermShapeElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermShapeElement">4.1. Define a path: The offset-path property</a> <a href="#ref-for-TermShapeElement①">(2)</a> <a href="#ref-for-TermShapeElement②">(3)</a> <a href="#ref-for-TermShapeElement③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStackingContext">
-   <a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStackingContext" class="dfn-panel" data-for="term-for-TermStackingContext" id="infopanel-for-term-for-TermStackingContext" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStackingContext" style="display:none">Info about the 'stacking contexts' external reference.</span><a href="https://svgwg.org/svg2-draft/render.html#TermStackingContext">https://svgwg.org/svg2-draft/render.html#TermStackingContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStackingContext">2. Module interactions</a>
     <li><a href="#ref-for-TermStackingContext①">4.1. Define a path: The offset-path property</a>
@@ -2865,8 +2865,8 @@ for their reviews, comments, and corrections.</p>
    <div class="issue"> Do we need to say how to get the position in more detail? <a class="issue-return" href="#issue-8c7a4468" title="Jump to section">↵</a></div>
    <div class="issue"> There needs to be a process for converting <a class="css" data-link-type="maybe" href="https://drafts.csswg.org/css-transforms-1/#funcdef-transform-rotate">rotate()</a> to an angle. <a class="issue-return" href="#issue-af0945aa" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="propdef-offset-path">
-   <b><a href="#propdef-offset-path">#propdef-offset-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset-path" class="dfn-panel" data-for="propdef-offset-path" id="infopanel-for-propdef-offset-path" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset-path" style="display:none">Info about the 'offset-path' definition.</span><b><a href="#propdef-offset-path">#propdef-offset-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-path">2. Module interactions</a>
     <li><a href="#ref-for-propdef-offset-path①">4. Motion Paths</a>
@@ -2879,8 +2879,8 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-offset-path①⑥">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offset-path">
-   <b><a href="#offset-path">#offset-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offset-path" class="dfn-panel" data-for="offset-path" id="infopanel-for-offset-path" role="dialog">
+   <span id="infopaneltitle-for-offset-path" style="display:none">Info about the 'offset path' definition.</span><b><a href="#offset-path">#offset-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offset-path">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offset-path①">(2)</a> <a href="#ref-for-offset-path②">(3)</a> <a href="#ref-for-offset-path③">(4)</a> <a href="#ref-for-offset-path④">(5)</a> <a href="#ref-for-offset-path⑤">(6)</a>
     <li><a href="#ref-for-offset-path⑥">4.1.1. Examples Of ray() Positioning</a>
@@ -2894,54 +2894,54 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-offset-path③③">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offset-path-initial-position">
-   <b><a href="#offset-path-initial-position">#offset-path-initial-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offset-path-initial-position" class="dfn-panel" data-for="offset-path-initial-position" id="infopanel-for-offset-path-initial-position" role="dialog">
+   <span id="infopaneltitle-for-offset-path-initial-position" style="display:none">Info about the 'initial position' definition.</span><b><a href="#offset-path-initial-position">#offset-path-initial-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offset-path-initial-position">4.1. Define a path: The offset-path property</a>
     <li><a href="#ref-for-offset-path-initial-position①">4.1.3. Examples of &lt;coord-box> Positioning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-offset-path-ray">
-   <b><a href="#funcdef-offset-path-ray">#funcdef-offset-path-ray</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-offset-path-ray" class="dfn-panel" data-for="funcdef-offset-path-ray" id="infopanel-for-funcdef-offset-path-ray" role="dialog">
+   <span id="infopaneltitle-for-funcdef-offset-path-ray" style="display:none">Info about the 'ray()' definition.</span><b><a href="#funcdef-offset-path-ray">#funcdef-offset-path-ray</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-offset-path-ray">4.1. Define a path: The offset-path property</a>
     <li><a href="#ref-for-funcdef-offset-path-ray①">4.1.1. Examples Of ray() Positioning</a>
     <li><a href="#ref-for-funcdef-offset-path-ray②">Changes</a> <a href="#ref-for-funcdef-offset-path-ray③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-closest-side">
-   <b><a href="#size-closest-side">#size-closest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-closest-side" class="dfn-panel" data-for="size-closest-side" id="infopanel-for-size-closest-side" role="dialog">
+   <span id="infopaneltitle-for-size-closest-side" style="display:none">Info about the 'closest-side' definition.</span><b><a href="#size-closest-side">#size-closest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-closest-side">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-farthest-side">
-   <b><a href="#size-farthest-side">#size-farthest-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-farthest-side" class="dfn-panel" data-for="size-farthest-side" id="infopanel-for-size-farthest-side" role="dialog">
+   <span id="infopaneltitle-for-size-farthest-side" style="display:none">Info about the 'farthest-side' definition.</span><b><a href="#size-farthest-side">#size-farthest-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-farthest-side">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="size-sides">
-   <b><a href="#size-sides">#size-sides</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-size-sides" class="dfn-panel" data-for="size-sides" id="infopanel-for-size-sides" role="dialog">
+   <span id="infopaneltitle-for-size-sides" style="display:none">Info about the 'sides' definition.</span><b><a href="#size-sides">#size-sides</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-size-sides">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-offsetpath-pathfunc-path">
-   <b><a href="#funcdef-offsetpath-pathfunc-path">#funcdef-offsetpath-pathfunc-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-offsetpath-pathfunc-path" class="dfn-panel" data-for="funcdef-offsetpath-pathfunc-path" id="infopanel-for-funcdef-offsetpath-pathfunc-path" role="dialog">
+   <span id="infopaneltitle-for-funcdef-offsetpath-pathfunc-path" style="display:none">Info about the 'path()' definition.</span><b><a href="#funcdef-offsetpath-pathfunc-path">#funcdef-offsetpath-pathfunc-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-offsetpath-pathfunc-path">4.1. Define a path: The offset-path property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offsetpath-none">
-   <b><a href="#offsetpath-none">#offsetpath-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offsetpath-none" class="dfn-panel" data-for="offsetpath-none" id="infopanel-for-offsetpath-none" role="dialog">
+   <span id="infopaneltitle-for-offsetpath-none" style="display:none">Info about the 'none' definition.</span><b><a href="#offsetpath-none">#offsetpath-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offsetpath-none">4.1. Define a path: The offset-path property</a> <a href="#ref-for-offsetpath-none">(2)</a>
     <li><a href="#ref-for-offsetpath-none">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-offsetpath-none">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-offset-distance">
-   <b><a href="#propdef-offset-distance">#propdef-offset-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset-distance" class="dfn-panel" data-for="propdef-offset-distance" id="infopanel-for-propdef-offset-distance" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset-distance" style="display:none">Info about the 'offset-distance' definition.</span><b><a href="#propdef-offset-distance">#propdef-offset-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-distance">4. Motion Paths</a>
     <li><a href="#ref-for-propdef-offset-distance①">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-distance②">(2)</a> <a href="#ref-for-propdef-offset-distance③">(3)</a> <a href="#ref-for-propdef-offset-distance④">(4)</a> <a href="#ref-for-propdef-offset-distance⑤">(5)</a> <a href="#ref-for-propdef-offset-distance⑥">(6)</a> <a href="#ref-for-propdef-offset-distance⑦">(7)</a>
@@ -2952,28 +2952,28 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-offset-distance①④">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="used-offset-distance">
-   <b><a href="#used-offset-distance">#used-offset-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-used-offset-distance" class="dfn-panel" data-for="used-offset-distance" id="infopanel-for-used-offset-distance" role="dialog">
+   <span id="infopaneltitle-for-used-offset-distance" style="display:none">Info about the 'used offset distance' definition.</span><b><a href="#used-offset-distance">#used-offset-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-offset-distance">4.1.1. Examples Of ray() Positioning</a>
     <li><a href="#ref-for-used-offset-distance①">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-used-offset-distance②">(2)</a> <a href="#ref-for-used-offset-distance③">(3)</a> <a href="#ref-for-used-offset-distance④">(4)</a> <a href="#ref-for-used-offset-distance⑤">(5)</a>
     <li><a href="#ref-for-used-offset-distance⑥">4.5.1. Calculating the path transform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="offset-distance">
-   <b><a href="#offset-distance">#offset-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-offset-distance" class="dfn-panel" data-for="offset-distance" id="infopanel-for-offset-distance" role="dialog">
+   <span id="infopaneltitle-for-offset-distance" style="display:none">Info about the 'offset distance' definition.</span><b><a href="#offset-distance">#offset-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-offset-distance">4.2.1. Calculating the computed distance along a path</a> <a href="#ref-for-offset-distance①">(2)</a> <a href="#ref-for-offset-distance②">(3)</a> <a href="#ref-for-offset-distance③">(4)</a> <a href="#ref-for-offset-distance④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="total-length">
-   <b><a href="#total-length">#total-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-total-length" class="dfn-panel" data-for="total-length" id="infopanel-for-total-length" role="dialog">
+   <span id="infopaneltitle-for-total-length" style="display:none">Info about the 'total length' definition.</span><b><a href="#total-length">#total-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-total-length">4.2.1. Calculating the computed distance along a path</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-offset-position">
-   <b><a href="#propdef-offset-position">#propdef-offset-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset-position" class="dfn-panel" data-for="propdef-offset-position" id="infopanel-for-propdef-offset-position" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset-position" style="display:none">Info about the 'offset-position' definition.</span><b><a href="#propdef-offset-position">#propdef-offset-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-position">2. Module interactions</a>
     <li><a href="#ref-for-propdef-offset-position①">4. Motion Paths</a>
@@ -2985,8 +2985,8 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-offset-position②②">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-offset-anchor">
-   <b><a href="#propdef-offset-anchor">#propdef-offset-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset-anchor" class="dfn-panel" data-for="propdef-offset-anchor" id="infopanel-for-propdef-offset-anchor" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset-anchor" style="display:none">Info about the 'offset-anchor' definition.</span><b><a href="#propdef-offset-anchor">#propdef-offset-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-anchor">4. Motion Paths</a>
     <li><a href="#ref-for-propdef-offset-anchor①">4.4. Define an anchor point: The offset-anchor property</a> <a href="#ref-for-propdef-offset-anchor②">(2)</a> <a href="#ref-for-propdef-offset-anchor③">(3)</a>
@@ -2994,8 +2994,8 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-offset-anchor⑥">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anchor-point">
-   <b><a href="#anchor-point">#anchor-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anchor-point" class="dfn-panel" data-for="anchor-point" id="infopanel-for-anchor-point" role="dialog">
+   <span id="infopaneltitle-for-anchor-point" style="display:none">Info about the 'anchor point' definition.</span><b><a href="#anchor-point">#anchor-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-point">4. Motion Paths</a>
     <li><a href="#ref-for-anchor-point①">4.2. Position on the path: The offset-distance property</a>
@@ -3004,8 +3004,8 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-anchor-point①①">4.5.1. Calculating the path transform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-offset-rotate">
-   <b><a href="#propdef-offset-rotate">#propdef-offset-rotate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset-rotate" class="dfn-panel" data-for="propdef-offset-rotate" id="infopanel-for-propdef-offset-rotate" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset-rotate" style="display:none">Info about the 'offset-rotate' definition.</span><b><a href="#propdef-offset-rotate">#propdef-offset-rotate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset-rotate">4. Motion Paths</a>
     <li><a href="#ref-for-propdef-offset-rotate①">4.1. Define a path: The offset-path property</a> <a href="#ref-for-propdef-offset-rotate②">(2)</a> <a href="#ref-for-propdef-offset-rotate③">(3)</a>
@@ -3015,8 +3015,8 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-propdef-offset-rotate①③">Changes</a> <a href="#ref-for-propdef-offset-rotate①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-offset-rotate-auto">
-   <b><a href="#valdef-offset-rotate-auto">#valdef-offset-rotate-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-offset-rotate-auto" class="dfn-panel" data-for="valdef-offset-rotate-auto" id="infopanel-for-valdef-offset-rotate-auto" role="dialog">
+   <span id="infopaneltitle-for-valdef-offset-rotate-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#valdef-offset-rotate-auto">#valdef-offset-rotate-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-offset-rotate-auto">4.1. Define a path: The offset-path property</a>
     <li><a href="#ref-for-valdef-offset-rotate-auto①">4.3. Define the starting point of the path: The offset-position property</a> <a href="#ref-for-valdef-offset-rotate-auto②">(2)</a> <a href="#ref-for-valdef-offset-rotate-auto③">(3)</a>
@@ -3025,33 +3025,33 @@ for their reviews, comments, and corrections.</p>
     <li><a href="#ref-for-valdef-offset-rotate-auto①③">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-offset-rotate-reverse">
-   <b><a href="#valdef-offset-rotate-reverse">#valdef-offset-rotate-reverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-offset-rotate-reverse" class="dfn-panel" data-for="valdef-offset-rotate-reverse" id="infopanel-for-valdef-offset-rotate-reverse" role="dialog">
+   <span id="infopaneltitle-for-valdef-offset-rotate-reverse" style="display:none">Info about the 'reverse' definition.</span><b><a href="#valdef-offset-rotate-reverse">#valdef-offset-rotate-reverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-offset-rotate-reverse">4.5. Rotation at point: The offset-rotate property</a> <a href="#ref-for-valdef-offset-rotate-reverse①">(2)</a> <a href="#ref-for-valdef-offset-rotate-reverse②">(3)</a> <a href="#ref-for-valdef-offset-rotate-reverse③">(4)</a> <a href="#ref-for-valdef-offset-rotate-reverse④">(5)</a>
     <li><a href="#ref-for-valdef-offset-rotate-reverse⑤">Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="t1">
-   <b><a href="#t1">#t1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-t1" class="dfn-panel" data-for="t1" id="infopanel-for-t1" role="dialog">
+   <span id="infopaneltitle-for-t1" style="display:none">Info about the 'T1' definition.</span><b><a href="#t1">#t1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-t1">4.5.1. Calculating the path transform</a> <a href="#ref-for-t1①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="t2">
-   <b><a href="#t2">#t2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-t2" class="dfn-panel" data-for="t2" id="infopanel-for-t2" role="dialog">
+   <span id="infopaneltitle-for-t2" style="display:none">Info about the 'T2' definition.</span><b><a href="#t2">#t2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-t2">4.5.1. Calculating the path transform</a> <a href="#ref-for-t2①">(2)</a> <a href="#ref-for-t2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="p">
-   <b><a href="#p">#p</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-p" class="dfn-panel" data-for="p" id="infopanel-for-p" role="dialog">
+   <span id="infopaneltitle-for-p" style="display:none">Info about the 'P' definition.</span><b><a href="#p">#p</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-p">4.5.1. Calculating the path transform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-offset">
-   <b><a href="#propdef-offset">#propdef-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-offset" class="dfn-panel" data-for="propdef-offset" id="infopanel-for-propdef-offset" role="dialog">
+   <span id="infopaneltitle-for-propdef-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#propdef-offset">#propdef-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-offset">4.6. Offset shorthand: The offset property</a>
     <li><a href="#ref-for-propdef-offset①">Changes</a>
@@ -3059,59 +3059,115 @@ for their reviews, comments, and corrections.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/geolocation-sensor/index.html
+++ b/tests/github/w3c/geolocation-sensor/index.html
@@ -1144,206 +1144,206 @@ from 2008 until 2017.</p>
     </ul>
    <li><a href="#dom-geolocationsensorreading-timestamp">timestamp</a><span>, in § 5.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-aborted-flag">
-   <a href="https://dom.spec.whatwg.org#abortsignal-aborted-flag">https://dom.spec.whatwg.org#abortsignal-aborted-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-aborted-flag" class="dfn-panel" data-for="term-for-abortsignal-aborted-flag" id="infopanel-for-term-for-abortsignal-aborted-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-aborted-flag" style="display:none">Info about the 'aborted flag' external reference.</span><a href="https://dom.spec.whatwg.org#abortsignal-aborted-flag">https://dom.spec.whatwg.org#abortsignal-aborted-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-aborted-flag">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org#abortsignal-add">https://dom.spec.whatwg.org#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add the following abort steps' external reference.</span><a href="https://dom.spec.whatwg.org#abortsignal-add">https://dom.spec.whatwg.org#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-geolocation">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-geolocation">https://w3c.github.io/sensors/#dom-mocksensortype-geolocation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-geolocation" class="dfn-panel" data-for="term-for-dom-mocksensortype-geolocation" id="infopanel-for-term-for-dom-mocksensortype-geolocation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-geolocation" style="display:none">Info about the '"geolocation"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-geolocation">https://w3c.github.io/sensors/#dom-mocksensortype-geolocation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-geolocation">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">1. Introduction</a>
     <li><a href="#ref-for-sensor①">4. Model</a> <a href="#ref-for-sensor②">(2)</a>
     <li><a href="#ref-for-sensor③">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors#automation">https://w3c.github.io/sensors#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors#automation">https://w3c.github.io/sensors#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">https://w3c.github.io/sensors#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">https://w3c.github.io/sensors#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extensibility">
-   <a href="https://w3c.github.io/sensors#extensibility">https://w3c.github.io/sensors#extensibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extensibility" class="dfn-panel" data-for="term-for-extensibility" id="infopanel-for-term-for-extensibility" role="menu">
+   <span id="infopaneltitle-for-term-for-extensibility" style="display:none">Info about the 'extensible' external reference.</span><a href="https://w3c.github.io/sensors#extensibility">https://w3c.github.io/sensors#extensibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extensibility">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors#initialize-a-sensor-object">https://w3c.github.io/sensors#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">https://w3c.github.io/sensors#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">4. Model</a>
     <li><a href="#ref-for-latest-reading①">5.1.5. GeolocationSensor.accuracy</a> <a href="#ref-for-latest-reading②">(2)</a> <a href="#ref-for-latest-reading③">(3)</a> <a href="#ref-for-latest-reading④">(4)</a>
     <li><a href="#ref-for-latest-reading⑤">5.1.6. GeolocationSensor.altitudeAccuracy</a> <a href="#ref-for-latest-reading⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors#mock-sensor-reading-values">https://w3c.github.io/sensors#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors#mock-sensor-reading-values">https://w3c.github.io/sensors#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors#mock-sensor-type">https://w3c.github.io/sensors#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors#mock-sensor-type">https://w3c.github.io/sensors#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-security-and-privacy">
-   <a href="https://w3c.github.io/sensors#security-and-privacy">https://w3c.github.io/sensors#security-and-privacy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-security-and-privacy" class="dfn-panel" data-for="term-for-security-and-privacy" id="infopanel-for-term-for-security-and-privacy" role="menu">
+   <span id="infopaneltitle-for-term-for-security-and-privacy" style="display:none">Info about the 'security and privacy' external reference.</span><a href="https://w3c.github.io/sensors#security-and-privacy">https://w3c.github.io/sensors#security-and-privacy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-and-privacy">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors#sensor-type">https://w3c.github.io/sensors#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors#sensor-type">https://w3c.github.io/sensors#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">4. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-sensor-start">
-   <a href="https://w3c.github.io/sensors/#dom-sensor-start">https://w3c.github.io/sensors/#dom-sensor-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-sensor-start" class="dfn-panel" data-for="term-for-dom-sensor-start" id="infopanel-for-term-for-dom-sensor-start" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-sensor-start" style="display:none">Info about the 'start()' external reference.</span><a href="https://w3c.github.io/sensors/#dom-sensor-start">https://w3c.github.io/sensors/#dom-sensor-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-start">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-sensor-stop">
-   <a href="https://w3c.github.io/sensors/#dom-sensor-stop">https://w3c.github.io/sensors/#dom-sensor-stop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-sensor-stop" class="dfn-panel" data-for="term-for-dom-sensor-stop" id="infopanel-for-term-for-dom-sensor-stop" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-sensor-stop" style="display:none">Info about the 'stop()' external reference.</span><a href="https://w3c.github.io/sensors/#dom-sensor-stop">https://w3c.github.io/sensors/#dom-sensor-stop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-stop">5.1.1. GeolocationSensor.read()</a> <a href="#ref-for-dom-sensor-stop①">(2)</a> <a href="#ref-for-dom-sensor-stop②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">http://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="http://w3c.github.io/hr-time/#dom-domhighrestimestamp">http://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">5.1.1. GeolocationSensor.read()</a> <a href="#ref-for-aborterror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">5.1.1. GeolocationSensor.read()</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a>
     <li><a href="#ref-for-idl-DOMException⑤">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. The GeolocationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5.1. The GeolocationSensor Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a> <a href="#ref-for-idl-double④">(5)</a> <a href="#ref-for-idl-double⑤">(6)</a> <a href="#ref-for-idl-double⑥">(7)</a>
     <li><a href="#ref-for-idl-double⑦">7.1. Mock Sensor Type</a> <a href="#ref-for-idl-double⑧">(2)</a> <a href="#ref-for-idl-double⑨">(3)</a> <a href="#ref-for-idl-double①⓪">(4)</a> <a href="#ref-for-idl-double①①">(5)</a> <a href="#ref-for-idl-double①②">(6)</a> <a href="#ref-for-idl-double①③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">5.1. The GeolocationSensor Interface</a> <a href="#ref-for-idl-unrestricted-double①">(2)</a> <a href="#ref-for-idl-unrestricted-double②">(3)</a> <a href="#ref-for-idl-unrestricted-double③">(4)</a> <a href="#ref-for-idl-unrestricted-double④">(5)</a> <a href="#ref-for-idl-unrestricted-double⑤">(6)</a> <a href="#ref-for-idl-unrestricted-double⑥">(7)</a>
    </ul>
@@ -1476,8 +1476,8 @@ from 2008 until 2017.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="geolocation">
-   <b><a href="#geolocation">#geolocation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geolocation" class="dfn-panel" data-for="geolocation" id="infopanel-for-geolocation" role="dialog">
+   <span id="infopaneltitle-for-geolocation" style="display:none">Info about the 'geolocation' definition.</span><b><a href="#geolocation">#geolocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geolocation①">1. Introduction</a>
     <li><a href="#ref-for-geolocation②">4. Model</a> <a href="#ref-for-geolocation③">(2)</a>
@@ -1487,20 +1487,20 @@ from 2008 until 2017.</p>
     <li><a href="#ref-for-geolocation⑦">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geolocation-sensor">
-   <b><a href="#geolocation-sensor">#geolocation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geolocation-sensor" class="dfn-panel" data-for="geolocation-sensor" id="infopanel-for-geolocation-sensor" role="dialog">
+   <span id="infopaneltitle-for-geolocation-sensor" style="display:none">Info about the 'Geolocation Sensor' definition.</span><b><a href="#geolocation-sensor">#geolocation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geolocation-sensor">4. Model</a> <a href="#ref-for-geolocation-sensor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="latest-geolocation-reading">
-   <b><a href="#latest-geolocation-reading">#latest-geolocation-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-latest-geolocation-reading" class="dfn-panel" data-for="latest-geolocation-reading" id="infopanel-for-latest-geolocation-reading" role="dialog">
+   <span id="infopaneltitle-for-latest-geolocation-reading" style="display:none">Info about the 'latest geolocation reading' definition.</span><b><a href="#latest-geolocation-reading">#latest-geolocation-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-geolocation-reading">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geolocationsensor">
-   <b><a href="#geolocationsensor">#geolocationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geolocationsensor" class="dfn-panel" data-for="geolocationsensor" id="infopanel-for-geolocationsensor" role="dialog">
+   <span id="infopaneltitle-for-geolocationsensor" style="display:none">Info about the 'GeolocationSensor' definition.</span><b><a href="#geolocationsensor">#geolocationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geolocationsensor①">1. Introduction</a> <a href="#ref-for-geolocationsensor②">(2)</a>
     <li><a href="#ref-for-geolocationsensor③">4. Model</a>
@@ -1517,83 +1517,83 @@ from 2008 until 2017.</p>
     <li><a href="#ref-for-geolocationsensor①⑥">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-read">
-   <b><a href="#dom-geolocationsensor-read">#dom-geolocationsensor-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-read" class="dfn-panel" data-for="dom-geolocationsensor-read" id="infopanel-for-dom-geolocationsensor-read" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-read" style="display:none">Info about the 'read' definition.</span><b><a href="#dom-geolocationsensor-read">#dom-geolocationsensor-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-read">5.1.1. GeolocationSensor.read()</a> <a href="#ref-for-dom-geolocationsensor-read①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-latitude">
-   <b><a href="#dom-geolocationsensor-latitude">#dom-geolocationsensor-latitude</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-latitude" class="dfn-panel" data-for="dom-geolocationsensor-latitude" id="infopanel-for-dom-geolocationsensor-latitude" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-latitude" style="display:none">Info about the 'latitude' definition.</span><b><a href="#dom-geolocationsensor-latitude">#dom-geolocationsensor-latitude</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-latitude">5.1.2. GeolocationSensor.latitude</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-longitude">
-   <b><a href="#dom-geolocationsensor-longitude">#dom-geolocationsensor-longitude</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-longitude" class="dfn-panel" data-for="dom-geolocationsensor-longitude" id="infopanel-for-dom-geolocationsensor-longitude" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-longitude" style="display:none">Info about the 'longitude' definition.</span><b><a href="#dom-geolocationsensor-longitude">#dom-geolocationsensor-longitude</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-longitude">5.1.3. GeolocationSensor.longitude</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-altitude">
-   <b><a href="#dom-geolocationsensor-altitude">#dom-geolocationsensor-altitude</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-altitude" class="dfn-panel" data-for="dom-geolocationsensor-altitude" id="infopanel-for-dom-geolocationsensor-altitude" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-altitude" style="display:none">Info about the 'altitude' definition.</span><b><a href="#dom-geolocationsensor-altitude">#dom-geolocationsensor-altitude</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-altitude">5.1.4. GeolocationSensor.altitude</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-accuracy">
-   <b><a href="#dom-geolocationsensor-accuracy">#dom-geolocationsensor-accuracy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-accuracy" class="dfn-panel" data-for="dom-geolocationsensor-accuracy" id="infopanel-for-dom-geolocationsensor-accuracy" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-accuracy" style="display:none">Info about the 'accuracy' definition.</span><b><a href="#dom-geolocationsensor-accuracy">#dom-geolocationsensor-accuracy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-accuracy">5.1.5. GeolocationSensor.accuracy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-altitudeaccuracy">
-   <b><a href="#dom-geolocationsensor-altitudeaccuracy">#dom-geolocationsensor-altitudeaccuracy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-altitudeaccuracy" class="dfn-panel" data-for="dom-geolocationsensor-altitudeaccuracy" id="infopanel-for-dom-geolocationsensor-altitudeaccuracy" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-altitudeaccuracy" style="display:none">Info about the 'altitudeAccuracy' definition.</span><b><a href="#dom-geolocationsensor-altitudeaccuracy">#dom-geolocationsensor-altitudeaccuracy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-altitudeaccuracy">5.1.6. GeolocationSensor.altitudeAccuracy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-heading">
-   <b><a href="#dom-geolocationsensor-heading">#dom-geolocationsensor-heading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-heading" class="dfn-panel" data-for="dom-geolocationsensor-heading" id="infopanel-for-dom-geolocationsensor-heading" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-heading" style="display:none">Info about the 'heading' definition.</span><b><a href="#dom-geolocationsensor-heading">#dom-geolocationsensor-heading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-heading">5.1.7. GeolocationSensor.heading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-geolocationsensor-speed">
-   <b><a href="#dom-geolocationsensor-speed">#dom-geolocationsensor-speed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-geolocationsensor-speed" class="dfn-panel" data-for="dom-geolocationsensor-speed" id="infopanel-for-dom-geolocationsensor-speed" role="dialog">
+   <span id="infopaneltitle-for-dom-geolocationsensor-speed" style="display:none">Info about the 'speed' definition.</span><b><a href="#dom-geolocationsensor-speed">#dom-geolocationsensor-speed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-geolocationsensor-speed">5.1.8. GeolocationSensor.speed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-geolocationsensoroptions">
-   <b><a href="#dictdef-geolocationsensoroptions">#dictdef-geolocationsensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-geolocationsensoroptions" class="dfn-panel" data-for="dictdef-geolocationsensoroptions" id="infopanel-for-dictdef-geolocationsensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-geolocationsensoroptions" style="display:none">Info about the 'GeolocationSensorOptions' definition.</span><b><a href="#dictdef-geolocationsensoroptions">#dictdef-geolocationsensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-geolocationsensoroptions">5.1. The GeolocationSensor Interface</a> <a href="#ref-for-dictdef-geolocationsensoroptions①">(2)</a>
     <li><a href="#ref-for-dictdef-geolocationsensoroptions②">6.1. Construct a geolocation sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readoptions">
-   <b><a href="#dictdef-readoptions">#dictdef-readoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readoptions" class="dfn-panel" data-for="dictdef-readoptions" id="infopanel-for-dictdef-readoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readoptions" style="display:none">Info about the 'ReadOptions' definition.</span><b><a href="#dictdef-readoptions">#dictdef-readoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readoptions">5.1. The GeolocationSensor Interface</a>
     <li><a href="#ref-for-dictdef-readoptions①">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-geolocationsensorreading">
-   <b><a href="#dictdef-geolocationsensorreading">#dictdef-geolocationsensorreading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-geolocationsensorreading" class="dfn-panel" data-for="dictdef-geolocationsensorreading" id="infopanel-for-dictdef-geolocationsensorreading" role="dialog">
+   <span id="infopaneltitle-for-dictdef-geolocationsensorreading" style="display:none">Info about the 'GeolocationSensorReading' definition.</span><b><a href="#dictdef-geolocationsensorreading">#dictdef-geolocationsensorreading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-geolocationsensorreading">5.1. The GeolocationSensor Interface</a>
     <li><a href="#ref-for-dictdef-geolocationsensorreading①">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resolve-a-geolocation-promise">
-   <b><a href="#resolve-a-geolocation-promise">#resolve-a-geolocation-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resolve-a-geolocation-promise" class="dfn-panel" data-for="resolve-a-geolocation-promise" id="infopanel-for-resolve-a-geolocation-promise" role="dialog">
+   <span id="infopaneltitle-for-resolve-a-geolocation-promise" style="display:none">Info about the 'resolve a geolocation promise' definition.</span><b><a href="#resolve-a-geolocation-promise">#resolve-a-geolocation-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve-a-geolocation-promise">5.1.1. GeolocationSensor.read()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-geolocation-sensor-object">
-   <b><a href="#construct-a-geolocation-sensor-object">#construct-a-geolocation-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-geolocation-sensor-object" class="dfn-panel" data-for="construct-a-geolocation-sensor-object" id="infopanel-for-construct-a-geolocation-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-construct-a-geolocation-sensor-object" style="display:none">Info about the '6.1. Construct a geolocation sensor object' definition.</span><b><a href="#construct-a-geolocation-sensor-object">#construct-a-geolocation-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-geolocation-sensor-object">5.1. The GeolocationSensor Interface</a>
     <li><a href="#ref-for-construct-a-geolocation-sensor-object①">5.1.1. GeolocationSensor.read()</a>
@@ -1602,59 +1602,115 @@ from 2008 until 2017.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/gyroscope/index.html
+++ b/tests/github/w3c/gyroscope/index.html
@@ -882,201 +882,201 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#dom-gyroscopereadingvalues-z">dict-member for GyroscopeReadingValues</a><span>, in § 8.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-device-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-coordinate-system" class="dfn-panel" data-for="term-for-device-coordinate-system" id="infopanel-for-term-for-device-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-device-coordinate-system" style="display:none">Info about the 'device coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-coordinate-system">5.1. Reference Frame</a>
     <li><a href="#ref-for-device-coordinate-system①">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-screen-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-screen-coordinate-system" class="dfn-panel" data-for="term-for-screen-coordinate-system" id="infopanel-for-term-for-screen-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-screen-coordinate-system" style="display:none">Info about the 'screen coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screen-coordinate-system">5.1. Reference Frame</a>
     <li><a href="#ref-for-screen-coordinate-system①">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-gyroscope">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-gyroscope">https://w3c.github.io/sensors/#dom-mocksensortype-gyroscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-gyroscope" class="dfn-panel" data-for="term-for-dom-mocksensortype-gyroscope" id="infopanel-for-term-for-dom-mocksensortype-gyroscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-gyroscope" style="display:none">Info about the '"gyroscope"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-gyroscope">https://w3c.github.io/sensors/#dom-mocksensortype-gyroscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-gyroscope">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">5. Model</a> <a href="#ref-for-sensor①">(2)</a>
     <li><a href="#ref-for-sensor②">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">8. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sensor">
-   <a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sensor" class="dfn-panel" data-for="term-for-default-sensor" id="infopanel-for-term-for-default-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sensor" style="display:none">Info about the 'default sensor' external reference.</span><a href="https://w3c.github.io/sensors/#default-sensor">https://w3c.github.io/sensors/#default-sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sensor">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eavesdropping">
-   <a href="https://w3c.github.io/sensors/#eavesdropping">https://w3c.github.io/sensors/#eavesdropping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eavesdropping" class="dfn-panel" data-for="term-for-eavesdropping" id="infopanel-for-term-for-eavesdropping" role="menu">
+   <span id="infopaneltitle-for-term-for-eavesdropping" style="display:none">Info about the 'eavesdropping' external reference.</span><a href="https://w3c.github.io/sensors/#eavesdropping">https://w3c.github.io/sensors/#eavesdropping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eavesdropping">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-device-fingerprinting">
-   <a href="https://w3c.github.io/sensors/#device-fingerprinting">https://w3c.github.io/sensors/#device-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-fingerprinting" class="dfn-panel" data-for="term-for-device-fingerprinting" id="infopanel-for-term-for-device-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-device-fingerprinting" style="display:none">Info about the 'fingerprinting' external reference.</span><a href="https://w3c.github.io/sensors/#device-fingerprinting">https://w3c.github.io/sensors/#device-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-fingerprinting">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
-   <a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mitigation-strategies" class="dfn-panel" data-for="term-for-mitigation-strategies" id="infopanel-for-term-for-mitigation-strategies" role="menu">
+   <span id="infopaneltitle-for-term-for-mitigation-strategies" style="display:none">Info about the 'generic mitigations' external reference.</span><a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mitigation-strategies">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keystroke-monitoring">
-   <a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keystroke-monitoring" class="dfn-panel" data-for="term-for-keystroke-monitoring" id="infopanel-for-term-for-keystroke-monitoring" role="menu">
+   <span id="infopaneltitle-for-term-for-keystroke-monitoring" style="display:none">Info about the 'keylogging' external reference.</span><a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keystroke-monitoring">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">5. Model</a> <a href="#ref-for-local-coordinate-system①">(2)</a>
     <li><a href="#ref-for-local-coordinate-system②">5.1. Reference Frame</a>
     <li><a href="#ref-for-local-coordinate-system③">7.1. Construct a Gyroscope object</a> <a href="#ref-for-local-coordinate-system④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location-tracking">
-   <a href="https://w3c.github.io/sensors/#location-tracking">https://w3c.github.io/sensors/#location-tracking</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location-tracking" class="dfn-panel" data-for="term-for-location-tracking" id="infopanel-for-term-for-location-tracking" role="menu">
+   <span id="infopaneltitle-for-term-for-location-tracking" style="display:none">Info about the 'location tracking' external reference.</span><a href="https://w3c.github.io/sensors/#location-tracking">https://w3c.github.io/sensors/#location-tracking</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location-tracking">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-permission-names">
-   <a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-permission-names" class="dfn-panel" data-for="term-for-sensor-permission-names" id="infopanel-for-term-for-sensor-permission-names" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-permission-names" style="display:none">Info about the 'sensor permission name' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-reading">
-   <a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-reading" class="dfn-panel" data-for="term-for-sensor-reading" id="infopanel-for-term-for-sensor-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-reading" style="display:none">Info about the 'sensor reading' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-reading">4. Security and Privacy Considerations</a> <a href="#ref-for-sensor-reading①">(2)</a>
     <li><a href="#ref-for-sensor-reading②">5.1. Reference Frame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">5. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-sensor-options">
-   <a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-sensor-options" class="dfn-panel" data-for="term-for-supported-sensor-options" id="infopanel-for-term-for-supported-sensor-options" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-sensor-options" style="display:none">Info about the 'supported sensor options' external reference.</span><a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-sensor-options">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-identifying">
-   <a href="https://w3c.github.io/sensors/#user-identifying">https://w3c.github.io/sensors/#user-identifying</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-identifying" class="dfn-panel" data-for="term-for-user-identifying" id="infopanel-for-term-for-user-identifying" role="menu">
+   <span id="infopaneltitle-for-term-for-user-identifying" style="display:none">Info about the 'user identifying' external reference.</span><a href="https://w3c.github.io/sensors/#user-identifying">https://w3c.github.io/sensors/#user-identifying</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-identifying">4. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.1. The Gyroscope Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
     <li><a href="#ref-for-idl-double③">8.1. Mock Sensor Type</a> <a href="#ref-for-idl-double④">(2)</a> <a href="#ref-for-idl-double⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">7.1. Construct a Gyroscope object</a>
    </ul>
@@ -1177,15 +1177,15 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="gyroscope-sensor-type">
-   <b><a href="#gyroscope-sensor-type">#gyroscope-sensor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gyroscope-sensor-type" class="dfn-panel" data-for="gyroscope-sensor-type" id="infopanel-for-gyroscope-sensor-type" role="dialog">
+   <span id="infopaneltitle-for-gyroscope-sensor-type" style="display:none">Info about the 'Gyroscope' definition.</span><b><a href="#gyroscope-sensor-type">#gyroscope-sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-sensor-type">5. Model</a> <a href="#ref-for-gyroscope-sensor-type①">(2)</a> <a href="#ref-for-gyroscope-sensor-type②">(3)</a>
     <li><a href="#ref-for-gyroscope-sensor-type③">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="angular-velocity">
-   <b><a href="#angular-velocity">#angular-velocity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-angular-velocity" class="dfn-panel" data-for="angular-velocity" id="infopanel-for-angular-velocity" role="dialog">
+   <span id="infopaneltitle-for-angular-velocity" style="display:none">Info about the 'angular velocity' definition.</span><b><a href="#angular-velocity">#angular-velocity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">5. Model</a> <a href="#ref-for-angular-velocity①">(2)</a>
     <li><a href="#ref-for-angular-velocity②">6.1.1. Gyroscope.x</a>
@@ -1193,8 +1193,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-angular-velocity④">6.1.3. Gyroscope.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gyroscope">
-   <b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gyroscope" class="dfn-panel" data-for="gyroscope" id="infopanel-for-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-gyroscope" style="display:none">Info about the 'Gyroscope' definition.</span><b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">5. Model</a>
     <li><a href="#ref-for-gyroscope①">5.1. Reference Frame</a>
@@ -1207,45 +1207,45 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-gyroscope①⓪">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gyroscope-x">
-   <b><a href="#dom-gyroscope-x">#dom-gyroscope-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gyroscope-x" class="dfn-panel" data-for="dom-gyroscope-x" id="infopanel-for-dom-gyroscope-x" role="dialog">
+   <span id="infopaneltitle-for-dom-gyroscope-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-gyroscope-x">#dom-gyroscope-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gyroscope-x">6.1.1. Gyroscope.x</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gyroscope-y">
-   <b><a href="#dom-gyroscope-y">#dom-gyroscope-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gyroscope-y" class="dfn-panel" data-for="dom-gyroscope-y" id="infopanel-for-dom-gyroscope-y" role="dialog">
+   <span id="infopaneltitle-for-dom-gyroscope-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-gyroscope-y">#dom-gyroscope-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gyroscope-y">6.1.2. Gyroscope.y</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gyroscope-z">
-   <b><a href="#dom-gyroscope-z">#dom-gyroscope-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gyroscope-z" class="dfn-panel" data-for="dom-gyroscope-z" id="infopanel-for-dom-gyroscope-z" role="dialog">
+   <span id="infopaneltitle-for-dom-gyroscope-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-gyroscope-z">#dom-gyroscope-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gyroscope-z">6.1.3. Gyroscope.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-gyroscopelocalcoordinatesystem">
-   <b><a href="#enumdef-gyroscopelocalcoordinatesystem">#enumdef-gyroscopelocalcoordinatesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-gyroscopelocalcoordinatesystem" class="dfn-panel" data-for="enumdef-gyroscopelocalcoordinatesystem" id="infopanel-for-enumdef-gyroscopelocalcoordinatesystem" role="dialog">
+   <span id="infopaneltitle-for-enumdef-gyroscopelocalcoordinatesystem" style="display:none">Info about the 'GyroscopeLocalCoordinateSystem' definition.</span><b><a href="#enumdef-gyroscopelocalcoordinatesystem">#enumdef-gyroscopelocalcoordinatesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-gyroscopelocalcoordinatesystem">6.1. The Gyroscope Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-gyroscopesensoroptions">
-   <b><a href="#dictdef-gyroscopesensoroptions">#dictdef-gyroscopesensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-gyroscopesensoroptions" class="dfn-panel" data-for="dictdef-gyroscopesensoroptions" id="infopanel-for-dictdef-gyroscopesensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-gyroscopesensoroptions" style="display:none">Info about the 'GyroscopeSensorOptions' definition.</span><b><a href="#dictdef-gyroscopesensoroptions">#dictdef-gyroscopesensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-gyroscopesensoroptions">6.1. The Gyroscope Interface</a>
     <li><a href="#ref-for-dictdef-gyroscopesensoroptions①">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-gyroscopesensoroptions-referenceframe">
-   <b><a href="#dom-gyroscopesensoroptions-referenceframe">#dom-gyroscopesensoroptions-referenceframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-gyroscopesensoroptions-referenceframe" class="dfn-panel" data-for="dom-gyroscopesensoroptions-referenceframe" id="infopanel-for-dom-gyroscopesensoroptions-referenceframe" role="dialog">
+   <span id="infopaneltitle-for-dom-gyroscopesensoroptions-referenceframe" style="display:none">Info about the 'referenceFrame' definition.</span><b><a href="#dom-gyroscopesensoroptions-referenceframe">#dom-gyroscopesensoroptions-referenceframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-gyroscopesensoroptions-referenceframe">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-gyroscope-object">
-   <b><a href="#construct-a-gyroscope-object">#construct-a-gyroscope-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-gyroscope-object" class="dfn-panel" data-for="construct-a-gyroscope-object" id="infopanel-for-construct-a-gyroscope-object" role="dialog">
+   <span id="infopaneltitle-for-construct-a-gyroscope-object" style="display:none">Info about the '7.1. Construct a Gyroscope object' definition.</span><b><a href="#construct-a-gyroscope-object">#construct-a-gyroscope-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-gyroscope-object">6.1. The Gyroscope Interface</a>
     <li><a href="#ref-for-construct-a-gyroscope-object">7.1. Construct a Gyroscope object</a>
@@ -1253,59 +1253,115 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/longtasks/index.html
+++ b/tests/github/w3c/longtasks/index.html
@@ -1492,224 +1492,224 @@ showing task type or additional attribution to untrusted cross origin observers.
     </ul>
    <li><a href="#unknown">unknown</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-id">
-   <a href="https://dom.spec.whatwg.org/#concept-id">https://dom.spec.whatwg.org/#concept-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-id" class="dfn-panel" data-for="term-for-concept-id" id="infopanel-for-term-for-concept-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-id" style="display:none">Info about the 'id' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-id">https://dom.spec.whatwg.org/#concept-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-id">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'javascript realms' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">4.1. Report long tasks</a> <a href="#ref-for-sec-code-realms①">(2)</a> <a href="#ref-for-sec-code-realms②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" class="dfn-panel" data-for="term-for-idl-def-domhighrestimestamp" id="infopanel-for-term-for-idl-def-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp">https://w3c.github.io/hr-time/#idl-def-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-domhighrestimestamp">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-idl-def-domhighrestimestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">4.1. Report long tasks</a> <a href="#ref-for-nav-document①">(2)</a> <a href="#ref-for-nav-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-integration-with-the-javascript-agent-cluster-formalism">
-   <a href="https://html.spec.whatwg.org/multipage/#integration-with-the-javascript-agent-cluster-formalism">https://html.spec.whatwg.org/multipage/#integration-with-the-javascript-agent-cluster-formalism</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-integration-with-the-javascript-agent-cluster-formalism" class="dfn-panel" data-for="term-for-integration-with-the-javascript-agent-cluster-formalism" id="infopanel-for-term-for-integration-with-the-javascript-agent-cluster-formalism" role="menu">
+   <span id="infopaneltitle-for-term-for-integration-with-the-javascript-agent-cluster-formalism" style="display:none">Info about the 'agent cluster' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#integration-with-the-javascript-agent-cluster-formalism">https://html.spec.whatwg.org/multipage/#integration-with-the-javascript-agent-cluster-formalism</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integration-with-the-javascript-agent-cluster-formalism">3.3. Pointing to the culprit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ancestor-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/#ancestor-browsing-context">https://html.spec.whatwg.org/multipage/#ancestor-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ancestor-browsing-context" class="dfn-panel" data-for="term-for-ancestor-browsing-context" id="infopanel-for-term-for-ancestor-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-ancestor-browsing-context" style="display:none">Info about the 'ancestor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#ancestor-browsing-context">https://html.spec.whatwg.org/multipage/#ancestor-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ancestor-browsing-context">4.1. Report long tasks</a> <a href="#ref-for-ancestor-browsing-context①">(2)</a> <a href="#ref-for-ancestor-browsing-context②">(3)</a> <a href="#ref-for-ancestor-browsing-context③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/#browsing-context">https://html.spec.whatwg.org/multipage/#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#browsing-context">https://html.spec.whatwg.org/multipage/#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a> <a href="#ref-for-browsing-context③">(4)</a>
     <li><a href="#ref-for-browsing-context④">3.3. Pointing to the culprit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">4.1. Report long tasks</a> <a href="#ref-for-window-bc①">(2)</a> <a href="#ref-for-window-bc②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-object-data">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-object-data" class="dfn-panel" data-for="term-for-attr-object-data" id="infopanel-for-term-for-attr-object-data" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-object-data" style="display:none">Info about the 'data' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-object-data">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-embed-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-embed-element" class="dfn-panel" data-for="term-for-the-embed-element" id="infopanel-for-term-for-the-embed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-embed-element" style="display:none">Info about the 'embed' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-embed-element">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/#event-loop">https://html.spec.whatwg.org/multipage/#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#event-loop">https://html.spec.whatwg.org/multipage/#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">2. Terminology</a>
     <li><a href="#ref-for-event-loop①">3.1. PerformanceLongTaskTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame" class="dfn-panel" data-for="term-for-frame" id="infopanel-for-term-for-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-frame" style="display:none">Info about the 'frame' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">4.1. Report long tasks</a> <a href="#ref-for-concept-settings-object-global①">(2)</a> <a href="#ref-for-concept-settings-object-global②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2. Terminology</a>
     <li><a href="#ref-for-the-iframe-element①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts">
-   <a href="https://html.spec.whatwg.org/multipage/#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" class="dfn-panel" data-for="term-for-list-of-the-descendant-browsing-contexts" id="infopanel-for-term-for-list-of-the-descendant-browsing-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-the-descendant-browsing-contexts" style="display:none">Info about the 'list of the descendant browsing contexts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#list-of-the-descendant-browsing-contexts">https://html.spec.whatwg.org/multipage/#list-of-the-descendant-browsing-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-the-descendant-browsing-contexts">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-list-of-the-descendant-browsing-contexts①">(2)</a>
     <li><a href="#ref-for-list-of-the-descendant-browsing-contexts②">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#microtask">https://html.spec.whatwg.org/multipage/webappapis.html#microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-microtask" class="dfn-panel" data-for="term-for-microtask" id="infopanel-for-term-for-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-microtask" style="display:none">Info about the 'microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#microtask">https://html.spec.whatwg.org/multipage/webappapis.html#microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-microtask">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-name">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-name" class="dfn-panel" data-for="term-for-attr-iframe-name" id="infopanel-for-term-for-attr-iframe-name" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-name" style="display:none">Info about the 'name' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-name">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">2. Terminology</a>
     <li><a href="#ref-for-the-object-element①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.1. Report long tasks</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" class="dfn-panel" data-for="term-for-perform-a-microtask-checkpoint" id="infopanel-for-term-for-perform-a-microtask-checkpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-perform-a-microtask-checkpoint" style="display:none">Info about the 'perform a microtask checkpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-perform-a-microtask-checkpoint">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.1. Report long tasks</a> <a href="#ref-for-concept-relevant-realm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-same-origin①">(2)</a> <a href="#ref-for-same-origin②">(3)</a>
     <li><a href="#ref-for-same-origin④">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-evaluation-environment-settings-object-set">
-   <a href="https://html.spec.whatwg.org/multipage/#script-evaluation-environment-settings-object-set">https://html.spec.whatwg.org/multipage/#script-evaluation-environment-settings-object-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-evaluation-environment-settings-object-set" class="dfn-panel" data-for="term-for-script-evaluation-environment-settings-object-set" id="infopanel-for-term-for-script-evaluation-environment-settings-object-set" role="menu">
+   <span id="infopaneltitle-for-term-for-script-evaluation-environment-settings-object-set" style="display:none">Info about the 'script evaluation environment settings object set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#script-evaluation-environment-settings-object-set">https://html.spec.whatwg.org/multipage/#script-evaluation-environment-settings-object-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-evaluation-environment-settings-object-set">4.1. Report long tasks</a> <a href="#ref-for-script-evaluation-environment-settings-object-set①">(2)</a> <a href="#ref-for-script-evaluation-environment-settings-object-set②">(3)</a> <a href="#ref-for-script-evaluation-environment-settings-object-set③">(4)</a> <a href="#ref-for-script-evaluation-environment-settings-object-set④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-embed-src">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-embed-src" class="dfn-panel" data-for="term-for-attr-embed-src" id="infopanel-for-term-for-attr-embed-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-embed-src" style="display:none">Info about the 'src (for embed)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-embed-src">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-src">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-src" class="dfn-panel" data-for="term-for-attr-iframe-src" id="infopanel-for-term-for-attr-iframe-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-src" style="display:none">Info about the 'src (for iframe)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-src">4.1. Report long tasks</a> <a href="#ref-for-attr-iframe-src①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2. Terminology</a> <a href="#ref-for-concept-task①">(2)</a>
     <li><a href="#ref-for-concept-task②">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-concept-task③">(2)</a> <a href="#ref-for-concept-task④">(3)</a> <a href="#ref-for-concept-task⑤">(4)</a> <a href="#ref-for-concept-task⑥">(5)</a> <a href="#ref-for-concept-task⑦">(6)</a> <a href="#ref-for-concept-task⑧">(7)</a> <a href="#ref-for-concept-task⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unit-of-related-browsing-contexts">
-   <a href="https://html.spec.whatwg.org/multipage/#unit-of-related-browsing-contexts">https://html.spec.whatwg.org/multipage/#unit-of-related-browsing-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unit-of-related-browsing-contexts" class="dfn-panel" data-for="term-for-unit-of-related-browsing-contexts" id="infopanel-for-term-for-unit-of-related-browsing-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-unit-of-related-browsing-contexts" style="display:none">Info about the 'unit of related browsing contexts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#unit-of-related-browsing-contexts">https://html.spec.whatwg.org/multipage/#unit-of-related-browsing-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unit-of-related-browsing-contexts">3.3. Pointing to the culprit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#the-performanceentry-interface">https://w3c.github.io/performance-timeline/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-the-performanceentry-interface①">3.2. TaskAttributionTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-duration">https://w3c.github.io/performance-timeline/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-duration①">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-duration②">4.1. Report long tasks</a> <a href="#ref-for-dom-performanceentry-duration③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype">https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-entrytype①">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-entrytype②">4.1. Report long tasks</a> <a href="#ref-for-dom-performanceentry-entrytype③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-name">https://w3c.github.io/performance-timeline/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-name①">3.2. TaskAttributionTiming interface</a>
@@ -1718,54 +1718,54 @@ showing task type or additional attribution to untrusted cross origin observers.
     <li><a href="#ref-for-dom-performanceentry-name⑧">5. Security &amp; privacy considerations</a> <a href="#ref-for-dom-performanceentry-name⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry">
-   <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" class="dfn-panel" data-for="term-for-dfn-queue-a-performanceentry" id="infopanel-for-term-for-dfn-queue-a-performanceentry" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-queue-a-performanceentry" style="display:none">Info about the 'queue the performanceentry' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-queue-a-performanceentry">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime">https://w3c.github.io/performance-timeline/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-starttime①">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-starttime②">4.1. Report long tasks</a> <a href="#ref-for-dom-performanceentry-starttime③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute">https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">4. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. TaskAttributionTiming interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Default">
-   <a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Default" class="dfn-panel" data-for="term-for-Default" id="infopanel-for-term-for-Default" role="menu">
+   <span id="infopaneltitle-for-term-for-Default" style="display:none">Info about the 'Default' external reference.</span><a href="https://webidl.spec.whatwg.org/#Default">https://webidl.spec.whatwg.org/#Default</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Default">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-Default①">3.2. TaskAttributionTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-Exposed①">3.2. TaskAttributionTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3.1. PerformanceLongTaskTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-idl-object①">3.2. TaskAttributionTiming interface</a>
@@ -1880,108 +1880,108 @@ showing task type or additional attribution to untrusted cross origin observers.
   <div style="counter-reset:issue">
    <div class="issue"> there is some ongoing discussion regarding the scope of which <code class="idl"><a data-link-type="idl" href="https://dom.spec.whatwg.org/#document">Documents</a></code> gain visibility over which long tasks, so this logic could change in the future. <a href="https://github.com/w3c/longtasks/issues/75">[Issue #75]</a> <a class="issue-return" href="#issue-63aa4f38" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="long-task">
-   <b><a href="#long-task">#long-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-long-task" class="dfn-panel" data-for="long-task" id="infopanel-for-long-task" role="dialog">
+   <span id="infopaneltitle-for-long-task" style="display:none">Info about the 'Long task' definition.</span><b><a href="#long-task">#long-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-long-task">2. Terminology</a>
     <li><a href="#ref-for-long-task①">3.3. Pointing to the culprit</a> <a href="#ref-for-long-task②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="culprit-browsing-context-container">
-   <b><a href="#culprit-browsing-context-container">#culprit-browsing-context-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-culprit-browsing-context-container" class="dfn-panel" data-for="culprit-browsing-context-container" id="infopanel-for-culprit-browsing-context-container" role="dialog">
+   <span id="infopaneltitle-for-culprit-browsing-context-container" style="display:none">Info about the 'Culprit browsing context container' definition.</span><b><a href="#culprit-browsing-context-container">#culprit-browsing-context-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-culprit-browsing-context-container">2. Terminology</a>
     <li><a href="#ref-for-culprit-browsing-context-container①">3.2. TaskAttributionTiming interface</a> <a href="#ref-for-culprit-browsing-context-container②">(2)</a> <a href="#ref-for-culprit-browsing-context-container③">(3)</a> <a href="#ref-for-culprit-browsing-context-container④">(4)</a> <a href="#ref-for-culprit-browsing-context-container⑤">(5)</a> <a href="#ref-for-culprit-browsing-context-container⑥">(6)</a> <a href="#ref-for-culprit-browsing-context-container⑦">(7)</a> <a href="#ref-for-culprit-browsing-context-container⑧">(8)</a>
     <li><a href="#ref-for-culprit-browsing-context-container⑨">3.3. Pointing to the culprit</a> <a href="#ref-for-culprit-browsing-context-container①⓪">(2)</a> <a href="#ref-for-culprit-browsing-context-container①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attribution">
-   <b><a href="#attribution">#attribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attribution" class="dfn-panel" data-for="attribution" id="infopanel-for-attribution" role="dialog">
+   <span id="infopaneltitle-for-attribution" style="display:none">Info about the 'Attribution' definition.</span><b><a href="#attribution">#attribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribution">3.3. Pointing to the culprit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performancelongtasktiming">
-   <b><a href="#performancelongtasktiming">#performancelongtasktiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performancelongtasktiming" class="dfn-panel" data-for="performancelongtasktiming" id="infopanel-for-performancelongtasktiming" role="dialog">
+   <span id="infopaneltitle-for-performancelongtasktiming" style="display:none">Info about the 'PerformanceLongTaskTiming' definition.</span><b><a href="#performancelongtasktiming">#performancelongtasktiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performancelongtasktiming">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-performancelongtasktiming①">(2)</a>
     <li><a href="#ref-for-performancelongtasktiming②">3.3. Pointing to the culprit</a> <a href="#ref-for-performancelongtasktiming③">(2)</a>
     <li><a href="#ref-for-performancelongtasktiming④">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unknown">
-   <b><a href="#unknown">#unknown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unknown" class="dfn-panel" data-for="unknown" id="infopanel-for-unknown" role="dialog">
+   <span id="infopaneltitle-for-unknown" style="display:none">Info about the 'unknown' definition.</span><b><a href="#unknown">#unknown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknown">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-unknown①">4.1. Report long tasks</a> <a href="#ref-for-unknown②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="self">
-   <b><a href="#self">#self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-self" class="dfn-panel" data-for="self" id="infopanel-for-self" role="dialog">
+   <span id="infopaneltitle-for-self" style="display:none">Info about the 'self' definition.</span><b><a href="#self">#self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-self①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-origin-ancestor">
-   <b><a href="#same-origin-ancestor">#same-origin-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-origin-ancestor" class="dfn-panel" data-for="same-origin-ancestor" id="infopanel-for-same-origin-ancestor" role="dialog">
+   <span id="infopaneltitle-for-same-origin-ancestor" style="display:none">Info about the 'same-origin-ancestor' definition.</span><b><a href="#same-origin-ancestor">#same-origin-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-ancestor">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-same-origin-ancestor①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-origin-descendant">
-   <b><a href="#same-origin-descendant">#same-origin-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-origin-descendant" class="dfn-panel" data-for="same-origin-descendant" id="infopanel-for-same-origin-descendant" role="dialog">
+   <span id="infopaneltitle-for-same-origin-descendant" style="display:none">Info about the 'same-origin-descendant' definition.</span><b><a href="#same-origin-descendant">#same-origin-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-descendant">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-same-origin-descendant①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-origin">
-   <b><a href="#same-origin">#same-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-origin" class="dfn-panel" data-for="same-origin" id="infopanel-for-same-origin" role="dialog">
+   <span id="infopaneltitle-for-same-origin" style="display:none">Info about the 'same-origin' definition.</span><b><a href="#same-origin">#same-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin③">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-same-origin⑤">4.1. Report long tasks</a> <a href="#ref-for-same-origin⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-ancestor">
-   <b><a href="#cross-origin-ancestor">#cross-origin-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-ancestor" class="dfn-panel" data-for="cross-origin-ancestor" id="infopanel-for-cross-origin-ancestor" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-ancestor" style="display:none">Info about the 'cross-origin-ancestor' definition.</span><b><a href="#cross-origin-ancestor">#cross-origin-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-ancestor">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-cross-origin-ancestor①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-descendant">
-   <b><a href="#cross-origin-descendant">#cross-origin-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-descendant" class="dfn-panel" data-for="cross-origin-descendant" id="infopanel-for-cross-origin-descendant" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-descendant" style="display:none">Info about the 'cross-origin-descendant' definition.</span><b><a href="#cross-origin-descendant">#cross-origin-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-descendant">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-cross-origin-descendant①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-unreachable">
-   <b><a href="#cross-origin-unreachable">#cross-origin-unreachable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-unreachable" class="dfn-panel" data-for="cross-origin-unreachable" id="infopanel-for-cross-origin-unreachable" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-unreachable" style="display:none">Info about the 'cross-origin-unreachable' definition.</span><b><a href="#cross-origin-unreachable">#cross-origin-unreachable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-unreachable">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-cross-origin-unreachable①">4.1. Report long tasks</a> <a href="#ref-for-cross-origin-unreachable②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multiple-contexts">
-   <b><a href="#multiple-contexts">#multiple-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multiple-contexts" class="dfn-panel" data-for="multiple-contexts" id="infopanel-for-multiple-contexts" role="dialog">
+   <span id="infopaneltitle-for-multiple-contexts" style="display:none">Info about the 'multiple-contexts' definition.</span><b><a href="#multiple-contexts">#multiple-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multiple-contexts">3.3. Pointing to the culprit</a>
     <li><a href="#ref-for-multiple-contexts①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-performancelongtasktiming-attribution">
-   <b><a href="#dom-performancelongtasktiming-attribution">#dom-performancelongtasktiming-attribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-performancelongtasktiming-attribution" class="dfn-panel" data-for="dom-performancelongtasktiming-attribution" id="infopanel-for-dom-performancelongtasktiming-attribution" role="dialog">
+   <span id="infopaneltitle-for-dom-performancelongtasktiming-attribution" style="display:none">Info about the 'attribution' definition.</span><b><a href="#dom-performancelongtasktiming-attribution">#dom-performancelongtasktiming-attribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performancelongtasktiming-attribution">3.1. PerformanceLongTaskTiming interface</a>
     <li><a href="#ref-for-dom-performancelongtasktiming-attribution①">3.3. Pointing to the culprit</a> <a href="#ref-for-dom-performancelongtasktiming-attribution②">(2)</a> <a href="#ref-for-dom-performancelongtasktiming-attribution③">(3)</a>
     <li><a href="#ref-for-dom-performancelongtasktiming-attribution④">4.1. Report long tasks</a> <a href="#ref-for-dom-performancelongtasktiming-attribution⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="taskattributiontiming">
-   <b><a href="#taskattributiontiming">#taskattributiontiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-taskattributiontiming" class="dfn-panel" data-for="taskattributiontiming" id="infopanel-for-taskattributiontiming" role="dialog">
+   <span id="infopaneltitle-for-taskattributiontiming" style="display:none">Info about the 'TaskAttributionTiming' definition.</span><b><a href="#taskattributiontiming">#taskattributiontiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-taskattributiontiming">3.1. PerformanceLongTaskTiming interface</a> <a href="#ref-for-taskattributiontiming①">(2)</a>
     <li><a href="#ref-for-taskattributiontiming②">3.2. TaskAttributionTiming interface</a> <a href="#ref-for-taskattributiontiming③">(2)</a>
@@ -1989,95 +1989,151 @@ showing task type or additional attribution to untrusted cross origin observers.
     <li><a href="#ref-for-taskattributiontiming⑤">4.1. Report long tasks</a> <a href="#ref-for-taskattributiontiming⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-taskattributiontiming-containertype">
-   <b><a href="#dom-taskattributiontiming-containertype">#dom-taskattributiontiming-containertype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-taskattributiontiming-containertype" class="dfn-panel" data-for="dom-taskattributiontiming-containertype" id="infopanel-for-dom-taskattributiontiming-containertype" role="dialog">
+   <span id="infopaneltitle-for-dom-taskattributiontiming-containertype" style="display:none">Info about the 'containerType' definition.</span><b><a href="#dom-taskattributiontiming-containertype">#dom-taskattributiontiming-containertype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-taskattributiontiming-containertype">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-taskattributiontiming-containertype①">4.1. Report long tasks</a> <a href="#ref-for-dom-taskattributiontiming-containertype②">(2)</a> <a href="#ref-for-dom-taskattributiontiming-containertype③">(3)</a> <a href="#ref-for-dom-taskattributiontiming-containertype④">(4)</a> <a href="#ref-for-dom-taskattributiontiming-containertype⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-taskattributiontiming-containername">
-   <b><a href="#dom-taskattributiontiming-containername">#dom-taskattributiontiming-containername</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-taskattributiontiming-containername" class="dfn-panel" data-for="dom-taskattributiontiming-containername" id="infopanel-for-dom-taskattributiontiming-containername" role="dialog">
+   <span id="infopaneltitle-for-dom-taskattributiontiming-containername" style="display:none">Info about the 'containerName' definition.</span><b><a href="#dom-taskattributiontiming-containername">#dom-taskattributiontiming-containername</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-taskattributiontiming-containername">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-taskattributiontiming-containername①">4.1. Report long tasks</a> <a href="#ref-for-dom-taskattributiontiming-containername②">(2)</a> <a href="#ref-for-dom-taskattributiontiming-containername③">(3)</a> <a href="#ref-for-dom-taskattributiontiming-containername④">(4)</a> <a href="#ref-for-dom-taskattributiontiming-containername⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-taskattributiontiming-containerid">
-   <b><a href="#dom-taskattributiontiming-containerid">#dom-taskattributiontiming-containerid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-taskattributiontiming-containerid" class="dfn-panel" data-for="dom-taskattributiontiming-containerid" id="infopanel-for-dom-taskattributiontiming-containerid" role="dialog">
+   <span id="infopaneltitle-for-dom-taskattributiontiming-containerid" style="display:none">Info about the 'containerId' definition.</span><b><a href="#dom-taskattributiontiming-containerid">#dom-taskattributiontiming-containerid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-taskattributiontiming-containerid">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-taskattributiontiming-containerid①">4.1. Report long tasks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-taskattributiontiming-containersrc">
-   <b><a href="#dom-taskattributiontiming-containersrc">#dom-taskattributiontiming-containersrc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-taskattributiontiming-containersrc" class="dfn-panel" data-for="dom-taskattributiontiming-containersrc" id="infopanel-for-dom-taskattributiontiming-containersrc" role="dialog">
+   <span id="infopaneltitle-for-dom-taskattributiontiming-containersrc" style="display:none">Info about the 'containerSrc' definition.</span><b><a href="#dom-taskattributiontiming-containersrc">#dom-taskattributiontiming-containersrc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-taskattributiontiming-containersrc">3.2. TaskAttributionTiming interface</a>
     <li><a href="#ref-for-dom-taskattributiontiming-containersrc①">4.1. Report long tasks</a> <a href="#ref-for-dom-taskattributiontiming-containersrc②">(2)</a> <a href="#ref-for-dom-taskattributiontiming-containersrc③">(3)</a> <a href="#ref-for-dom-taskattributiontiming-containersrc④">(4)</a> <a href="#ref-for-dom-taskattributiontiming-containersrc⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minimal-culprit-attribution">
-   <b><a href="#minimal-culprit-attribution">#minimal-culprit-attribution</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minimal-culprit-attribution" class="dfn-panel" data-for="minimal-culprit-attribution" id="infopanel-for-minimal-culprit-attribution" role="dialog">
+   <span id="infopaneltitle-for-minimal-culprit-attribution" style="display:none">Info about the 'minimal culprit attribution' definition.</span><b><a href="#minimal-culprit-attribution">#minimal-culprit-attribution</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minimal-culprit-attribution">4.1. Report long tasks</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/magnetometer/index.html
+++ b/tests/github/w3c/magnetometer/index.html
@@ -1078,199 +1078,199 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#dom-uncalibratedmagnetometerreadingvalues-zbias">dict-member for UncalibratedMagnetometerReadingValues</a><span>, in § 7.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-device-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-coordinate-system" class="dfn-panel" data-for="term-for-device-coordinate-system" id="infopanel-for-term-for-device-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-device-coordinate-system" style="display:none">Info about the 'device coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-coordinate-system">4.1. Reference Frame</a>
     <li><a href="#ref-for-device-coordinate-system①">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-screen-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-screen-coordinate-system" class="dfn-panel" data-for="term-for-screen-coordinate-system" id="infopanel-for-term-for-screen-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-screen-coordinate-system" style="display:none">Info about the 'screen coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screen-coordinate-system">4.1. Reference Frame</a>
     <li><a href="#ref-for-screen-coordinate-system①">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-magnetometer">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-magnetometer">https://w3c.github.io/sensors/#dom-mocksensortype-magnetometer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-magnetometer" class="dfn-panel" data-for="term-for-dom-mocksensortype-magnetometer" id="infopanel-for-term-for-dom-mocksensortype-magnetometer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-magnetometer" style="display:none">Info about the '"magnetometer"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-magnetometer">https://w3c.github.io/sensors/#dom-mocksensortype-magnetometer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-magnetometer">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-uncalibrated-magnetometer">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-uncalibrated-magnetometer">https://w3c.github.io/sensors/#dom-mocksensortype-uncalibrated-magnetometer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-uncalibrated-magnetometer" class="dfn-panel" data-for="term-for-dom-mocksensortype-uncalibrated-magnetometer" id="infopanel-for-term-for-dom-mocksensortype-uncalibrated-magnetometer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-uncalibrated-magnetometer" style="display:none">Info about the '"uncalibrated-magnetometer"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-uncalibrated-magnetometer">https://w3c.github.io/sensors/#dom-mocksensortype-uncalibrated-magnetometer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-uncalibrated-magnetometer">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">4. Model</a> <a href="#ref-for-sensor①">(2)</a>
     <li><a href="#ref-for-sensor②">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-sensor③">5.2. The UncalibratedMagnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">5.1. The Magnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keystroke-monitoring">
-   <a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keystroke-monitoring" class="dfn-panel" data-for="term-for-keystroke-monitoring" id="infopanel-for-term-for-keystroke-monitoring" role="menu">
+   <span id="infopaneltitle-for-term-for-keystroke-monitoring" style="display:none">Info about the 'keystroke monitoring' external reference.</span><a href="https://w3c.github.io/sensors/#keystroke-monitoring">https://w3c.github.io/sensors/#keystroke-monitoring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keystroke-monitoring">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">4. Model</a> <a href="#ref-for-latest-reading①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">4. Model</a>
     <li><a href="#ref-for-local-coordinate-system①">4.1. Reference Frame</a>
     <li><a href="#ref-for-local-coordinate-system②">6.1. Construct a magnetometer object</a> <a href="#ref-for-local-coordinate-system③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
-   <a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mitigation-strategies" class="dfn-panel" data-for="term-for-mitigation-strategies" id="infopanel-for-term-for-mitigation-strategies" role="menu">
+   <span id="infopaneltitle-for-term-for-mitigation-strategies" style="display:none">Info about the 'mitigation strategies' external reference.</span><a href="https://w3c.github.io/sensors/#mitigation-strategies">https://w3c.github.io/sensors/#mitigation-strategies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mitigation-strategies">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">7.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-reading-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">7.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-permission-names">
-   <a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-permission-names" class="dfn-panel" data-for="term-for-sensor-permission-names" id="infopanel-for-term-for-sensor-permission-names" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-permission-names" style="display:none">Info about the 'sensor permission name' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-permission-names">https://w3c.github.io/sensors/#sensor-permission-names</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-reading">
-   <a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-reading" class="dfn-panel" data-for="term-for-sensor-reading" id="infopanel-for-term-for-sensor-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-reading" style="display:none">Info about the 'sensor readings' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-reading">https://w3c.github.io/sensors/#sensor-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-reading">4.1. Reference Frame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">4. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-sensor-options">
-   <a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-sensor-options" class="dfn-panel" data-for="term-for-supported-sensor-options" id="infopanel-for-term-for-supported-sensor-options" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-sensor-options" style="display:none">Info about the 'supported sensor options' external reference.</span><a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-sensor-options">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-supported-sensor-options①">5.2. The UncalibratedMagnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">4. Model</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">4. Model</a> <a href="#ref-for-map-getting-the-keys①">(2)</a> <a href="#ref-for-map-getting-the-keys②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4. Model</a> <a href="#ref-for-map-getting-the-values①">(2)</a> <a href="#ref-for-map-getting-the-values②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-orientation">
-   <a href="https://w3c.github.io/motion-sensors/#absolute-orientation">https://w3c.github.io/motion-sensors/#absolute-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-orientation" class="dfn-panel" data-for="term-for-absolute-orientation" id="infopanel-for-term-for-absolute-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-orientation" style="display:none">Info about the 'absolute orientation sensor' external reference.</span><a href="https://w3c.github.io/motion-sensors/#absolute-orientation">https://w3c.github.io/motion-sensors/#absolute-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation">9. Use Cases and Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-Exposed①">5.2. The UncalibratedMagnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-SecureContext①">5.2. The UncalibratedMagnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5.1. The Magnetometer Interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
     <li><a href="#ref-for-idl-double③">5.2. The UncalibratedMagnetometer Interface</a> <a href="#ref-for-idl-double④">(2)</a> <a href="#ref-for-idl-double⑤">(3)</a> <a href="#ref-for-idl-double⑥">(4)</a> <a href="#ref-for-idl-double⑦">(5)</a> <a href="#ref-for-idl-double⑧">(6)</a>
     <li><a href="#ref-for-idl-double⑨">7.1. Mock Sensor Type</a> <a href="#ref-for-idl-double①⓪">(2)</a> <a href="#ref-for-idl-double①①">(3)</a> <a href="#ref-for-idl-double①②">(4)</a> <a href="#ref-for-idl-double①③">(5)</a> <a href="#ref-for-idl-double①④">(6)</a> <a href="#ref-for-idl-double①⑤">(7)</a> <a href="#ref-for-idl-double①⑥">(8)</a> <a href="#ref-for-idl-double①⑦">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">6.1. Construct a magnetometer object</a> <a href="#ref-for-dfn-identifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface" class="dfn-panel" data-for="term-for-dfn-interface" id="infopanel-for-term-for-dfn-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface" style="display:none">Info about the 'interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface">6.1. Construct a magnetometer object</a> <a href="#ref-for-dfn-interface①">(2)</a> <a href="#ref-for-dfn-interface②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1. Construct a magnetometer object</a>
    </ul>
@@ -1400,8 +1400,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="magnetic-field">
-   <b><a href="#magnetic-field">#magnetic-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetic-field" class="dfn-panel" data-for="magnetic-field" id="infopanel-for-magnetic-field" role="dialog">
+   <span id="infopaneltitle-for-magnetic-field" style="display:none">Info about the 'magnetic field' definition.</span><b><a href="#magnetic-field">#magnetic-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-field">1. Introduction</a> <a href="#ref-for-magnetic-field①">(2)</a> <a href="#ref-for-magnetic-field②">(3)</a> <a href="#ref-for-magnetic-field③">(4)</a> <a href="#ref-for-magnetic-field④">(5)</a> <a href="#ref-for-magnetic-field⑤">(6)</a> <a href="#ref-for-magnetic-field⑥">(7)</a>
     <li><a href="#ref-for-magnetic-field⑦">4. Model</a> <a href="#ref-for-magnetic-field⑧">(2)</a>
@@ -1412,8 +1412,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-magnetic-field①③">8. Limitations of Magnetometer Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hard-iron-distortion">
-   <b><a href="#hard-iron-distortion">#hard-iron-distortion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hard-iron-distortion" class="dfn-panel" data-for="hard-iron-distortion" id="infopanel-for-hard-iron-distortion" role="dialog">
+   <span id="infopaneltitle-for-hard-iron-distortion" style="display:none">Info about the 'Hard iron distortion' definition.</span><b><a href="#hard-iron-distortion">#hard-iron-distortion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hard-iron-distortion">1. Introduction</a> <a href="#ref-for-hard-iron-distortion①">(2)</a>
     <li><a href="#ref-for-hard-iron-distortion②">4. Model</a> <a href="#ref-for-hard-iron-distortion③">(2)</a>
@@ -1422,20 +1422,20 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-hard-iron-distortion⑥">5.2.6. UncalibratedMagnetometer.zBias</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="soft-iron-distortion">
-   <b><a href="#soft-iron-distortion">#soft-iron-distortion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-soft-iron-distortion" class="dfn-panel" data-for="soft-iron-distortion" id="infopanel-for-soft-iron-distortion" role="dialog">
+   <span id="infopaneltitle-for-soft-iron-distortion" style="display:none">Info about the 'Soft iron distortion' definition.</span><b><a href="#soft-iron-distortion">#soft-iron-distortion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-iron-distortion">1. Introduction</a> <a href="#ref-for-soft-iron-distortion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calibrated-magnetic-field">
-   <b><a href="#calibrated-magnetic-field">#calibrated-magnetic-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calibrated-magnetic-field" class="dfn-panel" data-for="calibrated-magnetic-field" id="infopanel-for-calibrated-magnetic-field" role="dialog">
+   <span id="infopaneltitle-for-calibrated-magnetic-field" style="display:none">Info about the 'calibrated magnetic field' definition.</span><b><a href="#calibrated-magnetic-field">#calibrated-magnetic-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibrated-magnetic-field">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uncalibrated-magnetic-field">
-   <b><a href="#uncalibrated-magnetic-field">#uncalibrated-magnetic-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uncalibrated-magnetic-field" class="dfn-panel" data-for="uncalibrated-magnetic-field" id="infopanel-for-uncalibrated-magnetic-field" role="dialog">
+   <span id="infopaneltitle-for-uncalibrated-magnetic-field" style="display:none">Info about the 'uncalibrated magnetic field' definition.</span><b><a href="#uncalibrated-magnetic-field">#uncalibrated-magnetic-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uncalibrated-magnetic-field">1. Introduction</a>
     <li><a href="#ref-for-uncalibrated-magnetic-field①">4. Model</a> <a href="#ref-for-uncalibrated-magnetic-field②">(2)</a>
@@ -1444,14 +1444,14 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-uncalibrated-magnetic-field⑤">5.2.3. UncalibratedMagnetometer.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetometer-sensor-type">
-   <b><a href="#magnetometer-sensor-type">#magnetometer-sensor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetometer-sensor-type" class="dfn-panel" data-for="magnetometer-sensor-type" id="infopanel-for-magnetometer-sensor-type" role="dialog">
+   <span id="infopaneltitle-for-magnetometer-sensor-type" style="display:none">Info about the 'Magnetometer' definition.</span><b><a href="#magnetometer-sensor-type">#magnetometer-sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-sensor-type">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetometer">
-   <b><a href="#magnetometer">#magnetometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetometer" class="dfn-panel" data-for="magnetometer" id="infopanel-for-magnetometer" role="dialog">
+   <span id="infopaneltitle-for-magnetometer" style="display:none">Info about the 'Magnetometer' definition.</span><b><a href="#magnetometer">#magnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer">1. Introduction</a>
     <li><a href="#ref-for-magnetometer①">4. Model</a> <a href="#ref-for-magnetometer②">(2)</a>
@@ -1465,48 +1465,48 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-magnetometer①④">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-magnetometer-x">
-   <b><a href="#dom-magnetometer-x">#dom-magnetometer-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-magnetometer-x" class="dfn-panel" data-for="dom-magnetometer-x" id="infopanel-for-dom-magnetometer-x" role="dialog">
+   <span id="infopaneltitle-for-dom-magnetometer-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-magnetometer-x">#dom-magnetometer-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-magnetometer-x">5.1.1. Magnetometer.x</a>
     <li><a href="#ref-for-dom-magnetometer-x①">10. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-magnetometer-y">
-   <b><a href="#dom-magnetometer-y">#dom-magnetometer-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-magnetometer-y" class="dfn-panel" data-for="dom-magnetometer-y" id="infopanel-for-dom-magnetometer-y" role="dialog">
+   <span id="infopaneltitle-for-dom-magnetometer-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-magnetometer-y">#dom-magnetometer-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-magnetometer-y">5.1.2. Magnetometer.y</a>
     <li><a href="#ref-for-dom-magnetometer-y①">10. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-magnetometer-z">
-   <b><a href="#dom-magnetometer-z">#dom-magnetometer-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-magnetometer-z" class="dfn-panel" data-for="dom-magnetometer-z" id="infopanel-for-dom-magnetometer-z" role="dialog">
+   <span id="infopaneltitle-for-dom-magnetometer-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-magnetometer-z">#dom-magnetometer-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-magnetometer-z">5.1.3. Magnetometer.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-magnetometerlocalcoordinatesystem">
-   <b><a href="#enumdef-magnetometerlocalcoordinatesystem">#enumdef-magnetometerlocalcoordinatesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-magnetometerlocalcoordinatesystem" class="dfn-panel" data-for="enumdef-magnetometerlocalcoordinatesystem" id="infopanel-for-enumdef-magnetometerlocalcoordinatesystem" role="dialog">
+   <span id="infopaneltitle-for-enumdef-magnetometerlocalcoordinatesystem" style="display:none">Info about the 'MagnetometerLocalCoordinateSystem' definition.</span><b><a href="#enumdef-magnetometerlocalcoordinatesystem">#enumdef-magnetometerlocalcoordinatesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-magnetometerlocalcoordinatesystem">5.1. The Magnetometer Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-magnetometersensoroptions">
-   <b><a href="#dictdef-magnetometersensoroptions">#dictdef-magnetometersensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-magnetometersensoroptions" class="dfn-panel" data-for="dictdef-magnetometersensoroptions" id="infopanel-for-dictdef-magnetometersensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-magnetometersensoroptions" style="display:none">Info about the 'MagnetometerSensorOptions' definition.</span><b><a href="#dictdef-magnetometersensoroptions">#dictdef-magnetometersensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-magnetometersensoroptions">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-dictdef-magnetometersensoroptions①">5.2. The UncalibratedMagnetometer Interface</a>
     <li><a href="#ref-for-dictdef-magnetometersensoroptions②">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-magnetometersensoroptions-referenceframe">
-   <b><a href="#dom-magnetometersensoroptions-referenceframe">#dom-magnetometersensoroptions-referenceframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-magnetometersensoroptions-referenceframe" class="dfn-panel" data-for="dom-magnetometersensoroptions-referenceframe" id="infopanel-for-dom-magnetometersensoroptions-referenceframe" role="dialog">
+   <span id="infopaneltitle-for-dom-magnetometersensoroptions-referenceframe" style="display:none">Info about the 'referenceFrame' definition.</span><b><a href="#dom-magnetometersensoroptions-referenceframe">#dom-magnetometersensoroptions-referenceframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-magnetometersensoroptions-referenceframe">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uncalibratedmagnetometer">
-   <b><a href="#uncalibratedmagnetometer">#uncalibratedmagnetometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uncalibratedmagnetometer" class="dfn-panel" data-for="uncalibratedmagnetometer" id="infopanel-for-uncalibratedmagnetometer" role="dialog">
+   <span id="infopaneltitle-for-uncalibratedmagnetometer" style="display:none">Info about the 'UncalibratedMagnetometer' definition.</span><b><a href="#uncalibratedmagnetometer">#uncalibratedmagnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uncalibratedmagnetometer">1. Introduction</a>
     <li><a href="#ref-for-uncalibratedmagnetometer①">4. Model</a> <a href="#ref-for-uncalibratedmagnetometer②">(2)</a>
@@ -1523,117 +1523,173 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-uncalibratedmagnetometer①⑥">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-x">
-   <b><a href="#dom-uncalibratedmagnetometer-x">#dom-uncalibratedmagnetometer-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-x" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-x" id="infopanel-for-dom-uncalibratedmagnetometer-x" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-uncalibratedmagnetometer-x">#dom-uncalibratedmagnetometer-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-x">5.2.1. UncalibratedMagnetometer.x</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-y">
-   <b><a href="#dom-uncalibratedmagnetometer-y">#dom-uncalibratedmagnetometer-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-y" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-y" id="infopanel-for-dom-uncalibratedmagnetometer-y" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-uncalibratedmagnetometer-y">#dom-uncalibratedmagnetometer-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-y">5.2.2. UncalibratedMagnetometer.y</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-z">
-   <b><a href="#dom-uncalibratedmagnetometer-z">#dom-uncalibratedmagnetometer-z</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-z" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-z" id="infopanel-for-dom-uncalibratedmagnetometer-z" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-z" style="display:none">Info about the 'z' definition.</span><b><a href="#dom-uncalibratedmagnetometer-z">#dom-uncalibratedmagnetometer-z</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-z">5.2.3. UncalibratedMagnetometer.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-xbias">
-   <b><a href="#dom-uncalibratedmagnetometer-xbias">#dom-uncalibratedmagnetometer-xbias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-xbias" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-xbias" id="infopanel-for-dom-uncalibratedmagnetometer-xbias" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-xbias" style="display:none">Info about the 'xBias' definition.</span><b><a href="#dom-uncalibratedmagnetometer-xbias">#dom-uncalibratedmagnetometer-xbias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-xbias">5.2.4. UncalibratedMagnetometer.xBias</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-ybias">
-   <b><a href="#dom-uncalibratedmagnetometer-ybias">#dom-uncalibratedmagnetometer-ybias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-ybias" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-ybias" id="infopanel-for-dom-uncalibratedmagnetometer-ybias" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-ybias" style="display:none">Info about the 'yBias' definition.</span><b><a href="#dom-uncalibratedmagnetometer-ybias">#dom-uncalibratedmagnetometer-ybias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-ybias">5.2.5. UncalibratedMagnetometer.yBias</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-uncalibratedmagnetometer-zbias">
-   <b><a href="#dom-uncalibratedmagnetometer-zbias">#dom-uncalibratedmagnetometer-zbias</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-uncalibratedmagnetometer-zbias" class="dfn-panel" data-for="dom-uncalibratedmagnetometer-zbias" id="infopanel-for-dom-uncalibratedmagnetometer-zbias" role="dialog">
+   <span id="infopaneltitle-for-dom-uncalibratedmagnetometer-zbias" style="display:none">Info about the 'zBias' definition.</span><b><a href="#dom-uncalibratedmagnetometer-zbias">#dom-uncalibratedmagnetometer-zbias</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uncalibratedmagnetometer-zbias">5.2.6. UncalibratedMagnetometer.zBias</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-magnetometer-object">
-   <b><a href="#construct-a-magnetometer-object">#construct-a-magnetometer-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-magnetometer-object" class="dfn-panel" data-for="construct-a-magnetometer-object" id="infopanel-for-construct-a-magnetometer-object" role="dialog">
+   <span id="infopaneltitle-for-construct-a-magnetometer-object" style="display:none">Info about the '6.1. Construct a magnetometer object' definition.</span><b><a href="#construct-a-magnetometer-object">#construct-a-magnetometer-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-magnetometer-object">5.1. The Magnetometer Interface</a>
     <li><a href="#ref-for-construct-a-magnetometer-object①">5.2. The UncalibratedMagnetometer Interface</a>
     <li><a href="#ref-for-construct-a-magnetometer-object">6.1. Construct a magnetometer object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetic-declination">
-   <b><a href="#magnetic-declination">#magnetic-declination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetic-declination" class="dfn-panel" data-for="magnetic-declination" id="infopanel-for-magnetic-declination" role="dialog">
+   <span id="infopaneltitle-for-magnetic-declination" style="display:none">Info about the 'Magnetic declination' definition.</span><b><a href="#magnetic-declination">#magnetic-declination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-declination">10. Compass Heading Using Magnetometers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declination-angle">
-   <b><a href="#declination-angle">#declination-angle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declination-angle" class="dfn-panel" data-for="declination-angle" id="infopanel-for-declination-angle" role="dialog">
+   <span id="infopaneltitle-for-declination-angle" style="display:none">Info about the 'declination angle' definition.</span><b><a href="#declination-angle">#declination-angle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declination-angle">10. Compass Heading Using Magnetometers</a> <a href="#ref-for-declination-angle①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/media-capabilities/index.html
+++ b/tests/github/w3c/media-capabilities/index.html
@@ -1564,64 +1564,64 @@ based on the device’s display.</p>
     </ul>
    <li><a href="#dom-videoconfiguration-width">width</a><span>, in § 2.1.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">2.5. Media Capabilities Interface</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediakeysystemaccess-interface">
-   <a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemaccess-interface">https://www.w3.org/TR/encrypted-media/#mediakeysystemaccess-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediakeysystemaccess-interface" class="dfn-panel" data-for="term-for-mediakeysystemaccess-interface" id="infopanel-for-term-for-mediakeysystemaccess-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-mediakeysystemaccess-interface" style="display:none">Info about the 'MediaKeySystemAccess' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemaccess-interface">https://www.w3.org/TR/encrypted-media/#mediakeysystemaccess-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediakeysystemaccess-interface">2.2. Media Capabilities Information</a> <a href="#ref-for-mediakeysystemaccess-interface①">(2)</a>
     <li><a href="#ref-for-mediakeysystemaccess-interface②">2.3.3. 
           Check Encrypted Decoding Support </a> <a href="#ref-for-mediakeysystemaccess-interface③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediakeysystemconfiguration-dictionary">
-   <a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary">https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediakeysystemconfiguration-dictionary" class="dfn-panel" data-for="term-for-mediakeysystemconfiguration-dictionary" id="infopanel-for-term-for-mediakeysystemconfiguration-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-mediakeysystemconfiguration-dictionary" style="display:none">Info about the 'MediaKeySystemConfiguration' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary">https://www.w3.org/TR/encrypted-media/#mediakeysystemconfiguration-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediakeysystemconfiguration-dictionary">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediakeysystemmediacapability-dictionary">
-   <a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemmediacapability-dictionary">https://www.w3.org/TR/encrypted-media/#mediakeysystemmediacapability-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediakeysystemmediacapability-dictionary" class="dfn-panel" data-for="term-for-mediakeysystemmediacapability-dictionary" id="infopanel-for-term-for-mediakeysystemmediacapability-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-mediakeysystemmediacapability-dictionary" style="display:none">Info about the 'MediaKeySystemMediaCapability' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#mediakeysystemmediacapability-dictionary">https://www.w3.org/TR/encrypted-media/#mediakeysystemmediacapability-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediakeysystemmediacapability-dictionary">2.3.3. 
           Check Encrypted Decoding Support </a> <a href="#ref-for-mediakeysystemmediacapability-dictionary①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediakeys-interface">
-   <a href="https://www.w3.org/TR/encrypted-media/#mediakeys-interface">https://www.w3.org/TR/encrypted-media/#mediakeys-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediakeys-interface" class="dfn-panel" data-for="term-for-mediakeys-interface" id="infopanel-for-term-for-mediakeys-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-mediakeys-interface" style="display:none">Info about the 'MediaKeys' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#mediakeys-interface">https://www.w3.org/TR/encrypted-media/#mediakeys-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediakeys-interface">2.2. Media Capabilities Information</a>
     <li><a href="#ref-for-mediakeys-interface①">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-audiocapabilities">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-audiocapabilities">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-audiocapabilities</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-audiocapabilities" class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-audiocapabilities" id="infopanel-for-term-for-dom-mediakeysystemconfiguration-audiocapabilities" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-audiocapabilities" style="display:none">Info about the 'audioCapabilities' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-audiocapabilities">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-audiocapabilities</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemconfiguration-audiocapabilities">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-contenttype">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-contenttype">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-contenttype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-contenttype" class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-contenttype" id="infopanel-for-term-for-dom-mediakeysystemmediacapability-contenttype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-contenttype" style="display:none">Info about the 'contentType' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-contenttype">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-contenttype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemmediacapability-contenttype">2.3.3. 
           Check Encrypted Decoding Support </a> <a href="#ref-for-dom-mediakeysystemmediacapability-contenttype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-distinctiveidentifier">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-distinctiveidentifier">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-distinctiveidentifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-distinctiveidentifier" class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-distinctiveidentifier" id="infopanel-for-term-for-dom-mediakeysystemconfiguration-distinctiveidentifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-distinctiveidentifier" style="display:none">Info about the 'distinctiveIdentifier' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-distinctiveidentifier">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-distinctiveidentifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemconfiguration-distinctiveidentifier">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -1629,15 +1629,15 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-supported-configuration">
-   <a href="https://www.w3.org/TR/encrypted-media/#get-supported-configuration">https://www.w3.org/TR/encrypted-media/#get-supported-configuration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-supported-configuration" class="dfn-panel" data-for="term-for-get-supported-configuration" id="infopanel-for-term-for-get-supported-configuration" role="menu">
+   <span id="infopaneltitle-for-term-for-get-supported-configuration" style="display:none">Info about the 'get supported configuration' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#get-supported-configuration">https://www.w3.org/TR/encrypted-media/#get-supported-configuration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-supported-configuration">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-initdatatypes">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-initdatatypes">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-initdatatypes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-initdatatypes" class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-initdatatypes" id="infopanel-for-term-for-dom-mediakeysystemconfiguration-initdatatypes" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-initdatatypes" style="display:none">Info about the 'initDataTypes' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-initdatatypes">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-initdatatypes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemconfiguration-initdatatypes">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -1645,15 +1645,15 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-key-system">
-   <a href="https://www.w3.org/TR/encrypted-media/#key-system">https://www.w3.org/TR/encrypted-media/#key-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-key-system" class="dfn-panel" data-for="term-for-key-system" id="infopanel-for-term-for-key-system" role="menu">
+   <span id="infopaneltitle-for-term-for-key-system" style="display:none">Info about the 'key system' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#key-system">https://www.w3.org/TR/encrypted-media/#key-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-system">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess-keysystem">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-keysystem">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-keysystem</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemaccess-keysystem" class="dfn-panel" data-for="term-for-dom-mediakeysystemaccess-keysystem" id="infopanel-for-term-for-dom-mediakeysystemaccess-keysystem" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemaccess-keysystem" style="display:none">Info about the 'keySystem' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-keysystem">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemaccess-keysystem</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemaccess-keysystem">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -1661,8 +1661,8 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-persistentstate">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-persistentstate">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-persistentstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-persistentstate" class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-persistentstate" id="infopanel-for-term-for-dom-mediakeysystemconfiguration-persistentstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-persistentstate" style="display:none">Info about the 'persistentState' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-persistentstate">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-persistentstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemconfiguration-persistentstate">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -1670,15 +1670,15 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()">
-   <a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" class="dfn-panel" data-for="term-for-navigator-extension:-requestmediakeysystemaccess()" id="infopanel-for-term-for-navigator-extension:-requestmediakeysystemaccess()" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator-extension:-requestmediakeysystemaccess()" style="display:none">Info about the 'requestMediaKeySystemAccess()' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()">https://www.w3.org/TR/encrypted-media/#navigator-extension:-requestmediakeysystemaccess()</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator-extension:-requestmediakeysystemaccess()">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-robustness">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-robustness">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-robustness</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-robustness" class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-robustness" id="infopanel-for-term-for-dom-mediakeysystemmediacapability-robustness" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-robustness" style="display:none">Info about the 'robustness' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-robustness">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemmediacapability-robustness</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemmediacapability-robustness">2.1.11. 
       KeySystemTrackConfiguration </a>
@@ -1686,8 +1686,8 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a> <a href="#ref-for-dom-mediakeysystemmediacapability-robustness②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-sessiontypes">
-   <a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-sessiontypes">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-sessiontypes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-sessiontypes" class="dfn-panel" data-for="term-for-dom-mediakeysystemconfiguration-sessiontypes" id="infopanel-for-term-for-dom-mediakeysystemconfiguration-sessiontypes" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemconfiguration-sessiontypes" style="display:none">Info about the 'sessionTypes' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-sessiontypes">https://www.w3.org/TR/encrypted-media/#dom-mediakeysystemconfiguration-sessiontypes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemconfiguration-sessiontypes">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -1695,8 +1695,8 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-encryptionscheme">
-   <a href="https://w3c.github.io/encrypted-media/#dom-mediakeysystemmediacapability-encryptionscheme">https://w3c.github.io/encrypted-media/#dom-mediakeysystemmediacapability-encryptionscheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-encryptionscheme" class="dfn-panel" data-for="term-for-dom-mediakeysystemmediacapability-encryptionscheme" id="infopanel-for-term-for-dom-mediakeysystemmediacapability-encryptionscheme" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediakeysystemmediacapability-encryptionscheme" style="display:none">Info about the 'encryptionScheme' external reference.</span><a href="https://w3c.github.io/encrypted-media/#dom-mediakeysystemmediacapability-encryptionscheme">https://w3c.github.io/encrypted-media/#dom-mediakeysystemmediacapability-encryptionscheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme">2.1.11. 
       KeySystemTrackConfiguration </a>
@@ -1704,57 +1704,57 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a> <a href="#ref-for-dom-mediakeysystemmediacapability-encryptionscheme②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2.4. Navigator and WorkerNavigator extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">2.4. Navigator and WorkerNavigator extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-canplaytype">
-   <a href="https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype">https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-canplaytype" class="dfn-panel" data-for="term-for-dom-navigator-canplaytype" id="infopanel-for-term-for-dom-navigator-canplaytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-canplaytype" style="display:none">Info about the 'canPlayType()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype">https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-canplaytype">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/#global-object">https://html.spec.whatwg.org/multipage/#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#global-object">https://html.spec.whatwg.org/multipage/#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">2.5. Media Capabilities Interface</a> <a href="#ref-for-global-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.5. Media Capabilities Interface</a> <a href="#ref-for-in-parallel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/#concept-origin">https://html.spec.whatwg.org/multipage/#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#concept-origin">https://html.spec.whatwg.org/multipage/#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/#relevant-settings-object">https://html.spec.whatwg.org/multipage/#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#relevant-settings-object">https://html.spec.whatwg.org/multipage/#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">2.1.1. MediaConfiguration</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a> <a href="#ref-for-map-exists④">(5)</a> <a href="#ref-for-map-exists⑤">(6)</a> <a href="#ref-for-map-exists⑥">(7)</a> <a href="#ref-for-map-exists⑦">(8)</a> <a href="#ref-for-map-exists⑧">(9)</a>
     <li><a href="#ref-for-map-exists⑨">2.1.9. AudioConfiguration</a>
@@ -1765,44 +1765,44 @@ based on the device’s display.</p>
     <li><a href="#ref-for-map-exists①⑥">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediasource">
-   <a href="https://www.w3.org/TR/media-source/#mediasource">https://www.w3.org/TR/media-source/#mediasource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediasource" class="dfn-panel" data-for="term-for-mediasource" id="infopanel-for-term-for-mediasource" role="menu">
+   <span id="infopaneltitle-for-term-for-mediasource" style="display:none">Info about the 'MediaSource' external reference.</span><a href="https://www.w3.org/TR/media-source/#mediasource">https://www.w3.org/TR/media-source/#mediasource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediasource">2.1.2. MediaDecodingType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediasource-istypesupported">
-   <a href="https://www.w3.org/TR/media-source/#dom-mediasource-istypesupported">https://www.w3.org/TR/media-source/#dom-mediasource-istypesupported</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediasource-istypesupported" class="dfn-panel" data-for="term-for-dom-mediasource-istypesupported" id="infopanel-for-term-for-dom-mediasource-istypesupported" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediasource-istypesupported" style="display:none">Info about the 'isTypeSupported()' external reference.</span><a href="https://www.w3.org/TR/media-source/#dom-mediasource-istypesupported">https://www.w3.org/TR/media-source/#dom-mediasource-istypesupported</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasource-istypesupported">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediarecorder">
-   <a href="https://www.w3.org/TR/mediastream-recording/#mediarecorder">https://www.w3.org/TR/mediastream-recording/#mediarecorder</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediarecorder" class="dfn-panel" data-for="term-for-mediarecorder" id="infopanel-for-term-for-mediarecorder" role="menu">
+   <span id="infopaneltitle-for-term-for-mediarecorder" style="display:none">Info about the 'MediaRecorder' external reference.</span><a href="https://www.w3.org/TR/mediastream-recording/#mediarecorder">https://www.w3.org/TR/mediastream-recording/#mediarecorder</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediarecorder">2.1.3. MediaEncodingType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">https://mimesniff.spec.whatwg.org/#valid-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-mime-type" class="dfn-panel" data-for="term-for-valid-mime-type" id="infopanel-for-term-for-valid-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-mime-type" style="display:none">Info about the 'valid mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#valid-mime-type">https://mimesniff.spec.whatwg.org/#valid-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-mime-type">2.1.4. MIME types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="https://www.w3.org/TR/secure-contexts/#settings-object">https://www.w3.org/TR/secure-contexts/#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'is the environment settings object settings a secure context?' external reference.</span><a href="https://www.w3.org/TR/secure-contexts/#settings-object">https://www.w3.org/TR/secure-contexts/#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://heycam.github.io/webidl/#idl-DOMException">https://heycam.github.io/webidl/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMException">https://heycam.github.io/webidl/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.5. Media Capabilities Interface</a> <a href="#ref-for-idl-DOMException①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1.5. VideoConfiguration</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">2.1.9. AudioConfiguration</a> <a href="#ref-for-idl-DOMString③">(2)</a>
@@ -1812,80 +1812,80 @@ based on the device’s display.</p>
       KeySystemTrackConfiguration </a> <a href="#ref-for-idl-DOMString⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.4. Navigator and WorkerNavigator extension</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">2.5. Media Capabilities Interface</a> <a href="#ref-for-NewObject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.5. Media Capabilities Interface</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.4. Navigator and WorkerNavigator extension</a> <a href="#ref-for-SameObject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.1.5. VideoConfiguration</a>
     <li><a href="#ref-for-idl-boolean①">2.1.9. AudioConfiguration</a>
     <li><a href="#ref-for-idl-boolean②">2.2. Media Capabilities Information</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'invalidstateerror' external reference.</span><a href="https://heycam.github.io/webidl/#invalidstateerror">https://heycam.github.io/webidl/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'securityerror' external reference.</span><a href="https://heycam.github.io/webidl/#securityerror">https://heycam.github.io/webidl/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2.1.5. VideoConfiguration</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">2.1.9. AudioConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">2.1.5. VideoConfiguration</a>
     <li><a href="#ref-for-idl-unsigned-long-long①">2.1.9. AudioConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-definition">
-   <a href="https://www.w3.org/TR/webrtc/#interface-definition">https://www.w3.org/TR/webrtc/#interface-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-definition" class="dfn-panel" data-for="term-for-interface-definition" id="infopanel-for-term-for-interface-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-definition" style="display:none">Info about the 'RTCPeerConnection' external reference.</span><a href="https://www.w3.org/TR/webrtc/#interface-definition">https://www.w3.org/TR/webrtc/#interface-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-definition">2.1.2. MediaDecodingType</a>
     <li><a href="#ref-for-interface-definition①">2.1.3. MediaEncodingType</a>
@@ -2156,28 +2156,28 @@ based on the device’s display.</p>
    <div class="issue"> The <code class="idl"><a data-link-type="idl" href="#dom-audioconfiguration-channels">channels</a></code> needs to be defined as a <code>double</code> (2.1, 4.1, 5.1, ...), an <code>unsigned short</code> (number of channels) or as an <code>enum</code> value. The current
         definition is a placeholder. <a class="issue-return" href="#issue-a7738173" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dictdef-mediaconfiguration">
-   <b><a href="#dictdef-mediaconfiguration">#dictdef-mediaconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediaconfiguration" class="dfn-panel" data-for="dictdef-mediaconfiguration" id="infopanel-for-dictdef-mediaconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediaconfiguration" style="display:none">Info about the 'MediaConfiguration' definition.</span><b><a href="#dictdef-mediaconfiguration">#dictdef-mediaconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediaconfiguration">2.1.1. MediaConfiguration</a> <a href="#ref-for-dictdef-mediaconfiguration①">(2)</a> <a href="#ref-for-dictdef-mediaconfiguration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaconfiguration-video">
-   <b><a href="#dom-mediaconfiguration-video">#dom-mediaconfiguration-video</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaconfiguration-video" class="dfn-panel" data-for="dom-mediaconfiguration-video" id="infopanel-for-dom-mediaconfiguration-video" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaconfiguration-video" style="display:none">Info about the 'video' definition.</span><b><a href="#dom-mediaconfiguration-video">#dom-mediaconfiguration-video</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaconfiguration-video">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaconfiguration-audio">
-   <b><a href="#dom-mediaconfiguration-audio">#dom-mediaconfiguration-audio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaconfiguration-audio" class="dfn-panel" data-for="dom-mediaconfiguration-audio" id="infopanel-for-dom-mediaconfiguration-audio" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaconfiguration-audio" style="display:none">Info about the 'audio' definition.</span><b><a href="#dom-mediaconfiguration-audio">#dom-mediaconfiguration-audio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaconfiguration-audio">2.3.3. 
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediadecodingconfiguration">
-   <b><a href="#dictdef-mediadecodingconfiguration">#dictdef-mediadecodingconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediadecodingconfiguration" class="dfn-panel" data-for="dictdef-mediadecodingconfiguration" id="infopanel-for-dictdef-mediadecodingconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediadecodingconfiguration" style="display:none">Info about the 'MediaDecodingConfiguration' definition.</span><b><a href="#dictdef-mediadecodingconfiguration">#dictdef-mediadecodingconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediadecodingconfiguration">2.1.1. MediaConfiguration</a> <a href="#ref-for-dictdef-mediadecodingconfiguration①">(2)</a> <a href="#ref-for-dictdef-mediadecodingconfiguration②">(3)</a>
     <li><a href="#ref-for-dictdef-mediadecodingconfiguration③">2.1.2. MediaDecodingType</a>
@@ -2189,8 +2189,8 @@ based on the device’s display.</p>
     <li><a href="#ref-for-dictdef-mediadecodingconfiguration⑧">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediadecodingconfiguration-keysystemconfiguration">
-   <b><a href="#dom-mediadecodingconfiguration-keysystemconfiguration">#dom-mediadecodingconfiguration-keysystemconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediadecodingconfiguration-keysystemconfiguration" class="dfn-panel" data-for="dom-mediadecodingconfiguration-keysystemconfiguration" id="infopanel-for-dom-mediadecodingconfiguration-keysystemconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dom-mediadecodingconfiguration-keysystemconfiguration" style="display:none">Info about the 'keySystemConfiguration' definition.</span><b><a href="#dom-mediadecodingconfiguration-keysystemconfiguration">#dom-mediadecodingconfiguration-keysystemconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadecodingconfiguration-keysystemconfiguration">2.1.1. MediaConfiguration</a>
     <li><a href="#ref-for-dom-mediadecodingconfiguration-keysystemconfiguration①">2.3.3. 
@@ -2198,8 +2198,8 @@ based on the device’s display.</p>
     <li><a href="#ref-for-dom-mediadecodingconfiguration-keysystemconfiguration②">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediaencodingconfiguration">
-   <b><a href="#dictdef-mediaencodingconfiguration">#dictdef-mediaencodingconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediaencodingconfiguration" class="dfn-panel" data-for="dictdef-mediaencodingconfiguration" id="infopanel-for-dictdef-mediaencodingconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediaencodingconfiguration" style="display:none">Info about the 'MediaEncodingConfiguration' definition.</span><b><a href="#dictdef-mediaencodingconfiguration">#dictdef-mediaencodingconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediaencodingconfiguration">2.1.1. MediaConfiguration</a>
     <li><a href="#ref-for-dictdef-mediaencodingconfiguration①">2.1.3. MediaEncodingType</a>
@@ -2209,85 +2209,87 @@ based on the device’s display.</p>
     <li><a href="#ref-for-dictdef-mediaencodingconfiguration⑤">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-mediaconfiguration">
-   <b><a href="#valid-mediaconfiguration">#valid-mediaconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-mediaconfiguration" class="dfn-panel" data-for="valid-mediaconfiguration" id="infopanel-for-valid-mediaconfiguration" role="dialog">
+   <span id="infopaneltitle-for-valid-mediaconfiguration" style="display:none">Info about the 'valid
+        MediaConfiguration' definition.</span><b><a href="#valid-mediaconfiguration">#valid-mediaconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-mediaconfiguration">2.1.1. MediaConfiguration</a>
     <li><a href="#ref-for-valid-mediaconfiguration①">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-mediadecodingconfiguration">
-   <b><a href="#valid-mediadecodingconfiguration">#valid-mediadecodingconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-mediadecodingconfiguration" class="dfn-panel" data-for="valid-mediadecodingconfiguration" id="infopanel-for-valid-mediadecodingconfiguration" role="dialog">
+   <span id="infopaneltitle-for-valid-mediadecodingconfiguration" style="display:none">Info about the 'valid
+        MediaDecodingConfiguration' definition.</span><b><a href="#valid-mediadecodingconfiguration">#valid-mediadecodingconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-mediadecodingconfiguration">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mediadecodingtype">
-   <b><a href="#enumdef-mediadecodingtype">#enumdef-mediadecodingtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mediadecodingtype" class="dfn-panel" data-for="enumdef-mediadecodingtype" id="infopanel-for-enumdef-mediadecodingtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mediadecodingtype" style="display:none">Info about the 'MediaDecodingType' definition.</span><b><a href="#enumdef-mediadecodingtype">#enumdef-mediadecodingtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mediadecodingtype">2.1.1. MediaConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediadecodingtype-file">
-   <b><a href="#dom-mediadecodingtype-file">#dom-mediadecodingtype-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediadecodingtype-file" class="dfn-panel" data-for="dom-mediadecodingtype-file" id="infopanel-for-dom-mediadecodingtype-file" role="dialog">
+   <span id="infopaneltitle-for-dom-mediadecodingtype-file" style="display:none">Info about the 'file' definition.</span><b><a href="#dom-mediadecodingtype-file">#dom-mediadecodingtype-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadecodingtype-file">2.1.2. MediaDecodingType</a>
     <li><a href="#ref-for-dom-mediadecodingtype-file①">2.1.4. MIME types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediadecodingtype-media-source">
-   <b><a href="#dom-mediadecodingtype-media-source">#dom-mediadecodingtype-media-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediadecodingtype-media-source" class="dfn-panel" data-for="dom-mediadecodingtype-media-source" id="infopanel-for-dom-mediadecodingtype-media-source" role="dialog">
+   <span id="infopaneltitle-for-dom-mediadecodingtype-media-source" style="display:none">Info about the 'media-source' definition.</span><b><a href="#dom-mediadecodingtype-media-source">#dom-mediadecodingtype-media-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadecodingtype-media-source">2.1.2. MediaDecodingType</a>
     <li><a href="#ref-for-dom-mediadecodingtype-media-source①">2.1.4. MIME types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediadecodingtype-webrtc">
-   <b><a href="#dom-mediadecodingtype-webrtc">#dom-mediadecodingtype-webrtc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediadecodingtype-webrtc" class="dfn-panel" data-for="dom-mediadecodingtype-webrtc" id="infopanel-for-dom-mediadecodingtype-webrtc" role="dialog">
+   <span id="infopaneltitle-for-dom-mediadecodingtype-webrtc" style="display:none">Info about the 'webrtc' definition.</span><b><a href="#dom-mediadecodingtype-webrtc">#dom-mediadecodingtype-webrtc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadecodingtype-webrtc">2.1.2. MediaDecodingType</a>
     <li><a href="#ref-for-dom-mediadecodingtype-webrtc①">2.1.4. MIME types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mediaencodingtype">
-   <b><a href="#enumdef-mediaencodingtype">#enumdef-mediaencodingtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mediaencodingtype" class="dfn-panel" data-for="enumdef-mediaencodingtype" id="infopanel-for-enumdef-mediaencodingtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mediaencodingtype" style="display:none">Info about the 'MediaEncodingType' definition.</span><b><a href="#enumdef-mediaencodingtype">#enumdef-mediaencodingtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mediaencodingtype">2.1.1. MediaConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaencodingtype-record">
-   <b><a href="#dom-mediaencodingtype-record">#dom-mediaencodingtype-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaencodingtype-record" class="dfn-panel" data-for="dom-mediaencodingtype-record" id="infopanel-for-dom-mediaencodingtype-record" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaencodingtype-record" style="display:none">Info about the 'record' definition.</span><b><a href="#dom-mediaencodingtype-record">#dom-mediaencodingtype-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaencodingtype-record">2.1.3. MediaEncodingType</a>
     <li><a href="#ref-for-dom-mediaencodingtype-record①">2.1.4. MIME types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaencodingtype-webrtc">
-   <b><a href="#dom-mediaencodingtype-webrtc">#dom-mediaencodingtype-webrtc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaencodingtype-webrtc" class="dfn-panel" data-for="dom-mediaencodingtype-webrtc" id="infopanel-for-dom-mediaencodingtype-webrtc" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaencodingtype-webrtc" style="display:none">Info about the 'webrtc' definition.</span><b><a href="#dom-mediaencodingtype-webrtc">#dom-mediaencodingtype-webrtc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaencodingtype-webrtc">2.1.3. MediaEncodingType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-media-mime-type">
-   <b><a href="#valid-media-mime-type">#valid-media-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-media-mime-type" class="dfn-panel" data-for="valid-media-mime-type" id="infopanel-for-valid-media-mime-type" role="dialog">
+   <span id="infopaneltitle-for-valid-media-mime-type" style="display:none">Info about the 'valid media MIME type' definition.</span><b><a href="#valid-media-mime-type">#valid-media-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-media-mime-type">2.1.4. MIME types</a> <a href="#ref-for-valid-media-mime-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-audio-mime-type">
-   <b><a href="#valid-audio-mime-type">#valid-audio-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-audio-mime-type" class="dfn-panel" data-for="valid-audio-mime-type" id="infopanel-for-valid-audio-mime-type" role="dialog">
+   <span id="infopaneltitle-for-valid-audio-mime-type" style="display:none">Info about the 'valid audio MIME type' definition.</span><b><a href="#valid-audio-mime-type">#valid-audio-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-audio-mime-type">2.1.9. AudioConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-video-mime-type">
-   <b><a href="#valid-video-mime-type">#valid-video-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-video-mime-type" class="dfn-panel" data-for="valid-video-mime-type" id="infopanel-for-valid-video-mime-type" role="dialog">
+   <span id="infopaneltitle-for-valid-video-mime-type" style="display:none">Info about the 'valid video MIME type' definition.</span><b><a href="#valid-video-mime-type">#valid-video-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-video-mime-type">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-videoconfiguration">
-   <b><a href="#dictdef-videoconfiguration">#dictdef-videoconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-videoconfiguration" class="dfn-panel" data-for="dictdef-videoconfiguration" id="infopanel-for-dictdef-videoconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-videoconfiguration" style="display:none">Info about the 'VideoConfiguration' definition.</span><b><a href="#dictdef-videoconfiguration">#dictdef-videoconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-videoconfiguration">2.1.1. MediaConfiguration</a>
     <li><a href="#ref-for-dictdef-videoconfiguration①">2.1.5. VideoConfiguration</a>
@@ -2298,147 +2300,147 @@ based on the device’s display.</p>
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-contenttype">
-   <b><a href="#dom-videoconfiguration-contenttype">#dom-videoconfiguration-contenttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-contenttype" class="dfn-panel" data-for="dom-videoconfiguration-contenttype" id="infopanel-for-dom-videoconfiguration-contenttype" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-contenttype" style="display:none">Info about the 'contentType' definition.</span><b><a href="#dom-videoconfiguration-contenttype">#dom-videoconfiguration-contenttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-contenttype">2.1.5. VideoConfiguration</a> <a href="#ref-for-dom-videoconfiguration-contenttype①">(2)</a> <a href="#ref-for-dom-videoconfiguration-contenttype②">(3)</a> <a href="#ref-for-dom-videoconfiguration-contenttype③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-video-configuration">
-   <b><a href="#valid-video-configuration">#valid-video-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-video-configuration" class="dfn-panel" data-for="valid-video-configuration" id="infopanel-for-valid-video-configuration" role="dialog">
+   <span id="infopaneltitle-for-valid-video-configuration" style="display:none">Info about the 'valid video configuration' definition.</span><b><a href="#valid-video-configuration">#valid-video-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-video-configuration">2.1.1. MediaConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-width">
-   <b><a href="#dom-videoconfiguration-width">#dom-videoconfiguration-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-width" class="dfn-panel" data-for="dom-videoconfiguration-width" id="infopanel-for-dom-videoconfiguration-width" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-videoconfiguration-width">#dom-videoconfiguration-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-width">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-height">
-   <b><a href="#dom-videoconfiguration-height">#dom-videoconfiguration-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-height" class="dfn-panel" data-for="dom-videoconfiguration-height" id="infopanel-for-dom-videoconfiguration-height" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-videoconfiguration-height">#dom-videoconfiguration-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-height">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-bitrate">
-   <b><a href="#dom-videoconfiguration-bitrate">#dom-videoconfiguration-bitrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-bitrate" class="dfn-panel" data-for="dom-videoconfiguration-bitrate" id="infopanel-for-dom-videoconfiguration-bitrate" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-bitrate" style="display:none">Info about the 'bitrate' definition.</span><b><a href="#dom-videoconfiguration-bitrate">#dom-videoconfiguration-bitrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-bitrate">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-framerate">
-   <b><a href="#dom-videoconfiguration-framerate">#dom-videoconfiguration-framerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-framerate" class="dfn-panel" data-for="dom-videoconfiguration-framerate" id="infopanel-for-dom-videoconfiguration-framerate" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-framerate" style="display:none">Info about the 'framerate' definition.</span><b><a href="#dom-videoconfiguration-framerate">#dom-videoconfiguration-framerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-framerate">2.1.5. VideoConfiguration</a> <a href="#ref-for-dom-videoconfiguration-framerate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-hasalphachannel">
-   <b><a href="#dom-videoconfiguration-hasalphachannel">#dom-videoconfiguration-hasalphachannel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-hasalphachannel" class="dfn-panel" data-for="dom-videoconfiguration-hasalphachannel" id="infopanel-for-dom-videoconfiguration-hasalphachannel" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-hasalphachannel" style="display:none">Info about the 'hasAlphaChannel' definition.</span><b><a href="#dom-videoconfiguration-hasalphachannel">#dom-videoconfiguration-hasalphachannel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-hasalphachannel">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-hdrmetadatatype">
-   <b><a href="#dom-videoconfiguration-hdrmetadatatype">#dom-videoconfiguration-hdrmetadatatype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-hdrmetadatatype" class="dfn-panel" data-for="dom-videoconfiguration-hdrmetadatatype" id="infopanel-for-dom-videoconfiguration-hdrmetadatatype" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-hdrmetadatatype" style="display:none">Info about the 'hdrMetadataType' definition.</span><b><a href="#dom-videoconfiguration-hdrmetadatatype">#dom-videoconfiguration-hdrmetadatatype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-hdrmetadatatype">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-colorgamut">
-   <b><a href="#dom-videoconfiguration-colorgamut">#dom-videoconfiguration-colorgamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-colorgamut" class="dfn-panel" data-for="dom-videoconfiguration-colorgamut" id="infopanel-for-dom-videoconfiguration-colorgamut" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-colorgamut" style="display:none">Info about the 'colorGamut' definition.</span><b><a href="#dom-videoconfiguration-colorgamut">#dom-videoconfiguration-colorgamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-colorgamut">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-transferfunction">
-   <b><a href="#dom-videoconfiguration-transferfunction">#dom-videoconfiguration-transferfunction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-transferfunction" class="dfn-panel" data-for="dom-videoconfiguration-transferfunction" id="infopanel-for-dom-videoconfiguration-transferfunction" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-transferfunction" style="display:none">Info about the 'transferFunction' definition.</span><b><a href="#dom-videoconfiguration-transferfunction">#dom-videoconfiguration-transferfunction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-transferfunction">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-videoconfiguration-scalabilitymode">
-   <b><a href="#dom-videoconfiguration-scalabilitymode">#dom-videoconfiguration-scalabilitymode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-videoconfiguration-scalabilitymode" class="dfn-panel" data-for="dom-videoconfiguration-scalabilitymode" id="infopanel-for-dom-videoconfiguration-scalabilitymode" role="dialog">
+   <span id="infopaneltitle-for-dom-videoconfiguration-scalabilitymode" style="display:none">Info about the 'scalabilityMode' definition.</span><b><a href="#dom-videoconfiguration-scalabilitymode">#dom-videoconfiguration-scalabilitymode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-videoconfiguration-scalabilitymode">2.1.5. VideoConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-hdrmetadatatype">
-   <b><a href="#enumdef-hdrmetadatatype">#enumdef-hdrmetadatatype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-hdrmetadatatype" class="dfn-panel" data-for="enumdef-hdrmetadatatype" id="infopanel-for-enumdef-hdrmetadatatype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-hdrmetadatatype" style="display:none">Info about the 'HdrMetadataType' definition.</span><b><a href="#enumdef-hdrmetadatatype">#enumdef-hdrmetadatatype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-hdrmetadatatype">2.1.5. VideoConfiguration</a> <a href="#ref-for-enumdef-hdrmetadatatype①">(2)</a>
     <li><a href="#ref-for-enumdef-hdrmetadatatype②">2.1.6. HdrMetadataType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2086">
-   <b><a href="#dom-hdrmetadatatype-smptest2086">#dom-hdrmetadatatype-smptest2086</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-hdrmetadatatype-smptest2086" class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2086" id="infopanel-for-dom-hdrmetadatatype-smptest2086" role="dialog">
+   <span id="infopaneltitle-for-dom-hdrmetadatatype-smptest2086" style="display:none">Info about the 'smpteSt2086' definition.</span><b><a href="#dom-hdrmetadatatype-smptest2086">#dom-hdrmetadatatype-smptest2086</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-hdrmetadatatype-smptest2086">2.1.6. HdrMetadataType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2094-10">
-   <b><a href="#dom-hdrmetadatatype-smptest2094-10">#dom-hdrmetadatatype-smptest2094-10</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-hdrmetadatatype-smptest2094-10" class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2094-10" id="infopanel-for-dom-hdrmetadatatype-smptest2094-10" role="dialog">
+   <span id="infopaneltitle-for-dom-hdrmetadatatype-smptest2094-10" style="display:none">Info about the 'smpteSt2094-10' definition.</span><b><a href="#dom-hdrmetadatatype-smptest2094-10">#dom-hdrmetadatatype-smptest2094-10</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-hdrmetadatatype-smptest2094-10">2.1.6. HdrMetadataType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2094-40">
-   <b><a href="#dom-hdrmetadatatype-smptest2094-40">#dom-hdrmetadatatype-smptest2094-40</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-hdrmetadatatype-smptest2094-40" class="dfn-panel" data-for="dom-hdrmetadatatype-smptest2094-40" id="infopanel-for-dom-hdrmetadatatype-smptest2094-40" role="dialog">
+   <span id="infopaneltitle-for-dom-hdrmetadatatype-smptest2094-40" style="display:none">Info about the 'smpteSt2094-40' definition.</span><b><a href="#dom-hdrmetadatatype-smptest2094-40">#dom-hdrmetadatatype-smptest2094-40</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-hdrmetadatatype-smptest2094-40">2.1.6. HdrMetadataType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-colorgamut">
-   <b><a href="#enumdef-colorgamut">#enumdef-colorgamut</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-colorgamut" class="dfn-panel" data-for="enumdef-colorgamut" id="infopanel-for-enumdef-colorgamut" role="dialog">
+   <span id="infopaneltitle-for-enumdef-colorgamut" style="display:none">Info about the 'ColorGamut' definition.</span><b><a href="#enumdef-colorgamut">#enumdef-colorgamut</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-colorgamut">2.1.5. VideoConfiguration</a> <a href="#ref-for-enumdef-colorgamut①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-colorgamut-srgb">
-   <b><a href="#dom-colorgamut-srgb">#dom-colorgamut-srgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-colorgamut-srgb" class="dfn-panel" data-for="dom-colorgamut-srgb" id="infopanel-for-dom-colorgamut-srgb" role="dialog">
+   <span id="infopaneltitle-for-dom-colorgamut-srgb" style="display:none">Info about the 'srgb' definition.</span><b><a href="#dom-colorgamut-srgb">#dom-colorgamut-srgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-colorgamut-srgb">2.1.7. ColorGamut</a> <a href="#ref-for-dom-colorgamut-srgb①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-colorgamut-p3">
-   <b><a href="#dom-colorgamut-p3">#dom-colorgamut-p3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-colorgamut-p3" class="dfn-panel" data-for="dom-colorgamut-p3" id="infopanel-for-dom-colorgamut-p3" role="dialog">
+   <span id="infopaneltitle-for-dom-colorgamut-p3" style="display:none">Info about the 'p3' definition.</span><b><a href="#dom-colorgamut-p3">#dom-colorgamut-p3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-colorgamut-p3">2.1.7. ColorGamut</a> <a href="#ref-for-dom-colorgamut-p3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-colorgamut-rec2020">
-   <b><a href="#dom-colorgamut-rec2020">#dom-colorgamut-rec2020</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-colorgamut-rec2020" class="dfn-panel" data-for="dom-colorgamut-rec2020" id="infopanel-for-dom-colorgamut-rec2020" role="dialog">
+   <span id="infopaneltitle-for-dom-colorgamut-rec2020" style="display:none">Info about the 'rec2020' definition.</span><b><a href="#dom-colorgamut-rec2020">#dom-colorgamut-rec2020</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-colorgamut-rec2020">2.1.7. ColorGamut</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-transferfunction">
-   <b><a href="#enumdef-transferfunction">#enumdef-transferfunction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-transferfunction" class="dfn-panel" data-for="enumdef-transferfunction" id="infopanel-for-enumdef-transferfunction" role="dialog">
+   <span id="infopaneltitle-for-enumdef-transferfunction" style="display:none">Info about the 'TransferFunction' definition.</span><b><a href="#enumdef-transferfunction">#enumdef-transferfunction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-transferfunction">2.1.5. VideoConfiguration</a> <a href="#ref-for-enumdef-transferfunction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transferfunction-srgb">
-   <b><a href="#dom-transferfunction-srgb">#dom-transferfunction-srgb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transferfunction-srgb" class="dfn-panel" data-for="dom-transferfunction-srgb" id="infopanel-for-dom-transferfunction-srgb" role="dialog">
+   <span id="infopaneltitle-for-dom-transferfunction-srgb" style="display:none">Info about the 'srgb' definition.</span><b><a href="#dom-transferfunction-srgb">#dom-transferfunction-srgb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transferfunction-srgb">2.1.8. TransferFunction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transferfunction-pq">
-   <b><a href="#dom-transferfunction-pq">#dom-transferfunction-pq</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transferfunction-pq" class="dfn-panel" data-for="dom-transferfunction-pq" id="infopanel-for-dom-transferfunction-pq" role="dialog">
+   <span id="infopaneltitle-for-dom-transferfunction-pq" style="display:none">Info about the 'pq' definition.</span><b><a href="#dom-transferfunction-pq">#dom-transferfunction-pq</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transferfunction-pq">2.1.8. TransferFunction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transferfunction-hlg">
-   <b><a href="#dom-transferfunction-hlg">#dom-transferfunction-hlg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transferfunction-hlg" class="dfn-panel" data-for="dom-transferfunction-hlg" id="infopanel-for-dom-transferfunction-hlg" role="dialog">
+   <span id="infopaneltitle-for-dom-transferfunction-hlg" style="display:none">Info about the 'hlg' definition.</span><b><a href="#dom-transferfunction-hlg">#dom-transferfunction-hlg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transferfunction-hlg">2.1.8. TransferFunction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-audioconfiguration">
-   <b><a href="#dictdef-audioconfiguration">#dictdef-audioconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-audioconfiguration" class="dfn-panel" data-for="dictdef-audioconfiguration" id="infopanel-for-dictdef-audioconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-audioconfiguration" style="display:none">Info about the 'AudioConfiguration' definition.</span><b><a href="#dictdef-audioconfiguration">#dictdef-audioconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-audioconfiguration">2.1.1. MediaConfiguration</a>
     <li><a href="#ref-for-dictdef-audioconfiguration①">2.1.9. AudioConfiguration</a>
@@ -2446,50 +2448,50 @@ based on the device’s display.</p>
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioconfiguration-contenttype">
-   <b><a href="#dom-audioconfiguration-contenttype">#dom-audioconfiguration-contenttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioconfiguration-contenttype" class="dfn-panel" data-for="dom-audioconfiguration-contenttype" id="infopanel-for-dom-audioconfiguration-contenttype" role="dialog">
+   <span id="infopaneltitle-for-dom-audioconfiguration-contenttype" style="display:none">Info about the 'contentType' definition.</span><b><a href="#dom-audioconfiguration-contenttype">#dom-audioconfiguration-contenttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioconfiguration-contenttype">2.1.9. AudioConfiguration</a> <a href="#ref-for-dom-audioconfiguration-contenttype①">(2)</a> <a href="#ref-for-dom-audioconfiguration-contenttype②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-audio-configuration">
-   <b><a href="#valid-audio-configuration">#valid-audio-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-audio-configuration" class="dfn-panel" data-for="valid-audio-configuration" id="infopanel-for-valid-audio-configuration" role="dialog">
+   <span id="infopaneltitle-for-valid-audio-configuration" style="display:none">Info about the 'valid audio configuration' definition.</span><b><a href="#valid-audio-configuration">#valid-audio-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-audio-configuration">2.1.1. MediaConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioconfiguration-channels">
-   <b><a href="#dom-audioconfiguration-channels">#dom-audioconfiguration-channels</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioconfiguration-channels" class="dfn-panel" data-for="dom-audioconfiguration-channels" id="infopanel-for-dom-audioconfiguration-channels" role="dialog">
+   <span id="infopaneltitle-for-dom-audioconfiguration-channels" style="display:none">Info about the 'channels' definition.</span><b><a href="#dom-audioconfiguration-channels">#dom-audioconfiguration-channels</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioconfiguration-channels">2.1.9. AudioConfiguration</a> <a href="#ref-for-dom-audioconfiguration-channels①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioconfiguration-bitrate">
-   <b><a href="#dom-audioconfiguration-bitrate">#dom-audioconfiguration-bitrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioconfiguration-bitrate" class="dfn-panel" data-for="dom-audioconfiguration-bitrate" id="infopanel-for-dom-audioconfiguration-bitrate" role="dialog">
+   <span id="infopaneltitle-for-dom-audioconfiguration-bitrate" style="display:none">Info about the 'bitrate' definition.</span><b><a href="#dom-audioconfiguration-bitrate">#dom-audioconfiguration-bitrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioconfiguration-bitrate">2.1.9. AudioConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioconfiguration-samplerate">
-   <b><a href="#dom-audioconfiguration-samplerate">#dom-audioconfiguration-samplerate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioconfiguration-samplerate" class="dfn-panel" data-for="dom-audioconfiguration-samplerate" id="infopanel-for-dom-audioconfiguration-samplerate" role="dialog">
+   <span id="infopaneltitle-for-dom-audioconfiguration-samplerate" style="display:none">Info about the 'samplerate' definition.</span><b><a href="#dom-audioconfiguration-samplerate">#dom-audioconfiguration-samplerate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioconfiguration-samplerate">2.1.9. AudioConfiguration</a> <a href="#ref-for-dom-audioconfiguration-samplerate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-audioconfiguration-spatialrendering">
-   <b><a href="#dom-audioconfiguration-spatialrendering">#dom-audioconfiguration-spatialrendering</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-audioconfiguration-spatialrendering" class="dfn-panel" data-for="dom-audioconfiguration-spatialrendering" id="infopanel-for-dom-audioconfiguration-spatialrendering" role="dialog">
+   <span id="infopaneltitle-for-dom-audioconfiguration-spatialrendering" style="display:none">Info about the 'spatialRendering' definition.</span><b><a href="#dom-audioconfiguration-spatialrendering">#dom-audioconfiguration-spatialrendering</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-audioconfiguration-spatialrendering">2.1.9. AudioConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediacapabilitieskeysystemconfiguration">
-   <b><a href="#dictdef-mediacapabilitieskeysystemconfiguration">#dictdef-mediacapabilitieskeysystemconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediacapabilitieskeysystemconfiguration" class="dfn-panel" data-for="dictdef-mediacapabilitieskeysystemconfiguration" id="infopanel-for-dictdef-mediacapabilitieskeysystemconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediacapabilitieskeysystemconfiguration" style="display:none">Info about the 'MediaCapabilitiesKeySystemConfiguration' definition.</span><b><a href="#dictdef-mediacapabilitieskeysystemconfiguration">#dictdef-mediacapabilitieskeysystemconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediacapabilitieskeysystemconfiguration">2.1.1. MediaConfiguration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-keysystem">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-keysystem">#dom-mediacapabilitieskeysystemconfiguration-keysystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-keysystem" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-keysystem" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-keysystem" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-keysystem" style="display:none">Info about the 'keySystem' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-keysystem">#dom-mediacapabilitieskeysystemconfiguration-keysystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-keysystem">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
@@ -2497,77 +2499,77 @@ based on the device’s display.</p>
           Check Encrypted Decoding Support </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-initdatatype">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-initdatatype">#dom-mediacapabilitieskeysystemconfiguration-initdatatype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-initdatatype" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-initdatatype" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-initdatatype" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-initdatatype" style="display:none">Info about the 'initDataType' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-initdatatype">#dom-mediacapabilitieskeysystemconfiguration-initdatatype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-initdatatype">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier">#dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier" style="display:none">Info about the 'distinctiveIdentifier' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier">#dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-distinctiveidentifier">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-persistentstate">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-persistentstate">#dom-mediacapabilitieskeysystemconfiguration-persistentstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-persistentstate" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-persistentstate" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-persistentstate" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-persistentstate" style="display:none">Info about the 'persistentState' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-persistentstate">#dom-mediacapabilitieskeysystemconfiguration-persistentstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-persistentstate">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-sessiontypes">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-sessiontypes">#dom-mediacapabilitieskeysystemconfiguration-sessiontypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-sessiontypes" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-sessiontypes" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-sessiontypes" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-sessiontypes" style="display:none">Info about the 'sessionTypes' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-sessiontypes">#dom-mediacapabilitieskeysystemconfiguration-sessiontypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-sessiontypes">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-audio">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-audio">#dom-mediacapabilitieskeysystemconfiguration-audio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-audio" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-audio" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-audio" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-audio" style="display:none">Info about the 'audio' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-audio">#dom-mediacapabilitieskeysystemconfiguration-audio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-audio">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-video">
-   <b><a href="#dom-mediacapabilitieskeysystemconfiguration-video">#dom-mediacapabilitieskeysystemconfiguration-video</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-video" class="dfn-panel" data-for="dom-mediacapabilitieskeysystemconfiguration-video" id="infopanel-for-dom-mediacapabilitieskeysystemconfiguration-video" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitieskeysystemconfiguration-video" style="display:none">Info about the 'video' definition.</span><b><a href="#dom-mediacapabilitieskeysystemconfiguration-video">#dom-mediacapabilitieskeysystemconfiguration-video</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitieskeysystemconfiguration-video">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-keysystemtrackconfiguration">
-   <b><a href="#dictdef-keysystemtrackconfiguration">#dictdef-keysystemtrackconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-keysystemtrackconfiguration" class="dfn-panel" data-for="dictdef-keysystemtrackconfiguration" id="infopanel-for-dictdef-keysystemtrackconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-keysystemtrackconfiguration" style="display:none">Info about the 'KeySystemTrackConfiguration' definition.</span><b><a href="#dictdef-keysystemtrackconfiguration">#dictdef-keysystemtrackconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-keysystemtrackconfiguration">2.1.10. 
         MediaCapabilitiesKeySystemConfiguration </a> <a href="#ref-for-dictdef-keysystemtrackconfiguration①">(2)</a> <a href="#ref-for-dictdef-keysystemtrackconfiguration②">(3)</a> <a href="#ref-for-dictdef-keysystemtrackconfiguration③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keysystemtrackconfiguration-robustness">
-   <b><a href="#dom-keysystemtrackconfiguration-robustness">#dom-keysystemtrackconfiguration-robustness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keysystemtrackconfiguration-robustness" class="dfn-panel" data-for="dom-keysystemtrackconfiguration-robustness" id="infopanel-for-dom-keysystemtrackconfiguration-robustness" role="dialog">
+   <span id="infopaneltitle-for-dom-keysystemtrackconfiguration-robustness" style="display:none">Info about the 'robustness' definition.</span><b><a href="#dom-keysystemtrackconfiguration-robustness">#dom-keysystemtrackconfiguration-robustness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keysystemtrackconfiguration-robustness">2.1.11. 
       KeySystemTrackConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-keysystemtrackconfiguration-encryptionscheme">
-   <b><a href="#dom-keysystemtrackconfiguration-encryptionscheme">#dom-keysystemtrackconfiguration-encryptionscheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-keysystemtrackconfiguration-encryptionscheme" class="dfn-panel" data-for="dom-keysystemtrackconfiguration-encryptionscheme" id="infopanel-for-dom-keysystemtrackconfiguration-encryptionscheme" role="dialog">
+   <span id="infopaneltitle-for-dom-keysystemtrackconfiguration-encryptionscheme" style="display:none">Info about the 'encryptionScheme' definition.</span><b><a href="#dom-keysystemtrackconfiguration-encryptionscheme">#dom-keysystemtrackconfiguration-encryptionscheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-keysystemtrackconfiguration-encryptionscheme">2.1.11. 
       KeySystemTrackConfiguration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediacapabilitiesinfo">
-   <b><a href="#dictdef-mediacapabilitiesinfo">#dictdef-mediacapabilitiesinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediacapabilitiesinfo" class="dfn-panel" data-for="dictdef-mediacapabilitiesinfo" id="infopanel-for-dictdef-mediacapabilitiesinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediacapabilitiesinfo" style="display:none">Info about the 'MediaCapabilitiesInfo' definition.</span><b><a href="#dictdef-mediacapabilitiesinfo">#dictdef-mediacapabilitiesinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediacapabilitiesinfo">2.2. Media Capabilities Information</a> <a href="#ref-for-dictdef-mediacapabilitiesinfo①">(2)</a> <a href="#ref-for-dictdef-mediacapabilitiesinfo②">(3)</a> <a href="#ref-for-dictdef-mediacapabilitiesinfo③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediacapabilitiesdecodinginfo">
-   <b><a href="#dictdef-mediacapabilitiesdecodinginfo">#dictdef-mediacapabilitiesdecodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediacapabilitiesdecodinginfo" class="dfn-panel" data-for="dictdef-mediacapabilitiesdecodinginfo" id="infopanel-for-dictdef-mediacapabilitiesdecodinginfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediacapabilitiesdecodinginfo" style="display:none">Info about the 'MediaCapabilitiesDecodingInfo' definition.</span><b><a href="#dictdef-mediacapabilitiesdecodinginfo">#dictdef-mediacapabilitiesdecodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediacapabilitiesdecodinginfo">2.2. Media Capabilities Information</a> <a href="#ref-for-dictdef-mediacapabilitiesdecodinginfo①">(2)</a> <a href="#ref-for-dictdef-mediacapabilitiesdecodinginfo②">(3)</a>
     <li><a href="#ref-for-dictdef-mediacapabilitiesdecodinginfo③">2.3.2. 
@@ -2575,8 +2577,8 @@ based on the device’s display.</p>
     <li><a href="#ref-for-dictdef-mediacapabilitiesdecodinginfo⑤">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediacapabilitiesencodinginfo">
-   <b><a href="#dictdef-mediacapabilitiesencodinginfo">#dictdef-mediacapabilitiesencodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediacapabilitiesencodinginfo" class="dfn-panel" data-for="dictdef-mediacapabilitiesencodinginfo" id="infopanel-for-dictdef-mediacapabilitiesencodinginfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediacapabilitiesencodinginfo" style="display:none">Info about the 'MediaCapabilitiesEncodingInfo' definition.</span><b><a href="#dictdef-mediacapabilitiesencodinginfo">#dictdef-mediacapabilitiesencodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediacapabilitiesencodinginfo">2.2. Media Capabilities Information</a> <a href="#ref-for-dictdef-mediacapabilitiesencodinginfo①">(2)</a>
     <li><a href="#ref-for-dictdef-mediacapabilitiesencodinginfo②">2.3.1. 
@@ -2584,8 +2586,8 @@ based on the device’s display.</p>
     <li><a href="#ref-for-dictdef-mediacapabilitiesencodinginfo④">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesinfo-supported">
-   <b><a href="#dom-mediacapabilitiesinfo-supported">#dom-mediacapabilitiesinfo-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesinfo-supported" class="dfn-panel" data-for="dom-mediacapabilitiesinfo-supported" id="infopanel-for-dom-mediacapabilitiesinfo-supported" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesinfo-supported" style="display:none">Info about the 'supported' definition.</span><b><a href="#dom-mediacapabilitiesinfo-supported">#dom-mediacapabilitiesinfo-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-supported">2.1.9. AudioConfiguration</a>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-supported①">2.2. Media Capabilities Information</a>
@@ -2595,8 +2597,8 @@ based on the device’s display.</p>
           Create a MediaCapabilitiesDecodingInfo </a> <a href="#ref-for-dom-mediacapabilitiesinfo-supported④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesinfo-smooth">
-   <b><a href="#dom-mediacapabilitiesinfo-smooth">#dom-mediacapabilitiesinfo-smooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesinfo-smooth" class="dfn-panel" data-for="dom-mediacapabilitiesinfo-smooth" id="infopanel-for-dom-mediacapabilitiesinfo-smooth" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesinfo-smooth" style="display:none">Info about the 'smooth' definition.</span><b><a href="#dom-mediacapabilitiesinfo-smooth">#dom-mediacapabilitiesinfo-smooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-smooth">2.2. Media Capabilities Information</a>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-smooth①">2.3.1. 
@@ -2605,8 +2607,8 @@ based on the device’s display.</p>
           Create a MediaCapabilitiesDecodingInfo </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesinfo-powerefficient">
-   <b><a href="#dom-mediacapabilitiesinfo-powerefficient">#dom-mediacapabilitiesinfo-powerefficient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesinfo-powerefficient" class="dfn-panel" data-for="dom-mediacapabilitiesinfo-powerefficient" id="infopanel-for-dom-mediacapabilitiesinfo-powerefficient" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesinfo-powerefficient" style="display:none">Info about the 'powerEfficient' definition.</span><b><a href="#dom-mediacapabilitiesinfo-powerefficient">#dom-mediacapabilitiesinfo-powerefficient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-powerefficient">2.2. Media Capabilities Information</a> <a href="#ref-for-dom-mediacapabilitiesinfo-powerefficient①">(2)</a>
     <li><a href="#ref-for-dom-mediacapabilitiesinfo-powerefficient②">2.3.1. 
@@ -2615,64 +2617,64 @@ based on the device’s display.</p>
           Create a MediaCapabilitiesDecodingInfo </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesdecodinginfo-keysystemaccess">
-   <b><a href="#dom-mediacapabilitiesdecodinginfo-keysystemaccess">#dom-mediacapabilitiesdecodinginfo-keysystemaccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess" class="dfn-panel" data-for="dom-mediacapabilitiesdecodinginfo-keysystemaccess" id="infopanel-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess" style="display:none">Info about the 'keySystemAccess' definition.</span><b><a href="#dom-mediacapabilitiesdecodinginfo-keysystemaccess">#dom-mediacapabilitiesdecodinginfo-keysystemaccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess">2.2. Media Capabilities Information</a>
     <li><a href="#ref-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess①">2.3.2. 
           Create a MediaCapabilitiesDecodingInfo </a> <a href="#ref-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess②">(2)</a> <a href="#ref-for-dom-mediacapabilitiesdecodinginfo-keysystemaccess③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesdecodinginfo-configuration">
-   <b><a href="#dom-mediacapabilitiesdecodinginfo-configuration">#dom-mediacapabilitiesdecodinginfo-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesdecodinginfo-configuration" class="dfn-panel" data-for="dom-mediacapabilitiesdecodinginfo-configuration" id="infopanel-for-dom-mediacapabilitiesdecodinginfo-configuration" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesdecodinginfo-configuration" style="display:none">Info about the 'configuration' definition.</span><b><a href="#dom-mediacapabilitiesdecodinginfo-configuration">#dom-mediacapabilitiesdecodinginfo-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesdecodinginfo-configuration">2.2. Media Capabilities Information</a>
     <li><a href="#ref-for-dom-mediacapabilitiesdecodinginfo-configuration①">2.3.2. 
           Create a MediaCapabilitiesDecodingInfo </a> <a href="#ref-for-dom-mediacapabilitiesdecodinginfo-configuration②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilitiesencodinginfo-configuration">
-   <b><a href="#dom-mediacapabilitiesencodinginfo-configuration">#dom-mediacapabilitiesencodinginfo-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilitiesencodinginfo-configuration" class="dfn-panel" data-for="dom-mediacapabilitiesencodinginfo-configuration" id="infopanel-for-dom-mediacapabilitiesencodinginfo-configuration" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilitiesencodinginfo-configuration" style="display:none">Info about the 'configuration' definition.</span><b><a href="#dom-mediacapabilitiesencodinginfo-configuration">#dom-mediacapabilitiesencodinginfo-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilitiesencodinginfo-configuration">2.2. Media Capabilities Information</a>
     <li><a href="#ref-for-dom-mediacapabilitiesencodinginfo-configuration①">2.3.1. 
           Create a MediaCapabilitiesEncodingInfo </a> <a href="#ref-for-dom-mediacapabilitiesencodinginfo-configuration②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-mediacapabilitiesencodinginfo">
-   <b><a href="#create-a-mediacapabilitiesencodinginfo">#create-a-mediacapabilitiesencodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-mediacapabilitiesencodinginfo" class="dfn-panel" data-for="create-a-mediacapabilitiesencodinginfo" id="infopanel-for-create-a-mediacapabilitiesencodinginfo" role="dialog">
+   <span id="infopaneltitle-for-create-a-mediacapabilitiesencodinginfo" style="display:none">Info about the 'Create a MediaCapabilitiesEncodingInfo' definition.</span><b><a href="#create-a-mediacapabilitiesencodinginfo">#create-a-mediacapabilitiesencodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-mediacapabilitiesencodinginfo">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-mediacapabilitiesdecodinginfo">
-   <b><a href="#create-a-mediacapabilitiesdecodinginfo">#create-a-mediacapabilitiesdecodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-mediacapabilitiesdecodinginfo" class="dfn-panel" data-for="create-a-mediacapabilitiesdecodinginfo" id="infopanel-for-create-a-mediacapabilitiesdecodinginfo" role="dialog">
+   <span id="infopaneltitle-for-create-a-mediacapabilitiesdecodinginfo" style="display:none">Info about the 'Create a MediaCapabilitiesDecodingInfo' definition.</span><b><a href="#create-a-mediacapabilitiesdecodinginfo">#create-a-mediacapabilitiesdecodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-mediacapabilitiesdecodinginfo">2.5. Media Capabilities Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-encrypted-decoding-support">
-   <b><a href="#check-encrypted-decoding-support">#check-encrypted-decoding-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-encrypted-decoding-support" class="dfn-panel" data-for="check-encrypted-decoding-support" id="infopanel-for-check-encrypted-decoding-support" role="dialog">
+   <span id="infopaneltitle-for-check-encrypted-decoding-support" style="display:none">Info about the 'Check Encrypted Decoding Support' definition.</span><b><a href="#check-encrypted-decoding-support">#check-encrypted-decoding-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-encrypted-decoding-support">2.3.2. 
           Create a MediaCapabilitiesDecodingInfo </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediacapabilities">
-   <b><a href="#mediacapabilities">#mediacapabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediacapabilities" class="dfn-panel" data-for="mediacapabilities" id="infopanel-for-mediacapabilities" role="dialog">
+   <span id="infopaneltitle-for-mediacapabilities" style="display:none">Info about the 'MediaCapabilities' definition.</span><b><a href="#mediacapabilities">#mediacapabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediacapabilities">2.4. Navigator and WorkerNavigator extension</a> <a href="#ref-for-mediacapabilities①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilities-decodinginfo">
-   <b><a href="#dom-mediacapabilities-decodinginfo">#dom-mediacapabilities-decodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilities-decodinginfo" class="dfn-panel" data-for="dom-mediacapabilities-decodinginfo" id="infopanel-for-dom-mediacapabilities-decodinginfo" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilities-decodinginfo" style="display:none">Info about the 'decodingInfo' definition.</span><b><a href="#dom-mediacapabilities-decodinginfo">#dom-mediacapabilities-decodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilities-decodinginfo">2.5. Media Capabilities Interface</a> <a href="#ref-for-dom-mediacapabilities-decodinginfo①">(2)</a>
     <li><a href="#ref-for-dom-mediacapabilities-decodinginfo②">4.1. Query playback capabilities with decodingInfo()</a> <a href="#ref-for-dom-mediacapabilities-decodinginfo③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediacapabilities-encodinginfo">
-   <b><a href="#dom-mediacapabilities-encodinginfo">#dom-mediacapabilities-encodinginfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediacapabilities-encodinginfo" class="dfn-panel" data-for="dom-mediacapabilities-encodinginfo" id="infopanel-for-dom-mediacapabilities-encodinginfo" role="dialog">
+   <span id="infopaneltitle-for-dom-mediacapabilities-encodinginfo" style="display:none">Info about the 'encodingInfo' definition.</span><b><a href="#dom-mediacapabilities-encodinginfo">#dom-mediacapabilities-encodinginfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediacapabilities-encodinginfo">2.5. Media Capabilities Interface</a>
     <li><a href="#ref-for-dom-mediacapabilities-encodinginfo①">4.2. Query recording capabilities with encodingInfo()</a>
@@ -2680,57 +2682,113 @@ based on the device’s display.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/mediacapture-image/index.html
+++ b/tests/github/w3c/mediacapture-image/index.html
@@ -1880,35 +1880,35 @@ For instance, embedding the user’s location in the metadata of the digitzed im
      <li><a href="#dom-mediatracksupportedconstraints-zoom">dict-member for MediaTrackSupportedConstraints</a><span>, in § 9.1.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-def-ConstrainBoolean">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-ConstrainBoolean">https://www.w3.org/TR/mediacapture-streams/#idl-def-ConstrainBoolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-ConstrainBoolean" class="dfn-panel" data-for="term-for-idl-def-ConstrainBoolean" id="infopanel-for-term-for-idl-def-ConstrainBoolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-ConstrainBoolean" style="display:none">Info about the 'ConstrainBoolean' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-ConstrainBoolean">https://www.w3.org/TR/mediacapture-streams/#idl-def-ConstrainBoolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-ConstrainBoolean">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-idl-def-ConstrainBoolean①">9.3.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-constraindomstring">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindomstring">https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindomstring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-constraindomstring" class="dfn-panel" data-for="term-for-idl-def-constraindomstring" id="infopanel-for-term-for-idl-def-constraindomstring" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-constraindomstring" style="display:none">Info about the 'ConstrainDOMString' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindomstring">https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindomstring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-constraindomstring">9.3. MediaTrackConstraintSet dictionary</a> <a href="#ref-for-idl-def-constraindomstring①">(2)</a> <a href="#ref-for-idl-def-constraindomstring②">(3)</a>
     <li><a href="#ref-for-idl-def-constraindomstring③">9.3.1. Members</a> <a href="#ref-for-idl-def-constraindomstring④">(2)</a> <a href="#ref-for-idl-def-constraindomstring⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-constraindouble">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindouble">https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindouble</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-constraindouble" class="dfn-panel" data-for="term-for-idl-def-constraindouble" id="infopanel-for-term-for-idl-def-constraindouble" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-constraindouble" style="display:none">Info about the 'ConstrainDouble' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindouble">https://www.w3.org/TR/mediacapture-streams/#idl-def-constraindouble</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-constraindouble">9.3. MediaTrackConstraintSet dictionary</a> <a href="#ref-for-idl-def-constraindouble①">(2)</a> <a href="#ref-for-idl-def-constraindouble②">(3)</a> <a href="#ref-for-idl-def-constraindouble③">(4)</a> <a href="#ref-for-idl-def-constraindouble④">(5)</a> <a href="#ref-for-idl-def-constraindouble⑤">(6)</a> <a href="#ref-for-idl-def-constraindouble⑥">(7)</a> <a href="#ref-for-idl-def-constraindouble⑦">(8)</a> <a href="#ref-for-idl-def-constraindouble⑧">(9)</a> <a href="#ref-for-idl-def-constraindouble⑨">(10)</a> <a href="#ref-for-idl-def-constraindouble①⓪">(11)</a> <a href="#ref-for-idl-def-constraindouble①①">(12)</a>
     <li><a href="#ref-for-idl-def-constraindouble①②">9.3.1. Members</a> <a href="#ref-for-idl-def-constraindouble①③">(2)</a> <a href="#ref-for-idl-def-constraindouble①④">(3)</a> <a href="#ref-for-idl-def-constraindouble①⑤">(4)</a> <a href="#ref-for-idl-def-constraindouble①⑥">(5)</a> <a href="#ref-for-idl-def-constraindouble①⑦">(6)</a> <a href="#ref-for-idl-def-constraindouble①⑧">(7)</a> <a href="#ref-for-idl-def-constraindouble①⑨">(8)</a> <a href="#ref-for-idl-def-constraindouble②⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediadevices-interface-extensions">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#mediadevices-interface-extensions">https://www.w3.org/TR/mediacapture-streams/#mediadevices-interface-extensions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediadevices-interface-extensions" class="dfn-panel" data-for="term-for-mediadevices-interface-extensions" id="infopanel-for-term-for-mediadevices-interface-extensions" role="menu">
+   <span id="infopaneltitle-for-term-for-mediadevices-interface-extensions" style="display:none">Info about the 'MediaDevices' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#mediadevices-interface-extensions">https://www.w3.org/TR/mediacapture-streams/#mediadevices-interface-extensions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediadevices-interface-extensions">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediastreamtrack">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediastreamtrack" class="dfn-panel" data-for="term-for-mediastreamtrack" id="infopanel-for-term-for-mediastreamtrack" role="menu">
+   <span id="infopaneltitle-for-term-for-mediastreamtrack" style="display:none">Info about the 'MediaStreamTrack' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamtrack">Unnumbered Section</a>
     <li><a href="#ref-for-mediastreamtrack①">1. Introduction</a> <a href="#ref-for-mediastreamtrack②">(2)</a>
@@ -1918,230 +1918,230 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-mediastreamtrack①②">9. Extensions</a> <a href="#ref-for-mediastreamtrack①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaTrackCapabilities">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackCapabilities">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackCapabilities</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaTrackCapabilities" class="dfn-panel" data-for="term-for-idl-def-MediaTrackCapabilities" id="infopanel-for-term-for-idl-def-MediaTrackCapabilities" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaTrackCapabilities" style="display:none">Info about the 'MediaTrackCapabilities' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackCapabilities">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackCapabilities</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaTrackCapabilities">9.2. MediaTrackCapabilities dictionary</a> <a href="#ref-for-idl-def-MediaTrackCapabilities①">(2)</a> <a href="#ref-for-idl-def-MediaTrackCapabilities②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaTrackConstraintSet">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraintSet">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraintSet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaTrackConstraintSet" class="dfn-panel" data-for="term-for-idl-def-MediaTrackConstraintSet" id="infopanel-for-term-for-idl-def-MediaTrackConstraintSet" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaTrackConstraintSet" style="display:none">Info about the 'MediaTrackConstraintSet' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraintSet">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraintSet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaTrackConstraintSet">9.3. MediaTrackConstraintSet dictionary</a> <a href="#ref-for-idl-def-MediaTrackConstraintSet①">(2)</a> <a href="#ref-for-idl-def-MediaTrackConstraintSet②">(3)</a>
     <li><a href="#ref-for-idl-def-MediaTrackConstraintSet③">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-idl-def-MediaTrackConstraintSet④">(2)</a> <a href="#ref-for-idl-def-MediaTrackConstraintSet⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaTrackConstraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaTrackConstraints" class="dfn-panel" data-for="term-for-idl-def-MediaTrackConstraints" id="infopanel-for-term-for-idl-def-MediaTrackConstraints" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaTrackConstraints" style="display:none">Info about the 'MediaTrackConstraints' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackConstraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaTrackConstraints">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaTrackSettings">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSettings">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSettings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaTrackSettings" class="dfn-panel" data-for="term-for-idl-def-MediaTrackSettings" id="infopanel-for-term-for-idl-def-MediaTrackSettings" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaTrackSettings" style="display:none">Info about the 'MediaTrackSettings' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSettings">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSettings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaTrackSettings">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-idl-def-MediaTrackSettings①">9.4. MediaTrackSettings dictionary</a> <a href="#ref-for-idl-def-MediaTrackSettings②">(2)</a> <a href="#ref-for-idl-def-MediaTrackSettings③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaTrackSupportedConstraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSupportedConstraints">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSupportedConstraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaTrackSupportedConstraints" class="dfn-panel" data-for="term-for-idl-def-MediaTrackSupportedConstraints" id="infopanel-for-term-for-idl-def-MediaTrackSupportedConstraints" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaTrackSupportedConstraints" style="display:none">Info about the 'MediaTrackSupportedConstraints' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSupportedConstraints">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaTrackSupportedConstraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaTrackSupportedConstraints">9.1. MediaTrackSupportedConstraints dictionary</a> <a href="#ref-for-idl-def-MediaTrackSupportedConstraints①">(2)</a> <a href="#ref-for-idl-def-MediaTrackSupportedConstraints②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-advanced-constraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dfn-advanced-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-advanced-constraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-advanced-constraints" class="dfn-panel" data-for="term-for-dfn-advanced-constraints" id="infopanel-for-term-for-dfn-advanced-constraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-advanced-constraints" style="display:none">Info about the 'advanced constraints' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dfn-advanced-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-advanced-constraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-advanced-constraints">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-allowed-required-constraints-for-device-selection">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dfn-allowed-required-constraints-for-device-selection">https://www.w3.org/TR/mediacapture-streams/#dfn-allowed-required-constraints-for-device-selection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-allowed-required-constraints-for-device-selection" class="dfn-panel" data-for="term-for-dfn-allowed-required-constraints-for-device-selection" id="infopanel-for-term-for-dfn-allowed-required-constraints-for-device-selection" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-allowed-required-constraints-for-device-selection" style="display:none">Info about the 'allowed required constraints for device selection' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dfn-allowed-required-constraints-for-device-selection">https://www.w3.org/TR/mediacapture-streams/#dfn-allowed-required-constraints-for-device-selection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-allowed-required-constraints-for-device-selection">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack-applyconstraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack-applyconstraints" class="dfn-panel" data-for="term-for-dom-mediastreamtrack-applyconstraints" id="infopanel-for-term-for-dom-mediastreamtrack-applyconstraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack-applyconstraints" style="display:none">Info about the 'applyConstraints()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-applyconstraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack-applyconstraints">9. Extensions</a>
     <li><a href="#ref-for-dom-mediastreamtrack-applyconstraints①">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-dom-mediastreamtrack-applyconstraints②">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-mediastreamtrack-applyconstraints③">(2)</a> <a href="#ref-for-dom-mediastreamtrack-applyconstraints④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-defining-a-new-constrainable-property">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#defining-a-new-constrainable-property">https://www.w3.org/TR/mediacapture-streams/#defining-a-new-constrainable-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-defining-a-new-constrainable-property" class="dfn-panel" data-for="term-for-defining-a-new-constrainable-property" id="infopanel-for-term-for-defining-a-new-constrainable-property" role="menu">
+   <span id="infopaneltitle-for-term-for-defining-a-new-constrainable-property" style="display:none">Info about the 'constrainable property' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#defining-a-new-constrainable-property">https://www.w3.org/TR/mediacapture-streams/#defining-a-new-constrainable-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-defining-a-new-constrainable-property">9. Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-fitness-distance">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dfn-fitness-distance">https://www.w3.org/TR/mediacapture-streams/#dfn-fitness-distance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-fitness-distance" class="dfn-panel" data-for="term-for-dfn-fitness-distance" id="infopanel-for-term-for-dfn-fitness-distance" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-fitness-distance" style="display:none">Info about the 'fitness distance' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dfn-fitness-distance">https://www.w3.org/TR/mediacapture-streams/#dfn-fitness-distance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fitness-distance">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dfn-fitness-distance①">(2)</a> <a href="#ref-for-dfn-fitness-distance②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities" id="infopanel-for-term-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities" style="display:none">Info about the 'getCapabilities()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities">9. Extensions</a>
     <li><a href="#ref-for-widl-MediaStreamTrack-getCapabilities-MediaTrackCapabilities①">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getConstraints-MediaTrackConstraints">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getConstraints-MediaTrackConstraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints" id="infopanel-for-term-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints" style="display:none">Info about the 'getConstraints()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getConstraints-MediaTrackConstraints">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-getConstraints-MediaTrackConstraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints">9. Extensions</a>
     <li><a href="#ref-for-widl-MediaStreamTrack-getConstraints-MediaTrackConstraints①">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-ConstrainablePattern-getSettings-Settings">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-ConstrainablePattern-getSettings-Settings">https://www.w3.org/TR/mediacapture-streams/#widl-ConstrainablePattern-getSettings-Settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-ConstrainablePattern-getSettings-Settings" class="dfn-panel" data-for="term-for-widl-ConstrainablePattern-getSettings-Settings" id="infopanel-for-term-for-widl-ConstrainablePattern-getSettings-Settings" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-ConstrainablePattern-getSettings-Settings" style="display:none">Info about the 'getSettings()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-ConstrainablePattern-getSettings-Settings">https://www.w3.org/TR/mediacapture-streams/#widl-ConstrainablePattern-getSettings-Settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-ConstrainablePattern-getSettings-Settings">9. Extensions</a>
     <li><a href="#ref-for-widl-ConstrainablePattern-getSettings-Settings①">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints">https://www.w3.org/TR/mediacapture-streams/#widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints" class="dfn-panel" data-for="term-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints" id="infopanel-for-term-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints" style="display:none">Info about the 'getSupportedConstraints()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints">https://www.w3.org/TR/mediacapture-streams/#widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaDevices-getSupportedConstraints-MediaTrackSupportedConstraints">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia" id="infopanel-for-term-for-dom-mediadevices-getusermedia" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" style="display:none">Info about the 'getUserMedia()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadevices-getusermedia">9.2.1. Members</a>
     <li><a href="#ref-for-dom-mediadevices-getusermedia①">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-kind">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-kind">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-kind" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-kind" id="infopanel-for-term-for-widl-MediaStreamTrack-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-kind" style="display:none">Info about the 'kind' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-kind">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-kind">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.live">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.live" class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.live" id="infopanel-for-term-for-idl-def-MediaStreamTrackState.live" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.live" style="display:none">Info about the 'live' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaStreamTrackState.live">3.2. Methods</a> <a href="#ref-for-idl-def-MediaStreamTrackState.live①">(2)</a> <a href="#ref-for-idl-def-MediaStreamTrackState.live②">(3)</a> <a href="#ref-for-idl-def-MediaStreamTrackState.live③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-onmute">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onmute">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onmute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-onmute" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-onmute" id="infopanel-for-term-for-widl-MediaStreamTrack-onmute" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-onmute" style="display:none">Info about the 'onmute' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onmute">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onmute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-onmute">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-onunmute">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onunmute">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onunmute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-onunmute" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-onunmute" id="infopanel-for-term-for-widl-MediaStreamTrack-onunmute" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-onunmute" style="display:none">Info about the 'onunmute' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onunmute">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-onunmute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-onunmute">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-optional-basic-constraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dfn-optional-basic-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-optional-basic-constraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-optional-basic-constraints" class="dfn-panel" data-for="term-for-dfn-optional-basic-constraints" id="infopanel-for-term-for-dfn-optional-basic-constraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-optional-basic-constraints" style="display:none">Info about the 'optional basic constraints' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dfn-optional-basic-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-optional-basic-constraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-optional-basic-constraints">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-readyState">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-readyState">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-readyState</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-widl-MediaStreamTrack-readyState" class="dfn-panel" data-for="term-for-widl-MediaStreamTrack-readyState" id="infopanel-for-term-for-widl-MediaStreamTrack-readyState" role="menu">
+   <span id="infopaneltitle-for-term-for-widl-MediaStreamTrack-readyState" style="display:none">Info about the 'readyState' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-readyState">https://www.w3.org/TR/mediacapture-streams/#widl-MediaStreamTrack-readyState</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-widl-MediaStreamTrack-readyState">3.2. Methods</a> <a href="#ref-for-widl-MediaStreamTrack-readyState①">(2)</a> <a href="#ref-for-widl-MediaStreamTrack-readyState②">(3)</a> <a href="#ref-for-widl-MediaStreamTrack-readyState③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-required-constraints">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dfn-required-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-required-constraints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-required-constraints" class="dfn-panel" data-for="term-for-dfn-required-constraints" id="infopanel-for-term-for-dfn-required-constraints" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-required-constraints" style="display:none">Info about the 'required constraints' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dfn-required-constraints">https://www.w3.org/TR/mediacapture-streams/#dfn-required-constraints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-required-constraints">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visibilitystate" class="dfn-panel" data-for="term-for-dom-visibilitystate" id="infopanel-for-term-for-dom-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilitystate">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-visibilitystate①">(2)</a> <a href="#ref-for-dom-visibilitystate②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">1. Introduction</a>
     <li><a href="#ref-for-dfn-Blob①">3. Image Capture API</a> <a href="#ref-for-dfn-Blob②">(2)</a>
     <li><a href="#ref-for-dfn-Blob③">3.2. Methods</a> <a href="#ref-for-dfn-Blob④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastream">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastream">https://w3c.github.io/mediacapture-main/#dom-mediastream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastream" class="dfn-panel" data-for="term-for-dom-mediastream" id="infopanel-for-term-for-dom-mediastream" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastream" style="display:none">Info about the 'MediaStream' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastream">https://w3c.github.io/mediacapture-main/#dom-mediastream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastream">9.2.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-devicepermissiondescriptor-deviceid">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-devicepermissiondescriptor-deviceid">https://w3c.github.io/mediacapture-main/#dom-devicepermissiondescriptor-deviceid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-devicepermissiondescriptor-deviceid" class="dfn-panel" data-for="term-for-dom-devicepermissiondescriptor-deviceid" id="infopanel-for-term-for-dom-devicepermissiondescriptor-deviceid" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-devicepermissiondescriptor-deviceid" style="display:none">Info about the 'deviceId' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-devicepermissiondescriptor-deviceid">https://w3c.github.io/mediacapture-main/#dom-devicepermissiondescriptor-deviceid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicepermissiondescriptor-deviceid">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-devicepermissiondescriptor-deviceid①">(2)</a> <a href="#ref-for-dom-devicepermissiondescriptor-deviceid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-cameradevicepermissiondescriptor-pantiltzoom">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-cameradevicepermissiondescriptor-pantiltzoom">https://w3c.github.io/mediacapture-main/#dom-cameradevicepermissiondescriptor-pantiltzoom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-cameradevicepermissiondescriptor-pantiltzoom" class="dfn-panel" data-for="term-for-dom-cameradevicepermissiondescriptor-pantiltzoom" id="infopanel-for-term-for-dom-cameradevicepermissiondescriptor-pantiltzoom" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-cameradevicepermissiondescriptor-pantiltzoom" style="display:none">Info about the 'panTiltZoom' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-cameradevicepermissiondescriptor-pantiltzoom">https://w3c.github.io/mediacapture-main/#dom-cameradevicepermissiondescriptor-pantiltzoom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom">9.2.1. Members</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom①">(2)</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom②">(3)</a>
     <li><a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom③">9.4.1. Members</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom④">(2)</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom⑤">(3)</a>
     <li><a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom⑥">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom⑦">(2)</a> <a href="#ref-for-dom-cameradevicepermissiondescriptor-pantiltzoom⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagebitmap">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagebitmap" class="dfn-panel" data-for="term-for-imagebitmap" id="infopanel-for-term-for-imagebitmap" role="menu">
+   <span id="infopaneltitle-for-term-for-imagebitmap" style="display:none">Info about the 'ImageBitmap' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagebitmap">1. Introduction</a>
     <li><a href="#ref-for-imagebitmap①">3. Image Capture API</a> <a href="#ref-for-imagebitmap②">(2)</a>
     <li><a href="#ref-for-imagebitmap③">3.2. Methods</a> <a href="#ref-for-imagebitmap④">(2)</a> <a href="#ref-for-imagebitmap⑤">(3)</a> <a href="#ref-for-imagebitmap⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-imagebitmap-height">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-height">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-imagebitmap-height" class="dfn-panel" data-for="term-for-dom-imagebitmap-height" id="infopanel-for-term-for-dom-imagebitmap-height" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-imagebitmap-height" style="display:none">Info about the 'height' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-height">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagebitmap-height">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-top-level-browsing-context①">(2)</a> <a href="#ref-for-top-level-browsing-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-imagebitmap-width">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-imagebitmap-width" class="dfn-panel" data-for="term-for-dom-imagebitmap-width" id="infopanel-for-term-for-dom-imagebitmap-width" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-imagebitmap-width" style="display:none">Info about the 'width' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-imagebitmap-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagebitmap-width">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">9.2.1. Members</a> <a href="#ref-for-dfn-request-permission-to-use①">(2)</a> <a href="#ref-for-dfn-request-permission-to-use②">(3)</a>
     <li><a href="#ref-for-dfn-request-permission-to-use③">9.4.1. Members</a> <a href="#ref-for-dfn-request-permission-to-use④">(2)</a> <a href="#ref-for-dfn-request-permission-to-use⑤">(3)</a>
     <li><a href="#ref-for-dfn-request-permission-to-use⑥">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dfn-request-permission-to-use⑦">(2)</a> <a href="#ref-for-dfn-request-permission-to-use⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use①" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use①" style="display:none">Info about the 'requesting permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">9.2.1. Members</a> <a href="#ref-for-dfn-request-permission-to-use①">(2)</a> <a href="#ref-for-dfn-request-permission-to-use②">(3)</a>
     <li><a href="#ref-for-dfn-request-permission-to-use③">9.4.1. Members</a> <a href="#ref-for-dfn-request-permission-to-use④">(2)</a> <a href="#ref-for-dfn-request-permission-to-use⑤">(3)</a>
     <li><a href="#ref-for-dfn-request-permission-to-use⑥">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dfn-request-permission-to-use⑦">(2)</a> <a href="#ref-for-dfn-request-permission-to-use⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.2. Methods</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a> <a href="#ref-for-idl-DOMException⑥">(7)</a> <a href="#ref-for-idl-DOMException⑦">(8)</a> <a href="#ref-for-idl-DOMException⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">9.2. MediaTrackCapabilities dictionary</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">9.2.1. Members</a> <a href="#ref-for-idl-DOMString④">(2)</a> <a href="#ref-for-idl-DOMString⑤">(3)</a>
@@ -2149,56 +2149,56 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-idl-DOMString⑨">9.4.1. Members</a> <a href="#ref-for-idl-DOMString①⓪">(2)</a> <a href="#ref-for-idl-DOMString①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Image Capture API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.2. Methods</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-operationerror">
-   <a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-operationerror" class="dfn-panel" data-for="term-for-operationerror" id="infopanel-for-term-for-operationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-operationerror" style="display:none">Info about the 'OperationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#operationerror">https://webidl.spec.whatwg.org/#operationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-operationerror">3.2. Methods</a> <a href="#ref-for-operationerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. Image Capture API</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a> <a href="#ref-for-idl-promise④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-securityerror①">(2)</a> <a href="#ref-for-securityerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">3.2. Methods</a> <a href="#ref-for-unknownerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">3.2. Methods</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a> <a href="#ref-for-a-promise-rejected-with③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5. PhotoSettings</a>
     <li><a href="#ref-for-idl-boolean①">5.1. Members</a>
@@ -2211,8 +2211,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-idl-boolean④②">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5. PhotoSettings</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">5.1. Members</a> <a href="#ref-for-idl-double③">(2)</a>
@@ -2224,8 +2224,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-idl-double③⑥">12.1. Members</a> <a href="#ref-for-idl-double③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. PhotoCapabilities</a>
     <li><a href="#ref-for-idl-sequence①">9.2. MediaTrackCapabilities dictionary</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-sequence③">(3)</a>
@@ -2494,20 +2494,20 @@ For instance, embedding the user’s location in the metadata of the digitzed im
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="imagecapture">
-   <b><a href="#imagecapture">#imagecapture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-imagecapture" class="dfn-panel" data-for="imagecapture" id="infopanel-for-imagecapture" role="dialog">
+   <span id="infopaneltitle-for-imagecapture" style="display:none">Info about the 'ImageCapture' definition.</span><b><a href="#imagecapture">#imagecapture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagecapture">9. Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-takephoto-photosettings-photosettings">
-   <b><a href="#dom-imagecapture-takephoto-photosettings-photosettings">#dom-imagecapture-takephoto-photosettings-photosettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-takephoto-photosettings-photosettings" class="dfn-panel" data-for="dom-imagecapture-takephoto-photosettings-photosettings" id="infopanel-for-dom-imagecapture-takephoto-photosettings-photosettings" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-takephoto-photosettings-photosettings" style="display:none">Info about the 'photoSettings' definition.</span><b><a href="#dom-imagecapture-takephoto-photosettings-photosettings">#dom-imagecapture-takephoto-photosettings-photosettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-takephoto-photosettings-photosettings">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-track">
-   <b><a href="#dom-imagecapture-track">#dom-imagecapture-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-track" class="dfn-panel" data-for="dom-imagecapture-track" id="infopanel-for-dom-imagecapture-track" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-track" style="display:none">Info about the 'track' definition.</span><b><a href="#dom-imagecapture-track">#dom-imagecapture-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-track">3. Image Capture API</a> <a href="#ref-for-dom-imagecapture-track①">(2)</a>
     <li><a href="#ref-for-dom-imagecapture-track②">3.2. Methods</a> <a href="#ref-for-dom-imagecapture-track③">(2)</a> <a href="#ref-for-dom-imagecapture-track④">(3)</a> <a href="#ref-for-dom-imagecapture-track⑤">(4)</a> <a href="#ref-for-dom-imagecapture-track⑥">(5)</a> <a href="#ref-for-dom-imagecapture-track⑦">(6)</a> <a href="#ref-for-dom-imagecapture-track⑧">(7)</a> <a href="#ref-for-dom-imagecapture-track⑨">(8)</a> <a href="#ref-for-dom-imagecapture-track①⓪">(9)</a> <a href="#ref-for-dom-imagecapture-track①①">(10)</a> <a href="#ref-for-dom-imagecapture-track①②">(11)</a> <a href="#ref-for-dom-imagecapture-track①③">(12)</a>
@@ -2515,14 +2515,14 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-dom-imagecapture-track①⑤">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-imagecapture">
-   <b><a href="#dom-imagecapture-imagecapture">#dom-imagecapture-imagecapture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-imagecapture" class="dfn-panel" data-for="dom-imagecapture-imagecapture" id="infopanel-for-dom-imagecapture-imagecapture" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-imagecapture" style="display:none">Info about the 'ImageCapture(MediaStreamTrack videoTrack)' definition.</span><b><a href="#dom-imagecapture-imagecapture">#dom-imagecapture-imagecapture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-imagecapture">3. Image Capture API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-takephoto">
-   <b><a href="#dom-imagecapture-takephoto">#dom-imagecapture-takephoto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-takephoto" class="dfn-panel" data-for="dom-imagecapture-takephoto" id="infopanel-for-dom-imagecapture-takephoto" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-takephoto" style="display:none">Info about the 'takePhoto(optional PhotoSettings photoSettings)' definition.</span><b><a href="#dom-imagecapture-takephoto">#dom-imagecapture-takephoto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-takephoto">1. Introduction</a> <a href="#ref-for-dom-imagecapture-takephoto①">(2)</a>
     <li><a href="#ref-for-dom-imagecapture-takephoto②">3. Image Capture API</a> <a href="#ref-for-dom-imagecapture-takephoto③">(2)</a>
@@ -2532,24 +2532,24 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-dom-imagecapture-takephoto①①">13.4. Update camera focus distance and takePhoto()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-getphotocapabilities">
-   <b><a href="#dom-imagecapture-getphotocapabilities">#dom-imagecapture-getphotocapabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-getphotocapabilities" class="dfn-panel" data-for="dom-imagecapture-getphotocapabilities" id="infopanel-for-dom-imagecapture-getphotocapabilities" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-getphotocapabilities" style="display:none">Info about the 'getPhotoCapabilities()' definition.</span><b><a href="#dom-imagecapture-getphotocapabilities">#dom-imagecapture-getphotocapabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-getphotocapabilities">1. Introduction</a>
     <li><a href="#ref-for-dom-imagecapture-getphotocapabilities①">3. Image Capture API</a>
     <li><a href="#ref-for-dom-imagecapture-getphotocapabilities②">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-getphotosettings">
-   <b><a href="#dom-imagecapture-getphotosettings">#dom-imagecapture-getphotosettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-getphotosettings" class="dfn-panel" data-for="dom-imagecapture-getphotosettings" id="infopanel-for-dom-imagecapture-getphotosettings" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-getphotosettings" style="display:none">Info about the 'getPhotoSettings()' definition.</span><b><a href="#dom-imagecapture-getphotosettings">#dom-imagecapture-getphotosettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-getphotosettings">1. Introduction</a>
     <li><a href="#ref-for-dom-imagecapture-getphotosettings①">3. Image Capture API</a>
     <li><a href="#ref-for-dom-imagecapture-getphotosettings②">3.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-imagecapture-grabframe">
-   <b><a href="#dom-imagecapture-grabframe">#dom-imagecapture-grabframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-imagecapture-grabframe" class="dfn-panel" data-for="dom-imagecapture-grabframe" id="infopanel-for-dom-imagecapture-grabframe" role="dialog">
+   <span id="infopaneltitle-for-dom-imagecapture-grabframe" style="display:none">Info about the 'grabFrame()' definition.</span><b><a href="#dom-imagecapture-grabframe">#dom-imagecapture-grabframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imagecapture-grabframe">1. Introduction</a>
     <li><a href="#ref-for-dom-imagecapture-grabframe①">3. Image Capture API</a> <a href="#ref-for-dom-imagecapture-grabframe②">(2)</a>
@@ -2557,76 +2557,76 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-dom-imagecapture-grabframe⑥">13.2. Repeated grabbing of a frame with grabFrame()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-photocapabilities">
-   <b><a href="#dictdef-photocapabilities">#dictdef-photocapabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-photocapabilities" class="dfn-panel" data-for="dictdef-photocapabilities" id="infopanel-for-dictdef-photocapabilities" role="dialog">
+   <span id="infopaneltitle-for-dictdef-photocapabilities" style="display:none">Info about the 'PhotoCapabilities' definition.</span><b><a href="#dictdef-photocapabilities">#dictdef-photocapabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-photocapabilities">3. Image Capture API</a>
     <li><a href="#ref-for-dictdef-photocapabilities①">3.2. Methods</a> <a href="#ref-for-dictdef-photocapabilities②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photocapabilities-redeyereduction">
-   <b><a href="#dom-photocapabilities-redeyereduction">#dom-photocapabilities-redeyereduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photocapabilities-redeyereduction" class="dfn-panel" data-for="dom-photocapabilities-redeyereduction" id="infopanel-for-dom-photocapabilities-redeyereduction" role="dialog">
+   <span id="infopaneltitle-for-dom-photocapabilities-redeyereduction" style="display:none">Info about the 'redEyeReduction' definition.</span><b><a href="#dom-photocapabilities-redeyereduction">#dom-photocapabilities-redeyereduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photocapabilities-redeyereduction">4. PhotoCapabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photocapabilities-imageheight">
-   <b><a href="#dom-photocapabilities-imageheight">#dom-photocapabilities-imageheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photocapabilities-imageheight" class="dfn-panel" data-for="dom-photocapabilities-imageheight" id="infopanel-for-dom-photocapabilities-imageheight" role="dialog">
+   <span id="infopaneltitle-for-dom-photocapabilities-imageheight" style="display:none">Info about the 'imageHeight' definition.</span><b><a href="#dom-photocapabilities-imageheight">#dom-photocapabilities-imageheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photocapabilities-imageheight">4. PhotoCapabilities</a>
     <li><a href="#ref-for-dom-photocapabilities-imageheight①">4.1. Members</a>
     <li><a href="#ref-for-dom-photocapabilities-imageheight②">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photocapabilities-imagewidth">
-   <b><a href="#dom-photocapabilities-imagewidth">#dom-photocapabilities-imagewidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photocapabilities-imagewidth" class="dfn-panel" data-for="dom-photocapabilities-imagewidth" id="infopanel-for-dom-photocapabilities-imagewidth" role="dialog">
+   <span id="infopaneltitle-for-dom-photocapabilities-imagewidth" style="display:none">Info about the 'imageWidth' definition.</span><b><a href="#dom-photocapabilities-imagewidth">#dom-photocapabilities-imagewidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photocapabilities-imagewidth">4. PhotoCapabilities</a>
     <li><a href="#ref-for-dom-photocapabilities-imagewidth①">4.1. Members</a>
     <li><a href="#ref-for-dom-photocapabilities-imagewidth②">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photocapabilities-filllightmode">
-   <b><a href="#dom-photocapabilities-filllightmode">#dom-photocapabilities-filllightmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photocapabilities-filllightmode" class="dfn-panel" data-for="dom-photocapabilities-filllightmode" id="infopanel-for-dom-photocapabilities-filllightmode" role="dialog">
+   <span id="infopaneltitle-for-dom-photocapabilities-filllightmode" style="display:none">Info about the 'fillLightMode' definition.</span><b><a href="#dom-photocapabilities-filllightmode">#dom-photocapabilities-filllightmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photocapabilities-filllightmode">4. PhotoCapabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-photosettings">
-   <b><a href="#dictdef-photosettings">#dictdef-photosettings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-photosettings" class="dfn-panel" data-for="dictdef-photosettings" id="infopanel-for-dictdef-photosettings" role="dialog">
+   <span id="infopaneltitle-for-dictdef-photosettings" style="display:none">Info about the 'PhotoSettings' definition.</span><b><a href="#dictdef-photosettings">#dictdef-photosettings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-photosettings">1. Introduction</a>
     <li><a href="#ref-for-dictdef-photosettings①">3. Image Capture API</a> <a href="#ref-for-dictdef-photosettings②">(2)</a>
     <li><a href="#ref-for-dictdef-photosettings③">3.2. Methods</a> <a href="#ref-for-dictdef-photosettings④">(2)</a> <a href="#ref-for-dictdef-photosettings⑤">(3)</a> <a href="#ref-for-dictdef-photosettings⑥">(4)</a> <a href="#ref-for-dictdef-photosettings⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photosettings-redeyereduction">
-   <b><a href="#dom-photosettings-redeyereduction">#dom-photosettings-redeyereduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photosettings-redeyereduction" class="dfn-panel" data-for="dom-photosettings-redeyereduction" id="infopanel-for-dom-photosettings-redeyereduction" role="dialog">
+   <span id="infopaneltitle-for-dom-photosettings-redeyereduction" style="display:none">Info about the 'redEyeReduction' definition.</span><b><a href="#dom-photosettings-redeyereduction">#dom-photosettings-redeyereduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photosettings-redeyereduction">5. PhotoSettings</a>
     <li><a href="#ref-for-dom-photosettings-redeyereduction①">7.1. Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photosettings-imageheight">
-   <b><a href="#dom-photosettings-imageheight">#dom-photosettings-imageheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photosettings-imageheight" class="dfn-panel" data-for="dom-photosettings-imageheight" id="infopanel-for-dom-photosettings-imageheight" role="dialog">
+   <span id="infopaneltitle-for-dom-photosettings-imageheight" style="display:none">Info about the 'imageHeight' definition.</span><b><a href="#dom-photosettings-imageheight">#dom-photosettings-imageheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photosettings-imageheight">5. PhotoSettings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photosettings-imagewidth">
-   <b><a href="#dom-photosettings-imagewidth">#dom-photosettings-imagewidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photosettings-imagewidth" class="dfn-panel" data-for="dom-photosettings-imagewidth" id="infopanel-for-dom-photosettings-imagewidth" role="dialog">
+   <span id="infopaneltitle-for-dom-photosettings-imagewidth" style="display:none">Info about the 'imageWidth' definition.</span><b><a href="#dom-photosettings-imagewidth">#dom-photosettings-imagewidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photosettings-imagewidth">5. PhotoSettings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-photosettings-filllightmode">
-   <b><a href="#dom-photosettings-filllightmode">#dom-photosettings-filllightmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-photosettings-filllightmode" class="dfn-panel" data-for="dom-photosettings-filllightmode" id="infopanel-for-dom-photosettings-filllightmode" role="dialog">
+   <span id="infopaneltitle-for-dom-photosettings-filllightmode" style="display:none">Info about the 'fillLightMode' definition.</span><b><a href="#dom-photosettings-filllightmode">#dom-photosettings-filllightmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-photosettings-filllightmode">5. PhotoSettings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediasettingsrange">
-   <b><a href="#dictdef-mediasettingsrange">#dictdef-mediasettingsrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediasettingsrange" class="dfn-panel" data-for="dictdef-mediasettingsrange" id="infopanel-for-dictdef-mediasettingsrange" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediasettingsrange" style="display:none">Info about the 'MediaSettingsRange' definition.</span><b><a href="#dictdef-mediasettingsrange">#dictdef-mediasettingsrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediasettingsrange">4. PhotoCapabilities</a> <a href="#ref-for-dictdef-mediasettingsrange①">(2)</a>
     <li><a href="#ref-for-dictdef-mediasettingsrange②">4.1. Members</a> <a href="#ref-for-dictdef-mediasettingsrange③">(2)</a>
@@ -2635,52 +2635,52 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-dictdef-mediasettingsrange①⑦">9.2.1. Members</a> <a href="#ref-for-dictdef-mediasettingsrange①⑧">(2)</a> <a href="#ref-for-dictdef-mediasettingsrange①⑨">(3)</a> <a href="#ref-for-dictdef-mediasettingsrange②⓪">(4)</a> <a href="#ref-for-dictdef-mediasettingsrange②①">(5)</a> <a href="#ref-for-dictdef-mediasettingsrange②②">(6)</a> <a href="#ref-for-dictdef-mediasettingsrange②③">(7)</a> <a href="#ref-for-dictdef-mediasettingsrange②④">(8)</a> <a href="#ref-for-dictdef-mediasettingsrange②⑤">(9)</a> <a href="#ref-for-dictdef-mediasettingsrange②⑥">(10)</a> <a href="#ref-for-dictdef-mediasettingsrange②⑦">(11)</a> <a href="#ref-for-dictdef-mediasettingsrange②⑧">(12)</a> <a href="#ref-for-dictdef-mediasettingsrange②⑨">(13)</a> <a href="#ref-for-dictdef-mediasettingsrange③⓪">(14)</a> <a href="#ref-for-dictdef-mediasettingsrange③①">(15)</a> <a href="#ref-for-dictdef-mediasettingsrange③②">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasettingsrange-max">
-   <b><a href="#dom-mediasettingsrange-max">#dom-mediasettingsrange-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasettingsrange-max" class="dfn-panel" data-for="dom-mediasettingsrange-max" id="infopanel-for-dom-mediasettingsrange-max" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasettingsrange-max" style="display:none">Info about the 'max' definition.</span><b><a href="#dom-mediasettingsrange-max">#dom-mediasettingsrange-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasettingsrange-max">6. MediaSettingsRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasettingsrange-min">
-   <b><a href="#dom-mediasettingsrange-min">#dom-mediasettingsrange-min</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasettingsrange-min" class="dfn-panel" data-for="dom-mediasettingsrange-min" id="infopanel-for-dom-mediasettingsrange-min" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasettingsrange-min" style="display:none">Info about the 'min' definition.</span><b><a href="#dom-mediasettingsrange-min">#dom-mediasettingsrange-min</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasettingsrange-min">6. MediaSettingsRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasettingsrange-step">
-   <b><a href="#dom-mediasettingsrange-step">#dom-mediasettingsrange-step</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasettingsrange-step" class="dfn-panel" data-for="dom-mediasettingsrange-step" id="infopanel-for-dom-mediasettingsrange-step" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasettingsrange-step" style="display:none">Info about the 'step' definition.</span><b><a href="#dom-mediasettingsrange-step">#dom-mediasettingsrange-step</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasettingsrange-step">6. MediaSettingsRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-redeyereduction">
-   <b><a href="#enumdef-redeyereduction">#enumdef-redeyereduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-redeyereduction" class="dfn-panel" data-for="enumdef-redeyereduction" id="infopanel-for-enumdef-redeyereduction" role="dialog">
+   <span id="infopaneltitle-for-enumdef-redeyereduction" style="display:none">Info about the 'RedEyeReduction' definition.</span><b><a href="#enumdef-redeyereduction">#enumdef-redeyereduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-redeyereduction">4. PhotoCapabilities</a>
     <li><a href="#ref-for-enumdef-redeyereduction①">4.1. Members</a>
     <li><a href="#ref-for-enumdef-redeyereduction②">7. RedEyeReduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-redeyereduction-never">
-   <b><a href="#dom-redeyereduction-never">#dom-redeyereduction-never</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-redeyereduction-never" class="dfn-panel" data-for="dom-redeyereduction-never" id="infopanel-for-dom-redeyereduction-never" role="dialog">
+   <span id="infopaneltitle-for-dom-redeyereduction-never" style="display:none">Info about the 'never' definition.</span><b><a href="#dom-redeyereduction-never">#dom-redeyereduction-never</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-redeyereduction-never">7. RedEyeReduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-redeyereduction-always">
-   <b><a href="#dom-redeyereduction-always">#dom-redeyereduction-always</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-redeyereduction-always" class="dfn-panel" data-for="dom-redeyereduction-always" id="infopanel-for-dom-redeyereduction-always" role="dialog">
+   <span id="infopaneltitle-for-dom-redeyereduction-always" style="display:none">Info about the 'always' definition.</span><b><a href="#dom-redeyereduction-always">#dom-redeyereduction-always</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-redeyereduction-always">7. RedEyeReduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-redeyereduction-controllable">
-   <b><a href="#dom-redeyereduction-controllable">#dom-redeyereduction-controllable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-redeyereduction-controllable" class="dfn-panel" data-for="dom-redeyereduction-controllable" id="infopanel-for-dom-redeyereduction-controllable" role="dialog">
+   <span id="infopaneltitle-for-dom-redeyereduction-controllable" style="display:none">Info about the 'controllable' definition.</span><b><a href="#dom-redeyereduction-controllable">#dom-redeyereduction-controllable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-redeyereduction-controllable">7. RedEyeReduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-filllightmode">
-   <b><a href="#enumdef-filllightmode">#enumdef-filllightmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-filllightmode" class="dfn-panel" data-for="enumdef-filllightmode" id="infopanel-for-enumdef-filllightmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-filllightmode" style="display:none">Info about the 'FillLightMode' definition.</span><b><a href="#enumdef-filllightmode">#enumdef-filllightmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-filllightmode">4. PhotoCapabilities</a>
     <li><a href="#ref-for-enumdef-filllightmode①">4.1. Members</a>
@@ -2689,460 +2689,460 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-enumdef-filllightmode④">8. FillLightMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filllightmode-auto">
-   <b><a href="#dom-filllightmode-auto">#dom-filllightmode-auto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filllightmode-auto" class="dfn-panel" data-for="dom-filllightmode-auto" id="infopanel-for-dom-filllightmode-auto" role="dialog">
+   <span id="infopaneltitle-for-dom-filllightmode-auto" style="display:none">Info about the 'auto' definition.</span><b><a href="#dom-filllightmode-auto">#dom-filllightmode-auto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filllightmode-auto">8. FillLightMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filllightmode-off">
-   <b><a href="#dom-filllightmode-off">#dom-filllightmode-off</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filllightmode-off" class="dfn-panel" data-for="dom-filllightmode-off" id="infopanel-for-dom-filllightmode-off" role="dialog">
+   <span id="infopaneltitle-for-dom-filllightmode-off" style="display:none">Info about the 'off' definition.</span><b><a href="#dom-filllightmode-off">#dom-filllightmode-off</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filllightmode-off">8. FillLightMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-filllightmode-flash">
-   <b><a href="#dom-filllightmode-flash">#dom-filllightmode-flash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-filllightmode-flash" class="dfn-panel" data-for="dom-filllightmode-flash" id="infopanel-for-dom-filllightmode-flash" role="dialog">
+   <span id="infopaneltitle-for-dom-filllightmode-flash" style="display:none">Info about the 'flash' definition.</span><b><a href="#dom-filllightmode-flash">#dom-filllightmode-flash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-filllightmode-flash">8. FillLightMode</a>
     <li><a href="#ref-for-dom-filllightmode-flash①">8.1. Values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-whitebalancemode">
-   <b><a href="#dom-mediatracksupportedconstraints-whitebalancemode">#dom-mediatracksupportedconstraints-whitebalancemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-whitebalancemode" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-whitebalancemode" id="infopanel-for-dom-mediatracksupportedconstraints-whitebalancemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-whitebalancemode" style="display:none">Info about the 'whiteBalanceMode' definition.</span><b><a href="#dom-mediatracksupportedconstraints-whitebalancemode">#dom-mediatracksupportedconstraints-whitebalancemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-whitebalancemode">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-colortemperature">
-   <b><a href="#dom-mediatracksupportedconstraints-colortemperature">#dom-mediatracksupportedconstraints-colortemperature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-colortemperature" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-colortemperature" id="infopanel-for-dom-mediatracksupportedconstraints-colortemperature" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-colortemperature" style="display:none">Info about the 'colorTemperature' definition.</span><b><a href="#dom-mediatracksupportedconstraints-colortemperature">#dom-mediatracksupportedconstraints-colortemperature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-colortemperature">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposuremode">
-   <b><a href="#dom-mediatracksupportedconstraints-exposuremode">#dom-mediatracksupportedconstraints-exposuremode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-exposuremode" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposuremode" id="infopanel-for-dom-mediatracksupportedconstraints-exposuremode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-exposuremode" style="display:none">Info about the 'exposureMode' definition.</span><b><a href="#dom-mediatracksupportedconstraints-exposuremode">#dom-mediatracksupportedconstraints-exposuremode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-exposuremode">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposurecompensation">
-   <b><a href="#dom-mediatracksupportedconstraints-exposurecompensation">#dom-mediatracksupportedconstraints-exposurecompensation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-exposurecompensation" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposurecompensation" id="infopanel-for-dom-mediatracksupportedconstraints-exposurecompensation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-exposurecompensation" style="display:none">Info about the 'exposureCompensation' definition.</span><b><a href="#dom-mediatracksupportedconstraints-exposurecompensation">#dom-mediatracksupportedconstraints-exposurecompensation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-exposurecompensation">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposuretime">
-   <b><a href="#dom-mediatracksupportedconstraints-exposuretime">#dom-mediatracksupportedconstraints-exposuretime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-exposuretime" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-exposuretime" id="infopanel-for-dom-mediatracksupportedconstraints-exposuretime" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-exposuretime" style="display:none">Info about the 'exposureTime' definition.</span><b><a href="#dom-mediatracksupportedconstraints-exposuretime">#dom-mediatracksupportedconstraints-exposuretime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-exposuretime">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-iso">
-   <b><a href="#dom-mediatracksupportedconstraints-iso">#dom-mediatracksupportedconstraints-iso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-iso" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-iso" id="infopanel-for-dom-mediatracksupportedconstraints-iso" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-iso" style="display:none">Info about the 'iso' definition.</span><b><a href="#dom-mediatracksupportedconstraints-iso">#dom-mediatracksupportedconstraints-iso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-iso">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-focusmode">
-   <b><a href="#dom-mediatracksupportedconstraints-focusmode">#dom-mediatracksupportedconstraints-focusmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-focusmode" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-focusmode" id="infopanel-for-dom-mediatracksupportedconstraints-focusmode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-focusmode" style="display:none">Info about the 'focusMode' definition.</span><b><a href="#dom-mediatracksupportedconstraints-focusmode">#dom-mediatracksupportedconstraints-focusmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-focusmode">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-pointsofinterest">
-   <b><a href="#dom-mediatracksupportedconstraints-pointsofinterest">#dom-mediatracksupportedconstraints-pointsofinterest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-pointsofinterest" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-pointsofinterest" id="infopanel-for-dom-mediatracksupportedconstraints-pointsofinterest" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-pointsofinterest" style="display:none">Info about the 'pointsOfInterest' definition.</span><b><a href="#dom-mediatracksupportedconstraints-pointsofinterest">#dom-mediatracksupportedconstraints-pointsofinterest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-pointsofinterest">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-brightness">
-   <b><a href="#dom-mediatracksupportedconstraints-brightness">#dom-mediatracksupportedconstraints-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-brightness" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-brightness" id="infopanel-for-dom-mediatracksupportedconstraints-brightness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-brightness" style="display:none">Info about the 'brightness' definition.</span><b><a href="#dom-mediatracksupportedconstraints-brightness">#dom-mediatracksupportedconstraints-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-brightness">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-contrast">
-   <b><a href="#dom-mediatracksupportedconstraints-contrast">#dom-mediatracksupportedconstraints-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-contrast" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-contrast" id="infopanel-for-dom-mediatracksupportedconstraints-contrast" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-contrast" style="display:none">Info about the 'contrast' definition.</span><b><a href="#dom-mediatracksupportedconstraints-contrast">#dom-mediatracksupportedconstraints-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-contrast">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-pan">
-   <b><a href="#dom-mediatracksupportedconstraints-pan">#dom-mediatracksupportedconstraints-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-pan" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-pan" id="infopanel-for-dom-mediatracksupportedconstraints-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-mediatracksupportedconstraints-pan">#dom-mediatracksupportedconstraints-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-pan">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-saturation">
-   <b><a href="#dom-mediatracksupportedconstraints-saturation">#dom-mediatracksupportedconstraints-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-saturation" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-saturation" id="infopanel-for-dom-mediatracksupportedconstraints-saturation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#dom-mediatracksupportedconstraints-saturation">#dom-mediatracksupportedconstraints-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-saturation">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-sharpness">
-   <b><a href="#dom-mediatracksupportedconstraints-sharpness">#dom-mediatracksupportedconstraints-sharpness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-sharpness" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-sharpness" id="infopanel-for-dom-mediatracksupportedconstraints-sharpness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-sharpness" style="display:none">Info about the 'sharpness' definition.</span><b><a href="#dom-mediatracksupportedconstraints-sharpness">#dom-mediatracksupportedconstraints-sharpness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-sharpness">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-focusdistance">
-   <b><a href="#dom-mediatracksupportedconstraints-focusdistance">#dom-mediatracksupportedconstraints-focusdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-focusdistance" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-focusdistance" id="infopanel-for-dom-mediatracksupportedconstraints-focusdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-focusdistance" style="display:none">Info about the 'focusDistance' definition.</span><b><a href="#dom-mediatracksupportedconstraints-focusdistance">#dom-mediatracksupportedconstraints-focusdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-focusdistance">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-tilt">
-   <b><a href="#dom-mediatracksupportedconstraints-tilt">#dom-mediatracksupportedconstraints-tilt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-tilt" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-tilt" id="infopanel-for-dom-mediatracksupportedconstraints-tilt" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-tilt" style="display:none">Info about the 'tilt' definition.</span><b><a href="#dom-mediatracksupportedconstraints-tilt">#dom-mediatracksupportedconstraints-tilt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-tilt">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-zoom">
-   <b><a href="#dom-mediatracksupportedconstraints-zoom">#dom-mediatracksupportedconstraints-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-zoom" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-zoom" id="infopanel-for-dom-mediatracksupportedconstraints-zoom" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#dom-mediatracksupportedconstraints-zoom">#dom-mediatracksupportedconstraints-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-zoom">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksupportedconstraints-torch">
-   <b><a href="#dom-mediatracksupportedconstraints-torch">#dom-mediatracksupportedconstraints-torch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksupportedconstraints-torch" class="dfn-panel" data-for="dom-mediatracksupportedconstraints-torch" id="infopanel-for-dom-mediatracksupportedconstraints-torch" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksupportedconstraints-torch" style="display:none">Info about the 'torch' definition.</span><b><a href="#dom-mediatracksupportedconstraints-torch">#dom-mediatracksupportedconstraints-torch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksupportedconstraints-torch">9.1. MediaTrackSupportedConstraints dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-whitebalancemode">
-   <b><a href="#dom-mediatrackcapabilities-whitebalancemode">#dom-mediatrackcapabilities-whitebalancemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-whitebalancemode" class="dfn-panel" data-for="dom-mediatrackcapabilities-whitebalancemode" id="infopanel-for-dom-mediatrackcapabilities-whitebalancemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-whitebalancemode" style="display:none">Info about the 'whiteBalanceMode' definition.</span><b><a href="#dom-mediatrackcapabilities-whitebalancemode">#dom-mediatrackcapabilities-whitebalancemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-whitebalancemode">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-colortemperature">
-   <b><a href="#dom-mediatrackcapabilities-colortemperature">#dom-mediatrackcapabilities-colortemperature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-colortemperature" class="dfn-panel" data-for="dom-mediatrackcapabilities-colortemperature" id="infopanel-for-dom-mediatrackcapabilities-colortemperature" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-colortemperature" style="display:none">Info about the 'colorTemperature' definition.</span><b><a href="#dom-mediatrackcapabilities-colortemperature">#dom-mediatrackcapabilities-colortemperature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-colortemperature">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-exposuremode">
-   <b><a href="#dom-mediatrackcapabilities-exposuremode">#dom-mediatrackcapabilities-exposuremode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-exposuremode" class="dfn-panel" data-for="dom-mediatrackcapabilities-exposuremode" id="infopanel-for-dom-mediatrackcapabilities-exposuremode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-exposuremode" style="display:none">Info about the 'exposureMode' definition.</span><b><a href="#dom-mediatrackcapabilities-exposuremode">#dom-mediatrackcapabilities-exposuremode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-exposuremode">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-exposurecompensation">
-   <b><a href="#dom-mediatrackcapabilities-exposurecompensation">#dom-mediatrackcapabilities-exposurecompensation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-exposurecompensation" class="dfn-panel" data-for="dom-mediatrackcapabilities-exposurecompensation" id="infopanel-for-dom-mediatrackcapabilities-exposurecompensation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-exposurecompensation" style="display:none">Info about the 'exposureCompensation' definition.</span><b><a href="#dom-mediatrackcapabilities-exposurecompensation">#dom-mediatrackcapabilities-exposurecompensation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-exposurecompensation">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-exposuretime">
-   <b><a href="#dom-mediatrackcapabilities-exposuretime">#dom-mediatrackcapabilities-exposuretime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-exposuretime" class="dfn-panel" data-for="dom-mediatrackcapabilities-exposuretime" id="infopanel-for-dom-mediatrackcapabilities-exposuretime" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-exposuretime" style="display:none">Info about the 'exposureTime' definition.</span><b><a href="#dom-mediatrackcapabilities-exposuretime">#dom-mediatrackcapabilities-exposuretime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-exposuretime">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-iso">
-   <b><a href="#dom-mediatrackcapabilities-iso">#dom-mediatrackcapabilities-iso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-iso" class="dfn-panel" data-for="dom-mediatrackcapabilities-iso" id="infopanel-for-dom-mediatrackcapabilities-iso" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-iso" style="display:none">Info about the 'iso' definition.</span><b><a href="#dom-mediatrackcapabilities-iso">#dom-mediatrackcapabilities-iso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-iso">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-focusmode">
-   <b><a href="#dom-mediatrackcapabilities-focusmode">#dom-mediatrackcapabilities-focusmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-focusmode" class="dfn-panel" data-for="dom-mediatrackcapabilities-focusmode" id="infopanel-for-dom-mediatrackcapabilities-focusmode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-focusmode" style="display:none">Info about the 'focusMode' definition.</span><b><a href="#dom-mediatrackcapabilities-focusmode">#dom-mediatrackcapabilities-focusmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-focusmode">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-brightness">
-   <b><a href="#dom-mediatrackcapabilities-brightness">#dom-mediatrackcapabilities-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-brightness" class="dfn-panel" data-for="dom-mediatrackcapabilities-brightness" id="infopanel-for-dom-mediatrackcapabilities-brightness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-brightness" style="display:none">Info about the 'brightness' definition.</span><b><a href="#dom-mediatrackcapabilities-brightness">#dom-mediatrackcapabilities-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-brightness">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-contrast">
-   <b><a href="#dom-mediatrackcapabilities-contrast">#dom-mediatrackcapabilities-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-contrast" class="dfn-panel" data-for="dom-mediatrackcapabilities-contrast" id="infopanel-for-dom-mediatrackcapabilities-contrast" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-contrast" style="display:none">Info about the 'contrast' definition.</span><b><a href="#dom-mediatrackcapabilities-contrast">#dom-mediatrackcapabilities-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-contrast">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-pan">
-   <b><a href="#dom-mediatrackcapabilities-pan">#dom-mediatrackcapabilities-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-pan" class="dfn-panel" data-for="dom-mediatrackcapabilities-pan" id="infopanel-for-dom-mediatrackcapabilities-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-mediatrackcapabilities-pan">#dom-mediatrackcapabilities-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-pan">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-saturation">
-   <b><a href="#dom-mediatrackcapabilities-saturation">#dom-mediatrackcapabilities-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-saturation" class="dfn-panel" data-for="dom-mediatrackcapabilities-saturation" id="infopanel-for-dom-mediatrackcapabilities-saturation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#dom-mediatrackcapabilities-saturation">#dom-mediatrackcapabilities-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-saturation">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-sharpness">
-   <b><a href="#dom-mediatrackcapabilities-sharpness">#dom-mediatrackcapabilities-sharpness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-sharpness" class="dfn-panel" data-for="dom-mediatrackcapabilities-sharpness" id="infopanel-for-dom-mediatrackcapabilities-sharpness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-sharpness" style="display:none">Info about the 'sharpness' definition.</span><b><a href="#dom-mediatrackcapabilities-sharpness">#dom-mediatrackcapabilities-sharpness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-sharpness">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-focusdistance">
-   <b><a href="#dom-mediatrackcapabilities-focusdistance">#dom-mediatrackcapabilities-focusdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-focusdistance" class="dfn-panel" data-for="dom-mediatrackcapabilities-focusdistance" id="infopanel-for-dom-mediatrackcapabilities-focusdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-focusdistance" style="display:none">Info about the 'focusDistance' definition.</span><b><a href="#dom-mediatrackcapabilities-focusdistance">#dom-mediatrackcapabilities-focusdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-focusdistance">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-tilt">
-   <b><a href="#dom-mediatrackcapabilities-tilt">#dom-mediatrackcapabilities-tilt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-tilt" class="dfn-panel" data-for="dom-mediatrackcapabilities-tilt" id="infopanel-for-dom-mediatrackcapabilities-tilt" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-tilt" style="display:none">Info about the 'tilt' definition.</span><b><a href="#dom-mediatrackcapabilities-tilt">#dom-mediatrackcapabilities-tilt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-tilt">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-zoom">
-   <b><a href="#dom-mediatrackcapabilities-zoom">#dom-mediatrackcapabilities-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-zoom" class="dfn-panel" data-for="dom-mediatrackcapabilities-zoom" id="infopanel-for-dom-mediatrackcapabilities-zoom" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#dom-mediatrackcapabilities-zoom">#dom-mediatrackcapabilities-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-zoom">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackcapabilities-torch">
-   <b><a href="#dom-mediatrackcapabilities-torch">#dom-mediatrackcapabilities-torch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackcapabilities-torch" class="dfn-panel" data-for="dom-mediatrackcapabilities-torch" id="infopanel-for-dom-mediatrackcapabilities-torch" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackcapabilities-torch" style="display:none">Info about the 'torch' definition.</span><b><a href="#dom-mediatrackcapabilities-torch">#dom-mediatrackcapabilities-torch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackcapabilities-torch">9.2. MediaTrackCapabilities dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-whitebalancemode">
-   <b><a href="#dom-mediatrackconstraintset-whitebalancemode">#dom-mediatrackconstraintset-whitebalancemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-whitebalancemode" class="dfn-panel" data-for="dom-mediatrackconstraintset-whitebalancemode" id="infopanel-for-dom-mediatrackconstraintset-whitebalancemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-whitebalancemode" style="display:none">Info about the 'whiteBalanceMode' definition.</span><b><a href="#dom-mediatrackconstraintset-whitebalancemode">#dom-mediatrackconstraintset-whitebalancemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-whitebalancemode">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-exposuremode">
-   <b><a href="#dom-mediatrackconstraintset-exposuremode">#dom-mediatrackconstraintset-exposuremode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-exposuremode" class="dfn-panel" data-for="dom-mediatrackconstraintset-exposuremode" id="infopanel-for-dom-mediatrackconstraintset-exposuremode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-exposuremode" style="display:none">Info about the 'exposureMode' definition.</span><b><a href="#dom-mediatrackconstraintset-exposuremode">#dom-mediatrackconstraintset-exposuremode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-exposuremode">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-focusmode">
-   <b><a href="#dom-mediatrackconstraintset-focusmode">#dom-mediatrackconstraintset-focusmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-focusmode" class="dfn-panel" data-for="dom-mediatrackconstraintset-focusmode" id="infopanel-for-dom-mediatrackconstraintset-focusmode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-focusmode" style="display:none">Info about the 'focusMode' definition.</span><b><a href="#dom-mediatrackconstraintset-focusmode">#dom-mediatrackconstraintset-focusmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-focusmode">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-colortemperature">
-   <b><a href="#dom-mediatrackconstraintset-colortemperature">#dom-mediatrackconstraintset-colortemperature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-colortemperature" class="dfn-panel" data-for="dom-mediatrackconstraintset-colortemperature" id="infopanel-for-dom-mediatrackconstraintset-colortemperature" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-colortemperature" style="display:none">Info about the 'colorTemperature' definition.</span><b><a href="#dom-mediatrackconstraintset-colortemperature">#dom-mediatrackconstraintset-colortemperature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-colortemperature">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-exposurecompensation">
-   <b><a href="#dom-mediatrackconstraintset-exposurecompensation">#dom-mediatrackconstraintset-exposurecompensation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-exposurecompensation" class="dfn-panel" data-for="dom-mediatrackconstraintset-exposurecompensation" id="infopanel-for-dom-mediatrackconstraintset-exposurecompensation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-exposurecompensation" style="display:none">Info about the 'exposureCompensation' definition.</span><b><a href="#dom-mediatrackconstraintset-exposurecompensation">#dom-mediatrackconstraintset-exposurecompensation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-exposurecompensation">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-exposuretime">
-   <b><a href="#dom-mediatrackconstraintset-exposuretime">#dom-mediatrackconstraintset-exposuretime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-exposuretime" class="dfn-panel" data-for="dom-mediatrackconstraintset-exposuretime" id="infopanel-for-dom-mediatrackconstraintset-exposuretime" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-exposuretime" style="display:none">Info about the 'exposureTime' definition.</span><b><a href="#dom-mediatrackconstraintset-exposuretime">#dom-mediatrackconstraintset-exposuretime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-exposuretime">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-iso">
-   <b><a href="#dom-mediatrackconstraintset-iso">#dom-mediatrackconstraintset-iso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-iso" class="dfn-panel" data-for="dom-mediatrackconstraintset-iso" id="infopanel-for-dom-mediatrackconstraintset-iso" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-iso" style="display:none">Info about the 'iso' definition.</span><b><a href="#dom-mediatrackconstraintset-iso">#dom-mediatrackconstraintset-iso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-iso">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-pointsofinterest">
-   <b><a href="#dom-mediatrackconstraintset-pointsofinterest">#dom-mediatrackconstraintset-pointsofinterest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-pointsofinterest" class="dfn-panel" data-for="dom-mediatrackconstraintset-pointsofinterest" id="infopanel-for-dom-mediatrackconstraintset-pointsofinterest" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-pointsofinterest" style="display:none">Info about the 'pointsOfInterest' definition.</span><b><a href="#dom-mediatrackconstraintset-pointsofinterest">#dom-mediatrackconstraintset-pointsofinterest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-pointsofinterest">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-brightness">
-   <b><a href="#dom-mediatrackconstraintset-brightness">#dom-mediatrackconstraintset-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-brightness" class="dfn-panel" data-for="dom-mediatrackconstraintset-brightness" id="infopanel-for-dom-mediatrackconstraintset-brightness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-brightness" style="display:none">Info about the 'brightness' definition.</span><b><a href="#dom-mediatrackconstraintset-brightness">#dom-mediatrackconstraintset-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-brightness">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-contrast">
-   <b><a href="#dom-mediatrackconstraintset-contrast">#dom-mediatrackconstraintset-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-contrast" class="dfn-panel" data-for="dom-mediatrackconstraintset-contrast" id="infopanel-for-dom-mediatrackconstraintset-contrast" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-contrast" style="display:none">Info about the 'contrast' definition.</span><b><a href="#dom-mediatrackconstraintset-contrast">#dom-mediatrackconstraintset-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-contrast">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-pan">
-   <b><a href="#dom-mediatrackconstraintset-pan">#dom-mediatrackconstraintset-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-pan" class="dfn-panel" data-for="dom-mediatrackconstraintset-pan" id="infopanel-for-dom-mediatrackconstraintset-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-mediatrackconstraintset-pan">#dom-mediatrackconstraintset-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-pan">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-dom-mediatrackconstraintset-pan①">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-mediatrackconstraintset-pan②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-saturation">
-   <b><a href="#dom-mediatrackconstraintset-saturation">#dom-mediatrackconstraintset-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-saturation" class="dfn-panel" data-for="dom-mediatrackconstraintset-saturation" id="infopanel-for-dom-mediatrackconstraintset-saturation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#dom-mediatrackconstraintset-saturation">#dom-mediatrackconstraintset-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-saturation">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-sharpness">
-   <b><a href="#dom-mediatrackconstraintset-sharpness">#dom-mediatrackconstraintset-sharpness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-sharpness" class="dfn-panel" data-for="dom-mediatrackconstraintset-sharpness" id="infopanel-for-dom-mediatrackconstraintset-sharpness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-sharpness" style="display:none">Info about the 'sharpness' definition.</span><b><a href="#dom-mediatrackconstraintset-sharpness">#dom-mediatrackconstraintset-sharpness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-sharpness">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-focusdistance">
-   <b><a href="#dom-mediatrackconstraintset-focusdistance">#dom-mediatrackconstraintset-focusdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-focusdistance" class="dfn-panel" data-for="dom-mediatrackconstraintset-focusdistance" id="infopanel-for-dom-mediatrackconstraintset-focusdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-focusdistance" style="display:none">Info about the 'focusDistance' definition.</span><b><a href="#dom-mediatrackconstraintset-focusdistance">#dom-mediatrackconstraintset-focusdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-focusdistance">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-tilt">
-   <b><a href="#dom-mediatrackconstraintset-tilt">#dom-mediatrackconstraintset-tilt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-tilt" class="dfn-panel" data-for="dom-mediatrackconstraintset-tilt" id="infopanel-for-dom-mediatrackconstraintset-tilt" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-tilt" style="display:none">Info about the 'tilt' definition.</span><b><a href="#dom-mediatrackconstraintset-tilt">#dom-mediatrackconstraintset-tilt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-tilt">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-dom-mediatrackconstraintset-tilt①">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-mediatrackconstraintset-tilt②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-zoom">
-   <b><a href="#dom-mediatrackconstraintset-zoom">#dom-mediatrackconstraintset-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-zoom" class="dfn-panel" data-for="dom-mediatrackconstraintset-zoom" id="infopanel-for-dom-mediatrackconstraintset-zoom" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#dom-mediatrackconstraintset-zoom">#dom-mediatrackconstraintset-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-zoom">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-dom-mediatrackconstraintset-zoom①">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-mediatrackconstraintset-zoom②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatrackconstraintset-torch">
-   <b><a href="#dom-mediatrackconstraintset-torch">#dom-mediatrackconstraintset-torch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatrackconstraintset-torch" class="dfn-panel" data-for="dom-mediatrackconstraintset-torch" id="infopanel-for-dom-mediatrackconstraintset-torch" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatrackconstraintset-torch" style="display:none">Info about the 'torch' definition.</span><b><a href="#dom-mediatrackconstraintset-torch">#dom-mediatrackconstraintset-torch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatrackconstraintset-torch">9.3. MediaTrackConstraintSet dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-whitebalancemode">
-   <b><a href="#dom-mediatracksettings-whitebalancemode">#dom-mediatracksettings-whitebalancemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-whitebalancemode" class="dfn-panel" data-for="dom-mediatracksettings-whitebalancemode" id="infopanel-for-dom-mediatracksettings-whitebalancemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-whitebalancemode" style="display:none">Info about the 'whiteBalanceMode' definition.</span><b><a href="#dom-mediatracksettings-whitebalancemode">#dom-mediatracksettings-whitebalancemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-whitebalancemode">9.4. MediaTrackSettings dictionary</a>
     <li><a href="#ref-for-dom-mediatracksettings-whitebalancemode①">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-exposuremode">
-   <b><a href="#dom-mediatracksettings-exposuremode">#dom-mediatracksettings-exposuremode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-exposuremode" class="dfn-panel" data-for="dom-mediatracksettings-exposuremode" id="infopanel-for-dom-mediatracksettings-exposuremode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-exposuremode" style="display:none">Info about the 'exposureMode' definition.</span><b><a href="#dom-mediatracksettings-exposuremode">#dom-mediatracksettings-exposuremode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-exposuremode">9.4. MediaTrackSettings dictionary</a>
     <li><a href="#ref-for-dom-mediatracksettings-exposuremode①">9.4.1. Members</a> <a href="#ref-for-dom-mediatracksettings-exposuremode②">(2)</a>
     <li><a href="#ref-for-dom-mediatracksettings-exposuremode③">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-mediatracksettings-exposuremode④">(2)</a> <a href="#ref-for-dom-mediatracksettings-exposuremode⑤">(3)</a> <a href="#ref-for-dom-mediatracksettings-exposuremode⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-colortemperature">
-   <b><a href="#dom-mediatracksettings-colortemperature">#dom-mediatracksettings-colortemperature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-colortemperature" class="dfn-panel" data-for="dom-mediatracksettings-colortemperature" id="infopanel-for-dom-mediatracksettings-colortemperature" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-colortemperature" style="display:none">Info about the 'colorTemperature' definition.</span><b><a href="#dom-mediatracksettings-colortemperature">#dom-mediatracksettings-colortemperature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-colortemperature">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-exposurecompensation">
-   <b><a href="#dom-mediatracksettings-exposurecompensation">#dom-mediatracksettings-exposurecompensation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-exposurecompensation" class="dfn-panel" data-for="dom-mediatracksettings-exposurecompensation" id="infopanel-for-dom-mediatracksettings-exposurecompensation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-exposurecompensation" style="display:none">Info about the 'exposureCompensation' definition.</span><b><a href="#dom-mediatracksettings-exposurecompensation">#dom-mediatracksettings-exposurecompensation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-exposurecompensation">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-exposuretime">
-   <b><a href="#dom-mediatracksettings-exposuretime">#dom-mediatracksettings-exposuretime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-exposuretime" class="dfn-panel" data-for="dom-mediatracksettings-exposuretime" id="infopanel-for-dom-mediatracksettings-exposuretime" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-exposuretime" style="display:none">Info about the 'exposureTime' definition.</span><b><a href="#dom-mediatracksettings-exposuretime">#dom-mediatracksettings-exposuretime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-exposuretime">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-iso">
-   <b><a href="#dom-mediatracksettings-iso">#dom-mediatracksettings-iso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-iso" class="dfn-panel" data-for="dom-mediatracksettings-iso" id="infopanel-for-dom-mediatracksettings-iso" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-iso" style="display:none">Info about the 'iso' definition.</span><b><a href="#dom-mediatracksettings-iso">#dom-mediatracksettings-iso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-iso">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-focusmode">
-   <b><a href="#dom-mediatracksettings-focusmode">#dom-mediatracksettings-focusmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-focusmode" class="dfn-panel" data-for="dom-mediatracksettings-focusmode" id="infopanel-for-dom-mediatracksettings-focusmode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-focusmode" style="display:none">Info about the 'focusMode' definition.</span><b><a href="#dom-mediatracksettings-focusmode">#dom-mediatracksettings-focusmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-focusmode">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-pointsofinterest">
-   <b><a href="#dom-mediatracksettings-pointsofinterest">#dom-mediatracksettings-pointsofinterest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-pointsofinterest" class="dfn-panel" data-for="dom-mediatracksettings-pointsofinterest" id="infopanel-for-dom-mediatracksettings-pointsofinterest" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-pointsofinterest" style="display:none">Info about the 'pointsOfInterest' definition.</span><b><a href="#dom-mediatracksettings-pointsofinterest">#dom-mediatracksettings-pointsofinterest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-pointsofinterest">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-brightness">
-   <b><a href="#dom-mediatracksettings-brightness">#dom-mediatracksettings-brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-brightness" class="dfn-panel" data-for="dom-mediatracksettings-brightness" id="infopanel-for-dom-mediatracksettings-brightness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-brightness" style="display:none">Info about the 'brightness' definition.</span><b><a href="#dom-mediatracksettings-brightness">#dom-mediatracksettings-brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-brightness">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-contrast">
-   <b><a href="#dom-mediatracksettings-contrast">#dom-mediatracksettings-contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-contrast" class="dfn-panel" data-for="dom-mediatracksettings-contrast" id="infopanel-for-dom-mediatracksettings-contrast" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-contrast" style="display:none">Info about the 'contrast' definition.</span><b><a href="#dom-mediatracksettings-contrast">#dom-mediatracksettings-contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-contrast">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-pan">
-   <b><a href="#dom-mediatracksettings-pan">#dom-mediatracksettings-pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-pan" class="dfn-panel" data-for="dom-mediatracksettings-pan" id="infopanel-for-dom-mediatracksettings-pan" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-pan" style="display:none">Info about the 'pan' definition.</span><b><a href="#dom-mediatracksettings-pan">#dom-mediatracksettings-pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-pan">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-saturation">
-   <b><a href="#dom-mediatracksettings-saturation">#dom-mediatracksettings-saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-saturation" class="dfn-panel" data-for="dom-mediatracksettings-saturation" id="infopanel-for-dom-mediatracksettings-saturation" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#dom-mediatracksettings-saturation">#dom-mediatracksettings-saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-saturation">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-sharpness">
-   <b><a href="#dom-mediatracksettings-sharpness">#dom-mediatracksettings-sharpness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-sharpness" class="dfn-panel" data-for="dom-mediatracksettings-sharpness" id="infopanel-for-dom-mediatracksettings-sharpness" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-sharpness" style="display:none">Info about the 'sharpness' definition.</span><b><a href="#dom-mediatracksettings-sharpness">#dom-mediatracksettings-sharpness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-sharpness">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-focusdistance">
-   <b><a href="#dom-mediatracksettings-focusdistance">#dom-mediatracksettings-focusdistance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-focusdistance" class="dfn-panel" data-for="dom-mediatracksettings-focusdistance" id="infopanel-for-dom-mediatracksettings-focusdistance" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-focusdistance" style="display:none">Info about the 'focusDistance' definition.</span><b><a href="#dom-mediatracksettings-focusdistance">#dom-mediatracksettings-focusdistance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-focusdistance">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-tilt">
-   <b><a href="#dom-mediatracksettings-tilt">#dom-mediatracksettings-tilt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-tilt" class="dfn-panel" data-for="dom-mediatracksettings-tilt" id="infopanel-for-dom-mediatracksettings-tilt" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-tilt" style="display:none">Info about the 'tilt' definition.</span><b><a href="#dom-mediatracksettings-tilt">#dom-mediatracksettings-tilt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-tilt">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-zoom">
-   <b><a href="#dom-mediatracksettings-zoom">#dom-mediatracksettings-zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-zoom" class="dfn-panel" data-for="dom-mediatracksettings-zoom" id="infopanel-for-dom-mediatracksettings-zoom" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-zoom" style="display:none">Info about the 'zoom' definition.</span><b><a href="#dom-mediatracksettings-zoom">#dom-mediatracksettings-zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-zoom">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediatracksettings-torch">
-   <b><a href="#dom-mediatracksettings-torch">#dom-mediatracksettings-torch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediatracksettings-torch" class="dfn-panel" data-for="dom-mediatracksettings-torch" id="infopanel-for-dom-mediatracksettings-torch" role="dialog">
+   <span id="infopaneltitle-for-dom-mediatracksettings-torch" style="display:none">Info about the 'torch' definition.</span><b><a href="#dom-mediatracksettings-torch">#dom-mediatracksettings-torch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediatracksettings-torch">9.4. MediaTrackSettings dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-constrainpoint2dparameters">
-   <b><a href="#dictdef-constrainpoint2dparameters">#dictdef-constrainpoint2dparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-constrainpoint2dparameters" class="dfn-panel" data-for="dictdef-constrainpoint2dparameters" id="infopanel-for-dictdef-constrainpoint2dparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-constrainpoint2dparameters" style="display:none">Info about the 'ConstrainPoint2DParameters' definition.</span><b><a href="#dictdef-constrainpoint2dparameters">#dictdef-constrainpoint2dparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-constrainpoint2dparameters">9.5. Additional Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-constrainpoint2d">
-   <b><a href="#typedefdef-constrainpoint2d">#typedefdef-constrainpoint2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-constrainpoint2d" class="dfn-panel" data-for="typedefdef-constrainpoint2d" id="infopanel-for-typedefdef-constrainpoint2d" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-constrainpoint2d" style="display:none">Info about the 'ConstrainPoint2D' definition.</span><b><a href="#typedefdef-constrainpoint2d">#typedefdef-constrainpoint2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-constrainpoint2d">9.3. MediaTrackConstraintSet dictionary</a>
     <li><a href="#ref-for-typedefdef-constrainpoint2d①">9.3.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-constrainpoint2dparameters-exact">
-   <b><a href="#dom-constrainpoint2dparameters-exact">#dom-constrainpoint2dparameters-exact</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-constrainpoint2dparameters-exact" class="dfn-panel" data-for="dom-constrainpoint2dparameters-exact" id="infopanel-for-dom-constrainpoint2dparameters-exact" role="dialog">
+   <span id="infopaneltitle-for-dom-constrainpoint2dparameters-exact" style="display:none">Info about the 'exact' definition.</span><b><a href="#dom-constrainpoint2dparameters-exact">#dom-constrainpoint2dparameters-exact</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-constrainpoint2dparameters-exact">9.5. Additional Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-constrainpoint2dparameters-ideal">
-   <b><a href="#dom-constrainpoint2dparameters-ideal">#dom-constrainpoint2dparameters-ideal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-constrainpoint2dparameters-ideal" class="dfn-panel" data-for="dom-constrainpoint2dparameters-ideal" id="infopanel-for-dom-constrainpoint2dparameters-ideal" role="dialog">
+   <span id="infopaneltitle-for-dom-constrainpoint2dparameters-ideal" style="display:none">Info about the 'ideal' definition.</span><b><a href="#dom-constrainpoint2dparameters-ideal">#dom-constrainpoint2dparameters-ideal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-constrainpoint2dparameters-ideal">9.5. Additional Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="white-balance-mode">
-   <b><a href="#white-balance-mode">#white-balance-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-white-balance-mode" class="dfn-panel" data-for="white-balance-mode" id="infopanel-for-white-balance-mode" role="dialog">
+   <span id="infopaneltitle-for-white-balance-mode" style="display:none">Info about the 'White balance mode' definition.</span><b><a href="#white-balance-mode">#white-balance-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-balance-mode">9.1.1. Members</a>
     <li><a href="#ref-for-white-balance-mode①">9.2.1. Members</a>
@@ -3151,8 +3151,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-white-balance-mode④">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="color-temperature">
-   <b><a href="#color-temperature">#color-temperature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-color-temperature" class="dfn-panel" data-for="color-temperature" id="infopanel-for-color-temperature" role="dialog">
+   <span id="infopaneltitle-for-color-temperature" style="display:none">Info about the 'Color temperature' definition.</span><b><a href="#color-temperature">#color-temperature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-color-temperature">9.1.1. Members</a>
     <li><a href="#ref-for-color-temperature①">9.2.1. Members</a>
@@ -3160,8 +3160,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-color-temperature③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exposure">
-   <b><a href="#exposure">#exposure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exposure" class="dfn-panel" data-for="exposure" id="infopanel-for-exposure" role="dialog">
+   <span id="infopaneltitle-for-exposure" style="display:none">Info about the 'Exposure' definition.</span><b><a href="#exposure">#exposure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exposure">9.1.1. Members</a>
     <li><a href="#ref-for-exposure①">9.2.1. Members</a>
@@ -3170,8 +3170,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-exposure④">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="focus-mode">
-   <b><a href="#focus-mode">#focus-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-focus-mode" class="dfn-panel" data-for="focus-mode" id="infopanel-for-focus-mode" role="dialog">
+   <span id="infopaneltitle-for-focus-mode" style="display:none">Info about the 'Focus mode' definition.</span><b><a href="#focus-mode">#focus-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-mode">9.1.1. Members</a>
     <li><a href="#ref-for-focus-mode①">9.2.1. Members</a>
@@ -3180,8 +3180,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-focus-mode④">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="points-of-interest">
-   <b><a href="#points-of-interest">#points-of-interest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-points-of-interest" class="dfn-panel" data-for="points-of-interest" id="infopanel-for-points-of-interest" role="dialog">
+   <span id="infopaneltitle-for-points-of-interest" style="display:none">Info about the 'Points of interest' definition.</span><b><a href="#points-of-interest">#points-of-interest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-points-of-interest">9.1.1. Members</a>
     <li><a href="#ref-for-points-of-interest①">9.3.1. Members</a>
@@ -3189,8 +3189,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-points-of-interest③">9.5.1. Members</a> <a href="#ref-for-points-of-interest④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exposure-compensation">
-   <b><a href="#exposure-compensation">#exposure-compensation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exposure-compensation" class="dfn-panel" data-for="exposure-compensation" id="infopanel-for-exposure-compensation" role="dialog">
+   <span id="infopaneltitle-for-exposure-compensation" style="display:none">Info about the 'Exposure Compensation' definition.</span><b><a href="#exposure-compensation">#exposure-compensation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exposure-compensation">9.1.1. Members</a>
     <li><a href="#ref-for-exposure-compensation①">9.2.1. Members</a>
@@ -3198,8 +3198,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-exposure-compensation③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exposure-time">
-   <b><a href="#exposure-time">#exposure-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exposure-time" class="dfn-panel" data-for="exposure-time" id="infopanel-for-exposure-time" role="dialog">
+   <span id="infopaneltitle-for-exposure-time" style="display:none">Info about the 'Exposure Time' definition.</span><b><a href="#exposure-time">#exposure-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exposure-time">9.1.1. Members</a>
     <li><a href="#ref-for-exposure-time①">9.2.1. Members</a>
@@ -3207,8 +3207,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-exposure-time③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso">
-   <b><a href="#iso">#iso</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso" class="dfn-panel" data-for="iso" id="infopanel-for-iso" role="dialog">
+   <span id="infopaneltitle-for-iso" style="display:none">Info about the 'ISO' definition.</span><b><a href="#iso">#iso</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso">9.1.1. Members</a>
     <li><a href="#ref-for-iso①">9.2.1. Members</a>
@@ -3216,16 +3216,16 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-iso③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="red-eye-reduction">
-   <b><a href="#red-eye-reduction">#red-eye-reduction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-red-eye-reduction" class="dfn-panel" data-for="red-eye-reduction" id="infopanel-for-red-eye-reduction" role="dialog">
+   <span id="infopaneltitle-for-red-eye-reduction" style="display:none">Info about the 'Red Eye Reduction' definition.</span><b><a href="#red-eye-reduction">#red-eye-reduction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-red-eye-reduction">4.1. Members</a>
     <li><a href="#ref-for-red-eye-reduction①">5.1. Members</a>
     <li><a href="#ref-for-red-eye-reduction②">7.1. Values</a> <a href="#ref-for-red-eye-reduction③">(2)</a> <a href="#ref-for-red-eye-reduction④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="brightness">
-   <b><a href="#brightness">#brightness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-brightness" class="dfn-panel" data-for="brightness" id="infopanel-for-brightness" role="dialog">
+   <span id="infopaneltitle-for-brightness" style="display:none">Info about the 'brightness' definition.</span><b><a href="#brightness">#brightness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-brightness">9.1.1. Members</a>
     <li><a href="#ref-for-brightness①">9.2.1. Members</a>
@@ -3234,8 +3234,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-brightness④">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contrast">
-   <b><a href="#contrast">#contrast</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contrast" class="dfn-panel" data-for="contrast" id="infopanel-for-contrast" role="dialog">
+   <span id="infopaneltitle-for-contrast" style="display:none">Info about the 'Contrast' definition.</span><b><a href="#contrast">#contrast</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contrast">9.1.1. Members</a>
     <li><a href="#ref-for-contrast①">9.2.1. Members</a>
@@ -3244,8 +3244,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-contrast④">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-contrast⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="saturation">
-   <b><a href="#saturation">#saturation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-saturation" class="dfn-panel" data-for="saturation" id="infopanel-for-saturation" role="dialog">
+   <span id="infopaneltitle-for-saturation" style="display:none">Info about the 'saturation' definition.</span><b><a href="#saturation">#saturation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-saturation">9.1.1. Members</a>
     <li><a href="#ref-for-saturation①">9.2.1. Members</a>
@@ -3254,8 +3254,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-saturation④">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sharpness">
-   <b><a href="#sharpness">#sharpness</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sharpness" class="dfn-panel" data-for="sharpness" id="infopanel-for-sharpness" role="dialog">
+   <span id="infopaneltitle-for-sharpness" style="display:none">Info about the 'Sharpness' definition.</span><b><a href="#sharpness">#sharpness</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharpness">9.1.1. Members</a>
     <li><a href="#ref-for-sharpness①">9.2.1. Members</a>
@@ -3264,22 +3264,22 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-sharpness④">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-sharpness⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-width">
-   <b><a href="#image-width">#image-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-width" class="dfn-panel" data-for="image-width" id="infopanel-for-image-width" role="dialog">
+   <span id="infopaneltitle-for-image-width" style="display:none">Info about the 'Image width' definition.</span><b><a href="#image-width">#image-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-width">4.1. Members</a>
     <li><a href="#ref-for-image-width①">5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-height">
-   <b><a href="#image-height">#image-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-height" class="dfn-panel" data-for="image-height" id="infopanel-for-image-height" role="dialog">
+   <span id="infopaneltitle-for-image-height" style="display:none">Info about the 'image height' definition.</span><b><a href="#image-height">#image-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-height">4.1. Members</a>
     <li><a href="#ref-for-image-height①">5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="focus-distance">
-   <b><a href="#focus-distance">#focus-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-focus-distance" class="dfn-panel" data-for="focus-distance" id="infopanel-for-focus-distance" role="dialog">
+   <span id="infopaneltitle-for-focus-distance" style="display:none">Info about the 'Focus distance' definition.</span><b><a href="#focus-distance">#focus-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus-distance">9.1.1. Members</a>
     <li><a href="#ref-for-focus-distance①">9.2.1. Members</a>
@@ -3287,8 +3287,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-focus-distance③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pan">
-   <b><a href="#pan">#pan</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pan" class="dfn-panel" data-for="pan" id="infopanel-for-pan" role="dialog">
+   <span id="infopaneltitle-for-pan" style="display:none">Info about the 'Pan' definition.</span><b><a href="#pan">#pan</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pan">9.1.1. Members</a>
     <li><a href="#ref-for-pan①">9.2.1. Members</a> <a href="#ref-for-pan②">(2)</a> <a href="#ref-for-pan③">(3)</a> <a href="#ref-for-pan④">(4)</a> <a href="#ref-for-pan⑤">(5)</a> <a href="#ref-for-pan⑥">(6)</a>
@@ -3297,8 +3297,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-pan①①">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tilt">
-   <b><a href="#tilt">#tilt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tilt" class="dfn-panel" data-for="tilt" id="infopanel-for-tilt" role="dialog">
+   <span id="infopaneltitle-for-tilt" style="display:none">Info about the 'Tilt' definition.</span><b><a href="#tilt">#tilt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tilt">9.1.1. Members</a>
     <li><a href="#ref-for-tilt①">9.2.1. Members</a> <a href="#ref-for-tilt②">(2)</a> <a href="#ref-for-tilt③">(3)</a> <a href="#ref-for-tilt④">(4)</a> <a href="#ref-for-tilt⑤">(5)</a> <a href="#ref-for-tilt⑥">(6)</a>
@@ -3307,8 +3307,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-tilt①①">10. Photo Capabilities and Constrainable Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="zoom">
-   <b><a href="#zoom">#zoom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-zoom" class="dfn-panel" data-for="zoom" id="infopanel-for-zoom" role="dialog">
+   <span id="infopaneltitle-for-zoom" style="display:none">Info about the 'Zoom' definition.</span><b><a href="#zoom">#zoom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-zoom">9.1.1. Members</a>
     <li><a href="#ref-for-zoom①">9.2.1. Members</a> <a href="#ref-for-zoom②">(2)</a> <a href="#ref-for-zoom③">(3)</a> <a href="#ref-for-zoom④">(4)</a> <a href="#ref-for-zoom⑤">(5)</a> <a href="#ref-for-zoom⑥">(6)</a>
@@ -3317,15 +3317,15 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-zoom⑨">9.4.1. Members</a> <a href="#ref-for-zoom①⓪">(2)</a> <a href="#ref-for-zoom①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fill-light-mode">
-   <b><a href="#fill-light-mode">#fill-light-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fill-light-mode" class="dfn-panel" data-for="fill-light-mode" id="infopanel-for-fill-light-mode" role="dialog">
+   <span id="infopaneltitle-for-fill-light-mode" style="display:none">Info about the 'Fill light mode' definition.</span><b><a href="#fill-light-mode">#fill-light-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fill-light-mode">4.1. Members</a>
     <li><a href="#ref-for-fill-light-mode①">5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="torch">
-   <b><a href="#torch">#torch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-torch" class="dfn-panel" data-for="torch" id="infopanel-for-torch" role="dialog">
+   <span id="infopaneltitle-for-torch" style="display:none">Info about the 'Torch' definition.</span><b><a href="#torch">#torch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-torch">9.1.1. Members</a>
     <li><a href="#ref-for-torch①">9.2.1. Members</a>
@@ -3333,8 +3333,8 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-torch③">9.4.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-meteringmode">
-   <b><a href="#enumdef-meteringmode">#enumdef-meteringmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-meteringmode" class="dfn-panel" data-for="enumdef-meteringmode" id="infopanel-for-enumdef-meteringmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-meteringmode" style="display:none">Info about the 'MeteringMode' definition.</span><b><a href="#enumdef-meteringmode">#enumdef-meteringmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-meteringmode">9.2.1. Members</a> <a href="#ref-for-enumdef-meteringmode①">(2)</a> <a href="#ref-for-enumdef-meteringmode②">(3)</a>
     <li><a href="#ref-for-enumdef-meteringmode③">9.3.1. Members</a> <a href="#ref-for-enumdef-meteringmode④">(2)</a> <a href="#ref-for-enumdef-meteringmode⑤">(3)</a>
@@ -3342,38 +3342,38 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-enumdef-meteringmode⑨">11. MeteringMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-meteringmode-none">
-   <b><a href="#dom-meteringmode-none">#dom-meteringmode-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-meteringmode-none" class="dfn-panel" data-for="dom-meteringmode-none" id="infopanel-for-dom-meteringmode-none" role="dialog">
+   <span id="infopaneltitle-for-dom-meteringmode-none" style="display:none">Info about the 'none' definition.</span><b><a href="#dom-meteringmode-none">#dom-meteringmode-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-meteringmode-none">11. MeteringMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-meteringmode-manual">
-   <b><a href="#dom-meteringmode-manual">#dom-meteringmode-manual</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-meteringmode-manual" class="dfn-panel" data-for="dom-meteringmode-manual" id="infopanel-for-dom-meteringmode-manual" role="dialog">
+   <span id="infopaneltitle-for-dom-meteringmode-manual" style="display:none">Info about the 'manual' definition.</span><b><a href="#dom-meteringmode-manual">#dom-meteringmode-manual</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-meteringmode-manual">9.4.1. Members</a> <a href="#ref-for-dom-meteringmode-manual①">(2)</a>
     <li><a href="#ref-for-dom-meteringmode-manual②">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-meteringmode-manual③">(2)</a>
     <li><a href="#ref-for-dom-meteringmode-manual④">11. MeteringMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-meteringmode-single-shot">
-   <b><a href="#dom-meteringmode-single-shot">#dom-meteringmode-single-shot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-meteringmode-single-shot" class="dfn-panel" data-for="dom-meteringmode-single-shot" id="infopanel-for-dom-meteringmode-single-shot" role="dialog">
+   <span id="infopaneltitle-for-dom-meteringmode-single-shot" style="display:none">Info about the 'single-shot' definition.</span><b><a href="#dom-meteringmode-single-shot">#dom-meteringmode-single-shot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-meteringmode-single-shot">9.4.1. Members</a>
     <li><a href="#ref-for-dom-meteringmode-single-shot①">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-meteringmode-single-shot②">(2)</a>
     <li><a href="#ref-for-dom-meteringmode-single-shot③">11. MeteringMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-meteringmode-continuous">
-   <b><a href="#dom-meteringmode-continuous">#dom-meteringmode-continuous</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-meteringmode-continuous" class="dfn-panel" data-for="dom-meteringmode-continuous" id="infopanel-for-dom-meteringmode-continuous" role="dialog">
+   <span id="infopaneltitle-for-dom-meteringmode-continuous" style="display:none">Info about the 'continuous' definition.</span><b><a href="#dom-meteringmode-continuous">#dom-meteringmode-continuous</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-meteringmode-continuous">9.4.1. Members</a>
     <li><a href="#ref-for-dom-meteringmode-continuous①">10. Photo Capabilities and Constrainable Properties</a> <a href="#ref-for-dom-meteringmode-continuous②">(2)</a>
     <li><a href="#ref-for-dom-meteringmode-continuous③">11. MeteringMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-point2d">
-   <b><a href="#dictdef-point2d">#dictdef-point2d</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-point2d" class="dfn-panel" data-for="dictdef-point2d" id="infopanel-for-dictdef-point2d" role="dialog">
+   <span id="infopaneltitle-for-dictdef-point2d" style="display:none">Info about the 'Point2D' definition.</span><b><a href="#dictdef-point2d">#dictdef-point2d</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-point2d">9.4. MediaTrackSettings dictionary</a>
     <li><a href="#ref-for-dictdef-point2d①">9.4.1. Members</a> <a href="#ref-for-dictdef-point2d②">(2)</a>
@@ -3383,15 +3383,15 @@ For instance, embedding the user’s location in the metadata of the digitzed im
     <li><a href="#ref-for-dictdef-point2d①⓪">12. Point2D</a> <a href="#ref-for-dictdef-point2d①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-point2d-x">
-   <b><a href="#dom-point2d-x">#dom-point2d-x</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-point2d-x" class="dfn-panel" data-for="dom-point2d-x" id="infopanel-for-dom-point2d-x" role="dialog">
+   <span id="infopaneltitle-for-dom-point2d-x" style="display:none">Info about the 'x' definition.</span><b><a href="#dom-point2d-x">#dom-point2d-x</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-point2d-x">10. Photo Capabilities and Constrainable Properties</a>
     <li><a href="#ref-for-dom-point2d-x">12. Point2D</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-point2d-y">
-   <b><a href="#dom-point2d-y">#dom-point2d-y</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-point2d-y" class="dfn-panel" data-for="dom-point2d-y" id="infopanel-for-dom-point2d-y" role="dialog">
+   <span id="infopaneltitle-for-dom-point2d-y" style="display:none">Info about the 'y' definition.</span><b><a href="#dom-point2d-y">#dom-point2d-y</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-point2d-y">10. Photo Capabilities and Constrainable Properties</a>
     <li><a href="#ref-for-dom-point2d-y">12. Point2D</a>
@@ -3399,57 +3399,113 @@ For instance, embedding the user’s location in the metadata of the digitzed im
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/mediacapture-record/MediaRecorder.html
+++ b/tests/github/w3c/mediacapture-record/MediaRecorder.html
@@ -1526,8 +1526,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
      <li><a href="#dom-mediarecorderoptions-videobitspersecond">dict-member for MediaRecorderOptions</a><span>, in § 2.5.1</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">3. Blob Event</a>
     <li><a href="#ref-for-dom-domhighrestimestamp①">3.2. Attributes</a> <a href="#ref-for-dom-domhighrestimestamp②">(2)</a>
@@ -1535,8 +1535,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-domhighrestimestamp④">3.3.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediastream">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#mediastream">https://www.w3.org/TR/mediacapture-streams/#mediastream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediastream" class="dfn-panel" data-for="term-for-mediastream" id="infopanel-for-term-for-mediastream" role="menu">
+   <span id="infopaneltitle-for-term-for-mediastream" style="display:none">Info about the 'MediaStream' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#mediastream">https://www.w3.org/TR/mediacapture-streams/#mediastream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastream">Unnumbered Section</a>
     <li><a href="#ref-for-mediastream①">2. Media Recorder API</a> <a href="#ref-for-mediastream②">(2)</a>
@@ -1547,8 +1547,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-mediastream①⓪">7.2. Recording webcam video and audio</a> <a href="#ref-for-mediastream①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mediastreamtrack">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mediastreamtrack" class="dfn-panel" data-for="term-for-mediastreamtrack" id="infopanel-for-term-for-mediastreamtrack" role="menu">
+   <span id="infopaneltitle-for-term-for-mediastreamtrack" style="display:none">Info about the 'MediaStreamTrack' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack">https://www.w3.org/TR/mediacapture-streams/#mediastreamtrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamtrack">1. Overview</a>
     <li><a href="#ref-for-mediastreamtrack①">4.1. General principles</a>
@@ -1556,90 +1556,90 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-mediastreamtrack③">7.2. Recording webcam video and audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-fingerprinting">
-   <a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-active-fingerprinting">https://www.w3.org/TR/fingerprinting-guidance/#dfn-active-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-fingerprinting" class="dfn-panel" data-for="term-for-dfn-active-fingerprinting" id="infopanel-for-term-for-dfn-active-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-fingerprinting" style="display:none">Info about the 'active fingerprinting' external reference.</span><a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-active-fingerprinting">https://www.w3.org/TR/fingerprinting-guidance/#dfn-active-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-fingerprinting">6.2. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack-enabled">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-enabled">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-enabled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack-enabled" class="dfn-panel" data-for="term-for-dom-mediastreamtrack-enabled" id="infopanel-for-term-for-dom-mediastreamtrack-enabled" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack-enabled" style="display:none">Info about the 'enabled' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-enabled">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-enabled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack-enabled">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.ended">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.ended">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.ended</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.ended" class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.ended" id="infopanel-for-term-for-idl-def-MediaStreamTrackState.ended" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.ended" style="display:none">Info about the 'ended' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.ended">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.ended</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaStreamTrackState.ended">2.3. Methods</a>
     <li><a href="#ref-for-idl-def-MediaStreamTrackState.ended①">7.2. Recording webcam video and audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-fingerprinting-surface">
-   <a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface">https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-fingerprinting-surface" class="dfn-panel" data-for="term-for-dfn-fingerprinting-surface" id="infopanel-for-term-for-dfn-fingerprinting-surface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-fingerprinting-surface" style="display:none">Info about the 'fingerprinting surface' external reference.</span><a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface">https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fingerprinting-surface">6.2. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia" id="infopanel-for-term-for-dom-mediadevices-getusermedia" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" style="display:none">Info about the 'getUserMedia()' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia">https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadevices-getusermedia">7.2. Recording webcam video and audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stream-inactive">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#stream-inactive">https://www.w3.org/TR/mediacapture-streams/#stream-inactive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stream-inactive" class="dfn-panel" data-for="term-for-stream-inactive" id="infopanel-for-term-for-stream-inactive" role="menu">
+   <span id="infopaneltitle-for-term-for-stream-inactive" style="display:none">Info about the 'inactive' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#stream-inactive">https://www.w3.org/TR/mediacapture-streams/#stream-inactive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stream-inactive">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isolated-media-streams">
-   <a href="https://www.w3.org/TR/webrtc-identity/#isolated-media-streams">https://www.w3.org/TR/webrtc-identity/#isolated-media-streams</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isolated-media-streams" class="dfn-panel" data-for="term-for-isolated-media-streams" id="infopanel-for-term-for-isolated-media-streams" role="menu">
+   <span id="infopaneltitle-for-term-for-isolated-media-streams" style="display:none">Info about the 'isolation properties' external reference.</span><a href="https://www.w3.org/TR/webrtc-identity/#isolated-media-streams">https://www.w3.org/TR/webrtc-identity/#isolated-media-streams</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isolated-media-streams">2.3. Methods</a> <a href="#ref-for-isolated-media-streams①">(2)</a> <a href="#ref-for-isolated-media-streams②">(3)</a>
     <li><a href="#ref-for-isolated-media-streams③">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.live">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.live" class="dfn-panel" data-for="term-for-idl-def-MediaStreamTrackState.live" id="infopanel-for-term-for-idl-def-MediaStreamTrackState.live" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-MediaStreamTrackState.live" style="display:none">Info about the 'live' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live">https://www.w3.org/TR/mediacapture-streams/#idl-def-MediaStreamTrackState.live</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-MediaStreamTrackState.live">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack-muted">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-muted">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-muted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack-muted" class="dfn-panel" data-for="term-for-dom-mediastreamtrack-muted" id="infopanel-for-term-for-dom-mediastreamtrack-muted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack-muted" style="display:none">Info about the 'muted' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-muted">https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-muted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack-muted">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-track-set">
-   <a href="https://www.w3.org/TR/mediacapture-streams/#track-set">https://www.w3.org/TR/mediacapture-streams/#track-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-track-set" class="dfn-panel" data-for="term-for-track-set" id="infopanel-for-term-for-track-set" role="menu">
+   <span id="infopaneltitle-for-term-for-track-set" style="display:none">Info about the 'track set' external reference.</span><a href="https://www.w3.org/TR/mediacapture-streams/#track-set">https://www.w3.org/TR/mediacapture-streams/#track-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-track-set">2.3. Methods</a> <a href="#ref-for-track-set①">(2)</a> <a href="#ref-for-track-set②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3. Blob Event</a>
     <li><a href="#ref-for-event①">4.2. MediaRecorderErrorEvent</a>
     <li><a href="#ref-for-event②">5. Event summary</a> <a href="#ref-for-event③">(2)</a> <a href="#ref-for-event④">(3)</a> <a href="#ref-for-event⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2.3. Methods</a> <a href="#ref-for-concept-event-fire①">(2)</a> <a href="#ref-for-concept-event-fire②">(3)</a> <a href="#ref-for-concept-event-fire③">(4)</a> <a href="#ref-for-concept-event-fire④">(5)</a> <a href="#ref-for-concept-event-fire⑤">(6)</a> <a href="#ref-for-concept-event-fire⑥">(7)</a> <a href="#ref-for-concept-event-fire⑦">(8)</a>
     <li><a href="#ref-for-concept-event-fire⑧">2.4. Data handling</a>
@@ -1647,14 +1647,14 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#termref-for-concept-event-fire">5. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch-resume">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch-resume">https://fetch.spec.whatwg.org/#concept-fetch-resume</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch-resume" class="dfn-panel" data-for="term-for-concept-fetch-resume" id="infopanel-for-term-for-concept-fetch-resume" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch-resume" style="display:none">Info about the 'resumed' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch-resume">https://fetch.spec.whatwg.org/#concept-fetch-resume</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-resume">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">1. Overview</a>
     <li><a href="#ref-for-dfn-Blob①">2.2. Attributes</a>
@@ -1668,34 +1668,34 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dfn-Blob①⑥">5. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.2. Attributes</a>
     <li><a href="#ref-for-dfn-type①">6.2. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">2. Media Recorder API</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a>
     <li><a href="#ref-for-eventhandler⑥">2.2. Attributes</a> <a href="#ref-for-eventhandler⑦">(2)</a> <a href="#ref-for-eventhandler⑧">(3)</a> <a href="#ref-for-eventhandler⑨">(4)</a> <a href="#ref-for-eventhandler①⓪">(5)</a> <a href="#ref-for-eventhandler①①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">6. Privacy and Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.1. Constructors</a>
     <li><a href="#ref-for-idl-DOMException①">2.3. Methods</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a> <a href="#ref-for-idl-DOMException⑤">(5)</a> <a href="#ref-for-idl-DOMException⑥">(6)</a> <a href="#ref-for-idl-DOMException⑦">(7)</a>
@@ -1706,8 +1706,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-idl-DOMException①⑥">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Media Recorder API</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">2.2. Attributes</a>
@@ -1717,70 +1717,70 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-idl-DOMString⑥">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2. Media Recorder API</a>
     <li><a href="#ref-for-Exposed①">3. Blob Event</a>
     <li><a href="#ref-for-Exposed②">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">2.3. Methods</a>
     <li><a href="#ref-for-invalidmodificationerror①">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.3. Methods</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a> <a href="#ref-for-invalidstateerror③">(4)</a>
     <li><a href="#ref-for-invalidstateerror④">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">2.1. Constructors</a>
     <li><a href="#ref-for-notsupportederror①">2.3. Methods</a> <a href="#ref-for-notsupportederror②">(2)</a>
     <li><a href="#ref-for-notsupportederror③">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. Blob Event</a>
     <li><a href="#ref-for-SameObject①">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">2.3. Methods</a> <a href="#ref-for-securityerror①">(2)</a>
     <li><a href="#ref-for-securityerror②">4.3. Exception Summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2. Media Recorder API</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">2. Media Recorder API</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a>
     <li><a href="#ref-for-idl-unsigned-long③">2.2. Attributes</a> <a href="#ref-for-idl-unsigned-long④">(2)</a>
@@ -1943,8 +1943,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="mediarecorder">
-   <b><a href="#mediarecorder">#mediarecorder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediarecorder" class="dfn-panel" data-for="mediarecorder" id="infopanel-for-mediarecorder" role="dialog">
+   <span id="infopaneltitle-for-mediarecorder" style="display:none">Info about the 'MediaRecorder' definition.</span><b><a href="#mediarecorder">#mediarecorder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediarecorder">1. Overview</a>
     <li><a href="#ref-for-mediarecorder①">2.1. Constructors</a>
@@ -1957,36 +1957,36 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-mediarecorder①⑨">7.1. Check for MediaRecorder and content types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-start-timeslice-timeslice">
-   <b><a href="#dom-mediarecorder-start-timeslice-timeslice">#dom-mediarecorder-start-timeslice-timeslice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-start-timeslice-timeslice" class="dfn-panel" data-for="dom-mediarecorder-start-timeslice-timeslice" id="infopanel-for-dom-mediarecorder-start-timeslice-timeslice" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-start-timeslice-timeslice" style="display:none">Info about the 'timeslice' definition.</span><b><a href="#dom-mediarecorder-start-timeslice-timeslice">#dom-mediarecorder-start-timeslice-timeslice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-start-timeslice-timeslice">2.3. Methods</a>
     <li><a href="#ref-for-dom-mediarecorder-start-timeslice-timeslice①">6.1. Resource exhaustion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-mediarecorder">
-   <b><a href="#dom-mediarecorder-mediarecorder">#dom-mediarecorder-mediarecorder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-mediarecorder" class="dfn-panel" data-for="dom-mediarecorder-mediarecorder" id="infopanel-for-dom-mediarecorder-mediarecorder" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-mediarecorder" style="display:none">Info about the 'MediaRecorder(MediaStream stream, optional MediaRecorderOptions options = {})' definition.</span><b><a href="#dom-mediarecorder-mediarecorder">#dom-mediarecorder-mediarecorder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-mediarecorder">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-mediarecorder①">2.1. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constrainedmimetype">
-   <b><a href="#constrainedmimetype">#constrainedmimetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constrainedmimetype" class="dfn-panel" data-for="constrainedmimetype" id="infopanel-for-constrainedmimetype" role="dialog">
+   <span id="infopaneltitle-for-constrainedmimetype" style="display:none">Info about the '[[ConstrainedMimeType]]' definition.</span><b><a href="#constrainedmimetype">#constrainedmimetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constrainedmimetype">2.1. Constructors</a>
     <li><a href="#ref-for-constrainedmimetype①">2.3. Methods</a> <a href="#ref-for-constrainedmimetype②">(2)</a> <a href="#ref-for-constrainedmimetype③">(3)</a> <a href="#ref-for-constrainedmimetype④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="constrainedbitspersecond">
-   <b><a href="#constrainedbitspersecond">#constrainedbitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-constrainedbitspersecond" class="dfn-panel" data-for="constrainedbitspersecond" id="infopanel-for-constrainedbitspersecond" role="dialog">
+   <span id="infopaneltitle-for-constrainedbitspersecond" style="display:none">Info about the '[[ConstrainedBitsPerSecond]]' definition.</span><b><a href="#constrainedbitspersecond">#constrainedbitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constrainedbitspersecond">2.1. Constructors</a> <a href="#ref-for-constrainedbitspersecond①">(2)</a>
     <li><a href="#ref-for-constrainedbitspersecond②">2.3. Methods</a> <a href="#ref-for-constrainedbitspersecond③">(2)</a> <a href="#ref-for-constrainedbitspersecond④">(3)</a> <a href="#ref-for-constrainedbitspersecond⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-stream">
-   <b><a href="#dom-mediarecorder-stream">#dom-mediarecorder-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-stream" class="dfn-panel" data-for="dom-mediarecorder-stream" id="infopanel-for-dom-mediarecorder-stream" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-stream" style="display:none">Info about the 'stream' definition.</span><b><a href="#dom-mediarecorder-stream">#dom-mediarecorder-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-stream">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-stream①">2.1. Constructors</a>
@@ -1994,8 +1994,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-stream④">5. Event summary</a> <a href="#ref-for-dom-mediarecorder-stream⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-mimetype">
-   <b><a href="#dom-mediarecorder-mimetype">#dom-mediarecorder-mimetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-mimetype" class="dfn-panel" data-for="dom-mediarecorder-mimetype" id="infopanel-for-dom-mediarecorder-mimetype" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-mimetype" style="display:none">Info about the 'mimeType' definition.</span><b><a href="#dom-mediarecorder-mimetype">#dom-mediarecorder-mimetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-mimetype">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-mimetype①">2.1. Constructors</a>
@@ -2003,8 +2003,8 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-mimetype③">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-mimetype④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-state">
-   <b><a href="#dom-mediarecorder-state">#dom-mediarecorder-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-state" class="dfn-panel" data-for="dom-mediarecorder-state" id="infopanel-for-dom-mediarecorder-state" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-mediarecorder-state">#dom-mediarecorder-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-state">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-state①">2.1. Constructors</a>
@@ -2012,20 +2012,20 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-state①④">2.4. Data handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-onstart">
-   <b><a href="#dom-mediarecorder-onstart">#dom-mediarecorder-onstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-onstart" class="dfn-panel" data-for="dom-mediarecorder-onstart" id="infopanel-for-dom-mediarecorder-onstart" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-onstart" style="display:none">Info about the 'onstart' definition.</span><b><a href="#dom-mediarecorder-onstart">#dom-mediarecorder-onstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-onstart">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-onstop">
-   <b><a href="#dom-mediarecorder-onstop">#dom-mediarecorder-onstop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-onstop" class="dfn-panel" data-for="dom-mediarecorder-onstop" id="infopanel-for-dom-mediarecorder-onstop" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-onstop" style="display:none">Info about the 'onstop' definition.</span><b><a href="#dom-mediarecorder-onstop">#dom-mediarecorder-onstop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-onstop">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-ondataavailable">
-   <b><a href="#dom-mediarecorder-ondataavailable">#dom-mediarecorder-ondataavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-ondataavailable" class="dfn-panel" data-for="dom-mediarecorder-ondataavailable" id="infopanel-for-dom-mediarecorder-ondataavailable" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-ondataavailable" style="display:none">Info about the 'ondataavailable' definition.</span><b><a href="#dom-mediarecorder-ondataavailable">#dom-mediarecorder-ondataavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-ondataavailable">1. Overview</a>
     <li><a href="#ref-for-dom-mediarecorder-ondataavailable①">2. Media Recorder API</a>
@@ -2033,50 +2033,50 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-ondataavailable③">7.2. Recording webcam video and audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-onpause">
-   <b><a href="#dom-mediarecorder-onpause">#dom-mediarecorder-onpause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-onpause" class="dfn-panel" data-for="dom-mediarecorder-onpause" id="infopanel-for-dom-mediarecorder-onpause" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-onpause" style="display:none">Info about the 'onpause' definition.</span><b><a href="#dom-mediarecorder-onpause">#dom-mediarecorder-onpause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-onpause">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-onresume">
-   <b><a href="#dom-mediarecorder-onresume">#dom-mediarecorder-onresume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-onresume" class="dfn-panel" data-for="dom-mediarecorder-onresume" id="infopanel-for-dom-mediarecorder-onresume" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-onresume" style="display:none">Info about the 'onresume' definition.</span><b><a href="#dom-mediarecorder-onresume">#dom-mediarecorder-onresume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-onresume">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-onerror">
-   <b><a href="#dom-mediarecorder-onerror">#dom-mediarecorder-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-onerror" class="dfn-panel" data-for="dom-mediarecorder-onerror" id="infopanel-for-dom-mediarecorder-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-mediarecorder-onerror">#dom-mediarecorder-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-onerror">2. Media Recorder API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-videobitspersecond">
-   <b><a href="#dom-mediarecorder-videobitspersecond">#dom-mediarecorder-videobitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-videobitspersecond" class="dfn-panel" data-for="dom-mediarecorder-videobitspersecond" id="infopanel-for-dom-mediarecorder-videobitspersecond" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-videobitspersecond" style="display:none">Info about the 'videoBitsPerSecond' definition.</span><b><a href="#dom-mediarecorder-videobitspersecond">#dom-mediarecorder-videobitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-videobitspersecond">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-videobitspersecond①">2.1. Constructors</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond②">(2)</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond③">(3)</a>
     <li><a href="#ref-for-dom-mediarecorder-videobitspersecond④">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond⑤">(2)</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond⑥">(3)</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond⑦">(4)</a> <a href="#ref-for-dom-mediarecorder-videobitspersecond⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-audiobitspersecond">
-   <b><a href="#dom-mediarecorder-audiobitspersecond">#dom-mediarecorder-audiobitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-audiobitspersecond" class="dfn-panel" data-for="dom-mediarecorder-audiobitspersecond" id="infopanel-for-dom-mediarecorder-audiobitspersecond" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-audiobitspersecond" style="display:none">Info about the 'audioBitsPerSecond' definition.</span><b><a href="#dom-mediarecorder-audiobitspersecond">#dom-mediarecorder-audiobitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-audiobitspersecond">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-audiobitspersecond①">2.1. Constructors</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond②">(2)</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond③">(3)</a>
     <li><a href="#ref-for-dom-mediarecorder-audiobitspersecond④">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond⑤">(2)</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond⑥">(3)</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond⑦">(4)</a> <a href="#ref-for-dom-mediarecorder-audiobitspersecond⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-audiobitratemode">
-   <b><a href="#dom-mediarecorder-audiobitratemode">#dom-mediarecorder-audiobitratemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-audiobitratemode" class="dfn-panel" data-for="dom-mediarecorder-audiobitratemode" id="infopanel-for-dom-mediarecorder-audiobitratemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-audiobitratemode" style="display:none">Info about the 'audioBitrateMode' definition.</span><b><a href="#dom-mediarecorder-audiobitratemode">#dom-mediarecorder-audiobitratemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-audiobitratemode">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-audiobitratemode①">2.1. Constructors</a> <a href="#ref-for-dom-mediarecorder-audiobitratemode②">(2)</a>
     <li><a href="#ref-for-dom-mediarecorder-audiobitratemode③">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-start">
-   <b><a href="#dom-mediarecorder-start">#dom-mediarecorder-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-start" class="dfn-panel" data-for="dom-mediarecorder-start" id="infopanel-for-dom-mediarecorder-start" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-start" style="display:none">Info about the 'start(optional unsigned long timeslice)' definition.</span><b><a href="#dom-mediarecorder-start">#dom-mediarecorder-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-start">1. Overview</a>
     <li><a href="#ref-for-dom-mediarecorder-start①">2. Media Recorder API</a>
@@ -2085,14 +2085,14 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-start④">6.1. Resource exhaustion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-inactivate-the-recorder">
-   <b><a href="#abstract-opdef-inactivate-the-recorder">#abstract-opdef-inactivate-the-recorder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-inactivate-the-recorder" class="dfn-panel" data-for="abstract-opdef-inactivate-the-recorder" id="infopanel-for-abstract-opdef-inactivate-the-recorder" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-inactivate-the-recorder" style="display:none">Info about the 'Inactivate the recorder' definition.</span><b><a href="#abstract-opdef-inactivate-the-recorder">#abstract-opdef-inactivate-the-recorder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-inactivate-the-recorder">2.3. Methods</a> <a href="#ref-for-abstract-opdef-inactivate-the-recorder①">(2)</a> <a href="#ref-for-abstract-opdef-inactivate-the-recorder②">(3)</a> <a href="#ref-for-abstract-opdef-inactivate-the-recorder③">(4)</a> <a href="#ref-for-abstract-opdef-inactivate-the-recorder④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-stop">
-   <b><a href="#dom-mediarecorder-stop">#dom-mediarecorder-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-stop" class="dfn-panel" data-for="dom-mediarecorder-stop" id="infopanel-for-dom-mediarecorder-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-stop" style="display:none">Info about the 'stop()' definition.</span><b><a href="#dom-mediarecorder-stop">#dom-mediarecorder-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-stop">1. Overview</a>
     <li><a href="#ref-for-dom-mediarecorder-stop①">2. Media Recorder API</a>
@@ -2100,95 +2100,96 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-mediarecorder-stop④">7.2. Recording webcam video and audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-pause">
-   <b><a href="#dom-mediarecorder-pause">#dom-mediarecorder-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-pause" class="dfn-panel" data-for="dom-mediarecorder-pause" id="infopanel-for-dom-mediarecorder-pause" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-pause" style="display:none">Info about the 'pause()' definition.</span><b><a href="#dom-mediarecorder-pause">#dom-mediarecorder-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-pause">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-pause①">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-pause②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-resume">
-   <b><a href="#dom-mediarecorder-resume">#dom-mediarecorder-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-resume" class="dfn-panel" data-for="dom-mediarecorder-resume" id="infopanel-for-dom-mediarecorder-resume" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-resume" style="display:none">Info about the 'resume()' definition.</span><b><a href="#dom-mediarecorder-resume">#dom-mediarecorder-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-resume">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-resume①">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-requestdata">
-   <b><a href="#dom-mediarecorder-requestdata">#dom-mediarecorder-requestdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-requestdata" class="dfn-panel" data-for="dom-mediarecorder-requestdata" id="infopanel-for-dom-mediarecorder-requestdata" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-requestdata" style="display:none">Info about the 'requestData()' definition.</span><b><a href="#dom-mediarecorder-requestdata">#dom-mediarecorder-requestdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-requestdata">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-requestdata①">2.3. Methods</a> <a href="#ref-for-dom-mediarecorder-requestdata②">(2)</a> <a href="#ref-for-dom-mediarecorder-requestdata③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorder-istypesupported">
-   <b><a href="#dom-mediarecorder-istypesupported">#dom-mediarecorder-istypesupported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorder-istypesupported" class="dfn-panel" data-for="dom-mediarecorder-istypesupported" id="infopanel-for-dom-mediarecorder-istypesupported" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorder-istypesupported" style="display:none">Info about the 'isTypeSupported(DOMString type)
+    ' definition.</span><b><a href="#dom-mediarecorder-istypesupported">#dom-mediarecorder-istypesupported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorder-istypesupported">2. Media Recorder API</a>
     <li><a href="#ref-for-dom-mediarecorder-istypesupported①">6.2. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-is-type-supported">
-   <b><a href="#abstract-opdef-is-type-supported">#abstract-opdef-is-type-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-is-type-supported" class="dfn-panel" data-for="abstract-opdef-is-type-supported" id="infopanel-for-abstract-opdef-is-type-supported" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-is-type-supported" style="display:none">Info about the 'is type supported' definition.</span><b><a href="#abstract-opdef-is-type-supported">#abstract-opdef-is-type-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-is-type-supported">2.1. Constructors</a>
     <li><a href="#ref-for-abstract-opdef-is-type-supported①">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-blob-event">
-   <b><a href="#fire-a-blob-event">#fire-a-blob-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-blob-event" class="dfn-panel" data-for="fire-a-blob-event" id="infopanel-for-fire-a-blob-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-blob-event" style="display:none">Info about the 'fire a blob event' definition.</span><b><a href="#fire-a-blob-event">#fire-a-blob-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-blob-event">2.3. Methods</a> <a href="#ref-for-fire-a-blob-event①">(2)</a> <a href="#ref-for-fire-a-blob-event②">(3)</a> <a href="#ref-for-fire-a-blob-event③">(4)</a> <a href="#ref-for-fire-a-blob-event④">(5)</a> <a href="#ref-for-fire-a-blob-event⑤">(6)</a> <a href="#ref-for-fire-a-blob-event⑥">(7)</a>
     <li><a href="#ref-for-fire-a-blob-event⑦">4.1. General principles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediarecorderoptions">
-   <b><a href="#dictdef-mediarecorderoptions">#dictdef-mediarecorderoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediarecorderoptions" class="dfn-panel" data-for="dictdef-mediarecorderoptions" id="infopanel-for-dictdef-mediarecorderoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediarecorderoptions" style="display:none">Info about the 'MediaRecorderOptions' definition.</span><b><a href="#dictdef-mediarecorderoptions">#dictdef-mediarecorderoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediarecorderoptions">2. Media Recorder API</a>
     <li><a href="#ref-for-dictdef-mediarecorderoptions①">6.2. Fingerprinting</a> <a href="#ref-for-dictdef-mediarecorderoptions②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorderoptions-mimetype">
-   <b><a href="#dom-mediarecorderoptions-mimetype">#dom-mediarecorderoptions-mimetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorderoptions-mimetype" class="dfn-panel" data-for="dom-mediarecorderoptions-mimetype" id="infopanel-for-dom-mediarecorderoptions-mimetype" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorderoptions-mimetype" style="display:none">Info about the 'mimeType' definition.</span><b><a href="#dom-mediarecorderoptions-mimetype">#dom-mediarecorderoptions-mimetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorderoptions-mimetype">2.1. Constructors</a> <a href="#ref-for-dom-mediarecorderoptions-mimetype①">(2)</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-mimetype②">2.5. MediaRecorderOptions</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-mimetype③">2.5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorderoptions-audiobitspersecond">
-   <b><a href="#dom-mediarecorderoptions-audiobitspersecond">#dom-mediarecorderoptions-audiobitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorderoptions-audiobitspersecond" class="dfn-panel" data-for="dom-mediarecorderoptions-audiobitspersecond" id="infopanel-for-dom-mediarecorderoptions-audiobitspersecond" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorderoptions-audiobitspersecond" style="display:none">Info about the 'audioBitsPerSecond' definition.</span><b><a href="#dom-mediarecorderoptions-audiobitspersecond">#dom-mediarecorderoptions-audiobitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorderoptions-audiobitspersecond">2.1. Constructors</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-audiobitspersecond①">2.5. MediaRecorderOptions</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-audiobitspersecond②">2.5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorderoptions-videobitspersecond">
-   <b><a href="#dom-mediarecorderoptions-videobitspersecond">#dom-mediarecorderoptions-videobitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorderoptions-videobitspersecond" class="dfn-panel" data-for="dom-mediarecorderoptions-videobitspersecond" id="infopanel-for-dom-mediarecorderoptions-videobitspersecond" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorderoptions-videobitspersecond" style="display:none">Info about the 'videoBitsPerSecond' definition.</span><b><a href="#dom-mediarecorderoptions-videobitspersecond">#dom-mediarecorderoptions-videobitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorderoptions-videobitspersecond">2.1. Constructors</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-videobitspersecond①">2.5. MediaRecorderOptions</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-videobitspersecond②">2.5.1. Members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorderoptions-bitspersecond">
-   <b><a href="#dom-mediarecorderoptions-bitspersecond">#dom-mediarecorderoptions-bitspersecond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorderoptions-bitspersecond" class="dfn-panel" data-for="dom-mediarecorderoptions-bitspersecond" id="infopanel-for-dom-mediarecorderoptions-bitspersecond" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorderoptions-bitspersecond" style="display:none">Info about the 'bitsPerSecond' definition.</span><b><a href="#dom-mediarecorderoptions-bitspersecond">#dom-mediarecorderoptions-bitspersecond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorderoptions-bitspersecond">2.1. Constructors</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-bitspersecond①">2.5. MediaRecorderOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecorderoptions-audiobitratemode">
-   <b><a href="#dom-mediarecorderoptions-audiobitratemode">#dom-mediarecorderoptions-audiobitratemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecorderoptions-audiobitratemode" class="dfn-panel" data-for="dom-mediarecorderoptions-audiobitratemode" id="infopanel-for-dom-mediarecorderoptions-audiobitratemode" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecorderoptions-audiobitratemode" style="display:none">Info about the 'audioBitrateMode' definition.</span><b><a href="#dom-mediarecorderoptions-audiobitratemode">#dom-mediarecorderoptions-audiobitratemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecorderoptions-audiobitratemode">2.1. Constructors</a> <a href="#ref-for-dom-mediarecorderoptions-audiobitratemode①">(2)</a>
     <li><a href="#ref-for-dom-mediarecorderoptions-audiobitratemode②">2.5. MediaRecorderOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-bitratemode">
-   <b><a href="#enumdef-bitratemode">#enumdef-bitratemode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-bitratemode" class="dfn-panel" data-for="enumdef-bitratemode" id="infopanel-for-enumdef-bitratemode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-bitratemode" style="display:none">Info about the 'BitrateMode' definition.</span><b><a href="#enumdef-bitratemode">#enumdef-bitratemode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-bitratemode">2. Media Recorder API</a>
     <li><a href="#ref-for-enumdef-bitratemode①">2.1. Constructors</a>
@@ -2198,50 +2199,50 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-enumdef-bitratemode⑥">2.5.1. Members</a> <a href="#ref-for-enumdef-bitratemode⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bitratemode-constant">
-   <b><a href="#dom-bitratemode-constant">#dom-bitratemode-constant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bitratemode-constant" class="dfn-panel" data-for="dom-bitratemode-constant" id="infopanel-for-dom-bitratemode-constant" role="dialog">
+   <span id="infopaneltitle-for-dom-bitratemode-constant" style="display:none">Info about the 'constant' definition.</span><b><a href="#dom-bitratemode-constant">#dom-bitratemode-constant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bitratemode-constant">2.6. BitrateMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bitratemode-variable">
-   <b><a href="#dom-bitratemode-variable">#dom-bitratemode-variable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bitratemode-variable" class="dfn-panel" data-for="dom-bitratemode-variable" id="infopanel-for-dom-bitratemode-variable" role="dialog">
+   <span id="infopaneltitle-for-dom-bitratemode-variable" style="display:none">Info about the 'variable' definition.</span><b><a href="#dom-bitratemode-variable">#dom-bitratemode-variable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bitratemode-variable">2.6. BitrateMode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-recordingstate">
-   <b><a href="#enumdef-recordingstate">#enumdef-recordingstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-recordingstate" class="dfn-panel" data-for="enumdef-recordingstate" id="infopanel-for-enumdef-recordingstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-recordingstate" style="display:none">Info about the 'RecordingState' definition.</span><b><a href="#enumdef-recordingstate">#enumdef-recordingstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-recordingstate">2. Media Recorder API</a>
     <li><a href="#ref-for-enumdef-recordingstate①">2.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-recordingstate-inactive">
-   <b><a href="#dom-recordingstate-inactive">#dom-recordingstate-inactive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-recordingstate-inactive" class="dfn-panel" data-for="dom-recordingstate-inactive" id="infopanel-for-dom-recordingstate-inactive" role="dialog">
+   <span id="infopaneltitle-for-dom-recordingstate-inactive" style="display:none">Info about the 'inactive' definition.</span><b><a href="#dom-recordingstate-inactive">#dom-recordingstate-inactive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-recordingstate-inactive">2.1. Constructors</a>
     <li><a href="#ref-for-dom-recordingstate-inactive①">2.3. Methods</a> <a href="#ref-for-dom-recordingstate-inactive②">(2)</a> <a href="#ref-for-dom-recordingstate-inactive③">(3)</a> <a href="#ref-for-dom-recordingstate-inactive④">(4)</a> <a href="#ref-for-dom-recordingstate-inactive⑤">(5)</a> <a href="#ref-for-dom-recordingstate-inactive⑥">(6)</a>
     <li><a href="#ref-for-dom-recordingstate-inactive⑦">2.7. RecordingState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-recordingstate-recording">
-   <b><a href="#dom-recordingstate-recording">#dom-recordingstate-recording</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-recordingstate-recording" class="dfn-panel" data-for="dom-recordingstate-recording" id="infopanel-for-dom-recordingstate-recording" role="dialog">
+   <span id="infopaneltitle-for-dom-recordingstate-recording" style="display:none">Info about the 'recording' definition.</span><b><a href="#dom-recordingstate-recording">#dom-recordingstate-recording</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-recordingstate-recording">2.3. Methods</a> <a href="#ref-for-dom-recordingstate-recording①">(2)</a> <a href="#ref-for-dom-recordingstate-recording②">(3)</a>
     <li><a href="#ref-for-dom-recordingstate-recording③">2.4. Data handling</a>
     <li><a href="#ref-for-dom-recordingstate-recording④">2.7. RecordingState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-recordingstate-paused">
-   <b><a href="#dom-recordingstate-paused">#dom-recordingstate-paused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-recordingstate-paused" class="dfn-panel" data-for="dom-recordingstate-paused" id="infopanel-for-dom-recordingstate-paused" role="dialog">
+   <span id="infopaneltitle-for-dom-recordingstate-paused" style="display:none">Info about the 'paused' definition.</span><b><a href="#dom-recordingstate-paused">#dom-recordingstate-paused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-recordingstate-paused">2.3. Methods</a> <a href="#ref-for-dom-recordingstate-paused①">(2)</a>
     <li><a href="#ref-for-dom-recordingstate-paused②">2.7. RecordingState</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blobevent">
-   <b><a href="#blobevent">#blobevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blobevent" class="dfn-panel" data-for="blobevent" id="infopanel-for-blobevent" role="dialog">
+   <span id="infopaneltitle-for-blobevent" style="display:none">Info about the 'BlobEvent' definition.</span><b><a href="#blobevent">#blobevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blobevent">2.4. Data handling</a>
     <li><a href="#ref-for-blobevent①">3.2. Attributes</a> <a href="#ref-for-blobevent②">(2)</a>
@@ -2249,14 +2250,14 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-blobevent⑤">5. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobevent-blobevent">
-   <b><a href="#dom-blobevent-blobevent">#dom-blobevent-blobevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobevent-blobevent" class="dfn-panel" data-for="dom-blobevent-blobevent" id="infopanel-for-dom-blobevent-blobevent" role="dialog">
+   <span id="infopaneltitle-for-dom-blobevent-blobevent" style="display:none">Info about the 'BlobEvent(DOMString type, BlobEventInit eventInitDict)' definition.</span><b><a href="#dom-blobevent-blobevent">#dom-blobevent-blobevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobevent-blobevent">3. Blob Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobevent-data">
-   <b><a href="#dom-blobevent-data">#dom-blobevent-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobevent-data" class="dfn-panel" data-for="dom-blobevent-data" id="infopanel-for-dom-blobevent-data" role="dialog">
+   <span id="infopaneltitle-for-dom-blobevent-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-blobevent-data">#dom-blobevent-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobevent-data">2.2. Attributes</a>
     <li><a href="#ref-for-dom-blobevent-data①">2.4. Data handling</a>
@@ -2265,45 +2266,45 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-dom-blobevent-data④">5. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobevent-timecode">
-   <b><a href="#dom-blobevent-timecode">#dom-blobevent-timecode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobevent-timecode" class="dfn-panel" data-for="dom-blobevent-timecode" id="infopanel-for-dom-blobevent-timecode" role="dialog">
+   <span id="infopaneltitle-for-dom-blobevent-timecode" style="display:none">Info about the 'timecode' definition.</span><b><a href="#dom-blobevent-timecode">#dom-blobevent-timecode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobevent-timecode">3. Blob Event</a>
     <li><a href="#ref-for-dom-blobevent-timecode①">3.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-blobeventinit">
-   <b><a href="#dictdef-blobeventinit">#dictdef-blobeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-blobeventinit" class="dfn-panel" data-for="dictdef-blobeventinit" id="infopanel-for-dictdef-blobeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-blobeventinit" style="display:none">Info about the 'BlobEventInit' definition.</span><b><a href="#dictdef-blobeventinit">#dictdef-blobeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-blobeventinit">3. Blob Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobeventinit-data">
-   <b><a href="#dom-blobeventinit-data">#dom-blobeventinit-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobeventinit-data" class="dfn-panel" data-for="dom-blobeventinit-data" id="infopanel-for-dom-blobeventinit-data" role="dialog">
+   <span id="infopaneltitle-for-dom-blobeventinit-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-blobeventinit-data">#dom-blobeventinit-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobeventinit-data">3.3. BlobEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-blobeventinit-timecode">
-   <b><a href="#dom-blobeventinit-timecode">#dom-blobeventinit-timecode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-blobeventinit-timecode" class="dfn-panel" data-for="dom-blobeventinit-timecode" id="infopanel-for-dom-blobeventinit-timecode" role="dialog">
+   <span id="infopaneltitle-for-dom-blobeventinit-timecode" style="display:none">Info about the 'timecode' definition.</span><b><a href="#dom-blobeventinit-timecode">#dom-blobeventinit-timecode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-blobeventinit-timecode">3.3. BlobEventInit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-an-error-event">
-   <b><a href="#fire-an-error-event">#fire-an-error-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-an-error-event" class="dfn-panel" data-for="fire-an-error-event" id="infopanel-for-fire-an-error-event" role="dialog">
+   <span id="infopaneltitle-for-fire-an-error-event" style="display:none">Info about the 'fire an error event' definition.</span><b><a href="#fire-an-error-event">#fire-an-error-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-an-error-event">2.3. Methods</a> <a href="#ref-for-fire-an-error-event①">(2)</a> <a href="#ref-for-fire-an-error-event②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediarecordererroreventinit">
-   <b><a href="#dictdef-mediarecordererroreventinit">#dictdef-mediarecordererroreventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediarecordererroreventinit" class="dfn-panel" data-for="dictdef-mediarecordererroreventinit" id="infopanel-for-dictdef-mediarecordererroreventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediarecordererroreventinit" style="display:none">Info about the 'MediaRecorderErrorEventInit' definition.</span><b><a href="#dictdef-mediarecordererroreventinit">#dictdef-mediarecordererroreventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediarecordererroreventinit">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediarecordererrorevent">
-   <b><a href="#mediarecordererrorevent">#mediarecordererrorevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediarecordererrorevent" class="dfn-panel" data-for="mediarecordererrorevent" id="infopanel-for-mediarecordererrorevent" role="dialog">
+   <span id="infopaneltitle-for-mediarecordererrorevent" style="display:none">Info about the 'MediaRecorderErrorEvent' definition.</span><b><a href="#mediarecordererrorevent">#mediarecordererrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediarecordererrorevent">2.2. Attributes</a>
     <li><a href="#ref-for-mediarecordererrorevent①">4.1. General principles</a>
@@ -2312,114 +2313,170 @@ the <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/mediac
     <li><a href="#ref-for-mediarecordererrorevent⑤">5. Event summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecordererrorevent-mediarecordererrorevent">
-   <b><a href="#dom-mediarecordererrorevent-mediarecordererrorevent">#dom-mediarecordererrorevent-mediarecordererrorevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecordererrorevent-mediarecordererrorevent" class="dfn-panel" data-for="dom-mediarecordererrorevent-mediarecordererrorevent" id="infopanel-for-dom-mediarecordererrorevent-mediarecordererrorevent" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecordererrorevent-mediarecordererrorevent" style="display:none">Info about the 'MediaRecorderErrorEvent(DOMString type, MediaRecorderErrorEventInit eventInitDict)' definition.</span><b><a href="#dom-mediarecordererrorevent-mediarecordererrorevent">#dom-mediarecordererrorevent-mediarecordererrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecordererrorevent-mediarecordererrorevent">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecordererrorevent-error">
-   <b><a href="#dom-mediarecordererrorevent-error">#dom-mediarecordererrorevent-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecordererrorevent-error" class="dfn-panel" data-for="dom-mediarecordererrorevent-error" id="infopanel-for-dom-mediarecordererrorevent-error" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecordererrorevent-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-mediarecordererrorevent-error">#dom-mediarecordererrorevent-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecordererrorevent-error">4.2. MediaRecorderErrorEvent</a> <a href="#ref-for-dom-mediarecordererrorevent-error①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediarecordererroreventinit-error">
-   <b><a href="#dom-mediarecordererroreventinit-error">#dom-mediarecordererroreventinit-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediarecordererroreventinit-error" class="dfn-panel" data-for="dom-mediarecordererroreventinit-error" id="infopanel-for-dom-mediarecordererroreventinit-error" role="dialog">
+   <span id="infopaneltitle-for-dom-mediarecordererroreventinit-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-mediarecordererroreventinit-error">#dom-mediarecordererroreventinit-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediarecordererroreventinit-error">4.2. MediaRecorderErrorEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediarecorder-start">
-   <b><a href="#eventdef-mediarecorder-start">#eventdef-mediarecorder-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediarecorder-start" class="dfn-panel" data-for="eventdef-mediarecorder-start" id="infopanel-for-eventdef-mediarecorder-start" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediarecorder-start" style="display:none">Info about the 'start' definition.</span><b><a href="#eventdef-mediarecorder-start">#eventdef-mediarecorder-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediarecorder-start">2.2. Attributes</a>
     <li><a href="#ref-for-eventdef-mediarecorder-start①">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediarecorder-stop">
-   <b><a href="#eventdef-mediarecorder-stop">#eventdef-mediarecorder-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediarecorder-stop" class="dfn-panel" data-for="eventdef-mediarecorder-stop" id="infopanel-for-eventdef-mediarecorder-stop" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediarecorder-stop" style="display:none">Info about the 'stop' definition.</span><b><a href="#eventdef-mediarecorder-stop">#eventdef-mediarecorder-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediarecorder-stop">2.2. Attributes</a>
     <li><a href="#ref-for-eventdef-mediarecorder-stop①">2.3. Methods</a> <a href="#ref-for-eventdef-mediarecorder-stop②">(2)</a> <a href="#ref-for-eventdef-mediarecorder-stop③">(3)</a> <a href="#ref-for-eventdef-mediarecorder-stop④">(4)</a> <a href="#ref-for-eventdef-mediarecorder-stop⑤">(5)</a>
     <li><a href="#ref-for-eventdef-mediarecorder-stop⑥">4.1. General principles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediarecorder-dataavailable">
-   <b><a href="#eventdef-mediarecorder-dataavailable">#eventdef-mediarecorder-dataavailable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediarecorder-dataavailable" class="dfn-panel" data-for="eventdef-mediarecorder-dataavailable" id="infopanel-for-eventdef-mediarecorder-dataavailable" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediarecorder-dataavailable" style="display:none">Info about the 'dataavailable' definition.</span><b><a href="#eventdef-mediarecorder-dataavailable">#eventdef-mediarecorder-dataavailable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediarecorder-dataavailable">2.2. Attributes</a>
     <li><a href="#ref-for-eventdef-mediarecorder-dataavailable①">2.3. Methods</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable②">(2)</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable③">(3)</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable④">(4)</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable⑤">(5)</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable⑥">(6)</a> <a href="#ref-for-eventdef-mediarecorder-dataavailable⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediarecorder-pause">
-   <b><a href="#eventdef-mediarecorder-pause">#eventdef-mediarecorder-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediarecorder-pause" class="dfn-panel" data-for="eventdef-mediarecorder-pause" id="infopanel-for-eventdef-mediarecorder-pause" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediarecorder-pause" style="display:none">Info about the 'pause' definition.</span><b><a href="#eventdef-mediarecorder-pause">#eventdef-mediarecorder-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediarecorder-pause">2.2. Attributes</a>
     <li><a href="#ref-for-eventdef-mediarecorder-pause①">2.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-mediarecorder-resume">
-   <b><a href="#eventdef-mediarecorder-resume">#eventdef-mediarecorder-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-mediarecorder-resume" class="dfn-panel" data-for="eventdef-mediarecorder-resume" id="infopanel-for-eventdef-mediarecorder-resume" role="dialog">
+   <span id="infopaneltitle-for-eventdef-mediarecorder-resume" style="display:none">Info about the 'resume' definition.</span><b><a href="#eventdef-mediarecorder-resume">#eventdef-mediarecorder-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-mediarecorder-resume">2.2. Attributes</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/mediacapture-transform/index.html
+++ b/tests/github/w3c/mediacapture-transform/index.html
@@ -974,8 +974,8 @@ significant security risk.</p>
      <li><a href="#mediastreamtrackprocessor-writablecontrol">dfn for MediaStreamTrackProcessor</a><span>, in § 3.1.3</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack" class="dfn-panel" data-for="term-for-dom-mediastreamtrack" id="infopanel-for-term-for-dom-mediastreamtrack" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack" style="display:none">Info about the 'MediaStreamTrack' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack">Unnumbered Section</a>
     <li><a href="#ref-for-dom-mediastreamtrack①">3. Specification</a> <a href="#ref-for-dom-mediastreamtrack②">(2)</a>
@@ -987,66 +987,66 @@ significant security risk.</p>
     <li><a href="#ref-for-dom-mediastreamtrack①⓪">3.2.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack-kind">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack-kind" class="dfn-panel" data-for="term-for-dom-mediastreamtrack-kind" id="infopanel-for-term-for-dom-mediastreamtrack-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack-kind" style="display:none">Info about the 'kind' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack-kind">3.2.2. Constructor</a> <a href="#ref-for-dom-mediastreamtrack-kind①">(2)</a>
     <li><a href="#ref-for-dom-mediastreamtrack-kind②">3.2.3. Attributes</a> <a href="#ref-for-dom-mediastreamtrack-kind③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">3.1. MediaStreamTrackProcessor interface</a>
     <li><a href="#ref-for-readablestream①">3.2. MediaStreamTrackGenerator interface</a>
     <li><a href="#ref-for-readablestream②">3.2.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream">
-   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream" class="dfn-panel" data-for="term-for-writablestream" id="infopanel-for-term-for-writablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream" style="display:none">Info about the 'WritableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">3.1. MediaStreamTrackProcessor interface</a>
     <li><a href="#ref-for-writablestream①">3.2. MediaStreamTrackGenerator interface</a>
     <li><a href="#ref-for-writablestream②">3.2.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audioframe">
-   <a href="https://wicg.github.io/web-codecs/#audioframe">https://wicg.github.io/web-codecs/#audioframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audioframe" class="dfn-panel" data-for="term-for-audioframe" id="infopanel-for-term-for-audioframe" role="menu">
+   <span id="infopaneltitle-for-term-for-audioframe" style="display:none">Info about the 'AudioFrame' external reference.</span><a href="https://wicg.github.io/web-codecs/#audioframe">https://wicg.github.io/web-codecs/#audioframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audioframe">3.1.3. Attributes</a>
     <li><a href="#ref-for-audioframe①">3.2.3. Attributes</a>
     <li><a href="#ref-for-audioframe②">5. Security and Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-videoframe">
-   <a href="https://wicg.github.io/web-codecs/#videoframe">https://wicg.github.io/web-codecs/#videoframe</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-videoframe" class="dfn-panel" data-for="term-for-videoframe" id="infopanel-for-term-for-videoframe" role="menu">
+   <span id="infopaneltitle-for-term-for-videoframe" style="display:none">Info about the 'VideoFrame' external reference.</span><a href="https://wicg.github.io/web-codecs/#videoframe">https://wicg.github.io/web-codecs/#videoframe</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-videoframe">3.1.3. Attributes</a>
     <li><a href="#ref-for-videoframe①">3.2.3. Attributes</a>
     <li><a href="#ref-for-videoframe②">5. Security and Privacy considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.2. MediaStreamTrackGenerator interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">3.1. MediaStreamTrackProcessor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">3.1.2. Constructor</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">3.2.2. Constructor</a> <a href="#ref-for-exceptiondef-typeerror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">3.1. MediaStreamTrackProcessor interface</a>
    </ul>
@@ -1135,8 +1135,8 @@ significant security risk.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="mediastreamtrackprocessor">
-   <b><a href="#mediastreamtrackprocessor">#mediastreamtrackprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediastreamtrackprocessor" class="dfn-panel" data-for="mediastreamtrackprocessor" id="infopanel-for-mediastreamtrackprocessor" role="dialog">
+   <span id="infopaneltitle-for-mediastreamtrackprocessor" style="display:none">Info about the 'MediaStreamTrackProcessor' definition.</span><b><a href="#mediastreamtrackprocessor">#mediastreamtrackprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamtrackprocessor">3.1.1. Internal slots</a> <a href="#ref-for-mediastreamtrackprocessor①">(2)</a>
     <li><a href="#ref-for-mediastreamtrackprocessor②">3.1.2. Constructor</a>
@@ -1144,45 +1144,47 @@ significant security risk.</p>
     <li><a href="#ref-for-mediastreamtrackprocessor④">3.3. Stream control</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackprocessor-readable">
-   <b><a href="#dom-mediastreamtrackprocessor-readable">#dom-mediastreamtrackprocessor-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackprocessor-readable" class="dfn-panel" data-for="dom-mediastreamtrackprocessor-readable" id="infopanel-for-dom-mediastreamtrackprocessor-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackprocessor-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-mediastreamtrackprocessor-readable">#dom-mediastreamtrackprocessor-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackprocessor-readable">3.1.3. Attributes</a> <a href="#ref-for-dom-mediastreamtrackprocessor-readable①">(2)</a> <a href="#ref-for-dom-mediastreamtrackprocessor-readable②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackprocessor-writablecontrol">
-   <b><a href="#dom-mediastreamtrackprocessor-writablecontrol">#dom-mediastreamtrackprocessor-writablecontrol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackprocessor-writablecontrol" class="dfn-panel" data-for="dom-mediastreamtrackprocessor-writablecontrol" id="infopanel-for-dom-mediastreamtrackprocessor-writablecontrol" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackprocessor-writablecontrol" style="display:none">Info about the 'writableControl' definition.</span><b><a href="#dom-mediastreamtrackprocessor-writablecontrol">#dom-mediastreamtrackprocessor-writablecontrol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackprocessor-writablecontrol">3.3. Stream control</a>
     <li><a href="#ref-for-dom-mediastreamtrackprocessor-writablecontrol①">3.3.1. Implicit signaling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediastreamtrackprocessorinit">
-   <b><a href="#dictdef-mediastreamtrackprocessorinit">#dictdef-mediastreamtrackprocessorinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediastreamtrackprocessorinit" class="dfn-panel" data-for="dictdef-mediastreamtrackprocessorinit" id="infopanel-for-dictdef-mediastreamtrackprocessorinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediastreamtrackprocessorinit" style="display:none">Info about the 'MediaStreamTrackProcessorInit' definition.</span><b><a href="#dictdef-mediastreamtrackprocessorinit">#dictdef-mediastreamtrackprocessorinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediastreamtrackprocessorinit">3.1. MediaStreamTrackProcessor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackprocessorinit-track">
-   <b><a href="#dom-mediastreamtrackprocessorinit-track">#dom-mediastreamtrackprocessorinit-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackprocessorinit-track" class="dfn-panel" data-for="dom-mediastreamtrackprocessorinit-track" id="infopanel-for-dom-mediastreamtrackprocessorinit-track" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackprocessorinit-track" style="display:none">Info about the 'track' definition.</span><b><a href="#dom-mediastreamtrackprocessorinit-track">#dom-mediastreamtrackprocessorinit-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackprocessorinit-track">3.1.2. Constructor</a> <a href="#ref-for-dom-mediastreamtrackprocessorinit-track①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackprocessorinit-maxbuffersize">
-   <b><a href="#dom-mediastreamtrackprocessorinit-maxbuffersize">#dom-mediastreamtrackprocessorinit-maxbuffersize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackprocessorinit-maxbuffersize" class="dfn-panel" data-for="dom-mediastreamtrackprocessorinit-maxbuffersize" id="infopanel-for-dom-mediastreamtrackprocessorinit-maxbuffersize" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackprocessorinit-maxbuffersize" style="display:none">Info about the 'maxBufferSize' definition.</span><b><a href="#dom-mediastreamtrackprocessorinit-maxbuffersize">#dom-mediastreamtrackprocessorinit-maxbuffersize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackprocessorinit-maxbuffersize">3.1.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackprocessor-mediastreamtrackprocessor">
-   <b><a href="#dom-mediastreamtrackprocessor-mediastreamtrackprocessor">#dom-mediastreamtrackprocessor-mediastreamtrackprocessor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackprocessor-mediastreamtrackprocessor" class="dfn-panel" data-for="dom-mediastreamtrackprocessor-mediastreamtrackprocessor" id="infopanel-for-dom-mediastreamtrackprocessor-mediastreamtrackprocessor" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackprocessor-mediastreamtrackprocessor" style="display:none">Info about the '
+  MediaStreamTrackProcessor(init)
+' definition.</span><b><a href="#dom-mediastreamtrackprocessor-mediastreamtrackprocessor">#dom-mediastreamtrackprocessor-mediastreamtrackprocessor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackprocessor-mediastreamtrackprocessor">3.1. MediaStreamTrackProcessor interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediastreamtrackgenerator">
-   <b><a href="#mediastreamtrackgenerator">#mediastreamtrackgenerator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediastreamtrackgenerator" class="dfn-panel" data-for="mediastreamtrackgenerator" id="infopanel-for-mediastreamtrackgenerator" role="dialog">
+   <span id="infopaneltitle-for-mediastreamtrackgenerator" style="display:none">Info about the 'MediaStreamTrackGenerator' definition.</span><b><a href="#mediastreamtrackgenerator">#mediastreamtrackgenerator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediastreamtrackgenerator">3.2.1. Internal slots</a>
     <li><a href="#ref-for-mediastreamtrackgenerator①">3.2.2. Constructor</a>
@@ -1190,50 +1192,52 @@ significant security risk.</p>
     <li><a href="#ref-for-mediastreamtrackgenerator④">3.3. Stream control</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediastreamtrackgeneratorinit">
-   <b><a href="#dictdef-mediastreamtrackgeneratorinit">#dictdef-mediastreamtrackgeneratorinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediastreamtrackgeneratorinit" class="dfn-panel" data-for="dictdef-mediastreamtrackgeneratorinit" id="infopanel-for-dictdef-mediastreamtrackgeneratorinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediastreamtrackgeneratorinit" style="display:none">Info about the 'MediaStreamTrackGeneratorInit' definition.</span><b><a href="#dictdef-mediastreamtrackgeneratorinit">#dictdef-mediastreamtrackgeneratorinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediastreamtrackgeneratorinit">3.2. MediaStreamTrackGenerator interface</a>
     <li><a href="#ref-for-dictdef-mediastreamtrackgeneratorinit①">3.3.1. Implicit signaling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackgeneratorinit-kind">
-   <b><a href="#dom-mediastreamtrackgeneratorinit-kind">#dom-mediastreamtrackgeneratorinit-kind</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackgeneratorinit-kind" class="dfn-panel" data-for="dom-mediastreamtrackgeneratorinit-kind" id="infopanel-for-dom-mediastreamtrackgeneratorinit-kind" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackgeneratorinit-kind" style="display:none">Info about the 'kind' definition.</span><b><a href="#dom-mediastreamtrackgeneratorinit-kind">#dom-mediastreamtrackgeneratorinit-kind</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackgeneratorinit-kind">3.2.2. Constructor</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-kind①">(2)</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-kind②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackgeneratorinit-signaltarget">
-   <b><a href="#dom-mediastreamtrackgeneratorinit-signaltarget">#dom-mediastreamtrackgeneratorinit-signaltarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackgeneratorinit-signaltarget" class="dfn-panel" data-for="dom-mediastreamtrackgeneratorinit-signaltarget" id="infopanel-for-dom-mediastreamtrackgeneratorinit-signaltarget" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackgeneratorinit-signaltarget" style="display:none">Info about the 'signalTarget' definition.</span><b><a href="#dom-mediastreamtrackgeneratorinit-signaltarget">#dom-mediastreamtrackgeneratorinit-signaltarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget">3.2.2. Constructor</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget①">(2)</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget②">(3)</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget③">(4)</a> <a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget④">(5)</a>
     <li><a href="#ref-for-dom-mediastreamtrackgeneratorinit-signaltarget⑤">3.3.1. Implicit signaling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackgenerator-mediastreamtrackgenerator">
-   <b><a href="#dom-mediastreamtrackgenerator-mediastreamtrackgenerator">#dom-mediastreamtrackgenerator-mediastreamtrackgenerator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackgenerator-mediastreamtrackgenerator" class="dfn-panel" data-for="dom-mediastreamtrackgenerator-mediastreamtrackgenerator" id="infopanel-for-dom-mediastreamtrackgenerator-mediastreamtrackgenerator" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackgenerator-mediastreamtrackgenerator" style="display:none">Info about the '
+  MediaStreamTrackGenerator(init)
+' definition.</span><b><a href="#dom-mediastreamtrackgenerator-mediastreamtrackgenerator">#dom-mediastreamtrackgenerator-mediastreamtrackgenerator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-mediastreamtrackgenerator">3.2. MediaStreamTrackGenerator interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackgenerator-writable">
-   <b><a href="#dom-mediastreamtrackgenerator-writable">#dom-mediastreamtrackgenerator-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackgenerator-writable" class="dfn-panel" data-for="dom-mediastreamtrackgenerator-writable" id="infopanel-for-dom-mediastreamtrackgenerator-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackgenerator-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-mediastreamtrackgenerator-writable">#dom-mediastreamtrackgenerator-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-writable">3.2. MediaStreamTrackGenerator interface</a>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-writable①">3.2.3. Attributes</a>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-writable②">3.3. Stream control</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtrackgenerator-readablecontrol">
-   <b><a href="#dom-mediastreamtrackgenerator-readablecontrol">#dom-mediastreamtrackgenerator-readablecontrol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtrackgenerator-readablecontrol" class="dfn-panel" data-for="dom-mediastreamtrackgenerator-readablecontrol" id="infopanel-for-dom-mediastreamtrackgenerator-readablecontrol" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtrackgenerator-readablecontrol" style="display:none">Info about the 'readableControl' definition.</span><b><a href="#dom-mediastreamtrackgenerator-readablecontrol">#dom-mediastreamtrackgenerator-readablecontrol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-readablecontrol">3.2. MediaStreamTrackGenerator interface</a>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-readablecontrol①">3.3. Stream control</a>
     <li><a href="#ref-for-dom-mediastreamtrackgenerator-readablecontrol②">3.3.1. Implicit signaling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediastreamtracksignal">
-   <b><a href="#dictdef-mediastreamtracksignal">#dictdef-mediastreamtracksignal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediastreamtracksignal" class="dfn-panel" data-for="dictdef-mediastreamtracksignal" id="infopanel-for-dictdef-mediastreamtracksignal" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediastreamtracksignal" style="display:none">Info about the 'MediaStreamTrackSignal' definition.</span><b><a href="#dictdef-mediastreamtracksignal">#dictdef-mediastreamtracksignal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediastreamtracksignal">3.1.3. Attributes</a>
     <li><a href="#ref-for-dictdef-mediastreamtracksignal①">3.2.3. Attributes</a>
@@ -1241,71 +1245,127 @@ significant security risk.</p>
     <li><a href="#ref-for-dictdef-mediastreamtracksignal④">3.3.1. Implicit signaling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediastreamtracksignal-signaltype">
-   <b><a href="#dom-mediastreamtracksignal-signaltype">#dom-mediastreamtracksignal-signaltype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediastreamtracksignal-signaltype" class="dfn-panel" data-for="dom-mediastreamtracksignal-signaltype" id="infopanel-for-dom-mediastreamtracksignal-signaltype" role="dialog">
+   <span id="infopaneltitle-for-dom-mediastreamtracksignal-signaltype" style="display:none">Info about the 'signalType' definition.</span><b><a href="#dom-mediastreamtracksignal-signaltype">#dom-mediastreamtracksignal-signaltype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtracksignal-signaltype">3.3. Stream control</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mediastreamtracksignaltype">
-   <b><a href="#enumdef-mediastreamtracksignaltype">#enumdef-mediastreamtracksignaltype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mediastreamtracksignaltype" class="dfn-panel" data-for="enumdef-mediastreamtracksignaltype" id="infopanel-for-enumdef-mediastreamtracksignaltype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mediastreamtracksignaltype" style="display:none">Info about the 'MediaStreamTrackSignalType' definition.</span><b><a href="#enumdef-mediastreamtracksignaltype">#enumdef-mediastreamtracksignaltype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mediastreamtracksignaltype">3.3. Stream control</a> <a href="#ref-for-enumdef-mediastreamtracksignaltype①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/mediasession/index.html
+++ b/tests/github/w3c/mediasession/index.html
@@ -1611,50 +1611,50 @@ support in making this specification happen.</p>
    <li><a href="#update-action-handler-algorithm">update action handler algorithm</a><span>, in § 5.4</span>
    <li><a href="#update-metadata-algorithm">update metadata algorithm</a><span>, in § 5.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-imageresource">
-   <a href="https://www.w3.org/TR/appmanifest/#dom-imageresource">https://www.w3.org/TR/appmanifest/#dom-imageresource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-imageresource" class="dfn-panel" data-for="term-for-dom-imageresource" id="infopanel-for-term-for-dom-imageresource" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-imageresource" style="display:none">Info about the 'imageresource' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dom-imageresource">https://www.w3.org/TR/appmanifest/#dom-imageresource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-imageresource">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">5.3. Metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-internal-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-internal-response" class="dfn-panel" data-for="term-for-concept-internal-response" id="infopanel-for-term-for-concept-internal-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-internal-response" style="display:none">Info about the 'internal response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-internal-response">5.3. Metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">5.3. Metadata</a> <a href="#ref-for-concept-response①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'response type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">5.3. Metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">6. The MediaSession interface</a> <a href="#ref-for-navigator①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-activation-notification">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">https://html.spec.whatwg.org/multipage/interaction.html#activation-notification</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-activation-notification" class="dfn-panel" data-for="term-for-activation-notification" id="infopanel-for-term-for-activation-notification" role="menu">
+   <span id="infopaneltitle-for-term-for-activation-notification" style="display:none">Info about the 'activation notification' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">https://html.spec.whatwg.org/multipage/interaction.html#activation-notification</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activation-notification">5.4. Actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">5.1. Playback State</a> <a href="#ref-for-browsing-context①">(2)</a> <a href="#ref-for-browsing-context②">(3)</a> <a href="#ref-for-browsing-context③">(4)</a>
     <li><a href="#ref-for-browsing-context④">5.2. Routing</a> <a href="#ref-for-browsing-context⑤">(2)</a>
@@ -1663,147 +1663,147 @@ support in making this specification happen.</p>
     <li><a href="#ref-for-browsing-context⑧">6. The MediaSession interface</a> <a href="#ref-for-browsing-context⑨">(2)</a> <a href="#ref-for-browsing-context①⓪">(3)</a> <a href="#ref-for-browsing-context①①">(4)</a> <a href="#ref-for-browsing-context①②">(5)</a> <a href="#ref-for-browsing-context①③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-entry-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-entry-settings-object" class="dfn-panel" data-for="term-for-entry-settings-object" id="infopanel-for-term-for-entry-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-entry-settings-object" style="display:none">Info about the 'entry settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-settings-object">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.3. Metadata</a>
     <li><a href="#ref-for-in-parallel①">6. The MediaSession interface</a>
     <li><a href="#ref-for-in-parallel②">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element" class="dfn-panel" data-for="term-for-media-element" id="infopanel-for-term-for-media-element" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element" style="display:none">Info about the 'media element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-media-muted">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-muted">https://html.spec.whatwg.org/multipage/media.html#concept-media-muted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-media-muted" class="dfn-panel" data-for="term-for-concept-media-muted" id="infopanel-for-term-for-concept-media-muted" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-media-muted" style="display:none">Info about the 'muted' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-muted">https://html.spec.whatwg.org/multipage/media.html#concept-media-muted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-media-muted">5.1. Playback State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-playing">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#potentially-playing">https://html.spec.whatwg.org/multipage/media.html#potentially-playing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-playing" class="dfn-panel" data-for="term-for-potentially-playing" id="infopanel-for-term-for-potentially-playing" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-playing" style="display:none">Info about the 'potentially playing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#potentially-playing">https://html.spec.whatwg.org/multipage/media.html#potentially-playing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-playing">5.1. Playback State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">5.4. Actions</a>
     <li><a href="#ref-for-queue-a-task①">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-link-sizes">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#dom-link-sizes">https://html.spec.whatwg.org/multipage/semantics.html#dom-link-sizes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-link-sizes" class="dfn-panel" data-for="term-for-dom-link-sizes" id="infopanel-for-term-for-dom-link-sizes" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-link-sizes" style="display:none">Info about the 'sizes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#dom-link-sizes">https://html.spec.whatwg.org/multipage/semantics.html#dom-link-sizes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-link-sizes">8. The MediaImage dictionary</a> <a href="#ref-for-dom-link-sizes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">5.2. Routing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unordered-set-of-unique-space-separated-tokens">
-   <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#unordered-set-of-unique-space-separated-tokens">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#unordered-set-of-unique-space-separated-tokens</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unordered-set-of-unique-space-separated-tokens" class="dfn-panel" data-for="term-for-unordered-set-of-unique-space-separated-tokens" id="infopanel-for-term-for-unordered-set-of-unique-space-separated-tokens" role="menu">
+   <span id="infopaneltitle-for-term-for-unordered-set-of-unique-space-separated-tokens" style="display:none">Info about the 'unordered set of unique space-separated tokens' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#unordered-set-of-unique-space-separated-tokens">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#unordered-set-of-unique-space-separated-tokens</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unordered-set-of-unique-space-separated-tokens">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_case_sensitive">
-   <a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_case_sensitive" class="dfn-panel" data-for="term-for-def_case_sensitive" id="infopanel-for-term-for-def_case_sensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-def_case_sensitive" style="display:none">Info about the 'case-sensitive' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_case_sensitive">2. Conformance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">8. The MediaImage dictionary</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">7. The MediaMetadata interface</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a>
     <li><a href="#ref-for-idl-DOMString⑥">8. The MediaImage dictionary</a> <a href="#ref-for-idl-DOMString⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6. The MediaSession interface</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6. The MediaSession interface</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a> <a href="#ref-for-exceptiondef-typeerror③">(4)</a>
     <li><a href="#ref-for-exceptiondef-typeerror④">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-frozen-array" class="dfn-panel" data-for="term-for-dfn-create-frozen-array" id="infopanel-for-term-for-dfn-create-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary-member">
-   <a href="https://webidl.spec.whatwg.org/#dfn-dictionary-member">https://webidl.spec.whatwg.org/#dfn-dictionary-member</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary-member" class="dfn-panel" data-for="term-for-dfn-dictionary-member" id="infopanel-for-term-for-dfn-dictionary-member" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary-member" style="display:none">Info about the 'dictionary members' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-dictionary-member">https://webidl.spec.whatwg.org/#dfn-dictionary-member</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary-member">8. The MediaImage dictionary</a> <a href="#ref-for-dfn-dictionary-member①">(2)</a> <a href="#ref-for-dfn-dictionary-member②">(3)</a>
     <li><a href="#ref-for-dfn-dictionary-member③">9. The MediaPositionState
@@ -1812,8 +1812,8 @@ dictionary</a> <a href="#ref-for-dfn-dictionary-member④">(2)</a> <a href="#ref
 MediaSessionActionDetails dictionary</a> <a href="#ref-for-dfn-dictionary-member⑦">(2)</a> <a href="#ref-for-dfn-dictionary-member⑧">(3)</a> <a href="#ref-for-dfn-dictionary-member⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">9. The MediaPositionState
 dictionary</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a>
@@ -1821,20 +1821,20 @@ dictionary</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-do
 MediaSessionActionDetails dictionary</a> <a href="#ref-for-idl-double④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object.freeze">
-   <a href="https://tc39.es/ecma262/#sec-object.freeze">https://tc39.es/ecma262/#sec-object.freeze</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object.freeze" class="dfn-panel" data-for="term-for-sec-object.freeze" id="infopanel-for-term-for-sec-object.freeze" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object.freeze" style="display:none">Info about the 'freeze' external reference.</span><a href="https://tc39.es/ecma262/#sec-object.freeze">https://tc39.es/ecma262/#sec-object.freeze</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object.freeze">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6. The MediaSession interface</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a>
    </ul>
@@ -2007,14 +2007,14 @@ MediaSessionActionDetails dictionary</a> <a href="#ref-for-idl-double④">(2)</a
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="guessed-playback-state">
-   <b><a href="#guessed-playback-state">#guessed-playback-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-guessed-playback-state" class="dfn-panel" data-for="guessed-playback-state" id="infopanel-for-guessed-playback-state" role="dialog">
+   <span id="infopaneltitle-for-guessed-playback-state" style="display:none">Info about the 'guessed playback state' definition.</span><b><a href="#guessed-playback-state">#guessed-playback-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-guessed-playback-state">5.1. Playback State</a> <a href="#ref-for-guessed-playback-state①">(2)</a> <a href="#ref-for-guessed-playback-state②">(3)</a> <a href="#ref-for-guessed-playback-state③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-playback-state">
-   <b><a href="#actual-playback-state">#actual-playback-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-playback-state" class="dfn-panel" data-for="actual-playback-state" id="infopanel-for-actual-playback-state" role="dialog">
+   <span id="infopaneltitle-for-actual-playback-state" style="display:none">Info about the 'actual playback state' definition.</span><b><a href="#actual-playback-state">#actual-playback-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-playback-state">5.1. Playback State</a> <a href="#ref-for-actual-playback-state①">(2)</a>
     <li><a href="#ref-for-actual-playback-state②">5.4. Actions</a> <a href="#ref-for-actual-playback-state③">(2)</a>
@@ -2022,8 +2022,8 @@ MediaSessionActionDetails dictionary</a> <a href="#ref-for-idl-double④">(2)</a
     <li><a href="#ref-for-actual-playback-state⑤">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-media-session">
-   <b><a href="#active-media-session">#active-media-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-media-session" class="dfn-panel" data-for="active-media-session" id="infopanel-for-active-media-session" role="dialog">
+   <span id="infopaneltitle-for-active-media-session" style="display:none">Info about the 'active media session' definition.</span><b><a href="#active-media-session">#active-media-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-media-session">4.3. Media Session Actions</a>
     <li><a href="#ref-for-active-media-session①">5.1. Playback State</a> <a href="#ref-for-active-media-session②">(2)</a>
@@ -2032,34 +2032,35 @@ MediaSessionActionDetails dictionary</a> <a href="#ref-for-idl-double④">(2)</a
     <li><a href="#ref-for-active-media-session①⑤">5.4. Actions</a> <a href="#ref-for-active-media-session①⑥">(2)</a> <a href="#ref-for-active-media-session①⑦">(3)</a> <a href="#ref-for-active-media-session①⑧">(4)</a> <a href="#ref-for-active-media-session①⑨">(5)</a> <a href="#ref-for-active-media-session②⓪">(6)</a> <a href="#ref-for-active-media-session②①">(7)</a> <a href="#ref-for-active-media-session②②">(8)</a> <a href="#ref-for-active-media-session②③">(9)</a> <a href="#ref-for-active-media-session②④">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audio-focus">
-   <b><a href="#audio-focus">#audio-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audio-focus" class="dfn-panel" data-for="audio-focus" id="infopanel-for-audio-focus" role="dialog">
+   <span id="infopaneltitle-for-audio-focus" style="display:none">Info about the 'audio focus' definition.</span><b><a href="#audio-focus">#audio-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio-focus">5.2. Routing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-metadata-algorithm">
-   <b><a href="#update-metadata-algorithm">#update-metadata-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-metadata-algorithm" class="dfn-panel" data-for="update-metadata-algorithm" id="infopanel-for-update-metadata-algorithm" role="dialog">
+   <span id="infopaneltitle-for-update-metadata-algorithm" style="display:none">Info about the 'update metadata
+    algorithm' definition.</span><b><a href="#update-metadata-algorithm">#update-metadata-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-metadata-algorithm">5.2. Routing</a>
     <li><a href="#ref-for-update-metadata-algorithm①">6. The MediaSession interface</a>
     <li><a href="#ref-for-update-metadata-algorithm②">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-image-algorithm">
-   <b><a href="#fetch-image-algorithm">#fetch-image-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-image-algorithm" class="dfn-panel" data-for="fetch-image-algorithm" id="infopanel-for-fetch-image-algorithm" role="dialog">
+   <span id="infopaneltitle-for-fetch-image-algorithm" style="display:none">Info about the 'fetch image algorithm' definition.</span><b><a href="#fetch-image-algorithm">#fetch-image-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-image-algorithm">5.3. Metadata</a> <a href="#ref-for-fetch-image-algorithm①">(2)</a> <a href="#ref-for-fetch-image-algorithm②">(3)</a> <a href="#ref-for-fetch-image-algorithm③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preferred-artwork-image">
-   <b><a href="#preferred-artwork-image">#preferred-artwork-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preferred-artwork-image" class="dfn-panel" data-for="preferred-artwork-image" id="infopanel-for-preferred-artwork-image" role="dialog">
+   <span id="infopaneltitle-for-preferred-artwork-image" style="display:none">Info about the 'preferred artwork image' definition.</span><b><a href="#preferred-artwork-image">#preferred-artwork-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preferred-artwork-image">5.3. Metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-session-action">
-   <b><a href="#media-session-action">#media-session-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-session-action" class="dfn-panel" data-for="media-session-action" id="infopanel-for-media-session-action" role="dialog">
+   <span id="infopaneltitle-for-media-session-action" style="display:none">Info about the 'media session action' definition.</span><b><a href="#media-session-action">#media-session-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-session-action">4.3. Media Session Actions</a>
     <li><a href="#ref-for-media-session-action①">5.4. Actions</a> <a href="#ref-for-media-session-action②">(2)</a> <a href="#ref-for-media-session-action③">(3)</a> <a href="#ref-for-media-session-action④">(4)</a> <a href="#ref-for-media-session-action⑤">(5)</a> <a href="#ref-for-media-session-action⑥">(6)</a> <a href="#ref-for-media-session-action⑦">(7)</a> <a href="#ref-for-media-session-action⑧">(8)</a>
@@ -2068,96 +2069,98 @@ MediaSessionActionDetails dictionary</a> <a href="#ref-for-media-session-action�
     <li><a href="#ref-for-media-session-action①③">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-session-action-source">
-   <b><a href="#media-session-action-source">#media-session-action-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-session-action-source" class="dfn-panel" data-for="media-session-action-source" id="infopanel-for-media-session-action-source" role="dialog">
+   <span id="infopaneltitle-for-media-session-action-source" style="display:none">Info about the 'media session action
+      source' definition.</span><b><a href="#media-session-action-source">#media-session-action-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-session-action-source">5.4. Actions</a> <a href="#ref-for-media-session-action-source①">(2)</a> <a href="#ref-for-media-session-action-source②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-play">
-   <b><a href="#dom-mediasessionaction-play">#dom-mediasessionaction-play</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-play" class="dfn-panel" data-for="dom-mediasessionaction-play" id="infopanel-for-dom-mediasessionaction-play" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-play" style="display:none">Info about the 'play' definition.</span><b><a href="#dom-mediasessionaction-play">#dom-mediasessionaction-play</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-play">5.1. Playback State</a> <a href="#ref-for-dom-mediasessionaction-play①">(2)</a>
     <li><a href="#ref-for-dom-mediasessionaction-play②">5.4. Actions</a> <a href="#ref-for-dom-mediasessionaction-play③">(2)</a> <a href="#ref-for-dom-mediasessionaction-play④">(3)</a> <a href="#ref-for-dom-mediasessionaction-play⑤">(4)</a>
     <li><a href="#ref-for-dom-mediasessionaction-play⑥">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-pause">
-   <b><a href="#dom-mediasessionaction-pause">#dom-mediasessionaction-pause</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-pause" class="dfn-panel" data-for="dom-mediasessionaction-pause" id="infopanel-for-dom-mediasessionaction-pause" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-pause" style="display:none">Info about the 'pause' definition.</span><b><a href="#dom-mediasessionaction-pause">#dom-mediasessionaction-pause</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-pause">5.1. Playback State</a> <a href="#ref-for-dom-mediasessionaction-pause①">(2)</a> <a href="#ref-for-dom-mediasessionaction-pause②">(3)</a>
     <li><a href="#ref-for-dom-mediasessionaction-pause③">5.4. Actions</a> <a href="#ref-for-dom-mediasessionaction-pause④">(2)</a> <a href="#ref-for-dom-mediasessionaction-pause⑤">(3)</a> <a href="#ref-for-dom-mediasessionaction-pause⑥">(4)</a>
     <li><a href="#ref-for-dom-mediasessionaction-pause⑦">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-seekbackward">
-   <b><a href="#dom-mediasessionaction-seekbackward">#dom-mediasessionaction-seekbackward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-seekbackward" class="dfn-panel" data-for="dom-mediasessionaction-seekbackward" id="infopanel-for-dom-mediasessionaction-seekbackward" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-seekbackward" style="display:none">Info about the 'seekbackward' definition.</span><b><a href="#dom-mediasessionaction-seekbackward">#dom-mediasessionaction-seekbackward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-seekbackward">6. The MediaSession interface</a>
     <li><a href="#ref-for-dom-mediasessionaction-seekbackward①">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-seekforward">
-   <b><a href="#dom-mediasessionaction-seekforward">#dom-mediasessionaction-seekforward</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-seekforward" class="dfn-panel" data-for="dom-mediasessionaction-seekforward" id="infopanel-for-dom-mediasessionaction-seekforward" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-seekforward" style="display:none">Info about the 'seekforward' definition.</span><b><a href="#dom-mediasessionaction-seekforward">#dom-mediasessionaction-seekforward</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-seekforward">6. The MediaSession interface</a>
     <li><a href="#ref-for-dom-mediasessionaction-seekforward①">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-previoustrack">
-   <b><a href="#dom-mediasessionaction-previoustrack">#dom-mediasessionaction-previoustrack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-previoustrack" class="dfn-panel" data-for="dom-mediasessionaction-previoustrack" id="infopanel-for-dom-mediasessionaction-previoustrack" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-previoustrack" style="display:none">Info about the 'previoustrack' definition.</span><b><a href="#dom-mediasessionaction-previoustrack">#dom-mediasessionaction-previoustrack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-previoustrack">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-nexttrack">
-   <b><a href="#dom-mediasessionaction-nexttrack">#dom-mediasessionaction-nexttrack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-nexttrack" class="dfn-panel" data-for="dom-mediasessionaction-nexttrack" id="infopanel-for-dom-mediasessionaction-nexttrack" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-nexttrack" style="display:none">Info about the 'nexttrack' definition.</span><b><a href="#dom-mediasessionaction-nexttrack">#dom-mediasessionaction-nexttrack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-nexttrack">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-skipad">
-   <b><a href="#dom-mediasessionaction-skipad">#dom-mediasessionaction-skipad</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-skipad" class="dfn-panel" data-for="dom-mediasessionaction-skipad" id="infopanel-for-dom-mediasessionaction-skipad" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-skipad" style="display:none">Info about the 'skipad' definition.</span><b><a href="#dom-mediasessionaction-skipad">#dom-mediasessionaction-skipad</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-skipad">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-stop">
-   <b><a href="#dom-mediasessionaction-stop">#dom-mediasessionaction-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-stop" class="dfn-panel" data-for="dom-mediasessionaction-stop" id="infopanel-for-dom-mediasessionaction-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-stop" style="display:none">Info about the 'stop' definition.</span><b><a href="#dom-mediasessionaction-stop">#dom-mediasessionaction-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-stop">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionaction-seekto">
-   <b><a href="#dom-mediasessionaction-seekto">#dom-mediasessionaction-seekto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionaction-seekto" class="dfn-panel" data-for="dom-mediasessionaction-seekto" id="infopanel-for-dom-mediasessionaction-seekto" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionaction-seekto" style="display:none">Info about the 'seekto' definition.</span><b><a href="#dom-mediasessionaction-seekto">#dom-mediasessionaction-seekto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionaction-seekto">6. The MediaSession interface</a>
     <li><a href="#ref-for-dom-mediasessionaction-seekto①">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-media-session-actions">
-   <b><a href="#supported-media-session-actions">#supported-media-session-actions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-media-session-actions" class="dfn-panel" data-for="supported-media-session-actions" id="infopanel-for-supported-media-session-actions" role="dialog">
+   <span id="infopaneltitle-for-supported-media-session-actions" style="display:none">Info about the 'supported media session
+      actions' definition.</span><b><a href="#supported-media-session-actions">#supported-media-session-actions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-media-session-actions">5.4. Actions</a> <a href="#ref-for-supported-media-session-actions①">(2)</a> <a href="#ref-for-supported-media-session-actions②">(3)</a> <a href="#ref-for-supported-media-session-actions③">(4)</a> <a href="#ref-for-supported-media-session-actions④">(5)</a> <a href="#ref-for-supported-media-session-actions⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-action-handler-algorithm">
-   <b><a href="#update-action-handler-algorithm">#update-action-handler-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-action-handler-algorithm" class="dfn-panel" data-for="update-action-handler-algorithm" id="infopanel-for-update-action-handler-algorithm" role="dialog">
+   <span id="infopaneltitle-for-update-action-handler-algorithm" style="display:none">Info about the 'update action handler algorithm' definition.</span><b><a href="#update-action-handler-algorithm">#update-action-handler-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-action-handler-algorithm">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-media-session-action">
-   <b><a href="#handle-media-session-action">#handle-media-session-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-media-session-action" class="dfn-panel" data-for="handle-media-session-action" id="infopanel-for-handle-media-session-action" role="dialog">
+   <span id="infopaneltitle-for-handle-media-session-action" style="display:none">Info about the 'handle media session action' definition.</span><b><a href="#handle-media-session-action">#handle-media-session-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-media-session-action">5.4. Actions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-session-actions-update-algorithm">
-   <b><a href="#media-session-actions-update-algorithm">#media-session-actions-update-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-session-actions-update-algorithm" class="dfn-panel" data-for="media-session-actions-update-algorithm" id="infopanel-for-media-session-actions-update-algorithm" role="dialog">
+   <span id="infopaneltitle-for-media-session-actions-update-algorithm" style="display:none">Info about the 'media session actions update algorithm' definition.</span><b><a href="#media-session-actions-update-algorithm">#media-session-actions-update-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-session-actions-update-algorithm">5.1. Playback State</a>
     <li><a href="#ref-for-media-session-actions-update-algorithm①">5.2. Routing</a>
@@ -2165,65 +2168,65 @@ MediaSessionActionDetails dictionary</a>
     <li><a href="#ref-for-media-session-actions-update-algorithm④">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="position-state①">
-   <b><a href="#position-state①">#position-state①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-position-state①" class="dfn-panel" data-for="position-state①" id="infopanel-for-position-state①" role="dialog">
+   <span id="infopaneltitle-for-position-state①" style="display:none">Info about the 'position state' definition.</span><b><a href="#position-state①">#position-state①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-position-state①">5.5. Position State</a> <a href="#ref-for-position-state①①">(2)</a> <a href="#ref-for-position-state①②">(3)</a> <a href="#ref-for-position-state①③">(4)</a>
     <li><a href="#ref-for-position-state①④">6. The MediaSession interface</a> <a href="#ref-for-position-state①⑤">(2)</a>
     <li><a href="#ref-for-position-state①⑥">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="duration">
-   <b><a href="#duration">#duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-duration" class="dfn-panel" data-for="duration" id="infopanel-for-duration" role="dialog">
+   <span id="infopaneltitle-for-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#duration">#duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-duration">5.5. Position State</a> <a href="#ref-for-duration①">(2)</a> <a href="#ref-for-duration②">(3)</a>
     <li><a href="#ref-for-duration③">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="playback-rate">
-   <b><a href="#playback-rate">#playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-playback-rate" class="dfn-panel" data-for="playback-rate" id="infopanel-for-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-playback-rate" style="display:none">Info about the 'playback rate' definition.</span><b><a href="#playback-rate">#playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-playback-rate">5.5. Position State</a>
     <li><a href="#ref-for-playback-rate①">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-reported-playback-position">
-   <b><a href="#last-reported-playback-position">#last-reported-playback-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-reported-playback-position" class="dfn-panel" data-for="last-reported-playback-position" id="infopanel-for-last-reported-playback-position" role="dialog">
+   <span id="infopaneltitle-for-last-reported-playback-position" style="display:none">Info about the 'last reported playback position' definition.</span><b><a href="#last-reported-playback-position">#last-reported-playback-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-reported-playback-position">5.5. Position State</a>
     <li><a href="#ref-for-last-reported-playback-position①">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-position-updated-time">
-   <b><a href="#last-position-updated-time">#last-position-updated-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-position-updated-time" class="dfn-panel" data-for="last-position-updated-time" id="infopanel-for-last-position-updated-time" role="dialog">
+   <span id="infopaneltitle-for-last-position-updated-time" style="display:none">Info about the 'last position updated time' definition.</span><b><a href="#last-position-updated-time">#last-position-updated-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-position-updated-time">5.5. Position State</a>
     <li><a href="#ref-for-last-position-updated-time①">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actual-playback-rate">
-   <b><a href="#actual-playback-rate">#actual-playback-rate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actual-playback-rate" class="dfn-panel" data-for="actual-playback-rate" id="infopanel-for-actual-playback-rate" role="dialog">
+   <span id="infopaneltitle-for-actual-playback-rate" style="display:none">Info about the 'actual playback rate' definition.</span><b><a href="#actual-playback-rate">#actual-playback-rate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-playback-rate">5.5. Position State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-playback-position">
-   <b><a href="#current-playback-position">#current-playback-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-playback-position" class="dfn-panel" data-for="current-playback-position" id="infopanel-for-current-playback-position" role="dialog">
+   <span id="infopaneltitle-for-current-playback-position" style="display:none">Info about the 'current playback position' definition.</span><b><a href="#current-playback-position">#current-playback-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-playback-position">5.5. Position State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mediasessionplaybackstate">
-   <b><a href="#enumdef-mediasessionplaybackstate">#enumdef-mediasessionplaybackstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mediasessionplaybackstate" class="dfn-panel" data-for="enumdef-mediasessionplaybackstate" id="infopanel-for-enumdef-mediasessionplaybackstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mediasessionplaybackstate" style="display:none">Info about the 'MediaSessionPlaybackState' definition.</span><b><a href="#enumdef-mediasessionplaybackstate">#enumdef-mediasessionplaybackstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mediasessionplaybackstate">6. The MediaSession interface</a> <a href="#ref-for-enumdef-mediasessionplaybackstate①">(2)</a> <a href="#ref-for-enumdef-mediasessionplaybackstate②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mediasessionaction">
-   <b><a href="#enumdef-mediasessionaction">#enumdef-mediasessionaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mediasessionaction" class="dfn-panel" data-for="enumdef-mediasessionaction" id="infopanel-for-enumdef-mediasessionaction" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mediasessionaction" style="display:none">Info about the 'MediaSessionAction' definition.</span><b><a href="#enumdef-mediasessionaction">#enumdef-mediasessionaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mediasessionaction">5.4. Actions</a>
     <li><a href="#ref-for-enumdef-mediasessionaction①">6. The MediaSession interface</a>
@@ -2231,8 +2234,8 @@ dictionary</a>
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-mediasessionactionhandler">
-   <b><a href="#callbackdef-mediasessionactionhandler">#callbackdef-mediasessionactionhandler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-mediasessionactionhandler" class="dfn-panel" data-for="callbackdef-mediasessionactionhandler" id="infopanel-for-callbackdef-mediasessionactionhandler" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-mediasessionactionhandler" style="display:none">Info about the 'MediaSessionActionHandler' definition.</span><b><a href="#callbackdef-mediasessionactionhandler">#callbackdef-mediasessionactionhandler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-mediasessionactionhandler">5.4. Actions</a> <a href="#ref-for-callbackdef-mediasessionactionhandler①">(2)</a> <a href="#ref-for-callbackdef-mediasessionactionhandler②">(3)</a>
     <li><a href="#ref-for-callbackdef-mediasessionactionhandler③">6. The MediaSession interface</a>
@@ -2240,8 +2243,8 @@ MediaSessionActionDetails dictionary</a>
 MediaSessionActionDetails dictionary</a> <a href="#ref-for-callbackdef-mediasessionactionhandler⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediasession">
-   <b><a href="#mediasession">#mediasession</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediasession" class="dfn-panel" data-for="mediasession" id="infopanel-for-mediasession" role="dialog">
+   <span id="infopaneltitle-for-mediasession" style="display:none">Info about the 'MediaSession' definition.</span><b><a href="#mediasession">#mediasession</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediasession">5.2. Routing</a> <a href="#ref-for-mediasession①">(2)</a> <a href="#ref-for-mediasession②">(3)</a>
     <li><a href="#ref-for-mediasession③">5.4. Actions</a> <a href="#ref-for-mediasession④">(2)</a> <a href="#ref-for-mediasession⑤">(3)</a> <a href="#ref-for-mediasession⑥">(4)</a> <a href="#ref-for-mediasession⑦">(5)</a>
@@ -2251,28 +2254,28 @@ MediaSessionActionDetails dictionary</a> <a href="#ref-for-callbackdef-mediasess
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediasession-metadata">
-   <b><a href="#mediasession-metadata">#mediasession-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediasession-metadata" class="dfn-panel" data-for="mediasession-metadata" id="infopanel-for-mediasession-metadata" role="dialog">
+   <span id="infopaneltitle-for-mediasession-metadata" style="display:none">Info about the 'metadata' definition.</span><b><a href="#mediasession-metadata">#mediasession-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediasession-metadata">6. The MediaSession interface</a> <a href="#ref-for-mediasession-metadata①">(2)</a> <a href="#ref-for-mediasession-metadata②">(3)</a> <a href="#ref-for-mediasession-metadata③">(4)</a> <a href="#ref-for-mediasession-metadata④">(5)</a>
     <li><a href="#ref-for-mediasession-metadata⑤">11. Examples</a> <a href="#ref-for-mediasession-metadata⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-mediasession">
-   <b><a href="#dom-navigator-mediasession">#dom-navigator-mediasession</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-mediasession" class="dfn-panel" data-for="dom-navigator-mediasession" id="infopanel-for-dom-navigator-mediasession" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-mediasession" style="display:none">Info about the 'mediaSession' definition.</span><b><a href="#dom-navigator-mediasession">#dom-navigator-mediasession</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-mediasession">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasession-metadata">
-   <b><a href="#dom-mediasession-metadata">#dom-mediasession-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasession-metadata" class="dfn-panel" data-for="dom-mediasession-metadata" id="infopanel-for-dom-mediasession-metadata" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasession-metadata" style="display:none">Info about the 'metadata' definition.</span><b><a href="#dom-mediasession-metadata">#dom-mediasession-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasession-metadata">5.3. Metadata</a> <a href="#ref-for-dom-mediasession-metadata①">(2)</a> <a href="#ref-for-dom-mediasession-metadata②">(3)</a>
     <li><a href="#ref-for-dom-mediasession-metadata③">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasession-playbackstate">
-   <b><a href="#dom-mediasession-playbackstate">#dom-mediasession-playbackstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasession-playbackstate" class="dfn-panel" data-for="dom-mediasession-playbackstate" id="infopanel-for-dom-mediasession-playbackstate" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasession-playbackstate" style="display:none">Info about the 'playbackState' definition.</span><b><a href="#dom-mediasession-playbackstate">#dom-mediasession-playbackstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasession-playbackstate">5.1. Playback State</a> <a href="#ref-for-dom-mediasession-playbackstate①">(2)</a>
     <li><a href="#ref-for-dom-mediasession-playbackstate②">5.2. Routing</a>
@@ -2280,48 +2283,48 @@ dictionary</a>
     <li><a href="#ref-for-dom-mediasession-playbackstate⑦">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-playback-state">
-   <b><a href="#declared-playback-state">#declared-playback-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-playback-state" class="dfn-panel" data-for="declared-playback-state" id="infopanel-for-declared-playback-state" role="dialog">
+   <span id="infopaneltitle-for-declared-playback-state" style="display:none">Info about the 'declared playback state' definition.</span><b><a href="#declared-playback-state">#declared-playback-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-playback-state">5.1. Playback State</a> <a href="#ref-for-declared-playback-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionplaybackstate-none">
-   <b><a href="#dom-mediasessionplaybackstate-none">#dom-mediasessionplaybackstate-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionplaybackstate-none" class="dfn-panel" data-for="dom-mediasessionplaybackstate-none" id="infopanel-for-dom-mediasessionplaybackstate-none" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionplaybackstate-none" style="display:none">Info about the 'none' definition.</span><b><a href="#dom-mediasessionplaybackstate-none">#dom-mediasessionplaybackstate-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-none">6. The MediaSession interface</a> <a href="#ref-for-dom-mediasessionplaybackstate-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionplaybackstate-playing">
-   <b><a href="#dom-mediasessionplaybackstate-playing">#dom-mediasessionplaybackstate-playing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionplaybackstate-playing" class="dfn-panel" data-for="dom-mediasessionplaybackstate-playing" id="infopanel-for-dom-mediasessionplaybackstate-playing" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionplaybackstate-playing" style="display:none">Info about the 'playing' definition.</span><b><a href="#dom-mediasessionplaybackstate-playing">#dom-mediasessionplaybackstate-playing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-playing">5.1. Playback State</a> <a href="#ref-for-dom-mediasessionplaybackstate-playing①">(2)</a> <a href="#ref-for-dom-mediasessionplaybackstate-playing②">(3)</a>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-playing③">5.4. Actions</a> <a href="#ref-for-dom-mediasessionplaybackstate-playing④">(2)</a>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-playing⑤">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionplaybackstate-paused">
-   <b><a href="#dom-mediasessionplaybackstate-paused">#dom-mediasessionplaybackstate-paused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionplaybackstate-paused" class="dfn-panel" data-for="dom-mediasessionplaybackstate-paused" id="infopanel-for-dom-mediasessionplaybackstate-paused" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionplaybackstate-paused" style="display:none">Info about the 'paused' definition.</span><b><a href="#dom-mediasessionplaybackstate-paused">#dom-mediasessionplaybackstate-paused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-paused">5.1. Playback State</a>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-paused①">5.5. Position State</a>
     <li><a href="#ref-for-dom-mediasessionplaybackstate-paused②">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasession-setactionhandler">
-   <b><a href="#dom-mediasession-setactionhandler">#dom-mediasession-setactionhandler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasession-setactionhandler" class="dfn-panel" data-for="dom-mediasession-setactionhandler" id="infopanel-for-dom-mediasession-setactionhandler" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasession-setactionhandler" style="display:none">Info about the 'setActionHandler(action, handler)' definition.</span><b><a href="#dom-mediasession-setactionhandler">#dom-mediasession-setactionhandler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasession-setactionhandler">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasession-setpositionstate">
-   <b><a href="#dom-mediasession-setpositionstate">#dom-mediasession-setpositionstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasession-setpositionstate" class="dfn-panel" data-for="dom-mediasession-setpositionstate" id="infopanel-for-dom-mediasession-setpositionstate" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasession-setpositionstate" style="display:none">Info about the 'setPositionState(state)' definition.</span><b><a href="#dom-mediasession-setpositionstate">#dom-mediasession-setpositionstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasession-setpositionstate">6. The MediaSession interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata">
-   <b><a href="#mediametadata">#mediametadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata" class="dfn-panel" data-for="mediametadata" id="infopanel-for-mediametadata" role="dialog">
+   <span id="infopaneltitle-for-mediametadata" style="display:none">Info about the 'MediaMetadata' definition.</span><b><a href="#mediametadata">#mediametadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata">4.1. User interface guidelines</a> <a href="#ref-for-mediametadata①">(2)</a> <a href="#ref-for-mediametadata②">(3)</a> <a href="#ref-for-mediametadata③">(4)</a> <a href="#ref-for-mediametadata④">(5)</a>
     <li><a href="#ref-for-mediametadata⑤">4.2. Incognito mode</a>
@@ -2329,144 +2332,146 @@ dictionary</a>
     <li><a href="#ref-for-mediametadata⑧">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata⑨">(2)</a> <a href="#ref-for-mediametadata①⓪">(3)</a> <a href="#ref-for-mediametadata①①">(4)</a> <a href="#ref-for-mediametadata①②">(5)</a> <a href="#ref-for-mediametadata①③">(6)</a> <a href="#ref-for-mediametadata①④">(7)</a> <a href="#ref-for-mediametadata①⑤">(8)</a> <a href="#ref-for-mediametadata①⑥">(9)</a> <a href="#ref-for-mediametadata①⑦">(10)</a> <a href="#ref-for-mediametadata①⑧">(11)</a> <a href="#ref-for-mediametadata①⑨">(12)</a> <a href="#ref-for-mediametadata②⓪">(13)</a> <a href="#ref-for-mediametadata②①">(14)</a> <a href="#ref-for-mediametadata②②">(15)</a> <a href="#ref-for-mediametadata②③">(16)</a> <a href="#ref-for-mediametadata②④">(17)</a> <a href="#ref-for-mediametadata②⑤">(18)</a> <a href="#ref-for-mediametadata②⑥">(19)</a> <a href="#ref-for-mediametadata②⑦">(20)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediametadatainit">
-   <b><a href="#dictdef-mediametadatainit">#dictdef-mediametadatainit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediametadatainit" class="dfn-panel" data-for="dictdef-mediametadatainit" id="infopanel-for-dictdef-mediametadatainit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediametadatainit" style="display:none">Info about the 'MediaMetadataInit' definition.</span><b><a href="#dictdef-mediametadatainit">#dictdef-mediametadatainit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediametadatainit">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadatainit-title">
-   <b><a href="#dom-mediametadatainit-title">#dom-mediametadatainit-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadatainit-title" class="dfn-panel" data-for="dom-mediametadatainit-title" id="infopanel-for-dom-mediametadatainit-title" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadatainit-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-mediametadatainit-title">#dom-mediametadatainit-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadatainit-title">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadatainit-artist">
-   <b><a href="#dom-mediametadatainit-artist">#dom-mediametadatainit-artist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadatainit-artist" class="dfn-panel" data-for="dom-mediametadatainit-artist" id="infopanel-for-dom-mediametadatainit-artist" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadatainit-artist" style="display:none">Info about the 'artist' definition.</span><b><a href="#dom-mediametadatainit-artist">#dom-mediametadatainit-artist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadatainit-artist">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadatainit-album">
-   <b><a href="#dom-mediametadatainit-album">#dom-mediametadatainit-album</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadatainit-album" class="dfn-panel" data-for="dom-mediametadatainit-album" id="infopanel-for-dom-mediametadatainit-album" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadatainit-album" style="display:none">Info about the 'album' definition.</span><b><a href="#dom-mediametadatainit-album">#dom-mediametadatainit-album</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadatainit-album">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadatainit-artwork">
-   <b><a href="#dom-mediametadatainit-artwork">#dom-mediametadatainit-artwork</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadatainit-artwork" class="dfn-panel" data-for="dom-mediametadatainit-artwork" id="infopanel-for-dom-mediametadatainit-artwork" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadatainit-artwork" style="display:none">Info about the 'artwork' definition.</span><b><a href="#dom-mediametadatainit-artwork">#dom-mediametadatainit-artwork</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadatainit-artwork">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediametadatainit-artwork①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata-media-session">
-   <b><a href="#mediametadata-media-session">#mediametadata-media-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata-media-session" class="dfn-panel" data-for="mediametadata-media-session" id="infopanel-for-mediametadata-media-session" role="dialog">
+   <span id="infopaneltitle-for-mediametadata-media-session" style="display:none">Info about the 'media
+  session' definition.</span><b><a href="#mediametadata-media-session">#mediametadata-media-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata-media-session">6. The MediaSession interface</a> <a href="#ref-for-mediametadata-media-session①">(2)</a> <a href="#ref-for-mediametadata-media-session②">(3)</a>
     <li><a href="#ref-for-mediametadata-media-session③">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata-media-session④">(2)</a>
     <li><a href="#ref-for-mediametadata-media-session⑤">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata-title">
-   <b><a href="#mediametadata-title">#mediametadata-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata-title" class="dfn-panel" data-for="mediametadata-title" id="infopanel-for-mediametadata-title" role="dialog">
+   <span id="infopaneltitle-for-mediametadata-title" style="display:none">Info about the 'title' definition.</span><b><a href="#mediametadata-title">#mediametadata-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata-title">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata-title①">(2)</a> <a href="#ref-for-mediametadata-title②">(3)</a> <a href="#ref-for-mediametadata-title③">(4)</a> <a href="#ref-for-mediametadata-title④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata-artist">
-   <b><a href="#mediametadata-artist">#mediametadata-artist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata-artist" class="dfn-panel" data-for="mediametadata-artist" id="infopanel-for-mediametadata-artist" role="dialog">
+   <span id="infopaneltitle-for-mediametadata-artist" style="display:none">Info about the 'artist' definition.</span><b><a href="#mediametadata-artist">#mediametadata-artist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata-artist">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata-artist①">(2)</a> <a href="#ref-for-mediametadata-artist②">(3)</a> <a href="#ref-for-mediametadata-artist③">(4)</a> <a href="#ref-for-mediametadata-artist④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata-album">
-   <b><a href="#mediametadata-album">#mediametadata-album</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata-album" class="dfn-panel" data-for="mediametadata-album" id="infopanel-for-mediametadata-album" role="dialog">
+   <span id="infopaneltitle-for-mediametadata-album" style="display:none">Info about the 'album' definition.</span><b><a href="#mediametadata-album">#mediametadata-album</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata-album">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata-album①">(2)</a> <a href="#ref-for-mediametadata-album②">(3)</a> <a href="#ref-for-mediametadata-album③">(4)</a> <a href="#ref-for-mediametadata-album④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mediametadata-artwork-images">
-   <b><a href="#mediametadata-artwork-images">#mediametadata-artwork-images</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mediametadata-artwork-images" class="dfn-panel" data-for="mediametadata-artwork-images" id="infopanel-for-mediametadata-artwork-images" role="dialog">
+   <span id="infopaneltitle-for-mediametadata-artwork-images" style="display:none">Info about the 'artwork
+  images' definition.</span><b><a href="#mediametadata-artwork-images">#mediametadata-artwork-images</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mediametadata-artwork-images">5.3. Metadata</a>
     <li><a href="#ref-for-mediametadata-artwork-images①">7. The MediaMetadata interface</a> <a href="#ref-for-mediametadata-artwork-images②">(2)</a> <a href="#ref-for-mediametadata-artwork-images③">(3)</a> <a href="#ref-for-mediametadata-artwork-images④">(4)</a> <a href="#ref-for-mediametadata-artwork-images⑤">(5)</a> <a href="#ref-for-mediametadata-artwork-images⑥">(6)</a>
     <li><a href="#ref-for-mediametadata-artwork-images⑦">11. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-metadata">
-   <b><a href="#empty-metadata">#empty-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-metadata" class="dfn-panel" data-for="empty-metadata" id="infopanel-for-empty-metadata" role="dialog">
+   <span id="infopaneltitle-for-empty-metadata" style="display:none">Info about the 'empty metadata' definition.</span><b><a href="#empty-metadata">#empty-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-metadata">5.3. Metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadata-mediametadata">
-   <b><a href="#dom-mediametadata-mediametadata">#dom-mediametadata-mediametadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadata-mediametadata" class="dfn-panel" data-for="dom-mediametadata-mediametadata" id="infopanel-for-dom-mediametadata-mediametadata" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadata-mediametadata" style="display:none">Info about the 'MediaMetadata(init)' definition.</span><b><a href="#dom-mediametadata-mediametadata">#dom-mediametadata-mediametadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadata-mediametadata">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-artwork-algorithm">
-   <b><a href="#convert-artwork-algorithm">#convert-artwork-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-artwork-algorithm" class="dfn-panel" data-for="convert-artwork-algorithm" id="infopanel-for-convert-artwork-algorithm" role="dialog">
+   <span id="infopaneltitle-for-convert-artwork-algorithm" style="display:none">Info about the 'convert artwork algorithm' definition.</span><b><a href="#convert-artwork-algorithm">#convert-artwork-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-artwork-algorithm">7. The MediaMetadata interface</a> <a href="#ref-for-convert-artwork-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadata-title">
-   <b><a href="#dom-mediametadata-title">#dom-mediametadata-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadata-title" class="dfn-panel" data-for="dom-mediametadata-title" id="infopanel-for-dom-mediametadata-title" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadata-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-mediametadata-title">#dom-mediametadata-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadata-title">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediametadata-title①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadata-artist">
-   <b><a href="#dom-mediametadata-artist">#dom-mediametadata-artist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadata-artist" class="dfn-panel" data-for="dom-mediametadata-artist" id="infopanel-for-dom-mediametadata-artist" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadata-artist" style="display:none">Info about the 'artist' definition.</span><b><a href="#dom-mediametadata-artist">#dom-mediametadata-artist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadata-artist">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediametadata-artist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadata-album">
-   <b><a href="#dom-mediametadata-album">#dom-mediametadata-album</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadata-album" class="dfn-panel" data-for="dom-mediametadata-album" id="infopanel-for-dom-mediametadata-album" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadata-album" style="display:none">Info about the 'album' definition.</span><b><a href="#dom-mediametadata-album">#dom-mediametadata-album</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadata-album">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediametadata-album①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediametadata-artwork">
-   <b><a href="#dom-mediametadata-artwork">#dom-mediametadata-artwork</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediametadata-artwork" class="dfn-panel" data-for="dom-mediametadata-artwork" id="infopanel-for-dom-mediametadata-artwork" role="dialog">
+   <span id="infopaneltitle-for-dom-mediametadata-artwork" style="display:none">Info about the 'artwork' definition.</span><b><a href="#dom-mediametadata-artwork">#dom-mediametadata-artwork</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediametadata-artwork">5.3. Metadata</a> <a href="#ref-for-dom-mediametadata-artwork①">(2)</a>
     <li><a href="#ref-for-dom-mediametadata-artwork②">7. The MediaMetadata interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediaimage">
-   <b><a href="#dictdef-mediaimage">#dictdef-mediaimage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediaimage" class="dfn-panel" data-for="dictdef-mediaimage" id="infopanel-for-dictdef-mediaimage" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediaimage" style="display:none">Info about the 'MediaImage' definition.</span><b><a href="#dictdef-mediaimage">#dictdef-mediaimage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediaimage">7. The MediaMetadata interface</a> <a href="#ref-for-dictdef-mediaimage①">(2)</a> <a href="#ref-for-dictdef-mediaimage②">(3)</a> <a href="#ref-for-dictdef-mediaimage③">(4)</a> <a href="#ref-for-dictdef-mediaimage④">(5)</a> <a href="#ref-for-dictdef-mediaimage⑤">(6)</a>
     <li><a href="#ref-for-dictdef-mediaimage⑥">8. The MediaImage dictionary</a> <a href="#ref-for-dictdef-mediaimage⑦">(2)</a> <a href="#ref-for-dictdef-mediaimage⑧">(3)</a> <a href="#ref-for-dictdef-mediaimage⑨">(4)</a> <a href="#ref-for-dictdef-mediaimage①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaimage-src">
-   <b><a href="#dom-mediaimage-src">#dom-mediaimage-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaimage-src" class="dfn-panel" data-for="dom-mediaimage-src" id="infopanel-for-dom-mediaimage-src" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaimage-src" style="display:none">Info about the 'src' definition.</span><b><a href="#dom-mediaimage-src">#dom-mediaimage-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaimage-src">5.3. Metadata</a>
     <li><a href="#ref-for-dom-mediaimage-src①">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediaimage-src②">(2)</a> <a href="#ref-for-dom-mediaimage-src③">(3)</a> <a href="#ref-for-dom-mediaimage-src④">(4)</a>
     <li><a href="#ref-for-dom-mediaimage-src⑤">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaimage-sizes">
-   <b><a href="#dom-mediaimage-sizes">#dom-mediaimage-sizes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaimage-sizes" class="dfn-panel" data-for="dom-mediaimage-sizes" id="infopanel-for-dom-mediaimage-sizes" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaimage-sizes" style="display:none">Info about the 'sizes' definition.</span><b><a href="#dom-mediaimage-sizes">#dom-mediaimage-sizes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaimage-sizes">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediaimage-sizes①">(2)</a> <a href="#ref-for-dom-mediaimage-sizes②">(3)</a> <a href="#ref-for-dom-mediaimage-sizes③">(4)</a>
     <li><a href="#ref-for-dom-mediaimage-sizes④">8. The MediaImage dictionary</a> <a href="#ref-for-dom-mediaimage-sizes⑤">(2)</a> <a href="#ref-for-dom-mediaimage-sizes⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediaimage-type">
-   <b><a href="#dom-mediaimage-type">#dom-mediaimage-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediaimage-type" class="dfn-panel" data-for="dom-mediaimage-type" id="infopanel-for-dom-mediaimage-type" role="dialog">
+   <span id="infopaneltitle-for-dom-mediaimage-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-mediaimage-type">#dom-mediaimage-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediaimage-type">7. The MediaMetadata interface</a> <a href="#ref-for-dom-mediaimage-type①">(2)</a> <a href="#ref-for-dom-mediaimage-type②">(3)</a> <a href="#ref-for-dom-mediaimage-type③">(4)</a>
     <li><a href="#ref-for-dom-mediaimage-type④">8. The MediaImage dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediapositionstate">
-   <b><a href="#dictdef-mediapositionstate">#dictdef-mediapositionstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediapositionstate" class="dfn-panel" data-for="dictdef-mediapositionstate" id="infopanel-for-dictdef-mediapositionstate" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediapositionstate" style="display:none">Info about the 'MediaPositionState' definition.</span><b><a href="#dictdef-mediapositionstate">#dictdef-mediapositionstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediapositionstate">5.5. Position State</a>
     <li><a href="#ref-for-dictdef-mediapositionstate①">6. The MediaSession interface</a>
@@ -2474,32 +2479,32 @@ dictionary</a>
 dictionary</a> <a href="#ref-for-dictdef-mediapositionstate③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediapositionstate-duration">
-   <b><a href="#dom-mediapositionstate-duration">#dom-mediapositionstate-duration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediapositionstate-duration" class="dfn-panel" data-for="dom-mediapositionstate-duration" id="infopanel-for-dom-mediapositionstate-duration" role="dialog">
+   <span id="infopaneltitle-for-dom-mediapositionstate-duration" style="display:none">Info about the 'duration' definition.</span><b><a href="#dom-mediapositionstate-duration">#dom-mediapositionstate-duration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediapositionstate-duration">6. The MediaSession interface</a> <a href="#ref-for-dom-mediapositionstate-duration①">(2)</a> <a href="#ref-for-dom-mediapositionstate-duration②">(3)</a>
     <li><a href="#ref-for-dom-mediapositionstate-duration③">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediapositionstate-playbackrate">
-   <b><a href="#dom-mediapositionstate-playbackrate">#dom-mediapositionstate-playbackrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediapositionstate-playbackrate" class="dfn-panel" data-for="dom-mediapositionstate-playbackrate" id="infopanel-for-dom-mediapositionstate-playbackrate" role="dialog">
+   <span id="infopaneltitle-for-dom-mediapositionstate-playbackrate" style="display:none">Info about the 'playbackRate' definition.</span><b><a href="#dom-mediapositionstate-playbackrate">#dom-mediapositionstate-playbackrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediapositionstate-playbackrate">6. The MediaSession interface</a> <a href="#ref-for-dom-mediapositionstate-playbackrate①">(2)</a>
     <li><a href="#ref-for-dom-mediapositionstate-playbackrate②">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediapositionstate-position">
-   <b><a href="#dom-mediapositionstate-position">#dom-mediapositionstate-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediapositionstate-position" class="dfn-panel" data-for="dom-mediapositionstate-position" id="infopanel-for-dom-mediapositionstate-position" role="dialog">
+   <span id="infopaneltitle-for-dom-mediapositionstate-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-mediapositionstate-position">#dom-mediapositionstate-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediapositionstate-position">6. The MediaSession interface</a> <a href="#ref-for-dom-mediapositionstate-position①">(2)</a>
     <li><a href="#ref-for-dom-mediapositionstate-position②">9. The MediaPositionState
 dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mediasessionactiondetails">
-   <b><a href="#dictdef-mediasessionactiondetails">#dictdef-mediasessionactiondetails</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mediasessionactiondetails" class="dfn-panel" data-for="dictdef-mediasessionactiondetails" id="infopanel-for-dictdef-mediasessionactiondetails" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mediasessionactiondetails" style="display:none">Info about the 'MediaSessionActionDetails' definition.</span><b><a href="#dictdef-mediasessionactiondetails">#dictdef-mediasessionactiondetails</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mediasessionactiondetails">5.4. Actions</a>
     <li><a href="#ref-for-dictdef-mediasessionactiondetails①">6. The MediaSession interface</a>
@@ -2507,29 +2512,29 @@ dictionary</a>
 MediaSessionActionDetails dictionary</a> <a href="#ref-for-dictdef-mediasessionactiondetails③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionactiondetails-action">
-   <b><a href="#dom-mediasessionactiondetails-action">#dom-mediasessionactiondetails-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionactiondetails-action" class="dfn-panel" data-for="dom-mediasessionactiondetails-action" id="infopanel-for-dom-mediasessionactiondetails-action" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionactiondetails-action" style="display:none">Info about the 'action' definition.</span><b><a href="#dom-mediasessionactiondetails-action">#dom-mediasessionactiondetails-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionactiondetails-action">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionactiondetails-seekoffset">
-   <b><a href="#dom-mediasessionactiondetails-seekoffset">#dom-mediasessionactiondetails-seekoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionactiondetails-seekoffset" class="dfn-panel" data-for="dom-mediasessionactiondetails-seekoffset" id="infopanel-for-dom-mediasessionactiondetails-seekoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionactiondetails-seekoffset" style="display:none">Info about the 'seekOffset' definition.</span><b><a href="#dom-mediasessionactiondetails-seekoffset">#dom-mediasessionactiondetails-seekoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionactiondetails-seekoffset">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionactiondetails-seektime">
-   <b><a href="#dom-mediasessionactiondetails-seektime">#dom-mediasessionactiondetails-seektime</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionactiondetails-seektime" class="dfn-panel" data-for="dom-mediasessionactiondetails-seektime" id="infopanel-for-dom-mediasessionactiondetails-seektime" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionactiondetails-seektime" style="display:none">Info about the 'seekTime' definition.</span><b><a href="#dom-mediasessionactiondetails-seektime">#dom-mediasessionactiondetails-seektime</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionactiondetails-seektime">10. The
 MediaSessionActionDetails dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mediasessionactiondetails-fastseek">
-   <b><a href="#dom-mediasessionactiondetails-fastseek">#dom-mediasessionactiondetails-fastseek</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mediasessionactiondetails-fastseek" class="dfn-panel" data-for="dom-mediasessionactiondetails-fastseek" id="infopanel-for-dom-mediasessionactiondetails-fastseek" role="dialog">
+   <span id="infopaneltitle-for-dom-mediasessionactiondetails-fastseek" style="display:none">Info about the 'fastSeek' definition.</span><b><a href="#dom-mediasessionactiondetails-fastseek">#dom-mediasessionactiondetails-fastseek</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediasessionactiondetails-fastseek">10. The
 MediaSessionActionDetails dictionary</a>
@@ -2537,57 +2542,113 @@ MediaSessionActionDetails dictionary</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/motion-sensors/index.html
+++ b/tests/github/w3c/motion-sensors/index.html
@@ -1066,20 +1066,20 @@ processing algorithms have enough samples to provide accurate results.</p>
    <li><a href="#relative-orientation-sensor">Relative Orientation Sensor</a><span>, in § 4.5</span>
    <li><a href="#tilt-compensation">tilt compensation</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-acceleration">
-   <a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-acceleration" class="dfn-panel" data-for="term-for-acceleration" id="infopanel-for-term-for-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-acceleration" style="display:none">Info about the 'acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
-   <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer-interface" class="dfn-panel" data-for="term-for-accelerometer-interface" id="infopanel-for-term-for-accelerometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer-interface" style="display:none">Info about the 'accelerometer interface' external reference.</span><a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-interface">3.1. Accelerometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravity">
-   <a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravity" class="dfn-panel" data-for="term-for-gravity" id="infopanel-for-term-for-gravity" role="menu">
+   <span id="infopaneltitle-for-term-for-gravity" style="display:none">Info about the 'gravity' external reference.</span><a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity">3.1. Accelerometer</a> <a href="#ref-for-gravity①">(2)</a> <a href="#ref-for-gravity②">(3)</a> <a href="#ref-for-gravity③">(4)</a> <a href="#ref-for-gravity④">(5)</a> <a href="#ref-for-gravity⑤">(6)</a> <a href="#ref-for-gravity⑥">(7)</a> <a href="#ref-for-gravity⑦">(8)</a>
     <li><a href="#ref-for-gravity⑧">3.3. Magnetometer</a> <a href="#ref-for-gravity⑨">(2)</a>
@@ -1090,62 +1090,62 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gravity②④">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-gravity②⑤">(2)</a> <a href="#ref-for-gravity②⑥">(3)</a> <a href="#ref-for-gravity②⑦">(4)</a> <a href="#ref-for-gravity②⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
-   <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravitysensor-interface" class="dfn-panel" data-for="term-for-gravitysensor-interface" id="infopanel-for-term-for-gravitysensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gravitysensor-interface" style="display:none">Info about the 'gravitysensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linear-acceleration">
-   <a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linear-acceleration" class="dfn-panel" data-for="term-for-linear-acceleration" id="infopanel-for-term-for-linear-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-linear-acceleration" style="display:none">Info about the 'linear acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration">3.1. Accelerometer</a> <a href="#ref-for-linear-acceleration①">(2)</a>
     <li><a href="#ref-for-linear-acceleration②">4.5. Relative Orientation Sensor</a>
     <li><a href="#ref-for-linear-acceleration③">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-linear-acceleration④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
-   <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linearaccelerationsensor-interface" class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface" id="infopanel-for-term-for-linearaccelerationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-linearaccelerationsensor-interface" style="display:none">Info about the 'linearaccelerationsensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calibration">
-   <a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calibration" class="dfn-panel" data-for="term-for-calibration" id="infopanel-for-term-for-calibration" role="menu">
+   <span id="infopaneltitle-for-term-for-calibration" style="display:none">Info about the 'calibration' external reference.</span><a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibration">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angular-velocity">
-   <a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angular-velocity" class="dfn-panel" data-for="term-for-angular-velocity" id="infopanel-for-term-for-angular-velocity" role="menu">
+   <span id="infopaneltitle-for-term-for-angular-velocity" style="display:none">Info about the 'angular velocity' external reference.</span><a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">3.2. Gyroscope</a> <a href="#ref-for-angular-velocity①">(2)</a> <a href="#ref-for-angular-velocity②">(3)</a>
     <li><a href="#ref-for-angular-velocity③">4. High-level Sensors</a>
     <li><a href="#ref-for-angular-velocity④">4.5.1. Complementary filter</a> <a href="#ref-for-angular-velocity⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
-   <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope-interface" class="dfn-panel" data-for="term-for-gyroscope-interface" id="infopanel-for-term-for-gyroscope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope-interface" style="display:none">Info about the 'gyroscope interface' external reference.</span><a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-interface">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetic-field">
-   <a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetic-field" class="dfn-panel" data-for="term-for-magnetic-field" id="infopanel-for-term-for-magnetic-field" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetic-field" style="display:none">Info about the 'magnetic field' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-field">3.3. Magnetometer</a> <a href="#ref-for-magnetic-field①">(2)</a> <a href="#ref-for-magnetic-field②">(3)</a>
     <li><a href="#ref-for-magnetic-field③">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-magnetic-field④">(2)</a> <a href="#ref-for-magnetic-field⑤">(3)</a> <a href="#ref-for-magnetic-field⑥">(4)</a> <a href="#ref-for-magnetic-field⑦">(5)</a>
     <li><a href="#ref-for-magnetic-field⑧">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer-interface" class="dfn-panel" data-for="term-for-magnetometer-interface" id="infopanel-for-term-for-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer-interface" style="display:none">Info about the 'magnetometer interface' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-interface">3.3. Magnetometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor-interface" class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface" id="infopanel-for-term-for-absoluteorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor-interface" style="display:none">Info about the 'absoluteorientationsensor interface' external reference.</span><a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-interface">4.3. Absolute Orientation Sensor</a>
    </ul>
@@ -1218,8 +1218,8 @@ processing algorithms have enough samples to provide accurate results.</p>
    <dt id="biblio-videostabilizer">[VIDEOSTABILIZER]
    <dd>Hanning, Gustav, et al.. <a href="http://ieeexplore.ieee.org/abstract/document/6130215/"><cite>Stabilizing cell phone video using inertial measurement sensors</cite></a>. 2011. Informational. URL: <a href="http://ieeexplore.ieee.org/abstract/document/6130215/">http://ieeexplore.ieee.org/abstract/document/6130215/</a>
   </dl>
-  <aside class="dfn-panel" data-for="accelerometer">
-   <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accelerometer" class="dfn-panel" data-for="accelerometer" id="infopanel-for-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-accelerometer" style="display:none">Info about the 'accelerometer' definition.</span><b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer">1. Introduction</a>
     <li><a href="#ref-for-accelerometer①">3.1. Accelerometer</a>
@@ -1231,14 +1231,14 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-accelerometer②①">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-accelerometer②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inertial-frame-sensor">
-   <b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inertial-frame-sensor" class="dfn-panel" data-for="inertial-frame-sensor" id="infopanel-for-inertial-frame-sensor" role="dialog">
+   <span id="infopaneltitle-for-inertial-frame-sensor" style="display:none">Info about the 'inertial-frame sensor' definition.</span><b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inertial-frame-sensor">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gyroscope">
-   <b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gyroscope" class="dfn-panel" data-for="gyroscope" id="infopanel-for-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-gyroscope" style="display:none">Info about the 'gyroscope' definition.</span><b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">1. Introduction</a>
     <li><a href="#ref-for-gyroscope①">4.1. Common fusion sensors</a> <a href="#ref-for-gyroscope②">(2)</a> <a href="#ref-for-gyroscope③">(3)</a> <a href="#ref-for-gyroscope④">(4)</a> <a href="#ref-for-gyroscope⑤">(5)</a>
@@ -1250,8 +1250,8 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gyroscope①⑦">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetometer-magnetometers">
-   <b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetometer-magnetometers" class="dfn-panel" data-for="magnetometer-magnetometers" id="infopanel-for-magnetometer-magnetometers" role="dialog">
+   <span id="infopaneltitle-for-magnetometer-magnetometers" style="display:none">Info about the 'Magnetometers' definition.</span><b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-magnetometers">1. Introduction</a>
     <li><a href="#ref-for-magnetometer-magnetometers①">4.1. Common fusion sensors</a> <a href="#ref-for-magnetometer-magnetometers②">(2)</a> <a href="#ref-for-magnetometer-magnetometers③">(3)</a> <a href="#ref-for-magnetometer-magnetometers④">(4)</a>
@@ -1260,61 +1260,61 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-magnetometer-magnetometers⑨">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="low-pass-filter">
-   <b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-low-pass-filter" class="dfn-panel" data-for="low-pass-filter" id="infopanel-for-low-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-low-pass-filter" style="display:none">Info about the 'low-pass filter' definition.</span><b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-low-pass-filter①">(2)</a> <a href="#ref-for-low-pass-filter②">(3)</a>
     <li><a href="#ref-for-low-pass-filter③">4.2.2. High-pass filter</a>
     <li><a href="#ref-for-low-pass-filter④">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="high-pass-filter">
-   <b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-high-pass-filter" class="dfn-panel" data-for="high-pass-filter" id="infopanel-for-high-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-high-pass-filter" style="display:none">Info about the 'High-pass filter' definition.</span><b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-high-pass-filter①">(2)</a>
     <li><a href="#ref-for-high-pass-filter②">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-orientation-sensor">
-   <b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-orientation-sensor" class="dfn-panel" data-for="absolute-orientation-sensor" id="infopanel-for-absolute-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-absolute-orientation-sensor" style="display:none">Info about the 'Absolute Orientation Sensor' definition.</span><b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-absolute-orientation-sensor①">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-absolute-orientation-sensor②">(2)</a>
     <li><a href="#ref-for-absolute-orientation-sensor③">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geomagnetic-orientation-sensor">
-   <b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geomagnetic-orientation-sensor" class="dfn-panel" data-for="geomagnetic-orientation-sensor" id="infopanel-for-geomagnetic-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-geomagnetic-orientation-sensor" style="display:none">Info about the 'Geomagnetic Orientation Sensor' definition.</span><b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geomagnetic-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-geomagnetic-orientation-sensor①">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-orientation-sensor">
-   <b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-orientation-sensor" class="dfn-panel" data-for="relative-orientation-sensor" id="infopanel-for-relative-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-relative-orientation-sensor" style="display:none">Info about the 'Relative Orientation Sensor' definition.</span><b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-relative-orientation-sensor①">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complementary-filter">
-   <b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complementary-filter" class="dfn-panel" data-for="complementary-filter" id="infopanel-for-complementary-filter" role="dialog">
+   <span id="infopaneltitle-for-complementary-filter" style="display:none">Info about the 'complementary filter' definition.</span><b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complementary-filter">4.5. Relative Orientation Sensor</a> <a href="#ref-for-complementary-filter①">(2)</a>
     <li><a href="#ref-for-complementary-filter②">4.5.1. Complementary filter</a>
     <li><a href="#ref-for-complementary-filter③">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-acceleration-sensor">
-   <b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-acceleration-sensor" class="dfn-panel" data-for="linear-acceleration-sensor" id="infopanel-for-linear-acceleration-sensor" role="dialog">
+   <span id="infopaneltitle-for-linear-acceleration-sensor" style="display:none">Info about the 'Linear Acceleration Sensor' definition.</span><b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-linear-acceleration-sensor①">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-linear-acceleration-sensor②">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gravity-sensor">
-   <b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gravity-sensor" class="dfn-panel" data-for="gravity-sensor" id="infopanel-for-gravity-sensor" role="dialog">
+   <span id="infopaneltitle-for-gravity-sensor" style="display:none">Info about the 'Gravity Sensor' definition.</span><b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-gravity-sensor①">4.1. Common fusion sensors</a>
@@ -1323,57 +1323,113 @@ processing algorithms have enough samples to provide accurate results.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/motion-sensors/releases/NOTE/NOTE.html
+++ b/tests/github/w3c/motion-sensors/releases/NOTE/NOTE.html
@@ -776,20 +776,20 @@ processing algorithms have enough samples to provide accurate results.</p>
    <li><a href="#relative-orientation-sensor">Relative Orientation Sensor</a><span>, in § 4.5</span>
    <li><a href="#tilt-compensation">tilt compensation</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-acceleration">
-   <a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-acceleration" class="dfn-panel" data-for="term-for-acceleration" id="infopanel-for-term-for-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-acceleration" style="display:none">Info about the 'acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
-   <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer-interface" class="dfn-panel" data-for="term-for-accelerometer-interface" id="infopanel-for-term-for-accelerometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer-interface" style="display:none">Info about the 'accelerometer interface' external reference.</span><a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-interface">3.1. Accelerometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravity">
-   <a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravity" class="dfn-panel" data-for="term-for-gravity" id="infopanel-for-term-for-gravity" role="menu">
+   <span id="infopaneltitle-for-term-for-gravity" style="display:none">Info about the 'gravity' external reference.</span><a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity">3.1. Accelerometer</a> <a href="#ref-for-gravity①">(2)</a> <a href="#ref-for-gravity②">(3)</a> <a href="#ref-for-gravity③">(4)</a> <a href="#ref-for-gravity④">(5)</a> <a href="#ref-for-gravity⑤">(6)</a> <a href="#ref-for-gravity⑥">(7)</a> <a href="#ref-for-gravity⑦">(8)</a>
     <li><a href="#ref-for-gravity⑧">3.3. Magnetometer</a> <a href="#ref-for-gravity⑨">(2)</a>
@@ -800,62 +800,62 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gravity②④">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-gravity②⑤">(2)</a> <a href="#ref-for-gravity②⑥">(3)</a> <a href="#ref-for-gravity②⑦">(4)</a> <a href="#ref-for-gravity②⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
-   <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravitysensor-interface" class="dfn-panel" data-for="term-for-gravitysensor-interface" id="infopanel-for-term-for-gravitysensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gravitysensor-interface" style="display:none">Info about the 'gravitysensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linear-acceleration">
-   <a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linear-acceleration" class="dfn-panel" data-for="term-for-linear-acceleration" id="infopanel-for-term-for-linear-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-linear-acceleration" style="display:none">Info about the 'linear acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration">3.1. Accelerometer</a> <a href="#ref-for-linear-acceleration①">(2)</a>
     <li><a href="#ref-for-linear-acceleration②">4.5. Relative Orientation Sensor</a>
     <li><a href="#ref-for-linear-acceleration③">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-linear-acceleration④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
-   <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linearaccelerationsensor-interface" class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface" id="infopanel-for-term-for-linearaccelerationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-linearaccelerationsensor-interface" style="display:none">Info about the 'linearaccelerationsensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calibration">
-   <a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calibration" class="dfn-panel" data-for="term-for-calibration" id="infopanel-for-term-for-calibration" role="menu">
+   <span id="infopaneltitle-for-term-for-calibration" style="display:none">Info about the 'calibration' external reference.</span><a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibration">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angular-velocity">
-   <a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angular-velocity" class="dfn-panel" data-for="term-for-angular-velocity" id="infopanel-for-term-for-angular-velocity" role="menu">
+   <span id="infopaneltitle-for-term-for-angular-velocity" style="display:none">Info about the 'angular velocity' external reference.</span><a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">3.2. Gyroscope</a> <a href="#ref-for-angular-velocity①">(2)</a> <a href="#ref-for-angular-velocity②">(3)</a>
     <li><a href="#ref-for-angular-velocity③">4. High-level Sensors</a>
     <li><a href="#ref-for-angular-velocity④">4.5.1. Complementary filter</a> <a href="#ref-for-angular-velocity⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
-   <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope-interface" class="dfn-panel" data-for="term-for-gyroscope-interface" id="infopanel-for-term-for-gyroscope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope-interface" style="display:none">Info about the 'gyroscope interface' external reference.</span><a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-interface">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetic-field">
-   <a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetic-field" class="dfn-panel" data-for="term-for-magnetic-field" id="infopanel-for-term-for-magnetic-field" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetic-field" style="display:none">Info about the 'magnetic field' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-field">3.3. Magnetometer</a> <a href="#ref-for-magnetic-field①">(2)</a> <a href="#ref-for-magnetic-field②">(3)</a>
     <li><a href="#ref-for-magnetic-field③">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-magnetic-field④">(2)</a> <a href="#ref-for-magnetic-field⑤">(3)</a> <a href="#ref-for-magnetic-field⑥">(4)</a> <a href="#ref-for-magnetic-field⑦">(5)</a>
     <li><a href="#ref-for-magnetic-field⑧">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer-interface" class="dfn-panel" data-for="term-for-magnetometer-interface" id="infopanel-for-term-for-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer-interface" style="display:none">Info about the 'magnetometer interface' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-interface">3.3. Magnetometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor-interface" class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface" id="infopanel-for-term-for-absoluteorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor-interface" style="display:none">Info about the 'absoluteorientationsensor interface' external reference.</span><a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-interface">4.3. Absolute Orientation Sensor</a>
    </ul>
@@ -922,8 +922,8 @@ processing algorithms have enough samples to provide accurate results.</p>
    <dt id="biblio-videostabilizer">[VIDEOSTABILIZER]
    <dd>Hanning, Gustav, et al.. <a href="http://ieeexplore.ieee.org/abstract/document/6130215/"><cite>Stabilizing cell phone video using inertial measurement sensors</cite></a>. 2011. Informational. URL: <a href="http://ieeexplore.ieee.org/abstract/document/6130215/">http://ieeexplore.ieee.org/abstract/document/6130215/</a>
   </dl>
-  <aside class="dfn-panel" data-for="accelerometer">
-   <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accelerometer" class="dfn-panel" data-for="accelerometer" id="infopanel-for-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-accelerometer" style="display:none">Info about the 'accelerometer' definition.</span><b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer">1. Introduction</a>
     <li><a href="#ref-for-accelerometer①">3.1. Accelerometer</a>
@@ -935,14 +935,14 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-accelerometer②①">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-accelerometer②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inertial-frame-sensor">
-   <b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inertial-frame-sensor" class="dfn-panel" data-for="inertial-frame-sensor" id="infopanel-for-inertial-frame-sensor" role="dialog">
+   <span id="infopaneltitle-for-inertial-frame-sensor" style="display:none">Info about the 'inertial-frame sensor' definition.</span><b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inertial-frame-sensor">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gyroscope">
-   <b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gyroscope" class="dfn-panel" data-for="gyroscope" id="infopanel-for-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-gyroscope" style="display:none">Info about the 'gyroscope' definition.</span><b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">1. Introduction</a>
     <li><a href="#ref-for-gyroscope①">4.1. Common fusion sensors</a> <a href="#ref-for-gyroscope②">(2)</a> <a href="#ref-for-gyroscope③">(3)</a> <a href="#ref-for-gyroscope④">(4)</a> <a href="#ref-for-gyroscope⑤">(5)</a>
@@ -954,8 +954,8 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gyroscope①⑦">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetometer-magnetometers">
-   <b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetometer-magnetometers" class="dfn-panel" data-for="magnetometer-magnetometers" id="infopanel-for-magnetometer-magnetometers" role="dialog">
+   <span id="infopaneltitle-for-magnetometer-magnetometers" style="display:none">Info about the 'Magnetometers' definition.</span><b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-magnetometers">1. Introduction</a>
     <li><a href="#ref-for-magnetometer-magnetometers①">4.1. Common fusion sensors</a> <a href="#ref-for-magnetometer-magnetometers②">(2)</a> <a href="#ref-for-magnetometer-magnetometers③">(3)</a> <a href="#ref-for-magnetometer-magnetometers④">(4)</a>
@@ -964,61 +964,61 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-magnetometer-magnetometers⑨">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="low-pass-filter">
-   <b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-low-pass-filter" class="dfn-panel" data-for="low-pass-filter" id="infopanel-for-low-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-low-pass-filter" style="display:none">Info about the 'low-pass filter' definition.</span><b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-low-pass-filter①">(2)</a> <a href="#ref-for-low-pass-filter②">(3)</a>
     <li><a href="#ref-for-low-pass-filter③">4.2.2. High-pass filter</a>
     <li><a href="#ref-for-low-pass-filter④">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="high-pass-filter">
-   <b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-high-pass-filter" class="dfn-panel" data-for="high-pass-filter" id="infopanel-for-high-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-high-pass-filter" style="display:none">Info about the 'High-pass filter' definition.</span><b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-high-pass-filter①">(2)</a>
     <li><a href="#ref-for-high-pass-filter②">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-orientation-sensor">
-   <b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-orientation-sensor" class="dfn-panel" data-for="absolute-orientation-sensor" id="infopanel-for-absolute-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-absolute-orientation-sensor" style="display:none">Info about the 'Absolute Orientation Sensor' definition.</span><b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-absolute-orientation-sensor①">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-absolute-orientation-sensor②">(2)</a>
     <li><a href="#ref-for-absolute-orientation-sensor③">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geomagnetic-orientation-sensor">
-   <b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geomagnetic-orientation-sensor" class="dfn-panel" data-for="geomagnetic-orientation-sensor" id="infopanel-for-geomagnetic-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-geomagnetic-orientation-sensor" style="display:none">Info about the 'Geomagnetic Orientation Sensor' definition.</span><b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geomagnetic-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-geomagnetic-orientation-sensor①">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-orientation-sensor">
-   <b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-orientation-sensor" class="dfn-panel" data-for="relative-orientation-sensor" id="infopanel-for-relative-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-relative-orientation-sensor" style="display:none">Info about the 'Relative Orientation Sensor' definition.</span><b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-relative-orientation-sensor①">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complementary-filter">
-   <b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complementary-filter" class="dfn-panel" data-for="complementary-filter" id="infopanel-for-complementary-filter" role="dialog">
+   <span id="infopaneltitle-for-complementary-filter" style="display:none">Info about the 'complementary filter' definition.</span><b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complementary-filter">4.5. Relative Orientation Sensor</a> <a href="#ref-for-complementary-filter①">(2)</a>
     <li><a href="#ref-for-complementary-filter②">4.5.1. Complementary filter</a>
     <li><a href="#ref-for-complementary-filter③">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-acceleration-sensor">
-   <b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-acceleration-sensor" class="dfn-panel" data-for="linear-acceleration-sensor" id="infopanel-for-linear-acceleration-sensor" role="dialog">
+   <span id="infopaneltitle-for-linear-acceleration-sensor" style="display:none">Info about the 'Linear Acceleration Sensor' definition.</span><b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-linear-acceleration-sensor①">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-linear-acceleration-sensor②">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gravity-sensor">
-   <b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gravity-sensor" class="dfn-panel" data-for="gravity-sensor" id="infopanel-for-gravity-sensor" role="dialog">
+   <span id="infopaneltitle-for-gravity-sensor" style="display:none">Info about the 'Gravity Sensor' definition.</span><b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-gravity-sensor①">4.1. Common fusion sensors</a>
@@ -1027,57 +1027,113 @@ processing algorithms have enough samples to provide accurate results.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/motion-sensors/releases/NOTE2/index.html
+++ b/tests/github/w3c/motion-sensors/releases/NOTE2/index.html
@@ -756,20 +756,20 @@ processing algorithms have enough samples to provide accurate results.</p>
    <li><a href="#relative-orientation-sensor">Relative Orientation Sensor</a><span>, in § 4.5</span>
    <li><a href="#tilt-compensation">tilt compensation</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-acceleration">
-   <a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-acceleration" class="dfn-panel" data-for="term-for-acceleration" id="infopanel-for-term-for-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-acceleration" style="display:none">Info about the 'acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
-   <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer-interface" class="dfn-panel" data-for="term-for-accelerometer-interface" id="infopanel-for-term-for-accelerometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer-interface" style="display:none">Info about the 'accelerometer interface' external reference.</span><a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-interface">3.1. Accelerometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravity">
-   <a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravity" class="dfn-panel" data-for="term-for-gravity" id="infopanel-for-term-for-gravity" role="menu">
+   <span id="infopaneltitle-for-term-for-gravity" style="display:none">Info about the 'gravity' external reference.</span><a href="https://w3c.github.io/accelerometer#gravity">https://w3c.github.io/accelerometer#gravity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity">3.1. Accelerometer</a> <a href="#ref-for-gravity①">(2)</a> <a href="#ref-for-gravity②">(3)</a> <a href="#ref-for-gravity③">(4)</a> <a href="#ref-for-gravity④">(5)</a> <a href="#ref-for-gravity⑤">(6)</a> <a href="#ref-for-gravity⑥">(7)</a> <a href="#ref-for-gravity⑦">(8)</a>
     <li><a href="#ref-for-gravity⑧">3.3. Magnetometer</a> <a href="#ref-for-gravity⑨">(2)</a>
@@ -780,62 +780,62 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gravity②④">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-gravity②⑤">(2)</a> <a href="#ref-for-gravity②⑥">(3)</a> <a href="#ref-for-gravity②⑦">(4)</a> <a href="#ref-for-gravity②⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
-   <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravitysensor-interface" class="dfn-panel" data-for="term-for-gravitysensor-interface" id="infopanel-for-term-for-gravitysensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gravitysensor-interface" style="display:none">Info about the 'gravitysensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linear-acceleration">
-   <a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linear-acceleration" class="dfn-panel" data-for="term-for-linear-acceleration" id="infopanel-for-term-for-linear-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-linear-acceleration" style="display:none">Info about the 'linear acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#linear-acceleration">https://w3c.github.io/accelerometer#linear-acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration">3.1. Accelerometer</a> <a href="#ref-for-linear-acceleration①">(2)</a>
     <li><a href="#ref-for-linear-acceleration②">4.5. Relative Orientation Sensor</a>
     <li><a href="#ref-for-linear-acceleration③">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-linear-acceleration④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
-   <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linearaccelerationsensor-interface" class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface" id="infopanel-for-term-for-linearaccelerationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-linearaccelerationsensor-interface" style="display:none">Info about the 'linearaccelerationsensor interface' external reference.</span><a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor-interface">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-calibration">
-   <a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-calibration" class="dfn-panel" data-for="term-for-calibration" id="infopanel-for-term-for-calibration" role="menu">
+   <span id="infopaneltitle-for-term-for-calibration" style="display:none">Info about the 'calibration' external reference.</span><a href="https://w3c.github.io/sensors#calibration">https://w3c.github.io/sensors#calibration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibration">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angular-velocity">
-   <a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angular-velocity" class="dfn-panel" data-for="term-for-angular-velocity" id="infopanel-for-term-for-angular-velocity" role="menu">
+   <span id="infopaneltitle-for-term-for-angular-velocity" style="display:none">Info about the 'angular velocity' external reference.</span><a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">3.2. Gyroscope</a> <a href="#ref-for-angular-velocity①">(2)</a> <a href="#ref-for-angular-velocity②">(3)</a>
     <li><a href="#ref-for-angular-velocity③">4. High-level Sensors</a>
     <li><a href="#ref-for-angular-velocity④">4.5.1. Complementary filter</a> <a href="#ref-for-angular-velocity⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
-   <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope-interface" class="dfn-panel" data-for="term-for-gyroscope-interface" id="infopanel-for-term-for-gyroscope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope-interface" style="display:none">Info about the 'gyroscope interface' external reference.</span><a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-interface">3.2. Gyroscope</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetic-field">
-   <a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetic-field" class="dfn-panel" data-for="term-for-magnetic-field" id="infopanel-for-term-for-magnetic-field" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetic-field" style="display:none">Info about the 'magnetic field' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-field">3.3. Magnetometer</a> <a href="#ref-for-magnetic-field①">(2)</a> <a href="#ref-for-magnetic-field②">(3)</a>
     <li><a href="#ref-for-magnetic-field③">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-magnetic-field④">(2)</a> <a href="#ref-for-magnetic-field⑤">(3)</a> <a href="#ref-for-magnetic-field⑥">(4)</a> <a href="#ref-for-magnetic-field⑦">(5)</a>
     <li><a href="#ref-for-magnetic-field⑧">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer-interface" class="dfn-panel" data-for="term-for-magnetometer-interface" id="infopanel-for-term-for-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer-interface" style="display:none">Info about the 'magnetometer interface' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-interface">3.3. Magnetometer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor-interface" class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface" id="infopanel-for-term-for-absoluteorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor-interface" style="display:none">Info about the 'absoluteorientationsensor interface' external reference.</span><a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-interface">4.3. Absolute Orientation Sensor</a>
    </ul>
@@ -908,8 +908,8 @@ processing algorithms have enough samples to provide accurate results.</p>
    <dt id="biblio-videostabilizer">[VIDEOSTABILIZER]
    <dd>Hanning, Gustav, et al.. <a href="http://ieeexplore.ieee.org/abstract/document/6130215/"><cite>Stabilizing cell phone video using inertial measurement sensors</cite></a>. 2011. Informational. URL: <a href="http://ieeexplore.ieee.org/abstract/document/6130215/">http://ieeexplore.ieee.org/abstract/document/6130215/</a>
   </dl>
-  <aside class="dfn-panel" data-for="accelerometer">
-   <b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accelerometer" class="dfn-panel" data-for="accelerometer" id="infopanel-for-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-accelerometer" style="display:none">Info about the 'accelerometer' definition.</span><b><a href="#accelerometer">#accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer">1. Introduction</a>
     <li><a href="#ref-for-accelerometer①">3.1. Accelerometer</a>
@@ -921,14 +921,14 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-accelerometer②①">4.6. Gravity and Linear Acceleration Sensor</a> <a href="#ref-for-accelerometer②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inertial-frame-sensor">
-   <b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inertial-frame-sensor" class="dfn-panel" data-for="inertial-frame-sensor" id="infopanel-for-inertial-frame-sensor" role="dialog">
+   <span id="infopaneltitle-for-inertial-frame-sensor" style="display:none">Info about the 'inertial-frame sensor' definition.</span><b><a href="#inertial-frame-sensor">#inertial-frame-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inertial-frame-sensor">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gyroscope">
-   <b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gyroscope" class="dfn-panel" data-for="gyroscope" id="infopanel-for-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-gyroscope" style="display:none">Info about the 'gyroscope' definition.</span><b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">1. Introduction</a>
     <li><a href="#ref-for-gyroscope①">4.1. Common fusion sensors</a> <a href="#ref-for-gyroscope②">(2)</a> <a href="#ref-for-gyroscope③">(3)</a> <a href="#ref-for-gyroscope④">(4)</a> <a href="#ref-for-gyroscope⑤">(5)</a>
@@ -940,8 +940,8 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-gyroscope①⑦">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="magnetometer-magnetometers">
-   <b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-magnetometer-magnetometers" class="dfn-panel" data-for="magnetometer-magnetometers" id="infopanel-for-magnetometer-magnetometers" role="dialog">
+   <span id="infopaneltitle-for-magnetometer-magnetometers" style="display:none">Info about the 'Magnetometers' definition.</span><b><a href="#magnetometer-magnetometers">#magnetometer-magnetometers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-magnetometers">1. Introduction</a>
     <li><a href="#ref-for-magnetometer-magnetometers①">4.1. Common fusion sensors</a> <a href="#ref-for-magnetometer-magnetometers②">(2)</a> <a href="#ref-for-magnetometer-magnetometers③">(3)</a> <a href="#ref-for-magnetometer-magnetometers④">(4)</a>
@@ -950,61 +950,61 @@ processing algorithms have enough samples to provide accurate results.</p>
     <li><a href="#ref-for-magnetometer-magnetometers⑨">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="low-pass-filter">
-   <b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-low-pass-filter" class="dfn-panel" data-for="low-pass-filter" id="infopanel-for-low-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-low-pass-filter" style="display:none">Info about the 'low-pass filter' definition.</span><b><a href="#low-pass-filter">#low-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-low-pass-filter①">(2)</a> <a href="#ref-for-low-pass-filter②">(3)</a>
     <li><a href="#ref-for-low-pass-filter③">4.2.2. High-pass filter</a>
     <li><a href="#ref-for-low-pass-filter④">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="high-pass-filter">
-   <b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-high-pass-filter" class="dfn-panel" data-for="high-pass-filter" id="infopanel-for-high-pass-filter" role="dialog">
+   <span id="infopaneltitle-for-high-pass-filter" style="display:none">Info about the 'High-pass filter' definition.</span><b><a href="#high-pass-filter">#high-pass-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-pass-filter">3.1. Accelerometer</a> <a href="#ref-for-high-pass-filter①">(2)</a>
     <li><a href="#ref-for-high-pass-filter②">4.5.1. Complementary filter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-orientation-sensor">
-   <b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-orientation-sensor" class="dfn-panel" data-for="absolute-orientation-sensor" id="infopanel-for-absolute-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-absolute-orientation-sensor" style="display:none">Info about the 'Absolute Orientation Sensor' definition.</span><b><a href="#absolute-orientation-sensor">#absolute-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-absolute-orientation-sensor①">4.3. Absolute Orientation Sensor</a> <a href="#ref-for-absolute-orientation-sensor②">(2)</a>
     <li><a href="#ref-for-absolute-orientation-sensor③">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="geomagnetic-orientation-sensor">
-   <b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-geomagnetic-orientation-sensor" class="dfn-panel" data-for="geomagnetic-orientation-sensor" id="infopanel-for-geomagnetic-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-geomagnetic-orientation-sensor" style="display:none">Info about the 'Geomagnetic Orientation Sensor' definition.</span><b><a href="#geomagnetic-orientation-sensor">#geomagnetic-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geomagnetic-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-geomagnetic-orientation-sensor①">4.4. Geomagnetic Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-orientation-sensor">
-   <b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-orientation-sensor" class="dfn-panel" data-for="relative-orientation-sensor" id="infopanel-for-relative-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-relative-orientation-sensor" style="display:none">Info about the 'Relative Orientation Sensor' definition.</span><b><a href="#relative-orientation-sensor">#relative-orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-orientation-sensor">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-relative-orientation-sensor①">4.3. Absolute Orientation Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="complementary-filter">
-   <b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-complementary-filter" class="dfn-panel" data-for="complementary-filter" id="infopanel-for-complementary-filter" role="dialog">
+   <span id="infopaneltitle-for-complementary-filter" style="display:none">Info about the 'complementary filter' definition.</span><b><a href="#complementary-filter">#complementary-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-complementary-filter">4.5. Relative Orientation Sensor</a> <a href="#ref-for-complementary-filter①">(2)</a>
     <li><a href="#ref-for-complementary-filter②">4.5.1. Complementary filter</a>
     <li><a href="#ref-for-complementary-filter③">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="linear-acceleration-sensor">
-   <b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-linear-acceleration-sensor" class="dfn-panel" data-for="linear-acceleration-sensor" id="infopanel-for-linear-acceleration-sensor" role="dialog">
+   <span id="infopaneltitle-for-linear-acceleration-sensor" style="display:none">Info about the 'Linear Acceleration Sensor' definition.</span><b><a href="#linear-acceleration-sensor">#linear-acceleration-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linear-acceleration-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-linear-acceleration-sensor①">4.1. Common fusion sensors</a>
     <li><a href="#ref-for-linear-acceleration-sensor②">4.6. Gravity and Linear Acceleration Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gravity-sensor">
-   <b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gravity-sensor" class="dfn-panel" data-for="gravity-sensor" id="infopanel-for-gravity-sensor" role="dialog">
+   <span id="infopaneltitle-for-gravity-sensor" style="display:none">Info about the 'Gravity Sensor' definition.</span><b><a href="#gravity-sensor">#gravity-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravity-sensor">3.1. Accelerometer</a>
     <li><a href="#ref-for-gravity-sensor①">4.1. Common fusion sensors</a>
@@ -1013,57 +1013,113 @@ processing algorithms have enough samples to provide accurate results.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/openscreenprotocol/index.html
+++ b/tests/github/w3c/openscreenprotocol/index.html
@@ -3021,14 +3021,14 @@ extensions.</p>
    <li><a href="#suspicious-agent">suspicious agent</a><span>, in § 12.5.2</span>
    <li><a href="#verified-display-name">verified display name</a><span>, in § 12.6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-media-have_nothing">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-have_nothing" class="dfn-panel" data-for="term-for-dom-media-have_nothing" id="infopanel-for-term-for-dom-media-have_nothing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-have_nothing" style="display:none">Info about the 'HAVE_NOTHING' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-have_nothing">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlmediaelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlmediaelement" class="dfn-panel" data-for="term-for-htmlmediaelement" id="infopanel-for-term-for-htmlmediaelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlmediaelement" style="display:none">Info about the 'HTMLMediaElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement">https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlmediaelement">2.3. Remote Playback API Requirements</a> <a href="#ref-for-htmlmediaelement①">(2)</a> <a href="#ref-for-htmlmediaelement②">(3)</a> <a href="#ref-for-htmlmediaelement③">(4)</a> <a href="#ref-for-htmlmediaelement④">(5)</a>
     <li><a href="#ref-for-htmlmediaelement⑤">8. Remote Playback Protocol</a>
@@ -3036,445 +3036,445 @@ extensions.</p>
     <li><a href="#ref-for-htmlmediaelement⑦">8.2. Remote Playback API</a> <a href="#ref-for-htmlmediaelement⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-network_empty">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-network_empty">https://html.spec.whatwg.org/multipage/media.html#dom-media-network_empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-network_empty" class="dfn-panel" data-for="term-for-dom-media-network_empty" id="infopanel-for-term-for-dom-media-network_empty" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-network_empty" style="display:none">Info about the 'NETWORK_EMPTY' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-network_empty">https://html.spec.whatwg.org/multipage/media.html#dom-media-network_empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-network_empty">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-addtexttrack">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack">https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-addtexttrack" class="dfn-panel" data-for="term-for-dom-media-addtexttrack" id="infopanel-for-term-for-dom-media-addtexttrack" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-addtexttrack" style="display:none">Info about the 'addTextTrack(kind, label, language)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack">https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-addtexttrack">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-audiotracks">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-audiotracks" class="dfn-panel" data-for="term-for-dom-media-audiotracks" id="infopanel-for-term-for-dom-media-audiotracks" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-audiotracks" style="display:none">Info about the 'audioTracks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-audiotracks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-audiotracks">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-audiotracks①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-audiotracks②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-buffered">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered">https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-buffered" class="dfn-panel" data-for="term-for-dom-media-buffered" id="infopanel-for-term-for-dom-media-buffered" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-buffered" style="display:none">Info about the 'buffered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered">https://html.spec.whatwg.org/multipage/media.html#dom-media-buffered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-buffered">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-buffered①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-currentsrc">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc">https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-currentsrc" class="dfn-panel" data-for="term-for-dom-media-currentsrc" id="infopanel-for-term-for-dom-media-currentsrc" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-currentsrc" style="display:none">Info about the 'currentSrc' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc">https://html.spec.whatwg.org/multipage/media.html#dom-media-currentsrc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-currentsrc">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-currentsrc①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-currenttime">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-currenttime" class="dfn-panel" data-for="term-for-dom-media-currenttime" id="infopanel-for-term-for-dom-media-currenttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-currenttime" style="display:none">Info about the 'currentTime' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime">https://html.spec.whatwg.org/multipage/media.html#dom-media-currenttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-currenttime">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-currenttime①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-currenttime②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-duration">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-duration">https://html.spec.whatwg.org/multipage/media.html#dom-media-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-duration" class="dfn-panel" data-for="term-for-dom-media-duration" id="infopanel-for-term-for-dom-media-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-duration">https://html.spec.whatwg.org/multipage/media.html#dom-media-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-duration">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-duration①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-ended">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-ended">https://html.spec.whatwg.org/multipage/media.html#dom-media-ended</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-ended" class="dfn-panel" data-for="term-for-dom-media-ended" id="infopanel-for-term-for-dom-media-ended" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-ended" style="display:none">Info about the 'ended' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-ended">https://html.spec.whatwg.org/multipage/media.html#dom-media-ended</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-ended">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-ended①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-error">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-error">https://html.spec.whatwg.org/multipage/media.html#dom-media-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-error" class="dfn-panel" data-for="term-for-dom-media-error" id="infopanel-for-term-for-dom-media-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-error" style="display:none">Info about the 'error' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-error">https://html.spec.whatwg.org/multipage/media.html#dom-media-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-error">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-error①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-fastseek">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek">https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-fastseek" class="dfn-panel" data-for="term-for-dom-media-fastseek" id="infopanel-for-term-for-dom-media-fastseek" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-fastseek" style="display:none">Info about the 'fastSeek(time)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek">https://html.spec.whatwg.org/multipage/media.html#dom-media-fastseek</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-fastseek">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-fastseek①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-getstartdate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate">https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-getstartdate" class="dfn-panel" data-for="term-for-dom-media-getstartdate" id="infopanel-for-term-for-dom-media-getstartdate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-getstartdate" style="display:none">Info about the 'getStartDate()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate">https://html.spec.whatwg.org/multipage/media.html#dom-media-getstartdate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-getstartdate">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-loop">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-loop">https://html.spec.whatwg.org/multipage/media.html#dom-media-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-loop" class="dfn-panel" data-for="term-for-dom-media-loop" id="infopanel-for-term-for-dom-media-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-loop" style="display:none">Info about the 'loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-loop">https://html.spec.whatwg.org/multipage/media.html#dom-media-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-loop">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element" class="dfn-panel" data-for="term-for-media-element" id="infopanel-for-term-for-media-element" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element" style="display:none">Info about the 'media elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#media-element">https://html.spec.whatwg.org/multipage/media.html#media-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element">1. Introduction</a>
     <li><a href="#ref-for-media-element①">1.1. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-mediaerror-code">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code">https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-mediaerror-code" class="dfn-panel" data-for="term-for-concept-mediaerror-code" id="infopanel-for-term-for-concept-mediaerror-code" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-mediaerror-code" style="display:none">Info about the 'media error code' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code">https://html.spec.whatwg.org/multipage/media.html#concept-mediaerror-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-mediaerror-code">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-muted">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-muted">https://html.spec.whatwg.org/multipage/media.html#dom-media-muted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-muted" class="dfn-panel" data-for="term-for-dom-media-muted" id="infopanel-for-term-for-dom-media-muted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-muted" style="display:none">Info about the 'muted' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-muted">https://html.spec.whatwg.org/multipage/media.html#dom-media-muted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-muted">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-muted①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-muted②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-networkstate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate">https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-networkstate" class="dfn-panel" data-for="term-for-dom-media-networkstate" id="infopanel-for-term-for-dom-media-networkstate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-networkstate" style="display:none">Info about the 'networkState' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate">https://html.spec.whatwg.org/multipage/media.html#dom-media-networkstate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-networkstate">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-networkstate①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-official-playback-position">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#official-playback-position">https://html.spec.whatwg.org/multipage/media.html#official-playback-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-official-playback-position" class="dfn-panel" data-for="term-for-official-playback-position" id="infopanel-for-term-for-official-playback-position" role="menu">
+   <span id="infopaneltitle-for-term-for-official-playback-position" style="display:none">Info about the 'official playback position' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#official-playback-position">https://html.spec.whatwg.org/multipage/media.html#official-playback-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-official-playback-position">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-pause">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-pause">https://html.spec.whatwg.org/multipage/media.html#dom-media-pause</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-pause" class="dfn-panel" data-for="term-for-dom-media-pause" id="infopanel-for-term-for-dom-media-pause" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-pause" style="display:none">Info about the 'pause()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-pause">https://html.spec.whatwg.org/multipage/media.html#dom-media-pause</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-pause">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-pause①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-paused">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-paused" class="dfn-panel" data-for="term-for-dom-media-paused" id="infopanel-for-term-for-dom-media-paused" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-paused" style="display:none">Info about the 'paused' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-paused">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-paused①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-play">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-play">https://html.spec.whatwg.org/multipage/media.html#dom-media-play</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-play" class="dfn-panel" data-for="term-for-dom-media-play" id="infopanel-for-term-for-dom-media-play" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-play" style="display:none">Info about the 'play()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-play">https://html.spec.whatwg.org/multipage/media.html#dom-media-play</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-play">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-play①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-playbackrate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-playbackrate" class="dfn-panel" data-for="term-for-dom-media-playbackrate" id="infopanel-for-term-for-dom-media-playbackrate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-playbackrate" style="display:none">Info about the 'playbackRate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate">https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-playbackrate">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-playbackrate①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-playbackrate②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-played">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-played">https://html.spec.whatwg.org/multipage/media.html#dom-media-played</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-played" class="dfn-panel" data-for="term-for-dom-media-played" id="infopanel-for-term-for-dom-media-played" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-played" style="display:none">Info about the 'played' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-played">https://html.spec.whatwg.org/multipage/media.html#dom-media-played</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-played">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-played①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-postmessage" class="dfn-panel" data-for="term-for-dom-window-postmessage" id="infopanel-for-term-for-dom-window-postmessage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-postmessage" style="display:none">Info about the 'postMessage(message, targetOrigin, transfer)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-postmessage">12.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-poster-frame">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#poster-frame">https://html.spec.whatwg.org/multipage/media.html#poster-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-poster-frame" class="dfn-panel" data-for="term-for-poster-frame" id="infopanel-for-term-for-poster-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-poster-frame" style="display:none">Info about the 'poster frame' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#poster-frame">https://html.spec.whatwg.org/multipage/media.html#poster-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-poster-frame">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-preload">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-preload">https://html.spec.whatwg.org/multipage/media.html#dom-media-preload</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-preload" class="dfn-panel" data-for="term-for-dom-media-preload" id="infopanel-for-term-for-dom-media-preload" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-preload" style="display:none">Info about the 'preload' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-preload">https://html.spec.whatwg.org/multipage/media.html#dom-media-preload</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-preload">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-readystate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-readystate" class="dfn-panel" data-for="term-for-dom-media-readystate" id="infopanel-for-term-for-dom-media-readystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-readystate" style="display:none">Info about the 'readyState' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-readystate">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-readystate①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-seekable">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable">https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-seekable" class="dfn-panel" data-for="term-for-dom-media-seekable" id="infopanel-for-term-for-dom-media-seekable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-seekable" style="display:none">Info about the 'seekable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable">https://html.spec.whatwg.org/multipage/media.html#dom-media-seekable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-seekable">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-seekable①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-seeking">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking">https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-seeking" class="dfn-panel" data-for="term-for-dom-media-seeking" id="infopanel-for-term-for-dom-media-seeking" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-seeking" style="display:none">Info about the 'seeking' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking">https://html.spec.whatwg.org/multipage/media.html#dom-media-seeking</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-seeking">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-seeking①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-src">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-src">https://html.spec.whatwg.org/multipage/media.html#dom-media-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-src" class="dfn-panel" data-for="term-for-dom-media-src" id="infopanel-for-term-for-dom-media-src" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-src" style="display:none">Info about the 'src (for HTMLMediaElement)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-src">https://html.spec.whatwg.org/multipage/media.html#dom-media-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-src">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-source-src">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-source-src" class="dfn-panel" data-for="term-for-attr-source-src" id="infopanel-for-term-for-attr-source-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-source-src" style="display:none">Info about the 'src (for source)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-source-src">8. Remote Playback Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-media-stalled">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#event-media-stalled">https://html.spec.whatwg.org/multipage/media.html#event-media-stalled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-media-stalled" class="dfn-panel" data-for="term-for-event-media-stalled" id="infopanel-for-term-for-event-media-stalled" role="menu">
+   <span id="infopaneltitle-for-term-for-event-media-stalled" style="display:none">Info about the 'stalled' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#event-media-stalled">https://html.spec.whatwg.org/multipage/media.html#event-media-stalled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-media-stalled">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-event-media-stalled①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-texttracks">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-texttracks" class="dfn-panel" data-for="term-for-dom-media-texttracks" id="infopanel-for-term-for-dom-media-texttracks" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-texttracks" style="display:none">Info about the 'textTracks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-texttracks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-texttracks">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-texttracks①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-texttracks②">(2)</a> <a href="#ref-for-dom-media-texttracks③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeline-offset">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#timeline-offset">https://html.spec.whatwg.org/multipage/media.html#timeline-offset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeline-offset" class="dfn-panel" data-for="term-for-timeline-offset" id="infopanel-for-term-for-timeline-offset" role="menu">
+   <span id="infopaneltitle-for-term-for-timeline-offset" style="display:none">Info about the 'timeline offset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#timeline-offset">https://html.spec.whatwg.org/multipage/media.html#timeline-offset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeline-offset">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-timeline-offset①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-source-type">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-type">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-source-type" class="dfn-panel" data-for="term-for-attr-source-type" id="infopanel-for-term-for-attr-source-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-source-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-type">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-source-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-source-type">8. Remote Playback Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videoheight">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videoheight" class="dfn-panel" data-for="term-for-dom-video-videoheight" id="infopanel-for-term-for-dom-video-videoheight" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videoheight" style="display:none">Info about the 'videoHeight' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight">https://html.spec.whatwg.org/multipage/media.html#dom-video-videoheight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videoheight">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-video-videoheight①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-videotracks">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-videotracks" class="dfn-panel" data-for="term-for-dom-media-videotracks" id="infopanel-for-term-for-dom-media-videotracks" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-videotracks" style="display:none">Info about the 'videoTracks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks">https://html.spec.whatwg.org/multipage/media.html#dom-media-videotracks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-videotracks">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-videotracks①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-videotracks②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-video-videowidth">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-video-videowidth" class="dfn-panel" data-for="term-for-dom-video-videowidth" id="infopanel-for-term-for-dom-video-videowidth" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-video-videowidth" style="display:none">Info about the 'videoWidth' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth">https://html.spec.whatwg.org/multipage/media.html#dom-video-videowidth</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-video-videowidth">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-video-videowidth①">8.1. Remote Playback State and Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-volume">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-volume">https://html.spec.whatwg.org/multipage/media.html#dom-media-volume</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-volume" class="dfn-panel" data-for="term-for-dom-media-volume" id="infopanel-for-term-for-dom-media-volume" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-volume" style="display:none">Info about the 'volume' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-volume">https://html.spec.whatwg.org/multipage/media.html#dom-media-volume</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-volume">8. Remote Playback Protocol</a>
     <li><a href="#ref-for-dom-media-volume①">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dom-media-volume②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-presentationconnection">
-   <a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-presentationconnection" class="dfn-panel" data-for="term-for-presentationconnection" id="infopanel-for-term-for-presentationconnection" role="menu">
+   <span id="infopaneltitle-for-term-for-presentationconnection" style="display:none">Info about the 'PresentationConnection' external reference.</span><a href="https://w3c.github.io/presentation-api/#presentationconnection">https://w3c.github.io/presentation-api/#presentationconnection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-presentationconnection">2.2. Presentation API Requirements</a> <a href="#ref-for-presentationconnection①">(2)</a>
     <li><a href="#ref-for-presentationconnection②">12.1.4. Same-Origin Policy Violations</a>
     <li><a href="#ref-for-presentationconnection③">12.3. Presentation API Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-available-presentation-display">
-   <a href="https://w3c.github.io/presentation-api/#dfn-available-presentation-display">https://w3c.github.io/presentation-api/#dfn-available-presentation-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-available-presentation-display" class="dfn-panel" data-for="term-for-dfn-available-presentation-display" id="infopanel-for-term-for-dfn-available-presentation-display" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-available-presentation-display" style="display:none">Info about the 'available presentation display' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-available-presentation-display">https://w3c.github.io/presentation-api/#dfn-available-presentation-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-available-presentation-display">7. Presentation Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-controlling-user-agent">
-   <a href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent">https://w3c.github.io/presentation-api/#dfn-controlling-user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-controlling-user-agent" class="dfn-panel" data-for="term-for-dfn-controlling-user-agent" id="infopanel-for-term-for-dfn-controlling-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-controlling-user-agent" style="display:none">Info about the 'controlling user agent' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-controlling-user-agent">https://w3c.github.io/presentation-api/#dfn-controlling-user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-controlling-user-agent">1.1. Terminology</a>
     <li><a href="#ref-for-dfn-controlling-user-agent①">7.1. Presentation API</a> <a href="#ref-for-dfn-controlling-user-agent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-presentation">
-   <a href="https://w3c.github.io/presentation-api/#dfn-presentation">https://w3c.github.io/presentation-api/#dfn-presentation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-presentation" class="dfn-panel" data-for="term-for-dfn-presentation" id="infopanel-for-term-for-dfn-presentation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-presentation" style="display:none">Info about the 'presentation' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-presentation">https://w3c.github.io/presentation-api/#dfn-presentation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation">1.1. Terminology</a>
     <li><a href="#ref-for-dfn-presentation①">2.2. Presentation API Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-presentation-id">
-   <a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-presentation-id" class="dfn-panel" data-for="term-for-dfn-presentation-id" id="infopanel-for-term-for-dfn-presentation-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-presentation-id" style="display:none">Info about the 'presentation id' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-presentation-id">https://w3c.github.io/presentation-api/#dfn-presentation-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation-id">2.2. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-id①">(2)</a> <a href="#ref-for-dfn-presentation-id②">(3)</a>
     <li><a href="#ref-for-dfn-presentation-id③">12.1.4. Same-Origin Policy Violations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-presentation-request-url">
-   <a href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url">https://w3c.github.io/presentation-api/#dfn-presentation-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-presentation-request-url" class="dfn-panel" data-for="term-for-dfn-presentation-request-url" id="infopanel-for-term-for-dfn-presentation-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-presentation-request-url" style="display:none">Info about the 'presentation request url' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-presentation-request-url">https://w3c.github.io/presentation-api/#dfn-presentation-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-presentation-request-url">2.2. Presentation API Requirements</a> <a href="#ref-for-dfn-presentation-request-url①">(2)</a> <a href="#ref-for-dfn-presentation-request-url②">(3)</a> <a href="#ref-for-dfn-presentation-request-url③">(4)</a>
     <li><a href="#ref-for-dfn-presentation-request-url④">7. Presentation Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-receiving-user-agent">
-   <a href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent">https://w3c.github.io/presentation-api/#dfn-receiving-user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-receiving-user-agent" class="dfn-panel" data-for="term-for-dfn-receiving-user-agent" id="infopanel-for-term-for-dfn-receiving-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-receiving-user-agent" style="display:none">Info about the 'receiving user agent' external reference.</span><a href="https://w3c.github.io/presentation-api/#dfn-receiving-user-agent">https://w3c.github.io/presentation-api/#dfn-receiving-user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-receiving-user-agent">1.1. Terminology</a>
     <li><a href="#ref-for-dfn-receiving-user-agent①">7.1. Presentation API</a> <a href="#ref-for-dfn-receiving-user-agent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-19.19">
-   <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.19">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.19</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-19.19" class="dfn-panel" data-for="term-for-section-19.19" id="infopanel-for-term-for-section-19.19" role="menu">
+   <span id="infopaneltitle-for-term-for-section-19.19" style="display:none">Info about the 'connection_close frames' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.19">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-19.19</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-19.19">5. Messages delivery using CBOR and QUIC streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-18">
-   <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-18">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-18</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-18" class="dfn-panel" data-for="term-for-section-18" id="infopanel-for-term-for-section-18" role="menu">
+   <span id="infopaneltitle-for-term-for-section-18" style="display:none">Info about the 'transport parameter encoding' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-18">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-18</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-18">4.3. Metadata Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-16">
-   <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-16" class="dfn-panel" data-for="term-for-section-16" id="infopanel-for-term-for-section-16" role="menu">
+   <span id="infopaneltitle-for-term-for-section-16" style="display:none">Info about the 'variable-length integer' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-16">3. Discovery with mDNS</a>
     <li><a href="#ref-for-section-16①">5. Messages delivery using CBOR and QUIC streams</a> <a href="#ref-for-section-16②">(2)</a>
     <li><a href="#ref-for-section-16③">Appendix B: Message Type Key Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-16">
-   <a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-16" class="dfn-panel" data-for="term-for-section-16" id="infopanel-for-term-for-section-16①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-16①" style="display:none">Info about the 'variable-length integer encoding' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16">https://tools.ietf.org/html/draft-ietf-quic-transport-34#section-16</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-16">3. Discovery with mDNS</a>
     <li><a href="#ref-for-section-16①">5. Messages delivery using CBOR and QUIC streams</a> <a href="#ref-for-section-16②">(2)</a>
     <li><a href="#ref-for-section-16③">Appendix B: Message Type Key Ranges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-availability-sources-set">
-   <a href="https://w3c.github.io/remote-playback/#dfn-availability-sources-set">https://w3c.github.io/remote-playback/#dfn-availability-sources-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-availability-sources-set" class="dfn-panel" data-for="term-for-dfn-availability-sources-set" id="infopanel-for-term-for-dfn-availability-sources-set" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-availability-sources-set" style="display:none">Info about the 'availability sources set' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-availability-sources-set">https://w3c.github.io/remote-playback/#dfn-availability-sources-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-availability-sources-set">8.2. Remote Playback API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-compatible-remote-playback-device">
-   <a href="https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device">https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-compatible-remote-playback-device" class="dfn-panel" data-for="term-for-dfn-compatible-remote-playback-device" id="infopanel-for-term-for-dfn-compatible-remote-playback-device" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-compatible-remote-playback-device" style="display:none">Info about the 'compatible remote playback device' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device">https://w3c.github.io/remote-playback/#dfn-compatible-remote-playback-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-compatible-remote-playback-device">8. Remote Playback Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-initiate-remote-playback">
-   <a href="https://w3c.github.io/remote-playback/#dfn-initiate-remote-playback">https://w3c.github.io/remote-playback/#dfn-initiate-remote-playback</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-initiate-remote-playback" class="dfn-panel" data-for="term-for-dfn-initiate-remote-playback" id="infopanel-for-term-for-dfn-initiate-remote-playback" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-initiate-remote-playback" style="display:none">Info about the 'initiate remote playback' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-initiate-remote-playback">https://w3c.github.io/remote-playback/#dfn-initiate-remote-playback</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-initiate-remote-playback">2.3. Remote Playback API Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-media-element-state">
-   <a href="https://w3c.github.io/remote-playback/#dfn-media-element-state">https://w3c.github.io/remote-playback/#dfn-media-element-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-media-element-state" class="dfn-panel" data-for="term-for-dfn-media-element-state" id="infopanel-for-term-for-dfn-media-element-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-media-element-state" style="display:none">Info about the 'media element state' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-media-element-state">https://w3c.github.io/remote-playback/#dfn-media-element-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-media-element-state">2.3. Remote Playback API Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-media-resources">
-   <a href="https://w3c.github.io/remote-playback/#dfn-media-resources">https://w3c.github.io/remote-playback/#dfn-media-resources</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-media-resources" class="dfn-panel" data-for="term-for-dfn-media-resources" id="infopanel-for-term-for-dfn-media-resources" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-media-resources" style="display:none">Info about the 'media resources' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-media-resources">https://w3c.github.io/remote-playback/#dfn-media-resources</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-media-resources">8. Remote Playback Protocol</a> <a href="#ref-for-dfn-media-resources①">(2)</a> <a href="#ref-for-dfn-media-resources②">(3)</a> <a href="#ref-for-dfn-media-resources③">(4)</a>
     <li><a href="#ref-for-dfn-media-resources④">8.1. Remote Playback State and Controls</a> <a href="#ref-for-dfn-media-resources⑤">(2)</a> <a href="#ref-for-dfn-media-resources⑥">(3)</a> <a href="#ref-for-dfn-media-resources⑦">(4)</a> <a href="#ref-for-dfn-media-resources⑧">(5)</a> <a href="#ref-for-dfn-media-resources⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-devices">
-   <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices">https://w3c.github.io/remote-playback/#dfn-remote-playback-devices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-playback-devices" class="dfn-panel" data-for="term-for-dfn-remote-playback-devices" id="infopanel-for-term-for-dfn-remote-playback-devices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-playback-devices" style="display:none">Info about the 'remote playback devices' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices">https://w3c.github.io/remote-playback/#dfn-remote-playback-devices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-playback-devices">1.1. Terminology</a>
     <li><a href="#ref-for-dfn-remote-playback-devices①">8.2. Remote Playback API</a> <a href="#ref-for-dfn-remote-playback-devices②">(2)</a> <a href="#ref-for-dfn-remote-playback-devices③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-source">
-   <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-source">https://w3c.github.io/remote-playback/#dfn-remote-playback-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-playback-source" class="dfn-panel" data-for="term-for-dfn-remote-playback-source" id="infopanel-for-term-for-dfn-remote-playback-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-playback-source" style="display:none">Info about the 'remote playback source' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-source">https://w3c.github.io/remote-playback/#dfn-remote-playback-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-playback-source">8.2. Remote Playback API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.4">
-   <a href="https://tools.ietf.org/html/rfc4122#section-4.4">https://tools.ietf.org/html/rfc4122#section-4.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.4" class="dfn-panel" data-for="term-for-section-4.4" id="infopanel-for-term-for-section-4.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.4" style="display:none">Info about the 'uuid' external reference.</span><a href="https://tools.ietf.org/html/rfc4122#section-4.4">https://tools.ietf.org/html/rfc4122#section-4.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.4">8. Remote Playback Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2">
-   <a href="https://tools.ietf.org/html/rfc5646#section-2">https://tools.ietf.org/html/rfc5646#section-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2" class="dfn-panel" data-for="term-for-section-2" id="infopanel-for-term-for-section-2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2" style="display:none">Info about the 'language tag' external reference.</span><a href="https://tools.ietf.org/html/rfc5646#section-2">https://tools.ietf.org/html/rfc5646#section-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2">4.3. Metadata Discovery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc6381#section-3">https://tools.ietf.org/html/rfc6381#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'codecs parameter' external reference.</span><a href="https://tools.ietf.org/html/rfc6381#section-3">https://tools.ietf.org/html/rfc6381#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">9.1. Streaming Protocol Capabilities</a>
     <li><a href="#ref-for-section-3①">9.2. Sessions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-9">
-   <a href="https://tools.ietf.org/html/rfc6762#section-9">https://tools.ietf.org/html/rfc6762#section-9</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-9" class="dfn-panel" data-for="term-for-section-9" id="infopanel-for-term-for-section-9" role="menu">
+   <span id="infopaneltitle-for-term-for-section-9" style="display:none">Info about the 'conflict resolution' external reference.</span><a href="https://tools.ietf.org/html/rfc6762#section-9">https://tools.ietf.org/html/rfc6762#section-9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-9">3. Discovery with mDNS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1.1">
-   <a href="https://tools.ietf.org/html/rfc6763#section-4.1.1">https://tools.ietf.org/html/rfc6763#section-4.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1.1" class="dfn-panel" data-for="term-for-section-4.1.1" id="infopanel-for-term-for-section-4.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1.1" style="display:none">Info about the 'instance name' external reference.</span><a href="https://tools.ietf.org/html/rfc6763#section-4.1.1">https://tools.ietf.org/html/rfc6763#section-4.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.1">3. Discovery with mDNS</a>
     <li><a href="#ref-for-section-4.1.1①">12.6.1. Instance and Display Names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7">
-   <a href="https://tools.ietf.org/html/rfc6763#section-7">https://tools.ietf.org/html/rfc6763#section-7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7" class="dfn-panel" data-for="term-for-section-7" id="infopanel-for-term-for-section-7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7" style="display:none">Info about the 'service name' external reference.</span><a href="https://tools.ietf.org/html/rfc6763#section-7">https://tools.ietf.org/html/rfc6763#section-7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7">3. Discovery with mDNS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5" class="dfn-panel" data-for="term-for-section-5" id="infopanel-for-term-for-section-5" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5" style="display:none">Info about the 'md2' external reference.</span><a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">3. Discovery with mDNS</a> <a href="#ref-for-section-5①">(2)</a> <a href="#ref-for-section-5②">(3)</a> <a href="#ref-for-section-5③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5" class="dfn-panel" data-for="term-for-section-5" id="infopanel-for-term-for-section-5①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5①" style="display:none">Info about the 'md5' external reference.</span><a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">3. Discovery with mDNS</a> <a href="#ref-for-section-5①">(2)</a> <a href="#ref-for-section-5②">(3)</a> <a href="#ref-for-section-5③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5" class="dfn-panel" data-for="term-for-section-5" id="infopanel-for-term-for-section-5②" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5②" style="display:none">Info about the 'sha-256' external reference.</span><a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">3. Discovery with mDNS</a> <a href="#ref-for-section-5①">(2)</a> <a href="#ref-for-section-5②">(3)</a> <a href="#ref-for-section-5③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5" class="dfn-panel" data-for="term-for-section-5" id="infopanel-for-term-for-section-5③" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5③" style="display:none">Info about the 'sha-512' external reference.</span><a href="https://tools.ietf.org/html/rfc8122#section-5">https://tools.ietf.org/html/rfc8122#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">3. Discovery with mDNS</a> <a href="#ref-for-section-5①">(2)</a> <a href="#ref-for-section-5②">(3)</a> <a href="#ref-for-section-5③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc8610#section-3">https://tools.ietf.org/html/rfc8610#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3①" style="display:none">Info about the 'concise data definition language' external reference.</span><a href="https://tools.ietf.org/html/rfc8610#section-3">https://tools.ietf.org/html/rfc8610#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3②">Appendix A: Messages</a>
    </ul>
@@ -3663,8 +3663,9 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
    <div class="issue"> Align capabilities for HDR rendering and display with Media Capabilities. <a href="https://github.com/w3c/openscreenprotocol/issues/194">[Issue #194]</a> <a class="issue-return" href="#issue-a057c285" title="Jump to section">↵</a></div>
    <div class="issue"> Fate of metadata / authentication history when clearing browsing data. <a href="https://github.com/w3c/openscreenprotocol/issues/132">[Issue #132]</a> <a class="issue-return" href="#issue-8bf4aa9f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="open-screen-protocol-agent">
-   <b><a href="#open-screen-protocol-agent">#open-screen-protocol-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-open-screen-protocol-agent" class="dfn-panel" data-for="open-screen-protocol-agent" id="infopanel-for-open-screen-protocol-agent" role="dialog">
+   <span id="infopaneltitle-for-open-screen-protocol-agent" style="display:none">Info about the 'Open Screen Protocol
+agent' definition.</span><b><a href="#open-screen-protocol-agent">#open-screen-protocol-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-open-screen-protocol-agent">2.1. General Requirements</a>
     <li><a href="#ref-for-open-screen-protocol-agent①">3. Discovery with mDNS</a>
@@ -3678,8 +3679,8 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
     <li><a href="#ref-for-open-screen-protocol-agent①①">12. Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="controller">
-   <b><a href="#controller">#controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-controller" class="dfn-panel" data-for="controller" id="infopanel-for-controller" role="dialog">
+   <span id="infopaneltitle-for-controller" style="display:none">Info about the 'controller' definition.</span><b><a href="#controller">#controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-controller">1.1. Terminology</a>
     <li><a href="#ref-for-controller①">2.2. Presentation API Requirements</a>
@@ -3687,8 +3688,8 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
     <li><a href="#ref-for-controller③">7.1. Presentation API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="receiver">
-   <b><a href="#receiver">#receiver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-receiver" class="dfn-panel" data-for="receiver" id="infopanel-for-receiver" role="dialog">
+   <span id="infopaneltitle-for-receiver" style="display:none">Info about the 'receiver' definition.</span><b><a href="#receiver">#receiver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-receiver">1.1. Terminology</a>
     <li><a href="#ref-for-receiver①">2.2. Presentation API Requirements</a>
@@ -3697,22 +3698,22 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
     <li><a href="#ref-for-receiver④">8.2. Remote Playback API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-sender">
-   <b><a href="#media-sender">#media-sender</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-sender" class="dfn-panel" data-for="media-sender" id="infopanel-for-media-sender" role="dialog">
+   <span id="infopaneltitle-for-media-sender" style="display:none">Info about the 'media sender' definition.</span><b><a href="#media-sender">#media-sender</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-sender">9. Streaming Protocol</a>
     <li><a href="#ref-for-media-sender①">9.3. Audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-receiver">
-   <b><a href="#media-receiver">#media-receiver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-receiver" class="dfn-panel" data-for="media-receiver" id="infopanel-for-media-receiver" role="dialog">
+   <span id="infopaneltitle-for-media-receiver" style="display:none">Info about the 'media receiver' definition.</span><b><a href="#media-receiver">#media-receiver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-receiver">9. Streaming Protocol</a>
     <li><a href="#ref-for-media-receiver①">9.3. Audio</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advertising-agent">
-   <b><a href="#advertising-agent">#advertising-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advertising-agent" class="dfn-panel" data-for="advertising-agent" id="infopanel-for-advertising-agent" role="dialog">
+   <span id="infopaneltitle-for-advertising-agent" style="display:none">Info about the 'advertising agent' definition.</span><b><a href="#advertising-agent">#advertising-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advertising-agent">2.4. Non-Functional Requirements</a>
     <li><a href="#ref-for-advertising-agent①">4. Transport and metadata discovery with QUIC</a>
@@ -3723,14 +3724,15 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
     <li><a href="#ref-for-advertising-agent⑥">9. Streaming Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="display-name">
-   <b><a href="#display-name">#display-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-display-name" class="dfn-panel" data-for="display-name" id="infopanel-for-display-name" role="dialog">
+   <span id="infopaneltitle-for-display-name" style="display:none">Info about the 'display
+name' definition.</span><b><a href="#display-name">#display-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-display-name">12.2.1. Personally Identifiable Information &amp; High-Value Data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="listening-agent">
-   <b><a href="#listening-agent">#listening-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-listening-agent" class="dfn-panel" data-for="listening-agent" id="infopanel-for-listening-agent" role="dialog">
+   <span id="infopaneltitle-for-listening-agent" style="display:none">Info about the 'listening agent' definition.</span><b><a href="#listening-agent">#listening-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-listening-agent">2.4. Non-Functional Requirements</a>
     <li><a href="#ref-for-listening-agent①">4. Transport and metadata discovery with QUIC</a>
@@ -3740,86 +3742,144 @@ it to a message. <a href="https://github.com/w3c/presentation-api/issues/471">[I
     <li><a href="#ref-for-listening-agent⑤">9. Streaming Protocol</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="agent-fingerprint">
-   <b><a href="#agent-fingerprint">#agent-fingerprint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-agent-fingerprint" class="dfn-panel" data-for="agent-fingerprint" id="infopanel-for-agent-fingerprint" role="dialog">
+   <span id="infopaneltitle-for-agent-fingerprint" style="display:none">Info about the 'agent fingerprint' definition.</span><b><a href="#agent-fingerprint">#agent-fingerprint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-agent-fingerprint">4.1. TLS 1.3</a>
     <li><a href="#ref-for-agent-fingerprint①">4.2. Agent Certificates</a>
     <li><a href="#ref-for-agent-fingerprint②">6.1. Authentication with SPAKE2</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="agent-certificate">
-   <b><a href="#agent-certificate">#agent-certificate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-agent-certificate" class="dfn-panel" data-for="agent-certificate" id="infopanel-for-agent-certificate" role="dialog">
+   <span id="infopaneltitle-for-agent-certificate" style="display:none">Info about the 'agent
+certificate' definition.</span><b><a href="#agent-certificate">#agent-certificate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-agent-certificate">3. Discovery with mDNS</a>
     <li><a href="#ref-for-agent-certificate①">4.2. Agent Certificates</a> <a href="#ref-for-agent-certificate②">(2)</a> <a href="#ref-for-agent-certificate③">(3)</a> <a href="#ref-for-agent-certificate④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suspicious-agent">
-   <b><a href="#suspicious-agent">#suspicious-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suspicious-agent" class="dfn-panel" data-for="suspicious-agent" id="infopanel-for-suspicious-agent" role="dialog">
+   <span id="infopaneltitle-for-suspicious-agent" style="display:none">Info about the 'suspicious
+agent' definition.</span><b><a href="#suspicious-agent">#suspicious-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suspicious-agent">12.6. User Interface Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="verified-display-name">
-   <b><a href="#verified-display-name">#verified-display-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-verified-display-name" class="dfn-panel" data-for="verified-display-name" id="infopanel-for-verified-display-name" role="dialog">
+   <span id="infopaneltitle-for-verified-display-name" style="display:none">Info about the 'verified display name' definition.</span><b><a href="#verified-display-name">#verified-display-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-verified-display-name">12.6.1. Instance and Display Names</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/orientation-sensor/index.html
+++ b/tests/github/w3c/orientation-sensor/index.html
@@ -1125,86 +1125,86 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#dom-orientationsensorlocalcoordinatesystem-screen">"screen"</a><span>, in § 6.1</span>
    <li><a href="#stationary-reference-coordinate-system">stationary reference coordinate system</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-accelerometer">
-   <a href="https://w3c.github.io/accelerometer/#accelerometer">https://w3c.github.io/accelerometer/#accelerometer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer" class="dfn-panel" data-for="term-for-accelerometer" id="infopanel-for-term-for-accelerometer" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer" style="display:none">Info about the 'Accelerometer' external reference.</span><a href="https://w3c.github.io/accelerometer/#accelerometer">https://w3c.github.io/accelerometer/#accelerometer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer">5. Model</a> <a href="#ref-for-accelerometer①">(2)</a> <a href="#ref-for-accelerometer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-device-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-coordinate-system" class="dfn-panel" data-for="term-for-device-coordinate-system" id="infopanel-for-term-for-device-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-device-coordinate-system" style="display:none">Info about the 'device coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#device-coordinate-system">https://w3c.github.io/accelerometer/#device-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-coordinate-system">5.1. The AbsoluteOrientationSensor Model</a>
     <li><a href="#ref-for-device-coordinate-system①">5.2. The RelativeOrientationSensor Model</a>
     <li><a href="#ref-for-device-coordinate-system②">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-screen-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-screen-coordinate-system" class="dfn-panel" data-for="term-for-screen-coordinate-system" id="infopanel-for-term-for-screen-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-screen-coordinate-system" style="display:none">Info about the 'screen coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer/#screen-coordinate-system">https://w3c.github.io/accelerometer/#screen-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screen-coordinate-system">5.1. The AbsoluteOrientationSensor Model</a>
     <li><a href="#ref-for-screen-coordinate-system①">5.2. The RelativeOrientationSensor Model</a>
     <li><a href="#ref-for-screen-coordinate-system②">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deviceorientation_event">
-   <a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event">https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deviceorientation_event" class="dfn-panel" data-for="term-for-deviceorientation_event" id="infopanel-for-term-for-deviceorientation_event" role="menu">
+   <span id="infopaneltitle-for-term-for-deviceorientation_event" style="display:none">Info about the 'DeviceOrientationEvent' external reference.</span><a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event">https://www.w3.org/TR/2016/CR-orientation-event-20160818/#deviceorientation_event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deviceorientation_event">1. Introduction</a> <a href="#ref-for-deviceorientation_event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-absolute-orientation">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-absolute-orientation">https://w3c.github.io/sensors/#dom-mocksensortype-absolute-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-absolute-orientation" class="dfn-panel" data-for="term-for-dom-mocksensortype-absolute-orientation" id="infopanel-for-term-for-dom-mocksensortype-absolute-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-absolute-orientation" style="display:none">Info about the '"absolute-orientation"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-absolute-orientation">https://w3c.github.io/sensors/#dom-mocksensortype-absolute-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-absolute-orientation">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-relative-orientation">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-relative-orientation">https://w3c.github.io/sensors/#dom-mocksensortype-relative-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-relative-orientation" class="dfn-panel" data-for="term-for-dom-mocksensortype-relative-orientation" id="infopanel-for-term-for-dom-mocksensortype-relative-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-relative-orientation" style="display:none">Info about the '"relative-orientation"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-relative-orientation">https://w3c.github.io/sensors/#dom-mocksensortype-relative-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-relative-orientation">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">5. Model</a> <a href="#ref-for-sensor①">(2)</a>
     <li><a href="#ref-for-sensor②">6.1. The OrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">1. Introduction</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">6.1. The OrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors/#automation">https://w3c.github.io/sensors/#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">8. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors/#check-sensor-policy-controlled-features">https://w3c.github.io/sensors/#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-equivalent">
-   <a href="https://w3c.github.io/sensors/#equivalent">https://w3c.github.io/sensors/#equivalent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-equivalent" class="dfn-panel" data-for="term-for-equivalent" id="infopanel-for-term-for-equivalent" role="menu">
+   <span id="infopaneltitle-for-term-for-equivalent" style="display:none">Info about the 'equivalent' external reference.</span><a href="https://w3c.github.io/sensors/#equivalent">https://w3c.github.io/sensors/#equivalent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-equivalent">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors/#initialize-a-sensor-object">https://w3c.github.io/sensors/#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors/#latest-reading">https://w3c.github.io/sensors/#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">5. Model</a> <a href="#ref-for-latest-reading①">(2)</a>
     <li><a href="#ref-for-latest-reading②">5.1. The AbsoluteOrientationSensor Model</a> <a href="#ref-for-latest-reading③">(2)</a>
@@ -1212,16 +1212,16 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-latest-reading⑤">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://w3c.github.io/sensors/#local-coordinate-system">https://w3c.github.io/sensors/#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">5.1. The AbsoluteOrientationSensor Model</a> <a href="#ref-for-local-coordinate-system①">(2)</a> <a href="#ref-for-local-coordinate-system②">(3)</a>
     <li><a href="#ref-for-local-coordinate-system③">5.2. The RelativeOrientationSensor Model</a> <a href="#ref-for-local-coordinate-system④">(2)</a>
     <li><a href="#ref-for-local-coordinate-system⑤">7.1. Construct an Orientation Sensor object</a> <a href="#ref-for-local-coordinate-system⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-low-level">
-   <a href="https://w3c.github.io/sensors/#low-level">https://w3c.github.io/sensors/#low-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-low-level" class="dfn-panel" data-for="term-for-low-level" id="infopanel-for-term-for-low-level" role="menu">
+   <span id="infopaneltitle-for-term-for-low-level" style="display:none">Info about the 'low-level' external reference.</span><a href="https://w3c.github.io/sensors/#low-level">https://w3c.github.io/sensors/#low-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-level">1. Introduction</a>
     <li><a href="#ref-for-low-level①">5. Model</a> <a href="#ref-for-low-level②">(2)</a> <a href="#ref-for-low-level③">(3)</a> <a href="#ref-for-low-level④">(4)</a> <a href="#ref-for-low-level⑤">(5)</a>
@@ -1229,207 +1229,207 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-low-level⑦">5.2. The RelativeOrientationSensor Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-reading-values">https://w3c.github.io/sensors/#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">8.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-reading-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#mock-sensor-type">https://w3c.github.io/sensors/#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">8.1. Mock Sensor Type</a> <a href="#ref-for-mock-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-sensor-onerror">
-   <a href="https://w3c.github.io/sensors/#dom-sensor-onerror">https://w3c.github.io/sensors/#dom-sensor-onerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-sensor-onerror" class="dfn-panel" data-for="term-for-dom-sensor-onerror" id="infopanel-for-term-for-dom-sensor-onerror" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-sensor-onerror" style="display:none">Info about the 'onerror' external reference.</span><a href="https://w3c.github.io/sensors/#dom-sensor-onerror">https://w3c.github.io/sensors/#dom-sensor-onerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-onerror">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-type">https://w3c.github.io/sensors/#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">5. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-fusion">
-   <a href="https://w3c.github.io/sensors/#sensor-fusion">https://w3c.github.io/sensors/#sensor-fusion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-fusion" class="dfn-panel" data-for="term-for-sensor-fusion" id="infopanel-for-term-for-sensor-fusion" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-fusion" style="display:none">Info about the 'sensor-fusion' external reference.</span><a href="https://w3c.github.io/sensors/#sensor-fusion">https://w3c.github.io/sensors/#sensor-fusion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-fusion">5. Model</a> <a href="#ref-for-sensor-fusion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-sensor-start">
-   <a href="https://w3c.github.io/sensors/#dom-sensor-start">https://w3c.github.io/sensors/#dom-sensor-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-sensor-start" class="dfn-panel" data-for="term-for-dom-sensor-start" id="infopanel-for-term-for-dom-sensor-start" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-sensor-start" style="display:none">Info about the 'start()' external reference.</span><a href="https://w3c.github.io/sensors/#dom-sensor-start">https://w3c.github.io/sensors/#dom-sensor-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-start">5. Model</a> <a href="#ref-for-dom-sensor-start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supported-sensor-options">
-   <a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supported-sensor-options" class="dfn-panel" data-for="term-for-supported-sensor-options" id="infopanel-for-term-for-supported-sensor-options" role="menu">
+   <span id="infopaneltitle-for-term-for-supported-sensor-options" style="display:none">Info about the 'supported sensor options' external reference.</span><a href="https://w3c.github.io/sensors/#supported-sensor-options">https://w3c.github.io/sensors/#supported-sensor-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-sensor-options">6.2. The AbsoluteOrientationSensor Interface</a>
     <li><a href="#ref-for-supported-sensor-options①">6.3. The RelativeOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrix">
-   <a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrix" class="dfn-panel" data-for="term-for-dommatrix" id="infopanel-for-term-for-dommatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrix" style="display:none">Info about the 'DOMMatrix' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#dommatrix">https://drafts.fxtf.org/geometry-1/#dommatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrix">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-dommatrix①">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope">
-   <a href="https://w3c.github.io/gyroscope/#gyroscope">https://w3c.github.io/gyroscope/#gyroscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope" class="dfn-panel" data-for="term-for-gyroscope" id="infopanel-for-term-for-gyroscope" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope" style="display:none">Info about the 'Gyroscope' external reference.</span><a href="https://w3c.github.io/gyroscope/#gyroscope">https://w3c.github.io/gyroscope/#gyroscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">5. Model</a> <a href="#ref-for-gyroscope①">(2)</a> <a href="#ref-for-gyroscope②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5. Model</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer">
-   <a href="https://w3c.github.io/magnetometer/#magnetometer">https://w3c.github.io/magnetometer/#magnetometer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer" class="dfn-panel" data-for="term-for-magnetometer" id="infopanel-for-term-for-magnetometer" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer" style="display:none">Info about the 'Magnetometer' external reference.</span><a href="https://w3c.github.io/magnetometer/#magnetometer">https://w3c.github.io/magnetometer/#magnetometer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer">5. Model</a> <a href="#ref-for-magnetometer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-orientation">
-   <a href="https://w3c.github.io/motion-sensors/#absolute-orientation">https://w3c.github.io/motion-sensors/#absolute-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-orientation" class="dfn-panel" data-for="term-for-absolute-orientation" id="infopanel-for-term-for-absolute-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-orientation" style="display:none">Info about the 'absolute orientation sensor' external reference.</span><a href="https://w3c.github.io/motion-sensors/#absolute-orientation">https://w3c.github.io/motion-sensors/#absolute-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation">5.1. The AbsoluteOrientationSensor Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relative-orientation">
-   <a href="https://w3c.github.io/motion-sensors/#relative-orientation">https://w3c.github.io/motion-sensors/#relative-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relative-orientation" class="dfn-panel" data-for="term-for-relative-orientation" id="infopanel-for-term-for-relative-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-relative-orientation" style="display:none">Info about the 'relative orientation sensor' external reference.</span><a href="https://w3c.github.io/motion-sensors/#relative-orientation">https://w3c.github.io/motion-sensors/#relative-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-orientation">5.2. The RelativeOrientationSensor Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1.2. OrientationSensor.populateMatrix()</a>
     <li><a href="#ref-for-idl-DOMException①">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-Exposed①">6.2. The AbsoluteOrientationSensor Interface</a>
     <li><a href="#ref-for-Exposed②">6.3. The RelativeOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-Float32Array①">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-idl-Float32Array②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float64Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float64Array" class="dfn-panel" data-for="term-for-idl-Float64Array" id="infopanel-for-term-for-idl-Float64Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float64Array" style="display:none">Info about the 'Float64Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float64Array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-Float64Array①">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-idl-Float64Array②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-frozen-array①">6.1.1. OrientationSensor.quaternion</a>
     <li><a href="#ref-for-idl-frozen-array②">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notreadableerror">
-   <a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notreadableerror" class="dfn-panel" data-for="term-for-notreadableerror" id="infopanel-for-term-for-notreadableerror" role="menu">
+   <span id="infopaneltitle-for-term-for-notreadableerror" style="display:none">Info about the 'NotReadableError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notreadableerror">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-SecureContext①">6.2. The AbsoluteOrientationSensor Interface</a>
     <li><a href="#ref-for-SecureContext②">6.3. The RelativeOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-double①">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherited-interfaces">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherited-interfaces" class="dfn-panel" data-for="term-for-dfn-inherited-interfaces" id="infopanel-for-term-for-dfn-inherited-interfaces" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherited-interfaces" style="display:none">Info about the 'inherited interfaces' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-interfaces">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface" class="dfn-panel" data-for="term-for-dfn-interface" id="infopanel-for-term-for-dfn-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface" style="display:none">Info about the 'interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface">7.1. Construct an Orientation Sensor object</a> <a href="#ref-for-dfn-interface①">(2)</a> <a href="#ref-for-dfn-interface②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6.1. The OrientationSensor Interface</a>
    </ul>
@@ -1588,34 +1588,35 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="orientation-sensor">
-   <b><a href="#orientation-sensor">#orientation-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-orientation-sensor" class="dfn-panel" data-for="orientation-sensor" id="infopanel-for-orientation-sensor" role="dialog">
+   <span id="infopaneltitle-for-orientation-sensor" style="display:none">Info about the 'Orientation Sensor' definition.</span><b><a href="#orientation-sensor">#orientation-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-orientation-sensor">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="earths-reference-coordinate-system">
-   <b><a href="#earths-reference-coordinate-system">#earths-reference-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-earths-reference-coordinate-system" class="dfn-panel" data-for="earths-reference-coordinate-system" id="infopanel-for-earths-reference-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-earths-reference-coordinate-system" style="display:none">Info about the 'Earth’s reference
+coordinate system' definition.</span><b><a href="#earths-reference-coordinate-system">#earths-reference-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-earths-reference-coordinate-system">1. Introduction</a>
     <li><a href="#ref-for-earths-reference-coordinate-system①">5.1. The AbsoluteOrientationSensor Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stationary-reference-coordinate-system">
-   <b><a href="#stationary-reference-coordinate-system">#stationary-reference-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stationary-reference-coordinate-system" class="dfn-panel" data-for="stationary-reference-coordinate-system" id="infopanel-for-stationary-reference-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-stationary-reference-coordinate-system" style="display:none">Info about the 'stationary reference coordinate system' definition.</span><b><a href="#stationary-reference-coordinate-system">#stationary-reference-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stationary-reference-coordinate-system">5.2. The RelativeOrientationSensor Model</a> <a href="#ref-for-stationary-reference-coordinate-system①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-rotationmatrixtype">
-   <b><a href="#typedefdef-rotationmatrixtype">#typedefdef-rotationmatrixtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-rotationmatrixtype" class="dfn-panel" data-for="typedefdef-rotationmatrixtype" id="infopanel-for-typedefdef-rotationmatrixtype" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-rotationmatrixtype" style="display:none">Info about the 'RotationMatrixType' definition.</span><b><a href="#typedefdef-rotationmatrixtype">#typedefdef-rotationmatrixtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-rotationmatrixtype">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-typedefdef-rotationmatrixtype①">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="orientationsensor">
-   <b><a href="#orientationsensor">#orientationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-orientationsensor" class="dfn-panel" data-for="orientationsensor" id="infopanel-for-orientationsensor" role="dialog">
+   <span id="infopaneltitle-for-orientationsensor" style="display:none">Info about the 'OrientationSensor' definition.</span><b><a href="#orientationsensor">#orientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-orientationsensor">1. Introduction</a> <a href="#ref-for-orientationsensor①">(2)</a> <a href="#ref-for-orientationsensor②">(3)</a> <a href="#ref-for-orientationsensor③">(4)</a>
     <li><a href="#ref-for-orientationsensor④">5. Model</a> <a href="#ref-for-orientationsensor⑤">(2)</a>
@@ -1626,40 +1627,40 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-orientationsensor①⓪">7.1. Construct an Orientation Sensor object</a> <a href="#ref-for-orientationsensor①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-orientationsensor-populatematrix">
-   <b><a href="#dom-orientationsensor-populatematrix">#dom-orientationsensor-populatematrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-orientationsensor-populatematrix" class="dfn-panel" data-for="dom-orientationsensor-populatematrix" id="infopanel-for-dom-orientationsensor-populatematrix" role="dialog">
+   <span id="infopaneltitle-for-dom-orientationsensor-populatematrix" style="display:none">Info about the 'populateMatrix' definition.</span><b><a href="#dom-orientationsensor-populatematrix">#dom-orientationsensor-populatematrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-orientationsensor-populatematrix">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-dom-orientationsensor-populatematrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-orientationsensorlocalcoordinatesystem">
-   <b><a href="#enumdef-orientationsensorlocalcoordinatesystem">#enumdef-orientationsensorlocalcoordinatesystem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-orientationsensorlocalcoordinatesystem" class="dfn-panel" data-for="enumdef-orientationsensorlocalcoordinatesystem" id="infopanel-for-enumdef-orientationsensorlocalcoordinatesystem" role="dialog">
+   <span id="infopaneltitle-for-enumdef-orientationsensorlocalcoordinatesystem" style="display:none">Info about the 'OrientationSensorLocalCoordinateSystem' definition.</span><b><a href="#enumdef-orientationsensorlocalcoordinatesystem">#enumdef-orientationsensorlocalcoordinatesystem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-orientationsensorlocalcoordinatesystem">6.1. The OrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-orientationsensoroptions">
-   <b><a href="#dictdef-orientationsensoroptions">#dictdef-orientationsensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-orientationsensoroptions" class="dfn-panel" data-for="dictdef-orientationsensoroptions" id="infopanel-for-dictdef-orientationsensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-orientationsensoroptions" style="display:none">Info about the 'OrientationSensorOptions' definition.</span><b><a href="#dictdef-orientationsensoroptions">#dictdef-orientationsensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-orientationsensoroptions">6.2. The AbsoluteOrientationSensor Interface</a>
     <li><a href="#ref-for-dictdef-orientationsensoroptions①">6.3. The RelativeOrientationSensor Interface</a>
     <li><a href="#ref-for-dictdef-orientationsensoroptions②">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-orientationsensoroptions-referenceframe">
-   <b><a href="#dom-orientationsensoroptions-referenceframe">#dom-orientationsensoroptions-referenceframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-orientationsensoroptions-referenceframe" class="dfn-panel" data-for="dom-orientationsensoroptions-referenceframe" id="infopanel-for-dom-orientationsensoroptions-referenceframe" role="dialog">
+   <span id="infopaneltitle-for-dom-orientationsensoroptions-referenceframe" style="display:none">Info about the 'referenceFrame' definition.</span><b><a href="#dom-orientationsensoroptions-referenceframe">#dom-orientationsensoroptions-referenceframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-orientationsensoroptions-referenceframe">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="populate-rotation-matrix">
-   <b><a href="#populate-rotation-matrix">#populate-rotation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-populate-rotation-matrix" class="dfn-panel" data-for="populate-rotation-matrix" id="infopanel-for-populate-rotation-matrix" role="dialog">
+   <span id="infopaneltitle-for-populate-rotation-matrix" style="display:none">Info about the 'populate rotation matrix' definition.</span><b><a href="#populate-rotation-matrix">#populate-rotation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-populate-rotation-matrix">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absoluteorientationsensor">
-   <b><a href="#absoluteorientationsensor">#absoluteorientationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absoluteorientationsensor" class="dfn-panel" data-for="absoluteorientationsensor" id="infopanel-for-absoluteorientationsensor" role="dialog">
+   <span id="infopaneltitle-for-absoluteorientationsensor" style="display:none">Info about the 'AbsoluteOrientationSensor' definition.</span><b><a href="#absoluteorientationsensor">#absoluteorientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor">1. Introduction</a>
     <li><a href="#ref-for-absoluteorientationsensor①">5. Model</a> <a href="#ref-for-absoluteorientationsensor②">(2)</a> <a href="#ref-for-absoluteorientationsensor③">(3)</a>
@@ -1669,8 +1670,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-absoluteorientationsensor⑨">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relativeorientationsensor">
-   <b><a href="#relativeorientationsensor">#relativeorientationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relativeorientationsensor" class="dfn-panel" data-for="relativeorientationsensor" id="infopanel-for-relativeorientationsensor" role="dialog">
+   <span id="infopaneltitle-for-relativeorientationsensor" style="display:none">Info about the 'RelativeOrientationSensor' definition.</span><b><a href="#relativeorientationsensor">#relativeorientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relativeorientationsensor">5. Model</a> <a href="#ref-for-relativeorientationsensor①">(2)</a>
     <li><a href="#ref-for-relativeorientationsensor②">5.2. The RelativeOrientationSensor Model</a>
@@ -1679,75 +1680,131 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-relativeorientationsensor⑦">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-an-orientation-sensor-object">
-   <b><a href="#construct-an-orientation-sensor-object">#construct-an-orientation-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-an-orientation-sensor-object" class="dfn-panel" data-for="construct-an-orientation-sensor-object" id="infopanel-for-construct-an-orientation-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-construct-an-orientation-sensor-object" style="display:none">Info about the '7.1. Construct an Orientation Sensor object' definition.</span><b><a href="#construct-an-orientation-sensor-object">#construct-an-orientation-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-an-orientation-sensor-object">6.2. The AbsoluteOrientationSensor Interface</a>
     <li><a href="#ref-for-construct-an-orientation-sensor-object①">6.3. The RelativeOrientationSensor Interface</a>
     <li><a href="#ref-for-construct-an-orientation-sensor-object">7.1. Construct an Orientation Sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-absoluteorientationreadingvalues">
-   <b><a href="#dictdef-absoluteorientationreadingvalues">#dictdef-absoluteorientationreadingvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-absoluteorientationreadingvalues" class="dfn-panel" data-for="dictdef-absoluteorientationreadingvalues" id="infopanel-for-dictdef-absoluteorientationreadingvalues" role="dialog">
+   <span id="infopaneltitle-for-dictdef-absoluteorientationreadingvalues" style="display:none">Info about the 'AbsoluteOrientationReadingValues' definition.</span><b><a href="#dictdef-absoluteorientationreadingvalues">#dictdef-absoluteorientationreadingvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-absoluteorientationreadingvalues">8.1. Mock Sensor Type</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/orientation-sensor/releases/FPWD.html
+++ b/tests/github/w3c/orientation-sensor/releases/FPWD.html
@@ -667,179 +667,179 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#dom-orientationsensor-quaternion">quaternion</a><span>, in § 6.1</span>
    <li><a href="#typedefdef-rotationmatrixtype">RotationMatrixType</a><span>, in § 6.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-acceleration">
-   <a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-acceleration" class="dfn-panel" data-for="term-for-acceleration" id="infopanel-for-term-for-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-acceleration" style="display:none">Info about the 'acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-coordinate-system">
-   <a href="https://w3c.github.io/accelerometer#local-coordinate-system">https://w3c.github.io/accelerometer#local-coordinate-system</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-coordinate-system" class="dfn-panel" data-for="term-for-local-coordinate-system" id="infopanel-for-term-for-local-coordinate-system" role="menu">
+   <span id="infopaneltitle-for-term-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' external reference.</span><a href="https://w3c.github.io/accelerometer#local-coordinate-system">https://w3c.github.io/accelerometer#local-coordinate-system</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">5. Model</a> <a href="#ref-for-local-coordinate-system①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deviceorientation_event">
-   <a href="https://www.w3.org/TR/orientation-event#deviceorientation_event">https://www.w3.org/TR/orientation-event#deviceorientation_event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deviceorientation_event" class="dfn-panel" data-for="term-for-deviceorientation_event" id="infopanel-for-term-for-deviceorientation_event" role="menu">
+   <span id="infopaneltitle-for-term-for-deviceorientation_event" style="display:none">Info about the 'DeviceOrientationEvent' external reference.</span><a href="https://www.w3.org/TR/orientation-event#deviceorientation_event">https://www.w3.org/TR/orientation-event#deviceorientation_event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deviceorientation_event">1. Introduction</a> <a href="#ref-for-deviceorientation_event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://www.w3.org/TR/generic-sensor/#sensor">https://www.w3.org/TR/generic-sensor/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://www.w3.org/TR/generic-sensor/#sensor">https://www.w3.org/TR/generic-sensor/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">5. Model</a>
     <li><a href="#ref-for-sensor②">6.1. The OrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://www.w3.org/TR/generic-sensor/#dictdef-sensoroptions">https://www.w3.org/TR/generic-sensor/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://www.w3.org/TR/generic-sensor/#dictdef-sensoroptions">https://www.w3.org/TR/generic-sensor/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">1. Introduction</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">6.2. The AbsoluteOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-construct-sensor-object">
-   <a href="https://w3c.github.io/sensors#construct-sensor-object">https://w3c.github.io/sensors#construct-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-construct-sensor-object" class="dfn-panel" data-for="term-for-construct-sensor-object" id="infopanel-for-term-for-construct-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-construct-sensor-object" style="display:none">Info about the 'construct a sensor object' external reference.</span><a href="https://w3c.github.io/sensors#construct-sensor-object">https://w3c.github.io/sensors#construct-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-sensor-object">6.2. The AbsoluteOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-equivalent">
-   <a href="https://w3c.github.io/sensors#equivalent">https://w3c.github.io/sensors#equivalent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-equivalent" class="dfn-panel" data-for="term-for-equivalent" id="infopanel-for-term-for-equivalent" role="menu">
+   <span id="infopaneltitle-for-term-for-equivalent" style="display:none">Info about the 'equivalent' external reference.</span><a href="https://w3c.github.io/sensors#equivalent">https://w3c.github.io/sensors#equivalent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-equivalent">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-high-level">
-   <a href="https://w3c.github.io/sensors#high-level">https://w3c.github.io/sensors#high-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-high-level" class="dfn-panel" data-for="term-for-high-level" id="infopanel-for-term-for-high-level" role="menu">
+   <span id="infopaneltitle-for-term-for-high-level" style="display:none">Info about the 'high-level' external reference.</span><a href="https://w3c.github.io/sensors#high-level">https://w3c.github.io/sensors#high-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-level">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">5. Model</a> <a href="#ref-for-latest-reading①">(2)</a> <a href="#ref-for-latest-reading②">(3)</a> <a href="#ref-for-latest-reading③">(4)</a>
     <li><a href="#ref-for-latest-reading④">6.1.1. OrientationSensor.quaternion</a>
     <li><a href="#ref-for-latest-reading⑤">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-latest-reading⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-low-level">
-   <a href="https://w3c.github.io/sensors#low-level">https://w3c.github.io/sensors#low-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-low-level" class="dfn-panel" data-for="term-for-low-level" id="infopanel-for-term-for-low-level" role="menu">
+   <span id="infopaneltitle-for-term-for-low-level" style="display:none">Info about the 'low-level' external reference.</span><a href="https://w3c.github.io/sensors#low-level">https://w3c.github.io/sensors#low-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-level">1. Introduction</a>
     <li><a href="#ref-for-low-level①">5. Model</a> <a href="#ref-for-low-level②">(2)</a> <a href="#ref-for-low-level③">(3)</a> <a href="#ref-for-low-level④">(4)</a> <a href="#ref-for-low-level⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors#sensor">https://w3c.github.io/sensors#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor①" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor①" style="display:none">Info about the 'sensor' external reference.</span><a href="https://w3c.github.io/sensors#sensor">https://w3c.github.io/sensors#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor①">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-fusion">
-   <a href="https://w3c.github.io/sensors#sensor-fusion">https://w3c.github.io/sensors#sensor-fusion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-fusion" class="dfn-panel" data-for="term-for-sensor-fusion" id="infopanel-for-term-for-sensor-fusion" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-fusion" style="display:none">Info about the 'sensor-fusion' external reference.</span><a href="https://w3c.github.io/sensors#sensor-fusion">https://w3c.github.io/sensors#sensor-fusion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-fusion">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dommatrix">
-   <a href="https://www.w3.org/TR/geometry-1/#dommatrix">https://www.w3.org/TR/geometry-1/#dommatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dommatrix" class="dfn-panel" data-for="term-for-dommatrix" id="infopanel-for-term-for-dommatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-dommatrix" style="display:none">Info about the 'DOMMatrix' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#dommatrix">https://www.w3.org/TR/geometry-1/#dommatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dommatrix">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-dommatrix①">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angular-velocity">
-   <a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angular-velocity" class="dfn-panel" data-for="term-for-angular-velocity" id="infopanel-for-term-for-angular-velocity" role="menu">
+   <span id="infopaneltitle-for-term-for-angular-velocity" style="display:none">Info about the 'angular velocity' external reference.</span><a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5. Model</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetic-field">
-   <a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetic-field" class="dfn-panel" data-for="term-for-magnetic-field" id="infopanel-for-term-for-magnetic-field" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetic-field" style="display:none">Info about the 'magnetic field' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetic-field">https://w3c.github.io/magnetometer#magnetic-field</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetic-field">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-orientation">
-   <a href="https://w3c.github.io/motion-sensors#absolute-orientation">https://w3c.github.io/motion-sensors#absolute-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-orientation" class="dfn-panel" data-for="term-for-absolute-orientation" id="infopanel-for-term-for-absolute-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-orientation" style="display:none">Info about the 'absolute orientation sensor' external reference.</span><a href="https://w3c.github.io/motion-sensors#absolute-orientation">https://w3c.github.io/motion-sensors#absolute-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-orientation">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float32Array" class="dfn-panel" data-for="term-for-idl-Float32Array" id="infopanel-for-term-for-idl-Float32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float32Array" style="display:none">Info about the 'Float32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float32Array">https://webidl.spec.whatwg.org/#idl-Float32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float32Array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-Float32Array①">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-idl-Float32Array②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Float64Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Float64Array" class="dfn-panel" data-for="term-for-idl-Float64Array" id="infopanel-for-term-for-idl-Float64Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Float64Array" style="display:none">Info about the 'Float64Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Float64Array">https://webidl.spec.whatwg.org/#idl-Float64Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Float64Array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-Float64Array①">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-idl-Float64Array②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-idl-frozen-array①">6.1.1. OrientationSensor.quaternion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notreadableerror">
-   <a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notreadableerror" class="dfn-panel" data-for="term-for-notreadableerror" id="infopanel-for-term-for-notreadableerror" role="menu">
+   <span id="infopaneltitle-for-term-for-notreadableerror" style="display:none">Info about the 'NotReadableError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notreadableerror">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">6.1. The OrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
    </ul>
@@ -952,42 +952,42 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="earths-reference-coordinate-system">
-   <b><a href="#earths-reference-coordinate-system">#earths-reference-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-earths-reference-coordinate-system" class="dfn-panel" data-for="earths-reference-coordinate-system" id="infopanel-for-earths-reference-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-earths-reference-coordinate-system" style="display:none">Info about the 'Earth’s reference coordinate system' definition.</span><b><a href="#earths-reference-coordinate-system">#earths-reference-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-earths-reference-coordinate-system">1. Introduction</a>
     <li><a href="#ref-for-earths-reference-coordinate-system①">5. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-rotationmatrixtype">
-   <b><a href="#typedefdef-rotationmatrixtype">#typedefdef-rotationmatrixtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-rotationmatrixtype" class="dfn-panel" data-for="typedefdef-rotationmatrixtype" id="infopanel-for-typedefdef-rotationmatrixtype" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-rotationmatrixtype" style="display:none">Info about the 'RotationMatrixType' definition.</span><b><a href="#typedefdef-rotationmatrixtype">#typedefdef-rotationmatrixtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-rotationmatrixtype">6.1. The OrientationSensor Interface</a>
     <li><a href="#ref-for-typedefdef-rotationmatrixtype①">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="orientationsensor">
-   <b><a href="#orientationsensor">#orientationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-orientationsensor" class="dfn-panel" data-for="orientationsensor" id="infopanel-for-orientationsensor" role="dialog">
+   <span id="infopaneltitle-for-orientationsensor" style="display:none">Info about the 'OrientationSensor' definition.</span><b><a href="#orientationsensor">#orientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-orientationsensor">1. Introduction</a> <a href="#ref-for-orientationsensor①">(2)</a> <a href="#ref-for-orientationsensor②">(3)</a> <a href="#ref-for-orientationsensor③">(4)</a>
     <li><a href="#ref-for-orientationsensor④">5. Model</a> <a href="#ref-for-orientationsensor⑤">(2)</a>
     <li><a href="#ref-for-orientationsensor⑥">6.2. The AbsoluteOrientationSensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-orientationsensor-populatematrix">
-   <b><a href="#dom-orientationsensor-populatematrix">#dom-orientationsensor-populatematrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-orientationsensor-populatematrix" class="dfn-panel" data-for="dom-orientationsensor-populatematrix" id="infopanel-for-dom-orientationsensor-populatematrix" role="dialog">
+   <span id="infopaneltitle-for-dom-orientationsensor-populatematrix" style="display:none">Info about the 'populateMatrix' definition.</span><b><a href="#dom-orientationsensor-populatematrix">#dom-orientationsensor-populatematrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-orientationsensor-populatematrix">6.1.2. OrientationSensor.populateMatrix()</a> <a href="#ref-for-dom-orientationsensor-populatematrix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="populate-rotation-matrix">
-   <b><a href="#populate-rotation-matrix">#populate-rotation-matrix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-populate-rotation-matrix" class="dfn-panel" data-for="populate-rotation-matrix" id="infopanel-for-populate-rotation-matrix" role="dialog">
+   <span id="infopaneltitle-for-populate-rotation-matrix" style="display:none">Info about the 'populate rotation matrix' definition.</span><b><a href="#populate-rotation-matrix">#populate-rotation-matrix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-populate-rotation-matrix">6.1.2. OrientationSensor.populateMatrix()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absoluteorientationsensor">
-   <b><a href="#absoluteorientationsensor">#absoluteorientationsensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absoluteorientationsensor" class="dfn-panel" data-for="absoluteorientationsensor" id="infopanel-for-absoluteorientationsensor" role="dialog">
+   <span id="infopaneltitle-for-absoluteorientationsensor" style="display:none">Info about the 'AbsoluteOrientationSensor' definition.</span><b><a href="#absoluteorientationsensor">#absoluteorientationsensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor">1. Introduction</a>
     <li><a href="#ref-for-absoluteorientationsensor①">5. Model</a> <a href="#ref-for-absoluteorientationsensor②">(2)</a>
@@ -995,59 +995,115 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/paint-timing/painttiming.html
+++ b/tests/github/w3c/paint-timing/painttiming.html
@@ -1165,202 +1165,202 @@ specification.</p>
    <li><a href="#report-paint-timing">Report paint timing</a><span>, in § 4.1.2</span>
    <li><a href="#should-report-first-contentful-paint">should report first contentful paint</a><span>, in § 4.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-img-available">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#img-available">https://html.spec.whatwg.org/multipage/images.html#img-available</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-img-available" class="dfn-panel" data-for="term-for-img-available" id="infopanel-for-term-for-img-available" role="menu">
+   <span id="infopaneltitle-for-term-for-img-available" style="display:none">Info about the 'available' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#img-available">https://html.spec.whatwg.org/multipage/images.html#img-available</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-img-available">2. Terminology</a> <a href="#ref-for-img-available①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-being-rendered">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-being-rendered" class="dfn-panel" data-for="term-for-being-rendered" id="infopanel-for-term-for-being-rendered" role="menu">
+   <span id="infopaneltitle-for-term-for-being-rendered" style="display:none">Info about the 'being rendered' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#being-rendered">https://html.spec.whatwg.org/multipage/rendering.html#being-rendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-being-rendered">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2. Terminology</a>
     <li><a href="#ref-for-browsing-context①">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-canvas">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-canvas" class="dfn-panel" data-for="term-for-canvas" id="infopanel-for-term-for-canvas" role="menu">
+   <span id="infopaneltitle-for-term-for-canvas" style="display:none">Info about the 'canvas' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">https://html.spec.whatwg.org/multipage/canvas.html#canvas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canvas">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-canvas-context-mode">
-   <a href="https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-context-mode">https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-context-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-canvas-context-mode" class="dfn-panel" data-for="term-for-concept-canvas-context-mode" id="infopanel-for-term-for-concept-canvas-context-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-canvas-context-mode" style="display:none">Info about the 'context mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-context-mode">https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-context-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-canvas-context-mode">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-image">
-   <a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-image" class="dfn-panel" data-for="term-for-typedef-image" id="infopanel-for-term-for-typedef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-image" style="display:none">Info about the 'css image' external reference.</span><a href="https://www.w3.org/TR/css-images-3/#typedef-image">https://www.w3.org/TR/css-images-3/#typedef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-image">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#element">https://html.spec.whatwg.org/multipage/dom.html#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#element">https://html.spec.whatwg.org/multipage/dom.html#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2. Terminology</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a> <a href="#ref-for-element④">(5)</a> <a href="#ref-for-element⑤">(6)</a>
     <li><a href="#ref-for-element⑥">4.1.1. First Contentful Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generated-content">
-   <a href="https://drafts.csswg.org/css-pseudo-4#generated-content">https://drafts.csswg.org/css-pseudo-4#generated-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generated-content" class="dfn-panel" data-for="term-for-generated-content" id="infopanel-for-term-for-generated-content" role="menu">
+   <span id="infopaneltitle-for-term-for-generated-content" style="display:none">Info about the 'generated content pseudo-element' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4#generated-content">https://drafts.csswg.org/css-pseudo-4#generated-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generated-content">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://www.w3.org/TR/cssom-view#dom-element-getboundingclientrect">https://www.w3.org/TR/cssom-view#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getboundingclientrect' external reference.</span><a href="https://www.w3.org/TR/cssom-view#dom-element-getboundingclientrect">https://www.w3.org/TR/cssom-view#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-realm-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-realm-global" class="dfn-panel" data-for="term-for-concept-realm-global" id="infopanel-for-term-for-concept-realm-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-realm-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-realm-global">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-images">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#images">https://html.spec.whatwg.org/multipage/images.html#images</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-images" class="dfn-panel" data-for="term-for-images" id="infopanel-for-term-for-images" role="menu">
+   <span id="infopaneltitle-for-term-for-images" style="display:none">Info about the 'image' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#images">https://html.spec.whatwg.org/multipage/images.html#images</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-images">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nested-browsing-context" class="dfn-panel" data-for="term-for-nested-browsing-context" id="infopanel-for-term-for-nested-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-nested-browsing-context" style="display:none">Info about the 'nested browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-poster-frame">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#poster-frame">https://html.spec.whatwg.org/multipage/media.html#poster-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-poster-frame" class="dfn-panel" data-for="term-for-poster-frame" id="infopanel-for-term-for-poster-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-poster-frame" style="display:none">Info about the 'poster frame' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#poster-frame">https://html.spec.whatwg.org/multipage/media.html#poster-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-poster-frame">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-elements">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-elements" class="dfn-panel" data-for="term-for-replaced-elements" id="infopanel-for-term-for-replaced-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-elements" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements">https://html.spec.whatwg.org/multipage/rendering.html#replaced-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-elements">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-represents">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#represents">https://html.spec.whatwg.org/multipage/dom.html#represents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-represents" class="dfn-panel" data-for="term-for-represents" id="infopanel-for-term-for-represents" role="menu">
+   <span id="infopaneltitle-for-term-for-represents" style="display:none">Info about the 'represents' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#represents">https://html.spec.whatwg.org/multipage/dom.html#represents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-represents">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scrolling-area">
-   <a href="https://www.w3.org/TR/cssom-view#scrolling-area">https://www.w3.org/TR/cssom-view#scrolling-area</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scrolling-area" class="dfn-panel" data-for="term-for-scrolling-area" id="infopanel-for-term-for-scrolling-area" role="menu">
+   <span id="infopaneltitle-for-term-for-scrolling-area" style="display:none">Info about the 'scrolling area' external reference.</span><a href="https://www.w3.org/TR/cssom-view#scrolling-area">https://www.w3.org/TR/cssom-view#scrolling-area</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scrolling-area">2. Terminology</a> <a href="#ref-for-scrolling-area①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sets">
-   <a href="https://infra.spec.whatwg.org/#sets">https://infra.spec.whatwg.org/#sets</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sets" class="dfn-panel" data-for="term-for-sets" id="infopanel-for-term-for-sets" role="menu">
+   <span id="infopaneltitle-for-term-for-sets" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#sets">https://infra.spec.whatwg.org/#sets</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sets">4.1. Reporting paint timing</a> <a href="#ref-for-sets①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typographic-pseudos">
-   <a href="https://drafts.csswg.org/css-pseudo-4#typographic-pseudos">https://drafts.csswg.org/css-pseudo-4#typographic-pseudos</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typographic-pseudos" class="dfn-panel" data-for="term-for-typographic-pseudos" id="infopanel-for-term-for-typographic-pseudos" role="menu">
+   <span id="infopaneltitle-for-term-for-typographic-pseudos" style="display:none">Info about the 'typographical pseudo-element' external reference.</span><a href="https://drafts.csswg.org/css-pseudo-4#typographic-pseudos">https://drafts.csswg.org/css-pseudo-4#typographic-pseudos</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typographic-pseudos">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://www.w3.org/TR/css3-values/#url-value">https://www.w3.org/TR/css3-values/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the 'url valued' external reference.</span><a href="https://www.w3.org/TR/css3-values/#url-value">https://www.w3.org/TR/css3-values/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used">
-   <a href="https://drafts.csswg.org/css-cascade-4/#used">https://drafts.csswg.org/css-cascade-4/#used</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used" class="dfn-panel" data-for="term-for-used" id="infopanel-for-term-for-used" role="menu">
+   <span id="infopaneltitle-for-term-for-used" style="display:none">Info about the 'used' external reference.</span><a href="https://drafts.csswg.org/css-cascade-4/#used">https://drafts.csswg.org/css-cascade-4/#used</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used">2. Terminology</a> <a href="#ref-for-used①">(2)</a> <a href="#ref-for-used②">(3)</a> <a href="#ref-for-used③">(4)</a> <a href="#ref-for-used④">(5)</a> <a href="#ref-for-used⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-value">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-value">https://html.spec.whatwg.org/multipage/input.html#attr-input-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-value" class="dfn-panel" data-for="term-for-attr-input-value" id="infopanel-for-term-for-attr-input-value" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-value" style="display:none">Info about the 'value attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-value">https://html.spec.whatwg.org/multipage/input.html#attr-input-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-value">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-video-element">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">https://html.spec.whatwg.org/multipage/media.html#the-video-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-video-element" class="dfn-panel" data-for="term-for-the-video-element" id="infopanel-for-term-for-the-video-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-video-element" style="display:none">Info about the 'video element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">https://html.spec.whatwg.org/multipage/media.html#the-video-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-video-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Rendered-vs-NonRendered">
-   <a href="https://www.w3.org/TR/SVG2/render.html#Rendered-vs-NonRendered">https://www.w3.org/TR/SVG2/render.html#Rendered-vs-NonRendered</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Rendered-vs-NonRendered" class="dfn-panel" data-for="term-for-Rendered-vs-NonRendered" id="infopanel-for-term-for-Rendered-vs-NonRendered" role="menu">
+   <span id="infopaneltitle-for-term-for-Rendered-vs-NonRendered" style="display:none">Info about the 'svg element with rendered descendants' external reference.</span><a href="https://www.w3.org/TR/SVG2/render.html#Rendered-vs-NonRendered">https://www.w3.org/TR/SVG2/render.html#Rendered-vs-NonRendered</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Rendered-vs-NonRendered">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://www.w3.org/TR/CSS22/visufx.html#propdef-visibility">https://www.w3.org/TR/CSS22/visufx.html#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://www.w3.org/TR/CSS22/visufx.html#propdef-visibility">https://www.w3.org/TR/CSS22/visufx.html#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">2. Terminology</a> <a href="#ref-for-propdef-visibility①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image">https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-background-size">
-   <a href="https://www.w3.org/TR/css-backgrounds-3/#background-size">https://www.w3.org/TR/css-backgrounds-3/#background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-background-size" class="dfn-panel" data-for="term-for-background-size" id="infopanel-for-term-for-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://www.w3.org/TR/css-backgrounds-3/#background-size">https://www.w3.org/TR/css-backgrounds-3/#background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-background-size">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opacity">
-   <a href="https://www.w3.org/TR/css-color-3#opacity">https://www.w3.org/TR/css-color-3#opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opacity" class="dfn-panel" data-for="term-for-opacity" id="infopanel-for-term-for-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://www.w3.org/TR/css-color-3#opacity">https://www.w3.org/TR/css-color-3#opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opacity">2. Terminology</a> <a href="#ref-for-opacity①">(2)</a> <a href="#ref-for-opacity②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-box">
-   <a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-box" class="dfn-panel" data-for="term-for-box" id="infopanel-for-term-for-box" role="menu">
+   <span id="infopaneltitle-for-term-for-box" style="display:none">Info about the 'box' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#box">https://drafts.csswg.org/css-display-3/#box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-box">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-nodes">
-   <a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-nodes" class="dfn-panel" data-for="term-for-text-nodes" id="infopanel-for-term-for-text-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-text-nodes" style="display:none">Info about the 'text node' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#text-nodes">https://drafts.csswg.org/css-display-3/#text-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-nodes">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-white-space" class="dfn-panel" data-for="term-for-white-space" id="infopanel-for-term-for-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-white-space" style="display:none">Info about the 'document white space characters' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#white-space">https://drafts.csswg.org/css-text-4/#white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-white-space">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2. Terminology</a> <a href="#ref-for-concept-document①">(2)</a>
     <li><a href="#ref-for-concept-document②">4.1. Reporting paint timing</a>
@@ -1368,110 +1368,110 @@ specification.</p>
     <li><a href="#ref-for-concept-document④">4.1.2. Mark paint timing</a> <a href="#ref-for-concept-document⑤">(2)</a> <a href="#ref-for-concept-document⑥">(3)</a> <a href="#ref-for-concept-document⑦">(4)</a> <a href="#ref-for-concept-document⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-domhighrestimestampdomhighrestimestamp">
-   <a href="https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestampdomhighrestimestamp">https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestampdomhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-domhighrestimestampdomhighrestimestamp" class="dfn-panel" data-for="term-for-idl-def-domhighrestimestampdomhighrestimestamp" id="infopanel-for-term-for-idl-def-domhighrestimestampdomhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-domhighrestimestampdomhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestampdomhighrestimestamp">https://www.w3.org/TR/hr-time-2/#idl-def-domhighrestimestampdomhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-domhighrestimestampdomhighrestimestamp">2. Terminology</a>
     <li><a href="#ref-for-idl-def-domhighrestimestampdomhighrestimestamp①">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-high-resolution-time" class="dfn-panel" data-for="term-for-dfn-current-high-resolution-time" id="infopanel-for-term-for-dfn-current-high-resolution-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-high-resolution-time" style="display:none">Info about the 'current high resolution time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-current-high-resolution-time">https://w3c.github.io/hr-time/#dfn-current-high-resolution-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-high-resolution-time">4.1.2. Mark paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">4.1.2. Mark paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context (for Window)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-the-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-the-rendering" class="dfn-panel" data-for="term-for-update-the-rendering" id="infopanel-for-term-for-update-the-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-update-the-rendering" style="display:none">Info about the 'update the rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering">https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-rendering">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-performanceentry-interface">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#the-performanceentry-interface">https://www.w3.org/TR/performance-timeline-2/#the-performanceentry-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-performanceentry-interface" class="dfn-panel" data-for="term-for-the-performanceentry-interface" id="infopanel-for-term-for-the-performanceentry-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-the-performanceentry-interface" style="display:none">Info about the 'PerformanceEntry' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#the-performanceentry-interface">https://www.w3.org/TR/performance-timeline-2/#the-performanceentry-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-performanceentry-interface">3. The PerformancePaintTiming interface</a> <a href="#ref-for-the-performanceentry-interface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-duration">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-duration">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-duration" class="dfn-panel" data-for="term-for-dom-performanceentry-duration" id="infopanel-for-term-for-dom-performanceentry-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-duration" style="display:none">Info about the 'duration' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-duration">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-duration">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-duration①">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-entrytype">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-entrytype" class="dfn-panel" data-for="term-for-dom-performanceentry-entrytype" id="infopanel-for-term-for-dom-performanceentry-entrytype" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-entrytype" style="display:none">Info about the 'entryType' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-entrytype">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-entrytype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-entrytype">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-entrytype①">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-name">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-name">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-name" class="dfn-panel" data-for="term-for-dom-performanceentry-name" id="infopanel-for-term-for-dom-performanceentry-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-name" style="display:none">Info about the 'name' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-name">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-name">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-name①">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-performanceentry-starttime">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-starttime">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-starttime</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-performanceentry-starttime" class="dfn-panel" data-for="term-for-dom-performanceentry-starttime" id="infopanel-for-term-for-dom-performanceentry-starttime" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-performanceentry-starttime" style="display:none">Info about the 'startTime' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-starttime">https://www.w3.org/TR/performance-timeline-2/#dom-performanceentry-starttime</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-performanceentry-starttime">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-dom-performanceentry-starttime①">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedentrytypes-attribute">
-   <a href="https://www.w3.org/TR/performance-timeline-2/#supportedentrytypes-attribute">https://www.w3.org/TR/performance-timeline-2/#supportedentrytypes-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedentrytypes-attribute" class="dfn-panel" data-for="term-for-supportedentrytypes-attribute" id="infopanel-for-term-for-supportedentrytypes-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedentrytypes-attribute" style="display:none">Info about the 'supportedEntryTypes' external reference.</span><a href="https://www.w3.org/TR/performance-timeline-2/#supportedentrytypes-attribute">https://www.w3.org/TR/performance-timeline-2/#supportedentrytypes-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedentrytypes-attribute">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2. Terminology</a>
     <li><a href="#ref-for-idl-DOMString①">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. The PerformancePaintTiming interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">4.1.3. Report paint timing</a>
    </ul>
@@ -1622,74 +1622,74 @@ specification.</p>
   <div style="counter-reset:issue">
    <div class="issue"> This should be turned into a normative note. <a class="issue-return" href="#issue-6cf50d70" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="paintable-pseudo-element">
-   <b><a href="#paintable-pseudo-element">#paintable-pseudo-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintable-pseudo-element" class="dfn-panel" data-for="paintable-pseudo-element" id="infopanel-for-paintable-pseudo-element" role="dialog">
+   <span id="infopaneltitle-for-paintable-pseudo-element" style="display:none">Info about the 'paintable pseudo-element' definition.</span><b><a href="#paintable-pseudo-element">#paintable-pseudo-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintable-pseudo-element">2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contentful-image">
-   <b><a href="#contentful-image">#contentful-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contentful-image" class="dfn-panel" data-for="contentful-image" id="infopanel-for-contentful-image" role="dialog">
+   <span id="infopaneltitle-for-contentful-image" style="display:none">Info about the 'contentful image' definition.</span><b><a href="#contentful-image">#contentful-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contentful-image">2. Terminology</a> <a href="#ref-for-contentful-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-empty">
-   <b><a href="#non-empty">#non-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-empty" class="dfn-panel" data-for="non-empty" id="infopanel-for-non-empty" role="dialog">
+   <span id="infopaneltitle-for-non-empty" style="display:none">Info about the 'non-empty' definition.</span><b><a href="#non-empty">#non-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-empty">2. Terminology</a> <a href="#ref-for-non-empty①">(2)</a> <a href="#ref-for-non-empty②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contentful">
-   <b><a href="#contentful">#contentful</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contentful" class="dfn-panel" data-for="contentful" id="infopanel-for-contentful" role="dialog">
+   <span id="infopaneltitle-for-contentful" style="display:none">Info about the 'contentful' definition.</span><b><a href="#contentful">#contentful</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contentful">4.1.1. First Contentful Paint</a>
     <li><a href="#ref-for-contentful①">4.1.2. Mark paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintable-bounding-rect">
-   <b><a href="#paintable-bounding-rect">#paintable-bounding-rect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintable-bounding-rect" class="dfn-panel" data-for="paintable-bounding-rect" id="infopanel-for-paintable-bounding-rect" role="dialog">
+   <span id="infopaneltitle-for-paintable-bounding-rect" style="display:none">Info about the 'paintable bounding rect' definition.</span><b><a href="#paintable-bounding-rect">#paintable-bounding-rect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintable-bounding-rect">2. Terminology</a> <a href="#ref-for-paintable-bounding-rect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paintable">
-   <b><a href="#paintable">#paintable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paintable" class="dfn-panel" data-for="paintable" id="infopanel-for-paintable" role="dialog">
+   <span id="infopaneltitle-for-paintable" style="display:none">Info about the 'paintable' definition.</span><b><a href="#paintable">#paintable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintable">4.1.1. First Contentful Paint</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-paint">
-   <b><a href="#first-paint">#first-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-paint" class="dfn-panel" data-for="first-paint" id="infopanel-for-first-paint" role="dialog">
+   <span id="infopaneltitle-for-first-paint" style="display:none">Info about the 'First paint' definition.</span><b><a href="#first-paint">#first-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-paint">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-first-paint①">4.1.2. Mark paint timing</a> <a href="#ref-for-first-paint②">(2)</a> <a href="#ref-for-first-paint③">(3)</a> <a href="#ref-for-first-paint④">(4)</a> <a href="#ref-for-first-paint⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="paint-timing-eligible">
-   <b><a href="#paint-timing-eligible">#paint-timing-eligible</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-paint-timing-eligible" class="dfn-panel" data-for="paint-timing-eligible" id="infopanel-for-paint-timing-eligible" role="dialog">
+   <span id="infopaneltitle-for-paint-timing-eligible" style="display:none">Info about the 'paint-timing eligible' definition.</span><b><a href="#paint-timing-eligible">#paint-timing-eligible</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paint-timing-eligible">3. The PerformancePaintTiming interface</a>
     <li><a href="#ref-for-paint-timing-eligible①">4.1.2. Mark paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="performancepainttiming">
-   <b><a href="#performancepainttiming">#performancepainttiming</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-performancepainttiming" class="dfn-panel" data-for="performancepainttiming" id="infopanel-for-performancepainttiming" role="dialog">
+   <span id="infopaneltitle-for-performancepainttiming" style="display:none">Info about the 'PerformancePaintTiming' definition.</span><b><a href="#performancepainttiming">#performancepainttiming</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-performancepainttiming">3. The PerformancePaintTiming interface</a> <a href="#ref-for-performancepainttiming①">(2)</a> <a href="#ref-for-performancepainttiming②">(3)</a>
     <li><a href="#ref-for-performancepainttiming③">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="previously-reported-paints">
-   <b><a href="#previously-reported-paints">#previously-reported-paints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-previously-reported-paints" class="dfn-panel" data-for="previously-reported-paints" id="infopanel-for-previously-reported-paints" role="dialog">
+   <span id="infopaneltitle-for-previously-reported-paints" style="display:none">Info about the 'previously reported paints' definition.</span><b><a href="#previously-reported-paints">#previously-reported-paints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-previously-reported-paints">4.1.1. First Contentful Paint</a>
     <li><a href="#ref-for-previously-reported-paints①">4.1.2. Mark paint timing</a>
     <li><a href="#ref-for-previously-reported-paints②">4.1.3. Report paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-contentful-paint">
-   <b><a href="#first-contentful-paint">#first-contentful-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-contentful-paint" class="dfn-panel" data-for="first-contentful-paint" id="infopanel-for-first-contentful-paint" role="dialog">
+   <span id="infopaneltitle-for-first-contentful-paint" style="display:none">Info about the '4.1.1. First Contentful Paint' definition.</span><b><a href="#first-contentful-paint">#first-contentful-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-contentful-paint">2. Terminology</a>
     <li><a href="#ref-for-first-contentful-paint①">3. The PerformancePaintTiming interface</a>
@@ -1697,20 +1697,20 @@ specification.</p>
     <li><a href="#ref-for-first-contentful-paint②">4.1.2. Mark paint timing</a> <a href="#ref-for-first-contentful-paint③">(2)</a> <a href="#ref-for-first-contentful-paint④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-report-first-contentful-paint">
-   <b><a href="#should-report-first-contentful-paint">#should-report-first-contentful-paint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-report-first-contentful-paint" class="dfn-panel" data-for="should-report-first-contentful-paint" id="infopanel-for-should-report-first-contentful-paint" role="dialog">
+   <span id="infopaneltitle-for-should-report-first-contentful-paint" style="display:none">Info about the 'should report first contentful paint' definition.</span><b><a href="#should-report-first-contentful-paint">#should-report-first-contentful-paint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-report-first-contentful-paint">4.1.2. Mark paint timing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mark-paint-timing">
-   <b><a href="#mark-paint-timing">#mark-paint-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mark-paint-timing" class="dfn-panel" data-for="mark-paint-timing" id="infopanel-for-mark-paint-timing" role="dialog">
+   <span id="infopaneltitle-for-mark-paint-timing" style="display:none">Info about the '4.1.2. Mark paint timing' definition.</span><b><a href="#mark-paint-timing">#mark-paint-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mark-paint-timing">4.1.2. Mark paint timing</a> <a href="#ref-for-mark-paint-timing">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-paint-timing">
-   <b><a href="#report-paint-timing">#report-paint-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-paint-timing" class="dfn-panel" data-for="report-paint-timing" id="infopanel-for-report-paint-timing" role="dialog">
+   <span id="infopaneltitle-for-report-paint-timing" style="display:none">Info about the '4.1.3. Report paint timing' definition.</span><b><a href="#report-paint-timing">#report-paint-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-paint-timing">4.1.2. Mark paint timing</a> <a href="#ref-for-report-paint-timing">(2)</a>
     <li><a href="#ref-for-report-paint-timing">4.1.3. Report paint timing</a> <a href="#ref-for-report-paint-timing">(2)</a>
@@ -1718,59 +1718,115 @@ specification.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/payment-method-manifest/index.html
+++ b/tests/github/w3c/payment-method-manifest/index.html
@@ -835,190 +835,190 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
    <li><a href="#valid-payment-method-manifest">validity</a><span>, in § 2</span>
    <li><a href="#valid-payment-method-manifest">valid payment method manifest</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dfn-processed-manifest">
-   <a href="https://www.w3.org/TR/appmanifest/#dfn-processed-manifest">https://www.w3.org/TR/appmanifest/#dfn-processed-manifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-processed-manifest" class="dfn-panel" data-for="term-for-dfn-processed-manifest" id="infopanel-for-term-for-dfn-processed-manifest" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-processed-manifest" style="display:none">Info about the 'processed web app manifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dfn-processed-manifest">https://www.w3.org/TR/appmanifest/#dfn-processed-manifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-processed-manifest">3.2. Ingesting payment method manifests</a> <a href="#ref-for-dfn-processed-manifest①">(2)</a> <a href="#ref-for-dfn-processed-manifest②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-obtaining-the-manifest">
-   <a href="https://www.w3.org/TR/appmanifest/#dfn-obtaining-the-manifest">https://www.w3.org/TR/appmanifest/#dfn-obtaining-the-manifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-obtaining-the-manifest" class="dfn-panel" data-for="term-for-dfn-obtaining-the-manifest" id="infopanel-for-term-for-dfn-obtaining-the-manifest" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-obtaining-the-manifest" style="display:none">Info about the 'steps for obtaining a web app manifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dfn-obtaining-the-manifest">https://www.w3.org/TR/appmanifest/#dfn-obtaining-the-manifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-obtaining-the-manifest">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-processing-a-manifest">
-   <a href="https://www.w3.org/TR/appmanifest/#dfn-processing-a-manifest">https://www.w3.org/TR/appmanifest/#dfn-processing-a-manifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-processing-a-manifest" class="dfn-panel" data-for="term-for-dfn-processing-a-manifest" id="infopanel-for-term-for-dfn-processing-a-manifest" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-processing-a-manifest" style="display:none">Info about the 'steps for processing a web app manifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dfn-processing-a-manifest">https://www.w3.org/TR/appmanifest/#dfn-processing-a-manifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-processing-a-manifest">3.2. Ingesting payment method manifests</a> <a href="#ref-for-dfn-processing-a-manifest①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-manifest-url">
-   <a href="https://www.w3.org/TR/appmanifest/#dfn-manifest-url">https://www.w3.org/TR/appmanifest/#dfn-manifest-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-manifest-url" class="dfn-panel" data-for="term-for-dfn-manifest-url" id="infopanel-for-term-for-dfn-manifest-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-manifest-url" style="display:none">Info about the 'url' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dfn-manifest-url">https://www.w3.org/TR/appmanifest/#dfn-manifest-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-manifest-url">1.1. Use cases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-manifest">
-   <a href="https://www.w3.org/TR/appmanifest/#dfn-manifest">https://www.w3.org/TR/appmanifest/#dfn-manifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-manifest" class="dfn-panel" data-for="term-for-dfn-manifest" id="infopanel-for-term-for-dfn-manifest" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-manifest" style="display:none">Info about the 'web app manifest' external reference.</span><a href="https://www.w3.org/TR/appmanifest/#dfn-manifest">https://www.w3.org/TR/appmanifest/#dfn-manifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-manifest">1.1. Use cases</a>
     <li><a href="#ref-for-dfn-manifest①">1.3. Example manifest file</a>
     <li><a href="#ref-for-dfn-manifest②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">2. Manifest format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">3.4. Validating and parsing payment method manifests</a>
     <li><a href="#ref-for-utf-8-decode①">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a>
     <li><a href="#ref-for-concept-response-body③">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request-client①">(2)</a>
     <li><a href="#ref-for-concept-request-client②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request-credentials-mode①">(2)</a>
     <li><a href="#ref-for-concept-request-credentials-mode②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extract-header-list-values" class="dfn-panel" data-for="term-for-extract-header-list-values" id="infopanel-for-term-for-extract-header-list-values" role="menu">
+   <span id="infopaneltitle-for-term-for-extract-header-list-values" style="display:none">Info about the 'extract header list values' external reference.</span><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-fetch①">(2)</a> <a href="#ref-for-concept-fetch②">(3)</a>
     <li><a href="#ref-for-concept-fetch③">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request-mode①">(2)</a>
     <li><a href="#ref-for-concept-request-mode②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-network-error①">(2)</a>
     <li><a href="#ref-for-concept-network-error②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">3.3. Fetching payment method manifests</a> <a href="#ref-for-ok-status①">(2)</a>
     <li><a href="#ref-for-ok-status②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request-redirect-mode①">(2)</a>
     <li><a href="#ref-for-concept-request-redirect-mode②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer" class="dfn-panel" data-for="term-for-concept-request-referrer" id="infopanel-for-term-for-concept-request-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer" style="display:none">Info about the 'referrer' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer">https://fetch.spec.whatwg.org/#concept-request-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer">3.3. Fetching payment method manifests</a>
     <li><a href="#ref-for-concept-request-referrer①">3.5. Fetching web app manifests</a>
     <li><a href="#ref-for-concept-request-referrer②">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-referrer-policy">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-referrer-policy" class="dfn-panel" data-for="term-for-concept-request-referrer-policy" id="infopanel-for-term-for-concept-request-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-referrer-policy">https://fetch.spec.whatwg.org/#concept-request-referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer-policy">3.3. Fetching payment method manifests</a>
     <li><a href="#ref-for-concept-request-referrer-policy①">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request①">(2)</a>
     <li><a href="#ref-for-concept-request②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-response①">(2)</a> <a href="#ref-for-concept-response②">(3)</a>
     <li><a href="#ref-for-concept-response③">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-response-status①">(2)</a>
     <li><a href="#ref-for-concept-response-status②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-request-url①">(2)</a>
     <li><a href="#ref-for-concept-request-url②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-response-url①">(2)</a> <a href="#ref-for-concept-response-url②">(3)</a> <a href="#ref-for-concept-response-url③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">3.1. Modifications to Payment Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3.2. Ingesting payment method manifests</a>
     <li><a href="#ref-for-environment-settings-object①">3.3. Fetching payment method manifests</a>
     <li><a href="#ref-for-environment-settings-object②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">1.1. Use cases</a>
     <li><a href="#ref-for-concept-origin①">1.3. Example manifest file</a>
@@ -1027,142 +1027,142 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-concept-origin④">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">2. Manifest format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-set-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.3. Fetching payment method manifests</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3.3. Fetching payment method manifests</a> <a href="#ref-for-byte-sequence①">(2)</a> <a href="#ref-for-byte-sequence②">(3)</a>
     <li><a href="#ref-for-byte-sequence③">3.4. Validating and parsing payment method manifests</a>
     <li><a href="#ref-for-byte-sequence④">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3.2. Ingesting payment method manifests</a> <a href="#ref-for-iteration-continue①">(2)</a>
     <li><a href="#ref-for-iteration-continue②">3.3. Fetching payment method manifests</a> <a href="#ref-for-iteration-continue③">(2)</a> <a href="#ref-for-iteration-continue④">(3)</a> <a href="#ref-for-iteration-continue⑤">(4)</a> <a href="#ref-for-iteration-continue⑥">(5)</a> <a href="#ref-for-iteration-continue⑦">(6)</a> <a href="#ref-for-iteration-continue⑧">(7)</a> <a href="#ref-for-iteration-continue⑨">(8)</a> <a href="#ref-for-iteration-continue①⓪">(9)</a> <a href="#ref-for-iteration-continue①①">(10)</a> <a href="#ref-for-iteration-continue①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-map-exists①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.2. Ingesting payment method manifests</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">3.3. Fetching payment method manifests</a> <a href="#ref-for-list-iterate③">(2)</a> <a href="#ref-for-list-iterate④">(3)</a>
     <li><a href="#ref-for-list-iterate⑤">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-list-iterate⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">3.1. Modifications to Payment Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'javascript string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.3. Fetching payment method manifests</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.3. Fetching payment method manifests</a> <a href="#ref-for-ordered-map①">(2)</a>
     <li><a href="#ref-for-ordered-map②">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map①" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.3. Fetching payment method manifests</a> <a href="#ref-for-ordered-map①">(2)</a>
     <li><a href="#ref-for-ordered-map②">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-ordered-set①">(2)</a> <a href="#ref-for-ordered-set②">(3)</a> <a href="#ref-for-ordered-set③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value">
-   <a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value" id="infopanel-for-term-for-parse-a-json-string-to-an-infra-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" style="display:none">Info about the 'parse json into infra values' external reference.</span><a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-json-string-to-an-infra-value">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value-string">
-   <a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value-string" class="dfn-panel" data-for="term-for-scalar-value-string" id="infopanel-for-term-for-scalar-value-string" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value-string" style="display:none">Info about the 'scalar value string' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.3. Fetching payment method manifests</a> <a href="#ref-for-map-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-payment-method-identifiers">
-   <a href="https://w3c.github.io/payment-method-id/#dfn-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-payment-method-identifiers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-payment-method-identifiers" class="dfn-panel" data-for="term-for-dfn-payment-method-identifiers" id="infopanel-for-term-for-dfn-payment-method-identifiers" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-payment-method-identifiers" style="display:none">Info about the 'payment method identifier' external reference.</span><a href="https://w3c.github.io/payment-method-id/#dfn-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-payment-method-identifiers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-payment-method-identifiers">1.1. Use cases</a>
     <li><a href="#ref-for-dfn-payment-method-identifiers①">1.2. Accessing the manifest</a> <a href="#ref-for-dfn-payment-method-identifiers②">(2)</a> <a href="#ref-for-dfn-payment-method-identifiers③">(3)</a> <a href="#ref-for-dfn-payment-method-identifiers④">(4)</a>
@@ -1170,47 +1170,47 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-dfn-payment-method-identifiers⑥">3.3. Fetching payment method manifests</a> <a href="#ref-for-dfn-payment-method-identifiers⑦">(2)</a> <a href="#ref-for-dfn-payment-method-identifiers⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-standardized-payment-method-identifiers">
-   <a href="https://w3c.github.io/payment-method-id/#dfn-standardized-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-standardized-payment-method-identifiers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-standardized-payment-method-identifiers" class="dfn-panel" data-for="term-for-dfn-standardized-payment-method-identifiers" id="infopanel-for-term-for-dfn-standardized-payment-method-identifiers" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-standardized-payment-method-identifiers" style="display:none">Info about the 'standardized payment method identifier' external reference.</span><a href="https://w3c.github.io/payment-method-id/#dfn-standardized-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-standardized-payment-method-identifiers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-standardized-payment-method-identifiers">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-url-based-payment-method-identifiers">
-   <a href="https://w3c.github.io/payment-method-id/#dfn-url-based-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-url-based-payment-method-identifiers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-url-based-payment-method-identifiers" class="dfn-panel" data-for="term-for-dfn-url-based-payment-method-identifiers" id="infopanel-for-term-for-dfn-url-based-payment-method-identifiers" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-url-based-payment-method-identifiers" style="display:none">Info about the 'url-based payment method identifier' external reference.</span><a href="https://w3c.github.io/payment-method-id/#dfn-url-based-payment-method-identifiers">https://w3c.github.io/payment-method-id/#dfn-url-based-payment-method-identifiers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-url-based-payment-method-identifiers">1.1. Use cases</a>
     <li><a href="#ref-for-dfn-url-based-payment-method-identifiers①">3.3. Fetching payment method manifests</a>
     <li><a href="#ref-for-dfn-url-based-payment-method-identifiers②">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-validate-a-url-based-payment-method-identifier">
-   <a href="https://w3c.github.io/payment-method-id/#dfn-validate-a-url-based-payment-method-identifier">https://w3c.github.io/payment-method-id/#dfn-validate-a-url-based-payment-method-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-validate-a-url-based-payment-method-identifier" class="dfn-panel" data-for="term-for-dfn-validate-a-url-based-payment-method-identifier" id="infopanel-for-term-for-dfn-validate-a-url-based-payment-method-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-validate-a-url-based-payment-method-identifier" style="display:none">Info about the 'validate a url-based payment method identifier' external reference.</span><a href="https://w3c.github.io/payment-method-id/#dfn-validate-a-url-based-payment-method-identifier">https://w3c.github.io/payment-method-id/#dfn-validate-a-url-based-payment-method-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-validate-a-url-based-payment-method-identifier">3.3. Fetching payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-paymentrequest">
-   <a href="https://w3c.github.io/payment-request/#dom-paymentrequest">https://w3c.github.io/payment-request/#dom-paymentrequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-paymentrequest" class="dfn-panel" data-for="term-for-dom-paymentrequest" id="infopanel-for-term-for-dom-paymentrequest" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-paymentrequest" style="display:none">Info about the 'PaymentRequest' external reference.</span><a href="https://w3c.github.io/payment-request/#dom-paymentrequest">https://w3c.github.io/payment-request/#dom-paymentrequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paymentrequest">3.1. Modifications to Payment Request API</a> <a href="#ref-for-dom-paymentrequest①">(2)</a>
     <li><a href="#ref-for-dom-paymentrequest②">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-paymentrequest-paymentrequest">
-   <a href="https://w3c.github.io/payment-request/#dfn-paymentrequest-paymentrequest">https://w3c.github.io/payment-request/#dfn-paymentrequest-paymentrequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-paymentrequest-paymentrequest" class="dfn-panel" data-for="term-for-dfn-paymentrequest-paymentrequest" id="infopanel-for-term-for-dfn-paymentrequest-paymentrequest" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-paymentrequest-paymentrequest" style="display:none">Info about the 'PaymentRequest(methodData, details, options)' external reference.</span><a href="https://w3c.github.io/payment-request/#dfn-paymentrequest-paymentrequest">https://w3c.github.io/payment-request/#dfn-paymentrequest-paymentrequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-paymentrequest-paymentrequest">3.1. Modifications to Payment Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-serializedmethoddata">
-   <a href="https://w3c.github.io/payment-request/#dfn-serializedmethoddata">https://w3c.github.io/payment-request/#dfn-serializedmethoddata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-serializedmethoddata" class="dfn-panel" data-for="term-for-dfn-serializedmethoddata" id="infopanel-for-term-for-dfn-serializedmethoddata" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-serializedmethoddata" style="display:none">Info about the '[[serializedmethoddata]]' external reference.</span><a href="https://w3c.github.io/payment-request/#dfn-serializedmethoddata">https://w3c.github.io/payment-request/#dfn-serializedmethoddata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-serializedmethoddata">3.1. Modifications to Payment Request API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-payment-apps">
-   <a href="https://w3c.github.io/payment-request/#dfn-payment-apps">https://w3c.github.io/payment-request/#dfn-payment-apps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-payment-apps" class="dfn-panel" data-for="term-for-dfn-payment-apps" id="infopanel-for-term-for-dfn-payment-apps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-payment-apps" style="display:none">Info about the 'payment app' external reference.</span><a href="https://w3c.github.io/payment-request/#dfn-payment-apps">https://w3c.github.io/payment-request/#dfn-payment-apps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-payment-apps">1.1. Use cases</a> <a href="#ref-for-dfn-payment-apps①">(2)</a> <a href="#ref-for-dfn-payment-apps②">(3)</a>
     <li><a href="#ref-for-dfn-payment-apps③">1.3. Example manifest file</a> <a href="#ref-for-dfn-payment-apps④">(2)</a> <a href="#ref-for-dfn-payment-apps⑤">(3)</a>
@@ -1220,8 +1220,8 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-dfn-payment-apps①①">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-payment-method">
-   <a href="https://w3c.github.io/payment-request/#dfn-payment-method">https://w3c.github.io/payment-request/#dfn-payment-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-payment-method" class="dfn-panel" data-for="term-for-dfn-payment-method" id="infopanel-for-term-for-dfn-payment-method" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-payment-method" style="display:none">Info about the 'payment method' external reference.</span><a href="https://w3c.github.io/payment-request/#dfn-payment-method">https://w3c.github.io/payment-request/#dfn-payment-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-payment-method">Unnumbered Section</a>
     <li><a href="#ref-for-dfn-payment-method①">1.1. Use cases</a> <a href="#ref-for-dfn-payment-method②">(2)</a> <a href="#ref-for-dfn-payment-method③">(3)</a> <a href="#ref-for-dfn-payment-method④">(4)</a> <a href="#ref-for-dfn-payment-method⑤">(5)</a> <a href="#ref-for-dfn-payment-method⑥">(6)</a>
@@ -1232,60 +1232,60 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-dfn-payment-method①④">5.1. The payment-method-manifest link relation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'get a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">3.3. Fetching payment method manifests</a> <a href="#ref-for-readablestream-get-a-reader①">(2)</a>
     <li><a href="#ref-for-readablestream-get-a-reader②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-url-string">
-   <a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-url-string" class="dfn-panel" data-for="term-for-absolute-url-string" id="infopanel-for-term-for-absolute-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-url-string" style="display:none">Info about the 'absolute-url string' external reference.</span><a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-string">1.1. Use cases</a>
     <li><a href="#ref-for-absolute-url-string①">2. Manifest format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-basic-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-basic-url-parser">https://url.spec.whatwg.org/#concept-basic-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-basic-url-parser" class="dfn-panel" data-for="term-for-concept-basic-url-parser" id="infopanel-for-term-for-concept-basic-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-basic-url-parser" style="display:none">Info about the 'basic url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-basic-url-parser">https://url.spec.whatwg.org/#concept-basic-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-basic-url-parser">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-basic-url-parser①">(2)</a>
     <li><a href="#ref-for-concept-basic-url-parser②">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-concept-basic-url-parser③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2. Manifest format</a>
     <li><a href="#ref-for-concept-url-origin①">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-password">
-   <a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-password" class="dfn-panel" data-for="term-for-concept-url-password" id="infopanel-for-term-for-concept-url-password" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-password" style="display:none">Info about the 'password' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-password">https://url.spec.whatwg.org/#concept-url-password</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-password">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-query">
-   <a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-query" class="dfn-panel" data-for="term-for-concept-url-query" id="infopanel-for-term-for-concept-url-query" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-query" style="display:none">Info about the 'query' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-query">https://url.spec.whatwg.org/#concept-url-query</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">2. Manifest format</a>
     <li><a href="#ref-for-concept-url-scheme①">3.3. Fetching payment method manifests</a>
@@ -1293,8 +1293,8 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-concept-url-scheme④">4.2. Considerations for development environments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">2. Manifest format</a> <a href="#ref-for-concept-url①">(2)</a>
     <li><a href="#ref-for-concept-url②">3.3. Fetching payment method manifests</a> <a href="#ref-for-concept-url③">(2)</a> <a href="#ref-for-concept-url④">(3)</a>
@@ -1302,27 +1302,27 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-concept-url⑦">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-username">
-   <a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-username" class="dfn-panel" data-for="term-for-concept-url-username" id="infopanel-for-term-for-concept-url-username" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-username" style="display:none">Info about the 'username' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-username">https://url.spec.whatwg.org/#concept-url-username</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-username">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-url-string">
-   <a href="https://url.spec.whatwg.org/#valid-url-string">https://url.spec.whatwg.org/#valid-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-url-string" class="dfn-panel" data-for="term-for-valid-url-string" id="infopanel-for-term-for-valid-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-url-string" style="display:none">Info about the 'valid url string' external reference.</span><a href="https://url.spec.whatwg.org/#valid-url-string">https://url.spec.whatwg.org/#valid-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-url-string">2. Manifest format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">3.3. Fetching payment method manifests</a> <a href="#ref-for-upon-fulfillment①">(2)</a>
     <li><a href="#ref-for-upon-fulfillment②">3.5. Fetching web app manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">3.5. Fetching web app manifests</a>
    </ul>
@@ -1475,8 +1475,8 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
    <dt id="biblio-payment-handler">[PAYMENT-HANDLER]
    <dd>Adrian Hope-Bailie; et al. <a href="https://w3c.github.io/payment-handler/"><cite>Payment Handler API</cite></a>. URL: <a href="https://w3c.github.io/payment-handler/">https://w3c.github.io/payment-handler/</a>
   </dl>
-  <aside class="dfn-panel" data-for="payment-method-manifest">
-   <b><a href="#payment-method-manifest">#payment-method-manifest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-payment-method-manifest" class="dfn-panel" data-for="payment-method-manifest" id="infopanel-for-payment-method-manifest" role="dialog">
+   <span id="infopaneltitle-for-payment-method-manifest" style="display:none">Info about the 'payment method manifest' definition.</span><b><a href="#payment-method-manifest">#payment-method-manifest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-payment-method-manifest">1.1. Use cases</a>
     <li><a href="#ref-for-payment-method-manifest①">1.2. Accessing the manifest</a> <a href="#ref-for-payment-method-manifest②">(2)</a>
@@ -1484,114 +1484,170 @@ Rouslan Solomakhin for their contributions to making this specification awesome!
     <li><a href="#ref-for-payment-method-manifest④">2. Manifest format</a> <a href="#ref-for-payment-method-manifest⑤">(2)</a> <a href="#ref-for-payment-method-manifest⑥">(3)</a> <a href="#ref-for-payment-method-manifest⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-payment-method-manifest">
-   <b><a href="#valid-payment-method-manifest">#valid-payment-method-manifest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-payment-method-manifest" class="dfn-panel" data-for="valid-payment-method-manifest" id="infopanel-for-valid-payment-method-manifest" role="dialog">
+   <span id="infopaneltitle-for-valid-payment-method-manifest" style="display:none">Info about the 'valid payment method manifest' definition.</span><b><a href="#valid-payment-method-manifest">#valid-payment-method-manifest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-payment-method-manifest">2. Manifest format</a> <a href="#ref-for-valid-payment-method-manifest①">(2)</a> <a href="#ref-for-valid-payment-method-manifest②">(3)</a>
     <li><a href="#ref-for-valid-payment-method-manifest③">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ingest-payment-method-manifests">
-   <b><a href="#ingest-payment-method-manifests">#ingest-payment-method-manifests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ingest-payment-method-manifests" class="dfn-panel" data-for="ingest-payment-method-manifests" id="infopanel-for-ingest-payment-method-manifests" role="dialog">
+   <span id="infopaneltitle-for-ingest-payment-method-manifests" style="display:none">Info about the 'ingest payment method manifests' definition.</span><b><a href="#ingest-payment-method-manifests">#ingest-payment-method-manifests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ingest-payment-method-manifests">3.1. Modifications to Payment Request API</a>
     <li><a href="#ref-for-ingest-payment-method-manifests①">4.1. Revealing user activity to payment providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-payment-method-manifests">
-   <b><a href="#fetch-payment-method-manifests">#fetch-payment-method-manifests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-payment-method-manifests" class="dfn-panel" data-for="fetch-payment-method-manifests" id="infopanel-for-fetch-payment-method-manifests" role="dialog">
+   <span id="infopaneltitle-for-fetch-payment-method-manifests" style="display:none">Info about the 'fetch payment method manifests' definition.</span><b><a href="#fetch-payment-method-manifests">#fetch-payment-method-manifests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-payment-method-manifests">3.2. Ingesting payment method manifests</a>
     <li><a href="#ref-for-fetch-payment-method-manifests①">4.1. Revealing user activity to payment providers</a>
     <li><a href="#ref-for-fetch-payment-method-manifests②">4.2. Considerations for development environments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsed-payment-method-manifest">
-   <b><a href="#parsed-payment-method-manifest">#parsed-payment-method-manifest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsed-payment-method-manifest" class="dfn-panel" data-for="parsed-payment-method-manifest" id="infopanel-for-parsed-payment-method-manifest" role="dialog">
+   <span id="infopaneltitle-for-parsed-payment-method-manifest" style="display:none">Info about the 'parsed payment method manifest' definition.</span><b><a href="#parsed-payment-method-manifest">#parsed-payment-method-manifest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsed-payment-method-manifest">3.4. Validating and parsing payment method manifests</a> <a href="#ref-for-parsed-payment-method-manifest①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsed-payment-method-manifest-default-applications">
-   <b><a href="#parsed-payment-method-manifest-default-applications">#parsed-payment-method-manifest-default-applications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsed-payment-method-manifest-default-applications" class="dfn-panel" data-for="parsed-payment-method-manifest-default-applications" id="infopanel-for-parsed-payment-method-manifest-default-applications" role="dialog">
+   <span id="infopaneltitle-for-parsed-payment-method-manifest-default-applications" style="display:none">Info about the 'default applications' definition.</span><b><a href="#parsed-payment-method-manifest-default-applications">#parsed-payment-method-manifest-default-applications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsed-payment-method-manifest-default-applications">3.2. Ingesting payment method manifests</a>
     <li><a href="#ref-for-parsed-payment-method-manifest-default-applications①">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parsed-payment-method-manifest-supported-origins">
-   <b><a href="#parsed-payment-method-manifest-supported-origins">#parsed-payment-method-manifest-supported-origins</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parsed-payment-method-manifest-supported-origins" class="dfn-panel" data-for="parsed-payment-method-manifest-supported-origins" id="infopanel-for-parsed-payment-method-manifest-supported-origins" role="dialog">
+   <span id="infopaneltitle-for-parsed-payment-method-manifest-supported-origins" style="display:none">Info about the 'supported origins' definition.</span><b><a href="#parsed-payment-method-manifest-supported-origins">#parsed-payment-method-manifest-supported-origins</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parsed-payment-method-manifest-supported-origins">3.2. Ingesting payment method manifests</a>
     <li><a href="#ref-for-parsed-payment-method-manifest-supported-origins①">3.4. Validating and parsing payment method manifests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-and-parse-the-payment-method-manifest">
-   <b><a href="#validate-and-parse-the-payment-method-manifest">#validate-and-parse-the-payment-method-manifest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-and-parse-the-payment-method-manifest" class="dfn-panel" data-for="validate-and-parse-the-payment-method-manifest" id="infopanel-for-validate-and-parse-the-payment-method-manifest" role="dialog">
+   <span id="infopaneltitle-for-validate-and-parse-the-payment-method-manifest" style="display:none">Info about the 'validate and parse' definition.</span><b><a href="#validate-and-parse-the-payment-method-manifest">#validate-and-parse-the-payment-method-manifest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-and-parse-the-payment-method-manifest">3.2. Ingesting payment method manifests</a>
     <li><a href="#ref-for-validate-and-parse-the-payment-method-manifest①">4.2. Considerations for development environments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-the-web-app-manifest-for-a-default-payment-app">
-   <b><a href="#fetch-the-web-app-manifest-for-a-default-payment-app">#fetch-the-web-app-manifest-for-a-default-payment-app</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-the-web-app-manifest-for-a-default-payment-app" class="dfn-panel" data-for="fetch-the-web-app-manifest-for-a-default-payment-app" id="infopanel-for-fetch-the-web-app-manifest-for-a-default-payment-app" role="dialog">
+   <span id="infopaneltitle-for-fetch-the-web-app-manifest-for-a-default-payment-app" style="display:none">Info about the 'fetch the web app manifest for a default payment app' definition.</span><b><a href="#fetch-the-web-app-manifest-for-a-default-payment-app">#fetch-the-web-app-manifest-for-a-default-payment-app</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-the-web-app-manifest-for-a-default-payment-app">3.2. Ingesting payment method manifests</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/permissions/index.html
+++ b/tests/github/w3c/permissions/index.html
@@ -1865,28 +1865,28 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
    <li><a href="#dom-midipermissiondescriptor-sysex">sysex</a><span>, in § 10.4</span>
    <li><a href="#dom-pushpermissiondescriptor-uservisibleonly">userVisibleOnly</a><span>, in § 10.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm' external reference.</span><a href="https://tc39.github.io/ecma262/#current-realm">https://tc39.github.io/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-code-realms">https://tc39.github.io/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">5. Permission states</a>
     <li><a href="#ref-for-sec-code-realms①">5.2. Requesting more permission</a> <a href="#ref-for-sec-code-realms②">(2)</a> <a href="#ref-for-sec-code-realms③">(3)</a>
@@ -1895,61 +1895,61 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a> <a href="#ref-for-sec-code-realms⑥">(2)</a> <a href="#ref-for-sec-code-realms⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">7. 
     Navigator and WorkerNavigator extension </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">7. 
     Navigator and WorkerNavigator extension </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">5.1. Reading the current permission state</a> <a href="#ref-for-current-settings-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">3. Definitions</a>
     <li><a href="#ref-for-environment-settings-object①">5.1. Reading the current permission state</a> <a href="#ref-for-environment-settings-object②">(2)</a>
@@ -1957,29 +1957,29 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a> <a href="#ref-for-environment-settings-object④">(2)</a> <a href="#ref-for-environment-settings-object⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-non-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-non-secure-context" class="dfn-panel" data-for="term-for-non-secure-context" id="infopanel-for-term-for-non-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-non-secure-context" style="display:none">Info about the 'non-secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#non-secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-secure-context">5.1. Reading the current permission state</a>
     <li><a href="#ref-for-non-secure-context①">10. 
@@ -1988,15 +1988,15 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">11.1. 
       Set Permission </a> <a href="#ref-for-concept-settings-object-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">5.3. Reacting to users revoking permission</a>
     <li><a href="#ref-for-queue-a-task①">6. 
@@ -2005,21 +2005,21 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">5.3. Reacting to users revoking permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">5.2. Requesting more permission</a> <a href="#ref-for-same-origin①">(2)</a>
     <li><a href="#ref-for-same-origin②">10.5. 
@@ -2028,36 +2028,36 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">11.1. 
       Set Permission </a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-agent">
-   <a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-agent" class="dfn-panel" data-for="term-for-user-agent" id="infopanel-for-term-for-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-user-agent" style="display:none">Info about the 'user agent' external reference.</span><a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">6. 
     Status of a permission </a> <a href="#ref-for-user-agent①">(2)</a> <a href="#ref-for-user-agent②">(3)</a>
@@ -2067,47 +2067,47 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-install">
-   <a href="https://w3c.github.io/manifest/#dfn-install">https://w3c.github.io/manifest/#dfn-install</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-install" class="dfn-panel" data-for="term-for-dfn-install" id="infopanel-for-term-for-dfn-install" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-install" style="display:none">Info about the 'install' external reference.</span><a href="https://w3c.github.io/manifest/#dfn-install">https://w3c.github.io/manifest/#dfn-install</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-install">3. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-deviceid">
-   <a href="https://w3c.github.io/mediacapture-main/#deviceid">https://w3c.github.io/mediacapture-main/#deviceid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-deviceid" class="dfn-panel" data-for="term-for-deviceid" id="infopanel-for-term-for-deviceid" role="menu">
+   <span id="infopaneltitle-for-term-for-deviceid" style="display:none">Info about the 'deviceId' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#deviceid">https://w3c.github.io/mediacapture-main/#deviceid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deviceid">10.5. 
       Media Devices </a> <a href="#ref-for-deviceid①">(2)</a> <a href="#ref-for-deviceid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-devicechange">
-   <a href="https://w3c.github.io/mediacapture-main/#devicechange">https://w3c.github.io/mediacapture-main/#devicechange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-devicechange" class="dfn-panel" data-for="term-for-devicechange" id="infopanel-for-term-for-devicechange" role="menu">
+   <span id="infopaneltitle-for-term-for-devicechange" style="display:none">Info about the 'devicechange' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#devicechange">https://w3c.github.io/mediacapture-main/#devicechange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicechange">10.5. 
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" class="dfn-panel" data-for="term-for-dom-mediadevices-getusermedia" id="infopanel-for-term-for-dom-mediadevices-getusermedia" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediadevices-getusermedia" style="display:none">Info about the 'getUserMedia()' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediadevices-getusermedia">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
-   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-request-algorithm" class="dfn-panel" data-for="term-for-permission-request-algorithm" id="infopanel-for-term-for-permission-request-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-request-algorithm" style="display:none">Info about the 'permission request algorithm' external reference.</span><a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">10.5. 
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generic-sensor-permission-revocation-algorithm">
-   <a href="https://w3c.github.io/sensors/#generic-sensor-permission-revocation-algorithm">https://w3c.github.io/sensors/#generic-sensor-permission-revocation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generic-sensor-permission-revocation-algorithm" class="dfn-panel" data-for="term-for-generic-sensor-permission-revocation-algorithm" id="infopanel-for-term-for-generic-sensor-permission-revocation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-generic-sensor-permission-revocation-algorithm" style="display:none">Info about the 'generic sensor permission revocation algorithm' external reference.</span><a href="https://w3c.github.io/sensors/#generic-sensor-permission-revocation-algorithm">https://w3c.github.io/sensors/#generic-sensor-permission-revocation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-sensor-permission-revocation-algorithm">10.10. 
       Ambient Light Sensor </a>
@@ -2119,36 +2119,36 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Magnetometer </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bucket-mode">
-   <a href="https://storage.spec.whatwg.org/#bucket-mode">https://storage.spec.whatwg.org/#bucket-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bucket-mode" class="dfn-panel" data-for="term-for-bucket-mode" id="infopanel-for-term-for-bucket-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-bucket-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://storage.spec.whatwg.org/#bucket-mode">https://storage.spec.whatwg.org/#bucket-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bucket-mode">10.9. 
       Persistent Storage </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-bluetoothlescanfilterinit">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-bluetoothlescanfilterinit" class="dfn-panel" data-for="term-for-dictdef-bluetoothlescanfilterinit" id="infopanel-for-term-for-dictdef-bluetoothlescanfilterinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-bluetoothlescanfilterinit" style="display:none">Info about the 'BluetoothLEScanFilterInit' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit">https://webbluetoothcg.github.io/web-bluetooth/#dictdef-bluetoothlescanfilterinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-bluetoothlescanfilterinit">4. 
     Descriptions of permission requests </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedefdef-bluetoothserviceuuid">
-   <a href="https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-bluetoothserviceuuid">https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-bluetoothserviceuuid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedefdef-bluetoothserviceuuid" class="dfn-panel" data-for="term-for-typedefdef-bluetoothserviceuuid" id="infopanel-for-term-for-typedefdef-bluetoothserviceuuid" role="menu">
+   <span id="infopaneltitle-for-term-for-typedefdef-bluetoothserviceuuid" style="display:none">Info about the 'BluetoothServiceUUID' external reference.</span><a href="https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-bluetoothserviceuuid">https://webbluetoothcg.github.io/web-bluetooth/#typedefdef-bluetoothserviceuuid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-bluetoothserviceuuid">4. 
     Descriptions of permission requests </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-browsing-context">
-   <a href="https://w3c.github.io/webdriver/#dfn-current-browsing-context">https://w3c.github.io/webdriver/#dfn-current-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-browsing-context" class="dfn-panel" data-for="term-for-dfn-current-browsing-context" id="infopanel-for-term-for-dfn-current-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-browsing-context" style="display:none">Info about the 'current browsing context' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-current-browsing-context">https://w3c.github.io/webdriver/#dfn-current-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-browsing-context">11.1. 
       Set Permission </a> <a href="#ref-for-dfn-current-browsing-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-commands">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-commands">https://w3c.github.io/webdriver/#dfn-extension-commands</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-commands" class="dfn-panel" data-for="term-for-dfn-extension-commands" id="infopanel-for-term-for-dfn-extension-commands" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-commands" style="display:none">Info about the 'extension command' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-commands">https://w3c.github.io/webdriver/#dfn-extension-commands</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-commands">11. 
     Automation </a>
@@ -2156,71 +2156,71 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command-uri-template" class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template" id="infopanel-for-term-for-dfn-extension-command-uri-template" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command-uri-template" style="display:none">Info about the 'extension command uri template' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command-uri-template">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-invalid-argument">
-   <a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-invalid-argument" class="dfn-panel" data-for="term-for-dfn-invalid-argument" id="infopanel-for-term-for-dfn-invalid-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-invalid-argument" style="display:none">Info about the 'invalid argument' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-invalid-argument">11.1. 
       Set Permission </a> <a href="#ref-for-dfn-invalid-argument①">(2)</a> <a href="#ref-for-dfn-invalid-argument②">(3)</a> <a href="#ref-for-dfn-invalid-argument③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-local-end">
-   <a href="https://w3c.github.io/webdriver/#dfn-local-end">https://w3c.github.io/webdriver/#dfn-local-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-local-end" class="dfn-panel" data-for="term-for-dfn-local-end" id="infopanel-for-term-for-dfn-local-end" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-local-end" style="display:none">Info about the 'local end' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-local-end">https://w3c.github.io/webdriver/#dfn-local-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-local-end">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-session">
-   <a href="https://w3c.github.io/webdriver/#dfn-session">https://w3c.github.io/webdriver/#dfn-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-session" class="dfn-panel" data-for="term-for-dfn-session" id="infopanel-for-term-for-dfn-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-session" style="display:none">Info about the 'session' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-session">https://w3c.github.io/webdriver/#dfn-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-session">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'success' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error">
-   <a href="https://w3c.github.io/webdriver/#dfn-error">https://w3c.github.io/webdriver/#dfn-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error" class="dfn-panel" data-for="term-for-dfn-error" id="infopanel-for-term-for-dfn-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error" style="display:none">Info about the 'webdriver error' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error">https://w3c.github.io/webdriver/#dfn-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error">11.1. 
       Set Permission </a> <a href="#ref-for-dfn-error①">(2)</a> <a href="#ref-for-dfn-error②">(3)</a> <a href="#ref-for-dfn-error③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'webdriver error code' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">11.1. 
       Set Permission </a> <a href="#ref-for-dfn-error-code①">(2)</a> <a href="#ref-for-dfn-error-code②">(3)</a> <a href="#ref-for-dfn-error-code③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">10.5. 
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6. 
     Status of a permission </a>
@@ -2230,8 +2230,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permissions interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">8. 
     Permissions interface </a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
@@ -2239,22 +2239,22 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Examples </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">7. 
     Navigator and WorkerNavigator extension </a> <a href="#ref-for-SameObject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">8. 
     Permissions interface </a> <a href="#ref-for-a-promise-rejected-with①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">10.3. 
       Push </a>
@@ -2266,8 +2266,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Automation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">8. 
     Permissions interface </a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">(2)</a>
@@ -2275,8 +2275,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">8. 
     Permissions interface </a>
@@ -2536,8 +2536,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
         test which of the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realms-settings-objects-global-objects">several
         possible settings objects</a> it uses. <a class="issue-return" href="#issue-current-entry-incumbent-or-relevant" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="new-information-about-the-users-intent">
-   <b><a href="#new-information-about-the-users-intent">#new-information-about-the-users-intent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-new-information-about-the-users-intent" class="dfn-panel" data-for="new-information-about-the-users-intent" id="infopanel-for-new-information-about-the-users-intent" role="dialog">
+   <span id="infopaneltitle-for-new-information-about-the-users-intent" style="display:none">Info about the 'New information about the user’s intent' definition.</span><b><a href="#new-information-about-the-users-intent">#new-information-about-the-users-intent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new-information-about-the-users-intent">5.1. Reading the current permission state</a> <a href="#ref-for-new-information-about-the-users-intent①">(2)</a>
     <li><a href="#ref-for-new-information-about-the-users-intent②">5.2. Requesting more permission</a> <a href="#ref-for-new-information-about-the-users-intent③">(2)</a> <a href="#ref-for-new-information-about-the-users-intent④">(3)</a>
@@ -2545,14 +2545,14 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implicit-signals">
-   <b><a href="#implicit-signals">#implicit-signals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implicit-signals" class="dfn-panel" data-for="implicit-signals" id="infopanel-for-implicit-signals" role="dialog">
+   <span id="infopaneltitle-for-implicit-signals" style="display:none">Info about the 'implicit signals' definition.</span><b><a href="#implicit-signals">#implicit-signals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implicit-signals">3. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="powerful-feature">
-   <b><a href="#powerful-feature">#powerful-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-powerful-feature" class="dfn-panel" data-for="powerful-feature" id="infopanel-for-powerful-feature" role="dialog">
+   <span id="infopaneltitle-for-powerful-feature" style="display:none">Info about the 'Powerful feature' definition.</span><b><a href="#powerful-feature">#powerful-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-powerful-feature">4. 
     Descriptions of permission requests </a> <a href="#ref-for-powerful-feature①">(2)</a>
@@ -2566,8 +2566,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-permissiondescriptor">
-   <b><a href="#dictdef-permissiondescriptor">#dictdef-permissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-permissiondescriptor" class="dfn-panel" data-for="dictdef-permissiondescriptor" id="infopanel-for-dictdef-permissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' definition.</span><b><a href="#dictdef-permissiondescriptor">#dictdef-permissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-permissiondescriptor">4. 
     Descriptions of permission requests </a>
@@ -2593,8 +2593,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissiondescriptor-name">
-   <b><a href="#dom-permissiondescriptor-name">#dom-permissiondescriptor-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissiondescriptor-name" class="dfn-panel" data-for="dom-permissiondescriptor-name" id="infopanel-for-dom-permissiondescriptor-name" role="dialog">
+   <span id="infopaneltitle-for-dom-permissiondescriptor-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-permissiondescriptor-name">#dom-permissiondescriptor-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor-name">5. Permission states</a>
     <li><a href="#ref-for-dom-permissiondescriptor-name①">5.1. Reading the current permission state</a> <a href="#ref-for-dom-permissiondescriptor-name②">(2)</a> <a href="#ref-for-dom-permissiondescriptor-name③">(3)</a> <a href="#ref-for-dom-permissiondescriptor-name④">(4)</a> <a href="#ref-for-dom-permissiondescriptor-name⑤">(5)</a>
@@ -2607,15 +2607,15 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a> <a href="#ref-for-dom-permissiondescriptor-name①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="aspects">
-   <b><a href="#aspects">#aspects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aspects" class="dfn-panel" data-for="aspects" id="infopanel-for-aspects" role="dialog">
+   <span id="infopaneltitle-for-aspects" style="display:none">Info about the 'aspects' definition.</span><b><a href="#aspects">#aspects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aspects">4. 
     Descriptions of permission requests </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-state">
-   <b><a href="#permission-state">#permission-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-state" class="dfn-panel" data-for="permission-state" id="infopanel-for-permission-state" role="dialog">
+   <span id="infopaneltitle-for-permission-state" style="display:none">Info about the 'permission state' definition.</span><b><a href="#permission-state">#permission-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-state">2. 
     Privacy considerations </a> <a href="#ref-for-permission-state①">(2)</a>
@@ -2633,8 +2633,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a> <a href="#ref-for-permission-state①⑨">(2)</a> <a href="#ref-for-permission-state②⓪">(3)</a> <a href="#ref-for-permission-state②①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extra-permission-data">
-   <b><a href="#extra-permission-data">#extra-permission-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extra-permission-data" class="dfn-panel" data-for="extra-permission-data" id="infopanel-for-extra-permission-data" role="dialog">
+   <span id="infopaneltitle-for-extra-permission-data" style="display:none">Info about the 'extra permission data' definition.</span><b><a href="#extra-permission-data">#extra-permission-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extra-permission-data">10. 
     Permission Registry </a> <a href="#ref-for-extra-permission-data①">(2)</a> <a href="#ref-for-extra-permission-data②">(3)</a>
@@ -2642,20 +2642,20 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-permission-to-use">
-   <b><a href="#request-permission-to-use">#request-permission-to-use</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-permission-to-use" class="dfn-panel" data-for="request-permission-to-use" id="infopanel-for-request-permission-to-use" role="dialog">
+   <span id="infopaneltitle-for-request-permission-to-use" style="display:none">Info about the 'request permission to use' definition.</span><b><a href="#request-permission-to-use">#request-permission-to-use</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-permission-to-use">5.2. Requesting more permission</a> <a href="#ref-for-request-permission-to-use①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="prompt-the-user-to-choose">
-   <b><a href="#prompt-the-user-to-choose">#prompt-the-user-to-choose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-prompt-the-user-to-choose" class="dfn-panel" data-for="prompt-the-user-to-choose" id="infopanel-for-prompt-the-user-to-choose" role="dialog">
+   <span id="infopaneltitle-for-prompt-the-user-to-choose" style="display:none">Info about the 'prompt the user to choose' definition.</span><b><a href="#prompt-the-user-to-choose">#prompt-the-user-to-choose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prompt-the-user-to-choose">5.2. Requesting more permission</a> <a href="#ref-for-prompt-the-user-to-choose①">(2)</a> <a href="#ref-for-prompt-the-user-to-choose②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-permissionstate">
-   <b><a href="#enumdef-permissionstate">#enumdef-permissionstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-permissionstate" class="dfn-panel" data-for="enumdef-permissionstate" id="infopanel-for-enumdef-permissionstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-permissionstate" style="display:none">Info about the 'PermissionState' definition.</span><b><a href="#enumdef-permissionstate">#enumdef-permissionstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-permissionstate">5.1. Reading the current permission state</a>
     <li><a href="#ref-for-enumdef-permissionstate①">6. 
@@ -2664,8 +2664,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Automation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstate-granted">
-   <b><a href="#dom-permissionstate-granted">#dom-permissionstate-granted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstate-granted" class="dfn-panel" data-for="dom-permissionstate-granted" id="infopanel-for-dom-permissionstate-granted" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstate-granted" style="display:none">Info about the '"granted"' definition.</span><b><a href="#dom-permissionstate-granted">#dom-permissionstate-granted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">2. 
     Privacy considerations </a>
@@ -2681,8 +2681,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Screen Capture </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstate-denied">
-   <b><a href="#dom-permissionstate-denied">#dom-permissionstate-denied</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstate-denied" class="dfn-panel" data-for="dom-permissionstate-denied" id="infopanel-for-dom-permissionstate-denied" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstate-denied" style="display:none">Info about the '"denied"' definition.</span><b><a href="#dom-permissionstate-denied">#dom-permissionstate-denied</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-denied">5.1. Reading the current permission state</a> <a href="#ref-for-dom-permissionstate-denied①">(2)</a> <a href="#ref-for-dom-permissionstate-denied②">(3)</a> <a href="#ref-for-dom-permissionstate-denied③">(4)</a>
     <li><a href="#ref-for-dom-permissionstate-denied④">5.2. Requesting more permission</a> <a href="#ref-for-dom-permissionstate-denied⑤">(2)</a> <a href="#ref-for-dom-permissionstate-denied⑥">(3)</a> <a href="#ref-for-dom-permissionstate-denied⑦">(4)</a> <a href="#ref-for-dom-permissionstate-denied⑧">(5)</a> <a href="#ref-for-dom-permissionstate-denied⑨">(6)</a>
@@ -2698,8 +2698,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstate-prompt">
-   <b><a href="#dom-permissionstate-prompt">#dom-permissionstate-prompt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstate-prompt" class="dfn-panel" data-for="dom-permissionstate-prompt" id="infopanel-for-dom-permissionstate-prompt" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstate-prompt" style="display:none">Info about the '"prompt"' definition.</span><b><a href="#dom-permissionstate-prompt">#dom-permissionstate-prompt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-prompt">5.1. Reading the current permission state</a> <a href="#ref-for-dom-permissionstate-prompt①">(2)</a>
     <li><a href="#ref-for-dom-permissionstate-prompt②">5.2. Requesting more permission</a>
@@ -2711,8 +2711,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Screen Capture </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionstatus">
-   <b><a href="#permissionstatus">#permissionstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionstatus" class="dfn-panel" data-for="permissionstatus" id="infopanel-for-permissionstatus" role="dialog">
+   <span id="infopaneltitle-for-permissionstatus" style="display:none">Info about the 'PermissionStatus' definition.</span><b><a href="#permissionstatus">#permissionstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionstatus">6. 
     Status of a permission </a> <a href="#ref-for-permissionstatus①">(2)</a>
@@ -2724,8 +2724,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permission Registry </a> <a href="#ref-for-permissionstatus⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstatus-query-slot">
-   <b><a href="#dom-permissionstatus-query-slot">#dom-permissionstatus-query-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstatus-query-slot" class="dfn-panel" data-for="dom-permissionstatus-query-slot" id="infopanel-for-dom-permissionstatus-query-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstatus-query-slot" style="display:none">Info about the '[[query]]' definition.</span><b><a href="#dom-permissionstatus-query-slot">#dom-permissionstatus-query-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-query-slot">6. 
     Status of a permission </a> <a href="#ref-for-dom-permissionstatus-query-slot①">(2)</a> <a href="#ref-for-dom-permissionstatus-query-slot②">(3)</a>
@@ -2733,36 +2733,36 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permissions interface </a> <a href="#ref-for-dom-permissionstatus-query-slot④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-permissionstatus">
-   <b><a href="#create-a-permissionstatus">#create-a-permissionstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-permissionstatus" class="dfn-panel" data-for="create-a-permissionstatus" id="infopanel-for-create-a-permissionstatus" role="dialog">
+   <span id="infopaneltitle-for-create-a-permissionstatus" style="display:none">Info about the 'create a PermissionStatus' definition.</span><b><a href="#create-a-permissionstatus">#create-a-permissionstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-permissionstatus">8. 
     Permissions interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstatus-state">
-   <b><a href="#dom-permissionstatus-state">#dom-permissionstatus-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstatus-state" class="dfn-panel" data-for="dom-permissionstatus-state" id="infopanel-for-dom-permissionstatus-state" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstatus-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-permissionstatus-state">#dom-permissionstatus-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-state">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionstatus-onchange">
-   <b><a href="#dom-permissionstatus-onchange">#dom-permissionstatus-onchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionstatus-onchange" class="dfn-panel" data-for="dom-permissionstatus-onchange" id="infopanel-for-dom-permissionstatus-onchange" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionstatus-onchange" style="display:none">Info about the 'onchange' definition.</span><b><a href="#dom-permissionstatus-onchange">#dom-permissionstatus-onchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstatus-onchange">6. 
     Status of a permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-task-source">
-   <b><a href="#permission-task-source">#permission-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-task-source" class="dfn-panel" data-for="permission-task-source" id="infopanel-for-permission-task-source" role="dialog">
+   <span id="infopaneltitle-for-permission-task-source" style="display:none">Info about the 'permission task source' definition.</span><b><a href="#permission-task-source">#permission-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-task-source">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissions">
-   <b><a href="#permissions">#permissions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissions" class="dfn-panel" data-for="permissions" id="infopanel-for-permissions" role="dialog">
+   <span id="infopaneltitle-for-permissions" style="display:none">Info about the 'Permissions' definition.</span><b><a href="#permissions">#permissions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions">7. 
     Navigator and WorkerNavigator extension </a> <a href="#ref-for-permissions①">(2)</a>
@@ -2770,8 +2770,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissions-query">
-   <b><a href="#dom-permissions-query">#dom-permissions-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissions-query" class="dfn-panel" data-for="dom-permissions-query" id="infopanel-for-dom-permissions-query" role="dialog">
+   <span id="infopaneltitle-for-dom-permissions-query" style="display:none">Info about the 'query(permissionDesc)' definition.</span><b><a href="#dom-permissions-query">#dom-permissions-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissions-query">1. 
     Scope of this document </a>
@@ -2781,15 +2781,15 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean-permission-query-algorithm">
-   <b><a href="#boolean-permission-query-algorithm">#boolean-permission-query-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean-permission-query-algorithm" class="dfn-panel" data-for="boolean-permission-query-algorithm" id="infopanel-for-boolean-permission-query-algorithm" role="dialog">
+   <span id="infopaneltitle-for-boolean-permission-query-algorithm" style="display:none">Info about the 'boolean permission query algorithm' definition.</span><b><a href="#boolean-permission-query-algorithm">#boolean-permission-query-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean-permission-query-algorithm">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-permissionname">
-   <b><a href="#enumdef-permissionname">#enumdef-permissionname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-permissionname" class="dfn-panel" data-for="enumdef-permissionname" id="infopanel-for-enumdef-permissionname" role="dialog">
+   <span id="infopaneltitle-for-enumdef-permissionname" style="display:none">Info about the 'PermissionName' definition.</span><b><a href="#enumdef-permissionname">#enumdef-permissionname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-permissionname">4. 
     Descriptions of permission requests </a>
@@ -2799,8 +2799,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permission Registry </a> <a href="#ref-for-enumdef-permissionname⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-in-non-secure-contexts">
-   <b><a href="#allowed-in-non-secure-contexts">#allowed-in-non-secure-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-in-non-secure-contexts" class="dfn-panel" data-for="allowed-in-non-secure-contexts" id="infopanel-for-allowed-in-non-secure-contexts" role="dialog">
+   <span id="infopaneltitle-for-allowed-in-non-secure-contexts" style="display:none">Info about the 'allowed in non-secure contexts' definition.</span><b><a href="#allowed-in-non-secure-contexts">#allowed-in-non-secure-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-in-non-secure-contexts">5.1. Reading the current permission state</a>
     <li><a href="#ref-for-allowed-in-non-secure-contexts①">10.1. 
@@ -2813,8 +2813,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-descriptor-type">
-   <b><a href="#permission-descriptor-type">#permission-descriptor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-descriptor-type" class="dfn-panel" data-for="permission-descriptor-type" id="infopanel-for-permission-descriptor-type" role="dialog">
+   <span id="infopaneltitle-for-permission-descriptor-type" style="display:none">Info about the 'permission descriptor type' definition.</span><b><a href="#permission-descriptor-type">#permission-descriptor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-descriptor-type">4. 
     Descriptions of permission requests </a> <a href="#ref-for-permission-descriptor-type①">(2)</a> <a href="#ref-for-permission-descriptor-type②">(3)</a>
@@ -2835,8 +2835,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissiondescriptor-stronger-than">
-   <b><a href="#permissiondescriptor-stronger-than">#permissiondescriptor-stronger-than</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissiondescriptor-stronger-than" class="dfn-panel" data-for="permissiondescriptor-stronger-than" id="infopanel-for-permissiondescriptor-stronger-than" role="dialog">
+   <span id="infopaneltitle-for-permissiondescriptor-stronger-than" style="display:none">Info about the 'stronger than' definition.</span><b><a href="#permissiondescriptor-stronger-than">#permissiondescriptor-stronger-than</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissiondescriptor-stronger-than">10. 
     Permission Registry </a>
@@ -2848,30 +2848,30 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-state-constraints">
-   <b><a href="#permission-state-constraints">#permission-state-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-state-constraints" class="dfn-panel" data-for="permission-state-constraints" id="infopanel-for-permission-state-constraints" role="dialog">
+   <span id="infopaneltitle-for-permission-state-constraints" style="display:none">Info about the 'permission state constraints' definition.</span><b><a href="#permission-state-constraints">#permission-state-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-state-constraints">5.1. Reading the current permission state</a>
     <li><a href="#ref-for-permission-state-constraints①">10.16. 
       Screen Capture </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extra-permission-data-type">
-   <b><a href="#extra-permission-data-type">#extra-permission-data-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extra-permission-data-type" class="dfn-panel" data-for="extra-permission-data-type" id="infopanel-for-extra-permission-data-type" role="dialog">
+   <span id="infopaneltitle-for-extra-permission-data-type" style="display:none">Info about the 'extra permission data type' definition.</span><b><a href="#extra-permission-data-type">#extra-permission-data-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extra-permission-data-type">5.1. Reading the current permission state</a> <a href="#ref-for-extra-permission-data-type①">(2)</a>
     <li><a href="#ref-for-extra-permission-data-type②">10.5. 
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extra-permission-data-constraints">
-   <b><a href="#extra-permission-data-constraints">#extra-permission-data-constraints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extra-permission-data-constraints" class="dfn-panel" data-for="extra-permission-data-constraints" id="infopanel-for-extra-permission-data-constraints" role="dialog">
+   <span id="infopaneltitle-for-extra-permission-data-constraints" style="display:none">Info about the 'extra permission data constraints' definition.</span><b><a href="#extra-permission-data-constraints">#extra-permission-data-constraints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extra-permission-data-constraints">5.1. Reading the current permission state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-result-type">
-   <b><a href="#permission-result-type">#permission-result-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-result-type" class="dfn-panel" data-for="permission-result-type" id="infopanel-for-permission-result-type" role="dialog">
+   <span id="infopaneltitle-for-permission-result-type" style="display:none">Info about the 'permission result type' definition.</span><b><a href="#permission-result-type">#permission-result-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-result-type">6. 
     Status of a permission </a>
@@ -2879,8 +2879,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
     Permission Registry </a> <a href="#ref-for-permission-result-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-query-algorithm">
-   <b><a href="#permission-query-algorithm">#permission-query-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-query-algorithm" class="dfn-panel" data-for="permission-query-algorithm" id="infopanel-for-permission-query-algorithm" role="dialog">
+   <span id="infopaneltitle-for-permission-query-algorithm" style="display:none">Info about the 'permission query algorithm' definition.</span><b><a href="#permission-query-algorithm">#permission-query-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-query-algorithm">6. 
     Status of a permission </a>
@@ -2890,8 +2890,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission-revocation-algorithm">
-   <b><a href="#permission-revocation-algorithm">#permission-revocation-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission-revocation-algorithm" class="dfn-panel" data-for="permission-revocation-algorithm" id="infopanel-for-permission-revocation-algorithm" role="dialog">
+   <span id="infopaneltitle-for-permission-revocation-algorithm" style="display:none">Info about the 'permission revocation algorithm' definition.</span><b><a href="#permission-revocation-algorithm">#permission-revocation-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-revocation-algorithm">5.3. Reacting to users revoking permission</a>
     <li><a href="#ref-for-permission-revocation-algorithm①">10.5. 
@@ -2906,8 +2906,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Magnetometer </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean-feature">
-   <b><a href="#boolean-feature">#boolean-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean-feature" class="dfn-panel" data-for="boolean-feature" id="infopanel-for-boolean-feature" role="dialog">
+   <span id="infopaneltitle-for-boolean-feature" style="display:none">Info about the 'boolean feature' definition.</span><b><a href="#boolean-feature">#boolean-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean-feature">10.1. 
       Geolocation </a>
@@ -2915,71 +2915,71 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Notifications </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-geolocation">
-   <b><a href="#dom-permissionname-geolocation">#dom-permissionname-geolocation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-geolocation" class="dfn-panel" data-for="dom-permissionname-geolocation" id="infopanel-for-dom-permissionname-geolocation" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-geolocation" style="display:none">Info about the '"geolocation"' definition.</span><b><a href="#dom-permissionname-geolocation">#dom-permissionname-geolocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-geolocation">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-notifications">
-   <b><a href="#dom-permissionname-notifications">#dom-permissionname-notifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-notifications" class="dfn-panel" data-for="dom-permissionname-notifications" id="infopanel-for-dom-permissionname-notifications" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-notifications" style="display:none">Info about the '"notifications"' definition.</span><b><a href="#dom-permissionname-notifications">#dom-permissionname-notifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-notifications">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-push">
-   <b><a href="#dom-permissionname-push">#dom-permissionname-push</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-push" class="dfn-panel" data-for="dom-permissionname-push" id="infopanel-for-dom-permissionname-push" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-push" style="display:none">Info about the '"push"' definition.</span><b><a href="#dom-permissionname-push">#dom-permissionname-push</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-push">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-midi">
-   <b><a href="#dom-permissionname-midi">#dom-permissionname-midi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-midi" class="dfn-panel" data-for="dom-permissionname-midi" id="infopanel-for-dom-permissionname-midi" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-midi" style="display:none">Info about the '"midi"' definition.</span><b><a href="#dom-permissionname-midi">#dom-permissionname-midi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-midi">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-camera">
-   <b><a href="#dom-permissionname-camera">#dom-permissionname-camera</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-camera" class="dfn-panel" data-for="dom-permissionname-camera" id="infopanel-for-dom-permissionname-camera" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-camera" style="display:none">Info about the '"camera"' definition.</span><b><a href="#dom-permissionname-camera">#dom-permissionname-camera</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-camera">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-microphone">
-   <b><a href="#dom-permissionname-microphone">#dom-permissionname-microphone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-microphone" class="dfn-panel" data-for="dom-permissionname-microphone" id="infopanel-for-dom-permissionname-microphone" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-microphone" style="display:none">Info about the '"microphone"' definition.</span><b><a href="#dom-permissionname-microphone">#dom-permissionname-microphone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-microphone">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-speaker-selection">
-   <b><a href="#dom-permissionname-speaker-selection">#dom-permissionname-speaker-selection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-speaker-selection" class="dfn-panel" data-for="dom-permissionname-speaker-selection" id="infopanel-for-dom-permissionname-speaker-selection" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-speaker-selection" style="display:none">Info about the '"speaker-selection"' definition.</span><b><a href="#dom-permissionname-speaker-selection">#dom-permissionname-speaker-selection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-speaker-selection">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-devicepermissiondescriptor">
-   <b><a href="#dictdef-devicepermissiondescriptor">#dictdef-devicepermissiondescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-devicepermissiondescriptor" class="dfn-panel" data-for="dictdef-devicepermissiondescriptor" id="infopanel-for-dictdef-devicepermissiondescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-devicepermissiondescriptor" style="display:none">Info about the 'DevicePermissionDescriptor' definition.</span><b><a href="#dictdef-devicepermissiondescriptor">#dictdef-devicepermissiondescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-devicepermissiondescriptor">10.5. 
       Media Devices </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-devicepermissiondescriptor-deviceid">
-   <b><a href="#dom-devicepermissiondescriptor-deviceid">#dom-devicepermissiondescriptor-deviceid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-devicepermissiondescriptor-deviceid" class="dfn-panel" data-for="dom-devicepermissiondescriptor-deviceid" id="infopanel-for-dom-devicepermissiondescriptor-deviceid" role="dialog">
+   <span id="infopaneltitle-for-dom-devicepermissiondescriptor-deviceid" style="display:none">Info about the 'deviceId' definition.</span><b><a href="#dom-devicepermissiondescriptor-deviceid">#dom-devicepermissiondescriptor-deviceid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-devicepermissiondescriptor-deviceid">10.5. 
       Media Devices </a> <a href="#ref-for-dom-devicepermissiondescriptor-deviceid①">(2)</a> <a href="#ref-for-dom-devicepermissiondescriptor-deviceid②">(3)</a> <a href="#ref-for-dom-devicepermissiondescriptor-deviceid③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-device-info">
-   <b><a href="#dom-permissionname-device-info">#dom-permissionname-device-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-device-info" class="dfn-panel" data-for="dom-permissionname-device-info" id="infopanel-for-dom-permissionname-device-info" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-device-info" style="display:none">Info about the '"device-info"' definition.</span><b><a href="#dom-permissionname-device-info">#dom-permissionname-device-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-device-info">10. 
     Permission Registry </a>
@@ -2987,36 +2987,36 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Media Devices </a> <a href="#ref-for-dom-permissionname-device-info②">(2)</a> <a href="#ref-for-dom-permissionname-device-info③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-background-fetch">
-   <b><a href="#dom-permissionname-background-fetch">#dom-permissionname-background-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-background-fetch" class="dfn-panel" data-for="dom-permissionname-background-fetch" id="infopanel-for-dom-permissionname-background-fetch" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-background-fetch" style="display:none">Info about the '"background-fetch"' definition.</span><b><a href="#dom-permissionname-background-fetch">#dom-permissionname-background-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-background-fetch">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-background-sync">
-   <b><a href="#dom-permissionname-background-sync">#dom-permissionname-background-sync</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-background-sync" class="dfn-panel" data-for="dom-permissionname-background-sync" id="infopanel-for-dom-permissionname-background-sync" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-background-sync" style="display:none">Info about the '"background-sync"' definition.</span><b><a href="#dom-permissionname-background-sync">#dom-permissionname-background-sync</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-background-sync">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-bluetooth">
-   <b><a href="#dom-permissionname-bluetooth">#dom-permissionname-bluetooth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-bluetooth" class="dfn-panel" data-for="dom-permissionname-bluetooth" id="infopanel-for-dom-permissionname-bluetooth" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-bluetooth" style="display:none">Info about the '"bluetooth"' definition.</span><b><a href="#dom-permissionname-bluetooth">#dom-permissionname-bluetooth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-bluetooth">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-persistent-storage">
-   <b><a href="#dom-permissionname-persistent-storage">#dom-permissionname-persistent-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-persistent-storage" class="dfn-panel" data-for="dom-permissionname-persistent-storage" id="infopanel-for-dom-permissionname-persistent-storage" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-persistent-storage" style="display:none">Info about the '"persistent-storage"' definition.</span><b><a href="#dom-permissionname-persistent-storage">#dom-permissionname-persistent-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-persistent-storage">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-ambient-light-sensor">
-   <b><a href="#dom-permissionname-ambient-light-sensor">#dom-permissionname-ambient-light-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-ambient-light-sensor" class="dfn-panel" data-for="dom-permissionname-ambient-light-sensor" id="infopanel-for-dom-permissionname-ambient-light-sensor" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-ambient-light-sensor" style="display:none">Info about the '"ambient-light-sensor"' definition.</span><b><a href="#dom-permissionname-ambient-light-sensor">#dom-permissionname-ambient-light-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-ambient-light-sensor">10. 
     Permission Registry </a>
@@ -3024,8 +3024,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Ambient Light Sensor </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-accelerometer">
-   <b><a href="#dom-permissionname-accelerometer">#dom-permissionname-accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-accelerometer" class="dfn-panel" data-for="dom-permissionname-accelerometer" id="infopanel-for-dom-permissionname-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-accelerometer" style="display:none">Info about the '"accelerometer"' definition.</span><b><a href="#dom-permissionname-accelerometer">#dom-permissionname-accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-accelerometer">10. 
     Permission Registry </a>
@@ -3033,8 +3033,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Accelerometer </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-gyroscope">
-   <b><a href="#dom-permissionname-gyroscope">#dom-permissionname-gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-gyroscope" class="dfn-panel" data-for="dom-permissionname-gyroscope" id="infopanel-for-dom-permissionname-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-gyroscope" style="display:none">Info about the '"gyroscope"' definition.</span><b><a href="#dom-permissionname-gyroscope">#dom-permissionname-gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-gyroscope">10. 
     Permission Registry </a>
@@ -3042,8 +3042,8 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Gyroscope </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-magnetometer">
-   <b><a href="#dom-permissionname-magnetometer">#dom-permissionname-magnetometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-magnetometer" class="dfn-panel" data-for="dom-permissionname-magnetometer" id="infopanel-for-dom-permissionname-magnetometer" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-magnetometer" style="display:none">Info about the '"magnetometer"' definition.</span><b><a href="#dom-permissionname-magnetometer">#dom-permissionname-magnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-magnetometer">10. 
     Permission Registry </a>
@@ -3051,57 +3051,57 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
       Magnetometer </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-clipboard-read">
-   <b><a href="#dom-permissionname-clipboard-read">#dom-permissionname-clipboard-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-clipboard-read" class="dfn-panel" data-for="dom-permissionname-clipboard-read" id="infopanel-for-dom-permissionname-clipboard-read" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-clipboard-read" style="display:none">Info about the '"clipboard-read"' definition.</span><b><a href="#dom-permissionname-clipboard-read">#dom-permissionname-clipboard-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-clipboard-read">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-clipboard-write">
-   <b><a href="#dom-permissionname-clipboard-write">#dom-permissionname-clipboard-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-clipboard-write" class="dfn-panel" data-for="dom-permissionname-clipboard-write" id="infopanel-for-dom-permissionname-clipboard-write" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-clipboard-write" style="display:none">Info about the '"clipboard-write"' definition.</span><b><a href="#dom-permissionname-clipboard-write">#dom-permissionname-clipboard-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-clipboard-write">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-display-capture">
-   <b><a href="#dom-permissionname-display-capture">#dom-permissionname-display-capture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-display-capture" class="dfn-panel" data-for="dom-permissionname-display-capture" id="infopanel-for-dom-permissionname-display-capture" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-display-capture" style="display:none">Info about the '"display-capture"' definition.</span><b><a href="#dom-permissionname-display-capture">#dom-permissionname-display-capture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-display-capture">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionname-nfc">
-   <b><a href="#dom-permissionname-nfc">#dom-permissionname-nfc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionname-nfc" class="dfn-panel" data-for="dom-permissionname-nfc" id="infopanel-for-dom-permissionname-nfc" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionname-nfc" style="display:none">Info about the '"nfc"' definition.</span><b><a href="#dom-permissionname-nfc">#dom-permissionname-nfc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionname-nfc">10. 
     Permission Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-permissionsetparameters">
-   <b><a href="#dictdef-permissionsetparameters">#dictdef-permissionsetparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-permissionsetparameters" class="dfn-panel" data-for="dictdef-permissionsetparameters" id="infopanel-for-dictdef-permissionsetparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-permissionsetparameters" style="display:none">Info about the 'PermissionSetParameters' definition.</span><b><a href="#dictdef-permissionsetparameters">#dictdef-permissionsetparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-permissionsetparameters">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionsetparameters-descriptor">
-   <b><a href="#dom-permissionsetparameters-descriptor">#dom-permissionsetparameters-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionsetparameters-descriptor" class="dfn-panel" data-for="dom-permissionsetparameters-descriptor" id="infopanel-for-dom-permissionsetparameters-descriptor" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionsetparameters-descriptor" style="display:none">Info about the 'descriptor' definition.</span><b><a href="#dom-permissionsetparameters-descriptor">#dom-permissionsetparameters-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionsetparameters-descriptor">11.1. 
       Set Permission </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionsetparameters-state">
-   <b><a href="#dom-permissionsetparameters-state">#dom-permissionsetparameters-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionsetparameters-state" class="dfn-panel" data-for="dom-permissionsetparameters-state" id="infopanel-for-dom-permissionsetparameters-state" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionsetparameters-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-permissionsetparameters-state">#dom-permissionsetparameters-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionsetparameters-state">11.1. 
       Set Permission </a> <a href="#ref-for-dom-permissionsetparameters-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionsetparameters-onerealm">
-   <b><a href="#dom-permissionsetparameters-onerealm">#dom-permissionsetparameters-onerealm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionsetparameters-onerealm" class="dfn-panel" data-for="dom-permissionsetparameters-onerealm" id="infopanel-for-dom-permissionsetparameters-onerealm" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionsetparameters-onerealm" style="display:none">Info about the 'oneRealm' definition.</span><b><a href="#dom-permissionsetparameters-onerealm">#dom-permissionsetparameters-onerealm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionsetparameters-onerealm">11.1. 
       Set Permission </a>
@@ -3109,59 +3109,115 @@ navigator.permissions.query({ name: 'notifications' }).then((result) => {
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/picture-in-picture/index.html
+++ b/tests/github/w3c/picture-in-picture/index.html
@@ -1180,134 +1180,134 @@ Wörner for their contributions to this document.</p>
    <li><a href="#eventdef-pictureinpicturewindow-resize">resize</a><span>, in § 4.5</span>
    <li><a href="#dom-pictureinpicturewindow-width">width</a><span>, in § 4.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">4.4. Interface PictureInPictureWindow</a> <a href="#ref-for-px①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.9. One Picture-in-Picture window</a>
     <li><a href="#ref-for-document①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">4.3. Extension to DocumentOrShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">4.3. Extension to DocumentOrShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-dom-event-bubbles①">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">4.3. Extension to DocumentOrShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.8. Interaction with Page Visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-concept-event-fire①">3.2. Exit Picture-in-Picture</a>
     <li><a href="#ref-for-concept-event-fire②">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">3.3. Disable Picture-in-Picture</a>
     <li><a href="#ref-for-concept-reflect①">3.4. Auto Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-retarget">
-   <a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-retarget" class="dfn-panel" data-for="term-for-retarget" id="infopanel-for-term-for-retarget" role="menu">
+   <span id="infopaneltitle-for-term-for-retarget" style="display:none">Info about the 'retargeting' external reference.</span><a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retarget">4.3. Extension to DocumentOrShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree" class="dfn-panel" data-for="term-for-concept-tree" id="infopanel-for-term-for-concept-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree" style="display:none">Info about the 'tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree">4.3. Extension to DocumentOrShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-exit-fullscreen">
-   <a href="https://fullscreen.spec.whatwg.org#fully-exit-fullscreen">https://fullscreen.spec.whatwg.org#fully-exit-fullscreen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-exit-fullscreen" class="dfn-panel" data-for="term-for-fully-exit-fullscreen" id="infopanel-for-term-for-fully-exit-fullscreen" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-exit-fullscreen" style="display:none">Info about the 'exit fullscreen' external reference.</span><a href="https://fullscreen.spec.whatwg.org#fully-exit-fullscreen">https://fullscreen.spec.whatwg.org#fully-exit-fullscreen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-exit-fullscreen">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fullscreen-flag">
-   <a href="https://fullscreen.spec.whatwg.org#fullscreen-flag">https://fullscreen.spec.whatwg.org#fullscreen-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fullscreen-flag" class="dfn-panel" data-for="term-for-fullscreen-flag" id="infopanel-for-term-for-fullscreen-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-fullscreen-flag" style="display:none">Info about the 'fullscreen flag' external reference.</span><a href="https://fullscreen.spec.whatwg.org#fullscreen-flag">https://fullscreen.spec.whatwg.org#fullscreen-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-flag">3.5. Interaction with Fullscreen</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-fullscreenelement">
-   <a href="https://fullscreen.spec.whatwg.org#dom-document-fullscreenelement">https://fullscreen.spec.whatwg.org#dom-document-fullscreenelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-fullscreenelement" class="dfn-panel" data-for="term-for-dom-document-fullscreenelement" id="infopanel-for-term-for-dom-document-fullscreenelement" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-fullscreenelement" style="display:none">Info about the 'fullscreenelement' external reference.</span><a href="https://fullscreen.spec.whatwg.org#dom-document-fullscreenelement">https://fullscreen.spec.whatwg.org#dom-document-fullscreenelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-fullscreenelement">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">4.1. Extensions to HTMLVideoElement</a> <a href="#ref-for-cereactions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.1. Extensions to HTMLVideoElement</a> <a href="#ref-for-eventhandler①">(2)</a>
     <li><a href="#ref-for-eventhandler②">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-have_nothing">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-have_nothing" class="dfn-panel" data-for="term-for-dom-media-have_nothing" id="infopanel-for-term-for-dom-media-have_nothing" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-have_nothing" style="display:none">Info about the 'HAVE_NOTHING' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing">https://html.spec.whatwg.org/multipage/media.html#dom-media-have_nothing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-have_nothing">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlvideoelement">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlvideoelement" class="dfn-panel" data-for="term-for-htmlvideoelement" id="infopanel-for-term-for-htmlvideoelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlvideoelement" style="display:none">Info about the 'HTMLVideoElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement">https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlvideoelement">1. Introduction</a>
     <li><a href="#ref-for-htmlvideoelement①">4.1. Extensions to HTMLVideoElement</a>
@@ -1316,208 +1316,208 @@ Wörner for their contributions to this document.</p>
     <li><a href="#ref-for-htmlvideoelement⑤">5. Security considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-allowed-to-use①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">5.1. Secure Context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. Extensions to HTMLVideoElement</a>
     <li><a href="#ref-for-in-parallel①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element-event-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source">https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element-event-task-source" class="dfn-panel" data-for="term-for-media-element-event-task-source" id="infopanel-for-term-for-media-element-event-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element-event-task-source" style="display:none">Info about the 'media element event task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source">https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element-event-task-source">4.6. Task source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-paused">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-paused" class="dfn-panel" data-for="term-for-dom-media-paused" id="infopanel-for-term-for-dom-media-paused" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-paused" style="display:none">Info about the 'paused' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-paused">https://html.spec.whatwg.org/multipage/media.html#dom-media-paused</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-paused">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-queue-a-task①">3.2. Exit Picture-in-Picture</a>
     <li><a href="#ref-for-queue-a-task②">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-media-readystate">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-media-readystate" class="dfn-panel" data-for="term-for-dom-media-readystate" id="infopanel-for-term-for-dom-media-readystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-media-readystate" style="display:none">Info about the 'readyState' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate">https://html.spec.whatwg.org/multipage/media.html#dom-media-readystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-media-readystate">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">4.6. Task source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3.4. Auto Picture-in-Picture</a> <a href="#ref-for-top-level-browsing-context①">(2)</a>
     <li><a href="#ref-for-top-level-browsing-context②">3.8. Interaction with Page Visibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps">
-   <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unloading-document-cleanup-steps" class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps" id="infopanel-for-term-for-unloading-document-cleanup-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-unloading-document-cleanup-steps" style="display:none">Info about the 'unloading document cleanup steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unloading-document-cleanup-steps">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visibilitystate" class="dfn-panel" data-for="term-for-dom-visibilitystate" id="infopanel-for-term-for-dom-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visibilitystate" style="display:none">Info about the 'visibilityState' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#dom-visibilitystate">https://www.w3.org/TR/page-visibility/#dom-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilitystate">3.8. Interaction with Page Visibility</a> <a href="#ref-for-dom-visibilitystate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">5.2. Feature Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-policy-controlled-feature①">5.2. Feature Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-local-playback-device">
-   <a href="https://w3c.github.io/remote-playback/#dfn-local-playback-device">https://w3c.github.io/remote-playback/#dfn-local-playback-device</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-local-playback-device" class="dfn-panel" data-for="term-for-dfn-local-playback-device" id="infopanel-for-term-for-dfn-local-playback-device" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-local-playback-device" style="display:none">Info about the 'local playback device' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-local-playback-device">https://w3c.github.io/remote-playback/#dfn-local-playback-device</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-local-playback-device">3.6. Interaction with Remote Playback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-local-playback-state">
-   <a href="https://w3c.github.io/remote-playback/#dfn-local-playback-state">https://w3c.github.io/remote-playback/#dfn-local-playback-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-local-playback-state" class="dfn-panel" data-for="term-for-dfn-local-playback-state" id="infopanel-for-term-for-dfn-local-playback-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-local-playback-state" style="display:none">Info about the 'local playback state' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-local-playback-state">https://w3c.github.io/remote-playback/#dfn-local-playback-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-local-playback-state">3.6. Interaction with Remote Playback</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-class" class="dfn-panel" data-for="term-for-pseudo-class" id="infopanel-for-term-for-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-class" style="display:none">Info about the 'pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">4.7. CSS pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.4. Interface PictureInPictureWindow</a>
     <li><a href="#ref-for-Exposed①">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.1. Request Picture-in-Picture</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
     <li><a href="#ref-for-invalidstateerror③">3.2. Exit Picture-in-Picture</a>
     <li><a href="#ref-for-invalidstateerror④">3.3. Disable Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">4.1. Extensions to HTMLVideoElement</a>
     <li><a href="#ref-for-NewObject①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.1. Extensions to HTMLVideoElement</a>
     <li><a href="#ref-for-idl-promise①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-securityerror①">5.2. Feature Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.1. Extensions to HTMLVideoElement</a>
     <li><a href="#ref-for-a-new-promise①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.1. Extensions to HTMLVideoElement</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">4.4. Interface PictureInPictureWindow</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.2. Extensions to Document</a>
    </ul>
@@ -1685,16 +1685,16 @@ Wörner for their contributions to this document.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="request-picture-in-picture-algorithm">
-   <b><a href="#request-picture-in-picture-algorithm">#request-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-picture-in-picture-algorithm" class="dfn-panel" data-for="request-picture-in-picture-algorithm" id="infopanel-for-request-picture-in-picture-algorithm" role="dialog">
+   <span id="infopaneltitle-for-request-picture-in-picture-algorithm" style="display:none">Info about the 'request Picture-in-Picture algorithm' definition.</span><b><a href="#request-picture-in-picture-algorithm">#request-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-picture-in-picture-algorithm">3.4. Auto Picture-in-Picture</a> <a href="#ref-for-request-picture-in-picture-algorithm①">(2)</a>
     <li><a href="#ref-for-request-picture-in-picture-algorithm②">4.1. Extensions to HTMLVideoElement</a>
     <li><a href="#ref-for-request-picture-in-picture-algorithm③">5.2. Feature Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="picture-in-picture-window">
-   <b><a href="#picture-in-picture-window">#picture-in-picture-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-picture-in-picture-window" class="dfn-panel" data-for="picture-in-picture-window" id="infopanel-for-picture-in-picture-window" role="dialog">
+   <span id="infopaneltitle-for-picture-in-picture-window" style="display:none">Info about the 'Picture-in-Picture window' definition.</span><b><a href="#picture-in-picture-window">#picture-in-picture-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-picture-in-picture-window">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-picture-in-picture-window①">3.2. Exit Picture-in-Picture</a> <a href="#ref-for-picture-in-picture-window②">(2)</a>
@@ -1702,8 +1702,8 @@ Wörner for their contributions to this document.</p>
     <li><a href="#ref-for-picture-in-picture-window④">4.4. Interface PictureInPictureWindow</a> <a href="#ref-for-picture-in-picture-window⑤">(2)</a> <a href="#ref-for-picture-in-picture-window⑥">(3)</a> <a href="#ref-for-picture-in-picture-window⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exit-picture-in-picture-algorithm">
-   <b><a href="#exit-picture-in-picture-algorithm">#exit-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exit-picture-in-picture-algorithm" class="dfn-panel" data-for="exit-picture-in-picture-algorithm" id="infopanel-for-exit-picture-in-picture-algorithm" role="dialog">
+   <span id="infopaneltitle-for-exit-picture-in-picture-algorithm" style="display:none">Info about the 'exit Picture-in-Picture algorithm' definition.</span><b><a href="#exit-picture-in-picture-algorithm">#exit-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exit-picture-in-picture-algorithm">3.2. Exit Picture-in-Picture</a> <a href="#ref-for-exit-picture-in-picture-algorithm①">(2)</a>
     <li><a href="#ref-for-exit-picture-in-picture-algorithm②">3.3. Disable Picture-in-Picture</a>
@@ -1712,55 +1712,55 @@ Wörner for their contributions to this document.</p>
     <li><a href="#ref-for-exit-picture-in-picture-algorithm⑤">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="autopictureinpictureelement">
-   <b><a href="#autopictureinpictureelement">#autopictureinpictureelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-autopictureinpictureelement" class="dfn-panel" data-for="autopictureinpictureelement" id="infopanel-for-autopictureinpictureelement" role="dialog">
+   <span id="infopaneltitle-for-autopictureinpictureelement" style="display:none">Info about the 'autoPictureInPictureElement' definition.</span><b><a href="#autopictureinpictureelement">#autopictureinpictureelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-autopictureinpictureelement">3.4. Auto Picture-in-Picture</a> <a href="#ref-for-autopictureinpictureelement①">(2)</a> <a href="#ref-for-autopictureinpictureelement②">(3)</a> <a href="#ref-for-autopictureinpictureelement③">(4)</a> <a href="#ref-for-autopictureinpictureelement④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlvideoelement-requestpictureinpicture">
-   <b><a href="#dom-htmlvideoelement-requestpictureinpicture">#dom-htmlvideoelement-requestpictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlvideoelement-requestpictureinpicture" class="dfn-panel" data-for="dom-htmlvideoelement-requestpictureinpicture" id="infopanel-for-dom-htmlvideoelement-requestpictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlvideoelement-requestpictureinpicture" style="display:none">Info about the 'requestPictureInPicture' definition.</span><b><a href="#dom-htmlvideoelement-requestpictureinpicture">#dom-htmlvideoelement-requestpictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlvideoelement-requestpictureinpicture">3.3. Disable Picture-in-Picture</a>
     <li><a href="#ref-for-dom-htmlvideoelement-requestpictureinpicture①">4.1. Extensions to HTMLVideoElement</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlvideoelement-autopictureinpicture">
-   <b><a href="#dom-htmlvideoelement-autopictureinpicture">#dom-htmlvideoelement-autopictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlvideoelement-autopictureinpicture" class="dfn-panel" data-for="dom-htmlvideoelement-autopictureinpicture" id="infopanel-for-dom-htmlvideoelement-autopictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlvideoelement-autopictureinpicture" style="display:none">Info about the 'autoPictureInPicture' definition.</span><b><a href="#dom-htmlvideoelement-autopictureinpicture">#dom-htmlvideoelement-autopictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlvideoelement-autopictureinpicture">3.4. Auto Picture-in-Picture</a> <a href="#ref-for-dom-htmlvideoelement-autopictureinpicture①">(2)</a> <a href="#ref-for-dom-htmlvideoelement-autopictureinpicture②">(3)</a> <a href="#ref-for-dom-htmlvideoelement-autopictureinpicture③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlvideoelement-disablepictureinpicture">
-   <b><a href="#dom-htmlvideoelement-disablepictureinpicture">#dom-htmlvideoelement-disablepictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlvideoelement-disablepictureinpicture" class="dfn-panel" data-for="dom-htmlvideoelement-disablepictureinpicture" id="infopanel-for-dom-htmlvideoelement-disablepictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlvideoelement-disablepictureinpicture" style="display:none">Info about the 'disablePictureInPicture' definition.</span><b><a href="#dom-htmlvideoelement-disablepictureinpicture">#dom-htmlvideoelement-disablepictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture①">3.3. Disable Picture-in-Picture</a> <a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture②">(2)</a> <a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture③">(3)</a> <a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture④">(4)</a>
     <li><a href="#ref-for-dom-htmlvideoelement-disablepictureinpicture⑤">3.4. Auto Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-pictureinpictureenabled">
-   <b><a href="#dom-document-pictureinpictureenabled">#dom-document-pictureinpictureenabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-pictureinpictureenabled" class="dfn-panel" data-for="dom-document-pictureinpictureenabled" id="infopanel-for-dom-document-pictureinpictureenabled" role="dialog">
+   <span id="infopaneltitle-for-dom-document-pictureinpictureenabled" style="display:none">Info about the 'pictureInPictureEnabled' definition.</span><b><a href="#dom-document-pictureinpictureenabled">#dom-document-pictureinpictureenabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-pictureinpictureenabled">4.2. Extensions to Document</a>
     <li><a href="#ref-for-dom-document-pictureinpictureenabled①">5.2. Feature Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-exitpictureinpicture">
-   <b><a href="#dom-document-exitpictureinpicture">#dom-document-exitpictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-exitpictureinpicture" class="dfn-panel" data-for="dom-document-exitpictureinpicture" id="infopanel-for-dom-document-exitpictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-dom-document-exitpictureinpicture" style="display:none">Info about the 'exitPictureInPicture' definition.</span><b><a href="#dom-document-exitpictureinpicture">#dom-document-exitpictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-exitpictureinpicture">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="picture-in-picture-support">
-   <b><a href="#picture-in-picture-support">#picture-in-picture-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-picture-in-picture-support" class="dfn-panel" data-for="picture-in-picture-support" id="infopanel-for-picture-in-picture-support" role="dialog">
+   <span id="infopaneltitle-for-picture-in-picture-support" style="display:none">Info about the 'Picture-in-Picture support' definition.</span><b><a href="#picture-in-picture-support">#picture-in-picture-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-picture-in-picture-support">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-picture-in-picture-support①">4.2. Extensions to Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documentorshadowroot-pictureinpictureelement">
-   <b><a href="#dom-documentorshadowroot-pictureinpictureelement">#dom-documentorshadowroot-pictureinpictureelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documentorshadowroot-pictureinpictureelement" class="dfn-panel" data-for="dom-documentorshadowroot-pictureinpictureelement" id="infopanel-for-dom-documentorshadowroot-pictureinpictureelement" role="dialog">
+   <span id="infopaneltitle-for-dom-documentorshadowroot-pictureinpictureelement" style="display:none">Info about the 'pictureInPictureElement' definition.</span><b><a href="#dom-documentorshadowroot-pictureinpictureelement">#dom-documentorshadowroot-pictureinpictureelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement">3.1. Request Picture-in-Picture</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement①">(2)</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement②">(3)</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement③">(4)</a>
     <li><a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement④">3.2. Exit Picture-in-Picture</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement⑤">(2)</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement⑥">(3)</a> <a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement⑦">(4)</a>
@@ -1774,8 +1774,8 @@ Wörner for their contributions to this document.</p>
     <li><a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement②⓪">4.7. CSS pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pictureinpicturewindow">
-   <b><a href="#pictureinpicturewindow">#pictureinpicturewindow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pictureinpicturewindow" class="dfn-panel" data-for="pictureinpicturewindow" id="infopanel-for-pictureinpicturewindow" role="dialog">
+   <span id="infopaneltitle-for-pictureinpicturewindow" style="display:none">Info about the 'PictureInPictureWindow' definition.</span><b><a href="#pictureinpicturewindow">#pictureinpicturewindow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pictureinpicturewindow">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-pictureinpicturewindow①">4.1. Extensions to HTMLVideoElement</a>
@@ -1783,115 +1783,171 @@ Wörner for their contributions to this document.</p>
     <li><a href="#ref-for-pictureinpicturewindow⑤">4.5. Event types</a> <a href="#ref-for-pictureinpicturewindow⑥">(2)</a> <a href="#ref-for-pictureinpicturewindow⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pictureinpicturewindow-width">
-   <b><a href="#dom-pictureinpicturewindow-width">#dom-pictureinpicturewindow-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pictureinpicturewindow-width" class="dfn-panel" data-for="dom-pictureinpicturewindow-width" id="infopanel-for-dom-pictureinpicturewindow-width" role="dialog">
+   <span id="infopaneltitle-for-dom-pictureinpicturewindow-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-pictureinpicturewindow-width">#dom-pictureinpicturewindow-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pictureinpicturewindow-width">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pictureinpicturewindow-height">
-   <b><a href="#dom-pictureinpicturewindow-height">#dom-pictureinpicturewindow-height</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pictureinpicturewindow-height" class="dfn-panel" data-for="dom-pictureinpicturewindow-height" id="infopanel-for-dom-pictureinpicturewindow-height" role="dialog">
+   <span id="infopaneltitle-for-dom-pictureinpicturewindow-height" style="display:none">Info about the 'height' definition.</span><b><a href="#dom-pictureinpicturewindow-height">#dom-pictureinpicturewindow-height</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pictureinpicturewindow-height">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="close-window-algorithm">
-   <b><a href="#close-window-algorithm">#close-window-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-close-window-algorithm" class="dfn-panel" data-for="close-window-algorithm" id="infopanel-for-close-window-algorithm" role="dialog">
+   <span id="infopaneltitle-for-close-window-algorithm" style="display:none">Info about the 'close window algorithm' definition.</span><b><a href="#close-window-algorithm">#close-window-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-window-algorithm">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pictureinpictureevent">
-   <b><a href="#pictureinpictureevent">#pictureinpictureevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pictureinpictureevent" class="dfn-panel" data-for="pictureinpictureevent" id="infopanel-for-pictureinpictureevent" role="dialog">
+   <span id="infopaneltitle-for-pictureinpictureevent" style="display:none">Info about the 'PictureInPictureEvent' definition.</span><b><a href="#pictureinpictureevent">#pictureinpictureevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pictureinpictureevent">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-pictureinpictureevent①">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-pictureinpictureevent-pictureinpicturewindow">
-   <b><a href="#dom-pictureinpictureevent-pictureinpicturewindow">#dom-pictureinpictureevent-pictureinpicturewindow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-pictureinpictureevent-pictureinpicturewindow" class="dfn-panel" data-for="dom-pictureinpictureevent-pictureinpicturewindow" id="infopanel-for-dom-pictureinpictureevent-pictureinpicturewindow" role="dialog">
+   <span id="infopaneltitle-for-dom-pictureinpictureevent-pictureinpicturewindow" style="display:none">Info about the 'pictureInPictureWindow' definition.</span><b><a href="#dom-pictureinpictureevent-pictureinpicturewindow">#dom-pictureinpictureevent-pictureinpicturewindow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pictureinpictureevent-pictureinpicturewindow">3.1. Request Picture-in-Picture</a>
     <li><a href="#ref-for-dom-pictureinpictureevent-pictureinpicturewindow①">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-pictureinpictureeventinit">
-   <b><a href="#dictdef-pictureinpictureeventinit">#dictdef-pictureinpictureeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-pictureinpictureeventinit" class="dfn-panel" data-for="dictdef-pictureinpictureeventinit" id="infopanel-for-dictdef-pictureinpictureeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-pictureinpictureeventinit" style="display:none">Info about the 'PictureInPictureEventInit' definition.</span><b><a href="#dictdef-pictureinpictureeventinit">#dictdef-pictureinpictureeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-pictureinpictureeventinit">4.5. Event types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-htmlvideoelement-enterpictureinpicture">
-   <b><a href="#eventdef-htmlvideoelement-enterpictureinpicture">#eventdef-htmlvideoelement-enterpictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-htmlvideoelement-enterpictureinpicture" class="dfn-panel" data-for="eventdef-htmlvideoelement-enterpictureinpicture" id="infopanel-for-eventdef-htmlvideoelement-enterpictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-eventdef-htmlvideoelement-enterpictureinpicture" style="display:none">Info about the 'enterpictureinpicture' definition.</span><b><a href="#eventdef-htmlvideoelement-enterpictureinpicture">#eventdef-htmlvideoelement-enterpictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-htmlvideoelement-enterpictureinpicture">3.1. Request Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-htmlvideoelement-leavepictureinpicture">
-   <b><a href="#eventdef-htmlvideoelement-leavepictureinpicture">#eventdef-htmlvideoelement-leavepictureinpicture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-htmlvideoelement-leavepictureinpicture" class="dfn-panel" data-for="eventdef-htmlvideoelement-leavepictureinpicture" id="infopanel-for-eventdef-htmlvideoelement-leavepictureinpicture" role="dialog">
+   <span id="infopaneltitle-for-eventdef-htmlvideoelement-leavepictureinpicture" style="display:none">Info about the 'leavepictureinpicture' definition.</span><b><a href="#eventdef-htmlvideoelement-leavepictureinpicture">#eventdef-htmlvideoelement-leavepictureinpicture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-htmlvideoelement-leavepictureinpicture">3.2. Exit Picture-in-Picture</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-pictureinpicturewindow-resize">
-   <b><a href="#eventdef-pictureinpicturewindow-resize">#eventdef-pictureinpicturewindow-resize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-pictureinpicturewindow-resize" class="dfn-panel" data-for="eventdef-pictureinpicturewindow-resize" id="infopanel-for-eventdef-pictureinpicturewindow-resize" role="dialog">
+   <span id="infopaneltitle-for-eventdef-pictureinpicturewindow-resize" style="display:none">Info about the 'resize' definition.</span><b><a href="#eventdef-pictureinpicturewindow-resize">#eventdef-pictureinpicturewindow-resize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-pictureinpicturewindow-resize">4.4. Interface PictureInPictureWindow</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/proximity/index.html
+++ b/tests/github/w3c/proximity/index.html
@@ -867,156 +867,156 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li><a href="#dom-proximitysensor-proximitysensor">ProximitySensor(sensorOptions)</a><span>, in § 5.1</span>
    <li><a href="#sensing-range">sensing range</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-mocksensortype-proximity">
-   <a href="https://w3c.github.io/sensors/#dom-mocksensortype-proximity">https://w3c.github.io/sensors/#dom-mocksensortype-proximity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mocksensortype-proximity" class="dfn-panel" data-for="term-for-dom-mocksensortype-proximity" id="infopanel-for-term-for-dom-mocksensortype-proximity" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mocksensortype-proximity" style="display:none">Info about the '"proximity"' external reference.</span><a href="https://w3c.github.io/sensors/#dom-mocksensortype-proximity">https://w3c.github.io/sensors/#dom-mocksensortype-proximity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-proximity">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor">
-   <a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor" class="dfn-panel" data-for="term-for-sensor" id="infopanel-for-term-for-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor" style="display:none">Info about the 'Sensor' external reference.</span><a href="https://w3c.github.io/sensors/#sensor">https://w3c.github.io/sensors/#sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">4. Model</a> <a href="#ref-for-sensor①">(2)</a>
     <li><a href="#ref-for-sensor②">5.1. The ProximitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-sensoroptions">
-   <a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-sensoroptions" class="dfn-panel" data-for="term-for-dictdef-sensoroptions" id="infopanel-for-term-for-dictdef-sensoroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' external reference.</span><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">https://w3c.github.io/sensors/#dictdef-sensoroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">5.1. The ProximitySensor Interface</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">6.1. Construct a proximity sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-automation">
-   <a href="https://w3c.github.io/sensors#automation">https://w3c.github.io/sensors#automation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-automation" class="dfn-panel" data-for="term-for-automation" id="infopanel-for-term-for-automation" role="menu">
+   <span id="infopaneltitle-for-term-for-automation" style="display:none">Info about the 'automation' external reference.</span><a href="https://w3c.github.io/sensors#automation">https://w3c.github.io/sensors#automation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-automation">7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features">
-   <a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">https://w3c.github.io/sensors#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="term-for-check-sensor-policy-controlled-features" id="infopanel-for-term-for-check-sensor-policy-controlled-features" role="menu">
+   <span id="infopaneltitle-for-term-for-check-sensor-policy-controlled-features" style="display:none">Info about the 'check sensor policy-controlled features' external reference.</span><a href="https://w3c.github.io/sensors#check-sensor-policy-controlled-features">https://w3c.github.io/sensors#check-sensor-policy-controlled-features</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">6.1. Construct a proximity sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-sensor">
-   <a href="https://w3c.github.io/sensors#default-sensor">https://w3c.github.io/sensors#default-sensor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-sensor" class="dfn-panel" data-for="term-for-default-sensor" id="infopanel-for-term-for-default-sensor" role="menu">
+   <span id="infopaneltitle-for-term-for-default-sensor" style="display:none">Info about the 'default sensor' external reference.</span><a href="https://w3c.github.io/sensors#default-sensor">https://w3c.github.io/sensors#default-sensor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sensor">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-device-fingerprinting">
-   <a href="https://w3c.github.io/sensors#device-fingerprinting">https://w3c.github.io/sensors#device-fingerprinting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-device-fingerprinting" class="dfn-panel" data-for="term-for-device-fingerprinting" id="infopanel-for-term-for-device-fingerprinting" role="menu">
+   <span id="infopaneltitle-for-term-for-device-fingerprinting" style="display:none">Info about the 'fingerprinting' external reference.</span><a href="https://w3c.github.io/sensors#device-fingerprinting">https://w3c.github.io/sensors#device-fingerprinting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-device-fingerprinting">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialize-a-sensor-object">
-   <a href="https://w3c.github.io/sensors#initialize-a-sensor-object">https://w3c.github.io/sensors#initialize-a-sensor-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialize-a-sensor-object" class="dfn-panel" data-for="term-for-initialize-a-sensor-object" id="infopanel-for-term-for-initialize-a-sensor-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialize-a-sensor-object" style="display:none">Info about the 'initialize a sensor object' external reference.</span><a href="https://w3c.github.io/sensors#initialize-a-sensor-object">https://w3c.github.io/sensors#initialize-a-sensor-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">6.1. Construct a proximity sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-latest-reading">
-   <a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-latest-reading" class="dfn-panel" data-for="term-for-latest-reading" id="infopanel-for-term-for-latest-reading" role="menu">
+   <span id="infopaneltitle-for-term-for-latest-reading" style="display:none">Info about the 'latest reading' external reference.</span><a href="https://w3c.github.io/sensors#latest-reading">https://w3c.github.io/sensors#latest-reading</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mitigation-strategies">
-   <a href="https://w3c.github.io/sensors#mitigation-strategies">https://w3c.github.io/sensors#mitigation-strategies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mitigation-strategies" class="dfn-panel" data-for="term-for-mitigation-strategies" id="infopanel-for-term-for-mitigation-strategies" role="menu">
+   <span id="infopaneltitle-for-term-for-mitigation-strategies" style="display:none">Info about the 'mitigation strategies' external reference.</span><a href="https://w3c.github.io/sensors#mitigation-strategies">https://w3c.github.io/sensors#mitigation-strategies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mitigation-strategies">3. Security and Privacy Considerations</a> <a href="#ref-for-mitigation-strategies①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-reading-values">
-   <a href="https://w3c.github.io/sensors#mock-sensor-reading-values">https://w3c.github.io/sensors#mock-sensor-reading-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-reading-values" class="dfn-panel" data-for="term-for-mock-sensor-reading-values" id="infopanel-for-term-for-mock-sensor-reading-values" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-reading-values" style="display:none">Info about the 'mock sensor reading values' external reference.</span><a href="https://w3c.github.io/sensors#mock-sensor-reading-values">https://w3c.github.io/sensors#mock-sensor-reading-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mock-sensor-type">
-   <a href="https://w3c.github.io/sensors#mock-sensor-type">https://w3c.github.io/sensors#mock-sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mock-sensor-type" class="dfn-panel" data-for="term-for-mock-sensor-type" id="infopanel-for-term-for-mock-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' external reference.</span><a href="https://w3c.github.io/sensors#mock-sensor-type">https://w3c.github.io/sensors#mock-sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-readings">
-   <a href="https://w3c.github.io/sensors#sensor-readings">https://w3c.github.io/sensors#sensor-readings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-readings" class="dfn-panel" data-for="term-for-sensor-readings" id="infopanel-for-term-for-sensor-readings" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-readings" style="display:none">Info about the 'sensor readings' external reference.</span><a href="https://w3c.github.io/sensors#sensor-readings">https://w3c.github.io/sensors#sensor-readings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-readings">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sensor-type">
-   <a href="https://w3c.github.io/sensors#sensor-type">https://w3c.github.io/sensors#sensor-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sensor-type" class="dfn-panel" data-for="term-for-sensor-type" id="infopanel-for-term-for-sensor-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sensor-type" style="display:none">Info about the 'sensor type' external reference.</span><a href="https://w3c.github.io/sensors#sensor-type">https://w3c.github.io/sensors#sensor-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">4. Model</a> <a href="#ref-for-sensor-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-identifying">
-   <a href="https://w3c.github.io/sensors#user-identifying">https://w3c.github.io/sensors#user-identifying</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-identifying" class="dfn-panel" data-for="term-for-user-identifying" id="infopanel-for-term-for-user-identifying" role="menu">
+   <span id="infopaneltitle-for-term-for-user-identifying" style="display:none">Info about the 'user identifying' external reference.</span><a href="https://w3c.github.io/sensors#user-identifying">https://w3c.github.io/sensors#user-identifying</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-identifying">3. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">6.1. Construct a proximity sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. The ProximitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. The ProximitySensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">6.1. Construct a proximity sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5.1. The ProximitySensor Interface</a>
     <li><a href="#ref-for-idl-boolean①">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">5.1. The ProximitySensor Interface</a> <a href="#ref-for-idl-double①">(2)</a>
     <li><a href="#ref-for-idl-double②">7.1. Mock Sensor Type</a> <a href="#ref-for-idl-double③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1. Construct a proximity sensor object</a>
    </ul>
@@ -1089,43 +1089,43 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="proximity-sensor">
-   <b><a href="#proximity-sensor">#proximity-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proximity-sensor" class="dfn-panel" data-for="proximity-sensor" id="infopanel-for-proximity-sensor" role="dialog">
+   <span id="infopaneltitle-for-proximity-sensor" style="display:none">Info about the 'Proximity Sensor' definition.</span><b><a href="#proximity-sensor">#proximity-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proximity-sensor">4. Model</a> <a href="#ref-for-proximity-sensor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distance">
-   <b><a href="#distance">#distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distance" class="dfn-panel" data-for="distance" id="infopanel-for-distance" role="dialog">
+   <span id="infopaneltitle-for-distance" style="display:none">Info about the 'distance' definition.</span><b><a href="#distance">#distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distance">4. Model</a>
     <li><a href="#ref-for-distance①">5.1.3. The near attribute</a> <a href="#ref-for-distance②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensing-range">
-   <b><a href="#sensing-range">#sensing-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensing-range" class="dfn-panel" data-for="sensing-range" id="infopanel-for-sensing-range" role="dialog">
+   <span id="infopaneltitle-for-sensing-range" style="display:none">Info about the 'sensing range' definition.</span><b><a href="#sensing-range">#sensing-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensing-range">4. Model</a>
     <li><a href="#ref-for-sensing-range①">5.1.1. The distance attribute</a>
     <li><a href="#ref-for-sensing-range②">5.1.3. The near attribute</a> <a href="#ref-for-sensing-range③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max">
-   <b><a href="#max">#max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max" class="dfn-panel" data-for="max" id="infopanel-for-max" role="dialog">
+   <span id="infopaneltitle-for-max" style="display:none">Info about the 'max' definition.</span><b><a href="#max">#max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max">4. Model</a>
     <li><a href="#ref-for-max①">5.1.3. The near attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="near">
-   <b><a href="#near">#near</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-near" class="dfn-panel" data-for="near" id="infopanel-for-near" role="dialog">
+   <span id="infopaneltitle-for-near" style="display:none">Info about the 'near' definition.</span><b><a href="#near">#near</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-near">4. Model</a>
     <li><a href="#ref-for-near①">5.1.3. The near attribute</a> <a href="#ref-for-near②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proximitysensor">
-   <b><a href="#proximitysensor">#proximitysensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proximitysensor" class="dfn-panel" data-for="proximitysensor" id="infopanel-for-proximitysensor" role="dialog">
+   <span id="infopaneltitle-for-proximitysensor" style="display:none">Info about the 'ProximitySensor' definition.</span><b><a href="#proximitysensor">#proximitysensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proximitysensor">4. Model</a>
     <li><a href="#ref-for-proximitysensor①">5.1. The ProximitySensor Interface</a>
@@ -1137,26 +1137,26 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-proximitysensor⑨">7.1. Mock Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-proximitysensor-distance">
-   <b><a href="#dom-proximitysensor-distance">#dom-proximitysensor-distance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-proximitysensor-distance" class="dfn-panel" data-for="dom-proximitysensor-distance" id="infopanel-for-dom-proximitysensor-distance" role="dialog">
+   <span id="infopaneltitle-for-dom-proximitysensor-distance" style="display:none">Info about the 'distance' definition.</span><b><a href="#dom-proximitysensor-distance">#dom-proximitysensor-distance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-proximitysensor-distance">5.1.1. The distance attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-proximitysensor-max">
-   <b><a href="#dom-proximitysensor-max">#dom-proximitysensor-max</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-proximitysensor-max" class="dfn-panel" data-for="dom-proximitysensor-max" id="infopanel-for-dom-proximitysensor-max" role="dialog">
+   <span id="infopaneltitle-for-dom-proximitysensor-max" style="display:none">Info about the 'max' definition.</span><b><a href="#dom-proximitysensor-max">#dom-proximitysensor-max</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-proximitysensor-max">5.1.2. The max attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-proximitysensor-near">
-   <b><a href="#dom-proximitysensor-near">#dom-proximitysensor-near</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-proximitysensor-near" class="dfn-panel" data-for="dom-proximitysensor-near" id="infopanel-for-dom-proximitysensor-near" role="dialog">
+   <span id="infopaneltitle-for-dom-proximitysensor-near" style="display:none">Info about the 'near' definition.</span><b><a href="#dom-proximitysensor-near">#dom-proximitysensor-near</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-proximitysensor-near">5.1.3. The near attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-proximity-sensor-object">
-   <b><a href="#construct-a-proximity-sensor-object">#construct-a-proximity-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-proximity-sensor-object" class="dfn-panel" data-for="construct-a-proximity-sensor-object" id="infopanel-for-construct-a-proximity-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-construct-a-proximity-sensor-object" style="display:none">Info about the '6.1. Construct a proximity sensor object' definition.</span><b><a href="#construct-a-proximity-sensor-object">#construct-a-proximity-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-proximity-sensor-object">5.1. The ProximitySensor Interface</a>
     <li><a href="#ref-for-construct-a-proximity-sensor-object">6.1. Construct a proximity sensor object</a>
@@ -1164,59 +1164,115 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/reporting/network-reporting.html
+++ b/tests/github/w3c/reporting/network-reporting.html
@@ -1285,41 +1285,41 @@ Content-Type: application/reports+json
      <li><a href="#network_reporting_endpoints-weight">dfn for network_reporting_endpoints</a><span>, in § 3.1.7</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-directives-reporting">
-   <a href="https://w3c.github.io/webappsec-csp/#directives-reporting">https://w3c.github.io/webappsec-csp/#directives-reporting</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directives-reporting" class="dfn-panel" data-for="term-for-directives-reporting" id="infopanel-for-term-for-directives-reporting" role="menu">
+   <span id="infopaneltitle-for-term-for-directives-reporting" style="display:none">Info about the 'reports directive' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directives-reporting">https://w3c.github.io/webappsec-csp/#directives-reporting</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directives-reporting">1.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4. Report Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">4. Report Generation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-host">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-host" class="dfn-panel" data-for="term-for-concept-origin-host" id="infopanel-for-term-for-concept-origin-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-host" style="display:none">Info about the 'host' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-host">3.1.2. The include_subdomains member</a>
     <li><a href="#ref-for-concept-origin-host①">5.2. 
     Send reports </a> <a href="#ref-for-concept-origin-host②">(2)</a> <a href="#ref-for-concept-origin-host③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#origin">https://html.spec.whatwg.org/multipage/browsers.html#origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin" class="dfn-panel" data-for="term-for-origin" id="infopanel-for-term-for-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#origin">https://html.spec.whatwg.org/multipage/browsers.html#origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.1. Endpoint groups</a> <a href="#ref-for-origin①">(2)</a>
     <li><a href="#ref-for-origin②">2.3. Clients</a>
@@ -1331,47 +1331,47 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-origin⑧">(2)</a> <a href="#ref-for-origin⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">5.2. 
     Send reports </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-policy-manifest">
-   <a href="https://wicg.github.io/origin-policy/#origin-policy-manifest">https://wicg.github.io/origin-policy/#origin-policy-manifest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-policy-manifest" class="dfn-panel" data-for="term-for-origin-policy-manifest" id="infopanel-for-term-for-origin-policy-manifest" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-policy-manifest" style="display:none">Info about the 'origin policy manifest' external reference.</span><a href="https://wicg.github.io/origin-policy/#origin-policy-manifest">https://wicg.github.io/origin-policy/#origin-policy-manifest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-policy-manifest">3. Endpoint Delivery</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-attempts">
-   <a href="https://w3c.github.io/reporting/#report-attempts">https://w3c.github.io/reporting/#report-attempts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-attempts" class="dfn-panel" data-for="term-for-report-attempts" id="infopanel-for-term-for-report-attempts" role="menu">
+   <span id="infopaneltitle-for-term-for-report-attempts" style="display:none">Info about the 'attempts' external reference.</span><a href="https://w3c.github.io/reporting/#report-attempts">https://w3c.github.io/reporting/#report-attempts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-attempts">6.2. Garbage Collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-body">
-   <a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-body" class="dfn-panel" data-for="term-for-report-body" id="infopanel-for-term-for-report-body" role="menu">
+   <span id="infopaneltitle-for-term-for-report-body" style="display:none">Info about the 'body' external reference.</span><a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-body">8.1. Capability URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-destination">
-   <a href="https://w3c.github.io/reporting/#report-destination">https://w3c.github.io/reporting/#report-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-destination" class="dfn-panel" data-for="term-for-report-destination" id="infopanel-for-term-for-report-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-report-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://w3c.github.io/reporting/#report-destination">https://w3c.github.io/reporting/#report-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-destination">5.2. 
     Send reports </a> <a href="#ref-for-report-destination①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-endpoint">
-   <a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-endpoint" class="dfn-panel" data-for="term-for-endpoint" id="infopanel-for-term-for-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-endpoint" style="display:none">Info about the 'endpoint' external reference.</span><a href="https://w3c.github.io/reporting/#endpoint">https://w3c.github.io/reporting/#endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint">1.1. Guarantees</a>
     <li><a href="#ref-for-endpoint①">2.2. Network reporting endpoints</a>
@@ -1385,8 +1385,8 @@ Content-Type: application/reports+json
     <li><a href="#ref-for-endpoint⑨">6.2. Garbage Collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-endpoint-failures">
-   <a href="https://w3c.github.io/reporting/#dom-endpoint-failures">https://w3c.github.io/reporting/#dom-endpoint-failures</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-endpoint-failures" class="dfn-panel" data-for="term-for-dom-endpoint-failures" id="infopanel-for-term-for-dom-endpoint-failures" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-endpoint-failures" style="display:none">Info about the 'failures' external reference.</span><a href="https://w3c.github.io/reporting/#dom-endpoint-failures">https://w3c.github.io/reporting/#dom-endpoint-failures</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-failures">3.2. 
     Process origin policy configuration </a>
@@ -1394,15 +1394,15 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-dom-endpoint-failures②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-endpoint-name">
-   <a href="https://w3c.github.io/reporting/#dom-endpoint-name">https://w3c.github.io/reporting/#dom-endpoint-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-endpoint-name" class="dfn-panel" data-for="term-for-dom-endpoint-name" id="infopanel-for-term-for-dom-endpoint-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-endpoint-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/reporting/#dom-endpoint-name">https://w3c.github.io/reporting/#dom-endpoint-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-name">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report">
-   <a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report" class="dfn-panel" data-for="term-for-report" id="infopanel-for-term-for-report" role="menu">
+   <span id="infopaneltitle-for-term-for-report" style="display:none">Info about the 'report' external reference.</span><a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report">2.5. Storage</a>
     <li><a href="#ref-for-report①">5.2. 
@@ -1410,30 +1410,30 @@ Content-Type: application/reports+json
     <li><a href="#ref-for-report⑤">8.1. Capability URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope-reports">
-   <a href="https://w3c.github.io/reporting/#windoworworkerglobalscope-reports">https://w3c.github.io/reporting/#windoworworkerglobalscope-reports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope-reports" class="dfn-panel" data-for="term-for-windoworworkerglobalscope-reports" id="infopanel-for-term-for-windoworworkerglobalscope-reports" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope-reports" style="display:none">Info about the 'reports' external reference.</span><a href="https://w3c.github.io/reporting/#windoworworkerglobalscope-reports">https://w3c.github.io/reporting/#windoworworkerglobalscope-reports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope-reports">2.5. Storage</a> <a href="#ref-for-windoworworkerglobalscope-reports①">(2)</a>
     <li><a href="#ref-for-windoworworkerglobalscope-reports②">5. Report Delivery</a>
     <li><a href="#ref-for-windoworworkerglobalscope-reports③">6.2. Garbage Collection</a> <a href="#ref-for-windoworworkerglobalscope-reports④">(2)</a> <a href="#ref-for-windoworworkerglobalscope-reports⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-endpoint-url">
-   <a href="https://w3c.github.io/reporting/#dom-endpoint-url">https://w3c.github.io/reporting/#dom-endpoint-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-endpoint-url" class="dfn-panel" data-for="term-for-dom-endpoint-url" id="infopanel-for-term-for-dom-endpoint-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-endpoint-url" style="display:none">Info about the 'url (for endpoint)' external reference.</span><a href="https://w3c.github.io/reporting/#dom-endpoint-url">https://w3c.github.io/reporting/#dom-endpoint-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-url">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-url">
-   <a href="https://w3c.github.io/reporting/#report-url">https://w3c.github.io/reporting/#report-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-url" class="dfn-panel" data-for="term-for-report-url" id="infopanel-for-term-for-report-url" role="menu">
+   <span id="infopaneltitle-for-term-for-report-url" style="display:none">Info about the 'url (for report)' external reference.</span><a href="https://w3c.github.io/reporting/#report-url">https://w3c.github.io/reporting/#report-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-url">5.2. 
     Send reports </a> <a href="#ref-for-report-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://tools.ietf.org/html/rfc2782#">https://tools.ietf.org/html/rfc2782#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'srv record' external reference.</span><a href="https://tools.ietf.org/html/rfc2782#">https://tools.ietf.org/html/rfc2782#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">1.1. Guarantees</a>
     <li><a href="#termref-for-">2.4. Failover and load balancing</a>
@@ -1441,56 +1441,56 @@ Content-Type: application/reports+json
     Choose an endpoint from a group </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-4">
-   <a href="https://tools.ietf.org/html/rfc2782#page-4">https://tools.ietf.org/html/rfc2782#page-4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-4" class="dfn-panel" data-for="term-for-page-4" id="infopanel-for-term-for-page-4" role="menu">
+   <span id="infopaneltitle-for-term-for-page-4" style="display:none">Info about the 'target selection algorithm' external reference.</span><a href="https://tools.ietf.org/html/rfc2782#page-4">https://tools.ietf.org/html/rfc2782#page-4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-4">5.1. 
     Choose an endpoint from a group </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2" style="display:none">Info about the 'superdomain match' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">5.2. 
     Send reports </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-origin-trustworthy">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy">https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-origin-trustworthy" class="dfn-panel" data-for="term-for-is-origin-trustworthy" id="infopanel-for-term-for-is-origin-trustworthy" role="menu">
+   <span id="infopaneltitle-for-term-for-is-origin-trustworthy" style="display:none">Info about the 'potentially trustworthy' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy">https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-origin-trustworthy">3.1.5. The endpoints.url member</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-url-string">
-   <a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-url-string" class="dfn-panel" data-for="term-for-absolute-url-string" id="infopanel-for-term-for-absolute-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-url-string" style="display:none">Info about the 'absolute-url string' external reference.</span><a href="https://url.spec.whatwg.org/#absolute-url-string">https://url.spec.whatwg.org/#absolute-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-string">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-base-url">
-   <a href="https://url.spec.whatwg.org/#concept-base-url">https://url.spec.whatwg.org/#concept-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-base-url" class="dfn-panel" data-for="term-for-concept-base-url" id="infopanel-for-term-for-concept-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-base-url">https://url.spec.whatwg.org/#concept-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-base-url">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-domain">
-   <a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-domain" class="dfn-panel" data-for="term-for-concept-domain" id="infopanel-for-term-for-concept-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain">5.2. 
     Send reports </a> <a href="#ref-for-concept-domain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-path-absolute-url-string">
-   <a href="https://url.spec.whatwg.org/#path-absolute-url-string">https://url.spec.whatwg.org/#path-absolute-url-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-path-absolute-url-string" class="dfn-panel" data-for="term-for-path-absolute-url-string" id="infopanel-for-term-for-path-absolute-url-string" role="menu">
+   <span id="infopaneltitle-for-term-for-path-absolute-url-string" style="display:none">Info about the 'path-absolute-url string' external reference.</span><a href="https://url.spec.whatwg.org/#path-absolute-url-string">https://url.spec.whatwg.org/#path-absolute-url-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-absolute-url-string">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.2. 
     Process origin policy configuration </a>
@@ -1612,8 +1612,8 @@ Content-Type: application/reports+json
    <div class="issue"> Consider mitigations. For example, we could
   drop reports if we change from one network to another. <a href="https://github.com/w3c/BackgroundSync/issues/107">[Issue #w3c/BackgroundSync#107]</a> <a class="issue-return" href="#issue-acba119f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="endpoint-group">
-   <b><a href="#endpoint-group">#endpoint-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-endpoint-group" class="dfn-panel" data-for="endpoint-group" id="infopanel-for-endpoint-group" role="dialog">
+   <span id="infopaneltitle-for-endpoint-group" style="display:none">Info about the 'endpoint group' definition.</span><b><a href="#endpoint-group">#endpoint-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint-group">2.1. Endpoint groups</a> <a href="#ref-for-endpoint-group①">(2)</a> <a href="#ref-for-endpoint-group②">(3)</a> <a href="#ref-for-endpoint-group③">(4)</a> <a href="#ref-for-endpoint-group④">(5)</a> <a href="#ref-for-endpoint-group⑤">(6)</a>
     <li><a href="#ref-for-endpoint-group⑥">2.3. Clients</a>
@@ -1635,8 +1635,8 @@ Content-Type: application/reports+json
     <li><a href="#ref-for-endpoint-group②⑥">6.2. Garbage Collection</a> <a href="#ref-for-endpoint-group②⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endpoint-group-name">
-   <b><a href="#dom-endpoint-group-name">#dom-endpoint-group-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endpoint-group-name" class="dfn-panel" data-for="dom-endpoint-group-name" id="infopanel-for-dom-endpoint-group-name" role="dialog">
+   <span id="infopaneltitle-for-dom-endpoint-group-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-endpoint-group-name">#dom-endpoint-group-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-group-name">2.3. Clients</a>
     <li><a href="#ref-for-dom-endpoint-group-name①">3.1.1. The group member</a> <a href="#ref-for-dom-endpoint-group-name②">(2)</a>
@@ -1646,8 +1646,8 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-dom-endpoint-group-name⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endpoint-group-endpoints">
-   <b><a href="#dom-endpoint-group-endpoints">#dom-endpoint-group-endpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endpoint-group-endpoints" class="dfn-panel" data-for="dom-endpoint-group-endpoints" id="infopanel-for-dom-endpoint-group-endpoints" role="dialog">
+   <span id="infopaneltitle-for-dom-endpoint-group-endpoints" style="display:none">Info about the 'endpoints' definition.</span><b><a href="#dom-endpoint-group-endpoints">#dom-endpoint-group-endpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-group-endpoints">3.2. 
     Process origin policy configuration </a>
@@ -1655,8 +1655,8 @@ Content-Type: application/reports+json
     Choose an endpoint from a group </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endpoint-group-subdomains">
-   <b><a href="#dom-endpoint-group-subdomains">#dom-endpoint-group-subdomains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endpoint-group-subdomains" class="dfn-panel" data-for="dom-endpoint-group-subdomains" id="infopanel-for-dom-endpoint-group-subdomains" role="dialog">
+   <span id="infopaneltitle-for-dom-endpoint-group-subdomains" style="display:none">Info about the 'subdomains' definition.</span><b><a href="#dom-endpoint-group-subdomains">#dom-endpoint-group-subdomains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-group-subdomains">3.2. 
     Process origin policy configuration </a>
@@ -1664,30 +1664,30 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-dom-endpoint-group-subdomains②">(2)</a> <a href="#ref-for-dom-endpoint-group-subdomains③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endpoint-group-ttl">
-   <b><a href="#dom-endpoint-group-ttl">#dom-endpoint-group-ttl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endpoint-group-ttl" class="dfn-panel" data-for="dom-endpoint-group-ttl" id="infopanel-for-dom-endpoint-group-ttl" role="dialog">
+   <span id="infopaneltitle-for-dom-endpoint-group-ttl" style="display:none">Info about the 'ttl' definition.</span><b><a href="#dom-endpoint-group-ttl">#dom-endpoint-group-ttl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-group-ttl">2.1. Endpoint groups</a>
     <li><a href="#ref-for-dom-endpoint-group-ttl①">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-endpoint-group-creation">
-   <b><a href="#dom-endpoint-group-creation">#dom-endpoint-group-creation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-endpoint-group-creation" class="dfn-panel" data-for="dom-endpoint-group-creation" id="infopanel-for-dom-endpoint-group-creation" role="dialog">
+   <span id="infopaneltitle-for-dom-endpoint-group-creation" style="display:none">Info about the 'creation' definition.</span><b><a href="#dom-endpoint-group-creation">#dom-endpoint-group-creation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-endpoint-group-creation">2.1. Endpoint groups</a>
     <li><a href="#ref-for-dom-endpoint-group-creation①">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="endpoint-group-expired">
-   <b><a href="#endpoint-group-expired">#endpoint-group-expired</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-endpoint-group-expired" class="dfn-panel" data-for="endpoint-group-expired" id="infopanel-for-endpoint-group-expired" role="dialog">
+   <span id="infopaneltitle-for-endpoint-group-expired" style="display:none">Info about the 'expired' definition.</span><b><a href="#endpoint-group-expired">#endpoint-group-expired</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-endpoint-group-expired">6.2. Garbage Collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network-reporting-endpoint">
-   <b><a href="#network-reporting-endpoint">#network-reporting-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network-reporting-endpoint" class="dfn-panel" data-for="network-reporting-endpoint" id="infopanel-for-network-reporting-endpoint" role="dialog">
+   <span id="infopaneltitle-for-network-reporting-endpoint" style="display:none">Info about the 'network reporting endpoint' definition.</span><b><a href="#network-reporting-endpoint">#network-reporting-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network-reporting-endpoint">2.1. Endpoint groups</a> <a href="#ref-for-network-reporting-endpoint①">(2)</a>
     <li><a href="#ref-for-network-reporting-endpoint②">2.2. Network reporting endpoints</a> <a href="#ref-for-network-reporting-endpoint③">(2)</a> <a href="#ref-for-network-reporting-endpoint④">(3)</a> <a href="#ref-for-network-reporting-endpoint⑤">(4)</a>
@@ -1698,8 +1698,8 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-network-reporting-endpoint①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-network-reporting-endpoint-priority">
-   <b><a href="#dom-network-reporting-endpoint-priority">#dom-network-reporting-endpoint-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-network-reporting-endpoint-priority" class="dfn-panel" data-for="dom-network-reporting-endpoint-priority" id="infopanel-for-dom-network-reporting-endpoint-priority" role="dialog">
+   <span id="infopaneltitle-for-dom-network-reporting-endpoint-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#dom-network-reporting-endpoint-priority">#dom-network-reporting-endpoint-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-network-reporting-endpoint-priority">2.4. Failover and load balancing</a> <a href="#ref-for-dom-network-reporting-endpoint-priority①">(2)</a> <a href="#ref-for-dom-network-reporting-endpoint-priority②">(3)</a> <a href="#ref-for-dom-network-reporting-endpoint-priority③">(4)</a>
     <li><a href="#ref-for-dom-network-reporting-endpoint-priority④">3.2. 
@@ -1708,8 +1708,8 @@ Content-Type: application/reports+json
     Choose an endpoint from a group </a> <a href="#ref-for-dom-network-reporting-endpoint-priority⑥">(2)</a> <a href="#ref-for-dom-network-reporting-endpoint-priority⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-network-reporting-endpoint-weight">
-   <b><a href="#dom-network-reporting-endpoint-weight">#dom-network-reporting-endpoint-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-network-reporting-endpoint-weight" class="dfn-panel" data-for="dom-network-reporting-endpoint-weight" id="infopanel-for-dom-network-reporting-endpoint-weight" role="dialog">
+   <span id="infopaneltitle-for-dom-network-reporting-endpoint-weight" style="display:none">Info about the 'weight' definition.</span><b><a href="#dom-network-reporting-endpoint-weight">#dom-network-reporting-endpoint-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-network-reporting-endpoint-weight">2.4. Failover and load balancing</a> <a href="#ref-for-dom-network-reporting-endpoint-weight①">(2)</a>
     <li><a href="#ref-for-dom-network-reporting-endpoint-weight②">3.2. 
@@ -1718,8 +1718,8 @@ Content-Type: application/reports+json
     Choose an endpoint from a group </a> <a href="#ref-for-dom-network-reporting-endpoint-weight④">(2)</a> <a href="#ref-for-dom-network-reporting-endpoint-weight⑤">(3)</a> <a href="#ref-for-dom-network-reporting-endpoint-weight⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-network-reporting-endpoint-retry_after">
-   <b><a href="#dom-network-reporting-endpoint-retry_after">#dom-network-reporting-endpoint-retry_after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-network-reporting-endpoint-retry_after" class="dfn-panel" data-for="dom-network-reporting-endpoint-retry_after" id="infopanel-for-dom-network-reporting-endpoint-retry_after" role="dialog">
+   <span id="infopaneltitle-for-dom-network-reporting-endpoint-retry_after" style="display:none">Info about the 'retry_after' definition.</span><b><a href="#dom-network-reporting-endpoint-retry_after">#dom-network-reporting-endpoint-retry_after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-network-reporting-endpoint-retry_after">2.2. Network reporting endpoints</a>
     <li><a href="#ref-for-dom-network-reporting-endpoint-retry_after①">3.2. 
@@ -1728,15 +1728,15 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-dom-network-reporting-endpoint-retry_after③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network-reporting-endpoint-pending">
-   <b><a href="#network-reporting-endpoint-pending">#network-reporting-endpoint-pending</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network-reporting-endpoint-pending" class="dfn-panel" data-for="network-reporting-endpoint-pending" id="infopanel-for-network-reporting-endpoint-pending" role="dialog">
+   <span id="infopaneltitle-for-network-reporting-endpoint-pending" style="display:none">Info about the 'pending' definition.</span><b><a href="#network-reporting-endpoint-pending">#network-reporting-endpoint-pending</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network-reporting-endpoint-pending">5.1. 
     Choose an endpoint from a group </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client">
-   <b><a href="#client">#client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client" class="dfn-panel" data-for="client" id="infopanel-for-client" role="dialog">
+   <span id="infopaneltitle-for-client" style="display:none">Info about the 'client' definition.</span><b><a href="#client">#client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">2.3. Clients</a> <a href="#ref-for-client①">(2)</a>
     <li><a href="#ref-for-client②">2.5. Storage</a> <a href="#ref-for-client③">(2)</a>
@@ -1744,15 +1744,15 @@ Content-Type: application/reports+json
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-origin">
-   <b><a href="#dom-client-origin">#dom-client-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-origin" class="dfn-panel" data-for="dom-client-origin" id="infopanel-for-dom-client-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-client-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-client-origin">#dom-client-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-origin">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-client-endpoint-groups">
-   <b><a href="#dom-client-endpoint-groups">#dom-client-endpoint-groups</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-client-endpoint-groups" class="dfn-panel" data-for="dom-client-endpoint-groups" id="infopanel-for-dom-client-endpoint-groups" role="dialog">
+   <span id="infopaneltitle-for-dom-client-endpoint-groups" style="display:none">Info about the 'endpoint-groups' definition.</span><b><a href="#dom-client-endpoint-groups">#dom-client-endpoint-groups</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-client-endpoint-groups">3.2. 
     Process origin policy configuration </a>
@@ -1760,14 +1760,14 @@ Content-Type: application/reports+json
     Send reports </a> <a href="#ref-for-dom-client-endpoint-groups②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="failover-class">
-   <b><a href="#failover-class">#failover-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-failover-class" class="dfn-panel" data-for="failover-class" id="infopanel-for-failover-class" role="dialog">
+   <span id="infopaneltitle-for-failover-class" style="display:none">Info about the 'failover class' definition.</span><b><a href="#failover-class">#failover-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-failover-class">2.4. Failover and load balancing</a> <a href="#ref-for-failover-class①">(2)</a> <a href="#ref-for-failover-class②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reporting-cache">
-   <b><a href="#reporting-cache">#reporting-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reporting-cache" class="dfn-panel" data-for="reporting-cache" id="infopanel-for-reporting-cache" role="dialog">
+   <span id="infopaneltitle-for-reporting-cache" style="display:none">Info about the 'reporting cache' definition.</span><b><a href="#reporting-cache">#reporting-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reporting-cache">3.1.3. The max_age member</a>
     <li><a href="#ref-for-reporting-cache①">3.2. 
@@ -1779,61 +1779,61 @@ Content-Type: application/reports+json
     <li><a href="#ref-for-reporting-cache①②">9.5. Clearing the reporting cache</a> <a href="#ref-for-reporting-cache①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints">
-   <b><a href="#network_reporting_endpoints">#network_reporting_endpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints" class="dfn-panel" data-for="network_reporting_endpoints" id="infopanel-for-network_reporting_endpoints" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints" style="display:none">Info about the 'network_reporting_endpoints' definition.</span><b><a href="#network_reporting_endpoints">#network_reporting_endpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints">1.2. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-group">
-   <b><a href="#network_reporting_endpoints-group">#network_reporting_endpoints-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-group" class="dfn-panel" data-for="network_reporting_endpoints-group" id="infopanel-for-network_reporting_endpoints-group" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-group" style="display:none">Info about the 'group' definition.</span><b><a href="#network_reporting_endpoints-group">#network_reporting_endpoints-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-group">1.2. Examples</a>
     <li><a href="#ref-for-network_reporting_endpoints-group①">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-include_subdomains">
-   <b><a href="#network_reporting_endpoints-include_subdomains">#network_reporting_endpoints-include_subdomains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-include_subdomains" class="dfn-panel" data-for="network_reporting_endpoints-include_subdomains" id="infopanel-for-network_reporting_endpoints-include_subdomains" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-include_subdomains" style="display:none">Info about the 'include_subdomains' definition.</span><b><a href="#network_reporting_endpoints-include_subdomains">#network_reporting_endpoints-include_subdomains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-include_subdomains">3.2. 
     Process origin policy configuration </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-max_age">
-   <b><a href="#network_reporting_endpoints-max_age">#network_reporting_endpoints-max_age</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-max_age" class="dfn-panel" data-for="network_reporting_endpoints-max_age" id="infopanel-for-network_reporting_endpoints-max_age" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-max_age" style="display:none">Info about the 'max_age' definition.</span><b><a href="#network_reporting_endpoints-max_age">#network_reporting_endpoints-max_age</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-max_age">1.2. Examples</a>
     <li><a href="#ref-for-network_reporting_endpoints-max_age①">3.2. 
     Process origin policy configuration </a> <a href="#ref-for-network_reporting_endpoints-max_age②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-endpoints">
-   <b><a href="#network_reporting_endpoints-endpoints">#network_reporting_endpoints-endpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-endpoints" class="dfn-panel" data-for="network_reporting_endpoints-endpoints" id="infopanel-for-network_reporting_endpoints-endpoints" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-endpoints" style="display:none">Info about the 'endpoints' definition.</span><b><a href="#network_reporting_endpoints-endpoints">#network_reporting_endpoints-endpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-endpoints">1.2. Examples</a>
     <li><a href="#ref-for-network_reporting_endpoints-endpoints①">3.2. 
     Process origin policy configuration </a> <a href="#ref-for-network_reporting_endpoints-endpoints②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-url">
-   <b><a href="#network_reporting_endpoints-url">#network_reporting_endpoints-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-url" class="dfn-panel" data-for="network_reporting_endpoints-url" id="infopanel-for-network_reporting_endpoints-url" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-url" style="display:none">Info about the 'url' definition.</span><b><a href="#network_reporting_endpoints-url">#network_reporting_endpoints-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-url">1.2. Examples</a> <a href="#ref-for-network_reporting_endpoints-url①">(2)</a>
     <li><a href="#ref-for-network_reporting_endpoints-url②">3.2. 
     Process origin policy configuration </a> <a href="#ref-for-network_reporting_endpoints-url③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-priority">
-   <b><a href="#network_reporting_endpoints-priority">#network_reporting_endpoints-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-priority" class="dfn-panel" data-for="network_reporting_endpoints-priority" id="infopanel-for-network_reporting_endpoints-priority" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#network_reporting_endpoints-priority">#network_reporting_endpoints-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-priority">1.2. Examples</a> <a href="#ref-for-network_reporting_endpoints-priority①">(2)</a>
     <li><a href="#ref-for-network_reporting_endpoints-priority②">3.2. 
     Process origin policy configuration </a> <a href="#ref-for-network_reporting_endpoints-priority③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network_reporting_endpoints-weight">
-   <b><a href="#network_reporting_endpoints-weight">#network_reporting_endpoints-weight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network_reporting_endpoints-weight" class="dfn-panel" data-for="network_reporting_endpoints-weight" id="infopanel-for-network_reporting_endpoints-weight" role="dialog">
+   <span id="infopaneltitle-for-network_reporting_endpoints-weight" style="display:none">Info about the 'weight' definition.</span><b><a href="#network_reporting_endpoints-weight">#network_reporting_endpoints-weight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network_reporting_endpoints-weight">3.2. 
     Process origin policy configuration </a> <a href="#ref-for-network_reporting_endpoints-weight①">(2)</a>
@@ -1841,59 +1841,115 @@ Content-Type: application/reports+json
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/sensors/index.html
+++ b/tests/github/w3c/sensors/index.html
@@ -2968,69 +2968,69 @@ for their editorial input.</p>
    <li><a href="#update-latest-reading">Update latest reading</a><span>, in § 8.7</span>
    <li><a href="#update-mock-sensor-reading">update mock sensor reading</a><span>, in § 9.2.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
-   <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer-interface" class="dfn-panel" data-for="term-for-accelerometer-interface" id="infopanel-for-term-for-accelerometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer-interface" style="display:none">Info about the 'accelerometer' external reference.</span><a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
-   <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravitysensor-interface" class="dfn-panel" data-for="term-for-gravitysensor-interface" id="infopanel-for-term-for-gravitysensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gravitysensor-interface" style="display:none">Info about the 'gravitysensor' external reference.</span><a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
-   <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linearaccelerationsensor-interface" class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface" id="infopanel-for-term-for-linearaccelerationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-linearaccelerationsensor-interface" style="display:none">Info about the 'linearaccelerationsensor' external reference.</span><a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ambient-light-sensor-interface">
-   <a href="https://w3c.github.io/ambient-light#ambient-light-sensor-interface">https://w3c.github.io/ambient-light#ambient-light-sensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ambient-light-sensor-interface" class="dfn-panel" data-for="term-for-ambient-light-sensor-interface" id="infopanel-for-term-for-ambient-light-sensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-ambient-light-sensor-interface" style="display:none">Info about the 'ambientlightsensor' external reference.</span><a href="https://w3c.github.io/ambient-light#ambient-light-sensor-interface">https://w3c.github.io/ambient-light#ambient-light-sensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ambient-light-sensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">7.2. The SensorErrorEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">7.2. The SensorErrorEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">7.1. The Sensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4.2.2. Permissions Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org#concept-event">https://dom.spec.whatwg.org#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org#concept-event">https://dom.spec.whatwg.org#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">7.1. The Sensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org#concept-event-listener">https://dom.spec.whatwg.org#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org#concept-event-listener">https://dom.spec.whatwg.org#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-concept-event-listener①">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-concept-event-fire①">8.11. Notify new reading</a>
@@ -3038,34 +3038,34 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-event-fire③">8.13. Notify error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-geolocationsensor-interface">
-   <a href="https://w3c.github.io/geolocation-sensor/#geolocationsensor-interface">https://w3c.github.io/geolocation-sensor/#geolocationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-geolocationsensor-interface" class="dfn-panel" data-for="term-for-geolocationsensor-interface" id="infopanel-for-term-for-geolocationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-geolocationsensor-interface" style="display:none">Info about the 'geolocationsensor' external reference.</span><a href="https://w3c.github.io/geolocation-sensor/#geolocationsensor-interface">https://w3c.github.io/geolocation-sensor/#geolocationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-geolocationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
-   <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope-interface" class="dfn-panel" data-for="term-for-gyroscope-interface" id="infopanel-for-term-for-gyroscope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope-interface" style="display:none">Info about the 'gyroscope' external reference.</span><a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp">https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">7.1. The Sensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-time-origin">
-   <a href="https://www.w3.org/TR/hr-time-2/#dfn-time-origin">https://www.w3.org/TR/hr-time-2/#dfn-time-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-time-origin" class="dfn-panel" data-for="term-for-dfn-time-origin" id="infopanel-for-term-for-dfn-time-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-time-origin" style="display:none">Info about the 'time origin' external reference.</span><a href="https://www.w3.org/TR/hr-time-2/#dfn-time-origin">https://www.w3.org/TR/hr-time-2/#dfn-time-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-time-origin">6.2. Sensor</a>
     <li><a href="#ref-for-dfn-time-origin①">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-dfn-time-origin②">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">7.1. The Sensor Interface</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a>
     <li><a href="#ref-for-eventhandler③">7.1.9. Sensor.onreading</a>
@@ -3073,8 +3073,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-eventhandler⑤">7.1.11. Sensor.onerror</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">4.2.3. Focused Area</a>
     <li><a href="#ref-for-nav-document①">4.2.4. Visibility State</a>
@@ -3084,56 +3084,56 @@ for their editorial input.</p>
     <li><a href="#ref-for-nav-document⑦">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-allow">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-allow" class="dfn-panel" data-for="term-for-attr-iframe-allow" id="infopanel-for-term-for-attr-iframe-allow" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-allow" style="display:none">Info about the 'allow' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-allow">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">4.2.2. Permissions Policy</a>
     <li><a href="#ref-for-allowed-to-use①">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-allowed-to-use②">8.2. Check sensor policy-controlled features</a> <a href="#ref-for-allowed-to-use③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4.2.3. Focused Area</a>
     <li><a href="#ref-for-browsing-context①">6.2. Sensor</a> <a href="#ref-for-browsing-context②">(2)</a> <a href="#ref-for-browsing-context③">(3)</a> <a href="#ref-for-browsing-context④">(4)</a> <a href="#ref-for-browsing-context⑤">(5)</a> <a href="#ref-for-browsing-context⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" class="dfn-panel" data-for="term-for-currently-focused-area-of-a-top-level-browsing-context" id="infopanel-for-term-for-currently-focused-area-of-a-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-currently-focused-area-of-a-top-level-browsing-context" style="display:none">Info about the 'currently focused area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context">https://html.spec.whatwg.org/multipage/interaction.html#currently-focused-area-of-a-top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context">4.2.3. Focused Area</a>
     <li><a href="#ref-for-currently-focused-area-of-a-top-level-browsing-context①">5.6. Conditions to expose sensor readings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-event-handlers①">7.1.12. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-event-handler-event-type①">7.1.12. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gains-focus">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#gains-focus">https://html.spec.whatwg.org/multipage/interaction.html#gains-focus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gains-focus" class="dfn-panel" data-for="term-for-gains-focus" id="infopanel-for-term-for-gains-focus" role="menu">
+   <span id="infopaneltitle-for-term-for-gains-focus" style="display:none">Info about the 'gains focus' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#gains-focus">https://html.spec.whatwg.org/multipage/interaction.html#gains-focus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gains-focus">4.2.3. Focused Area</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">7.1.7. Sensor.start()</a>
     <li><a href="#ref-for-in-parallel①">7.1.8. Sensor.stop()</a>
@@ -3142,60 +3142,60 @@ for their editorial input.</p>
     <li><a href="#ref-for-in-parallel④">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-2">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#origin-2">https://html.spec.whatwg.org/multipage/origin.html#origin-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-2" class="dfn-panel" data-for="term-for-origin-2" id="infopanel-for-term-for-origin-2" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-2" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#origin-2">https://html.spec.whatwg.org/multipage/origin.html#origin-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-2">6.2. Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">4.2.3. Focused Area</a>
     <li><a href="#ref-for-same-origin-domain①">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-same-origin-domain②">6.2. Sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">4.2.1. Secure Context</a>
     <li><a href="#ref-for-secure-context①">5.6. Conditions to expose sensor readings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-spin-the-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-spin-the-event-loop" class="dfn-panel" data-for="term-for-spin-the-event-loop" id="infopanel-for-term-for-spin-the-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-spin-the-event-loop" style="display:none">Info about the 'spin the event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#spin-the-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spin-the-event-loop">8.10. Report latest reading updated</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-concept-task①">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">7.1. The Sensor Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">8.4. Activate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">6.1. Sensor Type</a>
     <li><a href="#ref-for-list-contain①">8.1. Initialize a sensor object</a>
@@ -3204,15 +3204,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-list-contain④">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-entry">
-   <a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-entry" class="dfn-panel" data-for="term-for-map-entry" id="infopanel-for-term-for-map-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-map-entry" style="display:none">Info about the 'entry' external reference.</span><a href="https://infra.spec.whatwg.org/#map-entry">https://infra.spec.whatwg.org/#map-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">6.2. Sensor</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a> <a href="#ref-for-map-entry③">(4)</a>
     <li><a href="#ref-for-map-entry④">9.1. Mock Sensors</a> <a href="#ref-for-map-entry⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">6.1. Sensor Type</a>
     <li><a href="#ref-for-list-iterate①">8.2. Check sensor policy-controlled features</a>
@@ -3221,8 +3221,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-list-iterate④">8.15. Request sensor access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">8.1. Initialize a sensor object</a>
     <li><a href="#ref-for-map-iterate①">8.7. Set sensor settings</a>
@@ -3230,37 +3230,37 @@ for their editorial input.</p>
     <li><a href="#ref-for-map-iterate③">9.2.3. Update mock sensor reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">6.1. Sensor Type</a> <a href="#ref-for-list-is-empty①">(2)</a>
     <li><a href="#ref-for-list-is-empty②">6.2. Sensor</a> <a href="#ref-for-list-is-empty③">(2)</a>
     <li><a href="#ref-for-list-is-empty④">8.7. Set sensor settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">6.2. Sensor</a>
     <li><a href="#ref-for-map-key①">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">6.2. Sensor</a>
     <li><a href="#ref-for-map-getting-the-keys①">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">6.2. Sensor</a> <a href="#ref-for-ordered-map①">(2)</a> <a href="#ref-for-ordered-map②">(3)</a> <a href="#ref-for-ordered-map③">(4)</a> <a href="#ref-for-ordered-map④">(5)</a> <a href="#ref-for-ordered-map⑤">(6)</a>
     <li><a href="#ref-for-ordered-map⑥">9.1. Mock Sensors</a> <a href="#ref-for-ordered-map⑦">(2)</a> <a href="#ref-for-ordered-map⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-ordered-set①">6.1. Sensor Type</a> <a href="#ref-for-ordered-set②">(2)</a> <a href="#ref-for-ordered-set③">(3)</a> <a href="#ref-for-ordered-set④">(4)</a>
@@ -3272,77 +3272,77 @@ for their editorial input.</p>
     <li><a href="#ref-for-ordered-set①②">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">8.7. Set sensor settings</a>
     <li><a href="#ref-for-map-set①">8.8. Update latest reading</a>
     <li><a href="#ref-for-map-set②">9.2.3. Update mock sensor reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">6.2. Sensor</a> <a href="#ref-for-map-value①">(2)</a>
     <li><a href="#ref-for-map-value②">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer-interface" class="dfn-panel" data-for="term-for-magnetometer-interface" id="infopanel-for-term-for-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer-interface" style="display:none">Info about the 'magnetometer' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uncalibrated-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface">https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uncalibrated-magnetometer-interface" class="dfn-panel" data-for="term-for-uncalibrated-magnetometer-interface" id="infopanel-for-term-for-uncalibrated-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-uncalibrated-magnetometer-interface" style="display:none">Info about the 'uncalibratedmagnetometer' external reference.</span><a href="https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface">https://w3c.github.io/magnetometer#uncalibrated-magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uncalibrated-magnetometer-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor-interface" class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface" id="infopanel-for-term-for-absoluteorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor-interface" style="display:none">Info about the 'absoluteorientationsensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relativeorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface">https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relativeorientationsensor-interface" class="dfn-panel" data-for="term-for-relativeorientationsensor-interface" id="infopanel-for-term-for-relativeorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-relativeorientationsensor-interface" style="display:none">Info about the 'relativeorientationsensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface">https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relativeorientationsensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-visibilitystate">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-visibilitystate" class="dfn-panel" data-for="term-for-dom-visibilitystate" id="infopanel-for-term-for-dom-visibilitystate" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-visibilitystate" style="display:none">Info about the 'document visibility state' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate">https://www.w3.org/TR/page-visibility-2/#dom-visibilitystate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilitystate">5.6. Conditions to expose sensor readings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-steps-to-determine-the-visibility-state">
-   <a href="https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state">https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-steps-to-determine-the-visibility-state" class="dfn-panel" data-for="term-for-dfn-steps-to-determine-the-visibility-state" id="infopanel-for-term-for-dfn-steps-to-determine-the-visibility-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-steps-to-determine-the-visibility-state" style="display:none">Info about the 'steps to determine the visibility state' external reference.</span><a href="https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state">https://www.w3.org/TR/page-visibility-2/#dfn-steps-to-determine-the-visibility-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-steps-to-determine-the-visibility-state">4.2.4. Visibility State</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissiondescriptor">
-   <a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissiondescriptor" class="dfn-panel" data-for="term-for-dom-permissiondescriptor" id="infopanel-for-term-for-dom-permissiondescriptor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissiondescriptor" style="display:none">Info about the 'PermissionDescriptor' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissiondescriptor">https://w3c.github.io/permissions/#dom-permissiondescriptor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissiondescriptor">10.8. Extending the Permission API</a> <a href="#ref-for-dom-permissiondescriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-permissionname">
-   <a href="https://www.w3.org/TR/permissions/#enumdef-permissionname">https://www.w3.org/TR/permissions/#enumdef-permissionname</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-permissionname" class="dfn-panel" data-for="term-for-enumdef-permissionname" id="infopanel-for-term-for-enumdef-permissionname" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-permissionname" style="display:none">Info about the 'permission name' external reference.</span><a href="https://www.w3.org/TR/permissions/#enumdef-permissionname">https://www.w3.org/TR/permissions/#enumdef-permissionname</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-permissionname">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-enumdef-permissionname①">6.1. Sensor Type</a> <a href="#ref-for-enumdef-permissionname②">(2)</a>
@@ -3350,34 +3350,34 @@ for their editorial input.</p>
     <li><a href="#ref-for-enumdef-permissionname⑤">10.8. Extending the Permission API</a> <a href="#ref-for-enumdef-permissionname⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm" id="infopanel-for-term-for-dfn-permission-revocation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" style="display:none">Info about the 'permission revocation algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-revocation-algorithm">6.1. Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-state">
-   <a href="https://www.w3.org/TR/permissions/#permission-state">https://www.w3.org/TR/permissions/#permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-state" class="dfn-panel" data-for="term-for-permission-state" id="infopanel-for-term-for-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://www.w3.org/TR/permissions/#permission-state">https://www.w3.org/TR/permissions/#permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-state">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-permission-state①">8.15. Request sensor access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'request permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">8.15. Request sensor access</a>
     <li><a href="#ref-for-dfn-request-permission-to-use①">10.8. Extending the Permission API</a> <a href="#ref-for-dfn-request-permission-to-use②">(2)</a> <a href="#ref-for-dfn-request-permission-to-use③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-default-allowlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">4.2.2. Permissions Policy</a>
     <li><a href="#ref-for-policy-controlled-feature①">5.6. Conditions to expose sensor readings</a>
@@ -3386,27 +3386,27 @@ for their editorial input.</p>
     <li><a href="#ref-for-policy-controlled-feature④">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-policy-controlled-feature⑤">(2)</a> <a href="#ref-for-policy-controlled-feature⑥">(3)</a> <a href="#ref-for-policy-controlled-feature⑦">(4)</a> <a href="#ref-for-policy-controlled-feature⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permission-request-algorithm">
-   <a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permission-request-algorithm" class="dfn-panel" data-for="term-for-permission-request-algorithm" id="infopanel-for-term-for-permission-request-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-permission-request-algorithm" style="display:none">Info about the 'permission request algorithm' external reference.</span><a href="https://wicg.github.io/permissions-request/#permission-request-algorithm">https://wicg.github.io/permissions-request/#permission-request-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission-request-algorithm">Unnumbered Section</a>
     <li><a href="#ref-for-permission-request-algorithm①">6.1. Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-proximity-sensor-interface">
-   <a href="https://w3c.github.io/proximity#proximity-sensor-interface">https://w3c.github.io/proximity#proximity-sensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-proximity-sensor-interface" class="dfn-panel" data-for="term-for-proximity-sensor-interface" id="infopanel-for-term-for-proximity-sensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-proximity-sensor-interface" style="display:none">Info about the 'proximitysensor' external reference.</span><a href="https://w3c.github.io/proximity#proximity-sensor-interface">https://w3c.github.io/proximity#proximity-sensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proximity-sensor-interface">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sop-violations">
-   <a href="https://w3ctag.github.io/security-questionnaire/#sop-violations">https://w3ctag.github.io/security-questionnaire/#sop-violations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sop-violations" class="dfn-panel" data-for="term-for-sop-violations" id="infopanel-for-term-for-sop-violations" role="menu">
+   <span id="infopaneltitle-for-term-for-sop-violations" style="display:none">Info about the 'same-origin policy violations' external reference.</span><a href="https://w3ctag.github.io/security-questionnaire/#sop-violations">https://w3ctag.github.io/security-questionnaire/#sop-violations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sop-violations">10.1. Security and Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-browsing-context">
-   <a href="https://w3c.github.io/webdriver/#dfn-current-browsing-context">https://w3c.github.io/webdriver/#dfn-current-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-browsing-context" class="dfn-panel" data-for="term-for-dfn-current-browsing-context" id="infopanel-for-term-for-dfn-current-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-browsing-context" style="display:none">Info about the 'current browsing context' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-current-browsing-context">https://w3c.github.io/webdriver/#dfn-current-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-browsing-context">9.1. Mock Sensors</a> <a href="#ref-for-dfn-current-browsing-context①">(2)</a>
     <li><a href="#ref-for-dfn-current-browsing-context②">9.1.2. MockSensor dictionary</a>
@@ -3416,8 +3416,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-current-browsing-context①②">9.2.4. Delete mock sensor</a> <a href="#ref-for-dfn-current-browsing-context①③">(2)</a> <a href="#ref-for-dfn-current-browsing-context①④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command-uri-template" class="dfn-panel" data-for="term-for-dfn-extension-command-uri-template" id="infopanel-for-term-for-dfn-extension-command-uri-template" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command-uri-template" style="display:none">Info about the 'extension command uri template' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command-uri-template">https://w3c.github.io/webdriver/#dfn-extension-command-uri-template</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command-uri-template">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-extension-command-uri-template①">9.2.2. Get mock sensor</a>
@@ -3425,8 +3425,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-extension-command-uri-template③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command" class="dfn-panel" data-for="term-for-dfn-extension-command" id="infopanel-for-term-for-dfn-extension-command" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command" style="display:none">Info about the 'extension commands' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command">9. Automation</a> <a href="#ref-for-dfn-extension-command①">(2)</a>
     <li><a href="#ref-for-dfn-extension-command②">9.2.1. Create mock sensor</a>
@@ -3435,8 +3435,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-extension-command⑤">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-handle-any-user-prompts">
-   <a href="https://w3c.github.io/webdriver/#dfn-handle-any-user-prompts">https://w3c.github.io/webdriver/#dfn-handle-any-user-prompts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-handle-any-user-prompts" class="dfn-panel" data-for="term-for-dfn-handle-any-user-prompts" id="infopanel-for-term-for-dfn-handle-any-user-prompts" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-handle-any-user-prompts" style="display:none">Info about the 'handle any user prompts' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-handle-any-user-prompts">https://w3c.github.io/webdriver/#dfn-handle-any-user-prompts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-handle-any-user-prompts">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-handle-any-user-prompts①">9.2.2. Get mock sensor</a>
@@ -3444,14 +3444,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-handle-any-user-prompts③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handling-errors">
-   <a href="https://w3c.github.io/webdriver/#handling-errors">https://w3c.github.io/webdriver/#handling-errors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handling-errors" class="dfn-panel" data-for="term-for-handling-errors" id="infopanel-for-term-for-handling-errors" role="menu">
+   <span id="infopaneltitle-for-term-for-handling-errors" style="display:none">Info about the 'handling errors' external reference.</span><a href="https://w3c.github.io/webdriver/#handling-errors">https://w3c.github.io/webdriver/#handling-errors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handling-errors">9.3. Handling errors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-invalid-argument">
-   <a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-invalid-argument" class="dfn-panel" data-for="term-for-dfn-invalid-argument" id="infopanel-for-term-for-dfn-invalid-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-invalid-argument" style="display:none">Info about the 'invalid argument' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-invalid-argument">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-invalid-argument①">9.2.2. Get mock sensor</a>
@@ -3459,14 +3459,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-invalid-argument④">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-local-end">
-   <a href="https://w3c.github.io/webdriver/#dfn-local-end">https://w3c.github.io/webdriver/#dfn-local-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-local-end" class="dfn-panel" data-for="term-for-dfn-local-end" id="infopanel-for-term-for-dfn-local-end" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-local-end" style="display:none">Info about the 'local end' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-local-end">https://w3c.github.io/webdriver/#dfn-local-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-local-end">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-no-longer-open">
-   <a href="https://w3c.github.io/webdriver/#dfn-no-longer-open">https://w3c.github.io/webdriver/#dfn-no-longer-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-no-longer-open" class="dfn-panel" data-for="term-for-dfn-no-longer-open" id="infopanel-for-term-for-dfn-no-longer-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-no-longer-open" style="display:none">Info about the 'no longer open' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-no-longer-open">https://w3c.github.io/webdriver/#dfn-no-longer-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-no-longer-open">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-no-longer-open①">9.2.2. Get mock sensor</a>
@@ -3474,8 +3474,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-no-longer-open③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-no-such-window">
-   <a href="https://w3c.github.io/webdriver/#dfn-no-such-window">https://w3c.github.io/webdriver/#dfn-no-such-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-no-such-window" class="dfn-panel" data-for="term-for-dfn-no-such-window" id="infopanel-for-term-for-dfn-no-such-window" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-no-such-window" style="display:none">Info about the 'no such window' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-no-such-window">https://w3c.github.io/webdriver/#dfn-no-such-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-no-such-window">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-no-such-window①">9.2.2. Get mock sensor</a>
@@ -3483,14 +3483,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-no-such-window③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-object">
-   <a href="https://w3c.github.io/webdriver/#dfn-object">https://w3c.github.io/webdriver/#dfn-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-object" class="dfn-panel" data-for="term-for-dfn-object" id="infopanel-for-term-for-dfn-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-object" style="display:none">Info about the 'object' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-object">https://w3c.github.io/webdriver/#dfn-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-object">9.1.2. MockSensor dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-remote-end-steps①">9.2.2. Get mock sensor</a>
@@ -3498,14 +3498,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-remote-end-steps③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-session">
-   <a href="https://w3c.github.io/webdriver/#dfn-session">https://w3c.github.io/webdriver/#dfn-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-session" class="dfn-panel" data-for="term-for-dfn-session" id="infopanel-for-term-for-dfn-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-session" style="display:none">Info about the 'session' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-session">https://w3c.github.io/webdriver/#dfn-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-session">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'success' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-success①">9.2.2. Get mock sensor</a>
@@ -3513,16 +3513,16 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-success③">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-url-variables">
-   <a href="https://w3c.github.io/webdriver/#dfn-url-variables">https://w3c.github.io/webdriver/#dfn-url-variables</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-url-variables" class="dfn-panel" data-for="term-for-dfn-url-variables" id="infopanel-for-term-for-dfn-url-variables" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-url-variables" style="display:none">Info about the 'url variable' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-url-variables">https://w3c.github.io/webdriver/#dfn-url-variables</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-url-variables">9.2.2. Get mock sensor</a>
     <li><a href="#ref-for-dfn-url-variables①">9.2.3. Update mock sensor reading</a>
     <li><a href="#ref-for-dfn-url-variables②">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-errors">
-   <a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-errors" class="dfn-panel" data-for="term-for-dfn-errors" id="infopanel-for-term-for-dfn-errors" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-errors" style="display:none">Info about the 'webdriver error' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-errors">9.2.1. Create mock sensor</a> <a href="#ref-for-dfn-errors①">(2)</a> <a href="#ref-for-dfn-errors②">(3)</a> <a href="#ref-for-dfn-errors③">(4)</a> <a href="#ref-for-dfn-errors④">(5)</a>
     <li><a href="#ref-for-dfn-errors⑤">9.2.2. Get mock sensor</a> <a href="#ref-for-dfn-errors⑥">(2)</a> <a href="#ref-for-dfn-errors⑦">(3)</a> <a href="#ref-for-dfn-errors⑧">(4)</a>
@@ -3530,8 +3530,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-errors①④">9.2.4. Delete mock sensor</a> <a href="#ref-for-dfn-errors①⑤">(2)</a> <a href="#ref-for-dfn-errors①⑥">(3)</a> <a href="#ref-for-dfn-errors①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'webdriver error code' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">9.2.1. Create mock sensor</a> <a href="#ref-for-dfn-error-code①">(2)</a> <a href="#ref-for-dfn-error-code②">(3)</a> <a href="#ref-for-dfn-error-code③">(4)</a>
     <li><a href="#ref-for-dfn-error-code④">9.2.2. Get mock sensor</a> <a href="#ref-for-dfn-error-code⑤">(2)</a> <a href="#ref-for-dfn-error-code⑥">(3)</a>
@@ -3540,8 +3540,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-error-code①④">9.3. Handling errors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">7.1.7. Sensor.start()</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">7.2. The SensorErrorEvent Interface</a> <a href="#ref-for-idl-DOMException③">(2)</a>
@@ -3551,98 +3551,98 @@ for their editorial input.</p>
     <li><a href="#ref-for-idl-DOMException⑦">8.13. Notify error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">7.2. The SensorErrorEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-Exposed①">7.2. The SensorErrorEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">7.1.7. Sensor.start()</a>
     <li><a href="#ref-for-notallowederror①">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notreadableerror">
-   <a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notreadableerror" class="dfn-panel" data-for="term-for-notreadableerror" id="infopanel-for-term-for-notreadableerror" role="menu">
+   <span id="infopaneltitle-for-term-for-notreadableerror" style="display:none">Info about the 'NotReadableError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notreadableerror">https://webidl.spec.whatwg.org/#notreadableerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notreadableerror">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">8.1. Initialize a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-SecureContext①">7.2. The SensorErrorEvent Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-attribute">
-   <a href="https://webidl.spec.whatwg.org/#dfn-attribute">https://webidl.spec.whatwg.org/#dfn-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-attribute" class="dfn-panel" data-for="term-for-dfn-attribute" id="infopanel-for-term-for-dfn-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-attribute" style="display:none">Info about the 'attribute' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-attribute">https://webidl.spec.whatwg.org/#dfn-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute">6.2. Sensor</a> <a href="#ref-for-dfn-attribute①">(2)</a> <a href="#ref-for-dfn-attribute②">(3)</a>
     <li><a href="#ref-for-dfn-attribute③">9.1.3. Mock sensor type</a>
     <li><a href="#ref-for-dfn-attribute④">10.6. Definition Requirements</a> <a href="#ref-for-dfn-attribute⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.1. The Sensor Interface</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">9.1.1. MockSensorConfiguration dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">9.2.1. Create mock sensor</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">9.2.2. Get mock sensor</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value②">9.2.3. Update mock sensor reading</a> <a href="#ref-for-dfn-convert-ecmascript-to-idl-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-exception" class="dfn-panel" data-for="term-for-dfn-create-exception" id="infopanel-for-term-for-dfn-create-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-exception" style="display:none">Info about the 'created' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-exception">https://webidl.spec.whatwg.org/#dfn-create-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-exception">7.1.7. Sensor.start()</a> <a href="#ref-for-dfn-create-exception①">(2)</a>
     <li><a href="#ref-for-dfn-create-exception②">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary">
-   <a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary" class="dfn-panel" data-for="term-for-dfn-dictionary" id="infopanel-for-term-for-dfn-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary" style="display:none">Info about the 'dictionary' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary">8.1. Initialize a sensor object</a>
     <li><a href="#ref-for-dfn-dictionary①">10.6. Definition Requirements</a> <a href="#ref-for-dfn-dictionary②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary-member">
-   <a href="https://webidl.spec.whatwg.org/#dfn-dictionary-member">https://webidl.spec.whatwg.org/#dfn-dictionary-member</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary-member" class="dfn-panel" data-for="term-for-dfn-dictionary-member" id="infopanel-for-term-for-dfn-dictionary-member" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary-member" style="display:none">Info about the 'dictionary members' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-dictionary-member">https://webidl.spec.whatwg.org/#dfn-dictionary-member</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary-member">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">7.1. The Sensor Interface</a>
     <li><a href="#ref-for-idl-double①">9.1.1. MockSensorConfiguration dictionary</a> <a href="#ref-for-idl-double②">(2)</a>
     <li><a href="#ref-for-idl-double③">9.1.2. MockSensor dictionary</a> <a href="#ref-for-idl-double④">(2)</a> <a href="#ref-for-idl-double⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">6.2. Sensor</a> <a href="#ref-for-dfn-identifier①">(2)</a>
     <li><a href="#ref-for-dfn-identifier②">9.1. Mock Sensors</a>
@@ -3650,38 +3650,38 @@ for their editorial input.</p>
     <li><a href="#ref-for-dfn-identifier④">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherited-dictionaries">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherited-dictionaries">https://webidl.spec.whatwg.org/#dfn-inherited-dictionaries</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherited-dictionaries" class="dfn-panel" data-for="term-for-dfn-inherited-dictionaries" id="infopanel-for-term-for-dfn-inherited-dictionaries" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherited-dictionaries" style="display:none">Info about the 'inherited dictionaries' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherited-dictionaries">https://webidl.spec.whatwg.org/#dfn-inherited-dictionaries</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-dictionaries">10.6. Definition Requirements</a> <a href="#ref-for-dfn-inherited-dictionaries①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherited-interfaces">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherited-interfaces" class="dfn-panel" data-for="term-for-dfn-inherited-interfaces" id="infopanel-for-term-for-dfn-inherited-interfaces" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherited-interfaces" style="display:none">Info about the 'inherited interfaces' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-interfaces">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface" class="dfn-panel" data-for="term-for-dfn-interface" id="infopanel-for-term-for-dfn-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface" style="display:none">Info about the 'interface' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface">https://webidl.spec.whatwg.org/#dfn-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-read-only">
-   <a href="https://webidl.spec.whatwg.org/#dfn-read-only">https://webidl.spec.whatwg.org/#dfn-read-only</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-read-only" class="dfn-panel" data-for="term-for-dfn-read-only" id="infopanel-for-term-for-dfn-read-only" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-read-only" style="display:none">Info about the 'read only' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-read-only">https://webidl.spec.whatwg.org/#dfn-read-only</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-read-only">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">8.1. Initialize a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">7.1. The Sensor Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
@@ -3993,33 +3993,33 @@ for their editorial input.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="limit-max-frequency">
-   <b><a href="#limit-max-frequency">#limit-max-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limit-max-frequency" class="dfn-panel" data-for="limit-max-frequency" id="infopanel-for-limit-max-frequency" role="dialog">
+   <span id="infopaneltitle-for-limit-max-frequency" style="display:none">Info about the '4.3.1. Limit maximum sampling frequency' definition.</span><b><a href="#limit-max-frequency">#limit-max-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limit-max-frequency">4.3.1. Limit maximum sampling frequency</a>
     <li><a href="#ref-for-limit-max-frequency">4.3.3. Limit number of delivered readings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stop-sensor">
-   <b><a href="#stop-sensor">#stop-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stop-sensor" class="dfn-panel" data-for="stop-sensor" id="infopanel-for-stop-sensor" role="dialog">
+   <span id="infopaneltitle-for-stop-sensor" style="display:none">Info about the '4.3.2. Stop the sensor altogether' definition.</span><b><a href="#stop-sensor">#stop-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-sensor">4.3.2. Stop the sensor altogether</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="limit-number-of-delivered-readings">
-   <b><a href="#limit-number-of-delivered-readings">#limit-number-of-delivered-readings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-limit-number-of-delivered-readings" class="dfn-panel" data-for="limit-number-of-delivered-readings" id="infopanel-for-limit-number-of-delivered-readings" role="dialog">
+   <span id="infopaneltitle-for-limit-number-of-delivered-readings" style="display:none">Info about the '4.3.3. Limit number of delivered readings' definition.</span><b><a href="#limit-number-of-delivered-readings">#limit-number-of-delivered-readings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-limit-number-of-delivered-readings">4.3.3. Limit number of delivered readings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reduce-accuracy">
-   <b><a href="#reduce-accuracy">#reduce-accuracy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reduce-accuracy" class="dfn-panel" data-for="reduce-accuracy" id="infopanel-for-reduce-accuracy" role="dialog">
+   <span id="infopaneltitle-for-reduce-accuracy" style="display:none">Info about the '4.3.4. Reduce accuracy' definition.</span><b><a href="#reduce-accuracy">#reduce-accuracy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reduce-accuracy">4.3.4. Reduce accuracy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-device-sensor">
-   <b><a href="#concept-device-sensor">#concept-device-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-device-sensor" class="dfn-panel" data-for="concept-device-sensor" id="infopanel-for-concept-device-sensor" role="dialog">
+   <span id="infopaneltitle-for-concept-device-sensor" style="display:none">Info about the 'device sensor' definition.</span><b><a href="#concept-device-sensor">#concept-device-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-device-sensor">2. Scope</a>
     <li><a href="#ref-for-concept-device-sensor①">4. Security and privacy considerations</a> <a href="#ref-for-concept-device-sensor②">(2)</a> <a href="#ref-for-concept-device-sensor③">(3)</a> <a href="#ref-for-concept-device-sensor④">(4)</a>
@@ -4034,8 +4034,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-device-sensor③③">10.10. Example WebIDL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-reading">
-   <b><a href="#sensor-reading">#sensor-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-reading" class="dfn-panel" data-for="sensor-reading" id="infopanel-for-sensor-reading" role="dialog">
+   <span id="infopaneltitle-for-sensor-reading" style="display:none">Info about the 'sensor reading' definition.</span><b><a href="#sensor-reading">#sensor-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-reading">4. Security and privacy considerations</a> <a href="#ref-for-sensor-reading①">(2)</a>
     <li><a href="#ref-for-sensor-reading②">4.1.1. Location Tracking</a>
@@ -4073,36 +4073,36 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-reading⑤⑧">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reading-timestamp">
-   <b><a href="#reading-timestamp">#reading-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reading-timestamp" class="dfn-panel" data-for="reading-timestamp" id="infopanel-for-reading-timestamp" role="dialog">
+   <span id="infopaneltitle-for-reading-timestamp" style="display:none">Info about the 'reading timestamp' definition.</span><b><a href="#reading-timestamp">#reading-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reading-timestamp">4.3.4. Reduce accuracy</a> <a href="#ref-for-reading-timestamp①">(2)</a>
     <li><a href="#ref-for-reading-timestamp②">6.2. Sensor</a> <a href="#ref-for-reading-timestamp③">(2)</a>
     <li><a href="#ref-for-reading-timestamp④">7.1.6. Sensor.timestamp</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-coordinate-system">
-   <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-coordinate-system" class="dfn-panel" data-for="local-coordinate-system" id="infopanel-for-local-coordinate-system" role="dialog">
+   <span id="infopaneltitle-for-local-coordinate-system" style="display:none">Info about the 'local coordinate system' definition.</span><b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-coordinate-system">5.1. Sensors</a> <a href="#ref-for-local-coordinate-system①">(2)</a>
     <li><a href="#ref-for-local-coordinate-system②">8.14. Get value from latest reading</a> <a href="#ref-for-local-coordinate-system③">(2)</a>
     <li><a href="#ref-for-local-coordinate-system④">10. Extensibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="spatial-sensor">
-   <b><a href="#spatial-sensor">#spatial-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-spatial-sensor" class="dfn-panel" data-for="spatial-sensor" id="infopanel-for-spatial-sensor" role="dialog">
+   <span id="infopaneltitle-for-spatial-sensor" style="display:none">Info about the 'spatial sensor' definition.</span><b><a href="#spatial-sensor">#spatial-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spatial-sensor">5.1. Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="triaxial">
-   <b><a href="#triaxial">#triaxial</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-triaxial" class="dfn-panel" data-for="triaxial" id="infopanel-for-triaxial" role="dialog">
+   <span id="infopaneltitle-for-triaxial" style="display:none">Info about the 'triaxial' definition.</span><b><a href="#triaxial">#triaxial</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-triaxial">5.2. Sensor Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-platform-sensor">
-   <b><a href="#concept-platform-sensor">#concept-platform-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-platform-sensor" class="dfn-panel" data-for="concept-platform-sensor" id="infopanel-for-concept-platform-sensor" role="dialog">
+   <span id="infopaneltitle-for-concept-platform-sensor" style="display:none">Info about the 'platform sensor' definition.</span><b><a href="#concept-platform-sensor">#concept-platform-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-platform-sensor">5.1. Sensors</a> <a href="#ref-for-concept-platform-sensor①">(2)</a> <a href="#ref-for-concept-platform-sensor②">(3)</a> <a href="#ref-for-concept-platform-sensor③">(4)</a> <a href="#ref-for-concept-platform-sensor④">(5)</a> <a href="#ref-for-concept-platform-sensor⑤">(6)</a>
     <li><a href="#ref-for-concept-platform-sensor⑥">5.4. Reading change threshold</a>
@@ -4128,15 +4128,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-concept-platform-sensor③⑨">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="calibration">
-   <b><a href="#calibration">#calibration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-calibration" class="dfn-panel" data-for="calibration" id="infopanel-for-calibration" role="dialog">
+   <span id="infopaneltitle-for-calibration" style="display:none">Info about the 'calibration' definition.</span><b><a href="#calibration">#calibration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-calibration">5.2. Sensor Types</a>
     <li><a href="#ref-for-calibration①">10. Extensibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="low-level">
-   <b><a href="#low-level">#low-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-low-level" class="dfn-panel" data-for="low-level" id="infopanel-for-low-level" role="dialog">
+   <span id="infopaneltitle-for-low-level" style="display:none">Info about the 'low-level' definition.</span><b><a href="#low-level">#low-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-low-level">1. Introduction</a>
     <li><a href="#ref-for-low-level①">5.2. Sensor Types</a> <a href="#ref-for-low-level②">(2)</a> <a href="#ref-for-low-level③">(3)</a> <a href="#ref-for-low-level④">(4)</a> <a href="#ref-for-low-level⑤">(5)</a> <a href="#ref-for-low-level⑥">(6)</a>
@@ -4147,8 +4147,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-low-level①④">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="high-level">
-   <b><a href="#high-level">#high-level</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-high-level" class="dfn-panel" data-for="high-level" id="infopanel-for-high-level" role="dialog">
+   <span id="infopaneltitle-for-high-level" style="display:none">Info about the 'high-level' definition.</span><b><a href="#high-level">#high-level</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-level">1. Introduction</a>
     <li><a href="#ref-for-high-level①">5.2. Sensor Types</a> <a href="#ref-for-high-level②">(2)</a> <a href="#ref-for-high-level③">(3)</a> <a href="#ref-for-high-level④">(4)</a> <a href="#ref-for-high-level⑤">(5)</a> <a href="#ref-for-high-level⑥">(6)</a>
@@ -4157,8 +4157,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-high-level⑨">10.4. Exposing High-Level vs. Low-Level Sensors</a> <a href="#ref-for-high-level①⓪">(2)</a> <a href="#ref-for-high-level①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-fusion">
-   <b><a href="#sensor-fusion">#sensor-fusion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-fusion" class="dfn-panel" data-for="sensor-fusion" id="infopanel-for-sensor-fusion" role="dialog">
+   <span id="infopaneltitle-for-sensor-fusion" style="display:none">Info about the 'sensor fusion' definition.</span><b><a href="#sensor-fusion">#sensor-fusion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-fusion">5.1. Sensors</a> <a href="#ref-for-sensor-fusion①">(2)</a> <a href="#ref-for-sensor-fusion②">(3)</a>
     <li><a href="#ref-for-sensor-fusion③">5.2. Sensor Types</a> <a href="#ref-for-sensor-fusion④">(2)</a> <a href="#ref-for-sensor-fusion⑤">(3)</a> <a href="#ref-for-sensor-fusion⑥">(4)</a> <a href="#ref-for-sensor-fusion⑦">(5)</a>
@@ -4167,8 +4167,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-fusion①⓪">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-sensor-fusion①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-sensor">
-   <b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-sensor" class="dfn-panel" data-for="default-sensor" id="infopanel-for-default-sensor" role="dialog">
+   <span id="infopaneltitle-for-default-sensor" style="display:none">Info about the 'default sensor' definition.</span><b><a href="#default-sensor">#default-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sensor">5.3. Default sensor</a> <a href="#ref-for-default-sensor①">(2)</a> <a href="#ref-for-default-sensor②">(3)</a>
     <li><a href="#ref-for-default-sensor③">6.1. Sensor Type</a>
@@ -4176,15 +4176,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-default-sensor⑥">10.6. Definition Requirements</a> <a href="#ref-for-default-sensor⑦">(2)</a> <a href="#ref-for-default-sensor⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reading-change-threshold">
-   <b><a href="#reading-change-threshold">#reading-change-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reading-change-threshold" class="dfn-panel" data-for="reading-change-threshold" id="infopanel-for-reading-change-threshold" role="dialog">
+   <span id="infopaneltitle-for-reading-change-threshold" style="display:none">Info about the 'reading change threshold' definition.</span><b><a href="#reading-change-threshold">#reading-change-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reading-change-threshold">5.4. Reading change threshold</a> <a href="#ref-for-reading-change-threshold①">(2)</a>
     <li><a href="#ref-for-reading-change-threshold②">5.5. Sampling Frequency and Reporting Frequency</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sampling-frequency">
-   <b><a href="#sampling-frequency">#sampling-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sampling-frequency" class="dfn-panel" data-for="sampling-frequency" id="infopanel-for-sampling-frequency" role="dialog">
+   <span id="infopaneltitle-for-sampling-frequency" style="display:none">Info about the 'sampling frequency' definition.</span><b><a href="#sampling-frequency">#sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sampling-frequency">4.3.1. Limit maximum sampling frequency</a> <a href="#ref-for-sampling-frequency①">(2)</a>
     <li><a href="#ref-for-sampling-frequency②">4.3.3. Limit number of delivered readings</a>
@@ -4198,8 +4198,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-sampling-frequency①⑦">10.8. Extending the Permission API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requested-sampling-frequency">
-   <b><a href="#requested-sampling-frequency">#requested-sampling-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requested-sampling-frequency" class="dfn-panel" data-for="requested-sampling-frequency" id="infopanel-for-requested-sampling-frequency" role="dialog">
+   <span id="infopaneltitle-for-requested-sampling-frequency" style="display:none">Info about the 'requested sampling frequency' definition.</span><b><a href="#requested-sampling-frequency">#requested-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requested-sampling-frequency">5.5. Sampling Frequency and Reporting Frequency</a> <a href="#ref-for-requested-sampling-frequency①">(2)</a> <a href="#ref-for-requested-sampling-frequency②">(3)</a>
     <li><a href="#ref-for-requested-sampling-frequency③">6.2. Sensor</a> <a href="#ref-for-requested-sampling-frequency④">(2)</a> <a href="#ref-for-requested-sampling-frequency⑤">(3)</a>
@@ -4210,30 +4210,30 @@ for their editorial input.</p>
     <li><a href="#ref-for-requested-sampling-frequency①②">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reporting-frequency">
-   <b><a href="#reporting-frequency">#reporting-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reporting-frequency" class="dfn-panel" data-for="reporting-frequency" id="infopanel-for-reporting-frequency" role="dialog">
+   <span id="infopaneltitle-for-reporting-frequency" style="display:none">Info about the 'reporting frequency' definition.</span><b><a href="#reporting-frequency">#reporting-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reporting-frequency">5.5. Sampling Frequency and Reporting Frequency</a>
     <li><a href="#ref-for-reporting-frequency①">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-reporting-frequency②">8.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="can-expose-sensor-readings">
-   <b><a href="#can-expose-sensor-readings">#can-expose-sensor-readings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-can-expose-sensor-readings" class="dfn-panel" data-for="can-expose-sensor-readings" id="infopanel-for-can-expose-sensor-readings" role="dialog">
+   <span id="infopaneltitle-for-can-expose-sensor-readings" style="display:none">Info about the 'can expose sensor readings' definition.</span><b><a href="#can-expose-sensor-readings">#can-expose-sensor-readings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-can-expose-sensor-readings">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-can-expose-sensor-readings①">6.2. Sensor</a>
     <li><a href="#ref-for-can-expose-sensor-readings②">9.1. Mock Sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mandatory-conditions">
-   <b><a href="#mandatory-conditions">#mandatory-conditions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mandatory-conditions" class="dfn-panel" data-for="mandatory-conditions" id="infopanel-for-mandatory-conditions" role="dialog">
+   <span id="infopaneltitle-for-mandatory-conditions" style="display:none">Info about the 'mandatory conditions' definition.</span><b><a href="#mandatory-conditions">#mandatory-conditions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mandatory-conditions">5.6. Conditions to expose sensor readings</a> <a href="#ref-for-mandatory-conditions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-type">
-   <b><a href="#sensor-type">#sensor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-type" class="dfn-panel" data-for="sensor-type" id="infopanel-for-sensor-type" role="dialog">
+   <span id="infopaneltitle-for-sensor-type" style="display:none">Info about the 'sensor type' definition.</span><b><a href="#sensor-type">#sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-type">4. Security and privacy considerations</a>
     <li><a href="#ref-for-sensor-type①">4.2.2. Permissions Policy</a>
@@ -4256,14 +4256,14 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-type④⑧">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-sensor-type④⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-sensors">
-   <b><a href="#associated-sensors">#associated-sensors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-sensors" class="dfn-panel" data-for="associated-sensors" id="infopanel-for-associated-sensors" role="dialog">
+   <span id="infopaneltitle-for-associated-sensors" style="display:none">Info about the 'associated sensors' definition.</span><b><a href="#associated-sensors">#associated-sensors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-sensors">6.1. Sensor Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-permission-names">
-   <b><a href="#sensor-permission-names">#sensor-permission-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-permission-names" class="dfn-panel" data-for="sensor-permission-names" id="infopanel-for-sensor-permission-names" role="dialog">
+   <span id="infopaneltitle-for-sensor-permission-names" style="display:none">Info about the 'sensor permission names' definition.</span><b><a href="#sensor-permission-names">#sensor-permission-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-permission-names">5.6. Conditions to expose sensor readings</a>
     <li><a href="#ref-for-sensor-permission-names①">6.1. Sensor Type</a>
@@ -4271,15 +4271,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor-permission-names③">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-feature-names">
-   <b><a href="#sensor-feature-names">#sensor-feature-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-feature-names" class="dfn-panel" data-for="sensor-feature-names" id="infopanel-for-sensor-feature-names" role="dialog">
+   <span id="infopaneltitle-for-sensor-feature-names" style="display:none">Info about the 'sensor feature names' definition.</span><b><a href="#sensor-feature-names">#sensor-feature-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-feature-names">8.2. Check sensor policy-controlled features</a> <a href="#ref-for-sensor-feature-names①">(2)</a>
     <li><a href="#ref-for-sensor-feature-names②">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-sensor-feature-names③">(2)</a> <a href="#ref-for-sensor-feature-names④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activated-sensor-objects">
-   <b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activated-sensor-objects" class="dfn-panel" data-for="activated-sensor-objects" id="infopanel-for-activated-sensor-objects" role="dialog">
+   <span id="infopaneltitle-for-activated-sensor-objects" style="display:none">Info about the 'activated sensor objects' definition.</span><b><a href="#activated-sensor-objects">#activated-sensor-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activated-sensor-objects">6.2. Sensor</a> <a href="#ref-for-activated-sensor-objects①">(2)</a> <a href="#ref-for-activated-sensor-objects②">(3)</a> <a href="#ref-for-activated-sensor-objects③">(4)</a> <a href="#ref-for-activated-sensor-objects④">(5)</a>
     <li><a href="#ref-for-activated-sensor-objects⑤">8.4. Activate a sensor object</a>
@@ -4289,8 +4289,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-activated-sensor-objects①⓪">8.8. Update latest reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="latest-reading">
-   <b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-latest-reading" class="dfn-panel" data-for="latest-reading" id="infopanel-for-latest-reading" role="dialog">
+   <span id="infopaneltitle-for-latest-reading" style="display:none">Info about the 'latest reading' definition.</span><b><a href="#latest-reading">#latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-latest-reading">6.2. Sensor</a> <a href="#ref-for-latest-reading①">(2)</a> <a href="#ref-for-latest-reading②">(3)</a> <a href="#ref-for-latest-reading③">(4)</a> <a href="#ref-for-latest-reading④">(5)</a> <a href="#ref-for-latest-reading⑤">(6)</a> <a href="#ref-for-latest-reading⑥">(7)</a>
     <li><a href="#ref-for-latest-reading⑦">8.7. Set sensor settings</a> <a href="#ref-for-latest-reading⑧">(2)</a>
@@ -4301,15 +4301,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-latest-reading①④">8.14. Get value from latest reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optimal-sampling-frequency">
-   <b><a href="#optimal-sampling-frequency">#optimal-sampling-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optimal-sampling-frequency" class="dfn-panel" data-for="optimal-sampling-frequency" id="infopanel-for-optimal-sampling-frequency" role="dialog">
+   <span id="infopaneltitle-for-optimal-sampling-frequency" style="display:none">Info about the 'optimal sampling frequency' definition.</span><b><a href="#optimal-sampling-frequency">#optimal-sampling-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimal-sampling-frequency">6.2. Sensor</a>
     <li><a href="#ref-for-optimal-sampling-frequency①">8.7. Set sensor settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor">
-   <b><a href="#sensor">#sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor" class="dfn-panel" data-for="sensor" id="infopanel-for-sensor" role="dialog">
+   <span id="infopaneltitle-for-sensor" style="display:none">Info about the 'Sensor' definition.</span><b><a href="#sensor">#sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor">3. A note on Feature Detection of Hardware Features</a>
     <li><a href="#ref-for-sensor①">5.3. Default sensor</a>
@@ -4344,78 +4344,78 @@ for their editorial input.</p>
     <li><a href="#ref-for-sensor④⑧">10.9. Extending the Permissions Policy API</a> <a href="#ref-for-sensor④⑨">(2)</a> <a href="#ref-for-sensor⑤⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-activated">
-   <b><a href="#dom-sensor-activated">#dom-sensor-activated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-activated" class="dfn-panel" data-for="dom-sensor-activated" id="infopanel-for-dom-sensor-activated" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-activated" style="display:none">Info about the 'activated' definition.</span><b><a href="#dom-sensor-activated">#dom-sensor-activated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-activated">7.1.4. Sensor.activated</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-hasreading">
-   <b><a href="#dom-sensor-hasreading">#dom-sensor-hasreading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-hasreading" class="dfn-panel" data-for="dom-sensor-hasreading" id="infopanel-for-dom-sensor-hasreading" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-hasreading" style="display:none">Info about the 'hasReading' definition.</span><b><a href="#dom-sensor-hasreading">#dom-sensor-hasreading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-hasreading">7.1.5. Sensor.hasReading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-timestamp">
-   <b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-timestamp" class="dfn-panel" data-for="dom-sensor-timestamp" id="infopanel-for-dom-sensor-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#dom-sensor-timestamp">#dom-sensor-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-timestamp">7.1.6. Sensor.timestamp</a>
     <li><a href="#ref-for-dom-sensor-timestamp①">8.1. Initialize a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-start">
-   <b><a href="#dom-sensor-start">#dom-sensor-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-start" class="dfn-panel" data-for="dom-sensor-start" id="infopanel-for-dom-sensor-start" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-start" style="display:none">Info about the 'start' definition.</span><b><a href="#dom-sensor-start">#dom-sensor-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-start">7.1.7. Sensor.start()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-stop">
-   <b><a href="#dom-sensor-stop">#dom-sensor-stop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-stop" class="dfn-panel" data-for="dom-sensor-stop" id="infopanel-for-dom-sensor-stop" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-stop" style="display:none">Info about the 'stop' definition.</span><b><a href="#dom-sensor-stop">#dom-sensor-stop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-stop">7.1.8. Sensor.stop()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-onreading">
-   <b><a href="#dom-sensor-onreading">#dom-sensor-onreading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-onreading" class="dfn-panel" data-for="dom-sensor-onreading" id="infopanel-for-dom-sensor-onreading" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-onreading" style="display:none">Info about the 'onreading' definition.</span><b><a href="#dom-sensor-onreading">#dom-sensor-onreading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-onreading">7.1.9. Sensor.onreading</a>
     <li><a href="#ref-for-dom-sensor-onreading①">10.5. When is Enabling Multiple Sensors of the Same Type Not the Right Choice?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-onactivate">
-   <b><a href="#dom-sensor-onactivate">#dom-sensor-onactivate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-onactivate" class="dfn-panel" data-for="dom-sensor-onactivate" id="infopanel-for-dom-sensor-onactivate" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-onactivate" style="display:none">Info about the 'onactivate' definition.</span><b><a href="#dom-sensor-onactivate">#dom-sensor-onactivate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-onactivate">7.1.10. Sensor.onactivate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-onerror">
-   <b><a href="#dom-sensor-onerror">#dom-sensor-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-onerror" class="dfn-panel" data-for="dom-sensor-onerror" id="infopanel-for-dom-sensor-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-sensor-onerror">#dom-sensor-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-onerror">7.1.11. Sensor.onerror</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-sensoroptions">
-   <b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-sensoroptions" class="dfn-panel" data-for="dictdef-sensoroptions" id="infopanel-for-dictdef-sensoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-sensoroptions" style="display:none">Info about the 'SensorOptions' definition.</span><b><a href="#dictdef-sensoroptions">#dictdef-sensoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensoroptions">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-dictdef-sensoroptions①">10.6. Definition Requirements</a> <a href="#ref-for-dictdef-sensoroptions②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensoroptions-frequency">
-   <b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensoroptions-frequency" class="dfn-panel" data-for="dom-sensoroptions-frequency" id="infopanel-for-dom-sensoroptions-frequency" role="dialog">
+   <span id="infopaneltitle-for-dom-sensoroptions-frequency" style="display:none">Info about the 'frequency' definition.</span><b><a href="#dom-sensoroptions-frequency">#dom-sensoroptions-frequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensoroptions-frequency">7.1.3. Sensor internal slots</a>
     <li><a href="#ref-for-dom-sensoroptions-frequency①">8.1. Initialize a sensor object</a> <a href="#ref-for-dom-sensoroptions-frequency②">(2)</a> <a href="#ref-for-dom-sensoroptions-frequency③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensor-task-source">
-   <b><a href="#sensor-task-source">#sensor-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensor-task-source" class="dfn-panel" data-for="sensor-task-source" id="infopanel-for-sensor-task-source" role="dialog">
+   <span id="infopaneltitle-for-sensor-task-source" style="display:none">Info about the 'sensor task source' definition.</span><b><a href="#sensor-task-source">#sensor-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensor-task-source">8.5. Deactivate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-state-slot">
-   <b><a href="#dom-sensor-state-slot">#dom-sensor-state-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-state-slot" class="dfn-panel" data-for="dom-sensor-state-slot" id="infopanel-for-dom-sensor-state-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-state-slot" style="display:none">Info about the '[[state]]' definition.</span><b><a href="#dom-sensor-state-slot">#dom-sensor-state-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-state-slot">7.1.2. Sensor garbage collection</a> <a href="#ref-for-dom-sensor-state-slot①">(2)</a> <a href="#ref-for-dom-sensor-state-slot②">(3)</a>
     <li><a href="#ref-for-dom-sensor-state-slot③">7.1.4. Sensor.activated</a>
@@ -4427,78 +4427,78 @@ for their editorial input.</p>
     <li><a href="#ref-for-dom-sensor-state-slot①①">8.14. Get value from latest reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-frequency-slot">
-   <b><a href="#dom-sensor-frequency-slot">#dom-sensor-frequency-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-frequency-slot" class="dfn-panel" data-for="dom-sensor-frequency-slot" id="infopanel-for-dom-sensor-frequency-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-frequency-slot" style="display:none">Info about the '[[frequency]]' definition.</span><b><a href="#dom-sensor-frequency-slot">#dom-sensor-frequency-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-frequency-slot">6.2. Sensor</a> <a href="#ref-for-dom-sensor-frequency-slot①">(2)</a>
     <li><a href="#ref-for-dom-sensor-frequency-slot②">8.1. Initialize a sensor object</a>
     <li><a href="#ref-for-dom-sensor-frequency-slot③">8.9. Find the reporting frequency of a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot">
-   <b><a href="#dom-sensor-lasteventfiredat-slot">#dom-sensor-lasteventfiredat-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-lasteventfiredat-slot" class="dfn-panel" data-for="dom-sensor-lasteventfiredat-slot" id="infopanel-for-dom-sensor-lasteventfiredat-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-lasteventfiredat-slot" style="display:none">Info about the '[[lastEventFiredAt]]' definition.</span><b><a href="#dom-sensor-lasteventfiredat-slot">#dom-sensor-lasteventfiredat-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot">8.5. Deactivate a sensor object</a>
     <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot①">8.10. Report latest reading updated</a>
     <li><a href="#ref-for-dom-sensor-lasteventfiredat-slot②">8.11. Notify new reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensor-pendingreadingnotification-slot">
-   <b><a href="#dom-sensor-pendingreadingnotification-slot">#dom-sensor-pendingreadingnotification-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensor-pendingreadingnotification-slot" class="dfn-panel" data-for="dom-sensor-pendingreadingnotification-slot" id="infopanel-for-dom-sensor-pendingreadingnotification-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-sensor-pendingreadingnotification-slot" style="display:none">Info about the '[[pendingReadingNotification]]' definition.</span><b><a href="#dom-sensor-pendingreadingnotification-slot">#dom-sensor-pendingreadingnotification-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot">8.5. Deactivate a sensor object</a>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot①">8.10. Report latest reading updated</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot②">(2)</a> <a href="#ref-for-dom-sensor-pendingreadingnotification-slot③">(3)</a>
     <li><a href="#ref-for-dom-sensor-pendingreadingnotification-slot④">8.11. Notify new reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sensorerrorevent">
-   <b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sensorerrorevent" class="dfn-panel" data-for="sensorerrorevent" id="infopanel-for-sensorerrorevent" role="dialog">
+   <span id="infopaneltitle-for-sensorerrorevent" style="display:none">Info about the 'SensorErrorEvent' definition.</span><b><a href="#sensorerrorevent">#sensorerrorevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sensorerrorevent">8.13. Notify error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sensorerrorevent-error">
-   <b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sensorerrorevent-error" class="dfn-panel" data-for="dom-sensorerrorevent-error" id="infopanel-for-dom-sensorerrorevent-error" role="dialog">
+   <span id="infopaneltitle-for-dom-sensorerrorevent-error" style="display:none">Info about the 'error' definition.</span><b><a href="#dom-sensorerrorevent-error">#dom-sensorerrorevent-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sensorerrorevent-error">8.13. Notify error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-sensorerroreventinit">
-   <b><a href="#dictdef-sensorerroreventinit">#dictdef-sensorerroreventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-sensorerroreventinit" class="dfn-panel" data-for="dictdef-sensorerroreventinit" id="infopanel-for-dictdef-sensorerroreventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-sensorerroreventinit" style="display:none">Info about the 'SensorErrorEventInit' definition.</span><b><a href="#dictdef-sensorerroreventinit">#dictdef-sensorerroreventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sensorerroreventinit">7.2. The SensorErrorEvent Interface</a>
     <li><a href="#ref-for-dictdef-sensorerroreventinit①">7.2.1. SensorErrorEvent.error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-a-sensor-object">
-   <b><a href="#initialize-a-sensor-object">#initialize-a-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-a-sensor-object" class="dfn-panel" data-for="initialize-a-sensor-object" id="infopanel-for-initialize-a-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-initialize-a-sensor-object" style="display:none">Info about the '8.1. Initialize a sensor object' definition.</span><b><a href="#initialize-a-sensor-object">#initialize-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-a-sensor-object">8.1. Initialize a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-sensor-policy-controlled-features">
-   <b><a href="#check-sensor-policy-controlled-features">#check-sensor-policy-controlled-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-sensor-policy-controlled-features" class="dfn-panel" data-for="check-sensor-policy-controlled-features" id="infopanel-for-check-sensor-policy-controlled-features" role="dialog">
+   <span id="infopaneltitle-for-check-sensor-policy-controlled-features" style="display:none">Info about the '8.2. Check sensor policy-controlled features' definition.</span><b><a href="#check-sensor-policy-controlled-features">#check-sensor-policy-controlled-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-sensor-policy-controlled-features">8.2. Check sensor policy-controlled features</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connect-to-sensor">
-   <b><a href="#connect-to-sensor">#connect-to-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connect-to-sensor" class="dfn-panel" data-for="connect-to-sensor" id="infopanel-for-connect-to-sensor" role="dialog">
+   <span id="infopaneltitle-for-connect-to-sensor" style="display:none">Info about the '8.3. Connect to sensor' definition.</span><b><a href="#connect-to-sensor">#connect-to-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect-to-sensor">7.1.7. Sensor.start()</a>
     <li><a href="#ref-for-connect-to-sensor">8.3. Connect to sensor</a>
     <li><a href="#ref-for-connect-to-sensor①">9.1.1. MockSensorConfiguration dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="activate-a-sensor-object">
-   <b><a href="#activate-a-sensor-object">#activate-a-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-activate-a-sensor-object" class="dfn-panel" data-for="activate-a-sensor-object" id="infopanel-for-activate-a-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-activate-a-sensor-object" style="display:none">Info about the '8.4. Activate a sensor object' definition.</span><b><a href="#activate-a-sensor-object">#activate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-activate-a-sensor-object">7.1.7. Sensor.start()</a>
     <li><a href="#ref-for-activate-a-sensor-object">8.4. Activate a sensor object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="deactivate-a-sensor-object">
-   <b><a href="#deactivate-a-sensor-object">#deactivate-a-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-deactivate-a-sensor-object" class="dfn-panel" data-for="deactivate-a-sensor-object" id="infopanel-for-deactivate-a-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-deactivate-a-sensor-object" style="display:none">Info about the '8.5. Deactivate a sensor object' definition.</span><b><a href="#deactivate-a-sensor-object">#deactivate-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-deactivate-a-sensor-object">7.1.2. Sensor garbage collection</a>
     <li><a href="#ref-for-deactivate-a-sensor-object①">7.1.8. Sensor.stop()</a>
@@ -4506,67 +4506,67 @@ for their editorial input.</p>
     <li><a href="#ref-for-deactivate-a-sensor-object②">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="revoke-sensor-permission">
-   <b><a href="#revoke-sensor-permission">#revoke-sensor-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-revoke-sensor-permission" class="dfn-panel" data-for="revoke-sensor-permission" id="infopanel-for-revoke-sensor-permission" role="dialog">
+   <span id="infopaneltitle-for-revoke-sensor-permission" style="display:none">Info about the '8.6. Revoke sensor permission' definition.</span><b><a href="#revoke-sensor-permission">#revoke-sensor-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-revoke-sensor-permission">6.1. Sensor Type</a>
     <li><a href="#ref-for-revoke-sensor-permission">8.6. Revoke sensor permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-sensor-settings">
-   <b><a href="#set-sensor-settings">#set-sensor-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-sensor-settings" class="dfn-panel" data-for="set-sensor-settings" id="infopanel-for-set-sensor-settings" role="dialog">
+   <span id="infopaneltitle-for-set-sensor-settings" style="display:none">Info about the '8.7. Set sensor settings' definition.</span><b><a href="#set-sensor-settings">#set-sensor-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-sensor-settings">8.4. Activate a sensor object</a>
     <li><a href="#ref-for-set-sensor-settings①">8.5. Deactivate a sensor object</a>
     <li><a href="#ref-for-set-sensor-settings">8.7. Set sensor settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-latest-reading">
-   <b><a href="#update-latest-reading">#update-latest-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-latest-reading" class="dfn-panel" data-for="update-latest-reading" id="infopanel-for-update-latest-reading" role="dialog">
+   <span id="infopaneltitle-for-update-latest-reading" style="display:none">Info about the '8.8. Update latest reading' definition.</span><b><a href="#update-latest-reading">#update-latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-latest-reading">6.2. Sensor</a>
     <li><a href="#ref-for-update-latest-reading">8.8. Update latest reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-the-reporting-frequency-of-a-sensor-object">
-   <b><a href="#find-the-reporting-frequency-of-a-sensor-object">#find-the-reporting-frequency-of-a-sensor-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-the-reporting-frequency-of-a-sensor-object" class="dfn-panel" data-for="find-the-reporting-frequency-of-a-sensor-object" id="infopanel-for-find-the-reporting-frequency-of-a-sensor-object" role="dialog">
+   <span id="infopaneltitle-for-find-the-reporting-frequency-of-a-sensor-object" style="display:none">Info about the '8.9. Find the reporting frequency of a sensor object' definition.</span><b><a href="#find-the-reporting-frequency-of-a-sensor-object">#find-the-reporting-frequency-of-a-sensor-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object">8.9. Find the reporting frequency of a sensor object</a>
     <li><a href="#ref-for-find-the-reporting-frequency-of-a-sensor-object">8.10. Report latest reading updated</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-latest-reading-updated">
-   <b><a href="#report-latest-reading-updated">#report-latest-reading-updated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-latest-reading-updated" class="dfn-panel" data-for="report-latest-reading-updated" id="infopanel-for-report-latest-reading-updated" role="dialog">
+   <span id="infopaneltitle-for-report-latest-reading-updated" style="display:none">Info about the '8.10. Report latest reading updated' definition.</span><b><a href="#report-latest-reading-updated">#report-latest-reading-updated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-latest-reading-updated">8.8. Update latest reading</a>
     <li><a href="#ref-for-report-latest-reading-updated">8.10. Report latest reading updated</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-new-reading">
-   <b><a href="#notify-new-reading">#notify-new-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-new-reading" class="dfn-panel" data-for="notify-new-reading" id="infopanel-for-notify-new-reading" role="dialog">
+   <span id="infopaneltitle-for-notify-new-reading" style="display:none">Info about the '8.11. Notify new reading' definition.</span><b><a href="#notify-new-reading">#notify-new-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-new-reading">8.10. Report latest reading updated</a> <a href="#ref-for-notify-new-reading①">(2)</a> <a href="#ref-for-notify-new-reading②">(3)</a> <a href="#ref-for-notify-new-reading③">(4)</a>
     <li><a href="#ref-for-notify-new-reading">8.11. Notify new reading</a>
     <li><a href="#ref-for-notify-new-reading④">8.12. Notify activated state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-activated-state">
-   <b><a href="#notify-activated-state">#notify-activated-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-activated-state" class="dfn-panel" data-for="notify-activated-state" id="infopanel-for-notify-activated-state" role="dialog">
+   <span id="infopaneltitle-for-notify-activated-state" style="display:none">Info about the '8.12. Notify activated state' definition.</span><b><a href="#notify-activated-state">#notify-activated-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-activated-state">8.4. Activate a sensor object</a>
     <li><a href="#ref-for-notify-activated-state">8.12. Notify activated state</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-error">
-   <b><a href="#notify-error">#notify-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-error" class="dfn-panel" data-for="notify-error" id="infopanel-for-notify-error" role="dialog">
+   <span id="infopaneltitle-for-notify-error" style="display:none">Info about the '8.13. Notify error' definition.</span><b><a href="#notify-error">#notify-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-error">7.1.7. Sensor.start()</a> <a href="#ref-for-notify-error①">(2)</a>
     <li><a href="#ref-for-notify-error②">8.6. Revoke sensor permission</a>
     <li><a href="#ref-for-notify-error">8.13. Notify error</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-value-from-latest-reading">
-   <b><a href="#get-value-from-latest-reading">#get-value-from-latest-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-value-from-latest-reading" class="dfn-panel" data-for="get-value-from-latest-reading" id="infopanel-for-get-value-from-latest-reading" role="dialog">
+   <span id="infopaneltitle-for-get-value-from-latest-reading" style="display:none">Info about the '8.14. Get value from latest reading' definition.</span><b><a href="#get-value-from-latest-reading">#get-value-from-latest-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-value-from-latest-reading">6.2. Sensor</a>
     <li><a href="#ref-for-get-value-from-latest-reading①">7.1.5. Sensor.hasReading</a>
@@ -4575,15 +4575,15 @@ for their editorial input.</p>
     <li><a href="#ref-for-get-value-from-latest-reading③">10.6. Definition Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-sensor-access">
-   <b><a href="#request-sensor-access">#request-sensor-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-sensor-access" class="dfn-panel" data-for="request-sensor-access" id="infopanel-for-request-sensor-access" role="dialog">
+   <span id="infopaneltitle-for-request-sensor-access" style="display:none">Info about the '8.15. Request sensor access' definition.</span><b><a href="#request-sensor-access">#request-sensor-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-sensor-access">7.1.7. Sensor.start()</a>
     <li><a href="#ref-for-request-sensor-access">8.15. Request sensor access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor">
-   <b><a href="#mock-sensor">#mock-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mock-sensor" class="dfn-panel" data-for="mock-sensor" id="infopanel-for-mock-sensor" role="dialog">
+   <span id="infopaneltitle-for-mock-sensor" style="display:none">Info about the 'mock sensor' definition.</span><b><a href="#mock-sensor">#mock-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor">9. Automation</a>
     <li><a href="#ref-for-mock-sensor①">9.1. Mock Sensors</a> <a href="#ref-for-mock-sensor②">(2)</a> <a href="#ref-for-mock-sensor③">(3)</a> <a href="#ref-for-mock-sensor④">(4)</a> <a href="#ref-for-mock-sensor⑤">(5)</a> <a href="#ref-for-mock-sensor⑥">(6)</a> <a href="#ref-for-mock-sensor⑦">(7)</a> <a href="#ref-for-mock-sensor⑧">(8)</a>
@@ -4596,87 +4596,87 @@ for their editorial input.</p>
     <li><a href="#ref-for-mock-sensor③②">9.3. Handling errors</a> <a href="#ref-for-mock-sensor③③">(2)</a> <a href="#ref-for-mock-sensor③④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor-reading">
-   <b><a href="#mock-sensor-reading">#mock-sensor-reading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mock-sensor-reading" class="dfn-panel" data-for="mock-sensor-reading" id="infopanel-for-mock-sensor-reading" role="dialog">
+   <span id="infopaneltitle-for-mock-sensor-reading" style="display:none">Info about the 'mock sensor reading' definition.</span><b><a href="#mock-sensor-reading">#mock-sensor-reading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading">9.1. Mock Sensors</a> <a href="#ref-for-mock-sensor-reading①">(2)</a> <a href="#ref-for-mock-sensor-reading②">(3)</a> <a href="#ref-for-mock-sensor-reading③">(4)</a> <a href="#ref-for-mock-sensor-reading④">(5)</a> <a href="#ref-for-mock-sensor-reading⑤">(6)</a>
     <li><a href="#ref-for-mock-sensor-reading⑥">9.1.3. Mock sensor type</a>
     <li><a href="#ref-for-mock-sensor-reading⑦">9.2.3. Update mock sensor reading</a> <a href="#ref-for-mock-sensor-reading⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mocksensorconfiguration">
-   <b><a href="#dictdef-mocksensorconfiguration">#dictdef-mocksensorconfiguration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mocksensorconfiguration" class="dfn-panel" data-for="dictdef-mocksensorconfiguration" id="infopanel-for-dictdef-mocksensorconfiguration" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mocksensorconfiguration" style="display:none">Info about the 'MockSensorConfiguration' definition.</span><b><a href="#dictdef-mocksensorconfiguration">#dictdef-mocksensorconfiguration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mocksensorconfiguration">9.1.1. MockSensorConfiguration dictionary</a>
     <li><a href="#ref-for-dictdef-mocksensorconfiguration①">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensorconfiguration-mocksensortype">
-   <b><a href="#dom-mocksensorconfiguration-mocksensortype">#dom-mocksensorconfiguration-mocksensortype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensorconfiguration-mocksensortype" class="dfn-panel" data-for="dom-mocksensorconfiguration-mocksensortype" id="infopanel-for-dom-mocksensorconfiguration-mocksensortype" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensorconfiguration-mocksensortype" style="display:none">Info about the 'mockSensorType' definition.</span><b><a href="#dom-mocksensorconfiguration-mocksensortype">#dom-mocksensorconfiguration-mocksensortype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensorconfiguration-mocksensortype">9.1.1. MockSensorConfiguration dictionary</a>
     <li><a href="#ref-for-dom-mocksensorconfiguration-mocksensortype①">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensorconfiguration-connected">
-   <b><a href="#dom-mocksensorconfiguration-connected">#dom-mocksensorconfiguration-connected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensorconfiguration-connected" class="dfn-panel" data-for="dom-mocksensorconfiguration-connected" id="infopanel-for-dom-mocksensorconfiguration-connected" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensorconfiguration-connected" style="display:none">Info about the 'connected' definition.</span><b><a href="#dom-mocksensorconfiguration-connected">#dom-mocksensorconfiguration-connected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensorconfiguration-connected">9.1.1. MockSensorConfiguration dictionary</a>
     <li><a href="#ref-for-dom-mocksensorconfiguration-connected①">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensorconfiguration-maxsamplingfrequency">
-   <b><a href="#dom-mocksensorconfiguration-maxsamplingfrequency">#dom-mocksensorconfiguration-maxsamplingfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensorconfiguration-maxsamplingfrequency" class="dfn-panel" data-for="dom-mocksensorconfiguration-maxsamplingfrequency" id="infopanel-for-dom-mocksensorconfiguration-maxsamplingfrequency" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensorconfiguration-maxsamplingfrequency" style="display:none">Info about the 'maxSamplingFrequency' definition.</span><b><a href="#dom-mocksensorconfiguration-maxsamplingfrequency">#dom-mocksensorconfiguration-maxsamplingfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensorconfiguration-maxsamplingfrequency">9.1.1. MockSensorConfiguration dictionary</a>
     <li><a href="#ref-for-dom-mocksensorconfiguration-maxsamplingfrequency①">9.2.1. Create mock sensor</a> <a href="#ref-for-dom-mocksensorconfiguration-maxsamplingfrequency②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensorconfiguration-minsamplingfrequency">
-   <b><a href="#dom-mocksensorconfiguration-minsamplingfrequency">#dom-mocksensorconfiguration-minsamplingfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensorconfiguration-minsamplingfrequency" class="dfn-panel" data-for="dom-mocksensorconfiguration-minsamplingfrequency" id="infopanel-for-dom-mocksensorconfiguration-minsamplingfrequency" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensorconfiguration-minsamplingfrequency" style="display:none">Info about the 'minSamplingFrequency' definition.</span><b><a href="#dom-mocksensorconfiguration-minsamplingfrequency">#dom-mocksensorconfiguration-minsamplingfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensorconfiguration-minsamplingfrequency">9.1.1. MockSensorConfiguration dictionary</a>
     <li><a href="#ref-for-dom-mocksensorconfiguration-minsamplingfrequency①">9.2.1. Create mock sensor</a> <a href="#ref-for-dom-mocksensorconfiguration-minsamplingfrequency②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-flag">
-   <b><a href="#connection-flag">#connection-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-flag" class="dfn-panel" data-for="connection-flag" id="infopanel-for-connection-flag" role="dialog">
+   <span id="infopaneltitle-for-connection-flag" style="display:none">Info about the 'connection flag' definition.</span><b><a href="#connection-flag">#connection-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-flag">9.2.1. Create mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mocksensor">
-   <b><a href="#dictdef-mocksensor">#dictdef-mocksensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mocksensor" class="dfn-panel" data-for="dictdef-mocksensor" id="infopanel-for-dictdef-mocksensor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mocksensor" style="display:none">Info about the 'MockSensor' definition.</span><b><a href="#dictdef-mocksensor">#dictdef-mocksensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mocksensor">9.1.2. MockSensor dictionary</a> <a href="#ref-for-dictdef-mocksensor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensor-maxsamplingfrequency">
-   <b><a href="#dom-mocksensor-maxsamplingfrequency">#dom-mocksensor-maxsamplingfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensor-maxsamplingfrequency" class="dfn-panel" data-for="dom-mocksensor-maxsamplingfrequency" id="infopanel-for-dom-mocksensor-maxsamplingfrequency" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensor-maxsamplingfrequency" style="display:none">Info about the 'maxSamplingFrequency' definition.</span><b><a href="#dom-mocksensor-maxsamplingfrequency">#dom-mocksensor-maxsamplingfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensor-maxsamplingfrequency">9.1.2. MockSensor dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensor-minsamplingfrequency">
-   <b><a href="#dom-mocksensor-minsamplingfrequency">#dom-mocksensor-minsamplingfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensor-minsamplingfrequency" class="dfn-panel" data-for="dom-mocksensor-minsamplingfrequency" id="infopanel-for-dom-mocksensor-minsamplingfrequency" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensor-minsamplingfrequency" style="display:none">Info about the 'minSamplingFrequency' definition.</span><b><a href="#dom-mocksensor-minsamplingfrequency">#dom-mocksensor-minsamplingfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensor-minsamplingfrequency">9.1.2. MockSensor dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensor-requestedsamplingfrequency">
-   <b><a href="#dom-mocksensor-requestedsamplingfrequency">#dom-mocksensor-requestedsamplingfrequency</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensor-requestedsamplingfrequency" class="dfn-panel" data-for="dom-mocksensor-requestedsamplingfrequency" id="infopanel-for-dom-mocksensor-requestedsamplingfrequency" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensor-requestedsamplingfrequency" style="display:none">Info about the 'requestedSamplingFrequency' definition.</span><b><a href="#dom-mocksensor-requestedsamplingfrequency">#dom-mocksensor-requestedsamplingfrequency</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensor-requestedsamplingfrequency">9.1.2. MockSensor dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-mock-sensor">
-   <b><a href="#serialized-mock-sensor">#serialized-mock-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-mock-sensor" class="dfn-panel" data-for="serialized-mock-sensor" id="infopanel-for-serialized-mock-sensor" role="dialog">
+   <span id="infopaneltitle-for-serialized-mock-sensor" style="display:none">Info about the 'serialized mock sensor' definition.</span><b><a href="#serialized-mock-sensor">#serialized-mock-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-mock-sensor">9.2.2. Get mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor-type">
-   <b><a href="#mock-sensor-type">#mock-sensor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mock-sensor-type" class="dfn-panel" data-for="mock-sensor-type" id="infopanel-for-mock-sensor-type" role="dialog">
+   <span id="infopaneltitle-for-mock-sensor-type" style="display:none">Info about the 'mock sensor type' definition.</span><b><a href="#mock-sensor-type">#mock-sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-type">9.1. Mock Sensors</a>
     <li><a href="#ref-for-mock-sensor-type①">9.1.1. MockSensorConfiguration dictionary</a>
@@ -4688,8 +4688,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-mock-sensor-type②①">10.7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-mocksensortype">
-   <b><a href="#enumdef-mocksensortype">#enumdef-mocksensortype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-mocksensortype" class="dfn-panel" data-for="enumdef-mocksensortype" id="infopanel-for-enumdef-mocksensortype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-mocksensortype" style="display:none">Info about the 'MockSensorType' definition.</span><b><a href="#enumdef-mocksensortype">#enumdef-mocksensortype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-mocksensortype">9.1.1. MockSensorConfiguration dictionary</a> <a href="#ref-for-enumdef-mocksensortype①">(2)</a>
     <li><a href="#ref-for-enumdef-mocksensortype②">9.1.3. Mock sensor type</a>
@@ -4699,103 +4699,103 @@ for their editorial input.</p>
     <li><a href="#ref-for-enumdef-mocksensortype⑥">10.7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-ambient-light">
-   <b><a href="#dom-mocksensortype-ambient-light">#dom-mocksensortype-ambient-light</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-ambient-light" class="dfn-panel" data-for="dom-mocksensortype-ambient-light" id="infopanel-for-dom-mocksensortype-ambient-light" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-ambient-light" style="display:none">Info about the '"ambient-light"' definition.</span><b><a href="#dom-mocksensortype-ambient-light">#dom-mocksensortype-ambient-light</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-ambient-light">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-accelerometer">
-   <b><a href="#dom-mocksensortype-accelerometer">#dom-mocksensortype-accelerometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-accelerometer" class="dfn-panel" data-for="dom-mocksensortype-accelerometer" id="infopanel-for-dom-mocksensortype-accelerometer" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-accelerometer" style="display:none">Info about the '"accelerometer"' definition.</span><b><a href="#dom-mocksensortype-accelerometer">#dom-mocksensortype-accelerometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-accelerometer">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-linear-acceleration">
-   <b><a href="#dom-mocksensortype-linear-acceleration">#dom-mocksensortype-linear-acceleration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-linear-acceleration" class="dfn-panel" data-for="dom-mocksensortype-linear-acceleration" id="infopanel-for-dom-mocksensortype-linear-acceleration" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-linear-acceleration" style="display:none">Info about the '"linear-acceleration"' definition.</span><b><a href="#dom-mocksensortype-linear-acceleration">#dom-mocksensortype-linear-acceleration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-linear-acceleration">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-gravity">
-   <b><a href="#dom-mocksensortype-gravity">#dom-mocksensortype-gravity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-gravity" class="dfn-panel" data-for="dom-mocksensortype-gravity" id="infopanel-for-dom-mocksensortype-gravity" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-gravity" style="display:none">Info about the '"gravity"' definition.</span><b><a href="#dom-mocksensortype-gravity">#dom-mocksensortype-gravity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-gravity">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-gyroscope">
-   <b><a href="#dom-mocksensortype-gyroscope">#dom-mocksensortype-gyroscope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-gyroscope" class="dfn-panel" data-for="dom-mocksensortype-gyroscope" id="infopanel-for-dom-mocksensortype-gyroscope" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-gyroscope" style="display:none">Info about the '"gyroscope"' definition.</span><b><a href="#dom-mocksensortype-gyroscope">#dom-mocksensortype-gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-gyroscope">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-magnetometer">
-   <b><a href="#dom-mocksensortype-magnetometer">#dom-mocksensortype-magnetometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-magnetometer" class="dfn-panel" data-for="dom-mocksensortype-magnetometer" id="infopanel-for-dom-mocksensortype-magnetometer" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-magnetometer" style="display:none">Info about the '"magnetometer"' definition.</span><b><a href="#dom-mocksensortype-magnetometer">#dom-mocksensortype-magnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-magnetometer">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-uncalibrated-magnetometer">
-   <b><a href="#dom-mocksensortype-uncalibrated-magnetometer">#dom-mocksensortype-uncalibrated-magnetometer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-uncalibrated-magnetometer" class="dfn-panel" data-for="dom-mocksensortype-uncalibrated-magnetometer" id="infopanel-for-dom-mocksensortype-uncalibrated-magnetometer" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-uncalibrated-magnetometer" style="display:none">Info about the '"uncalibrated-magnetometer"' definition.</span><b><a href="#dom-mocksensortype-uncalibrated-magnetometer">#dom-mocksensortype-uncalibrated-magnetometer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-uncalibrated-magnetometer">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-absolute-orientation">
-   <b><a href="#dom-mocksensortype-absolute-orientation">#dom-mocksensortype-absolute-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-absolute-orientation" class="dfn-panel" data-for="dom-mocksensortype-absolute-orientation" id="infopanel-for-dom-mocksensortype-absolute-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-absolute-orientation" style="display:none">Info about the '"absolute-orientation"' definition.</span><b><a href="#dom-mocksensortype-absolute-orientation">#dom-mocksensortype-absolute-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-absolute-orientation">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-relative-orientation">
-   <b><a href="#dom-mocksensortype-relative-orientation">#dom-mocksensortype-relative-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-relative-orientation" class="dfn-panel" data-for="dom-mocksensortype-relative-orientation" id="infopanel-for-dom-mocksensortype-relative-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-relative-orientation" style="display:none">Info about the '"relative-orientation"' definition.</span><b><a href="#dom-mocksensortype-relative-orientation">#dom-mocksensortype-relative-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-relative-orientation">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-geolocation">
-   <b><a href="#dom-mocksensortype-geolocation">#dom-mocksensortype-geolocation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-geolocation" class="dfn-panel" data-for="dom-mocksensortype-geolocation" id="infopanel-for-dom-mocksensortype-geolocation" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-geolocation" style="display:none">Info about the '"geolocation"' definition.</span><b><a href="#dom-mocksensortype-geolocation">#dom-mocksensortype-geolocation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-geolocation">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mocksensortype-proximity">
-   <b><a href="#dom-mocksensortype-proximity">#dom-mocksensortype-proximity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mocksensortype-proximity" class="dfn-panel" data-for="dom-mocksensortype-proximity" id="infopanel-for-dom-mocksensortype-proximity" role="dialog">
+   <span id="infopaneltitle-for-dom-mocksensortype-proximity" style="display:none">Info about the '"proximity"' definition.</span><b><a href="#dom-mocksensortype-proximity">#dom-mocksensortype-proximity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mocksensortype-proximity">9.1.3. Mock sensor type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor-reading-values">
-   <b><a href="#mock-sensor-reading-values">#mock-sensor-reading-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mock-sensor-reading-values" class="dfn-panel" data-for="mock-sensor-reading-values" id="infopanel-for-mock-sensor-reading-values" role="dialog">
+   <span id="infopaneltitle-for-mock-sensor-reading-values" style="display:none">Info about the 'Mock Sensor Reading Values' definition.</span><b><a href="#mock-sensor-reading-values">#mock-sensor-reading-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-reading-values">9.1.3. Mock sensor type</a>
     <li><a href="#ref-for-mock-sensor-reading-values①">10.7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mocksensorreadingvalues">
-   <b><a href="#dictdef-mocksensorreadingvalues">#dictdef-mocksensorreadingvalues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mocksensorreadingvalues" class="dfn-panel" data-for="dictdef-mocksensorreadingvalues" id="infopanel-for-dictdef-mocksensorreadingvalues" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mocksensorreadingvalues" style="display:none">Info about the 'MockSensorReadingValues' definition.</span><b><a href="#dictdef-mocksensorreadingvalues">#dictdef-mocksensorreadingvalues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mocksensorreadingvalues">9.1. Mock Sensors</a>
     <li><a href="#ref-for-dictdef-mocksensorreadingvalues①">9.1.3. Mock sensor type</a> <a href="#ref-for-dictdef-mocksensorreadingvalues②">(2)</a>
     <li><a href="#ref-for-dictdef-mocksensorreadingvalues③">9.2.3. Update mock sensor reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-such-mock-sensor">
-   <b><a href="#no-such-mock-sensor">#no-such-mock-sensor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-such-mock-sensor" class="dfn-panel" data-for="no-such-mock-sensor" id="infopanel-for-no-such-mock-sensor" role="dialog">
+   <span id="infopaneltitle-for-no-such-mock-sensor" style="display:none">Info about the 'no such mock sensor' definition.</span><b><a href="#no-such-mock-sensor">#no-such-mock-sensor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-such-mock-sensor">9.2.2. Get mock sensor</a>
     <li><a href="#ref-for-no-such-mock-sensor①">9.2.3. Update mock sensor reading</a>
     <li><a href="#ref-for-no-such-mock-sensor②">9.2.4. Delete mock sensor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mock-sensor-already-created">
-   <b><a href="#mock-sensor-already-created">#mock-sensor-already-created</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mock-sensor-already-created" class="dfn-panel" data-for="mock-sensor-already-created" id="infopanel-for-mock-sensor-already-created" role="dialog">
+   <span id="infopaneltitle-for-mock-sensor-already-created" style="display:none">Info about the 'mock sensor already created' definition.</span><b><a href="#mock-sensor-already-created">#mock-sensor-already-created</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mock-sensor-already-created">9.2.1. Create mock sensor</a> <a href="#ref-for-mock-sensor-already-created①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extension-specification">
-   <b><a href="#extension-specification">#extension-specification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extension-specification" class="dfn-panel" data-for="extension-specification" id="infopanel-for-extension-specification" role="dialog">
+   <span id="infopaneltitle-for-extension-specification" style="display:none">Info about the 'extension specifications' definition.</span><b><a href="#extension-specification">#extension-specification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extension-specification">4.2.1. Secure Context</a>
     <li><a href="#ref-for-extension-specification①">5.6. Conditions to expose sensor readings</a>
@@ -4812,8 +4812,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-extension-specification①⑧">10.9. Extending the Permissions Policy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extension-sensor-interface">
-   <b><a href="#extension-sensor-interface">#extension-sensor-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extension-sensor-interface" class="dfn-panel" data-for="extension-sensor-interface" id="infopanel-for-extension-sensor-interface" role="dialog">
+   <span id="infopaneltitle-for-extension-sensor-interface" style="display:none">Info about the 'extension sensor interface' definition.</span><b><a href="#extension-sensor-interface">#extension-sensor-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extension-sensor-interface">6.1. Sensor Type</a>
     <li><a href="#ref-for-extension-sensor-interface①">6.2. Sensor</a> <a href="#ref-for-extension-sensor-interface②">(2)</a>
@@ -4822,8 +4822,8 @@ for their editorial input.</p>
     <li><a href="#ref-for-extension-sensor-interface⑧">10.7. Automation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-sensor-options">
-   <b><a href="#supported-sensor-options">#supported-sensor-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-sensor-options" class="dfn-panel" data-for="supported-sensor-options" id="infopanel-for-supported-sensor-options" role="dialog">
+   <span id="infopaneltitle-for-supported-sensor-options" style="display:none">Info about the 'supported sensor options' definition.</span><b><a href="#supported-sensor-options">#supported-sensor-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-sensor-options">8.1. Initialize a sensor object</a>
     <li><a href="#ref-for-supported-sensor-options①">10.6. Definition Requirements</a> <a href="#ref-for-supported-sensor-options②">(2)</a>
@@ -4831,59 +4831,115 @@ for their editorial input.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/sensors/usecases.html
+++ b/tests/github/w3c/sensors/usecases.html
@@ -496,85 +496,85 @@ that will trigger hardware interrupt and provide one bit reading data (on / off)
   </main>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-acceleration">
-   <a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-acceleration" class="dfn-panel" data-for="term-for-acceleration" id="infopanel-for-term-for-acceleration" role="menu">
+   <span id="infopaneltitle-for-term-for-acceleration" style="display:none">Info about the 'acceleration' external reference.</span><a href="https://w3c.github.io/accelerometer#acceleration">https://w3c.github.io/accelerometer#acceleration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acceleration">2.2. Inertial sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-accelerometer-interface">
-   <a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-accelerometer-interface" class="dfn-panel" data-for="term-for-accelerometer-interface" id="infopanel-for-term-for-accelerometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-accelerometer-interface" style="display:none">Info about the 'accelerometer' external reference.</span><a href="https://w3c.github.io/accelerometer#accelerometer-interface">https://w3c.github.io/accelerometer#accelerometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accelerometer-interface">2.2. Inertial sensors</a> <a href="#ref-for-accelerometer-interface①">(2)</a>
     <li><a href="#ref-for-accelerometer-interface②">2.3. Fusion sensors</a> <a href="#ref-for-accelerometer-interface③">(2)</a> <a href="#ref-for-accelerometer-interface④">(3)</a>
     <li><a href="#ref-for-accelerometer-interface⑤">2.5. Trigger sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gravitysensor-interface">
-   <a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gravitysensor-interface" class="dfn-panel" data-for="term-for-gravitysensor-interface" id="infopanel-for-term-for-gravitysensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gravitysensor-interface" style="display:none">Info about the 'gravity sensor' external reference.</span><a href="https://w3c.github.io/accelerometer#gravitysensor-interface">https://w3c.github.io/accelerometer#gravitysensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gravitysensor-interface">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface">
-   <a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-linearaccelerationsensor-interface" class="dfn-panel" data-for="term-for-linearaccelerationsensor-interface" id="infopanel-for-term-for-linearaccelerationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-linearaccelerationsensor-interface" style="display:none">Info about the 'linear acceleration sensor' external reference.</span><a href="https://w3c.github.io/accelerometer#linearaccelerationsensor-interface">https://w3c.github.io/accelerometer#linearaccelerationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-linearaccelerationsensor-interface">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usecases-requirements">
-   <a href="https://w3c.github.io/ambient-light#usecases-requirements">https://w3c.github.io/ambient-light#usecases-requirements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usecases-requirements" class="dfn-panel" data-for="term-for-usecases-requirements" id="infopanel-for-term-for-usecases-requirements" role="menu">
+   <span id="infopaneltitle-for-term-for-usecases-requirements" style="display:none">Info about the 'ambient light sensor' external reference.</span><a href="https://w3c.github.io/ambient-light#usecases-requirements">https://w3c.github.io/ambient-light#usecases-requirements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usecases-requirements">2.1. Environmental sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-gyroscope-interface">
-   <a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-gyroscope-interface" class="dfn-panel" data-for="term-for-gyroscope-interface" id="infopanel-for-term-for-gyroscope-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-gyroscope-interface" style="display:none">Info about the 'gyroscope' external reference.</span><a href="https://w3c.github.io/gyroscope#gyroscope-interface">https://w3c.github.io/gyroscope#gyroscope-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-interface">2.2. Inertial sensors</a> <a href="#ref-for-gyroscope-interface①">(2)</a> <a href="#ref-for-gyroscope-interface②">(3)</a>
     <li><a href="#ref-for-gyroscope-interface③">2.3. Fusion sensors</a> <a href="#ref-for-gyroscope-interface④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angular-velocity">
-   <a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angular-velocity" class="dfn-panel" data-for="term-for-angular-velocity" id="infopanel-for-term-for-angular-velocity" role="menu">
+   <span id="infopaneltitle-for-term-for-angular-velocity" style="display:none">Info about the 'rotational rate' external reference.</span><a href="https://w3c.github.io/gyroscope#angular-velocity">https://w3c.github.io/gyroscope#angular-velocity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angular-velocity">2.2. Inertial sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-magnetometer-interface">
-   <a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-magnetometer-interface" class="dfn-panel" data-for="term-for-magnetometer-interface" id="infopanel-for-term-for-magnetometer-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-magnetometer-interface" style="display:none">Info about the 'magnetometer' external reference.</span><a href="https://w3c.github.io/magnetometer#magnetometer-interface">https://w3c.github.io/magnetometer#magnetometer-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-magnetometer-interface">2.2. Inertial sensors</a>
     <li><a href="#ref-for-magnetometer-interface①">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usecases-and-requirements">
-   <a href="https://w3c.github.io/magnetometer#usecases-and-requirements">https://w3c.github.io/magnetometer#usecases-and-requirements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usecases-and-requirements" class="dfn-panel" data-for="term-for-usecases-and-requirements" id="infopanel-for-term-for-usecases-and-requirements" role="menu">
+   <span id="infopaneltitle-for-term-for-usecases-and-requirements" style="display:none">Info about the 'magnetometer use cases' external reference.</span><a href="https://w3c.github.io/magnetometer#usecases-and-requirements">https://w3c.github.io/magnetometer#usecases-and-requirements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usecases-and-requirements">2.1. Environmental sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-usecases-and-requirements">
-   <a href="https://w3c.github.io/motion-sensors#usecases-and-requirements">https://w3c.github.io/motion-sensors#usecases-and-requirements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-usecases-and-requirements" class="dfn-panel" data-for="term-for-usecases-and-requirements" id="infopanel-for-term-for-usecases-and-requirements①" role="menu">
+   <span id="infopaneltitle-for-term-for-usecases-and-requirements①" style="display:none">Info about the 'motion sensors explainer' external reference.</span><a href="https://w3c.github.io/motion-sensors#usecases-and-requirements">https://w3c.github.io/motion-sensors#usecases-and-requirements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-usecases-and-requirements①">2.2. Inertial sensors</a>
     <li><a href="#ref-for-usecases-and-requirements②">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absoluteorientationsensor-interface" class="dfn-panel" data-for="term-for-absoluteorientationsensor-interface" id="infopanel-for-term-for-absoluteorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-absoluteorientationsensor-interface" style="display:none">Info about the 'absolute orientation sensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface">https://w3c.github.io/orientation-sensor#absoluteorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absoluteorientationsensor-interface">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relativeorientationsensor-interface">
-   <a href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface">https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relativeorientationsensor-interface" class="dfn-panel" data-for="term-for-relativeorientationsensor-interface" id="infopanel-for-term-for-relativeorientationsensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-relativeorientationsensor-interface" style="display:none">Info about the 'relative orientation sensor' external reference.</span><a href="https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface">https://w3c.github.io/orientation-sensor#relativeorientationsensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relativeorientationsensor-interface">2.3. Fusion sensors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-proximity-sensor-interface">
-   <a href="https://w3c.github.io/proximity#proximity-sensor-interface">https://w3c.github.io/proximity#proximity-sensor-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-proximity-sensor-interface" class="dfn-panel" data-for="term-for-proximity-sensor-interface" id="infopanel-for-term-for-proximity-sensor-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-proximity-sensor-interface" style="display:none">Info about the 'proximity sensor' external reference.</span><a href="https://w3c.github.io/proximity#proximity-sensor-interface">https://w3c.github.io/proximity#proximity-sensor-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proximity-sensor-interface">2.1. Environmental sensors</a>
    </ul>
@@ -643,57 +643,113 @@ that will trigger hardware interrupt and provide one bit reading data (on / off)
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/svgwg/specs/color/Overview.html
+++ b/tests/github/w3c/svgwg/specs/color/Overview.html
@@ -1217,75 +1217,75 @@ or when all rendering-intents are provided using the same table.</p>
   </div>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">5. The effect of the color property</a> <a href="#ref-for-propdef-color①">(2)</a> <a href="#ref-for-propdef-color②">(3)</a> <a href="#ref-for-propdef-color③">(4)</a> <a href="#ref-for-propdef-color④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.3. 
       ICC colors</a>
     <li><a href="#ref-for-number-value①">3.4. LAB color</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">6.2. The CSS @color-profile rule</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a> <a href="#ref-for-url-value③">(4)</a> <a href="#ref-for-url-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-value-def-identifier">
-   <a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-value-def-identifier" class="dfn-panel" data-for="term-for-value-def-identifier" id="infopanel-for-term-for-value-def-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-value-def-identifier" style="display:none">Info about the '&lt;identifier>' external reference.</span><a href="https://drafts.csswg.org/css2/#value-def-identifier">https://drafts.csswg.org/css2/#value-def-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-def-identifier">6.2. The CSS @color-profile rule</a> <a href="#ref-for-value-def-identifier①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill" class="dfn-panel" data-for="term-for-propdef-fill" id="infopanel-for-term-for-propdef-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill">5. The effect of the color property</a>
     <li><a href="#ref-for-propdef-fill①">6.2. The CSS @color-profile rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke" class="dfn-panel" data-for="term-for-propdef-stroke" id="infopanel-for-term-for-propdef-stroke" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke" style="display:none">Info about the 'stroke' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke">5. The effect of the color property</a>
     <li><a href="#ref-for-propdef-stroke①">6.2. The CSS @color-profile rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flood-color">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flood-color" class="dfn-panel" data-for="term-for-propdef-flood-color" id="infopanel-for-term-for-propdef-flood-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flood-color" style="display:none">Info about the 'flood-color' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color">https://drafts.fxtf.org/filter-effects-1/#propdef-flood-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flood-color">5. The effect of the color property</a>
     <li><a href="#ref-for-propdef-flood-color①">6.2. The CSS @color-profile rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-lighting-color">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color">https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-lighting-color" class="dfn-panel" data-for="term-for-propdef-lighting-color" id="infopanel-for-term-for-propdef-lighting-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-lighting-color" style="display:none">Info about the 'lighting-color' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color">https://drafts.fxtf.org/filter-effects-1/#propdef-lighting-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-lighting-color">5. The effect of the color property</a>
     <li><a href="#ref-for-propdef-lighting-color①">6.2. The CSS @color-profile rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorInterpolationProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorInterpolationProperty" class="dfn-panel" data-for="term-for-ColorInterpolationProperty" id="infopanel-for-term-for-ColorInterpolationProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorInterpolationProperty" style="display:none">Info about the 'color-interpolation' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorInterpolationProperty">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-StopColorProperty">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-StopColorProperty" class="dfn-panel" data-for="term-for-StopColorProperty" id="infopanel-for-term-for-StopColorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-StopColorProperty" style="display:none">Info about the 'stop-color' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">https://svgwg.org/svg2-draft/pservers.html#StopColorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StopColorProperty">5. The effect of the color property</a>
     <li><a href="#ref-for-StopColorProperty①">6.2. The CSS @color-profile rule</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermURLReference">
-   <a href="https://svgwg.org/svg2-draft/linking.html#TermURLReference">https://svgwg.org/svg2-draft/linking.html#TermURLReference</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermURLReference" class="dfn-panel" data-for="term-for-TermURLReference" id="infopanel-for-term-for-TermURLReference" role="menu">
+   <span id="infopaneltitle-for-term-for-TermURLReference" style="display:none">Info about the 'url reference' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#TermURLReference">https://svgwg.org/svg2-draft/linking.html#TermURLReference</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermURLReference">6.2. The CSS @color-profile rule</a>
    </ul>
@@ -1361,57 +1361,113 @@ or when all rendering-intents are provided using the same table. <a class="issue
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/svgwg/specs/marker/Overview.html
+++ b/tests/github/w3c/svgwg/specs/marker/Overview.html
@@ -1746,82 +1746,82 @@ contents are not part of the formal document structure.</p>
    <li><a href="#vertex-markers">vertex markers</a><span>, in § 1</span>
    <li><a href="#element-attrdef-marker-viewbox">viewBox</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">2. The marker element</a> <a href="#ref-for-propdef-display①">(2)</a> <a href="#ref-for-propdef-display②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-none">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-none" class="dfn-panel" data-for="term-for-valdef-display-none" id="infopanel-for-term-for-valdef-display-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-none">https://drafts.csswg.org/css-display-3/#valdef-display-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-none">2. The marker element</a> <a href="#ref-for-valdef-display-none①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-ellipse">
-   <a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-rg-ending-shape-ellipse" class="dfn-panel" data-for="term-for-valdef-rg-ending-shape-ellipse" id="infopanel-for-term-for-valdef-rg-ending-shape-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-rg-ending-shape-ellipse" style="display:none">Info about the 'ellipse' external reference.</span><a href="https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse">https://drafts.csswg.org/css-images-3/#valdef-rg-ending-shape-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-rg-ending-shape-ellipse">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-clippath">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-clippath" class="dfn-panel" data-for="term-for-elementdef-clippath" id="infopanel-for-term-for-elementdef-clippath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-clippath" style="display:none">Info about the 'clippath' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-clippath">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-mask" class="dfn-panel" data-for="term-for-elementdef-mask" id="infopanel-for-term-for-elementdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-mask">https://drafts.fxtf.org/css-masking-1/#elementdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-mask">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-hidden">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-hidden" class="dfn-panel" data-for="term-for-valdef-overflow-hidden" id="infopanel-for-term-for-valdef-overflow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. The marker element</a> <a href="#ref-for-propdef-overflow①">(2)</a>
     <li><a href="#ref-for-propdef-overflow②">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-voice-family-child">
-   <a href="https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child">https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-voice-family-child" class="dfn-panel" data-for="term-for-valdef-voice-family-child" id="infopanel-for-term-for-valdef-voice-family-child" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-voice-family-child" style="display:none">Info about the 'child' external reference.</span><a href="https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child">https://drafts.csswg.org/css-speech-1/#valdef-voice-family-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-voice-family-child">3. Referencing marker elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-zero-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-zero-plus" class="dfn-panel" data-for="term-for-mult-zero-plus" id="infopanel-for-term-for-mult-zero-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-zero-plus" style="display:none">Info about the '*' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-zero-plus">https://drafts.csswg.org/css-values-4/#mult-zero-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-zero-plus">6. Repeating markers: the marker-pattern property</a>
     <li><a href="#ref-for-mult-zero-plus①">7. Marker shorthand: the marker property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-one-plus">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-one-plus" class="dfn-panel" data-for="term-for-mult-one-plus" id="infopanel-for-term-for-mult-one-plus" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-one-plus" style="display:none">Info about the '+' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-one-plus">https://drafts.csswg.org/css-values-4/#mult-one-plus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-one-plus">6. Repeating markers: the marker-pattern property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-angle-value">
-   <a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-angle-value" class="dfn-panel" data-for="term-for-angle-value" id="infopanel-for-term-for-angle-value" role="menu">
+   <span id="infopaneltitle-for-term-for-angle-value" style="display:none">Info about the '&lt;angle>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#angle-value">https://drafts.csswg.org/css-values-4/#angle-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-angle-value">2. The marker element</a> <a href="#ref-for-angle-value①">(2)</a> <a href="#ref-for-angle-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">2. The marker element</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a> <a href="#ref-for-length-value③">(4)</a>
     <li><a href="#ref-for-length-value④">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-length-value⑤">(2)</a>
@@ -1829,8 +1829,8 @@ contents are not part of the formal document structure.</p>
     <li><a href="#ref-for-length-value⑧">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-length-value⑨">(2)</a> <a href="#ref-for-length-value①⓪">(3)</a> <a href="#ref-for-length-value①①">(4)</a> <a href="#ref-for-length-value①②">(5)</a> <a href="#ref-for-length-value①③">(6)</a> <a href="#ref-for-length-value①④">(7)</a> <a href="#ref-for-length-value①⑤">(8)</a> <a href="#ref-for-length-value①⑥">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">2. The marker element</a> <a href="#ref-for-number-value①">(2)</a> <a href="#ref-for-number-value②">(3)</a> <a href="#ref-for-number-value③">(4)</a> <a href="#ref-for-number-value④">(5)</a> <a href="#ref-for-number-value⑤">(6)</a> <a href="#ref-for-number-value⑥">(7)</a>
     <li><a href="#ref-for-number-value⑦">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-number-value⑧">(2)</a>
@@ -1838,8 +1838,8 @@ contents are not part of the formal document structure.</p>
     <li><a href="#ref-for-number-value①①">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-number-value①②">(2)</a> <a href="#ref-for-number-value①③">(3)</a> <a href="#ref-for-number-value①④">(4)</a> <a href="#ref-for-number-value①⑤">(5)</a> <a href="#ref-for-number-value①⑥">(6)</a> <a href="#ref-for-number-value①⑦">(7)</a> <a href="#ref-for-number-value①⑧">(8)</a> <a href="#ref-for-number-value①⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">2. The marker element</a> <a href="#ref-for-percentage-value①">(2)</a> <a href="#ref-for-percentage-value②">(3)</a> <a href="#ref-for-percentage-value③">(4)</a>
     <li><a href="#ref-for-percentage-value④">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-percentage-value⑤">(2)</a>
@@ -1847,8 +1847,8 @@ contents are not part of the formal document structure.</p>
     <li><a href="#ref-for-percentage-value⑧">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-percentage-value⑨">(2)</a> <a href="#ref-for-percentage-value①⓪">(3)</a> <a href="#ref-for-percentage-value①①">(4)</a> <a href="#ref-for-percentage-value①②">(5)</a> <a href="#ref-for-percentage-value①③">(6)</a> <a href="#ref-for-percentage-value①④">(7)</a> <a href="#ref-for-percentage-value①⑤">(8)</a> <a href="#ref-for-percentage-value①⑥">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-value">
-   <a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-value" class="dfn-panel" data-for="term-for-url-value" id="infopanel-for-term-for-url-value" role="menu">
+   <span id="infopaneltitle-for-term-for-url-value" style="display:none">Info about the '&lt;url>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#url-value">https://drafts.csswg.org/css-values-4/#url-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-value">3. Referencing marker elements</a> <a href="#ref-for-url-value①">(2)</a> <a href="#ref-for-url-value②">(3)</a>
     <li><a href="#ref-for-url-value③">4. Vertex markers: the marker-start,
@@ -1857,29 +1857,29 @@ marker-mid and marker-end properties</a>
     <li><a href="#ref-for-url-value⑤">6. Repeating markers: the marker-pattern property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-opt">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-opt" class="dfn-panel" data-for="term-for-mult-opt" id="infopanel-for-term-for-mult-opt" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-opt" style="display:none">Info about the '?' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-opt">https://drafts.csswg.org/css-values-4/#mult-opt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-opt">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-mult-opt①">(2)</a>
     <li><a href="#ref-for-mult-opt②">7. Marker shorthand: the marker property</a>
     <li><a href="#ref-for-mult-opt③">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-mult-opt④">(2)</a> <a href="#ref-for-mult-opt⑤">(3)</a> <a href="#ref-for-mult-opt⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num-range">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num-range" class="dfn-panel" data-for="term-for-mult-num-range" id="infopanel-for-term-for-mult-num-range" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num-range" style="display:none">Info about the '{a,b}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num-range">https://drafts.csswg.org/css-values-4/#mult-num-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num-range">7. Marker shorthand: the marker property</a> <a href="#ref-for-mult-num-range①">(2)</a>
     <li><a href="#ref-for-mult-num-range②">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mult-num">
-   <a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mult-num" class="dfn-panel" data-for="term-for-mult-num" id="infopanel-for-term-for-mult-num" role="menu">
+   <span id="infopaneltitle-for-term-for-mult-num" style="display:none">Info about the '{a}' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mult-num">https://drafts.csswg.org/css-values-4/#mult-num</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mult-num">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">4. Vertex markers: the marker-start,
 marker-mid and marker-end properties</a>
@@ -1889,88 +1889,88 @@ marker-mid and marker-end properties</a>
     <li><a href="#ref-for-comb-one①②">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-comb-one①③">(2)</a> <a href="#ref-for-comb-one①④">(3)</a> <a href="#ref-for-comb-one①⑤">(4)</a> <a href="#ref-for-comb-one①⑥">(5)</a> <a href="#ref-for-comb-one①⑦">(6)</a> <a href="#ref-for-comb-one①⑧">(7)</a> <a href="#ref-for-comb-one①⑨">(8)</a> <a href="#ref-for-comb-one②⓪">(9)</a> <a href="#ref-for-comb-one②①">(10)</a> <a href="#ref-for-comb-one②②">(11)</a> <a href="#ref-for-comb-one②③">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-fill">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-fill" class="dfn-panel" data-for="term-for-propdef-fill" id="infopanel-for-term-for-propdef-fill" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-fill" style="display:none">Info about the 'fill' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-fill">https://drafts.fxtf.org/fill-stroke-3/#propdef-fill</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-fill">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke" class="dfn-panel" data-for="term-for-propdef-stroke" id="infopanel-for-term-for-propdef-stroke" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke" style="display:none">Info about the 'stroke' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-stroke-width">
-   <a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-stroke-width" class="dfn-panel" data-for="term-for-propdef-stroke-width" id="infopanel-for-term-for-propdef-stroke-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-stroke-width" style="display:none">Info about the 'stroke-width' external reference.</span><a href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width">https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-stroke-width">2. The marker element</a>
     <li><a href="#ref-for-propdef-stroke-width①">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#elementdef-filter">https://drafts.fxtf.org/filter-effects-1/#elementdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-filter" class="dfn-panel" data-for="term-for-elementdef-filter" id="infopanel-for-term-for-elementdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#elementdef-filter">https://drafts.fxtf.org/filter-effects-1/#elementdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-filter">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-media-inverted-colors-inverted">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-inverted-colors-inverted">https://drafts.csswg.org/mediaqueries-5/#valdef-media-inverted-colors-inverted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-media-inverted-colors-inverted" class="dfn-panel" data-for="term-for-valdef-media-inverted-colors-inverted" id="infopanel-for-term-for-valdef-media-inverted-colors-inverted" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-media-inverted-colors-inverted" style="display:none">Info about the 'inverted' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-media-inverted-colors-inverted">https://drafts.csswg.org/mediaqueries-5/#valdef-media-inverted-colors-inverted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-media-inverted-colors-inverted">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-valdef-media-inverted-colors-inverted①">(2)</a> <a href="#ref-for-valdef-media-inverted-colors-inverted②">(3)</a> <a href="#ref-for-valdef-media-inverted-colors-inverted③">(4)</a> <a href="#ref-for-valdef-media-inverted-colors-inverted④">(5)</a> <a href="#ref-for-valdef-media-inverted-colors-inverted⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGMarkerElement">
-   <a href="https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement">https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGMarkerElement" class="dfn-panel" data-for="term-for-InterfaceSVGMarkerElement" id="infopanel-for-term-for-InterfaceSVGMarkerElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGMarkerElement" style="display:none">Info about the 'SVGMarkerElement' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement">https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGMarkerElement">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-a">
-   <a href="https://svgwg.org/svg2-draft/linking.html#elementdef-a">https://svgwg.org/svg2-draft/linking.html#elementdef-a</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-a" class="dfn-panel" data-for="term-for-elementdef-a" id="infopanel-for-term-for-elementdef-a" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-a" style="display:none">Info about the 'a' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#elementdef-a">https://svgwg.org/svg2-draft/linking.html#elementdef-a</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-a">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-element">
-   <a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-element" class="dfn-panel" data-for="term-for-container-element" id="infopanel-for-term-for-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-container-element" style="display:none">Info about the 'container element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#container-element">https://svgwg.org/svg2-draft/struct.html#container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-element">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermDescriptiveElement">
-   <a href="https://svgwg.org/svg2-draft/struct.html#TermDescriptiveElement">https://svgwg.org/svg2-draft/struct.html#TermDescriptiveElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermDescriptiveElement" class="dfn-panel" data-for="term-for-TermDescriptiveElement" id="infopanel-for-term-for-TermDescriptiveElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermDescriptiveElement" style="display:none">Info about the 'descriptive element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#TermDescriptiveElement">https://svgwg.org/svg2-draft/struct.html#TermDescriptiveElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermDescriptiveElement">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-foreignObject">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-foreignObject" class="dfn-panel" data-for="term-for-elementdef-foreignObject" id="infopanel-for-term-for-elementdef-foreignObject" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-foreignObject" style="display:none">Info about the 'foreignobject' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-foreignObject">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-image">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-image" class="dfn-panel" data-for="term-for-elementdef-image" id="infopanel-for-term-for-elementdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-image" style="display:none">Info about the 'image' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-image">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-line">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-line" class="dfn-panel" data-for="term-for-elementdef-line" id="infopanel-for-term-for-elementdef-line" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-line" style="display:none">Info about the 'line' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-line">Unnumbered Section</a>
     <li><a href="#ref-for-elementdef-line①">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPaintServerElement">
-   <a href="https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement">https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPaintServerElement" class="dfn-panel" data-for="term-for-TermPaintServerElement" id="infopanel-for-term-for-TermPaintServerElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPaintServerElement" style="display:none">Info about the 'paint server element' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement">https://svgwg.org/svg2-draft/painting.html#TermPaintServerElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPaintServerElement">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-path">
-   <a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-path" class="dfn-panel" data-for="term-for-elementdef-path" id="infopanel-for-term-for-elementdef-path" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-path" style="display:none">Info about the 'path' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-path">Unnumbered Section</a>
     <li><a href="#ref-for-elementdef-path①">1. Introduction</a>
@@ -1978,8 +1978,8 @@ marker-mid and marker-end properties</a>
 marker-mid and marker-end properties</a> <a href="#ref-for-elementdef-path③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polygon">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polygon" class="dfn-panel" data-for="term-for-elementdef-polygon" id="infopanel-for-term-for-elementdef-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polygon" style="display:none">Info about the 'polygon' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polygon">Unnumbered Section</a>
     <li><a href="#ref-for-elementdef-polygon①">1. Introduction</a>
@@ -1987,69 +1987,69 @@ marker-mid and marker-end properties</a> <a href="#ref-for-elementdef-path③">(
 marker-mid and marker-end properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polyline">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polyline" class="dfn-panel" data-for="term-for-elementdef-polyline" id="infopanel-for-term-for-elementdef-polyline" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polyline" style="display:none">Info about the 'polyline' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polyline">Unnumbered Section</a>
     <li><a href="#ref-for-elementdef-polyline①">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermPresentationAttribute">
-   <a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermPresentationAttribute" class="dfn-panel" data-for="term-for-TermPresentationAttribute" id="infopanel-for-term-for-TermPresentationAttribute" role="menu">
+   <span id="infopaneltitle-for-term-for-TermPresentationAttribute" style="display:none">Info about the 'presentation attributes' external reference.</span><a href="https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute">https://svgwg.org/svg2-draft/styling.html#TermPresentationAttribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermPresentationAttribute">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-script">
-   <a href="https://svgwg.org/svg2-draft/interact.html#elementdef-script">https://svgwg.org/svg2-draft/interact.html#elementdef-script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-script" class="dfn-panel" data-for="term-for-elementdef-script" id="infopanel-for-term-for-elementdef-script" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-script" style="display:none">Info about the 'script' external reference.</span><a href="https://svgwg.org/svg2-draft/interact.html#elementdef-script">https://svgwg.org/svg2-draft/interact.html#elementdef-script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-script">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermShapeElement">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">https://svgwg.org/svg2-draft/shapes.html#TermShapeElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermShapeElement" class="dfn-panel" data-for="term-for-TermShapeElement" id="infopanel-for-term-for-TermShapeElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermShapeElement" style="display:none">Info about the 'shape elements' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#TermShapeElement">https://svgwg.org/svg2-draft/shapes.html#TermShapeElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermShapeElement">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TermStructuralElement">
-   <a href="https://svgwg.org/svg2-draft/struct.html#TermStructuralElement">https://svgwg.org/svg2-draft/struct.html#TermStructuralElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TermStructuralElement" class="dfn-panel" data-for="term-for-TermStructuralElement" id="infopanel-for-term-for-TermStructuralElement" role="menu">
+   <span id="infopaneltitle-for-term-for-TermStructuralElement" style="display:none">Info about the 'structural element' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#TermStructuralElement">https://svgwg.org/svg2-draft/struct.html#TermStructuralElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TermStructuralElement">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-style">
-   <a href="https://svgwg.org/svg2-draft/styling.html#elementdef-style">https://svgwg.org/svg2-draft/styling.html#elementdef-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-style" class="dfn-panel" data-for="term-for-elementdef-style" id="infopanel-for-term-for-elementdef-style" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-style" style="display:none">Info about the 'style' external reference.</span><a href="https://svgwg.org/svg2-draft/styling.html#elementdef-style">https://svgwg.org/svg2-draft/styling.html#elementdef-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-style">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-switch">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-switch" class="dfn-panel" data-for="term-for-elementdef-switch" id="infopanel-for-term-for-elementdef-switch" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-switch" style="display:none">Info about the 'switch' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-switch">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-symbol">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-symbol" class="dfn-panel" data-for="term-for-elementdef-symbol" id="infopanel-for-term-for-elementdef-symbol" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-symbol" style="display:none">Info about the 'symbol' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-symbol">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-text">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-text" class="dfn-panel" data-for="term-for-elementdef-text" id="infopanel-for-term-for-elementdef-text" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-text" style="display:none">Info about the 'text' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-text">2. The marker element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-use">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-use" class="dfn-panel" data-for="term-for-elementdef-use" id="infopanel-for-term-for-elementdef-use" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-use" style="display:none">Info about the 'use' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-use">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-view">
-   <a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-view" class="dfn-panel" data-for="term-for-elementdef-view" id="infopanel-for-term-for-elementdef-view" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-view" style="display:none">Info about the 'view' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-view">2. The marker element</a>
    </ul>
@@ -2345,8 +2345,8 @@ to join them together. <a class="issue-return" href="#issue-fcb1a084" title="Jum
      <a class="issue-return" href="#issue-cb08f5ff" title="Jump to section">↵</a>
    </div>
   </div>
-  <aside class="dfn-panel" data-for="markable-elements">
-   <b><a href="#markable-elements">#markable-elements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-markable-elements" class="dfn-panel" data-for="markable-elements" id="infopanel-for-markable-elements" role="dialog">
+   <span id="infopaneltitle-for-markable-elements" style="display:none">Info about the 'markable elements' definition.</span><b><a href="#markable-elements">#markable-elements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-markable-elements">2. The marker element</a> <a href="#ref-for-markable-elements①">(2)</a> <a href="#ref-for-markable-elements②">(3)</a> <a href="#ref-for-markable-elements③">(4)</a> <a href="#ref-for-markable-elements④">(5)</a> <a href="#ref-for-markable-elements⑤">(6)</a> <a href="#ref-for-markable-elements⑥">(7)</a> <a href="#ref-for-markable-elements⑦">(8)</a>
     <li><a href="#ref-for-markable-elements⑧">4. Vertex markers: the marker-start,
@@ -2356,8 +2356,8 @@ marker-mid and marker-end properties</a> <a href="#ref-for-markable-elements⑨"
     <li><a href="#ref-for-markable-elements①③">7. Marker shorthand: the marker property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vertex-markers">
-   <b><a href="#vertex-markers">#vertex-markers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vertex-markers" class="dfn-panel" data-for="vertex-markers" id="infopanel-for-vertex-markers" role="dialog">
+   <span id="infopaneltitle-for-vertex-markers" style="display:none">Info about the 'vertex markers' definition.</span><b><a href="#vertex-markers">#vertex-markers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertex-markers">4. Vertex markers: the marker-start,
 marker-mid and marker-end properties</a>
@@ -2365,36 +2365,36 @@ marker-mid and marker-end properties</a>
     <li><a href="#ref-for-vertex-markers②">6. Repeating markers: the marker-pattern property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="segment-markers">
-   <b><a href="#segment-markers">#segment-markers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-segment-markers" class="dfn-panel" data-for="segment-markers" id="infopanel-for-segment-markers" role="dialog">
+   <span id="infopaneltitle-for-segment-markers" style="display:none">Info about the 'segment markers' definition.</span><b><a href="#segment-markers">#segment-markers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-segment-markers">2. The marker element</a> <a href="#ref-for-segment-markers①">(2)</a>
     <li><a href="#ref-for-segment-markers②">5. Segment markers: the marker-segment property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="repeating-markers">
-   <b><a href="#repeating-markers">#repeating-markers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-repeating-markers" class="dfn-panel" data-for="repeating-markers" id="infopanel-for-repeating-markers" role="dialog">
+   <span id="infopaneltitle-for-repeating-markers" style="display:none">Info about the 'repeating markers' definition.</span><b><a href="#repeating-markers">#repeating-markers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-repeating-markers">1. Introduction</a>
     <li><a href="#ref-for-repeating-markers①">2. The marker element</a>
     <li><a href="#ref-for-repeating-markers②">6. Repeating markers: the marker-pattern property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="positioned-markers">
-   <b><a href="#positioned-markers">#positioned-markers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-positioned-markers" class="dfn-panel" data-for="positioned-markers" id="infopanel-for-positioned-markers" role="dialog">
+   <span id="infopaneltitle-for-positioned-markers" style="display:none">Info about the 'positioned markers' definition.</span><b><a href="#positioned-markers">#positioned-markers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-positioned-markers">1. Introduction</a>
     <li><a href="#ref-for-positioned-markers①">2. The marker element</a> <a href="#ref-for-positioned-markers②">(2)</a> <a href="#ref-for-positioned-markers③">(3)</a> <a href="#ref-for-positioned-markers④">(4)</a> <a href="#ref-for-positioned-markers⑤">(5)</a> <a href="#ref-for-positioned-markers⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="marker-properties">
-   <b><a href="#marker-properties">#marker-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-marker-properties" class="dfn-panel" data-for="marker-properties" id="infopanel-for-marker-properties" role="dialog">
+   <span id="infopaneltitle-for-marker-properties" style="display:none">Info about the 'marker properties' definition.</span><b><a href="#marker-properties">#marker-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-marker-properties">2. The marker element</a> <a href="#ref-for-marker-properties①">(2)</a> <a href="#ref-for-marker-properties②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-marker">
-   <b><a href="#elementdef-marker">#elementdef-marker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-marker" class="dfn-panel" data-for="elementdef-marker" id="infopanel-for-elementdef-marker" role="dialog">
+   <span id="infopaneltitle-for-elementdef-marker" style="display:none">Info about the 'marker' definition.</span><b><a href="#elementdef-marker">#elementdef-marker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-marker">1. Introduction</a> <a href="#ref-for-elementdef-marker①">(2)</a> <a href="#ref-for-elementdef-marker②">(3)</a> <a href="#ref-for-elementdef-marker③">(4)</a>
     <li><a href="#ref-for-elementdef-marker④">2. The marker element</a> <a href="#ref-for-elementdef-marker⑤">(2)</a> <a href="#ref-for-elementdef-marker⑥">(3)</a> <a href="#ref-for-elementdef-marker⑦">(4)</a> <a href="#ref-for-elementdef-marker⑧">(5)</a> <a href="#ref-for-elementdef-marker⑨">(6)</a> <a href="#ref-for-elementdef-marker①⓪">(7)</a> <a href="#ref-for-elementdef-marker①①">(8)</a> <a href="#ref-for-elementdef-marker①②">(9)</a> <a href="#ref-for-elementdef-marker①③">(10)</a> <a href="#ref-for-elementdef-marker①④">(11)</a> <a href="#ref-for-elementdef-marker①⑤">(12)</a> <a href="#ref-for-elementdef-marker①⑥">(13)</a> <a href="#ref-for-elementdef-marker①⑦">(14)</a> <a href="#ref-for-elementdef-marker①⑧">(15)</a> <a href="#ref-for-elementdef-marker①⑨">(16)</a> <a href="#ref-for-elementdef-marker②⓪">(17)</a> <a href="#ref-for-elementdef-marker②①">(18)</a> <a href="#ref-for-elementdef-marker②②">(19)</a> <a href="#ref-for-elementdef-marker②③">(20)</a> <a href="#ref-for-elementdef-marker②④">(21)</a> <a href="#ref-for-elementdef-marker②⑤">(22)</a> <a href="#ref-for-elementdef-marker②⑥">(23)</a> <a href="#ref-for-elementdef-marker②⑦">(24)</a> <a href="#ref-for-elementdef-marker②⑧">(25)</a> <a href="#ref-for-elementdef-marker②⑨">(26)</a> <a href="#ref-for-elementdef-marker③⓪">(27)</a> <a href="#ref-for-elementdef-marker③①">(28)</a> <a href="#ref-for-elementdef-marker③②">(29)</a>
@@ -2407,85 +2407,85 @@ marker-mid and marker-end properties</a>
     <li><a href="#ref-for-elementdef-marker④⑤">9. Details on how markers are rendered</a> <a href="#ref-for-elementdef-marker④⑥">(2)</a> <a href="#ref-for-elementdef-marker④⑦">(3)</a> <a href="#ref-for-elementdef-marker④⑧">(4)</a> <a href="#ref-for-elementdef-marker④⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-markerunits">
-   <b><a href="#element-attrdef-marker-markerunits">#element-attrdef-marker-markerunits</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-markerunits" class="dfn-panel" data-for="element-attrdef-marker-markerunits" id="infopanel-for-element-attrdef-marker-markerunits" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-markerunits" style="display:none">Info about the 'markerUnits' definition.</span><b><a href="#element-attrdef-marker-markerunits">#element-attrdef-marker-markerunits</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-markerunits">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-markerunits①">(2)</a> <a href="#ref-for-element-attrdef-marker-markerunits②">(3)</a> <a href="#ref-for-element-attrdef-marker-markerunits③">(4)</a>
     <li><a href="#ref-for-element-attrdef-marker-markerunits④">9. Details on how markers are rendered</a> <a href="#ref-for-element-attrdef-marker-markerunits⑤">(2)</a> <a href="#ref-for-element-attrdef-marker-markerunits⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-markerunits-strokewidth">
-   <b><a href="#valdef-markerunits-strokewidth">#valdef-markerunits-strokewidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-markerunits-strokewidth" class="dfn-panel" data-for="valdef-markerunits-strokewidth" id="infopanel-for-valdef-markerunits-strokewidth" role="dialog">
+   <span id="infopaneltitle-for-valdef-markerunits-strokewidth" style="display:none">Info about the 'strokeWidth' definition.</span><b><a href="#valdef-markerunits-strokewidth">#valdef-markerunits-strokewidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-markerunits-strokewidth">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-markerunits-userspaceonuse">
-   <b><a href="#valdef-markerunits-userspaceonuse">#valdef-markerunits-userspaceonuse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-markerunits-userspaceonuse" class="dfn-panel" data-for="valdef-markerunits-userspaceonuse" id="infopanel-for-valdef-markerunits-userspaceonuse" role="dialog">
+   <span id="infopaneltitle-for-valdef-markerunits-userspaceonuse" style="display:none">Info about the 'userSpaceOnUse' definition.</span><b><a href="#valdef-markerunits-userspaceonuse">#valdef-markerunits-userspaceonuse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-markerunits-userspaceonuse">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-markerwidth">
-   <b><a href="#element-attrdef-marker-markerwidth">#element-attrdef-marker-markerwidth</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-markerwidth" class="dfn-panel" data-for="element-attrdef-marker-markerwidth" id="infopanel-for-element-attrdef-marker-markerwidth" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-markerwidth" style="display:none">Info about the 'markerWidth' definition.</span><b><a href="#element-attrdef-marker-markerwidth">#element-attrdef-marker-markerwidth</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-markerwidth">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-markerwidth①">(2)</a> <a href="#ref-for-element-attrdef-marker-markerwidth②">(3)</a> <a href="#ref-for-element-attrdef-marker-markerwidth③">(4)</a> <a href="#ref-for-element-attrdef-marker-markerwidth④">(5)</a> <a href="#ref-for-element-attrdef-marker-markerwidth⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-markerheight">
-   <b><a href="#element-attrdef-marker-markerheight">#element-attrdef-marker-markerheight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-markerheight" class="dfn-panel" data-for="element-attrdef-marker-markerheight" id="infopanel-for-element-attrdef-marker-markerheight" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-markerheight" style="display:none">Info about the 'markerHeight' definition.</span><b><a href="#element-attrdef-marker-markerheight">#element-attrdef-marker-markerheight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-markerheight">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-markerheight①">(2)</a> <a href="#ref-for-element-attrdef-marker-markerheight②">(3)</a> <a href="#ref-for-element-attrdef-marker-markerheight③">(4)</a> <a href="#ref-for-element-attrdef-marker-markerheight④">(5)</a> <a href="#ref-for-element-attrdef-marker-markerheight⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-refx">
-   <b><a href="#element-attrdef-marker-refx">#element-attrdef-marker-refx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-refx" class="dfn-panel" data-for="element-attrdef-marker-refx" id="infopanel-for-element-attrdef-marker-refx" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-refx" style="display:none">Info about the 'refX' definition.</span><b><a href="#element-attrdef-marker-refx">#element-attrdef-marker-refx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-refx">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-refx①">(2)</a> <a href="#ref-for-element-attrdef-marker-refx②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-refy">
-   <b><a href="#element-attrdef-marker-refy">#element-attrdef-marker-refy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-refy" class="dfn-panel" data-for="element-attrdef-marker-refy" id="infopanel-for-element-attrdef-marker-refy" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-refy" style="display:none">Info about the 'refY' definition.</span><b><a href="#element-attrdef-marker-refy">#element-attrdef-marker-refy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-refy">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-refy①">(2)</a> <a href="#ref-for-element-attrdef-marker-refy②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-orient">
-   <b><a href="#element-attrdef-marker-orient">#element-attrdef-marker-orient</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-orient" class="dfn-panel" data-for="element-attrdef-marker-orient" id="infopanel-for-element-attrdef-marker-orient" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-orient" style="display:none">Info about the 'orient' definition.</span><b><a href="#element-attrdef-marker-orient">#element-attrdef-marker-orient</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-orient">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-orient①">(2)</a> <a href="#ref-for-element-attrdef-marker-orient②">(3)</a>
     <li><a href="#ref-for-element-attrdef-marker-orient③">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-position">
-   <b><a href="#element-attrdef-marker-position">#element-attrdef-marker-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-position" class="dfn-panel" data-for="element-attrdef-marker-position" id="infopanel-for-element-attrdef-marker-position" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-position" style="display:none">Info about the 'position' definition.</span><b><a href="#element-attrdef-marker-position">#element-attrdef-marker-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-position">1. Introduction</a>
     <li><a href="#ref-for-element-attrdef-marker-position①">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-position②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-href">
-   <b><a href="#element-attrdef-marker-href">#element-attrdef-marker-href</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-href" class="dfn-panel" data-for="element-attrdef-marker-href" id="infopanel-for-element-attrdef-marker-href" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-href" style="display:none">Info about the 'href' definition.</span><b><a href="#element-attrdef-marker-href">#element-attrdef-marker-href</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-href">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-href①">(2)</a> <a href="#ref-for-element-attrdef-marker-href②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-viewbox">
-   <b><a href="#element-attrdef-marker-viewbox">#element-attrdef-marker-viewbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-viewbox" class="dfn-panel" data-for="element-attrdef-marker-viewbox" id="infopanel-for-element-attrdef-marker-viewbox" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-viewbox" style="display:none">Info about the 'viewBox' definition.</span><b><a href="#element-attrdef-marker-viewbox">#element-attrdef-marker-viewbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-viewbox">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-viewbox①">(2)</a> <a href="#ref-for-element-attrdef-marker-viewbox②">(3)</a> <a href="#ref-for-element-attrdef-marker-viewbox③">(4)</a> <a href="#ref-for-element-attrdef-marker-viewbox④">(5)</a> <a href="#ref-for-element-attrdef-marker-viewbox⑤">(6)</a> <a href="#ref-for-element-attrdef-marker-viewbox⑥">(7)</a> <a href="#ref-for-element-attrdef-marker-viewbox⑦">(8)</a> <a href="#ref-for-element-attrdef-marker-viewbox⑧">(9)</a>
     <li><a href="#ref-for-element-attrdef-marker-viewbox⑨">9. Details on how markers are rendered</a> <a href="#ref-for-element-attrdef-marker-viewbox①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-marker-preserveaspectratio">
-   <b><a href="#element-attrdef-marker-preserveaspectratio">#element-attrdef-marker-preserveaspectratio</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-marker-preserveaspectratio" class="dfn-panel" data-for="element-attrdef-marker-preserveaspectratio" id="infopanel-for-element-attrdef-marker-preserveaspectratio" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-marker-preserveaspectratio" style="display:none">Info about the 'preserveAspectRatio' definition.</span><b><a href="#element-attrdef-marker-preserveaspectratio">#element-attrdef-marker-preserveaspectratio</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-marker-preserveaspectratio">2. The marker element</a> <a href="#ref-for-element-attrdef-marker-preserveaspectratio①">(2)</a> <a href="#ref-for-element-attrdef-marker-preserveaspectratio②">(3)</a> <a href="#ref-for-element-attrdef-marker-preserveaspectratio③">(4)</a> <a href="#ref-for-element-attrdef-marker-preserveaspectratio④">(5)</a> <a href="#ref-for-element-attrdef-marker-preserveaspectratio⑤">(6)</a>
     <li><a href="#ref-for-element-attrdef-marker-preserveaspectratio⑥">9. Details on how markers are rendered</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="DataTypeMarkerRef">
-   <b><a href="#DataTypeMarkerRef">#DataTypeMarkerRef</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-DataTypeMarkerRef" class="dfn-panel" data-for="DataTypeMarkerRef" id="infopanel-for-DataTypeMarkerRef" role="dialog">
+   <span id="infopaneltitle-for-DataTypeMarkerRef" style="display:none">Info about the '&lt;marker-ref>' definition.</span><b><a href="#DataTypeMarkerRef">#DataTypeMarkerRef</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-DataTypeMarkerRef">3. Referencing marker elements</a>
     <li><a href="#ref-for-DataTypeMarkerRef①">4. Vertex markers: the marker-start,
@@ -2495,14 +2495,14 @@ marker-mid and marker-end properties</a> <a href="#ref-for-DataTypeMarkerRef②"
     <li><a href="#ref-for-DataTypeMarkerRef①①">7. Marker shorthand: the marker property</a> <a href="#ref-for-DataTypeMarkerRef①②">(2)</a> <a href="#ref-for-DataTypeMarkerRef①③">(3)</a> <a href="#ref-for-DataTypeMarkerRef①④">(4)</a> <a href="#ref-for-DataTypeMarkerRef①⑤">(5)</a> <a href="#ref-for-DataTypeMarkerRef①⑥">(6)</a> <a href="#ref-for-DataTypeMarkerRef①⑦">(7)</a> <a href="#ref-for-DataTypeMarkerRef①⑧">(8)</a> <a href="#ref-for-DataTypeMarkerRef①⑨">(9)</a> <a href="#ref-for-DataTypeMarkerRef②⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-child-selector">
-   <b><a href="#typedef-child-selector">#typedef-child-selector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-child-selector" class="dfn-panel" data-for="typedef-child-selector" id="infopanel-for-typedef-child-selector" role="dialog">
+   <span id="infopaneltitle-for-typedef-child-selector" style="display:none">Info about the '&lt;child-selector>' definition.</span><b><a href="#typedef-child-selector">#typedef-child-selector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-child-selector">3. Referencing marker elements</a> <a href="#ref-for-typedef-child-selector①">(2)</a> <a href="#ref-for-typedef-child-selector②">(3)</a> <a href="#ref-for-typedef-child-selector③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-start">
-   <b><a href="#propdef-marker-start">#propdef-marker-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-start" class="dfn-panel" data-for="propdef-marker-start" id="infopanel-for-propdef-marker-start" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-start" style="display:none">Info about the 'marker-start' definition.</span><b><a href="#propdef-marker-start">#propdef-marker-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-start">1. Introduction</a> <a href="#ref-for-propdef-marker-start①">(2)</a> <a href="#ref-for-propdef-marker-start②">(3)</a> <a href="#ref-for-propdef-marker-start③">(4)</a>
     <li><a href="#ref-for-propdef-marker-start④">2. The marker element</a>
@@ -2511,8 +2511,8 @@ marker-mid and marker-end properties</a> <a href="#ref-for-propdef-marker-start�
     <li><a href="#ref-for-propdef-marker-start⑨">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker-start①⓪">(2)</a> <a href="#ref-for-propdef-marker-start①①">(3)</a> <a href="#ref-for-propdef-marker-start①②">(4)</a> <a href="#ref-for-propdef-marker-start①③">(5)</a> <a href="#ref-for-propdef-marker-start①④">(6)</a> <a href="#ref-for-propdef-marker-start①⑤">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-mid">
-   <b><a href="#propdef-marker-mid">#propdef-marker-mid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-mid" class="dfn-panel" data-for="propdef-marker-mid" id="infopanel-for-propdef-marker-mid" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-mid" style="display:none">Info about the 'marker-mid' definition.</span><b><a href="#propdef-marker-mid">#propdef-marker-mid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-mid">1. Introduction</a> <a href="#ref-for-propdef-marker-mid①">(2)</a> <a href="#ref-for-propdef-marker-mid②">(3)</a>
     <li><a href="#ref-for-propdef-marker-mid③">4. Vertex markers: the marker-start,
@@ -2520,8 +2520,8 @@ marker-mid and marker-end properties</a> <a href="#ref-for-propdef-marker-mid④
     <li><a href="#ref-for-propdef-marker-mid⑥">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker-mid⑦">(2)</a> <a href="#ref-for-propdef-marker-mid⑧">(3)</a> <a href="#ref-for-propdef-marker-mid⑨">(4)</a> <a href="#ref-for-propdef-marker-mid①⓪">(5)</a> <a href="#ref-for-propdef-marker-mid①①">(6)</a> <a href="#ref-for-propdef-marker-mid①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-end">
-   <b><a href="#propdef-marker-end">#propdef-marker-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-end" class="dfn-panel" data-for="propdef-marker-end" id="infopanel-for-propdef-marker-end" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-end" style="display:none">Info about the 'marker-end' definition.</span><b><a href="#propdef-marker-end">#propdef-marker-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-end">1. Introduction</a> <a href="#ref-for-propdef-marker-end①">(2)</a> <a href="#ref-for-propdef-marker-end②">(3)</a>
     <li><a href="#ref-for-propdef-marker-end③">4. Vertex markers: the marker-start,
@@ -2529,133 +2529,189 @@ marker-mid and marker-end properties</a> <a href="#ref-for-propdef-marker-end④
     <li><a href="#ref-for-propdef-marker-end⑧">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker-end⑨">(2)</a> <a href="#ref-for-propdef-marker-end①⓪">(3)</a> <a href="#ref-for-propdef-marker-end①①">(4)</a> <a href="#ref-for-propdef-marker-end①②">(5)</a> <a href="#ref-for-propdef-marker-end①③">(6)</a> <a href="#ref-for-propdef-marker-end①④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-marker-start-none">
-   <b><a href="#valdef-marker-start-none">#valdef-marker-start-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-marker-start-none" class="dfn-panel" data-for="valdef-marker-start-none" id="infopanel-for-valdef-marker-start-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-marker-start-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-marker-start-none">#valdef-marker-start-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-marker-start-none">4. Vertex markers: the marker-start,
 marker-mid and marker-end properties</a>
     <li><a href="#ref-for-valdef-marker-start-none①">7. Marker shorthand: the marker property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-segment">
-   <b><a href="#propdef-marker-segment">#propdef-marker-segment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-segment" class="dfn-panel" data-for="propdef-marker-segment" id="infopanel-for-propdef-marker-segment" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-segment" style="display:none">Info about the 'marker-segment' definition.</span><b><a href="#propdef-marker-segment">#propdef-marker-segment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-segment">1. Introduction</a> <a href="#ref-for-propdef-marker-segment①">(2)</a> <a href="#ref-for-propdef-marker-segment②">(3)</a>
     <li><a href="#ref-for-propdef-marker-segment③">5. Segment markers: the marker-segment property</a> <a href="#ref-for-propdef-marker-segment④">(2)</a>
     <li><a href="#ref-for-propdef-marker-segment⑤">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker-segment⑥">(2)</a> <a href="#ref-for-propdef-marker-segment⑦">(3)</a> <a href="#ref-for-propdef-marker-segment⑧">(4)</a> <a href="#ref-for-propdef-marker-segment⑨">(5)</a> <a href="#ref-for-propdef-marker-segment①⓪">(6)</a> <a href="#ref-for-propdef-marker-segment①①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-pattern">
-   <b><a href="#propdef-marker-pattern">#propdef-marker-pattern</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-pattern" class="dfn-panel" data-for="propdef-marker-pattern" id="infopanel-for-propdef-marker-pattern" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-pattern" style="display:none">Info about the 'marker-pattern' definition.</span><b><a href="#propdef-marker-pattern">#propdef-marker-pattern</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-pattern">1. Introduction</a> <a href="#ref-for-propdef-marker-pattern①">(2)</a> <a href="#ref-for-propdef-marker-pattern②">(3)</a>
     <li><a href="#ref-for-propdef-marker-pattern③">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-propdef-marker-pattern④">(2)</a> <a href="#ref-for-propdef-marker-pattern⑤">(3)</a> <a href="#ref-for-propdef-marker-pattern⑥">(4)</a>
     <li><a href="#ref-for-propdef-marker-pattern⑦">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker-pattern⑧">(2)</a> <a href="#ref-for-propdef-marker-pattern⑨">(3)</a> <a href="#ref-for-propdef-marker-pattern①⓪">(4)</a> <a href="#ref-for-propdef-marker-pattern①①">(5)</a> <a href="#ref-for-propdef-marker-pattern①②">(6)</a> <a href="#ref-for-propdef-marker-pattern①③">(7)</a> <a href="#ref-for-propdef-marker-pattern①④">(8)</a> <a href="#ref-for-propdef-marker-pattern①⑤">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-marker-gap">
-   <b><a href="#typedef-marker-gap">#typedef-marker-gap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-marker-gap" class="dfn-panel" data-for="typedef-marker-gap" id="infopanel-for-typedef-marker-gap" role="dialog">
+   <span id="infopaneltitle-for-typedef-marker-gap" style="display:none">Info about the '&lt;marker-gap>' definition.</span><b><a href="#typedef-marker-gap">#typedef-marker-gap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-marker-gap">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-typedef-marker-gap①">(2)</a> <a href="#ref-for-typedef-marker-gap②">(3)</a> <a href="#ref-for-typedef-marker-gap③">(4)</a> <a href="#ref-for-typedef-marker-gap④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-marker-ref-group">
-   <b><a href="#typedef-marker-ref-group">#typedef-marker-ref-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-marker-ref-group" class="dfn-panel" data-for="typedef-marker-ref-group" id="infopanel-for-typedef-marker-ref-group" role="dialog">
+   <span id="infopaneltitle-for-typedef-marker-ref-group" style="display:none">Info about the '&lt;marker-ref-group>' definition.</span><b><a href="#typedef-marker-ref-group">#typedef-marker-ref-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-marker-ref-group">6. Repeating markers: the marker-pattern property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-marker-pattern-none">
-   <b><a href="#valdef-marker-pattern-none">#valdef-marker-pattern-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-marker-pattern-none" class="dfn-panel" data-for="valdef-marker-pattern-none" id="infopanel-for-valdef-marker-pattern-none" role="dialog">
+   <span id="infopaneltitle-for-valdef-marker-pattern-none" style="display:none">Info about the 'none' definition.</span><b><a href="#valdef-marker-pattern-none">#valdef-marker-pattern-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-marker-pattern-none">6. Repeating markers: the marker-pattern property</a> <a href="#ref-for-valdef-marker-pattern-none①">(2)</a>
     <li><a href="#ref-for-valdef-marker-pattern-none②">7. Marker shorthand: the marker property</a> <a href="#ref-for-valdef-marker-pattern-none③">(2)</a> <a href="#ref-for-valdef-marker-pattern-none④">(3)</a> <a href="#ref-for-valdef-marker-pattern-none⑤">(4)</a> <a href="#ref-for-valdef-marker-pattern-none⑥">(5)</a> <a href="#ref-for-valdef-marker-pattern-none⑦">(6)</a> <a href="#ref-for-valdef-marker-pattern-none⑧">(7)</a> <a href="#ref-for-valdef-marker-pattern-none⑨">(8)</a> <a href="#ref-for-valdef-marker-pattern-none①⓪">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker">
-   <b><a href="#propdef-marker">#propdef-marker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker" class="dfn-panel" data-for="propdef-marker" id="infopanel-for-propdef-marker" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker" style="display:none">Info about the 'marker' definition.</span><b><a href="#propdef-marker">#propdef-marker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker">2. The marker element</a>
     <li><a href="#ref-for-propdef-marker①">7. Marker shorthand: the marker property</a> <a href="#ref-for-propdef-marker②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-knockout-left">
-   <b><a href="#propdef-marker-knockout-left">#propdef-marker-knockout-left</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-knockout-left" class="dfn-panel" data-for="propdef-marker-knockout-left" id="infopanel-for-propdef-marker-knockout-left" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-knockout-left" style="display:none">Info about the 'marker-knockout-left' definition.</span><b><a href="#propdef-marker-knockout-left">#propdef-marker-knockout-left</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-knockout-left">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-propdef-marker-knockout-left①">(2)</a> <a href="#ref-for-propdef-marker-knockout-left②">(3)</a> <a href="#ref-for-propdef-marker-knockout-left③">(4)</a> <a href="#ref-for-propdef-marker-knockout-left④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-marker-knockout-right">
-   <b><a href="#propdef-marker-knockout-right">#propdef-marker-knockout-right</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-marker-knockout-right" class="dfn-panel" data-for="propdef-marker-knockout-right" id="infopanel-for-propdef-marker-knockout-right" role="dialog">
+   <span id="infopaneltitle-for-propdef-marker-knockout-right" style="display:none">Info about the 'marker-knockout-right' definition.</span><b><a href="#propdef-marker-knockout-right">#propdef-marker-knockout-right</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-marker-knockout-right">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-propdef-marker-knockout-right①">(2)</a> <a href="#ref-for-propdef-marker-knockout-right②">(3)</a> <a href="#ref-for-propdef-marker-knockout-right③">(4)</a> <a href="#ref-for-propdef-marker-knockout-right④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-knockout-offset">
-   <b><a href="#typedef-knockout-offset">#typedef-knockout-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-knockout-offset" class="dfn-panel" data-for="typedef-knockout-offset" id="infopanel-for-typedef-knockout-offset" role="dialog">
+   <span id="infopaneltitle-for-typedef-knockout-offset" style="display:none">Info about the '&lt;knockout-offset>' definition.</span><b><a href="#typedef-knockout-offset">#typedef-knockout-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-knockout-offset">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-typedef-knockout-offset①">(2)</a> <a href="#ref-for-typedef-knockout-offset②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-knockout-shape">
-   <b><a href="#typedef-knockout-shape">#typedef-knockout-shape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-knockout-shape" class="dfn-panel" data-for="typedef-knockout-shape" id="infopanel-for-typedef-knockout-shape" role="dialog">
+   <span id="infopaneltitle-for-typedef-knockout-shape" style="display:none">Info about the '&lt;knockout-shape>' definition.</span><b><a href="#typedef-knockout-shape">#typedef-knockout-shape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-knockout-shape">8. Knocking out the stroke: the marker-knockout-left and marker-knockout-right properties</a> <a href="#ref-for-typedef-knockout-shape①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/svgwg/specs/svg-native/index.html
+++ b/tests/github/w3c/svgwg/specs/svg-native/index.html
@@ -799,668 +799,668 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-valdef-align-self-auto">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-align-self-auto" class="dfn-panel" data-for="term-for-valdef-align-self-auto" id="infopanel-for-term-for-valdef-align-self-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-align-self-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-align-self-auto">https://drafts.csswg.org/css-align-3/#valdef-align-self-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-align-self-auto">2. Rendering Model</a>
     <li><a href="#ref-for-valdef-align-self-auto①">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-background-attachment-scroll" class="dfn-panel" data-for="term-for-valdef-background-attachment-scroll" id="infopanel-for-term-for-valdef-background-attachment-scroll" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-background-attachment-scroll" style="display:none">Info about the 'scroll' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll">https://drafts.csswg.org/css-backgrounds-3/#valdef-background-attachment-scroll</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-background-attachment-scroll">2. Rendering Model</a> <a href="#ref-for-valdef-background-attachment-scroll①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-all">
-   <a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-all" class="dfn-panel" data-for="term-for-propdef-all" id="infopanel-for-term-for-propdef-all" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-all" style="display:none">Info about the 'all' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#propdef-all">https://drafts.csswg.org/css-cascade-5/#propdef-all</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-all">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-inherit">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-inherit" class="dfn-panel" data-for="term-for-valdef-all-inherit" id="infopanel-for-term-for-valdef-all-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit">https://drafts.csswg.org/css-cascade-5/#valdef-all-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-inherit">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-initial">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-initial" class="dfn-panel" data-for="term-for-valdef-all-initial" id="infopanel-for-term-for-valdef-all-initial" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-initial" style="display:none">Info about the 'initial' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-initial">https://drafts.csswg.org/css-cascade-5/#valdef-all-initial</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-initial">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-revert">
-   <a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-revert" class="dfn-panel" data-for="term-for-valdef-all-revert" id="infopanel-for-term-for-valdef-all-revert" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-revert" style="display:none">Info about the 'revert' external reference.</span><a href="https://www.w3.org/TR/css-cascade-5/#valdef-all-revert">https://www.w3.org/TR/css-cascade-5/#valdef-all-revert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-revert">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-all-unset">
-   <a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-all-unset" class="dfn-panel" data-for="term-for-valdef-all-unset" id="infopanel-for-term-for-valdef-all-unset" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-all-unset" style="display:none">Info about the 'unset' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#valdef-all-unset">https://drafts.csswg.org/css-cascade-5/#valdef-all-unset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-all-unset">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">10. Painting: Filling, Stroking, and Marker Symbols</a> <a href="#ref-for-valdef-color-currentcolor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-env">
-   <a href="https://drafts.csswg.org/css-env-1/#funcdef-env">https://drafts.csswg.org/css-env-1/#funcdef-env</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-env" class="dfn-panel" data-for="term-for-funcdef-env" id="infopanel-for-term-for-funcdef-env" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-env" style="display:none">Info about the 'env()' external reference.</span><a href="https://drafts.csswg.org/css-env-1/#funcdef-env">https://drafts.csswg.org/css-env-1/#funcdef-env</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-env">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-family">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-family" class="dfn-panel" data-for="term-for-propdef-font-family" id="infopanel-for-term-for-propdef-font-family" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-family" style="display:none">Info about the 'font-family' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-family">https://drafts.csswg.org/css-fonts-4/#propdef-font-family</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-family">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-feature-settings">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-feature-settings" class="dfn-panel" data-for="term-for-propdef-font-feature-settings" id="infopanel-for-term-for-propdef-font-feature-settings" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-feature-settings" style="display:none">Info about the 'font-feature-settings' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings">https://drafts.csswg.org/css-fonts-4/#propdef-font-feature-settings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-feature-settings">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-kerning">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-kerning">https://drafts.csswg.org/css-fonts-4/#propdef-font-kerning</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-kerning" class="dfn-panel" data-for="term-for-propdef-font-kerning" id="infopanel-for-term-for-propdef-font-kerning" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-kerning" style="display:none">Info about the 'font-kerning' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-kerning">https://drafts.csswg.org/css-fonts-4/#propdef-font-kerning</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-kerning">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-stretch">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-stretch" class="dfn-panel" data-for="term-for-propdef-font-stretch" id="infopanel-for-term-for-propdef-font-stretch" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-stretch" style="display:none">Info about the 'font-stretch' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch">https://drafts.csswg.org/css-fonts-4/#propdef-font-stretch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-stretch">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-style">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-style" class="dfn-panel" data-for="term-for-propdef-font-style" id="infopanel-for-term-for-propdef-font-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-style" style="display:none">Info about the 'font-style' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-style">https://drafts.csswg.org/css-fonts-4/#propdef-font-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-style">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-variant">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-variant" class="dfn-panel" data-for="term-for-propdef-font-variant" id="infopanel-for-term-for-propdef-font-variant" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-variant" style="display:none">Info about the 'font-variant' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-variant">https://drafts.csswg.org/css-fonts-4/#propdef-font-variant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-variant">8. Text</a> <a href="#ref-for-propdef-font-variant①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-weight">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-weight" class="dfn-panel" data-for="term-for-propdef-font-weight" id="infopanel-for-term-for-propdef-font-weight" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-weight" style="display:none">Info about the 'font-weight' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-weight">https://drafts.csswg.org/css-fonts-4/#propdef-font-weight</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-weight">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size-adjust">
-   <a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size-adjust" class="dfn-panel" data-for="term-for-propdef-font-size-adjust" id="infopanel-for-term-for-propdef-font-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size-adjust" style="display:none">Info about the 'font-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust">https://drafts.csswg.org/css-fonts-5/#propdef-font-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size-adjust">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-alignment-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-alignment-baseline" class="dfn-panel" data-for="term-for-propdef-alignment-baseline" id="infopanel-for-term-for-propdef-alignment-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-alignment-baseline" style="display:none">Info about the 'alignment-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline">https://drafts.csswg.org/css-inline-3/#propdef-alignment-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-alignment-baseline">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-baseline-shift">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-baseline-shift" class="dfn-panel" data-for="term-for-propdef-baseline-shift" id="infopanel-for-term-for-propdef-baseline-shift" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-baseline-shift" style="display:none">Info about the 'baseline-shift' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift">https://drafts.csswg.org/css-inline-3/#propdef-baseline-shift</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-baseline-shift">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-dominant-baseline">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-dominant-baseline" class="dfn-panel" data-for="term-for-propdef-dominant-baseline" id="infopanel-for-term-for-propdef-dominant-baseline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-dominant-baseline" style="display:none">Info about the 'dominant-baseline' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline">https://drafts.csswg.org/css-inline-3/#propdef-dominant-baseline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-dominant-baseline">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-inline-size">
-   <a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-inline-size" class="dfn-panel" data-for="term-for-propdef-inline-size" id="infopanel-for-term-for-propdef-inline-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-inline-size" style="display:none">Info about the 'inline-size' external reference.</span><a href="https://drafts.csswg.org/css-logical-1/#propdef-inline-size">https://drafts.csswg.org/css-logical-1/#propdef-inline-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-inline-size">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">2. Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip-path">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip-path" class="dfn-panel" data-for="term-for-propdef-clip-path" id="infopanel-for-term-for-propdef-clip-path" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip-path" style="display:none">Info about the 'clip-path' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path">https://drafts.fxtf.org/css-masking-1/#propdef-clip-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip-path">2. Rendering Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-clippath">
-   <a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-clippath" class="dfn-panel" data-for="term-for-elementdef-clippath" id="infopanel-for-term-for-elementdef-clippath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-clippath" style="display:none">Info about the 'clippath' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#elementdef-clippath">https://drafts.fxtf.org/css-masking-1/#elementdef-clippath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-clippath">2. Rendering Model</a> <a href="#ref-for-elementdef-clippath①">(2)</a>
     <li><a href="#ref-for-elementdef-clippath②">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clippathunits-objectboundingbox">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-objectboundingbox">https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-objectboundingbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clippathunits-objectboundingbox" class="dfn-panel" data-for="term-for-valdef-clippathunits-objectboundingbox" id="infopanel-for-term-for-valdef-clippathunits-objectboundingbox" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clippathunits-objectboundingbox" style="display:none">Info about the 'objectboundingbox' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-objectboundingbox">https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-objectboundingbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clippathunits-objectboundingbox">11. Gradients and Patterns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-clippathunits-userspaceonuse">
-   <a href="https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-userspaceonuse">https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-userspaceonuse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-clippathunits-userspaceonuse" class="dfn-panel" data-for="term-for-valdef-clippathunits-userspaceonuse" id="infopanel-for-term-for-valdef-clippathunits-userspaceonuse" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-clippathunits-userspaceonuse" style="display:none">Info about the 'userspaceonuse' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-userspaceonuse">https://drafts.fxtf.org/css-masking-1/#valdef-clippathunits-userspaceonuse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-clippathunits-userspaceonuse">11. Gradients and Patterns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">2. Rendering Model</a> <a href="#ref-for-propdef-overflow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-overflow" class="dfn-panel" data-for="term-for-propdef-text-overflow" id="infopanel-for-term-for-propdef-text-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-overflow" style="display:none">Info about the 'text-overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow">https://drafts.csswg.org/css-overflow-4/#propdef-text-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-overflow">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-inside">
-   <a href="https://drafts.csswg.org/css-round-display-1/#propdef-shape-inside">https://drafts.csswg.org/css-round-display-1/#propdef-shape-inside</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-inside" class="dfn-panel" data-for="term-for-propdef-shape-inside" id="infopanel-for-term-for-propdef-shape-inside" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-inside" style="display:none">Info about the 'shape-inside' external reference.</span><a href="https://drafts.csswg.org/css-round-display-1/#propdef-shape-inside">https://drafts.csswg.org/css-round-display-1/#propdef-shape-inside</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-inside">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-image-threshold">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-image-threshold">https://drafts.csswg.org/css-shapes-1/#propdef-shape-image-threshold</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-image-threshold" class="dfn-panel" data-for="term-for-propdef-shape-image-threshold" id="infopanel-for-term-for-propdef-shape-image-threshold" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-image-threshold" style="display:none">Info about the 'shape-image-threshold' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-image-threshold">https://drafts.csswg.org/css-shapes-1/#propdef-shape-image-threshold</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-image-threshold">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-margin">
-   <a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-margin" class="dfn-panel" data-for="term-for-propdef-shape-margin" id="infopanel-for-term-for-propdef-shape-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-margin" style="display:none">Info about the 'shape-margin' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin">https://drafts.csswg.org/css-shapes-1/#propdef-shape-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-margin">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-shape-padding">
-   <a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding">https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-shape-padding" class="dfn-panel" data-for="term-for-propdef-shape-padding" id="infopanel-for-term-for-propdef-shape-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-shape-padding" style="display:none">Info about the 'shape-padding' external reference.</span><a href="https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding">https://drafts.csswg.org/css-shapes-2/#propdef-shape-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-shape-padding">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align-last">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-align-last">https://drafts.csswg.org/css-text-4/#propdef-text-align-last</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align-last" class="dfn-panel" data-for="term-for-propdef-text-align-last" id="infopanel-for-term-for-propdef-text-align-last" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align-last" style="display:none">Info about the 'text-align-last' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-align-last">https://drafts.csswg.org/css-text-4/#propdef-text-align-last</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align-last">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-color">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-color" class="dfn-panel" data-for="term-for-propdef-text-decoration-color" id="infopanel-for-term-for-propdef-text-decoration-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-color" style="display:none">Info about the 'text-decoration-color' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-color">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-line">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-line">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-line" class="dfn-panel" data-for="term-for-propdef-text-decoration-line" id="infopanel-for-term-for-propdef-text-decoration-line" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-line" style="display:none">Info about the 'text-decoration-line' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-line">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-line">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration-style">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-style">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration-style" class="dfn-panel" data-for="term-for-propdef-text-decoration-style" id="infopanel-for-term-for-propdef-text-decoration-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration-style" style="display:none">Info about the 'text-decoration-style' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-style">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration-style">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-pointer-events">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-pointer-events" class="dfn-panel" data-for="term-for-propdef-pointer-events" id="infopanel-for-term-for-propdef-pointer-events" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-pointer-events" style="display:none">Info about the 'pointer-events' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-pointer-events">https://drafts.csswg.org/css-ui-4/#propdef-pointer-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-pointer-events">12. Scripting and Interactivity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-calc">
-   <a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-calc" class="dfn-panel" data-for="term-for-funcdef-calc" id="infopanel-for-term-for-funcdef-calc" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-calc" style="display:none">Info about the 'calc()' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#funcdef-calc">https://drafts.csswg.org/css-values-4/#funcdef-calc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-calc">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cm">
-   <a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cm" class="dfn-panel" data-for="term-for-cm" id="infopanel-for-term-for-cm" role="menu">
+   <span id="infopaneltitle-for-term-for-cm" style="display:none">Info about the 'cm' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#cm">https://drafts.csswg.org/css-values-4/#cm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cm">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in">
-   <a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in" class="dfn-panel" data-for="term-for-in" id="infopanel-for-term-for-in" role="menu">
+   <span id="infopaneltitle-for-term-for-in" style="display:none">Info about the 'in' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#in">https://drafts.csswg.org/css-values-4/#in</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mm">
-   <a href="https://drafts.csswg.org/css-values-4/#mm">https://drafts.csswg.org/css-values-4/#mm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mm" class="dfn-panel" data-for="term-for-mm" id="infopanel-for-term-for-mm" role="menu">
+   <span id="infopaneltitle-for-term-for-mm" style="display:none">Info about the 'mm' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#mm">https://drafts.csswg.org/css-values-4/#mm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mm">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pc">
-   <a href="https://drafts.csswg.org/css-values-4/#pc">https://drafts.csswg.org/css-values-4/#pc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pc" class="dfn-panel" data-for="term-for-pc" id="infopanel-for-term-for-pc" role="menu">
+   <span id="infopaneltitle-for-term-for-pc" style="display:none">Info about the 'pc' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#pc">https://drafts.csswg.org/css-values-4/#pc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pc">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pt">
-   <a href="https://drafts.csswg.org/css-values-4/#pt">https://drafts.csswg.org/css-values-4/#pt</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pt" class="dfn-panel" data-for="term-for-pt" id="infopanel-for-term-for-pt" role="menu">
+   <span id="infopaneltitle-for-term-for-pt" style="display:none">Info about the 'pt' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#pt">https://drafts.csswg.org/css-values-4/#pt</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pt">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-var">
-   <a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-var" class="dfn-panel" data-for="term-for-funcdef-var" id="infopanel-for-term-for-funcdef-var" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-var" style="display:none">Info about the 'var()' external reference.</span><a href="https://drafts.csswg.org/css-variables-2/#funcdef-var">https://drafts.csswg.org/css-variables-2/#funcdef-var</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-var">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-direction" class="dfn-panel" data-for="term-for-propdef-direction" id="infopanel-for-term-for-propdef-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-direction" style="display:none">Info about the 'direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-direction">https://drafts.csswg.org/css-writing-modes-3/#propdef-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-direction">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" class="dfn-panel" data-for="term-for-propdef-glyph-orientation-vertical" id="infopanel-for-term-for-propdef-glyph-orientation-vertical" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-glyph-orientation-vertical" style="display:none">Info about the 'glyph-orientation-vertical' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical">https://drafts.csswg.org/css-writing-modes-4/#propdef-glyph-orientation-vertical</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-glyph-orientation-vertical">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-orientation">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-orientation" class="dfn-panel" data-for="term-for-propdef-text-orientation" id="infopanel-for-term-for-propdef-text-orientation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-orientation" style="display:none">Info about the 'text-orientation' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-orientation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-orientation">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">13. Linking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-font">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-font" class="dfn-panel" data-for="term-for-font" id="infopanel-for-term-for-font" role="menu">
+   <span id="infopaneltitle-for-term-for-font" style="display:none">Info about the 'font' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#font">https://html.spec.whatwg.org/multipage/obsolete.html#font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1.2. Basics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-meta" class="dfn-panel" data-for="term-for-meta" id="infopanel-for-term-for-meta" role="menu">
+   <span id="infopaneltitle-for-term-for-meta" style="display:none">Info about the 'meta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">3. Document Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script" class="dfn-panel" data-for="term-for-script" id="infopanel-for-term-for-script" role="menu">
+   <span id="infopaneltitle-for-term-for-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script">12. Scripting and Interactivity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">4. Styling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-circle">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-circle">https://svgwg.org/svg2-draft/shapes.html#elementdef-circle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-circle" class="dfn-panel" data-for="term-for-elementdef-circle" id="infopanel-for-term-for-elementdef-circle" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-circle" style="display:none">Info about the 'circle' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-circle">https://svgwg.org/svg2-draft/shapes.html#elementdef-circle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-circle">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ColorInterpolationProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ColorInterpolationProperty" class="dfn-panel" data-for="term-for-ColorInterpolationProperty" id="infopanel-for-term-for-ColorInterpolationProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ColorInterpolationProperty" style="display:none">Info about the 'color-interpolation' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ColorInterpolationProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-CxProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#CxProperty">https://svgwg.org/svg2-draft/geometry.html#CxProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-CxProperty" class="dfn-panel" data-for="term-for-CxProperty" id="infopanel-for-term-for-CxProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-CxProperty" style="display:none">Info about the 'cx' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#CxProperty">https://svgwg.org/svg2-draft/geometry.html#CxProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CxProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-CyProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#CyProperty">https://svgwg.org/svg2-draft/geometry.html#CyProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-CyProperty" class="dfn-panel" data-for="term-for-CyProperty" id="infopanel-for-term-for-CyProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-CyProperty" style="display:none">Info about the 'cy' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#CyProperty">https://svgwg.org/svg2-draft/geometry.html#CyProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-CyProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-defs">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-defs">https://svgwg.org/svg2-draft/struct.html#elementdef-defs</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-defs" class="dfn-panel" data-for="term-for-elementdef-defs" id="infopanel-for-term-for-elementdef-defs" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-defs" style="display:none">Info about the 'defs' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-defs">https://svgwg.org/svg2-draft/struct.html#elementdef-defs</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-defs">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-ellipse">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse">https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-ellipse" class="dfn-panel" data-for="term-for-elementdef-ellipse" id="infopanel-for-term-for-elementdef-ellipse" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-ellipse" style="display:none">Info about the 'ellipse' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse">https://svgwg.org/svg2-draft/shapes.html#elementdef-ellipse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-ellipse">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-foreignObject">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-foreignObject" class="dfn-panel" data-for="term-for-elementdef-foreignObject" id="infopanel-for-term-for-elementdef-foreignObject" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-foreignObject" style="display:none">Info about the 'foreignobject' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject">https://svgwg.org/svg2-draft/embedded.html#elementdef-foreignObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-foreignObject">9. Embedded Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-g">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-g" class="dfn-panel" data-for="term-for-elementdef-g" id="infopanel-for-term-for-elementdef-g" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-g" style="display:none">Info about the 'g' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-g">https://svgwg.org/svg2-draft/struct.html#elementdef-g</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-g">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-image">
-   <a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-image" class="dfn-panel" data-for="term-for-elementdef-image" id="infopanel-for-term-for-elementdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-image" style="display:none">Info about the 'image' external reference.</span><a href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">https://svgwg.org/svg2-draft/embedded.html#elementdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-image">3. Document Structure</a>
     <li><a href="#ref-for-elementdef-image①">6. Coordinate Systems, Transformations, and Units</a> <a href="#ref-for-elementdef-image②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-line">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-line" class="dfn-panel" data-for="term-for-elementdef-line" id="infopanel-for-term-for-elementdef-line" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-line" style="display:none">Info about the 'line' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">https://svgwg.org/svg2-draft/shapes.html#elementdef-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-line">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerProperty" class="dfn-panel" data-for="term-for-MarkerProperty" id="infopanel-for-term-for-MarkerProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerProperty" style="display:none">Info about the 'marker' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerProperty">https://svgwg.org/svg2-draft/painting.html#MarkerProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerEndProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerEndProperty" class="dfn-panel" data-for="term-for-MarkerEndProperty" id="infopanel-for-term-for-MarkerEndProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerEndProperty" style="display:none">Info about the 'marker-end' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty">https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerEndProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerMidProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerMidProperty" class="dfn-panel" data-for="term-for-MarkerMidProperty" id="infopanel-for-term-for-MarkerMidProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerMidProperty" style="display:none">Info about the 'marker-mid' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty">https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerMidProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-MarkerStartProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-MarkerStartProperty" class="dfn-panel" data-for="term-for-MarkerStartProperty" id="infopanel-for-term-for-MarkerStartProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-MarkerStartProperty" style="display:none">Info about the 'marker-start' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty">https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MarkerStartProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-metadata">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-metadata" class="dfn-panel" data-for="term-for-elementdef-metadata" id="infopanel-for-term-for-elementdef-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-metadata" style="display:none">Info about the 'metadata' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-metadata">3. Document Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PaintOrderProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty">https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PaintOrderProperty" class="dfn-panel" data-for="term-for-PaintOrderProperty" id="infopanel-for-term-for-PaintOrderProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-PaintOrderProperty" style="display:none">Info about the 'paint-order' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty">https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PaintOrderProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-path">
-   <a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-path" class="dfn-panel" data-for="term-for-elementdef-path" id="infopanel-for-term-for-elementdef-path" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-path" style="display:none">Info about the 'path' external reference.</span><a href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">https://svgwg.org/svg2-draft/paths.html#elementdef-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-path">6. Coordinate Systems, Transformations, and Units</a>
     <li><a href="#ref-for-elementdef-path①">7. Paths</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-pattern">
-   <a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-pattern" class="dfn-panel" data-for="term-for-elementdef-pattern" id="infopanel-for-term-for-elementdef-pattern" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-pattern" style="display:none">Info about the 'pattern' external reference.</span><a href="https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern">https://svgwg.org/svg2-draft/pservers.html#elementdef-pattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-pattern">6. Coordinate Systems, Transformations, and Units</a>
     <li><a href="#ref-for-elementdef-pattern①">11. Gradients and Patterns</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polygon">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polygon" class="dfn-panel" data-for="term-for-elementdef-polygon" id="infopanel-for-term-for-elementdef-polygon" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polygon" style="display:none">Info about the 'polygon' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polygon">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-polyline">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-polyline" class="dfn-panel" data-for="term-for-elementdef-polyline" id="infopanel-for-term-for-elementdef-polyline" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-polyline" style="display:none">Info about the 'polyline' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-polyline">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RProperty">https://svgwg.org/svg2-draft/geometry.html#RProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RProperty" class="dfn-panel" data-for="term-for-RProperty" id="infopanel-for-term-for-RProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RProperty" style="display:none">Info about the 'r' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RProperty">https://svgwg.org/svg2-draft/geometry.html#RProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-rect">
-   <a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-rect" class="dfn-panel" data-for="term-for-elementdef-rect" id="infopanel-for-term-for-elementdef-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-rect" style="display:none">Info about the 'rect' external reference.</span><a href="https://svgwg.org/svg2-draft/shapes.html#elementdef-rect">https://svgwg.org/svg2-draft/shapes.html#elementdef-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-rect">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RxProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RxProperty">https://svgwg.org/svg2-draft/geometry.html#RxProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RxProperty" class="dfn-panel" data-for="term-for-RxProperty" id="infopanel-for-term-for-RxProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RxProperty" style="display:none">Info about the 'rx' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RxProperty">https://svgwg.org/svg2-draft/geometry.html#RxProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RxProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-RyProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#RyProperty">https://svgwg.org/svg2-draft/geometry.html#RyProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-RyProperty" class="dfn-panel" data-for="term-for-RyProperty" id="infopanel-for-term-for-RyProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-RyProperty" style="display:none">Info about the 'ry' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#RyProperty">https://svgwg.org/svg2-draft/geometry.html#RyProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RyProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ShapesubtractProperty">
-   <a href="https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty">https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ShapesubtractProperty" class="dfn-panel" data-for="term-for-ShapesubtractProperty" id="infopanel-for-term-for-ShapesubtractProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-ShapesubtractProperty" style="display:none">Info about the 'shape-subtract' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty">https://svgwg.org/svg2-draft/text.html#ShapesubtractProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ShapesubtractProperty">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">3. Document Structure</a> <a href="#ref-for-elementdef-svg①">(2)</a>
     <li><a href="#ref-for-elementdef-svg②">6. Coordinate Systems, Transformations, and Units</a> <a href="#ref-for-elementdef-svg③">(2)</a> <a href="#ref-for-elementdef-svg④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-switch">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-switch" class="dfn-panel" data-for="term-for-elementdef-switch" id="infopanel-for-term-for-elementdef-switch" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-switch" style="display:none">Info about the 'switch' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">https://svgwg.org/svg2-draft/struct.html#elementdef-switch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-switch">3. Document Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-symbol">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-symbol" class="dfn-panel" data-for="term-for-elementdef-symbol" id="infopanel-for-term-for-elementdef-symbol" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-symbol" style="display:none">Info about the 'symbol' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">https://svgwg.org/svg2-draft/struct.html#elementdef-symbol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-symbol">3. Document Structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-text">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-text" class="dfn-panel" data-for="term-for-elementdef-text" id="infopanel-for-term-for-elementdef-text" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-text" style="display:none">Info about the 'text' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-text">https://svgwg.org/svg2-draft/text.html#elementdef-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-text">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextAnchorProperty">
-   <a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextAnchorProperty" class="dfn-panel" data-for="term-for-TextAnchorProperty" id="infopanel-for-term-for-TextAnchorProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextAnchorProperty" style="display:none">Info about the 'text-anchor' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#TextAnchorProperty">https://svgwg.org/svg2-draft/text.html#TextAnchorProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextAnchorProperty">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextDecorationFillProperty">
-   <a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextDecorationFillProperty" class="dfn-panel" data-for="term-for-TextDecorationFillProperty" id="infopanel-for-term-for-TextDecorationFillProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextDecorationFillProperty" style="display:none">Info about the 'text-decoration-fill' external reference.</span><a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationFillProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextDecorationFillProperty">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextDecorationStrokeProperty">
-   <a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextDecorationStrokeProperty" class="dfn-panel" data-for="term-for-TextDecorationStrokeProperty" id="infopanel-for-term-for-TextDecorationStrokeProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextDecorationStrokeProperty" style="display:none">Info about the 'text-decoration-stroke' external reference.</span><a href="https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty">https://www.w3.org/TR/SVG2/text.html#TextDecorationStrokeProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextDecorationStrokeProperty">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-TextRenderingProperty">
-   <a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-TextRenderingProperty" class="dfn-panel" data-for="term-for-TextRenderingProperty" id="infopanel-for-term-for-TextRenderingProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-TextRenderingProperty" style="display:none">Info about the 'text-rendering' external reference.</span><a href="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty">https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TextRenderingProperty">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-textPath">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-textPath" class="dfn-panel" data-for="term-for-elementdef-textPath" id="infopanel-for-term-for-elementdef-textPath" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-textPath" style="display:none">Info about the 'textpath' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-textPath">https://svgwg.org/svg2-draft/text.html#elementdef-textPath</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-textPath">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-tspan">
-   <a href="https://svgwg.org/svg2-draft/text.html#elementdef-tspan">https://svgwg.org/svg2-draft/text.html#elementdef-tspan</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-tspan" class="dfn-panel" data-for="term-for-elementdef-tspan" id="infopanel-for-term-for-elementdef-tspan" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-tspan" style="display:none">Info about the 'tspan' external reference.</span><a href="https://svgwg.org/svg2-draft/text.html#elementdef-tspan">https://svgwg.org/svg2-draft/text.html#elementdef-tspan</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-tspan">8. Text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-use">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-use" class="dfn-panel" data-for="term-for-elementdef-use" id="infopanel-for-term-for-elementdef-use" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-use" style="display:none">Info about the 'use' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">https://svgwg.org/svg2-draft/struct.html#elementdef-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-use">6. Coordinate Systems, Transformations, and Units</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-VectorEffectProperty">
-   <a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-VectorEffectProperty" class="dfn-panel" data-for="term-for-VectorEffectProperty" id="infopanel-for-term-for-VectorEffectProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-VectorEffectProperty" style="display:none">Info about the 'vector-effect' external reference.</span><a href="https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty">https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-VectorEffectProperty">10. Painting: Filling, Stroking, and Marker Symbols</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-view">
-   <a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-view" class="dfn-panel" data-for="term-for-elementdef-view" id="infopanel-for-term-for-elementdef-view" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-view" style="display:none">Info about the 'view' external reference.</span><a href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">https://svgwg.org/svg2-draft/linking.html#elementdef-view</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-view">13. Linking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-XProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">https://svgwg.org/svg2-draft/geometry.html#XProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-XProperty" class="dfn-panel" data-for="term-for-XProperty" id="infopanel-for-term-for-XProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-XProperty" style="display:none">Info about the 'x' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#XProperty">https://svgwg.org/svg2-draft/geometry.html#XProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-XProperty">5. Geometry Properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-YProperty">
-   <a href="https://svgwg.org/svg2-draft/geometry.html#YProperty">https://svgwg.org/svg2-draft/geometry.html#YProperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-YProperty" class="dfn-panel" data-for="term-for-YProperty" id="infopanel-for-term-for-YProperty" role="menu">
+   <span id="infopaneltitle-for-term-for-YProperty" style="display:none">Info about the 'y' external reference.</span><a href="https://svgwg.org/svg2-draft/geometry.html#YProperty">https://svgwg.org/svg2-draft/geometry.html#YProperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-YProperty">5. Geometry Properties</a>
    </ul>
@@ -1773,57 +1773,113 @@ dfn > a.self-link::before      { content: "#"; }
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/svgwg/specs/transform/Overview.html
+++ b/tests/github/w3c/svgwg/specs/transform/Overview.html
@@ -854,27 +854,27 @@ within the SVG document.</p>
   <ul class="index">
    <li><a href="#svgtransform">svg:transform</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-transform-list">
-   <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-transform-list" class="dfn-panel" data-for="term-for-typedef-transform-list" id="infopanel-for-term-for-typedef-transform-list" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-transform-list" style="display:none">Info about the '&lt;transform-list>' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">https://drafts.csswg.org/css-transforms-1/#typedef-transform-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-transform-list">2. The 'svg:transform' attribute</a> <a href="#ref-for-typedef-transform-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">1. Geographic coordinate systems</a> <a href="#ref-for-propdef-transform①">(2)</a>
     <li><a href="#ref-for-propdef-transform②">2. The 'svg:transform' attribute</a> <a href="#ref-for-propdef-transform③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-metadata">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-metadata" class="dfn-panel" data-for="term-for-elementdef-metadata" id="infopanel-for-term-for-elementdef-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-metadata" style="display:none">Info about the 'metadata' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-metadata">https://svgwg.org/svg2-draft/struct.html#elementdef-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-metadata">1. Geographic coordinate systems</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-elementdef-svg">
-   <a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-elementdef-svg" class="dfn-panel" data-for="term-for-elementdef-svg" id="infopanel-for-term-for-elementdef-svg" role="menu">
+   <span id="infopaneltitle-for-term-for-elementdef-svg" style="display:none">Info about the 'svg' external reference.</span><a href="https://svgwg.org/svg2-draft/struct.html#elementdef-svg">https://svgwg.org/svg2-draft/struct.html#elementdef-svg</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-svg">1. Geographic coordinate systems</a>
    </ul>
@@ -911,65 +911,121 @@ within the SVG document.</p>
    <dt id="biblio-rdf-primer">[RDF-PRIMER]
    <dd>Frank Manola; Eric Miller. <a href="https://www.w3.org/TR/rdf-primer/"><cite>RDF Primer</cite></a>. 10 February 2004. REC. URL: <a href="https://www.w3.org/TR/rdf-primer/">https://www.w3.org/TR/rdf-primer/</a>
   </dl>
-  <aside class="dfn-panel" data-for="svgtransform">
-   <b><a href="#svgtransform">#svgtransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-svgtransform" class="dfn-panel" data-for="svgtransform" id="infopanel-for-svgtransform" role="dialog">
+   <span id="infopaneltitle-for-svgtransform" style="display:none">Info about the 'svg:transform' definition.</span><b><a href="#svgtransform">#svgtransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svgtransform">2. The 'svg:transform' attribute</a> <a href="#ref-for-svgtransform①">(2)</a> <a href="#ref-for-svgtransform②">(3)</a> <a href="#ref-for-svgtransform③">(4)</a> <a href="#ref-for-svgtransform④">(5)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/w3process/index.html
+++ b/tests/github/w3c/w3process/index.html
@@ -4451,8 +4451,8 @@ dfn > a.self-link::before      { content: "#"; }
    <dt id="biblio-translation">[TRANSLATION]
    <dd><a href="https://www.w3.org/Consortium/Translation/"><cite>Translations of W3C technical reports</cite></a>. URL: <a href="https://www.w3.org/Consortium/Translation/">https://www.w3.org/Consortium/Translation/</a>
   </dl>
-  <aside class="dfn-panel" data-for="advisory-committee">
-   <b><a href="#advisory-committee">#advisory-committee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advisory-committee" class="dfn-panel" data-for="advisory-committee" id="infopanel-for-advisory-committee" role="dialog">
+   <span id="infopaneltitle-for-advisory-committee" style="display:none">Info about the 'Advisory Committee' definition.</span><b><a href="#advisory-committee">#advisory-committee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advisory-committee">2.1.3.1. 
 Advisory Committee Mailing Lists</a> <a href="#ref-for-advisory-committee①">(2)</a>
@@ -4498,8 +4498,8 @@ Acknowledgment of a Submission Request</a>
 Process Evolution</a> <a href="#ref-for-advisory-committee②⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advisory-committee-representative">
-   <b><a href="#advisory-committee-representative">#advisory-committee-representative</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advisory-committee-representative" class="dfn-panel" data-for="advisory-committee-representative" id="infopanel-for-advisory-committee-representative" role="dialog">
+   <span id="infopaneltitle-for-advisory-committee-representative" style="display:none">Info about the 'representative' definition.</span><b><a href="#advisory-committee-representative">#advisory-committee-representative</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advisory-committee-representative">2.1. 
 Members</a>
@@ -4545,15 +4545,15 @@ Submitter Rights and Obligations</a> <a href="#ref-for-advisory-committee-repres
 Rejection of a Submission Request, and Submission Appeals</a> <a href="#ref-for-advisory-committee-representative③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fdn-member-consortium">
-   <b><a href="#fdn-member-consortium">#fdn-member-consortium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fdn-member-consortium" class="dfn-panel" data-for="fdn-member-consortium" id="infopanel-for-fdn-member-consortium" role="dialog">
+   <span id="infopaneltitle-for-fdn-member-consortium" style="display:none">Info about the 'Member Consortium' definition.</span><b><a href="#fdn-member-consortium">#fdn-member-consortium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fdn-member-consortium">2.1.2.1. 
 Membership Consortia</a> <a href="#ref-for-fdn-member-consortium①">(2)</a> <a href="#ref-for-fdn-member-consortium②">(3)</a> <a href="#ref-for-fdn-member-consortium③">(4)</a> <a href="#ref-for-fdn-member-consortium④">(5)</a> <a href="#ref-for-fdn-member-consortium⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="related-member">
-   <b><a href="#related-member">#related-member</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-related-member" class="dfn-panel" data-for="related-member" id="infopanel-for-related-member" role="dialog">
+   <span id="infopaneltitle-for-related-member" style="display:none">Info about the 'related' definition.</span><b><a href="#related-member">#related-member</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-related-member">2.1.2.2. 
 Related Members</a>
@@ -4563,15 +4563,15 @@ Advisory Board and Technical Architecture Group Elections</a> <a href="#ref-for-
 Advisory Committee Votes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subsidiary">
-   <b><a href="#subsidiary">#subsidiary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subsidiary" class="dfn-panel" data-for="subsidiary" id="infopanel-for-subsidiary" role="dialog">
+   <span id="infopaneltitle-for-subsidiary" style="display:none">Info about the 'subsidiary' definition.</span><b><a href="#subsidiary">#subsidiary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subsidiary">2.1.2.2. 
 Related Members</a> <a href="#ref-for-subsidiary①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="team">
-   <b><a href="#team">#team</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-team" class="dfn-panel" data-for="team" id="infopanel-for-team" role="dialog">
+   <span id="infopaneltitle-for-team" style="display:none">Info about the 'Team' definition.</span><b><a href="#team">#team</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-team">1. 
 Introduction</a>
@@ -4655,15 +4655,15 @@ Rejection of a Submission Request, and Submission Appeals</a> <a href="#ref-for-
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ceo">
-   <b><a href="#ceo">#ceo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ceo" class="dfn-panel" data-for="ceo" id="infopanel-for-ceo" role="dialog">
+   <span id="infopaneltitle-for-ceo" style="display:none">Info about the 'CEO' definition.</span><b><a href="#ceo">#ceo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ceo">2.2. 
 The W3C Team</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fellows">
-   <b><a href="#fellows">#fellows</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fellows" class="dfn-panel" data-for="fellows" id="infopanel-for-fellows" role="dialog">
+   <span id="infopaneltitle-for-fellows" style="display:none">Info about the 'W3C Fellows' definition.</span><b><a href="#fellows">#fellows</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fellows">2.1.1. 
 Rights of Members</a>
@@ -4671,8 +4671,8 @@ Rights of Members</a>
 Advisory Board and Technical Architecture Group Elections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-Director">
-   <b><a href="#def-Director">#def-Director</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-Director" class="dfn-panel" data-for="def-Director" id="infopanel-for-def-Director" role="dialog">
+   <span id="infopaneltitle-for-def-Director" style="display:none">Info about the 'Director' definition.</span><b><a href="#def-Director">#def-Director</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-Director">2.2. 
 The W3C Team</a> <a href="#ref-for-def-Director①">(2)</a>
@@ -4720,8 +4720,8 @@ Member Submission Process</a>
 Rejection of a Submission Request, and Submission Appeals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hosts">
-   <b><a href="#hosts">#hosts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hosts" class="dfn-panel" data-for="hosts" id="infopanel-for-hosts" role="dialog">
+   <span id="infopaneltitle-for-hosts" style="display:none">Info about the '“Host” institutions' definition.</span><b><a href="#hosts">#hosts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hosts">2.2. 
 The W3C Team</a> <a href="#ref-for-hosts①">(2)</a>
@@ -4729,8 +4729,8 @@ The W3C Team</a> <a href="#ref-for-hosts①">(2)</a>
 Liaisons</a> <a href="#ref-for-hosts③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advisory-board">
-   <b><a href="#advisory-board">#advisory-board</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advisory-board" class="dfn-panel" data-for="advisory-board" id="infopanel-for-advisory-board" role="dialog">
+   <span id="infopaneltitle-for-advisory-board" style="display:none">Info about the 'Advisory Board' definition.</span><b><a href="#advisory-board">#advisory-board</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advisory-board">2.3. 
 Advisory Board (AB)</a> <a href="#ref-for-advisory-board①">(2)</a>
@@ -4758,8 +4758,8 @@ Rejection of a Submission Request, and Submission Appeals</a>
 Process Evolution</a> <a href="#ref-for-advisory-board②⓪">(2)</a> <a href="#ref-for-advisory-board②①">(3)</a> <a href="#ref-for-advisory-board②②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="technical-architecture-group">
-   <b><a href="#technical-architecture-group">#technical-architecture-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-technical-architecture-group" class="dfn-panel" data-for="technical-architecture-group" id="infopanel-for-technical-architecture-group" role="dialog">
+   <span id="infopaneltitle-for-technical-architecture-group" style="display:none">Info about the 'TAG' definition.</span><b><a href="#technical-architecture-group">#technical-architecture-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-technical-architecture-group">2.4. 
 Technical Architecture Group (TAG)</a> <a href="#ref-for-technical-architecture-group①">(2)</a> <a href="#ref-for-technical-architecture-group②">(3)</a> <a href="#ref-for-technical-architecture-group③">(4)</a> <a href="#ref-for-technical-architecture-group④">(5)</a> <a href="#ref-for-technical-architecture-group⑤">(6)</a> <a href="#ref-for-technical-architecture-group⑥">(7)</a> <a href="#ref-for-technical-architecture-group⑦">(8)</a>
@@ -4787,8 +4787,8 @@ Member Submission Process</a>
 Rejection of a Submission Request, and Submission Appeals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="primary-affiliation">
-   <b><a href="#primary-affiliation">#primary-affiliation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-primary-affiliation" class="dfn-panel" data-for="primary-affiliation" id="infopanel-for-primary-affiliation" role="dialog">
+   <span id="infopaneltitle-for-primary-affiliation" style="display:none">Info about the 'primary affiliation' definition.</span><b><a href="#primary-affiliation">#primary-affiliation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-primary-affiliation">2.5.1. 
 Advisory Board and Technical Architecture Group Participation Constraints</a> <a href="#ref-for-primary-affiliation①">(2)</a>
@@ -4796,8 +4796,8 @@ Advisory Board and Technical Architecture Group Participation Constraints</a> <a
 Advisory Board and Technical Architecture Group Elections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="w3c-group">
-   <b><a href="#w3c-group">#w3c-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-w3c-group" class="dfn-panel" data-for="w3c-group" id="infopanel-for-w3c-group" role="dialog">
+   <span id="infopaneltitle-for-w3c-group" style="display:none">Info about the 'W3C Group' definition.</span><b><a href="#w3c-group">#w3c-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-w3c-group">3.2. 
 Meetings</a>
@@ -4805,8 +4805,8 @@ Meetings</a>
 Tooling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="participant">
-   <b><a href="#participant">#participant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-participant" class="dfn-panel" data-for="participant" id="infopanel-for-participant" role="dialog">
+   <span id="infopaneltitle-for-participant" style="display:none">Info about the 'participant' definition.</span><b><a href="#participant">#participant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-participant">3.2. 
 Meetings</a>
@@ -4814,8 +4814,8 @@ Meetings</a>
 Votes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ftf-meeting">
-   <b><a href="#ftf-meeting">#ftf-meeting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ftf-meeting" class="dfn-panel" data-for="ftf-meeting" id="infopanel-for-ftf-meeting" role="dialog">
+   <span id="infopaneltitle-for-ftf-meeting" style="display:none">Info about the 'face-to-face meeting' definition.</span><b><a href="#ftf-meeting">#ftf-meeting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ftf-meeting">2.1.3.2. 
 Advisory Committee Meetings</a>
@@ -4825,15 +4825,15 @@ Consensus</a>
 Working Group and Interest Group Charters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="distributed-meeting">
-   <b><a href="#distributed-meeting">#distributed-meeting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-distributed-meeting" class="dfn-panel" data-for="distributed-meeting" id="infopanel-for-distributed-meeting" role="dialog">
+   <span id="infopaneltitle-for-distributed-meeting" style="display:none">Info about the 'distributed meeting' definition.</span><b><a href="#distributed-meeting">#distributed-meeting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-distributed-meeting">3.3. 
 Consensus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="minutes">
-   <b><a href="#minutes">#minutes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-minutes" class="dfn-panel" data-for="minutes" id="infopanel-for-minutes" role="dialog">
+   <span id="infopaneltitle-for-minutes" style="display:none">Info about the 'minutes' definition.</span><b><a href="#minutes">#minutes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-minutes">3.2.1. 
 Meeting Scheduling and Announcements</a>
@@ -4845,8 +4845,8 @@ Requirements for All Working and Interest Groups</a>
 Workshops and Symposia</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-Consensus">
-   <b><a href="#def-Consensus">#def-Consensus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-Consensus" class="dfn-panel" data-for="def-Consensus" id="infopanel-for-def-Consensus" role="dialog">
+   <span id="infopaneltitle-for-def-Consensus" style="display:none">Info about the 'Consensus' definition.</span><b><a href="#def-Consensus">#def-Consensus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#DirectorDecision">2.2. 
 The W3C Team</a>
@@ -4868,15 +4868,15 @@ After the Review Period</a>
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-Unanimity">
-   <b><a href="#def-Unanimity">#def-Unanimity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-Unanimity" class="dfn-panel" data-for="def-Unanimity" id="infopanel-for-def-Unanimity" role="dialog">
+   <span id="infopaneltitle-for-def-Unanimity" style="display:none">Info about the 'Unanimity' definition.</span><b><a href="#def-Unanimity">#def-Unanimity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-Unanimity">3.3. 
 Consensus</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-Dissent">
-   <b><a href="#def-Dissent">#def-Dissent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-Dissent" class="dfn-panel" data-for="def-Dissent" id="infopanel-for-def-Dissent" role="dialog">
+   <span id="infopaneltitle-for-def-Dissent" style="display:none">Info about the 'Dissent' definition.</span><b><a href="#def-Dissent">#def-Dissent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-Dissent">3.3.1. 
 Managing Dissent</a> <a href="#ref-for-def-Dissent①">(2)</a>
@@ -4888,8 +4888,8 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</a>
 After the Review Period</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="FormalObjection">
-   <b><a href="#FormalObjection">#FormalObjection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-FormalObjection" class="dfn-panel" data-for="FormalObjection" id="infopanel-for-FormalObjection" role="dialog">
+   <span id="infopaneltitle-for-FormalObjection" style="display:none">Info about the 'Formal Objection' definition.</span><b><a href="#FormalObjection">#FormalObjection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-FormalObjection">3.3. 
 Consensus</a> <a href="#ref-for-FormalObjection">(2)</a>
@@ -4913,8 +4913,8 @@ Elevating Group Notes to W3C Statement status</a>
 After the Review Period</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formally-addressed">
-   <b><a href="#formally-addressed">#formally-addressed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formally-addressed" class="dfn-panel" data-for="formally-addressed" id="infopanel-for-formally-addressed" role="dialog">
+   <span id="infopaneltitle-for-formally-addressed" style="display:none">Info about the 'formally addressed' definition.</span><b><a href="#formally-addressed">#formally-addressed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formally-addressed">6.1.2. 
 Reviews and Review Responsibilities</a>
@@ -4938,22 +4938,22 @@ After the Review Period</a>
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proxy">
-   <b><a href="#proxy">#proxy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proxy" class="dfn-panel" data-for="proxy" id="infopanel-for-proxy" role="dialog">
+   <span id="infopaneltitle-for-proxy" style="display:none">Info about the 'proxy' definition.</span><b><a href="#proxy">#proxy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proxy">5.2.1. 
 Working Group and Interest Group Participation Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="chair-decisions">
-   <b><a href="#chair-decisions">#chair-decisions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-chair-decisions" class="dfn-panel" data-for="chair-decisions" id="infopanel-for-chair-decisions" role="dialog">
+   <span id="infopaneltitle-for-chair-decisions" style="display:none">Info about the 'chair decisions' definition.</span><b><a href="#chair-decisions">#chair-decisions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chair-decisions">3.5. 
 Chair Decisions and Group Decisions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="group-decision">
-   <b><a href="#group-decision">#group-decision</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-group-decision" class="dfn-panel" data-for="group-decision" id="infopanel-for-group-decision" role="dialog">
+   <span id="infopaneltitle-for-group-decision" style="display:none">Info about the 'group decisions' definition.</span><b><a href="#group-decision">#group-decision</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group-decision">3.2.2. 
 Meeting Minutes</a> <a href="#ref-for-group-decision①">(2)</a>
@@ -4969,15 +4969,15 @@ Registry Data Reports</a>
 Switching Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wg-decision-appeal">
-   <b><a href="#wg-decision-appeal">#wg-decision-appeal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wg-decision-appeal" class="dfn-panel" data-for="wg-decision-appeal" id="infopanel-for-wg-decision-appeal" role="dialog">
+   <span id="infopaneltitle-for-wg-decision-appeal" style="display:none">Info about the 'Group Decision Appeal' definition.</span><b><a href="#wg-decision-appeal">#wg-decision-appeal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wg-decision-appeal">2.2. 
 The W3C Team</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Member-only">
-   <b><a href="#Member-only">#Member-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Member-only" class="dfn-panel" data-for="Member-only" id="infopanel-for-Member-only" role="dialog">
+   <span id="infopaneltitle-for-Member-only" style="display:none">Info about the 'Member-only' definition.</span><b><a href="#Member-only">#Member-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Member-only">2.1. 
 Members</a>
@@ -4997,8 +4997,8 @@ Start of a Review Period</a>
 Appeal by Advisory Committee Representatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="Team-only">
-   <b><a href="#Team-only">#Team-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-Team-only" class="dfn-panel" data-for="Team-only" id="infopanel-for-Team-only" role="dialog">
+   <span id="infopaneltitle-for-Team-only" style="display:none">Info about the 'Team-only' definition.</span><b><a href="#Team-only">#Team-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Team-only">2.1. 
 Members</a>
@@ -5014,8 +5014,8 @@ Start of a Review Period</a>
 Team Rights and Obligations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="GeneralChairs">
-   <b><a href="#GeneralChairs">#GeneralChairs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-GeneralChairs" class="dfn-panel" data-for="GeneralChairs" id="infopanel-for-GeneralChairs" role="dialog">
+   <span id="infopaneltitle-for-GeneralChairs" style="display:none">Info about the 'Chair' definition.</span><b><a href="#GeneralChairs">#GeneralChairs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-GeneralChairs">2.2. 
 The W3C Team</a>
@@ -5053,8 +5053,8 @@ The W3C Recommendation Track</a>
 Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="TeamContact">
-   <b><a href="#TeamContact">#TeamContact</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-TeamContact" class="dfn-panel" data-for="TeamContact" id="infopanel-for-TeamContact" role="dialog">
+   <span id="infopaneltitle-for-TeamContact" style="display:none">Info about the 'Team Contact' definition.</span><b><a href="#TeamContact">#TeamContact</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-TeamContact">3.5. 
 Chair Decisions and Group Decisions</a>
@@ -5074,8 +5074,8 @@ Call for Participation in a Working Group or Interest Group</a>
 Working Group and Interest Group Charter Extension</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="GroupsWG">
-   <b><a href="#GroupsWG">#GroupsWG</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-GroupsWG" class="dfn-panel" data-for="GroupsWG" id="infopanel-for-GroupsWG" role="dialog">
+   <span id="infopaneltitle-for-GroupsWG" style="display:none">Info about the 'Working Groups' definition.</span><b><a href="#GroupsWG">#GroupsWG</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-GroupsWG">3.5. 
 Chair Decisions and Group Decisions</a> <a href="#ref-for-GroupsWG①">(2)</a>
@@ -5163,8 +5163,8 @@ Scope of Member Submissions</a>
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="GroupsIG">
-   <b><a href="#GroupsIG">#GroupsIG</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-GroupsIG" class="dfn-panel" data-for="GroupsIG" id="infopanel-for-GroupsIG" role="dialog">
+   <span id="infopaneltitle-for-GroupsIG" style="display:none">Info about the 'Interest Groups' definition.</span><b><a href="#GroupsIG">#GroupsIG</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-GroupsIG">3.5. 
 Chair Decisions and Group Decisions</a> <a href="#ref-for-GroupsIG①">(2)</a>
@@ -5184,8 +5184,8 @@ Maturity Levels on the Recommendation Track</a> <a href="#ref-for-GroupsIG①⓪
 Group Notes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="wgparticipant">
-   <b><a href="#wgparticipant">#wgparticipant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-wgparticipant" class="dfn-panel" data-for="wgparticipant" id="infopanel-for-wgparticipant" role="dialog">
+   <span id="infopaneltitle-for-wgparticipant" style="display:none">Info about the 'participants in a Working Group' definition.</span><b><a href="#wgparticipant">#wgparticipant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wgparticipant">3. 
 General Policies for W3C Groups</a>
@@ -5193,8 +5193,8 @@ General Policies for W3C Groups</a>
 Advisory Committee Review of a Working Group or Interest Group Charter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="igparticipant">
-   <b><a href="#igparticipant">#igparticipant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-igparticipant" class="dfn-panel" data-for="igparticipant" id="infopanel-for-igparticipant" role="dialog">
+   <span id="infopaneltitle-for-igparticipant" style="display:none">Info about the 'participants in an Interest Group' definition.</span><b><a href="#igparticipant">#igparticipant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-igparticipant">3. 
 General Policies for W3C Groups</a>
@@ -5202,29 +5202,29 @@ General Policies for W3C Groups</a>
 Advisory Committee Review of a Working Group or Interest Group Charter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-participant-ig">
-   <b><a href="#public-participant-ig">#public-participant-ig</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-participant-ig" class="dfn-panel" data-for="public-participant-ig" id="infopanel-for-public-participant-ig" role="dialog">
+   <span id="infopaneltitle-for-public-participant-ig" style="display:none">Info about the 'public participants' definition.</span><b><a href="#public-participant-ig">#public-participant-ig</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-participant-ig">5.2.6. 
 Working Group and Interest Group Charters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mtg-substitute">
-   <b><a href="#mtg-substitute">#mtg-substitute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mtg-substitute" class="dfn-panel" data-for="mtg-substitute" id="infopanel-for-mtg-substitute" role="dialog">
+   <span id="infopaneltitle-for-mtg-substitute" style="display:none">Info about the 'substitute' definition.</span><b><a href="#mtg-substitute">#mtg-substitute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mtg-substitute">3.4. 
 Votes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="member-representative-in-an-interest-group">
-   <b><a href="#member-representative-in-an-interest-group">#member-representative-in-an-interest-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-member-representative-in-an-interest-group" class="dfn-panel" data-for="member-representative-in-an-interest-group" id="infopanel-for-member-representative-in-an-interest-group" role="dialog">
+   <span id="infopaneltitle-for-member-representative-in-an-interest-group" style="display:none">Info about the 'Member representative in an Interest Group' definition.</span><b><a href="#member-representative-in-an-interest-group">#member-representative-in-an-interest-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-member-representative-in-an-interest-group">5.2.1.2. 
 Member Representative in an Interest Group</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="invited-expert-in-a-working-group">
-   <b><a href="#invited-expert-in-a-working-group">#invited-expert-in-a-working-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-invited-expert-in-a-working-group" class="dfn-panel" data-for="invited-expert-in-a-working-group" id="infopanel-for-invited-expert-in-a-working-group" role="dialog">
+   <span id="infopaneltitle-for-invited-expert-in-a-working-group" style="display:none">Info about the 'Invited Expert in a Working Group' definition.</span><b><a href="#invited-expert-in-a-working-group">#invited-expert-in-a-working-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invited-expert-in-a-working-group">5.2.1.3. 
 Invited Expert in a Working Group</a>
@@ -5232,8 +5232,8 @@ Invited Expert in a Working Group</a>
 Invited Expert in an Interest Group</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inv-expert-info">
-   <b><a href="#inv-expert-info">#inv-expert-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inv-expert-info" class="dfn-panel" data-for="inv-expert-info" id="infopanel-for-inv-expert-info" role="dialog">
+   <span id="infopaneltitle-for-inv-expert-info" style="display:none">Info about the 'participate in a Working Group as an Invited Expert' definition.</span><b><a href="#inv-expert-info">#inv-expert-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inv-expert-info">2.5.2. 
 Advisory Board and Technical Architecture Group Elections</a>
@@ -5241,15 +5241,15 @@ Advisory Board and Technical Architecture Group Elections</a>
 Invited Expert in a Working Group</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-charter-extension">
-   <b><a href="#dfn-charter-extension">#dfn-charter-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-charter-extension" class="dfn-panel" data-for="dfn-charter-extension" id="infopanel-for-dfn-charter-extension" role="dialog">
+   <span id="infopaneltitle-for-dfn-charter-extension" style="display:none">Info about the 'extension' definition.</span><b><a href="#dfn-charter-extension">#dfn-charter-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-charter-extension">7.2. 
 Appeal by Advisory Committee Representatives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="charter">
-   <b><a href="#charter">#charter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-charter" class="dfn-panel" data-for="charter" id="infopanel-for-charter" role="dialog">
+   <span id="infopaneltitle-for-charter" style="display:none">Info about the 'charter' definition.</span><b><a href="#charter">#charter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-charter">5.2.4. 
 Call for Participation in a Working Group or Interest Group</a>
@@ -5259,22 +5259,22 @@ The W3C Recommendation Track</a>
 Advancement on the Recommendation Track</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="adopted-draft">
-   <b><a href="#adopted-draft">#adopted-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-adopted-draft" class="dfn-panel" data-for="adopted-draft" id="infopanel-for-adopted-draft" role="dialog">
+   <span id="infopaneltitle-for-adopted-draft" style="display:none">Info about the 'Adopted Draft' definition.</span><b><a href="#adopted-draft">#adopted-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-adopted-draft">5.2.6. 
 Working Group and Interest Group Charters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exclusion-draft">
-   <b><a href="#exclusion-draft">#exclusion-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusion-draft" class="dfn-panel" data-for="exclusion-draft" id="infopanel-for-exclusion-draft" role="dialog">
+   <span id="infopaneltitle-for-exclusion-draft" style="display:none">Info about the 'Exclusion Draft' definition.</span><b><a href="#exclusion-draft">#exclusion-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusion-draft">5.2.6. 
 Working Group and Interest Group Charters</a> <a href="#ref-for-exclusion-draft①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="publishing">
-   <b><a href="#publishing">#publishing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-publishing" class="dfn-panel" data-for="publishing" id="infopanel-for-publishing" role="dialog">
+   <span id="infopaneltitle-for-publishing" style="display:none">Info about the 'Publishing' definition.</span><b><a href="#publishing">#publishing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-publishing">6.1. 
 W3C Technical Reports</a>
@@ -5300,8 +5300,8 @@ Abandoning an Unfinished Technical Report</a> <a href="#ref-for-publishing①②
 Group Notes</a> <a href="#ref-for-publishing①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="technical-report">
-   <b><a href="#technical-report">#technical-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-technical-report" class="dfn-panel" data-for="technical-report" id="infopanel-for-technical-report" role="dialog">
+   <span id="infopaneltitle-for-technical-report" style="display:none">Info about the 'Technical Report' definition.</span><b><a href="#technical-report">#technical-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-technical-report">5.2.6. 
 Working Group and Interest Group Charters</a>
@@ -5333,8 +5333,8 @@ Switching Tracks</a> <a href="#ref-for-technical-report②⑦">(2)</a> <a href="
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-wide-review">
-   <b><a href="#dfn-wide-review">#dfn-wide-review</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-wide-review" class="dfn-panel" data-for="dfn-wide-review" id="infopanel-for-dfn-wide-review" role="dialog">
+   <span id="infopaneltitle-for-dfn-wide-review" style="display:none">Info about the 'wide review' definition.</span><b><a href="#dfn-wide-review">#dfn-wide-review</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-wide-review">6.1. 
 W3C Technical Reports</a> <a href="#ref-for-dfn-wide-review①">(2)</a>
@@ -5352,8 +5352,8 @@ Transitioning to Proposed Recommendation</a>
 Elevating Group Notes to W3C Statement status</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="editorial-change">
-   <b><a href="#editorial-change">#editorial-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editorial-change" class="dfn-panel" data-for="editorial-change" id="infopanel-for-editorial-change" role="dialog">
+   <span id="infopaneltitle-for-editorial-change" style="display:none">Info about the 'editorial changes' definition.</span><b><a href="#editorial-change">#editorial-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editorial-change">6.2.3. 
 Advancement on the Recommendation Track</a>
@@ -5375,8 +5375,8 @@ After the Review Period</a>
 Acknowledgment of a Submission Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="substantive-change">
-   <b><a href="#substantive-change">#substantive-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-substantive-change" class="dfn-panel" data-for="substantive-change" id="infopanel-for-substantive-change" role="dialog">
+   <span id="infopaneltitle-for-substantive-change" style="display:none">Info about the 'substantive changes' definition.</span><b><a href="#substantive-change">#substantive-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-substantive-change">6.1.2. 
 Reviews and Review Responsibilities</a>
@@ -5398,8 +5398,8 @@ Abandoning an Unfinished Technical Report</a>
 After the Review Period</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-change">
-   <b><a href="#registry-change">#registry-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-change" class="dfn-panel" data-for="registry-change" id="infopanel-for-registry-change" role="dialog">
+   <span id="infopaneltitle-for-registry-change" style="display:none">Info about the 'registry changes' definition.</span><b><a href="#registry-change">#registry-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-change">6.4.1. 
 Registry Definitions</a>
@@ -5409,8 +5409,8 @@ Publishing Registries</a> <a href="#ref-for-registry-change②">(2)</a>
 Updating Registry Tables</a> <a href="#ref-for-registry-change④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="erratum">
-   <b><a href="#erratum">#erratum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-erratum" class="dfn-panel" data-for="erratum" id="infopanel-for-erratum" role="dialog">
+   <span id="infopaneltitle-for-erratum" style="display:none">Info about the 'erratum' definition.</span><b><a href="#erratum">#erratum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-erratum">6.1.5. 
 Candidate Amendments</a> <a href="#ref-for-erratum①">(2)</a>
@@ -5420,8 +5420,8 @@ Revising a Recommendation: Editorial Changes</a>
 Revising a Recommendation: Substantive Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-correction">
-   <b><a href="#candidate-correction">#candidate-correction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-correction" class="dfn-panel" data-for="candidate-correction" id="infopanel-for-candidate-correction" role="dialog">
+   <span id="infopaneltitle-for-candidate-correction" style="display:none">Info about the 'candidate correction' definition.</span><b><a href="#candidate-correction">#candidate-correction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-correction">6.1.5. 
 Candidate Amendments</a> <a href="#ref-for-candidate-correction①">(2)</a> <a href="#ref-for-candidate-correction②">(3)</a> <a href="#ref-for-candidate-correction③">(4)</a>
@@ -5429,8 +5429,8 @@ Candidate Amendments</a> <a href="#ref-for-candidate-correction①">(2)</a> <a h
 Revising a Recommendation: Substantive Changes</a> <a href="#ref-for-candidate-correction⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-addition">
-   <b><a href="#candidate-addition">#candidate-addition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-addition" class="dfn-panel" data-for="candidate-addition" id="infopanel-for-candidate-addition" role="dialog">
+   <span id="infopaneltitle-for-candidate-addition" style="display:none">Info about the 'candidate addition' definition.</span><b><a href="#candidate-addition">#candidate-addition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-addition">6.1.5. 
 Candidate Amendments</a>
@@ -5438,8 +5438,8 @@ Candidate Amendments</a>
 Revising a Recommendation: New Features</a> <a href="#ref-for-candidate-addition②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="team-correction">
-   <b><a href="#team-correction">#team-correction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-team-correction" class="dfn-panel" data-for="team-correction" id="infopanel-for-team-correction" role="dialog">
+   <span id="infopaneltitle-for-team-correction" style="display:none">Info about the 'Team correction' definition.</span><b><a href="#team-correction">#team-correction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-team-correction">6.1.5. 
 Candidate Amendments</a>
@@ -5447,8 +5447,8 @@ Candidate Amendments</a>
 Revising a Recommendation: Editorial Changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-amendment">
-   <b><a href="#candidate-amendment">#candidate-amendment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-amendment" class="dfn-panel" data-for="candidate-amendment" id="infopanel-for-candidate-amendment" role="dialog">
+   <span id="infopaneltitle-for-candidate-amendment" style="display:none">Info about the 'candidate amendments' definition.</span><b><a href="#candidate-amendment">#candidate-amendment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-amendment">6.1.5. 
 Candidate Amendments</a> <a href="#ref-for-candidate-amendment①">(2)</a> <a href="#ref-for-candidate-amendment②">(3)</a>
@@ -5465,8 +5465,8 @@ Updating Registry Tables</a>
     <li><a href="#ref-for-candidate-amendment①②"> Changes since the 15 September 2020 Process</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="w3c-recommendation-track">
-   <b><a href="#w3c-recommendation-track">#w3c-recommendation-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-w3c-recommendation-track" class="dfn-panel" data-for="w3c-recommendation-track" id="infopanel-for-w3c-recommendation-track" role="dialog">
+   <span id="infopaneltitle-for-w3c-recommendation-track" style="display:none">Info about the 'W3C Recommendation Track' definition.</span><b><a href="#w3c-recommendation-track">#w3c-recommendation-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-w3c-recommendation-track">6.1. 
 W3C Technical Reports</a> <a href="#ref-for-w3c-recommendation-track①">(2)</a> <a href="#ref-for-w3c-recommendation-track②">(3)</a>
@@ -5482,8 +5482,8 @@ Publishing Registries</a> <a href="#ref-for-w3c-recommendation-track⑦">(2)</a>
 Switching Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="patent-review-drafts">
-   <b><a href="#patent-review-drafts">#patent-review-drafts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-patent-review-drafts" class="dfn-panel" data-for="patent-review-drafts" id="infopanel-for-patent-review-drafts" role="dialog">
+   <span id="infopaneltitle-for-patent-review-drafts" style="display:none">Info about the 'Patent Review Drafts' definition.</span><b><a href="#patent-review-drafts">#patent-review-drafts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-patent-review-drafts">6.2.1. 
 Maturity Levels on the Recommendation Track</a> <a href="#ref-for-patent-review-drafts①">(2)</a>
@@ -5495,8 +5495,8 @@ Publishing Registries</a>
 Switching Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsWD">
-   <b><a href="#RecsWD">#RecsWD</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsWD" class="dfn-panel" data-for="RecsWD" id="infopanel-for-RecsWD" role="dialog">
+   <span id="infopaneltitle-for-RecsWD" style="display:none">Info about the 'Working Draft' definition.</span><b><a href="#RecsWD">#RecsWD</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsWD">5.2.6. 
 Working Group and Interest Group Charters</a>
@@ -5516,8 +5516,8 @@ Abandoning an Unfinished Technical Report</a>
 Publishing Registries</a> <a href="#ref-for-RecsWD①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fpwd">
-   <b><a href="#fpwd">#fpwd</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fpwd" class="dfn-panel" data-for="fpwd" id="infopanel-for-fpwd" role="dialog">
+   <span id="infopaneltitle-for-fpwd" style="display:none">Info about the 'First Public Working Draft' definition.</span><b><a href="#fpwd">#fpwd</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fpwd">5.2.6. 
 Working Group and Interest Group Charters</a>
@@ -5533,8 +5533,8 @@ Revising a Recommendation: New Features</a>
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsCR">
-   <b><a href="#RecsCR">#RecsCR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsCR" class="dfn-panel" data-for="RecsCR" id="infopanel-for-RecsCR" role="dialog">
+   <span id="infopaneltitle-for-RecsCR" style="display:none">Info about the 'Candidate Recommendation' definition.</span><b><a href="#RecsCR">#RecsCR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsCR">6.1.2.1. 
 Wide Review</a>
@@ -5558,8 +5558,8 @@ Rescinding a Candidate Recommendation</a>
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-recommendation-snapshot">
-   <b><a href="#candidate-recommendation-snapshot">#candidate-recommendation-snapshot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-recommendation-snapshot" class="dfn-panel" data-for="candidate-recommendation-snapshot" id="infopanel-for-candidate-recommendation-snapshot" role="dialog">
+   <span id="infopaneltitle-for-candidate-recommendation-snapshot" style="display:none">Info about the 'Candidate Recommendation Snapshot' definition.</span><b><a href="#candidate-recommendation-snapshot">#candidate-recommendation-snapshot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-recommendation-snapshot">6.2.1. 
 Maturity Levels on the Recommendation Track</a> <a href="#ref-for-candidate-recommendation-snapshot①">(2)</a> <a href="#ref-for-candidate-recommendation-snapshot②">(3)</a> <a href="#ref-for-candidate-recommendation-snapshot③">(4)</a> <a href="#ref-for-candidate-recommendation-snapshot④">(5)</a>
@@ -5575,8 +5575,8 @@ Transitioning to Proposed Recommendation</a> <a href="#ref-for-candidate-recomme
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-recommendation-draft">
-   <b><a href="#candidate-recommendation-draft">#candidate-recommendation-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-recommendation-draft" class="dfn-panel" data-for="candidate-recommendation-draft" id="infopanel-for-candidate-recommendation-draft" role="dialog">
+   <span id="infopaneltitle-for-candidate-recommendation-draft" style="display:none">Info about the 'Candidate Recommendation Draft' definition.</span><b><a href="#candidate-recommendation-draft">#candidate-recommendation-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-recommendation-draft">6.2.1. 
 Maturity Levels on the Recommendation Track</a> <a href="#ref-for-candidate-recommendation-draft①">(2)</a>
@@ -5586,8 +5586,8 @@ Publishing a Candidate Recommendation Draft</a> <a href="#ref-for-candidate-reco
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rescinded-candidate-recommendation">
-   <b><a href="#rescinded-candidate-recommendation">#rescinded-candidate-recommendation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rescinded-candidate-recommendation" class="dfn-panel" data-for="rescinded-candidate-recommendation" id="infopanel-for-rescinded-candidate-recommendation" role="dialog">
+   <span id="infopaneltitle-for-rescinded-candidate-recommendation" style="display:none">Info about the 'Rescinded Candidate Recommendation' definition.</span><b><a href="#rescinded-candidate-recommendation">#rescinded-candidate-recommendation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rescinded-candidate-recommendation">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
@@ -5595,8 +5595,8 @@ Maturity Levels on the Recommendation Track</a>
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsPR">
-   <b><a href="#RecsPR">#RecsPR</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsPR" class="dfn-panel" data-for="RecsPR" id="infopanel-for-RecsPR" role="dialog">
+   <span id="infopaneltitle-for-RecsPR" style="display:none">Info about the 'Proposed Recommendation' definition.</span><b><a href="#RecsPR">#RecsPR</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsPR">2.1. 
 Members</a>
@@ -5618,8 +5618,8 @@ Transitioning to W3C Recommendation</a>
 Advisory Committee Reviews</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsW3C">
-   <b><a href="#RecsW3C">#RecsW3C</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsW3C" class="dfn-panel" data-for="RecsW3C" id="infopanel-for-RecsW3C" role="dialog">
+   <span id="infopaneltitle-for-RecsW3C" style="display:none">Info about the 'W3C Recommendation' definition.</span><b><a href="#RecsW3C">#RecsW3C</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsW3C">1. 
 Introduction</a> <a href="#ref-for-RecsW3C">(2)</a>
@@ -5669,8 +5669,8 @@ Switching Tracks</a>
 Member Submission Process</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsSup">
-   <b><a href="#RecsSup">#RecsSup</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsSup" class="dfn-panel" data-for="RecsSup" id="infopanel-for-RecsSup" role="dialog">
+   <span id="infopaneltitle-for-RecsSup" style="display:none">Info about the 'Superseded Recommendation' definition.</span><b><a href="#RecsSup">#RecsSup</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsSup">6.2.12.3. 
 Abandoning a W3C Recommendation</a>
@@ -5678,8 +5678,8 @@ Abandoning a W3C Recommendation</a>
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RecsObs">
-   <b><a href="#RecsObs">#RecsObs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RecsObs" class="dfn-panel" data-for="RecsObs" id="infopanel-for-RecsObs" role="dialog">
+   <span id="infopaneltitle-for-RecsObs" style="display:none">Info about the 'Obsolete Recommendation' definition.</span><b><a href="#RecsObs">#RecsObs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RecsObs">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
@@ -5691,8 +5691,8 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</a> 
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="RescindedRec">
-   <b><a href="#RescindedRec">#RescindedRec</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-RescindedRec" class="dfn-panel" data-for="RescindedRec" id="infopanel-for-RescindedRec" role="dialog">
+   <span id="infopaneltitle-for-RescindedRec" style="display:none">Info about the 'Rescinded Recommendation' definition.</span><b><a href="#RescindedRec">#RescindedRec</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-RescindedRec">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
@@ -5704,22 +5704,22 @@ Process for Rescinding, Obsoleting, Superseding, Restoring a Recommendation</a> 
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discontinuedREC">
-   <b><a href="#discontinuedREC">#discontinuedREC</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discontinuedREC" class="dfn-panel" data-for="discontinuedREC" id="infopanel-for-discontinuedREC" role="dialog">
+   <span id="infopaneltitle-for-discontinuedREC" style="display:none">Info about the 'Discontinued Draft' definition.</span><b><a href="#discontinuedREC">#discontinuedREC</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discontinuedREC">6.2.12.1. 
 Abandoning an Unfinished Technical Report</a> <a href="#ref-for-discontinuedREC①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="editors-draft">
-   <b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-editors-draft" class="dfn-panel" data-for="editors-draft" id="infopanel-for-editors-draft" role="dialog">
+   <span id="infopaneltitle-for-editors-draft" style="display:none">Info about the 'Editor’s drafts' definition.</span><b><a href="#editors-draft">#editors-draft</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-editors-draft">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="adequate-implementation">
-   <b><a href="#adequate-implementation">#adequate-implementation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-adequate-implementation" class="dfn-panel" data-for="adequate-implementation" id="infopanel-for-adequate-implementation" role="dialog">
+   <span id="infopaneltitle-for-adequate-implementation" style="display:none">Info about the 'adequate implementation experience' definition.</span><b><a href="#adequate-implementation">#adequate-implementation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-adequate-implementation">6.1. 
 W3C Technical Reports</a>
@@ -5733,8 +5733,8 @@ Transitioning to Proposed Recommendation</a>
 Incorporating Candidate Amendments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trans-req">
-   <b><a href="#trans-req">#trans-req</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trans-req" class="dfn-panel" data-for="trans-req" id="infopanel-for-trans-req" role="dialog">
+   <span id="infopaneltitle-for-trans-req" style="display:none">Info about the 'Transition Requests' definition.</span><b><a href="#trans-req">#trans-req</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trans-req">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
@@ -5746,8 +5746,8 @@ Updating Mature Publications on the Recommendation Track</a>
 Transitioning to Candidate Recommendation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-requests">
-   <b><a href="#update-requests">#update-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-requests" class="dfn-panel" data-for="update-requests" id="infopanel-for-update-requests" role="dialog">
+   <span id="infopaneltitle-for-update-requests" style="display:none">Info about the 'Update Requests' definition.</span><b><a href="#update-requests">#update-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-requests">6.2.1. 
 Maturity Levels on the Recommendation Track</a>
@@ -5767,8 +5767,8 @@ Incorporating Candidate Amendments</a>
 Updating Registry Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-risk">
-   <b><a href="#at-risk">#at-risk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-risk" class="dfn-panel" data-for="at-risk" id="infopanel-for-at-risk" role="dialog">
+   <span id="infopaneltitle-for-at-risk" style="display:none">Info about the 'at risk' definition.</span><b><a href="#at-risk">#at-risk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-risk">6.2.8.1. 
 Publishing a Candidate Recommendation Snapshot</a> <a href="#ref-for-at-risk①">(2)</a>
@@ -5778,8 +5778,8 @@ Publishing a Candidate Recommendation Draft</a>
 Transitioning to Proposed Recommendation</a> <a href="#ref-for-at-risk④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allow-new-features">
-   <b><a href="#allow-new-features">#allow-new-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allow-new-features" class="dfn-panel" data-for="allow-new-features" id="infopanel-for-allow-new-features" role="dialog">
+   <span id="infopaneltitle-for-allow-new-features" style="display:none">Info about the 'allow new features' definition.</span><b><a href="#allow-new-features">#allow-new-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allow-new-features">6.2.4.1. 
 Streamlined Publication Approval</a>
@@ -5789,8 +5789,8 @@ Revising a Recommendation: New Features</a>
 Incorporating Candidate Amendments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-call-review">
-   <b><a href="#last-call-review">#last-call-review</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-call-review" class="dfn-panel" data-for="last-call-review" id="infopanel-for-last-call-review" role="dialog">
+   <span id="infopaneltitle-for-last-call-review" style="display:none">Info about the 'Last Call for Review of Proposed Amendments' definition.</span><b><a href="#last-call-review">#last-call-review</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-call-review">6.2.11.3. 
 Revising a Recommendation: Substantive Changes</a>
@@ -5798,8 +5798,8 @@ Revising a Recommendation: Substantive Changes</a>
 Incorporating Candidate Amendments</a> <a href="#ref-for-last-call-review②">(2)</a> <a href="#ref-for-last-call-review③">(3)</a> <a href="#ref-for-last-call-review④">(4)</a> <a href="#ref-for-last-call-review⑤">(5)</a> <a href="#ref-for-last-call-review⑥">(6)</a> <a href="#ref-for-last-call-review⑦">(7)</a> <a href="#ref-for-last-call-review⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-call-for-review-of-proposed-corrections">
-   <b><a href="#last-call-for-review-of-proposed-corrections">#last-call-for-review-of-proposed-corrections</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-call-for-review-of-proposed-corrections" class="dfn-panel" data-for="last-call-for-review-of-proposed-corrections" id="infopanel-for-last-call-for-review-of-proposed-corrections" role="dialog">
+   <span id="infopaneltitle-for-last-call-for-review-of-proposed-corrections" style="display:none">Info about the 'Last Call for Review of Proposed Corrections' definition.</span><b><a href="#last-call-for-review-of-proposed-corrections">#last-call-for-review-of-proposed-corrections</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-call-for-review-of-proposed-corrections">6.2.4.1. 
 Streamlined Publication Approval</a>
@@ -5807,8 +5807,8 @@ Streamlined Publication Approval</a>
 Revising W3C Statements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-call-for-review-of-proposed-additions">
-   <b><a href="#last-call-for-review-of-proposed-additions">#last-call-for-review-of-proposed-additions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-call-for-review-of-proposed-additions" class="dfn-panel" data-for="last-call-for-review-of-proposed-additions" id="infopanel-for-last-call-for-review-of-proposed-additions" role="dialog">
+   <span id="infopaneltitle-for-last-call-for-review-of-proposed-additions" style="display:none">Info about the 'Last Call for Review of Proposed Additions' definition.</span><b><a href="#last-call-for-review-of-proposed-additions">#last-call-for-review-of-proposed-additions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-call-for-review-of-proposed-additions">6.2.4.1. 
 Streamlined Publication Approval</a>
@@ -5816,15 +5816,15 @@ Streamlined Publication Approval</a>
 Incorporating Candidate Amendments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="last-call-for-review-of-proposed-corrections-and-additions">
-   <b><a href="#last-call-for-review-of-proposed-corrections-and-additions">#last-call-for-review-of-proposed-corrections-and-additions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-last-call-for-review-of-proposed-corrections-and-additions" class="dfn-panel" data-for="last-call-for-review-of-proposed-corrections-and-additions" id="infopanel-for-last-call-for-review-of-proposed-corrections-and-additions" role="dialog">
+   <span id="infopaneltitle-for-last-call-for-review-of-proposed-corrections-and-additions" style="display:none">Info about the 'Last Call for Review of Proposed Corrections and Additions' definition.</span><b><a href="#last-call-for-review-of-proposed-corrections-and-additions">#last-call-for-review-of-proposed-corrections-and-additions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-last-call-for-review-of-proposed-corrections-and-additions">6.2.11.5. 
 Incorporating Candidate Amendments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proposed-amendments">
-   <b><a href="#proposed-amendments">#proposed-amendments</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proposed-amendments" class="dfn-panel" data-for="proposed-amendments" id="infopanel-for-proposed-amendments" role="dialog">
+   <span id="infopaneltitle-for-proposed-amendments" style="display:none">Info about the 'proposed amendments' definition.</span><b><a href="#proposed-amendments">#proposed-amendments</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proposed-amendments">6.2.11.5. 
 Incorporating Candidate Amendments</a> <a href="#ref-for-proposed-amendments①">(2)</a> <a href="#ref-for-proposed-amendments②">(3)</a> <a href="#ref-for-proposed-amendments③">(4)</a> <a href="#ref-for-proposed-amendments④">(5)</a> <a href="#ref-for-proposed-amendments⑤">(6)</a> <a href="#ref-for-proposed-amendments⑥">(7)</a> <a href="#ref-for-proposed-amendments⑦">(8)</a> <a href="#ref-for-proposed-amendments⑧">(9)</a> <a href="#ref-for-proposed-amendments⑨">(10)</a>
@@ -5834,22 +5834,22 @@ Revising W3C Statements</a> <a href="#ref-for-proposed-amendments①①">(2)</a>
 Updating Registry Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proposed-corrections">
-   <b><a href="#proposed-corrections">#proposed-corrections</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proposed-corrections" class="dfn-panel" data-for="proposed-corrections" id="infopanel-for-proposed-corrections" role="dialog">
+   <span id="infopaneltitle-for-proposed-corrections" style="display:none">Info about the 'proposed corrections' definition.</span><b><a href="#proposed-corrections">#proposed-corrections</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proposed-corrections">6.2.4.1. 
 Streamlined Publication Approval</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proposed-additions">
-   <b><a href="#proposed-additions">#proposed-additions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proposed-additions" class="dfn-panel" data-for="proposed-additions" id="infopanel-for-proposed-additions" role="dialog">
+   <span id="infopaneltitle-for-proposed-additions" style="display:none">Info about the 'proposed additions' definition.</span><b><a href="#proposed-additions">#proposed-additions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proposed-additions">6.2.4.1. 
 Streamlined Publication Approval</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="WGNote">
-   <b><a href="#WGNote">#WGNote</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-WGNote" class="dfn-panel" data-for="WGNote" id="infopanel-for-WGNote" role="dialog">
+   <span id="infopaneltitle-for-WGNote" style="display:none">Info about the 'Group Note' definition.</span><b><a href="#WGNote">#WGNote</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-WGNote">5.  
 Working Groups and Interest Groups</a>
@@ -5863,15 +5863,15 @@ Elevating Group Notes to W3C Statement status</a> <a href="#ref-for-WGNote①④
 Scope of Member Submissions</a> <a href="#ref-for-WGNote①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="draft-note">
-   <b><a href="#draft-note">#draft-note</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-draft-note" class="dfn-panel" data-for="draft-note" id="infopanel-for-draft-note" role="dialog">
+   <span id="infopaneltitle-for-draft-note" style="display:none">Info about the 'Draft Notes' definition.</span><b><a href="#draft-note">#draft-note</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-draft-note">6.3.1. 
 Group Notes</a> <a href="#ref-for-draft-note①">(2)</a> <a href="#ref-for-draft-note②">(3)</a> <a href="#ref-for-draft-note③">(4)</a> <a href="#ref-for-draft-note④">(5)</a> <a href="#ref-for-draft-note⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="statement">
-   <b><a href="#statement">#statement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-statement" class="dfn-panel" data-for="statement" id="infopanel-for-statement" role="dialog">
+   <span id="infopaneltitle-for-statement" style="display:none">Info about the 'W3C Statement' definition.</span><b><a href="#statement">#statement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-statement">6.3.2. 
 Elevating Group Notes to W3C Statement status</a> <a href="#ref-for-statement①">(2)</a> <a href="#ref-for-statement②">(3)</a> <a href="#ref-for-statement③">(4)</a> <a href="#ref-for-statement④">(5)</a> <a href="#ref-for-statement⑤">(6)</a> <a href="#ref-for-statement⑥">(7)</a>
@@ -5881,8 +5881,8 @@ Revising W3C Statements</a> <a href="#ref-for-statement⑧">(2)</a> <a href="#re
 Switching Tracks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry">
-   <b><a href="#registry">#registry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry" class="dfn-panel" data-for="registry" id="infopanel-for-registry" role="dialog">
+   <span id="infopaneltitle-for-registry" style="display:none">Info about the 'registry' definition.</span><b><a href="#registry">#registry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry">6.1. 
 W3C Technical Reports</a>
@@ -5896,8 +5896,8 @@ Publishing Registries</a> <a href="#ref-for-registry⑦">(2)</a>
 Registry Data Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-table">
-   <b><a href="#registry-table">#registry-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-table" class="dfn-panel" data-for="registry-table" id="infopanel-for-registry-table" role="dialog">
+   <span id="infopaneltitle-for-registry-table" style="display:none">Info about the 'registry tables' definition.</span><b><a href="#registry-table">#registry-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-table">6.1.3. 
 Classes of Changes</a> <a href="#ref-for-registry-table①">(2)</a>
@@ -5913,8 +5913,8 @@ Updating Registry Tables</a> <a href="#ref-for-registry-table①⑧">(2)</a>
 Registry Data Reports</a> <a href="#ref-for-registry-table②⓪">(2)</a> <a href="#ref-for-registry-table②①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-entry">
-   <b><a href="#registry-entry">#registry-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-entry" class="dfn-panel" data-for="registry-entry" id="infopanel-for-registry-entry" role="dialog">
+   <span id="infopaneltitle-for-registry-entry" style="display:none">Info about the 'registry entries' definition.</span><b><a href="#registry-entry">#registry-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-entry">6.1.3. 
 Classes of Changes</a>
@@ -5926,8 +5926,8 @@ Registry Data Reports</a>
 Specifications that Reference Registries</a> <a href="#ref-for-registry-entry④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-data">
-   <b><a href="#registry-data">#registry-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-data" class="dfn-panel" data-for="registry-data" id="infopanel-for-registry-data" role="dialog">
+   <span id="infopaneltitle-for-registry-data" style="display:none">Info about the 'registry data' definition.</span><b><a href="#registry-data">#registry-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-data">6.4.2. 
 Publishing Registries</a>
@@ -5935,8 +5935,8 @@ Publishing Registries</a>
 Registry Data Reports</a> <a href="#ref-for-registry-data②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-definition">
-   <b><a href="#registry-definition">#registry-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-definition" class="dfn-panel" data-for="registry-definition" id="infopanel-for-registry-definition" role="dialog">
+   <span id="infopaneltitle-for-registry-definition" style="display:none">Info about the 'registry definition' definition.</span><b><a href="#registry-definition">#registry-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-definition">6.1. 
 W3C Technical Reports</a>
@@ -5952,8 +5952,8 @@ Updating Registry Tables</a> <a href="#ref-for-registry-definition⑦">(2)</a> <
 Registry Data Reports</a> <a href="#ref-for-registry-definition①①">(2)</a> <a href="#ref-for-registry-definition①②">(3)</a> <a href="#ref-for-registry-definition①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custodian">
-   <b><a href="#custodian">#custodian</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custodian" class="dfn-panel" data-for="custodian" id="infopanel-for-custodian" role="dialog">
+   <span id="infopaneltitle-for-custodian" style="display:none">Info about the 'custodian' definition.</span><b><a href="#custodian">#custodian</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custodian">6.4. 
 The Registry Track</a>
@@ -5965,8 +5965,8 @@ Publishing Registries</a>
 Updating Registry Tables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-report">
-   <b><a href="#registry-report">#registry-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-report" class="dfn-panel" data-for="registry-report" id="infopanel-for-registry-report" role="dialog">
+   <span id="infopaneltitle-for-registry-report" style="display:none">Info about the 'registry report' definition.</span><b><a href="#registry-report">#registry-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-report">6.1. 
 W3C Technical Reports</a> <a href="#ref-for-registry-report①">(2)</a>
@@ -5974,8 +5974,8 @@ W3C Technical Reports</a> <a href="#ref-for-registry-report①">(2)</a>
 Publishing Registries</a> <a href="#ref-for-registry-report③">(2)</a> <a href="#ref-for-registry-report④">(3)</a> <a href="#ref-for-registry-report⑤">(4)</a> <a href="#ref-for-registry-report⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-section">
-   <b><a href="#registry-section">#registry-section</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-section" class="dfn-panel" data-for="registry-section" id="infopanel-for-registry-section" role="dialog">
+   <span id="infopaneltitle-for-registry-section" style="display:none">Info about the 'registry section' definition.</span><b><a href="#registry-section">#registry-section</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-section">6.1. 
 W3C Technical Reports</a>
@@ -5983,29 +5983,29 @@ W3C Technical Reports</a>
 Publishing Registries</a> <a href="#ref-for-registry-section②">(2)</a> <a href="#ref-for-registry-section③">(3)</a> <a href="#ref-for-registry-section④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-track">
-   <b><a href="#registry-track">#registry-track</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-track" class="dfn-panel" data-for="registry-track" id="infopanel-for-registry-track" role="dialog">
+   <span id="infopaneltitle-for-registry-track" style="display:none">Info about the 'Registry Track' definition.</span><b><a href="#registry-track">#registry-track</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-track">6.4.2. 
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="candidate-registry-snapshot">
-   <b><a href="#candidate-registry-snapshot">#candidate-registry-snapshot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-candidate-registry-snapshot" class="dfn-panel" data-for="candidate-registry-snapshot" id="infopanel-for-candidate-registry-snapshot" role="dialog">
+   <span id="infopaneltitle-for-candidate-registry-snapshot" style="display:none">Info about the 'Candidate Registry Snapshot' definition.</span><b><a href="#candidate-registry-snapshot">#candidate-registry-snapshot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-candidate-registry-snapshot">6.4.2. 
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="w3c-registry">
-   <b><a href="#w3c-registry">#w3c-registry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-w3c-registry" class="dfn-panel" data-for="w3c-registry" id="infopanel-for-w3c-registry" role="dialog">
+   <span id="infopaneltitle-for-w3c-registry" style="display:none">Info about the 'W3C Registry' definition.</span><b><a href="#w3c-registry">#w3c-registry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-w3c-registry">6.4.2. 
 Publishing Registries</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registry-data-report">
-   <b><a href="#registry-data-report">#registry-data-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registry-data-report" class="dfn-panel" data-for="registry-data-report" id="infopanel-for-registry-data-report" role="dialog">
+   <span id="infopaneltitle-for-registry-data-report" style="display:none">Info about the 'Registry Data Report' definition.</span><b><a href="#registry-data-report">#registry-data-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registry-data-report">6.4.2. 
 Publishing Registries</a>
@@ -6013,8 +6013,8 @@ Publishing Registries</a>
 Registry Data Reports</a> <a href="#ref-for-registry-data-report②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="def-w3c-decision">
-   <b><a href="#def-w3c-decision">#def-w3c-decision</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-def-w3c-decision" class="dfn-panel" data-for="def-w3c-decision" id="infopanel-for-def-w3c-decision" role="dialog">
+   <span id="infopaneltitle-for-def-w3c-decision" style="display:none">Info about the 'W3C decision' definition.</span><b><a href="#def-w3c-decision">#def-w3c-decision</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def-w3c-decision">6.2.10. 
 Transitioning to W3C Recommendation</a> <a href="#ref-for-def-w3c-decision①">(2)</a>
@@ -6034,8 +6034,8 @@ Appeal by Advisory Committee Representatives</a> <a href="#ref-for-def-w3c-decis
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advisory-committee-review">
-   <b><a href="#advisory-committee-review">#advisory-committee-review</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advisory-committee-review" class="dfn-panel" data-for="advisory-committee-review" id="infopanel-for-advisory-committee-review" role="dialog">
+   <span id="infopaneltitle-for-advisory-committee-review" style="display:none">Info about the ' Advisory Committee review' definition.</span><b><a href="#advisory-committee-review">#advisory-committee-review</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advisory-committee-review">5.2.3. 
 Advisory Committee Review of a Working Group or Interest Group Charter</a>
@@ -6067,15 +6067,15 @@ Liaisons</a>
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reviewform">
-   <b><a href="#reviewform">#reviewform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reviewform" class="dfn-panel" data-for="reviewform" id="infopanel-for-reviewform" role="dialog">
+   <span id="infopaneltitle-for-reviewform" style="display:none">Info about the 'Call for Review' definition.</span><b><a href="#reviewform">#reviewform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reviewform">7.1.1. 
 Start of a Review Period</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="advisory-committee-appeal">
-   <b><a href="#advisory-committee-appeal">#advisory-committee-appeal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-advisory-committee-appeal" class="dfn-panel" data-for="advisory-committee-appeal" id="infopanel-for-advisory-committee-appeal" role="dialog">
+   <span id="infopaneltitle-for-advisory-committee-appeal" style="display:none">Info about the 'Advisory Committee Appeal' definition.</span><b><a href="#advisory-committee-appeal">#advisory-committee-appeal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-advisory-committee-appeal">6.2.9. 
 Transitioning to Proposed Recommendation</a>
@@ -6099,15 +6099,15 @@ Liaisons</a> <a href="#ref-for-advisory-committee-appeal①⓪">(2)</a>
 Process Evolution</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="EventsW">
-   <b><a href="#EventsW">#EventsW</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-EventsW" class="dfn-panel" data-for="EventsW" id="infopanel-for-EventsW" role="dialog">
+   <span id="infopaneltitle-for-EventsW" style="display:none">Info about the 'Workshops' definition.</span><b><a href="#EventsW">#EventsW</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EventsW">4.  
 Dissemination Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mou">
-   <b><a href="#mou">#mou</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mou" class="dfn-panel" data-for="mou" id="infopanel-for-mou" role="dialog">
+   <span id="infopaneltitle-for-mou" style="display:none">Info about the 'Memorandum of Understanding' definition.</span><b><a href="#mou">#mou</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mou">7.2. 
 Appeal by Advisory Committee Representatives</a>
@@ -6115,8 +6115,8 @@ Appeal by Advisory Committee Representatives</a>
 Liaisons</a> <a href="#ref-for-mou②">(2)</a> <a href="#ref-for-mou③">(3)</a> <a href="#ref-for-mou④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="MemberSubmission">
-   <b><a href="#MemberSubmission">#MemberSubmission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-MemberSubmission" class="dfn-panel" data-for="MemberSubmission" id="infopanel-for-MemberSubmission" role="dialog">
+   <span id="infopaneltitle-for-MemberSubmission" style="display:none">Info about the 'Member Submission' definition.</span><b><a href="#MemberSubmission">#MemberSubmission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-MemberSubmission">10. 
 Member Submission Process</a> <a href="#ref-for-MemberSubmission①">(2)</a> <a href="#ref-for-MemberSubmission②">(3)</a> <a href="#ref-for-MemberSubmission③">(4)</a>
@@ -6128,8 +6128,8 @@ Team Rights and Obligations</a>
 Acknowledgment of a Submission Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="submitter">
-   <b><a href="#submitter">#submitter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-submitter" class="dfn-panel" data-for="submitter" id="infopanel-for-submitter" role="dialog">
+   <span id="infopaneltitle-for-submitter" style="display:none">Info about the 'Submitter(s)' definition.</span><b><a href="#submitter">#submitter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-submitter">10. 
 Member Submission Process</a> <a href="#ref-for-submitter①">(2)</a> <a href="#ref-for-submitter②">(3)</a> <a href="#ref-for-submitter③">(4)</a>
@@ -6145,8 +6145,8 @@ Acknowledgment of a Submission Request</a> <a href="#ref-for-submitter①⑥">(2
 Rejection of a Submission Request, and Submission Appeals</a> <a href="#ref-for-submitter①⑨">(2)</a> <a href="#ref-for-submitter②⓪">(3)</a> <a href="#ref-for-submitter②①">(4)</a> <a href="#ref-for-submitter②②">(5)</a> <a href="#ref-for-submitter②③">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validation-notice">
-   <b><a href="#validation-notice">#validation-notice</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validation-notice" class="dfn-panel" data-for="validation-notice" id="infopanel-for-validation-notice" role="dialog">
+   <span id="infopaneltitle-for-validation-notice" style="display:none">Info about the 'validation notice' definition.</span><b><a href="#validation-notice">#validation-notice</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validation-notice">10.3. 
 Acknowledgment of a Submission Request</a>
@@ -6154,57 +6154,113 @@ Acknowledgment of a Submission Request</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/wcag-act/act-rules-format.html
+++ b/tests/github/w3c/wcag-act/act-rules-format.html
@@ -1503,8 +1503,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <dt id="biblio-wcag">[WCAG]
    <dd>Wendy Chisholm; Gregg Vanderheiden; Ian Jacobs. <a href="https://www.w3.org/TR/WAI-WEBCONTENT/"><cite>Web Content Accessibility Guidelines 1.0</cite></a>. 5 May 1999. REC. URL: <a href="https://www.w3.org/TR/WAI-WEBCONTENT/">https://www.w3.org/TR/WAI-WEBCONTENT/</a>
   </dl>
-  <aside class="dfn-panel" data-for="atomic-rules">
-   <b><a href="#atomic-rules">#atomic-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-atomic-rules" class="dfn-panel" data-for="atomic-rules" id="infopanel-for-atomic-rules" role="dialog">
+   <span id="infopaneltitle-for-atomic-rules" style="display:none">Info about the 'Atomic rules' definition.</span><b><a href="#atomic-rules">#atomic-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-rules">3. ACT Rule Types</a>
     <li><a href="#ref-for-atomic-rules①">4.5. Rule Input</a>
@@ -1514,22 +1514,22 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-atomic-rules⑥">4.7.1. Expectations for Atomic Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composite-rules">
-   <b><a href="#composite-rules">#composite-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composite-rules" class="dfn-panel" data-for="composite-rules" id="infopanel-for-composite-rules" role="dialog">
+   <span id="infopaneltitle-for-composite-rules" style="display:none">Info about the 'Composite rules' definition.</span><b><a href="#composite-rules">#composite-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composite-rules">4.5. Rule Input</a>
     <li><a href="#ref-for-composite-rules①">4.5.2. Input Rules (Composite rules only)</a>
     <li><a href="#ref-for-composite-rules②">4.7.2. Expectations for Composite Rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descriptive-title">
-   <b><a href="#descriptive-title">#descriptive-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descriptive-title" class="dfn-panel" data-for="descriptive-title" id="infopanel-for-descriptive-title" role="dialog">
+   <span id="infopaneltitle-for-descriptive-title" style="display:none">Info about the 'Descriptive Title' definition.</span><b><a href="#descriptive-title">#descriptive-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descriptive-title">4.5.2. Input Rules (Composite rules only)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accessibility-requirement">
-   <b><a href="#accessibility-requirement">#accessibility-requirement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accessibility-requirement" class="dfn-panel" data-for="accessibility-requirement" id="infopanel-for-accessibility-requirement" role="dialog">
+   <span id="infopaneltitle-for-accessibility-requirement" style="display:none">Info about the 'Accessibility requirement' definition.</span><b><a href="#accessibility-requirement">#accessibility-requirement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accessibility-requirement">1. Introduction</a>
     <li><a href="#ref-for-accessibility-requirement①">2. Scope</a>
@@ -1541,8 +1541,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-accessibility-requirement①⓪">7. Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="accessibility-requirements-document">
-   <b><a href="#accessibility-requirements-document">#accessibility-requirements-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-accessibility-requirements-document" class="dfn-panel" data-for="accessibility-requirements-document" id="infopanel-for-accessibility-requirements-document" role="dialog">
+   <span id="infopaneltitle-for-accessibility-requirements-document" style="display:none">Info about the 'Accessibility requirements document' definition.</span><b><a href="#accessibility-requirements-document">#accessibility-requirements-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-accessibility-requirements-document">1. Introduction</a>
     <li><a href="#ref-for-accessibility-requirements-document①">4.4. Accessibility Requirements Mapping</a> <a href="#ref-for-accessibility-requirements-document②">(2)</a> <a href="#ref-for-accessibility-requirements-document③">(3)</a>
@@ -1551,8 +1551,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-accessibility-requirements-document⑦">4.4.4. External Accessibility Requirements Mapping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="outcome">
-   <b><a href="#outcome">#outcome</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-outcome" class="dfn-panel" data-for="outcome" id="infopanel-for-outcome" role="dialog">
+   <span id="infopaneltitle-for-outcome" style="display:none">Info about the 'Outcome' definition.</span><b><a href="#outcome">#outcome</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-outcome">3. ACT Rule Types</a> <a href="#ref-for-outcome①">(2)</a> <a href="#ref-for-outcome②">(3)</a> <a href="#ref-for-outcome③">(4)</a>
     <li><a href="#ref-for-outcome④">4.4. Accessibility Requirements Mapping</a>
@@ -1568,8 +1568,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-outcome①④">4.13. Issues List (optional)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="test-subject">
-   <b><a href="#test-subject">#test-subject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-test-subject" class="dfn-panel" data-for="test-subject" id="infopanel-for-test-subject" role="dialog">
+   <span id="infopaneltitle-for-test-subject" style="display:none">Info about the 'Test Subject' definition.</span><b><a href="#test-subject">#test-subject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-test-subject">3. ACT Rule Types</a> <a href="#ref-for-test-subject①">(2)</a>
     <li><a href="#ref-for-test-subject②">4.4.1. Outcome Mapping</a>
@@ -1580,8 +1580,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
     <li><a href="#ref-for-test-subject⑦">7. Definitions</a> <a href="#ref-for-test-subject⑧">(2)</a> <a href="#ref-for-test-subject⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="test-target">
-   <b><a href="#test-target">#test-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-test-target" class="dfn-panel" data-for="test-target" id="infopanel-for-test-target" role="dialog">
+   <span id="infopaneltitle-for-test-target" style="display:none">Info about the 'Test Target' definition.</span><b><a href="#test-target">#test-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-test-target">3. ACT Rule Types</a>
     <li><a href="#ref-for-test-target①">4.5.2. Input Rules (Composite rules only)</a>
@@ -1595,57 +1595,113 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-change-password-url/change-password-url.html
+++ b/tests/github/w3c/webappsec-change-password-url/change-password-url.html
@@ -672,122 +672,122 @@ for their feedback on this proposal. All of its features are theirs and all of i
    <li><a href="#change-password-url">change password url</a><span>, in § 3</span>
    <li><a href="#generate-a-change-password-url">generate a change password url</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-redirect-status">
-   <a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-redirect-status" class="dfn-panel" data-for="term-for-redirect-status" id="infopanel-for-term-for-redirect-status" role="menu">
+   <span id="infopaneltitle-for-term-for-redirect-status" style="display:none">Info about the 'redirect status' external reference.</span><a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-redirect-status">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-host">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-host" class="dfn-panel" data-for="term-for-concept-origin-host" id="infopanel-for-term-for-concept-origin-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-host" style="display:none">Info about the 'host' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-host">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv" class="dfn-panel" data-for="term-for-attr-meta-http-equiv" id="infopanel-for-term-for-attr-meta-http-equiv" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv" style="display:none">Info about the 'http-equiv' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-port">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-port">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-port" class="dfn-panel" data-for="term-for-concept-origin-port" id="infopanel-for-term-for-concept-origin-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-port" style="display:none">Info about the 'port' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-port">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-port">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv-refresh">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv-refresh" class="dfn-panel" data-for="term-for-attr-meta-http-equiv-refresh" id="infopanel-for-term-for-attr-meta-http-equiv-refresh" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv-refresh" style="display:none">Info about the 'refresh state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv-refresh">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-scheme">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-scheme" class="dfn-panel" data-for="term-for-concept-origin-scheme" id="infopanel-for-term-for-concept-origin-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-scheme">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ToUnicode">
-   <a href="https://www.unicode.org/reports/tr46/#ToUnicode">https://www.unicode.org/reports/tr46/#ToUnicode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ToUnicode" class="dfn-panel" data-for="term-for-ToUnicode" id="infopanel-for-term-for-ToUnicode" role="menu">
+   <span id="infopaneltitle-for-term-for-ToUnicode" style="display:none">Info about the 'ToUnicode' external reference.</span><a href="https://www.unicode.org/reports/tr46/#ToUnicode">https://www.unicode.org/reports/tr46/#ToUnicode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ToUnicode">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-test-the-reliability-of-an-origins-response-status-codes">
-   <a href="https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html#test-the-reliability-of-an-origins-response-status-codes">https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html#test-the-reliability-of-an-origins-response-status-codes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-test-the-reliability-of-an-origins-response-status-codes" class="dfn-panel" data-for="term-for-test-the-reliability-of-an-origins-response-status-codes" id="infopanel-for-term-for-test-the-reliability-of-an-origins-response-status-codes" role="menu">
+   <span id="infopaneltitle-for-term-for-test-the-reliability-of-an-origins-response-status-codes" style="display:none">Info about the 'test the reliability of an origin's response status codes' external reference.</span><a href="https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html#test-the-reliability-of-an-origins-response-status-codes">https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html#test-the-reliability-of-an-origins-response-status-codes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-test-the-reliability-of-an-origins-response-status-codes">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.2">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.2">https://tools.ietf.org/html/rfc7231#section-7.1.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.2" class="dfn-panel" data-for="term-for-section-7.1.2" id="infopanel-for-term-for-section-7.1.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.2" style="display:none">Info about the 'location' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.2">https://tools.ietf.org/html/rfc7231#section-7.1.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.2">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-origin">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-origin" class="dfn-panel" data-for="term-for-potentially-trustworthy-origin" id="infopanel-for-term-for-potentially-trustworthy-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-origin" style="display:none">Info about the 'potentially trustworthy origin' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-origin">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url">
-   <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url" class="dfn-panel" data-for="term-for-url" id="infopanel-for-term-for-url" role="menu">
+   <span id="infopaneltitle-for-term-for-url" style="display:none">Info about the 'URL' external reference.</span><a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">3. Change Password URLs</a> <a href="#ref-for-concept-url-origin①">(2)</a> <a href="#ref-for-concept-url-origin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">3. Change Password URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">3. Change Password URLs</a>
    </ul>
@@ -876,65 +876,121 @@ for their feedback on this proposal. All of its features are theirs and all of i
   <div style="counter-reset:issue">
    <div class="issue"> Make use of <a data-link-type="dfn" href="https://w3c.github.io/webappsec-change-password-url/response-code-reliability.html#test-the-reliability-of-an-origins-response-status-codes">test the reliability of an origin’s response status codes</a> from <a data-link-type="biblio" href="#biblio-response-code-reliability" title="Detecting the reliability of HTTP status codes">[RESPONSE-CODE-RELIABILITY]</a>. <a class="issue-return" href="#issue-99dd61ed" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="change-password-url">
-   <b><a href="#change-password-url">#change-password-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-change-password-url" class="dfn-panel" data-for="change-password-url" id="infopanel-for-change-password-url" role="dialog">
+   <span id="infopaneltitle-for-change-password-url" style="display:none">Info about the 'change password url' definition.</span><b><a href="#change-password-url">#change-password-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-change-password-url">3. Change Password URLs</a> <a href="#ref-for-change-password-url①">(2)</a> <a href="#ref-for-change-password-url②">(3)</a> <a href="#ref-for-change-password-url③">(4)</a> <a href="#ref-for-change-password-url④">(5)</a> <a href="#ref-for-change-password-url⑤">(6)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-change-password-url/response-code-reliability.html
+++ b/tests/github/w3c/webappsec-change-password-url/response-code-reliability.html
@@ -639,129 +639,129 @@ This registration will be submitted to the IESG for review, approval, and regist
   <ul class="index">
    <li><a href="#test-the-reliability-of-an-origins-response-status-codes">test the reliability of an origin’s response status codes</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-request-cache-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-cache-mode" class="dfn-panel" data-for="term-for-concept-request-cache-mode" id="infopanel-for-term-for-concept-request-cache-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-cache-mode">https://fetch.spec.whatwg.org/#concept-request-cache-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2. Detecting the reliability of HTTP status codes</a> <a href="#ref-for-concept-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ok-status">
-   <a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ok-status" class="dfn-panel" data-for="term-for-ok-status" id="infopanel-for-term-for-ok-status" role="menu">
+   <span id="infopaneltitle-for-term-for-ok-status" style="display:none">Info about the 'ok status' external reference.</span><a href="https://fetch.spec.whatwg.org/#ok-status">https://fetch.spec.whatwg.org/#ok-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">2. Detecting the reliability of HTTP status codes</a> <a href="#ref-for-ok-status①">(2)</a> <a href="#ref-for-ok-status②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">Introduction</a>
     <li><a href="#ref-for-concept-response-status①">2. Detecting the reliability of HTTP status codes</a> <a href="#ref-for-concept-response-status②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue the following steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-url-url">
-   <a href="https://url.spec.whatwg.org/#dom-url-url">https://url.spec.whatwg.org/#dom-url-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-url-url" class="dfn-panel" data-for="term-for-dom-url-url" id="infopanel-for-term-for-dom-url-url" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-url-url" style="display:none">Info about the 'URL(url, base)' external reference.</span><a href="https://url.spec.whatwg.org/#dom-url-url">https://url.spec.whatwg.org/#dom-url-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-url">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2. Detecting the reliability of HTTP status codes</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">2. Detecting the reliability of HTTP status codes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc8615#section-3">https://tools.ietf.org/html/rfc8615#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'well-known uri' external reference.</span><a href="https://tools.ietf.org/html/rfc8615#section-3">https://tools.ietf.org/html/rfc8615#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">Introduction</a> <a href="#ref-for-section-3①">(2)</a>
    </ul>
@@ -830,57 +830,113 @@ This registration will be submitted to the IESG for review, approval, and regist
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-credential-management/index.html
+++ b/tests/github/w3c/webappsec-credential-management/index.html
@@ -3200,103 +3200,103 @@ partial dictionary CredentialCreationOptions {
    <li><a href="#user-mediated">user mediated</a><span>, in § 5</span>
    <li><a href="#user-mediated">user mediation</a><span>, in § 5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-backgroundfetchmanager-fetch">
-   <a href="https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch">https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-backgroundfetchmanager-fetch" class="dfn-panel" data-for="term-for-dom-backgroundfetchmanager-fetch" id="infopanel-for-term-for-dom-backgroundfetchmanager-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-backgroundfetchmanager-fetch" style="display:none">Info about the 'fetch(id, requests)' external reference.</span><a href="https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch">https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch①">6.2. Credential Leakage</a>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch②">7.1. Website Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-child-src">
-   <a href="https://w3c.github.io/webappsec-csp/#child-src">https://w3c.github.io/webappsec-csp/#child-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-child-src" class="dfn-panel" data-for="term-for-child-src" id="infopanel-for-term-for-child-src" role="menu">
+   <span id="infopaneltitle-for-term-for-child-src" style="display:none">Info about the 'child-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#child-src">https://w3c.github.io/webappsec-csp/#child-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-src">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connect-src">
-   <a href="https://w3c.github.io/webappsec-csp/#connect-src">https://w3c.github.io/webappsec-csp/#connect-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connect-src" class="dfn-panel" data-for="term-for-connect-src" id="infopanel-for-term-for-connect-src" role="menu">
+   <span id="infopaneltitle-for-term-for-connect-src" style="display:none">Info about the 'connect-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#connect-src">https://w3c.github.io/webappsec-csp/#connect-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect-src">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-form-action">
-   <a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-form-action" class="dfn-panel" data-for="term-for-form-action" id="infopanel-for-term-for-form-action" role="menu">
+   <span id="infopaneltitle-for-term-for-form-action" style="display:none">Info about the 'form-action' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-action">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-src">
-   <a href="https://w3c.github.io/webappsec-csp/#object-src">https://w3c.github.io/webappsec-csp/#object-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-src" class="dfn-panel" data-for="term-for-object-src" id="infopanel-for-term-for-object-src" role="menu">
+   <span id="infopaneltitle-for-term-for-object-src" style="display:none">Info about the 'object-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#object-src">https://w3c.github.io/webappsec-csp/#object-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-src">
-   <a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-src" class="dfn-panel" data-for="term-for-script-src" id="infopanel-for-term-for-script-src" role="menu">
+   <span id="infopaneltitle-for-term-for-script-src" style="display:none">Info about the 'script-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-abortsignal①">(2)</a>
     <li><a href="#ref-for-abortsignal②">2.4. The CredentialCreationOptions Dictionary</a> <a href="#ref-for-abortsignal③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-ordinary-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinary-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal method' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinary-object-internal-methods-and-internal-slots">2.2.1. Credential Internal Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-response①">3.1.3. Change Password</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-service-workers-mode">
-   <a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-service-workers-mode" class="dfn-panel" data-for="term-for-request-service-workers-mode" id="infopanel-for-term-for-request-service-workers-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-service-workers-mode">https://fetch.spec.whatwg.org/#request-service-workers-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlformelement">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlformelement" class="dfn-panel" data-for="term-for-htmlformelement" id="infopanel-for-term-for-htmlformelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlformelement" style="display:none">Info about the 'HTMLFormElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlformelement">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-htmlformelement①">3.1.3. Change Password</a>
@@ -3307,32 +3307,32 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">2.3. navigator.credentials</a> <a href="#ref-for-navigator①">(2)</a> <a href="#ref-for-navigator②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">6.4. Origin Confusion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">2.1. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">4.1.1. Identifying Providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete" class="dfn-panel" data-for="term-for-attr-fe-autocomplete" id="infopanel-for-term-for-attr-fe-autocomplete" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete" style="display:none">Info about the 'autocomplete' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete">1. Introduction</a>
     <li><a href="#ref-for-attr-fe-autocomplete①">3.1.2. Post-sign-in Confirmation</a> <a href="#ref-for-attr-fe-autocomplete②">(2)</a> <a href="#ref-for-attr-fe-autocomplete③">(3)</a>
@@ -3341,15 +3341,15 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from an HTMLFormElement </a> <a href="#ref-for-attr-fe-autocomplete⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-autofill-detail-tokens">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-autofill-detail-tokens" class="dfn-panel" data-for="term-for-autofill-detail-tokens" id="infopanel-for-term-for-autofill-detail-tokens" role="menu">
+   <span id="infopaneltitle-for-term-for-autofill-detail-tokens" style="display:none">Info about the 'autofill detail tokens' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-detail-tokens</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-autofill-detail-tokens">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">2.3. navigator.credentials</a>
     <li><a href="#ref-for-current-settings-object①">2.3.1. The CredentialRequestOptions Dictionary</a>
@@ -3359,22 +3359,22 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-current-settings-object⑧">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-current-password">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-current-password" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-current-password" id="infopanel-for-term-for-attr-fe-autocomplete-current-password" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-current-password" style="display:none">Info about the 'current-password' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-current-password</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-current-password">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-attr-fe-autocomplete-current-password①">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-manipulation-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-manipulation-task-source" class="dfn-panel" data-for="term-for-dom-manipulation-task-source" id="infopanel-for-term-for-dom-manipulation-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-manipulation-task-source" style="display:none">Info about the 'dom manipulation task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-manipulation-task-source">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.1. Infrastructure</a>
     <li><a href="#ref-for-environment-settings-object①">2.2.1.1. [[CollectFromCredentialStore]] internal method</a>
@@ -3384,30 +3384,30 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-environment-settings-object⑤">2.5.5. Prevent Silent Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">3.1.1. Password-based Sign-in</a> <a href="#ref-for-the-form-element①">(2)</a>
     <li><a href="#ref-for-the-form-element②">6.2. Credential Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-form-owner">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-form-owner" class="dfn-panel" data-for="term-for-form-owner" id="infopanel-for-term-for-form-owner" role="menu">
+   <span id="infopaneltitle-for-term-for-form-owner" style="display:none">Info about the 'form owner' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-owner</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-owner">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.2.1.4. [[Create]] internal method</a>
     <li><a href="#ref-for-concept-settings-object-global①">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-concept-settings-object-global②">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
     <li><a href="#ref-for-in-parallel①">2.2.1.3. [[Store]] internal method</a>
@@ -3418,37 +3418,37 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-in-parallel⑥">2.5.5. Prevent Silent Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-name">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-name" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-name" id="infopanel-for-term-for-attr-fe-autocomplete-name" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-name" style="display:none">Info about the 'name (for autocomplete)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-name">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-name">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-name" class="dfn-panel" data-for="term-for-attr-fe-name" id="infopanel-for-term-for-attr-fe-name" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-name" style="display:none">Info about the 'name (for input)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-name">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-new-password">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-new-password" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-new-password" id="infopanel-for-term-for-attr-fe-autocomplete-new-password" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-new-password" style="display:none">Info about the 'new-password' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-new-password</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-new-password">3.1.3. Change Password</a>
     <li><a href="#ref-for-attr-fe-autocomplete-new-password①">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-nickname">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-nickname" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-nickname" id="infopanel-for-term-for-attr-fe-autocomplete-nickname" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-nickname" style="display:none">Info about the 'nickname' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-nickname</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-nickname">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2. Core API</a>
     <li><a href="#ref-for-concept-origin①">2.1. Infrastructure</a> <a href="#ref-for-concept-origin②">(2)</a>
@@ -3468,8 +3468,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-concept-origin①②">6.8. Locally Stored Data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.1. Infrastructure</a>
     <li><a href="#ref-for-concept-settings-object-origin①">2.2.1.1. [[CollectFromCredentialStore]] internal method</a>
@@ -3483,27 +3483,27 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-concept-settings-object-origin⑨">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-photo">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-photo" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-photo" id="infopanel-for-term-for-attr-fe-autocomplete-photo" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-photo" style="display:none">Info about the 'photo' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-photo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-photo">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.1. Infrastructure</a>
     <li><a href="#ref-for-same-origin①">3.3.1. 
@@ -3516,8 +3516,8 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[Store]](credential, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2.3. navigator.credentials</a>
     <li><a href="#ref-for-secure-context①">2.5.1. Request a Credential</a>
@@ -3526,34 +3526,34 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-secure-context④">6.3. Insecure Sites</a> <a href="#ref-for-secure-context⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-form-submit">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit">https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-form-submit" class="dfn-panel" data-for="term-for-dom-form-submit" id="infopanel-for-term-for-dom-form-submit" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-form-submit" style="display:none">Info about the 'submit()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit">https://html.spec.whatwg.org/multipage/forms.html#dom-form-submit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-form-submit">3.1.1. Password-based Sign-in</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-category-submit">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">https://html.spec.whatwg.org/multipage/forms.html#category-submit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-category-submit" class="dfn-panel" data-for="term-for-category-submit" id="infopanel-for-term-for-category-submit" role="menu">
+   <span id="infopaneltitle-for-term-for-category-submit" style="display:none">Info about the 'submittable elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#category-submit">https://html.spec.whatwg.org/multipage/forms.html#category-submit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-category-submit">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-category-submit①">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-task" class="dfn-panel" data-for="term-for-concept-task" id="infopanel-for-term-for-concept-task" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-task" style="display:none">Info about the 'task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-task">https://html.spec.whatwg.org/multipage/webappapis.html#concept-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-task">2.2.1.4. [[Create]] internal method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">6.4. Origin Confusion</a> <a href="#ref-for-top-level-browsing-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fe-autocomplete-username">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fe-autocomplete-username" class="dfn-panel" data-for="term-for-attr-fe-autocomplete-username" id="infopanel-for-term-for-attr-fe-autocomplete-username" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fe-autocomplete-username" style="display:none">Info about the 'username' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username">https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete-username</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fe-autocomplete-username">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-attr-fe-autocomplete-username①">3.1.3. Change Password</a>
@@ -3561,36 +3561,36 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-set-append①">2.5.2. Collect Credentials from the credential store</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-list-contain①">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a> <a href="#ref-for-list-contain②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">2.3.1. The CredentialRequestOptions Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-map-exists①">3.3.1. 
@@ -3603,52 +3603,52 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[Create]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-list-size①">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-priori-authenticated-url">
-   <a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-priori-authenticated-url" class="dfn-panel" data-for="term-for-a-priori-authenticated-url" id="infopanel-for-term-for-a-priori-authenticated-url" role="menu">
+   <span id="infopaneltitle-for-term-for-a-priori-authenticated-url" style="display:none">Info about the 'a priori authenticated url' external reference.</span><a href="https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-priori-authenticated-url">2.2.2. CredentialUserData Mixin</a>
     <li><a href="#ref-for-a-priori-authenticated-url①">6.3. Insecure Sites</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://publicsuffix.org/list/#">https://publicsuffix.org/list/#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'registerable domain' external reference.</span><a href="https://publicsuffix.org/list/#">https://publicsuffix.org/list/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.1. Cross-domain credential access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-publickeycredential">
-   <a href="https://w3c.github.io/webauthn/#publickeycredential">https://w3c.github.io/webauthn/#publickeycredential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-publickeycredential" class="dfn-panel" data-for="term-for-publickeycredential" id="infopanel-for-term-for-publickeycredential" role="menu">
+   <span id="infopaneltitle-for-term-for-publickeycredential" style="display:none">Info about the 'PublicKeyCredential' external reference.</span><a href="https://w3c.github.io/webauthn/#publickeycredential">https://w3c.github.io/webauthn/#publickeycredential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-publickeycredential">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-publickeycredential-create-slot">
-   <a href="https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot">https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-publickeycredential-create-slot" class="dfn-panel" data-for="term-for-dom-publickeycredential-create-slot" id="infopanel-for-term-for-dom-publickeycredential-create-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-publickeycredential-create-slot" style="display:none">Info about the '[[Create]](origin, options, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot">https://w3c.github.io/webauthn/#dom-publickeycredential-create-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-create-slot">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-publickeycredential-discoverfromexternalsource-slot">
-   <a href="https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot">https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-publickeycredential-discoverfromexternalsource-slot" class="dfn-panel" data-for="term-for-dom-publickeycredential-discoverfromexternalsource-slot" id="infopanel-for-term-for-dom-publickeycredential-discoverfromexternalsource-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-publickeycredential-discoverfromexternalsource-slot" style="display:none">Info about the '[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot">https://w3c.github.io/webauthn/#dom-publickeycredential-discoverfromexternalsource-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-slot">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-aborterror①">2.4. The CredentialCreationOptions Dictionary</a>
@@ -3656,8 +3656,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-aborterror③">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-idl-DOMException①">2.4. The CredentialCreationOptions Dictionary</a>
@@ -3673,15 +3673,15 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[Store]](credential, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. The Credential Interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">4.1. The FederatedCredential Interface</a> <a href="#ref-for-idl-DOMString③">(2)</a> <a href="#ref-for-idl-DOMString④">(3)</a> <a href="#ref-for-idl-DOMString⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. The Credential Interface</a>
     <li><a href="#ref-for-Exposed①">2.3. navigator.credentials</a>
@@ -3689,8 +3689,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-Exposed③">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
@@ -3702,8 +3702,8 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[Store]](credential, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">2.3. navigator.credentials</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a>
     <li><a href="#ref-for-idl-promise④">2.5.1. Request a Credential</a>
@@ -3712,14 +3712,14 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-idl-promise⑧">2.5.5. Prevent Silent Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.2. The Credential Interface</a>
     <li><a href="#ref-for-SecureContext①">2.2.2. CredentialUserData Mixin</a>
@@ -3728,8 +3728,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-SecureContext⑤">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">2.2.1.4. [[Create]] internal method</a>
@@ -3741,8 +3741,8 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2.2. The Credential Interface</a> <a href="#ref-for-idl-USVString①">(2)</a>
     <li><a href="#ref-for-idl-USVString②">2.2.2. CredentialUserData Mixin</a> <a href="#ref-for-idl-USVString③">(2)</a> <a href="#ref-for-idl-USVString④">(3)</a> <a href="#ref-for-idl-USVString⑤">(4)</a>
@@ -3751,8 +3751,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-idl-USVString①③">4.1. The FederatedCredential Interface</a> <a href="#ref-for-idl-USVString①④">(2)</a> <a href="#ref-for-idl-USVString①⑤">(3)</a> <a href="#ref-for-idl-USVString①⑥">(4)</a> <a href="#ref-for-idl-USVString①⑦">(5)</a> <a href="#ref-for-idl-USVString①⑧">(6)</a> <a href="#ref-for-idl-USVString①⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-a-new-promise①">2.5.3. Store a Credential</a>
@@ -3760,21 +3760,21 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-a-new-promise③">2.5.5. Prevent Silent Access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-a-promise-rejected-with①">2.5.4. Create a Credential</a> <a href="#ref-for-a-promise-rejected-with②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-exception">
-   <a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-exception" class="dfn-panel" data-for="term-for-dfn-exception" id="infopanel-for-term-for-dfn-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-exception" style="display:none">Info about the 'exception' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-exception">https://webidl.spec.whatwg.org/#dfn-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-exception">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-dfn-exception①">2.5.2. Collect Credentials from the credential store</a>
@@ -3794,21 +3794,21 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherit">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherit">https://webidl.spec.whatwg.org/#dfn-inherit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherit" class="dfn-panel" data-for="term-for-dfn-inherit" id="infopanel-for-term-for-dfn-inherit" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherit" style="display:none">Info about the 'inherit' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherit">https://webidl.spec.whatwg.org/#dfn-inherit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherit">2. Core API</a>
     <li><a href="#ref-for-dfn-inherit①">2.2.1. Credential Internal Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-inherited-interfaces">
-   <a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-inherited-interfaces" class="dfn-panel" data-for="term-for-dfn-inherited-interfaces" id="infopanel-for-term-for-dfn-inherited-interfaces" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-inherited-interfaces" style="display:none">Info about the 'inherited interfaces' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-inherited-interfaces">https://webidl.spec.whatwg.org/#dfn-inherited-interfaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-inherited-interfaces">2.3.1. The CredentialRequestOptions Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface-object" class="dfn-panel" data-for="term-for-dfn-interface-object" id="infopanel-for-term-for-dfn-interface-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface-object" style="display:none">Info about the 'interface object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-object">2.2. The Credential Interface</a> <a href="#ref-for-dfn-interface-object①">(2)</a> <a href="#ref-for-dfn-interface-object②">(3)</a> <a href="#ref-for-dfn-interface-object③">(4)</a>
     <li><a href="#ref-for-dfn-interface-object④">2.2.1. Credential Internal Methods</a> <a href="#ref-for-dfn-interface-object⑤">(2)</a>
@@ -3823,63 +3823,63 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dfn-interface-object①⑨">7.2. Extension Points</a> <a href="#ref-for-dfn-interface-object②⓪">(2)</a> <a href="#ref-for-dfn-interface-object②①">(3)</a> <a href="#ref-for-dfn-interface-object②②">(4)</a> <a href="#ref-for-dfn-interface-object②③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface-prototype-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface-prototype-object">https://webidl.spec.whatwg.org/#dfn-interface-prototype-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface-prototype-object" class="dfn-panel" data-for="term-for-dfn-interface-prototype-object" id="infopanel-for-term-for-dfn-interface-prototype-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface-prototype-object" style="display:none">Info about the 'interface prototype object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface-prototype-object">https://webidl.spec.whatwg.org/#dfn-interface-prototype-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-prototype-object">2.2. The Credential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">2.5.1. Request a Credential</a> <a href="#ref-for-reject①">(2)</a>
     <li><a href="#ref-for-reject②">2.5.3. Store a Credential</a>
     <li><a href="#ref-for-reject③">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.1. The FederatedCredential Interface</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.2. The PasswordCredential Interface</a> <a href="#ref-for-dfn-throw①">(2)</a>
     <li><a href="#ref-for-dfn-throw②">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-formdata">
-   <a href="https://xhr.spec.whatwg.org/#interface-formdata">https://xhr.spec.whatwg.org/#interface-formdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-formdata" class="dfn-panel" data-for="term-for-interface-formdata" id="infopanel-for-term-for-interface-formdata" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-formdata" style="display:none">Info about the 'FormData' external reference.</span><a href="https://xhr.spec.whatwg.org/#interface-formdata">https://xhr.spec.whatwg.org/#interface-formdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-formdata">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
     <li><a href="#ref-for-interface-formdata①">7.1. Website Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequest" class="dfn-panel" data-for="term-for-xmlhttprequest" id="infopanel-for-term-for-xmlhttprequest" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">1. Introduction</a>
     <li><a href="#ref-for-xmlhttprequest①">1.1. Use Cases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-formdata-get">
-   <a href="https://xhr.spec.whatwg.org/#dom-formdata-get">https://xhr.spec.whatwg.org/#dom-formdata-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-formdata-get" class="dfn-panel" data-for="term-for-dom-formdata-get" id="infopanel-for-term-for-dom-formdata-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-formdata-get" style="display:none">Info about the 'get(name)' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-formdata-get">https://xhr.spec.whatwg.org/#dom-formdata-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-get">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a> <a href="#ref-for-dom-formdata-get①">(2)</a> <a href="#ref-for-dom-formdata-get②">(3)</a> <a href="#ref-for-dom-formdata-get③">(4)</a> <a href="#ref-for-dom-formdata-get④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-formdata-has">
-   <a href="https://xhr.spec.whatwg.org/#dom-formdata-has">https://xhr.spec.whatwg.org/#dom-formdata-has</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-formdata-has" class="dfn-panel" data-for="term-for-dom-formdata-has" id="infopanel-for-term-for-dom-formdata-has" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-formdata-has" style="display:none">Info about the 'has(name)' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-formdata-has">https://xhr.spec.whatwg.org/#dom-formdata-has</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-has">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
@@ -4175,8 +4175,8 @@ partial dictionary CredentialCreationOptions {
    <div class="issue"> Describe encoding restrictions of submitting credentials by <code class="idl"><a data-link-type="idl" href="https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch">fetch()</a></code> with
   a <code class="idl"><a data-link-type="idl" href="https://xhr.spec.whatwg.org/#interface-formdata">FormData</a></code> body. <a class="issue-return" href="#issue-19b3ffaf" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="concept-credential">
-   <b><a href="#concept-credential">#concept-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-credential" class="dfn-panel" data-for="concept-credential" id="infopanel-for-concept-credential" role="dialog">
+   <span id="infopaneltitle-for-concept-credential" style="display:none">Info about the 'credential' definition.</span><b><a href="#concept-credential">#concept-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-credential">1. Introduction</a> <a href="#ref-for-concept-credential①">(2)</a>
     <li><a href="#ref-for-concept-credential②">2. Core API</a> <a href="#ref-for-concept-credential③">(2)</a> <a href="#ref-for-concept-credential④">(3)</a> <a href="#ref-for-concept-credential⑤">(4)</a>
@@ -4188,8 +4188,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-concept-credential①⑦">7.2. Extension Points</a> <a href="#ref-for-concept-credential①⑧">(2)</a> <a href="#ref-for-concept-credential①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-effective">
-   <b><a href="#credential-effective">#credential-effective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-effective" class="dfn-panel" data-for="credential-effective" id="infopanel-for-credential-effective" role="dialog">
+   <span id="infopaneltitle-for-credential-effective" style="display:none">Info about the 'effective' definition.</span><b><a href="#credential-effective">#credential-effective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-effective">2.1. Infrastructure</a>
     <li><a href="#ref-for-credential-effective①">2.2. The Credential Interface</a>
@@ -4197,15 +4197,16 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-credential-effective③">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-source">
-   <b><a href="#credential-source">#credential-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-source" class="dfn-panel" data-for="credential-source" id="infopanel-for-credential-source" role="dialog">
+   <span id="infopaneltitle-for-credential-source" style="display:none">Info about the 'credential source' definition.</span><b><a href="#credential-source">#credential-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-source">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
     <li><a href="#ref-for-credential-source①">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-credential-store">
-   <b><a href="#concept-credential-store">#concept-credential-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-credential-store" class="dfn-panel" data-for="concept-credential-store" id="infopanel-for-concept-credential-store" role="dialog">
+   <span id="infopaneltitle-for-concept-credential-store" style="display:none">Info about the 'credential
+  store' definition.</span><b><a href="#concept-credential-store">#concept-credential-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-credential-store">2.1. Infrastructure</a> <a href="#ref-for-concept-credential-store①">(2)</a> <a href="#ref-for-concept-credential-store②">(3)</a> <a href="#ref-for-concept-credential-store③">(4)</a>
     <li><a href="#ref-for-concept-credential-store④">2.2. The Credential Interface</a> <a href="#ref-for-concept-credential-store⑤">(2)</a>
@@ -4229,8 +4230,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-concept-credential-store②⑧">7.2. Extension Points</a> <a href="#ref-for-concept-credential-store②⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-credential-store-retrieve-a-list-of-credentials">
-   <b><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">#abstract-opdef-credential-store-retrieve-a-list-of-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials" class="dfn-panel" data-for="abstract-opdef-credential-store-retrieve-a-list-of-credentials" id="infopanel-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials" style="display:none">Info about the 'Retrieve a list of credentials' definition.</span><b><a href="#abstract-opdef-credential-store-retrieve-a-list-of-credentials">#abstract-opdef-credential-store-retrieve-a-list-of-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-credential-store-retrieve-a-list-of-credentials">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
@@ -4238,8 +4239,8 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-prevent-silent-access-flag">
-   <b><a href="#origin-prevent-silent-access-flag">#origin-prevent-silent-access-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-prevent-silent-access-flag" class="dfn-panel" data-for="origin-prevent-silent-access-flag" id="infopanel-for-origin-prevent-silent-access-flag" role="dialog">
+   <span id="infopaneltitle-for-origin-prevent-silent-access-flag" style="display:none">Info about the 'prevent silent access flag' definition.</span><b><a href="#origin-prevent-silent-access-flag">#origin-prevent-silent-access-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-prevent-silent-access-flag">2.3. navigator.credentials</a>
     <li><a href="#ref-for-origin-prevent-silent-access-flag①">2.3.2. Mediation Requirements</a> <a href="#ref-for-origin-prevent-silent-access-flag②">(2)</a>
@@ -4248,15 +4249,16 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-origin-prevent-silent-access-flag⑧">6.6. Signing-Out</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin-requires-user-mediation">
-   <b><a href="#origin-requires-user-mediation">#origin-requires-user-mediation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin-requires-user-mediation" class="dfn-panel" data-for="origin-requires-user-mediation" id="infopanel-for-origin-requires-user-mediation" role="dialog">
+   <span id="infopaneltitle-for-origin-requires-user-mediation" style="display:none">Info about the 'requires user mediation' definition.</span><b><a href="#origin-requires-user-mediation">#origin-requires-user-mediation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-requires-user-mediation">2.3.2. Mediation Requirements</a>
     <li><a href="#ref-for-origin-requires-user-mediation①">2.5.1. Request a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-origin-with-its-ancestors">
-   <b><a href="#same-origin-with-its-ancestors">#same-origin-with-its-ancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-origin-with-its-ancestors" class="dfn-panel" data-for="same-origin-with-its-ancestors" id="infopanel-for-same-origin-with-its-ancestors" role="dialog">
+   <span id="infopaneltitle-for-same-origin-with-its-ancestors" style="display:none">Info about the 'same-origin with its
+  ancestors' definition.</span><b><a href="#same-origin-with-its-ancestors">#same-origin-with-its-ancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-with-its-ancestors">2.2.1.1. [[CollectFromCredentialStore]] internal method</a>
     <li><a href="#ref-for-same-origin-with-its-ancestors①">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
@@ -4281,8 +4283,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-same-origin-with-its-ancestors①④">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential">
-   <b><a href="#credential">#credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential" class="dfn-panel" data-for="credential" id="infopanel-for-credential" role="dialog">
+   <span id="infopaneltitle-for-credential" style="display:none">Info about the 'Credential' definition.</span><b><a href="#credential">#credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential">2. Core API</a> <a href="#ref-for-credential①">(2)</a>
     <li><a href="#ref-for-credential②">2.2. The Credential Interface</a> <a href="#ref-for-credential③">(2)</a> <a href="#ref-for-credential④">(3)</a> <a href="#ref-for-credential⑤">(4)</a> <a href="#ref-for-credential⑥">(5)</a>
@@ -4312,8 +4314,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-credential⑥①">7.2. Extension Points</a> <a href="#ref-for-credential⑥②">(2)</a> <a href="#ref-for-credential⑥③">(3)</a> <a href="#ref-for-credential⑥④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-id">
-   <b><a href="#dom-credential-id">#dom-credential-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-id" class="dfn-panel" data-for="dom-credential-id" id="infopanel-for-dom-credential-id" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-credential-id">#dom-credential-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-id">2.2. The Credential Interface</a>
     <li><a href="#ref-for-dom-credential-id①">3.3.3. 
@@ -4326,15 +4328,15 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-type">
-   <b><a href="#dom-credential-type">#dom-credential-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-type" class="dfn-panel" data-for="dom-credential-type" id="infopanel-for-dom-credential-type" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-credential-type">#dom-credential-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type">2.2. The Credential Interface</a>
     <li><a href="#ref-for-dom-credential-type①">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credential-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-type-slot">
-   <b><a href="#dom-credential-type-slot">#dom-credential-type-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-type-slot" class="dfn-panel" data-for="dom-credential-type-slot" id="infopanel-for-dom-credential-type-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-type-slot" style="display:none">Info about the '[[type]]' definition.</span><b><a href="#dom-credential-type-slot">#dom-credential-type-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type-slot">2.2. The Credential Interface</a> <a href="#ref-for-dom-credential-type-slot①">(2)</a>
     <li><a href="#ref-for-dom-credential-type-slot②">2.3.1. The CredentialRequestOptions Dictionary</a>
@@ -4343,15 +4345,15 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-type-slot⑤">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-credential-type">
-   <b><a href="#credential-credential-type">#credential-credential-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-credential-type" class="dfn-panel" data-for="credential-credential-type" id="infopanel-for-credential-credential-type" role="dialog">
+   <span id="infopaneltitle-for-credential-credential-type" style="display:none">Info about the 'credential type' definition.</span><b><a href="#credential-credential-type">#credential-credential-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-credential-type">2.2. The Credential Interface</a>
     <li><a href="#ref-for-credential-credential-type①">2.2.1.4. [[Create]] internal method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-discovery-slot">
-   <b><a href="#dom-credential-discovery-slot">#dom-credential-discovery-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-discovery-slot" class="dfn-panel" data-for="dom-credential-discovery-slot" id="infopanel-for-dom-credential-discovery-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-discovery-slot" style="display:none">Info about the '[[discovery]]' definition.</span><b><a href="#dom-credential-discovery-slot">#dom-credential-discovery-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-discovery-slot">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credential-discovery-slot①">3.2. The PasswordCredential Interface</a>
@@ -4359,8 +4361,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-discovery-slot③">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-discovery-credential-store">
-   <b><a href="#dom-credential-discovery-credential-store">#dom-credential-discovery-credential-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-discovery-credential-store" class="dfn-panel" data-for="dom-credential-discovery-credential-store" id="infopanel-for-dom-credential-discovery-credential-store" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-discovery-credential-store" style="display:none">Info about the 'credential store' definition.</span><b><a href="#dom-credential-discovery-credential-store">#dom-credential-discovery-credential-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-discovery-credential-store">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credential-discovery-credential-store①">3.2. The PasswordCredential Interface</a>
@@ -4368,15 +4370,15 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-discovery-credential-store③">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-origin-bound">
-   <b><a href="#credential-origin-bound">#credential-origin-bound</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-origin-bound" class="dfn-panel" data-for="credential-origin-bound" id="infopanel-for-credential-origin-bound" role="dialog">
+   <span id="infopaneltitle-for-credential-origin-bound" style="display:none">Info about the 'origin bound' definition.</span><b><a href="#credential-origin-bound">#credential-origin-bound</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-origin-bound">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-credential-origin-bound①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-origin-slot">
-   <b><a href="#dom-credential-origin-slot">#dom-credential-origin-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-origin-slot" class="dfn-panel" data-for="dom-credential-origin-slot" id="infopanel-for-dom-credential-origin-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-origin-slot" style="display:none">Info about the '[[origin]]' definition.</span><b><a href="#dom-credential-origin-slot">#dom-credential-origin-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-origin-slot">3.3.1. 
     PasswordCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
@@ -4393,8 +4395,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-origin-slot①②">6.1. Cross-domain credential access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-collectfromcredentialstore-slot">
-   <b><a href="#dom-credential-collectfromcredentialstore-slot">#dom-credential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-collectfromcredentialstore-slot" class="dfn-panel" data-for="dom-credential-collectfromcredentialstore-slot" id="infopanel-for-dom-credential-collectfromcredentialstore-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-collectfromcredentialstore-slot" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-credential-collectfromcredentialstore-slot">#dom-credential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot">2.2.1.1. [[CollectFromCredentialStore]] internal method</a>
     <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot①">2.5.2. Collect Credentials from the credential store</a>
@@ -4402,8 +4404,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-collectfromcredentialstore-slot③">7.2. Extension Points</a> <a href="#ref-for-dom-credential-collectfromcredentialstore-slot④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-discoverfromexternalsource-slot">
-   <b><a href="#dom-credential-discoverfromexternalsource-slot">#dom-credential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-discoverfromexternalsource-slot" class="dfn-panel" data-for="dom-credential-discoverfromexternalsource-slot" id="infopanel-for-dom-credential-discoverfromexternalsource-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-discoverfromexternalsource-slot" style="display:none">Info about the '[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-credential-discoverfromexternalsource-slot">#dom-credential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot①">2.5.1. Request a Credential</a>
@@ -4413,8 +4415,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑤">7.2. Extension Points</a> <a href="#ref-for-dom-credential-discoverfromexternalsource-slot⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-store-slot">
-   <b><a href="#dom-credential-store-slot">#dom-credential-store-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-store-slot" class="dfn-panel" data-for="dom-credential-store-slot" id="infopanel-for-dom-credential-store-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-store-slot" style="display:none">Info about the '[[Store]](credential, sameOriginWithAncestors)' definition.</span><b><a href="#dom-credential-store-slot">#dom-credential-store-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-store-slot">2.2.1.3. [[Store]] internal method</a>
     <li><a href="#ref-for-dom-credential-store-slot①">2.5.3. Store a Credential</a>
@@ -4422,8 +4424,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-store-slot③">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-create-slot">
-   <b><a href="#dom-credential-create-slot">#dom-credential-create-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-create-slot" class="dfn-panel" data-for="dom-credential-create-slot" id="infopanel-for-dom-credential-create-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-create-slot" style="display:none">Info about the '[[Create]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-credential-create-slot">#dom-credential-create-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-create-slot">2.2.1.4. [[Create]] internal method</a>
     <li><a href="#ref-for-dom-credential-create-slot①">2.5.4. Create a Credential</a>
@@ -4431,15 +4433,15 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credential-create-slot③">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialuserdata">
-   <b><a href="#credentialuserdata">#credentialuserdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialuserdata" class="dfn-panel" data-for="credentialuserdata" id="infopanel-for-credentialuserdata" role="dialog">
+   <span id="infopaneltitle-for-credentialuserdata" style="display:none">Info about the 'CredentialUserData' definition.</span><b><a href="#credentialuserdata">#credentialuserdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialuserdata">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-credentialuserdata①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialuserdata-name">
-   <b><a href="#dom-credentialuserdata-name">#dom-credentialuserdata-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialuserdata-name" class="dfn-panel" data-for="dom-credentialuserdata-name" id="infopanel-for-dom-credentialuserdata-name" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialuserdata-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-credentialuserdata-name">#dom-credentialuserdata-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialuserdata-name">2.2.2. CredentialUserData Mixin</a>
     <li><a href="#ref-for-dom-credentialuserdata-name①">3.3.3. 
@@ -4454,8 +4456,8 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-name①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialuserdata-iconurl">
-   <b><a href="#dom-credentialuserdata-iconurl">#dom-credentialuserdata-iconurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialuserdata-iconurl" class="dfn-panel" data-for="dom-credentialuserdata-iconurl" id="infopanel-for-dom-credentialuserdata-iconurl" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialuserdata-iconurl" style="display:none">Info about the 'iconURL' definition.</span><b><a href="#dom-credentialuserdata-iconurl">#dom-credentialuserdata-iconurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialuserdata-iconurl">2.2.2. CredentialUserData Mixin</a>
     <li><a href="#ref-for-dom-credentialuserdata-iconurl①">3.3.3. 
@@ -4470,16 +4472,16 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialuserdata-iconurl①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigator-credentials">
-   <b><a href="#dom-navigator-credentials">#dom-navigator-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigator-credentials" class="dfn-panel" data-for="dom-navigator-credentials" id="infopanel-for-dom-navigator-credentials" role="dialog">
+   <span id="infopaneltitle-for-dom-navigator-credentials" style="display:none">Info about the 'credentials' definition.</span><b><a href="#dom-navigator-credentials">#dom-navigator-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-credentials">2.3. navigator.credentials</a> <a href="#ref-for-dom-navigator-credentials①">(2)</a>
     <li><a href="#ref-for-dom-navigator-credentials②">2.3.2.1. Examples</a> <a href="#ref-for-dom-navigator-credentials③">(2)</a> <a href="#ref-for-dom-navigator-credentials④">(3)</a> <a href="#ref-for-dom-navigator-credentials⑤">(4)</a>
     <li><a href="#ref-for-dom-navigator-credentials⑥">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-navigator-credentials⑦">(2)</a> <a href="#ref-for-dom-navigator-credentials⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialscontainer">
-   <b><a href="#credentialscontainer">#credentialscontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialscontainer" class="dfn-panel" data-for="credentialscontainer" id="infopanel-for-credentialscontainer" role="dialog">
+   <span id="infopaneltitle-for-credentialscontainer" style="display:none">Info about the 'CredentialsContainer' definition.</span><b><a href="#credentialscontainer">#credentialscontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialscontainer">2. Core API</a>
     <li><a href="#ref-for-credentialscontainer①">2.3. navigator.credentials</a> <a href="#ref-for-credentialscontainer②">(2)</a> <a href="#ref-for-credentialscontainer③">(3)</a> <a href="#ref-for-credentialscontainer④">(4)</a>
@@ -4487,15 +4489,15 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-credentialscontainer⑥">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-credentialdata">
-   <b><a href="#dictdef-credentialdata">#dictdef-credentialdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-credentialdata" class="dfn-panel" data-for="dictdef-credentialdata" id="infopanel-for-dictdef-credentialdata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-credentialdata" style="display:none">Info about the 'CredentialData' definition.</span><b><a href="#dictdef-credentialdata">#dictdef-credentialdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialdata">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-dictdef-credentialdata①">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialdata-id">
-   <b><a href="#dom-credentialdata-id">#dom-credentialdata-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialdata-id" class="dfn-panel" data-for="dom-credentialdata-id" id="infopanel-for-dom-credentialdata-id" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialdata-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-credentialdata-id">#dom-credentialdata-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialdata-id">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
@@ -4505,8 +4507,8 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-credentialdata-id④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-get">
-   <b><a href="#dom-credentialscontainer-get">#dom-credentialscontainer-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-get" class="dfn-panel" data-for="dom-credentialscontainer-get" id="infopanel-for-dom-credentialscontainer-get" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-get" style="display:none">Info about the 'get(options)' definition.</span><b><a href="#dom-credentialscontainer-get">#dom-credentialscontainer-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-get">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get①">(2)</a> <a href="#ref-for-dom-credentialscontainer-get②">(3)</a>
     <li><a href="#ref-for-dom-credentialscontainer-get③">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-get④">(2)</a> <a href="#ref-for-dom-credentialscontainer-get⑤">(3)</a>
@@ -4522,14 +4524,14 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialscontainer-get②⑥">7.3. Browser Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-get-options-options">
-   <b><a href="#dom-credentialscontainer-get-options-options">#dom-credentialscontainer-get-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-get-options-options" class="dfn-panel" data-for="dom-credentialscontainer-get-options-options" id="infopanel-for-dom-credentialscontainer-get-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-get-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-credentialscontainer-get-options-options">#dom-credentialscontainer-get-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-get-options-options">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-get-options-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-store">
-   <b><a href="#dom-credentialscontainer-store">#dom-credentialscontainer-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-store" class="dfn-panel" data-for="dom-credentialscontainer-store" id="infopanel-for-dom-credentialscontainer-store" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-store" style="display:none">Info about the 'store(credential)' definition.</span><b><a href="#dom-credentialscontainer-store">#dom-credentialscontainer-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-store">2. Core API</a>
     <li><a href="#ref-for-dom-credentialscontainer-store①">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store②">(2)</a> <a href="#ref-for-dom-credentialscontainer-store③">(3)</a>
@@ -4540,14 +4542,14 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialscontainer-store①③">7.3. Browser Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-store-credential-credential">
-   <b><a href="#dom-credentialscontainer-store-credential-credential">#dom-credentialscontainer-store-credential-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-store-credential-credential" class="dfn-panel" data-for="dom-credentialscontainer-store-credential-credential" id="infopanel-for-dom-credentialscontainer-store-credential-credential" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-store-credential-credential" style="display:none">Info about the 'credential' definition.</span><b><a href="#dom-credentialscontainer-store-credential-credential">#dom-credentialscontainer-store-credential-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-store-credential-credential">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-store-credential-credential①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-create">
-   <b><a href="#dom-credentialscontainer-create">#dom-credentialscontainer-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-create" class="dfn-panel" data-for="dom-credentialscontainer-create" id="infopanel-for-dom-credentialscontainer-create" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-create" style="display:none">Info about the 'create(options)' definition.</span><b><a href="#dom-credentialscontainer-create">#dom-credentialscontainer-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-create">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create①">(2)</a> <a href="#ref-for-dom-credentialscontainer-create②">(3)</a>
     <li><a href="#ref-for-dom-credentialscontainer-create③">2.4. The CredentialCreationOptions Dictionary</a> <a href="#ref-for-dom-credentialscontainer-create④">(2)</a>
@@ -4556,22 +4558,22 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialscontainer-create⑦">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-create-options-options">
-   <b><a href="#dom-credentialscontainer-create-options-options">#dom-credentialscontainer-create-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-create-options-options" class="dfn-panel" data-for="dom-credentialscontainer-create-options-options" id="infopanel-for-dom-credentialscontainer-create-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-create-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-credentialscontainer-create-options-options">#dom-credentialscontainer-create-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-create-options-options">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-create-options-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialscontainer-preventsilentaccess">
-   <b><a href="#dom-credentialscontainer-preventsilentaccess">#dom-credentialscontainer-preventsilentaccess</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialscontainer-preventsilentaccess" class="dfn-panel" data-for="dom-credentialscontainer-preventsilentaccess" id="infopanel-for-dom-credentialscontainer-preventsilentaccess" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialscontainer-preventsilentaccess" style="display:none">Info about the 'preventSilentAccess()' definition.</span><b><a href="#dom-credentialscontainer-preventsilentaccess">#dom-credentialscontainer-preventsilentaccess</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess">2.3. navigator.credentials</a> <a href="#ref-for-dom-credentialscontainer-preventsilentaccess①">(2)</a>
     <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess②">2.3.2. Mediation Requirements</a>
     <li><a href="#ref-for-dom-credentialscontainer-preventsilentaccess③">6.6. Signing-Out</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-credentialrequestoptions">
-   <b><a href="#dictdef-credentialrequestoptions">#dictdef-credentialrequestoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-credentialrequestoptions" class="dfn-panel" data-for="dictdef-credentialrequestoptions" id="infopanel-for-dictdef-credentialrequestoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-credentialrequestoptions" style="display:none">Info about the 'CredentialRequestOptions' definition.</span><b><a href="#dictdef-credentialrequestoptions">#dictdef-credentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialrequestoptions">2.2.1.1. [[CollectFromCredentialStore]] internal method</a>
     <li><a href="#ref-for-dictdef-credentialrequestoptions①">2.2.1.2. [[DiscoverFromExternalSource]] internal method</a>
@@ -4591,8 +4593,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dictdef-credentialrequestoptions①⑦">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-mediation">
-   <b><a href="#dom-credentialrequestoptions-mediation">#dom-credentialrequestoptions-mediation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-mediation" class="dfn-panel" data-for="dom-credentialrequestoptions-mediation" id="infopanel-for-dom-credentialrequestoptions-mediation" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-mediation" style="display:none">Info about the 'mediation' definition.</span><b><a href="#dom-credentialrequestoptions-mediation">#dom-credentialrequestoptions-mediation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-mediation">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation②">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation③">(4)</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-mediation④">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑤">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑥">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑦">(4)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑧">(5)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation⑨">(6)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①⓪">(7)</a> <a href="#ref-for-dom-credentialrequestoptions-mediation①①">(8)</a>
@@ -4600,15 +4602,15 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialrequestoptions-mediation①④">7.1. Website Authors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-signal">
-   <b><a href="#dom-credentialrequestoptions-signal">#dom-credentialrequestoptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-signal" class="dfn-panel" data-for="dom-credentialrequestoptions-signal" id="infopanel-for-dom-credentialrequestoptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-credentialrequestoptions-signal">#dom-credentialrequestoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-signal">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-signal①">2.5.1. Request a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialrequestoptions-relevant-credential-interface-objects">
-   <b><a href="#credentialrequestoptions-relevant-credential-interface-objects">#credentialrequestoptions-relevant-credential-interface-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialrequestoptions-relevant-credential-interface-objects" class="dfn-panel" data-for="credentialrequestoptions-relevant-credential-interface-objects" id="infopanel-for-credentialrequestoptions-relevant-credential-interface-objects" role="dialog">
+   <span id="infopaneltitle-for-credentialrequestoptions-relevant-credential-interface-objects" style="display:none">Info about the 'relevant credential interface objects' definition.</span><b><a href="#credentialrequestoptions-relevant-credential-interface-objects">#credentialrequestoptions-relevant-credential-interface-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects①">2.5.2. Collect Credentials from the credential store</a>
@@ -4616,23 +4618,23 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects③">5.3. Credential Selection</a> <a href="#ref-for-credentialrequestoptions-relevant-credential-interface-objects④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialrequestoptions-matchable-a-priori">
-   <b><a href="#credentialrequestoptions-matchable-a-priori">#credentialrequestoptions-matchable-a-priori</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialrequestoptions-matchable-a-priori" class="dfn-panel" data-for="credentialrequestoptions-matchable-a-priori" id="infopanel-for-credentialrequestoptions-matchable-a-priori" role="dialog">
+   <span id="infopaneltitle-for-credentialrequestoptions-matchable-a-priori" style="display:none">Info about the 'matchable a priori' definition.</span><b><a href="#credentialrequestoptions-matchable-a-priori">#credentialrequestoptions-matchable-a-priori</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori①">2.5.1. Request a Credential</a>
     <li><a href="#ref-for-credentialrequestoptions-matchable-a-priori②">5.3. Credential Selection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-credentialmediationrequirement">
-   <b><a href="#enumdef-credentialmediationrequirement">#enumdef-credentialmediationrequirement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-credentialmediationrequirement" class="dfn-panel" data-for="enumdef-credentialmediationrequirement" id="infopanel-for-enumdef-credentialmediationrequirement" role="dialog">
+   <span id="infopaneltitle-for-enumdef-credentialmediationrequirement" style="display:none">Info about the 'CredentialMediationRequirement' definition.</span><b><a href="#enumdef-credentialmediationrequirement">#enumdef-credentialmediationrequirement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-credentialmediationrequirement">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-enumdef-credentialmediationrequirement①">(2)</a> <a href="#ref-for-enumdef-credentialmediationrequirement②">(3)</a>
     <li><a href="#ref-for-enumdef-credentialmediationrequirement③">2.3.2. Mediation Requirements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-silent">
-   <b><a href="#dom-credentialmediationrequirement-silent">#dom-credentialmediationrequirement-silent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialmediationrequirement-silent" class="dfn-panel" data-for="dom-credentialmediationrequirement-silent" id="infopanel-for-dom-credentialmediationrequirement-silent" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialmediationrequirement-silent" style="display:none">Info about the 'silent' definition.</span><b><a href="#dom-credentialmediationrequirement-silent">#dom-credentialmediationrequirement-silent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialmediationrequirement-silent">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credentialmediationrequirement-silent①">2.3.2. Mediation Requirements</a>
@@ -4640,24 +4642,24 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dom-credentialmediationrequirement-silent④">2.5.1. Request a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-optional">
-   <b><a href="#dom-credentialmediationrequirement-optional">#dom-credentialmediationrequirement-optional</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialmediationrequirement-optional" class="dfn-panel" data-for="dom-credentialmediationrequirement-optional" id="infopanel-for-dom-credentialmediationrequirement-optional" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialmediationrequirement-optional" style="display:none">Info about the 'optional' definition.</span><b><a href="#dom-credentialmediationrequirement-optional">#dom-credentialmediationrequirement-optional</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialmediationrequirement-optional">2.3.1. The CredentialRequestOptions Dictionary</a>
     <li><a href="#ref-for-dom-credentialmediationrequirement-optional①">2.3.2. Mediation Requirements</a>
     <li><a href="#ref-for-dom-credentialmediationrequirement-optional②">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-optional③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialmediationrequirement-required">
-   <b><a href="#dom-credentialmediationrequirement-required">#dom-credentialmediationrequirement-required</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialmediationrequirement-required" class="dfn-panel" data-for="dom-credentialmediationrequirement-required" id="infopanel-for-dom-credentialmediationrequirement-required" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialmediationrequirement-required" style="display:none">Info about the 'required' definition.</span><b><a href="#dom-credentialmediationrequirement-required">#dom-credentialmediationrequirement-required</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialmediationrequirement-required">2.3.2. Mediation Requirements</a>
     <li><a href="#ref-for-dom-credentialmediationrequirement-required①">2.3.2.1. Examples</a> <a href="#ref-for-dom-credentialmediationrequirement-required②">(2)</a> <a href="#ref-for-dom-credentialmediationrequirement-required③">(3)</a> <a href="#ref-for-dom-credentialmediationrequirement-required④">(4)</a>
     <li><a href="#ref-for-dom-credentialmediationrequirement-required⑤">2.5.1. Request a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-credentialcreationoptions">
-   <b><a href="#dictdef-credentialcreationoptions">#dictdef-credentialcreationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-credentialcreationoptions" class="dfn-panel" data-for="dictdef-credentialcreationoptions" id="infopanel-for-dictdef-credentialcreationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-credentialcreationoptions" style="display:none">Info about the 'CredentialCreationOptions' definition.</span><b><a href="#dictdef-credentialcreationoptions">#dictdef-credentialcreationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialcreationoptions">2.2.1.4. [[Create]] internal method</a>
     <li><a href="#ref-for-dictdef-credentialcreationoptions①">2.3. navigator.credentials</a> <a href="#ref-for-dictdef-credentialcreationoptions②">(2)</a>
@@ -4672,45 +4674,45 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-dictdef-credentialcreationoptions①①">7.2. Extension Points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialcreationoptions-signal">
-   <b><a href="#dom-credentialcreationoptions-signal">#dom-credentialcreationoptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialcreationoptions-signal" class="dfn-panel" data-for="dom-credentialcreationoptions-signal" id="infopanel-for-dom-credentialcreationoptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialcreationoptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-credentialcreationoptions-signal">#dom-credentialcreationoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-signal">2.4. The CredentialCreationOptions Dictionary</a>
     <li><a href="#ref-for-dom-credentialcreationoptions-signal①">2.5.4. Create a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-request-a-credential">
-   <b><a href="#abstract-opdef-request-a-credential">#abstract-opdef-request-a-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-request-a-credential" class="dfn-panel" data-for="abstract-opdef-request-a-credential" id="infopanel-for-abstract-opdef-request-a-credential" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-request-a-credential" style="display:none">Info about the 'Request a Credential' definition.</span><b><a href="#abstract-opdef-request-a-credential">#abstract-opdef-request-a-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-request-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-collect-credentials-from-the-credential-store">
-   <b><a href="#abstract-opdef-collect-credentials-from-the-credential-store">#abstract-opdef-collect-credentials-from-the-credential-store</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-collect-credentials-from-the-credential-store" class="dfn-panel" data-for="abstract-opdef-collect-credentials-from-the-credential-store" id="infopanel-for-abstract-opdef-collect-credentials-from-the-credential-store" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-collect-credentials-from-the-credential-store" style="display:none">Info about the 'collect Credentials from the credential store' definition.</span><b><a href="#abstract-opdef-collect-credentials-from-the-credential-store">#abstract-opdef-collect-credentials-from-the-credential-store</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-collect-credentials-from-the-credential-store">2.5.1. Request a Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-store-a-credential">
-   <b><a href="#abstract-opdef-store-a-credential">#abstract-opdef-store-a-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-store-a-credential" class="dfn-panel" data-for="abstract-opdef-store-a-credential" id="infopanel-for-abstract-opdef-store-a-credential" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-store-a-credential" style="display:none">Info about the 'Store a Credential' definition.</span><b><a href="#abstract-opdef-store-a-credential">#abstract-opdef-store-a-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-store-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-credential">
-   <b><a href="#abstract-opdef-create-a-credential">#abstract-opdef-create-a-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-credential" class="dfn-panel" data-for="abstract-opdef-create-a-credential" id="infopanel-for-abstract-opdef-create-a-credential" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-credential" style="display:none">Info about the 'Create a Credential' definition.</span><b><a href="#abstract-opdef-create-a-credential">#abstract-opdef-create-a-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-credential">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-prevent-silent-access">
-   <b><a href="#abstract-opdef-prevent-silent-access">#abstract-opdef-prevent-silent-access</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-prevent-silent-access" class="dfn-panel" data-for="abstract-opdef-prevent-silent-access" id="infopanel-for-abstract-opdef-prevent-silent-access" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-prevent-silent-access" style="display:none">Info about the 'Prevent Silent Access' definition.</span><b><a href="#abstract-opdef-prevent-silent-access">#abstract-opdef-prevent-silent-access</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-prevent-silent-access">2.3. navigator.credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="passwordcredential">
-   <b><a href="#passwordcredential">#passwordcredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-passwordcredential" class="dfn-panel" data-for="passwordcredential" id="infopanel-for-passwordcredential" role="dialog">
+   <span id="infopaneltitle-for-passwordcredential" style="display:none">Info about the 'PasswordCredential' definition.</span><b><a href="#passwordcredential">#passwordcredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-passwordcredential">2. Core API</a>
     <li><a href="#ref-for-passwordcredential①">3. Password Credentials</a>
@@ -4732,8 +4734,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-passwordcredential②①">6.4. Origin Confusion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-password">
-   <b><a href="#dom-credentialrequestoptions-password">#dom-credentialrequestoptions-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-password" class="dfn-panel" data-for="dom-credentialrequestoptions-password" id="infopanel-for-dom-credentialrequestoptions-password" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-credentialrequestoptions-password">#dom-credentialrequestoptions-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-password">3.1.1. Password-based Sign-in</a> <a href="#ref-for-dom-credentialrequestoptions-password①">(2)</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-password②">3.3.1. 
@@ -4742,8 +4744,8 @@ partial dictionary CredentialCreationOptions {
     CredentialRequestOptions Matching for PasswordCredential </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-password">
-   <b><a href="#dom-passwordcredential-password">#dom-passwordcredential-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-password" class="dfn-panel" data-for="dom-passwordcredential-password" id="infopanel-for-dom-passwordcredential-password" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-passwordcredential-password">#dom-passwordcredential-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-password">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-dom-passwordcredential-password①">3.3.3. 
@@ -4752,28 +4754,28 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credential-type-password">
-   <b><a href="#dom-credential-type-password">#dom-credential-type-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credential-type-password" class="dfn-panel" data-for="dom-credential-type-password" id="infopanel-for-dom-credential-type-password" role="dialog">
+   <span id="infopaneltitle-for-dom-credential-type-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-credential-type-password">#dom-credential-type-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type-password">3.1.1. Password-based Sign-in</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-passwordcredential">
-   <b><a href="#dom-passwordcredential-passwordcredential">#dom-passwordcredential-passwordcredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-passwordcredential" class="dfn-panel" data-for="dom-passwordcredential-passwordcredential" id="infopanel-for-dom-passwordcredential-passwordcredential" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-passwordcredential" style="display:none">Info about the 'PasswordCredential(form)' definition.</span><b><a href="#dom-passwordcredential-passwordcredential">#dom-passwordcredential-passwordcredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-passwordcredential">3.1.2. Post-sign-in Confirmation</a>
     <li><a href="#ref-for-dom-passwordcredential-passwordcredential①">3.1.3. Change Password</a>
     <li><a href="#ref-for-dom-passwordcredential-passwordcredential②">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-passwordcredential-data">
-   <b><a href="#dom-passwordcredential-passwordcredential-data">#dom-passwordcredential-passwordcredential-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-passwordcredential-data" class="dfn-panel" data-for="dom-passwordcredential-passwordcredential-data" id="infopanel-for-dom-passwordcredential-passwordcredential-data" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-passwordcredential-data" style="display:none">Info about the 'PasswordCredential(data)' definition.</span><b><a href="#dom-passwordcredential-passwordcredential-data">#dom-passwordcredential-passwordcredential-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-passwordcredential-data">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-passwordcredentialdata">
-   <b><a href="#dictdef-passwordcredentialdata">#dictdef-passwordcredentialdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-passwordcredentialdata" class="dfn-panel" data-for="dictdef-passwordcredentialdata" id="infopanel-for-dictdef-passwordcredentialdata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-passwordcredentialdata" style="display:none">Info about the 'PasswordCredentialData' definition.</span><b><a href="#dictdef-passwordcredentialdata">#dictdef-passwordcredentialdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-passwordcredentialdata">3.2. The PasswordCredential Interface</a> <a href="#ref-for-dictdef-passwordcredentialdata①">(2)</a> <a href="#ref-for-dictdef-passwordcredentialdata②">(3)</a> <a href="#ref-for-dictdef-passwordcredentialdata③">(4)</a>
     <li><a href="#ref-for-dictdef-passwordcredentialdata④">3.3.2. 
@@ -4784,22 +4786,22 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredentialdata-name">
-   <b><a href="#dom-passwordcredentialdata-name">#dom-passwordcredentialdata-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredentialdata-name" class="dfn-panel" data-for="dom-passwordcredentialdata-name" id="infopanel-for-dom-passwordcredentialdata-name" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredentialdata-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-passwordcredentialdata-name">#dom-passwordcredentialdata-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredentialdata-name">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredentialdata-iconurl">
-   <b><a href="#dom-passwordcredentialdata-iconurl">#dom-passwordcredentialdata-iconurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredentialdata-iconurl" class="dfn-panel" data-for="dom-passwordcredentialdata-iconurl" id="infopanel-for-dom-passwordcredentialdata-iconurl" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredentialdata-iconurl" style="display:none">Info about the 'iconURL' definition.</span><b><a href="#dom-passwordcredentialdata-iconurl">#dom-passwordcredentialdata-iconurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredentialdata-iconurl">3.3.5. 
     Create a PasswordCredential from PasswordCredentialData </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredentialdata-origin">
-   <b><a href="#dom-passwordcredentialdata-origin">#dom-passwordcredentialdata-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredentialdata-origin" class="dfn-panel" data-for="dom-passwordcredentialdata-origin" id="infopanel-for-dom-passwordcredentialdata-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredentialdata-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-passwordcredentialdata-origin">#dom-passwordcredentialdata-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredentialdata-origin">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a>
@@ -4807,8 +4809,8 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-passwordcredentialdata-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredentialdata-password">
-   <b><a href="#dom-passwordcredentialdata-password">#dom-passwordcredentialdata-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredentialdata-password" class="dfn-panel" data-for="dom-passwordcredentialdata-password" id="infopanel-for-dom-passwordcredentialdata-password" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredentialdata-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-passwordcredentialdata-password">#dom-passwordcredentialdata-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredentialdata-password">3.3.4. 
     Create a PasswordCredential from an HTMLFormElement </a> <a href="#ref-for-dom-passwordcredentialdata-password①">(2)</a>
@@ -4816,48 +4818,48 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from PasswordCredentialData </a> <a href="#ref-for-dom-passwordcredentialdata-password③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-passwordcredentialinit">
-   <b><a href="#typedefdef-passwordcredentialinit">#typedefdef-passwordcredentialinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-passwordcredentialinit" class="dfn-panel" data-for="typedefdef-passwordcredentialinit" id="infopanel-for-typedefdef-passwordcredentialinit" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-passwordcredentialinit" style="display:none">Info about the 'PasswordCredentialInit' definition.</span><b><a href="#typedefdef-passwordcredentialinit">#typedefdef-passwordcredentialinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-passwordcredentialinit">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialcreationoptions-password">
-   <b><a href="#dom-credentialcreationoptions-password">#dom-credentialcreationoptions-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialcreationoptions-password" class="dfn-panel" data-for="dom-credentialcreationoptions-password" id="infopanel-for-dom-credentialcreationoptions-password" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialcreationoptions-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-credentialcreationoptions-password">#dom-credentialcreationoptions-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-password">3.3.2. 
     PasswordCredential's [[Create]](origin, options, sameOriginWithAncestors) </a> <a href="#ref-for-dom-credentialcreationoptions-password①">(2)</a> <a href="#ref-for-dom-credentialcreationoptions-password②">(3)</a> <a href="#ref-for-dom-credentialcreationoptions-password③">(4)</a> <a href="#ref-for-dom-credentialcreationoptions-password④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-collectfromcredentialstore-slot">
-   <b><a href="#dom-passwordcredential-collectfromcredentialstore-slot">#dom-passwordcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-collectfromcredentialstore-slot" class="dfn-panel" data-for="dom-passwordcredential-collectfromcredentialstore-slot" id="infopanel-for-dom-passwordcredential-collectfromcredentialstore-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-collectfromcredentialstore-slot" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-passwordcredential-collectfromcredentialstore-slot">#dom-passwordcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-collectfromcredentialstore-slot">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-dom-passwordcredential-collectfromcredentialstore-slot①">6.4. Origin Confusion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-create-slot">
-   <b><a href="#dom-passwordcredential-create-slot">#dom-passwordcredential-create-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-create-slot" class="dfn-panel" data-for="dom-passwordcredential-create-slot" id="infopanel-for-dom-passwordcredential-create-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-create-slot" style="display:none">Info about the '[[Create]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-passwordcredential-create-slot">#dom-passwordcredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-create-slot">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-passwordcredential-store-slot">
-   <b><a href="#dom-passwordcredential-store-slot">#dom-passwordcredential-store-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-passwordcredential-store-slot" class="dfn-panel" data-for="dom-passwordcredential-store-slot" id="infopanel-for-dom-passwordcredential-store-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-passwordcredential-store-slot" style="display:none">Info about the '[[Store]](credential, sameOriginWithAncestors)' definition.</span><b><a href="#dom-passwordcredential-store-slot">#dom-passwordcredential-store-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-passwordcredential-store-slot">3.2. The PasswordCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">
-   <b><a href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" id="infopanel-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement" style="display:none">Info about the 'Create a PasswordCredential from an HTMLFormElement' definition.</span><b><a href="#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">#abstract-opdef-create-a-passwordcredential-from-an-htmlformelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-an-htmlformelement①">3.3.2. 
     PasswordCredential's [[Create]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">
-   <b><a href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" class="dfn-panel" data-for="abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" id="infopanel-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata" style="display:none">Info about the 'Create a PasswordCredential from PasswordCredentialData' definition.</span><b><a href="#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">#abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata">3.2. The PasswordCredential Interface</a>
     <li><a href="#ref-for-abstract-opdef-create-a-passwordcredential-from-passwordcredentialdata①">3.3.2. 
@@ -4866,8 +4868,8 @@ partial dictionary CredentialCreationOptions {
     Create a PasswordCredential from an HTMLFormElement </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="federatedcredential">
-   <b><a href="#federatedcredential">#federatedcredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-federatedcredential" class="dfn-panel" data-for="federatedcredential" id="infopanel-for-federatedcredential" role="dialog">
+   <span id="infopaneltitle-for-federatedcredential" style="display:none">Info about the 'FederatedCredential' definition.</span><b><a href="#federatedcredential">#federatedcredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-federatedcredential">2. Core API</a>
     <li><a href="#ref-for-federatedcredential①">4.1. The FederatedCredential Interface</a> <a href="#ref-for-federatedcredential②">(2)</a> <a href="#ref-for-federatedcredential③">(3)</a> <a href="#ref-for-federatedcredential④">(4)</a> <a href="#ref-for-federatedcredential⑤">(5)</a> <a href="#ref-for-federatedcredential⑥">(6)</a>
@@ -4883,37 +4885,37 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-federatedcredential①④">8. Future Work</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-federatedcredentialrequestoptions">
-   <b><a href="#dictdef-federatedcredentialrequestoptions">#dictdef-federatedcredentialrequestoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-federatedcredentialrequestoptions" class="dfn-panel" data-for="dictdef-federatedcredentialrequestoptions" id="infopanel-for-dictdef-federatedcredentialrequestoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-federatedcredentialrequestoptions" style="display:none">Info about the 'FederatedCredentialRequestOptions' definition.</span><b><a href="#dictdef-federatedcredentialrequestoptions">#dictdef-federatedcredentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions">4.1. The FederatedCredential Interface</a>
     <li><a href="#ref-for-dictdef-federatedcredentialrequestoptions①">4.1.1. Identifying Providers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-providers">
-   <b><a href="#dom-federatedcredentialrequestoptions-providers">#dom-federatedcredentialrequestoptions-providers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredentialrequestoptions-providers" class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-providers" id="infopanel-for-dom-federatedcredentialrequestoptions-providers" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredentialrequestoptions-providers" style="display:none">Info about the 'providers' definition.</span><b><a href="#dom-federatedcredentialrequestoptions-providers">#dom-federatedcredentialrequestoptions-providers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers">4.1.1. Identifying Providers</a>
     <li><a href="#ref-for-dom-federatedcredentialrequestoptions-providers①">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-protocols">
-   <b><a href="#dom-federatedcredentialrequestoptions-protocols">#dom-federatedcredentialrequestoptions-protocols</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredentialrequestoptions-protocols" class="dfn-panel" data-for="dom-federatedcredentialrequestoptions-protocols" id="infopanel-for-dom-federatedcredentialrequestoptions-protocols" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredentialrequestoptions-protocols" style="display:none">Info about the 'protocols' definition.</span><b><a href="#dom-federatedcredentialrequestoptions-protocols">#dom-federatedcredentialrequestoptions-protocols</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredentialrequestoptions-protocols">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-federated">
-   <b><a href="#dom-credentialrequestoptions-federated">#dom-credentialrequestoptions-federated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-federated" class="dfn-panel" data-for="dom-credentialrequestoptions-federated" id="infopanel-for-dom-credentialrequestoptions-federated" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-federated" style="display:none">Info about the 'federated' definition.</span><b><a href="#dom-credentialrequestoptions-federated">#dom-credentialrequestoptions-federated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-federated">4.2.1. 
     FederatedCredential's [[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors) </a> <a href="#ref-for-dom-credentialrequestoptions-federated①">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-federated②">(3)</a> <a href="#ref-for-dom-credentialrequestoptions-federated③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-provider">
-   <b><a href="#dom-federatedcredential-provider">#dom-federatedcredential-provider</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-provider" class="dfn-panel" data-for="dom-federatedcredential-provider" id="infopanel-for-dom-federatedcredential-provider" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-provider" style="display:none">Info about the 'provider' definition.</span><b><a href="#dom-federatedcredential-provider">#dom-federatedcredential-provider</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-provider">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dom-federatedcredential-provider①">(2)</a>
     <li><a href="#ref-for-dom-federatedcredential-provider②">4.1.1. Identifying Providers</a>
@@ -4925,8 +4927,8 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-protocol">
-   <b><a href="#dom-federatedcredential-protocol">#dom-federatedcredential-protocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-protocol" class="dfn-panel" data-for="dom-federatedcredential-protocol" id="infopanel-for-dom-federatedcredential-protocol" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-protocol" style="display:none">Info about the 'protocol' definition.</span><b><a href="#dom-federatedcredential-protocol">#dom-federatedcredential-protocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-protocol">4.1. The FederatedCredential Interface</a>
     <li><a href="#ref-for-dom-federatedcredential-protocol①">4.2.1. 
@@ -4935,22 +4937,22 @@ partial dictionary CredentialCreationOptions {
     FederatedCredential's [[Store]](credential, sameOriginWithAncestors) </a> <a href="#ref-for-dom-federatedcredential-protocol③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-federatedcredential">
-   <b><a href="#dom-federatedcredential-federatedcredential">#dom-federatedcredential-federatedcredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-federatedcredential" class="dfn-panel" data-for="dom-federatedcredential-federatedcredential" id="infopanel-for-dom-federatedcredential-federatedcredential" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-federatedcredential" style="display:none">Info about the 'FederatedCredential(data)' definition.</span><b><a href="#dom-federatedcredential-federatedcredential">#dom-federatedcredential-federatedcredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-federatedcredential">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-federatedcredentialinit">
-   <b><a href="#dictdef-federatedcredentialinit">#dictdef-federatedcredentialinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-federatedcredentialinit" class="dfn-panel" data-for="dictdef-federatedcredentialinit" id="infopanel-for-dictdef-federatedcredentialinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-federatedcredentialinit" style="display:none">Info about the 'FederatedCredentialInit' definition.</span><b><a href="#dictdef-federatedcredentialinit">#dictdef-federatedcredentialinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-federatedcredentialinit">4.1. The FederatedCredential Interface</a> <a href="#ref-for-dictdef-federatedcredentialinit①">(2)</a> <a href="#ref-for-dictdef-federatedcredentialinit②">(3)</a> <a href="#ref-for-dictdef-federatedcredentialinit③">(4)</a>
     <li><a href="#ref-for-dictdef-federatedcredentialinit④">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredentialinit-origin">
-   <b><a href="#dom-federatedcredentialinit-origin">#dom-federatedcredentialinit-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredentialinit-origin" class="dfn-panel" data-for="dom-federatedcredentialinit-origin" id="infopanel-for-dom-federatedcredentialinit-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredentialinit-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-federatedcredentialinit-origin">#dom-federatedcredentialinit-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredentialinit-origin">4.2.2. 
     FederatedCredential's [[Create]](origin, options, sameOriginWithAncestors) </a>
@@ -4958,48 +4960,48 @@ partial dictionary CredentialCreationOptions {
     Create a FederatedCredential from FederatedCredentialInit </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredentialinit-provider">
-   <b><a href="#dom-federatedcredentialinit-provider">#dom-federatedcredentialinit-provider</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredentialinit-provider" class="dfn-panel" data-for="dom-federatedcredentialinit-provider" id="infopanel-for-dom-federatedcredentialinit-provider" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredentialinit-provider" style="display:none">Info about the 'provider' definition.</span><b><a href="#dom-federatedcredentialinit-provider">#dom-federatedcredentialinit-provider</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredentialinit-provider">4.2.4. 
     Create a FederatedCredential from FederatedCredentialInit </a> <a href="#ref-for-dom-federatedcredentialinit-provider①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialcreationoptions-federated">
-   <b><a href="#dom-credentialcreationoptions-federated">#dom-credentialcreationoptions-federated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialcreationoptions-federated" class="dfn-panel" data-for="dom-credentialcreationoptions-federated" id="infopanel-for-dom-credentialcreationoptions-federated" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialcreationoptions-federated" style="display:none">Info about the 'federated' definition.</span><b><a href="#dom-credentialcreationoptions-federated">#dom-credentialcreationoptions-federated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-federated">4.2.2. 
     FederatedCredential's [[Create]](origin, options, sameOriginWithAncestors) </a> <a href="#ref-for-dom-credentialcreationoptions-federated①">(2)</a> <a href="#ref-for-dom-credentialcreationoptions-federated②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-collectfromcredentialstore-slot">
-   <b><a href="#dom-federatedcredential-collectfromcredentialstore-slot">#dom-federatedcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-collectfromcredentialstore-slot" class="dfn-panel" data-for="dom-federatedcredential-collectfromcredentialstore-slot" id="infopanel-for-dom-federatedcredential-collectfromcredentialstore-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-collectfromcredentialstore-slot" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-federatedcredential-collectfromcredentialstore-slot">#dom-federatedcredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-collectfromcredentialstore-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-create-slot">
-   <b><a href="#dom-federatedcredential-create-slot">#dom-federatedcredential-create-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-create-slot" class="dfn-panel" data-for="dom-federatedcredential-create-slot" id="infopanel-for-dom-federatedcredential-create-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-create-slot" style="display:none">Info about the '[[Create]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-federatedcredential-create-slot">#dom-federatedcredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-create-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-federatedcredential-store-slot">
-   <b><a href="#dom-federatedcredential-store-slot">#dom-federatedcredential-store-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-federatedcredential-store-slot" class="dfn-panel" data-for="dom-federatedcredential-store-slot" id="infopanel-for-dom-federatedcredential-store-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-federatedcredential-store-slot" style="display:none">Info about the '[[Store]](credential, sameOriginWithAncestors)' definition.</span><b><a href="#dom-federatedcredential-store-slot">#dom-federatedcredential-store-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-federatedcredential-store-slot">4.1. The FederatedCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">
-   <b><a href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" class="dfn-panel" data-for="abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" id="infopanel-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit" style="display:none">Info about the 'Create a FederatedCredential from FederatedCredentialInit' definition.</span><b><a href="#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">#abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit">4.1. The FederatedCredential Interface</a>
     <li><a href="#ref-for-abstract-opdef-create-a-federatedcredential-from-federatedcredentialinit①">4.2.2. 
     FederatedCredential's [[Create]](origin, options, sameOriginWithAncestors) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-mediated">
-   <b><a href="#user-mediated">#user-mediated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-mediated" class="dfn-panel" data-for="user-mediated" id="infopanel-for-user-mediated" role="dialog">
+   <span id="infopaneltitle-for-user-mediated" style="display:none">Info about the 'user mediated' definition.</span><b><a href="#user-mediated">#user-mediated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-mediated">2.3.1. The CredentialRequestOptions Dictionary</a> <a href="#ref-for-user-mediated①">(2)</a>
     <li><a href="#ref-for-user-mediated②">2.3.2. Mediation Requirements</a> <a href="#ref-for-user-mediated③">(2)</a>
@@ -5015,8 +5017,8 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-user-mediated①⑤">6.1. Cross-domain credential access</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-chooser">
-   <b><a href="#credential-chooser">#credential-chooser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-chooser" class="dfn-panel" data-for="credential-chooser" id="infopanel-for-credential-chooser" role="dialog">
+   <span id="infopaneltitle-for-credential-chooser" style="display:none">Info about the 'credential chooser' definition.</span><b><a href="#credential-chooser">#credential-chooser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-chooser">2.2.2. CredentialUserData Mixin</a> <a href="#ref-for-credential-chooser①">(2)</a> <a href="#ref-for-credential-chooser②">(3)</a>
     <li><a href="#ref-for-credential-chooser③">2.3.2. Mediation Requirements</a>
@@ -5028,67 +5030,124 @@ partial dictionary CredentialCreationOptions {
     <li><a href="#ref-for-credential-chooser①⓪">6.7. Chooser Leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-ask-the-user-to-choose-a-credential">
-   <b><a href="#abstract-opdef-ask-the-user-to-choose-a-credential">#abstract-opdef-ask-the-user-to-choose-a-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-ask-the-user-to-choose-a-credential" class="dfn-panel" data-for="abstract-opdef-ask-the-user-to-choose-a-credential" id="infopanel-for-abstract-opdef-ask-the-user-to-choose-a-credential" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-ask-the-user-to-choose-a-credential" style="display:none">Info about the 'ask the user to choose a
+    Credential' definition.</span><b><a href="#abstract-opdef-ask-the-user-to-choose-a-credential">#abstract-opdef-ask-the-user-to-choose-a-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-ask-the-user-to-choose-a-credential">2.5.1. Request a Credential</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webappsec-csp/2/index.html
+++ b/tests/github/w3c/webappsec-csp/2/index.html
@@ -3045,93 +3045,93 @@ Content-Security-Policy: style-src 'none'
     </ul>
    <li><a href="#wsp">WSP</a><span>, in § 2.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-interface-document">
-   <a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-document" class="dfn-panel" data-for="term-for-interface-document" id="infopanel-for-term-for-interface-document" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-document" style="display:none">Info about the 'Document' external reference.</span><a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-document">7.14.1. Sandboxing and Workers</a>
     <li><a href="#ref-for-interface-document①">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="http://www.w3.org/TR/dom/#event">http://www.w3.org/TR/dom/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="http://www.w3.org/TR/dom/#event">http://www.w3.org/TR/dom/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventinit">
-   <a href="http://www.w3.org/TR/dom/#eventinit">http://www.w3.org/TR/dom/#eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventinit" class="dfn-panel" data-for="term-for-eventinit" id="infopanel-for-term-for-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="http://www.w3.org/TR/dom/#eventinit">http://www.w3.org/TR/dom/#eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventinit">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
-   <a href="http://www.w3.org/TR/html5/scripting-1.html#htmlscriptelement">http://www.w3.org/TR/html5/scripting-1.html#htmlscriptelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlscriptelement" class="dfn-panel" data-for="term-for-htmlscriptelement" id="infopanel-for-term-for-htmlscriptelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlscriptelement" style="display:none">Info about the 'HTMLScriptElement' external reference.</span><a href="http://www.w3.org/TR/html5/scripting-1.html#htmlscriptelement">http://www.w3.org/TR/html5/scripting-1.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlscriptelement">4.2.3. 
         The nonce attribute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlstyleelement">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#htmlstyleelement">http://www.w3.org/TR/html5/document-metadata.html#htmlstyleelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlstyleelement" class="dfn-panel" data-for="term-for-htmlstyleelement" id="infopanel-for-term-for-htmlstyleelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlstyleelement" style="display:none">Info about the 'HTMLStyleElement' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#htmlstyleelement">http://www.w3.org/TR/html5/document-metadata.html#htmlstyleelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlstyleelement">4.2.3. 
         The nonce attribute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="http://www.w3.org/TR/html5/browsers.html#active-document">http://www.w3.org/TR/html5/browsers.html#active-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-document" class="dfn-panel" data-for="term-for-active-document" id="infopanel-for-term-for-active-document" role="menu">
+   <span id="infopaneltitle-for-term-for-active-document" style="display:none">Info about the 'active document' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#active-document">http://www.w3.org/TR/html5/browsers.html#active-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-document">7.12. plugin-types</a> <a href="#ref-for-active-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-forms">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-forms">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-forms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-forms" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-forms" id="infopanel-for-term-for-attr-iframe-sandbox-allow-forms" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-forms" style="display:none">Info about the 'allow-forms' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-forms">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-forms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-forms">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-pointer-lock">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-pointer-lock">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-pointer-lock</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-pointer-lock" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-pointer-lock" id="infopanel-for-term-for-attr-iframe-sandbox-allow-pointer-lock" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-pointer-lock" style="display:none">Info about the 'allow-pointer-lock' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-pointer-lock">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-pointer-lock</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-pointer-lock">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-popups">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-popups">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-popups</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-popups" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-popups" id="infopanel-for-term-for-attr-iframe-sandbox-allow-popups" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-popups" style="display:none">Info about the 'allow-popups' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-popups">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-popups</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-popups">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-same-origin">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-same-origin">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-same-origin" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-same-origin" id="infopanel-for-term-for-attr-iframe-sandbox-allow-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-same-origin" style="display:none">Info about the 'allow-same-origin' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-same-origin">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-same-origin">7.14.1. Sandboxing and Workers</a> <a href="#ref-for-attr-iframe-sandbox-allow-same-origin①">(2)</a>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-same-origin②">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-scripts">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-scripts">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-scripts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-scripts" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-scripts" id="infopanel-for-term-for-attr-iframe-sandbox-allow-scripts" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-scripts" style="display:none">Info about the 'allow-scripts' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-scripts">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-scripts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-scripts">7.14.1. Sandboxing and Workers</a> <a href="#ref-for-attr-iframe-sandbox-allow-scripts①">(2)</a>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-scripts②">7.14.2. Usage</a> <a href="#ref-for-attr-iframe-sandbox-allow-scripts③">(2)</a> <a href="#ref-for-attr-iframe-sandbox-allow-scripts④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-top-navigation">
-   <a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-top-navigation">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-top-navigation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-top-navigation" class="dfn-panel" data-for="term-for-attr-iframe-sandbox-allow-top-navigation" id="infopanel-for-term-for-attr-iframe-sandbox-allow-top-navigation" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox-allow-top-navigation" style="display:none">Info about the 'allow-top-navigation' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-top-navigation">http://www.w3.org/TR/html5/browsers.html#attr-iframe-sandbox-allow-top-navigation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox-allow-top-navigation">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ancestor-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#ancestor-browsing-context">http://www.w3.org/TR/html5/browsers.html#ancestor-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ancestor-browsing-context" class="dfn-panel" data-for="term-for-ancestor-browsing-context" id="infopanel-for-term-for-ancestor-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-ancestor-browsing-context" style="display:none">Info about the 'ancestor browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#ancestor-browsing-context">http://www.w3.org/TR/html5/browsers.html#ancestor-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ancestor-browsing-context">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-applet-element">
-   <a href="http://www.w3.org/TR/html5/obsolete.html#the-applet-element">http://www.w3.org/TR/html5/obsolete.html#the-applet-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-applet-element" class="dfn-panel" data-for="term-for-the-applet-element" id="infopanel-for-term-for-the-applet-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-applet-element" style="display:none">Info about the 'applet' external reference.</span><a href="http://www.w3.org/TR/html5/obsolete.html#the-applet-element">http://www.w3.org/TR/html5/obsolete.html#the-applet-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-applet-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-applet-element①">7.7. frame-ancestors</a>
@@ -3139,14 +3139,14 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-the-applet-element④">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-applet-archive">
-   <a href="http://www.w3.org/TR/html5/obsolete.html#dom-applet-archive">http://www.w3.org/TR/html5/obsolete.html#dom-applet-archive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-applet-archive" class="dfn-panel" data-for="term-for-dom-applet-archive" id="infopanel-for-term-for-dom-applet-archive" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-applet-archive" style="display:none">Info about the 'archive' external reference.</span><a href="http://www.w3.org/TR/html5/obsolete.html#dom-applet-archive">http://www.w3.org/TR/html5/obsolete.html#dom-applet-archive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-applet-archive">7.11. object-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive match' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive">http://www.w3.org/TR/html5/infrastructure.html#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.3. 
       HTML meta Element </a>
@@ -3157,52 +3157,52 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-ascii-case-insensitive⑧">7.12. plugin-types</a> <a href="#ref-for-ascii-case-insensitive⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-audio-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-audio-element" class="dfn-panel" data-for="term-for-the-audio-element" id="infopanel-for-term-for-the-audio-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-audio-element" style="display:none">Info about the 'audio' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-audio-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-audio-element①">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-auxiliary-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#auxiliary-browsing-context">http://www.w3.org/TR/html5/browsers.html#auxiliary-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-auxiliary-browsing-context" class="dfn-panel" data-for="term-for-auxiliary-browsing-context" id="infopanel-for-term-for-auxiliary-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-auxiliary-browsing-context" style="display:none">Info about the 'auxiliary browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#auxiliary-browsing-context">http://www.w3.org/TR/html5/browsers.html#auxiliary-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-auxiliary-browsing-context">2.3. Relevant Concepts from HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-child-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#child-browsing-context">http://www.w3.org/TR/html5/browsers.html#child-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-child-browsing-context" class="dfn-panel" data-for="term-for-child-browsing-context" id="infopanel-for-term-for-child-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-child-browsing-context" style="display:none">Info about the 'child browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#child-browsing-context">http://www.w3.org/TR/html5/browsers.html#child-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-browsing-context">7.12. plugin-types</a> <a href="#ref-for-child-browsing-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-applet-code">
-   <a href="http://www.w3.org/TR/html5/obsolete.html#dom-applet-code">http://www.w3.org/TR/html5/obsolete.html#dom-applet-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-applet-code" class="dfn-panel" data-for="term-for-dom-applet-code" id="infopanel-for-term-for-dom-applet-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-applet-code" style="display:none">Info about the 'code' external reference.</span><a href="http://www.w3.org/TR/html5/obsolete.html#dom-applet-code">http://www.w3.org/TR/html5/obsolete.html#dom-applet-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-applet-code">7.11. object-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-content">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-content" class="dfn-panel" data-for="term-for-attr-meta-content" id="infopanel-for-term-for-attr-meta-content" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-content" style="display:none">Info about the 'content' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content">http://www.w3.org/TR/html5/document-metadata.html#attr-meta-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-content">3.3. 
       HTML meta Element </a> <a href="#ref-for-attr-meta-content①">(2)</a> <a href="#ref-for-attr-meta-content②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-object-data">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-data">http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-object-data" class="dfn-panel" data-for="term-for-attr-object-data" id="infopanel-for-term-for-attr-object-data" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-object-data" style="display:none">Info about the 'data' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-data">http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-object-data">7.11. object-src</a> <a href="#ref-for-attr-object-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-port">
-   <a href="http://www.w3.org/TR/url/#default-port">http://www.w3.org/TR/url/#default-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-port" class="dfn-panel" data-for="term-for-default-port" id="infopanel-for-term-for-default-port" role="menu">
+   <span id="infopaneltitle-for-term-for-default-port" style="display:none">Info about the 'default port' external reference.</span><a href="http://www.w3.org/TR/url/#default-port">http://www.w3.org/TR/url/#default-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-port">4.2.2. Matching Source Expressions</a> <a href="#ref-for-default-port①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-embed-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-embed-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-embed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-embed-element" class="dfn-panel" data-for="term-for-the-embed-element" id="infopanel-for-term-for-the-embed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-embed-element" style="display:none">Info about the 'embed' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-embed-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-embed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-embed-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-embed-element①">3.5. Policy applicability</a>
@@ -3214,8 +3214,8 @@ Content-Security-Policy: style-src 'none'
         Predeclaration of expected media types </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#fetch">http://www.w3.org/TR/html5/infrastructure.html#fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch" class="dfn-panel" data-for="term-for-fetch" id="infopanel-for-term-for-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#fetch">http://www.w3.org/TR/html5/infrastructure.html#fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch">4.4. Reporting</a>
     <li><a href="#ref-for-fetch①">7.2.2. Workers</a>
@@ -3230,55 +3230,55 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-fetch①⓪">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="http://www.w3.org/TR/html5/forms.html#the-form-element">http://www.w3.org/TR/html5/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="http://www.w3.org/TR/html5/forms.html#the-form-element">http://www.w3.org/TR/html5/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">7.6. form-action</a> <a href="#ref-for-the-form-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame">
-   <a href="http://www.w3.org/TR/html5/obsolete.html#frame">http://www.w3.org/TR/html5/obsolete.html#frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame" class="dfn-panel" data-for="term-for-frame" id="infopanel-for-term-for-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-frame" style="display:none">Info about the 'frame' external reference.</span><a href="http://www.w3.org/TR/html5/obsolete.html#frame">http://www.w3.org/TR/html5/obsolete.html#frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame">7.7. frame-ancestors</a>
     <li><a href="#ref-for-frame①">7.8. frame-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-head-element">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#the-head-element">http://www.w3.org/TR/html5/document-metadata.html#the-head-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-head-element" class="dfn-panel" data-for="term-for-the-head-element" id="infopanel-for-term-for-the-head-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-head-element" style="display:none">Info about the 'head' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#the-head-element">http://www.w3.org/TR/html5/document-metadata.html#the-head-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-head-element">3.3. 
       HTML meta Element </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="http://www.w3.org/TR/url/#concept-url-host">http://www.w3.org/TR/url/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-host">http://www.w3.org/TR/url/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">4.2.2. Matching Source Expressions</a> <a href="#ref-for-concept-url-host①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-href">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#attr-link-href">http://www.w3.org/TR/html5/document-metadata.html#attr-link-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-href" class="dfn-panel" data-for="term-for-attr-link-href" id="infopanel-for-term-for-attr-link-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-href" style="display:none">Info about the 'href' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-link-href">http://www.w3.org/TR/html5/document-metadata.html#attr-link-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-href">7.9. img-src</a>
     <li><a href="#ref-for-attr-link-href①">7.15. script-src</a>
     <li><a href="#ref-for-attr-link-href②">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-http-equiv">http://www.w3.org/TR/html5/document-metadata.html#attr-meta-http-equiv</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv" class="dfn-panel" data-for="term-for-attr-meta-http-equiv" id="infopanel-for-term-for-attr-meta-http-equiv" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv" style="display:none">Info about the 'http-equiv' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-meta-http-equiv">http://www.w3.org/TR/html5/document-metadata.html#attr-meta-http-equiv</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv">3.3. 
       HTML meta Element </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rel-icon">
-   <a href="http://www.w3.org/TR/html5/links.html#rel-icon">http://www.w3.org/TR/html5/links.html#rel-icon</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rel-icon" class="dfn-panel" data-for="term-for-rel-icon" id="infopanel-for-term-for-rel-icon" role="menu">
+   <span id="infopaneltitle-for-term-for-rel-icon" style="display:none">Info about the 'icon' external reference.</span><a href="http://www.w3.org/TR/html5/links.html#rel-icon">http://www.w3.org/TR/html5/links.html#rel-icon</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rel-icon">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-iframe-element①">3.5. Policy applicability</a>
@@ -3288,40 +3288,40 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-the-iframe-element⑥">7.14.2. Usage</a> <a href="#ref-for-the-iframe-element⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-type-image-keyword">
-   <a href="http://www.w3.org/TR/html5/forms.html#attr-input-type-image-keyword">http://www.w3.org/TR/html5/forms.html#attr-input-type-image-keyword</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-type-image-keyword" class="dfn-panel" data-for="term-for-attr-input-type-image-keyword" id="infopanel-for-term-for-attr-input-type-image-keyword" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-type-image-keyword" style="display:none">Info about the 'image' external reference.</span><a href="http://www.w3.org/TR/html5/forms.html#attr-input-type-image-keyword">http://www.w3.org/TR/html5/forms.html#attr-input-type-image-keyword</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-type-image-keyword">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-img-element①">3.5. Policy applicability</a> <a href="#ref-for-the-img-element②">(2)</a>
     <li><a href="#ref-for-the-img-element③">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="http://www.w3.org/TR/html5/forms.html#the-input-element">http://www.w3.org/TR/html5/forms.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="http://www.w3.org/TR/html5/forms.html#the-input-element">http://www.w3.org/TR/html5/forms.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.2">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.2" class="dfn-panel" data-for="term-for-section-3.2.2" id="infopanel-for-term-for-section-3.2.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.2" style="display:none">Info about the 'ipv4address' external reference.</span><a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.2">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv6">
-   <a href="http://www.w3.org/TR/url/#concept-ipv6">http://www.w3.org/TR/url/#concept-ipv6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv6" class="dfn-panel" data-for="term-for-concept-ipv6" id="infopanel-for-term-for-concept-ipv6" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv6" style="display:none">Info about the 'ipv6 address' external reference.</span><a href="http://www.w3.org/TR/url/#concept-ipv6">http://www.w3.org/TR/url/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#the-link-element">http://www.w3.org/TR/html5/document-metadata.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#the-link-element">http://www.w3.org/TR/html5/document-metadata.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-link-element①">3.3. 
@@ -3331,14 +3331,14 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-the-link-element④">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-link-type-stylesheet">
-   <a href="http://www.w3.org/TR/html5/links.html#link-type-stylesheet">http://www.w3.org/TR/html5/links.html#link-type-stylesheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-link-type-stylesheet" class="dfn-panel" data-for="term-for-link-type-stylesheet" id="infopanel-for-term-for-link-type-stylesheet" role="menu">
+   <span id="infopaneltitle-for-term-for-link-type-stylesheet" style="display:none">Info about the 'link type stylesheet' external reference.</span><a href="http://www.w3.org/TR/html5/links.html#link-type-stylesheet">http://www.w3.org/TR/html5/links.html#link-type-stylesheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-type-stylesheet">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://heycam.github.io/webidl/#idl-long">https://heycam.github.io/webidl/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">6.1. 
       SecurityPolicyViolationEvent Interface </a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a>
@@ -3346,8 +3346,8 @@ Content-Security-Policy: style-src 'none'
       SecurityPolicyViolationEventInit Interface </a> <a href="#ref-for-idl-long⑤">(2)</a> <a href="#ref-for-idl-long⑥">(3)</a> <a href="#ref-for-idl-long⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-meta-element">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">http://www.w3.org/TR/html5/document-metadata.html#the-meta-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-meta-element" class="dfn-panel" data-for="term-for-the-meta-element" id="infopanel-for-term-for-the-meta-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-meta-element" style="display:none">Info about the 'meta' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">http://www.w3.org/TR/html5/document-metadata.html#the-meta-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-meta-element">3. Policy Delivery</a>
     <li><a href="#ref-for-the-meta-element①">3.2. 
@@ -3357,8 +3357,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-the-meta-element①⑤">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">http://www.w3.org/TR/html5/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nested-browsing-context" class="dfn-panel" data-for="term-for-nested-browsing-context" id="infopanel-for-term-for-nested-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-nested-browsing-context" style="display:none">Info about the 'nested browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#nested-browsing-context">http://www.w3.org/TR/html5/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-nested-browsing-context①">7.7. frame-ancestors</a>
@@ -3367,8 +3367,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-nested-browsing-context⑥">10.1. Processing Complications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-object-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-object-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-object-element①">3.5. Policy applicability</a>
@@ -3380,32 +3380,32 @@ Content-Security-Policy: style-src 'none'
         Predeclaration of expected media types </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opener-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#opener-browsing-context">http://www.w3.org/TR/html5/browsers.html#opener-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opener-browsing-context" class="dfn-panel" data-for="term-for-opener-browsing-context" id="infopanel-for-term-for-opener-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-opener-browsing-context" style="display:none">Info about the 'opener browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#opener-browsing-context">http://www.w3.org/TR/html5/browsers.html#opener-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opener-browsing-context">2.3. Relevant Concepts from HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="http://www.w3.org/TR/url/#concept-url-origin">http://www.w3.org/TR/url/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin of a url' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-origin">http://www.w3.org/TR/url/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">4.2.2. Matching Source Expressions</a> <a href="#ref-for-concept-url-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="http://www.w3.org/TR/url/#concept-url-path">http://www.w3.org/TR/url/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-path">http://www.w3.org/TR/url/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percent-decode">
-   <a href="http://www.w3.org/TR/url/#percent-decode">http://www.w3.org/TR/url/#percent-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percent-decode" class="dfn-panel" data-for="term-for-percent-decode" id="infopanel-for-term-for-percent-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-percent-decode" style="display:none">Info about the 'percent decode' external reference.</span><a href="http://www.w3.org/TR/url/#percent-decode">http://www.w3.org/TR/url/#percent-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-decode">4.2.2. Matching Source Expressions</a> <a href="#ref-for-percent-decode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-plugin">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#plugin">http://www.w3.org/TR/html5/infrastructure.html#plugin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-plugin" class="dfn-panel" data-for="term-for-plugin" id="infopanel-for-term-for-plugin" role="menu">
+   <span id="infopaneltitle-for-term-for-plugin" style="display:none">Info about the 'plugin' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#plugin">http://www.w3.org/TR/html5/infrastructure.html#plugin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plugin">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-plugin①">4.3. Media Type List Syntax</a>
@@ -3413,54 +3413,54 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-plugin④">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="http://www.w3.org/TR/url/#concept-url-port">http://www.w3.org/TR/url/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-port">http://www.w3.org/TR/url/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">4.2.2. Matching Source Expressions</a>
     <li><a href="#ref-for-concept-url-port①">10.1. Processing Complications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-video-poster">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-video-poster">http://www.w3.org/TR/html5/embedded-content-0.html#attr-video-poster</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-video-poster" class="dfn-panel" data-for="term-for-attr-video-poster" id="infopanel-for-term-for-attr-video-poster" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-video-poster" style="display:none">Info about the 'poster' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-video-poster">http://www.w3.org/TR/html5/embedded-content-0.html#attr-video-poster</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-video-poster">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pragma-directives">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">http://www.w3.org/TR/html5/document-metadata.html#pragma-directives</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pragma-directives" class="dfn-panel" data-for="term-for-pragma-directives" id="infopanel-for-term-for-pragma-directives" role="menu">
+   <span id="infopaneltitle-for-term-for-pragma-directives" style="display:none">Info about the 'pragma directives' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#pragma-directives">http://www.w3.org/TR/html5/document-metadata.html#pragma-directives</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pragma-directives">3.3. 
       HTML meta Element </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-referrer">
-   <a href="http://www.w3.org/TR/html5/dom.html#dom-document-referrer">http://www.w3.org/TR/html5/dom.html#dom-document-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-referrer" class="dfn-panel" data-for="term-for-dom-document-referrer" id="infopanel-for-term-for-dom-document-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-referrer" style="display:none">Info about the 'referrer' external reference.</span><a href="http://www.w3.org/TR/html5/dom.html#dom-document-referrer">http://www.w3.org/TR/html5/dom.html#dom-document-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-referrer">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-link-rel">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#attr-link-rel">http://www.w3.org/TR/html5/document-metadata.html#attr-link-rel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-link-rel" class="dfn-panel" data-for="term-for-attr-link-rel" id="infopanel-for-term-for-attr-link-rel" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-link-rel" style="display:none">Info about the 'rel' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#attr-link-rel">http://www.w3.org/TR/html5/document-metadata.html#attr-link-rel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-link-rel">7.9. img-src</a>
     <li><a href="#ref-for-attr-link-rel①">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-sandbox">http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-sandbox">http://www.w3.org/TR/html5/embedded-content-0.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">7.14.2. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="http://www.w3.org/TR/url/#concept-url-scheme">http://www.w3.org/TR/url/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-scheme">http://www.w3.org/TR/url/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.2.2. Matching Source Expressions</a> <a href="#ref-for-concept-url-scheme①">(2)</a> <a href="#ref-for-concept-url-scheme②">(3)</a> <a href="#ref-for-concept-url-scheme③">(4)</a>
     <li><a href="#ref-for-concept-url-scheme④">10.1. Processing Complications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-script-element">
-   <a href="http://www.w3.org/TR/html5/scripting-1.html#the-script-element">http://www.w3.org/TR/html5/scripting-1.html#the-script-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-script-element" class="dfn-panel" data-for="term-for-the-script-element" id="infopanel-for-term-for-the-script-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-script-element" style="display:none">Info about the 'script' external reference.</span><a href="http://www.w3.org/TR/html5/scripting-1.html#the-script-element">http://www.w3.org/TR/html5/scripting-1.html#the-script-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-script-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-script-element①">3.3. 
@@ -3477,65 +3477,65 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-the-script-element①①">8.1. Sample Policy Definitions</a> <a href="#ref-for-the-script-element①②">(2)</a> <a href="#ref-for-the-script-element①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-windowtimers-setinterval">
-   <a href="http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-setinterval">http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-setinterval</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-windowtimers-setinterval" class="dfn-panel" data-for="term-for-dom-windowtimers-setinterval" id="infopanel-for-term-for-dom-windowtimers-setinterval" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-windowtimers-setinterval" style="display:none">Info about the 'setInterval()' external reference.</span><a href="http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-setinterval">http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-setinterval</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowtimers-setinterval">7.15. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-windowtimers-settimeout">
-   <a href="http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-settimeout">http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-settimeout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-windowtimers-settimeout" class="dfn-panel" data-for="term-for-dom-windowtimers-settimeout" id="infopanel-for-term-for-dom-windowtimers-settimeout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-windowtimers-settimeout" style="display:none">Info about the 'setTimeout()' external reference.</span><a href="http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-settimeout">http://www.w3.org/TR/html5/webappapis.html#dom-windowtimers-settimeout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windowtimers-settimeout">7.15. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-source-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-source-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-source-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-source-element" class="dfn-panel" data-for="term-for-the-source-element" id="infopanel-for-term-for-the-source-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-source-element" style="display:none">Info about the 'source' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-source-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-source-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-source-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-source-element①">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-embed-src">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-embed-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-embed-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-embed-src" class="dfn-panel" data-for="term-for-attr-embed-src" id="infopanel-for-term-for-attr-embed-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-embed-src" style="display:none">Info about the 'src (for embed)' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-embed-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-embed-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-embed-src">7.11. object-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-src">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-src" class="dfn-panel" data-for="term-for-attr-img-src" id="infopanel-for-term-for-attr-img-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-src" style="display:none">Info about the 'src (for img)' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-src">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-input-src">
-   <a href="http://www.w3.org/TR/html5/forms.html#attr-input-src">http://www.w3.org/TR/html5/forms.html#attr-input-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-input-src" class="dfn-panel" data-for="term-for-attr-input-src" id="infopanel-for-term-for-attr-input-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-input-src" style="display:none">Info about the 'src (for input)' external reference.</span><a href="http://www.w3.org/TR/html5/forms.html#attr-input-src">http://www.w3.org/TR/html5/forms.html#attr-input-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-input-src">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-script-src">
-   <a href="http://www.w3.org/TR/html5/scripting-1.html#attr-script-src">http://www.w3.org/TR/html5/scripting-1.html#attr-script-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-script-src" class="dfn-panel" data-for="term-for-attr-script-src" id="infopanel-for-term-for-attr-script-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-script-src" style="display:none">Info about the 'src (for script)' external reference.</span><a href="http://www.w3.org/TR/html5/scripting-1.html#attr-script-src">http://www.w3.org/TR/html5/scripting-1.html#attr-script-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-script-src">7.15. script-src</a>
     <li><a href="#ref-for-attr-script-src①">7.15.1. 
         Nonce usage for script elements </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-media-src">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-media-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-media-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-media-src" class="dfn-panel" data-for="term-for-attr-media-src" id="infopanel-for-term-for-attr-media-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-media-src" style="display:none">Info about the 'src (for video)' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-media-src">http://www.w3.org/TR/html5/embedded-content-0.html#attr-media-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-media-src">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-whitespace">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-whitespace" style="display:none">Info about the 'strip leading and trailing whitespace' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-whitespace">4.2.4. Valid Nonces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#the-style-element">http://www.w3.org/TR/html5/document-metadata.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#the-style-element">http://www.w3.org/TR/html5/document-metadata.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">4.2.3. 
         The nonce attribute </a>
@@ -3547,97 +3547,97 @@ Content-Security-Policy: style-src 'none'
         Hash usage for style elements </a> <a href="#ref-for-the-style-element⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SVGElement">
-   <a href="http://www.w3.org/TR/SVG2/struct.html#SVGElement">http://www.w3.org/TR/SVG2/struct.html#SVGElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SVGElement" class="dfn-panel" data-for="term-for-SVGElement" id="infopanel-for-term-for-SVGElement" role="menu">
+   <span id="infopaneltitle-for-term-for-SVGElement" style="display:none">Info about the 'svg' external reference.</span><a href="http://www.w3.org/TR/SVG2/struct.html#SVGElement">http://www.w3.org/TR/SVG2/struct.html#SVGElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SVGElement">3.5. Policy applicability</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-node-textcontent">
-   <a href="http://www.w3.org/TR/dom/#dom-node-textcontent">http://www.w3.org/TR/dom/#dom-node-textcontent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-node-textcontent" class="dfn-panel" data-for="term-for-dom-node-textcontent" id="infopanel-for-term-for-dom-node-textcontent" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-node-textcontent" style="display:none">Info about the 'textContent' external reference.</span><a href="http://www.w3.org/TR/dom/#dom-node-textcontent">http://www.w3.org/TR/dom/#dom-node-textcontent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-textcontent">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-track-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-track-element" class="dfn-panel" data-for="term-for-the-track-element" id="infopanel-for-term-for-the-track-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-track-element" style="display:none">Info about the 'track' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-track-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-track-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-track-element①">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-object-type">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-type">http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-object-type" class="dfn-panel" data-for="term-for-attr-object-type" id="infopanel-for-term-for-attr-object-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-object-type" style="display:none">Info about the 'type' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-type">http://www.w3.org/TR/html5/embedded-content-0.html#attr-object-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-object-type">7.12. plugin-types</a> <a href="#ref-for-attr-object-type①">(2)</a>
     <li><a href="#ref-for-attr-object-type②">7.12.2. 
         Predeclaration of expected media types </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="http://www.w3.org/TR/url/#concept-url-parser">http://www.w3.org/TR/url/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-parser">http://www.w3.org/TR/url/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uri">
-   <a href="http://www.w3.org/TR/CSS21/syndata.html#uri">http://www.w3.org/TR/CSS21/syndata.html#uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uri" class="dfn-panel" data-for="term-for-uri" id="infopanel-for-term-for-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-uri" style="display:none">Info about the 'url()' external reference.</span><a href="http://www.w3.org/TR/CSS21/syndata.html#uri">http://www.w3.org/TR/CSS21/syndata.html#uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uri">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-video-element">
-   <a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-video-element" class="dfn-panel" data-for="term-for-the-video-element" id="infopanel-for-term-for-the-video-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-video-element" style="display:none">Info about the 'video' external reference.</span><a href="http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element">http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-video-element">2.3. Relevant Concepts from HTML</a>
     <li><a href="#ref-for-the-video-element①">7.9. img-src</a>
     <li><a href="#ref-for-the-video-element②">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-image">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-image">https://drafts.csswg.org/css-images-4/#funcdef-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-image" class="dfn-panel" data-for="term-for-funcdef-image" id="infopanel-for-term-for-funcdef-image" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-image" style="display:none">Info about the 'image()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-image">https://drafts.csswg.org/css-images-4/#funcdef-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-image-set">
-   <a href="https://drafts.csswg.org/css-images-4/#funcdef-image-set">https://drafts.csswg.org/css-images-4/#funcdef-image-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-image-set" class="dfn-panel" data-for="term-for-funcdef-image-set" id="infopanel-for-term-for-funcdef-image-set" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-image-set" style="display:none">Info about the 'image-set()' external reference.</span><a href="https://drafts.csswg.org/css-images-4/#funcdef-image-set">https://drafts.csswg.org/css-images-4/#funcdef-image-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-image-set">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-insert-a-css-rule" class="dfn-panel" data-for="term-for-insert-a-css-rule" id="infopanel-for-term-for-insert-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-insert-a-css-rule" style="display:none">Info about the 'insert a css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#insert-a-css-rule">https://drafts.csswg.org/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-a-css-rule">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-css-declaration-block" class="dfn-panel" data-for="term-for-parse-a-css-declaration-block" id="infopanel-for-term-for-parse-a-css-declaration-block" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-css-declaration-block" style="display:none">Info about the 'parse a css declaration block' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block">https://drafts.csswg.org/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-declaration-block">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-css-rule" class="dfn-panel" data-for="term-for-parse-a-css-rule" id="infopanel-for-term-for-parse-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-css-rule" style="display:none">Info about the 'parse a css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#parse-a-css-rule">https://drafts.csswg.org/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-rule">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
-   <a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-group-of-selectors" class="dfn-panel" data-for="term-for-parse-a-group-of-selectors" id="infopanel-for-term-for-parse-a-group-of-selectors" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-group-of-selectors" style="display:none">Info about the 'parse a group of selectors' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors">https://drafts.csswg.org/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-group-of-selectors">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.2.3. 
         The nonce attribute </a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
@@ -3847,8 +3847,8 @@ Content-Security-Policy: style-src 'none'
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="security-policy">
-   <b><a href="#security-policy">#security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-security-policy" class="dfn-panel" data-for="security-policy" id="infopanel-for-security-policy" role="dialog">
+   <span id="infopaneltitle-for-security-policy" style="display:none">Info about the 'security policy' definition.</span><b><a href="#security-policy">#security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-policy">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-security-policy①">3. Policy Delivery</a>
@@ -3862,8 +3862,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-security-policy⑨">8.1. Sample Policy Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="security-policy-directive">
-   <b><a href="#security-policy-directive">#security-policy-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-security-policy-directive" class="dfn-panel" data-for="security-policy-directive" id="infopanel-for-security-policy-directive" role="dialog">
+   <span id="infopaneltitle-for-security-policy-directive" style="display:none">Info about the 'security policy directive' definition.</span><b><a href="#security-policy-directive">#security-policy-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-policy-directive">3.3. 
       HTML meta Element </a>
@@ -3871,20 +3871,20 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-security-policy-directive②">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="security-policy-directive-name">
-   <b><a href="#security-policy-directive-name">#security-policy-directive-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-security-policy-directive-name" class="dfn-panel" data-for="security-policy-directive-name" id="infopanel-for-security-policy-directive-name" role="dialog">
+   <span id="infopaneltitle-for-security-policy-directive-name" style="display:none">Info about the 'security policy directive name' definition.</span><b><a href="#security-policy-directive-name">#security-policy-directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-policy-directive-name">4.1. Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="security-policy-directive-value">
-   <b><a href="#security-policy-directive-value">#security-policy-directive-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-security-policy-directive-value" class="dfn-panel" data-for="security-policy-directive-value" id="infopanel-for-security-policy-directive-value" role="dialog">
+   <span id="infopaneltitle-for-security-policy-directive-value" style="display:none">Info about the 'security policy directive value' definition.</span><b><a href="#security-policy-directive-value">#security-policy-directive-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-policy-directive-value">4.1. Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="protected-resource">
-   <b><a href="#protected-resource">#protected-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-protected-resource" class="dfn-panel" data-for="protected-resource" id="infopanel-for-protected-resource" role="dialog">
+   <span id="infopaneltitle-for-protected-resource" style="display:none">Info about the 'protected resource' definition.</span><b><a href="#protected-resource">#protected-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-protected-resource">1.1. Changes from Level 1</a> <a href="#ref-for-protected-resource①">(2)</a> <a href="#ref-for-protected-resource②">(3)</a> <a href="#ref-for-protected-resource③">(4)</a> <a href="#ref-for-protected-resource④">(5)</a> <a href="#ref-for-protected-resource⑤">(6)</a> <a href="#ref-for-protected-resource⑥">(7)</a>
     <li><a href="#ref-for-protected-resource⑦">3.5. Policy applicability</a>
@@ -3903,40 +3903,40 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-protected-resource②②">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="globally-unique-identifier">
-   <b><a href="#globally-unique-identifier">#globally-unique-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-globally-unique-identifier" class="dfn-panel" data-for="globally-unique-identifier" id="infopanel-for-globally-unique-identifier" role="dialog">
+   <span id="infopaneltitle-for-globally-unique-identifier" style="display:none">Info about the 'globally unique identifier' definition.</span><b><a href="#globally-unique-identifier">#globally-unique-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-globally-unique-identifier">4.4. Reporting</a>
     <li><a href="#ref-for-globally-unique-identifier①">5.1. Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-200-response">
-   <b><a href="#http-200-response">#http-200-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-200-response" class="dfn-panel" data-for="http-200-response" id="infopanel-for-http-200-response" role="dialog">
+   <span id="infopaneltitle-for-http-200-response" style="display:none">Info about the 'HTTP 200 response' definition.</span><b><a href="#http-200-response">#http-200-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-200-response">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="json-object">
-   <b><a href="#json-object">#json-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-json-object" class="dfn-panel" data-for="json-object" id="infopanel-for-json-object" role="dialog">
+   <span id="infopaneltitle-for-json-object" style="display:none">Info about the 'JSON object' definition.</span><b><a href="#json-object">#json-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-json-object">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="json-stringification">
-   <b><a href="#json-stringification">#json-stringification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-json-stringification" class="dfn-panel" data-for="json-stringification" id="infopanel-for-json-stringification" role="dialog">
+   <span id="infopaneltitle-for-json-stringification" style="display:none">Info about the 'JSON stringification' definition.</span><b><a href="#json-stringification">#json-stringification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-json-stringification">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="origin">
-   <b><a href="#origin">#origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-origin" class="dfn-panel" data-for="origin" id="infopanel-for-origin" role="dialog">
+   <span id="infopaneltitle-for-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#origin">#origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin">2.2. Terms defined by reference</a>
     <li><a href="#ref-for-origin①">4.4. Reporting</a> <a href="#ref-for-origin②">(2)</a> <a href="#ref-for-origin③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resource-representation">
-   <b><a href="#resource-representation">#resource-representation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resource-representation" class="dfn-panel" data-for="resource-representation" id="infopanel-for-resource-representation" role="dialog">
+   <span id="infopaneltitle-for-resource-representation" style="display:none">Info about the 'resource representation' definition.</span><b><a href="#resource-representation">#resource-representation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resource-representation">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-resource-representation①">3.1. 
@@ -3945,39 +3945,39 @@ Content-Security-Policy: style-src 'none'
       Content-Security-Policy-Report-Only Header Field </a> <a href="#ref-for-resource-representation④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sha-256">
-   <b><a href="#sha-256">#sha-256</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sha-256" class="dfn-panel" data-for="sha-256" id="infopanel-for-sha-256" role="dialog">
+   <span id="infopaneltitle-for-sha-256" style="display:none">Info about the 'SHA-256' definition.</span><b><a href="#sha-256">#sha-256</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sha-256">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sha-384">
-   <b><a href="#sha-384">#sha-384</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sha-384" class="dfn-panel" data-for="sha-384" id="infopanel-for-sha-384" role="dialog">
+   <span id="infopaneltitle-for-sha-384" style="display:none">Info about the 'SHA-384' definition.</span><b><a href="#sha-384">#sha-384</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sha-384">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sha-512">
-   <b><a href="#sha-512">#sha-512</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sha-512" class="dfn-panel" data-for="sha-512" id="infopanel-for-sha-512" role="dialog">
+   <span id="infopaneltitle-for-sha-512" style="display:none">Info about the 'SHA-512' definition.</span><b><a href="#sha-512">#sha-512</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sha-512">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="runs-a-worker">
-   <b><a href="#runs-a-worker">#runs-a-worker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-runs-a-worker" class="dfn-panel" data-for="runs-a-worker" id="infopanel-for-runs-a-worker" role="dialog">
+   <span id="infopaneltitle-for-runs-a-worker" style="display:none">Info about the 'runs a worker' definition.</span><b><a href="#runs-a-worker">#runs-a-worker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-runs-a-worker">5.1. Workers</a>
     <li><a href="#ref-for-runs-a-worker①">7.14.1. Sandboxing and Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callable">
-   <b><a href="#callable">#callable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callable" class="dfn-panel" data-for="callable" id="infopanel-for-callable" role="dialog">
+   <span id="infopaneltitle-for-callable" style="display:none">Info about the 'callable' definition.</span><b><a href="#callable">#callable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callable">7.15. script-src</a> <a href="#ref-for-callable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy">
-   <b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy" class="dfn-panel" data-for="content-security-policy" id="infopanel-for-content-security-policy" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy" style="display:none">Info about the 'Content-Security-Policy' definition.</span><b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy">3.2. 
       Content-Security-Policy-Report-Only Header Field </a>
@@ -3986,8 +3986,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-content-security-policy⑤">11.1. Content-Security-Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy-report-only">
-   <b><a href="#content-security-policy-report-only">#content-security-policy-report-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy-report-only" class="dfn-panel" data-for="content-security-policy-report-only" id="infopanel-for-content-security-policy-report-only" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy-report-only" style="display:none">Info about the 'Content-Security-Policy-Report-Only' definition.</span><b><a href="#content-security-policy-report-only">#content-security-policy-report-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-report-only">3.2. 
       Content-Security-Policy-Report-Only Header Field </a>
@@ -3997,8 +3997,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-content-security-policy-report-only③">11.2. Content-Security-Policy-Report-Only</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-token">
-   <b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-token" class="dfn-panel" data-for="policy-token" id="infopanel-for-policy-token" role="dialog">
+   <span id="infopaneltitle-for-policy-token" style="display:none">Info about the 'policy-token' definition.</span><b><a href="#policy-token">#policy-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-token">3.1. 
       Content-Security-Policy Header Field </a>
@@ -4006,34 +4006,34 @@ Content-Security-Policy: style-src 'none'
       Content-Security-Policy-Report-Only Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-token">
-   <b><a href="#directive-token">#directive-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-token" class="dfn-panel" data-for="directive-token" id="infopanel-for-directive-token" role="dialog">
+   <span id="infopaneltitle-for-directive-token" style="display:none">Info about the 'directive-token' definition.</span><b><a href="#directive-token">#directive-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-token">4.1. Policy Syntax</a> <a href="#ref-for-directive-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-name">
-   <b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-name" class="dfn-panel" data-for="directive-name" id="infopanel-for-directive-name" role="dialog">
+   <span id="infopaneltitle-for-directive-name" style="display:none">Info about the 'directive-name' definition.</span><b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name">4.1. Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-value">
-   <b><a href="#directive-value">#directive-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-value" class="dfn-panel" data-for="directive-value" id="infopanel-for-directive-value" role="dialog">
+   <span id="infopaneltitle-for-directive-value" style="display:none">Info about the 'directive-value' definition.</span><b><a href="#directive-value">#directive-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value">4.1. Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-the-policy">
-   <b><a href="#parse-the-policy">#parse-the-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-the-policy" class="dfn-panel" data-for="parse-the-policy" id="infopanel-for-parse-the-policy" role="dialog">
+   <span id="infopaneltitle-for-parse-the-policy" style="display:none">Info about the 'parse the policy' definition.</span><b><a href="#parse-the-policy">#parse-the-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-the-policy">3.3. 
       HTML meta Element </a>
     <li><a href="#ref-for-parse-the-policy①">5. Processing Model</a> <a href="#ref-for-parse-the-policy②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-list①">
-   <b><a href="#source-list①">#source-list①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-list①" class="dfn-panel" data-for="source-list①" id="infopanel-for-source-list①" role="dialog">
+   <span id="infopaneltitle-for-source-list①" style="display:none">Info about the 'source-list' definition.</span><b><a href="#source-list①">#source-list①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-list①">7.1. base-uri</a>
     <li><a href="#ref-for-source-list①①">7.2. child-src</a>
@@ -4049,57 +4049,57 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-source-list①①①">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-expression①">
-   <b><a href="#source-expression①">#source-expression①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-expression①" class="dfn-panel" data-for="source-expression①" id="infopanel-for-source-expression①" role="dialog">
+   <span id="infopaneltitle-for-source-expression①" style="display:none">Info about the 'source-expression' definition.</span><b><a href="#source-expression①">#source-expression①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-expression①">4.2. Source List Syntax</a> <a href="#ref-for-source-expression①①">(2)</a>
     <li><a href="#ref-for-source-expression①②">4.2.1. Parsing Source Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-source">
-   <b><a href="#scheme-source">#scheme-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-source" class="dfn-panel" data-for="scheme-source" id="infopanel-for-scheme-source" role="dialog">
+   <span id="infopaneltitle-for-scheme-source" style="display:none">Info about the 'scheme-source' definition.</span><b><a href="#scheme-source">#scheme-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-source">4.2. Source List Syntax</a>
     <li><a href="#ref-for-scheme-source①">4.2.2. Matching Source Expressions</a>
     <li><a href="#ref-for-scheme-source②">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-source">
-   <b><a href="#host-source">#host-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-source" class="dfn-panel" data-for="host-source" id="infopanel-for-host-source" role="dialog">
+   <span id="infopaneltitle-for-host-source" style="display:none">Info about the 'host-source' definition.</span><b><a href="#host-source">#host-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-source">4.2. Source List Syntax</a>
     <li><a href="#ref-for-host-source①">4.2.2. Matching Source Expressions</a>
     <li><a href="#ref-for-host-source②">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keyword-source">
-   <b><a href="#keyword-source">#keyword-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keyword-source" class="dfn-panel" data-for="keyword-source" id="infopanel-for-keyword-source" role="dialog">
+   <span id="infopaneltitle-for-keyword-source" style="display:none">Info about the 'keyword-source' definition.</span><b><a href="#keyword-source">#keyword-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyword-source">4.2. Source List Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base64-value">
-   <b><a href="#base64-value">#base64-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base64-value" class="dfn-panel" data-for="base64-value" id="infopanel-for-base64-value" role="dialog">
+   <span id="infopaneltitle-for-base64-value" style="display:none">Info about the 'base64-value' definition.</span><b><a href="#base64-value">#base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base64-value">4.2. Source List Syntax</a> <a href="#ref-for-base64-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nonce-value">
-   <b><a href="#nonce-value">#nonce-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nonce-value" class="dfn-panel" data-for="nonce-value" id="infopanel-for-nonce-value" role="dialog">
+   <span id="infopaneltitle-for-nonce-value" style="display:none">Info about the 'nonce-value' definition.</span><b><a href="#nonce-value">#nonce-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nonce-value">4.2. Source List Syntax</a> <a href="#ref-for-nonce-value①">(2)</a> <a href="#ref-for-nonce-value②">(3)</a>
     <li><a href="#ref-for-nonce-value③">4.2.4. Valid Nonces</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hash-value">
-   <b><a href="#hash-value">#hash-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hash-value" class="dfn-panel" data-for="hash-value" id="infopanel-for-hash-value" role="dialog">
+   <span id="infopaneltitle-for-hash-value" style="display:none">Info about the 'hash-value' definition.</span><b><a href="#hash-value">#hash-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hash-value">4.2. Source List Syntax</a>
     <li><a href="#ref-for-hash-value①">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nonce-source">
-   <b><a href="#nonce-source">#nonce-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nonce-source" class="dfn-panel" data-for="nonce-source" id="infopanel-for-nonce-source" role="dialog">
+   <span id="infopaneltitle-for-nonce-source" style="display:none">Info about the 'nonce-source' definition.</span><b><a href="#nonce-source">#nonce-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nonce-source">4.2. Source List Syntax</a> <a href="#ref-for-nonce-source①">(2)</a>
     <li><a href="#ref-for-nonce-source②">4.2.4. Valid Nonces</a>
@@ -4107,15 +4107,15 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-nonce-source④">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hash-algo">
-   <b><a href="#hash-algo">#hash-algo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hash-algo" class="dfn-panel" data-for="hash-algo" id="infopanel-for-hash-algo" role="dialog">
+   <span id="infopaneltitle-for-hash-algo" style="display:none">Info about the 'hash-algo' definition.</span><b><a href="#hash-algo">#hash-algo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hash-algo">4.2. Source List Syntax</a>
     <li><a href="#ref-for-hash-algo①">4.2.5. Valid Hashes</a> <a href="#ref-for-hash-algo②">(2)</a> <a href="#ref-for-hash-algo③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hash-source">
-   <b><a href="#hash-source">#hash-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hash-source" class="dfn-panel" data-for="hash-source" id="infopanel-for-hash-source" role="dialog">
+   <span id="infopaneltitle-for-hash-source" style="display:none">Info about the 'hash-source' definition.</span><b><a href="#hash-source">#hash-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hash-source">4.2. Source List Syntax</a>
     <li><a href="#ref-for-hash-source①">4.2.5. Valid Hashes</a>
@@ -4123,42 +4123,42 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-hash-source③">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-part">
-   <b><a href="#scheme-part">#scheme-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-part" class="dfn-panel" data-for="scheme-part" id="infopanel-for-scheme-part" role="dialog">
+   <span id="infopaneltitle-for-scheme-part" style="display:none">Info about the 'scheme-part' definition.</span><b><a href="#scheme-part">#scheme-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-part">4.2. Source List Syntax</a> <a href="#ref-for-scheme-part①">(2)</a>
     <li><a href="#ref-for-scheme-part②">4.2.2. Matching Source Expressions</a> <a href="#ref-for-scheme-part③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-part">
-   <b><a href="#host-part">#host-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-part" class="dfn-panel" data-for="host-part" id="infopanel-for-host-part" role="dialog">
+   <span id="infopaneltitle-for-host-part" style="display:none">Info about the 'host-part' definition.</span><b><a href="#host-part">#host-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-part">4.2. Source List Syntax</a>
     <li><a href="#ref-for-host-part①">4.2.2. Matching Source Expressions</a> <a href="#ref-for-host-part②">(2)</a> <a href="#ref-for-host-part③">(3)</a> <a href="#ref-for-host-part④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-char">
-   <b><a href="#host-char">#host-char</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-char" class="dfn-panel" data-for="host-char" id="infopanel-for-host-char" role="dialog">
+   <span id="infopaneltitle-for-host-char" style="display:none">Info about the 'host-char' definition.</span><b><a href="#host-char">#host-char</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-char">4.2. Source List Syntax</a> <a href="#ref-for-host-char①">(2)</a> <a href="#ref-for-host-char②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-part">
-   <b><a href="#path-part">#path-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-part" class="dfn-panel" data-for="path-part" id="infopanel-for-path-part" role="dialog">
+   <span id="infopaneltitle-for-path-part" style="display:none">Info about the 'path-part' definition.</span><b><a href="#path-part">#path-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-part">4.2. Source List Syntax</a>
     <li><a href="#ref-for-path-part①">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="port-part">
-   <b><a href="#port-part">#port-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-port-part" class="dfn-panel" data-for="port-part" id="infopanel-for-port-part" role="dialog">
+   <span id="infopaneltitle-for-port-part" style="display:none">Info about the 'port-part' definition.</span><b><a href="#port-part">#port-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-port-part">4.2. Source List Syntax</a>
     <li><a href="#ref-for-port-part①">4.2.2. Matching Source Expressions</a> <a href="#ref-for-port-part②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-source-list">
-   <b><a href="#parse-a-source-list">#parse-a-source-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-source-list" class="dfn-panel" data-for="parse-a-source-list" id="infopanel-for-parse-a-source-list" role="dialog">
+   <span id="infopaneltitle-for-parse-a-source-list" style="display:none">Info about the 'parse a source list' definition.</span><b><a href="#parse-a-source-list">#parse-a-source-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-source-list">4.2.2. Matching Source Expressions</a>
     <li><a href="#ref-for-parse-a-source-list①">7.1. base-uri</a>
@@ -4176,14 +4176,14 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-parse-a-source-list①③">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-source-expression">
-   <b><a href="#match-a-source-expression">#match-a-source-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-source-expression" class="dfn-panel" data-for="match-a-source-expression" id="infopanel-for-match-a-source-expression" role="dialog">
+   <span id="infopaneltitle-for-match-a-source-expression" style="display:none">Info about the 'match a source expression' definition.</span><b><a href="#match-a-source-expression">#match-a-source-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-source-expression">4.2.2. Matching Source Expressions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-source-list">
-   <b><a href="#match-a-source-list">#match-a-source-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-source-list" class="dfn-panel" data-for="match-a-source-list" id="infopanel-for-match-a-source-list" role="dialog">
+   <span id="infopaneltitle-for-match-a-source-list" style="display:none">Info about the 'match a source list' definition.</span><b><a href="#match-a-source-list">#match-a-source-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-source-list">7.1. base-uri</a>
     <li><a href="#ref-for-match-a-source-list①">7.2.2. Workers</a>
@@ -4199,29 +4199,29 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-match-a-source-list①②">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlscriptelement-nonce">
-   <b><a href="#dom-htmlscriptelement-nonce">#dom-htmlscriptelement-nonce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlscriptelement-nonce" class="dfn-panel" data-for="dom-htmlscriptelement-nonce" id="infopanel-for-dom-htmlscriptelement-nonce" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlscriptelement-nonce" style="display:none">Info about the 'nonce' definition.</span><b><a href="#dom-htmlscriptelement-nonce">#dom-htmlscriptelement-nonce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlscriptelement-nonce">4.2.3. 
         The nonce attribute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-script-nonce">
-   <b><a href="#element-attrdef-script-nonce">#element-attrdef-script-nonce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-script-nonce" class="dfn-panel" data-for="element-attrdef-script-nonce" id="infopanel-for-element-attrdef-script-nonce" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-script-nonce" style="display:none">Info about the 'nonce' definition.</span><b><a href="#element-attrdef-script-nonce">#element-attrdef-script-nonce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-script-nonce">4.2.4. Valid Nonces</a>
     <li><a href="#ref-for-element-attrdef-script-nonce①">8.1. Sample Policy Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlstyleelement-nonce">
-   <b><a href="#dom-htmlstyleelement-nonce">#dom-htmlstyleelement-nonce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlstyleelement-nonce" class="dfn-panel" data-for="dom-htmlstyleelement-nonce" id="infopanel-for-dom-htmlstyleelement-nonce" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlstyleelement-nonce" style="display:none">Info about the 'nonce' definition.</span><b><a href="#dom-htmlstyleelement-nonce">#dom-htmlstyleelement-nonce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlstyleelement-nonce">4.2.3. 
         The nonce attribute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-nonce">
-   <b><a href="#valid-nonce">#valid-nonce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-nonce" class="dfn-panel" data-for="valid-nonce" id="infopanel-for-valid-nonce" role="dialog">
+   <span id="infopaneltitle-for-valid-nonce" style="display:none">Info about the 'valid nonce' definition.</span><b><a href="#valid-nonce">#valid-nonce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-nonce">7.15. script-src</a> <a href="#ref-for-valid-nonce①">(2)</a>
     <li><a href="#ref-for-valid-nonce②">7.15.1. 
@@ -4229,80 +4229,83 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-valid-nonce③">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elements-content">
-   <b><a href="#elements-content">#elements-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elements-content" class="dfn-panel" data-for="elements-content" id="infopanel-for-elements-content" role="dialog">
+   <span id="infopaneltitle-for-elements-content" style="display:none">Info about the 'element’s content' definition.</span><b><a href="#elements-content">#elements-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elements-content">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="digest-of-elements-content">
-   <b><a href="#digest-of-elements-content">#digest-of-elements-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-digest-of-elements-content" class="dfn-panel" data-for="digest-of-elements-content" id="infopanel-for-digest-of-elements-content" role="dialog">
+   <span id="infopaneltitle-for-digest-of-elements-content" style="display:none">Info about the 'digest of element’s content' definition.</span><b><a href="#digest-of-elements-content">#digest-of-elements-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-digest-of-elements-content">4.2.5. Valid Hashes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-hash">
-   <b><a href="#valid-hash">#valid-hash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-hash" class="dfn-panel" data-for="valid-hash" id="infopanel-for-valid-hash" role="dialog">
+   <span id="infopaneltitle-for-valid-hash" style="display:none">Info about the 'valid hash' definition.</span><b><a href="#valid-hash">#valid-hash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-hash">7.15. script-src</a>
     <li><a href="#ref-for-valid-hash①">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-type①">
-   <b><a href="#media-type①">#media-type①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-type①" class="dfn-panel" data-for="media-type①" id="infopanel-for-media-type①" role="dialog">
+   <span id="infopaneltitle-for-media-type①" style="display:none">Info about the 'media-type' definition.</span><b><a href="#media-type①">#media-type①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-type①">4.3. Media Type List Syntax</a> <a href="#ref-for-media-type①①">(2)</a>
     <li><a href="#ref-for-media-type①②">4.3.1. Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-media-type-list">
-   <b><a href="#parse-a-media-type-list">#parse-a-media-type-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-media-type-list" class="dfn-panel" data-for="parse-a-media-type-list" id="infopanel-for-parse-a-media-type-list" role="dialog">
+   <span id="infopaneltitle-for-parse-a-media-type-list" style="display:none">Info about the 'parse a media type list' definition.</span><b><a href="#parse-a-media-type-list">#parse-a-media-type-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-media-type-list">4.3.2. Matching</a>
     <li><a href="#ref-for-parse-a-media-type-list①">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-a-media-type-list">
-   <b><a href="#match-a-media-type-list">#match-a-media-type-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-a-media-type-list" class="dfn-panel" data-for="match-a-media-type-list" id="infopanel-for-match-a-media-type-list" role="dialog">
+   <span id="infopaneltitle-for-match-a-media-type-list" style="display:none">Info about the 'matches a media type
+      list' definition.</span><b><a href="#match-a-media-type-list">#match-a-media-type-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-media-type-list">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="strip-uri-for-reporting">
-   <b><a href="#strip-uri-for-reporting">#strip-uri-for-reporting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-strip-uri-for-reporting" class="dfn-panel" data-for="strip-uri-for-reporting" id="infopanel-for-strip-uri-for-reporting" role="dialog">
+   <span id="infopaneltitle-for-strip-uri-for-reporting" style="display:none">Info about the 'strip
+    uri for reporting' definition.</span><b><a href="#strip-uri-for-reporting">#strip-uri-for-reporting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-uri-for-reporting">4.4. Reporting</a> <a href="#ref-for-strip-uri-for-reporting①">(2)</a> <a href="#ref-for-strip-uri-for-reporting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate-a-violation-report-object">
-   <b><a href="#generate-a-violation-report-object">#generate-a-violation-report-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate-a-violation-report-object" class="dfn-panel" data-for="generate-a-violation-report-object" id="infopanel-for-generate-a-violation-report-object" role="dialog">
+   <span id="infopaneltitle-for-generate-a-violation-report-object" style="display:none">Info about the 'generate a violation report object' definition.</span><b><a href="#generate-a-violation-report-object">#generate-a-violation-report-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate-a-violation-report-object">4.4. Reporting</a>
     <li><a href="#ref-for-generate-a-violation-report-object①">6.3. Firing Violation Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-file">
-   <b><a href="#source-file">#source-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-file" class="dfn-panel" data-for="source-file" id="infopanel-for-source-file" role="dialog">
+   <span id="infopaneltitle-for-source-file" style="display:none">Info about the 'source-file' definition.</span><b><a href="#source-file">#source-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-file">4.4. Reporting</a> <a href="#ref-for-source-file①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="send-violation-reports">
-   <b><a href="#send-violation-reports">#send-violation-reports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-send-violation-reports" class="dfn-panel" data-for="send-violation-reports" id="infopanel-for-send-violation-reports" role="dialog">
+   <span id="infopaneltitle-for-send-violation-reports" style="display:none">Info about the 'send violation reports' definition.</span><b><a href="#send-violation-reports">#send-violation-reports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-send-violation-reports">3.2. 
       Content-Security-Policy-Report-Only Header Field </a>
     <li><a href="#ref-for-send-violation-reports①">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy-task-source">
-   <b><a href="#content-security-policy-task-source">#content-security-policy-task-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy-task-source" class="dfn-panel" data-for="content-security-policy-task-source" id="infopanel-for-content-security-policy-task-source" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy-task-source" style="display:none">Info about the 'Content Security Policy task
+          source' definition.</span><b><a href="#content-security-policy-task-source">#content-security-policy-task-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-task-source">6.3. Firing Violation Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-a-violation">
-   <b><a href="#report-a-violation">#report-a-violation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-a-violation" class="dfn-panel" data-for="report-a-violation" id="infopanel-for-report-a-violation" role="dialog">
+   <span id="infopaneltitle-for-report-a-violation" style="display:none">Info about the 'report a violation' definition.</span><b><a href="#report-a-violation">#report-a-violation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-a-violation">5. Processing Model</a>
     <li><a href="#ref-for-report-a-violation①">7.2.2. Workers</a>
@@ -4319,8 +4322,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-report-a-violation①⑤">7.16. style-src</a> <a href="#ref-for-report-a-violation①⑥">(2)</a> <a href="#ref-for-report-a-violation①⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enforce">
-   <b><a href="#enforce">#enforce</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enforce" class="dfn-panel" data-for="enforce" id="infopanel-for-enforce" role="dialog">
+   <span id="infopaneltitle-for-enforce" style="display:none">Info about the 'enforce' definition.</span><b><a href="#enforce">#enforce</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">3.1. 
       Content-Security-Policy Header Field </a>
@@ -4331,8 +4334,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-enforce⑦">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="monitor">
-   <b><a href="#monitor">#monitor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-monitor" class="dfn-panel" data-for="monitor" id="infopanel-for-monitor" role="dialog">
+   <span id="infopaneltitle-for-monitor" style="display:none">Info about the 'monitor' definition.</span><b><a href="#monitor">#monitor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">3.2. 
       Content-Security-Policy-Report-Only Header Field </a>
@@ -4345,206 +4348,206 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-monitor⑦">7.14. sandbox</a> <a href="#ref-for-monitor⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="securitypolicyviolationevent">
-   <b><a href="#securitypolicyviolationevent">#securitypolicyviolationevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-securitypolicyviolationevent" class="dfn-panel" data-for="securitypolicyviolationevent" id="infopanel-for-securitypolicyviolationevent" role="dialog">
+   <span id="infopaneltitle-for-securitypolicyviolationevent" style="display:none">Info about the 'SecurityPolicyViolationEvent' definition.</span><b><a href="#securitypolicyviolationevent">#securitypolicyviolationevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securitypolicyviolationevent">1.1. Changes from Level 1</a> <a href="#ref-for-securitypolicyviolationevent①">(2)</a>
     <li><a href="#ref-for-securitypolicyviolationevent②">6.3. Firing Violation Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturi">
-   <b><a href="#dom-securitypolicyviolationevent-documenturi">#dom-securitypolicyviolationevent-documenturi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-documenturi" class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturi" id="infopanel-for-dom-securitypolicyviolationevent-documenturi" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-documenturi" style="display:none">Info about the 'documentURI' definition.</span><b><a href="#dom-securitypolicyviolationevent-documenturi">#dom-securitypolicyviolationevent-documenturi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-documenturi">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-referrer">
-   <b><a href="#dom-securitypolicyviolationevent-referrer">#dom-securitypolicyviolationevent-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-referrer" class="dfn-panel" data-for="dom-securitypolicyviolationevent-referrer" id="infopanel-for-dom-securitypolicyviolationevent-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-securitypolicyviolationevent-referrer">#dom-securitypolicyviolationevent-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-referrer">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockeduri">
-   <b><a href="#dom-securitypolicyviolationevent-blockeduri">#dom-securitypolicyviolationevent-blockeduri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-blockeduri" class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockeduri" id="infopanel-for-dom-securitypolicyviolationevent-blockeduri" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-blockeduri" style="display:none">Info about the 'blockedURI' definition.</span><b><a href="#dom-securitypolicyviolationevent-blockeduri">#dom-securitypolicyviolationevent-blockeduri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-blockeduri">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-violateddirective">
-   <b><a href="#dom-securitypolicyviolationevent-violateddirective">#dom-securitypolicyviolationevent-violateddirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-violateddirective" class="dfn-panel" data-for="dom-securitypolicyviolationevent-violateddirective" id="infopanel-for-dom-securitypolicyviolationevent-violateddirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-violateddirective" style="display:none">Info about the 'violatedDirective' definition.</span><b><a href="#dom-securitypolicyviolationevent-violateddirective">#dom-securitypolicyviolationevent-violateddirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-violateddirective">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-effectivedirective">
-   <b><a href="#dom-securitypolicyviolationevent-effectivedirective">#dom-securitypolicyviolationevent-effectivedirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-effectivedirective" class="dfn-panel" data-for="dom-securitypolicyviolationevent-effectivedirective" id="infopanel-for-dom-securitypolicyviolationevent-effectivedirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-effectivedirective" style="display:none">Info about the 'effectiveDirective' definition.</span><b><a href="#dom-securitypolicyviolationevent-effectivedirective">#dom-securitypolicyviolationevent-effectivedirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-effectivedirective">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-effectivedirective①">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-originalpolicy">
-   <b><a href="#dom-securitypolicyviolationevent-originalpolicy">#dom-securitypolicyviolationevent-originalpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-originalpolicy" class="dfn-panel" data-for="dom-securitypolicyviolationevent-originalpolicy" id="infopanel-for-dom-securitypolicyviolationevent-originalpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-originalpolicy" style="display:none">Info about the 'originalPolicy' definition.</span><b><a href="#dom-securitypolicyviolationevent-originalpolicy">#dom-securitypolicyviolationevent-originalpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-originalpolicy">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-statuscode">
-   <b><a href="#dom-securitypolicyviolationevent-statuscode">#dom-securitypolicyviolationevent-statuscode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-statuscode" class="dfn-panel" data-for="dom-securitypolicyviolationevent-statuscode" id="infopanel-for-dom-securitypolicyviolationevent-statuscode" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-statuscode" style="display:none">Info about the 'statusCode' definition.</span><b><a href="#dom-securitypolicyviolationevent-statuscode">#dom-securitypolicyviolationevent-statuscode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-statuscode">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-statuscode①">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-sourcefile">
-   <b><a href="#dom-securitypolicyviolationevent-sourcefile">#dom-securitypolicyviolationevent-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-sourcefile" class="dfn-panel" data-for="dom-securitypolicyviolationevent-sourcefile" id="infopanel-for-dom-securitypolicyviolationevent-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#dom-securitypolicyviolationevent-sourcefile">#dom-securitypolicyviolationevent-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-sourcefile">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-sourcefile①">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-linenumber">
-   <b><a href="#dom-securitypolicyviolationevent-linenumber">#dom-securitypolicyviolationevent-linenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-linenumber" class="dfn-panel" data-for="dom-securitypolicyviolationevent-linenumber" id="infopanel-for-dom-securitypolicyviolationevent-linenumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-linenumber" style="display:none">Info about the 'lineNumber' definition.</span><b><a href="#dom-securitypolicyviolationevent-linenumber">#dom-securitypolicyviolationevent-linenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-linenumber">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-linenumber①">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-columnnumber">
-   <b><a href="#dom-securitypolicyviolationevent-columnnumber">#dom-securitypolicyviolationevent-columnnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-columnnumber" class="dfn-panel" data-for="dom-securitypolicyviolationevent-columnnumber" id="infopanel-for-dom-securitypolicyviolationevent-columnnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-columnnumber" style="display:none">Info about the 'columnNumber' definition.</span><b><a href="#dom-securitypolicyviolationevent-columnnumber">#dom-securitypolicyviolationevent-columnnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-columnnumber">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-columnnumber①">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-securitypolicyviolationeventinit">
-   <b><a href="#dictdef-securitypolicyviolationeventinit">#dictdef-securitypolicyviolationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-securitypolicyviolationeventinit" class="dfn-panel" data-for="dictdef-securitypolicyviolationeventinit" id="infopanel-for-dictdef-securitypolicyviolationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-securitypolicyviolationeventinit" style="display:none">Info about the 'SecurityPolicyViolationEventInit' definition.</span><b><a href="#dictdef-securitypolicyviolationeventinit">#dictdef-securitypolicyviolationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-securitypolicyviolationeventinit">6.1. 
       SecurityPolicyViolationEvent Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-documenturi">
-   <b><a href="#dom-securitypolicyviolationeventinit-documenturi">#dom-securitypolicyviolationeventinit-documenturi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-documenturi" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-documenturi" id="infopanel-for-dom-securitypolicyviolationeventinit-documenturi" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-documenturi" style="display:none">Info about the 'documentURI' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-documenturi">#dom-securitypolicyviolationeventinit-documenturi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-documenturi">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-referrer">
-   <b><a href="#dom-securitypolicyviolationeventinit-referrer">#dom-securitypolicyviolationeventinit-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-referrer" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-referrer" id="infopanel-for-dom-securitypolicyviolationeventinit-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-referrer">#dom-securitypolicyviolationeventinit-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-referrer">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-blockeduri">
-   <b><a href="#dom-securitypolicyviolationeventinit-blockeduri">#dom-securitypolicyviolationeventinit-blockeduri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-blockeduri" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-blockeduri" id="infopanel-for-dom-securitypolicyviolationeventinit-blockeduri" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-blockeduri" style="display:none">Info about the 'blockedURI' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-blockeduri">#dom-securitypolicyviolationeventinit-blockeduri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-blockeduri">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-violateddirective">
-   <b><a href="#dom-securitypolicyviolationeventinit-violateddirective">#dom-securitypolicyviolationeventinit-violateddirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-violateddirective" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-violateddirective" id="infopanel-for-dom-securitypolicyviolationeventinit-violateddirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-violateddirective" style="display:none">Info about the 'violatedDirective' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-violateddirective">#dom-securitypolicyviolationeventinit-violateddirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-violateddirective">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-effectivedirective">
-   <b><a href="#dom-securitypolicyviolationeventinit-effectivedirective">#dom-securitypolicyviolationeventinit-effectivedirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-effectivedirective" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-effectivedirective" id="infopanel-for-dom-securitypolicyviolationeventinit-effectivedirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-effectivedirective" style="display:none">Info about the 'effectiveDirective' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-effectivedirective">#dom-securitypolicyviolationeventinit-effectivedirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-effectivedirective">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-originalpolicy">
-   <b><a href="#dom-securitypolicyviolationeventinit-originalpolicy">#dom-securitypolicyviolationeventinit-originalpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-originalpolicy" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-originalpolicy" id="infopanel-for-dom-securitypolicyviolationeventinit-originalpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-originalpolicy" style="display:none">Info about the 'originalPolicy' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-originalpolicy">#dom-securitypolicyviolationeventinit-originalpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-originalpolicy">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-sourcefile">
-   <b><a href="#dom-securitypolicyviolationeventinit-sourcefile">#dom-securitypolicyviolationeventinit-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-sourcefile" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-sourcefile" id="infopanel-for-dom-securitypolicyviolationeventinit-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-sourcefile">#dom-securitypolicyviolationeventinit-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-sourcefile">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-linenumber">
-   <b><a href="#dom-securitypolicyviolationeventinit-linenumber">#dom-securitypolicyviolationeventinit-linenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-linenumber" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-linenumber" id="infopanel-for-dom-securitypolicyviolationeventinit-linenumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-linenumber" style="display:none">Info about the 'lineNumber' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-linenumber">#dom-securitypolicyviolationeventinit-linenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-linenumber">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-columnnumber">
-   <b><a href="#dom-securitypolicyviolationeventinit-columnnumber">#dom-securitypolicyviolationeventinit-columnnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationeventinit-columnnumber" class="dfn-panel" data-for="dom-securitypolicyviolationeventinit-columnnumber" id="infopanel-for-dom-securitypolicyviolationeventinit-columnnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationeventinit-columnnumber" style="display:none">Info about the 'columnNumber' definition.</span><b><a href="#dom-securitypolicyviolationeventinit-columnnumber">#dom-securitypolicyviolationeventinit-columnnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationeventinit-columnnumber">6.2. 
       SecurityPolicyViolationEventInit Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-violation-event">
-   <b><a href="#fire-a-violation-event">#fire-a-violation-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-violation-event" class="dfn-panel" data-for="fire-a-violation-event" id="infopanel-for-fire-a-violation-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-violation-event" style="display:none">Info about the 'fire a violation event' definition.</span><b><a href="#fire-a-violation-event">#fire-a-violation-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-violation-event">4.4. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-uri">
-   <b><a href="#base-uri">#base-uri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-uri" class="dfn-panel" data-for="base-uri" id="infopanel-for-base-uri" role="dialog">
+   <span id="infopaneltitle-for-base-uri" style="display:none">Info about the 'base-uri' definition.</span><b><a href="#base-uri">#base-uri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-uri">1.1. Changes from Level 1</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-base-urls">
-   <b><a href="#allowed-base-urls">#allowed-base-urls</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-base-urls" class="dfn-panel" data-for="allowed-base-urls" id="infopanel-for-allowed-base-urls" role="dialog">
+   <span id="infopaneltitle-for-allowed-base-urls" style="display:none">Info about the 'allowed base URLs' definition.</span><b><a href="#allowed-base-urls">#allowed-base-urls</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-base-urls">7.1. base-uri</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="child-src">
-   <b><a href="#child-src">#child-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-child-src" class="dfn-panel" data-for="child-src" id="infopanel-for-child-src" role="dialog">
+   <span id="infopaneltitle-for-child-src" style="display:none">Info about the 'child-src' definition.</span><b><a href="#child-src">#child-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-src">1.1. Changes from Level 1</a> <a href="#ref-for-child-src①">(2)</a>
     <li><a href="#ref-for-child-src②">7.4. default-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-child-sources">
-   <b><a href="#allowed-child-sources">#allowed-child-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-child-sources" class="dfn-panel" data-for="allowed-child-sources" id="infopanel-for-allowed-child-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-child-sources" style="display:none">Info about the 'allowed child sources' definition.</span><b><a href="#allowed-child-sources">#allowed-child-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-child-sources">7.2.2. Workers</a>
     <li><a href="#ref-for-allowed-child-sources①">7.8. frame-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connect-src">
-   <b><a href="#connect-src">#connect-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connect-src" class="dfn-panel" data-for="connect-src" id="infopanel-for-connect-src" role="dialog">
+   <span id="infopaneltitle-for-connect-src" style="display:none">Info about the 'connect-src' definition.</span><b><a href="#connect-src">#connect-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect-src">3.4. Enforcing multiple policies</a> <a href="#ref-for-connect-src①">(2)</a> <a href="#ref-for-connect-src②">(3)</a>
     <li><a href="#ref-for-connect-src③">7.3.1. Usage</a>
     <li><a href="#ref-for-connect-src④">7.4. default-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-connection-targets">
-   <b><a href="#allowed-connection-targets">#allowed-connection-targets</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-connection-targets" class="dfn-panel" data-for="allowed-connection-targets" id="infopanel-for-allowed-connection-targets" role="dialog">
+   <span id="infopaneltitle-for-allowed-connection-targets" style="display:none">Info about the 'allowed connection targets' definition.</span><b><a href="#allowed-connection-targets">#allowed-connection-targets</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-connection-targets">7.3. connect-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-src">
-   <b><a href="#default-src">#default-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-src" class="dfn-panel" data-for="default-src" id="infopanel-for-default-src" role="dialog">
+   <span id="infopaneltitle-for-default-src" style="display:none">Info about the 'default-src' definition.</span><b><a href="#default-src">#default-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-src">3.4. Enforcing multiple policies</a> <a href="#ref-for-default-src①">(2)</a>
     <li><a href="#ref-for-default-src②">4.2.2.1. 
@@ -4563,8 +4566,8 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-default-src①⑦">10. Implementation Considerations</a> <a href="#ref-for-default-src①⑧">(2)</a> <a href="#ref-for-default-src①⑨">(3)</a> <a href="#ref-for-default-src②⓪">(4)</a> <a href="#ref-for-default-src②①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-sources">
-   <b><a href="#default-sources">#default-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-sources" class="dfn-panel" data-for="default-sources" id="infopanel-for-default-sources" role="dialog">
+   <span id="infopaneltitle-for-default-sources" style="display:none">Info about the 'default sources' definition.</span><b><a href="#default-sources">#default-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-sources">4.4. Reporting</a>
     <li><a href="#ref-for-default-sources①">7.1. base-uri</a>
@@ -4581,33 +4584,33 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-default-sources①②">7.16. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-src">
-   <b><a href="#font-src">#font-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-src" class="dfn-panel" data-for="font-src" id="infopanel-for-font-src" role="dialog">
+   <span id="infopaneltitle-for-font-src" style="display:none">Info about the 'font-src' definition.</span><b><a href="#font-src">#font-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-src">7.4. default-src</a>
     <li><a href="#ref-for-font-src①">7.4.1. Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-font-sources">
-   <b><a href="#allowed-font-sources">#allowed-font-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-font-sources" class="dfn-panel" data-for="allowed-font-sources" id="infopanel-for-allowed-font-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-font-sources" style="display:none">Info about the 'allowed font sources' definition.</span><b><a href="#allowed-font-sources">#allowed-font-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-font-sources">7.5. font-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="form-action">
-   <b><a href="#form-action">#form-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-form-action" class="dfn-panel" data-for="form-action" id="infopanel-for-form-action" role="dialog">
+   <span id="infopaneltitle-for-form-action" style="display:none">Info about the 'form-action' definition.</span><b><a href="#form-action">#form-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-action">1.1. Changes from Level 1</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-form-actions">
-   <b><a href="#allowed-form-actions">#allowed-form-actions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-form-actions" class="dfn-panel" data-for="allowed-form-actions" id="infopanel-for-allowed-form-actions" role="dialog">
+   <span id="infopaneltitle-for-allowed-form-actions" style="display:none">Info about the 'allowed form actions' definition.</span><b><a href="#allowed-form-actions">#allowed-form-actions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-form-actions">7.6. form-action</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-ancestors">
-   <b><a href="#frame-ancestors">#frame-ancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-ancestors" class="dfn-panel" data-for="frame-ancestors" id="infopanel-for-frame-ancestors" role="dialog">
+   <span id="infopaneltitle-for-frame-ancestors" style="display:none">Info about the 'frame-ancestors' definition.</span><b><a href="#frame-ancestors">#frame-ancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-ancestors">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-frame-ancestors①">3.3. 
@@ -4619,64 +4622,64 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-frame-ancestors⑧">12. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ancestor-source-list">
-   <b><a href="#ancestor-source-list">#ancestor-source-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ancestor-source-list" class="dfn-panel" data-for="ancestor-source-list" id="infopanel-for-ancestor-source-list" role="dialog">
+   <span id="infopaneltitle-for-ancestor-source-list" style="display:none">Info about the 'ancestor-source-list' definition.</span><b><a href="#ancestor-source-list">#ancestor-source-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ancestor-source-list">7.7. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ancestor-source">
-   <b><a href="#ancestor-source">#ancestor-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ancestor-source" class="dfn-panel" data-for="ancestor-source" id="infopanel-for-ancestor-source" role="dialog">
+   <span id="infopaneltitle-for-ancestor-source" style="display:none">Info about the 'ancestor-source' definition.</span><b><a href="#ancestor-source">#ancestor-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ancestor-source">7.7. frame-ancestors</a> <a href="#ref-for-ancestor-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-frame-ancestors">
-   <b><a href="#allowed-frame-ancestors">#allowed-frame-ancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-frame-ancestors" class="dfn-panel" data-for="allowed-frame-ancestors" id="infopanel-for-allowed-frame-ancestors" role="dialog">
+   <span id="infopaneltitle-for-allowed-frame-ancestors" style="display:none">Info about the 'allowed frame ancestors' definition.</span><b><a href="#allowed-frame-ancestors">#allowed-frame-ancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-frame-ancestors">7.7. frame-ancestors</a> <a href="#ref-for-allowed-frame-ancestors①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-src">
-   <b><a href="#frame-src">#frame-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-src" class="dfn-panel" data-for="frame-src" id="infopanel-for-frame-src" role="dialog">
+   <span id="infopaneltitle-for-frame-src" style="display:none">Info about the 'frame-src' definition.</span><b><a href="#frame-src">#frame-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-src">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-frame-src①">7.2.1. Nested Browsing Contexts</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-frame-sources">
-   <b><a href="#allowed-frame-sources">#allowed-frame-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-frame-sources" class="dfn-panel" data-for="allowed-frame-sources" id="infopanel-for-allowed-frame-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-frame-sources" style="display:none">Info about the 'allowed frame sources' definition.</span><b><a href="#allowed-frame-sources">#allowed-frame-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-frame-sources">7.8. frame-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="img-src">
-   <b><a href="#img-src">#img-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-img-src" class="dfn-panel" data-for="img-src" id="infopanel-for-img-src" role="dialog">
+   <span id="infopaneltitle-for-img-src" style="display:none">Info about the 'img-src' definition.</span><b><a href="#img-src">#img-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-img-src">4.2.2.3. Paths and Redirects</a>
     <li><a href="#ref-for-img-src①">7.4. default-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-image-sources">
-   <b><a href="#allowed-image-sources">#allowed-image-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-image-sources" class="dfn-panel" data-for="allowed-image-sources" id="infopanel-for-allowed-image-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-image-sources" style="display:none">Info about the 'allowed image sources' definition.</span><b><a href="#allowed-image-sources">#allowed-image-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-image-sources">7.9. img-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-src">
-   <b><a href="#media-src">#media-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-src" class="dfn-panel" data-for="media-src" id="infopanel-for-media-src" role="dialog">
+   <span id="infopaneltitle-for-media-src" style="display:none">Info about the 'media-src' definition.</span><b><a href="#media-src">#media-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-src">7.4. default-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-media-sources">
-   <b><a href="#allowed-media-sources">#allowed-media-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-media-sources" class="dfn-panel" data-for="allowed-media-sources" id="infopanel-for-allowed-media-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-media-sources" style="display:none">Info about the 'allowed media sources' definition.</span><b><a href="#allowed-media-sources">#allowed-media-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-media-sources">7.10. media-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-src">
-   <b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-src" class="dfn-panel" data-for="object-src" id="infopanel-for-object-src" role="dialog">
+   <span id="infopaneltitle-for-object-src" style="display:none">Info about the 'object-src' definition.</span><b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">2.1. Terms defined by this specification</a> <a href="#ref-for-object-src①">(2)</a>
     <li><a href="#ref-for-object-src②">7. Directives</a>
@@ -4684,28 +4687,28 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-object-src④">8.1. Sample Policy Definitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-object-sources">
-   <b><a href="#allowed-object-sources">#allowed-object-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-object-sources" class="dfn-panel" data-for="allowed-object-sources" id="infopanel-for-allowed-object-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-object-sources" style="display:none">Info about the 'allowed object sources' definition.</span><b><a href="#allowed-object-sources">#allowed-object-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-object-sources">7.11. object-src</a> <a href="#ref-for-allowed-object-sources①">(2)</a> <a href="#ref-for-allowed-object-sources②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="plugin-types">
-   <b><a href="#plugin-types">#plugin-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-plugin-types" class="dfn-panel" data-for="plugin-types" id="infopanel-for-plugin-types" role="dialog">
+   <span id="infopaneltitle-for-plugin-types" style="display:none">Info about the 'plugin-types' definition.</span><b><a href="#plugin-types">#plugin-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plugin-types">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-plugin-types①">4.3. Media Type List Syntax</a>
     <li><a href="#ref-for-plugin-types②">7.12.1. Usage</a> <a href="#ref-for-plugin-types③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-plugin-media-types">
-   <b><a href="#allowed-plugin-media-types">#allowed-plugin-media-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-plugin-media-types" class="dfn-panel" data-for="allowed-plugin-media-types" id="infopanel-for-allowed-plugin-media-types" role="dialog">
+   <span id="infopaneltitle-for-allowed-plugin-media-types" style="display:none">Info about the 'allowed plugin media types' definition.</span><b><a href="#allowed-plugin-media-types">#allowed-plugin-media-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-plugin-media-types">7.12. plugin-types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-uri">
-   <b><a href="#report-uri">#report-uri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-uri" class="dfn-panel" data-for="report-uri" id="infopanel-for-report-uri" role="dialog">
+   <span id="infopaneltitle-for-report-uri" style="display:none">Info about the 'report-uri' definition.</span><b><a href="#report-uri">#report-uri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-uri">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-report-uri①">3.2. 
@@ -4715,20 +4718,20 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-report-uri④">8.2. Sample Violation Report</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uri-reference">
-   <b><a href="#uri-reference">#uri-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uri-reference" class="dfn-panel" data-for="uri-reference" id="infopanel-for-uri-reference" role="dialog">
+   <span id="infopaneltitle-for-uri-reference" style="display:none">Info about the 'uri-reference' definition.</span><b><a href="#uri-reference">#uri-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uri-reference">7.13. report-uri</a> <a href="#ref-for-uri-reference①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-of-report-urls">
-   <b><a href="#set-of-report-urls">#set-of-report-urls</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-of-report-urls" class="dfn-panel" data-for="set-of-report-urls" id="infopanel-for-set-of-report-urls" role="dialog">
+   <span id="infopaneltitle-for-set-of-report-urls" style="display:none">Info about the 'set of report URLs' definition.</span><b><a href="#set-of-report-urls">#set-of-report-urls</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-of-report-urls">4.4. Reporting</a> <a href="#ref-for-set-of-report-urls①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sandbox">
-   <b><a href="#sandbox">#sandbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sandbox" class="dfn-panel" data-for="sandbox" id="infopanel-for-sandbox" role="dialog">
+   <span id="infopaneltitle-for-sandbox" style="display:none">Info about the 'sandbox' definition.</span><b><a href="#sandbox">#sandbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-sandbox①">3.3. 
@@ -4737,14 +4740,14 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-sandbox④">7.14.2. Usage</a> <a href="#ref-for-sandbox⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sandbox-token">
-   <b><a href="#sandbox-token">#sandbox-token</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sandbox-token" class="dfn-panel" data-for="sandbox-token" id="infopanel-for-sandbox-token" role="dialog">
+   <span id="infopaneltitle-for-sandbox-token" style="display:none">Info about the 'sandbox-token' definition.</span><b><a href="#sandbox-token">#sandbox-token</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox-token">7.14. sandbox</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-src">
-   <b><a href="#script-src">#script-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-src" class="dfn-panel" data-for="script-src" id="infopanel-for-script-src" role="dialog">
+   <span id="infopaneltitle-for-script-src" style="display:none">Info about the 'script-src' definition.</span><b><a href="#script-src">#script-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src">1.1. Changes from Level 1</a>
     <li><a href="#ref-for-script-src①">2.1. Terms defined by this specification</a> <a href="#ref-for-script-src②">(2)</a>
@@ -4769,78 +4772,134 @@ Content-Security-Policy: style-src 'none'
     <li><a href="#ref-for-script-src②①">8.1. Sample Policy Definitions</a> <a href="#ref-for-script-src②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-script-sources">
-   <b><a href="#allowed-script-sources">#allowed-script-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-script-sources" class="dfn-panel" data-for="allowed-script-sources" id="infopanel-for-allowed-script-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-script-sources" style="display:none">Info about the 'allowed script sources' definition.</span><b><a href="#allowed-script-sources">#allowed-script-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-script-sources">7.15. script-src</a> <a href="#ref-for-allowed-script-sources①">(2)</a> <a href="#ref-for-allowed-script-sources②">(3)</a> <a href="#ref-for-allowed-script-sources③">(4)</a> <a href="#ref-for-allowed-script-sources④">(5)</a> <a href="#ref-for-allowed-script-sources⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-src">
-   <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-src" class="dfn-panel" data-for="style-src" id="infopanel-for-style-src" role="dialog">
+   <span id="infopaneltitle-for-style-src" style="display:none">Info about the 'style-src' definition.</span><b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src">7.4. default-src</a>
     <li><a href="#ref-for-style-src①">9.1. Cascading Style Sheet (CSS) Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowed-style-sources">
-   <b><a href="#allowed-style-sources">#allowed-style-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowed-style-sources" class="dfn-panel" data-for="allowed-style-sources" id="infopanel-for-allowed-style-sources" role="dialog">
+   <span id="infopaneltitle-for-allowed-style-sources" style="display:none">Info about the 'allowed style sources' definition.</span><b><a href="#allowed-style-sources">#allowed-style-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-style-sources">7.16. style-src</a> <a href="#ref-for-allowed-style-sources①">(2)</a> <a href="#ref-for-allowed-style-sources②">(3)</a> <a href="#ref-for-allowed-style-sources③">(4)</a> <a href="#ref-for-allowed-style-sources④">(5)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-csp/api/index.html
+++ b/tests/github/w3c/webappsec-csp/api/index.html
@@ -968,15 +968,15 @@ self.applySecurityPolicy(policy);
      <li><a href="#dom-sourceexpression-value">attribute for SourceExpression</a><span>, in § 1.5</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-policy-directive-set">
-   <a href="https://w3c.github.io/webappsec-csp/#policy-directive-set">https://w3c.github.io/webappsec-csp/#policy-directive-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-directive-set" class="dfn-panel" data-for="term-for-policy-directive-set" id="infopanel-for-term-for-policy-directive-set" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-directive-set" style="display:none">Info about the 'directive set' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#policy-directive-set">https://w3c.github.io/webappsec-csp/#policy-directive-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive-set">1.2. 
     SecurityPolicy Interface </a> <a href="#ref-for-policy-directive-set①">(2)</a> <a href="#ref-for-policy-directive-set②">(3)</a> <a href="#ref-for-policy-directive-set③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directives">
-   <a href="https://w3c.github.io/webappsec-csp/#directives">https://w3c.github.io/webappsec-csp/#directives</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directives" class="dfn-panel" data-for="term-for-directives" id="infopanel-for-term-for-directives" role="menu">
+   <span id="infopaneltitle-for-term-for-directives" style="display:none">Info about the 'directives' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directives">https://w3c.github.io/webappsec-csp/#directives</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directives">1.2. 
     SecurityPolicy Interface </a>
@@ -986,8 +986,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-name">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-name">https://w3c.github.io/webappsec-csp/#directive-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-name" class="dfn-panel" data-for="term-for-directive-name" id="infopanel-for-term-for-directive-name" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-name">https://w3c.github.io/webappsec-csp/#directive-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name">1.2. 
     SecurityPolicy Interface </a>
@@ -997,8 +997,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-violation-policy">
-   <a href="https://w3c.github.io/webappsec-csp/#violation-policy">https://w3c.github.io/webappsec-csp/#violation-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-violation-policy" class="dfn-panel" data-for="term-for-violation-policy" id="infopanel-for-term-for-violation-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-violation-policy" style="display:none">Info about the 'policy' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#violation-policy">https://w3c.github.io/webappsec-csp/#violation-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-policy">1.1. 
     Applying a Policy </a> <a href="#ref-for-violation-policy①">(2)</a>
@@ -1006,22 +1006,22 @@ self.applySecurityPolicy(policy);
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-source-expression">
-   <a href="https://w3c.github.io/webappsec-csp/#source-expression">https://w3c.github.io/webappsec-csp/#source-expression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-source-expression" class="dfn-panel" data-for="term-for-source-expression" id="infopanel-for-term-for-source-expression" role="menu">
+   <span id="infopaneltitle-for-term-for-source-expression" style="display:none">Info about the 'source expression' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#source-expression">https://w3c.github.io/webappsec-csp/#source-expression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-expression">1.5. 
     SourceExpression Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-source-lists">
-   <a href="https://w3c.github.io/webappsec-csp/#source-lists">https://w3c.github.io/webappsec-csp/#source-lists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-source-lists" class="dfn-panel" data-for="term-for-source-lists" id="infopanel-for-term-for-source-lists" role="menu">
+   <span id="infopaneltitle-for-term-for-source-lists" style="display:none">Info about the 'source lists' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#source-lists">https://w3c.github.io/webappsec-csp/#source-lists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-lists">1.4. 
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-value">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-value" class="dfn-panel" data-for="term-for-directive-value" id="infopanel-for-term-for-directive-value" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-value" style="display:none">Info about the 'value' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value">1.2. 
     SecurityPolicy Interface </a>
@@ -1031,8 +1031,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-node">
-   <a href="http://www.w3.org/TR/dom/#interface-node">http://www.w3.org/TR/dom/#interface-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-node" class="dfn-panel" data-for="term-for-interface-node" id="infopanel-for-term-for-interface-node" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-node" style="display:none">Info about the 'Node' external reference.</span><a href="http://www.w3.org/TR/dom/#interface-node">http://www.w3.org/TR/dom/#interface-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-node">1.2. 
     SecurityPolicy Interface </a>
@@ -1042,8 +1042,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-interface-node④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request">
-   <a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request" class="dfn-panel" data-for="term-for-request" id="infopanel-for-term-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-request" style="display:none">Info about the 'Request' external reference.</span><a href="https://fetch.spec.whatwg.org/#request">https://fetch.spec.whatwg.org/#request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">1.2. 
     SecurityPolicy Interface </a>
@@ -1051,36 +1051,36 @@ self.applySecurityPolicy(policy);
     SecurityPolicyDirective Interface </a> <a href="#ref-for-request②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">1.4. 
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">1.1. 
     Applying a Policy </a> <a href="#ref-for-window①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">1.1. 
     Applying a Policy </a> <a href="#ref-for-workerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="http://www.w3.org/TR/html5/dom.html#document">http://www.w3.org/TR/html5/dom.html#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="http://www.w3.org/TR/html5/dom.html#document">http://www.w3.org/TR/html5/dom.html#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">1.1. 
     Applying a Policy </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="http://www.w3.org/TR/html5/webappapis.html#settings-object">http://www.w3.org/TR/html5/webappapis.html#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="http://www.w3.org/TR/html5/webappapis.html#settings-object">http://www.w3.org/TR/html5/webappapis.html#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">1. 
     DOM API </a>
@@ -1088,8 +1088,8 @@ self.applySecurityPolicy(policy);
     Applying a Policy </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">1.2. 
     SecurityPolicy Interface </a>
@@ -1101,8 +1101,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-idl-DOMString⑥">(2)</a> <a href="#ref-for-idl-DOMString⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">1.2. 
     SecurityPolicy Interface </a>
@@ -1114,8 +1114,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">1.2. 
     SecurityPolicy Interface </a>
@@ -1123,8 +1123,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">1.2. 
     SecurityPolicy Interface </a>
@@ -1132,8 +1132,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-idl-USVString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">1.2. 
     SecurityPolicy Interface </a> <a href="#ref-for-idl-boolean①">(2)</a>
@@ -1143,8 +1143,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-idl-boolean⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">1.1. 
     Applying a Policy </a>
@@ -1292,29 +1292,29 @@ self.applySecurityPolicy(policy);
    <div class="issue"> Maybe this makes more sense as <code>window.csp.apply()</code>? Which would also
   allow <code>window.csp.enforced</code> and <code>window.csp.monitored</code> as sequences of <code class="idl"><a data-link-type="idl" href="#securitypolicy">SecurityPolicy</a></code> objects? <a class="issue-return" href="#issue-bb95a433" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="dom-window-applysecuritypolicy">
-   <b><a href="#dom-window-applysecuritypolicy">#dom-window-applysecuritypolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-applysecuritypolicy" class="dfn-panel" data-for="dom-window-applysecuritypolicy" id="infopanel-for-dom-window-applysecuritypolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-window-applysecuritypolicy" style="display:none">Info about the 'applySecurityPolicy(policy)' definition.</span><b><a href="#dom-window-applysecuritypolicy">#dom-window-applysecuritypolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-applysecuritypolicy">1.1. 
     Applying a Policy </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workerglobalscope-applysecuritypolicy">
-   <b><a href="#dom-workerglobalscope-applysecuritypolicy">#dom-workerglobalscope-applysecuritypolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workerglobalscope-applysecuritypolicy" class="dfn-panel" data-for="dom-workerglobalscope-applysecuritypolicy" id="infopanel-for-dom-workerglobalscope-applysecuritypolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-workerglobalscope-applysecuritypolicy" style="display:none">Info about the 'applySecurityPolicy(policy)' definition.</span><b><a href="#dom-workerglobalscope-applysecuritypolicy">#dom-workerglobalscope-applysecuritypolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workerglobalscope-applysecuritypolicy">1.1. 
     Applying a Policy </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-securitypolicytype">
-   <b><a href="#enumdef-securitypolicytype">#enumdef-securitypolicytype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-securitypolicytype" class="dfn-panel" data-for="enumdef-securitypolicytype" id="infopanel-for-enumdef-securitypolicytype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-securitypolicytype" style="display:none">Info about the 'SecurityPolicyType' definition.</span><b><a href="#enumdef-securitypolicytype">#enumdef-securitypolicytype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-securitypolicytype">1.2. 
     SecurityPolicy Interface </a> <a href="#ref-for-enumdef-securitypolicytype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="securitypolicy">
-   <b><a href="#securitypolicy">#securitypolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-securitypolicy" class="dfn-panel" data-for="securitypolicy" id="infopanel-for-securitypolicy" role="dialog">
+   <span id="infopaneltitle-for-securitypolicy" style="display:none">Info about the 'SecurityPolicy' definition.</span><b><a href="#securitypolicy">#securitypolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securitypolicy">1. 
     DOM API </a>
@@ -1324,50 +1324,50 @@ self.applySecurityPolicy(policy);
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-policy-slot">
-   <b><a href="#dom-securitypolicy-policy-slot">#dom-securitypolicy-policy-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-policy-slot" class="dfn-panel" data-for="dom-securitypolicy-policy-slot" id="infopanel-for-dom-securitypolicy-policy-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-policy-slot" style="display:none">Info about the '[[policy]]' definition.</span><b><a href="#dom-securitypolicy-policy-slot">#dom-securitypolicy-policy-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-policy-slot">1.2. 
     SecurityPolicy Interface </a> <a href="#ref-for-dom-securitypolicy-policy-slot①">(2)</a> <a href="#ref-for-dom-securitypolicy-policy-slot②">(3)</a> <a href="#ref-for-dom-securitypolicy-policy-slot③">(4)</a> <a href="#ref-for-dom-securitypolicy-policy-slot④">(5)</a> <a href="#ref-for-dom-securitypolicy-policy-slot⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-directives">
-   <b><a href="#dom-securitypolicy-directives">#dom-securitypolicy-directives</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-directives" class="dfn-panel" data-for="dom-securitypolicy-directives" id="infopanel-for-dom-securitypolicy-directives" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-directives" style="display:none">Info about the 'directives' definition.</span><b><a href="#dom-securitypolicy-directives">#dom-securitypolicy-directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-directives">1.2. 
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-type">
-   <b><a href="#dom-securitypolicy-type">#dom-securitypolicy-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-type" class="dfn-panel" data-for="dom-securitypolicy-type" id="infopanel-for-dom-securitypolicy-type" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-securitypolicy-type">#dom-securitypolicy-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-type">1.2. 
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-reportingendpoint">
-   <b><a href="#dom-securitypolicy-reportingendpoint">#dom-securitypolicy-reportingendpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-reportingendpoint" class="dfn-panel" data-for="dom-securitypolicy-reportingendpoint" id="infopanel-for-dom-securitypolicy-reportingendpoint" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-reportingendpoint" style="display:none">Info about the 'reportingEndpoint' definition.</span><b><a href="#dom-securitypolicy-reportingendpoint">#dom-securitypolicy-reportingendpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-reportingendpoint">1.2. 
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-requestmatches">
-   <b><a href="#dom-securitypolicy-requestmatches">#dom-securitypolicy-requestmatches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-requestmatches" class="dfn-panel" data-for="dom-securitypolicy-requestmatches" id="infopanel-for-dom-securitypolicy-requestmatches" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-requestmatches" style="display:none">Info about the 'requestMatches(request)' definition.</span><b><a href="#dom-securitypolicy-requestmatches">#dom-securitypolicy-requestmatches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-requestmatches">1.2. 
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicy-nodematches">
-   <b><a href="#dom-securitypolicy-nodematches">#dom-securitypolicy-nodematches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicy-nodematches" class="dfn-panel" data-for="dom-securitypolicy-nodematches" id="infopanel-for-dom-securitypolicy-nodematches" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicy-nodematches" style="display:none">Info about the 'nodeMatches(node)' definition.</span><b><a href="#dom-securitypolicy-nodematches">#dom-securitypolicy-nodematches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicy-nodematches">1.2. 
     SecurityPolicy Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-directivename">
-   <b><a href="#enumdef-directivename">#enumdef-directivename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-directivename" class="dfn-panel" data-for="enumdef-directivename" id="infopanel-for-enumdef-directivename" role="dialog">
+   <span id="infopaneltitle-for-enumdef-directivename" style="display:none">Info about the 'DirectiveName' definition.</span><b><a href="#enumdef-directivename">#enumdef-directivename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-directivename">1.3. 
     SecurityPolicyDirective Interface </a> <a href="#ref-for-enumdef-directivename①">(2)</a>
@@ -1375,8 +1375,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="securitypolicydirective">
-   <b><a href="#securitypolicydirective">#securitypolicydirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-securitypolicydirective" class="dfn-panel" data-for="securitypolicydirective" id="infopanel-for-securitypolicydirective" role="dialog">
+   <span id="infopaneltitle-for-securitypolicydirective" style="display:none">Info about the 'SecurityPolicyDirective' definition.</span><b><a href="#securitypolicydirective">#securitypolicydirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securitypolicydirective">1.2. 
     SecurityPolicy Interface </a> <a href="#ref-for-securitypolicydirective①">(2)</a>
@@ -1386,8 +1386,8 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a> <a href="#ref-for-securitypolicydirective⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicydirective-directive-slot">
-   <b><a href="#dom-securitypolicydirective-directive-slot">#dom-securitypolicydirective-directive-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicydirective-directive-slot" class="dfn-panel" data-for="dom-securitypolicydirective-directive-slot" id="infopanel-for-dom-securitypolicydirective-directive-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicydirective-directive-slot" style="display:none">Info about the '[[directive]]' definition.</span><b><a href="#dom-securitypolicydirective-directive-slot">#dom-securitypolicydirective-directive-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicydirective-directive-slot">1.3. 
     SecurityPolicyDirective Interface </a> <a href="#ref-for-dom-securitypolicydirective-directive-slot①">(2)</a> <a href="#ref-for-dom-securitypolicydirective-directive-slot②">(3)</a>
@@ -1395,29 +1395,29 @@ self.applySecurityPolicy(policy);
     SourceListDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicydirective-name">
-   <b><a href="#dom-securitypolicydirective-name">#dom-securitypolicydirective-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicydirective-name" class="dfn-panel" data-for="dom-securitypolicydirective-name" id="infopanel-for-dom-securitypolicydirective-name" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicydirective-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-securitypolicydirective-name">#dom-securitypolicydirective-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicydirective-name">1.3. 
     SecurityPolicyDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicydirective-requestmatches">
-   <b><a href="#dom-securitypolicydirective-requestmatches">#dom-securitypolicydirective-requestmatches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicydirective-requestmatches" class="dfn-panel" data-for="dom-securitypolicydirective-requestmatches" id="infopanel-for-dom-securitypolicydirective-requestmatches" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicydirective-requestmatches" style="display:none">Info about the 'requestMatches(request)' definition.</span><b><a href="#dom-securitypolicydirective-requestmatches">#dom-securitypolicydirective-requestmatches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicydirective-requestmatches">1.3. 
     SecurityPolicyDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicydirective-nodematches">
-   <b><a href="#dom-securitypolicydirective-nodematches">#dom-securitypolicydirective-nodematches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicydirective-nodematches" class="dfn-panel" data-for="dom-securitypolicydirective-nodematches" id="infopanel-for-dom-securitypolicydirective-nodematches" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicydirective-nodematches" style="display:none">Info about the 'nodeMatches(node)' definition.</span><b><a href="#dom-securitypolicydirective-nodematches">#dom-securitypolicydirective-nodematches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicydirective-nodematches">1.3. 
     SecurityPolicyDirective Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sourcelistdirective">
-   <b><a href="#sourcelistdirective">#sourcelistdirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sourcelistdirective" class="dfn-panel" data-for="sourcelistdirective" id="infopanel-for-sourcelistdirective" role="dialog">
+   <span id="infopaneltitle-for-sourcelistdirective" style="display:none">Info about the 'SourceListDirective' definition.</span><b><a href="#sourcelistdirective">#sourcelistdirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sourcelistdirective">1.3. 
     SecurityPolicyDirective Interface </a>
@@ -1427,8 +1427,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourcelistdirective-sources">
-   <b><a href="#dom-sourcelistdirective-sources">#dom-sourcelistdirective-sources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourcelistdirective-sources" class="dfn-panel" data-for="dom-sourcelistdirective-sources" id="infopanel-for-dom-sourcelistdirective-sources" role="dialog">
+   <span id="infopaneltitle-for-dom-sourcelistdirective-sources" style="display:none">Info about the 'sources' definition.</span><b><a href="#dom-sourcelistdirective-sources">#dom-sourcelistdirective-sources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourcelistdirective-sources">1.4. 
     SourceListDirective Interface </a> <a href="#ref-for-dom-sourcelistdirective-sources①">(2)</a> <a href="#ref-for-dom-sourcelistdirective-sources②">(3)</a>
@@ -1436,8 +1436,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sourceexpression">
-   <b><a href="#sourceexpression">#sourceexpression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sourceexpression" class="dfn-panel" data-for="sourceexpression" id="infopanel-for-sourceexpression" role="dialog">
+   <span id="infopaneltitle-for-sourceexpression" style="display:none">Info about the 'SourceExpression' definition.</span><b><a href="#sourceexpression">#sourceexpression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sourceexpression">1.4. 
     SourceListDirective Interface </a>
@@ -1445,15 +1445,15 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-sourceexpression②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourceexpression-value">
-   <b><a href="#dom-sourceexpression-value">#dom-sourceexpression-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourceexpression-value" class="dfn-panel" data-for="dom-sourceexpression-value" id="infopanel-for-dom-sourceexpression-value" role="dialog">
+   <span id="infopaneltitle-for-dom-sourceexpression-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-sourceexpression-value">#dom-sourceexpression-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourceexpression-value">1.5. 
     SourceExpression Interface </a> <a href="#ref-for-dom-sourceexpression-value①">(2)</a> <a href="#ref-for-dom-sourceexpression-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourceexpression-urlmatches">
-   <b><a href="#dom-sourceexpression-urlmatches">#dom-sourceexpression-urlmatches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourceexpression-urlmatches" class="dfn-panel" data-for="dom-sourceexpression-urlmatches" id="infopanel-for-dom-sourceexpression-urlmatches" role="dialog">
+   <span id="infopaneltitle-for-dom-sourceexpression-urlmatches" style="display:none">Info about the 'urlMatches(url)' definition.</span><b><a href="#dom-sourceexpression-urlmatches">#dom-sourceexpression-urlmatches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourceexpression-urlmatches">1.4. 
     SourceListDirective Interface </a>
@@ -1461,15 +1461,15 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-dom-sourceexpression-urlmatches②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourceexpression-urlmatches-url-url">
-   <b><a href="#dom-sourceexpression-urlmatches-url-url">#dom-sourceexpression-urlmatches-url-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourceexpression-urlmatches-url-url" class="dfn-panel" data-for="dom-sourceexpression-urlmatches-url-url" id="infopanel-for-dom-sourceexpression-urlmatches-url-url" role="dialog">
+   <span id="infopaneltitle-for-dom-sourceexpression-urlmatches-url-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-sourceexpression-urlmatches-url-url">#dom-sourceexpression-urlmatches-url-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourceexpression-urlmatches-url-url">1.5. 
     SourceExpression Interface </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourceexpression-nodematches">
-   <b><a href="#dom-sourceexpression-nodematches">#dom-sourceexpression-nodematches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourceexpression-nodematches" class="dfn-panel" data-for="dom-sourceexpression-nodematches" id="infopanel-for-dom-sourceexpression-nodematches" role="dialog">
+   <span id="infopaneltitle-for-dom-sourceexpression-nodematches" style="display:none">Info about the 'nodeMatches(node)' definition.</span><b><a href="#dom-sourceexpression-nodematches">#dom-sourceexpression-nodematches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourceexpression-nodematches">1.4. 
     SourceListDirective Interface </a>
@@ -1477,8 +1477,8 @@ self.applySecurityPolicy(policy);
     SourceExpression Interface </a> <a href="#ref-for-dom-sourceexpression-nodematches②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sourceexpression-nodematches-node-node">
-   <b><a href="#dom-sourceexpression-nodematches-node-node">#dom-sourceexpression-nodematches-node-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sourceexpression-nodematches-node-node" class="dfn-panel" data-for="dom-sourceexpression-nodematches-node-node" id="infopanel-for-dom-sourceexpression-nodematches-node-node" role="dialog">
+   <span id="infopaneltitle-for-dom-sourceexpression-nodematches-node-node" style="display:none">Info about the 'node' definition.</span><b><a href="#dom-sourceexpression-nodematches-node-node">#dom-sourceexpression-nodematches-node-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sourceexpression-nodematches-node-node">1.5. 
     SourceExpression Interface </a>
@@ -1486,57 +1486,113 @@ self.applySecurityPolicy(policy);
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-csp/cookies/index.html
+++ b/tests/github/w3c/webappsec-csp/cookies/index.html
@@ -502,107 +502,107 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
    <li><a href="#grammardef-scoping-rules">scoping-rules</a><span>, in § 2</span>
    <li><a href="#grammardef-secure">secure</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-content_security_policy">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#content_security_policy">https://mikewest.github.io/webappsec/specs/content-security-policy/#content_security_policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content_security_policy" class="dfn-panel" data-for="term-for-content_security_policy" id="infopanel-for-term-for-content_security_policy" role="menu">
+   <span id="infopaneltitle-for-term-for-content_security_policy" style="display:none">Info about the 'content-security-policy' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#content_security_policy">https://mikewest.github.io/webappsec/specs/content-security-policy/#content_security_policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content_security_policy">1.1. Examples</a> <a href="#ref-for-content_security_policy①">(2)</a> <a href="#ref-for-content_security_policy②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#directive">https://mikewest.github.io/webappsec/specs/content-security-policy/#directive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive" class="dfn-panel" data-for="term-for-directive" id="infopanel-for-term-for-directive" role="menu">
+   <span id="infopaneltitle-for-term-for-directive" style="display:none">Info about the 'directive' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#directive">https://mikewest.github.io/webappsec/specs/content-security-policy/#directive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive">2. The cookie-scope directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enforced-content-security-policies">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#enforced-content-security-policies">https://mikewest.github.io/webappsec/specs/content-security-policy/#enforced-content-security-policies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforced-content-security-policies" class="dfn-panel" data-for="term-for-enforced-content-security-policies" id="infopanel-for-term-for-enforced-content-security-policies" role="menu">
+   <span id="infopaneltitle-for-term-for-enforced-content-security-policies" style="display:none">Info about the 'enforced content security policies' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#enforced-content-security-policies">https://mikewest.github.io/webappsec/specs/content-security-policy/#enforced-content-security-policies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforced-content-security-policies">3.1. 
     Is cookie blocked for settings? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitored-content-security-policies">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#monitored-content-security-policies">https://mikewest.github.io/webappsec/specs/content-security-policy/#monitored-content-security-policies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitored-content-security-policies" class="dfn-panel" data-for="term-for-monitored-content-security-policies" id="infopanel-for-term-for-monitored-content-security-policies" role="menu">
+   <span id="infopaneltitle-for-term-for-monitored-content-security-policies" style="display:none">Info about the 'monitored content security policies' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#monitored-content-security-policies">https://mikewest.github.io/webappsec/specs/content-security-policy/#monitored-content-security-policies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitored-content-security-policies">3.1. 
     Is cookie blocked for settings? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-protected-resource">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#protected-resource">https://mikewest.github.io/webappsec/specs/content-security-policy/#protected-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-protected-resource" class="dfn-panel" data-for="term-for-protected-resource" id="infopanel-for-term-for-protected-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-protected-resource" style="display:none">Info about the 'protected resource' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#protected-resource">https://mikewest.github.io/webappsec/specs/content-security-policy/#protected-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-protected-resource">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-a-violation">
-   <a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#report-a-violation">https://mikewest.github.io/webappsec/specs/content-security-policy/#report-a-violation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-a-violation" class="dfn-panel" data-for="term-for-report-a-violation" id="infopanel-for-term-for-report-a-violation" role="menu">
+   <span id="infopaneltitle-for-term-for-report-a-violation" style="display:none">Info about the 'report a violation' external reference.</span><a href="https://mikewest.github.io/webappsec/specs/content-security-policy/#report-a-violation">https://mikewest.github.io/webappsec/specs/content-security-policy/#report-a-violation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-a-violation">3.1. 
     Is cookie blocked for settings? </a> <a href="#ref-for-report-a-violation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="http://www.w3.org/TR/html5/webappapis.html#settings-object">http://www.w3.org/TR/html5/webappapis.html#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="http://www.w3.org/TR/html5/webappapis.html#settings-object">http://www.w3.org/TR/html5/webappapis.html#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">3.1. 
     Is cookie blocked for settings? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-incumbent-settings-object">
-   <a href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-incumbent-settings-object" class="dfn-panel" data-for="term-for-incumbent-settings-object" id="infopanel-for-term-for-incumbent-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-incumbent-settings-object" style="display:none">Info about the 'incumbent settings object' external reference.</span><a href="http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object">http://www.w3.org/TR/html5/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incumbent-settings-object">2.1. Processing Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-a-string-on-spaces">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#split-a-string-on-spaces">http://www.w3.org/TR/html5/infrastructure.html#split-a-string-on-spaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-a-string-on-spaces" class="dfn-panel" data-for="term-for-split-a-string-on-spaces" id="infopanel-for-term-for-split-a-string-on-spaces" role="menu">
+   <span id="infopaneltitle-for-term-for-split-a-string-on-spaces" style="display:none">Info about the 'split a string on spaces' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#split-a-string-on-spaces">http://www.w3.org/TR/html5/infrastructure.html#split-a-string-on-spaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-a-string-on-spaces">3.3. 
     Parse string as a cookie-scope value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-whitespace">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-whitespace" style="display:none">Info about the 'strip leading and trailing whitespace' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace">http://www.w3.org/TR/html5/infrastructure.html#strip-leading-and-trailing-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-whitespace">3.3. 
     Parse string as a cookie-scope value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-1">
-   <a href="https://tools.ietf.org/html/rfc6265#section-1">https://tools.ietf.org/html/rfc6265#section-1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-1" class="dfn-panel" data-for="term-for-section-1" id="infopanel-for-term-for-section-1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-1" style="display:none">Info about the 'cookie' external reference.</span><a href="https://tools.ietf.org/html/rfc6265#section-1">https://tools.ietf.org/html/rfc6265#section-1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-1">2. The cookie-scope directive</a>
     <li><a href="#ref-for-section-1①">3.1. 
     Is cookie blocked for settings? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.3">
-   <a href="https://tools.ietf.org/html/rfc6265#section-5.3">https://tools.ietf.org/html/rfc6265#section-5.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.3" class="dfn-panel" data-for="term-for-section-5.3" id="infopanel-for-term-for-section-5.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.3" style="display:none">Info about the 'cookie store' external reference.</span><a href="https://tools.ietf.org/html/rfc6265#section-5.3">https://tools.ietf.org/html/rfc6265#section-5.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-section-5.3">2.1. Processing Model</a> <a href="#ref-for-section-5.3">(2)</a>
     <li><a href="#ref-for-section-5.3①">4.1. Existing Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'origin' external reference.</span><a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.3" class="dfn-panel" data-for="term-for-section-3.2.3" id="infopanel-for-term-for-section-3.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.3" style="display:none">Info about the 'rws' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.3">2. The cookie-scope directive</a> <a href="#ref-for-section-3.2.3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="http://www.w3.org/TR/url/#concept-url-port">http://www.w3.org/TR/url/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-port">http://www.w3.org/TR/url/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="http://www.w3.org/TR/url/#concept-url-scheme">http://www.w3.org/TR/url/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="http://www.w3.org/TR/url/#concept-url-scheme">http://www.w3.org/TR/url/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">1. Introduction</a>
    </ul>
@@ -683,8 +683,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
    <div class="issue"> We’ll need a mechanism to restrict reading from <code>document.cookie</code>, but I’d like something less specific than <code>cookie-scope disable-dom-access</code> or something similar. The linked GitHub bug is a proposal
   that’s a bit more general and widely applicable. <a href="https://github.com/w3c/webappsec-csp/issues/42">[Issue #w3c/webappsec-csp#42]</a> <a class="issue-return" href="#issue-324fe3fa" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="cookie-scope">
-   <b><a href="#cookie-scope">#cookie-scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cookie-scope" class="dfn-panel" data-for="cookie-scope" id="infopanel-for-cookie-scope" role="dialog">
+   <span id="infopaneltitle-for-cookie-scope" style="display:none">Info about the 'cookie-scope' definition.</span><b><a href="#cookie-scope">#cookie-scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-scope">1.1. Examples</a> <a href="#ref-for-cookie-scope①">(2)</a> <a href="#ref-for-cookie-scope②">(3)</a>
     <li><a href="#ref-for-cookie-scope③">3.2. 
@@ -693,16 +693,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
     Parse string as a cookie-scope value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-scoping-rules">
-   <b><a href="#grammardef-scoping-rules">#grammardef-scoping-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-scoping-rules" class="dfn-panel" data-for="grammardef-scoping-rules" id="infopanel-for-grammardef-scoping-rules" role="dialog">
+   <span id="infopaneltitle-for-grammardef-scoping-rules" style="display:none">Info about the 'scoping-rules' definition.</span><b><a href="#grammardef-scoping-rules">#grammardef-scoping-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-scoping-rules">2. The cookie-scope directive</a> <a href="#ref-for-grammardef-scoping-rules①">(2)</a>
     <li><a href="#ref-for-grammardef-scoping-rules②">3.3. 
     Parse string as a cookie-scope value </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-host">
-   <b><a href="#grammardef-host">#grammardef-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-host" class="dfn-panel" data-for="grammardef-host" id="infopanel-for-grammardef-host" role="dialog">
+   <span id="infopaneltitle-for-grammardef-host" style="display:none">Info about the 'host' definition.</span><b><a href="#grammardef-host">#grammardef-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host">1.1. Examples</a> <a href="#ref-for-grammardef-host①">(2)</a> <a href="#ref-for-grammardef-host②">(3)</a>
     <li><a href="#ref-for-grammardef-host③">2. The cookie-scope directive</a> <a href="#ref-for-grammardef-host④">(2)</a>
@@ -710,16 +710,16 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
     Does cookie violate policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-http">
-   <b><a href="#grammardef-http">#grammardef-http</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-http" class="dfn-panel" data-for="grammardef-http" id="infopanel-for-grammardef-http" role="dialog">
+   <span id="infopaneltitle-for-grammardef-http" style="display:none">Info about the 'http' definition.</span><b><a href="#grammardef-http">#grammardef-http</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-http">2. The cookie-scope directive</a>
     <li><a href="#ref-for-grammardef-http①">3.2. 
     Does cookie violate policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-none">
-   <b><a href="#grammardef-none">#grammardef-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-none" class="dfn-panel" data-for="grammardef-none" id="infopanel-for-grammardef-none" role="dialog">
+   <span id="infopaneltitle-for-grammardef-none" style="display:none">Info about the 'none' definition.</span><b><a href="#grammardef-none">#grammardef-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-none">1.1. Examples</a>
     <li><a href="#ref-for-grammardef-none①">2. The cookie-scope directive</a> <a href="#ref-for-grammardef-none②">(2)</a>
@@ -727,8 +727,8 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
     Does cookie violate policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-secure">
-   <b><a href="#grammardef-secure">#grammardef-secure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-secure" class="dfn-panel" data-for="grammardef-secure" id="infopanel-for-grammardef-secure" role="dialog">
+   <span id="infopaneltitle-for-grammardef-secure" style="display:none">Info about the 'secure' definition.</span><b><a href="#grammardef-secure">#grammardef-secure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-secure">1.1. Examples</a>
     <li><a href="#ref-for-grammardef-secure①">2. The cookie-scope directive</a> <a href="#ref-for-grammardef-secure②">(2)</a>
@@ -738,57 +738,113 @@ directive-value = <a data-link-type="grammar" href="#grammardef-scoping-rules" i
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-csp/document/index.html
+++ b/tests/github/w3c/webappsec-csp/document/index.html
@@ -650,63 +650,63 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   <ul class="index">
    <li><a href="#disable">disable</a><span>, in § 2.1.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-base-uri">
-   <a href="https://w3c.github.io/webappsec-csp/#base-uri">https://w3c.github.io/webappsec-csp/#base-uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-base-uri" class="dfn-panel" data-for="term-for-base-uri" id="infopanel-for-term-for-base-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-base-uri" style="display:none">Info about the 'base-uri' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#base-uri">https://w3c.github.io/webappsec-csp/#base-uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-uri">6. IANA Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-form-action">
-   <a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-form-action" class="dfn-panel" data-for="term-for-form-action" id="infopanel-for-term-for-form-action" role="menu">
+   <span id="infopaneltitle-for-term-for-form-action" style="display:none">Info about the 'form-action' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-action">6. IANA Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame-ancestors">
-   <a href="https://w3c.github.io/webappsec-csp/#frame-ancestors">https://w3c.github.io/webappsec-csp/#frame-ancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame-ancestors" class="dfn-panel" data-for="term-for-frame-ancestors" id="infopanel-for-term-for-frame-ancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-frame-ancestors" style="display:none">Info about the 'frame-ancestors' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#frame-ancestors">https://w3c.github.io/webappsec-csp/#frame-ancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-ancestors">5.1. Ancestor Origin Leakage</a>
     <li><a href="#ref-for-frame-ancestors①">6. IANA Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandbox">
-   <a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandbox" class="dfn-panel" data-for="term-for-sandbox" id="infopanel-for-term-for-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">6. IANA Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">2.1.1. disable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-base-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-base-element" class="dfn-panel" data-for="term-for-the-base-element" id="infopanel-for-term-for-the-base-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-base-element" style="display:none">Info about the 'base' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-base-element">3.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-base-href">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-base-href" class="dfn-panel" data-for="term-for-attr-base-href" id="infopanel-for-term-for-attr-base-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-base-href" style="display:none">Info about the 'href' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-base-href">3.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-frozen-base-url">
-   <a href="https://html.spec.whatwg.org/#set-the-frozen-base-url">https://html.spec.whatwg.org/#set-the-frozen-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-frozen-base-url" class="dfn-panel" data-for="term-for-set-the-frozen-base-url" id="infopanel-for-term-for-set-the-frozen-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-frozen-base-url" style="display:none">Info about the 'set the frozen base url' external reference.</span><a href="https://html.spec.whatwg.org/#set-the-frozen-base-url">https://html.spec.whatwg.org/#set-the-frozen-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-frozen-base-url">3.1. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.3" class="dfn-panel" data-for="term-for-section-3.2.3" id="infopanel-for-term-for-section-3.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.3" style="display:none">Info about the 'rws' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.3">2.1.1. disable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6" style="display:none">Info about the 'token' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">2.1.1. disable</a> <a href="#ref-for-section-3.2.6①">(2)</a>
    </ul>
@@ -770,57 +770,113 @@ directive-value = <a data-link-type="grammar" href="https://tools.ietf.org/html/
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-csp/index.html
+++ b/tests/github/w3c/webappsec-csp/index.html
@@ -4830,38 +4830,38 @@ rest of Google’s CSP Cabal.</p>
    <li><a href="#violation">violation</a><span>, in § 2.4</span>
    <li><a href="#worker-src">worker-src</a><span>, in § 6.1.17</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://www.w3.org/TR/css-cascade-5/#at-ruledef-import">https://www.w3.org/TR/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://www.w3.org/TR/css-cascade-5/#at-ruledef-import">https://www.w3.org/TR/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-insert-a-css-rule">
-   <a href="https://www.w3.org/TR/cssom-1/#insert-a-css-rule">https://www.w3.org/TR/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-insert-a-css-rule" class="dfn-panel" data-for="term-for-insert-a-css-rule" id="infopanel-for-term-for-insert-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-insert-a-css-rule" style="display:none">Info about the 'insert a css rule' external reference.</span><a href="https://www.w3.org/TR/cssom-1/#insert-a-css-rule">https://www.w3.org/TR/cssom-1/#insert-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-declaration-block">
-   <a href="https://www.w3.org/TR/cssom-1/#parse-a-css-declaration-block">https://www.w3.org/TR/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-css-declaration-block" class="dfn-panel" data-for="term-for-parse-a-css-declaration-block" id="infopanel-for-term-for-parse-a-css-declaration-block" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-css-declaration-block" style="display:none">Info about the 'parse a css declaration block' external reference.</span><a href="https://www.w3.org/TR/cssom-1/#parse-a-css-declaration-block">https://www.w3.org/TR/cssom-1/#parse-a-css-declaration-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-declaration-block">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-css-rule">
-   <a href="https://www.w3.org/TR/cssom-1/#parse-a-css-rule">https://www.w3.org/TR/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-css-rule" class="dfn-panel" data-for="term-for-parse-a-css-rule" id="infopanel-for-term-for-parse-a-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-css-rule" style="display:none">Info about the 'parse a css rule' external reference.</span><a href="https://www.w3.org/TR/cssom-1/#parse-a-css-rule">https://www.w3.org/TR/cssom-1/#parse-a-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-css-rule">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-group-of-selectors">
-   <a href="https://www.w3.org/TR/cssom-1/#parse-a-group-of-selectors">https://www.w3.org/TR/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-group-of-selectors" class="dfn-panel" data-for="term-for-parse-a-group-of-selectors" id="infopanel-for-term-for-parse-a-group-of-selectors" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-group-of-selectors" style="display:none">Info about the 'parse a group of selectors' external reference.</span><a href="https://www.w3.org/TR/cssom-1/#parse-a-group-of-selectors">https://www.w3.org/TR/cssom-1/#parse-a-group-of-selectors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-group-of-selectors">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">1.2. Goals</a>
     <li><a href="#ref-for-document①">2.2. Policies</a>
@@ -4888,8 +4888,8 @@ rest of Google’s CSP Cabal.</p>
     CSP Inheriting to avoid bypasses </a> <a href="#ref-for-document①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.3. Directives</a>
     <li><a href="#ref-for-element①">4.2.4. 
@@ -4914,105 +4914,105 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-composed">
-   <a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-composed" class="dfn-panel" data-for="term-for-dom-event-composed" id="infopanel-for-term-for-dom-event-composed" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-composed" style="display:none">Info about the 'composed' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-composed">5.3. 
     Report a violation </a> <a href="#ref-for-dom-event-composed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">6.3.3. navigate-to</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a> <a href="#ref-for-concept-document③">(4)</a> <a href="#ref-for-concept-document④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-root" class="dfn-panel" data-for="term-for-concept-shadow-including-root" id="infopanel-for-term-for-concept-shadow-including-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-root" style="display:none">Info about the 'shadow-including root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-root">https://dom.spec.whatwg.org/#concept-shadow-including-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-root">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-target" class="dfn-panel" data-for="term-for-dom-event-target" id="infopanel-for-term-for-dom-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-function-objects">
-   <a href="https://tc39.github.io/ecma262#sec-function-objects">https://tc39.github.io/ecma262#sec-function-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-function-objects" class="dfn-panel" data-for="term-for-sec-function-objects" id="infopanel-for-term-for-sec-function-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-function-objects" style="display:none">Info about the 'Function()' external reference.</span><a href="https://tc39.github.io/ecma262#sec-function-objects">https://tc39.github.io/ecma262#sec-function-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-function-objects">6.1.11. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-hostensurecancompilestrings">
-   <a href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">https://tc39.github.io/ecma262#sec-hostensurecancompilestrings</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-hostensurecancompilestrings" class="dfn-panel" data-for="term-for-sec-hostensurecancompilestrings" id="infopanel-for-term-for-sec-hostensurecancompilestrings" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-hostensurecancompilestrings" style="display:none">Info about the 'HostEnsureCanCompileStrings()' external reference.</span><a href="https://tc39.github.io/ecma262#sec-hostensurecancompilestrings">https://tc39.github.io/ecma262#sec-hostensurecancompilestrings</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-hostensurecancompilestrings">4.3. Integration with ECMAScript</a>
     <li><a href="#ref-for-sec-hostensurecancompilestrings①">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-eval-x">
-   <a href="https://tc39.github.io/ecma262#sec-eval-x">https://tc39.github.io/ecma262#sec-eval-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-eval-x" class="dfn-panel" data-for="term-for-sec-eval-x" id="infopanel-for-term-for-sec-eval-x" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-eval-x" style="display:none">Info about the 'eval()' external reference.</span><a href="https://tc39.github.io/ecma262#sec-eval-x">https://tc39.github.io/ecma262#sec-eval-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-eval-x">1.2. Goals</a>
     <li><a href="#ref-for-sec-eval-x①">6.1.11. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262#realm">https://tc39.github.io/ecma262#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262#realm">https://tc39.github.io/ecma262#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">6.6.3.3. 
     Does element match source list for type and source? </a>
@@ -5020,15 +5020,15 @@ rest of Google’s CSP Cabal.</p>
       Allowing external JavaScript via hashes </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">2.4.2. 
     Create a violation object for request, and policy. </a>
@@ -5050,15 +5050,15 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-nonce-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">https://fetch.spec.whatwg.org/#concept-request-nonce-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-nonce-metadata" class="dfn-panel" data-for="term-for-concept-request-nonce-metadata" id="infopanel-for-term-for-concept-request-nonce-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-nonce-metadata" style="display:none">Info about the 'cryptographic nonce metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-nonce-metadata">https://fetch.spec.whatwg.org/#concept-request-nonce-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">4.2. 
     Integration with HTML </a>
@@ -5078,8 +5078,8 @@ rest of Google’s CSP Cabal.</p>
     Does nonce match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-current-url" class="dfn-panel" data-for="term-for-concept-request-current-url" id="infopanel-for-term-for-concept-request-current-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-current-url" style="display:none">Info about the 'current url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">2.4.2. 
     Create a violation object for request, and policy. </a>
@@ -5090,8 +5090,8 @@ rest of Google’s CSP Cabal.</p>
     Does request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">5.3. 
     Report a violation </a>
@@ -5107,29 +5107,29 @@ rest of Google’s CSP Cabal.</p>
     Get the effective directive for request </a> <a href="#ref-for-concept-request-destination⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extract-header-list-values">
-   <a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extract-header-list-values" class="dfn-panel" data-for="term-for-extract-header-list-values" id="infopanel-for-term-for-extract-header-list-values" role="menu">
+   <span id="infopaneltitle-for-term-for-extract-header-list-values" style="display:none">Info about the 'extracting header list values' external reference.</span><a href="https://fetch.spec.whatwg.org/#extract-header-list-values">https://fetch.spec.whatwg.org/#extract-header-list-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">4.1.1. 
     Set response’s CSP list </a> <a href="#ref-for-extract-header-list-values①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">4.1. 
     Integration with Fetch </a>
@@ -5137,30 +5137,30 @@ rest of Google’s CSP Cabal.</p>
     Set response’s CSP list </a> <a href="#ref-for-concept-response-header-list②">(2)</a> <a href="#ref-for-concept-response-header-list③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-fetch" class="dfn-panel" data-for="term-for-concept-http-fetch" id="infopanel-for-term-for-concept-http-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-fetch" style="display:none">Info about the 'http fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-fetch">https://fetch.spec.whatwg.org/#concept-http-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">4.1. 
     Integration with Fetch </a> <a href="#ref-for-concept-http-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-scheme">
-   <a href="https://fetch.spec.whatwg.org/#http-scheme">https://fetch.spec.whatwg.org/#http-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-scheme" class="dfn-panel" data-for="term-for-http-scheme" id="infopanel-for-term-for-http-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-http-scheme" style="display:none">Info about the 'http(s) scheme' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-scheme">https://fetch.spec.whatwg.org/#http-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-scheme">1.3. Changes from Level 2</a> <a href="#ref-for-http-scheme①">(2)</a>
     <li><a href="#ref-for-http-scheme②">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-http-scheme③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-http-network-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-http-network-fetch">https://fetch.spec.whatwg.org/#concept-http-network-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-http-network-fetch" class="dfn-panel" data-for="term-for-concept-http-network-fetch" id="infopanel-for-term-for-concept-http-network-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-http-network-fetch" style="display:none">Info about the 'http-network fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-http-network-fetch">https://fetch.spec.whatwg.org/#concept-http-network-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-network-fetch">4.1. 
     Integration with Fetch </a> <a href="#ref-for-concept-http-network-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">5.3. 
     Report a violation </a>
@@ -5168,22 +5168,22 @@ rest of Google’s CSP Cabal.</p>
     Get the effective directive for request </a> <a href="#ref-for-concept-request-initiator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-integrity-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-integrity-metadata" class="dfn-panel" data-for="term-for-concept-request-integrity-metadata" id="infopanel-for-term-for-concept-request-integrity-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-integrity-metadata" style="display:none">Info about the 'integrity metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-integrity-metadata">https://fetch.spec.whatwg.org/#concept-request-integrity-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-integrity-metadata">6.6.1.1. 
     Script directives pre-request check </a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-keepalive-flag">
-   <a href="https://fetch.spec.whatwg.org/#request-keepalive-flag">https://fetch.spec.whatwg.org/#request-keepalive-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-keepalive-flag" class="dfn-panel" data-for="term-for-request-keepalive-flag" id="infopanel-for-term-for-request-keepalive-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-request-keepalive-flag" style="display:none">Info about the 'keepalive' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-keepalive-flag">https://fetch.spec.whatwg.org/#request-keepalive-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-keepalive-flag">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-scheme">
-   <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-scheme" class="dfn-panel" data-for="term-for-local-scheme" id="infopanel-for-term-for-local-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-local-scheme" style="display:none">Info about the 'local scheme' external reference.</span><a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-scheme">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-local-scheme①">2.2. Policies</a>
@@ -5195,43 +5195,43 @@ rest of Google’s CSP Cabal.</p>
     CSP Inheriting to avoid bypasses </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-main-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-main-fetch">https://fetch.spec.whatwg.org/#concept-main-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-main-fetch" class="dfn-panel" data-for="term-for-concept-main-fetch" id="infopanel-for-term-for-concept-main-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-main-fetch" style="display:none">Info about the 'main fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-main-fetch">https://fetch.spec.whatwg.org/#concept-main-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-main-fetch">4.1. 
     Integration with Fetch </a> <a href="#ref-for-concept-main-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">4.1. 
     Integration with Fetch </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-parser-metadata">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-parser-metadata" class="dfn-panel" data-for="term-for-concept-request-parser-metadata" id="infopanel-for-term-for-concept-request-parser-metadata" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-parser-metadata" style="display:none">Info about the 'parser metadata' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-parser-metadata">https://fetch.spec.whatwg.org/#concept-request-parser-metadata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">4.2. 
     Integration with HTML </a>
@@ -5241,8 +5241,8 @@ rest of Google’s CSP Cabal.</p>
     Script directives post-request check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-count">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-count" class="dfn-panel" data-for="term-for-concept-request-redirect-count" id="infopanel-for-term-for-concept-request-redirect-count" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-count" style="display:none">Info about the 'redirect count' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-count">https://fetch.spec.whatwg.org/#concept-request-redirect-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-count">6.6.2.3. 
     Does request match source list? </a>
@@ -5250,22 +5250,22 @@ rest of Google’s CSP Cabal.</p>
     Does response to request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-redirect-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-redirect-mode" class="dfn-panel" data-for="term-for-concept-request-redirect-mode" id="infopanel-for-term-for-concept-request-redirect-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-redirect-mode">https://fetch.spec.whatwg.org/#concept-request-redirect-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-redirect-status">
-   <a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-redirect-status" class="dfn-panel" data-for="term-for-redirect-status" id="infopanel-for-term-for-redirect-status" role="menu">
+   <span id="infopaneltitle-for-term-for-redirect-status" style="display:none">Info about the 'redirect status' external reference.</span><a href="https://fetch.spec.whatwg.org/#redirect-status">https://fetch.spec.whatwg.org/#redirect-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-redirect-status">6.3.3.2. 
     navigate-to Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2.3. Directives</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a> <a href="#ref-for-concept-request③">(4)</a> <a href="#ref-for-concept-request④">(5)</a>
     <li><a href="#ref-for-concept-request⑤">2.4.2. 
@@ -5383,8 +5383,8 @@ rest of Google’s CSP Cabal.</p>
     Get the effective directive for inline checks </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.3. Directives</a> <a href="#ref-for-concept-response①">(2)</a> <a href="#ref-for-concept-response②">(3)</a> <a href="#ref-for-concept-response③">(4)</a>
     <li><a href="#ref-for-concept-response④">4.1. 
@@ -5450,8 +5450,8 @@ rest of Google’s CSP Cabal.</p>
     Does response to request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-request-destination-script-like">
-   <a href="https://fetch.spec.whatwg.org/#request-destination-script-like">https://fetch.spec.whatwg.org/#request-destination-script-like</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-request-destination-script-like" class="dfn-panel" data-for="term-for-request-destination-script-like" id="infopanel-for-term-for-request-destination-script-like" role="menu">
+   <span id="infopaneltitle-for-term-for-request-destination-script-like" style="display:none">Info about the 'script-like' external reference.</span><a href="https://fetch.spec.whatwg.org/#request-destination-script-like">https://fetch.spec.whatwg.org/#request-destination-script-like</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-destination-script-like">6.1.11. script-src</a>
     <li><a href="#ref-for-request-destination-script-like①">6.6.1.1. 
@@ -5460,8 +5460,8 @@ rest of Google’s CSP Cabal.</p>
     Script directives post-request check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
@@ -5469,16 +5469,16 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-target-browsing-context">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">https://fetch.spec.whatwg.org/#concept-request-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-target-browsing-context" class="dfn-panel" data-for="term-for-concept-request-target-browsing-context" id="infopanel-for-term-for-concept-request-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-target-browsing-context">https://fetch.spec.whatwg.org/#concept-request-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-target-browsing-context">6.1.1. child-src</a>
     <li><a href="#ref-for-concept-request-target-browsing-context①">6.7.1. 
     Get the effective directive for request </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.4.2. 
     Create a violation object for request, and policy. </a> <a href="#ref-for-concept-request-url①">(2)</a>
@@ -5492,8 +5492,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">4.1.1. 
     Set response’s CSP list </a>
@@ -5508,15 +5508,15 @@ rest of Google’s CSP Cabal.</p>
     Does response to request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-window">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-window">https://fetch.spec.whatwg.org/#concept-request-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-window" class="dfn-panel" data-for="term-for-concept-request-window" id="infopanel-for-term-for-concept-request-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-window" style="display:none">Info about the 'window' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-window">https://fetch.spec.whatwg.org/#concept-request-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-window">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parser-inserted">
-   <a href="https://html.spec.whatwg.org/#parser-inserted">https://html.spec.whatwg.org/#parser-inserted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parser-inserted" class="dfn-panel" data-for="term-for-parser-inserted" id="infopanel-for-term-for-parser-inserted" role="menu">
+   <span id="infopaneltitle-for-term-for-parser-inserted" style="display:none">Info about the '"parser-inserted"' external reference.</span><a href="https://html.spec.whatwg.org/#parser-inserted">https://html.spec.whatwg.org/#parser-inserted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parser-inserted">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-parser-inserted①">6.6.1.1. 
@@ -5527,29 +5527,29 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-parser-inserted④">(2)</a> <a href="#ref-for-parser-inserted⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">4.2.2. 
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworker" class="dfn-panel" data-for="term-for-sharedworker" id="infopanel-for-term-for-sharedworker" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworker" style="display:none">Info about the 'SharedWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">6.1.1. child-src</a>
     <li><a href="#ref-for-sharedworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">4.2.2. 
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -5559,16 +5559,16 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-window③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">1.2. Goals</a>
     <li><a href="#ref-for-worker①">6.1.1. child-src</a>
     <li><a href="#ref-for-worker②">6.1.17. worker-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">2.2. Policies</a>
     <li><a href="#ref-for-workerglobalscope①">4.2. 
@@ -5577,8 +5577,8 @@ rest of Google’s CSP Cabal.</p>
     Retrieve the CSP list of an object </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">2.2. Policies</a>
     <li><a href="#ref-for-workletglobalscope①">4.2. 
@@ -5589,15 +5589,15 @@ rest of Google’s CSP Cabal.</p>
     Retrieve the CSP list of an object </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-a-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-a-element" class="dfn-panel" data-for="term-for-the-a-element" id="infopanel-for-term-for-the-a-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-a-element" style="display:none">Info about the 'a' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-a-element">6.1.2. connect-src</a>
     <li><a href="#ref-for-the-a-element①">6.3.3. navigate-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-an-iframe-srcdoc-document">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-an-iframe-srcdoc-document" class="dfn-panel" data-for="term-for-an-iframe-srcdoc-document" id="infopanel-for-term-for-an-iframe-srcdoc-document" role="menu">
+   <span id="infopaneltitle-for-term-for-an-iframe-srcdoc-document" style="display:none">Info about the 'an iframe srcdoc document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#an-iframe-srcdoc-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-an-iframe-srcdoc-document">4.2.1. 
     Initialize a Document's CSP list </a> <a href="#ref-for-an-iframe-srcdoc-document①">(2)</a>
@@ -5607,15 +5607,15 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">6.3.2.1. 
     frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">4.2.3. 
     Retrieve the CSP list of an object </a>
@@ -5623,8 +5623,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-concept-document-window②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-base-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-base-element" class="dfn-panel" data-for="term-for-the-base-element" id="infopanel-for-term-for-the-base-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-base-element" style="display:none">Info about the 'base' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">https://html.spec.whatwg.org/multipage/semantics.html#the-base-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-base-element">4.2. 
     Integration with HTML </a>
@@ -5634,8 +5634,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-base-element③">7.3. Nonce Retargeting</a> <a href="#ref-for-the-base-element④">(2)</a> <a href="#ref-for-the-base-element⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/#browsing-context">https://html.spec.whatwg.org/#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#browsing-context">https://html.spec.whatwg.org/#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.3. Directives</a>
     <li><a href="#ref-for-browsing-context①">4.2. 
@@ -5649,82 +5649,82 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Navigation Response Check </a> <a href="#ref-for-browsing-context⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-content">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-content" class="dfn-panel" data-for="term-for-attr-meta-content" id="infopanel-for-term-for-attr-meta-content" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-content" style="display:none">Info about the 'content' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-content">3.3. 
     The &lt;meta> element </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv-content-security-policy">
-   <a href="https://html.spec.whatwg.org/#attr-meta-http-equiv-content-security-policy">https://html.spec.whatwg.org/#attr-meta-http-equiv-content-security-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv-content-security-policy" class="dfn-panel" data-for="term-for-attr-meta-http-equiv-content-security-policy" id="infopanel-for-term-for-attr-meta-http-equiv-content-security-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv-content-security-policy" style="display:none">Info about the 'content security policy state' external reference.</span><a href="https://html.spec.whatwg.org/#attr-meta-http-equiv-content-security-policy">https://html.spec.whatwg.org/#attr-meta-http-equiv-content-security-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv-content-security-policy">3.3. 
     The &lt;meta> element </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
-   <a href="https://html.spec.whatwg.org/#initialise-the-document-object">https://html.spec.whatwg.org/#initialise-the-document-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initialise-the-document-object" class="dfn-panel" data-for="term-for-initialise-the-document-object" id="infopanel-for-term-for-initialise-the-document-object" role="menu">
+   <span id="infopaneltitle-for-term-for-initialise-the-document-object" style="display:none">Info about the 'create and initialize a new document object' external reference.</span><a href="https://html.spec.whatwg.org/#initialise-the-document-object">https://html.spec.whatwg.org/#initialise-the-document-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialise-the-document-object">4.2. 
     Integration with HTML </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-object-data">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-object-data" class="dfn-panel" data-for="term-for-attr-object-data" id="infopanel-for-term-for-attr-object-data" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-object-data" style="display:none">Info about the 'data' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-object-data">6.1.9. object-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-2">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-2" class="dfn-panel" data-for="term-for-dom-document-2" id="infopanel-for-term-for-dom-document-2" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-2" style="display:none">Info about the 'document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-2">2.4.1. 
     Create a violation object for global, policy, and directive </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-error-duplicate-attribute">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-error-duplicate-attribute" class="dfn-panel" data-for="term-for-parse-error-duplicate-attribute" id="infopanel-for-term-for-parse-error-duplicate-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-error-duplicate-attribute" style="display:none">Info about the 'duplicate-attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute">https://html.spec.whatwg.org/multipage/parsing.html#parse-error-duplicate-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-error-duplicate-attribute">6.6.3.1. 
     Is element nonceable? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-embed-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-embed-element" class="dfn-panel" data-for="term-for-the-embed-element" id="infopanel-for-term-for-the-embed-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-embed-element" style="display:none">Info about the 'embed' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-embed-element">6.1.9. object-src</a> <a href="#ref-for-the-embed-element①">(2)</a>
     <li><a href="#ref-for-the-embed-element②">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.2. Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">6.3.3. navigate-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame" class="dfn-panel" data-for="term-for-frame" id="infopanel-for-term-for-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-frame" style="display:none">Info about the 'frame' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frame">https://html.spec.whatwg.org/multipage/obsolete.html#frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame">6.1.1. child-src</a> <a href="#ref-for-frame①">(2)</a>
     <li><a href="#ref-for-frame②">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">2.3. Directives</a>
     <li><a href="#ref-for-global-object①">2.4. Violations</a> <a href="#ref-for-global-object②">(2)</a>
@@ -5744,8 +5744,8 @@ rest of Google’s CSP Cabal.</p>
     sandbox Initialization </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.4.2. 
     Create a violation object for request, and policy. </a>
@@ -5767,8 +5767,8 @@ rest of Google’s CSP Cabal.</p>
     in target be blocked by Content Security Policy? </a> <a href="#ref-for-concept-settings-object-global①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-base-href">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-base-href" class="dfn-panel" data-for="term-for-attr-base-href" id="infopanel-for-term-for-attr-base-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-base-href" style="display:none">Info about the 'href' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href">https://html.spec.whatwg.org/multipage/semantics.html#attr-base-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-base-href">4.2. 
     Integration with HTML </a>
@@ -5776,8 +5776,8 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv" class="dfn-panel" data-for="term-for-attr-meta-http-equiv" id="infopanel-for-term-for-attr-meta-http-equiv" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv" style="display:none">Info about the 'http-equiv' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv">https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv">3. 
     Policy Delivery </a>
@@ -5787,24 +5787,24 @@ rest of Google’s CSP Cabal.</p>
     Integration with HTML </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">6.1.1. child-src</a> <a href="#ref-for-the-iframe-element①">(2)</a>
     <li><a href="#ref-for-the-iframe-element②">6.2.2. sandbox</a> <a href="#ref-for-the-iframe-element③">(2)</a>
     <li><a href="#ref-for-the-iframe-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">3.3. 
     The &lt;meta> element </a>
     <li><a href="#ref-for-the-link-element①">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-meta">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-meta" class="dfn-panel" data-for="term-for-meta" id="infopanel-for-term-for-meta" role="menu">
+   <span id="infopaneltitle-for-term-for-meta" style="display:none">Info about the 'meta' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">3. 
     Policy Delivery </a>
@@ -5818,8 +5818,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-meta①①">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-nonce">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-nonce" class="dfn-panel" data-for="term-for-attr-nonce" id="infopanel-for-term-for-attr-nonce" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-nonce" style="display:none">Info about the 'nonce' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#attr-nonce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-nonce">6.6.3.3. 
     Does element match source list for type and source? </a>
@@ -5828,23 +5828,23 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-object-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-object-element" class="dfn-panel" data-for="term-for-the-object-element" id="infopanel-for-term-for-the-object-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-object-element" style="display:none">Info about the 'object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-object-element">6.1.9. object-src</a> <a href="#ref-for-the-object-element①">(2)</a> <a href="#ref-for-the-object-element②">(3)</a> <a href="#ref-for-the-object-element③">(4)</a>
     <li><a href="#ref-for-the-object-element④">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.2. Policies</a>
     <li><a href="#ref-for-concept-origin-opaque①">4.2.1. 
     Initialize a Document's CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/#concept-origin">https://html.spec.whatwg.org/#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/#concept-origin">https://html.spec.whatwg.org/#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.2. Policies</a>
     <li><a href="#ref-for-concept-origin①">6.6.2.5. 
@@ -5853,23 +5853,23 @@ rest of Google’s CSP Cabal.</p>
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-origin③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2.2. Policies</a>
     <li><a href="#ref-for-concept-settings-object-origin①">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set" id="infopanel-for-term-for-concept-WorkerGlobalScope-owner-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" style="display:none">Info about the 'owner set' external reference.</span><a href="https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">4.2.2. 
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-sandboxing-directive" class="dfn-panel" data-for="term-for-parse-a-sandboxing-directive" id="infopanel-for-term-for-parse-a-sandboxing-directive" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-sandboxing-directive" style="display:none">Info about the 'parse a sandboxing directive' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive">https://html.spec.whatwg.org/multipage/browsers.html#parse-a-sandboxing-directive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-sandboxing-directive">6.2.2.1. 
     sandbox Response Check </a>
@@ -5877,77 +5877,77 @@ rest of Google’s CSP Cabal.</p>
     sandbox Initialization </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ping">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#ping">https://html.spec.whatwg.org/multipage/links.html#ping</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ping" class="dfn-panel" data-for="term-for-ping" id="infopanel-for-term-for-ping" role="menu">
+   <span id="infopaneltitle-for-term-for-ping" style="display:none">Info about the 'ping' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#ping">https://html.spec.whatwg.org/multipage/links.html#ping</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ping">6.1.2. connect-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-the-iframe-attributes">
-   <a href="https://html.spec.whatwg.org/#process-the-iframe-attributes">https://html.spec.whatwg.org/#process-the-iframe-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-the-iframe-attributes" class="dfn-panel" data-for="term-for-process-the-iframe-attributes" id="infopanel-for-term-for-process-the-iframe-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-process-the-iframe-attributes" style="display:none">Info about the 'process the iframe attributes' external reference.</span><a href="https://html.spec.whatwg.org/#process-the-iframe-attributes">https://html.spec.whatwg.org/#process-the-iframe-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-the-iframe-attributes">4.2.1. 
     Initialize a Document's CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-referrer">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer">https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-referrer" class="dfn-panel" data-for="term-for-dom-document-referrer" id="infopanel-for-term-for-dom-document-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-referrer" style="display:none">Info about the 'referrer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer">https://html.spec.whatwg.org/multipage/dom.html#dom-document-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-referrer">2.4.1. 
     Create a violation object for global, policy, and directive </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">5.3. 
     Report a violation </a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-run-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-run-a-worker" class="dfn-panel" data-for="term-for-run-a-worker" id="infopanel-for-term-for-run-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-run-a-worker" style="display:none">Info about the 'run a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-a-worker">4.2. 
     Integration with HTML </a>
     <li><a href="#ref-for-run-a-worker①">6.1.1. child-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">6.2.2. sandbox</a> <a href="#ref-for-attr-iframe-sandbox①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxed-origin-browsing-context-flag">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandboxed-origin-browsing-context-flag" class="dfn-panel" data-for="term-for-sandboxed-origin-browsing-context-flag" id="infopanel-for-term-for-sandboxed-origin-browsing-context-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-sandboxed-origin-browsing-context-flag" style="display:none">Info about the 'sandboxed origin browsing context flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandboxed-origin-browsing-context-flag">6.2.2.1. 
     sandbox Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxed-scripts-browsing-context-flag">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-scripts-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-scripts-browsing-context-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandboxed-scripts-browsing-context-flag" class="dfn-panel" data-for="term-for-sandboxed-scripts-browsing-context-flag" id="infopanel-for-term-for-sandboxed-scripts-browsing-context-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-sandboxed-scripts-browsing-context-flag" style="display:none">Info about the 'sandboxed scripts browsing context flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-scripts-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-scripts-browsing-context-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandboxed-scripts-browsing-context-flag">6.2.2.1. 
     sandbox Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-scheme">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-scheme" class="dfn-panel" data-for="term-for-concept-origin-scheme" id="infopanel-for-term-for-concept-origin-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-scheme">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-concept-origin-scheme①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script" class="dfn-panel" data-for="term-for-script" id="infopanel-for-term-for-script" role="menu">
+   <span id="infopaneltitle-for-term-for-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script">1.3. Changes from Level 2</a> <a href="#ref-for-script①">(2)</a>
     <li><a href="#ref-for-script②">3.3. 
@@ -5964,28 +5964,28 @@ rest of Google’s CSP Cabal.</p>
       Allowing external JavaScript via hashes </a> <a href="#ref-for-script①⑦">(2)</a> <a href="#ref-for-script①⑧">(3)</a> <a href="#ref-for-script①⑨">(4)</a> <a href="#ref-for-script②⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-frozen-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-frozen-base-url" class="dfn-panel" data-for="term-for-set-the-frozen-base-url" id="infopanel-for-term-for-set-the-frozen-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-frozen-base-url" style="display:none">Info about the 'set the frozen base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url">https://html.spec.whatwg.org/multipage/semantics.html#set-the-frozen-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-frozen-base-url">4.2. 
     Integration with HTML </a>
     <li><a href="#ref-for-set-the-frozen-base-url①">6.2.1. base-uri</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-setinterval">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-setinterval" class="dfn-panel" data-for="term-for-dom-setinterval" id="infopanel-for-term-for-dom-setinterval" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-setinterval" style="display:none">Info about the 'setInterval(handler, timeout, ...arguments)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-setinterval</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-setinterval">6.1.11. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-settimeout">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-settimeout" class="dfn-panel" data-for="term-for-dom-settimeout" id="infopanel-for-term-for-dom-settimeout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-settimeout" style="display:none">Info about the 'setTimeout(handler, timeout, ...arguments)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-settimeout">6.1.11. script-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">6.1.14. style-src</a>
     <li><a href="#ref-for-the-style-element①">6.6.3.3. 
@@ -5993,35 +5993,35 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-the-style-element③">7.2.1. Dangling markup attacks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">6.1.9. object-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-update-a-style-block">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-update-a-style-block" class="dfn-panel" data-for="term-for-update-a-style-block" id="infopanel-for-term-for-update-a-style-block" role="menu">
+   <span id="infopaneltitle-for-term-for-update-a-style-block" style="display:none">Info about the 'update a style block' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block">https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-a-style-block">4.2. 
     Integration with HTML </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.2.2. 
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.2.1. 
     Parse a serialized CSP </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.3. 
     The &lt;meta> element </a>
@@ -6049,15 +6049,15 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#ref-for-ascii-case-insensitive②①">(2)</a> <a href="#ref-for-ascii-case-insensitive②②">(3)</a> <a href="#ref-for-ascii-case-insensitive②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">2.2.1. 
     Parse a serialized CSP </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">2.2. Policies</a> <a href="#ref-for-ascii-string①">(2)</a>
     <li><a href="#ref-for-ascii-string②">2.2.1. 
@@ -6074,30 +6074,30 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a> <a href="#ref-for-ascii-string①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">2.1. Infrastructure</a>
     <li><a href="#ref-for-ascii-whitespace①">2.2.1. 
     Parse a serialized CSP </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.2.2. 
     Parse a serialized CSP list </a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collecting a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">2.2.1. 
     Parse a serialized CSP </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.2. Policies</a>
     <li><a href="#ref-for-list-contain①">4.2.4. 
@@ -6106,8 +6106,8 @@ rest of Google’s CSP Cabal.</p>
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-iteration-continue①">(2)</a>
@@ -6115,28 +6115,28 @@ rest of Google’s CSP Cabal.</p>
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.2.2. 
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://infra.spec.whatwg.org/#">https://infra.spec.whatwg.org/#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'infra' external reference.</span><a href="https://infra.spec.whatwg.org/#">https://infra.spec.whatwg.org/#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.1. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'is' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">6.6.1.1. 
     Script directives pre-request check </a>
@@ -6148,36 +6148,36 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#ref-for-string-is④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.3. Directives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-decode" class="dfn-panel" data-for="term-for-isomorphic-decode" id="infopanel-for-term-for-isomorphic-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">2.2.2. 
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.2. Policies</a>
     <li><a href="#ref-for-list①">2.2.2. 
     Parse a serialized CSP list </a> <a href="#ref-for-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">5.2. 
     Obtain the deprecated serialization of violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
@@ -6186,15 +6186,15 @@ rest of Google’s CSP Cabal.</p>
     Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-an-infra-value-to-json-bytes">
-   <a href="https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-an-infra-value-to-json-bytes" class="dfn-panel" data-for="term-for-serialize-an-infra-value-to-json-bytes" id="infopanel-for-term-for-serialize-an-infra-value-to-json-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-an-infra-value-to-json-bytes" style="display:none">Info about the 'serialize an infra value to json bytes' external reference.</span><a href="https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-infra-value-to-json-bytes">5.2. 
     Obtain the deprecated serialization of violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set①" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.2. Policies</a>
     <li><a href="#ref-for-ordered-set①">2.3. Directives</a> <a href="#ref-for-ordered-set②">(2)</a>
@@ -6203,8 +6203,8 @@ rest of Google’s CSP Cabal.</p>
     Get fetch directive fallback list </a> <a href="#ref-for-ordered-set⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-ascii-whitespace" class="dfn-panel" data-for="term-for-split-on-ascii-whitespace" id="infopanel-for-term-for-split-on-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-ascii-whitespace" style="display:none">Info about the 'split a string on ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-ascii-whitespace">2.2.1. 
     Parse a serialized CSP </a>
@@ -6212,15 +6212,15 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-commas">
-   <a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-commas" class="dfn-panel" data-for="term-for-split-on-commas" id="infopanel-for-term-for-split-on-commas" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-commas" style="display:none">Info about the 'split a string on commas' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-commas">https://infra.spec.whatwg.org/#split-on-commas</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-commas">2.2.2. 
     Parse a serialized CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split a string' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">2.2.1. 
     Parse a serialized CSP </a>
@@ -6228,8 +6228,8 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.2.1. 
     Parse a serialized CSP </a>
@@ -6241,124 +6241,124 @@ rest of Google’s CSP Cabal.</p>
     Create a violation object for global, policy, and directive </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">2.2.1. 
     Parse a serialized CSP </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-group">
-   <a href="https://w3c.github.io/reporting/#group">https://w3c.github.io/reporting/#group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-group" class="dfn-panel" data-for="term-for-group" id="infopanel-for-term-for-group" role="menu">
+   <span id="infopaneltitle-for-term-for-group" style="display:none">Info about the 'group' external reference.</span><a href="https://w3c.github.io/reporting/#group">https://w3c.github.io/reporting/#group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group">6.4.2. report-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-report">
-   <a href="https://w3c.github.io/reporting/#queue-report">https://w3c.github.io/reporting/#queue-report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-report" class="dfn-panel" data-for="term-for-queue-report" id="infopanel-for-term-for-queue-report" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-report" style="display:none">Info about the 'queue report' external reference.</span><a href="https://w3c.github.io/reporting/#queue-report">https://w3c.github.io/reporting/#queue-report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-report">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-type">
-   <a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-type" class="dfn-panel" data-for="term-for-report-type" id="infopanel-for-term-for-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-report-type" style="display:none">Info about the 'report type' external reference.</span><a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-type">5. 
     Reporting </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-visible-to-reportingobservers">
-   <a href="https://w3c.github.io/reporting/#visible-to-reportingobservers">https://w3c.github.io/reporting/#visible-to-reportingobservers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-visible-to-reportingobservers" class="dfn-panel" data-for="term-for-visible-to-reportingobservers" id="infopanel-for-term-for-visible-to-reportingobservers" role="menu">
+   <span id="infopaneltitle-for-term-for-visible-to-reportingobservers" style="display:none">Info about the 'visible to reportingobservers' external reference.</span><a href="https://w3c.github.io/reporting/#visible-to-reportingobservers">https://w3c.github.io/reporting/#visible-to-reportingobservers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-to-reportingobservers">5. 
     Reporting </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reportbody">
-   <a href="https://www.w3.org/TR/reporting-1/#reportbody">https://www.w3.org/TR/reporting-1/#reportbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reportbody" class="dfn-panel" data-for="term-for-reportbody" id="infopanel-for-term-for-reportbody" role="menu">
+   <span id="infopaneltitle-for-term-for-reportbody" style="display:none">Info about the 'ReportBody' external reference.</span><a href="https://www.w3.org/TR/reporting-1/#reportbody">https://www.w3.org/TR/reporting-1/#reportbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reportbody">5. 
     Reporting </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.2">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.2" class="dfn-panel" data-for="term-for-section-3.2.2" id="infopanel-for-term-for-section-3.2.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.2" style="display:none">Info about the 'ipv4address' external reference.</span><a href="https://tools.ietf.org/html/rfc3986#section-3.2.2">https://tools.ietf.org/html/rfc3986#section-3.2.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.2">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.3">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.3">https://tools.ietf.org/html/rfc3986#section-3.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.3" class="dfn-panel" data-for="term-for-section-3.3" id="infopanel-for-term-for-section-3.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.3" style="display:none">Info about the 'path-absolute' external reference.</span><a href="https://tools.ietf.org/html/rfc3986#section-3.3">https://tools.ietf.org/html/rfc3986#section-3.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.3">2.3.1. Source Lists</a> <a href="#ref-for-section-3.3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1">
-   <a href="https://tools.ietf.org/html/rfc3986#section-3.1">https://tools.ietf.org/html/rfc3986#section-3.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1" class="dfn-panel" data-for="term-for-section-3.1" id="infopanel-for-term-for-section-3.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1" style="display:none">Info about the 'scheme' external reference.</span><a href="https://tools.ietf.org/html/rfc3986#section-3.1">https://tools.ietf.org/html/rfc3986#section-3.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1">2.3.1. Source Lists</a> <a href="#ref-for-section-3.1①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1">
-   <a href="https://tools.ietf.org/html/rfc3986#section-4.1">https://tools.ietf.org/html/rfc3986#section-4.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1" class="dfn-panel" data-for="term-for-section-4.1" id="infopanel-for-term-for-section-4.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1" style="display:none">Info about the 'uri-reference' external reference.</span><a href="https://tools.ietf.org/html/rfc3986#section-4.1">https://tools.ietf.org/html/rfc3986#section-4.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1">6.4.1. report-uri</a> <a href="#ref-for-section-4.1①">(2)</a> <a href="#ref-for-section-4.1②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4">
-   <a href="https://tools.ietf.org/html/rfc4648#section-4">https://tools.ietf.org/html/rfc4648#section-4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4" class="dfn-panel" data-for="term-for-section-4" id="infopanel-for-term-for-section-4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4" style="display:none">Info about the 'base64 encoding' external reference.</span><a href="https://tools.ietf.org/html/rfc4648#section-4">https://tools.ietf.org/html/rfc4648#section-4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4">2.3.1. Source Lists</a>
     <li><a href="#ref-for-section-4①">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-section-4②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5">
-   <a href="https://tools.ietf.org/html/rfc4648#section-5">https://tools.ietf.org/html/rfc4648#section-5</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5" class="dfn-panel" data-for="term-for-section-5" id="infopanel-for-term-for-section-5" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5" style="display:none">Info about the 'base64url encoding' external reference.</span><a href="https://tools.ietf.org/html/rfc4648#section-5">https://tools.ietf.org/html/rfc4648#section-5</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5">2.3.1. Source Lists</a>
     <li><a href="#ref-for-section-5①">6.6.3.3. 
     Does element match source list for type and source? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1" style="display:none">Info about the 'alpha' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
     <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1①" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1①" style="display:none">Info about the 'digit' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
     <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1②" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1②" style="display:none">Info about the 'vchar' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">2.3. Directives</a> <a href="#ref-for-appendix-B.1①">(2)</a> <a href="#ref-for-appendix-B.1②">(3)</a> <a href="#ref-for-appendix-B.1③">(4)</a> <a href="#ref-for-appendix-B.1④">(5)</a> <a href="#ref-for-appendix-B.1⑤">(6)</a> <a href="#ref-for-appendix-B.1⑥">(7)</a>
     <li><a href="#ref-for-appendix-B.1⑦">2.3.1. Source Lists</a> <a href="#ref-for-appendix-B.1⑧">(2)</a> <a href="#ref-for-appendix-B.1⑨">(3)</a> <a href="#ref-for-appendix-B.1①⓪">(4)</a> <a href="#ref-for-appendix-B.1①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.3" class="dfn-panel" data-for="term-for-section-3.2.3" id="infopanel-for-term-for-section-3.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.3" style="display:none">Info about the 'ows' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.3">2.1. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6" style="display:none">Info about the 'token' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">6.2.2. sandbox</a> <a href="#ref-for-section-3.2.6①">(2)</a>
     <li><a href="#ref-for-section-3.2.6②">6.4.2. report-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'representation' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">3. 
     Policy Delivery </a>
@@ -6368,8 +6368,8 @@ rest of Google’s CSP Cabal.</p>
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a> <a href="#ref-for-section-3④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3①" style="display:none">Info about the 'resource representation' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">3. 
     Policy Delivery </a>
@@ -6379,43 +6379,43 @@ rest of Google’s CSP Cabal.</p>
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a> <a href="#ref-for-section-3④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworker">
-   <a href="https://www.w3.org/TR/service-workers/#serviceworker">https://www.w3.org/TR/service-workers/#serviceworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworker" class="dfn-panel" data-for="term-for-serviceworker" id="infopanel-for-term-for-serviceworker" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworker" style="display:none">Info about the 'ServiceWorker' external reference.</span><a href="https://www.w3.org/TR/service-workers/#serviceworker">https://www.w3.org/TR/service-workers/#serviceworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworker">6.1.1. child-src</a>
     <li><a href="#ref-for-serviceworker①">6.1.17. worker-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://www.w3.org/TR/service-workers/#serviceworkerglobalscope">https://www.w3.org/TR/service-workers/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://www.w3.org/TR/service-workers/#serviceworkerglobalscope">https://www.w3.org/TR/service-workers/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">4.2.2. 
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-①" role="menu">
+   <span id="infopaneltitle-for-term-for-①" style="display:none">Info about the 'sha-256' external reference.</span><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-②" role="menu">
+   <span id="infopaneltitle-for-term-for-②" style="display:none">Info about the 'sha-384' external reference.</span><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-③" role="menu">
+   <span id="infopaneltitle-for-term-for-③" style="display:none">Info about the 'sha-512' external reference.</span><a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#">https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url">
-   <a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url" class="dfn-panel" data-for="term-for-url" id="infopanel-for-term-for-url" role="menu">
+   <span id="infopaneltitle-for-term-for-url" style="display:none">Info about the 'URL' external reference.</span><a href="https://url.spec.whatwg.org/#url">https://url.spec.whatwg.org/#url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">2.4. Violations</a> <a href="#ref-for-url①">(2)</a> <a href="#ref-for-url②">(3)</a> <a href="#ref-for-url③">(4)</a>
     <li><a href="#ref-for-url④">6.2.1. base-uri</a>
@@ -6430,15 +6430,15 @@ rest of Google’s CSP Cabal.</p>
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-base-url">
-   <a href="https://url.spec.whatwg.org/#concept-base-url">https://url.spec.whatwg.org/#concept-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-base-url" class="dfn-panel" data-for="term-for-concept-base-url" id="infopanel-for-term-for-concept-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-base-url" style="display:none">Info about the 'base url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-base-url">https://url.spec.whatwg.org/#concept-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-base-url">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-port">
-   <a href="https://url.spec.whatwg.org/#default-port">https://url.spec.whatwg.org/#default-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-port" class="dfn-panel" data-for="term-for-default-port" id="infopanel-for-term-for-default-port" role="menu">
+   <span id="infopaneltitle-for-term-for-default-port" style="display:none">Info about the 'default port' external reference.</span><a href="https://url.spec.whatwg.org/#default-port">https://url.spec.whatwg.org/#default-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -6446,29 +6446,29 @@ rest of Google’s CSP Cabal.</p>
     port-part matching </a> <a href="#ref-for-default-port②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-url-host">
-   <a href="https://url.spec.whatwg.org/#dom-url-host">https://url.spec.whatwg.org/#dom-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-url-host" class="dfn-panel" data-for="term-for-dom-url-host" id="infopanel-for-term-for-dom-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-url-host" style="display:none">Info about the 'host (for URL)' external reference.</span><a href="https://url.spec.whatwg.org/#dom-url-host">https://url.spec.whatwg.org/#dom-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-host">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-dom-url-host①">(2)</a> <a href="#ref-for-dom-url-host②">(3)</a> <a href="#ref-for-dom-url-host③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host (for url)' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv6">
-   <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv6" class="dfn-panel" data-for="term-for-concept-ipv6" id="infopanel-for-term-for-concept-ipv6" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv6" style="display:none">Info about the 'ipv6 address' external reference.</span><a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6">6.6.2.8. 
     host-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">4.1.1. 
     Set response’s CSP list </a>
@@ -6476,8 +6476,8 @@ rest of Google’s CSP Cabal.</p>
     Does url match expression in origin with redirect count? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -6485,22 +6485,22 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-percent-decode">
-   <a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-percent-decode" class="dfn-panel" data-for="term-for-string-percent-decode" id="infopanel-for-term-for-string-percent-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-string-percent-decode" style="display:none">Info about the 'percent-decode' external reference.</span><a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-percent-decode">6.6.2.10. 
     path-part matching </a> <a href="#ref-for-string-percent-decode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-url-port">
-   <a href="https://url.spec.whatwg.org/#dom-url-port">https://url.spec.whatwg.org/#dom-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-url-port" class="dfn-panel" data-for="term-for-dom-url-port" id="infopanel-for-term-for-dom-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-url-port" style="display:none">Info about the 'port (for URL)' external reference.</span><a href="https://url.spec.whatwg.org/#dom-url-port">https://url.spec.whatwg.org/#dom-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-dom-url-port①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port (for url)' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -6508,8 +6508,8 @@ rest of Google’s CSP Cabal.</p>
     port-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.2.1. 
     Initialize a Document's CSP list </a>
@@ -6526,8 +6526,8 @@ rest of Google’s CSP Cabal.</p>
     port-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">5.3. 
     Report a violation </a>
@@ -6535,8 +6535,8 @@ rest of Google’s CSP Cabal.</p>
     frame-ancestors Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">5.2. 
     Obtain the deprecated serialization of violation </a> <a href="#ref-for-concept-url-serializer①">(2)</a> <a href="#ref-for-concept-url-serializer②">(3)</a> <a href="#ref-for-concept-url-serializer③">(4)</a>
@@ -6544,8 +6544,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-concept-url-serializer⑤">(2)</a> <a href="#ref-for-concept-url-serializer⑥">(3)</a> <a href="#ref-for-concept-url-serializer⑦">(4)</a> <a href="#ref-for-concept-url-serializer⑧">(5)</a> <a href="#ref-for-concept-url-serializer⑨">(6)</a> <a href="#ref-for-concept-url-serializer①⓪">(7)</a> <a href="#ref-for-concept-url-serializer①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5. 
     Reporting </a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
@@ -6553,8 +6553,8 @@ rest of Google’s CSP Cabal.</p>
     Violation DOM Events </a> <a href="#ref-for-idl-DOMString④">(2)</a> <a href="#ref-for-idl-DOMString⑤">(3)</a> <a href="#ref-for-idl-DOMString⑥">(4)</a> <a href="#ref-for-idl-DOMString⑦">(5)</a> <a href="#ref-for-idl-DOMString⑧">(6)</a> <a href="#ref-for-idl-DOMString⑨">(7)</a> <a href="#ref-for-idl-DOMString①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5. 
     Reporting </a>
@@ -6562,8 +6562,8 @@ rest of Google’s CSP Cabal.</p>
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">5. 
     Reporting </a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a>
@@ -6571,8 +6571,8 @@ rest of Google’s CSP Cabal.</p>
     Violation DOM Events </a> <a href="#ref-for-idl-USVString⑤">(2)</a> <a href="#ref-for-idl-USVString⑥">(3)</a> <a href="#ref-for-idl-USVString⑦">(4)</a> <a href="#ref-for-idl-USVString⑧">(5)</a> <a href="#ref-for-idl-USVString⑨">(6)</a> <a href="#ref-for-idl-USVString①⓪">(7)</a> <a href="#ref-for-idl-USVString①①">(8)</a> <a href="#ref-for-idl-USVString①②">(9)</a> <a href="#ref-for-idl-USVString①③">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">5. 
     Reporting </a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
@@ -6580,8 +6580,8 @@ rest of Google’s CSP Cabal.</p>
     Violation DOM Events </a> <a href="#ref-for-idl-unsigned-long③">(2)</a> <a href="#ref-for-idl-unsigned-long④">(3)</a> <a href="#ref-for-idl-unsigned-long⑤">(4)</a> <a href="#ref-for-idl-unsigned-long⑥">(5)</a> <a href="#ref-for-idl-unsigned-long⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">5. 
     Reporting </a>
@@ -7021,23 +7021,23 @@ rest of Google’s CSP Cabal.</p>
   before the <a href="#is-element-nonceable">§ 6.6.3.1 Is element nonceable?</a> algorithm can be run which makes it
   impossible to actually detect duplicate attributes. <a href="https://github.com/whatwg/html/issues/3257">[Issue #whatwg/html#3257]</a> <a class="issue-return" href="#issue-74cb0fbd" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="content-security-policy">
-   <b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy" class="dfn-panel" data-for="content-security-policy" id="infopanel-for-content-security-policy" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy" style="display:none">Info about the 'Content Security Policy' definition.</span><b><a href="#content-security-policy">#content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy">4.2.6. 
     Should navigation response to navigation request of type
     in target be blocked by Content Security Policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-optional-ascii-whitespace">
-   <b><a href="#grammardef-optional-ascii-whitespace">#grammardef-optional-ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-optional-ascii-whitespace" class="dfn-panel" data-for="grammardef-optional-ascii-whitespace" id="infopanel-for-grammardef-optional-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-grammardef-optional-ascii-whitespace" style="display:none">Info about the 'optional-ascii-whitespace' definition.</span><b><a href="#grammardef-optional-ascii-whitespace">#grammardef-optional-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-optional-ascii-whitespace">2.1. Infrastructure</a> <a href="#ref-for-grammardef-optional-ascii-whitespace①">(2)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace②">(3)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace③">(4)</a> <a href="#ref-for-grammardef-optional-ascii-whitespace④">(5)</a>
     <li><a href="#ref-for-grammardef-optional-ascii-whitespace⑤">2.2. Policies</a> <a href="#ref-for-grammardef-optional-ascii-whitespace⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-required-ascii-whitespace">
-   <b><a href="#grammardef-required-ascii-whitespace">#grammardef-required-ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-required-ascii-whitespace" class="dfn-panel" data-for="grammardef-required-ascii-whitespace" id="infopanel-for-grammardef-required-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-grammardef-required-ascii-whitespace" style="display:none">Info about the 'required-ascii-whitespace' definition.</span><b><a href="#grammardef-required-ascii-whitespace">#grammardef-required-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-required-ascii-whitespace">2.3. Directives</a> <a href="#ref-for-grammardef-required-ascii-whitespace①">(2)</a>
     <li><a href="#ref-for-grammardef-required-ascii-whitespace②">2.3.1. Source Lists</a>
@@ -7046,8 +7046,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-required-ascii-whitespace⑤">6.4.1. report-uri</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy-object">
-   <b><a href="#content-security-policy-object">#content-security-policy-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy-object" class="dfn-panel" data-for="content-security-policy-object" id="infopanel-for-content-security-policy-object" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy-object" style="display:none">Info about the 'policy' definition.</span><b><a href="#content-security-policy-object">#content-security-policy-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-object">2.2. Policies</a> <a href="#ref-for-content-security-policy-object①">(2)</a> <a href="#ref-for-content-security-policy-object②">(3)</a>
     <li><a href="#ref-for-content-security-policy-object③">2.2.1. 
@@ -7175,8 +7175,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-content-security-policy-object⑧③">9.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-directive-set">
-   <b><a href="#policy-directive-set">#policy-directive-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-directive-set" class="dfn-panel" data-for="policy-directive-set" id="infopanel-for-policy-directive-set" role="dialog">
+   <span id="infopaneltitle-for-policy-directive-set" style="display:none">Info about the 'directive set' definition.</span><b><a href="#policy-directive-set">#policy-directive-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive-set">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-policy-directive-set①">(2)</a> <a href="#ref-for-policy-directive-set②">(3)</a> <a href="#ref-for-policy-directive-set③">(4)</a>
@@ -7191,8 +7191,8 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-disposition">
-   <b><a href="#policy-disposition">#policy-disposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-disposition" class="dfn-panel" data-for="policy-disposition" id="infopanel-for-policy-disposition" role="dialog">
+   <span id="infopaneltitle-for-policy-disposition" style="display:none">Info about the 'disposition' definition.</span><b><a href="#policy-disposition">#policy-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-disposition">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-policy-disposition①">(2)</a>
@@ -7229,8 +7229,8 @@ rest of Google’s CSP Cabal.</p>
 		Relation to X-Frame-Options </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-source">
-   <b><a href="#policy-source">#policy-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-source" class="dfn-panel" data-for="policy-source" id="infopanel-for-policy-source" role="dialog">
+   <span id="infopaneltitle-for-policy-source" style="display:none">Info about the 'source' definition.</span><b><a href="#policy-source">#policy-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-source">2.2. Policies</a>
     <li><a href="#ref-for-policy-source①">2.2.1. 
@@ -7241,8 +7241,8 @@ rest of Google’s CSP Cabal.</p>
     Set response’s CSP list </a> <a href="#ref-for-policy-source⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-self-origin">
-   <b><a href="#policy-self-origin">#policy-self-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-self-origin" class="dfn-panel" data-for="policy-self-origin" id="infopanel-for-policy-self-origin" role="dialog">
+   <span id="infopaneltitle-for-policy-self-origin" style="display:none">Info about the 'self-origin' definition.</span><b><a href="#policy-self-origin">#policy-self-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-self-origin">4.1.1. 
     Set response’s CSP list </a>
@@ -7258,14 +7258,14 @@ rest of Google’s CSP Cabal.</p>
     Does response to request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csp-list">
-   <b><a href="#csp-list">#csp-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csp-list" class="dfn-panel" data-for="csp-list" id="infopanel-for-csp-list" role="dialog">
+   <span id="infopaneltitle-for-csp-list" style="display:none">Info about the 'CSP list' definition.</span><b><a href="#csp-list">#csp-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csp-list">2.2. Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-csp">
-   <b><a href="#serialized-csp">#serialized-csp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-csp" class="dfn-panel" data-for="serialized-csp" id="infopanel-for-serialized-csp" role="dialog">
+   <span id="infopaneltitle-for-serialized-csp" style="display:none">Info about the 'serialized CSP' definition.</span><b><a href="#serialized-csp">#serialized-csp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-csp">2.2. Policies</a>
     <li><a href="#ref-for-serialized-csp①">2.3.1. Source Lists</a>
@@ -7283,8 +7283,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-serialized-csp⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-serialized-policy">
-   <b><a href="#grammardef-serialized-policy">#grammardef-serialized-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-serialized-policy" class="dfn-panel" data-for="grammardef-serialized-policy" id="infopanel-for-grammardef-serialized-policy" role="dialog">
+   <span id="infopaneltitle-for-grammardef-serialized-policy" style="display:none">Info about the 'serialized-policy' definition.</span><b><a href="#grammardef-serialized-policy">#grammardef-serialized-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-serialized-policy">2.2. Policies</a>
     <li><a href="#ref-for-grammardef-serialized-policy①">3.1. 
@@ -7293,8 +7293,8 @@ rest of Google’s CSP Cabal.</p>
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp">
-   <b><a href="#abstract-opdef-parse-a-serialized-csp">#abstract-opdef-parse-a-serialized-csp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-parse-a-serialized-csp" class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp" id="infopanel-for-abstract-opdef-parse-a-serialized-csp" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-parse-a-serialized-csp" style="display:none">Info about the 'parse a serialized CSP' definition.</span><b><a href="#abstract-opdef-parse-a-serialized-csp">#abstract-opdef-parse-a-serialized-csp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-parse-a-serialized-csp">2.2.2. 
     Parse a serialized CSP list </a>
@@ -7306,15 +7306,15 @@ rest of Google’s CSP Cabal.</p>
     Integration with Fetch </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp-list">
-   <b><a href="#abstract-opdef-parse-a-serialized-csp-list">#abstract-opdef-parse-a-serialized-csp-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-parse-a-serialized-csp-list" class="dfn-panel" data-for="abstract-opdef-parse-a-serialized-csp-list" id="infopanel-for-abstract-opdef-parse-a-serialized-csp-list" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-parse-a-serialized-csp-list" style="display:none">Info about the 'parse a serialized CSP list' definition.</span><b><a href="#abstract-opdef-parse-a-serialized-csp-list">#abstract-opdef-parse-a-serialized-csp-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-parse-a-serialized-csp-list">4.1.1. 
     Set response’s CSP list </a> <a href="#ref-for-abstract-opdef-parse-a-serialized-csp-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directives">
-   <b><a href="#directives">#directives</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directives" class="dfn-panel" data-for="directives" id="infopanel-for-directives" role="dialog">
+   <span id="infopaneltitle-for-directives" style="display:none">Info about the 'directives' definition.</span><b><a href="#directives">#directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directives">2.2. Policies</a>
     <li><a href="#ref-for-directives①">2.2.1. 
@@ -7364,8 +7364,8 @@ rest of Google’s CSP Cabal.</p>
     Get fetch directive fallback list </a> <a href="#ref-for-directives③④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-name">
-   <b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-name" class="dfn-panel" data-for="directive-name" id="infopanel-for-directive-name" role="dialog">
+   <span id="infopaneltitle-for-directive-name" style="display:none">Info about the 'name' definition.</span><b><a href="#directive-name">#directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name">2.2.1. 
     Parse a serialized CSP </a> <a href="#ref-for-directive-name①">(2)</a>
@@ -7398,8 +7398,8 @@ rest of Google’s CSP Cabal.</p>
     Should fetch directive execute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-value">
-   <b><a href="#directive-value">#directive-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-value" class="dfn-panel" data-for="directive-value" id="infopanel-for-directive-value" role="dialog">
+   <span id="infopaneltitle-for-directive-value" style="display:none">Info about the 'value' definition.</span><b><a href="#directive-value">#directive-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value">2.2.1. 
     Parse a serialized CSP </a>
@@ -7498,32 +7498,32 @@ rest of Google’s CSP Cabal.</p>
     Script directives post-request check </a> <a href="#ref-for-directive-value⑥②">(2)</a> <a href="#ref-for-directive-value⑥③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-directive">
-   <b><a href="#serialized-directive">#serialized-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-directive" class="dfn-panel" data-for="serialized-directive" id="infopanel-for-serialized-directive" role="dialog">
+   <span id="infopaneltitle-for-serialized-directive" style="display:none">Info about the 'serialized directive' definition.</span><b><a href="#serialized-directive">#serialized-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-directive">2.2. Policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-serialized-directive">
-   <b><a href="#grammardef-serialized-directive">#grammardef-serialized-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-serialized-directive" class="dfn-panel" data-for="grammardef-serialized-directive" id="infopanel-for-grammardef-serialized-directive" role="dialog">
+   <span id="infopaneltitle-for-grammardef-serialized-directive" style="display:none">Info about the 'serialized-directive' definition.</span><b><a href="#grammardef-serialized-directive">#grammardef-serialized-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-serialized-directive">2.2. Policies</a> <a href="#ref-for-grammardef-serialized-directive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-directive-name">
-   <b><a href="#grammardef-directive-name">#grammardef-directive-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-directive-name" class="dfn-panel" data-for="grammardef-directive-name" id="infopanel-for-grammardef-directive-name" role="dialog">
+   <span id="infopaneltitle-for-grammardef-directive-name" style="display:none">Info about the 'directive-name' definition.</span><b><a href="#grammardef-directive-name">#grammardef-directive-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-directive-name">2.3. Directives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-directive-value">
-   <b><a href="#grammardef-directive-value">#grammardef-directive-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-directive-value" class="dfn-panel" data-for="grammardef-directive-value" id="infopanel-for-grammardef-directive-value" role="dialog">
+   <span id="infopaneltitle-for-grammardef-directive-value" style="display:none">Info about the 'directive-value' definition.</span><b><a href="#grammardef-directive-value">#grammardef-directive-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-directive-value">2.3. Directives</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-pre-request-check">
-   <b><a href="#directive-pre-request-check">#directive-pre-request-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-pre-request-check" class="dfn-panel" data-for="directive-pre-request-check" id="infopanel-for-directive-pre-request-check" role="dialog">
+   <span id="infopaneltitle-for-directive-pre-request-check" style="display:none">Info about the 'pre-request check' definition.</span><b><a href="#directive-pre-request-check">#directive-pre-request-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-pre-request-check">4.1. 
     Integration with Fetch </a>
@@ -7565,8 +7565,8 @@ rest of Google’s CSP Cabal.</p>
     Does request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-post-request-check">
-   <b><a href="#directive-post-request-check">#directive-post-request-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-post-request-check" class="dfn-panel" data-for="directive-post-request-check" id="infopanel-for-directive-post-request-check" role="dialog">
+   <span id="infopaneltitle-for-directive-post-request-check" style="display:none">Info about the 'post-request check' definition.</span><b><a href="#directive-post-request-check">#directive-post-request-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-post-request-check">4.1. 
     Integration with Fetch </a>
@@ -7610,8 +7610,8 @@ rest of Google’s CSP Cabal.</p>
     Does response to request match source list? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-response-check">
-   <b><a href="#directive-response-check">#directive-response-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-response-check" class="dfn-panel" data-for="directive-response-check" id="infopanel-for-directive-response-check" role="dialog">
+   <span id="infopaneltitle-for-directive-response-check" style="display:none">Info about the 'response check' definition.</span><b><a href="#directive-response-check">#directive-response-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-response-check">4.1. 
     Integration with Fetch </a>
@@ -7623,8 +7623,8 @@ rest of Google’s CSP Cabal.</p>
     Directives Defined in Other Documents </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-inline-check">
-   <b><a href="#directive-inline-check">#directive-inline-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-inline-check" class="dfn-panel" data-for="directive-inline-check" id="infopanel-for-directive-inline-check" role="dialog">
+   <span id="infopaneltitle-for-directive-inline-check" style="display:none">Info about the 'inline check' definition.</span><b><a href="#directive-inline-check">#directive-inline-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-inline-check">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
@@ -7647,8 +7647,8 @@ rest of Google’s CSP Cabal.</p>
     style-src-attr Inline Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-initialization">
-   <b><a href="#directive-initialization">#directive-initialization</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-initialization" class="dfn-panel" data-for="directive-initialization" id="infopanel-for-directive-initialization" role="dialog">
+   <span id="infopaneltitle-for-directive-initialization" style="display:none">Info about the 'initialization' definition.</span><b><a href="#directive-initialization">#directive-initialization</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-initialization">4.2.1. 
     Initialize a Document's CSP list </a>
@@ -7660,8 +7660,8 @@ rest of Google’s CSP Cabal.</p>
     Directives Defined in Other Documents </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-pre-navigation-check">
-   <b><a href="#directive-pre-navigation-check">#directive-pre-navigation-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-pre-navigation-check" class="dfn-panel" data-for="directive-pre-navigation-check" id="infopanel-for-directive-pre-navigation-check" role="dialog">
+   <span id="infopaneltitle-for-directive-pre-navigation-check" style="display:none">Info about the 'pre-navigation check' definition.</span><b><a href="#directive-pre-navigation-check">#directive-pre-navigation-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-pre-navigation-check">4.2.5. 
     Should navigation request of type be blocked
@@ -7672,8 +7672,8 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Pre-Navigation Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="directive-navigation-response-check">
-   <b><a href="#directive-navigation-response-check">#directive-navigation-response-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-directive-navigation-response-check" class="dfn-panel" data-for="directive-navigation-response-check" id="infopanel-for-directive-navigation-response-check" role="dialog">
+   <span id="infopaneltitle-for-directive-navigation-response-check" style="display:none">Info about the 'navigation response check' definition.</span><b><a href="#directive-navigation-response-check">#directive-navigation-response-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-navigation-response-check">4.2.6. 
     Should navigation response to navigation request of type
@@ -7684,8 +7684,8 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-lists">
-   <b><a href="#source-lists">#source-lists</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-lists" class="dfn-panel" data-for="source-lists" id="infopanel-for-source-lists" role="dialog">
+   <span id="infopaneltitle-for-source-lists" style="display:none">Info about the 'source lists' definition.</span><b><a href="#source-lists">#source-lists</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-lists">6.1.1. child-src</a>
     <li><a href="#ref-for-source-lists①">6.1.2. connect-src</a>
@@ -7713,8 +7713,9 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-expression">
-   <b><a href="#source-expression">#source-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-expression" class="dfn-panel" data-for="source-expression" id="infopanel-for-source-expression" role="dialog">
+   <span id="infopaneltitle-for-source-expression" style="display:none">Info about the 'source
+  expression' definition.</span><b><a href="#source-expression">#source-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-expression">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-source-expression①">2.3.1. Source Lists</a>
@@ -7732,8 +7733,8 @@ rest of Google’s CSP Cabal.</p>
       Allowing external JavaScript via hashes </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-serialized-source-list">
-   <b><a href="#grammardef-serialized-source-list">#grammardef-serialized-source-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-serialized-source-list" class="dfn-panel" data-for="grammardef-serialized-source-list" id="infopanel-for-grammardef-serialized-source-list" role="dialog">
+   <span id="infopaneltitle-for-grammardef-serialized-source-list" style="display:none">Info about the 'serialized-source-list' definition.</span><b><a href="#grammardef-serialized-source-list">#grammardef-serialized-source-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-serialized-source-list">6.1.1. child-src</a>
     <li><a href="#ref-for-grammardef-serialized-source-list①">6.1.2. connect-src</a>
@@ -7757,21 +7758,21 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-grammardef-serialized-source-list①⑨">6.3.3. navigate-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-none">
-   <b><a href="#grammardef-none">#grammardef-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-none" class="dfn-panel" data-for="grammardef-none" id="infopanel-for-grammardef-none" role="dialog">
+   <span id="infopaneltitle-for-grammardef-none" style="display:none">Info about the ''none'' definition.</span><b><a href="#grammardef-none">#grammardef-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-none">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-none①">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-source-expression">
-   <b><a href="#grammardef-source-expression">#grammardef-source-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-source-expression" class="dfn-panel" data-for="grammardef-source-expression" id="infopanel-for-grammardef-source-expression" role="dialog">
+   <span id="infopaneltitle-for-grammardef-source-expression" style="display:none">Info about the 'source-expression' definition.</span><b><a href="#grammardef-source-expression">#grammardef-source-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-source-expression">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-source-expression①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-scheme-source">
-   <b><a href="#grammardef-scheme-source">#grammardef-scheme-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-scheme-source" class="dfn-panel" data-for="grammardef-scheme-source" id="infopanel-for-grammardef-scheme-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-scheme-source" style="display:none">Info about the 'scheme-source' definition.</span><b><a href="#grammardef-scheme-source">#grammardef-scheme-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-scheme-source①">6.3.2. frame-ancestors</a>
@@ -7781,8 +7782,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-host-source">
-   <b><a href="#grammardef-host-source">#grammardef-host-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-host-source" class="dfn-panel" data-for="grammardef-host-source" id="infopanel-for-grammardef-host-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-host-source" style="display:none">Info about the 'host-source' definition.</span><b><a href="#grammardef-host-source">#grammardef-host-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-host-source①">6.3.2. frame-ancestors</a>
@@ -7793,8 +7794,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-scheme-part">
-   <b><a href="#grammardef-scheme-part">#grammardef-scheme-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-scheme-part" class="dfn-panel" data-for="grammardef-scheme-part" id="infopanel-for-grammardef-scheme-part" role="dialog">
+   <span id="infopaneltitle-for-grammardef-scheme-part" style="display:none">Info about the 'scheme-part' definition.</span><b><a href="#grammardef-scheme-part">#grammardef-scheme-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-scheme-part">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-scheme-part①">(2)</a>
     <li><a href="#ref-for-grammardef-scheme-part②">6.6.2.6. 
@@ -7803,8 +7804,8 @@ rest of Google’s CSP Cabal.</p>
     scheme-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-host-part">
-   <b><a href="#grammardef-host-part">#grammardef-host-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-host-part" class="dfn-panel" data-for="grammardef-host-part" id="infopanel-for-grammardef-host-part" role="dialog">
+   <span id="infopaneltitle-for-grammardef-host-part" style="display:none">Info about the 'host-part' definition.</span><b><a href="#grammardef-host-part">#grammardef-host-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host-part">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-host-part①">6.6.2.6. 
@@ -7813,14 +7814,14 @@ rest of Google’s CSP Cabal.</p>
     host-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-host-char">
-   <b><a href="#grammardef-host-char">#grammardef-host-char</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-host-char" class="dfn-panel" data-for="grammardef-host-char" id="infopanel-for-grammardef-host-char" role="dialog">
+   <span id="infopaneltitle-for-grammardef-host-char" style="display:none">Info about the 'host-char' definition.</span><b><a href="#grammardef-host-char">#grammardef-host-char</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-host-char">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-host-char①">(2)</a> <a href="#ref-for-grammardef-host-char②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-port-part">
-   <b><a href="#grammardef-port-part">#grammardef-port-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-port-part" class="dfn-panel" data-for="grammardef-port-part" id="infopanel-for-grammardef-port-part" role="dialog">
+   <span id="infopaneltitle-for-grammardef-port-part" style="display:none">Info about the 'port-part' definition.</span><b><a href="#grammardef-port-part">#grammardef-port-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-port-part">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-port-part①">6.6.2.6. 
@@ -7829,8 +7830,8 @@ rest of Google’s CSP Cabal.</p>
     port-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-path-part">
-   <b><a href="#grammardef-path-part">#grammardef-path-part</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-path-part" class="dfn-panel" data-for="grammardef-path-part" id="infopanel-for-grammardef-path-part" role="dialog">
+   <span id="infopaneltitle-for-grammardef-path-part" style="display:none">Info about the 'path-part' definition.</span><b><a href="#grammardef-path-part">#grammardef-path-part</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-path-part">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-path-part①">6.6.2.6. 
@@ -7839,8 +7840,8 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-keyword-source">
-   <b><a href="#grammardef-keyword-source">#grammardef-keyword-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-keyword-source" class="dfn-panel" data-for="grammardef-keyword-source" id="infopanel-for-grammardef-keyword-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-keyword-source" style="display:none">Info about the 'keyword-source' definition.</span><b><a href="#grammardef-keyword-source">#grammardef-keyword-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-keyword-source">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-keyword-source①">6.3.3.1. 
@@ -7857,8 +7858,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-self">
-   <b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-self" class="dfn-panel" data-for="grammardef-self" id="infopanel-for-grammardef-self" role="dialog">
+   <span id="infopaneltitle-for-grammardef-self" style="display:none">Info about the ''self'' definition.</span><b><a href="#grammardef-self">#grammardef-self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-self">2.2. Policies</a> <a href="#ref-for-grammardef-self①">(2)</a>
     <li><a href="#ref-for-grammardef-self②">2.3.1. Source Lists</a>
@@ -7870,8 +7871,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-unsafe-inline">
-   <b><a href="#grammardef-unsafe-inline">#grammardef-unsafe-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-unsafe-inline" class="dfn-panel" data-for="grammardef-unsafe-inline" id="infopanel-for-grammardef-unsafe-inline" role="dialog">
+   <span id="infopaneltitle-for-grammardef-unsafe-inline" style="display:none">Info about the ''unsafe-inline'' definition.</span><b><a href="#grammardef-unsafe-inline">#grammardef-unsafe-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-inline">6. 
     Content Security Policy Directives </a>
@@ -7882,15 +7883,15 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-unsafe-eval">
-   <b><a href="#grammardef-unsafe-eval">#grammardef-unsafe-eval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-unsafe-eval" class="dfn-panel" data-for="grammardef-unsafe-eval" id="infopanel-for-grammardef-unsafe-eval" role="dialog">
+   <span id="infopaneltitle-for-grammardef-unsafe-eval" style="display:none">Info about the ''unsafe-eval'' definition.</span><b><a href="#grammardef-unsafe-eval">#grammardef-unsafe-eval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-eval">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-strict-dynamic">
-   <b><a href="#grammardef-strict-dynamic">#grammardef-strict-dynamic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-strict-dynamic" class="dfn-panel" data-for="grammardef-strict-dynamic" id="infopanel-for-grammardef-strict-dynamic" role="dialog">
+   <span id="infopaneltitle-for-grammardef-strict-dynamic" style="display:none">Info about the ''strict-dynamic'' definition.</span><b><a href="#grammardef-strict-dynamic">#grammardef-strict-dynamic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-strict-dynamic">6.6.1.1. 
     Script directives pre-request check </a> <a href="#ref-for-grammardef-strict-dynamic①">(2)</a>
@@ -7902,8 +7903,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a> <a href="#ref-for-grammardef-strict-dynamic⑤">(2)</a> <a href="#ref-for-grammardef-strict-dynamic⑥">(3)</a> <a href="#ref-for-grammardef-strict-dynamic⑦">(4)</a> <a href="#ref-for-grammardef-strict-dynamic⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-unsafe-hashes">
-   <b><a href="#grammardef-unsafe-hashes">#grammardef-unsafe-hashes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-unsafe-hashes" class="dfn-panel" data-for="grammardef-unsafe-hashes" id="infopanel-for-grammardef-unsafe-hashes" role="dialog">
+   <span id="infopaneltitle-for-grammardef-unsafe-hashes" style="display:none">Info about the ''unsafe-hashes'' definition.</span><b><a href="#grammardef-unsafe-hashes">#grammardef-unsafe-hashes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-hashes">6.6.3.3. 
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-unsafe-hashes①">(2)</a>
@@ -7911,8 +7912,8 @@ rest of Google’s CSP Cabal.</p>
       Usage of "'unsafe-hashes'" </a> <a href="#ref-for-grammardef-unsafe-hashes③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-report-sample">
-   <b><a href="#grammardef-report-sample">#grammardef-report-sample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-report-sample" class="dfn-panel" data-for="grammardef-report-sample" id="infopanel-for-grammardef-report-sample" role="dialog">
+   <span id="infopaneltitle-for-grammardef-report-sample" style="display:none">Info about the ''report-sample'' definition.</span><b><a href="#grammardef-report-sample">#grammardef-report-sample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-report-sample">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-grammardef-report-sample①">4.2.4. 
@@ -7921,8 +7922,8 @@ rest of Google’s CSP Cabal.</p>
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-unsafe-allow-redirects">
-   <b><a href="#grammardef-unsafe-allow-redirects">#grammardef-unsafe-allow-redirects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-unsafe-allow-redirects" class="dfn-panel" data-for="grammardef-unsafe-allow-redirects" id="infopanel-for-grammardef-unsafe-allow-redirects" role="dialog">
+   <span id="infopaneltitle-for-grammardef-unsafe-allow-redirects" style="display:none">Info about the ''unsafe-allow-redirects'' definition.</span><b><a href="#grammardef-unsafe-allow-redirects">#grammardef-unsafe-allow-redirects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-allow-redirects">6.3.3.1. 
     navigate-to Pre-Navigation Check </a>
@@ -7930,8 +7931,8 @@ rest of Google’s CSP Cabal.</p>
     navigate-to Navigation Response Check </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-nonce-source">
-   <b><a href="#grammardef-nonce-source">#grammardef-nonce-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-nonce-source" class="dfn-panel" data-for="grammardef-nonce-source" id="infopanel-for-grammardef-nonce-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-nonce-source" style="display:none">Info about the 'nonce-source' definition.</span><b><a href="#grammardef-nonce-source">#grammardef-nonce-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-nonce-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-nonce-source①">(2)</a>
     <li><a href="#ref-for-grammardef-nonce-source②">6.1.11. script-src</a>
@@ -7949,8 +7950,8 @@ rest of Google’s CSP Cabal.</p>
     Usage of "'strict-dynamic'" </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-base64-value">
-   <b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-base64-value" class="dfn-panel" data-for="grammardef-base64-value" id="infopanel-for-grammardef-base64-value" role="dialog">
+   <span id="infopaneltitle-for-grammardef-base64-value" style="display:none">Info about the 'base64-value' definition.</span><b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-base64-value">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-base64-value①">(2)</a> <a href="#ref-for-grammardef-base64-value②">(3)</a> <a href="#ref-for-grammardef-base64-value③">(4)</a>
     <li><a href="#ref-for-grammardef-base64-value④">6.6.1.1. 
@@ -7961,8 +7962,8 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-base64-value⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-hash-source">
-   <b><a href="#grammardef-hash-source">#grammardef-hash-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-hash-source" class="dfn-panel" data-for="grammardef-hash-source" id="infopanel-for-grammardef-hash-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-hash-source" style="display:none">Info about the 'hash-source' definition.</span><b><a href="#grammardef-hash-source">#grammardef-hash-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-source">2.3.1. Source Lists</a> <a href="#ref-for-grammardef-hash-source①">(2)</a>
     <li><a href="#ref-for-grammardef-hash-source②">6.1.11. script-src</a>
@@ -7979,8 +7980,8 @@ rest of Google’s CSP Cabal.</p>
       Allowing external JavaScript via hashes </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-hash-algorithm">
-   <b><a href="#grammardef-hash-algorithm">#grammardef-hash-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-hash-algorithm" class="dfn-panel" data-for="grammardef-hash-algorithm" id="infopanel-for-grammardef-hash-algorithm" role="dialog">
+   <span id="infopaneltitle-for-grammardef-hash-algorithm" style="display:none">Info about the 'hash-algorithm' definition.</span><b><a href="#grammardef-hash-algorithm">#grammardef-hash-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-algorithm">2.3.1. Source Lists</a>
     <li><a href="#ref-for-grammardef-hash-algorithm①">6.6.1.1. 
@@ -7989,8 +7990,8 @@ rest of Google’s CSP Cabal.</p>
     Does element match source list for type and source? </a> <a href="#ref-for-grammardef-hash-algorithm④">(2)</a> <a href="#ref-for-grammardef-hash-algorithm⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation">
-   <b><a href="#violation">#violation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation" class="dfn-panel" data-for="violation" id="infopanel-for-violation" role="dialog">
+   <span id="infopaneltitle-for-violation" style="display:none">Info about the 'violation' definition.</span><b><a href="#violation">#violation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation">2.4. Violations</a> <a href="#ref-for-violation①">(2)</a> <a href="#ref-for-violation②">(3)</a> <a href="#ref-for-violation③">(4)</a> <a href="#ref-for-violation④">(5)</a> <a href="#ref-for-violation⑤">(6)</a> <a href="#ref-for-violation⑥">(7)</a> <a href="#ref-for-violation⑦">(8)</a> <a href="#ref-for-violation⑧">(9)</a> <a href="#ref-for-violation⑨">(10)</a> <a href="#ref-for-violation①⓪">(11)</a> <a href="#ref-for-violation①①">(12)</a> <a href="#ref-for-violation①②">(13)</a> <a href="#ref-for-violation①③">(14)</a>
     <li><a href="#ref-for-violation①④">2.4.1. 
@@ -8005,8 +8006,8 @@ rest of Google’s CSP Cabal.</p>
     Reporting Directives </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-global-object">
-   <b><a href="#violation-global-object">#violation-global-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-global-object" class="dfn-panel" data-for="violation-global-object" id="infopanel-for-violation-global-object" role="dialog">
+   <span id="infopaneltitle-for-violation-global-object" style="display:none">Info about the 'global object' definition.</span><b><a href="#violation-global-object">#violation-global-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-global-object">2.4. Violations</a>
     <li><a href="#ref-for-violation-global-object①">2.4.1. 
@@ -8015,8 +8016,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-global-object④">(2)</a> <a href="#ref-for-violation-global-object⑤">(3)</a> <a href="#ref-for-violation-global-object⑥">(4)</a> <a href="#ref-for-violation-global-object⑦">(5)</a> <a href="#ref-for-violation-global-object⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-url">
-   <b><a href="#violation-url">#violation-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-url" class="dfn-panel" data-for="violation-url" id="infopanel-for-violation-url" role="dialog">
+   <span id="infopaneltitle-for-violation-url" style="display:none">Info about the 'url' definition.</span><b><a href="#violation-url">#violation-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-url">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -8024,8 +8025,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-url②">(2)</a> <a href="#ref-for-violation-url③">(3)</a> <a href="#ref-for-violation-url④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-status">
-   <b><a href="#violation-status">#violation-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-status" class="dfn-panel" data-for="violation-status" id="infopanel-for-violation-status" role="dialog">
+   <span id="infopaneltitle-for-violation-status" style="display:none">Info about the 'status' definition.</span><b><a href="#violation-status">#violation-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-status">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8035,8 +8036,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-status③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-resource">
-   <b><a href="#violation-resource">#violation-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-resource" class="dfn-panel" data-for="violation-resource" id="infopanel-for-violation-resource" role="dialog">
+   <span id="infopaneltitle-for-violation-resource" style="display:none">Info about the 'resource' definition.</span><b><a href="#violation-resource">#violation-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-resource">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8060,8 +8061,8 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-referrer">
-   <b><a href="#violation-referrer">#violation-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-referrer" class="dfn-panel" data-for="violation-referrer" id="infopanel-for-violation-referrer" role="dialog">
+   <span id="infopaneltitle-for-violation-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#violation-referrer">#violation-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-referrer">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8071,8 +8072,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-referrer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-policy">
-   <b><a href="#violation-policy">#violation-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-policy" class="dfn-panel" data-for="violation-policy" id="infopanel-for-violation-policy" role="dialog">
+   <span id="infopaneltitle-for-violation-policy" style="display:none">Info about the 'policy' definition.</span><b><a href="#violation-policy">#violation-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-policy">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8082,15 +8083,15 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-policy④">(2)</a> <a href="#ref-for-violation-policy⑤">(3)</a> <a href="#ref-for-violation-policy⑥">(4)</a> <a href="#ref-for-violation-policy⑦">(5)</a> <a href="#ref-for-violation-policy⑧">(6)</a> <a href="#ref-for-violation-policy⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-disposition">
-   <b><a href="#violation-disposition">#violation-disposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-disposition" class="dfn-panel" data-for="violation-disposition" id="infopanel-for-violation-disposition" role="dialog">
+   <span id="infopaneltitle-for-violation-disposition" style="display:none">Info about the 'disposition' definition.</span><b><a href="#violation-disposition">#violation-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-disposition">5.3. 
     Report a violation </a> <a href="#ref-for-violation-disposition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-effective-directive">
-   <b><a href="#violation-effective-directive">#violation-effective-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-effective-directive" class="dfn-panel" data-for="violation-effective-directive" id="infopanel-for-violation-effective-directive" role="dialog">
+   <span id="infopaneltitle-for-violation-effective-directive" style="display:none">Info about the 'effective directive' definition.</span><b><a href="#violation-effective-directive">#violation-effective-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-effective-directive">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8100,8 +8101,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-effective-directive③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-source-file">
-   <b><a href="#violation-source-file">#violation-source-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-source-file" class="dfn-panel" data-for="violation-source-file" id="infopanel-for-violation-source-file" role="dialog">
+   <span id="infopaneltitle-for-violation-source-file" style="display:none">Info about the 'source file' definition.</span><b><a href="#violation-source-file">#violation-source-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-source-file">2.4.1. 
     Create a violation object for global, policy, and directive </a> <a href="#ref-for-violation-source-file①">(2)</a>
@@ -8111,8 +8112,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-source-file⑤">(2)</a> <a href="#ref-for-violation-source-file⑥">(3)</a> <a href="#ref-for-violation-source-file⑦">(4)</a> <a href="#ref-for-violation-source-file⑧">(5)</a> <a href="#ref-for-violation-source-file⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-line-number">
-   <b><a href="#violation-line-number">#violation-line-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-line-number" class="dfn-panel" data-for="violation-line-number" id="infopanel-for-violation-line-number" role="dialog">
+   <span id="infopaneltitle-for-violation-line-number" style="display:none">Info about the 'line number' definition.</span><b><a href="#violation-line-number">#violation-line-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-line-number">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8122,8 +8123,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-line-number④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-column-number">
-   <b><a href="#violation-column-number">#violation-column-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-column-number" class="dfn-panel" data-for="violation-column-number" id="infopanel-for-violation-column-number" role="dialog">
+   <span id="infopaneltitle-for-violation-column-number" style="display:none">Info about the 'column number' definition.</span><b><a href="#violation-column-number">#violation-column-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-column-number">2.4.1. 
     Create a violation object for global, policy, and directive </a>
@@ -8133,8 +8134,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-column-number④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-element">
-   <b><a href="#violation-element">#violation-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-element" class="dfn-panel" data-for="violation-element" id="infopanel-for-violation-element" role="dialog">
+   <span id="infopaneltitle-for-violation-element" style="display:none">Info about the 'element' definition.</span><b><a href="#violation-element">#violation-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-element">4.2.4. 
     Should element’s inline type behavior be blocked by Content Security Policy? </a>
@@ -8142,8 +8143,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violation-sample">
-   <b><a href="#violation-sample">#violation-sample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violation-sample" class="dfn-panel" data-for="violation-sample" id="infopanel-for-violation-sample" role="dialog">
+   <span id="infopaneltitle-for-violation-sample" style="display:none">Info about the 'sample' definition.</span><b><a href="#violation-sample">#violation-sample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-sample">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-violation-sample①">2.4. Violations</a>
@@ -8157,8 +8158,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a> <a href="#ref-for-violation-sample⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="header-content-security-policy">
-   <b><a href="#header-content-security-policy">#header-content-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-header-content-security-policy" class="dfn-panel" data-for="header-content-security-policy" id="infopanel-for-header-content-security-policy" role="dialog">
+   <span id="infopaneltitle-for-header-content-security-policy" style="display:none">Info about the 'Content-Security-Policy' definition.</span><b><a href="#header-content-security-policy">#header-content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-content-security-policy">1.1.1. Control Execution</a>
     <li><a href="#ref-for-header-content-security-policy①">3.1. 
@@ -8188,8 +8189,8 @@ rest of Google’s CSP Cabal.</p>
       Allowing external JavaScript via hashes </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="header-content-security-policy-report-only">
-   <b><a href="#header-content-security-policy-report-only">#header-content-security-policy-report-only</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-header-content-security-policy-report-only" class="dfn-panel" data-for="header-content-security-policy-report-only" id="infopanel-for-header-content-security-policy-report-only" role="dialog">
+   <span id="infopaneltitle-for-header-content-security-policy-report-only" style="display:none">Info about the 'Content-Security-Policy-Report-Only' definition.</span><b><a href="#header-content-security-policy-report-only">#header-content-security-policy-report-only</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-content-security-policy-report-only">3.2. 
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a> <a href="#ref-for-header-content-security-policy-report-only①">(2)</a>
@@ -8198,8 +8199,10 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-header-content-security-policy-report-only③">6.2.2. sandbox</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-response-csp-list">
-   <b><a href="#set-response-csp-list">#set-response-csp-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-response-csp-list" class="dfn-panel" data-for="set-response-csp-list" id="infopanel-for-set-response-csp-list" role="dialog">
+   <span id="infopaneltitle-for-set-response-csp-list" style="display:none">Info about the '4.1.1. 
+    Set response’s CSP list
+  ' definition.</span><b><a href="#set-response-csp-list">#set-response-csp-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-response-csp-list">4.1. 
     Integration with Fetch </a>
@@ -8207,15 +8210,19 @@ rest of Google’s CSP Cabal.</p>
     Set response’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-for-request">
-   <b><a href="#report-for-request">#report-for-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-for-request" class="dfn-panel" data-for="report-for-request" id="infopanel-for-report-for-request" role="dialog">
+   <span id="infopaneltitle-for-report-for-request" style="display:none">Info about the '4.1.2. 
+    Report Content Security Policy violations for request
+  ' definition.</span><b><a href="#report-for-request">#report-for-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-for-request">4.1.2. 
     Report Content Security Policy violations for request </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-request">
-   <b><a href="#should-block-request">#should-block-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-request" class="dfn-panel" data-for="should-block-request" id="infopanel-for-should-block-request" role="dialog">
+   <span id="infopaneltitle-for-should-block-request" style="display:none">Info about the '4.1.3. 
+    Should request be blocked by Content Security Policy?
+  ' definition.</span><b><a href="#should-block-request">#should-block-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-request">2.3. Directives</a>
     <li><a href="#ref-for-should-block-request">4.1. 
@@ -8227,8 +8234,10 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-should-block-request">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-response">
-   <b><a href="#should-block-response">#should-block-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-response" class="dfn-panel" data-for="should-block-response" id="infopanel-for-should-block-response" role="dialog">
+   <span id="infopaneltitle-for-should-block-response" style="display:none">Info about the '4.1.4. 
+    Should response to request be blocked by Content Security Policy?
+  ' definition.</span><b><a href="#should-block-response">#should-block-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-response">2.3. Directives</a> <a href="#ref-for-should-block-response">(2)</a>
     <li><a href="#ref-for-should-block-response">4.1. 
@@ -8240,8 +8249,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-should-block-response">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="global-object-csp-list">
-   <b><a href="#global-object-csp-list">#global-object-csp-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-global-object-csp-list" class="dfn-panel" data-for="global-object-csp-list" id="infopanel-for-global-object-csp-list" role="dialog">
+   <span id="infopaneltitle-for-global-object-csp-list" style="display:none">Info about the 'CSP list' definition.</span><b><a href="#global-object-csp-list">#global-object-csp-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object-csp-list">4.1. 
     Integration with Fetch </a>
@@ -8276,8 +8285,8 @@ rest of Google’s CSP Cabal.</p>
     CSP Inheriting to avoid bypasses </a> <a href="#ref-for-global-object-csp-list②④">(2)</a> <a href="#ref-for-global-object-csp-list②⑤">(3)</a> <a href="#ref-for-global-object-csp-list②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enforced">
-   <b><a href="#enforced">#enforced</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enforced" class="dfn-panel" data-for="enforced" id="infopanel-for-enforced" role="dialog">
+   <span id="infopaneltitle-for-enforced" style="display:none">Info about the 'enforced' definition.</span><b><a href="#enforced">#enforced</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforced">3.1. 
     The Content-Security-Policy HTTP Response Header Field </a>
@@ -8285,15 +8294,15 @@ rest of Google’s CSP Cabal.</p>
     Integration with HTML </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="monitored">
-   <b><a href="#monitored">#monitored</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-monitored" class="dfn-panel" data-for="monitored" id="infopanel-for-monitored" role="dialog">
+   <span id="infopaneltitle-for-monitored" style="display:none">Info about the 'monitored' definition.</span><b><a href="#monitored">#monitored</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitored">3.2. 
     The Content-Security-Policy-Report-Only HTTP Response Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="embedding-document">
-   <b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-embedding-document" class="dfn-panel" data-for="embedding-document" id="infopanel-for-embedding-document" role="dialog">
+   <span id="infopaneltitle-for-embedding-document" style="display:none">Info about the 'embedding document' definition.</span><b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedding-document">4.2.1. 
     Initialize a Document's CSP list </a> <a href="#ref-for-embedding-document①">(2)</a>
@@ -8301,8 +8310,10 @@ rest of Google’s CSP Cabal.</p>
     Initialize a global object’s CSP list </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-document-csp">
-   <b><a href="#initialize-document-csp">#initialize-document-csp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-document-csp" class="dfn-panel" data-for="initialize-document-csp" id="infopanel-for-initialize-document-csp" role="dialog">
+   <span id="infopaneltitle-for-initialize-document-csp" style="display:none">Info about the '4.2.1. 
+    Initialize a Document's CSP list
+  ' definition.</span><b><a href="#initialize-document-csp">#initialize-document-csp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-document-csp">2.2. Policies</a> <a href="#ref-for-initialize-document-csp">(2)</a>
     <li><a href="#ref-for-initialize-document-csp">2.3. Directives</a>
@@ -8314,8 +8325,10 @@ rest of Google’s CSP Cabal.</p>
     CSP Inheriting to avoid bypasses </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-global-object-csp">
-   <b><a href="#initialize-global-object-csp">#initialize-global-object-csp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-global-object-csp" class="dfn-panel" data-for="initialize-global-object-csp" id="infopanel-for-initialize-global-object-csp" role="dialog">
+   <span id="infopaneltitle-for-initialize-global-object-csp" style="display:none">Info about the '4.2.2. 
+    Initialize a global object’s CSP list
+  ' definition.</span><b><a href="#initialize-global-object-csp">#initialize-global-object-csp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-global-object-csp">2.2. Policies</a>
     <li><a href="#ref-for-initialize-global-object-csp">4.2. 
@@ -8326,8 +8339,10 @@ rest of Google’s CSP Cabal.</p>
     CSP Inheriting to avoid bypasses </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-inline">
-   <b><a href="#should-block-inline">#should-block-inline</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-inline" class="dfn-panel" data-for="should-block-inline" id="infopanel-for-should-block-inline" role="dialog">
+   <span id="infopaneltitle-for-should-block-inline" style="display:none">Info about the '4.2.4. 
+    Should element’s inline type behavior be blocked by Content Security Policy?
+  ' definition.</span><b><a href="#should-block-inline">#should-block-inline</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-inline">2.3. Directives</a>
     <li><a href="#ref-for-should-block-inline">4.2. 
@@ -8338,8 +8353,11 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-should-block-inline">6.1.14. style-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-navigation-request">
-   <b><a href="#should-block-navigation-request">#should-block-navigation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-navigation-request" class="dfn-panel" data-for="should-block-navigation-request" id="infopanel-for-should-block-navigation-request" role="dialog">
+   <span id="infopaneltitle-for-should-block-navigation-request" style="display:none">Info about the '4.2.5. 
+    Should navigation request of type be blocked
+    by Content Security Policy?
+  ' definition.</span><b><a href="#should-block-navigation-request">#should-block-navigation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-navigation-request">2.3. Directives</a> <a href="#ref-for-should-block-navigation-request">(2)</a>
     <li><a href="#ref-for-should-block-navigation-request">4.2. 
@@ -8349,8 +8367,11 @@ rest of Google’s CSP Cabal.</p>
     by Content Security Policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-navigation-response">
-   <b><a href="#should-block-navigation-response">#should-block-navigation-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-navigation-response" class="dfn-panel" data-for="should-block-navigation-response" id="infopanel-for-should-block-navigation-response" role="dialog">
+   <span id="infopaneltitle-for-should-block-navigation-response" style="display:none">Info about the '4.2.6. 
+    Should navigation response to navigation request of type
+    in target be blocked by Content Security Policy?
+  ' definition.</span><b><a href="#should-block-navigation-response">#should-block-navigation-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-navigation-response">2.3. Directives</a>
     <li><a href="#ref-for-should-block-navigation-response">4.2. 
@@ -8360,107 +8381,109 @@ rest of Google’s CSP Cabal.</p>
     in target be blocked by Content Security Policy? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="can-compile-strings">
-   <b><a href="#can-compile-strings">#can-compile-strings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-can-compile-strings" class="dfn-panel" data-for="can-compile-strings" id="infopanel-for-can-compile-strings" role="dialog">
+   <span id="infopaneltitle-for-can-compile-strings" style="display:none">Info about the '4.3.1. 
+    EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source)
+  ' definition.</span><b><a href="#can-compile-strings">#can-compile-strings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-can-compile-strings">4.3.1. 
     EnsureCSPDoesNotBlockStringCompilation(callerRealm, calleeRealm, source) </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="csp-violation-report">
-   <b><a href="#csp-violation-report">#csp-violation-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-csp-violation-report" class="dfn-panel" data-for="csp-violation-report" id="infopanel-for-csp-violation-report" role="dialog">
+   <span id="infopaneltitle-for-csp-violation-report" style="display:none">Info about the 'csp violation report' definition.</span><b><a href="#csp-violation-report">#csp-violation-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-csp-violation-report">5. 
     Reporting </a> <a href="#ref-for-csp-violation-report①">(2)</a>
     <li><a href="#ref-for-csp-violation-report②">6.4.1. report-uri</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cspviolationreportbody">
-   <b><a href="#cspviolationreportbody">#cspviolationreportbody</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cspviolationreportbody" class="dfn-panel" data-for="cspviolationreportbody" id="infopanel-for-cspviolationreportbody" role="dialog">
+   <span id="infopaneltitle-for-cspviolationreportbody" style="display:none">Info about the 'CSPViolationReportBody' definition.</span><b><a href="#cspviolationreportbody">#cspviolationreportbody</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cspviolationreportbody">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-documenturl">
-   <b><a href="#dom-cspviolationreportbody-documenturl">#dom-cspviolationreportbody-documenturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-documenturl" class="dfn-panel" data-for="dom-cspviolationreportbody-documenturl" id="infopanel-for-dom-cspviolationreportbody-documenturl" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-documenturl" style="display:none">Info about the 'documentURL' definition.</span><b><a href="#dom-cspviolationreportbody-documenturl">#dom-cspviolationreportbody-documenturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-documenturl">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-referrer">
-   <b><a href="#dom-cspviolationreportbody-referrer">#dom-cspviolationreportbody-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-referrer" class="dfn-panel" data-for="dom-cspviolationreportbody-referrer" id="infopanel-for-dom-cspviolationreportbody-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-cspviolationreportbody-referrer">#dom-cspviolationreportbody-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-referrer">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-blockedurl">
-   <b><a href="#dom-cspviolationreportbody-blockedurl">#dom-cspviolationreportbody-blockedurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-blockedurl" class="dfn-panel" data-for="dom-cspviolationreportbody-blockedurl" id="infopanel-for-dom-cspviolationreportbody-blockedurl" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-blockedurl" style="display:none">Info about the 'blockedURL' definition.</span><b><a href="#dom-cspviolationreportbody-blockedurl">#dom-cspviolationreportbody-blockedurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-blockedurl">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-effectivedirective">
-   <b><a href="#dom-cspviolationreportbody-effectivedirective">#dom-cspviolationreportbody-effectivedirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-effectivedirective" class="dfn-panel" data-for="dom-cspviolationreportbody-effectivedirective" id="infopanel-for-dom-cspviolationreportbody-effectivedirective" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-effectivedirective" style="display:none">Info about the 'effectiveDirective' definition.</span><b><a href="#dom-cspviolationreportbody-effectivedirective">#dom-cspviolationreportbody-effectivedirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-effectivedirective">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-originalpolicy">
-   <b><a href="#dom-cspviolationreportbody-originalpolicy">#dom-cspviolationreportbody-originalpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-originalpolicy" class="dfn-panel" data-for="dom-cspviolationreportbody-originalpolicy" id="infopanel-for-dom-cspviolationreportbody-originalpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-originalpolicy" style="display:none">Info about the 'originalPolicy' definition.</span><b><a href="#dom-cspviolationreportbody-originalpolicy">#dom-cspviolationreportbody-originalpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-originalpolicy">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-sourcefile">
-   <b><a href="#dom-cspviolationreportbody-sourcefile">#dom-cspviolationreportbody-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-sourcefile" class="dfn-panel" data-for="dom-cspviolationreportbody-sourcefile" id="infopanel-for-dom-cspviolationreportbody-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#dom-cspviolationreportbody-sourcefile">#dom-cspviolationreportbody-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-sourcefile">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-sample">
-   <b><a href="#dom-cspviolationreportbody-sample">#dom-cspviolationreportbody-sample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-sample" class="dfn-panel" data-for="dom-cspviolationreportbody-sample" id="infopanel-for-dom-cspviolationreportbody-sample" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-sample" style="display:none">Info about the 'sample' definition.</span><b><a href="#dom-cspviolationreportbody-sample">#dom-cspviolationreportbody-sample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-sample">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-disposition">
-   <b><a href="#dom-cspviolationreportbody-disposition">#dom-cspviolationreportbody-disposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-disposition" class="dfn-panel" data-for="dom-cspviolationreportbody-disposition" id="infopanel-for-dom-cspviolationreportbody-disposition" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-disposition" style="display:none">Info about the 'disposition' definition.</span><b><a href="#dom-cspviolationreportbody-disposition">#dom-cspviolationreportbody-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-disposition">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-statuscode">
-   <b><a href="#dom-cspviolationreportbody-statuscode">#dom-cspviolationreportbody-statuscode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-statuscode" class="dfn-panel" data-for="dom-cspviolationreportbody-statuscode" id="infopanel-for-dom-cspviolationreportbody-statuscode" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-statuscode" style="display:none">Info about the 'statusCode' definition.</span><b><a href="#dom-cspviolationreportbody-statuscode">#dom-cspviolationreportbody-statuscode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-statuscode">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-linenumber">
-   <b><a href="#dom-cspviolationreportbody-linenumber">#dom-cspviolationreportbody-linenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-linenumber" class="dfn-panel" data-for="dom-cspviolationreportbody-linenumber" id="infopanel-for-dom-cspviolationreportbody-linenumber" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-linenumber" style="display:none">Info about the 'lineNumber' definition.</span><b><a href="#dom-cspviolationreportbody-linenumber">#dom-cspviolationreportbody-linenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-linenumber">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-cspviolationreportbody-columnnumber">
-   <b><a href="#dom-cspviolationreportbody-columnnumber">#dom-cspviolationreportbody-columnnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-cspviolationreportbody-columnnumber" class="dfn-panel" data-for="dom-cspviolationreportbody-columnnumber" id="infopanel-for-dom-cspviolationreportbody-columnnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-cspviolationreportbody-columnnumber" style="display:none">Info about the 'columnNumber' definition.</span><b><a href="#dom-cspviolationreportbody-columnnumber">#dom-cspviolationreportbody-columnnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-cspviolationreportbody-columnnumber">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-securitypolicyviolationeventdisposition">
-   <b><a href="#enumdef-securitypolicyviolationeventdisposition">#enumdef-securitypolicyviolationeventdisposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-securitypolicyviolationeventdisposition" class="dfn-panel" data-for="enumdef-securitypolicyviolationeventdisposition" id="infopanel-for-enumdef-securitypolicyviolationeventdisposition" role="dialog">
+   <span id="infopaneltitle-for-enumdef-securitypolicyviolationeventdisposition" style="display:none">Info about the 'SecurityPolicyViolationEventDisposition' definition.</span><b><a href="#enumdef-securitypolicyviolationeventdisposition">#enumdef-securitypolicyviolationeventdisposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-securitypolicyviolationeventdisposition">5. 
     Reporting </a>
@@ -8468,8 +8491,8 @@ rest of Google’s CSP Cabal.</p>
     Violation DOM Events </a> <a href="#ref-for-enumdef-securitypolicyviolationeventdisposition②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="securitypolicyviolationevent">
-   <b><a href="#securitypolicyviolationevent">#securitypolicyviolationevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-securitypolicyviolationevent" class="dfn-panel" data-for="securitypolicyviolationevent" id="infopanel-for-securitypolicyviolationevent" role="dialog">
+   <span id="infopaneltitle-for-securitypolicyviolationevent" style="display:none">Info about the 'SecurityPolicyViolationEvent' definition.</span><b><a href="#securitypolicyviolationevent">#securitypolicyviolationevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securitypolicyviolationevent">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -8478,8 +8501,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-securitypolicyviolationevent③">7.5. Violation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturl">
-   <b><a href="#dom-securitypolicyviolationevent-documenturl">#dom-securitypolicyviolationevent-documenturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-documenturl" class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturl" id="infopanel-for-dom-securitypolicyviolationevent-documenturl" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-documenturl" style="display:none">Info about the 'documentURL' definition.</span><b><a href="#dom-securitypolicyviolationevent-documenturl">#dom-securitypolicyviolationevent-documenturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-documenturl">5.1. 
     Violation DOM Events </a>
@@ -8487,15 +8510,15 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-referrer">
-   <b><a href="#dom-securitypolicyviolationevent-referrer">#dom-securitypolicyviolationevent-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-referrer" class="dfn-panel" data-for="dom-securitypolicyviolationevent-referrer" id="infopanel-for-dom-securitypolicyviolationevent-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-securitypolicyviolationevent-referrer">#dom-securitypolicyviolationevent-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-referrer">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockedurl">
-   <b><a href="#dom-securitypolicyviolationevent-blockedurl">#dom-securitypolicyviolationevent-blockedurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-blockedurl" class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockedurl" id="infopanel-for-dom-securitypolicyviolationevent-blockedurl" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-blockedurl" style="display:none">Info about the 'blockedURL' definition.</span><b><a href="#dom-securitypolicyviolationevent-blockedurl">#dom-securitypolicyviolationevent-blockedurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-blockedurl">5.1. 
     Violation DOM Events </a>
@@ -8503,8 +8526,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-effectivedirective">
-   <b><a href="#dom-securitypolicyviolationevent-effectivedirective">#dom-securitypolicyviolationevent-effectivedirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-effectivedirective" class="dfn-panel" data-for="dom-securitypolicyviolationevent-effectivedirective" id="infopanel-for-dom-securitypolicyviolationevent-effectivedirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-effectivedirective" style="display:none">Info about the 'effectiveDirective' definition.</span><b><a href="#dom-securitypolicyviolationevent-effectivedirective">#dom-securitypolicyviolationevent-effectivedirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-effectivedirective">5.1. 
     Violation DOM Events </a>
@@ -8512,22 +8535,22 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-originalpolicy">
-   <b><a href="#dom-securitypolicyviolationevent-originalpolicy">#dom-securitypolicyviolationevent-originalpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-originalpolicy" class="dfn-panel" data-for="dom-securitypolicyviolationevent-originalpolicy" id="infopanel-for-dom-securitypolicyviolationevent-originalpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-originalpolicy" style="display:none">Info about the 'originalPolicy' definition.</span><b><a href="#dom-securitypolicyviolationevent-originalpolicy">#dom-securitypolicyviolationevent-originalpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-originalpolicy">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-sourcefile">
-   <b><a href="#dom-securitypolicyviolationevent-sourcefile">#dom-securitypolicyviolationevent-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-sourcefile" class="dfn-panel" data-for="dom-securitypolicyviolationevent-sourcefile" id="infopanel-for-dom-securitypolicyviolationevent-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#dom-securitypolicyviolationevent-sourcefile">#dom-securitypolicyviolationevent-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-sourcefile">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-sample">
-   <b><a href="#dom-securitypolicyviolationevent-sample">#dom-securitypolicyviolationevent-sample</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-sample" class="dfn-panel" data-for="dom-securitypolicyviolationevent-sample" id="infopanel-for-dom-securitypolicyviolationevent-sample" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-sample" style="display:none">Info about the 'sample' definition.</span><b><a href="#dom-securitypolicyviolationevent-sample">#dom-securitypolicyviolationevent-sample</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-sample">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -8536,22 +8559,22 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-sample②">7.5. Violation Reports</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-disposition">
-   <b><a href="#dom-securitypolicyviolationevent-disposition">#dom-securitypolicyviolationevent-disposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-disposition" class="dfn-panel" data-for="dom-securitypolicyviolationevent-disposition" id="infopanel-for-dom-securitypolicyviolationevent-disposition" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-disposition" style="display:none">Info about the 'disposition' definition.</span><b><a href="#dom-securitypolicyviolationevent-disposition">#dom-securitypolicyviolationevent-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-disposition">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-statuscode">
-   <b><a href="#dom-securitypolicyviolationevent-statuscode">#dom-securitypolicyviolationevent-statuscode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-statuscode" class="dfn-panel" data-for="dom-securitypolicyviolationevent-statuscode" id="infopanel-for-dom-securitypolicyviolationevent-statuscode" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-statuscode" style="display:none">Info about the 'statusCode' definition.</span><b><a href="#dom-securitypolicyviolationevent-statuscode">#dom-securitypolicyviolationevent-statuscode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-statuscode">5.3. 
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-lineno">
-   <b><a href="#dom-securitypolicyviolationevent-lineno">#dom-securitypolicyviolationevent-lineno</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-lineno" class="dfn-panel" data-for="dom-securitypolicyviolationevent-lineno" id="infopanel-for-dom-securitypolicyviolationevent-lineno" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-lineno" style="display:none">Info about the 'lineno' definition.</span><b><a href="#dom-securitypolicyviolationevent-lineno">#dom-securitypolicyviolationevent-lineno</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-lineno">5.1. 
     Violation DOM Events </a>
@@ -8559,8 +8582,8 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-colno">
-   <b><a href="#dom-securitypolicyviolationevent-colno">#dom-securitypolicyviolationevent-colno</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-colno" class="dfn-panel" data-for="dom-securitypolicyviolationevent-colno" id="infopanel-for-dom-securitypolicyviolationevent-colno" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-colno" style="display:none">Info about the 'colno' definition.</span><b><a href="#dom-securitypolicyviolationevent-colno">#dom-securitypolicyviolationevent-colno</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-colno">5.1. 
     Violation DOM Events </a>
@@ -8568,50 +8591,50 @@ rest of Google’s CSP Cabal.</p>
     Report a violation </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-securitypolicyviolationeventinit">
-   <b><a href="#dictdef-securitypolicyviolationeventinit">#dictdef-securitypolicyviolationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-securitypolicyviolationeventinit" class="dfn-panel" data-for="dictdef-securitypolicyviolationeventinit" id="infopanel-for-dictdef-securitypolicyviolationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-securitypolicyviolationeventinit" style="display:none">Info about the 'SecurityPolicyViolationEventInit' definition.</span><b><a href="#dictdef-securitypolicyviolationeventinit">#dictdef-securitypolicyviolationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-securitypolicyviolationeventinit">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturi">
-   <b><a href="#dom-securitypolicyviolationevent-documenturi">#dom-securitypolicyviolationevent-documenturi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-documenturi" class="dfn-panel" data-for="dom-securitypolicyviolationevent-documenturi" id="infopanel-for-dom-securitypolicyviolationevent-documenturi" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-documenturi" style="display:none">Info about the 'documentURI' definition.</span><b><a href="#dom-securitypolicyviolationevent-documenturi">#dom-securitypolicyviolationevent-documenturi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-documenturi">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockeduri">
-   <b><a href="#dom-securitypolicyviolationevent-blockeduri">#dom-securitypolicyviolationevent-blockeduri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-blockeduri" class="dfn-panel" data-for="dom-securitypolicyviolationevent-blockeduri" id="infopanel-for-dom-securitypolicyviolationevent-blockeduri" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-blockeduri" style="display:none">Info about the 'blockedURI' definition.</span><b><a href="#dom-securitypolicyviolationevent-blockeduri">#dom-securitypolicyviolationevent-blockeduri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-blockeduri">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-violateddirective">
-   <b><a href="#dom-securitypolicyviolationevent-violateddirective">#dom-securitypolicyviolationevent-violateddirective</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-violateddirective" class="dfn-panel" data-for="dom-securitypolicyviolationevent-violateddirective" id="infopanel-for-dom-securitypolicyviolationevent-violateddirective" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-violateddirective" style="display:none">Info about the 'violatedDirective' definition.</span><b><a href="#dom-securitypolicyviolationevent-violateddirective">#dom-securitypolicyviolationevent-violateddirective</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-violateddirective">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-linenumber">
-   <b><a href="#dom-securitypolicyviolationevent-linenumber">#dom-securitypolicyviolationevent-linenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-linenumber" class="dfn-panel" data-for="dom-securitypolicyviolationevent-linenumber" id="infopanel-for-dom-securitypolicyviolationevent-linenumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-linenumber" style="display:none">Info about the 'lineNumber' definition.</span><b><a href="#dom-securitypolicyviolationevent-linenumber">#dom-securitypolicyviolationevent-linenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-linenumber">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-securitypolicyviolationevent-columnnumber">
-   <b><a href="#dom-securitypolicyviolationevent-columnnumber">#dom-securitypolicyviolationevent-columnnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-securitypolicyviolationevent-columnnumber" class="dfn-panel" data-for="dom-securitypolicyviolationevent-columnnumber" id="infopanel-for-dom-securitypolicyviolationevent-columnnumber" role="dialog">
+   <span id="infopaneltitle-for-dom-securitypolicyviolationevent-columnnumber" style="display:none">Info about the 'columnNumber' definition.</span><b><a href="#dom-securitypolicyviolationevent-columnnumber">#dom-securitypolicyviolationevent-columnnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-securitypolicyviolationevent-columnnumber">5.1. 
     Violation DOM Events </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-directives">
-   <b><a href="#fetch-directives">#fetch-directives</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-directives" class="dfn-panel" data-for="fetch-directives" id="infopanel-for-fetch-directives" role="dialog">
+   <span id="infopaneltitle-for-fetch-directives" style="display:none">Info about the 'Fetch directives' definition.</span><b><a href="#fetch-directives">#fetch-directives</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-directives">6.1.3. default-src</a> <a href="#ref-for-fetch-directives①">(2)</a>
     <li><a href="#ref-for-fetch-directives②">6.7.1. 
@@ -8620,16 +8643,16 @@ rest of Google’s CSP Cabal.</p>
     Should fetch directive execute </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="child-src">
-   <b><a href="#child-src">#child-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-child-src" class="dfn-panel" data-for="child-src" id="infopanel-for-child-src" role="dialog">
+   <span id="infopaneltitle-for-child-src" style="display:none">Info about the 'child-src' definition.</span><b><a href="#child-src">#child-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-child-src">6.1.1. child-src</a>
     <li><a href="#ref-for-child-src①">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connect-src">
-   <b><a href="#connect-src">#connect-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connect-src" class="dfn-panel" data-for="connect-src" id="infopanel-for-connect-src" role="dialog">
+   <span id="infopaneltitle-for-connect-src" style="display:none">Info about the 'connect-src' definition.</span><b><a href="#connect-src">#connect-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect-src">6.1.2. connect-src</a>
     <li><a href="#ref-for-connect-src①">6.1.3. default-src</a> <a href="#ref-for-connect-src②">(2)</a>
@@ -8637,8 +8660,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-src">
-   <b><a href="#default-src">#default-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-src" class="dfn-panel" data-for="default-src" id="infopanel-for-default-src" role="dialog">
+   <span id="infopaneltitle-for-default-src" style="display:none">Info about the 'default-src' definition.</span><b><a href="#default-src">#default-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-src">6. 
     Content Security Policy Directives </a>
@@ -8649,8 +8672,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-src">
-   <b><a href="#font-src">#font-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-src" class="dfn-panel" data-for="font-src" id="infopanel-for-font-src" role="dialog">
+   <span id="infopaneltitle-for-font-src" style="display:none">Info about the 'font-src' definition.</span><b><a href="#font-src">#font-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-src">6.1. 
     Fetch Directives </a>
@@ -8660,8 +8683,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-src">
-   <b><a href="#frame-src">#frame-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-src" class="dfn-panel" data-for="frame-src" id="infopanel-for-frame-src" role="dialog">
+   <span id="infopaneltitle-for-frame-src" style="display:none">Info about the 'frame-src' definition.</span><b><a href="#frame-src">#frame-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-src">6.1.3. default-src</a> <a href="#ref-for-frame-src①">(2)</a>
     <li><a href="#ref-for-frame-src②">6.1.5. frame-src</a>
@@ -8669,8 +8692,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="img-src">
-   <b><a href="#img-src">#img-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-img-src" class="dfn-panel" data-for="img-src" id="infopanel-for-img-src" role="dialog">
+   <span id="infopaneltitle-for-img-src" style="display:none">Info about the 'img-src' definition.</span><b><a href="#img-src">#img-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-img-src">6.1.3. default-src</a> <a href="#ref-for-img-src①">(2)</a>
     <li><a href="#ref-for-img-src②">6.1.6. img-src</a>
@@ -8679,8 +8702,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="manifest-src">
-   <b><a href="#manifest-src">#manifest-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-manifest-src" class="dfn-panel" data-for="manifest-src" id="infopanel-for-manifest-src" role="dialog">
+   <span id="infopaneltitle-for-manifest-src" style="display:none">Info about the 'manifest-src' definition.</span><b><a href="#manifest-src">#manifest-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-manifest-src">6.1.3. default-src</a> <a href="#ref-for-manifest-src①">(2)</a>
     <li><a href="#ref-for-manifest-src②">6.1.7. manifest-src</a>
@@ -8688,8 +8711,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="media-src">
-   <b><a href="#media-src">#media-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-media-src" class="dfn-panel" data-for="media-src" id="infopanel-for-media-src" role="dialog">
+   <span id="infopaneltitle-for-media-src" style="display:none">Info about the 'media-src' definition.</span><b><a href="#media-src">#media-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-src">6.1.3. default-src</a> <a href="#ref-for-media-src①">(2)</a>
     <li><a href="#ref-for-media-src②">6.1.8. media-src</a>
@@ -8697,8 +8720,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-src">
-   <b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-src" class="dfn-panel" data-for="object-src" id="infopanel-for-object-src" role="dialog">
+   <span id="infopaneltitle-for-object-src" style="display:none">Info about the 'object-src' definition.</span><b><a href="#object-src">#object-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">6. 
     Content Security Policy Directives </a>
@@ -8708,15 +8731,15 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="prefetch-src">
-   <b><a href="#prefetch-src">#prefetch-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-prefetch-src" class="dfn-panel" data-for="prefetch-src" id="infopanel-for-prefetch-src" role="dialog">
+   <span id="infopaneltitle-for-prefetch-src" style="display:none">Info about the 'prefetch-src' definition.</span><b><a href="#prefetch-src">#prefetch-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prefetch-src">6.1.3. default-src</a> <a href="#ref-for-prefetch-src①">(2)</a>
     <li><a href="#ref-for-prefetch-src②">6.1.10. prefetch-src</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-src">
-   <b><a href="#script-src">#script-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-src" class="dfn-panel" data-for="script-src" id="infopanel-for-script-src" role="dialog">
+   <span id="infopaneltitle-for-script-src" style="display:none">Info about the 'script-src' definition.</span><b><a href="#script-src">#script-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src">6. 
     Content Security Policy Directives </a>
@@ -8730,8 +8753,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-src-elem">
-   <b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-src-elem" class="dfn-panel" data-for="script-src-elem" id="infopanel-for-script-src-elem" role="dialog">
+   <span id="infopaneltitle-for-script-src-elem" style="display:none">Info about the 'script-src-elem' definition.</span><b><a href="#script-src-elem">#script-src-elem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src-elem">6.1.3. default-src</a> <a href="#ref-for-script-src-elem①">(2)</a> <a href="#ref-for-script-src-elem②">(3)</a>
     <li><a href="#ref-for-script-src-elem③">6.1.11. script-src</a> <a href="#ref-for-script-src-elem④">(2)</a>
@@ -8739,8 +8762,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="script-src-attr">
-   <b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-script-src-attr" class="dfn-panel" data-for="script-src-attr" id="infopanel-for-script-src-attr" role="dialog">
+   <span id="infopaneltitle-for-script-src-attr" style="display:none">Info about the 'script-src-attr' definition.</span><b><a href="#script-src-attr">#script-src-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src-attr">6.1.3. default-src</a> <a href="#ref-for-script-src-attr①">(2)</a>
     <li><a href="#ref-for-script-src-attr②">6.1.11. script-src</a> <a href="#ref-for-script-src-attr③">(2)</a>
@@ -8749,32 +8772,32 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-src">
-   <b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-src" class="dfn-panel" data-for="style-src" id="infopanel-for-style-src" role="dialog">
+   <span id="infopaneltitle-for-style-src" style="display:none">Info about the 'style-src' definition.</span><b><a href="#style-src">#style-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src">7.4. CSS Parsing</a>
     <li><a href="#ref-for-style-src①">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-src-elem">
-   <b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-src-elem" class="dfn-panel" data-for="style-src-elem" id="infopanel-for-style-src-elem" role="dialog">
+   <span id="infopaneltitle-for-style-src-elem" style="display:none">Info about the 'style-src-elem' definition.</span><b><a href="#style-src-elem">#style-src-elem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src-elem">6.1.3. default-src</a> <a href="#ref-for-style-src-elem①">(2)</a>
     <li><a href="#ref-for-style-src-elem②">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="style-src-attr">
-   <b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-style-src-attr" class="dfn-panel" data-for="style-src-attr" id="infopanel-for-style-src-attr" role="dialog">
+   <span id="infopaneltitle-for-style-src-attr" style="display:none">Info about the 'style-src-attr' definition.</span><b><a href="#style-src-attr">#style-src-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-style-src-attr">6.1.3. default-src</a> <a href="#ref-for-style-src-attr①">(2)</a>
     <li><a href="#ref-for-style-src-attr②">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="worker-src">
-   <b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-worker-src" class="dfn-panel" data-for="worker-src" id="infopanel-for-worker-src" role="dialog">
+   <span id="infopaneltitle-for-worker-src" style="display:none">Info about the 'worker-src' definition.</span><b><a href="#worker-src">#worker-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-src">6.1.3. default-src</a> <a href="#ref-for-worker-src①">(2)</a>
     <li><a href="#ref-for-worker-src②">6.1.11. script-src</a>
@@ -8783,8 +8806,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base-uri">
-   <b><a href="#base-uri">#base-uri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base-uri" class="dfn-panel" data-for="base-uri" id="infopanel-for-base-uri" role="dialog">
+   <span id="infopaneltitle-for-base-uri" style="display:none">Info about the 'base-uri' definition.</span><b><a href="#base-uri">#base-uri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base-uri">6.2.1.1. 
     Is base allowed for document? </a>
@@ -8793,8 +8816,10 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allow-base-for-document">
-   <b><a href="#allow-base-for-document">#allow-base-for-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allow-base-for-document" class="dfn-panel" data-for="allow-base-for-document" id="infopanel-for-allow-base-for-document" role="dialog">
+   <span id="infopaneltitle-for-allow-base-for-document" style="display:none">Info about the '6.2.1.1. 
+    Is base allowed for document?
+  ' definition.</span><b><a href="#allow-base-for-document">#allow-base-for-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allow-base-for-document">4.2. 
     Integration with HTML </a>
@@ -8802,8 +8827,8 @@ rest of Google’s CSP Cabal.</p>
     Is base allowed for document? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sandbox">
-   <b><a href="#sandbox">#sandbox</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sandbox" class="dfn-panel" data-for="sandbox" id="infopanel-for-sandbox" role="dialog">
+   <span id="infopaneltitle-for-sandbox" style="display:none">Info about the 'sandbox' definition.</span><b><a href="#sandbox">#sandbox</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">6.2.2.2. 
     sandbox Initialization </a>
@@ -8811,16 +8836,16 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="form-action">
-   <b><a href="#form-action">#form-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-form-action" class="dfn-panel" data-for="form-action" id="infopanel-for-form-action" role="dialog">
+   <span id="infopaneltitle-for-form-action" style="display:none">Info about the 'form-action' definition.</span><b><a href="#form-action">#form-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-action">6.3.3. navigate-to</a>
     <li><a href="#ref-for-form-action①">10.1. 
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="frame-ancestors">
-   <b><a href="#frame-ancestors">#frame-ancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-frame-ancestors" class="dfn-panel" data-for="frame-ancestors" id="infopanel-for-frame-ancestors" role="dialog">
+   <span id="infopaneltitle-for-frame-ancestors" style="display:none">Info about the 'frame-ancestors' definition.</span><b><a href="#frame-ancestors">#frame-ancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-ancestors">4.2.6. 
     Should navigation response to navigation request of type
@@ -8833,20 +8858,20 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-ancestor-source-list">
-   <b><a href="#grammardef-ancestor-source-list">#grammardef-ancestor-source-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-ancestor-source-list" class="dfn-panel" data-for="grammardef-ancestor-source-list" id="infopanel-for-grammardef-ancestor-source-list" role="dialog">
+   <span id="infopaneltitle-for-grammardef-ancestor-source-list" style="display:none">Info about the 'ancestor-source-list' definition.</span><b><a href="#grammardef-ancestor-source-list">#grammardef-ancestor-source-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-ancestor-source-list">6.3.2. frame-ancestors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-ancestor-source">
-   <b><a href="#grammardef-ancestor-source">#grammardef-ancestor-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-ancestor-source" class="dfn-panel" data-for="grammardef-ancestor-source" id="infopanel-for-grammardef-ancestor-source" role="dialog">
+   <span id="infopaneltitle-for-grammardef-ancestor-source" style="display:none">Info about the 'ancestor-source' definition.</span><b><a href="#grammardef-ancestor-source">#grammardef-ancestor-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-ancestor-source">6.3.2. frame-ancestors</a> <a href="#ref-for-grammardef-ancestor-source①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigate-to">
-   <b><a href="#navigate-to">#navigate-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigate-to" class="dfn-panel" data-for="navigate-to" id="infopanel-for-navigate-to" role="dialog">
+   <span id="infopaneltitle-for-navigate-to" style="display:none">Info about the 'navigate-to' definition.</span><b><a href="#navigate-to">#navigate-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate-to">1.3. Changes from Level 2</a>
     <li><a href="#ref-for-navigate-to①">4.2.6. 
@@ -8855,8 +8880,8 @@ rest of Google’s CSP Cabal.</p>
     <li><a href="#ref-for-navigate-to②">6.3.3. navigate-to</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-uri">
-   <b><a href="#report-uri">#report-uri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-uri" class="dfn-panel" data-for="report-uri" id="infopanel-for-report-uri" role="dialog">
+   <span id="infopaneltitle-for-report-uri" style="display:none">Info about the 'report-uri' definition.</span><b><a href="#report-uri">#report-uri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-uri">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -8867,8 +8892,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="report-to">
-   <b><a href="#report-to">#report-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-report-to" class="dfn-panel" data-for="report-to" id="infopanel-for-report-to" role="dialog">
+   <span id="infopaneltitle-for-report-to" style="display:none">Info about the 'report-to' definition.</span><b><a href="#report-to">#report-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-to">5.2. 
     Obtain the deprecated serialization of violation </a>
@@ -8879,8 +8904,8 @@ rest of Google’s CSP Cabal.</p>
     Directive Registry </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-part-match">
-   <b><a href="#scheme-part-match">#scheme-part-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-part-match" class="dfn-panel" data-for="scheme-part-match" id="infopanel-for-scheme-part-match" role="dialog">
+   <span id="infopaneltitle-for-scheme-part-match" style="display:none">Info about the 'scheme-part matches' definition.</span><b><a href="#scheme-part-match">#scheme-part-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a> <a href="#ref-for-scheme-part-match①">(2)</a>
@@ -8888,8 +8913,8 @@ rest of Google’s CSP Cabal.</p>
     scheme-part matching </a> <a href="#ref-for-scheme-part-match③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-part-match">
-   <b><a href="#host-part-match">#host-part-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-part-match" class="dfn-panel" data-for="host-part-match" id="infopanel-for-host-part-match" role="dialog">
+   <span id="infopaneltitle-for-host-part-match" style="display:none">Info about the 'host-part matches' definition.</span><b><a href="#host-part-match">#host-part-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -8897,8 +8922,8 @@ rest of Google’s CSP Cabal.</p>
     host-part matching </a> <a href="#ref-for-host-part-match②">(2)</a> <a href="#ref-for-host-part-match③">(3)</a> <a href="#ref-for-host-part-match④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="port-part-matches">
-   <b><a href="#port-part-matches">#port-part-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-port-part-matches" class="dfn-panel" data-for="port-part-matches" id="infopanel-for-port-part-matches" role="dialog">
+   <span id="infopaneltitle-for-port-part-matches" style="display:none">Info about the 'port-part matches' definition.</span><b><a href="#port-part-matches">#port-part-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-port-part-matches">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -8906,8 +8931,8 @@ rest of Google’s CSP Cabal.</p>
     port-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-part-match">
-   <b><a href="#path-part-match">#path-part-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-part-match" class="dfn-panel" data-for="path-part-match" id="infopanel-for-path-part-match" role="dialog">
+   <span id="infopaneltitle-for-path-part-match" style="display:none">Info about the 'path-part matches' definition.</span><b><a href="#path-part-match">#path-part-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-part-match">6.6.2.6. 
     Does url match expression in origin with redirect count? </a>
@@ -8915,15 +8940,15 @@ rest of Google’s CSP Cabal.</p>
     path-part matching </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="source-list-allows-all-inline-behavior">
-   <b><a href="#source-list-allows-all-inline-behavior">#source-list-allows-all-inline-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-source-list-allows-all-inline-behavior" class="dfn-panel" data-for="source-list-allows-all-inline-behavior" id="infopanel-for-source-list-allows-all-inline-behavior" role="dialog">
+   <span id="infopaneltitle-for-source-list-allows-all-inline-behavior" style="display:none">Info about the 'allows all inline behavior' definition.</span><b><a href="#source-list-allows-all-inline-behavior">#source-list-allows-all-inline-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-list-allows-all-inline-behavior">6.6.3.2. 
     Does a source list allow all inline behavior for type? </a> <a href="#ref-for-source-list-allows-all-inline-behavior①">(2)</a> <a href="#ref-for-source-list-allows-all-inline-behavior②">(3)</a> <a href="#ref-for-source-list-allows-all-inline-behavior③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-effective-directive">
-   <b><a href="#request-effective-directive">#request-effective-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-effective-directive" class="dfn-panel" data-for="request-effective-directive" id="infopanel-for-request-effective-directive" role="dialog">
+   <span id="infopaneltitle-for-request-effective-directive" style="display:none">Info about the 'effective directive' definition.</span><b><a href="#request-effective-directive">#request-effective-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-effective-directive">6.7.2. 
     Get the effective directive for inline checks </a>
@@ -8931,59 +8956,115 @@ rest of Google’s CSP Cabal.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/webappsec-csp/pinning/index.html
+++ b/tests/github/w3c/webappsec-csp/pinning/index.html
@@ -793,20 +793,20 @@ directive-value = 1*DIGIT
    <li><a href="#protected-host">protected host</a><span>, in § 2.1</span>
    <li><a href="#subdomains-included">subdomains included</a><span>, in § 2.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-content_security_policy">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content_security_policy">https://w3c.github.io/webappsec/specs/content-security-policy/#content_security_policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content_security_policy" class="dfn-panel" data-for="term-for-content_security_policy" id="infopanel-for-term-for-content_security_policy" role="menu">
+   <span id="infopaneltitle-for-term-for-content_security_policy" style="display:none">Info about the 'content-security-policy' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#content_security_policy">https://w3c.github.io/webappsec/specs/content-security-policy/#content_security_policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content_security_policy">3.3. Pinned Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-delivery-html-meta-element">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element">https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-delivery-html-meta-element" class="dfn-panel" data-for="term-for-delivery-html-meta-element" id="infopanel-for-term-for-delivery-html-meta-element" role="menu">
+   <span id="infopaneltitle-for-term-for-delivery-html-meta-element" style="display:none">Info about the 'delivery via meta element' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element">https://w3c.github.io/webappsec/specs/content-security-policy/#delivery-html-meta-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-delivery-html-meta-element">7.2. Pins override &lt;meta></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">https://w3c.github.io/webappsec/specs/content-security-policy/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce" style="display:none">Info about the 'enforce' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">https://w3c.github.io/webappsec/specs/content-security-policy/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">2.1. Terms defined by this specification</a> <a href="#ref-for-enforce①">(2)</a>
     <li><a href="#ref-for-enforce②">3. Pinned Policy Delivery</a> <a href="#ref-for-enforce③">(2)</a>
@@ -815,8 +815,8 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-enforce⑤">3.3.1. The max-age directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">https://w3c.github.io/webappsec/specs/content-security-policy/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce①" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce①" style="display:none">Info about the 'enforced' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#enforce">https://w3c.github.io/webappsec/specs/content-security-policy/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">2.1. Terms defined by this specification</a> <a href="#ref-for-enforce①">(2)</a>
     <li><a href="#ref-for-enforce②">3. Pinned Policy Delivery</a> <a href="#ref-for-enforce③">(2)</a>
@@ -825,8 +825,8 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-enforce⑤">3.3.1. The max-age directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#monitor">https://w3c.github.io/webappsec/specs/content-security-policy/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#monitor">https://w3c.github.io/webappsec/specs/content-security-policy/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-monitor①">3. Pinned Policy Delivery</a> <a href="#ref-for-monitor②">(2)</a>
@@ -834,8 +834,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#monitor">https://w3c.github.io/webappsec/specs/content-security-policy/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor①" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor①" style="display:none">Info about the 'monitored' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#monitor">https://w3c.github.io/webappsec/specs/content-security-policy/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-monitor①">3. Pinned Policy Delivery</a> <a href="#ref-for-monitor②">(2)</a>
@@ -843,21 +843,21 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-the-policy">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#parse-the-policy">https://w3c.github.io/webappsec/specs/content-security-policy/#parse-the-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-the-policy" class="dfn-panel" data-for="term-for-parse-the-policy" id="infopanel-for-term-for-parse-the-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-the-policy" style="display:none">Info about the 'parse the policy' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#parse-the-policy">https://w3c.github.io/webappsec/specs/content-security-policy/#parse-the-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-the-policy">4.1.2. 
     Pin policy for origin in mode </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-syntax">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#policy-syntax">https://w3c.github.io/webappsec/specs/content-security-policy/#policy-syntax</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-syntax" class="dfn-panel" data-for="term-for-policy-syntax" id="infopanel-for-term-for-policy-syntax" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-syntax" style="display:none">Info about the 'policy syntax' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#policy-syntax">https://w3c.github.io/webappsec/specs/content-security-policy/#policy-syntax</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-syntax">3.3. Pinned Policy Syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy_token">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#policy_token">https://w3c.github.io/webappsec/specs/content-security-policy/#policy_token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy_token" class="dfn-panel" data-for="term-for-policy_token" id="infopanel-for-term-for-policy_token" role="menu">
+   <span id="infopaneltitle-for-term-for-policy_token" style="display:none">Info about the 'policy-token' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#policy_token">https://w3c.github.io/webappsec/specs/content-security-policy/#policy_token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy_token">3.1. 
       Content-Security-Policy-Pin Header Field </a>
@@ -865,8 +865,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-security-policy">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#security-policy">https://w3c.github.io/webappsec/specs/content-security-policy/#security-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-security-policy" class="dfn-panel" data-for="term-for-security-policy" id="infopanel-for-term-for-security-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-security-policy" style="display:none">Info about the 'security policy' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#security-policy">https://w3c.github.io/webappsec/specs/content-security-policy/#security-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-security-policy">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-security-policy①">3. Pinned Policy Delivery</a>
@@ -876,20 +876,20 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-security-policy⑤">7.2. Pins override &lt;meta></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-send-violation-reports">
-   <a href="https://w3c.github.io/webappsec/specs/content-security-policy/#send-violation-reports">https://w3c.github.io/webappsec/specs/content-security-policy/#send-violation-reports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-send-violation-reports" class="dfn-panel" data-for="term-for-send-violation-reports" id="infopanel-for-term-for-send-violation-reports" role="menu">
+   <span id="infopaneltitle-for-term-for-send-violation-reports" style="display:none">Info about the 'send violation reports' external reference.</span><a href="https://w3c.github.io/webappsec/specs/content-security-policy/#send-violation-reports">https://w3c.github.io/webappsec/specs/content-security-policy/#send-violation-reports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-send-violation-reports">6.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-document">
-   <a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-document" class="dfn-panel" data-for="term-for-interface-document" id="infopanel-for-term-for-interface-document" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-document" style="display:none">Info about the 'Document' external reference.</span><a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-document">2.1. Terms defined by this specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">4.1.1. 
      Discover pinned policies for response </a>
@@ -899,16 +899,16 @@ directive-value = 1*DIGIT
     Remove expired pinned policies from the cache </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetching">
-   <a href="https://fetch.spec.whatwg.org/#fetching">https://fetch.spec.whatwg.org/#fetching</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetching" class="dfn-panel" data-for="term-for-fetching" id="infopanel-for-term-for-fetching" role="menu">
+   <span id="infopaneltitle-for-term-for-fetching" style="display:none">Info about the 'fetching' external reference.</span><a href="https://fetch.spec.whatwg.org/#fetching">https://fetch.spec.whatwg.org/#fetching</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetching">4. Pinned Policy Processing</a>
     <li><a href="#ref-for-fetching①">4.2.2. 
     Remove expired pinned policies from the cache </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">4.1.1. 
      Discover pinned policies for response </a> <a href="#ref-for-concept-response-header-list①">(2)</a>
@@ -916,8 +916,8 @@ directive-value = 1*DIGIT
     Pin a policy to response </a> <a href="#ref-for-concept-response-header-list③">(2)</a> <a href="#ref-for-concept-response-header-list④">(3)</a> <a href="#ref-for-concept-response-header-list⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-parse">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-parse" class="dfn-panel" data-for="term-for-concept-header-parse" id="infopanel-for-term-for-concept-header-parse" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-parse" style="display:none">Info about the 'parse header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-parse">https://fetch.spec.whatwg.org/#concept-header-parse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-parse">4.1.1. 
      Discover pinned policies for response </a> <a href="#ref-for-concept-header-parse①">(2)</a>
@@ -925,22 +925,22 @@ directive-value = 1*DIGIT
     Pin a policy to response </a> <a href="#ref-for-concept-header-parse③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-meta-element">
-   <a href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">http://www.w3.org/TR/html5/document-metadata.html#the-meta-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-meta-element" class="dfn-panel" data-for="term-for-the-meta-element" id="infopanel-for-term-for-the-meta-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-meta-element" style="display:none">Info about the 'meta' external reference.</span><a href="http://www.w3.org/TR/html5/document-metadata.html#the-meta-element">http://www.w3.org/TR/html5/document-metadata.html#the-meta-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-meta-element">3. Pinned Policy Delivery</a> <a href="#ref-for-the-meta-element①">(2)</a>
     <li><a href="#ref-for-the-meta-element②">7.2. Pins override &lt;meta></a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-priori-insecure-origin">
-   <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin">https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-priori-insecure-origin" class="dfn-panel" data-for="term-for-a-priori-insecure-origin" id="infopanel-for-term-for-a-priori-insecure-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-a-priori-insecure-origin" style="display:none">Info about the 'a priori insecure origin' external reference.</span><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin">https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-priori-insecure-origin">4.1.2. 
     Pin policy for origin in mode </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-priori-insecure-url">
-   <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-url">https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-priori-insecure-url" class="dfn-panel" data-for="term-for-a-priori-insecure-url" id="infopanel-for-term-for-a-priori-insecure-url" role="menu">
+   <span id="infopaneltitle-for-term-for-a-priori-insecure-url" style="display:none">Info about the 'a priori insecure url' external reference.</span><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-url">https://w3c.github.io/webappsec/specs/mixedcontent/#a-priori-insecure-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-priori-insecure-url">3.1. 
       Content-Security-Policy-Pin Header Field </a>
@@ -948,8 +948,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'origin' external reference.</span><a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">3.1. 
       Content-Security-Policy-Pin Header Field </a>
@@ -959,29 +959,29 @@ directive-value = 1*DIGIT
     Pin policy for origin in mode </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2" style="display:none">Info about the 'congruent match' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">4.2.1. 
     Get the mode pinned policy for host </a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2①" style="display:none">Info about the 'known hsts host domain name matching' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">4.2.1. 
     Get the mode pinned policy for host </a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2②" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2②" style="display:none">Info about the 'superdomain match' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">4.2.1. 
     Get the mode pinned policy for host </a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2">
-   <a href="https://tools.ietf.org/html/rfc7231#section-2">https://tools.ietf.org/html/rfc7231#section-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2" class="dfn-panel" data-for="term-for-section-2" id="infopanel-for-term-for-section-2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2" style="display:none">Info about the 'resource' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-2">https://tools.ietf.org/html/rfc7231#section-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2">3.1. 
       Content-Security-Policy-Pin Header Field </a>
@@ -989,8 +989,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'resource representation' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">3.1. 
       Content-Security-Policy-Pin Header Field </a> <a href="#ref-for-section-3①">(2)</a> <a href="#ref-for-section-3②">(3)</a>
@@ -1000,8 +1000,8 @@ directive-value = 1*DIGIT
         The includeSubDomains directive </a> <a href="#ref-for-section-3⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">3.3.2. 
         The includeSubDomains directive </a> <a href="#ref-for-concept-url-host①">(2)</a>
@@ -1009,8 +1009,8 @@ directive-value = 1*DIGIT
     Pin a policy to response </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin of a url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">4.1.1. 
      Discover pinned policies for response </a> <a href="#ref-for-concept-url-origin①">(2)</a> <a href="#ref-for-concept-url-origin②">(3)</a>
@@ -1018,8 +1018,8 @@ directive-value = 1*DIGIT
     Pin a policy to response </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">2.1. Terms defined by this specification</a>
    </ul>
@@ -1150,8 +1150,10 @@ directive-value = 1*DIGIT
   resources that don’t otherwise have a policy. Explain layering, granularity,
   etc. <a class="issue-return" href="#issue-4273d051" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="pinned-security-policy">
-   <b><a href="#pinned-security-policy">#pinned-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pinned-security-policy" class="dfn-panel" data-for="pinned-security-policy" id="infopanel-for-pinned-security-policy" role="dialog">
+   <span id="infopaneltitle-for-pinned-security-policy" style="display:none">Info about the '
+        pinned security policy
+      ' definition.</span><b><a href="#pinned-security-policy">#pinned-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinned-security-policy">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-pinned-security-policy①">3.3.1. The max-age directive</a>
@@ -1165,8 +1167,8 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-pinned-security-policy⑨">6.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pinned-policy-cache">
-   <b><a href="#pinned-policy-cache">#pinned-policy-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pinned-policy-cache" class="dfn-panel" data-for="pinned-policy-cache" id="infopanel-for-pinned-policy-cache" role="dialog">
+   <span id="infopaneltitle-for-pinned-policy-cache" style="display:none">Info about the 'pinned policy cache' definition.</span><b><a href="#pinned-policy-cache">#pinned-policy-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pinned-policy-cache">4. Pinned Policy Processing</a> <a href="#ref-for-pinned-policy-cache①">(2)</a> <a href="#ref-for-pinned-policy-cache②">(3)</a>
     <li><a href="#ref-for-pinned-policy-cache③">4.1.2. 
@@ -1178,8 +1180,8 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-pinned-policy-cache①①">6.1. Fingerprinting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="protected-host">
-   <b><a href="#protected-host">#protected-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-protected-host" class="dfn-panel" data-for="protected-host" id="infopanel-for-protected-host" role="dialog">
+   <span id="infopaneltitle-for-protected-host" style="display:none">Info about the 'protected host' definition.</span><b><a href="#protected-host">#protected-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-protected-host">2.1. Terms defined by this specification</a> <a href="#ref-for-protected-host①">(2)</a>
     <li><a href="#ref-for-protected-host②">4.1.2. 
@@ -1188,8 +1190,8 @@ directive-value = 1*DIGIT
     Get the mode pinned policy for host </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subdomains-included">
-   <b><a href="#subdomains-included">#subdomains-included</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subdomains-included" class="dfn-panel" data-for="subdomains-included" id="infopanel-for-subdomains-included" role="dialog">
+   <span id="infopaneltitle-for-subdomains-included" style="display:none">Info about the 'subdomains included' definition.</span><b><a href="#subdomains-included">#subdomains-included</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subdomains-included">4.1.2. 
     Pin policy for origin in mode </a> <a href="#ref-for-subdomains-included①">(2)</a>
@@ -1197,8 +1199,8 @@ directive-value = 1*DIGIT
     Get the mode pinned policy for host </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-expiration-date">
-   <b><a href="#policy-expiration-date">#policy-expiration-date</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-expiration-date" class="dfn-panel" data-for="policy-expiration-date" id="infopanel-for-policy-expiration-date" role="dialog">
+   <span id="infopaneltitle-for-policy-expiration-date" style="display:none">Info about the 'policy expiration date' definition.</span><b><a href="#policy-expiration-date">#policy-expiration-date</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-expiration-date">4.1.2. 
     Pin policy for origin in mode </a> <a href="#ref-for-policy-expiration-date①">(2)</a>
@@ -1206,8 +1208,8 @@ directive-value = 1*DIGIT
     Remove expired pinned policies from the cache </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-directive-set">
-   <b><a href="#policy-directive-set">#policy-directive-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-directive-set" class="dfn-panel" data-for="policy-directive-set" id="infopanel-for-policy-directive-set" role="dialog">
+   <span id="infopaneltitle-for-policy-directive-set" style="display:none">Info about the 'policy directive set' definition.</span><b><a href="#policy-directive-set">#policy-directive-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive-set">2.1. Terms defined by this specification</a> <a href="#ref-for-policy-directive-set①">(2)</a>
     <li><a href="#ref-for-policy-directive-set②">4.1.2. 
@@ -1216,8 +1218,8 @@ directive-value = 1*DIGIT
     Pin a policy to response </a> <a href="#ref-for-policy-directive-set⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mode">
-   <b><a href="#mode">#mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mode" class="dfn-panel" data-for="mode" id="infopanel-for-mode" role="dialog">
+   <span id="infopaneltitle-for-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#mode">#mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mode">2.1. Terms defined by this specification</a>
     <li><a href="#ref-for-mode①">4.1.2. 
@@ -1226,8 +1228,8 @@ directive-value = 1*DIGIT
     Get the mode pinned policy for host </a> <a href="#ref-for-mode③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy-pin">
-   <b><a href="#content-security-policy-pin">#content-security-policy-pin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy-pin" class="dfn-panel" data-for="content-security-policy-pin" id="infopanel-for-content-security-policy-pin" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy-pin" style="display:none">Info about the 'Content-Security-Policy-Pin' definition.</span><b><a href="#content-security-policy-pin">#content-security-policy-pin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-pin">1. Introduction</a>
     <li><a href="#ref-for-content-security-policy-pin①">3. Pinned Policy Delivery</a>
@@ -1245,8 +1247,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Pin </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="content-security-policy-report-only-pin">
-   <b><a href="#content-security-policy-report-only-pin">#content-security-policy-report-only-pin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-content-security-policy-report-only-pin" class="dfn-panel" data-for="content-security-policy-report-only-pin" id="infopanel-for-content-security-policy-report-only-pin" role="dialog">
+   <span id="infopaneltitle-for-content-security-policy-report-only-pin" style="display:none">Info about the 'Content-Security-Policy-Report-Only-Pin' definition.</span><b><a href="#content-security-policy-report-only-pin">#content-security-policy-report-only-pin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-report-only-pin">3. Pinned Policy Delivery</a>
     <li><a href="#ref-for-content-security-policy-report-only-pin①">3.2. 
@@ -1255,8 +1257,8 @@ directive-value = 1*DIGIT
       Content-Security-Policy-Report-Only-Pin </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="max-age">
-   <b><a href="#max-age">#max-age</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-max-age" class="dfn-panel" data-for="max-age" id="infopanel-for-max-age" role="dialog">
+   <span id="infopaneltitle-for-max-age" style="display:none">Info about the 'max-age' definition.</span><b><a href="#max-age">#max-age</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-max-age">1.1. Use Cases</a> <a href="#ref-for-max-age①">(2)</a>
     <li><a href="#ref-for-max-age②">3.3. Pinned Policy Syntax</a>
@@ -1265,8 +1267,8 @@ directive-value = 1*DIGIT
     <li><a href="#ref-for-max-age⑦">5.1. Hostile Pinning</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="includesubdomains">
-   <b><a href="#includesubdomains">#includesubdomains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-includesubdomains" class="dfn-panel" data-for="includesubdomains" id="infopanel-for-includesubdomains" role="dialog">
+   <span id="infopaneltitle-for-includesubdomains" style="display:none">Info about the 'includeSubDomains' definition.</span><b><a href="#includesubdomains">#includesubdomains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-includesubdomains">1.1. Use Cases</a> <a href="#ref-for-includesubdomains①">(2)</a>
     <li><a href="#ref-for-includesubdomains②">2.1. Terms defined by this specification</a>
@@ -1277,57 +1279,113 @@ directive-value = 1*DIGIT
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-fetch-metadata/index.html
+++ b/tests/github/w3c/webappsec-fetch-metadata/index.html
@@ -1047,20 +1047,20 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
    <li><a href="#abstract-opdef-set-user">set-user</a><span>, in § 2.4</span>
    <li><a href="#request-user-activation">user activation</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-current-url" class="dfn-panel" data-for="term-for-concept-request-current-url" id="infopanel-for-term-for-concept-request-current-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-current-url" style="display:none">Info about the 'current url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-current-url">https://fetch.spec.whatwg.org/#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">4.1. Redirects</a> <a href="#ref-for-concept-request-current-url①">(2)</a> <a href="#ref-for-concept-request-current-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">2.1. The Sec-Fetch-Dest HTTP Request Header</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a> <a href="#ref-for-concept-request-destination③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">2.1. The Sec-Fetch-Dest HTTP Request Header</a>
     <li><a href="#ref-for-concept-request-header-list①">2.2. The Sec-Fetch-Mode HTTP Request Header</a>
@@ -1068,28 +1068,28 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-concept-request-header-list③">2.4. The Sec-Fetch-User HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">2.2. The Sec-Fetch-Mode HTTP Request Header</a> <a href="#ref-for-concept-request-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">2.3. The Sec-Fetch-Site HTTP Request Header</a>
     <li><a href="#ref-for-navigation-request①">2.4. The Sec-Fetch-User HTTP Request Header</a> <a href="#ref-for-navigation-request②">(2)</a> <a href="#ref-for-navigation-request③">(3)</a>
     <li><a href="#ref-for-navigation-request④">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">2.3. The Sec-Fetch-Site HTTP Request Header</a> <a href="#ref-for-concept-request-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2. Fetch Metadata Headers</a>
     <li><a href="#ref-for-concept-request①">2.1. The Sec-Fetch-Dest HTTP Request Header</a> <a href="#ref-for-concept-request②">(2)</a>
@@ -1100,8 +1100,8 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-concept-request①①">4.1. Redirects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-set-structured-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-set-structured-header">https://fetch.spec.whatwg.org/#concept-header-list-set-structured-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-set-structured-header" class="dfn-panel" data-for="term-for-concept-header-list-set-structured-header" id="infopanel-for-term-for-concept-header-list-set-structured-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-set-structured-header" style="display:none">Info about the 'set a structured field value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-set-structured-header">https://fetch.spec.whatwg.org/#concept-header-list-set-structured-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-set-structured-header">2.1. The Sec-Fetch-Dest HTTP Request Header</a>
     <li><a href="#ref-for-concept-header-list-set-structured-header①">2.2. The Sec-Fetch-Mode HTTP Request Header</a>
@@ -1109,8 +1109,8 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-concept-header-list-set-structured-header③">2.4. The Sec-Fetch-User HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.1. The Sec-Fetch-Dest HTTP Request Header</a>
     <li><a href="#ref-for-concept-request-url①">2.2. The Sec-Fetch-Mode HTTP Request Header</a>
@@ -1119,57 +1119,57 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-concept-request-url④">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url-list">https://fetch.spec.whatwg.org/#concept-request-url-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url-list" class="dfn-panel" data-for="term-for-concept-request-url-list" id="infopanel-for-term-for-concept-request-url-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url-list" style="display:none">Info about the 'url list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url-list">https://fetch.spec.whatwg.org/#concept-request-url-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url-list">2.3. The Sec-Fetch-Site HTTP Request Header</a>
     <li><a href="#ref-for-concept-request-url-list①">4.1. Redirects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windowproxy">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windowproxy" class="dfn-panel" data-for="term-for-windowproxy" id="infopanel-for-term-for-windowproxy" role="menu">
+   <span id="infopaneltitle-for-term-for-windowproxy" style="display:none">Info about the 'WindowProxy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowproxy">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-picture-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-picture-element" class="dfn-panel" data-for="term-for-the-picture-element" id="infopanel-for-term-for-the-picture-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-picture-element" style="display:none">Info about the 'picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-picture-element">1.1. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.3. The Sec-Fetch-Site HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-site-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-site-same-site" class="dfn-panel" data-for="term-for-concept-site-same-site" id="infopanel-for-term-for-concept-site-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-site-same-site" style="display:none">Info about the 'same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-site-same-site">2.3. The Sec-Fetch-Site HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.9">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.9" class="dfn-panel" data-for="term-for-section-3.9" id="infopanel-for-term-for-section-3.9" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.9" style="display:none">Info about the 'boolean' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.9">2.4. The Sec-Fetch-User HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'structured header' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2.1. The Sec-Fetch-Dest HTTP Request Header</a> <a href="#termref-for-">(2)</a>
     <li><a href="#termref-for-">2.2. The Sec-Fetch-Mode HTTP Request Header</a> <a href="#termref-for-">(2)</a>
@@ -1177,8 +1177,8 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#termref-for-">2.4. The Sec-Fetch-User HTTP Request Header</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.7">
-   <a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.7">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.7" class="dfn-panel" data-for="term-for-section-3.7" id="infopanel-for-term-for-section-3.7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.7" style="display:none">Info about the 'token' external reference.</span><a href="https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.7">https://tools.ietf.org/html/draft-ietf-httpbis-header-structure#section-3.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.7">2.1. The Sec-Fetch-Dest HTTP Request Header</a> <a href="#ref-for-section-3.7①">(2)</a> <a href="#ref-for-section-3.7②">(3)</a>
     <li><a href="#ref-for-section-3.7③">2.2. The Sec-Fetch-Mode HTTP Request Header</a> <a href="#ref-for-section-3.7④">(2)</a>
@@ -1186,20 +1186,20 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-section-3.7⑦">2.4. The Sec-Fetch-User HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">2.3. The Sec-Fetch-Site HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">2.3. The Sec-Fetch-Site HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
-   <a href="https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url">https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-url" class="dfn-panel" data-for="term-for-potentially-trustworthy-url" id="infopanel-for-term-for-potentially-trustworthy-url" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-url" style="display:none">Info about the 'potentially trustworthy url' external reference.</span><a href="https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url">https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-url">2.1. The Sec-Fetch-Dest HTTP Request Header</a>
     <li><a href="#ref-for-potentially-trustworthy-url①">2.2. The Sec-Fetch-Mode HTTP Request Header</a>
@@ -1208,8 +1208,8 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
     <li><a href="#ref-for-potentially-trustworthy-url④">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2.3. The Sec-Fetch-Site HTTP Request Header</a>
    </ul>
@@ -1298,67 +1298,67 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
    <div class="issue"> This should be defined in HTML. <a href="https://github.com/whatwg/html/issues/5203">[Issue #whatwg/html#5203]</a> <a class="issue-return" href="#issue-b1fabf90" title="Jump to section">↵</a></div>
    <div class="issue"> This should be called from in Fetch. <a href="https://github.com/whatwg/fetch/issues/993">[Issue #whatwg/fetch#993]</a> <a class="issue-return" href="#issue-03cc838f" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="fetch-metadata-headers">
-   <b><a href="#fetch-metadata-headers">#fetch-metadata-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-metadata-headers" class="dfn-panel" data-for="fetch-metadata-headers" id="infopanel-for-fetch-metadata-headers" role="dialog">
+   <span id="infopaneltitle-for-fetch-metadata-headers" style="display:none">Info about the 'fetch metadata headers' definition.</span><b><a href="#fetch-metadata-headers">#fetch-metadata-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-metadata-headers">1. Introduction</a>
     <li><a href="#ref-for-fetch-metadata-headers①">5.1. Vary</a>
     <li><a href="#ref-for-fetch-metadata-headers②">6. IANA Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-fetch-dest">
-   <b><a href="#http-headerdef-sec-fetch-dest">#http-headerdef-sec-fetch-dest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-fetch-dest" class="dfn-panel" data-for="http-headerdef-sec-fetch-dest" id="infopanel-for-http-headerdef-sec-fetch-dest" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-fetch-dest" style="display:none">Info about the 'Sec-Fetch-Dest' definition.</span><b><a href="#http-headerdef-sec-fetch-dest">#http-headerdef-sec-fetch-dest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-fetch-dest">2.1. The Sec-Fetch-Dest HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-set-dest">
-   <b><a href="#abstract-opdef-set-dest">#abstract-opdef-set-dest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-set-dest" class="dfn-panel" data-for="abstract-opdef-set-dest" id="infopanel-for-abstract-opdef-set-dest" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-set-dest" style="display:none">Info about the 'set the Sec-Fetch-Dest header' definition.</span><b><a href="#abstract-opdef-set-dest">#abstract-opdef-set-dest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-set-dest">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-fetch-mode">
-   <b><a href="#http-headerdef-sec-fetch-mode">#http-headerdef-sec-fetch-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-fetch-mode" class="dfn-panel" data-for="http-headerdef-sec-fetch-mode" id="infopanel-for-http-headerdef-sec-fetch-mode" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-fetch-mode" style="display:none">Info about the 'Sec-Fetch-Mode' definition.</span><b><a href="#http-headerdef-sec-fetch-mode">#http-headerdef-sec-fetch-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-fetch-mode">2.2. The Sec-Fetch-Mode HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-set-mode">
-   <b><a href="#abstract-opdef-set-mode">#abstract-opdef-set-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-set-mode" class="dfn-panel" data-for="abstract-opdef-set-mode" id="infopanel-for-abstract-opdef-set-mode" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-set-mode" style="display:none">Info about the 'set the Sec-Fetch-Mode header' definition.</span><b><a href="#abstract-opdef-set-mode">#abstract-opdef-set-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-set-mode">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-fetch-site">
-   <b><a href="#http-headerdef-sec-fetch-site">#http-headerdef-sec-fetch-site</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-fetch-site" class="dfn-panel" data-for="http-headerdef-sec-fetch-site" id="infopanel-for-http-headerdef-sec-fetch-site" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-fetch-site" style="display:none">Info about the 'Sec-Fetch-Site' definition.</span><b><a href="#http-headerdef-sec-fetch-site">#http-headerdef-sec-fetch-site</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-fetch-site">2.3. The Sec-Fetch-Site HTTP Request Header</a>
     <li><a href="#ref-for-http-headerdef-sec-fetch-site①">4.1. Redirects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-set-site">
-   <b><a href="#abstract-opdef-set-site">#abstract-opdef-set-site</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-set-site" class="dfn-panel" data-for="abstract-opdef-set-site" id="infopanel-for-abstract-opdef-set-site" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-set-site" style="display:none">Info about the 'set the Sec-Fetch-Site header' definition.</span><b><a href="#abstract-opdef-set-site">#abstract-opdef-set-site</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-set-site">3. Integration with Fetch and HTML</a>
     <li><a href="#ref-for-abstract-opdef-set-site①">4.1. Redirects</a>
     <li><a href="#ref-for-abstract-opdef-set-site②">4.3. Directly User-Initiated Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-sec-fetch-user">
-   <b><a href="#http-headerdef-sec-fetch-user">#http-headerdef-sec-fetch-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-sec-fetch-user" class="dfn-panel" data-for="http-headerdef-sec-fetch-user" id="infopanel-for-http-headerdef-sec-fetch-user" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-sec-fetch-user" style="display:none">Info about the 'Sec-Fetch-User' definition.</span><b><a href="#http-headerdef-sec-fetch-user">#http-headerdef-sec-fetch-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-sec-fetch-user">2.4. The Sec-Fetch-User HTTP Request Header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-set-user">
-   <b><a href="#abstract-opdef-set-user">#abstract-opdef-set-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-set-user" class="dfn-panel" data-for="abstract-opdef-set-user" id="infopanel-for-abstract-opdef-set-user" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-set-user" style="display:none">Info about the 'set the Sec-Fetch-User header' definition.</span><b><a href="#abstract-opdef-set-user">#abstract-opdef-set-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-set-user">3. Integration with Fetch and HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-user-activation">
-   <b><a href="#request-user-activation">#request-user-activation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-user-activation" class="dfn-panel" data-for="request-user-activation" id="infopanel-for-request-user-activation" role="dialog">
+   <span id="infopaneltitle-for-request-user-activation" style="display:none">Info about the 'user activation' definition.</span><b><a href="#request-user-activation">#request-user-activation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-user-activation">2.4. The Sec-Fetch-User HTTP Request Header</a>
     <li><a href="#ref-for-request-user-activation①">3. Integration with Fetch and HTML</a>
@@ -1366,59 +1366,115 @@ Roberto Clapis, who all provided substantial support in the design of this mecha
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webappsec-mixed-content/index.html
+++ b/tests/github/w3c/webappsec-mixed-content/index.html
@@ -961,39 +961,39 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#upgradeable-mixed-content">upgradeable mixed content</a><span>, in § 3.1</span>
    <li><a href="#upgrade-algorithm">Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.1. Upgradeable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-image" class="dfn-panel" data-for="term-for-propdef-border-image" id="infopanel-for-term-for-propdef-border-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-image" style="display:none">Info about the 'border-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-image">3.1. Upgradeable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-document①">7.1. Form Submission</a> <a href="#ref-for-document②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">5.2. Modifications to HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">5.2. Modifications to HTML</a> <a href="#ref-for-concept-document-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a>
     <li><a href="#ref-for-concept-request-client①">4.4. 
@@ -1003,8 +1003,8 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-destination">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-destination" class="dfn-panel" data-for="term-for-concept-request-destination" id="infopanel-for-term-for-concept-request-destination" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-destination" style="display:none">Info about the 'destination' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-destination">https://fetch.spec.whatwg.org/#concept-request-destination</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">3.1. Upgradeable Content</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a>
     <li><a href="#ref-for-concept-request-destination③">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a> <a href="#ref-for-concept-request-destination④">(2)</a>
@@ -1015,27 +1015,27 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-initiator">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-initiator" class="dfn-panel" data-for="term-for-concept-request-initiator" id="infopanel-for-term-for-concept-request-initiator" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-initiator" style="display:none">Info about the 'initiator' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-initiator">https://fetch.spec.whatwg.org/#concept-request-initiator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">3.1. Upgradeable Content</a>
     <li><a href="#ref-for-concept-request-initiator①">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">3.2. Blockable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a>
     <li><a href="#ref-for-concept-request③">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a>
@@ -1046,8 +1046,8 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-response①">(2)</a>
     <li><a href="#ref-for-concept-response②">4.5. 
@@ -1055,8 +1055,8 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-concept-request-url①">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a> <a href="#ref-for-concept-request-url②">(2)</a> <a href="#ref-for-concept-request-url③">(3)</a> <a href="#ref-for-concept-request-url④">(4)</a>
@@ -1064,8 +1064,8 @@ dfn > a.self-link::before      { content: "#"; }
       Should fetching request be blocked as mixed content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-concept-response-url①">4.5. 
@@ -1073,96 +1073,96 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url-list">https://fetch.spec.whatwg.org/#concept-response-url-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url-list" class="dfn-panel" data-for="term-for-concept-response-url-list" id="infopanel-for-term-for-concept-response-url-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url-list" style="display:none">Info about the 'url list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url-list">https://fetch.spec.whatwg.org/#concept-response-url-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url-list">5.2. Modifications to HTML</a> <a href="#ref-for-concept-response-url-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-fs-action">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-fs-action" class="dfn-panel" data-for="term-for-attr-fs-action" id="infopanel-for-term-for-attr-fs-action" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-fs-action" style="display:none">Info about the 'action' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-fs-action">7.1. Form Submission</a> <a href="#ref-for-attr-fs-action①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">5.2. Modifications to HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audio">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audio" class="dfn-panel" data-for="term-for-audio" id="infopanel-for-term-for-audio" role="menu">
+   <span id="infopaneltitle-for-term-for-audio" style="display:none">Info about the 'audio' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio">3.1. Upgradeable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-doc-container-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document">https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-doc-container-document" class="dfn-panel" data-for="term-for-doc-container-document" id="infopanel-for-term-for-doc-container-document" role="menu">
+   <span id="infopaneltitle-for-term-for-doc-container-document" style="display:none">Info about the 'container document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document">https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-doc-container-document">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-downloading-hyperlinks">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-downloading-hyperlinks" class="dfn-panel" data-for="term-for-downloading-hyperlinks" id="infopanel-for-term-for-downloading-hyperlinks" role="menu">
+   <span id="infopaneltitle-for-term-for-downloading-hyperlinks" style="display:none">Info about the 'download the hyperlink' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-downloading-hyperlinks">5.2. Modifications to HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">4.3. 
       Does settings prohibit mixed security contexts? </a> <a href="#ref-for-environment-settings-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">7.1. Form Submission</a> <a href="#ref-for-the-form-element①">(2)</a> <a href="#ref-for-the-form-element②">(3)</a> <a href="#ref-for-the-form-element③">(4)</a> <a href="#ref-for-the-form-element④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">3.1. Upgradeable Content</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.3. 
       Does settings prohibit mixed security contexts? </a> <a href="#ref-for-concept-settings-object-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-plugin">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugin">https://html.spec.whatwg.org/multipage/infrastructure.html#plugin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-plugin" class="dfn-panel" data-for="term-for-plugin" id="infopanel-for-term-for-plugin" role="menu">
+   <span id="infopaneltitle-for-term-for-plugin" style="display:none">Info about the 'plugin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugin">https://html.spec.whatwg.org/multipage/infrastructure.html#plugin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-plugin">3.2. Blockable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.3. 
       Does settings prohibit mixed security contexts? </a>
     <li><a href="#ref-for-relevant-settings-object①">7.1. Form Submission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-source-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-source-element" class="dfn-panel" data-for="term-for-the-source-element" id="infopanel-for-term-for-the-source-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-source-element" style="display:none">Info about the 'source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-source-element">3.1. Upgradeable Content</a> <a href="#ref-for-the-source-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">4.4. 
       Should fetching request be blocked as mixed content? </a>
@@ -1171,8 +1171,8 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3.2. Blockable Content</a>
     <li><a href="#ref-for-top-level-browsing-context①">4.3. 
@@ -1180,27 +1180,27 @@ dfn > a.self-link::before      { content: "#"; }
     <li><a href="#ref-for-top-level-browsing-context②">7.1. Form Submission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-use-srcset-or-picture">
-   <a href="https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture">https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-use-srcset-or-picture" class="dfn-panel" data-for="term-for-use-srcset-or-picture" id="infopanel-for-term-for-use-srcset-or-picture" role="menu">
+   <span id="infopaneltitle-for-term-for-use-srcset-or-picture" style="display:none">Info about the 'use srcset or picture' external reference.</span><a href="https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture">https://html.spec.whatwg.org/multipage/images.html#use-srcset-or-picture</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-use-srcset-or-picture">3.1. Upgradeable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">3.1. Upgradeable Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-origin">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-origin" class="dfn-panel" data-for="term-for-potentially-trustworthy-origin" id="infopanel-for-term-for-potentially-trustworthy-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-origin" style="display:none">Info about the 'potentially trustworthy origin' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-origin">4.3. 
       Does settings prohibit mixed security contexts? </a> <a href="#ref-for-potentially-trustworthy-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-url" class="dfn-panel" data-for="term-for-potentially-trustworthy-url" id="infopanel-for-term-for-potentially-trustworthy-url" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-url" style="display:none">Info about the 'potentially trustworthy url' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-url">2. Key Concepts and Terminology</a> <a href="#ref-for-potentially-trustworthy-url①">(2)</a> <a href="#ref-for-potentially-trustworthy-url②">(3)</a>
     <li><a href="#ref-for-potentially-trustworthy-url③">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a> <a href="#ref-for-potentially-trustworthy-url④">(2)</a>
@@ -1213,14 +1213,14 @@ dfn > a.self-link::before      { content: "#"; }
     <li><a href="#ref-for-potentially-trustworthy-url①①">7.1. Form Submission</a> <a href="#ref-for-potentially-trustworthy-url①②">(2)</a> <a href="#ref-for-potentially-trustworthy-url①③">(3)</a> <a href="#ref-for-potentially-trustworthy-url①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequest" class="dfn-panel" data-for="term-for-xmlhttprequest" id="infopanel-for-term-for-xmlhttprequest" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">3.2. Blockable Content</a>
    </ul>
@@ -1323,8 +1323,8 @@ dfn > a.self-link::before      { content: "#"; }
    <dt id="biblio-xml">[XML]
    <dd>Tim Bray; et al. <a href="https://www.w3.org/TR/xml/"><cite>Extensible Markup Language (XML) 1.0 (Fifth Edition)</cite></a>. 26 November 2008. REC. URL: <a href="https://www.w3.org/TR/xml/">https://www.w3.org/TR/xml/</a>
   </dl>
-  <aside class="dfn-panel" data-for="mixed-content">
-   <b><a href="#mixed-content">#mixed-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mixed-content" class="dfn-panel" data-for="mixed-content" id="infopanel-for-mixed-content" role="dialog">
+   <span id="infopaneltitle-for-mixed-content" style="display:none">Info about the 'mixed content' definition.</span><b><a href="#mixed-content">#mixed-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mixed-content">3. Content Categories</a>
     <li><a href="#ref-for-mixed-content①">3.1. Upgradeable Content</a>
@@ -1335,8 +1335,10 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unauthenticated-response">
-   <b><a href="#unauthenticated-response">#unauthenticated-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unauthenticated-response" class="dfn-panel" data-for="unauthenticated-response" id="infopanel-for-unauthenticated-response" role="dialog">
+   <span id="infopaneltitle-for-unauthenticated-response" style="display:none">Info about the '
+        unauthenticated response
+      ' definition.</span><b><a href="#unauthenticated-response">#unauthenticated-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unauthenticated-response">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-unauthenticated-response①">4.5. 
@@ -1344,23 +1346,23 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a> <a href="#ref-for-unauthenticated-response②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="embedding-document">
-   <b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-embedding-document" class="dfn-panel" data-for="embedding-document" id="infopanel-for-embedding-document" role="dialog">
+   <span id="infopaneltitle-for-embedding-document" style="display:none">Info about the 'embedding document' definition.</span><b><a href="#embedding-document">#embedding-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedding-document">4.3. 
       Does settings prohibit mixed security contexts? </a> <a href="#ref-for-embedding-document①">(2)</a> <a href="#ref-for-embedding-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgradeable-mixed-content">
-   <b><a href="#upgradeable-mixed-content">#upgradeable-mixed-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgradeable-mixed-content" class="dfn-panel" data-for="upgradeable-mixed-content" id="infopanel-for-upgradeable-mixed-content" role="dialog">
+   <span id="infopaneltitle-for-upgradeable-mixed-content" style="display:none">Info about the 'upgradeable' definition.</span><b><a href="#upgradeable-mixed-content">#upgradeable-mixed-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgradeable-mixed-content">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-upgradeable-mixed-content①">3.2. Blockable Content</a>
     <li><a href="#ref-for-upgradeable-mixed-content②">7.2. User Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blockable-mixed-content">
-   <b><a href="#blockable-mixed-content">#blockable-mixed-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blockable-mixed-content" class="dfn-panel" data-for="blockable-mixed-content" id="infopanel-for-blockable-mixed-content" role="dialog">
+   <span id="infopaneltitle-for-blockable-mixed-content" style="display:none">Info about the 'blockable' definition.</span><b><a href="#blockable-mixed-content">#blockable-mixed-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockable-mixed-content">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-blockable-mixed-content①">4.4. 
@@ -1372,15 +1374,17 @@ dfn > a.self-link::before      { content: "#"; }
     <li><a href="#ref-for-blockable-mixed-content⑤">7.2. User Controls</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-algorithm">
-   <b><a href="#upgrade-algorithm">#upgrade-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-algorithm" class="dfn-panel" data-for="upgrade-algorithm" id="infopanel-for-upgrade-algorithm" role="dialog">
+   <span id="infopaneltitle-for-upgrade-algorithm" style="display:none">Info about the '4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate' definition.</span><b><a href="#upgrade-algorithm">#upgrade-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-algorithm">4.1. Upgrade a mixed content request to a potentially trustworthy URL, if appropriate</a>
     <li><a href="#ref-for-upgrade-algorithm">5.1. Modifications to Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-fetch">
-   <b><a href="#should-block-fetch">#should-block-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-fetch" class="dfn-panel" data-for="should-block-fetch" id="infopanel-for-should-block-fetch" role="dialog">
+   <span id="infopaneltitle-for-should-block-fetch" style="display:none">Info about the '4.4. 
+      Should fetching request be blocked as mixed content?
+    ' definition.</span><b><a href="#should-block-fetch">#should-block-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-fetch">3.1. Upgradeable Content</a>
     <li><a href="#ref-for-should-block-fetch">3.2. Blockable Content</a>
@@ -1391,8 +1395,11 @@ dfn > a.self-link::before      { content: "#"; }
       content? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-block-response">
-   <b><a href="#should-block-response">#should-block-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-block-response" class="dfn-panel" data-for="should-block-response" id="infopanel-for-should-block-response" role="dialog">
+   <span id="infopaneltitle-for-should-block-response" style="display:none">Info about the '4.5. 
+      Should response to request be blocked as mixed
+      content?
+    ' definition.</span><b><a href="#should-block-response">#should-block-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-response">4.5. 
       Should response to request be blocked as mixed
@@ -1401,57 +1408,113 @@ dfn > a.self-link::before      { content: "#"; }
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-permissions-policy/index.html
+++ b/tests/github/w3c/webappsec-permissions-policy/index.html
@@ -2300,65 +2300,65 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
    <li><a href="#violate">violated</a><span>, in § 8</span>
    <li><a href="#violate">violation</a><span>, in § 8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sandbox">
-   <a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandbox" class="dfn-panel" data-for="term-for-sandbox" id="infopanel-for-term-for-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">3. Other and related mechanisms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.3. Inherited policies</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">7.2. The permissionsPolicy object</a> <a href="#ref-for-document③">(2)</a> <a href="#ref-for-document④">(3)</a> <a href="#ref-for-document⑤">(4)</a> <a href="#ref-for-document⑥">(5)</a> <a href="#ref-for-document⑦">(6)</a> <a href="#ref-for-document⑧">(7)</a>
     <li><a href="#ref-for-document⑨">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">7.2. The permissionsPolicy object</a> <a href="#ref-for-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">7.2. The permissionsPolicy object</a> <a href="#ref-for-concept-node-document①">(2)</a> <a href="#ref-for-concept-node-document②">(3)</a> <a href="#ref-for-concept-node-document③">(4)</a>
     <li><a href="#ref-for-concept-node-document④">9.8. Define an inherited policy for feature in container at origin</a> <a href="#ref-for-concept-node-document⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-get-structured-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header">https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-get-structured-header" class="dfn-panel" data-for="term-for-concept-header-list-get-structured-header" id="infopanel-for-term-for-concept-header-list-get-structured-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-get-structured-header" style="display:none">Info about the 'get a structured field value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header">https://fetch.spec.whatwg.org/#concept-header-list-get-structured-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get-structured-header">9.1. Process response policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-origin">https://fetch.spec.whatwg.org/#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-response" class="dfn-panel" data-for="term-for-concept-response-response" id="infopanel-for-term-for-concept-response-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-response">https://fetch.spec.whatwg.org/#concept-response-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">6.1. Permissions-Policy HTTP Header
     Field</a>
@@ -2366,72 +2366,72 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-concept-response-response②">9.6. Create a Permissions Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-window">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-window">https://fetch.spec.whatwg.org/#concept-request-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-window" class="dfn-panel" data-for="term-for-concept-request-window" id="infopanel-for-term-for-concept-request-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-window" style="display:none">Info about the 'window' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-window">https://fetch.spec.whatwg.org/#concept-request-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-window">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-requestfullscreen">
-   <a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-requestfullscreen" class="dfn-panel" data-for="term-for-dom-element-requestfullscreen" id="infopanel-for-term-for-dom-element-requestfullscreen" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-requestfullscreen" style="display:none">Info about the 'requestFullscreen()' external reference.</span><a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-requestfullscreen">6.3.1. allowfullscreen</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictionary">
-   <a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#dictionary">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictionary" class="dfn-panel" data-for="term-for-dictionary" id="infopanel-for-term-for-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-dictionary" style="display:none">Info about the 'sh-dictionary' external reference.</span><a href="https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#dictionary">https://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html#dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictionary">4.7. Policy directives</a>
     <li><a href="#ref-for-dictionary①">6.1. Permissions-Policy HTTP Header
     Field</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmliframeelement" class="dfn-panel" data-for="term-for-htmliframeelement" id="infopanel-for-term-for-htmliframeelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmliframeelement" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmliframeelement">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">9.5. Create a Permissions Policy for a browsing context</a>
     <li><a href="#ref-for-browsing-context①">9.6. Create a Permissions Policy for a browsing context from response</a>
     <li><a href="#ref-for-browsing-context②">9.7. Define an inherited policy for feature in browsing context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">9.10. Generate report for violation of permissions policy on settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">3. Other and related mechanisms</a>
     <li><a href="#ref-for-the-iframe-element①">6.2. The allow attribute of the
@@ -2441,8 +2441,8 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-the-iframe-element⑦">9.4. Process permissions policy attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">4.8. Allowlists</a> <a href="#ref-for-concept-origin①">(2)</a>
     <li><a href="#ref-for-concept-origin②">7.2. The permissionsPolicy object</a> <a href="#ref-for-concept-origin③">(2)</a>
@@ -2456,170 +2456,170 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-concept-origin①②">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">9.8. Define an inherited policy for feature in container at origin</a>
     <li><a href="#ref-for-same-origin①">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-domain" class="dfn-panel" data-for="term-for-same-origin-domain" id="infopanel-for-term-for-same-origin-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-domain" style="display:none">Info about the 'same origin-domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain">https://html.spec.whatwg.org/multipage/browsers.html#same-origin-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-domain">4.8. Allowlists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-sandbox">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-sandbox" class="dfn-panel" data-for="term-for-attr-iframe-sandbox" id="infopanel-for-term-for-attr-iframe-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-sandbox">3. Other and related mechanisms</a>
     <li><a href="#ref-for-attr-iframe-sandbox①">7.2. The permissionsPolicy object</a>
     <li><a href="#ref-for-attr-iframe-sandbox②">11. Privacy and Security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandboxed-origin-browsing-context-flag">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandboxed-origin-browsing-context-flag" class="dfn-panel" data-for="term-for-sandboxed-origin-browsing-context-flag" id="infopanel-for-term-for-sandboxed-origin-browsing-context-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-sandboxed-origin-browsing-context-flag" style="display:none">Info about the 'sandboxed origin browsing context flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag">https://html.spec.whatwg.org/multipage/browsers.html#sandboxed-origin-browsing-context-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandboxed-origin-browsing-context-flag">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">5.1. HTML attribute serialization</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">5.2. Structured header serialization</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin②">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-src">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-src" class="dfn-panel" data-for="term-for-attr-iframe-src" id="infopanel-for-term-for-attr-iframe-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-src" style="display:none">Info about the 'src' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-src">6.2. The allow attribute of the
     iframe element</a>
     <li><a href="#ref-for-attr-iframe-src①">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-srcdoc">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-srcdoc" class="dfn-panel" data-for="term-for-attr-iframe-srcdoc" id="infopanel-for-term-for-attr-iframe-srcdoc" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-srcdoc" style="display:none">Info about the 'srcdoc' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-srcdoc">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">4.3. Inherited policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">9.3. Parse policy directive</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">9.2. Construct policy from dictionary and origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">4.8. Allowlists</a>
     <li><a href="#ref-for-ordered-set①">9.2. Construct policy from dictionary and origin</a>
     <li><a href="#ref-for-ordered-set②">9.3. Parse policy directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-ascii-whitespace" class="dfn-panel" data-for="term-for-split-on-ascii-whitespace" id="infopanel-for-term-for-split-on-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-ascii-whitespace" style="display:none">Info about the 'split on ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-ascii-whitespace">9.3. Parse policy directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">9.3. Parse policy directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">5.2. Structured header serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reportbody">
-   <a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reportbody" class="dfn-panel" data-for="term-for-reportbody" id="infopanel-for-term-for-reportbody" role="menu">
+   <span id="infopaneltitle-for-term-for-reportbody" style="display:none">Info about the 'ReportBody' external reference.</span><a href="https://w3c.github.io/reporting/#reportbody">https://w3c.github.io/reporting/#reportbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reportbody">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-body">
-   <a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-body" class="dfn-panel" data-for="term-for-report-body" id="infopanel-for-term-for-report-body" role="menu">
+   <span id="infopaneltitle-for-term-for-report-body" style="display:none">Info about the 'body' external reference.</span><a href="https://w3c.github.io/reporting/#report-body">https://w3c.github.io/reporting/#report-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-body">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report">
-   <a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report" class="dfn-panel" data-for="term-for-report" id="infopanel-for-term-for-report" role="menu">
+   <span id="infopaneltitle-for-term-for-report" style="display:none">Info about the 'report' external reference.</span><a href="https://w3c.github.io/reporting/#report">https://w3c.github.io/reporting/#report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report">9.10. Generate report for violation of permissions policy on settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-type">
-   <a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-type" class="dfn-panel" data-for="term-for-report-type" id="infopanel-for-term-for-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-report-type" style="display:none">Info about the 'report type' external reference.</span><a href="https://w3c.github.io/reporting/#report-type">https://w3c.github.io/reporting/#report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-type">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-visible-to-reportingobservers">
-   <a href="https://w3c.github.io/reporting/#visible-to-reportingobservers">https://w3c.github.io/reporting/#visible-to-reportingobservers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-visible-to-reportingobservers" class="dfn-panel" data-for="term-for-visible-to-reportingobservers" id="infopanel-for-term-for-visible-to-reportingobservers" role="menu">
+   <span id="infopaneltitle-for-term-for-visible-to-reportingobservers" style="display:none">Info about the 'visible to reportingobservers' external reference.</span><a href="https://w3c.github.io/reporting/#visible-to-reportingobservers">https://w3c.github.io/reporting/#visible-to-reportingobservers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-to-reportingobservers">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">9.2. Construct policy from dictionary and origin</a>
     <li><a href="#ref-for-concept-url-parser①">9.3. Parse policy directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">7.2. The permissionsPolicy object</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a>
     <li><a href="#ref-for-idl-DOMString⑥">8. Reporting</a> <a href="#ref-for-idl-DOMString⑦">(2)</a> <a href="#ref-for-idl-DOMString⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7.2. The permissionsPolicy object</a>
     <li><a href="#ref-for-Exposed①">8. Reporting</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">7.2. The permissionsPolicy object</a> <a href="#ref-for-SameObject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">8. Reporting</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">7.2. The permissionsPolicy object</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
    </ul>
@@ -2794,8 +2794,8 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
  initiated within these contexts to use policy-controlled features. <em>Until</em> that’s resolved, disallow all policy-controlled features (e.g.,
  sending Client Hints to third parties) in these contexts. <a class="issue-return" href="#issue-154a63d1" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="policy-controlled-feature">
-   <b><a href="#policy-controlled-feature">#policy-controlled-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-controlled-feature" class="dfn-panel" data-for="policy-controlled-feature" id="infopanel-for-policy-controlled-feature" role="dialog">
+   <span id="infopaneltitle-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' definition.</span><b><a href="#policy-controlled-feature">#policy-controlled-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">4.1. Policy-controlled Features</a> <a href="#ref-for-policy-controlled-feature①">(2)</a> <a href="#ref-for-policy-controlled-feature②">(3)</a> <a href="#ref-for-policy-controlled-feature③">(4)</a> <a href="#ref-for-policy-controlled-feature④">(5)</a> <a href="#ref-for-policy-controlled-feature⑤">(6)</a>
     <li><a href="#ref-for-policy-controlled-feature⑥">4.3. Inherited policies</a> <a href="#ref-for-policy-controlled-feature⑦">(2)</a>
@@ -2811,16 +2811,16 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-policy-controlled-feature①⑦">9.3. Parse policy directive</a> <a href="#ref-for-policy-controlled-feature①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-features">
-   <b><a href="#supported-features">#supported-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-features" class="dfn-panel" data-for="supported-features" id="infopanel-for-supported-features" role="dialog">
+   <span id="infopaneltitle-for-supported-features" style="display:none">Info about the 'supported features' definition.</span><b><a href="#supported-features">#supported-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-features">4.2. Policies</a>
     <li><a href="#ref-for-supported-features①">4.3. Inherited policies</a>
     <li><a href="#ref-for-supported-features②">7.2. The permissionsPolicy object</a> <a href="#ref-for-supported-features③">(2)</a> <a href="#ref-for-supported-features④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissions-policy">
-   <b><a href="#permissions-policy">#permissions-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissions-policy" class="dfn-panel" data-for="permissions-policy" id="infopanel-for-permissions-policy" role="dialog">
+   <span id="infopaneltitle-for-permissions-policy" style="display:none">Info about the 'permissions policy' definition.</span><b><a href="#permissions-policy">#permissions-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions-policy">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-permissions-policy①">4.2. Policies</a>
@@ -2835,8 +2835,9 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-permissions-policy①①">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inherited-policy">
-   <b><a href="#inherited-policy">#inherited-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inherited-policy" class="dfn-panel" data-for="inherited-policy" id="infopanel-for-inherited-policy" role="dialog">
+   <span id="infopaneltitle-for-inherited-policy" style="display:none">Info about the 'inherited
+    policy' definition.</span><b><a href="#inherited-policy">#inherited-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inherited-policy">4.2. Policies</a> <a href="#ref-for-inherited-policy①">(2)</a>
     <li><a href="#ref-for-inherited-policy②">4.3. Inherited policies</a> <a href="#ref-for-inherited-policy③">(2)</a>
@@ -2847,8 +2848,9 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-inherited-policy⑨">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-policy">
-   <b><a href="#declared-policy">#declared-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-policy" class="dfn-panel" data-for="declared-policy" id="infopanel-for-declared-policy" role="dialog">
+   <span id="infopaneltitle-for-declared-policy" style="display:none">Info about the 'declared
+    policy' definition.</span><b><a href="#declared-policy">#declared-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-policy">4.2. Policies</a> <a href="#ref-for-declared-policy①">(2)</a>
     <li><a href="#ref-for-declared-policy②">4.3. Inherited policies</a>
@@ -2860,14 +2862,14 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-declared-policy⑨">9.9. Is feature enabled in document for origin?</a> <a href="#ref-for-declared-policy①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="header-policy">
-   <b><a href="#header-policy">#header-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-header-policy" class="dfn-panel" data-for="header-policy" id="infopanel-for-header-policy" role="dialog">
+   <span id="infopaneltitle-for-header-policy" style="display:none">Info about the 'header policy' definition.</span><b><a href="#header-policy">#header-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-policy">4.6. Container policies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="container-policy">
-   <b><a href="#container-policy">#container-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-container-policy" class="dfn-panel" data-for="container-policy" id="infopanel-for-container-policy" role="dialog">
+   <span id="infopaneltitle-for-container-policy" style="display:none">Info about the 'container policy' definition.</span><b><a href="#container-policy">#container-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-policy">4.3. Inherited policies</a>
     <li><a href="#ref-for-container-policy①">4.6. Container policies</a> <a href="#ref-for-container-policy②">(2)</a> <a href="#ref-for-container-policy③">(3)</a> <a href="#ref-for-container-policy④">(4)</a>
@@ -2877,8 +2879,9 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-container-policy⑦">9.4. Process permissions policy attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policy-directive">
-   <b><a href="#policy-directive">#policy-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policy-directive" class="dfn-panel" data-for="policy-directive" id="infopanel-for-policy-directive" role="dialog">
+   <span id="infopaneltitle-for-policy-directive" style="display:none">Info about the 'policy
+    directive' definition.</span><b><a href="#policy-directive">#policy-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-policy-directive①">4.5. Header policies</a>
@@ -2889,8 +2892,8 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-policy-directive⑦">9.3. Parse policy directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allowlist">
-   <b><a href="#allowlist">#allowlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allowlist" class="dfn-panel" data-for="allowlist" id="infopanel-for-allowlist" role="dialog">
+   <span id="infopaneltitle-for-allowlist" style="display:none">Info about the 'allowlist' definition.</span><b><a href="#allowlist">#allowlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowlist">2. Examples</a>
     <li><a href="#ref-for-allowlist①">4.4. Declared policies</a>
@@ -2906,8 +2909,8 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-allowlist①⑤">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-special-value">
-   <b><a href="#the-special-value">#the-special-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-special-value" class="dfn-panel" data-for="the-special-value" id="infopanel-for-the-special-value" role="dialog">
+   <span id="infopaneltitle-for-the-special-value" style="display:none">Info about the 'The special value *' definition.</span><b><a href="#the-special-value">#the-special-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-special-value">4.8. Allowlists</a>
     <li><a href="#ref-for-the-special-value①">9.2. Construct policy from dictionary and origin</a>
@@ -2915,15 +2918,15 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-the-special-value③">9.4. Process permissions policy attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches">
-   <b><a href="#matches">#matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches" class="dfn-panel" data-for="matches" id="infopanel-for-matches" role="dialog">
+   <span id="infopaneltitle-for-matches" style="display:none">Info about the 'matches' definition.</span><b><a href="#matches">#matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches">9.8. Define an inherited policy for feature in container at origin</a> <a href="#ref-for-matches①">(2)</a>
     <li><a href="#ref-for-matches②">9.9. Is feature enabled in document for origin?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-allowlist">
-   <b><a href="#default-allowlist">#default-allowlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-allowlist" class="dfn-panel" data-for="default-allowlist" id="infopanel-for-default-allowlist" role="dialog">
+   <span id="infopaneltitle-for-default-allowlist" style="display:none">Info about the 'default allowlist' definition.</span><b><a href="#default-allowlist">#default-allowlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">4.1. Policy-controlled Features</a>
     <li><a href="#ref-for-default-allowlist①">4.9. Default Allowlists</a> <a href="#ref-for-default-allowlist②">(2)</a>
@@ -2931,284 +2934,340 @@ set <var>body</var>’s <a data-link-type="dfn" href="#permissionspolicyviolatio
     <li><a href="#ref-for-default-allowlist⑤">9.9. Is feature enabled in document for origin?</a> <a href="#ref-for-default-allowlist⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-policy-directive">
-   <b><a href="#serialized-policy-directive">#serialized-policy-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-policy-directive" class="dfn-panel" data-for="serialized-policy-directive" id="infopanel-for-serialized-policy-directive" role="dialog">
+   <span id="infopaneltitle-for-serialized-policy-directive" style="display:none">Info about the 'serialized-policy-directive' definition.</span><b><a href="#serialized-policy-directive">#serialized-policy-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-policy-directive">5.1. HTML attribute serialization</a> <a href="#ref-for-serialized-policy-directive①">(2)</a>
     <li><a href="#ref-for-serialized-policy-directive">6.2. The allow attribute of the
     iframe element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="feature-identifier">
-   <b><a href="#feature-identifier">#feature-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-feature-identifier" class="dfn-panel" data-for="feature-identifier" id="infopanel-for-feature-identifier" role="dialog">
+   <span id="infopaneltitle-for-feature-identifier" style="display:none">Info about the 'feature-identifier' definition.</span><b><a href="#feature-identifier">#feature-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-feature-identifier">5.1. HTML attribute serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allow-list">
-   <b><a href="#allow-list">#allow-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allow-list" class="dfn-panel" data-for="allow-list" id="infopanel-for-allow-list" role="dialog">
+   <span id="infopaneltitle-for-allow-list" style="display:none">Info about the 'allow-list' definition.</span><b><a href="#allow-list">#allow-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allow-list">5.1. HTML attribute serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="allow-list-value">
-   <b><a href="#allow-list-value">#allow-list-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-allow-list-value" class="dfn-panel" data-for="allow-list-value" id="infopanel-for-allow-list-value" role="dialog">
+   <span id="infopaneltitle-for-allow-list-value" style="display:none">Info about the 'allow-list-value' definition.</span><b><a href="#allow-list-value">#allow-list-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allow-list-value">5.1. HTML attribute serialization</a> <a href="#ref-for-allow-list-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-origin">
-   <b><a href="#serialized-origin">#serialized-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-origin" class="dfn-panel" data-for="serialized-origin" id="infopanel-for-serialized-origin" role="dialog">
+   <span id="infopaneltitle-for-serialized-origin" style="display:none">Info about the 'serialized-origin' definition.</span><b><a href="#serialized-origin">#serialized-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-origin">5.1. HTML attribute serialization</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissions-policy-header">
-   <b><a href="#permissions-policy-header">#permissions-policy-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissions-policy-header" class="dfn-panel" data-for="permissions-policy-header" id="infopanel-for-permissions-policy-header" role="dialog">
+   <span id="infopaneltitle-for-permissions-policy-header" style="display:none">Info about the 'Permissions-Policy' definition.</span><b><a href="#permissions-policy-header">#permissions-policy-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions-policy-header">2. Examples</a> <a href="#ref-for-permissions-policy-header①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicy">
-   <b><a href="#permissionspolicy">#permissionspolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicy" class="dfn-panel" data-for="permissionspolicy" id="infopanel-for-permissionspolicy" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicy" style="display:none">Info about the 'PermissionsPolicy' definition.</span><b><a href="#permissionspolicy">#permissionspolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicy">7.1. Overview</a>
     <li><a href="#ref-for-permissionspolicy①">7.1.1. Document policies</a>
     <li><a href="#ref-for-permissionspolicy②">7.2. The permissionsPolicy object</a> <a href="#ref-for-permissionspolicy③">(2)</a> <a href="#ref-for-permissionspolicy④">(3)</a> <a href="#ref-for-permissionspolicy⑤">(4)</a> <a href="#ref-for-permissionspolicy⑥">(5)</a> <a href="#ref-for-permissionspolicy⑦">(6)</a> <a href="#ref-for-permissionspolicy⑧">(7)</a> <a href="#ref-for-permissionspolicy⑨">(8)</a> <a href="#ref-for-permissionspolicy①⓪">(9)</a> <a href="#ref-for-permissionspolicy①①">(10)</a> <a href="#ref-for-permissionspolicy①②">(11)</a> <a href="#ref-for-permissionspolicy①③">(12)</a> <a href="#ref-for-permissionspolicy①④">(13)</a> <a href="#ref-for-permissionspolicy①⑤">(14)</a> <a href="#ref-for-permissionspolicy①⑥">(15)</a> <a href="#ref-for-permissionspolicy①⑦">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionspolicy-allowsfeature">
-   <b><a href="#dom-permissionspolicy-allowsfeature">#dom-permissionspolicy-allowsfeature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionspolicy-allowsfeature" class="dfn-panel" data-for="dom-permissionspolicy-allowsfeature" id="infopanel-for-dom-permissionspolicy-allowsfeature" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionspolicy-allowsfeature" style="display:none">Info about the 'allowsFeature' definition.</span><b><a href="#dom-permissionspolicy-allowsfeature">#dom-permissionspolicy-allowsfeature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionspolicy-allowsfeature">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionspolicy-features">
-   <b><a href="#dom-permissionspolicy-features">#dom-permissionspolicy-features</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionspolicy-features" class="dfn-panel" data-for="dom-permissionspolicy-features" id="infopanel-for-dom-permissionspolicy-features" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionspolicy-features" style="display:none">Info about the 'features' definition.</span><b><a href="#dom-permissionspolicy-features">#dom-permissionspolicy-features</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionspolicy-features">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionspolicy-allowedfeatures">
-   <b><a href="#dom-permissionspolicy-allowedfeatures">#dom-permissionspolicy-allowedfeatures</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionspolicy-allowedfeatures" class="dfn-panel" data-for="dom-permissionspolicy-allowedfeatures" id="infopanel-for-dom-permissionspolicy-allowedfeatures" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionspolicy-allowedfeatures" style="display:none">Info about the 'allowedFeatures' definition.</span><b><a href="#dom-permissionspolicy-allowedfeatures">#dom-permissionspolicy-allowedfeatures</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionspolicy-allowedfeatures">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-permissionspolicy-getallowlistforfeature">
-   <b><a href="#dom-permissionspolicy-getallowlistforfeature">#dom-permissionspolicy-getallowlistforfeature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-permissionspolicy-getallowlistforfeature" class="dfn-panel" data-for="dom-permissionspolicy-getallowlistforfeature" id="infopanel-for-dom-permissionspolicy-getallowlistforfeature" role="dialog">
+   <span id="infopaneltitle-for-dom-permissionspolicy-getallowlistforfeature" style="display:none">Info about the 'getAllowlistForFeature' definition.</span><b><a href="#dom-permissionspolicy-getallowlistforfeature">#dom-permissionspolicy-getallowlistforfeature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionspolicy-getallowlistforfeature">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-permissionspolicy">
-   <b><a href="#dom-document-permissionspolicy">#dom-document-permissionspolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-permissionspolicy" class="dfn-panel" data-for="dom-document-permissionspolicy" id="infopanel-for-dom-document-permissionspolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-document-permissionspolicy" style="display:none">Info about the 'permissionsPolicy' definition.</span><b><a href="#dom-document-permissionspolicy">#dom-document-permissionspolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-permissionspolicy">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmliframeelement-permissionspolicy">
-   <b><a href="#dom-htmliframeelement-permissionspolicy">#dom-htmliframeelement-permissionspolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmliframeelement-permissionspolicy" class="dfn-panel" data-for="dom-htmliframeelement-permissionspolicy" id="infopanel-for-dom-htmliframeelement-permissionspolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-htmliframeelement-permissionspolicy" style="display:none">Info about the 'permissionsPolicy' definition.</span><b><a href="#dom-htmliframeelement-permissionspolicy">#dom-htmliframeelement-permissionspolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmliframeelement-permissionspolicy">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="associated-node">
-   <b><a href="#associated-node">#associated-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-associated-node" class="dfn-panel" data-for="associated-node" id="infopanel-for-associated-node" role="dialog">
+   <span id="infopaneltitle-for-associated-node" style="display:none">Info about the 'associated node' definition.</span><b><a href="#associated-node">#associated-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-associated-node">7.2. The permissionsPolicy object</a> <a href="#ref-for-associated-node①">(2)</a> <a href="#ref-for-associated-node②">(3)</a> <a href="#ref-for-associated-node③">(4)</a> <a href="#ref-for-associated-node④">(5)</a> <a href="#ref-for-associated-node⑤">(6)</a> <a href="#ref-for-associated-node⑥">(7)</a> <a href="#ref-for-associated-node⑦">(8)</a> <a href="#ref-for-associated-node⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-origin">
-   <b><a href="#default-origin">#default-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-origin" class="dfn-panel" data-for="default-origin" id="infopanel-for-default-origin" role="dialog">
+   <span id="infopaneltitle-for-default-origin" style="display:none">Info about the 'default origin' definition.</span><b><a href="#default-origin">#default-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-origin">7.2. The permissionsPolicy object</a> <a href="#ref-for-default-origin①">(2)</a> <a href="#ref-for-default-origin②">(3)</a> <a href="#ref-for-default-origin③">(4)</a> <a href="#ref-for-default-origin④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-policy-object">
-   <b><a href="#document-policy-object">#document-policy-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-policy-object" class="dfn-panel" data-for="document-policy-object" id="infopanel-for-document-policy-object" role="dialog">
+   <span id="infopaneltitle-for-document-policy-object" style="display:none">Info about the 'policy object' definition.</span><b><a href="#document-policy-object">#document-policy-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-policy-object">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iframe-policy-object">
-   <b><a href="#iframe-policy-object">#iframe-policy-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iframe-policy-object" class="dfn-panel" data-for="iframe-policy-object" id="infopanel-for-iframe-policy-object" role="dialog">
+   <span id="infopaneltitle-for-iframe-policy-object" style="display:none">Info about the 'policy object' definition.</span><b><a href="#iframe-policy-object">#iframe-policy-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iframe-policy-object">7.2. The permissionsPolicy object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="observable-policy">
-   <b><a href="#observable-policy">#observable-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-observable-policy" class="dfn-panel" data-for="observable-policy" id="infopanel-for-observable-policy" role="dialog">
+   <span id="infopaneltitle-for-observable-policy" style="display:none">Info about the 'observable policy' definition.</span><b><a href="#observable-policy">#observable-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-observable-policy">7.1.2. Frame policies</a> <a href="#ref-for-observable-policy①">(2)</a>
     <li><a href="#ref-for-observable-policy②">7.2. The permissionsPolicy object</a> <a href="#ref-for-observable-policy③">(2)</a> <a href="#ref-for-observable-policy④">(3)</a> <a href="#ref-for-observable-policy⑤">(4)</a> <a href="#ref-for-observable-policy⑥">(5)</a>
     <li><a href="#ref-for-observable-policy⑦">11.1. Exposure of cross-origin behavior</a> <a href="#ref-for-observable-policy⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="declared-origin">
-   <b><a href="#declared-origin">#declared-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-declared-origin" class="dfn-panel" data-for="declared-origin" id="infopanel-for-declared-origin" role="dialog">
+   <span id="infopaneltitle-for-declared-origin" style="display:none">Info about the 'declared origin' definition.</span><b><a href="#declared-origin">#declared-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-declared-origin">7.2. The permissionsPolicy object</a> <a href="#ref-for-declared-origin①">(2)</a> <a href="#ref-for-declared-origin②">(3)</a>
     <li><a href="#ref-for-declared-origin③">9.4. Process permissions policy attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissions-policy-violation-reports">
-   <b><a href="#permissions-policy-violation-reports">#permissions-policy-violation-reports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissions-policy-violation-reports" class="dfn-panel" data-for="permissions-policy-violation-reports" id="infopanel-for-permissions-policy-violation-reports" role="dialog">
+   <span id="infopaneltitle-for-permissions-policy-violation-reports" style="display:none">Info about the 'Permissions policy violation reports' definition.</span><b><a href="#permissions-policy-violation-reports">#permissions-policy-violation-reports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions-policy-violation-reports">8. Reporting</a> <a href="#ref-for-permissions-policy-violation-reports①">(2)</a> <a href="#ref-for-permissions-policy-violation-reports②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="violate">
-   <b><a href="#violate">#violate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-violate" class="dfn-panel" data-for="violate" id="infopanel-for-violate" role="dialog">
+   <span id="infopaneltitle-for-violate" style="display:none">Info about the 'violate' definition.</span><b><a href="#violate">#violate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violate">8. Reporting</a> <a href="#ref-for-violate①">(2)</a> <a href="#ref-for-violate②">(3)</a> <a href="#ref-for-violate③">(4)</a> <a href="#ref-for-violate④">(5)</a> <a href="#ref-for-violate⑤">(6)</a> <a href="#ref-for-violate⑥">(7)</a>
     <li><a href="#ref-for-violate⑦">9.10. Generate report for violation of permissions policy on settings</a> <a href="#ref-for-violate⑧">(2)</a>
     <li><a href="#ref-for-violate⑨">11.1. Exposure of cross-origin behavior</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody">
-   <b><a href="#permissionspolicyviolationreportbody">#permissionspolicyviolationreportbody</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody" class="dfn-panel" data-for="permissionspolicyviolationreportbody" id="infopanel-for-permissionspolicyviolationreportbody" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody" style="display:none">Info about the 'PermissionsPolicyViolationReportBody' definition.</span><b><a href="#permissionspolicyviolationreportbody">#permissionspolicyviolationreportbody</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody">8. Reporting</a>
     <li><a href="#ref-for-permissionspolicyviolationreportbody①">9.10. Generate report for violation of permissions policy on settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody-featureid">
-   <b><a href="#permissionspolicyviolationreportbody-featureid">#permissionspolicyviolationreportbody-featureid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody-featureid" class="dfn-panel" data-for="permissionspolicyviolationreportbody-featureid" id="infopanel-for-permissionspolicyviolationreportbody-featureid" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody-featureid" style="display:none">Info about the 'featureId' definition.</span><b><a href="#permissionspolicyviolationreportbody-featureid">#permissionspolicyviolationreportbody-featureid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-featureid">9.10. Generate report for violation of permissions policy on settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody-sourcefile">
-   <b><a href="#permissionspolicyviolationreportbody-sourcefile">#permissionspolicyviolationreportbody-sourcefile</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody-sourcefile" class="dfn-panel" data-for="permissionspolicyviolationreportbody-sourcefile" id="infopanel-for-permissionspolicyviolationreportbody-sourcefile" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody-sourcefile" style="display:none">Info about the 'sourceFile' definition.</span><b><a href="#permissionspolicyviolationreportbody-sourcefile">#permissionspolicyviolationreportbody-sourcefile</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-sourcefile">8. Reporting</a> <a href="#ref-for-permissionspolicyviolationreportbody-sourcefile①">(2)</a>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-sourcefile②">9.10. Generate report for violation of permissions policy on settings</a> <a href="#ref-for-permissionspolicyviolationreportbody-sourcefile③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody-linenumber">
-   <b><a href="#permissionspolicyviolationreportbody-linenumber">#permissionspolicyviolationreportbody-linenumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody-linenumber" class="dfn-panel" data-for="permissionspolicyviolationreportbody-linenumber" id="infopanel-for-permissionspolicyviolationreportbody-linenumber" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody-linenumber" style="display:none">Info about the 'lineNumber' definition.</span><b><a href="#permissionspolicyviolationreportbody-linenumber">#permissionspolicyviolationreportbody-linenumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-linenumber">9.10. Generate report for violation of permissions policy on settings</a> <a href="#ref-for-permissionspolicyviolationreportbody-linenumber①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody-columnnumber">
-   <b><a href="#permissionspolicyviolationreportbody-columnnumber">#permissionspolicyviolationreportbody-columnnumber</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody-columnnumber" class="dfn-panel" data-for="permissionspolicyviolationreportbody-columnnumber" id="infopanel-for-permissionspolicyviolationreportbody-columnnumber" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody-columnnumber" style="display:none">Info about the 'columnNumber' definition.</span><b><a href="#permissionspolicyviolationreportbody-columnnumber">#permissionspolicyviolationreportbody-columnnumber</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-columnnumber">9.10. Generate report for violation of permissions policy on settings</a> <a href="#ref-for-permissionspolicyviolationreportbody-columnnumber①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permissionspolicyviolationreportbody-disposition">
-   <b><a href="#permissionspolicyviolationreportbody-disposition">#permissionspolicyviolationreportbody-disposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permissionspolicyviolationreportbody-disposition" class="dfn-panel" data-for="permissionspolicyviolationreportbody-disposition" id="infopanel-for-permissionspolicyviolationreportbody-disposition" role="dialog">
+   <span id="infopaneltitle-for-permissionspolicyviolationreportbody-disposition" style="display:none">Info about the 'disposition' definition.</span><b><a href="#permissionspolicyviolationreportbody-disposition">#permissionspolicyviolationreportbody-disposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-disposition">8. Reporting</a> <a href="#ref-for-permissionspolicyviolationreportbody-disposition①">(2)</a>
     <li><a href="#ref-for-permissionspolicyviolationreportbody-disposition②">9.10. Generate report for violation of permissions policy on settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-response-policy">
-   <b><a href="#process-response-policy">#process-response-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-response-policy" class="dfn-panel" data-for="process-response-policy" id="infopanel-for-process-response-policy" role="dialog">
+   <span id="infopaneltitle-for-process-response-policy" style="display:none">Info about the 'Process response policy' definition.</span><b><a href="#process-response-policy">#process-response-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response-policy">9.6. Create a Permissions Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-policy-from-dictionary-and-origin">
-   <b><a href="#construct-policy-from-dictionary-and-origin">#construct-policy-from-dictionary-and-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-policy-from-dictionary-and-origin" class="dfn-panel" data-for="construct-policy-from-dictionary-and-origin" id="infopanel-for-construct-policy-from-dictionary-and-origin" role="dialog">
+   <span id="infopaneltitle-for-construct-policy-from-dictionary-and-origin" style="display:none">Info about the 'Construct policy from dictionary and origin' definition.</span><b><a href="#construct-policy-from-dictionary-and-origin">#construct-policy-from-dictionary-and-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-policy-from-dictionary-and-origin">9.1. Process response policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-policy-directive">
-   <b><a href="#parse-policy-directive">#parse-policy-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-policy-directive" class="dfn-panel" data-for="parse-policy-directive" id="infopanel-for-parse-policy-directive" role="dialog">
+   <span id="infopaneltitle-for-parse-policy-directive" style="display:none">Info about the 'Parse policy directive' definition.</span><b><a href="#parse-policy-directive">#parse-policy-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-policy-directive">9.4. Process permissions policy attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-permissions-policy-attributes">
-   <b><a href="#process-permissions-policy-attributes">#process-permissions-policy-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-permissions-policy-attributes" class="dfn-panel" data-for="process-permissions-policy-attributes" id="infopanel-for-process-permissions-policy-attributes" role="dialog">
+   <span id="infopaneltitle-for-process-permissions-policy-attributes" style="display:none">Info about the 'Process permissions policy attributes' definition.</span><b><a href="#process-permissions-policy-attributes">#process-permissions-policy-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-permissions-policy-attributes">9.8. Define an inherited policy for feature in container at origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-for-browsingcontext">
-   <b><a href="#create-for-browsingcontext">#create-for-browsingcontext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-for-browsingcontext" class="dfn-panel" data-for="create-for-browsingcontext" id="infopanel-for-create-for-browsingcontext" role="dialog">
+   <span id="infopaneltitle-for-create-for-browsingcontext" style="display:none">Info about the 'Create a Permissions Policy for a browsing context' definition.</span><b><a href="#create-for-browsingcontext">#create-for-browsingcontext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-for-browsingcontext">9.6. Create a Permissions Policy for a browsing context from response</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-inherited-policy">
-   <b><a href="#define-inherited-policy">#define-inherited-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-inherited-policy" class="dfn-panel" data-for="define-inherited-policy" id="infopanel-for-define-inherited-policy" role="dialog">
+   <span id="infopaneltitle-for-define-inherited-policy" style="display:none">Info about the 'Define an inherited policy for feature in browsing context' definition.</span><b><a href="#define-inherited-policy">#define-inherited-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-inherited-policy">9.5. Create a Permissions Policy for a browsing context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define-inherited-policy-in-container">
-   <b><a href="#define-inherited-policy-in-container">#define-inherited-policy-in-container</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define-inherited-policy-in-container" class="dfn-panel" data-for="define-inherited-policy-in-container" id="infopanel-for-define-inherited-policy-in-container" role="dialog">
+   <span id="infopaneltitle-for-define-inherited-policy-in-container" style="display:none">Info about the 'Define an inherited policy for feature in container at origin' definition.</span><b><a href="#define-inherited-policy-in-container">#define-inherited-policy-in-container</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define-inherited-policy-in-container">7.2. The permissionsPolicy object</a>
     <li><a href="#ref-for-define-inherited-policy-in-container①">9.7. Define an inherited policy for feature in browsing context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-feature-enabled">
-   <b><a href="#is-feature-enabled">#is-feature-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-feature-enabled" class="dfn-panel" data-for="is-feature-enabled" id="infopanel-for-is-feature-enabled" role="dialog">
+   <span id="infopaneltitle-for-is-feature-enabled" style="display:none">Info about the 'Is feature enabled in document for origin?' definition.</span><b><a href="#is-feature-enabled">#is-feature-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-feature-enabled">9.11. Should request be allowed to use feature?</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webappsec-post-spectre-webdev/index.html
+++ b/tests/github/w3c/webappsec-post-spectre-webdev/index.html
@@ -1034,104 +1034,104 @@ we currently espouse. The following is an incomplete list of those works:</p>
   </main>
 <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-header-content-security-policy">
-   <a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy">https://w3c.github.io/webappsec-csp/#header-content-security-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-content-security-policy" class="dfn-panel" data-for="term-for-header-content-security-policy" id="infopanel-for-term-for-header-content-security-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-header-content-security-policy" style="display:none">Info about the 'content-security-policy' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy">https://w3c.github.io/webappsec-csp/#header-content-security-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-content-security-policy">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frame-ancestors">
-   <a href="https://w3c.github.io/webappsec-csp/#frame-ancestors">https://w3c.github.io/webappsec-csp/#frame-ancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frame-ancestors" class="dfn-panel" data-for="term-for-frame-ancestors" id="infopanel-for-term-for-frame-ancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-frame-ancestors" style="display:none">Info about the 'frame-ancestors' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#frame-ancestors">https://w3c.github.io/webappsec-csp/#frame-ancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frame-ancestors">1.2. TL;DR</a>
     <li><a href="#ref-for-frame-ancestors①">2.2.3. Documents Expecting Cross-Origin Openers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sandbox">
-   <a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sandbox" class="dfn-panel" data-for="term-for-sandbox" id="infopanel-for-term-for-sandbox" role="menu">
+   <span id="infopaneltitle-for-term-for-sandbox" style="display:none">Info about the 'sandbox' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#sandbox">https://w3c.github.io/webappsec-csp/#sandbox</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sandbox">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-sharedarraybuffer-objects">
-   <a href="https://tc39.es/ecma262/#sec-sharedarraybuffer-objects">https://tc39.es/ecma262/#sec-sharedarraybuffer-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-sharedarraybuffer-objects" class="dfn-panel" data-for="term-for-sec-sharedarraybuffer-objects" id="infopanel-for-term-for-sec-sharedarraybuffer-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-sharedarraybuffer-objects" style="display:none">Info about the 'SharedArrayBuffer' external reference.</span><a href="https://tc39.es/ecma262/#sec-sharedarraybuffer-objects">https://tc39.es/ecma262/#sec-sharedarraybuffer-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-sharedarraybuffer-objects">2.2.1. Fully-Isolated Documents</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-corb">
-   <a href="https://fetch.spec.whatwg.org/#corb">https://fetch.spec.whatwg.org/#corb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-corb" class="dfn-panel" data-for="term-for-corb" id="infopanel-for-term-for-corb" role="menu">
+   <span id="infopaneltitle-for-term-for-corb" style="display:none">Info about the 'cross-origin read blocking' external reference.</span><a href="https://fetch.spec.whatwg.org/#corb">https://fetch.spec.whatwg.org/#corb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corb">1.2. TL;DR</a>
     <li><a href="#ref-for-corb①">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-cross-origin-resource-policy">
-   <a href="https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy">https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-cross-origin-resource-policy" class="dfn-panel" data-for="term-for-http-cross-origin-resource-policy" id="infopanel-for-term-for-http-cross-origin-resource-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-http-cross-origin-resource-policy" style="display:none">Info about the 'cross-origin resource policy' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy">https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-cross-origin-resource-policy">1.2. TL;DR</a>
     <li><a href="#ref-for-http-cross-origin-resource-policy①">2.1.2. Dynamic Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-cross-origin-resource-policy">
-   <a href="https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy">https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-cross-origin-resource-policy" class="dfn-panel" data-for="term-for-http-cross-origin-resource-policy" id="infopanel-for-term-for-http-cross-origin-resource-policy①" role="menu">
+   <span id="infopaneltitle-for-term-for-http-cross-origin-resource-policy①" style="display:none">Info about the 'cross-origin-resource-policy' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy">https://fetch.spec.whatwg.org/#http-cross-origin-resource-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-cross-origin-resource-policy">1.2. TL;DR</a>
     <li><a href="#ref-for-http-cross-origin-resource-policy①">2.1.2. Dynamic Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-header">
-   <a href="https://fetch.spec.whatwg.org/#origin-header">https://fetch.spec.whatwg.org/#origin-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-header" class="dfn-panel" data-for="term-for-origin-header" id="infopanel-for-term-for-origin-header" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-header" style="display:none">Info about the 'origin' external reference.</span><a href="https://fetch.spec.whatwg.org/#origin-header">https://fetch.spec.whatwg.org/#origin-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-header">1.2. TL;DR</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-x-content-type-options">
-   <a href="https://fetch.spec.whatwg.org/#http-x-content-type-options">https://fetch.spec.whatwg.org/#http-x-content-type-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-x-content-type-options" class="dfn-panel" data-for="term-for-http-x-content-type-options" id="infopanel-for-term-for-http-x-content-type-options" role="menu">
+   <span id="infopaneltitle-for-term-for-http-x-content-type-options" style="display:none">Info about the 'x-content-type-options' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-x-content-type-options">https://fetch.spec.whatwg.org/#http-x-content-type-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-x-content-type-options">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cross-origin-opener-policies">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies">https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cross-origin-opener-policies" class="dfn-panel" data-for="term-for-cross-origin-opener-policies" id="infopanel-for-term-for-cross-origin-opener-policies" role="menu">
+   <span id="infopaneltitle-for-term-for-cross-origin-opener-policies" style="display:none">Info about the 'cross-origin opener policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies">https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-opener-policies">1.2. TL;DR</a>
     <li><a href="#ref-for-cross-origin-opener-policies①">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cross-origin-opener-policies">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies">https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cross-origin-opener-policies" class="dfn-panel" data-for="term-for-cross-origin-opener-policies" id="infopanel-for-term-for-cross-origin-opener-policies①" role="menu">
+   <span id="infopaneltitle-for-term-for-cross-origin-opener-policies①" style="display:none">Info about the 'cross-origin-opener-policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies">https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-opener-policies">1.2. TL;DR</a>
     <li><a href="#ref-for-cross-origin-opener-policies①">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-postmessage-options">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-postmessage-options" class="dfn-panel" data-for="term-for-dom-window-postmessage-options" id="infopanel-for-term-for-dom-window-postmessage-options" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-postmessage-options" style="display:none">Info about the 'postMessage(message, options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options">https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage-options</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-postmessage-options">2.2.3. Documents Expecting Cross-Origin Openers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-x-frame-options-header">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header">https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-x-frame-options-header" class="dfn-panel" data-for="term-for-the-x-frame-options-header" id="infopanel-for-term-for-the-x-frame-options-header" role="menu">
+   <span id="infopaneltitle-for-term-for-the-x-frame-options-header" style="display:none">Info about the 'x-frame-options' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header">https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-x-frame-options-header">2.1. Subresources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">2.1. Subresources</a>
    </ul>
@@ -1243,57 +1243,113 @@ we currently espouse. The following is an incomplete list of those works:</p>
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-suborigins/index.html
+++ b/tests/github/w3c/webappsec-suborigins/index.html
@@ -1508,130 +1508,130 @@ otherwise.</p>
    <li><a href="#xmlhttprequest">XMLHttpRequest</a><span>, in § 2</span>
    <li><a href="#xss">XSS</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-cross-origin-request-with-preflight-0">
-   <a href="https://www.w3.org/TR/cors#cross-origin-request-with-preflight-0">https://www.w3.org/TR/cors#cross-origin-request-with-preflight-0</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cross-origin-request-with-preflight-0" class="dfn-panel" data-for="term-for-cross-origin-request-with-preflight-0" id="infopanel-for-term-for-cross-origin-request-with-preflight-0" role="menu">
+   <span id="infopaneltitle-for-term-for-cross-origin-request-with-preflight-0" style="display:none">Info about the 'cross-origin request with preflight' external reference.</span><a href="https://www.w3.org/TR/cors#cross-origin-request-with-preflight-0">https://www.w3.org/TR/cors#cross-origin-request-with-preflight-0</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-request-with-preflight-0">4.1. CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-simple-cross-origin-request">
-   <a href="https://www.w3.org/TR/cors#simple-cross-origin-request">https://www.w3.org/TR/cors#simple-cross-origin-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-simple-cross-origin-request" class="dfn-panel" data-for="term-for-simple-cross-origin-request" id="infopanel-for-term-for-simple-cross-origin-request" role="menu">
+   <span id="infopaneltitle-for-term-for-simple-cross-origin-request" style="display:none">Info about the 'simple cross-origin request' external reference.</span><a href="https://www.w3.org/TR/cors#simple-cross-origin-request">https://www.w3.org/TR/cors#simple-cross-origin-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-cross-origin-request">4.1. CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">5.1. Storage</a>
     <li><a href="#ref-for-document①">6.2.1. Cookies</a> <a href="#ref-for-document②">(2)</a> <a href="#ref-for-document③">(3)</a> <a href="#ref-for-document④">(4)</a> <a href="#ref-for-document⑤">(5)</a> <a href="#ref-for-document⑥">(6)</a>
     <li><a href="#ref-for-document⑦">6.3.3. 'unsafe-cookies'</a> <a href="#ref-for-document⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.7. Accessing the Suborigin in JavaScript</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-reflect">
-   <a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-reflect" class="dfn-panel" data-for="term-for-concept-reflect" id="infopanel-for-term-for-concept-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-reflect">https://dom.spec.whatwg.org/#concept-reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">3.7. Accessing the Suborigin in JavaScript</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credentials">
-   <a href="https://fetch.spec.whatwg.org#credentials">https://fetch.spec.whatwg.org#credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credentials" class="dfn-panel" data-for="term-for-credentials" id="infopanel-for-term-for-credentials" role="menu">
+   <span id="infopaneltitle-for-term-for-credentials" style="display:none">Info about the 'credentials' external reference.</span><a href="https://fetch.spec.whatwg.org#credentials">https://fetch.spec.whatwg.org#credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentials">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">https://fetch.spec.whatwg.org#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org#concept-request-credentials-mode">https://fetch.spec.whatwg.org#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-current-url">
-   <a href="https://fetch.spec.whatwg.org#concept-request-current-url">https://fetch.spec.whatwg.org#concept-request-current-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-current-url" class="dfn-panel" data-for="term-for-concept-request-current-url" id="infopanel-for-term-for-concept-request-current-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-current-url" style="display:none">Info about the 'current url' external reference.</span><a href="https://fetch.spec.whatwg.org#concept-request-current-url">https://fetch.spec.whatwg.org#concept-request-current-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org#concept-fetch">https://fetch.spec.whatwg.org#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org#concept-fetch">https://fetch.spec.whatwg.org#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">4.1. CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-network-or-cache-fetch">
-   <a href="https://fetch.spec.whatwg.org#http-network-or-cache-fetch">https://fetch.spec.whatwg.org#http-network-or-cache-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-network-or-cache-fetch" class="dfn-panel" data-for="term-for-http-network-or-cache-fetch" id="infopanel-for-term-for-http-network-or-cache-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-http-network-or-cache-fetch" style="display:none">Info about the 'http-network-or-cache fetch' external reference.</span><a href="https://fetch.spec.whatwg.org#http-network-or-cache-fetch">https://fetch.spec.whatwg.org#http-network-or-cache-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-network-or-cache-fetch">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-origin-header">
-   <a href="https://fetch.spec.whatwg.org#origin-header">https://fetch.spec.whatwg.org#origin-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-origin-header" class="dfn-panel" data-for="term-for-origin-header" id="infopanel-for-term-for-origin-header" role="menu">
+   <span id="infopaneltitle-for-term-for-origin-header" style="display:none">Info about the 'origin header' external reference.</span><a href="https://fetch.spec.whatwg.org#origin-header">https://fetch.spec.whatwg.org#origin-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-origin-header">4.1. CORS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-origin">
-   <a href="https://fetch.spec.whatwg.org#concept-request-origin">https://fetch.spec.whatwg.org#concept-request-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-origin" class="dfn-panel" data-for="term-for-concept-request-origin" id="infopanel-for-term-for-concept-request-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-origin" style="display:none">Info about the 'request origin' external reference.</span><a href="https://fetch.spec.whatwg.org#concept-request-origin">https://fetch.spec.whatwg.org#concept-request-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageeventsource">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#messageeventsource">https://html.spec.whatwg.org/multipage/comms.html#messageeventsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageeventsource" class="dfn-panel" data-for="term-for-messageeventsource" id="infopanel-for-term-for-messageeventsource" role="menu">
+   <span id="infopaneltitle-for-term-for-messageeventsource" style="display:none">Info about the 'MessageEventSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#messageeventsource">https://html.spec.whatwg.org/multipage/comms.html#messageeventsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageeventsource">4.2. postMessage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">4.2. postMessage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storage-2">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#storage-2">https://html.spec.whatwg.org/multipage/webstorage.html#storage-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storage-2" class="dfn-panel" data-for="term-for-storage-2" id="infopanel-for-term-for-storage-2" role="menu">
+   <span id="infopaneltitle-for-term-for-storage-2" style="display:none">Info about the 'Storage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#storage-2">https://html.spec.whatwg.org/multipage/webstorage.html#storage-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-2">5.1. Storage</a> <a href="#ref-for-storage-2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.2. postMessage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">6.1.6.2. ASCII Serialization of a Suborigin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-meta-http-equiv-set-cookie">
-   <a href="https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-set-cookie">https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-set-cookie</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-meta-http-equiv-set-cookie" class="dfn-panel" data-for="term-for-attr-meta-http-equiv-set-cookie" id="infopanel-for-term-for-attr-meta-http-equiv-set-cookie" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-meta-http-equiv-set-cookie" style="display:none">Info about the 'cookie setter' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-set-cookie">https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-set-cookie</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-meta-http-equiv-set-cookie">6.2.1. Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#environment-settings-object">https://html.spec.whatwg.org/multipage/comms.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#environment-settings-object">https://html.spec.whatwg.org/multipage/comms.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-localstorage">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-localstorage" class="dfn-panel" data-for="term-for-dom-localstorage" id="infopanel-for-term-for-dom-localstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-localstorage" style="display:none">Info about the 'localStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-localstorage">5.1. Storage</a> <a href="#ref-for-dom-localstorage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/#concept-origin">https://html.spec.whatwg.org/multipage/#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#concept-origin">https://html.spec.whatwg.org/multipage/#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3.2. Threat Model</a>
     <li><a href="#ref-for-concept-origin①">5.1. Storage</a> <a href="#ref-for-concept-origin②">(2)</a>
@@ -1640,160 +1640,160 @@ otherwise.</p>
     <li><a href="#ref-for-concept-origin⑤">6.1.3. Physical Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/#concept-origin-tuple">https://html.spec.whatwg.org/multipage/#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'origin tuple' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#concept-origin-tuple">https://html.spec.whatwg.org/multipage/#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">6.1.2. Origin Tuple</a>
     <li><a href="#ref-for-concept-origin-tuple①">6.1.3. Physical Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-messageport-postmessage">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage">https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-messageport-postmessage" class="dfn-panel" data-for="term-for-dom-messageport-postmessage" id="infopanel-for-term-for-dom-messageport-postmessage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-messageport-postmessage" style="display:none">Info about the 'postmessage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage">https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-messageport-postmessage">1. Introduction</a>
     <li><a href="#ref-for-dom-messageport-postmessage①">4. Access Control</a>
     <li><a href="#ref-for-dom-messageport-postmessage②">4.2. postMessage</a> <a href="#ref-for-dom-messageport-postmessage③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin②">6.1.4. Comparing Origins</a>
     <li><a href="#ref-for-same-origin③">6.1.5. Comparing Physical Origins</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/#same-origin">https://html.spec.whatwg.org/multipage/#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin①" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin①" style="display:none">Info about the 'same-origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#same-origin">https://html.spec.whatwg.org/multipage/#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3. Defining a Suborigin</a> <a href="#ref-for-same-origin①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-sessionstorage">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-sessionstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-sessionstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-sessionstorage" class="dfn-panel" data-for="term-for-dom-sessionstorage" id="infopanel-for-term-for-dom-sessionstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-sessionstorage" style="display:none">Info about the 'sessionStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-sessionstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-sessionstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sessionstorage">5.1. Storage</a> <a href="#ref-for-dom-sessionstorage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/#concept-origin-tuple">https://html.spec.whatwg.org/multipage/#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple①" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple①" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#concept-origin-tuple">https://html.spec.whatwg.org/multipage/#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">6.1.2. Origin Tuple</a>
     <li><a href="#ref-for-concept-origin-tuple①">6.1.3. Physical Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unicode-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unicode-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-unicode-serialisation-of-an-origin" id="infopanel-for-term-for-unicode-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-unicode-serialisation-of-an-origin" style="display:none">Info about the 'unicode serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unicode-serialisation-of-an-origin">6.1.6.1. Unicode Serialization of a Suborigin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cookie-averse">
-   <a href="http://www.w3.org/TR/html51/dom.html#cookie-averse">http://www.w3.org/TR/html51/dom.html#cookie-averse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cookie-averse" class="dfn-panel" data-for="term-for-cookie-averse" id="infopanel-for-term-for-cookie-averse" role="menu">
+   <span id="infopaneltitle-for-term-for-cookie-averse" style="display:none">Info about the 'cookie-averse' external reference.</span><a href="http://www.w3.org/TR/html51/dom.html#cookie-averse">http://www.w3.org/TR/html51/dom.html#cookie-averse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cookie-averse">6.2.1. Cookies</a> <a href="#ref-for-cookie-averse①">(2)</a> <a href="#ref-for-cookie-averse②">(3)</a> <a href="#ref-for-cookie-averse③">(4)</a>
     <li><a href="#ref-for-cookie-averse④">6.3.3. 'unsafe-cookies'</a> <a href="#ref-for-cookie-averse⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resource-metadata-management">
-   <a href="http://www.w3.org/TR/html51/dom.html#resource-metadata-management">http://www.w3.org/TR/html51/dom.html#resource-metadata-management</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resource-metadata-management" class="dfn-panel" data-for="term-for-resource-metadata-management" id="infopanel-for-term-for-resource-metadata-management" role="menu">
+   <span id="infopaneltitle-for-term-for-resource-metadata-management" style="display:none">Info about the 'resource metadata management' external reference.</span><a href="http://www.w3.org/TR/html51/dom.html#resource-metadata-management">http://www.w3.org/TR/html51/dom.html#resource-metadata-management</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resource-metadata-management">6.2.1. Cookies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.3" class="dfn-panel" data-for="term-for-section-3.2.3" id="infopanel-for-term-for-section-3.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.3" style="display:none">Info about the 'ows' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.3">3.5. The suborigin header</a> <a href="#ref-for-section-3.2.3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.3">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.3" class="dfn-panel" data-for="term-for-section-3.2.3" id="infopanel-for-term-for-section-3.2.3①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.3①" style="display:none">Info about the 'rws' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.3">https://tools.ietf.org/html/rfc7230#section-3.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.3">3.5. The suborigin header</a> <a href="#ref-for-section-3.2.3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1" style="display:none">Info about the 'alpha' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">2.1. Grammatical Concepts</a>
     <li><a href="#ref-for-appendix-B.1①">3.5. The suborigin header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1①" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1①" style="display:none">Info about the 'digit' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">2.1. Grammatical Concepts</a>
     <li><a href="#ref-for-appendix-B.1①">3.5. The suborigin header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-domain">
-   <a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-domain" class="dfn-panel" data-for="term-for-concept-domain" id="infopanel-for-term-for-concept-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain">6.1.2. Origin Tuple</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-host">
-   <a href="https://url.spec.whatwg.org/#concept-host">https://url.spec.whatwg.org/#concept-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-host" class="dfn-panel" data-for="term-for-concept-host" id="infopanel-for-term-for-concept-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-host">https://url.spec.whatwg.org/#concept-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-host">3. Defining a Suborigin</a> <a href="#ref-for-concept-host①">(2)</a>
     <li><a href="#ref-for-concept-host②">3.6. Representation of Suborigins</a>
     <li><a href="#ref-for-concept-host③">6.1.2. Origin Tuple</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-port">
-   <a href="https://url.spec.whatwg.org/#concept-port">https://url.spec.whatwg.org/#concept-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-port" class="dfn-panel" data-for="term-for-concept-port" id="infopanel-for-term-for-concept-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-port" style="display:none">Info about the 'port' external reference.</span><a href="https://url.spec.whatwg.org/#concept-port">https://url.spec.whatwg.org/#concept-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-port">3. Defining a Suborigin</a> <a href="#ref-for-concept-port①">(2)</a>
     <li><a href="#ref-for-concept-port②">3.6. Representation of Suborigins</a>
     <li><a href="#ref-for-concept-port③">6.1.2. Origin Tuple</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-scheme">https://url.spec.whatwg.org/#concept-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-scheme" class="dfn-panel" data-for="term-for-concept-scheme" id="infopanel-for-term-for-concept-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-scheme">https://url.spec.whatwg.org/#concept-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-scheme">3. Defining a Suborigin</a> <a href="#ref-for-concept-scheme①">(2)</a>
     <li><a href="#ref-for-concept-scheme②">3.6. Representation of Suborigins</a>
     <li><a href="#ref-for-concept-scheme③">6.1.2. Origin Tuple</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">4.2. postMessage</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">4.2. postMessage</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">4.2. postMessage</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.2. postMessage</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">4.2. postMessage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.2. postMessage</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-withcredentials-attribute">
-   <a href="https://xhr.spec.whatwg.org/#the-withcredentials-attribute">https://xhr.spec.whatwg.org/#the-withcredentials-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-withcredentials-attribute" class="dfn-panel" data-for="term-for-the-withcredentials-attribute" id="infopanel-for-term-for-the-withcredentials-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-the-withcredentials-attribute" style="display:none">Info about the 'withcredentials' external reference.</span><a href="https://xhr.spec.whatwg.org/#the-withcredentials-attribute">https://xhr.spec.whatwg.org/#the-withcredentials-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-withcredentials-attribute">6.3.4. 'unsafe-credentials'</a>
    </ul>
@@ -2006,60 +2006,60 @@ otherwise.</p>
   recognize the suborigin serialization, esp. if they blocklist origins. <a class="issue-return" href="#issue-d8492fe3" title="Jump to section">↵</a></div>
    <div class="issue"> TODO: Do we have privacy issues? <a class="issue-return" href="#issue-747044d5" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="cors">
-   <b><a href="#cors">#cors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors" class="dfn-panel" data-for="cors" id="infopanel-for-cors" role="dialog">
+   <span id="infopaneltitle-for-cors" style="display:none">Info about the 'CORS' definition.</span><b><a href="#cors">#cors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors">1. Introduction</a>
     <li><a href="#ref-for-cors①">4. Access Control</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xmlhttprequest">
-   <b><a href="#xmlhttprequest">#xmlhttprequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmlhttprequest" class="dfn-panel" data-for="xmlhttprequest" id="infopanel-for-xmlhttprequest" role="dialog">
+   <span id="infopaneltitle-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' definition.</span><b><a href="#xmlhttprequest">#xmlhttprequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">4.1. CORS</a>
     <li><a href="#ref-for-xmlhttprequest①">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xss">
-   <b><a href="#xss">#xss</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xss" class="dfn-panel" data-for="xss" id="infopanel-for-xss" role="dialog">
+   <span id="infopaneltitle-for-xss" style="display:none">Info about the 'XSS' definition.</span><b><a href="#xss">#xss</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xss">3.2.1. Cross-Document Attacker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-loweralpha">
-   <b><a href="#grammardef-loweralpha">#grammardef-loweralpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-loweralpha" class="dfn-panel" data-for="grammardef-loweralpha" id="infopanel-for-grammardef-loweralpha" role="dialog">
+   <span id="infopaneltitle-for-grammardef-loweralpha" style="display:none">Info about the 'LOWERALPHA' definition.</span><b><a href="#grammardef-loweralpha">#grammardef-loweralpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-loweralpha">3.5. The suborigin header</a> <a href="#ref-for-grammardef-loweralpha①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suborigin">
-   <b><a href="#suborigin">#suborigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suborigin" class="dfn-panel" data-for="suborigin" id="infopanel-for-suborigin" role="dialog">
+   <span id="infopaneltitle-for-suborigin" style="display:none">Info about the 'suborigin' definition.</span><b><a href="#suborigin">#suborigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suborigin">5.3. WebSockets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-suborigin-name">
-   <b><a href="#grammardef-suborigin-name">#grammardef-suborigin-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-suborigin-name" class="dfn-panel" data-for="grammardef-suborigin-name" id="infopanel-for-grammardef-suborigin-name" role="dialog">
+   <span id="infopaneltitle-for-grammardef-suborigin-name" style="display:none">Info about the 'suborigin-name' definition.</span><b><a href="#grammardef-suborigin-name">#grammardef-suborigin-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-suborigin-name">3.5. The suborigin header</a> <a href="#ref-for-grammardef-suborigin-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-suborigin-policy-option">
-   <b><a href="#grammardef-suborigin-policy-option">#grammardef-suborigin-policy-option</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-suborigin-policy-option" class="dfn-panel" data-for="grammardef-suborigin-policy-option" id="infopanel-for-grammardef-suborigin-policy-option" role="dialog">
+   <span id="infopaneltitle-for-grammardef-suborigin-policy-option" style="display:none">Info about the 'suborigin-policy-option' definition.</span><b><a href="#grammardef-suborigin-policy-option">#grammardef-suborigin-policy-option</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-suborigin-policy-option">3.5. The suborigin header</a> <a href="#ref-for-grammardef-suborigin-policy-option①">(2)</a>
     <li><a href="#ref-for-grammardef-suborigin-policy-option②">6.2.1. Cookies</a>
     <li><a href="#ref-for-grammardef-suborigin-policy-option③">6.3. Security Model Opt-Outs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-suborigin-policy-list">
-   <b><a href="#grammardef-suborigin-policy-list">#grammardef-suborigin-policy-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-suborigin-policy-list" class="dfn-panel" data-for="grammardef-suborigin-policy-list" id="infopanel-for-grammardef-suborigin-policy-list" role="dialog">
+   <span id="infopaneltitle-for-grammardef-suborigin-policy-list" style="display:none">Info about the 'suborigin-policy-list' definition.</span><b><a href="#grammardef-suborigin-policy-list">#grammardef-suborigin-policy-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-suborigin-policy-list">3.5. The suborigin header</a> <a href="#ref-for-grammardef-suborigin-policy-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suborigin-namespace">
-   <b><a href="#suborigin-namespace">#suborigin-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suborigin-namespace" class="dfn-panel" data-for="suborigin-namespace" id="infopanel-for-suborigin-namespace" role="dialog">
+   <span id="infopaneltitle-for-suborigin-namespace" style="display:none">Info about the 'suborigin namespace' definition.</span><b><a href="#suborigin-namespace">#suborigin-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suborigin-namespace">3. Defining a Suborigin</a> <a href="#ref-for-suborigin-namespace①">(2)</a>
     <li><a href="#ref-for-suborigin-namespace②">3.6. Representation of Suborigins</a> <a href="#ref-for-suborigin-namespace③">(2)</a>
@@ -2068,22 +2068,22 @@ otherwise.</p>
     <li><a href="#ref-for-suborigin-namespace⑦">6.2.1. Cookies</a> <a href="#ref-for-suborigin-namespace⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="suborigin-policy">
-   <b><a href="#suborigin-policy">#suborigin-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-suborigin-policy" class="dfn-panel" data-for="suborigin-policy" id="infopanel-for-suborigin-policy" role="dialog">
+   <span id="infopaneltitle-for-suborigin-policy" style="display:none">Info about the 'suborigin policy' definition.</span><b><a href="#suborigin-policy">#suborigin-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-suborigin-policy">6.2.1. Cookies</a>
     <li><a href="#ref-for-suborigin-policy①">6.3. Security Model Opt-Outs</a> <a href="#ref-for-suborigin-policy②">(2)</a>
     <li><a href="#ref-for-suborigin-policy③">6.3.3. 'unsafe-cookies'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-extendedorigin">
-   <b><a href="#dictdef-extendedorigin">#dictdef-extendedorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-extendedorigin" class="dfn-panel" data-for="dictdef-extendedorigin" id="infopanel-for-dictdef-extendedorigin" role="dialog">
+   <span id="infopaneltitle-for-dictdef-extendedorigin" style="display:none">Info about the 'ExtendedOrigin' definition.</span><b><a href="#dictdef-extendedorigin">#dictdef-extendedorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendedorigin">4.2. postMessage</a> <a href="#ref-for-dictdef-extendedorigin①">(2)</a> <a href="#ref-for-dictdef-extendedorigin②">(3)</a> <a href="#ref-for-dictdef-extendedorigin③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="physical-origin">
-   <b><a href="#physical-origin">#physical-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-physical-origin" class="dfn-panel" data-for="physical-origin" id="infopanel-for-physical-origin" role="dialog">
+   <span id="infopaneltitle-for-physical-origin" style="display:none">Info about the 'physical origin' definition.</span><b><a href="#physical-origin">#physical-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-physical-origin">3.6. Representation of Suborigins</a>
     <li><a href="#ref-for-physical-origin①">6.1.5. Comparing Physical Origins</a> <a href="#ref-for-physical-origin②">(2)</a>
@@ -2092,65 +2092,121 @@ otherwise.</p>
     <li><a href="#ref-for-physical-origin⑤">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-physical-origin">
-   <b><a href="#same-physical-origin">#same-physical-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-physical-origin" class="dfn-panel" data-for="same-physical-origin" id="infopanel-for-same-physical-origin" role="dialog">
+   <span id="infopaneltitle-for-same-physical-origin" style="display:none">Info about the 'same physical origin' definition.</span><b><a href="#same-physical-origin">#same-physical-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-physical-origin">6.3.4. 'unsafe-credentials'</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-subresource-integrity/index.html
+++ b/tests/github/w3c/webappsec-subresource-integrity/index.html
@@ -1025,76 +1025,76 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <li><a href="#grammardef-integrity-metadata">integrity-metadata</a><span>, in § 3.5</span>
    <li><a href="#grammardef-option-expression">option-expression</a><span>, in § 3.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1" style="display:none">Info about the 'vchar' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-appendix-B.1">2.1. Grammatical Concepts</a> <a href="#ref-for-appendix-B.1">(2)</a> <a href="#ref-for-appendix-B.1①">(3)</a>
     <li><a href="#ref-for-appendix-B.1②">3.5. The integrity attribute</a> <a href="#ref-for-appendix-B.1③">(2)</a> <a href="#ref-for-appendix-B.1④">(3)</a> <a href="#ref-for-appendix-B.1⑤">(4)</a> <a href="#ref-for-appendix-B.1⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1①" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1①" style="display:none">Info about the 'wsp' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-appendix-B.1">2.1. Grammatical Concepts</a> <a href="#ref-for-appendix-B.1">(2)</a> <a href="#ref-for-appendix-B.1①">(3)</a>
     <li><a href="#ref-for-appendix-B.1②">3.5. The integrity attribute</a> <a href="#ref-for-appendix-B.1③">(2)</a> <a href="#ref-for-appendix-B.1④">(3)</a> <a href="#ref-for-appendix-B.1⑤">(4)</a> <a href="#ref-for-appendix-B.1⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org#concept-request">https://fetch.spec.whatwg.org#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org#concept-request">https://fetch.spec.whatwg.org#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.1. Integrity metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-settings-attributes">
-   <a href="http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes">http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-settings-attributes" class="dfn-panel" data-for="term-for-cors-settings-attributes" id="infopanel-for-term-for-cors-settings-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-settings-attributes" style="display:none">Info about the 'cors settings attribute' external reference.</span><a href="http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes">http://www.w3.org/TR/html5/infrastructure.html#cors-settings-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-settings-attributes">5.3. Cross-origin data leakage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3.3.2. Parse metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">3.3.2. Parse metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2">
-   <a href="https://tools.ietf.org/html/rfc7234#section-5.2">https://tools.ietf.org/html/rfc7234#section-5.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2" class="dfn-panel" data-for="term-for-section-5.2" id="infopanel-for-term-for-section-5.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2" style="display:none">Info about the 'cache-control' external reference.</span><a href="https://tools.ietf.org/html/rfc7234#section-5.2">https://tools.ietf.org/html/rfc7234#section-5.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2">4. Proxies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2.1.6">
-   <a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.6">https://tools.ietf.org/html/rfc7234#section-5.2.1.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2.1.6" class="dfn-panel" data-for="term-for-section-5.2.1.6" id="infopanel-for-term-for-section-5.2.1.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2.1.6" style="display:none">Info about the 'no-transform' external reference.</span><a href="https://tools.ietf.org/html/rfc7234#section-5.2.1.6">https://tools.ietf.org/html/rfc7234#section-5.2.1.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2.1.6">4. Proxies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="http://www.w3.org/TR/powerful-features/#secure-context">http://www.w3.org/TR/powerful-features/#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="http://www.w3.org/TR/powerful-features/#secure-context">http://www.w3.org/TR/powerful-features/#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">5.1. Non-secure contexts remain non-secure</a> <a href="#ref-for-secure-context①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-" role="menu">
+   <span id="infopaneltitle-for-term-for-" style="display:none">Info about the 'sha-2' external reference.</span><a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2. Key Concepts and Terminology</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">3.1. Integrity metadata</a>
@@ -1102,8 +1102,8 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#termref-for-">3.3.4. Do bytes match metadataList?</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-①" role="menu">
+   <span id="infopaneltitle-for-term-for-①" style="display:none">Info about the 'sha-256' external reference.</span><a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2. Key Concepts and Terminology</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">3.1. Integrity metadata</a>
@@ -1111,8 +1111,8 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#termref-for-">3.3.4. Do bytes match metadataList?</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-②" role="menu">
+   <span id="infopaneltitle-for-term-for-②" style="display:none">Info about the 'sha-384' external reference.</span><a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2. Key Concepts and Terminology</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">3.1. Integrity metadata</a>
@@ -1120,8 +1120,8 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#termref-for-">3.3.4. Do bytes match metadataList?</a> <a href="#termref-for-">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-">
-   <a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-" class="dfn-panel" data-for="term-for-" id="infopanel-for-term-for-③" role="menu">
+   <span id="infopaneltitle-for-term-for-③" style="display:none">Info about the 'sha-512' external reference.</span><a href="http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#">http://csrc.nist.gov/publications/fips/fips180-4/fips-180-4.pdf#</a><b>Referenced in:</b>
    <ul>
     <li><a href="#termref-for-">2. Key Concepts and Terminology</a> <a href="#termref-for-">(2)</a> <a href="#termref-for-">(3)</a> <a href="#termref-for-">(4)</a>
     <li><a href="#termref-for-">3.1. Integrity metadata</a>
@@ -1216,21 +1216,22 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
    <dt id="biblio-tls">[TLS]
    <dd>E. Rescorla. <a href="https://www.rfc-editor.org/rfc/rfc8446"><cite>The Transport Layer Security (TLS) Protocol Version 1.3</cite></a>. August 2018. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8446">https://www.rfc-editor.org/rfc/rfc8446</a>
   </dl>
-  <aside class="dfn-panel" data-for="digest">
-   <b><a href="#digest">#digest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-digest" class="dfn-panel" data-for="digest" id="infopanel-for-digest" role="dialog">
+   <span id="infopaneltitle-for-digest" style="display:none">Info about the 'digest' definition.</span><b><a href="#digest">#digest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-digest">3.1. Integrity metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="base64-encoding">
-   <b><a href="#base64-encoding">#base64-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base64-encoding" class="dfn-panel" data-for="base64-encoding" id="infopanel-for-base64-encoding" role="dialog">
+   <span id="infopaneltitle-for-base64-encoding" style="display:none">Info about the 'base64 encoding' definition.</span><b><a href="#base64-encoding">#base64-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base64-encoding">3.1. Integrity metadata</a>
     <li><a href="#ref-for-base64-encoding①">3.3.1. Apply algorithm to bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="integrity-metadata">
-   <b><a href="#integrity-metadata">#integrity-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-integrity-metadata" class="dfn-panel" data-for="integrity-metadata" id="infopanel-for-integrity-metadata" role="dialog">
+   <span id="infopaneltitle-for-integrity-metadata" style="display:none">Info about the 'integrity
+  metadata' definition.</span><b><a href="#integrity-metadata">#integrity-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-integrity-metadata">1.2.1. Resource Integrity</a> <a href="#ref-for-integrity-metadata①">(2)</a> <a href="#ref-for-integrity-metadata②">(3)</a>
     <li><a href="#ref-for-integrity-metadata③">3.2. Cryptographic hash functions</a>
@@ -1240,105 +1241,161 @@ sha512-Q2bFTOhEALkN8hOms2FKTDLy7eugP2zFZ1T8LCvX42Fp3WoNr3bjZSAHeOsHrbV1Fu9/A0EzC
     <li><a href="#ref-for-integrity-metadata⑦">5.1. Non-secure contexts remain non-secure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="getprioritizedhashfunction">
-   <b><a href="#getprioritizedhashfunction">#getprioritizedhashfunction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-getprioritizedhashfunction" class="dfn-panel" data-for="getprioritizedhashfunction" id="infopanel-for-getprioritizedhashfunction" role="dialog">
+   <span id="infopaneltitle-for-getprioritizedhashfunction" style="display:none">Info about the 'getPrioritizedHashFunction' definition.</span><b><a href="#getprioritizedhashfunction">#getprioritizedhashfunction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-getprioritizedhashfunction">3.2.2. Priority</a>
     <li><a href="#ref-for-getprioritizedhashfunction①">3.3.3. Get the strongest metadata from set</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="does-response-match-metadatalist">
-   <b><a href="#does-response-match-metadatalist">#does-response-match-metadatalist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-does-response-match-metadatalist" class="dfn-panel" data-for="does-response-match-metadatalist" id="infopanel-for-does-response-match-metadatalist" role="dialog">
+   <span id="infopaneltitle-for-does-response-match-metadatalist" style="display:none">Info about the '3.3.4. Do bytes match metadataList?' definition.</span><b><a href="#does-response-match-metadatalist">#does-response-match-metadatalist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-does-response-match-metadatalist">3.2.1. Agility</a>
     <li><a href="#ref-for-does-response-match-metadatalist">3.3.4. Do bytes match metadataList?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-hash-with-options">
-   <b><a href="#grammardef-hash-with-options">#grammardef-hash-with-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-hash-with-options" class="dfn-panel" data-for="grammardef-hash-with-options" id="infopanel-for-grammardef-hash-with-options" role="dialog">
+   <span id="infopaneltitle-for-grammardef-hash-with-options" style="display:none">Info about the 'hash-with-options' definition.</span><b><a href="#grammardef-hash-with-options">#grammardef-hash-with-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-with-options">3.3.2. Parse metadata</a>
     <li><a href="#ref-for-grammardef-hash-with-options①">3.5. The integrity attribute</a> <a href="#ref-for-grammardef-hash-with-options②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-option-expression">
-   <b><a href="#grammardef-option-expression">#grammardef-option-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-option-expression" class="dfn-panel" data-for="grammardef-option-expression" id="infopanel-for-grammardef-option-expression" role="dialog">
+   <span id="infopaneltitle-for-grammardef-option-expression" style="display:none">Info about the 'option-expression' definition.</span><b><a href="#grammardef-option-expression">#grammardef-option-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-option-expression">3.5. The integrity attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-hash-algo">
-   <b><a href="#grammardef-hash-algo">#grammardef-hash-algo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-hash-algo" class="dfn-panel" data-for="grammardef-hash-algo" id="infopanel-for-grammardef-hash-algo" role="dialog">
+   <span id="infopaneltitle-for-grammardef-hash-algo" style="display:none">Info about the 'hash-algo' definition.</span><b><a href="#grammardef-hash-algo">#grammardef-hash-algo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-algo">3.3.2. Parse metadata</a>
     <li><a href="#ref-for-grammardef-hash-algo①">3.5. The integrity attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-base64-value">
-   <b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-base64-value" class="dfn-panel" data-for="grammardef-base64-value" id="infopanel-for-grammardef-base64-value" role="dialog">
+   <span id="infopaneltitle-for-grammardef-base64-value" style="display:none">Info about the 'base64-value' definition.</span><b><a href="#grammardef-base64-value">#grammardef-base64-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-base64-value">3.5. The integrity attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="grammardef-hash-expression">
-   <b><a href="#grammardef-hash-expression">#grammardef-hash-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-grammardef-hash-expression" class="dfn-panel" data-for="grammardef-hash-expression" id="infopanel-for-grammardef-hash-expression" role="dialog">
+   <span id="infopaneltitle-for-grammardef-hash-expression" style="display:none">Info about the 'hash-expression' definition.</span><b><a href="#grammardef-hash-expression">#grammardef-hash-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-hash-expression">3.5. The integrity attribute</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-trusted-types/spec/index.html
+++ b/tests/github/w3c/webappsec-trusted-types/spec/index.html
@@ -3482,33 +3482,33 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
    <li><a href="#dom-document-writeln">writeln(...text)</a><span>, in § 4.3.2</span>
    <li><a href="#dom-document-write">write(...text)</a><span>, in § 4.3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-grammardef-report-sample">
-   <a href="https://w3c.github.io/webappsec-csp/#grammardef-report-sample">https://w3c.github.io/webappsec-csp/#grammardef-report-sample</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grammardef-report-sample" class="dfn-panel" data-for="term-for-grammardef-report-sample" id="infopanel-for-term-for-grammardef-report-sample" role="menu">
+   <span id="infopaneltitle-for-term-for-grammardef-report-sample" style="display:none">Info about the ''report-sample'' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#grammardef-report-sample">https://w3c.github.io/webappsec-csp/#grammardef-report-sample</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-report-sample">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-grammardef-unsafe-eval">
-   <a href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval">https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-grammardef-unsafe-eval" class="dfn-panel" data-for="term-for-grammardef-unsafe-eval" id="infopanel-for-term-for-grammardef-unsafe-eval" role="menu">
+   <span id="infopaneltitle-for-term-for-grammardef-unsafe-eval" style="display:none">Info about the ''unsafe-eval'' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval">https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-grammardef-unsafe-eval">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-security-policy-object">
-   <a href="https://w3c.github.io/webappsec-csp/#content-security-policy-object">https://w3c.github.io/webappsec-csp/#content-security-policy-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-security-policy-object" class="dfn-panel" data-for="term-for-content-security-policy-object" id="infopanel-for-term-for-content-security-policy-object" role="menu">
+   <span id="infopaneltitle-for-term-for-content-security-policy-object" style="display:none">Info about the 'content security policy object' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#content-security-policy-object">https://w3c.github.io/webappsec-csp/#content-security-policy-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-object">3.3. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-content-security-policy-object①">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-content-security-policy-report-only">
-   <a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy-report-only">https://w3c.github.io/webappsec-csp/#header-content-security-policy-report-only</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-content-security-policy-report-only" class="dfn-panel" data-for="term-for-header-content-security-policy-report-only" id="infopanel-for-term-for-header-content-security-policy-report-only" role="menu">
+   <span id="infopaneltitle-for-term-for-header-content-security-policy-report-only" style="display:none">Info about the 'content-security-policy-report-only' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#header-content-security-policy-report-only">https://w3c.github.io/webappsec-csp/#header-content-security-policy-report-only</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-content-security-policy-report-only">2.4.1. Content Security Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object-csp-list">
-   <a href="https://w3c.github.io/webappsec-csp/#global-object-csp-list">https://w3c.github.io/webappsec-csp/#global-object-csp-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object-csp-list" class="dfn-panel" data-for="term-for-global-object-csp-list" id="infopanel-for-term-for-global-object-csp-list" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object-csp-list" style="display:none">Info about the 'csp list' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#global-object-csp-list">https://w3c.github.io/webappsec-csp/#global-object-csp-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object-csp-list">3.3. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-global-object-csp-list①">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
@@ -3516,16 +3516,16 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-global-object-csp-list③">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-directive-set">
-   <a href="https://w3c.github.io/webappsec-csp/#policy-directive-set">https://w3c.github.io/webappsec-csp/#policy-directive-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-directive-set" class="dfn-panel" data-for="term-for-policy-directive-set" id="infopanel-for-term-for-policy-directive-set" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-directive-set" style="display:none">Info about the 'directive set' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#policy-directive-set">https://w3c.github.io/webappsec-csp/#policy-directive-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-directive-set">3.3. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-policy-directive-set①">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-policy-directive-set②">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directives">
-   <a href="https://w3c.github.io/webappsec-csp/#directives">https://w3c.github.io/webappsec-csp/#directives</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directives" class="dfn-panel" data-for="term-for-directives" id="infopanel-for-term-for-directives" role="menu">
+   <span id="infopaneltitle-for-term-for-directives" style="display:none">Info about the 'directives' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directives">https://w3c.github.io/webappsec-csp/#directives</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directives">3.3. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-directives①">4.8.1. require-trusted-types-for directive</a>
@@ -3535,22 +3535,22 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-directives⑧">4.8.6. Support for dynamic code compilation</a> <a href="#ref-for-directives⑨">(2)</a> <a href="#ref-for-directives①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-disposition">
-   <a href="https://w3c.github.io/webappsec-csp/#policy-disposition">https://w3c.github.io/webappsec-csp/#policy-disposition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-disposition" class="dfn-panel" data-for="term-for-policy-disposition" id="infopanel-for-term-for-policy-disposition" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-disposition" style="display:none">Info about the 'disposition' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#policy-disposition">https://w3c.github.io/webappsec-csp/#policy-disposition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-disposition">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-policy-disposition①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-policy-disposition②">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-inline-check">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-inline-check">https://w3c.github.io/webappsec-csp/#directive-inline-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-inline-check" class="dfn-panel" data-for="term-for-directive-inline-check" id="infopanel-for-term-for-directive-inline-check" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-inline-check" style="display:none">Info about the 'inline check' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-inline-check">https://w3c.github.io/webappsec-csp/#directive-inline-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-inline-check">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-name">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-name">https://w3c.github.io/webappsec-csp/#directive-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-name" class="dfn-panel" data-for="term-for-directive-name" id="infopanel-for-term-for-directive-name" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-name">https://w3c.github.io/webappsec-csp/#directive-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-name">4.8.1. require-trusted-types-for directive</a>
     <li><a href="#ref-for-directive-name①">4.8.2. trusted-types directive</a>
@@ -3558,20 +3558,20 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-directive-name③">4.8.6. Support for dynamic code compilation</a> <a href="#ref-for-directive-name④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-object-src">
-   <a href="https://w3c.github.io/webappsec-csp/#object-src">https://w3c.github.io/webappsec-csp/#object-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-object-src" class="dfn-panel" data-for="term-for-object-src" id="infopanel-for-term-for-object-src" role="menu">
+   <span id="infopaneltitle-for-term-for-object-src" style="display:none">Info about the 'object-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#object-src">https://w3c.github.io/webappsec-csp/#object-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-src">5.3. Plugin navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-pre-navigation-check">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check">https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-pre-navigation-check" class="dfn-panel" data-for="term-for-directive-pre-navigation-check" id="infopanel-for-term-for-directive-pre-navigation-check" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-pre-navigation-check" style="display:none">Info about the 'pre-navigation check' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check">https://w3c.github.io/webappsec-csp/#directive-pre-navigation-check</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-pre-navigation-check">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-violation-resource">
-   <a href="https://w3c.github.io/webappsec-csp/#violation-resource">https://w3c.github.io/webappsec-csp/#violation-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-violation-resource" class="dfn-panel" data-for="term-for-violation-resource" id="infopanel-for-term-for-violation-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-violation-resource" style="display:none">Info about the 'resource' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#violation-resource">https://w3c.github.io/webappsec-csp/#violation-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-resource">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-resource①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
@@ -3579,28 +3579,28 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-violation-resource③">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-violation-sample">
-   <a href="https://w3c.github.io/webappsec-csp/#violation-sample">https://w3c.github.io/webappsec-csp/#violation-sample</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-violation-sample" class="dfn-panel" data-for="term-for-violation-sample" id="infopanel-for-term-for-violation-sample" role="menu">
+   <span id="infopaneltitle-for-term-for-violation-sample" style="display:none">Info about the 'sample' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#violation-sample">https://w3c.github.io/webappsec-csp/#violation-sample</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation-sample">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-sample①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-sample②">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-src">
-   <a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-src" class="dfn-panel" data-for="term-for-script-src" id="infopanel-for-term-for-script-src" role="menu">
+   <span id="infopaneltitle-for-term-for-script-src" style="display:none">Info about the 'script-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src">1.2. Non-goals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-source-expression">
-   <a href="https://w3c.github.io/webappsec-csp/#source-expression">https://w3c.github.io/webappsec-csp/#source-expression</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-source-expression" class="dfn-panel" data-for="term-for-source-expression" id="infopanel-for-term-for-source-expression" role="menu">
+   <span id="infopaneltitle-for-term-for-source-expression" style="display:none">Info about the 'source expression' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#source-expression">https://w3c.github.io/webappsec-csp/#source-expression</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-source-expression">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-directive-value">
-   <a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-directive-value" class="dfn-panel" data-for="term-for-directive-value" id="infopanel-for-term-for-directive-value" role="menu">
+   <span id="infopaneltitle-for-term-for-directive-value" style="display:none">Info about the 'value' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#directive-value">https://w3c.github.io/webappsec-csp/#directive-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-directive-value">4.8.1. require-trusted-types-for directive</a>
     <li><a href="#ref-for-directive-value①">4.8.2. trusted-types directive</a> <a href="#ref-for-directive-value②">(2)</a>
@@ -3609,14 +3609,14 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-directive-value⑧">4.8.6. Support for dynamic code compilation</a> <a href="#ref-for-directive-value⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-violation">
-   <a href="https://w3c.github.io/webappsec-csp/#violation">https://w3c.github.io/webappsec-csp/#violation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-violation" class="dfn-panel" data-for="term-for-violation" id="infopanel-for-term-for-violation" role="menu">
+   <span id="infopaneltitle-for-term-for-violation" style="display:none">Info about the 'violation' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#violation">https://w3c.github.io/webappsec-csp/#violation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-violation">4.8.5. Violation object changes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.1.1. HTML injection sinks</a>
     <li><a href="#ref-for-document①">3.5. Prepare the script URL and text</a> <a href="#ref-for-document②">(2)</a>
@@ -3625,14 +3625,14 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-document⑥">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentfragment">
-   <a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentfragment" class="dfn-panel" data-for="term-for-documentfragment" id="infopanel-for-term-for-documentfragment" role="menu">
+   <span id="infopaneltitle-for-term-for-documentfragment" style="display:none">Info about the 'DocumentFragment' external reference.</span><a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentfragment">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">2.1.2. DOM XSS injection sinks</a> <a href="#ref-for-element①">(2)</a>
     <li><a href="#ref-for-element②">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-element③">(2)</a>
@@ -3640,46 +3640,46 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-element⑤">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">4.3.8. Web Workers</a> <a href="#ref-for-eventtarget①">(2)</a> <a href="#ref-for-eventtarget②">(3)</a>
     <li><a href="#ref-for-eventtarget③">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-range">
-   <a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-range" class="dfn-panel" data-for="term-for-range" id="infopanel-for-term-for-range" role="menu">
+   <span id="infopaneltitle-for-term-for-range" style="display:none">Info about the 'Range' external reference.</span><a href="https://dom.spec.whatwg.org/#range">https://dom.spec.whatwg.org/#range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-append">
-   <a href="https://dom.spec.whatwg.org/#concept-node-append">https://dom.spec.whatwg.org/#concept-node-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-append" class="dfn-panel" data-for="term-for-concept-node-append" id="infopanel-for-term-for-concept-node-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-append" style="display:none">Info about the 'append' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-append">https://dom.spec.whatwg.org/#concept-node-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-append">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute" class="dfn-panel" data-for="term-for-concept-attribute" id="infopanel-for-term-for-concept-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute" style="display:none">Info about the 'attribute' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute">4.5. Integration with SVG</a>
     <li><a href="#ref-for-concept-attribute①">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attributes-change-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attributes-change-ext">https://dom.spec.whatwg.org/#concept-element-attributes-change-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attributes-change-ext" class="dfn-panel" data-for="term-for-concept-element-attributes-change-ext" id="infopanel-for-term-for-concept-element-attributes-change-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attributes-change-ext" style="display:none">Info about the 'attribute change steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attributes-change-ext">https://dom.spec.whatwg.org/#concept-element-attributes-change-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-change-ext">4.3.6. Enforcement in event handler content attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attribute" class="dfn-panel" data-for="term-for-concept-element-attribute" id="infopanel-for-term-for-concept-element-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attribute" style="display:none">Info about the 'attribute list' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-child-text-content">
-   <a href="https://dom.spec.whatwg.org/#concept-child-text-content">https://dom.spec.whatwg.org/#concept-child-text-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-child-text-content" class="dfn-panel" data-for="term-for-concept-child-text-content" id="infopanel-for-term-for-concept-child-text-content" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-child-text-content" style="display:none">Info about the 'child text content' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-child-text-content">https://dom.spec.whatwg.org/#concept-child-text-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-child-text-content">3.5. Prepare the script URL and text</a> <a href="#ref-for-concept-child-text-content①">(2)</a>
     <li><a href="#ref-for-concept-child-text-content②">4.3.3.1. Slots with trusted values</a>
@@ -3687,116 +3687,116 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#script-processing-model:child-text-content">4.3.3.3. Slot value verification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">4.6. Integration with DOM</a> <a href="#ref-for-concept-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-element">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-element">https://dom.spec.whatwg.org/#concept-attribute-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-element" class="dfn-panel" data-for="term-for-concept-attribute-element" id="infopanel-for-term-for-concept-attribute-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-element" style="display:none">Info about the 'element (for Attr)' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-element">https://dom.spec.whatwg.org/#concept-attribute-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-element">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-interface">
-   <a href="https://dom.spec.whatwg.org/#concept-element-interface">https://dom.spec.whatwg.org/#concept-element-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-interface" class="dfn-panel" data-for="term-for-concept-element-interface" id="infopanel-for-term-for-concept-element-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-interface" style="display:none">Info about the 'element interface' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-interface">https://dom.spec.whatwg.org/#concept-element-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-interface">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-concept-element-interface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handle-attribute-changes">
-   <a href="https://dom.spec.whatwg.org/#handle-attribute-changes">https://dom.spec.whatwg.org/#handle-attribute-changes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handle-attribute-changes" class="dfn-panel" data-for="term-for-handle-attribute-changes" id="infopanel-for-term-for-handle-attribute-changes" role="menu">
+   <span id="infopaneltitle-for-term-for-handle-attribute-changes" style="display:none">Info about the 'handle attribute changes' external reference.</span><a href="https://dom.spec.whatwg.org/#handle-attribute-changes">https://dom.spec.whatwg.org/#handle-attribute-changes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-attribute-changes">4.6. Integration with DOM</a> <a href="#ref-for-handle-attribute-changes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-local-name">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-local-name">https://dom.spec.whatwg.org/#concept-attribute-local-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-local-name" class="dfn-panel" data-for="term-for-concept-attribute-local-name" id="infopanel-for-term-for-concept-attribute-local-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-local-name" style="display:none">Info about the 'local name (for Attr)' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-local-name">https://dom.spec.whatwg.org/#concept-attribute-local-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-local-name">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-local-name">
-   <a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-local-name" class="dfn-panel" data-for="term-for-concept-element-local-name" id="infopanel-for-term-for-concept-element-local-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-local-name" style="display:none">Info about the 'local name (for Element)' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-local-name">https://dom.spec.whatwg.org/#concept-element-local-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-local-name">4.3.6. Enforcement in event handler content attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-namespace">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-namespace">https://dom.spec.whatwg.org/#concept-attribute-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-namespace" class="dfn-panel" data-for="term-for-concept-attribute-namespace" id="infopanel-for-term-for-concept-attribute-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-namespace" style="display:none">Info about the 'namespace' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-namespace">https://dom.spec.whatwg.org/#concept-attribute-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-namespace">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-other-applicable-specifications">
-   <a href="https://dom.spec.whatwg.org/#other-applicable-specifications">https://dom.spec.whatwg.org/#other-applicable-specifications</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-other-applicable-specifications" class="dfn-panel" data-for="term-for-other-applicable-specifications" id="infopanel-for-term-for-other-applicable-specifications" role="menu">
+   <span id="infopaneltitle-for-term-for-other-applicable-specifications" style="display:none">Info about the 'other applicable specifications' external reference.</span><a href="https://dom.spec.whatwg.org/#other-applicable-specifications">https://dom.spec.whatwg.org/#other-applicable-specifications</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-other-applicable-specifications">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-node-textcontent">
-   <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">https://dom.spec.whatwg.org/#dom-node-textcontent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-node-textcontent" class="dfn-panel" data-for="term-for-dom-node-textcontent" id="infopanel-for-term-for-dom-node-textcontent" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-node-textcontent" style="display:none">Info about the 'textContent' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-node-textcontent">https://dom.spec.whatwg.org/#dom-node-textcontent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-textcontent">4.3.3.2. Setting slot values</a> <a href="#ref-for-dom-node-textcontent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-value">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-value">https://dom.spec.whatwg.org/#concept-attribute-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-value" class="dfn-panel" data-for="term-for-concept-attribute-value" id="infopanel-for-term-for-concept-attribute-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-value" style="display:none">Info about the 'value' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-value">https://dom.spec.whatwg.org/#concept-attribute-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-value">4.6. Integration with DOM</a> <a href="#ref-for-concept-attribute-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-innerhtml">
-   <a href="https://w3c.github.io/DOM-Parsing/#dom-innerhtml">https://w3c.github.io/DOM-Parsing/#dom-innerhtml</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-innerhtml" class="dfn-panel" data-for="term-for-dom-innerhtml" id="infopanel-for-term-for-dom-innerhtml" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-innerhtml" style="display:none">Info about the 'InnerHTML' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#dom-innerhtml">https://w3c.github.io/DOM-Parsing/#dom-innerhtml</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-innerhtml">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-supportedtype">
-   <a href="https://w3c.github.io/DOM-Parsing/#supportedtype">https://w3c.github.io/DOM-Parsing/#supportedtype</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-supportedtype" class="dfn-panel" data-for="term-for-supportedtype" id="infopanel-for-term-for-supportedtype" role="menu">
+   <span id="infopaneltitle-for-term-for-supportedtype" style="display:none">Info about the 'SupportedType' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#supportedtype">https://w3c.github.io/DOM-Parsing/#supportedtype</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supportedtype">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'ToString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">4.2.2. Type conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-local-scheme">
-   <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-local-scheme" class="dfn-panel" data-for="term-for-local-scheme" id="infopanel-for-term-for-local-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-local-scheme" style="display:none">Info about the 'local scheme' external reference.</span><a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-scheme">5.1. Cross-document vectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">4.8.1.1. require-trusted-types-for Pre-Navigation check</a> <a href="#ref-for-concept-request-url①">(2)</a> <a href="#ref-for-concept-request-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">5.1. Cross-document vectors</a> <a href="#ref-for-dfn-Blob①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">4.3.2. Extensions to the Document interface</a> <a href="#ref-for-cereactions①">(2)</a>
     <li><a href="#ref-for-cereactions②">4.3.3.2. Setting slot values</a> <a href="#ref-for-cereactions③">(2)</a> <a href="#ref-for-cereactions④">(3)</a> <a href="#ref-for-cereactions⑤">(4)</a>
@@ -3804,27 +3804,27 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-cereactions①⓪">4.7. Integration with DOM Parsing</a> <a href="#ref-for-cereactions①①">(2)</a> <a href="#ref-for-cereactions①②">(3)</a> <a href="#ref-for-cereactions①③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlembedelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlembedelement" class="dfn-panel" data-for="term-for-htmlembedelement" id="infopanel-for-term-for-htmlembedelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlembedelement" style="display:none">Info about the 'HTMLEmbedElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlembedelement">4.3.4. Enforcement in element attributes</a>
     <li><a href="#ref-for-htmlembedelement①">5.3. Plugin navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmliframeelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmliframeelement" class="dfn-panel" data-for="term-for-htmliframeelement" id="infopanel-for-term-for-htmliframeelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmliframeelement" style="display:none">Info about the 'HTMLIFrameElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmliframeelement">4.3.4. Enforcement in element attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlobjectelement">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlobjectelement" class="dfn-panel" data-for="term-for-htmlobjectelement" id="infopanel-for-term-for-htmlobjectelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlobjectelement" style="display:none">Info about the 'HTMLObjectElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlobjectelement">4.3.4. Enforcement in element attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlscriptelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlscriptelement" class="dfn-panel" data-for="term-for-htmlscriptelement" id="infopanel-for-term-for-htmlscriptelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlscriptelement" style="display:none">Info about the 'HTMLScriptElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlscriptelement">3.5. Prepare the script URL and text</a>
     <li><a href="#ref-for-htmlscriptelement①">4.3.3.1. Slots with trusted values</a>
@@ -3832,71 +3832,71 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-htmlscriptelement⑤">4.3.3.3. Slot value verification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworker" class="dfn-panel" data-for="term-for-sharedworker" id="infopanel-for-term-for-sharedworker" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworker" style="display:none">Info about the 'SharedWorker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworker">https://html.spec.whatwg.org/multipage/workers.html#sharedworker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworker">4.3.8. Web Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.3. Integration with HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">4.3.1. Extensions to the WindowOrWorkerGlobalScope interface</a> <a href="#ref-for-windoworworkerglobalscope①">(2)</a>
     <li><a href="#ref-for-windoworworkerglobalscope②">4.3.5. Enforcement in timer functions</a> <a href="#ref-for-windoworworkerglobalscope③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.3. Integration with HTML</a>
     <li><a href="#ref-for-worker①">4.3.8. Web Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4.3.8. Web Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workeroptions">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workeroptions">https://html.spec.whatwg.org/multipage/workers.html#workeroptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workeroptions" class="dfn-panel" data-for="term-for-workeroptions" id="infopanel-for-term-for-workeroptions" role="menu">
+   <span id="infopaneltitle-for-term-for-workeroptions" style="display:none">Info about the 'WorkerOptions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workeroptions">https://html.spec.whatwg.org/multipage/workers.html#workeroptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workeroptions">4.3.8. Web Workers</a> <a href="#ref-for-workeroptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-innertext">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext">https://html.spec.whatwg.org/multipage/dom.html#dom-innertext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-innertext" class="dfn-panel" data-for="term-for-dom-innertext" id="infopanel-for-term-for-dom-innertext" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-innertext" style="display:none">Info about the 'innerText' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#dom-innertext">https://html.spec.whatwg.org/multipage/dom.html#dom-innertext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-innertext">4.3.3.2. Setting slot values</a> <a href="#ref-for-dom-innertext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-global-object-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-global-object-realm" class="dfn-panel" data-for="term-for-concept-global-object-realm" id="infopanel-for-term-for-concept-global-object-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-global-object-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-object-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-global-object-realm">2.3. Policies</a>
     <li><a href="#ref-for-concept-global-object-realm①">4.8.1. require-trusted-types-for directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reflect">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reflect" class="dfn-panel" data-for="term-for-reflect" id="infopanel-for-term-for-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reflect">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">2.3.1. TrustedTypePolicyFactory</a>
     <li><a href="#ref-for-concept-relevant-global①">3.5. Prepare the script URL and text</a> <a href="#ref-for-concept-relevant-global②">(2)</a>
@@ -3907,126 +3907,126 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-concept-relevant-global⑧">4.5. Integration with SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-embed-src">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-embed-src" class="dfn-panel" data-for="term-for-attr-embed-src" id="infopanel-for-term-for-attr-embed-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-embed-src" style="display:none">Info about the 'src (for embed)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-embed-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-embed-src">5.3. Plugin navigation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-script-src">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-src">https://html.spec.whatwg.org/multipage/scripting.html#attr-script-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-script-src" class="dfn-panel" data-for="term-for-attr-script-src" id="infopanel-for-term-for-attr-script-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-script-src" style="display:none">Info about the 'src (for script)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-src">https://html.spec.whatwg.org/multipage/scripting.html#attr-script-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-script-src">3.5. Prepare the script URL and text</a> <a href="#ref-for-attr-script-src①">(2)</a> <a href="#ref-for-attr-script-src②">(3)</a>
     <li><a href="#ref-for-attr-script-src③">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.6. Integration with DOM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#script-processing-model:ascii-case-insensitive">4.3.3.3. Slot value verification</a> <a href="#script-processing-model:ascii-case-insensitive-2">(2)</a> <a href="#script-processing-model:ascii-case-insensitive-3">(3)</a>
     <li><a href="#ref-for-ascii-case-insensitive">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-ascii-lowercase①">(2)</a> <a href="#ref-for-ascii-lowercase②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenate' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">4.3.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-string-concatenate①">4.3.7. Validate the string in context</a>
     <li><a href="#ref-for-string-concatenate②">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-html-namespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-registrationoptions">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-registrationoptions">https://w3c.github.io/ServiceWorker/#dictdef-registrationoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-registrationoptions" class="dfn-panel" data-for="term-for-dictdef-registrationoptions" id="infopanel-for-term-for-dictdef-registrationoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-registrationoptions" style="display:none">Info about the 'RegistrationOptions' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-registrationoptions">https://w3c.github.io/ServiceWorker/#dictdef-registrationoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-registrationoptions">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkercontainer">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkercontainer">https://w3c.github.io/ServiceWorker/#serviceworkercontainer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkercontainer" class="dfn-panel" data-for="term-for-serviceworkercontainer" id="infopanel-for-term-for-serviceworkercontainer" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkercontainer" style="display:none">Info about the 'ServiceWorkerContainer' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkercontainer">https://w3c.github.io/ServiceWorker/#serviceworkercontainer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkercontainer">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedString">
-   <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGAnimatedString" class="dfn-panel" data-for="term-for-InterfaceSVGAnimatedString" id="infopanel-for-term-for-InterfaceSVGAnimatedString" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGAnimatedString" style="display:none">Info about the 'SVGAnimatedString' external reference.</span><a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGAnimatedString">4.5. Integration with SVG</a> <a href="#ref-for-InterfaceSVGAnimatedString①">(2)</a> <a href="#ref-for-InterfaceSVGAnimatedString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-InterfaceSVGScriptElement">
-   <a href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement">https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-InterfaceSVGScriptElement" class="dfn-panel" data-for="term-for-InterfaceSVGScriptElement" id="infopanel-for-term-for-InterfaceSVGScriptElement" role="menu">
+   <span id="infopaneltitle-for-term-for-InterfaceSVGScriptElement" style="display:none">Info about the 'SVGScriptElement' external reference.</span><a href="https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement">https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-InterfaceSVGScriptElement">4.5. Integration with SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-AllowShared">
-   <a href="https://webidl.spec.whatwg.org/#AllowShared">https://webidl.spec.whatwg.org/#AllowShared</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-AllowShared" class="dfn-panel" data-for="term-for-AllowShared" id="infopanel-for-term-for-AllowShared" role="menu">
+   <span id="infopaneltitle-for-term-for-AllowShared" style="display:none">Info about the 'AllowShared' external reference.</span><a href="https://webidl.spec.whatwg.org/#AllowShared">https://webidl.spec.whatwg.org/#AllowShared</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AllowShared">4.2.1. Extended attributes applicable to types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Clamp">
-   <a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Clamp" class="dfn-panel" data-for="term-for-Clamp" id="infopanel-for-term-for-Clamp" role="menu">
+   <span id="infopaneltitle-for-term-for-Clamp" style="display:none">Info about the 'Clamp' external reference.</span><a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Clamp">4.2.1. Extended attributes applicable to types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-idl-DOMString①">2.2.2. TrustedScript</a>
@@ -4041,20 +4041,20 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-idl-DOMString③⓪">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">4.2.1. Extended attributes applicable to types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-evalerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-evalerror">https://webidl.spec.whatwg.org/#exceptiondef-evalerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-evalerror" class="dfn-panel" data-for="term-for-exceptiondef-evalerror" id="infopanel-for-term-for-exceptiondef-evalerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-evalerror" style="display:none">Info about the 'EvalError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-evalerror">https://webidl.spec.whatwg.org/#exceptiondef-evalerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-evalerror">4.8.6. Support for dynamic code compilation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-Exposed①">2.2.2. TrustedScript</a>
@@ -4067,14 +4067,14 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-Exposed①⓪">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Function">
-   <a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Function" class="dfn-panel" data-for="term-for-Function" id="infopanel-for-term-for-Function" role="menu">
+   <span id="infopaneltitle-for-term-for-Function" style="display:none">Info about the 'Function' external reference.</span><a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Function">4.3.5. Enforcement in timer functions</a> <a href="#ref-for-Function①">(2)</a> <a href="#ref-for-Function②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyNullToEmptyString">
-   <a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyNullToEmptyString" class="dfn-panel" data-for="term-for-LegacyNullToEmptyString" id="infopanel-for-term-for-LegacyNullToEmptyString" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyNullToEmptyString" style="display:none">Info about the 'LegacyNullToEmptyString' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNullToEmptyString">4.2.1. Extended attributes applicable to types</a>
     <li><a href="#ref-for-LegacyNullToEmptyString①">4.2.2. Type conversion</a>
@@ -4082,27 +4082,27 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-LegacyNullToEmptyString③">4.7. Integration with DOM Parsing</a> <a href="#ref-for-LegacyNullToEmptyString④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">4.4. Integration with Service Workers</a>
     <li><a href="#ref-for-NewObject①">4.7. Integration with DOM Parsing</a> <a href="#ref-for-NewObject②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">4.4. Integration with Service Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">2.2.3. TrustedScriptURL</a>
     <li><a href="#ref-for-idl-USVString①">2.3.3. TrustedTypePolicyOptions</a>
@@ -4110,8 +4110,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-idl-USVString③">4.2. [StringContext]</a> <a href="#ref-for-idl-USVString④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a>
     <li><a href="#ref-for-idl-any③">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-idl-any④">(2)</a> <a href="#ref-for-idl-any⑤">(3)</a>
@@ -4119,32 +4119,32 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-idl-any⑨">4.3.5. Enforcement in timer functions</a> <a href="#ref-for-idl-any①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-attribute">
-   <a href="https://webidl.spec.whatwg.org/#dfn-attribute">https://webidl.spec.whatwg.org/#dfn-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-attribute" class="dfn-panel" data-for="term-for-dfn-attribute" id="infopanel-for-term-for-dfn-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-attribute" style="display:none">Info about the 'attribute' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-attribute">https://webidl.spec.whatwg.org/#dfn-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-attribute">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-dfn-attribute①">(2)</a> <a href="#ref-for-dfn-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">4.2.2. Type conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extended-attribute">
-   <a href="https://webidl.spec.whatwg.org/#dfn-extended-attribute">https://webidl.spec.whatwg.org/#dfn-extended-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extended-attribute" class="dfn-panel" data-for="term-for-dfn-extended-attribute" id="infopanel-for-term-for-dfn-extended-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extended-attribute" style="display:none">Info about the 'extended attribute' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-extended-attribute">https://webidl.spec.whatwg.org/#dfn-extended-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extended-attribute">4.2. [StringContext]</a> <a href="#ref-for-dfn-extended-attribute①">(2)</a> <a href="#ref-for-dfn-extended-attribute②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">4.2. [StringContext]</a>
     <li><a href="#ref-for-dfn-identifier①">4.2.2. Type conversion</a> <a href="#ref-for-dfn-identifier②">(2)</a>
@@ -4152,83 +4152,83 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-dfn-identifier⑤">4.3.7. Validate the string in context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-idl-fragment">
-   <a href="https://webidl.spec.whatwg.org/#dfn-idl-fragment">https://webidl.spec.whatwg.org/#dfn-idl-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-idl-fragment" class="dfn-panel" data-for="term-for-dfn-idl-fragment" id="infopanel-for-term-for-dfn-idl-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-idl-fragment" style="display:none">Info about the 'idl fragment' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-idl-fragment">https://webidl.spec.whatwg.org/#dfn-idl-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-idl-fragment">4.2. [StringContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include">
-   <a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include" class="dfn-panel" data-for="term-for-include" id="infopanel-for-term-for-include" role="menu">
+   <span id="infopaneltitle-for-term-for-include" style="display:none">Info about the 'include' external reference.</span><a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-mixin">
-   <a href="https://webidl.spec.whatwg.org/#interface-mixin">https://webidl.spec.whatwg.org/#interface-mixin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-mixin" class="dfn-panel" data-for="term-for-interface-mixin" id="infopanel-for-term-for-interface-mixin" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-mixin" style="display:none">Info about the 'interface mixin' external reference.</span><a href="https://webidl.spec.whatwg.org/#interface-mixin">https://webidl.spec.whatwg.org/#interface-mixin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-mixin">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">4.3.5. Enforcement in timer functions</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-operation">
-   <a href="https://webidl.spec.whatwg.org/#dfn-operation">https://webidl.spec.whatwg.org/#dfn-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-operation" class="dfn-panel" data-for="term-for-dfn-operation" id="infopanel-for-term-for-dfn-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-operation" style="display:none">Info about the 'operation' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-operation">https://webidl.spec.whatwg.org/#dfn-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-operation">4.2. [StringContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-platform-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-platform-object" class="dfn-panel" data-for="term-for-dfn-platform-object" id="infopanel-for-term-for-dfn-platform-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-platform-object" style="display:none">Info about the 'platform object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object">4.2.3. Validate the string in context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-read-only">
-   <a href="https://webidl.spec.whatwg.org/#dfn-read-only">https://webidl.spec.whatwg.org/#dfn-read-only</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-read-only" class="dfn-panel" data-for="term-for-dfn-read-only" id="infopanel-for-term-for-dfn-read-only" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-read-only" style="display:none">Info about the 'read only' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-read-only">https://webidl.spec.whatwg.org/#dfn-read-only</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-read-only">4.2. [StringContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-regular-attribute">
-   <a href="https://webidl.spec.whatwg.org/#dfn-regular-attribute">https://webidl.spec.whatwg.org/#dfn-regular-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-regular-attribute" class="dfn-panel" data-for="term-for-dfn-regular-attribute" id="infopanel-for-term-for-dfn-regular-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-regular-attribute" style="display:none">Info about the 'regular attribute' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-regular-attribute">https://webidl.spec.whatwg.org/#dfn-regular-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-regular-attribute">4.2. [StringContext]</a> <a href="#ref-for-dfn-regular-attribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-regular-operation">
-   <a href="https://webidl.spec.whatwg.org/#dfn-regular-operation">https://webidl.spec.whatwg.org/#dfn-regular-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-regular-operation" class="dfn-panel" data-for="term-for-dfn-regular-operation" id="infopanel-for-term-for-dfn-regular-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-regular-operation" style="display:none">Info about the 'regular operation' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-regular-operation">https://webidl.spec.whatwg.org/#dfn-regular-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-regular-operation">4.2. [StringContext]</a> <a href="#ref-for-dfn-regular-operation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-xattr-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-xattr-identifier">https://webidl.spec.whatwg.org/#dfn-xattr-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-xattr-identifier" class="dfn-panel" data-for="term-for-dfn-xattr-identifier" id="infopanel-for-term-for-dfn-xattr-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-xattr-identifier" style="display:none">Info about the 'takes an identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-xattr-identifier">https://webidl.spec.whatwg.org/#dfn-xattr-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-xattr-identifier">4.2. [StringContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://heycam.github.io/webidl/#this">https://heycam.github.io/webidl/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://heycam.github.io/webidl/#this">https://heycam.github.io/webidl/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">4.2.2. Type conversion</a>
     <li><a href="#ref-for-this①">4.3.1. Extensions to the WindowOrWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.3.2. Extensions to the Document interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">4.3.8. Web Workers</a>
     <li><a href="#ref-for-idl-undefined③">4.7. Integration with DOM Parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-variadic">
-   <a href="https://webidl.spec.whatwg.org/#dfn-variadic">https://webidl.spec.whatwg.org/#dfn-variadic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-variadic" class="dfn-panel" data-for="term-for-dfn-variadic" id="infopanel-for-term-for-dfn-variadic" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-variadic" style="display:none">Info about the 'variadic' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-variadic">https://webidl.spec.whatwg.org/#dfn-variadic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-variadic">4.2. [StringContext]</a>
    </ul>
@@ -4441,8 +4441,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
    <div class="issue"> Remove when <a href="https://github.com/whatwg/dom/pull/809">DOM #809</a> is merged. <a class="issue-return" href="#issue-52c8f9b0" title="Jump to section">↵</a></div>
    <div class="issue"> Refer to the external document on secure policy design. <a class="issue-return" href="#issue-2eb927d2" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="injection-sink">
-   <b><a href="#injection-sink">#injection-sink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-injection-sink" class="dfn-panel" data-for="injection-sink" id="infopanel-for-injection-sink" role="dialog">
+   <span id="infopaneltitle-for-injection-sink" style="display:none">Info about the 'injection sink' definition.</span><b><a href="#injection-sink">#injection-sink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-injection-sink">1. Introduction</a>
     <li><a href="#ref-for-injection-sink①">1.3. Use cases</a>
@@ -4468,8 +4468,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-injection-sink③⓪">7.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trusted-type">
-   <b><a href="#trusted-type">#trusted-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trusted-type" class="dfn-panel" data-for="trusted-type" id="infopanel-for-trusted-type" role="dialog">
+   <span id="infopaneltitle-for-trusted-type" style="display:none">Info about the 'Trusted Type' definition.</span><b><a href="#trusted-type">#trusted-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trusted-type">2.3. Policies</a>
     <li><a href="#ref-for-trusted-type①">2.3.1. TrustedTypePolicyFactory</a>
@@ -4479,8 +4479,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trusted-type⑤">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedhtml">
-   <b><a href="#trustedhtml">#trustedhtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedhtml" class="dfn-panel" data-for="trustedhtml" id="infopanel-for-trustedhtml" role="dialog">
+   <span id="infopaneltitle-for-trustedhtml" style="display:none">Info about the 'TrustedHTML' definition.</span><b><a href="#trustedhtml">#trustedhtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedhtml">2.3. Policies</a>
     <li><a href="#ref-for-trustedhtml①">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-trustedhtml②">(2)</a> <a href="#ref-for-trustedhtml③">(3)</a> <a href="#ref-for-trustedhtml④">(4)</a>
@@ -4489,20 +4489,20 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trustedhtml⑧">4.2. [StringContext]</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedhtml-tojson">
-   <b><a href="#dom-trustedhtml-tojson">#dom-trustedhtml-tojson</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedhtml-tojson" class="dfn-panel" data-for="dom-trustedhtml-tojson" id="infopanel-for-dom-trustedhtml-tojson" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedhtml-tojson" style="display:none">Info about the 'toJSON()' definition.</span><b><a href="#dom-trustedhtml-tojson">#dom-trustedhtml-tojson</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedhtml-tojson">2.2.1. TrustedHTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedhtml-stringification-behavior">
-   <b><a href="#trustedhtml-stringification-behavior">#trustedhtml-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedhtml-stringification-behavior" class="dfn-panel" data-for="trustedhtml-stringification-behavior" id="infopanel-for-trustedhtml-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-trustedhtml-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#trustedhtml-stringification-behavior">#trustedhtml-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedhtml-stringification-behavior">2.2.1. TrustedHTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedscript">
-   <b><a href="#trustedscript">#trustedscript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedscript" class="dfn-panel" data-for="trustedscript" id="infopanel-for-trustedscript" role="dialog">
+   <span id="infopaneltitle-for-trustedscript" style="display:none">Info about the 'TrustedScript' definition.</span><b><a href="#trustedscript">#trustedscript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedscript">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-trustedscript①">(2)</a> <a href="#ref-for-trustedscript②">(3)</a> <a href="#ref-for-trustedscript③">(4)</a>
     <li><a href="#ref-for-trustedscript④">2.3.2. TrustedTypePolicy</a>
@@ -4515,20 +4515,20 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trustedscript①④">4.8.6. Support for dynamic code compilation</a> <a href="#ref-for-trustedscript①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedscript-tojson">
-   <b><a href="#dom-trustedscript-tojson">#dom-trustedscript-tojson</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedscript-tojson" class="dfn-panel" data-for="dom-trustedscript-tojson" id="infopanel-for-dom-trustedscript-tojson" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedscript-tojson" style="display:none">Info about the 'toJSON()' definition.</span><b><a href="#dom-trustedscript-tojson">#dom-trustedscript-tojson</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedscript-tojson">2.2.2. TrustedScript</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedscript-stringification-behavior">
-   <b><a href="#trustedscript-stringification-behavior">#trustedscript-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedscript-stringification-behavior" class="dfn-panel" data-for="trustedscript-stringification-behavior" id="infopanel-for-trustedscript-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-trustedscript-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#trustedscript-stringification-behavior">#trustedscript-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedscript-stringification-behavior">2.2.2. TrustedScript</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedscripturl">
-   <b><a href="#trustedscripturl">#trustedscripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedscripturl" class="dfn-panel" data-for="trustedscripturl" id="infopanel-for-trustedscripturl" role="dialog">
+   <span id="infopaneltitle-for-trustedscripturl" style="display:none">Info about the 'TrustedScriptURL' definition.</span><b><a href="#trustedscripturl">#trustedscripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedscripturl">2.3.1. TrustedTypePolicyFactory</a>
     <li><a href="#ref-for-trustedscripturl①">2.3.2. TrustedTypePolicy</a>
@@ -4539,20 +4539,20 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trustedscripturl⑨">5.3. Plugin navigation</a> <a href="#ref-for-trustedscripturl①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedscripturl-tojson">
-   <b><a href="#dom-trustedscripturl-tojson">#dom-trustedscripturl-tojson</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedscripturl-tojson" class="dfn-panel" data-for="dom-trustedscripturl-tojson" id="infopanel-for-dom-trustedscripturl-tojson" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedscripturl-tojson" style="display:none">Info about the 'toJSON()' definition.</span><b><a href="#dom-trustedscripturl-tojson">#dom-trustedscripturl-tojson</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedscripturl-tojson">2.2.3. TrustedScriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedscripturl-stringification-behavior">
-   <b><a href="#trustedscripturl-stringification-behavior">#trustedscripturl-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedscripturl-stringification-behavior" class="dfn-panel" data-for="trustedscripturl-stringification-behavior" id="infopanel-for-trustedscripturl-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-trustedscripturl-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#trustedscripturl-stringification-behavior">#trustedscripturl-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedscripturl-stringification-behavior">2.2.3. TrustedScriptURL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="policies">
-   <b><a href="#policies">#policies</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-policies" class="dfn-panel" data-for="policies" id="infopanel-for-policies" role="dialog">
+   <span id="infopaneltitle-for-policies" style="display:none">Info about the 'Policies' definition.</span><b><a href="#policies">#policies</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policies">1. Introduction</a>
     <li><a href="#ref-for-policies①">1.3. Use cases</a>
@@ -4563,71 +4563,71 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-policies⑥">5.5. Best practices for policy design</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedtypepolicyfactory">
-   <b><a href="#trustedtypepolicyfactory">#trustedtypepolicyfactory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedtypepolicyfactory" class="dfn-panel" data-for="trustedtypepolicyfactory" id="infopanel-for-trustedtypepolicyfactory" role="dialog">
+   <span id="infopaneltitle-for-trustedtypepolicyfactory" style="display:none">Info about the 'TrustedTypePolicyFactory' definition.</span><b><a href="#trustedtypepolicyfactory">#trustedtypepolicyfactory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedtypepolicyfactory">3.1. Create a Trusted Type Policy</a>
     <li><a href="#ref-for-trustedtypepolicyfactory①">4.3. Integration with HTML</a>
     <li><a href="#ref-for-trustedtypepolicyfactory②">4.3.1. Extensions to the WindowOrWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-createpolicy">
-   <b><a href="#dom-trustedtypepolicyfactory-createpolicy">#dom-trustedtypepolicyfactory-createpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-createpolicy" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-createpolicy" id="infopanel-for-dom-trustedtypepolicyfactory-createpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-createpolicy" style="display:none">Info about the 'createPolicy(policyName, policyOptions)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-createpolicy">#dom-trustedtypepolicyfactory-createpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-createpolicy">2.3. Policies</a> <a href="#ref-for-dom-trustedtypepolicyfactory-createpolicy①">(2)</a>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-createpolicy②">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-ishtml">
-   <b><a href="#dom-trustedtypepolicyfactory-ishtml">#dom-trustedtypepolicyfactory-ishtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-ishtml" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-ishtml" id="infopanel-for-dom-trustedtypepolicyfactory-ishtml" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-ishtml" style="display:none">Info about the 'isHTML(value)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-ishtml">#dom-trustedtypepolicyfactory-ishtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-ishtml">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-isscript">
-   <b><a href="#dom-trustedtypepolicyfactory-isscript">#dom-trustedtypepolicyfactory-isscript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-isscript" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-isscript" id="infopanel-for-dom-trustedtypepolicyfactory-isscript" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-isscript" style="display:none">Info about the 'isScript(value)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-isscript">#dom-trustedtypepolicyfactory-isscript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-isscript">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-isscripturl">
-   <b><a href="#dom-trustedtypepolicyfactory-isscripturl">#dom-trustedtypepolicyfactory-isscripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-isscripturl" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-isscripturl" id="infopanel-for-dom-trustedtypepolicyfactory-isscripturl" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-isscripturl" style="display:none">Info about the 'isScriptURL(value)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-isscripturl">#dom-trustedtypepolicyfactory-isscripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-isscripturl">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-getpropertytype">
-   <b><a href="#dom-trustedtypepolicyfactory-getpropertytype">#dom-trustedtypepolicyfactory-getpropertytype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-getpropertytype" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-getpropertytype" id="infopanel-for-dom-trustedtypepolicyfactory-getpropertytype" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-getpropertytype" style="display:none">Info about the 'getPropertyType(tagName, property, elementNs)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-getpropertytype">#dom-trustedtypepolicyfactory-getpropertytype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-getpropertytype">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-getattributetype">
-   <b><a href="#dom-trustedtypepolicyfactory-getattributetype">#dom-trustedtypepolicyfactory-getattributetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-getattributetype" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-getattributetype" id="infopanel-for-dom-trustedtypepolicyfactory-getattributetype" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-getattributetype" style="display:none">Info about the 'getAttributeType(tagName, attribute, elementNs, attrNs)' definition.</span><b><a href="#dom-trustedtypepolicyfactory-getattributetype">#dom-trustedtypepolicyfactory-getattributetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-getattributetype">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-emptyhtml">
-   <b><a href="#dom-trustedtypepolicyfactory-emptyhtml">#dom-trustedtypepolicyfactory-emptyhtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-emptyhtml" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-emptyhtml" id="infopanel-for-dom-trustedtypepolicyfactory-emptyhtml" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-emptyhtml" style="display:none">Info about the 'emptyHTML' definition.</span><b><a href="#dom-trustedtypepolicyfactory-emptyhtml">#dom-trustedtypepolicyfactory-emptyhtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-emptyhtml">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-emptyscript">
-   <b><a href="#dom-trustedtypepolicyfactory-emptyscript">#dom-trustedtypepolicyfactory-emptyscript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-emptyscript" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-emptyscript" id="infopanel-for-dom-trustedtypepolicyfactory-emptyscript" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-emptyscript" style="display:none">Info about the 'emptyScript' definition.</span><b><a href="#dom-trustedtypepolicyfactory-emptyscript">#dom-trustedtypepolicyfactory-emptyscript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-emptyscript">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyfactory-defaultpolicy">
-   <b><a href="#dom-trustedtypepolicyfactory-defaultpolicy">#dom-trustedtypepolicyfactory-defaultpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyfactory-defaultpolicy" class="dfn-panel" data-for="dom-trustedtypepolicyfactory-defaultpolicy" id="infopanel-for-dom-trustedtypepolicyfactory-defaultpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyfactory-defaultpolicy" style="display:none">Info about the 'defaultPolicy' definition.</span><b><a href="#dom-trustedtypepolicyfactory-defaultpolicy">#dom-trustedtypepolicyfactory-defaultpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyfactory-defaultpolicy">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedtypepolicy">
-   <b><a href="#trustedtypepolicy">#trustedtypepolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedtypepolicy" class="dfn-panel" data-for="trustedtypepolicy" id="infopanel-for-trustedtypepolicy" role="dialog">
+   <span id="infopaneltitle-for-trustedtypepolicy" style="display:none">Info about the 'TrustedTypePolicy' definition.</span><b><a href="#trustedtypepolicy">#trustedtypepolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedtypepolicy">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-trustedtypepolicy①">2.2.2. TrustedScript</a>
@@ -4639,83 +4639,83 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trustedtypepolicy①②">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trustedtypepolicy-name">
-   <b><a href="#trustedtypepolicy-name">#trustedtypepolicy-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trustedtypepolicy-name" class="dfn-panel" data-for="trustedtypepolicy-name" id="infopanel-for-trustedtypepolicy-name" role="dialog">
+   <span id="infopaneltitle-for-trustedtypepolicy-name" style="display:none">Info about the 'name' definition.</span><b><a href="#trustedtypepolicy-name">#trustedtypepolicy-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trustedtypepolicy-name">2.3.4. Default policy</a>
     <li><a href="#ref-for-trustedtypepolicy-name①">3.2. Create a Trusted Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicy-createhtml">
-   <b><a href="#dom-trustedtypepolicy-createhtml">#dom-trustedtypepolicy-createhtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicy-createhtml" class="dfn-panel" data-for="dom-trustedtypepolicy-createhtml" id="infopanel-for-dom-trustedtypepolicy-createhtml" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicy-createhtml" style="display:none">Info about the 'createHTML(input, ...arguments)' definition.</span><b><a href="#dom-trustedtypepolicy-createhtml">#dom-trustedtypepolicy-createhtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicy-createhtml">2.2.1. TrustedHTML</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createhtml①">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createhtml②">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicy-createscript">
-   <b><a href="#dom-trustedtypepolicy-createscript">#dom-trustedtypepolicy-createscript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicy-createscript" class="dfn-panel" data-for="dom-trustedtypepolicy-createscript" id="infopanel-for-dom-trustedtypepolicy-createscript" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicy-createscript" style="display:none">Info about the 'createScript(input, ...arguments)' definition.</span><b><a href="#dom-trustedtypepolicy-createscript">#dom-trustedtypepolicy-createscript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscript">2.2.2. TrustedScript</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscript①">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscript②">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicy-createscripturl">
-   <b><a href="#dom-trustedtypepolicy-createscripturl">#dom-trustedtypepolicy-createscripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicy-createscripturl" class="dfn-panel" data-for="dom-trustedtypepolicy-createscripturl" id="infopanel-for-dom-trustedtypepolicy-createscripturl" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicy-createscripturl" style="display:none">Info about the 'createScriptURL(input, ...arguments)' definition.</span><b><a href="#dom-trustedtypepolicy-createscripturl">#dom-trustedtypepolicy-createscripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscripturl">2.2.3. TrustedScriptURL</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscripturl①">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-dom-trustedtypepolicy-createscripturl②">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-trustedtypepolicyoptions">
-   <b><a href="#dictdef-trustedtypepolicyoptions">#dictdef-trustedtypepolicyoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-trustedtypepolicyoptions" class="dfn-panel" data-for="dictdef-trustedtypepolicyoptions" id="infopanel-for-dictdef-trustedtypepolicyoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-trustedtypepolicyoptions" style="display:none">Info about the 'TrustedTypePolicyOptions' definition.</span><b><a href="#dictdef-trustedtypepolicyoptions">#dictdef-trustedtypepolicyoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-trustedtypepolicyoptions">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-dictdef-trustedtypepolicyoptions①">(2)</a>
     <li><a href="#ref-for-dictdef-trustedtypepolicyoptions②">2.3.2. TrustedTypePolicy</a>
     <li><a href="#ref-for-dictdef-trustedtypepolicyoptions③">3.1. Create a Trusted Type Policy</a> <a href="#ref-for-dictdef-trustedtypepolicyoptions④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createhtml">
-   <b><a href="#dom-trustedtypepolicyoptions-createhtml">#dom-trustedtypepolicyoptions-createhtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyoptions-createhtml" class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createhtml" id="infopanel-for-dom-trustedtypepolicyoptions-createhtml" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyoptions-createhtml" style="display:none">Info about the 'createHTML' definition.</span><b><a href="#dom-trustedtypepolicyoptions-createhtml">#dom-trustedtypepolicyoptions-createhtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyoptions-createhtml">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createscript">
-   <b><a href="#dom-trustedtypepolicyoptions-createscript">#dom-trustedtypepolicyoptions-createscript</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyoptions-createscript" class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createscript" id="infopanel-for-dom-trustedtypepolicyoptions-createscript" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyoptions-createscript" style="display:none">Info about the 'createScript' definition.</span><b><a href="#dom-trustedtypepolicyoptions-createscript">#dom-trustedtypepolicyoptions-createscript</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyoptions-createscript">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createscripturl">
-   <b><a href="#dom-trustedtypepolicyoptions-createscripturl">#dom-trustedtypepolicyoptions-createscripturl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-trustedtypepolicyoptions-createscripturl" class="dfn-panel" data-for="dom-trustedtypepolicyoptions-createscripturl" id="infopanel-for-dom-trustedtypepolicyoptions-createscripturl" role="dialog">
+   <span id="infopaneltitle-for-dom-trustedtypepolicyoptions-createscripturl" style="display:none">Info about the 'createScriptURL' definition.</span><b><a href="#dom-trustedtypepolicyoptions-createscripturl">#dom-trustedtypepolicyoptions-createscripturl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-trustedtypepolicyoptions-createscripturl">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-createhtmlcallback">
-   <b><a href="#callbackdef-createhtmlcallback">#callbackdef-createhtmlcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-createhtmlcallback" class="dfn-panel" data-for="callbackdef-createhtmlcallback" id="infopanel-for-callbackdef-createhtmlcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-createhtmlcallback" style="display:none">Info about the 'CreateHTMLCallback' definition.</span><b><a href="#callbackdef-createhtmlcallback">#callbackdef-createhtmlcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-createhtmlcallback">2.3.3. TrustedTypePolicyOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-createscriptcallback">
-   <b><a href="#callbackdef-createscriptcallback">#callbackdef-createscriptcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-createscriptcallback" class="dfn-panel" data-for="callbackdef-createscriptcallback" id="infopanel-for-callbackdef-createscriptcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-createscriptcallback" style="display:none">Info about the 'CreateScriptCallback' definition.</span><b><a href="#callbackdef-createscriptcallback">#callbackdef-createscriptcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-createscriptcallback">2.3.3. TrustedTypePolicyOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-createscripturlcallback">
-   <b><a href="#callbackdef-createscripturlcallback">#callbackdef-createscripturlcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-createscripturlcallback" class="dfn-panel" data-for="callbackdef-createscripturlcallback" id="infopanel-for-callbackdef-createscripturlcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-createscripturlcallback" style="display:none">Info about the 'CreateScriptURLCallback' definition.</span><b><a href="#callbackdef-createscripturlcallback">#callbackdef-createscripturlcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-createscripturlcallback">2.3.3. TrustedTypePolicyOptions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-policy">
-   <b><a href="#default-policy">#default-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-policy" class="dfn-panel" data-for="default-policy" id="infopanel-for-default-policy" role="dialog">
+   <span id="infopaneltitle-for-default-policy" style="display:none">Info about the 'Default policy' definition.</span><b><a href="#default-policy">#default-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-policy">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
     <li><a href="#ref-for-default-policy①">4.8.2. trusted-types directive</a>
@@ -4724,8 +4724,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-default-policy④">7.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enforcement">
-   <b><a href="#enforcement">#enforcement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enforcement" class="dfn-panel" data-for="enforcement" id="infopanel-for-enforcement" role="dialog">
+   <span id="infopaneltitle-for-enforcement" style="display:none">Info about the 'Enforcement' definition.</span><b><a href="#enforcement">#enforcement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforcement">1.3. Use cases</a>
     <li><a href="#ref-for-enforcement①">2.1. Injection sinks</a>
@@ -4735,21 +4735,21 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-enforcement⑥">3.3. Get Trusted Type compliant string</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type-policy">
-   <b><a href="#abstract-opdef-create-a-trusted-type-policy">#abstract-opdef-create-a-trusted-type-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-trusted-type-policy" class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type-policy" id="infopanel-for-abstract-opdef-create-a-trusted-type-policy" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-trusted-type-policy" style="display:none">Info about the 'Create a Trusted Type Policy' definition.</span><b><a href="#abstract-opdef-create-a-trusted-type-policy">#abstract-opdef-create-a-trusted-type-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-trusted-type-policy">2.3.1. TrustedTypePolicyFactory</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type">
-   <b><a href="#abstract-opdef-create-a-trusted-type">#abstract-opdef-create-a-trusted-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-create-a-trusted-type" class="dfn-panel" data-for="abstract-opdef-create-a-trusted-type" id="infopanel-for-abstract-opdef-create-a-trusted-type" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-create-a-trusted-type" style="display:none">Info about the 'Create a Trusted Type' definition.</span><b><a href="#abstract-opdef-create-a-trusted-type">#abstract-opdef-create-a-trusted-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-create-a-trusted-type">2.3.2. TrustedTypePolicy</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type①">(2)</a> <a href="#ref-for-abstract-opdef-create-a-trusted-type②">(3)</a>
     <li><a href="#ref-for-abstract-opdef-create-a-trusted-type③">3.4. Process value with a default policy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-get-trusted-type-compliant-string">
-   <b><a href="#abstract-opdef-get-trusted-type-compliant-string">#abstract-opdef-get-trusted-type-compliant-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-get-trusted-type-compliant-string" class="dfn-panel" data-for="abstract-opdef-get-trusted-type-compliant-string" id="infopanel-for-abstract-opdef-get-trusted-type-compliant-string" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-get-trusted-type-compliant-string" style="display:none">Info about the 'Get Trusted Type compliant string' definition.</span><b><a href="#abstract-opdef-get-trusted-type-compliant-string">#abstract-opdef-get-trusted-type-compliant-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string">3.2. Create a Trusted Type</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string①">3.5. Prepare the script URL and text</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string②">(2)</a>
@@ -4760,36 +4760,36 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">4.8.6. Support for dynamic code compilation</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-process-value-with-a-default-policy">
-   <b><a href="#abstract-opdef-process-value-with-a-default-policy">#abstract-opdef-process-value-with-a-default-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-process-value-with-a-default-policy" class="dfn-panel" data-for="abstract-opdef-process-value-with-a-default-policy" id="infopanel-for-abstract-opdef-process-value-with-a-default-policy" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-process-value-with-a-default-policy" style="display:none">Info about the 'Process value with a default policy' definition.</span><b><a href="#abstract-opdef-process-value-with-a-default-policy">#abstract-opdef-process-value-with-a-default-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-process-value-with-a-default-policy">3.3. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-abstract-opdef-process-value-with-a-default-policy①">4.8.1.1. require-trusted-types-for Pre-Navigation check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-prepare-the-script-url-and-text">
-   <b><a href="#abstract-opdef-prepare-the-script-url-and-text">#abstract-opdef-prepare-the-script-url-and-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-prepare-the-script-url-and-text" class="dfn-panel" data-for="abstract-opdef-prepare-the-script-url-and-text" id="infopanel-for-abstract-opdef-prepare-the-script-url-and-text" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-prepare-the-script-url-and-text" style="display:none">Info about the 'Prepare the script URL and text' definition.</span><b><a href="#abstract-opdef-prepare-the-script-url-and-text">#abstract-opdef-prepare-the-script-url-and-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-prepare-the-script-url-and-text">4.3.3.3. Slot value verification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-htmlstring">
-   <b><a href="#typedefdef-htmlstring">#typedefdef-htmlstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-htmlstring" class="dfn-panel" data-for="typedefdef-htmlstring" id="infopanel-for-typedefdef-htmlstring" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-htmlstring" style="display:none">Info about the 'HTMLString' definition.</span><b><a href="#typedefdef-htmlstring">#typedefdef-htmlstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-htmlstring">4.3.2. Extensions to the Document interface</a> <a href="#ref-for-typedefdef-htmlstring①">(2)</a>
     <li><a href="#ref-for-typedefdef-htmlstring②">4.3.4. Enforcement in element attributes</a>
     <li><a href="#ref-for-typedefdef-htmlstring③">4.7. Integration with DOM Parsing</a> <a href="#ref-for-typedefdef-htmlstring④">(2)</a> <a href="#ref-for-typedefdef-htmlstring⑤">(3)</a> <a href="#ref-for-typedefdef-htmlstring⑥">(4)</a> <a href="#ref-for-typedefdef-htmlstring⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-scriptstring">
-   <b><a href="#typedefdef-scriptstring">#typedefdef-scriptstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-scriptstring" class="dfn-panel" data-for="typedefdef-scriptstring" id="infopanel-for-typedefdef-scriptstring" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-scriptstring" style="display:none">Info about the 'ScriptString' definition.</span><b><a href="#typedefdef-scriptstring">#typedefdef-scriptstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-scriptstring">4.3.3.2. Setting slot values</a> <a href="#ref-for-typedefdef-scriptstring①">(2)</a> <a href="#ref-for-typedefdef-scriptstring②">(3)</a>
     <li><a href="#ref-for-typedefdef-scriptstring③">4.3.5. Enforcement in timer functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-scripturlstring">
-   <b><a href="#typedefdef-scripturlstring">#typedefdef-scripturlstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-scripturlstring" class="dfn-panel" data-for="typedefdef-scripturlstring" id="infopanel-for-typedefdef-scripturlstring" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-scripturlstring" style="display:none">Info about the 'ScriptURLString' definition.</span><b><a href="#typedefdef-scripturlstring">#typedefdef-scripturlstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-scripturlstring">4.3.3.2. Setting slot values</a>
     <li><a href="#ref-for-typedefdef-scripturlstring①">4.3.4. Enforcement in element attributes</a> <a href="#ref-for-typedefdef-scripturlstring②">(2)</a> <a href="#ref-for-typedefdef-scripturlstring③">(3)</a>
@@ -4797,16 +4797,16 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-typedefdef-scripturlstring⑧">4.4. Integration with Service Workers</a> <a href="#ref-for-typedefdef-scripturlstring⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-trustedtype">
-   <b><a href="#typedefdef-trustedtype">#typedefdef-trustedtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-trustedtype" class="dfn-panel" data-for="typedefdef-trustedtype" id="infopanel-for-typedefdef-trustedtype" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-trustedtype" style="display:none">Info about the 'TrustedType' definition.</span><b><a href="#typedefdef-trustedtype">#typedefdef-trustedtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-trustedtype">3.3. Get Trusted Type compliant string</a> <a href="#ref-for-typedefdef-trustedtype①">(2)</a>
     <li><a href="#ref-for-typedefdef-trustedtype②">3.4. Process value with a default policy</a> <a href="#ref-for-typedefdef-trustedtype③">(2)</a>
     <li><a href="#ref-for-typedefdef-trustedtype④">4.3.5. Enforcement in timer functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="StringContext">
-   <b><a href="#StringContext">#StringContext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-StringContext" class="dfn-panel" data-for="StringContext" id="infopanel-for-StringContext" role="dialog">
+   <span id="infopaneltitle-for-StringContext" style="display:none">Info about the '4.2. [StringContext]' definition.</span><b><a href="#StringContext">#StringContext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-StringContext">2.3.1. TrustedTypePolicyFactory</a> <a href="#ref-for-StringContext①">(2)</a> <a href="#ref-for-StringContext②">(3)</a> <a href="#ref-for-StringContext③">(4)</a>
     <li><a href="#ref-for-StringContext④">4. Integrations</a> <a href="#ref-for-StringContext⑤">(2)</a> <a href="#ref-for-StringContext⑥">(3)</a>
@@ -4818,109 +4818,109 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-StringContext②④">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="related-construct">
-   <b><a href="#related-construct">#related-construct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-related-construct" class="dfn-panel" data-for="related-construct" id="infopanel-for-related-construct" role="dialog">
+   <span id="infopaneltitle-for-related-construct" style="display:none">Info about the 'related construct' definition.</span><b><a href="#related-construct">#related-construct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-related-construct">4.2.2. Type conversion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn-validate-the-string-in-context">
-   <b><a href="#dfn-validate-the-string-in-context">#dfn-validate-the-string-in-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn-validate-the-string-in-context" class="dfn-panel" data-for="dfn-validate-the-string-in-context" id="infopanel-for-dfn-validate-the-string-in-context" role="dialog">
+   <span id="infopaneltitle-for-dfn-validate-the-string-in-context" style="display:none">Info about the 'validate the string in context' definition.</span><b><a href="#dfn-validate-the-string-in-context">#dfn-validate-the-string-in-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-validate-the-string-in-context">4.2.2. Type conversion</a>
     <li><a href="#ref-for-dfn-validate-the-string-in-context①">4.3.7. Validate the string in context</a> <a href="#ref-for-dfn-validate-the-string-in-context②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="window-trusted-type-policy-factory">
-   <b><a href="#window-trusted-type-policy-factory">#window-trusted-type-policy-factory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-trusted-type-policy-factory" class="dfn-panel" data-for="window-trusted-type-policy-factory" id="infopanel-for-window-trusted-type-policy-factory" role="dialog">
+   <span id="infopaneltitle-for-window-trusted-type-policy-factory" style="display:none">Info about the 'trusted type policy factory' definition.</span><b><a href="#window-trusted-type-policy-factory">#window-trusted-type-policy-factory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-trusted-type-policy-factory">3.4. Process value with a default policy</a>
     <li><a href="#ref-for-window-trusted-type-policy-factory①">4.3.7. Validate the string in context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-windoworworkerglobalscope-trustedtypes">
-   <b><a href="#dom-windoworworkerglobalscope-trustedtypes">#dom-windoworworkerglobalscope-trustedtypes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-windoworworkerglobalscope-trustedtypes" class="dfn-panel" data-for="dom-windoworworkerglobalscope-trustedtypes" id="infopanel-for-dom-windoworworkerglobalscope-trustedtypes" role="dialog">
+   <span id="infopaneltitle-for-dom-windoworworkerglobalscope-trustedtypes" style="display:none">Info about the 'trustedTypes' definition.</span><b><a href="#dom-windoworworkerglobalscope-trustedtypes">#dom-windoworworkerglobalscope-trustedtypes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-trustedtypes">2.4. Enforcement</a>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-trustedtypes①">4.3.1. Extensions to the WindowOrWorkerGlobalScope interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-write">
-   <b><a href="#dom-document-write">#dom-document-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-write" class="dfn-panel" data-for="dom-document-write" id="infopanel-for-dom-document-write" role="dialog">
+   <span id="infopaneltitle-for-dom-document-write" style="display:none">Info about the 'write' definition.</span><b><a href="#dom-document-write">#dom-document-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-write">2.1.1. HTML injection sinks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlscriptelement-scripturl-slot">
-   <b><a href="#dom-htmlscriptelement-scripturl-slot">#dom-htmlscriptelement-scripturl-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlscriptelement-scripturl-slot" class="dfn-panel" data-for="dom-htmlscriptelement-scripturl-slot" id="infopanel-for-dom-htmlscriptelement-scripturl-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlscriptelement-scripturl-slot" style="display:none">Info about the '[[ScriptURL]]' definition.</span><b><a href="#dom-htmlscriptelement-scripturl-slot">#dom-htmlscriptelement-scripturl-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlscriptelement-scripturl-slot">3.5. Prepare the script URL and text</a> <a href="#ref-for-dom-htmlscriptelement-scripturl-slot①">(2)</a> <a href="#ref-for-dom-htmlscriptelement-scripturl-slot②">(3)</a>
     <li><a href="#ref-for-dom-htmlscriptelement-scripturl-slot③">4.3.3.1. Slots with trusted values</a>
     <li><a href="#ref-for-dom-htmlscriptelement-scripturl-slot④">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlscriptelement-scripttext-slot">
-   <b><a href="#dom-htmlscriptelement-scripttext-slot">#dom-htmlscriptelement-scripttext-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlscriptelement-scripttext-slot" class="dfn-panel" data-for="dom-htmlscriptelement-scripttext-slot" id="infopanel-for-dom-htmlscriptelement-scripttext-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlscriptelement-scripttext-slot" style="display:none">Info about the '[[ScriptText]]' definition.</span><b><a href="#dom-htmlscriptelement-scripttext-slot">#dom-htmlscriptelement-scripttext-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlscriptelement-scripttext-slot">3.5. Prepare the script URL and text</a> <a href="#ref-for-dom-htmlscriptelement-scripttext-slot①">(2)</a>
     <li><a href="#ref-for-dom-htmlscriptelement-scripttext-slot②">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlscriptelement-src">
-   <b><a href="#dom-htmlscriptelement-src">#dom-htmlscriptelement-src</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlscriptelement-src" class="dfn-panel" data-for="dom-htmlscriptelement-src" id="infopanel-for-dom-htmlscriptelement-src" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlscriptelement-src" style="display:none">Info about the 'src' definition.</span><b><a href="#dom-htmlscriptelement-src">#dom-htmlscriptelement-src</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlscriptelement-src">2.1.2. DOM XSS injection sinks</a>
     <li><a href="#ref-for-dom-htmlscriptelement-src①">4.3.3.1. Slots with trusted values</a>
     <li><a href="#ref-for-dom-htmlscriptelement-src②">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlscriptelement-text">
-   <b><a href="#dom-htmlscriptelement-text">#dom-htmlscriptelement-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlscriptelement-text" class="dfn-panel" data-for="dom-htmlscriptelement-text" id="infopanel-for-dom-htmlscriptelement-text" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlscriptelement-text" style="display:none">Info about the 'text' definition.</span><b><a href="#dom-htmlscriptelement-text">#dom-htmlscriptelement-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlscriptelement-text">2.1.2. DOM XSS injection sinks</a>
     <li><a href="#ref-for-dom-htmlscriptelement-text①">4.3.3.2. Setting slot values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-trustedtimerhandler">
-   <b><a href="#typedefdef-trustedtimerhandler">#typedefdef-trustedtimerhandler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-trustedtimerhandler" class="dfn-panel" data-for="typedefdef-trustedtimerhandler" id="infopanel-for-typedefdef-trustedtimerhandler" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-trustedtimerhandler" style="display:none">Info about the 'TrustedTimerHandler' definition.</span><b><a href="#typedefdef-trustedtimerhandler">#typedefdef-trustedtimerhandler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-trustedtimerhandler">4.3.5. Enforcement in timer functions</a> <a href="#ref-for-typedefdef-trustedtimerhandler①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-workerglobalscope-importscripts">
-   <b><a href="#dom-workerglobalscope-importscripts">#dom-workerglobalscope-importscripts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-workerglobalscope-importscripts" class="dfn-panel" data-for="dom-workerglobalscope-importscripts" id="infopanel-for-dom-workerglobalscope-importscripts" role="dialog">
+   <span id="infopaneltitle-for-dom-workerglobalscope-importscripts" style="display:none">Info about the 'importScripts' definition.</span><b><a href="#dom-workerglobalscope-importscripts">#dom-workerglobalscope-importscripts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-workerglobalscope-importscripts">4.3.8. Web Workers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-svganimatedstring-baseval">
-   <b><a href="#dom-svganimatedstring-baseval">#dom-svganimatedstring-baseval</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-svganimatedstring-baseval" class="dfn-panel" data-for="dom-svganimatedstring-baseval" id="infopanel-for-dom-svganimatedstring-baseval" role="dialog">
+   <span id="infopaneltitle-for-dom-svganimatedstring-baseval" style="display:none">Info about the 'baseVal' definition.</span><b><a href="#dom-svganimatedstring-baseval">#dom-svganimatedstring-baseval</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-svganimatedstring-baseval">4.5. Integration with SVG</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-validation-ext">
-   <b><a href="#concept-element-attributes-validation-ext">#concept-element-attributes-validation-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-validation-ext" class="dfn-panel" data-for="concept-element-attributes-validation-ext" id="infopanel-for-concept-element-attributes-validation-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-validation-ext" style="display:none">Info about the 'attribute validation steps' definition.</span><b><a href="#concept-element-attributes-validation-ext">#concept-element-attributes-validation-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-validation-ext">4.6. Integration with DOM</a> <a href="#ref-for-concept-element-attributes-validation-ext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domparser-parsefromstring">
-   <b><a href="#dom-domparser-parsefromstring">#dom-domparser-parsefromstring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domparser-parsefromstring" class="dfn-panel" data-for="dom-domparser-parsefromstring" id="infopanel-for-dom-domparser-parsefromstring" role="dialog">
+   <span id="infopaneltitle-for-dom-domparser-parsefromstring" style="display:none">Info about the 'parseFromString' definition.</span><b><a href="#dom-domparser-parsefromstring">#dom-domparser-parsefromstring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domparser-parsefromstring">2.1.1. HTML injection sinks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="require-trusted-types-for-directive">
-   <b><a href="#require-trusted-types-for-directive">#require-trusted-types-for-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-require-trusted-types-for-directive" class="dfn-panel" data-for="require-trusted-types-for-directive" id="infopanel-for-require-trusted-types-for-directive" role="dialog">
+   <span id="infopaneltitle-for-require-trusted-types-for-directive" style="display:none">Info about the 'require-trusted-types-for' definition.</span><b><a href="#require-trusted-types-for-directive">#require-trusted-types-for-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-require-trusted-types-for-directive">2.4.1. Content Security Policy</a>
     <li><a href="#ref-for-require-trusted-types-for-directive①">4.8.1. require-trusted-types-for directive</a>
     <li><a href="#ref-for-require-trusted-types-for-directive②">4.8.1.1. require-trusted-types-for Pre-Navigation check</a> <a href="#ref-for-require-trusted-types-for-directive③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trusted-types-sink-group">
-   <b><a href="#trusted-types-sink-group">#trusted-types-sink-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trusted-types-sink-group" class="dfn-panel" data-for="trusted-types-sink-group" id="infopanel-for-trusted-types-sink-group" role="dialog">
+   <span id="infopaneltitle-for-trusted-types-sink-group" style="display:none">Info about the 'trusted-types-sink-group' definition.</span><b><a href="#trusted-types-sink-group">#trusted-types-sink-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trusted-types-sink-group">2.1. Injection sinks</a>
     <li><a href="#ref-for-trusted-types-sink-group①">2.1.1. HTML injection sinks</a>
@@ -4930,113 +4930,169 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-trusted-types-sink-group⑥">4.8.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trusted-types-directive">
-   <b><a href="#trusted-types-directive">#trusted-types-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trusted-types-directive" class="dfn-panel" data-for="trusted-types-directive" id="infopanel-for-trusted-types-directive" role="dialog">
+   <span id="infopaneltitle-for-trusted-types-directive" style="display:none">Info about the 'trusted-types' definition.</span><b><a href="#trusted-types-directive">#trusted-types-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trusted-types-directive">2.3.1. TrustedTypePolicyFactory</a>
     <li><a href="#ref-for-trusted-types-directive①">4.8.2. trusted-types directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialized-tt-configuration">
-   <b><a href="#serialized-tt-configuration">#serialized-tt-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialized-tt-configuration" class="dfn-panel" data-for="serialized-tt-configuration" id="infopanel-for-serialized-tt-configuration" role="dialog">
+   <span id="infopaneltitle-for-serialized-tt-configuration" style="display:none">Info about the 'serialized-tt-configuration' definition.</span><b><a href="#serialized-tt-configuration">#serialized-tt-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialized-tt-configuration">4.8.2. trusted-types directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tt-expression">
-   <b><a href="#tt-expression">#tt-expression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tt-expression" class="dfn-panel" data-for="tt-expression" id="infopanel-for-tt-expression" role="dialog">
+   <span id="infopaneltitle-for-tt-expression" style="display:none">Info about the 'tt-expression' definition.</span><b><a href="#tt-expression">#tt-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tt-expression">4.8.2. trusted-types directive</a> <a href="#ref-for-tt-expression①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tt-wildcard">
-   <b><a href="#tt-wildcard">#tt-wildcard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tt-wildcard" class="dfn-panel" data-for="tt-wildcard" id="infopanel-for-tt-wildcard" role="dialog">
+   <span id="infopaneltitle-for-tt-wildcard" style="display:none">Info about the 'tt-wildcard' definition.</span><b><a href="#tt-wildcard">#tt-wildcard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tt-wildcard">4.8.2. trusted-types directive</a>
     <li><a href="#ref-for-tt-wildcard①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tt-policy-name">
-   <b><a href="#tt-policy-name">#tt-policy-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tt-policy-name" class="dfn-panel" data-for="tt-policy-name" id="infopanel-for-tt-policy-name" role="dialog">
+   <span id="infopaneltitle-for-tt-policy-name" style="display:none">Info about the 'tt-policy-name' definition.</span><b><a href="#tt-policy-name">#tt-policy-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tt-policy-name">4.8.2. trusted-types directive</a>
     <li><a href="#ref-for-tt-policy-name①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tt-keyword">
-   <b><a href="#tt-keyword">#tt-keyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tt-keyword" class="dfn-panel" data-for="tt-keyword" id="infopanel-for-tt-keyword" role="dialog">
+   <span id="infopaneltitle-for-tt-keyword" style="display:none">Info about the 'tt-keyword' definition.</span><b><a href="#tt-keyword">#tt-keyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tt-keyword">4.8.2. trusted-types directive</a>
     <li><a href="#ref-for-tt-keyword①">4.8.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a> <a href="#ref-for-tt-keyword②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">
-   <b><a href="#abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">#abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy" class="dfn-panel" data-for="abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy" id="infopanel-for-abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy" style="display:none">Info about the 'Should sink type mismatch violation be blocked by Content Security Policy?' definition.</span><b><a href="#abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">#abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-should-sink-type-mismatch-violation-be-blocked-by-content-security-policy">3.3. Get Trusted Type compliant string</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">
-   <b><a href="#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy" class="dfn-panel" data-for="abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy" id="infopanel-for-abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy" style="display:none">Info about the 'Should Trusted Type policy creation be blocked by Content Security Policy?' definition.</span><b><a href="#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">3.1. Create a Trusted Type Policy</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webappsec-uisecurity/index.html
+++ b/tests/github/w3c/webappsec-uisecurity/index.html
@@ -1062,51 +1062,51 @@ directive-value   = ['area-threshold=' num-val]
    <li><a href="#visible-margin">visible-margin</a><span>, in § 4.1.1</span>
    <li><a href="#dom-visibilityobserverinit-visiblemargin">visibleMargin</a><span>, in § 3.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-domhighrestimestamp">
-   <a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domhighrestimestamp" class="dfn-panel" data-for="term-for-domhighrestimestamp" id="infopanel-for-term-for-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="http://www.w3.org/TR/hr-time/#domhighrestimestamp">http://www.w3.org/TR/hr-time/#domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domhighrestimestamp">3.2. The VisibilityObserverEntry interface</a> <a href="#ref-for-domhighrestimestamp①">(2)</a> <a href="#ref-for-domhighrestimestamp②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-this-value">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value">https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-this-value" class="dfn-panel" data-for="term-for-dfn-callback-this-value" id="infopanel-for-term-for-dfn-callback-this-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value">https://html.spec.whatwg.org/multipage/infrastructure.html#dfn-callback-this-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">5.2.2. Notify VisibilityObservers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cancelled-flag">
-   <a href="https://dom.spec.whatwg.org/#cancelled-flag">https://dom.spec.whatwg.org/#cancelled-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cancelled-flag" class="dfn-panel" data-for="term-for-cancelled-flag" id="infopanel-for-term-for-cancelled-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-cancelled-flag" style="display:none">Info about the 'cancelled flag' external reference.</span><a href="https://dom.spec.whatwg.org/#cancelled-flag">https://dom.spec.whatwg.org/#cancelled-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancelled-flag">5.2.6. Handle a Violation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dispatching-events">
-   <a href="https://dom.spec.whatwg.org/#dispatching-events">https://dom.spec.whatwg.org/#dispatching-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dispatching-events" class="dfn-panel" data-for="term-for-dispatching-events" id="infopanel-for-term-for-dispatching-events" role="menu">
+   <span id="infopaneltitle-for-term-for-dispatching-events" style="display:none">Info about the 'dispatching events' external reference.</span><a href="https://dom.spec.whatwg.org/#dispatching-events">https://dom.spec.whatwg.org/#dispatching-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatching-events">5.2.5. Enforce An input-protection Directive</a>
     <li><a href="#termref-for-dispatching-events">5.3.2. DOM: Dispatching Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-list-of-idle-request-callbacks">
-   <a href="http://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks">http://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-list-of-idle-request-callbacks" class="dfn-panel" data-for="term-for-dfn-list-of-idle-request-callbacks" id="infopanel-for-term-for-dfn-list-of-idle-request-callbacks" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-list-of-idle-request-callbacks" style="display:none">Info about the 'list of idle request callbacks' external reference.</span><a href="http://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks">http://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-list-of-idle-request-callbacks">5.2.1. Queue a VisibilityObserver Task</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parent-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parent-browsing-context" class="dfn-panel" data-for="term-for-parent-browsing-context" id="infopanel-for-term-for-parent-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-parent-browsing-context" style="display:none">Info about the 'parent browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#parent-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-browsing-context">5.2.4. Promote Observed GraphicsLayers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">5.2.2. Notify VisibilityObservers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unit-of-related-similar-origin-browsing-contexts">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unit-of-related-similar-origin-browsing-contexts" class="dfn-panel" data-for="term-for-unit-of-related-similar-origin-browsing-contexts" id="infopanel-for-term-for-unit-of-related-similar-origin-browsing-contexts" role="menu">
+   <span id="infopaneltitle-for-term-for-unit-of-related-similar-origin-browsing-contexts" style="display:none">Info about the 'unit of related similar-origin browsing contexts' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts">https://html.spec.whatwg.org/multipage/browsers.html#unit-of-related-similar-origin-browsing-contexts</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unit-of-related-similar-origin-browsing-contexts">5.1.1. Browsing Contexts</a>
     <li><a href="#ref-for-unit-of-related-similar-origin-browsing-contexts①">5.2.1. Queue a VisibilityObserver Task</a>
@@ -1114,22 +1114,22 @@ directive-value   = ['area-threshold=' num-val]
     <li><a href="#ref-for-unit-of-related-similar-origin-browsing-contexts③">5.2.3. Queue a VisibilityObserverEntry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://www.w3.org/TR/css-box-4/#propdef-margin">https://www.w3.org/TR/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://www.w3.org/TR/css-box-4/#propdef-margin">https://www.w3.org/TR/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.4. The VisibilityObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://www.w3.org/TR/cssom-view-1/#dom-element-getboundingclientrect">https://www.w3.org/TR/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://www.w3.org/TR/cssom-view-1/#dom-element-getboundingclientrect">https://www.w3.org/TR/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">3.4. The VisibilityObserverInit dictionary</a> <a href="#ref-for-dom-element-getboundingclientrect①">(2)</a>
     <li><a href="#ref-for-dom-element-getboundingclientrect②">4.1.1. Directive Value</a>
     <li><a href="#ref-for-dom-element-getboundingclientrect③">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-dom-element-getboundingclientrect④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-document①">4.1.1. Directive Value</a>
@@ -1140,8 +1140,8 @@ directive-value   = ['area-threshold=' num-val]
     <li><a href="#ref-for-document⑧">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3.4. The VisibilityObserverInit dictionary</a> <a href="#ref-for-element①">(2)</a>
     <li><a href="#ref-for-element②">4.1.1. Directive Value</a>
@@ -1149,73 +1149,73 @@ directive-value   = ['area-threshold=' num-val]
     <li><a href="#ref-for-element④">5.2.5. Enforce An input-protection Directive</a> <a href="#ref-for-element⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.2.5. Enforce An input-protection Directive</a>
     <li><a href="#ref-for-event①">5.3.3. isUnsafe Attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-nonelementparentnode-getelementbyid">
-   <a href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-nonelementparentnode-getelementbyid" class="dfn-panel" data-for="term-for-dom-nonelementparentnode-getelementbyid" id="infopanel-for-term-for-dom-nonelementparentnode-getelementbyid" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-nonelementparentnode-getelementbyid" style="display:none">Info about the 'getElementById(elementId)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nonelementparentnode-getelementbyid">4.1.1. Directive Value</a>
     <li><a href="#ref-for-dom-nonelementparentnode-getelementbyid①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stop-propagation-flag">
-   <a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stop-propagation-flag" class="dfn-panel" data-for="term-for-stop-propagation-flag" id="infopanel-for-term-for-stop-propagation-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' external reference.</span><a href="https://dom.spec.whatwg.org/#stop-propagation-flag">https://dom.spec.whatwg.org/#stop-propagation-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">5.2.6. Handle a Violation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrect">
-   <a href="https://www.w3.org/TR/geometry-1/#domrect">https://www.w3.org/TR/geometry-1/#domrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrect" class="dfn-panel" data-for="term-for-domrect" id="infopanel-for-term-for-domrect" role="menu">
+   <span id="infopaneltitle-for-term-for-domrect" style="display:none">Info about the 'DOMRect' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#domrect">https://www.w3.org/TR/geometry-1/#domrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrect">3.2. The VisibilityObserverEntry interface</a> <a href="#ref-for-domrect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-domrectinit">
-   <a href="https://www.w3.org/TR/geometry-1/#dictdef-domrectinit">https://www.w3.org/TR/geometry-1/#dictdef-domrectinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-domrectinit" class="dfn-panel" data-for="term-for-dictdef-domrectinit" id="infopanel-for-term-for-dictdef-domrectinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-domrectinit" style="display:none">Info about the 'DOMRectInit' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#dictdef-domrectinit">https://www.w3.org/TR/geometry-1/#dictdef-domrectinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-domrectinit">3.2. The VisibilityObserverEntry interface</a> <a href="#ref-for-dictdef-domrectinit①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domrectreadonly">
-   <a href="https://www.w3.org/TR/geometry-1/#domrectreadonly">https://www.w3.org/TR/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domrectreadonly" class="dfn-panel" data-for="term-for-domrectreadonly" id="infopanel-for-term-for-domrectreadonly" role="menu">
+   <span id="infopaneltitle-for-term-for-domrectreadonly" style="display:none">Info about the 'DOMRectReadOnly' external reference.</span><a href="https://www.w3.org/TR/geometry-1/#domrectreadonly">https://www.w3.org/TR/geometry-1/#domrectreadonly</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domrectreadonly">3.2. The VisibilityObserverEntry interface</a> <a href="#ref-for-domrectreadonly①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-idl-DOMString①">4.1.1. Directive Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3.2. The VisibilityObserverEntry interface</a>
     <li><a href="#ref-for-Exposed①">3.3. The VisibilityObserver Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-idl-boolean①">5.3.3. isUnsafe Attribute</a> <a href="#ref-for-idl-boolean②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">3.4. The VisibilityObserverInit dictionary</a> <a href="#ref-for-idl-double①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3.1. The VisibilityObserverCallback</a>
     <li><a href="#ref-for-idl-sequence①">3.3. The VisibilityObserver Interface</a>
@@ -1334,48 +1334,48 @@ directive-value   = ['area-threshold=' num-val]
    <div class="issue"> need to also clip to any other layers that were promoted ahead of us! <a class="issue-return" href="#issue-6397a33f" title="Jump to section">↵</a></div>
    <div class="issue"> if a parent and child layer both request to be promoted, the parent’s clipping window will have a complex geometry with holes in it that is not accounted for by this algorithm.  Likely need to specify that graphics layers be processed by order of depth. <a class="issue-return" href="#issue-22658f2c" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="callbackdef-visibilityobservercallback">
-   <b><a href="#callbackdef-visibilityobservercallback">#callbackdef-visibilityobservercallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-visibilityobservercallback" class="dfn-panel" data-for="callbackdef-visibilityobservercallback" id="infopanel-for-callbackdef-visibilityobservercallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-visibilityobservercallback" style="display:none">Info about the 'VisibilityObserverCallback' definition.</span><b><a href="#callbackdef-visibilityobservercallback">#callbackdef-visibilityobservercallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-visibilityobservercallback">3.2. The VisibilityObserverEntry interface</a>
     <li><a href="#ref-for-callbackdef-visibilityobservercallback①">3.3. The VisibilityObserver Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visibilityobserverentry">
-   <b><a href="#visibilityobserverentry">#visibilityobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visibilityobserverentry" class="dfn-panel" data-for="visibilityobserverentry" id="infopanel-for-visibilityobserverentry" role="dialog">
+   <span id="infopaneltitle-for-visibilityobserverentry" style="display:none">Info about the 'VisibilityObserverEntry' definition.</span><b><a href="#visibilityobserverentry">#visibilityobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visibilityobserverentry">3.1. The VisibilityObserverCallback</a>
     <li><a href="#ref-for-visibilityobserverentry①">3.3. The VisibilityObserver Interface</a>
     <li><a href="#ref-for-visibilityobserverentry②">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-visibilityobserverentryinit">
-   <b><a href="#dictdef-visibilityobserverentryinit">#dictdef-visibilityobserverentryinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-visibilityobserverentryinit" class="dfn-panel" data-for="dictdef-visibilityobserverentryinit" id="infopanel-for-dictdef-visibilityobserverentryinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-visibilityobserverentryinit" style="display:none">Info about the 'VisibilityObserverEntryInit' definition.</span><b><a href="#dictdef-visibilityobserverentryinit">#dictdef-visibilityobserverentryinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-visibilityobserverentryinit">3.2. The VisibilityObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverentry-globalvisiblebounds">
-   <b><a href="#dom-visibilityobserverentry-globalvisiblebounds">#dom-visibilityobserverentry-globalvisiblebounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverentry-globalvisiblebounds" class="dfn-panel" data-for="dom-visibilityobserverentry-globalvisiblebounds" id="infopanel-for-dom-visibilityobserverentry-globalvisiblebounds" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverentry-globalvisiblebounds" style="display:none">Info about the 'globalVisibleBounds' definition.</span><b><a href="#dom-visibilityobserverentry-globalvisiblebounds">#dom-visibilityobserverentry-globalvisiblebounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverentry-globalvisiblebounds">3.2. The VisibilityObserverEntry interface</a> <a href="#ref-for-dom-visibilityobserverentry-globalvisiblebounds①">(2)</a> <a href="#ref-for-dom-visibilityobserverentry-globalvisiblebounds②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverentry-visiblebounds">
-   <b><a href="#dom-visibilityobserverentry-visiblebounds">#dom-visibilityobserverentry-visiblebounds</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverentry-visiblebounds" class="dfn-panel" data-for="dom-visibilityobserverentry-visiblebounds" id="infopanel-for-dom-visibilityobserverentry-visiblebounds" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverentry-visiblebounds" style="display:none">Info about the 'visibleBounds' definition.</span><b><a href="#dom-visibilityobserverentry-visiblebounds">#dom-visibilityobserverentry-visiblebounds</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverentry-visiblebounds">3.2. The VisibilityObserverEntry interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverentry-time">
-   <b><a href="#dom-visibilityobserverentry-time">#dom-visibilityobserverentry-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverentry-time" class="dfn-panel" data-for="dom-visibilityobserverentry-time" id="infopanel-for-dom-visibilityobserverentry-time" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverentry-time" style="display:none">Info about the 'time' definition.</span><b><a href="#dom-visibilityobserverentry-time">#dom-visibilityobserverentry-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverentry-time">3.2. The VisibilityObserverEntry interface</a>
     <li><a href="#ref-for-dom-visibilityobserverentry-time①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visibilityobserver">
-   <b><a href="#visibilityobserver">#visibilityobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visibilityobserver" class="dfn-panel" data-for="visibilityobserver" id="infopanel-for-visibilityobserver" role="dialog">
+   <span id="infopaneltitle-for-visibilityobserver" style="display:none">Info about the 'VisibilityObserver' definition.</span><b><a href="#visibilityobserver">#visibilityobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visibilityobserver">3.1. The VisibilityObserverCallback</a>
     <li><a href="#ref-for-visibilityobserver①">3.3. The VisibilityObserver Interface</a>
@@ -1384,125 +1384,125 @@ directive-value   = ['area-threshold=' num-val]
     <li><a href="#ref-for-visibilityobserver④">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-visibilityobserver">
-   <b><a href="#dom-visibilityobserver-visibilityobserver">#dom-visibilityobserver-visibilityobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-visibilityobserver" class="dfn-panel" data-for="dom-visibilityobserver-visibilityobserver" id="infopanel-for-dom-visibilityobserver-visibilityobserver" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-visibilityobserver" style="display:none">Info about the 'new VisibilityObserver(callback, options)' definition.</span><b><a href="#dom-visibilityobserver-visibilityobserver">#dom-visibilityobserver-visibilityobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-visibilityobserver">5.1.4. VisibilityObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-observe">
-   <b><a href="#dom-visibilityobserver-observe">#dom-visibilityobserver-observe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-observe" class="dfn-panel" data-for="dom-visibilityobserver-observe" id="infopanel-for-dom-visibilityobserver-observe" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-observe" style="display:none">Info about the 'observe()' definition.</span><b><a href="#dom-visibilityobserver-observe">#dom-visibilityobserver-observe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-observe">3.3. The VisibilityObserver Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-unobserve">
-   <b><a href="#dom-visibilityobserver-unobserve">#dom-visibilityobserver-unobserve</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-unobserve" class="dfn-panel" data-for="dom-visibilityobserver-unobserve" id="infopanel-for-dom-visibilityobserver-unobserve" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-unobserve" style="display:none">Info about the 'unobserve()' definition.</span><b><a href="#dom-visibilityobserver-unobserve">#dom-visibilityobserver-unobserve</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-unobserve">3.3. The VisibilityObserver Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-takerecords">
-   <b><a href="#dom-visibilityobserver-takerecords">#dom-visibilityobserver-takerecords</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-takerecords" class="dfn-panel" data-for="dom-visibilityobserver-takerecords" id="infopanel-for-dom-visibilityobserver-takerecords" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-takerecords" style="display:none">Info about the 'takeRecords()' definition.</span><b><a href="#dom-visibilityobserver-takerecords">#dom-visibilityobserver-takerecords</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-takerecords">3.3. The VisibilityObserver Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-visibilityobserverinit">
-   <b><a href="#dictdef-visibilityobserverinit">#dictdef-visibilityobserverinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-visibilityobserverinit" class="dfn-panel" data-for="dictdef-visibilityobserverinit" id="infopanel-for-dictdef-visibilityobserverinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-visibilityobserverinit" style="display:none">Info about the 'VisibilityObserverInit' definition.</span><b><a href="#dictdef-visibilityobserverinit">#dictdef-visibilityobserverinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-visibilityobserverinit">5.1.4. VisibilityObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverinit-areathreshold">
-   <b><a href="#dom-visibilityobserverinit-areathreshold">#dom-visibilityobserverinit-areathreshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverinit-areathreshold" class="dfn-panel" data-for="dom-visibilityobserverinit-areathreshold" id="infopanel-for-dom-visibilityobserverinit-areathreshold" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverinit-areathreshold" style="display:none">Info about the 'areaThreshold' definition.</span><b><a href="#dom-visibilityobserverinit-areathreshold">#dom-visibilityobserverinit-areathreshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverinit-areathreshold">3.4. The VisibilityObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverinit-displacementaware">
-   <b><a href="#dom-visibilityobserverinit-displacementaware">#dom-visibilityobserverinit-displacementaware</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverinit-displacementaware" class="dfn-panel" data-for="dom-visibilityobserverinit-displacementaware" id="infopanel-for-dom-visibilityobserverinit-displacementaware" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverinit-displacementaware" style="display:none">Info about the 'displacementAware' definition.</span><b><a href="#dom-visibilityobserverinit-displacementaware">#dom-visibilityobserverinit-displacementaware</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverinit-displacementaware">3.4. The VisibilityObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverinit-visiblemargin">
-   <b><a href="#dom-visibilityobserverinit-visiblemargin">#dom-visibilityobserverinit-visiblemargin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverinit-visiblemargin" class="dfn-panel" data-for="dom-visibilityobserverinit-visiblemargin" id="infopanel-for-dom-visibilityobserverinit-visiblemargin" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverinit-visiblemargin" style="display:none">Info about the 'visibleMargin' definition.</span><b><a href="#dom-visibilityobserverinit-visiblemargin">#dom-visibilityobserverinit-visiblemargin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverinit-visiblemargin">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-dom-visibilityobserverinit-visiblemargin①">4.1.1. Directive Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserverinit-observedelement">
-   <b><a href="#dom-visibilityobserverinit-observedelement">#dom-visibilityobserverinit-observedelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserverinit-observedelement" class="dfn-panel" data-for="dom-visibilityobserverinit-observedelement" id="infopanel-for-dom-visibilityobserverinit-observedelement" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserverinit-observedelement" style="display:none">Info about the 'observedElement' definition.</span><b><a href="#dom-visibilityobserverinit-observedelement">#dom-visibilityobserverinit-observedelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserverinit-observedelement">3.4. The VisibilityObserverInit dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="input-protection-directive">
-   <b><a href="#input-protection-directive">#input-protection-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-input-protection-directive" class="dfn-panel" data-for="input-protection-directive" id="infopanel-for-input-protection-directive" role="dialog">
+   <span id="infopaneltitle-for-input-protection-directive" style="display:none">Info about the 'input-protection Directive' definition.</span><b><a href="#input-protection-directive">#input-protection-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-input-protection-directive">5.1.4. VisibilityObserver</a>
     <li><a href="#ref-for-input-protection-directive①">5.2.5. Enforce An input-protection Directive</a>
     <li><a href="#ref-for-input-protection-directive②">5.2.6. Handle a Violation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="area-threshold">
-   <b><a href="#area-threshold">#area-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-area-threshold" class="dfn-panel" data-for="area-threshold" id="infopanel-for-area-threshold" role="dialog">
+   <span id="infopaneltitle-for-area-threshold" style="display:none">Info about the 'area-threshold' definition.</span><b><a href="#area-threshold">#area-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-area-threshold">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="protected-element">
-   <b><a href="#protected-element">#protected-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-protected-element" class="dfn-panel" data-for="protected-element" id="infopanel-for-protected-element" role="dialog">
+   <span id="infopaneltitle-for-protected-element" style="display:none">Info about the 'protected-element' definition.</span><b><a href="#protected-element">#protected-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-protected-element">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-protected-element①">4.1.1. Directive Value</a>
     <li><a href="#ref-for-protected-element②">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="time-threshold">
-   <b><a href="#time-threshold">#time-threshold</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-time-threshold" class="dfn-panel" data-for="time-threshold" id="infopanel-for-time-threshold" role="dialog">
+   <span id="infopaneltitle-for-time-threshold" style="display:none">Info about the 'time-threshold' definition.</span><b><a href="#time-threshold">#time-threshold</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time-threshold">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="visible-margin">
-   <b><a href="#visible-margin">#visible-margin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-visible-margin" class="dfn-panel" data-for="visible-margin" id="infopanel-for-visible-margin" role="dialog">
+   <span id="infopaneltitle-for-visible-margin" style="display:none">Info about the 'visible-margin' definition.</span><b><a href="#visible-margin">#visible-margin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visible-margin">4.1.1. Directive Value</a>
     <li><a href="#ref-for-visible-margin①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="browsing-context-visibilityobservertaskqueued">
-   <b><a href="#browsing-context-visibilityobservertaskqueued">#browsing-context-visibilityobservertaskqueued</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-browsing-context-visibilityobservertaskqueued" class="dfn-panel" data-for="browsing-context-visibilityobservertaskqueued" id="infopanel-for-browsing-context-visibilityobservertaskqueued" role="dialog">
+   <span id="infopaneltitle-for-browsing-context-visibilityobservertaskqueued" style="display:none">Info about the 'VisibilityObserverTaskQueued' definition.</span><b><a href="#browsing-context-visibilityobservertaskqueued">#browsing-context-visibilityobservertaskqueued</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-visibilityobservertaskqueued">5.2.1. Queue a VisibilityObserver Task</a> <a href="#ref-for-browsing-context-visibilityobservertaskqueued①">(2)</a>
     <li><a href="#ref-for-browsing-context-visibilityobservertaskqueued②">5.2.2. Notify VisibilityObservers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-inputprotectionobservers-slot">
-   <b><a href="#dom-element-inputprotectionobservers-slot">#dom-element-inputprotectionobservers-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-inputprotectionobservers-slot" class="dfn-panel" data-for="dom-element-inputprotectionobservers-slot" id="infopanel-for-dom-element-inputprotectionobservers-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-element-inputprotectionobservers-slot" style="display:none">Info about the '[[InputProtectionObservers]]' definition.</span><b><a href="#dom-element-inputprotectionobservers-slot">#dom-element-inputprotectionobservers-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-inputprotectionobservers-slot">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-registeredvisibilityobservers-slot">
-   <b><a href="#dom-document-registeredvisibilityobservers-slot">#dom-document-registeredvisibilityobservers-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-registeredvisibilityobservers-slot" class="dfn-panel" data-for="dom-document-registeredvisibilityobservers-slot" id="infopanel-for-dom-document-registeredvisibilityobservers-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-document-registeredvisibilityobservers-slot" style="display:none">Info about the '[[RegisteredVisibilityObservers]]' definition.</span><b><a href="#dom-document-registeredvisibilityobservers-slot">#dom-document-registeredvisibilityobservers-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-registeredvisibilityobservers-slot">3.3. The VisibilityObserver Interface</a> <a href="#ref-for-dom-document-registeredvisibilityobservers-slot①">(2)</a>
     <li><a href="#ref-for-dom-document-registeredvisibilityobservers-slot②">5.2.2. Notify VisibilityObservers</a>
     <li><a href="#ref-for-dom-document-registeredvisibilityobservers-slot③">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-dom-document-registeredvisibilityobservers-slot④">(2)</a> <a href="#ref-for-dom-document-registeredvisibilityobservers-slot⑤">(3)</a> <a href="#ref-for-dom-document-registeredvisibilityobservers-slot⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-inputprotectionrequested-slot">
-   <b><a href="#dom-document-inputprotectionrequested-slot">#dom-document-inputprotectionrequested-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-inputprotectionrequested-slot" class="dfn-panel" data-for="dom-document-inputprotectionrequested-slot" id="infopanel-for-dom-document-inputprotectionrequested-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-document-inputprotectionrequested-slot" style="display:none">Info about the '[[InputProtectionRequested]]' definition.</span><b><a href="#dom-document-inputprotectionrequested-slot">#dom-document-inputprotectionrequested-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-inputprotectionrequested-slot">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-queuedentries-slot">
-   <b><a href="#dom-visibilityobserver-queuedentries-slot">#dom-visibilityobserver-queuedentries-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-queuedentries-slot" class="dfn-panel" data-for="dom-visibilityobserver-queuedentries-slot" id="infopanel-for-dom-visibilityobserver-queuedentries-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-queuedentries-slot" style="display:none">Info about the '[[QueuedEntries]]' definition.</span><b><a href="#dom-visibilityobserver-queuedentries-slot">#dom-visibilityobserver-queuedentries-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-queuedentries-slot">3.3. The VisibilityObserver Interface</a> <a href="#ref-for-dom-visibilityobserver-queuedentries-slot①">(2)</a>
     <li><a href="#ref-for-dom-visibilityobserver-queuedentries-slot②">5.2.2. Notify VisibilityObservers</a> <a href="#ref-for-dom-visibilityobserver-queuedentries-slot③">(2)</a> <a href="#ref-for-dom-visibilityobserver-queuedentries-slot④">(3)</a>
@@ -1510,113 +1510,113 @@ directive-value   = ['area-threshold=' num-val]
     <li><a href="#ref-for-dom-visibilityobserver-queuedentries-slot⑥">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-previousvisibleratio-slot">
-   <b><a href="#dom-visibilityobserver-previousvisibleratio-slot">#dom-visibilityobserver-previousvisibleratio-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-previousvisibleratio-slot" class="dfn-panel" data-for="dom-visibilityobserver-previousvisibleratio-slot" id="infopanel-for-dom-visibilityobserver-previousvisibleratio-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-previousvisibleratio-slot" style="display:none">Info about the '[[previousVisibleRatio]]' definition.</span><b><a href="#dom-visibilityobserver-previousvisibleratio-slot">#dom-visibilityobserver-previousvisibleratio-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-previousvisibleratio-slot">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-dom-visibilityobserver-previousvisibleratio-slot①">(2)</a>
     <li><a href="#ref-for-dom-visibilityobserver-previousvisibleratio-slot②">5.2.5. Enforce An input-protection Directive</a> <a href="#ref-for-dom-visibilityobserver-previousvisibleratio-slot③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-previousglobalviewportposition-slot">
-   <b><a href="#dom-visibilityobserver-previousglobalviewportposition-slot">#dom-visibilityobserver-previousglobalviewportposition-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-previousglobalviewportposition-slot" class="dfn-panel" data-for="dom-visibilityobserver-previousglobalviewportposition-slot" id="infopanel-for-dom-visibilityobserver-previousglobalviewportposition-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-previousglobalviewportposition-slot" style="display:none">Info about the '[[previousGlobalViewportPosition]]' definition.</span><b><a href="#dom-visibilityobserver-previousglobalviewportposition-slot">#dom-visibilityobserver-previousglobalviewportposition-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-previousglobalviewportposition-slot">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-dom-visibilityobserver-previousglobalviewportposition-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-callback-slot">
-   <b><a href="#dom-visibilityobserver-callback-slot">#dom-visibilityobserver-callback-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-callback-slot" class="dfn-panel" data-for="dom-visibilityobserver-callback-slot" id="infopanel-for-dom-visibilityobserver-callback-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-callback-slot" style="display:none">Info about the '[[callback]]' definition.</span><b><a href="#dom-visibilityobserver-callback-slot">#dom-visibilityobserver-callback-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-callback-slot">3.3. The VisibilityObserver Interface</a>
     <li><a href="#ref-for-dom-visibilityobserver-callback-slot①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-areathreshold-slot">
-   <b><a href="#dom-visibilityobserver-areathreshold-slot">#dom-visibilityobserver-areathreshold-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-areathreshold-slot" class="dfn-panel" data-for="dom-visibilityobserver-areathreshold-slot" id="infopanel-for-dom-visibilityobserver-areathreshold-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-areathreshold-slot" style="display:none">Info about the '[[areaThreshold]]' definition.</span><b><a href="#dom-visibilityobserver-areathreshold-slot">#dom-visibilityobserver-areathreshold-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-areathreshold-slot">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-dom-visibilityobserver-areathreshold-slot①">(2)</a>
     <li><a href="#ref-for-dom-visibilityobserver-areathreshold-slot②">5.2.5. Enforce An input-protection Directive</a> <a href="#ref-for-dom-visibilityobserver-areathreshold-slot③">(2)</a> <a href="#ref-for-dom-visibilityobserver-areathreshold-slot④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-displacementaware-slot">
-   <b><a href="#dom-visibilityobserver-displacementaware-slot">#dom-visibilityobserver-displacementaware-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-displacementaware-slot" class="dfn-panel" data-for="dom-visibilityobserver-displacementaware-slot" id="infopanel-for-dom-visibilityobserver-displacementaware-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-displacementaware-slot" style="display:none">Info about the '[[displacementAware]]' definition.</span><b><a href="#dom-visibilityobserver-displacementaware-slot">#dom-visibilityobserver-displacementaware-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-displacementaware-slot">5.2.4. Promote Observed GraphicsLayers</a>
     <li><a href="#ref-for-dom-visibilityobserver-displacementaware-slot①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-visiblemargin-slot">
-   <b><a href="#dom-visibilityobserver-visiblemargin-slot">#dom-visibilityobserver-visiblemargin-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-visiblemargin-slot" class="dfn-panel" data-for="dom-visibilityobserver-visiblemargin-slot" id="infopanel-for-dom-visibilityobserver-visiblemargin-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-visiblemargin-slot" style="display:none">Info about the '[[visibleMargin]]' definition.</span><b><a href="#dom-visibilityobserver-visiblemargin-slot">#dom-visibilityobserver-visiblemargin-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-visiblemargin-slot">5.2.4. Promote Observed GraphicsLayers</a>
     <li><a href="#ref-for-dom-visibilityobserver-visiblemargin-slot①">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-observedelement-slot">
-   <b><a href="#dom-visibilityobserver-observedelement-slot">#dom-visibilityobserver-observedelement-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-observedelement-slot" class="dfn-panel" data-for="dom-visibilityobserver-observedelement-slot" id="infopanel-for-dom-visibilityobserver-observedelement-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-observedelement-slot" style="display:none">Info about the '[[observedElement]]' definition.</span><b><a href="#dom-visibilityobserver-observedelement-slot">#dom-visibilityobserver-observedelement-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-observedelement-slot">3.4. The VisibilityObserverInit dictionary</a>
     <li><a href="#ref-for-dom-visibilityobserver-observedelement-slot①">5.2.4. Promote Observed GraphicsLayers</a>
     <li><a href="#ref-for-dom-visibilityobserver-observedelement-slot②">5.2.5. Enforce An input-protection Directive</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-timethreshold-slot">
-   <b><a href="#dom-visibilityobserver-timethreshold-slot">#dom-visibilityobserver-timethreshold-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-timethreshold-slot" class="dfn-panel" data-for="dom-visibilityobserver-timethreshold-slot" id="infopanel-for-dom-visibilityobserver-timethreshold-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-timethreshold-slot" style="display:none">Info about the '[[timeThreshold]]' definition.</span><b><a href="#dom-visibilityobserver-timethreshold-slot">#dom-visibilityobserver-timethreshold-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-timethreshold-slot">5.2.5. Enforce An input-protection Directive</a> <a href="#ref-for-dom-visibilityobserver-timethreshold-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-visibilityobserver-associatedcontentsecuritypolicy-slot">
-   <b><a href="#dom-visibilityobserver-associatedcontentsecuritypolicy-slot">#dom-visibilityobserver-associatedcontentsecuritypolicy-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-visibilityobserver-associatedcontentsecuritypolicy-slot" class="dfn-panel" data-for="dom-visibilityobserver-associatedcontentsecuritypolicy-slot" id="infopanel-for-dom-visibilityobserver-associatedcontentsecuritypolicy-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-visibilityobserver-associatedcontentsecuritypolicy-slot" style="display:none">Info about the '[[associatedContentSecurityPolicy]]' definition.</span><b><a href="#dom-visibilityobserver-associatedcontentsecuritypolicy-slot">#dom-visibilityobserver-associatedcontentsecuritypolicy-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-visibilityobserver-associatedcontentsecuritypolicy-slot">5.2.5. Enforce An input-protection Directive</a>
     <li><a href="#ref-for-dom-visibilityobserver-associatedcontentsecuritypolicy-slot①">5.2.6. Handle a Violation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-visibility-observer-task">
-   <b><a href="#queue-a-visibility-observer-task">#queue-a-visibility-observer-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-visibility-observer-task" class="dfn-panel" data-for="queue-a-visibility-observer-task" id="infopanel-for-queue-a-visibility-observer-task" role="dialog">
+   <span id="infopaneltitle-for-queue-a-visibility-observer-task" style="display:none">Info about the 'queue a visibility observer task' definition.</span><b><a href="#queue-a-visibility-observer-task">#queue-a-visibility-observer-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-visibility-observer-task">5.2.3. Queue a VisibilityObserverEntry</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-visibility-observers">
-   <b><a href="#notify-visibility-observers">#notify-visibility-observers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-visibility-observers" class="dfn-panel" data-for="notify-visibility-observers" id="infopanel-for-notify-visibility-observers" role="dialog">
+   <span id="infopaneltitle-for-notify-visibility-observers" style="display:none">Info about the 'notify visibility observers' definition.</span><b><a href="#notify-visibility-observers">#notify-visibility-observers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-visibility-observers">5.2.1. Queue a VisibilityObserver Task</a> <a href="#ref-for-notify-visibility-observers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-visibilityobserverentry">
-   <b><a href="#queue-a-visibilityobserverentry">#queue-a-visibilityobserverentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-visibilityobserverentry" class="dfn-panel" data-for="queue-a-visibilityobserverentry" id="infopanel-for-queue-a-visibilityobserverentry" role="dialog">
+   <span id="infopaneltitle-for-queue-a-visibilityobserverentry" style="display:none">Info about the 'queue a VisibilityObserverEntry' definition.</span><b><a href="#queue-a-visibilityobserverentry">#queue-a-visibilityobserverentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-visibilityobserverentry">5.2.4. Promote Observed GraphicsLayers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="graphicslayer">
-   <b><a href="#graphicslayer">#graphicslayer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-graphicslayer" class="dfn-panel" data-for="graphicslayer" id="infopanel-for-graphicslayer" role="dialog">
+   <span id="infopaneltitle-for-graphicslayer" style="display:none">Info about the 'GraphicsLayer' definition.</span><b><a href="#graphicslayer">#graphicslayer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-graphicslayer">5.2.4. Promote Observed GraphicsLayers</a> <a href="#ref-for-graphicslayer①">(2)</a> <a href="#ref-for-graphicslayer②">(3)</a> <a href="#ref-for-graphicslayer③">(4)</a> <a href="#ref-for-graphicslayer④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="promote-observed-graphicslayers">
-   <b><a href="#promote-observed-graphicslayers">#promote-observed-graphicslayers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-promote-observed-graphicslayers" class="dfn-panel" data-for="promote-observed-graphicslayers" id="infopanel-for-promote-observed-graphicslayers" role="dialog">
+   <span id="infopaneltitle-for-promote-observed-graphicslayers" style="display:none">Info about the 'promote observed graphicsLayers' definition.</span><b><a href="#promote-observed-graphicslayers">#promote-observed-graphicslayers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-promote-observed-graphicslayers">5.2.4. Promote Observed GraphicsLayers</a>
     <li><a href="#ref-for-promote-observed-graphicslayers①">5.3.1. HTML Processing Model: Event Loop</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enforce-an-input-protection-directive">
-   <b><a href="#enforce-an-input-protection-directive">#enforce-an-input-protection-directive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enforce-an-input-protection-directive" class="dfn-panel" data-for="enforce-an-input-protection-directive" id="infopanel-for-enforce-an-input-protection-directive" role="dialog">
+   <span id="infopaneltitle-for-enforce-an-input-protection-directive" style="display:none">Info about the 'enforce an input-protection directive' definition.</span><b><a href="#enforce-an-input-protection-directive">#enforce-an-input-protection-directive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce-an-input-protection-directive">5.3.2. DOM: Dispatching Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-a-violation">
-   <b><a href="#handle-a-violation">#handle-a-violation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-a-violation" class="dfn-panel" data-for="handle-a-violation" id="infopanel-for-handle-a-violation" role="dialog">
+   <span id="infopaneltitle-for-handle-a-violation" style="display:none">Info about the 'handle a violation' definition.</span><b><a href="#handle-a-violation">#handle-a-violation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-a-violation">5.2.5. Enforce An input-protection Directive</a> <a href="#ref-for-handle-a-violation①">(2)</a> <a href="#ref-for-handle-a-violation②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-isunsafe">
-   <b><a href="#dom-event-isunsafe">#dom-event-isunsafe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-isunsafe" class="dfn-panel" data-for="dom-event-isunsafe" id="infopanel-for-dom-event-isunsafe" role="dialog">
+   <span id="infopaneltitle-for-dom-event-isunsafe" style="display:none">Info about the 'isUnsafe' definition.</span><b><a href="#dom-event-isunsafe">#dom-event-isunsafe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-isunsafe">5.2.6. Handle a Violation</a>
     <li><a href="#ref-for-dom-event-isunsafe①">5.3.3. isUnsafe Attribute</a>
@@ -1624,57 +1624,113 @@ directive-value   = ['area-threshold=' num-val]
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webappsec-upgrade-insecure-requests/index.html
+++ b/tests/github/w3c/webappsec-upgrade-insecure-requests/index.html
@@ -1455,15 +1455,15 @@ Location: https://example.com/
    <li><a href="#upgrade-insecure-requests-http-request-header-field">Upgrade-Insecure-Requests HTTP request header field</a><span>, in § 3.2.1</span>
    <li><a href="#upgrade-request">Upgrade request to a potentially trustworthy URL, if appropriate</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-appendix-B.1">
-   <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-appendix-B.1" class="dfn-panel" data-for="term-for-appendix-B.1" id="infopanel-for-term-for-appendix-B.1" role="menu">
+   <span id="infopaneltitle-for-term-for-appendix-B.1" style="display:none">Info about the 'wsp' external reference.</span><a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">https://tools.ietf.org/html/rfc5234#appendix-B.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appendix-B.1">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-appendix-B.1①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-security-policy">
-   <a href="https://www.w3.org/TR/CSP/#content-security-policy">https://www.w3.org/TR/CSP/#content-security-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-security-policy" class="dfn-panel" data-for="term-for-content-security-policy" id="infopanel-for-term-for-content-security-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-content-security-policy" style="display:none">Info about the 'content-security-policy' external reference.</span><a href="https://www.w3.org/TR/CSP/#content-security-policy">https://www.w3.org/TR/CSP/#content-security-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy">1.2.1. Non-navigational Upgrades</a>
     <li><a href="#ref-for-content-security-policy①">1.2.2. Navigational Upgrades</a>
@@ -1473,54 +1473,54 @@ Location: https://example.com/
     <li><a href="#ref-for-content-security-policy⑤">3.4. Reporting Upgrades</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-security-policy-report-only">
-   <a href="https://www.w3.org/TR/CSP/#content-security-policy-report-only">https://www.w3.org/TR/CSP/#content-security-policy-report-only</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-security-policy-report-only" class="dfn-panel" data-for="term-for-content-security-policy-report-only" id="infopanel-for-term-for-content-security-policy-report-only" role="menu">
+   <span id="infopaneltitle-for-term-for-content-security-policy-report-only" style="display:none">Info about the 'content-security-policy-report-only' external reference.</span><a href="https://www.w3.org/TR/CSP/#content-security-policy-report-only">https://www.w3.org/TR/CSP/#content-security-policy-report-only</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-report-only">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a> <a href="#ref-for-content-security-policy-report-only①">(2)</a> <a href="#ref-for-content-security-policy-report-only②">(3)</a>
     <li><a href="#ref-for-content-security-policy-report-only③">3.4. Reporting Upgrades</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-src">
-   <a href="https://www.w3.org/TR/CSP/#default-src">https://www.w3.org/TR/CSP/#default-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-src" class="dfn-panel" data-for="term-for-default-src" id="infopanel-for-term-for-default-src" role="menu">
+   <span id="infopaneltitle-for-term-for-default-src" style="display:none">Info about the 'default-src' external reference.</span><a href="https://www.w3.org/TR/CSP/#default-src">https://www.w3.org/TR/CSP/#default-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-src">3.4. Reporting Upgrades</a> <a href="#ref-for-default-src①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://www.w3.org/TR/CSP/#enforce">https://www.w3.org/TR/CSP/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce" style="display:none">Info about the 'enforce' external reference.</span><a href="https://www.w3.org/TR/CSP/#enforce">https://www.w3.org/TR/CSP/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-enforce①">3.4. Reporting Upgrades</a> <a href="#ref-for-enforce②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enforce">
-   <a href="https://www.w3.org/TR/CSP/#enforce">https://www.w3.org/TR/CSP/#enforce</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enforce" class="dfn-panel" data-for="term-for-enforce" id="infopanel-for-term-for-enforce①" role="menu">
+   <span id="infopaneltitle-for-term-for-enforce①" style="display:none">Info about the 'enforced' external reference.</span><a href="https://www.w3.org/TR/CSP/#enforce">https://www.w3.org/TR/CSP/#enforce</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enforce">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-enforce①">3.4. Reporting Upgrades</a> <a href="#ref-for-enforce②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://www.w3.org/TR/CSP/#monitor">https://www.w3.org/TR/CSP/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor" style="display:none">Info about the 'monitor' external reference.</span><a href="https://www.w3.org/TR/CSP/#monitor">https://www.w3.org/TR/CSP/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-monitor①">3.4. Reporting Upgrades</a> <a href="#ref-for-monitor②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-monitor">
-   <a href="https://www.w3.org/TR/CSP/#monitor">https://www.w3.org/TR/CSP/#monitor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-monitor" class="dfn-panel" data-for="term-for-monitor" id="infopanel-for-term-for-monitor①" role="menu">
+   <span id="infopaneltitle-for-term-for-monitor①" style="display:none">Info about the 'monitored' external reference.</span><a href="https://www.w3.org/TR/CSP/#monitor">https://www.w3.org/TR/CSP/#monitor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-monitor">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-monitor①">3.4. Reporting Upgrades</a> <a href="#ref-for-monitor②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-protected-resource">
-   <a href="https://www.w3.org/TR/CSP/#protected-resource">https://www.w3.org/TR/CSP/#protected-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-protected-resource" class="dfn-panel" data-for="term-for-protected-resource" id="infopanel-for-term-for-protected-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-protected-resource" style="display:none">Info about the 'protected resource' external reference.</span><a href="https://www.w3.org/TR/CSP/#protected-resource">https://www.w3.org/TR/CSP/#protected-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-protected-resource">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a> <a href="#ref-for-protected-resource①">(2)</a> <a href="#ref-for-protected-resource②">(3)</a>
@@ -1530,26 +1530,26 @@ Location: https://example.com/
     <li><a href="#ref-for-protected-resource⑤">7.2. Relation to HSTS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-uri">
-   <a href="https://www.w3.org/TR/CSP/#report-uri">https://www.w3.org/TR/CSP/#report-uri</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-uri" class="dfn-panel" data-for="term-for-report-uri" id="infopanel-for-term-for-report-uri" role="menu">
+   <span id="infopaneltitle-for-term-for-report-uri" style="display:none">Info about the 'report-uri' external reference.</span><a href="https://www.w3.org/TR/CSP/#report-uri">https://www.w3.org/TR/CSP/#report-uri</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-uri">3.4. Reporting Upgrades</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-send-violation-reports">
-   <a href="https://www.w3.org/TR/CSP/#send-violation-reports">https://www.w3.org/TR/CSP/#send-violation-reports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-send-violation-reports" class="dfn-panel" data-for="term-for-send-violation-reports" id="infopanel-for-term-for-send-violation-reports" role="menu">
+   <span id="infopaneltitle-for-term-for-send-violation-reports" style="display:none">Info about the 'send violation reports' external reference.</span><a href="https://www.w3.org/TR/CSP/#send-violation-reports">https://www.w3.org/TR/CSP/#send-violation-reports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-send-violation-reports">7.1. Legacy Clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-example-violation-report">
-   <a href="https://www.w3.org/TR/CSP/#example-violation-report">https://www.w3.org/TR/CSP/#example-violation-report</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-example-violation-report" class="dfn-panel" data-for="term-for-example-violation-report" id="infopanel-for-term-for-example-violation-report" role="menu">
+   <span id="infopaneltitle-for-term-for-example-violation-report" style="display:none">Info about the 'violation report' external reference.</span><a href="https://www.w3.org/TR/CSP/#example-violation-report">https://www.w3.org/TR/CSP/#example-violation-report</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-example-violation-report">3.4. Reporting Upgrades</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-interface-document">
-   <a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-interface-document" class="dfn-panel" data-for="term-for-interface-document" id="infopanel-for-term-for-interface-document" role="menu">
+   <span id="infopaneltitle-for-term-for-interface-document" style="display:none">Info about the 'Document' external reference.</span><a href="http://www.w3.org/TR/dom/#interface-document">http://www.w3.org/TR/dom/#interface-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-document">3.3. Policy Inheritance</a>
     <li><a href="#ref-for-interface-document①">4.2. 
@@ -1557,15 +1557,15 @@ Location: https://example.com/
     <li><a href="#ref-for-interface-document②">5.2. CSP Violation Reports</a> <a href="#ref-for-interface-document③">(2)</a> <a href="#ref-for-interface-document④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-append">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-append" class="dfn-panel" data-for="term-for-concept-header-list-append" id="infopanel-for-term-for-concept-header-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-append">https://fetch.spec.whatwg.org/#concept-header-list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-append">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-concept-request-client①">(2)</a> <a href="#ref-for-concept-request-client②">(3)</a> <a href="#ref-for-concept-request-client③">(4)</a>
@@ -1573,30 +1573,30 @@ Location: https://example.com/
     Should insecure requests be upgraded for client? </a> <a href="#ref-for-concept-request-client⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">3. Upgrading Insecure Resource Requests</a>
     <li><a href="#ref-for-concept-fetch①">3.1.1. Relation to "Mixed Content"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-concept-request-header-list①">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-main-fetch">
-   <a href="https://fetch.spec.whatwg.org/#main-fetch">https://fetch.spec.whatwg.org/#main-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-main-fetch" class="dfn-panel" data-for="term-for-main-fetch" id="infopanel-for-term-for-main-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-main-fetch" style="display:none">Info about the 'main fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#main-fetch">https://fetch.spec.whatwg.org/#main-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-main-fetch">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigation-request">
-   <a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigation-request" class="dfn-panel" data-for="term-for-navigation-request" id="infopanel-for-term-for-navigation-request" role="menu">
+   <span id="infopaneltitle-for-term-for-navigation-request" style="display:none">Info about the 'navigation request' external reference.</span><a href="https://fetch.spec.whatwg.org/#navigation-request">https://fetch.spec.whatwg.org/#navigation-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">3. Upgrading Insecure Resource Requests</a>
     <li><a href="#ref-for-navigation-request①">3.2. Feature Detecting Clients Capable of Upgrading</a>
@@ -1605,8 +1605,8 @@ Location: https://example.com/
     <li><a href="#ref-for-navigation-request⑦">6. Performance Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2. Key Concepts and Terminology</a> <a href="#ref-for-concept-request①">(2)</a> <a href="#ref-for-concept-request②">(3)</a>
     <li><a href="#ref-for-concept-request③">3.2. Feature Detecting Clients Capable of Upgrading</a>
@@ -1619,8 +1619,8 @@ Location: https://example.com/
     Should insecure requests be upgraded for client? </a> <a href="#ref-for-concept-request①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-concept-request-url①">(2)</a>
@@ -1628,8 +1628,8 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-concept-request-url③">(2)</a> <a href="#ref-for-concept-request-url④">(3)</a> <a href="#ref-for-concept-request-url⑤">(4)</a> <a href="#ref-for-concept-request-url⑥">(5)</a> <a href="#ref-for-concept-request-url⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3. Upgrading Insecure Resource Requests</a> <a href="#ref-for-browsing-context①">(2)</a>
     <li><a href="#ref-for-browsing-context②">3.3. Policy Inheritance</a>
@@ -1637,118 +1637,118 @@ Location: https://example.com/
     Should insecure requests be upgraded for client? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-document-object">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#create-a-document-object">https://html.spec.whatwg.org/multipage/browsers.html#create-a-document-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-document-object" class="dfn-panel" data-for="term-for-create-a-document-object" id="infopanel-for-term-for-create-a-document-object" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-document-object" style="display:none">Info about the 'creating a new document object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#create-a-document-object">https://html.spec.whatwg.org/multipage/browsers.html#create-a-document-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-document-object">3.3. Policy Inheritance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">3. Upgrading Insecure Resource Requests</a> <a href="#ref-for-settings-object①">(2)</a>
     <li><a href="#ref-for-settings-object②">4.2. 
     Should insecure requests be upgraded for client? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-incumbent-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-incumbent-settings-object" class="dfn-panel" data-for="term-for-incumbent-settings-object" id="infopanel-for-term-for-incumbent-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-incumbent-settings-object" style="display:none">Info about the 'incumbent settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incumbent-settings-object">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-incumbent-settings-object①">3.3. Policy Inheritance</a> <a href="#ref-for-incumbent-settings-object②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nested-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nested-browsing-context" class="dfn-panel" data-for="term-for-nested-browsing-context" id="infopanel-for-term-for-nested-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-nested-browsing-context" style="display:none">Info about the 'nested browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nested-browsing-context">3.3. Policy Inheritance</a> <a href="#ref-for-nested-browsing-context①">(2)</a>
     <li><a href="#ref-for-nested-browsing-context②">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-browsing-context" class="dfn-panel" data-for="term-for-responsible-browsing-context" id="infopanel-for-term-for-responsible-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-browsing-context" style="display:none">Info about the 'responsible browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-browsing-context">4.2. 
     Should insecure requests be upgraded for client? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-document">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-document" class="dfn-panel" data-for="term-for-responsible-document" id="infopanel-for-term-for-responsible-document" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-document" style="display:none">Info about the 'responsible document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-document">4.2. 
     Should insecure requests be upgraded for client? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">4.1. 
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-all-mixed-content">
-   <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#block-all-mixed-content">https://w3c.github.io/webappsec/specs/mixedcontent/#block-all-mixed-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-all-mixed-content" class="dfn-panel" data-for="term-for-block-all-mixed-content" id="infopanel-for-term-for-block-all-mixed-content" role="menu">
+   <span id="infopaneltitle-for-term-for-block-all-mixed-content" style="display:none">Info about the 'block-all-mixed-content' external reference.</span><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#block-all-mixed-content">https://w3c.github.io/webappsec/specs/mixedcontent/#block-all-mixed-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-all-mixed-content">1.3. Recommendations</a>
     <li><a href="#ref-for-block-all-mixed-content①">3.1.1. Relation to "Mixed Content"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedding-document">
-   <a href="https://w3c.github.io/webappsec-mixed-content/#embedding-document">https://w3c.github.io/webappsec-mixed-content/#embedding-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedding-document" class="dfn-panel" data-for="term-for-embedding-document" id="infopanel-for-term-for-embedding-document" role="menu">
+   <span id="infopaneltitle-for-term-for-embedding-document" style="display:none">Info about the 'embedding document' external reference.</span><a href="https://w3c.github.io/webappsec-mixed-content/#embedding-document">https://w3c.github.io/webappsec-mixed-content/#embedding-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedding-document">3.3. Policy Inheritance</a> <a href="#ref-for-embedding-document①">(2)</a>
     <li><a href="#ref-for-embedding-document②">4.2. 
     Should insecure requests be upgraded for client? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strict-mode">
-   <a href="https://w3c.github.io/webappsec/specs/mixedcontent/#strict-mode">https://w3c.github.io/webappsec/specs/mixedcontent/#strict-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strict-mode" class="dfn-panel" data-for="term-for-strict-mode" id="infopanel-for-term-for-strict-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-strict-mode" style="display:none">Info about the 'strict mode' external reference.</span><a href="https://w3c.github.io/webappsec/specs/mixedcontent/#strict-mode">https://w3c.github.io/webappsec/specs/mixedcontent/#strict-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strict-mode">1.1. Goals</a>
     <li><a href="#ref-for-strict-mode①">1.3. Recommendations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'origin' external reference.</span><a href="https://tools.ietf.org/html/rfc6454#section-3.2">https://tools.ietf.org/html/rfc6454#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">2. Key Concepts and Terminology</a> <a href="#ref-for-section-3.2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2" style="display:none">Info about the 'congruent match' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">2. Key Concepts and Terminology</a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-6.1.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-6.1.2">https://tools.ietf.org/html/rfc6797#section-6.1.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-6.1.2" class="dfn-panel" data-for="term-for-section-6.1.2" id="infopanel-for-term-for-section-6.1.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-6.1.2" style="display:none">Info about the 'includesubdomains' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-6.1.2">https://tools.ietf.org/html/rfc6797#section-6.1.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-6.1.2">2. Key Concepts and Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.1.1">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.1.1">https://tools.ietf.org/html/rfc6797#section-8.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.1.1" class="dfn-panel" data-for="term-for-section-8.1.1" id="infopanel-for-term-for-section-8.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.1.1" style="display:none">Info about the 'known hsts host' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.1.1">https://tools.ietf.org/html/rfc6797#section-8.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.1.1">2. Key Concepts and Terminology</a> <a href="#ref-for-section-8.1.1①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2①" style="display:none">Info about the 'known hsts host domain name matching' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">2. Key Concepts and Terminology</a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-6.1">
-   <a href="https://tools.ietf.org/html/rfc6797#section-6.1">https://tools.ietf.org/html/rfc6797#section-6.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-6.1" class="dfn-panel" data-for="term-for-section-6.1" id="infopanel-for-term-for-section-6.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-6.1" style="display:none">Info about the 'strict-transport-security' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-6.1">https://tools.ietf.org/html/rfc6797#section-6.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-6.1">1.3. Recommendations</a> <a href="#ref-for-section-6.1①">(2)</a> <a href="#ref-for-section-6.1②">(3)</a>
     <li><a href="#ref-for-section-6.1③">2. Key Concepts and Terminology</a> <a href="#ref-for-section-6.1④">(2)</a> <a href="#ref-for-section-6.1⑤">(3)</a>
@@ -1758,48 +1758,48 @@ Location: https://example.com/
     <li><a href="#ref-for-section-6.1⑧">5.1. Interaction with HSTS</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.2">
-   <a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.2" class="dfn-panel" data-for="term-for-section-8.2" id="infopanel-for-term-for-section-8.2②" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.2②" style="display:none">Info about the 'superdomain match' external reference.</span><a href="https://tools.ietf.org/html/rfc6797#section-8.2">https://tools.ietf.org/html/rfc6797#section-8.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.2">2. Key Concepts and Terminology</a> <a href="#ref-for-section-8.2①">(2)</a> <a href="#ref-for-section-8.2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'resource representation' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-3">https://tools.ietf.org/html/rfc7231#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">2. Key Concepts and Terminology</a> <a href="#ref-for-section-3①">(2)</a> <a href="#ref-for-section-3②">(3)</a> <a href="#ref-for-section-3③">(4)</a> <a href="#ref-for-section-3④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'vary' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-7.1.4">https://tools.ietf.org/html/rfc7231#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-section-7.1.4①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2">
-   <a href="https://tools.ietf.org/html/rfc7234#section-5.2">https://tools.ietf.org/html/rfc7234#section-5.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2" class="dfn-panel" data-for="term-for-section-5.2" id="infopanel-for-term-for-section-5.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2" style="display:none">Info about the 'cache-control' external reference.</span><a href="https://tools.ietf.org/html/rfc7234#section-5.2">https://tools.ietf.org/html/rfc7234#section-5.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-section-5.2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2.2.3">
-   <a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.3">https://tools.ietf.org/html/rfc7234#section-5.2.2.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2.2.3" class="dfn-panel" data-for="term-for-section-5.2.2.3" id="infopanel-for-term-for-section-5.2.2.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2.2.3" style="display:none">Info about the 'no-store' external reference.</span><a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.3">https://tools.ietf.org/html/rfc7234#section-5.2.2.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2.2.3">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2">
-   <a href="https://tools.ietf.org/html/rfc7240#section-2">https://tools.ietf.org/html/rfc7240#section-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2" class="dfn-panel" data-for="term-for-section-2" id="infopanel-for-term-for-section-2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2" style="display:none">Info about the 'prefer' external reference.</span><a href="https://tools.ietf.org/html/rfc7240#section-2">https://tools.ietf.org/html/rfc7240#section-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-potentially-trustworthy-url">
-   <a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-potentially-trustworthy-url" class="dfn-panel" data-for="term-for-potentially-trustworthy-url" id="infopanel-for-term-for-potentially-trustworthy-url" role="menu">
+   <span id="infopaneltitle-for-term-for-potentially-trustworthy-url" style="display:none">Info about the 'potentially trustworthy url' external reference.</span><a href="https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url">https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potentially-trustworthy-url">1.3. Recommendations</a>
     <li><a href="#ref-for-potentially-trustworthy-url①">3. Upgrading Insecure Resource Requests</a>
@@ -1809,8 +1809,8 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-potentially-trustworthy-url⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">1.1. Goals</a>
     <li><a href="#ref-for-concept-url-host①">2. Key Concepts and Terminology</a>
@@ -1823,14 +1823,14 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-concept-url-host⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">1.1. Goals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">3. Upgrading Insecure Resource Requests</a>
     <li><a href="#ref-for-concept-url-port①">3.1. 
@@ -1839,8 +1839,8 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">1.1. Goals</a>
     <li><a href="#ref-for-concept-url-scheme①">2. Key Concepts and Terminology</a>
@@ -1848,23 +1848,23 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-concept-url-scheme③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="http://www.w3.org/TR/workers/#worker">http://www.w3.org/TR/workers/#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">4.2. 
     Should insecure requests be upgraded for client? </a>
     <li><a href="#ref-for-worker①">5.2. CSP Violation Reports</a> <a href="#ref-for-worker②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-settings-for-workers">
-   <a href="http://www.w3.org/TR/workers/#script-settings-for-workers">http://www.w3.org/TR/workers/#script-settings-for-workers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-settings-for-workers" class="dfn-panel" data-for="term-for-script-settings-for-workers" id="infopanel-for-term-for-script-settings-for-workers" role="menu">
+   <span id="infopaneltitle-for-term-for-script-settings-for-workers" style="display:none">Info about the 'set up a worker environment settings object' external reference.</span><a href="http://www.w3.org/TR/workers/#script-settings-for-workers">http://www.w3.org/TR/workers/#script-settings-for-workers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-settings-for-workers">3.3. Policy Inheritance</a>
    </ul>
@@ -2026,14 +2026,14 @@ Location: https://example.com/
    <dt id="biblio-web-https">[WEB-HTTPS]
    <dd>Mark Nottingham. <a href="http://www.w3.org/2001/tag/doc/web-https"><cite>Securing the Web</cite></a>. TAG Finding. URL: <a href="http://www.w3.org/2001/tag/doc/web-https">http://www.w3.org/2001/tag/doc/web-https</a>
   </dl>
-  <aside class="dfn-panel" data-for="safely-upgradable-requests">
-   <b><a href="#safely-upgradable-requests">#safely-upgradable-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-safely-upgradable-requests" class="dfn-panel" data-for="safely-upgradable-requests" id="infopanel-for-safely-upgradable-requests" role="dialog">
+   <span id="infopaneltitle-for-safely-upgradable-requests" style="display:none">Info about the 'safely upgradable requests' definition.</span><b><a href="#safely-upgradable-requests">#safely-upgradable-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-safely-upgradable-requests">1.3. Recommendations</a> <a href="#ref-for-safely-upgradable-requests①">(2)</a> <a href="#ref-for-safely-upgradable-requests②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hsts-safe-origin">
-   <b><a href="#hsts-safe-origin">#hsts-safe-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hsts-safe-origin" class="dfn-panel" data-for="hsts-safe-origin" id="infopanel-for-hsts-safe-origin" role="dialog">
+   <span id="infopaneltitle-for-hsts-safe-origin" style="display:none">Info about the 'HSTS-safe origin' definition.</span><b><a href="#hsts-safe-origin">#hsts-safe-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hsts-safe-origin">1.3. Recommendations</a>
     <li><a href="#ref-for-hsts-safe-origin①">2. Key Concepts and Terminology</a>
@@ -2041,8 +2041,8 @@ Location: https://example.com/
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-hsts-safe-origin③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conditionally-hsts-safe-origin">
-   <b><a href="#conditionally-hsts-safe-origin">#conditionally-hsts-safe-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conditionally-hsts-safe-origin" class="dfn-panel" data-for="conditionally-hsts-safe-origin" id="infopanel-for-conditionally-hsts-safe-origin" role="dialog">
+   <span id="infopaneltitle-for-conditionally-hsts-safe-origin" style="display:none">Info about the 'conditionally HSTS-safe origin' definition.</span><b><a href="#conditionally-hsts-safe-origin">#conditionally-hsts-safe-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conditionally-hsts-safe-origin">1.3. Recommendations</a>
     <li><a href="#ref-for-conditionally-hsts-safe-origin①">2. Key Concepts and Terminology</a>
@@ -2051,8 +2051,8 @@ Location: https://example.com/
     The Upgrade-Insecure-Requests HTTP Request Header Field </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="preloadable-hsts-host">
-   <b><a href="#preloadable-hsts-host">#preloadable-hsts-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-preloadable-hsts-host" class="dfn-panel" data-for="preloadable-hsts-host" id="infopanel-for-preloadable-hsts-host" role="dialog">
+   <span id="infopaneltitle-for-preloadable-hsts-host" style="display:none">Info about the 'preloadable HSTS host' definition.</span><b><a href="#preloadable-hsts-host">#preloadable-hsts-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-preloadable-hsts-host">3.2.1. 
     The Upgrade-Insecure-Requests HTTP Request Header Field </a> <a href="#ref-for-preloadable-hsts-host①">(2)</a> <a href="#ref-for-preloadable-hsts-host②">(3)</a>
@@ -2061,8 +2061,8 @@ Location: https://example.com/
     <li><a href="#ref-for-preloadable-hsts-host④">6. Performance Considerations</a> <a href="#ref-for-preloadable-hsts-host⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="insecure-requests-policy">
-   <b><a href="#insecure-requests-policy">#insecure-requests-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-insecure-requests-policy" class="dfn-panel" data-for="insecure-requests-policy" id="infopanel-for-insecure-requests-policy" role="dialog">
+   <span id="infopaneltitle-for-insecure-requests-policy" style="display:none">Info about the 'insecure requests policy' definition.</span><b><a href="#insecure-requests-policy">#insecure-requests-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insecure-requests-policy">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
@@ -2071,8 +2071,9 @@ Location: https://example.com/
     Should insecure requests be upgraded for client? </a> <a href="#ref-for-insecure-requests-policy⑨">(2)</a> <a href="#ref-for-insecure-requests-policy①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-insecure-requests-policy-do-not-upgrade">
-   <b><a href="#valdef-insecure-requests-policy-do-not-upgrade">#valdef-insecure-requests-policy-do-not-upgrade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-insecure-requests-policy-do-not-upgrade" class="dfn-panel" data-for="valdef-insecure-requests-policy-do-not-upgrade" id="infopanel-for-valdef-insecure-requests-policy-do-not-upgrade" role="dialog">
+   <span id="infopaneltitle-for-valdef-insecure-requests-policy-do-not-upgrade" style="display:none">Info about the 'Do Not
+      Upgrade' definition.</span><b><a href="#valdef-insecure-requests-policy-do-not-upgrade">#valdef-insecure-requests-policy-do-not-upgrade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-insecure-requests-policy-do-not-upgrade">3. Upgrading Insecure Resource Requests</a>
     <li><a href="#ref-for-valdef-insecure-requests-policy-do-not-upgrade①">4.1. 
@@ -2081,16 +2082,16 @@ Location: https://example.com/
     Should insecure requests be upgraded for client? </a> <a href="#ref-for-valdef-insecure-requests-policy-do-not-upgrade③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-insecure-requests-policy-upgrade">
-   <b><a href="#valdef-insecure-requests-policy-upgrade">#valdef-insecure-requests-policy-upgrade</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-insecure-requests-policy-upgrade" class="dfn-panel" data-for="valdef-insecure-requests-policy-upgrade" id="infopanel-for-valdef-insecure-requests-policy-upgrade" role="dialog">
+   <span id="infopaneltitle-for-valdef-insecure-requests-policy-upgrade" style="display:none">Info about the 'Upgrade' definition.</span><b><a href="#valdef-insecure-requests-policy-upgrade">#valdef-insecure-requests-policy-upgrade</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-insecure-requests-policy-upgrade">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
     <li><a href="#ref-for-valdef-insecure-requests-policy-upgrade①">3.3. Policy Inheritance</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade②">(2)</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade③">(3)</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade④">(4)</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade⑤">(5)</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade⑥">(6)</a> <a href="#ref-for-valdef-insecure-requests-policy-upgrade⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-insecure-navigations-set">
-   <b><a href="#upgrade-insecure-navigations-set">#upgrade-insecure-navigations-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-insecure-navigations-set" class="dfn-panel" data-for="upgrade-insecure-navigations-set" id="infopanel-for-upgrade-insecure-navigations-set" role="dialog">
+   <span id="infopaneltitle-for-upgrade-insecure-navigations-set" style="display:none">Info about the 'upgrade insecure navigations set' definition.</span><b><a href="#upgrade-insecure-navigations-set">#upgrade-insecure-navigations-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-insecure-navigations-set">3.1. 
     The upgrade-insecure-requests Content Security Policy directive </a>
@@ -2099,8 +2100,8 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-insecure-requests">
-   <b><a href="#upgrade-insecure-requests">#upgrade-insecure-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-insecure-requests" class="dfn-panel" data-for="upgrade-insecure-requests" id="infopanel-for-upgrade-insecure-requests" role="dialog">
+   <span id="infopaneltitle-for-upgrade-insecure-requests" style="display:none">Info about the 'upgrade-insecure-requests' definition.</span><b><a href="#upgrade-insecure-requests">#upgrade-insecure-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-insecure-requests">1. Introduction</a>
     <li><a href="#ref-for-upgrade-insecure-requests①">1.2.1. Non-navigational Upgrades</a>
@@ -2120,8 +2121,10 @@ Location: https://example.com/
     <li><a href="#ref-for-upgrade-insecure-requests②③">7.2. Relation to HSTS</a> <a href="#ref-for-upgrade-insecure-requests②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-insecure-requests-http-request-header-field">
-   <b><a href="#upgrade-insecure-requests-http-request-header-field">#upgrade-insecure-requests-http-request-header-field</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-insecure-requests-http-request-header-field" class="dfn-panel" data-for="upgrade-insecure-requests-http-request-header-field" id="infopanel-for-upgrade-insecure-requests-http-request-header-field" role="dialog">
+   <span id="infopaneltitle-for-upgrade-insecure-requests-http-request-header-field" style="display:none">Info about the '
+  Upgrade-Insecure-Requests HTTP request header
+  field' definition.</span><b><a href="#upgrade-insecure-requests-http-request-header-field">#upgrade-insecure-requests-http-request-header-field</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-insecure-requests-http-request-header-field">2. Key Concepts and Terminology</a>
     <li><a href="#ref-for-upgrade-insecure-requests-http-request-header-field①">3.2. Feature Detecting Clients Capable of Upgrading</a>
@@ -2131,8 +2134,10 @@ Location: https://example.com/
     Upgrade request to a potentially trustworthy URL, if appropriate </a> <a href="#ref-for-upgrade-insecure-requests-http-request-header-field①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upgrade-request">
-   <b><a href="#upgrade-request">#upgrade-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upgrade-request" class="dfn-panel" data-for="upgrade-request" id="infopanel-for-upgrade-request" role="dialog">
+   <span id="infopaneltitle-for-upgrade-request" style="display:none">Info about the '4.1. 
+    Upgrade request to a potentially trustworthy URL, if appropriate
+  ' definition.</span><b><a href="#upgrade-request">#upgrade-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-request">3. Upgrading Insecure Resource Requests</a> <a href="#ref-for-upgrade-request">(2)</a>
     <li><a href="#ref-for-upgrade-request">3.1.1. Relation to "Mixed Content"</a>
@@ -2144,59 +2149,115 @@ Location: https://example.com/
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webauthn/index.html
+++ b/tests/github/w3c/webauthn/index.html
@@ -7667,74 +7667,74 @@ for their contributions as our W3C Team Contacts.</p>
    <li><a href="#dom-authenticationextensionslargeblobinputs-write">write</a><span>, in § 10.5</span>
    <li><a href="#dom-authenticationextensionslargebloboutputs-written">written</a><span>, in § 10.5</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-credential">
-   <a href="https://w3c.github.io/webappsec-credential-management/#credential">https://w3c.github.io/webappsec-credential-management/#credential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credential" class="dfn-panel" data-for="term-for-credential" id="infopanel-for-term-for-credential" role="menu">
+   <span id="infopaneltitle-for-term-for-credential" style="display:none">Info about the 'Credential' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#credential">https://w3c.github.io/webappsec-credential-management/#credential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential">3. Dependencies</a>
     <li><a href="#ref-for-credential①">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-credential②">(2)</a> <a href="#ref-for-credential③">(3)</a> <a href="#ref-for-credential④">(4)</a> <a href="#ref-for-credential⑤">(5)</a> <a href="#ref-for-credential⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-credentialcreationoptions">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialcreationoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialcreationoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-credentialcreationoptions" class="dfn-panel" data-for="term-for-dictdef-credentialcreationoptions" id="infopanel-for-term-for-dictdef-credentialcreationoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-credentialcreationoptions" style="display:none">Info about the 'CredentialCreationOptions' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialcreationoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialcreationoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialcreationoptions">5.1.1. CredentialCreationOptions Dictionary Extension</a> <a href="#ref-for-dictdef-credentialcreationoptions①">(2)</a>
     <li><a href="#ref-for-dictdef-credentialcreationoptions②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-credentialrequestoptions">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-credentialrequestoptions" class="dfn-panel" data-for="term-for-dictdef-credentialrequestoptions" id="infopanel-for-term-for-dictdef-credentialrequestoptions" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-credentialrequestoptions" style="display:none">Info about the 'CredentialRequestOptions' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions">https://w3c.github.io/webappsec-credential-management/#dictdef-credentialrequestoptions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialrequestoptions">5.1.2. CredentialRequestOptions Dictionary Extension</a> <a href="#ref-for-dictdef-credentialrequestoptions①">(2)</a>
     <li><a href="#ref-for-dictdef-credentialrequestoptions②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credentialscontainer">
-   <a href="https://w3c.github.io/webappsec-credential-management/#credentialscontainer">https://w3c.github.io/webappsec-credential-management/#credentialscontainer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credentialscontainer" class="dfn-panel" data-for="term-for-credentialscontainer" id="infopanel-for-term-for-credentialscontainer" role="menu">
+   <span id="infopaneltitle-for-term-for-credentialscontainer" style="display:none">Info about the 'CredentialsContainer' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#credentialscontainer">https://w3c.github.io/webappsec-credential-management/#credentialscontainer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialscontainer">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-credentialscontainer①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-credentialscontainer②">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstract-opdef-request-a-credential">
-   <a href="https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential">https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-opdef-request-a-credential" class="dfn-panel" data-for="term-for-abstract-opdef-request-a-credential" id="infopanel-for-term-for-abstract-opdef-request-a-credential" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-opdef-request-a-credential" style="display:none">Info about the 'Request a Credential' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential">https://w3c.github.io/webappsec-credential-management/#abstract-opdef-request-a-credential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-request-a-credential">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" class="dfn-panel" data-for="term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" id="infopanel-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-collectfromcredentialstore-origin-options-sameoriginwithancestors" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#collectfromcredentialstore-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collectfromcredentialstore-origin-options-sameoriginwithancestors">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-collectfromcredentialstore-origin-options-sameoriginwithancestors①">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-origin-options-sameoriginwithancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#create-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#create-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-origin-options-sameoriginwithancestors" class="dfn-panel" data-for="term-for-create-origin-options-sameoriginwithancestors" id="infopanel-for-term-for-create-origin-options-sameoriginwithancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-create-origin-options-sameoriginwithancestors" style="display:none">Info about the '[[Create]](origin, options, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#create-origin-options-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#create-origin-options-sameoriginwithancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-origin-options-sameoriginwithancestors">5.6. Abort Operations with AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-store-credential-sameoriginwithancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#store-credential-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#store-credential-sameoriginwithancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-store-credential-sameoriginwithancestors" class="dfn-panel" data-for="term-for-store-credential-sameoriginwithancestors" id="infopanel-for-term-for-store-credential-sameoriginwithancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-store-credential-sameoriginwithancestors" style="display:none">Info about the '[[Store]](credential, sameOriginWithAncestors)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#store-credential-sameoriginwithancestors">https://w3c.github.io/webappsec-credential-management/#store-credential-sameoriginwithancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-store-credential-sameoriginwithancestors">5.1. PublicKeyCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-discovery-slot">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-discovery-slot" class="dfn-panel" data-for="term-for-dom-credential-discovery-slot" id="infopanel-for-term-for-dom-credential-discovery-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-discovery-slot" style="display:none">Info about the '[[discovery]]' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-discovery-slot">5.1. PublicKeyCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-type-slot">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-type-slot" class="dfn-panel" data-for="term-for-dom-credential-type-slot" id="infopanel-for-term-for-dom-credential-type-slot" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-type-slot" style="display:none">Info about the '[[type]]' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot">https://w3c.github.io/webappsec-credential-management/#dom-credential-type-slot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type-slot">5.1. PublicKeyCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialscontainer-create">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialscontainer-create" class="dfn-panel" data-for="term-for-dom-credentialscontainer-create" id="infopanel-for-term-for-dom-credentialscontainer-create" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialscontainer-create" style="display:none">Info about the 'create()' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-create">1. Introduction</a>
     <li><a href="#ref-for-dom-credentialscontainer-create①">4. Terminology</a>
@@ -7756,8 +7756,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-credentialscontainer-create②⑤">11.6. Get Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-credential">
-   <a href="https://w3c.github.io/webappsec-credential-management/#concept-credential">https://w3c.github.io/webappsec-credential-management/#concept-credential</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-credential" class="dfn-panel" data-for="term-for-concept-credential" id="infopanel-for-term-for-concept-credential" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-credential" style="display:none">Info about the 'credential' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#concept-credential">https://w3c.github.io/webappsec-credential-management/#concept-credential</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-credential">4. Terminology</a> <a href="#ref-for-concept-credential①">(2)</a> <a href="#ref-for-concept-credential②">(3)</a> <a href="#ref-for-concept-credential③">(4)</a>
     <li><a href="#ref-for-concept-credential④">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a> <a href="#ref-for-concept-credential⑤">(2)</a> <a href="#ref-for-concept-credential⑥">(3)</a>
@@ -7769,15 +7769,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-credential①③">14.4.2. Privacy of personally identifying information Stored in Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credential-source">
-   <a href="https://w3c.github.io/webappsec-credential-management/#credential-source">https://w3c.github.io/webappsec-credential-management/#credential-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credential-source" class="dfn-panel" data-for="term-for-credential-source" id="infopanel-for-term-for-credential-source" role="menu">
+   <span id="infopaneltitle-for-term-for-credential-source" style="display:none">Info about the 'credential source' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#credential-source">https://w3c.github.io/webappsec-credential-management/#credential-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-source">4. Terminology</a>
     <li><a href="#ref-for-credential-source①">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a> <a href="#ref-for-credential-source②">(2)</a> <a href="#ref-for-credential-source③">(3)</a> <a href="#ref-for-credential-source④">(4)</a> <a href="#ref-for-credential-source⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialscontainer-get">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialscontainer-get" class="dfn-panel" data-for="term-for-dom-credentialscontainer-get" id="infopanel-for-term-for-dom-credentialscontainer-get" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialscontainer-get" style="display:none">Info about the 'get()' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-get">1. Introduction</a>
     <li><a href="#ref-for-dom-credentialscontainer-get①">4. Terminology</a> <a href="#ref-for-dom-credentialscontainer-get②">(2)</a> <a href="#ref-for-dom-credentialscontainer-get③">(3)</a> <a href="#ref-for-dom-credentialscontainer-get④">(4)</a> <a href="#ref-for-dom-credentialscontainer-get⑤">(5)</a> <a href="#ref-for-dom-credentialscontainer-get⑥">(6)</a> <a href="#ref-for-dom-credentialscontainer-get⑦">(7)</a> <a href="#ref-for-dom-credentialscontainer-get⑧">(8)</a>
@@ -7800,85 +7800,85 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-credentialscontainer-get③④">14.6.2. Username Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-id">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-id" class="dfn-panel" data-for="term-for-dom-credential-id" id="infopanel-for-term-for-dom-credential-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-id" style="display:none">Info about the 'id' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-id">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dom-credential-id①">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-dom-credential-id②">(2)</a> <a href="#ref-for-dom-credential-id③">(3)</a> <a href="#ref-for-dom-credential-id④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-discovery-remote">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-remote">https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-remote</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-discovery-remote" class="dfn-panel" data-for="term-for-dom-credential-discovery-remote" id="infopanel-for-term-for-dom-credential-discovery-remote" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-discovery-remote" style="display:none">Info about the 'remote' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-remote">https://w3c.github.io/webappsec-credential-management/#dom-credential-discovery-remote</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-discovery-remote">5.1. PublicKeyCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin-with-its-ancestors">
-   <a href="https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors">https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin-with-its-ancestors" class="dfn-panel" data-for="term-for-same-origin-with-its-ancestors" id="infopanel-for-term-for-same-origin-with-its-ancestors" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin-with-its-ancestors" style="display:none">Info about the 'same-origin with its ancestors' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors">https://w3c.github.io/webappsec-credential-management/#same-origin-with-its-ancestors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-with-its-ancestors">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-same-origin-with-its-ancestors①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-same-origin-with-its-ancestors②">5.1.5. Store an Existing Credential - PublicKeyCredential’s [[Store]](credential, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialcreationoptions-signal">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialcreationoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialcreationoptions-signal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialcreationoptions-signal" class="dfn-panel" data-for="term-for-dom-credentialcreationoptions-signal" id="infopanel-for-term-for-dom-credentialcreationoptions-signal" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialcreationoptions-signal" style="display:none">Info about the 'signal (for CredentialCreationOptions)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialcreationoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialcreationoptions-signal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-signal">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialcreationoptions-signal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialrequestoptions-signal">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialrequestoptions-signal" class="dfn-panel" data-for="term-for-dom-credentialrequestoptions-signal" id="infopanel-for-term-for-dom-credentialrequestoptions-signal" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialrequestoptions-signal" style="display:none">Info about the 'signal (for CredentialRequestOptions)' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal">https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-signal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-signal">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialrequestoptions-signal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credentialscontainer-store">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-store">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-store</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credentialscontainer-store" class="dfn-panel" data-for="term-for-dom-credentialscontainer-store" id="infopanel-for-term-for-dom-credentialscontainer-store" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credentialscontainer-store" style="display:none">Info about the 'store()' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-store">https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-store</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialscontainer-store">5.1.5. Store an Existing Credential - PublicKeyCredential’s [[Store]](credential, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-type">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type">https://w3c.github.io/webappsec-credential-management/#dom-credential-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-type" class="dfn-panel" data-for="term-for-dom-credential-type" id="infopanel-for-term-for-dom-credential-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-type">https://w3c.github.io/webappsec-credential-management/#dom-credential-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-type">5.1. PublicKeyCredential Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-mediated">
-   <a href="https://w3c.github.io/webappsec-credential-management/#user-mediated">https://w3c.github.io/webappsec-credential-management/#user-mediated</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-mediated" class="dfn-panel" data-for="term-for-user-mediated" id="infopanel-for-term-for-user-mediated" role="menu">
+   <span id="infopaneltitle-for-term-for-user-mediated" style="display:none">Info about the 'user mediation' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#user-mediated">https://w3c.github.io/webappsec-credential-management/#user-mediated</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-mediated">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'window' external reference.</span><a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">5.6. Abort Operations with AbortSignal</a> <a href="#ref-for-window①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortcontroller">
-   <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortcontroller" class="dfn-panel" data-for="term-for-abortcontroller" id="infopanel-for-term-for-abortcontroller" role="menu">
+   <span id="infopaneltitle-for-term-for-abortcontroller" style="display:none">Info about the 'AbortController' external reference.</span><a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-abortcontroller①">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a>
     <li><a href="#ref-for-abortcontroller②">5.6. Abort Operations with AbortSignal</a> <a href="#ref-for-abortcontroller③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">5.6. Abort Operations with AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-arraybuffer-constructor">https://tc39.github.io/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-constructor" class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor" id="infopanel-for-term-for-sec-arraybuffer-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-constructor" style="display:none">Info about the '%arraybuffer%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraybuffer-constructor">https://tc39.github.io/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-constructor">3. Dependencies</a>
     <li><a href="#ref-for-sec-arraybuffer-constructor①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-sec-arraybuffer-constructor②">(2)</a> <a href="#ref-for-sec-arraybuffer-constructor③">(3)</a>
@@ -7886,8 +7886,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-sec-arraybuffer-constructor①⓪">9. WebAuthn Extensions</a> <a href="#ref-for-sec-arraybuffer-constructor①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal method' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">4. Terminology</a>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots①">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots②">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots③">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots④">(4)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑤">(5)</a>
@@ -7901,8 +7901,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots①⑧">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots①" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">4. Terminology</a>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots①">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots②">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots③">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots④">(4)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑤">(5)</a>
@@ -7916,43 +7916,43 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots①⑧">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-own-property">
-   <a href="https://tc39.github.io/ecma262/#sec-own-property">https://tc39.github.io/ecma262/#sec-own-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-own-property" class="dfn-panel" data-for="term-for-sec-own-property" id="infopanel-for-term-for-sec-own-property" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-own-property" style="display:none">Info about the 'own property' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-own-property">https://tc39.github.io/ecma262/#sec-own-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-own-property">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">7.1. Registering a New Credential</a> <a href="#ref-for-utf-8-decode①">(2)</a> <a href="#ref-for-utf-8-decode②">(3)</a>
     <li><a href="#ref-for-utf-8-decode③">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-utf-8-decode④">(2)</a> <a href="#ref-for-utf-8-decode⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">8.5. Android SafetyNet Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-if-a-caller-s-facetid-is-authorized-for-an-appid">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-if-a-caller-s-facetid-is-authorized-for-an-appid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid" class="dfn-panel" data-for="term-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid" id="infopanel-for-term-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid" role="menu">
+   <span id="infopaneltitle-for-term-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid" style="display:none">Info about the 'determining if a caller's facetid is authorized for an appid' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-if-a-caller-s-facetid-is-authorized-for-an-appid">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-if-a-caller-s-facetid-is-authorized-for-an-appid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid">3. Dependencies</a>
     <li><a href="#ref-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid①">10.1. FIDO AppID Extension (appid)</a> <a href="#ref-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid②">(2)</a>
     <li><a href="#ref-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid③">10.2. FIDO AppID Exclusion Extension (appidExclude)</a> <a href="#ref-for-determining-if-a-caller-s-facetid-is-authorized-for-an-appid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-determining-the-facetid-of-a-calling-application">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-the-facetid-of-a-calling-application">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-the-facetid-of-a-calling-application</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-determining-the-facetid-of-a-calling-application" class="dfn-panel" data-for="term-for-determining-the-facetid-of-a-calling-application" id="infopanel-for-term-for-determining-the-facetid-of-a-calling-application" role="menu">
+   <span id="infopaneltitle-for-term-for-determining-the-facetid-of-a-calling-application" style="display:none">Info about the 'determining the facetid of a calling application' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-the-facetid-of-a-calling-application">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-appid-and-facets-v2.0-id-20180227.html#determining-the-facetid-of-a-calling-application</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determining-the-facetid-of-a-calling-application">3. Dependencies</a>
     <li><a href="#ref-for-determining-the-facetid-of-a-calling-application①">10.1. FIDO AppID Extension (appid)</a>
     <li><a href="#ref-for-determining-the-facetid-of-a-calling-application②">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ctap2-canonical-cbor-encoding-form">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ctap2-canonical-cbor-encoding-form">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ctap2-canonical-cbor-encoding-form</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ctap2-canonical-cbor-encoding-form" class="dfn-panel" data-for="term-for-ctap2-canonical-cbor-encoding-form" id="infopanel-for-term-for-ctap2-canonical-cbor-encoding-form" role="menu">
+   <span id="infopaneltitle-for-term-for-ctap2-canonical-cbor-encoding-form" style="display:none">Info about the 'ctap2 canonical cbor encoding form' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ctap2-canonical-cbor-encoding-form">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#ctap2-canonical-cbor-encoding-form</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ctap2-canonical-cbor-encoding-form">2.4. All Conformance Classes</a> <a href="#ref-for-ctap2-canonical-cbor-encoding-form①">(2)</a>
     <li><a href="#ref-for-ctap2-canonical-cbor-encoding-form②">3. Dependencies</a>
@@ -7961,63 +7961,63 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-ctap2-canonical-cbor-encoding-form⑤">9. WebAuthn Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-large-blob">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#large-blob">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#large-blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-large-blob" class="dfn-panel" data-for="term-for-large-blob" id="infopanel-for-term-for-large-blob" role="menu">
+   <span id="infopaneltitle-for-term-for-large-blob" style="display:none">Info about the 'large, per-credential blobs' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#large-blob">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#large-blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-large-blob">10.5. Large blob storage extension (largeBlob)</a>
     <li><a href="#ref-for-large-blob①">11.5. Add Credential</a> <a href="#ref-for-large-blob②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responses">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#responses">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#responses</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responses" class="dfn-panel" data-for="term-for-responses" id="infopanel-for-term-for-responses" role="menu">
+   <span id="infopaneltitle-for-term-for-responses" style="display:none">Info about the '§6.2. responses' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#responses">https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#responses</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responses">6. WebAuthn Authenticator Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-verification-methods">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#user-verification-methods">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#user-verification-methods</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-verification-methods" class="dfn-panel" data-for="term-for-user-verification-methods" id="infopanel-for-term-for-user-verification-methods" role="menu">
+   <span id="infopaneltitle-for-term-for-user-verification-methods" style="display:none">Info about the 'section 3.1 user verification methods' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#user-verification-methods">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#user-verification-methods</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-verification-methods">10.3. User Verification Method Extension (uvm)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-key-protection-types">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#key-protection-types">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#key-protection-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-key-protection-types" class="dfn-panel" data-for="term-for-key-protection-types" id="infopanel-for-term-for-key-protection-types" role="menu">
+   <span id="infopaneltitle-for-term-for-key-protection-types" style="display:none">Info about the 'section 3.2 key protection types' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#key-protection-types">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#key-protection-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-key-protection-types">10.3. User Verification Method Extension (uvm)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-matcher-protection-types">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#matcher-protection-types">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#matcher-protection-types</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-matcher-protection-types" class="dfn-panel" data-for="term-for-matcher-protection-types" id="infopanel-for-term-for-matcher-protection-types" role="menu">
+   <span id="infopaneltitle-for-term-for-matcher-protection-types" style="display:none">Info about the 'section 3.3 matcher protection types' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#matcher-protection-types">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#matcher-protection-types</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matcher-protection-types">10.3. User Verification Method Extension (uvm)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-public-key-representation-formats">
-   <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#public-key-representation-formats">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#public-key-representation-formats</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-public-key-representation-formats" class="dfn-panel" data-for="term-for-public-key-representation-formats" id="infopanel-for-term-for-public-key-representation-formats" role="menu">
+   <span id="infopaneltitle-for-term-for-public-key-representation-formats" style="display:none">Info about the 'section 3.6.2 public key representation formats' external reference.</span><a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#public-key-representation-formats">https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-registry-v2.0-id-20180227.html#public-key-representation-formats</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-representation-formats">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-authentication-request-message---u2f_authenticate">
-   <a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-request-message---u2f_authenticate">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-request-message---u2f_authenticate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-authentication-request-message---u2f_authenticate" class="dfn-panel" data-for="term-for-authentication-request-message---u2f_authenticate" id="infopanel-for-term-for-authentication-request-message---u2f_authenticate" role="menu">
+   <span id="infopaneltitle-for-term-for-authentication-request-message---u2f_authenticate" style="display:none">Info about the 'application parameter' external reference.</span><a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-request-message---u2f_authenticate">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-request-message---u2f_authenticate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-request-message---u2f_authenticate">6.1.2. FIDO U2F Signature Format Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-registration-response-message-success">
-   <a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#registration-response-message-success">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#registration-response-message-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-registration-response-message-success" class="dfn-panel" data-for="term-for-registration-response-message-success" id="infopanel-for-term-for-registration-response-message-success" role="menu">
+   <span id="infopaneltitle-for-term-for-registration-response-message-success" style="display:none">Info about the 'section 4.3' external reference.</span><a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#registration-response-message-success">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#registration-response-message-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration-response-message-success">8.6. FIDO U2F Attestation Statement Format</a> <a href="#ref-for-registration-response-message-success①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-authentication-response-message-success">
-   <a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-response-message-success">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-response-message-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-authentication-response-message-success" class="dfn-panel" data-for="term-for-authentication-response-message-success" id="infopanel-for-term-for-authentication-response-message-success" role="menu">
+   <span id="infopaneltitle-for-term-for-authentication-response-message-success" style="display:none">Info about the 'section 5.4' external reference.</span><a href="https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-response-message-success">https://fidoalliance.org/specs/fido-u2f-v1.1-id-20160915/fido-u2f-raw-message-formats-v1.1-id-20160915.html#authentication-response-message-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-response-message-success">6.1.2. FIDO U2F Signature Format Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-entry-object">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-entry-object">https://w3c.github.io/FileAPI/#blob-url-entry-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-entry-object" class="dfn-panel" data-for="term-for-blob-url-entry-object" id="infopanel-for-term-for-blob-url-entry-object" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-entry-object" style="display:none">Info about the 'object' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-entry-object">https://w3c.github.io/FileAPI/#blob-url-entry-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry-object">11.3. Add Virtual Authenticator</a> <a href="#ref-for-blob-url-entry-object①">(2)</a>
     <li><a href="#ref-for-blob-url-entry-object②">11.5. Add Credential</a> <a href="#ref-for-blob-url-entry-object③">(2)</a>
@@ -8025,47 +8025,47 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-blob-url-entry-object⑤">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-allow">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-allow" class="dfn-panel" data-for="term-for-attr-iframe-allow" id="infopanel-for-term-for-attr-iframe-allow" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-allow" style="display:none">Info about the 'allow' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-allow">5.10. Using Web Authentication within iframe elements</a> <a href="#ref-for-attr-iframe-allow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">5.1.7. Availability of User-Verifying Platform Authenticator - PublicKeyCredential’s isUserVerifyingPlatformAuthenticatorAvailable() Method</a>
     <li><a href="#ref-for-allowed-to-use①">5.9. Permissions Policy integration</a> <a href="#ref-for-allowed-to-use②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">3. Dependencies</a>
     <li><a href="#ref-for-browsing-context①">5.1.7. Availability of User-Verifying Platform Authenticator - PublicKeyCredential’s isUserVerifyingPlatformAuthenticatorAvailable() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-domain">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain">https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-domain" class="dfn-panel" data-for="term-for-dom-document-domain" id="infopanel-for-term-for-dom-document-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-domain" style="display:none">Info about the 'document.domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain">https://html.spec.whatwg.org/multipage/origin.html#dom-document-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-domain">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-effective-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-effective-domain" class="dfn-panel" data-for="term-for-concept-origin-effective-domain" id="infopanel-for-term-for-concept-origin-effective-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-effective-domain" style="display:none">Info about the 'effective domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-effective-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-effective-domain">4. Terminology</a> <a href="#ref-for-concept-origin-effective-domain①">(2)</a> <a href="#ref-for-concept-origin-effective-domain②">(3)</a> <a href="#ref-for-concept-origin-effective-domain③">(4)</a>
     <li><a href="#ref-for-concept-origin-effective-domain④">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-origin-effective-domain⑤">(2)</a> <a href="#ref-for-concept-origin-effective-domain⑥">(3)</a> <a href="#ref-for-concept-origin-effective-domain⑦">(4)</a>
@@ -8074,37 +8074,37 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-origin-effective-domain①③">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-environment-settings-object①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-environment-settings-object②">5.1.5. Store an Existing Credential - PublicKeyCredential’s [[Store]](credential, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-settings-object-global①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">5.8.1.2. Limited Verification Algorithm</a>
     <li><a href="#ref-for-the-iframe-element①">5.10. Using Web Authentication within iframe elements</a> <a href="#ref-for-the-iframe-element②">(2)</a> <a href="#ref-for-the-iframe-element③">(3)</a>
     <li><a href="#ref-for-the-iframe-element④">13.4.2. Visibility Considerations for Embedded Usage</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-a-registrable-domain-suffix-of-or-is-equal-to">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to">https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" class="dfn-panel" data-for="term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" id="infopanel-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" role="menu">
+   <span id="infopaneltitle-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" style="display:none">Info about the 'is a registrable domain suffix of or is equal to' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to">https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to">3. Dependencies</a>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to①">4. Terminology</a> <a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to②">(2)</a>
@@ -8112,8 +8112,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to④">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-a-registrable-domain-suffix-of-or-is-equal-to">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to">https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" class="dfn-panel" data-for="term-for-is-a-registrable-domain-suffix-of-or-is-equal-to" id="infopanel-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to①" role="menu">
+   <span id="infopaneltitle-for-term-for-is-a-registrable-domain-suffix-of-or-is-equal-to①" style="display:none">Info about the 'is not a registrable domain suffix of and is not equal to' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to">https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to">3. Dependencies</a>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to①">4. Terminology</a> <a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to②">(2)</a>
@@ -8121,16 +8121,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-is-a-registrable-domain-suffix-of-or-is-equal-to④">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">3. Dependencies</a>
     <li><a href="#ref-for-concept-origin-opaque①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-origin-opaque②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">https://html.spec.whatwg.org/multipage/origin.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">1. Introduction</a>
     <li><a href="#ref-for-concept-origin①">1.3.3. Authentication</a>
@@ -8144,8 +8144,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-origin①⑤">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4. Terminology</a> <a href="#ref-for-concept-settings-object-origin①">(2)</a>
     <li><a href="#ref-for-concept-settings-object-origin②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-settings-object-origin③">(2)</a>
@@ -8154,8 +8154,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-settings-object-origin⑦">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-permissions-policy">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-permissions-policy" class="dfn-panel" data-for="term-for-concept-document-permissions-policy" id="infopanel-for-term-for-concept-document-permissions-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-permissions-policy" style="display:none">Info about the 'permissions policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-permissions-policy">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-document-permissions-policy①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8163,8 +8163,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-document-permissions-policy③">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3. Dependencies</a>
     <li><a href="#ref-for-relevant-settings-object①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8173,63 +8173,63 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-relevant-settings-object④">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">5. Web Authentication API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/origin.html#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">3. Dependencies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-append①">(2)</a> <a href="#ref-for-list-append②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-set-append①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-set-append②">(2)</a>
     <li><a href="#ref-for-set-append③">6.3.3. The authenticatorGetAssertion Operation</a> <a href="#ref-for-set-append④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boolean">
-   <a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boolean" class="dfn-panel" data-for="term-for-boolean" id="infopanel-for-term-for-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://infra.spec.whatwg.org/#boolean">https://infra.spec.whatwg.org/#boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-boolean①">11.1.1. Authenticator Extension Capabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">4. Terminology</a> <a href="#ref-for-byte-sequence①">(2)</a>
     <li><a href="#ref-for-byte-sequence②">5.4.3. User Account Parameters for Credential Generation (dictionary PublicKeyCredentialUserEntity)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a> <a href="#ref-for-iteration-continue④">(5)</a> <a href="#ref-for-iteration-continue⑤">(6)</a> <a href="#ref-for-iteration-continue⑥">(7)</a> <a href="#ref-for-iteration-continue⑦">(8)</a> <a href="#ref-for-iteration-continue⑧">(9)</a> <a href="#ref-for-iteration-continue⑨">(10)</a>
     <li><a href="#ref-for-iteration-continue①⓪">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-iteration-continue①①">(2)</a> <a href="#ref-for-iteration-continue①②">(3)</a> <a href="#ref-for-iteration-continue①③">(4)</a> <a href="#ref-for-iteration-continue①④">(5)</a>
     <li><a href="#ref-for-iteration-continue①⑤">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">13.4.7. Unprotected account detection</a>
     <li><a href="#ref-for-list-empty①">14.6.3. Privacy leak via credential IDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-map-exists①">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-map-exists②">(2)</a> <a href="#ref-for-map-exists③">(3)</a>
@@ -8237,8 +8237,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-map-exists⑤">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-iterate①">(2)</a> <a href="#ref-for-list-iterate②">(3)</a> <a href="#ref-for-list-iterate③">(4)</a> <a href="#ref-for-list-iterate④">(5)</a> <a href="#ref-for-list-iterate⑤">(6)</a> <a href="#ref-for-list-iterate⑥">(7)</a> <a href="#ref-for-list-iterate⑦">(8)</a> <a href="#ref-for-list-iterate⑧">(9)</a>
     <li><a href="#ref-for-list-iterate⑨">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-iterate①⓪">(2)</a> <a href="#ref-for-list-iterate①①">(3)</a> <a href="#ref-for-list-iterate①②">(4)</a> <a href="#ref-for-list-iterate①③">(5)</a> <a href="#ref-for-list-iterate①④">(6)</a> <a href="#ref-for-list-iterate①⑤">(7)</a>
@@ -8247,8 +8247,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-list-iterate①⑧">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-map-iterate①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8257,8 +8257,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-map-iterate④">6.3.3. The authenticatorGetAssertion Operation</a> <a href="#ref-for-map-iterate⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4. Terminology</a> <a href="#ref-for-list-is-empty①">(2)</a>
     <li><a href="#ref-for-list-is-empty②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-is-empty③">(2)</a>
@@ -8266,8 +8266,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-list-is-empty⑨">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty①" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4. Terminology</a> <a href="#ref-for-list-is-empty①">(2)</a>
     <li><a href="#ref-for-list-is-empty②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-is-empty③">(2)</a>
@@ -8275,8 +8275,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-list-is-empty⑨">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-item①">(2)</a>
     <li><a href="#ref-for-list-item②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-item③">(2)</a> <a href="#ref-for-list-item④">(3)</a> <a href="#ref-for-list-item⑤">(4)</a>
@@ -8285,24 +8285,24 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-list-item⑨">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item (for struct)' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">4. Terminology</a> <a href="#ref-for-struct-item①">(2)</a>
     <li><a href="#ref-for-struct-item②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-struct-item③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list①">(2)</a>
     <li><a href="#ref-for-list②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-list③">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-ordered-map①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-ordered-map②">(2)</a>
@@ -8313,38 +8313,38 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-ordered-map⑨">9.4. Client Extension Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-ordered-set③">(2)</a> <a href="#ref-for-ordered-set④">(3)</a> <a href="#ref-for-ordered-set⑤">(4)</a>
     <li><a href="#ref-for-ordered-set⑥">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-remove①">(2)</a> <a href="#ref-for-list-remove②">(3)</a> <a href="#ref-for-list-remove③">(4)</a> <a href="#ref-for-list-remove④">(5)</a> <a href="#ref-for-list-remove⑤">(6)</a> <a href="#ref-for-list-remove⑥">(7)</a> <a href="#ref-for-list-remove⑦">(8)</a> <a href="#ref-for-list-remove⑧">(9)</a> <a href="#ref-for-list-remove⑨">(10)</a> <a href="#ref-for-list-remove①⓪">(11)</a>
     <li><a href="#ref-for-list-remove①①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-list-remove①②">(2)</a> <a href="#ref-for-list-remove①③">(3)</a> <a href="#ref-for-list-remove①④">(4)</a> <a href="#ref-for-list-remove①⑤">(5)</a> <a href="#ref-for-list-remove①⑥">(6)</a> <a href="#ref-for-list-remove①⑦">(7)</a> <a href="#ref-for-list-remove①⑧">(8)</a> <a href="#ref-for-list-remove①⑨">(9)</a>
     <li><a href="#ref-for-list-remove②⓪">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-javascript-value-to-json-bytes">
-   <a href="https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-javascript-value-to-json-bytes" class="dfn-panel" data-for="term-for-serialize-a-javascript-value-to-json-bytes" id="infopanel-for-term-for-serialize-a-javascript-value-to-json-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-javascript-value-to-json-bytes" style="display:none">Info about the 'serialize json to bytes' external reference.</span><a href="https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-a-javascript-value-to-json-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-javascript-value-to-json-bytes">5.8.1.1. Serialization</a> <a href="#ref-for-serialize-a-javascript-value-to-json-bytes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set①" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-ordered-set③">(2)</a> <a href="#ref-for-ordered-set④">(3)</a> <a href="#ref-for-ordered-set⑤">(4)</a>
     <li><a href="#ref-for-ordered-set⑥">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-map-set①">(2)</a>
     <li><a href="#ref-for-map-set②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-map-set③">(2)</a>
@@ -8352,85 +8352,85 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-map-set⑤">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">4. Terminology</a>
     <li><a href="#ref-for-struct①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-struct②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-while">
-   <a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-while" class="dfn-panel" data-for="term-for-iteration-while" id="infopanel-for-term-for-iteration-while" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-while" style="display:none">Info about the 'while' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-iteration-while①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-willful-violation">
-   <a href="https://infra.spec.whatwg.org/#willful-violation">https://infra.spec.whatwg.org/#willful-violation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-willful-violation" class="dfn-panel" data-for="term-for-willful-violation" id="infopanel-for-term-for-willful-violation" role="menu">
+   <span id="infopaneltitle-for-term-for-willful-violation" style="display:none">Info about the 'willful violation' external reference.</span><a href="https://infra.spec.whatwg.org/#willful-violation">https://infra.spec.whatwg.org/#willful-violation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-willful-violation">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-visibility-states">
-   <a href="https://www.w3.org/TR/page-visibility/#visibility-states">https://www.w3.org/TR/page-visibility/#visibility-states</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-visibility-states" class="dfn-panel" data-for="term-for-visibility-states" id="infopanel-for-term-for-visibility-states" role="menu">
+   <span id="infopaneltitle-for-term-for-visibility-states" style="display:none">Info about the 'visibility states' external reference.</span><a href="https://www.w3.org/TR/page-visibility/#visibility-states">https://www.w3.org/TR/page-visibility/#visibility-states</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-visibility-states">5.6. Abort Operations with AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">5.9. Permissions Policy integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-186">
-   <a href="https://tools.ietf.org/html/rfc4949#page-186">https://tools.ietf.org/html/rfc4949#page-186</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-186" class="dfn-panel" data-for="term-for-page-186" id="infopanel-for-term-for-page-186" role="menu">
+   <span id="infopaneltitle-for-term-for-page-186" style="display:none">Info about the 'man-in-the-middle attack' external reference.</span><a href="https://tools.ietf.org/html/rfc4949#page-186">https://tools.ietf.org/html/rfc4949#page-186</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-186">13.4.1. Security Benefits for WebAuthn Relying Parties</a>
     <li><a href="#ref-for-page-186①">13.4.4. Attestation Limitations</a> <a href="#ref-for-page-186②">(2)</a> <a href="#ref-for-page-186③">(3)</a> <a href="#ref-for-page-186④">(4)</a> <a href="#ref-for-page-186⑤">(5)</a> <a href="#ref-for-page-186⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-258">
-   <a href="https://tools.ietf.org/html/rfc4949#page-258">https://tools.ietf.org/html/rfc4949#page-258</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-258" class="dfn-panel" data-for="term-for-page-258" id="infopanel-for-term-for-page-258" role="menu">
+   <span id="infopaneltitle-for-term-for-page-258" style="display:none">Info about the 'salt' external reference.</span><a href="https://tools.ietf.org/html/rfc4949#page-258">https://tools.ietf.org/html/rfc4949#page-258</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-258">14.6.1. User Handle Contents</a> <a href="#ref-for-page-258①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-page-258">
-   <a href="https://tools.ietf.org/html/rfc4949#page-258">https://tools.ietf.org/html/rfc4949#page-258</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-page-258" class="dfn-panel" data-for="term-for-page-258" id="infopanel-for-term-for-page-258①" role="menu">
+   <span id="infopaneltitle-for-term-for-page-258①" style="display:none">Info about the 'salted' external reference.</span><a href="https://tools.ietf.org/html/rfc4949#page-258">https://tools.ietf.org/html/rfc4949#page-258</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-page-258">14.6.1. User Handle Contents</a> <a href="#ref-for-page-258①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1.2.7">
-   <a href="https://tools.ietf.org/html/rfc5280#section-4.1.2.7">https://tools.ietf.org/html/rfc5280#section-4.1.2.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1.2.7" class="dfn-panel" data-for="term-for-section-4.1.2.7" id="infopanel-for-term-for-section-4.1.2.7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1.2.7" style="display:none">Info about the 'subjectpublickeyinfo' external reference.</span><a href="https://tools.ietf.org/html/rfc5280#section-4.1.2.7">https://tools.ietf.org/html/rfc5280#section-4.1.2.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1.2.7">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-section-4.1.2.7①">5.2.1.1. Easily accessing credential data</a> <a href="#ref-for-section-4.1.2.7②">(2)</a> <a href="#ref-for-section-4.1.2.7③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2.1">
-   <a href="https://tools.ietf.org/html/bcp47#section-2.1">https://tools.ietf.org/html/bcp47#section-2.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2.1" class="dfn-panel" data-for="term-for-section-2.1" id="infopanel-for-term-for-section-2.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2.1" style="display:none">Info about the 'language tag' external reference.</span><a href="https://tools.ietf.org/html/bcp47#section-2.1">https://tools.ietf.org/html/bcp47#section-2.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2.1">6.4.2. Language and Direction Encoding</a> <a href="#ref-for-section-2.1①">(2)</a> <a href="#ref-for-section-2.1②">(3)</a> <a href="#ref-for-section-2.1③">(4)</a> <a href="#ref-for-section-2.1④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7">
-   <a href="https://tools.ietf.org/html/rfc8152#section-7">https://tools.ietf.org/html/rfc8152#section-7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7" class="dfn-panel" data-for="term-for-section-7" id="infopanel-for-term-for-section-7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7" style="display:none">Info about the 'cose key' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-7">https://tools.ietf.org/html/rfc8152#section-7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7">5.8.5. Cryptographic Algorithm Identifier (typedef COSEAlgorithmIdentifier)</a>
     <li><a href="#ref-for-section-7①">6.1. Authenticator Data</a>
@@ -8439,27 +8439,27 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-section-7④">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-13.1.1">
-   <a href="https://tools.ietf.org/html/rfc8152#section-13.1.1">https://tools.ietf.org/html/rfc8152#section-13.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-13.1.1" class="dfn-panel" data-for="term-for-section-13.1.1" id="infopanel-for-term-for-section-13.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-13.1.1" style="display:none">Info about the 'crv' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-13.1.1">https://tools.ietf.org/html/rfc8152#section-13.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-13.1.1">5.2.1.1. Easily accessing credential data</a> <a href="#ref-for-section-13.1.1①">(2)</a>
     <li><a href="#ref-for-section-13.1.1②">5.8.5. Cryptographic Algorithm Identifier (typedef COSEAlgorithmIdentifier)</a> <a href="#ref-for-section-13.1.1③">(2)</a> <a href="#ref-for-section-13.1.1④">(3)</a> <a href="#ref-for-section-13.1.1⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1">
-   <a href="https://tools.ietf.org/html/rfc8152#section-7.1">https://tools.ietf.org/html/rfc8152#section-7.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1" class="dfn-panel" data-for="term-for-section-7.1" id="infopanel-for-term-for-section-7.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1" style="display:none">Info about the 'kty' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-7.1">https://tools.ietf.org/html/rfc8152#section-7.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1">5.2.1.1. Easily accessing credential data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-13.1">
-   <a href="https://tools.ietf.org/html/rfc8152#section-13.1">https://tools.ietf.org/html/rfc8152#section-13.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-13.1" class="dfn-panel" data-for="term-for-section-13.1" id="infopanel-for-term-for-section-13.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-13.1" style="display:none">Info about the 'section 13.1' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-13.1">https://tools.ietf.org/html/rfc8152#section-13.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-13.1">6.5.1.1. Examples of credentialPublicKey Values Encoded in COSE_Key Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7">
-   <a href="https://tools.ietf.org/html/rfc8152#section-7">https://tools.ietf.org/html/rfc8152#section-7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7" class="dfn-panel" data-for="term-for-section-7" id="infopanel-for-term-for-section-7①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7①" style="display:none">Info about the 'section 7' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-7">https://tools.ietf.org/html/rfc8152#section-7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7">5.8.5. Cryptographic Algorithm Identifier (typedef COSEAlgorithmIdentifier)</a>
     <li><a href="#ref-for-section-7①">6.1. Authenticator Data</a>
@@ -8468,32 +8468,32 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-section-7④">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.1">
-   <a href="https://tools.ietf.org/html/rfc8152#section-8.1">https://tools.ietf.org/html/rfc8152#section-8.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.1" class="dfn-panel" data-for="term-for-section-8.1" id="infopanel-for-term-for-section-8.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.1" style="display:none">Info about the 'section 8.1' external reference.</span><a href="https://tools.ietf.org/html/rfc8152#section-8.1">https://tools.ietf.org/html/rfc8152#section-8.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.1">6.5.1.1. Examples of credentialPublicKey Values Encoded in COSE_Key Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2">
-   <a href="https://tools.ietf.org/html/rfc8230#section-2">https://tools.ietf.org/html/rfc8230#section-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2" class="dfn-panel" data-for="term-for-section-2" id="infopanel-for-term-for-section-2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2" style="display:none">Info about the 'section 2' external reference.</span><a href="https://tools.ietf.org/html/rfc8230#section-2">https://tools.ietf.org/html/rfc8230#section-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2">6.5.1.1. Examples of credentialPublicKey Values Encoded in COSE_Key Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4">
-   <a href="https://tools.ietf.org/html/rfc8230#section-4">https://tools.ietf.org/html/rfc8230#section-4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4" class="dfn-panel" data-for="term-for-section-4" id="infopanel-for-term-for-section-4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4" style="display:none">Info about the 'section 4' external reference.</span><a href="https://tools.ietf.org/html/rfc8230#section-4">https://tools.ietf.org/html/rfc8230#section-4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4">6.5.1.1. Examples of credentialPublicKey Values Encoded in COSE_Key Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.9">
-   <a href="https://tools.ietf.org/html/rfc8610#section-3.9">https://tools.ietf.org/html/rfc8610#section-3.9</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.9" class="dfn-panel" data-for="term-for-section-3.9" id="infopanel-for-term-for-section-3.9" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.9" style="display:none">Info about the 'group sockets' external reference.</span><a href="https://tools.ietf.org/html/rfc8610#section-3.9">https://tools.ietf.org/html/rfc8610#section-3.9</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.9">9.3. Extending Request Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af" role="menu">
+   <span id="infopaneltitle-for-term-for-af" style="display:none">Info about the 'authentication factor' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8502,8 +8502,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af①" role="menu">
+   <span id="infopaneltitle-for-term-for-af①" style="display:none">Info about the 'multi-factor' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8512,8 +8512,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af②" role="menu">
+   <span id="infopaneltitle-for-term-for-af②" style="display:none">Info about the 'second-factor' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8522,14 +8522,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sf">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#sf">https://pages.nist.gov/800-63-3/sp800-63-3.html#sf</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sf" class="dfn-panel" data-for="term-for-sf" id="infopanel-for-term-for-sf" role="menu">
+   <span id="infopaneltitle-for-term-for-sf" style="display:none">Info about the 'single-factor' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#sf">https://pages.nist.gov/800-63-3/sp800-63-3.html#sf</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sf">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af③" role="menu">
+   <span id="infopaneltitle-for-term-for-af③" style="display:none">Info about the 'something you are' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8538,8 +8538,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af④" role="menu">
+   <span id="infopaneltitle-for-term-for-af④" style="display:none">Info about the 'something you have' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8548,8 +8548,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-af">
-   <a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-af" class="dfn-panel" data-for="term-for-af" id="infopanel-for-term-for-af⑤" role="menu">
+   <span id="infopaneltitle-for-term-for-af⑤" style="display:none">Info about the 'something you know' external reference.</span><a href="https://pages.nist.gov/800-63-3/sp800-63-3.html#af">https://pages.nist.gov/800-63-3/sp800-63-3.html#af</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-af">4. Terminology</a>
     <li><a href="#ref-for-af①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-af②">(2)</a> <a href="#ref-for-af③">(3)</a> <a href="#ref-for-af④">(4)</a> <a href="#ref-for-af⑤">(5)</a> <a href="#ref-for-af⑥">(6)</a> <a href="#ref-for-af⑦">(7)</a> <a href="#ref-for-af⑧">(8)</a>
@@ -8558,8 +8558,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-af②①">13.2. Physical Proximity between Client and Authenticator</a> <a href="#ref-for-af②②">(2)</a> <a href="#ref-for-af②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-1">
-   <a href="https://tools.ietf.org/html/rfc8471#section-1">https://tools.ietf.org/html/rfc8471#section-1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-1" class="dfn-panel" data-for="term-for-section-1" id="infopanel-for-term-for-section-1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-1" style="display:none">Info about the 'token binding' external reference.</span><a href="https://tools.ietf.org/html/rfc8471#section-1">https://tools.ietf.org/html/rfc8471#section-1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-1">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-section-1①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8568,8 +8568,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-section-1⑤">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-section-1⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc8471#section-3.2">https://tools.ietf.org/html/rfc8471#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'token binding id' external reference.</span><a href="https://tools.ietf.org/html/rfc8471#section-3.2">https://tools.ietf.org/html/rfc8471#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-section-3.2①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8578,92 +8578,92 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-section-3.2⑤">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-domain">
-   <a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-domain" class="dfn-panel" data-for="term-for-concept-domain" id="infopanel-for-term-for-concept-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain">4. Terminology</a>
     <li><a href="#ref-for-concept-domain①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-domain②">(2)</a>
     <li><a href="#ref-for-concept-domain③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-domain④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-empty-host">
-   <a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-empty-host" class="dfn-panel" data-for="term-for-empty-host" id="infopanel-for-term-for-empty-host" role="menu">
+   <span id="infopaneltitle-for-term-for-empty-host" style="display:none">Info about the 'empty host' external reference.</span><a href="https://url.spec.whatwg.org/#empty-host">https://url.spec.whatwg.org/#empty-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-host">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-empty-host①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">4. Terminology</a>
     <li><a href="#ref-for-concept-url-host①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-url-host②">(2)</a>
     <li><a href="#ref-for-concept-url-host③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-concept-url-host④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv4">
-   <a href="https://url.spec.whatwg.org/#concept-ipv4">https://url.spec.whatwg.org/#concept-ipv4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv4" class="dfn-panel" data-for="term-for-concept-ipv4" id="infopanel-for-term-for-concept-ipv4" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv4" style="display:none">Info about the 'ipv4 address' external reference.</span><a href="https://url.spec.whatwg.org/#concept-ipv4">https://url.spec.whatwg.org/#concept-ipv4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv4">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-ipv4①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-ipv6">
-   <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-ipv6" class="dfn-panel" data-for="term-for-concept-ipv6" id="infopanel-for-term-for-concept-ipv6" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-ipv6" style="display:none">Info about the 'ipv6 address' external reference.</span><a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-concept-ipv6①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-opaque-host">
-   <a href="https://url.spec.whatwg.org/#opaque-host">https://url.spec.whatwg.org/#opaque-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-opaque-host" class="dfn-panel" data-for="term-for-opaque-host" id="infopanel-for-term-for-opaque-host" role="menu">
+   <span id="infopaneltitle-for-term-for-opaque-host" style="display:none">Info about the 'opaque host' external reference.</span><a href="https://url.spec.whatwg.org/#opaque-host">https://url.spec.whatwg.org/#opaque-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-host">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-opaque-host①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org#concept-url-port">https://url.spec.whatwg.org#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="https://url.spec.whatwg.org#concept-url-port">https://url.spec.whatwg.org#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">4. Terminology</a> <a href="#ref-for-concept-url-port①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org#concept-url-scheme">https://url.spec.whatwg.org#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org#concept-url-scheme">https://url.spec.whatwg.org#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4. Terminology</a> <a href="#ref-for-concept-url-scheme①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-domain">
-   <a href="https://url.spec.whatwg.org/#valid-domain">https://url.spec.whatwg.org/#valid-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-domain" class="dfn-panel" data-for="term-for-valid-domain" id="infopanel-for-term-for-valid-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-domain" style="display:none">Info about the 'valid domain' external reference.</span><a href="https://url.spec.whatwg.org/#valid-domain">https://url.spec.whatwg.org/#valid-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-domain">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-valid-domain①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-domain-string">
-   <a href="https://url.spec.whatwg.org/#valid-domain-string">https://url.spec.whatwg.org/#valid-domain-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-domain-string" class="dfn-panel" data-for="term-for-valid-domain-string" id="infopanel-for-term-for-valid-domain-string" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-domain-string" style="display:none">Info about the 'valid domain string' external reference.</span><a href="https://url.spec.whatwg.org/#valid-domain-string">https://url.spec.whatwg.org/#valid-domain-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-domain-string">4. Terminology</a> <a href="#ref-for-valid-domain-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-endpoint-node">
-   <a href="https://w3c.github.io/webdriver/#dfn-endpoint-node">https://w3c.github.io/webdriver/#dfn-endpoint-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-endpoint-node" class="dfn-panel" data-for="term-for-dfn-endpoint-node" id="infopanel-for-term-for-dfn-endpoint-node" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-endpoint-node" style="display:none">Info about the 'endpoint node' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-endpoint-node">https://w3c.github.io/webdriver/#dfn-endpoint-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-endpoint-node">11.1. WebAuthn WebDriver Extension Capability</a> <a href="#ref-for-dfn-endpoint-node①">(2)</a>
     <li><a href="#ref-for-dfn-endpoint-node②">11.1.1. Authenticator Extension Capabilities</a> <a href="#ref-for-dfn-endpoint-node③">(2)</a> <a href="#ref-for-dfn-endpoint-node④">(3)</a>
     <li><a href="#ref-for-dfn-endpoint-node⑤">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-capability">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-capability">https://w3c.github.io/webdriver/#dfn-extension-capability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-capability" class="dfn-panel" data-for="term-for-dfn-extension-capability" id="infopanel-for-term-for-dfn-extension-capability" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-capability" style="display:none">Info about the 'extension capability' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-capability">https://w3c.github.io/webdriver/#dfn-extension-capability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-capability">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-extension-capability①">11.1.1. Authenticator Extension Capabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-extension-command">
-   <a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-extension-command" class="dfn-panel" data-for="term-for-dfn-extension-command" id="infopanel-for-term-for-dfn-extension-command" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-extension-command" style="display:none">Info about the 'extension command' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-extension-command">https://w3c.github.io/webdriver/#dfn-extension-command</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-extension-command">11. User Agent Automation</a>
     <li><a href="#ref-for-dfn-extension-command①">11.1. WebAuthn WebDriver Extension Capability</a>
@@ -8677,14 +8677,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-extension-command⑨">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-getting-properties">
-   <a href="https://w3c.github.io/webdriver/#dfn-getting-properties">https://w3c.github.io/webdriver/#dfn-getting-properties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-getting-properties" class="dfn-panel" data-for="term-for-dfn-getting-properties" id="infopanel-for-term-for-dfn-getting-properties" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-getting-properties" style="display:none">Info about the 'getting a property' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-getting-properties">https://w3c.github.io/webdriver/#dfn-getting-properties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-getting-properties">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-invalid-argument">
-   <a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-invalid-argument" class="dfn-panel" data-for="term-for-dfn-invalid-argument" id="infopanel-for-term-for-dfn-invalid-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-invalid-argument" style="display:none">Info about the 'invalid argument' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-invalid-argument">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-invalid-argument①">11.1.1. Authenticator Extension Capabilities</a>
@@ -8697,15 +8697,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-invalid-argument②②">11.9. Set User Verified</a> <a href="#ref-for-dfn-invalid-argument②③">(2)</a> <a href="#ref-for-dfn-invalid-argument②④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-matching-capabilities">
-   <a href="https://w3c.github.io/webdriver/#dfn-matching-capabilities">https://w3c.github.io/webdriver/#dfn-matching-capabilities</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-matching-capabilities" class="dfn-panel" data-for="term-for-dfn-matching-capabilities" id="infopanel-for-term-for-dfn-matching-capabilities" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-matching-capabilities" style="display:none">Info about the 'matching capabilities' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-matching-capabilities">https://w3c.github.io/webdriver/#dfn-matching-capabilities</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-matching-capabilities">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-matching-capabilities①">11.1.1. Authenticator Extension Capabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">11.3. Add Virtual Authenticator</a> <a href="#ref-for-dfn-remote-end-steps①">(2)</a>
     <li><a href="#ref-for-dfn-remote-end-steps②">11.4. Remove Virtual Authenticator</a>
@@ -8716,14 +8716,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-remote-end-steps⑧">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-a-property">
-   <a href="https://w3c.github.io/webdriver/#dfn-set-a-property">https://w3c.github.io/webdriver/#dfn-set-a-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-a-property" class="dfn-panel" data-for="term-for-dfn-set-a-property" id="infopanel-for-term-for-dfn-set-a-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-a-property" style="display:none">Info about the 'set a property' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-set-a-property">https://w3c.github.io/webdriver/#dfn-set-a-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-a-property">11.3. Add Virtual Authenticator</a> <a href="#ref-for-dfn-set-a-property①">(2)</a> <a href="#ref-for-dfn-set-a-property②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'success' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">11.3. Add Virtual Authenticator</a>
     <li><a href="#ref-for-dfn-success①">11.4. Remove Virtual Authenticator</a>
@@ -8734,21 +8734,21 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-success⑥">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-unsupported-operation">
-   <a href="https://w3c.github.io/webdriver/#dfn-unsupported-operation">https://w3c.github.io/webdriver/#dfn-unsupported-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-unsupported-operation" class="dfn-panel" data-for="term-for-dfn-unsupported-operation" id="infopanel-for-term-for-dfn-unsupported-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-unsupported-operation" style="display:none">Info about the 'unsupported operation' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-unsupported-operation">https://w3c.github.io/webdriver/#dfn-unsupported-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unsupported-operation">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-validate-capabilities">
-   <a href="https://w3c.github.io/webdriver/#dfn-validate-capabilities">https://w3c.github.io/webdriver/#dfn-validate-capabilities</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-validate-capabilities" class="dfn-panel" data-for="term-for-dfn-validate-capabilities" id="infopanel-for-term-for-dfn-validate-capabilities" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-validate-capabilities" style="display:none">Info about the 'validating capabilities' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-validate-capabilities">https://w3c.github.io/webdriver/#dfn-validate-capabilities</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-validate-capabilities">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-validate-capabilities①">11.1.1. Authenticator Extension Capabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error">
-   <a href="https://w3c.github.io/webdriver/#dfn-error">https://w3c.github.io/webdriver/#dfn-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error" class="dfn-panel" data-for="term-for-dfn-error" id="infopanel-for-term-for-dfn-error" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error" style="display:none">Info about the 'webdriver error' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error">https://w3c.github.io/webdriver/#dfn-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-error①">11.1.1. Authenticator Extension Capabilities</a>
@@ -8761,8 +8761,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-error②③">11.9. Set User Verified</a> <a href="#ref-for-dfn-error②④">(2)</a> <a href="#ref-for-dfn-error②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'webdriver error code' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">11.1. WebAuthn WebDriver Extension Capability</a>
     <li><a href="#ref-for-dfn-error-code①">11.1.1. Authenticator Extension Capabilities</a>
@@ -8775,15 +8775,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dfn-error-code②③">11.9. Set User Verified</a> <a href="#ref-for-dfn-error-code②④">(2)</a> <a href="#ref-for-dfn-error-code②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-aborterror①">(2)</a>
     <li><a href="#ref-for-aborterror②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-aborterror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a>
     <li><a href="#ref-for-idl-ArrayBuffer②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-idl-ArrayBuffer③">(2)</a> <a href="#ref-for-idl-ArrayBuffer④">(3)</a>
@@ -8795,8 +8795,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-ArrayBuffer②④">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-idl-ArrayBuffer②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-BufferSource①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8807,14 +8807,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-BufferSource①⓪">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-BufferSource①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constrainterror">
-   <a href="https://webidl.spec.whatwg.org/#constrainterror">https://webidl.spec.whatwg.org/#constrainterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constrainterror" class="dfn-panel" data-for="term-for-constrainterror" id="infopanel-for-term-for-constrainterror" role="menu">
+   <span id="infopaneltitle-for-term-for-constrainterror" style="display:none">Info about the 'ConstraintError' external reference.</span><a href="https://webidl.spec.whatwg.org/#constrainterror">https://webidl.spec.whatwg.org/#constrainterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constrainterror">6.3.2. The authenticatorMakeCredential Operation</a> <a href="#ref-for-constrainterror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3. Dependencies</a>
     <li><a href="#ref-for-idl-DOMException①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a> <a href="#ref-for-idl-DOMException⑤">(5)</a> <a href="#ref-for-idl-DOMException⑥">(6)</a> <a href="#ref-for-idl-DOMException⑦">(7)</a> <a href="#ref-for-idl-DOMException⑧">(8)</a> <a href="#ref-for-idl-DOMException⑨">(9)</a> <a href="#ref-for-idl-DOMException①⓪">(10)</a>
@@ -8826,8 +8826,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-DOMException②③">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-idl-DOMException②④">(2)</a> <a href="#ref-for-idl-DOMException②⑤">(3)</a> <a href="#ref-for-idl-DOMException②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.1.1. Enumerations as DOMString types</a>
     <li><a href="#ref-for-idl-DOMString①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8844,8 +8844,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-DOMString③⑥">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-idl-DOMString③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-Exposed①">5.2. Authenticator Responses (interface AuthenticatorResponse)</a>
@@ -8853,8 +8853,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-Exposed③">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-invalidstateerror①">(2)</a> <a href="#ref-for-invalidstateerror②">(3)</a>
     <li><a href="#ref-for-invalidstateerror③">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -8862,8 +8862,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-invalidstateerror⑤">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notallowederror" class="dfn-panel" data-for="term-for-notallowederror" id="infopanel-for-term-for-notallowederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notallowederror" style="display:none">Info about the 'NotAllowedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-notallowederror①">(2)</a> <a href="#ref-for-notallowederror②">(3)</a> <a href="#ref-for-notallowederror③">(4)</a>
     <li><a href="#ref-for-notallowederror④">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-notallowederror⑤">(2)</a> <a href="#ref-for-notallowederror⑥">(3)</a> <a href="#ref-for-notallowederror⑦">(4)</a>
@@ -8872,8 +8872,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-notallowederror①①">6.3.3. The authenticatorGetAssertion Operation</a> <a href="#ref-for-notallowederror①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-notsupportederror①">5.1.5. Store an Existing Credential - PublicKeyCredential’s [[Store]](credential, sameOriginWithAncestors) Method</a>
@@ -8881,8 +8881,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-notsupportederror③">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-notsupportederror④">(2)</a> <a href="#ref-for-notsupportederror⑤">(3)</a> <a href="#ref-for-notsupportederror⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. Dependencies</a>
     <li><a href="#ref-for-idl-promise①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -8891,8 +8891,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-promise④">5.1.7. Availability of User-Verifying Platform Authenticator - PublicKeyCredential’s isUserVerifyingPlatformAuthenticatorAvailable() Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-SameObject①">(2)</a>
     <li><a href="#ref-for-SameObject②">5.2. Authenticator Responses (interface AuthenticatorResponse)</a>
@@ -8900,8 +8900,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-SameObject④">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a> <a href="#ref-for-SameObject⑤">(2)</a> <a href="#ref-for-SameObject⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-SecureContext①">5.2. Authenticator Responses (interface AuthenticatorResponse)</a>
@@ -8909,8 +8909,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-SecureContext③">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-securityerror①">(2)</a>
     <li><a href="#ref-for-securityerror②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-securityerror③">(2)</a>
@@ -8918,29 +8918,29 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-securityerror⑤">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a> <a href="#ref-for-idl-USVString①">(2)</a>
     <li><a href="#ref-for-idl-USVString②">10.1. FIDO AppID Extension (appid)</a>
     <li><a href="#ref-for-idl-USVString③">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unknownerror">
-   <a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unknownerror" class="dfn-panel" data-for="term-for-unknownerror" id="infopanel-for-term-for-unknownerror" role="menu">
+   <span id="infopaneltitle-for-term-for-unknownerror" style="display:none">Info about the 'UnknownError' external reference.</span><a href="https://webidl.spec.whatwg.org/#unknownerror">https://webidl.spec.whatwg.org/#unknownerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unknownerror">6.3.2. The authenticatorMakeCredential Operation</a> <a href="#ref-for-unknownerror①">(2)</a>
     <li><a href="#ref-for-unknownerror②">6.3.3. The authenticatorGetAssertion Operation</a> <a href="#ref-for-unknownerror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5.1.7. Availability of User-Verifying Platform Authenticator - PublicKeyCredential’s isUserVerifyingPlatformAuthenticatorAvailable() Method</a>
     <li><a href="#ref-for-idl-boolean①">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-idl-boolean②">(2)</a>
@@ -8952,28 +8952,28 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-boolean①①">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-idl-boolean①②">(2)</a> <a href="#ref-for-idl-boolean①③">(3)</a> <a href="#ref-for-idl-boolean①④">(4)</a> <a href="#ref-for-idl-boolean①⑤">(5)</a> <a href="#ref-for-idl-boolean①⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-reference">
-   <a href="https://heycam.github.io/webidl#dfn-get-buffer-source-reference">https://heycam.github.io/webidl#dfn-get-buffer-source-reference</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-reference" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-reference" id="infopanel-for-term-for-dfn-get-buffer-source-reference" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-reference" style="display:none">Info about the 'get a copy of the bytes held by the buffer source' external reference.</span><a href="https://heycam.github.io/webidl#dfn-get-buffer-source-reference">https://heycam.github.io/webidl#dfn-get-buffer-source-reference</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-reference">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dfn-get-buffer-source-reference①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-interface-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-interface-object" class="dfn-panel" data-for="term-for-dfn-interface-object" id="infopanel-for-term-for-dfn-interface-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-interface-object" style="display:none">Info about the 'interface object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-interface-object">https://webidl.spec.whatwg.org/#dfn-interface-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-interface-object">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-dfn-interface-object①">(2)</a> <a href="#ref-for-dfn-interface-object②">(3)</a>
     <li><a href="#ref-for-dfn-interface-object③">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">5.8.5. Cryptographic Algorithm Identifier (typedef COSEAlgorithmIdentifier)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-idl-sequence①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-idl-sequence②">(2)</a>
@@ -8982,22 +8982,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-idl-sequence⑤">10.3. User Verification Method Extension (uvm)</a> <a href="#ref-for-idl-sequence⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long②">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a> <a href="#ref-for-idl-unsigned-long③">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long④">10.3. User Verification Method Extension (uvm)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focus">
-   <a href="https://html.spec.whatwg.org/#focus">https://html.spec.whatwg.org/#focus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focus" class="dfn-panel" data-for="term-for-focus" id="infopanel-for-term-for-focus" role="menu">
+   <span id="infopaneltitle-for-term-for-focus" style="display:none">Info about the 'focus' external reference.</span><a href="https://html.spec.whatwg.org/#focus">https://html.spec.whatwg.org/#focus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focus">5.6. Abort Operations with AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-host-same-site">
-   <a href="https://url.spec.whatwg.org/#host-same-site">https://url.spec.whatwg.org/#host-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-host-same-site" class="dfn-panel" data-for="term-for-host-same-site" id="infopanel-for-term-for-host-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-host-same-site" style="display:none">Info about the 'same site' external reference.</span><a href="https://url.spec.whatwg.org/#host-same-site">https://url.spec.whatwg.org/#host-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-same-site">3. Dependencies</a>
     <li><a href="#ref-for-host-same-site①">10.1. FIDO AppID Extension (appid)</a>
@@ -9639,8 +9639,8 @@ for their contributions as our W3C Team Contacts.</p>
     loses focuses. If a hook is provided, the above paragraph will be updated to include the hook.
     See <a href="https://github.com/whatwg/html/issues/2711">WHATWG HTML WG Issue #2711</a> for more details. <a class="issue-return" href="#issue-c0359d2a" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="base64url-encoding">
-   <b><a href="#base64url-encoding">#base64url-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-base64url-encoding" class="dfn-panel" data-for="base64url-encoding" id="infopanel-for-base64url-encoding" role="dialog">
+   <span id="infopaneltitle-for-base64url-encoding" style="display:none">Info about the 'Base64url Encoding' definition.</span><b><a href="#base64url-encoding">#base64url-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-base64url-encoding">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-base64url-encoding①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-base64url-encoding②">(2)</a>
@@ -9655,8 +9655,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-base64url-encoding①③">11.5. Add Credential</a> <a href="#ref-for-base64url-encoding①④">(2)</a> <a href="#ref-for-base64url-encoding①⑤">(3)</a> <a href="#ref-for-base64url-encoding①⑥">(4)</a> <a href="#ref-for-base64url-encoding①⑦">(5)</a> <a href="#ref-for-base64url-encoding①⑧">(6)</a> <a href="#ref-for-base64url-encoding①⑨">(7)</a> <a href="#ref-for-base64url-encoding②⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cbor">
-   <b><a href="#cbor">#cbor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cbor" class="dfn-panel" data-for="cbor" id="infopanel-for-cbor" role="dialog">
+   <span id="infopaneltitle-for-cbor" style="display:none">Info about the 'CBOR' definition.</span><b><a href="#cbor">#cbor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cbor">2.4. All Conformance Classes</a>
     <li><a href="#ref-for-cbor①">3. Dependencies</a>
@@ -9674,16 +9674,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-cbor②④">9.5. Authenticator Extension Processing</a> <a href="#ref-for-cbor②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cddl">
-   <b><a href="#cddl">#cddl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cddl" class="dfn-panel" data-for="cddl" id="infopanel-for-cddl" role="dialog">
+   <span id="infopaneltitle-for-cddl" style="display:none">Info about the 'CDDL' definition.</span><b><a href="#cddl">#cddl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cddl">5.7.3. Authentication Extensions Authenticator Inputs (CDDL type AuthenticationExtensionsAuthenticatorInputs)</a>
     <li><a href="#ref-for-cddl①">5.7.4. Authentication Extensions Authenticator Outputs (CDDL type AuthenticationExtensionsAuthenticatorOutputs)</a>
     <li><a href="#ref-for-cddl②">9.3. Extending Request Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation">
-   <b><a href="#attestation">#attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation" class="dfn-panel" data-for="attestation" id="infopanel-for-attestation" role="dialog">
+   <span id="infopaneltitle-for-attestation" style="display:none">Info about the 'Attestation' definition.</span><b><a href="#attestation">#attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation②">1.1. Specification Roadmap</a>
     <li><a href="#ref-for-attestation③">4. Terminology</a> <a href="#ref-for-attestation④">(2)</a> <a href="#ref-for-attestation⑤">(3)</a>
@@ -9698,8 +9698,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation②①">13. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-certificate">
-   <b><a href="#attestation-certificate">#attestation-certificate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-certificate" class="dfn-panel" data-for="attestation-certificate" id="infopanel-for-attestation-certificate" role="dialog">
+   <span id="infopaneltitle-for-attestation-certificate" style="display:none">Info about the 'Attestation Certificate' definition.</span><b><a href="#attestation-certificate">#attestation-certificate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-certificate">4. Terminology</a> <a href="#ref-for-attestation-certificate①">(2)</a>
     <li><a href="#ref-for-attestation-certificate②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -9713,8 +9713,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-certificate①⑤">14.4.1. Attestation Privacy</a> <a href="#ref-for-attestation-certificate①⑥">(2)</a> <a href="#ref-for-attestation-certificate①⑦">(3)</a> <a href="#ref-for-attestation-certificate①⑧">(4)</a> <a href="#ref-for-attestation-certificate①⑨">(5)</a> <a href="#ref-for-attestation-certificate②⓪">(6)</a> <a href="#ref-for-attestation-certificate②①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-key-pair">
-   <b><a href="#attestation-key-pair">#attestation-key-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-key-pair" class="dfn-panel" data-for="attestation-key-pair" id="infopanel-for-attestation-key-pair" role="dialog">
+   <span id="infopaneltitle-for-attestation-key-pair" style="display:none">Info about the 'attestation key pair' definition.</span><b><a href="#attestation-key-pair">#attestation-key-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-key-pair">4. Terminology</a> <a href="#ref-for-attestation-key-pair①">(2)</a>
     <li><a href="#ref-for-attestation-key-pair②">6.5. Attestation</a>
@@ -9723,8 +9723,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-key-pair⑦">14.4.1. Attestation Privacy</a> <a href="#ref-for-attestation-key-pair⑧">(2)</a> <a href="#ref-for-attestation-key-pair⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-private-key">
-   <b><a href="#attestation-private-key">#attestation-private-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-private-key" class="dfn-panel" data-for="attestation-private-key" id="infopanel-for-attestation-private-key" role="dialog">
+   <span id="infopaneltitle-for-attestation-private-key" style="display:none">Info about the 'attestation private key' definition.</span><b><a href="#attestation-private-key">#attestation-private-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-private-key">6. WebAuthn Authenticator Model</a>
     <li><a href="#ref-for-attestation-private-key①">6.5. Attestation</a>
@@ -9734,15 +9734,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-private-key⑥">14.4.1. Attestation Privacy</a> <a href="#ref-for-attestation-private-key⑦">(2)</a> <a href="#ref-for-attestation-private-key⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-public-key">
-   <b><a href="#attestation-public-key">#attestation-public-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-public-key" class="dfn-panel" data-for="attestation-public-key" id="infopanel-for-attestation-public-key" role="dialog">
+   <span id="infopaneltitle-for-attestation-public-key" style="display:none">Info about the 'attestation public key' definition.</span><b><a href="#attestation-public-key">#attestation-public-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-public-key">6.5. Attestation</a>
     <li><a href="#ref-for-attestation-public-key①">13.3.2. Attestation Certificate and Attestation Certificate CA Compromise</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication">
-   <b><a href="#authentication">#authentication</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication" class="dfn-panel" data-for="authentication" id="infopanel-for-authentication" role="dialog">
+   <span id="infopaneltitle-for-authentication" style="display:none">Info about the 'Authentication' definition.</span><b><a href="#authentication">#authentication</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication">1. Introduction</a> <a href="#ref-for-authentication①">(2)</a>
     <li><a href="#ref-for-authentication②">1.1. Specification Roadmap</a>
@@ -9757,8 +9757,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authentication①⑦">16. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication-ceremony">
-   <b><a href="#authentication-ceremony">#authentication-ceremony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication-ceremony" class="dfn-panel" data-for="authentication-ceremony" id="infopanel-for-authentication-ceremony" role="dialog">
+   <span id="infopaneltitle-for-authentication-ceremony" style="display:none">Info about the 'Authentication Ceremony' definition.</span><b><a href="#authentication-ceremony">#authentication-ceremony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-ceremony">4. Terminology</a> <a href="#ref-for-authentication-ceremony①">(2)</a> <a href="#ref-for-authentication-ceremony②">(3)</a> <a href="#ref-for-authentication-ceremony③">(4)</a> <a href="#ref-for-authentication-ceremony④">(5)</a>
     <li><a href="#ref-for-authentication-ceremony⑤">6.2.1. Authenticator Attachment Modality</a>
@@ -9775,8 +9775,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authentication-ceremony②⑨">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication-assertion">
-   <b><a href="#authentication-assertion">#authentication-assertion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication-assertion" class="dfn-panel" data-for="authentication-assertion" id="infopanel-for-authentication-assertion" role="dialog">
+   <span id="infopaneltitle-for-authentication-assertion" style="display:none">Info about the 'Authentication Assertion' definition.</span><b><a href="#authentication-assertion">#authentication-assertion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-assertion">1. Introduction</a>
     <li><a href="#ref-for-authentication-assertion①">4. Terminology</a> <a href="#ref-for-authentication-assertion②">(2)</a> <a href="#ref-for-authentication-assertion③">(3)</a> <a href="#ref-for-authentication-assertion④">(4)</a> <a href="#ref-for-authentication-assertion⑤">(5)</a> <a href="#ref-for-authentication-assertion⑥">(6)</a> <a href="#ref-for-authentication-assertion⑦">(7)</a>
@@ -9789,8 +9789,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authentication-assertion①⑤">13.4.4. Attestation Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertion">
-   <b><a href="#assertion">#assertion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertion" class="dfn-panel" data-for="assertion" id="infopanel-for-assertion" role="dialog">
+   <span id="infopaneltitle-for-assertion" style="display:none">Info about the 'Assertion' definition.</span><b><a href="#assertion">#assertion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertion">4. Terminology</a>
     <li><a href="#ref-for-assertion①">6.1. Authenticator Data</a>
@@ -9801,8 +9801,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-assertion⑦">14.3. Authenticator-local Biometric Recognition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator">
-   <b><a href="#authenticator">#authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator" class="dfn-panel" data-for="authenticator" id="infopanel-for-authenticator" role="dialog">
+   <span id="infopaneltitle-for-authenticator" style="display:none">Info about the 'Authenticator' definition.</span><b><a href="#authenticator">#authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator⑤">1. Introduction</a> <a href="#ref-for-authenticator⑥">(2)</a> <a href="#ref-for-authenticator⑦">(3)</a>
     <li><a href="#ref-for-authenticator⑧">1.1. Specification Roadmap</a> <a href="#ref-for-authenticator⑨">(2)</a> <a href="#ref-for-authenticator①⓪">(3)</a> <a href="#ref-for-authenticator①①">(4)</a> <a href="#ref-for-authenticator①②">(5)</a> <a href="#ref-for-authenticator①③">(6)</a> <a href="#ref-for-authenticator①④">(7)</a> <a href="#ref-for-authenticator①⑤">(8)</a>
@@ -9875,8 +9875,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator②⑦⓪">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-authenticator">
-   <b><a href="#webauthn-authenticator">#webauthn-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-authenticator" class="dfn-panel" data-for="webauthn-authenticator" id="infopanel-for-webauthn-authenticator" role="dialog">
+   <span id="infopaneltitle-for-webauthn-authenticator" style="display:none">Info about the 'WebAuthn Authenticator' definition.</span><b><a href="#webauthn-authenticator">#webauthn-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-authenticator">1. Introduction</a>
     <li><a href="#ref-for-webauthn-authenticator①">2.2. Authenticators</a>
@@ -9891,8 +9891,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-webauthn-authenticator①⑥">14.4.1. Attestation Privacy</a> <a href="#ref-for-webauthn-authenticator①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authorization-gesture">
-   <b><a href="#authorization-gesture">#authorization-gesture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authorization-gesture" class="dfn-panel" data-for="authorization-gesture" id="infopanel-for-authorization-gesture" role="dialog">
+   <span id="infopaneltitle-for-authorization-gesture" style="display:none">Info about the 'Authorization Gesture' definition.</span><b><a href="#authorization-gesture">#authorization-gesture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authorization-gesture">1.2.1. Registration</a>
     <li><a href="#ref-for-authorization-gesture①">1.2.2. Authentication</a>
@@ -9910,23 +9910,23 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authorization-gesture③⓪">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="biometric-recognition">
-   <b><a href="#biometric-recognition">#biometric-recognition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-biometric-recognition" class="dfn-panel" data-for="biometric-recognition" id="infopanel-for-biometric-recognition" role="dialog">
+   <span id="infopaneltitle-for-biometric-recognition" style="display:none">Info about the 'Biometric Recognition' definition.</span><b><a href="#biometric-recognition">#biometric-recognition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-biometric-recognition">4. Terminology</a> <a href="#ref-for-biometric-recognition①">(2)</a> <a href="#ref-for-biometric-recognition②">(3)</a>
     <li><a href="#ref-for-biometric-recognition③">6.2. Authenticator Taxonomy</a>
     <li><a href="#ref-for-biometric-recognition④">14.3. Authenticator-local Biometric Recognition</a> <a href="#ref-for-biometric-recognition⑤">(2)</a> <a href="#ref-for-biometric-recognition⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="biometric-authenticator">
-   <b><a href="#biometric-authenticator">#biometric-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-biometric-authenticator" class="dfn-panel" data-for="biometric-authenticator" id="infopanel-for-biometric-authenticator" role="dialog">
+   <span id="infopaneltitle-for-biometric-authenticator" style="display:none">Info about the 'Biometric Authenticator' definition.</span><b><a href="#biometric-authenticator">#biometric-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-biometric-authenticator">6.2.3. Authentication Factor Capability</a>
     <li><a href="#ref-for-biometric-authenticator①">14.3. Authenticator-local Biometric Recognition</a> <a href="#ref-for-biometric-authenticator②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bound-credential">
-   <b><a href="#bound-credential">#bound-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bound-credential" class="dfn-panel" data-for="bound-credential" id="infopanel-for-bound-credential" role="dialog">
+   <span id="infopaneltitle-for-bound-credential" style="display:none">Info about the 'Bound credential' definition.</span><b><a href="#bound-credential">#bound-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bound-credential①">4. Terminology</a> <a href="#ref-for-bound-credential②">(2)</a> <a href="#ref-for-bound-credential③">(3)</a>
     <li><a href="#ref-for-bound-credential④">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-bound-credential⑤">(2)</a> <a href="#ref-for-bound-credential⑥">(3)</a>
@@ -9937,8 +9937,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-bound-credential①④">14.5.1. Registration Ceremony Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ceremony">
-   <b><a href="#ceremony">#ceremony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ceremony" class="dfn-panel" data-for="ceremony" id="infopanel-for-ceremony" role="dialog">
+   <span id="infopaneltitle-for-ceremony" style="display:none">Info about the 'Ceremony' definition.</span><b><a href="#ceremony">#ceremony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ceremony">1. Introduction</a>
     <li><a href="#ref-for-ceremony①">4. Terminology</a> <a href="#ref-for-ceremony②">(2)</a> <a href="#ref-for-ceremony③">(3)</a> <a href="#ref-for-ceremony④">(4)</a> <a href="#ref-for-ceremony⑤">(5)</a> <a href="#ref-for-ceremony⑥">(6)</a> <a href="#ref-for-ceremony⑦">(7)</a>
@@ -9950,8 +9950,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-ceremony①④">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client">
-   <b><a href="#client">#client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client" class="dfn-panel" data-for="client" id="infopanel-for-client" role="dialog">
+   <span id="infopaneltitle-for-client" style="display:none">Info about the 'Client' definition.</span><b><a href="#client">#client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client">1.1. Specification Roadmap</a>
     <li><a href="#ref-for-client①">1.3.1. Registration</a> <a href="#ref-for-client②">(2)</a>
@@ -9992,8 +9992,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client⑧⑧">14.5. Privacy considerations for clients</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-client">
-   <b><a href="#webauthn-client">#webauthn-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-client" class="dfn-panel" data-for="webauthn-client" id="infopanel-for-webauthn-client" role="dialog">
+   <span id="infopaneltitle-for-webauthn-client" style="display:none">Info about the 'WebAuthn Client' definition.</span><b><a href="#webauthn-client">#webauthn-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-client">1.1. Specification Roadmap</a>
     <li><a href="#ref-for-webauthn-client①">4. Terminology</a> <a href="#ref-for-webauthn-client②">(2)</a> <a href="#ref-for-webauthn-client③">(3)</a> <a href="#ref-for-webauthn-client④">(4)</a> <a href="#ref-for-webauthn-client⑤">(5)</a>
@@ -10001,8 +10001,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-webauthn-client⑦">13. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-device">
-   <b><a href="#client-device">#client-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-device" class="dfn-panel" data-for="client-device" id="infopanel-for-client-device" role="dialog">
+   <span id="infopaneltitle-for-client-device" style="display:none">Info about the 'Client Device' definition.</span><b><a href="#client-device">#client-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-device">1.2.3. New Device Registration</a> <a href="#ref-for-client-device①">(2)</a> <a href="#ref-for-client-device②">(3)</a>
     <li><a href="#ref-for-client-device③">1.3. Sample API Usage Scenarios</a>
@@ -10019,14 +10019,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-device④⑥">14.5.3. Privacy Between Operating System Accounts</a> <a href="#ref-for-client-device④⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-client-device">
-   <b><a href="#webauthn-client-device">#webauthn-client-device</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-client-device" class="dfn-panel" data-for="webauthn-client-device" id="infopanel-for-webauthn-client-device" role="dialog">
+   <span id="infopaneltitle-for-webauthn-client-device" style="display:none">Info about the 'WebAuthn Client Device' definition.</span><b><a href="#webauthn-client-device">#webauthn-client-device</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-client-device">4. Terminology</a> <a href="#ref-for-webauthn-client-device①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-platform">
-   <b><a href="#client-platform">#client-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-platform" class="dfn-panel" data-for="client-platform" id="infopanel-for-client-platform" role="dialog">
+   <span id="infopaneltitle-for-client-platform" style="display:none">Info about the 'Client Platform' definition.</span><b><a href="#client-platform">#client-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-platform">1.3. Sample API Usage Scenarios</a> <a href="#ref-for-client-platform①">(2)</a> <a href="#ref-for-client-platform②">(3)</a>
     <li><a href="#ref-for-client-platform③">1.3.1. Registration</a>
@@ -10057,14 +10057,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-platform④⑨">15. Accessibility Considerations</a> <a href="#ref-for-client-platform⑤⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-side">
-   <b><a href="#client-side">#client-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-side" class="dfn-panel" data-for="client-side" id="infopanel-for-client-side" role="dialog">
+   <span id="infopaneltitle-for-client-side" style="display:none">Info about the 'Client-Side' definition.</span><b><a href="#client-side">#client-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-side">4. Terminology</a> <a href="#ref-for-client-side①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-side-discoverable-public-key-credential-source">
-   <b><a href="#client-side-discoverable-public-key-credential-source">#client-side-discoverable-public-key-credential-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-side-discoverable-public-key-credential-source" class="dfn-panel" data-for="client-side-discoverable-public-key-credential-source" id="infopanel-for-client-side-discoverable-public-key-credential-source" role="dialog">
+   <span id="infopaneltitle-for-client-side-discoverable-public-key-credential-source" style="display:none">Info about the 'Client-side discoverable Public Key Credential Source' definition.</span><b><a href="#client-side-discoverable-public-key-credential-source">#client-side-discoverable-public-key-credential-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-side-discoverable-public-key-credential-source">4. Terminology</a>
     <li><a href="#ref-for-client-side-discoverable-public-key-credential-source①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-client-side-discoverable-public-key-credential-source②">(2)</a>
@@ -10074,8 +10074,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-side-discoverable-public-key-credential-source⑧">14.2. Anonymous, Scoped, Non-correlatable Public Key Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-side-discoverable-credential">
-   <b><a href="#client-side-discoverable-credential">#client-side-discoverable-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-side-discoverable-credential" class="dfn-panel" data-for="client-side-discoverable-credential" id="infopanel-for-client-side-discoverable-credential" role="dialog">
+   <span id="infopaneltitle-for-client-side-discoverable-credential" style="display:none">Info about the 'Client-side discoverable Credential' definition.</span><b><a href="#client-side-discoverable-credential">#client-side-discoverable-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-side-discoverable-credential">4. Terminology</a> <a href="#ref-for-client-side-discoverable-credential①">(2)</a> <a href="#ref-for-client-side-discoverable-credential②">(3)</a> <a href="#ref-for-client-side-discoverable-credential③">(4)</a> <a href="#ref-for-client-side-discoverable-credential④">(5)</a> <a href="#ref-for-client-side-discoverable-credential⑤">(6)</a>
     <li><a href="#ref-for-client-side-discoverable-credential⑥">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
@@ -10086,8 +10086,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-side-discoverable-credential①⑧">14.6.3. Privacy leak via credential IDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discoverable-credential">
-   <b><a href="#discoverable-credential">#discoverable-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discoverable-credential" class="dfn-panel" data-for="discoverable-credential" id="infopanel-for-discoverable-credential" role="dialog">
+   <span id="infopaneltitle-for-discoverable-credential" style="display:none">Info about the 'Discoverable Credential' definition.</span><b><a href="#discoverable-credential">#discoverable-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discoverable-credential">4. Terminology</a> <a href="#ref-for-discoverable-credential①">(2)</a>
     <li><a href="#ref-for-discoverable-credential②">5.4.3. User Account Parameters for Credential Generation (dictionary PublicKeyCredentialUserEntity)</a>
@@ -10095,22 +10095,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-discoverable-credential④">10.4. Credential Properties Extension (credProps)</a> <a href="#ref-for-discoverable-credential⑤">(2)</a> <a href="#ref-for-discoverable-credential⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resident-credential">
-   <b><a href="#resident-credential">#resident-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resident-credential" class="dfn-panel" data-for="resident-credential" id="infopanel-for-resident-credential" role="dialog">
+   <span id="infopaneltitle-for-resident-credential" style="display:none">Info about the 'Resident Credential' definition.</span><b><a href="#resident-credential">#resident-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resident-credential">4. Terminology</a>
     <li><a href="#ref-for-resident-credential①">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resident-key">
-   <b><a href="#resident-key">#resident-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resident-key" class="dfn-panel" data-for="resident-key" id="infopanel-for-resident-key" role="dialog">
+   <span id="infopaneltitle-for-resident-key" style="display:none">Info about the 'Resident Key' definition.</span><b><a href="#resident-key">#resident-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resident-key">4. Terminology</a> <a href="#ref-for-resident-key①">(2)</a>
     <li><a href="#ref-for-resident-key②">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="conforming-user-agent">
-   <b><a href="#conforming-user-agent">#conforming-user-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-conforming-user-agent" class="dfn-panel" data-for="conforming-user-agent" id="infopanel-for-conforming-user-agent" role="dialog">
+   <span id="infopaneltitle-for-conforming-user-agent" style="display:none">Info about the 'Conforming User Agent' definition.</span><b><a href="#conforming-user-agent">#conforming-user-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-conforming-user-agent">1. Introduction</a>
     <li><a href="#ref-for-conforming-user-agent①">2.1. User Agents</a>
@@ -10119,8 +10119,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-conforming-user-agent④">6.4.1. String Truncation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-id">
-   <b><a href="#credential-id">#credential-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-id" class="dfn-panel" data-for="credential-id" id="infopanel-for-credential-id" role="dialog">
+   <span id="infopaneltitle-for-credential-id" style="display:none">Info about the 'Credential ID' definition.</span><b><a href="#credential-id">#credential-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-id">1.3.1. Registration</a>
     <li><a href="#ref-for-credential-id①">1.3.3. Authentication</a> <a href="#ref-for-credential-id②">(2)</a> <a href="#ref-for-credential-id③">(3)</a>
@@ -10144,15 +10144,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-credential-id③⑧">14.6.3. Privacy leak via credential IDs</a> <a href="#ref-for-credential-id③⑨">(2)</a> <a href="#ref-for-credential-id④⓪">(3)</a> <a href="#ref-for-credential-id④①">(4)</a> <a href="#ref-for-credential-id④②">(5)</a> <a href="#ref-for-credential-id④③">(6)</a> <a href="#ref-for-credential-id④④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-key-pair">
-   <b><a href="#credential-key-pair">#credential-key-pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-key-pair" class="dfn-panel" data-for="credential-key-pair" id="infopanel-for-credential-key-pair" role="dialog">
+   <span id="infopaneltitle-for-credential-key-pair" style="display:none">Info about the 'Credential Key Pair' definition.</span><b><a href="#credential-key-pair">#credential-key-pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-key-pair">4. Terminology</a> <a href="#ref-for-credential-key-pair①">(2)</a> <a href="#ref-for-credential-key-pair②">(3)</a> <a href="#ref-for-credential-key-pair③">(4)</a> <a href="#ref-for-credential-key-pair④">(5)</a>
     <li><a href="#ref-for-credential-key-pair⑤">14.2. Anonymous, Scoped, Non-correlatable Public Key Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-private-key">
-   <b><a href="#credential-private-key">#credential-private-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-private-key" class="dfn-panel" data-for="credential-private-key" id="infopanel-for-credential-private-key" role="dialog">
+   <span id="infopaneltitle-for-credential-private-key" style="display:none">Info about the 'Credential Private Key' definition.</span><b><a href="#credential-private-key">#credential-private-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-private-key">4. Terminology</a> <a href="#ref-for-credential-private-key①">(2)</a> <a href="#ref-for-credential-private-key②">(3)</a> <a href="#ref-for-credential-private-key③">(4)</a> <a href="#ref-for-credential-private-key④">(5)</a> <a href="#ref-for-credential-private-key⑤">(6)</a> <a href="#ref-for-credential-private-key⑥">(7)</a>
     <li><a href="#ref-for-credential-private-key⑦">5.1. PublicKeyCredential Interface</a>
@@ -10168,8 +10168,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-credential-private-key②⑤">14.1. De-anonymization Prevention Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-public-key">
-   <b><a href="#credential-public-key">#credential-public-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-public-key" class="dfn-panel" data-for="credential-public-key" id="infopanel-for-credential-public-key" role="dialog">
+   <span id="infopaneltitle-for-credential-public-key" style="display:none">Info about the 'Credential Public Key' definition.</span><b><a href="#credential-public-key">#credential-public-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-public-key">1.3.1. Registration</a> <a href="#ref-for-credential-public-key①">(2)</a>
     <li><a href="#ref-for-credential-public-key②">4. Terminology</a> <a href="#ref-for-credential-public-key③">(2)</a> <a href="#ref-for-credential-public-key④">(3)</a> <a href="#ref-for-credential-public-key⑤">(4)</a> <a href="#ref-for-credential-public-key⑥">(5)</a> <a href="#ref-for-credential-public-key⑦">(6)</a> <a href="#ref-for-credential-public-key⑧">(7)</a> <a href="#ref-for-credential-public-key⑨">(8)</a> <a href="#ref-for-credential-public-key①⓪">(9)</a> <a href="#ref-for-credential-public-key①①">(10)</a>
@@ -10188,38 +10188,38 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-credential-public-key③⑧">14.2. Anonymous, Scoped, Non-correlatable Public Key Credentials</a> <a href="#ref-for-credential-public-key③⑨">(2)</a> <a href="#ref-for-credential-public-key④⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-public-key">
-   <b><a href="#user-public-key">#user-public-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-public-key" class="dfn-panel" data-for="user-public-key" id="infopanel-for-user-public-key" role="dialog">
+   <span id="infopaneltitle-for-user-public-key" style="display:none">Info about the 'User Public Key' definition.</span><b><a href="#user-public-key">#user-public-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-public-key">4. Terminology</a>
     <li><a href="#ref-for-user-public-key①">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-properties">
-   <b><a href="#credential-properties">#credential-properties</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-properties" class="dfn-panel" data-for="credential-properties" id="infopanel-for-credential-properties" role="dialog">
+   <span id="infopaneltitle-for-credential-properties" style="display:none">Info about the 'Credential Properties' definition.</span><b><a href="#credential-properties">#credential-properties</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-properties">4. Terminology</a>
     <li><a href="#ref-for-credential-properties①">10.4. Credential Properties Extension (credProps)</a> <a href="#ref-for-credential-properties②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="human-palatability">
-   <b><a href="#human-palatability">#human-palatability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-human-palatability" class="dfn-panel" data-for="human-palatability" id="infopanel-for-human-palatability" role="dialog">
+   <span id="infopaneltitle-for-human-palatability" style="display:none">Info about the 'Human Palatability' definition.</span><b><a href="#human-palatability">#human-palatability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-human-palatability">4. Terminology</a>
     <li><a href="#ref-for-human-palatability①">5.4.1. Public Key Entity Description (dictionary PublicKeyCredentialEntity)</a> <a href="#ref-for-human-palatability②">(2)</a> <a href="#ref-for-human-palatability③">(3)</a>
     <li><a href="#ref-for-human-palatability④">5.4.3. User Account Parameters for Credential Generation (dictionary PublicKeyCredentialUserEntity)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-discoverable-credential">
-   <b><a href="#non-discoverable-credential">#non-discoverable-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-discoverable-credential" class="dfn-panel" data-for="non-discoverable-credential" id="infopanel-for-non-discoverable-credential" role="dialog">
+   <span id="infopaneltitle-for-non-discoverable-credential" style="display:none">Info about the 'Non-Discoverable Credential' definition.</span><b><a href="#non-discoverable-credential">#non-discoverable-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-discoverable-credential">4. Terminology</a> <a href="#ref-for-non-discoverable-credential①">(2)</a>
     <li><a href="#ref-for-non-discoverable-credential②">5.4.3. User Account Parameters for Credential Generation (dictionary PublicKeyCredentialUserEntity)</a>
     <li><a href="#ref-for-non-discoverable-credential③">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source">
-   <b><a href="#public-key-credential-source">#public-key-credential-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source" class="dfn-panel" data-for="public-key-credential-source" id="infopanel-for-public-key-credential-source" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source" style="display:none">Info about the 'Public Key Credential Source' definition.</span><b><a href="#public-key-credential-source">#public-key-credential-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source">4. Terminology</a> <a href="#ref-for-public-key-credential-source①">(2)</a> <a href="#ref-for-public-key-credential-source②">(3)</a> <a href="#ref-for-public-key-credential-source③">(4)</a> <a href="#ref-for-public-key-credential-source④">(5)</a> <a href="#ref-for-public-key-credential-source⑤">(6)</a> <a href="#ref-for-public-key-credential-source⑥">(7)</a> <a href="#ref-for-public-key-credential-source⑦">(8)</a> <a href="#ref-for-public-key-credential-source⑧">(9)</a> <a href="#ref-for-public-key-credential-source⑨">(10)</a> <a href="#ref-for-public-key-credential-source①⓪">(11)</a> <a href="#ref-for-public-key-credential-source①①">(12)</a> <a href="#ref-for-public-key-credential-source①②">(13)</a> <a href="#ref-for-public-key-credential-source①③">(14)</a> <a href="#ref-for-public-key-credential-source①④">(15)</a> <a href="#ref-for-public-key-credential-source①⑤">(16)</a> <a href="#ref-for-public-key-credential-source①⑥">(17)</a> <a href="#ref-for-public-key-credential-source①⑦">(18)</a> <a href="#ref-for-public-key-credential-source①⑧">(19)</a> <a href="#ref-for-public-key-credential-source①⑨">(20)</a> <a href="#ref-for-public-key-credential-source②⓪">(21)</a>
     <li><a href="#ref-for-public-key-credential-source②①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -10236,15 +10236,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-public-key-credential-source④⓪">11.8. Remove All Credentials</a> <a href="#ref-for-public-key-credential-source④①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-type">
-   <b><a href="#public-key-credential-source-type">#public-key-credential-source-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-type" class="dfn-panel" data-for="public-key-credential-source-type" id="infopanel-for-public-key-credential-source-type" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-type" style="display:none">Info about the 'type' definition.</span><b><a href="#public-key-credential-source-type">#public-key-credential-source-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-type">6.3.2. The authenticatorMakeCredential Operation</a>
     <li><a href="#ref-for-public-key-credential-source-type①">11.5. Add Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-id">
-   <b><a href="#public-key-credential-source-id">#public-key-credential-source-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-id" class="dfn-panel" data-for="public-key-credential-source-id" id="infopanel-for-public-key-credential-source-id" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-id" style="display:none">Info about the 'id' definition.</span><b><a href="#public-key-credential-source-id">#public-key-credential-source-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-id">6.3.1. Lookup Credential Source by Credential ID Algorithm</a> <a href="#ref-for-public-key-credential-source-id①">(2)</a>
     <li><a href="#ref-for-public-key-credential-source-id②">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -10252,16 +10252,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-public-key-credential-source-id④">11.5. Add Credential</a> <a href="#ref-for-public-key-credential-source-id⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-privatekey">
-   <b><a href="#public-key-credential-source-privatekey">#public-key-credential-source-privatekey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-privatekey" class="dfn-panel" data-for="public-key-credential-source-privatekey" id="infopanel-for-public-key-credential-source-privatekey" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-privatekey" style="display:none">Info about the 'privateKey' definition.</span><b><a href="#public-key-credential-source-privatekey">#public-key-credential-source-privatekey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-privatekey">6.3.2. The authenticatorMakeCredential Operation</a>
     <li><a href="#ref-for-public-key-credential-source-privatekey①">6.3.3. The authenticatorGetAssertion Operation</a>
     <li><a href="#ref-for-public-key-credential-source-privatekey②">11.5. Add Credential</a> <a href="#ref-for-public-key-credential-source-privatekey③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-rpid">
-   <b><a href="#public-key-credential-source-rpid">#public-key-credential-source-rpid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-rpid" class="dfn-panel" data-for="public-key-credential-source-rpid" id="infopanel-for-public-key-credential-source-rpid" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-rpid" style="display:none">Info about the 'rpId' definition.</span><b><a href="#public-key-credential-source-rpid">#public-key-credential-source-rpid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-rpid">6. WebAuthn Authenticator Model</a>
     <li><a href="#ref-for-public-key-credential-source-rpid①">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -10269,8 +10269,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-public-key-credential-source-rpid③">11.5. Add Credential</a> <a href="#ref-for-public-key-credential-source-rpid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-userhandle">
-   <b><a href="#public-key-credential-source-userhandle">#public-key-credential-source-userhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-userhandle" class="dfn-panel" data-for="public-key-credential-source-userhandle" id="infopanel-for-public-key-credential-source-userhandle" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-userhandle" style="display:none">Info about the 'userHandle' definition.</span><b><a href="#public-key-credential-source-userhandle">#public-key-credential-source-userhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-userhandle">6. WebAuthn Authenticator Model</a>
     <li><a href="#ref-for-public-key-credential-source-userhandle①">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -10278,29 +10278,29 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-public-key-credential-source-userhandle④">11.5. Add Credential</a> <a href="#ref-for-public-key-credential-source-userhandle⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-otherui">
-   <b><a href="#public-key-credential-source-otherui">#public-key-credential-source-otherui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-otherui" class="dfn-panel" data-for="public-key-credential-source-otherui" id="infopanel-for-public-key-credential-source-otherui" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-otherui" style="display:none">Info about the 'otherUI' definition.</span><b><a href="#public-key-credential-source-otherui">#public-key-credential-source-otherui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-otherui">4. Terminology</a> <a href="#ref-for-public-key-credential-source-otherui①">(2)</a>
     <li><a href="#ref-for-public-key-credential-source-otherui②">6.3.2. The authenticatorMakeCredential Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-mutable-item">
-   <b><a href="#public-key-credential-source-mutable-item">#public-key-credential-source-mutable-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-mutable-item" class="dfn-panel" data-for="public-key-credential-source-mutable-item" id="infopanel-for-public-key-credential-source-mutable-item" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-mutable-item" style="display:none">Info about the 'mutable item' definition.</span><b><a href="#public-key-credential-source-mutable-item">#public-key-credential-source-mutable-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-mutable-item">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential-source-managing-authenticator">
-   <b><a href="#public-key-credential-source-managing-authenticator">#public-key-credential-source-managing-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential-source-managing-authenticator" class="dfn-panel" data-for="public-key-credential-source-managing-authenticator" id="infopanel-for-public-key-credential-source-managing-authenticator" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential-source-managing-authenticator" style="display:none">Info about the 'managing authenticator' definition.</span><b><a href="#public-key-credential-source-managing-authenticator">#public-key-credential-source-managing-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential-source-managing-authenticator">4. Terminology</a> <a href="#ref-for-public-key-credential-source-managing-authenticator①">(2)</a> <a href="#ref-for-public-key-credential-source-managing-authenticator②">(3)</a> <a href="#ref-for-public-key-credential-source-managing-authenticator③">(4)</a>
     <li><a href="#ref-for-public-key-credential-source-managing-authenticator④">5. Web Authentication API</a> <a href="#ref-for-public-key-credential-source-managing-authenticator⑤">(2)</a>
     <li><a href="#ref-for-public-key-credential-source-managing-authenticator⑥">5.8.3. Credential Descriptor (dictionary PublicKeyCredentialDescriptor)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="public-key-credential">
-   <b><a href="#public-key-credential">#public-key-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-public-key-credential" class="dfn-panel" data-for="public-key-credential" id="infopanel-for-public-key-credential" role="dialog">
+   <span id="infopaneltitle-for-public-key-credential" style="display:none">Info about the 'Public Key Credential' definition.</span><b><a href="#public-key-credential">#public-key-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-public-key-credential②">1. Introduction</a> <a href="#ref-for-public-key-credential③">(2)</a> <a href="#ref-for-public-key-credential④">(3)</a> <a href="#ref-for-public-key-credential⑤">(4)</a> <a href="#ref-for-public-key-credential⑥">(5)</a>
     <li><a href="#ref-for-public-key-credential⑦">1.3. Sample API Usage Scenarios</a>
@@ -10339,14 +10339,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-public-key-credential⑦⑥">14.5.2. Authentication Ceremony Privacy</a> <a href="#ref-for-public-key-credential⑦⑦">(2)</a> <a href="#ref-for-public-key-credential⑦⑧">(3)</a> <a href="#ref-for-public-key-credential⑦⑨">(4)</a> <a href="#ref-for-public-key-credential⑧⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rate-limiting">
-   <b><a href="#rate-limiting">#rate-limiting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rate-limiting" class="dfn-panel" data-for="rate-limiting" id="infopanel-for-rate-limiting" role="dialog">
+   <span id="infopaneltitle-for-rate-limiting" style="display:none">Info about the 'Rate Limiting' definition.</span><b><a href="#rate-limiting">#rate-limiting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rate-limiting">4. Terminology</a> <a href="#ref-for-rate-limiting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registration">
-   <b><a href="#registration">#registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registration" class="dfn-panel" data-for="registration" id="infopanel-for-registration" role="dialog">
+   <span id="infopaneltitle-for-registration" style="display:none">Info about the 'Registration' definition.</span><b><a href="#registration">#registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration">1. Introduction</a> <a href="#ref-for-registration①">(2)</a>
     <li><a href="#ref-for-registration②">1.1. Specification Roadmap</a>
@@ -10360,8 +10360,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-registration②⓪">16. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registration-ceremony">
-   <b><a href="#registration-ceremony">#registration-ceremony</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registration-ceremony" class="dfn-panel" data-for="registration-ceremony" id="infopanel-for-registration-ceremony" role="dialog">
+   <span id="infopaneltitle-for-registration-ceremony" style="display:none">Info about the 'Registration Ceremony' definition.</span><b><a href="#registration-ceremony">#registration-ceremony</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration-ceremony">4. Terminology</a> <a href="#ref-for-registration-ceremony①">(2)</a> <a href="#ref-for-registration-ceremony②">(3)</a>
     <li><a href="#ref-for-registration-ceremony③">7. WebAuthn Relying Party Operations</a>
@@ -10373,8 +10373,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-registration-ceremony①⑥">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relying-party">
-   <b><a href="#relying-party">#relying-party</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relying-party" class="dfn-panel" data-for="relying-party" id="infopanel-for-relying-party" role="dialog">
+   <span id="infopaneltitle-for-relying-party" style="display:none">Info about the 'Relying Party' definition.</span><b><a href="#relying-party">#relying-party</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relying-party①">1. Introduction</a> <a href="#ref-for-relying-party②">(2)</a> <a href="#ref-for-relying-party③">(3)</a> <a href="#ref-for-relying-party④">(4)</a> <a href="#ref-for-relying-party⑤">(5)</a> <a href="#ref-for-relying-party⑥">(6)</a> <a href="#ref-for-relying-party⑦">(7)</a>
     <li><a href="#ref-for-relying-party⑧">1.1. Specification Roadmap</a> <a href="#ref-for-relying-party⑨">(2)</a> <a href="#ref-for-relying-party①⓪">(3)</a> <a href="#ref-for-relying-party①①">(4)</a> <a href="#ref-for-relying-party①②">(5)</a> <a href="#ref-for-relying-party①③">(6)</a> <a href="#ref-for-relying-party①④">(7)</a> <a href="#ref-for-relying-party①⑤">(8)</a>
@@ -10458,16 +10458,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-relying-party③③⑦">15. Accessibility Considerations</a> <a href="#ref-for-relying-party③③⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relying-party-identifier">
-   <b><a href="#relying-party-identifier">#relying-party-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relying-party-identifier" class="dfn-panel" data-for="relying-party-identifier" id="infopanel-for-relying-party-identifier" role="dialog">
+   <span id="infopaneltitle-for-relying-party-identifier" style="display:none">Info about the 'Relying Party Identifier' definition.</span><b><a href="#relying-party-identifier">#relying-party-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relying-party-identifier">4. Terminology</a> <a href="#ref-for-relying-party-identifier①">(2)</a> <a href="#ref-for-relying-party-identifier②">(3)</a>
     <li><a href="#ref-for-relying-party-identifier③">5. Web Authentication API</a>
     <li><a href="#ref-for-relying-party-identifier④">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rp-id">
-   <b><a href="#rp-id">#rp-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rp-id" class="dfn-panel" data-for="rp-id" id="infopanel-for-rp-id" role="dialog">
+   <span id="infopaneltitle-for-rp-id" style="display:none">Info about the 'RP ID' definition.</span><b><a href="#rp-id">#rp-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rp-id">4. Terminology</a> <a href="#ref-for-rp-id①">(2)</a> <a href="#ref-for-rp-id②">(3)</a> <a href="#ref-for-rp-id③">(4)</a> <a href="#ref-for-rp-id④">(5)</a> <a href="#ref-for-rp-id⑤">(6)</a> <a href="#ref-for-rp-id⑥">(7)</a> <a href="#ref-for-rp-id⑦">(8)</a> <a href="#ref-for-rp-id⑧">(9)</a> <a href="#ref-for-rp-id⑨">(10)</a> <a href="#ref-for-rp-id①⓪">(11)</a> <a href="#ref-for-rp-id①①">(12)</a>
     <li><a href="#ref-for-rp-id①②">5. Web Authentication API</a> <a href="#ref-for-rp-id①③">(2)</a> <a href="#ref-for-rp-id①④">(3)</a> <a href="#ref-for-rp-id①⑤">(4)</a> <a href="#ref-for-rp-id①⑥">(5)</a>
@@ -10487,8 +10487,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-rp-id④③">11.5. Add Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scope">
-   <b><a href="#scope">#scope</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scope" class="dfn-panel" data-for="scope" id="infopanel-for-scope" role="dialog">
+   <span id="infopaneltitle-for-scope" style="display:none">Info about the 'scope' definition.</span><b><a href="#scope">#scope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scope②">1. Introduction</a> <a href="#ref-for-scope③">(2)</a> <a href="#ref-for-scope④">(3)</a>
     <li><a href="#ref-for-scope⑤">4. Terminology</a> <a href="#ref-for-scope⑥">(2)</a>
@@ -10505,21 +10505,21 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-scope②②">14.2. Anonymous, Scoped, Non-correlatable Public Key Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised">
-   <b><a href="#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised">#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised" class="dfn-panel" data-for="determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised" id="infopanel-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised" role="dialog">
+   <span id="infopaneltitle-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised" style="display:none">Info about the 'determines the set of origins on which the public key credential may be exercised' definition.</span><b><a href="#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised">#determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised">4. Terminology</a> <a href="#ref-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised①">(2)</a> <a href="#ref-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised②">(3)</a> <a href="#ref-for-determines-the-set-of-origins-on-which-the-public-key-credential-may-be-exercised③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="server-side-public-key-credential-source">
-   <b><a href="#server-side-public-key-credential-source">#server-side-public-key-credential-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-server-side-public-key-credential-source" class="dfn-panel" data-for="server-side-public-key-credential-source" id="infopanel-for-server-side-public-key-credential-source" role="dialog">
+   <span id="infopaneltitle-for-server-side-public-key-credential-source" style="display:none">Info about the 'Server-side Public Key Credential Source' definition.</span><b><a href="#server-side-public-key-credential-source">#server-side-public-key-credential-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-server-side-public-key-credential-source">4. Terminology</a> <a href="#ref-for-server-side-public-key-credential-source①">(2)</a>
     <li><a href="#ref-for-server-side-public-key-credential-source②">11.5. Add Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="server-side-credential">
-   <b><a href="#server-side-credential">#server-side-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-server-side-credential" class="dfn-panel" data-for="server-side-credential" id="infopanel-for-server-side-credential" role="dialog">
+   <span id="infopaneltitle-for-server-side-credential" style="display:none">Info about the 'Server-side Credential' definition.</span><b><a href="#server-side-credential">#server-side-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-server-side-credential">4. Terminology</a> <a href="#ref-for-server-side-credential①">(2)</a> <a href="#ref-for-server-side-credential②">(3)</a> <a href="#ref-for-server-side-credential③">(4)</a> <a href="#ref-for-server-side-credential④">(5)</a>
     <li><a href="#ref-for-server-side-credential⑤">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-server-side-credential⑥">(2)</a> <a href="#ref-for-server-side-credential⑦">(3)</a> <a href="#ref-for-server-side-credential⑧">(4)</a> <a href="#ref-for-server-side-credential⑨">(5)</a>
@@ -10529,14 +10529,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-server-side-credential①④">14.6.3. Privacy leak via credential IDs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-resident-credential">
-   <b><a href="#non-resident-credential">#non-resident-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-resident-credential" class="dfn-panel" data-for="non-resident-credential" id="infopanel-for-non-resident-credential" role="dialog">
+   <span id="infopaneltitle-for-non-resident-credential" style="display:none">Info about the 'Non-Resident Credential' definition.</span><b><a href="#non-resident-credential">#non-resident-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-resident-credential">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="test-of-user-presence">
-   <b><a href="#test-of-user-presence">#test-of-user-presence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-test-of-user-presence" class="dfn-panel" data-for="test-of-user-presence" id="infopanel-for-test-of-user-presence" role="dialog">
+   <span id="infopaneltitle-for-test-of-user-presence" style="display:none">Info about the 'Test of User Presence' definition.</span><b><a href="#test-of-user-presence">#test-of-user-presence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-test-of-user-presence">4. Terminology</a> <a href="#ref-for-test-of-user-presence①">(2)</a> <a href="#ref-for-test-of-user-presence②">(3)</a> <a href="#ref-for-test-of-user-presence③">(4)</a> <a href="#ref-for-test-of-user-presence④">(5)</a> <a href="#ref-for-test-of-user-presence⑤">(6)</a>
     <li><a href="#ref-for-test-of-user-presence⑥">6.1. Authenticator Data</a> <a href="#ref-for-test-of-user-presence⑦">(2)</a>
@@ -10545,8 +10545,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-test-of-user-presence①③">11.2. Virtual Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-consent">
-   <b><a href="#user-consent">#user-consent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-consent" class="dfn-panel" data-for="user-consent" id="infopanel-for-user-consent" role="dialog">
+   <span id="infopaneltitle-for-user-consent" style="display:none">Info about the 'User Consent' definition.</span><b><a href="#user-consent">#user-consent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-consent①">1. Introduction</a> <a href="#ref-for-user-consent②">(2)</a>
     <li><a href="#ref-for-user-consent③">4. Terminology</a> <a href="#ref-for-user-consent④">(2)</a>
@@ -10566,8 +10566,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-user-consent②⑨">14.5.2. Authentication Ceremony Privacy</a> <a href="#ref-for-user-consent③⓪">(2)</a> <a href="#ref-for-user-consent③①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-handle">
-   <b><a href="#user-handle">#user-handle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-handle" class="dfn-panel" data-for="user-handle" id="infopanel-for-user-handle" role="dialog">
+   <span id="infopaneltitle-for-user-handle" style="display:none">Info about the 'User Handle' definition.</span><b><a href="#user-handle">#user-handle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-handle">2.2.1. Backwards Compatibility with FIDO U2F</a>
     <li><a href="#ref-for-user-handle①">4. Terminology</a>
@@ -10583,8 +10583,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-user-handle①⑧">14.6.1. User Handle Contents</a> <a href="#ref-for-user-handle①⑨">(2)</a> <a href="#ref-for-user-handle②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-verification">
-   <b><a href="#user-verification">#user-verification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-verification" class="dfn-panel" data-for="user-verification" id="infopanel-for-user-verification" role="dialog">
+   <span id="infopaneltitle-for-user-verification" style="display:none">Info about the 'User Verification' definition.</span><b><a href="#user-verification">#user-verification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-verification">4. Terminology</a> <a href="#ref-for-user-verification①">(2)</a> <a href="#ref-for-user-verification②">(3)</a> <a href="#ref-for-user-verification③">(4)</a> <a href="#ref-for-user-verification④">(5)</a> <a href="#ref-for-user-verification⑤">(6)</a> <a href="#ref-for-user-verification⑥">(7)</a> <a href="#ref-for-user-verification⑦">(8)</a> <a href="#ref-for-user-verification⑧">(9)</a> <a href="#ref-for-user-verification⑨">(10)</a> <a href="#ref-for-user-verification①⓪">(11)</a> <a href="#ref-for-user-verification①①">(12)</a>
     <li><a href="#ref-for-user-verification①②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-user-verification①③">(2)</a> <a href="#ref-for-user-verification①④">(3)</a>
@@ -10608,8 +10608,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-user-verification⑤①">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-user-present">
-   <b><a href="#concept-user-present">#concept-user-present</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-user-present" class="dfn-panel" data-for="concept-user-present" id="infopanel-for-concept-user-present" role="dialog">
+   <span id="infopaneltitle-for-concept-user-present" style="display:none">Info about the 'User Present' definition.</span><b><a href="#concept-user-present">#concept-user-present</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-user-present">4. Terminology</a>
     <li><a href="#ref-for-concept-user-present①">6.1. Authenticator Data</a> <a href="#ref-for-concept-user-present②">(2)</a> <a href="#ref-for-concept-user-present③">(3)</a>
@@ -10618,15 +10618,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-user-present⑥">13.2. Physical Proximity between Client and Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="up">
-   <b><a href="#up">#up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-up" class="dfn-panel" data-for="up" id="infopanel-for-up" role="dialog">
+   <span id="infopaneltitle-for-up" style="display:none">Info about the 'UP' definition.</span><b><a href="#up">#up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-up">6.1. Authenticator Data</a>
     <li><a href="#ref-for-up①">6.1.2. FIDO U2F Signature Format Compatibility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-user-verified">
-   <b><a href="#concept-user-verified">#concept-user-verified</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-user-verified" class="dfn-panel" data-for="concept-user-verified" id="infopanel-for-concept-user-verified" role="dialog">
+   <span id="infopaneltitle-for-concept-user-verified" style="display:none">Info about the 'User Verified' definition.</span><b><a href="#concept-user-verified">#concept-user-verified</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-user-verified">4. Terminology</a>
     <li><a href="#ref-for-concept-user-verified①">6.1. Authenticator Data</a> <a href="#ref-for-concept-user-verified②">(2)</a> <a href="#ref-for-concept-user-verified③">(3)</a>
@@ -10635,8 +10635,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-concept-user-verified⑥">14.4.2. Privacy of personally identifying information Stored in Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="uv">
-   <b><a href="#uv">#uv</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-uv" class="dfn-panel" data-for="uv" id="infopanel-for-uv" role="dialog">
+   <span id="infopaneltitle-for-uv" style="display:none">Info about the 'UV' definition.</span><b><a href="#uv">#uv</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uv">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a> <a href="#ref-for-uv①">(2)</a>
     <li><a href="#ref-for-uv②">6.1. Authenticator Data</a>
@@ -10644,8 +10644,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-uv⑥">14.3. Authenticator-local Biometric Recognition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-relying-party">
-   <b><a href="#webauthn-relying-party">#webauthn-relying-party</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-relying-party" class="dfn-panel" data-for="webauthn-relying-party" id="infopanel-for-webauthn-relying-party" role="dialog">
+   <span id="infopaneltitle-for-webauthn-relying-party" style="display:none">Info about the 'WebAuthn Relying Party' definition.</span><b><a href="#webauthn-relying-party">#webauthn-relying-party</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-relying-party①">1. Introduction</a>
     <li><a href="#ref-for-webauthn-relying-party②">1.1. Specification Roadmap</a>
@@ -10693,8 +10693,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-webauthn-relying-party⑤⓪">14.6.2. Username Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-application">
-   <b><a href="#web-application">#web-application</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-application" class="dfn-panel" data-for="web-application" id="infopanel-for-web-application" role="dialog">
+   <span id="infopaneltitle-for-web-application" style="display:none">Info about the 'web application' definition.</span><b><a href="#web-application">#web-application</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-application①">1. Introduction</a>
     <li><a href="#ref-for-web-application②">1.1. Specification Roadmap</a> <a href="#ref-for-web-application③">(2)</a>
@@ -10703,8 +10703,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-web-application⑥">13. Security Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="web-authentication-api">
-   <b><a href="#web-authentication-api">#web-authentication-api</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-web-authentication-api" class="dfn-panel" data-for="web-authentication-api" id="infopanel-for-web-authentication-api" role="dialog">
+   <span id="infopaneltitle-for-web-authentication-api" style="display:none">Info about the 'Web Authentication API' definition.</span><b><a href="#web-authentication-api">#web-authentication-api</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-web-authentication-api">1. Introduction</a> <a href="#ref-for-web-authentication-api①">(2)</a> <a href="#ref-for-web-authentication-api②">(3)</a>
     <li><a href="#ref-for-web-authentication-api③">4. Terminology</a> <a href="#ref-for-web-authentication-api④">(2)</a> <a href="#ref-for-web-authentication-api⑤">(3)</a> <a href="#ref-for-web-authentication-api⑥">(4)</a> <a href="#ref-for-web-authentication-api⑦">(5)</a> <a href="#ref-for-web-authentication-api⑧">(6)</a> <a href="#ref-for-web-authentication-api⑨">(7)</a> <a href="#ref-for-web-authentication-api①⓪">(8)</a>
@@ -10715,8 +10715,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-web-authentication-api①⑥">14.1. De-anonymization Prevention Measures</a> <a href="#ref-for-web-authentication-api①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="publickeycredential">
-   <b><a href="#publickeycredential">#publickeycredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-publickeycredential" class="dfn-panel" data-for="publickeycredential" id="infopanel-for-publickeycredential" role="dialog">
+   <span id="infopaneltitle-for-publickeycredential" style="display:none">Info about the 'PublicKeyCredential' definition.</span><b><a href="#publickeycredential">#publickeycredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-publickeycredential">1. Introduction</a>
     <li><a href="#ref-for-publickeycredential①">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-publickeycredential②">(2)</a> <a href="#ref-for-publickeycredential③">(3)</a> <a href="#ref-for-publickeycredential④">(4)</a> <a href="#ref-for-publickeycredential⑤">(5)</a> <a href="#ref-for-publickeycredential⑥">(6)</a> <a href="#ref-for-publickeycredential⑦">(7)</a> <a href="#ref-for-publickeycredential⑧">(8)</a>
@@ -10730,16 +10730,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-publickeycredential①⑧">13.4.4. Attestation Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-rawid">
-   <b><a href="#dom-publickeycredential-rawid">#dom-publickeycredential-rawid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-rawid" class="dfn-panel" data-for="dom-publickeycredential-rawid" id="infopanel-for-dom-publickeycredential-rawid" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-rawid" style="display:none">Info about the 'rawId' definition.</span><b><a href="#dom-publickeycredential-rawid">#dom-publickeycredential-rawid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-rawid">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dom-publickeycredential-rawid①">7.2. Verifying an Authentication Assertion</a>
     <li><a href="#ref-for-dom-publickeycredential-rawid②">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-getclientextensionresults">
-   <b><a href="#dom-publickeycredential-getclientextensionresults">#dom-publickeycredential-getclientextensionresults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-getclientextensionresults" class="dfn-panel" data-for="dom-publickeycredential-getclientextensionresults" id="infopanel-for-dom-publickeycredential-getclientextensionresults" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-getclientextensionresults" style="display:none">Info about the 'getClientExtensionResults' definition.</span><b><a href="#dom-publickeycredential-getclientextensionresults">#dom-publickeycredential-getclientextensionresults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-getclientextensionresults">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dom-publickeycredential-getclientextensionresults①">7.1. Registering a New Credential</a>
@@ -10747,8 +10747,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredential-getclientextensionresults③">9.4. Client Extension Processing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-response">
-   <b><a href="#dom-publickeycredential-response">#dom-publickeycredential-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-response" class="dfn-panel" data-for="dom-publickeycredential-response" id="infopanel-for-dom-publickeycredential-response" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dom-publickeycredential-response">#dom-publickeycredential-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-response">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dom-publickeycredential-response①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -10757,40 +10757,41 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredential-response⑤">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-dom-publickeycredential-response⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-identifier-slot">
-   <b><a href="#dom-publickeycredential-identifier-slot">#dom-publickeycredential-identifier-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-identifier-slot" class="dfn-panel" data-for="dom-publickeycredential-identifier-slot" id="infopanel-for-dom-publickeycredential-identifier-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-identifier-slot" style="display:none">Info about the '[[identifier]]' definition.</span><b><a href="#dom-publickeycredential-identifier-slot">#dom-publickeycredential-identifier-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-identifier-slot">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-dom-publickeycredential-identifier-slot①">(2)</a>
     <li><a href="#ref-for-dom-publickeycredential-identifier-slot②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredential-identifier-slot③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-clientextensionsresults-slot">
-   <b><a href="#dom-publickeycredential-clientextensionsresults-slot">#dom-publickeycredential-clientextensionsresults-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-clientextensionsresults-slot" class="dfn-panel" data-for="dom-publickeycredential-clientextensionsresults-slot" id="infopanel-for-dom-publickeycredential-clientextensionsresults-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-clientextensionsresults-slot" style="display:none">Info about the '[[clientExtensionsResults]]' definition.</span><b><a href="#dom-publickeycredential-clientextensionsresults-slot">#dom-publickeycredential-clientextensionsresults-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-clientextensionsresults-slot">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dom-publickeycredential-clientextensionsresults-slot①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredential-clientextensionsresults-slot②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialcreationoptions-publickey">
-   <b><a href="#dom-credentialcreationoptions-publickey">#dom-credentialcreationoptions-publickey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialcreationoptions-publickey" class="dfn-panel" data-for="dom-credentialcreationoptions-publickey" id="infopanel-for-dom-credentialcreationoptions-publickey" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialcreationoptions-publickey" style="display:none">Info about the 'publicKey' definition.</span><b><a href="#dom-credentialcreationoptions-publickey">#dom-credentialcreationoptions-publickey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialcreationoptions-publickey">4. Terminology</a>
     <li><a href="#ref-for-dom-credentialcreationoptions-publickey①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialcreationoptions-publickey②">(2)</a> <a href="#ref-for-dom-credentialcreationoptions-publickey③">(3)</a>
     <li><a href="#ref-for-dom-credentialcreationoptions-publickey④">7.1. Registering a New Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialrequestoptions-publickey">
-   <b><a href="#dom-credentialrequestoptions-publickey">#dom-credentialrequestoptions-publickey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialrequestoptions-publickey" class="dfn-panel" data-for="dom-credentialrequestoptions-publickey" id="infopanel-for-dom-credentialrequestoptions-publickey" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialrequestoptions-publickey" style="display:none">Info about the 'publicKey' definition.</span><b><a href="#dom-credentialrequestoptions-publickey">#dom-credentialrequestoptions-publickey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialrequestoptions-publickey">4. Terminology</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-publickey①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-credentialrequestoptions-publickey②">(2)</a> <a href="#ref-for-dom-credentialrequestoptions-publickey③">(3)</a>
     <li><a href="#ref-for-dom-credentialrequestoptions-publickey④">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-create-slot">
-   <b><a href="#dom-publickeycredential-create-slot">#dom-publickeycredential-create-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-create-slot" class="dfn-panel" data-for="dom-publickeycredential-create-slot" id="infopanel-for-dom-publickeycredential-create-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-create-slot" style="display:none">Info about the '[[Create]](origin,
+options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-publickeycredential-create-slot">#dom-publickeycredential-create-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-create-slot">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredential-create-slot①">5.1. PublicKeyCredential Interface</a>
@@ -10802,75 +10803,75 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredential-create-slot①②">14.5.1. Registration Ceremony Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin">
-   <b><a href="#dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin">#dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin" class="dfn-panel" data-for="dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin" id="infopanel-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin">#dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-origin">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors">
-   <b><a href="#dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors">#dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors" class="dfn-panel" data-for="dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors" id="infopanel-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors" style="display:none">Info about the 'sameOriginWithAncestors' definition.</span><b><a href="#dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors">#dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-create-origin-options-sameoriginwithancestors-sameoriginwithancestors">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-candidate-authenticator">
-   <b><a href="#create-candidate-authenticator">#create-candidate-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-candidate-authenticator" class="dfn-panel" data-for="create-candidate-authenticator" id="infopanel-for-create-candidate-authenticator" role="dialog">
+   <span id="infopaneltitle-for-create-candidate-authenticator" style="display:none">Info about the 'candidate authenticator' definition.</span><b><a href="#create-candidate-authenticator">#create-candidate-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-candidate-authenticator">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-create-candidate-authenticator①">(2)</a> <a href="#ref-for-create-candidate-authenticator②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-resident-key-requirement-for-credential-creation">
-   <b><a href="#effective-resident-key-requirement-for-credential-creation">#effective-resident-key-requirement-for-credential-creation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-resident-key-requirement-for-credential-creation" class="dfn-panel" data-for="effective-resident-key-requirement-for-credential-creation" id="infopanel-for-effective-resident-key-requirement-for-credential-creation" role="dialog">
+   <span id="infopaneltitle-for-effective-resident-key-requirement-for-credential-creation" style="display:none">Info about the 'effective resident key requirement for credential creation' definition.</span><b><a href="#effective-resident-key-requirement-for-credential-creation">#effective-resident-key-requirement-for-credential-creation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-resident-key-requirement-for-credential-creation">6.3.2. The authenticatorMakeCredential Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-user-verification-requirement-for-credential-creation">
-   <b><a href="#effective-user-verification-requirement-for-credential-creation">#effective-user-verification-requirement-for-credential-creation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-user-verification-requirement-for-credential-creation" class="dfn-panel" data-for="effective-user-verification-requirement-for-credential-creation" id="infopanel-for-effective-user-verification-requirement-for-credential-creation" role="dialog">
+   <span id="infopaneltitle-for-effective-user-verification-requirement-for-credential-creation" style="display:none">Info about the 'effective user verification requirement for credential creation' definition.</span><b><a href="#effective-user-verification-requirement-for-credential-creation">#effective-user-verification-requirement-for-credential-creation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-user-verification-requirement-for-credential-creation">6.3.2. The authenticatorMakeCredential Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-selected-authenticator">
-   <b><a href="#create-selected-authenticator">#create-selected-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-selected-authenticator" class="dfn-panel" data-for="create-selected-authenticator" id="infopanel-for-create-selected-authenticator" role="dialog">
+   <span id="infopaneltitle-for-create-selected-authenticator" style="display:none">Info about the 'selected authenticator' definition.</span><b><a href="#create-selected-authenticator">#create-selected-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-selected-authenticator">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-create-selected-authenticator①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialcreationdata-attestationobjectresult">
-   <b><a href="#credentialcreationdata-attestationobjectresult">#credentialcreationdata-attestationobjectresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialcreationdata-attestationobjectresult" class="dfn-panel" data-for="credentialcreationdata-attestationobjectresult" id="infopanel-for-credentialcreationdata-attestationobjectresult" role="dialog">
+   <span id="infopaneltitle-for-credentialcreationdata-attestationobjectresult" style="display:none">Info about the 'attestationObjectResult' definition.</span><b><a href="#credentialcreationdata-attestationobjectresult">#credentialcreationdata-attestationobjectresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialcreationdata-attestationobjectresult">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-credentialcreationdata-attestationobjectresult①">(2)</a> <a href="#ref-for-credentialcreationdata-attestationobjectresult②">(3)</a> <a href="#ref-for-credentialcreationdata-attestationobjectresult③">(4)</a> <a href="#ref-for-credentialcreationdata-attestationobjectresult④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialcreationdata-clientdatajsonresult">
-   <b><a href="#credentialcreationdata-clientdatajsonresult">#credentialcreationdata-clientdatajsonresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialcreationdata-clientdatajsonresult" class="dfn-panel" data-for="credentialcreationdata-clientdatajsonresult" id="infopanel-for-credentialcreationdata-clientdatajsonresult" role="dialog">
+   <span id="infopaneltitle-for-credentialcreationdata-clientdatajsonresult" style="display:none">Info about the 'clientDataJSONResult' definition.</span><b><a href="#credentialcreationdata-clientdatajsonresult">#credentialcreationdata-clientdatajsonresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialcreationdata-clientdatajsonresult">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialcreationdata-attestationconveyancepreferenceoption">
-   <b><a href="#credentialcreationdata-attestationconveyancepreferenceoption">#credentialcreationdata-attestationconveyancepreferenceoption</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialcreationdata-attestationconveyancepreferenceoption" class="dfn-panel" data-for="credentialcreationdata-attestationconveyancepreferenceoption" id="infopanel-for-credentialcreationdata-attestationconveyancepreferenceoption" role="dialog">
+   <span id="infopaneltitle-for-credentialcreationdata-attestationconveyancepreferenceoption" style="display:none">Info about the 'attestationConveyancePreferenceOption' definition.</span><b><a href="#credentialcreationdata-attestationconveyancepreferenceoption">#credentialcreationdata-attestationconveyancepreferenceoption</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialcreationdata-attestationconveyancepreferenceoption">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialcreationdata-clientextensionresults">
-   <b><a href="#credentialcreationdata-clientextensionresults">#credentialcreationdata-clientextensionresults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialcreationdata-clientextensionresults" class="dfn-panel" data-for="credentialcreationdata-clientextensionresults" id="infopanel-for-credentialcreationdata-clientextensionresults" role="dialog">
+   <span id="infopaneltitle-for-credentialcreationdata-clientextensionresults" style="display:none">Info about the 'clientExtensionResults' definition.</span><b><a href="#credentialcreationdata-clientextensionresults">#credentialcreationdata-clientextensionresults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialcreationdata-clientextensionresults">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-credentialcreationdata-clientextensionresults①">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-collectfromcredentialstore-slot">
-   <b><a href="#dom-publickeycredential-collectfromcredentialstore-slot">#dom-publickeycredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-collectfromcredentialstore-slot" class="dfn-panel" data-for="dom-publickeycredential-collectfromcredentialstore-slot" id="infopanel-for-dom-publickeycredential-collectfromcredentialstore-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-collectfromcredentialstore-slot" style="display:none">Info about the '[[CollectFromCredentialStore]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-publickeycredential-collectfromcredentialstore-slot">#dom-publickeycredential-collectfromcredentialstore-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-collectfromcredentialstore-slot">5.1.4. Use an Existing Credential to Make an Assertion - PublicKeyCredential’s [[Get]](options) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-slot">
-   <b><a href="#dom-publickeycredential-discoverfromexternalsource-slot">#dom-publickeycredential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-slot" class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-slot" id="infopanel-for-dom-publickeycredential-discoverfromexternalsource-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-slot" style="display:none">Info about the '[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)' definition.</span><b><a href="#dom-publickeycredential-discoverfromexternalsource-slot">#dom-publickeycredential-discoverfromexternalsource-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-slot">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-slot①">5.1. PublicKeyCredential Interface</a>
@@ -10883,63 +10884,63 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-slot①②">14.5.2. Authentication Ceremony Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin">
-   <b><a href="#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin">#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin" class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin" id="infopanel-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin">#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-origin">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors">
-   <b><a href="#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors">#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors" class="dfn-panel" data-for="dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors" id="infopanel-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors" style="display:none">Info about the 'sameOriginWithAncestors' definition.</span><b><a href="#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors">#dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-sameoriginwithancestors">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="effective-user-verification-requirement-for-assertion">
-   <b><a href="#effective-user-verification-requirement-for-assertion">#effective-user-verification-requirement-for-assertion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-effective-user-verification-requirement-for-assertion" class="dfn-panel" data-for="effective-user-verification-requirement-for-assertion" id="infopanel-for-effective-user-verification-requirement-for-assertion" role="dialog">
+   <span id="infopaneltitle-for-effective-user-verification-requirement-for-assertion" style="display:none">Info about the 'effective user verification requirement for assertion' definition.</span><b><a href="#effective-user-verification-requirement-for-assertion">#effective-user-verification-requirement-for-assertion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-effective-user-verification-requirement-for-assertion">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-credentialidresult">
-   <b><a href="#assertioncreationdata-credentialidresult">#assertioncreationdata-credentialidresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-credentialidresult" class="dfn-panel" data-for="assertioncreationdata-credentialidresult" id="infopanel-for-assertioncreationdata-credentialidresult" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-credentialidresult" style="display:none">Info about the 'credentialIdResult' definition.</span><b><a href="#assertioncreationdata-credentialidresult">#assertioncreationdata-credentialidresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-credentialidresult">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-assertioncreationdata-credentialidresult①">(2)</a> <a href="#ref-for-assertioncreationdata-credentialidresult②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-clientdatajsonresult">
-   <b><a href="#assertioncreationdata-clientdatajsonresult">#assertioncreationdata-clientdatajsonresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-clientdatajsonresult" class="dfn-panel" data-for="assertioncreationdata-clientdatajsonresult" id="infopanel-for-assertioncreationdata-clientdatajsonresult" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-clientdatajsonresult" style="display:none">Info about the 'clientDataJSONResult' definition.</span><b><a href="#assertioncreationdata-clientdatajsonresult">#assertioncreationdata-clientdatajsonresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-clientdatajsonresult">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-authenticatordataresult">
-   <b><a href="#assertioncreationdata-authenticatordataresult">#assertioncreationdata-authenticatordataresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-authenticatordataresult" class="dfn-panel" data-for="assertioncreationdata-authenticatordataresult" id="infopanel-for-assertioncreationdata-authenticatordataresult" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-authenticatordataresult" style="display:none">Info about the 'authenticatorDataResult' definition.</span><b><a href="#assertioncreationdata-authenticatordataresult">#assertioncreationdata-authenticatordataresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-authenticatordataresult">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-signatureresult">
-   <b><a href="#assertioncreationdata-signatureresult">#assertioncreationdata-signatureresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-signatureresult" class="dfn-panel" data-for="assertioncreationdata-signatureresult" id="infopanel-for-assertioncreationdata-signatureresult" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-signatureresult" style="display:none">Info about the 'signatureResult' definition.</span><b><a href="#assertioncreationdata-signatureresult">#assertioncreationdata-signatureresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-signatureresult">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-userhandleresult">
-   <b><a href="#assertioncreationdata-userhandleresult">#assertioncreationdata-userhandleresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-userhandleresult" class="dfn-panel" data-for="assertioncreationdata-userhandleresult" id="infopanel-for-assertioncreationdata-userhandleresult" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-userhandleresult" style="display:none">Info about the 'userHandleResult' definition.</span><b><a href="#assertioncreationdata-userhandleresult">#assertioncreationdata-userhandleresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-userhandleresult">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-assertioncreationdata-userhandleresult①">(2)</a> <a href="#ref-for-assertioncreationdata-userhandleresult②">(3)</a> <a href="#ref-for-assertioncreationdata-userhandleresult③">(4)</a>
     <li><a href="#ref-for-assertioncreationdata-userhandleresult④">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertioncreationdata-clientextensionresults">
-   <b><a href="#assertioncreationdata-clientextensionresults">#assertioncreationdata-clientextensionresults</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertioncreationdata-clientextensionresults" class="dfn-panel" data-for="assertioncreationdata-clientextensionresults" id="infopanel-for-assertioncreationdata-clientextensionresults" role="dialog">
+   <span id="infopaneltitle-for-assertioncreationdata-clientextensionresults" style="display:none">Info about the 'clientExtensionResults' definition.</span><b><a href="#assertioncreationdata-clientextensionresults">#assertioncreationdata-clientextensionresults</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertioncreationdata-clientextensionresults">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorresponse">
-   <b><a href="#authenticatorresponse">#authenticatorresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorresponse" class="dfn-panel" data-for="authenticatorresponse" id="infopanel-for-authenticatorresponse" role="dialog">
+   <span id="infopaneltitle-for-authenticatorresponse" style="display:none">Info about the 'AuthenticatorResponse' definition.</span><b><a href="#authenticatorresponse">#authenticatorresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorresponse">5.1. PublicKeyCredential Interface</a> <a href="#ref-for-authenticatorresponse①">(2)</a>
     <li><a href="#ref-for-authenticatorresponse②">5.2. Authenticator Responses (interface AuthenticatorResponse)</a> <a href="#ref-for-authenticatorresponse③">(2)</a>
@@ -10947,8 +10948,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatorresponse⑥">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a> <a href="#ref-for-authenticatorresponse⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorresponse-clientdatajson">
-   <b><a href="#dom-authenticatorresponse-clientdatajson">#dom-authenticatorresponse-clientdatajson</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorresponse-clientdatajson" class="dfn-panel" data-for="dom-authenticatorresponse-clientdatajson" id="infopanel-for-dom-authenticatorresponse-clientdatajson" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorresponse-clientdatajson" style="display:none">Info about the 'clientDataJSON' definition.</span><b><a href="#dom-authenticatorresponse-clientdatajson">#dom-authenticatorresponse-clientdatajson</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorresponse-clientdatajson">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorresponse-clientdatajson①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -10960,8 +10961,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-authenticatorresponse-clientdatajson⑧">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorattestationresponse">
-   <b><a href="#authenticatorattestationresponse">#authenticatorattestationresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorattestationresponse" class="dfn-panel" data-for="authenticatorattestationresponse" id="infopanel-for-authenticatorattestationresponse" role="dialog">
+   <span id="infopaneltitle-for-authenticatorattestationresponse" style="display:none">Info about the 'AuthenticatorAttestationResponse' definition.</span><b><a href="#authenticatorattestationresponse">#authenticatorattestationresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorattestationresponse">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-authenticatorattestationresponse①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -10971,8 +10972,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatorattestationresponse⑥">7.1. Registering a New Credential</a> <a href="#ref-for-authenticatorattestationresponse⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-gettransports">
-   <b><a href="#dom-authenticatorattestationresponse-gettransports">#dom-authenticatorattestationresponse-gettransports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-gettransports" class="dfn-panel" data-for="dom-authenticatorattestationresponse-gettransports" id="infopanel-for-dom-authenticatorattestationresponse-gettransports" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-gettransports" style="display:none">Info about the 'getTransports' definition.</span><b><a href="#dom-authenticatorattestationresponse-gettransports">#dom-authenticatorattestationresponse-gettransports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-gettransports">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-gettransports①">5.8.3. Credential Descriptor (dictionary PublicKeyCredentialDescriptor)</a> <a href="#ref-for-dom-authenticatorattestationresponse-gettransports②">(2)</a>
@@ -10981,29 +10982,29 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-gettransports⑤">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-getauthenticatordata">
-   <b><a href="#dom-authenticatorattestationresponse-getauthenticatordata">#dom-authenticatorattestationresponse-getauthenticatordata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-getauthenticatordata" class="dfn-panel" data-for="dom-authenticatorattestationresponse-getauthenticatordata" id="infopanel-for-dom-authenticatorattestationresponse-getauthenticatordata" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-getauthenticatordata" style="display:none">Info about the 'getAuthenticatorData' definition.</span><b><a href="#dom-authenticatorattestationresponse-getauthenticatordata">#dom-authenticatorattestationresponse-getauthenticatordata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getauthenticatordata">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getauthenticatordata①">5.2.1.1. Easily accessing credential data</a> <a href="#ref-for-dom-authenticatorattestationresponse-getauthenticatordata②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-getpublickey">
-   <b><a href="#dom-authenticatorattestationresponse-getpublickey">#dom-authenticatorattestationresponse-getpublickey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-getpublickey" class="dfn-panel" data-for="dom-authenticatorattestationresponse-getpublickey" id="infopanel-for-dom-authenticatorattestationresponse-getpublickey" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-getpublickey" style="display:none">Info about the 'getPublicKey' definition.</span><b><a href="#dom-authenticatorattestationresponse-getpublickey">#dom-authenticatorattestationresponse-getpublickey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getpublickey">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getpublickey①">5.2.1.1. Easily accessing credential data</a> <a href="#ref-for-dom-authenticatorattestationresponse-getpublickey②">(2)</a> <a href="#ref-for-dom-authenticatorattestationresponse-getpublickey③">(3)</a> <a href="#ref-for-dom-authenticatorattestationresponse-getpublickey④">(4)</a> <a href="#ref-for-dom-authenticatorattestationresponse-getpublickey⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-getpublickeyalgorithm">
-   <b><a href="#dom-authenticatorattestationresponse-getpublickeyalgorithm">#dom-authenticatorattestationresponse-getpublickeyalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-getpublickeyalgorithm" class="dfn-panel" data-for="dom-authenticatorattestationresponse-getpublickeyalgorithm" id="infopanel-for-dom-authenticatorattestationresponse-getpublickeyalgorithm" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-getpublickeyalgorithm" style="display:none">Info about the 'getPublicKeyAlgorithm' definition.</span><b><a href="#dom-authenticatorattestationresponse-getpublickeyalgorithm">#dom-authenticatorattestationresponse-getpublickeyalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getpublickeyalgorithm">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-getpublickeyalgorithm①">5.2.1.1. Easily accessing credential data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-attestationobject">
-   <b><a href="#dom-authenticatorattestationresponse-attestationobject">#dom-authenticatorattestationresponse-attestationobject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-attestationobject" class="dfn-panel" data-for="dom-authenticatorattestationresponse-attestationobject" id="infopanel-for-dom-authenticatorattestationresponse-attestationobject" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-attestationobject" style="display:none">Info about the 'attestationObject' definition.</span><b><a href="#dom-authenticatorattestationresponse-attestationobject">#dom-authenticatorattestationresponse-attestationobject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-attestationobject">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-attestationobject①">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a> <a href="#ref-for-dom-authenticatorattestationresponse-attestationobject②">(2)</a>
@@ -11011,15 +11012,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-attestationobject⑥">7.1. Registering a New Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattestationresponse-transports-slot">
-   <b><a href="#dom-authenticatorattestationresponse-transports-slot">#dom-authenticatorattestationresponse-transports-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattestationresponse-transports-slot" class="dfn-panel" data-for="dom-authenticatorattestationresponse-transports-slot" id="infopanel-for-dom-authenticatorattestationresponse-transports-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattestationresponse-transports-slot" style="display:none">Info about the '[[transports]]' definition.</span><b><a href="#dom-authenticatorattestationresponse-transports-slot">#dom-authenticatorattestationresponse-transports-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-transports-slot">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorattestationresponse-transports-slot①">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorassertionresponse">
-   <b><a href="#authenticatorassertionresponse">#authenticatorassertionresponse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorassertionresponse" class="dfn-panel" data-for="authenticatorassertionresponse" id="infopanel-for-authenticatorassertionresponse" role="dialog">
+   <span id="infopaneltitle-for-authenticatorassertionresponse" style="display:none">Info about the 'AuthenticatorAssertionResponse' definition.</span><b><a href="#authenticatorassertionresponse">#authenticatorassertionresponse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorassertionresponse">4. Terminology</a>
     <li><a href="#ref-for-authenticatorassertionresponse①">5.1. PublicKeyCredential Interface</a>
@@ -11030,24 +11031,24 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatorassertionresponse⑦">14.6.2. Username Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorassertionresponse-authenticatordata">
-   <b><a href="#dom-authenticatorassertionresponse-authenticatordata">#dom-authenticatorassertionresponse-authenticatordata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorassertionresponse-authenticatordata" class="dfn-panel" data-for="dom-authenticatorassertionresponse-authenticatordata" id="infopanel-for-dom-authenticatorassertionresponse-authenticatordata" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorassertionresponse-authenticatordata" style="display:none">Info about the 'authenticatorData' definition.</span><b><a href="#dom-authenticatorassertionresponse-authenticatordata">#dom-authenticatorassertionresponse-authenticatordata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-authenticatordata">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-authenticatordata①">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-authenticatordata②">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorassertionresponse-signature">
-   <b><a href="#dom-authenticatorassertionresponse-signature">#dom-authenticatorassertionresponse-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorassertionresponse-signature" class="dfn-panel" data-for="dom-authenticatorassertionresponse-signature" id="infopanel-for-dom-authenticatorassertionresponse-signature" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorassertionresponse-signature" style="display:none">Info about the 'signature' definition.</span><b><a href="#dom-authenticatorassertionresponse-signature">#dom-authenticatorassertionresponse-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-signature">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-signature①">5.2.2. Web Authentication Assertion (interface AuthenticatorAssertionResponse)</a>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-signature②">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorassertionresponse-userhandle">
-   <b><a href="#dom-authenticatorassertionresponse-userhandle">#dom-authenticatorassertionresponse-userhandle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorassertionresponse-userhandle" class="dfn-panel" data-for="dom-authenticatorassertionresponse-userhandle" id="infopanel-for-dom-authenticatorassertionresponse-userhandle" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorassertionresponse-userhandle" style="display:none">Info about the 'userHandle' definition.</span><b><a href="#dom-authenticatorassertionresponse-userhandle">#dom-authenticatorassertionresponse-userhandle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-userhandle">2.2.1. Backwards Compatibility with FIDO U2F</a>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-userhandle①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11055,30 +11056,30 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-authenticatorassertionresponse-userhandle③">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-dom-authenticatorassertionresponse-userhandle④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialparameters">
-   <b><a href="#dictdef-publickeycredentialparameters">#dictdef-publickeycredentialparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialparameters" class="dfn-panel" data-for="dictdef-publickeycredentialparameters" id="infopanel-for-dictdef-publickeycredentialparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialparameters" style="display:none">Info about the 'PublicKeyCredentialParameters' definition.</span><b><a href="#dictdef-publickeycredentialparameters">#dictdef-publickeycredentialparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialparameters">5.3. Parameters for Credential Generation (dictionary PublicKeyCredentialParameters)</a> <a href="#ref-for-dictdef-publickeycredentialparameters①">(2)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialparameters②">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-publickeycredentialparameters③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialparameters-type">
-   <b><a href="#dom-publickeycredentialparameters-type">#dom-publickeycredentialparameters-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialparameters-type" class="dfn-panel" data-for="dom-publickeycredentialparameters-type" id="infopanel-for-dom-publickeycredentialparameters-type" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialparameters-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-publickeycredentialparameters-type">#dom-publickeycredentialparameters-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialparameters-type">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialparameters-type①">(2)</a>
     <li><a href="#ref-for-dom-publickeycredentialparameters-type②">5.3. Parameters for Credential Generation (dictionary PublicKeyCredentialParameters)</a> <a href="#ref-for-dom-publickeycredentialparameters-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialparameters-alg">
-   <b><a href="#dom-publickeycredentialparameters-alg">#dom-publickeycredentialparameters-alg</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialparameters-alg" class="dfn-panel" data-for="dom-publickeycredentialparameters-alg" id="infopanel-for-dom-publickeycredentialparameters-alg" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialparameters-alg" style="display:none">Info about the 'alg' definition.</span><b><a href="#dom-publickeycredentialparameters-alg">#dom-publickeycredentialparameters-alg</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialparameters-alg">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialparameters-alg①">5.3. Parameters for Credential Generation (dictionary PublicKeyCredentialParameters)</a>
     <li><a href="#ref-for-dom-publickeycredentialparameters-alg②">7.1. Registering a New Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialcreationoptions">
-   <b><a href="#dictdef-publickeycredentialcreationoptions">#dictdef-publickeycredentialcreationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialcreationoptions" class="dfn-panel" data-for="dictdef-publickeycredentialcreationoptions" id="infopanel-for-dictdef-publickeycredentialcreationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialcreationoptions" style="display:none">Info about the 'PublicKeyCredentialCreationOptions' definition.</span><b><a href="#dictdef-publickeycredentialcreationoptions">#dictdef-publickeycredentialcreationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialcreationoptions">5.1.1. CredentialCreationOptions Dictionary Extension</a>
     <li><a href="#ref-for-dictdef-publickeycredentialcreationoptions①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11089,15 +11090,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-publickeycredentialcreationoptions⑥">13.4.3. Cryptographic Challenges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-rp">
-   <b><a href="#dom-publickeycredentialcreationoptions-rp">#dom-publickeycredentialcreationoptions-rp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-rp" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-rp" id="infopanel-for-dom-publickeycredentialcreationoptions-rp" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-rp" style="display:none">Info about the 'rp' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-rp">#dom-publickeycredentialcreationoptions-rp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-rp">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp①">(2)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp②">(3)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp③">(4)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp④">(5)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp⑤">(6)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-rp⑥">(7)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-rp⑦">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-user">
-   <b><a href="#dom-publickeycredentialcreationoptions-user">#dom-publickeycredentialcreationoptions-user</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-user" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-user" id="infopanel-for-dom-publickeycredentialcreationoptions-user" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-user" style="display:none">Info about the 'user' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-user">#dom-publickeycredentialcreationoptions-user</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-user">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-user①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-user②">(2)</a>
@@ -11106,8 +11107,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-user⑤">13.4.6. Credential Loss and Key Mobility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-challenge">
-   <b><a href="#dom-publickeycredentialcreationoptions-challenge">#dom-publickeycredentialcreationoptions-challenge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-challenge" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-challenge" id="infopanel-for-dom-publickeycredentialcreationoptions-challenge" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-challenge" style="display:none">Info about the 'challenge' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-challenge">#dom-publickeycredentialcreationoptions-challenge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-challenge">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-challenge①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11115,8 +11116,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-challenge③">13.4.3. Cryptographic Challenges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-pubkeycredparams">
-   <b><a href="#dom-publickeycredentialcreationoptions-pubkeycredparams">#dom-publickeycredentialcreationoptions-pubkeycredparams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-pubkeycredparams" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-pubkeycredparams" id="infopanel-for-dom-publickeycredentialcreationoptions-pubkeycredparams" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-pubkeycredparams" style="display:none">Info about the 'pubKeyCredParams' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-pubkeycredparams">#dom-publickeycredentialcreationoptions-pubkeycredparams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-pubkeycredparams">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-pubkeycredparams①">(2)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-pubkeycredparams②">5.2.1.1. Easily accessing credential data</a>
@@ -11124,16 +11125,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-pubkeycredparams④">7.1. Registering a New Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-timeout">
-   <b><a href="#dom-publickeycredentialcreationoptions-timeout">#dom-publickeycredentialcreationoptions-timeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-timeout" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-timeout" id="infopanel-for-dom-publickeycredentialcreationoptions-timeout" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-timeout" style="display:none">Info about the 'timeout' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-timeout">#dom-publickeycredentialcreationoptions-timeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-timeout">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-timeout①">(2)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-timeout②">(3)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-timeout③">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-timeout④">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-excludecredentials">
-   <b><a href="#dom-publickeycredentialcreationoptions-excludecredentials">#dom-publickeycredentialcreationoptions-excludecredentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-excludecredentials" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-excludecredentials" id="infopanel-for-dom-publickeycredentialcreationoptions-excludecredentials" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-excludecredentials" style="display:none">Info about the 'excludeCredentials' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-excludecredentials">#dom-publickeycredentialcreationoptions-excludecredentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-excludecredentials">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-excludecredentials①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11142,23 +11143,23 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-excludecredentials③">14.5.1. Registration Ceremony Privacy</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-excludecredentials④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-authenticatorselection">
-   <b><a href="#dom-publickeycredentialcreationoptions-authenticatorselection">#dom-publickeycredentialcreationoptions-authenticatorselection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-authenticatorselection" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-authenticatorselection" id="infopanel-for-dom-publickeycredentialcreationoptions-authenticatorselection" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-authenticatorselection" style="display:none">Info about the 'authenticatorSelection' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-authenticatorselection">#dom-publickeycredentialcreationoptions-authenticatorselection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection①">(2)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection②">(3)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection③">(4)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection④">(5)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection⑤">(6)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection⑥">(7)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection⑦">(8)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection⑧">(9)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection⑨">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection①⓪">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-authenticatorselection①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-attestation">
-   <b><a href="#dom-publickeycredentialcreationoptions-attestation">#dom-publickeycredentialcreationoptions-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-attestation" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-attestation" id="infopanel-for-dom-publickeycredentialcreationoptions-attestation" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-attestation" style="display:none">Info about the 'attestation' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-attestation">#dom-publickeycredentialcreationoptions-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-attestation">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-attestation①">(2)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-attestation②">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-extensions">
-   <b><a href="#dom-publickeycredentialcreationoptions-extensions">#dom-publickeycredentialcreationoptions-extensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialcreationoptions-extensions" class="dfn-panel" data-for="dom-publickeycredentialcreationoptions-extensions" id="infopanel-for-dom-publickeycredentialcreationoptions-extensions" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialcreationoptions-extensions" style="display:none">Info about the 'extensions' definition.</span><b><a href="#dom-publickeycredentialcreationoptions-extensions">#dom-publickeycredentialcreationoptions-extensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-extensions">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-extensions①">(2)</a> <a href="#ref-for-dom-publickeycredentialcreationoptions-extensions②">(3)</a>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-extensions③">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11166,16 +11167,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialcreationoptions-extensions⑦">9.3. Extending Request Parameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialentity">
-   <b><a href="#dictdef-publickeycredentialentity">#dictdef-publickeycredentialentity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialentity" class="dfn-panel" data-for="dictdef-publickeycredentialentity" id="infopanel-for-dictdef-publickeycredentialentity" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialentity" style="display:none">Info about the 'PublicKeyCredentialEntity' definition.</span><b><a href="#dictdef-publickeycredentialentity">#dictdef-publickeycredentialentity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialentity">5.4.1. Public Key Entity Description (dictionary PublicKeyCredentialEntity)</a> <a href="#ref-for-dictdef-publickeycredentialentity①">(2)</a> <a href="#ref-for-dictdef-publickeycredentialentity②">(3)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialentity③">5.4.2. Relying Party Parameters for Credential Generation (dictionary PublicKeyCredentialRpEntity)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialentity④">5.4.3. User Account Parameters for Credential Generation (dictionary PublicKeyCredentialUserEntity)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialentity-name">
-   <b><a href="#dom-publickeycredentialentity-name">#dom-publickeycredentialentity-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialentity-name" class="dfn-panel" data-for="dom-publickeycredentialentity-name" id="infopanel-for-dom-publickeycredentialentity-name" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialentity-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-publickeycredentialentity-name">#dom-publickeycredentialentity-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialentity-name">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dom-publickeycredentialentity-name①">(2)</a>
     <li><a href="#ref-for-dom-publickeycredentialentity-name②">5.4.1. Public Key Entity Description (dictionary PublicKeyCredentialEntity)</a> <a href="#ref-for-dom-publickeycredentialentity-name③">(2)</a> <a href="#ref-for-dom-publickeycredentialentity-name④">(3)</a> <a href="#ref-for-dom-publickeycredentialentity-name⑤">(4)</a> <a href="#ref-for-dom-publickeycredentialentity-name⑥">(5)</a> <a href="#ref-for-dom-publickeycredentialentity-name⑦">(6)</a> <a href="#ref-for-dom-publickeycredentialentity-name⑧">(7)</a>
@@ -11184,8 +11185,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialentity-name①②">6.4. String Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialrpentity">
-   <b><a href="#dictdef-publickeycredentialrpentity">#dictdef-publickeycredentialrpentity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialrpentity" class="dfn-panel" data-for="dictdef-publickeycredentialrpentity" id="infopanel-for-dictdef-publickeycredentialrpentity" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialrpentity" style="display:none">Info about the 'PublicKeyCredentialRpEntity' definition.</span><b><a href="#dictdef-publickeycredentialrpentity">#dictdef-publickeycredentialrpentity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialrpentity">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-publickeycredentialrpentity①">(2)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialrpentity②">5.4.1. Public Key Entity Description (dictionary PublicKeyCredentialEntity)</a>
@@ -11193,8 +11194,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-publickeycredentialrpentity⑤">6.3.2. The authenticatorMakeCredential Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrpentity-id">
-   <b><a href="#dom-publickeycredentialrpentity-id">#dom-publickeycredentialrpentity-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrpentity-id" class="dfn-panel" data-for="dom-publickeycredentialrpentity-id" id="infopanel-for-dom-publickeycredentialrpentity-id" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrpentity-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-publickeycredentialrpentity-id">#dom-publickeycredentialrpentity-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrpentity-id">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrpentity-id①">(2)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id②">(3)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id③">(4)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id④">(5)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id⑤">(6)</a>
     <li><a href="#ref-for-dom-publickeycredentialrpentity-id⑥">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11202,8 +11203,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialrpentity-id⑧">6.3.2. The authenticatorMakeCredential Operation</a> <a href="#ref-for-dom-publickeycredentialrpentity-id⑨">(2)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id①⓪">(3)</a> <a href="#ref-for-dom-publickeycredentialrpentity-id①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialuserentity">
-   <b><a href="#dictdef-publickeycredentialuserentity">#dictdef-publickeycredentialuserentity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialuserentity" class="dfn-panel" data-for="dictdef-publickeycredentialuserentity" id="infopanel-for-dictdef-publickeycredentialuserentity" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialuserentity" style="display:none">Info about the 'PublicKeyCredentialUserEntity' definition.</span><b><a href="#dictdef-publickeycredentialuserentity">#dictdef-publickeycredentialuserentity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialuserentity">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-publickeycredentialuserentity①">(2)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialuserentity②">5.4.1. Public Key Entity Description (dictionary PublicKeyCredentialEntity)</a>
@@ -11213,8 +11214,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-publickeycredentialuserentity⑦">14.4.2. Privacy of personally identifying information Stored in Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialuserentity-id">
-   <b><a href="#dom-publickeycredentialuserentity-id">#dom-publickeycredentialuserentity-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialuserentity-id" class="dfn-panel" data-for="dom-publickeycredentialuserentity-id" id="infopanel-for-dom-publickeycredentialuserentity-id" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialuserentity-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-publickeycredentialuserentity-id">#dom-publickeycredentialuserentity-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-id">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-id①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11225,8 +11226,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-id⑦">14.4.2. Privacy of personally identifying information Stored in Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialuserentity-displayname">
-   <b><a href="#dom-publickeycredentialuserentity-displayname">#dom-publickeycredentialuserentity-displayname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialuserentity-displayname" class="dfn-panel" data-for="dom-publickeycredentialuserentity-displayname" id="infopanel-for-dom-publickeycredentialuserentity-displayname" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialuserentity-displayname" style="display:none">Info about the 'displayName' definition.</span><b><a href="#dom-publickeycredentialuserentity-displayname">#dom-publickeycredentialuserentity-displayname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-displayname">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-displayname①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11236,22 +11237,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialuserentity-displayname①①">6.4. String Handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-authenticatorselectioncriteria">
-   <b><a href="#dictdef-authenticatorselectioncriteria">#dictdef-authenticatorselectioncriteria</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-authenticatorselectioncriteria" class="dfn-panel" data-for="dictdef-authenticatorselectioncriteria" id="infopanel-for-dictdef-authenticatorselectioncriteria" role="dialog">
+   <span id="infopaneltitle-for-dictdef-authenticatorselectioncriteria" style="display:none">Info about the 'AuthenticatorSelectionCriteria' definition.</span><b><a href="#dictdef-authenticatorselectioncriteria">#dictdef-authenticatorselectioncriteria</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-authenticatorselectioncriteria">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-authenticatorselectioncriteria①">(2)</a>
     <li><a href="#ref-for-dictdef-authenticatorselectioncriteria②">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-dictdef-authenticatorselectioncriteria③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorselectioncriteria-authenticatorattachment">
-   <b><a href="#dom-authenticatorselectioncriteria-authenticatorattachment">#dom-authenticatorselectioncriteria-authenticatorattachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorselectioncriteria-authenticatorattachment" class="dfn-panel" data-for="dom-authenticatorselectioncriteria-authenticatorattachment" id="infopanel-for-dom-authenticatorselectioncriteria-authenticatorattachment" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorselectioncriteria-authenticatorattachment" style="display:none">Info about the 'authenticatorAttachment' definition.</span><b><a href="#dom-authenticatorselectioncriteria-authenticatorattachment">#dom-authenticatorselectioncriteria-authenticatorattachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-authenticatorattachment">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-authenticatorattachment①">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorselectioncriteria-residentkey">
-   <b><a href="#dom-authenticatorselectioncriteria-residentkey">#dom-authenticatorselectioncriteria-residentkey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorselectioncriteria-residentkey" class="dfn-panel" data-for="dom-authenticatorselectioncriteria-residentkey" id="infopanel-for-dom-authenticatorselectioncriteria-residentkey" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorselectioncriteria-residentkey" style="display:none">Info about the 'residentKey' definition.</span><b><a href="#dom-authenticatorselectioncriteria-residentkey">#dom-authenticatorselectioncriteria-residentkey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-residentkey">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-authenticatorselectioncriteria-residentkey①">(2)</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-residentkey②">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-dom-authenticatorselectioncriteria-residentkey③">(2)</a> <a href="#ref-for-dom-authenticatorselectioncriteria-residentkey④">(3)</a>
@@ -11259,73 +11260,73 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-residentkey⑦">6.2.2. Credential Storage Modality</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorselectioncriteria-requireresidentkey">
-   <b><a href="#dom-authenticatorselectioncriteria-requireresidentkey">#dom-authenticatorselectioncriteria-requireresidentkey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorselectioncriteria-requireresidentkey" class="dfn-panel" data-for="dom-authenticatorselectioncriteria-requireresidentkey" id="infopanel-for-dom-authenticatorselectioncriteria-requireresidentkey" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorselectioncriteria-requireresidentkey" style="display:none">Info about the 'requireResidentKey' definition.</span><b><a href="#dom-authenticatorselectioncriteria-requireresidentkey">#dom-authenticatorselectioncriteria-requireresidentkey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-requireresidentkey">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-authenticatorselectioncriteria-requireresidentkey①">(2)</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-requireresidentkey②">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-dom-authenticatorselectioncriteria-requireresidentkey③">(2)</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-requireresidentkey④">6.2.2. Credential Storage Modality</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorselectioncriteria-userverification">
-   <b><a href="#dom-authenticatorselectioncriteria-userverification">#dom-authenticatorselectioncriteria-userverification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorselectioncriteria-userverification" class="dfn-panel" data-for="dom-authenticatorselectioncriteria-userverification" id="infopanel-for-dom-authenticatorselectioncriteria-userverification" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorselectioncriteria-userverification" style="display:none">Info about the 'userVerification' definition.</span><b><a href="#dom-authenticatorselectioncriteria-userverification">#dom-authenticatorselectioncriteria-userverification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-userverification">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-authenticatorselectioncriteria-userverification①">(2)</a> <a href="#ref-for-dom-authenticatorselectioncriteria-userverification②">(3)</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-userverification③">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
     <li><a href="#ref-for-dom-authenticatorselectioncriteria-userverification④">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-authenticatorattachment">
-   <b><a href="#enumdef-authenticatorattachment">#enumdef-authenticatorattachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-authenticatorattachment" class="dfn-panel" data-for="enumdef-authenticatorattachment" id="infopanel-for-enumdef-authenticatorattachment" role="dialog">
+   <span id="infopaneltitle-for-enumdef-authenticatorattachment" style="display:none">Info about the 'AuthenticatorAttachment' definition.</span><b><a href="#enumdef-authenticatorattachment">#enumdef-authenticatorattachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-authenticatorattachment">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
     <li><a href="#ref-for-enumdef-authenticatorattachment①">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a> <a href="#ref-for-enumdef-authenticatorattachment②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattachment-platform">
-   <b><a href="#dom-authenticatorattachment-platform">#dom-authenticatorattachment-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattachment-platform" class="dfn-panel" data-for="dom-authenticatorattachment-platform" id="infopanel-for-dom-authenticatorattachment-platform" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattachment-platform" style="display:none">Info about the 'platform' definition.</span><b><a href="#dom-authenticatorattachment-platform">#dom-authenticatorattachment-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattachment-platform">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatorattachment-cross-platform">
-   <b><a href="#dom-authenticatorattachment-cross-platform">#dom-authenticatorattachment-cross-platform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatorattachment-cross-platform" class="dfn-panel" data-for="dom-authenticatorattachment-cross-platform" id="infopanel-for-dom-authenticatorattachment-cross-platform" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatorattachment-cross-platform" style="display:none">Info about the 'cross-platform' definition.</span><b><a href="#dom-authenticatorattachment-cross-platform">#dom-authenticatorattachment-cross-platform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatorattachment-cross-platform">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-residentkeyrequirement">
-   <b><a href="#enumdef-residentkeyrequirement">#enumdef-residentkeyrequirement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-residentkeyrequirement" class="dfn-panel" data-for="enumdef-residentkeyrequirement" id="infopanel-for-enumdef-residentkeyrequirement" role="dialog">
+   <span id="infopaneltitle-for-enumdef-residentkeyrequirement" style="display:none">Info about the 'ResidentKeyRequirement' definition.</span><b><a href="#enumdef-residentkeyrequirement">#enumdef-residentkeyrequirement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-residentkeyrequirement">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-enumdef-residentkeyrequirement①">(2)</a>
     <li><a href="#ref-for-enumdef-residentkeyrequirement②">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-enumdef-residentkeyrequirement③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-residentkeyrequirement-discouraged">
-   <b><a href="#dom-residentkeyrequirement-discouraged">#dom-residentkeyrequirement-discouraged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-residentkeyrequirement-discouraged" class="dfn-panel" data-for="dom-residentkeyrequirement-discouraged" id="infopanel-for-dom-residentkeyrequirement-discouraged" role="dialog">
+   <span id="infopaneltitle-for-dom-residentkeyrequirement-discouraged" style="display:none">Info about the 'discouraged' definition.</span><b><a href="#dom-residentkeyrequirement-discouraged">#dom-residentkeyrequirement-discouraged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-residentkeyrequirement-discouraged">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-residentkeyrequirement-discouraged①">(2)</a>
     <li><a href="#ref-for-dom-residentkeyrequirement-discouraged②">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
     <li><a href="#ref-for-dom-residentkeyrequirement-discouraged③">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-dom-residentkeyrequirement-discouraged④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-residentkeyrequirement-preferred">
-   <b><a href="#dom-residentkeyrequirement-preferred">#dom-residentkeyrequirement-preferred</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-residentkeyrequirement-preferred" class="dfn-panel" data-for="dom-residentkeyrequirement-preferred" id="infopanel-for-dom-residentkeyrequirement-preferred" role="dialog">
+   <span id="infopaneltitle-for-dom-residentkeyrequirement-preferred" style="display:none">Info about the 'preferred' definition.</span><b><a href="#dom-residentkeyrequirement-preferred">#dom-residentkeyrequirement-preferred</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-residentkeyrequirement-preferred">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-residentkeyrequirement-preferred①">(2)</a>
     <li><a href="#ref-for-dom-residentkeyrequirement-preferred②">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-dom-residentkeyrequirement-preferred③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-residentkeyrequirement-required">
-   <b><a href="#dom-residentkeyrequirement-required">#dom-residentkeyrequirement-required</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-residentkeyrequirement-required" class="dfn-panel" data-for="dom-residentkeyrequirement-required" id="infopanel-for-dom-residentkeyrequirement-required" role="dialog">
+   <span id="infopaneltitle-for-dom-residentkeyrequirement-required" style="display:none">Info about the 'required' definition.</span><b><a href="#dom-residentkeyrequirement-required">#dom-residentkeyrequirement-required</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-residentkeyrequirement-required">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-residentkeyrequirement-required①">(2)</a>
     <li><a href="#ref-for-dom-residentkeyrequirement-required②">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a> <a href="#ref-for-dom-residentkeyrequirement-required③">(2)</a>
     <li><a href="#ref-for-dom-residentkeyrequirement-required④">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-conveyance">
-   <b><a href="#attestation-conveyance">#attestation-conveyance</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-conveyance" class="dfn-panel" data-for="attestation-conveyance" id="infopanel-for-attestation-conveyance" role="dialog">
+   <span id="infopaneltitle-for-attestation-conveyance" style="display:none">Info about the 'Attestation Conveyance' definition.</span><b><a href="#attestation-conveyance">#attestation-conveyance</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-conveyance">4. Terminology</a>
     <li><a href="#ref-for-attestation-conveyance①">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
@@ -11333,43 +11334,43 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-conveyance③">6.5.3. Attestation Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-attestationconveyancepreference">
-   <b><a href="#enumdef-attestationconveyancepreference">#enumdef-attestationconveyancepreference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-attestationconveyancepreference" class="dfn-panel" data-for="enumdef-attestationconveyancepreference" id="infopanel-for-enumdef-attestationconveyancepreference" role="dialog">
+   <span id="infopaneltitle-for-enumdef-attestationconveyancepreference" style="display:none">Info about the 'AttestationConveyancePreference' definition.</span><b><a href="#enumdef-attestationconveyancepreference">#enumdef-attestationconveyancepreference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-attestationconveyancepreference">5.2.1.1. Easily accessing credential data</a>
     <li><a href="#ref-for-enumdef-attestationconveyancepreference">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-enumdef-attestationconveyancepreference①">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a> <a href="#ref-for-enumdef-attestationconveyancepreference②">(2)</a> <a href="#ref-for-enumdef-attestationconveyancepreference③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attestationconveyancepreference-none">
-   <b><a href="#dom-attestationconveyancepreference-none">#dom-attestationconveyancepreference-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attestationconveyancepreference-none" class="dfn-panel" data-for="dom-attestationconveyancepreference-none" id="infopanel-for-dom-attestationconveyancepreference-none" role="dialog">
+   <span id="infopaneltitle-for-dom-attestationconveyancepreference-none" style="display:none">Info about the 'none' definition.</span><b><a href="#dom-attestationconveyancepreference-none">#dom-attestationconveyancepreference-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attestationconveyancepreference-none">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a>
     <li><a href="#ref-for-dom-attestationconveyancepreference-none①">6.5.3. Attestation Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attestationconveyancepreference-indirect">
-   <b><a href="#dom-attestationconveyancepreference-indirect">#dom-attestationconveyancepreference-indirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attestationconveyancepreference-indirect" class="dfn-panel" data-for="dom-attestationconveyancepreference-indirect" id="infopanel-for-dom-attestationconveyancepreference-indirect" role="dialog">
+   <span id="infopaneltitle-for-dom-attestationconveyancepreference-indirect" style="display:none">Info about the 'indirect' definition.</span><b><a href="#dom-attestationconveyancepreference-indirect">#dom-attestationconveyancepreference-indirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attestationconveyancepreference-indirect">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attestationconveyancepreference-direct">
-   <b><a href="#dom-attestationconveyancepreference-direct">#dom-attestationconveyancepreference-direct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attestationconveyancepreference-direct" class="dfn-panel" data-for="dom-attestationconveyancepreference-direct" id="infopanel-for-dom-attestationconveyancepreference-direct" role="dialog">
+   <span id="infopaneltitle-for-dom-attestationconveyancepreference-direct" style="display:none">Info about the 'direct' definition.</span><b><a href="#dom-attestationconveyancepreference-direct">#dom-attestationconveyancepreference-direct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attestationconveyancepreference-direct">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attestationconveyancepreference-enterprise">
-   <b><a href="#dom-attestationconveyancepreference-enterprise">#dom-attestationconveyancepreference-enterprise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attestationconveyancepreference-enterprise" class="dfn-panel" data-for="dom-attestationconveyancepreference-enterprise" id="infopanel-for-dom-attestationconveyancepreference-enterprise" role="dialog">
+   <span id="infopaneltitle-for-dom-attestationconveyancepreference-enterprise" style="display:none">Info about the 'enterprise' definition.</span><b><a href="#dom-attestationconveyancepreference-enterprise">#dom-attestationconveyancepreference-enterprise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attestationconveyancepreference-enterprise">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-attestationconveyancepreference-enterprise①">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a>
     <li><a href="#ref-for-dom-attestationconveyancepreference-enterprise②">6.3.2. The authenticatorMakeCredential Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialrequestoptions">
-   <b><a href="#dictdef-publickeycredentialrequestoptions">#dictdef-publickeycredentialrequestoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialrequestoptions" class="dfn-panel" data-for="dictdef-publickeycredentialrequestoptions" id="infopanel-for-dictdef-publickeycredentialrequestoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialrequestoptions" style="display:none">Info about the 'PublicKeyCredentialRequestOptions' definition.</span><b><a href="#dictdef-publickeycredentialrequestoptions">#dictdef-publickeycredentialrequestoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialrequestoptions">5.1.2. CredentialRequestOptions Dictionary Extension</a>
     <li><a href="#ref-for-dictdef-publickeycredentialrequestoptions①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11381,8 +11382,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-publickeycredentialrequestoptions⑧">14.6.2. Username Enumeration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-challenge">
-   <b><a href="#dom-publickeycredentialrequestoptions-challenge">#dom-publickeycredentialrequestoptions-challenge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-challenge" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-challenge" id="infopanel-for-dom-publickeycredentialrequestoptions-challenge" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-challenge" style="display:none">Info about the 'challenge' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-challenge">#dom-publickeycredentialrequestoptions-challenge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-challenge">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-challenge①">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-challenge②">(2)</a>
@@ -11390,24 +11391,24 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-challenge④">13.4.3. Cryptographic Challenges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-timeout">
-   <b><a href="#dom-publickeycredentialrequestoptions-timeout">#dom-publickeycredentialrequestoptions-timeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-timeout" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-timeout" id="infopanel-for-dom-publickeycredentialrequestoptions-timeout" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-timeout" style="display:none">Info about the 'timeout' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-timeout">#dom-publickeycredentialrequestoptions-timeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-timeout">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-timeout①">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-timeout②">(3)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-timeout③">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-timeout④">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-rpid">
-   <b><a href="#dom-publickeycredentialrequestoptions-rpid">#dom-publickeycredentialrequestoptions-rpid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-rpid" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-rpid" id="infopanel-for-dom-publickeycredentialrequestoptions-rpid" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-rpid" style="display:none">Info about the 'rpId' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-rpid">#dom-publickeycredentialrequestoptions-rpid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-rpid">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-rpid①">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-rpid②">(3)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-rpid③">(4)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-rpid④">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-rpid⑤">10.1. FIDO AppID Extension (appid)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-allowcredentials">
-   <b><a href="#dom-publickeycredentialrequestoptions-allowcredentials">#dom-publickeycredentialrequestoptions-allowcredentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-allowcredentials" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-allowcredentials" id="infopanel-for-dom-publickeycredentialrequestoptions-allowcredentials" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-allowcredentials" style="display:none">Info about the 'allowCredentials' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-allowcredentials">#dom-publickeycredentialrequestoptions-allowcredentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials">4. Terminology</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials①">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials②">(3)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials③">(4)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials④">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials⑤">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials⑥">(3)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials⑦">(4)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials⑧">(5)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials⑨">(6)</a>
@@ -11423,23 +11424,23 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials②⑥">14.6.3. Privacy leak via credential IDs</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials②⑦">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials②⑧">(3)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials②⑨">(4)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-allowcredentials③⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-userverification">
-   <b><a href="#dom-publickeycredentialrequestoptions-userverification">#dom-publickeycredentialrequestoptions-userverification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-userverification" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-userverification" id="infopanel-for-dom-publickeycredentialrequestoptions-userverification" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-userverification" style="display:none">Info about the 'userVerification' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-userverification">#dom-publickeycredentialrequestoptions-userverification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-userverification">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-userverification①">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-userverification②">(3)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-userverification③">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-extensions">
-   <b><a href="#dom-publickeycredentialrequestoptions-extensions">#dom-publickeycredentialrequestoptions-extensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialrequestoptions-extensions" class="dfn-panel" data-for="dom-publickeycredentialrequestoptions-extensions" id="infopanel-for-dom-publickeycredentialrequestoptions-extensions" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialrequestoptions-extensions" style="display:none">Info about the 'extensions' definition.</span><b><a href="#dom-publickeycredentialrequestoptions-extensions">#dom-publickeycredentialrequestoptions-extensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-extensions">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-extensions①">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-extensions②">(3)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-extensions③">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
     <li><a href="#ref-for-dom-publickeycredentialrequestoptions-extensions④">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-extensions⑤">(2)</a> <a href="#ref-for-dom-publickeycredentialrequestoptions-extensions⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-authenticationextensionsclientinputs">
-   <b><a href="#dictdef-authenticationextensionsclientinputs">#dictdef-authenticationextensionsclientinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-authenticationextensionsclientinputs" class="dfn-panel" data-for="dictdef-authenticationextensionsclientinputs" id="infopanel-for-dictdef-authenticationextensionsclientinputs" role="dialog">
+   <span id="infopaneltitle-for-dictdef-authenticationextensionsclientinputs" style="display:none">Info about the 'AuthenticationExtensionsClientInputs' definition.</span><b><a href="#dictdef-authenticationextensionsclientinputs">#dictdef-authenticationextensionsclientinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientinputs">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-authenticationextensionsclientinputs①">(2)</a>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientinputs②">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a> <a href="#ref-for-dictdef-authenticationextensionsclientinputs③">(2)</a>
@@ -11452,8 +11453,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientinputs①⓪">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-authenticationextensionsclientoutputs">
-   <b><a href="#dictdef-authenticationextensionsclientoutputs">#dictdef-authenticationextensionsclientoutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-authenticationextensionsclientoutputs" class="dfn-panel" data-for="dictdef-authenticationextensionsclientoutputs" id="infopanel-for-dictdef-authenticationextensionsclientoutputs" role="dialog">
+   <span id="infopaneltitle-for-dictdef-authenticationextensionsclientoutputs" style="display:none">Info about the 'AuthenticationExtensionsClientOutputs' definition.</span><b><a href="#dictdef-authenticationextensionsclientoutputs">#dictdef-authenticationextensionsclientoutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientoutputs">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientoutputs①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11467,8 +11468,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-authenticationextensionsclientoutputs⑨">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dictdef-authenticationextensionsclientoutputs①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-collectedclientdata">
-   <b><a href="#dictdef-collectedclientdata">#dictdef-collectedclientdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-collectedclientdata" class="dfn-panel" data-for="dictdef-collectedclientdata" id="infopanel-for-dictdef-collectedclientdata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-collectedclientdata" style="display:none">Info about the 'CollectedClientData' definition.</span><b><a href="#dictdef-collectedclientdata">#dictdef-collectedclientdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-collectedclientdata">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dictdef-collectedclientdata①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11478,8 +11479,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-collectedclientdata①①">5.8.1.3. Future development</a> <a href="#ref-for-dictdef-collectedclientdata①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-data">
-   <b><a href="#client-data">#client-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-data" class="dfn-panel" data-for="client-data" id="infopanel-for-client-data" role="dialog">
+   <span id="infopaneltitle-for-client-data" style="display:none">Info about the 'client data' definition.</span><b><a href="#client-data">#client-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-data">5.2. Authenticator Responses (interface AuthenticatorResponse)</a> <a href="#ref-for-client-data①">(2)</a>
     <li><a href="#ref-for-client-data②">6. WebAuthn Authenticator Model</a> <a href="#ref-for-client-data③">(2)</a> <a href="#ref-for-client-data④">(3)</a> <a href="#ref-for-client-data⑤">(4)</a>
@@ -11491,20 +11492,20 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-data①③">9. WebAuthn Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-tokenbinding">
-   <b><a href="#dictdef-tokenbinding">#dictdef-tokenbinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-tokenbinding" class="dfn-panel" data-for="dictdef-tokenbinding" id="infopanel-for-dictdef-tokenbinding" role="dialog">
+   <span id="infopaneltitle-for-dictdef-tokenbinding" style="display:none">Info about the 'TokenBinding' definition.</span><b><a href="#dictdef-tokenbinding">#dictdef-tokenbinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-tokenbinding">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a> <a href="#ref-for-dictdef-tokenbinding①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-tokenbindingstatus">
-   <b><a href="#enumdef-tokenbindingstatus">#enumdef-tokenbindingstatus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-tokenbindingstatus" class="dfn-panel" data-for="enumdef-tokenbindingstatus" id="infopanel-for-enumdef-tokenbindingstatus" role="dialog">
+   <span id="infopaneltitle-for-enumdef-tokenbindingstatus" style="display:none">Info about the 'TokenBindingStatus' definition.</span><b><a href="#enumdef-tokenbindingstatus">#enumdef-tokenbindingstatus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-tokenbindingstatus">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a> <a href="#ref-for-enumdef-tokenbindingstatus①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-collectedclientdata-type">
-   <b><a href="#dom-collectedclientdata-type">#dom-collectedclientdata-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-collectedclientdata-type" class="dfn-panel" data-for="dom-collectedclientdata-type" id="infopanel-for-dom-collectedclientdata-type" role="dialog">
+   <span id="infopaneltitle-for-dom-collectedclientdata-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-collectedclientdata-type">#dom-collectedclientdata-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-collectedclientdata-type">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-collectedclientdata-type①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11516,8 +11517,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-collectedclientdata-type⑧">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-collectedclientdata-challenge">
-   <b><a href="#dom-collectedclientdata-challenge">#dom-collectedclientdata-challenge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-collectedclientdata-challenge" class="dfn-panel" data-for="dom-collectedclientdata-challenge" id="infopanel-for-dom-collectedclientdata-challenge" role="dialog">
+   <span id="infopaneltitle-for-dom-collectedclientdata-challenge" style="display:none">Info about the 'challenge' definition.</span><b><a href="#dom-collectedclientdata-challenge">#dom-collectedclientdata-challenge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-collectedclientdata-challenge">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-collectedclientdata-challenge①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11529,8 +11530,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-collectedclientdata-challenge⑧">13.4.3. Cryptographic Challenges</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-collectedclientdata-origin">
-   <b><a href="#dom-collectedclientdata-origin">#dom-collectedclientdata-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-collectedclientdata-origin" class="dfn-panel" data-for="dom-collectedclientdata-origin" id="infopanel-for-dom-collectedclientdata-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-collectedclientdata-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-collectedclientdata-origin">#dom-collectedclientdata-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-collectedclientdata-origin">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-collectedclientdata-origin①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11542,8 +11543,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-collectedclientdata-origin⑧">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-collectedclientdata-crossorigin">
-   <b><a href="#dom-collectedclientdata-crossorigin">#dom-collectedclientdata-crossorigin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-collectedclientdata-crossorigin" class="dfn-panel" data-for="dom-collectedclientdata-crossorigin" id="infopanel-for-dom-collectedclientdata-crossorigin" role="dialog">
+   <span id="infopaneltitle-for-dom-collectedclientdata-crossorigin" style="display:none">Info about the 'crossOrigin' definition.</span><b><a href="#dom-collectedclientdata-crossorigin">#dom-collectedclientdata-crossorigin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-collectedclientdata-crossorigin">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-collectedclientdata-crossorigin①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11552,8 +11553,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-collectedclientdata-crossorigin⑤">5.8.1.3. Future development</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-collectedclientdata-tokenbinding">
-   <b><a href="#dom-collectedclientdata-tokenbinding">#dom-collectedclientdata-tokenbinding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-collectedclientdata-tokenbinding" class="dfn-panel" data-for="dom-collectedclientdata-tokenbinding" id="infopanel-for-dom-collectedclientdata-tokenbinding" role="dialog">
+   <span id="infopaneltitle-for-dom-collectedclientdata-tokenbinding" style="display:none">Info about the 'tokenBinding' definition.</span><b><a href="#dom-collectedclientdata-tokenbinding">#dom-collectedclientdata-tokenbinding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-collectedclientdata-tokenbinding">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-collectedclientdata-tokenbinding①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11562,36 +11563,36 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-collectedclientdata-tokenbinding⑥">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-dom-collectedclientdata-tokenbinding⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-tokenbinding-status">
-   <b><a href="#dom-tokenbinding-status">#dom-tokenbinding-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-tokenbinding-status" class="dfn-panel" data-for="dom-tokenbinding-status" id="infopanel-for-dom-tokenbinding-status" role="dialog">
+   <span id="infopaneltitle-for-dom-tokenbinding-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-tokenbinding-status">#dom-tokenbinding-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-tokenbinding-status">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a> <a href="#ref-for-dom-tokenbinding-status①">(2)</a>
     <li><a href="#ref-for-dom-tokenbinding-status②">7.1. Registering a New Credential</a>
     <li><a href="#ref-for-dom-tokenbinding-status③">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-tokenbindingstatus-supported">
-   <b><a href="#dom-tokenbindingstatus-supported">#dom-tokenbindingstatus-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-tokenbindingstatus-supported" class="dfn-panel" data-for="dom-tokenbindingstatus-supported" id="infopanel-for-dom-tokenbindingstatus-supported" role="dialog">
+   <span id="infopaneltitle-for-dom-tokenbindingstatus-supported" style="display:none">Info about the 'supported' definition.</span><b><a href="#dom-tokenbindingstatus-supported">#dom-tokenbindingstatus-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-tokenbindingstatus-supported">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-tokenbindingstatus-present">
-   <b><a href="#dom-tokenbindingstatus-present">#dom-tokenbindingstatus-present</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-tokenbindingstatus-present" class="dfn-panel" data-for="dom-tokenbindingstatus-present" id="infopanel-for-dom-tokenbindingstatus-present" role="dialog">
+   <span id="infopaneltitle-for-dom-tokenbindingstatus-present" style="display:none">Info about the 'present' definition.</span><b><a href="#dom-tokenbindingstatus-present">#dom-tokenbindingstatus-present</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-tokenbindingstatus-present">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a> <a href="#ref-for-dom-tokenbindingstatus-present①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-tokenbinding-id">
-   <b><a href="#dom-tokenbinding-id">#dom-tokenbinding-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-tokenbinding-id" class="dfn-panel" data-for="dom-tokenbinding-id" id="infopanel-for-dom-tokenbinding-id" role="dialog">
+   <span id="infopaneltitle-for-dom-tokenbinding-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-tokenbinding-id">#dom-tokenbinding-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-tokenbinding-id">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a> <a href="#ref-for-dom-tokenbinding-id①">(2)</a>
     <li><a href="#ref-for-dom-tokenbinding-id②">7.1. Registering a New Credential</a>
     <li><a href="#ref-for-dom-tokenbinding-id③">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collectedclientdata-json-compatible-serialization-of-client-data">
-   <b><a href="#collectedclientdata-json-compatible-serialization-of-client-data">#collectedclientdata-json-compatible-serialization-of-client-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collectedclientdata-json-compatible-serialization-of-client-data" class="dfn-panel" data-for="collectedclientdata-json-compatible-serialization-of-client-data" id="infopanel-for-collectedclientdata-json-compatible-serialization-of-client-data" role="dialog">
+   <span id="infopaneltitle-for-collectedclientdata-json-compatible-serialization-of-client-data" style="display:none">Info about the 'JSON-compatible serialization of client data' definition.</span><b><a href="#collectedclientdata-json-compatible-serialization-of-client-data">#collectedclientdata-json-compatible-serialization-of-client-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collectedclientdata-json-compatible-serialization-of-client-data">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-collectedclientdata-json-compatible-serialization-of-client-data①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11600,8 +11601,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-collectedclientdata-json-compatible-serialization-of-client-data⑤">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collectedclientdata-hash-of-the-serialized-client-data">
-   <b><a href="#collectedclientdata-hash-of-the-serialized-client-data">#collectedclientdata-hash-of-the-serialized-client-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collectedclientdata-hash-of-the-serialized-client-data" class="dfn-panel" data-for="collectedclientdata-hash-of-the-serialized-client-data" id="infopanel-for-collectedclientdata-hash-of-the-serialized-client-data" role="dialog">
+   <span id="infopaneltitle-for-collectedclientdata-hash-of-the-serialized-client-data" style="display:none">Info about the 'Hash of the serialized client data' definition.</span><b><a href="#collectedclientdata-hash-of-the-serialized-client-data">#collectedclientdata-hash-of-the-serialized-client-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collectedclientdata-hash-of-the-serialized-client-data">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-collectedclientdata-hash-of-the-serialized-client-data①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11622,15 +11623,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-collectedclientdata-hash-of-the-serialized-client-data①⑨">8.8. Apple Anonymous Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ccdtostring">
-   <b><a href="#ccdtostring">#ccdtostring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ccdtostring" class="dfn-panel" data-for="ccdtostring" id="infopanel-for-ccdtostring" role="dialog">
+   <span id="infopaneltitle-for-ccdtostring" style="display:none">Info about the 'CCDToString' definition.</span><b><a href="#ccdtostring">#ccdtostring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ccdtostring">5.8.1.1. Serialization</a> <a href="#ref-for-ccdtostring①">(2)</a> <a href="#ref-for-ccdtostring②">(3)</a>
     <li><a href="#ref-for-ccdtostring③">5.8.1.2. Limited Verification Algorithm</a> <a href="#ref-for-ccdtostring④">(2)</a> <a href="#ref-for-ccdtostring⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-publickeycredentialtype">
-   <b><a href="#enumdef-publickeycredentialtype">#enumdef-publickeycredentialtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-publickeycredentialtype" class="dfn-panel" data-for="enumdef-publickeycredentialtype" id="infopanel-for-enumdef-publickeycredentialtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-publickeycredentialtype" style="display:none">Info about the 'PublicKeyCredentialType' definition.</span><b><a href="#enumdef-publickeycredentialtype">#enumdef-publickeycredentialtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-publickeycredentialtype">4. Terminology</a>
     <li><a href="#ref-for-enumdef-publickeycredentialtype①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-enumdef-publickeycredentialtype②">(2)</a> <a href="#ref-for-enumdef-publickeycredentialtype③">(3)</a>
@@ -11640,8 +11641,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-enumdef-publickeycredentialtype⑧">6.3.2. The authenticatorMakeCredential Operation</a> <a href="#ref-for-enumdef-publickeycredentialtype⑨">(2)</a> <a href="#ref-for-enumdef-publickeycredentialtype①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialtype-public-key">
-   <b><a href="#dom-publickeycredentialtype-public-key">#dom-publickeycredentialtype-public-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialtype-public-key" class="dfn-panel" data-for="dom-publickeycredentialtype-public-key" id="infopanel-for-dom-publickeycredentialtype-public-key" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialtype-public-key" style="display:none">Info about the 'public-key' definition.</span><b><a href="#dom-publickeycredentialtype-public-key">#dom-publickeycredentialtype-public-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialtype-public-key">4. Terminology</a>
     <li><a href="#ref-for-dom-publickeycredentialtype-public-key①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialtype-public-key②">(2)</a>
@@ -11651,8 +11652,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialtype-public-key⑥">11.5. Add Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-publickeycredentialdescriptor">
-   <b><a href="#dictdef-publickeycredentialdescriptor">#dictdef-publickeycredentialdescriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-publickeycredentialdescriptor" class="dfn-panel" data-for="dictdef-publickeycredentialdescriptor" id="infopanel-for-dictdef-publickeycredentialdescriptor" role="dialog">
+   <span id="infopaneltitle-for-dictdef-publickeycredentialdescriptor" style="display:none">Info about the 'PublicKeyCredentialDescriptor' definition.</span><b><a href="#dictdef-publickeycredentialdescriptor">#dictdef-publickeycredentialdescriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-publickeycredentialdescriptor">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dictdef-publickeycredentialdescriptor①">(2)</a> <a href="#ref-for-dictdef-publickeycredentialdescriptor②">(3)</a>
     <li><a href="#ref-for-dictdef-publickeycredentialdescriptor③">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a> <a href="#ref-for-dictdef-publickeycredentialdescriptor④">(2)</a>
@@ -11663,8 +11664,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dictdef-publickeycredentialdescriptor">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialdescriptor-type">
-   <b><a href="#dom-publickeycredentialdescriptor-type">#dom-publickeycredentialdescriptor-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialdescriptor-type" class="dfn-panel" data-for="dom-publickeycredentialdescriptor-type" id="infopanel-for-dom-publickeycredentialdescriptor-type" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialdescriptor-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-publickeycredentialdescriptor-type">#dom-publickeycredentialdescriptor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-type">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-type①">5.8.3. Credential Descriptor (dictionary PublicKeyCredentialDescriptor)</a> <a href="#ref-for-dom-publickeycredentialdescriptor-type②">(2)</a>
@@ -11672,8 +11673,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-type④">10.1. FIDO AppID Extension (appid)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialdescriptor-id">
-   <b><a href="#dom-publickeycredentialdescriptor-id">#dom-publickeycredentialdescriptor-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialdescriptor-id" class="dfn-panel" data-for="dom-publickeycredentialdescriptor-id" id="infopanel-for-dom-publickeycredentialdescriptor-id" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialdescriptor-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-publickeycredentialdescriptor-id">#dom-publickeycredentialdescriptor-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-id">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-id①">5.8.3. Credential Descriptor (dictionary PublicKeyCredentialDescriptor)</a>
@@ -11683,8 +11684,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-id⑧">10.2. FIDO AppID Exclusion Extension (appidExclude)</a> <a href="#ref-for-dom-publickeycredentialdescriptor-id⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-publickeycredentialdescriptor-transports">
-   <b><a href="#dom-publickeycredentialdescriptor-transports">#dom-publickeycredentialdescriptor-transports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-publickeycredentialdescriptor-transports" class="dfn-panel" data-for="dom-publickeycredentialdescriptor-transports" id="infopanel-for-dom-publickeycredentialdescriptor-transports" role="dialog">
+   <span id="infopaneltitle-for-dom-publickeycredentialdescriptor-transports" style="display:none">Info about the 'transports' definition.</span><b><a href="#dom-publickeycredentialdescriptor-transports">#dom-publickeycredentialdescriptor-transports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-transports">2.1.1. Enumerations as DOMString types</a>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-transports①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-publickeycredentialdescriptor-transports②">(2)</a> <a href="#ref-for-dom-publickeycredentialdescriptor-transports③">(3)</a>
@@ -11694,8 +11695,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-dom-publickeycredentialdescriptor-transports①①">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-authenticatortransport">
-   <b><a href="#enumdef-authenticatortransport">#enumdef-authenticatortransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-authenticatortransport" class="dfn-panel" data-for="enumdef-authenticatortransport" id="infopanel-for-enumdef-authenticatortransport" role="dialog">
+   <span id="infopaneltitle-for-enumdef-authenticatortransport" style="display:none">Info about the 'AuthenticatorTransport' definition.</span><b><a href="#enumdef-authenticatortransport">#enumdef-authenticatortransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-authenticatortransport">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-enumdef-authenticatortransport①">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
@@ -11705,34 +11706,34 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-enumdef-authenticatortransport⑥">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatortransport-usb">
-   <b><a href="#dom-authenticatortransport-usb">#dom-authenticatortransport-usb</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatortransport-usb" class="dfn-panel" data-for="dom-authenticatortransport-usb" id="infopanel-for-dom-authenticatortransport-usb" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatortransport-usb" style="display:none">Info about the 'usb' definition.</span><b><a href="#dom-authenticatortransport-usb">#dom-authenticatortransport-usb</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatortransport-usb">5.8.4. Authenticator Transport Enumeration (enum AuthenticatorTransport)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatortransport-nfc">
-   <b><a href="#dom-authenticatortransport-nfc">#dom-authenticatortransport-nfc</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatortransport-nfc" class="dfn-panel" data-for="dom-authenticatortransport-nfc" id="infopanel-for-dom-authenticatortransport-nfc" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatortransport-nfc" style="display:none">Info about the 'nfc' definition.</span><b><a href="#dom-authenticatortransport-nfc">#dom-authenticatortransport-nfc</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatortransport-nfc">5.8.4. Authenticator Transport Enumeration (enum AuthenticatorTransport)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatortransport-ble">
-   <b><a href="#dom-authenticatortransport-ble">#dom-authenticatortransport-ble</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatortransport-ble" class="dfn-panel" data-for="dom-authenticatortransport-ble" id="infopanel-for-dom-authenticatortransport-ble" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatortransport-ble" style="display:none">Info about the 'ble' definition.</span><b><a href="#dom-authenticatortransport-ble">#dom-authenticatortransport-ble</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatortransport-ble">5.8.4. Authenticator Transport Enumeration (enum AuthenticatorTransport)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticatortransport-internal">
-   <b><a href="#dom-authenticatortransport-internal">#dom-authenticatortransport-internal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticatortransport-internal" class="dfn-panel" data-for="dom-authenticatortransport-internal" id="infopanel-for-dom-authenticatortransport-internal" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticatortransport-internal" style="display:none">Info about the 'internal' definition.</span><b><a href="#dom-authenticatortransport-internal">#dom-authenticatortransport-internal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticatortransport-internal">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-dom-authenticatortransport-internal①">5.8.4. Authenticator Transport Enumeration (enum AuthenticatorTransport)</a>
     <li><a href="#ref-for-dom-authenticatortransport-internal②">11.2. Virtual Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-cosealgorithmidentifier">
-   <b><a href="#typedefdef-cosealgorithmidentifier">#typedefdef-cosealgorithmidentifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cosealgorithmidentifier" class="dfn-panel" data-for="typedefdef-cosealgorithmidentifier" id="infopanel-for-typedefdef-cosealgorithmidentifier" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cosealgorithmidentifier" style="display:none">Info about the 'COSEAlgorithmIdentifier' definition.</span><b><a href="#typedefdef-cosealgorithmidentifier">#typedefdef-cosealgorithmidentifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cosealgorithmidentifier">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-typedefdef-cosealgorithmidentifier①">(2)</a>
     <li><a href="#ref-for-typedefdef-cosealgorithmidentifier②">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a> <a href="#ref-for-typedefdef-cosealgorithmidentifier③">(2)</a>
@@ -11745,46 +11746,46 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-typedefdef-cosealgorithmidentifier①③">8.3. TPM Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-userverificationrequirement">
-   <b><a href="#enumdef-userverificationrequirement">#enumdef-userverificationrequirement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-userverificationrequirement" class="dfn-panel" data-for="enumdef-userverificationrequirement" id="infopanel-for-enumdef-userverificationrequirement" role="dialog">
+   <span id="infopaneltitle-for-enumdef-userverificationrequirement" style="display:none">Info about the 'UserVerificationRequirement' definition.</span><b><a href="#enumdef-userverificationrequirement">#enumdef-userverificationrequirement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-userverificationrequirement">5.4.4. Authenticator Selection Criteria (dictionary AuthenticatorSelectionCriteria)</a>
     <li><a href="#ref-for-enumdef-userverificationrequirement①">5.5. Options for Assertion Generation (dictionary PublicKeyCredentialRequestOptions)</a>
     <li><a href="#ref-for-enumdef-userverificationrequirement②">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a> <a href="#ref-for-enumdef-userverificationrequirement③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-userverificationrequirement-required">
-   <b><a href="#dom-userverificationrequirement-required">#dom-userverificationrequirement-required</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-userverificationrequirement-required" class="dfn-panel" data-for="dom-userverificationrequirement-required" id="infopanel-for-dom-userverificationrequirement-required" role="dialog">
+   <span id="infopaneltitle-for-dom-userverificationrequirement-required" style="display:none">Info about the 'required' definition.</span><b><a href="#dom-userverificationrequirement-required">#dom-userverificationrequirement-required</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-userverificationrequirement-required">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-required①">(2)</a> <a href="#ref-for-dom-userverificationrequirement-required②">(3)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-required③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-required④">(2)</a> <a href="#ref-for-dom-userverificationrequirement-required⑤">(3)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-required⑥">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-userverificationrequirement-preferred">
-   <b><a href="#dom-userverificationrequirement-preferred">#dom-userverificationrequirement-preferred</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-userverificationrequirement-preferred" class="dfn-panel" data-for="dom-userverificationrequirement-preferred" id="infopanel-for-dom-userverificationrequirement-preferred" role="dialog">
+   <span id="infopaneltitle-for-dom-userverificationrequirement-preferred" style="display:none">Info about the 'preferred' definition.</span><b><a href="#dom-userverificationrequirement-preferred">#dom-userverificationrequirement-preferred</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-userverificationrequirement-preferred">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-preferred①">(2)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-preferred②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-preferred③">(2)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-preferred④">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-userverificationrequirement-discouraged">
-   <b><a href="#dom-userverificationrequirement-discouraged">#dom-userverificationrequirement-discouraged</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-userverificationrequirement-discouraged" class="dfn-panel" data-for="dom-userverificationrequirement-discouraged" id="infopanel-for-dom-userverificationrequirement-discouraged" role="dialog">
+   <span id="infopaneltitle-for-dom-userverificationrequirement-discouraged" style="display:none">Info about the 'discouraged' definition.</span><b><a href="#dom-userverificationrequirement-discouraged">#dom-userverificationrequirement-discouraged</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-userverificationrequirement-discouraged">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-discouraged①">(2)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-discouraged②">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-dom-userverificationrequirement-discouraged③">(2)</a>
     <li><a href="#ref-for-dom-userverificationrequirement-discouraged④">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="publickey-credentials-get-feature">
-   <b><a href="#publickey-credentials-get-feature">#publickey-credentials-get-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-publickey-credentials-get-feature" class="dfn-panel" data-for="publickey-credentials-get-feature" id="infopanel-for-publickey-credentials-get-feature" role="dialog">
+   <span id="infopaneltitle-for-publickey-credentials-get-feature" style="display:none">Info about the 'publickey-credentials-get' definition.</span><b><a href="#publickey-credentials-get-feature">#publickey-credentials-get-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-publickey-credentials-get-feature">5.10. Using Web Authentication within iframe elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-model">
-   <b><a href="#authenticator-model">#authenticator-model</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-model" class="dfn-panel" data-for="authenticator-model" id="infopanel-for-authenticator-model" role="dialog">
+   <span id="infopaneltitle-for-authenticator-model" style="display:none">Info about the 'Authenticator Model' definition.</span><b><a href="#authenticator-model">#authenticator-model</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-model">4. Terminology</a> <a href="#ref-for-authenticator-model①">(2)</a>
     <li><a href="#ref-for-authenticator-model②">6. WebAuthn Authenticator Model</a>
@@ -11792,8 +11793,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-model④">13.2. Physical Proximity between Client and Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-credentials-map">
-   <b><a href="#authenticator-credentials-map">#authenticator-credentials-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-credentials-map" class="dfn-panel" data-for="authenticator-credentials-map" id="infopanel-for-authenticator-credentials-map" role="dialog">
+   <span id="infopaneltitle-for-authenticator-credentials-map" style="display:none">Info about the 'credentials map' definition.</span><b><a href="#authenticator-credentials-map">#authenticator-credentials-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-credentials-map">4. Terminology</a> <a href="#ref-for-authenticator-credentials-map①">(2)</a>
     <li><a href="#ref-for-authenticator-credentials-map②">6.3.1. Lookup Credential Source by Credential ID Algorithm</a>
@@ -11801,8 +11802,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-credentials-map④">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-signature">
-   <b><a href="#attestation-signature">#attestation-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-signature" class="dfn-panel" data-for="attestation-signature" id="infopanel-for-attestation-signature" role="dialog">
+   <span id="infopaneltitle-for-attestation-signature" style="display:none">Info about the 'attestation signature' definition.</span><b><a href="#attestation-signature">#attestation-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-signature">4. Terminology</a>
     <li><a href="#ref-for-attestation-signature①">6. WebAuthn Authenticator Model</a> <a href="#ref-for-attestation-signature②">(2)</a> <a href="#ref-for-attestation-signature③">(3)</a> <a href="#ref-for-attestation-signature④">(4)</a>
@@ -11815,8 +11816,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-signature①③">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assertion-signature">
-   <b><a href="#assertion-signature">#assertion-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assertion-signature" class="dfn-panel" data-for="assertion-signature" id="infopanel-for-assertion-signature" role="dialog">
+   <span id="infopaneltitle-for-assertion-signature" style="display:none">Info about the 'assertion signature' definition.</span><b><a href="#assertion-signature">#assertion-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assertion-signature">1.3.3. Authentication</a>
     <li><a href="#ref-for-assertion-signature①">4. Terminology</a>
@@ -11826,15 +11827,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-assertion-signature⑧">6.3.3. The authenticatorGetAssertion Operation</a> <a href="#ref-for-assertion-signature⑨">(2)</a> <a href="#ref-for-assertion-signature①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-signature">
-   <b><a href="#webauthn-signature">#webauthn-signature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-signature" class="dfn-panel" data-for="webauthn-signature" id="infopanel-for-webauthn-signature" role="dialog">
+   <span id="infopaneltitle-for-webauthn-signature" style="display:none">Info about the 'WebAuthn signature' definition.</span><b><a href="#webauthn-signature">#webauthn-signature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-signature">5.8.1. Client Data Used in WebAuthn Signatures (dictionary CollectedClientData)</a>
     <li><a href="#ref-for-webauthn-signature①">6. WebAuthn Authenticator Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-data">
-   <b><a href="#authenticator-data">#authenticator-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-data" class="dfn-panel" data-for="authenticator-data" id="infopanel-for-authenticator-data" role="dialog">
+   <span id="infopaneltitle-for-authenticator-data" style="display:none">Info about the 'authenticator data' definition.</span><b><a href="#authenticator-data">#authenticator-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-data">1.1. Specification Roadmap</a>
     <li><a href="#ref-for-authenticator-data①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -11860,8 +11861,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-data④⑤">13.3.1. Attestation Certificate Hierarchy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rpidhash">
-   <b><a href="#rpidhash">#rpidhash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rpidhash" class="dfn-panel" data-for="rpidhash" id="infopanel-for-rpidhash" role="dialog">
+   <span id="infopaneltitle-for-rpidhash" style="display:none">Info about the 'rpIdHash' definition.</span><b><a href="#rpidhash">#rpidhash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rpidhash">6.1. Authenticator Data</a>
     <li><a href="#ref-for-rpidhash①">6.1.2. FIDO U2F Signature Format Compatibility</a>
@@ -11870,8 +11871,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-rpidhash④">10.1. FIDO AppID Extension (appid)</a> <a href="#ref-for-rpidhash⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flags">
-   <b><a href="#flags">#flags</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flags" class="dfn-panel" data-for="flags" id="infopanel-for-flags" role="dialog">
+   <span id="infopaneltitle-for-flags" style="display:none">Info about the 'flags' definition.</span><b><a href="#flags">#flags</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flags">5.8.6. User Verification Requirement Enumeration (enum UserVerificationRequirement)</a> <a href="#ref-for-flags①">(2)</a>
     <li><a href="#ref-for-flags②">6.1. Authenticator Data</a> <a href="#ref-for-flags③">(2)</a> <a href="#ref-for-flags④">(3)</a> <a href="#ref-for-flags⑤">(4)</a> <a href="#ref-for-flags⑥">(5)</a> <a href="#ref-for-flags⑦">(6)</a> <a href="#ref-for-flags⑧">(7)</a> <a href="#ref-for-flags⑨">(8)</a> <a href="#ref-for-flags①⓪">(9)</a> <a href="#ref-for-flags①①">(10)</a> <a href="#ref-for-flags①②">(11)</a>
@@ -11882,16 +11883,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-flags②⓪">14.3. Authenticator-local Biometric Recognition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signcount">
-   <b><a href="#signcount">#signcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signcount" class="dfn-panel" data-for="signcount" id="infopanel-for-signcount" role="dialog">
+   <span id="infopaneltitle-for-signcount" style="display:none">Info about the 'signCount' definition.</span><b><a href="#signcount">#signcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signcount">6.1.1. Signature Counter Considerations</a> <a href="#ref-for-signcount①">(2)</a> <a href="#ref-for-signcount②">(3)</a>
     <li><a href="#ref-for-signcount③">7.1. Registering a New Credential</a>
     <li><a href="#ref-for-signcount④">7.2. Verifying an Authentication Assertion</a> <a href="#ref-for-signcount⑤">(2)</a> <a href="#ref-for-signcount⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestedcredentialdata">
-   <b><a href="#attestedcredentialdata">#attestedcredentialdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestedcredentialdata" class="dfn-panel" data-for="attestedcredentialdata" id="infopanel-for-attestedcredentialdata" role="dialog">
+   <span id="infopaneltitle-for-attestedcredentialdata" style="display:none">Info about the 'attestedCredentialData' definition.</span><b><a href="#attestedcredentialdata">#attestedcredentialdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestedcredentialdata">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-attestedcredentialdata①">5.2.1.1. Easily accessing credential data</a>
@@ -11905,8 +11906,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestedcredentialdata①①">8.6. FIDO U2F Attestation Statement Format</a> <a href="#ref-for-attestedcredentialdata①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authdataextensions">
-   <b><a href="#authdataextensions">#authdataextensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authdataextensions" class="dfn-panel" data-for="authdataextensions" id="infopanel-for-authdataextensions" role="dialog">
+   <span id="infopaneltitle-for-authdataextensions" style="display:none">Info about the 'extensions' definition.</span><b><a href="#authdataextensions">#authdataextensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authdataextensions">6.1. Authenticator Data</a> <a href="#ref-for-authdataextensions①">(2)</a> <a href="#ref-for-authdataextensions②">(3)</a> <a href="#ref-for-authdataextensions③">(4)</a>
     <li><a href="#ref-for-authdataextensions④">6.1.2. FIDO U2F Signature Format Compatibility</a>
@@ -11917,15 +11918,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authdataextensions⑨">9.5. Authenticator Extension Processing</a> <a href="#ref-for-authdataextensions①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure">
-   <b><a href="#authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure">#authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure" class="dfn-panel" data-for="authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure" id="infopanel-for-authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure" role="dialog">
+   <span id="infopaneltitle-for-authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure" style="display:none">Info about the 'perform the following steps to generate an authenticator data structure' definition.</span><b><a href="#authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure">#authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure">6.3.2. The authenticatorMakeCredential Operation</a>
     <li><a href="#ref-for-authenticator-data-perform-the-following-steps-to-generate-an-authenticator-data-structure①">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signature-counter">
-   <b><a href="#signature-counter">#signature-counter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signature-counter" class="dfn-panel" data-for="signature-counter" id="infopanel-for-signature-counter" role="dialog">
+   <span id="infopaneltitle-for-signature-counter" style="display:none">Info about the 'Signature Counter' definition.</span><b><a href="#signature-counter">#signature-counter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signature-counter">6.1. Authenticator Data</a>
     <li><a href="#ref-for-signature-counter①">6.1.1. Signature Counter Considerations</a> <a href="#ref-for-signature-counter②">(2)</a> <a href="#ref-for-signature-counter③">(3)</a> <a href="#ref-for-signature-counter④">(4)</a> <a href="#ref-for-signature-counter⑤">(5)</a> <a href="#ref-for-signature-counter⑥">(6)</a> <a href="#ref-for-signature-counter⑦">(7)</a> <a href="#ref-for-signature-counter⑧">(8)</a> <a href="#ref-for-signature-counter⑨">(9)</a> <a href="#ref-for-signature-counter①⓪">(10)</a> <a href="#ref-for-signature-counter①①">(11)</a>
@@ -11936,50 +11937,50 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-signature-counter②④">11.5. Add Credential</a> <a href="#ref-for-signature-counter②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-type">
-   <b><a href="#authenticator-type">#authenticator-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-type" class="dfn-panel" data-for="authenticator-type" id="infopanel-for-authenticator-type" role="dialog">
+   <span id="infopaneltitle-for-authenticator-type" style="display:none">Info about the 'authenticator type' definition.</span><b><a href="#authenticator-type">#authenticator-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-type">4. Terminology</a>
     <li><a href="#ref-for-authenticator-type①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-authenticator-type②">(2)</a> <a href="#ref-for-authenticator-type③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="second-factor-platform-authenticator">
-   <b><a href="#second-factor-platform-authenticator">#second-factor-platform-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-second-factor-platform-authenticator" class="dfn-panel" data-for="second-factor-platform-authenticator" id="infopanel-for-second-factor-platform-authenticator" role="dialog">
+   <span id="infopaneltitle-for-second-factor-platform-authenticator" style="display:none">Info about the 'Second-factor platform authenticator' definition.</span><b><a href="#second-factor-platform-authenticator">#second-factor-platform-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-second-factor-platform-authenticator">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-verifying-platform-authenticator">
-   <b><a href="#user-verifying-platform-authenticator">#user-verifying-platform-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-verifying-platform-authenticator" class="dfn-panel" data-for="user-verifying-platform-authenticator" id="infopanel-for-user-verifying-platform-authenticator" role="dialog">
+   <span id="infopaneltitle-for-user-verifying-platform-authenticator" style="display:none">Info about the 'User-verifying platform authenticator' definition.</span><b><a href="#user-verifying-platform-authenticator">#user-verifying-platform-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-verifying-platform-authenticator">1.3.2. Registration Specifically with User-Verifying Platform Authenticator</a> <a href="#ref-for-user-verifying-platform-authenticator①">(2)</a>
     <li><a href="#ref-for-user-verifying-platform-authenticator②">5.1.7. Availability of User-Verifying Platform Authenticator - PublicKeyCredential’s isUserVerifyingPlatformAuthenticatorAvailable() Method</a> <a href="#ref-for-user-verifying-platform-authenticator③">(2)</a> <a href="#ref-for-user-verifying-platform-authenticator④">(3)</a>
     <li><a href="#ref-for-user-verifying-platform-authenticator⑤">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="second-factor-roaming-authenticator">
-   <b><a href="#second-factor-roaming-authenticator">#second-factor-roaming-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-second-factor-roaming-authenticator" class="dfn-panel" data-for="second-factor-roaming-authenticator" id="infopanel-for-second-factor-roaming-authenticator" role="dialog">
+   <span id="infopaneltitle-for-second-factor-roaming-authenticator" style="display:none">Info about the 'Second-factor roaming authenticator' definition.</span><b><a href="#second-factor-roaming-authenticator">#second-factor-roaming-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-second-factor-roaming-authenticator">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="first-factor-roaming-authenticator">
-   <b><a href="#first-factor-roaming-authenticator">#first-factor-roaming-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-first-factor-roaming-authenticator" class="dfn-panel" data-for="first-factor-roaming-authenticator" id="infopanel-for-first-factor-roaming-authenticator" role="dialog">
+   <span id="infopaneltitle-for-first-factor-roaming-authenticator" style="display:none">Info about the 'First-factor roaming authenticator' definition.</span><b><a href="#first-factor-roaming-authenticator">#first-factor-roaming-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-factor-roaming-authenticator">1.3. Sample API Usage Scenarios</a>
     <li><a href="#ref-for-first-factor-roaming-authenticator①">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-attachment-modality">
-   <b><a href="#authenticator-attachment-modality">#authenticator-attachment-modality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-attachment-modality" class="dfn-panel" data-for="authenticator-attachment-modality" id="infopanel-for-authenticator-attachment-modality" role="dialog">
+   <span id="infopaneltitle-for-authenticator-attachment-modality" style="display:none">Info about the 'Authenticator Attachment Modality' definition.</span><b><a href="#authenticator-attachment-modality">#authenticator-attachment-modality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-attachment-modality">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-authenticator-attachment-modality①">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a> <a href="#ref-for-authenticator-attachment-modality②">(2)</a> <a href="#ref-for-authenticator-attachment-modality③">(3)</a> <a href="#ref-for-authenticator-attachment-modality④">(4)</a>
     <li><a href="#ref-for-authenticator-attachment-modality⑤">6.2. Authenticator Taxonomy</a> <a href="#ref-for-authenticator-attachment-modality⑥">(2)</a> <a href="#ref-for-authenticator-attachment-modality⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="platform-authenticators">
-   <b><a href="#platform-authenticators">#platform-authenticators</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-platform-authenticators" class="dfn-panel" data-for="platform-authenticators" id="infopanel-for-platform-authenticators" role="dialog">
+   <span id="infopaneltitle-for-platform-authenticators" style="display:none">Info about the 'platform authenticators' definition.</span><b><a href="#platform-authenticators">#platform-authenticators</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-platform-authenticators">1. Introduction</a>
     <li><a href="#ref-for-platform-authenticators①">1.2.3. New Device Registration</a> <a href="#ref-for-platform-authenticators②">(2)</a> <a href="#ref-for-platform-authenticators③">(3)</a> <a href="#ref-for-platform-authenticators④">(4)</a> <a href="#ref-for-platform-authenticators⑤">(5)</a> <a href="#ref-for-platform-authenticators⑥">(6)</a>
@@ -12001,8 +12002,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-platform-authenticators③③">15. Accessibility Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="roaming-authenticators">
-   <b><a href="#roaming-authenticators">#roaming-authenticators</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-roaming-authenticators" class="dfn-panel" data-for="roaming-authenticators" id="infopanel-for-roaming-authenticators" role="dialog">
+   <span id="infopaneltitle-for-roaming-authenticators" style="display:none">Info about the 'roaming authenticators' definition.</span><b><a href="#roaming-authenticators">#roaming-authenticators</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-roaming-authenticators">1. Introduction</a>
     <li><a href="#ref-for-roaming-authenticators①">1.2.3. New Device Registration</a> <a href="#ref-for-roaming-authenticators②">(2)</a>
@@ -12015,16 +12016,16 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-roaming-authenticators②③">15. Accessibility Considerations</a> <a href="#ref-for-roaming-authenticators②④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="platform-attachment">
-   <b><a href="#platform-attachment">#platform-attachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-platform-attachment" class="dfn-panel" data-for="platform-attachment" id="infopanel-for-platform-attachment" role="dialog">
+   <span id="infopaneltitle-for-platform-attachment" style="display:none">Info about the 'platform attachment' definition.</span><b><a href="#platform-attachment">#platform-attachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-platform-attachment">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
     <li><a href="#ref-for-platform-attachment①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-platform-attachment②">(2)</a>
     <li><a href="#ref-for-platform-attachment③">11.2. Virtual Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="platform-credential">
-   <b><a href="#platform-credential">#platform-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-platform-credential" class="dfn-panel" data-for="platform-credential" id="infopanel-for-platform-credential" role="dialog">
+   <span id="infopaneltitle-for-platform-credential" style="display:none">Info about the 'platform credential' definition.</span><b><a href="#platform-credential">#platform-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-platform-credential">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
     <li><a href="#ref-for-platform-credential①">6.2. Authenticator Taxonomy</a>
@@ -12032,8 +12033,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-platform-credential③">14.5.3. Privacy Between Operating System Accounts</a> <a href="#ref-for-platform-credential④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-platform-attachment">
-   <b><a href="#cross-platform-attachment">#cross-platform-attachment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-platform-attachment" class="dfn-panel" data-for="cross-platform-attachment" id="infopanel-for-cross-platform-attachment" role="dialog">
+   <span id="infopaneltitle-for-cross-platform-attachment" style="display:none">Info about the 'cross-platform attachment' definition.</span><b><a href="#cross-platform-attachment">#cross-platform-attachment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-platform-attachment">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
     <li><a href="#ref-for-cross-platform-attachment①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-cross-platform-attachment②">(2)</a>
@@ -12041,21 +12042,23 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-cross-platform-attachment④">11.2. Virtual Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="roaming-credential">
-   <b><a href="#roaming-credential">#roaming-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-roaming-credential" class="dfn-panel" data-for="roaming-credential" id="infopanel-for-roaming-credential" role="dialog">
+   <span id="infopaneltitle-for-roaming-credential" style="display:none">Info about the 'roaming
+credential' definition.</span><b><a href="#roaming-credential">#roaming-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-roaming-credential">5.4.5. Authenticator Attachment Enumeration (enum AuthenticatorAttachment)</a>
     <li><a href="#ref-for-roaming-credential①">13.4.6. Credential Loss and Key Mobility</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-storage-modality">
-   <b><a href="#credential-storage-modality">#credential-storage-modality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-storage-modality" class="dfn-panel" data-for="credential-storage-modality" id="infopanel-for-credential-storage-modality" role="dialog">
+   <span id="infopaneltitle-for-credential-storage-modality" style="display:none">Info about the 'credential storage
+modality' definition.</span><b><a href="#credential-storage-modality">#credential-storage-modality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-storage-modality">6.2. Authenticator Taxonomy</a> <a href="#ref-for-credential-storage-modality①">(2)</a> <a href="#ref-for-credential-storage-modality②">(3)</a> <a href="#ref-for-credential-storage-modality③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-side-credential-storage-modality">
-   <b><a href="#client-side-credential-storage-modality">#client-side-credential-storage-modality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-side-credential-storage-modality" class="dfn-panel" data-for="client-side-credential-storage-modality" id="infopanel-for-client-side-credential-storage-modality" role="dialog">
+   <span id="infopaneltitle-for-client-side-credential-storage-modality" style="display:none">Info about the 'client-side credential storage modality' definition.</span><b><a href="#client-side-credential-storage-modality">#client-side-credential-storage-modality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-side-credential-storage-modality">4. Terminology</a>
     <li><a href="#ref-for-client-side-credential-storage-modality①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-client-side-credential-storage-modality②">(2)</a>
@@ -12063,48 +12066,49 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-side-credential-storage-modality④">6.2.2. Credential Storage Modality</a> <a href="#ref-for-client-side-credential-storage-modality⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="discoverable-credential-capable">
-   <b><a href="#discoverable-credential-capable">#discoverable-credential-capable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-discoverable-credential-capable" class="dfn-panel" data-for="discoverable-credential-capable" id="infopanel-for-discoverable-credential-capable" role="dialog">
+   <span id="infopaneltitle-for-discoverable-credential-capable" style="display:none">Info about the 'discoverable
+credential capable' definition.</span><b><a href="#discoverable-credential-capable">#discoverable-credential-capable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-discoverable-credential-capable">4. Terminology</a>
     <li><a href="#ref-for-discoverable-credential-capable①">6.2. Authenticator Taxonomy</a> <a href="#ref-for-discoverable-credential-capable②">(2)</a> <a href="#ref-for-discoverable-credential-capable③">(3)</a> <a href="#ref-for-discoverable-credential-capable④">(4)</a>
     <li><a href="#ref-for-discoverable-credential-capable⑤">6.2.2. Credential Storage Modality</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="server-side-credential-storage-modality">
-   <b><a href="#server-side-credential-storage-modality">#server-side-credential-storage-modality</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-server-side-credential-storage-modality" class="dfn-panel" data-for="server-side-credential-storage-modality" id="infopanel-for-server-side-credential-storage-modality" role="dialog">
+   <span id="infopaneltitle-for-server-side-credential-storage-modality" style="display:none">Info about the 'server-side credential storage modality' definition.</span><b><a href="#server-side-credential-storage-modality">#server-side-credential-storage-modality</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-server-side-credential-storage-modality">4. Terminology</a>
     <li><a href="#ref-for-server-side-credential-storage-modality①">6.2. Authenticator Taxonomy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication-factor-capability">
-   <b><a href="#authentication-factor-capability">#authentication-factor-capability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication-factor-capability" class="dfn-panel" data-for="authentication-factor-capability" id="infopanel-for-authentication-factor-capability" role="dialog">
+   <span id="infopaneltitle-for-authentication-factor-capability" style="display:none">Info about the 'Authentication Factor Capability' definition.</span><b><a href="#authentication-factor-capability">#authentication-factor-capability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-factor-capability">6.2. Authenticator Taxonomy</a> <a href="#ref-for-authentication-factor-capability①">(2)</a> <a href="#ref-for-authentication-factor-capability②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="multi-factor-capable">
-   <b><a href="#multi-factor-capable">#multi-factor-capable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-multi-factor-capable" class="dfn-panel" data-for="multi-factor-capable" id="infopanel-for-multi-factor-capable" role="dialog">
+   <span id="infopaneltitle-for-multi-factor-capable" style="display:none">Info about the 'multi-factor capable' definition.</span><b><a href="#multi-factor-capable">#multi-factor-capable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multi-factor-capable">6.2. Authenticator Taxonomy</a> <a href="#ref-for-multi-factor-capable①">(2)</a> <a href="#ref-for-multi-factor-capable②">(3)</a> <a href="#ref-for-multi-factor-capable③">(4)</a>
     <li><a href="#ref-for-multi-factor-capable④">6.2.3. Authentication Factor Capability</a> <a href="#ref-for-multi-factor-capable⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-factor-capable">
-   <b><a href="#single-factor-capable">#single-factor-capable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-factor-capable" class="dfn-panel" data-for="single-factor-capable" id="infopanel-for-single-factor-capable" role="dialog">
+   <span id="infopaneltitle-for-single-factor-capable" style="display:none">Info about the 'single-factor capable' definition.</span><b><a href="#single-factor-capable">#single-factor-capable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-factor-capable">6.2. Authenticator Taxonomy</a> <a href="#ref-for-single-factor-capable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-operations">
-   <b><a href="#authenticator-operations">#authenticator-operations</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-operations" class="dfn-panel" data-for="authenticator-operations" id="infopanel-for-authenticator-operations" role="dialog">
+   <span id="infopaneltitle-for-authenticator-operations" style="display:none">Info about the 'Authenticator Operations' definition.</span><b><a href="#authenticator-operations">#authenticator-operations</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-operations">4. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-session">
-   <b><a href="#authenticator-session">#authenticator-session</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-session" class="dfn-panel" data-for="authenticator-session" id="infopanel-for-authenticator-session" role="dialog">
+   <span id="infopaneltitle-for-authenticator-session" style="display:none">Info about the 'authenticator session' definition.</span><b><a href="#authenticator-session">#authenticator-session</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-session">5.6. Abort Operations with AbortSignal</a> <a href="#ref-for-authenticator-session①">(2)</a>
     <li><a href="#ref-for-authenticator-session②">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -12112,15 +12116,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-session④">6.3.4. The authenticatorCancel Operation</a> <a href="#ref-for-authenticator-session⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-id-looking-up">
-   <b><a href="#credential-id-looking-up">#credential-id-looking-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-id-looking-up" class="dfn-panel" data-for="credential-id-looking-up" id="infopanel-for-credential-id-looking-up" role="dialog">
+   <span id="infopaneltitle-for-credential-id-looking-up" style="display:none">Info about the 'looking up' definition.</span><b><a href="#credential-id-looking-up">#credential-id-looking-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-id-looking-up">6.3.2. The authenticatorMakeCredential Operation</a>
     <li><a href="#ref-for-credential-id-looking-up①">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatormakecredential">
-   <b><a href="#authenticatormakecredential">#authenticatormakecredential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatormakecredential" class="dfn-panel" data-for="authenticatormakecredential" id="infopanel-for-authenticatormakecredential" role="dialog">
+   <span id="infopaneltitle-for-authenticatormakecredential" style="display:none">Info about the 'authenticatorMakeCredential' definition.</span><b><a href="#authenticatormakecredential">#authenticatormakecredential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatormakecredential">4. Terminology</a> <a href="#ref-for-authenticatormakecredential①">(2)</a> <a href="#ref-for-authenticatormakecredential②">(3)</a> <a href="#ref-for-authenticatormakecredential③">(4)</a>
     <li><a href="#ref-for-authenticatormakecredential④">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-authenticatormakecredential⑤">(2)</a>
@@ -12136,8 +12140,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatormakecredential①⑧">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorgetassertion">
-   <b><a href="#authenticatorgetassertion">#authenticatorgetassertion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorgetassertion" class="dfn-panel" data-for="authenticatorgetassertion" id="infopanel-for-authenticatorgetassertion" role="dialog">
+   <span id="infopaneltitle-for-authenticatorgetassertion" style="display:none">Info about the 'authenticatorGetAssertion' definition.</span><b><a href="#authenticatorgetassertion">#authenticatorgetassertion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorgetassertion">4. Terminology</a> <a href="#ref-for-authenticatorgetassertion①">(2)</a> <a href="#ref-for-authenticatorgetassertion②">(3)</a>
     <li><a href="#ref-for-authenticatorgetassertion③">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-authenticatorgetassertion④">(2)</a> <a href="#ref-for-authenticatorgetassertion⑤">(3)</a> <a href="#ref-for-authenticatorgetassertion⑥">(4)</a>
@@ -12151,8 +12155,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatorgetassertion①⑧">10.1. FIDO AppID Extension (appid)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorcancel">
-   <b><a href="#authenticatorcancel">#authenticatorcancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorcancel" class="dfn-panel" data-for="authenticatorcancel" id="infopanel-for-authenticatorcancel" role="dialog">
+   <span id="infopaneltitle-for-authenticatorcancel" style="display:none">Info about the 'authenticatorCancel' definition.</span><b><a href="#authenticatorcancel">#authenticatorcancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorcancel">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-authenticatorcancel①">(2)</a> <a href="#ref-for-authenticatorcancel②">(3)</a> <a href="#ref-for-authenticatorcancel③">(4)</a> <a href="#ref-for-authenticatorcancel④">(5)</a> <a href="#ref-for-authenticatorcancel⑤">(6)</a>
     <li><a href="#ref-for-authenticatorcancel⑥">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-authenticatorcancel⑦">(2)</a> <a href="#ref-for-authenticatorcancel⑧">(3)</a> <a href="#ref-for-authenticatorcancel⑨">(4)</a> <a href="#ref-for-authenticatorcancel①⓪">(5)</a>
@@ -12160,8 +12164,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticatorcancel①②">6.3.3. The authenticatorGetAssertion Operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-object">
-   <b><a href="#attestation-object">#attestation-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-object" class="dfn-panel" data-for="attestation-object" id="infopanel-for-attestation-object" role="dialog">
+   <span id="infopaneltitle-for-attestation-object" style="display:none">Info about the 'attestation object' definition.</span><b><a href="#attestation-object">#attestation-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-object">4. Terminology</a> <a href="#ref-for-attestation-object①">(2)</a> <a href="#ref-for-attestation-object②">(3)</a>
     <li><a href="#ref-for-attestation-object③">5. Web Authentication API</a>
@@ -12176,8 +12180,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-object①⑧">13.4.4. Attestation Limitations</a> <a href="#ref-for-attestation-object①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-statement">
-   <b><a href="#attestation-statement">#attestation-statement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-statement" class="dfn-panel" data-for="attestation-statement" id="infopanel-for-attestation-statement" role="dialog">
+   <span id="infopaneltitle-for-attestation-statement" style="display:none">Info about the 'attestation statement' definition.</span><b><a href="#attestation-statement">#attestation-statement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-statement">4. Terminology</a> <a href="#ref-for-attestation-statement①">(2)</a>
     <li><a href="#ref-for-attestation-statement②">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-attestation-statement③">(2)</a>
@@ -12195,8 +12199,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-statement④①">14.1. De-anonymization Prevention Measures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-statement-format">
-   <b><a href="#attestation-statement-format">#attestation-statement-format</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-statement-format" class="dfn-panel" data-for="attestation-statement-format" id="infopanel-for-attestation-statement-format" role="dialog">
+   <span id="infopaneltitle-for-attestation-statement-format" style="display:none">Info about the 'attestation statement format' definition.</span><b><a href="#attestation-statement-format">#attestation-statement-format</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-statement-format">5.2.1. Information About Public Key Credential (interface AuthenticatorAttestationResponse)</a>
     <li><a href="#ref-for-attestation-statement-format①">6.3.2. The authenticatorMakeCredential Operation</a>
@@ -12207,8 +12211,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-statement-format①⑥">8.1. Attestation Statement Format Identifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-type">
-   <b><a href="#attestation-type">#attestation-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-type" class="dfn-panel" data-for="attestation-type" id="infopanel-for-attestation-type" role="dialog">
+   <span id="infopaneltitle-for-attestation-type" style="display:none">Info about the 'attestation type' definition.</span><b><a href="#attestation-type">#attestation-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-type">6.5. Attestation</a> <a href="#ref-for-attestation-type①">(2)</a> <a href="#ref-for-attestation-type②">(3)</a> <a href="#ref-for-attestation-type③">(4)</a> <a href="#ref-for-attestation-type④">(5)</a> <a href="#ref-for-attestation-type⑤">(6)</a>
     <li><a href="#ref-for-attestation-type⑥">6.5.2. Attestation Statement Formats</a> <a href="#ref-for-attestation-type⑦">(2)</a>
@@ -12222,8 +12226,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-type②②">13.4.4. Attestation Limitations</a> <a href="#ref-for-attestation-type②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attested-credential-data">
-   <b><a href="#attested-credential-data">#attested-credential-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attested-credential-data" class="dfn-panel" data-for="attested-credential-data" id="infopanel-for-attested-credential-data" role="dialog">
+   <span id="infopaneltitle-for-attested-credential-data" style="display:none">Info about the 'Attested credential data' definition.</span><b><a href="#attested-credential-data">#attested-credential-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attested-credential-data">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-attested-credential-data①">(2)</a>
     <li><a href="#ref-for-attested-credential-data②">6.1. Authenticator Data</a> <a href="#ref-for-attested-credential-data③">(2)</a> <a href="#ref-for-attested-credential-data④">(3)</a> <a href="#ref-for-attested-credential-data⑤">(4)</a> <a href="#ref-for-attested-credential-data⑥">(5)</a> <a href="#ref-for-attested-credential-data⑦">(6)</a>
@@ -12232,8 +12236,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attested-credential-data①①">6.5.1. Attested Credential Data</a> <a href="#ref-for-attested-credential-data①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="aaguid">
-   <b><a href="#aaguid">#aaguid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-aaguid" class="dfn-panel" data-for="aaguid" id="infopanel-for-aaguid" role="dialog">
+   <span id="infopaneltitle-for-aaguid" style="display:none">Info about the 'aaguid' definition.</span><b><a href="#aaguid">#aaguid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aaguid">4. Terminology</a>
     <li><a href="#ref-for-aaguid①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-aaguid②">(2)</a> <a href="#ref-for-aaguid③">(3)</a> <a href="#ref-for-aaguid④">(4)</a>
@@ -12243,22 +12247,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-aaguid⑧">8.3. TPM Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialidlength">
-   <b><a href="#credentialidlength">#credentialidlength</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialidlength" class="dfn-panel" data-for="credentialidlength" id="infopanel-for-credentialidlength" role="dialog">
+   <span id="infopaneltitle-for-credentialidlength" style="display:none">Info about the 'credentialIdLength' definition.</span><b><a href="#credentialidlength">#credentialidlength</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialidlength">6.1. Authenticator Data</a> <a href="#ref-for-credentialidlength①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialid">
-   <b><a href="#credentialid">#credentialid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialid" class="dfn-panel" data-for="credentialid" id="infopanel-for-credentialid" role="dialog">
+   <span id="infopaneltitle-for-credentialid" style="display:none">Info about the 'credentialId' definition.</span><b><a href="#credentialid">#credentialid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialid">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-credentialid①">6.1. Authenticator Data</a> <a href="#ref-for-credentialid②">(2)</a>
     <li><a href="#ref-for-credentialid③">7.1. Registering a New Credential</a> <a href="#ref-for-credentialid④">(2)</a> <a href="#ref-for-credentialid⑤">(3)</a> <a href="#ref-for-credentialid⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialpublickey">
-   <b><a href="#credentialpublickey">#credentialpublickey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialpublickey" class="dfn-panel" data-for="credentialpublickey" id="infopanel-for-credentialpublickey" role="dialog">
+   <span id="infopaneltitle-for-credentialpublickey" style="display:none">Info about the 'credentialPublicKey' definition.</span><b><a href="#credentialpublickey">#credentialpublickey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialpublickey">5.2.1.1. Easily accessing credential data</a>
     <li><a href="#ref-for-credentialpublickey①">6.1. Authenticator Data</a> <a href="#ref-for-credentialpublickey②">(2)</a> <a href="#ref-for-credentialpublickey③">(3)</a>
@@ -12269,16 +12273,17 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-credentialpublickey⑨">8.4. Android Key Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signing-procedure">
-   <b><a href="#signing-procedure">#signing-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signing-procedure" class="dfn-panel" data-for="signing-procedure" id="infopanel-for-signing-procedure" role="dialog">
+   <span id="infopaneltitle-for-signing-procedure" style="display:none">Info about the 'Signing procedure' definition.</span><b><a href="#signing-procedure">#signing-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signing-procedure">5.2.1.1. Easily accessing credential data</a>
     <li><a href="#ref-for-signing-procedure">6.5.2. Attestation Statement Formats</a>
     <li><a href="#ref-for-signing-procedure①">6.5.4. Generating an Attestation Object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-data-for-the-attestation">
-   <b><a href="#authenticator-data-for-the-attestation">#authenticator-data-for-the-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-data-for-the-attestation" class="dfn-panel" data-for="authenticator-data-for-the-attestation" id="infopanel-for-authenticator-data-for-the-attestation" role="dialog">
+   <span id="infopaneltitle-for-authenticator-data-for-the-attestation" style="display:none">Info about the 'authenticator data
+for the attestation' definition.</span><b><a href="#authenticator-data-for-the-attestation">#authenticator-data-for-the-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-data-for-the-attestation">8.2. Packed Attestation Statement Format</a>
     <li><a href="#ref-for-authenticator-data-for-the-attestation①">8.3. TPM Attestation Statement Format</a>
@@ -12287,8 +12292,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-data-for-the-attestation⑤">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="verification-procedure">
-   <b><a href="#verification-procedure">#verification-procedure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-verification-procedure" class="dfn-panel" data-for="verification-procedure" id="infopanel-for-verification-procedure" role="dialog">
+   <span id="infopaneltitle-for-verification-procedure" style="display:none">Info about the 'Verification procedure' definition.</span><b><a href="#verification-procedure">#verification-procedure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-verification-procedure">6.5.3. Attestation Types</a> <a href="#ref-for-verification-procedure①">(2)</a> <a href="#ref-for-verification-procedure②">(3)</a>
     <li><a href="#ref-for-verification-procedure③">7.1. Registering a New Credential</a> <a href="#ref-for-verification-procedure④">(2)</a> <a href="#ref-for-verification-procedure⑤">(3)</a> <a href="#ref-for-verification-procedure⑥">(4)</a>
@@ -12299,8 +12304,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-verification-procedure①①">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="verification-procedure-inputs">
-   <b><a href="#verification-procedure-inputs">#verification-procedure-inputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-verification-procedure-inputs" class="dfn-panel" data-for="verification-procedure-inputs" id="infopanel-for-verification-procedure-inputs" role="dialog">
+   <span id="infopaneltitle-for-verification-procedure-inputs" style="display:none">Info about the 'verification procedure inputs' definition.</span><b><a href="#verification-procedure-inputs">#verification-procedure-inputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-verification-procedure-inputs">8.2. Packed Attestation Statement Format</a>
     <li><a href="#ref-for-verification-procedure-inputs①">8.3. TPM Attestation Statement Format</a>
@@ -12309,14 +12314,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-verification-procedure-inputs④">8.6. FIDO U2F Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-data-claimed-to-have-been-used-for-the-attestation">
-   <b><a href="#authenticator-data-claimed-to-have-been-used-for-the-attestation">#authenticator-data-claimed-to-have-been-used-for-the-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-data-claimed-to-have-been-used-for-the-attestation" class="dfn-panel" data-for="authenticator-data-claimed-to-have-been-used-for-the-attestation" id="infopanel-for-authenticator-data-claimed-to-have-been-used-for-the-attestation" role="dialog">
+   <span id="infopaneltitle-for-authenticator-data-claimed-to-have-been-used-for-the-attestation" style="display:none">Info about the 'authenticator data claimed to have been used for the attestation' definition.</span><b><a href="#authenticator-data-claimed-to-have-been-used-for-the-attestation">#authenticator-data-claimed-to-have-been-used-for-the-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-data-claimed-to-have-been-used-for-the-attestation">8.4. Android Key Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-trust-path">
-   <b><a href="#attestation-trust-path">#attestation-trust-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-trust-path" class="dfn-panel" data-for="attestation-trust-path" id="infopanel-for-attestation-trust-path" role="dialog">
+   <span id="infopaneltitle-for-attestation-trust-path" style="display:none">Info about the 'attestation trust path' definition.</span><b><a href="#attestation-trust-path">#attestation-trust-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-trust-path">6.5.2. Attestation Statement Formats</a>
     <li><a href="#ref-for-attestation-trust-path①">6.5.3. Attestation Types</a>
@@ -12329,15 +12334,15 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attestation-trust-path⑨">8.7. None Attestation Statement Format</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="basic-attestation">
-   <b><a href="#basic-attestation">#basic-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-basic-attestation" class="dfn-panel" data-for="basic-attestation" id="infopanel-for-basic-attestation" role="dialog">
+   <span id="infopaneltitle-for-basic-attestation" style="display:none">Info about the 'Basic Attestation' definition.</span><b><a href="#basic-attestation">#basic-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-attestation">6.5.3. Attestation Types</a>
     <li><a href="#ref-for-basic-attestation①">14.4.1. Attestation Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="basic">
-   <b><a href="#basic">#basic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-basic" class="dfn-panel" data-for="basic" id="infopanel-for-basic" role="dialog">
+   <span id="infopaneltitle-for-basic" style="display:none">Info about the 'Basic' definition.</span><b><a href="#basic">#basic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic">6.5.3. Attestation Types</a>
     <li><a href="#ref-for-basic①">8.2. Packed Attestation Statement Format</a> <a href="#ref-for-basic②">(2)</a> <a href="#ref-for-basic③">(3)</a> <a href="#ref-for-basic④">(4)</a>
@@ -12346,14 +12351,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-basic⑨">8.6. FIDO U2F Attestation Statement Format</a> <a href="#ref-for-basic①⓪">(2)</a> <a href="#ref-for-basic①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="batch-attestation">
-   <b><a href="#batch-attestation">#batch-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-batch-attestation" class="dfn-panel" data-for="batch-attestation" id="infopanel-for-batch-attestation" role="dialog">
+   <span id="infopaneltitle-for-batch-attestation" style="display:none">Info about the 'batch attestation' definition.</span><b><a href="#batch-attestation">#batch-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-batch-attestation">14.4.1. Attestation Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="self-attestation">
-   <b><a href="#self-attestation">#self-attestation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-self-attestation" class="dfn-panel" data-for="self-attestation" id="infopanel-for-self-attestation" role="dialog">
+   <span id="infopaneltitle-for-self-attestation" style="display:none">Info about the 'Self Attestation' definition.</span><b><a href="#self-attestation">#self-attestation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self-attestation">4. Terminology</a> <a href="#ref-for-self-attestation①">(2)</a> <a href="#ref-for-self-attestation②">(3)</a> <a href="#ref-for-self-attestation③">(4)</a>
     <li><a href="#ref-for-self-attestation④">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -12367,22 +12372,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-self-attestation①⑧">13.4.5. Revoked Attestation Certificates</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="self">
-   <b><a href="#self">#self</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-self" class="dfn-panel" data-for="self" id="infopanel-for-self" role="dialog">
+   <span id="infopaneltitle-for-self" style="display:none">Info about the 'Self' definition.</span><b><a href="#self">#self</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-self">8.2. Packed Attestation Statement Format</a> <a href="#ref-for-self①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-ca">
-   <b><a href="#attestation-ca">#attestation-ca</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-ca" class="dfn-panel" data-for="attestation-ca" id="infopanel-for-attestation-ca" role="dialog">
+   <span id="infopaneltitle-for-attestation-ca" style="display:none">Info about the 'Attestation CA' definition.</span><b><a href="#attestation-ca">#attestation-ca</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-ca">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a>
     <li><a href="#ref-for-attestation-ca①">6.5.3. Attestation Types</a> <a href="#ref-for-attestation-ca②">(2)</a>
     <li><a href="#ref-for-attestation-ca③">14.4.1. Attestation Privacy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attca">
-   <b><a href="#attca">#attca</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attca" class="dfn-panel" data-for="attca" id="infopanel-for-attca" role="dialog">
+   <span id="infopaneltitle-for-attca" style="display:none">Info about the 'AttCA' definition.</span><b><a href="#attca">#attca</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attca">6.5.3. Attestation Types</a>
     <li><a href="#ref-for-attca①">8.2. Packed Attestation Statement Format</a> <a href="#ref-for-attca②">(2)</a> <a href="#ref-for-attca③">(3)</a> <a href="#ref-for-attca④">(4)</a>
@@ -12390,8 +12395,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-attca⑦">8.6. FIDO U2F Attestation Statement Format</a> <a href="#ref-for-attca⑧">(2)</a> <a href="#ref-for-attca⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anonymization-ca">
-   <b><a href="#anonymization-ca">#anonymization-ca</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anonymization-ca" class="dfn-panel" data-for="anonymization-ca" id="infopanel-for-anonymization-ca" role="dialog">
+   <span id="infopaneltitle-for-anonymization-ca" style="display:none">Info about the 'Anonymization CA' definition.</span><b><a href="#anonymization-ca">#anonymization-ca</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonymization-ca">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-anonymization-ca①">5.4.7. Attestation Conveyance Preference Enumeration (enum AttestationConveyancePreference)</a> <a href="#ref-for-anonymization-ca②">(2)</a>
@@ -12400,14 +12405,14 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-anonymization-ca⑥">14.4.1. Attestation Privacy</a> <a href="#ref-for-anonymization-ca⑦">(2)</a> <a href="#ref-for-anonymization-ca⑧">(3)</a> <a href="#ref-for-anonymization-ca⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="anonca">
-   <b><a href="#anonca">#anonca</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-anonca" class="dfn-panel" data-for="anonca" id="infopanel-for-anonca" role="dialog">
+   <span id="infopaneltitle-for-anonca" style="display:none">Info about the 'AnonCA' definition.</span><b><a href="#anonca">#anonca</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anonca">6.5.3. Attestation Types</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="none">
-   <b><a href="#none">#none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-none" class="dfn-panel" data-for="none" id="infopanel-for-none" role="dialog">
+   <span id="infopaneltitle-for-none" style="display:none">Info about the 'None' definition.</span><b><a href="#none">#none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-none">6.5. Attestation</a> <a href="#ref-for-none①">(2)</a>
     <li><a href="#ref-for-none②">6.5.3. Attestation Types</a>
@@ -12416,21 +12421,22 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-none⑦">13.4.4. Attestation Limitations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attestation-statement-format-identifier">
-   <b><a href="#attestation-statement-format-identifier">#attestation-statement-format-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attestation-statement-format-identifier" class="dfn-panel" data-for="attestation-statement-format-identifier" id="infopanel-for-attestation-statement-format-identifier" role="dialog">
+   <span id="infopaneltitle-for-attestation-statement-format-identifier" style="display:none">Info about the 'attestation statement format identifier' definition.</span><b><a href="#attestation-statement-format-identifier">#attestation-statement-format-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attestation-statement-format-identifier">6.5.2. Attestation Statement Formats</a>
     <li><a href="#ref-for-attestation-statement-format-identifier①">6.5.4. Generating an Attestation Object</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="android-key-attestation-certificate-extension-data">
-   <b><a href="#android-key-attestation-certificate-extension-data">#android-key-attestation-certificate-extension-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-android-key-attestation-certificate-extension-data" class="dfn-panel" data-for="android-key-attestation-certificate-extension-data" id="infopanel-for-android-key-attestation-certificate-extension-data" role="dialog">
+   <span id="infopaneltitle-for-android-key-attestation-certificate-extension-data" style="display:none">Info about the 'android key attestation certificate extension
+data' definition.</span><b><a href="#android-key-attestation-certificate-extension-data">#android-key-attestation-certificate-extension-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-android-key-attestation-certificate-extension-data">8.4. Android Key Attestation Statement Format</a> <a href="#ref-for-android-key-attestation-certificate-extension-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webauthn-extensions">
-   <b><a href="#webauthn-extensions">#webauthn-extensions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webauthn-extensions" class="dfn-panel" data-for="webauthn-extensions" id="infopanel-for-webauthn-extensions" role="dialog">
+   <span id="infopaneltitle-for-webauthn-extensions" style="display:none">Info about the 'WebAuthn Extensions' definition.</span><b><a href="#webauthn-extensions">#webauthn-extensions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webauthn-extensions">5.4. Options for Credential Creation (dictionary PublicKeyCredentialCreationOptions)</a>
     <li><a href="#ref-for-webauthn-extensions①">5.7. WebAuthn Extensions Inputs and Outputs</a>
@@ -12442,8 +12448,9 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-webauthn-extensions⑦">9. WebAuthn Extensions</a> <a href="#ref-for-webauthn-extensions⑧">(2)</a> <a href="#ref-for-webauthn-extensions⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registration-extension">
-   <b><a href="#registration-extension">#registration-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registration-extension" class="dfn-panel" data-for="registration-extension" id="infopanel-for-registration-extension" role="dialog">
+   <span id="infopaneltitle-for-registration-extension" style="display:none">Info about the 'registration
+extension' definition.</span><b><a href="#registration-extension">#registration-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registration-extension">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-registration-extension①">5.7. WebAuthn Extensions Inputs and Outputs</a>
@@ -12456,8 +12463,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-registration-extension②⓪">12.4. WebAuthn Extension Identifier Registrations</a> <a href="#ref-for-registration-extension②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication-extension">
-   <b><a href="#authentication-extension">#authentication-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication-extension" class="dfn-panel" data-for="authentication-extension" id="infopanel-for-authentication-extension" role="dialog">
+   <span id="infopaneltitle-for-authentication-extension" style="display:none">Info about the 'authentication extension' definition.</span><b><a href="#authentication-extension">#authentication-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-extension">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-authentication-extension①">5.7. WebAuthn Extensions Inputs and Outputs</a>
@@ -12469,8 +12476,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authentication-extension①⑧">12.4. WebAuthn Extension Identifier Registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-extension">
-   <b><a href="#client-extension">#client-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-extension" class="dfn-panel" data-for="client-extension" id="infopanel-for-client-extension" role="dialog">
+   <span id="infopaneltitle-for-client-extension" style="display:none">Info about the 'client extension' definition.</span><b><a href="#client-extension">#client-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-extension">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-client-extension①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -12484,8 +12491,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-extension⑨">12.4. WebAuthn Extension Identifier Registrations</a> <a href="#ref-for-client-extension①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-extension">
-   <b><a href="#authenticator-extension">#authenticator-extension</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-extension" class="dfn-panel" data-for="authenticator-extension" id="infopanel-for-authenticator-extension" role="dialog">
+   <span id="infopaneltitle-for-authenticator-extension" style="display:none">Info about the 'authenticator extension' definition.</span><b><a href="#authenticator-extension">#authenticator-extension</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-extension">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
     <li><a href="#ref-for-authenticator-extension①">5.1.4.1. PublicKeyCredential’s [[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors) Method</a>
@@ -12499,8 +12506,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-extension①④">11.2. Virtual Authenticators</a> <a href="#ref-for-authenticator-extension①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extension-identifier">
-   <b><a href="#extension-identifier">#extension-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extension-identifier" class="dfn-panel" data-for="extension-identifier" id="infopanel-for-extension-identifier" role="dialog">
+   <span id="infopaneltitle-for-extension-identifier" style="display:none">Info about the 'extension identifier' definition.</span><b><a href="#extension-identifier">#extension-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extension-identifier">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-extension-identifier①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a>
@@ -12519,8 +12526,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-extension-identifier②③">12.4. WebAuthn Extension Identifier Registrations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-extension-input">
-   <b><a href="#client-extension-input">#client-extension-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-extension-input" class="dfn-panel" data-for="client-extension-input" id="infopanel-for-client-extension-input" role="dialog">
+   <span id="infopaneltitle-for-client-extension-input" style="display:none">Info about the 'client extension input' definition.</span><b><a href="#client-extension-input">#client-extension-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-extension-input">5.7.1. Authentication Extensions Client Inputs (dictionary AuthenticationExtensionsClientInputs)</a>
     <li><a href="#ref-for-client-extension-input①">7.1. Registering a New Credential</a>
@@ -12531,8 +12538,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-extension-input①④">9.4. Client Extension Processing</a> <a href="#ref-for-client-extension-input①⑤">(2)</a> <a href="#ref-for-client-extension-input①⑥">(3)</a> <a href="#ref-for-client-extension-input①⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-extension-input">
-   <b><a href="#authenticator-extension-input">#authenticator-extension-input</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-extension-input" class="dfn-panel" data-for="authenticator-extension-input" id="infopanel-for-authenticator-extension-input" role="dialog">
+   <span id="infopaneltitle-for-authenticator-extension-input" style="display:none">Info about the 'authenticator extension input' definition.</span><b><a href="#authenticator-extension-input">#authenticator-extension-input</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-extension-input">5.7.3. Authentication Extensions Authenticator Inputs (CDDL type AuthenticationExtensionsAuthenticatorInputs)</a>
     <li><a href="#ref-for-authenticator-extension-input①">6.3.2. The authenticatorMakeCredential Operation</a> <a href="#ref-for-authenticator-extension-input②">(2)</a>
@@ -12544,8 +12551,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-extension-input①⑦">9.5. Authenticator Extension Processing</a> <a href="#ref-for-authenticator-extension-input①⑧">(2)</a> <a href="#ref-for-authenticator-extension-input①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-extension-processing">
-   <b><a href="#client-extension-processing">#client-extension-processing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-extension-processing" class="dfn-panel" data-for="client-extension-processing" id="infopanel-for-client-extension-processing" role="dialog">
+   <span id="infopaneltitle-for-client-extension-processing" style="display:none">Info about the 'Client Extension Processing' definition.</span><b><a href="#client-extension-processing">#client-extension-processing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-extension-processing">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-client-extension-processing①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-client-extension-processing②">(2)</a>
@@ -12554,8 +12561,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-extension-processing⑨">9.2. Defining Extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="client-extension-output">
-   <b><a href="#client-extension-output">#client-extension-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-client-extension-output" class="dfn-panel" data-for="client-extension-output" id="infopanel-for-client-extension-output" role="dialog">
+   <span id="infopaneltitle-for-client-extension-output" style="display:none">Info about the 'client extension output' definition.</span><b><a href="#client-extension-output">#client-extension-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-client-extension-output">5.1. PublicKeyCredential Interface</a>
     <li><a href="#ref-for-client-extension-output①">5.1.3. Create a New Credential - PublicKeyCredential’s [[Create]](origin, options, sameOriginWithAncestors) Method</a> <a href="#ref-for-client-extension-output②">(2)</a>
@@ -12569,8 +12576,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-client-extension-output②⓪">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-extension-processing">
-   <b><a href="#authenticator-extension-processing">#authenticator-extension-processing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-extension-processing" class="dfn-panel" data-for="authenticator-extension-processing" id="infopanel-for-authenticator-extension-processing" role="dialog">
+   <span id="infopaneltitle-for-authenticator-extension-processing" style="display:none">Info about the 'Authenticator Extension Processing' definition.</span><b><a href="#authenticator-extension-processing">#authenticator-extension-processing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-extension-processing">6.3.2. The authenticatorMakeCredential Operation</a>
     <li><a href="#ref-for-authenticator-extension-processing①">6.3.3. The authenticatorGetAssertion Operation</a>
@@ -12580,8 +12587,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-extension-processing⑤">11.1.1. Authenticator Extension Capabilities</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-extension-output">
-   <b><a href="#authenticator-extension-output">#authenticator-extension-output</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-extension-output" class="dfn-panel" data-for="authenticator-extension-output" id="infopanel-for-authenticator-extension-output" role="dialog">
+   <span id="infopaneltitle-for-authenticator-extension-output" style="display:none">Info about the 'authenticator extension output' definition.</span><b><a href="#authenticator-extension-output">#authenticator-extension-output</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-extension-output">5.7. WebAuthn Extensions Inputs and Outputs</a>
     <li><a href="#ref-for-authenticator-extension-output①">5.7.4. Authentication Extensions Authenticator Outputs (CDDL type AuthenticationExtensionsAuthenticatorOutputs)</a>
@@ -12597,173 +12604,173 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-authenticator-extension-output①⑧">11.2. Virtual Authenticators</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="appid">
-   <b><a href="#appid">#appid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-appid" class="dfn-panel" data-for="appid" id="infopanel-for-appid" role="dialog">
+   <span id="infopaneltitle-for-appid" style="display:none">Info about the 'AppID' definition.</span><b><a href="#appid">#appid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-appid">3. Dependencies</a>
     <li><a href="#ref-for-appid①">7.2. Verifying an Authentication Assertion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionsclientinputs-appid">
-   <b><a href="#dom-authenticationextensionsclientinputs-appid">#dom-authenticationextensionsclientinputs-appid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionsclientinputs-appid" class="dfn-panel" data-for="dom-authenticationextensionsclientinputs-appid" id="infopanel-for-dom-authenticationextensionsclientinputs-appid" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionsclientinputs-appid" style="display:none">Info about the 'appid' definition.</span><b><a href="#dom-authenticationextensionsclientinputs-appid">#dom-authenticationextensionsclientinputs-appid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionsclientinputs-appid">10.1. FIDO AppID Extension (appid)</a> <a href="#ref-for-dom-authenticationextensionsclientinputs-appid①">(2)</a> <a href="#ref-for-dom-authenticationextensionsclientinputs-appid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionsclientinputs-appidexclude">
-   <b><a href="#dom-authenticationextensionsclientinputs-appidexclude">#dom-authenticationextensionsclientinputs-appidexclude</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionsclientinputs-appidexclude" class="dfn-panel" data-for="dom-authenticationextensionsclientinputs-appidexclude" id="infopanel-for-dom-authenticationextensionsclientinputs-appidexclude" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionsclientinputs-appidexclude" style="display:none">Info about the 'appidExclude' definition.</span><b><a href="#dom-authenticationextensionsclientinputs-appidexclude">#dom-authenticationextensionsclientinputs-appidexclude</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionsclientinputs-appidexclude">10.2. FIDO AppID Exclusion Extension (appidExclude)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-verification-method">
-   <b><a href="#user-verification-method">#user-verification-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-verification-method" class="dfn-panel" data-for="user-verification-method" id="infopanel-for-user-verification-method" role="dialog">
+   <span id="infopaneltitle-for-user-verification-method" style="display:none">Info about the 'User Verification Method' definition.</span><b><a href="#user-verification-method">#user-verification-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-verification-method">11.1.1. Authenticator Extension Capabilities</a>
     <li><a href="#ref-for-user-verification-method①">11.2. Virtual Authenticators</a> <a href="#ref-for-user-verification-method②">(2)</a>
     <li><a href="#ref-for-user-verification-method③">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-uvmentry">
-   <b><a href="#typedefdef-uvmentry">#typedefdef-uvmentry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-uvmentry" class="dfn-panel" data-for="typedefdef-uvmentry" id="infopanel-for-typedefdef-uvmentry" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-uvmentry" style="display:none">Info about the 'UvmEntry' definition.</span><b><a href="#typedefdef-uvmentry">#typedefdef-uvmentry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-uvmentry">10.3. User Verification Method Extension (uvm)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-uvmentries">
-   <b><a href="#typedefdef-uvmentries">#typedefdef-uvmentries</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-uvmentries" class="dfn-panel" data-for="typedefdef-uvmentries" id="infopanel-for-typedefdef-uvmentries" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-uvmentries" style="display:none">Info about the 'UvmEntries' definition.</span><b><a href="#typedefdef-uvmentries">#typedefdef-uvmentries</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-uvmentries">10.3. User Verification Method Extension (uvm)</a>
     <li><a href="#ref-for-typedefdef-uvmentries①">11.2. Virtual Authenticators</a>
     <li><a href="#ref-for-typedefdef-uvmentries②">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credprops">
-   <b><a href="#credprops">#credprops</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credprops" class="dfn-panel" data-for="credprops" id="infopanel-for-credprops" role="dialog">
+   <span id="infopaneltitle-for-credprops" style="display:none">Info about the 'credProps' definition.</span><b><a href="#credprops">#credprops</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credprops">1.3.3. Authentication</a>
     <li><a href="#ref-for-credprops①">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a> <a href="#ref-for-credprops②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-credentialpropertiesoutput">
-   <b><a href="#dictdef-credentialpropertiesoutput">#dictdef-credentialpropertiesoutput</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-credentialpropertiesoutput" class="dfn-panel" data-for="dictdef-credentialpropertiesoutput" id="infopanel-for-dictdef-credentialpropertiesoutput" role="dialog">
+   <span id="infopaneltitle-for-dictdef-credentialpropertiesoutput" style="display:none">Info about the 'CredentialPropertiesOutput' definition.</span><b><a href="#dictdef-credentialpropertiesoutput">#dictdef-credentialpropertiesoutput</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-credentialpropertiesoutput">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionsclientoutputs-credprops">
-   <b><a href="#dom-authenticationextensionsclientoutputs-credprops">#dom-authenticationextensionsclientoutputs-credprops</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionsclientoutputs-credprops" class="dfn-panel" data-for="dom-authenticationextensionsclientoutputs-credprops" id="infopanel-for-dom-authenticationextensionsclientoutputs-credprops" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionsclientoutputs-credprops" style="display:none">Info about the 'credProps' definition.</span><b><a href="#dom-authenticationextensionsclientoutputs-credprops">#dom-authenticationextensionsclientoutputs-credprops</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionsclientoutputs-credprops">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-credentialpropertiesoutput-rk">
-   <b><a href="#dom-credentialpropertiesoutput-rk">#dom-credentialpropertiesoutput-rk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-credentialpropertiesoutput-rk" class="dfn-panel" data-for="dom-credentialpropertiesoutput-rk" id="infopanel-for-dom-credentialpropertiesoutput-rk" role="dialog">
+   <span id="infopaneltitle-for-dom-credentialpropertiesoutput-rk" style="display:none">Info about the 'rk' definition.</span><b><a href="#dom-credentialpropertiesoutput-rk">#dom-credentialpropertiesoutput-rk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credentialpropertiesoutput-rk">5.4.6. Resident Key Requirement Enumeration (enum ResidentKeyRequirement)</a>
     <li><a href="#ref-for-dom-credentialpropertiesoutput-rk①">10.4. Credential Properties Extension (credProps)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk②">(2)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk③">(3)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk④">(4)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk⑤">(5)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk⑥">(6)</a> <a href="#ref-for-dom-credentialpropertiesoutput-rk⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialpropertiesoutput-resident-key-credential-property">
-   <b><a href="#credentialpropertiesoutput-resident-key-credential-property">#credentialpropertiesoutput-resident-key-credential-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialpropertiesoutput-resident-key-credential-property" class="dfn-panel" data-for="credentialpropertiesoutput-resident-key-credential-property" id="infopanel-for-credentialpropertiesoutput-resident-key-credential-property" role="dialog">
+   <span id="infopaneltitle-for-credentialpropertiesoutput-resident-key-credential-property" style="display:none">Info about the 'resident key credential property' definition.</span><b><a href="#credentialpropertiesoutput-resident-key-credential-property">#credentialpropertiesoutput-resident-key-credential-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialpropertiesoutput-resident-key-credential-property">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentialpropertiesoutput-client-side-discoverable-credential-property">
-   <b><a href="#credentialpropertiesoutput-client-side-discoverable-credential-property">#credentialpropertiesoutput-client-side-discoverable-credential-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentialpropertiesoutput-client-side-discoverable-credential-property" class="dfn-panel" data-for="credentialpropertiesoutput-client-side-discoverable-credential-property" id="infopanel-for-credentialpropertiesoutput-client-side-discoverable-credential-property" role="dialog">
+   <span id="infopaneltitle-for-credentialpropertiesoutput-client-side-discoverable-credential-property" style="display:none">Info about the 'client-side discoverable credential property' definition.</span><b><a href="#credentialpropertiesoutput-client-side-discoverable-credential-property">#credentialpropertiesoutput-client-side-discoverable-credential-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentialpropertiesoutput-client-side-discoverable-credential-property">10.4. Credential Properties Extension (credProps)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="largeblob">
-   <b><a href="#largeblob">#largeblob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-largeblob" class="dfn-panel" data-for="largeblob" id="infopanel-for-largeblob" role="dialog">
+   <span id="infopaneltitle-for-largeblob" style="display:none">Info about the 'largeBlob' definition.</span><b><a href="#largeblob">#largeblob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-largeblob">10.5. Large blob storage extension (largeBlob)</a>
     <li><a href="#ref-for-largeblob①">11.1.1. Authenticator Extension Capabilities</a>
     <li><a href="#ref-for-largeblob②">11.5. Add Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-largeblobsupport">
-   <b><a href="#enumdef-largeblobsupport">#enumdef-largeblobsupport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-largeblobsupport" class="dfn-panel" data-for="enumdef-largeblobsupport" id="infopanel-for-enumdef-largeblobsupport" role="dialog">
+   <span id="infopaneltitle-for-enumdef-largeblobsupport" style="display:none">Info about the 'LargeBlobSupport' definition.</span><b><a href="#enumdef-largeblobsupport">#enumdef-largeblobsupport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-largeblobsupport">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largeblobsupport-required">
-   <b><a href="#dom-largeblobsupport-required">#dom-largeblobsupport-required</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largeblobsupport-required" class="dfn-panel" data-for="dom-largeblobsupport-required" id="infopanel-for-dom-largeblobsupport-required" role="dialog">
+   <span id="infopaneltitle-for-dom-largeblobsupport-required" style="display:none">Info about the '"required"' definition.</span><b><a href="#dom-largeblobsupport-required">#dom-largeblobsupport-required</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largeblobsupport-required">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-largeblobsupport-preferred">
-   <b><a href="#dom-largeblobsupport-preferred">#dom-largeblobsupport-preferred</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-largeblobsupport-preferred" class="dfn-panel" data-for="dom-largeblobsupport-preferred" id="infopanel-for-dom-largeblobsupport-preferred" role="dialog">
+   <span id="infopaneltitle-for-dom-largeblobsupport-preferred" style="display:none">Info about the '"preferred"' definition.</span><b><a href="#dom-largeblobsupport-preferred">#dom-largeblobsupport-preferred</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-largeblobsupport-preferred">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-authenticationextensionslargeblobinputs">
-   <b><a href="#dictdef-authenticationextensionslargeblobinputs">#dictdef-authenticationextensionslargeblobinputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-authenticationextensionslargeblobinputs" class="dfn-panel" data-for="dictdef-authenticationextensionslargeblobinputs" id="infopanel-for-dictdef-authenticationextensionslargeblobinputs" role="dialog">
+   <span id="infopaneltitle-for-dictdef-authenticationextensionslargeblobinputs" style="display:none">Info about the 'AuthenticationExtensionsLargeBlobInputs' definition.</span><b><a href="#dictdef-authenticationextensionslargeblobinputs">#dictdef-authenticationextensionslargeblobinputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-authenticationextensionslargeblobinputs">10.5. Large blob storage extension (largeBlob)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-support">
-   <b><a href="#dom-authenticationextensionslargeblobinputs-support">#dom-authenticationextensionslargeblobinputs-support</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-support" class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-support" id="infopanel-for-dom-authenticationextensionslargeblobinputs-support" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-support" style="display:none">Info about the 'support' definition.</span><b><a href="#dom-authenticationextensionslargeblobinputs-support">#dom-authenticationextensionslargeblobinputs-support</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargeblobinputs-support">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-support①">(2)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-support②">(3)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-support③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-read">
-   <b><a href="#dom-authenticationextensionslargeblobinputs-read">#dom-authenticationextensionslargeblobinputs-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-read" class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-read" id="infopanel-for-dom-authenticationextensionslargeblobinputs-read" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-read" style="display:none">Info about the 'read' definition.</span><b><a href="#dom-authenticationextensionslargeblobinputs-read">#dom-authenticationextensionslargeblobinputs-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargeblobinputs-read">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-read①">(2)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-read②">(3)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-read③">(4)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-read④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-write">
-   <b><a href="#dom-authenticationextensionslargeblobinputs-write">#dom-authenticationextensionslargeblobinputs-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-write" class="dfn-panel" data-for="dom-authenticationextensionslargeblobinputs-write" id="infopanel-for-dom-authenticationextensionslargeblobinputs-write" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargeblobinputs-write" style="display:none">Info about the 'write' definition.</span><b><a href="#dom-authenticationextensionslargeblobinputs-write">#dom-authenticationextensionslargeblobinputs-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargeblobinputs-write">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-write①">(2)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-write②">(3)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-write③">(4)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-write④">(5)</a> <a href="#ref-for-dom-authenticationextensionslargeblobinputs-write⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionsclientoutputs-largeblob">
-   <b><a href="#dom-authenticationextensionsclientoutputs-largeblob">#dom-authenticationextensionsclientoutputs-largeblob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionsclientoutputs-largeblob" class="dfn-panel" data-for="dom-authenticationextensionsclientoutputs-largeblob" id="infopanel-for-dom-authenticationextensionsclientoutputs-largeblob" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionsclientoutputs-largeblob" style="display:none">Info about the 'largeBlob' definition.</span><b><a href="#dom-authenticationextensionsclientoutputs-largeblob">#dom-authenticationextensionsclientoutputs-largeblob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionsclientoutputs-largeblob">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionsclientoutputs-largeblob①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-authenticationextensionslargebloboutputs">
-   <b><a href="#dictdef-authenticationextensionslargebloboutputs">#dictdef-authenticationextensionslargebloboutputs</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-authenticationextensionslargebloboutputs" class="dfn-panel" data-for="dictdef-authenticationextensionslargebloboutputs" id="infopanel-for-dictdef-authenticationextensionslargebloboutputs" role="dialog">
+   <span id="infopaneltitle-for-dictdef-authenticationextensionslargebloboutputs" style="display:none">Info about the 'AuthenticationExtensionsLargeBlobOutputs' definition.</span><b><a href="#dictdef-authenticationextensionslargebloboutputs">#dictdef-authenticationextensionslargebloboutputs</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-authenticationextensionslargebloboutputs">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dictdef-authenticationextensionslargebloboutputs①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-supported">
-   <b><a href="#dom-authenticationextensionslargebloboutputs-supported">#dom-authenticationextensionslargebloboutputs-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-supported" class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-supported" id="infopanel-for-dom-authenticationextensionslargebloboutputs-supported" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-supported" style="display:none">Info about the 'supported' definition.</span><b><a href="#dom-authenticationextensionslargebloboutputs-supported">#dom-authenticationextensionslargebloboutputs-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargebloboutputs-supported">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargebloboutputs-supported①">(2)</a> <a href="#ref-for-dom-authenticationextensionslargebloboutputs-supported②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-blob">
-   <b><a href="#dom-authenticationextensionslargebloboutputs-blob">#dom-authenticationextensionslargebloboutputs-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-blob" class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-blob" id="infopanel-for-dom-authenticationextensionslargebloboutputs-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-blob" style="display:none">Info about the 'blob' definition.</span><b><a href="#dom-authenticationextensionslargebloboutputs-blob">#dom-authenticationextensionslargebloboutputs-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargebloboutputs-blob">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargebloboutputs-blob①">(2)</a> <a href="#ref-for-dom-authenticationextensionslargebloboutputs-blob②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-written">
-   <b><a href="#dom-authenticationextensionslargebloboutputs-written">#dom-authenticationextensionslargebloboutputs-written</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-written" class="dfn-panel" data-for="dom-authenticationextensionslargebloboutputs-written" id="infopanel-for-dom-authenticationextensionslargebloboutputs-written" role="dialog">
+   <span id="infopaneltitle-for-dom-authenticationextensionslargebloboutputs-written" style="display:none">Info about the 'written' definition.</span><b><a href="#dom-authenticationextensionslargebloboutputs-written">#dom-authenticationextensionslargebloboutputs-written</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-authenticationextensionslargebloboutputs-written">10.5. Large blob storage extension (largeBlob)</a> <a href="#ref-for-dom-authenticationextensionslargebloboutputs-written①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-extension-capabilities">
-   <b><a href="#authenticator-extension-capabilities">#authenticator-extension-capabilities</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-extension-capabilities" class="dfn-panel" data-for="authenticator-extension-capabilities" id="infopanel-for-authenticator-extension-capabilities" role="dialog">
+   <span id="infopaneltitle-for-authenticator-extension-capabilities" style="display:none">Info about the 'Authenticator Extension Capabilities' definition.</span><b><a href="#authenticator-extension-capabilities">#authenticator-extension-capabilities</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-extension-capabilities">11.1.1. Authenticator Extension Capabilities</a> <a href="#ref-for-authenticator-extension-capabilities①">(2)</a> <a href="#ref-for-authenticator-extension-capabilities②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="virtual-authenticators">
-   <b><a href="#virtual-authenticators">#virtual-authenticators</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-virtual-authenticators" class="dfn-panel" data-for="virtual-authenticators" id="infopanel-for-virtual-authenticators" role="dialog">
+   <span id="infopaneltitle-for-virtual-authenticators" style="display:none">Info about the 'Virtual Authenticators' definition.</span><b><a href="#virtual-authenticators">#virtual-authenticators</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-virtual-authenticators">11.1. WebAuthn WebDriver Extension Capability</a> <a href="#ref-for-virtual-authenticators①">(2)</a>
     <li><a href="#ref-for-virtual-authenticators②">11.2. Virtual Authenticators</a> <a href="#ref-for-virtual-authenticators③">(2)</a> <a href="#ref-for-virtual-authenticators④">(3)</a> <a href="#ref-for-virtual-authenticators⑤">(4)</a> <a href="#ref-for-virtual-authenticators⑥">(5)</a> <a href="#ref-for-virtual-authenticators⑦">(6)</a> <a href="#ref-for-virtual-authenticators⑧">(7)</a> <a href="#ref-for-virtual-authenticators⑨">(8)</a> <a href="#ref-for-virtual-authenticators①⓪">(9)</a> <a href="#ref-for-virtual-authenticators①①">(10)</a>
@@ -12776,8 +12783,8 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-virtual-authenticators②⑧">11.9. Set User Verified</a> <a href="#ref-for-virtual-authenticators②⑨">(2)</a> <a href="#ref-for-virtual-authenticators③⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="virtual-authenticator-database">
-   <b><a href="#virtual-authenticator-database">#virtual-authenticator-database</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-virtual-authenticator-database" class="dfn-panel" data-for="virtual-authenticator-database" id="infopanel-for-virtual-authenticator-database" role="dialog">
+   <span id="infopaneltitle-for-virtual-authenticator-database" style="display:none">Info about the 'Virtual Authenticator Database' definition.</span><b><a href="#virtual-authenticator-database">#virtual-authenticator-database</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-virtual-authenticator-database">11.3. Add Virtual Authenticator</a>
     <li><a href="#ref-for-virtual-authenticator-database①">11.4. Remove Virtual Authenticator</a> <a href="#ref-for-virtual-authenticator-database②">(2)</a>
@@ -12788,70 +12795,70 @@ for their contributions as our W3C Team Contacts.</p>
     <li><a href="#ref-for-virtual-authenticator-database⑦">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticatorid">
-   <b><a href="#authenticatorid">#authenticatorid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticatorid" class="dfn-panel" data-for="authenticatorid" id="infopanel-for-authenticatorid" role="dialog">
+   <span id="infopaneltitle-for-authenticatorid" style="display:none">Info about the 'authenticatorId' definition.</span><b><a href="#authenticatorid">#authenticatorid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticatorid">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-virtual-authenticator">
-   <b><a href="#add-virtual-authenticator">#add-virtual-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-virtual-authenticator" class="dfn-panel" data-for="add-virtual-authenticator" id="infopanel-for-add-virtual-authenticator" role="dialog">
+   <span id="infopaneltitle-for-add-virtual-authenticator" style="display:none">Info about the 'Add Virtual Authenticator' definition.</span><b><a href="#add-virtual-authenticator">#add-virtual-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-virtual-authenticator">11.3. Add Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authenticator-configuration">
-   <b><a href="#authenticator-configuration">#authenticator-configuration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authenticator-configuration" class="dfn-panel" data-for="authenticator-configuration" id="infopanel-for-authenticator-configuration" role="dialog">
+   <span id="infopaneltitle-for-authenticator-configuration" style="display:none">Info about the 'Authenticator Configuration' definition.</span><b><a href="#authenticator-configuration">#authenticator-configuration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authenticator-configuration">11.3. Add Virtual Authenticator</a> <a href="#ref-for-authenticator-configuration①">(2)</a> <a href="#ref-for-authenticator-configuration②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-virtual-authenticator">
-   <b><a href="#remove-virtual-authenticator">#remove-virtual-authenticator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-virtual-authenticator" class="dfn-panel" data-for="remove-virtual-authenticator" id="infopanel-for-remove-virtual-authenticator" role="dialog">
+   <span id="infopaneltitle-for-remove-virtual-authenticator" style="display:none">Info about the 'Remove Virtual Authenticator' definition.</span><b><a href="#remove-virtual-authenticator">#remove-virtual-authenticator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-virtual-authenticator">11.4. Remove Virtual Authenticator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-credential">
-   <b><a href="#add-credential">#add-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-credential" class="dfn-panel" data-for="add-credential" id="infopanel-for-add-credential" role="dialog">
+   <span id="infopaneltitle-for-add-credential" style="display:none">Info about the 'Add Credential' definition.</span><b><a href="#add-credential">#add-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-credential">11.5. Add Credential</a>
     <li><a href="#ref-for-add-credential①">11.6. Get Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credential-parameters">
-   <b><a href="#credential-parameters">#credential-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credential-parameters" class="dfn-panel" data-for="credential-parameters" id="infopanel-for-credential-parameters" role="dialog">
+   <span id="infopaneltitle-for-credential-parameters" style="display:none">Info about the 'Credential Parameters' definition.</span><b><a href="#credential-parameters">#credential-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credential-parameters">11.5. Add Credential</a>
     <li><a href="#ref-for-credential-parameters①">11.6. Get Credentials</a> <a href="#ref-for-credential-parameters②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-credentials">
-   <b><a href="#get-credentials">#get-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-credentials" class="dfn-panel" data-for="get-credentials" id="infopanel-for-get-credentials" role="dialog">
+   <span id="infopaneltitle-for-get-credentials" style="display:none">Info about the 'Get Credentials' definition.</span><b><a href="#get-credentials">#get-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-credentials">11.6. Get Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-credential">
-   <b><a href="#remove-credential">#remove-credential</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-credential" class="dfn-panel" data-for="remove-credential" id="infopanel-for-remove-credential" role="dialog">
+   <span id="infopaneltitle-for-remove-credential" style="display:none">Info about the 'Remove Credential' definition.</span><b><a href="#remove-credential">#remove-credential</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-credential">11.7. Remove Credential</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-all-credentials">
-   <b><a href="#remove-all-credentials">#remove-all-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-all-credentials" class="dfn-panel" data-for="remove-all-credentials" id="infopanel-for-remove-all-credentials" role="dialog">
+   <span id="infopaneltitle-for-remove-all-credentials" style="display:none">Info about the 'Remove All Credentials' definition.</span><b><a href="#remove-all-credentials">#remove-all-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-all-credentials">11.8. Remove All Credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-user-verified">
-   <b><a href="#set-user-verified">#set-user-verified</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-user-verified" class="dfn-panel" data-for="set-user-verified" id="infopanel-for-set-user-verified" role="dialog">
+   <span id="infopaneltitle-for-set-user-verified" style="display:none">Info about the 'Set User Verified' definition.</span><b><a href="#set-user-verified">#set-user-verified</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-user-verified">11.9. Set User Verified</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ui-redressing">
-   <b><a href="#ui-redressing">#ui-redressing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ui-redressing" class="dfn-panel" data-for="ui-redressing" id="infopanel-for-ui-redressing" role="dialog">
+   <span id="infopaneltitle-for-ui-redressing" style="display:none">Info about the 'UI Redressing' definition.</span><b><a href="#ui-redressing">#ui-redressing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ui-redressing">5.10. Using Web Authentication within iframe elements</a>
     <li><a href="#ref-for-ui-redressing①">13.4.2. Visibility Considerations for Embedded Usage</a>
@@ -12859,59 +12866,115 @@ for their contributions as our W3C Team Contacts.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-mdn-anno */
 document.body.addEventListener("click", (e) => {

--- a/tests/github/w3c/webdriver-bidi/index.html
+++ b/tests/github/w3c/webdriver-bidi/index.html
@@ -2890,431 +2890,431 @@ end:</p>
    <li><a href="#websocket-connection">WebSocket connection</a><span>, in § 4</span>
    <li><a href="#websocket-listener">WebSocket listener</a><span>, in § 4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-namespacedef-console">
-   <a href="https://console.spec.whatwg.org/#namespacedef-console">https://console.spec.whatwg.org/#namespacedef-console</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespacedef-console" class="dfn-panel" data-for="term-for-namespacedef-console" id="infopanel-for-term-for-namespacedef-console" role="menu">
+   <span id="infopaneltitle-for-term-for-namespacedef-console" style="display:none">Info about the 'console' external reference.</span><a href="https://console.spec.whatwg.org/#namespacedef-console">https://console.spec.whatwg.org/#namespacedef-console</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-console">7.2. Console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatter">
-   <a href="https://console.spec.whatwg.org#formatter">https://console.spec.whatwg.org#formatter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatter" class="dfn-panel" data-for="term-for-formatter" id="infopanel-for-term-for-formatter" role="menu">
+   <span id="infopaneltitle-for-term-for-formatter" style="display:none">Info about the 'formatter' external reference.</span><a href="https://console.spec.whatwg.org#formatter">https://console.spec.whatwg.org#formatter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatter">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formatting-specifiers">
-   <a href="https://console.spec.whatwg.org#formatting-specifiers">https://console.spec.whatwg.org#formatting-specifiers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formatting-specifiers" class="dfn-panel" data-for="term-for-formatting-specifiers" id="infopanel-for-term-for-formatting-specifiers" role="menu">
+   <span id="infopaneltitle-for-term-for-formatting-specifiers" style="display:none">Info about the 'formatting specifier' external reference.</span><a href="https://console.spec.whatwg.org#formatting-specifiers">https://console.spec.whatwg.org#formatting-specifiers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatting-specifiers">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-printer">
-   <a href="https://console.spec.whatwg.org#printer">https://console.spec.whatwg.org#printer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-printer" class="dfn-panel" data-for="term-for-printer" id="infopanel-for-term-for-printer" role="menu">
+   <span id="infopaneltitle-for-term-for-printer" style="display:none">Info about the 'printer' external reference.</span><a href="https://console.spec.whatwg.org#printer">https://console.spec.whatwg.org#printer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-printer">7.2. Console</a> <a href="#ref-for-printer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'window' external reference.</span><a href="https://drafts.csswg.org/css-color-3/#window">https://drafts.csswg.org/css-color-3/#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-paintworkletglobalscope">
-   <a href="https://drafts.css-houdini.org/css-paint-api-1/#paintworkletglobalscope">https://drafts.css-houdini.org/css-paint-api-1/#paintworkletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-paintworkletglobalscope" class="dfn-panel" data-for="term-for-paintworkletglobalscope" id="infopanel-for-term-for-paintworkletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-paintworkletglobalscope" style="display:none">Info about the 'PaintWorkletGlobalScope' external reference.</span><a href="https://drafts.css-houdini.org/css-paint-api-1/#paintworkletglobalscope">https://drafts.css-houdini.org/css-paint-api-1/#paintworkletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-paintworkletglobalscope">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute" class="dfn-panel" data-for="term-for-concept-attribute" id="infopanel-for-term-for-concept-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute" style="display:none">Info about the 'attribute' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute">https://dom.spec.whatwg.org/#concept-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-attribute">
-   <a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-attribute" class="dfn-panel" data-for="term-for-concept-element-attribute" id="infopanel-for-term-for-concept-element-attribute" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-attribute" style="display:none">Info about the 'attribute list' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-attribute">https://dom.spec.whatwg.org/#concept-element-attribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child" style="display:none">Info about the 'children' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">5.1. Remote Value</a> <a href="#ref-for-concept-tree-child①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">4. Transport</a> <a href="#ref-for-concept-document①">(2)</a>
     <li><a href="#ref-for-concept-document②">6.3.3.1. The script.getRealms Command</a>
     <li><a href="#ref-for-concept-document③">6.3.4.1. The script.realmCreated Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">5.1. Remote Value</a> <a href="#ref-for-concept-element①">(2)</a> <a href="#ref-for-concept-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-boundary-point-node">
-   <a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-boundary-point-node" class="dfn-panel" data-for="term-for-boundary-point-node" id="infopanel-for-term-for-boundary-point-node" role="menu">
+   <span id="infopaneltitle-for-term-for-boundary-point-node" style="display:none">Info about the 'node' external reference.</span><a href="https://dom.spec.whatwg.org/#boundary-point-node">https://dom.spec.whatwg.org/#boundary-point-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node">
-   <a href="https://dom.spec.whatwg.org/#concept-node">https://dom.spec.whatwg.org/#concept-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node" class="dfn-panel" data-for="term-for-concept-node" id="infopanel-for-term-for-concept-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node" style="display:none">Info about the 'nodes' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node">https://dom.spec.whatwg.org/#concept-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-qualified-name">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-qualified-name">https://dom.spec.whatwg.org/#concept-attribute-qualified-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-qualified-name" class="dfn-panel" data-for="term-for-concept-attribute-qualified-name" id="infopanel-for-term-for-concept-attribute-qualified-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-qualified-name" style="display:none">Info about the 'qualified name' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-qualified-name">https://dom.spec.whatwg.org/#concept-attribute-qualified-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-qualified-name">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-element-shadow-root">https://dom.spec.whatwg.org/#concept-element-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-shadow-root" class="dfn-panel" data-for="term-for-concept-element-shadow-root" id="infopanel-for-term-for-concept-element-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-shadow-root">https://dom.spec.whatwg.org/#concept-element-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-shadow-root">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-attribute-value">
-   <a href="https://dom.spec.whatwg.org/#concept-attribute-value">https://dom.spec.whatwg.org/#concept-attribute-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-attribute-value" class="dfn-panel" data-for="term-for-concept-attribute-value" id="infopanel-for-term-for-concept-attribute-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-attribute-value" style="display:none">Info about the 'value' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-attribute-value">https://dom.spec.whatwg.org/#concept-attribute-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-value">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createarrayiterator">
-   <a href="https://tc39.es/ecma262/#sec-createarrayiterator">https://tc39.es/ecma262/#sec-createarrayiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createarrayiterator" class="dfn-panel" data-for="term-for-sec-createarrayiterator" id="infopanel-for-term-for-sec-createarrayiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createarrayiterator" style="display:none">Info about the 'createarrayiterator' external reference.</span><a href="https://tc39.es/ecma262/#sec-createarrayiterator">https://tc39.es/ecma262/#sec-createarrayiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createarrayiterator">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createlistfromarraylike">
-   <a href="https://tc39.es/ecma262/#sec-createlistfromarraylike">https://tc39.es/ecma262/#sec-createlistfromarraylike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createlistfromarraylike" class="dfn-panel" data-for="term-for-sec-createlistfromarraylike" id="infopanel-for-term-for-sec-createlistfromarraylike" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createlistfromarraylike" style="display:none">Info about the 'createlistfromarraylike' external reference.</span><a href="https://tc39.es/ecma262/#sec-createlistfromarraylike">https://tc39.es/ecma262/#sec-createlistfromarraylike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createlistfromarraylike">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createmapiterator">
-   <a href="https://tc39.es/ecma262/#sec-createmapiterator">https://tc39.es/ecma262/#sec-createmapiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createmapiterator" class="dfn-panel" data-for="term-for-sec-createmapiterator" id="infopanel-for-term-for-sec-createmapiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createmapiterator" style="display:none">Info about the 'createmapiterator' external reference.</span><a href="https://tc39.es/ecma262/#sec-createmapiterator">https://tc39.es/ecma262/#sec-createmapiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createmapiterator">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createsetiterator">
-   <a href="https://tc39.es/ecma262/#sec-createsetiterator">https://tc39.es/ecma262/#sec-createsetiterator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createsetiterator" class="dfn-panel" data-for="term-for-sec-createsetiterator" id="infopanel-for-term-for-sec-createsetiterator" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createsetiterator" style="display:none">Info about the 'createsetiterator' external reference.</span><a href="https://tc39.es/ecma262/#sec-createsetiterator">https://tc39.es/ecma262/#sec-createsetiterator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createsetiterator">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'current realm record' external reference.</span><a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-enumerableownpropertynames">
-   <a href="https://tc39.es/ecma262/#sec-enumerableownpropertynames">https://tc39.es/ecma262/#sec-enumerableownpropertynames</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-enumerableownpropertynames" class="dfn-panel" data-for="term-for-sec-enumerableownpropertynames" id="infopanel-for-term-for-sec-enumerableownpropertynames" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-enumerableownpropertynames" style="display:none">Info about the 'enumerableownpropertynames' external reference.</span><a href="https://tc39.es/ecma262/#sec-enumerableownpropertynames">https://tc39.es/ecma262/#sec-enumerableownpropertynames</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-enumerableownpropertynames">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get">
-   <a href="https://tc39.es/ecma262/#sec-get">https://tc39.es/ecma262/#sec-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get" class="dfn-panel" data-for="term-for-sec-get" id="infopanel-for-term-for-sec-get" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get" style="display:none">Info about the 'get' external reference.</span><a href="https://tc39.es/ecma262/#sec-get">https://tc39.es/ecma262/#sec-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get">5.1. Remote Value</a> <a href="#ref-for-sec-get①">(2)</a> <a href="#ref-for-sec-get②">(3)</a> <a href="#ref-for-sec-get③">(4)</a> <a href="#ref-for-sec-get④">(5)</a> <a href="#ref-for-sec-get⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">5.1. Remote Value</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots①">(2)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots②">(3)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots③">(4)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots④">(5)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑤">(6)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑥">(7)</a> <a href="#ref-for-sec-object-internal-methods-and-internal-slots⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isarray">
-   <a href="https://tc39.es/ecma262/#sec-isarray">https://tc39.es/ecma262/#sec-isarray</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isarray" class="dfn-panel" data-for="term-for-sec-isarray" id="infopanel-for-term-for-sec-isarray" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isarray" style="display:none">Info about the 'isarray' external reference.</span><a href="https://tc39.es/ecma262/#sec-isarray">https://tc39.es/ecma262/#sec-isarray</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isarray">5.1. Remote Value</a> <a href="#ref-for-sec-isarray①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-iscallable">
-   <a href="https://tc39.es/ecma262/#sec-iscallable">https://tc39.es/ecma262/#sec-iscallable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-iscallable" class="dfn-panel" data-for="term-for-sec-iscallable" id="infopanel-for-term-for-sec-iscallable" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-iscallable" style="display:none">Info about the 'iscallable' external reference.</span><a href="https://tc39.es/ecma262/#sec-iscallable">https://tc39.es/ecma262/#sec-iscallable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-iscallable">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ispromise">
-   <a href="https://tc39.es/ecma262/#sec-ispromise">https://tc39.es/ecma262/#sec-ispromise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ispromise" class="dfn-panel" data-for="term-for-sec-ispromise" id="infopanel-for-term-for-sec-ispromise" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ispromise" style="display:none">Info about the 'ispromise' external reference.</span><a href="https://tc39.es/ecma262/#sec-ispromise">https://tc39.es/ecma262/#sec-ispromise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ispromise">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isregexp">
-   <a href="https://tc39.es/ecma262/#sec-isregexp">https://tc39.es/ecma262/#sec-isregexp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isregexp" class="dfn-panel" data-for="term-for-sec-isregexp" id="infopanel-for-term-for-sec-isregexp" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isregexp" style="display:none">Info about the 'isregexp' external reference.</span><a href="https://tc39.es/ecma262/#sec-isregexp">https://tc39.es/ecma262/#sec-isregexp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isregexp">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-primitive-value">
-   <a href="https://tc39.es/ecma262/#sec-primitive-value">https://tc39.es/ecma262/#sec-primitive-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-primitive-value" class="dfn-panel" data-for="term-for-sec-primitive-value" id="infopanel-for-term-for-sec-primitive-value" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-primitive-value" style="display:none">Info about the 'primitive value' external reference.</span><a href="https://tc39.es/ecma262/#sec-primitive-value">https://tc39.es/ecma262/#sec-primitive-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-primitive-value">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.es/ecma262/#sec-code-realms">https://tc39.es/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.es/ecma262/#sec-code-realms">https://tc39.es/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">6.3.2.1. The script.Realm type</a>
     <li><a href="#ref-for-sec-code-realms①">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-running-execution-context">
-   <a href="https://tc39.es/ecma262/#running-execution-context">https://tc39.es/ecma262/#running-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-running-execution-context" class="dfn-panel" data-for="term-for-running-execution-context" id="infopanel-for-term-for-running-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-running-execution-context" style="display:none">Info about the 'running execution context' external reference.</span><a href="https://tc39.es/ecma262/#running-execution-context">https://tc39.es/ecma262/#running-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-running-execution-context">6.4.2.2. log.StackFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-thistimevalue">
-   <a href="https://tc39.es/ecma262/#thistimevalue">https://tc39.es/ecma262/#thistimevalue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-thistimevalue" class="dfn-panel" data-for="term-for-thistimevalue" id="infopanel-for-term-for-thistimevalue" role="menu">
+   <span id="infopaneltitle-for-term-for-thistimevalue" style="display:none">Info about the 'thistimevalue' external reference.</span><a href="https://tc39.es/ecma262/#thistimevalue">https://tc39.es/ecma262/#thistimevalue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-thistimevalue">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-time-values-and-time-range">
-   <a href="https://tc39.es/ecma262/#sec-time-values-and-time-range">https://tc39.es/ecma262/#sec-time-values-and-time-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-time-values-and-time-range" class="dfn-panel" data-for="term-for-sec-time-values-and-time-range" id="infopanel-for-term-for-sec-time-values-and-time-range" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-time-values-and-time-range" style="display:none">Info about the 'time value' external reference.</span><a href="https://tc39.es/ecma262/#sec-time-values-and-time-range">https://tc39.es/ecma262/#sec-time-values-and-time-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-time-values-and-time-range">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-todatestring">
-   <a href="https://tc39.es/ecma262/#sec-todatestring">https://tc39.es/ecma262/#sec-todatestring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-todatestring" class="dfn-panel" data-for="term-for-sec-todatestring" id="infopanel-for-term-for-sec-todatestring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-todatestring" style="display:none">Info about the 'todatestring' external reference.</span><a href="https://tc39.es/ecma262/#sec-todatestring">https://tc39.es/ecma262/#sec-todatestring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-todatestring">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.es/ecma262/#sec-tostring">https://tc39.es/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'tostring' external reference.</span><a href="https://tc39.es/ecma262/#sec-tostring">https://tc39.es/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">5.1. Remote Value</a> <a href="#ref-for-sec-tostring①">(2)</a> <a href="#ref-for-sec-tostring②">(3)</a>
     <li><a href="#ref-for-sec-tostring③">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'type' external reference.</span><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">5.1. Remote Value</a> <a href="#ref-for-sec-ecmascript-data-types-and-values①">(2)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values②">(3)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values③">(4)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values④">(5)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑤">(6)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑥">(7)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑦">(8)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑧">(9)</a>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values⑨">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-connection">
-   <a href="https://fetch.spec.whatwg.org/#concept-connection">https://fetch.spec.whatwg.org/#concept-connection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-connection" class="dfn-panel" data-for="term-for-concept-connection" id="infopanel-for-term-for-concept-connection" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-connection" style="display:none">Info about the 'connection' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-connection">https://fetch.spec.whatwg.org/#concept-connection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection">4. Transport</a> <a href="#ref-for-concept-connection①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-contains">
-   <a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-contains" class="dfn-panel" data-for="term-for-header-list-contains" id="infopanel-for-term-for-header-list-contains" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-contains" style="display:none">Info about the 'contains' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-contains">https://fetch.spec.whatwg.org/#header-list-contains</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">3.5. Events</a> <a href="#ref-for-header-list-contains①">(2)</a> <a href="#ref-for-header-list-contains②">(3)</a>
     <li><a href="#ref-for-header-list-contains③">4. Transport</a> <a href="#ref-for-header-list-contains④">(2)</a>
     <li><a href="#ref-for-header-list-contains⑤">6.1.1. Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sharedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sharedworkerglobalscope" class="dfn-panel" data-for="term-for-sharedworkerglobalscope" id="infopanel-for-term-for-sharedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-sharedworkerglobalscope" style="display:none">Info about the 'SharedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#sharedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sharedworkerglobalscope">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windowproxy">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windowproxy" class="dfn-panel" data-for="term-for-windowproxy" id="infopanel-for-term-for-windowproxy" role="menu">
+   <span id="infopaneltitle-for-term-for-windowproxy" style="display:none">Info about the 'WindowProxy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy">https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windowproxy">5.1. Remote Value</a> <a href="#ref-for-windowproxy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workerglobalscope" class="dfn-panel" data-for="term-for-workerglobalscope" id="infopanel-for-term-for-workerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workerglobalscope" style="display:none">Info about the 'WorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">4. Transport</a>
     <li><a href="#ref-for-workerglobalscope①">6.3.2.2. The script.RealmInfo type</a> <a href="#ref-for-workerglobalscope②">(2)</a>
     <li><a href="#ref-for-workerglobalscope③">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workletglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workletglobalscope" class="dfn-panel" data-for="term-for-workletglobalscope" id="infopanel-for-term-for-workletglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-workletglobalscope" style="display:none">Info about the 'WorkletGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope">https://html.spec.whatwg.org/multipage/worklets.html#workletglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workletglobalscope">6.3.2.2. The script.RealmInfo type</a> <a href="#ref-for-workletglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-browsing-context-is-discarded">
-   <a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">https://html.spec.whatwg.org/#a-browsing-context-is-discarded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-browsing-context-is-discarded" class="dfn-panel" data-for="term-for-a-browsing-context-is-discarded" id="infopanel-for-term-for-a-browsing-context-is-discarded" role="menu">
+   <span id="infopaneltitle-for-term-for-a-browsing-context-is-discarded" style="display:none">Info about the 'a browsing context is discarded' external reference.</span><a href="https://html.spec.whatwg.org/#a-browsing-context-is-discarded">https://html.spec.whatwg.org/#a-browsing-context-is-discarded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-browsing-context-is-discarded">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
     <li><a href="#ref-for-nav-document①">6.2.4.1. The browsingContext.contextCreated Event</a>
     <li><a href="#ref-for-nav-document②">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">6.2.2.1. The browsingContext.BrowsingContext Type</a>
     <li><a href="#ref-for-browsing-context①">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
     <li><a href="#ref-for-browsing-context②">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">4. Transport</a> <a href="#ref-for-concept-document-bc①">(2)</a>
     <li><a href="#ref-for-concept-document-bc②">6.3.4.1. The script.realmCreated Event</a>
     <li><a href="#ref-for-concept-document-bc③">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-creating-a-new-browsing-context">
-   <a href="https://html.spec.whatwg.org/#creating-a-new-browsing-context">https://html.spec.whatwg.org/#creating-a-new-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-creating-a-new-browsing-context" class="dfn-panel" data-for="term-for-creating-a-new-browsing-context" id="infopanel-for-term-for-creating-a-new-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-creating-a-new-browsing-context" style="display:none">Info about the 'create a new browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#creating-a-new-browsing-context">https://html.spec.whatwg.org/#creating-a-new-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-creating-a-new-browsing-context">6.2.4.1. The browsingContext.contextCreated Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">6.3.3.1. The script.getRealms Command</a>
     <li><a href="#ref-for-environment-settings-object①">6.3.4.1. The script.realmCreated Event</a> <a href="#ref-for-environment-settings-object②">(2)</a>
     <li><a href="#ref-for-environment-settings-object③">6.3.4.2. The script.realmDestroyed Event</a> <a href="#ref-for-environment-settings-object④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm">
-   <a href="https://html.spec.whatwg.org/#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/#environment-settings-object's-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" class="dfn-panel" data-for="term-for-environment-settings-object&apos;s-realm" id="infopanel-for-term-for-environment-settings-object&apos;s-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object&apos;s-realm" style="display:none">Info about the 'environment settings object's realm' external reference.</span><a href="https://html.spec.whatwg.org/#environment-settings-object&apos;s-realm">https://html.spec.whatwg.org/#environment-settings-object's-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object&apos;s-realm">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" class="dfn-panel" data-for="term-for-concept-environment-execution-ready-flag" id="infopanel-for-term-for-concept-environment-execution-ready-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-execution-ready-flag" style="display:none">Info about the 'execution ready flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-execution-ready-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-execution-ready-flag">6.3.3.1. The script.getRealms Command</a>
     <li><a href="#ref-for-concept-environment-execution-ready-flag①">6.3.4.1. The script.realmCreated Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-error-handled">
-   <a href="https://html.spec.whatwg.org/#concept-error-handled">https://html.spec.whatwg.org/#concept-error-handled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-error-handled" class="dfn-panel" data-for="term-for-concept-error-handled" id="infopanel-for-term-for-concept-error-handled" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-error-handled" style="display:none">Info about the 'handled' external reference.</span><a href="https://html.spec.whatwg.org/#concept-error-handled">https://html.spec.whatwg.org/#concept-error-handled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-error-handled">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" class="dfn-panel" data-for="term-for-concept-WorkerGlobalScope-owner-set" id="infopanel-for-term-for-concept-WorkerGlobalScope-owner-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-WorkerGlobalScope-owner-set" style="display:none">Info about the 'owner set' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set">https://html.spec.whatwg.org/multipage/workers.html#concept-WorkerGlobalScope-owner-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set">4. Transport</a>
     <li><a href="#ref-for-concept-WorkerGlobalScope-owner-set①">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm-execution-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm-execution-context" class="dfn-panel" data-for="term-for-realm-execution-context" id="infopanel-for-term-for-realm-execution-context" role="menu">
+   <span id="infopaneltitle-for-term-for-realm-execution-context" style="display:none">Info about the 'realm execution context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context">https://html.spec.whatwg.org/multipage/webappapis.html#realm-execution-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-execution-context">6.3.2.2. The script.RealmInfo type</a>
     <li><a href="#ref-for-realm-execution-context①">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bcg-remove">
-   <a href="https://html.spec.whatwg.org/#bcg-remove">https://html.spec.whatwg.org/#bcg-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bcg-remove" class="dfn-panel" data-for="term-for-bcg-remove" id="infopanel-for-term-for-bcg-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-bcg-remove" style="display:none">Info about the 'remove a browsing context' external reference.</span><a href="https://html.spec.whatwg.org/#bcg-remove">https://html.spec.whatwg.org/#bcg-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bcg-remove">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-error">
-   <a href="https://html.spec.whatwg.org/#report-the-error">https://html.spec.whatwg.org/#report-the-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-error" class="dfn-panel" data-for="term-for-report-the-error" id="infopanel-for-term-for-report-the-error" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-error" style="display:none">Info about the 'report an error' external reference.</span><a href="https://html.spec.whatwg.org/#report-the-error">https://html.spec.whatwg.org/#report-the-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-error">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-responsible-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-responsible-event-loop" class="dfn-panel" data-for="term-for-responsible-event-loop" id="infopanel-for-term-for-responsible-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-responsible-event-loop" style="display:none">Info about the 'responsible event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#responsible-event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsible-event-loop">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-session-history">
-   <a href="https://html.spec.whatwg.org/#session-history">https://html.spec.whatwg.org/#session-history</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-session-history" class="dfn-panel" data-for="term-for-session-history" id="infopanel-for-term-for-session-history" role="menu">
+   <span id="infopaneltitle-for-term-for-session-history" style="display:none">Info about the 'session history' external reference.</span><a href="https://html.spec.whatwg.org/#session-history">https://html.spec.whatwg.org/#session-history</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-history">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-up-a-window-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object">https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-up-a-window-environment-settings-object" class="dfn-panel" data-for="term-for-set-up-a-window-environment-settings-object" id="infopanel-for-term-for-set-up-a-window-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-set-up-a-window-environment-settings-object" style="display:none">Info about the 'set up a window environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object">https://html.spec.whatwg.org/#set-up-a-window-environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-a-window-environment-settings-object">6.3.4.1. The script.realmCreated Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-up-a-worker-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object">https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-up-a-worker-environment-settings-object" class="dfn-panel" data-for="term-for-set-up-a-worker-environment-settings-object" id="infopanel-for-term-for-set-up-a-worker-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-set-up-a-worker-environment-settings-object" style="display:none">Info about the 'set up a worker environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object">https://html.spec.whatwg.org/#set-up-a-worker-environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-a-worker-environment-settings-object">6.3.4.1. The script.realmCreated Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-settings-object" class="dfn-panel" data-for="term-for-settings-object" id="infopanel-for-term-for-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-settings-object" style="display:none">Info about the 'settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-settings-object">4. Transport</a>
     <li><a href="#ref-for-settings-object①">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-terminate-a-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-terminate-a-worker" class="dfn-panel" data-for="term-for-terminate-a-worker" id="infopanel-for-term-for-terminate-a-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-terminate-a-worker" style="display:none">Info about the 'terminate a worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker">https://html.spec.whatwg.org/multipage/workers.html#terminate-a-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-terminate-a-worker">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3.5. Events</a> <a href="#ref-for-top-level-browsing-context①">(2)</a>
     <li><a href="#ref-for-top-level-browsing-context②">6.1.1. Definition</a>
@@ -3325,58 +3325,58 @@ end:</p>
     <li><a href="#ref-for-top-level-browsing-context⑦">7.1. HTML</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps">
-   <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unloading-document-cleanup-steps" class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps" id="infopanel-for-term-for-unloading-document-cleanup-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-unloading-document-cleanup-steps" style="display:none">Info about the 'unloading document cleanup steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unloading-document-cleanup-steps">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker-event-loop-2">
-   <a href="https://html.spec.whatwg.org/#worker-event-loop-2">https://html.spec.whatwg.org/#worker-event-loop-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker-event-loop-2" class="dfn-panel" data-for="term-for-worker-event-loop-2" id="infopanel-for-term-for-worker-event-loop-2" role="menu">
+   <span id="infopaneltitle-for-term-for-worker-event-loop-2" style="display:none">Info about the 'worker event loop' external reference.</span><a href="https://html.spec.whatwg.org/#worker-event-loop-2">https://html.spec.whatwg.org/#worker-event-loop-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker-event-loop-2">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-worklet-global-scopes">
-   <a href="https://html.spec.whatwg.org/#concept-document-worklet-global-scopes">https://html.spec.whatwg.org/#concept-document-worklet-global-scopes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-worklet-global-scopes" class="dfn-panel" data-for="term-for-concept-document-worklet-global-scopes" id="infopanel-for-term-for-concept-document-worklet-global-scopes" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-worklet-global-scopes" style="display:none">Info about the 'worklet global scopes' external reference.</span><a href="https://html.spec.whatwg.org/#concept-document-worklet-global-scopes">https://html.spec.whatwg.org/#concept-document-worklet-global-scopes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-worklet-global-scopes">6.3.4.2. The script.realmDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-assert">
-   <a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-assert" class="dfn-panel" data-for="term-for-assert" id="infopanel-for-term-for-assert" role="menu">
+   <span id="infopaneltitle-for-term-for-assert" style="display:none">Info about the 'assert' external reference.</span><a href="https://infra.spec.whatwg.org/#assert">https://infra.spec.whatwg.org/#assert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">4. Transport</a> <a href="#ref-for-assert①">(2)</a>
     <li><a href="#ref-for-assert②">4.1. Establishing a Connection</a>
     <li><a href="#ref-for-assert③">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-clone">
-   <a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-clone" class="dfn-panel" data-for="term-for-list-clone" id="infopanel-for-term-for-list-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-list-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">6.1.1. Definition</a> <a href="#ref-for-list-clone①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">6.1.2.1. The session.status Command</a>
     <li><a href="#ref-for-ordered-map①">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
@@ -3386,172 +3386,172 @@ end:</p>
     <li><a href="#ref-for-ordered-map⑤">6.4. Log</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value">
-   <a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" class="dfn-panel" data-for="term-for-parse-a-json-string-to-an-infra-value" id="infopanel-for-term-for-parse-a-json-string-to-an-infra-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-json-string-to-an-infra-value" style="display:none">Info about the 'parse json into infra values' external reference.</span><a href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-json-string-to-an-infra-value">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value-string">
-   <a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value-string" class="dfn-panel" data-for="term-for-scalar-value-string" id="infopanel-for-term-for-scalar-value-string" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value-string" style="display:none">Info about the 'scalar value string' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-an-infra-value-to-json-bytes">
-   <a href="https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-an-infra-value-to-json-bytes" class="dfn-panel" data-for="term-for-serialize-an-infra-value-to-json-bytes" id="infopanel-for-term-for-serialize-an-infra-value-to-json-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-an-infra-value-to-json-bytes" style="display:none">Info about the 'serialize an infra value to json bytes' external reference.</span><a href="https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes">https://infra.spec.whatwg.org/#serialize-an-infra-value-to-json-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-infra-value-to-json-bytes">4. Transport</a> <a href="#ref-for-serialize-an-infra-value-to-json-bytes①">(2)</a> <a href="#ref-for-serialize-an-infra-value-to-json-bytes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">4. Transport</a>
     <li><a href="#ref-for-ordered-set①">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">5.1. Remote Value</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-size">
-   <a href="https://infra.spec.whatwg.org/#map-size">https://infra.spec.whatwg.org/#map-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-size" class="dfn-panel" data-for="term-for-map-size" id="infopanel-for-term-for-map-size" role="menu">
+   <span id="infopaneltitle-for-term-for-map-size" style="display:none">Info about the 'size (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-size">https://infra.spec.whatwg.org/#map-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-size">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-sort-in-ascending-order">
-   <a href="https://infra.spec.whatwg.org/#map-sort-in-ascending-order">https://infra.spec.whatwg.org/#map-sort-in-ascending-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-sort-in-ascending-order" class="dfn-panel" data-for="term-for-map-sort-in-ascending-order" id="infopanel-for-term-for-map-sort-in-ascending-order" role="menu">
+   <span id="infopaneltitle-for-term-for-map-sort-in-ascending-order" style="display:none">Info about the 'sort in ascending order' external reference.</span><a href="https://infra.spec.whatwg.org/#map-sort-in-ascending-order">https://infra.spec.whatwg.org/#map-sort-in-ascending-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-sort-in-ascending-order">6.1.2.2. The session.subscribe Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-5.2">
-   <a href="https://tools.ietf.org/html/rfc6455#section-5.2">https://tools.ietf.org/html/rfc6455#section-5.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-5.2" class="dfn-panel" data-for="term-for-section-5.2" id="infopanel-for-term-for-section-5.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-5.2" style="display:none">Info about the '%x1 denotes a text frame' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-5.2">https://tools.ietf.org/html/rfc6455#section-5.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-5.2">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-6.2">
-   <a href="https://tools.ietf.org/html/rfc6455#section-6.2">https://tools.ietf.org/html/rfc6455#section-6.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-6.2" class="dfn-panel" data-for="term-for-section-6.2" id="infopanel-for-term-for-section-6.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-6.2" style="display:none">Info about the 'a websocket message has been received' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-6.2">https://tools.ietf.org/html/rfc6455#section-6.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-6.2">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1">
-   <a href="https://tools.ietf.org/html/rfc6455#section-4.1">https://tools.ietf.org/html/rfc6455#section-4.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1" class="dfn-panel" data-for="term-for-section-4.1" id="infopanel-for-term-for-section-4.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1" style="display:none">Info about the 'establishes a websocket connection' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-4.1">https://tools.ietf.org/html/rfc6455#section-4.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.7">
-   <a href="https://tools.ietf.org/html/rfc6455#section-7.1.7">https://tools.ietf.org/html/rfc6455#section-7.1.7</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.7" class="dfn-panel" data-for="term-for-section-7.1.7" id="infopanel-for-term-for-section-7.1.7" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.7" style="display:none">Info about the 'fail the websocket connection' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-7.1.7">https://tools.ietf.org/html/rfc6455#section-7.1.7</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.7">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-8.1">
-   <a href="https://tools.ietf.org/html/rfc6455#section-8.1">https://tools.ietf.org/html/rfc6455#section-8.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-8.1" class="dfn-panel" data-for="term-for-section-8.1" id="infopanel-for-term-for-section-8.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-8.1" style="display:none">Info about the 'handling errors in utf-8-encoded data' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-8.1">https://tools.ietf.org/html/rfc6455#section-8.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-8.1">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2.1">
-   <a href="https://tools.ietf.org/html/rfc6455#section-4.2.1">https://tools.ietf.org/html/rfc6455#section-4.2.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2.1" class="dfn-panel" data-for="term-for-section-4.2.1" id="infopanel-for-term-for-section-4.2.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2.1" style="display:none">Info about the 'reading the client's opening handshake' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-4.2.1">https://tools.ietf.org/html/rfc6455#section-4.2.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2.1">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-6.1">
-   <a href="https://tools.ietf.org/html/rfc6455#section-6.1">https://tools.ietf.org/html/rfc6455#section-6.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-6.1" class="dfn-panel" data-for="term-for-section-6.1" id="infopanel-for-term-for-section-6.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-6.1" style="display:none">Info about the 'send a websocket message' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-6.1">https://tools.ietf.org/html/rfc6455#section-6.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-6.1">4. Transport</a> <a href="#ref-for-section-6.1①">(2)</a> <a href="#ref-for-section-6.1②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2">
-   <a href="https://tools.ietf.org/html/rfc6455#section-4.2">https://tools.ietf.org/html/rfc6455#section-4.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2" class="dfn-panel" data-for="term-for-section-4.2" id="infopanel-for-term-for-section-4.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2" style="display:none">Info about the 'server-side requirements' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-4.2">https://tools.ietf.org/html/rfc6455#section-4.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2">4. Transport</a> <a href="#ref-for-section-4.2①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.4">
-   <a href="https://tools.ietf.org/html/rfc6455#section-7.4">https://tools.ietf.org/html/rfc6455#section-7.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.4" class="dfn-panel" data-for="term-for-section-7.4" id="infopanel-for-term-for-section-7.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.4" style="display:none">Info about the 'status codes' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-7.4">https://tools.ietf.org/html/rfc6455#section-7.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.4">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.3">
-   <a href="https://tools.ietf.org/html/rfc6455#section-7.1.3">https://tools.ietf.org/html/rfc6455#section-7.1.3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.3" class="dfn-panel" data-for="term-for-section-7.1.3" id="infopanel-for-term-for-section-7.1.3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.3" style="display:none">Info about the 'the websocket closing handshake is started' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-7.1.3">https://tools.ietf.org/html/rfc6455#section-7.1.3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.3">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-7.1.4">
-   <a href="https://tools.ietf.org/html/rfc6455#section-7.1.4">https://tools.ietf.org/html/rfc6455#section-7.1.4</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-7.1.4" class="dfn-panel" data-for="term-for-section-7.1.4" id="infopanel-for-term-for-section-7.1.4" role="menu">
+   <span id="infopaneltitle-for-term-for-section-7.1.4" style="display:none">Info about the 'the websocket connection is closed' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-7.1.4">https://tools.ietf.org/html/rfc6455#section-7.1.4</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-7.1.4">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3">
-   <a href="https://tools.ietf.org/html/rfc6455#section-3">https://tools.ietf.org/html/rfc6455#section-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3" class="dfn-panel" data-for="term-for-section-3" id="infopanel-for-term-for-section-3" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3" style="display:none">Info about the 'websocket uri' external reference.</span><a href="https://tools.ietf.org/html/rfc6455#section-3">https://tools.ietf.org/html/rfc6455#section-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">6.4.2.2. log.StackFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
     <li><a href="#ref-for-concept-url-serializer①">6.4.2.2. log.StackFrame</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-AudioWorkletGlobalScope">
-   <a href="https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope">https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-AudioWorkletGlobalScope" class="dfn-panel" data-for="term-for-AudioWorkletGlobalScope" id="infopanel-for-term-for-AudioWorkletGlobalScope" role="menu">
+   <span id="infopaneltitle-for-term-for-AudioWorkletGlobalScope" style="display:none">Info about the 'AudioWorkletGlobalScope' external reference.</span><a href="https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope">https://webaudio.github.io/web-audio-api/#AudioWorkletGlobalScope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AudioWorkletGlobalScope">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-session">
-   <a href="https://w3c.github.io/webdriver/#dfn-active-session">https://w3c.github.io/webdriver/#dfn-active-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-session" class="dfn-panel" data-for="term-for-dfn-active-session" id="infopanel-for-term-for-dfn-active-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-session" style="display:none">Info about the 'active sessions' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-active-session">https://w3c.github.io/webdriver/#dfn-active-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-session">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-additional-capability-deserialization-algorithm">
-   <a href="https://w3c.github.io/webdriver/#dfn-additional-capability-deserialization-algorithm">https://w3c.github.io/webdriver/#dfn-additional-capability-deserialization-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-additional-capability-deserialization-algorithm" class="dfn-panel" data-for="term-for-dfn-additional-capability-deserialization-algorithm" id="infopanel-for-term-for-dfn-additional-capability-deserialization-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-additional-capability-deserialization-algorithm" style="display:none">Info about the 'additional capability deserialization algorithm' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-additional-capability-deserialization-algorithm">https://w3c.github.io/webdriver/#dfn-additional-capability-deserialization-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-additional-capability-deserialization-algorithm">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-additional-webdriver-capability">
-   <a href="https://w3c.github.io/webdriver/#dfn-additional-webdriver-capability">https://w3c.github.io/webdriver/#dfn-additional-webdriver-capability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-additional-webdriver-capability" class="dfn-panel" data-for="term-for-dfn-additional-webdriver-capability" id="infopanel-for-term-for-dfn-additional-webdriver-capability" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-additional-webdriver-capability" style="display:none">Info about the 'additional webdriver capability' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-additional-webdriver-capability">https://w3c.github.io/webdriver/#dfn-additional-webdriver-capability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-additional-webdriver-capability">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-capability-name">
-   <a href="https://w3c.github.io/webdriver/#dfn-capability-name">https://w3c.github.io/webdriver/#dfn-capability-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-capability-name" class="dfn-panel" data-for="term-for-dfn-capability-name" id="infopanel-for-term-for-dfn-capability-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-capability-name" style="display:none">Info about the 'capability name' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-capability-name">https://w3c.github.io/webdriver/#dfn-capability-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-capability-name">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-current-session">
-   <a href="https://w3c.github.io/webdriver/#dfn-current-session">https://w3c.github.io/webdriver/#dfn-current-session</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-current-session" class="dfn-panel" data-for="term-for-dfn-current-session" id="infopanel-for-term-for-dfn-current-session" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-current-session" style="display:none">Info about the 'current session' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-current-session">https://w3c.github.io/webdriver/#dfn-current-session</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-current-session">4. Transport</a> <a href="#ref-for-dfn-current-session①">(2)</a> <a href="#ref-for-dfn-current-session②">(3)</a> <a href="#ref-for-dfn-current-session③">(4)</a>
     <li><a href="#ref-for-dfn-current-session④">5.1. Remote Value</a>
@@ -3562,14 +3562,14 @@ end:</p>
     <li><a href="#ref-for-dfn-current-session⑨">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-endpoint-node">
-   <a href="https://w3c.github.io/webdriver/#dfn-endpoint-node">https://w3c.github.io/webdriver/#dfn-endpoint-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-endpoint-node" class="dfn-panel" data-for="term-for-dfn-endpoint-node" id="infopanel-for-term-for-dfn-endpoint-node" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-endpoint-node" style="display:none">Info about the 'endpoint node' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-endpoint-node">https://w3c.github.io/webdriver/#dfn-endpoint-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-endpoint-node">4. Transport</a> <a href="#ref-for-dfn-endpoint-node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-errors">
-   <a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-errors" class="dfn-panel" data-for="term-for-dfn-errors" id="infopanel-for-term-for-dfn-errors" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-errors" style="display:none">Info about the 'error' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-errors">https://w3c.github.io/webdriver/#dfn-errors</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-errors">3.5. Events</a> <a href="#ref-for-dfn-errors①">(2)</a>
     <li><a href="#ref-for-dfn-errors②">4. Transport</a>
@@ -3579,8 +3579,8 @@ end:</p>
     <li><a href="#ref-for-dfn-errors⑦">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-error-code">
-   <a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-error-code" class="dfn-panel" data-for="term-for-dfn-error-code" id="infopanel-for-term-for-dfn-error-code" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-error-code" style="display:none">Info about the 'error code' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-error-code">https://w3c.github.io/webdriver/#dfn-error-code</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-error-code">3.5. Events</a> <a href="#ref-for-dfn-error-code①">(2)</a>
     <li><a href="#ref-for-dfn-error-code②">4. Transport</a>
@@ -3589,20 +3589,20 @@ end:</p>
     <li><a href="#ref-for-dfn-error-code⑥">6.2.2.1. The browsingContext.BrowsingContext Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-a-property">
-   <a href="https://w3c.github.io/webdriver/#dfn-get-a-property">https://w3c.github.io/webdriver/#dfn-get-a-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-a-property" class="dfn-panel" data-for="term-for-dfn-get-a-property" id="infopanel-for-term-for-dfn-get-a-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-a-property" style="display:none">Info about the 'getting a property' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-get-a-property">https://w3c.github.io/webdriver/#dfn-get-a-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-a-property">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-intermediary-node">
-   <a href="https://w3c.github.io/webdriver/#dfn-intermediary-node">https://w3c.github.io/webdriver/#dfn-intermediary-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-intermediary-node" class="dfn-panel" data-for="term-for-dfn-intermediary-node" id="infopanel-for-term-for-dfn-intermediary-node" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-intermediary-node" style="display:none">Info about the 'intermediary node' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-intermediary-node">https://w3c.github.io/webdriver/#dfn-intermediary-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-intermediary-node">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-invalid-argument">
-   <a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-invalid-argument" class="dfn-panel" data-for="term-for-dfn-invalid-argument" id="infopanel-for-term-for-dfn-invalid-argument" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-invalid-argument" style="display:none">Info about the 'invalid argument' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-invalid-argument">https://w3c.github.io/webdriver/#dfn-invalid-argument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-invalid-argument">3.5. Events</a> <a href="#ref-for-dfn-invalid-argument①">(2)</a>
     <li><a href="#ref-for-dfn-invalid-argument②">4. Transport</a> <a href="#ref-for-dfn-invalid-argument③">(2)</a> <a href="#ref-for-dfn-invalid-argument④">(3)</a>
@@ -3610,8 +3610,8 @@ end:</p>
     <li><a href="#ref-for-dfn-invalid-argument⑥">6.1.1. Definition</a> <a href="#ref-for-dfn-invalid-argument⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-local-ends">
-   <a href="https://w3c.github.io/webdriver/#dfn-local-ends">https://w3c.github.io/webdriver/#dfn-local-ends</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-local-ends" class="dfn-panel" data-for="term-for-dfn-local-ends" id="infopanel-for-term-for-dfn-local-ends" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-local-ends" style="display:none">Info about the 'local end' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-local-ends">https://w3c.github.io/webdriver/#dfn-local-ends</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-local-ends">3. Protocol</a> <a href="#ref-for-dfn-local-ends①">(2)</a>
     <li><a href="#ref-for-dfn-local-ends②">3.4. Commands</a> <a href="#ref-for-dfn-local-ends③">(2)</a> <a href="#ref-for-dfn-local-ends④">(3)</a> <a href="#ref-for-dfn-local-ends⑤">(4)</a> <a href="#ref-for-dfn-local-ends⑥">(5)</a> <a href="#ref-for-dfn-local-ends⑦">(6)</a>
@@ -3619,20 +3619,20 @@ end:</p>
     <li><a href="#ref-for-dfn-local-ends⑨">4. Transport</a> <a href="#ref-for-dfn-local-ends①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-matched-capability-serialization-algorithm">
-   <a href="https://w3c.github.io/webdriver/#dfn-matched-capability-serialization-algorithm">https://w3c.github.io/webdriver/#dfn-matched-capability-serialization-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-matched-capability-serialization-algorithm" class="dfn-panel" data-for="term-for-dfn-matched-capability-serialization-algorithm" id="infopanel-for-term-for-dfn-matched-capability-serialization-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-matched-capability-serialization-algorithm" style="display:none">Info about the 'matched capability serialization algorithm' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-matched-capability-serialization-algorithm">https://w3c.github.io/webdriver/#dfn-matched-capability-serialization-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-matched-capability-serialization-algorithm">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-no-such-frame">
-   <a href="https://w3c.github.io/webdriver/#dfn-no-such-frame">https://w3c.github.io/webdriver/#dfn-no-such-frame</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-no-such-frame" class="dfn-panel" data-for="term-for-dfn-no-such-frame" id="infopanel-for-term-for-dfn-no-such-frame" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-no-such-frame" style="display:none">Info about the 'no such frame' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-no-such-frame">https://w3c.github.io/webdriver/#dfn-no-such-frame</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-no-such-frame">6.2.2.1. The browsingContext.BrowsingContext Type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-ends">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-ends">https://w3c.github.io/webdriver/#dfn-remote-ends</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-ends" class="dfn-panel" data-for="term-for-dfn-remote-ends" id="infopanel-for-term-for-dfn-remote-ends" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-ends" style="display:none">Info about the 'remote end' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-ends">https://w3c.github.io/webdriver/#dfn-remote-ends</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-ends">3. Protocol</a> <a href="#ref-for-dfn-remote-ends①">(2)</a>
     <li><a href="#ref-for-dfn-remote-ends②">3.4. Commands</a> <a href="#ref-for-dfn-remote-ends③">(2)</a>
@@ -3641,8 +3641,8 @@ end:</p>
     <li><a href="#ref-for-dfn-remote-ends①④">6.1.2.1. The session.status Command</a> <a href="#ref-for-dfn-remote-ends①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-end-steps">
-   <a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-end-steps" class="dfn-panel" data-for="term-for-dfn-remote-end-steps" id="infopanel-for-term-for-dfn-remote-end-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-end-steps" style="display:none">Info about the 'remote end steps' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-remote-end-steps">https://w3c.github.io/webdriver/#dfn-remote-end-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-end-steps">3.4. Commands</a>
     <li><a href="#ref-for-dfn-remote-end-steps①">4. Transport</a>
@@ -3653,8 +3653,8 @@ end:</p>
     <li><a href="#ref-for-dfn-remote-end-steps⑥">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-sessions">
-   <a href="https://w3c.github.io/webdriver/#dfn-sessions">https://w3c.github.io/webdriver/#dfn-sessions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-sessions" class="dfn-panel" data-for="term-for-dfn-sessions" id="infopanel-for-term-for-dfn-sessions" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-sessions" style="display:none">Info about the 'session' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-sessions">https://w3c.github.io/webdriver/#dfn-sessions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-sessions">3.2. Session</a>
     <li><a href="#ref-for-dfn-sessions①">3.5. Events</a> <a href="#ref-for-dfn-sessions②">(2)</a>
@@ -3663,20 +3663,20 @@ end:</p>
     <li><a href="#ref-for-dfn-sessions①②">6.4. Log</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-session-id">
-   <a href="https://w3c.github.io/webdriver/#dfn-session-id">https://w3c.github.io/webdriver/#dfn-session-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-session-id" class="dfn-panel" data-for="term-for-dfn-session-id" id="infopanel-for-term-for-dfn-session-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-session-id" style="display:none">Info about the 'session id' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-session-id">https://w3c.github.io/webdriver/#dfn-session-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-session-id">4. Transport</a> <a href="#ref-for-dfn-session-id①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-a-property">
-   <a href="https://w3c.github.io/webdriver/#dfn-set-a-property">https://w3c.github.io/webdriver/#dfn-set-a-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-a-property" class="dfn-panel" data-for="term-for-dfn-set-a-property" id="infopanel-for-term-for-dfn-set-a-property" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-a-property" style="display:none">Info about the 'set a property' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-set-a-property">https://w3c.github.io/webdriver/#dfn-set-a-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-a-property">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-success">
-   <a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-success" class="dfn-panel" data-for="term-for-dfn-success" id="infopanel-for-term-for-dfn-success" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-success" style="display:none">Info about the 'success' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-success">https://w3c.github.io/webdriver/#dfn-success</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-success">3.5. Events</a> <a href="#ref-for-dfn-success①">(2)</a>
     <li><a href="#ref-for-dfn-success②">4.1. Establishing a Connection</a> <a href="#ref-for-dfn-success③">(2)</a> <a href="#ref-for-dfn-success④">(3)</a>
@@ -3689,8 +3689,8 @@ end:</p>
     <li><a href="#ref-for-dfn-success①②">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-try">
-   <a href="https://w3c.github.io/webdriver/#dfn-try">https://w3c.github.io/webdriver/#dfn-try</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-try" class="dfn-panel" data-for="term-for-dfn-try" id="infopanel-for-term-for-dfn-try" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-try" style="display:none">Info about the 'try' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-try">https://w3c.github.io/webdriver/#dfn-try</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-try">6.1.1. Definition</a> <a href="#ref-for-dfn-try①">(2)</a>
     <li><a href="#ref-for-dfn-try②">6.1.2.2. The session.subscribe Command</a>
@@ -3699,39 +3699,39 @@ end:</p>
     <li><a href="#ref-for-dfn-try⑤">6.3.3.1. The script.getRealms Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-unknown-command">
-   <a href="https://w3c.github.io/webdriver/#dfn-unknown-command">https://w3c.github.io/webdriver/#dfn-unknown-command</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-unknown-command" class="dfn-panel" data-for="term-for-dfn-unknown-command" id="infopanel-for-term-for-dfn-unknown-command" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-unknown-command" style="display:none">Info about the 'unknown command' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-unknown-command">https://w3c.github.io/webdriver/#dfn-unknown-command</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unknown-command">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-web-element-reference">
-   <a href="https://w3c.github.io/webdriver/#dfn-web-element-reference">https://w3c.github.io/webdriver/#dfn-web-element-reference</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-web-element-reference" class="dfn-panel" data-for="term-for-dfn-web-element-reference" id="infopanel-for-term-for-dfn-web-element-reference" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-web-element-reference" style="display:none">Info about the 'web element reference' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-web-element-reference">https://w3c.github.io/webdriver/#dfn-web-element-reference</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-web-element-reference">5.1. Remote Value</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-webdriver-new-session-algorithm">
-   <a href="https://w3c.github.io/webdriver/#dfn-webdriver-new-session-algorithm">https://w3c.github.io/webdriver/#dfn-webdriver-new-session-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-webdriver-new-session-algorithm" class="dfn-panel" data-for="term-for-dfn-webdriver-new-session-algorithm" id="infopanel-for-term-for-dfn-webdriver-new-session-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-webdriver-new-session-algorithm" style="display:none">Info about the 'webdriver new session algorithm' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-webdriver-new-session-algorithm">https://w3c.github.io/webdriver/#dfn-webdriver-new-session-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-webdriver-new-session-algorithm">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-window-handle">
-   <a href="https://w3c.github.io/webdriver/#dfn-window-handle">https://w3c.github.io/webdriver/#dfn-window-handle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-window-handle" class="dfn-panel" data-for="term-for-dfn-window-handle" id="infopanel-for-term-for-dfn-window-handle" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-window-handle" style="display:none">Info about the 'window handle' external reference.</span><a href="https://w3c.github.io/webdriver/#dfn-window-handle">https://w3c.github.io/webdriver/#dfn-window-handle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-window-handle">5.1. Remote Value</a>
     <li><a href="#ref-for-dfn-window-handle①">6.2.2.1. The browsingContext.BrowsingContext Type</a> <a href="#ref-for-dfn-window-handle②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-platform-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-platform-object" class="dfn-panel" data-for="term-for-dfn-platform-object" id="infopanel-for-term-for-dfn-platform-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-platform-object" style="display:none">Info about the 'platform object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object">5.1. Remote Value</a> <a href="#ref-for-dfn-platform-object①">(2)</a> <a href="#ref-for-dfn-platform-object②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-return-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-return-type">https://webidl.spec.whatwg.org/#dfn-return-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-return-type" class="dfn-panel" data-for="term-for-dfn-return-type" id="infopanel-for-term-for-dfn-return-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-return-type" style="display:none">Info about the 'return type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-return-type">https://webidl.spec.whatwg.org/#dfn-return-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-return-type">3.4. Commands</a>
    </ul>
@@ -4006,8 +4006,8 @@ the js exception and console API types that are represented by different methods
 called by external callers and an inner algorithm that’s used for recursive calls. That’s quite hard
 to express as a patch to the specification since it requires changing multiple parts. <a class="issue-return" href="#issue-b664c1e3" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="remote-end-definition">
-   <b><a href="#remote-end-definition">#remote-end-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remote-end-definition" class="dfn-panel" data-for="remote-end-definition" id="infopanel-for-remote-end-definition" role="dialog">
+   <span id="infopaneltitle-for-remote-end-definition" style="display:none">Info about the 'remote end definition' definition.</span><b><a href="#remote-end-definition">#remote-end-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remote-end-definition">3.1. Definition</a> <a href="#ref-for-remote-end-definition①">(2)</a>
     <li><a href="#ref-for-remote-end-definition②">3.3. Modules</a> <a href="#ref-for-remote-end-definition③">(2)</a>
@@ -4022,8 +4022,9 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-remote-end-definition①②">6.4.1. Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-end-definition">
-   <b><a href="#local-end-definition">#local-end-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-end-definition" class="dfn-panel" data-for="local-end-definition" id="infopanel-for-local-end-definition" role="dialog">
+   <span id="infopaneltitle-for-local-end-definition" style="display:none">Info about the 'local end
+definition' definition.</span><b><a href="#local-end-definition">#local-end-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-end-definition">3.1. Definition</a> <a href="#ref-for-local-end-definition①">(2)</a>
     <li><a href="#ref-for-local-end-definition②">3.3. Modules</a> <a href="#ref-for-local-end-definition③">(2)</a> <a href="#ref-for-local-end-definition④">(3)</a>
@@ -4040,56 +4041,57 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-local-end-definition③⑨">6.3.2.2. The script.RealmInfo type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="module-name">
-   <b><a href="#module-name">#module-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-module-name" class="dfn-panel" data-for="module-name" id="infopanel-for-module-name" role="dialog">
+   <span id="infopaneltitle-for-module-name" style="display:none">Info about the 'module name' definition.</span><b><a href="#module-name">#module-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-module-name">3.3. Modules</a> <a href="#ref-for-module-name①">(2)</a>
     <li><a href="#ref-for-module-name②">3.5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extension-modules">
-   <b><a href="#extension-modules">#extension-modules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extension-modules" class="dfn-panel" data-for="extension-modules" id="infopanel-for-extension-modules" role="dialog">
+   <span id="infopaneltitle-for-extension-modules" style="display:none">Info about the 'extension modules' definition.</span><b><a href="#extension-modules">#extension-modules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extension-modules">3.4. Commands</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="command">
-   <b><a href="#command">#command</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-command" class="dfn-panel" data-for="command" id="infopanel-for-command" role="dialog">
+   <span id="infopaneltitle-for-command" style="display:none">Info about the 'command' definition.</span><b><a href="#command">#command</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-command">3.3. Modules</a> <a href="#ref-for-command①">(2)</a> <a href="#ref-for-command②">(3)</a> <a href="#ref-for-command③">(4)</a>
     <li><a href="#ref-for-command④">3.4. Commands</a>
     <li><a href="#ref-for-command⑤">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="command-command-name">
-   <b><a href="#command-command-name">#command-command-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-command-command-name" class="dfn-panel" data-for="command-command-name" id="infopanel-for-command-command-name" role="dialog">
+   <span id="infopaneltitle-for-command-command-name" style="display:none">Info about the 'command
+name' definition.</span><b><a href="#command-command-name">#command-command-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-command-command-name">3.3. Modules</a>
     <li><a href="#ref-for-command-command-name①">3.4. Commands</a>
     <li><a href="#ref-for-command-command-name②">4. Transport</a> <a href="#ref-for-command-command-name③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="command-command-parameters">
-   <b><a href="#command-command-parameters">#command-command-parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-command-command-parameters" class="dfn-panel" data-for="command-command-parameters" id="infopanel-for-command-command-parameters" role="dialog">
+   <span id="infopaneltitle-for-command-command-parameters" style="display:none">Info about the 'command parameters' definition.</span><b><a href="#command-command-parameters">#command-command-parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-command-command-parameters">3.4. Commands</a>
     <li><a href="#ref-for-command-command-parameters①">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="command-result-type">
-   <b><a href="#command-result-type">#command-result-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-command-result-type" class="dfn-panel" data-for="command-result-type" id="infopanel-for-command-result-type" role="dialog">
+   <span id="infopaneltitle-for-command-result-type" style="display:none">Info about the 'result type' definition.</span><b><a href="#command-result-type">#command-result-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-command-result-type">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="command-set-of-all-command-names">
-   <b><a href="#command-set-of-all-command-names">#command-set-of-all-command-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-command-set-of-all-command-names" class="dfn-panel" data-for="command-set-of-all-command-names" id="infopanel-for-command-set-of-all-command-names" role="dialog">
+   <span id="infopaneltitle-for-command-set-of-all-command-names" style="display:none">Info about the 'set of all command names' definition.</span><b><a href="#command-set-of-all-command-names">#command-set-of-all-command-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-command-set-of-all-command-names">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event">
-   <b><a href="#event">#event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event" class="dfn-panel" data-for="event" id="infopanel-for-event" role="dialog">
+   <span id="infopaneltitle-for-event" style="display:none">Info about the 'event' definition.</span><b><a href="#event">#event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">3.3. Modules</a> <a href="#ref-for-event①">(2)</a> <a href="#ref-for-event②">(3)</a>
     <li><a href="#ref-for-event③">3.5. Events</a>
@@ -4097,22 +4099,23 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-event⑤">6.1.2.2. The session.subscribe Command</a> <a href="#ref-for-event⑥">(2)</a> <a href="#ref-for-event⑦">(3)</a> <a href="#ref-for-event⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-event-type">
-   <b><a href="#event-event-type">#event-event-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-event-type" class="dfn-panel" data-for="event-event-type" id="infopanel-for-event-event-type" role="dialog">
+   <span id="infopaneltitle-for-event-event-type" style="display:none">Info about the 'event type' definition.</span><b><a href="#event-event-type">#event-event-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-event-type">3.5. Events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-event-name">
-   <b><a href="#event-event-name">#event-event-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-event-name" class="dfn-panel" data-for="event-event-name" id="infopanel-for-event-event-name" role="dialog">
+   <span id="infopaneltitle-for-event-event-name" style="display:none">Info about the 'event
+name' definition.</span><b><a href="#event-event-name">#event-event-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-event-name">3.3. Modules</a>
     <li><a href="#ref-for-event-event-name①">3.5. Events</a> <a href="#ref-for-event-event-name②">(2)</a> <a href="#ref-for-event-event-name③">(3)</a> <a href="#ref-for-event-event-name④">(4)</a>
     <li><a href="#ref-for-event-event-name⑤">6.1.2.2. The session.subscribe Command</a> <a href="#ref-for-event-event-name⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remote-end-event-trigger">
-   <b><a href="#remote-end-event-trigger">#remote-end-event-trigger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remote-end-event-trigger" class="dfn-panel" data-for="remote-end-event-trigger" id="infopanel-for-remote-end-event-trigger" role="dialog">
+   <span id="infopaneltitle-for-remote-end-event-trigger" style="display:none">Info about the 'remote end event trigger' definition.</span><b><a href="#remote-end-event-trigger">#remote-end-event-trigger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remote-end-event-trigger">6.2.4.1. The browsingContext.contextCreated Event</a>
     <li><a href="#ref-for-remote-end-event-trigger①">6.2.4.2. The browsingContext.contextDestroyed Event</a>
@@ -4121,8 +4124,8 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-remote-end-event-trigger④">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remote-end-subscribe-steps">
-   <b><a href="#remote-end-subscribe-steps">#remote-end-subscribe-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remote-end-subscribe-steps" class="dfn-panel" data-for="remote-end-subscribe-steps" id="infopanel-for-remote-end-subscribe-steps" role="dialog">
+   <span id="infopaneltitle-for-remote-end-subscribe-steps" style="display:none">Info about the 'remote end subscribe steps' definition.</span><b><a href="#remote-end-subscribe-steps">#remote-end-subscribe-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remote-end-subscribe-steps">6.1.2.2. The session.subscribe Command</a> <a href="#ref-for-remote-end-subscribe-steps①">(2)</a>
     <li><a href="#ref-for-remote-end-subscribe-steps②">6.2.4.1. The browsingContext.contextCreated Event</a>
@@ -4130,8 +4133,8 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-remote-end-subscribe-steps④">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subscribe-priority">
-   <b><a href="#subscribe-priority">#subscribe-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subscribe-priority" class="dfn-panel" data-for="subscribe-priority" id="infopanel-for-subscribe-priority" role="dialog">
+   <span id="infopaneltitle-for-subscribe-priority" style="display:none">Info about the 'subscribe priority' definition.</span><b><a href="#subscribe-priority">#subscribe-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subscribe-priority">6.1.2.2. The session.subscribe Command</a>
     <li><a href="#ref-for-subscribe-priority①">6.2.4.1. The browsingContext.contextCreated Event</a>
@@ -4139,120 +4142,121 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-subscribe-priority③">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-global-event-set">
-   <b><a href="#event-global-event-set">#event-global-event-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-global-event-set" class="dfn-panel" data-for="event-global-event-set" id="infopanel-for-event-global-event-set" role="dialog">
+   <span id="infopaneltitle-for-event-global-event-set" style="display:none">Info about the 'global event set' definition.</span><b><a href="#event-global-event-set">#event-global-event-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-global-event-set">3.5. Events</a>
     <li><a href="#ref-for-event-global-event-set①">6.1.1. Definition</a> <a href="#ref-for-event-global-event-set②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-browsing-context-event-map">
-   <b><a href="#event-browsing-context-event-map">#event-browsing-context-event-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-browsing-context-event-map" class="dfn-panel" data-for="event-browsing-context-event-map" id="infopanel-for-event-browsing-context-event-map" role="dialog">
+   <span id="infopaneltitle-for-event-browsing-context-event-map" style="display:none">Info about the 'browsing context event map' definition.</span><b><a href="#event-browsing-context-event-map">#event-browsing-context-event-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-browsing-context-event-map">3.5. Events</a> <a href="#ref-for-event-browsing-context-event-map①">(2)</a>
     <li><a href="#ref-for-event-browsing-context-event-map②">6.1.1. Definition</a> <a href="#ref-for-event-browsing-context-event-map③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-enabled-browsing-contexts">
-   <b><a href="#event-enabled-browsing-contexts">#event-enabled-browsing-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-enabled-browsing-contexts" class="dfn-panel" data-for="event-enabled-browsing-contexts" id="infopanel-for-event-enabled-browsing-contexts" role="dialog">
+   <span id="infopaneltitle-for-event-enabled-browsing-contexts" style="display:none">Info about the 'event enabled browsing contexts' definition.</span><b><a href="#event-enabled-browsing-contexts">#event-enabled-browsing-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-enabled-browsing-contexts">6.1.1. Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-is-enabled">
-   <b><a href="#event-is-enabled">#event-is-enabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-is-enabled" class="dfn-panel" data-for="event-is-enabled" id="infopanel-for-event-is-enabled" role="dialog">
+   <span id="infopaneltitle-for-event-is-enabled" style="display:none">Info about the 'event is enabled' definition.</span><b><a href="#event-is-enabled">#event-is-enabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-is-enabled">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-set-of-event-names">
-   <b><a href="#obtain-a-set-of-event-names">#obtain-a-set-of-event-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-set-of-event-names" class="dfn-panel" data-for="obtain-a-set-of-event-names" id="infopanel-for-obtain-a-set-of-event-names" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-set-of-event-names" style="display:none">Info about the 'obtain a set of event names' definition.</span><b><a href="#obtain-a-set-of-event-names">#obtain-a-set-of-event-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-set-of-event-names">6.1.1. Definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="websocket-listener">
-   <b><a href="#websocket-listener">#websocket-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-websocket-listener" class="dfn-panel" data-for="websocket-listener" id="infopanel-for-websocket-listener" role="dialog">
+   <span id="infopaneltitle-for-websocket-listener" style="display:none">Info about the 'WebSocket listener' definition.</span><b><a href="#websocket-listener">#websocket-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-websocket-listener">4. Transport</a> <a href="#ref-for-websocket-listener①">(2)</a> <a href="#ref-for-websocket-listener②">(3)</a> <a href="#ref-for-websocket-listener③">(4)</a> <a href="#ref-for-websocket-listener④">(5)</a> <a href="#ref-for-websocket-listener⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="listener-host">
-   <b><a href="#listener-host">#listener-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-listener-host" class="dfn-panel" data-for="listener-host" id="infopanel-for-listener-host" role="dialog">
+   <span id="infopaneltitle-for-listener-host" style="display:none">Info about the 'host' definition.</span><b><a href="#listener-host">#listener-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-listener-host">4. Transport</a> <a href="#ref-for-listener-host①">(2)</a> <a href="#ref-for-listener-host②">(3)</a> <a href="#ref-for-listener-host③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="listener-port">
-   <b><a href="#listener-port">#listener-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-listener-port" class="dfn-panel" data-for="listener-port" id="infopanel-for-listener-port" role="dialog">
+   <span id="infopaneltitle-for-listener-port" style="display:none">Info about the 'port' definition.</span><b><a href="#listener-port">#listener-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-listener-port">4. Transport</a> <a href="#ref-for-listener-port①">(2)</a> <a href="#ref-for-listener-port②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="listener-secure-flag">
-   <b><a href="#listener-secure-flag">#listener-secure-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-listener-secure-flag" class="dfn-panel" data-for="listener-secure-flag" id="infopanel-for-listener-secure-flag" role="dialog">
+   <span id="infopaneltitle-for-listener-secure-flag" style="display:none">Info about the 'secure flag' definition.</span><b><a href="#listener-secure-flag">#listener-secure-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-listener-secure-flag">4. Transport</a> <a href="#ref-for-listener-secure-flag①">(2)</a> <a href="#ref-for-listener-secure-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-websocket-resources">
-   <b><a href="#list-of-websocket-resources">#list-of-websocket-resources</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-websocket-resources" class="dfn-panel" data-for="list-of-websocket-resources" id="infopanel-for-list-of-websocket-resources" role="dialog">
+   <span id="infopaneltitle-for-list-of-websocket-resources" style="display:none">Info about the 'list of WebSocket resources' definition.</span><b><a href="#list-of-websocket-resources">#list-of-websocket-resources</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-websocket-resources">4. Transport</a> <a href="#ref-for-list-of-websocket-resources①">(2)</a> <a href="#ref-for-list-of-websocket-resources②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-listeners">
-   <b><a href="#active-listeners">#active-listeners</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-listeners" class="dfn-panel" data-for="active-listeners" id="infopanel-for-active-listeners" role="dialog">
+   <span id="infopaneltitle-for-active-listeners" style="display:none">Info about the 'active
+listeners' definition.</span><b><a href="#active-listeners">#active-listeners</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-listeners">4. Transport</a> <a href="#ref-for-active-listeners①">(2)</a> <a href="#ref-for-active-listeners②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="websocket-connection">
-   <b><a href="#websocket-connection">#websocket-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-websocket-connection" class="dfn-panel" data-for="websocket-connection" id="infopanel-for-websocket-connection" role="dialog">
+   <span id="infopaneltitle-for-websocket-connection" style="display:none">Info about the 'WebSocket connection' definition.</span><b><a href="#websocket-connection">#websocket-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-websocket-connection">4. Transport</a> <a href="#ref-for-websocket-connection①">(2)</a> <a href="#ref-for-websocket-connection②">(3)</a> <a href="#ref-for-websocket-connection③">(4)</a> <a href="#ref-for-websocket-connection④">(5)</a> <a href="#ref-for-websocket-connection⑤">(6)</a> <a href="#ref-for-websocket-connection⑥">(7)</a> <a href="#ref-for-websocket-connection⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-websocket-resource-name">
-   <b><a href="#construct-a-websocket-resource-name">#construct-a-websocket-resource-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-websocket-resource-name" class="dfn-panel" data-for="construct-a-websocket-resource-name" id="infopanel-for-construct-a-websocket-resource-name" role="dialog">
+   <span id="infopaneltitle-for-construct-a-websocket-resource-name" style="display:none">Info about the 'construct a WebSocket resource name' definition.</span><b><a href="#construct-a-websocket-resource-name">#construct-a-websocket-resource-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-websocket-resource-name">4. Transport</a> <a href="#ref-for-construct-a-websocket-resource-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="construct-a-websocket-url">
-   <b><a href="#construct-a-websocket-url">#construct-a-websocket-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-construct-a-websocket-url" class="dfn-panel" data-for="construct-a-websocket-url" id="infopanel-for-construct-a-websocket-url" role="dialog">
+   <span id="infopaneltitle-for-construct-a-websocket-url" style="display:none">Info about the 'construct a WebSocket URL' definition.</span><b><a href="#construct-a-websocket-url">#construct-a-websocket-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-websocket-url">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-session-id-for-a-websocket-resource">
-   <b><a href="#get-a-session-id-for-a-websocket-resource">#get-a-session-id-for-a-websocket-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-session-id-for-a-websocket-resource" class="dfn-panel" data-for="get-a-session-id-for-a-websocket-resource" id="infopanel-for-get-a-session-id-for-a-websocket-resource" role="dialog">
+   <span id="infopaneltitle-for-get-a-session-id-for-a-websocket-resource" style="display:none">Info about the 'get a session ID for a WebSocket resource' definition.</span><b><a href="#get-a-session-id-for-a-websocket-resource">#get-a-session-id-for-a-websocket-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-session-id-for-a-websocket-resource">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-listening-for-a-websocket-connection">
-   <b><a href="#start-listening-for-a-websocket-connection">#start-listening-for-a-websocket-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-listening-for-a-websocket-connection" class="dfn-panel" data-for="start-listening-for-a-websocket-connection" id="infopanel-for-start-listening-for-a-websocket-connection" role="dialog">
+   <span id="infopaneltitle-for-start-listening-for-a-websocket-connection" style="display:none">Info about the 'start listening for a WebSocket connection' definition.</span><b><a href="#start-listening-for-a-websocket-connection">#start-listening-for-a-websocket-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-listening-for-a-websocket-connection">4.1. Establishing a Connection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-an-incoming-message">
-   <b><a href="#handle-an-incoming-message">#handle-an-incoming-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-an-incoming-message" class="dfn-panel" data-for="handle-an-incoming-message" id="infopanel-for-handle-an-incoming-message" role="dialog">
+   <span id="infopaneltitle-for-handle-an-incoming-message" style="display:none">Info about the 'handle an incoming message' definition.</span><b><a href="#handle-an-incoming-message">#handle-an-incoming-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-an-incoming-message">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-related-browsing-contexts">
-   <b><a href="#get-related-browsing-contexts">#get-related-browsing-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-related-browsing-contexts" class="dfn-panel" data-for="get-related-browsing-contexts" id="infopanel-for-get-related-browsing-contexts" role="dialog">
+   <span id="infopaneltitle-for-get-related-browsing-contexts" style="display:none">Info about the 'get related browsing contexts' definition.</span><b><a href="#get-related-browsing-contexts">#get-related-browsing-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-related-browsing-contexts">6.3.4.1. The script.realmCreated Event</a>
     <li><a href="#ref-for-get-related-browsing-contexts①">6.3.4.2. The script.realmDestroyed Event</a>
     <li><a href="#ref-for-get-related-browsing-contexts②">6.4.3.1. entryAdded</a> <a href="#ref-for-get-related-browsing-contexts③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="emit-an-event">
-   <b><a href="#emit-an-event">#emit-an-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-emit-an-event" class="dfn-panel" data-for="emit-an-event" id="infopanel-for-emit-an-event" role="dialog">
+   <span id="infopaneltitle-for-emit-an-event" style="display:none">Info about the 'emit an event' definition.</span><b><a href="#emit-an-event">#emit-an-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-emit-an-event">6.2.4.1. The browsingContext.contextCreated Event</a>
     <li><a href="#ref-for-emit-an-event①">6.2.4.2. The browsingContext.contextDestroyed Event</a>
@@ -4261,66 +4265,67 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-emit-an-event⑥">6.4.3.1. entryAdded</a> <a href="#ref-for-emit-an-event⑦">(2)</a> <a href="#ref-for-emit-an-event⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="respond-with-an-error">
-   <b><a href="#respond-with-an-error">#respond-with-an-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-respond-with-an-error" class="dfn-panel" data-for="respond-with-an-error" id="infopanel-for-respond-with-an-error" role="dialog">
+   <span id="infopaneltitle-for-respond-with-an-error" style="display:none">Info about the 'respond with an error' definition.</span><b><a href="#respond-with-an-error">#respond-with-an-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-respond-with-an-error">4. Transport</a> <a href="#ref-for-respond-with-an-error①">(2)</a> <a href="#ref-for-respond-with-an-error②">(3)</a> <a href="#ref-for-respond-with-an-error③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-a-connection-closing">
-   <b><a href="#handle-a-connection-closing">#handle-a-connection-closing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-a-connection-closing" class="dfn-panel" data-for="handle-a-connection-closing" id="infopanel-for-handle-a-connection-closing" role="dialog">
+   <span id="infopaneltitle-for-handle-a-connection-closing" style="display:none">Info about the 'handle a connection closing' definition.</span><b><a href="#handle-a-connection-closing">#handle-a-connection-closing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-a-connection-closing">4. Transport</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-id-map">
-   <b><a href="#object-id-map">#object-id-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-id-map" class="dfn-panel" data-for="object-id-map" id="infopanel-for-object-id-map" role="dialog">
+   <span id="infopaneltitle-for-object-id-map" style="display:none">Info about the 'object id map' definition.</span><b><a href="#object-id-map">#object-id-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-id-map">5.1. Remote Value</a> <a href="#ref-for-object-id-map①">(2)</a> <a href="#ref-for-object-id-map②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="object-id-for-an-object">
-   <b><a href="#object-id-for-an-object">#object-id-for-an-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-object-id-for-an-object" class="dfn-panel" data-for="object-id-for-an-object" id="infopanel-for-object-id-for-an-object" role="dialog">
+   <span id="infopaneltitle-for-object-id-for-an-object" style="display:none">Info about the 'object id for an object' definition.</span><b><a href="#object-id-for-an-object">#object-id-for-an-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-object-id-for-an-object">5.1. Remote Value</a> <a href="#ref-for-object-id-for-an-object①">(2)</a> <a href="#ref-for-object-id-for-an-object②">(3)</a> <a href="#ref-for-object-id-for-an-object③">(4)</a> <a href="#ref-for-object-id-for-an-object④">(5)</a> <a href="#ref-for-object-id-for-an-object⑤">(6)</a> <a href="#ref-for-object-id-for-an-object⑥">(7)</a> <a href="#ref-for-object-id-for-an-object⑦">(8)</a> <a href="#ref-for-object-id-for-an-object⑧">(9)</a> <a href="#ref-for-object-id-for-an-object⑨">(10)</a> <a href="#ref-for-object-id-for-an-object①⓪">(11)</a> <a href="#ref-for-object-id-for-an-object①①">(12)</a> <a href="#ref-for-object-id-for-an-object①②">(13)</a> <a href="#ref-for-object-id-for-an-object①③">(14)</a> <a href="#ref-for-object-id-for-an-object①④">(15)</a> <a href="#ref-for-object-id-for-an-object①⑤">(16)</a> <a href="#ref-for-object-id-for-an-object①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-as-a-remote-value">
-   <b><a href="#serialize-as-a-remote-value">#serialize-as-a-remote-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-as-a-remote-value" class="dfn-panel" data-for="serialize-as-a-remote-value" id="infopanel-for-serialize-as-a-remote-value" role="dialog">
+   <span id="infopaneltitle-for-serialize-as-a-remote-value" style="display:none">Info about the 'serialize as a remote value' definition.</span><b><a href="#serialize-as-a-remote-value">#serialize-as-a-remote-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-as-a-remote-value">5.1. Remote Value</a> <a href="#ref-for-serialize-as-a-remote-value①">(2)</a> <a href="#ref-for-serialize-as-a-remote-value②">(3)</a> <a href="#ref-for-serialize-as-a-remote-value③">(4)</a> <a href="#ref-for-serialize-as-a-remote-value④">(5)</a>
     <li><a href="#ref-for-serialize-as-a-remote-value⑤">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-as-a-list">
-   <b><a href="#serialize-as-a-list">#serialize-as-a-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-as-a-list" class="dfn-panel" data-for="serialize-as-a-list" id="infopanel-for-serialize-as-a-list" role="dialog">
+   <span id="infopaneltitle-for-serialize-as-a-list" style="display:none">Info about the 'serialize as a list' definition.</span><b><a href="#serialize-as-a-list">#serialize-as-a-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-as-a-list">5.1. Remote Value</a> <a href="#ref-for-serialize-as-a-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-as-a-mapping">
-   <b><a href="#serialize-as-a-mapping">#serialize-as-a-mapping</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-as-a-mapping" class="dfn-panel" data-for="serialize-as-a-mapping" id="infopanel-for-serialize-as-a-mapping" role="dialog">
+   <span id="infopaneltitle-for-serialize-as-a-mapping" style="display:none">Info about the 'serialize as a mapping' definition.</span><b><a href="#serialize-as-a-mapping">#serialize-as-a-mapping</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-as-a-mapping">5.1. Remote Value</a> <a href="#ref-for-serialize-as-a-mapping①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-the-event-map">
-   <b><a href="#update-the-event-map">#update-the-event-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-the-event-map" class="dfn-panel" data-for="update-the-event-map" id="infopanel-for-update-the-event-map" role="dialog">
+   <span id="infopaneltitle-for-update-the-event-map" style="display:none">Info about the 'update the event map' definition.</span><b><a href="#update-the-event-map">#update-the-event-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-the-event-map">6.1.2.2. The session.subscribe Command</a>
     <li><a href="#ref-for-update-the-event-map①">6.1.2.3. The session.unsubscribe Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="browsing-context-id">
-   <b><a href="#browsing-context-id">#browsing-context-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-browsing-context-id" class="dfn-panel" data-for="browsing-context-id" id="infopanel-for-browsing-context-id" role="dialog">
+   <span id="infopaneltitle-for-browsing-context-id" style="display:none">Info about the 'browsing context
+id' definition.</span><b><a href="#browsing-context-id">#browsing-context-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-id">6.2.2.1. The browsingContext.BrowsingContext Type</a> <a href="#ref-for-browsing-context-id①">(2)</a>
     <li><a href="#ref-for-browsing-context-id②">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a> <a href="#ref-for-browsing-context-id③">(2)</a>
     <li><a href="#ref-for-browsing-context-id④">6.4. Log</a> <a href="#ref-for-browsing-context-id⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-a-browsing-context">
-   <b><a href="#get-a-browsing-context">#get-a-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-a-browsing-context" class="dfn-panel" data-for="get-a-browsing-context" id="infopanel-for-get-a-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-get-a-browsing-context" style="display:none">Info about the 'get a browsing context' definition.</span><b><a href="#get-a-browsing-context">#get-a-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-a-browsing-context">6.1.1. Definition</a>
     <li><a href="#ref-for-get-a-browsing-context①">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
@@ -4328,81 +4333,82 @@ to express as a patch to the specification since it requires changing multiple p
     <li><a href="#ref-for-get-a-browsing-context③">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-browsing-context-info">
-   <b><a href="#get-the-browsing-context-info">#get-the-browsing-context-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-browsing-context-info" class="dfn-panel" data-for="get-the-browsing-context-info" id="infopanel-for-get-the-browsing-context-info" role="dialog">
+   <span id="infopaneltitle-for-get-the-browsing-context-info" style="display:none">Info about the 'get the browsing context info' definition.</span><b><a href="#get-the-browsing-context-info">#get-the-browsing-context-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-browsing-context-info">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
     <li><a href="#ref-for-get-the-browsing-context-info①">6.2.4.1. The browsingContext.contextCreated Event</a>
     <li><a href="#ref-for-get-the-browsing-context-info②">6.2.4.2. The browsingContext.contextDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-descendent-browsing-contexts">
-   <b><a href="#get-the-descendent-browsing-contexts">#get-the-descendent-browsing-contexts</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-descendent-browsing-contexts" class="dfn-panel" data-for="get-the-descendent-browsing-contexts" id="infopanel-for-get-the-descendent-browsing-contexts" role="dialog">
+   <span id="infopaneltitle-for-get-the-descendent-browsing-contexts" style="display:none">Info about the 'get the descendent browsing contexts' definition.</span><b><a href="#get-the-descendent-browsing-contexts">#get-the-descendent-browsing-contexts</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-descendent-browsing-contexts">6.2.2.2. The browsingContext.BrowsingContextInfo Type</a>
     <li><a href="#ref-for-get-the-descendent-browsing-contexts①">6.2.3.1. The browsingContext.getTree Command</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="recursively-emit-context-created-events">
-   <b><a href="#recursively-emit-context-created-events">#recursively-emit-context-created-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-recursively-emit-context-created-events" class="dfn-panel" data-for="recursively-emit-context-created-events" id="infopanel-for-recursively-emit-context-created-events" role="dialog">
+   <span id="infopaneltitle-for-recursively-emit-context-created-events" style="display:none">Info about the 'Recursively emit context created events' definition.</span><b><a href="#recursively-emit-context-created-events">#recursively-emit-context-created-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-recursively-emit-context-created-events">6.2.4.1. The browsingContext.contextCreated Event</a> <a href="#ref-for-recursively-emit-context-created-events①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="emit-a-context-created-event">
-   <b><a href="#emit-a-context-created-event">#emit-a-context-created-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-emit-a-context-created-event" class="dfn-panel" data-for="emit-a-context-created-event" id="infopanel-for-emit-a-context-created-event" role="dialog">
+   <span id="infopaneltitle-for-emit-a-context-created-event" style="display:none">Info about the 'Emit a context created event' definition.</span><b><a href="#emit-a-context-created-event">#emit-a-context-created-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-emit-a-context-created-event">6.2.4.1. The browsingContext.contextCreated Event</a> <a href="#ref-for-emit-a-context-created-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="realm-id">
-   <b><a href="#realm-id">#realm-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-realm-id" class="dfn-panel" data-for="realm-id" id="infopanel-for-realm-id" role="dialog">
+   <span id="infopaneltitle-for-realm-id" style="display:none">Info about the 'realm id' definition.</span><b><a href="#realm-id">#realm-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm-id">6.3.2.2. The script.RealmInfo type</a>
     <li><a href="#ref-for-realm-id①">6.3.4.2. The script.realmDestroyed Event</a> <a href="#ref-for-realm-id②">(2)</a> <a href="#ref-for-realm-id③">(3)</a>
     <li><a href="#ref-for-realm-id④">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-realm-info">
-   <b><a href="#get-the-realm-info">#get-the-realm-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-realm-info" class="dfn-panel" data-for="get-the-realm-info" id="infopanel-for-get-the-realm-info" role="dialog">
+   <span id="infopaneltitle-for-get-the-realm-info" style="display:none">Info about the 'get the realm info' definition.</span><b><a href="#get-the-realm-info">#get-the-realm-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-realm-info">6.3.3.1. The script.getRealms Command</a>
     <li><a href="#ref-for-get-the-realm-info①">6.3.4.1. The script.realmCreated Event</a> <a href="#ref-for-get-the-realm-info②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="log-event-buffer">
-   <b><a href="#log-event-buffer">#log-event-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-log-event-buffer" class="dfn-panel" data-for="log-event-buffer" id="infopanel-for-log-event-buffer" role="dialog">
+   <span id="infopaneltitle-for-log-event-buffer" style="display:none">Info about the 'log event buffer' definition.</span><b><a href="#log-event-buffer">#log-event-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-log-event-buffer">6.4. Log</a>
     <li><a href="#ref-for-log-event-buffer①">6.4.3.1. entryAdded</a> <a href="#ref-for-log-event-buffer②">(2)</a> <a href="#ref-for-log-event-buffer③">(3)</a> <a href="#ref-for-log-event-buffer④">(4)</a> <a href="#ref-for-log-event-buffer⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="buffer-a-log-event">
-   <b><a href="#buffer-a-log-event">#buffer-a-log-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-buffer-a-log-event" class="dfn-panel" data-for="buffer-a-log-event" id="infopanel-for-buffer-a-log-event" role="dialog">
+   <span id="infopaneltitle-for-buffer-a-log-event" style="display:none">Info about the 'buffer a log event' definition.</span><b><a href="#buffer-a-log-event">#buffer-a-log-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-buffer-a-log-event">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="current-stack-trace">
-   <b><a href="#current-stack-trace">#current-stack-trace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-current-stack-trace" class="dfn-panel" data-for="current-stack-trace" id="infopanel-for-current-stack-trace" role="dialog">
+   <span id="infopaneltitle-for-current-stack-trace" style="display:none">Info about the 'current stack trace' definition.</span><b><a href="#current-stack-trace">#current-stack-trace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-stack-trace">6.4.3.1. entryAdded</a> <a href="#ref-for-current-stack-trace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="browsing-context-tree-discarded">
-   <b><a href="#browsing-context-tree-discarded">#browsing-context-tree-discarded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-browsing-context-tree-discarded" class="dfn-panel" data-for="browsing-context-tree-discarded" id="infopanel-for-browsing-context-tree-discarded" role="dialog">
+   <span id="infopaneltitle-for-browsing-context-tree-discarded" style="display:none">Info about the 'browsing context
+  tree discarded' definition.</span><b><a href="#browsing-context-tree-discarded">#browsing-context-tree-discarded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context-tree-discarded">6.2.4.2. The browsingContext.contextDestroyed Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="error-reporting-steps">
-   <b><a href="#error-reporting-steps">#error-reporting-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-error-reporting-steps" class="dfn-panel" data-for="error-reporting-steps" id="infopanel-for-error-reporting-steps" role="dialog">
+   <span id="infopaneltitle-for-error-reporting-steps" style="display:none">Info about the 'error reporting steps' definition.</span><b><a href="#error-reporting-steps">#error-reporting-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-error-reporting-steps">6.4.3.1. entryAdded</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="console-steps">
-   <b><a href="#console-steps">#console-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-console-steps" class="dfn-panel" data-for="console-steps" id="infopanel-for-console-steps" role="dialog">
+   <span id="infopaneltitle-for-console-steps" style="display:none">Info about the 'console steps' definition.</span><b><a href="#console-steps">#console-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-console-steps">6.4.3.1. entryAdded</a>
     <li><a href="#ref-for-console-steps①">7.2. Console</a> <a href="#ref-for-console-steps②">(2)</a>
@@ -4410,59 +4416,115 @@ to express as a patch to the specification since it requires changing multiple p
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/webrtc-encoded-transform/index.html
+++ b/tests/github/w3c/webrtc-encoded-transform/index.html
@@ -1246,315 +1246,315 @@ otherwise unavailable, which allows some fingerprinting surface.</p>
     </ul>
    <li><a href="#writeencodeddata">writeEncodedData</a><span>, in § 3.1.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-abortcontroller">
-   <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortcontroller" class="dfn-panel" data-for="term-for-abortcontroller" id="infopanel-for-term-for-abortcontroller" role="menu">
+   <span id="infopaneltitle-for-term-for-abortcontroller" style="display:none">Info about the 'AbortController' external reference.</span><a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">3.1.1. Stream creation</a>
     <li><a href="#ref-for-abortcontroller①">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-create">
-   <a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-create" class="dfn-panel" data-for="term-for-concept-event-create" id="infopanel-for-term-for-concept-event-create" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-create" style="display:none">Info about the 'creating an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-create">https://dom.spec.whatwg.org/#concept-event-create</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">5.1. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-signal-abort">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-signal-abort" class="dfn-panel" data-for="term-for-abortsignal-signal-abort" id="infopanel-for-term-for-abortsignal-signal-abort" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-signal-abort" style="display:none">Info about the 'signal abort' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-signal-abort">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dedicatedworkerglobalscope" class="dfn-panel" data-for="term-for-dedicatedworkerglobalscope" id="infopanel-for-term-for-dedicatedworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-dedicatedworkerglobalscope" style="display:none">Info about the 'DedicatedWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dedicatedworkerglobalscope">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">5.1. Operations</a> <a href="#ref-for-structureddeserialize①">(2)</a> <a href="#ref-for-structureddeserialize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">5.1. Operations</a> <a href="#ref-for-structuredserializewithtransfer①">(2)</a> <a href="#ref-for-structuredserializewithtransfer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.1.2. Stream processing</a> <a href="#ref-for-in-parallel①">(2)</a>
     <li><a href="#ref-for-in-parallel②">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3.1.1. Stream creation</a>
     <li><a href="#ref-for-queue-a-task①">5.1. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-source" class="dfn-panel" data-for="term-for-task-source" id="infopanel-for-term-for-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-task-source" style="display:none">Info about the 'task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-source">https://html.spec.whatwg.org/multipage/webappapis.html#task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-source">5.1. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-mediastreamtrack">
-   <a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-mediastreamtrack" class="dfn-panel" data-for="term-for-dom-mediastreamtrack" id="infopanel-for-term-for-dom-mediastreamtrack" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-mediastreamtrack" style="display:none">Info about the 'MediaStreamTrack' external reference.</span><a href="https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack">https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mediastreamtrack">Unnumbered Section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generictransformstream">
-   <a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generictransformstream" class="dfn-panel" data-for="term-for-generictransformstream" id="infopanel-for-term-for-generictransformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-generictransformstream" style="display:none">Info about the 'GenericTransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">3. Specification</a>
     <li><a href="#ref-for-readablestream①">3.1.1. Stream creation</a>
     <li><a href="#ref-for-readablestream②">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream">
-   <a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream" class="dfn-panel" data-for="term-for-transformstream" id="infopanel-for-term-for-transformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream" style="display:none">Info about the 'TransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream">
-   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream" class="dfn-panel" data-for="term-for-writablestream" id="infopanel-for-term-for-writablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream" style="display:none">Info about the 'WritableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">3. Specification</a>
     <li><a href="#ref-for-writablestream①">3.1.1. Stream creation</a>
     <li><a href="#ref-for-writablestream②">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">3.1.2. Stream processing</a>
     <li><a href="#ref-for-readablestream-enqueue①">4.1. Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'getting a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-get-a-writer">
-   <a href="https://streams.spec.whatwg.org/#writablestream-get-a-writer">https://streams.spec.whatwg.org/#writablestream-get-a-writer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-get-a-writer" class="dfn-panel" data-for="term-for-writablestream-get-a-writer" id="infopanel-for-term-for-writablestream-get-a-writer" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-get-a-writer" style="display:none">Info about the 'getting a writer' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-get-a-writer">https://streams.spec.whatwg.org/#writablestream-get-a-writer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-get-a-writer">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-identity-transform-stream">
-   <a href="https://streams.spec.whatwg.org/#identity-transform-stream">https://streams.spec.whatwg.org/#identity-transform-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-identity-transform-stream" class="dfn-panel" data-for="term-for-identity-transform-stream" id="infopanel-for-term-for-identity-transform-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-identity-transform-stream" style="display:none">Info about the 'identity transform stream' external reference.</span><a href="https://streams.spec.whatwg.org/#identity-transform-stream">https://streams.spec.whatwg.org/#identity-transform-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform-stream">3.2. Extension attribute</a>
     <li><a href="#ref-for-identity-transform-stream①">5.1. Operations</a> <a href="#ref-for-identity-transform-stream②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-release">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-release">https://streams.spec.whatwg.org/#readablestreamdefaultreader-release</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-release" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-release" id="infopanel-for-term-for-readablestreamdefaultreader-release" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-release" style="display:none">Info about the 'release (for ReadableStreamDefaultReader)' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-release">https://streams.spec.whatwg.org/#readablestreamdefaultreader-release</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-release">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-release">
-   <a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestreamdefaultwriter-release" class="dfn-panel" data-for="term-for-writablestreamdefaultwriter-release" id="infopanel-for-term-for-writablestreamdefaultwriter-release" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestreamdefaultwriter-release" style="display:none">Info about the 'release (for WritableStreamDefaultWriter)' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release">https://streams.spec.whatwg.org/#writablestreamdefaultwriter-release</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-release">3.2. Extension attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up">https://streams.spec.whatwg.org/#readablestream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up" class="dfn-panel" data-for="term-for-readablestream-set-up" id="infopanel-for-term-for-readablestream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up" style="display:none">Info about the 'set up (for ReadableStream)' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up">https://streams.spec.whatwg.org/#readablestream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up">3.1.1. Stream creation</a>
     <li><a href="#ref-for-readablestream-set-up①">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up">https://streams.spec.whatwg.org/#writablestream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up" class="dfn-panel" data-for="term-for-writablestream-set-up" id="infopanel-for-term-for-writablestream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up" style="display:none">Info about the 'set up (for WritableStream)' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up">https://streams.spec.whatwg.org/#writablestream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-set-up-transformalgorithm">
-   <a href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-set-up-transformalgorithm" class="dfn-panel" data-for="term-for-transformstream-set-up-transformalgorithm" id="infopanel-for-term-for-transformstream-set-up-transformalgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-set-up-transformalgorithm" style="display:none">Info about the 'transformalgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm">https://streams.spec.whatwg.org/#transformstream-set-up-transformalgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up-transformalgorithm">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream-set-up-writealgorithm">
-   <a href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream-set-up-writealgorithm" class="dfn-panel" data-for="term-for-writablestream-set-up-writealgorithm" id="infopanel-for-term-for-writablestream-set-up-writealgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream-set-up-writealgorithm" style="display:none">Info about the 'writealgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm">https://streams.spec.whatwg.org/#writablestream-set-up-writealgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up-writealgorithm">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-CryptoKey">
-   <a href="https://w3c.github.io/webcrypto/#dfn-CryptoKey">https://w3c.github.io/webcrypto/#dfn-CryptoKey</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-CryptoKey" class="dfn-panel" data-for="term-for-dfn-CryptoKey" id="infopanel-for-term-for-dfn-CryptoKey" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-CryptoKey" style="display:none">Info about the 'CryptoKey' external reference.</span><a href="https://w3c.github.io/webcrypto/#dfn-CryptoKey">https://w3c.github.io/webcrypto/#dfn-CryptoKey</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-CryptoKey">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">4.1. Algorithm</a>
     <li><a href="#ref-for-idl-ArrayBuffer①">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-ArrayBuffer②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">4.1. Algorithm</a> <a href="#ref-for-BufferSource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.1.1. Stream creation</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4. SFrameTransform</a>
     <li><a href="#ref-for-Exposed①">5. RTCRtpScriptTransform</a> <a href="#ref-for-Exposed②">(2)</a> <a href="#ref-for-Exposed③">(3)</a> <a href="#ref-for-Exposed④">(4)</a> <a href="#ref-for-Exposed⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">3.1.1. Stream creation</a> <a href="#ref-for-invalidaccesserror①">(2)</a> <a href="#ref-for-invalidaccesserror②">(3)</a> <a href="#ref-for-invalidaccesserror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidmodificationerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidmodificationerror" class="dfn-panel" data-for="term-for-invalidmodificationerror" id="infopanel-for-term-for-invalidmodificationerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidmodificationerror" style="display:none">Info about the 'InvalidModificationError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidmodificationerror">https://webidl.spec.whatwg.org/#invalidmodificationerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidmodificationerror">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">3.1.2. Stream processing</a> <a href="#ref-for-a-promise-resolved-with①">(2)</a> <a href="#ref-for-a-promise-resolved-with②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-bigint">
-   <a href="https://webidl.spec.whatwg.org/#idl-bigint">https://webidl.spec.whatwg.org/#idl-bigint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-bigint" class="dfn-panel" data-for="term-for-idl-bigint" id="infopanel-for-term-for-idl-bigint" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-bigint" style="display:none">Info about the 'bigint' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-bigint">https://webidl.spec.whatwg.org/#idl-bigint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-bigint">4. SFrameTransform</a>
     <li><a href="#ref-for-idl-bigint①">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. Specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a> <a href="#ref-for-idl-long④">(5)</a> <a href="#ref-for-idl-long⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long-long" class="dfn-panel" data-for="term-for-idl-long-long" id="infopanel-for-term-for-idl-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long-long" style="display:none">Info about the 'long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-long-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.2. Methods</a> <a href="#ref-for-reject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.2. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1.1. Stream creation</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a> <a href="#ref-for-this⑧">(9)</a> <a href="#ref-for-this⑨">(10)</a> <a href="#ref-for-this①⓪">(11)</a> <a href="#ref-for-this①①">(12)</a> <a href="#ref-for-this①②">(13)</a> <a href="#ref-for-this①③">(14)</a> <a href="#ref-for-this①④">(15)</a> <a href="#ref-for-this①⑤">(16)</a> <a href="#ref-for-this①⑥">(17)</a> <a href="#ref-for-this①⑦">(18)</a> <a href="#ref-for-this①⑧">(19)</a> <a href="#ref-for-this①⑨">(20)</a> <a href="#ref-for-this②⓪">(21)</a> <a href="#ref-for-this②①">(22)</a> <a href="#ref-for-this②②">(23)</a> <a href="#ref-for-this②③">(24)</a>
     <li><a href="#ref-for-this②④">3.2. Extension attribute</a> <a href="#ref-for-this②⑤">(2)</a> <a href="#ref-for-this②⑥">(3)</a> <a href="#ref-for-this②⑦">(4)</a> <a href="#ref-for-this②⑧">(5)</a> <a href="#ref-for-this②⑨">(6)</a>
@@ -1562,34 +1562,34 @@ otherwise unavailable, which allows some fingerprinting surface.</p>
     <li><a href="#ref-for-this③①">5.2. Attributes</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">4. SFrameTransform</a>
     <li><a href="#ref-for-idl-unsigned-long-long①">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-unsigned-long-long②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">5. RTCRtpScriptTransform</a> <a href="#ref-for-idl-unsigned-short①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcconfiguration">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration">https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcconfiguration" class="dfn-panel" data-for="term-for-dom-rtcconfiguration" id="infopanel-for-term-for-dom-rtcconfiguration" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcconfiguration" style="display:none">Info about the 'RTCConfiguration' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration">https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcconfiguration">3. Specification</a>
     <li><a href="#ref-for-dom-rtcconfiguration①">3.1. Extension operation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcpeerconnection">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection">https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcpeerconnection" class="dfn-panel" data-for="term-for-dom-rtcpeerconnection" id="infopanel-for-term-for-dom-rtcpeerconnection" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcpeerconnection" style="display:none">Info about the 'RTCPeerConnection' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection">https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcpeerconnection">Unnumbered Section</a>
     <li><a href="#ref-for-dom-rtcpeerconnection①">3. Specification</a>
@@ -1597,8 +1597,8 @@ otherwise unavailable, which allows some fingerprinting surface.</p>
     <li><a href="#ref-for-dom-rtcpeerconnection③">3.1.1. Stream creation</a> <a href="#ref-for-dom-rtcpeerconnection④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcrtpreceiver">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver">https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcrtpreceiver" class="dfn-panel" data-for="term-for-dom-rtcrtpreceiver" id="infopanel-for-term-for-dom-rtcrtpreceiver" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcrtpreceiver" style="display:none">Info about the 'RTCRtpReceiver' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver">https://w3c.github.io/webrtc-pc/#dom-rtcrtpreceiver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpreceiver">3. Specification</a> <a href="#ref-for-dom-rtcrtpreceiver①">(2)</a>
     <li><a href="#ref-for-dom-rtcrtpreceiver②">3.1.1. Stream creation</a>
@@ -1607,8 +1607,8 @@ otherwise unavailable, which allows some fingerprinting surface.</p>
     <li><a href="#ref-for-dom-rtcrtpreceiver⑦">4.1. Algorithm</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcrtpsender">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender">https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcrtpsender" class="dfn-panel" data-for="term-for-dom-rtcrtpsender" id="infopanel-for-term-for-dom-rtcrtpsender" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcrtpsender" style="display:none">Info about the 'RTCRtpSender' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender">https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpsender">3. Specification</a> <a href="#ref-for-dom-rtcrtpsender①">(2)</a>
     <li><a href="#ref-for-dom-rtcrtpsender②">3.1.1. Stream creation</a>
@@ -1844,260 +1844,316 @@ otherwise unavailable, which allows some fingerprinting surface.</p>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dictdef-rtcinsertablestreams">
-   <b><a href="#dictdef-rtcinsertablestreams">#dictdef-rtcinsertablestreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-rtcinsertablestreams" class="dfn-panel" data-for="dictdef-rtcinsertablestreams" id="infopanel-for-dictdef-rtcinsertablestreams" role="dialog">
+   <span id="infopaneltitle-for-dictdef-rtcinsertablestreams" style="display:none">Info about the 'RTCInsertableStreams' definition.</span><b><a href="#dictdef-rtcinsertablestreams">#dictdef-rtcinsertablestreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-rtcinsertablestreams">3. Specification</a> <a href="#ref-for-dictdef-rtcinsertablestreams①">(2)</a>
     <li><a href="#ref-for-dictdef-rtcinsertablestreams②">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcinsertablestreams-readable">
-   <b><a href="#dom-rtcinsertablestreams-readable">#dom-rtcinsertablestreams-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcinsertablestreams-readable" class="dfn-panel" data-for="dom-rtcinsertablestreams-readable" id="infopanel-for-dom-rtcinsertablestreams-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcinsertablestreams-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-rtcinsertablestreams-readable">#dom-rtcinsertablestreams-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcinsertablestreams-readable">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcinsertablestreams-writable">
-   <b><a href="#dom-rtcinsertablestreams-writable">#dom-rtcinsertablestreams-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcinsertablestreams-writable" class="dfn-panel" data-for="dom-rtcinsertablestreams-writable" id="infopanel-for-dom-rtcinsertablestreams-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcinsertablestreams-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-rtcinsertablestreams-writable">#dom-rtcinsertablestreams-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcinsertablestreams-writable">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcconfiguration-encodedinsertablestreams">
-   <b><a href="#dom-rtcconfiguration-encodedinsertablestreams">#dom-rtcconfiguration-encodedinsertablestreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcconfiguration-encodedinsertablestreams" class="dfn-panel" data-for="dom-rtcconfiguration-encodedinsertablestreams" id="infopanel-for-dom-rtcconfiguration-encodedinsertablestreams" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcconfiguration-encodedinsertablestreams" style="display:none">Info about the 'encodedInsertableStreams' definition.</span><b><a href="#dom-rtcconfiguration-encodedinsertablestreams">#dom-rtcconfiguration-encodedinsertablestreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcconfiguration-encodedinsertablestreams">3.1.1. Stream creation</a> <a href="#ref-for-dom-rtcconfiguration-encodedinsertablestreams①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-rtcrtptransform">
-   <b><a href="#typedefdef-rtcrtptransform">#typedefdef-rtcrtptransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-rtcrtptransform" class="dfn-panel" data-for="typedefdef-rtcrtptransform" id="infopanel-for-typedefdef-rtcrtptransform" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-rtcrtptransform" style="display:none">Info about the 'RTCRtpTransform' definition.</span><b><a href="#typedefdef-rtcrtptransform">#typedefdef-rtcrtptransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-rtcrtptransform">3. Specification</a> <a href="#ref-for-typedefdef-rtcrtptransform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpsender-createencodedstreams">
-   <b><a href="#dom-rtcrtpsender-createencodedstreams">#dom-rtcrtpsender-createencodedstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpsender-createencodedstreams" class="dfn-panel" data-for="dom-rtcrtpsender-createencodedstreams" id="infopanel-for-dom-rtcrtpsender-createencodedstreams" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpsender-createencodedstreams" style="display:none">Info about the 'createEncodedStreams()' definition.</span><b><a href="#dom-rtcrtpsender-createencodedstreams">#dom-rtcrtpsender-createencodedstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpsender-createencodedstreams">3. Specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readencodeddata">
-   <b><a href="#readencodeddata">#readencodeddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readencodeddata" class="dfn-panel" data-for="readencodeddata" id="infopanel-for-readencodeddata" role="dialog">
+   <span id="infopaneltitle-for-readencodeddata" style="display:none">Info about the 'readEncodedData' definition.</span><b><a href="#readencodeddata">#readencodeddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readencodeddata">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writeencodeddata">
-   <b><a href="#writeencodeddata">#writeencodeddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writeencodeddata" class="dfn-panel" data-for="writeencodeddata" id="infopanel-for-writeencodeddata" role="dialog">
+   <span id="infopaneltitle-for-writeencodeddata" style="display:none">Info about the 'writeEncodedData' definition.</span><b><a href="#writeencodeddata">#writeencodeddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writeencodeddata">3.1.1. Stream creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpsender-transform">
-   <b><a href="#dom-rtcrtpsender-transform">#dom-rtcrtpsender-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpsender-transform" class="dfn-panel" data-for="dom-rtcrtpsender-transform" id="infopanel-for-dom-rtcrtpsender-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpsender-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#dom-rtcrtpsender-transform">#dom-rtcrtpsender-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpsender-transform">3. Specification</a> <a href="#ref-for-dom-rtcrtpsender-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="chain-transform-algorithm">
-   <b><a href="#chain-transform-algorithm">#chain-transform-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-chain-transform-algorithm" class="dfn-panel" data-for="chain-transform-algorithm" id="infopanel-for-chain-transform-algorithm" role="dialog">
+   <span id="infopaneltitle-for-chain-transform-algorithm" style="display:none">Info about the 'chain transform algorithm' definition.</span><b><a href="#chain-transform-algorithm">#chain-transform-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chain-transform-algorithm">3.2. Extension attribute</a> <a href="#ref-for-chain-transform-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-sframetransformrole">
-   <b><a href="#enumdef-sframetransformrole">#enumdef-sframetransformrole</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-sframetransformrole" class="dfn-panel" data-for="enumdef-sframetransformrole" id="infopanel-for-enumdef-sframetransformrole" role="dialog">
+   <span id="infopaneltitle-for-enumdef-sframetransformrole" style="display:none">Info about the 'SFrameTransformRole' definition.</span><b><a href="#enumdef-sframetransformrole">#enumdef-sframetransformrole</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-sframetransformrole">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-sframetransformoptions">
-   <b><a href="#dictdef-sframetransformoptions">#dictdef-sframetransformoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-sframetransformoptions" class="dfn-panel" data-for="dictdef-sframetransformoptions" id="infopanel-for-dictdef-sframetransformoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-sframetransformoptions" style="display:none">Info about the 'SFrameTransformOptions' definition.</span><b><a href="#dictdef-sframetransformoptions">#dictdef-sframetransformoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sframetransformoptions">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sframetransformoptions-role">
-   <b><a href="#dom-sframetransformoptions-role">#dom-sframetransformoptions-role</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sframetransformoptions-role" class="dfn-panel" data-for="dom-sframetransformoptions-role" id="infopanel-for-dom-sframetransformoptions-role" role="dialog">
+   <span id="infopaneltitle-for-dom-sframetransformoptions-role" style="display:none">Info about the 'role' definition.</span><b><a href="#dom-sframetransformoptions-role">#dom-sframetransformoptions-role</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sframetransformoptions-role">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-smallcryptokeyid">
-   <b><a href="#typedefdef-smallcryptokeyid">#typedefdef-smallcryptokeyid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-smallcryptokeyid" class="dfn-panel" data-for="typedefdef-smallcryptokeyid" id="infopanel-for-typedefdef-smallcryptokeyid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-smallcryptokeyid" style="display:none">Info about the 'SmallCryptoKeyID' definition.</span><b><a href="#typedefdef-smallcryptokeyid">#typedefdef-smallcryptokeyid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-smallcryptokeyid">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-cryptokeyid">
-   <b><a href="#typedefdef-cryptokeyid">#typedefdef-cryptokeyid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-cryptokeyid" class="dfn-panel" data-for="typedefdef-cryptokeyid" id="infopanel-for-typedefdef-cryptokeyid" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-cryptokeyid" style="display:none">Info about the 'CryptoKeyID' definition.</span><b><a href="#typedefdef-cryptokeyid">#typedefdef-cryptokeyid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-cryptokeyid">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sframetransform">
-   <b><a href="#sframetransform">#sframetransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sframetransform" class="dfn-panel" data-for="sframetransform" id="infopanel-for-sframetransform" role="dialog">
+   <span id="infopaneltitle-for-sframetransform" style="display:none">Info about the 'SFrameTransform' definition.</span><b><a href="#sframetransform">#sframetransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sframetransform">3. Specification</a>
     <li><a href="#ref-for-sframetransform①">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sframetransform-sframetransform">
-   <b><a href="#dom-sframetransform-sframetransform">#dom-sframetransform-sframetransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sframetransform-sframetransform" class="dfn-panel" data-for="dom-sframetransform-sframetransform" id="infopanel-for-dom-sframetransform-sframetransform" role="dialog">
+   <span id="infopaneltitle-for-dom-sframetransform-sframetransform" style="display:none">Info about the 'new SFrameTransform(options)' definition.</span><b><a href="#dom-sframetransform-sframetransform">#dom-sframetransform-sframetransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sframetransform-sframetransform">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sframetransform-setencryptionkey">
-   <b><a href="#dom-sframetransform-setencryptionkey">#dom-sframetransform-setencryptionkey</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sframetransform-setencryptionkey" class="dfn-panel" data-for="dom-sframetransform-setencryptionkey" id="infopanel-for-dom-sframetransform-setencryptionkey" role="dialog">
+   <span id="infopaneltitle-for-dom-sframetransform-setencryptionkey" style="display:none">Info about the 'setEncryptionKey(key, keyID)' definition.</span><b><a href="#dom-sframetransform-setencryptionkey">#dom-sframetransform-setencryptionkey</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sframetransform-setencryptionkey">4. SFrameTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-rtcencodedvideoframetype">
-   <b><a href="#enumdef-rtcencodedvideoframetype">#enumdef-rtcencodedvideoframetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-rtcencodedvideoframetype" class="dfn-panel" data-for="enumdef-rtcencodedvideoframetype" id="infopanel-for-enumdef-rtcencodedvideoframetype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-rtcencodedvideoframetype" style="display:none">Info about the 'RTCEncodedVideoFrameType' definition.</span><b><a href="#enumdef-rtcencodedvideoframetype">#enumdef-rtcencodedvideoframetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-rtcencodedvideoframetype">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-rtcencodedvideoframemetadata">
-   <b><a href="#dictdef-rtcencodedvideoframemetadata">#dictdef-rtcencodedvideoframemetadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-rtcencodedvideoframemetadata" class="dfn-panel" data-for="dictdef-rtcencodedvideoframemetadata" id="infopanel-for-dictdef-rtcencodedvideoframemetadata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-rtcencodedvideoframemetadata" style="display:none">Info about the 'RTCEncodedVideoFrameMetadata' definition.</span><b><a href="#dictdef-rtcencodedvideoframemetadata">#dictdef-rtcencodedvideoframemetadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-rtcencodedvideoframemetadata">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rtcencodedvideoframe">
-   <b><a href="#rtcencodedvideoframe">#rtcencodedvideoframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rtcencodedvideoframe" class="dfn-panel" data-for="rtcencodedvideoframe" id="infopanel-for-rtcencodedvideoframe" role="dialog">
+   <span id="infopaneltitle-for-rtcencodedvideoframe" style="display:none">Info about the 'RTCEncodedVideoFrame' definition.</span><b><a href="#rtcencodedvideoframe">#rtcencodedvideoframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtcencodedvideoframe">4.1. Algorithm</a> <a href="#ref-for-rtcencodedvideoframe①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcencodedvideoframe-timestamp">
-   <b><a href="#dom-rtcencodedvideoframe-timestamp">#dom-rtcencodedvideoframe-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcencodedvideoframe-timestamp" class="dfn-panel" data-for="dom-rtcencodedvideoframe-timestamp" id="infopanel-for-dom-rtcencodedvideoframe-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcencodedvideoframe-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#dom-rtcencodedvideoframe-timestamp">#dom-rtcencodedvideoframe-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcencodedvideoframe-timestamp">3.1.2. Stream processing</a> <a href="#ref-for-dom-rtcencodedvideoframe-timestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcencodedvideoframe-data">
-   <b><a href="#dom-rtcencodedvideoframe-data">#dom-rtcencodedvideoframe-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcencodedvideoframe-data" class="dfn-panel" data-for="dom-rtcencodedvideoframe-data" id="infopanel-for-dom-rtcencodedvideoframe-data" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcencodedvideoframe-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-rtcencodedvideoframe-data">#dom-rtcencodedvideoframe-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcencodedvideoframe-data">4.1. Algorithm</a> <a href="#ref-for-dom-rtcencodedvideoframe-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-rtcencodedaudioframemetadata">
-   <b><a href="#dictdef-rtcencodedaudioframemetadata">#dictdef-rtcencodedaudioframemetadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-rtcencodedaudioframemetadata" class="dfn-panel" data-for="dictdef-rtcencodedaudioframemetadata" id="infopanel-for-dictdef-rtcencodedaudioframemetadata" role="dialog">
+   <span id="infopaneltitle-for-dictdef-rtcencodedaudioframemetadata" style="display:none">Info about the 'RTCEncodedAudioFrameMetadata' definition.</span><b><a href="#dictdef-rtcencodedaudioframemetadata">#dictdef-rtcencodedaudioframemetadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-rtcencodedaudioframemetadata">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rtcencodedaudioframe">
-   <b><a href="#rtcencodedaudioframe">#rtcencodedaudioframe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rtcencodedaudioframe" class="dfn-panel" data-for="rtcencodedaudioframe" id="infopanel-for-rtcencodedaudioframe" role="dialog">
+   <span id="infopaneltitle-for-rtcencodedaudioframe" style="display:none">Info about the 'RTCEncodedAudioFrame' definition.</span><b><a href="#rtcencodedaudioframe">#rtcencodedaudioframe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtcencodedaudioframe">4.1. Algorithm</a> <a href="#ref-for-rtcencodedaudioframe①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcencodedaudioframe-data">
-   <b><a href="#dom-rtcencodedaudioframe-data">#dom-rtcencodedaudioframe-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcencodedaudioframe-data" class="dfn-panel" data-for="dom-rtcencodedaudioframe-data" id="infopanel-for-dom-rtcencodedaudioframe-data" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcencodedaudioframe-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-rtcencodedaudioframe-data">#dom-rtcencodedaudioframe-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcencodedaudioframe-data">4.1. Algorithm</a> <a href="#ref-for-dom-rtcencodedaudioframe-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rtctransformevent">
-   <b><a href="#rtctransformevent">#rtctransformevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rtctransformevent" class="dfn-panel" data-for="rtctransformevent" id="infopanel-for-rtctransformevent" role="dialog">
+   <span id="infopaneltitle-for-rtctransformevent" style="display:none">Info about the 'RTCTransformEvent' definition.</span><b><a href="#rtctransformevent">#rtctransformevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtctransformevent">5.1. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rtcrtpscripttransformer">
-   <b><a href="#rtcrtpscripttransformer">#rtcrtpscripttransformer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rtcrtpscripttransformer" class="dfn-panel" data-for="rtcrtpscripttransformer" id="infopanel-for-rtcrtpscripttransformer" role="dialog">
+   <span id="infopaneltitle-for-rtcrtpscripttransformer" style="display:none">Info about the 'RTCRtpScriptTransformer' definition.</span><b><a href="#rtcrtpscripttransformer">#rtcrtpscripttransformer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtcrtpscripttransformer">5. RTCRtpScriptTransform</a>
     <li><a href="#ref-for-rtcrtpscripttransformer①">5.1. Operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rtcrtpscripttransform">
-   <b><a href="#rtcrtpscripttransform">#rtcrtpscripttransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rtcrtpscripttransform" class="dfn-panel" data-for="rtcrtpscripttransform" id="infopanel-for-rtcrtpscripttransform" role="dialog">
+   <span id="infopaneltitle-for-rtcrtpscripttransform" style="display:none">Info about the 'RTCRtpScriptTransform' definition.</span><b><a href="#rtcrtpscripttransform">#rtcrtpscripttransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rtcrtpscripttransform">3. Specification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpscripttransform-rtcrtpscripttransform">
-   <b><a href="#dom-rtcrtpscripttransform-rtcrtpscripttransform">#dom-rtcrtpscripttransform-rtcrtpscripttransform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpscripttransform-rtcrtpscripttransform" class="dfn-panel" data-for="dom-rtcrtpscripttransform-rtcrtpscripttransform" id="infopanel-for-dom-rtcrtpscripttransform-rtcrtpscripttransform" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpscripttransform-rtcrtpscripttransform" style="display:none">Info about the 'new RTCRtpScriptTransform(worker, options, transfer)' definition.</span><b><a href="#dom-rtcrtpscripttransform-rtcrtpscripttransform">#dom-rtcrtpscripttransform-rtcrtpscripttransform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpscripttransform-rtcrtpscripttransform">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpscripttransformer-options">
-   <b><a href="#dom-rtcrtpscripttransformer-options">#dom-rtcrtpscripttransformer-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpscripttransformer-options" class="dfn-panel" data-for="dom-rtcrtpscripttransformer-options" id="infopanel-for-dom-rtcrtpscripttransformer-options" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpscripttransformer-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-rtcrtpscripttransformer-options">#dom-rtcrtpscripttransformer-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpscripttransformer-options">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpscripttransformer-readable">
-   <b><a href="#dom-rtcrtpscripttransformer-readable">#dom-rtcrtpscripttransformer-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpscripttransformer-readable" class="dfn-panel" data-for="dom-rtcrtpscripttransformer-readable" id="infopanel-for-dom-rtcrtpscripttransformer-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpscripttransformer-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-rtcrtpscripttransformer-readable">#dom-rtcrtpscripttransformer-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpscripttransformer-readable">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpscripttransformer-writable">
-   <b><a href="#dom-rtcrtpscripttransformer-writable">#dom-rtcrtpscripttransformer-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpscripttransformer-writable" class="dfn-panel" data-for="dom-rtcrtpscripttransformer-writable" id="infopanel-for-dom-rtcrtpscripttransformer-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpscripttransformer-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-rtcrtpscripttransformer-writable">#dom-rtcrtpscripttransformer-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpscripttransformer-writable">5. RTCRtpScriptTransform</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webrtc-priority/index.html
+++ b/tests/github/w3c/webrtc-priority/index.html
@@ -881,29 +881,29 @@ WebRTC) will prevent network overload in most cases.</p>
    <li><a href="#dom-rtcprioritytype-very-low">"very-low"</a><span>, in § 3.1</span>
    <li><a href="#dom-rtcprioritytype-very-low">very-low</a><span>, in § 3.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdatachannel">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel">https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdatachannel" class="dfn-panel" data-for="term-for-dom-rtcdatachannel" id="infopanel-for-term-for-dom-rtcdatachannel" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdatachannel" style="display:none">Info about the 'RTCDataChannel' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel">https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdatachannel">4. Extensions for RTCDataChannel</a>
     <li><a href="#ref-for-dom-rtcdatachannel①">4.1. New RTCDataChannel attribute</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdatachannelinit">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit">https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdatachannelinit" class="dfn-panel" data-for="term-for-dom-rtcdatachannelinit" id="infopanel-for-term-for-dom-rtcdatachannelinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdatachannelinit" style="display:none">Info about the 'RTCDataChannelInit' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit">https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdatachannelinit">4. Extensions for RTCDataChannel</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcrtpencodingparameters">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters">https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcrtpencodingparameters" class="dfn-panel" data-for="term-for-dom-rtcrtpencodingparameters" id="infopanel-for-term-for-dom-rtcrtpencodingparameters" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcrtpencodingparameters" style="display:none">Info about the 'RTCRtpEncodingParameters' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters">https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpencodingparameters">1. Introduction</a> <a href="#ref-for-dom-rtcrtpencodingparameters①">(2)</a>
     <li><a href="#ref-for-dom-rtcrtpencodingparameters②">2. Priority and QoS Model</a>
     <li><a href="#ref-for-dom-rtcrtpencodingparameters③">3.2. Extension to RTCRtpEncodingParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcrtpsender">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender">https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcrtpsender" class="dfn-panel" data-for="term-for-dom-rtcrtpsender" id="infopanel-for-term-for-dom-rtcrtpsender" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcrtpsender" style="display:none">Info about the 'RTCRtpSender' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender">https://w3c.github.io/webrtc-pc/#dom-rtcrtpsender</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpsender">3.2. Extension to RTCRtpEncodingParameters</a> <a href="#ref-for-dom-rtcrtpsender①">(2)</a> <a href="#ref-for-dom-rtcrtpsender②">(3)</a>
    </ul>
@@ -956,8 +956,8 @@ WebRTC) will prevent network overload in most cases.</p>
 
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-rtcprioritytype">
-   <b><a href="#enumdef-rtcprioritytype">#enumdef-rtcprioritytype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-rtcprioritytype" class="dfn-panel" data-for="enumdef-rtcprioritytype" id="infopanel-for-enumdef-rtcprioritytype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-rtcprioritytype" style="display:none">Info about the 'RTCPriorityType' definition.</span><b><a href="#enumdef-rtcprioritytype">#enumdef-rtcprioritytype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-rtcprioritytype">3.2. Extension to RTCRtpEncodingParameters</a> <a href="#ref-for-enumdef-rtcprioritytype①">(2)</a> <a href="#ref-for-enumdef-rtcprioritytype②">(3)</a> <a href="#ref-for-enumdef-rtcprioritytype③">(4)</a>
     <li><a href="#ref-for-enumdef-rtcprioritytype④">4. Extensions for RTCDataChannel</a> <a href="#ref-for-enumdef-rtcprioritytype⑤">(2)</a>
@@ -966,114 +966,170 @@ WebRTC) will prevent network overload in most cases.</p>
     <li><a href="#ref-for-enumdef-rtcprioritytype⑧">4.3. RTCDataChannel processing steps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcprioritytype-very-low">
-   <b><a href="#dom-rtcprioritytype-very-low">#dom-rtcprioritytype-very-low</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcprioritytype-very-low" class="dfn-panel" data-for="dom-rtcprioritytype-very-low" id="infopanel-for-dom-rtcprioritytype-very-low" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcprioritytype-very-low" style="display:none">Info about the 'very-low' definition.</span><b><a href="#dom-rtcprioritytype-very-low">#dom-rtcprioritytype-very-low</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcprioritytype-very-low">3.1. RTCPriorityType Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcprioritytype-low">
-   <b><a href="#dom-rtcprioritytype-low">#dom-rtcprioritytype-low</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcprioritytype-low" class="dfn-panel" data-for="dom-rtcprioritytype-low" id="infopanel-for-dom-rtcprioritytype-low" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcprioritytype-low" style="display:none">Info about the 'low' definition.</span><b><a href="#dom-rtcprioritytype-low">#dom-rtcprioritytype-low</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcprioritytype-low">3.1. RTCPriorityType Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcprioritytype-medium">
-   <b><a href="#dom-rtcprioritytype-medium">#dom-rtcprioritytype-medium</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcprioritytype-medium" class="dfn-panel" data-for="dom-rtcprioritytype-medium" id="infopanel-for-dom-rtcprioritytype-medium" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcprioritytype-medium" style="display:none">Info about the 'medium' definition.</span><b><a href="#dom-rtcprioritytype-medium">#dom-rtcprioritytype-medium</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcprioritytype-medium">3.1. RTCPriorityType Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcprioritytype-high">
-   <b><a href="#dom-rtcprioritytype-high">#dom-rtcprioritytype-high</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcprioritytype-high" class="dfn-panel" data-for="dom-rtcprioritytype-high" id="infopanel-for-dom-rtcprioritytype-high" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcprioritytype-high" style="display:none">Info about the 'high' definition.</span><b><a href="#dom-rtcprioritytype-high">#dom-rtcprioritytype-high</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcprioritytype-high">3.1. RTCPriorityType Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpencodingparameters-priority">
-   <b><a href="#dom-rtcrtpencodingparameters-priority">#dom-rtcrtpencodingparameters-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpencodingparameters-priority" class="dfn-panel" data-for="dom-rtcrtpencodingparameters-priority" id="infopanel-for-dom-rtcrtpencodingparameters-priority" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpencodingparameters-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#dom-rtcrtpencodingparameters-priority">#dom-rtcrtpencodingparameters-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpencodingparameters-priority">3.2. Extension to RTCRtpEncodingParameters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcrtpencodingparameters-networkpriority">
-   <b><a href="#dom-rtcrtpencodingparameters-networkpriority">#dom-rtcrtpencodingparameters-networkpriority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcrtpencodingparameters-networkpriority" class="dfn-panel" data-for="dom-rtcrtpencodingparameters-networkpriority" id="infopanel-for-dom-rtcrtpencodingparameters-networkpriority" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcrtpencodingparameters-networkpriority" style="display:none">Info about the 'networkPriority' definition.</span><b><a href="#dom-rtcrtpencodingparameters-networkpriority">#dom-rtcrtpencodingparameters-networkpriority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcrtpencodingparameters-networkpriority">3.2. Extension to RTCRtpEncodingParameters</a> <a href="#ref-for-dom-rtcrtpencodingparameters-networkpriority①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcdatachannel-priority">
-   <b><a href="#dom-rtcdatachannel-priority">#dom-rtcdatachannel-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcdatachannel-priority" class="dfn-panel" data-for="dom-rtcdatachannel-priority" id="infopanel-for-dom-rtcdatachannel-priority" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcdatachannel-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#dom-rtcdatachannel-priority">#dom-rtcdatachannel-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdatachannel-priority">3.2. Extension to RTCRtpEncodingParameters</a> <a href="#ref-for-dom-rtcdatachannel-priority①">(2)</a>
     <li><a href="#ref-for-dom-rtcdatachannel-priority②">4. Extensions for RTCDataChannel</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-rtcdatachannelinit-priority">
-   <b><a href="#dom-rtcdatachannelinit-priority">#dom-rtcdatachannelinit-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-rtcdatachannelinit-priority" class="dfn-panel" data-for="dom-rtcdatachannelinit-priority" id="infopanel-for-dom-rtcdatachannelinit-priority" role="dialog">
+   <span id="infopaneltitle-for-dom-rtcdatachannelinit-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#dom-rtcdatachannelinit-priority">#dom-rtcdatachannelinit-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdatachannelinit-priority">4. Extensions for RTCDataChannel</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datachannelpriority">
-   <b><a href="#datachannelpriority">#datachannelpriority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datachannelpriority" class="dfn-panel" data-for="datachannelpriority" id="infopanel-for-datachannelpriority" role="dialog">
+   <span id="infopaneltitle-for-datachannelpriority" style="display:none">Info about the '[[DataChannelPriority]]' definition.</span><b><a href="#datachannelpriority">#datachannelpriority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datachannelpriority">4.3. RTCDataChannel processing steps</a> <a href="#ref-for-datachannelpriority①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3c/webtransport/index.html
+++ b/tests/github/w3c/webtransport/index.html
@@ -2135,14 +2135,14 @@ and has been adapted for use in this specification.</p>
    <li><a href="#writedatagrams">writeDatagrams</a><span>, in § 6.2</span>
    <li><a href="#dom-sendstream-writingaborted">writingAborted</a><span>, in § 9.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects" style="display:none">Info about the 'fulfilled' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. Terminology</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a> <a href="#ref-for-sec-promise-objects③">(4)</a> <a href="#ref-for-sec-promise-objects④">(5)</a>
     <li><a href="#ref-for-sec-promise-objects⑤">4.1. Methods</a> <a href="#ref-for-sec-promise-objects⑥">(2)</a> <a href="#ref-for-sec-promise-objects⑦">(3)</a> <a href="#ref-for-sec-promise-objects⑧">(4)</a>
@@ -2154,8 +2154,8 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects②⓪">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects①" style="display:none">Info about the 'pending' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. Terminology</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a> <a href="#ref-for-sec-promise-objects③">(4)</a> <a href="#ref-for-sec-promise-objects④">(5)</a>
     <li><a href="#ref-for-sec-promise-objects⑤">4.1. Methods</a> <a href="#ref-for-sec-promise-objects⑥">(2)</a> <a href="#ref-for-sec-promise-objects⑦">(3)</a> <a href="#ref-for-sec-promise-objects⑧">(4)</a>
@@ -2167,8 +2167,8 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects②⓪">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects②" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects②" style="display:none">Info about the 'rejected' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. Terminology</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a> <a href="#ref-for-sec-promise-objects③">(4)</a> <a href="#ref-for-sec-promise-objects④">(5)</a>
     <li><a href="#ref-for-sec-promise-objects⑤">4.1. Methods</a> <a href="#ref-for-sec-promise-objects⑥">(2)</a> <a href="#ref-for-sec-promise-objects⑦">(3)</a> <a href="#ref-for-sec-promise-objects⑧">(4)</a>
@@ -2180,8 +2180,8 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects②⓪">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects③" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects③" style="display:none">Info about the 'resolved' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. Terminology</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a> <a href="#ref-for-sec-promise-objects③">(4)</a> <a href="#ref-for-sec-promise-objects④">(5)</a>
     <li><a href="#ref-for-sec-promise-objects⑤">4.1. Methods</a> <a href="#ref-for-sec-promise-objects⑥">(2)</a> <a href="#ref-for-sec-promise-objects⑦">(3)</a> <a href="#ref-for-sec-promise-objects⑧">(4)</a>
@@ -2193,8 +2193,8 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects②⓪">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-promise-objects">
-   <a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-promise-objects" class="dfn-panel" data-for="term-for-sec-promise-objects" id="infopanel-for-term-for-sec-promise-objects④" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-promise-objects④" style="display:none">Info about the 'settled' external reference.</span><a href="http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects">http://www.ecma-international.org/ecma-262/6.0/index.html#sec-promise-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-promise-objects">3. Terminology</a> <a href="#ref-for-sec-promise-objects①">(2)</a> <a href="#ref-for-sec-promise-objects②">(3)</a> <a href="#ref-for-sec-promise-objects③">(4)</a> <a href="#ref-for-sec-promise-objects④">(5)</a>
     <li><a href="#ref-for-sec-promise-objects⑤">4.1. Methods</a> <a href="#ref-for-sec-promise-objects⑥">(2)</a> <a href="#ref-for-sec-promise-objects⑦">(3)</a> <a href="#ref-for-sec-promise-objects⑧">(4)</a>
@@ -2206,82 +2206,82 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-sec-promise-objects②⓪">10.2. Attributes</a> <a href="#ref-for-sec-promise-objects②①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-textdecoderstream">
-   <a href="https://encoding.spec.whatwg.org/#textdecoderstream">https://encoding.spec.whatwg.org/#textdecoderstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-textdecoderstream" class="dfn-panel" data-for="term-for-textdecoderstream" id="infopanel-for-term-for-textdecoderstream" role="menu">
+   <span id="infopaneltitle-for-term-for-textdecoderstream" style="display:none">Info about the 'TextDecoderStream' external reference.</span><a href="https://encoding.spec.whatwg.org/#textdecoderstream">https://encoding.spec.whatwg.org/#textdecoderstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoderstream">14.5. Receiving incoming streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-textencoderstream">
-   <a href="https://encoding.spec.whatwg.org/#textencoderstream">https://encoding.spec.whatwg.org/#textencoderstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-textencoderstream" class="dfn-panel" data-for="term-for-textencoderstream" id="infopanel-for-term-for-textencoderstream" role="menu">
+   <span id="infopaneltitle-for-term-for-textencoderstream" style="display:none">Info about the 'TextEncoderStream' external reference.</span><a href="https://encoding.spec.whatwg.org/#textencoderstream">https://encoding.spec.whatwg.org/#textencoderstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencoderstream">14.4. Sending a stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-connection">
-   <a href="https://fetch.spec.whatwg.org/#concept-connection">https://fetch.spec.whatwg.org/#concept-connection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-connection" class="dfn-panel" data-for="term-for-concept-connection" id="infopanel-for-term-for-concept-connection" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-connection" style="display:none">Info about the 'connection' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-connection">https://fetch.spec.whatwg.org/#concept-connection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection">8.1. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-determine-the-network-partition-key">
-   <a href="https://fetch.spec.whatwg.org/#determine-the-network-partition-key">https://fetch.spec.whatwg.org/#determine-the-network-partition-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-determine-the-network-partition-key" class="dfn-panel" data-for="term-for-determine-the-network-partition-key" id="infopanel-for-term-for-determine-the-network-partition-key" role="menu">
+   <span id="infopaneltitle-for-term-for-determine-the-network-partition-key" style="display:none">Info about the 'determine the network partition key' external reference.</span><a href="https://fetch.spec.whatwg.org/#determine-the-network-partition-key">https://fetch.spec.whatwg.org/#determine-the-network-partition-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-network-partition-key">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-connection-http3only">
-   <a href="https://fetch.spec.whatwg.org/#obtain-a-connection-http3only">https://fetch.spec.whatwg.org/#obtain-a-connection-http3only</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-connection-http3only" class="dfn-panel" data-for="term-for-obtain-a-connection-http3only" id="infopanel-for-term-for-obtain-a-connection-http3only" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-connection-http3only" style="display:none">Info about the 'http3only' external reference.</span><a href="https://fetch.spec.whatwg.org/#obtain-a-connection-http3only">https://fetch.spec.whatwg.org/#obtain-a-connection-http3only</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-connection-http3only">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-connection-obtain">
-   <a href="https://fetch.spec.whatwg.org/#concept-connection-obtain">https://fetch.spec.whatwg.org/#concept-connection-obtain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-connection-obtain" class="dfn-panel" data-for="term-for-concept-connection-obtain" id="infopanel-for-term-for-concept-connection-obtain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-connection-obtain" style="display:none">Info about the 'obtain a connection' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-connection-obtain">https://fetch.spec.whatwg.org/#concept-connection-obtain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection-obtain">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">8.8. WebTransportStats Dictionary</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a> <a href="#ref-for-dom-domhighrestimestamp②">(3)</a> <a href="#ref-for-dom-domhighrestimestamp③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-errorevent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-errorevent" class="dfn-panel" data-for="term-for-errorevent" id="infopanel-for-term-for-errorevent" role="menu">
+   <span id="infopaneltitle-for-term-for-errorevent" style="display:none">Info about the 'ErrorEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#errorevent">https://html.spec.whatwg.org/multipage/webappapis.html#errorevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-errorevent">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. Terminology</a>
     <li><a href="#ref-for-eventhandler①">8. WebTransport Interface</a>
     <li><a href="#ref-for-eventhandler②">8.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. Methods</a>
     <li><a href="#ref-for-in-parallel①">5.1. Methods</a>
@@ -2289,75 +2289,75 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-in-parallel③">8.4. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networking-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networking-task-source" class="dfn-panel" data-for="term-for-networking-task-source" id="infopanel-for-term-for-networking-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-networking-task-source" style="display:none">Info about the 'networking task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networking-task-source">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">6.2. Procedures</a>
     <li><a href="#ref-for-implementation-defined①">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url record' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">8.2. Constructor</a> <a href="#ref-for-concept-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">8.7. WebTransportCloseInfo Dictionary</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">9.4. StreamAbortInfo Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7. DatagramDuplexStream Interface</a>
     <li><a href="#ref-for-Exposed①">8. WebTransport Interface</a>
@@ -2366,22 +2366,22 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-Exposed④">11. Interface BidirectionalStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">4.1. Methods</a> <a href="#ref-for-invalidstateerror①">(2)</a>
     <li><a href="#ref-for-invalidstateerror②">5.1. Methods</a> <a href="#ref-for-invalidstateerror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">8.4. Methods</a>
     <li><a href="#ref-for-notsupportederror①">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-idl-promise①">5. BidirectionalStreamsTransport Mixin</a>
@@ -2390,86 +2390,86 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-idl-promise⑥">10. Interface ReceiveStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">8.2. Constructor</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.2. Procedures</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">8.2. Constructor</a> <a href="#ref-for-exceptiondef-typeerror②">(2)</a> <a href="#ref-for-exceptiondef-typeerror③">(3)</a> <a href="#ref-for-exceptiondef-typeerror④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">6.2. Procedures</a>
     <li><a href="#ref-for-idl-Uint8Array①">9. Interface SendStream</a>
     <li><a href="#ref-for-idl-Uint8Array②">10. Interface ReceiveStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">6.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">8.5. Configuration</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">8.1. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">7. DatagramDuplexStream Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-octet">
-   <a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-octet" class="dfn-panel" data-for="term-for-idl-octet" id="infopanel-for-term-for-idl-octet" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-octet" style="display:none">Info about the 'octet' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-octet">9.4. StreamAbortInfo Dictionary</a> <a href="#ref-for-idl-octet①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">6.1. Attributes</a>
     <li><a href="#ref-for-this①">7.1. Attributes</a> <a href="#ref-for-this②">(2)</a>
     <li><a href="#ref-for-this③">8.3. Attributes</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3. Terminology</a>
     <li><a href="#ref-for-dfn-throw①">8.2. Constructor</a> <a href="#ref-for-dfn-throw②">(2)</a> <a href="#ref-for-dfn-throw③">(3)</a> <a href="#ref-for-dfn-throw④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">8. WebTransport Interface</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">8.2. Constructor</a> <a href="#ref-for-idl-undefined③">(2)</a>
@@ -2478,58 +2478,58 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-idl-undefined⑥">10. Interface ReceiveStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">8.8. WebTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a> <a href="#ref-for-idl-unsigned-long④">(5)</a> <a href="#ref-for-idl-unsigned-long⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">8.7. WebTransportCloseInfo Dictionary</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long-long②">8.8. WebTransportStats Dictionary</a> <a href="#ref-for-idl-unsigned-long-long③">(2)</a> <a href="#ref-for-idl-unsigned-long-long④">(3)</a> <a href="#ref-for-idl-unsigned-long-long⑤">(4)</a> <a href="#ref-for-idl-unsigned-long-long⑥">(5)</a> <a href="#ref-for-idl-unsigned-long-long⑦">(6)</a> <a href="#ref-for-idl-unsigned-long-long⑧">(7)</a> <a href="#ref-for-idl-unsigned-long-long⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-idl-unsigned-short①">6.1. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint" class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint" id="infopanel-for-term-for-dom-rtcdtlsfingerprint" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint" style="display:none">Info about the 'RTCDtlsFingerprint' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdtlsfingerprint">8.5. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-algorithm">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-algorithm">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint-algorithm" class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-algorithm" id="infopanel-for-term-for-dom-rtcdtlsfingerprint-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint-algorithm" style="display:none">Info about the 'algorithm' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-algorithm">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdtlsfingerprint-algorithm">8.5. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-value">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-value">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint-value" class="dfn-panel" data-for="term-for-dom-rtcdtlsfingerprint-value" id="infopanel-for-term-for-dom-rtcdtlsfingerprint-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdtlsfingerprint-value" style="display:none">Info about the 'value' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-value">https://w3c.github.io/webrtc-pc/#dom-rtcdtlsfingerprint-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdtlsfingerprint-value">8.5. Configuration</a> <a href="#ref-for-dom-rtcdtlsfingerprint-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">3. Terminology</a>
     <li><a href="#ref-for-readablestream①">4. UnidirectionalStreamsTransport Mixin</a>
@@ -2547,8 +2547,8 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-readablestream②②">14.4. Sending a stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writablestream">
-   <a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writablestream" class="dfn-panel" data-for="term-for-writablestream" id="infopanel-for-term-for-writablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-writablestream" style="display:none">Info about the 'WritableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#writablestream">https://streams.spec.whatwg.org/#writablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">3. Terminology</a>
     <li><a href="#ref-for-writablestream①">6.1. Attributes</a>
@@ -2560,20 +2560,20 @@ and has been adapted for use in this specification.</p>
     <li><a href="#ref-for-writablestream⑧">9.1. Overview</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">6.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-high-water-mark">
-   <a href="https://streams.spec.whatwg.org/#high-water-mark">https://streams.spec.whatwg.org/#high-water-mark</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-high-water-mark" class="dfn-panel" data-for="term-for-high-water-mark" id="infopanel-for-term-for-high-water-mark" role="menu">
+   <span id="infopaneltitle-for-term-for-high-water-mark" style="display:none">Info about the 'high water mark' external reference.</span><a href="https://streams.spec.whatwg.org/#high-water-mark">https://streams.spec.whatwg.org/#high-water-mark</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-water-mark">8.1. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-writer-ready">
-   <a href="https://streams.spec.whatwg.org/#default-writer-ready">https://streams.spec.whatwg.org/#default-writer-ready</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-writer-ready" class="dfn-panel" data-for="term-for-default-writer-ready" id="infopanel-for-term-for-default-writer-ready" role="menu">
+   <span id="infopaneltitle-for-term-for-default-writer-ready" style="display:none">Info about the 'ready' external reference.</span><a href="https://streams.spec.whatwg.org/#default-writer-ready">https://streams.spec.whatwg.org/#default-writer-ready</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-ready">6.2. Procedures</a>
    </ul>
@@ -2840,84 +2840,84 @@ revised. Some of those are safe to expose for HTTP/2 and HTTP/3 connections
 (like min-RTT), while most would either result in information disclosure
 or are impossible to define for pooled connections. <a class="issue-return" href="#issue-29939a8a" title="Jump to section">↵</a></div>
   </div>
-  <aside class="dfn-panel" data-for="unidirectionalstreamstransport">
-   <b><a href="#unidirectionalstreamstransport">#unidirectionalstreamstransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unidirectionalstreamstransport" class="dfn-panel" data-for="unidirectionalstreamstransport" id="infopanel-for-unidirectionalstreamstransport" role="dialog">
+   <span id="infopaneltitle-for-unidirectionalstreamstransport" style="display:none">Info about the 'UnidirectionalStreamsTransport' definition.</span><b><a href="#unidirectionalstreamstransport">#unidirectionalstreamstransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unidirectionalstreamstransport">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-unidirectionalstreamstransport①">8. WebTransport Interface</a> <a href="#ref-for-unidirectionalstreamstransport②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-createunidirectionalstream">
-   <b><a href="#dom-unidirectionalstreamstransport-createunidirectionalstream">#dom-unidirectionalstreamstransport-createunidirectionalstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-unidirectionalstreamstransport-createunidirectionalstream" class="dfn-panel" data-for="dom-unidirectionalstreamstransport-createunidirectionalstream" id="infopanel-for-dom-unidirectionalstreamstransport-createunidirectionalstream" role="dialog">
+   <span id="infopaneltitle-for-dom-unidirectionalstreamstransport-createunidirectionalstream" style="display:none">Info about the 'createUnidirectionalStream()' definition.</span><b><a href="#dom-unidirectionalstreamstransport-createunidirectionalstream">#dom-unidirectionalstreamstransport-createunidirectionalstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-unidirectionalstreamstransport-createunidirectionalstream">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-dom-unidirectionalstreamstransport-createunidirectionalstream①">14.4. Sending a stream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-unidirectionalstreamstransport-incomingunidirectionalstreams">
-   <b><a href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams">#dom-unidirectionalstreamstransport-incomingunidirectionalstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams" class="dfn-panel" data-for="dom-unidirectionalstreamstransport-incomingunidirectionalstreams" id="infopanel-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams" role="dialog">
+   <span id="infopaneltitle-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams" style="display:none">Info about the 'incomingUnidirectionalStreams' definition.</span><b><a href="#dom-unidirectionalstreamstransport-incomingunidirectionalstreams">#dom-unidirectionalstreamstransport-incomingunidirectionalstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-dom-unidirectionalstreamstransport-incomingunidirectionalstreams①">14.5. Receiving incoming streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sendstream-create">
-   <b><a href="#sendstream-create">#sendstream-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sendstream-create" class="dfn-panel" data-for="sendstream-create" id="infopanel-for-sendstream-create" role="dialog">
+   <span id="infopaneltitle-for-sendstream-create" style="display:none">Info about the 'create' definition.</span><b><a href="#sendstream-create">#sendstream-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sendstream-create">4.1. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-sendstreamparameters">
-   <b><a href="#dictdef-sendstreamparameters">#dictdef-sendstreamparameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-sendstreamparameters" class="dfn-panel" data-for="dictdef-sendstreamparameters" id="infopanel-for-dictdef-sendstreamparameters" role="dialog">
+   <span id="infopaneltitle-for-dictdef-sendstreamparameters" style="display:none">Info about the 'SendStreamParameters' definition.</span><b><a href="#dictdef-sendstreamparameters">#dictdef-sendstreamparameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-sendstreamparameters">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-dictdef-sendstreamparameters①">4.3. SendStreamParameters Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidirectionalstreamstransport">
-   <b><a href="#bidirectionalstreamstransport">#bidirectionalstreamstransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidirectionalstreamstransport" class="dfn-panel" data-for="bidirectionalstreamstransport" id="infopanel-for-bidirectionalstreamstransport" role="dialog">
+   <span id="infopaneltitle-for-bidirectionalstreamstransport" style="display:none">Info about the 'BidirectionalStreamsTransport' definition.</span><b><a href="#bidirectionalstreamstransport">#bidirectionalstreamstransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidirectionalstreamstransport">5. BidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-bidirectionalstreamstransport①">5.1. Methods</a>
     <li><a href="#ref-for-bidirectionalstreamstransport②">8. WebTransport Interface</a> <a href="#ref-for-bidirectionalstreamstransport③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bidirectionalstreamstransport-createbidirectionalstream">
-   <b><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">#dom-bidirectionalstreamstransport-createbidirectionalstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bidirectionalstreamstransport-createbidirectionalstream" class="dfn-panel" data-for="dom-bidirectionalstreamstransport-createbidirectionalstream" id="infopanel-for-dom-bidirectionalstreamstransport-createbidirectionalstream" role="dialog">
+   <span id="infopaneltitle-for-dom-bidirectionalstreamstransport-createbidirectionalstream" style="display:none">Info about the 'createBidirectionalStream()' definition.</span><b><a href="#dom-bidirectionalstreamstransport-createbidirectionalstream">#dom-bidirectionalstreamstransport-createbidirectionalstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream">5. BidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-dom-bidirectionalstreamstransport-createbidirectionalstream①">5.1. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bidirectionalstreamstransport-incomingbidirectionalstreams">
-   <b><a href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams">#dom-bidirectionalstreamstransport-incomingbidirectionalstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams" class="dfn-panel" data-for="dom-bidirectionalstreamstransport-incomingbidirectionalstreams" id="infopanel-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams" role="dialog">
+   <span id="infopaneltitle-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams" style="display:none">Info about the 'incomingBidirectionalStreams' definition.</span><b><a href="#dom-bidirectionalstreamstransport-incomingbidirectionalstreams">#dom-bidirectionalstreamstransport-incomingbidirectionalstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bidirectionalstreamstransport-incomingbidirectionalstreams">5. BidirectionalStreamsTransport Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidirectionalstream-create">
-   <b><a href="#bidirectionalstream-create">#bidirectionalstream-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidirectionalstream-create" class="dfn-panel" data-for="bidirectionalstream-create" id="infopanel-for-bidirectionalstream-create" role="dialog">
+   <span id="infopaneltitle-for-bidirectionalstream-create" style="display:none">Info about the 'create' definition.</span><b><a href="#bidirectionalstream-create">#bidirectionalstream-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidirectionalstream-create">3. Terminology</a>
     <li><a href="#ref-for-bidirectionalstream-create①">5.1. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datagramtransport">
-   <b><a href="#datagramtransport">#datagramtransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datagramtransport" class="dfn-panel" data-for="datagramtransport" id="infopanel-for-datagramtransport" role="dialog">
+   <span id="infopaneltitle-for-datagramtransport" style="display:none">Info about the 'DatagramTransport' definition.</span><b><a href="#datagramtransport">#datagramtransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramtransport">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-datagramtransport①">8. WebTransport Interface</a> <a href="#ref-for-datagramtransport②">(2)</a>
     <li><a href="#ref-for-datagramtransport③">14.1. Sending a buffer of datagrams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramtransport-maxdatagramsize">
-   <b><a href="#dom-datagramtransport-maxdatagramsize">#dom-datagramtransport-maxdatagramsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datagramtransport-maxdatagramsize" class="dfn-panel" data-for="dom-datagramtransport-maxdatagramsize" id="infopanel-for-dom-datagramtransport-maxdatagramsize" role="dialog">
+   <span id="infopaneltitle-for-dom-datagramtransport-maxdatagramsize" style="display:none">Info about the 'maxDatagramSize' definition.</span><b><a href="#dom-datagramtransport-maxdatagramsize">#dom-datagramtransport-maxdatagramsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datagramtransport-maxdatagramsize">6. DatagramTransport Mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramtransport-datagrams">
-   <b><a href="#dom-datagramtransport-datagrams">#dom-datagramtransport-datagrams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datagramtransport-datagrams" class="dfn-panel" data-for="dom-datagramtransport-datagrams" id="infopanel-for-dom-datagramtransport-datagrams" role="dialog">
+   <span id="infopaneltitle-for-dom-datagramtransport-datagrams" style="display:none">Info about the 'datagrams' definition.</span><b><a href="#dom-datagramtransport-datagrams">#dom-datagramtransport-datagrams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datagramtransport-datagrams">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-dom-datagramtransport-datagrams①">6.1. Attributes</a>
@@ -2927,27 +2927,27 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-dom-datagramtransport-datagrams⑤">14.3. Receiving datagrams</a> <a href="#ref-for-dom-datagramtransport-datagrams⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readdatagrams">
-   <b><a href="#readdatagrams">#readdatagrams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readdatagrams" class="dfn-panel" data-for="readdatagrams" id="infopanel-for-readdatagrams" role="dialog">
+   <span id="infopaneltitle-for-readdatagrams" style="display:none">Info about the 'readDatagrams' definition.</span><b><a href="#readdatagrams">#readdatagrams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readdatagrams">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writedatagrams">
-   <b><a href="#writedatagrams">#writedatagrams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writedatagrams" class="dfn-panel" data-for="writedatagrams" id="infopanel-for-writedatagrams" role="dialog">
+   <span id="infopaneltitle-for-writedatagrams" style="display:none">Info about the 'writeDatagrams' definition.</span><b><a href="#writedatagrams">#writedatagrams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writedatagrams">6.2. Procedures</a> <a href="#ref-for-writedatagrams①">(2)</a>
     <li><a href="#ref-for-writedatagrams②">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="senddatagrams">
-   <b><a href="#senddatagrams">#senddatagrams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-senddatagrams" class="dfn-panel" data-for="senddatagrams" id="infopanel-for-senddatagrams" role="dialog">
+   <span id="infopaneltitle-for-senddatagrams" style="display:none">Info about the 'sendDatagrams' definition.</span><b><a href="#senddatagrams">#senddatagrams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-senddatagrams">6.2. Procedures</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datagramduplexstream">
-   <b><a href="#datagramduplexstream">#datagramduplexstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datagramduplexstream" class="dfn-panel" data-for="datagramduplexstream" id="infopanel-for-datagramduplexstream" role="dialog">
+   <span id="infopaneltitle-for-datagramduplexstream" style="display:none">Info about the 'DatagramDuplexStream' definition.</span><b><a href="#datagramduplexstream">#datagramduplexstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramduplexstream">6. DatagramTransport Mixin</a>
     <li><a href="#ref-for-datagramduplexstream①">6.1. Attributes</a>
@@ -2956,34 +2956,34 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-datagramduplexstream⑥">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datagramduplexstream-create">
-   <b><a href="#datagramduplexstream-create">#datagramduplexstream-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datagramduplexstream-create" class="dfn-panel" data-for="datagramduplexstream-create" id="infopanel-for-datagramduplexstream-create" role="dialog">
+   <span id="infopaneltitle-for-datagramduplexstream-create" style="display:none">Info about the 'create' definition.</span><b><a href="#datagramduplexstream-create">#datagramduplexstream-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramduplexstream-create">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datagramduplexstream-create-readable">
-   <b><a href="#datagramduplexstream-create-readable">#datagramduplexstream-create-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datagramduplexstream-create-readable" class="dfn-panel" data-for="datagramduplexstream-create-readable" id="infopanel-for-datagramduplexstream-create-readable" role="dialog">
+   <span id="infopaneltitle-for-datagramduplexstream-create-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#datagramduplexstream-create-readable">#datagramduplexstream-create-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramduplexstream-create-readable">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="datagramduplexstream-create-writable">
-   <b><a href="#datagramduplexstream-create-writable">#datagramduplexstream-create-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-datagramduplexstream-create-writable" class="dfn-panel" data-for="datagramduplexstream-create-writable" id="infopanel-for-datagramduplexstream-create-writable" role="dialog">
+   <span id="infopaneltitle-for-datagramduplexstream-create-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#datagramduplexstream-create-writable">#datagramduplexstream-create-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datagramduplexstream-create-writable">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramduplexstream-readable">
-   <b><a href="#dom-datagramduplexstream-readable">#dom-datagramduplexstream-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datagramduplexstream-readable" class="dfn-panel" data-for="dom-datagramduplexstream-readable" id="infopanel-for-dom-datagramduplexstream-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-datagramduplexstream-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-datagramduplexstream-readable">#dom-datagramduplexstream-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datagramduplexstream-readable">7. DatagramDuplexStream Interface</a>
     <li><a href="#ref-for-dom-datagramduplexstream-readable①">8.8. WebTransportStats Dictionary</a>
     <li><a href="#ref-for-dom-datagramduplexstream-readable②">14.3. Receiving datagrams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-datagramduplexstream-writable">
-   <b><a href="#dom-datagramduplexstream-writable">#dom-datagramduplexstream-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-datagramduplexstream-writable" class="dfn-panel" data-for="dom-datagramduplexstream-writable" id="infopanel-for-dom-datagramduplexstream-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-datagramduplexstream-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-datagramduplexstream-writable">#dom-datagramduplexstream-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-datagramduplexstream-writable">6.1. Attributes</a>
     <li><a href="#ref-for-dom-datagramduplexstream-writable①">7. DatagramDuplexStream Interface</a>
@@ -2991,8 +2991,8 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-dom-datagramduplexstream-writable③">14.2. Sending datagrams at a fixed rate</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport">
-   <b><a href="#webtransport">#webtransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport" class="dfn-panel" data-for="webtransport" id="infopanel-for-webtransport" role="dialog">
+   <span id="infopaneltitle-for-webtransport" style="display:none">Info about the 'WebTransport' definition.</span><b><a href="#webtransport">#webtransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport">6.2. Procedures</a> <a href="#ref-for-webtransport①">(2)</a>
     <li><a href="#ref-for-webtransport②">8. WebTransport Interface</a> <a href="#ref-for-webtransport③">(2)</a> <a href="#ref-for-webtransport④">(3)</a>
@@ -3008,26 +3008,26 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-webtransport②⓪">15. Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-webtransport">
-   <b><a href="#dom-webtransport-webtransport">#dom-webtransport-webtransport</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-webtransport" class="dfn-panel" data-for="dom-webtransport-webtransport" id="infopanel-for-dom-webtransport-webtransport" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-webtransport" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-webtransport-webtransport">#dom-webtransport-webtransport</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-webtransport">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-webtransport-url-options-url">
-   <b><a href="#dom-webtransport-webtransport-url-options-url">#dom-webtransport-webtransport-url-options-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-webtransport-url-options-url" class="dfn-panel" data-for="dom-webtransport-webtransport-url-options-url" id="infopanel-for-dom-webtransport-webtransport-url-options-url" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-webtransport-url-options-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-webtransport-webtransport-url-options-url">#dom-webtransport-webtransport-url-options-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-webtransport-url-options-url">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-webtransport-url-options-options">
-   <b><a href="#dom-webtransport-webtransport-url-options-options">#dom-webtransport-webtransport-url-options-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-webtransport-url-options-options" class="dfn-panel" data-for="dom-webtransport-webtransport-url-options-options" id="infopanel-for-dom-webtransport-webtransport-url-options-options" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-webtransport-url-options-options" style="display:none">Info about the 'options' definition.</span><b><a href="#dom-webtransport-webtransport-url-options-options">#dom-webtransport-webtransport-url-options-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-webtransport-url-options-options">8.2. Constructor</a> <a href="#ref-for-dom-webtransport-webtransport-url-options-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-outgoingstreams">
-   <b><a href="#webtransport-outgoingstreams">#webtransport-outgoingstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-outgoingstreams" class="dfn-panel" data-for="webtransport-outgoingstreams" id="infopanel-for-webtransport-outgoingstreams" role="dialog">
+   <span id="infopaneltitle-for-webtransport-outgoingstreams" style="display:none">Info about the '[[OutgoingStreams]]' definition.</span><b><a href="#webtransport-outgoingstreams">#webtransport-outgoingstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-outgoingstreams">4.2.1. Add SendStream to UnidirectionalStreamsTransport</a>
     <li><a href="#ref-for-webtransport-outgoingstreams①">5.2.1. Add BidirectionalStream to BidirectionalStreamsTransport</a>
@@ -3037,16 +3037,16 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-webtransport-outgoingstreams⑧">9.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-receivedstreams">
-   <b><a href="#webtransport-receivedstreams">#webtransport-receivedstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-receivedstreams" class="dfn-panel" data-for="webtransport-receivedstreams" id="infopanel-for-webtransport-receivedstreams" role="dialog">
+   <span id="infopaneltitle-for-webtransport-receivedstreams" style="display:none">Info about the '[[ReceivedStreams]]' definition.</span><b><a href="#webtransport-receivedstreams">#webtransport-receivedstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-receivedstreams">4.1. Methods</a> <a href="#ref-for-webtransport-receivedstreams①">(2)</a>
     <li><a href="#ref-for-webtransport-receivedstreams②">8.2. Constructor</a>
     <li><a href="#ref-for-webtransport-receivedstreams③">8.6. WebTransportState Enum</a> <a href="#ref-for-webtransport-receivedstreams④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-receivedbidirectionalstreams">
-   <b><a href="#webtransport-receivedbidirectionalstreams">#webtransport-receivedbidirectionalstreams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-receivedbidirectionalstreams" class="dfn-panel" data-for="webtransport-receivedbidirectionalstreams" id="infopanel-for-webtransport-receivedbidirectionalstreams" role="dialog">
+   <span id="infopaneltitle-for-webtransport-receivedbidirectionalstreams" style="display:none">Info about the '[[ReceivedBidirectionalStreams]]' definition.</span><b><a href="#webtransport-receivedbidirectionalstreams">#webtransport-receivedbidirectionalstreams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-receivedbidirectionalstreams">5.1. Methods</a> <a href="#ref-for-webtransport-receivedbidirectionalstreams①">(2)</a>
     <li><a href="#ref-for-webtransport-receivedbidirectionalstreams②">5.2.1. Add BidirectionalStream to BidirectionalStreamsTransport</a>
@@ -3054,8 +3054,8 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-webtransport-receivedbidirectionalstreams④">8.6. WebTransportState Enum</a> <a href="#ref-for-webtransport-receivedbidirectionalstreams⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-state">
-   <b><a href="#webtransport-state">#webtransport-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-state" class="dfn-panel" data-for="webtransport-state" id="infopanel-for-webtransport-state" role="dialog">
+   <span id="infopaneltitle-for-webtransport-state" style="display:none">Info about the '[[State]]' definition.</span><b><a href="#webtransport-state">#webtransport-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-state">6.2. Procedures</a>
     <li><a href="#ref-for-webtransport-state①">8.2. Constructor</a> <a href="#ref-for-webtransport-state②">(2)</a> <a href="#ref-for-webtransport-state③">(3)</a> <a href="#ref-for-webtransport-state④">(4)</a>
@@ -3064,147 +3064,147 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-webtransport-state⑨">8.6. WebTransportState Enum</a> <a href="#ref-for-webtransport-state①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-ready">
-   <b><a href="#webtransport-ready">#webtransport-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-ready" class="dfn-panel" data-for="webtransport-ready" id="infopanel-for-webtransport-ready" role="dialog">
+   <span id="infopaneltitle-for-webtransport-ready" style="display:none">Info about the '[[Ready]]' definition.</span><b><a href="#webtransport-ready">#webtransport-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-ready">8.2. Constructor</a> <a href="#ref-for-webtransport-ready①">(2)</a> <a href="#ref-for-webtransport-ready②">(3)</a>
     <li><a href="#ref-for-webtransport-ready③">8.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-closed">
-   <b><a href="#webtransport-closed">#webtransport-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-closed" class="dfn-panel" data-for="webtransport-closed" id="infopanel-for-webtransport-closed" role="dialog">
+   <span id="infopaneltitle-for-webtransport-closed" style="display:none">Info about the '[[Closed]]' definition.</span><b><a href="#webtransport-closed">#webtransport-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-closed">8.2. Constructor</a> <a href="#ref-for-webtransport-closed①">(2)</a>
     <li><a href="#ref-for-webtransport-closed②">8.3. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-datagrams">
-   <b><a href="#webtransport-datagrams">#webtransport-datagrams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-datagrams" class="dfn-panel" data-for="webtransport-datagrams" id="infopanel-for-webtransport-datagrams" role="dialog">
+   <span id="infopaneltitle-for-webtransport-datagrams" style="display:none">Info about the '[[Datagrams]]' definition.</span><b><a href="#webtransport-datagrams">#webtransport-datagrams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-datagrams">6.1. Attributes</a>
     <li><a href="#ref-for-webtransport-datagrams①">8.2. Constructor</a> <a href="#ref-for-webtransport-datagrams②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-outgoingdatagramsqueue">
-   <b><a href="#webtransport-outgoingdatagramsqueue">#webtransport-outgoingdatagramsqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-outgoingdatagramsqueue" class="dfn-panel" data-for="webtransport-outgoingdatagramsqueue" id="infopanel-for-webtransport-outgoingdatagramsqueue" role="dialog">
+   <span id="infopaneltitle-for-webtransport-outgoingdatagramsqueue" style="display:none">Info about the '[[OutgoingDatagramsQueue]]' definition.</span><b><a href="#webtransport-outgoingdatagramsqueue">#webtransport-outgoingdatagramsqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-outgoingdatagramsqueue">6.2. Procedures</a> <a href="#ref-for-webtransport-outgoingdatagramsqueue①">(2)</a> <a href="#ref-for-webtransport-outgoingdatagramsqueue②">(3)</a>
     <li><a href="#ref-for-webtransport-outgoingdatagramsqueue③">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-outgoingdatagramshighwatermark">
-   <b><a href="#webtransport-outgoingdatagramshighwatermark">#webtransport-outgoingdatagramshighwatermark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-outgoingdatagramshighwatermark" class="dfn-panel" data-for="webtransport-outgoingdatagramshighwatermark" id="infopanel-for-webtransport-outgoingdatagramshighwatermark" role="dialog">
+   <span id="infopaneltitle-for-webtransport-outgoingdatagramshighwatermark" style="display:none">Info about the '[[OutgoingDatagramsHighWaterMark]]' definition.</span><b><a href="#webtransport-outgoingdatagramshighwatermark">#webtransport-outgoingdatagramshighwatermark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-outgoingdatagramshighwatermark">6.2. Procedures</a>
     <li><a href="#ref-for-webtransport-outgoingdatagramshighwatermark①">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-outgoingdatagramsexpirationduration">
-   <b><a href="#webtransport-outgoingdatagramsexpirationduration">#webtransport-outgoingdatagramsexpirationduration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-outgoingdatagramsexpirationduration" class="dfn-panel" data-for="webtransport-outgoingdatagramsexpirationduration" id="infopanel-for-webtransport-outgoingdatagramsexpirationduration" role="dialog">
+   <span id="infopaneltitle-for-webtransport-outgoingdatagramsexpirationduration" style="display:none">Info about the '[[OutgoingDatagramsExpirationDuration]]' definition.</span><b><a href="#webtransport-outgoingdatagramsexpirationduration">#webtransport-outgoingdatagramsexpirationduration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-outgoingdatagramsexpirationduration">6.2. Procedures</a>
     <li><a href="#ref-for-webtransport-outgoingdatagramsexpirationduration①">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webtransport-connection">
-   <b><a href="#webtransport-connection">#webtransport-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webtransport-connection" class="dfn-panel" data-for="webtransport-connection" id="infopanel-for-webtransport-connection" role="dialog">
+   <span id="infopaneltitle-for-webtransport-connection" style="display:none">Info about the '[[Connection]]' definition.</span><b><a href="#webtransport-connection">#webtransport-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webtransport-connection">8.2. Constructor</a> <a href="#ref-for-webtransport-connection①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-webtransport-over-http">
-   <b><a href="#initialize-webtransport-over-http">#initialize-webtransport-over-http</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-webtransport-over-http" class="dfn-panel" data-for="initialize-webtransport-over-http" id="infopanel-for-initialize-webtransport-over-http" role="dialog">
+   <span id="infopaneltitle-for-initialize-webtransport-over-http" style="display:none">Info about the 'initialize WebTransport over HTTP' definition.</span><b><a href="#initialize-webtransport-over-http">#initialize-webtransport-over-http</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-webtransport-over-http">8.2. Constructor</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-state">
-   <b><a href="#dom-webtransport-state">#dom-webtransport-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-state" class="dfn-panel" data-for="dom-webtransport-state" id="infopanel-for-dom-webtransport-state" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-state" style="display:none">Info about the 'state' definition.</span><b><a href="#dom-webtransport-state">#dom-webtransport-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-state">4.1. Methods</a> <a href="#ref-for-dom-webtransport-state①">(2)</a>
     <li><a href="#ref-for-dom-webtransport-state②">5.1. Methods</a> <a href="#ref-for-dom-webtransport-state③">(2)</a>
     <li><a href="#ref-for-dom-webtransport-state④">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-ready">
-   <b><a href="#dom-webtransport-ready">#dom-webtransport-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-ready" class="dfn-panel" data-for="dom-webtransport-ready" id="infopanel-for-dom-webtransport-ready" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#dom-webtransport-ready">#dom-webtransport-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-ready">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-closed">
-   <b><a href="#dom-webtransport-closed">#dom-webtransport-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-closed" class="dfn-panel" data-for="dom-webtransport-closed" id="infopanel-for-dom-webtransport-closed" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-closed" style="display:none">Info about the 'closed' definition.</span><b><a href="#dom-webtransport-closed">#dom-webtransport-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-closed">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-onstatechange">
-   <b><a href="#dom-webtransport-onstatechange">#dom-webtransport-onstatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-onstatechange" class="dfn-panel" data-for="dom-webtransport-onstatechange" id="infopanel-for-dom-webtransport-onstatechange" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-onstatechange" style="display:none">Info about the 'onstatechange' definition.</span><b><a href="#dom-webtransport-onstatechange">#dom-webtransport-onstatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-onstatechange">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-close">
-   <b><a href="#dom-webtransport-close">#dom-webtransport-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-close" class="dfn-panel" data-for="dom-webtransport-close" id="infopanel-for-dom-webtransport-close" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#dom-webtransport-close">#dom-webtransport-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-close">8. WebTransport Interface</a>
     <li><a href="#ref-for-dom-webtransport-close①">8.3. Attributes</a>
     <li><a href="#ref-for-dom-webtransport-close②">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="immediate-close">
-   <b><a href="#immediate-close">#immediate-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-immediate-close" class="dfn-panel" data-for="immediate-close" id="infopanel-for-immediate-close" role="dialog">
+   <span id="infopaneltitle-for-immediate-close" style="display:none">Info about the 'Immediate Close' definition.</span><b><a href="#immediate-close">#immediate-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-immediate-close">8.4. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransport-getstats">
-   <b><a href="#dom-webtransport-getstats">#dom-webtransport-getstats</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransport-getstats" class="dfn-panel" data-for="dom-webtransport-getstats" id="infopanel-for-dom-webtransport-getstats" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransport-getstats" style="display:none">Info about the 'getStats()' definition.</span><b><a href="#dom-webtransport-getstats">#dom-webtransport-getstats</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransport-getstats">8. WebTransport Interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-webtransportoptions">
-   <b><a href="#dictdef-webtransportoptions">#dictdef-webtransportoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-webtransportoptions" class="dfn-panel" data-for="dictdef-webtransportoptions" id="infopanel-for-dictdef-webtransportoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-webtransportoptions" style="display:none">Info about the 'WebTransportOptions' definition.</span><b><a href="#dictdef-webtransportoptions">#dictdef-webtransportoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-webtransportoptions">8. WebTransport Interface</a>
     <li><a href="#ref-for-dictdef-webtransportoptions①">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportoptions-allowpooling">
-   <b><a href="#dom-webtransportoptions-allowpooling">#dom-webtransportoptions-allowpooling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportoptions-allowpooling" class="dfn-panel" data-for="dom-webtransportoptions-allowpooling" id="infopanel-for-dom-webtransportoptions-allowpooling" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportoptions-allowpooling" style="display:none">Info about the 'allowPooling' definition.</span><b><a href="#dom-webtransportoptions-allowpooling">#dom-webtransportoptions-allowpooling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportoptions-allowpooling">8.2. Constructor</a>
     <li><a href="#ref-for-dom-webtransportoptions-allowpooling①">8.5. Configuration</a> <a href="#ref-for-dom-webtransportoptions-allowpooling②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportoptions-servercertificatefingerprints">
-   <b><a href="#dom-webtransportoptions-servercertificatefingerprints">#dom-webtransportoptions-servercertificatefingerprints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportoptions-servercertificatefingerprints" class="dfn-panel" data-for="dom-webtransportoptions-servercertificatefingerprints" id="infopanel-for-dom-webtransportoptions-servercertificatefingerprints" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportoptions-servercertificatefingerprints" style="display:none">Info about the 'serverCertificateFingerprints' definition.</span><b><a href="#dom-webtransportoptions-servercertificatefingerprints">#dom-webtransportoptions-servercertificatefingerprints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportoptions-servercertificatefingerprints">8.2. Constructor</a>
     <li><a href="#ref-for-dom-webtransportoptions-servercertificatefingerprints①">8.5. Configuration</a> <a href="#ref-for-dom-webtransportoptions-servercertificatefingerprints②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-a-certificate-fingerprint">
-   <b><a href="#compute-a-certificate-fingerprint">#compute-a-certificate-fingerprint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-a-certificate-fingerprint" class="dfn-panel" data-for="compute-a-certificate-fingerprint" id="infopanel-for-compute-a-certificate-fingerprint" role="dialog">
+   <span id="infopaneltitle-for-compute-a-certificate-fingerprint" style="display:none">Info about the 'compute a certificate fingerprint' definition.</span><b><a href="#compute-a-certificate-fingerprint">#compute-a-certificate-fingerprint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-a-certificate-fingerprint">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="verify-a-certificate-fingerprint">
-   <b><a href="#verify-a-certificate-fingerprint">#verify-a-certificate-fingerprint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-verify-a-certificate-fingerprint" class="dfn-panel" data-for="verify-a-certificate-fingerprint" id="infopanel-for-verify-a-certificate-fingerprint" role="dialog">
+   <span id="infopaneltitle-for-verify-a-certificate-fingerprint" style="display:none">Info about the 'verify a certificate fingerprint' definition.</span><b><a href="#verify-a-certificate-fingerprint">#verify-a-certificate-fingerprint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-verify-a-certificate-fingerprint">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="custom-certificate-requirements">
-   <b><a href="#custom-certificate-requirements">#custom-certificate-requirements</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-custom-certificate-requirements" class="dfn-panel" data-for="custom-certificate-requirements" id="infopanel-for-custom-certificate-requirements" role="dialog">
+   <span id="infopaneltitle-for-custom-certificate-requirements" style="display:none">Info about the 'custom certificate requirements' definition.</span><b><a href="#custom-certificate-requirements">#custom-certificate-requirements</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-certificate-requirements">8.5. Configuration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-webtransportstate">
-   <b><a href="#enumdef-webtransportstate">#enumdef-webtransportstate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-webtransportstate" class="dfn-panel" data-for="enumdef-webtransportstate" id="infopanel-for-enumdef-webtransportstate" role="dialog">
+   <span id="infopaneltitle-for-enumdef-webtransportstate" style="display:none">Info about the 'WebTransportState' definition.</span><b><a href="#enumdef-webtransportstate">#enumdef-webtransportstate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-webtransportstate">8. WebTransport Interface</a>
     <li><a href="#ref-for-enumdef-webtransportstate①">8.1. Internal slots</a>
@@ -3212,116 +3212,116 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-enumdef-webtransportstate③">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstate-connecting">
-   <b><a href="#dom-webtransportstate-connecting">#dom-webtransportstate-connecting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstate-connecting" class="dfn-panel" data-for="dom-webtransportstate-connecting" id="infopanel-for-dom-webtransportstate-connecting" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstate-connecting" style="display:none">Info about the '"connecting"' definition.</span><b><a href="#dom-webtransportstate-connecting">#dom-webtransportstate-connecting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstate-connecting">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstate-connected">
-   <b><a href="#dom-webtransportstate-connected">#dom-webtransportstate-connected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstate-connected" class="dfn-panel" data-for="dom-webtransportstate-connected" id="infopanel-for-dom-webtransportstate-connected" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstate-connected" style="display:none">Info about the '"connected"' definition.</span><b><a href="#dom-webtransportstate-connected">#dom-webtransportstate-connected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstate-connected">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstate-closed">
-   <b><a href="#dom-webtransportstate-closed">#dom-webtransportstate-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstate-closed" class="dfn-panel" data-for="dom-webtransportstate-closed" id="infopanel-for-dom-webtransportstate-closed" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstate-closed" style="display:none">Info about the '"closed"' definition.</span><b><a href="#dom-webtransportstate-closed">#dom-webtransportstate-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstate-closed">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstate-failed">
-   <b><a href="#dom-webtransportstate-failed">#dom-webtransportstate-failed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstate-failed" class="dfn-panel" data-for="dom-webtransportstate-failed" id="infopanel-for-dom-webtransportstate-failed" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstate-failed" style="display:none">Info about the '"failed"' definition.</span><b><a href="#dom-webtransportstate-failed">#dom-webtransportstate-failed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstate-failed">8.6. WebTransportState Enum</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-webtransportcloseinfo">
-   <b><a href="#dictdef-webtransportcloseinfo">#dictdef-webtransportcloseinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-webtransportcloseinfo" class="dfn-panel" data-for="dictdef-webtransportcloseinfo" id="infopanel-for-dictdef-webtransportcloseinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-webtransportcloseinfo" style="display:none">Info about the 'WebTransportCloseInfo' definition.</span><b><a href="#dictdef-webtransportcloseinfo">#dictdef-webtransportcloseinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-webtransportcloseinfo">8. WebTransport Interface</a> <a href="#ref-for-dictdef-webtransportcloseinfo①">(2)</a>
     <li><a href="#ref-for-dictdef-webtransportcloseinfo②">8.3. Attributes</a> <a href="#ref-for-dictdef-webtransportcloseinfo③">(2)</a>
     <li><a href="#ref-for-dictdef-webtransportcloseinfo④">8.7. WebTransportCloseInfo Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportcloseinfo-errorcode">
-   <b><a href="#dom-webtransportcloseinfo-errorcode">#dom-webtransportcloseinfo-errorcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportcloseinfo-errorcode" class="dfn-panel" data-for="dom-webtransportcloseinfo-errorcode" id="infopanel-for-dom-webtransportcloseinfo-errorcode" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportcloseinfo-errorcode" style="display:none">Info about the 'errorCode' definition.</span><b><a href="#dom-webtransportcloseinfo-errorcode">#dom-webtransportcloseinfo-errorcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportcloseinfo-errorcode">8.4. Methods</a>
     <li><a href="#ref-for-dom-webtransportcloseinfo-errorcode①">8.7. WebTransportCloseInfo Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportcloseinfo-reason">
-   <b><a href="#dom-webtransportcloseinfo-reason">#dom-webtransportcloseinfo-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportcloseinfo-reason" class="dfn-panel" data-for="dom-webtransportcloseinfo-reason" id="infopanel-for-dom-webtransportcloseinfo-reason" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportcloseinfo-reason" style="display:none">Info about the 'reason' definition.</span><b><a href="#dom-webtransportcloseinfo-reason">#dom-webtransportcloseinfo-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportcloseinfo-reason">8.4. Methods</a>
     <li><a href="#ref-for-dom-webtransportcloseinfo-reason①">8.7. WebTransportCloseInfo Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-webtransportstats">
-   <b><a href="#dictdef-webtransportstats">#dictdef-webtransportstats</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-webtransportstats" class="dfn-panel" data-for="dictdef-webtransportstats" id="infopanel-for-dictdef-webtransportstats" role="dialog">
+   <span id="infopaneltitle-for-dictdef-webtransportstats" style="display:none">Info about the 'WebTransportStats' definition.</span><b><a href="#dictdef-webtransportstats">#dictdef-webtransportstats</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-webtransportstats">8. WebTransport Interface</a>
     <li><a href="#ref-for-dictdef-webtransportstats①">8.4. Methods</a>
     <li><a href="#ref-for-dictdef-webtransportstats②">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-timestamp">
-   <b><a href="#dom-webtransportstats-timestamp">#dom-webtransportstats-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-timestamp" class="dfn-panel" data-for="dom-webtransportstats-timestamp" id="infopanel-for-dom-webtransportstats-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#dom-webtransportstats-timestamp">#dom-webtransportstats-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-timestamp">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-bytessent">
-   <b><a href="#dom-webtransportstats-bytessent">#dom-webtransportstats-bytessent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-bytessent" class="dfn-panel" data-for="dom-webtransportstats-bytessent" id="infopanel-for-dom-webtransportstats-bytessent" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-bytessent" style="display:none">Info about the 'bytesSent' definition.</span><b><a href="#dom-webtransportstats-bytessent">#dom-webtransportstats-bytessent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-bytessent">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-packetssent">
-   <b><a href="#dom-webtransportstats-packetssent">#dom-webtransportstats-packetssent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-packetssent" class="dfn-panel" data-for="dom-webtransportstats-packetssent" id="infopanel-for-dom-webtransportstats-packetssent" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-packetssent" style="display:none">Info about the 'packetsSent' definition.</span><b><a href="#dom-webtransportstats-packetssent">#dom-webtransportstats-packetssent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-packetssent">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-numoutgoingstreamscreated">
-   <b><a href="#dom-webtransportstats-numoutgoingstreamscreated">#dom-webtransportstats-numoutgoingstreamscreated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-numoutgoingstreamscreated" class="dfn-panel" data-for="dom-webtransportstats-numoutgoingstreamscreated" id="infopanel-for-dom-webtransportstats-numoutgoingstreamscreated" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-numoutgoingstreamscreated" style="display:none">Info about the 'numOutgoingStreamsCreated' definition.</span><b><a href="#dom-webtransportstats-numoutgoingstreamscreated">#dom-webtransportstats-numoutgoingstreamscreated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-numoutgoingstreamscreated">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-numincomingstreamscreated">
-   <b><a href="#dom-webtransportstats-numincomingstreamscreated">#dom-webtransportstats-numincomingstreamscreated</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-numincomingstreamscreated" class="dfn-panel" data-for="dom-webtransportstats-numincomingstreamscreated" id="infopanel-for-dom-webtransportstats-numincomingstreamscreated" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-numincomingstreamscreated" style="display:none">Info about the 'numIncomingStreamsCreated' definition.</span><b><a href="#dom-webtransportstats-numincomingstreamscreated">#dom-webtransportstats-numincomingstreamscreated</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-numincomingstreamscreated">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-bytesreceived">
-   <b><a href="#dom-webtransportstats-bytesreceived">#dom-webtransportstats-bytesreceived</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-bytesreceived" class="dfn-panel" data-for="dom-webtransportstats-bytesreceived" id="infopanel-for-dom-webtransportstats-bytesreceived" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-bytesreceived" style="display:none">Info about the 'bytesReceived' definition.</span><b><a href="#dom-webtransportstats-bytesreceived">#dom-webtransportstats-bytesreceived</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-bytesreceived">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-packetsreceived">
-   <b><a href="#dom-webtransportstats-packetsreceived">#dom-webtransportstats-packetsreceived</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-packetsreceived" class="dfn-panel" data-for="dom-webtransportstats-packetsreceived" id="infopanel-for-dom-webtransportstats-packetsreceived" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-packetsreceived" style="display:none">Info about the 'packetsReceived' definition.</span><b><a href="#dom-webtransportstats-packetsreceived">#dom-webtransportstats-packetsreceived</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-packetsreceived">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-minrtt">
-   <b><a href="#dom-webtransportstats-minrtt">#dom-webtransportstats-minrtt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-minrtt" class="dfn-panel" data-for="dom-webtransportstats-minrtt" id="infopanel-for-dom-webtransportstats-minrtt" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-minrtt" style="display:none">Info about the 'minRtt' definition.</span><b><a href="#dom-webtransportstats-minrtt">#dom-webtransportstats-minrtt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-minrtt">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-webtransportstats-numreceiveddatagramsdropped">
-   <b><a href="#dom-webtransportstats-numreceiveddatagramsdropped">#dom-webtransportstats-numreceiveddatagramsdropped</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-webtransportstats-numreceiveddatagramsdropped" class="dfn-panel" data-for="dom-webtransportstats-numreceiveddatagramsdropped" id="infopanel-for-dom-webtransportstats-numreceiveddatagramsdropped" role="dialog">
+   <span id="infopaneltitle-for-dom-webtransportstats-numreceiveddatagramsdropped" style="display:none">Info about the 'numReceivedDatagramsDropped' definition.</span><b><a href="#dom-webtransportstats-numreceiveddatagramsdropped">#dom-webtransportstats-numreceiveddatagramsdropped</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-webtransportstats-numreceiveddatagramsdropped">8.8. WebTransportStats Dictionary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sendstream">
-   <b><a href="#sendstream">#sendstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sendstream" class="dfn-panel" data-for="sendstream" id="infopanel-for-sendstream" role="dialog">
+   <span id="infopaneltitle-for-sendstream" style="display:none">Info about the 'SendStream' definition.</span><b><a href="#sendstream">#sendstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sendstream">4. UnidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-sendstream①">4.1. Methods</a> <a href="#ref-for-sendstream②">(2)</a>
@@ -3335,21 +3335,21 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-sendstream①⑤">11. Interface BidirectionalStream</a> <a href="#ref-for-sendstream①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sendstream-writingaborted">
-   <b><a href="#dom-sendstream-writingaborted">#dom-sendstream-writingaborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sendstream-writingaborted" class="dfn-panel" data-for="dom-sendstream-writingaborted" id="infopanel-for-dom-sendstream-writingaborted" role="dialog">
+   <span id="infopaneltitle-for-dom-sendstream-writingaborted" style="display:none">Info about the 'writingAborted' definition.</span><b><a href="#dom-sendstream-writingaborted">#dom-sendstream-writingaborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sendstream-writingaborted">9. Interface SendStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-sendstream-abortwriting">
-   <b><a href="#dom-sendstream-abortwriting">#dom-sendstream-abortwriting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-sendstream-abortwriting" class="dfn-panel" data-for="dom-sendstream-abortwriting" id="infopanel-for-dom-sendstream-abortwriting" role="dialog">
+   <span id="infopaneltitle-for-dom-sendstream-abortwriting" style="display:none">Info about the 'abortWriting()' definition.</span><b><a href="#dom-sendstream-abortwriting">#dom-sendstream-abortwriting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-sendstream-abortwriting">9. Interface SendStream</a>
     <li><a href="#ref-for-dom-sendstream-abortwriting①">12. Protocol Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-streamabortinfo">
-   <b><a href="#dictdef-streamabortinfo">#dictdef-streamabortinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-streamabortinfo" class="dfn-panel" data-for="dictdef-streamabortinfo" id="infopanel-for-dictdef-streamabortinfo" role="dialog">
+   <span id="infopaneltitle-for-dictdef-streamabortinfo" style="display:none">Info about the 'StreamAbortInfo' definition.</span><b><a href="#dictdef-streamabortinfo">#dictdef-streamabortinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-streamabortinfo">9. Interface SendStream</a> <a href="#ref-for-dictdef-streamabortinfo①">(2)</a>
     <li><a href="#ref-for-dictdef-streamabortinfo②">9.2. Attributes</a> <a href="#ref-for-dictdef-streamabortinfo③">(2)</a>
@@ -3358,16 +3358,16 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-dictdef-streamabortinfo⑦">10.2. Attributes</a> <a href="#ref-for-dictdef-streamabortinfo⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-streamabortinfo-errorcode">
-   <b><a href="#dom-streamabortinfo-errorcode">#dom-streamabortinfo-errorcode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-streamabortinfo-errorcode" class="dfn-panel" data-for="dom-streamabortinfo-errorcode" id="infopanel-for-dom-streamabortinfo-errorcode" role="dialog">
+   <span id="infopaneltitle-for-dom-streamabortinfo-errorcode" style="display:none">Info about the 'errorCode' definition.</span><b><a href="#dom-streamabortinfo-errorcode">#dom-streamabortinfo-errorcode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-streamabortinfo-errorcode">9.2. Attributes</a>
     <li><a href="#ref-for-dom-streamabortinfo-errorcode①">9.4. StreamAbortInfo Dictionary</a>
     <li><a href="#ref-for-dom-streamabortinfo-errorcode②">10.2. Attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="receivestream">
-   <b><a href="#receivestream">#receivestream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-receivestream" class="dfn-panel" data-for="receivestream" id="infopanel-for-receivestream" role="dialog">
+   <span id="infopaneltitle-for-receivestream" style="display:none">Info about the 'ReceiveStream' definition.</span><b><a href="#receivestream">#receivestream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-receivestream">4.1. Methods</a> <a href="#ref-for-receivestream①">(2)</a>
     <li><a href="#ref-for-receivestream②">8.1. Internal slots</a>
@@ -3379,21 +3379,21 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-receivestream①①">14.5. Receiving incoming streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-receivestream-readingaborted">
-   <b><a href="#dom-receivestream-readingaborted">#dom-receivestream-readingaborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-receivestream-readingaborted" class="dfn-panel" data-for="dom-receivestream-readingaborted" id="infopanel-for-dom-receivestream-readingaborted" role="dialog">
+   <span id="infopaneltitle-for-dom-receivestream-readingaborted" style="display:none">Info about the 'readingAborted' definition.</span><b><a href="#dom-receivestream-readingaborted">#dom-receivestream-readingaborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-receivestream-readingaborted">10. Interface ReceiveStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-receivestream-abortreading">
-   <b><a href="#dom-receivestream-abortreading">#dom-receivestream-abortreading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-receivestream-abortreading" class="dfn-panel" data-for="dom-receivestream-abortreading" id="infopanel-for-dom-receivestream-abortreading" role="dialog">
+   <span id="infopaneltitle-for-dom-receivestream-abortreading" style="display:none">Info about the 'abortReading()' definition.</span><b><a href="#dom-receivestream-abortreading">#dom-receivestream-abortreading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-receivestream-abortreading">10. Interface ReceiveStream</a>
     <li><a href="#ref-for-dom-receivestream-abortreading①">12. Protocol Mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bidirectionalstream">
-   <b><a href="#bidirectionalstream">#bidirectionalstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bidirectionalstream" class="dfn-panel" data-for="bidirectionalstream" id="infopanel-for-bidirectionalstream" role="dialog">
+   <span id="infopaneltitle-for-bidirectionalstream" style="display:none">Info about the 'BidirectionalStream' definition.</span><b><a href="#bidirectionalstream">#bidirectionalstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bidirectionalstream">5. BidirectionalStreamsTransport Mixin</a>
     <li><a href="#ref-for-bidirectionalstream①">5.1. Methods</a> <a href="#ref-for-bidirectionalstream②">(2)</a> <a href="#ref-for-bidirectionalstream③">(3)</a> <a href="#ref-for-bidirectionalstream④">(4)</a> <a href="#ref-for-bidirectionalstream⑤">(5)</a> <a href="#ref-for-bidirectionalstream⑥">(6)</a>
@@ -3402,73 +3402,129 @@ or are impossible to define for pooled connections. <a class="issue-return" href
     <li><a href="#ref-for-bidirectionalstream①⓪">11. Interface BidirectionalStream</a> <a href="#ref-for-bidirectionalstream①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bidirectionalstream-readable">
-   <b><a href="#dom-bidirectionalstream-readable">#dom-bidirectionalstream-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bidirectionalstream-readable" class="dfn-panel" data-for="dom-bidirectionalstream-readable" id="infopanel-for-dom-bidirectionalstream-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-bidirectionalstream-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-bidirectionalstream-readable">#dom-bidirectionalstream-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bidirectionalstream-readable">12. Protocol Mappings</a> <a href="#ref-for-dom-bidirectionalstream-readable①">(2)</a> <a href="#ref-for-dom-bidirectionalstream-readable②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-bidirectionalstream-writable">
-   <b><a href="#dom-bidirectionalstream-writable">#dom-bidirectionalstream-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-bidirectionalstream-writable" class="dfn-panel" data-for="dom-bidirectionalstream-writable" id="infopanel-for-dom-bidirectionalstream-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-bidirectionalstream-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-bidirectionalstream-writable">#dom-bidirectionalstream-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-bidirectionalstream-writable">12. Protocol Mappings</a> <a href="#ref-for-dom-bidirectionalstream-writable①">(2)</a> <a href="#ref-for-dom-bidirectionalstream-writable②">(3)</a> <a href="#ref-for-dom-bidirectionalstream-writable③">(4)</a> <a href="#ref-for-dom-bidirectionalstream-writable④">(5)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3c/webvtt/index.html
+++ b/tests/github/w3c/webvtt/index.html
@@ -5348,8 +5348,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
    <li><a href="#webvtt-voice-object">WebVTT Voice Object</a><span>, in § 6.4</span>
    <li><a href="#dom-vttregion-width">width</a><span>, in § 9.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-ascii-digits">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-digits" class="dfn-panel" data-for="term-for-ascii-digits" id="infopanel-for-term-for-ascii-digits" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-digits" style="display:none">Info about the 'ascii digits' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits">https://html.spec.whatwg.org/multipage/infrastructure.html#ascii-digits</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-digits">4.1. WebVTT file structure</a> <a href="#ref-for-ascii-digits①">(2)</a> <a href="#ref-for-ascii-digits②">(3)</a> <a href="#ref-for-ascii-digits③">(4)</a> <a href="#ref-for-ascii-digits④">(5)</a> <a href="#ref-for-ascii-digits⑤">(6)</a>
     <li><a href="#ref-for-ascii-digits⑥">4.3. WebVTT region settings</a>
@@ -5359,54 +5359,54 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-ascii-digits①⑦">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntax-charref">
-   <a href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref">https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntax-charref" class="dfn-panel" data-for="term-for-syntax-charref" id="infopanel-for-term-for-syntax-charref" role="menu">
+   <span id="infopaneltitle-for-term-for-syntax-charref" style="display:none">Info about the 'character references' external reference.</span><a href="https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref">https://html.spec.whatwg.org/multipage/syntax.html#syntax-charref</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntax-charref">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-syntax-charref①">(2)</a>
     <li><a href="#ref-for-syntax-charref②">4.2.3. WebVTT chapter title text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-playback-position">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-playback-position" class="dfn-panel" data-for="term-for-current-playback-position" id="infopanel-for-term-for-current-playback-position" role="menu">
+   <span id="infopaneltitle-for-term-for-current-playback-position" style="display:none">Info about the 'current playback position' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position">https://html.spec.whatwg.org/multipage/embedded-content.html#current-playback-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-playback-position">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-current-playback-position①">8.1. Introduction</a> <a href="#ref-for-current-playback-position②">(2)</a>
     <li><a href="#ref-for-current-playback-position③">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-current-playback-position④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-entry-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-entry-settings-object" class="dfn-panel" data-for="term-for-entry-settings-object" id="infopanel-for-term-for-entry-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-entry-settings-object" style="display:none">Info about the 'entry settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-settings-object">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-expose-a-user-interface-to-the-user">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user">https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-expose-a-user-interface-to-the-user" class="dfn-panel" data-for="term-for-expose-a-user-interface-to-the-user" id="infopanel-for-term-for-expose-a-user-interface-to-the-user" role="menu">
+   <span id="infopaneltitle-for-term-for-expose-a-user-interface-to-the-user" style="display:none">Info about the 'expose a user interface to the user' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user">https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-expose-a-user-interface-to-the-user">7.1. Processing model</a> <a href="#ref-for-expose-a-user-interface-to-the-user①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-honor-user-preferences-for-automatic-text-track-selection">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection">https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-honor-user-preferences-for-automatic-text-track-selection" class="dfn-panel" data-for="term-for-honor-user-preferences-for-automatic-text-track-selection" id="infopanel-for-term-for-honor-user-preferences-for-automatic-text-track-selection" role="menu">
+   <span id="infopaneltitle-for-term-for-honor-user-preferences-for-automatic-text-track-selection" style="display:none">Info about the 'honor user preferences for automatic text track selection' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection">https://html.spec.whatwg.org/multipage/embedded-content.html#honor-user-preferences-for-automatic-text-track-selection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-honor-user-preferences-for-automatic-text-track-selection">Privacy of preference</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-lang">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">https://html.spec.whatwg.org/multipage/dom.html#attr-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-lang" class="dfn-panel" data-for="term-for-attr-lang" id="infopanel-for-term-for-attr-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-lang" style="display:none">Info about the 'lang' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-lang">https://html.spec.whatwg.org/multipage/dom.html#attr-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-lang">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-of-text-tracks">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks">https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-of-text-tracks" class="dfn-panel" data-for="term-for-list-of-text-tracks" id="infopanel-for-term-for-list-of-text-tracks" role="menu">
+   <span id="infopaneltitle-for-term-for-list-of-text-tracks" style="display:none">Info about the 'list of text tracks' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks">https://html.spec.whatwg.org/multipage/embedded-content.html#list-of-text-tracks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-text-tracks">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-list-of-text-tracks①">(2)</a>
     <li><a href="#ref-for-list-of-text-tracks②">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">https://html.spec.whatwg.org/multipage/embedded-content.html#media-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-element" class="dfn-panel" data-for="term-for-media-element" id="infopanel-for-term-for-media-element" role="menu">
+   <span id="infopaneltitle-for-term-for-media-element" style="display:none">Info about the 'media element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#media-element">https://html.spec.whatwg.org/multipage/embedded-content.html#media-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-element">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-media-element①">(2)</a> <a href="#ref-for-media-element②">(3)</a>
     <li><a href="#ref-for-media-element③">7.1. Processing model</a> <a href="#ref-for-media-element④">(2)</a> <a href="#ref-for-media-element⑤">(3)</a> <a href="#ref-for-media-element⑥">(4)</a> <a href="#ref-for-media-element⑦">(5)</a>
@@ -5415,14 +5415,14 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-media-element①④">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-media-element①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rules-for-extracting-the-chapter-title">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title">https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rules-for-extracting-the-chapter-title" class="dfn-panel" data-for="term-for-rules-for-extracting-the-chapter-title" id="infopanel-for-term-for-rules-for-extracting-the-chapter-title" role="menu">
+   <span id="infopaneltitle-for-term-for-rules-for-extracting-the-chapter-title" style="display:none">Info about the 'rules for extracting the chapter title' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title">https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-extracting-the-chapter-title</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-extracting-the-chapter-title">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rules-for-updating-the-text-track-rendering">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rules-for-updating-the-text-track-rendering" class="dfn-panel" data-for="term-for-rules-for-updating-the-text-track-rendering" id="infopanel-for-term-for-rules-for-updating-the-text-track-rendering" role="menu">
+   <span id="infopaneltitle-for-term-for-rules-for-updating-the-text-track-rendering" style="display:none">Info about the 'rules for updating the text track rendering' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering">https://html.spec.whatwg.org/multipage/embedded-content.html#rules-for-updating-the-text-track-rendering</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-updating-the-text-track-rendering">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-rules-for-updating-the-text-track-rendering①">7.1. Processing model</a>
@@ -5430,21 +5430,21 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-rules-for-updating-the-text-track-rendering③">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-skip-whitespace">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace">https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-skip-whitespace" class="dfn-panel" data-for="term-for-skip-whitespace" id="infopanel-for-term-for-skip-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-skip-whitespace" style="display:none">Info about the 'skip whitespace' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace">https://html.spec.whatwg.org/multipage/infrastructure.html#skip-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skip-whitespace">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-skip-whitespace①">(2)</a> <a href="#ref-for-skip-whitespace②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-a-string-on-spaces">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces">https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-a-string-on-spaces" class="dfn-panel" data-for="term-for-split-a-string-on-spaces" id="infopanel-for-term-for-split-a-string-on-spaces" role="menu">
+   <span id="infopaneltitle-for-term-for-split-a-string-on-spaces" style="display:none">Info about the 'split a string on spaces' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces">https://html.spec.whatwg.org/multipage/infrastructure.html#split-a-string-on-spaces</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-a-string-on-spaces">6.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-split-a-string-on-spaces①">6.3. WebVTT cue timings and settings parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track" class="dfn-panel" data-for="term-for-text-track" id="infopanel-for-term-for-text-track" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track" style="display:none">Info about the 'text track' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track">3.1. Overview</a> <a href="#ref-for-text-track①">(2)</a>
     <li><a href="#ref-for-text-track②">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-text-track③">(2)</a> <a href="#ref-for-text-track④">(3)</a> <a href="#ref-for-text-track⑤">(4)</a> <a href="#ref-for-text-track⑥">(5)</a> <a href="#ref-for-text-track⑦">(6)</a> <a href="#ref-for-text-track⑧">(7)</a> <a href="#ref-for-text-track⑨">(8)</a>
@@ -5457,8 +5457,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-text-track①⑨">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue" class="dfn-panel" data-for="term-for-text-track-cue" id="infopanel-for-term-for-text-track-cue" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue" style="display:none">Info about the 'text track cue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue">3.2. WebVTT cues</a>
     <li><a href="#ref-for-text-track-cue①">6.3. WebVTT cue timings and settings parsing</a>
@@ -5467,15 +5467,15 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-text-track-cue⑤">8.2. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-active-flag">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-active-flag" class="dfn-panel" data-for="term-for-text-track-cue-active-flag" id="infopanel-for-term-for-text-track-cue-active-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-active-flag" style="display:none">Info about the 'text track cue active flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-active-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-active-flag">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-text-track-cue-active-flag①">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-display-state">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-display-state" class="dfn-panel" data-for="term-for-text-track-cue-display-state" id="infopanel-for-term-for-text-track-cue-display-state" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-display-state" style="display:none">Info about the 'text track cue display state' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-display-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-display-state">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-text-track-cue-display-state①">7.1. Processing model</a> <a href="#ref-for-text-track-cue-display-state②">(2)</a> <a href="#ref-for-text-track-cue-display-state③">(3)</a>
@@ -5483,15 +5483,15 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-text-track-cue-display-state⑤">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-end-time">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-end-time" class="dfn-panel" data-for="term-for-text-track-cue-end-time" id="infopanel-for-term-for-text-track-cue-end-time" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-end-time" style="display:none">Info about the 'text track cue end time' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-end-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-end-time">6.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-text-track-cue-end-time①">9.1. The VTTCue interface</a> <a href="#ref-for-text-track-cue-end-time②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-identifier">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-identifier" class="dfn-panel" data-for="term-for-text-track-cue-identifier" id="infopanel-for-term-for-text-track-cue-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-identifier" style="display:none">Info about the 'text track cue identifier' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-identifier">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-text-track-cue-identifier①">8.1. Introduction</a>
@@ -5499,173 +5499,173 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-text-track-cue-identifier③">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-order">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-order" class="dfn-panel" data-for="term-for-text-track-cue-order" id="infopanel-for-term-for-text-track-cue-order" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-order" style="display:none">Info about the 'text track cue order' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-order">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-pause-on-exit-flag">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-pause-on-exit-flag" class="dfn-panel" data-for="term-for-text-track-cue-pause-on-exit-flag" id="infopanel-for-term-for-text-track-cue-pause-on-exit-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-pause-on-exit-flag" style="display:none">Info about the 'text track cue pause-on-exit flag' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-pause-on-exit-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-pause-on-exit-flag">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-text-track-cue-pause-on-exit-flag①">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-cue-start-time">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-cue-start-time" class="dfn-panel" data-for="term-for-text-track-cue-start-time" id="infopanel-for-term-for-text-track-cue-start-time" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-cue-start-time" style="display:none">Info about the 'text track cue start time' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-cue-start-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-cue-start-time">6.3. WebVTT cue timings and settings parsing</a>
     <li><a href="#ref-for-text-track-cue-start-time①">9.1. The VTTCue interface</a> <a href="#ref-for-text-track-cue-start-time②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-kind">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-kind" class="dfn-panel" data-for="term-for-text-track-kind" id="infopanel-for-term-for-text-track-kind" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-kind" style="display:none">Info about the 'text track kind' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-kind</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-kind">1.1. A simple caption file</a>
     <li><a href="#ref-for-text-track-kind①">3.1. Overview</a>
     <li><a href="#ref-for-text-track-kind②">4.2.1. WebVTT metadata text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-list-of-cues">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-list-of-cues" class="dfn-panel" data-for="term-for-text-track-list-of-cues" id="infopanel-for-term-for-text-track-list-of-cues" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-list-of-cues" style="display:none">Info about the 'text track list of cues' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-list-of-cues</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-list-of-cues">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-text-track-list-of-cues①">(2)</a>
     <li><a href="#ref-for-text-track-list-of-cues②">6.1. WebVTT file parsing</a> <a href="#ref-for-text-track-list-of-cues③">(2)</a>
     <li><a href="#ref-for-text-track-list-of-cues④">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-mode">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-mode" class="dfn-panel" data-for="term-for-text-track-mode" id="infopanel-for-term-for-text-track-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-mode" style="display:none">Info about the 'text track mode' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-mode">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-text-track-mode①">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text-track-showing">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text-track-showing" class="dfn-panel" data-for="term-for-text-track-showing" id="infopanel-for-term-for-text-track-showing" role="menu">
+   <span id="infopaneltitle-for-term-for-text-track-showing" style="display:none">Info about the 'text track showing' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing">https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-showing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-showing">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-text-track-showing①">(2)</a>
     <li><a href="#ref-for-text-track-showing②">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-title">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#attr-title">https://html.spec.whatwg.org/multipage/dom.html#attr-title</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-title" class="dfn-panel" data-for="term-for-attr-title" id="infopanel-for-term-for-attr-title" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-title" style="display:none">Info about the 'title' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#attr-title">https://html.spec.whatwg.org/multipage/dom.html#attr-title</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-title">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-self-position-flex-end">
-   <a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-flex-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-flex-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-self-position-flex-end" class="dfn-panel" data-for="term-for-valdef-self-position-flex-end" id="infopanel-for-term-for-valdef-self-position-flex-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-self-position-flex-end" style="display:none">Info about the 'flex-end' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#valdef-self-position-flex-end">https://drafts.csswg.org/css-align-3/#valdef-self-position-flex-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-self-position-flex-end">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background" class="dfn-panel" data-for="term-for-propdef-background" id="infopanel-for-term-for-propdef-background" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background" style="display:none">Info about the 'background' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background">https://drafts.csswg.org/css-backgrounds-3/#propdef-background</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background">5.2. Default text background colors</a>
     <li><a href="#ref-for-propdef-background①">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-background②">(2)</a>
     <li><a href="#ref-for-propdef-background③">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-background④">(2)</a> <a href="#ref-for-propdef-background⑤">(3)</a> <a href="#ref-for-propdef-background⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">5.2. Default text background colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-import">
-   <a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-import" class="dfn-panel" data-for="term-for-at-ruledef-import" id="infopanel-for-term-for-at-ruledef-import" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-import" style="display:none">Info about the '@import' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#at-ruledef-import">https://drafts.csswg.org/css-cascade-5/#at-ruledef-import</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-import">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cascade">
-   <a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cascade" class="dfn-panel" data-for="term-for-cascade" id="infopanel-for-term-for-cascade" role="menu">
+   <span id="infopaneltitle-for-term-for-cascade" style="display:none">Info about the 'cascade' external reference.</span><a href="https://drafts.csswg.org/css-cascade-6/#cascade">https://drafts.csswg.org/css-cascade-6/#cascade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cascade">5.2. Default text background colors</a>
     <li><a href="#ref-for-cascade①">7.3. Obtaining CSS boxes</a> <a href="#ref-for-cascade②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">5.1. Default text colors</a> <a href="#ref-for-propdef-color①">(2)</a>
     <li><a href="#ref-for-propdef-color②">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-color③">(2)</a>
     <li><a href="#ref-for-propdef-color④">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-color⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-green">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-green">https://drafts.csswg.org/css-color-4/#valdef-color-green</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-green" class="dfn-panel" data-for="term-for-valdef-color-green" id="infopanel-for-term-for-valdef-color-green" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-green" style="display:none">Info about the 'green' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-green">https://drafts.csswg.org/css-color-4/#valdef-color-green</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-green">5.1. Default text colors</a>
     <li><a href="#ref-for-valdef-color-green①">5.2. Default text background colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-opacity">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-opacity" class="dfn-panel" data-for="term-for-propdef-opacity" id="infopanel-for-term-for-propdef-opacity" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-opacity" style="display:none">Info about the 'opacity' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-opacity">https://drafts.csswg.org/css-color-4/#propdef-opacity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-opacity">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-opacity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">7.3. Obtaining CSS boxes</a> <a href="#ref-for-propdef-display①">(2)</a>
     <li><a href="#ref-for-propdef-display②">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-display③">(2)</a> <a href="#ref-for-propdef-display④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline" class="dfn-panel" data-for="term-for-valdef-display-inline" id="infopanel-for-term-for-valdef-display-inline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline" style="display:none">Info about the 'inline' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-inline">https://drafts.csswg.org/css-display-3/#valdef-display-inline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-visibility">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-visibility" class="dfn-panel" data-for="term-for-propdef-visibility" id="infopanel-for-term-for-propdef-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-visibility" style="display:none">Info about the 'visibility' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-visibility">https://drafts.csswg.org/css-display-3/#propdef-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-visibility">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-visibility①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-flex" class="dfn-panel" data-for="term-for-valdef-display-inline-flex" id="infopanel-for-term-for-valdef-display-inline-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-flex" style="display:none">Info about the 'inline-flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-flex">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-weight-bold">
-   <a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-weight-bold" class="dfn-panel" data-for="term-for-valdef-font-weight-bold" id="infopanel-for-term-for-valdef-font-weight-bold" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-weight-bold" style="display:none">Info about the 'bold' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold">https://drafts.csswg.org/css-fonts-4/#valdef-font-weight-bold</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-weight-bold">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font" class="dfn-panel" data-for="term-for-propdef-font" id="infopanel-for-term-for-propdef-font" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font" style="display:none">Info about the 'font' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font">https://drafts.csswg.org/css-fonts-4/#propdef-font</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-font①">(2)</a>
     <li><a href="#ref-for-propdef-font②">8.2. Processing model</a>
@@ -5673,147 +5673,147 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-propdef-font⑤">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-font-style-italic">
-   <a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic">https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-font-style-italic" class="dfn-panel" data-for="term-for-valdef-font-style-italic" id="infopanel-for-term-for-valdef-font-style-italic" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-font-style-italic" style="display:none">Info about the 'italic' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic">https://drafts.csswg.org/css-fonts-4/#valdef-font-style-italic</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-font-style-italic">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-hidden">
-   <a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-hidden" class="dfn-panel" data-for="term-for-valdef-overflow-hidden" id="infopanel-for-term-for-valdef-overflow-hidden" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-hidden" style="display:none">Info about the 'hidden' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden">https://drafts.csswg.org/css-overflow-3/#valdef-overflow-hidden</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-hidden">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow">
-   <a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow" class="dfn-panel" data-for="term-for-propdef-overflow" id="infopanel-for-term-for-propdef-overflow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow" style="display:none">Info about the 'overflow' external reference.</span><a href="https://drafts.csswg.org/css-overflow-3/#propdef-overflow">https://drafts.csswg.org/css-overflow-3/#propdef-overflow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-absolute">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-absolute" class="dfn-panel" data-for="term-for-valdef-position-absolute" id="infopanel-for-term-for-valdef-position-absolute" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-absolute" style="display:none">Info about the 'absolute' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-absolute">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-valdef-position-absolute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-left①">(2)</a> <a href="#ref-for-propdef-left②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-position①">(2)</a> <a href="#ref-for-propdef-position②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-top①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">7.2. Processing cue settings</a> <a href="#ref-for-valdef-width-auto①">(2)</a>
     <li><a href="#ref-for-valdef-width-auto②">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-height①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-width①">(2)</a> <a href="#ref-for-propdef-width②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-stylesheet">
-   <a href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet">https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-stylesheet" class="dfn-panel" data-for="term-for-parse-a-stylesheet" id="infopanel-for-term-for-parse-a-stylesheet" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-stylesheet" style="display:none">Info about the 'parse a stylesheet' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet">https://drafts.csswg.org/css-syntax-3/#parse-a-stylesheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-stylesheet">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-align">
-   <a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-align" class="dfn-panel" data-for="term-for-propdef-text-align" id="infopanel-for-term-for-propdef-text-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-align" style="display:none">Info about the 'text-align' external reference.</span><a href="https://drafts.csswg.org/css-text-3/#propdef-text-align">https://drafts.csswg.org/css-text-3/#propdef-text-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-align">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-text-align①">(2)</a> <a href="#ref-for-propdef-text-align②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-wrap-balance">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance">https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-wrap-balance" class="dfn-panel" data-for="term-for-valdef-text-wrap-balance" id="infopanel-for-term-for-valdef-text-wrap-balance" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-wrap-balance" style="display:none">Info about the 'balance' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance">https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-wrap-balance">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-overflow-wrap-break-word">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-overflow-wrap-break-word">https://drafts.csswg.org/css-text-4/#valdef-overflow-wrap-break-word</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-overflow-wrap-break-word" class="dfn-panel" data-for="term-for-valdef-overflow-wrap-break-word" id="infopanel-for-term-for-valdef-overflow-wrap-break-word" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-overflow-wrap-break-word" style="display:none">Info about the 'break-word' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-overflow-wrap-break-word">https://drafts.csswg.org/css-text-4/#valdef-overflow-wrap-break-word</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-overflow-wrap-break-word">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-valdef-overflow-wrap-break-word①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-center">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-center" class="dfn-panel" data-for="term-for-valdef-text-align-center" id="infopanel-for-term-for-valdef-text-align-center" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-center" style="display:none">Info about the 'center' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-center">https://drafts.csswg.org/css-text-4/#valdef-text-align-center</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-center">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-end">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-end">https://drafts.csswg.org/css-text-4/#valdef-text-align-end</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-end" class="dfn-panel" data-for="term-for-valdef-text-align-end" id="infopanel-for-term-for-valdef-text-align-end" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-end" style="display:none">Info about the 'end' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-end">https://drafts.csswg.org/css-text-4/#valdef-text-align-end</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-end">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-left">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-left">https://drafts.csswg.org/css-text-4/#valdef-text-align-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-left" class="dfn-panel" data-for="term-for-valdef-text-align-left" id="infopanel-for-term-for-valdef-text-align-left" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-left">https://drafts.csswg.org/css-text-4/#valdef-text-align-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-left">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-overflow-wrap">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap">https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-overflow-wrap" class="dfn-panel" data-for="term-for-propdef-overflow-wrap" id="infopanel-for-term-for-propdef-overflow-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-overflow-wrap" style="display:none">Info about the 'overflow-wrap' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap">https://drafts.csswg.org/css-text-4/#propdef-overflow-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-overflow-wrap">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-overflow-wrap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-white-space-pre-line">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-white-space-pre-line" class="dfn-panel" data-for="term-for-valdef-white-space-pre-line" id="infopanel-for-term-for-valdef-white-space-pre-line" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-white-space-pre-line" style="display:none">Info about the 'pre-line' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line">https://drafts.csswg.org/css-text-4/#valdef-white-space-pre-line</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-white-space-pre-line">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-right">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-right">https://drafts.csswg.org/css-text-4/#valdef-text-align-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-right" class="dfn-panel" data-for="term-for-valdef-text-align-right" id="infopanel-for-term-for-valdef-text-align-right" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-right">https://drafts.csswg.org/css-text-4/#valdef-text-align-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-right">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-align-start">
-   <a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-start">https://drafts.csswg.org/css-text-4/#valdef-text-align-start</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-align-start" class="dfn-panel" data-for="term-for-valdef-text-align-start" id="infopanel-for-term-for-valdef-text-align-start" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-align-start" style="display:none">Info about the 'start' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#valdef-text-align-start">https://drafts.csswg.org/css-text-4/#valdef-text-align-start</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-align-start">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-wrap">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-wrap">https://drafts.csswg.org/css-text-4/#propdef-text-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-wrap" class="dfn-panel" data-for="term-for-propdef-text-wrap" id="infopanel-for-term-for-propdef-text-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-wrap" style="display:none">Info about the 'text-wrap' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-wrap">https://drafts.csswg.org/css-text-4/#propdef-text-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-wrap">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-white-space">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-white-space" class="dfn-panel" data-for="term-for-propdef-white-space" id="infopanel-for-term-for-propdef-white-space" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-white-space" style="display:none">Info about the 'white-space' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-white-space">https://drafts.csswg.org/css-text-4/#propdef-white-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-white-space">7.4. Applying CSS properties to WebVTT Node Objects</a>
     <li><a href="#ref-for-propdef-white-space①">8.2. Processing model</a>
@@ -5821,357 +5821,357 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-propdef-white-space④">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-decoration">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-decoration" class="dfn-panel" data-for="term-for-propdef-text-decoration" id="infopanel-for-term-for-propdef-text-decoration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-decoration" style="display:none">Info about the 'text-decoration' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration">https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-decoration">7.4. Applying CSS properties to WebVTT Node Objects</a>
     <li><a href="#ref-for-propdef-text-decoration①">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-text-decoration②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-shadow">
-   <a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-shadow" class="dfn-panel" data-for="term-for-propdef-text-shadow" id="infopanel-for-term-for-propdef-text-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-shadow" style="display:none">Info about the 'text-shadow' external reference.</span><a href="https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow">https://drafts.csswg.org/css-text-decor-4/#propdef-text-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-shadow">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-text-shadow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-duration">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-duration" class="dfn-panel" data-for="term-for-propdef-transition-duration" id="infopanel-for-term-for-propdef-transition-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-duration" style="display:none">Info about the 'transition-duration' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-duration">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-property">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-property" class="dfn-panel" data-for="term-for-propdef-transition-property" id="infopanel-for-term-for-propdef-transition-property" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-property" style="display:none">Info about the 'transition-property' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-property">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-outline">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-outline" class="dfn-panel" data-for="term-for-propdef-outline" id="infopanel-for-term-for-propdef-outline" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-outline" style="display:none">Info about the 'outline' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef-outline">https://drafts.csswg.org/css-ui-4/#propdef-outline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-outline">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-outline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vh">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vh">https://drafts.csswg.org/css-values-4/#valdef-length-vh</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vh" class="dfn-panel" data-for="term-for-valdef-length-vh" id="infopanel-for-term-for-valdef-length-vh" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vh" style="display:none">Info about the 'vh' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vh">https://drafts.csswg.org/css-values-4/#valdef-length-vh</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vh">7.1. Processing model</a>
     <li><a href="#ref-for-valdef-length-vh①">7.2. Processing cue settings</a> <a href="#ref-for-valdef-length-vh②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-length-vw">
-   <a href="https://drafts.csswg.org/css-values-4/#valdef-length-vw">https://drafts.csswg.org/css-values-4/#valdef-length-vw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-length-vw" class="dfn-panel" data-for="term-for-valdef-length-vw" id="infopanel-for-term-for-valdef-length-vw" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-length-vw" style="display:none">Info about the 'vw' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#valdef-length-vw">https://drafts.csswg.org/css-values-4/#valdef-length-vw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-length-vw">7.1. Processing model</a>
     <li><a href="#ref-for-valdef-length-vw①">7.2. Processing cue settings</a> <a href="#ref-for-valdef-length-vw②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-unicode-bidi">
-   <a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-unicode-bidi" class="dfn-panel" data-for="term-for-propdef-unicode-bidi" id="infopanel-for-term-for-propdef-unicode-bidi" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-unicode-bidi" style="display:none">Info about the 'unicode-bidi' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi">https://drafts.csswg.org/css-writing-modes-3/#propdef-unicode-bidi</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-unicode-bidi">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-propdef-unicode-bidi①">(2)</a>
     <li><a href="#ref-for-propdef-unicode-bidi②">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-unicode-bidi③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" class="dfn-panel" data-for="term-for-valdef-writing-mode-horizontal-tb" id="infopanel-for-term-for-valdef-writing-mode-horizontal-tb" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-writing-mode-horizontal-tb" style="display:none">Info about the 'horizontal-tb' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb">https://drafts.csswg.org/css-writing-modes-4/#valdef-writing-mode-horizontal-tb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-writing-mode-horizontal-tb">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-unicode-bidi-plaintext">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-unicode-bidi-plaintext" class="dfn-panel" data-for="term-for-valdef-unicode-bidi-plaintext" id="infopanel-for-term-for-valdef-unicode-bidi-plaintext" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-unicode-bidi-plaintext" style="display:none">Info about the 'plaintext' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext">https://drafts.csswg.org/css-writing-modes-4/#valdef-unicode-bidi-plaintext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-unicode-bidi-plaintext">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-valdef-unicode-bidi-plaintext①">(2)</a> <a href="#ref-for-valdef-unicode-bidi-plaintext②">(3)</a>
     <li><a href="#ref-for-valdef-unicode-bidi-plaintext③">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-valdef-unicode-bidi-plaintext④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-combine-upright">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-combine-upright" class="dfn-panel" data-for="term-for-propdef-text-combine-upright" id="infopanel-for-term-for-propdef-text-combine-upright" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-combine-upright" style="display:none">Info about the 'text-combine-upright' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright">https://drafts.csswg.org/css-writing-modes-4/#propdef-text-combine-upright</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-combine-upright">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-text-combine-upright①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-writing-mode" class="dfn-panel" data-for="term-for-propdef-writing-mode" id="infopanel-for-term-for-propdef-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-writing-mode" style="display:none">Info about the 'writing-mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#propdef-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-writing-mode">7.4. Applying CSS properties to WebVTT Node Objects</a> <a href="#ref-for-propdef-writing-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-selectordef-lang">
-   <a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-selectordef-lang" class="dfn-panel" data-for="term-for-selectordef-lang" id="infopanel-for-term-for-selectordef-lang" role="menu">
+   <span id="infopaneltitle-for-term-for-selectordef-lang" style="display:none">Info about the ':lang()' external reference.</span><a href="https://drafts.csswg.org/css2/#selectordef-lang">https://drafts.csswg.org/css2/#selectordef-lang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-selectordef-lang">8.1. Introduction</a>
     <li><a href="#ref-for-selectordef-lang①">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">8.2. Processing model</a>
     <li><a href="#ref-for-propdef-line-height①">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-line-height②">(2)</a>
     <li><a href="#ref-for-propdef-line-height③">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-text-decoration-underline">
-   <a href="https://drafts.csswg.org/css2/#valdef-text-decoration-underline">https://drafts.csswg.org/css2/#valdef-text-decoration-underline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-text-decoration-underline" class="dfn-panel" data-for="term-for-valdef-text-decoration-underline" id="infopanel-for-term-for-valdef-text-decoration-underline" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-text-decoration-underline" style="display:none">Info about the 'underline' external reference.</span><a href="https://drafts.csswg.org/css2/#valdef-text-decoration-underline">https://drafts.csswg.org/css2/#valdef-text-decoration-underline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-text-decoration-underline">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-ruby">
-   <a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-ruby" class="dfn-panel" data-for="term-for-valdef-display-ruby" id="infopanel-for-term-for-valdef-display-ruby" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-ruby" style="display:none">Info about the 'ruby' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-ruby-base">
-   <a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-ruby-base" class="dfn-panel" data-for="term-for-valdef-display-ruby-base" id="infopanel-for-term-for-valdef-display-ruby-base" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-ruby-base" style="display:none">Info about the 'ruby-base' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-base</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby-base">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-ruby-position">
-   <a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-ruby-position" class="dfn-panel" data-for="term-for-propdef-ruby-position" id="infopanel-for-term-for-propdef-ruby-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-ruby-position" style="display:none">Info about the 'ruby-position' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position">https://drafts.csswg.org/css-ruby-1/#propdef-ruby-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-ruby-position">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-propdef-ruby-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-ruby-text">
-   <a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-ruby-text" class="dfn-panel" data-for="term-for-valdef-display-ruby-text" id="infopanel-for-term-for-valdef-display-ruby-text" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-ruby-text" style="display:none">Info about the 'ruby-text' external reference.</span><a href="https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text">https://drafts.csswg.org/css-ruby-1/#valdef-display-ruby-text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-ruby-text">7.4. Applying CSS properties to WebVTT Node Objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-alternate-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-alternate-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-alternate-flag" id="infopanel-for-term-for-concept-css-style-sheet-alternate-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-alternate-flag" style="display:none">Info about the 'alternate flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-alternate-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-alternate-flag">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-create-a-css-style-sheet">
-   <a href="https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet">https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-create-a-css-style-sheet" class="dfn-panel" data-for="term-for-create-a-css-style-sheet" id="infopanel-for-term-for-create-a-css-style-sheet" role="menu">
+   <span id="infopaneltitle-for-term-for-create-a-css-style-sheet" style="display:none">Info about the 'create a css style sheet' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet">https://drafts.csswg.org/cssom-1/#create-a-css-style-sheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-css-style-sheet">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-css-rules">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-css-rules" class="dfn-panel" data-for="term-for-concept-css-style-sheet-css-rules" id="infopanel-for-term-for-concept-css-style-sheet-css-rules" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-css-rules" style="display:none">Info about the 'css rules' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-css-rules</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-css-rules">6.1. WebVTT file parsing</a> <a href="#ref-for-concept-css-style-sheet-css-rules①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-style-sheet">
-   <a href="https://drafts.csswg.org/cssom-1/#css-style-sheet">https://drafts.csswg.org/cssom-1/#css-style-sheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-style-sheet" class="dfn-panel" data-for="term-for-css-style-sheet" id="infopanel-for-term-for-css-style-sheet" role="menu">
+   <span id="infopaneltitle-for-term-for-css-style-sheet" style="display:none">Info about the 'css style sheet' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#css-style-sheet">https://drafts.csswg.org/cssom-1/#css-style-sheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-style-sheet">6.1. WebVTT file parsing</a> <a href="#ref-for-css-style-sheet①">(2)</a> <a href="#ref-for-css-style-sheet②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">Styling-related privacy and security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-location">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-location" class="dfn-panel" data-for="term-for-concept-css-style-sheet-location" id="infopanel-for-term-for-concept-css-style-sheet-location" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-location" style="display:none">Info about the 'location' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-location">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-media">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-media" class="dfn-panel" data-for="term-for-concept-css-style-sheet-media" id="infopanel-for-term-for-concept-css-style-sheet-media" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-media" style="display:none">Info about the 'media' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-media">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" class="dfn-panel" data-for="term-for-concept-css-style-sheet-origin-clean-flag" id="infopanel-for-term-for-concept-css-style-sheet-origin-clean-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-origin-clean-flag" style="display:none">Info about the 'origin-clean flag' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-origin-clean-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-origin-clean-flag">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-css-rule">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-owner-css-rule" class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-css-rule" id="infopanel-for-term-for-concept-css-style-sheet-owner-css-rule" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-owner-css-rule" style="display:none">Info about the 'owner css rule' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-css-rule</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-css-rule">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-node">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-owner-node" class="dfn-panel" data-for="term-for-concept-css-style-sheet-owner-node" id="infopanel-for-term-for-concept-css-style-sheet-owner-node" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-owner-node" style="display:none">Info about the 'owner node' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-owner-node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-owner-node">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-parent-css-style-sheet">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-parent-css-style-sheet" class="dfn-panel" data-for="term-for-concept-css-style-sheet-parent-css-style-sheet" id="infopanel-for-term-for-concept-css-style-sheet-parent-css-style-sheet" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-parent-css-style-sheet" style="display:none">Info about the 'parent css style sheet' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-parent-css-style-sheet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-parent-css-style-sheet">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-css-style-sheet-title">
-   <a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-css-style-sheet-title" class="dfn-panel" data-for="term-for-concept-css-style-sheet-title" id="infopanel-for-term-for-concept-css-style-sheet-title" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-css-style-sheet-title" style="display:none">Info about the 'title' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title">https://drafts.csswg.org/cssom-1/#concept-css-style-sheet-title</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-css-style-sheet-title">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentfragment">
-   <a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentfragment" class="dfn-panel" data-for="term-for-documentfragment" id="infopanel-for-term-for-documentfragment" role="menu">
+   <span id="infopaneltitle-for-term-for-documentfragment" style="display:none">Info about the 'DocumentFragment' external reference.</span><a href="https://dom.spec.whatwg.org/#documentfragment">https://dom.spec.whatwg.org/#documentfragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentfragment">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-documentfragment①">(2)</a> <a href="#ref-for-documentfragment②">(3)</a>
     <li><a href="#ref-for-documentfragment③">9.1. The VTTCue interface</a> <a href="#ref-for-documentfragment④">(2)</a> <a href="#ref-for-documentfragment⑤">(3)</a> <a href="#ref-for-documentfragment⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-processinginstruction">
-   <a href="https://dom.spec.whatwg.org/#processinginstruction">https://dom.spec.whatwg.org/#processinginstruction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-processinginstruction" class="dfn-panel" data-for="term-for-processinginstruction" id="infopanel-for-term-for-processinginstruction" role="menu">
+   <span id="infopaneltitle-for-term-for-processinginstruction" style="display:none">Info about the 'ProcessingInstruction' external reference.</span><a href="https://dom.spec.whatwg.org/#processinginstruction">https://dom.spec.whatwg.org/#processinginstruction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processinginstruction">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-text">
-   <a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-text" class="dfn-panel" data-for="term-for-text" id="infopanel-for-term-for-text" role="menu">
+   <span id="infopaneltitle-for-term-for-text" style="display:none">Info about the 'Text' external reference.</span><a href="https://dom.spec.whatwg.org/#text">https://dom.spec.whatwg.org/#text</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text">6.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-text①">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-characterdata-data">
-   <a href="https://dom.spec.whatwg.org/#dom-characterdata-data">https://dom.spec.whatwg.org/#dom-characterdata-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-characterdata-data" class="dfn-panel" data-for="term-for-dom-characterdata-data" id="infopanel-for-term-for-dom-characterdata-data" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-characterdata-data" style="display:none">Info about the 'data' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-characterdata-data">https://dom.spec.whatwg.org/#dom-characterdata-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-data">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-dom-characterdata-data①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-node-ownerdocument">
-   <a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">https://dom.spec.whatwg.org/#dom-node-ownerdocument</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-node-ownerdocument" class="dfn-panel" data-for="term-for-dom-node-ownerdocument" id="infopanel-for-term-for-dom-node-ownerdocument" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-node-ownerdocument" style="display:none">Info about the 'ownerDocument' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-node-ownerdocument">https://dom.spec.whatwg.org/#dom-node-ownerdocument</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-ownerdocument">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-processinginstruction-target">
-   <a href="https://dom.spec.whatwg.org/#dom-processinginstruction-target">https://dom.spec.whatwg.org/#dom-processinginstruction-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-processinginstruction-target" class="dfn-panel" data-for="term-for-dom-processinginstruction-target" id="infopanel-for-term-for-dom-processinginstruction-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-processinginstruction-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-processinginstruction-target">https://dom.spec.whatwg.org/#dom-processinginstruction-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-processinginstruction-target">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-texttrackcue">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">https://html.spec.whatwg.org/multipage/media.html#texttrackcue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-texttrackcue" class="dfn-panel" data-for="term-for-texttrackcue" id="infopanel-for-term-for-texttrackcue" role="menu">
+   <span id="infopaneltitle-for-term-for-texttrackcue" style="display:none">Info about the 'TextTrackCue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#texttrackcue">https://html.spec.whatwg.org/multipage/media.html#texttrackcue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-texttrackcue">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-texttrack-addcue">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue">https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-texttrack-addcue" class="dfn-panel" data-for="term-for-dom-texttrack-addcue" id="infopanel-for-term-for-dom-texttrack-addcue" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-texttrack-addcue" style="display:none">Info about the 'addCue(cue)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue">https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-addcue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-texttrack-addcue">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-audio">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-audio" class="dfn-panel" data-for="term-for-audio" id="infopanel-for-term-for-audio" role="menu">
+   <span id="infopaneltitle-for-term-for-audio" style="display:none">Info about the 'audio' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#audio">https://html.spec.whatwg.org/multipage/media.html#audio</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-b-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-b-element" class="dfn-panel" data-for="term-for-the-b-element" id="infopanel-for-term-for-the-b-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-b-element" style="display:none">Info about the 'b' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-b-element">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-classes">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#classes">https://html.spec.whatwg.org/multipage/dom.html#classes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-classes" class="dfn-panel" data-for="term-for-classes" id="infopanel-for-term-for-classes" role="menu">
+   <span id="infopaneltitle-for-term-for-classes" style="display:none">Info about the 'class' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#classes">https://html.spec.whatwg.org/multipage/dom.html#classes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-classes">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-elements">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-elements" class="dfn-panel" data-for="term-for-html-elements" id="infopanel-for-term-for-html-elements" role="menu">
+   <span id="infopaneltitle-for-term-for-html-elements" style="display:none">Info about the 'html elements' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-elements">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-i-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-i-element" class="dfn-panel" data-for="term-for-the-i-element" id="infopanel-for-term-for-the-i-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-i-element" style="display:none">Info about the 'i' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-i-element">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-presentational-hints">
-   <a href="https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints">https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-presentational-hints" class="dfn-panel" data-for="term-for-presentational-hints" id="infopanel-for-term-for-presentational-hints" role="menu">
+   <span id="infopaneltitle-for-term-for-presentational-hints" style="display:none">Info about the 'presentational hints' external reference.</span><a href="https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints">https://html.spec.whatwg.org/multipage/rendering.html#presentational-hints</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-presentational-hints">5.1. Default text colors</a>
     <li><a href="#ref-for-presentational-hints①">5.2. Default text background colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-rt-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-rt-element" class="dfn-panel" data-for="term-for-the-rt-element" id="infopanel-for-term-for-the-rt-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-rt-element" style="display:none">Info about the 'rt' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-rt-element">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-ruby-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-ruby-element" class="dfn-panel" data-for="term-for-the-ruby-element" id="infopanel-for-term-for-the-ruby-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-ruby-element" style="display:none">Info about the 'ruby' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-ruby-element">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rules-for-parsing-floating-point-number-values">
-   <a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rules-for-parsing-floating-point-number-values" class="dfn-panel" data-for="term-for-rules-for-parsing-floating-point-number-values" id="infopanel-for-term-for-rules-for-parsing-floating-point-number-values" role="menu">
+   <span id="infopaneltitle-for-term-for-rules-for-parsing-floating-point-number-values" style="display:none">Info about the 'rules for parsing floating-point number values' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values">https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-floating-point-number-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-parsing-floating-point-number-values">6.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-rules-for-parsing-floating-point-number-values①">6.3. WebVTT cue timings and settings parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-span-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-span-element" class="dfn-panel" data-for="term-for-the-span-element" id="infopanel-for-term-for-the-span-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-span-element" style="display:none">Info about the 'span' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-span-element">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-the-span-element①">(2)</a> <a href="#ref-for-the-span-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-track-srclang">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-track-srclang" class="dfn-panel" data-for="term-for-attr-track-srclang" id="infopanel-for-term-for-attr-track-srclang" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-track-srclang" style="display:none">Info about the 'srclang' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang">https://html.spec.whatwg.org/multipage/media.html#attr-track-srclang</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-track-srclang">8.1. Introduction</a> <a href="#ref-for-attr-track-srclang①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-style-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-style-element" class="dfn-panel" data-for="term-for-the-style-element" id="infopanel-for-term-for-the-style-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-style-element" style="display:none">Info about the 'style' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">https://html.spec.whatwg.org/multipage/semantics.html#the-style-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-style-element">1.3. Styling captions</a>
     <li><a href="#ref-for-the-style-element①">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-track-element">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">https://html.spec.whatwg.org/multipage/media.html#the-track-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-track-element" class="dfn-panel" data-for="term-for-the-track-element" id="infopanel-for-term-for-the-track-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-track-element" style="display:none">Info about the 'track' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">https://html.spec.whatwg.org/multipage/media.html#the-track-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-track-element">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-u-element">
-   <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-u-element" class="dfn-panel" data-for="term-for-the-u-element" id="infopanel-for-term-for-the-u-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-u-element" style="display:none">Info about the 'u' external reference.</span><a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element">https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-u-element">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-video">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-video" class="dfn-panel" data-for="term-for-video" id="infopanel-for-term-for-video" role="menu">
+   <span id="infopaneltitle-for-term-for-video" style="display:none">Info about the 'video' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#video">https://html.spec.whatwg.org/multipage/media.html#video</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-video">1.3. Styling captions</a>
     <li><a href="#ref-for-video①">7.1. Processing model</a> <a href="#ref-for-video②">(2)</a> <a href="#ref-for-video③">(3)</a>
@@ -6180,8 +6180,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-video⑦">8.2. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_case_sensitive">
-   <a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_case_sensitive" class="dfn-panel" data-for="term-for-def_case_sensitive" id="infopanel-for-term-for-def_case_sensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-def_case_sensitive" style="display:none">Info about the 'case-sensitive' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_case_sensitive">https://w3c.github.io/i18n-glossary/#def_case_sensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_case_sensitive">6.2. WebVTT region settings parsing</a> <a href="#ref-for-def_case_sensitive①">(2)</a> <a href="#ref-for-def_case_sensitive②">(3)</a> <a href="#ref-for-def_case_sensitive③">(4)</a> <a href="#ref-for-def_case_sensitive④">(5)</a> <a href="#ref-for-def_case_sensitive⑤">(6)</a> <a href="#ref-for-def_case_sensitive⑥">(7)</a>
     <li><a href="#ref-for-def_case_sensitive⑦">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-def_case_sensitive⑧">(2)</a> <a href="#ref-for-def_case_sensitive⑨">(3)</a> <a href="#ref-for-def_case_sensitive①⓪">(4)</a> <a href="#ref-for-def_case_sensitive①①">(5)</a> <a href="#ref-for-def_case_sensitive①②">(6)</a> <a href="#ref-for-def_case_sensitive①③">(7)</a> <a href="#ref-for-def_case_sensitive①④">(8)</a> <a href="#ref-for-def_case_sensitive①⑤">(9)</a> <a href="#ref-for-def_case_sensitive①⑥">(10)</a> <a href="#ref-for-def_case_sensitive①⑦">(11)</a> <a href="#ref-for-def_case_sensitive①⑧">(12)</a> <a href="#ref-for-def_case_sensitive①⑨">(13)</a> <a href="#ref-for-def_case_sensitive②⓪">(14)</a> <a href="#ref-for-def_case_sensitive②①">(15)</a> <a href="#ref-for-def_case_sensitive②②">(16)</a> <a href="#ref-for-def_case_sensitive②③">(17)</a> <a href="#ref-for-def_case_sensitive②④">(18)</a> <a href="#ref-for-def_case_sensitive②⑤">(19)</a>
@@ -6189,47 +6189,47 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-def_case_sensitive③⓪">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">4.3. WebVTT region settings</a>
     <li><a href="#ref-for-ascii-whitespace①">6.1. WebVTT file parsing</a> <a href="#ref-for-ascii-whitespace②">(2)</a>
     <li><a href="#ref-for-ascii-whitespace③">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-ascii-whitespace④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collect a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">6.1. WebVTT file parsing</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points②">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points③">(4)</a>
     <li><a href="#ref-for-collect-a-sequence-of-code-points④">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-collect-a-sequence-of-code-points⑤">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points⑥">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">4.1. WebVTT file structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sel-after">
-   <a href="https://drafts.csswg.org/selectors-3/#sel-after">https://drafts.csswg.org/selectors-3/#sel-after</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sel-after" class="dfn-panel" data-for="term-for-sel-after" id="infopanel-for-term-for-sel-after" role="menu">
+   <span id="infopaneltitle-for-term-for-sel-after" style="display:none">Info about the '::after' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#sel-after">https://drafts.csswg.org/selectors-3/#sel-after</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sel-after">Styling-related privacy and security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sel-before">
-   <a href="https://drafts.csswg.org/selectors-3/#sel-before">https://drafts.csswg.org/selectors-3/#sel-before</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sel-before" class="dfn-panel" data-for="term-for-sel-before" id="infopanel-for-term-for-sel-before" role="menu">
+   <span id="infopaneltitle-for-term-for-sel-before" style="display:none">Info about the '::before' external reference.</span><a href="https://drafts.csswg.org/selectors-3/#sel-before">https://drafts.csswg.org/selectors-3/#sel-before</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sel-before">Styling-related privacy and security</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-future-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#future-pseudo">https://drafts.csswg.org/selectors-4/#future-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-future-pseudo" class="dfn-panel" data-for="term-for-future-pseudo" id="infopanel-for-term-for-future-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-future-pseudo" style="display:none">Info about the ':future' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#future-pseudo">https://drafts.csswg.org/selectors-4/#future-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-future-pseudo">8.1. Introduction</a> <a href="#ref-for-future-pseudo①">(2)</a>
     <li><a href="#ref-for-future-pseudo②">8.2. Processing model</a>
@@ -6237,8 +6237,8 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-future-pseudo④">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-future-pseudo⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-past-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#past-pseudo">https://drafts.csswg.org/selectors-4/#past-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-past-pseudo" class="dfn-panel" data-for="term-for-past-pseudo" id="infopanel-for-term-for-past-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-past-pseudo" style="display:none">Info about the ':past' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#past-pseudo">https://drafts.csswg.org/selectors-4/#past-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-past-pseudo">8.1. Introduction</a> <a href="#ref-for-past-pseudo①">(2)</a>
     <li><a href="#ref-for-past-pseudo②">8.2. Processing model</a>
@@ -6246,72 +6246,72 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
     <li><a href="#ref-for-past-pseudo④">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-past-pseudo⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attribute-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attribute-selector" class="dfn-panel" data-for="term-for-attribute-selector" id="infopanel-for-term-for-attribute-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-attribute-selector" style="display:none">Info about the 'attribute selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-selector">8.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-class-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#class-selector">https://drafts.csswg.org/selectors-4/#class-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-class-selector" class="dfn-panel" data-for="term-for-class-selector" id="infopanel-for-term-for-class-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-class-selector" style="display:none">Info about the 'class selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#class-selector">https://drafts.csswg.org/selectors-4/#class-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-class-selector">8.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-id-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#id-selector">https://drafts.csswg.org/selectors-4/#id-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-id-selector" class="dfn-panel" data-for="term-for-id-selector" id="infopanel-for-term-for-id-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-id-selector" style="display:none">Info about the 'id selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#id-selector">https://drafts.csswg.org/selectors-4/#id-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-id-selector">8.1. Introduction</a> <a href="#ref-for-id-selector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-originating-element">
-   <a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-originating-element" class="dfn-panel" data-for="term-for-originating-element" id="infopanel-for-term-for-originating-element" role="menu">
+   <span id="infopaneltitle-for-term-for-originating-element" style="display:none">Info about the 'originating element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#originating-element">https://drafts.csswg.org/selectors-4/#originating-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-originating-element">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type-selector" class="dfn-panel" data-for="term-for-type-selector" id="infopanel-for-term-for-type-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-type-selector" style="display:none">Info about the 'type selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">8.1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">9.1. The VTTCue interface</a> <a href="#ref-for-idl-DOMString①">(2)</a>
     <li><a href="#ref-for-idl-DOMString②">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">9.1. The VTTCue interface</a>
     <li><a href="#ref-for-Exposed①">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indexsizeerror">
-   <a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indexsizeerror" class="dfn-panel" data-for="term-for-indexsizeerror" id="infopanel-for-term-for-indexsizeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-indexsizeerror" style="display:none">Info about the 'IndexSizeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indexsizeerror">9.1. The VTTCue interface</a> <a href="#ref-for-indexsizeerror①">(2)</a>
     <li><a href="#ref-for-indexsizeerror②">9.2. The VTTRegion interface</a> <a href="#ref-for-indexsizeerror③">(2)</a> <a href="#ref-for-indexsizeerror④">(3)</a> <a href="#ref-for-indexsizeerror⑤">(4)</a> <a href="#ref-for-indexsizeerror⑥">(5)</a> <a href="#ref-for-indexsizeerror⑦">(6)</a> <a href="#ref-for-indexsizeerror⑧">(7)</a> <a href="#ref-for-indexsizeerror⑨">(8)</a> <a href="#ref-for-indexsizeerror①⓪">(9)</a> <a href="#ref-for-indexsizeerror①①">(10)</a> <a href="#ref-for-indexsizeerror①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">9.1. The VTTCue interface</a> <a href="#ref-for-idl-double①">(2)</a> <a href="#ref-for-idl-double②">(3)</a> <a href="#ref-for-idl-double③">(4)</a>
     <li><a href="#ref-for-idl-double④">9.2. The VTTRegion interface</a> <a href="#ref-for-idl-double⑤">(2)</a> <a href="#ref-for-idl-double⑥">(3)</a> <a href="#ref-for-idl-double⑦">(4)</a> <a href="#ref-for-idl-double⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">9.2. The VTTRegion interface</a>
    </ul>
@@ -6716,28 +6716,28 @@ originally specified. <a data-link-type="biblio" href="#biblio-html" title="HTML
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="webvtt">
-   <b><a href="#webvtt">#webvtt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt" class="dfn-panel" data-for="webvtt" id="infopanel-for-webvtt" role="dialog">
+   <span id="infopaneltitle-for-webvtt" style="display:none">Info about the 'WebVTT' definition.</span><b><a href="#webvtt">#webvtt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt">2.1. Conformance classes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agents-that-do-not-support-css">
-   <b><a href="#user-agents-that-do-not-support-css">#user-agents-that-do-not-support-css</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agents-that-do-not-support-css" class="dfn-panel" data-for="user-agents-that-do-not-support-css" id="infopanel-for-user-agents-that-do-not-support-css" role="dialog">
+   <span id="infopaneltitle-for-user-agents-that-do-not-support-css" style="display:none">Info about the 'User agents that do not support CSS' definition.</span><b><a href="#user-agents-that-do-not-support-css">#user-agents-that-do-not-support-css</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agents-that-do-not-support-css">7. Rendering</a>
     <li><a href="#ref-for-user-agents-that-do-not-support-css①">8. CSS extensions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agents-that-do-not-support-a-full-html-css-engine">
-   <b><a href="#user-agents-that-do-not-support-a-full-html-css-engine">#user-agents-that-do-not-support-a-full-html-css-engine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agents-that-do-not-support-a-full-html-css-engine" class="dfn-panel" data-for="user-agents-that-do-not-support-a-full-html-css-engine" id="infopanel-for-user-agents-that-do-not-support-a-full-html-css-engine" role="dialog">
+   <span id="infopaneltitle-for-user-agents-that-do-not-support-a-full-html-css-engine" style="display:none">Info about the 'User agents that do not support a full HTML CSS engine' definition.</span><b><a href="#user-agents-that-do-not-support-a-full-html-css-engine">#user-agents-that-do-not-support-a-full-html-css-engine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agents-that-do-not-support-a-full-html-css-engine">2.1. Conformance classes</a>
     <li><a href="#ref-for-user-agents-that-do-not-support-a-full-html-css-engine①">7. Rendering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue">
-   <b><a href="#webvtt-cue">#webvtt-cue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue" class="dfn-panel" data-for="webvtt-cue" id="infopanel-for-webvtt-cue" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue" style="display:none">Info about the 'WebVTT cue' definition.</span><b><a href="#webvtt-cue">#webvtt-cue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue">1.1. A simple caption file</a>
     <li><a href="#ref-for-webvtt-cue①">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue②">(2)</a> <a href="#ref-for-webvtt-cue③">(3)</a> <a href="#ref-for-webvtt-cue④">(4)</a> <a href="#ref-for-webvtt-cue⑤">(5)</a> <a href="#ref-for-webvtt-cue⑥">(6)</a> <a href="#ref-for-webvtt-cue⑦">(7)</a> <a href="#ref-for-webvtt-cue⑧">(8)</a> <a href="#ref-for-webvtt-cue⑨">(9)</a> <a href="#ref-for-webvtt-cue①⓪">(10)</a> <a href="#ref-for-webvtt-cue①①">(11)</a> <a href="#ref-for-webvtt-cue①②">(12)</a>
@@ -6758,8 +6758,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue③⑤">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue③⑥">(2)</a> <a href="#ref-for-webvtt-cue③⑦">(3)</a> <a href="#ref-for-webvtt-cue③⑧">(4)</a> <a href="#ref-for-webvtt-cue③⑨">(5)</a> <a href="#ref-for-webvtt-cue④⓪">(6)</a> <a href="#ref-for-webvtt-cue④①">(7)</a> <a href="#ref-for-webvtt-cue④②">(8)</a> <a href="#ref-for-webvtt-cue④③">(9)</a> <a href="#ref-for-webvtt-cue④④">(10)</a> <a href="#ref-for-webvtt-cue④⑤">(11)</a> <a href="#ref-for-webvtt-cue④⑥">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-text">
-   <b><a href="#cue-text">#cue-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-text" class="dfn-panel" data-for="cue-text" id="infopanel-for-cue-text" role="dialog">
+   <span id="infopaneltitle-for-cue-text" style="display:none">Info about the 'A cue text' definition.</span><b><a href="#cue-text">#cue-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-text">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-cue-text①">(2)</a> <a href="#ref-for-cue-text②">(3)</a>
     <li><a href="#ref-for-cue-text③">3.5. WebVTT chapter cues</a>
@@ -6774,23 +6774,23 @@ title</a>
     <li><a href="#ref-for-cue-text①③">9.1. The VTTCue interface</a> <a href="#ref-for-cue-text①④">(2)</a> <a href="#ref-for-cue-text①⑤">(3)</a> <a href="#ref-for-cue-text①⑥">(4)</a> <a href="#ref-for-cue-text①⑦">(5)</a> <a href="#ref-for-cue-text①⑧">(6)</a> <a href="#ref-for-cue-text①⑨">(7)</a> <a href="#ref-for-cue-text②⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue">
-   <b><a href="#webvtt-caption-or-subtitle-cue">#webvtt-caption-or-subtitle-cue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-caption-or-subtitle-cue" class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue" id="infopanel-for-webvtt-caption-or-subtitle-cue" role="dialog">
+   <span id="infopaneltitle-for-webvtt-caption-or-subtitle-cue" style="display:none">Info about the 'WebVTT caption or subtitle cue' definition.</span><b><a href="#webvtt-caption-or-subtitle-cue">#webvtt-caption-or-subtitle-cue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue">3.4. WebVTT caption or subtitle regions</a>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue①">7. Rendering</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-box">
-   <b><a href="#webvtt-cue-box">#webvtt-cue-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-box" class="dfn-panel" data-for="webvtt-cue-box" id="infopanel-for-webvtt-cue-box" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-box" style="display:none">Info about the 'A cue box' definition.</span><b><a href="#webvtt-cue-box">#webvtt-cue-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-box">1.4. Other caption and subtitling features</a> <a href="#ref-for-webvtt-cue-box①">(2)</a> <a href="#ref-for-webvtt-cue-box②">(3)</a> <a href="#ref-for-webvtt-cue-box③">(4)</a> <a href="#ref-for-webvtt-cue-box④">(5)</a>
     <li><a href="#ref-for-webvtt-cue-box⑤">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-box⑥">(2)</a> <a href="#ref-for-webvtt-cue-box⑦">(3)</a> <a href="#ref-for-webvtt-cue-box⑧">(4)</a> <a href="#ref-for-webvtt-cue-box⑨">(5)</a> <a href="#ref-for-webvtt-cue-box①⓪">(6)</a> <a href="#ref-for-webvtt-cue-box①①">(7)</a> <a href="#ref-for-webvtt-cue-box①②">(8)</a> <a href="#ref-for-webvtt-cue-box①③">(9)</a> <a href="#ref-for-webvtt-cue-box①④">(10)</a> <a href="#ref-for-webvtt-cue-box①⑤">(11)</a> <a href="#ref-for-webvtt-cue-box①⑥">(12)</a> <a href="#ref-for-webvtt-cue-box①⑦">(13)</a> <a href="#ref-for-webvtt-cue-box①⑧">(14)</a> <a href="#ref-for-webvtt-cue-box①⑨">(15)</a> <a href="#ref-for-webvtt-cue-box②⓪">(16)</a> <a href="#ref-for-webvtt-cue-box②①">(17)</a> <a href="#ref-for-webvtt-cue-box②②">(18)</a>
     <li><a href="#ref-for-webvtt-cue-box②③">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-box②④">(2)</a> <a href="#ref-for-webvtt-cue-box②⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-writing-direction">
-   <b><a href="#webvtt-cue-writing-direction">#webvtt-cue-writing-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-writing-direction" class="dfn-panel" data-for="webvtt-cue-writing-direction" id="infopanel-for-webvtt-cue-writing-direction" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-writing-direction" style="display:none">Info about the 'A writing direction' definition.</span><b><a href="#webvtt-cue-writing-direction">#webvtt-cue-writing-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-writing-direction">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction②">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction③">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction④">(5)</a> <a href="#ref-for-webvtt-cue-writing-direction⑤">(6)</a> <a href="#ref-for-webvtt-cue-writing-direction⑥">(7)</a> <a href="#ref-for-webvtt-cue-writing-direction⑦">(8)</a> <a href="#ref-for-webvtt-cue-writing-direction⑧">(9)</a> <a href="#ref-for-webvtt-cue-writing-direction⑨">(10)</a> <a href="#ref-for-webvtt-cue-writing-direction①⓪">(11)</a>
     <li><a href="#ref-for-webvtt-cue-writing-direction①①">4.4. WebVTT cue settings</a>
@@ -6800,8 +6800,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-writing-direction③③">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-writing-direction③④">(2)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑤">(3)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑥">(4)</a> <a href="#ref-for-webvtt-cue-writing-direction③⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-horizontal-writing-direction">
-   <b><a href="#webvtt-cue-horizontal-writing-direction">#webvtt-cue-horizontal-writing-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-horizontal-writing-direction" class="dfn-panel" data-for="webvtt-cue-horizontal-writing-direction" id="infopanel-for-webvtt-cue-horizontal-writing-direction" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-horizontal-writing-direction" style="display:none">Info about the 'horizontal' definition.</span><b><a href="#webvtt-cue-horizontal-writing-direction">#webvtt-cue-horizontal-writing-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②">(3)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction③">(4)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction④">(5)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑤">(6)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑥">(7)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑦">(8)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑧">(9)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction⑨">(10)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①⓪">(11)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction①①">(12)</a>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction①②">6.1. WebVTT file parsing</a>
@@ -6810,8 +6810,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-horizontal-writing-direction②①">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②②">(2)</a> <a href="#ref-for-webvtt-cue-horizontal-writing-direction②③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-left-writing-direction">
-   <b><a href="#webvtt-cue-vertical-growing-left-writing-direction">#webvtt-cue-vertical-growing-left-writing-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-vertical-growing-left-writing-direction" class="dfn-panel" data-for="webvtt-cue-vertical-growing-left-writing-direction" id="infopanel-for-webvtt-cue-vertical-growing-left-writing-direction" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-vertical-growing-left-writing-direction" style="display:none">Info about the 'vertical growing left' definition.</span><b><a href="#webvtt-cue-vertical-growing-left-writing-direction">#webvtt-cue-vertical-growing-left-writing-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction②">(3)</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction③">6.3. WebVTT cue timings and settings parsing</a>
@@ -6819,8 +6819,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①①">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-left-writing-direction①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-vertical-growing-right-writing-direction">
-   <b><a href="#webvtt-cue-vertical-growing-right-writing-direction">#webvtt-cue-vertical-growing-right-writing-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-vertical-growing-right-writing-direction" class="dfn-panel" data-for="webvtt-cue-vertical-growing-right-writing-direction" id="infopanel-for-webvtt-cue-vertical-growing-right-writing-direction" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-vertical-growing-right-writing-direction" style="display:none">Info about the 'vertical growing right' definition.</span><b><a href="#webvtt-cue-vertical-growing-right-writing-direction">#webvtt-cue-vertical-growing-right-writing-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①">(2)</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction②">(3)</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction③">6.3. WebVTT cue timings and settings parsing</a>
@@ -6828,8 +6828,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①①">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-vertical-growing-right-writing-direction①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-snap-to-lines-flag">
-   <b><a href="#webvtt-cue-snap-to-lines-flag">#webvtt-cue-snap-to-lines-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-snap-to-lines-flag" class="dfn-panel" data-for="webvtt-cue-snap-to-lines-flag" id="infopanel-for-webvtt-cue-snap-to-lines-flag" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-snap-to-lines-flag" style="display:none">Info about the 'A snap-to-lines flag' definition.</span><b><a href="#webvtt-cue-snap-to-lines-flag">#webvtt-cue-snap-to-lines-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag②">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag③">(4)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag④">(5)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag⑤">(6)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag⑥">(7)</a>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag⑦">6.1. WebVTT file parsing</a>
@@ -6838,8 +6838,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-snap-to-lines-flag①③">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①④">(2)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑤">(3)</a> <a href="#ref-for-webvtt-cue-snap-to-lines-flag①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line">
-   <b><a href="#webvtt-cue-line">#webvtt-cue-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line" class="dfn-panel" data-for="webvtt-cue-line" id="infopanel-for-webvtt-cue-line" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line" style="display:none">Info about the 'A line' definition.</span><b><a href="#webvtt-cue-line">#webvtt-cue-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-line①">(2)</a> <a href="#ref-for-webvtt-cue-line②">(3)</a> <a href="#ref-for-webvtt-cue-line③">(4)</a> <a href="#ref-for-webvtt-cue-line④">(5)</a> <a href="#ref-for-webvtt-cue-line⑤">(6)</a> <a href="#ref-for-webvtt-cue-line⑥">(7)</a> <a href="#ref-for-webvtt-cue-line⑦">(8)</a> <a href="#ref-for-webvtt-cue-line⑧">(9)</a> <a href="#ref-for-webvtt-cue-line⑨">(10)</a> <a href="#ref-for-webvtt-cue-line①⓪">(11)</a> <a href="#ref-for-webvtt-cue-line①①">(12)</a> <a href="#ref-for-webvtt-cue-line①②">(13)</a> <a href="#ref-for-webvtt-cue-line①③">(14)</a> <a href="#ref-for-webvtt-cue-line①④">(15)</a> <a href="#ref-for-webvtt-cue-line①⑤">(16)</a> <a href="#ref-for-webvtt-cue-line①⑥">(17)</a> <a href="#ref-for-webvtt-cue-line①⑦">(18)</a> <a href="#ref-for-webvtt-cue-line①⑧">(19)</a> <a href="#ref-for-webvtt-cue-line①⑨">(20)</a>
     <li><a href="#ref-for-webvtt-cue-line②⓪">6.1. WebVTT file parsing</a>
@@ -6847,8 +6847,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line②③">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line②④">(2)</a> <a href="#ref-for-webvtt-cue-line②⑤">(3)</a> <a href="#ref-for-webvtt-cue-line②⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line-automatic">
-   <b><a href="#webvtt-cue-line-automatic">#webvtt-cue-line-automatic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line-automatic" class="dfn-panel" data-for="webvtt-cue-line-automatic" id="infopanel-for-webvtt-cue-line-automatic" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line-automatic" style="display:none">Info about the 'auto' definition.</span><b><a href="#webvtt-cue-line-automatic">#webvtt-cue-line-automatic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-automatic">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-line-automatic①">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic②">(3)</a>
     <li><a href="#ref-for-webvtt-cue-line-automatic③">6.1. WebVTT file parsing</a>
@@ -6856,15 +6856,15 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-automatic⑤">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-automatic⑥">(2)</a> <a href="#ref-for-webvtt-cue-line-automatic⑦">(3)</a> <a href="#ref-for-webvtt-cue-line-automatic⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-computed-line">
-   <b><a href="#cue-computed-line">#cue-computed-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-computed-line" class="dfn-panel" data-for="cue-computed-line" id="infopanel-for-cue-computed-line" role="dialog">
+   <span id="infopaneltitle-for-cue-computed-line" style="display:none">Info about the 'computed line' definition.</span><b><a href="#cue-computed-line">#cue-computed-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-computed-line">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-cue-computed-line①">7.2. Processing cue settings</a> <a href="#ref-for-cue-computed-line②">(2)</a> <a href="#ref-for-cue-computed-line③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line-alignment">
-   <b><a href="#webvtt-cue-line-alignment">#webvtt-cue-line-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line-alignment" class="dfn-panel" data-for="webvtt-cue-line-alignment" id="infopanel-for-webvtt-cue-line-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line-alignment" style="display:none">Info about the 'A line alignment' definition.</span><b><a href="#webvtt-cue-line-alignment">#webvtt-cue-line-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-line-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment③">(4)</a>
     <li><a href="#ref-for-webvtt-cue-line-alignment④">4.4. WebVTT cue settings</a>
@@ -6874,8 +6874,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-alignment①③">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-alignment①④">(2)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑤">(3)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑥">(4)</a> <a href="#ref-for-webvtt-cue-line-alignment①⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line-start-alignment">
-   <b><a href="#webvtt-cue-line-start-alignment">#webvtt-cue-line-start-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line-start-alignment" class="dfn-panel" data-for="webvtt-cue-line-start-alignment" id="infopanel-for-webvtt-cue-line-start-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line-start-alignment" style="display:none">Info about the 'Start alignment' definition.</span><b><a href="#webvtt-cue-line-start-alignment">#webvtt-cue-line-start-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-line-start-alignment②">(2)</a>
@@ -6884,8 +6884,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-start-alignment⑤">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-start-alignment⑥">(2)</a> <a href="#ref-for-webvtt-cue-line-start-alignment⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line-center-alignment">
-   <b><a href="#webvtt-cue-line-center-alignment">#webvtt-cue-line-center-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line-center-alignment" class="dfn-panel" data-for="webvtt-cue-line-center-alignment" id="infopanel-for-webvtt-cue-line-center-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line-center-alignment" style="display:none">Info about the 'Center alignment' definition.</span><b><a href="#webvtt-cue-line-center-alignment">#webvtt-cue-line-center-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment①">6.3. WebVTT cue timings and settings parsing</a>
@@ -6893,8 +6893,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-center-alignment④">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-center-alignment⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-line-end-alignment">
-   <b><a href="#webvtt-cue-line-end-alignment">#webvtt-cue-line-end-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-line-end-alignment" class="dfn-panel" data-for="webvtt-cue-line-end-alignment" id="infopanel-for-webvtt-cue-line-end-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-line-end-alignment" style="display:none">Info about the 'End alignment' definition.</span><b><a href="#webvtt-cue-line-end-alignment">#webvtt-cue-line-end-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment①">6.3. WebVTT cue timings and settings parsing</a>
@@ -6902,8 +6902,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-line-end-alignment④">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-line-end-alignment⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position">
-   <b><a href="#webvtt-cue-position">#webvtt-cue-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position" class="dfn-panel" data-for="webvtt-cue-position" id="infopanel-for-webvtt-cue-position" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position" style="display:none">Info about the 'A position' definition.</span><b><a href="#webvtt-cue-position">#webvtt-cue-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-position①">(2)</a> <a href="#ref-for-webvtt-cue-position②">(3)</a> <a href="#ref-for-webvtt-cue-position③">(4)</a> <a href="#ref-for-webvtt-cue-position④">(5)</a> <a href="#ref-for-webvtt-cue-position⑤">(6)</a> <a href="#ref-for-webvtt-cue-position⑥">(7)</a> <a href="#ref-for-webvtt-cue-position⑦">(8)</a> <a href="#ref-for-webvtt-cue-position⑧">(9)</a> <a href="#ref-for-webvtt-cue-position⑨">(10)</a> <a href="#ref-for-webvtt-cue-position①⓪">(11)</a> <a href="#ref-for-webvtt-cue-position①①">(12)</a> <a href="#ref-for-webvtt-cue-position①②">(13)</a> <a href="#ref-for-webvtt-cue-position①③">(14)</a> <a href="#ref-for-webvtt-cue-position①④">(15)</a> <a href="#ref-for-webvtt-cue-position①⑤">(16)</a> <a href="#ref-for-webvtt-cue-position①⑥">(17)</a> <a href="#ref-for-webvtt-cue-position①⑦">(18)</a> <a href="#ref-for-webvtt-cue-position①⑧">(19)</a>
     <li><a href="#ref-for-webvtt-cue-position①⑨">6.1. WebVTT file parsing</a>
@@ -6911,8 +6911,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position②②">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position②③">(2)</a> <a href="#ref-for-webvtt-cue-position②④">(3)</a> <a href="#ref-for-webvtt-cue-position②⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-automatic-position">
-   <b><a href="#webvtt-cue-automatic-position">#webvtt-cue-automatic-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-automatic-position" class="dfn-panel" data-for="webvtt-cue-automatic-position" id="infopanel-for-webvtt-cue-automatic-position" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-automatic-position" style="display:none">Info about the 'auto' definition.</span><b><a href="#webvtt-cue-automatic-position">#webvtt-cue-automatic-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-automatic-position">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-automatic-position①">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position②">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position③">(4)</a> <a href="#ref-for-webvtt-cue-automatic-position④">(5)</a>
     <li><a href="#ref-for-webvtt-cue-automatic-position⑤">6.1. WebVTT file parsing</a>
@@ -6920,15 +6920,15 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-automatic-position⑦">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-automatic-position⑧">(2)</a> <a href="#ref-for-webvtt-cue-automatic-position⑨">(3)</a> <a href="#ref-for-webvtt-cue-automatic-position①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-computed-position">
-   <b><a href="#cue-computed-position">#cue-computed-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-computed-position" class="dfn-panel" data-for="cue-computed-position" id="infopanel-for-cue-computed-position" role="dialog">
+   <span id="infopaneltitle-for-cue-computed-position" style="display:none">Info about the 'computed position' definition.</span><b><a href="#cue-computed-position">#cue-computed-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-computed-position">7.1. Processing model</a>
     <li><a href="#ref-for-cue-computed-position①">7.2. Processing cue settings</a> <a href="#ref-for-cue-computed-position②">(2)</a> <a href="#ref-for-cue-computed-position③">(3)</a> <a href="#ref-for-cue-computed-position④">(4)</a> <a href="#ref-for-cue-computed-position⑤">(5)</a> <a href="#ref-for-cue-computed-position⑥">(6)</a> <a href="#ref-for-cue-computed-position⑦">(7)</a> <a href="#ref-for-cue-computed-position⑧">(8)</a> <a href="#ref-for-cue-computed-position⑨">(9)</a> <a href="#ref-for-cue-computed-position①⓪">(10)</a> <a href="#ref-for-cue-computed-position①①">(11)</a> <a href="#ref-for-cue-computed-position①②">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position-alignment">
-   <b><a href="#webvtt-cue-position-alignment">#webvtt-cue-position-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position-alignment" class="dfn-panel" data-for="webvtt-cue-position-alignment" id="infopanel-for-webvtt-cue-position-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position-alignment" style="display:none">Info about the 'A position alignment' definition.</span><b><a href="#webvtt-cue-position-alignment">#webvtt-cue-position-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-position-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment④">(5)</a> <a href="#ref-for-webvtt-cue-position-alignment⑤">(6)</a>
     <li><a href="#ref-for-webvtt-cue-position-alignment⑥">6.1. WebVTT file parsing</a>
@@ -6936,8 +6936,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-alignment①⓪">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-alignment①①">(2)</a> <a href="#ref-for-webvtt-cue-position-alignment①②">(3)</a> <a href="#ref-for-webvtt-cue-position-alignment①③">(4)</a> <a href="#ref-for-webvtt-cue-position-alignment①④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position-line-left-alignment">
-   <b><a href="#webvtt-cue-position-line-left-alignment">#webvtt-cue-position-line-left-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position-line-left-alignment" class="dfn-panel" data-for="webvtt-cue-position-line-left-alignment" id="infopanel-for-webvtt-cue-position-line-left-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position-line-left-alignment" style="display:none">Info about the 'Line-left alignment' definition.</span><b><a href="#webvtt-cue-position-line-left-alignment">#webvtt-cue-position-line-left-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment③">(4)</a>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment④">4.4. WebVTT cue settings</a>
@@ -6946,8 +6946,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-line-left-alignment⑨">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-left-alignment①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position-center-alignment">
-   <b><a href="#webvtt-cue-position-center-alignment">#webvtt-cue-position-center-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position-center-alignment" class="dfn-panel" data-for="webvtt-cue-position-center-alignment" id="infopanel-for-webvtt-cue-position-center-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position-center-alignment" style="display:none">Info about the 'Center alignment' definition.</span><b><a href="#webvtt-cue-position-center-alignment">#webvtt-cue-position-center-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment①">6.3. WebVTT cue timings and settings parsing</a>
@@ -6956,8 +6956,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-center-alignment⑦">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-center-alignment⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position-line-right-alignment">
-   <b><a href="#webvtt-cue-position-line-right-alignment">#webvtt-cue-position-line-right-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position-line-right-alignment" class="dfn-panel" data-for="webvtt-cue-position-line-right-alignment" id="infopanel-for-webvtt-cue-position-line-right-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position-line-right-alignment" style="display:none">Info about the 'Line-right alignment' definition.</span><b><a href="#webvtt-cue-position-line-right-alignment">#webvtt-cue-position-line-right-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment②">(3)</a>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment③">4.4. WebVTT cue settings</a>
@@ -6967,24 +6967,25 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-position-line-right-alignment⑨">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-line-right-alignment①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-position-automatic-alignment">
-   <b><a href="#webvtt-cue-position-automatic-alignment">#webvtt-cue-position-automatic-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-position-automatic-alignment" class="dfn-panel" data-for="webvtt-cue-position-automatic-alignment" id="infopanel-for-webvtt-cue-position-automatic-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-position-automatic-alignment" style="display:none">Info about the 'Auto alignment' definition.</span><b><a href="#webvtt-cue-position-automatic-alignment">#webvtt-cue-position-automatic-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-position-automatic-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment①">(2)</a>
     <li><a href="#ref-for-webvtt-cue-position-automatic-alignment②">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-cue-position-automatic-alignment③">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment④">(2)</a> <a href="#ref-for-webvtt-cue-position-automatic-alignment⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-computed-position-alignment">
-   <b><a href="#cue-computed-position-alignment">#cue-computed-position-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-computed-position-alignment" class="dfn-panel" data-for="cue-computed-position-alignment" id="infopanel-for-cue-computed-position-alignment" role="dialog">
+   <span id="infopaneltitle-for-cue-computed-position-alignment" style="display:none">Info about the 'computed position
+  alignment' definition.</span><b><a href="#cue-computed-position-alignment">#cue-computed-position-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-computed-position-alignment">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-cue-computed-position-alignment①">7.1. Processing model</a> <a href="#ref-for-cue-computed-position-alignment②">(2)</a> <a href="#ref-for-cue-computed-position-alignment③">(3)</a>
     <li><a href="#ref-for-cue-computed-position-alignment④">7.2. Processing cue settings</a> <a href="#ref-for-cue-computed-position-alignment⑤">(2)</a> <a href="#ref-for-cue-computed-position-alignment⑥">(3)</a> <a href="#ref-for-cue-computed-position-alignment⑦">(4)</a> <a href="#ref-for-cue-computed-position-alignment⑧">(5)</a> <a href="#ref-for-cue-computed-position-alignment⑨">(6)</a> <a href="#ref-for-cue-computed-position-alignment①⓪">(7)</a> <a href="#ref-for-cue-computed-position-alignment①①">(8)</a> <a href="#ref-for-cue-computed-position-alignment①②">(9)</a> <a href="#ref-for-cue-computed-position-alignment①③">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-size">
-   <b><a href="#webvtt-cue-size">#webvtt-cue-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-size" class="dfn-panel" data-for="webvtt-cue-size" id="infopanel-for-webvtt-cue-size" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-size" style="display:none">Info about the 'A size' definition.</span><b><a href="#webvtt-cue-size">#webvtt-cue-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-size">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-size①">(2)</a> <a href="#ref-for-webvtt-cue-size②">(3)</a> <a href="#ref-for-webvtt-cue-size③">(4)</a> <a href="#ref-for-webvtt-cue-size④">(5)</a> <a href="#ref-for-webvtt-cue-size⑤">(6)</a>
     <li><a href="#ref-for-webvtt-cue-size⑥">6.1. WebVTT file parsing</a>
@@ -6993,8 +6994,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-size①①">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-size①②">(2)</a> <a href="#ref-for-webvtt-cue-size①③">(3)</a> <a href="#ref-for-webvtt-cue-size①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-text-alignment">
-   <b><a href="#webvtt-cue-text-alignment">#webvtt-cue-text-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-text-alignment" class="dfn-panel" data-for="webvtt-cue-text-alignment" id="infopanel-for-webvtt-cue-text-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-text-alignment" style="display:none">Info about the 'A text alignment' definition.</span><b><a href="#webvtt-cue-text-alignment">#webvtt-cue-text-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-text-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-text-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment④">(5)</a> <a href="#ref-for-webvtt-cue-text-alignment⑤">(6)</a> <a href="#ref-for-webvtt-cue-text-alignment⑥">(7)</a> <a href="#ref-for-webvtt-cue-text-alignment⑦">(8)</a> <a href="#ref-for-webvtt-cue-text-alignment⑧">(9)</a> <a href="#ref-for-webvtt-cue-text-alignment⑨">(10)</a> <a href="#ref-for-webvtt-cue-text-alignment①⓪">(11)</a> <a href="#ref-for-webvtt-cue-text-alignment①①">(12)</a> <a href="#ref-for-webvtt-cue-text-alignment①②">(13)</a> <a href="#ref-for-webvtt-cue-text-alignment①③">(14)</a>
     <li><a href="#ref-for-webvtt-cue-text-alignment①④">6.1. WebVTT file parsing</a>
@@ -7003,8 +7004,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-text-alignment②②">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-text-alignment②③">(2)</a> <a href="#ref-for-webvtt-cue-text-alignment②④">(3)</a> <a href="#ref-for-webvtt-cue-text-alignment②⑤">(4)</a> <a href="#ref-for-webvtt-cue-text-alignment②⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-start-alignment">
-   <b><a href="#webvtt-cue-start-alignment">#webvtt-cue-start-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-start-alignment" class="dfn-panel" data-for="webvtt-cue-start-alignment" id="infopanel-for-webvtt-cue-start-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-start-alignment" style="display:none">Info about the 'Start alignment' definition.</span><b><a href="#webvtt-cue-start-alignment">#webvtt-cue-start-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-start-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-start-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-start-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-start-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-start-alignment④">(5)</a> <a href="#ref-for-webvtt-cue-start-alignment⑤">(6)</a>
     <li><a href="#ref-for-webvtt-cue-start-alignment⑥">6.3. WebVTT cue timings and settings parsing</a>
@@ -7012,8 +7013,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-start-alignment⑧">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-start-alignment⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-center-alignment">
-   <b><a href="#webvtt-cue-center-alignment">#webvtt-cue-center-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-center-alignment" class="dfn-panel" data-for="webvtt-cue-center-alignment" id="infopanel-for-webvtt-cue-center-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-center-alignment" style="display:none">Info about the 'Center alignment' definition.</span><b><a href="#webvtt-cue-center-alignment">#webvtt-cue-center-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-center-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-center-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-center-alignment③">(4)</a>
     <li><a href="#ref-for-webvtt-cue-center-alignment④">6.1. WebVTT file parsing</a>
@@ -7022,8 +7023,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-center-alignment⑦">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-center-alignment⑧">(2)</a> <a href="#ref-for-webvtt-cue-center-alignment⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-end-alignment">
-   <b><a href="#webvtt-cue-end-alignment">#webvtt-cue-end-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-end-alignment" class="dfn-panel" data-for="webvtt-cue-end-alignment" id="infopanel-for-webvtt-cue-end-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-end-alignment" style="display:none">Info about the 'End alignment' definition.</span><b><a href="#webvtt-cue-end-alignment">#webvtt-cue-end-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-end-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-end-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-end-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-end-alignment③">(4)</a> <a href="#ref-for-webvtt-cue-end-alignment④">(5)</a>
     <li><a href="#ref-for-webvtt-cue-end-alignment⑤">6.3. WebVTT cue timings and settings parsing</a>
@@ -7031,8 +7032,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-end-alignment⑦">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-end-alignment⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-left-alignment">
-   <b><a href="#webvtt-cue-left-alignment">#webvtt-cue-left-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-left-alignment" class="dfn-panel" data-for="webvtt-cue-left-alignment" id="infopanel-for-webvtt-cue-left-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-left-alignment" style="display:none">Info about the 'Left alignment' definition.</span><b><a href="#webvtt-cue-left-alignment">#webvtt-cue-left-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-left-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-left-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-left-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-left-alignment③">(4)</a>
     <li><a href="#ref-for-webvtt-cue-left-alignment④">6.3. WebVTT cue timings and settings parsing</a>
@@ -7040,8 +7041,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-left-alignment⑥">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-left-alignment⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-right-alignment">
-   <b><a href="#webvtt-cue-right-alignment">#webvtt-cue-right-alignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-right-alignment" class="dfn-panel" data-for="webvtt-cue-right-alignment" id="infopanel-for-webvtt-cue-right-alignment" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-right-alignment" style="display:none">Info about the 'Right alignment' definition.</span><b><a href="#webvtt-cue-right-alignment">#webvtt-cue-right-alignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-right-alignment">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-cue-right-alignment①">(2)</a> <a href="#ref-for-webvtt-cue-right-alignment②">(3)</a> <a href="#ref-for-webvtt-cue-right-alignment③">(4)</a>
     <li><a href="#ref-for-webvtt-cue-right-alignment④">6.3. WebVTT cue timings and settings parsing</a>
@@ -7049,8 +7050,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-right-alignment⑥">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-right-alignment⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-region">
-   <b><a href="#webvtt-cue-region">#webvtt-cue-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-region" class="dfn-panel" data-for="webvtt-cue-region" id="infopanel-for-webvtt-cue-region" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-region" style="display:none">Info about the 'A region' definition.</span><b><a href="#webvtt-cue-region">#webvtt-cue-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-region">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-webvtt-cue-region①">6.1. WebVTT file parsing</a>
@@ -7059,8 +7060,8 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-region⑨">9.1. The VTTCue interface</a> <a href="#ref-for-webvtt-cue-region①⓪">(2)</a> <a href="#ref-for-webvtt-cue-region①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region">
-   <b><a href="#webvtt-region">#webvtt-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region" class="dfn-panel" data-for="webvtt-region" id="infopanel-for-webvtt-region" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region" style="display:none">Info about the 'WebVTT region' definition.</span><b><a href="#webvtt-region">#webvtt-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-webvtt-region①">(2)</a> <a href="#ref-for-webvtt-region②">(3)</a>
     <li><a href="#ref-for-webvtt-region③">3.4. WebVTT caption or subtitle regions</a> <a href="#ref-for-webvtt-region④">(2)</a>
@@ -7073,8 +7074,8 @@ title</a>
     <li><a href="#ref-for-webvtt-region①⑤">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region①⑥">(2)</a> <a href="#ref-for-webvtt-region①⑦">(3)</a> <a href="#ref-for-webvtt-region①⑧">(4)</a> <a href="#ref-for-webvtt-region①⑨">(5)</a> <a href="#ref-for-webvtt-region②⓪">(6)</a> <a href="#ref-for-webvtt-region②①">(7)</a> <a href="#ref-for-webvtt-region②②">(8)</a> <a href="#ref-for-webvtt-region②③">(9)</a> <a href="#ref-for-webvtt-region②④">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-identifier">
-   <b><a href="#webvtt-region-identifier">#webvtt-region-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-identifier" class="dfn-panel" data-for="webvtt-region-identifier" id="infopanel-for-webvtt-region-identifier" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-identifier" style="display:none">Info about the 'An identifier' definition.</span><b><a href="#webvtt-region-identifier">#webvtt-region-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-identifier">4.4. WebVTT cue settings</a>
     <li><a href="#ref-for-webvtt-region-identifier①">6.1. WebVTT file parsing</a>
@@ -7085,8 +7086,8 @@ title</a>
     <li><a href="#ref-for-webvtt-region-identifier⑥">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-identifier⑦">(2)</a> <a href="#ref-for-webvtt-region-identifier⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-width">
-   <b><a href="#webvtt-region-width">#webvtt-region-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-width" class="dfn-panel" data-for="webvtt-region-width" id="infopanel-for-webvtt-region-width" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-width" style="display:none">Info about the 'A width' definition.</span><b><a href="#webvtt-region-width">#webvtt-region-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-width">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-width①">6.2. WebVTT region settings parsing</a>
@@ -7094,8 +7095,8 @@ title</a>
     <li><a href="#ref-for-webvtt-region-width⑥">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-width⑦">(2)</a> <a href="#ref-for-webvtt-region-width⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-lines">
-   <b><a href="#webvtt-region-lines">#webvtt-region-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-lines" class="dfn-panel" data-for="webvtt-region-lines" id="infopanel-for-webvtt-region-lines" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-lines" style="display:none">Info about the 'A lines value' definition.</span><b><a href="#webvtt-region-lines">#webvtt-region-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-lines">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-lines①">6.2. WebVTT region settings parsing</a>
@@ -7103,8 +7104,8 @@ title</a>
     <li><a href="#ref-for-webvtt-region-lines③">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-lines④">(2)</a> <a href="#ref-for-webvtt-region-lines⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-anchor">
-   <b><a href="#webvtt-region-anchor">#webvtt-region-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-anchor" class="dfn-panel" data-for="webvtt-region-anchor" id="infopanel-for-webvtt-region-anchor" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-anchor" style="display:none">Info about the 'A region anchor point' definition.</span><b><a href="#webvtt-region-anchor">#webvtt-region-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-anchor">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-anchor①">6.2. WebVTT region settings parsing</a>
@@ -7112,16 +7113,16 @@ title</a>
     <li><a href="#ref-for-webvtt-region-anchor⑥">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-anchor⑦">(2)</a> <a href="#ref-for-webvtt-region-anchor⑧">(3)</a> <a href="#ref-for-webvtt-region-anchor⑨">(4)</a> <a href="#ref-for-webvtt-region-anchor①⓪">(5)</a> <a href="#ref-for-webvtt-region-anchor①①">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-viewport-anchor">
-   <b><a href="#webvtt-region-viewport-anchor">#webvtt-region-viewport-anchor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-viewport-anchor" class="dfn-panel" data-for="webvtt-region-viewport-anchor" id="infopanel-for-webvtt-region-viewport-anchor" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-viewport-anchor" style="display:none">Info about the 'A region viewport anchor point' definition.</span><b><a href="#webvtt-region-viewport-anchor">#webvtt-region-viewport-anchor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-viewport-anchor">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-viewport-anchor①">6.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-viewport-anchor②">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-viewport-anchor③">(2)</a> <a href="#ref-for-webvtt-region-viewport-anchor④">(3)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑤">(4)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑥">(5)</a> <a href="#ref-for-webvtt-region-viewport-anchor⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-scroll">
-   <b><a href="#webvtt-region-scroll">#webvtt-region-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-scroll" class="dfn-panel" data-for="webvtt-region-scroll" id="infopanel-for-webvtt-region-scroll" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-scroll" style="display:none">Info about the 'A scroll value' definition.</span><b><a href="#webvtt-region-scroll">#webvtt-region-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll①">6.2. WebVTT region settings parsing</a>
@@ -7129,31 +7130,31 @@ title</a>
     <li><a href="#ref-for-webvtt-region-scroll③">9.2. The VTTRegion interface</a> <a href="#ref-for-webvtt-region-scroll④">(2)</a> <a href="#ref-for-webvtt-region-scroll⑤">(3)</a> <a href="#ref-for-webvtt-region-scroll⑥">(4)</a> <a href="#ref-for-webvtt-region-scroll⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-scroll-none">
-   <b><a href="#webvtt-region-scroll-none">#webvtt-region-scroll-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-scroll-none" class="dfn-panel" data-for="webvtt-region-scroll-none" id="infopanel-for-webvtt-region-scroll-none" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-scroll-none" style="display:none">Info about the 'None' definition.</span><b><a href="#webvtt-region-scroll-none">#webvtt-region-scroll-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll-none">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll-none①">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-scroll-up">
-   <b><a href="#webvtt-region-scroll-up">#webvtt-region-scroll-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-scroll-up" class="dfn-panel" data-for="webvtt-region-scroll-up" id="infopanel-for-webvtt-region-scroll-up" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-scroll-up" style="display:none">Info about the 'Up' definition.</span><b><a href="#webvtt-region-scroll-up">#webvtt-region-scroll-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll-up">6.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-webvtt-region-scroll-up①">7.1. Processing model</a>
     <li><a href="#ref-for-webvtt-region-scroll-up②">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-track-list-of-regions">
-   <b><a href="#text-track-list-of-regions">#text-track-list-of-regions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-track-list-of-regions" class="dfn-panel" data-for="text-track-list-of-regions" id="infopanel-for-text-track-list-of-regions" role="dialog">
+   <span id="infopaneltitle-for-text-track-list-of-regions" style="display:none">Info about the 'A text track list of regions' definition.</span><b><a href="#text-track-list-of-regions">#text-track-list-of-regions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-track-list-of-regions">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-text-track-list-of-regions①">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-text-track-list-of-regions②">(2)</a>
     <li><a href="#ref-for-text-track-list-of-regions③">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-file">
-   <b><a href="#webvtt-file">#webvtt-file</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-file" class="dfn-panel" data-for="webvtt-file" id="infopanel-for-webvtt-file" role="dialog">
+   <span id="infopaneltitle-for-webvtt-file" style="display:none">Info about the 'WebVTT file' definition.</span><b><a href="#webvtt-file">#webvtt-file</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-file">2.1. Conformance classes</a> <a href="#ref-for-webvtt-file①">(2)</a> <a href="#ref-for-webvtt-file②">(3)</a> <a href="#ref-for-webvtt-file③">(4)</a> <a href="#ref-for-webvtt-file④">(5)</a> <a href="#ref-for-webvtt-file⑤">(6)</a>
     <li><a href="#ref-for-webvtt-file⑥">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-file⑦">(2)</a>
@@ -7165,14 +7166,14 @@ title</a>
     <li><a href="#ref-for-webvtt-file①③">6.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-file①④">(2)</a> <a href="#ref-for-webvtt-file①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-file-body">
-   <b><a href="#webvtt-file-body">#webvtt-file-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-file-body" class="dfn-panel" data-for="webvtt-file-body" id="infopanel-for-webvtt-file-body" role="dialog">
+   <span id="infopaneltitle-for-webvtt-file-body" style="display:none">Info about the 'WebVTT file body' definition.</span><b><a href="#webvtt-file-body">#webvtt-file-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-file-body">4.1. WebVTT file structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-line-terminator">
-   <b><a href="#webvtt-line-terminator">#webvtt-line-terminator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-line-terminator" class="dfn-panel" data-for="webvtt-line-terminator" id="infopanel-for-webvtt-line-terminator" role="dialog">
+   <span id="infopaneltitle-for-webvtt-line-terminator" style="display:none">Info about the 'WebVTT line terminator' definition.</span><b><a href="#webvtt-line-terminator">#webvtt-line-terminator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-line-terminator">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-line-terminator①">(2)</a> <a href="#ref-for-webvtt-line-terminator②">(3)</a> <a href="#ref-for-webvtt-line-terminator③">(4)</a> <a href="#ref-for-webvtt-line-terminator④">(5)</a> <a href="#ref-for-webvtt-line-terminator⑤">(6)</a> <a href="#ref-for-webvtt-line-terminator⑥">(7)</a> <a href="#ref-for-webvtt-line-terminator⑦">(8)</a> <a href="#ref-for-webvtt-line-terminator⑧">(9)</a> <a href="#ref-for-webvtt-line-terminator⑨">(10)</a> <a href="#ref-for-webvtt-line-terminator①⓪">(11)</a> <a href="#ref-for-webvtt-line-terminator①①">(12)</a> <a href="#ref-for-webvtt-line-terminator①②">(13)</a> <a href="#ref-for-webvtt-line-terminator①③">(14)</a> <a href="#ref-for-webvtt-line-terminator①④">(15)</a> <a href="#ref-for-webvtt-line-terminator①⑤">(16)</a>
     <li><a href="#ref-for-webvtt-line-terminator①⑥">4.2.1. WebVTT metadata text</a> <a href="#ref-for-webvtt-line-terminator①⑦">(2)</a> <a href="#ref-for-webvtt-line-terminator①⑧">(3)</a>
@@ -7181,27 +7182,27 @@ title</a>
     <li><a href="#ref-for-webvtt-line-terminator②⑤">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-line-terminator②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-definition-block">
-   <b><a href="#webvtt-region-definition-block">#webvtt-region-definition-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-definition-block" class="dfn-panel" data-for="webvtt-region-definition-block" id="infopanel-for-webvtt-region-definition-block" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-definition-block" style="display:none">Info about the 'WebVTT region definition block' definition.</span><b><a href="#webvtt-region-definition-block">#webvtt-region-definition-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-definition-block">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-region-definition-block①">4.3. WebVTT region settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-style-block">
-   <b><a href="#webvtt-style-block">#webvtt-style-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-style-block" class="dfn-panel" data-for="webvtt-style-block" id="infopanel-for-webvtt-style-block" role="dialog">
+   <span id="infopaneltitle-for-webvtt-style-block" style="display:none">Info about the 'WebVTT style block' definition.</span><b><a href="#webvtt-style-block">#webvtt-style-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-style-block">4.1. WebVTT file structure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-block">
-   <b><a href="#webvtt-cue-block">#webvtt-cue-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-block" class="dfn-panel" data-for="webvtt-cue-block" id="infopanel-for-webvtt-cue-block" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-block" style="display:none">Info about the 'WebVTT cue block' definition.</span><b><a href="#webvtt-cue-block">#webvtt-cue-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-block">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-block①">(2)</a> <a href="#ref-for-webvtt-cue-block②">(3)</a> <a href="#ref-for-webvtt-cue-block③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-payload">
-   <b><a href="#cue-payload">#cue-payload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-payload" class="dfn-panel" data-for="cue-payload" id="infopanel-for-cue-payload" role="dialog">
+   <span id="infopaneltitle-for-cue-payload" style="display:none">Info about the 'cue payload' definition.</span><b><a href="#cue-payload">#cue-payload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-payload">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-cue-payload①">4.2.2. WebVTT caption or subtitle cue text</a>
@@ -7210,56 +7211,56 @@ title</a>
     <li><a href="#ref-for-cue-payload④">4.6.3. WebVTT file using caption or subtitle cue text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-identifier">
-   <b><a href="#webvtt-cue-identifier">#webvtt-cue-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-identifier" class="dfn-panel" data-for="webvtt-cue-identifier" id="infopanel-for-webvtt-cue-identifier" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-identifier" style="display:none">Info about the 'WebVTT cue identifier' definition.</span><b><a href="#webvtt-cue-identifier">#webvtt-cue-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-identifier">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-identifier①">(2)</a> <a href="#ref-for-webvtt-cue-identifier②">(3)</a> <a href="#ref-for-webvtt-cue-identifier③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-timings">
-   <b><a href="#webvtt-cue-timings">#webvtt-cue-timings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-timings" class="dfn-panel" data-for="webvtt-cue-timings" id="infopanel-for-webvtt-cue-timings" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-timings" style="display:none">Info about the 'WebVTT cue timings' definition.</span><b><a href="#webvtt-cue-timings">#webvtt-cue-timings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-timings">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-cue-timings①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-timestamp">
-   <b><a href="#webvtt-timestamp">#webvtt-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-timestamp" class="dfn-panel" data-for="webvtt-timestamp" id="infopanel-for-webvtt-timestamp" role="dialog">
+   <span id="infopaneltitle-for-webvtt-timestamp" style="display:none">Info about the 'WebVTT timestamp' definition.</span><b><a href="#webvtt-timestamp">#webvtt-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-timestamp">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-timestamp①">(2)</a> <a href="#ref-for-webvtt-timestamp②">(3)</a> <a href="#ref-for-webvtt-timestamp③">(4)</a> <a href="#ref-for-webvtt-timestamp④">(5)</a>
     <li><a href="#ref-for-webvtt-timestamp⑤">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-timestamp⑥">(2)</a>
     <li><a href="#ref-for-webvtt-timestamp⑦">6.5. WebVTT cue text DOM construction rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-settings-list">
-   <b><a href="#webvtt-cue-settings-list">#webvtt-cue-settings-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-settings-list" class="dfn-panel" data-for="webvtt-cue-settings-list" id="infopanel-for-webvtt-cue-settings-list" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-settings-list" style="display:none">Info about the 'WebVTT cue settings list' definition.</span><b><a href="#webvtt-cue-settings-list">#webvtt-cue-settings-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-settings-list">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-cue-settings-list①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-cue-settings-list②">(2)</a>
     <li><a href="#ref-for-webvtt-cue-settings-list③">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-settings-list④">(2)</a> <a href="#ref-for-webvtt-cue-settings-list⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-setting">
-   <b><a href="#webvtt-cue-setting">#webvtt-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-setting" class="dfn-panel" data-for="webvtt-cue-setting" id="infopanel-for-webvtt-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-setting" style="display:none">Info about the 'WebVTT cue settings' definition.</span><b><a href="#webvtt-cue-setting">#webvtt-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting①">(2)</a> <a href="#ref-for-webvtt-cue-setting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-setting-name">
-   <b><a href="#webvtt-cue-setting-name">#webvtt-cue-setting-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-setting-name" class="dfn-panel" data-for="webvtt-cue-setting-name" id="infopanel-for-webvtt-cue-setting-name" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-setting-name" style="display:none">Info about the 'WebVTT cue setting name' definition.</span><b><a href="#webvtt-cue-setting-name">#webvtt-cue-setting-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-setting-name">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-cue-setting-name①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-name②">(2)</a> <a href="#ref-for-webvtt-cue-setting-name③">(3)</a> <a href="#ref-for-webvtt-cue-setting-name④">(4)</a> <a href="#ref-for-webvtt-cue-setting-name⑤">(5)</a> <a href="#ref-for-webvtt-cue-setting-name⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-setting-value">
-   <b><a href="#webvtt-cue-setting-value">#webvtt-cue-setting-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-setting-value" class="dfn-panel" data-for="webvtt-cue-setting-value" id="infopanel-for-webvtt-cue-setting-value" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-setting-value" style="display:none">Info about the 'WebVTT cue setting value' definition.</span><b><a href="#webvtt-cue-setting-value">#webvtt-cue-setting-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-setting-value">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-cue-setting-value①">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-cue-setting-value②">(2)</a> <a href="#ref-for-webvtt-cue-setting-value③">(3)</a> <a href="#ref-for-webvtt-cue-setting-value④">(4)</a> <a href="#ref-for-webvtt-cue-setting-value⑤">(5)</a> <a href="#ref-for-webvtt-cue-setting-value⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-percentage">
-   <b><a href="#webvtt-percentage">#webvtt-percentage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-percentage" class="dfn-panel" data-for="webvtt-percentage" id="infopanel-for-webvtt-percentage" role="dialog">
+   <span id="infopaneltitle-for-webvtt-percentage" style="display:none">Info about the 'WebVTT percentage' definition.</span><b><a href="#webvtt-percentage">#webvtt-percentage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-percentage">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-percentage①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-percentage②">(2)</a> <a href="#ref-for-webvtt-percentage③">(3)</a> <a href="#ref-for-webvtt-percentage④">(4)</a> <a href="#ref-for-webvtt-percentage⑤">(5)</a>
@@ -7267,22 +7268,22 @@ title</a>
     <li><a href="#ref-for-webvtt-percentage⑨">6.2. WebVTT region settings parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-comment-block">
-   <b><a href="#webvtt-comment-block">#webvtt-comment-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-comment-block" class="dfn-panel" data-for="webvtt-comment-block" id="infopanel-for-webvtt-comment-block" role="dialog">
+   <span id="infopaneltitle-for-webvtt-comment-block" style="display:none">Info about the 'WebVTT comment block' definition.</span><b><a href="#webvtt-comment-block">#webvtt-comment-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-comment-block">4.1. WebVTT file structure</a> <a href="#ref-for-webvtt-comment-block①">(2)</a> <a href="#ref-for-webvtt-comment-block②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-metadata-text">
-   <b><a href="#webvtt-metadata-text">#webvtt-metadata-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-metadata-text" class="dfn-panel" data-for="webvtt-metadata-text" id="infopanel-for-webvtt-metadata-text" role="dialog">
+   <span id="infopaneltitle-for-webvtt-metadata-text" style="display:none">Info about the 'WebVTT metadata text' definition.</span><b><a href="#webvtt-metadata-text">#webvtt-metadata-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-metadata-text">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-metadata-text①">4.2.1. WebVTT metadata text</a>
     <li><a href="#ref-for-webvtt-metadata-text②">4.6.1. WebVTT file using metadata content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-text">
-   <b><a href="#webvtt-caption-or-subtitle-cue-text">#webvtt-caption-or-subtitle-cue-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-caption-or-subtitle-cue-text" class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-text" id="infopanel-for-webvtt-caption-or-subtitle-cue-text" role="dialog">
+   <span id="infopaneltitle-for-webvtt-caption-or-subtitle-cue-text" style="display:none">Info about the 'WebVTT caption or subtitle cue text' definition.</span><b><a href="#webvtt-caption-or-subtitle-cue-text">#webvtt-caption-or-subtitle-cue-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text">2.1. Conformance classes</a>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text①">4.1. WebVTT file structure</a>
@@ -7291,8 +7292,8 @@ title</a>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-text④">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text⑤">(2)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text⑥">(3)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text⑦">(4)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text⑧">(5)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text⑨">(6)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text①⓪">(7)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-text①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-components">
-   <b><a href="#webvtt-caption-or-subtitle-cue-components">#webvtt-caption-or-subtitle-cue-components</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-caption-or-subtitle-cue-components" class="dfn-panel" data-for="webvtt-caption-or-subtitle-cue-components" id="infopanel-for-webvtt-caption-or-subtitle-cue-components" role="dialog">
+   <span id="infopaneltitle-for-webvtt-caption-or-subtitle-cue-components" style="display:none">Info about the 'WebVTT caption or subtitle cue components' definition.</span><b><a href="#webvtt-caption-or-subtitle-cue-components">#webvtt-caption-or-subtitle-cue-components</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-components">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-components①">(2)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-components②">(3)</a> <a href="#ref-for-webvtt-caption-or-subtitle-cue-components③">(4)</a>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-components④">5. Default classes for WebVTT Caption or Subtitle Cue Components</a>
@@ -7300,8 +7301,8 @@ title</a>
     <li><a href="#ref-for-webvtt-caption-or-subtitle-cue-components⑥">5.2. Default text background colors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cue-component-class-names">
-   <b><a href="#cue-component-class-names">#cue-component-class-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cue-component-class-names" class="dfn-panel" data-for="cue-component-class-names" id="infopanel-for-cue-component-class-names" role="dialog">
+   <span id="infopaneltitle-for-cue-component-class-names" style="display:none">Info about the 'cue component class names' definition.</span><b><a href="#cue-component-class-names">#cue-component-class-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cue-component-class-names">5. Default classes for WebVTT Caption or Subtitle Cue Components</a>
     <li><a href="#ref-for-cue-component-class-names①">5.1. Default text colors</a> <a href="#ref-for-cue-component-class-names②">(2)</a>
@@ -7309,225 +7310,226 @@ title</a>
     <li><a href="#ref-for-cue-component-class-names⑤">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-internal-text">
-   <b><a href="#webvtt-cue-internal-text">#webvtt-cue-internal-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-internal-text" class="dfn-panel" data-for="webvtt-cue-internal-text" id="infopanel-for-webvtt-cue-internal-text" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-internal-text" style="display:none">Info about the 'WebVTT cue internal text' definition.</span><b><a href="#webvtt-cue-internal-text">#webvtt-cue-internal-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-internal-text">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-internal-text①">(2)</a> <a href="#ref-for-webvtt-cue-internal-text②">(3)</a> <a href="#ref-for-webvtt-cue-internal-text③">(4)</a> <a href="#ref-for-webvtt-cue-internal-text④">(5)</a> <a href="#ref-for-webvtt-cue-internal-text⑤">(6)</a> <a href="#ref-for-webvtt-cue-internal-text⑥">(7)</a> <a href="#ref-for-webvtt-cue-internal-text⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-class-span">
-   <b><a href="#webvtt-cue-class-span">#webvtt-cue-class-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-class-span" class="dfn-panel" data-for="webvtt-cue-class-span" id="infopanel-for-webvtt-cue-class-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-class-span" style="display:none">Info about the 'WebVTT cue class span' definition.</span><b><a href="#webvtt-cue-class-span">#webvtt-cue-class-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-class-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-class-span①">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-italics-span">
-   <b><a href="#webvtt-cue-italics-span">#webvtt-cue-italics-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-italics-span" class="dfn-panel" data-for="webvtt-cue-italics-span" id="infopanel-for-webvtt-cue-italics-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-italics-span" style="display:none">Info about the 'WebVTT cue italics span' definition.</span><b><a href="#webvtt-cue-italics-span">#webvtt-cue-italics-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-italics-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-italics-span①">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-bold-span">
-   <b><a href="#webvtt-cue-bold-span">#webvtt-cue-bold-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-bold-span" class="dfn-panel" data-for="webvtt-cue-bold-span" id="infopanel-for-webvtt-cue-bold-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-bold-span" style="display:none">Info about the 'WebVTT cue bold span' definition.</span><b><a href="#webvtt-cue-bold-span">#webvtt-cue-bold-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-bold-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-bold-span①">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-underline-span">
-   <b><a href="#webvtt-cue-underline-span">#webvtt-cue-underline-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-underline-span" class="dfn-panel" data-for="webvtt-cue-underline-span" id="infopanel-for-webvtt-cue-underline-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-underline-span" style="display:none">Info about the 'WebVTT cue underline span' definition.</span><b><a href="#webvtt-cue-underline-span">#webvtt-cue-underline-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-underline-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-underline-span①">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-ruby-span">
-   <b><a href="#webvtt-cue-ruby-span">#webvtt-cue-ruby-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-ruby-span" class="dfn-panel" data-for="webvtt-cue-ruby-span" id="infopanel-for-webvtt-cue-ruby-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-ruby-span" style="display:none">Info about the 'WebVTT cue ruby span' definition.</span><b><a href="#webvtt-cue-ruby-span">#webvtt-cue-ruby-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-ruby-span">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-ruby-span①">(2)</a>
     <li><a href="#ref-for-webvtt-cue-ruby-span②">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-ruby-text-span">
-   <b><a href="#webvtt-cue-ruby-text-span">#webvtt-cue-ruby-text-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-ruby-text-span" class="dfn-panel" data-for="webvtt-cue-ruby-text-span" id="infopanel-for-webvtt-cue-ruby-text-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-ruby-text-span" style="display:none">Info about the 'WebVTT cue ruby text span' definition.</span><b><a href="#webvtt-cue-ruby-text-span">#webvtt-cue-ruby-text-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-ruby-text-span">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-voice-span">
-   <b><a href="#webvtt-cue-voice-span">#webvtt-cue-voice-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-voice-span" class="dfn-panel" data-for="webvtt-cue-voice-span" id="infopanel-for-webvtt-cue-voice-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-voice-span" style="display:none">Info about the 'WebVTT cue voice span' definition.</span><b><a href="#webvtt-cue-voice-span">#webvtt-cue-voice-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-voice-span">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-voice-span①">(2)</a>
     <li><a href="#ref-for-webvtt-cue-voice-span②">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-language-span">
-   <b><a href="#webvtt-cue-language-span">#webvtt-cue-language-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-language-span" class="dfn-panel" data-for="webvtt-cue-language-span" id="infopanel-for-webvtt-cue-language-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-language-span" style="display:none">Info about the 'WebVTT cue language span' definition.</span><b><a href="#webvtt-cue-language-span">#webvtt-cue-language-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-language-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-language-span①">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-span-start-tag">
-   <b><a href="#webvtt-cue-span-start-tag">#webvtt-cue-span-start-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-span-start-tag" class="dfn-panel" data-for="webvtt-cue-span-start-tag" id="infopanel-for-webvtt-cue-span-start-tag" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-span-start-tag" style="display:none">Info about the 'WebVTT cue span start tag' definition.</span><b><a href="#webvtt-cue-span-start-tag">#webvtt-cue-span-start-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-span-start-tag">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-span-start-tag①">(2)</a> <a href="#ref-for-webvtt-cue-span-start-tag②">(3)</a> <a href="#ref-for-webvtt-cue-span-start-tag③">(4)</a> <a href="#ref-for-webvtt-cue-span-start-tag④">(5)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑤">(6)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑥">(7)</a> <a href="#ref-for-webvtt-cue-span-start-tag⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-span-end-tag">
-   <b><a href="#webvtt-cue-span-end-tag">#webvtt-cue-span-end-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-span-end-tag" class="dfn-panel" data-for="webvtt-cue-span-end-tag" id="infopanel-for-webvtt-cue-span-end-tag" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-span-end-tag" style="display:none">Info about the 'WebVTT cue span end tag' definition.</span><b><a href="#webvtt-cue-span-end-tag">#webvtt-cue-span-end-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-span-end-tag">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-span-end-tag①">(2)</a> <a href="#ref-for-webvtt-cue-span-end-tag②">(3)</a> <a href="#ref-for-webvtt-cue-span-end-tag③">(4)</a> <a href="#ref-for-webvtt-cue-span-end-tag④">(5)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑤">(6)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑥">(7)</a> <a href="#ref-for-webvtt-cue-span-end-tag⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-timestamp">
-   <b><a href="#webvtt-cue-timestamp">#webvtt-cue-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-timestamp" class="dfn-panel" data-for="webvtt-cue-timestamp" id="infopanel-for-webvtt-cue-timestamp" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-timestamp" style="display:none">Info about the 'WebVTT cue timestamp' definition.</span><b><a href="#webvtt-cue-timestamp">#webvtt-cue-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-timestamp">4.2.2. WebVTT caption or subtitle cue text</a> <a href="#ref-for-webvtt-cue-timestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-text-span">
-   <b><a href="#webvtt-cue-text-span">#webvtt-cue-text-span</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-text-span" class="dfn-panel" data-for="webvtt-cue-text-span" id="infopanel-for-webvtt-cue-text-span" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-text-span" style="display:none">Info about the 'WebVTT cue text span' definition.</span><b><a href="#webvtt-cue-text-span">#webvtt-cue-text-span</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-text-span">4.2.2. WebVTT caption or subtitle cue text</a>
     <li><a href="#ref-for-webvtt-cue-text-span①">4.2.3. WebVTT chapter title text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-span-start-tag-annotation-text">
-   <b><a href="#webvtt-cue-span-start-tag-annotation-text">#webvtt-cue-span-start-tag-annotation-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-span-start-tag-annotation-text" class="dfn-panel" data-for="webvtt-cue-span-start-tag-annotation-text" id="infopanel-for-webvtt-cue-span-start-tag-annotation-text" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-span-start-tag-annotation-text" style="display:none">Info about the 'WebVTT cue span start tag annotation text' definition.</span><b><a href="#webvtt-cue-span-start-tag-annotation-text">#webvtt-cue-span-start-tag-annotation-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-span-start-tag-annotation-text">4.2.2. WebVTT caption or subtitle cue text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-chapter-title-text">
-   <b><a href="#webvtt-chapter-title-text">#webvtt-chapter-title-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-chapter-title-text" class="dfn-panel" data-for="webvtt-chapter-title-text" id="infopanel-for-webvtt-chapter-title-text" role="dialog">
+   <span id="infopaneltitle-for-webvtt-chapter-title-text" style="display:none">Info about the 'WebVTT chapter title text' definition.</span><b><a href="#webvtt-chapter-title-text">#webvtt-chapter-title-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-chapter-title-text">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-chapter-title-text①">4.6.2. WebVTT file using chapter title text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-settings-list">
-   <b><a href="#webvtt-region-settings-list">#webvtt-region-settings-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-settings-list" class="dfn-panel" data-for="webvtt-region-settings-list" id="infopanel-for-webvtt-region-settings-list" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-settings-list" style="display:none">Info about the 'WebVTT region settings list' definition.</span><b><a href="#webvtt-region-settings-list">#webvtt-region-settings-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-settings-list">4.1. WebVTT file structure</a>
     <li><a href="#ref-for-webvtt-region-settings-list①">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-settings-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-identifier-setting">
-   <b><a href="#webvtt-region-identifier-setting">#webvtt-region-identifier-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-identifier-setting" class="dfn-panel" data-for="webvtt-region-identifier-setting" id="infopanel-for-webvtt-region-identifier-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-identifier-setting" style="display:none">Info about the 'WebVTT region identifier setting' definition.</span><b><a href="#webvtt-region-identifier-setting">#webvtt-region-identifier-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-identifier-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-identifier-setting①">(2)</a> <a href="#ref-for-webvtt-region-identifier-setting②">(3)</a> <a href="#ref-for-webvtt-region-identifier-setting③">(4)</a> <a href="#ref-for-webvtt-region-identifier-setting④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-width-setting">
-   <b><a href="#webvtt-region-width-setting">#webvtt-region-width-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-width-setting" class="dfn-panel" data-for="webvtt-region-width-setting" id="infopanel-for-webvtt-region-width-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-width-setting" style="display:none">Info about the 'WebVTT region width setting' definition.</span><b><a href="#webvtt-region-width-setting">#webvtt-region-width-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-width-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-width-setting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-lines-setting">
-   <b><a href="#webvtt-region-lines-setting">#webvtt-region-lines-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-lines-setting" class="dfn-panel" data-for="webvtt-region-lines-setting" id="infopanel-for-webvtt-region-lines-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-lines-setting" style="display:none">Info about the 'WebVTT region lines setting' definition.</span><b><a href="#webvtt-region-lines-setting">#webvtt-region-lines-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-lines-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-lines-setting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-anchor-setting">
-   <b><a href="#webvtt-region-anchor-setting">#webvtt-region-anchor-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-anchor-setting" class="dfn-panel" data-for="webvtt-region-anchor-setting" id="infopanel-for-webvtt-region-anchor-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-anchor-setting" style="display:none">Info about the 'WebVTT region anchor setting' definition.</span><b><a href="#webvtt-region-anchor-setting">#webvtt-region-anchor-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-anchor-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-anchor-setting①">(2)</a> <a href="#ref-for-webvtt-region-anchor-setting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-viewport-anchor-setting">
-   <b><a href="#webvtt-region-viewport-anchor-setting">#webvtt-region-viewport-anchor-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-viewport-anchor-setting" class="dfn-panel" data-for="webvtt-region-viewport-anchor-setting" id="infopanel-for-webvtt-region-viewport-anchor-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-viewport-anchor-setting" style="display:none">Info about the 'WebVTT region viewport anchor setting' definition.</span><b><a href="#webvtt-region-viewport-anchor-setting">#webvtt-region-viewport-anchor-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-viewport-anchor-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-viewport-anchor-setting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-scroll-setting">
-   <b><a href="#webvtt-region-scroll-setting">#webvtt-region-scroll-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-scroll-setting" class="dfn-panel" data-for="webvtt-region-scroll-setting" id="infopanel-for-webvtt-region-scroll-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-scroll-setting" style="display:none">Info about the 'WebVTT region scroll setting' definition.</span><b><a href="#webvtt-region-scroll-setting">#webvtt-region-scroll-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-scroll-setting">4.3. WebVTT region settings</a> <a href="#ref-for-webvtt-region-scroll-setting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-vertical-text-cue-setting">
-   <b><a href="#webvtt-vertical-text-cue-setting">#webvtt-vertical-text-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-vertical-text-cue-setting" class="dfn-panel" data-for="webvtt-vertical-text-cue-setting" id="infopanel-for-webvtt-vertical-text-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-vertical-text-cue-setting" style="display:none">Info about the 'WebVTT vertical text cue setting' definition.</span><b><a href="#webvtt-vertical-text-cue-setting">#webvtt-vertical-text-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-vertical-text-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-vertical-text-cue-setting①">(2)</a> <a href="#ref-for-webvtt-vertical-text-cue-setting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-line-cue-setting">
-   <b><a href="#webvtt-line-cue-setting">#webvtt-line-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-line-cue-setting" class="dfn-panel" data-for="webvtt-line-cue-setting" id="infopanel-for-webvtt-line-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-line-cue-setting" style="display:none">Info about the 'WebVTT line cue setting' definition.</span><b><a href="#webvtt-line-cue-setting">#webvtt-line-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-line-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-line-cue-setting①">(2)</a> <a href="#ref-for-webvtt-line-cue-setting②">(3)</a> <a href="#ref-for-webvtt-line-cue-setting③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-position-cue-setting">
-   <b><a href="#webvtt-position-cue-setting">#webvtt-position-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-position-cue-setting" class="dfn-panel" data-for="webvtt-position-cue-setting" id="infopanel-for-webvtt-position-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-position-cue-setting" style="display:none">Info about the 'WebVTT position cue setting' definition.</span><b><a href="#webvtt-position-cue-setting">#webvtt-position-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-position-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-position-cue-setting①">(2)</a> <a href="#ref-for-webvtt-position-cue-setting②">(3)</a> <a href="#ref-for-webvtt-position-cue-setting③">(4)</a> <a href="#ref-for-webvtt-position-cue-setting④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-size-cue-setting">
-   <b><a href="#webvtt-size-cue-setting">#webvtt-size-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-size-cue-setting" class="dfn-panel" data-for="webvtt-size-cue-setting" id="infopanel-for-webvtt-size-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-size-cue-setting" style="display:none">Info about the 'WebVTT size cue setting' definition.</span><b><a href="#webvtt-size-cue-setting">#webvtt-size-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-size-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-size-cue-setting①">(2)</a> <a href="#ref-for-webvtt-size-cue-setting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-alignment-cue-setting">
-   <b><a href="#webvtt-alignment-cue-setting">#webvtt-alignment-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-alignment-cue-setting" class="dfn-panel" data-for="webvtt-alignment-cue-setting" id="infopanel-for-webvtt-alignment-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-alignment-cue-setting" style="display:none">Info about the 'WebVTT alignment cue setting' definition.</span><b><a href="#webvtt-alignment-cue-setting">#webvtt-alignment-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-alignment-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-alignment-cue-setting①">(2)</a> <a href="#ref-for-webvtt-alignment-cue-setting②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-cue-setting">
-   <b><a href="#webvtt-region-cue-setting">#webvtt-region-cue-setting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-cue-setting" class="dfn-panel" data-for="webvtt-region-cue-setting" id="infopanel-for-webvtt-region-cue-setting" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-cue-setting" style="display:none">Info about the 'WebVTT region cue setting' definition.</span><b><a href="#webvtt-region-cue-setting">#webvtt-region-cue-setting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-cue-setting">4.4. WebVTT cue settings</a> <a href="#ref-for-webvtt-region-cue-setting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-file-using-only-nested-cues">
-   <b><a href="#webvtt-file-using-only-nested-cues">#webvtt-file-using-only-nested-cues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-file-using-only-nested-cues" class="dfn-panel" data-for="webvtt-file-using-only-nested-cues" id="infopanel-for-webvtt-file-using-only-nested-cues" role="dialog">
+   <span id="infopaneltitle-for-webvtt-file-using-only-nested-cues" style="display:none">Info about the 'WebVTT file
+using only nested cues' definition.</span><b><a href="#webvtt-file-using-only-nested-cues">#webvtt-file-using-only-nested-cues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-file-using-only-nested-cues">4.5.1. WebVTT file using only nested cues</a> <a href="#ref-for-webvtt-file-using-only-nested-cues①">(2)</a>
     <li><a href="#ref-for-webvtt-file-using-only-nested-cues②">4.6.2. WebVTT file using chapter title text</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-parser">
-   <b><a href="#webvtt-parser">#webvtt-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-parser" class="dfn-panel" data-for="webvtt-parser" id="infopanel-for-webvtt-parser" role="dialog">
+   <span id="infopaneltitle-for-webvtt-parser" style="display:none">Info about the 'WebVTT parser' definition.</span><b><a href="#webvtt-parser">#webvtt-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-parser">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-webvtt-parser①">6.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-parser②">(2)</a> <a href="#ref-for-webvtt-parser③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="incremental-webvtt-parser">
-   <b><a href="#incremental-webvtt-parser">#incremental-webvtt-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-incremental-webvtt-parser" class="dfn-panel" data-for="incremental-webvtt-parser" id="infopanel-for-incremental-webvtt-parser" role="dialog">
+   <span id="infopaneltitle-for-incremental-webvtt-parser" style="display:none">Info about the 'incremental WebVTT parser' definition.</span><b><a href="#incremental-webvtt-parser">#incremental-webvtt-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incremental-webvtt-parser">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-parser-algorithm">
-   <b><a href="#webvtt-parser-algorithm">#webvtt-parser-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-parser-algorithm" class="dfn-panel" data-for="webvtt-parser-algorithm" id="infopanel-for-webvtt-parser-algorithm" role="dialog">
+   <span id="infopaneltitle-for-webvtt-parser-algorithm" style="display:none">Info about the 'WebVTT parser algorithm' definition.</span><b><a href="#webvtt-parser-algorithm">#webvtt-parser-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-parser-algorithm">6.1. WebVTT file parsing</a>
     <li><a href="#ref-for-webvtt-parser-algorithm①">6.2. WebVTT region settings parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-a-webvtt-block">
-   <b><a href="#collect-a-webvtt-block">#collect-a-webvtt-block</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-a-webvtt-block" class="dfn-panel" data-for="collect-a-webvtt-block" id="infopanel-for-collect-a-webvtt-block" role="dialog">
+   <span id="infopaneltitle-for-collect-a-webvtt-block" style="display:none">Info about the 'collect a WebVTT block' definition.</span><b><a href="#collect-a-webvtt-block">#collect-a-webvtt-block</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-webvtt-block">6.1. WebVTT file parsing</a> <a href="#ref-for-collect-a-webvtt-block①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-webvtt-region-settings">
-   <b><a href="#collect-webvtt-region-settings">#collect-webvtt-region-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-webvtt-region-settings" class="dfn-panel" data-for="collect-webvtt-region-settings" id="infopanel-for-collect-webvtt-region-settings" role="dialog">
+   <span id="infopaneltitle-for-collect-webvtt-region-settings" style="display:none">Info about the 'collect WebVTT region settings' definition.</span><b><a href="#collect-webvtt-region-settings">#collect-webvtt-region-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-webvtt-region-settings">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-region-object">
-   <b><a href="#webvtt-region-object">#webvtt-region-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-region-object" class="dfn-panel" data-for="webvtt-region-object" id="infopanel-for-webvtt-region-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-region-object" style="display:none">Info about the 'WebVTT region object' definition.</span><b><a href="#webvtt-region-object">#webvtt-region-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-region-object">6.1. WebVTT file parsing</a> <a href="#ref-for-webvtt-region-object①">(2)</a>
     <li><a href="#ref-for-webvtt-region-object②">6.2. WebVTT region settings parsing</a>
@@ -7538,34 +7540,34 @@ title</a>
     <li><a href="#ref-for-webvtt-region-object①①">8.2.3. The ::cue-region pseudo-element</a> <a href="#ref-for-webvtt-region-object①②">(2)</a> <a href="#ref-for-webvtt-region-object①③">(3)</a> <a href="#ref-for-webvtt-region-object①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-percentage-string">
-   <b><a href="#parse-a-percentage-string">#parse-a-percentage-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-percentage-string" class="dfn-panel" data-for="parse-a-percentage-string" id="infopanel-for-parse-a-percentage-string" role="dialog">
+   <span id="infopaneltitle-for-parse-a-percentage-string" style="display:none">Info about the 'parse a percentage string' definition.</span><b><a href="#parse-a-percentage-string">#parse-a-percentage-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-percentage-string">6.2. WebVTT region settings parsing</a> <a href="#ref-for-parse-a-percentage-string①">(2)</a> <a href="#ref-for-parse-a-percentage-string②">(3)</a> <a href="#ref-for-parse-a-percentage-string③">(4)</a> <a href="#ref-for-parse-a-percentage-string④">(5)</a>
     <li><a href="#ref-for-parse-a-percentage-string⑤">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-parse-a-percentage-string⑥">(2)</a> <a href="#ref-for-parse-a-percentage-string⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-webvtt-cue-timings-and-settings">
-   <b><a href="#collect-webvtt-cue-timings-and-settings">#collect-webvtt-cue-timings-and-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-webvtt-cue-timings-and-settings" class="dfn-panel" data-for="collect-webvtt-cue-timings-and-settings" id="infopanel-for-collect-webvtt-cue-timings-and-settings" role="dialog">
+   <span id="infopaneltitle-for-collect-webvtt-cue-timings-and-settings" style="display:none">Info about the 'collect WebVTT cue timings and settings' definition.</span><b><a href="#collect-webvtt-cue-timings-and-settings">#collect-webvtt-cue-timings-and-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-webvtt-cue-timings-and-settings">6.1. WebVTT file parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-the-webvtt-cue-settings">
-   <b><a href="#parse-the-webvtt-cue-settings">#parse-the-webvtt-cue-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-the-webvtt-cue-settings" class="dfn-panel" data-for="parse-the-webvtt-cue-settings" id="infopanel-for-parse-the-webvtt-cue-settings" role="dialog">
+   <span id="infopaneltitle-for-parse-the-webvtt-cue-settings" style="display:none">Info about the 'parse the WebVTT cue settings' definition.</span><b><a href="#parse-the-webvtt-cue-settings">#parse-the-webvtt-cue-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-the-webvtt-cue-settings">6.3. WebVTT cue timings and settings parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-a-webvtt-timestamp">
-   <b><a href="#collect-a-webvtt-timestamp">#collect-a-webvtt-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-a-webvtt-timestamp" class="dfn-panel" data-for="collect-a-webvtt-timestamp" id="infopanel-for-collect-a-webvtt-timestamp" role="dialog">
+   <span id="infopaneltitle-for-collect-a-webvtt-timestamp" style="display:none">Info about the 'collect a WebVTT timestamp' definition.</span><b><a href="#collect-a-webvtt-timestamp">#collect-a-webvtt-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-webvtt-timestamp">6.3. WebVTT cue timings and settings parsing</a> <a href="#ref-for-collect-a-webvtt-timestamp①">(2)</a>
     <li><a href="#ref-for-collect-a-webvtt-timestamp②">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-node-object">
-   <b><a href="#webvtt-node-object">#webvtt-node-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-node-object" class="dfn-panel" data-for="webvtt-node-object" id="infopanel-for-webvtt-node-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-node-object" style="display:none">Info about the 'WebVTT Node Object' definition.</span><b><a href="#webvtt-node-object">#webvtt-node-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-node-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-object①">(2)</a> <a href="#ref-for-webvtt-node-object②">(3)</a> <a href="#ref-for-webvtt-node-object③">(4)</a> <a href="#ref-for-webvtt-node-object④">(5)</a>
     <li><a href="#ref-for-webvtt-node-object⑤">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-node-object⑥">(2)</a> <a href="#ref-for-webvtt-node-object⑦">(3)</a>
@@ -7576,8 +7578,8 @@ title</a>
     <li><a href="#ref-for-webvtt-node-object①⑤">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-node-object①⑥">(2)</a> <a href="#ref-for-webvtt-node-object①⑦">(3)</a> <a href="#ref-for-webvtt-node-object①⑧">(4)</a> <a href="#ref-for-webvtt-node-object①⑨">(5)</a> <a href="#ref-for-webvtt-node-object②⓪">(6)</a> <a href="#ref-for-webvtt-node-object②①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-internal-node-object">
-   <b><a href="#webvtt-internal-node-object">#webvtt-internal-node-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-internal-node-object" class="dfn-panel" data-for="webvtt-internal-node-object" id="infopanel-for-webvtt-internal-node-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-internal-node-object" style="display:none">Info about the 'WebVTT Internal Node Objects' definition.</span><b><a href="#webvtt-internal-node-object">#webvtt-internal-node-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-internal-node-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-internal-node-object①">(2)</a> <a href="#ref-for-webvtt-internal-node-object②">(3)</a> <a href="#ref-for-webvtt-internal-node-object③">(4)</a> <a href="#ref-for-webvtt-internal-node-object④">(5)</a> <a href="#ref-for-webvtt-internal-node-object⑤">(6)</a> <a href="#ref-for-webvtt-internal-node-object⑥">(7)</a>
     <li><a href="#ref-for-webvtt-internal-node-object⑦">6.5. WebVTT cue text DOM construction rules</a>
@@ -7586,8 +7588,9 @@ title</a>
     <li><a href="#ref-for-webvtt-internal-node-object①④">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-internal-node-object①⑤">(2)</a> <a href="#ref-for-webvtt-internal-node-object①⑥">(3)</a> <a href="#ref-for-webvtt-internal-node-object①⑦">(4)</a> <a href="#ref-for-webvtt-internal-node-object①⑧">(5)</a> <a href="#ref-for-webvtt-internal-node-object①⑨">(6)</a> <a href="#ref-for-webvtt-internal-node-object②⓪">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-classes">
-   <b><a href="#webvtt-node-objects-applicable-classes">#webvtt-node-objects-applicable-classes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-node-objects-applicable-classes" class="dfn-panel" data-for="webvtt-node-objects-applicable-classes" id="infopanel-for-webvtt-node-objects-applicable-classes" role="dialog">
+   <span id="infopaneltitle-for-webvtt-node-objects-applicable-classes" style="display:none">Info about the 'applicable
+classes' definition.</span><b><a href="#webvtt-node-objects-applicable-classes">#webvtt-node-objects-applicable-classes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-node-objects-applicable-classes">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-classes①">(2)</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-classes②">6.5. WebVTT cue text DOM construction rules</a>
@@ -7595,8 +7598,8 @@ title</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-classes④">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-node-objects-applicable-language">
-   <b><a href="#webvtt-node-objects-applicable-language">#webvtt-node-objects-applicable-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-node-objects-applicable-language" class="dfn-panel" data-for="webvtt-node-objects-applicable-language" id="infopanel-for-webvtt-node-objects-applicable-language" role="dialog">
+   <span id="infopaneltitle-for-webvtt-node-objects-applicable-language" style="display:none">Info about the 'applicable language' definition.</span><b><a href="#webvtt-node-objects-applicable-language">#webvtt-node-objects-applicable-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-node-objects-applicable-language">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-node-objects-applicable-language①">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language②">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language③">(4)</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-language④">6.5. WebVTT cue text DOM construction rules</a>
@@ -7604,8 +7607,8 @@ title</a>
     <li><a href="#ref-for-webvtt-node-objects-applicable-language⑨">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-node-objects-applicable-language①⓪">(2)</a> <a href="#ref-for-webvtt-node-objects-applicable-language①①">(3)</a> <a href="#ref-for-webvtt-node-objects-applicable-language①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-webvtt-node-objects">
-   <b><a href="#list-of-webvtt-node-objects">#list-of-webvtt-node-objects</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-webvtt-node-objects" class="dfn-panel" data-for="list-of-webvtt-node-objects" id="infopanel-for-list-of-webvtt-node-objects" role="dialog">
+   <span id="infopaneltitle-for-list-of-webvtt-node-objects" style="display:none">Info about the 'Lists of WebVTT Node Objects' definition.</span><b><a href="#list-of-webvtt-node-objects">#list-of-webvtt-node-objects</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-webvtt-node-objects">6.2. WebVTT region settings parsing</a>
     <li><a href="#ref-for-list-of-webvtt-node-objects①">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-list-of-webvtt-node-objects②">(2)</a>
@@ -7621,16 +7624,16 @@ title</a>
     <li><a href="#ref-for-list-of-webvtt-node-objects③②">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-list-of-webvtt-node-objects③③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-class-object">
-   <b><a href="#webvtt-class-object">#webvtt-class-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-class-object" class="dfn-panel" data-for="webvtt-class-object" id="infopanel-for-webvtt-class-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-class-object" style="display:none">Info about the 'WebVTT Class Objects' definition.</span><b><a href="#webvtt-class-object">#webvtt-class-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-class-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-class-object①">(2)</a>
     <li><a href="#ref-for-webvtt-class-object②">6.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-webvtt-class-object③">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-italic-object">
-   <b><a href="#webvtt-italic-object">#webvtt-italic-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-italic-object" class="dfn-panel" data-for="webvtt-italic-object" id="infopanel-for-webvtt-italic-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-italic-object" style="display:none">Info about the 'WebVTT Italic Objects' definition.</span><b><a href="#webvtt-italic-object">#webvtt-italic-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-italic-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-italic-object①">(2)</a>
     <li><a href="#ref-for-webvtt-italic-object②">6.5. WebVTT cue text DOM construction rules</a>
@@ -7638,8 +7641,8 @@ title</a>
     <li><a href="#ref-for-webvtt-italic-object④">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-bold-object">
-   <b><a href="#webvtt-bold-object">#webvtt-bold-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-bold-object" class="dfn-panel" data-for="webvtt-bold-object" id="infopanel-for-webvtt-bold-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-bold-object" style="display:none">Info about the 'WebVTT Bold Objects' definition.</span><b><a href="#webvtt-bold-object">#webvtt-bold-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-bold-object">1.3. Styling captions</a>
     <li><a href="#ref-for-webvtt-bold-object①">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-bold-object②">(2)</a>
@@ -7648,8 +7651,8 @@ title</a>
     <li><a href="#ref-for-webvtt-bold-object⑤">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-underline-object">
-   <b><a href="#webvtt-underline-object">#webvtt-underline-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-underline-object" class="dfn-panel" data-for="webvtt-underline-object" id="infopanel-for-webvtt-underline-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-underline-object" style="display:none">Info about the 'WebVTT Underline Objects' definition.</span><b><a href="#webvtt-underline-object">#webvtt-underline-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-underline-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-underline-object①">(2)</a>
     <li><a href="#ref-for-webvtt-underline-object②">6.5. WebVTT cue text DOM construction rules</a>
@@ -7657,8 +7660,8 @@ title</a>
     <li><a href="#ref-for-webvtt-underline-object④">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-ruby-object">
-   <b><a href="#webvtt-ruby-object">#webvtt-ruby-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-ruby-object" class="dfn-panel" data-for="webvtt-ruby-object" id="infopanel-for-webvtt-ruby-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-ruby-object" style="display:none">Info about the 'WebVTT Ruby Objects' definition.</span><b><a href="#webvtt-ruby-object">#webvtt-ruby-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-ruby-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-object①">(2)</a> <a href="#ref-for-webvtt-ruby-object②">(3)</a>
     <li><a href="#ref-for-webvtt-ruby-object③">6.5. WebVTT cue text DOM construction rules</a>
@@ -7667,8 +7670,8 @@ title</a>
     <li><a href="#ref-for-webvtt-ruby-object⑥">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-ruby-text-object">
-   <b><a href="#webvtt-ruby-text-object">#webvtt-ruby-text-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-ruby-text-object" class="dfn-panel" data-for="webvtt-ruby-text-object" id="infopanel-for-webvtt-ruby-text-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-ruby-text-object" style="display:none">Info about the 'WebVTT Ruby Text Objects' definition.</span><b><a href="#webvtt-ruby-text-object">#webvtt-ruby-text-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-ruby-text-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-ruby-text-object①">(2)</a> <a href="#ref-for-webvtt-ruby-text-object②">(3)</a>
     <li><a href="#ref-for-webvtt-ruby-text-object③">6.5. WebVTT cue text DOM construction rules</a>
@@ -7679,8 +7682,8 @@ title</a>
     <li><a href="#ref-for-webvtt-ruby-text-object⑧">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-voice-object">
-   <b><a href="#webvtt-voice-object">#webvtt-voice-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-voice-object" class="dfn-panel" data-for="webvtt-voice-object" id="infopanel-for-webvtt-voice-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-voice-object" style="display:none">Info about the 'WebVTT Voice Objects' definition.</span><b><a href="#webvtt-voice-object">#webvtt-voice-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-voice-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-voice-object①">(2)</a> <a href="#ref-for-webvtt-voice-object②">(3)</a>
     <li><a href="#ref-for-webvtt-voice-object③">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-voice-object④">(2)</a>
@@ -7688,8 +7691,8 @@ title</a>
     <li><a href="#ref-for-webvtt-voice-object⑥">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-voice-object⑦">(2)</a> <a href="#ref-for-webvtt-voice-object⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-language-object">
-   <b><a href="#webvtt-language-object">#webvtt-language-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-language-object" class="dfn-panel" data-for="webvtt-language-object" id="infopanel-for-webvtt-language-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-language-object" style="display:none">Info about the 'WebVTT Language Objects' definition.</span><b><a href="#webvtt-language-object">#webvtt-language-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-language-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-language-object①">(2)</a>
     <li><a href="#ref-for-webvtt-language-object②">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-language-object③">(2)</a>
@@ -7697,15 +7700,15 @@ title</a>
     <li><a href="#ref-for-webvtt-language-object⑤">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-language-object⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-leaf-node-object">
-   <b><a href="#webvtt-leaf-node-object">#webvtt-leaf-node-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-leaf-node-object" class="dfn-panel" data-for="webvtt-leaf-node-object" id="infopanel-for-webvtt-leaf-node-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-leaf-node-object" style="display:none">Info about the 'WebVTT Leaf Node Objects' definition.</span><b><a href="#webvtt-leaf-node-object">#webvtt-leaf-node-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-leaf-node-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-leaf-node-object①">(2)</a>
     <li><a href="#ref-for-webvtt-leaf-node-object②">8.2.1. The ::cue pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-text-object">
-   <b><a href="#webvtt-text-object">#webvtt-text-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-text-object" class="dfn-panel" data-for="webvtt-text-object" id="infopanel-for-webvtt-text-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-text-object" style="display:none">Info about the 'WebVTT Text Objects' definition.</span><b><a href="#webvtt-text-object">#webvtt-text-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-text-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-text-object①">(2)</a> <a href="#ref-for-webvtt-text-object②">(3)</a>
     <li><a href="#ref-for-webvtt-text-object③">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-text-object④">(2)</a>
@@ -7714,8 +7717,8 @@ title</a>
     <li><a href="#ref-for-webvtt-text-object⑥">7.3. Obtaining CSS boxes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-timestamp-object">
-   <b><a href="#webvtt-timestamp-object">#webvtt-timestamp-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-timestamp-object" class="dfn-panel" data-for="webvtt-timestamp-object" id="infopanel-for-webvtt-timestamp-object" role="dialog">
+   <span id="infopaneltitle-for-webvtt-timestamp-object" style="display:none">Info about the 'WebVTT Timestamp Objects' definition.</span><b><a href="#webvtt-timestamp-object">#webvtt-timestamp-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-timestamp-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-timestamp-object①">(2)</a>
     <li><a href="#ref-for-webvtt-timestamp-object②">6.5. WebVTT cue text DOM construction rules</a> <a href="#ref-for-webvtt-timestamp-object③">(2)</a>
@@ -7723,8 +7726,8 @@ title</a>
     <li><a href="#ref-for-webvtt-timestamp-object⑤">8.2.2. The :past and :future pseudo-classes</a> <a href="#ref-for-webvtt-timestamp-object⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-text-parsing-rules">
-   <b><a href="#webvtt-cue-text-parsing-rules">#webvtt-cue-text-parsing-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-text-parsing-rules" class="dfn-panel" data-for="webvtt-cue-text-parsing-rules" id="infopanel-for-webvtt-cue-text-parsing-rules" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-text-parsing-rules" style="display:none">Info about the 'WebVTT cue text parsing rules' definition.</span><b><a href="#webvtt-cue-text-parsing-rules">#webvtt-cue-text-parsing-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-text-parsing-rules">6.6. WebVTT rules for extracting the chapter
 title</a>
@@ -7732,92 +7735,92 @@ title</a>
     <li><a href="#ref-for-webvtt-cue-text-parsing-rules②">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attach-a-webvtt-internal-node-object">
-   <b><a href="#attach-a-webvtt-internal-node-object">#attach-a-webvtt-internal-node-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attach-a-webvtt-internal-node-object" class="dfn-panel" data-for="attach-a-webvtt-internal-node-object" id="infopanel-for-attach-a-webvtt-internal-node-object" role="dialog">
+   <span id="infopaneltitle-for-attach-a-webvtt-internal-node-object" style="display:none">Info about the 'attach a WebVTT Internal Node Object' definition.</span><b><a href="#attach-a-webvtt-internal-node-object">#attach-a-webvtt-internal-node-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attach-a-webvtt-internal-node-object">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-attach-a-webvtt-internal-node-object①">(2)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object②">(3)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object③">(4)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object④">(5)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑤">(6)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑥">(7)</a> <a href="#ref-for-attach-a-webvtt-internal-node-object⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-text-tokenizer">
-   <b><a href="#webvtt-cue-text-tokenizer">#webvtt-cue-text-tokenizer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-text-tokenizer" class="dfn-panel" data-for="webvtt-cue-text-tokenizer" id="infopanel-for-webvtt-cue-text-tokenizer" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-text-tokenizer" style="display:none">Info about the 'WebVTT cue text tokenizer' definition.</span><b><a href="#webvtt-cue-text-tokenizer">#webvtt-cue-text-tokenizer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-text-tokenizer">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-data-state">
-   <b><a href="#webvtt-data-state">#webvtt-data-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-data-state" class="dfn-panel" data-for="webvtt-data-state" id="infopanel-for-webvtt-data-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-data-state" style="display:none">Info about the 'WebVTT data state' definition.</span><b><a href="#webvtt-data-state">#webvtt-data-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-data-state">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-data-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="html-character-reference-in-data-state">
-   <b><a href="#html-character-reference-in-data-state">#html-character-reference-in-data-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-html-character-reference-in-data-state" class="dfn-panel" data-for="html-character-reference-in-data-state" id="infopanel-for-html-character-reference-in-data-state" role="dialog">
+   <span id="infopaneltitle-for-html-character-reference-in-data-state" style="display:none">Info about the 'HTML character reference in data state' definition.</span><b><a href="#html-character-reference-in-data-state">#html-character-reference-in-data-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-character-reference-in-data-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-tag-state">
-   <b><a href="#webvtt-tag-state">#webvtt-tag-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-tag-state" class="dfn-panel" data-for="webvtt-tag-state" id="infopanel-for-webvtt-tag-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-tag-state" style="display:none">Info about the 'WebVTT tag state' definition.</span><b><a href="#webvtt-tag-state">#webvtt-tag-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-tag-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-start-tag-state">
-   <b><a href="#webvtt-start-tag-state">#webvtt-start-tag-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-start-tag-state" class="dfn-panel" data-for="webvtt-start-tag-state" id="infopanel-for-webvtt-start-tag-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-start-tag-state" style="display:none">Info about the 'WebVTT start tag state' definition.</span><b><a href="#webvtt-start-tag-state">#webvtt-start-tag-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-start-tag-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-start-tag-class-state">
-   <b><a href="#webvtt-start-tag-class-state">#webvtt-start-tag-class-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-start-tag-class-state" class="dfn-panel" data-for="webvtt-start-tag-class-state" id="infopanel-for-webvtt-start-tag-class-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-start-tag-class-state" style="display:none">Info about the 'WebVTT start tag class state' definition.</span><b><a href="#webvtt-start-tag-class-state">#webvtt-start-tag-class-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-start-tag-class-state">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-class-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-start-tag-annotation-state">
-   <b><a href="#webvtt-start-tag-annotation-state">#webvtt-start-tag-annotation-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-start-tag-annotation-state" class="dfn-panel" data-for="webvtt-start-tag-annotation-state" id="infopanel-for-webvtt-start-tag-annotation-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-start-tag-annotation-state" style="display:none">Info about the 'WebVTT start tag annotation state' definition.</span><b><a href="#webvtt-start-tag-annotation-state">#webvtt-start-tag-annotation-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-start-tag-annotation-state">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-webvtt-start-tag-annotation-state①">(2)</a> <a href="#ref-for-webvtt-start-tag-annotation-state②">(3)</a> <a href="#ref-for-webvtt-start-tag-annotation-state③">(4)</a> <a href="#ref-for-webvtt-start-tag-annotation-state④">(5)</a> <a href="#ref-for-webvtt-start-tag-annotation-state⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="html-character-reference-in-annotation-state">
-   <b><a href="#html-character-reference-in-annotation-state">#html-character-reference-in-annotation-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-html-character-reference-in-annotation-state" class="dfn-panel" data-for="html-character-reference-in-annotation-state" id="infopanel-for-html-character-reference-in-annotation-state" role="dialog">
+   <span id="infopaneltitle-for-html-character-reference-in-annotation-state" style="display:none">Info about the 'HTML character reference in annotation state' definition.</span><b><a href="#html-character-reference-in-annotation-state">#html-character-reference-in-annotation-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-character-reference-in-annotation-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-end-tag-state">
-   <b><a href="#webvtt-end-tag-state">#webvtt-end-tag-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-end-tag-state" class="dfn-panel" data-for="webvtt-end-tag-state" id="infopanel-for-webvtt-end-tag-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-end-tag-state" style="display:none">Info about the 'WebVTT end tag state' definition.</span><b><a href="#webvtt-end-tag-state">#webvtt-end-tag-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-end-tag-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-timestamp-tag-state">
-   <b><a href="#webvtt-timestamp-tag-state">#webvtt-timestamp-tag-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-timestamp-tag-state" class="dfn-panel" data-for="webvtt-timestamp-tag-state" id="infopanel-for-webvtt-timestamp-tag-state" role="dialog">
+   <span id="infopaneltitle-for-webvtt-timestamp-tag-state" style="display:none">Info about the 'WebVTT timestamp tag state' definition.</span><b><a href="#webvtt-timestamp-tag-state">#webvtt-timestamp-tag-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-timestamp-tag-state">6.4. WebVTT cue text parsing rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consume-an-html-character-reference">
-   <b><a href="#consume-an-html-character-reference">#consume-an-html-character-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consume-an-html-character-reference" class="dfn-panel" data-for="consume-an-html-character-reference" id="infopanel-for-consume-an-html-character-reference" role="dialog">
+   <span id="infopaneltitle-for-consume-an-html-character-reference" style="display:none">Info about the 'consume an HTML character reference' definition.</span><b><a href="#consume-an-html-character-reference">#consume-an-html-character-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consume-an-html-character-reference">6.4. WebVTT cue text parsing rules</a> <a href="#ref-for-consume-an-html-character-reference①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-text-dom-construction-rules">
-   <b><a href="#webvtt-cue-text-dom-construction-rules">#webvtt-cue-text-dom-construction-rules</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-text-dom-construction-rules" class="dfn-panel" data-for="webvtt-cue-text-dom-construction-rules" id="infopanel-for-webvtt-cue-text-dom-construction-rules" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-text-dom-construction-rules" style="display:none">Info about the 'WebVTT cue text DOM construction rules' definition.</span><b><a href="#webvtt-cue-text-dom-construction-rules">#webvtt-cue-text-dom-construction-rules</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-text-dom-construction-rules">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-rules-for-extracting-the-chapter-title">
-   <b><a href="#webvtt-rules-for-extracting-the-chapter-title">#webvtt-rules-for-extracting-the-chapter-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-rules-for-extracting-the-chapter-title" class="dfn-panel" data-for="webvtt-rules-for-extracting-the-chapter-title" id="infopanel-for-webvtt-rules-for-extracting-the-chapter-title" role="dialog">
+   <span id="infopaneltitle-for-webvtt-rules-for-extracting-the-chapter-title" style="display:none">Info about the 'WebVTT rules for extracting the chapter title' definition.</span><b><a href="#webvtt-rules-for-extracting-the-chapter-title">#webvtt-rules-for-extracting-the-chapter-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-rules-for-extracting-the-chapter-title">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rules-for-updating-the-display-of-webvtt-text-tracks">
-   <b><a href="#rules-for-updating-the-display-of-webvtt-text-tracks">#rules-for-updating-the-display-of-webvtt-text-tracks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rules-for-updating-the-display-of-webvtt-text-tracks" class="dfn-panel" data-for="rules-for-updating-the-display-of-webvtt-text-tracks" id="infopanel-for-rules-for-updating-the-display-of-webvtt-text-tracks" role="dialog">
+   <span id="infopaneltitle-for-rules-for-updating-the-display-of-webvtt-text-tracks" style="display:none">Info about the 'rules for updating the display of WebVTT text tracks' definition.</span><b><a href="#rules-for-updating-the-display-of-webvtt-text-tracks">#rules-for-updating-the-display-of-webvtt-text-tracks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks">3.3. WebVTT caption or subtitle cues</a> <a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks①">(2)</a>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks②">7.1. Processing model</a>
@@ -7826,272 +7829,331 @@ title</a>
     <li><a href="#ref-for-rules-for-updating-the-display-of-webvtt-text-tracks⑧">8.2.3. The ::cue-region pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="apply-webvtt-cue-settings">
-   <b><a href="#apply-webvtt-cue-settings">#apply-webvtt-cue-settings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-apply-webvtt-cue-settings" class="dfn-panel" data-for="apply-webvtt-cue-settings" id="infopanel-for-apply-webvtt-cue-settings" role="dialog">
+   <span id="infopaneltitle-for-apply-webvtt-cue-settings" style="display:none">Info about the 'apply WebVTT cue
+settings' definition.</span><b><a href="#apply-webvtt-cue-settings">#apply-webvtt-cue-settings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-apply-webvtt-cue-settings">7.1. Processing model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-set-of-css-boxes">
-   <b><a href="#obtain-a-set-of-css-boxes">#obtain-a-set-of-css-boxes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-set-of-css-boxes" class="dfn-panel" data-for="obtain-a-set-of-css-boxes" id="infopanel-for-obtain-a-set-of-css-boxes" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-set-of-css-boxes" style="display:none">Info about the 'obtain a set of CSS
+boxes' definition.</span><b><a href="#obtain-a-set-of-css-boxes">#obtain-a-set-of-css-boxes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-set-of-css-boxes">7.1. Processing model</a>
     <li><a href="#ref-for-obtain-a-set-of-css-boxes①">7.2. Processing cue settings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="webvtt-cue-background-box">
-   <b><a href="#webvtt-cue-background-box">#webvtt-cue-background-box</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-webvtt-cue-background-box" class="dfn-panel" data-for="webvtt-cue-background-box" id="infopanel-for-webvtt-cue-background-box" role="dialog">
+   <span id="infopaneltitle-for-webvtt-cue-background-box" style="display:none">Info about the 'WebVTT cue background box' definition.</span><b><a href="#webvtt-cue-background-box">#webvtt-cue-background-box</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webvtt-cue-background-box">7.4. Applying CSS properties to WebVTT Node Objects</a>
     <li><a href="#ref-for-webvtt-cue-background-box①">8.2.1. The ::cue pseudo-element</a> <a href="#ref-for-webvtt-cue-background-box②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-autokeyword">
-   <b><a href="#enumdef-autokeyword">#enumdef-autokeyword</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-autokeyword" class="dfn-panel" data-for="enumdef-autokeyword" id="infopanel-for-enumdef-autokeyword" role="dialog">
+   <span id="infopaneltitle-for-enumdef-autokeyword" style="display:none">Info about the 'AutoKeyword' definition.</span><b><a href="#enumdef-autokeyword">#enumdef-autokeyword</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-autokeyword">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-lineandpositionsetting">
-   <b><a href="#typedefdef-lineandpositionsetting">#typedefdef-lineandpositionsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-lineandpositionsetting" class="dfn-panel" data-for="typedefdef-lineandpositionsetting" id="infopanel-for-typedefdef-lineandpositionsetting" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-lineandpositionsetting" style="display:none">Info about the 'LineAndPositionSetting' definition.</span><b><a href="#typedefdef-lineandpositionsetting">#typedefdef-lineandpositionsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-lineandpositionsetting">9.1. The VTTCue interface</a> <a href="#ref-for-typedefdef-lineandpositionsetting①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-directionsetting">
-   <b><a href="#enumdef-directionsetting">#enumdef-directionsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-directionsetting" class="dfn-panel" data-for="enumdef-directionsetting" id="infopanel-for-enumdef-directionsetting" role="dialog">
+   <span id="infopaneltitle-for-enumdef-directionsetting" style="display:none">Info about the 'DirectionSetting' definition.</span><b><a href="#enumdef-directionsetting">#enumdef-directionsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-directionsetting">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-linealignsetting">
-   <b><a href="#enumdef-linealignsetting">#enumdef-linealignsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-linealignsetting" class="dfn-panel" data-for="enumdef-linealignsetting" id="infopanel-for-enumdef-linealignsetting" role="dialog">
+   <span id="infopaneltitle-for-enumdef-linealignsetting" style="display:none">Info about the 'LineAlignSetting' definition.</span><b><a href="#enumdef-linealignsetting">#enumdef-linealignsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-linealignsetting">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-positionalignsetting">
-   <b><a href="#enumdef-positionalignsetting">#enumdef-positionalignsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-positionalignsetting" class="dfn-panel" data-for="enumdef-positionalignsetting" id="infopanel-for-enumdef-positionalignsetting" role="dialog">
+   <span id="infopaneltitle-for-enumdef-positionalignsetting" style="display:none">Info about the 'PositionAlignSetting' definition.</span><b><a href="#enumdef-positionalignsetting">#enumdef-positionalignsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-positionalignsetting">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-alignsetting">
-   <b><a href="#enumdef-alignsetting">#enumdef-alignsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-alignsetting" class="dfn-panel" data-for="enumdef-alignsetting" id="infopanel-for-enumdef-alignsetting" role="dialog">
+   <span id="infopaneltitle-for-enumdef-alignsetting" style="display:none">Info about the 'AlignSetting' definition.</span><b><a href="#enumdef-alignsetting">#enumdef-alignsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-alignsetting">9.1. The VTTCue interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vttcue">
-   <b><a href="#vttcue">#vttcue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vttcue" class="dfn-panel" data-for="vttcue" id="infopanel-for-vttcue" role="dialog">
+   <span id="infopaneltitle-for-vttcue" style="display:none">Info about the 'VTTCue' definition.</span><b><a href="#vttcue">#vttcue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vttcue">6.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-vttcue①">9.1. The VTTCue interface</a> <a href="#ref-for-vttcue②">(2)</a> <a href="#ref-for-vttcue③">(3)</a> <a href="#ref-for-vttcue④">(4)</a> <a href="#ref-for-vttcue⑤">(5)</a> <a href="#ref-for-vttcue⑥">(6)</a> <a href="#ref-for-vttcue⑦">(7)</a> <a href="#ref-for-vttcue⑧">(8)</a> <a href="#ref-for-vttcue⑨">(9)</a> <a href="#ref-for-vttcue①⓪">(10)</a> <a href="#ref-for-vttcue①①">(11)</a> <a href="#ref-for-vttcue①②">(12)</a> <a href="#ref-for-vttcue①③">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-vttcue">
-   <b><a href="#dom-vttcue-vttcue">#dom-vttcue-vttcue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-vttcue" class="dfn-panel" data-for="dom-vttcue-vttcue" id="infopanel-for-dom-vttcue-vttcue" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-vttcue" style="display:none">Info about the 'VTTCue(startTime,
+endTime, text)' definition.</span><b><a href="#dom-vttcue-vttcue">#dom-vttcue-vttcue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-vttcue">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vttcue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-region">
-   <b><a href="#dom-vttcue-region">#dom-vttcue-region</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-region" class="dfn-panel" data-for="dom-vttcue-region" id="infopanel-for-dom-vttcue-region" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-region" style="display:none">Info about the 'region' definition.</span><b><a href="#dom-vttcue-region">#dom-vttcue-region</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-region">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-region①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-vertical">
-   <b><a href="#dom-vttcue-vertical">#dom-vttcue-vertical</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-vertical" class="dfn-panel" data-for="dom-vttcue-vertical" id="infopanel-for-dom-vttcue-vertical" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-vertical" style="display:none">Info about the 'vertical' definition.</span><b><a href="#dom-vttcue-vertical">#dom-vttcue-vertical</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-vertical">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-vertical①">(2)</a> <a href="#ref-for-dom-vttcue-vertical②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-snaptolines">
-   <b><a href="#dom-vttcue-snaptolines">#dom-vttcue-snaptolines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-snaptolines" class="dfn-panel" data-for="dom-vttcue-snaptolines" id="infopanel-for-dom-vttcue-snaptolines" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-snaptolines" style="display:none">Info about the 'snapToLines' definition.</span><b><a href="#dom-vttcue-snaptolines">#dom-vttcue-snaptolines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-snaptolines">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-dom-vttcue-snaptolines①">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-snaptolines②">(2)</a> <a href="#ref-for-dom-vttcue-snaptolines③">(3)</a> <a href="#ref-for-dom-vttcue-snaptolines④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-line">
-   <b><a href="#dom-vttcue-line">#dom-vttcue-line</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-line" class="dfn-panel" data-for="dom-vttcue-line" id="infopanel-for-dom-vttcue-line" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-line" style="display:none">Info about the 'line' definition.</span><b><a href="#dom-vttcue-line">#dom-vttcue-line</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-line">3.3. WebVTT caption or subtitle cues</a>
     <li><a href="#ref-for-dom-vttcue-line①">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-line②">(2)</a> <a href="#ref-for-dom-vttcue-line③">(3)</a> <a href="#ref-for-dom-vttcue-line④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-linealign">
-   <b><a href="#dom-vttcue-linealign">#dom-vttcue-linealign</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-linealign" class="dfn-panel" data-for="dom-vttcue-linealign" id="infopanel-for-dom-vttcue-linealign" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-linealign" style="display:none">Info about the 'lineAlign' definition.</span><b><a href="#dom-vttcue-linealign">#dom-vttcue-linealign</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-linealign">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-linealign①">(2)</a> <a href="#ref-for-dom-vttcue-linealign②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-position">
-   <b><a href="#dom-vttcue-position">#dom-vttcue-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-position" class="dfn-panel" data-for="dom-vttcue-position" id="infopanel-for-dom-vttcue-position" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-position" style="display:none">Info about the 'position' definition.</span><b><a href="#dom-vttcue-position">#dom-vttcue-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-position">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-position①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-positionalign">
-   <b><a href="#dom-vttcue-positionalign">#dom-vttcue-positionalign</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-positionalign" class="dfn-panel" data-for="dom-vttcue-positionalign" id="infopanel-for-dom-vttcue-positionalign" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-positionalign" style="display:none">Info about the 'positionAlign' definition.</span><b><a href="#dom-vttcue-positionalign">#dom-vttcue-positionalign</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-positionalign">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-positionalign①">(2)</a> <a href="#ref-for-dom-vttcue-positionalign②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-size">
-   <b><a href="#dom-vttcue-size">#dom-vttcue-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-size" class="dfn-panel" data-for="dom-vttcue-size" id="infopanel-for-dom-vttcue-size" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-size" style="display:none">Info about the 'size' definition.</span><b><a href="#dom-vttcue-size">#dom-vttcue-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-size">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-align">
-   <b><a href="#dom-vttcue-align">#dom-vttcue-align</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-align" class="dfn-panel" data-for="dom-vttcue-align" id="infopanel-for-dom-vttcue-align" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-align" style="display:none">Info about the 'align' definition.</span><b><a href="#dom-vttcue-align">#dom-vttcue-align</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-align">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-align①">(2)</a> <a href="#ref-for-dom-vttcue-align②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-text">
-   <b><a href="#dom-vttcue-text">#dom-vttcue-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-text" class="dfn-panel" data-for="dom-vttcue-text" id="infopanel-for-dom-vttcue-text" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-text" style="display:none">Info about the 'text' definition.</span><b><a href="#dom-vttcue-text">#dom-vttcue-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-text">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-text①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttcue-getcueashtml">
-   <b><a href="#dom-vttcue-getcueashtml">#dom-vttcue-getcueashtml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttcue-getcueashtml" class="dfn-panel" data-for="dom-vttcue-getcueashtml" id="infopanel-for-dom-vttcue-getcueashtml" role="dialog">
+   <span id="infopaneltitle-for-dom-vttcue-getcueashtml" style="display:none">Info about the 'getCueAsHTML()' definition.</span><b><a href="#dom-vttcue-getcueashtml">#dom-vttcue-getcueashtml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttcue-getcueashtml">6.5. WebVTT cue text DOM construction rules</a>
     <li><a href="#ref-for-dom-vttcue-getcueashtml①">9.1. The VTTCue interface</a> <a href="#ref-for-dom-vttcue-getcueashtml②">(2)</a> <a href="#ref-for-dom-vttcue-getcueashtml③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-scrollsetting">
-   <b><a href="#enumdef-scrollsetting">#enumdef-scrollsetting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-scrollsetting" class="dfn-panel" data-for="enumdef-scrollsetting" id="infopanel-for-enumdef-scrollsetting" role="dialog">
+   <span id="infopaneltitle-for-enumdef-scrollsetting" style="display:none">Info about the 'ScrollSetting' definition.</span><b><a href="#enumdef-scrollsetting">#enumdef-scrollsetting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-scrollsetting">9.2. The VTTRegion interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vttregion">
-   <b><a href="#vttregion">#vttregion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vttregion" class="dfn-panel" data-for="vttregion" id="infopanel-for-vttregion" role="dialog">
+   <span id="infopaneltitle-for-vttregion" style="display:none">Info about the 'VTTRegion' definition.</span><b><a href="#vttregion">#vttregion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vttregion">9.1. The VTTCue interface</a> <a href="#ref-for-vttregion①">(2)</a> <a href="#ref-for-vttregion②">(3)</a>
     <li><a href="#ref-for-vttregion③">9.2. The VTTRegion interface</a> <a href="#ref-for-vttregion④">(2)</a> <a href="#ref-for-vttregion⑤">(3)</a> <a href="#ref-for-vttregion⑥">(4)</a> <a href="#ref-for-vttregion⑦">(5)</a> <a href="#ref-for-vttregion⑧">(6)</a> <a href="#ref-for-vttregion⑨">(7)</a> <a href="#ref-for-vttregion①⓪">(8)</a> <a href="#ref-for-vttregion①①">(9)</a> <a href="#ref-for-vttregion①②">(10)</a> <a href="#ref-for-vttregion①③">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-vttregion">
-   <b><a href="#dom-vttregion-vttregion">#dom-vttregion-vttregion</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-vttregion" class="dfn-panel" data-for="dom-vttregion-vttregion" id="infopanel-for-dom-vttregion-vttregion" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-vttregion" style="display:none">Info about the 'VTTRegion()' definition.</span><b><a href="#dom-vttregion-vttregion">#dom-vttregion-vttregion</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-vttregion">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-vttregion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-id">
-   <b><a href="#dom-vttregion-id">#dom-vttregion-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-id" class="dfn-panel" data-for="dom-vttregion-id" id="infopanel-for-dom-vttregion-id" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-vttregion-id">#dom-vttregion-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-id">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-id①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-width">
-   <b><a href="#dom-vttregion-width">#dom-vttregion-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-width" class="dfn-panel" data-for="dom-vttregion-width" id="infopanel-for-dom-vttregion-width" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-width" style="display:none">Info about the 'width' definition.</span><b><a href="#dom-vttregion-width">#dom-vttregion-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-width">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-lines">
-   <b><a href="#dom-vttregion-lines">#dom-vttregion-lines</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-lines" class="dfn-panel" data-for="dom-vttregion-lines" id="infopanel-for-dom-vttregion-lines" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-lines" style="display:none">Info about the 'lines' definition.</span><b><a href="#dom-vttregion-lines">#dom-vttregion-lines</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-lines">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-lines①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-regionanchorx">
-   <b><a href="#dom-vttregion-regionanchorx">#dom-vttregion-regionanchorx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-regionanchorx" class="dfn-panel" data-for="dom-vttregion-regionanchorx" id="infopanel-for-dom-vttregion-regionanchorx" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-regionanchorx" style="display:none">Info about the 'regionAnchorX' definition.</span><b><a href="#dom-vttregion-regionanchorx">#dom-vttregion-regionanchorx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-regionanchorx">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchorx①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-regionanchory">
-   <b><a href="#dom-vttregion-regionanchory">#dom-vttregion-regionanchory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-regionanchory" class="dfn-panel" data-for="dom-vttregion-regionanchory" id="infopanel-for-dom-vttregion-regionanchory" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-regionanchory" style="display:none">Info about the 'regionAnchorY' definition.</span><b><a href="#dom-vttregion-regionanchory">#dom-vttregion-regionanchory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-regionanchory">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-regionanchory①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-viewportanchorx">
-   <b><a href="#dom-vttregion-viewportanchorx">#dom-vttregion-viewportanchorx</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-viewportanchorx" class="dfn-panel" data-for="dom-vttregion-viewportanchorx" id="infopanel-for-dom-vttregion-viewportanchorx" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-viewportanchorx" style="display:none">Info about the 'viewportAnchorX' definition.</span><b><a href="#dom-vttregion-viewportanchorx">#dom-vttregion-viewportanchorx</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-viewportanchorx">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchorx①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-viewportanchory">
-   <b><a href="#dom-vttregion-viewportanchory">#dom-vttregion-viewportanchory</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-viewportanchory" class="dfn-panel" data-for="dom-vttregion-viewportanchory" id="infopanel-for-dom-vttregion-viewportanchory" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-viewportanchory" style="display:none">Info about the 'viewportAnchorY' definition.</span><b><a href="#dom-vttregion-viewportanchory">#dom-vttregion-viewportanchory</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-viewportanchory">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-viewportanchory①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-vttregion-scroll">
-   <b><a href="#dom-vttregion-scroll">#dom-vttregion-scroll</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-vttregion-scroll" class="dfn-panel" data-for="dom-vttregion-scroll" id="infopanel-for-dom-vttregion-scroll" role="dialog">
+   <span id="infopaneltitle-for-dom-vttregion-scroll" style="display:none">Info about the 'scroll' definition.</span><b><a href="#dom-vttregion-scroll">#dom-vttregion-scroll</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-vttregion-scroll">9.2. The VTTRegion interface</a> <a href="#ref-for-dom-vttregion-scroll①">(2)</a> <a href="#ref-for-dom-vttregion-scroll②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-vtt">
-   <b><a href="#text-vtt">#text-vtt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-vtt" class="dfn-panel" data-for="text-vtt" id="infopanel-for-text-vtt" role="dialog">
+   <span id="infopaneltitle-for-text-vtt" style="display:none">Info about the 'text/vtt' definition.</span><b><a href="#text-vtt">#text-vtt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-vtt">2.1. Conformance classes</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/w3ctag/design-principles/index.html
+++ b/tests/github/w3ctag/design-principles/index.html
@@ -2861,137 +2861,137 @@ so they can correct this omission.</p>
    <li><a href="#live-object">live object</a><span>, in § 5.2</span>
    <li><a href="#static-object">static object</a><span>, in § 5.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dfn-short_name">
-   <a href="https://w3c.github.io/manifest/#dfn-short_name">https://w3c.github.io/manifest/#dfn-short_name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-short_name" class="dfn-panel" data-for="term-for-dfn-short_name" id="infopanel-for-term-for-dfn-short_name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-short_name" style="display:none">Info about the 'short_name' external reference.</span><a href="https://w3c.github.io/manifest/#dfn-short_name">https://w3c.github.io/manifest/#dfn-short_name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-short_name">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-credential-id">
-   <a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-credential-id" class="dfn-panel" data-for="term-for-dom-credential-id" id="infopanel-for-term-for-dom-credential-id" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-credential-id" style="display:none">Info about the 'id' external reference.</span><a href="https://w3c.github.io/webappsec-credential-management/#dom-credential-id">https://w3c.github.io/webappsec-credential-management/#dom-credential-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-credential-id">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-image">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-image" class="dfn-panel" data-for="term-for-propdef-background-image" id="infopanel-for-term-for-propdef-background-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-image" style="display:none">Info about the 'background-image' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-image">3.2. Make appropriate choices for whether CSS properties are inherited</a> <a href="#ref-for-propdef-background-image①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-actual-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-actual-value" class="dfn-panel" data-for="term-for-actual-value" id="infopanel-for-term-for-actual-value" role="menu">
+   <span id="infopaneltitle-for-term-for-actual-value" style="display:none">Info about the 'actual value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#actual-value">https://drafts.csswg.org/css-cascade-5/#actual-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actual-value">3.3. Choose the computed value type based on how the property should inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.3. Choose the computed value type based on how the property should inherit</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-css-inheritance">
-   <a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-css-inheritance" class="dfn-panel" data-for="term-for-css-inheritance" id="infopanel-for-term-for-css-inheritance" role="menu">
+   <span id="infopaneltitle-for-term-for-css-inheritance" style="display:none">Info about the 'inherit' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#css-inheritance">https://drafts.csswg.org/css-cascade-5/#css-inheritance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-inheritance">3.3. Choose the computed value type based on how the property should inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.3. Choose the computed value type based on how the property should inherit</a> <a href="#ref-for-used-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">2.3. New features should be detectable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">3.2. Make appropriate choices for whether CSS properties are inherited</a> <a href="#ref-for-propdef-font-size①">(2)</a> <a href="#ref-for-propdef-font-size②">(3)</a>
     <li><a href="#ref-for-propdef-font-size③">3.3. Choose the computed value type based on how the property should inherit</a> <a href="#ref-for-propdef-font-size④">(2)</a> <a href="#ref-for-propdef-font-size⑤">(3)</a> <a href="#ref-for-propdef-font-size⑥">(4)</a> <a href="#ref-for-propdef-font-size⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter" class="dfn-panel" data-for="term-for-propdef-initial-letter" id="infopanel-for-term-for-propdef-initial-letter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter" style="display:none">Info about the 'initial-letter' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter">3.1. Separate CSS properties based on what should cascade separately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-initial-letter-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-initial-letter-align" class="dfn-panel" data-for="term-for-propdef-initial-letter-align" id="infopanel-for-term-for-propdef-initial-letter-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-initial-letter-align" style="display:none">Info about the 'initial-letter-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align">https://drafts.csswg.org/css-inline-3/#propdef-initial-letter-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-initial-letter-align">3.1. Separate CSS properties based on what should cascade separately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.3. Choose the computed value type based on how the property should inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.3. Choose the computed value type based on how the property should inherit</a> <a href="#ref-for-number-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3.3. Choose the computed value type based on how the property should inherit</a> <a href="#ref-for-propdef-line-height①">(2)</a> <a href="#ref-for-propdef-line-height②">(3)</a> <a href="#ref-for-propdef-line-height③">(4)</a> <a href="#ref-for-propdef-line-height④">(5)</a> <a href="#ref-for-propdef-line-height⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle">
-   <a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-getcomputedstyle" class="dfn-panel" data-for="term-for-dom-window-getcomputedstyle" id="infopanel-for-term-for-dom-window-getcomputedstyle" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-getcomputedstyle" style="display:none">Info about the 'getComputedStyle(elt)' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle">https://drafts.csswg.org/cssom-1/#dom-window-getcomputedstyle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-getcomputedstyle">3.3. Choose the computed value type based on how the property should inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolved-value">
-   <a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolved-value" class="dfn-panel" data-for="term-for-resolved-value" id="infopanel-for-term-for-resolved-value" role="menu">
+   <span id="infopaneltitle-for-term-for-resolved-value" style="display:none">Info about the 'resolved value' external reference.</span><a href="https://drafts.csswg.org/cssom-1/#resolved-value">https://drafts.csswg.org/cssom-1/#resolved-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolved-value">3.3. Choose the computed value type based on how the property should inherit</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-element-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-element-getboundingclientrect" id="infopanel-for-term-for-dom-element-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-element-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getboundingclientrect">5.1. Attributes should behave like data properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-htmlelement-offsettop">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-htmlelement-offsettop">https://drafts.csswg.org/cssom-view-1/#dom-htmlelement-offsettop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-htmlelement-offsettop" class="dfn-panel" data-for="term-for-dom-htmlelement-offsettop" id="infopanel-for-term-for-dom-htmlelement-offsettop" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-htmlelement-offsettop" style="display:none">Info about the 'offsetTop' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-htmlelement-offsettop">https://drafts.csswg.org/cssom-view-1/#dom-htmlelement-offsettop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlelement-offsettop">5.1. Attributes should behave like data properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortcontroller">
-   <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortcontroller" class="dfn-panel" data-for="term-for-abortcontroller" id="infopanel-for-term-for-abortcontroller" role="menu">
+   <span id="infopaneltitle-for-term-for-abortcontroller" style="display:none">Info about the 'AbortController' external reference.</span><a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">5.9. Cancel asynchronous APIs/operations using AbortSignal</a>
     <li><a href="#ref-for-abortcontroller①">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">5.9. Cancel asynchronous APIs/operations using AbortSignal</a>
     <li><a href="#ref-for-abortsignal①">6.6. Guard against potential recursion</a> <a href="#ref-for-abortsignal②">(2)</a> <a href="#ref-for-abortsignal③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-domtokenlist">
-   <a href="https://dom.spec.whatwg.org/#domtokenlist">https://dom.spec.whatwg.org/#domtokenlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-domtokenlist" class="dfn-panel" data-for="term-for-domtokenlist" id="infopanel-for-term-for-domtokenlist" role="menu">
+   <span id="infopaneltitle-for-term-for-domtokenlist" style="display:none">Info about the 'DOMTokenList' external reference.</span><a href="https://dom.spec.whatwg.org/#domtokenlist">https://dom.spec.whatwg.org/#domtokenlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domtokenlist">5.6. Classes should have constructors when possible</a> <a href="#ref-for-domtokenlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5.6. Classes should have constructors when possible</a> <a href="#ref-for-event①">(2)</a>
     <li><a href="#ref-for-event②">6.6. Guard against potential recursion</a>
@@ -2999,674 +2999,674 @@ so they can correct this omission.</p>
     <li><a href="#ref-for-event⑥">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">6.8. How to decide between Events and Observers</a> <a href="#ref-for-eventtarget①">(2)</a> <a href="#ref-for-eventtarget②">(3)</a> <a href="#ref-for-eventtarget③">(4)</a> <a href="#ref-for-eventtarget④">(5)</a> <a href="#ref-for-eventtarget⑤">(6)</a> <a href="#ref-for-eventtarget⑥">(7)</a> <a href="#ref-for-eventtarget⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlcollection">
-   <a href="https://dom.spec.whatwg.org/#htmlcollection">https://dom.spec.whatwg.org/#htmlcollection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlcollection" class="dfn-panel" data-for="term-for-htmlcollection" id="infopanel-for-term-for-htmlcollection" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlcollection" style="display:none">Info about the 'HTMLCollection' external reference.</span><a href="https://dom.spec.whatwg.org/#htmlcollection">https://dom.spec.whatwg.org/#htmlcollection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcollection">4.3. Don’t expose garbage collection</a> <a href="#ref-for-htmlcollection①">(2)</a>
     <li><a href="#ref-for-htmlcollection②">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mutationobserver">
-   <a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mutationobserver" class="dfn-panel" data-for="term-for-mutationobserver" id="infopanel-for-term-for-mutationobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-mutationobserver" style="display:none">Info about the 'MutationObserver' external reference.</span><a href="https://dom.spec.whatwg.org/#mutationobserver">https://dom.spec.whatwg.org/#mutationobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationobserver">6.8. How to decide between Events and Observers</a> <a href="#ref-for-mutationobserver①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namednodemap">
-   <a href="https://dom.spec.whatwg.org/#namednodemap">https://dom.spec.whatwg.org/#namednodemap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namednodemap" class="dfn-panel" data-for="term-for-namednodemap" id="infopanel-for-term-for-namednodemap" role="menu">
+   <span id="infopaneltitle-for-term-for-namednodemap" style="display:none">Info about the 'NamedNodeMap' external reference.</span><a href="https://dom.spec.whatwg.org/#namednodemap">https://dom.spec.whatwg.org/#namednodemap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namednodemap">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-node">
-   <a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-node" class="dfn-panel" data-for="term-for-node" id="infopanel-for-term-for-node" role="menu">
+   <span id="infopaneltitle-for-term-for-node" style="display:none">Info about the 'Node' external reference.</span><a href="https://dom.spec.whatwg.org/#node">https://dom.spec.whatwg.org/#node</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">Live objects</a>
     <li><a href="#ref-for-node①">6.8. How to decide between Events and Observers</a> <a href="#ref-for-node②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nonelementparentnode">
-   <a href="https://dom.spec.whatwg.org/#nonelementparentnode">https://dom.spec.whatwg.org/#nonelementparentnode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nonelementparentnode" class="dfn-panel" data-for="term-for-nonelementparentnode" id="infopanel-for-term-for-nonelementparentnode" role="menu">
+   <span id="infopaneltitle-for-term-for-nonelementparentnode" style="display:none">Info about the 'NonElementParentNode' external reference.</span><a href="https://dom.spec.whatwg.org/#nonelementparentnode">https://dom.spec.whatwg.org/#nonelementparentnode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nonelementparentnode">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-abortcontroller-abort">
-   <a href="https://dom.spec.whatwg.org/#dom-abortcontroller-abort">https://dom.spec.whatwg.org/#dom-abortcontroller-abort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-abortcontroller-abort" class="dfn-panel" data-for="term-for-dom-abortcontroller-abort" id="infopanel-for-term-for-dom-abortcontroller-abort" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-abortcontroller-abort" style="display:none">Info about the 'abort()' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-abortcontroller-abort">https://dom.spec.whatwg.org/#dom-abortcontroller-abort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortcontroller-abort">5.9. Cancel asynchronous APIs/operations using AbortSignal</a>
     <li><a href="#ref-for-dom-abortcontroller-abort①">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">6.6. Guard against potential recursion</a> <a href="#ref-for-abortsignal-add①">(2)</a> <a href="#ref-for-abortsignal-add②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener">
-   <a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" class="dfn-panel" data-for="term-for-dom-eventtarget-addeventlistener" id="infopanel-for-term-for-dom-eventtarget-addeventlistener" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-eventtarget-addeventlistener" style="display:none">Info about the 'addEventListener(type, callback)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener">https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener">5.4. Make function parameters optional if possible</a>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener①">5.5. Naming optional parameters</a>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener②">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-compatmode">
-   <a href="https://dom.spec.whatwg.org/#dom-document-compatmode">https://dom.spec.whatwg.org/#dom-document-compatmode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-compatmode" class="dfn-panel" data-for="term-for-dom-document-compatmode" id="infopanel-for-term-for-dom-document-compatmode" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-compatmode" style="display:none">Info about the 'compatMode' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-compatmode">https://dom.spec.whatwg.org/#dom-document-compatmode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-compatmode">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-createattribute">
-   <a href="https://dom.spec.whatwg.org/#dom-document-createattribute">https://dom.spec.whatwg.org/#dom-document-createattribute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-createattribute" class="dfn-panel" data-for="term-for-dom-document-createattribute" id="infopanel-for-term-for-dom-document-createattribute" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-createattribute" style="display:none">Info about the 'createAttribute(localName)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-createattribute">https://dom.spec.whatwg.org/#dom-document-createattribute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createattribute">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-nonelementparentnode-getelementbyid">
-   <a href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-nonelementparentnode-getelementbyid" class="dfn-panel" data-for="term-for-dom-nonelementparentnode-getelementbyid" id="infopanel-for-term-for-dom-nonelementparentnode-getelementbyid" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-nonelementparentnode-getelementbyid" style="display:none">Info about the 'getElementById(elementId)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid">https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nonelementparentnode-getelementbyid">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-getelementsbytagname">
-   <a href="https://dom.spec.whatwg.org/#dom-document-getelementsbytagname">https://dom.spec.whatwg.org/#dom-document-getelementsbytagname</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-getelementsbytagname" class="dfn-panel" data-for="term-for-dom-document-getelementsbytagname" id="infopanel-for-term-for-dom-document-getelementsbytagname" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-getelementsbytagname" style="display:none">Info about the 'getElementsByTagName' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-document-getelementsbytagname">https://dom.spec.whatwg.org/#dom-document-getelementsbytagname</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-getelementsbytagname">4.3. Don’t expose garbage collection</a> <a href="#ref-for-dom-document-getelementsbytagname①">(2)</a> <a href="#ref-for-dom-document-getelementsbytagname②">(3)</a>
     <li><a href="#ref-for-dom-document-getelementsbytagname③">Static objects</a> <a href="#ref-for-dom-document-getelementsbytagname④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-addeventlisteneroptions-once">
-   <a href="https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-once">https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-once</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-addeventlisteneroptions-once" class="dfn-panel" data-for="term-for-dom-addeventlisteneroptions-once" id="infopanel-for-term-for-dom-addeventlisteneroptions-once" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-addeventlisteneroptions-once" style="display:none">Info about the 'once' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-once">https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-once</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-addeventlisteneroptions-once">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-parentnode-queryselectorall">
-   <a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall">https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-parentnode-queryselectorall" class="dfn-panel" data-for="term-for-dom-parentnode-queryselectorall" id="infopanel-for-term-for-dom-parentnode-queryselectorall" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-parentnode-queryselectorall" style="display:none">Info about the 'querySelectorAll(selectors)' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall">https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-queryselectorall">Static objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-remove">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-remove">https://dom.spec.whatwg.org/#abortsignal-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-remove" class="dfn-panel" data-for="term-for-abortsignal-remove" id="infopanel-for-term-for-abortsignal-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-remove">https://dom.spec.whatwg.org/#abortsignal-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-remove">6.6. Guard against potential recursion</a> <a href="#ref-for-abortsignal-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-signal-abort">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-signal-abort" class="dfn-panel" data-for="term-for-abortsignal-signal-abort" id="infopanel-for-term-for-abortsignal-signal-abort" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-signal-abort" style="display:none">Info about the 'signal abort' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-signal-abort">https://dom.spec.whatwg.org/#abortsignal-signal-abort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-signal-abort">6.6. Guard against potential recursion</a> <a href="#ref-for-abortsignal-signal-abort①">(2)</a> <a href="#ref-for-abortsignal-signal-abort②">(3)</a> <a href="#ref-for-abortsignal-signal-abort③">(4)</a> <a href="#ref-for-abortsignal-signal-abort④">(5)</a> <a href="#ref-for-abortsignal-signal-abort⑤">(6)</a> <a href="#ref-for-abortsignal-signal-abort⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-target">
-   <a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-target" class="dfn-panel" data-for="term-for-dom-event-target" id="infopanel-for-term-for-dom-event-target" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-target" style="display:none">Info about the 'target' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-target">https://dom.spec.whatwg.org/#dom-event-target</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">6.7. State and Event subclasses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-innerhtml-innerhtml">
-   <a href="https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml">https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-innerhtml-innerhtml" class="dfn-panel" data-for="term-for-dom-innerhtml-innerhtml" id="infopanel-for-term-for-dom-innerhtml-innerhtml" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-innerhtml-innerhtml" style="display:none">Info about the 'innerHTML' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml">https://w3c.github.io/DOM-Parsing/#dom-innerhtml-innerhtml</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-innerhtml-innerhtml">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-bigint-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-bigint-objects">https://tc39.github.io/ecma262/#sec-bigint-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-bigint-objects" class="dfn-panel" data-for="term-for-sec-bigint-objects" id="infopanel-for-term-for-sec-bigint-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-bigint-objects" style="display:none">Info about the 'BigInt' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-bigint-objects">https://tc39.github.io/ecma262/#sec-bigint-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-bigint-objects">7.1. Use numeric types appropriately</a> <a href="#ref-for-sec-bigint-objects①">(2)</a> <a href="#ref-for-sec-bigint-objects②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-date-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-date-objects" class="dfn-panel" data-for="term-for-sec-date-objects" id="infopanel-for-term-for-sec-date-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-date-objects" style="display:none">Info about the 'Date' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-date-objects">https://tc39.github.io/ecma262/#sec-date-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-date-objects">7.3. Use milliseconds for time measurement</a>
     <li><a href="#ref-for-sec-date-objects①">7.4. Use the appropriate type to represent times and dates</a> <a href="#ref-for-sec-date-objects②">(2)</a> <a href="#ref-for-sec-date-objects③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-error-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-error-objects" class="dfn-panel" data-for="term-for-sec-error-objects" id="infopanel-for-term-for-sec-error-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-error-objects" style="display:none">Info about the 'Error' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-error-objects">https://tc39.github.io/ecma262/#sec-error-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-error-objects">7.5. Use Error or DOMException for errors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-finalization-registry-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-finalization-registry-objects">https://tc39.github.io/ecma262/#sec-finalization-registry-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-finalization-registry-objects" class="dfn-panel" data-for="term-for-sec-finalization-registry-objects" id="infopanel-for-term-for-sec-finalization-registry-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-finalization-registry-objects" style="display:none">Info about the 'FinalizationRegistry' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-finalization-registry-objects">https://tc39.github.io/ecma262/#sec-finalization-registry-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-finalization-registry-objects">4.3. Don’t expose garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-number-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-number-objects">https://tc39.github.io/ecma262/#sec-number-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-number-objects" class="dfn-panel" data-for="term-for-sec-number-objects" id="infopanel-for-term-for-sec-number-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-number-objects" style="display:none">Info about the 'Number' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-number-objects">https://tc39.github.io/ecma262/#sec-number-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-number-objects">7.1. Use numeric types appropriately</a> <a href="#ref-for-sec-number-objects①">(2)</a> <a href="#ref-for-sec-number-objects②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-weak-ref-objects">
-   <a href="https://tc39.github.io/ecma262/#sec-weak-ref-objects">https://tc39.github.io/ecma262/#sec-weak-ref-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-weak-ref-objects" class="dfn-panel" data-for="term-for-sec-weak-ref-objects" id="infopanel-for-term-for-sec-weak-ref-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-weak-ref-objects" style="display:none">Info about the 'WeakRef' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-weak-ref-objects">https://tc39.github.io/ecma262/#sec-weak-ref-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-weak-ref-objects">4.3. Don’t expose garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-body">
-   <a href="https://fetch.spec.whatwg.org/#body">https://fetch.spec.whatwg.org/#body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-body" class="dfn-panel" data-for="term-for-body" id="infopanel-for-term-for-body" role="menu">
+   <span id="infopaneltitle-for-term-for-body" style="display:none">Info about the 'Body' external reference.</span><a href="https://fetch.spec.whatwg.org/#body">https://fetch.spec.whatwg.org/#body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body">11.1. Use common words</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-body-json">
-   <a href="https://fetch.spec.whatwg.org/#dom-body-json">https://fetch.spec.whatwg.org/#dom-body-json</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-body-json" class="dfn-panel" data-for="term-for-dom-body-json" id="infopanel-for-term-for-dom-body-json" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-body-json" style="display:none">Info about the 'json()' external reference.</span><a href="https://fetch.spec.whatwg.org/#dom-body-json">https://fetch.spec.whatwg.org/#dom-body-json</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-json">11.1. Use common words</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">7.4. Use the appropriate type to represent times and dates</a> <a href="#ref-for-dom-domhighrestimestamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">6.4. Always add event handler attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-globaleventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-globaleventhandlers" class="dfn-panel" data-for="term-for-globaleventhandlers" id="infopanel-for-term-for-globaleventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-globaleventhandlers" style="display:none">Info about the 'GlobalEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-globaleventhandlers">6.4. Always add event handler attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhrelement">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#htmlhrelement">https://html.spec.whatwg.org/multipage/grouping-content.html#htmlhrelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlhrelement" class="dfn-panel" data-for="term-for-htmlhrelement" id="infopanel-for-term-for-htmlhrelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlhrelement" style="display:none">Info about the 'HTMLHRElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#htmlhrelement">https://html.spec.whatwg.org/multipage/grouping-content.html#htmlhrelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlhrelement">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhtmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlhtmlelement" class="dfn-panel" data-for="term-for-htmlhtmlelement" id="infopanel-for-term-for-htmlhtmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlhtmlelement" style="display:none">Info about the 'HTMLHtmlElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlhtmlelement">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlimageelement">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlimageelement" class="dfn-panel" data-for="term-for-htmlimageelement" id="infopanel-for-term-for-htmlimageelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlimageelement" style="display:none">Info about the 'HTMLImageElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement">https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlimageelement">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-history-3">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#history-3">https://html.spec.whatwg.org/multipage/nav-history-apis.html#history-3</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-history-3" class="dfn-panel" data-for="term-for-history-3" id="infopanel-for-term-for-history-3" role="menu">
+   <span id="infopaneltitle-for-term-for-history-3" style="display:none">Info about the 'History' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#history-3">https://html.spec.whatwg.org/multipage/nav-history-apis.html#history-3</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-history-3">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-imagebitmap">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-imagebitmap" class="dfn-panel" data-for="term-for-imagebitmap" id="infopanel-for-term-for-imagebitmap" role="menu">
+   <span id="infopaneltitle-for-term-for-imagebitmap" style="display:none">Info about the 'ImageBitmap' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-imagebitmap">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">5.6. Classes should have constructors when possible</a>
     <li><a href="#ref-for-window①">6.4. Always add event handler attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoweventhandlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoweventhandlers" class="dfn-panel" data-for="term-for-windoweventhandlers" id="infopanel-for-term-for-windoweventhandlers" role="menu">
+   <span id="infopaneltitle-for-term-for-windoweventhandlers" style="display:none">Info about the 'WindowEventHandlers' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers">https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoweventhandlers">6.4. Always add event handler attributes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-alert-noargs">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert-noargs">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert-noargs</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-alert-noargs" class="dfn-panel" data-for="term-for-dom-alert-noargs" id="infopanel-for-term-for-dom-alert-noargs" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-alert-noargs" style="display:none">Info about the 'alert()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert-noargs">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert-noargs</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-alert-noargs">1.3. Trusted user interface should be trustworthy</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-bgcolor">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-bgcolor">https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-bgcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-bgcolor" class="dfn-panel" data-for="term-for-dom-document-bgcolor" id="infopanel-for-term-for-dom-document-bgcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-bgcolor" style="display:none">Info about the 'bgColor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-bgcolor">https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-bgcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-bgcolor">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-createimagebitmap">
-   <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-createimagebitmap" class="dfn-panel" data-for="term-for-dom-createimagebitmap" id="infopanel-for-term-for-dom-createimagebitmap" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-createimagebitmap" style="display:none">Info about the 'createImageBitmap(image, options)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap">https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#dom-createimagebitmap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-createimagebitmap">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element" class="dfn-panel" data-for="term-for-custom-element" id="infopanel-for-term-for-custom-element" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element" style="display:none">Info about the 'custom element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">6.4. Always add event handler attributes</a> <a href="#ref-for-event-handler-idl-attributes①">(2)</a> <a href="#ref-for-event-handler-idl-attributes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">4.2. Preserve run-to-completion semantics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-figcaption-element">
-   <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-figcaption-element" class="dfn-panel" data-for="term-for-the-figcaption-element" id="infopanel-for-term-for-the-figcaption-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-figcaption-element" style="display:none">Info about the 'figcaption' external reference.</span><a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element">https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-figcaption-element">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-hyperlink-href">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-hyperlink-href" class="dfn-panel" data-for="term-for-attr-hyperlink-href" id="infopanel-for-term-for-attr-hyperlink-href" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-hyperlink-href" style="display:none">Info about the 'href' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-hyperlink-href">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-img-ismap">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-ismap">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-ismap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-img-ismap" class="dfn-panel" data-for="term-for-dom-img-ismap" id="infopanel-for-term-for-dom-img-ismap" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-img-ismap" style="display:none">Info about the 'isMap' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-ismap">https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-ismap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-img-ismap">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-ismap">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-ismap">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-ismap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-ismap" class="dfn-panel" data-for="term-for-attr-img-ismap" id="infopanel-for-term-for-attr-img-ismap" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-ismap" style="display:none">Info about the 'ismap' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-ismap">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-ismap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-ismap">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-online">
-   <a href="https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online">https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-online" class="dfn-panel" data-for="term-for-dom-navigator-online" id="infopanel-for-term-for-dom-navigator-online" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-online" style="display:none">Info about the 'onLine' external reference.</span><a href="https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online">https://html.spec.whatwg.org/multipage/offline.html#dom-navigator-online</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-online">4.2. Preserve run-to-completion semantics</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-open">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-open" class="dfn-panel" data-for="term-for-dom-open" id="infopanel-for-term-for-dom-open" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-open" style="display:none">Info about the 'open(url, target, features)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-open</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-open">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">4.2. Preserve run-to-completion semantics</a>
     <li><a href="#ref-for-queue-a-task①">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reflect">
-   <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reflect" class="dfn-panel" data-for="term-for-reflect" id="infopanel-for-term-for-reflect" role="menu">
+   <span id="infopaneltitle-for-term-for-reflect" style="display:none">Info about the 'reflect' external reference.</span><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect">https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reflect">7.2. Represent strings appropriately</a>
     <li><a href="#ref-for-reflect①">Use casing rules consistent with existing APIs</a> <a href="#ref-for-reflect②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-media-resize">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#event-media-resize">https://html.spec.whatwg.org/multipage/media.html#event-media-resize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-media-resize" class="dfn-panel" data-for="term-for-event-media-resize" id="infopanel-for-term-for-event-media-resize" role="menu">
+   <span id="infopaneltitle-for-term-for-event-media-resize" style="display:none">Info about the 'resize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#event-media-resize">https://html.spec.whatwg.org/multipage/media.html#event-media-resize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-media-resize">6.5. Events are for notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-dialog-showmodal">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal">https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-dialog-showmodal" class="dfn-panel" data-for="term-for-dom-dialog-showmodal" id="infopanel-for-term-for-dom-dialog-showmodal" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-dialog-showmodal" style="display:none">Info about the 'showModal()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal">https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-dialog-showmodal">10.2.1. Defining algorithms in specifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-task-queue">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-task-queue" class="dfn-panel" data-for="term-for-task-queue" id="infopanel-for-term-for-task-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-task-queue" style="display:none">Info about the 'task queues' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">https://html.spec.whatwg.org/multipage/webappapis.html#task-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-task-queue">6.6. Guard against potential recursion</a> <a href="#ref-for-task-queue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_code_unit">
-   <a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_code_unit" class="dfn-panel" data-for="term-for-def_code_unit" id="infopanel-for-term-for-def_code_unit" role="menu">
+   <span id="infopaneltitle-for-term-for-def_code_unit" style="display:none">Info about the 'code units' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_code_unit">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-surrogate">
-   <a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-surrogate" class="dfn-panel" data-for="term-for-dfn-surrogate" id="infopanel-for-term-for-dfn-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-surrogate" style="display:none">Info about the 'surrogates' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-surrogate">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbdatabase">
-   <a href="https://w3c.github.io/IndexedDB/#idbdatabase">https://w3c.github.io/IndexedDB/#idbdatabase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbdatabase" class="dfn-panel" data-for="term-for-idbdatabase" id="infopanel-for-term-for-idbdatabase" role="menu">
+   <span id="infopaneltitle-for-term-for-idbdatabase" style="display:none">Info about the 'IDBDatabase' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbdatabase">https://w3c.github.io/IndexedDB/#idbdatabase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbdatabase">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-code-point">
-   <a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-code-point" class="dfn-panel" data-for="term-for-ascii-code-point" id="infopanel-for-term-for-ascii-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-code-point" style="display:none">Info about the 'ascii code point' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-code-point">11.2. Use ASCII names</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">8.2. Use care when exposing APIs for selecting or enumerating devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value">
-   <a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value" class="dfn-panel" data-for="term-for-scalar-value" id="infopanel-for-term-for-scalar-value" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value" style="display:none">Info about the 'scalar value' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value-string">
-   <a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value-string" class="dfn-panel" data-for="term-for-scalar-value-string" id="infopanel-for-term-for-scalar-value-string" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value-string" style="display:none">Info about the 'scalar value string' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-intersectionobserver">
-   <a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver">https://w3c.github.io/IntersectionObserver/#intersectionobserver</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-intersectionobserver" class="dfn-panel" data-for="term-for-intersectionobserver" id="infopanel-for-term-for-intersectionobserver" role="menu">
+   <span id="infopaneltitle-for-term-for-intersectionobserver" style="display:none">Info about the 'IntersectionObserver' external reference.</span><a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver">https://w3c.github.io/IntersectionObserver/#intersectionobserver</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-intersectionobserver">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-false">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-false" class="dfn-panel" data-for="term-for-valdef-custom-media-false" id="infopanel-for-term-for-valdef-custom-media-false" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-false" style="display:none">Info about the 'false' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-false</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-false">3.4. Naming of CSS properties and values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-custom-media-true">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-custom-media-true" class="dfn-panel" data-for="term-for-valdef-custom-media-true" id="infopanel-for-term-for-valdef-custom-media-true" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-custom-media-true" style="display:none">Info about the 'true' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true">https://drafts.csswg.org/mediaqueries-5/#valdef-custom-media-true</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-custom-media-true">3.4. Naming of CSS properties and values</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-state">
-   <a href="https://www.w3.org/TR/payment-request/#dfn-state">https://www.w3.org/TR/payment-request/#dfn-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-state" class="dfn-panel" data-for="term-for-dfn-state" id="infopanel-for-term-for-dfn-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-state" style="display:none">Info about the '[[state]]' external reference.</span><a href="https://www.w3.org/TR/payment-request/#dfn-state">https://www.w3.org/TR/payment-request/#dfn-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-state">6.6. Guard against potential recursion</a> <a href="#ref-for-dfn-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-paymentrequest">
-   <a href="https://w3c.github.io/payment-request/#dom-paymentrequest">https://w3c.github.io/payment-request/#dom-paymentrequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-paymentrequest" class="dfn-panel" data-for="term-for-dom-paymentrequest" id="infopanel-for-term-for-dom-paymentrequest" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-paymentrequest" style="display:none">Info about the 'PaymentRequest' external reference.</span><a href="https://w3c.github.io/payment-request/#dom-paymentrequest">https://w3c.github.io/payment-request/#dom-paymentrequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paymentrequest">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-paymentrequest-show">
-   <a href="https://w3c.github.io/payment-request/#dom-paymentrequest-show">https://w3c.github.io/payment-request/#dom-paymentrequest-show</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-paymentrequest-show" class="dfn-panel" data-for="term-for-dom-paymentrequest-show" id="infopanel-for-term-for-dom-paymentrequest-show" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-paymentrequest-show" style="display:none">Info about the 'show()' external reference.</span><a href="https://w3c.github.io/payment-request/#dom-paymentrequest-show">https://w3c.github.io/payment-request/#dom-paymentrequest-show</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-paymentrequest-show">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-pointerevent-pointerid">
-   <a href="https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid">https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-pointerevent-pointerid" class="dfn-panel" data-for="term-for-dom-pointerevent-pointerid" id="infopanel-for-term-for-dom-pointerevent-pointerid" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-pointerevent-pointerid" style="display:none">Info about the 'pointerId' external reference.</span><a href="https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid">https://w3c.github.io/pointerevents/#dom-pointerevent-pointerid</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-pointerevent-pointerid">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-referrerpolicy-no-referrer-when-downgrade">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#dom-referrerpolicy-no-referrer-when-downgrade">https://w3c.github.io/webappsec-referrer-policy/#dom-referrerpolicy-no-referrer-when-downgrade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-referrerpolicy-no-referrer-when-downgrade" class="dfn-panel" data-for="term-for-dom-referrerpolicy-no-referrer-when-downgrade" id="infopanel-for-term-for-dom-referrerpolicy-no-referrer-when-downgrade" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-referrerpolicy-no-referrer-when-downgrade" style="display:none">Info about the '"no-referrer-when-downgrade"' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#dom-referrerpolicy-no-referrer-when-downgrade">https://w3c.github.io/webappsec-referrer-policy/#dom-referrerpolicy-no-referrer-when-downgrade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-referrerpolicy-no-referrer-when-downgrade">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-remoteplayback-interface">
-   <a href="https://w3c.github.io/remote-playback/#remoteplayback-interface">https://w3c.github.io/remote-playback/#remoteplayback-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-remoteplayback-interface" class="dfn-panel" data-for="term-for-remoteplayback-interface" id="infopanel-for-term-for-remoteplayback-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-remoteplayback-interface" style="display:none">Info about the 'RemotePlayback' external reference.</span><a href="https://w3c.github.io/remote-playback/#remoteplayback-interface">https://w3c.github.io/remote-playback/#remoteplayback-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remoteplayback-interface">8.2. Use care when exposing APIs for selecting or enumerating devices</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-remote-playback-devices">
-   <a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices">https://w3c.github.io/remote-playback/#dfn-remote-playback-devices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-remote-playback-devices" class="dfn-panel" data-for="term-for-dfn-remote-playback-devices" id="infopanel-for-term-for-dfn-remote-playback-devices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-remote-playback-devices" style="display:none">Info about the 'remote playback device' external reference.</span><a href="https://w3c.github.io/remote-playback/#dfn-remote-playback-devices">https://w3c.github.io/remote-playback/#dfn-remote-playback-devices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-remote-playback-devices">8.2. Use care when exposing APIs for selecting or enumerating devices</a> <a href="#ref-for-dfn-remote-playback-devices①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyboardevent">
-   <a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyboardevent" class="dfn-panel" data-for="term-for-keyboardevent" id="infopanel-for-term-for-keyboardevent" role="menu">
+   <span id="infopaneltitle-for-term-for-keyboardevent" style="display:none">Info about the 'KeyboardEvent' external reference.</span><a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboardevent">11.4. Future-proofing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-urlsearchparams">
-   <a href="https://url.spec.whatwg.org/#urlsearchparams">https://url.spec.whatwg.org/#urlsearchparams</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-urlsearchparams" class="dfn-panel" data-for="term-for-urlsearchparams" id="infopanel-for-term-for-urlsearchparams" role="menu">
+   <span id="infopaneltitle-for-term-for-urlsearchparams" style="display:none">Info about the 'URLSearchParams' external reference.</span><a href="https://url.spec.whatwg.org/#urlsearchparams">https://url.spec.whatwg.org/#urlsearchparams</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-urlsearchparams">Static objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percent-encode">
-   <a href="https://url.spec.whatwg.org/#percent-encode">https://url.spec.whatwg.org/#percent-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percent-encode" class="dfn-panel" data-for="term-for-percent-encode" id="infopanel-for-term-for-percent-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-percent-encode" style="display:none">Info about the 'percent-encode' external reference.</span><a href="https://url.spec.whatwg.org/#percent-encode">https://url.spec.whatwg.org/#percent-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-encode">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Crypto">
-   <a href="https://w3c.github.io/webcrypto/#dfn-Crypto">https://w3c.github.io/webcrypto/#dfn-Crypto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Crypto" class="dfn-panel" data-for="term-for-dfn-Crypto" id="infopanel-for-term-for-dfn-Crypto" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Crypto" style="display:none">Info about the 'Crypto' external reference.</span><a href="https://w3c.github.io/webcrypto/#dfn-Crypto">https://w3c.github.io/webcrypto/#dfn-Crypto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Crypto">5.6. Classes should have constructors when possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">7.2. Represent strings appropriately</a> <a href="#ref-for-idl-ByteString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Clamp">
-   <a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Clamp" class="dfn-panel" data-for="term-for-Clamp" id="infopanel-for-term-for-Clamp" role="menu">
+   <span id="infopaneltitle-for-term-for-Clamp" style="display:none">Info about the 'Clamp' external reference.</span><a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Clamp">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">7.5. Use Error or DOMException for errors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">7.2. Represent strings appropriately</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">7.1. Use numeric types appropriately</a> <a href="#ref-for-EnforceRange①">(2)</a> <a href="#ref-for-EnforceRange②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">2.4. Consider limiting new features to secure contexts</a> <a href="#ref-for-SecureContext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">5.6. Classes should have constructors when possible</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">7.1. Use numeric types appropriately</a> <a href="#ref-for-exceptiondef-typeerror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">7.2. Represent strings appropriately</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-bigint">
-   <a href="https://webidl.spec.whatwg.org/#idl-bigint">https://webidl.spec.whatwg.org/#idl-bigint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-bigint" class="dfn-panel" data-for="term-for-idl-bigint" id="infopanel-for-term-for-idl-bigint" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-bigint" style="display:none">Info about the 'bigint' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-bigint">https://webidl.spec.whatwg.org/#idl-bigint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-bigint">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-byte">
-   <a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-byte" class="dfn-panel" data-for="term-for-idl-byte" id="infopanel-for-term-for-idl-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-byte">https://webidl.spec.whatwg.org/#idl-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-byte">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-double" class="dfn-panel" data-for="term-for-idl-double" id="infopanel-for-term-for-idl-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-double" style="display:none">Info about the 'double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-double">https://webidl.spec.whatwg.org/#idl-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-double">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long-long" class="dfn-panel" data-for="term-for-idl-long-long" id="infopanel-for-term-for-idl-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long-long" style="display:none">Info about the 'long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long-long">https://webidl.spec.whatwg.org/#idl-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long-long">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-maplike">
-   <a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-maplike" class="dfn-panel" data-for="term-for-dfn-maplike" id="infopanel-for-term-for-dfn-maplike" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-maplike" style="display:none">Info about the 'maplike' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-maplike">https://webidl.spec.whatwg.org/#dfn-maplike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-maplike">Static objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-namespace">
-   <a href="https://webidl.spec.whatwg.org/#dfn-namespace">https://webidl.spec.whatwg.org/#dfn-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-namespace" class="dfn-panel" data-for="term-for-dfn-namespace" id="infopanel-for-term-for-dfn-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-namespace" style="display:none">Info about the 'namespace' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-namespace">https://webidl.spec.whatwg.org/#dfn-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-namespace">5.6. Classes should have constructors when possible</a> <a href="#ref-for-dfn-namespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-octet">
-   <a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-octet" class="dfn-panel" data-for="term-for-idl-octet" id="infopanel-for-term-for-idl-octet" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-octet" style="display:none">Info about the 'octet' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-octet">https://webidl.spec.whatwg.org/#idl-octet</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-octet">7.1. Use numeric types appropriately</a> <a href="#ref-for-idl-octet①">(2)</a> <a href="#ref-for-idl-octet②">(3)</a> <a href="#ref-for-idl-octet③">(4)</a> <a href="#ref-for-idl-octet④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sequence-type">
-   <a href="https://webidl.spec.whatwg.org/#sequence-type">https://webidl.spec.whatwg.org/#sequence-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sequence-type" class="dfn-panel" data-for="term-for-sequence-type" id="infopanel-for-term-for-sequence-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sequence-type" style="display:none">Info about the 'sequence type' external reference.</span><a href="https://webidl.spec.whatwg.org/#sequence-type">https://webidl.spec.whatwg.org/#sequence-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sequence-type">7.2. Represent strings appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-setlike">
-   <a href="https://webidl.spec.whatwg.org/#dfn-setlike">https://webidl.spec.whatwg.org/#dfn-setlike</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-setlike" class="dfn-panel" data-for="term-for-dfn-setlike" id="infopanel-for-term-for-dfn-setlike" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-setlike" style="display:none">Info about the 'setlike' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-setlike">https://webidl.spec.whatwg.org/#dfn-setlike</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-setlike">Static objects</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.4. Make function parameters optional if possible</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">7.1. Use numeric types appropriately</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-rtcdtmfsender">
-   <a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtmfsender">https://w3c.github.io/webrtc-pc/#dom-rtcdtmfsender</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-rtcdtmfsender" class="dfn-panel" data-for="term-for-dom-rtcdtmfsender" id="infopanel-for-term-for-dom-rtcdtmfsender" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-rtcdtmfsender" style="display:none">Info about the 'RTCDTMFSender' external reference.</span><a href="https://w3c.github.io/webrtc-pc/#dom-rtcdtmfsender">https://w3c.github.io/webrtc-pc/#dom-rtcdtmfsender</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-rtcdtmfsender">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-progressevent">
-   <a href="https://xhr.spec.whatwg.org/#progressevent">https://xhr.spec.whatwg.org/#progressevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-progressevent" class="dfn-panel" data-for="term-for-progressevent" id="infopanel-for-term-for-progressevent" role="menu">
+   <span id="infopaneltitle-for-term-for-progressevent" style="display:none">Info about the 'ProgressEvent' external reference.</span><a href="https://xhr.spec.whatwg.org/#progressevent">https://xhr.spec.whatwg.org/#progressevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-progressevent">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequest" class="dfn-panel" data-for="term-for-xmlhttprequest" id="infopanel-for-term-for-xmlhttprequest" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">5.4. Make function parameters optional if possible</a>
     <li><a href="#ref-for-xmlhttprequest①">Use casing rules consistent with existing APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequesteventtarget">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequesteventtarget">https://xhr.spec.whatwg.org/#xmlhttprequesteventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequesteventtarget" class="dfn-panel" data-for="term-for-xmlhttprequesteventtarget" id="infopanel-for-term-for-xmlhttprequesteventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequesteventtarget" style="display:none">Info about the 'XMLHttpRequestEventTarget' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequesteventtarget">https://xhr.spec.whatwg.org/#xmlhttprequesteventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequesteventtarget">6.8. How to decide between Events and Observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-progressevent-loaded">
-   <a href="https://xhr.spec.whatwg.org/#dom-progressevent-loaded">https://xhr.spec.whatwg.org/#dom-progressevent-loaded</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-progressevent-loaded" class="dfn-panel" data-for="term-for-dom-progressevent-loaded" id="infopanel-for-term-for-dom-progressevent-loaded" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-progressevent-loaded" style="display:none">Info about the 'loaded' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-progressevent-loaded">https://xhr.spec.whatwg.org/#dom-progressevent-loaded</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-progressevent-loaded">6.6. Guard against potential recursion</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-progressevent-total">
-   <a href="https://xhr.spec.whatwg.org/#dom-progressevent-total">https://xhr.spec.whatwg.org/#dom-progressevent-total</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-progressevent-total" class="dfn-panel" data-for="term-for-dom-progressevent-total" id="infopanel-for-term-for-dom-progressevent-total" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-progressevent-total" style="display:none">Info about the 'total' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-progressevent-total">https://xhr.spec.whatwg.org/#dom-progressevent-total</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-progressevent-total">6.6. Guard against potential recursion</a>
    </ul>
@@ -4031,57 +4031,113 @@ be sure to take this nuance into account. <a href="https://github.com/w3ctag/des
   </div>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3ctag/promises-guide/index.html
+++ b/tests/github/w3ctag/promises-guide/index.html
@@ -2390,129 +2390,129 @@ Parts of this work may be from another specification document.  If so, those par
 })();
 </script>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2.2. One-time "events"</a>
     <li><a href="#ref-for-eventtarget①">3.1. Recurring events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-error-objects">
-   <a href="https://tc39.es/ecma262/#sec-error-objects">https://tc39.es/ecma262/#sec-error-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-error-objects" class="dfn-panel" data-for="term-for-sec-error-objects" id="infopanel-for-term-for-sec-error-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-error-objects" style="display:none">Info about the 'Error' external reference.</span><a href="https://tc39.es/ecma262/#sec-error-objects">https://tc39.es/ecma262/#sec-error-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-error-objects">4.1.2. Rejection reasons must be Error instances</a> <a href="#ref-for-sec-error-objects①">(2)</a> <a href="#ref-for-sec-error-objects②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">2.3. More general state transitions</a> <a href="#ref-for-the-img-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">2.2. One-time "events"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-img-src">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-img-src" class="dfn-panel" data-for="term-for-attr-img-src" id="infopanel-for-term-for-attr-img-src" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-img-src" style="display:none">Info about the 'src' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src">https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-img-src">2.3. More general state transitions</a> <a href="#ref-for-attr-img-src①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idbrequest">
-   <a href="https://w3c.github.io/IndexedDB/#idbrequest">https://w3c.github.io/IndexedDB/#idbrequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idbrequest" class="dfn-panel" data-for="term-for-idbrequest" id="infopanel-for-term-for-idbrequest" role="menu">
+   <span id="infopaneltitle-for-term-for-idbrequest" style="display:none">Info about the 'IDBRequest' external reference.</span><a href="https://w3c.github.io/IndexedDB/#idbrequest">https://w3c.github.io/IndexedDB/#idbrequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idbrequest">Appendix: legacy APIs for asynchronicity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbrequest-onerror">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbrequest-onerror">https://w3c.github.io/IndexedDB/#dom-idbrequest-onerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbrequest-onerror" class="dfn-panel" data-for="term-for-dom-idbrequest-onerror" id="infopanel-for-term-for-dom-idbrequest-onerror" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbrequest-onerror" style="display:none">Info about the 'onerror' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbrequest-onerror">https://w3c.github.io/IndexedDB/#dom-idbrequest-onerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-onerror">Appendix: legacy APIs for asynchronicity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-idbrequest-onsuccess">
-   <a href="https://w3c.github.io/IndexedDB/#dom-idbrequest-onsuccess">https://w3c.github.io/IndexedDB/#dom-idbrequest-onsuccess</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-idbrequest-onsuccess" class="dfn-panel" data-for="term-for-dom-idbrequest-onsuccess" id="infopanel-for-term-for-dom-idbrequest-onsuccess" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-idbrequest-onsuccess" style="display:none">Info about the 'onsuccess' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-idbrequest-onsuccess">https://w3c.github.io/IndexedDB/#dom-idbrequest-onsuccess</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-idbrequest-onsuccess">Appendix: legacy APIs for asynchronicity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-notification-requestpermission">
-   <a href="https://notifications.spec.whatwg.org/#dom-notification-requestpermission">https://notifications.spec.whatwg.org/#dom-notification-requestpermission</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-notification-requestpermission" class="dfn-panel" data-for="term-for-dom-notification-requestpermission" id="infopanel-for-term-for-dom-notification-requestpermission" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-notification-requestpermission" style="display:none">Info about the 'requestPermission(deprecatedCallback)' external reference.</span><a href="https://notifications.spec.whatwg.org/#dom-notification-requestpermission">https://notifications.spec.whatwg.org/#dom-notification-requestpermission</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-requestpermission">Appendix: legacy APIs for asynchronicity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">3.2. Streaming data</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-writer-close">
-   <a href="https://streams.spec.whatwg.org/#default-writer-close">https://streams.spec.whatwg.org/#default-writer-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-writer-close" class="dfn-panel" data-for="term-for-default-writer-close" id="infopanel-for-term-for-default-writer-close" role="menu">
+   <span id="infopaneltitle-for-term-for-default-writer-close" style="display:none">Info about the 'close()' external reference.</span><a href="https://streams.spec.whatwg.org/#default-writer-close">https://streams.spec.whatwg.org/#default-writer-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-close">2.3. More general state transitions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.1.2. Rejection reasons must be Error instances</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.2.1. Promise arguments should be resolved</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-function" class="dfn-panel" data-for="term-for-dfn-callback-function" id="infopanel-for-term-for-dfn-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-function" style="display:none">Info about the 'callback function' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-function">https://webidl.spec.whatwg.org/#dfn-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-function">4.2.2. Developer-supplied promise-returning functions should be "promise-called"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.2.2. Developer-supplied promise-returning functions should be "promise-called"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-operation">
-   <a href="https://webidl.spec.whatwg.org/#dfn-operation">https://webidl.spec.whatwg.org/#dfn-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-operation" class="dfn-panel" data-for="term-for-dfn-operation" id="infopanel-for-term-for-dfn-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-operation" style="display:none">Info about the 'operation' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-operation">https://webidl.spec.whatwg.org/#dfn-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-operation">4.1.1. Promise-returning functions must always return promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-promise-type">
-   <a href="https://webidl.spec.whatwg.org/#dfn-promise-type">https://webidl.spec.whatwg.org/#dfn-promise-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-promise-type" class="dfn-panel" data-for="term-for-dfn-promise-type" id="infopanel-for-term-for-dfn-promise-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-promise-type" style="display:none">Info about the 'promise type' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-promise-type">https://webidl.spec.whatwg.org/#dfn-promise-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-promise-type">4.1.1. Promise-returning functions must always return promises</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handler-xhr-onreadystatechange">
-   <a href="https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange">https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handler-xhr-onreadystatechange" class="dfn-panel" data-for="term-for-handler-xhr-onreadystatechange" id="infopanel-for-term-for-handler-xhr-onreadystatechange" role="menu">
+   <span id="infopaneltitle-for-term-for-handler-xhr-onreadystatechange" style="display:none">Info about the 'onreadystatechange' external reference.</span><a href="https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange">https://xhr.spec.whatwg.org/#handler-xhr-onreadystatechange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onreadystatechange">Appendix: legacy APIs for asynchronicity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-xmlhttprequest-send">
-   <a href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-xmlhttprequest-send" class="dfn-panel" data-for="term-for-dom-xmlhttprequest-send" id="infopanel-for-term-for-dom-xmlhttprequest-send" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-xmlhttprequest-send" style="display:none">Info about the 'send()' external reference.</span><a href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send">https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-send">Appendix: legacy APIs for asynchronicity</a>
    </ul>
@@ -2602,57 +2602,113 @@ Parts of this work may be from another specification document.  If so, those par
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/w3ctag/security-questionnaire/index.html
+++ b/tests/github/w3ctag/security-questionnaire/index.html
@@ -1578,134 +1578,134 @@ practices before the site prompted for location.</p>
    <li><a href="#same-origin-policy">same-origin policy</a><span>, in § 3.3</span>
    <li><a href="#cross-site-scripting-attacks">XSS</a><span>, in § 3.3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-connect-src">
-   <a href="https://w3c.github.io/webappsec-csp/#connect-src">https://w3c.github.io/webappsec-csp/#connect-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connect-src" class="dfn-panel" data-for="term-for-connect-src" id="infopanel-for-term-for-connect-src" role="menu">
+   <span id="infopaneltitle-for-term-for-connect-src" style="display:none">Info about the 'connect-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#connect-src">https://w3c.github.io/webappsec-csp/#connect-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connect-src">2.4. 
   How do the features in your specification deal with sensitive information? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-form-action">
-   <a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-form-action" class="dfn-panel" data-for="term-for-form-action" id="infopanel-for-term-for-form-action" role="menu">
+   <span id="infopaneltitle-for-term-for-form-action" style="display:none">Info about the 'form-action' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#form-action">https://w3c.github.io/webappsec-csp/#form-action</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-form-action">2.4. 
   How do the features in your specification deal with sensitive information? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script-src">
-   <a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script-src" class="dfn-panel" data-for="term-for-script-src" id="infopanel-for-term-for-script-src" role="menu">
+   <span id="infopaneltitle-for-term-for-script-src" style="display:none">Info about the 'script-src' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#script-src">https://w3c.github.io/webappsec-csp/#script-src</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script-src">2.10. 
   Do features in this specification enable new script execution/loading
   mechanisms? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-eval-x">
-   <a href="https://tc39.github.io/ecma262/#sec-eval-x">https://tc39.github.io/ecma262/#sec-eval-x</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-eval-x" class="dfn-panel" data-for="term-for-sec-eval-x" id="infopanel-for-term-for-sec-eval-x" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-eval-x" style="display:none">Info about the 'eval()' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-eval-x">https://tc39.github.io/ecma262/#sec-eval-x</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-eval-x">2.10. 
   Do features in this specification enable new script execution/loading
   mechanisms? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cdm">
-   <a href="https://www.w3.org/TR/encrypted-media/#cdm">https://www.w3.org/TR/encrypted-media/#cdm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cdm" class="dfn-panel" data-for="term-for-cdm" id="infopanel-for-term-for-cdm" role="menu">
+   <span id="infopaneltitle-for-term-for-cdm" style="display:none">Info about the 'content decryption module' external reference.</span><a href="https://www.w3.org/TR/encrypted-media/#cdm">https://www.w3.org/TR/encrypted-media/#cdm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cdm">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-document-domain">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-document-domain" class="dfn-panel" data-for="term-for-dom-document-domain" id="infopanel-for-term-for-dom-document-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-document-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain">https://html.spec.whatwg.org/multipage/browsers.html#dom-document-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-domain">2.17. 
   Do features in your specification enable origins to downgrade default
   security protections? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2.17. 
   Do features in your specification enable origins to downgrade default
   security protections? </a> <a href="#ref-for-the-iframe-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-link-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-link-element" class="dfn-panel" data-for="term-for-the-link-element" id="infopanel-for-term-for-the-link-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-link-element" style="display:none">Info about the 'link' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">https://html.spec.whatwg.org/multipage/semantics.html#the-link-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-link-element">2.10. 
   Do features in this specification enable new script execution/loading
   mechanisms? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-localstorage">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-localstorage" class="dfn-panel" data-for="term-for-dom-localstorage" id="infopanel-for-term-for-dom-localstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-localstorage" style="display:none">Info about the 'localStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage">https://html.spec.whatwg.org/multipage/webstorage.html#dom-localstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-localstorage">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script" class="dfn-panel" data-for="term-for-script" id="infopanel-for-term-for-script" role="menu">
+   <span id="infopaneltitle-for-term-for-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script">2.10. 
   Do features in this specification enable new script execution/loading
   mechanisms? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-secure-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-secure-context" class="dfn-panel" data-for="term-for-secure-context" id="infopanel-for-term-for-secure-context" role="menu">
+   <span id="infopaneltitle-for-term-for-secure-context" style="display:none">Info about the 'secure context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context">https://html.spec.whatwg.org/multipage/webappapis.html#secure-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-secure-context">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-settimeout">
-   <a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-settimeout" class="dfn-panel" data-for="term-for-dom-settimeout" id="infopanel-for-term-for-dom-settimeout" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-settimeout" style="display:none">Info about the 'setTimeout(handler, timeout, ...arguments)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout">https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-settimeout">2.10. 
   Do features in this specification enable new script execution/loading
   mechanisms? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-indexeddb">
-   <a href="https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb">https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-indexeddb" class="dfn-panel" data-for="term-for-dom-windoworworkerglobalscope-indexeddb" id="infopanel-for-term-for-dom-windoworworkerglobalscope-indexeddb" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-windoworworkerglobalscope-indexeddb" style="display:none">Info about the 'indexedDB' external reference.</span><a href="https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb">https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-windoworworkerglobalscope-indexeddb">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">2.17. 
   Do features in your specification enable origins to downgrade default
   security protections? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-first-party-site-context">
-   <a href="https://privacycg.github.io/storage-access/#first-party-site-context">https://privacycg.github.io/storage-access/#first-party-site-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-first-party-site-context" class="dfn-panel" data-for="term-for-first-party-site-context" id="infopanel-for-term-for-first-party-site-context" role="menu">
+   <span id="infopaneltitle-for-term-for-first-party-site-context" style="display:none">Info about the 'first-party-site context' external reference.</span><a href="https://privacycg.github.io/storage-access/#first-party-site-context">https://privacycg.github.io/storage-access/#first-party-site-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-first-party-site-context">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-third-party-context">
-   <a href="https://privacycg.github.io/storage-access/#third-party-context">https://privacycg.github.io/storage-access/#third-party-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-third-party-context" class="dfn-panel" data-for="term-for-third-party-context" id="infopanel-for-term-for-third-party-context" role="menu">
+   <span id="infopaneltitle-for-term-for-third-party-context" style="display:none">Info about the 'third-party context' external reference.</span><a href="https://privacycg.github.io/storage-access/#third-party-context">https://privacycg.github.io/storage-access/#third-party-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-third-party-context">2.5. 
   Do the features in your specification introduce new state for an origin
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formdata">
-   <a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formdata" class="dfn-panel" data-for="term-for-formdata" id="infopanel-for-term-for-formdata" role="menu">
+   <span id="infopaneltitle-for-term-for-formdata" style="display:none">Info about the 'FormData' external reference.</span><a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formdata">2.4. 
   How do the features in your specification deal with sensitive information? </a>
@@ -1858,15 +1858,15 @@ practices before the site prompted for location.</p>
    <dt id="biblio-yubikey-attack">[YUBIKEY-ATTACK]
    <dd>Andy Greenberg. <a href="https://www.wired.com/story/chrome-yubikey-phishing-webusb/"><cite>Chrome Lets Hackers Phish Even 'Unphishable' YubiKey Users</cite></a>. URL: <a href="https://www.wired.com/story/chrome-yubikey-phishing-webusb/">https://www.wired.com/story/chrome-yubikey-phishing-webusb/</a>
   </dl>
-  <aside class="dfn-panel" data-for="passive-network-attacker">
-   <b><a href="#passive-network-attacker">#passive-network-attacker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-passive-network-attacker" class="dfn-panel" data-for="passive-network-attacker" id="infopanel-for-passive-network-attacker" role="dialog">
+   <span id="infopaneltitle-for-passive-network-attacker" style="display:none">Info about the 'passive network attacker' definition.</span><b><a href="#passive-network-attacker">#passive-network-attacker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-passive-network-attacker">4.5. 
   Secure Contexts </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active-network-attacker">
-   <b><a href="#active-network-attacker">#active-network-attacker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active-network-attacker" class="dfn-panel" data-for="active-network-attacker" id="infopanel-for-active-network-attacker" role="dialog">
+   <span id="infopaneltitle-for-active-network-attacker" style="display:none">Info about the 'active network attacker' definition.</span><b><a href="#active-network-attacker">#active-network-attacker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-network-attacker">2.5. 
   Do the features in your specification introduce new state for an origin
@@ -1875,8 +1875,8 @@ practices before the site prompted for location.</p>
   Secure Contexts </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="same-origin-policy">
-   <b><a href="#same-origin-policy">#same-origin-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-same-origin-policy" class="dfn-panel" data-for="same-origin-policy" id="infopanel-for-same-origin-policy" role="dialog">
+   <span id="infopaneltitle-for-same-origin-policy" style="display:none">Info about the 'same-origin policy' definition.</span><b><a href="#same-origin-policy">#same-origin-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin-policy">2.9. 
   What data do the features in this specification expose to an origin? Please
@@ -1887,8 +1887,8 @@ practices before the site prompted for location.</p>
   security protections? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-site-scripting-attacks">
-   <b><a href="#cross-site-scripting-attacks">#cross-site-scripting-attacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-site-scripting-attacks" class="dfn-panel" data-for="cross-site-scripting-attacks" id="infopanel-for-cross-site-scripting-attacks" role="dialog">
+   <span id="infopaneltitle-for-cross-site-scripting-attacks" style="display:none">Info about the 'Cross-site scripting attacks' definition.</span><b><a href="#cross-site-scripting-attacks">#cross-site-scripting-attacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-site-scripting-attacks">2.4. 
   How do the features in your specification deal with sensitive information? </a>
@@ -1897,8 +1897,8 @@ practices before the site prompted for location.</p>
   that persists across browsing sessions? </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-site-request-forgery-attacks">
-   <b><a href="#cross-site-request-forgery-attacks">#cross-site-request-forgery-attacks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-site-request-forgery-attacks" class="dfn-panel" data-for="cross-site-request-forgery-attacks" id="infopanel-for-cross-site-request-forgery-attacks" role="dialog">
+   <span id="infopaneltitle-for-cross-site-request-forgery-attacks" style="display:none">Info about the 'Cross-site request forgery attacks' definition.</span><b><a href="#cross-site-request-forgery-attacks">#cross-site-request-forgery-attacks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-site-request-forgery-attacks">2.7. 
   Does this specification allow an origin to send data to the underlying
@@ -1907,57 +1907,113 @@ practices before the site prompted for location.</p>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/compat/compatibility.html
+++ b/tests/github/whatwg/compat/compatibility.html
@@ -1059,15 +1059,15 @@ if ("serviceWorker" in navigator) {
    <li><a href="#propdef--webkit-transition-property">-webkit-transition-property</a><span>, in § 3.4.1</span>
    <li><a href="#propdef--webkit-transition-timing-function">-webkit-transition-timing-function</a><span>, in § 3.4.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-screenorientation-interface">
-   <a href="https://w3c.github.io/screen-orientation/#screenorientation-interface">https://w3c.github.io/screen-orientation/#screenorientation-interface</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-screenorientation-interface" class="dfn-panel" data-for="term-for-screenorientation-interface" id="infopanel-for-term-for-screenorientation-interface" role="menu">
+   <span id="infopaneltitle-for-term-for-screenorientation-interface" style="display:none">Info about the 'ScreenOrientation' external reference.</span><a href="https://w3c.github.io/screen-orientation/#screenorientation-interface">https://w3c.github.io/screen-orientation/#screenorientation-interface</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-screenorientation-interface">4.2.1. window.orientation angle</a>
     <li><a href="#ref-for-screenorientation-interface①">Acknowledgements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-animtype-color">
-   <a href="https://drafts.csswg.org/css-transitions/#animtype-color">https://drafts.csswg.org/css-transitions/#animtype-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-animtype-color" class="dfn-panel" data-for="term-for-animtype-color" id="infopanel-for-term-for-animtype-color" role="menu">
+   <span id="infopaneltitle-for-term-for-animtype-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-transitions/#animtype-color">https://drafts.csswg.org/css-transitions/#animtype-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-animtype-color">3.4.7.1. Foreground Text Color: the 
 -webkit-text-fill-color property</a>
@@ -1075,121 +1075,121 @@ if ("serviceWorker" in navigator) {
 -webkit-text-stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dppx">
-   <a href="https://drafts.csswg.org/css-values-3/#dppx">https://drafts.csswg.org/css-values-3/#dppx</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dppx" class="dfn-panel" data-for="term-for-dppx" id="infopanel-for-term-for-dppx" role="menu">
+   <span id="infopaneltitle-for-term-for-dppx" style="display:none">Info about the 'dppx' external reference.</span><a href="https://drafts.csswg.org/css-values-3/#dppx">https://drafts.csswg.org/css-values-3/#dppx</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dppx">3.2.1. 
   -webkit-device-pixel-ratio </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-special-backgrounds">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#special-backgrounds">https://drafts.csswg.org/css-backgrounds-3/#special-backgrounds</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-special-backgrounds" class="dfn-panel" data-for="term-for-special-backgrounds" id="infopanel-for-term-for-special-backgrounds" role="menu">
+   <span id="infopaneltitle-for-term-for-special-backgrounds" style="display:none">Info about the 'the backgrounds of special elements' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#special-backgrounds">https://drafts.csswg.org/css-backgrounds-3/#special-backgrounds</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-backgrounds">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-update-the-orientation-information">
-   <a href="https://w3c.github.io/screen-orientation/#dfn-update-the-orientation-information">https://w3c.github.io/screen-orientation/#dfn-update-the-orientation-information</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-update-the-orientation-information" class="dfn-panel" data-for="term-for-dfn-update-the-orientation-information" id="infopanel-for-term-for-dfn-update-the-orientation-information" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-update-the-orientation-information" style="display:none">Info about the 'update the orientation information' external reference.</span><a href="https://w3c.github.io/screen-orientation/#dfn-update-the-orientation-information">https://w3c.github.io/screen-orientation/#dfn-update-the-orientation-information</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-update-the-orientation-information">4.2.1. window.orientation angle</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-content" class="dfn-panel" data-for="term-for-propdef-align-content" id="infopanel-for-term-for-propdef-align-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-content" style="display:none">Info about the 'align-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-content">https://drafts.csswg.org/css-align-3/#propdef-align-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-content">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-items">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-items" class="dfn-panel" data-for="term-for-propdef-align-items" id="infopanel-for-term-for-propdef-align-items" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-items" style="display:none">Info about the 'align-items' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-items">https://drafts.csswg.org/css-align-3/#propdef-align-items</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-items">3.4.1. Simple property aliases</a>
     <li><a href="#ref-for-propdef-align-items①">3.4.4. Property mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-align-self">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-align-self" class="dfn-panel" data-for="term-for-propdef-align-self" id="infopanel-for-term-for-propdef-align-self" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-align-self" style="display:none">Info about the 'align-self' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-align-self">https://drafts.csswg.org/css-align-3/#propdef-align-self</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-align-self">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-justify-content">
-   <a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-justify-content" class="dfn-panel" data-for="term-for-propdef-justify-content" id="infopanel-for-term-for-propdef-justify-content" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-justify-content" style="display:none">Info about the 'justify-content' external reference.</span><a href="https://drafts.csswg.org/css-align-3/#propdef-justify-content">https://drafts.csswg.org/css-align-3/#propdef-justify-content</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-justify-content">3.4.1. Simple property aliases</a>
     <li><a href="#ref-for-propdef-justify-content①">3.4.4. Property mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-keyframes">
-   <a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-keyframes" class="dfn-panel" data-for="term-for-at-ruledef-keyframes" id="infopanel-for-term-for-at-ruledef-keyframes" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-keyframes" style="display:none">Info about the '@keyframes' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes">https://drafts.csswg.org/css-animations-1/#at-ruledef-keyframes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-keyframes">3.1. CSS At-rules</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation" class="dfn-panel" data-for="term-for-propdef-animation" id="infopanel-for-term-for-propdef-animation" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation" style="display:none">Info about the 'animation' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation">https://drafts.csswg.org/css-animations-1/#propdef-animation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-delay">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-delay">https://drafts.csswg.org/css-animations-1/#propdef-animation-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-delay" class="dfn-panel" data-for="term-for-propdef-animation-delay" id="infopanel-for-term-for-propdef-animation-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-delay" style="display:none">Info about the 'animation-delay' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-delay">https://drafts.csswg.org/css-animations-1/#propdef-animation-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-delay">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-direction">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-direction">https://drafts.csswg.org/css-animations-1/#propdef-animation-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-direction" class="dfn-panel" data-for="term-for-propdef-animation-direction" id="infopanel-for-term-for-propdef-animation-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-direction" style="display:none">Info about the 'animation-direction' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-direction">https://drafts.csswg.org/css-animations-1/#propdef-animation-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-direction">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-duration">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-duration">https://drafts.csswg.org/css-animations-1/#propdef-animation-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-duration" class="dfn-panel" data-for="term-for-propdef-animation-duration" id="infopanel-for-term-for-propdef-animation-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-duration" style="display:none">Info about the 'animation-duration' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-duration">https://drafts.csswg.org/css-animations-1/#propdef-animation-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-duration">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-fill-mode">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-fill-mode" class="dfn-panel" data-for="term-for-propdef-animation-fill-mode" id="infopanel-for-term-for-propdef-animation-fill-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-fill-mode" style="display:none">Info about the 'animation-fill-mode' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode">https://drafts.csswg.org/css-animations-1/#propdef-animation-fill-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-fill-mode">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-iteration-count">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-iteration-count" class="dfn-panel" data-for="term-for-propdef-animation-iteration-count" id="infopanel-for-term-for-propdef-animation-iteration-count" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-iteration-count" style="display:none">Info about the 'animation-iteration-count' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count">https://drafts.csswg.org/css-animations-1/#propdef-animation-iteration-count</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-iteration-count">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-name">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-name" class="dfn-panel" data-for="term-for-propdef-animation-name" id="infopanel-for-term-for-propdef-animation-name" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-name" style="display:none">Info about the 'animation-name' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-name">https://drafts.csswg.org/css-animations-1/#propdef-animation-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-name">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-play-state">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state">https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-play-state" class="dfn-panel" data-for="term-for-propdef-animation-play-state" id="infopanel-for-term-for-propdef-animation-play-state" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-play-state" style="display:none">Info about the 'animation-play-state' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state">https://drafts.csswg.org/css-animations-1/#propdef-animation-play-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-play-state">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-animation-timing-function">
-   <a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-animation-timing-function" class="dfn-panel" data-for="term-for-propdef-animation-timing-function" id="infopanel-for-term-for-propdef-animation-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-animation-timing-function" style="display:none">Info about the 'animation-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function">https://drafts.csswg.org/css-animations-1/#propdef-animation-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-animation-timing-function">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-box">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-box" class="dfn-panel" data-for="term-for-typedef-box" id="infopanel-for-term-for-typedef-box" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-box" style="display:none">Info about the '&lt;box>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-box">https://drafts.csswg.org/css-backgrounds-3/#typedef-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-box">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-line-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-line-width" class="dfn-panel" data-for="term-for-typedef-line-width" id="infopanel-for-term-for-typedef-line-width" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-line-width" style="display:none">Info about the '&lt;line-width>' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width">https://drafts.csswg.org/css-backgrounds-3/#typedef-line-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-line-width">3.4.7.3. Text Stroke Thickness: the 
 -webkit-text-stroke-width property</a>
@@ -1197,63 +1197,63 @@ if ("serviceWorker" in navigator) {
 -webkit-text-stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-clip">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-clip" class="dfn-panel" data-for="term-for-propdef-background-clip" id="infopanel-for-term-for-propdef-background-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-clip" style="display:none">Info about the 'background-clip' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-clip">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-origin">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-origin" class="dfn-panel" data-for="term-for-propdef-background-origin" id="infopanel-for-term-for-propdef-background-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-origin" style="display:none">Info about the 'background-origin' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-origin">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-size">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-size" class="dfn-panel" data-for="term-for-propdef-background-size" id="infopanel-for-term-for-propdef-background-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-size" style="display:none">Info about the 'background-size' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-size">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-left-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-left-radius" class="dfn-panel" data-for="term-for-propdef-border-bottom-left-radius" id="infopanel-for-term-for-propdef-border-bottom-left-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-left-radius" style="display:none">Info about the 'border-bottom-left-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-left-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-left-radius">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-right-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-right-radius" class="dfn-panel" data-for="term-for-propdef-border-bottom-right-radius" id="infopanel-for-term-for-propdef-border-bottom-right-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-right-radius" style="display:none">Info about the 'border-bottom-right-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-right-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-right-radius">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-radius" class="dfn-panel" data-for="term-for-propdef-border-radius" id="infopanel-for-term-for-propdef-border-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-radius" style="display:none">Info about the 'border-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-radius">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-left-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-left-radius" class="dfn-panel" data-for="term-for-propdef-border-top-left-radius" id="infopanel-for-term-for-propdef-border-top-left-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-left-radius" style="display:none">Info about the 'border-top-left-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-left-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-left-radius">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-right-radius">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-right-radius" class="dfn-panel" data-for="term-for-propdef-border-top-right-radius" id="infopanel-for-term-for-propdef-border-top-right-radius" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-right-radius" style="display:none">Info about the 'border-top-right-radius' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-right-radius</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-right-radius">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-shadow">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-shadow" class="dfn-panel" data-for="term-for-propdef-box-shadow" id="infopanel-for-term-for-propdef-box-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-shadow" style="display:none">Info about the 'box-shadow' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow">https://drafts.csswg.org/css-backgrounds-3/#propdef-box-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-shadow">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">3.4.7.1. Foreground Text Color: the 
 -webkit-text-fill-color property</a>
@@ -1263,8 +1263,8 @@ if ("serviceWorker" in navigator) {
 -webkit-text-stroke property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-currentcolor">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-currentcolor" class="dfn-panel" data-for="term-for-valdef-color-currentcolor" id="infopanel-for-term-for-valdef-color-currentcolor" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-currentcolor" style="display:none">Info about the 'currentcolor' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor">https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-currentcolor">3.4.7.1. Foreground Text Color: the 
 -webkit-text-fill-color property</a>
@@ -1272,8 +1272,8 @@ if ("serviceWorker" in navigator) {
 -webkit-text-stroke-color property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-media">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-media" class="dfn-panel" data-for="term-for-at-ruledef-media" id="infopanel-for-term-for-at-ruledef-media" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-media" style="display:none">Info about the '@media' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-media">https://drafts.csswg.org/css-conditional-3/#at-ruledef-media</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-media">3.2.1. 
   -webkit-device-pixel-ratio </a>
@@ -1281,269 +1281,269 @@ if ("serviceWorker" in navigator) {
   -webkit-transform-3d </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-flex">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-flex" class="dfn-panel" data-for="term-for-valdef-display-flex" id="infopanel-for-term-for-valdef-display-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-flex">https://drafts.csswg.org/css-display-3/#valdef-display-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-flex">3.4.5. Keyword mappings</a> <a href="#ref-for-valdef-display-flex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-order">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-order" class="dfn-panel" data-for="term-for-propdef-order" id="infopanel-for-term-for-propdef-order" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-order" style="display:none">Info about the 'order' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-order">https://drafts.csswg.org/css-display-3/#propdef-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-order">3.4.1. Simple property aliases</a>
     <li><a href="#ref-for-propdef-order①">3.4.4. Property mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex" class="dfn-panel" data-for="term-for-propdef-flex" id="infopanel-for-term-for-propdef-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex" style="display:none">Info about the 'flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex">https://drafts.csswg.org/css-flexbox-1/#propdef-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-basis">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-basis" class="dfn-panel" data-for="term-for-propdef-flex-basis" id="infopanel-for-term-for-propdef-flex-basis" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-basis" style="display:none">Info about the 'flex-basis' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-basis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-basis">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-direction">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-direction" class="dfn-panel" data-for="term-for-propdef-flex-direction" id="infopanel-for-term-for-propdef-flex-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-direction" style="display:none">Info about the 'flex-direction' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-direction">3.4.1. Simple property aliases</a>
     <li><a href="#ref-for-propdef-flex-direction①">3.4.4. Property mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-flow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-flow" class="dfn-panel" data-for="term-for-propdef-flex-flow" id="infopanel-for-term-for-propdef-flex-flow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-flow" style="display:none">Info about the 'flex-flow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-flow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-flow">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-grow">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-grow" class="dfn-panel" data-for="term-for-propdef-flex-grow" id="infopanel-for-term-for-propdef-flex-grow" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-grow" style="display:none">Info about the 'flex-grow' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-grow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-grow">3.4.1. Simple property aliases</a>
     <li><a href="#ref-for-propdef-flex-grow①">3.4.4. Property mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-shrink">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-shrink" class="dfn-panel" data-for="term-for-propdef-flex-shrink" id="infopanel-for-term-for-propdef-flex-shrink" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-shrink" style="display:none">Info about the 'flex-shrink' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-shrink</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-shrink">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-flex-wrap">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-flex-wrap" class="dfn-panel" data-for="term-for-propdef-flex-wrap" id="infopanel-for-term-for-propdef-flex-wrap" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-flex-wrap" style="display:none">Info about the 'flex-wrap' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap">https://drafts.csswg.org/css-flexbox-1/#propdef-flex-wrap</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-flex-wrap">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-inline-flex">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-inline-flex" class="dfn-panel" data-for="term-for-valdef-display-inline-flex" id="infopanel-for-term-for-valdef-display-inline-flex" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-inline-flex" style="display:none">Info about the 'inline-flex' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex">https://drafts.csswg.org/css-flexbox-1/#valdef-display-inline-flex</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-inline-flex">3.4.5. Keyword mappings</a> <a href="#ref-for-valdef-display-inline-flex①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clipping-region">
-   <a href="https://drafts.fxtf.org/css-masking-1/#clipping-region">https://drafts.fxtf.org/css-masking-1/#clipping-region</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clipping-region" class="dfn-panel" data-for="term-for-clipping-region" id="infopanel-for-term-for-clipping-region" role="menu">
+   <span id="infopaneltitle-for-term-for-clipping-region" style="display:none">Info about the 'clipping region' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#clipping-region">https://drafts.fxtf.org/css-masking-1/#clipping-region</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clipping-region">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask" class="dfn-panel" data-for="term-for-propdef-mask" id="infopanel-for-term-for-propdef-mask" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask" style="display:none">Info about the 'mask' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask">https://drafts.fxtf.org/css-masking-1/#propdef-mask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border" class="dfn-panel" data-for="term-for-propdef-mask-border" id="infopanel-for-term-for-propdef-mask-border" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border" style="display:none">Info about the 'mask-border' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-outset">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-outset" class="dfn-panel" data-for="term-for-propdef-mask-border-outset" id="infopanel-for-term-for-propdef-mask-border-outset" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-outset" style="display:none">Info about the 'mask-border-outset' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-outset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-outset">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-repeat">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-repeat" class="dfn-panel" data-for="term-for-propdef-mask-border-repeat" id="infopanel-for-term-for-propdef-mask-border-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-repeat" style="display:none">Info about the 'mask-border-repeat' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-repeat">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-slice">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-slice" class="dfn-panel" data-for="term-for-propdef-mask-border-slice" id="infopanel-for-term-for-propdef-mask-border-slice" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-slice" style="display:none">Info about the 'mask-border-slice' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-slice</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-slice">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-source">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-source" class="dfn-panel" data-for="term-for-propdef-mask-border-source" id="infopanel-for-term-for-propdef-mask-border-source" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-source" style="display:none">Info about the 'mask-border-source' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-source">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-border-width">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-border-width" class="dfn-panel" data-for="term-for-propdef-mask-border-width" id="infopanel-for-term-for-propdef-mask-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-border-width" style="display:none">Info about the 'mask-border-width' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width">https://drafts.fxtf.org/css-masking-1/#propdef-mask-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-border-width">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip">https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-clip" class="dfn-panel" data-for="term-for-propdef-mask-clip" id="infopanel-for-term-for-propdef-mask-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-clip" style="display:none">Info about the 'mask-clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip">https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-clip">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-composite">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite">https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-composite" class="dfn-panel" data-for="term-for-propdef-mask-composite" id="infopanel-for-term-for-propdef-mask-composite" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-composite" style="display:none">Info about the 'mask-composite' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite">https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-composite">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-image">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-image" class="dfn-panel" data-for="term-for-propdef-mask-image" id="infopanel-for-term-for-propdef-mask-image" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-image" style="display:none">Info about the 'mask-image' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-image">https://drafts.fxtf.org/css-masking-1/#propdef-mask-image</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-image">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-origin">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin">https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-origin" class="dfn-panel" data-for="term-for-propdef-mask-origin" id="infopanel-for-term-for-propdef-mask-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-origin" style="display:none">Info about the 'mask-origin' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin">https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-origin">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-position">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-position">https://drafts.fxtf.org/css-masking-1/#propdef-mask-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-position" class="dfn-panel" data-for="term-for-propdef-mask-position" id="infopanel-for-term-for-propdef-mask-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-position" style="display:none">Info about the 'mask-position' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-position">https://drafts.fxtf.org/css-masking-1/#propdef-mask-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-position">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-repeat">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-repeat" class="dfn-panel" data-for="term-for-propdef-mask-repeat" id="infopanel-for-term-for-propdef-mask-repeat" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-repeat" style="display:none">Info about the 'mask-repeat' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat">https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-repeat">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-mask-size">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-size">https://drafts.fxtf.org/css-masking-1/#propdef-mask-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-mask-size" class="dfn-panel" data-for="term-for-propdef-mask-size" id="infopanel-for-term-for-propdef-mask-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-mask-size" style="display:none">Info about the 'mask-size' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-mask-size">https://drafts.fxtf.org/css-masking-1/#propdef-mask-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-mask-size">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-size-adjust">
-   <a href="https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust">https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-size-adjust" class="dfn-panel" data-for="term-for-propdef-text-size-adjust" id="infopanel-for-term-for-propdef-text-size-adjust" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-size-adjust" style="display:none">Info about the 'text-size-adjust' external reference.</span><a href="https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust">https://drafts.csswg.org/css-size-adjust-1/#propdef-text-size-adjust</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-size-adjust">3.4.2. Prefixed property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform" class="dfn-panel" data-for="term-for-propdef-transform" id="infopanel-for-term-for-propdef-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform">https://drafts.csswg.org/css-transforms-1/#propdef-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-origin">
-   <a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-origin" class="dfn-panel" data-for="term-for-propdef-transform-origin" id="infopanel-for-term-for-propdef-transform-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-origin" style="display:none">Info about the 'transform-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin">https://drafts.csswg.org/css-transforms-1/#propdef-transform-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-origin">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-backface-visibility">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-backface-visibility" class="dfn-panel" data-for="term-for-propdef-backface-visibility" id="infopanel-for-term-for-propdef-backface-visibility" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-backface-visibility" style="display:none">Info about the 'backface-visibility' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility">https://drafts.csswg.org/css-transforms-2/#propdef-backface-visibility</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-backface-visibility">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-perspective">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-perspective" class="dfn-panel" data-for="term-for-propdef-perspective" id="infopanel-for-term-for-propdef-perspective" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-perspective" style="display:none">Info about the 'perspective' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective">https://drafts.csswg.org/css-transforms-2/#propdef-perspective</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-perspective-origin">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin">https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-perspective-origin" class="dfn-panel" data-for="term-for-propdef-perspective-origin" id="infopanel-for-term-for-propdef-perspective-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-perspective-origin" style="display:none">Info about the 'perspective-origin' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin">https://drafts.csswg.org/css-transforms-2/#propdef-perspective-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-perspective-origin">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transform-style">
-   <a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transform-style" class="dfn-panel" data-for="term-for-propdef-transform-style" id="infopanel-for-term-for-propdef-transform-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transform-style" style="display:none">Info about the 'transform-style' external reference.</span><a href="https://drafts.csswg.org/css-transforms-2/#propdef-transform-style">https://drafts.csswg.org/css-transforms-2/#propdef-transform-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transform-style">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition">https://drafts.csswg.org/css-transitions-1/#propdef-transition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition" class="dfn-panel" data-for="term-for-propdef-transition" id="infopanel-for-term-for-propdef-transition" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition" style="display:none">Info about the 'transition' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition">https://drafts.csswg.org/css-transitions-1/#propdef-transition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-delay">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-delay" class="dfn-panel" data-for="term-for-propdef-transition-delay" id="infopanel-for-term-for-propdef-transition-delay" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-delay" style="display:none">Info about the 'transition-delay' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay">https://drafts.csswg.org/css-transitions-1/#propdef-transition-delay</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-delay">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-duration">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-duration" class="dfn-panel" data-for="term-for-propdef-transition-duration" id="infopanel-for-term-for-propdef-transition-duration" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-duration" style="display:none">Info about the 'transition-duration' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration">https://drafts.csswg.org/css-transitions-1/#propdef-transition-duration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-duration">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-property">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-property" class="dfn-panel" data-for="term-for-propdef-transition-property" id="infopanel-for-term-for-propdef-transition-property" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-property" style="display:none">Info about the 'transition-property' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-property">https://drafts.csswg.org/css-transitions-1/#propdef-transition-property</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-property">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-transition-timing-function">
-   <a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-transition-timing-function" class="dfn-panel" data-for="term-for-propdef-transition-timing-function" id="infopanel-for-term-for-propdef-transition-timing-function" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-transition-timing-function" style="display:none">Info about the 'transition-timing-function' external reference.</span><a href="https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function">https://drafts.csswg.org/css-transitions-1/#propdef-transition-timing-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-transition-timing-function">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef--webkit-appearance">
-   <a href="https://drafts.csswg.org/css-ui-4/#propdef--webkit-appearance">https://drafts.csswg.org/css-ui-4/#propdef--webkit-appearance</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef--webkit-appearance" class="dfn-panel" data-for="term-for-propdef--webkit-appearance" id="infopanel-for-term-for-propdef--webkit-appearance" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef--webkit-appearance" style="display:none">Info about the '-webkit-appearance' external reference.</span><a href="https://drafts.csswg.org/css-ui-4/#propdef--webkit-appearance">https://drafts.csswg.org/css-ui-4/#propdef--webkit-appearance</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-appearance">3.4.3. Non-aliased vendor prefixed properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number-value">
-   <a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number-value" class="dfn-panel" data-for="term-for-number-value" id="infopanel-for-term-for-number-value" role="menu">
+   <span id="infopaneltitle-for-term-for-number-value" style="display:none">Info about the '&lt;number>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number-value">https://drafts.csswg.org/css-values-4/#number-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number-value">3.2.1. 
   -webkit-device-pixel-ratio </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a> <a href="#ref-for-comb-one①">(2)</a> <a href="#ref-for-comb-one②">(3)</a>
     <li><a href="#ref-for-comb-one③">3.5.1. Additional touch-action values</a> <a href="#ref-for-comb-one④">(2)</a> <a href="#ref-for-comb-one⑤">(3)</a> <a href="#ref-for-comb-one⑥">(4)</a> <a href="#ref-for-comb-one⑦">(5)</a> <a href="#ref-for-comb-one⑧">(6)</a> <a href="#ref-for-comb-one⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-any">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-any" class="dfn-panel" data-for="term-for-comb-any" id="infopanel-for-term-for-comb-any" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-any" style="display:none">Info about the '||' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-any">https://drafts.csswg.org/css-values-4/#comb-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-any">3.4.7.4. Text Stroke Shorthand: the 
 -webkit-text-stroke property</a>
     <li><a href="#ref-for-comb-any①">3.5.1. Additional touch-action values</a> <a href="#ref-for-comb-any②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vendor-prefix">
-   <a href="https://www.w3.org/TR/CSS/#vendor-prefix">https://www.w3.org/TR/CSS/#vendor-prefix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vendor-prefix" class="dfn-panel" data-for="term-for-vendor-prefix" id="infopanel-for-term-for-vendor-prefix" role="menu">
+   <span id="infopaneltitle-for-term-for-vendor-prefix" style="display:none">Info about the 'vendor prefix' external reference.</span><a href="https://www.w3.org/TR/CSS/#vendor-prefix">https://www.w3.org/TR/CSS/#vendor-prefix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vendor-prefix">3.1. CSS At-rules</a>
     <li><a href="#ref-for-vendor-prefix①">3.4.1. Simple property aliases</a>
@@ -1552,140 +1552,140 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-vendor-prefix④">3.4.5. Keyword mappings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ltlinear-gradient">
-   <a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltlinear-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltlinear-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ltlinear-gradient" class="dfn-panel" data-for="term-for-ltlinear-gradient" id="infopanel-for-term-for-ltlinear-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-ltlinear-gradient" style="display:none">Info about the 'linear-gradient' external reference.</span><a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltlinear-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltlinear-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltlinear-gradient">3.3.1. 
   -webkit-linear-gradient() </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ltradial-gradient">
-   <a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltradial-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltradial-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ltradial-gradient" class="dfn-panel" data-for="term-for-ltradial-gradient" id="infopanel-for-term-for-ltradial-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-ltradial-gradient" style="display:none">Info about the 'radial-gradient' external reference.</span><a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltradial-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltradial-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltradial-gradient">3.3.2. 
   -webkit-radial-gradient() </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ltrepeating-linear-gradient">
-   <a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-linear-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-linear-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ltrepeating-linear-gradient" class="dfn-panel" data-for="term-for-ltrepeating-linear-gradient" id="infopanel-for-term-for-ltrepeating-linear-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-ltrepeating-linear-gradient" style="display:none">Info about the 'repeating-linear-gradient' external reference.</span><a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-linear-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-linear-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltrepeating-linear-gradient">3.3.3. 
   -webkit-repeating-linear-gradient() </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ltrepeating-radial-gradient">
-   <a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-radial-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-radial-gradient</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ltrepeating-radial-gradient" class="dfn-panel" data-for="term-for-ltrepeating-radial-gradient" id="infopanel-for-term-for-ltrepeating-radial-gradient" role="menu">
+   <span id="infopaneltitle-for-term-for-ltrepeating-radial-gradient" style="display:none">Info about the 'repeating-radial-gradient' external reference.</span><a href="https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-radial-gradient">https://www.w3.org/TR/2011/WD-css3-images-20110217/#ltrepeating-radial-gradient</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ltrepeating-radial-gradient">3.3.4. 
   -webkit-repeating-radial-gradient() </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">4.2. window.orientation API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-filter">
-   <a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-filter" class="dfn-panel" data-for="term-for-propdef-filter" id="infopanel-for-term-for-propdef-filter" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-filter" style="display:none">Info about the 'filter' external reference.</span><a href="https://drafts.fxtf.org/filter-effects-1/#propdef-filter">https://drafts.fxtf.org/filter-effects-1/#propdef-filter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-filter">3.4.1. Simple property aliases</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-webkitcssmatrix">
-   <a href="https://drafts.fxtf.org/geometry-1/#webkitcssmatrix">https://drafts.fxtf.org/geometry-1/#webkitcssmatrix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-webkitcssmatrix" class="dfn-panel" data-for="term-for-webkitcssmatrix" id="infopanel-for-term-for-webkitcssmatrix" role="menu">
+   <span id="infopaneltitle-for-term-for-webkitcssmatrix" style="display:none">Info about the 'WebKitCSSMatrix' external reference.</span><a href="https://drafts.fxtf.org/geometry-1/#webkitcssmatrix">https://drafts.fxtf.org/geometry-1/#webkitcssmatrix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-webkitcssmatrix">4.1. The WebKitCSSMatrix interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">4.2. window.orientation API</a> <a href="#ref-for-eventhandler①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlbodyelement">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#htmlbodyelement">https://html.spec.whatwg.org/multipage/sections.html#htmlbodyelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlbodyelement" class="dfn-panel" data-for="term-for-htmlbodyelement" id="infopanel-for-term-for-htmlbodyelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlbodyelement" style="display:none">Info about the 'HTMLBodyElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#htmlbodyelement">https://html.spec.whatwg.org/multipage/sections.html#htmlbodyelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlbodyelement">4.2. window.orientation API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">4.2. window.orientation API</a> <a href="#ref-for-window①">(2)</a>
     <li><a href="#ref-for-window②">4.2.2. Event Handlers on Window objects and body elements</a> <a href="#ref-for-window③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">4.2. window.orientation API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">4.2. window.orientation API</a>
     <li><a href="#ref-for-the-body-element①">4.2.2. Event Handlers on Window objects and body elements</a> <a href="#ref-for-the-body-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">4.2.2. Event Handlers on Window objects and body elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">4.2.2. Event Handlers on Window objects and body elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-resolution">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-resolution" class="dfn-panel" data-for="term-for-descdef-media-resolution" id="infopanel-for-term-for-descdef-media-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-resolution" style="display:none">Info about the 'max-resolution' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-resolution">3.2.1. 
   -webkit-device-pixel-ratio </a> <a href="#ref-for-descdef-media-resolution①">(2)</a> <a href="#ref-for-descdef-media-resolution②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-media-feature">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#media-feature">https://drafts.csswg.org/mediaqueries-4/#media-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-media-feature" class="dfn-panel" data-for="term-for-media-feature" id="infopanel-for-term-for-media-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-media-feature" style="display:none">Info about the 'media feature' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#media-feature">https://drafts.csswg.org/mediaqueries-4/#media-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-media-feature">3.2.1. 
   -webkit-device-pixel-ratio </a> <a href="#ref-for-media-feature①">(2)</a> <a href="#ref-for-media-feature②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-resolution">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-resolution" class="dfn-panel" data-for="term-for-descdef-media-resolution" id="infopanel-for-term-for-descdef-media-resolution①" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-resolution①" style="display:none">Info about the 'min-resolution' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-resolution">3.2.1. 
   -webkit-device-pixel-ratio </a> <a href="#ref-for-descdef-media-resolution①">(2)</a> <a href="#ref-for-descdef-media-resolution②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mq-min-max">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#mq-min-max">https://drafts.csswg.org/mediaqueries-4/#mq-min-max</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mq-min-max" class="dfn-panel" data-for="term-for-mq-min-max" id="infopanel-for-term-for-mq-min-max" role="menu">
+   <span id="infopaneltitle-for-term-for-mq-min-max" style="display:none">Info about the 'prefixes on range features' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#mq-min-max">https://drafts.csswg.org/mediaqueries-4/#mq-min-max</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mq-min-max">3.2.1. 
   -webkit-device-pixel-ratio </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-descdef-media-resolution">
-   <a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-descdef-media-resolution" class="dfn-panel" data-for="term-for-descdef-media-resolution" id="infopanel-for-term-for-descdef-media-resolution②" role="menu">
+   <span id="infopaneltitle-for-term-for-descdef-media-resolution②" style="display:none">Info about the 'resolution' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution">https://drafts.csswg.org/mediaqueries-4/#descdef-media-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-media-resolution">3.2.1. 
   -webkit-device-pixel-ratio </a> <a href="#ref-for-descdef-media-resolution①">(2)</a> <a href="#ref-for-descdef-media-resolution②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-mq-boolean">
-   <a href="https://drafts.csswg.org/mediaqueries-5/#typedef-mq-boolean">https://drafts.csswg.org/mediaqueries-5/#typedef-mq-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-mq-boolean" class="dfn-panel" data-for="term-for-typedef-mq-boolean" id="infopanel-for-term-for-typedef-mq-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-mq-boolean" style="display:none">Info about the '&lt;mq-boolean>' external reference.</span><a href="https://drafts.csswg.org/mediaqueries-5/#typedef-mq-boolean">https://drafts.csswg.org/mediaqueries-5/#typedef-mq-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-mq-boolean">3.2.2. 
   -webkit-transform-3d </a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">4.2. window.orientation API</a>
    </ul>
@@ -2071,22 +2071,22 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="propdef--webkit-background-clip">
-   <b><a href="#propdef--webkit-background-clip">#propdef--webkit-background-clip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-background-clip" class="dfn-panel" data-for="propdef--webkit-background-clip" id="infopanel-for-propdef--webkit-background-clip" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-background-clip" style="display:none">Info about the '-webkit-background-clip' definition.</span><b><a href="#propdef--webkit-background-clip">#propdef--webkit-background-clip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-background-clip">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a> <a href="#ref-for-propdef--webkit-background-clip①">(2)</a> <a href="#ref-for-propdef--webkit-background-clip②">(3)</a> <a href="#ref-for-propdef--webkit-background-clip③">(4)</a> <a href="#ref-for-propdef--webkit-background-clip④">(5)</a> <a href="#ref-for-propdef--webkit-background-clip⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef--webkit-background-clip-text">
-   <b><a href="#valdef--webkit-background-clip-text">#valdef--webkit-background-clip-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef--webkit-background-clip-text" class="dfn-panel" data-for="valdef--webkit-background-clip-text" id="infopanel-for-valdef--webkit-background-clip-text" role="dialog">
+   <span id="infopaneltitle-for-valdef--webkit-background-clip-text" style="display:none">Info about the 'text' definition.</span><b><a href="#valdef--webkit-background-clip-text">#valdef--webkit-background-clip-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef--webkit-background-clip-text">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef--webkit-text-fill-color">
-   <b><a href="#propdef--webkit-text-fill-color">#propdef--webkit-text-fill-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-text-fill-color" class="dfn-panel" data-for="propdef--webkit-text-fill-color" id="infopanel-for-propdef--webkit-text-fill-color" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-text-fill-color" style="display:none">Info about the '-webkit-text-fill-color' definition.</span><b><a href="#propdef--webkit-text-fill-color">#propdef--webkit-text-fill-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-text-fill-color">3.4.6. Foreground Text Clipping: the 
 -webkit-background-clip property</a>
@@ -2094,42 +2094,42 @@ if ("serviceWorker" in navigator) {
 -webkit-text-fill-color property</a> <a href="#ref-for-propdef--webkit-text-fill-color②">(2)</a> <a href="#ref-for-propdef--webkit-text-fill-color③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef--webkit-text-stroke-color">
-   <b><a href="#propdef--webkit-text-stroke-color">#propdef--webkit-text-stroke-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-text-stroke-color" class="dfn-panel" data-for="propdef--webkit-text-stroke-color" id="infopanel-for-propdef--webkit-text-stroke-color" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-text-stroke-color" style="display:none">Info about the '-webkit-text-stroke-color' definition.</span><b><a href="#propdef--webkit-text-stroke-color">#propdef--webkit-text-stroke-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-text-stroke-color">3.4.7.2. Text Stroke Color: the 
 -webkit-text-stroke-color property</a> <a href="#ref-for-propdef--webkit-text-stroke-color①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef--webkit-text-stroke-width">
-   <b><a href="#propdef--webkit-text-stroke-width">#propdef--webkit-text-stroke-width</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-text-stroke-width" class="dfn-panel" data-for="propdef--webkit-text-stroke-width" id="infopanel-for-propdef--webkit-text-stroke-width" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-text-stroke-width" style="display:none">Info about the '-webkit-text-stroke-width' definition.</span><b><a href="#propdef--webkit-text-stroke-width">#propdef--webkit-text-stroke-width</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-text-stroke-width">3.4.7.3. Text Stroke Thickness: the 
 -webkit-text-stroke-width property</a> <a href="#ref-for-propdef--webkit-text-stroke-width①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef--webkit-text-stroke">
-   <b><a href="#propdef--webkit-text-stroke">#propdef--webkit-text-stroke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef--webkit-text-stroke" class="dfn-panel" data-for="propdef--webkit-text-stroke" id="infopanel-for-propdef--webkit-text-stroke" role="dialog">
+   <span id="infopaneltitle-for-propdef--webkit-text-stroke" style="display:none">Info about the '-webkit-text-stroke' definition.</span><b><a href="#propdef--webkit-text-stroke">#propdef--webkit-text-stroke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef--webkit-text-stroke">3.4.7.4. Text Stroke Shorthand: the 
 -webkit-text-stroke property</a> <a href="#ref-for-propdef--webkit-text-stroke①">(2)</a> <a href="#ref-for-propdef--webkit-text-stroke②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-onorientationchange">
-   <b><a href="#dom-window-onorientationchange">#dom-window-onorientationchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-onorientationchange" class="dfn-panel" data-for="dom-window-onorientationchange" id="infopanel-for-dom-window-onorientationchange" role="dialog">
+   <span id="infopaneltitle-for-dom-window-onorientationchange" style="display:none">Info about the 'onorientationchange' definition.</span><b><a href="#dom-window-onorientationchange">#dom-window-onorientationchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-onorientationchange">4.2.2. Event Handlers on Window objects and body elements</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-orientation">
-   <b><a href="#dom-window-orientation">#dom-window-orientation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-orientation" class="dfn-panel" data-for="dom-window-orientation" id="infopanel-for-dom-window-orientation" role="dialog">
+   <span id="infopaneltitle-for-dom-window-orientation" style="display:none">Info about the 'orientation' definition.</span><b><a href="#dom-window-orientation">#dom-window-orientation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-orientation">4.2. window.orientation API</a> <a href="#ref-for-dom-window-orientation①">(2)</a> <a href="#ref-for-dom-window-orientation②">(3)</a>
     <li><a href="#ref-for-dom-window-orientation③">4.2.1. window.orientation angle</a> <a href="#ref-for-dom-window-orientation④">(2)</a> <a href="#ref-for-dom-window-orientation⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-orientationchange">
-   <b><a href="#event-orientationchange">#event-orientationchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-orientationchange" class="dfn-panel" data-for="event-orientationchange" id="infopanel-for-event-orientationchange" role="dialog">
+   <span id="infopaneltitle-for-event-orientationchange" style="display:none">Info about the 'orientationchange' definition.</span><b><a href="#event-orientationchange">#event-orientationchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-orientationchange">4.2. window.orientation API</a>
     <li><a href="#ref-for-event-orientationchange①">4.2.2. Event Handlers on Window objects and body elements</a>
@@ -2137,57 +2137,113 @@ if ("serviceWorker" in navigator) {
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/console/index.html
+++ b/tests/github/whatwg/console/index.html
@@ -1080,212 +1080,212 @@ if ("serviceWorker" in navigator) {
    <li><a href="#warn">warn()</a><span>, in § 1.1.8</span>
    <li><a href="#warn">warn(...data)</a><span>, in § 1.1.8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object">
-   <a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object" id="infopanel-for-term-for-sec-properties-of-the-object-prototype-object" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" style="display:none">Info about the '%ObjectPrototype%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-properties-of-the-object-prototype-object">1. Namespace console</a> <a href="#ref-for-sec-properties-of-the-object-prototype-object①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-string-constructor">
-   <a href="https://tc39.github.io/ecma262/#sec-string-constructor">https://tc39.github.io/ecma262/#sec-string-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-string-constructor" class="dfn-panel" data-for="term-for-sec-string-constructor" id="infopanel-for-term-for-sec-string-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-string-constructor" style="display:none">Info about the '%String%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-string-constructor">https://tc39.github.io/ecma262/#sec-string-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-string-constructor">2.2. Formatter(args)</a>
     <li><a href="#ref-for-sec-string-constructor①">2.2.1. Summary of formatting specifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-parsefloat-string">
-   <a href="https://tc39.github.io/ecma262/#sec-parsefloat-string">https://tc39.github.io/ecma262/#sec-parsefloat-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-parsefloat-string" class="dfn-panel" data-for="term-for-sec-parsefloat-string" id="infopanel-for-term-for-sec-parsefloat-string" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-parsefloat-string" style="display:none">Info about the '%parsefloat%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-parsefloat-string">https://tc39.github.io/ecma262/#sec-parsefloat-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-parsefloat-string">2.2. Formatter(args)</a>
     <li><a href="#ref-for-sec-parsefloat-string①">2.2.1. Summary of formatting specifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-parseint-string-radix">
-   <a href="https://tc39.github.io/ecma262/#sec-parseint-string-radix">https://tc39.github.io/ecma262/#sec-parseint-string-radix</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-parseint-string-radix" class="dfn-panel" data-for="term-for-sec-parseint-string-radix" id="infopanel-for-term-for-sec-parseint-string-radix" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-parseint-string-radix" style="display:none">Info about the '%parseint%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-parseint-string-radix">https://tc39.github.io/ecma262/#sec-parseint-string-radix</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-parseint-string-radix">2.2. Formatter(args)</a>
     <li><a href="#ref-for-sec-parseint-string-radix①">2.2.1. Summary of formatting specifiers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-call">
-   <a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-call" class="dfn-panel" data-for="term-for-sec-call" id="infopanel-for-term-for-sec-call" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-call" style="display:none">Info about the 'Call' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-call">2.2. Formatter(args)</a> <a href="#ref-for-sec-call①">(2)</a> <a href="#ref-for-sec-call②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-objectcreate">
-   <a href="https://tc39.github.io/ecma262/#sec-objectcreate">https://tc39.github.io/ecma262/#sec-objectcreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-objectcreate" class="dfn-panel" data-for="term-for-sec-objectcreate" id="infopanel-for-term-for-sec-objectcreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-objectcreate" style="display:none">Info about the 'ObjectCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-objectcreate">https://tc39.github.io/ecma262/#sec-objectcreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-objectcreate">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'ToString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">1.2.1. count(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'Type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">1.1.1. assert(condition, ...data)</a>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values①">2.2. Formatter(args)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">1.1.1. assert(condition, ...data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">1.2.1. count(label)</a>
     <li><a href="#ref-for-map-exists①">1.2.2. countReset(label)</a>
     <li><a href="#ref-for-map-exists②">1.4.1. time(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">1.1.2. clear()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists①" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists①" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">1.2.1. count(label)</a>
     <li><a href="#ref-for-map-exists①">1.2.2. countReset(label)</a>
     <li><a href="#ref-for-map-exists②">1.4.1. time(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">1.1.11. dirxml(...data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">1.1.1. assert(condition, ...data)</a>
     <li><a href="#ref-for-list-is-empty①">1.3.1. group(...data)</a>
     <li><a href="#ref-for-list-is-empty②">2.1. Logger(logLevel, args)</a> <a href="#ref-for-list-is-empty③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">1.1.11. dirxml(...data)</a>
     <li><a href="#ref-for-list①">2.1. Logger(logLevel, args)</a>
     <li><a href="#ref-for-list②">2.2. Formatter(args)</a> <a href="#ref-for-list③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">1.2. Counting functions</a>
     <li><a href="#ref-for-ordered-map①">1.4. Timing functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-pop">
-   <a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-pop" class="dfn-panel" data-for="term-for-stack-pop" id="infopanel-for-term-for-stack-pop" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-pop" style="display:none">Info about the 'pop' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-pop">https://infra.spec.whatwg.org/#stack-pop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-pop">1.3.3. groupEnd()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">1.1.1. assert(condition, ...data)</a>
     <li><a href="#ref-for-list-prepend①">1.4.2. timeLog(label, ...data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack-push">
-   <a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack-push" class="dfn-panel" data-for="term-for-stack-push" id="infopanel-for-term-for-stack-push" role="menu">
+   <span id="infopaneltitle-for-term-for-stack-push" style="display:none">Info about the 'push' external reference.</span><a href="https://infra.spec.whatwg.org/#stack-push">https://infra.spec.whatwg.org/#stack-push</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-push">1.3.1. group(...data)</a>
     <li><a href="#ref-for-stack-push①">1.3.2. groupCollapsed(...data)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">1.4.3. timeEnd(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">1.2.1. count(label)</a> <a href="#ref-for-map-set①">(2)</a>
     <li><a href="#ref-for-map-set②">1.2.2. countReset(label)</a>
     <li><a href="#ref-for-map-set③">1.4.1. time(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">2.2. Formatter(args)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-stack">
-   <a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-stack" class="dfn-panel" data-for="term-for-stack" id="infopanel-for-term-for-stack" role="menu">
+   <span id="infopaneltitle-for-term-for-stack" style="display:none">Info about the 'stack' external reference.</span><a href="https://infra.spec.whatwg.org/#stack">https://infra.spec.whatwg.org/#stack</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack">1.3. Grouping functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">1.2. Counting functions</a>
     <li><a href="#ref-for-string①">1.4. Timing functions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">1. Namespace console</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">1. Namespace console</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a> <a href="#ref-for-idl-any③">(4)</a> <a href="#ref-for-idl-any④">(5)</a> <a href="#ref-for-idl-any⑤">(6)</a> <a href="#ref-for-idl-any⑥">(7)</a> <a href="#ref-for-idl-any⑦">(8)</a> <a href="#ref-for-idl-any⑧">(9)</a> <a href="#ref-for-idl-any⑨">(10)</a> <a href="#ref-for-idl-any①⓪">(11)</a> <a href="#ref-for-idl-any①①">(12)</a> <a href="#ref-for-idl-any①②">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-namespace-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-namespace-object">https://webidl.spec.whatwg.org/#dfn-namespace-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-namespace-object" class="dfn-panel" data-for="term-for-dfn-namespace-object" id="infopanel-for-term-for-dfn-namespace-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-namespace-object" style="display:none">Info about the 'namespace object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-namespace-object">https://webidl.spec.whatwg.org/#dfn-namespace-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-namespace-object">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">1. Namespace console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">1. Namespace console</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a> <a href="#ref-for-idl-undefined⑤">(6)</a> <a href="#ref-for-idl-undefined⑥">(7)</a> <a href="#ref-for-idl-undefined⑦">(8)</a> <a href="#ref-for-idl-undefined⑧">(9)</a> <a href="#ref-for-idl-undefined⑨">(10)</a> <a href="#ref-for-idl-undefined①⓪">(11)</a> <a href="#ref-for-idl-undefined①①">(12)</a> <a href="#ref-for-idl-undefined①②">(13)</a> <a href="#ref-for-idl-undefined①③">(14)</a> <a href="#ref-for-idl-undefined①④">(15)</a> <a href="#ref-for-idl-undefined①⑤">(16)</a> <a href="#ref-for-idl-undefined①⑥">(17)</a> <a href="#ref-for-idl-undefined①⑦">(18)</a> <a href="#ref-for-idl-undefined①⑧">(19)</a>
    </ul>
@@ -1379,8 +1379,8 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="namespacedef-console">
-   <b><a href="#namespacedef-console">#namespacedef-console</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namespacedef-console" class="dfn-panel" data-for="namespacedef-console" id="infopanel-for-namespacedef-console" role="dialog">
+   <span id="infopaneltitle-for-namespacedef-console" style="display:none">Info about the 'console' definition.</span><b><a href="#namespacedef-console">#namespacedef-console</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-console">1. Namespace console</a> <a href="#ref-for-namespacedef-console①">(2)</a> <a href="#ref-for-namespacedef-console②">(3)</a> <a href="#ref-for-namespacedef-console③">(4)</a>
     <li><a href="#ref-for-namespacedef-console④">1.2. Counting functions</a>
@@ -1389,117 +1389,117 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-namespacedef-console⑦">2.3.1. Indicating logLevel severity</a> <a href="#ref-for-namespacedef-console⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assert">
-   <b><a href="#assert">#assert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assert" class="dfn-panel" data-for="assert" id="infopanel-for-assert" role="dialog">
+   <span id="infopaneltitle-for-assert" style="display:none">Info about the '1.1.1. assert(condition, ...data)' definition.</span><b><a href="#assert">#assert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">1. Namespace console</a>
     <li><a href="#ref-for-assert">1.1.1. assert(condition, ...data)</a>
     <li><a href="#ref-for-assert①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clear">
-   <b><a href="#clear">#clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clear" class="dfn-panel" data-for="clear" id="infopanel-for-clear" role="dialog">
+   <span id="infopaneltitle-for-clear" style="display:none">Info about the '1.1.2. clear()' definition.</span><b><a href="#clear">#clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clear">1. Namespace console</a>
     <li><a href="#ref-for-clear">1.1.2. clear()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="debug">
-   <b><a href="#debug">#debug</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-debug" class="dfn-panel" data-for="debug" id="infopanel-for-debug" role="dialog">
+   <span id="infopaneltitle-for-debug" style="display:none">Info about the '1.1.3. debug(...data)' definition.</span><b><a href="#debug">#debug</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-debug">1. Namespace console</a>
     <li><a href="#ref-for-debug">1.1.3. debug(...data)</a>
     <li><a href="#ref-for-debug①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="error">
-   <b><a href="#error">#error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-error" class="dfn-panel" data-for="error" id="infopanel-for-error" role="dialog">
+   <span id="infopaneltitle-for-error" style="display:none">Info about the '1.1.4. error(...data)' definition.</span><b><a href="#error">#error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-error">1. Namespace console</a>
     <li><a href="#ref-for-error">1.1.4. error(...data)</a>
     <li><a href="#ref-for-error①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="info">
-   <b><a href="#info">#info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-info" class="dfn-panel" data-for="info" id="infopanel-for-info" role="dialog">
+   <span id="infopaneltitle-for-info" style="display:none">Info about the '1.1.5. info(...data)' definition.</span><b><a href="#info">#info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-info">1. Namespace console</a>
     <li><a href="#ref-for-info">1.1.5. info(...data)</a>
     <li><a href="#ref-for-info①">2.3.1. Indicating logLevel severity</a> <a href="#ref-for-info②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="log">
-   <b><a href="#log">#log</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-log" class="dfn-panel" data-for="log" id="infopanel-for-log" role="dialog">
+   <span id="infopaneltitle-for-log" style="display:none">Info about the '1.1.6. log(...data)' definition.</span><b><a href="#log">#log</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-log">1. Namespace console</a>
     <li><a href="#ref-for-log">1.1.6. log(...data)</a>
     <li><a href="#ref-for-log①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="table">
-   <b><a href="#table">#table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-table" class="dfn-panel" data-for="table" id="infopanel-for-table" role="dialog">
+   <span id="infopaneltitle-for-table" style="display:none">Info about the '1.1.7. table(tabularData, properties)' definition.</span><b><a href="#table">#table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table">1. Namespace console</a>
     <li><a href="#ref-for-table">1.1.7. table(tabularData, properties)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="trace">
-   <b><a href="#trace">#trace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-trace" class="dfn-panel" data-for="trace" id="infopanel-for-trace" role="dialog">
+   <span id="infopaneltitle-for-trace" style="display:none">Info about the '1.1.8. trace(...data)' definition.</span><b><a href="#trace">#trace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-trace">1. Namespace console</a>
     <li><a href="#ref-for-trace">1.1.8. trace(...data)</a>
     <li><a href="#ref-for-trace①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="warn">
-   <b><a href="#warn">#warn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-warn" class="dfn-panel" data-for="warn" id="infopanel-for-warn" role="dialog">
+   <span id="infopaneltitle-for-warn" style="display:none">Info about the '1.1.9. warn(...data)' definition.</span><b><a href="#warn">#warn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-warn">1. Namespace console</a>
     <li><a href="#ref-for-warn">1.1.9. warn(...data)</a>
     <li><a href="#ref-for-warn①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dir">
-   <b><a href="#dir">#dir</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dir" class="dfn-panel" data-for="dir" id="infopanel-for-dir" role="dialog">
+   <span id="infopaneltitle-for-dir" style="display:none">Info about the '1.1.10. dir(item, options)' definition.</span><b><a href="#dir">#dir</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dir">1. Namespace console</a>
     <li><a href="#ref-for-dir">1.1.10. dir(item, options)</a>
     <li><a href="#ref-for-dir①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dirxml">
-   <b><a href="#dirxml">#dirxml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dirxml" class="dfn-panel" data-for="dirxml" id="infopanel-for-dirxml" role="dialog">
+   <span id="infopaneltitle-for-dirxml" style="display:none">Info about the '1.1.11. dirxml(...data)' definition.</span><b><a href="#dirxml">#dirxml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dirxml">1. Namespace console</a>
     <li><a href="#ref-for-dirxml">1.1.11. dirxml(...data)</a>
     <li><a href="#ref-for-dirxml①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="count-map">
-   <b><a href="#count-map">#count-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-count-map" class="dfn-panel" data-for="count-map" id="infopanel-for-count-map" role="dialog">
+   <span id="infopaneltitle-for-count-map" style="display:none">Info about the 'count map' definition.</span><b><a href="#count-map">#count-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-count-map">1.2.1. count(label)</a>
     <li><a href="#ref-for-count-map①">1.2.2. countReset(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="count">
-   <b><a href="#count">#count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-count" class="dfn-panel" data-for="count" id="infopanel-for-count" role="dialog">
+   <span id="infopaneltitle-for-count" style="display:none">Info about the '1.2.1. count(label)' definition.</span><b><a href="#count">#count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-count">1. Namespace console</a>
     <li><a href="#ref-for-count">1.2.1. count(label)</a>
     <li><a href="#ref-for-count①">2.3.1. Indicating logLevel severity</a> <a href="#ref-for-count②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="countreset">
-   <b><a href="#countreset">#countreset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-countreset" class="dfn-panel" data-for="countreset" id="infopanel-for-countreset" role="dialog">
+   <span id="infopaneltitle-for-countreset" style="display:none">Info about the '1.2.2. countReset(label)' definition.</span><b><a href="#countreset">#countreset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-countreset">1. Namespace console</a>
     <li><a href="#ref-for-countreset">1.2.2. countReset(label)</a>
     <li><a href="#ref-for-countreset①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-group">
-   <b><a href="#concept-group">#concept-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-group" class="dfn-panel" data-for="concept-group" id="infopanel-for-concept-group" role="dialog">
+   <span id="infopaneltitle-for-concept-group" style="display:none">Info about the 'group' definition.</span><b><a href="#concept-group">#concept-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-group">1.3. Grouping functions</a>
     <li><a href="#ref-for-concept-group①">1.3.1. group(...data)</a> <a href="#ref-for-concept-group②">(2)</a>
@@ -1508,8 +1508,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-group⑥">2.3. Printer(logLevel, args[, options])</a> <a href="#ref-for-concept-group⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="group-stack">
-   <b><a href="#group-stack">#group-stack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-group-stack" class="dfn-panel" data-for="group-stack" id="infopanel-for-group-stack" role="dialog">
+   <span id="infopaneltitle-for-group-stack" style="display:none">Info about the 'group stack' definition.</span><b><a href="#group-stack">#group-stack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group-stack">1.1.2. clear()</a>
     <li><a href="#ref-for-group-stack①">1.3. Grouping functions</a>
@@ -1520,31 +1520,31 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-group-stack⑦">2.3.2. Printer user experience innovation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="group">
-   <b><a href="#group">#group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-group" class="dfn-panel" data-for="group" id="infopanel-for-group" role="dialog">
+   <span id="infopaneltitle-for-group" style="display:none">Info about the '1.3.1. group(...data)' definition.</span><b><a href="#group">#group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-group">1. Namespace console</a>
     <li><a href="#ref-for-group">1.3.1. group(...data)</a>
     <li><a href="#ref-for-group①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="groupcollapsed">
-   <b><a href="#groupcollapsed">#groupcollapsed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-groupcollapsed" class="dfn-panel" data-for="groupcollapsed" id="infopanel-for-groupcollapsed" role="dialog">
+   <span id="infopaneltitle-for-groupcollapsed" style="display:none">Info about the '1.3.2. groupCollapsed(...data)' definition.</span><b><a href="#groupcollapsed">#groupcollapsed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-groupcollapsed">1. Namespace console</a>
     <li><a href="#ref-for-groupcollapsed">1.3.2. groupCollapsed(...data)</a>
     <li><a href="#ref-for-groupcollapsed①">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="groupend">
-   <b><a href="#groupend">#groupend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-groupend" class="dfn-panel" data-for="groupend" id="infopanel-for-groupend" role="dialog">
+   <span id="infopaneltitle-for-groupend" style="display:none">Info about the '1.3.3. groupEnd()' definition.</span><b><a href="#groupend">#groupend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-groupend">1. Namespace console</a>
     <li><a href="#ref-for-groupend">1.3.3. groupEnd()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timer-table">
-   <b><a href="#timer-table">#timer-table</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timer-table" class="dfn-panel" data-for="timer-table" id="infopanel-for-timer-table" role="dialog">
+   <span id="infopaneltitle-for-timer-table" style="display:none">Info about the 'timer table' definition.</span><b><a href="#timer-table">#timer-table</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timer-table">1.4.1. time(label)</a> <a href="#ref-for-timer-table①">(2)</a>
     <li><a href="#ref-for-timer-table②">1.4.2. timeLog(label, ...data)</a>
@@ -1552,15 +1552,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-timer-table⑤">2.3.2. Printer user experience innovation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="time">
-   <b><a href="#time">#time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-time" class="dfn-panel" data-for="time" id="infopanel-for-time" role="dialog">
+   <span id="infopaneltitle-for-time" style="display:none">Info about the '1.4.1. time(label)' definition.</span><b><a href="#time">#time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-time">1. Namespace console</a>
     <li><a href="#ref-for-time">1.4.1. time(label)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timelog">
-   <b><a href="#timelog">#timelog</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timelog" class="dfn-panel" data-for="timelog" id="infopanel-for-timelog" role="dialog">
+   <span id="infopaneltitle-for-timelog" style="display:none">Info about the '1.4.2. timeLog(label, ...data)' definition.</span><b><a href="#timelog">#timelog</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timelog">1. Namespace console</a>
     <li><a href="#ref-for-timelog">1.4.2. timeLog(label, ...data)</a> <a href="#ref-for-timelog①">(2)</a>
@@ -1568,16 +1568,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-timelog③">2.3.1. Indicating logLevel severity</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeend">
-   <b><a href="#timeend">#timeend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeend" class="dfn-panel" data-for="timeend" id="infopanel-for-timeend" role="dialog">
+   <span id="infopaneltitle-for-timeend" style="display:none">Info about the '1.4.3. timeEnd(label)' definition.</span><b><a href="#timeend">#timeend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeend">1. Namespace console</a>
     <li><a href="#ref-for-timeend">1.4.3. timeEnd(label)</a> <a href="#ref-for-timeend①">(2)</a>
     <li><a href="#ref-for-timeend②">2.3.1. Indicating logLevel severity</a> <a href="#ref-for-timeend③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="logger">
-   <b><a href="#logger">#logger</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-logger" class="dfn-panel" data-for="logger" id="infopanel-for-logger" role="dialog">
+   <span id="infopaneltitle-for-logger" style="display:none">Info about the '2.1. Logger(logLevel, args)' definition.</span><b><a href="#logger">#logger</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-logger">1.1.1. assert(condition, ...data)</a>
     <li><a href="#ref-for-logger①">1.1.3. debug(...data)</a>
@@ -1592,8 +1592,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-logger">2.1. Logger(logLevel, args)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formatter">
-   <b><a href="#formatter">#formatter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formatter" class="dfn-panel" data-for="formatter" id="infopanel-for-formatter" role="dialog">
+   <span id="infopaneltitle-for-formatter" style="display:none">Info about the '2.2. Formatter(args)' definition.</span><b><a href="#formatter">#formatter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formatter">1.1.8. trace(...data)</a>
     <li><a href="#ref-for-formatter①">1.3.1. group(...data)</a>
@@ -1602,8 +1602,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-formatter">2.2. Formatter(args)</a> <a href="#ref-for-formatter④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="printer">
-   <b><a href="#printer">#printer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-printer" class="dfn-panel" data-for="printer" id="infopanel-for-printer" role="dialog">
+   <span id="infopaneltitle-for-printer" style="display:none">Info about the '2.3. Printer(logLevel, args[, options])' definition.</span><b><a href="#printer">#printer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-printer">1.1.8. trace(...data)</a>
     <li><a href="#ref-for-printer①">1.1.10. dir(item, options)</a>
@@ -1619,8 +1619,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-printer①③">2.4. Reporting warnings to the console</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generic-javascript-object-formatting">
-   <b><a href="#generic-javascript-object-formatting">#generic-javascript-object-formatting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generic-javascript-object-formatting" class="dfn-panel" data-for="generic-javascript-object-formatting" id="infopanel-for-generic-javascript-object-formatting" role="dialog">
+   <span id="infopaneltitle-for-generic-javascript-object-formatting" style="display:none">Info about the 'generic JavaScript object formatting' definition.</span><b><a href="#generic-javascript-object-formatting">#generic-javascript-object-formatting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-javascript-object-formatting">1.1.10. dir(item, options)</a>
     <li><a href="#ref-for-generic-javascript-object-formatting①">2.2. Formatter(args)</a>
@@ -1628,8 +1628,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-generic-javascript-object-formatting③">2.3. Printer(logLevel, args[, options])</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="optimally-useful-formatting">
-   <b><a href="#optimally-useful-formatting">#optimally-useful-formatting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-optimally-useful-formatting" class="dfn-panel" data-for="optimally-useful-formatting" id="infopanel-for-optimally-useful-formatting" role="dialog">
+   <span id="infopaneltitle-for-optimally-useful-formatting" style="display:none">Info about the 'optimally useful formatting' definition.</span><b><a href="#optimally-useful-formatting">#optimally-useful-formatting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-optimally-useful-formatting">1.1.11. dirxml(...data)</a>
     <li><a href="#ref-for-optimally-useful-formatting①">2.2. Formatter(args)</a>
@@ -1639,57 +1639,113 @@ if ("serviceWorker" in navigator) {
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/dom/dom.html
+++ b/tests/github/whatwg/dom/dom.html
@@ -12651,145 +12651,145 @@ if ("serviceWorker" in navigator) {
    <li><a href="#callbackdef-xpathnsresolver">XPathNSResolver</a><span>, in § 8.3</span>
    <li><a href="#xpathresult">XPathResult</a><span>, in § 8.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-devicemotion">
-   <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion">https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-devicemotion" class="dfn-panel" data-for="term-for-devicemotion" id="infopanel-for-term-for-devicemotion" role="menu">
+   <span id="infopaneltitle-for-term-for-devicemotion" style="display:none">Info about the 'DeviceMotionEvent' external reference.</span><a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion">https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicemotion">4.5. Interface Document</a> <a href="#ref-for-devicemotion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-devicemotion">
-   <a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion">https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-devicemotion" class="dfn-panel" data-for="term-for-devicemotion" id="infopanel-for-term-for-devicemotion①" role="menu">
+   <span id="infopaneltitle-for-term-for-devicemotion①" style="display:none">Info about the 'DeviceOrientationEvent' external reference.</span><a href="https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion">https://w3c.github.io/deviceorientation/spec-source-orientation.html#devicemotion</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-devicemotion">4.5. Interface Document</a> <a href="#ref-for-devicemotion①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-def-touchevent">
-   <a href="https://w3c.github.io/touch-events/#idl-def-touchevent">https://w3c.github.io/touch-events/#idl-def-touchevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-touchevent" class="dfn-panel" data-for="term-for-idl-def-touchevent" id="infopanel-for-term-for-idl-def-touchevent" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-touchevent" style="display:none">Info about the 'TouchEvent' external reference.</span><a href="https://w3c.github.io/touch-events/#idl-def-touchevent">https://w3c.github.io/touch-events/#idl-def-touchevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-touchevent">2.2. Interface Event</a>
     <li><a href="#ref-for-idl-def-touchevent①">2.8. Observing event listeners</a> <a href="#ref-for-idl-def-touchevent②">(2)</a>
     <li><a href="#ref-for-idl-def-touchevent③">4.5. Interface Document</a> <a href="#ref-for-idl-def-touchevent④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NT-Char">
-   <a href="https://www.w3.org/TR/xml/#NT-Char">https://www.w3.org/TR/xml/#NT-Char</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NT-Char" class="dfn-panel" data-for="term-for-NT-Char" id="infopanel-for-term-for-NT-Char" role="menu">
+   <span id="infopaneltitle-for-term-for-NT-Char" style="display:none">Info about the 'char' external reference.</span><a href="https://www.w3.org/TR/xml/#NT-Char">https://www.w3.org/TR/xml/#NT-Char</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NT-Char">4.5. Interface Document</a> <a href="#ref-for-NT-Char①">(2)</a> <a href="#ref-for-NT-Char②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-createcontextualfragment-fragment">
-   <a href="https://w3c.github.io/DOM-Parsing/#dfn-createcontextualfragment-fragment">https://w3c.github.io/DOM-Parsing/#dfn-createcontextualfragment-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-createcontextualfragment-fragment" class="dfn-panel" data-for="term-for-dfn-createcontextualfragment-fragment" id="infopanel-for-term-for-dfn-createcontextualfragment-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-createcontextualfragment-fragment" style="display:none">Info about the 'createContextualFragment()' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#dfn-createcontextualfragment-fragment">https://w3c.github.io/DOM-Parsing/#dfn-createcontextualfragment-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-createcontextualfragment-fragment">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NT-Name">
-   <a href="https://www.w3.org/TR/xml/#NT-Name">https://www.w3.org/TR/xml/#NT-Name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NT-Name" class="dfn-panel" data-for="term-for-NT-Name" id="infopanel-for-term-for-NT-Name" role="menu">
+   <span id="infopaneltitle-for-term-for-NT-Name" style="display:none">Info about the 'name' external reference.</span><a href="https://www.w3.org/TR/xml/#NT-Name">https://www.w3.org/TR/xml/#NT-Name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NT-Name">4.5. Interface Document</a> <a href="#ref-for-NT-Name①">(2)</a> <a href="#ref-for-NT-Name②">(3)</a> <a href="#ref-for-NT-Name③">(4)</a> <a href="#ref-for-NT-Name④">(5)</a>
     <li><a href="#ref-for-NT-Name⑤">4.5.1. Interface DOMImplementation</a>
     <li><a href="#ref-for-NT-Name⑥">4.9. Interface Element</a> <a href="#ref-for-NT-Name⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NT-PubidChar">
-   <a href="https://www.w3.org/TR/xml/#NT-PubidChar">https://www.w3.org/TR/xml/#NT-PubidChar</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NT-PubidChar" class="dfn-panel" data-for="term-for-NT-PubidChar" id="infopanel-for-term-for-NT-PubidChar" role="menu">
+   <span id="infopaneltitle-for-term-for-NT-PubidChar" style="display:none">Info about the 'pubidchar' external reference.</span><a href="https://www.w3.org/TR/xml/#NT-PubidChar">https://www.w3.org/TR/xml/#NT-PubidChar</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NT-PubidChar">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NT-QName">
-   <a href="https://www.w3.org/TR/xml-names/#NT-QName">https://www.w3.org/TR/xml-names/#NT-QName</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NT-QName" class="dfn-panel" data-for="term-for-NT-QName" id="infopanel-for-term-for-NT-QName" role="menu">
+   <span id="infopaneltitle-for-term-for-NT-QName" style="display:none">Info about the 'qname' external reference.</span><a href="https://www.w3.org/TR/xml-names/#NT-QName">https://www.w3.org/TR/xml-names/#NT-QName</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NT-QName">1.4. Namespaces</a>
     <li><a href="#ref-for-NT-QName①">4.5. Interface Document</a>
     <li><a href="#ref-for-NT-QName②">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-a-warning-to-the-console">
-   <a href="https://console.spec.whatwg.org/#report-a-warning-to-the-console">https://console.spec.whatwg.org/#report-a-warning-to-the-console</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-a-warning-to-the-console" class="dfn-panel" data-for="term-for-report-a-warning-to-the-console" id="infopanel-for-term-for-report-a-warning-to-the-console" role="menu">
+   <span id="infopaneltitle-for-term-for-report-a-warning-to-the-console" style="display:none">Info about the 'report a warning to the console' external reference.</span><a href="https://console.spec.whatwg.org/#report-a-warning-to-the-console">https://console.spec.whatwg.org/#report-a-warning-to-the-console</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-a-warning-to-the-console">2.7. Interface EventTarget</a> <a href="#ref-for-report-a-warning-to-the-console①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-range-getboundingclientrect" class="dfn-panel" data-for="term-for-dom-range-getboundingclientrect" id="infopanel-for-term-for-dom-range-getboundingclientrect" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-range-getboundingclientrect" style="display:none">Info about the 'getBoundingClientRect()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect">https://drafts.csswg.org/cssom-view-1/#dom-range-getboundingclientrect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-getboundingclientrect">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-range-getclientrects">
-   <a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-range-getclientrects" class="dfn-panel" data-for="term-for-dom-range-getclientrects" id="infopanel-for-term-for-dom-range-getclientrects" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-range-getclientrects" style="display:none">Info about the 'getClientRects()' external reference.</span><a href="https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects">https://drafts.csswg.org/cssom-view-1/#dom-range-getclientrects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-getclientrects">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventdef-htmlslotelement-slotchange">
-   <a href="https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange">https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventdef-htmlslotelement-slotchange" class="dfn-panel" data-for="term-for-eventdef-htmlslotelement-slotchange" id="infopanel-for-term-for-eventdef-htmlslotelement-slotchange" role="menu">
+   <span id="infopaneltitle-for-term-for-eventdef-htmlslotelement-slotchange" style="display:none">Info about the 'slotchange' external reference.</span><a href="https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange">https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-htmlslotelement-slotchange">4.3. Mutation observers</a>
     <li><a href="#ref-for-eventdef-htmlslotelement-slotchange①">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-surrounding-agent">
-   <a href="https://tc39.github.io/ecma262/#surrounding-agent">https://tc39.github.io/ecma262/#surrounding-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-surrounding-agent" class="dfn-panel" data-for="term-for-surrounding-agent" id="infopanel-for-term-for-surrounding-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-surrounding-agent" style="display:none">Info about the 'surrounding agent' external reference.</span><a href="https://tc39.github.io/ecma262/#surrounding-agent">https://tc39.github.io/ecma262/#surrounding-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrounding-agent">4.3. Mutation observers</a> <a href="#ref-for-surrounding-agent①">(2)</a> <a href="#ref-for-surrounding-agent②">(3)</a> <a href="#ref-for-surrounding-agent③">(4)</a> <a href="#ref-for-surrounding-agent④">(5)</a> <a href="#ref-for-surrounding-agent⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-encoding">
-   <a href="https://encoding.spec.whatwg.org/#encoding">https://encoding.spec.whatwg.org/#encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-encoding" class="dfn-panel" data-for="term-for-encoding" id="infopanel-for-term-for-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-encoding" style="display:none">Info about the 'encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#encoding">https://encoding.spec.whatwg.org/#encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encoding">4.5. Interface Document</a> <a href="#ref-for-encoding①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-name">
-   <a href="https://encoding.spec.whatwg.org/#name">https://encoding.spec.whatwg.org/#name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-name" class="dfn-panel" data-for="term-for-name" id="infopanel-for-term-for-name" role="menu">
+   <span id="infopaneltitle-for-term-for-name" style="display:none">Info about the 'name' external reference.</span><a href="https://encoding.spec.whatwg.org/#name">https://encoding.spec.whatwg.org/#name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">2.2. Interface Event</a>
     <li><a href="#ref-for-dom-domhighrestimestamp①">2.5. Constructing events</a>
     <li><a href="#ref-for-dom-domhighrestimestamp②">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-clock-resolution">
-   <a href="https://w3c.github.io/hr-time/#clock-resolution">https://w3c.github.io/hr-time/#clock-resolution</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-clock-resolution" class="dfn-panel" data-for="term-for-clock-resolution" id="infopanel-for-term-for-clock-resolution" role="menu">
+   <span id="infopaneltitle-for-term-for-clock-resolution" style="display:none">Info about the 'clock resolution' external reference.</span><a href="https://w3c.github.io/hr-time/#clock-resolution">https://w3c.github.io/hr-time/#clock-resolution</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clock-resolution">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-time-origin">
-   <a href="https://w3c.github.io/hr-time/#dfn-time-origin">https://w3c.github.io/hr-time/#dfn-time-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-time-origin" class="dfn-panel" data-for="term-for-dfn-time-origin" id="infopanel-for-term-for-dfn-time-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-time-origin" style="display:none">Info about the 'time origin' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-time-origin">https://w3c.github.io/hr-time/#dfn-time-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-time-origin">2.2. Interface Event</a>
     <li><a href="#ref-for-dfn-time-origin①">2.5. Constructing events</a>
     <li><a href="#ref-for-dfn-time-origin②">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-beforeunloadevent">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#beforeunloadevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#beforeunloadevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-beforeunloadevent" class="dfn-panel" data-for="term-for-beforeunloadevent" id="infopanel-for-term-for-beforeunloadevent" role="menu">
+   <span id="infopaneltitle-for-term-for-beforeunloadevent" style="display:none">Info about the 'BeforeUnloadEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#beforeunloadevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#beforeunloadevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-beforeunloadevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cereactions">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cereactions" class="dfn-panel" data-for="term-for-cereactions" id="infopanel-for-term-for-cereactions" role="menu">
+   <span id="infopaneltitle-for-term-for-cereactions" style="display:none">Info about the 'CEReactions' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions">https://html.spec.whatwg.org/multipage/custom-elements.html#cereactions</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cereactions">4.2.6. Mixin ParentNode</a> <a href="#ref-for-cereactions①">(2)</a> <a href="#ref-for-cereactions②">(3)</a>
     <li><a href="#ref-for-cereactions③">4.2.8. Mixin ChildNode</a> <a href="#ref-for-cereactions④">(2)</a> <a href="#ref-for-cereactions⑤">(3)</a> <a href="#ref-for-cereactions⑥">(4)</a>
@@ -12802,76 +12802,76 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-cereactions④①">7.1. Interface DOMTokenList</a> <a href="#ref-for-cereactions④②">(2)</a> <a href="#ref-for-cereactions④③">(3)</a> <a href="#ref-for-cereactions④④">(4)</a> <a href="#ref-for-cereactions④⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dragevent">
-   <a href="https://html.spec.whatwg.org/multipage/dnd.html#dragevent">https://html.spec.whatwg.org/multipage/dnd.html#dragevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dragevent" class="dfn-panel" data-for="term-for-dragevent" id="infopanel-for-term-for-dragevent" role="menu">
+   <span id="infopaneltitle-for-term-for-dragevent" style="display:none">Info about the 'DragEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dnd.html#dragevent">https://html.spec.whatwg.org/multipage/dnd.html#dragevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dragevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-eventhandler①">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlelement" class="dfn-panel" data-for="term-for-htmlelement" id="infopanel-for-term-for-htmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlelement" style="display:none">Info about the 'HTMLElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlelement">https://html.spec.whatwg.org/multipage/dom.html#htmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlelement">4.9. Interface Element</a> <a href="#ref-for-htmlelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlhtmlelement">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlhtmlelement" class="dfn-panel" data-for="term-for-htmlhtmlelement" id="infopanel-for-term-for-htmlhtmlelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlhtmlelement" style="display:none">Info about the 'HTMLHtmlElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement">https://html.spec.whatwg.org/multipage/semantics.html#htmlhtmlelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlhtmlelement">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlslotelement">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlslotelement" class="dfn-panel" data-for="term-for-htmlslotelement" id="infopanel-for-term-for-htmlslotelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlslotelement" style="display:none">Info about the 'HTMLSlotElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement">https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlslotelement">4.2.9. Mixin Slottable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlunknownelement">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement">https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlunknownelement" class="dfn-panel" data-for="term-for-htmlunknownelement" id="infopanel-for-term-for-htmlunknownelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlunknownelement" style="display:none">Info about the 'HTMLUnknownElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement">https://html.spec.whatwg.org/multipage/dom.html#htmlunknownelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlunknownelement">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hashchangeevent">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hashchangeevent" class="dfn-panel" data-for="term-for-hashchangeevent" id="infopanel-for-term-for-hashchangeevent" role="menu">
+   <span id="infopaneltitle-for-term-for-hashchangeevent" style="display:none">Info about the 'HashChangeEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hashchangeevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageevent">
-   <a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageevent" class="dfn-panel" data-for="term-for-messageevent" id="infopanel-for-term-for-messageevent" role="menu">
+   <span id="infopaneltitle-for-term-for-messageevent" style="display:none">Info about the 'MessageEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/comms.html#messageevent">https://html.spec.whatwg.org/multipage/comms.html#messageevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-storageevent">
-   <a href="https://html.spec.whatwg.org/multipage/webstorage.html#storageevent">https://html.spec.whatwg.org/multipage/webstorage.html#storageevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-storageevent" class="dfn-panel" data-for="term-for-storageevent" id="infopanel-for-term-for-storageevent" role="menu">
+   <span id="infopaneltitle-for-term-for-storageevent" style="display:none">Info about the 'StorageEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webstorage.html#storageevent">https://html.spec.whatwg.org/multipage/webstorage.html#storageevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storageevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.3. Legacy extensions to the Window interface</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a>
     <li><a href="#ref-for-window③">2.9. Dispatching events</a> <a href="#ref-for-window④">(2)</a> <a href="#ref-for-window⑤">(3)</a> <a href="#ref-for-window⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-area-element">
-   <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-area-element" class="dfn-panel" data-for="term-for-the-area-element" id="infopanel-for-term-for-the-area-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-area-element" style="display:none">Info about the 'area' external reference.</span><a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-area-element">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-window" class="dfn-panel" data-for="term-for-concept-document-window" id="infopanel-for-term-for-concept-document-window" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-window" style="display:none">Info about the 'associated document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-window">2.9. Dispatching events</a>
     <li><a href="#ref-for-concept-document-window①">4.5. Interface Document</a>
@@ -12881,38 +12881,38 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-document-window⑤">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-bc">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-bc" class="dfn-panel" data-for="term-for-concept-document-bc" id="infopanel-for-term-for-concept-document-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-bc" style="display:none">Info about the 'browsing context (for Document)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc">https://html.spec.whatwg.org/multipage/document-sequences.html#concept-document-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-bc">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-click">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-click">https://html.spec.whatwg.org/multipage/interaction.html#dom-click</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-click" class="dfn-panel" data-for="term-for-dom-click" id="infopanel-for-term-for-dom-click" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-click" style="display:none">Info about the 'click()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-click">https://html.spec.whatwg.org/multipage/interaction.html#dom-click</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-click">2.2. Interface Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-custom-element-definition-constructor">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-constructor">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-custom-element-definition-constructor" class="dfn-panel" data-for="term-for-concept-custom-element-definition-constructor" id="infopanel-for-term-for-concept-custom-element-definition-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-custom-element-definition-constructor" style="display:none">Info about the 'constructor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-constructor">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-custom-element-definition-constructor">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">4.5. Interface Document</a>
     <li><a href="#ref-for-current-global-object①">4.7. Interface DocumentFragment</a>
@@ -12921,234 +12921,234 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-current-global-object④">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-custom-element-constructor">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-constructor">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-custom-element-constructor" class="dfn-panel" data-for="term-for-custom-element-constructor" id="infopanel-for-term-for-custom-element-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-custom-element-constructor" style="display:none">Info about the 'custom element constructor' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-constructor">https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-custom-element-constructor">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-customized-built-in-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#customized-built-in-element">https://html.spec.whatwg.org/multipage/custom-elements.html#customized-built-in-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-customized-built-in-element" class="dfn-panel" data-for="term-for-customized-built-in-element" id="infopanel-for-term-for-customized-built-in-element" role="menu">
+   <span id="infopaneltitle-for-term-for-customized-built-in-element" style="display:none">Info about the 'customized built-in element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#customized-built-in-element">https://html.spec.whatwg.org/multipage/custom-elements.html#customized-built-in-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-customized-built-in-element">4.5. Interface Document</a> <a href="#ref-for-customized-built-in-element①">(2)</a>
     <li><a href="#ref-for-customized-built-in-element②">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-custom-element-definition-disable-shadow">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-disable-shadow">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-disable-shadow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-custom-element-definition-disable-shadow" class="dfn-panel" data-for="term-for-concept-custom-element-definition-disable-shadow" id="infopanel-for-term-for-concept-custom-element-definition-disable-shadow" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-custom-element-definition-disable-shadow" style="display:none">Info about the 'disable shadow' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-disable-shadow">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-disable-shadow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-custom-element-definition-disable-shadow">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-base-url" class="dfn-panel" data-for="term-for-document-base-url" id="infopanel-for-term-for-document-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-document-base-url" style="display:none">Info about the 'document base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-base-url">4.4. Interface Node</a> <a href="#ref-for-document-base-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-a-custom-element-callback-reaction">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-callback-reaction">https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-callback-reaction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-a-custom-element-callback-reaction" class="dfn-panel" data-for="term-for-enqueue-a-custom-element-callback-reaction" id="infopanel-for-term-for-enqueue-a-custom-element-callback-reaction" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-a-custom-element-callback-reaction" style="display:none">Info about the 'enqueue a custom element callback reaction' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-callback-reaction">https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-callback-reaction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-a-custom-element-callback-reaction">4.2.3. Mutation algorithms</a> <a href="#ref-for-enqueue-a-custom-element-callback-reaction①">(2)</a> <a href="#ref-for-enqueue-a-custom-element-callback-reaction②">(3)</a>
     <li><a href="#ref-for-enqueue-a-custom-element-callback-reaction③">4.5. Interface Document</a>
     <li><a href="#ref-for-enqueue-a-custom-element-callback-reaction④">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-a-custom-element-upgrade-reaction">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-upgrade-reaction">https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-upgrade-reaction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-a-custom-element-upgrade-reaction" class="dfn-panel" data-for="term-for-enqueue-a-custom-element-upgrade-reaction" id="infopanel-for-term-for-enqueue-a-custom-element-upgrade-reaction" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-a-custom-element-upgrade-reaction" style="display:none">Info about the 'enqueue a custom element upgrade reaction' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-upgrade-reaction">https://html.spec.whatwg.org/multipage/custom-elements.html#enqueue-a-custom-element-upgrade-reaction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-a-custom-element-upgrade-reaction">4.9. Interface Element</a> <a href="#ref-for-enqueue-a-custom-element-upgrade-reaction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-event-handlers①">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-event-handlers②">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-event-handler-event-type①">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-event-handler-idl-attributes①">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-head-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">https://html.spec.whatwg.org/multipage/semantics.html#the-head-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-head-element" class="dfn-panel" data-for="term-for-the-head-element" id="infopanel-for-term-for-the-head-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-head-element" style="display:none">Info about the 'head' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">https://html.spec.whatwg.org/multipage/semantics.html#the-head-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-head-element">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-the-head-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-html-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-html-element" class="dfn-panel" data-for="term-for-the-html-element" id="infopanel-for-term-for-the-html-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-html-element" style="display:none">Info about the 'html' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-html-element">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-the-html-element①">(2)</a> <a href="#ref-for-the-html-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-parser">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#html-parser">https://html.spec.whatwg.org/multipage/parsing.html#html-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-parser" class="dfn-panel" data-for="term-for-html-parser" id="infopanel-for-term-for-html-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-html-parser" style="display:none">Info about the 'html parser' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#html-parser">https://html.spec.whatwg.org/multipage/parsing.html#html-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-parser">4.1. Introduction to "The DOM"</a>
     <li><a href="#ref-for-html-parser①">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.8. Observing event listeners</a>
     <li><a href="#ref-for-in-parallel①">3.3. Using AbortController and AbortSignal objects in
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-input-element">
-   <a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-input-element" class="dfn-panel" data-for="term-for-the-input-element" id="infopanel-for-term-for-the-input-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-input-element" style="display:none">Info about the 'input' external reference.</span><a href="https://html.spec.whatwg.org/multipage/input.html#the-input-element">https://html.spec.whatwg.org/multipage/input.html#the-input-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-input-element">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-the-input-element①">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-custom-element-definition-local-name">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-local-name">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-local-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-custom-element-definition-local-name" class="dfn-panel" data-for="term-for-concept-custom-element-definition-local-name" id="infopanel-for-term-for-concept-custom-element-definition-local-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-custom-element-definition-local-name" style="display:none">Info about the 'local name' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-local-name">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-local-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-custom-element-definition-local-name">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-look-up-a-custom-element-definition">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-look-up-a-custom-element-definition" class="dfn-panel" data-for="term-for-look-up-a-custom-element-definition" id="infopanel-for-term-for-look-up-a-custom-element-definition" role="menu">
+   <span id="infopaneltitle-for-term-for-look-up-a-custom-element-definition" style="display:none">Info about the 'look up a custom element definition' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition">https://html.spec.whatwg.org/multipage/custom-elements.html#look-up-a-custom-element-definition</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-look-up-a-custom-element-definition">4.9. Interface Element</a> <a href="#ref-for-look-up-a-custom-element-definition①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-manually-assigned-nodes">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes">https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-manually-assigned-nodes" class="dfn-panel" data-for="term-for-manually-assigned-nodes" id="infopanel-for-term-for-manually-assigned-nodes" role="menu">
+   <span id="infopaneltitle-for-term-for-manually-assigned-nodes" style="display:none">Info about the 'manually assigned nodes' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes">https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-manually-assigned-nodes">4.2.2.3. Finding slots and slottables</a> <a href="#ref-for-manually-assigned-nodes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#microtask">https://html.spec.whatwg.org/multipage/webappapis.html#microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-microtask" class="dfn-panel" data-for="term-for-microtask" id="infopanel-for-term-for-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-microtask" style="display:none">Info about the 'microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#microtask">https://html.spec.whatwg.org/multipage/webappapis.html#microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-microtask">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-custom-element-definition-name">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-custom-element-definition-name" class="dfn-panel" data-for="term-for-concept-custom-element-definition-name" id="infopanel-for-term-for-concept-custom-element-definition-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-custom-element-definition-name" style="display:none">Info about the 'name' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-custom-element-definition-name">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-agent" class="dfn-panel" data-for="term-for-relevant-agent" id="infopanel-for-term-for-relevant-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-agent" style="display:none">Info about the 'relevant agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-agent">4.2.2.5. Signaling slot change</a>
     <li><a href="#ref-for-relevant-agent①">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">4.5. Interface Document</a> <a href="#ref-for-concept-relevant-global①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">2.10. Firing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">2.9. Dispatching events</a>
     <li><a href="#ref-for-report-the-exception①">4.3. Mutation observers</a>
     <li><a href="#ref-for-report-the-exception②">4.9. Interface Element</a> <a href="#ref-for-report-the-exception③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script" class="dfn-panel" data-for="term-for-script" id="infopanel-for-term-for-script" role="menu">
+   <span id="infopaneltitle-for-term-for-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script">4.4. Interface Node</a> <a href="#ref-for-script①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-similar-origin-window-agent">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#similar-origin-window-agent">https://html.spec.whatwg.org/multipage/webappapis.html#similar-origin-window-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-similar-origin-window-agent" class="dfn-panel" data-for="term-for-similar-origin-window-agent" id="infopanel-for-term-for-similar-origin-window-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-similar-origin-window-agent" style="display:none">Info about the 'similar-origin window agent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#similar-origin-window-agent">https://html.spec.whatwg.org/multipage/webappapis.html#similar-origin-window-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-similar-origin-window-agent">4.2.2.5. Signaling slot change</a>
     <li><a href="#ref-for-similar-origin-window-agent①">4.3. Mutation observers</a> <a href="#ref-for-similar-origin-window-agent②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-slot-element">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-slot-element" class="dfn-panel" data-for="term-for-the-slot-element" id="infopanel-for-term-for-the-slot-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-slot-element" style="display:none">Info about the 'slot' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-slot-element">4.2.2.1. Slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-template-element">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">https://html.spec.whatwg.org/multipage/scripting.html#the-template-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-template-element" class="dfn-panel" data-for="term-for-the-template-element" id="infopanel-for-term-for-the-template-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-template-element" style="display:none">Info about the 'template' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">https://html.spec.whatwg.org/multipage/scripting.html#the-template-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-template-element">4.7. Interface DocumentFragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-title-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">https://html.spec.whatwg.org/multipage/semantics.html#the-title-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-title-element" class="dfn-panel" data-for="term-for-the-title-element" id="infopanel-for-term-for-the-title-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-title-element" style="display:none">Info about the 'title' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">https://html.spec.whatwg.org/multipage/semantics.html#the-title-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-title-element">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-the-title-element①">(2)</a> <a href="#ref-for-the-title-element②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-try-upgrade">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-try-upgrade">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-try-upgrade</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-try-upgrade" class="dfn-panel" data-for="term-for-concept-try-upgrade" id="infopanel-for-term-for-concept-try-upgrade" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-try-upgrade" style="display:none">Info about the 'try to upgrade an element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-try-upgrade">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-try-upgrade</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-try-upgrade">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-upgrade-an-element">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-upgrade-an-element">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-upgrade-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-upgrade-an-element" class="dfn-panel" data-for="term-for-concept-upgrade-an-element" id="infopanel-for-term-for-concept-upgrade-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-upgrade-an-element" style="display:none">Info about the 'upgrade an element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#concept-upgrade-an-element">https://html.spec.whatwg.org/multipage/custom-elements.html#concept-upgrade-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-upgrade-an-element">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-upgrade-an-element①">4.9. Interface Element</a> <a href="#ref-for-concept-upgrade-an-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valid-custom-element-name">
-   <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name">https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valid-custom-element-name" class="dfn-panel" data-for="term-for-valid-custom-element-name" id="infopanel-for-term-for-valid-custom-element-name" role="menu">
+   <span id="infopaneltitle-for-term-for-valid-custom-element-name" style="display:none">Info about the 'valid custom element name' external reference.</span><a href="https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name">https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-custom-element-name">4.9. Interface Element</a> <a href="#ref-for-valid-custom-element-name①">(2)</a> <a href="#ref-for-valid-custom-element-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_code_unit">
-   <a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_code_unit" class="dfn-panel" data-for="term-for-def_code_unit" id="infopanel-for-term-for-def_code_unit" role="menu">
+   <span id="infopaneltitle-for-term-for-def_code_unit" style="display:none">Info about the 'code units' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_code_unit">4.10. Interface CharacterData</a> <a href="#ref-for-def_code_unit①">(2)</a> <a href="#ref-for-def_code_unit②">(3)</a> <a href="#ref-for-def_code_unit③">(4)</a> <a href="#ref-for-def_code_unit④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.2. Interface Event</a> <a href="#ref-for-list-append①">(2)</a>
     <li><a href="#ref-for-list-append②">2.7. Interface EventTarget</a>
@@ -13159,8 +13159,8 @@ APIs</a>
     <li><a href="#ref-for-list-append①①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">1.2. Ordered sets</a>
     <li><a href="#ref-for-set-append①">3.2. Interface AbortSignal</a>
@@ -13170,16 +13170,16 @@ APIs</a>
     <li><a href="#ref-for-set-append⑤">7.1. Interface DOMTokenList</a> <a href="#ref-for-set-append⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.4. Interface Node</a>
     <li><a href="#ref-for-ascii-case-insensitive①">4.5. Interface Document</a>
     <li><a href="#ref-for-ascii-case-insensitive②">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.4. Interface Node</a>
     <li><a href="#ref-for-ascii-lowercase①">4.5. Interface Document</a> <a href="#ref-for-ascii-lowercase②">(2)</a>
@@ -13188,43 +13188,43 @@ APIs</a>
     <li><a href="#ref-for-ascii-lowercase⑧">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-uppercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-uppercase">https://infra.spec.whatwg.org/#ascii-uppercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-uppercase" class="dfn-panel" data-for="term-for-ascii-uppercase" id="infopanel-for-term-for-ascii-uppercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-uppercase" style="display:none">Info about the 'ascii uppercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-uppercase">https://infra.spec.whatwg.org/#ascii-uppercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-uppercase">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">4.1. Introduction to "The DOM"</a>
     <li><a href="#ref-for-ascii-whitespace①">7.1. Interface DOMTokenList</a> <a href="#ref-for-ascii-whitespace②">(2)</a> <a href="#ref-for-ascii-whitespace③">(3)</a> <a href="#ref-for-ascii-whitespace④">(4)</a> <a href="#ref-for-ascii-whitespace⑤">(5)</a> <a href="#ref-for-ascii-whitespace⑥">(6)</a> <a href="#ref-for-ascii-whitespace⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">2.2. Interface Event</a>
     <li><a href="#ref-for-iteration-break①">6.1. Interface NodeIterator</a>
     <li><a href="#ref-for-iteration-break②">6.2. Interface TreeWalker</a> <a href="#ref-for-iteration-break③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-clone">
-   <a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-clone" class="dfn-panel" data-for="term-for-list-clone" id="infopanel-for-term-for-list-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-list-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">2.9. Dispatching events</a>
     <li><a href="#ref-for-list-clone①">4.3. Mutation observers</a> <a href="#ref-for-list-clone②">(2)</a> <a href="#ref-for-list-clone③">(3)</a>
     <li><a href="#ref-for-list-clone④">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit">
-   <a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit" class="dfn-panel" data-for="term-for-code-unit" id="infopanel-for-term-for-code-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit" style="display:none">Info about the 'code unit' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit">4.10. Interface CharacterData</a> <a href="#ref-for-code-unit①">(2)</a> <a href="#ref-for-code-unit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-concatenate">
-   <a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-concatenate" class="dfn-panel" data-for="term-for-string-concatenate" id="infopanel-for-term-for-string-concatenate" role="menu">
+   <span id="infopaneltitle-for-term-for-string-concatenate" style="display:none">Info about the 'concatenation' external reference.</span><a href="https://infra.spec.whatwg.org/#string-concatenate">https://infra.spec.whatwg.org/#string-concatenate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">1.2. Ordered sets</a>
     <li><a href="#ref-for-string-concatenate①">4.4. Interface Node</a>
@@ -13232,8 +13232,8 @@ APIs</a>
     <li><a href="#ref-for-string-concatenate⑤">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.7. Interface EventTarget</a> <a href="#ref-for-list-contain①">(2)</a>
     <li><a href="#ref-for-list-contain②">4.2.2.3. Finding slots and slottables</a>
@@ -13242,15 +13242,15 @@ APIs</a>
     <li><a href="#ref-for-list-contain⑥">7.1. Interface DOMTokenList</a> <a href="#ref-for-list-contain⑦">(2)</a> <a href="#ref-for-list-contain⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">2.9. Dispatching events</a> <a href="#ref-for-iteration-continue①">(2)</a> <a href="#ref-for-iteration-continue②">(3)</a> <a href="#ref-for-iteration-continue③">(4)</a>
     <li><a href="#ref-for-iteration-continue④">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-list-empty①">4.3. Mutation observers</a> <a href="#ref-for-list-empty②">(2)</a>
@@ -13258,14 +13258,14 @@ APIs</a>
     <li><a href="#ref-for-list-empty⑤">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-enqueue">
-   <a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-enqueue" class="dfn-panel" data-for="term-for-queue-enqueue" id="infopanel-for-term-for-queue-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue-enqueue">https://infra.spec.whatwg.org/#queue-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-enqueue">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain①" style="display:none">Info about the 'exist (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.7. Interface EventTarget</a> <a href="#ref-for-list-contain①">(2)</a>
     <li><a href="#ref-for-list-contain②">4.2.2.3. Finding slots and slottables</a>
@@ -13274,8 +13274,8 @@ APIs</a>
     <li><a href="#ref-for-list-contain⑥">7.1. Interface DOMTokenList</a> <a href="#ref-for-list-contain⑦">(2)</a> <a href="#ref-for-list-contain⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-map-exists①">4.3.1. Interface MutationObserver</a> <a href="#ref-for-map-exists②">(2)</a> <a href="#ref-for-map-exists③">(3)</a> <a href="#ref-for-map-exists④">(4)</a>
@@ -13283,8 +13283,8 @@ APIs</a>
     <li><a href="#ref-for-map-exists⑨">4.5. Interface Document</a> <a href="#ref-for-map-exists①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">1.2. Ordered sets</a>
     <li><a href="#ref-for-list-iterate①">2.7. Interface EventTarget</a>
@@ -13300,15 +13300,15 @@ APIs</a>
     <li><a href="#ref-for-list-iterate②⓪">7.1. Interface DOMTokenList</a> <a href="#ref-for-list-iterate②①">(2)</a> <a href="#ref-for-list-iterate②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">2.5. Constructing events</a>
     <li><a href="#ref-for-map-iterate①">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-html-namespace①">(2)</a>
     <li><a href="#ref-for-html-namespace②">4.4. Interface Node</a> <a href="#ref-for-html-namespace③">(2)</a>
@@ -13318,20 +13318,20 @@ APIs</a>
     <li><a href="#ref-for-html-namespace②⑨">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-is">
-   <a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-is" class="dfn-panel" data-for="term-for-string-is" id="infopanel-for-term-for-string-is" role="menu">
+   <span id="infopaneltitle-for-term-for-string-is" style="display:none">Info about the 'identical to' external reference.</span><a href="https://infra.spec.whatwg.org/#string-is">https://infra.spec.whatwg.org/#string-is</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-insert">
-   <a href="https://infra.spec.whatwg.org/#list-insert">https://infra.spec.whatwg.org/#list-insert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-insert" class="dfn-panel" data-for="term-for-list-insert" id="infopanel-for-term-for-list-insert" role="menu">
+   <span id="infopaneltitle-for-term-for-list-insert" style="display:none">Info about the 'insert' external reference.</span><a href="https://infra.spec.whatwg.org/#list-insert">https://infra.spec.whatwg.org/#list-insert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-insert">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.2. Interface Event</a>
     <li><a href="#ref-for-list-is-empty①">4.2.3. Mutation algorithms</a>
@@ -13342,8 +13342,8 @@ APIs</a>
     <li><a href="#ref-for-list-is-empty⑧">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty①" style="display:none">Info about the 'is not empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.2. Interface Event</a>
     <li><a href="#ref-for-list-is-empty①">4.2.3. Mutation algorithms</a>
@@ -13354,15 +13354,15 @@ APIs</a>
     <li><a href="#ref-for-list-is-empty⑧">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">4.2. Node tree</a>
     <li><a href="#ref-for-string-length①">4.10. Interface CharacterData</a> <a href="#ref-for-string-length②">(2)</a> <a href="#ref-for-string-length③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.2. Interface Event</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a> <a href="#ref-for-list③">(4)</a>
     <li><a href="#ref-for-list④">2.7. Interface EventTarget</a>
@@ -13372,14 +13372,14 @@ APIs</a>
     <li><a href="#ref-for-list⑨">4.9. Interface Element</a> <a href="#ref-for-list①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">1.1. Trees</a>
     <li><a href="#ref-for-ordered-set①">1.2. Ordered sets</a>
@@ -13389,20 +13389,20 @@ APIs</a>
     <li><a href="#ref-for-ordered-set⑤">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">2.2. Interface Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue">
-   <a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue" class="dfn-panel" data-for="term-for-queue" id="infopanel-for-term-for-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue" style="display:none">Info about the 'queue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-list-remove①">2.9. Dispatching events</a>
@@ -13414,20 +13414,20 @@ APIs</a>
     <li><a href="#ref-for-list-remove⑧">7.1. Interface DOMTokenList</a> <a href="#ref-for-list-remove⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-replace">
-   <a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-replace" class="dfn-panel" data-for="term-for-list-replace" id="infopanel-for-term-for-list-replace" role="menu">
+   <span id="infopaneltitle-for-term-for-list-replace" style="display:none">Info about the 'replace (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-replace">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-replace">
-   <a href="https://infra.spec.whatwg.org/#set-replace">https://infra.spec.whatwg.org/#set-replace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-replace" class="dfn-panel" data-for="term-for-set-replace" id="infopanel-for-term-for-set-replace" role="menu">
+   <span id="infopaneltitle-for-term-for-set-replace" style="display:none">Info about the 'replace (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-replace">https://infra.spec.whatwg.org/#set-replace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-replace">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set①" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set①" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">1.1. Trees</a>
     <li><a href="#ref-for-ordered-set①">1.2. Ordered sets</a>
@@ -13437,14 +13437,14 @@ APIs</a>
     <li><a href="#ref-for-ordered-set⑤">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">4.3.2. Queuing a mutation record</a> <a href="#ref-for-map-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">2.2. Interface Event</a> <a href="#ref-for-list-size①">(2)</a>
     <li><a href="#ref-for-list-size②">4.2.3. Mutation algorithms</a>
@@ -13453,134 +13453,134 @@ APIs</a>
     <li><a href="#ref-for-list-size⑦">7.1. Interface DOMTokenList</a> <a href="#ref-for-list-size⑧">(2)</a> <a href="#ref-for-list-size⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-split-on-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-split-on-ascii-whitespace" class="dfn-panel" data-for="term-for-split-on-ascii-whitespace" id="infopanel-for-term-for-split-on-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-split-on-ascii-whitespace" style="display:none">Info about the 'split on ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#split-on-ascii-whitespace">https://infra.spec.whatwg.org/#split-on-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-ascii-whitespace">1.2. Ordered sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">2.2. Interface Event</a> <a href="#ref-for-struct①">(2)</a>
     <li><a href="#ref-for-struct②">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-svg-namespace">
-   <a href="https://infra.spec.whatwg.org/#svg-namespace">https://infra.spec.whatwg.org/#svg-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-svg-namespace" class="dfn-panel" data-for="term-for-svg-namespace" id="infopanel-for-term-for-svg-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-svg-namespace" style="display:none">Info about the 'svg namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#svg-namespace">https://infra.spec.whatwg.org/#svg-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-svg-namespace">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-tuple">
-   <a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-tuple" class="dfn-panel" data-for="term-for-tuple" id="infopanel-for-term-for-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-tuple" style="display:none">Info about the 'tuple' external reference.</span><a href="https://infra.spec.whatwg.org/#tuple">https://infra.spec.whatwg.org/#tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">5.1. Introduction to "DOM Ranges"</a>
     <li><a href="#ref-for-tuple①">5.2. Boundary points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-namespace">
-   <a href="https://infra.spec.whatwg.org/#xml-namespace">https://infra.spec.whatwg.org/#xml-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-namespace" class="dfn-panel" data-for="term-for-xml-namespace" id="infopanel-for-term-for-xml-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-namespace" style="display:none">Info about the 'xml namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#xml-namespace">https://infra.spec.whatwg.org/#xml-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-namespace">1.4. Namespaces</a>
     <li><a href="#ref-for-xml-namespace①">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlns-namespace">
-   <a href="https://infra.spec.whatwg.org/#xmlns-namespace">https://infra.spec.whatwg.org/#xmlns-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlns-namespace" class="dfn-panel" data-for="term-for-xmlns-namespace" id="infopanel-for-term-for-xmlns-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlns-namespace" style="display:none">Info about the 'xmlns namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#xmlns-namespace">https://infra.spec.whatwg.org/#xmlns-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlns-namespace">1.4. Namespaces</a> <a href="#ref-for-xmlns-namespace①">(2)</a>
     <li><a href="#ref-for-xmlns-namespace②">4.4. Interface Node</a> <a href="#ref-for-xmlns-namespace③">(2)</a>
     <li><a href="#ref-for-xmlns-namespace④">4.5. Interface Document</a> <a href="#ref-for-xmlns-namespace⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-defined-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#defined-pseudo">https://drafts.csswg.org/selectors-4/#defined-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-defined-pseudo" class="dfn-panel" data-for="term-for-defined-pseudo" id="infopanel-for-term-for-defined-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-defined-pseudo" style="display:none">Info about the ':defined' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#defined-pseudo">https://drafts.csswg.org/selectors-4/#defined-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-defined-pseudo">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-a-selector-against-a-tree">
-   <a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree">https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-a-selector-against-a-tree" class="dfn-panel" data-for="term-for-match-a-selector-against-a-tree" id="infopanel-for-term-for-match-a-selector-against-a-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-match-a-selector-against-a-tree" style="display:none">Info about the 'match a selector against a tree' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree">https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-a-tree">1.3. Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-match-a-selector-against-an-element">
-   <a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-match-a-selector-against-an-element" class="dfn-panel" data-for="term-for-match-a-selector-against-an-element" id="infopanel-for-term-for-match-a-selector-against-an-element" role="menu">
+   <span id="infopaneltitle-for-term-for-match-a-selector-against-an-element" style="display:none">Info about the 'match a selector against an element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element">https://drafts.csswg.org/selectors-4/#match-a-selector-against-an-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-a-selector-against-an-element">4.9. Interface Element</a> <a href="#ref-for-match-a-selector-against-an-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#parse-a-selector">https://drafts.csswg.org/selectors-4/#parse-a-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-selector" class="dfn-panel" data-for="term-for-parse-a-selector" id="infopanel-for-term-for-parse-a-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-selector" style="display:none">Info about the 'parse a selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#parse-a-selector">https://drafts.csswg.org/selectors-4/#parse-a-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-selector">1.3. Selectors</a>
     <li><a href="#ref-for-parse-a-selector①">4.9. Interface Element</a> <a href="#ref-for-parse-a-selector②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scoping-root">
-   <a href="https://drafts.csswg.org/selectors-4/#scoping-root">https://drafts.csswg.org/selectors-4/#scoping-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scoping-root" class="dfn-panel" data-for="term-for-scoping-root" id="infopanel-for-term-for-scoping-root" role="menu">
+   <span id="infopaneltitle-for-term-for-scoping-root" style="display:none">Info about the 'scoping root' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#scoping-root">https://drafts.csswg.org/selectors-4/#scoping-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scoping-root">1.3. Selectors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">2.7. Interface EventTarget</a> <a href="#ref-for-serviceworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-has-ever-been-evaluated-flag">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-has-ever-been-evaluated-flag" class="dfn-panel" data-for="term-for-dfn-has-ever-been-evaluated-flag" id="infopanel-for-term-for-dfn-has-ever-been-evaluated-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-has-ever-been-evaluated-flag" style="display:none">Info about the 'has ever been evaluated flag' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag">https://w3c.github.io/ServiceWorker/#dfn-has-ever-been-evaluated-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-has-ever-been-evaluated-flag">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-script-resource">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">https://w3c.github.io/ServiceWorker/#dfn-script-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-script-resource" class="dfn-panel" data-for="term-for-dfn-script-resource" id="infopanel-for-term-for-dfn-script-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-script-resource" style="display:none">Info about the 'script resource' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-script-resource">https://w3c.github.io/ServiceWorker/#dfn-script-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-script-resource">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope-service-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope-service-worker">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope-service-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope-service-worker" class="dfn-panel" data-for="term-for-serviceworkerglobalscope-service-worker" id="infopanel-for-term-for-serviceworkerglobalscope-service-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope-service-worker" style="display:none">Info about the 'service worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope-service-worker">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope-service-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope-service-worker">2.7. Interface EventTarget</a> <a href="#ref-for-serviceworkerglobalscope-service-worker①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-service-worker-events">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-events">https://w3c.github.io/ServiceWorker/#dfn-service-worker-events</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-service-worker-events" class="dfn-panel" data-for="term-for-dfn-service-worker-events" id="infopanel-for-term-for-dfn-service-worker-events" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-service-worker-events" style="display:none">Info about the 'service worker events' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-service-worker-events">https://w3c.github.io/ServiceWorker/#dfn-service-worker-events</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-service-worker-events">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-set-of-event-types-to-handle">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-set-of-event-types-to-handle">https://w3c.github.io/ServiceWorker/#dfn-set-of-event-types-to-handle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-set-of-event-types-to-handle" class="dfn-panel" data-for="term-for-dfn-set-of-event-types-to-handle" id="infopanel-for-term-for-dfn-set-of-event-types-to-handle" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-set-of-event-types-to-handle" style="display:none">Info about the 'set of event types to handle' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-set-of-event-types-to-handle">https://w3c.github.io/ServiceWorker/#dfn-set-of-event-types-to-handle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-set-of-event-types-to-handle">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compositionevent">
-   <a href="https://w3c.github.io/uievents/#compositionevent">https://w3c.github.io/uievents/#compositionevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compositionevent" class="dfn-panel" data-for="term-for-compositionevent" id="infopanel-for-term-for-compositionevent" role="menu">
+   <span id="infopaneltitle-for-term-for-compositionevent" style="display:none">Info about the 'CompositionEvent' external reference.</span><a href="https://w3c.github.io/uievents/#compositionevent">https://w3c.github.io/uievents/#compositionevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compositionevent">4.5. Interface Document</a> <a href="#ref-for-compositionevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-focusevent">
-   <a href="https://w3c.github.io/uievents/#focusevent">https://w3c.github.io/uievents/#focusevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-focusevent" class="dfn-panel" data-for="term-for-focusevent" id="infopanel-for-term-for-focusevent" role="menu">
+   <span id="infopaneltitle-for-term-for-focusevent" style="display:none">Info about the 'FocusEvent' external reference.</span><a href="https://w3c.github.io/uievents/#focusevent">https://w3c.github.io/uievents/#focusevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-focusevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-keyboardevent">
-   <a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-keyboardevent" class="dfn-panel" data-for="term-for-keyboardevent" id="infopanel-for-term-for-keyboardevent" role="menu">
+   <span id="infopaneltitle-for-term-for-keyboardevent" style="display:none">Info about the 'KeyboardEvent' external reference.</span><a href="https://w3c.github.io/uievents/#keyboardevent">https://w3c.github.io/uievents/#keyboardevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keyboardevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mouseevent">
-   <a href="https://w3c.github.io/uievents/#mouseevent">https://w3c.github.io/uievents/#mouseevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mouseevent" class="dfn-panel" data-for="term-for-mouseevent" id="infopanel-for-term-for-mouseevent" role="menu">
+   <span id="infopaneltitle-for-term-for-mouseevent" style="display:none">Info about the 'MouseEvent' external reference.</span><a href="https://w3c.github.io/uievents/#mouseevent">https://w3c.github.io/uievents/#mouseevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mouseevent">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-mouseevent①">2.9. Dispatching events</a>
@@ -13588,41 +13588,41 @@ APIs</a>
     <li><a href="#ref-for-mouseevent③">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-uievent">
-   <a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-uievent" class="dfn-panel" data-for="term-for-uievent" id="infopanel-for-term-for-uievent" role="menu">
+   <span id="infopaneltitle-for-term-for-uievent" style="display:none">Info about the 'UIEvent' external reference.</span><a href="https://w3c.github.io/uievents/#uievent">https://w3c.github.io/uievents/#uievent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-uievent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-uievent-detail">
-   <a href="https://w3c.github.io/uievents/#dom-uievent-detail">https://w3c.github.io/uievents/#dom-uievent-detail</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-uievent-detail" class="dfn-panel" data-for="term-for-dom-uievent-detail" id="infopanel-for-term-for-dom-uievent-detail" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-uievent-detail" style="display:none">Info about the 'detail' external reference.</span><a href="https://w3c.github.io/uievents/#dom-uievent-detail">https://w3c.github.io/uievents/#dom-uievent-detail</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-uievent-detail">2.10. Firing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-url-serializer①">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">3. Aborting ongoing activities</a>
     <li><a href="#ref-for-aborterror①">3.3. Using AbortController and AbortSignal objects in
 APIs</a> <a href="#ref-for-aborterror②">(2)</a> <a href="#ref-for-aborterror③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">1.3. Selectors</a>
     <li><a href="#ref-for-idl-DOMException①">1.4. Namespaces</a> <a href="#ref-for-idl-DOMException②">(2)</a> <a href="#ref-for-idl-DOMException③">(3)</a> <a href="#ref-for-idl-DOMException④">(4)</a> <a href="#ref-for-idl-DOMException⑤">(5)</a>
@@ -13646,8 +13646,8 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-idl-DOMException⑨⑤">7.1. Interface DOMTokenList</a> <a href="#ref-for-idl-DOMException⑨⑥">(2)</a> <a href="#ref-for-idl-DOMException⑨⑦">(3)</a> <a href="#ref-for-idl-DOMException⑨⑧">(4)</a> <a href="#ref-for-idl-DOMException⑨⑨">(5)</a> <a href="#ref-for-idl-DOMException①⓪⓪">(6)</a> <a href="#ref-for-idl-DOMException①⓪①">(7)</a> <a href="#ref-for-idl-DOMException①⓪②">(8)</a> <a href="#ref-for-idl-DOMException①⓪③">(9)</a> <a href="#ref-for-idl-DOMException①⓪④">(10)</a> <a href="#ref-for-idl-DOMException①⓪⑤">(11)</a> <a href="#ref-for-idl-DOMException①⓪⑥">(12)</a> <a href="#ref-for-idl-DOMException①⓪⑦">(13)</a> <a href="#ref-for-idl-DOMException①⓪⑧">(14)</a> <a href="#ref-for-idl-DOMException①⓪⑨">(15)</a> <a href="#ref-for-idl-DOMException①①⓪">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">2.2. Interface Event</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
     <li><a href="#ref-for-idl-DOMString③">2.4. Interface CustomEvent</a> <a href="#ref-for-idl-DOMString④">(2)</a>
@@ -13674,8 +13674,8 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-idl-DOMString①③②">8.3. Mixin XPathEvaluatorBase</a> <a href="#ref-for-idl-DOMString①③③">(2)</a> <a href="#ref-for-idl-DOMString①③④">(3)</a> <a href="#ref-for-idl-DOMString①③⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">2.2. Interface Event</a>
     <li><a href="#ref-for-Exposed①">2.4. Interface CustomEvent</a>
@@ -13712,8 +13712,8 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-Exposed③③">8.4. Interface XPathEvaluator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hierarchyrequesterror">
-   <a href="https://webidl.spec.whatwg.org/#hierarchyrequesterror">https://webidl.spec.whatwg.org/#hierarchyrequesterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hierarchyrequesterror" class="dfn-panel" data-for="term-for-hierarchyrequesterror" id="infopanel-for-term-for-hierarchyrequesterror" role="menu">
+   <span id="infopaneltitle-for-term-for-hierarchyrequesterror" style="display:none">Info about the 'HierarchyRequestError' external reference.</span><a href="https://webidl.spec.whatwg.org/#hierarchyrequesterror">https://webidl.spec.whatwg.org/#hierarchyrequesterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hierarchyrequesterror">4.2.3. Mutation algorithms</a> <a href="#ref-for-hierarchyrequesterror①">(2)</a> <a href="#ref-for-hierarchyrequesterror②">(3)</a> <a href="#ref-for-hierarchyrequesterror③">(4)</a> <a href="#ref-for-hierarchyrequesterror④">(5)</a> <a href="#ref-for-hierarchyrequesterror⑤">(6)</a> <a href="#ref-for-hierarchyrequesterror⑥">(7)</a> <a href="#ref-for-hierarchyrequesterror⑦">(8)</a> <a href="#ref-for-hierarchyrequesterror⑧">(9)</a> <a href="#ref-for-hierarchyrequesterror⑨">(10)</a>
     <li><a href="#ref-for-hierarchyrequesterror①⓪">4.2.6. Mixin ParentNode</a> <a href="#ref-for-hierarchyrequesterror①①">(2)</a> <a href="#ref-for-hierarchyrequesterror①②">(3)</a>
@@ -13722,22 +13722,22 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-hierarchyrequesterror①⑧">5.5. Interface Range</a> <a href="#ref-for-hierarchyrequesterror①⑨">(2)</a> <a href="#ref-for-hierarchyrequesterror②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inuseattributeerror">
-   <a href="https://webidl.spec.whatwg.org/#inuseattributeerror">https://webidl.spec.whatwg.org/#inuseattributeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inuseattributeerror" class="dfn-panel" data-for="term-for-inuseattributeerror" id="infopanel-for-term-for-inuseattributeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-inuseattributeerror" style="display:none">Info about the 'InUseAttributeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#inuseattributeerror">https://webidl.spec.whatwg.org/#inuseattributeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inuseattributeerror">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-indexsizeerror">
-   <a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-indexsizeerror" class="dfn-panel" data-for="term-for-indexsizeerror" id="infopanel-for-term-for-indexsizeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-indexsizeerror" style="display:none">Info about the 'IndexSizeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#indexsizeerror">https://webidl.spec.whatwg.org/#indexsizeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-indexsizeerror">4.10. Interface CharacterData</a> <a href="#ref-for-indexsizeerror①">(2)</a>
     <li><a href="#ref-for-indexsizeerror②">4.11. Interface Text</a>
     <li><a href="#ref-for-indexsizeerror③">5.5. Interface Range</a> <a href="#ref-for-indexsizeerror④">(2)</a> <a href="#ref-for-indexsizeerror⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidcharactererror">
-   <a href="https://webidl.spec.whatwg.org/#invalidcharactererror">https://webidl.spec.whatwg.org/#invalidcharactererror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidcharactererror" class="dfn-panel" data-for="term-for-invalidcharactererror" id="infopanel-for-term-for-invalidcharactererror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidcharactererror" style="display:none">Info about the 'InvalidCharacterError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidcharactererror">https://webidl.spec.whatwg.org/#invalidcharactererror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidcharactererror">1.4. Namespaces</a>
     <li><a href="#ref-for-invalidcharactererror①">4.5. Interface Document</a> <a href="#ref-for-invalidcharactererror②">(2)</a> <a href="#ref-for-invalidcharactererror③">(3)</a> <a href="#ref-for-invalidcharactererror④">(4)</a> <a href="#ref-for-invalidcharactererror⑤">(5)</a> <a href="#ref-for-invalidcharactererror⑥">(6)</a> <a href="#ref-for-invalidcharactererror⑦">(7)</a> <a href="#ref-for-invalidcharactererror⑧">(8)</a> <a href="#ref-for-invalidcharactererror⑨">(9)</a>
@@ -13746,51 +13746,51 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-invalidcharactererror①③">7.1. Interface DOMTokenList</a> <a href="#ref-for-invalidcharactererror①④">(2)</a> <a href="#ref-for-invalidcharactererror①⑤">(3)</a> <a href="#ref-for-invalidcharactererror①⑥">(4)</a> <a href="#ref-for-invalidcharactererror①⑦">(5)</a> <a href="#ref-for-invalidcharactererror①⑧">(6)</a> <a href="#ref-for-invalidcharactererror①⑨">(7)</a> <a href="#ref-for-invalidcharactererror②⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidnodetypeerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidnodetypeerror">https://webidl.spec.whatwg.org/#invalidnodetypeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidnodetypeerror" class="dfn-panel" data-for="term-for-invalidnodetypeerror" id="infopanel-for-term-for-invalidnodetypeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidnodetypeerror" style="display:none">Info about the 'InvalidNodeTypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidnodetypeerror">https://webidl.spec.whatwg.org/#invalidnodetypeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidnodetypeerror">5.4. Interface StaticRange</a>
     <li><a href="#ref-for-invalidnodetypeerror①">5.5. Interface Range</a> <a href="#ref-for-invalidnodetypeerror②">(2)</a> <a href="#ref-for-invalidnodetypeerror③">(3)</a> <a href="#ref-for-invalidnodetypeerror④">(4)</a> <a href="#ref-for-invalidnodetypeerror⑤">(5)</a> <a href="#ref-for-invalidnodetypeerror⑥">(6)</a> <a href="#ref-for-invalidnodetypeerror⑦">(7)</a> <a href="#ref-for-invalidnodetypeerror⑧">(8)</a> <a href="#ref-for-invalidnodetypeerror⑨">(9)</a> <a href="#ref-for-invalidnodetypeerror①⓪">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-invalidstateerror①">5.5. Interface Range</a>
     <li><a href="#ref-for-invalidstateerror②">6. Traversal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyNullToEmptyString">
-   <a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyNullToEmptyString" class="dfn-panel" data-for="term-for-LegacyNullToEmptyString" id="infopanel-for-term-for-LegacyNullToEmptyString" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyNullToEmptyString" style="display:none">Info about the 'LegacyNullToEmptyString' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyNullToEmptyString">https://webidl.spec.whatwg.org/#LegacyNullToEmptyString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyNullToEmptyString">4.5.1. Interface DOMImplementation</a>
     <li><a href="#ref-for-LegacyNullToEmptyString①">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyUnenumerableNamedProperties">
-   <a href="https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties">https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyUnenumerableNamedProperties" class="dfn-panel" data-for="term-for-LegacyUnenumerableNamedProperties" id="infopanel-for-term-for-LegacyUnenumerableNamedProperties" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyUnenumerableNamedProperties" style="display:none">Info about the 'LegacyUnenumerableNamedProperties' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties">https://webidl.spec.whatwg.org/#LegacyUnenumerableNamedProperties</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties">4.2.10.2. Interface HTMLCollection</a>
     <li><a href="#ref-for-LegacyUnenumerableNamedProperties①">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyUnforgeable">
-   <a href="https://webidl.spec.whatwg.org/#LegacyUnforgeable">https://webidl.spec.whatwg.org/#LegacyUnforgeable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyUnforgeable" class="dfn-panel" data-for="term-for-LegacyUnforgeable" id="infopanel-for-term-for-LegacyUnforgeable" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyUnforgeable" style="display:none">Info about the 'LegacyUnforgeable' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyUnforgeable">https://webidl.spec.whatwg.org/#LegacyUnforgeable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyUnforgeable">2.2. Interface Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-namespaceerror">
-   <a href="https://webidl.spec.whatwg.org/#namespaceerror">https://webidl.spec.whatwg.org/#namespaceerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-namespaceerror" class="dfn-panel" data-for="term-for-namespaceerror" id="infopanel-for-term-for-namespaceerror" role="menu">
+   <span id="infopaneltitle-for-term-for-namespaceerror" style="display:none">Info about the 'NamespaceError' external reference.</span><a href="https://webidl.spec.whatwg.org/#namespaceerror">https://webidl.spec.whatwg.org/#namespaceerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespaceerror">1.4. Namespaces</a> <a href="#ref-for-namespaceerror①">(2)</a> <a href="#ref-for-namespaceerror②">(3)</a> <a href="#ref-for-namespaceerror③">(4)</a>
     <li><a href="#ref-for-namespaceerror④">4.5. Interface Document</a>
     <li><a href="#ref-for-namespaceerror⑤">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">3.2. Interface AbortSignal</a>
     <li><a href="#ref-for-NewObject①">4.2.6. Mixin ParentNode</a>
@@ -13802,16 +13802,16 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-NewObject②④">8.3. Mixin XPathEvaluatorBase</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notfounderror">
-   <a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notfounderror" class="dfn-panel" data-for="term-for-notfounderror" id="infopanel-for-term-for-notfounderror" role="menu">
+   <span id="infopaneltitle-for-term-for-notfounderror" style="display:none">Info about the 'NotFoundError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notfounderror">https://webidl.spec.whatwg.org/#notfounderror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notfounderror">4.2.3. Mutation algorithms</a> <a href="#ref-for-notfounderror①">(2)</a> <a href="#ref-for-notfounderror②">(3)</a>
     <li><a href="#ref-for-notfounderror③">4.9. Interface Element</a>
     <li><a href="#ref-for-notfounderror④">4.9.1. Interface NamedNodeMap</a> <a href="#ref-for-notfounderror⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-notsupportederror">
-   <a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-notsupportederror" class="dfn-panel" data-for="term-for-notsupportederror" id="infopanel-for-term-for-notsupportederror" role="menu">
+   <span id="infopaneltitle-for-term-for-notsupportederror" style="display:none">Info about the 'NotSupportedError' external reference.</span><a href="https://webidl.spec.whatwg.org/#notsupportederror">https://webidl.spec.whatwg.org/#notsupportederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notsupportederror">4.4. Interface Node</a>
     <li><a href="#ref-for-notsupportederror①">4.5. Interface Document</a> <a href="#ref-for-notsupportederror②">(2)</a> <a href="#ref-for-notsupportederror③">(3)</a> <a href="#ref-for-notsupportederror④">(4)</a> <a href="#ref-for-notsupportederror⑤">(5)</a> <a href="#ref-for-notsupportederror⑥">(6)</a> <a href="#ref-for-notsupportederror⑦">(7)</a>
@@ -13819,20 +13819,20 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-notsupportederror①⑦">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-PutForwards">
-   <a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-PutForwards" class="dfn-panel" data-for="term-for-PutForwards" id="infopanel-for-term-for-PutForwards" role="menu">
+   <span id="infopaneltitle-for-term-for-PutForwards" style="display:none">Info about the 'PutForwards' external reference.</span><a href="https://webidl.spec.whatwg.org/#PutForwards">https://webidl.spec.whatwg.org/#PutForwards</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-PutForwards">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Replaceable">
-   <a href="https://webidl.spec.whatwg.org/#Replaceable">https://webidl.spec.whatwg.org/#Replaceable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Replaceable" class="dfn-panel" data-for="term-for-Replaceable" id="infopanel-for-term-for-Replaceable" role="menu">
+   <span id="infopaneltitle-for-term-for-Replaceable" style="display:none">Info about the 'Replaceable' external reference.</span><a href="https://webidl.spec.whatwg.org/#Replaceable">https://webidl.spec.whatwg.org/#Replaceable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Replaceable">2.3. Legacy extensions to the Window interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3.1. Interface AbortController</a>
     <li><a href="#ref-for-SameObject①">4.2.6. Mixin ParentNode</a>
@@ -13844,56 +13844,56 @@ APIs</a> <a href="#ref-for-idl-DOMException⑨">(2)</a> <a href="#ref-for-idl-DO
     <li><a href="#ref-for-SameObject①⓪">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">1.3. Selectors</a>
     <li><a href="#ref-for-syntaxerror①">4.9. Interface Element</a> <a href="#ref-for-syntaxerror②">(2)</a> <a href="#ref-for-syntaxerror③">(3)</a>
     <li><a href="#ref-for-syntaxerror④">7.1. Interface DOMTokenList</a> <a href="#ref-for-syntaxerror⑤">(2)</a> <a href="#ref-for-syntaxerror⑥">(3)</a> <a href="#ref-for-syntaxerror⑦">(4)</a> <a href="#ref-for-syntaxerror⑧">(5)</a> <a href="#ref-for-syntaxerror⑨">(6)</a> <a href="#ref-for-syntaxerror①⓪">(7)</a> <a href="#ref-for-syntaxerror①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">4.4. Interface Node</a>
     <li><a href="#ref-for-idl-USVString①">4.5. Interface Document</a> <a href="#ref-for-idl-USVString②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Unscopable">
-   <a href="https://webidl.spec.whatwg.org/#Unscopable">https://webidl.spec.whatwg.org/#Unscopable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Unscopable" class="dfn-panel" data-for="term-for-Unscopable" id="infopanel-for-term-for-Unscopable" role="menu">
+   <span id="infopaneltitle-for-term-for-Unscopable" style="display:none">Info about the 'Unscopable' external reference.</span><a href="https://webidl.spec.whatwg.org/#Unscopable">https://webidl.spec.whatwg.org/#Unscopable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Unscopable">4.2.6. Mixin ParentNode</a> <a href="#ref-for-Unscopable①">(2)</a> <a href="#ref-for-Unscopable②">(3)</a>
     <li><a href="#ref-for-Unscopable③">4.2.8. Mixin ChildNode</a> <a href="#ref-for-Unscopable④">(2)</a> <a href="#ref-for-Unscopable⑤">(3)</a> <a href="#ref-for-Unscopable⑥">(4)</a>
     <li><a href="#ref-for-Unscopable⑦">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-wrongdocumenterror">
-   <a href="https://webidl.spec.whatwg.org/#wrongdocumenterror">https://webidl.spec.whatwg.org/#wrongdocumenterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-wrongdocumenterror" class="dfn-panel" data-for="term-for-wrongdocumenterror" id="infopanel-for-term-for-wrongdocumenterror" role="menu">
+   <span id="infopaneltitle-for-term-for-wrongdocumenterror" style="display:none">Info about the 'WrongDocumentError' external reference.</span><a href="https://webidl.spec.whatwg.org/#wrongdocumenterror">https://webidl.spec.whatwg.org/#wrongdocumenterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-wrongdocumenterror">5.5. Interface Range</a> <a href="#ref-for-wrongdocumenterror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">3.3. Using AbortController and AbortSignal objects in
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">2.4. Interface CustomEvent</a> <a href="#ref-for-idl-any①">(2)</a> <a href="#ref-for-idl-any②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-associated-realm">
-   <a href="https://webidl.spec.whatwg.org/#dfn-associated-realm">https://webidl.spec.whatwg.org/#dfn-associated-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-associated-realm" class="dfn-panel" data-for="term-for-dfn-associated-realm" id="infopanel-for-term-for-dfn-associated-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-associated-realm" style="display:none">Info about the 'associated realm' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-associated-realm">https://webidl.spec.whatwg.org/#dfn-associated-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-associated-realm">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">2.2. Interface Event</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a> <a href="#ref-for-idl-boolean③">(4)</a> <a href="#ref-for-idl-boolean④">(5)</a> <a href="#ref-for-idl-boolean⑤">(6)</a> <a href="#ref-for-idl-boolean⑥">(7)</a> <a href="#ref-for-idl-boolean⑦">(8)</a> <a href="#ref-for-idl-boolean⑧">(9)</a> <a href="#ref-for-idl-boolean⑨">(10)</a> <a href="#ref-for-idl-boolean①⓪">(11)</a> <a href="#ref-for-idl-boolean①①">(12)</a>
     <li><a href="#ref-for-idl-boolean①②">2.4. Interface CustomEvent</a> <a href="#ref-for-idl-boolean①③">(2)</a>
@@ -13912,74 +13912,74 @@ APIs</a>
     <li><a href="#ref-for-idl-boolean⑤⑥">8.1. Interface XPathResult</a> <a href="#ref-for-idl-boolean⑤⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-call-a-user-objects-operation">
-   <a href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">https://webidl.spec.whatwg.org/#call-a-user-objects-operation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-call-a-user-objects-operation" class="dfn-panel" data-for="term-for-call-a-user-objects-operation" id="infopanel-for-term-for-call-a-user-objects-operation" role="menu">
+   <span id="infopaneltitle-for-term-for-call-a-user-objects-operation" style="display:none">Info about the 'call a user object's operation' external reference.</span><a href="https://webidl.spec.whatwg.org/#call-a-user-objects-operation">https://webidl.spec.whatwg.org/#call-a-user-objects-operation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-call-a-user-objects-operation">2.9. Dispatching events</a>
     <li><a href="#ref-for-call-a-user-objects-operation①">6. Traversal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-construct-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#construct-a-callback-function">https://webidl.spec.whatwg.org/#construct-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-construct-a-callback-function" class="dfn-panel" data-for="term-for-construct-a-callback-function" id="infopanel-for-term-for-construct-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-construct-a-callback-function" style="display:none">Info about the 'construct' external reference.</span><a href="https://webidl.spec.whatwg.org/#construct-a-callback-function">https://webidl.spec.whatwg.org/#construct-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-construct-a-callback-function">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-dictionary">
-   <a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-dictionary" class="dfn-panel" data-for="term-for-dfn-dictionary" id="infopanel-for-term-for-dfn-dictionary" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-dictionary" style="display:none">Info about the 'dictionary' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-dictionary">https://webidl.spec.whatwg.org/#dfn-dictionary</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-dictionary">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-dfn-dictionary①">4.5. Interface Document</a> <a href="#ref-for-dfn-dictionary②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-identifier">
-   <a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-identifier" class="dfn-panel" data-for="term-for-dfn-identifier" id="infopanel-for-term-for-dfn-identifier" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-identifier" style="display:none">Info about the 'identifier' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-identifier">https://webidl.spec.whatwg.org/#dfn-identifier</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-identifier">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">3.3. Using AbortController and AbortSignal objects in
 APIs</a> <a href="#ref-for-reject①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">3.3. Using AbortController and AbortSignal objects in
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">2.2. Interface Event</a>
     <li><a href="#ref-for-idl-sequence①">4.3.1. Interface MutationObserver</a> <a href="#ref-for-idl-sequence②">(2)</a> <a href="#ref-for-idl-sequence③">(3)</a>
     <li><a href="#ref-for-idl-sequence④">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">5.5. Interface Range</a> <a href="#ref-for-idl-short①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-supported-property-indices">
-   <a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-supported-property-indices" class="dfn-panel" data-for="term-for-dfn-supported-property-indices" id="infopanel-for-term-for-dfn-supported-property-indices" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-supported-property-indices" style="display:none">Info about the 'supported property indices' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">https://webidl.spec.whatwg.org/#dfn-supported-property-indices</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-indices">4.2.10.1. Interface NodeList</a> <a href="#ref-for-dfn-supported-property-indices①">(2)</a>
     <li><a href="#ref-for-dfn-supported-property-indices②">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-dfn-supported-property-indices③">(2)</a>
@@ -13987,15 +13987,15 @@ APIs</a>
     <li><a href="#ref-for-dfn-supported-property-indices⑥">7.1. Interface DOMTokenList</a> <a href="#ref-for-dfn-supported-property-indices⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-supported-property-names">
-   <a href="https://webidl.spec.whatwg.org/#dfn-supported-property-names">https://webidl.spec.whatwg.org/#dfn-supported-property-names</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-supported-property-names" class="dfn-panel" data-for="term-for-dfn-supported-property-names" id="infopanel-for-term-for-dfn-supported-property-names" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-supported-property-names" style="display:none">Info about the 'supported property names' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-supported-property-names">https://webidl.spec.whatwg.org/#dfn-supported-property-names</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-supported-property-names">4.2.10.2. Interface HTMLCollection</a>
     <li><a href="#ref-for-dfn-supported-property-names①">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">1. Infrastructure</a> <a href="#ref-for-this①">(2)</a>
     <li><a href="#ref-for-this②">2.2. Interface Event</a> <a href="#ref-for-this③">(2)</a> <a href="#ref-for-this④">(3)</a> <a href="#ref-for-this⑤">(4)</a> <a href="#ref-for-this⑥">(5)</a> <a href="#ref-for-this⑦">(6)</a> <a href="#ref-for-this⑧">(7)</a> <a href="#ref-for-this⑨">(8)</a> <a href="#ref-for-this①⓪">(9)</a> <a href="#ref-for-this①①">(10)</a> <a href="#ref-for-this①②">(11)</a> <a href="#ref-for-this①③">(12)</a> <a href="#ref-for-this①④">(13)</a> <a href="#ref-for-this①⑤">(14)</a> <a href="#ref-for-this①⑥">(15)</a> <a href="#ref-for-this①⑦">(16)</a>
@@ -14029,8 +14029,8 @@ APIs</a>
     <li><a href="#ref-for-this③①②">7.1. Interface DOMTokenList</a> <a href="#ref-for-this③①③">(2)</a> <a href="#ref-for-this③①④">(3)</a> <a href="#ref-for-this③①⑤">(4)</a> <a href="#ref-for-this③①⑥">(5)</a> <a href="#ref-for-this③①⑦">(6)</a> <a href="#ref-for-this③①⑧">(7)</a> <a href="#ref-for-this③①⑨">(8)</a> <a href="#ref-for-this③②⓪">(9)</a> <a href="#ref-for-this③②①">(10)</a> <a href="#ref-for-this③②②">(11)</a> <a href="#ref-for-this③②③">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">1.3. Selectors</a>
     <li><a href="#ref-for-dfn-throw①">1.4. Namespaces</a> <a href="#ref-for-dfn-throw②">(2)</a> <a href="#ref-for-dfn-throw③">(3)</a> <a href="#ref-for-dfn-throw④">(4)</a> <a href="#ref-for-dfn-throw⑤">(5)</a>
@@ -14050,8 +14050,8 @@ APIs</a>
     <li><a href="#ref-for-dfn-throw⑧④">7.1. Interface DOMTokenList</a> <a href="#ref-for-dfn-throw⑧⑤">(2)</a> <a href="#ref-for-dfn-throw⑧⑥">(3)</a> <a href="#ref-for-dfn-throw⑧⑦">(4)</a> <a href="#ref-for-dfn-throw⑧⑧">(5)</a> <a href="#ref-for-dfn-throw⑧⑨">(6)</a> <a href="#ref-for-dfn-throw⑨⓪">(7)</a> <a href="#ref-for-dfn-throw⑨①">(8)</a> <a href="#ref-for-dfn-throw⑨②">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">2.2. Interface Event</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
     <li><a href="#ref-for-idl-undefined④">2.3. Legacy extensions to the Window interface</a>
@@ -14069,14 +14069,14 @@ APIs</a>
     <li><a href="#ref-for-idl-undefined④④">7.1. Interface DOMTokenList</a> <a href="#ref-for-idl-undefined④⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">8.1. Interface XPathResult</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">4.2.6. Mixin ParentNode</a>
     <li><a href="#ref-for-idl-unsigned-long①">4.2.10.1. Interface NodeList</a> <a href="#ref-for-idl-unsigned-long②">(2)</a>
@@ -14095,8 +14095,8 @@ APIs</a>
     <li><a href="#ref-for-idl-unsigned-long④③">8.1. Interface XPathResult</a> <a href="#ref-for-idl-unsigned-long④④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">2.2. Interface Event</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a> <a href="#ref-for-idl-unsigned-short③">(4)</a> <a href="#ref-for-idl-unsigned-short④">(5)</a>
     <li><a href="#ref-for-idl-unsigned-short⑤">4.4. Interface Node</a> <a href="#ref-for-idl-unsigned-short⑥">(2)</a> <a href="#ref-for-idl-unsigned-short⑦">(3)</a> <a href="#ref-for-idl-unsigned-short⑧">(4)</a> <a href="#ref-for-idl-unsigned-short⑨">(5)</a> <a href="#ref-for-idl-unsigned-short①⓪">(6)</a> <a href="#ref-for-idl-unsigned-short①①">(7)</a> <a href="#ref-for-idl-unsigned-short①②">(8)</a> <a href="#ref-for-idl-unsigned-short①③">(9)</a> <a href="#ref-for-idl-unsigned-short①④">(10)</a> <a href="#ref-for-idl-unsigned-short①⑤">(11)</a> <a href="#ref-for-idl-unsigned-short①⑥">(12)</a> <a href="#ref-for-idl-unsigned-short①⑦">(13)</a> <a href="#ref-for-idl-unsigned-short①⑧">(14)</a> <a href="#ref-for-idl-unsigned-short①⑨">(15)</a> <a href="#ref-for-idl-unsigned-short②⓪">(16)</a> <a href="#ref-for-idl-unsigned-short②①">(17)</a> <a href="#ref-for-idl-unsigned-short②②">(18)</a> <a href="#ref-for-idl-unsigned-short②③">(19)</a> <a href="#ref-for-idl-unsigned-short②④">(20)</a>
@@ -15030,14 +15030,14 @@ APIs</a>
 <a data-link-type="idl-name" href="#xpathevaluator"><c- n>XPathEvaluator</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="#xpathevaluatorbase"><c- n>XPathEvaluatorBase</c-></a>;
 
 </pre>
-  <aside class="dfn-panel" data-for="context-object">
-   <b><a href="#context-object">#context-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-context-object" class="dfn-panel" data-for="context-object" id="infopanel-for-context-object" role="dialog">
+   <span id="infopaneltitle-for-context-object" style="display:none">Info about the 'context object' definition.</span><b><a href="#context-object">#context-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-context-object">1. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="other-applicable-specifications">
-   <b><a href="#other-applicable-specifications">#other-applicable-specifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-other-applicable-specifications" class="dfn-panel" data-for="other-applicable-specifications" id="infopanel-for-other-applicable-specifications" role="dialog">
+   <span id="infopaneltitle-for-other-applicable-specifications" style="display:none">Info about the 'applicable specifications' definition.</span><b><a href="#other-applicable-specifications">#other-applicable-specifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-other-applicable-specifications">2.5. Constructing events</a>
     <li><a href="#ref-for-other-applicable-specifications①">4.2.3. Mutation algorithms</a> <a href="#ref-for-other-applicable-specifications②">(2)</a> <a href="#ref-for-other-applicable-specifications③">(3)</a>
@@ -15047,8 +15047,8 @@ APIs</a>
     <li><a href="#ref-for-other-applicable-specifications⑧">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree">
-   <b><a href="#concept-tree">#concept-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree" class="dfn-panel" data-for="concept-tree" id="infopanel-for-concept-tree" role="dialog">
+   <span id="infopaneltitle-for-concept-tree" style="display:none">Info about the 'tree' definition.</span><b><a href="#concept-tree">#concept-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree">1.1. Trees</a> <a href="#ref-for-concept-tree①">(2)</a> <a href="#ref-for-concept-tree②">(3)</a> <a href="#ref-for-concept-tree③">(4)</a> <a href="#ref-for-concept-tree④">(5)</a> <a href="#ref-for-concept-tree⑤">(6)</a>
     <li><a href="#ref-for-concept-tree⑥">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-tree⑦">(2)</a>
@@ -15063,8 +15063,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree②②">6. Traversal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-order">
-   <b><a href="#concept-tree-order">#concept-tree-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-order" class="dfn-panel" data-for="concept-tree-order" id="infopanel-for-concept-tree-order" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-order" style="display:none">Info about the 'tree order' definition.</span><b><a href="#concept-tree-order">#concept-tree-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">1.1. Trees</a> <a href="#ref-for-concept-tree-order①">(2)</a>
     <li><a href="#ref-for-concept-tree-order②">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-tree-order③">(2)</a>
@@ -15085,8 +15085,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-order②⑨">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-participate">
-   <b><a href="#concept-tree-participate">#concept-tree-participate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-participate" class="dfn-panel" data-for="concept-tree-participate" id="infopanel-for-concept-tree-participate" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-participate" style="display:none">Info about the 'participates' definition.</span><b><a href="#concept-tree-participate">#concept-tree-participate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-participate">1.1. Trees</a>
     <li><a href="#ref-for-concept-tree-participate①">2.1. Introduction to "DOM Events"</a>
@@ -15095,8 +15095,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-participate⑤">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-parent">
-   <b><a href="#concept-tree-parent">#concept-tree-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-parent" class="dfn-panel" data-for="concept-tree-parent" id="infopanel-for-concept-tree-parent" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-parent" style="display:none">Info about the 'parent' definition.</span><b><a href="#concept-tree-parent">#concept-tree-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-parent">1.1. Trees</a> <a href="#ref-for-concept-tree-parent①">(2)</a> <a href="#ref-for-concept-tree-parent②">(3)</a> <a href="#ref-for-concept-tree-parent③">(4)</a> <a href="#ref-for-concept-tree-parent④">(5)</a>
     <li><a href="#ref-for-concept-tree-parent⑤">4.2.1. Document tree</a>
@@ -15115,8 +15115,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-parent⑥①">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-parent⑥②">(2)</a> <a href="#ref-for-concept-tree-parent⑥③">(3)</a> <a href="#ref-for-concept-tree-parent⑥④">(4)</a> <a href="#ref-for-concept-tree-parent⑥⑤">(5)</a> <a href="#ref-for-concept-tree-parent⑥⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-child">
-   <b><a href="#concept-tree-child">#concept-tree-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-child" class="dfn-panel" data-for="concept-tree-child" id="infopanel-for-concept-tree-child" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-child" style="display:none">Info about the 'children' definition.</span><b><a href="#concept-tree-child">#concept-tree-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">1.1. Trees</a> <a href="#ref-for-concept-tree-child①">(2)</a> <a href="#ref-for-concept-tree-child②">(3)</a> <a href="#ref-for-concept-tree-child③">(4)</a> <a href="#ref-for-concept-tree-child④">(5)</a> <a href="#ref-for-concept-tree-child⑤">(6)</a> <a href="#ref-for-concept-tree-child⑥">(7)</a>
     <li><a href="#ref-for-concept-tree-child⑦">4.1. Introduction to "The DOM"</a>
@@ -15135,8 +15135,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-child⑦⑤">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-child⑦⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-root">
-   <b><a href="#concept-tree-root">#concept-tree-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-root" class="dfn-panel" data-for="concept-tree-root" id="infopanel-for-concept-tree-root" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-root" style="display:none">Info about the 'root' definition.</span><b><a href="#concept-tree-root">#concept-tree-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">1.1. Trees</a> <a href="#ref-for-concept-tree-root①">(2)</a>
     <li><a href="#ref-for-concept-tree-root②">1.3. Selectors</a>
@@ -15155,8 +15155,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-root④⓪">5.5. Interface Range</a> <a href="#ref-for-concept-tree-root④①">(2)</a> <a href="#ref-for-concept-tree-root④②">(3)</a> <a href="#ref-for-concept-tree-root④③">(4)</a> <a href="#ref-for-concept-tree-root④④">(5)</a> <a href="#ref-for-concept-tree-root④⑤">(6)</a> <a href="#ref-for-concept-tree-root④⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-descendant">
-   <b><a href="#concept-tree-descendant">#concept-tree-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-descendant" class="dfn-panel" data-for="concept-tree-descendant" id="infopanel-for-concept-tree-descendant" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-descendant" style="display:none">Info about the 'descendant' definition.</span><b><a href="#concept-tree-descendant">#concept-tree-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-descendant">1.1. Trees</a> <a href="#ref-for-concept-tree-descendant①">(2)</a> <a href="#ref-for-concept-tree-descendant②">(3)</a>
     <li><a href="#ref-for-concept-tree-descendant③">4.2.2.3. Finding slots and slottables</a> <a href="#ref-for-concept-tree-descendant④">(2)</a>
@@ -15171,8 +15171,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-descendant③②">5.5. Interface Range</a> <a href="#ref-for-concept-tree-descendant③③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-inclusive-descendant">
-   <b><a href="#concept-tree-inclusive-descendant">#concept-tree-inclusive-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-inclusive-descendant" class="dfn-panel" data-for="concept-tree-inclusive-descendant" id="infopanel-for-concept-tree-inclusive-descendant" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-inclusive-descendant" style="display:none">Info about the 'inclusive descendant' definition.</span><b><a href="#concept-tree-inclusive-descendant">#concept-tree-inclusive-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-inclusive-descendant">4.2.2.4. Assigning slottables and slots</a>
     <li><a href="#ref-for-concept-tree-inclusive-descendant①">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-inclusive-descendant②">(2)</a> <a href="#ref-for-concept-tree-inclusive-descendant③">(3)</a>
@@ -15180,8 +15180,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-inclusive-descendant⑥">6.1. Interface NodeIterator</a> <a href="#ref-for-concept-tree-inclusive-descendant⑦">(2)</a> <a href="#ref-for-concept-tree-inclusive-descendant⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-ancestor">
-   <b><a href="#concept-tree-ancestor">#concept-tree-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-ancestor" class="dfn-panel" data-for="concept-tree-ancestor" id="infopanel-for-concept-tree-ancestor" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-ancestor" style="display:none">Info about the 'ancestor' definition.</span><b><a href="#concept-tree-ancestor">#concept-tree-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-ancestor">1.1. Trees</a>
     <li><a href="#ref-for-concept-tree-ancestor①">2.1. Introduction to "DOM Events"</a>
@@ -15191,8 +15191,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-ancestor⑥">5.5. Interface Range</a> <a href="#ref-for-concept-tree-ancestor⑦">(2)</a> <a href="#ref-for-concept-tree-ancestor⑧">(3)</a> <a href="#ref-for-concept-tree-ancestor⑨">(4)</a> <a href="#ref-for-concept-tree-ancestor①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-inclusive-ancestor">
-   <b><a href="#concept-tree-inclusive-ancestor">#concept-tree-inclusive-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-inclusive-ancestor" class="dfn-panel" data-for="concept-tree-inclusive-ancestor" id="infopanel-for-concept-tree-inclusive-ancestor" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-inclusive-ancestor" style="display:none">Info about the 'inclusive ancestor' definition.</span><b><a href="#concept-tree-inclusive-ancestor">#concept-tree-inclusive-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-inclusive-ancestor">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-tree-inclusive-ancestor①">(2)</a>
     <li><a href="#ref-for-concept-tree-inclusive-ancestor②">4.2.3. Mutation algorithms</a>
@@ -15203,8 +15203,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-inclusive-ancestor②⑧">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-sibling">
-   <b><a href="#concept-tree-sibling">#concept-tree-sibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-sibling" class="dfn-panel" data-for="concept-tree-sibling" id="infopanel-for-concept-tree-sibling" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-sibling" style="display:none">Info about the 'sibling' definition.</span><b><a href="#concept-tree-sibling">#concept-tree-sibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-sibling">1.1. Trees</a> <a href="#ref-for-concept-tree-sibling①">(2)</a> <a href="#ref-for-concept-tree-sibling②">(3)</a> <a href="#ref-for-concept-tree-sibling③">(4)</a> <a href="#ref-for-concept-tree-sibling④">(5)</a> <a href="#ref-for-concept-tree-sibling⑤">(6)</a>
     <li><a href="#ref-for-concept-tree-sibling⑥">4.2.7. Mixin NonDocumentTypeChildNode</a> <a href="#ref-for-concept-tree-sibling⑦">(2)</a> <a href="#ref-for-concept-tree-sibling⑧">(3)</a> <a href="#ref-for-concept-tree-sibling⑨">(4)</a>
@@ -15214,8 +15214,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-sibling①⑤">5.5. Interface Range</a> <a href="#ref-for-concept-tree-sibling①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-preceding">
-   <b><a href="#concept-tree-preceding">#concept-tree-preceding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-preceding" class="dfn-panel" data-for="concept-tree-preceding" id="infopanel-for-concept-tree-preceding" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-preceding" style="display:none">Info about the 'preceding' definition.</span><b><a href="#concept-tree-preceding">#concept-tree-preceding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-preceding">1.1. Trees</a> <a href="#ref-for-concept-tree-preceding①">(2)</a> <a href="#ref-for-concept-tree-preceding②">(3)</a>
     <li><a href="#ref-for-concept-tree-preceding③">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-preceding④">(2)</a>
@@ -15226,8 +15226,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-preceding①②">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-following">
-   <b><a href="#concept-tree-following">#concept-tree-following</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-following" class="dfn-panel" data-for="concept-tree-following" id="infopanel-for-concept-tree-following" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-following" style="display:none">Info about the 'following' definition.</span><b><a href="#concept-tree-following">#concept-tree-following</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-following">1.1. Trees</a> <a href="#ref-for-concept-tree-following①">(2)</a>
     <li><a href="#ref-for-concept-tree-following②">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-following③">(2)</a> <a href="#ref-for-concept-tree-following④">(3)</a> <a href="#ref-for-concept-tree-following⑤">(4)</a>
@@ -15238,8 +15238,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-following①②">6.1. Interface NodeIterator</a> <a href="#ref-for-concept-tree-following①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-first-child">
-   <b><a href="#concept-tree-first-child">#concept-tree-first-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-first-child" class="dfn-panel" data-for="concept-tree-first-child" id="infopanel-for-concept-tree-first-child" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-first-child" style="display:none">Info about the 'first child' definition.</span><b><a href="#concept-tree-first-child">#concept-tree-first-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-first-child">4.2.6. Mixin ParentNode</a> <a href="#ref-for-concept-tree-first-child①">(2)</a>
     <li><a href="#ref-for-concept-tree-first-child②">4.2.8. Mixin ChildNode</a>
@@ -15248,8 +15248,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-first-child⑥">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-first-child⑦">(2)</a> <a href="#ref-for-concept-tree-first-child⑧">(3)</a> <a href="#ref-for-concept-tree-first-child⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-last-child">
-   <b><a href="#concept-tree-last-child">#concept-tree-last-child</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-last-child" class="dfn-panel" data-for="concept-tree-last-child" id="infopanel-for-concept-tree-last-child" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-last-child" style="display:none">Info about the 'last child' definition.</span><b><a href="#concept-tree-last-child">#concept-tree-last-child</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-last-child">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-tree-last-child①">4.2.6. Mixin ParentNode</a>
@@ -15257,8 +15257,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-last-child④">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-last-child⑤">(2)</a> <a href="#ref-for-concept-tree-last-child⑥">(3)</a> <a href="#ref-for-concept-tree-last-child⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-previous-sibling">
-   <b><a href="#concept-tree-previous-sibling">#concept-tree-previous-sibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-previous-sibling" class="dfn-panel" data-for="concept-tree-previous-sibling" id="infopanel-for-concept-tree-previous-sibling" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-previous-sibling" style="display:none">Info about the 'previous sibling' definition.</span><b><a href="#concept-tree-previous-sibling">#concept-tree-previous-sibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-previous-sibling">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-previous-sibling①">(2)</a> <a href="#ref-for-concept-tree-previous-sibling②">(3)</a>
     <li><a href="#ref-for-concept-tree-previous-sibling③">4.3.3. Interface MutationRecord</a>
@@ -15268,8 +15268,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-previous-sibling①⓪">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-previous-sibling①①">(2)</a> <a href="#ref-for-concept-tree-previous-sibling①②">(3)</a> <a href="#ref-for-concept-tree-previous-sibling①③">(4)</a> <a href="#ref-for-concept-tree-previous-sibling①④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-next-sibling">
-   <b><a href="#concept-tree-next-sibling">#concept-tree-next-sibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-next-sibling" class="dfn-panel" data-for="concept-tree-next-sibling" id="infopanel-for-concept-tree-next-sibling" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-next-sibling" style="display:none">Info about the 'next sibling' definition.</span><b><a href="#concept-tree-next-sibling">#concept-tree-next-sibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-next-sibling">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-next-sibling①">(2)</a> <a href="#ref-for-concept-tree-next-sibling②">(3)</a> <a href="#ref-for-concept-tree-next-sibling③">(4)</a>
     <li><a href="#ref-for-concept-tree-next-sibling④">4.2.8. Mixin ChildNode</a>
@@ -15281,8 +15281,8 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-next-sibling①⑤">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-tree-next-sibling①⑥">(2)</a> <a href="#ref-for-concept-tree-next-sibling①⑦">(3)</a> <a href="#ref-for-concept-tree-next-sibling①⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-index">
-   <b><a href="#concept-tree-index">#concept-tree-index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-index" class="dfn-panel" data-for="concept-tree-index" id="infopanel-for-concept-tree-index" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-index" style="display:none">Info about the 'index' definition.</span><b><a href="#concept-tree-index">#concept-tree-index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-index">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-index①">(2)</a> <a href="#ref-for-concept-tree-index②">(3)</a> <a href="#ref-for-concept-tree-index③">(4)</a>
     <li><a href="#ref-for-concept-tree-index④">4.4. Interface Node</a> <a href="#ref-for-concept-tree-index⑤">(2)</a> <a href="#ref-for-concept-tree-index⑥">(3)</a>
@@ -15291,41 +15291,41 @@ APIs</a>
     <li><a href="#ref-for-concept-tree-index①⓪">5.5. Interface Range</a> <a href="#ref-for-concept-tree-index①①">(2)</a> <a href="#ref-for-concept-tree-index①②">(3)</a> <a href="#ref-for-concept-tree-index①③">(4)</a> <a href="#ref-for-concept-tree-index①④">(5)</a> <a href="#ref-for-concept-tree-index①⑤">(6)</a> <a href="#ref-for-concept-tree-index①⑥">(7)</a> <a href="#ref-for-concept-tree-index①⑦">(8)</a> <a href="#ref-for-concept-tree-index①⑧">(9)</a> <a href="#ref-for-concept-tree-index①⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ordered-set-parser">
-   <b><a href="#concept-ordered-set-parser">#concept-ordered-set-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ordered-set-parser" class="dfn-panel" data-for="concept-ordered-set-parser" id="infopanel-for-concept-ordered-set-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-ordered-set-parser" style="display:none">Info about the 'ordered set parser' definition.</span><b><a href="#concept-ordered-set-parser">#concept-ordered-set-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ordered-set-parser">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-ordered-set-parser①">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ordered-set-serializer">
-   <b><a href="#concept-ordered-set-serializer">#concept-ordered-set-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ordered-set-serializer" class="dfn-panel" data-for="concept-ordered-set-serializer" id="infopanel-for-concept-ordered-set-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-ordered-set-serializer" style="display:none">Info about the 'ordered set serializer' definition.</span><b><a href="#concept-ordered-set-serializer">#concept-ordered-set-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ordered-set-serializer">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scope-match-a-selectors-string">
-   <b><a href="#scope-match-a-selectors-string">#scope-match-a-selectors-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scope-match-a-selectors-string" class="dfn-panel" data-for="scope-match-a-selectors-string" id="infopanel-for-scope-match-a-selectors-string" role="dialog">
+   <span id="infopaneltitle-for-scope-match-a-selectors-string" style="display:none">Info about the 'scope-match a selectors string' definition.</span><b><a href="#scope-match-a-selectors-string">#scope-match-a-selectors-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scope-match-a-selectors-string">4.2.6. Mixin ParentNode</a> <a href="#ref-for-scope-match-a-selectors-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate">
-   <b><a href="#validate">#validate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate" class="dfn-panel" data-for="validate" id="infopanel-for-validate" role="dialog">
+   <span id="infopaneltitle-for-validate" style="display:none">Info about the 'validate' definition.</span><b><a href="#validate">#validate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate">1.4. Namespaces</a>
     <li><a href="#ref-for-validate①">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-and-extract">
-   <b><a href="#validate-and-extract">#validate-and-extract</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-and-extract" class="dfn-panel" data-for="validate-and-extract" id="infopanel-for-validate-and-extract" role="dialog">
+   <span id="infopaneltitle-for-validate-and-extract" style="display:none">Info about the 'validate and extract' definition.</span><b><a href="#validate-and-extract">#validate-and-extract</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-and-extract">4.5. Interface Document</a> <a href="#ref-for-validate-and-extract①">(2)</a>
     <li><a href="#ref-for-validate-and-extract②">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event">
-   <b><a href="#event">#event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event" class="dfn-panel" data-for="event" id="infopanel-for-event" role="dialog">
+   <span id="infopaneltitle-for-event" style="display:none">Info about the 'Event' definition.</span><b><a href="#event">#event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-event①">2.2. Interface Event</a> <a href="#ref-for-event②">(2)</a>
@@ -15338,22 +15338,22 @@ APIs</a>
     <li><a href="#ref-for-event①⑦">4.5. Interface Document</a> <a href="#ref-for-event①⑧">(2)</a> <a href="#ref-for-event①⑨">(3)</a> <a href="#ref-for-event②⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-event">
-   <b><a href="#dom-event-event">#dom-event-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-event" class="dfn-panel" data-for="dom-event-event" id="infopanel-for-dom-event-event" role="dialog">
+   <span id="infopaneltitle-for-dom-event-event" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-event-event">#dom-event-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-event">2.2. Interface Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-eventinit">
-   <b><a href="#dictdef-eventinit">#dictdef-eventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-eventinit" class="dfn-panel" data-for="dictdef-eventinit" id="infopanel-for-dictdef-eventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' definition.</span><b><a href="#dictdef-eventinit">#dictdef-eventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">2.2. Interface Event</a>
     <li><a href="#ref-for-dictdef-eventinit①">2.4. Interface CustomEvent</a>
     <li><a href="#ref-for-dictdef-eventinit②">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event">
-   <b><a href="#concept-event">#concept-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event" class="dfn-panel" data-for="concept-event" id="infopanel-for-concept-event" role="dialog">
+   <span id="infopaneltitle-for-concept-event" style="display:none">Info about the 'event' definition.</span><b><a href="#concept-event">#concept-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-event①">(2)</a> <a href="#ref-for-concept-event②">(3)</a> <a href="#ref-for-concept-event③">(4)</a> <a href="#ref-for-concept-event④">(5)</a> <a href="#ref-for-concept-event⑤">(6)</a> <a href="#ref-for-concept-event⑥">(7)</a> <a href="#ref-for-concept-event⑦">(8)</a> <a href="#ref-for-concept-event⑧">(9)</a> <a href="#ref-for-concept-event⑨">(10)</a> <a href="#ref-for-concept-event①⓪">(11)</a> <a href="#ref-for-concept-event①①">(12)</a> <a href="#ref-for-concept-event①②">(13)</a> <a href="#ref-for-concept-event①③">(14)</a> <a href="#ref-for-concept-event①④">(15)</a> <a href="#ref-for-concept-event①⑤">(16)</a> <a href="#ref-for-concept-event①⑥">(17)</a>
     <li><a href="#ref-for-concept-event①⑦">2.2. Interface Event</a> <a href="#ref-for-concept-event①⑧">(2)</a> <a href="#ref-for-concept-event①⑨">(3)</a> <a href="#ref-for-concept-event②⓪">(4)</a> <a href="#ref-for-concept-event②①">(5)</a> <a href="#ref-for-concept-event②②">(6)</a> <a href="#ref-for-concept-event②③">(7)</a> <a href="#ref-for-concept-event②④">(8)</a> <a href="#ref-for-concept-event②⑤">(9)</a> <a href="#ref-for-concept-event②⑥">(10)</a> <a href="#ref-for-concept-event②⑦">(11)</a> <a href="#ref-for-concept-event②⑧">(12)</a> <a href="#ref-for-concept-event②⑨">(13)</a> <a href="#ref-for-concept-event③⓪">(14)</a> <a href="#ref-for-concept-event③①">(15)</a> <a href="#ref-for-concept-event③②">(16)</a> <a href="#ref-for-concept-event③③">(17)</a>
@@ -15365,89 +15365,89 @@ APIs</a>
     <li><a href="#ref-for-concept-event⑤③">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="potential-event-target">
-   <b><a href="#potential-event-target">#potential-event-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-potential-event-target" class="dfn-panel" data-for="potential-event-target" id="infopanel-for-potential-event-target" role="dialog">
+   <span id="infopaneltitle-for-potential-event-target" style="display:none">Info about the 'potential event target' definition.</span><b><a href="#potential-event-target">#potential-event-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-potential-event-target">2.2. Interface Event</a> <a href="#ref-for-potential-event-target①">(2)</a> <a href="#ref-for-potential-event-target②">(3)</a> <a href="#ref-for-potential-event-target③">(4)</a> <a href="#ref-for-potential-event-target④">(5)</a> <a href="#ref-for-potential-event-target⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-target">
-   <b><a href="#event-target">#event-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-target" class="dfn-panel" data-for="event-target" id="infopanel-for-event-target" role="dialog">
+   <span id="infopaneltitle-for-event-target" style="display:none">Info about the 'target' definition.</span><b><a href="#event-target">#event-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-target">2.2. Interface Event</a> <a href="#ref-for-event-target①">(2)</a> <a href="#ref-for-event-target②">(3)</a> <a href="#ref-for-event-target③">(4)</a> <a href="#ref-for-event-target④">(5)</a> <a href="#ref-for-event-target⑤">(6)</a> <a href="#ref-for-event-target⑥">(7)</a> <a href="#ref-for-event-target⑦">(8)</a> <a href="#ref-for-event-target⑧">(9)</a>
     <li><a href="#ref-for-event-target⑨">2.9. Dispatching events</a> <a href="#ref-for-event-target①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-relatedtarget">
-   <b><a href="#event-relatedtarget">#event-relatedtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-relatedtarget" class="dfn-panel" data-for="event-relatedtarget" id="infopanel-for-event-relatedtarget" role="dialog">
+   <span id="infopaneltitle-for-event-relatedtarget" style="display:none">Info about the 'relatedTarget' definition.</span><b><a href="#event-relatedtarget">#event-relatedtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-relatedtarget">2.2. Interface Event</a>
     <li><a href="#ref-for-event-relatedtarget①">2.9. Dispatching events</a> <a href="#ref-for-event-relatedtarget②">(2)</a> <a href="#ref-for-event-relatedtarget③">(3)</a> <a href="#ref-for-event-relatedtarget④">(4)</a> <a href="#ref-for-event-relatedtarget⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-touch-target-list">
-   <b><a href="#event-touch-target-list">#event-touch-target-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-touch-target-list" class="dfn-panel" data-for="event-touch-target-list" id="infopanel-for-event-touch-target-list" role="dialog">
+   <span id="infopaneltitle-for-event-touch-target-list" style="display:none">Info about the 'touch target list' definition.</span><b><a href="#event-touch-target-list">#event-touch-target-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-touch-target-list">2.2. Interface Event</a>
     <li><a href="#ref-for-event-touch-target-list①">2.9. Dispatching events</a> <a href="#ref-for-event-touch-target-list②">(2)</a> <a href="#ref-for-event-touch-target-list③">(3)</a> <a href="#ref-for-event-touch-target-list④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path">
-   <b><a href="#event-path">#event-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path" class="dfn-panel" data-for="event-path" id="infopanel-for-event-path" role="dialog">
+   <span id="infopaneltitle-for-event-path" style="display:none">Info about the 'path' definition.</span><b><a href="#event-path">#event-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path">2.2. Interface Event</a> <a href="#ref-for-event-path①">(2)</a> <a href="#ref-for-event-path②">(3)</a> <a href="#ref-for-event-path③">(4)</a>
     <li><a href="#ref-for-event-path④">2.9. Dispatching events</a> <a href="#ref-for-event-path⑤">(2)</a> <a href="#ref-for-event-path⑥">(3)</a> <a href="#ref-for-event-path⑦">(4)</a> <a href="#ref-for-event-path⑧">(5)</a> <a href="#ref-for-event-path⑨">(6)</a>
     <li><a href="#ref-for-event-path①⓪">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-invocation-target">
-   <b><a href="#event-path-invocation-target">#event-path-invocation-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-invocation-target" class="dfn-panel" data-for="event-path-invocation-target" id="infopanel-for-event-path-invocation-target" role="dialog">
+   <span id="infopaneltitle-for-event-path-invocation-target" style="display:none">Info about the 'invocation target' definition.</span><b><a href="#event-path-invocation-target">#event-path-invocation-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-invocation-target">2.2. Interface Event</a> <a href="#ref-for-event-path-invocation-target①">(2)</a> <a href="#ref-for-event-path-invocation-target②">(3)</a> <a href="#ref-for-event-path-invocation-target③">(4)</a>
     <li><a href="#ref-for-event-path-invocation-target④">2.9. Dispatching events</a> <a href="#ref-for-event-path-invocation-target⑤">(2)</a>
     <li><a href="#ref-for-event-path-invocation-target⑥">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-invocation-target-in-shadow-tree">
-   <b><a href="#event-path-invocation-target-in-shadow-tree">#event-path-invocation-target-in-shadow-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-invocation-target-in-shadow-tree" class="dfn-panel" data-for="event-path-invocation-target-in-shadow-tree" id="infopanel-for-event-path-invocation-target-in-shadow-tree" role="dialog">
+   <span id="infopaneltitle-for-event-path-invocation-target-in-shadow-tree" style="display:none">Info about the 'invocation-target-in-shadow-tree' definition.</span><b><a href="#event-path-invocation-target-in-shadow-tree">#event-path-invocation-target-in-shadow-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-invocation-target-in-shadow-tree">2.9. Dispatching events</a> <a href="#ref-for-event-path-invocation-target-in-shadow-tree①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-shadow-adjusted-target">
-   <b><a href="#event-path-shadow-adjusted-target">#event-path-shadow-adjusted-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-shadow-adjusted-target" class="dfn-panel" data-for="event-path-shadow-adjusted-target" id="infopanel-for-event-path-shadow-adjusted-target" role="dialog">
+   <span id="infopaneltitle-for-event-path-shadow-adjusted-target" style="display:none">Info about the 'shadow-adjusted target' definition.</span><b><a href="#event-path-shadow-adjusted-target">#event-path-shadow-adjusted-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-shadow-adjusted-target">2.9. Dispatching events</a> <a href="#ref-for-event-path-shadow-adjusted-target①">(2)</a> <a href="#ref-for-event-path-shadow-adjusted-target②">(3)</a> <a href="#ref-for-event-path-shadow-adjusted-target③">(4)</a> <a href="#ref-for-event-path-shadow-adjusted-target④">(5)</a> <a href="#ref-for-event-path-shadow-adjusted-target⑤">(6)</a> <a href="#ref-for-event-path-shadow-adjusted-target⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-relatedtarget">
-   <b><a href="#event-path-relatedtarget">#event-path-relatedtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-relatedtarget" class="dfn-panel" data-for="event-path-relatedtarget" id="infopanel-for-event-path-relatedtarget" role="dialog">
+   <span id="infopaneltitle-for-event-path-relatedtarget" style="display:none">Info about the 'relatedTarget' definition.</span><b><a href="#event-path-relatedtarget">#event-path-relatedtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-relatedtarget">2.9. Dispatching events</a> <a href="#ref-for-event-path-relatedtarget①">(2)</a> <a href="#ref-for-event-path-relatedtarget②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-touch-target-list">
-   <b><a href="#event-path-touch-target-list">#event-path-touch-target-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-touch-target-list" class="dfn-panel" data-for="event-path-touch-target-list" id="infopanel-for-event-path-touch-target-list" role="dialog">
+   <span id="infopaneltitle-for-event-path-touch-target-list" style="display:none">Info about the 'touch target list' definition.</span><b><a href="#event-path-touch-target-list">#event-path-touch-target-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-touch-target-list">2.9. Dispatching events</a> <a href="#ref-for-event-path-touch-target-list①">(2)</a> <a href="#ref-for-event-path-touch-target-list②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-root-of-closed-tree">
-   <b><a href="#event-path-root-of-closed-tree">#event-path-root-of-closed-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-root-of-closed-tree" class="dfn-panel" data-for="event-path-root-of-closed-tree" id="infopanel-for-event-path-root-of-closed-tree" role="dialog">
+   <span id="infopaneltitle-for-event-path-root-of-closed-tree" style="display:none">Info about the 'root-of-closed-tree' definition.</span><b><a href="#event-path-root-of-closed-tree">#event-path-root-of-closed-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-root-of-closed-tree">2.2. Interface Event</a> <a href="#ref-for-event-path-root-of-closed-tree①">(2)</a> <a href="#ref-for-event-path-root-of-closed-tree②">(3)</a>
     <li><a href="#ref-for-event-path-root-of-closed-tree③">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-path-slot-in-closed-tree">
-   <b><a href="#event-path-slot-in-closed-tree">#event-path-slot-in-closed-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-path-slot-in-closed-tree" class="dfn-panel" data-for="event-path-slot-in-closed-tree" id="infopanel-for-event-path-slot-in-closed-tree" role="dialog">
+   <span id="infopaneltitle-for-event-path-slot-in-closed-tree" style="display:none">Info about the 'slot-in-closed-tree' definition.</span><b><a href="#event-path-slot-in-closed-tree">#event-path-slot-in-closed-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-path-slot-in-closed-tree">2.2. Interface Event</a> <a href="#ref-for-event-path-slot-in-closed-tree①">(2)</a> <a href="#ref-for-event-path-slot-in-closed-tree②">(3)</a>
     <li><a href="#ref-for-event-path-slot-in-closed-tree③">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-type">
-   <b><a href="#dom-event-type">#dom-event-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-type" class="dfn-panel" data-for="dom-event-type" id="infopanel-for-dom-event-type" role="dialog">
+   <span id="infopaneltitle-for-dom-event-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-event-type">#dom-event-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-dom-event-type①">(2)</a>
     <li><a href="#ref-for-dom-event-type②">2.2. Interface Event</a> <a href="#ref-for-dom-event-type③">(2)</a> <a href="#ref-for-dom-event-type④">(3)</a> <a href="#ref-for-dom-event-type⑤">(4)</a>
@@ -15458,35 +15458,35 @@ APIs</a>
     <li><a href="#ref-for-dom-event-type①⑦">4.5. Interface Document</a> <a href="#ref-for-dom-event-type①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-target">
-   <b><a href="#dom-event-target">#dom-event-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-target" class="dfn-panel" data-for="dom-event-target" id="infopanel-for-dom-event-target" role="dialog">
+   <span id="infopaneltitle-for-dom-event-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-event-target">#dom-event-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-target">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-dom-event-target①">(2)</a>
     <li><a href="#ref-for-dom-event-target②">2.2. Interface Event</a> <a href="#ref-for-dom-event-target③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-srcelement">
-   <b><a href="#dom-event-srcelement">#dom-event-srcelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-srcelement" class="dfn-panel" data-for="dom-event-srcelement" id="infopanel-for-dom-event-srcelement" role="dialog">
+   <span id="infopaneltitle-for-dom-event-srcelement" style="display:none">Info about the 'srcElement' definition.</span><b><a href="#dom-event-srcelement">#dom-event-srcelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-srcelement">2.2. Interface Event</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-currenttarget">
-   <b><a href="#dom-event-currenttarget">#dom-event-currenttarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-currenttarget" class="dfn-panel" data-for="dom-event-currenttarget" id="infopanel-for-dom-event-currenttarget" role="dialog">
+   <span id="infopaneltitle-for-dom-event-currenttarget" style="display:none">Info about the 'currentTarget' definition.</span><b><a href="#dom-event-currenttarget">#dom-event-currenttarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-currenttarget">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-currenttarget①">2.2. Interface Event</a> <a href="#ref-for-dom-event-currenttarget②">(2)</a> <a href="#ref-for-dom-event-currenttarget③">(3)</a> <a href="#ref-for-dom-event-currenttarget④">(4)</a>
     <li><a href="#ref-for-dom-event-currenttarget⑤">2.9. Dispatching events</a> <a href="#ref-for-dom-event-currenttarget⑥">(2)</a> <a href="#ref-for-dom-event-currenttarget⑦">(3)</a> <a href="#ref-for-dom-event-currenttarget⑧">(4)</a> <a href="#ref-for-dom-event-currenttarget⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-composedpath">
-   <b><a href="#dom-event-composedpath">#dom-event-composedpath</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-composedpath" class="dfn-panel" data-for="dom-event-composedpath" id="infopanel-for-dom-event-composedpath" role="dialog">
+   <span id="infopaneltitle-for-dom-event-composedpath" style="display:none">Info about the 'composedPath()' definition.</span><b><a href="#dom-event-composedpath">#dom-event-composedpath</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-composedpath">2.2. Interface Event</a> <a href="#ref-for-dom-event-composedpath①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-eventphase">
-   <b><a href="#dom-event-eventphase">#dom-event-eventphase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-eventphase" class="dfn-panel" data-for="dom-event-eventphase" id="infopanel-for-dom-event-eventphase" role="dialog">
+   <span id="infopaneltitle-for-dom-event-eventphase" style="display:none">Info about the 'eventPhase' definition.</span><b><a href="#dom-event-eventphase">#dom-event-eventphase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-eventphase">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-dom-event-eventphase①">(2)</a>
     <li><a href="#ref-for-dom-event-eventphase②">2.2. Interface Event</a> <a href="#ref-for-dom-event-eventphase③">(2)</a>
@@ -15494,15 +15494,15 @@ APIs</a>
     <li><a href="#ref-for-dom-event-eventphase⑦">2.9. Dispatching events</a> <a href="#ref-for-dom-event-eventphase⑧">(2)</a> <a href="#ref-for-dom-event-eventphase⑨">(3)</a> <a href="#ref-for-dom-event-eventphase①⓪">(4)</a> <a href="#ref-for-dom-event-eventphase①①">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-none">
-   <b><a href="#dom-event-none">#dom-event-none</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-none" class="dfn-panel" data-for="dom-event-none" id="infopanel-for-dom-event-none" role="dialog">
+   <span id="infopaneltitle-for-dom-event-none" style="display:none">Info about the 'NONE' definition.</span><b><a href="#dom-event-none">#dom-event-none</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-none">2.2. Interface Event</a> <a href="#ref-for-dom-event-none①">(2)</a> <a href="#ref-for-dom-event-none②">(3)</a>
     <li><a href="#ref-for-dom-event-none③">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-capturing_phase">
-   <b><a href="#dom-event-capturing_phase">#dom-event-capturing_phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-capturing_phase" class="dfn-panel" data-for="dom-event-capturing_phase" id="infopanel-for-dom-event-capturing_phase" role="dialog">
+   <span id="infopaneltitle-for-dom-event-capturing_phase" style="display:none">Info about the 'CAPTURING_PHASE' definition.</span><b><a href="#dom-event-capturing_phase">#dom-event-capturing_phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-capturing_phase">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-capturing_phase①">2.2. Interface Event</a> <a href="#ref-for-dom-event-capturing_phase②">(2)</a>
@@ -15510,8 +15510,8 @@ APIs</a>
     <li><a href="#ref-for-dom-event-capturing_phase④">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-at_target">
-   <b><a href="#dom-event-at_target">#dom-event-at_target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-at_target" class="dfn-panel" data-for="dom-event-at_target" id="infopanel-for-dom-event-at_target" role="dialog">
+   <span id="infopaneltitle-for-dom-event-at_target" style="display:none">Info about the 'AT_TARGET' definition.</span><b><a href="#dom-event-at_target">#dom-event-at_target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-at_target">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-at_target①">2.2. Interface Event</a> <a href="#ref-for-dom-event-at_target②">(2)</a>
@@ -15519,8 +15519,8 @@ APIs</a>
     <li><a href="#ref-for-dom-event-at_target④">2.9. Dispatching events</a> <a href="#ref-for-dom-event-at_target⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-bubbling_phase">
-   <b><a href="#dom-event-bubbling_phase">#dom-event-bubbling_phase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-bubbling_phase" class="dfn-panel" data-for="dom-event-bubbling_phase" id="infopanel-for-dom-event-bubbling_phase" role="dialog">
+   <span id="infopaneltitle-for-dom-event-bubbling_phase" style="display:none">Info about the 'BUBBLING_PHASE' definition.</span><b><a href="#dom-event-bubbling_phase">#dom-event-bubbling_phase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbling_phase">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-bubbling_phase①">2.2. Interface Event</a> <a href="#ref-for-dom-event-bubbling_phase②">(2)</a>
@@ -15528,43 +15528,43 @@ APIs</a>
     <li><a href="#ref-for-dom-event-bubbling_phase④">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stop-propagation-flag">
-   <b><a href="#stop-propagation-flag">#stop-propagation-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stop-propagation-flag" class="dfn-panel" data-for="stop-propagation-flag" id="infopanel-for-stop-propagation-flag" role="dialog">
+   <span id="infopaneltitle-for-stop-propagation-flag" style="display:none">Info about the 'stop propagation flag' definition.</span><b><a href="#stop-propagation-flag">#stop-propagation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-propagation-flag">2.2. Interface Event</a> <a href="#ref-for-stop-propagation-flag①">(2)</a> <a href="#ref-for-stop-propagation-flag②">(3)</a> <a href="#ref-for-stop-propagation-flag③">(4)</a> <a href="#ref-for-stop-propagation-flag④">(5)</a>
     <li><a href="#ref-for-stop-propagation-flag⑤">2.9. Dispatching events</a> <a href="#ref-for-stop-propagation-flag⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stop-immediate-propagation-flag">
-   <b><a href="#stop-immediate-propagation-flag">#stop-immediate-propagation-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stop-immediate-propagation-flag" class="dfn-panel" data-for="stop-immediate-propagation-flag" id="infopanel-for-stop-immediate-propagation-flag" role="dialog">
+   <span id="infopaneltitle-for-stop-immediate-propagation-flag" style="display:none">Info about the 'stop immediate propagation flag' definition.</span><b><a href="#stop-immediate-propagation-flag">#stop-immediate-propagation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stop-immediate-propagation-flag">2.2. Interface Event</a> <a href="#ref-for-stop-immediate-propagation-flag①">(2)</a>
     <li><a href="#ref-for-stop-immediate-propagation-flag②">2.9. Dispatching events</a> <a href="#ref-for-stop-immediate-propagation-flag③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="canceled-flag">
-   <b><a href="#canceled-flag">#canceled-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-canceled-flag" class="dfn-panel" data-for="canceled-flag" id="infopanel-for-canceled-flag" role="dialog">
+   <span id="infopaneltitle-for-canceled-flag" style="display:none">Info about the 'canceled flag' definition.</span><b><a href="#canceled-flag">#canceled-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-canceled-flag">2.2. Interface Event</a> <a href="#ref-for-canceled-flag①">(2)</a> <a href="#ref-for-canceled-flag②">(3)</a> <a href="#ref-for-canceled-flag③">(4)</a>
     <li><a href="#ref-for-canceled-flag④">2.9. Dispatching events</a> <a href="#ref-for-canceled-flag⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-passive-listener-flag">
-   <b><a href="#in-passive-listener-flag">#in-passive-listener-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-passive-listener-flag" class="dfn-panel" data-for="in-passive-listener-flag" id="infopanel-for-in-passive-listener-flag" role="dialog">
+   <span id="infopaneltitle-for-in-passive-listener-flag" style="display:none">Info about the 'in passive listener flag' definition.</span><b><a href="#in-passive-listener-flag">#in-passive-listener-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-passive-listener-flag">2.2. Interface Event</a>
     <li><a href="#ref-for-in-passive-listener-flag①">2.9. Dispatching events</a> <a href="#ref-for-in-passive-listener-flag②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="composed-flag">
-   <b><a href="#composed-flag">#composed-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-composed-flag" class="dfn-panel" data-for="composed-flag" id="infopanel-for-composed-flag" role="dialog">
+   <span id="infopaneltitle-for-composed-flag" style="display:none">Info about the 'composed flag' definition.</span><b><a href="#composed-flag">#composed-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-composed-flag">2.2. Interface Event</a>
     <li><a href="#ref-for-composed-flag①">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialized-flag">
-   <b><a href="#initialized-flag">#initialized-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialized-flag" class="dfn-panel" data-for="initialized-flag" id="infopanel-for-initialized-flag" role="dialog">
+   <span id="infopaneltitle-for-initialized-flag" style="display:none">Info about the 'initialized flag' definition.</span><b><a href="#initialized-flag">#initialized-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialized-flag">2.2. Interface Event</a>
     <li><a href="#ref-for-initialized-flag①">2.5. Constructing events</a>
@@ -15572,8 +15572,8 @@ APIs</a>
     <li><a href="#ref-for-initialized-flag③">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dispatch-flag">
-   <b><a href="#dispatch-flag">#dispatch-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dispatch-flag" class="dfn-panel" data-for="dispatch-flag" id="infopanel-for-dispatch-flag" role="dialog">
+   <span id="infopaneltitle-for-dispatch-flag" style="display:none">Info about the 'dispatch flag' definition.</span><b><a href="#dispatch-flag">#dispatch-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dispatch-flag">2.2. Interface Event</a>
     <li><a href="#ref-for-dispatch-flag①">2.4. Interface CustomEvent</a>
@@ -15581,26 +15581,26 @@ APIs</a>
     <li><a href="#ref-for-dispatch-flag③">2.9. Dispatching events</a> <a href="#ref-for-dispatch-flag④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-stoppropagation">
-   <b><a href="#dom-event-stoppropagation">#dom-event-stoppropagation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-stoppropagation" class="dfn-panel" data-for="dom-event-stoppropagation" id="infopanel-for-dom-event-stoppropagation" role="dialog">
+   <span id="infopaneltitle-for-dom-event-stoppropagation" style="display:none">Info about the 'stopPropagation()' definition.</span><b><a href="#dom-event-stoppropagation">#dom-event-stoppropagation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-stoppropagation">2.2. Interface Event</a> <a href="#ref-for-dom-event-stoppropagation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-cancelbubble">
-   <b><a href="#dom-event-cancelbubble">#dom-event-cancelbubble</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-cancelbubble" class="dfn-panel" data-for="dom-event-cancelbubble" id="infopanel-for-dom-event-cancelbubble" role="dialog">
+   <span id="infopaneltitle-for-dom-event-cancelbubble" style="display:none">Info about the 'cancelBubble' definition.</span><b><a href="#dom-event-cancelbubble">#dom-event-cancelbubble</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelbubble">2.2. Interface Event</a> <a href="#ref-for-dom-event-cancelbubble①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-stopimmediatepropagation">
-   <b><a href="#dom-event-stopimmediatepropagation">#dom-event-stopimmediatepropagation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-stopimmediatepropagation" class="dfn-panel" data-for="dom-event-stopimmediatepropagation" id="infopanel-for-dom-event-stopimmediatepropagation" role="dialog">
+   <span id="infopaneltitle-for-dom-event-stopimmediatepropagation" style="display:none">Info about the 'stopImmediatePropagation()' definition.</span><b><a href="#dom-event-stopimmediatepropagation">#dom-event-stopimmediatepropagation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-stopimmediatepropagation">2.2. Interface Event</a> <a href="#ref-for-dom-event-stopimmediatepropagation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-bubbles">
-   <b><a href="#dom-event-bubbles">#dom-event-bubbles</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-bubbles" class="dfn-panel" data-for="dom-event-bubbles" id="infopanel-for-dom-event-bubbles" role="dialog">
+   <span id="infopaneltitle-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' definition.</span><b><a href="#dom-event-bubbles">#dom-event-bubbles</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-bubbles①">2.2. Interface Event</a> <a href="#ref-for-dom-event-bubbles②">(2)</a> <a href="#ref-for-dom-event-bubbles③">(3)</a> <a href="#ref-for-dom-event-bubbles④">(4)</a>
@@ -15609,8 +15609,8 @@ APIs</a>
     <li><a href="#ref-for-dom-event-bubbles⑧">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-cancelable">
-   <b><a href="#dom-event-cancelable">#dom-event-cancelable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-cancelable" class="dfn-panel" data-for="dom-event-cancelable" id="infopanel-for-dom-event-cancelable" role="dialog">
+   <span id="infopaneltitle-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' definition.</span><b><a href="#dom-event-cancelable">#dom-event-cancelable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">2.2. Interface Event</a> <a href="#ref-for-dom-event-cancelable①">(2)</a> <a href="#ref-for-dom-event-cancelable②">(3)</a> <a href="#ref-for-dom-event-cancelable③">(4)</a> <a href="#ref-for-dom-event-cancelable④">(5)</a> <a href="#ref-for-dom-event-cancelable⑤">(6)</a>
     <li><a href="#ref-for-dom-event-cancelable⑥">2.7. Interface EventTarget</a>
@@ -15618,20 +15618,20 @@ APIs</a>
     <li><a href="#ref-for-dom-event-cancelable⑨">2.10. Firing events</a> <a href="#ref-for-dom-event-cancelable①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-canceled-flag">
-   <b><a href="#set-the-canceled-flag">#set-the-canceled-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-canceled-flag" class="dfn-panel" data-for="set-the-canceled-flag" id="infopanel-for-set-the-canceled-flag" role="dialog">
+   <span id="infopaneltitle-for-set-the-canceled-flag" style="display:none">Info about the 'set the canceled flag' definition.</span><b><a href="#set-the-canceled-flag">#set-the-canceled-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-canceled-flag">2.2. Interface Event</a> <a href="#ref-for-set-the-canceled-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-returnvalue">
-   <b><a href="#dom-event-returnvalue">#dom-event-returnvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-returnvalue" class="dfn-panel" data-for="dom-event-returnvalue" id="infopanel-for-dom-event-returnvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-event-returnvalue" style="display:none">Info about the 'returnValue' definition.</span><b><a href="#dom-event-returnvalue">#dom-event-returnvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-returnvalue">2.2. Interface Event</a> <a href="#ref-for-dom-event-returnvalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-preventdefault">
-   <b><a href="#dom-event-preventdefault">#dom-event-preventdefault</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-preventdefault" class="dfn-panel" data-for="dom-event-preventdefault" id="infopanel-for-dom-event-preventdefault" role="dialog">
+   <span id="infopaneltitle-for-dom-event-preventdefault" style="display:none">Info about the 'preventDefault()' definition.</span><b><a href="#dom-event-preventdefault">#dom-event-preventdefault</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-preventdefault">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-event-preventdefault①">2.2. Interface Event</a> <a href="#ref-for-dom-event-preventdefault②">(2)</a> <a href="#ref-for-dom-event-preventdefault③">(3)</a> <a href="#ref-for-dom-event-preventdefault④">(4)</a> <a href="#ref-for-dom-event-preventdefault⑤">(5)</a>
@@ -15640,20 +15640,20 @@ APIs</a>
     <li><a href="#ref-for-dom-event-preventdefault⑨">2.11. Action versus occurrence</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-defaultprevented">
-   <b><a href="#dom-event-defaultprevented">#dom-event-defaultprevented</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-defaultprevented" class="dfn-panel" data-for="dom-event-defaultprevented" id="infopanel-for-dom-event-defaultprevented" role="dialog">
+   <span id="infopaneltitle-for-dom-event-defaultprevented" style="display:none">Info about the 'defaultPrevented' definition.</span><b><a href="#dom-event-defaultprevented">#dom-event-defaultprevented</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-defaultprevented">2.2. Interface Event</a> <a href="#ref-for-dom-event-defaultprevented①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-composed">
-   <b><a href="#dom-event-composed">#dom-event-composed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-composed" class="dfn-panel" data-for="dom-event-composed" id="infopanel-for-dom-event-composed" role="dialog">
+   <span id="infopaneltitle-for-dom-event-composed" style="display:none">Info about the 'composed' definition.</span><b><a href="#dom-event-composed">#dom-event-composed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-composed">2.2. Interface Event</a> <a href="#ref-for-dom-event-composed①">(2)</a> <a href="#ref-for-dom-event-composed②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-istrusted">
-   <b><a href="#dom-event-istrusted">#dom-event-istrusted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-istrusted" class="dfn-panel" data-for="dom-event-istrusted" id="infopanel-for-dom-event-istrusted" role="dialog">
+   <span id="infopaneltitle-for-dom-event-istrusted" style="display:none">Info about the 'isTrusted' definition.</span><b><a href="#dom-event-istrusted">#dom-event-istrusted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-istrusted">2.2. Interface Event</a> <a href="#ref-for-dom-event-istrusted①">(2)</a> <a href="#ref-for-dom-event-istrusted②">(3)</a> <a href="#ref-for-dom-event-istrusted③">(4)</a> <a href="#ref-for-dom-event-istrusted④">(5)</a>
     <li><a href="#ref-for-dom-event-istrusted⑤">2.5. Constructing events</a>
@@ -15663,94 +15663,94 @@ APIs</a>
     <li><a href="#ref-for-dom-event-istrusted⑨">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-timestamp">
-   <b><a href="#dom-event-timestamp">#dom-event-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-timestamp" class="dfn-panel" data-for="dom-event-timestamp" id="infopanel-for-dom-event-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-event-timestamp" style="display:none">Info about the 'timeStamp' definition.</span><b><a href="#dom-event-timestamp">#dom-event-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-timestamp">2.2. Interface Event</a> <a href="#ref-for-dom-event-timestamp①">(2)</a>
     <li><a href="#ref-for-dom-event-timestamp②">2.5. Constructing events</a> <a href="#ref-for-dom-event-timestamp③">(2)</a>
     <li><a href="#ref-for-dom-event-timestamp④">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-initialize">
-   <b><a href="#concept-event-initialize">#concept-event-initialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-initialize" class="dfn-panel" data-for="concept-event-initialize" id="infopanel-for-concept-event-initialize" role="dialog">
+   <span id="infopaneltitle-for-concept-event-initialize" style="display:none">Info about the 'initialize' definition.</span><b><a href="#concept-event-initialize">#concept-event-initialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-initialize">2.2. Interface Event</a>
     <li><a href="#ref-for-concept-event-initialize①">2.4. Interface CustomEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-event-initevent">
-   <b><a href="#dom-event-initevent">#dom-event-initevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-event-initevent" class="dfn-panel" data-for="dom-event-initevent" id="infopanel-for-dom-event-initevent" role="dialog">
+   <span id="infopaneltitle-for-dom-event-initevent" style="display:none">Info about the 'initEvent(type, bubbles, cancelable)' definition.</span><b><a href="#dom-event-initevent">#dom-event-initevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-initevent">2.2. Interface Event</a> <a href="#ref-for-dom-event-initevent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="window-current-event">
-   <b><a href="#window-current-event">#window-current-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-window-current-event" class="dfn-panel" data-for="window-current-event" id="infopanel-for-window-current-event" role="dialog">
+   <span id="infopaneltitle-for-window-current-event" style="display:none">Info about the 'current event' definition.</span><b><a href="#window-current-event">#window-current-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-current-event">2.3. Legacy extensions to the Window interface</a>
     <li><a href="#ref-for-window-current-event①">2.9. Dispatching events</a> <a href="#ref-for-window-current-event②">(2)</a> <a href="#ref-for-window-current-event③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-window-event">
-   <b><a href="#dom-window-event">#dom-window-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-window-event" class="dfn-panel" data-for="dom-window-event" id="infopanel-for-dom-window-event" role="dialog">
+   <span id="infopaneltitle-for-dom-window-event" style="display:none">Info about the 'event' definition.</span><b><a href="#dom-window-event">#dom-window-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-event">2.3. Legacy extensions to the Window interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="customevent">
-   <b><a href="#customevent">#customevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-customevent" class="dfn-panel" data-for="customevent" id="infopanel-for-customevent" role="dialog">
+   <span id="infopaneltitle-for-customevent" style="display:none">Info about the 'CustomEvent' definition.</span><b><a href="#customevent">#customevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-customevent">2.4. Interface CustomEvent</a> <a href="#ref-for-customevent①">(2)</a>
     <li><a href="#ref-for-customevent②">2.6. Defining event interfaces</a>
     <li><a href="#ref-for-customevent③">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-customevent-customevent">
-   <b><a href="#dom-customevent-customevent">#dom-customevent-customevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-customevent-customevent" class="dfn-panel" data-for="dom-customevent-customevent" id="infopanel-for-dom-customevent-customevent" role="dialog">
+   <span id="infopaneltitle-for-dom-customevent-customevent" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-customevent-customevent">#dom-customevent-customevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-customevent-customevent">2.4. Interface CustomEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-customeventinit">
-   <b><a href="#dictdef-customeventinit">#dictdef-customeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-customeventinit" class="dfn-panel" data-for="dictdef-customeventinit" id="infopanel-for-dictdef-customeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-customeventinit" style="display:none">Info about the 'CustomEventInit' definition.</span><b><a href="#dictdef-customeventinit">#dictdef-customeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-customeventinit">2.4. Interface CustomEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-customevent-detail">
-   <b><a href="#dom-customevent-detail">#dom-customevent-detail</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-customevent-detail" class="dfn-panel" data-for="dom-customevent-detail" id="infopanel-for-dom-customevent-detail" role="dialog">
+   <span id="infopaneltitle-for-dom-customevent-detail" style="display:none">Info about the 'detail' definition.</span><b><a href="#dom-customevent-detail">#dom-customevent-detail</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-customevent-detail">2.4. Interface CustomEvent</a> <a href="#ref-for-dom-customevent-detail①">(2)</a> <a href="#ref-for-dom-customevent-detail②">(3)</a> <a href="#ref-for-dom-customevent-detail③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-customevent-initcustomevent">
-   <b><a href="#dom-customevent-initcustomevent">#dom-customevent-initcustomevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-customevent-initcustomevent" class="dfn-panel" data-for="dom-customevent-initcustomevent" id="infopanel-for-dom-customevent-initcustomevent" role="dialog">
+   <span id="infopaneltitle-for-dom-customevent-initcustomevent" style="display:none">Info about the 'initCustomEvent(type, bubbles, cancelable, detail)' definition.</span><b><a href="#dom-customevent-initcustomevent">#dom-customevent-initcustomevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-customevent-initcustomevent">2.4. Interface CustomEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-constructor-ext">
-   <b><a href="#concept-event-constructor-ext">#concept-event-constructor-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-constructor-ext" class="dfn-panel" data-for="concept-event-constructor-ext" id="infopanel-for-concept-event-constructor-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-event-constructor-ext" style="display:none">Info about the 'event constructing steps' definition.</span><b><a href="#concept-event-constructor-ext">#concept-event-constructor-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-constructor-ext">2.5. Constructing events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-create">
-   <b><a href="#concept-event-create">#concept-event-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-create" class="dfn-panel" data-for="concept-event-create" id="infopanel-for-concept-event-create" role="dialog">
+   <span id="infopaneltitle-for-concept-event-create" style="display:none">Info about the 'create an event' definition.</span><b><a href="#concept-event-create">#concept-event-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-create">2.5. Constructing events</a> <a href="#ref-for-concept-event-create①">(2)</a>
     <li><a href="#ref-for-concept-event-create②">2.10. Firing events</a> <a href="#ref-for-concept-event-create③">(2)</a>
     <li><a href="#ref-for-concept-event-create④">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="inner-event-creation-steps">
-   <b><a href="#inner-event-creation-steps">#inner-event-creation-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-inner-event-creation-steps" class="dfn-panel" data-for="inner-event-creation-steps" id="infopanel-for-inner-event-creation-steps" role="dialog">
+   <span id="infopaneltitle-for-inner-event-creation-steps" style="display:none">Info about the 'inner event creation steps' definition.</span><b><a href="#inner-event-creation-steps">#inner-event-creation-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inner-event-creation-steps">2.5. Constructing events</a> <a href="#ref-for-inner-event-creation-steps①">(2)</a> <a href="#ref-for-inner-event-creation-steps②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventtarget">
-   <b><a href="#eventtarget">#eventtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventtarget" class="dfn-panel" data-for="eventtarget" id="infopanel-for-eventtarget" role="dialog">
+   <span id="infopaneltitle-for-eventtarget" style="display:none">Info about the 'EventTarget' definition.</span><b><a href="#eventtarget">#eventtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-eventtarget①">2.2. Interface Event</a> <a href="#ref-for-eventtarget②">(2)</a> <a href="#ref-for-eventtarget③">(3)</a> <a href="#ref-for-eventtarget④">(4)</a> <a href="#ref-for-eventtarget⑤">(5)</a> <a href="#ref-for-eventtarget⑥">(6)</a>
@@ -15760,59 +15760,59 @@ APIs</a>
     <li><a href="#ref-for-eventtarget②③">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-eventlistener">
-   <b><a href="#callbackdef-eventlistener">#callbackdef-eventlistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-eventlistener" class="dfn-panel" data-for="callbackdef-eventlistener" id="infopanel-for-callbackdef-eventlistener" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-eventlistener" style="display:none">Info about the 'EventListener' definition.</span><b><a href="#callbackdef-eventlistener">#callbackdef-eventlistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-eventlistener">2.7. Interface EventTarget</a> <a href="#ref-for-callbackdef-eventlistener①">(2)</a> <a href="#ref-for-callbackdef-eventlistener②">(3)</a> <a href="#ref-for-callbackdef-eventlistener③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-eventlisteneroptions">
-   <b><a href="#dictdef-eventlisteneroptions">#dictdef-eventlisteneroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-eventlisteneroptions" class="dfn-panel" data-for="dictdef-eventlisteneroptions" id="infopanel-for-dictdef-eventlisteneroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-eventlisteneroptions" style="display:none">Info about the 'EventListenerOptions' definition.</span><b><a href="#dictdef-eventlisteneroptions">#dictdef-eventlisteneroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventlisteneroptions">2.7. Interface EventTarget</a> <a href="#ref-for-dictdef-eventlisteneroptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventlisteneroptions-capture">
-   <b><a href="#dom-eventlisteneroptions-capture">#dom-eventlisteneroptions-capture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventlisteneroptions-capture" class="dfn-panel" data-for="dom-eventlisteneroptions-capture" id="infopanel-for-dom-eventlisteneroptions-capture" role="dialog">
+   <span id="infopaneltitle-for-dom-eventlisteneroptions-capture" style="display:none">Info about the 'capture' definition.</span><b><a href="#dom-eventlisteneroptions-capture">#dom-eventlisteneroptions-capture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventlisteneroptions-capture">2.7. Interface EventTarget</a> <a href="#ref-for-dom-eventlisteneroptions-capture①">(2)</a> <a href="#ref-for-dom-eventlisteneroptions-capture②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-addeventlisteneroptions">
-   <b><a href="#dictdef-addeventlisteneroptions">#dictdef-addeventlisteneroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-addeventlisteneroptions" class="dfn-panel" data-for="dictdef-addeventlisteneroptions" id="infopanel-for-dictdef-addeventlisteneroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-addeventlisteneroptions" style="display:none">Info about the 'AddEventListenerOptions' definition.</span><b><a href="#dictdef-addeventlisteneroptions">#dictdef-addeventlisteneroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-addeventlisteneroptions">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-addeventlisteneroptions-passive">
-   <b><a href="#dom-addeventlisteneroptions-passive">#dom-addeventlisteneroptions-passive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-addeventlisteneroptions-passive" class="dfn-panel" data-for="dom-addeventlisteneroptions-passive" id="infopanel-for-dom-addeventlisteneroptions-passive" role="dialog">
+   <span id="infopaneltitle-for-dom-addeventlisteneroptions-passive" style="display:none">Info about the 'passive' definition.</span><b><a href="#dom-addeventlisteneroptions-passive">#dom-addeventlisteneroptions-passive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-addeventlisteneroptions-passive">2.2. Interface Event</a>
     <li><a href="#ref-for-dom-addeventlisteneroptions-passive①">2.7. Interface EventTarget</a> <a href="#ref-for-dom-addeventlisteneroptions-passive②">(2)</a>
     <li><a href="#ref-for-dom-addeventlisteneroptions-passive③">2.8. Observing event listeners</a> <a href="#ref-for-dom-addeventlisteneroptions-passive④">(2)</a> <a href="#ref-for-dom-addeventlisteneroptions-passive⑤">(3)</a> <a href="#ref-for-dom-addeventlisteneroptions-passive⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-addeventlisteneroptions-once">
-   <b><a href="#dom-addeventlisteneroptions-once">#dom-addeventlisteneroptions-once</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-addeventlisteneroptions-once" class="dfn-panel" data-for="dom-addeventlisteneroptions-once" id="infopanel-for-dom-addeventlisteneroptions-once" role="dialog">
+   <span id="infopaneltitle-for-dom-addeventlisteneroptions-once" style="display:none">Info about the 'once' definition.</span><b><a href="#dom-addeventlisteneroptions-once">#dom-addeventlisteneroptions-once</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-addeventlisteneroptions-once">2.7. Interface EventTarget</a> <a href="#ref-for-dom-addeventlisteneroptions-once①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-addeventlisteneroptions-signal">
-   <b><a href="#dom-addeventlisteneroptions-signal">#dom-addeventlisteneroptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-addeventlisteneroptions-signal" class="dfn-panel" data-for="dom-addeventlisteneroptions-signal" id="infopanel-for-dom-addeventlisteneroptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-addeventlisteneroptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-addeventlisteneroptions-signal">#dom-addeventlisteneroptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-addeventlisteneroptions-signal">2.7. Interface EventTarget</a> <a href="#ref-for-dom-addeventlisteneroptions-signal①">(2)</a> <a href="#ref-for-dom-addeventlisteneroptions-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventtarget-event-listener-list">
-   <b><a href="#eventtarget-event-listener-list">#eventtarget-event-listener-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventtarget-event-listener-list" class="dfn-panel" data-for="eventtarget-event-listener-list" id="infopanel-for-eventtarget-event-listener-list" role="dialog">
+   <span id="infopaneltitle-for-eventtarget-event-listener-list" style="display:none">Info about the 'event listener list' definition.</span><b><a href="#eventtarget-event-listener-list">#eventtarget-event-listener-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-event-listener-list">2.7. Interface EventTarget</a> <a href="#ref-for-eventtarget-event-listener-list①">(2)</a> <a href="#ref-for-eventtarget-event-listener-list②">(3)</a> <a href="#ref-for-eventtarget-event-listener-list③">(4)</a> <a href="#ref-for-eventtarget-event-listener-list④">(5)</a> <a href="#ref-for-eventtarget-event-listener-list⑤">(6)</a> <a href="#ref-for-eventtarget-event-listener-list⑥">(7)</a>
     <li><a href="#ref-for-eventtarget-event-listener-list⑦">2.9. Dispatching events</a> <a href="#ref-for-eventtarget-event-listener-list⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-listener">
-   <b><a href="#concept-event-listener">#concept-event-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-listener" class="dfn-panel" data-for="concept-event-listener" id="infopanel-for-concept-event-listener" role="dialog">
+   <span id="infopaneltitle-for-concept-event-listener" style="display:none">Info about the 'event listener' definition.</span><b><a href="#concept-event-listener">#concept-event-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-event-listener①">(2)</a> <a href="#ref-for-concept-event-listener②">(3)</a> <a href="#ref-for-concept-event-listener③">(4)</a> <a href="#ref-for-concept-event-listener④">(5)</a> <a href="#ref-for-concept-event-listener⑤">(6)</a> <a href="#ref-for-concept-event-listener⑥">(7)</a> <a href="#ref-for-concept-event-listener⑦">(8)</a> <a href="#ref-for-concept-event-listener⑧">(9)</a>
     <li><a href="#ref-for-concept-event-listener⑨">2.2. Interface Event</a> <a href="#ref-for-concept-event-listener①⓪">(2)</a>
@@ -15821,15 +15821,15 @@ APIs</a>
     <li><a href="#ref-for-concept-event-listener②⑥">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-type">
-   <b><a href="#event-listener-type">#event-listener-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-type" class="dfn-panel" data-for="event-listener-type" id="infopanel-for-event-listener-type" role="dialog">
+   <span id="infopaneltitle-for-event-listener-type" style="display:none">Info about the 'type' definition.</span><b><a href="#event-listener-type">#event-listener-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-type">2.7. Interface EventTarget</a> <a href="#ref-for-event-listener-type①">(2)</a> <a href="#ref-for-event-listener-type②">(3)</a> <a href="#ref-for-event-listener-type③">(4)</a> <a href="#ref-for-event-listener-type④">(5)</a> <a href="#ref-for-event-listener-type⑤">(6)</a>
     <li><a href="#ref-for-event-listener-type⑥">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-callback">
-   <b><a href="#event-listener-callback">#event-listener-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-callback" class="dfn-panel" data-for="event-listener-callback" id="infopanel-for-event-listener-callback" role="dialog">
+   <span id="infopaneltitle-for-event-listener-callback" style="display:none">Info about the 'callback' definition.</span><b><a href="#event-listener-callback">#event-listener-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-callback">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-event-listener-callback①">2.2. Interface Event</a>
@@ -15838,43 +15838,43 @@ APIs</a>
     <li><a href="#ref-for-event-listener-callback①⑥">2.9. Dispatching events</a> <a href="#ref-for-event-listener-callback①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-capture">
-   <b><a href="#event-listener-capture">#event-listener-capture</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-capture" class="dfn-panel" data-for="event-listener-capture" id="infopanel-for-event-listener-capture" role="dialog">
+   <span id="infopaneltitle-for-event-listener-capture" style="display:none">Info about the 'capture' definition.</span><b><a href="#event-listener-capture">#event-listener-capture</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-capture">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-event-listener-capture①">(2)</a>
     <li><a href="#ref-for-event-listener-capture②">2.7. Interface EventTarget</a> <a href="#ref-for-event-listener-capture③">(2)</a> <a href="#ref-for-event-listener-capture④">(3)</a> <a href="#ref-for-event-listener-capture⑤">(4)</a> <a href="#ref-for-event-listener-capture⑥">(5)</a>
     <li><a href="#ref-for-event-listener-capture⑦">2.9. Dispatching events</a> <a href="#ref-for-event-listener-capture⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-passive">
-   <b><a href="#event-listener-passive">#event-listener-passive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-passive" class="dfn-panel" data-for="event-listener-passive" id="infopanel-for-event-listener-passive" role="dialog">
+   <span id="infopaneltitle-for-event-listener-passive" style="display:none">Info about the 'passive' definition.</span><b><a href="#event-listener-passive">#event-listener-passive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-passive">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-event-listener-passive①">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-once">
-   <b><a href="#event-listener-once">#event-listener-once</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-once" class="dfn-panel" data-for="event-listener-once" id="infopanel-for-event-listener-once" role="dialog">
+   <span id="infopaneltitle-for-event-listener-once" style="display:none">Info about the 'once' definition.</span><b><a href="#event-listener-once">#event-listener-once</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-once">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-event-listener-once①">2.9. Dispatching events</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-signal">
-   <b><a href="#event-listener-signal">#event-listener-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-signal" class="dfn-panel" data-for="event-listener-signal" id="infopanel-for-event-listener-signal" role="dialog">
+   <span id="infopaneltitle-for-event-listener-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#event-listener-signal">#event-listener-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-signal">2.7. Interface EventTarget</a> <a href="#ref-for-event-listener-signal①">(2)</a> <a href="#ref-for-event-listener-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-listener-removed">
-   <b><a href="#event-listener-removed">#event-listener-removed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-listener-removed" class="dfn-panel" data-for="event-listener-removed" id="infopanel-for-event-listener-removed" role="dialog">
+   <span id="infopaneltitle-for-event-listener-removed" style="display:none">Info about the 'removed' definition.</span><b><a href="#event-listener-removed">#event-listener-removed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-listener-removed">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-event-listener-removed①">2.9. Dispatching events</a> <a href="#ref-for-event-listener-removed②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-the-parent">
-   <b><a href="#get-the-parent">#get-the-parent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-the-parent" class="dfn-panel" data-for="get-the-parent" id="infopanel-for-get-the-parent" role="dialog">
+   <span id="infopaneltitle-for-get-the-parent" style="display:none">Info about the 'get the parent' definition.</span><b><a href="#get-the-parent">#get-the-parent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-the-parent">2.7. Interface EventTarget</a> <a href="#ref-for-get-the-parent①">(2)</a> <a href="#ref-for-get-the-parent②">(3)</a>
     <li><a href="#ref-for-get-the-parent③">2.9. Dispatching events</a> <a href="#ref-for-get-the-parent④">(2)</a>
@@ -15883,81 +15883,81 @@ APIs</a>
     <li><a href="#ref-for-get-the-parent⑦">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventtarget-activation-behavior">
-   <b><a href="#eventtarget-activation-behavior">#eventtarget-activation-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventtarget-activation-behavior" class="dfn-panel" data-for="eventtarget-activation-behavior" id="infopanel-for-eventtarget-activation-behavior" role="dialog">
+   <span id="infopaneltitle-for-eventtarget-activation-behavior" style="display:none">Info about the 'activation behavior' definition.</span><b><a href="#eventtarget-activation-behavior">#eventtarget-activation-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-activation-behavior">2.7. Interface EventTarget</a> <a href="#ref-for-eventtarget-activation-behavior①">(2)</a>
     <li><a href="#ref-for-eventtarget-activation-behavior②">2.9. Dispatching events</a> <a href="#ref-for-eventtarget-activation-behavior③">(2)</a> <a href="#ref-for-eventtarget-activation-behavior④">(3)</a> <a href="#ref-for-eventtarget-activation-behavior⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventtarget-legacy-pre-activation-behavior">
-   <b><a href="#eventtarget-legacy-pre-activation-behavior">#eventtarget-legacy-pre-activation-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventtarget-legacy-pre-activation-behavior" class="dfn-panel" data-for="eventtarget-legacy-pre-activation-behavior" id="infopanel-for-eventtarget-legacy-pre-activation-behavior" role="dialog">
+   <span id="infopaneltitle-for-eventtarget-legacy-pre-activation-behavior" style="display:none">Info about the 'legacy-pre-activation behavior' definition.</span><b><a href="#eventtarget-legacy-pre-activation-behavior">#eventtarget-legacy-pre-activation-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-legacy-pre-activation-behavior">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-eventtarget-legacy-pre-activation-behavior①">2.9. Dispatching events</a> <a href="#ref-for-eventtarget-legacy-pre-activation-behavior②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventtarget-legacy-canceled-activation-behavior">
-   <b><a href="#eventtarget-legacy-canceled-activation-behavior">#eventtarget-legacy-canceled-activation-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventtarget-legacy-canceled-activation-behavior" class="dfn-panel" data-for="eventtarget-legacy-canceled-activation-behavior" id="infopanel-for-eventtarget-legacy-canceled-activation-behavior" role="dialog">
+   <span id="infopaneltitle-for-eventtarget-legacy-canceled-activation-behavior" style="display:none">Info about the 'legacy-canceled-activation behavior' definition.</span><b><a href="#eventtarget-legacy-canceled-activation-behavior">#eventtarget-legacy-canceled-activation-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget-legacy-canceled-activation-behavior">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-eventtarget-legacy-canceled-activation-behavior①">2.9. Dispatching events</a> <a href="#ref-for-eventtarget-legacy-canceled-activation-behavior②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-flatten-options">
-   <b><a href="#concept-flatten-options">#concept-flatten-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-flatten-options" class="dfn-panel" data-for="concept-flatten-options" id="infopanel-for-concept-flatten-options" role="dialog">
+   <span id="infopaneltitle-for-concept-flatten-options" style="display:none">Info about the 'flatten' definition.</span><b><a href="#concept-flatten-options">#concept-flatten-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-flatten-options">2.7. Interface EventTarget</a> <a href="#ref-for-concept-flatten-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-flatten-more">
-   <b><a href="#event-flatten-more">#event-flatten-more</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-flatten-more" class="dfn-panel" data-for="event-flatten-more" id="infopanel-for-event-flatten-more" role="dialog">
+   <span id="infopaneltitle-for-event-flatten-more" style="display:none">Info about the 'flatten more' definition.</span><b><a href="#event-flatten-more">#event-flatten-more</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-flatten-more">2.7. Interface EventTarget</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventtarget-eventtarget">
-   <b><a href="#dom-eventtarget-eventtarget">#dom-eventtarget-eventtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventtarget-eventtarget" class="dfn-panel" data-for="dom-eventtarget-eventtarget" id="infopanel-for-dom-eventtarget-eventtarget" role="dialog">
+   <span id="infopaneltitle-for-dom-eventtarget-eventtarget" style="display:none">Info about the 'new EventTarget()' definition.</span><b><a href="#dom-eventtarget-eventtarget">#dom-eventtarget-eventtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-eventtarget">2.7. Interface EventTarget</a> <a href="#ref-for-dom-eventtarget-eventtarget①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="add-an-event-listener">
-   <b><a href="#add-an-event-listener">#add-an-event-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-add-an-event-listener" class="dfn-panel" data-for="add-an-event-listener" id="infopanel-for-add-an-event-listener" role="dialog">
+   <span id="infopaneltitle-for-add-an-event-listener" style="display:none">Info about the 'add an event listener' definition.</span><b><a href="#add-an-event-listener">#add-an-event-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-add-an-event-listener">2.7. Interface EventTarget</a> <a href="#ref-for-add-an-event-listener①">(2)</a> <a href="#ref-for-add-an-event-listener②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventtarget-addeventlistener">
-   <b><a href="#dom-eventtarget-addeventlistener">#dom-eventtarget-addeventlistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventtarget-addeventlistener" class="dfn-panel" data-for="dom-eventtarget-addeventlistener" id="infopanel-for-dom-eventtarget-addeventlistener" role="dialog">
+   <span id="infopaneltitle-for-dom-eventtarget-addeventlistener" style="display:none">Info about the 'addEventListener(type, callback, options)' definition.</span><b><a href="#dom-eventtarget-addeventlistener">#dom-eventtarget-addeventlistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-dom-eventtarget-addeventlistener①">(2)</a>
     <li><a href="#ref-for-dom-eventtarget-addeventlistener②">2.7. Interface EventTarget</a> <a href="#ref-for-dom-eventtarget-addeventlistener③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remove-an-event-listener">
-   <b><a href="#remove-an-event-listener">#remove-an-event-listener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remove-an-event-listener" class="dfn-panel" data-for="remove-an-event-listener" id="infopanel-for-remove-an-event-listener" role="dialog">
+   <span id="infopaneltitle-for-remove-an-event-listener" style="display:none">Info about the 'remove an event listener' definition.</span><b><a href="#remove-an-event-listener">#remove-an-event-listener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remove-an-event-listener">2.7. Interface EventTarget</a> <a href="#ref-for-remove-an-event-listener①">(2)</a> <a href="#ref-for-remove-an-event-listener②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventtarget-removeeventlistener">
-   <b><a href="#dom-eventtarget-removeeventlistener">#dom-eventtarget-removeeventlistener</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventtarget-removeeventlistener" class="dfn-panel" data-for="dom-eventtarget-removeeventlistener" id="infopanel-for-dom-eventtarget-removeeventlistener" role="dialog">
+   <span id="infopaneltitle-for-dom-eventtarget-removeeventlistener" style="display:none">Info about the 'removeEventListener(type, callback, options)' definition.</span><b><a href="#dom-eventtarget-removeeventlistener">#dom-eventtarget-removeeventlistener</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-removeeventlistener">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-eventtarget-removeeventlistener①">2.7. Interface EventTarget</a> <a href="#ref-for-dom-eventtarget-removeeventlistener②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-eventtarget-dispatchevent">
-   <b><a href="#dom-eventtarget-dispatchevent">#dom-eventtarget-dispatchevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-eventtarget-dispatchevent" class="dfn-panel" data-for="dom-eventtarget-dispatchevent" id="infopanel-for-dom-eventtarget-dispatchevent" role="dialog">
+   <span id="infopaneltitle-for-dom-eventtarget-dispatchevent" style="display:none">Info about the 'dispatchEvent(event)' definition.</span><b><a href="#dom-eventtarget-dispatchevent">#dom-eventtarget-dispatchevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-eventtarget-dispatchevent">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-eventtarget-dispatchevent①">2.2. Interface Event</a>
     <li><a href="#ref-for-dom-eventtarget-dispatchevent②">2.7. Interface EventTarget</a> <a href="#ref-for-dom-eventtarget-dispatchevent③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-dispatch">
-   <b><a href="#concept-event-dispatch">#concept-event-dispatch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-dispatch" class="dfn-panel" data-for="concept-event-dispatch" id="infopanel-for-concept-event-dispatch" role="dialog">
+   <span id="infopaneltitle-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' definition.</span><b><a href="#concept-event-dispatch">#concept-event-dispatch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-event-dispatch①">(2)</a> <a href="#ref-for-concept-event-dispatch②">(3)</a> <a href="#ref-for-concept-event-dispatch③">(4)</a> <a href="#ref-for-concept-event-dispatch④">(5)</a> <a href="#ref-for-concept-event-dispatch⑤">(6)</a> <a href="#ref-for-concept-event-dispatch⑥">(7)</a>
     <li><a href="#ref-for-concept-event-dispatch⑦">2.2. Interface Event</a> <a href="#ref-for-concept-event-dispatch⑧">(2)</a> <a href="#ref-for-concept-event-dispatch⑨">(3)</a> <a href="#ref-for-concept-event-dispatch①⓪">(4)</a> <a href="#ref-for-concept-event-dispatch①①">(5)</a> <a href="#ref-for-concept-event-dispatch①②">(6)</a> <a href="#ref-for-concept-event-dispatch①③">(7)</a> <a href="#ref-for-concept-event-dispatch①④">(8)</a> <a href="#ref-for-concept-event-dispatch①⑤">(9)</a> <a href="#ref-for-concept-event-dispatch①⑥">(10)</a> <a href="#ref-for-concept-event-dispatch①⑦">(11)</a>
@@ -15967,26 +15967,26 @@ APIs</a>
     <li><a href="#ref-for-concept-event-dispatch②⑦">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-path-append">
-   <b><a href="#concept-event-path-append">#concept-event-path-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-path-append" class="dfn-panel" data-for="concept-event-path-append" id="infopanel-for-concept-event-path-append" role="dialog">
+   <span id="infopaneltitle-for-concept-event-path-append" style="display:none">Info about the 'append to an event path' definition.</span><b><a href="#concept-event-path-append">#concept-event-path-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-path-append">2.9. Dispatching events</a> <a href="#ref-for-concept-event-path-append①">(2)</a> <a href="#ref-for-concept-event-path-append②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-listener-invoke">
-   <b><a href="#concept-event-listener-invoke">#concept-event-listener-invoke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-listener-invoke" class="dfn-panel" data-for="concept-event-listener-invoke" id="infopanel-for-concept-event-listener-invoke" role="dialog">
+   <span id="infopaneltitle-for-concept-event-listener-invoke" style="display:none">Info about the 'invoke' definition.</span><b><a href="#concept-event-listener-invoke">#concept-event-listener-invoke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener-invoke">2.9. Dispatching events</a> <a href="#ref-for-concept-event-listener-invoke①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-listener-inner-invoke">
-   <b><a href="#concept-event-listener-inner-invoke">#concept-event-listener-inner-invoke</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-listener-inner-invoke" class="dfn-panel" data-for="concept-event-listener-inner-invoke" id="infopanel-for-concept-event-listener-inner-invoke" role="dialog">
+   <span id="infopaneltitle-for-concept-event-listener-inner-invoke" style="display:none">Info about the 'inner invoke' definition.</span><b><a href="#concept-event-listener-inner-invoke">#concept-event-listener-inner-invoke</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener-inner-invoke">2.9. Dispatching events</a> <a href="#ref-for-concept-event-listener-inner-invoke①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-fire">
-   <b><a href="#concept-event-fire">#concept-event-fire</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-fire" class="dfn-panel" data-for="concept-event-fire" id="infopanel-for-concept-event-fire" role="dialog">
+   <span id="infopaneltitle-for-concept-event-fire" style="display:none">Info about the 'fire an event' definition.</span><b><a href="#concept-event-fire">#concept-event-fire</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2.5. Constructing events</a>
     <li><a href="#ref-for-concept-event-fire①">2.10. Firing events</a> <a href="#ref-for-concept-event-fire②">(2)</a> <a href="#ref-for-concept-event-fire③">(3)</a> <a href="#ref-for-concept-event-fire④">(4)</a>
@@ -15994,8 +15994,8 @@ APIs</a>
     <li><a href="#ref-for-concept-event-fire⑥">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortcontroller">
-   <b><a href="#abortcontroller">#abortcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortcontroller" class="dfn-panel" data-for="abortcontroller" id="infopanel-for-abortcontroller" role="dialog">
+   <span id="infopaneltitle-for-abortcontroller" style="display:none">Info about the 'AbortController' definition.</span><b><a href="#abortcontroller">#abortcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">3. Aborting ongoing activities</a> <a href="#ref-for-abortcontroller①">(2)</a> <a href="#ref-for-abortcontroller②">(3)</a>
     <li><a href="#ref-for-abortcontroller③">3.1. Interface AbortController</a> <a href="#ref-for-abortcontroller④">(2)</a>
@@ -16004,26 +16004,26 @@ APIs</a>
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortcontroller-signal">
-   <b><a href="#abortcontroller-signal">#abortcontroller-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortcontroller-signal" class="dfn-panel" data-for="abortcontroller-signal" id="infopanel-for-abortcontroller-signal" role="dialog">
+   <span id="infopaneltitle-for-abortcontroller-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#abortcontroller-signal">#abortcontroller-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller-signal">3.1. Interface AbortController</a> <a href="#ref-for-abortcontroller-signal①">(2)</a> <a href="#ref-for-abortcontroller-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortcontroller-abortcontroller">
-   <b><a href="#dom-abortcontroller-abortcontroller">#dom-abortcontroller-abortcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortcontroller-abortcontroller" class="dfn-panel" data-for="dom-abortcontroller-abortcontroller" id="infopanel-for-dom-abortcontroller-abortcontroller" role="dialog">
+   <span id="infopaneltitle-for-dom-abortcontroller-abortcontroller" style="display:none">Info about the 'new AbortController()' definition.</span><b><a href="#dom-abortcontroller-abortcontroller">#dom-abortcontroller-abortcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortcontroller-abortcontroller">3.1. Interface AbortController</a> <a href="#ref-for-dom-abortcontroller-abortcontroller①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortcontroller-signal">
-   <b><a href="#dom-abortcontroller-signal">#dom-abortcontroller-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortcontroller-signal" class="dfn-panel" data-for="dom-abortcontroller-signal" id="infopanel-for-dom-abortcontroller-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-abortcontroller-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-abortcontroller-signal">#dom-abortcontroller-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortcontroller-signal">3.1. Interface AbortController</a> <a href="#ref-for-dom-abortcontroller-signal①">(2)</a> <a href="#ref-for-dom-abortcontroller-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortcontroller-abort">
-   <b><a href="#dom-abortcontroller-abort">#dom-abortcontroller-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortcontroller-abort" class="dfn-panel" data-for="dom-abortcontroller-abort" id="infopanel-for-dom-abortcontroller-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-abortcontroller-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-abortcontroller-abort">#dom-abortcontroller-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortcontroller-abort">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-dom-abortcontroller-abort①">3. Aborting ongoing activities</a> <a href="#ref-for-dom-abortcontroller-abort②">(2)</a>
@@ -16031,8 +16031,8 @@ APIs</a>
     <li><a href="#ref-for-dom-abortcontroller-abort⑤">3.2. Interface AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortsignal">
-   <b><a href="#abortsignal">#abortsignal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortsignal" class="dfn-panel" data-for="abortsignal" id="infopanel-for-abortsignal" role="dialog">
+   <span id="infopaneltitle-for-abortsignal" style="display:none">Info about the 'AbortSignal' definition.</span><b><a href="#abortsignal">#abortsignal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-abortsignal①">2.7. Interface EventTarget</a> <a href="#ref-for-abortsignal②">(2)</a> <a href="#ref-for-abortsignal③">(3)</a>
@@ -16043,8 +16043,8 @@ APIs</a>
 APIs</a> <a href="#ref-for-abortsignal②⑨">(2)</a> <a href="#ref-for-abortsignal③⓪">(3)</a> <a href="#ref-for-abortsignal③①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortsignal-aborted-flag">
-   <b><a href="#abortsignal-aborted-flag">#abortsignal-aborted-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortsignal-aborted-flag" class="dfn-panel" data-for="abortsignal-aborted-flag" id="infopanel-for-abortsignal-aborted-flag" role="dialog">
+   <span id="infopaneltitle-for-abortsignal-aborted-flag" style="display:none">Info about the 'aborted flag' definition.</span><b><a href="#abortsignal-aborted-flag">#abortsignal-aborted-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-aborted-flag">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-abortsignal-aborted-flag①">3.1. Interface AbortController</a>
@@ -16053,16 +16053,16 @@ APIs</a> <a href="#ref-for-abortsignal②⑨">(2)</a> <a href="#ref-for-abortsig
 APIs</a> <a href="#ref-for-abortsignal-aborted-flag①③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortsignal-abort-algorithms">
-   <b><a href="#abortsignal-abort-algorithms">#abortsignal-abort-algorithms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortsignal-abort-algorithms" class="dfn-panel" data-for="abortsignal-abort-algorithms" id="infopanel-for-abortsignal-abort-algorithms" role="dialog">
+   <span id="infopaneltitle-for-abortsignal-abort-algorithms" style="display:none">Info about the 'abort algorithms' definition.</span><b><a href="#abortsignal-abort-algorithms">#abortsignal-abort-algorithms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-abort-algorithms">3.2. Interface AbortSignal</a> <a href="#ref-for-abortsignal-abort-algorithms①">(2)</a> <a href="#ref-for-abortsignal-abort-algorithms②">(3)</a> <a href="#ref-for-abortsignal-abort-algorithms③">(4)</a> <a href="#ref-for-abortsignal-abort-algorithms④">(5)</a>
     <li><a href="#ref-for-abortsignal-abort-algorithms⑤">3.3. Using AbortController and AbortSignal objects in
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortsignal-add">
-   <b><a href="#abortsignal-add">#abortsignal-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortsignal-add" class="dfn-panel" data-for="abortsignal-add" id="infopanel-for-abortsignal-add" role="dialog">
+   <span id="infopaneltitle-for-abortsignal-add" style="display:none">Info about the 'add' definition.</span><b><a href="#abortsignal-add">#abortsignal-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">2.7. Interface EventTarget</a>
     <li><a href="#ref-for-abortsignal-add①">3.2. Interface AbortSignal</a>
@@ -16070,39 +16070,39 @@ APIs</a>
 APIs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortsignal-abort">
-   <b><a href="#dom-abortsignal-abort">#dom-abortsignal-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortsignal-abort" class="dfn-panel" data-for="dom-abortsignal-abort" id="infopanel-for-dom-abortsignal-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-abortsignal-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-abortsignal-abort">#dom-abortsignal-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortsignal-abort">3.2. Interface AbortSignal</a> <a href="#ref-for-dom-abortsignal-abort①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortsignal-aborted">
-   <b><a href="#dom-abortsignal-aborted">#dom-abortsignal-aborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortsignal-aborted" class="dfn-panel" data-for="dom-abortsignal-aborted" id="infopanel-for-dom-abortsignal-aborted" role="dialog">
+   <span id="infopaneltitle-for-dom-abortsignal-aborted" style="display:none">Info about the 'aborted' definition.</span><b><a href="#dom-abortsignal-aborted">#dom-abortsignal-aborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortsignal-aborted">3.2. Interface AbortSignal</a> <a href="#ref-for-dom-abortsignal-aborted①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-abortsignal-onabort">
-   <b><a href="#dom-abortsignal-onabort">#dom-abortsignal-onabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-abortsignal-onabort" class="dfn-panel" data-for="dom-abortsignal-onabort" id="infopanel-for-dom-abortsignal-onabort" role="dialog">
+   <span id="infopaneltitle-for-dom-abortsignal-onabort" style="display:none">Info about the 'onabort' definition.</span><b><a href="#dom-abortsignal-onabort">#dom-abortsignal-onabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-abortsignal-onabort">3.2. Interface AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eventdef-abortsignal-abort">
-   <b><a href="#eventdef-abortsignal-abort">#eventdef-abortsignal-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eventdef-abortsignal-abort" class="dfn-panel" data-for="eventdef-abortsignal-abort" id="infopanel-for-eventdef-abortsignal-abort" role="dialog">
+   <span id="infopaneltitle-for-eventdef-abortsignal-abort" style="display:none">Info about the 'abort' definition.</span><b><a href="#eventdef-abortsignal-abort">#eventdef-abortsignal-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventdef-abortsignal-abort">3.2. Interface AbortSignal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abortsignal-signal-abort">
-   <b><a href="#abortsignal-signal-abort">#abortsignal-signal-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abortsignal-signal-abort" class="dfn-panel" data-for="abortsignal-signal-abort" id="infopanel-for-abortsignal-signal-abort" role="dialog">
+   <span id="infopaneltitle-for-abortsignal-signal-abort" style="display:none">Info about the 'signal abort' definition.</span><b><a href="#abortsignal-signal-abort">#abortsignal-signal-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-signal-abort">3.1. Interface AbortController</a>
     <li><a href="#ref-for-abortsignal-signal-abort①">3.2. Interface AbortSignal</a> <a href="#ref-for-abortsignal-signal-abort②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node">
-   <b><a href="#concept-node">#concept-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node" class="dfn-panel" data-for="concept-node" id="infopanel-for-concept-node" role="dialog">
+   <span id="infopaneltitle-for-concept-node" style="display:none">Info about the 'nodes' definition.</span><b><a href="#concept-node">#concept-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node">2.2. Interface Event</a>
     <li><a href="#ref-for-concept-node①">2.7. Interface EventTarget</a>
@@ -16137,8 +16137,8 @@ APIs</a>
     <li><a href="#ref-for-concept-node⑧⑤">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-tree">
-   <b><a href="#concept-node-tree">#concept-node-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-tree" class="dfn-panel" data-for="concept-node-tree" id="infopanel-for-concept-node-tree" role="dialog">
+   <span id="infopaneltitle-for-concept-node-tree" style="display:none">Info about the 'node tree' definition.</span><b><a href="#concept-node-tree">#concept-node-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-tree">4.1. Introduction to "The DOM"</a>
     <li><a href="#ref-for-concept-node-tree①">4.2. Node tree</a>
@@ -16153,8 +16153,8 @@ APIs</a>
     <li><a href="#ref-for-concept-node-tree②⑦">5.4. Interface StaticRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-length">
-   <b><a href="#concept-node-length">#concept-node-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-length" class="dfn-panel" data-for="concept-node-length" id="infopanel-for-concept-node-length" role="dialog">
+   <span id="infopaneltitle-for-concept-node-length" style="display:none">Info about the 'length' definition.</span><b><a href="#concept-node-length">#concept-node-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-length">4.4. Interface Node</a> <a href="#ref-for-concept-node-length①">(2)</a> <a href="#ref-for-concept-node-length②">(3)</a> <a href="#ref-for-concept-node-length③">(4)</a>
     <li><a href="#ref-for-concept-node-length④">4.10. Interface CharacterData</a> <a href="#ref-for-concept-node-length⑤">(2)</a> <a href="#ref-for-concept-node-length⑥">(3)</a> <a href="#ref-for-concept-node-length⑦">(4)</a> <a href="#ref-for-concept-node-length⑧">(5)</a>
@@ -16162,34 +16162,34 @@ APIs</a>
     <li><a href="#ref-for-concept-node-length①⓪">5.2. Boundary points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-empty">
-   <b><a href="#concept-node-empty">#concept-node-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-empty" class="dfn-panel" data-for="concept-node-empty" id="infopanel-for-concept-node-empty" role="dialog">
+   <span id="infopaneltitle-for-concept-node-empty" style="display:none">Info about the 'empty' definition.</span><b><a href="#concept-node-empty">#concept-node-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-empty">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-element">
-   <b><a href="#document-element">#document-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-element" class="dfn-panel" data-for="document-element" id="infopanel-for-document-element" role="dialog">
+   <span id="infopaneltitle-for-document-element" style="display:none">Info about the 'document element' definition.</span><b><a href="#document-element">#document-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-element">4.4. Interface Node</a> <a href="#ref-for-document-element①">(2)</a> <a href="#ref-for-document-element②">(3)</a> <a href="#ref-for-document-element③">(4)</a>
     <li><a href="#ref-for-document-element④">4.5. Interface Document</a> <a href="#ref-for-document-element⑤">(2)</a>
     <li><a href="#ref-for-document-element⑥">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-a-document-tree">
-   <b><a href="#in-a-document-tree">#in-a-document-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-a-document-tree" class="dfn-panel" data-for="in-a-document-tree" id="infopanel-for-in-a-document-tree" role="dialog">
+   <span id="infopaneltitle-for-in-a-document-tree" style="display:none">Info about the 'in a document tree' definition.</span><b><a href="#in-a-document-tree">#in-a-document-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-a-document-tree">4.2.1. Document tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="in-a-document">
-   <b><a href="#in-a-document">#in-a-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-in-a-document" class="dfn-panel" data-for="in-a-document" id="infopanel-for-in-a-document" role="dialog">
+   <span id="infopaneltitle-for-in-a-document" style="display:none">Info about the 'in a document' definition.</span><b><a href="#in-a-document">#in-a-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-a-document">4.2.1. Document tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-tree">
-   <b><a href="#concept-shadow-tree">#concept-shadow-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-tree" class="dfn-panel" data-for="concept-shadow-tree" id="infopanel-for-concept-shadow-tree" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-tree" style="display:none">Info about the 'shadow tree' definition.</span><b><a href="#concept-shadow-tree">#concept-shadow-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-tree">2.2. Interface Event</a>
     <li><a href="#ref-for-concept-shadow-tree①">2.3. Legacy extensions to the Window interface</a>
@@ -16198,21 +16198,21 @@ APIs</a>
     <li><a href="#ref-for-concept-shadow-tree⑥">4.2.2.1. Slots</a> <a href="#ref-for-concept-shadow-tree⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-light-tree">
-   <b><a href="#concept-light-tree">#concept-light-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-light-tree" class="dfn-panel" data-for="concept-light-tree" id="infopanel-for-concept-light-tree" role="dialog">
+   <span id="infopaneltitle-for-concept-light-tree" style="display:none">Info about the 'light tree' definition.</span><b><a href="#concept-light-tree">#concept-light-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-light-tree">4.2.2. Shadow tree</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connected">
-   <b><a href="#connected">#connected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connected" class="dfn-panel" data-for="connected" id="infopanel-for-connected" role="dialog">
+   <span id="infopaneltitle-for-connected" style="display:none">Info about the 'connected' definition.</span><b><a href="#connected">#connected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">4.2.3. Mutation algorithms</a> <a href="#ref-for-connected①">(2)</a>
     <li><a href="#ref-for-connected②">4.4. Interface Node</a> <a href="#ref-for-connected③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-slot">
-   <b><a href="#concept-slot">#concept-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-slot" class="dfn-panel" data-for="concept-slot" id="infopanel-for-concept-slot" role="dialog">
+   <span id="infopaneltitle-for-concept-slot" style="display:none">Info about the 'slots' definition.</span><b><a href="#concept-slot">#concept-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-slot">2.9. Dispatching events</a>
     <li><a href="#ref-for-concept-slot①">4.2.2.1. Slots</a> <a href="#ref-for-concept-slot②">(2)</a> <a href="#ref-for-concept-slot③">(3)</a> <a href="#ref-for-concept-slot④">(4)</a> <a href="#ref-for-concept-slot⑤">(5)</a> <a href="#ref-for-concept-slot⑥">(6)</a>
@@ -16223,22 +16223,22 @@ APIs</a>
     <li><a href="#ref-for-concept-slot②⓪">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-slot②①">(2)</a> <a href="#ref-for-concept-slot②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slot-name">
-   <b><a href="#slot-name">#slot-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slot-name" class="dfn-panel" data-for="slot-name" id="infopanel-for-slot-name" role="dialog">
+   <span id="infopaneltitle-for-slot-name" style="display:none">Info about the 'name' definition.</span><b><a href="#slot-name">#slot-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slot-name">4.2.2.1. Slots</a> <a href="#ref-for-slot-name①">(2)</a> <a href="#ref-for-slot-name②">(3)</a> <a href="#ref-for-slot-name③">(4)</a>
     <li><a href="#ref-for-slot-name④">4.2.2.3. Finding slots and slottables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slot-assigned-nodes">
-   <b><a href="#slot-assigned-nodes">#slot-assigned-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slot-assigned-nodes" class="dfn-panel" data-for="slot-assigned-nodes" id="infopanel-for-slot-assigned-nodes" role="dialog">
+   <span id="infopaneltitle-for-slot-assigned-nodes" style="display:none">Info about the 'assigned nodes' definition.</span><b><a href="#slot-assigned-nodes">#slot-assigned-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slot-assigned-nodes">4.2.2.4. Assigning slottables and slots</a> <a href="#ref-for-slot-assigned-nodes①">(2)</a>
     <li><a href="#ref-for-slot-assigned-nodes②">4.2.3. Mutation algorithms</a> <a href="#ref-for-slot-assigned-nodes③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-slotable">
-   <b><a href="#concept-slotable">#concept-slotable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-slotable" class="dfn-panel" data-for="concept-slotable" id="infopanel-for-concept-slotable" role="dialog">
+   <span id="infopaneltitle-for-concept-slotable" style="display:none">Info about the 'slottables' definition.</span><b><a href="#concept-slotable">#concept-slotable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-slotable">2.9. Dispatching events</a> <a href="#ref-for-concept-slotable①">(2)</a>
     <li><a href="#ref-for-concept-slotable②">4.2.2.1. Slots</a>
@@ -16248,15 +16248,15 @@ APIs</a>
     <li><a href="#ref-for-concept-slotable①⑥">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slotable-name">
-   <b><a href="#slotable-name">#slotable-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slotable-name" class="dfn-panel" data-for="slotable-name" id="infopanel-for-slotable-name" role="dialog">
+   <span id="infopaneltitle-for-slotable-name" style="display:none">Info about the 'name' definition.</span><b><a href="#slotable-name">#slotable-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slotable-name">4.2.2.2. Slottables</a> <a href="#ref-for-slotable-name①">(2)</a> <a href="#ref-for-slotable-name②">(3)</a>
     <li><a href="#ref-for-slotable-name③">4.2.2.3. Finding slots and slottables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slotable-assigned-slot">
-   <b><a href="#slotable-assigned-slot">#slotable-assigned-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slotable-assigned-slot" class="dfn-panel" data-for="slotable-assigned-slot" id="infopanel-for-slotable-assigned-slot" role="dialog">
+   <span id="infopaneltitle-for-slotable-assigned-slot" style="display:none">Info about the 'assigned slot' definition.</span><b><a href="#slotable-assigned-slot">#slotable-assigned-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slotable-assigned-slot">4.2.2.2. Slottables</a> <a href="#ref-for-slotable-assigned-slot①">(2)</a>
     <li><a href="#ref-for-slotable-assigned-slot②">4.2.2.4. Assigning slottables and slots</a>
@@ -16264,8 +16264,8 @@ APIs</a>
     <li><a href="#ref-for-slotable-assigned-slot④">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slotable-assigned">
-   <b><a href="#slotable-assigned">#slotable-assigned</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slotable-assigned" class="dfn-panel" data-for="slotable-assigned" id="infopanel-for-slotable-assigned" role="dialog">
+   <span id="infopaneltitle-for-slotable-assigned" style="display:none">Info about the 'assigned' definition.</span><b><a href="#slotable-assigned">#slotable-assigned</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slotable-assigned">2.9. Dispatching events</a> <a href="#ref-for-slotable-assigned①">(2)</a>
     <li><a href="#ref-for-slotable-assigned②">4.2.2.2. Slottables</a>
@@ -16273,79 +16273,79 @@ APIs</a>
     <li><a href="#ref-for-slotable-assigned④">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slottable-manual-slot-assignment">
-   <b><a href="#slottable-manual-slot-assignment">#slottable-manual-slot-assignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slottable-manual-slot-assignment" class="dfn-panel" data-for="slottable-manual-slot-assignment" id="infopanel-for-slottable-manual-slot-assignment" role="dialog">
+   <span id="infopaneltitle-for-slottable-manual-slot-assignment" style="display:none">Info about the 'manual slot assignment' definition.</span><b><a href="#slottable-manual-slot-assignment">#slottable-manual-slot-assignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slottable-manual-slot-assignment">4.2.2.2. Slottables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-a-slot">
-   <b><a href="#find-a-slot">#find-a-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-a-slot" class="dfn-panel" data-for="find-a-slot" id="infopanel-for-find-a-slot" role="dialog">
+   <span id="infopaneltitle-for-find-a-slot" style="display:none">Info about the 'find a slot' definition.</span><b><a href="#find-a-slot">#find-a-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-a-slot">4.2.2.3. Finding slots and slottables</a>
     <li><a href="#ref-for-find-a-slot①">4.2.2.4. Assigning slottables and slots</a>
     <li><a href="#ref-for-find-a-slot②">4.2.9. Mixin Slottable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-slotables">
-   <b><a href="#find-slotables">#find-slotables</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-slotables" class="dfn-panel" data-for="find-slotables" id="infopanel-for-find-slotables" role="dialog">
+   <span id="infopaneltitle-for-find-slotables" style="display:none">Info about the 'find slottables' definition.</span><b><a href="#find-slotables">#find-slotables</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-slotables">4.2.2.3. Finding slots and slottables</a>
     <li><a href="#ref-for-find-slotables①">4.2.2.4. Assigning slottables and slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="find-flattened-slotables">
-   <b><a href="#find-flattened-slotables">#find-flattened-slotables</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-find-flattened-slotables" class="dfn-panel" data-for="find-flattened-slotables" id="infopanel-for-find-flattened-slotables" role="dialog">
+   <span id="infopaneltitle-for-find-flattened-slotables" style="display:none">Info about the 'find flattened slottables' definition.</span><b><a href="#find-flattened-slotables">#find-flattened-slotables</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-find-flattened-slotables">4.2.2.3. Finding slots and slottables</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assign-slotables">
-   <b><a href="#assign-slotables">#assign-slotables</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assign-slotables" class="dfn-panel" data-for="assign-slotables" id="infopanel-for-assign-slotables" role="dialog">
+   <span id="infopaneltitle-for-assign-slotables" style="display:none">Info about the 'assign slottables' definition.</span><b><a href="#assign-slotables">#assign-slotables</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assign-slotables">4.2.2.2. Slottables</a>
     <li><a href="#ref-for-assign-slotables①">4.2.2.4. Assigning slottables and slots</a> <a href="#ref-for-assign-slotables②">(2)</a>
     <li><a href="#ref-for-assign-slotables③">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assign-slotables-for-a-tree">
-   <b><a href="#assign-slotables-for-a-tree">#assign-slotables-for-a-tree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assign-slotables-for-a-tree" class="dfn-panel" data-for="assign-slotables-for-a-tree" id="infopanel-for-assign-slotables-for-a-tree" role="dialog">
+   <span id="infopaneltitle-for-assign-slotables-for-a-tree" style="display:none">Info about the 'assign slottables for a tree' definition.</span><b><a href="#assign-slotables-for-a-tree">#assign-slotables-for-a-tree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assign-slotables-for-a-tree">4.2.2.1. Slots</a>
     <li><a href="#ref-for-assign-slotables-for-a-tree①">4.2.3. Mutation algorithms</a> <a href="#ref-for-assign-slotables-for-a-tree②">(2)</a> <a href="#ref-for-assign-slotables-for-a-tree③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assign-a-slot">
-   <b><a href="#assign-a-slot">#assign-a-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assign-a-slot" class="dfn-panel" data-for="assign-a-slot" id="infopanel-for-assign-a-slot" role="dialog">
+   <span id="infopaneltitle-for-assign-a-slot" style="display:none">Info about the 'assign a slot' definition.</span><b><a href="#assign-a-slot">#assign-a-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assign-a-slot">4.2.2.2. Slottables</a>
     <li><a href="#ref-for-assign-a-slot①">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signal-slot-list">
-   <b><a href="#signal-slot-list">#signal-slot-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signal-slot-list" class="dfn-panel" data-for="signal-slot-list" id="infopanel-for-signal-slot-list" role="dialog">
+   <span id="infopaneltitle-for-signal-slot-list" style="display:none">Info about the 'signal slots' definition.</span><b><a href="#signal-slot-list">#signal-slot-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signal-slot-list">4.2.2.5. Signaling slot change</a>
     <li><a href="#ref-for-signal-slot-list①">4.3. Mutation observers</a> <a href="#ref-for-signal-slot-list②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="signal-a-slot-change">
-   <b><a href="#signal-a-slot-change">#signal-a-slot-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-signal-a-slot-change" class="dfn-panel" data-for="signal-a-slot-change" id="infopanel-for-signal-a-slot-change" role="dialog">
+   <span id="infopaneltitle-for-signal-a-slot-change" style="display:none">Info about the 'signal a slot change' definition.</span><b><a href="#signal-a-slot-change">#signal-a-slot-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-signal-a-slot-change">4.2.2.4. Assigning slottables and slots</a>
     <li><a href="#ref-for-signal-a-slot-change①">4.2.3. Mutation algorithms</a> <a href="#ref-for-signal-a-slot-change②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-ensure-pre-insertion-validity">
-   <b><a href="#concept-node-ensure-pre-insertion-validity">#concept-node-ensure-pre-insertion-validity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-ensure-pre-insertion-validity" class="dfn-panel" data-for="concept-node-ensure-pre-insertion-validity" id="infopanel-for-concept-node-ensure-pre-insertion-validity" role="dialog">
+   <span id="infopaneltitle-for-concept-node-ensure-pre-insertion-validity" style="display:none">Info about the 'ensure pre-insertion validity' definition.</span><b><a href="#concept-node-ensure-pre-insertion-validity">#concept-node-ensure-pre-insertion-validity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-ensure-pre-insertion-validity">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-node-ensure-pre-insertion-validity①">4.2.6. Mixin ParentNode</a>
     <li><a href="#ref-for-concept-node-ensure-pre-insertion-validity②">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-pre-insert">
-   <b><a href="#concept-node-pre-insert">#concept-node-pre-insert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-pre-insert" class="dfn-panel" data-for="concept-node-pre-insert" id="infopanel-for-concept-node-pre-insert" role="dialog">
+   <span id="infopaneltitle-for-concept-node-pre-insert" style="display:none">Info about the 'pre-insert' definition.</span><b><a href="#concept-node-pre-insert">#concept-node-pre-insert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-pre-insert">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-pre-insert①">(2)</a>
     <li><a href="#ref-for-concept-node-pre-insert②">4.2.6. Mixin ParentNode</a>
@@ -16356,21 +16356,21 @@ APIs</a>
     <li><a href="#ref-for-concept-node-pre-insert①②">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-insert-ext">
-   <b><a href="#concept-node-insert-ext">#concept-node-insert-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-insert-ext" class="dfn-panel" data-for="concept-node-insert-ext" id="infopanel-for-concept-node-insert-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-node-insert-ext" style="display:none">Info about the 'insertion steps' definition.</span><b><a href="#concept-node-insert-ext">#concept-node-insert-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-insert-ext">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-children-changed-ext">
-   <b><a href="#concept-node-children-changed-ext">#concept-node-children-changed-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-children-changed-ext" class="dfn-panel" data-for="concept-node-children-changed-ext" id="infopanel-for-concept-node-children-changed-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-node-children-changed-ext" style="display:none">Info about the 'children changed steps' definition.</span><b><a href="#concept-node-children-changed-ext">#concept-node-children-changed-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-children-changed-ext">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-children-changed-ext①">(2)</a>
     <li><a href="#ref-for-concept-node-children-changed-ext②">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-insert">
-   <b><a href="#concept-node-insert">#concept-node-insert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-insert" class="dfn-panel" data-for="concept-node-insert" id="infopanel-for-concept-node-insert" role="dialog">
+   <span id="infopaneltitle-for-concept-node-insert" style="display:none">Info about the 'insert' definition.</span><b><a href="#concept-node-insert">#concept-node-insert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-insert">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-insert①">(2)</a> <a href="#ref-for-concept-node-insert②">(3)</a> <a href="#ref-for-concept-node-insert③">(4)</a> <a href="#ref-for-concept-node-insert④">(5)</a>
     <li><a href="#ref-for-concept-node-insert⑤">4.11. Interface Text</a>
@@ -16378,8 +16378,8 @@ APIs</a>
     <li><a href="#ref-for-concept-node-insert⑦">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-append">
-   <b><a href="#concept-node-append">#concept-node-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-append" class="dfn-panel" data-for="concept-node-append" id="infopanel-for-concept-node-append" role="dialog">
+   <span id="infopaneltitle-for-concept-node-append" style="display:none">Info about the 'append' definition.</span><b><a href="#concept-node-append">#concept-node-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-append">4.2.6. Mixin ParentNode</a> <a href="#ref-for-concept-node-append①">(2)</a>
     <li><a href="#ref-for-concept-node-append②">4.4. Interface Node</a>
@@ -16387,36 +16387,36 @@ APIs</a>
     <li><a href="#ref-for-concept-node-append①①">5.5. Interface Range</a> <a href="#ref-for-concept-node-append①②">(2)</a> <a href="#ref-for-concept-node-append①③">(3)</a> <a href="#ref-for-concept-node-append①④">(4)</a> <a href="#ref-for-concept-node-append①⑤">(5)</a> <a href="#ref-for-concept-node-append①⑥">(6)</a> <a href="#ref-for-concept-node-append①⑦">(7)</a> <a href="#ref-for-concept-node-append①⑧">(8)</a> <a href="#ref-for-concept-node-append①⑨">(9)</a> <a href="#ref-for-concept-node-append②⓪">(10)</a> <a href="#ref-for-concept-node-append②①">(11)</a> <a href="#ref-for-concept-node-append②②">(12)</a> <a href="#ref-for-concept-node-append②③">(13)</a> <a href="#ref-for-concept-node-append②④">(14)</a> <a href="#ref-for-concept-node-append②⑤">(15)</a> <a href="#ref-for-concept-node-append②⑥">(16)</a> <a href="#ref-for-concept-node-append②⑦">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-replace">
-   <b><a href="#concept-node-replace">#concept-node-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-replace" class="dfn-panel" data-for="concept-node-replace" id="infopanel-for-concept-node-replace" role="dialog">
+   <span id="infopaneltitle-for-concept-node-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#concept-node-replace">#concept-node-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-replace">4.2.8. Mixin ChildNode</a>
     <li><a href="#ref-for-concept-node-replace①">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-node-replace②">4.7. Interface DocumentFragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-replace-all">
-   <b><a href="#concept-node-replace-all">#concept-node-replace-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-replace-all" class="dfn-panel" data-for="concept-node-replace-all" id="infopanel-for-concept-node-replace-all" role="dialog">
+   <span id="infopaneltitle-for-concept-node-replace-all" style="display:none">Info about the 'replace all' definition.</span><b><a href="#concept-node-replace-all">#concept-node-replace-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-replace-all">4.2.6. Mixin ParentNode</a>
     <li><a href="#ref-for-concept-node-replace-all①">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-node-replace-all②">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-pre-remove">
-   <b><a href="#concept-node-pre-remove">#concept-node-pre-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-pre-remove" class="dfn-panel" data-for="concept-node-pre-remove" id="infopanel-for-concept-node-pre-remove" role="dialog">
+   <span id="infopaneltitle-for-concept-node-pre-remove" style="display:none">Info about the 'pre-remove' definition.</span><b><a href="#concept-node-pre-remove">#concept-node-pre-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-pre-remove">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-remove-ext">
-   <b><a href="#concept-node-remove-ext">#concept-node-remove-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-remove-ext" class="dfn-panel" data-for="concept-node-remove-ext" id="infopanel-for-concept-node-remove-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-node-remove-ext" style="display:none">Info about the 'removing steps' definition.</span><b><a href="#concept-node-remove-ext">#concept-node-remove-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-remove-ext">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-remove-ext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-remove">
-   <b><a href="#concept-node-remove">#concept-node-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-remove" class="dfn-panel" data-for="concept-node-remove" id="infopanel-for-concept-node-remove" role="dialog">
+   <span id="infopaneltitle-for-concept-node-remove" style="display:none">Info about the 'remove' definition.</span><b><a href="#concept-node-remove">#concept-node-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-remove">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-remove①">(2)</a> <a href="#ref-for-concept-node-remove②">(3)</a> <a href="#ref-for-concept-node-remove③">(4)</a> <a href="#ref-for-concept-node-remove④">(5)</a> <a href="#ref-for-concept-node-remove⑤">(6)</a>
     <li><a href="#ref-for-concept-node-remove⑥">4.2.8. Mixin ChildNode</a>
@@ -16426,155 +16426,155 @@ APIs</a>
     <li><a href="#ref-for-concept-node-remove①①">5.5. Interface Range</a> <a href="#ref-for-concept-node-remove①②">(2)</a> <a href="#ref-for-concept-node-remove①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nonelementparentnode">
-   <b><a href="#nonelementparentnode">#nonelementparentnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nonelementparentnode" class="dfn-panel" data-for="nonelementparentnode" id="infopanel-for-nonelementparentnode" role="dialog">
+   <span id="infopaneltitle-for-nonelementparentnode" style="display:none">Info about the 'NonElementParentNode' definition.</span><b><a href="#nonelementparentnode">#nonelementparentnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nonelementparentnode">4.2.4. Mixin NonElementParentNode</a> <a href="#ref-for-nonelementparentnode①">(2)</a> <a href="#ref-for-nonelementparentnode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nonelementparentnode-getelementbyid">
-   <b><a href="#dom-nonelementparentnode-getelementbyid">#dom-nonelementparentnode-getelementbyid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nonelementparentnode-getelementbyid" class="dfn-panel" data-for="dom-nonelementparentnode-getelementbyid" id="infopanel-for-dom-nonelementparentnode-getelementbyid" role="dialog">
+   <span id="infopaneltitle-for-dom-nonelementparentnode-getelementbyid" style="display:none">Info about the 'getElementById(elementId)' definition.</span><b><a href="#dom-nonelementparentnode-getelementbyid">#dom-nonelementparentnode-getelementbyid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nonelementparentnode-getelementbyid">4.2.4. Mixin NonElementParentNode</a> <a href="#ref-for-dom-nonelementparentnode-getelementbyid①">(2)</a> <a href="#ref-for-dom-nonelementparentnode-getelementbyid②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="documentorshadowroot">
-   <b><a href="#documentorshadowroot">#documentorshadowroot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documentorshadowroot" class="dfn-panel" data-for="documentorshadowroot" id="infopanel-for-documentorshadowroot" role="dialog">
+   <span id="infopaneltitle-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' definition.</span><b><a href="#documentorshadowroot">#documentorshadowroot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">4.2.5. Mixin DocumentOrShadowRoot</a> <a href="#ref-for-documentorshadowroot①">(2)</a> <a href="#ref-for-documentorshadowroot②">(3)</a> <a href="#ref-for-documentorshadowroot③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="converting-nodes-into-a-node">
-   <b><a href="#converting-nodes-into-a-node">#converting-nodes-into-a-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-converting-nodes-into-a-node" class="dfn-panel" data-for="converting-nodes-into-a-node" id="infopanel-for-converting-nodes-into-a-node" role="dialog">
+   <span id="infopaneltitle-for-converting-nodes-into-a-node" style="display:none">Info about the 'convert nodes into a node' definition.</span><b><a href="#converting-nodes-into-a-node">#converting-nodes-into-a-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-converting-nodes-into-a-node">4.2.6. Mixin ParentNode</a> <a href="#ref-for-converting-nodes-into-a-node①">(2)</a> <a href="#ref-for-converting-nodes-into-a-node②">(3)</a>
     <li><a href="#ref-for-converting-nodes-into-a-node③">4.2.8. Mixin ChildNode</a> <a href="#ref-for-converting-nodes-into-a-node④">(2)</a> <a href="#ref-for-converting-nodes-into-a-node⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parentnode">
-   <b><a href="#parentnode">#parentnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parentnode" class="dfn-panel" data-for="parentnode" id="infopanel-for-parentnode" role="dialog">
+   <span id="infopaneltitle-for-parentnode" style="display:none">Info about the 'ParentNode' definition.</span><b><a href="#parentnode">#parentnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parentnode">4.2.4. Mixin NonElementParentNode</a>
     <li><a href="#ref-for-parentnode①">4.2.6. Mixin ParentNode</a> <a href="#ref-for-parentnode②">(2)</a> <a href="#ref-for-parentnode③">(3)</a> <a href="#ref-for-parentnode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-children">
-   <b><a href="#dom-parentnode-children">#dom-parentnode-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-children" class="dfn-panel" data-for="dom-parentnode-children" id="infopanel-for-dom-parentnode-children" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-children" style="display:none">Info about the 'children' definition.</span><b><a href="#dom-parentnode-children">#dom-parentnode-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-children">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-children①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-firstelementchild">
-   <b><a href="#dom-parentnode-firstelementchild">#dom-parentnode-firstelementchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-firstelementchild" class="dfn-panel" data-for="dom-parentnode-firstelementchild" id="infopanel-for-dom-parentnode-firstelementchild" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-firstelementchild" style="display:none">Info about the 'firstElementChild' definition.</span><b><a href="#dom-parentnode-firstelementchild">#dom-parentnode-firstelementchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-firstelementchild">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-firstelementchild①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-lastelementchild">
-   <b><a href="#dom-parentnode-lastelementchild">#dom-parentnode-lastelementchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-lastelementchild" class="dfn-panel" data-for="dom-parentnode-lastelementchild" id="infopanel-for-dom-parentnode-lastelementchild" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-lastelementchild" style="display:none">Info about the 'lastElementChild' definition.</span><b><a href="#dom-parentnode-lastelementchild">#dom-parentnode-lastelementchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-lastelementchild">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-lastelementchild①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-childelementcount">
-   <b><a href="#dom-parentnode-childelementcount">#dom-parentnode-childelementcount</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-childelementcount" class="dfn-panel" data-for="dom-parentnode-childelementcount" id="infopanel-for-dom-parentnode-childelementcount" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-childelementcount" style="display:none">Info about the 'childElementCount' definition.</span><b><a href="#dom-parentnode-childelementcount">#dom-parentnode-childelementcount</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-childelementcount">4.2.6. Mixin ParentNode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-prepend">
-   <b><a href="#dom-parentnode-prepend">#dom-parentnode-prepend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-prepend" class="dfn-panel" data-for="dom-parentnode-prepend" id="infopanel-for-dom-parentnode-prepend" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-prepend" style="display:none">Info about the 'prepend(nodes)' definition.</span><b><a href="#dom-parentnode-prepend">#dom-parentnode-prepend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-prepend">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-prepend①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-append">
-   <b><a href="#dom-parentnode-append">#dom-parentnode-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-append" class="dfn-panel" data-for="dom-parentnode-append" id="infopanel-for-dom-parentnode-append" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-append" style="display:none">Info about the 'append(nodes)' definition.</span><b><a href="#dom-parentnode-append">#dom-parentnode-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-append">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-replacechildren">
-   <b><a href="#dom-parentnode-replacechildren">#dom-parentnode-replacechildren</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-replacechildren" class="dfn-panel" data-for="dom-parentnode-replacechildren" id="infopanel-for-dom-parentnode-replacechildren" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-replacechildren" style="display:none">Info about the 'replaceChildren(nodes)' definition.</span><b><a href="#dom-parentnode-replacechildren">#dom-parentnode-replacechildren</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-replacechildren">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-replacechildren①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-queryselector">
-   <b><a href="#dom-parentnode-queryselector">#dom-parentnode-queryselector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-queryselector" class="dfn-panel" data-for="dom-parentnode-queryselector" id="infopanel-for-dom-parentnode-queryselector" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-queryselector" style="display:none">Info about the 'querySelector(selectors)' definition.</span><b><a href="#dom-parentnode-queryselector">#dom-parentnode-queryselector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-queryselector">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-queryselector①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-parentnode-queryselectorall">
-   <b><a href="#dom-parentnode-queryselectorall">#dom-parentnode-queryselectorall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-parentnode-queryselectorall" class="dfn-panel" data-for="dom-parentnode-queryselectorall" id="infopanel-for-dom-parentnode-queryselectorall" role="dialog">
+   <span id="infopaneltitle-for-dom-parentnode-queryselectorall" style="display:none">Info about the 'querySelectorAll(selectors)' definition.</span><b><a href="#dom-parentnode-queryselectorall">#dom-parentnode-queryselectorall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-parentnode-queryselectorall">4.2.6. Mixin ParentNode</a> <a href="#ref-for-dom-parentnode-queryselectorall①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nondocumenttypechildnode">
-   <b><a href="#nondocumenttypechildnode">#nondocumenttypechildnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nondocumenttypechildnode" class="dfn-panel" data-for="nondocumenttypechildnode" id="infopanel-for-nondocumenttypechildnode" role="dialog">
+   <span id="infopaneltitle-for-nondocumenttypechildnode" style="display:none">Info about the 'NonDocumentTypeChildNode' definition.</span><b><a href="#nondocumenttypechildnode">#nondocumenttypechildnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nondocumenttypechildnode">4.2.7. Mixin NonDocumentTypeChildNode</a> <a href="#ref-for-nondocumenttypechildnode①">(2)</a> <a href="#ref-for-nondocumenttypechildnode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nondocumenttypechildnode-previouselementsibling">
-   <b><a href="#dom-nondocumenttypechildnode-previouselementsibling">#dom-nondocumenttypechildnode-previouselementsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nondocumenttypechildnode-previouselementsibling" class="dfn-panel" data-for="dom-nondocumenttypechildnode-previouselementsibling" id="infopanel-for-dom-nondocumenttypechildnode-previouselementsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-nondocumenttypechildnode-previouselementsibling" style="display:none">Info about the 'previousElementSibling' definition.</span><b><a href="#dom-nondocumenttypechildnode-previouselementsibling">#dom-nondocumenttypechildnode-previouselementsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nondocumenttypechildnode-previouselementsibling">4.2.7. Mixin NonDocumentTypeChildNode</a> <a href="#ref-for-dom-nondocumenttypechildnode-previouselementsibling①">(2)</a> <a href="#ref-for-dom-nondocumenttypechildnode-previouselementsibling②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nondocumenttypechildnode-nextelementsibling">
-   <b><a href="#dom-nondocumenttypechildnode-nextelementsibling">#dom-nondocumenttypechildnode-nextelementsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nondocumenttypechildnode-nextelementsibling" class="dfn-panel" data-for="dom-nondocumenttypechildnode-nextelementsibling" id="infopanel-for-dom-nondocumenttypechildnode-nextelementsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-nondocumenttypechildnode-nextelementsibling" style="display:none">Info about the 'nextElementSibling' definition.</span><b><a href="#dom-nondocumenttypechildnode-nextelementsibling">#dom-nondocumenttypechildnode-nextelementsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nondocumenttypechildnode-nextelementsibling">4.2.7. Mixin NonDocumentTypeChildNode</a> <a href="#ref-for-dom-nondocumenttypechildnode-nextelementsibling①">(2)</a> <a href="#ref-for-dom-nondocumenttypechildnode-nextelementsibling②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="childnode">
-   <b><a href="#childnode">#childnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-childnode" class="dfn-panel" data-for="childnode" id="infopanel-for-childnode" role="dialog">
+   <span id="infopaneltitle-for-childnode" style="display:none">Info about the 'ChildNode' definition.</span><b><a href="#childnode">#childnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-childnode">4.2.7. Mixin NonDocumentTypeChildNode</a>
     <li><a href="#ref-for-childnode①">4.2.8. Mixin ChildNode</a> <a href="#ref-for-childnode②">(2)</a> <a href="#ref-for-childnode③">(3)</a> <a href="#ref-for-childnode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-childnode-before">
-   <b><a href="#dom-childnode-before">#dom-childnode-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-childnode-before" class="dfn-panel" data-for="dom-childnode-before" id="infopanel-for-dom-childnode-before" role="dialog">
+   <span id="infopaneltitle-for-dom-childnode-before" style="display:none">Info about the 'before(nodes)' definition.</span><b><a href="#dom-childnode-before">#dom-childnode-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-childnode-before">4.2.8. Mixin ChildNode</a> <a href="#ref-for-dom-childnode-before①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-childnode-after">
-   <b><a href="#dom-childnode-after">#dom-childnode-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-childnode-after" class="dfn-panel" data-for="dom-childnode-after" id="infopanel-for-dom-childnode-after" role="dialog">
+   <span id="infopaneltitle-for-dom-childnode-after" style="display:none">Info about the 'after(nodes)' definition.</span><b><a href="#dom-childnode-after">#dom-childnode-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-childnode-after">4.2.8. Mixin ChildNode</a> <a href="#ref-for-dom-childnode-after①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-childnode-replacewith">
-   <b><a href="#dom-childnode-replacewith">#dom-childnode-replacewith</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-childnode-replacewith" class="dfn-panel" data-for="dom-childnode-replacewith" id="infopanel-for-dom-childnode-replacewith" role="dialog">
+   <span id="infopaneltitle-for-dom-childnode-replacewith" style="display:none">Info about the 'replaceWith(nodes)' definition.</span><b><a href="#dom-childnode-replacewith">#dom-childnode-replacewith</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-childnode-replacewith">4.2.8. Mixin ChildNode</a> <a href="#ref-for-dom-childnode-replacewith①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-childnode-remove">
-   <b><a href="#dom-childnode-remove">#dom-childnode-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-childnode-remove" class="dfn-panel" data-for="dom-childnode-remove" id="infopanel-for-dom-childnode-remove" role="dialog">
+   <span id="infopaneltitle-for-dom-childnode-remove" style="display:none">Info about the 'remove()' definition.</span><b><a href="#dom-childnode-remove">#dom-childnode-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-childnode-remove">4.2.8. Mixin ChildNode</a> <a href="#ref-for-dom-childnode-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="slotable">
-   <b><a href="#slotable">#slotable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-slotable" class="dfn-panel" data-for="slotable" id="infopanel-for-slotable" role="dialog">
+   <span id="infopaneltitle-for-slotable" style="display:none">Info about the 'Slottable' definition.</span><b><a href="#slotable">#slotable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-slotable">4.2.9. Mixin Slottable</a> <a href="#ref-for-slotable①">(2)</a> <a href="#ref-for-slotable②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-slotable-assignedslot">
-   <b><a href="#dom-slotable-assignedslot">#dom-slotable-assignedslot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-slotable-assignedslot" class="dfn-panel" data-for="dom-slotable-assignedslot" id="infopanel-for-dom-slotable-assignedslot" role="dialog">
+   <span id="infopaneltitle-for-dom-slotable-assignedslot" style="display:none">Info about the 'assignedSlot' definition.</span><b><a href="#dom-slotable-assignedslot">#dom-slotable-assignedslot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-slotable-assignedslot">4.2.9. Mixin Slottable</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-collection">
-   <b><a href="#concept-collection">#concept-collection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-collection" class="dfn-panel" data-for="concept-collection" id="infopanel-for-concept-collection" role="dialog">
+   <span id="infopaneltitle-for-concept-collection" style="display:none">Info about the 'collection' definition.</span><b><a href="#concept-collection">#concept-collection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-collection">4.2.6. Mixin ParentNode</a>
     <li><a href="#ref-for-concept-collection①">4.2.10. Old-style collections: NodeList and HTMLCollection</a> <a href="#ref-for-concept-collection②">(2)</a> <a href="#ref-for-concept-collection③">(3)</a> <a href="#ref-for-concept-collection④">(4)</a> <a href="#ref-for-concept-collection⑤">(5)</a> <a href="#ref-for-concept-collection⑥">(6)</a> <a href="#ref-for-concept-collection⑦">(7)</a>
@@ -16583,27 +16583,27 @@ APIs</a>
     <li><a href="#ref-for-concept-collection①⑨">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-collection-live">
-   <b><a href="#concept-collection-live">#concept-collection-live</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-collection-live" class="dfn-panel" data-for="concept-collection-live" id="infopanel-for-concept-collection-live" role="dialog">
+   <span id="infopaneltitle-for-concept-collection-live" style="display:none">Info about the 'live' definition.</span><b><a href="#concept-collection-live">#concept-collection-live</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-collection-live">4.2.10. Old-style collections: NodeList and HTMLCollection</a> <a href="#ref-for-concept-collection-live①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-collection-static">
-   <b><a href="#concept-collection-static">#concept-collection-static</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-collection-static" class="dfn-panel" data-for="concept-collection-static" id="infopanel-for-concept-collection-static" role="dialog">
+   <span id="infopaneltitle-for-concept-collection-static" style="display:none">Info about the 'static' definition.</span><b><a href="#concept-collection-static">#concept-collection-static</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-collection-static">4.2.6. Mixin ParentNode</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="represented-by-the-collection">
-   <b><a href="#represented-by-the-collection">#represented-by-the-collection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-represented-by-the-collection" class="dfn-panel" data-for="represented-by-the-collection" id="infopanel-for-represented-by-the-collection" role="dialog">
+   <span id="infopaneltitle-for-represented-by-the-collection" style="display:none">Info about the 'represents' definition.</span><b><a href="#represented-by-the-collection">#represented-by-the-collection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-represented-by-the-collection">4.2.10.1. Interface NodeList</a> <a href="#ref-for-represented-by-the-collection①">(2)</a>
     <li><a href="#ref-for-represented-by-the-collection②">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-represented-by-the-collection③">(2)</a> <a href="#ref-for-represented-by-the-collection④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nodelist">
-   <b><a href="#nodelist">#nodelist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nodelist" class="dfn-panel" data-for="nodelist" id="infopanel-for-nodelist" role="dialog">
+   <span id="infopaneltitle-for-nodelist" style="display:none">Info about the 'NodeList' definition.</span><b><a href="#nodelist">#nodelist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodelist">4.2.6. Mixin ParentNode</a>
     <li><a href="#ref-for-nodelist①">4.2.10. Old-style collections: NodeList and HTMLCollection</a>
@@ -16612,20 +16612,20 @@ APIs</a>
     <li><a href="#ref-for-nodelist⑥">4.4. Interface Node</a> <a href="#ref-for-nodelist⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodelist-length">
-   <b><a href="#dom-nodelist-length">#dom-nodelist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodelist-length" class="dfn-panel" data-for="dom-nodelist-length" id="infopanel-for-dom-nodelist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-nodelist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-nodelist-length">#dom-nodelist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodelist-length">4.2.10.1. Interface NodeList</a> <a href="#ref-for-dom-nodelist-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodelist-item">
-   <b><a href="#dom-nodelist-item">#dom-nodelist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodelist-item" class="dfn-panel" data-for="dom-nodelist-item" id="infopanel-for-dom-nodelist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-nodelist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-nodelist-item">#dom-nodelist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodelist-item">4.2.10.1. Interface NodeList</a> <a href="#ref-for-dom-nodelist-item①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="htmlcollection">
-   <b><a href="#htmlcollection">#htmlcollection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-htmlcollection" class="dfn-panel" data-for="htmlcollection" id="infopanel-for-htmlcollection" role="dialog">
+   <span id="infopaneltitle-for-htmlcollection" style="display:none">Info about the 'HTMLCollection' definition.</span><b><a href="#htmlcollection">#htmlcollection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlcollection">4.2.6. Mixin ParentNode</a> <a href="#ref-for-htmlcollection①">(2)</a>
     <li><a href="#ref-for-htmlcollection②">4.2.10. Old-style collections: NodeList and HTMLCollection</a>
@@ -16635,52 +16635,52 @@ APIs</a>
     <li><a href="#ref-for-htmlcollection③②">4.9. Interface Element</a> <a href="#ref-for-htmlcollection③③">(2)</a> <a href="#ref-for-htmlcollection③④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlcollection-nameditem">
-   <b><a href="#dom-htmlcollection-nameditem">#dom-htmlcollection-nameditem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlcollection-nameditem" class="dfn-panel" data-for="dom-htmlcollection-nameditem" id="infopanel-for-dom-htmlcollection-nameditem" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlcollection-nameditem" style="display:none">Info about the 'namedItem' definition.</span><b><a href="#dom-htmlcollection-nameditem">#dom-htmlcollection-nameditem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlcollection-nameditem">4.2.10.2. Interface HTMLCollection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlcollection-length">
-   <b><a href="#dom-htmlcollection-length">#dom-htmlcollection-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlcollection-length" class="dfn-panel" data-for="dom-htmlcollection-length" id="infopanel-for-dom-htmlcollection-length" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlcollection-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-htmlcollection-length">#dom-htmlcollection-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlcollection-length">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-dom-htmlcollection-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-htmlcollection-item">
-   <b><a href="#dom-htmlcollection-item">#dom-htmlcollection-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-htmlcollection-item" class="dfn-panel" data-for="dom-htmlcollection-item" id="infopanel-for-dom-htmlcollection-item" role="dialog">
+   <span id="infopaneltitle-for-dom-htmlcollection-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-htmlcollection-item">#dom-htmlcollection-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-htmlcollection-item">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-dom-htmlcollection-item①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mutation-observer-compound-microtask-queued-flag">
-   <b><a href="#mutation-observer-compound-microtask-queued-flag">#mutation-observer-compound-microtask-queued-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mutation-observer-compound-microtask-queued-flag" class="dfn-panel" data-for="mutation-observer-compound-microtask-queued-flag" id="infopanel-for-mutation-observer-compound-microtask-queued-flag" role="dialog">
+   <span id="infopaneltitle-for-mutation-observer-compound-microtask-queued-flag" style="display:none">Info about the 'mutation observer microtask queued' definition.</span><b><a href="#mutation-observer-compound-microtask-queued-flag">#mutation-observer-compound-microtask-queued-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutation-observer-compound-microtask-queued-flag">4.3. Mutation observers</a> <a href="#ref-for-mutation-observer-compound-microtask-queued-flag①">(2)</a> <a href="#ref-for-mutation-observer-compound-microtask-queued-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mutation-observer-list">
-   <b><a href="#mutation-observer-list">#mutation-observer-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mutation-observer-list" class="dfn-panel" data-for="mutation-observer-list" id="infopanel-for-mutation-observer-list" role="dialog">
+   <span id="infopaneltitle-for-mutation-observer-list" style="display:none">Info about the 'mutation observers' definition.</span><b><a href="#mutation-observer-list">#mutation-observer-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutation-observer-list">4.3. Mutation observers</a>
     <li><a href="#ref-for-mutation-observer-list①">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-mutation-observer-compound-microtask">
-   <b><a href="#queue-a-mutation-observer-compound-microtask">#queue-a-mutation-observer-compound-microtask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-mutation-observer-compound-microtask" class="dfn-panel" data-for="queue-a-mutation-observer-compound-microtask" id="infopanel-for-queue-a-mutation-observer-compound-microtask" role="dialog">
+   <span id="infopaneltitle-for-queue-a-mutation-observer-compound-microtask" style="display:none">Info about the 'queue a mutation observer microtask' definition.</span><b><a href="#queue-a-mutation-observer-compound-microtask">#queue-a-mutation-observer-compound-microtask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-mutation-observer-compound-microtask">4.2.2.5. Signaling slot change</a>
     <li><a href="#ref-for-queue-a-mutation-observer-compound-microtask①">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notify-mutation-observers">
-   <b><a href="#notify-mutation-observers">#notify-mutation-observers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notify-mutation-observers" class="dfn-panel" data-for="notify-mutation-observers" id="infopanel-for-notify-mutation-observers" role="dialog">
+   <span id="infopaneltitle-for-notify-mutation-observers" style="display:none">Info about the 'notify mutation observers' definition.</span><b><a href="#notify-mutation-observers">#notify-mutation-observers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notify-mutation-observers">4.3. Mutation observers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered-observer-list">
-   <b><a href="#registered-observer-list">#registered-observer-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-observer-list" class="dfn-panel" data-for="registered-observer-list" id="infopanel-for-registered-observer-list" role="dialog">
+   <span id="infopaneltitle-for-registered-observer-list" style="display:none">Info about the 'registered observer list' definition.</span><b><a href="#registered-observer-list">#registered-observer-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-observer-list">4.2.3. Mutation algorithms</a> <a href="#ref-for-registered-observer-list①">(2)</a>
     <li><a href="#ref-for-registered-observer-list②">4.3. Mutation observers</a>
@@ -16690,16 +16690,16 @@ APIs</a>
     <li><a href="#ref-for-registered-observer-list①⓪">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered-observer">
-   <b><a href="#registered-observer">#registered-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-observer" class="dfn-panel" data-for="registered-observer" id="infopanel-for-registered-observer" role="dialog">
+   <span id="infopaneltitle-for-registered-observer" style="display:none">Info about the 'registered observer' definition.</span><b><a href="#registered-observer">#registered-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-observer">4.3. Mutation observers</a> <a href="#ref-for-registered-observer①">(2)</a> <a href="#ref-for-registered-observer②">(3)</a>
     <li><a href="#ref-for-registered-observer③">4.3.1. Interface MutationObserver</a> <a href="#ref-for-registered-observer④">(2)</a>
     <li><a href="#ref-for-registered-observer⑤">4.3.4. Garbage collection</a> <a href="#ref-for-registered-observer⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered-observer-observer">
-   <b><a href="#registered-observer-observer">#registered-observer-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-observer-observer" class="dfn-panel" data-for="registered-observer-observer" id="infopanel-for-registered-observer-observer" role="dialog">
+   <span id="infopaneltitle-for-registered-observer-observer" style="display:none">Info about the 'observer' definition.</span><b><a href="#registered-observer-observer">#registered-observer-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-observer-observer">4.2.3. Mutation algorithms</a> <a href="#ref-for-registered-observer-observer①">(2)</a>
     <li><a href="#ref-for-registered-observer-observer②">4.3. Mutation observers</a>
@@ -16707,72 +16707,72 @@ APIs</a>
     <li><a href="#ref-for-registered-observer-observer⑥">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered-observer-options">
-   <b><a href="#registered-observer-options">#registered-observer-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-observer-options" class="dfn-panel" data-for="registered-observer-options" id="infopanel-for-registered-observer-options" role="dialog">
+   <span id="infopaneltitle-for-registered-observer-options" style="display:none">Info about the 'options' definition.</span><b><a href="#registered-observer-options">#registered-observer-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-observer-options">4.2.3. Mutation algorithms</a> <a href="#ref-for-registered-observer-options①">(2)</a> <a href="#ref-for-registered-observer-options②">(3)</a>
     <li><a href="#ref-for-registered-observer-options③">4.3.1. Interface MutationObserver</a> <a href="#ref-for-registered-observer-options④">(2)</a>
     <li><a href="#ref-for-registered-observer-options⑤">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transient-registered-observer">
-   <b><a href="#transient-registered-observer">#transient-registered-observer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transient-registered-observer" class="dfn-panel" data-for="transient-registered-observer" id="infopanel-for-transient-registered-observer" role="dialog">
+   <span id="infopaneltitle-for-transient-registered-observer" style="display:none">Info about the 'transient registered observer' definition.</span><b><a href="#transient-registered-observer">#transient-registered-observer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-registered-observer">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-transient-registered-observer①">4.3. Mutation observers</a> <a href="#ref-for-transient-registered-observer②">(2)</a>
     <li><a href="#ref-for-transient-registered-observer③">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transient-registered-observer-source">
-   <b><a href="#transient-registered-observer-source">#transient-registered-observer-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transient-registered-observer-source" class="dfn-panel" data-for="transient-registered-observer-source" id="infopanel-for-transient-registered-observer-source" role="dialog">
+   <span id="infopaneltitle-for-transient-registered-observer-source" style="display:none">Info about the 'source' definition.</span><b><a href="#transient-registered-observer-source">#transient-registered-observer-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-registered-observer-source">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-transient-registered-observer-source①">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mutationobserver">
-   <b><a href="#mutationobserver">#mutationobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mutationobserver" class="dfn-panel" data-for="mutationobserver" id="infopanel-for-mutationobserver" role="dialog">
+   <span id="infopaneltitle-for-mutationobserver" style="display:none">Info about the 'MutationObserver' definition.</span><b><a href="#mutationobserver">#mutationobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationobserver">4.3. Mutation observers</a> <a href="#ref-for-mutationobserver①">(2)</a>
     <li><a href="#ref-for-mutationobserver②">4.3.1. Interface MutationObserver</a> <a href="#ref-for-mutationobserver③">(2)</a> <a href="#ref-for-mutationobserver④">(3)</a> <a href="#ref-for-mutationobserver⑤">(4)</a> <a href="#ref-for-mutationobserver⑥">(5)</a> <a href="#ref-for-mutationobserver⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-mutationcallback">
-   <b><a href="#callbackdef-mutationcallback">#callbackdef-mutationcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-mutationcallback" class="dfn-panel" data-for="callbackdef-mutationcallback" id="infopanel-for-callbackdef-mutationcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-mutationcallback" style="display:none">Info about the 'MutationCallback' definition.</span><b><a href="#callbackdef-mutationcallback">#callbackdef-mutationcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-mutationcallback">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-mutationobserverinit">
-   <b><a href="#dictdef-mutationobserverinit">#dictdef-mutationobserverinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-mutationobserverinit" class="dfn-panel" data-for="dictdef-mutationobserverinit" id="infopanel-for-dictdef-mutationobserverinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-mutationobserverinit" style="display:none">Info about the 'MutationObserverInit' definition.</span><b><a href="#dictdef-mutationobserverinit">#dictdef-mutationobserverinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-mutationobserverinit">4.3. Mutation observers</a>
     <li><a href="#ref-for-dictdef-mutationobserverinit①">4.3.1. Interface MutationObserver</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-childlist">
-   <b><a href="#dom-mutationobserverinit-childlist">#dom-mutationobserverinit-childlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-childlist" class="dfn-panel" data-for="dom-mutationobserverinit-childlist" id="infopanel-for-dom-mutationobserverinit-childlist" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-childlist" style="display:none">Info about the 'childList' definition.</span><b><a href="#dom-mutationobserverinit-childlist">#dom-mutationobserverinit-childlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-childlist">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-childlist①">(2)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-childlist②">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-attributes">
-   <b><a href="#dom-mutationobserverinit-attributes">#dom-mutationobserverinit-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-attributes" class="dfn-panel" data-for="dom-mutationobserverinit-attributes" id="infopanel-for-dom-mutationobserverinit-attributes" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-attributes" style="display:none">Info about the 'attributes' definition.</span><b><a href="#dom-mutationobserverinit-attributes">#dom-mutationobserverinit-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-attributes">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-attributes①">(2)</a> <a href="#ref-for-dom-mutationobserverinit-attributes②">(3)</a> <a href="#ref-for-dom-mutationobserverinit-attributes③">(4)</a> <a href="#ref-for-dom-mutationobserverinit-attributes④">(5)</a> <a href="#ref-for-dom-mutationobserverinit-attributes⑤">(6)</a> <a href="#ref-for-dom-mutationobserverinit-attributes⑥">(7)</a> <a href="#ref-for-dom-mutationobserverinit-attributes⑦">(8)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-attributes⑧">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-characterdata">
-   <b><a href="#dom-mutationobserverinit-characterdata">#dom-mutationobserverinit-characterdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-characterdata" class="dfn-panel" data-for="dom-mutationobserverinit-characterdata" id="infopanel-for-dom-mutationobserverinit-characterdata" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-characterdata" style="display:none">Info about the 'characterData' definition.</span><b><a href="#dom-mutationobserverinit-characterdata">#dom-mutationobserverinit-characterdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-characterdata">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-characterdata①">(2)</a> <a href="#ref-for-dom-mutationobserverinit-characterdata②">(3)</a> <a href="#ref-for-dom-mutationobserverinit-characterdata③">(4)</a> <a href="#ref-for-dom-mutationobserverinit-characterdata④">(5)</a> <a href="#ref-for-dom-mutationobserverinit-characterdata⑤">(6)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-characterdata⑥">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-subtree">
-   <b><a href="#dom-mutationobserverinit-subtree">#dom-mutationobserverinit-subtree</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-subtree" class="dfn-panel" data-for="dom-mutationobserverinit-subtree" id="infopanel-for-dom-mutationobserverinit-subtree" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-subtree" style="display:none">Info about the 'subtree' definition.</span><b><a href="#dom-mutationobserverinit-subtree">#dom-mutationobserverinit-subtree</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-subtree">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-dom-mutationobserverinit-subtree①">4.3. Mutation observers</a>
@@ -16780,160 +16780,160 @@ APIs</a>
     <li><a href="#ref-for-dom-mutationobserverinit-subtree③">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-attributeoldvalue">
-   <b><a href="#dom-mutationobserverinit-attributeoldvalue">#dom-mutationobserverinit-attributeoldvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-attributeoldvalue" class="dfn-panel" data-for="dom-mutationobserverinit-attributeoldvalue" id="infopanel-for-dom-mutationobserverinit-attributeoldvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-attributeoldvalue" style="display:none">Info about the 'attributeOldValue' definition.</span><b><a href="#dom-mutationobserverinit-attributeoldvalue">#dom-mutationobserverinit-attributeoldvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-attributeoldvalue">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-attributeoldvalue①">(2)</a> <a href="#ref-for-dom-mutationobserverinit-attributeoldvalue②">(3)</a> <a href="#ref-for-dom-mutationobserverinit-attributeoldvalue③">(4)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-attributeoldvalue④">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-characterdataoldvalue">
-   <b><a href="#dom-mutationobserverinit-characterdataoldvalue">#dom-mutationobserverinit-characterdataoldvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-characterdataoldvalue" class="dfn-panel" data-for="dom-mutationobserverinit-characterdataoldvalue" id="infopanel-for-dom-mutationobserverinit-characterdataoldvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-characterdataoldvalue" style="display:none">Info about the 'characterDataOldValue' definition.</span><b><a href="#dom-mutationobserverinit-characterdataoldvalue">#dom-mutationobserverinit-characterdataoldvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-characterdataoldvalue">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-characterdataoldvalue①">(2)</a> <a href="#ref-for-dom-mutationobserverinit-characterdataoldvalue②">(3)</a> <a href="#ref-for-dom-mutationobserverinit-characterdataoldvalue③">(4)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-characterdataoldvalue④">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserverinit-attributefilter">
-   <b><a href="#dom-mutationobserverinit-attributefilter">#dom-mutationobserverinit-attributefilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserverinit-attributefilter" class="dfn-panel" data-for="dom-mutationobserverinit-attributefilter" id="infopanel-for-dom-mutationobserverinit-attributefilter" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserverinit-attributefilter" style="display:none">Info about the 'attributeFilter' definition.</span><b><a href="#dom-mutationobserverinit-attributefilter">#dom-mutationobserverinit-attributefilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserverinit-attributefilter">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserverinit-attributefilter①">(2)</a> <a href="#ref-for-dom-mutationobserverinit-attributefilter②">(3)</a> <a href="#ref-for-dom-mutationobserverinit-attributefilter③">(4)</a>
     <li><a href="#ref-for-dom-mutationobserverinit-attributefilter④">4.3.2. Queuing a mutation record</a> <a href="#ref-for-dom-mutationobserverinit-attributefilter⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-mo-callback">
-   <b><a href="#concept-mo-callback">#concept-mo-callback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-mo-callback" class="dfn-panel" data-for="concept-mo-callback" id="infopanel-for-concept-mo-callback" role="dialog">
+   <span id="infopaneltitle-for-concept-mo-callback" style="display:none">Info about the 'callback' definition.</span><b><a href="#concept-mo-callback">#concept-mo-callback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-mo-callback">4.3. Mutation observers</a>
     <li><a href="#ref-for-concept-mo-callback①">4.3.1. Interface MutationObserver</a> <a href="#ref-for-concept-mo-callback②">(2)</a> <a href="#ref-for-concept-mo-callback③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mutationobserver-node-list">
-   <b><a href="#mutationobserver-node-list">#mutationobserver-node-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mutationobserver-node-list" class="dfn-panel" data-for="mutationobserver-node-list" id="infopanel-for-mutationobserver-node-list" role="dialog">
+   <span id="infopaneltitle-for-mutationobserver-node-list" style="display:none">Info about the 'node list' definition.</span><b><a href="#mutationobserver-node-list">#mutationobserver-node-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationobserver-node-list">4.3. Mutation observers</a>
     <li><a href="#ref-for-mutationobserver-node-list①">4.3.1. Interface MutationObserver</a> <a href="#ref-for-mutationobserver-node-list②">(2)</a> <a href="#ref-for-mutationobserver-node-list③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-mo-queue">
-   <b><a href="#concept-mo-queue">#concept-mo-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-mo-queue" class="dfn-panel" data-for="concept-mo-queue" id="infopanel-for-concept-mo-queue" role="dialog">
+   <span id="infopaneltitle-for-concept-mo-queue" style="display:none">Info about the 'record queue' definition.</span><b><a href="#concept-mo-queue">#concept-mo-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-mo-queue">4.3. Mutation observers</a> <a href="#ref-for-concept-mo-queue①">(2)</a>
     <li><a href="#ref-for-concept-mo-queue②">4.3.1. Interface MutationObserver</a> <a href="#ref-for-concept-mo-queue③">(2)</a> <a href="#ref-for-concept-mo-queue④">(3)</a> <a href="#ref-for-concept-mo-queue⑤">(4)</a>
     <li><a href="#ref-for-concept-mo-queue⑥">4.3.2. Queuing a mutation record</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserver-mutationobserver">
-   <b><a href="#dom-mutationobserver-mutationobserver">#dom-mutationobserver-mutationobserver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserver-mutationobserver" class="dfn-panel" data-for="dom-mutationobserver-mutationobserver" id="infopanel-for-dom-mutationobserver-mutationobserver" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserver-mutationobserver" style="display:none">Info about the 'new MutationObserver(callback)' definition.</span><b><a href="#dom-mutationobserver-mutationobserver">#dom-mutationobserver-mutationobserver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserver-mutationobserver">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserver-mutationobserver①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserver-observe">
-   <b><a href="#dom-mutationobserver-observe">#dom-mutationobserver-observe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserver-observe" class="dfn-panel" data-for="dom-mutationobserver-observe" id="infopanel-for-dom-mutationobserver-observe" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserver-observe" style="display:none">Info about the 'observe(target, options)' definition.</span><b><a href="#dom-mutationobserver-observe">#dom-mutationobserver-observe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserver-observe">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserver-observe①">(2)</a> <a href="#ref-for-dom-mutationobserver-observe②">(3)</a> <a href="#ref-for-dom-mutationobserver-observe③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserver-disconnect">
-   <b><a href="#dom-mutationobserver-disconnect">#dom-mutationobserver-disconnect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserver-disconnect" class="dfn-panel" data-for="dom-mutationobserver-disconnect" id="infopanel-for-dom-mutationobserver-disconnect" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserver-disconnect" style="display:none">Info about the 'disconnect()' definition.</span><b><a href="#dom-mutationobserver-disconnect">#dom-mutationobserver-disconnect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserver-disconnect">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserver-disconnect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationobserver-takerecords">
-   <b><a href="#dom-mutationobserver-takerecords">#dom-mutationobserver-takerecords</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationobserver-takerecords" class="dfn-panel" data-for="dom-mutationobserver-takerecords" id="infopanel-for-dom-mutationobserver-takerecords" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationobserver-takerecords" style="display:none">Info about the 'takeRecords()' definition.</span><b><a href="#dom-mutationobserver-takerecords">#dom-mutationobserver-takerecords</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationobserver-takerecords">4.3.1. Interface MutationObserver</a> <a href="#ref-for-dom-mutationobserver-takerecords①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-mutation-record">
-   <b><a href="#queue-a-mutation-record">#queue-a-mutation-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-mutation-record" class="dfn-panel" data-for="queue-a-mutation-record" id="infopanel-for-queue-a-mutation-record" role="dialog">
+   <span id="infopaneltitle-for-queue-a-mutation-record" style="display:none">Info about the 'queue a mutation record' definition.</span><b><a href="#queue-a-mutation-record">#queue-a-mutation-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-mutation-record">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-queue-a-mutation-record①">4.9. Interface Element</a>
     <li><a href="#ref-for-queue-a-mutation-record②">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-tree-mutation-record">
-   <b><a href="#queue-a-tree-mutation-record">#queue-a-tree-mutation-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-tree-mutation-record" class="dfn-panel" data-for="queue-a-tree-mutation-record" id="infopanel-for-queue-a-tree-mutation-record" role="dialog">
+   <span id="infopaneltitle-for-queue-a-tree-mutation-record" style="display:none">Info about the 'queue a tree mutation record' definition.</span><b><a href="#queue-a-tree-mutation-record">#queue-a-tree-mutation-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-tree-mutation-record">4.2.3. Mutation algorithms</a> <a href="#ref-for-queue-a-tree-mutation-record①">(2)</a> <a href="#ref-for-queue-a-tree-mutation-record②">(3)</a> <a href="#ref-for-queue-a-tree-mutation-record③">(4)</a> <a href="#ref-for-queue-a-tree-mutation-record④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mutationrecord">
-   <b><a href="#mutationrecord">#mutationrecord</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mutationrecord" class="dfn-panel" data-for="mutationrecord" id="infopanel-for-mutationrecord" role="dialog">
+   <span id="infopaneltitle-for-mutationrecord" style="display:none">Info about the 'MutationRecord' definition.</span><b><a href="#mutationrecord">#mutationrecord</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mutationrecord">4.3.1. Interface MutationObserver</a> <a href="#ref-for-mutationrecord①">(2)</a> <a href="#ref-for-mutationrecord②">(3)</a> <a href="#ref-for-mutationrecord③">(4)</a>
     <li><a href="#ref-for-mutationrecord④">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-mutationrecord⑤">4.3.3. Interface MutationRecord</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-type">
-   <b><a href="#dom-mutationrecord-type">#dom-mutationrecord-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-type" class="dfn-panel" data-for="dom-mutationrecord-type" id="infopanel-for-dom-mutationrecord-type" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-mutationrecord-type">#dom-mutationrecord-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-type">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-type①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-type②">(2)</a> <a href="#ref-for-dom-mutationrecord-type③">(3)</a> <a href="#ref-for-dom-mutationrecord-type④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-target">
-   <b><a href="#dom-mutationrecord-target">#dom-mutationrecord-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-target" class="dfn-panel" data-for="dom-mutationrecord-target" id="infopanel-for-dom-mutationrecord-target" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-mutationrecord-target">#dom-mutationrecord-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-target">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-target①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-target②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-addednodes">
-   <b><a href="#dom-mutationrecord-addednodes">#dom-mutationrecord-addednodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-addednodes" class="dfn-panel" data-for="dom-mutationrecord-addednodes" id="infopanel-for-dom-mutationrecord-addednodes" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-addednodes" style="display:none">Info about the 'addedNodes' definition.</span><b><a href="#dom-mutationrecord-addednodes">#dom-mutationrecord-addednodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-addednodes">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-addednodes①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-addednodes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-removednodes">
-   <b><a href="#dom-mutationrecord-removednodes">#dom-mutationrecord-removednodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-removednodes" class="dfn-panel" data-for="dom-mutationrecord-removednodes" id="infopanel-for-dom-mutationrecord-removednodes" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-removednodes" style="display:none">Info about the 'removedNodes' definition.</span><b><a href="#dom-mutationrecord-removednodes">#dom-mutationrecord-removednodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-removednodes">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-removednodes①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-removednodes②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-previoussibling">
-   <b><a href="#dom-mutationrecord-previoussibling">#dom-mutationrecord-previoussibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-previoussibling" class="dfn-panel" data-for="dom-mutationrecord-previoussibling" id="infopanel-for-dom-mutationrecord-previoussibling" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-previoussibling" style="display:none">Info about the 'previousSibling' definition.</span><b><a href="#dom-mutationrecord-previoussibling">#dom-mutationrecord-previoussibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-previoussibling">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-previoussibling①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-previoussibling②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-nextsibling">
-   <b><a href="#dom-mutationrecord-nextsibling">#dom-mutationrecord-nextsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-nextsibling" class="dfn-panel" data-for="dom-mutationrecord-nextsibling" id="infopanel-for-dom-mutationrecord-nextsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-nextsibling" style="display:none">Info about the 'nextSibling' definition.</span><b><a href="#dom-mutationrecord-nextsibling">#dom-mutationrecord-nextsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-nextsibling">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-nextsibling①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-nextsibling②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-attributename">
-   <b><a href="#dom-mutationrecord-attributename">#dom-mutationrecord-attributename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-attributename" class="dfn-panel" data-for="dom-mutationrecord-attributename" id="infopanel-for-dom-mutationrecord-attributename" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-attributename" style="display:none">Info about the 'attributeName' definition.</span><b><a href="#dom-mutationrecord-attributename">#dom-mutationrecord-attributename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-attributename">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-attributename①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-attributename②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-attributenamespace">
-   <b><a href="#dom-mutationrecord-attributenamespace">#dom-mutationrecord-attributenamespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-attributenamespace" class="dfn-panel" data-for="dom-mutationrecord-attributenamespace" id="infopanel-for-dom-mutationrecord-attributenamespace" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-attributenamespace" style="display:none">Info about the 'attributeNamespace' definition.</span><b><a href="#dom-mutationrecord-attributenamespace">#dom-mutationrecord-attributenamespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-attributenamespace">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-attributenamespace①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-attributenamespace②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-mutationrecord-oldvalue">
-   <b><a href="#dom-mutationrecord-oldvalue">#dom-mutationrecord-oldvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-mutationrecord-oldvalue" class="dfn-panel" data-for="dom-mutationrecord-oldvalue" id="infopanel-for-dom-mutationrecord-oldvalue" role="dialog">
+   <span id="infopaneltitle-for-dom-mutationrecord-oldvalue" style="display:none">Info about the 'oldValue' definition.</span><b><a href="#dom-mutationrecord-oldvalue">#dom-mutationrecord-oldvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-mutationrecord-oldvalue">4.3.2. Queuing a mutation record</a>
     <li><a href="#ref-for-dom-mutationrecord-oldvalue①">4.3.3. Interface MutationRecord</a> <a href="#ref-for-dom-mutationrecord-oldvalue②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="node">
-   <b><a href="#node">#node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-node" class="dfn-panel" data-for="node" id="infopanel-for-node" role="dialog">
+   <span id="infopaneltitle-for-node" style="display:none">Info about the 'Node' definition.</span><b><a href="#node">#node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-node">4.2.6. Mixin ParentNode</a> <a href="#ref-for-node①">(2)</a> <a href="#ref-for-node②">(3)</a>
     <li><a href="#ref-for-node③">4.2.8. Mixin ChildNode</a> <a href="#ref-for-node④">(2)</a> <a href="#ref-for-node⑤">(3)</a>
@@ -16959,20 +16959,20 @@ APIs</a>
     <li><a href="#ref-for-node⑨⑧">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-getrootnodeoptions">
-   <b><a href="#dictdef-getrootnodeoptions">#dictdef-getrootnodeoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-getrootnodeoptions" class="dfn-panel" data-for="dictdef-getrootnodeoptions" id="infopanel-for-dictdef-getrootnodeoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-getrootnodeoptions" style="display:none">Info about the 'GetRootNodeOptions' definition.</span><b><a href="#dictdef-getrootnodeoptions">#dictdef-getrootnodeoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-getrootnodeoptions">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-getrootnodeoptions-composed">
-   <b><a href="#dom-getrootnodeoptions-composed">#dom-getrootnodeoptions-composed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-getrootnodeoptions-composed" class="dfn-panel" data-for="dom-getrootnodeoptions-composed" id="infopanel-for-dom-getrootnodeoptions-composed" role="dialog">
+   <span id="infopaneltitle-for-dom-getrootnodeoptions-composed" style="display:none">Info about the 'composed' definition.</span><b><a href="#dom-getrootnodeoptions-composed">#dom-getrootnodeoptions-composed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-getrootnodeoptions-composed">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-document">
-   <b><a href="#concept-node-document">#concept-node-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-document" class="dfn-panel" data-for="concept-node-document" id="infopanel-for-concept-node-document" role="dialog">
+   <span id="infopaneltitle-for-concept-node-document" style="display:none">Info about the 'node document' definition.</span><b><a href="#concept-node-document">#concept-node-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-node-document①">(2)</a> <a href="#ref-for-concept-node-document②">(3)</a>
     <li><a href="#ref-for-concept-node-document③">4.2.6. Mixin ParentNode</a> <a href="#ref-for-concept-node-document④">(2)</a> <a href="#ref-for-concept-node-document⑤">(3)</a> <a href="#ref-for-concept-node-document⑥">(4)</a> <a href="#ref-for-concept-node-document⑦">(5)</a>
@@ -16988,333 +16988,334 @@ APIs</a>
     <li><a href="#ref-for-concept-node-document⑥⑤">5.5. Interface Range</a> <a href="#ref-for-concept-node-document⑥⑥">(2)</a> <a href="#ref-for-concept-node-document⑥⑦">(3)</a> <a href="#ref-for-concept-node-document⑥⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-nodetype">
-   <b><a href="#dom-node-nodetype">#dom-node-nodetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-nodetype" class="dfn-panel" data-for="dom-node-nodetype" id="infopanel-for-dom-node-nodetype" role="dialog">
+   <span id="infopaneltitle-for-dom-node-nodetype" style="display:none">Info about the 'nodeType' definition.</span><b><a href="#dom-node-nodetype">#dom-node-nodetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-nodetype">4.4. Interface Node</a> <a href="#ref-for-dom-node-nodetype①">(2)</a> <a href="#ref-for-dom-node-nodetype②">(3)</a>
     <li><a href="#ref-for-dom-node-nodetype③">6. Traversal</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-element_node">
-   <b><a href="#dom-node-element_node">#dom-node-element_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-element_node" class="dfn-panel" data-for="dom-node-element_node" id="infopanel-for-dom-node-element_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-element_node" style="display:none">Info about the 'ELEMENT_NODE' definition.</span><b><a href="#dom-node-element_node">#dom-node-element_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-element_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-element_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-attribute_node">
-   <b><a href="#dom-node-attribute_node">#dom-node-attribute_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-attribute_node" class="dfn-panel" data-for="dom-node-attribute_node" id="infopanel-for-dom-node-attribute_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-attribute_node" style="display:none">Info about the 'ATTRIBUTE_NODE' definition.</span><b><a href="#dom-node-attribute_node">#dom-node-attribute_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-attribute_node">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-text_node">
-   <b><a href="#dom-node-text_node">#dom-node-text_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-text_node" class="dfn-panel" data-for="dom-node-text_node" id="infopanel-for-dom-node-text_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-text_node" style="display:none">Info about the 'TEXT_NODE' definition.</span><b><a href="#dom-node-text_node">#dom-node-text_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-text_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-text_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-cdata_section_node">
-   <b><a href="#dom-node-cdata_section_node">#dom-node-cdata_section_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-cdata_section_node" class="dfn-panel" data-for="dom-node-cdata_section_node" id="infopanel-for-dom-node-cdata_section_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-cdata_section_node" style="display:none">Info about the 'CDATA_SECTION_NODE' definition.</span><b><a href="#dom-node-cdata_section_node">#dom-node-cdata_section_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-cdata_section_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-cdata_section_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-processing_instruction_node">
-   <b><a href="#dom-node-processing_instruction_node">#dom-node-processing_instruction_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-processing_instruction_node" class="dfn-panel" data-for="dom-node-processing_instruction_node" id="infopanel-for-dom-node-processing_instruction_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-processing_instruction_node" style="display:none">Info about the 'PROCESSING_INSTRUCTION_NODE' definition.</span><b><a href="#dom-node-processing_instruction_node">#dom-node-processing_instruction_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-processing_instruction_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-processing_instruction_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-comment_node">
-   <b><a href="#dom-node-comment_node">#dom-node-comment_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-comment_node" class="dfn-panel" data-for="dom-node-comment_node" id="infopanel-for-dom-node-comment_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-comment_node" style="display:none">Info about the 'COMMENT_NODE' definition.</span><b><a href="#dom-node-comment_node">#dom-node-comment_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-comment_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-comment_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_node">
-   <b><a href="#dom-node-document_node">#dom-node-document_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_node" class="dfn-panel" data-for="dom-node-document_node" id="infopanel-for-dom-node-document_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_node" style="display:none">Info about the 'DOCUMENT_NODE' definition.</span><b><a href="#dom-node-document_node">#dom-node-document_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_type_node">
-   <b><a href="#dom-node-document_type_node">#dom-node-document_type_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_type_node" class="dfn-panel" data-for="dom-node-document_type_node" id="infopanel-for-dom-node-document_type_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_type_node" style="display:none">Info about the 'DOCUMENT_TYPE_NODE' definition.</span><b><a href="#dom-node-document_type_node">#dom-node-document_type_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_type_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_type_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_fragment_node">
-   <b><a href="#dom-node-document_fragment_node">#dom-node-document_fragment_node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_fragment_node" class="dfn-panel" data-for="dom-node-document_fragment_node" id="infopanel-for-dom-node-document_fragment_node" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_fragment_node" style="display:none">Info about the 'DOCUMENT_FRAGMENT_NODE' definition.</span><b><a href="#dom-node-document_fragment_node">#dom-node-document_fragment_node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_fragment_node">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_fragment_node①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-nodename">
-   <b><a href="#dom-node-nodename">#dom-node-nodename</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-nodename" class="dfn-panel" data-for="dom-node-nodename" id="infopanel-for-dom-node-nodename" role="dialog">
+   <span id="infopaneltitle-for-dom-node-nodename" style="display:none">Info about the 'nodeName' definition.</span><b><a href="#dom-node-nodename">#dom-node-nodename</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-nodename">4.4. Interface Node</a> <a href="#ref-for-dom-node-nodename①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-baseuri">
-   <b><a href="#dom-node-baseuri">#dom-node-baseuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-baseuri" class="dfn-panel" data-for="dom-node-baseuri" id="infopanel-for-dom-node-baseuri" role="dialog">
+   <span id="infopaneltitle-for-dom-node-baseuri" style="display:none">Info about the 'baseURI' definition.</span><b><a href="#dom-node-baseuri">#dom-node-baseuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-baseuri">4.4. Interface Node</a> <a href="#ref-for-dom-node-baseuri①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-isconnected">
-   <b><a href="#dom-node-isconnected">#dom-node-isconnected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-isconnected" class="dfn-panel" data-for="dom-node-isconnected" id="infopanel-for-dom-node-isconnected" role="dialog">
+   <span id="infopaneltitle-for-dom-node-isconnected" style="display:none">Info about the 'isConnected' definition.</span><b><a href="#dom-node-isconnected">#dom-node-isconnected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-isconnected">4.4. Interface Node</a> <a href="#ref-for-dom-node-isconnected①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-ownerdocument">
-   <b><a href="#dom-node-ownerdocument">#dom-node-ownerdocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-ownerdocument" class="dfn-panel" data-for="dom-node-ownerdocument" id="infopanel-for-dom-node-ownerdocument" role="dialog">
+   <span id="infopaneltitle-for-dom-node-ownerdocument" style="display:none">Info about the 'ownerDocument' definition.</span><b><a href="#dom-node-ownerdocument">#dom-node-ownerdocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-ownerdocument">4.4. Interface Node</a> <a href="#ref-for-dom-node-ownerdocument①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-getrootnode">
-   <b><a href="#dom-node-getrootnode">#dom-node-getrootnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-getrootnode" class="dfn-panel" data-for="dom-node-getrootnode" id="infopanel-for-dom-node-getrootnode" role="dialog">
+   <span id="infopaneltitle-for-dom-node-getrootnode" style="display:none">Info about the 'getRootNode(options)' definition.</span><b><a href="#dom-node-getrootnode">#dom-node-getrootnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-getrootnode">4.4. Interface Node</a> <a href="#ref-for-dom-node-getrootnode①">(2)</a> <a href="#ref-for-dom-node-getrootnode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-parentnode">
-   <b><a href="#dom-node-parentnode">#dom-node-parentnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-parentnode" class="dfn-panel" data-for="dom-node-parentnode" id="infopanel-for-dom-node-parentnode" role="dialog">
+   <span id="infopaneltitle-for-dom-node-parentnode" style="display:none">Info about the 'parentNode' definition.</span><b><a href="#dom-node-parentnode">#dom-node-parentnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-parentnode">4.4. Interface Node</a> <a href="#ref-for-dom-node-parentnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-parentelement">
-   <b><a href="#dom-node-parentelement">#dom-node-parentelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-parentelement" class="dfn-panel" data-for="dom-node-parentelement" id="infopanel-for-dom-node-parentelement" role="dialog">
+   <span id="infopaneltitle-for-dom-node-parentelement" style="display:none">Info about the 'parentElement' definition.</span><b><a href="#dom-node-parentelement">#dom-node-parentelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-parentelement">4.4. Interface Node</a> <a href="#ref-for-dom-node-parentelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-haschildnodes">
-   <b><a href="#dom-node-haschildnodes">#dom-node-haschildnodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-haschildnodes" class="dfn-panel" data-for="dom-node-haschildnodes" id="infopanel-for-dom-node-haschildnodes" role="dialog">
+   <span id="infopaneltitle-for-dom-node-haschildnodes" style="display:none">Info about the 'hasChildNodes()' definition.</span><b><a href="#dom-node-haschildnodes">#dom-node-haschildnodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-haschildnodes">4.4. Interface Node</a> <a href="#ref-for-dom-node-haschildnodes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-childnodes">
-   <b><a href="#dom-node-childnodes">#dom-node-childnodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-childnodes" class="dfn-panel" data-for="dom-node-childnodes" id="infopanel-for-dom-node-childnodes" role="dialog">
+   <span id="infopaneltitle-for-dom-node-childnodes" style="display:none">Info about the 'childNodes' definition.</span><b><a href="#dom-node-childnodes">#dom-node-childnodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-childnodes">4.4. Interface Node</a> <a href="#ref-for-dom-node-childnodes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-firstchild">
-   <b><a href="#dom-node-firstchild">#dom-node-firstchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-firstchild" class="dfn-panel" data-for="dom-node-firstchild" id="infopanel-for-dom-node-firstchild" role="dialog">
+   <span id="infopaneltitle-for-dom-node-firstchild" style="display:none">Info about the 'firstChild ' definition.</span><b><a href="#dom-node-firstchild">#dom-node-firstchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-firstchild">4.4. Interface Node</a> <a href="#ref-for-dom-node-firstchild①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-lastchild">
-   <b><a href="#dom-node-lastchild">#dom-node-lastchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-lastchild" class="dfn-panel" data-for="dom-node-lastchild" id="infopanel-for-dom-node-lastchild" role="dialog">
+   <span id="infopaneltitle-for-dom-node-lastchild" style="display:none">Info about the 'lastChild' definition.</span><b><a href="#dom-node-lastchild">#dom-node-lastchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-lastchild">4.4. Interface Node</a> <a href="#ref-for-dom-node-lastchild①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-previoussibling">
-   <b><a href="#dom-node-previoussibling">#dom-node-previoussibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-previoussibling" class="dfn-panel" data-for="dom-node-previoussibling" id="infopanel-for-dom-node-previoussibling" role="dialog">
+   <span id="infopaneltitle-for-dom-node-previoussibling" style="display:none">Info about the 'previousSibling' definition.</span><b><a href="#dom-node-previoussibling">#dom-node-previoussibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-previoussibling">4.4. Interface Node</a> <a href="#ref-for-dom-node-previoussibling①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-nextsibling">
-   <b><a href="#dom-node-nextsibling">#dom-node-nextsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-nextsibling" class="dfn-panel" data-for="dom-node-nextsibling" id="infopanel-for-dom-node-nextsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-node-nextsibling" style="display:none">Info about the 'nextSibling' definition.</span><b><a href="#dom-node-nextsibling">#dom-node-nextsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-nextsibling">4.4. Interface Node</a> <a href="#ref-for-dom-node-nextsibling①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-nodevalue">
-   <b><a href="#dom-node-nodevalue">#dom-node-nodevalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-nodevalue" class="dfn-panel" data-for="dom-node-nodevalue" id="infopanel-for-dom-node-nodevalue" role="dialog">
+   <span id="infopaneltitle-for-dom-node-nodevalue" style="display:none">Info about the 'nodeValue' definition.</span><b><a href="#dom-node-nodevalue">#dom-node-nodevalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-nodevalue">4.4. Interface Node</a> <a href="#ref-for-dom-node-nodevalue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-textcontent">
-   <b><a href="#dom-node-textcontent">#dom-node-textcontent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-textcontent" class="dfn-panel" data-for="dom-node-textcontent" id="infopanel-for-dom-node-textcontent" role="dialog">
+   <span id="infopaneltitle-for-dom-node-textcontent" style="display:none">Info about the 'textContent' definition.</span><b><a href="#dom-node-textcontent">#dom-node-textcontent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-textcontent">4.4. Interface Node</a> <a href="#ref-for-dom-node-textcontent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-replace-all">
-   <b><a href="#string-replace-all">#string-replace-all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-replace-all" class="dfn-panel" data-for="string-replace-all" id="infopanel-for-string-replace-all" role="dialog">
+   <span id="infopaneltitle-for-string-replace-all" style="display:none">Info about the 'string replace all' definition.</span><b><a href="#string-replace-all">#string-replace-all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-replace-all">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-normalize">
-   <b><a href="#dom-node-normalize">#dom-node-normalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-normalize" class="dfn-panel" data-for="dom-node-normalize" id="infopanel-for-dom-node-normalize" role="dialog">
+   <span id="infopaneltitle-for-dom-node-normalize" style="display:none">Info about the 'normalize()' definition.</span><b><a href="#dom-node-normalize">#dom-node-normalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-normalize">4.4. Interface Node</a> <a href="#ref-for-dom-node-normalize①">(2)</a>
     <li><a href="#ref-for-dom-node-normalize②">5.1. Introduction to "DOM Ranges"</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-clone-ext">
-   <b><a href="#concept-node-clone-ext">#concept-node-clone-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-clone-ext" class="dfn-panel" data-for="concept-node-clone-ext" id="infopanel-for-concept-node-clone-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-node-clone-ext" style="display:none">Info about the 'cloning steps' definition.</span><b><a href="#concept-node-clone-ext">#concept-node-clone-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-clone-ext">4.4. Interface Node</a> <a href="#ref-for-concept-node-clone-ext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-clone">
-   <b><a href="#concept-node-clone">#concept-node-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-clone" class="dfn-panel" data-for="concept-node-clone" id="infopanel-for-concept-node-clone" role="dialog">
+   <span id="infopaneltitle-for-concept-node-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#concept-node-clone">#concept-node-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-clone">4.4. Interface Node</a> <a href="#ref-for-concept-node-clone①">(2)</a> <a href="#ref-for-concept-node-clone②">(3)</a> <a href="#ref-for-concept-node-clone③">(4)</a>
     <li><a href="#ref-for-concept-node-clone④">4.5. Interface Document</a>
     <li><a href="#ref-for-concept-node-clone⑤">5.5. Interface Range</a> <a href="#ref-for-concept-node-clone⑥">(2)</a> <a href="#ref-for-concept-node-clone⑦">(3)</a> <a href="#ref-for-concept-node-clone⑧">(4)</a> <a href="#ref-for-concept-node-clone⑨">(5)</a> <a href="#ref-for-concept-node-clone①⓪">(6)</a> <a href="#ref-for-concept-node-clone①①">(7)</a> <a href="#ref-for-concept-node-clone①②">(8)</a> <a href="#ref-for-concept-node-clone①③">(9)</a> <a href="#ref-for-concept-node-clone①④">(10)</a> <a href="#ref-for-concept-node-clone①⑤">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-clonenode">
-   <b><a href="#dom-node-clonenode">#dom-node-clonenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-clonenode" class="dfn-panel" data-for="dom-node-clonenode" id="infopanel-for-dom-node-clonenode" role="dialog">
+   <span id="infopaneltitle-for-dom-node-clonenode" style="display:none">Info about the 'cloneNode(deep)' definition.</span><b><a href="#dom-node-clonenode">#dom-node-clonenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-clonenode">4.4. Interface Node</a> <a href="#ref-for-dom-node-clonenode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-equals">
-   <b><a href="#concept-node-equals">#concept-node-equals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-equals" class="dfn-panel" data-for="concept-node-equals" id="infopanel-for-concept-node-equals" role="dialog">
+   <span id="infopaneltitle-for-concept-node-equals" style="display:none">Info about the 'equals' definition.</span><b><a href="#concept-node-equals">#concept-node-equals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-equals">4.4. Interface Node</a> <a href="#ref-for-concept-node-equals①">(2)</a> <a href="#ref-for-concept-node-equals②">(3)</a> <a href="#ref-for-concept-node-equals③">(4)</a> <a href="#ref-for-concept-node-equals④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-isequalnode">
-   <b><a href="#dom-node-isequalnode">#dom-node-isequalnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-isequalnode" class="dfn-panel" data-for="dom-node-isequalnode" id="infopanel-for-dom-node-isequalnode" role="dialog">
+   <span id="infopaneltitle-for-dom-node-isequalnode" style="display:none">Info about the 'isEqualNode(otherNode)' definition.</span><b><a href="#dom-node-isequalnode">#dom-node-isequalnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-isequalnode">4.4. Interface Node</a> <a href="#ref-for-dom-node-isequalnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-issamenode">
-   <b><a href="#dom-node-issamenode">#dom-node-issamenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-issamenode" class="dfn-panel" data-for="dom-node-issamenode" id="infopanel-for-dom-node-issamenode" role="dialog">
+   <span id="infopaneltitle-for-dom-node-issamenode" style="display:none">Info about the 'isSameNode(otherNode)' definition.</span><b><a href="#dom-node-issamenode">#dom-node-issamenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-issamenode">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_disconnected">
-   <b><a href="#dom-node-document_position_disconnected">#dom-node-document_position_disconnected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_disconnected" class="dfn-panel" data-for="dom-node-document_position_disconnected" id="infopanel-for-dom-node-document_position_disconnected" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_disconnected" style="display:none">Info about the 'DOCUMENT_POSITION_DISCONNECTED' definition.</span><b><a href="#dom-node-document_position_disconnected">#dom-node-document_position_disconnected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_disconnected">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_disconnected①">(2)</a> <a href="#ref-for-dom-node-document_position_disconnected②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_preceding">
-   <b><a href="#dom-node-document_position_preceding">#dom-node-document_position_preceding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_preceding" class="dfn-panel" data-for="dom-node-document_position_preceding" id="infopanel-for-dom-node-document_position_preceding" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_preceding" style="display:none">Info about the 'DOCUMENT_POSITION_PRECEDING' definition.</span><b><a href="#dom-node-document_position_preceding">#dom-node-document_position_preceding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_preceding">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_preceding①">(2)</a> <a href="#ref-for-dom-node-document_position_preceding②">(3)</a> <a href="#ref-for-dom-node-document_position_preceding③">(4)</a> <a href="#ref-for-dom-node-document_position_preceding④">(5)</a> <a href="#ref-for-dom-node-document_position_preceding⑤">(6)</a> <a href="#ref-for-dom-node-document_position_preceding⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_following">
-   <b><a href="#dom-node-document_position_following">#dom-node-document_position_following</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_following" class="dfn-panel" data-for="dom-node-document_position_following" id="infopanel-for-dom-node-document_position_following" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_following" style="display:none">Info about the 'DOCUMENT_POSITION_FOLLOWING' definition.</span><b><a href="#dom-node-document_position_following">#dom-node-document_position_following</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_following">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_following①">(2)</a> <a href="#ref-for-dom-node-document_position_following②">(3)</a> <a href="#ref-for-dom-node-document_position_following③">(4)</a> <a href="#ref-for-dom-node-document_position_following④">(5)</a> <a href="#ref-for-dom-node-document_position_following⑤">(6)</a> <a href="#ref-for-dom-node-document_position_following⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_contains">
-   <b><a href="#dom-node-document_position_contains">#dom-node-document_position_contains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_contains" class="dfn-panel" data-for="dom-node-document_position_contains" id="infopanel-for-dom-node-document_position_contains" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_contains" style="display:none">Info about the 'DOCUMENT_POSITION_CONTAINS' definition.</span><b><a href="#dom-node-document_position_contains">#dom-node-document_position_contains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_contains">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_contains①">(2)</a> <a href="#ref-for-dom-node-document_position_contains②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_contained_by">
-   <b><a href="#dom-node-document_position_contained_by">#dom-node-document_position_contained_by</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_contained_by" class="dfn-panel" data-for="dom-node-document_position_contained_by" id="infopanel-for-dom-node-document_position_contained_by" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_contained_by" style="display:none">Info about the 'DOCUMENT_POSITION_CONTAINED_BY' definition.</span><b><a href="#dom-node-document_position_contained_by">#dom-node-document_position_contained_by</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_contained_by">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_contained_by①">(2)</a> <a href="#ref-for-dom-node-document_position_contained_by②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-document_position_implementation_specific">
-   <b><a href="#dom-node-document_position_implementation_specific">#dom-node-document_position_implementation_specific</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-document_position_implementation_specific" class="dfn-panel" data-for="dom-node-document_position_implementation_specific" id="infopanel-for-dom-node-document_position_implementation_specific" role="dialog">
+   <span id="infopaneltitle-for-dom-node-document_position_implementation_specific" style="display:none">Info about the 'DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC' definition.</span><b><a href="#dom-node-document_position_implementation_specific">#dom-node-document_position_implementation_specific</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-document_position_implementation_specific">4.4. Interface Node</a> <a href="#ref-for-dom-node-document_position_implementation_specific①">(2)</a> <a href="#ref-for-dom-node-document_position_implementation_specific②">(3)</a> <a href="#ref-for-dom-node-document_position_implementation_specific③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-comparedocumentposition">
-   <b><a href="#dom-node-comparedocumentposition">#dom-node-comparedocumentposition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-comparedocumentposition" class="dfn-panel" data-for="dom-node-comparedocumentposition" id="infopanel-for-dom-node-comparedocumentposition" role="dialog">
+   <span id="infopaneltitle-for-dom-node-comparedocumentposition" style="display:none">Info about the 'compareDocumentPosition(other)' definition.</span><b><a href="#dom-node-comparedocumentposition">#dom-node-comparedocumentposition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-comparedocumentposition">4.4. Interface Node</a> <a href="#ref-for-dom-node-comparedocumentposition①">(2)</a> <a href="#ref-for-dom-node-comparedocumentposition②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-contains">
-   <b><a href="#dom-node-contains">#dom-node-contains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-contains" class="dfn-panel" data-for="dom-node-contains" id="infopanel-for-dom-node-contains" role="dialog">
+   <span id="infopaneltitle-for-dom-node-contains" style="display:none">Info about the 'contains(other)' definition.</span><b><a href="#dom-node-contains">#dom-node-contains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-contains">4.4. Interface Node</a> <a href="#ref-for-dom-node-contains①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="locate-a-namespace-prefix">
-   <b><a href="#locate-a-namespace-prefix">#locate-a-namespace-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-locate-a-namespace-prefix" class="dfn-panel" data-for="locate-a-namespace-prefix" id="infopanel-for-locate-a-namespace-prefix" role="dialog">
+   <span id="infopaneltitle-for-locate-a-namespace-prefix" style="display:none">Info about the 'locate a namespace prefix' definition.</span><b><a href="#locate-a-namespace-prefix">#locate-a-namespace-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-locate-a-namespace-prefix">4.4. Interface Node</a> <a href="#ref-for-locate-a-namespace-prefix①">(2)</a> <a href="#ref-for-locate-a-namespace-prefix②">(3)</a> <a href="#ref-for-locate-a-namespace-prefix③">(4)</a> <a href="#ref-for-locate-a-namespace-prefix④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="locate-a-namespace">
-   <b><a href="#locate-a-namespace">#locate-a-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-locate-a-namespace" class="dfn-panel" data-for="locate-a-namespace" id="infopanel-for-locate-a-namespace" role="dialog">
+   <span id="infopaneltitle-for-locate-a-namespace" style="display:none">Info about the 'locate a namespace' definition.</span><b><a href="#locate-a-namespace">#locate-a-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-locate-a-namespace">4.4. Interface Node</a> <a href="#ref-for-locate-a-namespace①">(2)</a> <a href="#ref-for-locate-a-namespace②">(3)</a> <a href="#ref-for-locate-a-namespace③">(4)</a> <a href="#ref-for-locate-a-namespace④">(5)</a> <a href="#ref-for-locate-a-namespace⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-lookupprefix">
-   <b><a href="#dom-node-lookupprefix">#dom-node-lookupprefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-lookupprefix" class="dfn-panel" data-for="dom-node-lookupprefix" id="infopanel-for-dom-node-lookupprefix" role="dialog">
+   <span id="infopaneltitle-for-dom-node-lookupprefix" style="display:none">Info about the 'lookupPrefix(namespace)' definition.</span><b><a href="#dom-node-lookupprefix">#dom-node-lookupprefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-lookupprefix">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-lookupnamespaceuri">
-   <b><a href="#dom-node-lookupnamespaceuri">#dom-node-lookupnamespaceuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-lookupnamespaceuri" class="dfn-panel" data-for="dom-node-lookupnamespaceuri" id="infopanel-for-dom-node-lookupnamespaceuri" role="dialog">
+   <span id="infopaneltitle-for-dom-node-lookupnamespaceuri" style="display:none">Info about the 'lookupNamespaceURI(prefix)' definition.</span><b><a href="#dom-node-lookupnamespaceuri">#dom-node-lookupnamespaceuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-lookupnamespaceuri">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-isdefaultnamespace">
-   <b><a href="#dom-node-isdefaultnamespace">#dom-node-isdefaultnamespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-isdefaultnamespace" class="dfn-panel" data-for="dom-node-isdefaultnamespace" id="infopanel-for-dom-node-isdefaultnamespace" role="dialog">
+   <span id="infopaneltitle-for-dom-node-isdefaultnamespace" style="display:none">Info about the 'isDefaultNamespace(namespace)' definition.</span><b><a href="#dom-node-isdefaultnamespace">#dom-node-isdefaultnamespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-isdefaultnamespace">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-insertbefore">
-   <b><a href="#dom-node-insertbefore">#dom-node-insertbefore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-insertbefore" class="dfn-panel" data-for="dom-node-insertbefore" id="infopanel-for-dom-node-insertbefore" role="dialog">
+   <span id="infopaneltitle-for-dom-node-insertbefore" style="display:none">Info about the 'insertBefore(node, child)' definition.</span><b><a href="#dom-node-insertbefore">#dom-node-insertbefore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-insertbefore">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-appendchild">
-   <b><a href="#dom-node-appendchild">#dom-node-appendchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-appendchild" class="dfn-panel" data-for="dom-node-appendchild" id="infopanel-for-dom-node-appendchild" role="dialog">
+   <span id="infopaneltitle-for-dom-node-appendchild" style="display:none">Info about the 'appendChild(node)' definition.</span><b><a href="#dom-node-appendchild">#dom-node-appendchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-appendchild">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-replacechild">
-   <b><a href="#dom-node-replacechild">#dom-node-replacechild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-replacechild" class="dfn-panel" data-for="dom-node-replacechild" id="infopanel-for-dom-node-replacechild" role="dialog">
+   <span id="infopaneltitle-for-dom-node-replacechild" style="display:none">Info about the 'replaceChild(node, child)' definition.</span><b><a href="#dom-node-replacechild">#dom-node-replacechild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-replacechild">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-node-removechild">
-   <b><a href="#dom-node-removechild">#dom-node-removechild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-node-removechild" class="dfn-panel" data-for="dom-node-removechild" id="infopanel-for-dom-node-removechild" role="dialog">
+   <span id="infopaneltitle-for-dom-node-removechild" style="display:none">Info about the 'removeChild(child)' definition.</span><b><a href="#dom-node-removechild">#dom-node-removechild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-node-removechild">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-getelementsbytagname">
-   <b><a href="#concept-getelementsbytagname">#concept-getelementsbytagname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-getelementsbytagname" class="dfn-panel" data-for="concept-getelementsbytagname" id="infopanel-for-concept-getelementsbytagname" role="dialog">
+   <span id="infopaneltitle-for-concept-getelementsbytagname" style="display:none">Info about the 'list of elements with qualified name qualifiedName' definition.</span><b><a href="#concept-getelementsbytagname">#concept-getelementsbytagname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-getelementsbytagname">4.5. Interface Document</a>
     <li><a href="#ref-for-concept-getelementsbytagname①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-getelementsbytagnamens">
-   <b><a href="#concept-getelementsbytagnamens">#concept-getelementsbytagnamens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-getelementsbytagnamens" class="dfn-panel" data-for="concept-getelementsbytagnamens" id="infopanel-for-concept-getelementsbytagnamens" role="dialog">
+   <span id="infopaneltitle-for-concept-getelementsbytagnamens" style="display:none">Info about the 'list of elements with namespace
+namespace and local name localName' definition.</span><b><a href="#concept-getelementsbytagnamens">#concept-getelementsbytagnamens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-getelementsbytagnamens">4.5. Interface Document</a>
     <li><a href="#ref-for-concept-getelementsbytagnamens①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-getelementsbyclassname">
-   <b><a href="#concept-getelementsbyclassname">#concept-getelementsbyclassname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-getelementsbyclassname" class="dfn-panel" data-for="concept-getelementsbyclassname" id="infopanel-for-concept-getelementsbyclassname" role="dialog">
+   <span id="infopaneltitle-for-concept-getelementsbyclassname" style="display:none">Info about the 'list of elements with class names classNames' definition.</span><b><a href="#concept-getelementsbyclassname">#concept-getelementsbyclassname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-getelementsbyclassname">4.5. Interface Document</a>
     <li><a href="#ref-for-concept-getelementsbyclassname①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document">
-   <b><a href="#document">#document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document" class="dfn-panel" data-for="document" id="infopanel-for-document" role="dialog">
+   <span id="infopaneltitle-for-document" style="display:none">Info about the 'Document' definition.</span><b><a href="#document">#document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">4.2. Node tree</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">4.2.3. Mutation algorithms</a> <a href="#ref-for-document③">(2)</a>
@@ -17332,27 +17333,27 @@ APIs</a>
     <li><a href="#ref-for-document②⑤">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xmldocument">
-   <b><a href="#xmldocument">#xmldocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmldocument" class="dfn-panel" data-for="xmldocument" id="infopanel-for-xmldocument" role="dialog">
+   <span id="infopaneltitle-for-xmldocument" style="display:none">Info about the 'XMLDocument' definition.</span><b><a href="#xmldocument">#xmldocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmldocument">4.5. Interface Document</a>
     <li><a href="#ref-for-xmldocument①">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-xmldocument②">(2)</a> <a href="#ref-for-xmldocument③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-elementcreationoptions">
-   <b><a href="#dictdef-elementcreationoptions">#dictdef-elementcreationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-elementcreationoptions" class="dfn-panel" data-for="dictdef-elementcreationoptions" id="infopanel-for-dictdef-elementcreationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-elementcreationoptions" style="display:none">Info about the 'ElementCreationOptions' definition.</span><b><a href="#dictdef-elementcreationoptions">#dictdef-elementcreationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-elementcreationoptions">4.5. Interface Document</a> <a href="#ref-for-dictdef-elementcreationoptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-elementcreationoptions-is">
-   <b><a href="#dom-elementcreationoptions-is">#dom-elementcreationoptions-is</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-elementcreationoptions-is" class="dfn-panel" data-for="dom-elementcreationoptions-is" id="infopanel-for-dom-elementcreationoptions-is" role="dialog">
+   <span id="infopaneltitle-for-dom-elementcreationoptions-is" style="display:none">Info about the 'is' definition.</span><b><a href="#dom-elementcreationoptions-is">#dom-elementcreationoptions-is</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-elementcreationoptions-is">4.5. Interface Document</a> <a href="#ref-for-dom-elementcreationoptions-is①">(2)</a> <a href="#ref-for-dom-elementcreationoptions-is②">(3)</a> <a href="#ref-for-dom-elementcreationoptions-is③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document">
-   <b><a href="#concept-document">#concept-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document" class="dfn-panel" data-for="concept-document" id="infopanel-for-concept-document" role="dialog">
+   <span id="infopaneltitle-for-concept-document" style="display:none">Info about the 'documents' definition.</span><b><a href="#concept-document">#concept-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2.1. Introduction to "DOM Events"</a>
     <li><a href="#ref-for-concept-document①">2.7. Interface EventTarget</a>
@@ -17367,58 +17368,58 @@ APIs</a>
     <li><a href="#ref-for-concept-document④⑥">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-encoding">
-   <b><a href="#concept-document-encoding">#concept-document-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-encoding" class="dfn-panel" data-for="concept-document-encoding" id="infopanel-for-concept-document-encoding" role="dialog">
+   <span id="infopaneltitle-for-concept-document-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#concept-document-encoding">#concept-document-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-encoding">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-document-encoding①">4.5. Interface Document</a> <a href="#ref-for-concept-document-encoding②">(2)</a> <a href="#ref-for-concept-document-encoding③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-content-type">
-   <b><a href="#concept-document-content-type">#concept-document-content-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-content-type" class="dfn-panel" data-for="concept-document-content-type" id="infopanel-for-concept-document-content-type" role="dialog">
+   <span id="infopaneltitle-for-concept-document-content-type" style="display:none">Info about the 'content type' definition.</span><b><a href="#concept-document-content-type">#concept-document-content-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-content-type">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-document-content-type①">4.5. Interface Document</a> <a href="#ref-for-concept-document-content-type②">(2)</a> <a href="#ref-for-concept-document-content-type③">(3)</a> <a href="#ref-for-concept-document-content-type④">(4)</a> <a href="#ref-for-concept-document-content-type⑤">(5)</a>
     <li><a href="#ref-for-concept-document-content-type⑥">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-concept-document-content-type⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-url">
-   <b><a href="#concept-document-url">#concept-document-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-url" class="dfn-panel" data-for="concept-document-url" id="infopanel-for-concept-document-url" role="dialog">
+   <span id="infopaneltitle-for-concept-document-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-document-url">#concept-document-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-document-url①">4.5. Interface Document</a> <a href="#ref-for-concept-document-url②">(2)</a> <a href="#ref-for-concept-document-url③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-origin">
-   <b><a href="#concept-document-origin">#concept-document-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-origin" class="dfn-panel" data-for="concept-document-origin" id="infopanel-for-concept-document-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-document-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#concept-document-origin">#concept-document-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-document-origin①">4.5. Interface Document</a> <a href="#ref-for-concept-document-origin②">(2)</a> <a href="#ref-for-concept-document-origin③">(3)</a>
     <li><a href="#ref-for-concept-document-origin④">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-concept-document-origin⑤">(2)</a> <a href="#ref-for-concept-document-origin⑥">(3)</a> <a href="#ref-for-concept-document-origin⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-type">
-   <b><a href="#concept-document-type">#concept-document-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-type" class="dfn-panel" data-for="concept-document-type" id="infopanel-for-concept-document-type" role="dialog">
+   <span id="infopaneltitle-for-concept-document-type" style="display:none">Info about the 'type' definition.</span><b><a href="#concept-document-type">#concept-document-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-type">4.4. Interface Node</a> <a href="#ref-for-concept-document-type①">(2)</a>
     <li><a href="#ref-for-concept-document-type②">4.5. Interface Document</a> <a href="#ref-for-concept-document-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-mode">
-   <b><a href="#concept-document-mode">#concept-document-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-mode" class="dfn-panel" data-for="concept-document-mode" id="infopanel-for-concept-document-mode" role="dialog">
+   <span id="infopaneltitle-for-concept-document-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#concept-document-mode">#concept-document-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-mode">4.4. Interface Node</a> <a href="#ref-for-concept-document-mode①">(2)</a>
     <li><a href="#ref-for-concept-document-mode②">4.5. Interface Document</a> <a href="#ref-for-concept-document-mode③">(2)</a> <a href="#ref-for-concept-document-mode④">(3)</a> <a href="#ref-for-concept-document-mode⑤">(4)</a> <a href="#ref-for-concept-document-mode⑥">(5)</a> <a href="#ref-for-concept-document-mode⑦">(6)</a> <a href="#ref-for-concept-document-mode⑧">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xml-document">
-   <b><a href="#xml-document">#xml-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xml-document" class="dfn-panel" data-for="xml-document" id="infopanel-for-xml-document" role="dialog">
+   <span id="infopaneltitle-for-xml-document" style="display:none">Info about the 'XML document' definition.</span><b><a href="#xml-document">#xml-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-document">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="html-document">
-   <b><a href="#html-document">#html-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-html-document" class="dfn-panel" data-for="html-document" id="infopanel-for-html-document" role="dialog">
+   <span id="infopaneltitle-for-html-document" style="display:none">Info about the 'HTML document' definition.</span><b><a href="#html-document">#html-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-document">4.4. Interface Node</a>
     <li><a href="#ref-for-html-document①">4.5. Interface Document</a> <a href="#ref-for-html-document②">(2)</a> <a href="#ref-for-html-document③">(3)</a> <a href="#ref-for-html-document④">(4)</a> <a href="#ref-for-html-document⑤">(5)</a> <a href="#ref-for-html-document⑥">(6)</a> <a href="#ref-for-html-document⑦">(7)</a> <a href="#ref-for-html-document⑧">(8)</a> <a href="#ref-for-html-document⑨">(9)</a>
@@ -17427,258 +17428,258 @@ APIs</a>
     <li><a href="#ref-for-html-document①⑥">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-no-quirks">
-   <b><a href="#concept-document-no-quirks">#concept-document-no-quirks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-no-quirks" class="dfn-panel" data-for="concept-document-no-quirks" id="infopanel-for-concept-document-no-quirks" role="dialog">
+   <span id="infopaneltitle-for-concept-document-no-quirks" style="display:none">Info about the 'no-quirks mode' definition.</span><b><a href="#concept-document-no-quirks">#concept-document-no-quirks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-no-quirks">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-document-limited-quirks">
-   <b><a href="#concept-document-limited-quirks">#concept-document-limited-quirks</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-document-limited-quirks" class="dfn-panel" data-for="concept-document-limited-quirks" id="infopanel-for-concept-document-limited-quirks" role="dialog">
+   <span id="infopaneltitle-for-concept-document-limited-quirks" style="display:none">Info about the 'limited-quirks mode' definition.</span><b><a href="#concept-document-limited-quirks">#concept-document-limited-quirks</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-limited-quirks">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-document">
-   <b><a href="#dom-document-document">#dom-document-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-document" class="dfn-panel" data-for="dom-document-document" id="infopanel-for-dom-document-document" role="dialog">
+   <span id="infopaneltitle-for-dom-document-document" style="display:none">Info about the 'new Document()' definition.</span><b><a href="#dom-document-document">#dom-document-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-document">4.5. Interface Document</a> <a href="#ref-for-dom-document-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-implementation">
-   <b><a href="#dom-document-implementation">#dom-document-implementation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-implementation" class="dfn-panel" data-for="dom-document-implementation" id="infopanel-for-dom-document-implementation" role="dialog">
+   <span id="infopaneltitle-for-dom-document-implementation" style="display:none">Info about the 'implementation' definition.</span><b><a href="#dom-document-implementation">#dom-document-implementation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-implementation">4.5. Interface Document</a> <a href="#ref-for-dom-document-implementation①">(2)</a>
     <li><a href="#ref-for-dom-document-implementation②">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-dom-document-implementation③">(2)</a> <a href="#ref-for-dom-document-implementation④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-url">
-   <b><a href="#dom-document-url">#dom-document-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-url" class="dfn-panel" data-for="dom-document-url" id="infopanel-for-dom-document-url" role="dialog">
+   <span id="infopaneltitle-for-dom-document-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#dom-document-url">#dom-document-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-url">4.5. Interface Document</a> <a href="#ref-for-dom-document-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-documenturi">
-   <b><a href="#dom-document-documenturi">#dom-document-documenturi</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-documenturi" class="dfn-panel" data-for="dom-document-documenturi" id="infopanel-for-dom-document-documenturi" role="dialog">
+   <span id="infopaneltitle-for-dom-document-documenturi" style="display:none">Info about the 'documentURI' definition.</span><b><a href="#dom-document-documenturi">#dom-document-documenturi</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-documenturi">4.5. Interface Document</a> <a href="#ref-for-dom-document-documenturi①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-compatmode">
-   <b><a href="#dom-document-compatmode">#dom-document-compatmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-compatmode" class="dfn-panel" data-for="dom-document-compatmode" id="infopanel-for-dom-document-compatmode" role="dialog">
+   <span id="infopaneltitle-for-dom-document-compatmode" style="display:none">Info about the 'compatMode' definition.</span><b><a href="#dom-document-compatmode">#dom-document-compatmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-compatmode">4.5. Interface Document</a> <a href="#ref-for-dom-document-compatmode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-characterset">
-   <b><a href="#dom-document-characterset">#dom-document-characterset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-characterset" class="dfn-panel" data-for="dom-document-characterset" id="infopanel-for-dom-document-characterset" role="dialog">
+   <span id="infopaneltitle-for-dom-document-characterset" style="display:none">Info about the 'characterSet' definition.</span><b><a href="#dom-document-characterset">#dom-document-characterset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-characterset">4.5. Interface Document</a> <a href="#ref-for-dom-document-characterset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-charset">
-   <b><a href="#dom-document-charset">#dom-document-charset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-charset" class="dfn-panel" data-for="dom-document-charset" id="infopanel-for-dom-document-charset" role="dialog">
+   <span id="infopaneltitle-for-dom-document-charset" style="display:none">Info about the 'charset' definition.</span><b><a href="#dom-document-charset">#dom-document-charset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-charset">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-inputencoding">
-   <b><a href="#dom-document-inputencoding">#dom-document-inputencoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-inputencoding" class="dfn-panel" data-for="dom-document-inputencoding" id="infopanel-for-dom-document-inputencoding" role="dialog">
+   <span id="infopaneltitle-for-dom-document-inputencoding" style="display:none">Info about the 'inputEncoding' definition.</span><b><a href="#dom-document-inputencoding">#dom-document-inputencoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-inputencoding">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-contenttype">
-   <b><a href="#dom-document-contenttype">#dom-document-contenttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-contenttype" class="dfn-panel" data-for="dom-document-contenttype" id="infopanel-for-dom-document-contenttype" role="dialog">
+   <span id="infopaneltitle-for-dom-document-contenttype" style="display:none">Info about the 'contentType' definition.</span><b><a href="#dom-document-contenttype">#dom-document-contenttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-contenttype">4.5. Interface Document</a> <a href="#ref-for-dom-document-contenttype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-doctype">
-   <b><a href="#dom-document-doctype">#dom-document-doctype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-doctype" class="dfn-panel" data-for="dom-document-doctype" id="infopanel-for-dom-document-doctype" role="dialog">
+   <span id="infopaneltitle-for-dom-document-doctype" style="display:none">Info about the 'doctype' definition.</span><b><a href="#dom-document-doctype">#dom-document-doctype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-doctype">4.5. Interface Document</a> <a href="#ref-for-dom-document-doctype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-documentelement">
-   <b><a href="#dom-document-documentelement">#dom-document-documentelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-documentelement" class="dfn-panel" data-for="dom-document-documentelement" id="infopanel-for-dom-document-documentelement" role="dialog">
+   <span id="infopaneltitle-for-dom-document-documentelement" style="display:none">Info about the 'documentElement' definition.</span><b><a href="#dom-document-documentelement">#dom-document-documentelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-documentelement">4.5. Interface Document</a> <a href="#ref-for-dom-document-documentelement①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-getelementsbytagname">
-   <b><a href="#dom-document-getelementsbytagname">#dom-document-getelementsbytagname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-getelementsbytagname" class="dfn-panel" data-for="dom-document-getelementsbytagname" id="infopanel-for-dom-document-getelementsbytagname" role="dialog">
+   <span id="infopaneltitle-for-dom-document-getelementsbytagname" style="display:none">Info about the 'getElementsByTagName(qualifiedName)' definition.</span><b><a href="#dom-document-getelementsbytagname">#dom-document-getelementsbytagname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-getelementsbytagname">4.5. Interface Document</a> <a href="#ref-for-dom-document-getelementsbytagname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-getelementsbytagnamens">
-   <b><a href="#dom-document-getelementsbytagnamens">#dom-document-getelementsbytagnamens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-getelementsbytagnamens" class="dfn-panel" data-for="dom-document-getelementsbytagnamens" id="infopanel-for-dom-document-getelementsbytagnamens" role="dialog">
+   <span id="infopaneltitle-for-dom-document-getelementsbytagnamens" style="display:none">Info about the 'getElementsByTagNameNS(namespace, localName)' definition.</span><b><a href="#dom-document-getelementsbytagnamens">#dom-document-getelementsbytagnamens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-getelementsbytagnamens">4.5. Interface Document</a> <a href="#ref-for-dom-document-getelementsbytagnamens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-getelementsbyclassname">
-   <b><a href="#dom-document-getelementsbyclassname">#dom-document-getelementsbyclassname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-getelementsbyclassname" class="dfn-panel" data-for="dom-document-getelementsbyclassname" id="infopanel-for-dom-document-getelementsbyclassname" role="dialog">
+   <span id="infopaneltitle-for-dom-document-getelementsbyclassname" style="display:none">Info about the 'getElementsByClassName(classNames)' definition.</span><b><a href="#dom-document-getelementsbyclassname">#dom-document-getelementsbyclassname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-getelementsbyclassname">4.5. Interface Document</a> <a href="#ref-for-dom-document-getelementsbyclassname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-interface">
-   <b><a href="#concept-element-interface">#concept-element-interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-interface" class="dfn-panel" data-for="concept-element-interface" id="infopanel-for-concept-element-interface" role="dialog">
+   <span id="infopaneltitle-for-concept-element-interface" style="display:none">Info about the 'element interface' definition.</span><b><a href="#concept-element-interface">#concept-element-interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-interface">4.9. Interface Element</a> <a href="#ref-for-concept-element-interface①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createelement">
-   <b><a href="#dom-document-createelement">#dom-document-createelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createelement" class="dfn-panel" data-for="dom-document-createelement" id="infopanel-for-dom-document-createelement" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createelement" style="display:none">Info about the 'createElement(localName, options)' definition.</span><b><a href="#dom-document-createelement">#dom-document-createelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createelement">4.5. Interface Document</a> <a href="#ref-for-dom-document-createelement①">(2)</a> <a href="#ref-for-dom-document-createelement②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="internal-createelementns-steps">
-   <b><a href="#internal-createelementns-steps">#internal-createelementns-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-internal-createelementns-steps" class="dfn-panel" data-for="internal-createelementns-steps" id="infopanel-for-internal-createelementns-steps" role="dialog">
+   <span id="infopaneltitle-for-internal-createelementns-steps" style="display:none">Info about the 'internal createElementNS steps' definition.</span><b><a href="#internal-createelementns-steps">#internal-createelementns-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-createelementns-steps">4.5. Interface Document</a>
     <li><a href="#ref-for-internal-createelementns-steps①">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createelementns">
-   <b><a href="#dom-document-createelementns">#dom-document-createelementns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createelementns" class="dfn-panel" data-for="dom-document-createelementns" id="infopanel-for-dom-document-createelementns" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createelementns" style="display:none">Info about the 'createElementNS(namespace, qualifiedName, options)' definition.</span><b><a href="#dom-document-createelementns">#dom-document-createelementns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createelementns">4.5. Interface Document</a> <a href="#ref-for-dom-document-createelementns①">(2)</a> <a href="#ref-for-dom-document-createelementns②">(3)</a>
     <li><a href="#ref-for-dom-document-createelementns③">4.5.1. Interface DOMImplementation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createdocumentfragment">
-   <b><a href="#dom-document-createdocumentfragment">#dom-document-createdocumentfragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createdocumentfragment" class="dfn-panel" data-for="dom-document-createdocumentfragment" id="infopanel-for-dom-document-createdocumentfragment" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createdocumentfragment" style="display:none">Info about the 'createDocumentFragment()' definition.</span><b><a href="#dom-document-createdocumentfragment">#dom-document-createdocumentfragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createdocumentfragment">4.5. Interface Document</a> <a href="#ref-for-dom-document-createdocumentfragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createtextnode">
-   <b><a href="#dom-document-createtextnode">#dom-document-createtextnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createtextnode" class="dfn-panel" data-for="dom-document-createtextnode" id="infopanel-for-dom-document-createtextnode" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createtextnode" style="display:none">Info about the 'createTextNode(data)' definition.</span><b><a href="#dom-document-createtextnode">#dom-document-createtextnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createtextnode">4.5. Interface Document</a> <a href="#ref-for-dom-document-createtextnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createcdatasection">
-   <b><a href="#dom-document-createcdatasection">#dom-document-createcdatasection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createcdatasection" class="dfn-panel" data-for="dom-document-createcdatasection" id="infopanel-for-dom-document-createcdatasection" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createcdatasection" style="display:none">Info about the 'createCDATASection(data)' definition.</span><b><a href="#dom-document-createcdatasection">#dom-document-createcdatasection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createcdatasection">4.5. Interface Document</a> <a href="#ref-for-dom-document-createcdatasection①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createcomment">
-   <b><a href="#dom-document-createcomment">#dom-document-createcomment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createcomment" class="dfn-panel" data-for="dom-document-createcomment" id="infopanel-for-dom-document-createcomment" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createcomment" style="display:none">Info about the 'createComment(data)' definition.</span><b><a href="#dom-document-createcomment">#dom-document-createcomment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createcomment">4.5. Interface Document</a> <a href="#ref-for-dom-document-createcomment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createprocessinginstruction">
-   <b><a href="#dom-document-createprocessinginstruction">#dom-document-createprocessinginstruction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createprocessinginstruction" class="dfn-panel" data-for="dom-document-createprocessinginstruction" id="infopanel-for-dom-document-createprocessinginstruction" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createprocessinginstruction" style="display:none">Info about the 'createProcessingInstruction(target, data)' definition.</span><b><a href="#dom-document-createprocessinginstruction">#dom-document-createprocessinginstruction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createprocessinginstruction">4.5. Interface Document</a> <a href="#ref-for-dom-document-createprocessinginstruction①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-importnode">
-   <b><a href="#dom-document-importnode">#dom-document-importnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-importnode" class="dfn-panel" data-for="dom-document-importnode" id="infopanel-for-dom-document-importnode" role="dialog">
+   <span id="infopaneltitle-for-dom-document-importnode" style="display:none">Info about the 'importNode(node, deep)' definition.</span><b><a href="#dom-document-importnode">#dom-document-importnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-importnode">4.5. Interface Document</a> <a href="#ref-for-dom-document-importnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-adopt-ext">
-   <b><a href="#concept-node-adopt-ext">#concept-node-adopt-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-adopt-ext" class="dfn-panel" data-for="concept-node-adopt-ext" id="infopanel-for-concept-node-adopt-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-node-adopt-ext" style="display:none">Info about the 'adopting steps' definition.</span><b><a href="#concept-node-adopt-ext">#concept-node-adopt-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-adopt-ext">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-adopt">
-   <b><a href="#concept-node-adopt">#concept-node-adopt</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-adopt" class="dfn-panel" data-for="concept-node-adopt" id="infopanel-for-concept-node-adopt" role="dialog">
+   <span id="infopaneltitle-for-concept-node-adopt" style="display:none">Info about the 'adopt' definition.</span><b><a href="#concept-node-adopt">#concept-node-adopt</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-adopt">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-node-adopt①">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-node-adopt②">4.5. Interface Document</a> <a href="#ref-for-concept-node-adopt③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-adoptnode">
-   <b><a href="#dom-document-adoptnode">#dom-document-adoptnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-adoptnode" class="dfn-panel" data-for="dom-document-adoptnode" id="infopanel-for-dom-document-adoptnode" role="dialog">
+   <span id="infopaneltitle-for-dom-document-adoptnode" style="display:none">Info about the 'adoptNode(node)' definition.</span><b><a href="#dom-document-adoptnode">#dom-document-adoptnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-adoptnode">4.5. Interface Document</a> <a href="#ref-for-dom-document-adoptnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createattribute">
-   <b><a href="#dom-document-createattribute">#dom-document-createattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createattribute" class="dfn-panel" data-for="dom-document-createattribute" id="infopanel-for-dom-document-createattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createattribute" style="display:none">Info about the 'createAttribute(localName)' definition.</span><b><a href="#dom-document-createattribute">#dom-document-createattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createattribute">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createattributens">
-   <b><a href="#dom-document-createattributens">#dom-document-createattributens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createattributens" class="dfn-panel" data-for="dom-document-createattributens" id="infopanel-for-dom-document-createattributens" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createattributens" style="display:none">Info about the 'createAttributeNS(namespace, qualifiedName)' definition.</span><b><a href="#dom-document-createattributens">#dom-document-createattributens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createattributens">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createevent">
-   <b><a href="#dom-document-createevent">#dom-document-createevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createevent" class="dfn-panel" data-for="dom-document-createevent" id="infopanel-for-dom-document-createevent" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createevent" style="display:none">Info about the 'createEvent(interface)' definition.</span><b><a href="#dom-document-createevent">#dom-document-createevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createevent">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createrange">
-   <b><a href="#dom-document-createrange">#dom-document-createrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createrange" class="dfn-panel" data-for="dom-document-createrange" id="infopanel-for-dom-document-createrange" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createrange" style="display:none">Info about the 'createRange()' definition.</span><b><a href="#dom-document-createrange">#dom-document-createrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createrange">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createnodeiterator">
-   <b><a href="#dom-document-createnodeiterator">#dom-document-createnodeiterator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createnodeiterator" class="dfn-panel" data-for="dom-document-createnodeiterator" id="infopanel-for-dom-document-createnodeiterator" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createnodeiterator" style="display:none">Info about the 'createNodeIterator(root, whatToShow, filter)' definition.</span><b><a href="#dom-document-createnodeiterator">#dom-document-createnodeiterator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createnodeiterator">4.5. Interface Document</a>
     <li><a href="#ref-for-dom-document-createnodeiterator①">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-createtreewalker">
-   <b><a href="#dom-document-createtreewalker">#dom-document-createtreewalker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-createtreewalker" class="dfn-panel" data-for="dom-document-createtreewalker" id="infopanel-for-dom-document-createtreewalker" role="dialog">
+   <span id="infopaneltitle-for-dom-document-createtreewalker" style="display:none">Info about the 'createTreeWalker(root, whatToShow, filter)' definition.</span><b><a href="#dom-document-createtreewalker">#dom-document-createtreewalker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-createtreewalker">4.5. Interface Document</a>
     <li><a href="#ref-for-dom-document-createtreewalker①">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domimplementation">
-   <b><a href="#domimplementation">#domimplementation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domimplementation" class="dfn-panel" data-for="domimplementation" id="infopanel-for-domimplementation" role="dialog">
+   <span id="infopaneltitle-for-domimplementation" style="display:none">Info about the 'DOMImplementation' definition.</span><b><a href="#domimplementation">#domimplementation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domimplementation">4.5. Interface Document</a> <a href="#ref-for-domimplementation①">(2)</a> <a href="#ref-for-domimplementation②">(3)</a>
     <li><a href="#ref-for-domimplementation③">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-domimplementation④">(2)</a>
     <li><a href="#ref-for-domimplementation⑤">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domimplementation-createdocumenttype">
-   <b><a href="#dom-domimplementation-createdocumenttype">#dom-domimplementation-createdocumenttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domimplementation-createdocumenttype" class="dfn-panel" data-for="dom-domimplementation-createdocumenttype" id="infopanel-for-dom-domimplementation-createdocumenttype" role="dialog">
+   <span id="infopaneltitle-for-dom-domimplementation-createdocumenttype" style="display:none">Info about the 'createDocumentType(qualifiedName, publicId, systemId)' definition.</span><b><a href="#dom-domimplementation-createdocumenttype">#dom-domimplementation-createdocumenttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domimplementation-createdocumenttype">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-dom-domimplementation-createdocumenttype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domimplementation-createdocument">
-   <b><a href="#dom-domimplementation-createdocument">#dom-domimplementation-createdocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domimplementation-createdocument" class="dfn-panel" data-for="dom-domimplementation-createdocument" id="infopanel-for-dom-domimplementation-createdocument" role="dialog">
+   <span id="infopaneltitle-for-dom-domimplementation-createdocument" style="display:none">Info about the 'createDocument(namespace, qualifiedName, doctype)' definition.</span><b><a href="#dom-domimplementation-createdocument">#dom-domimplementation-createdocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domimplementation-createdocument">4.5. Interface Document</a>
     <li><a href="#ref-for-dom-domimplementation-createdocument①">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-dom-domimplementation-createdocument②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domimplementation-createhtmldocument">
-   <b><a href="#dom-domimplementation-createhtmldocument">#dom-domimplementation-createhtmldocument</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domimplementation-createhtmldocument" class="dfn-panel" data-for="dom-domimplementation-createhtmldocument" id="infopanel-for-dom-domimplementation-createhtmldocument" role="dialog">
+   <span id="infopaneltitle-for-dom-domimplementation-createhtmldocument" style="display:none">Info about the 'createHTMLDocument(title)' definition.</span><b><a href="#dom-domimplementation-createhtmldocument">#dom-domimplementation-createhtmldocument</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domimplementation-createhtmldocument">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-dom-domimplementation-createhtmldocument①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domimplementation-hasfeature">
-   <b><a href="#dom-domimplementation-hasfeature">#dom-domimplementation-hasfeature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domimplementation-hasfeature" class="dfn-panel" data-for="dom-domimplementation-hasfeature" id="infopanel-for-dom-domimplementation-hasfeature" role="dialog">
+   <span id="infopaneltitle-for-dom-domimplementation-hasfeature" style="display:none">Info about the 'hasFeature()' definition.</span><b><a href="#dom-domimplementation-hasfeature">#dom-domimplementation-hasfeature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domimplementation-hasfeature">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-dom-domimplementation-hasfeature①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="documenttype">
-   <b><a href="#documenttype">#documenttype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documenttype" class="dfn-panel" data-for="documenttype" id="infopanel-for-documenttype" role="dialog">
+   <span id="infopaneltitle-for-documenttype" style="display:none">Info about the 'DocumentType' definition.</span><b><a href="#documenttype">#documenttype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documenttype">4.2. Node tree</a> <a href="#ref-for-documenttype①">(2)</a> <a href="#ref-for-documenttype②">(3)</a> <a href="#ref-for-documenttype③">(4)</a>
     <li><a href="#ref-for-documenttype④">4.2.3. Mutation algorithms</a> <a href="#ref-for-documenttype⑤">(2)</a>
@@ -17692,8 +17693,8 @@ APIs</a>
     <li><a href="#ref-for-documenttype②②">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-doctype">
-   <b><a href="#concept-doctype">#concept-doctype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-doctype" class="dfn-panel" data-for="concept-doctype" id="infopanel-for-concept-doctype" role="dialog">
+   <span id="infopaneltitle-for-concept-doctype" style="display:none">Info about the 'doctypes' definition.</span><b><a href="#concept-doctype">#concept-doctype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-doctype">4.1. Introduction to "The DOM"</a>
     <li><a href="#ref-for-concept-doctype①">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-doctype②">(2)</a> <a href="#ref-for-concept-doctype③">(3)</a> <a href="#ref-for-concept-doctype④">(4)</a> <a href="#ref-for-concept-doctype⑤">(5)</a> <a href="#ref-for-concept-doctype⑥">(6)</a> <a href="#ref-for-concept-doctype⑦">(7)</a> <a href="#ref-for-concept-doctype⑧">(8)</a> <a href="#ref-for-concept-doctype⑨">(9)</a> <a href="#ref-for-concept-doctype①⓪">(10)</a> <a href="#ref-for-concept-doctype①①">(11)</a> <a href="#ref-for-concept-doctype①②">(12)</a>
@@ -17705,50 +17706,50 @@ APIs</a>
     <li><a href="#ref-for-concept-doctype②④">5.5. Interface Range</a> <a href="#ref-for-concept-doctype②⑤">(2)</a> <a href="#ref-for-concept-doctype②⑥">(3)</a> <a href="#ref-for-concept-doctype②⑦">(4)</a> <a href="#ref-for-concept-doctype②⑧">(5)</a> <a href="#ref-for-concept-doctype②⑨">(6)</a> <a href="#ref-for-concept-doctype③⓪">(7)</a> <a href="#ref-for-concept-doctype③①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-doctype-name">
-   <b><a href="#concept-doctype-name">#concept-doctype-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-doctype-name" class="dfn-panel" data-for="concept-doctype-name" id="infopanel-for-concept-doctype-name" role="dialog">
+   <span id="infopaneltitle-for-concept-doctype-name" style="display:none">Info about the 'name' definition.</span><b><a href="#concept-doctype-name">#concept-doctype-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-doctype-name">4.4. Interface Node</a> <a href="#ref-for-concept-doctype-name①">(2)</a> <a href="#ref-for-concept-doctype-name②">(3)</a> <a href="#ref-for-concept-doctype-name③">(4)</a>
     <li><a href="#ref-for-concept-doctype-name④">4.5.1. Interface DOMImplementation</a> <a href="#ref-for-concept-doctype-name⑤">(2)</a>
     <li><a href="#ref-for-concept-doctype-name⑥">4.6. Interface DocumentType</a> <a href="#ref-for-concept-doctype-name⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-doctype-publicid">
-   <b><a href="#concept-doctype-publicid">#concept-doctype-publicid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-doctype-publicid" class="dfn-panel" data-for="concept-doctype-publicid" id="infopanel-for-concept-doctype-publicid" role="dialog">
+   <span id="infopaneltitle-for-concept-doctype-publicid" style="display:none">Info about the 'public ID' definition.</span><b><a href="#concept-doctype-publicid">#concept-doctype-publicid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-doctype-publicid">4.4. Interface Node</a> <a href="#ref-for-concept-doctype-publicid①">(2)</a>
     <li><a href="#ref-for-concept-doctype-publicid②">4.5.1. Interface DOMImplementation</a>
     <li><a href="#ref-for-concept-doctype-publicid③">4.6. Interface DocumentType</a> <a href="#ref-for-concept-doctype-publicid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-doctype-systemid">
-   <b><a href="#concept-doctype-systemid">#concept-doctype-systemid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-doctype-systemid" class="dfn-panel" data-for="concept-doctype-systemid" id="infopanel-for-concept-doctype-systemid" role="dialog">
+   <span id="infopaneltitle-for-concept-doctype-systemid" style="display:none">Info about the 'system ID' definition.</span><b><a href="#concept-doctype-systemid">#concept-doctype-systemid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-doctype-systemid">4.4. Interface Node</a> <a href="#ref-for-concept-doctype-systemid①">(2)</a>
     <li><a href="#ref-for-concept-doctype-systemid②">4.5.1. Interface DOMImplementation</a>
     <li><a href="#ref-for-concept-doctype-systemid③">4.6. Interface DocumentType</a> <a href="#ref-for-concept-doctype-systemid④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttype-name">
-   <b><a href="#dom-documenttype-name">#dom-documenttype-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttype-name" class="dfn-panel" data-for="dom-documenttype-name" id="infopanel-for-dom-documenttype-name" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttype-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-documenttype-name">#dom-documenttype-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttype-name">4.6. Interface DocumentType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttype-publicid">
-   <b><a href="#dom-documenttype-publicid">#dom-documenttype-publicid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttype-publicid" class="dfn-panel" data-for="dom-documenttype-publicid" id="infopanel-for-dom-documenttype-publicid" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttype-publicid" style="display:none">Info about the 'publicId' definition.</span><b><a href="#dom-documenttype-publicid">#dom-documenttype-publicid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttype-publicid">4.6. Interface DocumentType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documenttype-systemid">
-   <b><a href="#dom-documenttype-systemid">#dom-documenttype-systemid</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documenttype-systemid" class="dfn-panel" data-for="dom-documenttype-systemid" id="infopanel-for-dom-documenttype-systemid" role="dialog">
+   <span id="infopaneltitle-for-dom-documenttype-systemid" style="display:none">Info about the 'systemId' definition.</span><b><a href="#dom-documenttype-systemid">#dom-documenttype-systemid</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documenttype-systemid">4.6. Interface DocumentType</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="documentfragment">
-   <b><a href="#documentfragment">#documentfragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documentfragment" class="dfn-panel" data-for="documentfragment" id="infopanel-for-documentfragment" role="dialog">
+   <span id="infopaneltitle-for-documentfragment" style="display:none">Info about the 'DocumentFragment' definition.</span><b><a href="#documentfragment">#documentfragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentfragment">4.2. Node tree</a> <a href="#ref-for-documentfragment①">(2)</a>
     <li><a href="#ref-for-documentfragment②">4.2.3. Mutation algorithms</a> <a href="#ref-for-documentfragment③">(2)</a> <a href="#ref-for-documentfragment④">(3)</a> <a href="#ref-for-documentfragment⑤">(4)</a> <a href="#ref-for-documentfragment⑥">(5)</a> <a href="#ref-for-documentfragment⑦">(6)</a> <a href="#ref-for-documentfragment⑧">(7)</a> <a href="#ref-for-documentfragment⑨">(8)</a> <a href="#ref-for-documentfragment①⓪">(9)</a> <a href="#ref-for-documentfragment①①">(10)</a>
@@ -17761,8 +17762,8 @@ APIs</a>
     <li><a href="#ref-for-documentfragment③③">5.5. Interface Range</a> <a href="#ref-for-documentfragment③④">(2)</a> <a href="#ref-for-documentfragment③⑤">(3)</a> <a href="#ref-for-documentfragment③⑥">(4)</a> <a href="#ref-for-documentfragment③⑦">(5)</a> <a href="#ref-for-documentfragment③⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-documentfragment-host">
-   <b><a href="#concept-documentfragment-host">#concept-documentfragment-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-documentfragment-host" class="dfn-panel" data-for="concept-documentfragment-host" id="infopanel-for-concept-documentfragment-host" role="dialog">
+   <span id="infopaneltitle-for-concept-documentfragment-host" style="display:none">Info about the 'host' definition.</span><b><a href="#concept-documentfragment-host">#concept-documentfragment-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">4.2.2. Shadow tree</a> <a href="#ref-for-concept-documentfragment-host①">(2)</a>
     <li><a href="#ref-for-concept-documentfragment-host②">4.2.2.3. Finding slots and slottables</a>
@@ -17772,21 +17773,21 @@ APIs</a>
     <li><a href="#ref-for-concept-documentfragment-host①④">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tree-host-including-inclusive-ancestor">
-   <b><a href="#concept-tree-host-including-inclusive-ancestor">#concept-tree-host-including-inclusive-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tree-host-including-inclusive-ancestor" class="dfn-panel" data-for="concept-tree-host-including-inclusive-ancestor" id="infopanel-for-concept-tree-host-including-inclusive-ancestor" role="dialog">
+   <span id="infopaneltitle-for-concept-tree-host-including-inclusive-ancestor" style="display:none">Info about the 'host-including inclusive ancestor' definition.</span><b><a href="#concept-tree-host-including-inclusive-ancestor">#concept-tree-host-including-inclusive-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-host-including-inclusive-ancestor">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-tree-host-including-inclusive-ancestor①">(2)</a>
     <li><a href="#ref-for-concept-tree-host-including-inclusive-ancestor②">4.7. Interface DocumentFragment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-documentfragment-documentfragment">
-   <b><a href="#dom-documentfragment-documentfragment">#dom-documentfragment-documentfragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-documentfragment-documentfragment" class="dfn-panel" data-for="dom-documentfragment-documentfragment" id="infopanel-for-dom-documentfragment-documentfragment" role="dialog">
+   <span id="infopaneltitle-for-dom-documentfragment-documentfragment" style="display:none">Info about the 'new DocumentFragment()' definition.</span><b><a href="#dom-documentfragment-documentfragment">#dom-documentfragment-documentfragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-documentfragment-documentfragment">4.7. Interface DocumentFragment</a> <a href="#ref-for-dom-documentfragment-documentfragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadowroot">
-   <b><a href="#shadowroot">#shadowroot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadowroot" class="dfn-panel" data-for="shadowroot" id="infopanel-for-shadowroot" role="dialog">
+   <span id="infopaneltitle-for-shadowroot" style="display:none">Info about the 'ShadowRoot' definition.</span><b><a href="#shadowroot">#shadowroot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot">2.2. Interface Event</a>
     <li><a href="#ref-for-shadowroot①">4.2.5. Mixin DocumentOrShadowRoot</a>
@@ -17794,22 +17795,22 @@ APIs</a>
     <li><a href="#ref-for-shadowroot④">4.9. Interface Element</a> <a href="#ref-for-shadowroot⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-shadowrootmode">
-   <b><a href="#enumdef-shadowrootmode">#enumdef-shadowrootmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-shadowrootmode" class="dfn-panel" data-for="enumdef-shadowrootmode" id="infopanel-for-enumdef-shadowrootmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-shadowrootmode" style="display:none">Info about the 'ShadowRootMode' definition.</span><b><a href="#enumdef-shadowrootmode">#enumdef-shadowrootmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-shadowrootmode">4.8. Interface ShadowRoot</a>
     <li><a href="#ref-for-enumdef-shadowrootmode①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-slotassignmentmode">
-   <b><a href="#enumdef-slotassignmentmode">#enumdef-slotassignmentmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-slotassignmentmode" class="dfn-panel" data-for="enumdef-slotassignmentmode" id="infopanel-for-enumdef-slotassignmentmode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-slotassignmentmode" style="display:none">Info about the 'SlotAssignmentMode' definition.</span><b><a href="#enumdef-slotassignmentmode">#enumdef-slotassignmentmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-slotassignmentmode">4.8. Interface ShadowRoot</a>
     <li><a href="#ref-for-enumdef-slotassignmentmode①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-root">
-   <b><a href="#concept-shadow-root">#concept-shadow-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-root" class="dfn-panel" data-for="concept-shadow-root" id="infopanel-for-concept-shadow-root" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-root" style="display:none">Info about the 'shadow roots' definition.</span><b><a href="#concept-shadow-root">#concept-shadow-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">2.2. Interface Event</a>
     <li><a href="#ref-for-concept-shadow-root①">2.7. Interface EventTarget</a>
@@ -17825,8 +17826,8 @@ APIs</a>
     <li><a href="#ref-for-concept-shadow-root③⑤">4.9. Interface Element</a> <a href="#ref-for-concept-shadow-root③⑥">(2)</a> <a href="#ref-for-concept-shadow-root③⑦">(3)</a> <a href="#ref-for-concept-shadow-root③⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadowroot-mode">
-   <b><a href="#shadowroot-mode">#shadowroot-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadowroot-mode" class="dfn-panel" data-for="shadowroot-mode" id="infopanel-for-shadowroot-mode" role="dialog">
+   <span id="infopaneltitle-for-shadowroot-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#shadowroot-mode">#shadowroot-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot-mode">2.2. Interface Event</a>
     <li><a href="#ref-for-shadowroot-mode①">2.9. Dispatching events</a> <a href="#ref-for-shadowroot-mode②">(2)</a>
@@ -17835,20 +17836,20 @@ APIs</a>
     <li><a href="#ref-for-shadowroot-mode⑥">4.9. Interface Element</a> <a href="#ref-for-shadowroot-mode⑦">(2)</a> <a href="#ref-for-shadowroot-mode⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadowroot-delegates-focus">
-   <b><a href="#shadowroot-delegates-focus">#shadowroot-delegates-focus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadowroot-delegates-focus" class="dfn-panel" data-for="shadowroot-delegates-focus" id="infopanel-for-shadowroot-delegates-focus" role="dialog">
+   <span id="infopaneltitle-for-shadowroot-delegates-focus" style="display:none">Info about the 'delegates focus' definition.</span><b><a href="#shadowroot-delegates-focus">#shadowroot-delegates-focus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot-delegates-focus">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadowroot-available-to-element-internals">
-   <b><a href="#shadowroot-available-to-element-internals">#shadowroot-available-to-element-internals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadowroot-available-to-element-internals" class="dfn-panel" data-for="shadowroot-available-to-element-internals" id="infopanel-for-shadowroot-available-to-element-internals" role="dialog">
+   <span id="infopaneltitle-for-shadowroot-available-to-element-internals" style="display:none">Info about the 'available to element internals' definition.</span><b><a href="#shadowroot-available-to-element-internals">#shadowroot-available-to-element-internals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot-available-to-element-internals">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadowroot-slot-assignment">
-   <b><a href="#shadowroot-slot-assignment">#shadowroot-slot-assignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadowroot-slot-assignment" class="dfn-panel" data-for="shadowroot-slot-assignment" id="infopanel-for-shadowroot-slot-assignment" role="dialog">
+   <span id="infopaneltitle-for-shadowroot-slot-assignment" style="display:none">Info about the 'slot assignment' definition.</span><b><a href="#shadowroot-slot-assignment">#shadowroot-slot-assignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot-slot-assignment">4.2.2.3. Finding slots and slottables</a> <a href="#ref-for-shadowroot-slot-assignment①">(2)</a>
     <li><a href="#ref-for-shadowroot-slot-assignment②">4.2.3. Mutation algorithms</a>
@@ -17856,94 +17857,94 @@ APIs</a>
     <li><a href="#ref-for-shadowroot-slot-assignment④">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowroot-mode">
-   <b><a href="#dom-shadowroot-mode">#dom-shadowroot-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowroot-mode" class="dfn-panel" data-for="dom-shadowroot-mode" id="infopanel-for-dom-shadowroot-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowroot-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-shadowroot-mode">#dom-shadowroot-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowroot-mode">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowroot-host">
-   <b><a href="#dom-shadowroot-host">#dom-shadowroot-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowroot-host" class="dfn-panel" data-for="dom-shadowroot-host" id="infopanel-for-dom-shadowroot-host" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowroot-host" style="display:none">Info about the 'host' definition.</span><b><a href="#dom-shadowroot-host">#dom-shadowroot-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowroot-host">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowroot-onslotchange">
-   <b><a href="#dom-shadowroot-onslotchange">#dom-shadowroot-onslotchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowroot-onslotchange" class="dfn-panel" data-for="dom-shadowroot-onslotchange" id="infopanel-for-dom-shadowroot-onslotchange" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowroot-onslotchange" style="display:none">Info about the 'onslotchange' definition.</span><b><a href="#dom-shadowroot-onslotchange">#dom-shadowroot-onslotchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowroot-onslotchange">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowroot-slotassignment">
-   <b><a href="#dom-shadowroot-slotassignment">#dom-shadowroot-slotassignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowroot-slotassignment" class="dfn-panel" data-for="dom-shadowroot-slotassignment" id="infopanel-for-dom-shadowroot-slotassignment" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowroot-slotassignment" style="display:none">Info about the 'slotAssignment' definition.</span><b><a href="#dom-shadowroot-slotassignment">#dom-shadowroot-slotassignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowroot-slotassignment">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-tree-order">
-   <b><a href="#concept-shadow-including-tree-order">#concept-shadow-including-tree-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="concept-shadow-including-tree-order" id="infopanel-for-concept-shadow-including-tree-order" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' definition.</span><b><a href="#concept-shadow-including-tree-order">#concept-shadow-including-tree-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-shadow-including-tree-order①">(2)</a>
     <li><a href="#ref-for-concept-shadow-including-tree-order②">4.5. Interface Document</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shadow-including-preorder-depth-first-traversal">
-   <b><a href="#shadow-including-preorder-depth-first-traversal">#shadow-including-preorder-depth-first-traversal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shadow-including-preorder-depth-first-traversal" class="dfn-panel" data-for="shadow-including-preorder-depth-first-traversal" id="infopanel-for-shadow-including-preorder-depth-first-traversal" role="dialog">
+   <span id="infopaneltitle-for-shadow-including-preorder-depth-first-traversal" style="display:none">Info about the 'Shadow-including preorder, depth-first traversal' definition.</span><b><a href="#shadow-including-preorder-depth-first-traversal">#shadow-including-preorder-depth-first-traversal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadow-including-preorder-depth-first-traversal">4.8. Interface ShadowRoot</a> <a href="#ref-for-shadow-including-preorder-depth-first-traversal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-root">
-   <b><a href="#concept-shadow-including-root">#concept-shadow-including-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-root" class="dfn-panel" data-for="concept-shadow-including-root" id="infopanel-for-concept-shadow-including-root" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-root" style="display:none">Info about the 'shadow-including root' definition.</span><b><a href="#concept-shadow-including-root">#concept-shadow-including-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-root">4.2.2. Shadow tree</a>
     <li><a href="#ref-for-concept-shadow-including-root①">4.4. Interface Node</a> <a href="#ref-for-concept-shadow-including-root②">(2)</a>
     <li><a href="#ref-for-concept-shadow-including-root③">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-descendant">
-   <b><a href="#concept-shadow-including-descendant">#concept-shadow-including-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-descendant" class="dfn-panel" data-for="concept-shadow-including-descendant" id="infopanel-for-concept-shadow-including-descendant" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-descendant" style="display:none">Info about the 'shadow-including descendant' definition.</span><b><a href="#concept-shadow-including-descendant">#concept-shadow-including-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-descendant">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-shadow-including-descendant①">4.8. Interface ShadowRoot</a> <a href="#ref-for-concept-shadow-including-descendant②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-inclusive-descendant">
-   <b><a href="#concept-shadow-including-inclusive-descendant">#concept-shadow-including-inclusive-descendant</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-inclusive-descendant" class="dfn-panel" data-for="concept-shadow-including-inclusive-descendant" id="infopanel-for-concept-shadow-including-inclusive-descendant" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-inclusive-descendant" style="display:none">Info about the 'shadow-including inclusive descendant' definition.</span><b><a href="#concept-shadow-including-inclusive-descendant">#concept-shadow-including-inclusive-descendant</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-inclusive-descendant">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-shadow-including-inclusive-descendant①">4.5. Interface Document</a> <a href="#ref-for-concept-shadow-including-inclusive-descendant②">(2)</a> <a href="#ref-for-concept-shadow-including-inclusive-descendant③">(3)</a>
     <li><a href="#ref-for-concept-shadow-including-inclusive-descendant④">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-ancestor">
-   <b><a href="#concept-shadow-including-ancestor">#concept-shadow-including-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-ancestor" class="dfn-panel" data-for="concept-shadow-including-ancestor" id="infopanel-for-concept-shadow-including-ancestor" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-ancestor" style="display:none">Info about the 'shadow-including ancestor' definition.</span><b><a href="#concept-shadow-including-ancestor">#concept-shadow-including-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-ancestor">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-shadow-including-inclusive-ancestor">
-   <b><a href="#concept-shadow-including-inclusive-ancestor">#concept-shadow-including-inclusive-ancestor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-shadow-including-inclusive-ancestor" class="dfn-panel" data-for="concept-shadow-including-inclusive-ancestor" id="infopanel-for-concept-shadow-including-inclusive-ancestor" role="dialog">
+   <span id="infopaneltitle-for-concept-shadow-including-inclusive-ancestor" style="display:none">Info about the 'shadow-including inclusive ancestor' definition.</span><b><a href="#concept-shadow-including-inclusive-ancestor">#concept-shadow-including-inclusive-ancestor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor">2.9. Dispatching events</a>
     <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor①">4.8. Interface ShadowRoot</a> <a href="#ref-for-concept-shadow-including-inclusive-ancestor②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-closed-shadow-hidden">
-   <b><a href="#concept-closed-shadow-hidden">#concept-closed-shadow-hidden</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-closed-shadow-hidden" class="dfn-panel" data-for="concept-closed-shadow-hidden" id="infopanel-for-concept-closed-shadow-hidden" role="dialog">
+   <span id="infopaneltitle-for-concept-closed-shadow-hidden" style="display:none">Info about the 'closed-shadow-hidden' definition.</span><b><a href="#concept-closed-shadow-hidden">#concept-closed-shadow-hidden</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-closed-shadow-hidden">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="retarget">
-   <b><a href="#retarget">#retarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-retarget" class="dfn-panel" data-for="retarget" id="infopanel-for-retarget" role="dialog">
+   <span id="infopaneltitle-for-retarget" style="display:none">Info about the 'retarget' definition.</span><b><a href="#retarget">#retarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retarget">2.9. Dispatching events</a> <a href="#ref-for-retarget①">(2)</a> <a href="#ref-for-retarget②">(3)</a> <a href="#ref-for-retarget③">(4)</a>
     <li><a href="#ref-for-retarget④">4.8. Interface ShadowRoot</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element">
-   <b><a href="#element">#element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element" class="dfn-panel" data-for="element" id="infopanel-for-element" role="dialog">
+   <span id="infopaneltitle-for-element" style="display:none">Info about the 'Element' definition.</span><b><a href="#element">#element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">4.1. Introduction to "The DOM"</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a>
     <li><a href="#ref-for-element④">4.2. Node tree</a> <a href="#ref-for-element⑤">(2)</a> <a href="#ref-for-element⑥">(3)</a> <a href="#ref-for-element⑦">(4)</a>
@@ -17964,32 +17965,32 @@ APIs</a>
     <li><a href="#ref-for-element⑤⓪">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-shadowrootinit">
-   <b><a href="#dictdef-shadowrootinit">#dictdef-shadowrootinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-shadowrootinit" class="dfn-panel" data-for="dictdef-shadowrootinit" id="infopanel-for-dictdef-shadowrootinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-shadowrootinit" style="display:none">Info about the 'ShadowRootInit' definition.</span><b><a href="#dictdef-shadowrootinit">#dictdef-shadowrootinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-shadowrootinit">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowrootinit-mode">
-   <b><a href="#dom-shadowrootinit-mode">#dom-shadowrootinit-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowrootinit-mode" class="dfn-panel" data-for="dom-shadowrootinit-mode" id="infopanel-for-dom-shadowrootinit-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowrootinit-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-shadowrootinit-mode">#dom-shadowrootinit-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowrootinit-mode">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowrootinit-delegatesfocus">
-   <b><a href="#dom-shadowrootinit-delegatesfocus">#dom-shadowrootinit-delegatesfocus</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowrootinit-delegatesfocus" class="dfn-panel" data-for="dom-shadowrootinit-delegatesfocus" id="infopanel-for-dom-shadowrootinit-delegatesfocus" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowrootinit-delegatesfocus" style="display:none">Info about the 'delegatesFocus' definition.</span><b><a href="#dom-shadowrootinit-delegatesfocus">#dom-shadowrootinit-delegatesfocus</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowrootinit-delegatesfocus">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-shadowrootinit-slotassignment">
-   <b><a href="#dom-shadowrootinit-slotassignment">#dom-shadowrootinit-slotassignment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-shadowrootinit-slotassignment" class="dfn-panel" data-for="dom-shadowrootinit-slotassignment" id="infopanel-for-dom-shadowrootinit-slotassignment" role="dialog">
+   <span id="infopaneltitle-for-dom-shadowrootinit-slotassignment" style="display:none">Info about the 'slotAssignment' definition.</span><b><a href="#dom-shadowrootinit-slotassignment">#dom-shadowrootinit-slotassignment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-shadowrootinit-slotassignment">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element">
-   <b><a href="#concept-element">#concept-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element" class="dfn-panel" data-for="concept-element" id="infopanel-for-concept-element" role="dialog">
+   <span id="infopaneltitle-for-concept-element" style="display:none">Info about the 'elements' definition.</span><b><a href="#concept-element">#concept-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">2.1. Introduction to "DOM Events"</a> <a href="#ref-for-concept-element①">(2)</a> <a href="#ref-for-concept-element②">(3)</a> <a href="#ref-for-concept-element③">(4)</a>
     <li><a href="#ref-for-concept-element④">4.2.1. Document tree</a> <a href="#ref-for-concept-element⑤">(2)</a> <a href="#ref-for-concept-element⑥">(3)</a> <a href="#ref-for-concept-element⑦">(4)</a>
@@ -18012,8 +18013,8 @@ APIs</a>
     <li><a href="#ref-for-concept-element①①⑤">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-element①①⑥">(2)</a> <a href="#ref-for-concept-element①①⑦">(3)</a> <a href="#ref-for-concept-element①①⑧">(4)</a> <a href="#ref-for-concept-element①①⑨">(5)</a> <a href="#ref-for-concept-element①②⓪">(6)</a> <a href="#ref-for-concept-element①②①">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-namespace">
-   <b><a href="#concept-element-namespace">#concept-element-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-namespace" class="dfn-panel" data-for="concept-element-namespace" id="infopanel-for-concept-element-namespace" role="dialog">
+   <span id="infopaneltitle-for-concept-element-namespace" style="display:none">Info about the 'namespace' definition.</span><b><a href="#concept-element-namespace">#concept-element-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-namespace">4.4. Interface Node</a> <a href="#ref-for-concept-element-namespace①">(2)</a> <a href="#ref-for-concept-element-namespace②">(3)</a> <a href="#ref-for-concept-element-namespace③">(4)</a> <a href="#ref-for-concept-element-namespace④">(5)</a> <a href="#ref-for-concept-element-namespace⑤">(6)</a> <a href="#ref-for-concept-element-namespace⑥">(7)</a> <a href="#ref-for-concept-element-namespace⑦">(8)</a> <a href="#ref-for-concept-element-namespace⑧">(9)</a>
     <li><a href="#ref-for-concept-element-namespace⑨">4.5. Interface Document</a> <a href="#ref-for-concept-element-namespace①⓪">(2)</a> <a href="#ref-for-concept-element-namespace①①">(3)</a> <a href="#ref-for-concept-element-namespace①②">(4)</a>
@@ -18021,16 +18022,16 @@ APIs</a>
     <li><a href="#ref-for-concept-element-namespace①④">4.9. Interface Element</a> <a href="#ref-for-concept-element-namespace①⑤">(2)</a> <a href="#ref-for-concept-element-namespace①⑥">(3)</a> <a href="#ref-for-concept-element-namespace①⑦">(4)</a> <a href="#ref-for-concept-element-namespace①⑧">(5)</a> <a href="#ref-for-concept-element-namespace①⑨">(6)</a> <a href="#ref-for-concept-element-namespace②⓪">(7)</a> <a href="#ref-for-concept-element-namespace②①">(8)</a> <a href="#ref-for-concept-element-namespace②②">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-namespace-prefix">
-   <b><a href="#concept-element-namespace-prefix">#concept-element-namespace-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-namespace-prefix" class="dfn-panel" data-for="concept-element-namespace-prefix" id="infopanel-for-concept-element-namespace-prefix" role="dialog">
+   <span id="infopaneltitle-for-concept-element-namespace-prefix" style="display:none">Info about the 'namespace prefix' definition.</span><b><a href="#concept-element-namespace-prefix">#concept-element-namespace-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-namespace-prefix">4.4. Interface Node</a> <a href="#ref-for-concept-element-namespace-prefix①">(2)</a> <a href="#ref-for-concept-element-namespace-prefix②">(3)</a> <a href="#ref-for-concept-element-namespace-prefix③">(4)</a> <a href="#ref-for-concept-element-namespace-prefix④">(5)</a>
     <li><a href="#ref-for-concept-element-namespace-prefix⑤">4.5. Interface Document</a> <a href="#ref-for-concept-element-namespace-prefix⑥">(2)</a> <a href="#ref-for-concept-element-namespace-prefix⑦">(3)</a> <a href="#ref-for-concept-element-namespace-prefix⑧">(4)</a> <a href="#ref-for-concept-element-namespace-prefix⑨">(5)</a>
     <li><a href="#ref-for-concept-element-namespace-prefix①⓪">4.9. Interface Element</a> <a href="#ref-for-concept-element-namespace-prefix①①">(2)</a> <a href="#ref-for-concept-element-namespace-prefix①②">(3)</a> <a href="#ref-for-concept-element-namespace-prefix①③">(4)</a> <a href="#ref-for-concept-element-namespace-prefix①④">(5)</a> <a href="#ref-for-concept-element-namespace-prefix①⑤">(6)</a> <a href="#ref-for-concept-element-namespace-prefix①⑥">(7)</a> <a href="#ref-for-concept-element-namespace-prefix①⑦">(8)</a> <a href="#ref-for-concept-element-namespace-prefix①⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-local-name">
-   <b><a href="#concept-element-local-name">#concept-element-local-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-local-name" class="dfn-panel" data-for="concept-element-local-name" id="infopanel-for-concept-element-local-name" role="dialog">
+   <span id="infopaneltitle-for-concept-element-local-name" style="display:none">Info about the 'local name' definition.</span><b><a href="#concept-element-local-name">#concept-element-local-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-local-name">4.4. Interface Node</a> <a href="#ref-for-concept-element-local-name①">(2)</a> <a href="#ref-for-concept-element-local-name②">(3)</a> <a href="#ref-for-concept-element-local-name③">(4)</a>
     <li><a href="#ref-for-concept-element-local-name④">4.5. Interface Document</a> <a href="#ref-for-concept-element-local-name⑤">(2)</a> <a href="#ref-for-concept-element-local-name⑥">(3)</a> <a href="#ref-for-concept-element-local-name⑦">(4)</a>
@@ -18038,33 +18039,33 @@ APIs</a>
     <li><a href="#ref-for-concept-element-local-name⑨">4.9. Interface Element</a> <a href="#ref-for-concept-element-local-name①⓪">(2)</a> <a href="#ref-for-concept-element-local-name①①">(3)</a> <a href="#ref-for-concept-element-local-name①②">(4)</a> <a href="#ref-for-concept-element-local-name①③">(5)</a> <a href="#ref-for-concept-element-local-name①④">(6)</a> <a href="#ref-for-concept-element-local-name①⑤">(7)</a> <a href="#ref-for-concept-element-local-name①⑥">(8)</a> <a href="#ref-for-concept-element-local-name①⑦">(9)</a> <a href="#ref-for-concept-element-local-name①⑧">(10)</a> <a href="#ref-for-concept-element-local-name①⑨">(11)</a> <a href="#ref-for-concept-element-local-name②⓪">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-custom-element-state">
-   <b><a href="#concept-element-custom-element-state">#concept-element-custom-element-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-custom-element-state" class="dfn-panel" data-for="concept-element-custom-element-state" id="infopanel-for-concept-element-custom-element-state" role="dialog">
+   <span id="infopaneltitle-for-concept-element-custom-element-state" style="display:none">Info about the 'custom element state' definition.</span><b><a href="#concept-element-custom-element-state">#concept-element-custom-element-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-custom-element-state">4.9. Interface Element</a> <a href="#ref-for-concept-element-custom-element-state①">(2)</a> <a href="#ref-for-concept-element-custom-element-state②">(3)</a> <a href="#ref-for-concept-element-custom-element-state③">(4)</a> <a href="#ref-for-concept-element-custom-element-state④">(5)</a> <a href="#ref-for-concept-element-custom-element-state⑤">(6)</a> <a href="#ref-for-concept-element-custom-element-state⑥">(7)</a> <a href="#ref-for-concept-element-custom-element-state⑦">(8)</a> <a href="#ref-for-concept-element-custom-element-state⑧">(9)</a> <a href="#ref-for-concept-element-custom-element-state⑨">(10)</a> <a href="#ref-for-concept-element-custom-element-state①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-custom-element-definition">
-   <b><a href="#concept-element-custom-element-definition">#concept-element-custom-element-definition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-custom-element-definition" class="dfn-panel" data-for="concept-element-custom-element-definition" id="infopanel-for-concept-element-custom-element-definition" role="dialog">
+   <span id="infopaneltitle-for-concept-element-custom-element-definition" style="display:none">Info about the 'custom element definition' definition.</span><b><a href="#concept-element-custom-element-definition">#concept-element-custom-element-definition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-custom-element-definition">4.9. Interface Element</a> <a href="#ref-for-concept-element-custom-element-definition①">(2)</a> <a href="#ref-for-concept-element-custom-element-definition②">(3)</a> <a href="#ref-for-concept-element-custom-element-definition③">(4)</a> <a href="#ref-for-concept-element-custom-element-definition④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-is-value">
-   <b><a href="#concept-element-is-value">#concept-element-is-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-is-value" class="dfn-panel" data-for="concept-element-is-value" id="infopanel-for-concept-element-is-value" role="dialog">
+   <span id="infopaneltitle-for-concept-element-is-value" style="display:none">Info about the 'is value' definition.</span><b><a href="#concept-element-is-value">#concept-element-is-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-is-value">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-element-is-value①">4.9. Interface Element</a> <a href="#ref-for-concept-element-is-value②">(2)</a> <a href="#ref-for-concept-element-is-value③">(3)</a> <a href="#ref-for-concept-element-is-value④">(4)</a> <a href="#ref-for-concept-element-is-value⑤">(5)</a> <a href="#ref-for-concept-element-is-value⑥">(6)</a> <a href="#ref-for-concept-element-is-value⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-defined">
-   <b><a href="#concept-element-defined">#concept-element-defined</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-defined" class="dfn-panel" data-for="concept-element-defined" id="infopanel-for-concept-element-defined" role="dialog">
+   <span id="infopaneltitle-for-concept-element-defined" style="display:none">Info about the 'defined' definition.</span><b><a href="#concept-element-defined">#concept-element-defined</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-defined">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-custom">
-   <b><a href="#concept-element-custom">#concept-element-custom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-custom" class="dfn-panel" data-for="concept-element-custom" id="infopanel-for-concept-element-custom" role="dialog">
+   <span id="infopaneltitle-for-concept-element-custom" style="display:none">Info about the 'custom' definition.</span><b><a href="#concept-element-custom">#concept-element-custom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-custom">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-element-custom①">(2)</a> <a href="#ref-for-concept-element-custom②">(3)</a> <a href="#ref-for-concept-element-custom③">(4)</a>
     <li><a href="#ref-for-concept-element-custom④">4.5. Interface Document</a>
@@ -18072,39 +18073,39 @@ APIs</a>
     <li><a href="#ref-for-concept-element-custom⑦">Intellectual property rights</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-shadow-root">
-   <b><a href="#concept-element-shadow-root">#concept-element-shadow-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-shadow-root" class="dfn-panel" data-for="concept-element-shadow-root" id="infopanel-for-concept-element-shadow-root" role="dialog">
+   <span id="infopaneltitle-for-concept-element-shadow-root" style="display:none">Info about the 'shadow root' definition.</span><b><a href="#concept-element-shadow-root">#concept-element-shadow-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-shadow-root">4.2.2.3. Finding slots and slottables</a>
     <li><a href="#ref-for-concept-element-shadow-root①">4.8. Interface ShadowRoot</a>
     <li><a href="#ref-for-concept-element-shadow-root②">4.9. Interface Element</a> <a href="#ref-for-concept-element-shadow-root③">(2)</a> <a href="#ref-for-concept-element-shadow-root④">(3)</a> <a href="#ref-for-concept-element-shadow-root⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-shadow-host">
-   <b><a href="#element-shadow-host">#element-shadow-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-shadow-host" class="dfn-panel" data-for="element-shadow-host" id="infopanel-for-element-shadow-host" role="dialog">
+   <span id="infopaneltitle-for-element-shadow-host" style="display:none">Info about the 'shadow host' definition.</span><b><a href="#element-shadow-host">#element-shadow-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-shadow-host">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-element-shadow-host①">4.8. Interface ShadowRoot</a>
     <li><a href="#ref-for-element-shadow-host②">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-qualified-name">
-   <b><a href="#concept-element-qualified-name">#concept-element-qualified-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-qualified-name" class="dfn-panel" data-for="concept-element-qualified-name" id="infopanel-for-concept-element-qualified-name" role="dialog">
+   <span id="infopaneltitle-for-concept-element-qualified-name" style="display:none">Info about the 'qualified name' definition.</span><b><a href="#concept-element-qualified-name">#concept-element-qualified-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-qualified-name">4.4. Interface Node</a> <a href="#ref-for-concept-element-qualified-name①">(2)</a> <a href="#ref-for-concept-element-qualified-name②">(3)</a>
     <li><a href="#ref-for-concept-element-qualified-name③">4.5. Interface Document</a>
     <li><a href="#ref-for-concept-element-qualified-name④">4.9. Interface Element</a> <a href="#ref-for-concept-element-qualified-name⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-html-uppercased-qualified-name">
-   <b><a href="#element-html-uppercased-qualified-name">#element-html-uppercased-qualified-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-html-uppercased-qualified-name" class="dfn-panel" data-for="element-html-uppercased-qualified-name" id="infopanel-for-element-html-uppercased-qualified-name" role="dialog">
+   <span id="infopaneltitle-for-element-html-uppercased-qualified-name" style="display:none">Info about the 'HTML-uppercased qualified name' definition.</span><b><a href="#element-html-uppercased-qualified-name">#element-html-uppercased-qualified-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-html-uppercased-qualified-name">4.4. Interface Node</a> <a href="#ref-for-element-html-uppercased-qualified-name①">(2)</a>
     <li><a href="#ref-for-element-html-uppercased-qualified-name②">4.9. Interface Element</a> <a href="#ref-for-element-html-uppercased-qualified-name③">(2)</a> <a href="#ref-for-element-html-uppercased-qualified-name④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-create-element">
-   <b><a href="#concept-create-element">#concept-create-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-create-element" class="dfn-panel" data-for="concept-create-element" id="infopanel-for-concept-create-element" role="dialog">
+   <span id="infopaneltitle-for-concept-create-element" style="display:none">Info about the 'create an element' definition.</span><b><a href="#concept-create-element">#concept-create-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-create-element">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-create-element①">4.5. Interface Document</a> <a href="#ref-for-concept-create-element②">(2)</a>
@@ -18112,8 +18113,8 @@ APIs</a>
     <li><a href="#ref-for-concept-create-element⑦">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attribute">
-   <b><a href="#concept-element-attribute">#concept-element-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attribute" class="dfn-panel" data-for="concept-element-attribute" id="infopanel-for-concept-element-attribute" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attribute" style="display:none">Info about the 'attribute list' definition.</span><b><a href="#concept-element-attribute">#concept-element-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute">4.4. Interface Node</a> <a href="#ref-for-concept-element-attribute①">(2)</a> <a href="#ref-for-concept-element-attribute②">(3)</a> <a href="#ref-for-concept-element-attribute③">(4)</a> <a href="#ref-for-concept-element-attribute④">(5)</a>
     <li><a href="#ref-for-concept-element-attribute⑤">4.5. Interface Document</a>
@@ -18121,16 +18122,16 @@ APIs</a>
     <li><a href="#ref-for-concept-element-attribute①⑨">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attribute-has">
-   <b><a href="#concept-element-attribute-has">#concept-element-attribute-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attribute-has" class="dfn-panel" data-for="concept-element-attribute-has" id="infopanel-for-concept-element-attribute-has" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attribute-has" style="display:none">Info about the 'has' definition.</span><b><a href="#concept-element-attribute-has">#concept-element-attribute-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attribute-has">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-concept-element-attribute-has①">(2)</a>
     <li><a href="#ref-for-concept-element-attribute-has②">4.4. Interface Node</a> <a href="#ref-for-concept-element-attribute-has③">(2)</a> <a href="#ref-for-concept-element-attribute-has④">(3)</a>
     <li><a href="#ref-for-concept-element-attribute-has⑤">4.9. Interface Element</a> <a href="#ref-for-concept-element-attribute-has⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-change-ext">
-   <b><a href="#concept-element-attributes-change-ext">#concept-element-attributes-change-ext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-change-ext" class="dfn-panel" data-for="concept-element-attributes-change-ext" id="infopanel-for-concept-element-attributes-change-ext" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-change-ext" style="display:none">Info about the 'attribute change steps' definition.</span><b><a href="#concept-element-attributes-change-ext">#concept-element-attributes-change-ext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-change-ext">4.2.2.1. Slots</a>
     <li><a href="#ref-for-concept-element-attributes-change-ext①">4.2.2.2. Slottables</a>
@@ -18138,400 +18139,400 @@ APIs</a>
     <li><a href="#ref-for-concept-element-attributes-change-ext④">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-element-attributes-change-ext⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-attribute-changes">
-   <b><a href="#handle-attribute-changes">#handle-attribute-changes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-attribute-changes" class="dfn-panel" data-for="handle-attribute-changes" id="infopanel-for-handle-attribute-changes" role="dialog">
+   <span id="infopaneltitle-for-handle-attribute-changes" style="display:none">Info about the 'handle attribute changes' definition.</span><b><a href="#handle-attribute-changes">#handle-attribute-changes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-attribute-changes">4.9. Interface Element</a> <a href="#ref-for-handle-attribute-changes①">(2)</a> <a href="#ref-for-handle-attribute-changes②">(3)</a> <a href="#ref-for-handle-attribute-changes③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-change">
-   <b><a href="#concept-element-attributes-change">#concept-element-attributes-change</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-change" class="dfn-panel" data-for="concept-element-attributes-change" id="infopanel-for-concept-element-attributes-change" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-change" style="display:none">Info about the 'change' definition.</span><b><a href="#concept-element-attributes-change">#concept-element-attributes-change</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-change">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-change①">(2)</a>
     <li><a href="#ref-for-concept-element-attributes-change②">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-append">
-   <b><a href="#concept-element-attributes-append">#concept-element-attributes-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-append" class="dfn-panel" data-for="concept-element-attributes-append" id="infopanel-for-concept-element-attributes-append" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-append" style="display:none">Info about the 'append' definition.</span><b><a href="#concept-element-attributes-append">#concept-element-attributes-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-append">4.4. Interface Node</a>
     <li><a href="#ref-for-concept-element-attributes-append①">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-append②">(2)</a> <a href="#ref-for-concept-element-attributes-append③">(3)</a> <a href="#ref-for-concept-element-attributes-append④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-remove">
-   <b><a href="#concept-element-attributes-remove">#concept-element-attributes-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-remove" class="dfn-panel" data-for="concept-element-attributes-remove" id="infopanel-for-concept-element-attributes-remove" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-remove" style="display:none">Info about the 'remove' definition.</span><b><a href="#concept-element-attributes-remove">#concept-element-attributes-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-remove">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-remove①">(2)</a> <a href="#ref-for-concept-element-attributes-remove②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-replace">
-   <b><a href="#concept-element-attributes-replace">#concept-element-attributes-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-replace" class="dfn-panel" data-for="concept-element-attributes-replace" id="infopanel-for-concept-element-attributes-replace" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#concept-element-attributes-replace">#concept-element-attributes-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-replace">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-get-by-name">
-   <b><a href="#concept-element-attributes-get-by-name">#concept-element-attributes-get-by-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-get-by-name" class="dfn-panel" data-for="concept-element-attributes-get-by-name" id="infopanel-for-concept-element-attributes-get-by-name" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-get-by-name" style="display:none">Info about the 'get an attribute by name' definition.</span><b><a href="#concept-element-attributes-get-by-name">#concept-element-attributes-get-by-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-get-by-name">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-get-by-name①">(2)</a> <a href="#ref-for-concept-element-attributes-get-by-name②">(3)</a>
     <li><a href="#ref-for-concept-element-attributes-get-by-name③">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-get-by-namespace">
-   <b><a href="#concept-element-attributes-get-by-namespace">#concept-element-attributes-get-by-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-get-by-namespace" class="dfn-panel" data-for="concept-element-attributes-get-by-namespace" id="infopanel-for-concept-element-attributes-get-by-namespace" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-get-by-namespace" style="display:none">Info about the 'get an attribute by namespace and local name' definition.</span><b><a href="#concept-element-attributes-get-by-namespace">#concept-element-attributes-get-by-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-get-by-namespace">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-get-by-namespace①">(2)</a> <a href="#ref-for-concept-element-attributes-get-by-namespace②">(3)</a> <a href="#ref-for-concept-element-attributes-get-by-namespace③">(4)</a> <a href="#ref-for-concept-element-attributes-get-by-namespace④">(5)</a> <a href="#ref-for-concept-element-attributes-get-by-namespace⑤">(6)</a>
     <li><a href="#ref-for-concept-element-attributes-get-by-namespace⑥">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-get-value">
-   <b><a href="#concept-element-attributes-get-value">#concept-element-attributes-get-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-get-value" class="dfn-panel" data-for="concept-element-attributes-get-value" id="infopanel-for-concept-element-attributes-get-value" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-get-value" style="display:none">Info about the 'get an attribute value' definition.</span><b><a href="#concept-element-attributes-get-value">#concept-element-attributes-get-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-get-value">4.9. Interface Element</a>
     <li><a href="#ref-for-concept-element-attributes-get-value①">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-element-attributes-get-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-set">
-   <b><a href="#concept-element-attributes-set">#concept-element-attributes-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-set" class="dfn-panel" data-for="concept-element-attributes-set" id="infopanel-for-concept-element-attributes-set" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-set" style="display:none">Info about the 'set an attribute' definition.</span><b><a href="#concept-element-attributes-set">#concept-element-attributes-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-set">4.9. Interface Element</a>
     <li><a href="#ref-for-concept-element-attributes-set①">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-set-value">
-   <b><a href="#concept-element-attributes-set-value">#concept-element-attributes-set-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-set-value" class="dfn-panel" data-for="concept-element-attributes-set-value" id="infopanel-for-concept-element-attributes-set-value" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-set-value" style="display:none">Info about the 'set an attribute value' definition.</span><b><a href="#concept-element-attributes-set-value">#concept-element-attributes-set-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-set-value">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-set-value①">(2)</a>
     <li><a href="#ref-for-concept-element-attributes-set-value②">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-element-attributes-set-value③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-remove-by-name">
-   <b><a href="#concept-element-attributes-remove-by-name">#concept-element-attributes-remove-by-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-remove-by-name" class="dfn-panel" data-for="concept-element-attributes-remove-by-name" id="infopanel-for-concept-element-attributes-remove-by-name" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-remove-by-name" style="display:none">Info about the 'remove an attribute by name' definition.</span><b><a href="#concept-element-attributes-remove-by-name">#concept-element-attributes-remove-by-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-remove-by-name">4.9. Interface Element</a> <a href="#ref-for-concept-element-attributes-remove-by-name①">(2)</a>
     <li><a href="#ref-for-concept-element-attributes-remove-by-name②">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-element-attributes-remove-by-namespace">
-   <b><a href="#concept-element-attributes-remove-by-namespace">#concept-element-attributes-remove-by-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-element-attributes-remove-by-namespace" class="dfn-panel" data-for="concept-element-attributes-remove-by-namespace" id="infopanel-for-concept-element-attributes-remove-by-namespace" role="dialog">
+   <span id="infopaneltitle-for-concept-element-attributes-remove-by-namespace" style="display:none">Info about the 'remove an attribute by namespace and local name' definition.</span><b><a href="#concept-element-attributes-remove-by-namespace">#concept-element-attributes-remove-by-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-attributes-remove-by-namespace">4.9. Interface Element</a>
     <li><a href="#ref-for-concept-element-attributes-remove-by-namespace①">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-id">
-   <b><a href="#concept-id">#concept-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-id" class="dfn-panel" data-for="concept-id" id="infopanel-for-concept-id" role="dialog">
+   <span id="infopaneltitle-for-concept-id" style="display:none">Info about the 'unique identifier (ID)' definition.</span><b><a href="#concept-id">#concept-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-id">4.2.4. Mixin NonElementParentNode</a> <a href="#ref-for-concept-id①">(2)</a>
     <li><a href="#ref-for-concept-id②">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-concept-id③">(2)</a> <a href="#ref-for-concept-id④">(3)</a> <a href="#ref-for-concept-id⑤">(4)</a>
     <li><a href="#ref-for-concept-id⑥">4.9. Interface Element</a> <a href="#ref-for-concept-id⑦">(2)</a> <a href="#ref-for-concept-id⑧">(3)</a> <a href="#ref-for-concept-id⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parent-element">
-   <b><a href="#parent-element">#parent-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parent-element" class="dfn-panel" data-for="parent-element" id="infopanel-for-parent-element" role="dialog">
+   <span id="infopaneltitle-for-parent-element" style="display:none">Info about the 'parent element' definition.</span><b><a href="#parent-element">#parent-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parent-element">4.4. Interface Node</a> <a href="#ref-for-parent-element①">(2)</a> <a href="#ref-for-parent-element②">(3)</a> <a href="#ref-for-parent-element③">(4)</a> <a href="#ref-for-parent-element④">(5)</a> <a href="#ref-for-parent-element⑤">(6)</a> <a href="#ref-for-parent-element⑥">(7)</a> <a href="#ref-for-parent-element⑦">(8)</a> <a href="#ref-for-parent-element⑧">(9)</a>
     <li><a href="#ref-for-parent-element⑨">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-namespaceuri">
-   <b><a href="#dom-element-namespaceuri">#dom-element-namespaceuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-namespaceuri" class="dfn-panel" data-for="dom-element-namespaceuri" id="infopanel-for-dom-element-namespaceuri" role="dialog">
+   <span id="infopaneltitle-for-dom-element-namespaceuri" style="display:none">Info about the 'namespaceURI' definition.</span><b><a href="#dom-element-namespaceuri">#dom-element-namespaceuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-namespaceuri">4.9. Interface Element</a> <a href="#ref-for-dom-element-namespaceuri①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-prefix">
-   <b><a href="#dom-element-prefix">#dom-element-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-prefix" class="dfn-panel" data-for="dom-element-prefix" id="infopanel-for-dom-element-prefix" role="dialog">
+   <span id="infopaneltitle-for-dom-element-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#dom-element-prefix">#dom-element-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-prefix">4.9. Interface Element</a> <a href="#ref-for-dom-element-prefix①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-localname">
-   <b><a href="#dom-element-localname">#dom-element-localname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-localname" class="dfn-panel" data-for="dom-element-localname" id="infopanel-for-dom-element-localname" role="dialog">
+   <span id="infopaneltitle-for-dom-element-localname" style="display:none">Info about the 'localName' definition.</span><b><a href="#dom-element-localname">#dom-element-localname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-localname">4.9. Interface Element</a> <a href="#ref-for-dom-element-localname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-tagname">
-   <b><a href="#dom-element-tagname">#dom-element-tagname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-tagname" class="dfn-panel" data-for="dom-element-tagname" id="infopanel-for-dom-element-tagname" role="dialog">
+   <span id="infopaneltitle-for-dom-element-tagname" style="display:none">Info about the 'tagName' definition.</span><b><a href="#dom-element-tagname">#dom-element-tagname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-tagname">4.9. Interface Element</a> <a href="#ref-for-dom-element-tagname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-reflect">
-   <b><a href="#concept-reflect">#concept-reflect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-reflect" class="dfn-panel" data-for="concept-reflect" id="infopanel-for-concept-reflect" role="dialog">
+   <span id="infopaneltitle-for-concept-reflect" style="display:none">Info about the 'reflect' definition.</span><b><a href="#concept-reflect">#concept-reflect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-reflect">4.9. Interface Element</a> <a href="#ref-for-concept-reflect①">(2)</a> <a href="#ref-for-concept-reflect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-id">
-   <b><a href="#dom-element-id">#dom-element-id</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-id" class="dfn-panel" data-for="dom-element-id" id="infopanel-for-dom-element-id" role="dialog">
+   <span id="infopaneltitle-for-dom-element-id" style="display:none">Info about the 'id' definition.</span><b><a href="#dom-element-id">#dom-element-id</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-id">4.9. Interface Element</a> <a href="#ref-for-dom-element-id①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-classname">
-   <b><a href="#dom-element-classname">#dom-element-classname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-classname" class="dfn-panel" data-for="dom-element-classname" id="infopanel-for-dom-element-classname" role="dialog">
+   <span id="infopaneltitle-for-dom-element-classname" style="display:none">Info about the 'className' definition.</span><b><a href="#dom-element-classname">#dom-element-classname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-classname">4.9. Interface Element</a> <a href="#ref-for-dom-element-classname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-classlist">
-   <b><a href="#dom-element-classlist">#dom-element-classlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-classlist" class="dfn-panel" data-for="dom-element-classlist" id="infopanel-for-dom-element-classlist" role="dialog">
+   <span id="infopaneltitle-for-dom-element-classlist" style="display:none">Info about the 'classList' definition.</span><b><a href="#dom-element-classlist">#dom-element-classlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-classlist">4.9. Interface Element</a> <a href="#ref-for-dom-element-classlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-class">
-   <b><a href="#concept-class">#concept-class</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-class" class="dfn-panel" data-for="concept-class" id="infopanel-for-concept-class" role="dialog">
+   <span id="infopaneltitle-for-concept-class" style="display:none">Info about the 'classes' definition.</span><b><a href="#concept-class">#concept-class</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-class">4.4. Interface Node</a> <a href="#ref-for-concept-class①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-slot">
-   <b><a href="#dom-element-slot">#dom-element-slot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-slot" class="dfn-panel" data-for="dom-element-slot" id="infopanel-for-dom-element-slot" role="dialog">
+   <span id="infopaneltitle-for-dom-element-slot" style="display:none">Info about the 'slot' definition.</span><b><a href="#dom-element-slot">#dom-element-slot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-slot">4.9. Interface Element</a> <a href="#ref-for-dom-element-slot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-hasattributes">
-   <b><a href="#dom-element-hasattributes">#dom-element-hasattributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-hasattributes" class="dfn-panel" data-for="dom-element-hasattributes" id="infopanel-for-dom-element-hasattributes" role="dialog">
+   <span id="infopaneltitle-for-dom-element-hasattributes" style="display:none">Info about the 'hasAttributes()' definition.</span><b><a href="#dom-element-hasattributes">#dom-element-hasattributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-hasattributes">4.9. Interface Element</a> <a href="#ref-for-dom-element-hasattributes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-attributes">
-   <b><a href="#dom-element-attributes">#dom-element-attributes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-attributes" class="dfn-panel" data-for="dom-element-attributes" id="infopanel-for-dom-element-attributes" role="dialog">
+   <span id="infopaneltitle-for-dom-element-attributes" style="display:none">Info about the 'attributes' definition.</span><b><a href="#dom-element-attributes">#dom-element-attributes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-attributes">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getattributenames">
-   <b><a href="#dom-element-getattributenames">#dom-element-getattributenames</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getattributenames" class="dfn-panel" data-for="dom-element-getattributenames" id="infopanel-for-dom-element-getattributenames" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getattributenames" style="display:none">Info about the 'getAttributeNames()' definition.</span><b><a href="#dom-element-getattributenames">#dom-element-getattributenames</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getattributenames">4.9. Interface Element</a> <a href="#ref-for-dom-element-getattributenames①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getattribute">
-   <b><a href="#dom-element-getattribute">#dom-element-getattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getattribute" class="dfn-panel" data-for="dom-element-getattribute" id="infopanel-for-dom-element-getattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getattribute" style="display:none">Info about the 'getAttribute(qualifiedName)' definition.</span><b><a href="#dom-element-getattribute">#dom-element-getattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getattribute">4.9. Interface Element</a> <a href="#ref-for-dom-element-getattribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getattributens">
-   <b><a href="#dom-element-getattributens">#dom-element-getattributens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getattributens" class="dfn-panel" data-for="dom-element-getattributens" id="infopanel-for-dom-element-getattributens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getattributens" style="display:none">Info about the 'getAttributeNS(namespace, localName)' definition.</span><b><a href="#dom-element-getattributens">#dom-element-getattributens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getattributens">4.9. Interface Element</a> <a href="#ref-for-dom-element-getattributens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-setattribute">
-   <b><a href="#dom-element-setattribute">#dom-element-setattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-setattribute" class="dfn-panel" data-for="dom-element-setattribute" id="infopanel-for-dom-element-setattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-element-setattribute" style="display:none">Info about the 'setAttribute(qualifiedName, value)' definition.</span><b><a href="#dom-element-setattribute">#dom-element-setattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-setattribute">4.9. Interface Element</a> <a href="#ref-for-dom-element-setattribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-setattributens">
-   <b><a href="#dom-element-setattributens">#dom-element-setattributens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-setattributens" class="dfn-panel" data-for="dom-element-setattributens" id="infopanel-for-dom-element-setattributens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-setattributens" style="display:none">Info about the 'setAttributeNS(namespace, qualifiedName, value)' definition.</span><b><a href="#dom-element-setattributens">#dom-element-setattributens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-setattributens">4.9. Interface Element</a> <a href="#ref-for-dom-element-setattributens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-removeattribute">
-   <b><a href="#dom-element-removeattribute">#dom-element-removeattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-removeattribute" class="dfn-panel" data-for="dom-element-removeattribute" id="infopanel-for-dom-element-removeattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-element-removeattribute" style="display:none">Info about the 'removeAttribute(qualifiedName)' definition.</span><b><a href="#dom-element-removeattribute">#dom-element-removeattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-removeattribute">4.9. Interface Element</a> <a href="#ref-for-dom-element-removeattribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-removeattributens">
-   <b><a href="#dom-element-removeattributens">#dom-element-removeattributens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-removeattributens" class="dfn-panel" data-for="dom-element-removeattributens" id="infopanel-for-dom-element-removeattributens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-removeattributens" style="display:none">Info about the 'removeAttributeNS(namespace, localName)' definition.</span><b><a href="#dom-element-removeattributens">#dom-element-removeattributens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-removeattributens">4.9. Interface Element</a> <a href="#ref-for-dom-element-removeattributens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-hasattribute">
-   <b><a href="#dom-element-hasattribute">#dom-element-hasattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-hasattribute" class="dfn-panel" data-for="dom-element-hasattribute" id="infopanel-for-dom-element-hasattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-element-hasattribute" style="display:none">Info about the 'hasAttribute(qualifiedName)' definition.</span><b><a href="#dom-element-hasattribute">#dom-element-hasattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-hasattribute">4.9. Interface Element</a> <a href="#ref-for-dom-element-hasattribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-toggleattribute">
-   <b><a href="#dom-element-toggleattribute">#dom-element-toggleattribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-toggleattribute" class="dfn-panel" data-for="dom-element-toggleattribute" id="infopanel-for-dom-element-toggleattribute" role="dialog">
+   <span id="infopaneltitle-for-dom-element-toggleattribute" style="display:none">Info about the 'toggleAttribute(qualifiedName, force)' definition.</span><b><a href="#dom-element-toggleattribute">#dom-element-toggleattribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-toggleattribute">4.9. Interface Element</a> <a href="#ref-for-dom-element-toggleattribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-hasattributens">
-   <b><a href="#dom-element-hasattributens">#dom-element-hasattributens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-hasattributens" class="dfn-panel" data-for="dom-element-hasattributens" id="infopanel-for-dom-element-hasattributens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-hasattributens" style="display:none">Info about the 'hasAttributeNS(namespace, localName)' definition.</span><b><a href="#dom-element-hasattributens">#dom-element-hasattributens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-hasattributens">4.9. Interface Element</a> <a href="#ref-for-dom-element-hasattributens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getattributenode">
-   <b><a href="#dom-element-getattributenode">#dom-element-getattributenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getattributenode" class="dfn-panel" data-for="dom-element-getattributenode" id="infopanel-for-dom-element-getattributenode" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getattributenode" style="display:none">Info about the 'getAttributeNode(qualifiedName)' definition.</span><b><a href="#dom-element-getattributenode">#dom-element-getattributenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getattributenode">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getattributenodens">
-   <b><a href="#dom-element-getattributenodens">#dom-element-getattributenodens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getattributenodens" class="dfn-panel" data-for="dom-element-getattributenodens" id="infopanel-for-dom-element-getattributenodens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getattributenodens" style="display:none">Info about the 'getAttributeNodeNS(namespace, localName)' definition.</span><b><a href="#dom-element-getattributenodens">#dom-element-getattributenodens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getattributenodens">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-setattributenode">
-   <b><a href="#dom-element-setattributenode">#dom-element-setattributenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-setattributenode" class="dfn-panel" data-for="dom-element-setattributenode" id="infopanel-for-dom-element-setattributenode" role="dialog">
+   <span id="infopaneltitle-for-dom-element-setattributenode" style="display:none">Info about the 'setAttributeNode(attr)' definition.</span><b><a href="#dom-element-setattributenode">#dom-element-setattributenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-setattributenode">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-setattributenodens">
-   <b><a href="#dom-element-setattributenodens">#dom-element-setattributenodens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-setattributenodens" class="dfn-panel" data-for="dom-element-setattributenodens" id="infopanel-for-dom-element-setattributenodens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-setattributenodens" style="display:none">Info about the 'setAttributeNodeNS(attr)' definition.</span><b><a href="#dom-element-setattributenodens">#dom-element-setattributenodens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-setattributenodens">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-removeattributenode">
-   <b><a href="#dom-element-removeattributenode">#dom-element-removeattributenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-removeattributenode" class="dfn-panel" data-for="dom-element-removeattributenode" id="infopanel-for-dom-element-removeattributenode" role="dialog">
+   <span id="infopaneltitle-for-dom-element-removeattributenode" style="display:none">Info about the 'removeAttributeNode(attr)' definition.</span><b><a href="#dom-element-removeattributenode">#dom-element-removeattributenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-removeattributenode">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-attachshadow">
-   <b><a href="#dom-element-attachshadow">#dom-element-attachshadow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-attachshadow" class="dfn-panel" data-for="dom-element-attachshadow" id="infopanel-for-dom-element-attachshadow" role="dialog">
+   <span id="infopaneltitle-for-dom-element-attachshadow" style="display:none">Info about the 'attachShadow(init)' definition.</span><b><a href="#dom-element-attachshadow">#dom-element-attachshadow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-attachshadow">4.9. Interface Element</a> <a href="#ref-for-dom-element-attachshadow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-shadowroot">
-   <b><a href="#dom-element-shadowroot">#dom-element-shadowroot</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-shadowroot" class="dfn-panel" data-for="dom-element-shadowroot" id="infopanel-for-dom-element-shadowroot" role="dialog">
+   <span id="infopaneltitle-for-dom-element-shadowroot" style="display:none">Info about the 'shadowRoot' definition.</span><b><a href="#dom-element-shadowroot">#dom-element-shadowroot</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-shadowroot">4.9. Interface Element</a> <a href="#ref-for-dom-element-shadowroot①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-closest">
-   <b><a href="#dom-element-closest">#dom-element-closest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-closest" class="dfn-panel" data-for="dom-element-closest" id="infopanel-for-dom-element-closest" role="dialog">
+   <span id="infopaneltitle-for-dom-element-closest" style="display:none">Info about the 'closest(selectors)' definition.</span><b><a href="#dom-element-closest">#dom-element-closest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-closest">4.9. Interface Element</a> <a href="#ref-for-dom-element-closest①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-matches">
-   <b><a href="#dom-element-matches">#dom-element-matches</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-matches" class="dfn-panel" data-for="dom-element-matches" id="infopanel-for-dom-element-matches" role="dialog">
+   <span id="infopaneltitle-for-dom-element-matches" style="display:none">Info about the 'matches(selectors)' definition.</span><b><a href="#dom-element-matches">#dom-element-matches</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-matches">4.9. Interface Element</a> <a href="#ref-for-dom-element-matches①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-webkitmatchesselector">
-   <b><a href="#dom-element-webkitmatchesselector">#dom-element-webkitmatchesselector</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-webkitmatchesselector" class="dfn-panel" data-for="dom-element-webkitmatchesselector" id="infopanel-for-dom-element-webkitmatchesselector" role="dialog">
+   <span id="infopaneltitle-for-dom-element-webkitmatchesselector" style="display:none">Info about the 'webkitMatchesSelector(selectors)' definition.</span><b><a href="#dom-element-webkitmatchesselector">#dom-element-webkitmatchesselector</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-webkitmatchesselector">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getelementsbytagname">
-   <b><a href="#dom-element-getelementsbytagname">#dom-element-getelementsbytagname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getelementsbytagname" class="dfn-panel" data-for="dom-element-getelementsbytagname" id="infopanel-for-dom-element-getelementsbytagname" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getelementsbytagname" style="display:none">Info about the 'getElementsByTagName(qualifiedName)' definition.</span><b><a href="#dom-element-getelementsbytagname">#dom-element-getelementsbytagname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getelementsbytagname">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getelementsbytagnamens">
-   <b><a href="#dom-element-getelementsbytagnamens">#dom-element-getelementsbytagnamens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getelementsbytagnamens" class="dfn-panel" data-for="dom-element-getelementsbytagnamens" id="infopanel-for-dom-element-getelementsbytagnamens" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getelementsbytagnamens" style="display:none">Info about the 'getElementsByTagNameNS(namespace, localName)' definition.</span><b><a href="#dom-element-getelementsbytagnamens">#dom-element-getelementsbytagnamens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getelementsbytagnamens">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-getelementsbyclassname">
-   <b><a href="#dom-element-getelementsbyclassname">#dom-element-getelementsbyclassname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-getelementsbyclassname" class="dfn-panel" data-for="dom-element-getelementsbyclassname" id="infopanel-for-dom-element-getelementsbyclassname" role="dialog">
+   <span id="infopaneltitle-for-dom-element-getelementsbyclassname" style="display:none">Info about the 'getElementsByClassName(classNames)' definition.</span><b><a href="#dom-element-getelementsbyclassname">#dom-element-getelementsbyclassname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-getelementsbyclassname">4.5. Interface Document</a>
     <li><a href="#ref-for-dom-element-getelementsbyclassname①">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="insert-adjacent">
-   <b><a href="#insert-adjacent">#insert-adjacent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-insert-adjacent" class="dfn-panel" data-for="insert-adjacent" id="infopanel-for-insert-adjacent" role="dialog">
+   <span id="infopaneltitle-for-insert-adjacent" style="display:none">Info about the 'insert adjacent' definition.</span><b><a href="#insert-adjacent">#insert-adjacent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-insert-adjacent">4.9. Interface Element</a> <a href="#ref-for-insert-adjacent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-insertadjacentelement">
-   <b><a href="#dom-element-insertadjacentelement">#dom-element-insertadjacentelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-insertadjacentelement" class="dfn-panel" data-for="dom-element-insertadjacentelement" id="infopanel-for-dom-element-insertadjacentelement" role="dialog">
+   <span id="infopaneltitle-for-dom-element-insertadjacentelement" style="display:none">Info about the 'insertAdjacentElement(where, element)' definition.</span><b><a href="#dom-element-insertadjacentelement">#dom-element-insertadjacentelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-insertadjacentelement">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-insertadjacenttext">
-   <b><a href="#dom-element-insertadjacenttext">#dom-element-insertadjacenttext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-insertadjacenttext" class="dfn-panel" data-for="dom-element-insertadjacenttext" id="infopanel-for-dom-element-insertadjacenttext" role="dialog">
+   <span id="infopaneltitle-for-dom-element-insertadjacenttext" style="display:none">Info about the 'insertAdjacentText(where, data)' definition.</span><b><a href="#dom-element-insertadjacenttext">#dom-element-insertadjacenttext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-insertadjacenttext">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="namednodemap">
-   <b><a href="#namednodemap">#namednodemap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namednodemap" class="dfn-panel" data-for="namednodemap" id="infopanel-for-namednodemap" role="dialog">
+   <span id="infopaneltitle-for-namednodemap" style="display:none">Info about the 'NamedNodeMap' definition.</span><b><a href="#namednodemap">#namednodemap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namednodemap">4.9. Interface Element</a> <a href="#ref-for-namednodemap①">(2)</a> <a href="#ref-for-namednodemap②">(3)</a>
     <li><a href="#ref-for-namednodemap③">4.9.1. Interface NamedNodeMap</a> <a href="#ref-for-namednodemap④">(2)</a> <a href="#ref-for-namednodemap⑤">(3)</a> <a href="#ref-for-namednodemap⑥">(4)</a> <a href="#ref-for-namednodemap⑦">(5)</a> <a href="#ref-for-namednodemap⑧">(6)</a> <a href="#ref-for-namednodemap⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-namednodemap-element">
-   <b><a href="#concept-namednodemap-element">#concept-namednodemap-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-namednodemap-element" class="dfn-panel" data-for="concept-namednodemap-element" id="infopanel-for-concept-namednodemap-element" role="dialog">
+   <span id="infopaneltitle-for-concept-namednodemap-element" style="display:none">Info about the 'element' definition.</span><b><a href="#concept-namednodemap-element">#concept-namednodemap-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-namednodemap-element">4.9.1. Interface NamedNodeMap</a> <a href="#ref-for-concept-namednodemap-element①">(2)</a> <a href="#ref-for-concept-namednodemap-element②">(3)</a> <a href="#ref-for-concept-namednodemap-element③">(4)</a> <a href="#ref-for-concept-namednodemap-element④">(5)</a> <a href="#ref-for-concept-namednodemap-element⑤">(6)</a> <a href="#ref-for-concept-namednodemap-element⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-namednodemap-attribute">
-   <b><a href="#concept-namednodemap-attribute">#concept-namednodemap-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-namednodemap-attribute" class="dfn-panel" data-for="concept-namednodemap-attribute" id="infopanel-for-concept-namednodemap-attribute" role="dialog">
+   <span id="infopaneltitle-for-concept-namednodemap-attribute" style="display:none">Info about the 'attribute list' definition.</span><b><a href="#concept-namednodemap-attribute">#concept-namednodemap-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-namednodemap-attribute">4.9.1. Interface NamedNodeMap</a> <a href="#ref-for-concept-namednodemap-attribute①">(2)</a> <a href="#ref-for-concept-namednodemap-attribute②">(3)</a> <a href="#ref-for-concept-namednodemap-attribute③">(4)</a> <a href="#ref-for-concept-namednodemap-attribute④">(5)</a> <a href="#ref-for-concept-namednodemap-attribute⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-length">
-   <b><a href="#dom-namednodemap-length">#dom-namednodemap-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-length" class="dfn-panel" data-for="dom-namednodemap-length" id="infopanel-for-dom-namednodemap-length" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-namednodemap-length">#dom-namednodemap-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-length">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-item">
-   <b><a href="#dom-namednodemap-item">#dom-namednodemap-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-item" class="dfn-panel" data-for="dom-namednodemap-item" id="infopanel-for-dom-namednodemap-item" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-namednodemap-item">#dom-namednodemap-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-item">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-getnameditem">
-   <b><a href="#dom-namednodemap-getnameditem">#dom-namednodemap-getnameditem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-getnameditem" class="dfn-panel" data-for="dom-namednodemap-getnameditem" id="infopanel-for-dom-namednodemap-getnameditem" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-getnameditem" style="display:none">Info about the 'getNamedItem(qualifiedName)' definition.</span><b><a href="#dom-namednodemap-getnameditem">#dom-namednodemap-getnameditem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-getnameditem">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-getnameditemns">
-   <b><a href="#dom-namednodemap-getnameditemns">#dom-namednodemap-getnameditemns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-getnameditemns" class="dfn-panel" data-for="dom-namednodemap-getnameditemns" id="infopanel-for-dom-namednodemap-getnameditemns" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-getnameditemns" style="display:none">Info about the 'getNamedItemNS(namespace, localName)' definition.</span><b><a href="#dom-namednodemap-getnameditemns">#dom-namednodemap-getnameditemns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-getnameditemns">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-setnameditem">
-   <b><a href="#dom-namednodemap-setnameditem">#dom-namednodemap-setnameditem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-setnameditem" class="dfn-panel" data-for="dom-namednodemap-setnameditem" id="infopanel-for-dom-namednodemap-setnameditem" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-setnameditem" style="display:none">Info about the 'setNamedItem(attr)' definition.</span><b><a href="#dom-namednodemap-setnameditem">#dom-namednodemap-setnameditem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-setnameditem">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-setnameditemns">
-   <b><a href="#dom-namednodemap-setnameditemns">#dom-namednodemap-setnameditemns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-setnameditemns" class="dfn-panel" data-for="dom-namednodemap-setnameditemns" id="infopanel-for-dom-namednodemap-setnameditemns" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-setnameditemns" style="display:none">Info about the 'setNamedItemNS(attr)' definition.</span><b><a href="#dom-namednodemap-setnameditemns">#dom-namednodemap-setnameditemns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-setnameditemns">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-removenameditem">
-   <b><a href="#dom-namednodemap-removenameditem">#dom-namednodemap-removenameditem</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-removenameditem" class="dfn-panel" data-for="dom-namednodemap-removenameditem" id="infopanel-for-dom-namednodemap-removenameditem" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-removenameditem" style="display:none">Info about the 'removeNamedItem(qualifiedName)' definition.</span><b><a href="#dom-namednodemap-removenameditem">#dom-namednodemap-removenameditem</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-removenameditem">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-namednodemap-removenameditemns">
-   <b><a href="#dom-namednodemap-removenameditemns">#dom-namednodemap-removenameditemns</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-namednodemap-removenameditemns" class="dfn-panel" data-for="dom-namednodemap-removenameditemns" id="infopanel-for-dom-namednodemap-removenameditemns" role="dialog">
+   <span id="infopaneltitle-for-dom-namednodemap-removenameditemns" style="display:none">Info about the 'removeNamedItemNS(namespace, localName)' definition.</span><b><a href="#dom-namednodemap-removenameditemns">#dom-namednodemap-removenameditemns</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-namednodemap-removenameditemns">4.9.1. Interface NamedNodeMap</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr">
-   <b><a href="#attr">#attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr" class="dfn-panel" data-for="attr" id="infopanel-for-attr" role="dialog">
+   <span id="infopaneltitle-for-attr" style="display:none">Info about the 'Attr' definition.</span><b><a href="#attr">#attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr">4.4. Interface Node</a> <a href="#ref-for-attr①">(2)</a> <a href="#ref-for-attr②">(3)</a> <a href="#ref-for-attr③">(4)</a> <a href="#ref-for-attr④">(5)</a> <a href="#ref-for-attr⑤">(6)</a> <a href="#ref-for-attr⑥">(7)</a> <a href="#ref-for-attr⑦">(8)</a> <a href="#ref-for-attr⑧">(9)</a> <a href="#ref-for-attr⑨">(10)</a> <a href="#ref-for-attr①⓪">(11)</a> <a href="#ref-for-attr①①">(12)</a> <a href="#ref-for-attr①②">(13)</a>
     <li><a href="#ref-for-attr①③">4.5. Interface Document</a> <a href="#ref-for-attr①④">(2)</a>
@@ -18542,8 +18543,8 @@ APIs</a>
     <li><a href="#ref-for-attr③⑤">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute">
-   <b><a href="#concept-attribute">#concept-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute" class="dfn-panel" data-for="concept-attribute" id="infopanel-for-concept-attribute" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute" style="display:none">Info about the 'attributes' definition.</span><b><a href="#concept-attribute">#concept-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute">4.3.1. Interface MutationObserver</a> <a href="#ref-for-concept-attribute①">(2)</a> <a href="#ref-for-concept-attribute②">(3)</a> <a href="#ref-for-concept-attribute③">(4)</a>
     <li><a href="#ref-for-concept-attribute④">4.3.3. Interface MutationRecord</a> <a href="#ref-for-concept-attribute⑤">(2)</a> <a href="#ref-for-concept-attribute⑥">(3)</a> <a href="#ref-for-concept-attribute⑦">(4)</a> <a href="#ref-for-concept-attribute⑧">(5)</a>
@@ -18556,8 +18557,8 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute⑥⑦">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-attribute⑥⑧">(2)</a> <a href="#ref-for-concept-attribute⑥⑨">(3)</a> <a href="#ref-for-concept-attribute⑦⓪">(4)</a> <a href="#ref-for-concept-attribute⑦①">(5)</a> <a href="#ref-for-concept-attribute⑦②">(6)</a> <a href="#ref-for-concept-attribute⑦③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-namespace">
-   <b><a href="#concept-attribute-namespace">#concept-attribute-namespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-namespace" class="dfn-panel" data-for="concept-attribute-namespace" id="infopanel-for-concept-attribute-namespace" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-namespace" style="display:none">Info about the 'namespace' definition.</span><b><a href="#concept-attribute-namespace">#concept-attribute-namespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-namespace">4.3.1. Interface MutationObserver</a>
     <li><a href="#ref-for-concept-attribute-namespace①">4.3.3. Interface MutationRecord</a>
@@ -18567,8 +18568,8 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute-namespace①⑧">4.9.2. Interface Attr</a> <a href="#ref-for-concept-attribute-namespace①⑨">(2)</a> <a href="#ref-for-concept-attribute-namespace②⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-namespace-prefix">
-   <b><a href="#concept-attribute-namespace-prefix">#concept-attribute-namespace-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-namespace-prefix" class="dfn-panel" data-for="concept-attribute-namespace-prefix" id="infopanel-for-concept-attribute-namespace-prefix" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-namespace-prefix" style="display:none">Info about the 'namespace prefix' definition.</span><b><a href="#concept-attribute-namespace-prefix">#concept-attribute-namespace-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-namespace-prefix">4.4. Interface Node</a> <a href="#ref-for-concept-attribute-namespace-prefix①">(2)</a> <a href="#ref-for-concept-attribute-namespace-prefix②">(3)</a> <a href="#ref-for-concept-attribute-namespace-prefix③">(4)</a>
     <li><a href="#ref-for-concept-attribute-namespace-prefix④">4.5. Interface Document</a>
@@ -18576,8 +18577,8 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute-namespace-prefix⑥">4.9.2. Interface Attr</a> <a href="#ref-for-concept-attribute-namespace-prefix⑦">(2)</a> <a href="#ref-for-concept-attribute-namespace-prefix⑧">(3)</a> <a href="#ref-for-concept-attribute-namespace-prefix⑨">(4)</a> <a href="#ref-for-concept-attribute-namespace-prefix①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-local-name">
-   <b><a href="#concept-attribute-local-name">#concept-attribute-local-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-local-name" class="dfn-panel" data-for="concept-attribute-local-name" id="infopanel-for-concept-attribute-local-name" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-local-name" style="display:none">Info about the 'local name' definition.</span><b><a href="#concept-attribute-local-name">#concept-attribute-local-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-local-name">4.3.1. Interface MutationObserver</a>
     <li><a href="#ref-for-concept-attribute-local-name①">4.3.3. Interface MutationRecord</a>
@@ -18588,8 +18589,8 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute-local-name②⑧">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-attribute-local-name②⑨">(2)</a> <a href="#ref-for-concept-attribute-local-name③⓪">(3)</a> <a href="#ref-for-concept-attribute-local-name③①">(4)</a> <a href="#ref-for-concept-attribute-local-name③②">(5)</a> <a href="#ref-for-concept-attribute-local-name③③">(6)</a> <a href="#ref-for-concept-attribute-local-name③④">(7)</a> <a href="#ref-for-concept-attribute-local-name③⑤">(8)</a> <a href="#ref-for-concept-attribute-local-name③⑥">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-value">
-   <b><a href="#concept-attribute-value">#concept-attribute-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-value" class="dfn-panel" data-for="concept-attribute-value" id="infopanel-for-concept-attribute-value" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-value" style="display:none">Info about the 'value' definition.</span><b><a href="#concept-attribute-value">#concept-attribute-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-value">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-concept-attribute-value①">(2)</a> <a href="#ref-for-concept-attribute-value②">(3)</a>
     <li><a href="#ref-for-concept-attribute-value③">4.3.1. Interface MutationObserver</a>
@@ -18599,16 +18600,16 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute-value②⑤">4.9.2. Interface Attr</a> <a href="#ref-for-concept-attribute-value②⑥">(2)</a> <a href="#ref-for-concept-attribute-value②⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-element">
-   <b><a href="#concept-attribute-element">#concept-attribute-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-element" class="dfn-panel" data-for="concept-attribute-element" id="infopanel-for-concept-attribute-element" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-element" style="display:none">Info about the 'element' definition.</span><b><a href="#concept-attribute-element">#concept-attribute-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-element">4.4. Interface Node</a> <a href="#ref-for-concept-attribute-element①">(2)</a> <a href="#ref-for-concept-attribute-element②">(3)</a> <a href="#ref-for-concept-attribute-element③">(4)</a> <a href="#ref-for-concept-attribute-element④">(5)</a> <a href="#ref-for-concept-attribute-element⑤">(6)</a>
     <li><a href="#ref-for-concept-attribute-element⑥">4.9. Interface Element</a> <a href="#ref-for-concept-attribute-element⑦">(2)</a> <a href="#ref-for-concept-attribute-element⑧">(3)</a> <a href="#ref-for-concept-attribute-element⑨">(4)</a> <a href="#ref-for-concept-attribute-element①⓪">(5)</a> <a href="#ref-for-concept-attribute-element①①">(6)</a> <a href="#ref-for-concept-attribute-element①②">(7)</a> <a href="#ref-for-concept-attribute-element①③">(8)</a> <a href="#ref-for-concept-attribute-element①④">(9)</a> <a href="#ref-for-concept-attribute-element①⑤">(10)</a> <a href="#ref-for-concept-attribute-element①⑥">(11)</a>
     <li><a href="#ref-for-concept-attribute-element①⑦">4.9.2. Interface Attr</a> <a href="#ref-for-concept-attribute-element①⑧">(2)</a> <a href="#ref-for-concept-attribute-element①⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-attribute-qualified-name">
-   <b><a href="#concept-attribute-qualified-name">#concept-attribute-qualified-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-attribute-qualified-name" class="dfn-panel" data-for="concept-attribute-qualified-name" id="infopanel-for-concept-attribute-qualified-name" role="dialog">
+   <span id="infopaneltitle-for-concept-attribute-qualified-name" style="display:none">Info about the 'qualified name' definition.</span><b><a href="#concept-attribute-qualified-name">#concept-attribute-qualified-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-attribute-qualified-name">4.4. Interface Node</a> <a href="#ref-for-concept-attribute-qualified-name①">(2)</a>
     <li><a href="#ref-for-concept-attribute-qualified-name②">4.9. Interface Element</a> <a href="#ref-for-concept-attribute-qualified-name③">(2)</a> <a href="#ref-for-concept-attribute-qualified-name④">(3)</a> <a href="#ref-for-concept-attribute-qualified-name⑤">(4)</a> <a href="#ref-for-concept-attribute-qualified-name⑥">(5)</a> <a href="#ref-for-concept-attribute-qualified-name⑦">(6)</a> <a href="#ref-for-concept-attribute-qualified-name⑧">(7)</a> <a href="#ref-for-concept-attribute-qualified-name⑨">(8)</a> <a href="#ref-for-concept-attribute-qualified-name①⓪">(9)</a> <a href="#ref-for-concept-attribute-qualified-name①①">(10)</a>
@@ -18616,64 +18617,64 @@ APIs</a>
     <li><a href="#ref-for-concept-attribute-qualified-name①③">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-named-attribute">
-   <b><a href="#concept-named-attribute">#concept-named-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-named-attribute" class="dfn-panel" data-for="concept-named-attribute" id="infopanel-for-concept-named-attribute" role="dialog">
+   <span id="infopaneltitle-for-concept-named-attribute" style="display:none">Info about the 'A attribute' definition.</span><b><a href="#concept-named-attribute">#concept-named-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-named-attribute">4.2.10.2. Interface HTMLCollection</a> <a href="#ref-for-concept-named-attribute①">(2)</a> <a href="#ref-for-concept-named-attribute②">(3)</a>
     <li><a href="#ref-for-concept-named-attribute③">4.9. Interface Element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-namespaceuri">
-   <b><a href="#dom-attr-namespaceuri">#dom-attr-namespaceuri</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-namespaceuri" class="dfn-panel" data-for="dom-attr-namespaceuri" id="infopanel-for-dom-attr-namespaceuri" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-namespaceuri" style="display:none">Info about the 'namespaceURI' definition.</span><b><a href="#dom-attr-namespaceuri">#dom-attr-namespaceuri</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-namespaceuri">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-prefix">
-   <b><a href="#dom-attr-prefix">#dom-attr-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-prefix" class="dfn-panel" data-for="dom-attr-prefix" id="infopanel-for-dom-attr-prefix" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#dom-attr-prefix">#dom-attr-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-prefix">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-localname">
-   <b><a href="#dom-attr-localname">#dom-attr-localname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-localname" class="dfn-panel" data-for="dom-attr-localname" id="infopanel-for-dom-attr-localname" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-localname" style="display:none">Info about the 'localName' definition.</span><b><a href="#dom-attr-localname">#dom-attr-localname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-localname">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-name">
-   <b><a href="#dom-attr-name">#dom-attr-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-name" class="dfn-panel" data-for="dom-attr-name" id="infopanel-for-dom-attr-name" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-name" style="display:none">Info about the 'name' definition.</span><b><a href="#dom-attr-name">#dom-attr-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-name">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-value">
-   <b><a href="#dom-attr-value">#dom-attr-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-value" class="dfn-panel" data-for="dom-attr-value" id="infopanel-for-dom-attr-value" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-attr-value">#dom-attr-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-value">4.9.2. Interface Attr</a> <a href="#ref-for-dom-attr-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-an-existing-attribute-value">
-   <b><a href="#set-an-existing-attribute-value">#set-an-existing-attribute-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-an-existing-attribute-value" class="dfn-panel" data-for="set-an-existing-attribute-value" id="infopanel-for-set-an-existing-attribute-value" role="dialog">
+   <span id="infopaneltitle-for-set-an-existing-attribute-value" style="display:none">Info about the 'set an existing attribute value' definition.</span><b><a href="#set-an-existing-attribute-value">#set-an-existing-attribute-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-an-existing-attribute-value">4.4. Interface Node</a> <a href="#ref-for-set-an-existing-attribute-value①">(2)</a>
     <li><a href="#ref-for-set-an-existing-attribute-value②">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-ownerelement">
-   <b><a href="#dom-attr-ownerelement">#dom-attr-ownerelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-ownerelement" class="dfn-panel" data-for="dom-attr-ownerelement" id="infopanel-for-dom-attr-ownerelement" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-ownerelement" style="display:none">Info about the 'ownerElement' definition.</span><b><a href="#dom-attr-ownerelement">#dom-attr-ownerelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-ownerelement">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-attr-specified">
-   <b><a href="#dom-attr-specified">#dom-attr-specified</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-attr-specified" class="dfn-panel" data-for="dom-attr-specified" id="infopanel-for-dom-attr-specified" role="dialog">
+   <span id="infopaneltitle-for-dom-attr-specified" style="display:none">Info about the 'specified' definition.</span><b><a href="#dom-attr-specified">#dom-attr-specified</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-attr-specified">4.9.2. Interface Attr</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="characterdata">
-   <b><a href="#characterdata">#characterdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-characterdata" class="dfn-panel" data-for="characterdata" id="infopanel-for-characterdata" role="dialog">
+   <span id="infopaneltitle-for-characterdata" style="display:none">Info about the 'CharacterData' definition.</span><b><a href="#characterdata">#characterdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-characterdata">4.2.7. Mixin NonDocumentTypeChildNode</a>
     <li><a href="#ref-for-characterdata①">4.2.8. Mixin ChildNode</a>
@@ -18684,8 +18685,8 @@ APIs</a>
     <li><a href="#ref-for-characterdata⑨">4.14. Interface Comment</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cd-data">
-   <b><a href="#concept-cd-data">#concept-cd-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cd-data" class="dfn-panel" data-for="concept-cd-data" id="infopanel-for-concept-cd-data" role="dialog">
+   <span id="infopaneltitle-for-concept-cd-data" style="display:none">Info about the 'data' definition.</span><b><a href="#concept-cd-data">#concept-cd-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-data">4.2. Node tree</a>
     <li><a href="#ref-for-concept-cd-data①">4.2.6. Mixin ParentNode</a>
@@ -18701,8 +18702,8 @@ APIs</a>
     <li><a href="#ref-for-concept-cd-data④⓪">5.5. Interface Range</a> <a href="#ref-for-concept-cd-data④①">(2)</a> <a href="#ref-for-concept-cd-data④②">(3)</a> <a href="#ref-for-concept-cd-data④③">(4)</a> <a href="#ref-for-concept-cd-data④④">(5)</a> <a href="#ref-for-concept-cd-data④⑤">(6)</a> <a href="#ref-for-concept-cd-data④⑥">(7)</a> <a href="#ref-for-concept-cd-data④⑦">(8)</a> <a href="#ref-for-concept-cd-data④⑧">(9)</a> <a href="#ref-for-concept-cd-data④⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cd-replace">
-   <b><a href="#concept-cd-replace">#concept-cd-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cd-replace" class="dfn-panel" data-for="concept-cd-replace" id="infopanel-for-concept-cd-replace" role="dialog">
+   <span id="infopaneltitle-for-concept-cd-replace" style="display:none">Info about the 'replace data' definition.</span><b><a href="#concept-cd-replace">#concept-cd-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-replace">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-cd-replace①">4.4. Interface Node</a> <a href="#ref-for-concept-cd-replace②">(2)</a> <a href="#ref-for-concept-cd-replace③">(3)</a>
@@ -18712,58 +18713,58 @@ APIs</a>
     <li><a href="#ref-for-concept-cd-replace①①">5.5. Interface Range</a> <a href="#ref-for-concept-cd-replace①②">(2)</a> <a href="#ref-for-concept-cd-replace①③">(3)</a> <a href="#ref-for-concept-cd-replace①④">(4)</a> <a href="#ref-for-concept-cd-replace①⑤">(5)</a> <a href="#ref-for-concept-cd-replace①⑥">(6)</a> <a href="#ref-for-concept-cd-replace①⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cd-substring">
-   <b><a href="#concept-cd-substring">#concept-cd-substring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cd-substring" class="dfn-panel" data-for="concept-cd-substring" id="infopanel-for-concept-cd-substring" role="dialog">
+   <span id="infopaneltitle-for-concept-cd-substring" style="display:none">Info about the 'substring data' definition.</span><b><a href="#concept-cd-substring">#concept-cd-substring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cd-substring">4.10. Interface CharacterData</a>
     <li><a href="#ref-for-concept-cd-substring①">4.11. Interface Text</a>
     <li><a href="#ref-for-concept-cd-substring②">5.5. Interface Range</a> <a href="#ref-for-concept-cd-substring③">(2)</a> <a href="#ref-for-concept-cd-substring④">(3)</a> <a href="#ref-for-concept-cd-substring⑤">(4)</a> <a href="#ref-for-concept-cd-substring⑥">(5)</a> <a href="#ref-for-concept-cd-substring⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-data">
-   <b><a href="#dom-characterdata-data">#dom-characterdata-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-data" class="dfn-panel" data-for="dom-characterdata-data" id="infopanel-for-dom-characterdata-data" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-characterdata-data">#dom-characterdata-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-data">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-length">
-   <b><a href="#dom-characterdata-length">#dom-characterdata-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-length" class="dfn-panel" data-for="dom-characterdata-length" id="infopanel-for-dom-characterdata-length" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-characterdata-length">#dom-characterdata-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-length">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-substringdata">
-   <b><a href="#dom-characterdata-substringdata">#dom-characterdata-substringdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-substringdata" class="dfn-panel" data-for="dom-characterdata-substringdata" id="infopanel-for-dom-characterdata-substringdata" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-substringdata" style="display:none">Info about the 'substringData(offset, count)' definition.</span><b><a href="#dom-characterdata-substringdata">#dom-characterdata-substringdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-substringdata">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-appenddata">
-   <b><a href="#dom-characterdata-appenddata">#dom-characterdata-appenddata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-appenddata" class="dfn-panel" data-for="dom-characterdata-appenddata" id="infopanel-for-dom-characterdata-appenddata" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-appenddata" style="display:none">Info about the 'appendData(data)' definition.</span><b><a href="#dom-characterdata-appenddata">#dom-characterdata-appenddata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-appenddata">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-insertdata">
-   <b><a href="#dom-characterdata-insertdata">#dom-characterdata-insertdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-insertdata" class="dfn-panel" data-for="dom-characterdata-insertdata" id="infopanel-for-dom-characterdata-insertdata" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-insertdata" style="display:none">Info about the 'insertData(offset, data)' definition.</span><b><a href="#dom-characterdata-insertdata">#dom-characterdata-insertdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-insertdata">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-deletedata">
-   <b><a href="#dom-characterdata-deletedata">#dom-characterdata-deletedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-deletedata" class="dfn-panel" data-for="dom-characterdata-deletedata" id="infopanel-for-dom-characterdata-deletedata" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-deletedata" style="display:none">Info about the 'deleteData(offset, count)' definition.</span><b><a href="#dom-characterdata-deletedata">#dom-characterdata-deletedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-deletedata">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-characterdata-replacedata">
-   <b><a href="#dom-characterdata-replacedata">#dom-characterdata-replacedata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-characterdata-replacedata" class="dfn-panel" data-for="dom-characterdata-replacedata" id="infopanel-for-dom-characterdata-replacedata" role="dialog">
+   <span id="infopaneltitle-for-dom-characterdata-replacedata" style="display:none">Info about the 'replaceData(offset, count, data)' definition.</span><b><a href="#dom-characterdata-replacedata">#dom-characterdata-replacedata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-characterdata-replacedata">4.10. Interface CharacterData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text">
-   <b><a href="#text">#text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text" class="dfn-panel" data-for="text" id="infopanel-for-text" role="dialog">
+   <span id="infopaneltitle-for-text" style="display:none">Info about the 'Text' definition.</span><b><a href="#text">#text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text">4.1. Introduction to "The DOM"</a> <a href="#ref-for-text①">(2)</a> <a href="#ref-for-text②">(3)</a> <a href="#ref-for-text③">(4)</a>
     <li><a href="#ref-for-text④">4.2. Node tree</a> <a href="#ref-for-text⑤">(2)</a> <a href="#ref-for-text⑥">(3)</a> <a href="#ref-for-text⑦">(4)</a>
@@ -18784,60 +18785,60 @@ APIs</a>
     <li><a href="#ref-for-text⑧①">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exclusive-text-node">
-   <b><a href="#exclusive-text-node">#exclusive-text-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exclusive-text-node" class="dfn-panel" data-for="exclusive-text-node" id="infopanel-for-exclusive-text-node" role="dialog">
+   <span id="infopaneltitle-for-exclusive-text-node" style="display:none">Info about the 'exclusive Text node' definition.</span><b><a href="#exclusive-text-node">#exclusive-text-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exclusive-text-node">4.4. Interface Node</a> <a href="#ref-for-exclusive-text-node①">(2)</a> <a href="#ref-for-exclusive-text-node②">(3)</a> <a href="#ref-for-exclusive-text-node③">(4)</a>
     <li><a href="#ref-for-exclusive-text-node④">4.11. Interface Text</a> <a href="#ref-for-exclusive-text-node⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contiguous-text-nodes">
-   <b><a href="#contiguous-text-nodes">#contiguous-text-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contiguous-text-nodes" class="dfn-panel" data-for="contiguous-text-nodes" id="infopanel-for-contiguous-text-nodes" role="dialog">
+   <span id="infopaneltitle-for-contiguous-text-nodes" style="display:none">Info about the 'contiguous Text nodes' definition.</span><b><a href="#contiguous-text-nodes">#contiguous-text-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contiguous-text-nodes">4.11. Interface Text</a> <a href="#ref-for-contiguous-text-nodes①">(2)</a> <a href="#ref-for-contiguous-text-nodes②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contiguous-exclusive-text-nodes">
-   <b><a href="#contiguous-exclusive-text-nodes">#contiguous-exclusive-text-nodes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contiguous-exclusive-text-nodes" class="dfn-panel" data-for="contiguous-exclusive-text-nodes" id="infopanel-for-contiguous-exclusive-text-nodes" role="dialog">
+   <span id="infopaneltitle-for-contiguous-exclusive-text-nodes" style="display:none">Info about the 'contiguous exclusive Text nodes' definition.</span><b><a href="#contiguous-exclusive-text-nodes">#contiguous-exclusive-text-nodes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contiguous-exclusive-text-nodes">4.4. Interface Node</a> <a href="#ref-for-contiguous-exclusive-text-nodes①">(2)</a> <a href="#ref-for-contiguous-exclusive-text-nodes②">(3)</a>
     <li><a href="#ref-for-contiguous-exclusive-text-nodes③">4.11. Interface Text</a> <a href="#ref-for-contiguous-exclusive-text-nodes④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-descendant-text-content">
-   <b><a href="#concept-descendant-text-content">#concept-descendant-text-content</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-descendant-text-content" class="dfn-panel" data-for="concept-descendant-text-content" id="infopanel-for-concept-descendant-text-content" role="dialog">
+   <span id="infopaneltitle-for-concept-descendant-text-content" style="display:none">Info about the 'descendant text content' definition.</span><b><a href="#concept-descendant-text-content">#concept-descendant-text-content</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-descendant-text-content">4.4. Interface Node</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-text-text">
-   <b><a href="#dom-text-text">#dom-text-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-text-text" class="dfn-panel" data-for="dom-text-text" id="infopanel-for-dom-text-text" role="dialog">
+   <span id="infopaneltitle-for-dom-text-text" style="display:none">Info about the 'new Text(data)' definition.</span><b><a href="#dom-text-text">#dom-text-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-text-text">4.11. Interface Text</a> <a href="#ref-for-dom-text-text①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-text-split">
-   <b><a href="#concept-text-split">#concept-text-split</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-text-split" class="dfn-panel" data-for="concept-text-split" id="infopanel-for-concept-text-split" role="dialog">
+   <span id="infopaneltitle-for-concept-text-split" style="display:none">Info about the 'split' definition.</span><b><a href="#concept-text-split">#concept-text-split</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-text-split">4.11. Interface Text</a>
     <li><a href="#ref-for-concept-text-split①">5.1. Introduction to "DOM Ranges"</a>
     <li><a href="#ref-for-concept-text-split②">5.5. Interface Range</a> <a href="#ref-for-concept-text-split③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-text-splittext">
-   <b><a href="#dom-text-splittext">#dom-text-splittext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-text-splittext" class="dfn-panel" data-for="dom-text-splittext" id="infopanel-for-dom-text-splittext" role="dialog">
+   <span id="infopaneltitle-for-dom-text-splittext" style="display:none">Info about the 'splitText(offset)' definition.</span><b><a href="#dom-text-splittext">#dom-text-splittext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-text-splittext">4.11. Interface Text</a> <a href="#ref-for-dom-text-splittext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-text-wholetext">
-   <b><a href="#dom-text-wholetext">#dom-text-wholetext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-text-wholetext" class="dfn-panel" data-for="dom-text-wholetext" id="infopanel-for-dom-text-wholetext" role="dialog">
+   <span id="infopaneltitle-for-dom-text-wholetext" style="display:none">Info about the 'wholeText' definition.</span><b><a href="#dom-text-wholetext">#dom-text-wholetext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-text-wholetext">4.11. Interface Text</a> <a href="#ref-for-dom-text-wholetext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cdatasection">
-   <b><a href="#cdatasection">#cdatasection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cdatasection" class="dfn-panel" data-for="cdatasection" id="infopanel-for-cdatasection" role="dialog">
+   <span id="infopaneltitle-for-cdatasection" style="display:none">Info about the 'CDATASection' definition.</span><b><a href="#cdatasection">#cdatasection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cdatasection">4.4. Interface Node</a> <a href="#ref-for-cdatasection①">(2)</a> <a href="#ref-for-cdatasection②">(3)</a> <a href="#ref-for-cdatasection③">(4)</a>
     <li><a href="#ref-for-cdatasection④">4.5. Interface Document</a> <a href="#ref-for-cdatasection⑤">(2)</a> <a href="#ref-for-cdatasection⑥">(3)</a>
@@ -18845,8 +18846,8 @@ APIs</a>
     <li><a href="#ref-for-cdatasection⑧">4.12. Interface CDATASection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="processinginstruction">
-   <b><a href="#processinginstruction">#processinginstruction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-processinginstruction" class="dfn-panel" data-for="processinginstruction" id="infopanel-for-processinginstruction" role="dialog">
+   <span id="infopaneltitle-for-processinginstruction" style="display:none">Info about the 'ProcessingInstruction' definition.</span><b><a href="#processinginstruction">#processinginstruction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-processinginstruction">4.2. Node tree</a> <a href="#ref-for-processinginstruction①">(2)</a> <a href="#ref-for-processinginstruction②">(3)</a> <a href="#ref-for-processinginstruction③">(4)</a> <a href="#ref-for-processinginstruction④">(5)</a> <a href="#ref-for-processinginstruction⑤">(6)</a> <a href="#ref-for-processinginstruction⑥">(7)</a>
     <li><a href="#ref-for-processinginstruction⑦">4.2.3. Mutation algorithms</a> <a href="#ref-for-processinginstruction⑧">(2)</a>
@@ -18857,22 +18858,22 @@ APIs</a>
     <li><a href="#ref-for-processinginstruction②⑥">5.5. Interface Range</a> <a href="#ref-for-processinginstruction②⑦">(2)</a> <a href="#ref-for-processinginstruction②⑧">(3)</a> <a href="#ref-for-processinginstruction②⑨">(4)</a> <a href="#ref-for-processinginstruction③⓪">(5)</a> <a href="#ref-for-processinginstruction③①">(6)</a> <a href="#ref-for-processinginstruction③②">(7)</a> <a href="#ref-for-processinginstruction③③">(8)</a> <a href="#ref-for-processinginstruction③④">(9)</a> <a href="#ref-for-processinginstruction③⑤">(10)</a> <a href="#ref-for-processinginstruction③⑥">(11)</a> <a href="#ref-for-processinginstruction③⑦">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-pi-target">
-   <b><a href="#concept-pi-target">#concept-pi-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-pi-target" class="dfn-panel" data-for="concept-pi-target" id="infopanel-for-concept-pi-target" role="dialog">
+   <span id="infopaneltitle-for-concept-pi-target" style="display:none">Info about the 'target' definition.</span><b><a href="#concept-pi-target">#concept-pi-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-pi-target">4.4. Interface Node</a> <a href="#ref-for-concept-pi-target①">(2)</a> <a href="#ref-for-concept-pi-target②">(3)</a> <a href="#ref-for-concept-pi-target③">(4)</a>
     <li><a href="#ref-for-concept-pi-target④">4.5. Interface Document</a> <a href="#ref-for-concept-pi-target⑤">(2)</a>
     <li><a href="#ref-for-concept-pi-target⑥">4.13. Interface ProcessingInstruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-processinginstruction-target">
-   <b><a href="#dom-processinginstruction-target">#dom-processinginstruction-target</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-processinginstruction-target" class="dfn-panel" data-for="dom-processinginstruction-target" id="infopanel-for-dom-processinginstruction-target" role="dialog">
+   <span id="infopaneltitle-for-dom-processinginstruction-target" style="display:none">Info about the 'target' definition.</span><b><a href="#dom-processinginstruction-target">#dom-processinginstruction-target</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-processinginstruction-target">4.13. Interface ProcessingInstruction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="comment">
-   <b><a href="#comment">#comment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-comment" class="dfn-panel" data-for="comment" id="infopanel-for-comment" role="dialog">
+   <span id="infopaneltitle-for-comment" style="display:none">Info about the 'Comment' definition.</span><b><a href="#comment">#comment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comment">4.2. Node tree</a> <a href="#ref-for-comment①">(2)</a> <a href="#ref-for-comment②">(3)</a> <a href="#ref-for-comment③">(4)</a> <a href="#ref-for-comment④">(5)</a> <a href="#ref-for-comment⑤">(6)</a> <a href="#ref-for-comment⑥">(7)</a>
     <li><a href="#ref-for-comment⑦">4.2.3. Mutation algorithms</a> <a href="#ref-for-comment⑧">(2)</a>
@@ -18883,14 +18884,14 @@ APIs</a>
     <li><a href="#ref-for-comment②⑥">5.5. Interface Range</a> <a href="#ref-for-comment②⑦">(2)</a> <a href="#ref-for-comment②⑧">(3)</a> <a href="#ref-for-comment②⑨">(4)</a> <a href="#ref-for-comment③⓪">(5)</a> <a href="#ref-for-comment③①">(6)</a> <a href="#ref-for-comment③②">(7)</a> <a href="#ref-for-comment③③">(8)</a> <a href="#ref-for-comment③④">(9)</a> <a href="#ref-for-comment③⑤">(10)</a> <a href="#ref-for-comment③⑥">(11)</a> <a href="#ref-for-comment③⑦">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-comment-comment">
-   <b><a href="#dom-comment-comment">#dom-comment-comment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-comment-comment" class="dfn-panel" data-for="dom-comment-comment" id="infopanel-for-dom-comment-comment" role="dialog">
+   <span id="infopaneltitle-for-dom-comment-comment" style="display:none">Info about the 'new Comment(data)' definition.</span><b><a href="#dom-comment-comment">#dom-comment-comment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-comment-comment">4.14. Interface Comment</a> <a href="#ref-for-dom-comment-comment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp">
-   <b><a href="#concept-range-bp">#concept-range-bp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp" class="dfn-panel" data-for="concept-range-bp" id="infopanel-for-concept-range-bp" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp" style="display:none">Info about the 'boundary point' definition.</span><b><a href="#concept-range-bp">#concept-range-bp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp">5.1. Introduction to "DOM Ranges"</a> <a href="#ref-for-concept-range-bp①">(2)</a> <a href="#ref-for-concept-range-bp②">(3)</a>
     <li><a href="#ref-for-concept-range-bp③">5.2. Boundary points</a> <a href="#ref-for-concept-range-bp④">(2)</a> <a href="#ref-for-concept-range-bp⑤">(3)</a> <a href="#ref-for-concept-range-bp⑥">(4)</a>
@@ -18898,8 +18899,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-bp⑧">5.5. Interface Range</a> <a href="#ref-for-concept-range-bp⑨">(2)</a> <a href="#ref-for-concept-range-bp①⓪">(3)</a> <a href="#ref-for-concept-range-bp①①">(4)</a> <a href="#ref-for-concept-range-bp①②">(5)</a> <a href="#ref-for-concept-range-bp①③">(6)</a> <a href="#ref-for-concept-range-bp①④">(7)</a> <a href="#ref-for-concept-range-bp①⑤">(8)</a> <a href="#ref-for-concept-range-bp①⑥">(9)</a> <a href="#ref-for-concept-range-bp①⑦">(10)</a> <a href="#ref-for-concept-range-bp①⑧">(11)</a> <a href="#ref-for-concept-range-bp①⑨">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boundary-point-node">
-   <b><a href="#boundary-point-node">#boundary-point-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boundary-point-node" class="dfn-panel" data-for="boundary-point-node" id="infopanel-for-boundary-point-node" role="dialog">
+   <span id="infopaneltitle-for-boundary-point-node" style="display:none">Info about the 'node' definition.</span><b><a href="#boundary-point-node">#boundary-point-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boundary-point-node">2.2. Interface Event</a>
     <li><a href="#ref-for-boundary-point-node①">2.9. Dispatching events</a>
@@ -18925,52 +18926,52 @@ APIs</a>
     <li><a href="#ref-for-boundary-point-node①①⑧">6.1. Interface NodeIterator</a> <a href="#ref-for-boundary-point-node①①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-offset">
-   <b><a href="#concept-range-bp-offset">#concept-range-bp-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-offset" class="dfn-panel" data-for="concept-range-bp-offset" id="infopanel-for-concept-range-bp-offset" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-offset" style="display:none">Info about the 'offset' definition.</span><b><a href="#concept-range-bp-offset">#concept-range-bp-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-offset">5.1. Introduction to "DOM Ranges"</a>
     <li><a href="#ref-for-concept-range-bp-offset①">5.2. Boundary points</a>
     <li><a href="#ref-for-concept-range-bp-offset②">5.3. Interface AbstractRange</a> <a href="#ref-for-concept-range-bp-offset③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-position">
-   <b><a href="#concept-range-bp-position">#concept-range-bp-position</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-position" class="dfn-panel" data-for="concept-range-bp-position" id="infopanel-for-concept-range-bp-position" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-position" style="display:none">Info about the 'position' definition.</span><b><a href="#concept-range-bp-position">#concept-range-bp-position</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-position">5.2. Boundary points</a>
     <li><a href="#ref-for-concept-range-bp-position①">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-before">
-   <b><a href="#concept-range-bp-before">#concept-range-bp-before</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-before" class="dfn-panel" data-for="concept-range-bp-before" id="infopanel-for-concept-range-bp-before" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-before" style="display:none">Info about the 'before' definition.</span><b><a href="#concept-range-bp-before">#concept-range-bp-before</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-before">5.2. Boundary points</a> <a href="#ref-for-concept-range-bp-before①">(2)</a> <a href="#ref-for-concept-range-bp-before②">(3)</a> <a href="#ref-for-concept-range-bp-before③">(4)</a>
     <li><a href="#ref-for-concept-range-bp-before④">5.5. Interface Range</a> <a href="#ref-for-concept-range-bp-before⑤">(2)</a> <a href="#ref-for-concept-range-bp-before⑥">(3)</a> <a href="#ref-for-concept-range-bp-before⑦">(4)</a> <a href="#ref-for-concept-range-bp-before⑧">(5)</a> <a href="#ref-for-concept-range-bp-before⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-equal">
-   <b><a href="#concept-range-bp-equal">#concept-range-bp-equal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-equal" class="dfn-panel" data-for="concept-range-bp-equal" id="infopanel-for-concept-range-bp-equal" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-equal" style="display:none">Info about the 'equal' definition.</span><b><a href="#concept-range-bp-equal">#concept-range-bp-equal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-equal">5.2. Boundary points</a>
     <li><a href="#ref-for-concept-range-bp-equal①">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-after">
-   <b><a href="#concept-range-bp-after">#concept-range-bp-after</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-after" class="dfn-panel" data-for="concept-range-bp-after" id="infopanel-for-concept-range-bp-after" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-after" style="display:none">Info about the 'after' definition.</span><b><a href="#concept-range-bp-after">#concept-range-bp-after</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-after">5.2. Boundary points</a> <a href="#ref-for-concept-range-bp-after①">(2)</a> <a href="#ref-for-concept-range-bp-after②">(3)</a> <a href="#ref-for-concept-range-bp-after③">(4)</a>
     <li><a href="#ref-for-concept-range-bp-after④">5.5. Interface Range</a> <a href="#ref-for-concept-range-bp-after⑤">(2)</a> <a href="#ref-for-concept-range-bp-after⑥">(3)</a> <a href="#ref-for-concept-range-bp-after⑦">(4)</a> <a href="#ref-for-concept-range-bp-after⑧">(5)</a> <a href="#ref-for-concept-range-bp-after⑨">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstractrange">
-   <b><a href="#abstractrange">#abstractrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstractrange" class="dfn-panel" data-for="abstractrange" id="infopanel-for-abstractrange" role="dialog">
+   <span id="infopaneltitle-for-abstractrange" style="display:none">Info about the 'AbstractRange' definition.</span><b><a href="#abstractrange">#abstractrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstractrange">5.3. Interface AbstractRange</a> <a href="#ref-for-abstractrange①">(2)</a>
     <li><a href="#ref-for-abstractrange②">5.4. Interface StaticRange</a>
     <li><a href="#ref-for-abstractrange③">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range">
-   <b><a href="#concept-range">#concept-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range" class="dfn-panel" data-for="concept-range" id="infopanel-for-concept-range" role="dialog">
+   <span id="infopaneltitle-for-concept-range" style="display:none">Info about the 'ranges' definition.</span><b><a href="#concept-range">#concept-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range">5.1. Introduction to "DOM Ranges"</a> <a href="#ref-for-concept-range①">(2)</a> <a href="#ref-for-concept-range②">(3)</a> <a href="#ref-for-concept-range③">(4)</a> <a href="#ref-for-concept-range④">(5)</a> <a href="#ref-for-concept-range⑤">(6)</a> <a href="#ref-for-concept-range⑥">(7)</a> <a href="#ref-for-concept-range⑦">(8)</a>
     <li><a href="#ref-for-concept-range⑧">5.3. Interface AbstractRange</a> <a href="#ref-for-concept-range⑨">(2)</a> <a href="#ref-for-concept-range①⓪">(3)</a>
@@ -18978,8 +18979,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range①②">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-start">
-   <b><a href="#concept-range-start">#concept-range-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-start" class="dfn-panel" data-for="concept-range-start" id="infopanel-for-concept-range-start" role="dialog">
+   <span id="infopaneltitle-for-concept-range-start" style="display:none">Info about the 'start' definition.</span><b><a href="#concept-range-start">#concept-range-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-range-start①">4.5. Interface Document</a>
@@ -18989,8 +18990,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-start⑥">5.5. Interface Range</a> <a href="#ref-for-concept-range-start⑦">(2)</a> <a href="#ref-for-concept-range-start⑧">(3)</a> <a href="#ref-for-concept-range-start⑨">(4)</a> <a href="#ref-for-concept-range-start①⓪">(5)</a> <a href="#ref-for-concept-range-start①①">(6)</a> <a href="#ref-for-concept-range-start①②">(7)</a> <a href="#ref-for-concept-range-start①③">(8)</a> <a href="#ref-for-concept-range-start①④">(9)</a> <a href="#ref-for-concept-range-start①⑤">(10)</a> <a href="#ref-for-concept-range-start①⑥">(11)</a> <a href="#ref-for-concept-range-start①⑦">(12)</a> <a href="#ref-for-concept-range-start①⑧">(13)</a> <a href="#ref-for-concept-range-start①⑨">(14)</a> <a href="#ref-for-concept-range-start②⓪">(15)</a> <a href="#ref-for-concept-range-start②①">(16)</a> <a href="#ref-for-concept-range-start②②">(17)</a> <a href="#ref-for-concept-range-start②③">(18)</a> <a href="#ref-for-concept-range-start②④">(19)</a> <a href="#ref-for-concept-range-start②⑤">(20)</a> <a href="#ref-for-concept-range-start②⑥">(21)</a> <a href="#ref-for-concept-range-start②⑦">(22)</a> <a href="#ref-for-concept-range-start②⑧">(23)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-end">
-   <b><a href="#concept-range-end">#concept-range-end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-end" class="dfn-panel" data-for="concept-range-end" id="infopanel-for-concept-range-end" role="dialog">
+   <span id="infopaneltitle-for-concept-range-end" style="display:none">Info about the 'end' definition.</span><b><a href="#concept-range-end">#concept-range-end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-range-end①">4.5. Interface Document</a>
@@ -19000,8 +19001,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-end⑥">5.5. Interface Range</a> <a href="#ref-for-concept-range-end⑦">(2)</a> <a href="#ref-for-concept-range-end⑧">(3)</a> <a href="#ref-for-concept-range-end⑨">(4)</a> <a href="#ref-for-concept-range-end①⓪">(5)</a> <a href="#ref-for-concept-range-end①①">(6)</a> <a href="#ref-for-concept-range-end①②">(7)</a> <a href="#ref-for-concept-range-end①③">(8)</a> <a href="#ref-for-concept-range-end①④">(9)</a> <a href="#ref-for-concept-range-end①⑤">(10)</a> <a href="#ref-for-concept-range-end①⑥">(11)</a> <a href="#ref-for-concept-range-end①⑦">(12)</a> <a href="#ref-for-concept-range-end①⑧">(13)</a> <a href="#ref-for-concept-range-end①⑨">(14)</a> <a href="#ref-for-concept-range-end②⓪">(15)</a> <a href="#ref-for-concept-range-end②①">(16)</a> <a href="#ref-for-concept-range-end②②">(17)</a> <a href="#ref-for-concept-range-end②③">(18)</a> <a href="#ref-for-concept-range-end②④">(19)</a> <a href="#ref-for-concept-range-end②⑤">(20)</a> <a href="#ref-for-concept-range-end②⑥">(21)</a> <a href="#ref-for-concept-range-end②⑦">(22)</a> <a href="#ref-for-concept-range-end②⑧">(23)</a> <a href="#ref-for-concept-range-end②⑨">(24)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-start-node">
-   <b><a href="#concept-range-start-node">#concept-range-start-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-start-node" class="dfn-panel" data-for="concept-range-start-node" id="infopanel-for-concept-range-start-node" role="dialog">
+   <span id="infopaneltitle-for-concept-range-start-node" style="display:none">Info about the 'start node' definition.</span><b><a href="#concept-range-start-node">#concept-range-start-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-node">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-range-start-node①">(2)</a> <a href="#ref-for-concept-range-start-node②">(3)</a>
     <li><a href="#ref-for-concept-range-start-node③">4.4. Interface Node</a> <a href="#ref-for-concept-range-start-node④">(2)</a> <a href="#ref-for-concept-range-start-node⑤">(3)</a> <a href="#ref-for-concept-range-start-node⑥">(4)</a>
@@ -19011,8 +19012,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-start-node①⑤">5.5. Interface Range</a> <a href="#ref-for-concept-range-start-node①⑥">(2)</a> <a href="#ref-for-concept-range-start-node①⑦">(3)</a> <a href="#ref-for-concept-range-start-node①⑧">(4)</a> <a href="#ref-for-concept-range-start-node①⑨">(5)</a> <a href="#ref-for-concept-range-start-node②⓪">(6)</a> <a href="#ref-for-concept-range-start-node②①">(7)</a> <a href="#ref-for-concept-range-start-node②②">(8)</a> <a href="#ref-for-concept-range-start-node②③">(9)</a> <a href="#ref-for-concept-range-start-node②④">(10)</a> <a href="#ref-for-concept-range-start-node②⑤">(11)</a> <a href="#ref-for-concept-range-start-node②⑥">(12)</a> <a href="#ref-for-concept-range-start-node②⑦">(13)</a> <a href="#ref-for-concept-range-start-node②⑧">(14)</a> <a href="#ref-for-concept-range-start-node②⑨">(15)</a> <a href="#ref-for-concept-range-start-node③⓪">(16)</a> <a href="#ref-for-concept-range-start-node③①">(17)</a> <a href="#ref-for-concept-range-start-node③②">(18)</a> <a href="#ref-for-concept-range-start-node③③">(19)</a> <a href="#ref-for-concept-range-start-node③④">(20)</a> <a href="#ref-for-concept-range-start-node③⑤">(21)</a> <a href="#ref-for-concept-range-start-node③⑥">(22)</a> <a href="#ref-for-concept-range-start-node③⑦">(23)</a> <a href="#ref-for-concept-range-start-node③⑧">(24)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-start-offset">
-   <b><a href="#concept-range-start-offset">#concept-range-start-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-start-offset" class="dfn-panel" data-for="concept-range-start-offset" id="infopanel-for-concept-range-start-offset" role="dialog">
+   <span id="infopaneltitle-for-concept-range-start-offset" style="display:none">Info about the 'start offset' definition.</span><b><a href="#concept-range-start-offset">#concept-range-start-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-start-offset">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-range-start-offset①">(2)</a> <a href="#ref-for-concept-range-start-offset②">(3)</a> <a href="#ref-for-concept-range-start-offset③">(4)</a>
     <li><a href="#ref-for-concept-range-start-offset④">4.4. Interface Node</a> <a href="#ref-for-concept-range-start-offset⑤">(2)</a> <a href="#ref-for-concept-range-start-offset⑥">(3)</a>
@@ -19022,8 +19023,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-start-offset①⑧">5.5. Interface Range</a> <a href="#ref-for-concept-range-start-offset①⑨">(2)</a> <a href="#ref-for-concept-range-start-offset②⓪">(3)</a> <a href="#ref-for-concept-range-start-offset②①">(4)</a> <a href="#ref-for-concept-range-start-offset②②">(5)</a> <a href="#ref-for-concept-range-start-offset②③">(6)</a> <a href="#ref-for-concept-range-start-offset②④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-end-node">
-   <b><a href="#concept-range-end-node">#concept-range-end-node</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-end-node" class="dfn-panel" data-for="concept-range-end-node" id="infopanel-for-concept-range-end-node" role="dialog">
+   <span id="infopaneltitle-for-concept-range-end-node" style="display:none">Info about the 'end node' definition.</span><b><a href="#concept-range-end-node">#concept-range-end-node</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-node">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-range-end-node①">(2)</a> <a href="#ref-for-concept-range-end-node②">(3)</a>
     <li><a href="#ref-for-concept-range-end-node③">4.4. Interface Node</a> <a href="#ref-for-concept-range-end-node④">(2)</a> <a href="#ref-for-concept-range-end-node⑤">(3)</a> <a href="#ref-for-concept-range-end-node⑥">(4)</a>
@@ -19033,8 +19034,8 @@ APIs</a>
     <li><a href="#ref-for-concept-range-end-node①⑤">5.5. Interface Range</a> <a href="#ref-for-concept-range-end-node①⑥">(2)</a> <a href="#ref-for-concept-range-end-node①⑦">(3)</a> <a href="#ref-for-concept-range-end-node①⑧">(4)</a> <a href="#ref-for-concept-range-end-node①⑨">(5)</a> <a href="#ref-for-concept-range-end-node②⓪">(6)</a> <a href="#ref-for-concept-range-end-node②①">(7)</a> <a href="#ref-for-concept-range-end-node②②">(8)</a> <a href="#ref-for-concept-range-end-node②③">(9)</a> <a href="#ref-for-concept-range-end-node②④">(10)</a> <a href="#ref-for-concept-range-end-node②⑤">(11)</a> <a href="#ref-for-concept-range-end-node②⑥">(12)</a> <a href="#ref-for-concept-range-end-node②⑦">(13)</a> <a href="#ref-for-concept-range-end-node②⑧">(14)</a> <a href="#ref-for-concept-range-end-node②⑨">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-end-offset">
-   <b><a href="#concept-range-end-offset">#concept-range-end-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-end-offset" class="dfn-panel" data-for="concept-range-end-offset" id="infopanel-for-concept-range-end-offset" role="dialog">
+   <span id="infopaneltitle-for-concept-range-end-offset" style="display:none">Info about the 'end offset' definition.</span><b><a href="#concept-range-end-offset">#concept-range-end-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-end-offset">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-range-end-offset①">(2)</a> <a href="#ref-for-concept-range-end-offset②">(3)</a> <a href="#ref-for-concept-range-end-offset③">(4)</a>
     <li><a href="#ref-for-concept-range-end-offset④">4.4. Interface Node</a> <a href="#ref-for-concept-range-end-offset⑤">(2)</a> <a href="#ref-for-concept-range-end-offset⑥">(3)</a>
@@ -19044,120 +19045,120 @@ APIs</a>
     <li><a href="#ref-for-concept-range-end-offset①⑧">5.5. Interface Range</a> <a href="#ref-for-concept-range-end-offset①⑨">(2)</a> <a href="#ref-for-concept-range-end-offset②⓪">(3)</a> <a href="#ref-for-concept-range-end-offset②①">(4)</a> <a href="#ref-for-concept-range-end-offset②②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="range-collapsed">
-   <b><a href="#range-collapsed">#range-collapsed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-range-collapsed" class="dfn-panel" data-for="range-collapsed" id="infopanel-for-range-collapsed" role="dialog">
+   <span id="infopaneltitle-for-range-collapsed" style="display:none">Info about the 'collapsed' definition.</span><b><a href="#range-collapsed">#range-collapsed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range-collapsed">5.3. Interface AbstractRange</a> <a href="#ref-for-range-collapsed①">(2)</a>
     <li><a href="#ref-for-range-collapsed②">5.5. Interface Range</a> <a href="#ref-for-range-collapsed③">(2)</a> <a href="#ref-for-range-collapsed④">(3)</a> <a href="#ref-for-range-collapsed⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-startcontainer">
-   <b><a href="#dom-range-startcontainer">#dom-range-startcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-startcontainer" class="dfn-panel" data-for="dom-range-startcontainer" id="infopanel-for-dom-range-startcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-range-startcontainer" style="display:none">Info about the 'startContainer' definition.</span><b><a href="#dom-range-startcontainer">#dom-range-startcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-startcontainer">5.3. Interface AbstractRange</a> <a href="#ref-for-dom-range-startcontainer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-startoffset">
-   <b><a href="#dom-range-startoffset">#dom-range-startoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-startoffset" class="dfn-panel" data-for="dom-range-startoffset" id="infopanel-for-dom-range-startoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-range-startoffset" style="display:none">Info about the 'startOffset' definition.</span><b><a href="#dom-range-startoffset">#dom-range-startoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-startoffset">5.3. Interface AbstractRange</a> <a href="#ref-for-dom-range-startoffset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-endcontainer">
-   <b><a href="#dom-range-endcontainer">#dom-range-endcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-endcontainer" class="dfn-panel" data-for="dom-range-endcontainer" id="infopanel-for-dom-range-endcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-range-endcontainer" style="display:none">Info about the 'endContainer' definition.</span><b><a href="#dom-range-endcontainer">#dom-range-endcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-endcontainer">5.3. Interface AbstractRange</a> <a href="#ref-for-dom-range-endcontainer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-endoffset">
-   <b><a href="#dom-range-endoffset">#dom-range-endoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-endoffset" class="dfn-panel" data-for="dom-range-endoffset" id="infopanel-for-dom-range-endoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-range-endoffset" style="display:none">Info about the 'endOffset' definition.</span><b><a href="#dom-range-endoffset">#dom-range-endoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-endoffset">5.3. Interface AbstractRange</a> <a href="#ref-for-dom-range-endoffset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-collapsed">
-   <b><a href="#dom-range-collapsed">#dom-range-collapsed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-collapsed" class="dfn-panel" data-for="dom-range-collapsed" id="infopanel-for-dom-range-collapsed" role="dialog">
+   <span id="infopaneltitle-for-dom-range-collapsed" style="display:none">Info about the 'collapsed' definition.</span><b><a href="#dom-range-collapsed">#dom-range-collapsed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-collapsed">5.3. Interface AbstractRange</a> <a href="#ref-for-dom-range-collapsed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-staticrangeinit">
-   <b><a href="#dictdef-staticrangeinit">#dictdef-staticrangeinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-staticrangeinit" class="dfn-panel" data-for="dictdef-staticrangeinit" id="infopanel-for-dictdef-staticrangeinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-staticrangeinit" style="display:none">Info about the 'StaticRangeInit' definition.</span><b><a href="#dictdef-staticrangeinit">#dictdef-staticrangeinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-staticrangeinit">5.4. Interface StaticRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-staticrangeinit-startcontainer">
-   <b><a href="#dom-staticrangeinit-startcontainer">#dom-staticrangeinit-startcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-staticrangeinit-startcontainer" class="dfn-panel" data-for="dom-staticrangeinit-startcontainer" id="infopanel-for-dom-staticrangeinit-startcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-staticrangeinit-startcontainer" style="display:none">Info about the 'startContainer' definition.</span><b><a href="#dom-staticrangeinit-startcontainer">#dom-staticrangeinit-startcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-staticrangeinit-startcontainer">5.4. Interface StaticRange</a> <a href="#ref-for-dom-staticrangeinit-startcontainer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-staticrangeinit-startoffset">
-   <b><a href="#dom-staticrangeinit-startoffset">#dom-staticrangeinit-startoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-staticrangeinit-startoffset" class="dfn-panel" data-for="dom-staticrangeinit-startoffset" id="infopanel-for-dom-staticrangeinit-startoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-staticrangeinit-startoffset" style="display:none">Info about the 'startOffset' definition.</span><b><a href="#dom-staticrangeinit-startoffset">#dom-staticrangeinit-startoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-staticrangeinit-startoffset">5.4. Interface StaticRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-staticrangeinit-endcontainer">
-   <b><a href="#dom-staticrangeinit-endcontainer">#dom-staticrangeinit-endcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-staticrangeinit-endcontainer" class="dfn-panel" data-for="dom-staticrangeinit-endcontainer" id="infopanel-for-dom-staticrangeinit-endcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-staticrangeinit-endcontainer" style="display:none">Info about the 'endContainer' definition.</span><b><a href="#dom-staticrangeinit-endcontainer">#dom-staticrangeinit-endcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-staticrangeinit-endcontainer">5.4. Interface StaticRange</a> <a href="#ref-for-dom-staticrangeinit-endcontainer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-staticrangeinit-endoffset">
-   <b><a href="#dom-staticrangeinit-endoffset">#dom-staticrangeinit-endoffset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-staticrangeinit-endoffset" class="dfn-panel" data-for="dom-staticrangeinit-endoffset" id="infopanel-for-dom-staticrangeinit-endoffset" role="dialog">
+   <span id="infopaneltitle-for-dom-staticrangeinit-endoffset" style="display:none">Info about the 'endOffset' definition.</span><b><a href="#dom-staticrangeinit-endoffset">#dom-staticrangeinit-endoffset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-staticrangeinit-endoffset">5.4. Interface StaticRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="staticrange">
-   <b><a href="#staticrange">#staticrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-staticrange" class="dfn-panel" data-for="staticrange" id="infopanel-for-staticrange" role="dialog">
+   <span id="infopaneltitle-for-staticrange" style="display:none">Info about the 'StaticRange' definition.</span><b><a href="#staticrange">#staticrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-staticrange">5.1. Introduction to "DOM Ranges"</a> <a href="#ref-for-staticrange①">(2)</a> <a href="#ref-for-staticrange②">(3)</a>
     <li><a href="#ref-for-staticrange③">5.4. Interface StaticRange</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-staticrange-staticrange">
-   <b><a href="#dom-staticrange-staticrange">#dom-staticrange-staticrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-staticrange-staticrange" class="dfn-panel" data-for="dom-staticrange-staticrange" id="infopanel-for-dom-staticrange-staticrange" role="dialog">
+   <span id="infopaneltitle-for-dom-staticrange-staticrange" style="display:none">Info about the 'new StaticRange(init)' definition.</span><b><a href="#dom-staticrange-staticrange">#dom-staticrange-staticrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-staticrange-staticrange">5.4. Interface StaticRange</a> <a href="#ref-for-dom-staticrange-staticrange①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="range">
-   <b><a href="#range">#range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-range" class="dfn-panel" data-for="range" id="infopanel-for-range" role="dialog">
+   <span id="infopaneltitle-for-range" style="display:none">Info about the 'Range' definition.</span><b><a href="#range">#range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-range">4.5. Interface Document</a>
     <li><a href="#ref-for-range①">5.1. Introduction to "DOM Ranges"</a> <a href="#ref-for-range②">(2)</a> <a href="#ref-for-range③">(3)</a>
     <li><a href="#ref-for-range④">5.5. Interface Range</a> <a href="#ref-for-range⑤">(2)</a> <a href="#ref-for-range⑥">(3)</a> <a href="#ref-for-range⑦">(4)</a> <a href="#ref-for-range⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-start_to_start">
-   <b><a href="#dom-range-start_to_start">#dom-range-start_to_start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-start_to_start" class="dfn-panel" data-for="dom-range-start_to_start" id="infopanel-for-dom-range-start_to_start" role="dialog">
+   <span id="infopaneltitle-for-dom-range-start_to_start" style="display:none">Info about the 'START_TO_START' definition.</span><b><a href="#dom-range-start_to_start">#dom-range-start_to_start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-start_to_start">5.5. Interface Range</a> <a href="#ref-for-dom-range-start_to_start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-start_to_end">
-   <b><a href="#dom-range-start_to_end">#dom-range-start_to_end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-start_to_end" class="dfn-panel" data-for="dom-range-start_to_end" id="infopanel-for-dom-range-start_to_end" role="dialog">
+   <span id="infopaneltitle-for-dom-range-start_to_end" style="display:none">Info about the 'START_TO_END' definition.</span><b><a href="#dom-range-start_to_end">#dom-range-start_to_end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-start_to_end">5.5. Interface Range</a> <a href="#ref-for-dom-range-start_to_end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-end_to_end">
-   <b><a href="#dom-range-end_to_end">#dom-range-end_to_end</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-end_to_end" class="dfn-panel" data-for="dom-range-end_to_end" id="infopanel-for-dom-range-end_to_end" role="dialog">
+   <span id="infopaneltitle-for-dom-range-end_to_end" style="display:none">Info about the 'END_TO_END' definition.</span><b><a href="#dom-range-end_to_end">#dom-range-end_to_end</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-end_to_end">5.5. Interface Range</a> <a href="#ref-for-dom-range-end_to_end①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-end_to_start">
-   <b><a href="#dom-range-end_to_start">#dom-range-end_to_start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-end_to_start" class="dfn-panel" data-for="dom-range-end_to_start" id="infopanel-for-dom-range-end_to_start" role="dialog">
+   <span id="infopaneltitle-for-dom-range-end_to_start" style="display:none">Info about the 'END_TO_START' definition.</span><b><a href="#dom-range-end_to_start">#dom-range-end_to_start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-end_to_start">5.5. Interface Range</a> <a href="#ref-for-dom-range-end_to_start①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-live-range">
-   <b><a href="#concept-live-range">#concept-live-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-live-range" class="dfn-panel" data-for="concept-live-range" id="infopanel-for-concept-live-range" role="dialog">
+   <span id="infopaneltitle-for-concept-live-range" style="display:none">Info about the 'live ranges' definition.</span><b><a href="#concept-live-range">#concept-live-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-live-range">4.2.3. Mutation algorithms</a> <a href="#ref-for-concept-live-range①">(2)</a> <a href="#ref-for-concept-live-range②">(3)</a> <a href="#ref-for-concept-live-range③">(4)</a> <a href="#ref-for-concept-live-range④">(5)</a> <a href="#ref-for-concept-live-range⑤">(6)</a>
     <li><a href="#ref-for-concept-live-range⑥">4.4. Interface Node</a> <a href="#ref-for-concept-live-range⑦">(2)</a> <a href="#ref-for-concept-live-range⑧">(3)</a> <a href="#ref-for-concept-live-range⑨">(4)</a>
@@ -19168,202 +19169,202 @@ APIs</a>
     <li><a href="#ref-for-concept-live-range②④">5.5. Interface Range</a> <a href="#ref-for-concept-live-range②⑤">(2)</a> <a href="#ref-for-concept-live-range②⑥">(3)</a> <a href="#ref-for-concept-live-range②⑦">(4)</a> <a href="#ref-for-concept-live-range②⑧">(5)</a> <a href="#ref-for-concept-live-range②⑨">(6)</a> <a href="#ref-for-concept-live-range③⓪">(7)</a> <a href="#ref-for-concept-live-range③①">(8)</a> <a href="#ref-for-concept-live-range③②">(9)</a> <a href="#ref-for-concept-live-range③③">(10)</a> <a href="#ref-for-concept-live-range③④">(11)</a> <a href="#ref-for-concept-live-range③⑤">(12)</a> <a href="#ref-for-concept-live-range③⑥">(13)</a> <a href="#ref-for-concept-live-range③⑦">(14)</a> <a href="#ref-for-concept-live-range③⑧">(15)</a> <a href="#ref-for-concept-live-range③⑨">(16)</a> <a href="#ref-for-concept-live-range④⓪">(17)</a> <a href="#ref-for-concept-live-range④①">(18)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-root">
-   <b><a href="#concept-range-root">#concept-range-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-root" class="dfn-panel" data-for="concept-range-root" id="infopanel-for-concept-range-root" role="dialog">
+   <span id="infopaneltitle-for-concept-range-root" style="display:none">Info about the 'root' definition.</span><b><a href="#concept-range-root">#concept-range-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-root">5.5. Interface Range</a> <a href="#ref-for-concept-range-root①">(2)</a> <a href="#ref-for-concept-range-root②">(3)</a> <a href="#ref-for-concept-range-root③">(4)</a> <a href="#ref-for-concept-range-root④">(5)</a> <a href="#ref-for-concept-range-root⑤">(6)</a> <a href="#ref-for-concept-range-root⑥">(7)</a> <a href="#ref-for-concept-range-root⑦">(8)</a> <a href="#ref-for-concept-range-root⑧">(9)</a> <a href="#ref-for-concept-range-root⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="contained">
-   <b><a href="#contained">#contained</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-contained" class="dfn-panel" data-for="contained" id="infopanel-for-contained" role="dialog">
+   <span id="infopaneltitle-for-contained" style="display:none">Info about the 'contained' definition.</span><b><a href="#contained">#contained</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-contained">5.5. Interface Range</a> <a href="#ref-for-contained①">(2)</a> <a href="#ref-for-contained②">(3)</a> <a href="#ref-for-contained③">(4)</a> <a href="#ref-for-contained④">(5)</a> <a href="#ref-for-contained⑤">(6)</a> <a href="#ref-for-contained⑥">(7)</a> <a href="#ref-for-contained⑦">(8)</a> <a href="#ref-for-contained⑧">(9)</a> <a href="#ref-for-contained⑨">(10)</a> <a href="#ref-for-contained①⓪">(11)</a> <a href="#ref-for-contained①①">(12)</a> <a href="#ref-for-contained①②">(13)</a> <a href="#ref-for-contained①③">(14)</a> <a href="#ref-for-contained①④">(15)</a> <a href="#ref-for-contained①⑤">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="partially-contained">
-   <b><a href="#partially-contained">#partially-contained</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-partially-contained" class="dfn-panel" data-for="partially-contained" id="infopanel-for-partially-contained" role="dialog">
+   <span id="infopaneltitle-for-partially-contained" style="display:none">Info about the 'partially contained' definition.</span><b><a href="#partially-contained">#partially-contained</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-partially-contained">5.5. Interface Range</a> <a href="#ref-for-partially-contained①">(2)</a> <a href="#ref-for-partially-contained②">(3)</a> <a href="#ref-for-partially-contained③">(4)</a> <a href="#ref-for-partially-contained④">(5)</a> <a href="#ref-for-partially-contained⑤">(6)</a> <a href="#ref-for-partially-contained⑥">(7)</a> <a href="#ref-for-partially-contained⑦">(8)</a> <a href="#ref-for-partially-contained⑧">(9)</a> <a href="#ref-for-partially-contained⑨">(10)</a> <a href="#ref-for-partially-contained①⓪">(11)</a> <a href="#ref-for-partially-contained①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-range">
-   <b><a href="#dom-range-range">#dom-range-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-range" class="dfn-panel" data-for="dom-range-range" id="infopanel-for-dom-range-range" role="dialog">
+   <span id="infopaneltitle-for-dom-range-range" style="display:none">Info about the 'new Range()' definition.</span><b><a href="#dom-range-range">#dom-range-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-range">4.5. Interface Document</a>
     <li><a href="#ref-for-dom-range-range①">5.5. Interface Range</a> <a href="#ref-for-dom-range-range②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-commonancestorcontainer">
-   <b><a href="#dom-range-commonancestorcontainer">#dom-range-commonancestorcontainer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-commonancestorcontainer" class="dfn-panel" data-for="dom-range-commonancestorcontainer" id="infopanel-for-dom-range-commonancestorcontainer" role="dialog">
+   <span id="infopaneltitle-for-dom-range-commonancestorcontainer" style="display:none">Info about the 'commonAncestorContainer' definition.</span><b><a href="#dom-range-commonancestorcontainer">#dom-range-commonancestorcontainer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-commonancestorcontainer">5.5. Interface Range</a> <a href="#ref-for-dom-range-commonancestorcontainer①">(2)</a> <a href="#ref-for-dom-range-commonancestorcontainer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-bp-set">
-   <b><a href="#concept-range-bp-set">#concept-range-bp-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-bp-set" class="dfn-panel" data-for="concept-range-bp-set" id="infopanel-for-concept-range-bp-set" role="dialog">
+   <span id="infopaneltitle-for-concept-range-bp-set" style="display:none">Info about the 'set the start or end' definition.</span><b><a href="#concept-range-bp-set">#concept-range-bp-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-bp-set">5.5. Interface Range</a> <a href="#ref-for-concept-range-bp-set①">(2)</a> <a href="#ref-for-concept-range-bp-set②">(3)</a> <a href="#ref-for-concept-range-bp-set③">(4)</a> <a href="#ref-for-concept-range-bp-set④">(5)</a> <a href="#ref-for-concept-range-bp-set⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setstart">
-   <b><a href="#dom-range-setstart">#dom-range-setstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setstart" class="dfn-panel" data-for="dom-range-setstart" id="infopanel-for-dom-range-setstart" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setstart" style="display:none">Info about the 'setStart(node, offset)' definition.</span><b><a href="#dom-range-setstart">#dom-range-setstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setstart">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setend">
-   <b><a href="#dom-range-setend">#dom-range-setend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setend" class="dfn-panel" data-for="dom-range-setend" id="infopanel-for-dom-range-setend" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setend" style="display:none">Info about the 'setEnd(node, offset)' definition.</span><b><a href="#dom-range-setend">#dom-range-setend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setend">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setstartbefore">
-   <b><a href="#dom-range-setstartbefore">#dom-range-setstartbefore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setstartbefore" class="dfn-panel" data-for="dom-range-setstartbefore" id="infopanel-for-dom-range-setstartbefore" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setstartbefore" style="display:none">Info about the 'setStartBefore(node)' definition.</span><b><a href="#dom-range-setstartbefore">#dom-range-setstartbefore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setstartbefore">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setstartafter">
-   <b><a href="#dom-range-setstartafter">#dom-range-setstartafter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setstartafter" class="dfn-panel" data-for="dom-range-setstartafter" id="infopanel-for-dom-range-setstartafter" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setstartafter" style="display:none">Info about the 'setStartAfter(node)' definition.</span><b><a href="#dom-range-setstartafter">#dom-range-setstartafter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setstartafter">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setendbefore">
-   <b><a href="#dom-range-setendbefore">#dom-range-setendbefore</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setendbefore" class="dfn-panel" data-for="dom-range-setendbefore" id="infopanel-for-dom-range-setendbefore" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setendbefore" style="display:none">Info about the 'setEndBefore(node)' definition.</span><b><a href="#dom-range-setendbefore">#dom-range-setendbefore</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setendbefore">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-setendafter">
-   <b><a href="#dom-range-setendafter">#dom-range-setendafter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-setendafter" class="dfn-panel" data-for="dom-range-setendafter" id="infopanel-for-dom-range-setendafter" role="dialog">
+   <span id="infopaneltitle-for-dom-range-setendafter" style="display:none">Info about the 'setEndAfter(node)' definition.</span><b><a href="#dom-range-setendafter">#dom-range-setendafter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-setendafter">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-collapse">
-   <b><a href="#dom-range-collapse">#dom-range-collapse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-collapse" class="dfn-panel" data-for="dom-range-collapse" id="infopanel-for-dom-range-collapse" role="dialog">
+   <span id="infopaneltitle-for-dom-range-collapse" style="display:none">Info about the 'collapse(toStart)' definition.</span><b><a href="#dom-range-collapse">#dom-range-collapse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-collapse">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-select">
-   <b><a href="#concept-range-select">#concept-range-select</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-select" class="dfn-panel" data-for="concept-range-select" id="infopanel-for-concept-range-select" role="dialog">
+   <span id="infopaneltitle-for-concept-range-select" style="display:none">Info about the 'select' definition.</span><b><a href="#concept-range-select">#concept-range-select</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-select">5.5. Interface Range</a> <a href="#ref-for-concept-range-select①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-selectnode">
-   <b><a href="#dom-range-selectnode">#dom-range-selectnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-selectnode" class="dfn-panel" data-for="dom-range-selectnode" id="infopanel-for-dom-range-selectnode" role="dialog">
+   <span id="infopaneltitle-for-dom-range-selectnode" style="display:none">Info about the 'selectNode(node)' definition.</span><b><a href="#dom-range-selectnode">#dom-range-selectnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-selectnode">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-selectnodecontents">
-   <b><a href="#dom-range-selectnodecontents">#dom-range-selectnodecontents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-selectnodecontents" class="dfn-panel" data-for="dom-range-selectnodecontents" id="infopanel-for-dom-range-selectnodecontents" role="dialog">
+   <span id="infopaneltitle-for-dom-range-selectnodecontents" style="display:none">Info about the 'selectNodeContents(node)' definition.</span><b><a href="#dom-range-selectnodecontents">#dom-range-selectnodecontents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-selectnodecontents">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-compareboundarypoints">
-   <b><a href="#dom-range-compareboundarypoints">#dom-range-compareboundarypoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-compareboundarypoints" class="dfn-panel" data-for="dom-range-compareboundarypoints" id="infopanel-for-dom-range-compareboundarypoints" role="dialog">
+   <span id="infopaneltitle-for-dom-range-compareboundarypoints" style="display:none">Info about the 'compareBoundaryPoints(how, sourceRange)' definition.</span><b><a href="#dom-range-compareboundarypoints">#dom-range-compareboundarypoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-compareboundarypoints">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-deletecontents">
-   <b><a href="#dom-range-deletecontents">#dom-range-deletecontents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-deletecontents" class="dfn-panel" data-for="dom-range-deletecontents" id="infopanel-for-dom-range-deletecontents" role="dialog">
+   <span id="infopaneltitle-for-dom-range-deletecontents" style="display:none">Info about the 'deleteContents()' definition.</span><b><a href="#dom-range-deletecontents">#dom-range-deletecontents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-deletecontents">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-extract">
-   <b><a href="#concept-range-extract">#concept-range-extract</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-extract" class="dfn-panel" data-for="concept-range-extract" id="infopanel-for-concept-range-extract" role="dialog">
+   <span id="infopaneltitle-for-concept-range-extract" style="display:none">Info about the 'extract' definition.</span><b><a href="#concept-range-extract">#concept-range-extract</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-extract">5.5. Interface Range</a> <a href="#ref-for-concept-range-extract①">(2)</a> <a href="#ref-for-concept-range-extract②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-extractcontents">
-   <b><a href="#dom-range-extractcontents">#dom-range-extractcontents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-extractcontents" class="dfn-panel" data-for="dom-range-extractcontents" id="infopanel-for-dom-range-extractcontents" role="dialog">
+   <span id="infopaneltitle-for-dom-range-extractcontents" style="display:none">Info about the 'extractContents()' definition.</span><b><a href="#dom-range-extractcontents">#dom-range-extractcontents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-extractcontents">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-clone">
-   <b><a href="#concept-range-clone">#concept-range-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-clone" class="dfn-panel" data-for="concept-range-clone" id="infopanel-for-concept-range-clone" role="dialog">
+   <span id="infopaneltitle-for-concept-range-clone" style="display:none">Info about the 'clone the contents' definition.</span><b><a href="#concept-range-clone">#concept-range-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-clone">5.5. Interface Range</a> <a href="#ref-for-concept-range-clone①">(2)</a> <a href="#ref-for-concept-range-clone②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-clonecontents">
-   <b><a href="#dom-range-clonecontents">#dom-range-clonecontents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-clonecontents" class="dfn-panel" data-for="dom-range-clonecontents" id="infopanel-for-dom-range-clonecontents" role="dialog">
+   <span id="infopaneltitle-for-dom-range-clonecontents" style="display:none">Info about the 'cloneContents()' definition.</span><b><a href="#dom-range-clonecontents">#dom-range-clonecontents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-clonecontents">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-range-insert">
-   <b><a href="#concept-range-insert">#concept-range-insert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-range-insert" class="dfn-panel" data-for="concept-range-insert" id="infopanel-for-concept-range-insert" role="dialog">
+   <span id="infopaneltitle-for-concept-range-insert" style="display:none">Info about the 'insert' definition.</span><b><a href="#concept-range-insert">#concept-range-insert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-range-insert">5.5. Interface Range</a> <a href="#ref-for-concept-range-insert①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-insertnode">
-   <b><a href="#dom-range-insertnode">#dom-range-insertnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-insertnode" class="dfn-panel" data-for="dom-range-insertnode" id="infopanel-for-dom-range-insertnode" role="dialog">
+   <span id="infopaneltitle-for-dom-range-insertnode" style="display:none">Info about the 'insertNode(node)' definition.</span><b><a href="#dom-range-insertnode">#dom-range-insertnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-insertnode">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-surroundcontents">
-   <b><a href="#dom-range-surroundcontents">#dom-range-surroundcontents</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-surroundcontents" class="dfn-panel" data-for="dom-range-surroundcontents" id="infopanel-for-dom-range-surroundcontents" role="dialog">
+   <span id="infopaneltitle-for-dom-range-surroundcontents" style="display:none">Info about the 'surroundContents(newParent)' definition.</span><b><a href="#dom-range-surroundcontents">#dom-range-surroundcontents</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-surroundcontents">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-clonerange">
-   <b><a href="#dom-range-clonerange">#dom-range-clonerange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-clonerange" class="dfn-panel" data-for="dom-range-clonerange" id="infopanel-for-dom-range-clonerange" role="dialog">
+   <span id="infopaneltitle-for-dom-range-clonerange" style="display:none">Info about the 'cloneRange()' definition.</span><b><a href="#dom-range-clonerange">#dom-range-clonerange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-clonerange">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-detach">
-   <b><a href="#dom-range-detach">#dom-range-detach</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-detach" class="dfn-panel" data-for="dom-range-detach" id="infopanel-for-dom-range-detach" role="dialog">
+   <span id="infopaneltitle-for-dom-range-detach" style="display:none">Info about the 'detach()' definition.</span><b><a href="#dom-range-detach">#dom-range-detach</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-detach">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-ispointinrange">
-   <b><a href="#dom-range-ispointinrange">#dom-range-ispointinrange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-ispointinrange" class="dfn-panel" data-for="dom-range-ispointinrange" id="infopanel-for-dom-range-ispointinrange" role="dialog">
+   <span id="infopaneltitle-for-dom-range-ispointinrange" style="display:none">Info about the 'isPointInRange(node, offset)' definition.</span><b><a href="#dom-range-ispointinrange">#dom-range-ispointinrange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-ispointinrange">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-comparepoint">
-   <b><a href="#dom-range-comparepoint">#dom-range-comparepoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-comparepoint" class="dfn-panel" data-for="dom-range-comparepoint" id="infopanel-for-dom-range-comparepoint" role="dialog">
+   <span id="infopaneltitle-for-dom-range-comparepoint" style="display:none">Info about the 'comparePoint(node, offset)' definition.</span><b><a href="#dom-range-comparepoint">#dom-range-comparepoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-comparepoint">5.5. Interface Range</a> <a href="#ref-for-dom-range-comparepoint①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-intersectsnode">
-   <b><a href="#dom-range-intersectsnode">#dom-range-intersectsnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-intersectsnode" class="dfn-panel" data-for="dom-range-intersectsnode" id="infopanel-for-dom-range-intersectsnode" role="dialog">
+   <span id="infopaneltitle-for-dom-range-intersectsnode" style="display:none">Info about the 'intersectsNode(node)' definition.</span><b><a href="#dom-range-intersectsnode">#dom-range-intersectsnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-intersectsnode">5.5. Interface Range</a> <a href="#ref-for-dom-range-intersectsnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-range-stringifier">
-   <b><a href="#dom-range-stringifier">#dom-range-stringifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-range-stringifier" class="dfn-panel" data-for="dom-range-stringifier" id="infopanel-for-dom-range-stringifier" role="dialog">
+   <span id="infopaneltitle-for-dom-range-stringifier" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#dom-range-stringifier">#dom-range-stringifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-range-stringifier">5.5. Interface Range</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traversal-active">
-   <b><a href="#concept-traversal-active">#concept-traversal-active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traversal-active" class="dfn-panel" data-for="concept-traversal-active" id="infopanel-for-concept-traversal-active" role="dialog">
+   <span id="infopaneltitle-for-concept-traversal-active" style="display:none">Info about the 'active flag' definition.</span><b><a href="#concept-traversal-active">#concept-traversal-active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traversal-active">6. Traversal</a> <a href="#ref-for-concept-traversal-active①">(2)</a> <a href="#ref-for-concept-traversal-active②">(3)</a> <a href="#ref-for-concept-traversal-active③">(4)</a>
     <li><a href="#ref-for-concept-traversal-active④">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traversal-root">
-   <b><a href="#concept-traversal-root">#concept-traversal-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traversal-root" class="dfn-panel" data-for="concept-traversal-root" id="infopanel-for-concept-traversal-root" role="dialog">
+   <span id="infopaneltitle-for-concept-traversal-root" style="display:none">Info about the 'root' definition.</span><b><a href="#concept-traversal-root">#concept-traversal-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traversal-root">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-concept-traversal-root①">4.5. Interface Document</a> <a href="#ref-for-concept-traversal-root②">(2)</a>
@@ -19371,8 +19372,8 @@ APIs</a>
     <li><a href="#ref-for-concept-traversal-root⑧">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-traversal-root⑨">(2)</a> <a href="#ref-for-concept-traversal-root①⓪">(3)</a> <a href="#ref-for-concept-traversal-root①①">(4)</a> <a href="#ref-for-concept-traversal-root①②">(5)</a> <a href="#ref-for-concept-traversal-root①③">(6)</a> <a href="#ref-for-concept-traversal-root①④">(7)</a> <a href="#ref-for-concept-traversal-root①⑤">(8)</a> <a href="#ref-for-concept-traversal-root①⑥">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traversal-whattoshow">
-   <b><a href="#concept-traversal-whattoshow">#concept-traversal-whattoshow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traversal-whattoshow" class="dfn-panel" data-for="concept-traversal-whattoshow" id="infopanel-for-concept-traversal-whattoshow" role="dialog">
+   <span id="infopaneltitle-for-concept-traversal-whattoshow" style="display:none">Info about the 'whatToShow' definition.</span><b><a href="#concept-traversal-whattoshow">#concept-traversal-whattoshow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traversal-whattoshow">4.5. Interface Document</a> <a href="#ref-for-concept-traversal-whattoshow①">(2)</a>
     <li><a href="#ref-for-concept-traversal-whattoshow②">6. Traversal</a>
@@ -19381,8 +19382,8 @@ APIs</a>
     <li><a href="#ref-for-concept-traversal-whattoshow⑦">6.3. Interface NodeFilter</a> <a href="#ref-for-concept-traversal-whattoshow⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traversal-filter">
-   <b><a href="#concept-traversal-filter">#concept-traversal-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traversal-filter" class="dfn-panel" data-for="concept-traversal-filter" id="infopanel-for-concept-traversal-filter" role="dialog">
+   <span id="infopaneltitle-for-concept-traversal-filter" style="display:none">Info about the 'filter' definition.</span><b><a href="#concept-traversal-filter">#concept-traversal-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traversal-filter">4.5. Interface Document</a> <a href="#ref-for-concept-traversal-filter①">(2)</a>
     <li><a href="#ref-for-concept-traversal-filter②">6. Traversal</a> <a href="#ref-for-concept-traversal-filter③">(2)</a>
@@ -19391,15 +19392,15 @@ APIs</a>
     <li><a href="#ref-for-concept-traversal-filter⑧">6.3. Interface NodeFilter</a> <a href="#ref-for-concept-traversal-filter⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-node-filter">
-   <b><a href="#concept-node-filter">#concept-node-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-node-filter" class="dfn-panel" data-for="concept-node-filter" id="infopanel-for-concept-node-filter" role="dialog">
+   <span id="infopaneltitle-for-concept-node-filter" style="display:none">Info about the 'filter' definition.</span><b><a href="#concept-node-filter">#concept-node-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-filter">6.1. Interface NodeIterator</a>
     <li><a href="#ref-for-concept-node-filter①">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-node-filter②">(2)</a> <a href="#ref-for-concept-node-filter③">(3)</a> <a href="#ref-for-concept-node-filter④">(4)</a> <a href="#ref-for-concept-node-filter⑤">(5)</a> <a href="#ref-for-concept-node-filter⑥">(6)</a> <a href="#ref-for-concept-node-filter⑦">(7)</a> <a href="#ref-for-concept-node-filter⑧">(8)</a> <a href="#ref-for-concept-node-filter⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nodeiterator">
-   <b><a href="#nodeiterator">#nodeiterator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nodeiterator" class="dfn-panel" data-for="nodeiterator" id="infopanel-for-nodeiterator" role="dialog">
+   <span id="infopaneltitle-for-nodeiterator" style="display:none">Info about the 'NodeIterator' definition.</span><b><a href="#nodeiterator">#nodeiterator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodeiterator">4.2.3. Mutation algorithms</a>
     <li><a href="#ref-for-nodeiterator①">4.5. Interface Document</a> <a href="#ref-for-nodeiterator②">(2)</a>
@@ -19409,88 +19410,88 @@ APIs</a>
     <li><a href="#ref-for-nodeiterator①⑥">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iterator-collection">
-   <b><a href="#iterator-collection">#iterator-collection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iterator-collection" class="dfn-panel" data-for="iterator-collection" id="infopanel-for-iterator-collection" role="dialog">
+   <span id="infopaneltitle-for-iterator-collection" style="display:none">Info about the 'iterator collection' definition.</span><b><a href="#iterator-collection">#iterator-collection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iterator-collection">6.1. Interface NodeIterator</a> <a href="#ref-for-iterator-collection①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nodeiterator-reference">
-   <b><a href="#nodeiterator-reference">#nodeiterator-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nodeiterator-reference" class="dfn-panel" data-for="nodeiterator-reference" id="infopanel-for-nodeiterator-reference" role="dialog">
+   <span id="infopaneltitle-for-nodeiterator-reference" style="display:none">Info about the 'reference' definition.</span><b><a href="#nodeiterator-reference">#nodeiterator-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodeiterator-reference">4.5. Interface Document</a>
     <li><a href="#ref-for-nodeiterator-reference①">6.1. Interface NodeIterator</a> <a href="#ref-for-nodeiterator-reference②">(2)</a> <a href="#ref-for-nodeiterator-reference③">(3)</a> <a href="#ref-for-nodeiterator-reference④">(4)</a> <a href="#ref-for-nodeiterator-reference⑤">(5)</a> <a href="#ref-for-nodeiterator-reference⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nodeiterator-pointer-before-reference">
-   <b><a href="#nodeiterator-pointer-before-reference">#nodeiterator-pointer-before-reference</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nodeiterator-pointer-before-reference" class="dfn-panel" data-for="nodeiterator-pointer-before-reference" id="infopanel-for-nodeiterator-pointer-before-reference" role="dialog">
+   <span id="infopaneltitle-for-nodeiterator-pointer-before-reference" style="display:none">Info about the 'pointer before reference' definition.</span><b><a href="#nodeiterator-pointer-before-reference">#nodeiterator-pointer-before-reference</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodeiterator-pointer-before-reference">4.5. Interface Document</a>
     <li><a href="#ref-for-nodeiterator-pointer-before-reference①">6.1. Interface NodeIterator</a> <a href="#ref-for-nodeiterator-pointer-before-reference②">(2)</a> <a href="#ref-for-nodeiterator-pointer-before-reference③">(3)</a> <a href="#ref-for-nodeiterator-pointer-before-reference④">(4)</a> <a href="#ref-for-nodeiterator-pointer-before-reference⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="nodeiterator-pre-removing-steps">
-   <b><a href="#nodeiterator-pre-removing-steps">#nodeiterator-pre-removing-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-nodeiterator-pre-removing-steps" class="dfn-panel" data-for="nodeiterator-pre-removing-steps" id="infopanel-for-nodeiterator-pre-removing-steps" role="dialog">
+   <span id="infopaneltitle-for-nodeiterator-pre-removing-steps" style="display:none">Info about the 'NodeIterator pre-removing steps' definition.</span><b><a href="#nodeiterator-pre-removing-steps">#nodeiterator-pre-removing-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nodeiterator-pre-removing-steps">4.2.3. Mutation algorithms</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-root">
-   <b><a href="#dom-nodeiterator-root">#dom-nodeiterator-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-root" class="dfn-panel" data-for="dom-nodeiterator-root" id="infopanel-for-dom-nodeiterator-root" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-nodeiterator-root">#dom-nodeiterator-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-root">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-referencenode">
-   <b><a href="#dom-nodeiterator-referencenode">#dom-nodeiterator-referencenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-referencenode" class="dfn-panel" data-for="dom-nodeiterator-referencenode" id="infopanel-for-dom-nodeiterator-referencenode" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-referencenode" style="display:none">Info about the 'referenceNode' definition.</span><b><a href="#dom-nodeiterator-referencenode">#dom-nodeiterator-referencenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-referencenode">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-pointerbeforereferencenode">
-   <b><a href="#dom-nodeiterator-pointerbeforereferencenode">#dom-nodeiterator-pointerbeforereferencenode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-pointerbeforereferencenode" class="dfn-panel" data-for="dom-nodeiterator-pointerbeforereferencenode" id="infopanel-for-dom-nodeiterator-pointerbeforereferencenode" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-pointerbeforereferencenode" style="display:none">Info about the 'pointerBeforeReferenceNode' definition.</span><b><a href="#dom-nodeiterator-pointerbeforereferencenode">#dom-nodeiterator-pointerbeforereferencenode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-pointerbeforereferencenode">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-whattoshow">
-   <b><a href="#dom-nodeiterator-whattoshow">#dom-nodeiterator-whattoshow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-whattoshow" class="dfn-panel" data-for="dom-nodeiterator-whattoshow" id="infopanel-for-dom-nodeiterator-whattoshow" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-whattoshow" style="display:none">Info about the 'whatToShow' definition.</span><b><a href="#dom-nodeiterator-whattoshow">#dom-nodeiterator-whattoshow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-whattoshow">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-filter">
-   <b><a href="#dom-nodeiterator-filter">#dom-nodeiterator-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-filter" class="dfn-panel" data-for="dom-nodeiterator-filter" id="infopanel-for-dom-nodeiterator-filter" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-filter" style="display:none">Info about the 'filter' definition.</span><b><a href="#dom-nodeiterator-filter">#dom-nodeiterator-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-filter">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-nodeiterator-traverse">
-   <b><a href="#concept-nodeiterator-traverse">#concept-nodeiterator-traverse</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-nodeiterator-traverse" class="dfn-panel" data-for="concept-nodeiterator-traverse" id="infopanel-for-concept-nodeiterator-traverse" role="dialog">
+   <span id="infopaneltitle-for-concept-nodeiterator-traverse" style="display:none">Info about the 'traverse' definition.</span><b><a href="#concept-nodeiterator-traverse">#concept-nodeiterator-traverse</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-nodeiterator-traverse">6.1. Interface NodeIterator</a> <a href="#ref-for-concept-nodeiterator-traverse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-nextnode">
-   <b><a href="#dom-nodeiterator-nextnode">#dom-nodeiterator-nextnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-nextnode" class="dfn-panel" data-for="dom-nodeiterator-nextnode" id="infopanel-for-dom-nodeiterator-nextnode" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-nextnode" style="display:none">Info about the 'nextNode()' definition.</span><b><a href="#dom-nodeiterator-nextnode">#dom-nodeiterator-nextnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-nextnode">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-previousnode">
-   <b><a href="#dom-nodeiterator-previousnode">#dom-nodeiterator-previousnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-previousnode" class="dfn-panel" data-for="dom-nodeiterator-previousnode" id="infopanel-for-dom-nodeiterator-previousnode" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-previousnode" style="display:none">Info about the 'previousNode()' definition.</span><b><a href="#dom-nodeiterator-previousnode">#dom-nodeiterator-previousnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-previousnode">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodeiterator-detach">
-   <b><a href="#dom-nodeiterator-detach">#dom-nodeiterator-detach</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodeiterator-detach" class="dfn-panel" data-for="dom-nodeiterator-detach" id="infopanel-for-dom-nodeiterator-detach" role="dialog">
+   <span id="infopaneltitle-for-dom-nodeiterator-detach" style="display:none">Info about the 'detach()' definition.</span><b><a href="#dom-nodeiterator-detach">#dom-nodeiterator-detach</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodeiterator-detach">6.1. Interface NodeIterator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="treewalker">
-   <b><a href="#treewalker">#treewalker</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-treewalker" class="dfn-panel" data-for="treewalker" id="infopanel-for-treewalker" role="dialog">
+   <span id="infopaneltitle-for-treewalker" style="display:none">Info about the 'TreeWalker' definition.</span><b><a href="#treewalker">#treewalker</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-treewalker">4.5. Interface Document</a> <a href="#ref-for-treewalker①">(2)</a>
     <li><a href="#ref-for-treewalker②">6. Traversal</a> <a href="#ref-for-treewalker③">(2)</a> <a href="#ref-for-treewalker④">(3)</a> <a href="#ref-for-treewalker⑤">(4)</a>
@@ -19499,93 +19500,93 @@ APIs</a>
     <li><a href="#ref-for-treewalker①①">9. Historical</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="treewalker-current">
-   <b><a href="#treewalker-current">#treewalker-current</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-treewalker-current" class="dfn-panel" data-for="treewalker-current" id="infopanel-for-treewalker-current" role="dialog">
+   <span id="infopaneltitle-for-treewalker-current" style="display:none">Info about the 'current' definition.</span><b><a href="#treewalker-current">#treewalker-current</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-treewalker-current">4.5. Interface Document</a>
     <li><a href="#ref-for-treewalker-current①">6.2. Interface TreeWalker</a> <a href="#ref-for-treewalker-current②">(2)</a> <a href="#ref-for-treewalker-current③">(3)</a> <a href="#ref-for-treewalker-current④">(4)</a> <a href="#ref-for-treewalker-current⑤">(5)</a> <a href="#ref-for-treewalker-current⑥">(6)</a> <a href="#ref-for-treewalker-current⑦">(7)</a> <a href="#ref-for-treewalker-current⑧">(8)</a> <a href="#ref-for-treewalker-current⑨">(9)</a> <a href="#ref-for-treewalker-current①⓪">(10)</a> <a href="#ref-for-treewalker-current①①">(11)</a> <a href="#ref-for-treewalker-current①②">(12)</a> <a href="#ref-for-treewalker-current①③">(13)</a> <a href="#ref-for-treewalker-current①④">(14)</a> <a href="#ref-for-treewalker-current①⑤">(15)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-root">
-   <b><a href="#dom-treewalker-root">#dom-treewalker-root</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-root" class="dfn-panel" data-for="dom-treewalker-root" id="infopanel-for-dom-treewalker-root" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-root" style="display:none">Info about the 'root' definition.</span><b><a href="#dom-treewalker-root">#dom-treewalker-root</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-root">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-whattoshow">
-   <b><a href="#dom-treewalker-whattoshow">#dom-treewalker-whattoshow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-whattoshow" class="dfn-panel" data-for="dom-treewalker-whattoshow" id="infopanel-for-dom-treewalker-whattoshow" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-whattoshow" style="display:none">Info about the 'whatToShow' definition.</span><b><a href="#dom-treewalker-whattoshow">#dom-treewalker-whattoshow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-whattoshow">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-filter">
-   <b><a href="#dom-treewalker-filter">#dom-treewalker-filter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-filter" class="dfn-panel" data-for="dom-treewalker-filter" id="infopanel-for-dom-treewalker-filter" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-filter" style="display:none">Info about the 'filter' definition.</span><b><a href="#dom-treewalker-filter">#dom-treewalker-filter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-filter">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-currentnode">
-   <b><a href="#dom-treewalker-currentnode">#dom-treewalker-currentnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-currentnode" class="dfn-panel" data-for="dom-treewalker-currentnode" id="infopanel-for-dom-treewalker-currentnode" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-currentnode" style="display:none">Info about the 'currentNode' definition.</span><b><a href="#dom-treewalker-currentnode">#dom-treewalker-currentnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-currentnode">6.2. Interface TreeWalker</a> <a href="#ref-for-dom-treewalker-currentnode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-parentnode">
-   <b><a href="#dom-treewalker-parentnode">#dom-treewalker-parentnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-parentnode" class="dfn-panel" data-for="dom-treewalker-parentnode" id="infopanel-for-dom-treewalker-parentnode" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-parentnode" style="display:none">Info about the 'parentNode()' definition.</span><b><a href="#dom-treewalker-parentnode">#dom-treewalker-parentnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-parentnode">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traverse-children">
-   <b><a href="#concept-traverse-children">#concept-traverse-children</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traverse-children" class="dfn-panel" data-for="concept-traverse-children" id="infopanel-for-concept-traverse-children" role="dialog">
+   <span id="infopaneltitle-for-concept-traverse-children" style="display:none">Info about the 'traverse children' definition.</span><b><a href="#concept-traverse-children">#concept-traverse-children</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traverse-children">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-traverse-children①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-firstchild">
-   <b><a href="#dom-treewalker-firstchild">#dom-treewalker-firstchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-firstchild" class="dfn-panel" data-for="dom-treewalker-firstchild" id="infopanel-for-dom-treewalker-firstchild" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-firstchild" style="display:none">Info about the 'firstChild()' definition.</span><b><a href="#dom-treewalker-firstchild">#dom-treewalker-firstchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-firstchild">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-lastchild">
-   <b><a href="#dom-treewalker-lastchild">#dom-treewalker-lastchild</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-lastchild" class="dfn-panel" data-for="dom-treewalker-lastchild" id="infopanel-for-dom-treewalker-lastchild" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-lastchild" style="display:none">Info about the 'lastChild()' definition.</span><b><a href="#dom-treewalker-lastchild">#dom-treewalker-lastchild</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-lastchild">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-traverse-siblings">
-   <b><a href="#concept-traverse-siblings">#concept-traverse-siblings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-traverse-siblings" class="dfn-panel" data-for="concept-traverse-siblings" id="infopanel-for-concept-traverse-siblings" role="dialog">
+   <span id="infopaneltitle-for-concept-traverse-siblings" style="display:none">Info about the 'traverse siblings' definition.</span><b><a href="#concept-traverse-siblings">#concept-traverse-siblings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-traverse-siblings">6.2. Interface TreeWalker</a> <a href="#ref-for-concept-traverse-siblings①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-nextsibling">
-   <b><a href="#dom-treewalker-nextsibling">#dom-treewalker-nextsibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-nextsibling" class="dfn-panel" data-for="dom-treewalker-nextsibling" id="infopanel-for-dom-treewalker-nextsibling" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-nextsibling" style="display:none">Info about the 'nextSibling()' definition.</span><b><a href="#dom-treewalker-nextsibling">#dom-treewalker-nextsibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-nextsibling">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-previoussibling">
-   <b><a href="#dom-treewalker-previoussibling">#dom-treewalker-previoussibling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-previoussibling" class="dfn-panel" data-for="dom-treewalker-previoussibling" id="infopanel-for-dom-treewalker-previoussibling" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-previoussibling" style="display:none">Info about the 'previousSibling()' definition.</span><b><a href="#dom-treewalker-previoussibling">#dom-treewalker-previoussibling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-previoussibling">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-previousnode">
-   <b><a href="#dom-treewalker-previousnode">#dom-treewalker-previousnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-previousnode" class="dfn-panel" data-for="dom-treewalker-previousnode" id="infopanel-for-dom-treewalker-previousnode" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-previousnode" style="display:none">Info about the 'previousNode()' definition.</span><b><a href="#dom-treewalker-previousnode">#dom-treewalker-previousnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-previousnode">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-treewalker-nextnode">
-   <b><a href="#dom-treewalker-nextnode">#dom-treewalker-nextnode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-treewalker-nextnode" class="dfn-panel" data-for="dom-treewalker-nextnode" id="infopanel-for-dom-treewalker-nextnode" role="dialog">
+   <span id="infopaneltitle-for-dom-treewalker-nextnode" style="display:none">Info about the 'nextNode()' definition.</span><b><a href="#dom-treewalker-nextnode">#dom-treewalker-nextnode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-treewalker-nextnode">6.2. Interface TreeWalker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-nodefilter">
-   <b><a href="#callbackdef-nodefilter">#callbackdef-nodefilter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-nodefilter" class="dfn-panel" data-for="callbackdef-nodefilter" id="infopanel-for-callbackdef-nodefilter" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-nodefilter" style="display:none">Info about the 'NodeFilter' definition.</span><b><a href="#callbackdef-nodefilter">#callbackdef-nodefilter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-nodefilter">4.5. Interface Document</a> <a href="#ref-for-callbackdef-nodefilter①">(2)</a>
     <li><a href="#ref-for-callbackdef-nodefilter②">6.1. Interface NodeIterator</a>
@@ -19593,8 +19594,8 @@ APIs</a>
     <li><a href="#ref-for-callbackdef-nodefilter④">6.3. Interface NodeFilter</a> <a href="#ref-for-callbackdef-nodefilter⑤">(2)</a> <a href="#ref-for-callbackdef-nodefilter⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-filter_accept">
-   <b><a href="#dom-nodefilter-filter_accept">#dom-nodefilter-filter_accept</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-filter_accept" class="dfn-panel" data-for="dom-nodefilter-filter_accept" id="infopanel-for-dom-nodefilter-filter_accept" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-filter_accept" style="display:none">Info about the 'FILTER_ACCEPT' definition.</span><b><a href="#dom-nodefilter-filter_accept">#dom-nodefilter-filter_accept</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-filter_accept">6. Traversal</a>
     <li><a href="#ref-for-dom-nodefilter-filter_accept①">6.1. Interface NodeIterator</a>
@@ -19602,262 +19603,318 @@ APIs</a>
     <li><a href="#ref-for-dom-nodefilter-filter_accept①①">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-filter_reject">
-   <b><a href="#dom-nodefilter-filter_reject">#dom-nodefilter-filter_reject</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-filter_reject" class="dfn-panel" data-for="dom-nodefilter-filter_reject" id="infopanel-for-dom-nodefilter-filter_reject" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-filter_reject" style="display:none">Info about the 'FILTER_REJECT' definition.</span><b><a href="#dom-nodefilter-filter_reject">#dom-nodefilter-filter_reject</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-filter_reject">6.2. Interface TreeWalker</a> <a href="#ref-for-dom-nodefilter-filter_reject①">(2)</a> <a href="#ref-for-dom-nodefilter-filter_reject②">(3)</a>
     <li><a href="#ref-for-dom-nodefilter-filter_reject③">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-filter_skip">
-   <b><a href="#dom-nodefilter-filter_skip">#dom-nodefilter-filter_skip</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-filter_skip" class="dfn-panel" data-for="dom-nodefilter-filter_skip" id="infopanel-for-dom-nodefilter-filter_skip" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-filter_skip" style="display:none">Info about the 'FILTER_SKIP' definition.</span><b><a href="#dom-nodefilter-filter_skip">#dom-nodefilter-filter_skip</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-filter_skip">6. Traversal</a>
     <li><a href="#ref-for-dom-nodefilter-filter_skip①">6.2. Interface TreeWalker</a>
     <li><a href="#ref-for-dom-nodefilter-filter_skip②">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_all">
-   <b><a href="#dom-nodefilter-show_all">#dom-nodefilter-show_all</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_all" class="dfn-panel" data-for="dom-nodefilter-show_all" id="infopanel-for-dom-nodefilter-show_all" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_all" style="display:none">Info about the 'SHOW_ALL' definition.</span><b><a href="#dom-nodefilter-show_all">#dom-nodefilter-show_all</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_all">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_element">
-   <b><a href="#dom-nodefilter-show_element">#dom-nodefilter-show_element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_element" class="dfn-panel" data-for="dom-nodefilter-show_element" id="infopanel-for-dom-nodefilter-show_element" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_element" style="display:none">Info about the 'SHOW_ELEMENT' definition.</span><b><a href="#dom-nodefilter-show_element">#dom-nodefilter-show_element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_element">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_attribute">
-   <b><a href="#dom-nodefilter-show_attribute">#dom-nodefilter-show_attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_attribute" class="dfn-panel" data-for="dom-nodefilter-show_attribute" id="infopanel-for-dom-nodefilter-show_attribute" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_attribute" style="display:none">Info about the 'SHOW_ATTRIBUTE' definition.</span><b><a href="#dom-nodefilter-show_attribute">#dom-nodefilter-show_attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_attribute">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_text">
-   <b><a href="#dom-nodefilter-show_text">#dom-nodefilter-show_text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_text" class="dfn-panel" data-for="dom-nodefilter-show_text" id="infopanel-for-dom-nodefilter-show_text" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_text" style="display:none">Info about the 'SHOW_TEXT' definition.</span><b><a href="#dom-nodefilter-show_text">#dom-nodefilter-show_text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_text">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_cdata_section">
-   <b><a href="#dom-nodefilter-show_cdata_section">#dom-nodefilter-show_cdata_section</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_cdata_section" class="dfn-panel" data-for="dom-nodefilter-show_cdata_section" id="infopanel-for-dom-nodefilter-show_cdata_section" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_cdata_section" style="display:none">Info about the 'SHOW_CDATA_SECTION' definition.</span><b><a href="#dom-nodefilter-show_cdata_section">#dom-nodefilter-show_cdata_section</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_cdata_section">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_processing_instruction">
-   <b><a href="#dom-nodefilter-show_processing_instruction">#dom-nodefilter-show_processing_instruction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_processing_instruction" class="dfn-panel" data-for="dom-nodefilter-show_processing_instruction" id="infopanel-for-dom-nodefilter-show_processing_instruction" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_processing_instruction" style="display:none">Info about the 'SHOW_PROCESSING_INSTRUCTION' definition.</span><b><a href="#dom-nodefilter-show_processing_instruction">#dom-nodefilter-show_processing_instruction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_processing_instruction">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_comment">
-   <b><a href="#dom-nodefilter-show_comment">#dom-nodefilter-show_comment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_comment" class="dfn-panel" data-for="dom-nodefilter-show_comment" id="infopanel-for-dom-nodefilter-show_comment" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_comment" style="display:none">Info about the 'SHOW_COMMENT' definition.</span><b><a href="#dom-nodefilter-show_comment">#dom-nodefilter-show_comment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_comment">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_document">
-   <b><a href="#dom-nodefilter-show_document">#dom-nodefilter-show_document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_document" class="dfn-panel" data-for="dom-nodefilter-show_document" id="infopanel-for-dom-nodefilter-show_document" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_document" style="display:none">Info about the 'SHOW_DOCUMENT' definition.</span><b><a href="#dom-nodefilter-show_document">#dom-nodefilter-show_document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_document">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_document_type">
-   <b><a href="#dom-nodefilter-show_document_type">#dom-nodefilter-show_document_type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_document_type" class="dfn-panel" data-for="dom-nodefilter-show_document_type" id="infopanel-for-dom-nodefilter-show_document_type" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_document_type" style="display:none">Info about the 'SHOW_DOCUMENT_TYPE' definition.</span><b><a href="#dom-nodefilter-show_document_type">#dom-nodefilter-show_document_type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_document_type">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-nodefilter-show_document_fragment">
-   <b><a href="#dom-nodefilter-show_document_fragment">#dom-nodefilter-show_document_fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-nodefilter-show_document_fragment" class="dfn-panel" data-for="dom-nodefilter-show_document_fragment" id="infopanel-for-dom-nodefilter-show_document_fragment" role="dialog">
+   <span id="infopaneltitle-for-dom-nodefilter-show_document_fragment" style="display:none">Info about the 'SHOW_DOCUMENT_FRAGMENT' definition.</span><b><a href="#dom-nodefilter-show_document_fragment">#dom-nodefilter-show_document_fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-nodefilter-show_document_fragment">6.3. Interface NodeFilter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="domtokenlist">
-   <b><a href="#domtokenlist">#domtokenlist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-domtokenlist" class="dfn-panel" data-for="domtokenlist" id="infopanel-for-domtokenlist" role="dialog">
+   <span id="infopaneltitle-for-domtokenlist" style="display:none">Info about the 'DOMTokenList' definition.</span><b><a href="#domtokenlist">#domtokenlist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-domtokenlist">4.9. Interface Element</a> <a href="#ref-for-domtokenlist①">(2)</a> <a href="#ref-for-domtokenlist②">(3)</a> <a href="#ref-for-domtokenlist③">(4)</a>
     <li><a href="#ref-for-domtokenlist④">7. Sets</a>
     <li><a href="#ref-for-domtokenlist⑤">7.1. Interface DOMTokenList</a> <a href="#ref-for-domtokenlist⑥">(2)</a> <a href="#ref-for-domtokenlist⑦">(3)</a> <a href="#ref-for-domtokenlist⑧">(4)</a> <a href="#ref-for-domtokenlist⑨">(5)</a> <a href="#ref-for-domtokenlist①⓪">(6)</a> <a href="#ref-for-domtokenlist①①">(7)</a> <a href="#ref-for-domtokenlist①②">(8)</a> <a href="#ref-for-domtokenlist①③">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-dtl-tokens">
-   <b><a href="#concept-dtl-tokens">#concept-dtl-tokens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-dtl-tokens" class="dfn-panel" data-for="concept-dtl-tokens" id="infopanel-for-concept-dtl-tokens" role="dialog">
+   <span id="infopaneltitle-for-concept-dtl-tokens" style="display:none">Info about the 'token set' definition.</span><b><a href="#concept-dtl-tokens">#concept-dtl-tokens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dtl-tokens">4.9. Interface Element</a>
     <li><a href="#ref-for-concept-dtl-tokens①">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-dtl-tokens②">(2)</a> <a href="#ref-for-concept-dtl-tokens③">(3)</a> <a href="#ref-for-concept-dtl-tokens④">(4)</a> <a href="#ref-for-concept-dtl-tokens⑤">(5)</a> <a href="#ref-for-concept-dtl-tokens⑥">(6)</a> <a href="#ref-for-concept-dtl-tokens⑦">(7)</a> <a href="#ref-for-concept-dtl-tokens⑧">(8)</a> <a href="#ref-for-concept-dtl-tokens⑨">(9)</a> <a href="#ref-for-concept-dtl-tokens①⓪">(10)</a> <a href="#ref-for-concept-dtl-tokens①①">(11)</a> <a href="#ref-for-concept-dtl-tokens①②">(12)</a> <a href="#ref-for-concept-dtl-tokens①③">(13)</a> <a href="#ref-for-concept-dtl-tokens①④">(14)</a> <a href="#ref-for-concept-dtl-tokens①⑤">(15)</a> <a href="#ref-for-concept-dtl-tokens①⑥">(16)</a> <a href="#ref-for-concept-dtl-tokens①⑦">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-supported-tokens">
-   <b><a href="#concept-supported-tokens">#concept-supported-tokens</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-supported-tokens" class="dfn-panel" data-for="concept-supported-tokens" id="infopanel-for-concept-supported-tokens" role="dialog">
+   <span id="infopaneltitle-for-concept-supported-tokens" style="display:none">Info about the 'supported tokens' definition.</span><b><a href="#concept-supported-tokens">#concept-supported-tokens</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-supported-tokens">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-supported-tokens①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-domtokenlist-validation">
-   <b><a href="#concept-domtokenlist-validation">#concept-domtokenlist-validation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-domtokenlist-validation" class="dfn-panel" data-for="concept-domtokenlist-validation" id="infopanel-for-concept-domtokenlist-validation" role="dialog">
+   <span id="infopaneltitle-for-concept-domtokenlist-validation" style="display:none">Info about the 'validation steps' definition.</span><b><a href="#concept-domtokenlist-validation">#concept-domtokenlist-validation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domtokenlist-validation">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-dtl-update">
-   <b><a href="#concept-dtl-update">#concept-dtl-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-dtl-update" class="dfn-panel" data-for="concept-dtl-update" id="infopanel-for-concept-dtl-update" role="dialog">
+   <span id="infopaneltitle-for-concept-dtl-update" style="display:none">Info about the 'update steps' definition.</span><b><a href="#concept-dtl-update">#concept-dtl-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dtl-update">7.1. Interface DOMTokenList</a> <a href="#ref-for-concept-dtl-update①">(2)</a> <a href="#ref-for-concept-dtl-update②">(3)</a> <a href="#ref-for-concept-dtl-update③">(4)</a> <a href="#ref-for-concept-dtl-update④">(5)</a> <a href="#ref-for-concept-dtl-update⑤">(6)</a> <a href="#ref-for-concept-dtl-update⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-dtl-serialize">
-   <b><a href="#concept-dtl-serialize">#concept-dtl-serialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-dtl-serialize" class="dfn-panel" data-for="concept-dtl-serialize" id="infopanel-for-concept-dtl-serialize" role="dialog">
+   <span id="infopaneltitle-for-concept-dtl-serialize" style="display:none">Info about the 'serialize steps' definition.</span><b><a href="#concept-dtl-serialize">#concept-dtl-serialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-dtl-serialize">7.1. Interface DOMTokenList</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-length">
-   <b><a href="#dom-domtokenlist-length">#dom-domtokenlist-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-length" class="dfn-panel" data-for="dom-domtokenlist-length" id="infopanel-for-dom-domtokenlist-length" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-length" style="display:none">Info about the 'length' definition.</span><b><a href="#dom-domtokenlist-length">#dom-domtokenlist-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-length">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-item">
-   <b><a href="#dom-domtokenlist-item">#dom-domtokenlist-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-item" class="dfn-panel" data-for="dom-domtokenlist-item" id="infopanel-for-dom-domtokenlist-item" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-item" style="display:none">Info about the 'item(index)' definition.</span><b><a href="#dom-domtokenlist-item">#dom-domtokenlist-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-item">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-item①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-contains">
-   <b><a href="#dom-domtokenlist-contains">#dom-domtokenlist-contains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-contains" class="dfn-panel" data-for="dom-domtokenlist-contains" id="infopanel-for-dom-domtokenlist-contains" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-contains" style="display:none">Info about the 'contains(token)' definition.</span><b><a href="#dom-domtokenlist-contains">#dom-domtokenlist-contains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-contains">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-contains①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-add">
-   <b><a href="#dom-domtokenlist-add">#dom-domtokenlist-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-add" class="dfn-panel" data-for="dom-domtokenlist-add" id="infopanel-for-dom-domtokenlist-add" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-add" style="display:none">Info about the 'add(tokens…)' definition.</span><b><a href="#dom-domtokenlist-add">#dom-domtokenlist-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-add">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-add①">(2)</a> <a href="#ref-for-dom-domtokenlist-add②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-remove">
-   <b><a href="#dom-domtokenlist-remove">#dom-domtokenlist-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-remove" class="dfn-panel" data-for="dom-domtokenlist-remove" id="infopanel-for-dom-domtokenlist-remove" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-remove" style="display:none">Info about the 'remove(tokens…)' definition.</span><b><a href="#dom-domtokenlist-remove">#dom-domtokenlist-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-remove">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-remove①">(2)</a> <a href="#ref-for-dom-domtokenlist-remove②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-toggle">
-   <b><a href="#dom-domtokenlist-toggle">#dom-domtokenlist-toggle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-toggle" class="dfn-panel" data-for="dom-domtokenlist-toggle" id="infopanel-for-dom-domtokenlist-toggle" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-toggle" style="display:none">Info about the 'toggle(token, force)' definition.</span><b><a href="#dom-domtokenlist-toggle">#dom-domtokenlist-toggle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-toggle">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-toggle①">(2)</a> <a href="#ref-for-dom-domtokenlist-toggle②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-replace">
-   <b><a href="#dom-domtokenlist-replace">#dom-domtokenlist-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-replace" class="dfn-panel" data-for="dom-domtokenlist-replace" id="infopanel-for-dom-domtokenlist-replace" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-replace" style="display:none">Info about the 'replace(token, newToken)' definition.</span><b><a href="#dom-domtokenlist-replace">#dom-domtokenlist-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-replace">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-replace①">(2)</a> <a href="#ref-for-dom-domtokenlist-replace②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-supports">
-   <b><a href="#dom-domtokenlist-supports">#dom-domtokenlist-supports</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-supports" class="dfn-panel" data-for="dom-domtokenlist-supports" id="infopanel-for-dom-domtokenlist-supports" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-supports" style="display:none">Info about the 'supports(token)' definition.</span><b><a href="#dom-domtokenlist-supports">#dom-domtokenlist-supports</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-supports">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-supports①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-domtokenlist-value">
-   <b><a href="#dom-domtokenlist-value">#dom-domtokenlist-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-domtokenlist-value" class="dfn-panel" data-for="dom-domtokenlist-value" id="infopanel-for-dom-domtokenlist-value" role="dialog">
+   <span id="infopaneltitle-for-dom-domtokenlist-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-domtokenlist-value">#dom-domtokenlist-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domtokenlist-value">4.9. Interface Element</a>
     <li><a href="#ref-for-dom-domtokenlist-value①">7.1. Interface DOMTokenList</a> <a href="#ref-for-dom-domtokenlist-value②">(2)</a> <a href="#ref-for-dom-domtokenlist-value③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xpathresult">
-   <b><a href="#xpathresult">#xpathresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xpathresult" class="dfn-panel" data-for="xpathresult" id="infopanel-for-xpathresult" role="dialog">
+   <span id="infopaneltitle-for-xpathresult" style="display:none">Info about the 'XPathResult' definition.</span><b><a href="#xpathresult">#xpathresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xpathresult">8.1. Interface XPathResult</a>
     <li><a href="#ref-for-xpathresult①">8.2. Interface XPathExpression</a> <a href="#ref-for-xpathresult②">(2)</a>
     <li><a href="#ref-for-xpathresult③">8.3. Mixin XPathEvaluatorBase</a> <a href="#ref-for-xpathresult④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xpathexpression">
-   <b><a href="#xpathexpression">#xpathexpression</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xpathexpression" class="dfn-panel" data-for="xpathexpression" id="infopanel-for-xpathexpression" role="dialog">
+   <span id="infopaneltitle-for-xpathexpression" style="display:none">Info about the 'XPathExpression' definition.</span><b><a href="#xpathexpression">#xpathexpression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xpathexpression">8.2. Interface XPathExpression</a>
     <li><a href="#ref-for-xpathexpression①">8.3. Mixin XPathEvaluatorBase</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-xpathnsresolver">
-   <b><a href="#callbackdef-xpathnsresolver">#callbackdef-xpathnsresolver</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-xpathnsresolver" class="dfn-panel" data-for="callbackdef-xpathnsresolver" id="infopanel-for-callbackdef-xpathnsresolver" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-xpathnsresolver" style="display:none">Info about the 'XPathNSResolver' definition.</span><b><a href="#callbackdef-xpathnsresolver">#callbackdef-xpathnsresolver</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-xpathnsresolver">8.3. Mixin XPathEvaluatorBase</a> <a href="#ref-for-callbackdef-xpathnsresolver①">(2)</a> <a href="#ref-for-callbackdef-xpathnsresolver②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xpathevaluatorbase">
-   <b><a href="#xpathevaluatorbase">#xpathevaluatorbase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xpathevaluatorbase" class="dfn-panel" data-for="xpathevaluatorbase" id="infopanel-for-xpathevaluatorbase" role="dialog">
+   <span id="infopaneltitle-for-xpathevaluatorbase" style="display:none">Info about the 'XPathEvaluatorBase' definition.</span><b><a href="#xpathevaluatorbase">#xpathevaluatorbase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xpathevaluatorbase">8.3. Mixin XPathEvaluatorBase</a> <a href="#ref-for-xpathevaluatorbase①">(2)</a>
     <li><a href="#ref-for-xpathevaluatorbase②">8.4. Interface XPathEvaluator</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xpathevaluator">
-   <b><a href="#xpathevaluator">#xpathevaluator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xpathevaluator" class="dfn-panel" data-for="xpathevaluator" id="infopanel-for-xpathevaluator" role="dialog">
+   <span id="infopaneltitle-for-xpathevaluator" style="display:none">Info about the 'XPathEvaluator' definition.</span><b><a href="#xpathevaluator">#xpathevaluator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xpathevaluator">8.4. Interface XPathEvaluator</a> <a href="#ref-for-xpathevaluator①">(2)</a> <a href="#ref-for-xpathevaluator②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/encoding/encoding.html
+++ b/tests/github/whatwg/encoding/encoding.html
@@ -3665,41 +3665,41 @@ if ("serviceWorker" in navigator) {
    <li><a href="#x-user-defined-decoder">x-user-defined decoder</a><span>, in § 14.5</span>
    <li><a href="#x-user-defined-encoder">x-user-defined encoder</a><span>, in § 14.5.1</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. Terminology</a>
     <li><a href="#ref-for-in-parallel①">6. Hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-def_code_unit">
-   <a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-def_code_unit" class="dfn-panel" data-for="term-for-def_code_unit" id="infopanel-for-term-for-def_code_unit" role="menu">
+   <span id="infopaneltitle-for-term-for-def_code_unit" style="display:none">Info about the 'code units' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#def_code_unit">https://w3c.github.io/i18n-glossary/#def_code_unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-def_code_unit">7.4. Interface TextEncoder</a>
     <li><a href="#ref-for-def_code_unit①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-surrogate">
-   <a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-surrogate" class="dfn-panel" data-for="term-for-dfn-surrogate" id="infopanel-for-term-for-dfn-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-surrogate" style="display:none">Info about the 'surrogates' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-surrogate">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-dfn-surrogate①">6. Hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3. Terminology</a> <a href="#ref-for-list-append①">(2)</a> <a href="#ref-for-list-append②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-byte">
-   <a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-byte" class="dfn-panel" data-for="term-for-ascii-byte" id="infopanel-for-term-for-ascii-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-byte" style="display:none">Info about the 'ascii byte' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-byte">2. Security background</a>
     <li><a href="#ref-for-ascii-byte①">9.1. single-byte decoder</a>
@@ -3712,14 +3712,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ascii-byte①③">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.2. Names and labels</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-code-point">
-   <a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-code-point" class="dfn-panel" data-for="term-for-ascii-code-point" id="infopanel-for-term-for-ascii-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-code-point" style="display:none">Info about the 'ascii code point' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-code-point">2. Security background</a>
     <li><a href="#ref-for-ascii-code-point①">8.1.2. UTF-8 encoder</a>
@@ -3733,279 +3733,279 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ascii-code-point①②">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.2. Names and labels</a>
     <li><a href="#ref-for-ascii-lowercase①">7.1. Interface mixin TextDecoderCommon</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3. Terminology</a>
     <li><a href="#ref-for-iteration-break①">7.4. Interface TextEncoder</a> <a href="#ref-for-iteration-break②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte">
-   <a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte" class="dfn-panel" data-for="term-for-byte" id="infopanel-for-term-for-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">3. Terminology</a>
     <li><a href="#ref-for-byte①">4. Encodings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3. Terminology</a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">4.1. Encoders and decoders</a> <a href="#ref-for-code-point①">(2)</a>
     <li><a href="#ref-for-code-point②">6.1. Legacy hooks for standards</a> <a href="#ref-for-code-point③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-unit">
-   <a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-unit" class="dfn-panel" data-for="term-for-code-unit" id="infopanel-for-term-for-code-unit" role="menu">
+   <span id="infopaneltitle-for-term-for-code-unit" style="display:none">Info about the 'code unit' external reference.</span><a href="https://infra.spec.whatwg.org/#code-unit">https://infra.spec.whatwg.org/#code-unit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">3. Terminology</a> <a href="#ref-for-list-contain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">7.1. Interface mixin TextDecoderCommon</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-insert">
-   <a href="https://infra.spec.whatwg.org/#list-insert">https://infra.spec.whatwg.org/#list-insert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-insert" class="dfn-panel" data-for="term-for-list-insert" id="infopanel-for-term-for-list-insert" role="menu">
+   <span id="infopaneltitle-for-term-for-list-insert" style="display:none">Info about the 'insert' external reference.</span><a href="https://infra.spec.whatwg.org/#list-insert">https://infra.spec.whatwg.org/#list-insert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-insert">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">3. Terminology</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a> <a href="#ref-for-list-item③">(4)</a> <a href="#ref-for-list-item④">(5)</a> <a href="#ref-for-list-item⑤">(6)</a> <a href="#ref-for-list-item⑥">(7)</a> <a href="#ref-for-list-item⑦">(8)</a> <a href="#ref-for-list-item⑧">(9)</a> <a href="#ref-for-list-item⑨">(10)</a> <a href="#ref-for-list-item①⓪">(11)</a> <a href="#ref-for-list-item①①">(12)</a> <a href="#ref-for-list-item①②">(13)</a>
     <li><a href="#ref-for-list-item①③">4.1. Encoders and decoders</a> <a href="#ref-for-list-item①④">(2)</a> <a href="#ref-for-list-item①⑤">(3)</a> <a href="#ref-for-list-item①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">7.4. Interface TextEncoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3. Terminology</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a> <a href="#ref-for-list③">(4)</a> <a href="#ref-for-list④">(5)</a> <a href="#ref-for-list⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-prepend">
-   <a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-prepend" class="dfn-panel" data-for="term-for-list-prepend" id="infopanel-for-term-for-list-prepend" role="menu">
+   <span id="infopaneltitle-for-term-for-list-prepend" style="display:none">Info about the 'prepend' external reference.</span><a href="https://infra.spec.whatwg.org/#list-prepend">https://infra.spec.whatwg.org/#list-prepend</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue">
-   <a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue" class="dfn-panel" data-for="term-for-queue" id="infopanel-for-term-for-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-queue" style="display:none">Info about the 'queue' external reference.</span><a href="https://infra.spec.whatwg.org/#queue">https://infra.spec.whatwg.org/#queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">3. Terminology</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value">
-   <a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value" class="dfn-panel" data-for="term-for-scalar-value" id="infopanel-for-term-for-scalar-value" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value" style="display:none">Info about the 'scalar value' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value">https://infra.spec.whatwg.org/#scalar-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value">3. Terminology</a>
     <li><a href="#ref-for-scalar-value①">4. Encodings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value-string">
-   <a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value-string" class="dfn-panel" data-for="term-for-scalar-value-string" id="infopanel-for-term-for-scalar-value-string" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value-string" style="display:none">Info about the 'scalar value string' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3. Terminology</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-starts-with">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-starts-with">https://infra.spec.whatwg.org/#byte-sequence-starts-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-starts-with" class="dfn-panel" data-for="term-for-byte-sequence-starts-with" id="infopanel-for-term-for-byte-sequence-starts-with" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-starts-with" style="display:none">Info about the 'starts with' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-starts-with">https://infra.spec.whatwg.org/#byte-sequence-starts-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-starts-with">6.1. Legacy hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3. Terminology</a> <a href="#ref-for-string①">(2)</a>
     <li><a href="#ref-for-string②">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-surrogate">
-   <a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-surrogate" class="dfn-panel" data-for="term-for-surrogate" id="infopanel-for-term-for-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-surrogate" style="display:none">Info about the 'surrogate' external reference.</span><a href="https://infra.spec.whatwg.org/#surrogate">https://infra.spec.whatwg.org/#surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrogate">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-surrogate①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-range">
-   <a href="https://infra.spec.whatwg.org/#the-range">https://infra.spec.whatwg.org/#the-range</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-range" class="dfn-panel" data-for="term-for-the-range" id="infopanel-for-term-for-the-range" role="menu">
+   <span id="infopaneltitle-for-term-for-the-range" style="display:none">Info about the 'the range' external reference.</span><a href="https://infra.spec.whatwg.org/#the-range">https://infra.spec.whatwg.org/#the-range</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-range">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point-value">
-   <a href="https://infra.spec.whatwg.org/#code-point-value">https://infra.spec.whatwg.org/#code-point-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point-value" class="dfn-panel" data-for="term-for-code-point-value" id="infopanel-for-term-for-code-point-value" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point-value">https://infra.spec.whatwg.org/#code-point-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point-value">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-code-point-value①">6.1. Legacy hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generictransformstream">
-   <a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generictransformstream" class="dfn-panel" data-for="term-for-generictransformstream" id="infopanel-for-term-for-generictransformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-generictransformstream" style="display:none">Info about the 'GenericTransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#generictransformstream">https://streams.spec.whatwg.org/#generictransformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-generictransformstream①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">7.5. Interface TextDecoderStream</a> <a href="#ref-for-readablestream①">(2)</a>
     <li><a href="#ref-for-readablestream②">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream">
-   <a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream" class="dfn-panel" data-for="term-for-transformstream" id="infopanel-for-term-for-transformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream" style="display:none">Info about the 'TransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-transformstream①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-chunk">
-   <a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-chunk" class="dfn-panel" data-for="term-for-chunk" id="infopanel-for-term-for-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-chunk" style="display:none">Info about the 'chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-chunk①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#transformstream-enqueue">https://streams.spec.whatwg.org/#transformstream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-enqueue" class="dfn-panel" data-for="term-for-transformstream-enqueue" id="infopanel-for-term-for-transformstream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-enqueue">https://streams.spec.whatwg.org/#transformstream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-enqueue">7.5. Interface TextDecoderStream</a> <a href="#ref-for-transformstream-enqueue①">(2)</a>
     <li><a href="#ref-for-transformstream-enqueue②">7.6. Interface TextEncoderStream</a> <a href="#ref-for-transformstream-enqueue③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rs-pipe-through">
-   <a href="https://streams.spec.whatwg.org/#rs-pipe-through">https://streams.spec.whatwg.org/#rs-pipe-through</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rs-pipe-through" class="dfn-panel" data-for="term-for-rs-pipe-through" id="infopanel-for-term-for-rs-pipe-through" role="menu">
+   <span id="infopaneltitle-for-term-for-rs-pipe-through" style="display:none">Info about the 'pipeThrough(transform)' external reference.</span><a href="https://streams.spec.whatwg.org/#rs-pipe-through">https://streams.spec.whatwg.org/#rs-pipe-through</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipe-through">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-rs-pipe-through①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-generictransformstream-readable">
-   <a href="https://streams.spec.whatwg.org/#dom-generictransformstream-readable">https://streams.spec.whatwg.org/#dom-generictransformstream-readable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-generictransformstream-readable" class="dfn-panel" data-for="term-for-dom-generictransformstream-readable" id="infopanel-for-term-for-dom-generictransformstream-readable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-generictransformstream-readable" style="display:none">Info about the 'readable' external reference.</span><a href="https://streams.spec.whatwg.org/#dom-generictransformstream-readable">https://streams.spec.whatwg.org/#dom-generictransformstream-readable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-generictransformstream-readable">7.5. Interface TextDecoderStream</a> <a href="#ref-for-dom-generictransformstream-readable①">(2)</a> <a href="#ref-for-dom-generictransformstream-readable②">(3)</a>
     <li><a href="#ref-for-dom-generictransformstream-readable③">7.6. Interface TextEncoderStream</a> <a href="#ref-for-dom-generictransformstream-readable④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readable-stream">
-   <a href="https://streams.spec.whatwg.org/#readable-stream">https://streams.spec.whatwg.org/#readable-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readable-stream" class="dfn-panel" data-for="term-for-readable-stream" id="infopanel-for-term-for-readable-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-readable-stream" style="display:none">Info about the 'readable stream' external reference.</span><a href="https://streams.spec.whatwg.org/#readable-stream">https://streams.spec.whatwg.org/#readable-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-readable-stream①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-generictransformstream-transform">
-   <a href="https://streams.spec.whatwg.org/#generictransformstream-transform">https://streams.spec.whatwg.org/#generictransformstream-transform</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-generictransformstream-transform" class="dfn-panel" data-for="term-for-generictransformstream-transform" id="infopanel-for-term-for-generictransformstream-transform" role="menu">
+   <span id="infopaneltitle-for-term-for-generictransformstream-transform" style="display:none">Info about the 'transform' external reference.</span><a href="https://streams.spec.whatwg.org/#generictransformstream-transform">https://streams.spec.whatwg.org/#generictransformstream-transform</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream-transform">7.5. Interface TextDecoderStream</a> <a href="#ref-for-generictransformstream-transform①">(2)</a> <a href="#ref-for-generictransformstream-transform②">(3)</a>
     <li><a href="#ref-for-generictransformstream-transform③">7.6. Interface TextEncoderStream</a> <a href="#ref-for-generictransformstream-transform④">(2)</a> <a href="#ref-for-generictransformstream-transform⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-generictransformstream-writable">
-   <a href="https://streams.spec.whatwg.org/#dom-generictransformstream-writable">https://streams.spec.whatwg.org/#dom-generictransformstream-writable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-generictransformstream-writable" class="dfn-panel" data-for="term-for-dom-generictransformstream-writable" id="infopanel-for-term-for-dom-generictransformstream-writable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-generictransformstream-writable" style="display:none">Info about the 'writable' external reference.</span><a href="https://streams.spec.whatwg.org/#dom-generictransformstream-writable">https://streams.spec.whatwg.org/#dom-generictransformstream-writable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-generictransformstream-writable">7.5. Interface TextDecoderStream</a> <a href="#ref-for-dom-generictransformstream-writable①">(2)</a> <a href="#ref-for-dom-generictransformstream-writable②">(3)</a>
     <li><a href="#ref-for-dom-generictransformstream-writable③">7.6. Interface TextEncoderStream</a> <a href="#ref-for-dom-generictransformstream-writable④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-writable-stream">
-   <a href="https://streams.spec.whatwg.org/#writable-stream">https://streams.spec.whatwg.org/#writable-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-writable-stream" class="dfn-panel" data-for="term-for-writable-stream" id="infopanel-for-term-for-writable-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-writable-stream" style="display:none">Info about the 'writable stream' external reference.</span><a href="https://streams.spec.whatwg.org/#writable-stream">https://streams.spec.whatwg.org/#writable-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-writable-stream①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-AllowShared">
-   <a href="https://webidl.spec.whatwg.org/#AllowShared">https://webidl.spec.whatwg.org/#AllowShared</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-AllowShared" class="dfn-panel" data-for="term-for-AllowShared" id="infopanel-for-term-for-AllowShared" role="menu">
+   <span id="infopaneltitle-for-term-for-AllowShared" style="display:none">Info about the 'AllowShared' external reference.</span><a href="https://webidl.spec.whatwg.org/#AllowShared">https://webidl.spec.whatwg.org/#AllowShared</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-AllowShared">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-AllowShared①">7.4. Interface TextEncoder</a>
     <li><a href="#ref-for-AllowShared②">7.5. Interface TextDecoderStream</a> <a href="#ref-for-AllowShared③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">7. API</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a>
     <li><a href="#ref-for-idl-ArrayBuffer②">7.4. Interface TextEncoder</a> <a href="#ref-for-idl-ArrayBuffer③">(2)</a>
     <li><a href="#ref-for-idl-ArrayBuffer④">7.6. Interface TextEncoderStream</a> <a href="#ref-for-idl-ArrayBuffer⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-BufferSource①">7.5. Interface TextDecoderStream</a> <a href="#ref-for-BufferSource②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-idl-DOMString①">7.2. Interface TextDecoder</a>
@@ -4014,8 +4014,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-DOMString④">7.6. Interface TextEncoderStream</a> <a href="#ref-for-idl-DOMString⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-Exposed①">7.4. Interface TextEncoder</a>
@@ -4023,71 +4023,71 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-Exposed③">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">7.4. Interface TextEncoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">7.2. Interface TextDecoder</a> <a href="#ref-for-exceptiondef-rangeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-rangeerror②">7.5. Interface TextDecoderStream</a> <a href="#ref-for-exceptiondef-rangeerror③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">7.2. Interface TextDecoder</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a>
     <li><a href="#ref-for-exceptiondef-typeerror②">7.5. Interface TextDecoderStream</a> <a href="#ref-for-exceptiondef-typeerror③">(2)</a> <a href="#ref-for-exceptiondef-typeerror④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-idl-USVString①">7.4. Interface TextEncoder</a> <a href="#ref-for-idl-USVString②">(2)</a>
     <li><a href="#ref-for-idl-USVString③">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint32Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint32Array">https://webidl.spec.whatwg.org/#idl-Uint32Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint32Array" class="dfn-panel" data-for="term-for-idl-Uint32Array" id="infopanel-for-term-for-idl-Uint32Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint32Array" style="display:none">Info about the 'Uint32Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint32Array">https://webidl.spec.whatwg.org/#idl-Uint32Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint32Array">7. API</a> <a href="#ref-for-idl-Uint32Array①">(2)</a> <a href="#ref-for-idl-Uint32Array②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">7. API</a>
     <li><a href="#ref-for-idl-Uint8Array①">7.4. Interface TextEncoder</a> <a href="#ref-for-idl-Uint8Array②">(2)</a> <a href="#ref-for-idl-Uint8Array③">(3)</a>
     <li><a href="#ref-for-idl-Uint8Array④">7.6. Interface TextEncoderStream</a> <a href="#ref-for-idl-Uint8Array⑤">(2)</a> <a href="#ref-for-idl-Uint8Array⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">7.2. Interface TextDecoder</a> <a href="#ref-for-idl-boolean③">(2)</a> <a href="#ref-for-idl-boolean④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">7.5. Interface TextDecoderStream</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dfn-get-buffer-source-copy①">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a>
     <li><a href="#ref-for-this③">7.2. Interface TextDecoder</a> <a href="#ref-for-this④">(2)</a> <a href="#ref-for-this⑤">(3)</a> <a href="#ref-for-this⑥">(4)</a> <a href="#ref-for-this⑦">(5)</a> <a href="#ref-for-this⑧">(6)</a> <a href="#ref-for-this⑨">(7)</a> <a href="#ref-for-this①⓪">(8)</a> <a href="#ref-for-this①①">(9)</a> <a href="#ref-for-this①②">(10)</a> <a href="#ref-for-this①③">(11)</a> <a href="#ref-for-this①④">(12)</a> <a href="#ref-for-this①⑤">(13)</a> <a href="#ref-for-this①⑥">(14)</a> <a href="#ref-for-this①⑦">(15)</a> <a href="#ref-for-this①⑧">(16)</a> <a href="#ref-for-this①⑨">(17)</a> <a href="#ref-for-this②⓪">(18)</a> <a href="#ref-for-this②①">(19)</a>
@@ -4095,15 +4095,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-this③①">7.6. Interface TextEncoderStream</a> <a href="#ref-for-this③②">(2)</a> <a href="#ref-for-this③③">(3)</a> <a href="#ref-for-this③④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">7.2. Interface TextDecoder</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a>
     <li><a href="#ref-for-dfn-throw④">7.5. Interface TextDecoderStream</a> <a href="#ref-for-dfn-throw⑤">(2)</a> <a href="#ref-for-dfn-throw⑥">(3)</a> <a href="#ref-for-dfn-throw⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">7.4. Interface TextEncoder</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a>
    </ul>
@@ -4274,8 +4274,8 @@ if ("serviceWorker" in navigator) {
 <a data-link-type="idl-name" href="#textencoderstream"><c- n>TextEncoderStream</c-></a> <c- b>includes</c-> <a data-link-type="idl-name" href="https://streams.spec.whatwg.org/#generictransformstream"><c- n>GenericTransformStream</c-></a>;
 
 </pre>
-  <aside class="dfn-panel" data-for="concept-stream">
-   <b><a href="#concept-stream">#concept-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stream" class="dfn-panel" data-for="concept-stream" id="infopanel-for-concept-stream" role="dialog">
+   <span id="infopaneltitle-for-concept-stream" style="display:none">Info about the 'I/O queue' definition.</span><b><a href="#concept-stream">#concept-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stream">3. Terminology</a> <a href="#ref-for-concept-stream①">(2)</a> <a href="#ref-for-concept-stream②">(3)</a> <a href="#ref-for-concept-stream③">(4)</a> <a href="#ref-for-concept-stream④">(5)</a> <a href="#ref-for-concept-stream⑤">(6)</a> <a href="#ref-for-concept-stream⑥">(7)</a> <a href="#ref-for-concept-stream⑦">(8)</a> <a href="#ref-for-concept-stream⑧">(9)</a> <a href="#ref-for-concept-stream⑨">(10)</a> <a href="#ref-for-concept-stream①⓪">(11)</a> <a href="#ref-for-concept-stream①①">(12)</a> <a href="#ref-for-concept-stream①②">(13)</a> <a href="#ref-for-concept-stream①③">(14)</a>
     <li><a href="#ref-for-concept-stream①④">4.1. Encoders and decoders</a> <a href="#ref-for-concept-stream①⑤">(2)</a> <a href="#ref-for-concept-stream①⑥">(3)</a> <a href="#ref-for-concept-stream①⑦">(4)</a> <a href="#ref-for-concept-stream①⑧">(5)</a>
@@ -4287,8 +4287,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-stream③④">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="end-of-stream">
-   <b><a href="#end-of-stream">#end-of-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-end-of-stream" class="dfn-panel" data-for="end-of-stream" id="infopanel-for-end-of-stream" role="dialog">
+   <span id="infopaneltitle-for-end-of-stream" style="display:none">Info about the 'End-of-queue' definition.</span><b><a href="#end-of-stream">#end-of-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-of-stream">2. Security background</a>
     <li><a href="#ref-for-end-of-stream①">3. Terminology</a> <a href="#ref-for-end-of-stream②">(2)</a> <a href="#ref-for-end-of-stream③">(3)</a> <a href="#ref-for-end-of-stream④">(4)</a> <a href="#ref-for-end-of-stream⑤">(5)</a> <a href="#ref-for-end-of-stream⑥">(6)</a> <a href="#ref-for-end-of-stream⑦">(7)</a> <a href="#ref-for-end-of-stream⑧">(8)</a> <a href="#ref-for-end-of-stream⑨">(9)</a> <a href="#ref-for-end-of-stream①⓪">(10)</a> <a href="#ref-for-end-of-stream①①">(11)</a> <a href="#ref-for-end-of-stream①②">(12)</a> <a href="#ref-for-end-of-stream①③">(13)</a>
@@ -4322,8 +4322,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-end-of-stream⑥①">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-stream-read">
-   <b><a href="#concept-stream-read">#concept-stream-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stream-read" class="dfn-panel" data-for="concept-stream-read" id="infopanel-for-concept-stream-read" role="dialog">
+   <span id="infopaneltitle-for-concept-stream-read" style="display:none">Info about the 'read' definition.</span><b><a href="#concept-stream-read">#concept-stream-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stream-read">3. Terminology</a> <a href="#ref-for-concept-stream-read①">(2)</a> <a href="#ref-for-concept-stream-read②">(3)</a> <a href="#ref-for-concept-stream-read③">(4)</a>
     <li><a href="#ref-for-concept-stream-read④">4.1. Encoders and decoders</a>
@@ -4336,15 +4336,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-stream-read①③">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="i-o-queue-peek">
-   <b><a href="#i-o-queue-peek">#i-o-queue-peek</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-i-o-queue-peek" class="dfn-panel" data-for="i-o-queue-peek" id="infopanel-for-i-o-queue-peek" role="dialog">
+   <span id="infopaneltitle-for-i-o-queue-peek" style="display:none">Info about the 'peek' definition.</span><b><a href="#i-o-queue-peek">#i-o-queue-peek</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-i-o-queue-peek">6. Hooks for standards</a>
     <li><a href="#ref-for-i-o-queue-peek①">6.1. Legacy hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-stream-push">
-   <b><a href="#concept-stream-push">#concept-stream-push</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stream-push" class="dfn-panel" data-for="concept-stream-push" id="infopanel-for-concept-stream-push" role="dialog">
+   <span id="infopaneltitle-for-concept-stream-push" style="display:none">Info about the 'push' definition.</span><b><a href="#concept-stream-push">#concept-stream-push</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stream-push">3. Terminology</a> <a href="#ref-for-concept-stream-push①">(2)</a> <a href="#ref-for-concept-stream-push②">(3)</a>
     <li><a href="#ref-for-concept-stream-push③">4.1. Encoders and decoders</a> <a href="#ref-for-concept-stream-push④">(2)</a> <a href="#ref-for-concept-stream-push⑤">(3)</a> <a href="#ref-for-concept-stream-push⑥">(4)</a>
@@ -4353,8 +4353,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-stream-push⑨">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-stream-prepend">
-   <b><a href="#concept-stream-prepend">#concept-stream-prepend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stream-prepend" class="dfn-panel" data-for="concept-stream-prepend" id="infopanel-for-concept-stream-prepend" role="dialog">
+   <span id="infopaneltitle-for-concept-stream-prepend" style="display:none">Info about the 'prepend' definition.</span><b><a href="#concept-stream-prepend">#concept-stream-prepend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stream-prepend">3. Terminology</a>
     <li><a href="#ref-for-concept-stream-prepend①">7.6. Interface TextEncoderStream</a>
@@ -4370,22 +4370,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-stream-prepend①⑨">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="from-i-o-queue-convert">
-   <b><a href="#from-i-o-queue-convert">#from-i-o-queue-convert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-from-i-o-queue-convert" class="dfn-panel" data-for="from-i-o-queue-convert" id="infopanel-for-from-i-o-queue-convert" role="dialog">
+   <span id="infopaneltitle-for-from-i-o-queue-convert" style="display:none">Info about the 'convert' definition.</span><b><a href="#from-i-o-queue-convert">#from-i-o-queue-convert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-from-i-o-queue-convert">7.4. Interface TextEncoder</a>
     <li><a href="#ref-for-from-i-o-queue-convert①">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="to-i-o-queue-convert">
-   <b><a href="#to-i-o-queue-convert">#to-i-o-queue-convert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-to-i-o-queue-convert" class="dfn-panel" data-for="to-i-o-queue-convert" id="infopanel-for-to-i-o-queue-convert" role="dialog">
+   <span id="infopaneltitle-for-to-i-o-queue-convert" style="display:none">Info about the 'convert' definition.</span><b><a href="#to-i-o-queue-convert">#to-i-o-queue-convert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-to-i-o-queue-convert">7.4. Interface TextEncoder</a> <a href="#ref-for-to-i-o-queue-convert①">(2)</a>
     <li><a href="#ref-for-to-i-o-queue-convert②">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encoding">
-   <b><a href="#encoding">#encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encoding" class="dfn-panel" data-for="encoding" id="infopanel-for-encoding" role="dialog">
+   <span id="infopaneltitle-for-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#encoding">#encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encoding">4. Encodings</a> <a href="#ref-for-encoding①">(2)</a> <a href="#ref-for-encoding②">(3)</a> <a href="#ref-for-encoding③">(4)</a>
     <li><a href="#ref-for-encoding④">4.1. Encoders and decoders</a> <a href="#ref-for-encoding⑤">(2)</a> <a href="#ref-for-encoding⑥">(3)</a> <a href="#ref-for-encoding⑦">(4)</a> <a href="#ref-for-encoding⑧">(5)</a>
@@ -4399,22 +4399,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-encoding③①">Implementation considerations</a> <a href="#ref-for-encoding③②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="name">
-   <b><a href="#name">#name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-name" class="dfn-panel" data-for="name" id="infopanel-for-name" role="dialog">
+   <span id="infopaneltitle-for-name" style="display:none">Info about the 'name' definition.</span><b><a href="#name">#name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-name">4.2. Names and labels</a>
     <li><a href="#ref-for-name①">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-name②">9. Legacy single-byte encodings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="label">
-   <b><a href="#label">#label</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-label" class="dfn-panel" data-for="label" id="infopanel-for-label" role="dialog">
+   <span id="infopaneltitle-for-label" style="display:none">Info about the 'labels' definition.</span><b><a href="#label">#label</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-label">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decoder">
-   <b><a href="#decoder">#decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decoder" class="dfn-panel" data-for="decoder" id="infopanel-for-decoder" role="dialog">
+   <span id="infopaneltitle-for-decoder" style="display:none">Info about the 'decoder' definition.</span><b><a href="#decoder">#decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decoder">4.1. Encoders and decoders</a> <a href="#ref-for-decoder①">(2)</a> <a href="#ref-for-decoder②">(3)</a> <a href="#ref-for-decoder③">(4)</a> <a href="#ref-for-decoder④">(5)</a> <a href="#ref-for-decoder⑤">(6)</a>
     <li><a href="#ref-for-decoder⑥">5. Indexes</a>
@@ -4441,8 +4441,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-decoder④③">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encoder">
-   <b><a href="#encoder">#encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encoder" class="dfn-panel" data-for="encoder" id="infopanel-for-encoder" role="dialog">
+   <span id="infopaneltitle-for-encoder" style="display:none">Info about the 'encoder' definition.</span><b><a href="#encoder">#encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encoder">4.1. Encoders and decoders</a> <a href="#ref-for-encoder①">(2)</a> <a href="#ref-for-encoder②">(3)</a> <a href="#ref-for-encoder③">(4)</a> <a href="#ref-for-encoder④">(5)</a> <a href="#ref-for-encoder⑤">(6)</a> <a href="#ref-for-encoder⑥">(7)</a> <a href="#ref-for-encoder⑦">(8)</a>
     <li><a href="#ref-for-encoder⑧">5. Indexes</a>
@@ -4463,8 +4463,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-encoder③④">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler">
-   <b><a href="#handler">#handler</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler" class="dfn-panel" data-for="handler" id="infopanel-for-handler" role="dialog">
+   <span id="infopaneltitle-for-handler" style="display:none">Info about the 'handler' definition.</span><b><a href="#handler">#handler</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler">4.1. Encoders and decoders</a> <a href="#ref-for-handler①">(2)</a>
     <li><a href="#ref-for-handler②">7.4. Interface TextEncoder</a> <a href="#ref-for-handler③">(2)</a>
@@ -4490,8 +4490,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-handler②③">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finished">
-   <b><a href="#finished">#finished</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finished" class="dfn-panel" data-for="finished" id="infopanel-for-finished" role="dialog">
+   <span id="infopaneltitle-for-finished" style="display:none">Info about the 'finished' definition.</span><b><a href="#finished">#finished</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finished">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-finished①">7.2. Interface TextDecoder</a>
@@ -4519,8 +4519,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-finished②⑧">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="error">
-   <b><a href="#error">#error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-error" class="dfn-panel" data-for="error" id="infopanel-for-error" role="dialog">
+   <span id="infopaneltitle-for-error" style="display:none">Info about the 'error' definition.</span><b><a href="#error">#error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-error">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-error①">6. Hooks for standards</a>
@@ -4548,8 +4548,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-error⑥①">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="continue">
-   <b><a href="#continue">#continue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-continue" class="dfn-panel" data-for="continue" id="infopanel-for-continue" role="dialog">
+   <span id="infopaneltitle-for-continue" style="display:none">Info about the 'continue' definition.</span><b><a href="#continue">#continue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-continue">4.1. Encoders and decoders</a> <a href="#ref-for-continue①">(2)</a>
     <li><a href="#ref-for-continue②">7.6. Interface TextEncoderStream</a> <a href="#ref-for-continue③">(2)</a>
@@ -4563,22 +4563,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-continue②①">14.2.1. shared UTF-16 decoder</a> <a href="#ref-for-continue②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="error-mode">
-   <b><a href="#error-mode">#error-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-error-mode" class="dfn-panel" data-for="error-mode" id="infopanel-for-error-mode" role="dialog">
+   <span id="infopaneltitle-for-error-mode" style="display:none">Info about the 'error mode' definition.</span><b><a href="#error-mode">#error-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-error-mode">4.1. Encoders and decoders</a> <a href="#ref-for-error-mode①">(2)</a> <a href="#ref-for-error-mode②">(3)</a> <a href="#ref-for-error-mode③">(4)</a> <a href="#ref-for-error-mode④">(5)</a>
     <li><a href="#ref-for-error-mode⑤">7.1. Interface mixin TextDecoderCommon</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-encoding-run">
-   <b><a href="#concept-encoding-run">#concept-encoding-run</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-encoding-run" class="dfn-panel" data-for="concept-encoding-run" id="infopanel-for-concept-encoding-run" role="dialog">
+   <span id="infopaneltitle-for-concept-encoding-run" style="display:none">Info about the 'process a queue' definition.</span><b><a href="#concept-encoding-run">#concept-encoding-run</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-run">6. Hooks for standards</a> <a href="#ref-for-concept-encoding-run①">(2)</a> <a href="#ref-for-concept-encoding-run②">(3)</a>
     <li><a href="#ref-for-concept-encoding-run③">6.1. Legacy hooks for standards</a> <a href="#ref-for-concept-encoding-run④">(2)</a> <a href="#ref-for-concept-encoding-run⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-encoding-process">
-   <b><a href="#concept-encoding-process">#concept-encoding-process</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-encoding-process" class="dfn-panel" data-for="concept-encoding-process" id="infopanel-for-concept-encoding-process" role="dialog">
+   <span id="infopaneltitle-for-concept-encoding-process" style="display:none">Info about the 'process an item' definition.</span><b><a href="#concept-encoding-process">#concept-encoding-process</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-process">4.1. Encoders and decoders</a>
     <li><a href="#ref-for-concept-encoding-process①">7.2. Interface TextDecoder</a>
@@ -4587,31 +4587,31 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-encoding-process⑤">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-encoding-get">
-   <b><a href="#concept-encoding-get">#concept-encoding-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-encoding-get" class="dfn-panel" data-for="concept-encoding-get" id="infopanel-for-concept-encoding-get" role="dialog">
+   <span id="infopaneltitle-for-concept-encoding-get" style="display:none">Info about the 'get an encoding' definition.</span><b><a href="#concept-encoding-get">#concept-encoding-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-get">6.1. Legacy hooks for standards</a>
     <li><a href="#ref-for-concept-encoding-get①">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-concept-encoding-get②">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-an-output-encoding">
-   <b><a href="#get-an-output-encoding">#get-an-output-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-an-output-encoding" class="dfn-panel" data-for="get-an-output-encoding" id="infopanel-for-get-an-output-encoding" role="dialog">
+   <span id="infopaneltitle-for-get-an-output-encoding" style="display:none">Info about the 'get an output encoding' definition.</span><b><a href="#get-an-output-encoding">#get-an-output-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-output-encoding">4.3. Output encodings</a>
     <li><a href="#ref-for-get-an-output-encoding①">6.1. Legacy hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index">
-   <b><a href="#index">#index</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index" class="dfn-panel" data-for="index" id="infopanel-for-index" role="dialog">
+   <span id="infopaneltitle-for-index" style="display:none">Info about the 'index' definition.</span><b><a href="#index">#index</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index">5. Indexes</a> <a href="#ref-for-index①">(2)</a> <a href="#ref-for-index②">(3)</a> <a href="#ref-for-index③">(4)</a> <a href="#ref-for-index④">(5)</a> <a href="#ref-for-index⑤">(6)</a> <a href="#ref-for-index⑥">(7)</a> <a href="#ref-for-index⑦">(8)</a> <a href="#ref-for-index⑧">(9)</a> <a href="#ref-for-index⑨">(10)</a> <a href="#ref-for-index①⓪">(11)</a>
     <li><a href="#ref-for-index①①">9. Legacy single-byte encodings</a>
     <li><a href="#ref-for-index①②">11.1.1. Big5 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-code-point">
-   <b><a href="#index-code-point">#index-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-code-point" class="dfn-panel" data-for="index-code-point" id="infopanel-for-index-code-point" role="dialog">
+   <span id="infopaneltitle-for-index-code-point" style="display:none">Info about the 'index code point' definition.</span><b><a href="#index-code-point">#index-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-code-point">9.1. single-byte decoder</a>
     <li><a href="#ref-for-index-code-point①">10.2.1. gb18030 decoder</a>
@@ -4623,8 +4623,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-index-code-point⑦">13.1.1. EUC-KR decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-pointer">
-   <b><a href="#index-pointer">#index-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-pointer" class="dfn-panel" data-for="index-pointer" id="infopanel-for-index-pointer" role="dialog">
+   <span id="infopaneltitle-for-index-pointer" style="display:none">Info about the 'index pointer' definition.</span><b><a href="#index-pointer">#index-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-pointer">5. Indexes</a> <a href="#ref-for-index-pointer①">(2)</a>
     <li><a href="#ref-for-index-pointer②">9.2. single-byte encoder</a>
@@ -4634,35 +4634,35 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-index-pointer⑧">13.1.2. EUC-KR encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-big5">
-   <b><a href="#index-big5">#index-big5</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-big5" class="dfn-panel" data-for="index-big5" id="infopanel-for-index-big5" role="dialog">
+   <span id="infopaneltitle-for-index-big5" style="display:none">Info about the 'index Big5' definition.</span><b><a href="#index-big5">#index-big5</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-big5">5. Indexes</a>
     <li><a href="#ref-for-index-big5①">11.1.1. Big5 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-euc-kr">
-   <b><a href="#index-euc-kr">#index-euc-kr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-euc-kr" class="dfn-panel" data-for="index-euc-kr" id="infopanel-for-index-euc-kr" role="dialog">
+   <span id="infopaneltitle-for-index-euc-kr" style="display:none">Info about the 'index EUC-KR' definition.</span><b><a href="#index-euc-kr">#index-euc-kr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-euc-kr">13.1.1. EUC-KR decoder</a>
     <li><a href="#ref-for-index-euc-kr①">13.1.2. EUC-KR encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-gb18030">
-   <b><a href="#index-gb18030">#index-gb18030</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-gb18030" class="dfn-panel" data-for="index-gb18030" id="infopanel-for-index-gb18030" role="dialog">
+   <span id="infopaneltitle-for-index-gb18030" style="display:none">Info about the 'index gb18030' definition.</span><b><a href="#index-gb18030">#index-gb18030</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-gb18030">10.2.1. gb18030 decoder</a>
     <li><a href="#ref-for-index-gb18030①">10.2.2. gb18030 encoder</a> <a href="#ref-for-index-gb18030②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-gb18030-ranges">
-   <b><a href="#index-gb18030-ranges">#index-gb18030-ranges</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-gb18030-ranges" class="dfn-panel" data-for="index-gb18030-ranges" id="infopanel-for-index-gb18030-ranges" role="dialog">
+   <span id="infopaneltitle-for-index-gb18030-ranges" style="display:none">Info about the 'index gb18030 ranges' definition.</span><b><a href="#index-gb18030-ranges">#index-gb18030-ranges</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-gb18030-ranges">5. Indexes</a> <a href="#ref-for-index-gb18030-ranges①">(2)</a> <a href="#ref-for-index-gb18030-ranges②">(3)</a> <a href="#ref-for-index-gb18030-ranges③">(4)</a> <a href="#ref-for-index-gb18030-ranges④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-jis0208">
-   <b><a href="#index-jis0208">#index-jis0208</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-jis0208" class="dfn-panel" data-for="index-jis0208" id="infopanel-for-index-jis0208" role="dialog">
+   <span id="infopaneltitle-for-index-jis0208" style="display:none">Info about the 'index jis0208' definition.</span><b><a href="#index-jis0208">#index-jis0208</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-jis0208">5. Indexes</a> <a href="#ref-for-index-jis0208①">(2)</a> <a href="#ref-for-index-jis0208②">(3)</a>
     <li><a href="#ref-for-index-jis0208③">12.1.1. EUC-JP decoder</a>
@@ -4672,74 +4672,74 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-index-jis0208⑨">12.3.1. Shift_JIS decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-jis0212">
-   <b><a href="#index-jis0212">#index-jis0212</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-jis0212" class="dfn-panel" data-for="index-jis0212" id="infopanel-for-index-jis0212" role="dialog">
+   <span id="infopaneltitle-for-index-jis0212" style="display:none">Info about the 'index jis0212' definition.</span><b><a href="#index-jis0212">#index-jis0212</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-jis0212">12.1.1. EUC-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-iso-2022-jp-katakana">
-   <b><a href="#index-iso-2022-jp-katakana">#index-iso-2022-jp-katakana</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-iso-2022-jp-katakana" class="dfn-panel" data-for="index-iso-2022-jp-katakana" id="infopanel-for-index-iso-2022-jp-katakana" role="dialog">
+   <span id="infopaneltitle-for-index-iso-2022-jp-katakana" style="display:none">Info about the 'index ISO-2022-JP katakana' definition.</span><b><a href="#index-iso-2022-jp-katakana">#index-iso-2022-jp-katakana</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-iso-2022-jp-katakana">5. Indexes</a> <a href="#ref-for-index-iso-2022-jp-katakana①">(2)</a>
     <li><a href="#ref-for-index-iso-2022-jp-katakana②">12.2.2. ISO-2022-JP encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-gb18030-ranges-code-point">
-   <b><a href="#index-gb18030-ranges-code-point">#index-gb18030-ranges-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-gb18030-ranges-code-point" class="dfn-panel" data-for="index-gb18030-ranges-code-point" id="infopanel-for-index-gb18030-ranges-code-point" role="dialog">
+   <span id="infopaneltitle-for-index-gb18030-ranges-code-point" style="display:none">Info about the 'index gb18030 ranges code point' definition.</span><b><a href="#index-gb18030-ranges-code-point">#index-gb18030-ranges-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-gb18030-ranges-code-point">5. Indexes</a>
     <li><a href="#ref-for-index-gb18030-ranges-code-point①">10.2.1. gb18030 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-gb18030-ranges-pointer">
-   <b><a href="#index-gb18030-ranges-pointer">#index-gb18030-ranges-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-gb18030-ranges-pointer" class="dfn-panel" data-for="index-gb18030-ranges-pointer" id="infopanel-for-index-gb18030-ranges-pointer" role="dialog">
+   <span id="infopaneltitle-for-index-gb18030-ranges-pointer" style="display:none">Info about the 'index gb18030 ranges pointer' definition.</span><b><a href="#index-gb18030-ranges-pointer">#index-gb18030-ranges-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-gb18030-ranges-pointer">5. Indexes</a>
     <li><a href="#ref-for-index-gb18030-ranges-pointer①">10.2.2. gb18030 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-shift_jis-pointer">
-   <b><a href="#index-shift_jis-pointer">#index-shift_jis-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-shift_jis-pointer" class="dfn-panel" data-for="index-shift_jis-pointer" id="infopanel-for-index-shift_jis-pointer" role="dialog">
+   <span id="infopaneltitle-for-index-shift_jis-pointer" style="display:none">Info about the 'index Shift_JIS pointer' definition.</span><b><a href="#index-shift_jis-pointer">#index-shift_jis-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-shift_jis-pointer">12.3.2. Shift_JIS encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-big5-pointer">
-   <b><a href="#index-big5-pointer">#index-big5-pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-big5-pointer" class="dfn-panel" data-for="index-big5-pointer" id="infopanel-for-index-big5-pointer" role="dialog">
+   <span id="infopaneltitle-for-index-big5-pointer" style="display:none">Info about the 'index Big5 pointer' definition.</span><b><a href="#index-big5-pointer">#index-big5-pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-big5-pointer">11.1.2. Big5 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-decode">
-   <b><a href="#utf-8-decode">#utf-8-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-decode" class="dfn-panel" data-for="utf-8-decode" id="infopanel-for-utf-8-decode" role="dialog">
+   <span id="infopaneltitle-for-utf-8-decode" style="display:none">Info about the 'UTF-8 decode' definition.</span><b><a href="#utf-8-decode">#utf-8-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">4. Encodings</a>
     <li><a href="#ref-for-utf-8-decode①">6. Hooks for standards</a> <a href="#ref-for-utf-8-decode②">(2)</a>
     <li><a href="#ref-for-utf-8-decode③">8.1.1. UTF-8 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-decode-without-bom">
-   <b><a href="#utf-8-decode-without-bom">#utf-8-decode-without-bom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-decode-without-bom" class="dfn-panel" data-for="utf-8-decode-without-bom" id="infopanel-for-utf-8-decode-without-bom" role="dialog">
+   <span id="infopaneltitle-for-utf-8-decode-without-bom" style="display:none">Info about the 'UTF-8 decode without BOM' definition.</span><b><a href="#utf-8-decode-without-bom">#utf-8-decode-without-bom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom">6. Hooks for standards</a> <a href="#ref-for-utf-8-decode-without-bom①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-decode-without-bom-or-fail">
-   <b><a href="#utf-8-decode-without-bom-or-fail">#utf-8-decode-without-bom-or-fail</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-decode-without-bom-or-fail" class="dfn-panel" data-for="utf-8-decode-without-bom-or-fail" id="infopanel-for-utf-8-decode-without-bom-or-fail" role="dialog">
+   <span id="infopaneltitle-for-utf-8-decode-without-bom-or-fail" style="display:none">Info about the 'UTF-8 decode without BOM or fail' definition.</span><b><a href="#utf-8-decode-without-bom-or-fail">#utf-8-decode-without-bom-or-fail</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom-or-fail">6. Hooks for standards</a> <a href="#ref-for-utf-8-decode-without-bom-or-fail①">(2)</a> <a href="#ref-for-utf-8-decode-without-bom-or-fail②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-encode">
-   <b><a href="#utf-8-encode">#utf-8-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-encode" class="dfn-panel" data-for="utf-8-encode" id="infopanel-for-utf-8-encode" role="dialog">
+   <span id="infopaneltitle-for-utf-8-encode" style="display:none">Info about the 'UTF-8 encode' definition.</span><b><a href="#utf-8-encode">#utf-8-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">6. Hooks for standards</a> <a href="#ref-for-utf-8-encode①">(2)</a> <a href="#ref-for-utf-8-encode②">(3)</a>
     <li><a href="#ref-for-utf-8-encode③">6.1. Legacy hooks for standards</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decode">
-   <b><a href="#decode">#decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decode" class="dfn-panel" data-for="decode" id="infopanel-for-decode" role="dialog">
+   <span id="infopaneltitle-for-decode" style="display:none">Info about the 'decode' definition.</span><b><a href="#decode">#decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode">6. Hooks for standards</a>
     <li><a href="#ref-for-decode①">6.1. Legacy hooks for standards</a> <a href="#ref-for-decode②">(2)</a> <a href="#ref-for-decode③">(3)</a>
@@ -4748,303 +4748,303 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-decode⑥">14.2.1. shared UTF-16 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bom-sniff">
-   <b><a href="#bom-sniff">#bom-sniff</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bom-sniff" class="dfn-panel" data-for="bom-sniff" id="infopanel-for-bom-sniff" role="dialog">
+   <span id="infopaneltitle-for-bom-sniff" style="display:none">Info about the 'BOM sniff' definition.</span><b><a href="#bom-sniff">#bom-sniff</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bom-sniff">6.1. Legacy hooks for standards</a> <a href="#ref-for-bom-sniff①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encode">
-   <b><a href="#encode">#encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode" class="dfn-panel" data-for="encode" id="infopanel-for-encode" role="dialog">
+   <span id="infopaneltitle-for-encode" style="display:none">Info about the 'encode' definition.</span><b><a href="#encode">#encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode">6. Hooks for standards</a> <a href="#ref-for-encode①">(2)</a> <a href="#ref-for-encode②">(3)</a>
     <li><a href="#ref-for-encode③">6.1. Legacy hooks for standards</a> <a href="#ref-for-encode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="get-an-encoder">
-   <b><a href="#get-an-encoder">#get-an-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-get-an-encoder" class="dfn-panel" data-for="get-an-encoder" id="infopanel-for-get-an-encoder" role="dialog">
+   <span id="infopaneltitle-for-get-an-encoder" style="display:none">Info about the 'get an encoder' definition.</span><b><a href="#get-an-encoder">#get-an-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-encoder">6.1. Legacy hooks for standards</a> <a href="#ref-for-get-an-encoder①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encode-or-fail">
-   <b><a href="#encode-or-fail">#encode-or-fail</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode-or-fail" class="dfn-panel" data-for="encode-or-fail" id="infopanel-for-encode-or-fail" role="dialog">
+   <span id="infopaneltitle-for-encode-or-fail" style="display:none">Info about the 'encode or fail' definition.</span><b><a href="#encode-or-fail">#encode-or-fail</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode-or-fail">6.1. Legacy hooks for standards</a> <a href="#ref-for-encode-or-fail①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecodercommon">
-   <b><a href="#textdecodercommon">#textdecodercommon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecodercommon" class="dfn-panel" data-for="textdecodercommon" id="infopanel-for-textdecodercommon" role="dialog">
+   <span id="infopaneltitle-for-textdecodercommon" style="display:none">Info about the 'TextDecoderCommon' definition.</span><b><a href="#textdecodercommon">#textdecodercommon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecodercommon">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-textdecodercommon①">(2)</a> <a href="#ref-for-textdecodercommon②">(3)</a>
     <li><a href="#ref-for-textdecodercommon③">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-textdecodercommon④">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder-encoding">
-   <b><a href="#textdecoder-encoding">#textdecoder-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder-encoding" class="dfn-panel" data-for="textdecoder-encoding" id="infopanel-for-textdecoder-encoding" role="dialog">
+   <span id="infopaneltitle-for-textdecoder-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#textdecoder-encoding">#textdecoder-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder-encoding">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-textdecoder-encoding①">(2)</a>
     <li><a href="#ref-for-textdecoder-encoding②">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecoder-encoding③">(2)</a> <a href="#ref-for-textdecoder-encoding④">(3)</a> <a href="#ref-for-textdecoder-encoding⑤">(4)</a> <a href="#ref-for-textdecoder-encoding⑥">(5)</a>
     <li><a href="#ref-for-textdecoder-encoding⑦">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecoder-encoding⑧">(2)</a> <a href="#ref-for-textdecoder-encoding⑨">(3)</a> <a href="#ref-for-textdecoder-encoding①⓪">(4)</a> <a href="#ref-for-textdecoder-encoding①①">(5)</a> <a href="#ref-for-textdecoder-encoding①②">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecodercommon-decoder">
-   <b><a href="#textdecodercommon-decoder">#textdecodercommon-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecodercommon-decoder" class="dfn-panel" data-for="textdecodercommon-decoder" id="infopanel-for-textdecodercommon-decoder" role="dialog">
+   <span id="infopaneltitle-for-textdecodercommon-decoder" style="display:none">Info about the 'decoder' definition.</span><b><a href="#textdecodercommon-decoder">#textdecodercommon-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecodercommon-decoder">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecodercommon-decoder①">(2)</a> <a href="#ref-for-textdecodercommon-decoder②">(3)</a>
     <li><a href="#ref-for-textdecodercommon-decoder③">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecodercommon-decoder④">(2)</a> <a href="#ref-for-textdecodercommon-decoder⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecodercommon-i-o-queue">
-   <b><a href="#textdecodercommon-i-o-queue">#textdecodercommon-i-o-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecodercommon-i-o-queue" class="dfn-panel" data-for="textdecodercommon-i-o-queue" id="infopanel-for-textdecodercommon-i-o-queue" role="dialog">
+   <span id="infopaneltitle-for-textdecodercommon-i-o-queue" style="display:none">Info about the 'I/O queue' definition.</span><b><a href="#textdecodercommon-i-o-queue">#textdecodercommon-i-o-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecodercommon-i-o-queue">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecodercommon-i-o-queue①">(2)</a> <a href="#ref-for-textdecodercommon-i-o-queue②">(3)</a> <a href="#ref-for-textdecodercommon-i-o-queue③">(4)</a>
     <li><a href="#ref-for-textdecodercommon-i-o-queue④">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecodercommon-i-o-queue⑤">(2)</a> <a href="#ref-for-textdecodercommon-i-o-queue⑥">(3)</a> <a href="#ref-for-textdecodercommon-i-o-queue⑦">(4)</a> <a href="#ref-for-textdecodercommon-i-o-queue⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder-ignore-bom-flag">
-   <b><a href="#textdecoder-ignore-bom-flag">#textdecoder-ignore-bom-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder-ignore-bom-flag" class="dfn-panel" data-for="textdecoder-ignore-bom-flag" id="infopanel-for-textdecoder-ignore-bom-flag" role="dialog">
+   <span id="infopaneltitle-for-textdecoder-ignore-bom-flag" style="display:none">Info about the 'ignore BOM' definition.</span><b><a href="#textdecoder-ignore-bom-flag">#textdecoder-ignore-bom-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder-ignore-bom-flag">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-textdecoder-ignore-bom-flag①">(2)</a>
     <li><a href="#ref-for-textdecoder-ignore-bom-flag②">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecoder-ignore-bom-flag③">(2)</a>
     <li><a href="#ref-for-textdecoder-ignore-bom-flag④">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecoder-ignore-bom-flag⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder-bom-seen-flag">
-   <b><a href="#textdecoder-bom-seen-flag">#textdecoder-bom-seen-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder-bom-seen-flag" class="dfn-panel" data-for="textdecoder-bom-seen-flag" id="infopanel-for-textdecoder-bom-seen-flag" role="dialog">
+   <span id="infopaneltitle-for-textdecoder-bom-seen-flag" style="display:none">Info about the 'BOM seen' definition.</span><b><a href="#textdecoder-bom-seen-flag">#textdecoder-bom-seen-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder-bom-seen-flag">7.1. Interface mixin TextDecoderCommon</a> <a href="#ref-for-textdecoder-bom-seen-flag①">(2)</a>
     <li><a href="#ref-for-textdecoder-bom-seen-flag②">7.2. Interface TextDecoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder-error-mode">
-   <b><a href="#textdecoder-error-mode">#textdecoder-error-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder-error-mode" class="dfn-panel" data-for="textdecoder-error-mode" id="infopanel-for-textdecoder-error-mode" role="dialog">
+   <span id="infopaneltitle-for-textdecoder-error-mode" style="display:none">Info about the 'error mode' definition.</span><b><a href="#textdecoder-error-mode">#textdecoder-error-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder-error-mode">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-textdecoder-error-mode①">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecoder-error-mode②">(2)</a> <a href="#ref-for-textdecoder-error-mode③">(3)</a> <a href="#ref-for-textdecoder-error-mode④">(4)</a>
     <li><a href="#ref-for-textdecoder-error-mode⑤">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecoder-error-mode⑥">(2)</a> <a href="#ref-for-textdecoder-error-mode⑦">(3)</a> <a href="#ref-for-textdecoder-error-mode⑧">(4)</a> <a href="#ref-for-textdecoder-error-mode⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-td-serialize">
-   <b><a href="#concept-td-serialize">#concept-td-serialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-td-serialize" class="dfn-panel" data-for="concept-td-serialize" id="infopanel-for-concept-td-serialize" role="dialog">
+   <span id="infopaneltitle-for-concept-td-serialize" style="display:none">Info about the 'serialize I/O queue' definition.</span><b><a href="#concept-td-serialize">#concept-td-serialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-td-serialize">7.2. Interface TextDecoder</a> <a href="#ref-for-concept-td-serialize①">(2)</a>
     <li><a href="#ref-for-concept-td-serialize②">7.5. Interface TextDecoderStream</a> <a href="#ref-for-concept-td-serialize③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoder-encoding">
-   <b><a href="#dom-textdecoder-encoding">#dom-textdecoder-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoder-encoding" class="dfn-panel" data-for="dom-textdecoder-encoding" id="infopanel-for-dom-textdecoder-encoding" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoder-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#dom-textdecoder-encoding">#dom-textdecoder-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoder-encoding">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-dom-textdecoder-encoding①">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dom-textdecoder-encoding②">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoder-fatal">
-   <b><a href="#dom-textdecoder-fatal">#dom-textdecoder-fatal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoder-fatal" class="dfn-panel" data-for="dom-textdecoder-fatal" id="infopanel-for-dom-textdecoder-fatal" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoder-fatal" style="display:none">Info about the 'fatal' definition.</span><b><a href="#dom-textdecoder-fatal">#dom-textdecoder-fatal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoder-fatal">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-dom-textdecoder-fatal①">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dom-textdecoder-fatal②">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoder-ignorebom">
-   <b><a href="#dom-textdecoder-ignorebom">#dom-textdecoder-ignorebom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoder-ignorebom" class="dfn-panel" data-for="dom-textdecoder-ignorebom" id="infopanel-for-dom-textdecoder-ignorebom" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoder-ignorebom" style="display:none">Info about the 'ignoreBOM' definition.</span><b><a href="#dom-textdecoder-ignorebom">#dom-textdecoder-ignorebom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoder-ignorebom">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-dom-textdecoder-ignorebom①">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dom-textdecoder-ignorebom②">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoderoptions">
-   <b><a href="#textdecoderoptions">#textdecoderoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoderoptions" class="dfn-panel" data-for="textdecoderoptions" id="infopanel-for-textdecoderoptions" role="dialog">
+   <span id="infopaneltitle-for-textdecoderoptions" style="display:none">Info about the 'TextDecoderOptions' definition.</span><b><a href="#textdecoderoptions">#textdecoderoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoderoptions">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-textdecoderoptions①">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoderoptions-fatal">
-   <b><a href="#dom-textdecoderoptions-fatal">#dom-textdecoderoptions-fatal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoderoptions-fatal" class="dfn-panel" data-for="dom-textdecoderoptions-fatal" id="infopanel-for-dom-textdecoderoptions-fatal" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoderoptions-fatal" style="display:none">Info about the 'fatal' definition.</span><b><a href="#dom-textdecoderoptions-fatal">#dom-textdecoderoptions-fatal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoderoptions-fatal">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dom-textdecoderoptions-fatal①">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoderoptions-ignorebom">
-   <b><a href="#dom-textdecoderoptions-ignorebom">#dom-textdecoderoptions-ignorebom</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoderoptions-ignorebom" class="dfn-panel" data-for="dom-textdecoderoptions-ignorebom" id="infopanel-for-dom-textdecoderoptions-ignorebom" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoderoptions-ignorebom" style="display:none">Info about the 'ignoreBOM' definition.</span><b><a href="#dom-textdecoderoptions-ignorebom">#dom-textdecoderoptions-ignorebom</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoderoptions-ignorebom">7.2. Interface TextDecoder</a>
     <li><a href="#ref-for-dom-textdecoderoptions-ignorebom①">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecodeoptions">
-   <b><a href="#textdecodeoptions">#textdecodeoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecodeoptions" class="dfn-panel" data-for="textdecodeoptions" id="infopanel-for-textdecodeoptions" role="dialog">
+   <span id="infopaneltitle-for-textdecodeoptions" style="display:none">Info about the 'TextDecodeOptions' definition.</span><b><a href="#textdecodeoptions">#textdecodeoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecodeoptions">7.2. Interface TextDecoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecodeoptions-stream">
-   <b><a href="#dom-textdecodeoptions-stream">#dom-textdecodeoptions-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecodeoptions-stream" class="dfn-panel" data-for="dom-textdecodeoptions-stream" id="infopanel-for-dom-textdecodeoptions-stream" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecodeoptions-stream" style="display:none">Info about the 'stream' definition.</span><b><a href="#dom-textdecodeoptions-stream">#dom-textdecodeoptions-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecodeoptions-stream">7.2. Interface TextDecoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder">
-   <b><a href="#textdecoder">#textdecoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder" class="dfn-panel" data-for="textdecoder" id="infopanel-for-textdecoder" role="dialog">
+   <span id="infopaneltitle-for-textdecoder" style="display:none">Info about the 'TextDecoder' definition.</span><b><a href="#textdecoder">#textdecoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-textdecoder①">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecoder②">(2)</a> <a href="#ref-for-textdecoder③">(3)</a> <a href="#ref-for-textdecoder④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoder-do-not-flush-flag">
-   <b><a href="#textdecoder-do-not-flush-flag">#textdecoder-do-not-flush-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoder-do-not-flush-flag" class="dfn-panel" data-for="textdecoder-do-not-flush-flag" id="infopanel-for-textdecoder-do-not-flush-flag" role="dialog">
+   <span id="infopaneltitle-for-textdecoder-do-not-flush-flag" style="display:none">Info about the 'do not flush' definition.</span><b><a href="#textdecoder-do-not-flush-flag">#textdecoder-do-not-flush-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoder-do-not-flush-flag">7.2. Interface TextDecoder</a> <a href="#ref-for-textdecoder-do-not-flush-flag①">(2)</a> <a href="#ref-for-textdecoder-do-not-flush-flag②">(3)</a> <a href="#ref-for-textdecoder-do-not-flush-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoder">
-   <b><a href="#dom-textdecoder">#dom-textdecoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoder" class="dfn-panel" data-for="dom-textdecoder" id="infopanel-for-dom-textdecoder" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoder" style="display:none">Info about the 'new TextDecoder(label, options)' definition.</span><b><a href="#dom-textdecoder">#dom-textdecoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoder">7.2. Interface TextDecoder</a> <a href="#ref-for-dom-textdecoder①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoder-decode">
-   <b><a href="#dom-textdecoder-decode">#dom-textdecoder-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoder-decode" class="dfn-panel" data-for="dom-textdecoder-decode" id="infopanel-for-dom-textdecoder-decode" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoder-decode" style="display:none">Info about the 'decode(input, options)' definition.</span><b><a href="#dom-textdecoder-decode">#dom-textdecoder-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoder-decode">7.2. Interface TextDecoder</a> <a href="#ref-for-dom-textdecoder-decode①">(2)</a> <a href="#ref-for-dom-textdecoder-decode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textencodercommon">
-   <b><a href="#textencodercommon">#textencodercommon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textencodercommon" class="dfn-panel" data-for="textencodercommon" id="infopanel-for-textencodercommon" role="dialog">
+   <span id="infopaneltitle-for-textencodercommon" style="display:none">Info about the 'TextEncoderCommon' definition.</span><b><a href="#textencodercommon">#textencodercommon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencodercommon">7.3. Interface mixin TextEncoderCommon</a> <a href="#ref-for-textencodercommon①">(2)</a>
     <li><a href="#ref-for-textencodercommon②">7.4. Interface TextEncoder</a>
     <li><a href="#ref-for-textencodercommon③">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoder-encoding">
-   <b><a href="#dom-textencoder-encoding">#dom-textencoder-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoder-encoding" class="dfn-panel" data-for="dom-textencoder-encoding" id="infopanel-for-dom-textencoder-encoding" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoder-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#dom-textencoder-encoding">#dom-textencoder-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoder-encoding">7.3. Interface mixin TextEncoderCommon</a>
     <li><a href="#ref-for-dom-textencoder-encoding①">7.4. Interface TextEncoder</a>
     <li><a href="#ref-for-dom-textencoder-encoding②">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-textencoderencodeintoresult">
-   <b><a href="#dictdef-textencoderencodeintoresult">#dictdef-textencoderencodeintoresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-textencoderencodeintoresult" class="dfn-panel" data-for="dictdef-textencoderencodeintoresult" id="infopanel-for-dictdef-textencoderencodeintoresult" role="dialog">
+   <span id="infopaneltitle-for-dictdef-textencoderencodeintoresult" style="display:none">Info about the 'TextEncoderEncodeIntoResult' definition.</span><b><a href="#dictdef-textencoderencodeintoresult">#dictdef-textencoderencodeintoresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-textencoderencodeintoresult">7.4. Interface TextEncoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoderencodeintoresult-read">
-   <b><a href="#dom-textencoderencodeintoresult-read">#dom-textencoderencodeintoresult-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoderencodeintoresult-read" class="dfn-panel" data-for="dom-textencoderencodeintoresult-read" id="infopanel-for-dom-textencoderencodeintoresult-read" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoderencodeintoresult-read" style="display:none">Info about the 'read' definition.</span><b><a href="#dom-textencoderencodeintoresult-read">#dom-textencoderencodeintoresult-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoderencodeintoresult-read">7.4. Interface TextEncoder</a> <a href="#ref-for-dom-textencoderencodeintoresult-read①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoderencodeintoresult-written">
-   <b><a href="#dom-textencoderencodeintoresult-written">#dom-textencoderencodeintoresult-written</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoderencodeintoresult-written" class="dfn-panel" data-for="dom-textencoderencodeintoresult-written" id="infopanel-for-dom-textencoderencodeintoresult-written" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoderencodeintoresult-written" style="display:none">Info about the 'written' definition.</span><b><a href="#dom-textencoderencodeintoresult-written">#dom-textencoderencodeintoresult-written</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoderencodeintoresult-written">7.4. Interface TextEncoder</a> <a href="#ref-for-dom-textencoderencodeintoresult-written①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textencoder">
-   <b><a href="#textencoder">#textencoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textencoder" class="dfn-panel" data-for="textencoder" id="infopanel-for-textencoder" role="dialog">
+   <span id="infopaneltitle-for-textencoder" style="display:none">Info about the 'TextEncoder' definition.</span><b><a href="#textencoder">#textencoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencoder">7. API</a>
     <li><a href="#ref-for-textencoder①">7.3. Interface mixin TextEncoderCommon</a>
     <li><a href="#ref-for-textencoder②">7.4. Interface TextEncoder</a> <a href="#ref-for-textencoder③">(2)</a> <a href="#ref-for-textencoder④">(3)</a> <a href="#ref-for-textencoder⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoder">
-   <b><a href="#dom-textencoder">#dom-textencoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoder" class="dfn-panel" data-for="dom-textencoder" id="infopanel-for-dom-textencoder" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoder" style="display:none">Info about the 'new TextEncoder()' definition.</span><b><a href="#dom-textencoder">#dom-textencoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoder">7.4. Interface TextEncoder</a> <a href="#ref-for-dom-textencoder①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoder-encode">
-   <b><a href="#dom-textencoder-encode">#dom-textencoder-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoder-encode" class="dfn-panel" data-for="dom-textencoder-encode" id="infopanel-for-dom-textencoder-encode" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoder-encode" style="display:none">Info about the 'encode(input)' definition.</span><b><a href="#dom-textencoder-encode">#dom-textencoder-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoder-encode">7.4. Interface TextEncoder</a> <a href="#ref-for-dom-textencoder-encode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoder-encodeinto">
-   <b><a href="#dom-textencoder-encodeinto">#dom-textencoder-encodeinto</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoder-encodeinto" class="dfn-panel" data-for="dom-textencoder-encodeinto" id="infopanel-for-dom-textencoder-encodeinto" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoder-encodeinto" style="display:none">Info about the 'encodeInto(source, destination)' definition.</span><b><a href="#dom-textencoder-encodeinto">#dom-textencoder-encodeinto</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoder-encodeinto">7.4. Interface TextEncoder</a> <a href="#ref-for-dom-textencoder-encodeinto①">(2)</a> <a href="#ref-for-dom-textencoder-encodeinto②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textdecoderstream">
-   <b><a href="#textdecoderstream">#textdecoderstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textdecoderstream" class="dfn-panel" data-for="textdecoderstream" id="infopanel-for-textdecoderstream" role="dialog">
+   <span id="infopaneltitle-for-textdecoderstream" style="display:none">Info about the 'TextDecoderStream' definition.</span><b><a href="#textdecoderstream">#textdecoderstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoderstream">7.1. Interface mixin TextDecoderCommon</a>
     <li><a href="#ref-for-textdecoderstream①">7.5. Interface TextDecoderStream</a> <a href="#ref-for-textdecoderstream②">(2)</a> <a href="#ref-for-textdecoderstream③">(3)</a> <a href="#ref-for-textdecoderstream④">(4)</a> <a href="#ref-for-textdecoderstream⑤">(5)</a> <a href="#ref-for-textdecoderstream⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textdecoderstream">
-   <b><a href="#dom-textdecoderstream">#dom-textdecoderstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textdecoderstream" class="dfn-panel" data-for="dom-textdecoderstream" id="infopanel-for-dom-textdecoderstream" role="dialog">
+   <span id="infopaneltitle-for-dom-textdecoderstream" style="display:none">Info about the 'new TextDecoderStream(label, options)' definition.</span><b><a href="#dom-textdecoderstream">#dom-textdecoderstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textdecoderstream">7.5. Interface TextDecoderStream</a> <a href="#ref-for-dom-textdecoderstream①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="decode-and-enqueue-a-chunk">
-   <b><a href="#decode-and-enqueue-a-chunk">#decode-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-decode-and-enqueue-a-chunk" class="dfn-panel" data-for="decode-and-enqueue-a-chunk" id="infopanel-for-decode-and-enqueue-a-chunk" role="dialog">
+   <span id="infopaneltitle-for-decode-and-enqueue-a-chunk" style="display:none">Info about the 'decode and enqueue a chunk' definition.</span><b><a href="#decode-and-enqueue-a-chunk">#decode-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode-and-enqueue-a-chunk">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="flush-and-enqueue">
-   <b><a href="#flush-and-enqueue">#flush-and-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-flush-and-enqueue" class="dfn-panel" data-for="flush-and-enqueue" id="infopanel-for-flush-and-enqueue" role="dialog">
+   <span id="infopaneltitle-for-flush-and-enqueue" style="display:none">Info about the 'flush and enqueue' definition.</span><b><a href="#flush-and-enqueue">#flush-and-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flush-and-enqueue">7.5. Interface TextDecoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textencoderstream">
-   <b><a href="#textencoderstream">#textencoderstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textencoderstream" class="dfn-panel" data-for="textencoderstream" id="infopanel-for-textencoderstream" role="dialog">
+   <span id="infopaneltitle-for-textencoderstream" style="display:none">Info about the 'TextEncoderStream' definition.</span><b><a href="#textencoderstream">#textencoderstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencoderstream">7.3. Interface mixin TextEncoderCommon</a>
     <li><a href="#ref-for-textencoderstream①">7.6. Interface TextEncoderStream</a> <a href="#ref-for-textencoderstream②">(2)</a> <a href="#ref-for-textencoderstream③">(3)</a> <a href="#ref-for-textencoderstream④">(4)</a> <a href="#ref-for-textencoderstream⑤">(5)</a> <a href="#ref-for-textencoderstream⑥">(6)</a> <a href="#ref-for-textencoderstream⑦">(7)</a> <a href="#ref-for-textencoderstream⑧">(8)</a> <a href="#ref-for-textencoderstream⑨">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textencoderstream-encoder">
-   <b><a href="#textencoderstream-encoder">#textencoderstream-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textencoderstream-encoder" class="dfn-panel" data-for="textencoderstream-encoder" id="infopanel-for-textencoderstream-encoder" role="dialog">
+   <span id="infopaneltitle-for-textencoderstream-encoder" style="display:none">Info about the 'encoder' definition.</span><b><a href="#textencoderstream-encoder">#textencoderstream-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencoderstream-encoder">7.6. Interface TextEncoderStream</a> <a href="#ref-for-textencoderstream-encoder①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="textencoderstream-pending-high-surrogate">
-   <b><a href="#textencoderstream-pending-high-surrogate">#textencoderstream-pending-high-surrogate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-textencoderstream-pending-high-surrogate" class="dfn-panel" data-for="textencoderstream-pending-high-surrogate" id="infopanel-for-textencoderstream-pending-high-surrogate" role="dialog">
+   <span id="infopaneltitle-for-textencoderstream-pending-high-surrogate" style="display:none">Info about the 'pending high surrogate' definition.</span><b><a href="#textencoderstream-pending-high-surrogate">#textencoderstream-pending-high-surrogate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textencoderstream-pending-high-surrogate">7.6. Interface TextEncoderStream</a> <a href="#ref-for-textencoderstream-pending-high-surrogate①">(2)</a> <a href="#ref-for-textencoderstream-pending-high-surrogate②">(3)</a> <a href="#ref-for-textencoderstream-pending-high-surrogate③">(4)</a> <a href="#ref-for-textencoderstream-pending-high-surrogate④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-textencoderstream">
-   <b><a href="#dom-textencoderstream">#dom-textencoderstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-textencoderstream" class="dfn-panel" data-for="dom-textencoderstream" id="infopanel-for-dom-textencoderstream" role="dialog">
+   <span id="infopaneltitle-for-dom-textencoderstream" style="display:none">Info about the 'new TextEncoderStream()' definition.</span><b><a href="#dom-textencoderstream">#dom-textencoderstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-textencoderstream">7.6. Interface TextEncoderStream</a> <a href="#ref-for-dom-textencoderstream①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encode-and-enqueue-a-chunk">
-   <b><a href="#encode-and-enqueue-a-chunk">#encode-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode-and-enqueue-a-chunk" class="dfn-panel" data-for="encode-and-enqueue-a-chunk" id="infopanel-for-encode-and-enqueue-a-chunk" role="dialog">
+   <span id="infopaneltitle-for-encode-and-enqueue-a-chunk" style="display:none">Info about the 'encode and enqueue a chunk' definition.</span><b><a href="#encode-and-enqueue-a-chunk">#encode-and-enqueue-a-chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode-and-enqueue-a-chunk">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-code-unit-to-scalar-value">
-   <b><a href="#convert-code-unit-to-scalar-value">#convert-code-unit-to-scalar-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-code-unit-to-scalar-value" class="dfn-panel" data-for="convert-code-unit-to-scalar-value" id="infopanel-for-convert-code-unit-to-scalar-value" role="dialog">
+   <span id="infopaneltitle-for-convert-code-unit-to-scalar-value" style="display:none">Info about the 'convert code unit to scalar value' definition.</span><b><a href="#convert-code-unit-to-scalar-value">#convert-code-unit-to-scalar-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-code-unit-to-scalar-value">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encode-and-flush">
-   <b><a href="#encode-and-flush">#encode-and-flush</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode-and-flush" class="dfn-panel" data-for="encode-and-flush" id="infopanel-for-encode-and-flush" role="dialog">
+   <span id="infopaneltitle-for-encode-and-flush" style="display:none">Info about the 'encode and flush' definition.</span><b><a href="#encode-and-flush">#encode-and-flush</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode-and-flush">7.6. Interface TextEncoderStream</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8">
-   <b><a href="#utf-8">#utf-8</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8" class="dfn-panel" data-for="utf-8" id="infopanel-for-utf-8" role="dialog">
+   <span id="infopaneltitle-for-utf-8" style="display:none">Info about the '8.1. UTF-8' definition.</span><b><a href="#utf-8">#utf-8</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">4. Encodings</a> <a href="#ref-for-utf-8①">(2)</a>
     <li><a href="#ref-for-utf-8②">4.1. Encoders and decoders</a>
@@ -5061,52 +5061,52 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-8②④">8.1.2. UTF-8 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-decoder">
-   <b><a href="#utf-8-decoder">#utf-8-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-decoder" class="dfn-panel" data-for="utf-8-decoder" id="infopanel-for-utf-8-decoder" role="dialog">
+   <span id="infopaneltitle-for-utf-8-decoder" style="display:none">Info about the '8.1.1. UTF-8 decoder' definition.</span><b><a href="#utf-8-decoder">#utf-8-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decoder">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-decoder">(2)</a> <a href="#ref-for-utf-8-decoder①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-code-point">
-   <b><a href="#utf-8-code-point">#utf-8-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-code-point" class="dfn-panel" data-for="utf-8-code-point" id="infopanel-for-utf-8-code-point" role="dialog">
+   <span id="infopaneltitle-for-utf-8-code-point" style="display:none">Info about the 'UTF-8 code point' definition.</span><b><a href="#utf-8-code-point">#utf-8-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-code-point">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-code-point①">(2)</a> <a href="#ref-for-utf-8-code-point②">(3)</a> <a href="#ref-for-utf-8-code-point③">(4)</a> <a href="#ref-for-utf-8-code-point④">(5)</a> <a href="#ref-for-utf-8-code-point⑤">(6)</a> <a href="#ref-for-utf-8-code-point⑥">(7)</a> <a href="#ref-for-utf-8-code-point⑦">(8)</a> <a href="#ref-for-utf-8-code-point⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-bytes-seen">
-   <b><a href="#utf-8-bytes-seen">#utf-8-bytes-seen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-bytes-seen" class="dfn-panel" data-for="utf-8-bytes-seen" id="infopanel-for-utf-8-bytes-seen" role="dialog">
+   <span id="infopaneltitle-for-utf-8-bytes-seen" style="display:none">Info about the 'UTF-8 bytes seen' definition.</span><b><a href="#utf-8-bytes-seen">#utf-8-bytes-seen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-bytes-seen">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-bytes-seen①">(2)</a> <a href="#ref-for-utf-8-bytes-seen②">(3)</a> <a href="#ref-for-utf-8-bytes-seen③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-bytes-needed">
-   <b><a href="#utf-8-bytes-needed">#utf-8-bytes-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-bytes-needed" class="dfn-panel" data-for="utf-8-bytes-needed" id="infopanel-for-utf-8-bytes-needed" role="dialog">
+   <span id="infopaneltitle-for-utf-8-bytes-needed" style="display:none">Info about the 'UTF-8 bytes needed' definition.</span><b><a href="#utf-8-bytes-needed">#utf-8-bytes-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-bytes-needed">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-bytes-needed①">(2)</a> <a href="#ref-for-utf-8-bytes-needed②">(3)</a> <a href="#ref-for-utf-8-bytes-needed③">(4)</a> <a href="#ref-for-utf-8-bytes-needed④">(5)</a> <a href="#ref-for-utf-8-bytes-needed⑤">(6)</a> <a href="#ref-for-utf-8-bytes-needed⑥">(7)</a> <a href="#ref-for-utf-8-bytes-needed⑦">(8)</a> <a href="#ref-for-utf-8-bytes-needed⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-lower-boundary">
-   <b><a href="#utf-8-lower-boundary">#utf-8-lower-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-lower-boundary" class="dfn-panel" data-for="utf-8-lower-boundary" id="infopanel-for-utf-8-lower-boundary" role="dialog">
+   <span id="infopaneltitle-for-utf-8-lower-boundary" style="display:none">Info about the 'UTF-8 lower boundary' definition.</span><b><a href="#utf-8-lower-boundary">#utf-8-lower-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-lower-boundary">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-lower-boundary①">(2)</a> <a href="#ref-for-utf-8-lower-boundary②">(3)</a> <a href="#ref-for-utf-8-lower-boundary③">(4)</a> <a href="#ref-for-utf-8-lower-boundary④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-upper-boundary">
-   <b><a href="#utf-8-upper-boundary">#utf-8-upper-boundary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-upper-boundary" class="dfn-panel" data-for="utf-8-upper-boundary" id="infopanel-for-utf-8-upper-boundary" role="dialog">
+   <span id="infopaneltitle-for-utf-8-upper-boundary" style="display:none">Info about the 'UTF-8 upper boundary' definition.</span><b><a href="#utf-8-upper-boundary">#utf-8-upper-boundary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-upper-boundary">8.1.1. UTF-8 decoder</a> <a href="#ref-for-utf-8-upper-boundary①">(2)</a> <a href="#ref-for-utf-8-upper-boundary②">(3)</a> <a href="#ref-for-utf-8-upper-boundary③">(4)</a> <a href="#ref-for-utf-8-upper-boundary④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-encoder">
-   <b><a href="#utf-8-encoder">#utf-8-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-encoder" class="dfn-panel" data-for="utf-8-encoder" id="infopanel-for-utf-8-encoder" role="dialog">
+   <span id="infopaneltitle-for-utf-8-encoder" style="display:none">Info about the '8.1.2. UTF-8 encoder' definition.</span><b><a href="#utf-8-encoder">#utf-8-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encoder">7.4. Interface TextEncoder</a> <a href="#ref-for-utf-8-encoder①">(2)</a> <a href="#ref-for-utf-8-encoder②">(3)</a> <a href="#ref-for-utf-8-encoder③">(4)</a> <a href="#ref-for-utf-8-encoder④">(5)</a>
     <li><a href="#ref-for-utf-8-encoder⑤">7.6. Interface TextEncoderStream</a>
     <li><a href="#ref-for-utf-8-encoder">8.1.2. UTF-8 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-byte-encoding">
-   <b><a href="#single-byte-encoding">#single-byte-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-byte-encoding" class="dfn-panel" data-for="single-byte-encoding" id="infopanel-for-single-byte-encoding" role="dialog">
+   <span id="infopaneltitle-for-single-byte-encoding" style="display:none">Info about the 'single-byte encoding' definition.</span><b><a href="#single-byte-encoding">#single-byte-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-byte-encoding">4.2. Names and labels</a>
     <li><a href="#ref-for-single-byte-encoding①">9. Legacy single-byte encodings</a> <a href="#ref-for-single-byte-encoding②">(2)</a> <a href="#ref-for-single-byte-encoding③">(3)</a>
@@ -5115,202 +5115,202 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-single-byte-encoding⑥">14.5. x-user-defined</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="index-single-byte">
-   <b><a href="#index-single-byte">#index-single-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-index-single-byte" class="dfn-panel" data-for="index-single-byte" id="infopanel-for-index-single-byte" role="dialog">
+   <span id="infopaneltitle-for-index-single-byte" style="display:none">Info about the 'Index single-byte' definition.</span><b><a href="#index-single-byte">#index-single-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-index-single-byte">5. Indexes</a>
     <li><a href="#ref-for-index-single-byte①">9.1. single-byte decoder</a>
     <li><a href="#ref-for-index-single-byte②">9.2. single-byte encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ibm866">
-   <b><a href="#ibm866">#ibm866</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ibm866" class="dfn-panel" data-for="ibm866" id="infopanel-for-ibm866" role="dialog">
+   <span id="infopaneltitle-for-ibm866" style="display:none">Info about the 'IBM866' definition.</span><b><a href="#ibm866">#ibm866</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ibm866">4.2. Names and labels</a> <a href="#ref-for-ibm866①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-2">
-   <b><a href="#iso-8859-2">#iso-8859-2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-2" class="dfn-panel" data-for="iso-8859-2" id="infopanel-for-iso-8859-2" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-2" style="display:none">Info about the 'ISO-8859-2' definition.</span><b><a href="#iso-8859-2">#iso-8859-2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-2">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-3">
-   <b><a href="#iso-8859-3">#iso-8859-3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-3" class="dfn-panel" data-for="iso-8859-3" id="infopanel-for-iso-8859-3" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-3" style="display:none">Info about the 'ISO-8859-3' definition.</span><b><a href="#iso-8859-3">#iso-8859-3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-3">4.2. Names and labels</a> <a href="#ref-for-iso-8859-3①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-4">
-   <b><a href="#iso-8859-4">#iso-8859-4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-4" class="dfn-panel" data-for="iso-8859-4" id="infopanel-for-iso-8859-4" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-4" style="display:none">Info about the 'ISO-8859-4' definition.</span><b><a href="#iso-8859-4">#iso-8859-4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-4">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-5">
-   <b><a href="#iso-8859-5">#iso-8859-5</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-5" class="dfn-panel" data-for="iso-8859-5" id="infopanel-for-iso-8859-5" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-5" style="display:none">Info about the 'ISO-8859-5' definition.</span><b><a href="#iso-8859-5">#iso-8859-5</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-5">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-6">
-   <b><a href="#iso-8859-6">#iso-8859-6</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-6" class="dfn-panel" data-for="iso-8859-6" id="infopanel-for-iso-8859-6" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-6" style="display:none">Info about the 'ISO-8859-6' definition.</span><b><a href="#iso-8859-6">#iso-8859-6</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-6">4.2. Names and labels</a>
     <li><a href="#ref-for-iso-8859-6①">9. Legacy single-byte encodings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-7">
-   <b><a href="#iso-8859-7">#iso-8859-7</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-7" class="dfn-panel" data-for="iso-8859-7" id="infopanel-for-iso-8859-7" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-7" style="display:none">Info about the 'ISO-8859-7' definition.</span><b><a href="#iso-8859-7">#iso-8859-7</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-7">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-8">
-   <b><a href="#iso-8859-8">#iso-8859-8</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-8" class="dfn-panel" data-for="iso-8859-8" id="infopanel-for-iso-8859-8" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-8" style="display:none">Info about the 'ISO-8859-8' definition.</span><b><a href="#iso-8859-8">#iso-8859-8</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-8">4.2. Names and labels</a>
     <li><a href="#ref-for-iso-8859-8①">9. Legacy single-byte encodings</a> <a href="#ref-for-iso-8859-8②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-8-i">
-   <b><a href="#iso-8859-8-i">#iso-8859-8-i</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-8-i" class="dfn-panel" data-for="iso-8859-8-i" id="infopanel-for-iso-8859-8-i" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-8-i" style="display:none">Info about the 'ISO-8859-8-I' definition.</span><b><a href="#iso-8859-8-i">#iso-8859-8-i</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-8-i">4.2. Names and labels</a>
     <li><a href="#ref-for-iso-8859-8-i①">9. Legacy single-byte encodings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-10">
-   <b><a href="#iso-8859-10">#iso-8859-10</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-10" class="dfn-panel" data-for="iso-8859-10" id="infopanel-for-iso-8859-10" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-10" style="display:none">Info about the 'ISO-8859-10' definition.</span><b><a href="#iso-8859-10">#iso-8859-10</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-10">4.2. Names and labels</a> <a href="#ref-for-iso-8859-10①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-13">
-   <b><a href="#iso-8859-13">#iso-8859-13</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-13" class="dfn-panel" data-for="iso-8859-13" id="infopanel-for-iso-8859-13" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-13" style="display:none">Info about the 'ISO-8859-13' definition.</span><b><a href="#iso-8859-13">#iso-8859-13</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-13">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-14">
-   <b><a href="#iso-8859-14">#iso-8859-14</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-14" class="dfn-panel" data-for="iso-8859-14" id="infopanel-for-iso-8859-14" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-14" style="display:none">Info about the 'ISO-8859-14' definition.</span><b><a href="#iso-8859-14">#iso-8859-14</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-14">4.2. Names and labels</a> <a href="#ref-for-iso-8859-14①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-15">
-   <b><a href="#iso-8859-15">#iso-8859-15</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-15" class="dfn-panel" data-for="iso-8859-15" id="infopanel-for-iso-8859-15" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-15" style="display:none">Info about the 'ISO-8859-15' definition.</span><b><a href="#iso-8859-15">#iso-8859-15</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-15">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-8859-16">
-   <b><a href="#iso-8859-16">#iso-8859-16</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-8859-16" class="dfn-panel" data-for="iso-8859-16" id="infopanel-for-iso-8859-16" role="dialog">
+   <span id="infopaneltitle-for-iso-8859-16" style="display:none">Info about the 'ISO-8859-16' definition.</span><b><a href="#iso-8859-16">#iso-8859-16</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-8859-16">4.2. Names and labels</a> <a href="#ref-for-iso-8859-16①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="koi8-r">
-   <b><a href="#koi8-r">#koi8-r</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-koi8-r" class="dfn-panel" data-for="koi8-r" id="infopanel-for-koi8-r" role="dialog">
+   <span id="infopaneltitle-for-koi8-r" style="display:none">Info about the 'KOI8-R' definition.</span><b><a href="#koi8-r">#koi8-r</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-koi8-r">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="koi8-u">
-   <b><a href="#koi8-u">#koi8-u</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-koi8-u" class="dfn-panel" data-for="koi8-u" id="infopanel-for-koi8-u" role="dialog">
+   <span id="infopaneltitle-for-koi8-u" style="display:none">Info about the 'KOI8-U' definition.</span><b><a href="#koi8-u">#koi8-u</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-koi8-u">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="macintosh">
-   <b><a href="#macintosh">#macintosh</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-macintosh" class="dfn-panel" data-for="macintosh" id="infopanel-for-macintosh" role="dialog">
+   <span id="infopaneltitle-for-macintosh" style="display:none">Info about the 'macintosh' definition.</span><b><a href="#macintosh">#macintosh</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-macintosh">4.2. Names and labels</a> <a href="#ref-for-macintosh①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-874">
-   <b><a href="#windows-874">#windows-874</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-874" class="dfn-panel" data-for="windows-874" id="infopanel-for-windows-874" role="dialog">
+   <span id="infopaneltitle-for-windows-874" style="display:none">Info about the 'windows-874' definition.</span><b><a href="#windows-874">#windows-874</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-874">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1250">
-   <b><a href="#windows-1250">#windows-1250</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1250" class="dfn-panel" data-for="windows-1250" id="infopanel-for-windows-1250" role="dialog">
+   <span id="infopaneltitle-for-windows-1250" style="display:none">Info about the 'windows-1250' definition.</span><b><a href="#windows-1250">#windows-1250</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1250">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1251">
-   <b><a href="#windows-1251">#windows-1251</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1251" class="dfn-panel" data-for="windows-1251" id="infopanel-for-windows-1251" role="dialog">
+   <span id="infopaneltitle-for-windows-1251" style="display:none">Info about the 'windows-1251' definition.</span><b><a href="#windows-1251">#windows-1251</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1251">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1252">
-   <b><a href="#windows-1252">#windows-1252</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1252" class="dfn-panel" data-for="windows-1252" id="infopanel-for-windows-1252" role="dialog">
+   <span id="infopaneltitle-for-windows-1252" style="display:none">Info about the 'windows-1252' definition.</span><b><a href="#windows-1252">#windows-1252</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1252">2. Security background</a>
     <li><a href="#ref-for-windows-1252①">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1253">
-   <b><a href="#windows-1253">#windows-1253</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1253" class="dfn-panel" data-for="windows-1253" id="infopanel-for-windows-1253" role="dialog">
+   <span id="infopaneltitle-for-windows-1253" style="display:none">Info about the 'windows-1253' definition.</span><b><a href="#windows-1253">#windows-1253</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1253">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1254">
-   <b><a href="#windows-1254">#windows-1254</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1254" class="dfn-panel" data-for="windows-1254" id="infopanel-for-windows-1254" role="dialog">
+   <span id="infopaneltitle-for-windows-1254" style="display:none">Info about the 'windows-1254' definition.</span><b><a href="#windows-1254">#windows-1254</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1254">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1255">
-   <b><a href="#windows-1255">#windows-1255</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1255" class="dfn-panel" data-for="windows-1255" id="infopanel-for-windows-1255" role="dialog">
+   <span id="infopaneltitle-for-windows-1255" style="display:none">Info about the 'windows-1255' definition.</span><b><a href="#windows-1255">#windows-1255</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1255">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1256">
-   <b><a href="#windows-1256">#windows-1256</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1256" class="dfn-panel" data-for="windows-1256" id="infopanel-for-windows-1256" role="dialog">
+   <span id="infopaneltitle-for-windows-1256" style="display:none">Info about the 'windows-1256' definition.</span><b><a href="#windows-1256">#windows-1256</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1256">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1257">
-   <b><a href="#windows-1257">#windows-1257</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1257" class="dfn-panel" data-for="windows-1257" id="infopanel-for-windows-1257" role="dialog">
+   <span id="infopaneltitle-for-windows-1257" style="display:none">Info about the 'windows-1257' definition.</span><b><a href="#windows-1257">#windows-1257</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1257">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-1258">
-   <b><a href="#windows-1258">#windows-1258</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-1258" class="dfn-panel" data-for="windows-1258" id="infopanel-for-windows-1258" role="dialog">
+   <span id="infopaneltitle-for-windows-1258" style="display:none">Info about the 'windows-1258' definition.</span><b><a href="#windows-1258">#windows-1258</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-1258">4.2. Names and labels</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-mac-cyrillic">
-   <b><a href="#x-mac-cyrillic">#x-mac-cyrillic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-mac-cyrillic" class="dfn-panel" data-for="x-mac-cyrillic" id="infopanel-for-x-mac-cyrillic" role="dialog">
+   <span id="infopaneltitle-for-x-mac-cyrillic" style="display:none">Info about the 'x-mac-cyrillic' definition.</span><b><a href="#x-mac-cyrillic">#x-mac-cyrillic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-mac-cyrillic">4.2. Names and labels</a> <a href="#ref-for-x-mac-cyrillic①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-byte-decoder">
-   <b><a href="#single-byte-decoder">#single-byte-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-byte-decoder" class="dfn-panel" data-for="single-byte-decoder" id="infopanel-for-single-byte-decoder" role="dialog">
+   <span id="infopaneltitle-for-single-byte-decoder" style="display:none">Info about the '9.1. single-byte decoder' definition.</span><b><a href="#single-byte-decoder">#single-byte-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-byte-decoder">9. Legacy single-byte encodings</a>
     <li><a href="#ref-for-single-byte-decoder">9.1. single-byte decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-byte-encoder">
-   <b><a href="#single-byte-encoder">#single-byte-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-byte-encoder" class="dfn-panel" data-for="single-byte-encoder" id="infopanel-for-single-byte-encoder" role="dialog">
+   <span id="infopaneltitle-for-single-byte-encoder" style="display:none">Info about the '9.2. single-byte encoder' definition.</span><b><a href="#single-byte-encoder">#single-byte-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-byte-encoder">9. Legacy single-byte encodings</a>
     <li><a href="#ref-for-single-byte-encoder">9.2. single-byte encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gbk">
-   <b><a href="#gbk">#gbk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gbk" class="dfn-panel" data-for="gbk" id="infopanel-for-gbk" role="dialog">
+   <span id="infopaneltitle-for-gbk" style="display:none">Info about the '10.1. GBK' definition.</span><b><a href="#gbk">#gbk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gbk">4.2. Names and labels</a>
     <li><a href="#ref-for-gbk">10.1. GBK</a>
@@ -5318,20 +5318,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-gbk②">10.1.2. GBK encoder</a> <a href="#ref-for-gbk③">(2)</a> <a href="#ref-for-gbk④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gbk-decoder">
-   <b><a href="#gbk-decoder">#gbk-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gbk-decoder" class="dfn-panel" data-for="gbk-decoder" id="infopanel-for-gbk-decoder" role="dialog">
+   <span id="infopaneltitle-for-gbk-decoder" style="display:none">Info about the '10.1.1. GBK decoder' definition.</span><b><a href="#gbk-decoder">#gbk-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gbk-decoder">10.1.1. GBK decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gbk-encoder">
-   <b><a href="#gbk-encoder">#gbk-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gbk-encoder" class="dfn-panel" data-for="gbk-encoder" id="infopanel-for-gbk-encoder" role="dialog">
+   <span id="infopaneltitle-for-gbk-encoder" style="display:none">Info about the '10.1.2. GBK encoder' definition.</span><b><a href="#gbk-encoder">#gbk-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gbk-encoder">10.1.2. GBK encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030">
-   <b><a href="#gb18030">#gb18030</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030" class="dfn-panel" data-for="gb18030" id="infopanel-for-gb18030" role="dialog">
+   <span id="infopaneltitle-for-gb18030" style="display:none">Info about the '10.2. gb18030' definition.</span><b><a href="#gb18030">#gb18030</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030">4.2. Names and labels</a>
     <li><a href="#ref-for-gb18030①">10.1.1. GBK decoder</a>
@@ -5342,49 +5342,49 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-gb18030⑧">Implementation considerations</a> <a href="#ref-for-gb18030⑨">(2)</a> <a href="#ref-for-gb18030①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030-decoder">
-   <b><a href="#gb18030-decoder">#gb18030-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030-decoder" class="dfn-panel" data-for="gb18030-decoder" id="infopanel-for-gb18030-decoder" role="dialog">
+   <span id="infopaneltitle-for-gb18030-decoder" style="display:none">Info about the '10.2.1. gb18030 decoder' definition.</span><b><a href="#gb18030-decoder">#gb18030-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030-decoder">2. Security background</a>
     <li><a href="#ref-for-gb18030-decoder">10.2.1. gb18030 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030-first">
-   <b><a href="#gb18030-first">#gb18030-first</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030-first" class="dfn-panel" data-for="gb18030-first" id="infopanel-for-gb18030-first" role="dialog">
+   <span id="infopaneltitle-for-gb18030-first" style="display:none">Info about the 'gb18030 first' definition.</span><b><a href="#gb18030-first">#gb18030-first</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030-first">10.2.1. gb18030 decoder</a> <a href="#ref-for-gb18030-first①">(2)</a> <a href="#ref-for-gb18030-first②">(3)</a> <a href="#ref-for-gb18030-first③">(4)</a> <a href="#ref-for-gb18030-first④">(5)</a> <a href="#ref-for-gb18030-first⑤">(6)</a> <a href="#ref-for-gb18030-first⑥">(7)</a> <a href="#ref-for-gb18030-first⑦">(8)</a> <a href="#ref-for-gb18030-first⑧">(9)</a> <a href="#ref-for-gb18030-first⑨">(10)</a> <a href="#ref-for-gb18030-first①⓪">(11)</a>
     <li><a href="#ref-for-gb18030-first①①">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030-second">
-   <b><a href="#gb18030-second">#gb18030-second</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030-second" class="dfn-panel" data-for="gb18030-second" id="infopanel-for-gb18030-second" role="dialog">
+   <span id="infopaneltitle-for-gb18030-second" style="display:none">Info about the 'gb18030 second' definition.</span><b><a href="#gb18030-second">#gb18030-second</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030-second">10.2.1. gb18030 decoder</a> <a href="#ref-for-gb18030-second①">(2)</a> <a href="#ref-for-gb18030-second②">(3)</a> <a href="#ref-for-gb18030-second③">(4)</a> <a href="#ref-for-gb18030-second④">(5)</a> <a href="#ref-for-gb18030-second⑤">(6)</a> <a href="#ref-for-gb18030-second⑥">(7)</a> <a href="#ref-for-gb18030-second⑦">(8)</a> <a href="#ref-for-gb18030-second⑧">(9)</a> <a href="#ref-for-gb18030-second⑨">(10)</a> <a href="#ref-for-gb18030-second①⓪">(11)</a>
     <li><a href="#ref-for-gb18030-second①①">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030-third">
-   <b><a href="#gb18030-third">#gb18030-third</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030-third" class="dfn-panel" data-for="gb18030-third" id="infopanel-for-gb18030-third" role="dialog">
+   <span id="infopaneltitle-for-gb18030-third" style="display:none">Info about the 'gb18030 third' definition.</span><b><a href="#gb18030-third">#gb18030-third</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030-third">10.2.1. gb18030 decoder</a> <a href="#ref-for-gb18030-third①">(2)</a> <a href="#ref-for-gb18030-third②">(3)</a> <a href="#ref-for-gb18030-third③">(4)</a> <a href="#ref-for-gb18030-third④">(5)</a> <a href="#ref-for-gb18030-third⑤">(6)</a> <a href="#ref-for-gb18030-third⑥">(7)</a> <a href="#ref-for-gb18030-third⑦">(8)</a> <a href="#ref-for-gb18030-third⑧">(9)</a>
     <li><a href="#ref-for-gb18030-third⑨">Implementation considerations</a> <a href="#ref-for-gb18030-third①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gb18030-encoder">
-   <b><a href="#gb18030-encoder">#gb18030-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gb18030-encoder" class="dfn-panel" data-for="gb18030-encoder" id="infopanel-for-gb18030-encoder" role="dialog">
+   <span id="infopaneltitle-for-gb18030-encoder" style="display:none">Info about the '10.2.2. gb18030 encoder' definition.</span><b><a href="#gb18030-encoder">#gb18030-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gb18030-encoder">10.2.2. gb18030 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="gbk-flag">
-   <b><a href="#gbk-flag">#gbk-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-gbk-flag" class="dfn-panel" data-for="gbk-flag" id="infopanel-for-gbk-flag" role="dialog">
+   <span id="infopaneltitle-for-gbk-flag" style="display:none">Info about the 'is GBK' definition.</span><b><a href="#gbk-flag">#gbk-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gbk-flag">10.1.2. GBK encoder</a>
     <li><a href="#ref-for-gbk-flag①">10.2.2. gb18030 encoder</a> <a href="#ref-for-gbk-flag②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="big5">
-   <b><a href="#big5">#big5</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-big5" class="dfn-panel" data-for="big5" id="infopanel-for-big5" role="dialog">
+   <span id="infopaneltitle-for-big5" style="display:none">Info about the '11.1. Big5' definition.</span><b><a href="#big5">#big5</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-big5">4.2. Names and labels</a>
     <li><a href="#ref-for-big5">11.1. Big5</a>
@@ -5392,26 +5392,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-big5③">11.1.2. Big5 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="big5-decoder">
-   <b><a href="#big5-decoder">#big5-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-big5-decoder" class="dfn-panel" data-for="big5-decoder" id="infopanel-for-big5-decoder" role="dialog">
+   <span id="infopaneltitle-for-big5-decoder" style="display:none">Info about the '11.1.1. Big5 decoder' definition.</span><b><a href="#big5-decoder">#big5-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-big5-decoder">11.1.1. Big5 decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="big5-lead">
-   <b><a href="#big5-lead">#big5-lead</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-big5-lead" class="dfn-panel" data-for="big5-lead" id="infopanel-for-big5-lead" role="dialog">
+   <span id="infopaneltitle-for-big5-lead" style="display:none">Info about the 'Big5 lead' definition.</span><b><a href="#big5-lead">#big5-lead</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-big5-lead">11.1.1. Big5 decoder</a> <a href="#ref-for-big5-lead①">(2)</a> <a href="#ref-for-big5-lead②">(3)</a> <a href="#ref-for-big5-lead③">(4)</a> <a href="#ref-for-big5-lead④">(5)</a> <a href="#ref-for-big5-lead⑤">(6)</a> <a href="#ref-for-big5-lead⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="big5-encoder">
-   <b><a href="#big5-encoder">#big5-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-big5-encoder" class="dfn-panel" data-for="big5-encoder" id="infopanel-for-big5-encoder" role="dialog">
+   <span id="infopaneltitle-for-big5-encoder" style="display:none">Info about the '11.1.2. Big5 encoder' definition.</span><b><a href="#big5-encoder">#big5-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-big5-encoder">11.1.2. Big5 encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-jp">
-   <b><a href="#euc-jp">#euc-jp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-jp" class="dfn-panel" data-for="euc-jp" id="infopanel-for-euc-jp" role="dialog">
+   <span id="infopaneltitle-for-euc-jp" style="display:none">Info about the '12.1. EUC-JP' definition.</span><b><a href="#euc-jp">#euc-jp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-jp">4.2. Names and labels</a>
     <li><a href="#ref-for-euc-jp">12.1. EUC-JP</a>
@@ -5419,33 +5419,33 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-euc-jp③">12.1.2. EUC-JP encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-jp-decoder">
-   <b><a href="#euc-jp-decoder">#euc-jp-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-jp-decoder" class="dfn-panel" data-for="euc-jp-decoder" id="infopanel-for-euc-jp-decoder" role="dialog">
+   <span id="infopaneltitle-for-euc-jp-decoder" style="display:none">Info about the '12.1.1. EUC-JP decoder' definition.</span><b><a href="#euc-jp-decoder">#euc-jp-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-jp-decoder">5. Indexes</a>
     <li><a href="#ref-for-euc-jp-decoder">12.1.1. EUC-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-jp-jis0212-flag">
-   <b><a href="#euc-jp-jis0212-flag">#euc-jp-jis0212-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-jp-jis0212-flag" class="dfn-panel" data-for="euc-jp-jis0212-flag" id="infopanel-for-euc-jp-jis0212-flag" role="dialog">
+   <span id="infopaneltitle-for-euc-jp-jis0212-flag" style="display:none">Info about the 'EUC-JP jis0212' definition.</span><b><a href="#euc-jp-jis0212-flag">#euc-jp-jis0212-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-jp-jis0212-flag">12.1.1. EUC-JP decoder</a> <a href="#ref-for-euc-jp-jis0212-flag①">(2)</a> <a href="#ref-for-euc-jp-jis0212-flag②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-jp-lead">
-   <b><a href="#euc-jp-lead">#euc-jp-lead</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-jp-lead" class="dfn-panel" data-for="euc-jp-lead" id="infopanel-for-euc-jp-lead" role="dialog">
+   <span id="infopaneltitle-for-euc-jp-lead" style="display:none">Info about the 'EUC-JP lead' definition.</span><b><a href="#euc-jp-lead">#euc-jp-lead</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-jp-lead">12.1.1. EUC-JP decoder</a> <a href="#ref-for-euc-jp-lead①">(2)</a> <a href="#ref-for-euc-jp-lead②">(3)</a> <a href="#ref-for-euc-jp-lead③">(4)</a> <a href="#ref-for-euc-jp-lead④">(5)</a> <a href="#ref-for-euc-jp-lead⑤">(6)</a> <a href="#ref-for-euc-jp-lead⑥">(7)</a> <a href="#ref-for-euc-jp-lead⑦">(8)</a> <a href="#ref-for-euc-jp-lead⑧">(9)</a> <a href="#ref-for-euc-jp-lead⑨">(10)</a> <a href="#ref-for-euc-jp-lead①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-jp-encoder">
-   <b><a href="#euc-jp-encoder">#euc-jp-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-jp-encoder" class="dfn-panel" data-for="euc-jp-encoder" id="infopanel-for-euc-jp-encoder" role="dialog">
+   <span id="infopaneltitle-for-euc-jp-encoder" style="display:none">Info about the '12.1.2. EUC-JP encoder' definition.</span><b><a href="#euc-jp-encoder">#euc-jp-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-jp-encoder">12.1.2. EUC-JP encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp">
-   <b><a href="#iso-2022-jp">#iso-2022-jp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp" class="dfn-panel" data-for="iso-2022-jp" id="infopanel-for-iso-2022-jp" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp" style="display:none">Info about the '12.2. ISO-2022-JP' definition.</span><b><a href="#iso-2022-jp">#iso-2022-jp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp">2. Security background</a>
     <li><a href="#ref-for-iso-2022-jp①">4.2. Names and labels</a>
@@ -5455,81 +5455,81 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-iso-2022-jp⑥">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder">
-   <b><a href="#iso-2022-jp-decoder">#iso-2022-jp-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder" class="dfn-panel" data-for="iso-2022-jp-decoder" id="infopanel-for-iso-2022-jp-decoder" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder" style="display:none">Info about the '12.2.1. ISO-2022-JP decoder' definition.</span><b><a href="#iso-2022-jp-decoder">#iso-2022-jp-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder">12.2.1. ISO-2022-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-state">
-   <b><a href="#iso-2022-jp-decoder-state">#iso-2022-jp-decoder-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-state" class="dfn-panel" data-for="iso-2022-jp-decoder-state" id="infopanel-for-iso-2022-jp-decoder-state" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-state" style="display:none">Info about the 'ISO-2022-JP decoder state' definition.</span><b><a href="#iso-2022-jp-decoder-state">#iso-2022-jp-decoder-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-state">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-decoder-state①">(2)</a> <a href="#ref-for-iso-2022-jp-decoder-state②">(3)</a> <a href="#ref-for-iso-2022-jp-decoder-state③">(4)</a> <a href="#ref-for-iso-2022-jp-decoder-state④">(5)</a> <a href="#ref-for-iso-2022-jp-decoder-state⑤">(6)</a> <a href="#ref-for-iso-2022-jp-decoder-state⑥">(7)</a> <a href="#ref-for-iso-2022-jp-decoder-state⑦">(8)</a> <a href="#ref-for-iso-2022-jp-decoder-state⑧">(9)</a> <a href="#ref-for-iso-2022-jp-decoder-state⑨">(10)</a> <a href="#ref-for-iso-2022-jp-decoder-state①⓪">(11)</a> <a href="#ref-for-iso-2022-jp-decoder-state①①">(12)</a> <a href="#ref-for-iso-2022-jp-decoder-state①②">(13)</a> <a href="#ref-for-iso-2022-jp-decoder-state①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-output-state">
-   <b><a href="#iso-2022-jp-decoder-output-state">#iso-2022-jp-decoder-output-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-output-state" class="dfn-panel" data-for="iso-2022-jp-decoder-output-state" id="infopanel-for-iso-2022-jp-decoder-output-state" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-output-state" style="display:none">Info about the 'ISO-2022-JP decoder output state' definition.</span><b><a href="#iso-2022-jp-decoder-output-state">#iso-2022-jp-decoder-output-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-output-state">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-decoder-output-state①">(2)</a> <a href="#ref-for-iso-2022-jp-decoder-output-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-lead">
-   <b><a href="#iso-2022-jp-lead">#iso-2022-jp-lead</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-lead" class="dfn-panel" data-for="iso-2022-jp-lead" id="infopanel-for-iso-2022-jp-lead" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-lead" style="display:none">Info about the 'ISO-2022-JP lead' definition.</span><b><a href="#iso-2022-jp-lead">#iso-2022-jp-lead</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-lead">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-lead①">(2)</a> <a href="#ref-for-iso-2022-jp-lead②">(3)</a> <a href="#ref-for-iso-2022-jp-lead③">(4)</a> <a href="#ref-for-iso-2022-jp-lead④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-output-flag">
-   <b><a href="#iso-2022-jp-output-flag">#iso-2022-jp-output-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-output-flag" class="dfn-panel" data-for="iso-2022-jp-output-flag" id="infopanel-for-iso-2022-jp-output-flag" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-output-flag" style="display:none">Info about the 'ISO-2022-JP output' definition.</span><b><a href="#iso-2022-jp-output-flag">#iso-2022-jp-output-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-output-flag">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-output-flag①">(2)</a> <a href="#ref-for-iso-2022-jp-output-flag②">(3)</a> <a href="#ref-for-iso-2022-jp-output-flag③">(4)</a> <a href="#ref-for-iso-2022-jp-output-flag④">(5)</a> <a href="#ref-for-iso-2022-jp-output-flag⑤">(6)</a> <a href="#ref-for-iso-2022-jp-output-flag⑥">(7)</a> <a href="#ref-for-iso-2022-jp-output-flag⑦">(8)</a> <a href="#ref-for-iso-2022-jp-output-flag⑧">(9)</a> <a href="#ref-for-iso-2022-jp-output-flag⑨">(10)</a> <a href="#ref-for-iso-2022-jp-output-flag①⓪">(11)</a> <a href="#ref-for-iso-2022-jp-output-flag①①">(12)</a> <a href="#ref-for-iso-2022-jp-output-flag①②">(13)</a> <a href="#ref-for-iso-2022-jp-output-flag①③">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-ascii">
-   <b><a href="#iso-2022-jp-decoder-ascii">#iso-2022-jp-decoder-ascii</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-ascii" class="dfn-panel" data-for="iso-2022-jp-decoder-ascii" id="infopanel-for-iso-2022-jp-decoder-ascii" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-ascii" style="display:none">Info about the 'ASCII' definition.</span><b><a href="#iso-2022-jp-decoder-ascii">#iso-2022-jp-decoder-ascii</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-ascii">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-decoder-ascii①">(2)</a> <a href="#ref-for-iso-2022-jp-decoder-ascii②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-roman">
-   <b><a href="#iso-2022-jp-decoder-roman">#iso-2022-jp-decoder-roman</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-roman" class="dfn-panel" data-for="iso-2022-jp-decoder-roman" id="infopanel-for-iso-2022-jp-decoder-roman" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-roman" style="display:none">Info about the 'Roman' definition.</span><b><a href="#iso-2022-jp-decoder-roman">#iso-2022-jp-decoder-roman</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-roman">6.1. Legacy hooks for standards</a>
     <li><a href="#ref-for-iso-2022-jp-decoder-roman①">12.2.1. ISO-2022-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-katakana">
-   <b><a href="#iso-2022-jp-decoder-katakana">#iso-2022-jp-decoder-katakana</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-katakana" class="dfn-panel" data-for="iso-2022-jp-decoder-katakana" id="infopanel-for-iso-2022-jp-decoder-katakana" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-katakana" style="display:none">Info about the 'katakana' definition.</span><b><a href="#iso-2022-jp-decoder-katakana">#iso-2022-jp-decoder-katakana</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-katakana">12.2.1. ISO-2022-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-lead-byte">
-   <b><a href="#iso-2022-jp-decoder-lead-byte">#iso-2022-jp-decoder-lead-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-lead-byte" class="dfn-panel" data-for="iso-2022-jp-decoder-lead-byte" id="infopanel-for-iso-2022-jp-decoder-lead-byte" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-lead-byte" style="display:none">Info about the 'Lead byte' definition.</span><b><a href="#iso-2022-jp-decoder-lead-byte">#iso-2022-jp-decoder-lead-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-lead-byte">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-decoder-lead-byte①">(2)</a> <a href="#ref-for-iso-2022-jp-decoder-lead-byte②">(3)</a> <a href="#ref-for-iso-2022-jp-decoder-lead-byte③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-trail-byte">
-   <b><a href="#iso-2022-jp-decoder-trail-byte">#iso-2022-jp-decoder-trail-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-trail-byte" class="dfn-panel" data-for="iso-2022-jp-decoder-trail-byte" id="infopanel-for-iso-2022-jp-decoder-trail-byte" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-trail-byte" style="display:none">Info about the 'Trail byte' definition.</span><b><a href="#iso-2022-jp-decoder-trail-byte">#iso-2022-jp-decoder-trail-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-trail-byte">12.2.1. ISO-2022-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-escape-start">
-   <b><a href="#iso-2022-jp-decoder-escape-start">#iso-2022-jp-decoder-escape-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-escape-start" class="dfn-panel" data-for="iso-2022-jp-decoder-escape-start" id="infopanel-for-iso-2022-jp-decoder-escape-start" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-escape-start" style="display:none">Info about the 'Escape start' definition.</span><b><a href="#iso-2022-jp-decoder-escape-start">#iso-2022-jp-decoder-escape-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-escape-start">12.2.1. ISO-2022-JP decoder</a> <a href="#ref-for-iso-2022-jp-decoder-escape-start①">(2)</a> <a href="#ref-for-iso-2022-jp-decoder-escape-start②">(3)</a> <a href="#ref-for-iso-2022-jp-decoder-escape-start③">(4)</a> <a href="#ref-for-iso-2022-jp-decoder-escape-start④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-decoder-escape">
-   <b><a href="#iso-2022-jp-decoder-escape">#iso-2022-jp-decoder-escape</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-decoder-escape" class="dfn-panel" data-for="iso-2022-jp-decoder-escape" id="infopanel-for-iso-2022-jp-decoder-escape" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-decoder-escape" style="display:none">Info about the 'Escape' definition.</span><b><a href="#iso-2022-jp-decoder-escape">#iso-2022-jp-decoder-escape</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-decoder-escape">12.2.1. ISO-2022-JP decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-encoder">
-   <b><a href="#iso-2022-jp-encoder">#iso-2022-jp-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-encoder" class="dfn-panel" data-for="iso-2022-jp-encoder" id="infopanel-for-iso-2022-jp-encoder" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-encoder" style="display:none">Info about the '12.2.2. ISO-2022-JP encoder' definition.</span><b><a href="#iso-2022-jp-encoder">#iso-2022-jp-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder">5. Indexes</a>
     <li><a href="#ref-for-iso-2022-jp-encoder①">6.1. Legacy hooks for standards</a> <a href="#ref-for-iso-2022-jp-encoder②">(2)</a> <a href="#ref-for-iso-2022-jp-encoder③">(3)</a>
@@ -5537,33 +5537,33 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-iso-2022-jp-encoder⑤">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-encoder-state">
-   <b><a href="#iso-2022-jp-encoder-state">#iso-2022-jp-encoder-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-encoder-state" class="dfn-panel" data-for="iso-2022-jp-encoder-state" id="infopanel-for-iso-2022-jp-encoder-state" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-encoder-state" style="display:none">Info about the 'ISO-2022-JP encoder state' definition.</span><b><a href="#iso-2022-jp-encoder-state">#iso-2022-jp-encoder-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder-state">12.2.2. ISO-2022-JP encoder</a> <a href="#ref-for-iso-2022-jp-encoder-state①">(2)</a> <a href="#ref-for-iso-2022-jp-encoder-state②">(3)</a> <a href="#ref-for-iso-2022-jp-encoder-state③">(4)</a> <a href="#ref-for-iso-2022-jp-encoder-state④">(5)</a> <a href="#ref-for-iso-2022-jp-encoder-state⑤">(6)</a> <a href="#ref-for-iso-2022-jp-encoder-state⑥">(7)</a> <a href="#ref-for-iso-2022-jp-encoder-state⑦">(8)</a> <a href="#ref-for-iso-2022-jp-encoder-state⑧">(9)</a> <a href="#ref-for-iso-2022-jp-encoder-state⑨">(10)</a> <a href="#ref-for-iso-2022-jp-encoder-state①⓪">(11)</a> <a href="#ref-for-iso-2022-jp-encoder-state①①">(12)</a> <a href="#ref-for-iso-2022-jp-encoder-state①②">(13)</a> <a href="#ref-for-iso-2022-jp-encoder-state①③">(14)</a>
     <li><a href="#ref-for-iso-2022-jp-encoder-state①④">Implementation considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-encoder-ascii">
-   <b><a href="#iso-2022-jp-encoder-ascii">#iso-2022-jp-encoder-ascii</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-encoder-ascii" class="dfn-panel" data-for="iso-2022-jp-encoder-ascii" id="infopanel-for-iso-2022-jp-encoder-ascii" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-encoder-ascii" style="display:none">Info about the 'ASCII' definition.</span><b><a href="#iso-2022-jp-encoder-ascii">#iso-2022-jp-encoder-ascii</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder-ascii">12.2.2. ISO-2022-JP encoder</a> <a href="#ref-for-iso-2022-jp-encoder-ascii①">(2)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii②">(3)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii③">(4)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii④">(5)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii⑤">(6)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii⑥">(7)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii⑦">(8)</a> <a href="#ref-for-iso-2022-jp-encoder-ascii⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-encoder-roman">
-   <b><a href="#iso-2022-jp-encoder-roman">#iso-2022-jp-encoder-roman</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-encoder-roman" class="dfn-panel" data-for="iso-2022-jp-encoder-roman" id="infopanel-for-iso-2022-jp-encoder-roman" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-encoder-roman" style="display:none">Info about the 'Roman' definition.</span><b><a href="#iso-2022-jp-encoder-roman">#iso-2022-jp-encoder-roman</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder-roman">12.2.2. ISO-2022-JP encoder</a> <a href="#ref-for-iso-2022-jp-encoder-roman①">(2)</a> <a href="#ref-for-iso-2022-jp-encoder-roman②">(3)</a> <a href="#ref-for-iso-2022-jp-encoder-roman③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iso-2022-jp-encoder-jis0208">
-   <b><a href="#iso-2022-jp-encoder-jis0208">#iso-2022-jp-encoder-jis0208</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iso-2022-jp-encoder-jis0208" class="dfn-panel" data-for="iso-2022-jp-encoder-jis0208" id="infopanel-for-iso-2022-jp-encoder-jis0208" role="dialog">
+   <span id="infopaneltitle-for-iso-2022-jp-encoder-jis0208" style="display:none">Info about the 'jis0208' definition.</span><b><a href="#iso-2022-jp-encoder-jis0208">#iso-2022-jp-encoder-jis0208</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder-jis0208">12.2.2. ISO-2022-JP encoder</a> <a href="#ref-for-iso-2022-jp-encoder-jis0208①">(2)</a> <a href="#ref-for-iso-2022-jp-encoder-jis0208②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shift_jis">
-   <b><a href="#shift_jis">#shift_jis</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shift_jis" class="dfn-panel" data-for="shift_jis" id="infopanel-for-shift_jis" role="dialog">
+   <span id="infopaneltitle-for-shift_jis" style="display:none">Info about the '12.3. Shift_JIS' definition.</span><b><a href="#shift_jis">#shift_jis</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shift_jis">2. Security background</a>
     <li><a href="#ref-for-shift_jis①">4.2. Names and labels</a>
@@ -5573,26 +5573,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-shift_jis⑤">12.3.2. Shift_JIS encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shift_jis-decoder">
-   <b><a href="#shift_jis-decoder">#shift_jis-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shift_jis-decoder" class="dfn-panel" data-for="shift_jis-decoder" id="infopanel-for-shift_jis-decoder" role="dialog">
+   <span id="infopaneltitle-for-shift_jis-decoder" style="display:none">Info about the '12.3.1. Shift_JIS decoder' definition.</span><b><a href="#shift_jis-decoder">#shift_jis-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shift_jis-decoder">12.3.1. Shift_JIS decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shift_jis-lead">
-   <b><a href="#shift_jis-lead">#shift_jis-lead</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shift_jis-lead" class="dfn-panel" data-for="shift_jis-lead" id="infopanel-for-shift_jis-lead" role="dialog">
+   <span id="infopaneltitle-for-shift_jis-lead" style="display:none">Info about the 'Shift_JIS lead' definition.</span><b><a href="#shift_jis-lead">#shift_jis-lead</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shift_jis-lead">12.3.1. Shift_JIS decoder</a> <a href="#ref-for-shift_jis-lead①">(2)</a> <a href="#ref-for-shift_jis-lead②">(3)</a> <a href="#ref-for-shift_jis-lead③">(4)</a> <a href="#ref-for-shift_jis-lead④">(5)</a> <a href="#ref-for-shift_jis-lead⑤">(6)</a> <a href="#ref-for-shift_jis-lead⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shift_jis-encoder">
-   <b><a href="#shift_jis-encoder">#shift_jis-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shift_jis-encoder" class="dfn-panel" data-for="shift_jis-encoder" id="infopanel-for-shift_jis-encoder" role="dialog">
+   <span id="infopaneltitle-for-shift_jis-encoder" style="display:none">Info about the '12.3.2. Shift_JIS encoder' definition.</span><b><a href="#shift_jis-encoder">#shift_jis-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shift_jis-encoder">12.3.2. Shift_JIS encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-kr">
-   <b><a href="#euc-kr">#euc-kr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-kr" class="dfn-panel" data-for="euc-kr" id="infopanel-for-euc-kr" role="dialog">
+   <span id="infopaneltitle-for-euc-kr" style="display:none">Info about the '13.1. EUC-KR' definition.</span><b><a href="#euc-kr">#euc-kr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-kr">4.2. Names and labels</a>
     <li><a href="#ref-for-euc-kr">13.1. EUC-KR</a>
@@ -5600,26 +5600,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-euc-kr③">13.1.2. EUC-KR encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-kr-decoder">
-   <b><a href="#euc-kr-decoder">#euc-kr-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-kr-decoder" class="dfn-panel" data-for="euc-kr-decoder" id="infopanel-for-euc-kr-decoder" role="dialog">
+   <span id="infopaneltitle-for-euc-kr-decoder" style="display:none">Info about the '13.1.1. EUC-KR decoder' definition.</span><b><a href="#euc-kr-decoder">#euc-kr-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-kr-decoder">13.1.1. EUC-KR decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-kr-lead">
-   <b><a href="#euc-kr-lead">#euc-kr-lead</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-kr-lead" class="dfn-panel" data-for="euc-kr-lead" id="infopanel-for-euc-kr-lead" role="dialog">
+   <span id="infopaneltitle-for-euc-kr-lead" style="display:none">Info about the 'EUC-KR lead' definition.</span><b><a href="#euc-kr-lead">#euc-kr-lead</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-kr-lead">13.1.1. EUC-KR decoder</a> <a href="#ref-for-euc-kr-lead①">(2)</a> <a href="#ref-for-euc-kr-lead②">(3)</a> <a href="#ref-for-euc-kr-lead③">(4)</a> <a href="#ref-for-euc-kr-lead④">(5)</a> <a href="#ref-for-euc-kr-lead⑤">(6)</a> <a href="#ref-for-euc-kr-lead⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="euc-kr-encoder">
-   <b><a href="#euc-kr-encoder">#euc-kr-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-euc-kr-encoder" class="dfn-panel" data-for="euc-kr-encoder" id="infopanel-for-euc-kr-encoder" role="dialog">
+   <span id="infopaneltitle-for-euc-kr-encoder" style="display:none">Info about the '13.1.2. EUC-KR encoder' definition.</span><b><a href="#euc-kr-encoder">#euc-kr-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-euc-kr-encoder">13.1.2. EUC-KR encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replacement">
-   <b><a href="#replacement">#replacement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replacement" class="dfn-panel" data-for="replacement" id="infopanel-for-replacement" role="dialog">
+   <span id="infopaneltitle-for-replacement" style="display:none">Info about the '14.1. replacement' definition.</span><b><a href="#replacement">#replacement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replacement">2. Security background</a>
     <li><a href="#ref-for-replacement①">4.1. Encoders and decoders</a>
@@ -5632,20 +5632,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-replacement①⓪">14.1.1. replacement decoder</a> <a href="#ref-for-replacement①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replacement-decoder">
-   <b><a href="#replacement-decoder">#replacement-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replacement-decoder" class="dfn-panel" data-for="replacement-decoder" id="infopanel-for-replacement-decoder" role="dialog">
+   <span id="infopaneltitle-for-replacement-decoder" style="display:none">Info about the '14.1.1. replacement decoder' definition.</span><b><a href="#replacement-decoder">#replacement-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replacement-decoder">14.1.1. replacement decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="replacement-error-returned-flag">
-   <b><a href="#replacement-error-returned-flag">#replacement-error-returned-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-replacement-error-returned-flag" class="dfn-panel" data-for="replacement-error-returned-flag" id="infopanel-for-replacement-error-returned-flag" role="dialog">
+   <span id="infopaneltitle-for-replacement-error-returned-flag" style="display:none">Info about the 'replacement error returned' definition.</span><b><a href="#replacement-error-returned-flag">#replacement-error-returned-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replacement-error-returned-flag">14.1.1. replacement decoder</a> <a href="#ref-for-replacement-error-returned-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16be-le">
-   <b><a href="#utf-16be-le">#utf-16be-le</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16be-le" class="dfn-panel" data-for="utf-16be-le" id="infopanel-for-utf-16be-le" role="dialog">
+   <span id="infopaneltitle-for-utf-16be-le" style="display:none">Info about the 'UTF-16BE/LE' definition.</span><b><a href="#utf-16be-le">#utf-16be-le</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16be-le">2. Security background</a>
     <li><a href="#ref-for-utf-16be-le①">4.1. Encoders and decoders</a>
@@ -5656,35 +5656,35 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-16be-le⑥">15. Browser UI</a> <a href="#ref-for-utf-16be-le⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shared-utf-16-decoder">
-   <b><a href="#shared-utf-16-decoder">#shared-utf-16-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shared-utf-16-decoder" class="dfn-panel" data-for="shared-utf-16-decoder" id="infopanel-for-shared-utf-16-decoder" role="dialog">
+   <span id="infopaneltitle-for-shared-utf-16-decoder" style="display:none">Info about the '14.2.1. shared UTF-16 decoder' definition.</span><b><a href="#shared-utf-16-decoder">#shared-utf-16-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shared-utf-16-decoder">14.2.1. shared UTF-16 decoder</a> <a href="#ref-for-shared-utf-16-decoder">(2)</a> <a href="#ref-for-shared-utf-16-decoder①">(3)</a> <a href="#ref-for-shared-utf-16-decoder②">(4)</a>
     <li><a href="#ref-for-shared-utf-16-decoder③">14.3.1. UTF-16BE decoder</a>
     <li><a href="#ref-for-shared-utf-16-decoder④">14.4.1. UTF-16LE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16-lead-byte">
-   <b><a href="#utf-16-lead-byte">#utf-16-lead-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16-lead-byte" class="dfn-panel" data-for="utf-16-lead-byte" id="infopanel-for-utf-16-lead-byte" role="dialog">
+   <span id="infopaneltitle-for-utf-16-lead-byte" style="display:none">Info about the 'UTF-16 lead byte' definition.</span><b><a href="#utf-16-lead-byte">#utf-16-lead-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16-lead-byte">14.2.1. shared UTF-16 decoder</a> <a href="#ref-for-utf-16-lead-byte①">(2)</a> <a href="#ref-for-utf-16-lead-byte②">(3)</a> <a href="#ref-for-utf-16-lead-byte③">(4)</a> <a href="#ref-for-utf-16-lead-byte④">(5)</a> <a href="#ref-for-utf-16-lead-byte⑤">(6)</a> <a href="#ref-for-utf-16-lead-byte⑥">(7)</a> <a href="#ref-for-utf-16-lead-byte⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16-lead-surrogate">
-   <b><a href="#utf-16-lead-surrogate">#utf-16-lead-surrogate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16-lead-surrogate" class="dfn-panel" data-for="utf-16-lead-surrogate" id="infopanel-for-utf-16-lead-surrogate" role="dialog">
+   <span id="infopaneltitle-for-utf-16-lead-surrogate" style="display:none">Info about the 'UTF-16 lead surrogate' definition.</span><b><a href="#utf-16-lead-surrogate">#utf-16-lead-surrogate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16-lead-surrogate">14.2.1. shared UTF-16 decoder</a> <a href="#ref-for-utf-16-lead-surrogate①">(2)</a> <a href="#ref-for-utf-16-lead-surrogate②">(3)</a> <a href="#ref-for-utf-16-lead-surrogate③">(4)</a> <a href="#ref-for-utf-16-lead-surrogate④">(5)</a> <a href="#ref-for-utf-16-lead-surrogate⑤">(6)</a> <a href="#ref-for-utf-16-lead-surrogate⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16be-decoder-flag">
-   <b><a href="#utf-16be-decoder-flag">#utf-16be-decoder-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16be-decoder-flag" class="dfn-panel" data-for="utf-16be-decoder-flag" id="infopanel-for-utf-16be-decoder-flag" role="dialog">
+   <span id="infopaneltitle-for-utf-16be-decoder-flag" style="display:none">Info about the 'is UTF-16BE decoder' definition.</span><b><a href="#utf-16be-decoder-flag">#utf-16be-decoder-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16be-decoder-flag">14.2.1. shared UTF-16 decoder</a> <a href="#ref-for-utf-16be-decoder-flag①">(2)</a> <a href="#ref-for-utf-16be-decoder-flag②">(3)</a>
     <li><a href="#ref-for-utf-16be-decoder-flag③">14.3.1. UTF-16BE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16be">
-   <b><a href="#utf-16be">#utf-16be</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16be" class="dfn-panel" data-for="utf-16be" id="infopanel-for-utf-16be" role="dialog">
+   <span id="infopaneltitle-for-utf-16be" style="display:none">Info about the '14.3. UTF-16BE' definition.</span><b><a href="#utf-16be">#utf-16be</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16be">4. Encodings</a> <a href="#ref-for-utf-16be①">(2)</a>
     <li><a href="#ref-for-utf-16be②">4.2. Names and labels</a>
@@ -5694,14 +5694,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-16be⑤">14.3.1. UTF-16BE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16be-decoder">
-   <b><a href="#utf-16be-decoder">#utf-16be-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16be-decoder" class="dfn-panel" data-for="utf-16be-decoder" id="infopanel-for-utf-16be-decoder" role="dialog">
+   <span id="infopaneltitle-for-utf-16be-decoder" style="display:none">Info about the '14.3.1. UTF-16BE decoder' definition.</span><b><a href="#utf-16be-decoder">#utf-16be-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16be-decoder">14.3.1. UTF-16BE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16le">
-   <b><a href="#utf-16le">#utf-16le</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16le" class="dfn-panel" data-for="utf-16le" id="infopanel-for-utf-16le" role="dialog">
+   <span id="infopaneltitle-for-utf-16le" style="display:none">Info about the '14.4. UTF-16LE' definition.</span><b><a href="#utf-16le">#utf-16le</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16le">4. Encodings</a> <a href="#ref-for-utf-16le①">(2)</a>
     <li><a href="#ref-for-utf-16le②">4.2. Names and labels</a>
@@ -5711,14 +5711,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-16le⑥">14.4.1. UTF-16LE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-16le-decoder">
-   <b><a href="#utf-16le-decoder">#utf-16le-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-16le-decoder" class="dfn-panel" data-for="utf-16le-decoder" id="infopanel-for-utf-16le-decoder" role="dialog">
+   <span id="infopaneltitle-for-utf-16le-decoder" style="display:none">Info about the '14.4.1. UTF-16LE decoder' definition.</span><b><a href="#utf-16le-decoder">#utf-16le-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-16le-decoder">14.4.1. UTF-16LE decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-user-defined">
-   <b><a href="#x-user-defined">#x-user-defined</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-user-defined" class="dfn-panel" data-for="x-user-defined" id="infopanel-for-x-user-defined" role="dialog">
+   <span id="infopaneltitle-for-x-user-defined" style="display:none">Info about the '14.5. x-user-defined' definition.</span><b><a href="#x-user-defined">#x-user-defined</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-user-defined">4.2. Names and labels</a>
     <li><a href="#ref-for-x-user-defined">14.5. x-user-defined</a>
@@ -5726,71 +5726,127 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-x-user-defined②">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-user-defined-decoder">
-   <b><a href="#x-user-defined-decoder">#x-user-defined-decoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-user-defined-decoder" class="dfn-panel" data-for="x-user-defined-decoder" id="infopanel-for-x-user-defined-decoder" role="dialog">
+   <span id="infopaneltitle-for-x-user-defined-decoder" style="display:none">Info about the '14.5.1. x-user-defined decoder' definition.</span><b><a href="#x-user-defined-decoder">#x-user-defined-decoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-user-defined-decoder">14.5.1. x-user-defined decoder</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="x-user-defined-encoder">
-   <b><a href="#x-user-defined-encoder">#x-user-defined-encoder</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-x-user-defined-encoder" class="dfn-panel" data-for="x-user-defined-encoder" id="infopanel-for-x-user-defined-encoder" role="dialog">
+   <span id="infopaneltitle-for-x-user-defined-encoder" style="display:none">Info about the '14.5.2. x-user-defined encoder' definition.</span><b><a href="#x-user-defined-encoder">#x-user-defined-encoder</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-x-user-defined-encoder">14.5.2. x-user-defined encoder</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/fetch/fetch.html
+++ b/tests/github/whatwg/fetch/fetch.html
@@ -7108,80 +7108,80 @@ if ("serviceWorker" in navigator) {
    <li><a href="#typedefdef-xmlhttprequestbodyinit">XMLHttpRequestBodyInit</a><span>, in § 5.2</span>
    <li><a href="#dom-requestdestination-xslt">"xslt"</a><span>, in § 5.4</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-content-security-policy-object">
-   <a href="https://w3c.github.io/webappsec-csp/#content-security-policy-object">https://w3c.github.io/webappsec-csp/#content-security-policy-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-security-policy-object" class="dfn-panel" data-for="term-for-content-security-policy-object" id="infopanel-for-term-for-content-security-policy-object" role="menu">
+   <span id="infopaneltitle-for-term-for-content-security-policy-object" style="display:none">Info about the 'content security policy object' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#content-security-policy-object">https://w3c.github.io/webappsec-csp/#content-security-policy-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-security-policy-object">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-for-request">
-   <a href="https://w3c.github.io/webappsec-csp/#report-for-request">https://w3c.github.io/webappsec-csp/#report-for-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-for-request" class="dfn-panel" data-for="term-for-report-for-request" id="infopanel-for-term-for-report-for-request" role="menu">
+   <span id="infopaneltitle-for-term-for-report-for-request" style="display:none">Info about the 'report content security policy violations for request' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#report-for-request">https://w3c.github.io/webappsec-csp/#report-for-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-for-request">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-should-block-request">
-   <a href="https://w3c.github.io/webappsec-csp/#should-block-request">https://w3c.github.io/webappsec-csp/#should-block-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-should-block-request" class="dfn-panel" data-for="term-for-should-block-request" id="infopanel-for-term-for-should-block-request" role="menu">
+   <span id="infopaneltitle-for-term-for-should-block-request" style="display:none">Info about the 'should request be blocked by content security policy?' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#should-block-request">https://w3c.github.io/webappsec-csp/#should-block-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-request">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-should-block-response">
-   <a href="https://w3c.github.io/webappsec-csp/#should-block-response">https://w3c.github.io/webappsec-csp/#should-block-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-should-block-response" class="dfn-panel" data-for="term-for-should-block-response" id="infopanel-for-term-for-should-block-response" role="menu">
+   <span id="infopaneltitle-for-term-for-should-block-response" style="display:none">Info about the 'should response to request be blocked by content security policy?' external reference.</span><a href="https://w3c.github.io/webappsec-csp/#should-block-response">https://w3c.github.io/webappsec-csp/#should-block-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-response①">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">5.4. Request class</a> <a href="#ref-for-abortsignal①">(2)</a> <a href="#ref-for-abortsignal②">(3)</a> <a href="#ref-for-abortsignal③">(4)</a> <a href="#ref-for-abortsignal④">(5)</a> <a href="#ref-for-abortsignal⑤">(6)</a> <a href="#ref-for-abortsignal⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-follow">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-follow">https://dom.spec.whatwg.org/#abortsignal-follow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-follow" class="dfn-panel" data-for="term-for-abortsignal-follow" id="infopanel-for-term-for-abortsignal-follow" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-follow" style="display:none">Info about the 'follow' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-follow">https://dom.spec.whatwg.org/#abortsignal-follow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-follow">5.4. Request class</a> <a href="#ref-for-abortsignal-follow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom" id="infopanel-for-term-for-utf-8-decode-without-bom" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom" style="display:none">Info about the 'utf-8 decode without bom' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request">
-   <a href="https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request">https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request" class="dfn-panel" data-for="term-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request" id="infopanel-for-term-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request" role="menu">
+   <span id="infopaneltitle-for-term-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request" style="display:none">Info about the 'append the Fetch metadata headers for a request' external reference.</span><a href="https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request">https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-append-the-fetch-metadata-headers-for-a-request">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">2.2.4. Bodies</a>
     <li><a href="#ref-for-dfn-Blob①">4.2. Scheme fetch</a>
@@ -7190,60 +7190,60 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dfn-Blob⑤">5.3. Body mixin</a> <a href="#ref-for-dfn-Blob⑥">(2)</a> <a href="#ref-for-dfn-Blob⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">5.3. Body mixin</a> <a href="#ref-for-dfn-file①">(2)</a> <a href="#ref-for-dfn-file②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-entry-object">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-entry-object">https://w3c.github.io/FileAPI/#blob-url-entry-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-entry-object" class="dfn-panel" data-for="term-for-blob-url-entry-object" id="infopanel-for-term-for-blob-url-entry-object" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-entry-object" style="display:none">Info about the 'object' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-entry-object">https://w3c.github.io/FileAPI/#blob-url-entry-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry-object">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readOperation">
-   <a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readOperation" class="dfn-panel" data-for="term-for-readOperation" id="infopanel-for-term-for-readOperation" role="menu">
+   <span id="infopaneltitle-for-term-for-readOperation" style="display:none">Info about the 'read operation' external reference.</span><a href="https://w3c.github.io/FileAPI/#readOperation">https://w3c.github.io/FileAPI/#readOperation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readOperation">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-size">
-   <a href="https://w3c.github.io/FileAPI/#dfn-size">https://w3c.github.io/FileAPI/#dfn-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-size" class="dfn-panel" data-for="term-for-dfn-size" id="infopanel-for-term-for-dfn-size" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-size" style="display:none">Info about the 'size' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-size">https://w3c.github.io/FileAPI/#dfn-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-size">4.2. Scheme fetch</a>
     <li><a href="#ref-for-dfn-size①">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">4.2. Scheme fetch</a>
     <li><a href="#ref-for-dfn-type①">5.2. BodyInit unions</a>
     <li><a href="#ref-for-dfn-type②">5.3. Body mixin</a> <a href="#ref-for-dfn-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-domhighrestimestamp">
-   <a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-domhighrestimestamp" class="dfn-panel" data-for="term-for-dom-domhighrestimestamp" id="infopanel-for-term-for-dom-domhighrestimestamp" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-domhighrestimestamp" style="display:none">Info about the 'DOMHighResTimeStamp' external reference.</span><a href="https://w3c.github.io/hr-time/#dom-domhighrestimestamp">https://w3c.github.io/hr-time/#dom-domhighrestimestamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-domhighrestimestamp">2. Infrastructure</a>
     <li><a href="#ref-for-dom-domhighrestimestamp①">2.5. Connections</a> <a href="#ref-for-dom-domhighrestimestamp②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-coarsen-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-coarsen-time">https://w3c.github.io/hr-time/#dfn-coarsen-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-coarsen-time" class="dfn-panel" data-for="term-for-dfn-coarsen-time" id="infopanel-for-term-for-dfn-coarsen-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-coarsen-time" style="display:none">Info about the 'coarsen time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-coarsen-time">https://w3c.github.io/hr-time/#dfn-coarsen-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-coarsen-time">2.5. Connections</a> <a href="#ref-for-dfn-coarsen-time①">(2)</a> <a href="#ref-for-dfn-coarsen-time②">(3)</a> <a href="#ref-for-dfn-coarsen-time③">(4)</a> <a href="#ref-for-dfn-coarsen-time④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-coarsened-shared-current-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-coarsened-shared-current-time">https://w3c.github.io/hr-time/#dfn-coarsened-shared-current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-coarsened-shared-current-time" class="dfn-panel" data-for="term-for-dfn-coarsened-shared-current-time" id="infopanel-for-term-for-dfn-coarsened-shared-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-coarsened-shared-current-time" style="display:none">Info about the 'coarsened shared current time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-coarsened-shared-current-time">https://w3c.github.io/hr-time/#dfn-coarsened-shared-current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-coarsened-shared-current-time">4. Fetching</a>
     <li><a href="#ref-for-dfn-coarsened-shared-current-time①">4.1. Main fetch</a>
@@ -7252,103 +7252,103 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dfn-coarsened-shared-current-time④">4.7. HTTP-network fetch</a> <a href="#ref-for-dfn-coarsened-shared-current-time⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-unsafe-shared-current-time">
-   <a href="https://w3c.github.io/hr-time/#dfn-unsafe-shared-current-time">https://w3c.github.io/hr-time/#dfn-unsafe-shared-current-time</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-unsafe-shared-current-time" class="dfn-panel" data-for="term-for-dfn-unsafe-shared-current-time" id="infopanel-for-term-for-dfn-unsafe-shared-current-time" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-unsafe-shared-current-time" style="display:none">Info about the 'unsafe shared current time' external reference.</span><a href="https://w3c.github.io/hr-time/#dfn-unsafe-shared-current-time">https://w3c.github.io/hr-time/#dfn-unsafe-shared-current-time</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-unsafe-shared-current-time">2.5. Connections</a> <a href="#ref-for-dfn-unsafe-shared-current-time①">(2)</a> <a href="#ref-for-dfn-unsafe-shared-current-time②">(3)</a> <a href="#ref-for-dfn-unsafe-shared-current-time③">(4)</a> <a href="#ref-for-dfn-unsafe-shared-current-time④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-coep-report-type">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-report-type">https://html.spec.whatwg.org/multipage/browsers.html#coep-report-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-coep-report-type" class="dfn-panel" data-for="term-for-coep-report-type" id="infopanel-for-term-for-coep-report-type" role="menu">
+   <span id="infopaneltitle-for-term-for-coep-report-type" style="display:none">Info about the '"coep" report type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-report-type">https://html.spec.whatwg.org/multipage/browsers.html#coep-report-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-coep-report-type">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventsource">
-   <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventsource" class="dfn-panel" data-for="term-for-eventsource" id="infopanel-for-term-for-eventsource" role="menu">
+   <span id="infopaneltitle-for-term-for-eventsource" style="display:none">Info about the 'EventSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventsource">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">2.2.5. Requests</a>
     <li><a href="#ref-for-window①">4. Fetching</a>
     <li><a href="#ref-for-window②">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-windoworworkerglobalscope">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-windoworworkerglobalscope" class="dfn-panel" data-for="term-for-windoworworkerglobalscope" id="infopanel-for-term-for-windoworworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-windoworworkerglobalscope" style="display:none">Info about the 'WindowOrWorkerGlobalScope' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope">https://html.spec.whatwg.org/multipage/webappapis.html#windoworworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windoworworkerglobalscope">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">5.4. Request class</a>
     <li><a href="#ref-for-api-base-url①">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'ascii serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">2.2.5. Requests</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">3.2.5. CORS protocol and credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window-bc">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window-bc" class="dfn-panel" data-for="term-for-window-bc" id="infopanel-for-term-for-window-bc" role="menu">
+   <span id="infopaneltitle-for-term-for-window-bc" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window-bc</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window-bc">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-cross-origin-isolated-capability">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-cross-origin-isolated-capability" class="dfn-panel" data-for="term-for-concept-settings-object-cross-origin-isolated-capability" id="infopanel-for-term-for-concept-settings-object-cross-origin-isolated-capability" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-cross-origin-isolated-capability" style="display:none">Info about the 'cross-origin isolated capability' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-cross-origin-isolated-capability">4. Fetching</a>
     <li><a href="#ref-for-concept-settings-object-cross-origin-isolated-capability①">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-downloading-hyperlinks">
-   <a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-downloading-hyperlinks" class="dfn-panel" data-for="term-for-downloading-hyperlinks" id="infopanel-for-term-for-downloading-hyperlinks" role="menu">
+   <span id="infopaneltitle-for-term-for-downloading-hyperlinks" style="display:none">Info about the 'download the hyperlink' external reference.</span><a href="https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks">https://html.spec.whatwg.org/multipage/links.html#downloading-hyperlinks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-downloading-hyperlinks">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy-value">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy-value" class="dfn-panel" data-for="term-for-embedder-policy-value" id="infopanel-for-term-for-embedder-policy-value" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy-value" style="display:none">Info about the 'embedder policy value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-value">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enqueue-the-following-steps">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enqueue-the-following-steps" class="dfn-panel" data-for="term-for-enqueue-the-following-steps" id="infopanel-for-term-for-enqueue-the-following-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-enqueue-the-following-steps" style="display:none">Info about the 'enqueue steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps">https://html.spec.whatwg.org/multipage/infrastructure.html#enqueue-the-following-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-the-following-steps">2. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment" class="dfn-panel" data-for="term-for-environment" id="infopanel-for-term-for-environment" role="menu">
+   <span id="infopaneltitle-for-term-for-environment" style="display:none">Info about the 'environment' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment">https://html.spec.whatwg.org/multipage/webappapis.html#environment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment">2.2.5. Requests</a> <a href="#ref-for-environment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.2.5. Requests</a> <a href="#ref-for-environment-settings-object①">(2)</a> <a href="#ref-for-environment-settings-object②">(3)</a> <a href="#ref-for-environment-settings-object③">(4)</a> <a href="#ref-for-environment-settings-object④">(5)</a> <a href="#ref-for-environment-settings-object⑤">(6)</a> <a href="#ref-for-environment-settings-object⑥">(7)</a>
     <li><a href="#ref-for-environment-settings-object⑦">2.4. Fetch groups</a>
@@ -7359,37 +7359,37 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-environment-settings-object①④">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-form-element">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-form-element" class="dfn-panel" data-for="term-for-the-form-element" id="infopanel-for-term-for-the-form-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-form-element" style="display:none">Info about the 'form' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">https://html.spec.whatwg.org/multipage/forms.html#the-form-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-form-element">3.2. CORS protocol</a>
     <li><a href="#ref-for-the-form-element①">3.2.1. General</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">2. Infrastructure</a> <a href="#ref-for-global-object①">(2)</a>
     <li><a href="#ref-for-global-object②">2.2.4. Bodies</a> <a href="#ref-for-global-object③">(2)</a> <a href="#ref-for-global-object④">(3)</a>
     <li><a href="#ref-for-global-object⑤">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-global" class="dfn-panel" data-for="term-for-concept-settings-object-global" id="infopanel-for-term-for-concept-settings-object-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-global" style="display:none">Info about the 'global object (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-global">2.2.5. Requests</a> <a href="#ref-for-concept-settings-object-global①">(2)</a>
     <li><a href="#ref-for-concept-settings-object-global②">4. Fetching</a> <a href="#ref-for-concept-settings-object-global③">(2)</a>
     <li><a href="#ref-for-concept-settings-object-global④">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-id">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-id" class="dfn-panel" data-for="term-for-concept-environment-id" id="infopanel-for-term-for-concept-environment-id" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-id" style="display:none">Info about the 'id' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-id</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-id">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.1. Main fetch</a>
     <li><a href="#ref-for-in-parallel①">4.5. Navigate-redirect fetch</a>
@@ -7398,45 +7398,45 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-in-parallel⑥">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multipart/form-data-boundary-string">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-boundary-string">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-boundary-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multipart/form-data-boundary-string" class="dfn-panel" data-for="term-for-multipart/form-data-boundary-string" id="infopanel-for-term-for-multipart/form-data-boundary-string" role="menu">
+   <span id="infopaneltitle-for-term-for-multipart/form-data-boundary-string" style="display:none">Info about the 'multipart/form-data boundary string' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-boundary-string">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-boundary-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multipart/form-data-boundary-string">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-multipart/form-data-encoding-algorithm">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-multipart/form-data-encoding-algorithm" class="dfn-panel" data-for="term-for-multipart/form-data-encoding-algorithm" id="infopanel-for-term-for-multipart/form-data-encoding-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-multipart/form-data-encoding-algorithm" style="display:none">Info about the 'multipart/form-data encoding algorithm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart/form-data-encoding-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-multipart/form-data-encoding-algorithm">5.2. BodyInit unions</a> <a href="#ref-for-multipart/form-data-encoding-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigate">
-   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigate" class="dfn-panel" data-for="term-for-navigate" id="infopanel-for-term-for-navigate" role="menu">
+   <span id="infopaneltitle-for-term-for-navigate" style="display:none">Info about the 'navigate' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigate">2.2.5. Requests</a>
     <li><a href="#ref-for-navigate①">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networking-task-source">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networking-task-source" class="dfn-panel" data-for="term-for-networking-task-source" id="infopanel-for-term-for-networking-task-source" role="menu">
+   <span id="infopaneltitle-for-term-for-networking-task-source" style="display:none">Info about the 'networking task source' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source">https://html.spec.whatwg.org/multipage/webappapis.html#networking-task-source</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networking-task-source">2. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-obtain-a-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-obtain-a-site" class="dfn-panel" data-for="term-for-obtain-a-site" id="infopanel-for-term-for-obtain-a-site" role="menu">
+   <span id="infopaneltitle-for-term-for-obtain-a-site" style="display:none">Info about the 'obtain a site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site">https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-site">2.6. Network partition keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2.2.5. Requests</a> <a href="#ref-for-concept-origin①">(2)</a>
     <li><a href="#ref-for-concept-origin②">2.5. Connections</a>
@@ -7446,73 +7446,73 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-origin⑥">CORS protocol and HTTP caches</a> <a href="#ref-for-concept-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4. Fetching</a>
     <li><a href="#ref-for-concept-settings-object-origin①">5.4. Request class</a> <a href="#ref-for-concept-settings-object-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parallel-queue" class="dfn-panel" data-for="term-for-parallel-queue" id="infopanel-for-term-for-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-parallel-queue" style="display:none">Info about the 'parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parallel-queue">2. Infrastructure</a> <a href="#ref-for-parallel-queue①">(2)</a> <a href="#ref-for-parallel-queue②">(3)</a>
     <li><a href="#ref-for-parallel-queue③">2.2.4. Bodies</a> <a href="#ref-for-parallel-queue④">(2)</a> <a href="#ref-for-parallel-queue⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-global-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-global-task" class="dfn-panel" data-for="term-for-queue-a-global-task" id="infopanel-for-term-for-queue-a-global-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-global-task" style="display:none">Info about the 'queue a global task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-global-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-global-task">2. Infrastructure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">5.4. Request class</a> <a href="#ref-for-concept-relevant-realm①">(2)</a> <a href="#ref-for-concept-relevant-realm②">(3)</a>
     <li><a href="#ref-for-concept-relevant-realm③">5.5. Response class</a> <a href="#ref-for-concept-relevant-realm④">(2)</a> <a href="#ref-for-concept-relevant-realm⑤">(3)</a> <a href="#ref-for-concept-relevant-realm⑥">(4)</a>
     <li><a href="#ref-for-concept-relevant-realm⑦">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">4.1. Main fetch</a>
     <li><a href="#ref-for-relevant-settings-object①">5.4. Request class</a> <a href="#ref-for-relevant-settings-object②">(2)</a> <a href="#ref-for-relevant-settings-object③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy-report-only-reporting-endpoint">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-reporting-endpoint">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-reporting-endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy-report-only-reporting-endpoint" class="dfn-panel" data-for="term-for-embedder-policy-report-only-reporting-endpoint" id="infopanel-for-term-for-embedder-policy-report-only-reporting-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy-report-only-reporting-endpoint" style="display:none">Info about the 'report only reporting endpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-reporting-endpoint">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-reporting-endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-reporting-endpoint">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy-report-only-value">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-value">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy-report-only-value" class="dfn-panel" data-for="term-for-embedder-policy-report-only-value" id="infopanel-for-term-for-embedder-policy-report-only-value" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy-report-only-value" style="display:none">Info about the 'report only value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-value">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-report-only-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-report-only-value">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy-reporting-endpoint">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy-reporting-endpoint" class="dfn-panel" data-for="term-for-embedder-policy-reporting-endpoint" id="infopanel-for-term-for-embedder-policy-reporting-endpoint" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy-reporting-endpoint" style="display:none">Info about the 'reporting endpoint' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-reporting-endpoint</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-reporting-endpoint">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-coep-require-corp">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-require-corp">https://html.spec.whatwg.org/multipage/browsers.html#coep-require-corp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-coep-require-corp" class="dfn-panel" data-for="term-for-coep-require-corp" id="infopanel-for-term-for-coep-require-corp" role="menu">
+   <span id="infopaneltitle-for-term-for-coep-require-corp" style="display:none">Info about the 'require-corp' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-require-corp">https://html.spec.whatwg.org/multipage/browsers.html#coep-require-corp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-coep-require-corp">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-media-load-resource">
-   <a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource">https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-media-load-resource" class="dfn-panel" data-for="term-for-concept-media-load-resource" id="infopanel-for-term-for-concept-media-load-resource" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-media-load-resource" style="display:none">Info about the 'resource fetch algorithm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource">https://html.spec.whatwg.org/multipage/media.html#concept-media-load-resource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-media-load-resource">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">3.1. `Origin` header</a>
     <li><a href="#ref-for-same-origin①">3.7. `Cross-Origin-Resource-Policy` header</a>
@@ -7521,96 +7521,96 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-same-origin⑥">5.4. Request class</a> <a href="#ref-for-same-origin⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-schemelessly-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site">https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-schemelessly-same-site" class="dfn-panel" data-for="term-for-schemelessly-same-site" id="infopanel-for-term-for-schemelessly-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-schemelessly-same-site" style="display:none">Info about the 'schemelessly same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site">https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-schemelessly-same-site">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin①" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin①" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">2.2.5. Requests</a>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin①">3.2.5. CORS protocol and credentials</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-site" class="dfn-panel" data-for="term-for-site" id="infopanel-for-term-for-site" role="menu">
+   <span id="infopaneltitle-for-term-for-site" style="display:none">Info about the 'site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#site">https://html.spec.whatwg.org/multipage/browsers.html#site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-site">2.6. Network partition keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-starting-a-new-parallel-queue" class="dfn-panel" data-for="term-for-starting-a-new-parallel-queue" id="infopanel-for-term-for-starting-a-new-parallel-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-starting-a-new-parallel-queue" style="display:none">Info about the 'starting a new parallel queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-starting-a-new-parallel-queue">2.2.4. Bodies</a> <a href="#ref-for-starting-a-new-parallel-queue①">(2)</a>
     <li><a href="#ref-for-starting-a-new-parallel-queue②">4. Fetching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-target-browsing-context" class="dfn-panel" data-for="term-for-concept-environment-target-browsing-context" id="infopanel-for-term-for-concept-environment-target-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-target-browsing-context" style="display:none">Info about the 'target browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-target-browsing-context">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-creation-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-creation-url" class="dfn-panel" data-for="term-for-concept-environment-top-level-creation-url" id="infopanel-for-term-for-concept-environment-top-level-creation-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-creation-url" style="display:none">Info about the 'top-level creation url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-creation-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-creation-url">2.6. Network partition keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-environment-top-level-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-environment-top-level-origin" class="dfn-panel" data-for="term-for-concept-environment-top-level-origin" id="infopanel-for-term-for-concept-environment-top-level-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-environment-top-level-origin" style="display:none">Info about the 'top-level origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-top-level-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-environment-top-level-origin">2.6. Network partition keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-tuple">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-tuple" class="dfn-panel" data-for="term-for-concept-origin-tuple" id="infopanel-for-term-for-concept-origin-tuple" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-tuple" style="display:none">Info about the 'tuple origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-tuple">3.1. `Origin` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-coep-unsafe-none">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-unsafe-none">https://html.spec.whatwg.org/multipage/browsers.html#coep-unsafe-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-coep-unsafe-none" class="dfn-panel" data-for="term-for-coep-unsafe-none" id="infopanel-for-term-for-coep-unsafe-none" role="menu">
+   <span id="infopaneltitle-for-term-for-coep-unsafe-none" style="display:none">Info about the 'unsafe-none' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#coep-unsafe-none">https://html.spec.whatwg.org/multipage/browsers.html#coep-unsafe-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-coep-unsafe-none">3.7. `Cross-Origin-Resource-Policy` header</a> <a href="#ref-for-coep-unsafe-none①">(2)</a> <a href="#ref-for-coep-unsafe-none②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-embedder-policy-value-2">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value-2">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-embedder-policy-value-2" class="dfn-panel" data-for="term-for-embedder-policy-value-2" id="infopanel-for-term-for-embedder-policy-value-2" role="menu">
+   <span id="infopaneltitle-for-term-for-embedder-policy-value-2" style="display:none">Info about the 'value' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value-2">https://html.spec.whatwg.org/multipage/browsers.html#embedder-policy-value-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-embedder-policy-value-2">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2" class="dfn-panel" data-for="term-for-section-3.2" id="infopanel-for-term-for-section-3.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2" style="display:none">Info about the 'field-name' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2">https://tools.ietf.org/html/rfc7230#section-3.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2">2.2.2. Headers</a>
     <li><a href="#ref-for-section-3.2①">3.2.4. HTTP new-header syntax</a> <a href="#ref-for-section-3.2②">(2)</a> <a href="#ref-for-section-3.2③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1.1">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.1.1">https://tools.ietf.org/html/rfc7230#section-3.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1.1" class="dfn-panel" data-for="term-for-section-3.1.1" id="infopanel-for-term-for-section-3.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1.1" style="display:none">Info about the 'method' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.1.1">https://tools.ietf.org/html/rfc7230#section-3.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1.1">2.2.1. Methods</a>
     <li><a href="#ref-for-section-3.1.1①">3.2.4. HTTP new-header syntax</a> <a href="#ref-for-section-3.1.1②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1.2">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.1.2">https://tools.ietf.org/html/rfc7230#section-3.1.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1.2" class="dfn-panel" data-for="term-for-section-3.1.2" id="infopanel-for-term-for-section-3.1.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1.2" style="display:none">Info about the 'reason-phrase' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.1.2">https://tools.ietf.org/html/rfc7230#section-3.1.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1.2">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-1.2.1">
-   <a href="https://tools.ietf.org/html/rfc7234#section-1.2.1">https://tools.ietf.org/html/rfc7234#section-1.2.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-1.2.1" class="dfn-panel" data-for="term-for-section-1.2.1" id="infopanel-for-term-for-section-1.2.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-1.2.1" style="display:none">Info about the 'delta-seconds' external reference.</span><a href="https://tools.ietf.org/html/rfc7234#section-1.2.1">https://tools.ietf.org/html/rfc7234#section-1.2.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-1.2.1">3.2.4. HTTP new-header syntax</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abort-when">
-   <a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abort-when" class="dfn-panel" data-for="term-for-abort-when" id="infopanel-for-term-for-abort-when" role="menu">
+   <span id="infopaneltitle-for-term-for-abort-when" style="display:none">Info about the 'abort when' external reference.</span><a href="https://infra.spec.whatwg.org/#abort-when">https://infra.spec.whatwg.org/#abort-when</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-when">2.5. Connections</a>
     <li><a href="#ref-for-abort-when①">4.2. Scheme fetch</a>
@@ -7618,59 +7618,59 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-abort-when③">4.7. HTTP-network fetch</a> <a href="#ref-for-abort-when④">(2)</a> <a href="#ref-for-abort-when⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.2.2. Headers</a> <a href="#ref-for-list-append①">(2)</a> <a href="#ref-for-list-append②">(3)</a> <a href="#ref-for-list-append③">(4)</a> <a href="#ref-for-list-append④">(5)</a> <a href="#ref-for-list-append⑤">(6)</a> <a href="#ref-for-list-append⑥">(7)</a> <a href="#ref-for-list-append⑦">(8)</a>
     <li><a href="#ref-for-list-append⑧">4.4. HTTP-redirect fetch</a>
     <li><a href="#ref-for-list-append⑨">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.5. `X-Content-Type-Options` header</a>
     <li><a href="#ref-for-ascii-case-insensitive①">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-digit">
-   <a href="https://infra.spec.whatwg.org/#ascii-digit">https://infra.spec.whatwg.org/#ascii-digit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-digit" class="dfn-panel" data-for="term-for-ascii-digit" id="infopanel-for-term-for-ascii-digit" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-digit" style="display:none">Info about the 'ascii digit' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-digit">https://infra.spec.whatwg.org/#ascii-digit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-digit">3.3. `Content-Length` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">2.2. HTTP</a> <a href="#ref-for-ascii-whitespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">2.2. HTTP</a> <a href="#ref-for-iteration-break①">(2)</a> <a href="#ref-for-iteration-break②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-less-than">
-   <a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-less-than" class="dfn-panel" data-for="term-for-byte-less-than" id="infopanel-for-term-for-byte-less-than" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-less-than" style="display:none">Info about the 'byte less than' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-less-than">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">2.2.2. Headers</a> <a href="#ref-for-byte-sequence①">(2)</a> <a href="#ref-for-byte-sequence②">(3)</a>
     <li><a href="#ref-for-byte-sequence③">2.2.4. Bodies</a> <a href="#ref-for-byte-sequence④">(2)</a> <a href="#ref-for-byte-sequence⑤">(3)</a> <a href="#ref-for-byte-sequence⑥">(4)</a>
@@ -7683,8 +7683,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte-sequence①⑨">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#byte-case-insensitive">https://infra.spec.whatwg.org/#byte-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-case-insensitive" class="dfn-panel" data-for="term-for-byte-case-insensitive" id="infopanel-for-term-for-byte-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-case-insensitive" style="display:none">Info about the 'byte-case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-case-insensitive">https://infra.spec.whatwg.org/#byte-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-case-insensitive">2.2.1. Methods</a> <a href="#ref-for-byte-case-insensitive①">(2)</a>
     <li><a href="#ref-for-byte-case-insensitive②">2.2.2. Headers</a> <a href="#ref-for-byte-case-insensitive③">(2)</a> <a href="#ref-for-byte-case-insensitive④">(3)</a> <a href="#ref-for-byte-case-insensitive⑤">(4)</a> <a href="#ref-for-byte-case-insensitive⑥">(5)</a> <a href="#ref-for-byte-case-insensitive⑦">(6)</a> <a href="#ref-for-byte-case-insensitive⑧">(7)</a> <a href="#ref-for-byte-case-insensitive⑨">(8)</a> <a href="#ref-for-byte-case-insensitive①⓪">(9)</a> <a href="#ref-for-byte-case-insensitive①①">(10)</a> <a href="#ref-for-byte-case-insensitive①②">(11)</a> <a href="#ref-for-byte-case-insensitive①③">(12)</a>
@@ -7693,27 +7693,27 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte-case-insensitive①⑦">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-lowercase">
-   <a href="https://infra.spec.whatwg.org/#byte-lowercase">https://infra.spec.whatwg.org/#byte-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-lowercase" class="dfn-panel" data-for="term-for-byte-lowercase" id="infopanel-for-term-for-byte-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-lowercase" style="display:none">Info about the 'byte-lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-lowercase">https://infra.spec.whatwg.org/#byte-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-lowercase">2.2.2. Headers</a> <a href="#ref-for-byte-lowercase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-uppercase">
-   <a href="https://infra.spec.whatwg.org/#byte-uppercase">https://infra.spec.whatwg.org/#byte-uppercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-uppercase" class="dfn-panel" data-for="term-for-byte-uppercase" id="infopanel-for-term-for-byte-uppercase" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-uppercase" style="display:none">Info about the 'byte-uppercase' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-uppercase">https://infra.spec.whatwg.org/#byte-uppercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-uppercase">2.2.1. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-clone">
-   <a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-clone" class="dfn-panel" data-for="term-for-list-clone" id="infopanel-for-term-for-list-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-list-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">4.1. Main fetch</a>
     <li><a href="#ref-for-list-clone①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">2.2. HTTP</a> <a href="#ref-for-code-point①">(2)</a> <a href="#ref-for-code-point②">(3)</a> <a href="#ref-for-code-point③">(4)</a>
     <li><a href="#ref-for-code-point④">2.2.2. Headers</a> <a href="#ref-for-code-point⑤">(2)</a>
@@ -7721,38 +7721,38 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-code-point⑦">7. data: URLs</a> <a href="#ref-for-code-point⑧">(2)</a> <a href="#ref-for-code-point⑨">(3)</a> <a href="#ref-for-code-point①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collecting a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">2.2. HTTP</a>
     <li><a href="#ref-for-collect-a-sequence-of-code-points①">2.2.2. Headers</a>
     <li><a href="#ref-for-collect-a-sequence-of-code-points②">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.2.2. Headers</a>
     <li><a href="#ref-for-list-contain①">4.11. TAO check</a> <a href="#ref-for-list-contain②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">2.2.2. Headers</a>
     <li><a href="#ref-for-iteration-continue①">3.4. `Content-Type` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.4. `Content-Type` header</a> <a href="#ref-for-map-exists①">(2)</a>
     <li><a href="#ref-for-map-exists②">5.4. Request class</a> <a href="#ref-for-map-exists③">(2)</a> <a href="#ref-for-map-exists④">(3)</a> <a href="#ref-for-map-exists⑤">(4)</a> <a href="#ref-for-map-exists⑥">(5)</a> <a href="#ref-for-map-exists⑦">(6)</a> <a href="#ref-for-map-exists⑧">(7)</a> <a href="#ref-for-map-exists⑨">(8)</a> <a href="#ref-for-map-exists①⓪">(9)</a> <a href="#ref-for-map-exists①①">(10)</a> <a href="#ref-for-map-exists①②">(11)</a> <a href="#ref-for-map-exists①③">(12)</a> <a href="#ref-for-map-exists①④">(13)</a> <a href="#ref-for-map-exists①⑤">(14)</a> <a href="#ref-for-map-exists①⑥">(15)</a>
     <li><a href="#ref-for-map-exists①⑦">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2.2.2. Headers</a> <a href="#ref-for-list-iterate①">(2)</a> <a href="#ref-for-list-iterate②">(3)</a> <a href="#ref-for-list-iterate③">(4)</a>
     <li><a href="#ref-for-list-iterate④">3.3. `Content-Length` header</a>
@@ -7764,26 +7764,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-iterate①①">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">5.1. Headers class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forgiving-base64-decode">
-   <a href="https://infra.spec.whatwg.org/#forgiving-base64-decode">https://infra.spec.whatwg.org/#forgiving-base64-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forgiving-base64-decode" class="dfn-panel" data-for="term-for-forgiving-base64-decode" id="infopanel-for-term-for-forgiving-base64-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-forgiving-base64-decode" style="display:none">Info about the 'forgiving-base64 decode' external reference.</span><a href="https://infra.spec.whatwg.org/#forgiving-base64-decode">https://infra.spec.whatwg.org/#forgiving-base64-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forgiving-base64-decode">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forgiving-base64-encode">
-   <a href="https://infra.spec.whatwg.org/#forgiving-base64-encode">https://infra.spec.whatwg.org/#forgiving-base64-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forgiving-base64-encode" class="dfn-panel" data-for="term-for-forgiving-base64-encode" id="infopanel-for-term-for-forgiving-base64-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-forgiving-base64-encode" style="display:none">Info about the 'forgiving-base64 encode' external reference.</span><a href="https://infra.spec.whatwg.org/#forgiving-base64-encode">https://infra.spec.whatwg.org/#forgiving-base64-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forgiving-base64-encode">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-if-aborted">
-   <a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-if-aborted" class="dfn-panel" data-for="term-for-if-aborted" id="infopanel-for-term-for-if-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-if-aborted" style="display:none">Info about the 'if aborted' external reference.</span><a href="https://infra.spec.whatwg.org/#if-aborted">https://infra.spec.whatwg.org/#if-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-if-aborted">2.5. Connections</a>
     <li><a href="#ref-for-if-aborted①">4.2. Scheme fetch</a>
@@ -7791,15 +7791,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-if-aborted③">4.7. HTTP-network fetch</a> <a href="#ref-for-if-aborted④">(2)</a> <a href="#ref-for-if-aborted⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">2.6. Network partition keys</a> <a href="#ref-for-implementation-defined①">(2)</a>
     <li><a href="#ref-for-implementation-defined②">4.3. HTTP fetch</a> <a href="#ref-for-implementation-defined③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.2.5. Requests</a>
     <li><a href="#ref-for-list-is-empty①">2.2.6. Responses</a>
@@ -7807,8 +7807,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-is-empty⑤">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty①" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty①" style="display:none">Info about the 'is not empty (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">2.2.5. Requests</a>
     <li><a href="#ref-for-list-is-empty①">2.2.6. Responses</a>
@@ -7816,21 +7816,21 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-is-empty⑤">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-is-empty">
-   <a href="https://infra.spec.whatwg.org/#map-is-empty">https://infra.spec.whatwg.org/#map-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-is-empty" class="dfn-panel" data-for="term-for-map-is-empty" id="infopanel-for-term-for-map-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-map-is-empty" style="display:none">Info about the 'is not empty (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-is-empty">https://infra.spec.whatwg.org/#map-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-is-empty">5.4. Request class</a> <a href="#ref-for-map-is-empty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-decode" class="dfn-panel" data-for="term-for-isomorphic-decode" id="infopanel-for-term-for-isomorphic-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">2.2.2. Headers</a>
     <li><a href="#ref-for-isomorphic-decode①">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-encode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-encode">https://infra.spec.whatwg.org/#isomorphic-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-encode" class="dfn-panel" data-for="term-for-isomorphic-encode" id="infopanel-for-term-for-isomorphic-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-encode" style="display:none">Info about the 'isomorphic encode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-encode">https://infra.spec.whatwg.org/#isomorphic-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-encode">2.2.5. Requests</a> <a href="#ref-for-isomorphic-encode①">(2)</a> <a href="#ref-for-isomorphic-encode②">(3)</a>
     <li><a href="#ref-for-isomorphic-encode③">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-isomorphic-encode④">(2)</a>
@@ -7838,30 +7838,30 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-isomorphic-encode⑥">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.3. HTTP fetch</a>
     <li><a href="#ref-for-list-item①">4.8. CORS-preflight fetch</a> <a href="#ref-for-list-item②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item (for struct)' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">2. Infrastructure</a> <a href="#ref-for-struct-item①">(2)</a>
     <li><a href="#ref-for-struct-item②">2.5. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">2.2.2. Headers</a> <a href="#ref-for-byte-sequence-length①">(2)</a>
     <li><a href="#ref-for-byte-sequence-length②">4.7. HTTP-network fetch</a> <a href="#ref-for-byte-sequence-length③">(2)</a> <a href="#ref-for-byte-sequence-length④">(3)</a>
     <li><a href="#ref-for-byte-sequence-length⑤">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.2.2. Headers</a> <a href="#ref-for-list①">(2)</a> <a href="#ref-for-list②">(3)</a> <a href="#ref-for-list③">(4)</a> <a href="#ref-for-list④">(5)</a> <a href="#ref-for-list⑤">(6)</a> <a href="#ref-for-list⑥">(7)</a>
     <li><a href="#ref-for-list⑦">2.2.5. Requests</a>
@@ -7869,68 +7869,68 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list①⓪">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-json-bytes-to-a-javascript-value">
-   <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-json-bytes-to-a-javascript-value" class="dfn-panel" data-for="term-for-parse-json-bytes-to-a-javascript-value" id="infopanel-for-term-for-parse-json-bytes-to-a-javascript-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-json-bytes-to-a-javascript-value" style="display:none">Info about the 'parse json from bytes' external reference.</span><a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-json-bytes-to-a-javascript-value">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-position-variable">
-   <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-position-variable" class="dfn-panel" data-for="term-for-string-position-variable" id="infopanel-for-term-for-string-position-variable" role="menu">
+   <span id="infopaneltitle-for-term-for-string-position-variable" style="display:none">Info about the 'position variable' external reference.</span><a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-position-variable">2.2. HTTP</a> <a href="#ref-for-string-position-variable①">(2)</a> <a href="#ref-for-string-position-variable②">(3)</a>
     <li><a href="#ref-for-string-position-variable③">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">2.2.2. Headers</a> <a href="#ref-for-list-remove①">(2)</a>
     <li><a href="#ref-for-list-remove②">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-scalar-value-string">
-   <a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-scalar-value-string" class="dfn-panel" data-for="term-for-scalar-value-string" id="infopanel-for-term-for-scalar-value-string" role="menu">
+   <span id="infopaneltitle-for-term-for-scalar-value-string" style="display:none">Info about the 'scalar value string' external reference.</span><a href="https://infra.spec.whatwg.org/#scalar-value-string">https://infra.spec.whatwg.org/#scalar-value-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-sort-in-ascending-order">
-   <a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-sort-in-ascending-order" class="dfn-panel" data-for="term-for-list-sort-in-ascending-order" id="infopanel-for-term-for-list-sort-in-ascending-order" role="menu">
+   <span id="infopaneltitle-for-term-for-list-sort-in-ascending-order" style="display:none">Info about the 'sorting' external reference.</span><a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-sort-in-ascending-order">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2.2. HTTP</a>
     <li><a href="#ref-for-string①">2.2.2. Headers</a>
     <li><a href="#ref-for-string②">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="term-for-strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-term-for-strip-leading-and-trailing-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace">https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">2. Infrastructure</a> <a href="#ref-for-struct①">(2)</a>
     <li><a href="#ref-for-struct②">2.5. Connections</a>
     <li><a href="#ref-for-struct③">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type-essence">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type-essence" class="dfn-panel" data-for="term-for-mime-type-essence" id="infopanel-for-term-for-mime-type-essence" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type-essence" style="display:none">Info about the 'essence' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type-essence">https://mimesniff.spec.whatwg.org/#mime-type-essence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type-essence">2.2.2. Headers</a>
     <li><a href="#ref-for-mime-type-essence①">2.9. Should
@@ -7942,27 +7942,27 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-mime-type-essence⑨">5.3. Body mixin</a> <a href="#ref-for-mime-type-essence①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#html-mime-type">https://mimesniff.spec.whatwg.org/#html-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-mime-type" class="dfn-panel" data-for="term-for-html-mime-type" id="infopanel-for-term-for-html-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-html-mime-type" style="display:none">Info about the 'html mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#html-mime-type">https://mimesniff.spec.whatwg.org/#html-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-mime-type">3.6. CORB</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-mime-type" class="dfn-panel" data-for="term-for-javascript-mime-type" id="infopanel-for-term-for-javascript-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-mime-type" style="display:none">Info about the 'javascript mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#javascript-mime-type">https://mimesniff.spec.whatwg.org/#javascript-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-mime-type">3.5.1. Should
 response to request be blocked due to nosniff?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-json-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#json-mime-type">https://mimesniff.spec.whatwg.org/#json-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-json-mime-type" class="dfn-panel" data-for="term-for-json-mime-type" id="infopanel-for-term-for-json-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-json-mime-type" style="display:none">Info about the 'json mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#json-mime-type">https://mimesniff.spec.whatwg.org/#json-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-json-mime-type">3.6. CORB</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">2.2. HTTP</a>
     <li><a href="#ref-for-mime-type①">3.4. `Content-Type` header</a> <a href="#ref-for-mime-type②">(2)</a>
@@ -7971,107 +7971,107 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-mime-type⑤">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parameters">
-   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parameters" class="dfn-panel" data-for="term-for-parameters" id="infopanel-for-term-for-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-parameters" style="display:none">Info about the 'parameters' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">3.4. `Content-Type` header</a> <a href="#ref-for-parameters①">(2)</a> <a href="#ref-for-parameters②">(3)</a> <a href="#ref-for-parameters③">(4)</a> <a href="#ref-for-parameters④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-mime-type" class="dfn-panel" data-for="term-for-parse-a-mime-type" id="infopanel-for-term-for-parse-a-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-mime-type" style="display:none">Info about the 'parse a mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type">2.2.2. Headers</a>
     <li><a href="#ref-for-parse-a-mime-type①">3.4. `Content-Type` header</a>
     <li><a href="#ref-for-parse-a-mime-type②">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-mime-type" class="dfn-panel" data-for="term-for-serialize-a-mime-type" id="infopanel-for-term-for-serialize-a-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-mime-type" style="display:none">Info about the 'serialize a mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-mime-type">3.4. `Content-Type` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-mime-type-to-bytes">
-   <a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-mime-type-to-bytes" class="dfn-panel" data-for="term-for-serialize-a-mime-type-to-bytes" id="infopanel-for-term-for-serialize-a-mime-type-to-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-mime-type-to-bytes" style="display:none">Info about the 'serialize a mime type to bytes' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-mime-type-to-bytes">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#xml-mime-type">https://mimesniff.spec.whatwg.org/#xml-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-mime-type" class="dfn-panel" data-for="term-for-xml-mime-type" id="infopanel-for-term-for-xml-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-mime-type" style="display:none">Info about the 'xml mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#xml-mime-type">https://mimesniff.spec.whatwg.org/#xml-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-mime-type">3.6. CORB</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-should-block-fetch">
-   <a href="https://w3c.github.io/webappsec-mixed-content/#should-block-fetch">https://w3c.github.io/webappsec-mixed-content/#should-block-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-should-block-fetch" class="dfn-panel" data-for="term-for-should-block-fetch" id="infopanel-for-term-for-should-block-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-should-block-fetch" style="display:none">Info about the 'should fetching request be blocked as mixed content?' external reference.</span><a href="https://w3c.github.io/webappsec-mixed-content/#should-block-fetch">https://w3c.github.io/webappsec-mixed-content/#should-block-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-fetch">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-should-block-response">
-   <a href="https://w3c.github.io/webappsec-mixed-content/#should-block-response">https://w3c.github.io/webappsec-mixed-content/#should-block-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-should-block-response" class="dfn-panel" data-for="term-for-should-block-response" id="infopanel-for-term-for-should-block-response①" role="menu">
+   <span id="infopaneltitle-for-term-for-should-block-response①" style="display:none">Info about the 'should response to request be blocked as mixed content?' external reference.</span><a href="https://w3c.github.io/webappsec-mixed-content/#should-block-response">https://w3c.github.io/webappsec-mixed-content/#should-block-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-block-response">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-enumdef-referrerpolicy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy">https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-enumdef-referrerpolicy" class="dfn-panel" data-for="term-for-enumdef-referrerpolicy" id="infopanel-for-term-for-enumdef-referrerpolicy" role="menu">
+   <span id="infopaneltitle-for-term-for-enumdef-referrerpolicy" style="display:none">Info about the 'ReferrerPolicy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy">https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-referrerpolicy">5.4. Request class</a> <a href="#ref-for-enumdef-referrerpolicy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-referrer-policy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-referrer-policy" class="dfn-panel" data-for="term-for-default-referrer-policy" id="infopanel-for-term-for-default-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-default-referrer-policy" style="display:none">Info about the 'default referrer policy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#default-referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-referrer-policy">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-determine-requests-referrer">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer">https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-determine-requests-referrer" class="dfn-panel" data-for="term-for-determine-requests-referrer" id="infopanel-for-term-for-determine-requests-referrer" role="menu">
+   <span id="infopaneltitle-for-term-for-determine-requests-referrer" style="display:none">Info about the 'determine request's referrer' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer">https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-requests-referrer">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-referrer-policy">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-referrer-policy" class="dfn-panel" data-for="term-for-referrer-policy" id="infopanel-for-term-for-referrer-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-referrer-policy" style="display:none">Info about the 'referrer policy' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#referrer-policy">https://w3c.github.io/webappsec-referrer-policy/#referrer-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-referrer-policy">2.2.5. Requests</a>
     <li><a href="#ref-for-referrer-policy①">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-requests-referrer-policy-on-redirect">
-   <a href="https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect">https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-requests-referrer-policy-on-redirect" class="dfn-panel" data-for="term-for-set-requests-referrer-policy-on-redirect" id="infopanel-for-term-for-set-requests-referrer-policy-on-redirect" role="menu">
+   <span id="infopaneltitle-for-term-for-set-requests-referrer-policy-on-redirect" style="display:none">Info about the 'set request's referrer policy on redirect' external reference.</span><a href="https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect">https://w3c.github.io/webappsec-referrer-policy/#set-requests-referrer-policy-on-redirect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-requests-referrer-policy-on-redirect">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.2">
-   <a href="https://tools.ietf.org/html/rfc8941#section-4.2">https://tools.ietf.org/html/rfc8941#section-4.2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.2" class="dfn-panel" data-for="term-for-section-4.2" id="infopanel-for-term-for-section-4.2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.2" style="display:none">Info about the 'parsing structured fields' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-4.2">https://tools.ietf.org/html/rfc8941#section-4.2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.2">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-4.1">
-   <a href="https://tools.ietf.org/html/rfc8941#section-4.1">https://tools.ietf.org/html/rfc8941#section-4.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-4.1" class="dfn-panel" data-for="term-for-section-4.1" id="infopanel-for-term-for-section-4.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-4.1" style="display:none">Info about the 'serializing structured fields' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-4.1">https://tools.ietf.org/html/rfc8941#section-4.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-4.1">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-2">
-   <a href="https://tools.ietf.org/html/rfc8941#section-2">https://tools.ietf.org/html/rfc8941#section-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-2" class="dfn-panel" data-for="term-for-section-2" id="infopanel-for-term-for-section-2" role="menu">
+   <span id="infopaneltitle-for-term-for-section-2" style="display:none">Info about the 'structured field value' external reference.</span><a href="https://tools.ietf.org/html/rfc8941#section-2">https://tools.ietf.org/html/rfc8941#section-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-2">2.2.2. Headers</a> <a href="#ref-for-section-2①">(2)</a> <a href="#ref-for-section-2②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-does-response-match-metadatalist">
-   <a href="https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist">https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-does-response-match-metadatalist" class="dfn-panel" data-for="term-for-does-response-match-metadatalist" id="infopanel-for-term-for-does-response-match-metadatalist" role="menu">
+   <span id="infopaneltitle-for-term-for-does-response-match-metadatalist" style="display:none">Info about the 'do bytes match metadatalist?' external reference.</span><a href="https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist">https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-does-response-match-metadatalist">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream">
-   <a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream" class="dfn-panel" data-for="term-for-readablestream" id="infopanel-for-term-for-readablestream" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream" style="display:none">Info about the 'ReadableStream' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream">https://streams.spec.whatwg.org/#readablestream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">2.2.4. Bodies</a>
     <li><a href="#ref-for-readablestream①">2.2.5. Requests</a>
@@ -8080,286 +8080,286 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-readablestream⑧">5.3. Body mixin</a> <a href="#ref-for-readablestream⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader">https://streams.spec.whatwg.org/#readablestreamdefaultreader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader" class="dfn-panel" data-for="term-for-readablestreamdefaultreader" id="infopanel-for-term-for-readablestreamdefaultreader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader" style="display:none">Info about the 'ReadableStreamDefaultReader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader">https://streams.spec.whatwg.org/#readablestreamdefaultreader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream">
-   <a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream" class="dfn-panel" data-for="term-for-transformstream" id="infopanel-for-term-for-transformstream" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream" style="display:none">Info about the 'TransformStream' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream">https://streams.spec.whatwg.org/#transformstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-cancel">
-   <a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-cancel" class="dfn-panel" data-for="term-for-readablestream-cancel" id="infopanel-for-term-for-readablestream-cancel" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-cancel" style="display:none">Info about the 'cancel' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-cancel">https://streams.spec.whatwg.org/#readablestream-cancel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-cancel">4.3. HTTP fetch</a>
     <li><a href="#ref-for-readablestream-cancel①">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up-cancelalgorithm">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up-cancelalgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-cancelalgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up-cancelalgorithm" class="dfn-panel" data-for="term-for-readablestream-set-up-cancelalgorithm" id="infopanel-for-term-for-readablestream-set-up-cancelalgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up-cancelalgorithm" style="display:none">Info about the 'cancelalgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up-cancelalgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-cancelalgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up-cancelalgorithm">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-chunk">
-   <a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-chunk" class="dfn-panel" data-for="term-for-chunk" id="infopanel-for-term-for-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-chunk" style="display:none">Info about the 'chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#chunk">https://streams.spec.whatwg.org/#chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-chunk-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-chunk-steps">https://streams.spec.whatwg.org/#read-request-chunk-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-chunk-steps" class="dfn-panel" data-for="term-for-read-request-chunk-steps" id="infopanel-for-term-for-read-request-chunk-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-chunk-steps" style="display:none">Info about the 'chunk steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-chunk-steps">https://streams.spec.whatwg.org/#read-request-chunk-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-chunk-steps">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-close">
-   <a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-close" class="dfn-panel" data-for="term-for-readablestream-close" id="infopanel-for-term-for-readablestream-close" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-close" style="display:none">Info about the 'close' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-close">https://streams.spec.whatwg.org/#readablestream-close</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-close">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-readablestream-close①">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-close-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-close-steps">https://streams.spec.whatwg.org/#read-request-close-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-close-steps" class="dfn-panel" data-for="term-for-read-request-close-steps" id="infopanel-for-term-for-read-request-close-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-close-steps" style="display:none">Info about the 'close steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-close-steps">https://streams.spec.whatwg.org/#read-request-close-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-close-steps">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-create-a-proxy">
-   <a href="https://streams.spec.whatwg.org/#readablestream-create-a-proxy">https://streams.spec.whatwg.org/#readablestream-create-a-proxy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-create-a-proxy" class="dfn-panel" data-for="term-for-readablestream-create-a-proxy" id="infopanel-for-term-for-readablestream-create-a-proxy" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-create-a-proxy" style="display:none">Info about the 'creating a proxy' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-create-a-proxy">https://streams.spec.whatwg.org/#readablestream-create-a-proxy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-create-a-proxy">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-is-readable-stream-disturbed">
-   <a href="https://streams.spec.whatwg.org/#is-readable-stream-disturbed">https://streams.spec.whatwg.org/#is-readable-stream-disturbed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-is-readable-stream-disturbed" class="dfn-panel" data-for="term-for-is-readable-stream-disturbed" id="infopanel-for-term-for-is-readable-stream-disturbed" role="menu">
+   <span id="infopaneltitle-for-term-for-is-readable-stream-disturbed" style="display:none">Info about the 'disturbed' external reference.</span><a href="https://streams.spec.whatwg.org/#is-readable-stream-disturbed">https://streams.spec.whatwg.org/#is-readable-stream-disturbed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-readable-stream-disturbed">5.2. BodyInit unions</a> <a href="#ref-for-is-readable-stream-disturbed①">(2)</a>
     <li><a href="#ref-for-is-readable-stream-disturbed②">5.3. Body mixin</a> <a href="#ref-for-is-readable-stream-disturbed③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-enqueue">
-   <a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-enqueue" class="dfn-panel" data-for="term-for-readablestream-enqueue" id="infopanel-for-term-for-readablestream-enqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-enqueue" style="display:none">Info about the 'enqueue' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-enqueue">https://streams.spec.whatwg.org/#readablestream-enqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-enqueue">4.3. HTTP fetch</a> <a href="#ref-for-readablestream-enqueue①">(2)</a> <a href="#ref-for-readablestream-enqueue②">(3)</a>
     <li><a href="#ref-for-readablestream-enqueue③">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-readablestream-enqueue④">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-error">
-   <a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-error" class="dfn-panel" data-for="term-for-readablestream-error" id="infopanel-for-term-for-readablestream-error" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-error" style="display:none">Info about the 'error' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-error">https://streams.spec.whatwg.org/#readablestream-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-error">4.7. HTTP-network fetch</a> <a href="#ref-for-readablestream-error①">(2)</a>
     <li><a href="#ref-for-readablestream-error②">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request-error-steps">
-   <a href="https://streams.spec.whatwg.org/#read-request-error-steps">https://streams.spec.whatwg.org/#read-request-error-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request-error-steps" class="dfn-panel" data-for="term-for-read-request-error-steps" id="infopanel-for-term-for-read-request-error-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request-error-steps" style="display:none">Info about the 'error steps' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request-error-steps">https://streams.spec.whatwg.org/#read-request-error-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-error-steps">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-errored">
-   <a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-errored" class="dfn-panel" data-for="term-for-readablestream-errored" id="infopanel-for-term-for-readablestream-errored" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-errored" style="display:none">Info about the 'errored' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-errored">https://streams.spec.whatwg.org/#readablestream-errored</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-errored">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-readablestream-errored①">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-rs-get-reader">
-   <a href="https://streams.spec.whatwg.org/#rs-get-reader">https://streams.spec.whatwg.org/#rs-get-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-rs-get-reader" class="dfn-panel" data-for="term-for-rs-get-reader" id="infopanel-for-term-for-rs-get-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-rs-get-reader" style="display:none">Info about the 'getReader()' external reference.</span><a href="https://streams.spec.whatwg.org/#rs-get-reader">https://streams.spec.whatwg.org/#rs-get-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-get-reader">5.7. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-get-a-reader">
-   <a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-get-a-reader" class="dfn-panel" data-for="term-for-readablestream-get-a-reader" id="infopanel-for-term-for-readablestream-get-a-reader" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-get-a-reader" style="display:none">Info about the 'getting a reader' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-get-a-reader">https://streams.spec.whatwg.org/#readablestream-get-a-reader</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">2.2.4. Bodies</a> <a href="#ref-for-readablestream-get-a-reader①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up-highwatermark">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up-highwatermark">https://streams.spec.whatwg.org/#readablestream-set-up-highwatermark</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up-highwatermark" class="dfn-panel" data-for="term-for-readablestream-set-up-highwatermark" id="infopanel-for-term-for-readablestream-set-up-highwatermark" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up-highwatermark" style="display:none">Info about the 'highwatermark' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up-highwatermark">https://streams.spec.whatwg.org/#readablestream-set-up-highwatermark</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up-highwatermark">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-locked">
-   <a href="https://streams.spec.whatwg.org/#readablestream-locked">https://streams.spec.whatwg.org/#readablestream-locked</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-locked" class="dfn-panel" data-for="term-for-readablestream-locked" id="infopanel-for-term-for-readablestream-locked" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-locked" style="display:none">Info about the 'locked' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-locked">https://streams.spec.whatwg.org/#readablestream-locked</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-locked">5.2. BodyInit unions</a> <a href="#ref-for-readablestream-locked①">(2)</a>
     <li><a href="#ref-for-readablestream-locked②">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-need-more-data">
-   <a href="https://streams.spec.whatwg.org/#readablestream-need-more-data">https://streams.spec.whatwg.org/#readablestream-need-more-data</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-need-more-data" class="dfn-panel" data-for="term-for-readablestream-need-more-data" id="infopanel-for-term-for-readablestream-need-more-data" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-need-more-data" style="display:none">Info about the 'need more data' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-need-more-data">https://streams.spec.whatwg.org/#readablestream-need-more-data</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-need-more-data">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-pipe-through">
-   <a href="https://streams.spec.whatwg.org/#readablestream-pipe-through">https://streams.spec.whatwg.org/#readablestream-pipe-through</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-pipe-through" class="dfn-panel" data-for="term-for-readablestream-pipe-through" id="infopanel-for-term-for-readablestream-pipe-through" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-pipe-through" style="display:none">Info about the 'piped through' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-pipe-through">https://streams.spec.whatwg.org/#readablestream-pipe-through</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-pipe-through">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up-pullalgorithm">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up-pullalgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-pullalgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up-pullalgorithm" class="dfn-panel" data-for="term-for-readablestream-set-up-pullalgorithm" id="infopanel-for-term-for-readablestream-set-up-pullalgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up-pullalgorithm" style="display:none">Info about the 'pullalgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up-pullalgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-pullalgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up-pullalgorithm">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-a-chunk" id="infopanel-for-term-for-readablestreamdefaultreader-read-a-chunk" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-a-chunk" style="display:none">Info about the 'read a chunk' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-a-chunk</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-a-chunk">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-read-request">
-   <a href="https://streams.spec.whatwg.org/#read-request">https://streams.spec.whatwg.org/#read-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-read-request" class="dfn-panel" data-for="term-for-read-request" id="infopanel-for-term-for-read-request" role="menu">
+   <span id="infopaneltitle-for-term-for-read-request" style="display:none">Info about the 'read request' external reference.</span><a href="https://streams.spec.whatwg.org/#read-request">https://streams.spec.whatwg.org/#read-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-readable">
-   <a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-readable" class="dfn-panel" data-for="term-for-readablestream-readable" id="infopanel-for-term-for-readablestream-readable" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-readable" style="display:none">Info about the 'readable' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-readable">https://streams.spec.whatwg.org/#readablestream-readable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-readable">4.7. HTTP-network fetch</a> <a href="#ref-for-readablestream-readable①">(2)</a> <a href="#ref-for-readablestream-readable②">(3)</a>
     <li><a href="#ref-for-readablestream-readable③">5.6. Fetch method</a> <a href="#ref-for-readablestream-readable④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes">
-   <a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" class="dfn-panel" data-for="term-for-readablestreamdefaultreader-read-all-bytes" id="infopanel-for-term-for-readablestreamdefaultreader-read-all-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestreamdefaultreader-read-all-bytes" style="display:none">Info about the 'reading all bytes' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes">https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-read-all-bytes">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up">https://streams.spec.whatwg.org/#readablestream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up" class="dfn-panel" data-for="term-for-readablestream-set-up" id="infopanel-for-term-for-readablestream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up" style="display:none">Info about the 'set up' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up">https://streams.spec.whatwg.org/#readablestream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-readablestream-set-up①">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transformstream-set-up">
-   <a href="https://streams.spec.whatwg.org/#transformstream-set-up">https://streams.spec.whatwg.org/#transformstream-set-up</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transformstream-set-up" class="dfn-panel" data-for="term-for-transformstream-set-up" id="infopanel-for-term-for-transformstream-set-up" role="menu">
+   <span id="infopaneltitle-for-term-for-transformstream-set-up" style="display:none">Info about the 'setting up' external reference.</span><a href="https://streams.spec.whatwg.org/#transformstream-set-up">https://streams.spec.whatwg.org/#transformstream-set-up</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-set-up-sizealgorithm">
-   <a href="https://streams.spec.whatwg.org/#readablestream-set-up-sizealgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-sizealgorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-set-up-sizealgorithm" class="dfn-panel" data-for="term-for-readablestream-set-up-sizealgorithm" id="infopanel-for-term-for-readablestream-set-up-sizealgorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-set-up-sizealgorithm" style="display:none">Info about the 'sizealgorithm' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-set-up-sizealgorithm">https://streams.spec.whatwg.org/#readablestream-set-up-sizealgorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up-sizealgorithm">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-readablestream-tee">
-   <a href="https://streams.spec.whatwg.org/#readablestream-tee">https://streams.spec.whatwg.org/#readablestream-tee</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-readablestream-tee" class="dfn-panel" data-for="term-for-readablestream-tee" id="infopanel-for-term-for-readablestream-tee" role="menu">
+   <span id="infopaneltitle-for-term-for-readablestream-tee" style="display:none">Info about the 'teeing' external reference.</span><a href="https://streams.spec.whatwg.org/#readablestream-tee">https://streams.spec.whatwg.org/#readablestream-tee</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-tee">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-global-scope-fetch-event">
-   <a href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event">https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="term-for-service-worker-global-scope-fetch-event" id="infopanel-for-term-for-service-worker-global-scope-fetch-event" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event">https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">2.2.5. Requests</a> <a href="#ref-for-service-worker-global-scope-fetch-event①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-handle-fetch">
-   <a href="https://w3c.github.io/ServiceWorker/#handle-fetch">https://w3c.github.io/ServiceWorker/#handle-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-handle-fetch" class="dfn-panel" data-for="term-for-handle-fetch" id="infopanel-for-term-for-handle-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-handle-fetch" style="display:none">Info about the 'handle fetch' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#handle-fetch">https://w3c.github.io/ServiceWorker/#handle-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-fetch">2.2.5. Requests</a>
     <li><a href="#ref-for-handle-fetch①">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upgrade-request">
-   <a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request">https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upgrade-request" class="dfn-panel" data-for="term-for-upgrade-request" id="infopanel-for-term-for-upgrade-request" role="menu">
+   <span id="infopaneltitle-for-term-for-upgrade-request" style="display:none">Info about the 'upgrade request to a potentially trustworthy url, if appropriate' external reference.</span><a href="https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request">https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upgrade-request">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-urlsearchparams">
-   <a href="https://url.spec.whatwg.org/#urlsearchparams">https://url.spec.whatwg.org/#urlsearchparams</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-urlsearchparams" class="dfn-panel" data-for="term-for-urlsearchparams" id="infopanel-for-term-for-urlsearchparams" role="menu">
+   <span id="infopaneltitle-for-term-for-urlsearchparams" style="display:none">Info about the 'URLSearchParams' external reference.</span><a href="https://url.spec.whatwg.org/#urlsearchparams">https://url.spec.whatwg.org/#urlsearchparams</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-urlsearchparams">5.2. BodyInit unions</a> <a href="#ref-for-urlsearchparams①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-absolute-url-with-fragment-string">
-   <a href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string">https://url.spec.whatwg.org/#absolute-url-with-fragment-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-absolute-url-with-fragment-string" class="dfn-panel" data-for="term-for-absolute-url-with-fragment-string" id="infopanel-for-term-for-absolute-url-with-fragment-string" role="menu">
+   <span id="infopaneltitle-for-term-for-absolute-url-with-fragment-string" style="display:none">Info about the 'absolute-url-with-fragment string' external reference.</span><a href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string">https://url.spec.whatwg.org/#absolute-url-with-fragment-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-with-fragment-string">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-blob-entry">
-   <a href="https://url.spec.whatwg.org/#concept-url-blob-entry">https://url.spec.whatwg.org/#concept-url-blob-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-blob-entry" class="dfn-panel" data-for="term-for-concept-url-blob-entry" id="infopanel-for-term-for-concept-url-blob-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-blob-entry" style="display:none">Info about the 'blob url entry' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-blob-entry">https://url.spec.whatwg.org/#concept-url-blob-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-blob-entry">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-domain">
-   <a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-domain" class="dfn-panel" data-for="term-for-concept-domain" id="infopanel-for-term-for-concept-domain" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-domain" style="display:none">Info about the 'domain' external reference.</span><a href="https://url.spec.whatwg.org/#concept-domain">https://url.spec.whatwg.org/#concept-domain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-url-serializer-exclude-fragment">
-   <a href="https://url.spec.whatwg.org/#url-serializer-exclude-fragment">https://url.spec.whatwg.org/#url-serializer-exclude-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-url-serializer-exclude-fragment" class="dfn-panel" data-for="term-for-url-serializer-exclude-fragment" id="infopanel-for-term-for-url-serializer-exclude-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-url-serializer-exclude-fragment" style="display:none">Info about the 'exclude fragment' external reference.</span><a href="https://url.spec.whatwg.org/#url-serializer-exclude-fragment">https://url.spec.whatwg.org/#url-serializer-exclude-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-serializer-exclude-fragment">2.2.5. Requests</a>
     <li><a href="#ref-for-url-serializer-exclude-fragment①">5.5. Response class</a>
     <li><a href="#ref-for-url-serializer-exclude-fragment②">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-fragment">
-   <a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-fragment" class="dfn-panel" data-for="term-for-concept-url-fragment" id="infopanel-for-term-for-concept-url-fragment" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-fragment" style="display:none">Info about the 'fragment' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-fragment">https://url.spec.whatwg.org/#concept-url-fragment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">2.2.6. Responses</a> <a href="#ref-for-concept-url-fragment①">(2)</a>
     <li><a href="#ref-for-concept-url-fragment②">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">3.1. `Origin` header</a>
     <li><a href="#ref-for-concept-url-host①">4.1. Main fetch</a> <a href="#ref-for-concept-url-host②">(2)</a>
     <li><a href="#ref-for-concept-url-host③">6.1. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include-credentials">
-   <a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include-credentials" class="dfn-panel" data-for="term-for-include-credentials" id="infopanel-for-term-for-include-credentials" role="menu">
+   <span id="infopaneltitle-for-term-for-include-credentials" style="display:none">Info about the 'include credentials' external reference.</span><a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include-credentials">4.4. HTTP-redirect fetch</a> <a href="#ref-for-include-credentials①">(2)</a>
     <li><a href="#ref-for-include-credentials②">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-include-credentials③">(2)</a>
     <li><a href="#ref-for-include-credentials④">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include-credentials">
-   <a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include-credentials" class="dfn-panel" data-for="term-for-include-credentials" id="infopanel-for-term-for-include-credentials①" role="menu">
+   <span id="infopaneltitle-for-term-for-include-credentials①" style="display:none">Info about the 'includes credentials' external reference.</span><a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include-credentials">4.4. HTTP-redirect fetch</a> <a href="#ref-for-include-credentials①">(2)</a>
     <li><a href="#ref-for-include-credentials②">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-include-credentials③">(2)</a>
     <li><a href="#ref-for-include-credentials④">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-urlsearchparams-list">
-   <a href="https://url.spec.whatwg.org/#concept-urlsearchparams-list">https://url.spec.whatwg.org/#concept-urlsearchparams-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-urlsearchparams-list" class="dfn-panel" data-for="term-for-concept-urlsearchparams-list" id="infopanel-for-term-for-concept-urlsearchparams-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-urlsearchparams-list" style="display:none">Info about the 'list' external reference.</span><a href="https://url.spec.whatwg.org/#concept-urlsearchparams-list">https://url.spec.whatwg.org/#concept-urlsearchparams-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlsearchparams-list">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-origin">
-   <a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-origin" class="dfn-panel" data-for="term-for-concept-url-origin" id="infopanel-for-term-for-concept-url-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-origin">https://url.spec.whatwg.org/#concept-url-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">2.6. Network partition keys</a>
     <li><a href="#ref-for-concept-url-origin①">3.1. `Origin` header</a>
@@ -8370,30 +8370,30 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-url-origin①③">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-path">
-   <a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-path" class="dfn-panel" data-for="term-for-concept-url-path" id="infopanel-for-term-for-concept-url-path" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-path" style="display:none">Info about the 'path' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-path">https://url.spec.whatwg.org/#concept-url-path</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">3.1. `Origin` header</a>
     <li><a href="#ref-for-concept-url-path①">4.2. Scheme fetch</a>
     <li><a href="#ref-for-concept-url-path②">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-percent-decode">
-   <a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-percent-decode" class="dfn-panel" data-for="term-for-string-percent-decode" id="infopanel-for-term-for-string-percent-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-string-percent-decode" style="display:none">Info about the 'percent-decode' external reference.</span><a href="https://url.spec.whatwg.org/#string-percent-decode">https://url.spec.whatwg.org/#string-percent-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-percent-decode">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-port">
-   <a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-port" class="dfn-panel" data-for="term-for-concept-url-port" id="infopanel-for-term-for-concept-url-port" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-port" style="display:none">Info about the 'port' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-port">https://url.spec.whatwg.org/#concept-url-port</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">2.8. Port blocking</a> <a href="#ref-for-concept-url-port①">(2)</a>
     <li><a href="#ref-for-concept-url-port②">3.1. `Origin` header</a>
     <li><a href="#ref-for-concept-url-port③">6.1. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
-   <a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-scheme" class="dfn-panel" data-for="term-for-concept-url-scheme" id="infopanel-for-term-for-concept-url-scheme" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-scheme" style="display:none">Info about the 'scheme' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-scheme">https://url.spec.whatwg.org/#concept-url-scheme</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">2.1. URL</a> <a href="#ref-for-concept-url-scheme①">(2)</a> <a href="#ref-for-concept-url-scheme②">(3)</a> <a href="#ref-for-concept-url-scheme③">(4)</a>
     <li><a href="#ref-for-concept-url-scheme④">2.8. Port blocking</a>
@@ -8409,22 +8409,22 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-url-scheme②①">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-password">
-   <a href="https://url.spec.whatwg.org/#set-the-password">https://url.spec.whatwg.org/#set-the-password</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-password" class="dfn-panel" data-for="term-for-set-the-password" id="infopanel-for-term-for-set-the-password" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-password" style="display:none">Info about the 'set the password' external reference.</span><a href="https://url.spec.whatwg.org/#set-the-password">https://url.spec.whatwg.org/#set-the-password</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-password">2.2.5. Requests</a>
     <li><a href="#ref-for-set-the-password①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-username">
-   <a href="https://url.spec.whatwg.org/#set-the-username">https://url.spec.whatwg.org/#set-the-username</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-username" class="dfn-panel" data-for="term-for-set-the-username" id="infopanel-for-term-for-set-the-username" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-username" style="display:none">Info about the 'set the username' external reference.</span><a href="https://url.spec.whatwg.org/#set-the-username">https://url.spec.whatwg.org/#set-the-username</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-username">2.2.5. Requests</a>
     <li><a href="#ref-for-set-the-username①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">2.1. URL</a>
     <li><a href="#ref-for-concept-url①">2.2.5. Requests</a> <a href="#ref-for-concept-url②">(2)</a> <a href="#ref-for-concept-url③">(3)</a> <a href="#ref-for-concept-url④">(4)</a> <a href="#ref-for-concept-url⑤">(5)</a> <a href="#ref-for-concept-url⑥">(6)</a>
@@ -8436,16 +8436,16 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-url①⑧">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-url-parser①">5.4. Request class</a> <a href="#ref-for-concept-url-parser②">(2)</a>
     <li><a href="#ref-for-concept-url-parser③">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-url-serializer①">4.6. HTTP-network-or-cache fetch</a>
@@ -8454,70 +8454,70 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-url-serializer⑥">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-urlencoded-parser">
-   <a href="https://url.spec.whatwg.org/#concept-urlencoded-parser">https://url.spec.whatwg.org/#concept-urlencoded-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-urlencoded-parser" class="dfn-panel" data-for="term-for-concept-urlencoded-parser" id="infopanel-for-term-for-concept-urlencoded-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-urlencoded-parser" style="display:none">Info about the 'urlencoded parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-urlencoded-parser">https://url.spec.whatwg.org/#concept-urlencoded-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded-parser">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-urlencoded-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-urlencoded-serializer">https://url.spec.whatwg.org/#concept-urlencoded-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-urlencoded-serializer" class="dfn-panel" data-for="term-for-concept-urlencoded-serializer" id="infopanel-for-term-for-concept-urlencoded-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-urlencoded-serializer" style="display:none">Info about the 'urlencoded serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-urlencoded-serializer">https://url.spec.whatwg.org/#concept-urlencoded-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded-serializer">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">4.7. HTTP-network fetch</a> <a href="#ref-for-aborterror①">(2)</a>
     <li><a href="#ref-for-aborterror②">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-idl-ArrayBuffer①">5.2. BodyInit unions</a>
     <li><a href="#ref-for-idl-ArrayBuffer②">5.3. Body mixin</a> <a href="#ref-for-idl-ArrayBuffer③">(2)</a> <a href="#ref-for-idl-ArrayBuffer④">(3)</a> <a href="#ref-for-idl-ArrayBuffer⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BufferSource">
-   <a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BufferSource" class="dfn-panel" data-for="term-for-BufferSource" id="infopanel-for-term-for-BufferSource" role="menu">
+   <span id="infopaneltitle-for-term-for-BufferSource" style="display:none">Info about the 'BufferSource' external reference.</span><a href="https://webidl.spec.whatwg.org/#BufferSource">https://webidl.spec.whatwg.org/#BufferSource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BufferSource">5.2. BodyInit unions</a> <a href="#ref-for-BufferSource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">5.1. Headers class</a> <a href="#ref-for-idl-ByteString①">(2)</a> <a href="#ref-for-idl-ByteString②">(3)</a> <a href="#ref-for-idl-ByteString③">(4)</a> <a href="#ref-for-idl-ByteString④">(5)</a> <a href="#ref-for-idl-ByteString⑤">(6)</a> <a href="#ref-for-idl-ByteString⑥">(7)</a> <a href="#ref-for-idl-ByteString⑦">(8)</a> <a href="#ref-for-idl-ByteString⑧">(9)</a> <a href="#ref-for-idl-ByteString⑨">(10)</a> <a href="#ref-for-idl-ByteString①⓪">(11)</a> <a href="#ref-for-idl-ByteString①①">(12)</a> <a href="#ref-for-idl-ByteString①②">(13)</a>
     <li><a href="#ref-for-idl-ByteString①③">5.4. Request class</a> <a href="#ref-for-idl-ByteString①④">(2)</a>
     <li><a href="#ref-for-idl-ByteString①⑤">5.5. Response class</a> <a href="#ref-for-idl-ByteString①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.7. HTTP-network fetch</a> <a href="#ref-for-idl-DOMException①">(2)</a>
     <li><a href="#ref-for-idl-DOMException②">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">5.4. Request class</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">5.1. Headers class</a>
     <li><a href="#ref-for-Exposed①">5.4. Request class</a>
     <li><a href="#ref-for-Exposed②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-NewObject">
-   <a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-NewObject" class="dfn-panel" data-for="term-for-NewObject" id="infopanel-for-term-for-NewObject" role="menu">
+   <span id="infopaneltitle-for-term-for-NewObject" style="display:none">Info about the 'NewObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#NewObject">https://webidl.spec.whatwg.org/#NewObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-NewObject">5.3. Body mixin</a> <a href="#ref-for-NewObject①">(2)</a> <a href="#ref-for-NewObject②">(3)</a> <a href="#ref-for-NewObject③">(4)</a> <a href="#ref-for-NewObject④">(5)</a>
     <li><a href="#ref-for-NewObject⑤">5.4. Request class</a>
@@ -8525,29 +8525,29 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-NewObject⑨">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">5.3. Body mixin</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a> <a href="#ref-for-idl-promise③">(4)</a> <a href="#ref-for-idl-promise④">(5)</a>
     <li><a href="#ref-for-idl-promise⑤">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">5.3. Body mixin</a>
     <li><a href="#ref-for-exceptiondef-rangeerror①">5.5. Response class</a> <a href="#ref-for-exceptiondef-rangeerror②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">5.4. Request class</a>
     <li><a href="#ref-for-SameObject①">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">2.2.4. Bodies</a>
     <li><a href="#ref-for-exceptiondef-typeerror①">4.7. HTTP-network fetch</a>
@@ -8559,8 +8559,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-exceptiondef-typeerror③③">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">5.2. BodyInit unions</a>
     <li><a href="#ref-for-idl-USVString①">5.3. Body mixin</a>
@@ -8568,8 +8568,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-idl-USVString⑥">5.5. Response class</a> <a href="#ref-for-idl-USVString⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-Uint8Array">
-   <a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-Uint8Array" class="dfn-panel" data-for="term-for-idl-Uint8Array" id="infopanel-for-term-for-idl-Uint8Array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-Uint8Array" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-Uint8Array">https://webidl.spec.whatwg.org/#idl-Uint8Array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-Uint8Array">2.2.4. Bodies</a>
     <li><a href="#ref-for-idl-Uint8Array①">4.3. HTTP fetch</a>
@@ -8577,28 +8577,28 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-idl-Uint8Array③">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">2.2.4. Bodies</a>
     <li><a href="#ref-for-a-promise-rejected-with①">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">5.3. Body mixin</a>
     <li><a href="#ref-for-idl-any①">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">5.1. Headers class</a>
     <li><a href="#ref-for-idl-boolean①">5.3. Body mixin</a>
@@ -8606,15 +8606,15 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-idl-boolean⑥">5.5. Response class</a> <a href="#ref-for-idl-boolean⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" class="dfn-panel" data-for="term-for-dfn-get-buffer-source-copy" id="infopanel-for-term-for-dfn-get-buffer-source-copy" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-buffer-source-copy" style="display:none">Info about the 'get a copy of the buffer source' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy">https://webidl.spec.whatwg.org/#dfn-get-buffer-source-copy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-buffer-source-copy">2.2.4. Bodies</a>
     <li><a href="#ref-for-dfn-get-buffer-source-copy①">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-new①">5.2. BodyInit unions</a>
@@ -8622,38 +8622,38 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-new⑦">5.5. Response class</a> <a href="#ref-for-new⑧">(2)</a> <a href="#ref-for-new⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'react' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">2.2.4. Bodies</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">5.1. Headers class</a> <a href="#ref-for-idl-record①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">5.6. Fetch method</a> <a href="#ref-for-reject①">(2)</a> <a href="#ref-for-reject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">5.1. Headers class</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">5.1. Headers class</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a> <a href="#ref-for-this⑧">(9)</a> <a href="#ref-for-this⑨">(10)</a> <a href="#ref-for-this①⓪">(11)</a> <a href="#ref-for-this①①">(12)</a> <a href="#ref-for-this①②">(13)</a> <a href="#ref-for-this①③">(14)</a> <a href="#ref-for-this①④">(15)</a> <a href="#ref-for-this①⑤">(16)</a> <a href="#ref-for-this①⑥">(17)</a> <a href="#ref-for-this①⑦">(18)</a> <a href="#ref-for-this①⑧">(19)</a> <a href="#ref-for-this①⑨">(20)</a> <a href="#ref-for-this②⓪">(21)</a>
     <li><a href="#ref-for-this②①">5.3. Body mixin</a> <a href="#ref-for-this②②">(2)</a> <a href="#ref-for-this②③">(3)</a> <a href="#ref-for-this②④">(4)</a> <a href="#ref-for-this②⑤">(5)</a> <a href="#ref-for-this②⑥">(6)</a> <a href="#ref-for-this②⑦">(7)</a> <a href="#ref-for-this②⑧">(8)</a> <a href="#ref-for-this②⑨">(9)</a>
@@ -8662,8 +8662,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-this⑨⑦">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">5.1. Headers class</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a> <a href="#ref-for-dfn-throw④">(5)</a> <a href="#ref-for-dfn-throw⑤">(6)</a> <a href="#ref-for-dfn-throw⑥">(7)</a> <a href="#ref-for-dfn-throw⑦">(8)</a> <a href="#ref-for-dfn-throw⑧">(9)</a>
     <li><a href="#ref-for-dfn-throw⑨">5.2. BodyInit unions</a> <a href="#ref-for-dfn-throw①⓪">(2)</a>
@@ -8672,47 +8672,47 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-dfn-throw②⑤">5.5. Response class</a> <a href="#ref-for-dfn-throw②⑥">(2)</a> <a href="#ref-for-dfn-throw②⑦">(3)</a> <a href="#ref-for-dfn-throw②⑧">(4)</a> <a href="#ref-for-dfn-throw②⑨">(5)</a> <a href="#ref-for-dfn-throw③⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">5.1. Headers class</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">5.5. Response class</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over">
-   <a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over" id="infopanel-for-term-for-dfn-value-pairs-to-iterate-over" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">5.1. Headers class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-websocket">
-   <a href="https://websockets.spec.whatwg.org/#websocket">https://websockets.spec.whatwg.org/#websocket</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-websocket" class="dfn-panel" data-for="term-for-websocket" id="infopanel-for-term-for-websocket" role="menu">
+   <span id="infopaneltitle-for-term-for-websocket" style="display:none">Info about the 'WebSocket' external reference.</span><a href="https://websockets.spec.whatwg.org/#websocket">https://websockets.spec.whatwg.org/#websocket</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-websocket">2.2.5. Requests</a>
     <li><a href="#ref-for-websocket①">5.7. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-formdata">
-   <a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-formdata" class="dfn-panel" data-for="term-for-formdata" id="infopanel-for-term-for-formdata" role="menu">
+   <span id="infopaneltitle-for-term-for-formdata" style="display:none">Info about the 'FormData' external reference.</span><a href="https://xhr.spec.whatwg.org/#formdata">https://xhr.spec.whatwg.org/#formdata</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formdata">2.2.4. Bodies</a>
     <li><a href="#ref-for-formdata①">5.2. BodyInit unions</a> <a href="#ref-for-formdata②">(2)</a>
     <li><a href="#ref-for-formdata③">5.3. Body mixin</a> <a href="#ref-for-formdata④">(2)</a> <a href="#ref-for-formdata⑤">(3)</a> <a href="#ref-for-formdata⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequest">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequest" class="dfn-panel" data-for="term-for-xmlhttprequest" id="infopanel-for-term-for-xmlhttprequest" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequest">https://xhr.spec.whatwg.org/#xmlhttprequest</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">2.2.2. Headers</a> <a href="#ref-for-xmlhttprequest①">(2)</a>
     <li><a href="#ref-for-xmlhttprequest②">2.2.5. Requests</a> <a href="#ref-for-xmlhttprequest③">(2)</a>
@@ -8723,14 +8723,14 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-xmlhttprequest⑧">Basic safe CORS protocol setup</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xmlhttprequestupload">
-   <a href="https://xhr.spec.whatwg.org/#xmlhttprequestupload">https://xhr.spec.whatwg.org/#xmlhttprequestupload</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xmlhttprequestupload" class="dfn-panel" data-for="term-for-xmlhttprequestupload" id="infopanel-for-term-for-xmlhttprequestupload" role="menu">
+   <span id="infopaneltitle-for-term-for-xmlhttprequestupload" style="display:none">Info about the 'XMLHttpRequestUpload' external reference.</span><a href="https://xhr.spec.whatwg.org/#xmlhttprequestupload">https://xhr.spec.whatwg.org/#xmlhttprequestupload</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequestupload">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-formdata-entry-list">
-   <a href="https://xhr.spec.whatwg.org/#concept-formdata-entry-list">https://xhr.spec.whatwg.org/#concept-formdata-entry-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-formdata-entry-list" class="dfn-panel" data-for="term-for-concept-formdata-entry-list" id="infopanel-for-term-for-concept-formdata-entry-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-formdata-entry-list" style="display:none">Info about the 'entry list' external reference.</span><a href="https://xhr.spec.whatwg.org/#concept-formdata-entry-list">https://xhr.spec.whatwg.org/#concept-formdata-entry-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-formdata-entry-list">5.2. BodyInit unions</a>
    </ul>
@@ -9268,8 +9268,8 @@ response to request be blocked due to nosniff?</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="abnf">
-   <b><a href="#abnf">#abnf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abnf" class="dfn-panel" data-for="abnf" id="infopanel-for-abnf" role="dialog">
+   <span id="infopaneltitle-for-abnf" style="display:none">Info about the 'ABNF' definition.</span><b><a href="#abnf">#abnf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abnf">2.2.2. Headers</a> <a href="#ref-for-abnf①">(2)</a> <a href="#ref-for-abnf②">(3)</a>
     <li><a href="#ref-for-abnf③">3.1. `Origin` header</a>
@@ -9278,8 +9278,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-abnf⑥">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="credentials">
-   <b><a href="#credentials">#credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-credentials" class="dfn-panel" data-for="credentials" id="infopanel-for-credentials" role="dialog">
+   <span id="infopaneltitle-for-credentials" style="display:none">Info about the 'Credentials' definition.</span><b><a href="#credentials">#credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentials">2.2.5. Requests</a>
     <li><a href="#ref-for-credentials①">3.2. CORS protocol</a>
@@ -9288,8 +9288,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-credentials①①">3.2.6. Examples</a> <a href="#ref-for-credentials①②">(2)</a> <a href="#ref-for-credentials①③">(3)</a> <a href="#ref-for-credentials①④">(4)</a> <a href="#ref-for-credentials①⑤">(5)</a> <a href="#ref-for-credentials①⑥">(6)</a> <a href="#ref-for-credentials①⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params">
-   <b><a href="#fetch-params">#fetch-params</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params" class="dfn-panel" data-for="fetch-params" id="infopanel-for-fetch-params" role="dialog">
+   <span id="infopaneltitle-for-fetch-params" style="display:none">Info about the 'fetch params' definition.</span><b><a href="#fetch-params">#fetch-params</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params">4. Fetching</a>
     <li><a href="#ref-for-fetch-params①">4.1. Main fetch</a> <a href="#ref-for-fetch-params②">(2)</a> <a href="#ref-for-fetch-params③">(3)</a>
@@ -9302,8 +9302,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-params①①">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-request">
-   <b><a href="#fetch-params-request">#fetch-params-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-request" class="dfn-panel" data-for="fetch-params-request" id="infopanel-for-fetch-params-request" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-request" style="display:none">Info about the 'request' definition.</span><b><a href="#fetch-params-request">#fetch-params-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-request">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-request①">4.1. Main fetch</a> <a href="#ref-for-fetch-params-request②">(2)</a>
@@ -9316,51 +9316,51 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-params-request①①">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-process-request-body">
-   <b><a href="#fetch-params-process-request-body">#fetch-params-process-request-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-process-request-body" class="dfn-panel" data-for="fetch-params-process-request-body" id="infopanel-for-fetch-params-process-request-body" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-process-request-body" style="display:none">Info about the 'process request body' definition.</span><b><a href="#fetch-params-process-request-body">#fetch-params-process-request-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-process-request-body">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-process-request-body①">4.7. HTTP-network fetch</a> <a href="#ref-for-fetch-params-process-request-body②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-process-request-end-of-body">
-   <b><a href="#fetch-params-process-request-end-of-body">#fetch-params-process-request-end-of-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-process-request-end-of-body" class="dfn-panel" data-for="fetch-params-process-request-end-of-body" id="infopanel-for-fetch-params-process-request-end-of-body" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-process-request-end-of-body" style="display:none">Info about the 'process request end-of-body' definition.</span><b><a href="#fetch-params-process-request-end-of-body">#fetch-params-process-request-end-of-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-process-request-end-of-body">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-process-request-end-of-body①">4.7. HTTP-network fetch</a> <a href="#ref-for-fetch-params-process-request-end-of-body②">(2)</a> <a href="#ref-for-fetch-params-process-request-end-of-body③">(3)</a> <a href="#ref-for-fetch-params-process-request-end-of-body④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-process-response">
-   <b><a href="#fetch-params-process-response">#fetch-params-process-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-process-response" class="dfn-panel" data-for="fetch-params-process-response" id="infopanel-for-fetch-params-process-response" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-process-response" style="display:none">Info about the 'process response' definition.</span><b><a href="#fetch-params-process-response">#fetch-params-process-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-process-response">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-process-response①">4.1. Main fetch</a> <a href="#ref-for-fetch-params-process-response②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-process-response-end-of-body">
-   <b><a href="#fetch-params-process-response-end-of-body">#fetch-params-process-response-end-of-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-process-response-end-of-body" class="dfn-panel" data-for="fetch-params-process-response-end-of-body" id="infopanel-for-fetch-params-process-response-end-of-body" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-process-response-end-of-body" style="display:none">Info about the 'process response end-of-body' definition.</span><b><a href="#fetch-params-process-response-end-of-body">#fetch-params-process-response-end-of-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-process-response-end-of-body">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-process-response-end-of-body①">4.1. Main fetch</a> <a href="#ref-for-fetch-params-process-response-end-of-body②">(2)</a> <a href="#ref-for-fetch-params-process-response-end-of-body③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-process-response-done">
-   <b><a href="#fetch-params-process-response-done">#fetch-params-process-response-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-process-response-done" class="dfn-panel" data-for="fetch-params-process-response-done" id="infopanel-for-fetch-params-process-response-done" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-process-response-done" style="display:none">Info about the 'process response done' definition.</span><b><a href="#fetch-params-process-response-done">#fetch-params-process-response-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-process-response-done">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-process-response-done①">4.1. Main fetch</a> <a href="#ref-for-fetch-params-process-response-done②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-task-destination">
-   <b><a href="#fetch-params-task-destination">#fetch-params-task-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-task-destination" class="dfn-panel" data-for="fetch-params-task-destination" id="infopanel-for-fetch-params-task-destination" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-task-destination" style="display:none">Info about the 'task destination' definition.</span><b><a href="#fetch-params-task-destination">#fetch-params-task-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-task-destination">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-task-destination①">4.1. Main fetch</a> <a href="#ref-for-fetch-params-task-destination②">(2)</a> <a href="#ref-for-fetch-params-task-destination③">(3)</a> <a href="#ref-for-fetch-params-task-destination④">(4)</a>
     <li><a href="#ref-for-fetch-params-task-destination⑤">4.7. HTTP-network fetch</a> <a href="#ref-for-fetch-params-task-destination⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-cross-origin-isolated-capability">
-   <b><a href="#fetch-params-cross-origin-isolated-capability">#fetch-params-cross-origin-isolated-capability</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-cross-origin-isolated-capability" class="dfn-panel" data-for="fetch-params-cross-origin-isolated-capability" id="infopanel-for-fetch-params-cross-origin-isolated-capability" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-cross-origin-isolated-capability" style="display:none">Info about the 'cross-origin isolated capability' definition.</span><b><a href="#fetch-params-cross-origin-isolated-capability">#fetch-params-cross-origin-isolated-capability</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-cross-origin-isolated-capability">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-cross-origin-isolated-capability①">4.3. HTTP fetch</a>
@@ -9368,8 +9368,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-params-cross-origin-isolated-capability③">4.7. HTTP-network fetch</a> <a href="#ref-for-fetch-params-cross-origin-isolated-capability④">(2)</a> <a href="#ref-for-fetch-params-cross-origin-isolated-capability⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-params-timing-info">
-   <b><a href="#fetch-params-timing-info">#fetch-params-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-params-timing-info" class="dfn-panel" data-for="fetch-params-timing-info" id="infopanel-for-fetch-params-timing-info" role="dialog">
+   <span id="infopaneltitle-for-fetch-params-timing-info" style="display:none">Info about the 'timing info' definition.</span><b><a href="#fetch-params-timing-info">#fetch-params-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-params-timing-info">4. Fetching</a>
     <li><a href="#ref-for-fetch-params-timing-info①">4.3. HTTP fetch</a> <a href="#ref-for-fetch-params-timing-info②">(2)</a> <a href="#ref-for-fetch-params-timing-info③">(3)</a>
@@ -9378,8 +9378,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-params-timing-info⑦">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info">
-   <b><a href="#fetch-timing-info">#fetch-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info" class="dfn-panel" data-for="fetch-timing-info" id="infopanel-for-fetch-timing-info" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info" style="display:none">Info about the 'fetch timing info' definition.</span><b><a href="#fetch-timing-info">#fetch-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info">2. Infrastructure</a>
     <li><a href="#ref-for-fetch-timing-info①">2.2.6. Responses</a>
@@ -9387,28 +9387,28 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-timing-info③">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-start-time">
-   <b><a href="#fetch-timing-info-start-time">#fetch-timing-info-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-start-time" class="dfn-panel" data-for="fetch-timing-info-start-time" id="infopanel-for-fetch-timing-info-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-start-time" style="display:none">Info about the 'start time' definition.</span><b><a href="#fetch-timing-info-start-time">#fetch-timing-info-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-start-time">4. Fetching</a>
     <li><a href="#ref-for-fetch-timing-info-start-time①">4.1. Main fetch</a> <a href="#ref-for-fetch-timing-info-start-time②">(2)</a>
     <li><a href="#ref-for-fetch-timing-info-start-time③">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-redirect-start-time">
-   <b><a href="#fetch-timing-info-redirect-start-time">#fetch-timing-info-redirect-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-redirect-start-time" class="dfn-panel" data-for="fetch-timing-info-redirect-start-time" id="infopanel-for-fetch-timing-info-redirect-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-redirect-start-time" style="display:none">Info about the 'redirect start time' definition.</span><b><a href="#fetch-timing-info-redirect-start-time">#fetch-timing-info-redirect-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-redirect-start-time">4.4. HTTP-redirect fetch</a> <a href="#ref-for-fetch-timing-info-redirect-start-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-redirect-end-time">
-   <b><a href="#fetch-timing-info-redirect-end-time">#fetch-timing-info-redirect-end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-redirect-end-time" class="dfn-panel" data-for="fetch-timing-info-redirect-end-time" id="infopanel-for-fetch-timing-info-redirect-end-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-redirect-end-time" style="display:none">Info about the 'redirect end time' definition.</span><b><a href="#fetch-timing-info-redirect-end-time">#fetch-timing-info-redirect-end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-redirect-end-time">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-post-redirect-start-time">
-   <b><a href="#fetch-timing-info-post-redirect-start-time">#fetch-timing-info-post-redirect-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-post-redirect-start-time" class="dfn-panel" data-for="fetch-timing-info-post-redirect-start-time" id="infopanel-for-fetch-timing-info-post-redirect-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-post-redirect-start-time" style="display:none">Info about the 'post-redirect start time' definition.</span><b><a href="#fetch-timing-info-post-redirect-start-time">#fetch-timing-info-post-redirect-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-post-redirect-start-time">4. Fetching</a>
     <li><a href="#ref-for-fetch-timing-info-post-redirect-start-time①">4.1. Main fetch</a>
@@ -9416,86 +9416,86 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-fetch-timing-info-post-redirect-start-time③">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-final-service-worker-start-time">
-   <b><a href="#fetch-timing-info-final-service-worker-start-time">#fetch-timing-info-final-service-worker-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-final-service-worker-start-time" class="dfn-panel" data-for="fetch-timing-info-final-service-worker-start-time" id="infopanel-for-fetch-timing-info-final-service-worker-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-final-service-worker-start-time" style="display:none">Info about the 'final service worker start time' definition.</span><b><a href="#fetch-timing-info-final-service-worker-start-time">#fetch-timing-info-final-service-worker-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-final-service-worker-start-time">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-final-network-request-start-time">
-   <b><a href="#fetch-timing-info-final-network-request-start-time">#fetch-timing-info-final-network-request-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-final-network-request-start-time" class="dfn-panel" data-for="fetch-timing-info-final-network-request-start-time" id="infopanel-for-fetch-timing-info-final-network-request-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-final-network-request-start-time" style="display:none">Info about the 'final network-request start time' definition.</span><b><a href="#fetch-timing-info-final-network-request-start-time">#fetch-timing-info-final-network-request-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-final-network-request-start-time">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-final-network-response-start-time">
-   <b><a href="#fetch-timing-info-final-network-response-start-time">#fetch-timing-info-final-network-response-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-final-network-response-start-time" class="dfn-panel" data-for="fetch-timing-info-final-network-response-start-time" id="infopanel-for-fetch-timing-info-final-network-response-start-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-final-network-response-start-time" style="display:none">Info about the 'final network-response start time' definition.</span><b><a href="#fetch-timing-info-final-network-response-start-time">#fetch-timing-info-final-network-response-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-final-network-response-start-time">4.7. HTTP-network fetch</a> <a href="#ref-for-fetch-timing-info-final-network-response-start-time①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-end-time">
-   <b><a href="#fetch-timing-info-end-time">#fetch-timing-info-end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-end-time" class="dfn-panel" data-for="fetch-timing-info-end-time" id="infopanel-for-fetch-timing-info-end-time" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-end-time" style="display:none">Info about the 'end time' definition.</span><b><a href="#fetch-timing-info-end-time">#fetch-timing-info-end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-end-time">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-encoded-body-size">
-   <b><a href="#fetch-timing-info-encoded-body-size">#fetch-timing-info-encoded-body-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-encoded-body-size" class="dfn-panel" data-for="fetch-timing-info-encoded-body-size" id="infopanel-for-fetch-timing-info-encoded-body-size" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-encoded-body-size" style="display:none">Info about the 'encoded body size' definition.</span><b><a href="#fetch-timing-info-encoded-body-size">#fetch-timing-info-encoded-body-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-encoded-body-size">2. Infrastructure</a> <a href="#ref-for-fetch-timing-info-encoded-body-size①">(2)</a>
     <li><a href="#ref-for-fetch-timing-info-encoded-body-size②">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-decoded-body-size">
-   <b><a href="#fetch-timing-info-decoded-body-size">#fetch-timing-info-decoded-body-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-decoded-body-size" class="dfn-panel" data-for="fetch-timing-info-decoded-body-size" id="infopanel-for-fetch-timing-info-decoded-body-size" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-decoded-body-size" style="display:none">Info about the 'decoded body size' definition.</span><b><a href="#fetch-timing-info-decoded-body-size">#fetch-timing-info-decoded-body-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-decoded-body-size">2. Infrastructure</a> <a href="#ref-for-fetch-timing-info-decoded-body-size①">(2)</a>
     <li><a href="#ref-for-fetch-timing-info-decoded-body-size②">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-timing-info-final-connection-timing-info">
-   <b><a href="#fetch-timing-info-final-connection-timing-info">#fetch-timing-info-final-connection-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-timing-info-final-connection-timing-info" class="dfn-panel" data-for="fetch-timing-info-final-connection-timing-info" id="infopanel-for-fetch-timing-info-final-connection-timing-info" role="dialog">
+   <span id="infopaneltitle-for-fetch-timing-info-final-connection-timing-info" style="display:none">Info about the 'final connection timing info' definition.</span><b><a href="#fetch-timing-info-final-connection-timing-info">#fetch-timing-info-final-connection-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-timing-info-final-connection-timing-info">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="update-timing-info-from-stored-response">
-   <b><a href="#update-timing-info-from-stored-response">#update-timing-info-from-stored-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-update-timing-info-from-stored-response" class="dfn-panel" data-for="update-timing-info-from-stored-response" id="infopanel-for-update-timing-info-from-stored-response" role="dialog">
+   <span id="infopaneltitle-for-update-timing-info-from-stored-response" style="display:none">Info about the 'update timing info from stored response' definition.</span><b><a href="#update-timing-info-from-stored-response">#update-timing-info-from-stored-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-update-timing-info-from-stored-response">4.3. HTTP fetch</a>
     <li><a href="#ref-for-update-timing-info-from-stored-response①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-fetch-task">
-   <b><a href="#queue-a-fetch-task">#queue-a-fetch-task</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-fetch-task" class="dfn-panel" data-for="queue-a-fetch-task" id="infopanel-for-queue-a-fetch-task" role="dialog">
+   <span id="infopaneltitle-for-queue-a-fetch-task" style="display:none">Info about the 'queue a fetch task' definition.</span><b><a href="#queue-a-fetch-task">#queue-a-fetch-task</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-fetch-task">2.2.4. Bodies</a> <a href="#ref-for-queue-a-fetch-task①">(2)</a> <a href="#ref-for-queue-a-fetch-task②">(3)</a> <a href="#ref-for-queue-a-fetch-task③">(4)</a> <a href="#ref-for-queue-a-fetch-task④">(5)</a>
     <li><a href="#ref-for-queue-a-fetch-task⑤">4.1. Main fetch</a> <a href="#ref-for-queue-a-fetch-task⑥">(2)</a> <a href="#ref-for-queue-a-fetch-task⑦">(3)</a>
     <li><a href="#ref-for-queue-a-fetch-task⑧">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-an-integer">
-   <b><a href="#serialize-an-integer">#serialize-an-integer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-an-integer" class="dfn-panel" data-for="serialize-an-integer" id="infopanel-for-serialize-an-integer" role="dialog">
+   <span id="infopaneltitle-for-serialize-an-integer" style="display:none">Info about the 'serialize an integer' definition.</span><b><a href="#serialize-an-integer">#serialize-an-integer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-integer">2.2.5. Requests</a> <a href="#ref-for-serialize-an-integer①">(2)</a>
     <li><a href="#ref-for-serialize-an-integer②">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-scheme">
-   <b><a href="#local-scheme">#local-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-scheme" class="dfn-panel" data-for="local-scheme" id="infopanel-for-local-scheme" role="dialog">
+   <span id="infopaneltitle-for-local-scheme" style="display:none">Info about the 'local scheme' definition.</span><b><a href="#local-scheme">#local-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-scheme">2.1. URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-local">
-   <b><a href="#is-local">#is-local</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-local" class="dfn-panel" data-for="is-local" id="infopanel-for-is-local" role="dialog">
+   <span id="infopaneltitle-for-is-local" style="display:none">Info about the 'is local' definition.</span><b><a href="#is-local">#is-local</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-local">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-scheme">
-   <b><a href="#http-scheme">#http-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-scheme" class="dfn-panel" data-for="http-scheme" id="infopanel-for-http-scheme" role="dialog">
+   <span id="infopaneltitle-for-http-scheme" style="display:none">Info about the 'HTTP(S) scheme' definition.</span><b><a href="#http-scheme">#http-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-scheme">2.1. URL</a> <a href="#ref-for-http-scheme①">(2)</a>
     <li><a href="#ref-for-http-scheme②">2.8. Port blocking</a>
@@ -9505,53 +9505,53 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-http-scheme⑦">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-scheme">
-   <b><a href="#fetch-scheme">#fetch-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-scheme" class="dfn-panel" data-for="fetch-scheme" id="infopanel-for-fetch-scheme" role="dialog">
+   <span id="infopaneltitle-for-fetch-scheme" style="display:none">Info about the 'fetch scheme' definition.</span><b><a href="#fetch-scheme">#fetch-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-scheme">2.1. URL</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-tab-or-space">
-   <b><a href="#http-tab-or-space">#http-tab-or-space</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-tab-or-space" class="dfn-panel" data-for="http-tab-or-space" id="infopanel-for-http-tab-or-space" role="dialog">
+   <span id="infopaneltitle-for-http-tab-or-space" style="display:none">Info about the 'HTTP tab or space' definition.</span><b><a href="#http-tab-or-space">#http-tab-or-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-tab-or-space">2.2. HTTP</a> <a href="#ref-for-http-tab-or-space①">(2)</a>
     <li><a href="#ref-for-http-tab-or-space②">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-whitespace">
-   <b><a href="#http-whitespace">#http-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-whitespace" class="dfn-panel" data-for="http-whitespace" id="infopanel-for-http-whitespace" role="dialog">
+   <span id="infopaneltitle-for-http-whitespace" style="display:none">Info about the 'HTTP whitespace' definition.</span><b><a href="#http-whitespace">#http-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-whitespace">2.2. HTTP</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-newline-byte">
-   <b><a href="#http-newline-byte">#http-newline-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-newline-byte" class="dfn-panel" data-for="http-newline-byte" id="infopanel-for-http-newline-byte" role="dialog">
+   <span id="infopaneltitle-for-http-newline-byte" style="display:none">Info about the 'HTTP newline byte' definition.</span><b><a href="#http-newline-byte">#http-newline-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-newline-byte">2.2. HTTP</a>
     <li><a href="#ref-for-http-newline-byte①">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-tab-or-space-byte">
-   <b><a href="#http-tab-or-space-byte">#http-tab-or-space-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-tab-or-space-byte" class="dfn-panel" data-for="http-tab-or-space-byte" id="infopanel-for-http-tab-or-space-byte" role="dialog">
+   <span id="infopaneltitle-for-http-tab-or-space-byte" style="display:none">Info about the 'HTTP tab or space byte' definition.</span><b><a href="#http-tab-or-space-byte">#http-tab-or-space-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-tab-or-space-byte">2.2. HTTP</a>
     <li><a href="#ref-for-http-tab-or-space-byte①">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-whitespace-byte">
-   <b><a href="#http-whitespace-byte">#http-whitespace-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-whitespace-byte" class="dfn-panel" data-for="http-whitespace-byte" id="infopanel-for-http-whitespace-byte" role="dialog">
+   <span id="infopaneltitle-for-http-whitespace-byte" style="display:none">Info about the 'HTTP whitespace byte' definition.</span><b><a href="#http-whitespace-byte">#http-whitespace-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-whitespace-byte">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-an-http-quoted-string">
-   <b><a href="#collect-an-http-quoted-string">#collect-an-http-quoted-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-an-http-quoted-string" class="dfn-panel" data-for="collect-an-http-quoted-string" id="infopanel-for-collect-an-http-quoted-string" role="dialog">
+   <span id="infopaneltitle-for-collect-an-http-quoted-string" style="display:none">Info about the 'collect an HTTP quoted string' definition.</span><b><a href="#collect-an-http-quoted-string">#collect-an-http-quoted-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-an-http-quoted-string">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-method">
-   <b><a href="#concept-method">#concept-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-method" class="dfn-panel" data-for="concept-method" id="infopanel-for-concept-method" role="dialog">
+   <span id="infopaneltitle-for-concept-method" style="display:none">Info about the 'method' definition.</span><b><a href="#concept-method">#concept-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-method">2.2.1. Methods</a> <a href="#ref-for-concept-method①">(2)</a> <a href="#ref-for-concept-method②">(3)</a> <a href="#ref-for-concept-method③">(4)</a> <a href="#ref-for-concept-method④">(5)</a>
     <li><a href="#ref-for-concept-method⑤">2.2.5. Requests</a>
@@ -9563,8 +9563,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-method①②">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-safelisted-method">
-   <b><a href="#cors-safelisted-method">#cors-safelisted-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-safelisted-method" class="dfn-panel" data-for="cors-safelisted-method" id="infopanel-for-cors-safelisted-method" role="dialog">
+   <span id="infopaneltitle-for-cors-safelisted-method" style="display:none">Info about the 'CORS-safelisted method' definition.</span><b><a href="#cors-safelisted-method">#cors-safelisted-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-safelisted-method">2.2.5. Requests</a>
     <li><a href="#ref-for-cors-safelisted-method①">4.1. Main fetch</a>
@@ -9573,22 +9573,22 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-cors-safelisted-method④">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forbidden-method">
-   <b><a href="#forbidden-method">#forbidden-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forbidden-method" class="dfn-panel" data-for="forbidden-method" id="infopanel-for-forbidden-method" role="dialog">
+   <span id="infopaneltitle-for-forbidden-method" style="display:none">Info about the 'forbidden method' definition.</span><b><a href="#forbidden-method">#forbidden-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forbidden-method">2.2.5. Requests</a>
     <li><a href="#ref-for-forbidden-method①">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-method-normalize">
-   <b><a href="#concept-method-normalize">#concept-method-normalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-method-normalize" class="dfn-panel" data-for="concept-method-normalize" id="infopanel-for-concept-method-normalize" role="dialog">
+   <span id="infopaneltitle-for-concept-method-normalize" style="display:none">Info about the 'normalize' definition.</span><b><a href="#concept-method-normalize">#concept-method-normalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-method-normalize">2.2.1. Methods</a> <a href="#ref-for-concept-method-normalize①">(2)</a>
     <li><a href="#ref-for-concept-method-normalize②">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list">
-   <b><a href="#concept-header-list">#concept-header-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list" class="dfn-panel" data-for="concept-header-list" id="infopanel-for-concept-header-list" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list" style="display:none">Info about the 'header list' definition.</span><b><a href="#concept-header-list">#concept-header-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list">2.2.2. Headers</a> <a href="#ref-for-concept-header-list①">(2)</a> <a href="#ref-for-concept-header-list②">(3)</a> <a href="#ref-for-concept-header-list③">(4)</a> <a href="#ref-for-concept-header-list④">(5)</a> <a href="#ref-for-concept-header-list⑤">(6)</a> <a href="#ref-for-concept-header-list⑥">(7)</a> <a href="#ref-for-concept-header-list⑦">(8)</a> <a href="#ref-for-concept-header-list⑧">(9)</a> <a href="#ref-for-concept-header-list⑨">(10)</a> <a href="#ref-for-concept-header-list①⓪">(11)</a> <a href="#ref-for-concept-header-list①①">(12)</a> <a href="#ref-for-concept-header-list①②">(13)</a> <a href="#ref-for-concept-header-list①③">(14)</a> <a href="#ref-for-concept-header-list①④">(15)</a>
     <li><a href="#ref-for-concept-header-list①⑤">2.2.5. Requests</a>
@@ -9599,14 +9599,14 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-list②⓪">5.1. Headers class</a> <a href="#ref-for-concept-header-list②①">(2)</a> <a href="#ref-for-concept-header-list②②">(3)</a> <a href="#ref-for-concept-header-list②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-get-structured-header">
-   <b><a href="#concept-header-list-get-structured-header">#concept-header-list-get-structured-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-get-structured-header" class="dfn-panel" data-for="concept-header-list-get-structured-header" id="infopanel-for-concept-header-list-get-structured-header" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-get-structured-header" style="display:none">Info about the 'get a structured field value' definition.</span><b><a href="#concept-header-list-get-structured-header">#concept-header-list-get-structured-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get-structured-header">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="header-list-contains">
-   <b><a href="#header-list-contains">#header-list-contains</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-header-list-contains" class="dfn-panel" data-for="header-list-contains" id="infopanel-for-header-list-contains" role="dialog">
+   <span id="infopaneltitle-for-header-list-contains" style="display:none">Info about the 'contains' definition.</span><b><a href="#header-list-contains">#header-list-contains</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-contains">2.2.2. Headers</a> <a href="#ref-for-header-list-contains①">(2)</a> <a href="#ref-for-header-list-contains②">(3)</a> <a href="#ref-for-header-list-contains③">(4)</a> <a href="#ref-for-header-list-contains④">(5)</a> <a href="#ref-for-header-list-contains⑤">(6)</a> <a href="#ref-for-header-list-contains⑥">(7)</a>
     <li><a href="#ref-for-header-list-contains⑦">2.2.5. Requests</a>
@@ -9618,8 +9618,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-header-list-contains②⑤">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-get">
-   <b><a href="#concept-header-list-get">#concept-header-list-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-get" class="dfn-panel" data-for="concept-header-list-get" id="infopanel-for-concept-header-list-get" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-get" style="display:none">Info about the 'get' definition.</span><b><a href="#concept-header-list-get">#concept-header-list-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get">2.2.2. Headers</a> <a href="#ref-for-concept-header-list-get①">(2)</a> <a href="#ref-for-concept-header-list-get②">(3)</a>
     <li><a href="#ref-for-concept-header-list-get③">3.7. `Cross-Origin-Resource-Policy` header</a>
@@ -9627,8 +9627,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-list-get⑥">5.1. Headers class</a> <a href="#ref-for-concept-header-list-get⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-get-decode-split">
-   <b><a href="#concept-header-list-get-decode-split">#concept-header-list-get-decode-split</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-get-decode-split" class="dfn-panel" data-for="concept-header-list-get-decode-split" id="infopanel-for-concept-header-list-get-decode-split" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-get-decode-split" style="display:none">Info about the 'get, decode, and split' definition.</span><b><a href="#concept-header-list-get-decode-split">#concept-header-list-get-decode-split</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get-decode-split">2.2.2. Headers</a>
     <li><a href="#ref-for-concept-header-list-get-decode-split①">3.3. `Content-Length` header</a>
@@ -9637,8 +9637,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-list-get-decode-split④">4.11. TAO check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-append">
-   <b><a href="#concept-header-list-append">#concept-header-list-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-append" class="dfn-panel" data-for="concept-header-list-append" id="infopanel-for-concept-header-list-append" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-append" style="display:none">Info about the 'append' definition.</span><b><a href="#concept-header-list-append">#concept-header-list-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-append">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-header-list-append①">3.1. `Origin` header</a> <a href="#ref-for-concept-header-list-append②">(2)</a>
@@ -9652,42 +9652,42 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-list-append②⑥">6.2. Opening handshake</a> <a href="#ref-for-concept-header-list-append②⑦">(2)</a> <a href="#ref-for-concept-header-list-append②⑧">(3)</a> <a href="#ref-for-concept-header-list-append②⑨">(4)</a> <a href="#ref-for-concept-header-list-append③⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-delete">
-   <b><a href="#concept-header-list-delete">#concept-header-list-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-delete" class="dfn-panel" data-for="concept-header-list-delete" id="infopanel-for-concept-header-list-delete" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-delete" style="display:none">Info about the 'delete' definition.</span><b><a href="#concept-header-list-delete">#concept-header-list-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-delete">4.4. HTTP-redirect fetch</a>
     <li><a href="#ref-for-concept-header-list-delete①">5.1. Headers class</a> <a href="#ref-for-concept-header-list-delete②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-set">
-   <b><a href="#concept-header-list-set">#concept-header-list-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-set" class="dfn-panel" data-for="concept-header-list-set" id="infopanel-for-concept-header-list-set" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-set" style="display:none">Info about the 'set' definition.</span><b><a href="#concept-header-list-set">#concept-header-list-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-set">2.2.2. Headers</a>
     <li><a href="#ref-for-concept-header-list-set①">5.1. Headers class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-combine">
-   <b><a href="#concept-header-list-combine">#concept-header-list-combine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-combine" class="dfn-panel" data-for="concept-header-list-combine" id="infopanel-for-concept-header-list-combine" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-combine" style="display:none">Info about the 'combine' definition.</span><b><a href="#concept-header-list-combine">#concept-header-list-combine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-combine">2.2.2. Headers</a>
     <li><a href="#ref-for-concept-header-list-combine①">4.8. CORS-preflight fetch</a>
     <li><a href="#ref-for-concept-header-list-combine②">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-header-names-to-a-sorted-lowercase-set">
-   <b><a href="#convert-header-names-to-a-sorted-lowercase-set">#convert-header-names-to-a-sorted-lowercase-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-header-names-to-a-sorted-lowercase-set" class="dfn-panel" data-for="convert-header-names-to-a-sorted-lowercase-set" id="infopanel-for-convert-header-names-to-a-sorted-lowercase-set" role="dialog">
+   <span id="infopaneltitle-for-convert-header-names-to-a-sorted-lowercase-set" style="display:none">Info about the 'convert header names to a sorted-lowercase set' definition.</span><b><a href="#convert-header-names-to-a-sorted-lowercase-set">#convert-header-names-to-a-sorted-lowercase-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-header-names-to-a-sorted-lowercase-set">2.2.2. Headers</a> <a href="#ref-for-convert-header-names-to-a-sorted-lowercase-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-list-sort-and-combine">
-   <b><a href="#concept-header-list-sort-and-combine">#concept-header-list-sort-and-combine</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-list-sort-and-combine" class="dfn-panel" data-for="concept-header-list-sort-and-combine" id="infopanel-for-concept-header-list-sort-and-combine" role="dialog">
+   <span id="infopaneltitle-for-concept-header-list-sort-and-combine" style="display:none">Info about the 'sort and combine' definition.</span><b><a href="#concept-header-list-sort-and-combine">#concept-header-list-sort-and-combine</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-sort-and-combine">5.1. Headers class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header">
-   <b><a href="#concept-header">#concept-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header" class="dfn-panel" data-for="concept-header" id="infopanel-for-concept-header" role="dialog">
+   <span id="infopaneltitle-for-concept-header" style="display:none">Info about the 'header' definition.</span><b><a href="#concept-header">#concept-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">2.2.2. Headers</a> <a href="#ref-for-concept-header①">(2)</a> <a href="#ref-for-concept-header②">(3)</a> <a href="#ref-for-concept-header③">(4)</a> <a href="#ref-for-concept-header④">(5)</a> <a href="#ref-for-concept-header⑤">(6)</a> <a href="#ref-for-concept-header⑥">(7)</a> <a href="#ref-for-concept-header⑦">(8)</a> <a href="#ref-for-concept-header⑧">(9)</a> <a href="#ref-for-concept-header⑨">(10)</a> <a href="#ref-for-concept-header①⓪">(11)</a> <a href="#ref-for-concept-header①①">(12)</a> <a href="#ref-for-concept-header①②">(13)</a> <a href="#ref-for-concept-header①③">(14)</a> <a href="#ref-for-concept-header①④">(15)</a> <a href="#ref-for-concept-header①⑤">(16)</a> <a href="#ref-for-concept-header①⑥">(17)</a> <a href="#ref-for-concept-header①⑦">(18)</a> <a href="#ref-for-concept-header①⑧">(19)</a> <a href="#ref-for-concept-header①⑨">(20)</a> <a href="#ref-for-concept-header②⓪">(21)</a> <a href="#ref-for-concept-header②①">(22)</a> <a href="#ref-for-concept-header②②">(23)</a> <a href="#ref-for-concept-header②③">(24)</a> <a href="#ref-for-concept-header②④">(25)</a> <a href="#ref-for-concept-header②⑤">(26)</a> <a href="#ref-for-concept-header②⑥">(27)</a> <a href="#ref-for-concept-header②⑦">(28)</a> <a href="#ref-for-concept-header②⑧">(29)</a> <a href="#ref-for-concept-header②⑨">(30)</a> <a href="#ref-for-concept-header③⓪">(31)</a>
     <li><a href="#ref-for-concept-header③①">2.2.6. Responses</a> <a href="#ref-for-concept-header③②">(2)</a> <a href="#ref-for-concept-header③③">(3)</a>
@@ -9708,8 +9708,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header⑥⑥">Basic safe CORS protocol setup</a> <a href="#ref-for-concept-header⑥⑦">(2)</a> <a href="#ref-for-concept-header⑥⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-name">
-   <b><a href="#concept-header-name">#concept-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-name" class="dfn-panel" data-for="concept-header-name" id="infopanel-for-concept-header-name" role="dialog">
+   <span id="infopaneltitle-for-concept-header-name" style="display:none">Info about the 'name' definition.</span><b><a href="#concept-header-name">#concept-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">2.2.2. Headers</a> <a href="#ref-for-concept-header-name①">(2)</a> <a href="#ref-for-concept-header-name②">(3)</a> <a href="#ref-for-concept-header-name③">(4)</a> <a href="#ref-for-concept-header-name④">(5)</a> <a href="#ref-for-concept-header-name⑤">(6)</a> <a href="#ref-for-concept-header-name⑥">(7)</a> <a href="#ref-for-concept-header-name⑦">(8)</a> <a href="#ref-for-concept-header-name⑧">(9)</a> <a href="#ref-for-concept-header-name⑨">(10)</a> <a href="#ref-for-concept-header-name①⓪">(11)</a> <a href="#ref-for-concept-header-name①①">(12)</a> <a href="#ref-for-concept-header-name①②">(13)</a> <a href="#ref-for-concept-header-name①③">(14)</a> <a href="#ref-for-concept-header-name①④">(15)</a> <a href="#ref-for-concept-header-name①⑤">(16)</a> <a href="#ref-for-concept-header-name①⑥">(17)</a> <a href="#ref-for-concept-header-name①⑦">(18)</a> <a href="#ref-for-concept-header-name①⑧">(19)</a> <a href="#ref-for-concept-header-name①⑨">(20)</a> <a href="#ref-for-concept-header-name②⓪">(21)</a> <a href="#ref-for-concept-header-name②①">(22)</a> <a href="#ref-for-concept-header-name②②">(23)</a> <a href="#ref-for-concept-header-name②③">(24)</a> <a href="#ref-for-concept-header-name②④">(25)</a> <a href="#ref-for-concept-header-name②⑤">(26)</a> <a href="#ref-for-concept-header-name②⑥">(27)</a> <a href="#ref-for-concept-header-name②⑦">(28)</a> <a href="#ref-for-concept-header-name②⑧">(29)</a> <a href="#ref-for-concept-header-name②⑨">(30)</a> <a href="#ref-for-concept-header-name③⓪">(31)</a> <a href="#ref-for-concept-header-name③①">(32)</a> <a href="#ref-for-concept-header-name③②">(33)</a> <a href="#ref-for-concept-header-name③③">(34)</a> <a href="#ref-for-concept-header-name③④">(35)</a> <a href="#ref-for-concept-header-name③⑤">(36)</a> <a href="#ref-for-concept-header-name③⑥">(37)</a> <a href="#ref-for-concept-header-name③⑦">(38)</a>
     <li><a href="#ref-for-concept-header-name③⑧">2.2.6. Responses</a> <a href="#ref-for-concept-header-name③⑨">(2)</a> <a href="#ref-for-concept-header-name④⓪">(3)</a>
@@ -9725,8 +9725,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-name⑤⑦">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-value">
-   <b><a href="#concept-header-value">#concept-header-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-value" class="dfn-panel" data-for="concept-header-value" id="infopanel-for-concept-header-value" role="dialog">
+   <span id="infopaneltitle-for-concept-header-value" style="display:none">Info about the 'value' definition.</span><b><a href="#concept-header-value">#concept-header-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">2.2.2. Headers</a> <a href="#ref-for-concept-header-value①">(2)</a> <a href="#ref-for-concept-header-value②">(3)</a> <a href="#ref-for-concept-header-value③">(4)</a> <a href="#ref-for-concept-header-value④">(5)</a> <a href="#ref-for-concept-header-value⑤">(6)</a> <a href="#ref-for-concept-header-value⑥">(7)</a> <a href="#ref-for-concept-header-value⑦">(8)</a> <a href="#ref-for-concept-header-value⑧">(9)</a> <a href="#ref-for-concept-header-value⑨">(10)</a> <a href="#ref-for-concept-header-value①⓪">(11)</a> <a href="#ref-for-concept-header-value①①">(12)</a> <a href="#ref-for-concept-header-value①②">(13)</a> <a href="#ref-for-concept-header-value①③">(14)</a> <a href="#ref-for-concept-header-value①④">(15)</a> <a href="#ref-for-concept-header-value①⑤">(16)</a> <a href="#ref-for-concept-header-value①⑥">(17)</a> <a href="#ref-for-concept-header-value①⑦">(18)</a> <a href="#ref-for-concept-header-value①⑧">(19)</a> <a href="#ref-for-concept-header-value①⑨">(20)</a> <a href="#ref-for-concept-header-value②⓪">(21)</a> <a href="#ref-for-concept-header-value②①">(22)</a> <a href="#ref-for-concept-header-value②②">(23)</a> <a href="#ref-for-concept-header-value②③">(24)</a>
     <li><a href="#ref-for-concept-header-value②④">2.2.6. Responses</a>
@@ -9744,96 +9744,96 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-value④①">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-value-normalize">
-   <b><a href="#concept-header-value-normalize">#concept-header-value-normalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-value-normalize" class="dfn-panel" data-for="concept-header-value-normalize" id="infopanel-for-concept-header-value-normalize" role="dialog">
+   <span id="infopaneltitle-for-concept-header-value-normalize" style="display:none">Info about the 'normalize' definition.</span><b><a href="#concept-header-value-normalize">#concept-header-value-normalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value-normalize">5.1. Headers class</a> <a href="#ref-for-concept-header-value-normalize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-safelisted-request-header">
-   <b><a href="#cors-safelisted-request-header">#cors-safelisted-request-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-safelisted-request-header" class="dfn-panel" data-for="cors-safelisted-request-header" id="infopanel-for-cors-safelisted-request-header" role="dialog">
+   <span id="infopaneltitle-for-cors-safelisted-request-header" style="display:none">Info about the 'CORS-safelisted request-header' definition.</span><b><a href="#cors-safelisted-request-header">#cors-safelisted-request-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-safelisted-request-header">2.2.2. Headers</a> <a href="#ref-for-cors-safelisted-request-header①">(2)</a>
     <li><a href="#ref-for-cors-safelisted-request-header②">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-unsafe-request-header-byte">
-   <b><a href="#cors-unsafe-request-header-byte">#cors-unsafe-request-header-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-unsafe-request-header-byte" class="dfn-panel" data-for="cors-unsafe-request-header-byte" id="infopanel-for-cors-unsafe-request-header-byte" role="dialog">
+   <span id="infopaneltitle-for-cors-unsafe-request-header-byte" style="display:none">Info about the 'CORS-unsafe request-header byte' definition.</span><b><a href="#cors-unsafe-request-header-byte">#cors-unsafe-request-header-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-unsafe-request-header-byte">2.2.2. Headers</a> <a href="#ref-for-cors-unsafe-request-header-byte①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-unsafe-request-header-names">
-   <b><a href="#cors-unsafe-request-header-names">#cors-unsafe-request-header-names</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-unsafe-request-header-names" class="dfn-panel" data-for="cors-unsafe-request-header-names" id="infopanel-for-cors-unsafe-request-header-names" role="dialog">
+   <span id="infopaneltitle-for-cors-unsafe-request-header-names" style="display:none">Info about the 'CORS-unsafe request-header names' definition.</span><b><a href="#cors-unsafe-request-header-names">#cors-unsafe-request-header-names</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-unsafe-request-header-names">4.1. Main fetch</a>
     <li><a href="#ref-for-cors-unsafe-request-header-names①">4.3. HTTP fetch</a>
     <li><a href="#ref-for-cors-unsafe-request-header-names②">4.8. CORS-preflight fetch</a> <a href="#ref-for-cors-unsafe-request-header-names③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-non-wildcard-request-header-name">
-   <b><a href="#cors-non-wildcard-request-header-name">#cors-non-wildcard-request-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-non-wildcard-request-header-name" class="dfn-panel" data-for="cors-non-wildcard-request-header-name" id="infopanel-for-cors-non-wildcard-request-header-name" role="dialog">
+   <span id="infopaneltitle-for-cors-non-wildcard-request-header-name" style="display:none">Info about the 'CORS non-wildcard request-header name' definition.</span><b><a href="#cors-non-wildcard-request-header-name">#cors-non-wildcard-request-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-non-wildcard-request-header-name">4.8. CORS-preflight fetch</a>
     <li><a href="#ref-for-cors-non-wildcard-request-header-name①">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="privileged-no-cors-request-header-name">
-   <b><a href="#privileged-no-cors-request-header-name">#privileged-no-cors-request-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-privileged-no-cors-request-header-name" class="dfn-panel" data-for="privileged-no-cors-request-header-name" id="infopanel-for-privileged-no-cors-request-header-name" role="dialog">
+   <span id="infopaneltitle-for-privileged-no-cors-request-header-name" style="display:none">Info about the 'privileged no-CORS request-header name' definition.</span><b><a href="#privileged-no-cors-request-header-name">#privileged-no-cors-request-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-privileged-no-cors-request-header-name">5.1. Headers class</a> <a href="#ref-for-privileged-no-cors-request-header-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-safelisted-response-header-name">
-   <b><a href="#cors-safelisted-response-header-name">#cors-safelisted-response-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-safelisted-response-header-name" class="dfn-panel" data-for="cors-safelisted-response-header-name" id="infopanel-for-cors-safelisted-response-header-name" role="dialog">
+   <span id="infopaneltitle-for-cors-safelisted-response-header-name" style="display:none">Info about the 'CORS-safelisted response-header name' definition.</span><b><a href="#cors-safelisted-response-header-name">#cors-safelisted-response-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-safelisted-response-header-name">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-cors-safelisted-request-header-name">
-   <b><a href="#no-cors-safelisted-request-header-name">#no-cors-safelisted-request-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-cors-safelisted-request-header-name" class="dfn-panel" data-for="no-cors-safelisted-request-header-name" id="infopanel-for-no-cors-safelisted-request-header-name" role="dialog">
+   <span id="infopaneltitle-for-no-cors-safelisted-request-header-name" style="display:none">Info about the 'no-CORS-safelisted request-header name' definition.</span><b><a href="#no-cors-safelisted-request-header-name">#no-cors-safelisted-request-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-cors-safelisted-request-header-name">2.2.2. Headers</a>
     <li><a href="#ref-for-no-cors-safelisted-request-header-name①">5.1. Headers class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-cors-safelisted-request-header">
-   <b><a href="#no-cors-safelisted-request-header">#no-cors-safelisted-request-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-cors-safelisted-request-header" class="dfn-panel" data-for="no-cors-safelisted-request-header" id="infopanel-for-no-cors-safelisted-request-header" role="dialog">
+   <span id="infopaneltitle-for-no-cors-safelisted-request-header" style="display:none">Info about the 'no-CORS-safelisted request-header' definition.</span><b><a href="#no-cors-safelisted-request-header">#no-cors-safelisted-request-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-cors-safelisted-request-header">5.1. Headers class</a> <a href="#ref-for-no-cors-safelisted-request-header①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forbidden-header-name">
-   <b><a href="#forbidden-header-name">#forbidden-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forbidden-header-name" class="dfn-panel" data-for="forbidden-header-name" id="infopanel-for-forbidden-header-name" role="dialog">
+   <span id="infopaneltitle-for-forbidden-header-name" style="display:none">Info about the 'forbidden header name' definition.</span><b><a href="#forbidden-header-name">#forbidden-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forbidden-header-name">2.2.5. Requests</a>
     <li><a href="#ref-for-forbidden-header-name①">5.1. Headers class</a> <a href="#ref-for-forbidden-header-name②">(2)</a> <a href="#ref-for-forbidden-header-name③">(3)</a>
     <li><a href="#ref-for-forbidden-header-name④">HTTP header layer division</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forbidden-response-header-name">
-   <b><a href="#forbidden-response-header-name">#forbidden-response-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forbidden-response-header-name" class="dfn-panel" data-for="forbidden-response-header-name" id="infopanel-for-forbidden-response-header-name" role="dialog">
+   <span id="infopaneltitle-for-forbidden-response-header-name" style="display:none">Info about the 'forbidden response-header name' definition.</span><b><a href="#forbidden-response-header-name">#forbidden-response-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forbidden-response-header-name">2.2.2. Headers</a>
     <li><a href="#ref-for-forbidden-response-header-name①">2.2.6. Responses</a>
     <li><a href="#ref-for-forbidden-response-header-name②">5.1. Headers class</a> <a href="#ref-for-forbidden-response-header-name③">(2)</a> <a href="#ref-for-forbidden-response-header-name④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-body-header-name">
-   <b><a href="#request-body-header-name">#request-body-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-body-header-name" class="dfn-panel" data-for="request-body-header-name" id="infopanel-for-request-body-header-name" role="dialog">
+   <span id="infopaneltitle-for-request-body-header-name" style="display:none">Info about the 'request-body-header name' definition.</span><b><a href="#request-body-header-name">#request-body-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-body-header-name">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-header-values">
-   <b><a href="#extract-header-values">#extract-header-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-header-values" class="dfn-panel" data-for="extract-header-values" id="infopanel-for-extract-header-values" role="dialog">
+   <span id="infopaneltitle-for-extract-header-values" style="display:none">Info about the 'extract header values' definition.</span><b><a href="#extract-header-values">#extract-header-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-values">2.2.2. Headers</a>
     <li><a href="#ref-for-extract-header-values①">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="extract-header-list-values">
-   <b><a href="#extract-header-list-values">#extract-header-list-values</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-extract-header-list-values" class="dfn-panel" data-for="extract-header-list-values" id="infopanel-for-extract-header-list-values" role="dialog">
+   <span id="infopaneltitle-for-extract-header-list-values" style="display:none">Info about the 'extract header list values' definition.</span><b><a href="#extract-header-list-values">#extract-header-list-values</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extract-header-list-values">2.2.6. Responses</a>
     <li><a href="#ref-for-extract-header-list-values①">4.1. Main fetch</a>
@@ -9842,36 +9842,36 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-extract-header-list-values⑥">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-user-agent-value">
-   <b><a href="#default-user-agent-value">#default-user-agent-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-user-agent-value" class="dfn-panel" data-for="default-user-agent-value" id="infopanel-for-default-user-agent-value" role="dialog">
+   <span id="infopaneltitle-for-default-user-agent-value" style="display:none">Info about the 'default `User-Agent` value' definition.</span><b><a href="#default-user-agent-value">#default-user-agent-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-user-agent-value">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-status">
-   <b><a href="#concept-status">#concept-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-status" class="dfn-panel" data-for="concept-status" id="infopanel-for-concept-status" role="dialog">
+   <span id="infopaneltitle-for-concept-status" style="display:none">Info about the 'status' definition.</span><b><a href="#concept-status">#concept-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-status">2.2.3. Statuses</a> <a href="#ref-for-concept-status①">(2)</a> <a href="#ref-for-concept-status②">(3)</a>
     <li><a href="#ref-for-concept-status③">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-status④">3.2.3. HTTP responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="null-body-status">
-   <b><a href="#null-body-status">#null-body-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-null-body-status" class="dfn-panel" data-for="null-body-status" id="infopanel-for-null-body-status" role="dialog">
+   <span id="infopaneltitle-for-null-body-status" style="display:none">Info about the 'null body status' definition.</span><b><a href="#null-body-status">#null-body-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-null-body-status">4.1. Main fetch</a>
     <li><a href="#ref-for-null-body-status①">5.5. Response class</a> <a href="#ref-for-null-body-status②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ok-status">
-   <b><a href="#ok-status">#ok-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ok-status" class="dfn-panel" data-for="ok-status" id="infopanel-for-ok-status" role="dialog">
+   <span id="infopaneltitle-for-ok-status" style="display:none">Info about the 'ok status' definition.</span><b><a href="#ok-status">#ok-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ok-status">4.8. CORS-preflight fetch</a>
     <li><a href="#ref-for-ok-status①">5.5. Response class</a> <a href="#ref-for-ok-status②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="redirect-status">
-   <b><a href="#redirect-status">#redirect-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-redirect-status" class="dfn-panel" data-for="redirect-status" id="infopanel-for-redirect-status" role="dialog">
+   <span id="infopaneltitle-for-redirect-status" style="display:none">Info about the 'redirect status' definition.</span><b><a href="#redirect-status">#redirect-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-redirect-status">2.2.6. Responses</a>
     <li><a href="#ref-for-redirect-status①">4.3. HTTP fetch</a>
@@ -9879,8 +9879,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-redirect-status③">Atomic HTTP redirect handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body">
-   <b><a href="#concept-body">#concept-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body" class="dfn-panel" data-for="concept-body" id="infopanel-for-concept-body" role="dialog">
+   <span id="infopaneltitle-for-concept-body" style="display:none">Info about the 'body' definition.</span><b><a href="#concept-body">#concept-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body">2.2.4. Bodies</a> <a href="#ref-for-concept-body①">(2)</a> <a href="#ref-for-concept-body②">(3)</a> <a href="#ref-for-concept-body③">(4)</a> <a href="#ref-for-concept-body④">(5)</a>
     <li><a href="#ref-for-concept-body⑤">2.2.5. Requests</a> <a href="#ref-for-concept-body⑥">(2)</a>
@@ -9891,8 +9891,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-body①⑤">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-stream">
-   <b><a href="#concept-body-stream">#concept-body-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-stream" class="dfn-panel" data-for="concept-body-stream" id="infopanel-for-concept-body-stream" role="dialog">
+   <span id="infopaneltitle-for-concept-body-stream" style="display:none">Info about the 'stream' definition.</span><b><a href="#concept-body-stream">#concept-body-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-stream">2.2.4. Bodies</a> <a href="#ref-for-concept-body-stream①">(2)</a> <a href="#ref-for-concept-body-stream②">(3)</a> <a href="#ref-for-concept-body-stream③">(4)</a> <a href="#ref-for-concept-body-stream④">(5)</a>
     <li><a href="#ref-for-concept-body-stream⑤">4.3. HTTP fetch</a> <a href="#ref-for-concept-body-stream⑥">(2)</a> <a href="#ref-for-concept-body-stream⑦">(3)</a>
@@ -9902,8 +9902,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-body-stream①③">5.3. Body mixin</a> <a href="#ref-for-concept-body-stream①④">(2)</a> <a href="#ref-for-concept-body-stream①⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-source">
-   <b><a href="#concept-body-source">#concept-body-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-source" class="dfn-panel" data-for="concept-body-source" id="infopanel-for-concept-body-source" role="dialog">
+   <span id="infopaneltitle-for-concept-body-source" style="display:none">Info about the 'source' definition.</span><b><a href="#concept-body-source">#concept-body-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-source">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-body-source①">4.4. HTTP-redirect fetch</a> <a href="#ref-for-concept-body-source②">(2)</a> <a href="#ref-for-concept-body-source③">(3)</a>
@@ -9913,55 +9913,55 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-body-source①①">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-total-bytes">
-   <b><a href="#concept-body-total-bytes">#concept-body-total-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-total-bytes" class="dfn-panel" data-for="concept-body-total-bytes" id="infopanel-for-concept-body-total-bytes" role="dialog">
+   <span id="infopaneltitle-for-concept-body-total-bytes" style="display:none">Info about the 'length' definition.</span><b><a href="#concept-body-total-bytes">#concept-body-total-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-total-bytes">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-body-total-bytes①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-body-total-bytes②">(2)</a>
     <li><a href="#ref-for-concept-body-total-bytes③">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-clone">
-   <b><a href="#concept-body-clone">#concept-body-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-clone" class="dfn-panel" data-for="concept-body-clone" id="infopanel-for-concept-body-clone" role="dialog">
+   <span id="infopaneltitle-for-concept-body-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#concept-body-clone">#concept-body-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-clone">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-body-clone①">2.2.6. Responses</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="body-incrementally-read">
-   <b><a href="#body-incrementally-read">#body-incrementally-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-body-incrementally-read" class="dfn-panel" data-for="body-incrementally-read" id="infopanel-for-body-incrementally-read" role="dialog">
+   <span id="infopaneltitle-for-body-incrementally-read" style="display:none">Info about the 'incrementally read' definition.</span><b><a href="#body-incrementally-read">#body-incrementally-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body-incrementally-read">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="incrementally-read-loop">
-   <b><a href="#incrementally-read-loop">#incrementally-read-loop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-incrementally-read-loop" class="dfn-panel" data-for="incrementally-read-loop" id="infopanel-for-incrementally-read-loop" role="dialog">
+   <span id="infopaneltitle-for-incrementally-read-loop" style="display:none">Info about the 'incrementally-read loop' definition.</span><b><a href="#incrementally-read-loop">#incrementally-read-loop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-incrementally-read-loop">2.2.4. Bodies</a> <a href="#ref-for-incrementally-read-loop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="body-fully-read">
-   <b><a href="#body-fully-read">#body-fully-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-body-fully-read" class="dfn-panel" data-for="body-fully-read" id="infopanel-for-body-fully-read" role="dialog">
+   <span id="infopaneltitle-for-body-fully-read" style="display:none">Info about the 'fully read' definition.</span><b><a href="#body-fully-read">#body-fully-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body-fully-read">4.1. Main fetch</a> <a href="#ref-for-body-fully-read①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fully-reading-body-as-promise">
-   <b><a href="#fully-reading-body-as-promise">#fully-reading-body-as-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fully-reading-body-as-promise" class="dfn-panel" data-for="fully-reading-body-as-promise" id="infopanel-for-fully-reading-body-as-promise" role="dialog">
+   <span id="infopaneltitle-for-fully-reading-body-as-promise" style="display:none">Info about the 'fully read body as promise' definition.</span><b><a href="#fully-reading-body-as-promise">#fully-reading-body-as-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-reading-body-as-promise">2.2.4. Bodies</a>
     <li><a href="#ref-for-fully-reading-body-as-promise①">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-content-codings">
-   <b><a href="#handle-content-codings">#handle-content-codings</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-content-codings" class="dfn-panel" data-for="handle-content-codings" id="infopanel-for-handle-content-codings" role="dialog">
+   <span id="infopaneltitle-for-handle-content-codings" style="display:none">Info about the 'handle content codings' definition.</span><b><a href="#handle-content-codings">#handle-content-codings</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-content-codings">4.6. HTTP-network-or-cache fetch</a>
     <li><a href="#ref-for-handle-content-codings①">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request">
-   <b><a href="#concept-request">#concept-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request" class="dfn-panel" data-for="concept-request" id="infopanel-for-concept-request" role="dialog">
+   <span id="infopaneltitle-for-concept-request" style="display:none">Info about the 'request' definition.</span><b><a href="#concept-request">#concept-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">2. Infrastructure</a>
     <li><a href="#ref-for-concept-request①">2.2.5. Requests</a> <a href="#ref-for-concept-request②">(2)</a> <a href="#ref-for-concept-request③">(3)</a> <a href="#ref-for-concept-request④">(4)</a> <a href="#ref-for-concept-request⑤">(5)</a> <a href="#ref-for-concept-request⑥">(6)</a> <a href="#ref-for-concept-request⑦">(7)</a> <a href="#ref-for-concept-request⑧">(8)</a> <a href="#ref-for-concept-request⑨">(9)</a> <a href="#ref-for-concept-request①⓪">(10)</a> <a href="#ref-for-concept-request①①">(11)</a> <a href="#ref-for-concept-request①②">(12)</a> <a href="#ref-for-concept-request①③">(13)</a> <a href="#ref-for-concept-request①④">(14)</a> <a href="#ref-for-concept-request①⑤">(15)</a> <a href="#ref-for-concept-request①⑥">(16)</a> <a href="#ref-for-concept-request①⑦">(17)</a> <a href="#ref-for-concept-request①⑧">(18)</a> <a href="#ref-for-concept-request①⑨">(19)</a> <a href="#ref-for-concept-request②⓪">(20)</a> <a href="#ref-for-concept-request②①">(21)</a> <a href="#ref-for-concept-request②②">(22)</a> <a href="#ref-for-concept-request②③">(23)</a> <a href="#ref-for-concept-request②④">(24)</a> <a href="#ref-for-concept-request②⑤">(25)</a> <a href="#ref-for-concept-request②⑥">(26)</a> <a href="#ref-for-concept-request②⑦">(27)</a> <a href="#ref-for-concept-request②⑧">(28)</a> <a href="#ref-for-concept-request②⑨">(29)</a> <a href="#ref-for-concept-request③⓪">(30)</a> <a href="#ref-for-concept-request③①">(31)</a> <a href="#ref-for-concept-request③②">(32)</a> <a href="#ref-for-concept-request③③">(33)</a> <a href="#ref-for-concept-request③④">(34)</a> <a href="#ref-for-concept-request③⑤">(35)</a> <a href="#ref-for-concept-request③⑥">(36)</a> <a href="#ref-for-concept-request③⑦">(37)</a> <a href="#ref-for-concept-request③⑧">(38)</a> <a href="#ref-for-concept-request③⑨">(39)</a> <a href="#ref-for-concept-request④⓪">(40)</a> <a href="#ref-for-concept-request④①">(41)</a> <a href="#ref-for-concept-request④②">(42)</a> <a href="#ref-for-concept-request④③">(43)</a> <a href="#ref-for-concept-request④④">(44)</a> <a href="#ref-for-concept-request④⑤">(45)</a> <a href="#ref-for-concept-request④⑥">(46)</a> <a href="#ref-for-concept-request④⑦">(47)</a> <a href="#ref-for-concept-request④⑧">(48)</a> <a href="#ref-for-concept-request④⑨">(49)</a> <a href="#ref-for-concept-request⑤⓪">(50)</a> <a href="#ref-for-concept-request⑤①">(51)</a> <a href="#ref-for-concept-request⑤②">(52)</a> <a href="#ref-for-concept-request⑤③">(53)</a> <a href="#ref-for-concept-request⑤④">(54)</a> <a href="#ref-for-concept-request⑤⑤">(55)</a> <a href="#ref-for-concept-request⑤⑥">(56)</a> <a href="#ref-for-concept-request⑤⑦">(57)</a> <a href="#ref-for-concept-request⑤⑧">(58)</a> <a href="#ref-for-concept-request⑤⑨">(59)</a> <a href="#ref-for-concept-request⑥⓪">(60)</a> <a href="#ref-for-concept-request⑥①">(61)</a> <a href="#ref-for-concept-request⑥②">(62)</a> <a href="#ref-for-concept-request⑥③">(63)</a> <a href="#ref-for-concept-request⑥④">(64)</a> <a href="#ref-for-concept-request⑥⑤">(65)</a>
@@ -9987,8 +9987,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request①⓪④">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-method">
-   <b><a href="#concept-request-method">#concept-request-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-method" class="dfn-panel" data-for="concept-request-method" id="infopanel-for-concept-request-method" role="dialog">
+   <span id="infopaneltitle-for-concept-request-method" style="display:none">Info about the 'method' definition.</span><b><a href="#concept-request-method">#concept-request-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-method①">3.1. `Origin` header</a> <a href="#ref-for-concept-request-method②">(2)</a>
@@ -10002,8 +10002,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-method①⑨">5.4. Request class</a> <a href="#ref-for-concept-request-method②⓪">(2)</a> <a href="#ref-for-concept-request-method②①">(3)</a> <a href="#ref-for-concept-request-method②②">(4)</a> <a href="#ref-for-concept-request-method②③">(5)</a> <a href="#ref-for-concept-request-method②④">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-url">
-   <b><a href="#concept-request-url">#concept-request-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-url" class="dfn-panel" data-for="concept-request-url" id="infopanel-for-concept-request-url" role="dialog">
+   <span id="infopaneltitle-for-concept-request-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-request-url">#concept-request-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-url①">4.8. CORS-preflight fetch</a>
@@ -10011,14 +10011,14 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-url⑤">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-urls-only-flag">
-   <b><a href="#local-urls-only-flag">#local-urls-only-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-urls-only-flag" class="dfn-panel" data-for="local-urls-only-flag" id="infopanel-for-local-urls-only-flag" role="dialog">
+   <span id="infopaneltitle-for-local-urls-only-flag" style="display:none">Info about the 'local-URLs-only flag' definition.</span><b><a href="#local-urls-only-flag">#local-urls-only-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-urls-only-flag">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-header-list">
-   <b><a href="#concept-request-header-list">#concept-request-header-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-header-list" class="dfn-panel" data-for="concept-request-header-list" id="infopanel-for-concept-request-header-list" role="dialog">
+   <span id="infopaneltitle-for-concept-request-header-list" style="display:none">Info about the 'header list' definition.</span><b><a href="#concept-request-header-list">#concept-request-header-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">2.2.5. Requests</a> <a href="#ref-for-concept-request-header-list①">(2)</a> <a href="#ref-for-concept-request-header-list②">(3)</a>
     <li><a href="#ref-for-concept-request-header-list③">3.1. `Origin` header</a> <a href="#ref-for-concept-request-header-list④">(2)</a>
@@ -10033,16 +10033,16 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-header-list④⑦">6.2. Opening handshake</a> <a href="#ref-for-concept-request-header-list④⑧">(2)</a> <a href="#ref-for-concept-request-header-list④⑨">(3)</a> <a href="#ref-for-concept-request-header-list⑤⓪">(4)</a> <a href="#ref-for-concept-request-header-list⑤①">(5)</a> <a href="#ref-for-concept-request-header-list⑤②">(6)</a> <a href="#ref-for-concept-request-header-list⑤③">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unsafe-request-flag">
-   <b><a href="#unsafe-request-flag">#unsafe-request-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unsafe-request-flag" class="dfn-panel" data-for="unsafe-request-flag" id="infopanel-for-unsafe-request-flag" role="dialog">
+   <span id="infopaneltitle-for-unsafe-request-flag" style="display:none">Info about the 'unsafe-request flag' definition.</span><b><a href="#unsafe-request-flag">#unsafe-request-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-request-flag">2.2.5. Requests</a>
     <li><a href="#ref-for-unsafe-request-flag①">4.1. Main fetch</a>
     <li><a href="#ref-for-unsafe-request-flag②">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-body">
-   <b><a href="#concept-request-body">#concept-request-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-body" class="dfn-panel" data-for="concept-request-body" id="infopanel-for-concept-request-body" role="dialog">
+   <span id="infopaneltitle-for-concept-request-body" style="display:none">Info about the 'body' definition.</span><b><a href="#concept-request-body">#concept-request-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">2.2.5. Requests</a> <a href="#ref-for-concept-request-body①">(2)</a> <a href="#ref-for-concept-request-body②">(3)</a> <a href="#ref-for-concept-request-body③">(4)</a>
     <li><a href="#ref-for-concept-request-body④">4. Fetching</a> <a href="#ref-for-concept-request-body⑤">(2)</a> <a href="#ref-for-concept-request-body⑥">(3)</a>
@@ -10054,8 +10054,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-body③⑨">5.6. Fetch method</a> <a href="#ref-for-concept-request-body④⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-client">
-   <b><a href="#concept-request-client">#concept-request-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-client" class="dfn-panel" data-for="concept-request-client" id="infopanel-for-concept-request-client" role="dialog">
+   <span id="infopaneltitle-for-concept-request-client" style="display:none">Info about the 'client' definition.</span><b><a href="#concept-request-client">#concept-request-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">2.2.5. Requests</a> <a href="#ref-for-concept-request-client①">(2)</a>
     <li><a href="#ref-for-concept-request-client②">2.6. Network partition keys</a> <a href="#ref-for-concept-request-client③">(2)</a>
@@ -10068,14 +10068,14 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-client①⑨">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-reserved-client">
-   <b><a href="#concept-request-reserved-client">#concept-request-reserved-client</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-reserved-client" class="dfn-panel" data-for="concept-request-reserved-client" id="infopanel-for-concept-request-reserved-client" role="dialog">
+   <span id="infopaneltitle-for-concept-request-reserved-client" style="display:none">Info about the 'reserved client' definition.</span><b><a href="#concept-request-reserved-client">#concept-request-reserved-client</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-reserved-client">2.6. Network partition keys</a> <a href="#ref-for-concept-request-reserved-client①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-window">
-   <b><a href="#concept-request-window">#concept-request-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-window" class="dfn-panel" data-for="concept-request-window" id="infopanel-for-concept-request-window" role="dialog">
+   <span id="infopaneltitle-for-concept-request-window" style="display:none">Info about the 'window' definition.</span><b><a href="#concept-request-window">#concept-request-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-window">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-window①">4. Fetching</a> <a href="#ref-for-concept-request-window②">(2)</a>
@@ -10084,16 +10084,16 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-window①⓪">5.4. Request class</a> <a href="#ref-for-concept-request-window①①">(2)</a> <a href="#ref-for-concept-request-window①②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-keepalive-flag">
-   <b><a href="#request-keepalive-flag">#request-keepalive-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-keepalive-flag" class="dfn-panel" data-for="request-keepalive-flag" id="infopanel-for-request-keepalive-flag" role="dialog">
+   <span id="infopaneltitle-for-request-keepalive-flag" style="display:none">Info about the 'keepalive' definition.</span><b><a href="#request-keepalive-flag">#request-keepalive-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-keepalive-flag">2.4. Fetch groups</a>
     <li><a href="#ref-for-request-keepalive-flag①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-request-keepalive-flag②">(2)</a>
     <li><a href="#ref-for-request-keepalive-flag③">5.4. Request class</a> <a href="#ref-for-request-keepalive-flag④">(2)</a> <a href="#ref-for-request-keepalive-flag⑤">(3)</a> <a href="#ref-for-request-keepalive-flag⑥">(4)</a> <a href="#ref-for-request-keepalive-flag⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-service-workers-mode">
-   <b><a href="#request-service-workers-mode">#request-service-workers-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-service-workers-mode" class="dfn-panel" data-for="request-service-workers-mode" id="infopanel-for-request-service-workers-mode" role="dialog">
+   <span id="infopaneltitle-for-request-service-workers-mode" style="display:none">Info about the 'service-workers mode' definition.</span><b><a href="#request-service-workers-mode">#request-service-workers-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-service-workers-mode">4.3. HTTP fetch</a> <a href="#ref-for-request-service-workers-mode①">(2)</a>
     <li><a href="#ref-for-request-service-workers-mode②">4.6. HTTP-network-or-cache fetch</a>
@@ -10102,8 +10102,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-request-service-workers-mode⑤">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-initiator">
-   <b><a href="#concept-request-initiator">#concept-request-initiator</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-initiator" class="dfn-panel" data-for="concept-request-initiator" id="infopanel-for-concept-request-initiator" role="dialog">
+   <span id="infopaneltitle-for-concept-request-initiator" style="display:none">Info about the 'initiator' definition.</span><b><a href="#concept-request-initiator">#concept-request-initiator</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-initiator">2.2.5. Requests</a> <a href="#ref-for-concept-request-initiator①">(2)</a> <a href="#ref-for-concept-request-initiator②">(3)</a>
     <li><a href="#ref-for-concept-request-initiator③">3.6. CORB</a>
@@ -10111,8 +10111,8 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-request-initiator⑤">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-request-initiator⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-destination">
-   <b><a href="#concept-request-destination">#concept-request-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-destination" class="dfn-panel" data-for="concept-request-destination" id="infopanel-for-concept-request-destination" role="dialog">
+   <span id="infopaneltitle-for-concept-request-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#concept-request-destination">#concept-request-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-destination">2.2.5. Requests</a> <a href="#ref-for-concept-request-destination①">(2)</a> <a href="#ref-for-concept-request-destination②">(3)</a> <a href="#ref-for-concept-request-destination③">(4)</a> <a href="#ref-for-concept-request-destination④">(5)</a> <a href="#ref-for-concept-request-destination⑤">(6)</a>
     <li><a href="#ref-for-concept-request-destination⑥">2.2.7. Miscellaneous</a> <a href="#ref-for-concept-request-destination⑦">(2)</a>
@@ -10127,8 +10127,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-req
     <li><a href="#ref-for-concept-request-destination①⑦">5.4. Request class</a> <a href="#ref-for-concept-request-destination①⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-destination-script-like">
-   <b><a href="#request-destination-script-like">#request-destination-script-like</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-destination-script-like" class="dfn-panel" data-for="request-destination-script-like" id="infopanel-for-request-destination-script-like" role="dialog">
+   <span id="infopaneltitle-for-request-destination-script-like" style="display:none">Info about the 'script-like' definition.</span><b><a href="#request-destination-script-like">#request-destination-script-like</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-destination-script-like">2.2.5. Requests</a>
     <li><a href="#ref-for-request-destination-script-like①">2.9. Should
@@ -10137,15 +10137,15 @@ response to request be blocked due to its MIME type?</a>
 response to request be blocked due to nosniff?</a> <a href="#ref-for-request-destination-script-like③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-priority">
-   <b><a href="#concept-request-priority">#concept-request-priority</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-priority" class="dfn-panel" data-for="concept-request-priority" id="infopanel-for-concept-request-priority" role="dialog">
+   <span id="infopaneltitle-for-concept-request-priority" style="display:none">Info about the 'priority' definition.</span><b><a href="#concept-request-priority">#concept-request-priority</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-priority">4. Fetching</a> <a href="#ref-for-concept-request-priority①">(2)</a>
     <li><a href="#ref-for-concept-request-priority②">5.4. Request class</a> <a href="#ref-for-concept-request-priority③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-origin">
-   <b><a href="#concept-request-origin">#concept-request-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-origin" class="dfn-panel" data-for="concept-request-origin" id="infopanel-for-concept-request-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-request-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#concept-request-origin">#concept-request-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-origin">2.2.5. Requests</a> <a href="#ref-for-concept-request-origin①">(2)</a>
     <li><a href="#ref-for-concept-request-origin②">3.1. `Origin` header</a> <a href="#ref-for-concept-request-origin③">(2)</a>
@@ -10158,8 +10158,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-origin①③">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-referrer">
-   <b><a href="#concept-request-referrer">#concept-request-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-referrer" class="dfn-panel" data-for="concept-request-referrer" id="infopanel-for-concept-request-referrer" role="dialog">
+   <span id="infopaneltitle-for-concept-request-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#concept-request-referrer">#concept-request-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-referrer①">4.1. Main fetch</a> <a href="#ref-for-concept-request-referrer②">(2)</a> <a href="#ref-for-concept-request-referrer③">(3)</a>
@@ -10169,8 +10169,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-referrer①⑧">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-referrer-policy">
-   <b><a href="#concept-request-referrer-policy">#concept-request-referrer-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-referrer-policy" class="dfn-panel" data-for="concept-request-referrer-policy" id="infopanel-for-concept-request-referrer-policy" role="dialog">
+   <span id="infopaneltitle-for-concept-request-referrer-policy" style="display:none">Info about the 'referrer policy' definition.</span><b><a href="#concept-request-referrer-policy">#concept-request-referrer-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-referrer-policy">3.1. `Origin` header</a> <a href="#ref-for-concept-request-referrer-policy①">(2)</a>
     <li><a href="#ref-for-concept-request-referrer-policy②">4.1. Main fetch</a> <a href="#ref-for-concept-request-referrer-policy③">(2)</a> <a href="#ref-for-concept-request-referrer-policy④">(3)</a> <a href="#ref-for-concept-request-referrer-policy⑤">(4)</a>
@@ -10178,8 +10178,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-referrer-policy⑧">5.4. Request class</a> <a href="#ref-for-concept-request-referrer-policy⑨">(2)</a> <a href="#ref-for-concept-request-referrer-policy①⓪">(3)</a> <a href="#ref-for-concept-request-referrer-policy①①">(4)</a> <a href="#ref-for-concept-request-referrer-policy①②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-mode">
-   <b><a href="#concept-request-mode">#concept-request-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-mode" class="dfn-panel" data-for="concept-request-mode" id="infopanel-for-concept-request-mode" role="dialog">
+   <span id="infopaneltitle-for-concept-request-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#concept-request-mode">#concept-request-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">2.2.5. Requests</a> <a href="#ref-for-concept-request-mode①">(2)</a> <a href="#ref-for-concept-request-mode②">(3)</a> <a href="#ref-for-concept-request-mode③">(4)</a>
     <li><a href="#ref-for-concept-request-mode④">3.1. `Origin` header</a>
@@ -10193,8 +10193,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-mode②③">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="use-cors-preflight-flag">
-   <b><a href="#use-cors-preflight-flag">#use-cors-preflight-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-use-cors-preflight-flag" class="dfn-panel" data-for="use-cors-preflight-flag" id="infopanel-for-use-cors-preflight-flag" role="dialog">
+   <span id="infopaneltitle-for-use-cors-preflight-flag" style="display:none">Info about the 'use-CORS-preflight flag' definition.</span><b><a href="#use-cors-preflight-flag">#use-cors-preflight-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-use-cors-preflight-flag">2.2.5. Requests</a> <a href="#ref-for-use-cors-preflight-flag①">(2)</a>
     <li><a href="#ref-for-use-cors-preflight-flag②">4.1. Main fetch</a>
@@ -10203,8 +10203,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-use-cors-preflight-flag⑥">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-credentials-mode">
-   <b><a href="#concept-request-credentials-mode">#concept-request-credentials-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-credentials-mode" class="dfn-panel" data-for="concept-request-credentials-mode" id="infopanel-for-concept-request-credentials-mode" role="dialog">
+   <span id="infopaneltitle-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' definition.</span><b><a href="#concept-request-credentials-mode">#concept-request-credentials-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">2.2.5. Requests</a> <a href="#ref-for-concept-request-credentials-mode①">(2)</a>
     <li><a href="#ref-for-concept-request-credentials-mode②">3.2.3. HTTP responses</a> <a href="#ref-for-concept-request-credentials-mode③">(2)</a>
@@ -10218,14 +10218,14 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-credentials-mode②④">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-use-url-credentials-flag">
-   <b><a href="#concept-request-use-url-credentials-flag">#concept-request-use-url-credentials-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-use-url-credentials-flag" class="dfn-panel" data-for="concept-request-use-url-credentials-flag" id="infopanel-for-concept-request-use-url-credentials-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-request-use-url-credentials-flag" style="display:none">Info about the 'use-URL-credentials flag' definition.</span><b><a href="#concept-request-use-url-credentials-flag">#concept-request-use-url-credentials-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-use-url-credentials-flag">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-request-use-url-credentials-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-cache-mode">
-   <b><a href="#concept-request-cache-mode">#concept-request-cache-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-cache-mode" class="dfn-panel" data-for="concept-request-cache-mode" id="infopanel-for-concept-request-cache-mode" role="dialog">
+   <span id="infopaneltitle-for-concept-request-cache-mode" style="display:none">Info about the 'cache mode' definition.</span><b><a href="#concept-request-cache-mode">#concept-request-cache-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-cache-mode">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-cache-mode①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-request-cache-mode②">(2)</a> <a href="#ref-for-concept-request-cache-mode③">(3)</a> <a href="#ref-for-concept-request-cache-mode④">(4)</a> <a href="#ref-for-concept-request-cache-mode⑤">(5)</a> <a href="#ref-for-concept-request-cache-mode⑥">(6)</a> <a href="#ref-for-concept-request-cache-mode⑦">(7)</a> <a href="#ref-for-concept-request-cache-mode⑧">(8)</a> <a href="#ref-for-concept-request-cache-mode⑨">(9)</a> <a href="#ref-for-concept-request-cache-mode①⓪">(10)</a>
@@ -10234,8 +10234,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-cache-mode①⑨">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-redirect-mode">
-   <b><a href="#concept-request-redirect-mode">#concept-request-redirect-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-redirect-mode" class="dfn-panel" data-for="concept-request-redirect-mode" id="infopanel-for-concept-request-redirect-mode" role="dialog">
+   <span id="infopaneltitle-for-concept-request-redirect-mode" style="display:none">Info about the 'redirect mode' definition.</span><b><a href="#concept-request-redirect-mode">#concept-request-redirect-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-mode">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-redirect-mode①">4.1. Main fetch</a>
@@ -10246,47 +10246,47 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-redirect-mode①③">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-integrity-metadata">
-   <b><a href="#concept-request-integrity-metadata">#concept-request-integrity-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-integrity-metadata" class="dfn-panel" data-for="concept-request-integrity-metadata" id="infopanel-for-concept-request-integrity-metadata" role="dialog">
+   <span id="infopaneltitle-for-concept-request-integrity-metadata" style="display:none">Info about the 'integrity metadata' definition.</span><b><a href="#concept-request-integrity-metadata">#concept-request-integrity-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-integrity-metadata">4.1. Main fetch</a> <a href="#ref-for-concept-request-integrity-metadata①">(2)</a>
     <li><a href="#ref-for-concept-request-integrity-metadata②">5.4. Request class</a> <a href="#ref-for-concept-request-integrity-metadata③">(2)</a> <a href="#ref-for-concept-request-integrity-metadata④">(3)</a> <a href="#ref-for-concept-request-integrity-metadata⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-nonce-metadata">
-   <b><a href="#concept-request-nonce-metadata">#concept-request-nonce-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-nonce-metadata" class="dfn-panel" data-for="concept-request-nonce-metadata" id="infopanel-for-concept-request-nonce-metadata" role="dialog">
+   <span id="infopaneltitle-for-concept-request-nonce-metadata" style="display:none">Info about the 'cryptographic nonce metadata' definition.</span><b><a href="#concept-request-nonce-metadata">#concept-request-nonce-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-nonce-metadata">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-parser-metadata">
-   <b><a href="#concept-request-parser-metadata">#concept-request-parser-metadata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-parser-metadata" class="dfn-panel" data-for="concept-request-parser-metadata" id="infopanel-for-concept-request-parser-metadata" role="dialog">
+   <span id="infopaneltitle-for-concept-request-parser-metadata" style="display:none">Info about the 'parser metadata' definition.</span><b><a href="#concept-request-parser-metadata">#concept-request-parser-metadata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-parser-metadata">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-reload-navigation-flag">
-   <b><a href="#concept-request-reload-navigation-flag">#concept-request-reload-navigation-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-reload-navigation-flag" class="dfn-panel" data-for="concept-request-reload-navigation-flag" id="infopanel-for-concept-request-reload-navigation-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-request-reload-navigation-flag" style="display:none">Info about the 'reload-navigation flag' definition.</span><b><a href="#concept-request-reload-navigation-flag">#concept-request-reload-navigation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-reload-navigation-flag">5.4. Request class</a> <a href="#ref-for-concept-request-reload-navigation-flag①">(2)</a> <a href="#ref-for-concept-request-reload-navigation-flag②">(3)</a> <a href="#ref-for-concept-request-reload-navigation-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-history-navigation-flag">
-   <b><a href="#concept-request-history-navigation-flag">#concept-request-history-navigation-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-history-navigation-flag" class="dfn-panel" data-for="concept-request-history-navigation-flag" id="infopanel-for-concept-request-history-navigation-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-request-history-navigation-flag" style="display:none">Info about the 'history-navigation flag' definition.</span><b><a href="#concept-request-history-navigation-flag">#concept-request-history-navigation-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-history-navigation-flag">5.4. Request class</a> <a href="#ref-for-concept-request-history-navigation-flag①">(2)</a> <a href="#ref-for-concept-request-history-navigation-flag②">(3)</a> <a href="#ref-for-concept-request-history-navigation-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-tainted-origin">
-   <b><a href="#concept-request-tainted-origin">#concept-request-tainted-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-tainted-origin" class="dfn-panel" data-for="concept-request-tainted-origin" id="infopanel-for-concept-request-tainted-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-request-tainted-origin" style="display:none">Info about the 'tainted origin flag' definition.</span><b><a href="#concept-request-tainted-origin">#concept-request-tainted-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-tainted-origin">2.2.5. Requests</a> <a href="#ref-for-concept-request-tainted-origin①">(2)</a>
     <li><a href="#ref-for-concept-request-tainted-origin②">4.4. HTTP-redirect fetch</a>
     <li><a href="#ref-for-concept-request-tainted-origin③">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-request-tainted-origin④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-url-list">
-   <b><a href="#concept-request-url-list">#concept-request-url-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-url-list" class="dfn-panel" data-for="concept-request-url-list" id="infopanel-for-concept-request-url-list" role="dialog">
+   <span id="infopaneltitle-for-concept-request-url-list" style="display:none">Info about the 'URL list' definition.</span><b><a href="#concept-request-url-list">#concept-request-url-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url-list">2.2.5. Requests</a> <a href="#ref-for-concept-request-url-list①">(2)</a> <a href="#ref-for-concept-request-url-list②">(3)</a>
     <li><a href="#ref-for-concept-request-url-list③">4.1. Main fetch</a>
@@ -10294,8 +10294,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-url-list⑤">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-current-url">
-   <b><a href="#concept-request-current-url">#concept-request-current-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-current-url" class="dfn-panel" data-for="concept-request-current-url" id="infopanel-for-concept-request-current-url" role="dialog">
+   <span id="infopaneltitle-for-concept-request-current-url" style="display:none">Info about the 'current URL' definition.</span><b><a href="#concept-request-current-url">#concept-request-current-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-current-url">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-current-url①">2.8. Port blocking</a>
@@ -10313,15 +10313,15 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-current-url③⑤">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-redirect-count">
-   <b><a href="#concept-request-redirect-count">#concept-request-redirect-count</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-redirect-count" class="dfn-panel" data-for="concept-request-redirect-count" id="infopanel-for-concept-request-redirect-count" role="dialog">
+   <span id="infopaneltitle-for-concept-request-redirect-count" style="display:none">Info about the 'redirect count' definition.</span><b><a href="#concept-request-redirect-count">#concept-request-redirect-count</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-redirect-count">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-request-redirect-count①">4.4. HTTP-redirect fetch</a> <a href="#ref-for-concept-request-redirect-count②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-response-tainting">
-   <b><a href="#concept-request-response-tainting">#concept-request-response-tainting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-response-tainting" class="dfn-panel" data-for="concept-request-response-tainting" id="infopanel-for-concept-request-response-tainting" role="dialog">
+   <span id="infopaneltitle-for-concept-request-response-tainting" style="display:none">Info about the 'response tainting' definition.</span><b><a href="#concept-request-response-tainting">#concept-request-response-tainting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-response-tainting">2.2.5. Requests</a> <a href="#ref-for-concept-request-response-tainting①">(2)</a>
     <li><a href="#ref-for-concept-request-response-tainting②">3.1. `Origin` header</a> <a href="#ref-for-concept-request-response-tainting③">(2)</a>
@@ -10333,14 +10333,14 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-request-response-tainting①⑨">4.11. TAO check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-cache-prevent-cache-control">
-   <b><a href="#no-cache-prevent-cache-control">#no-cache-prevent-cache-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-cache-prevent-cache-control" class="dfn-panel" data-for="no-cache-prevent-cache-control" id="infopanel-for-no-cache-prevent-cache-control" role="dialog">
+   <span id="infopaneltitle-for-no-cache-prevent-cache-control" style="display:none">Info about the 'prevent no-cache cache-control header modification flag' definition.</span><b><a href="#no-cache-prevent-cache-control">#no-cache-prevent-cache-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-cache-prevent-cache-control">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-no-cache-prevent-cache-control①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="done-flag">
-   <b><a href="#done-flag">#done-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-done-flag" class="dfn-panel" data-for="done-flag" id="infopanel-for-done-flag" role="dialog">
+   <span id="infopaneltitle-for-done-flag" style="display:none">Info about the 'done flag' definition.</span><b><a href="#done-flag">#done-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-done-flag">2.2.5. Requests</a>
     <li><a href="#ref-for-done-flag①">2.4. Fetch groups</a>
@@ -10348,8 +10348,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-done-flag③">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timing-allow-failed">
-   <b><a href="#timing-allow-failed">#timing-allow-failed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timing-allow-failed" class="dfn-panel" data-for="timing-allow-failed" id="infopanel-for-timing-allow-failed" role="dialog">
+   <span id="infopaneltitle-for-timing-allow-failed" style="display:none">Info about the 'timing allow failed flag' definition.</span><b><a href="#timing-allow-failed">#timing-allow-failed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timing-allow-failed">2.2.5. Requests</a>
     <li><a href="#ref-for-timing-allow-failed①">2.2.6. Responses</a>
@@ -10358,56 +10358,56 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-timing-allow-failed④">4.11. TAO check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subresource-request">
-   <b><a href="#subresource-request">#subresource-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subresource-request" class="dfn-panel" data-for="subresource-request" id="infopanel-for-subresource-request" role="dialog">
+   <span id="infopaneltitle-for-subresource-request" style="display:none">Info about the 'subresource request' definition.</span><b><a href="#subresource-request">#subresource-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subresource-request">4. Fetching</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigation-request">
-   <b><a href="#navigation-request">#navigation-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigation-request" class="dfn-panel" data-for="navigation-request" id="infopanel-for-navigation-request" role="dialog">
+   <span id="infopaneltitle-for-navigation-request" style="display:none">Info about the 'navigation request' definition.</span><b><a href="#navigation-request">#navigation-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigation-request">2.2.5. Requests</a> <a href="#ref-for-navigation-request①">(2)</a> <a href="#ref-for-navigation-request②">(3)</a>
     <li><a href="#ref-for-navigation-request③">CORS protocol and HTTP caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serializing-a-request-origin">
-   <b><a href="#serializing-a-request-origin">#serializing-a-request-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serializing-a-request-origin" class="dfn-panel" data-for="serializing-a-request-origin" id="infopanel-for-serializing-a-request-origin" role="dialog">
+   <span id="infopaneltitle-for-serializing-a-request-origin" style="display:none">Info about the 'Serializing a request origin' definition.</span><b><a href="#serializing-a-request-origin">#serializing-a-request-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serializing-a-request-origin">2.2.5. Requests</a>
     <li><a href="#ref-for-serializing-a-request-origin①">4.11. TAO check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-serializing-a-request-origin">
-   <b><a href="#byte-serializing-a-request-origin">#byte-serializing-a-request-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-serializing-a-request-origin" class="dfn-panel" data-for="byte-serializing-a-request-origin" id="infopanel-for-byte-serializing-a-request-origin" role="dialog">
+   <span id="infopaneltitle-for-byte-serializing-a-request-origin" style="display:none">Info about the 'Byte-serializing a request origin' definition.</span><b><a href="#byte-serializing-a-request-origin">#byte-serializing-a-request-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-serializing-a-request-origin">3.1. `Origin` header</a>
     <li><a href="#ref-for-byte-serializing-a-request-origin①">4.9. CORS-preflight cache</a> <a href="#ref-for-byte-serializing-a-request-origin②">(2)</a> <a href="#ref-for-byte-serializing-a-request-origin③">(3)</a>
     <li><a href="#ref-for-byte-serializing-a-request-origin④">4.10. CORS check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-clone">
-   <b><a href="#concept-request-clone">#concept-request-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-clone" class="dfn-panel" data-for="concept-request-clone" id="infopanel-for-concept-request-clone" role="dialog">
+   <span id="infopaneltitle-for-concept-request-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#concept-request-clone">#concept-request-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-clone">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-request-clone①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-request-clone②">(2)</a>
     <li><a href="#ref-for-concept-request-clone③">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-add-range-header">
-   <b><a href="#concept-request-add-range-header">#concept-request-add-range-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-add-range-header" class="dfn-panel" data-for="concept-request-add-range-header" id="infopanel-for-concept-request-add-range-header" role="dialog">
+   <span id="infopaneltitle-for-concept-request-add-range-header" style="display:none">Info about the 'add a range header' definition.</span><b><a href="#concept-request-add-range-header">#concept-request-add-range-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-add-range-header">2.2.2. Headers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-response-url-for-reporting">
-   <b><a href="#serialize-a-response-url-for-reporting">#serialize-a-response-url-for-reporting</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-response-url-for-reporting" class="dfn-panel" data-for="serialize-a-response-url-for-reporting" id="infopanel-for-serialize-a-response-url-for-reporting" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-response-url-for-reporting" style="display:none">Info about the 'serialize a response URL for reporting' definition.</span><b><a href="#serialize-a-response-url-for-reporting">#serialize-a-response-url-for-reporting</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-response-url-for-reporting">3.7. `Cross-Origin-Resource-Policy` header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response">
-   <b><a href="#concept-response">#concept-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response" class="dfn-panel" data-for="concept-response" id="infopanel-for-concept-response" role="dialog">
+   <span id="infopaneltitle-for-concept-response" style="display:none">Info about the 'response' definition.</span><b><a href="#concept-response">#concept-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2. Infrastructure</a>
     <li><a href="#ref-for-concept-response①">2.2.5. Requests</a>
@@ -10427,8 +10427,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-response⑥⑦">Atomic HTTP redirect handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-type">
-   <b><a href="#concept-response-type">#concept-response-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-type" class="dfn-panel" data-for="concept-response-type" id="infopanel-for-concept-response-type" role="dialog">
+   <span id="infopaneltitle-for-concept-response-type" style="display:none">Info about the 'type' definition.</span><b><a href="#concept-response-type">#concept-response-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">2.2.6. Responses</a> <a href="#ref-for-concept-response-type①">(2)</a> <a href="#ref-for-concept-response-type②">(3)</a> <a href="#ref-for-concept-response-type③">(4)</a> <a href="#ref-for-concept-response-type④">(5)</a> <a href="#ref-for-concept-response-type⑤">(6)</a>
     <li><a href="#ref-for-concept-response-type⑥">4.1. Main fetch</a>
@@ -10436,16 +10436,16 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-response-type①②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-aborted">
-   <b><a href="#concept-response-aborted">#concept-response-aborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-aborted" class="dfn-panel" data-for="concept-response-aborted" id="infopanel-for-concept-response-aborted" role="dialog">
+   <span id="infopaneltitle-for-concept-response-aborted" style="display:none">Info about the 'aborted flag' definition.</span><b><a href="#concept-response-aborted">#concept-response-aborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-aborted">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-response-aborted①">4.7. HTTP-network fetch</a> <a href="#ref-for-concept-response-aborted②">(2)</a>
     <li><a href="#ref-for-concept-response-aborted③">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-url">
-   <b><a href="#concept-response-url">#concept-response-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-url" class="dfn-panel" data-for="concept-response-url" id="infopanel-for-concept-response-url" role="dialog">
+   <span id="infopaneltitle-for-concept-response-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-response-url">#concept-response-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-response-url①">2.2.6. Responses</a> <a href="#ref-for-concept-response-url②">(2)</a>
@@ -10454,8 +10454,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-response-url⑧">5.5. Response class</a> <a href="#ref-for-concept-response-url⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-url-list">
-   <b><a href="#concept-response-url-list">#concept-response-url-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-url-list" class="dfn-panel" data-for="concept-response-url-list" id="infopanel-for-concept-response-url-list" role="dialog">
+   <span id="infopaneltitle-for-concept-response-url-list" style="display:none">Info about the 'URL list' definition.</span><b><a href="#concept-response-url-list">#concept-response-url-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url-list">2.2.5. Requests</a> <a href="#ref-for-concept-response-url-list①">(2)</a>
     <li><a href="#ref-for-concept-response-url-list②">2.2.6. Responses</a> <a href="#ref-for-concept-response-url-list③">(2)</a> <a href="#ref-for-concept-response-url-list④">(3)</a> <a href="#ref-for-concept-response-url-list⑤">(4)</a> <a href="#ref-for-concept-response-url-list⑥">(5)</a>
@@ -10465,8 +10465,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-response-url-list①③">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-status">
-   <b><a href="#concept-response-status">#concept-response-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-status" class="dfn-panel" data-for="concept-response-status" id="infopanel-for-concept-response-status" role="dialog">
+   <span id="infopaneltitle-for-concept-response-status" style="display:none">Info about the 'status' definition.</span><b><a href="#concept-response-status">#concept-response-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">2.2.6. Responses</a> <a href="#ref-for-concept-response-status①">(2)</a> <a href="#ref-for-concept-response-status②">(3)</a> <a href="#ref-for-concept-response-status③">(4)</a>
     <li><a href="#ref-for-concept-response-status④">3.6. CORB</a> <a href="#ref-for-concept-response-status⑤">(2)</a>
@@ -10481,16 +10481,16 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-request-des
     <li><a href="#ref-for-concept-response-status②⑧">Atomic HTTP redirect handling</a> <a href="#ref-for-concept-response-status②⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-status-message">
-   <b><a href="#concept-response-status-message">#concept-response-status-message</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-status-message" class="dfn-panel" data-for="concept-response-status-message" id="infopanel-for-concept-response-status-message" role="dialog">
+   <span id="infopaneltitle-for-concept-response-status-message" style="display:none">Info about the 'status message' definition.</span><b><a href="#concept-response-status-message">#concept-response-status-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status-message">2.2.6. Responses</a> <a href="#ref-for-concept-response-status-message①">(2)</a> <a href="#ref-for-concept-response-status-message②">(3)</a>
     <li><a href="#ref-for-concept-response-status-message③">4.2. Scheme fetch</a> <a href="#ref-for-concept-response-status-message④">(2)</a> <a href="#ref-for-concept-response-status-message⑤">(3)</a>
     <li><a href="#ref-for-concept-response-status-message⑥">5.5. Response class</a> <a href="#ref-for-concept-response-status-message⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-header-list">
-   <b><a href="#concept-response-header-list">#concept-response-header-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-header-list" class="dfn-panel" data-for="concept-response-header-list" id="infopanel-for-concept-response-header-list" role="dialog">
+   <span id="infopaneltitle-for-concept-response-header-list" style="display:none">Info about the 'header list' definition.</span><b><a href="#concept-response-header-list">#concept-response-header-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">2.2.6. Responses</a> <a href="#ref-for-concept-response-header-list①">(2)</a> <a href="#ref-for-concept-response-header-list②">(3)</a> <a href="#ref-for-concept-response-header-list③">(4)</a> <a href="#ref-for-concept-response-header-list④">(5)</a> <a href="#ref-for-concept-response-header-list⑤">(6)</a> <a href="#ref-for-concept-response-header-list⑥">(7)</a> <a href="#ref-for-concept-response-header-list⑦">(8)</a>
     <li><a href="#ref-for-concept-response-header-list⑧">2.9. Should
@@ -10509,8 +10509,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-response-header-list③②">5.5. Response class</a> <a href="#ref-for-concept-response-header-list③③">(2)</a> <a href="#ref-for-concept-response-header-list③④">(3)</a> <a href="#ref-for-concept-response-header-list③⑤">(4)</a> <a href="#ref-for-concept-response-header-list③⑥">(5)</a> <a href="#ref-for-concept-response-header-list③⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-body">
-   <b><a href="#concept-response-body">#concept-response-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-body" class="dfn-panel" data-for="concept-response-body" id="infopanel-for-concept-response-body" role="dialog">
+   <span id="infopaneltitle-for-concept-response-body" style="display:none">Info about the 'body' definition.</span><b><a href="#concept-response-body">#concept-response-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">2.2.6. Responses</a> <a href="#ref-for-concept-response-body①">(2)</a> <a href="#ref-for-concept-response-body②">(3)</a> <a href="#ref-for-concept-response-body③">(4)</a> <a href="#ref-for-concept-response-body④">(5)</a> <a href="#ref-for-concept-response-body⑤">(6)</a> <a href="#ref-for-concept-response-body⑥">(7)</a> <a href="#ref-for-concept-response-body⑦">(8)</a>
     <li><a href="#ref-for-concept-response-body⑧">4.1. Main fetch</a> <a href="#ref-for-concept-response-body⑨">(2)</a> <a href="#ref-for-concept-response-body①⓪">(3)</a> <a href="#ref-for-concept-response-body①①">(4)</a> <a href="#ref-for-concept-response-body①②">(5)</a> <a href="#ref-for-concept-response-body①③">(6)</a>
@@ -10522,41 +10522,41 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-response-body②④">5.6. Fetch method</a> <a href="#ref-for-concept-response-body②⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-cache-state">
-   <b><a href="#concept-response-cache-state">#concept-response-cache-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-cache-state" class="dfn-panel" data-for="concept-response-cache-state" id="infopanel-for-concept-response-cache-state" role="dialog">
+   <span id="infopaneltitle-for-concept-response-cache-state" style="display:none">Info about the 'cache state' definition.</span><b><a href="#concept-response-cache-state">#concept-response-cache-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-cache-state">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-response-cache-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-csp-list">
-   <b><a href="#concept-response-csp-list">#concept-response-csp-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-csp-list" class="dfn-panel" data-for="concept-response-csp-list" id="infopanel-for-concept-response-csp-list" role="dialog">
+   <span id="infopaneltitle-for-concept-response-csp-list" style="display:none">Info about the 'CSP list' definition.</span><b><a href="#concept-response-csp-list">#concept-response-csp-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-csp-list">4.1. Main fetch</a> <a href="#ref-for-concept-response-csp-list①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-cors-exposed-header-name-list">
-   <b><a href="#concept-response-cors-exposed-header-name-list">#concept-response-cors-exposed-header-name-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-cors-exposed-header-name-list" class="dfn-panel" data-for="concept-response-cors-exposed-header-name-list" id="infopanel-for-concept-response-cors-exposed-header-name-list" role="dialog">
+   <span id="infopaneltitle-for-concept-response-cors-exposed-header-name-list" style="display:none">Info about the 'CORS-exposed header-name list' definition.</span><b><a href="#concept-response-cors-exposed-header-name-list">#concept-response-cors-exposed-header-name-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-cors-exposed-header-name-list">2.2.2. Headers</a>
     <li><a href="#ref-for-concept-response-cors-exposed-header-name-list①">2.2.6. Responses</a> <a href="#ref-for-concept-response-cors-exposed-header-name-list②">(2)</a>
     <li><a href="#ref-for-concept-response-cors-exposed-header-name-list③">4.1. Main fetch</a> <a href="#ref-for-concept-response-cors-exposed-header-name-list④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-range-requested-flag">
-   <b><a href="#concept-response-range-requested-flag">#concept-response-range-requested-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-range-requested-flag" class="dfn-panel" data-for="concept-response-range-requested-flag" id="infopanel-for-concept-response-range-requested-flag" role="dialog">
+   <span id="infopaneltitle-for-concept-response-range-requested-flag" style="display:none">Info about the 'range-requested flag' definition.</span><b><a href="#concept-response-range-requested-flag">#concept-response-range-requested-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-range-requested-flag">4.1. Main fetch</a>
     <li><a href="#ref-for-concept-response-range-requested-flag①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-timing-allow-passed">
-   <b><a href="#concept-response-timing-allow-passed">#concept-response-timing-allow-passed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-timing-allow-passed" class="dfn-panel" data-for="concept-response-timing-allow-passed" id="infopanel-for-concept-response-timing-allow-passed" role="dialog">
+   <span id="infopaneltitle-for-concept-response-timing-allow-passed" style="display:none">Info about the 'timing allow passed flag' definition.</span><b><a href="#concept-response-timing-allow-passed">#concept-response-timing-allow-passed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-timing-allow-passed">4.1. Main fetch</a> <a href="#ref-for-concept-response-timing-allow-passed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-timing-info">
-   <b><a href="#concept-response-timing-info">#concept-response-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-timing-info" class="dfn-panel" data-for="concept-response-timing-info" id="infopanel-for-concept-response-timing-info" role="dialog">
+   <span id="infopaneltitle-for-concept-response-timing-info" style="display:none">Info about the 'timing info' definition.</span><b><a href="#concept-response-timing-info">#concept-response-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-timing-info">2. Infrastructure</a>
     <li><a href="#ref-for-concept-response-timing-info①">4.1. Main fetch</a> <a href="#ref-for-concept-response-timing-info②">(2)</a>
@@ -10564,16 +10564,16 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-response-timing-info④">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-aborted-network-error">
-   <b><a href="#concept-aborted-network-error">#concept-aborted-network-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-aborted-network-error" class="dfn-panel" data-for="concept-aborted-network-error" id="infopanel-for-concept-aborted-network-error" role="dialog">
+   <span id="infopaneltitle-for-concept-aborted-network-error" style="display:none">Info about the 'aborted network error' definition.</span><b><a href="#concept-aborted-network-error">#concept-aborted-network-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-aborted-network-error">4.2. Scheme fetch</a>
     <li><a href="#ref-for-concept-aborted-network-error①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-aborted-network-error②">(2)</a> <a href="#ref-for-concept-aborted-network-error③">(3)</a> <a href="#ref-for-concept-aborted-network-error④">(4)</a>
     <li><a href="#ref-for-concept-aborted-network-error⑤">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-network-error">
-   <b><a href="#concept-network-error">#concept-network-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-network-error" class="dfn-panel" data-for="concept-network-error" id="infopanel-for-concept-network-error" role="dialog">
+   <span id="infopaneltitle-for-concept-network-error" style="display:none">Info about the 'network error' definition.</span><b><a href="#concept-network-error">#concept-network-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">2.2.5. Requests</a> <a href="#ref-for-concept-network-error①">(2)</a> <a href="#ref-for-concept-network-error②">(3)</a> <a href="#ref-for-concept-network-error③">(4)</a>
     <li><a href="#ref-for-concept-network-error④">2.2.6. Responses</a> <a href="#ref-for-concept-network-error⑤">(2)</a> <a href="#ref-for-concept-network-error⑥">(3)</a>
@@ -10589,8 +10589,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-network-error⑥⓪">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-filtered-response">
-   <b><a href="#concept-filtered-response">#concept-filtered-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-filtered-response" class="dfn-panel" data-for="concept-filtered-response" id="infopanel-for-concept-filtered-response" role="dialog">
+   <span id="infopaneltitle-for-concept-filtered-response" style="display:none">Info about the 'filtered response' definition.</span><b><a href="#concept-filtered-response">#concept-filtered-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response">2.2.6. Responses</a> <a href="#ref-for-concept-filtered-response①">(2)</a> <a href="#ref-for-concept-filtered-response②">(3)</a> <a href="#ref-for-concept-filtered-response③">(4)</a> <a href="#ref-for-concept-filtered-response④">(5)</a> <a href="#ref-for-concept-filtered-response⑤">(6)</a> <a href="#ref-for-concept-filtered-response⑥">(7)</a> <a href="#ref-for-concept-filtered-response⑦">(8)</a>
     <li><a href="#ref-for-concept-filtered-response⑧">4.1. Main fetch</a> <a href="#ref-for-concept-filtered-response⑨">(2)</a> <a href="#ref-for-concept-filtered-response①⓪">(3)</a>
@@ -10598,8 +10598,8 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-filtered-response①②">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-internal-response">
-   <b><a href="#concept-internal-response">#concept-internal-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-internal-response" class="dfn-panel" data-for="concept-internal-response" id="infopanel-for-concept-internal-response" role="dialog">
+   <span id="infopaneltitle-for-concept-internal-response" style="display:none">Info about the 'internal response' definition.</span><b><a href="#concept-internal-response">#concept-internal-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-internal-response">2.2.6. Responses</a> <a href="#ref-for-concept-internal-response①">(2)</a> <a href="#ref-for-concept-internal-response②">(3)</a> <a href="#ref-for-concept-internal-response③">(4)</a> <a href="#ref-for-concept-internal-response④">(5)</a> <a href="#ref-for-concept-internal-response⑤">(6)</a> <a href="#ref-for-concept-internal-response⑥">(7)</a>
     <li><a href="#ref-for-concept-internal-response⑦">3.7. `Cross-Origin-Resource-Policy` header</a> <a href="#ref-for-concept-internal-response⑧">(2)</a>
@@ -10609,21 +10609,21 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-internal-response①④">Atomic HTTP redirect handling</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-filtered-response-basic">
-   <b><a href="#concept-filtered-response-basic">#concept-filtered-response-basic</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-filtered-response-basic" class="dfn-panel" data-for="concept-filtered-response-basic" id="infopanel-for-concept-filtered-response-basic" role="dialog">
+   <span id="infopaneltitle-for-concept-filtered-response-basic" style="display:none">Info about the 'basic filtered response' definition.</span><b><a href="#concept-filtered-response-basic">#concept-filtered-response-basic</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-basic">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-filtered-response-cors">
-   <b><a href="#concept-filtered-response-cors">#concept-filtered-response-cors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-filtered-response-cors" class="dfn-panel" data-for="concept-filtered-response-cors" id="infopanel-for-concept-filtered-response-cors" role="dialog">
+   <span id="infopaneltitle-for-concept-filtered-response-cors" style="display:none">Info about the 'CORS filtered response' definition.</span><b><a href="#concept-filtered-response-cors">#concept-filtered-response-cors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-cors">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-filtered-response-cors①">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-filtered-response-opaque">
-   <b><a href="#concept-filtered-response-opaque">#concept-filtered-response-opaque</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-filtered-response-opaque" class="dfn-panel" data-for="concept-filtered-response-opaque" id="infopanel-for-concept-filtered-response-opaque" role="dialog">
+   <span id="infopaneltitle-for-concept-filtered-response-opaque" style="display:none">Info about the 'opaque filtered response' definition.</span><b><a href="#concept-filtered-response-opaque">#concept-filtered-response-opaque</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-filtered-response-opaque①">2.2.6. Responses</a>
@@ -10631,231 +10631,232 @@ response to request be blocked due to nosniff?</a> <a href="#ref-for-concept-res
     <li><a href="#ref-for-concept-filtered-response-opaque④">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-filtered-response-opaque-redirect">
-   <b><a href="#concept-filtered-response-opaque-redirect">#concept-filtered-response-opaque-redirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-filtered-response-opaque-redirect" class="dfn-panel" data-for="concept-filtered-response-opaque-redirect" id="infopanel-for-concept-filtered-response-opaque-redirect" role="dialog">
+   <span id="infopaneltitle-for-concept-filtered-response-opaque-redirect" style="display:none">Info about the 'opaque-redirect filtered response' definition.</span><b><a href="#concept-filtered-response-opaque-redirect">#concept-filtered-response-opaque-redirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-filtered-response-opaque-redirect">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-filtered-response-opaque-redirect①">2.2.6. Responses</a> <a href="#ref-for-concept-filtered-response-opaque-redirect②">(2)</a>
     <li><a href="#ref-for-concept-filtered-response-opaque-redirect③">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-clone">
-   <b><a href="#concept-response-clone">#concept-response-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-clone" class="dfn-panel" data-for="concept-response-clone" id="infopanel-for-concept-response-clone" role="dialog">
+   <span id="infopaneltitle-for-concept-response-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#concept-response-clone">#concept-response-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-clone">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-response-clone①">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fresh-response">
-   <b><a href="#concept-fresh-response">#concept-fresh-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fresh-response" class="dfn-panel" data-for="concept-fresh-response" id="infopanel-for-concept-fresh-response" role="dialog">
+   <span id="infopaneltitle-for-concept-fresh-response" style="display:none">Info about the 'fresh response' definition.</span><b><a href="#concept-fresh-response">#concept-fresh-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fresh-response">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-fresh-response①">2.2.6. Responses</a> <a href="#ref-for-concept-fresh-response②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-stale-while-revalidate-response">
-   <b><a href="#concept-stale-while-revalidate-response">#concept-stale-while-revalidate-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stale-while-revalidate-response" class="dfn-panel" data-for="concept-stale-while-revalidate-response" id="infopanel-for-concept-stale-while-revalidate-response" role="dialog">
+   <span id="infopaneltitle-for-concept-stale-while-revalidate-response" style="display:none">Info about the 'stale-while-revalidate response' definition.</span><b><a href="#concept-stale-while-revalidate-response">#concept-stale-while-revalidate-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stale-while-revalidate-response">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-stale-while-revalidate-response①">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-stale-while-revalidate-response②">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-stale-response">
-   <b><a href="#concept-stale-response">#concept-stale-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-stale-response" class="dfn-panel" data-for="concept-stale-response" id="infopanel-for-concept-stale-response" role="dialog">
+   <span id="infopaneltitle-for-concept-stale-response" style="display:none">Info about the 'stale response' definition.</span><b><a href="#concept-stale-response">#concept-stale-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stale-response">2.2.5. Requests</a>
     <li><a href="#ref-for-concept-stale-response①">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-location-url">
-   <b><a href="#concept-response-location-url">#concept-response-location-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-location-url" class="dfn-panel" data-for="concept-response-location-url" id="infopanel-for-concept-response-location-url" role="dialog">
+   <span id="infopaneltitle-for-concept-response-location-url" style="display:none">Info about the 'location URL' definition.</span><b><a href="#concept-response-location-url">#concept-response-location-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-location-url">2.2.6. Responses</a>
     <li><a href="#ref-for-concept-response-location-url①">4.4. HTTP-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-potential-destination">
-   <b><a href="#concept-potential-destination">#concept-potential-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-potential-destination" class="dfn-panel" data-for="concept-potential-destination" id="infopanel-for-concept-potential-destination" role="dialog">
+   <span id="infopaneltitle-for-concept-potential-destination" style="display:none">Info about the 'potential destination' definition.</span><b><a href="#concept-potential-destination">#concept-potential-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-potential-destination">2.2.7. Miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authentication-entry">
-   <b><a href="#authentication-entry">#authentication-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authentication-entry" class="dfn-panel" data-for="authentication-entry" id="infopanel-for-authentication-entry" role="dialog">
+   <span id="infopaneltitle-for-authentication-entry" style="display:none">Info about the 'authentication entry' definition.</span><b><a href="#authentication-entry">#authentication-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authentication-entry">2. Infrastructure</a>
     <li><a href="#ref-for-authentication-entry①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-authentication-entry②">(2)</a> <a href="#ref-for-authentication-entry③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="proxy-authentication-entry">
-   <b><a href="#proxy-authentication-entry">#proxy-authentication-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-proxy-authentication-entry" class="dfn-panel" data-for="proxy-authentication-entry" id="infopanel-for-proxy-authentication-entry" role="dialog">
+   <span id="infopaneltitle-for-proxy-authentication-entry" style="display:none">Info about the 'proxy-authentication entry' definition.</span><b><a href="#proxy-authentication-entry">#proxy-authentication-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-proxy-authentication-entry">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-proxy-authentication-entry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-group">
-   <b><a href="#concept-fetch-group">#concept-fetch-group</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-group" class="dfn-panel" data-for="concept-fetch-group" id="infopanel-for-concept-fetch-group" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-group" style="display:none">Info about the 'fetch group' definition.</span><b><a href="#concept-fetch-group">#concept-fetch-group</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-group">2.4. Fetch groups</a> <a href="#ref-for-concept-fetch-group①">(2)</a>
     <li><a href="#ref-for-concept-fetch-group②">4. Fetching</a>
     <li><a href="#ref-for-concept-fetch-group③">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-record">
-   <b><a href="#concept-fetch-record">#concept-fetch-record</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-record" class="dfn-panel" data-for="concept-fetch-record" id="infopanel-for-concept-fetch-record" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-record" style="display:none">Info about the 'fetch records' definition.</span><b><a href="#concept-fetch-record">#concept-fetch-record</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-record">2.4. Fetch groups</a> <a href="#ref-for-concept-fetch-record①">(2)</a> <a href="#ref-for-concept-fetch-record②">(3)</a> <a href="#ref-for-concept-fetch-record③">(4)</a>
     <li><a href="#ref-for-concept-fetch-record④">4. Fetching</a> <a href="#ref-for-concept-fetch-record⑤">(2)</a>
     <li><a href="#ref-for-concept-fetch-record⑥">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-record-request">
-   <b><a href="#concept-fetch-record-request">#concept-fetch-record-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-record-request" class="dfn-panel" data-for="concept-fetch-record-request" id="infopanel-for-concept-fetch-record-request" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-record-request" style="display:none">Info about the 'request' definition.</span><b><a href="#concept-fetch-record-request">#concept-fetch-record-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-record-request">2.4. Fetch groups</a>
     <li><a href="#ref-for-concept-fetch-record-request①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-fetch-record-request②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-record-fetch">
-   <b><a href="#concept-fetch-record-fetch">#concept-fetch-record-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-record-fetch" class="dfn-panel" data-for="concept-fetch-record-fetch" id="infopanel-for-concept-fetch-record-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-record-fetch" style="display:none">Info about the 'fetch' definition.</span><b><a href="#concept-fetch-record-fetch">#concept-fetch-record-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-record-fetch">2.4. Fetch groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-connection-pool">
-   <b><a href="#concept-connection-pool">#concept-connection-pool</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-connection-pool" class="dfn-panel" data-for="concept-connection-pool" id="infopanel-for-concept-connection-pool" role="dialog">
+   <span id="infopaneltitle-for-concept-connection-pool" style="display:none">Info about the 'connection pool' definition.</span><b><a href="#concept-connection-pool">#concept-connection-pool</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection-pool">2.5. Connections</a> <a href="#ref-for-concept-connection-pool①">(2)</a> <a href="#ref-for-concept-connection-pool②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-connection">
-   <b><a href="#concept-connection">#concept-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-connection" class="dfn-panel" data-for="concept-connection" id="infopanel-for-concept-connection" role="dialog">
+   <span id="infopaneltitle-for-concept-connection" style="display:none">Info about the 'connections' definition.</span><b><a href="#concept-connection">#concept-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection">2.5. Connections</a> <a href="#ref-for-concept-connection①">(2)</a> <a href="#ref-for-concept-connection②">(3)</a> <a href="#ref-for-concept-connection③">(4)</a> <a href="#ref-for-concept-connection④">(5)</a> <a href="#ref-for-concept-connection⑤">(6)</a> <a href="#ref-for-concept-connection⑥">(7)</a> <a href="#ref-for-concept-connection⑦">(8)</a> <a href="#ref-for-concept-connection⑧">(9)</a> <a href="#ref-for-concept-connection⑨">(10)</a>
     <li><a href="#ref-for-concept-connection①⓪">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-connection①①">6.1. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-connection-timing-info">
-   <b><a href="#concept-connection-timing-info">#concept-connection-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-connection-timing-info" class="dfn-panel" data-for="concept-connection-timing-info" id="infopanel-for-concept-connection-timing-info" role="dialog">
+   <span id="infopaneltitle-for-concept-connection-timing-info" style="display:none">Info about the 'timing info' definition.</span><b><a href="#concept-connection-timing-info">#concept-connection-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection-timing-info">2.5. Connections</a>
     <li><a href="#ref-for-concept-connection-timing-info①">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info">
-   <b><a href="#connection-timing-info">#connection-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info" class="dfn-panel" data-for="connection-timing-info" id="infopanel-for-connection-timing-info" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info" style="display:none">Info about the 'connection timing info' definition.</span><b><a href="#connection-timing-info">#connection-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info">2. Infrastructure</a> <a href="#ref-for-connection-timing-info①">(2)</a>
     <li><a href="#ref-for-connection-timing-info②">2.5. Connections</a> <a href="#ref-for-connection-timing-info③">(2)</a> <a href="#ref-for-connection-timing-info④">(3)</a> <a href="#ref-for-connection-timing-info⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-domain-lookup-start-time">
-   <b><a href="#connection-timing-info-domain-lookup-start-time">#connection-timing-info-domain-lookup-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-domain-lookup-start-time" class="dfn-panel" data-for="connection-timing-info-domain-lookup-start-time" id="infopanel-for-connection-timing-info-domain-lookup-start-time" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-domain-lookup-start-time" style="display:none">Info about the 'domain lookup start time' definition.</span><b><a href="#connection-timing-info-domain-lookup-start-time">#connection-timing-info-domain-lookup-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-domain-lookup-start-time">2.5. Connections</a> <a href="#ref-for-connection-timing-info-domain-lookup-start-time①">(2)</a> <a href="#ref-for-connection-timing-info-domain-lookup-start-time②">(3)</a> <a href="#ref-for-connection-timing-info-domain-lookup-start-time③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-domain-lookup-end-time">
-   <b><a href="#connection-timing-info-domain-lookup-end-time">#connection-timing-info-domain-lookup-end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-domain-lookup-end-time" class="dfn-panel" data-for="connection-timing-info-domain-lookup-end-time" id="infopanel-for-connection-timing-info-domain-lookup-end-time" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-domain-lookup-end-time" style="display:none">Info about the 'domain lookup end time' definition.</span><b><a href="#connection-timing-info-domain-lookup-end-time">#connection-timing-info-domain-lookup-end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-domain-lookup-end-time">2.5. Connections</a> <a href="#ref-for-connection-timing-info-domain-lookup-end-time①">(2)</a> <a href="#ref-for-connection-timing-info-domain-lookup-end-time②">(3)</a> <a href="#ref-for-connection-timing-info-domain-lookup-end-time③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-connection-start-time">
-   <b><a href="#connection-timing-info-connection-start-time">#connection-timing-info-connection-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-connection-start-time" class="dfn-panel" data-for="connection-timing-info-connection-start-time" id="infopanel-for-connection-timing-info-connection-start-time" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-connection-start-time" style="display:none">Info about the 'connection start time' definition.</span><b><a href="#connection-timing-info-connection-start-time">#connection-timing-info-connection-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-connection-start-time">2.5. Connections</a> <a href="#ref-for-connection-timing-info-connection-start-time①">(2)</a> <a href="#ref-for-connection-timing-info-connection-start-time②">(3)</a> <a href="#ref-for-connection-timing-info-connection-start-time③">(4)</a> <a href="#ref-for-connection-timing-info-connection-start-time④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-connection-end-time">
-   <b><a href="#connection-timing-info-connection-end-time">#connection-timing-info-connection-end-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-connection-end-time" class="dfn-panel" data-for="connection-timing-info-connection-end-time" id="infopanel-for-connection-timing-info-connection-end-time" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-connection-end-time" style="display:none">Info about the 'connection end time' definition.</span><b><a href="#connection-timing-info-connection-end-time">#connection-timing-info-connection-end-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-connection-end-time">2.5. Connections</a> <a href="#ref-for-connection-timing-info-connection-end-time①">(2)</a> <a href="#ref-for-connection-timing-info-connection-end-time②">(3)</a> <a href="#ref-for-connection-timing-info-connection-end-time③">(4)</a> <a href="#ref-for-connection-timing-info-connection-end-time④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-secure-connection-start-time">
-   <b><a href="#connection-timing-info-secure-connection-start-time">#connection-timing-info-secure-connection-start-time</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-secure-connection-start-time" class="dfn-panel" data-for="connection-timing-info-secure-connection-start-time" id="infopanel-for-connection-timing-info-secure-connection-start-time" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-secure-connection-start-time" style="display:none">Info about the 'secure connection start time' definition.</span><b><a href="#connection-timing-info-secure-connection-start-time">#connection-timing-info-secure-connection-start-time</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-secure-connection-start-time">2.5. Connections</a> <a href="#ref-for-connection-timing-info-secure-connection-start-time①">(2)</a> <a href="#ref-for-connection-timing-info-secure-connection-start-time②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-timing-info-alpn-negotiated-protocol">
-   <b><a href="#connection-timing-info-alpn-negotiated-protocol">#connection-timing-info-alpn-negotiated-protocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-connection-timing-info-alpn-negotiated-protocol" class="dfn-panel" data-for="connection-timing-info-alpn-negotiated-protocol" id="infopanel-for-connection-timing-info-alpn-negotiated-protocol" role="dialog">
+   <span id="infopaneltitle-for-connection-timing-info-alpn-negotiated-protocol" style="display:none">Info about the 'ALPN negotiated protocol' definition.</span><b><a href="#connection-timing-info-alpn-negotiated-protocol">#connection-timing-info-alpn-negotiated-protocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connection-timing-info-alpn-negotiated-protocol">2.5. Connections</a> <a href="#ref-for-connection-timing-info-alpn-negotiated-protocol①">(2)</a> <a href="#ref-for-connection-timing-info-alpn-negotiated-protocol②">(3)</a> <a href="#ref-for-connection-timing-info-alpn-negotiated-protocol③">(4)</a> <a href="#ref-for-connection-timing-info-alpn-negotiated-protocol④">(5)</a> <a href="#ref-for-connection-timing-info-alpn-negotiated-protocol⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="clamp-and-coarsen-connection-timing-info">
-   <b><a href="#clamp-and-coarsen-connection-timing-info">#clamp-and-coarsen-connection-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-clamp-and-coarsen-connection-timing-info" class="dfn-panel" data-for="clamp-and-coarsen-connection-timing-info" id="infopanel-for-clamp-and-coarsen-connection-timing-info" role="dialog">
+   <span id="infopaneltitle-for-clamp-and-coarsen-connection-timing-info" style="display:none">Info about the 'clamp and coarsen connection timing info' definition.</span><b><a href="#clamp-and-coarsen-connection-timing-info">#clamp-and-coarsen-connection-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-clamp-and-coarsen-connection-timing-info">2.5. Connections</a>
     <li><a href="#ref-for-clamp-and-coarsen-connection-timing-info①">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-connection-obtain">
-   <b><a href="#concept-connection-obtain">#concept-connection-obtain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-connection-obtain" class="dfn-panel" data-for="concept-connection-obtain" id="infopanel-for-concept-connection-obtain" role="dialog">
+   <span id="infopaneltitle-for-concept-connection-obtain" style="display:none">Info about the 'obtain a connection' definition.</span><b><a href="#concept-connection-obtain">#concept-connection-obtain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-connection-obtain">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="record-connection-timing-info">
-   <b><a href="#record-connection-timing-info">#record-connection-timing-info</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-record-connection-timing-info" class="dfn-panel" data-for="record-connection-timing-info" id="infopanel-for-record-connection-timing-info" role="dialog">
+   <span id="infopaneltitle-for-record-connection-timing-info" style="display:none">Info about the 'record connection timing info' definition.</span><b><a href="#record-connection-timing-info">#record-connection-timing-info</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-record-connection-timing-info">2.5. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="network-partition-key">
-   <b><a href="#network-partition-key">#network-partition-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-network-partition-key" class="dfn-panel" data-for="network-partition-key" id="infopanel-for-network-partition-key" role="dialog">
+   <span id="infopaneltitle-for-network-partition-key" style="display:none">Info about the 'network partition key' definition.</span><b><a href="#network-partition-key">#network-partition-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-network-partition-key">2.5. Connections</a>
     <li><a href="#ref-for-network-partition-key①">4.9. CORS-preflight cache</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-network-partition-key">
-   <b><a href="#determine-the-network-partition-key">#determine-the-network-partition-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-network-partition-key" class="dfn-panel" data-for="determine-the-network-partition-key" id="infopanel-for-determine-the-network-partition-key" role="dialog">
+   <span id="infopaneltitle-for-determine-the-network-partition-key" style="display:none">Info about the 'determine the network partition key' definition.</span><b><a href="#determine-the-network-partition-key">#determine-the-network-partition-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-network-partition-key">2.6. Network partition keys</a> <a href="#ref-for-determine-the-network-partition-key①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-determine-the-network-partition-key">
-   <b><a href="#request-determine-the-network-partition-key">#request-determine-the-network-partition-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-determine-the-network-partition-key" class="dfn-panel" data-for="request-determine-the-network-partition-key" id="infopanel-for-request-determine-the-network-partition-key" role="dialog">
+   <span id="infopaneltitle-for-request-determine-the-network-partition-key" style="display:none">Info about the 'determine the network partition key' definition.</span><b><a href="#request-determine-the-network-partition-key">#request-determine-the-network-partition-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-determine-the-network-partition-key">2.7. HTTP cache partitions</a>
     <li><a href="#ref-for-request-determine-the-network-partition-key①">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-request-determine-the-network-partition-key②">4.9. CORS-preflight cache</a> <a href="#ref-for-request-determine-the-network-partition-key③">(2)</a> <a href="#ref-for-request-determine-the-network-partition-key④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-the-http-cache-partition">
-   <b><a href="#determine-the-http-cache-partition">#determine-the-http-cache-partition</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-the-http-cache-partition" class="dfn-panel" data-for="determine-the-http-cache-partition" id="infopanel-for-determine-the-http-cache-partition" role="dialog">
+   <span id="infopaneltitle-for-determine-the-http-cache-partition" style="display:none">Info about the 'determine the HTTP cache partition' definition.</span><b><a href="#determine-the-http-cache-partition">#determine-the-http-cache-partition</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-the-http-cache-partition">4.6. HTTP-network-or-cache fetch</a>
     <li><a href="#ref-for-determine-the-http-cache-partition①">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="block-bad-port">
-   <b><a href="#block-bad-port">#block-bad-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-block-bad-port" class="dfn-panel" data-for="block-bad-port" id="infopanel-for-block-bad-port" role="dialog">
+   <span id="infopaneltitle-for-block-bad-port" style="display:none">Info about the 'should be blocked due to a bad port' definition.</span><b><a href="#block-bad-port">#block-bad-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-bad-port">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bad-port">
-   <b><a href="#bad-port">#bad-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bad-port" class="dfn-panel" data-for="bad-port" id="infopanel-for-bad-port" role="dialog">
+   <span id="infopaneltitle-for-bad-port" style="display:none">Info about the 'bad port' definition.</span><b><a href="#bad-port">#bad-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bad-port">2.8. Port blocking</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-mime-type?">
-   <b><a href="#should-response-to-request-be-blocked-due-to-mime-type?">#should-response-to-request-be-blocked-due-to-mime-type?</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-response-to-request-be-blocked-due-to-mime-type?" class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-mime-type?" id="infopanel-for-should-response-to-request-be-blocked-due-to-mime-type?" role="dialog">
+   <span id="infopaneltitle-for-should-response-to-request-be-blocked-due-to-mime-type?" style="display:none">Info about the '2.9. Should
+response to request be blocked due to its MIME type?' definition.</span><b><a href="#should-response-to-request-be-blocked-due-to-mime-type?">#should-response-to-request-be-blocked-due-to-mime-type?</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-response-to-request-be-blocked-due-to-mime-type?">2.9. Should
 response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-should-response-to-request-be-blocked-due-to-mime-type?">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-origin">
-   <b><a href="#http-origin">#http-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-origin" class="dfn-panel" data-for="http-origin" id="infopanel-for-http-origin" role="dialog">
+   <span id="infopaneltitle-for-http-origin" style="display:none">Info about the 'Origin' definition.</span><b><a href="#http-origin">#http-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-origin">Goals</a>
     <li><a href="#ref-for-http-origin①">2.2.2. Headers</a>
@@ -10865,14 +10866,14 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-http-origin⑥">3.2.6. Examples</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="append-a-request-origin-header">
-   <b><a href="#append-a-request-origin-header">#append-a-request-origin-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-append-a-request-origin-header" class="dfn-panel" data-for="append-a-request-origin-header" id="infopanel-for-append-a-request-origin-header" role="dialog">
+   <span id="infopaneltitle-for-append-a-request-origin-header" style="display:none">Info about the 'append a request `Origin` header' definition.</span><b><a href="#append-a-request-origin-header">#append-a-request-origin-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-append-a-request-origin-header">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-protocol">
-   <b><a href="#cors-protocol">#cors-protocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-protocol" class="dfn-panel" data-for="cors-protocol" id="infopanel-for-cors-protocol" role="dialog">
+   <span id="infopaneltitle-for-cors-protocol" style="display:none">Info about the 'CORS protocol' definition.</span><b><a href="#cors-protocol">#cors-protocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-protocol">2.2.5. Requests</a> <a href="#ref-for-cors-protocol①">(2)</a>
     <li><a href="#ref-for-cors-protocol②">3.1. `Origin` header</a>
@@ -10890,8 +10891,8 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-cors-protocol②②">CORS protocol and HTTP caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-request">
-   <b><a href="#cors-request">#cors-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-request" class="dfn-panel" data-for="cors-request" id="infopanel-for-cors-request" role="dialog">
+   <span id="infopaneltitle-for-cors-request" style="display:none">Info about the 'CORS request' definition.</span><b><a href="#cors-request">#cors-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-request">2.2.5. Requests</a>
     <li><a href="#ref-for-cors-request①">3.2.2. HTTP requests</a> <a href="#ref-for-cors-request②">(2)</a> <a href="#ref-for-cors-request③">(3)</a>
@@ -10899,8 +10900,8 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-cors-request⑧">CORS protocol and HTTP caches</a> <a href="#ref-for-cors-request⑨">(2)</a> <a href="#ref-for-cors-request①⓪">(3)</a> <a href="#ref-for-cors-request①①">(4)</a> <a href="#ref-for-cors-request①②">(5)</a> <a href="#ref-for-cors-request①③">(6)</a> <a href="#ref-for-cors-request①④">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-preflight-request">
-   <b><a href="#cors-preflight-request">#cors-preflight-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-preflight-request" class="dfn-panel" data-for="cors-preflight-request" id="infopanel-for-cors-preflight-request" role="dialog">
+   <span id="infopaneltitle-for-cors-preflight-request" style="display:none">Info about the 'CORS-preflight request' definition.</span><b><a href="#cors-preflight-request">#cors-preflight-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-preflight-request">2.2.5. Requests</a>
     <li><a href="#ref-for-cors-preflight-request①">3.2.1. General</a>
@@ -10909,22 +10910,22 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-cors-preflight-request⑨">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-request-method">
-   <b><a href="#http-access-control-request-method">#http-access-control-request-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-request-method" class="dfn-panel" data-for="http-access-control-request-method" id="infopanel-for-http-access-control-request-method" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-request-method" style="display:none">Info about the 'Access-Control-Request-Method' definition.</span><b><a href="#http-access-control-request-method">#http-access-control-request-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-request-method">2.2.2. Headers</a>
     <li><a href="#ref-for-http-access-control-request-method①">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-request-headers">
-   <b><a href="#http-access-control-request-headers">#http-access-control-request-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-request-headers" class="dfn-panel" data-for="http-access-control-request-headers" id="infopanel-for-http-access-control-request-headers" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-request-headers" style="display:none">Info about the 'Access-Control-Request-Headers' definition.</span><b><a href="#http-access-control-request-headers">#http-access-control-request-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-request-headers">2.2.2. Headers</a>
     <li><a href="#ref-for-http-access-control-request-headers①">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-allow-origin">
-   <b><a href="#http-access-control-allow-origin">#http-access-control-allow-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-allow-origin" class="dfn-panel" data-for="http-access-control-allow-origin" id="infopanel-for-http-access-control-allow-origin" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-allow-origin" style="display:none">Info about the 'Access-Control-Allow-Origin' definition.</span><b><a href="#http-access-control-allow-origin">#http-access-control-allow-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-allow-origin">3.2.5. CORS protocol and credentials</a> <a href="#ref-for-http-access-control-allow-origin①">(2)</a> <a href="#ref-for-http-access-control-allow-origin②">(3)</a>
     <li><a href="#ref-for-http-access-control-allow-origin③">3.2.6. Examples</a> <a href="#ref-for-http-access-control-allow-origin④">(2)</a> <a href="#ref-for-http-access-control-allow-origin⑤">(3)</a>
@@ -10932,38 +10933,38 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-http-access-control-allow-origin⑦">CORS protocol and HTTP caches</a> <a href="#ref-for-http-access-control-allow-origin⑧">(2)</a> <a href="#ref-for-http-access-control-allow-origin⑨">(3)</a> <a href="#ref-for-http-access-control-allow-origin①⓪">(4)</a> <a href="#ref-for-http-access-control-allow-origin①①">(5)</a> <a href="#ref-for-http-access-control-allow-origin①②">(6)</a> <a href="#ref-for-http-access-control-allow-origin①③">(7)</a> <a href="#ref-for-http-access-control-allow-origin①④">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-allow-credentials">
-   <b><a href="#http-access-control-allow-credentials">#http-access-control-allow-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-allow-credentials" class="dfn-panel" data-for="http-access-control-allow-credentials" id="infopanel-for-http-access-control-allow-credentials" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-allow-credentials" style="display:none">Info about the 'Access-Control-Allow-Credentials' definition.</span><b><a href="#http-access-control-allow-credentials">#http-access-control-allow-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-allow-credentials">3.2.5. CORS protocol and credentials</a> <a href="#ref-for-http-access-control-allow-credentials①">(2)</a> <a href="#ref-for-http-access-control-allow-credentials②">(3)</a>
     <li><a href="#ref-for-http-access-control-allow-credentials③">3.2.6. Examples</a>
     <li><a href="#ref-for-http-access-control-allow-credentials④">4.10. CORS check</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-allow-methods">
-   <b><a href="#http-access-control-allow-methods">#http-access-control-allow-methods</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-allow-methods" class="dfn-panel" data-for="http-access-control-allow-methods" id="infopanel-for-http-access-control-allow-methods" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-allow-methods" style="display:none">Info about the 'Access-Control-Allow-Methods' definition.</span><b><a href="#http-access-control-allow-methods">#http-access-control-allow-methods</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-allow-methods">3.2.3. HTTP responses</a>
     <li><a href="#ref-for-http-access-control-allow-methods①">3.2.5. CORS protocol and credentials</a>
     <li><a href="#ref-for-http-access-control-allow-methods②">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-allow-headers">
-   <b><a href="#http-access-control-allow-headers">#http-access-control-allow-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-allow-headers" class="dfn-panel" data-for="http-access-control-allow-headers" id="infopanel-for-http-access-control-allow-headers" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-allow-headers" style="display:none">Info about the 'Access-Control-Allow-Headers' definition.</span><b><a href="#http-access-control-allow-headers">#http-access-control-allow-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-allow-headers">3.2.3. HTTP responses</a>
     <li><a href="#ref-for-http-access-control-allow-headers①">3.2.5. CORS protocol and credentials</a>
     <li><a href="#ref-for-http-access-control-allow-headers②">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-max-age">
-   <b><a href="#http-access-control-max-age">#http-access-control-max-age</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-max-age" class="dfn-panel" data-for="http-access-control-max-age" id="infopanel-for-http-access-control-max-age" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-max-age" style="display:none">Info about the 'Access-Control-Max-Age' definition.</span><b><a href="#http-access-control-max-age">#http-access-control-max-age</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-max-age">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-access-control-expose-headers">
-   <b><a href="#http-access-control-expose-headers">#http-access-control-expose-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-access-control-expose-headers" class="dfn-panel" data-for="http-access-control-expose-headers" id="infopanel-for-http-access-control-expose-headers" role="dialog">
+   <span id="infopaneltitle-for-http-access-control-expose-headers" style="display:none">Info about the 'Access-Control-Expose-Headers' definition.</span><b><a href="#http-access-control-expose-headers">#http-access-control-expose-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-access-control-expose-headers">2.2.6. Responses</a>
     <li><a href="#ref-for-http-access-control-expose-headers①">3.2.5. CORS protocol and credentials</a>
@@ -10971,8 +10972,8 @@ response to request be blocked due to its MIME type?</a>
     <li><a href="#ref-for-http-access-control-expose-headers⑤">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-header-extract-mime-type">
-   <b><a href="#concept-header-extract-mime-type">#concept-header-extract-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-header-extract-mime-type" class="dfn-panel" data-for="concept-header-extract-mime-type" id="infopanel-for-concept-header-extract-mime-type" role="dialog">
+   <span id="infopaneltitle-for-concept-header-extract-mime-type" style="display:none">Info about the 'extract a MIME type' definition.</span><b><a href="#concept-header-extract-mime-type">#concept-header-extract-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">2.2.2. Headers</a> <a href="#ref-for-concept-header-extract-mime-type①">(2)</a>
     <li><a href="#ref-for-concept-header-extract-mime-type②">2.9. Should
@@ -10985,66 +10986,67 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-header-extract-mime-type⑧">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-x-content-type-options">
-   <b><a href="#http-x-content-type-options">#http-x-content-type-options</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-x-content-type-options" class="dfn-panel" data-for="http-x-content-type-options" id="infopanel-for-http-x-content-type-options" role="dialog">
+   <span id="infopaneltitle-for-http-x-content-type-options" style="display:none">Info about the 'X-Content-Type-Options' definition.</span><b><a href="#http-x-content-type-options">#http-x-content-type-options</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-x-content-type-options">3.5. `X-Content-Type-Options` header</a> <a href="#ref-for-http-x-content-type-options①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="determine-nosniff">
-   <b><a href="#determine-nosniff">#determine-nosniff</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-determine-nosniff" class="dfn-panel" data-for="determine-nosniff" id="infopanel-for-determine-nosniff" role="dialog">
+   <span id="infopaneltitle-for-determine-nosniff" style="display:none">Info about the 'determine nosniff' definition.</span><b><a href="#determine-nosniff">#determine-nosniff</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-determine-nosniff">3.5.1. Should
 response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-determine-nosniff①">3.6. CORB</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-nosniff?">
-   <b><a href="#should-response-to-request-be-blocked-due-to-nosniff?">#should-response-to-request-be-blocked-due-to-nosniff?</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-should-response-to-request-be-blocked-due-to-nosniff?" class="dfn-panel" data-for="should-response-to-request-be-blocked-due-to-nosniff?" id="infopanel-for-should-response-to-request-be-blocked-due-to-nosniff?" role="dialog">
+   <span id="infopaneltitle-for-should-response-to-request-be-blocked-due-to-nosniff?" style="display:none">Info about the '3.5.1. Should
+response to request be blocked due to nosniff?' definition.</span><b><a href="#should-response-to-request-be-blocked-due-to-nosniff?">#should-response-to-request-be-blocked-due-to-nosniff?</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-should-response-to-request-be-blocked-due-to-nosniff?">3.5.1. Should
 response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-should-response-to-request-be-blocked-due-to-nosniff?">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="corb-protected-mime-type">
-   <b><a href="#corb-protected-mime-type">#corb-protected-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-corb-protected-mime-type" class="dfn-panel" data-for="corb-protected-mime-type" id="infopanel-for-corb-protected-mime-type" role="dialog">
+   <span id="infopaneltitle-for-corb-protected-mime-type" style="display:none">Info about the 'CORB-protected MIME type' definition.</span><b><a href="#corb-protected-mime-type">#corb-protected-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corb-protected-mime-type">3.6. CORB</a> <a href="#ref-for-corb-protected-mime-type①">(2)</a> <a href="#ref-for-corb-protected-mime-type②">(3)</a> <a href="#ref-for-corb-protected-mime-type③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="corb-check">
-   <b><a href="#corb-check">#corb-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-corb-check" class="dfn-panel" data-for="corb-check" id="infopanel-for-corb-check" role="dialog">
+   <span id="infopaneltitle-for-corb-check" style="display:none">Info about the 'CORB check' definition.</span><b><a href="#corb-check">#corb-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-corb-check">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-cross-origin-resource-policy">
-   <b><a href="#http-cross-origin-resource-policy">#http-cross-origin-resource-policy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-cross-origin-resource-policy" class="dfn-panel" data-for="http-cross-origin-resource-policy" id="infopanel-for-http-cross-origin-resource-policy" role="dialog">
+   <span id="infopaneltitle-for-http-cross-origin-resource-policy" style="display:none">Info about the 'Cross-Origin-Resource-Policy' definition.</span><b><a href="#http-cross-origin-resource-policy">#http-cross-origin-resource-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-cross-origin-resource-policy">3.7. `Cross-Origin-Resource-Policy` header</a> <a href="#ref-for-http-cross-origin-resource-policy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-resource-policy-check">
-   <b><a href="#cross-origin-resource-policy-check">#cross-origin-resource-policy-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-resource-policy-check" class="dfn-panel" data-for="cross-origin-resource-policy-check" id="infopanel-for-cross-origin-resource-policy-check" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-resource-policy-check" style="display:none">Info about the 'cross-origin resource policy check' definition.</span><b><a href="#cross-origin-resource-policy-check">#cross-origin-resource-policy-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-resource-policy-check">4.3. HTTP fetch</a> <a href="#ref-for-cross-origin-resource-policy-check①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-resource-policy-internal-check">
-   <b><a href="#cross-origin-resource-policy-internal-check">#cross-origin-resource-policy-internal-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-resource-policy-internal-check" class="dfn-panel" data-for="cross-origin-resource-policy-internal-check" id="infopanel-for-cross-origin-resource-policy-internal-check" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-resource-policy-internal-check" style="display:none">Info about the 'cross-origin resource policy internal check' definition.</span><b><a href="#cross-origin-resource-policy-internal-check">#cross-origin-resource-policy-internal-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-resource-policy-internal-check">3.7. `Cross-Origin-Resource-Policy` header</a> <a href="#ref-for-cross-origin-resource-policy-internal-check①">(2)</a> <a href="#ref-for-cross-origin-resource-policy-internal-check②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-a-cross-origin-embedder-policy-corp-violation-report">
-   <b><a href="#queue-a-cross-origin-embedder-policy-corp-violation-report">#queue-a-cross-origin-embedder-policy-corp-violation-report</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-a-cross-origin-embedder-policy-corp-violation-report" class="dfn-panel" data-for="queue-a-cross-origin-embedder-policy-corp-violation-report" id="infopanel-for-queue-a-cross-origin-embedder-policy-corp-violation-report" role="dialog">
+   <span id="infopaneltitle-for-queue-a-cross-origin-embedder-policy-corp-violation-report" style="display:none">Info about the 'queue a cross-origin embedder policy CORP violation report' definition.</span><b><a href="#queue-a-cross-origin-embedder-policy-corp-violation-report">#queue-a-cross-origin-embedder-policy-corp-violation-report</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-cross-origin-embedder-policy-corp-violation-report">3.7. `Cross-Origin-Resource-Policy` header</a> <a href="#ref-for-queue-a-cross-origin-embedder-policy-corp-violation-report①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch">
-   <b><a href="#concept-fetch">#concept-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch" class="dfn-panel" data-for="concept-fetch" id="infopanel-for-concept-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch" style="display:none">Info about the 'fetch' definition.</span><b><a href="#concept-fetch">#concept-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2. Infrastructure</a>
     <li><a href="#ref-for-concept-fetch①">2.2. HTTP</a>
@@ -11064,27 +11066,27 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-fetch③②">CORS protocol and HTTP caches</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="process-response">
-   <b><a href="#process-response">#process-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-process-response" class="dfn-panel" data-for="process-response" id="infopanel-for-process-response" role="dialog">
+   <span id="infopaneltitle-for-process-response" style="display:none">Info about the 'processResponse' definition.</span><b><a href="#process-response">#process-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response">5.6. Fetch method</a>
     <li><a href="#ref-for-process-response①">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-processresponsedone">
-   <b><a href="#fetch-processresponsedone">#fetch-processresponsedone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-processresponsedone" class="dfn-panel" data-for="fetch-processresponsedone" id="infopanel-for-fetch-processresponsedone" role="dialog">
+   <span id="infopaneltitle-for-fetch-processresponsedone" style="display:none">Info about the 'processResponseDone' definition.</span><b><a href="#fetch-processresponsedone">#fetch-processresponsedone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-processresponsedone">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-useparallelqueue">
-   <b><a href="#fetch-useparallelqueue">#fetch-useparallelqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-useparallelqueue" class="dfn-panel" data-for="fetch-useparallelqueue" id="infopanel-for-fetch-useparallelqueue" role="dialog">
+   <span id="infopaneltitle-for-fetch-useparallelqueue" style="display:none">Info about the 'useParallelQueue' definition.</span><b><a href="#fetch-useparallelqueue">#fetch-useparallelqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-useparallelqueue">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-terminate">
-   <b><a href="#concept-fetch-terminate">#concept-fetch-terminate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-terminate" class="dfn-panel" data-for="concept-fetch-terminate" id="infopanel-for-concept-fetch-terminate" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-terminate" style="display:none">Info about the 'terminated' definition.</span><b><a href="#concept-fetch-terminate">#concept-fetch-terminate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-terminate">2.4. Fetch groups</a>
     <li><a href="#ref-for-concept-fetch-terminate①">2.5. Connections</a>
@@ -11096,52 +11098,52 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-fetch-terminate②①">5.7. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-suspend">
-   <b><a href="#concept-fetch-suspend">#concept-fetch-suspend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-suspend" class="dfn-panel" data-for="concept-fetch-suspend" id="infopanel-for-concept-fetch-suspend" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-suspend" style="display:none">Info about the 'suspend' definition.</span><b><a href="#concept-fetch-suspend">#concept-fetch-suspend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-suspend">4.7. HTTP-network fetch</a> <a href="#ref-for-concept-fetch-suspend①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-fetch-resume">
-   <b><a href="#concept-fetch-resume">#concept-fetch-resume</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-fetch-resume" class="dfn-panel" data-for="concept-fetch-resume" id="infopanel-for-concept-fetch-resume" role="dialog">
+   <span id="infopaneltitle-for-concept-fetch-resume" style="display:none">Info about the 'resumed' definition.</span><b><a href="#concept-fetch-resume">#concept-fetch-resume</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch-resume">4.7. HTTP-network fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-main-fetch">
-   <b><a href="#concept-main-fetch">#concept-main-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-main-fetch" class="dfn-panel" data-for="concept-main-fetch" id="infopanel-for-concept-main-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-main-fetch" style="display:none">Info about the 'main fetch' definition.</span><b><a href="#concept-main-fetch">#concept-main-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-main-fetch">4. Fetching</a>
     <li><a href="#ref-for-concept-main-fetch①">4.4. HTTP-redirect fetch</a> <a href="#ref-for-concept-main-fetch②">(2)</a>
     <li><a href="#ref-for-concept-main-fetch③">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-finale">
-   <b><a href="#fetch-finale">#fetch-finale</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-finale" class="dfn-panel" data-for="fetch-finale" id="infopanel-for-fetch-finale" role="dialog">
+   <span id="infopaneltitle-for-fetch-finale" style="display:none">Info about the 'fetch finale' definition.</span><b><a href="#fetch-finale">#fetch-finale</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-finale">4.1. Main fetch</a> <a href="#ref-for-fetch-finale①">(2)</a> <a href="#ref-for-fetch-finale②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finalize-response">
-   <b><a href="#finalize-response">#finalize-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finalize-response" class="dfn-panel" data-for="finalize-response" id="infopanel-for-finalize-response" role="dialog">
+   <span id="infopaneltitle-for-finalize-response" style="display:none">Info about the 'finalize response' definition.</span><b><a href="#finalize-response">#finalize-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finalize-response">4.7. HTTP-network fetch</a> <a href="#ref-for-finalize-response①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="finalize-and-report-timing">
-   <b><a href="#finalize-and-report-timing">#finalize-and-report-timing</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-finalize-and-report-timing" class="dfn-panel" data-for="finalize-and-report-timing" id="infopanel-for-finalize-and-report-timing" role="dialog">
+   <span id="infopaneltitle-for-finalize-and-report-timing" style="display:none">Info about the 'finalize and report timing' definition.</span><b><a href="#finalize-and-report-timing">#finalize-and-report-timing</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-finalize-and-report-timing">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-scheme-fetch">
-   <b><a href="#concept-scheme-fetch">#concept-scheme-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-scheme-fetch" class="dfn-panel" data-for="concept-scheme-fetch" id="infopanel-for-concept-scheme-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-scheme-fetch" style="display:none">Info about the 'scheme fetch' definition.</span><b><a href="#concept-scheme-fetch">#concept-scheme-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-scheme-fetch">4.1. Main fetch</a> <a href="#ref-for-concept-scheme-fetch①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-http-fetch">
-   <b><a href="#concept-http-fetch">#concept-http-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-http-fetch" class="dfn-panel" data-for="concept-http-fetch" id="infopanel-for-concept-http-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-http-fetch" style="display:none">Info about the 'HTTP fetch' definition.</span><b><a href="#concept-http-fetch">#concept-http-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-fetch">2.2.5. Requests</a> <a href="#ref-for-concept-http-fetch①">(2)</a>
     <li><a href="#ref-for-concept-http-fetch②">3.1. `Origin` header</a>
@@ -11150,250 +11152,250 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-concept-http-fetch⑥">4.8. CORS-preflight fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-http-redirect-fetch">
-   <b><a href="#concept-http-redirect-fetch">#concept-http-redirect-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-http-redirect-fetch" class="dfn-panel" data-for="concept-http-redirect-fetch" id="infopanel-for-concept-http-redirect-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-http-redirect-fetch" style="display:none">Info about the 'HTTP-redirect fetch' definition.</span><b><a href="#concept-http-redirect-fetch">#concept-http-redirect-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-redirect-fetch">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-http-redirect-fetch①">4.5. Navigate-redirect fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-http-network-or-cache-fetch">
-   <b><a href="#concept-http-network-or-cache-fetch">#concept-http-network-or-cache-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-http-network-or-cache-fetch" class="dfn-panel" data-for="concept-http-network-or-cache-fetch" id="infopanel-for-concept-http-network-or-cache-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-http-network-or-cache-fetch" style="display:none">Info about the 'HTTP-network-or-cache fetch' definition.</span><b><a href="#concept-http-network-or-cache-fetch">#concept-http-network-or-cache-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-network-or-cache-fetch">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-http-network-or-cache-fetch①">4.6. HTTP-network-or-cache fetch</a> <a href="#ref-for-concept-http-network-or-cache-fetch②">(2)</a> <a href="#ref-for-concept-http-network-or-cache-fetch③">(3)</a>
     <li><a href="#ref-for-concept-http-network-or-cache-fetch④">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-http-network-or-cache-fetch⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-http-network-fetch">
-   <b><a href="#concept-http-network-fetch">#concept-http-network-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-http-network-fetch" class="dfn-panel" data-for="concept-http-network-fetch" id="infopanel-for-concept-http-network-fetch" role="dialog">
+   <span id="infopaneltitle-for-concept-http-network-fetch" style="display:none">Info about the 'HTTP-network fetch' definition.</span><b><a href="#concept-http-network-fetch">#concept-http-network-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-http-network-fetch">4.6. HTTP-network-or-cache fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cors-preflight-fetch-0">
-   <b><a href="#cors-preflight-fetch-0">#cors-preflight-fetch-0</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cors-preflight-fetch-0" class="dfn-panel" data-for="cors-preflight-fetch-0" id="infopanel-for-cors-preflight-fetch-0" role="dialog">
+   <span id="infopaneltitle-for-cors-preflight-fetch-0" style="display:none">Info about the 'CORS-preflight fetch' definition.</span><b><a href="#cors-preflight-fetch-0">#cors-preflight-fetch-0</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-preflight-fetch-0">2.2.5. Requests</a>
     <li><a href="#ref-for-cors-preflight-fetch-0①">4.3. HTTP fetch</a> <a href="#ref-for-cors-preflight-fetch-0②">(2)</a> <a href="#ref-for-cors-preflight-fetch-0③">(3)</a> <a href="#ref-for-cors-preflight-fetch-0④">(4)</a>
     <li><a href="#ref-for-cors-preflight-fetch-0⑤">4.8. CORS-preflight fetch</a> <a href="#ref-for-cors-preflight-fetch-0⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache">
-   <b><a href="#concept-cache">#concept-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache" class="dfn-panel" data-for="concept-cache" id="infopanel-for-concept-cache" role="dialog">
+   <span id="infopaneltitle-for-concept-cache" style="display:none">Info about the 'CORS-preflight cache' definition.</span><b><a href="#concept-cache">#concept-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-cache①">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cache②">(2)</a> <a href="#ref-for-concept-cache③">(3)</a>
     <li><a href="#ref-for-concept-cache④">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache⑤">(2)</a> <a href="#ref-for-concept-cache⑥">(3)</a> <a href="#ref-for-concept-cache⑦">(4)</a> <a href="#ref-for-concept-cache⑧">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cache-entry">
-   <b><a href="#cache-entry">#cache-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cache-entry" class="dfn-panel" data-for="cache-entry" id="infopanel-for-cache-entry" role="dialog">
+   <span id="infopaneltitle-for-cache-entry" style="display:none">Info about the 'cache entry' definition.</span><b><a href="#cache-entry">#cache-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-entry">4.9. CORS-preflight cache</a> <a href="#ref-for-cache-entry①">(2)</a> <a href="#ref-for-cache-entry②">(3)</a> <a href="#ref-for-cache-entry③">(4)</a> <a href="#ref-for-cache-entry④">(5)</a> <a href="#ref-for-cache-entry⑤">(6)</a> <a href="#ref-for-cache-entry⑥">(7)</a> <a href="#ref-for-cache-entry⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-key">
-   <b><a href="#concept-cache-key">#concept-cache-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-key" class="dfn-panel" data-for="concept-cache-key" id="infopanel-for-concept-cache-key" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-key" style="display:none">Info about the 'key' definition.</span><b><a href="#concept-cache-key">#concept-cache-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-key">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-key①">(2)</a> <a href="#ref-for-concept-cache-key②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-origin">
-   <b><a href="#concept-cache-origin">#concept-cache-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-origin" class="dfn-panel" data-for="concept-cache-origin" id="infopanel-for-concept-cache-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-origin" style="display:none">Info about the 'byte-serialized origin' definition.</span><b><a href="#concept-cache-origin">#concept-cache-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-origin">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-origin①">(2)</a> <a href="#ref-for-concept-cache-origin②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-url">
-   <b><a href="#concept-cache-url">#concept-cache-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-url" class="dfn-panel" data-for="concept-cache-url" id="infopanel-for-concept-cache-url" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-cache-url">#concept-cache-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-url">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-url①">(2)</a> <a href="#ref-for-concept-cache-url②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-max-age">
-   <b><a href="#concept-cache-max-age">#concept-cache-max-age</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-max-age" class="dfn-panel" data-for="concept-cache-max-age" id="infopanel-for-concept-cache-max-age" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-max-age" style="display:none">Info about the 'max-age' definition.</span><b><a href="#concept-cache-max-age">#concept-cache-max-age</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-max-age">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cache-max-age①">(2)</a> <a href="#ref-for-concept-cache-max-age②">(3)</a>
     <li><a href="#ref-for-concept-cache-max-age③">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-max-age④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-credentials">
-   <b><a href="#concept-cache-credentials">#concept-cache-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-credentials" class="dfn-panel" data-for="concept-cache-credentials" id="infopanel-for-concept-cache-credentials" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-credentials" style="display:none">Info about the 'credentials' definition.</span><b><a href="#concept-cache-credentials">#concept-cache-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-credentials">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-credentials①">(2)</a> <a href="#ref-for-concept-cache-credentials②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-method">
-   <b><a href="#concept-cache-method">#concept-cache-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-method" class="dfn-panel" data-for="concept-cache-method" id="infopanel-for-concept-cache-method" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-method" style="display:none">Info about the 'method' definition.</span><b><a href="#concept-cache-method">#concept-cache-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-method">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-method①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-header-name">
-   <b><a href="#concept-cache-header-name">#concept-cache-header-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-header-name" class="dfn-panel" data-for="concept-cache-header-name" id="infopanel-for-concept-cache-header-name" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-header-name" style="display:none">Info about the 'header name' definition.</span><b><a href="#concept-cache-header-name">#concept-cache-header-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-header-name">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-header-name①">(2)</a> <a href="#ref-for-concept-cache-header-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-create-entry">
-   <b><a href="#concept-cache-create-entry">#concept-cache-create-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-create-entry" class="dfn-panel" data-for="concept-cache-create-entry" id="infopanel-for-concept-cache-create-entry" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-create-entry" style="display:none">Info about the 'create a new cache entry' definition.</span><b><a href="#concept-cache-create-entry">#concept-cache-create-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-create-entry">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cache-create-entry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-clear">
-   <b><a href="#concept-cache-clear">#concept-cache-clear</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-clear" class="dfn-panel" data-for="concept-cache-clear" id="infopanel-for-concept-cache-clear" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-clear" style="display:none">Info about the 'clear cache entries' definition.</span><b><a href="#concept-cache-clear">#concept-cache-clear</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-clear">4.1. Main fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-match">
-   <b><a href="#concept-cache-match">#concept-cache-match</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-match" class="dfn-panel" data-for="concept-cache-match" id="infopanel-for-concept-cache-match" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-match" style="display:none">Info about the 'cache entry match' definition.</span><b><a href="#concept-cache-match">#concept-cache-match</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-match">4.9. CORS-preflight cache</a> <a href="#ref-for-concept-cache-match①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-match-method">
-   <b><a href="#concept-cache-match-method">#concept-cache-match-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-match-method" class="dfn-panel" data-for="concept-cache-match-method" id="infopanel-for-concept-cache-match-method" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-match-method" style="display:none">Info about the 'method cache entry match' definition.</span><b><a href="#concept-cache-match-method">#concept-cache-match-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-match-method">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-cache-match-method①">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cache-match-method②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cache-match-header">
-   <b><a href="#concept-cache-match-header">#concept-cache-match-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cache-match-header" class="dfn-panel" data-for="concept-cache-match-header" id="infopanel-for-concept-cache-match-header" role="dialog">
+   <span id="infopaneltitle-for-concept-cache-match-header" style="display:none">Info about the 'header-name cache entry match' definition.</span><b><a href="#concept-cache-match-header">#concept-cache-match-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cache-match-header">4.3. HTTP fetch</a>
     <li><a href="#ref-for-concept-cache-match-header①">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cache-match-header②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-cors-check">
-   <b><a href="#concept-cors-check">#concept-cors-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-cors-check" class="dfn-panel" data-for="concept-cors-check" id="infopanel-for-concept-cors-check" role="dialog">
+   <span id="infopaneltitle-for-concept-cors-check" style="display:none">Info about the 'CORS check' definition.</span><b><a href="#concept-cors-check">#concept-cors-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-cors-check">4.3. HTTP fetch</a> <a href="#ref-for-concept-cors-check①">(2)</a> <a href="#ref-for-concept-cors-check②">(3)</a>
     <li><a href="#ref-for-concept-cors-check③">4.8. CORS-preflight fetch</a> <a href="#ref-for-concept-cors-check④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-tao-check">
-   <b><a href="#concept-tao-check">#concept-tao-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-tao-check" class="dfn-panel" data-for="concept-tao-check" id="infopanel-for-concept-tao-check" role="dialog">
+   <span id="infopaneltitle-for-concept-tao-check" style="display:none">Info about the 'TAO check' definition.</span><b><a href="#concept-tao-check">#concept-tao-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tao-check">4.3. HTTP fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-headersinit">
-   <b><a href="#typedefdef-headersinit">#typedefdef-headersinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-headersinit" class="dfn-panel" data-for="typedefdef-headersinit" id="infopanel-for-typedefdef-headersinit" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-headersinit" style="display:none">Info about the 'HeadersInit' definition.</span><b><a href="#typedefdef-headersinit">#typedefdef-headersinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-headersinit">5.1. Headers class</a>
     <li><a href="#ref-for-typedefdef-headersinit①">5.4. Request class</a>
     <li><a href="#ref-for-typedefdef-headersinit②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="headers">
-   <b><a href="#headers">#headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-headers" class="dfn-panel" data-for="headers" id="infopanel-for-headers" role="dialog">
+   <span id="infopaneltitle-for-headers" style="display:none">Info about the 'Headers' definition.</span><b><a href="#headers">#headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers">5.1. Headers class</a> <a href="#ref-for-headers①">(2)</a> <a href="#ref-for-headers②">(3)</a> <a href="#ref-for-headers③">(4)</a> <a href="#ref-for-headers④">(5)</a> <a href="#ref-for-headers⑤">(6)</a> <a href="#ref-for-headers⑥">(7)</a> <a href="#ref-for-headers⑦">(8)</a>
     <li><a href="#ref-for-headers⑧">5.4. Request class</a> <a href="#ref-for-headers⑨">(2)</a> <a href="#ref-for-headers①⓪">(3)</a> <a href="#ref-for-headers①①">(4)</a> <a href="#ref-for-headers①②">(5)</a> <a href="#ref-for-headers①③">(6)</a> <a href="#ref-for-headers①④">(7)</a>
     <li><a href="#ref-for-headers①⑤">5.5. Response class</a> <a href="#ref-for-headers①⑥">(2)</a> <a href="#ref-for-headers①⑦">(3)</a> <a href="#ref-for-headers①⑧">(4)</a> <a href="#ref-for-headers①⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-headers-header-list">
-   <b><a href="#concept-headers-header-list">#concept-headers-header-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-headers-header-list" class="dfn-panel" data-for="concept-headers-header-list" id="infopanel-for-concept-headers-header-list" role="dialog">
+   <span id="infopaneltitle-for-concept-headers-header-list" style="display:none">Info about the 'header list' definition.</span><b><a href="#concept-headers-header-list">#concept-headers-header-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-header-list">5.1. Headers class</a> <a href="#ref-for-concept-headers-header-list①">(2)</a> <a href="#ref-for-concept-headers-header-list②">(3)</a> <a href="#ref-for-concept-headers-header-list③">(4)</a> <a href="#ref-for-concept-headers-header-list④">(5)</a> <a href="#ref-for-concept-headers-header-list⑤">(6)</a> <a href="#ref-for-concept-headers-header-list⑥">(7)</a> <a href="#ref-for-concept-headers-header-list⑦">(8)</a> <a href="#ref-for-concept-headers-header-list⑧">(9)</a>
     <li><a href="#ref-for-concept-headers-header-list⑨">5.4. Request class</a> <a href="#ref-for-concept-headers-header-list①⓪">(2)</a> <a href="#ref-for-concept-headers-header-list①①">(3)</a> <a href="#ref-for-concept-headers-header-list①②">(4)</a> <a href="#ref-for-concept-headers-header-list①③">(5)</a> <a href="#ref-for-concept-headers-header-list①④">(6)</a>
     <li><a href="#ref-for-concept-headers-header-list①⑤">5.5. Response class</a> <a href="#ref-for-concept-headers-header-list①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-headers-guard">
-   <b><a href="#concept-headers-guard">#concept-headers-guard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-headers-guard" class="dfn-panel" data-for="concept-headers-guard" id="infopanel-for-concept-headers-guard" role="dialog">
+   <span id="infopaneltitle-for-concept-headers-guard" style="display:none">Info about the 'guard' definition.</span><b><a href="#concept-headers-guard">#concept-headers-guard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-guard">5.1. Headers class</a> <a href="#ref-for-concept-headers-guard①">(2)</a> <a href="#ref-for-concept-headers-guard②">(3)</a> <a href="#ref-for-concept-headers-guard③">(4)</a> <a href="#ref-for-concept-headers-guard④">(5)</a> <a href="#ref-for-concept-headers-guard⑤">(6)</a> <a href="#ref-for-concept-headers-guard⑥">(7)</a> <a href="#ref-for-concept-headers-guard⑦">(8)</a> <a href="#ref-for-concept-headers-guard⑧">(9)</a> <a href="#ref-for-concept-headers-guard⑨">(10)</a> <a href="#ref-for-concept-headers-guard①⓪">(11)</a> <a href="#ref-for-concept-headers-guard①①">(12)</a> <a href="#ref-for-concept-headers-guard①②">(13)</a> <a href="#ref-for-concept-headers-guard①③">(14)</a> <a href="#ref-for-concept-headers-guard①④">(15)</a> <a href="#ref-for-concept-headers-guard①⑤">(16)</a>
     <li><a href="#ref-for-concept-headers-guard①⑥">5.4. Request class</a> <a href="#ref-for-concept-headers-guard①⑦">(2)</a> <a href="#ref-for-concept-headers-guard①⑧">(3)</a> <a href="#ref-for-concept-headers-guard①⑨">(4)</a>
     <li><a href="#ref-for-concept-headers-guard②⓪">5.5. Response class</a> <a href="#ref-for-concept-headers-guard②①">(2)</a> <a href="#ref-for-concept-headers-guard②②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="headers-guard">
-   <b><a href="#headers-guard">#headers-guard</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-headers-guard" class="dfn-panel" data-for="headers-guard" id="infopanel-for-headers-guard" role="dialog">
+   <span id="infopaneltitle-for-headers-guard" style="display:none">Info about the 'headers guard' definition.</span><b><a href="#headers-guard">#headers-guard</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-headers-guard">5.1. Headers class</a>
     <li><a href="#ref-for-headers-guard①">5.4. Request class</a>
     <li><a href="#ref-for-headers-guard②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-headers-append">
-   <b><a href="#concept-headers-append">#concept-headers-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-headers-append" class="dfn-panel" data-for="concept-headers-append" id="infopanel-for-concept-headers-append" role="dialog">
+   <span id="infopaneltitle-for-concept-headers-append" style="display:none">Info about the 'append' definition.</span><b><a href="#concept-headers-append">#concept-headers-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-append">5.1. Headers class</a> <a href="#ref-for-concept-headers-append①">(2)</a> <a href="#ref-for-concept-headers-append②">(3)</a>
     <li><a href="#ref-for-concept-headers-append③">5.4. Request class</a> <a href="#ref-for-concept-headers-append④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-headers-fill">
-   <b><a href="#concept-headers-fill">#concept-headers-fill</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-headers-fill" class="dfn-panel" data-for="concept-headers-fill" id="infopanel-for-concept-headers-fill" role="dialog">
+   <span id="infopaneltitle-for-concept-headers-fill" style="display:none">Info about the 'fill' definition.</span><b><a href="#concept-headers-fill">#concept-headers-fill</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-fill">5.1. Headers class</a>
     <li><a href="#ref-for-concept-headers-fill①">5.4. Request class</a>
     <li><a href="#ref-for-concept-headers-fill②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-headers-remove-privileged-no-cors-request-headers">
-   <b><a href="#concept-headers-remove-privileged-no-cors-request-headers">#concept-headers-remove-privileged-no-cors-request-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-headers-remove-privileged-no-cors-request-headers" class="dfn-panel" data-for="concept-headers-remove-privileged-no-cors-request-headers" id="infopanel-for-concept-headers-remove-privileged-no-cors-request-headers" role="dialog">
+   <span id="infopaneltitle-for-concept-headers-remove-privileged-no-cors-request-headers" style="display:none">Info about the 'remove privileged no-CORS request headers' definition.</span><b><a href="#concept-headers-remove-privileged-no-cors-request-headers">#concept-headers-remove-privileged-no-cors-request-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-headers-remove-privileged-no-cors-request-headers">5.1. Headers class</a> <a href="#ref-for-concept-headers-remove-privileged-no-cors-request-headers①">(2)</a> <a href="#ref-for-concept-headers-remove-privileged-no-cors-request-headers②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers">
-   <b><a href="#dom-headers">#dom-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers" class="dfn-panel" data-for="dom-headers" id="infopanel-for-dom-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-headers" style="display:none">Info about the 'new Headers(init)' definition.</span><b><a href="#dom-headers">#dom-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers">5.1. Headers class</a> <a href="#ref-for-dom-headers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers-append">
-   <b><a href="#dom-headers-append">#dom-headers-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers-append" class="dfn-panel" data-for="dom-headers-append" id="infopanel-for-dom-headers-append" role="dialog">
+   <span id="infopaneltitle-for-dom-headers-append" style="display:none">Info about the 'append(name, value)' definition.</span><b><a href="#dom-headers-append">#dom-headers-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-append">5.1. Headers class</a> <a href="#ref-for-dom-headers-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers-delete">
-   <b><a href="#dom-headers-delete">#dom-headers-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers-delete" class="dfn-panel" data-for="dom-headers-delete" id="infopanel-for-dom-headers-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-headers-delete" style="display:none">Info about the 'delete(name)' definition.</span><b><a href="#dom-headers-delete">#dom-headers-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-delete">5.1. Headers class</a> <a href="#ref-for-dom-headers-delete①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers-get">
-   <b><a href="#dom-headers-get">#dom-headers-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers-get" class="dfn-panel" data-for="dom-headers-get" id="infopanel-for-dom-headers-get" role="dialog">
+   <span id="infopaneltitle-for-dom-headers-get" style="display:none">Info about the 'get(name)' definition.</span><b><a href="#dom-headers-get">#dom-headers-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-get">5.1. Headers class</a> <a href="#ref-for-dom-headers-get①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers-has">
-   <b><a href="#dom-headers-has">#dom-headers-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers-has" class="dfn-panel" data-for="dom-headers-has" id="infopanel-for-dom-headers-has" role="dialog">
+   <span id="infopaneltitle-for-dom-headers-has" style="display:none">Info about the 'has(name)' definition.</span><b><a href="#dom-headers-has">#dom-headers-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-has">5.1. Headers class</a> <a href="#ref-for-dom-headers-has①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-headers-set">
-   <b><a href="#dom-headers-set">#dom-headers-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-headers-set" class="dfn-panel" data-for="dom-headers-set" id="infopanel-for-dom-headers-set" role="dialog">
+   <span id="infopaneltitle-for-dom-headers-set" style="display:none">Info about the 'set(name, value)' definition.</span><b><a href="#dom-headers-set">#dom-headers-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-headers-set">5.1. Headers class</a> <a href="#ref-for-dom-headers-set①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-xmlhttprequestbodyinit">
-   <b><a href="#typedefdef-xmlhttprequestbodyinit">#typedefdef-xmlhttprequestbodyinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-xmlhttprequestbodyinit" class="dfn-panel" data-for="typedefdef-xmlhttprequestbodyinit" id="infopanel-for-typedefdef-xmlhttprequestbodyinit" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-xmlhttprequestbodyinit" style="display:none">Info about the 'XMLHttpRequestBodyInit' definition.</span><b><a href="#typedefdef-xmlhttprequestbodyinit">#typedefdef-xmlhttprequestbodyinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-xmlhttprequestbodyinit">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bodyinit">
-   <b><a href="#bodyinit">#bodyinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bodyinit" class="dfn-panel" data-for="bodyinit" id="infopanel-for-bodyinit" role="dialog">
+   <span id="infopaneltitle-for-bodyinit" style="display:none">Info about the 'BodyInit' definition.</span><b><a href="#bodyinit">#bodyinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bodyinit">5.2. BodyInit unions</a> <a href="#ref-for-bodyinit①">(2)</a>
     <li><a href="#ref-for-bodyinit②">5.4. Request class</a> <a href="#ref-for-bodyinit③">(2)</a>
     <li><a href="#ref-for-bodyinit④">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bodyinit-safely-extract">
-   <b><a href="#bodyinit-safely-extract">#bodyinit-safely-extract</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bodyinit-safely-extract" class="dfn-panel" data-for="bodyinit-safely-extract" id="infopanel-for-bodyinit-safely-extract" role="dialog">
+   <span id="infopaneltitle-for-bodyinit-safely-extract" style="display:none">Info about the 'safely extract' definition.</span><b><a href="#bodyinit-safely-extract">#bodyinit-safely-extract</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bodyinit-safely-extract">2.2.5. Requests</a>
     <li><a href="#ref-for-bodyinit-safely-extract①">4. Fetching</a>
@@ -11403,115 +11405,115 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-bodyinit-safely-extract⑤">5.2. BodyInit unions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-bodyinit-extract">
-   <b><a href="#concept-bodyinit-extract">#concept-bodyinit-extract</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-bodyinit-extract" class="dfn-panel" data-for="concept-bodyinit-extract" id="infopanel-for-concept-bodyinit-extract" role="dialog">
+   <span id="infopaneltitle-for-concept-bodyinit-extract" style="display:none">Info about the 'extract' definition.</span><b><a href="#concept-bodyinit-extract">#concept-bodyinit-extract</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-bodyinit-extract">5.2. BodyInit unions</a> <a href="#ref-for-concept-bodyinit-extract①">(2)</a>
     <li><a href="#ref-for-concept-bodyinit-extract②">5.4. Request class</a>
     <li><a href="#ref-for-concept-bodyinit-extract③">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="keepalive">
-   <b><a href="#keepalive">#keepalive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-keepalive" class="dfn-panel" data-for="keepalive" id="infopanel-for-keepalive" role="dialog">
+   <span id="infopaneltitle-for-keepalive" style="display:none">Info about the 'keepalive' definition.</span><b><a href="#keepalive">#keepalive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-keepalive">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="body">
-   <b><a href="#body">#body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-body" class="dfn-panel" data-for="body" id="infopanel-for-body" role="dialog">
+   <span id="infopaneltitle-for-body" style="display:none">Info about the 'Body' definition.</span><b><a href="#body">#body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body">5.3. Body mixin</a> <a href="#ref-for-body①">(2)</a> <a href="#ref-for-body②">(3)</a>
     <li><a href="#ref-for-body③">5.4. Request class</a>
     <li><a href="#ref-for-body④">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-mime-type">
-   <b><a href="#concept-body-mime-type">#concept-body-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-mime-type" class="dfn-panel" data-for="concept-body-mime-type" id="infopanel-for-concept-body-mime-type" role="dialog">
+   <span id="infopaneltitle-for-concept-body-mime-type" style="display:none">Info about the 'MIME type' definition.</span><b><a href="#concept-body-mime-type">#concept-body-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-mime-type">5.3. Body mixin</a>
     <li><a href="#ref-for-concept-body-mime-type①">5.4. Request class</a>
     <li><a href="#ref-for-concept-body-mime-type②">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-body">
-   <b><a href="#concept-body-body">#concept-body-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-body" class="dfn-panel" data-for="concept-body-body" id="infopanel-for-concept-body-body" role="dialog">
+   <span id="infopaneltitle-for-concept-body-body" style="display:none">Info about the 'body' definition.</span><b><a href="#concept-body-body">#concept-body-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-body">5.3. Body mixin</a> <a href="#ref-for-concept-body-body①">(2)</a> <a href="#ref-for-concept-body-body②">(3)</a> <a href="#ref-for-concept-body-body③">(4)</a> <a href="#ref-for-concept-body-body④">(5)</a> <a href="#ref-for-concept-body-body⑤">(6)</a> <a href="#ref-for-concept-body-body⑥">(7)</a> <a href="#ref-for-concept-body-body⑦">(8)</a>
     <li><a href="#ref-for-concept-body-body⑧">5.4. Request class</a>
     <li><a href="#ref-for-concept-body-body⑨">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="body-unusable">
-   <b><a href="#body-unusable">#body-unusable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-body-unusable" class="dfn-panel" data-for="body-unusable" id="infopanel-for-body-unusable" role="dialog">
+   <span id="infopaneltitle-for-body-unusable" style="display:none">Info about the 'unusable' definition.</span><b><a href="#body-unusable">#body-unusable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body-unusable">5.3. Body mixin</a>
     <li><a href="#ref-for-body-unusable①">5.4. Request class</a> <a href="#ref-for-body-unusable②">(2)</a>
     <li><a href="#ref-for-body-unusable③">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-body">
-   <b><a href="#dom-body-body">#dom-body-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-body" class="dfn-panel" data-for="dom-body-body" id="infopanel-for-dom-body-body" role="dialog">
+   <span id="infopaneltitle-for-dom-body-body" style="display:none">Info about the 'body' definition.</span><b><a href="#dom-body-body">#dom-body-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-body">5.3. Body mixin</a> <a href="#ref-for-dom-body-body①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-bodyused">
-   <b><a href="#dom-body-bodyused">#dom-body-bodyused</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-bodyused" class="dfn-panel" data-for="dom-body-bodyused" id="infopanel-for-dom-body-bodyused" role="dialog">
+   <span id="infopaneltitle-for-dom-body-bodyused" style="display:none">Info about the 'bodyUsed' definition.</span><b><a href="#dom-body-bodyused">#dom-body-bodyused</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-bodyused">5.3. Body mixin</a> <a href="#ref-for-dom-body-bodyused①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-package-data">
-   <b><a href="#concept-body-package-data">#concept-body-package-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-package-data" class="dfn-panel" data-for="concept-body-package-data" id="infopanel-for-concept-body-package-data" role="dialog">
+   <span id="infopaneltitle-for-concept-body-package-data" style="display:none">Info about the 'package data' definition.</span><b><a href="#concept-body-package-data">#concept-body-package-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-package-data">5.3. Body mixin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-body-consume-body">
-   <b><a href="#concept-body-consume-body">#concept-body-consume-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-body-consume-body" class="dfn-panel" data-for="concept-body-consume-body" id="infopanel-for-concept-body-consume-body" role="dialog">
+   <span id="infopaneltitle-for-concept-body-consume-body" style="display:none">Info about the 'consume body' definition.</span><b><a href="#concept-body-consume-body">#concept-body-consume-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-consume-body">5.3. Body mixin</a> <a href="#ref-for-concept-body-consume-body①">(2)</a> <a href="#ref-for-concept-body-consume-body②">(3)</a> <a href="#ref-for-concept-body-consume-body③">(4)</a> <a href="#ref-for-concept-body-consume-body④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-arraybuffer">
-   <b><a href="#dom-body-arraybuffer">#dom-body-arraybuffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-arraybuffer" class="dfn-panel" data-for="dom-body-arraybuffer" id="infopanel-for-dom-body-arraybuffer" role="dialog">
+   <span id="infopaneltitle-for-dom-body-arraybuffer" style="display:none">Info about the 'arrayBuffer()' definition.</span><b><a href="#dom-body-arraybuffer">#dom-body-arraybuffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-arraybuffer">5.3. Body mixin</a> <a href="#ref-for-dom-body-arraybuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-blob">
-   <b><a href="#dom-body-blob">#dom-body-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-blob" class="dfn-panel" data-for="dom-body-blob" id="infopanel-for-dom-body-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-body-blob" style="display:none">Info about the 'blob()' definition.</span><b><a href="#dom-body-blob">#dom-body-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-blob">5.3. Body mixin</a> <a href="#ref-for-dom-body-blob①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-formdata">
-   <b><a href="#dom-body-formdata">#dom-body-formdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-formdata" class="dfn-panel" data-for="dom-body-formdata" id="infopanel-for-dom-body-formdata" role="dialog">
+   <span id="infopaneltitle-for-dom-body-formdata" style="display:none">Info about the 'formData()' definition.</span><b><a href="#dom-body-formdata">#dom-body-formdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-formdata">5.3. Body mixin</a> <a href="#ref-for-dom-body-formdata①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-json">
-   <b><a href="#dom-body-json">#dom-body-json</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-json" class="dfn-panel" data-for="dom-body-json" id="infopanel-for-dom-body-json" role="dialog">
+   <span id="infopaneltitle-for-dom-body-json" style="display:none">Info about the 'json()' definition.</span><b><a href="#dom-body-json">#dom-body-json</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-json">5.3. Body mixin</a> <a href="#ref-for-dom-body-json①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-body-text">
-   <b><a href="#dom-body-text">#dom-body-text</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-body-text" class="dfn-panel" data-for="dom-body-text" id="infopanel-for-dom-body-text" role="dialog">
+   <span id="infopaneltitle-for-dom-body-text" style="display:none">Info about the 'text()' definition.</span><b><a href="#dom-body-text">#dom-body-text</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-body-text">5.3. Body mixin</a> <a href="#ref-for-dom-body-text①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestinfo">
-   <b><a href="#requestinfo">#requestinfo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestinfo" class="dfn-panel" data-for="requestinfo" id="infopanel-for-requestinfo" role="dialog">
+   <span id="infopaneltitle-for-requestinfo" style="display:none">Info about the 'RequestInfo' definition.</span><b><a href="#requestinfo">#requestinfo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinfo">5.4. Request class</a>
     <li><a href="#ref-for-requestinfo①">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request">
-   <b><a href="#request">#request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request" class="dfn-panel" data-for="request" id="infopanel-for-request" role="dialog">
+   <span id="infopaneltitle-for-request" style="display:none">Info about the 'Request' definition.</span><b><a href="#request">#request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request">5.1. Headers class</a>
     <li><a href="#ref-for-request①">5.4. Request class</a> <a href="#ref-for-request②">(2)</a> <a href="#ref-for-request③">(3)</a> <a href="#ref-for-request④">(4)</a> <a href="#ref-for-request⑤">(5)</a> <a href="#ref-for-request⑥">(6)</a> <a href="#ref-for-request⑦">(7)</a> <a href="#ref-for-request⑧">(8)</a> <a href="#ref-for-request⑨">(9)</a> <a href="#ref-for-request①⓪">(10)</a> <a href="#ref-for-request①①">(11)</a> <a href="#ref-for-request①②">(12)</a> <a href="#ref-for-request①③">(13)</a> <a href="#ref-for-request①④">(14)</a>
@@ -11519,376 +11521,376 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-request①⑥">HTTP header layer division</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestinit">
-   <b><a href="#requestinit">#requestinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestinit" class="dfn-panel" data-for="requestinit" id="infopanel-for-requestinit" role="dialog">
+   <span id="infopaneltitle-for-requestinit" style="display:none">Info about the 'RequestInit' definition.</span><b><a href="#requestinit">#requestinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestinit">5.4. Request class</a>
     <li><a href="#ref-for-requestinit①">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-method">
-   <b><a href="#dom-requestinit-method">#dom-requestinit-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-method" class="dfn-panel" data-for="dom-requestinit-method" id="infopanel-for-dom-requestinit-method" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-method" style="display:none">Info about the 'method' definition.</span><b><a href="#dom-requestinit-method">#dom-requestinit-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-method">5.4. Request class</a> <a href="#ref-for-dom-requestinit-method①">(2)</a> <a href="#ref-for-dom-requestinit-method②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-headers">
-   <b><a href="#dom-requestinit-headers">#dom-requestinit-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-headers" class="dfn-panel" data-for="dom-requestinit-headers" id="infopanel-for-dom-requestinit-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#dom-requestinit-headers">#dom-requestinit-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-headers">5.4. Request class</a> <a href="#ref-for-dom-requestinit-headers①">(2)</a> <a href="#ref-for-dom-requestinit-headers②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-body">
-   <b><a href="#dom-requestinit-body">#dom-requestinit-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-body" class="dfn-panel" data-for="dom-requestinit-body" id="infopanel-for-dom-requestinit-body" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-body" style="display:none">Info about the 'body' definition.</span><b><a href="#dom-requestinit-body">#dom-requestinit-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-body">5.4. Request class</a> <a href="#ref-for-dom-requestinit-body①">(2)</a> <a href="#ref-for-dom-requestinit-body②">(3)</a> <a href="#ref-for-dom-requestinit-body③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-referrer">
-   <b><a href="#dom-requestinit-referrer">#dom-requestinit-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-referrer" class="dfn-panel" data-for="dom-requestinit-referrer" id="infopanel-for-dom-requestinit-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-requestinit-referrer">#dom-requestinit-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-referrer">5.4. Request class</a> <a href="#ref-for-dom-requestinit-referrer①">(2)</a> <a href="#ref-for-dom-requestinit-referrer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-referrerpolicy">
-   <b><a href="#dom-requestinit-referrerpolicy">#dom-requestinit-referrerpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-referrerpolicy" class="dfn-panel" data-for="dom-requestinit-referrerpolicy" id="infopanel-for-dom-requestinit-referrerpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-referrerpolicy" style="display:none">Info about the 'referrerPolicy' definition.</span><b><a href="#dom-requestinit-referrerpolicy">#dom-requestinit-referrerpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-referrerpolicy">5.4. Request class</a> <a href="#ref-for-dom-requestinit-referrerpolicy①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-mode">
-   <b><a href="#dom-requestinit-mode">#dom-requestinit-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-mode" class="dfn-panel" data-for="dom-requestinit-mode" id="infopanel-for-dom-requestinit-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-requestinit-mode">#dom-requestinit-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-mode">5.4. Request class</a> <a href="#ref-for-dom-requestinit-mode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-credentials">
-   <b><a href="#dom-requestinit-credentials">#dom-requestinit-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-credentials" class="dfn-panel" data-for="dom-requestinit-credentials" id="infopanel-for-dom-requestinit-credentials" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-credentials" style="display:none">Info about the 'credentials' definition.</span><b><a href="#dom-requestinit-credentials">#dom-requestinit-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-credentials">5.4. Request class</a> <a href="#ref-for-dom-requestinit-credentials①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-cache">
-   <b><a href="#dom-requestinit-cache">#dom-requestinit-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-cache" class="dfn-panel" data-for="dom-requestinit-cache" id="infopanel-for-dom-requestinit-cache" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-cache" style="display:none">Info about the 'cache' definition.</span><b><a href="#dom-requestinit-cache">#dom-requestinit-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-cache">5.4. Request class</a> <a href="#ref-for-dom-requestinit-cache①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-redirect">
-   <b><a href="#dom-requestinit-redirect">#dom-requestinit-redirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-redirect" class="dfn-panel" data-for="dom-requestinit-redirect" id="infopanel-for-dom-requestinit-redirect" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-redirect" style="display:none">Info about the 'redirect' definition.</span><b><a href="#dom-requestinit-redirect">#dom-requestinit-redirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-redirect">5.4. Request class</a> <a href="#ref-for-dom-requestinit-redirect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-integrity">
-   <b><a href="#dom-requestinit-integrity">#dom-requestinit-integrity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-integrity" class="dfn-panel" data-for="dom-requestinit-integrity" id="infopanel-for-dom-requestinit-integrity" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-integrity" style="display:none">Info about the 'integrity' definition.</span><b><a href="#dom-requestinit-integrity">#dom-requestinit-integrity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-integrity">5.4. Request class</a> <a href="#ref-for-dom-requestinit-integrity①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-keepalive">
-   <b><a href="#dom-requestinit-keepalive">#dom-requestinit-keepalive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-keepalive" class="dfn-panel" data-for="dom-requestinit-keepalive" id="infopanel-for-dom-requestinit-keepalive" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-keepalive" style="display:none">Info about the 'keepalive' definition.</span><b><a href="#dom-requestinit-keepalive">#dom-requestinit-keepalive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-keepalive">5.4. Request class</a> <a href="#ref-for-dom-requestinit-keepalive①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-signal">
-   <b><a href="#dom-requestinit-signal">#dom-requestinit-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-signal" class="dfn-panel" data-for="dom-requestinit-signal" id="infopanel-for-dom-requestinit-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-requestinit-signal">#dom-requestinit-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-signal">5.4. Request class</a> <a href="#ref-for-dom-requestinit-signal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-requestinit-window">
-   <b><a href="#dom-requestinit-window">#dom-requestinit-window</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-requestinit-window" class="dfn-panel" data-for="dom-requestinit-window" id="infopanel-for-dom-requestinit-window" role="dialog">
+   <span id="infopaneltitle-for-dom-requestinit-window" style="display:none">Info about the 'window' definition.</span><b><a href="#dom-requestinit-window">#dom-requestinit-window</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-requestinit-window">5.4. Request class</a> <a href="#ref-for-dom-requestinit-window①">(2)</a> <a href="#ref-for-dom-requestinit-window②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestdestination">
-   <b><a href="#requestdestination">#requestdestination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestdestination" class="dfn-panel" data-for="requestdestination" id="infopanel-for-requestdestination" role="dialog">
+   <span id="infopaneltitle-for-requestdestination" style="display:none">Info about the 'RequestDestination' definition.</span><b><a href="#requestdestination">#requestdestination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestdestination">5.4. Request class</a> <a href="#ref-for-requestdestination①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestmode">
-   <b><a href="#requestmode">#requestmode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestmode" class="dfn-panel" data-for="requestmode" id="infopanel-for-requestmode" role="dialog">
+   <span id="infopaneltitle-for-requestmode" style="display:none">Info about the 'RequestMode' definition.</span><b><a href="#requestmode">#requestmode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestmode">5.4. Request class</a> <a href="#ref-for-requestmode①">(2)</a> <a href="#ref-for-requestmode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestcredentials">
-   <b><a href="#requestcredentials">#requestcredentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestcredentials" class="dfn-panel" data-for="requestcredentials" id="infopanel-for-requestcredentials" role="dialog">
+   <span id="infopaneltitle-for-requestcredentials" style="display:none">Info about the 'RequestCredentials' definition.</span><b><a href="#requestcredentials">#requestcredentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestcredentials">5.4. Request class</a> <a href="#ref-for-requestcredentials①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestcache">
-   <b><a href="#requestcache">#requestcache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestcache" class="dfn-panel" data-for="requestcache" id="infopanel-for-requestcache" role="dialog">
+   <span id="infopaneltitle-for-requestcache" style="display:none">Info about the 'RequestCache' definition.</span><b><a href="#requestcache">#requestcache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestcache">5.4. Request class</a> <a href="#ref-for-requestcache①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="requestredirect">
-   <b><a href="#requestredirect">#requestredirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-requestredirect" class="dfn-panel" data-for="requestredirect" id="infopanel-for-requestredirect" role="dialog">
+   <span id="infopaneltitle-for-requestredirect" style="display:none">Info about the 'RequestRedirect' definition.</span><b><a href="#requestredirect">#requestredirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-requestredirect">5.4. Request class</a> <a href="#ref-for-requestredirect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-request-request">
-   <b><a href="#concept-request-request">#concept-request-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-request-request" class="dfn-panel" data-for="concept-request-request" id="infopanel-for-concept-request-request" role="dialog">
+   <span id="infopaneltitle-for-concept-request-request" style="display:none">Info about the 'request' definition.</span><b><a href="#concept-request-request">#concept-request-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-request">5.4. Request class</a> <a href="#ref-for-concept-request-request①">(2)</a> <a href="#ref-for-concept-request-request②">(3)</a> <a href="#ref-for-concept-request-request③">(4)</a> <a href="#ref-for-concept-request-request④">(5)</a> <a href="#ref-for-concept-request-request⑤">(6)</a> <a href="#ref-for-concept-request-request⑥">(7)</a> <a href="#ref-for-concept-request-request⑦">(8)</a> <a href="#ref-for-concept-request-request⑧">(9)</a> <a href="#ref-for-concept-request-request⑨">(10)</a> <a href="#ref-for-concept-request-request①⓪">(11)</a> <a href="#ref-for-concept-request-request①①">(12)</a> <a href="#ref-for-concept-request-request①②">(13)</a> <a href="#ref-for-concept-request-request①③">(14)</a> <a href="#ref-for-concept-request-request①④">(15)</a> <a href="#ref-for-concept-request-request①⑤">(16)</a> <a href="#ref-for-concept-request-request①⑥">(17)</a> <a href="#ref-for-concept-request-request①⑦">(18)</a> <a href="#ref-for-concept-request-request①⑧">(19)</a> <a href="#ref-for-concept-request-request①⑨">(20)</a> <a href="#ref-for-concept-request-request②⓪">(21)</a> <a href="#ref-for-concept-request-request②①">(22)</a> <a href="#ref-for-concept-request-request②②">(23)</a> <a href="#ref-for-concept-request-request②③">(24)</a> <a href="#ref-for-concept-request-request②④">(25)</a> <a href="#ref-for-concept-request-request②⑤">(26)</a> <a href="#ref-for-concept-request-request②⑥">(27)</a>
     <li><a href="#ref-for-concept-request-request②⑦">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-headers">
-   <b><a href="#request-headers">#request-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-headers" class="dfn-panel" data-for="request-headers" id="infopanel-for-request-headers" role="dialog">
+   <span id="infopaneltitle-for-request-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#request-headers">#request-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-headers">5.4. Request class</a> <a href="#ref-for-request-headers①">(2)</a> <a href="#ref-for-request-headers②">(3)</a> <a href="#ref-for-request-headers③">(4)</a> <a href="#ref-for-request-headers④">(5)</a> <a href="#ref-for-request-headers⑤">(6)</a> <a href="#ref-for-request-headers⑥">(7)</a> <a href="#ref-for-request-headers⑦">(8)</a> <a href="#ref-for-request-headers⑧">(9)</a> <a href="#ref-for-request-headers⑨">(10)</a> <a href="#ref-for-request-headers①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-signal">
-   <b><a href="#request-signal">#request-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-signal" class="dfn-panel" data-for="request-signal" id="infopanel-for-request-signal" role="dialog">
+   <span id="infopaneltitle-for-request-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#request-signal">#request-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-signal">5.4. Request class</a> <a href="#ref-for-request-signal①">(2)</a> <a href="#ref-for-request-signal②">(3)</a> <a href="#ref-for-request-signal③">(4)</a> <a href="#ref-for-request-signal④">(5)</a> <a href="#ref-for-request-signal⑤">(6)</a> <a href="#ref-for-request-signal⑥">(7)</a>
     <li><a href="#ref-for-request-signal⑦">5.6. Fetch method</a> <a href="#ref-for-request-signal⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-create">
-   <b><a href="#request-create">#request-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-create" class="dfn-panel" data-for="request-create" id="infopanel-for-request-create" role="dialog">
+   <span id="infopaneltitle-for-request-create" style="display:none">Info about the 'create' definition.</span><b><a href="#request-create">#request-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-create">5.4. Request class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request">
-   <b><a href="#dom-request">#dom-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request" class="dfn-panel" data-for="dom-request" id="infopanel-for-dom-request" role="dialog">
+   <span id="infopaneltitle-for-dom-request" style="display:none">Info about the 'new Request(input, init)' definition.</span><b><a href="#dom-request">#dom-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request">5.4. Request class</a> <a href="#ref-for-dom-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-method">
-   <b><a href="#dom-request-method">#dom-request-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-method" class="dfn-panel" data-for="dom-request-method" id="infopanel-for-dom-request-method" role="dialog">
+   <span id="infopaneltitle-for-dom-request-method" style="display:none">Info about the 'method' definition.</span><b><a href="#dom-request-method">#dom-request-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-method">5.4. Request class</a> <a href="#ref-for-dom-request-method①">(2)</a> <a href="#ref-for-dom-request-method②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-url">
-   <b><a href="#dom-request-url">#dom-request-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-url" class="dfn-panel" data-for="dom-request-url" id="infopanel-for-dom-request-url" role="dialog">
+   <span id="infopaneltitle-for-dom-request-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-request-url">#dom-request-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-url">5.4. Request class</a> <a href="#ref-for-dom-request-url①">(2)</a> <a href="#ref-for-dom-request-url②">(3)</a> <a href="#ref-for-dom-request-url③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-headers">
-   <b><a href="#dom-request-headers">#dom-request-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-headers" class="dfn-panel" data-for="dom-request-headers" id="infopanel-for-dom-request-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-request-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#dom-request-headers">#dom-request-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-headers">5.4. Request class</a> <a href="#ref-for-dom-request-headers①">(2)</a> <a href="#ref-for-dom-request-headers②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-destination">
-   <b><a href="#dom-request-destination">#dom-request-destination</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-destination" class="dfn-panel" data-for="dom-request-destination" id="infopanel-for-dom-request-destination" role="dialog">
+   <span id="infopaneltitle-for-dom-request-destination" style="display:none">Info about the 'destination' definition.</span><b><a href="#dom-request-destination">#dom-request-destination</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-destination">5.4. Request class</a> <a href="#ref-for-dom-request-destination①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-referrer">
-   <b><a href="#dom-request-referrer">#dom-request-referrer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-referrer" class="dfn-panel" data-for="dom-request-referrer" id="infopanel-for-dom-request-referrer" role="dialog">
+   <span id="infopaneltitle-for-dom-request-referrer" style="display:none">Info about the 'referrer' definition.</span><b><a href="#dom-request-referrer">#dom-request-referrer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-referrer">5.4. Request class</a> <a href="#ref-for-dom-request-referrer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-referrerpolicy">
-   <b><a href="#dom-request-referrerpolicy">#dom-request-referrerpolicy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-referrerpolicy" class="dfn-panel" data-for="dom-request-referrerpolicy" id="infopanel-for-dom-request-referrerpolicy" role="dialog">
+   <span id="infopaneltitle-for-dom-request-referrerpolicy" style="display:none">Info about the 'referrerPolicy' definition.</span><b><a href="#dom-request-referrerpolicy">#dom-request-referrerpolicy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-referrerpolicy">5.4. Request class</a> <a href="#ref-for-dom-request-referrerpolicy①">(2)</a> <a href="#ref-for-dom-request-referrerpolicy②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-mode">
-   <b><a href="#dom-request-mode">#dom-request-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-mode" class="dfn-panel" data-for="dom-request-mode" id="infopanel-for-dom-request-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-request-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-request-mode">#dom-request-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-mode">5.4. Request class</a> <a href="#ref-for-dom-request-mode①">(2)</a> <a href="#ref-for-dom-request-mode②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-credentials">
-   <b><a href="#dom-request-credentials">#dom-request-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-credentials" class="dfn-panel" data-for="dom-request-credentials" id="infopanel-for-dom-request-credentials" role="dialog">
+   <span id="infopaneltitle-for-dom-request-credentials" style="display:none">Info about the 'credentials' definition.</span><b><a href="#dom-request-credentials">#dom-request-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-credentials">5.4. Request class</a> <a href="#ref-for-dom-request-credentials①">(2)</a> <a href="#ref-for-dom-request-credentials②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-cache">
-   <b><a href="#dom-request-cache">#dom-request-cache</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-cache" class="dfn-panel" data-for="dom-request-cache" id="infopanel-for-dom-request-cache" role="dialog">
+   <span id="infopaneltitle-for-dom-request-cache" style="display:none">Info about the 'cache' definition.</span><b><a href="#dom-request-cache">#dom-request-cache</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-cache">5.4. Request class</a> <a href="#ref-for-dom-request-cache①">(2)</a> <a href="#ref-for-dom-request-cache②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-redirect">
-   <b><a href="#dom-request-redirect">#dom-request-redirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-redirect" class="dfn-panel" data-for="dom-request-redirect" id="infopanel-for-dom-request-redirect" role="dialog">
+   <span id="infopaneltitle-for-dom-request-redirect" style="display:none">Info about the 'redirect' definition.</span><b><a href="#dom-request-redirect">#dom-request-redirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-redirect">5.4. Request class</a> <a href="#ref-for-dom-request-redirect①">(2)</a> <a href="#ref-for-dom-request-redirect②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-integrity">
-   <b><a href="#dom-request-integrity">#dom-request-integrity</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-integrity" class="dfn-panel" data-for="dom-request-integrity" id="infopanel-for-dom-request-integrity" role="dialog">
+   <span id="infopaneltitle-for-dom-request-integrity" style="display:none">Info about the 'integrity' definition.</span><b><a href="#dom-request-integrity">#dom-request-integrity</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-integrity">5.4. Request class</a> <a href="#ref-for-dom-request-integrity①">(2)</a> <a href="#ref-for-dom-request-integrity②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-keepalive">
-   <b><a href="#dom-request-keepalive">#dom-request-keepalive</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-keepalive" class="dfn-panel" data-for="dom-request-keepalive" id="infopanel-for-dom-request-keepalive" role="dialog">
+   <span id="infopaneltitle-for-dom-request-keepalive" style="display:none">Info about the 'keepalive' definition.</span><b><a href="#dom-request-keepalive">#dom-request-keepalive</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-keepalive">5.4. Request class</a> <a href="#ref-for-dom-request-keepalive①">(2)</a> <a href="#ref-for-dom-request-keepalive②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-isreloadnavigation">
-   <b><a href="#dom-request-isreloadnavigation">#dom-request-isreloadnavigation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-isreloadnavigation" class="dfn-panel" data-for="dom-request-isreloadnavigation" id="infopanel-for-dom-request-isreloadnavigation" role="dialog">
+   <span id="infopaneltitle-for-dom-request-isreloadnavigation" style="display:none">Info about the 'isReloadNavigation' definition.</span><b><a href="#dom-request-isreloadnavigation">#dom-request-isreloadnavigation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-isreloadnavigation">5.4. Request class</a> <a href="#ref-for-dom-request-isreloadnavigation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-ishistorynavigation">
-   <b><a href="#dom-request-ishistorynavigation">#dom-request-ishistorynavigation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-ishistorynavigation" class="dfn-panel" data-for="dom-request-ishistorynavigation" id="infopanel-for-dom-request-ishistorynavigation" role="dialog">
+   <span id="infopaneltitle-for-dom-request-ishistorynavigation" style="display:none">Info about the 'isHistoryNavigation' definition.</span><b><a href="#dom-request-ishistorynavigation">#dom-request-ishistorynavigation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-ishistorynavigation">5.4. Request class</a> <a href="#ref-for-dom-request-ishistorynavigation①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-signal">
-   <b><a href="#dom-request-signal">#dom-request-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-signal" class="dfn-panel" data-for="dom-request-signal" id="infopanel-for-dom-request-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-request-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-request-signal">#dom-request-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-signal">5.4. Request class</a> <a href="#ref-for-dom-request-signal①">(2)</a> <a href="#ref-for-dom-request-signal②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-request-clone">
-   <b><a href="#dom-request-clone">#dom-request-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-request-clone" class="dfn-panel" data-for="dom-request-clone" id="infopanel-for-dom-request-clone" role="dialog">
+   <span id="infopaneltitle-for-dom-request-clone" style="display:none">Info about the 'clone()' definition.</span><b><a href="#dom-request-clone">#dom-request-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-request-clone">5.4. Request class</a> <a href="#ref-for-dom-request-clone①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response">
-   <b><a href="#response">#response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response" class="dfn-panel" data-for="response" id="infopanel-for-response" role="dialog">
+   <span id="infopaneltitle-for-response" style="display:none">Info about the 'Response' definition.</span><b><a href="#response">#response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">2.2.6. Responses</a>
     <li><a href="#ref-for-response①">5.5. Response class</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a> <a href="#ref-for-response④">(4)</a> <a href="#ref-for-response⑤">(5)</a> <a href="#ref-for-response⑥">(6)</a> <a href="#ref-for-response⑦">(7)</a> <a href="#ref-for-response⑧">(8)</a> <a href="#ref-for-response⑨">(9)</a> <a href="#ref-for-response①⓪">(10)</a> <a href="#ref-for-response①①">(11)</a> <a href="#ref-for-response①②">(12)</a> <a href="#ref-for-response①③">(13)</a> <a href="#ref-for-response①④">(14)</a> <a href="#ref-for-response①⑤">(15)</a> <a href="#ref-for-response①⑥">(16)</a> <a href="#ref-for-response①⑦">(17)</a> <a href="#ref-for-response①⑧">(18)</a>
     <li><a href="#ref-for-response①⑨">5.6. Fetch method</a> <a href="#ref-for-response②⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="responseinit">
-   <b><a href="#responseinit">#responseinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-responseinit" class="dfn-panel" data-for="responseinit" id="infopanel-for-responseinit" role="dialog">
+   <span id="infopaneltitle-for-responseinit" style="display:none">Info about the 'ResponseInit' definition.</span><b><a href="#responseinit">#responseinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responseinit">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-responseinit-status">
-   <b><a href="#dom-responseinit-status">#dom-responseinit-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-responseinit-status" class="dfn-panel" data-for="dom-responseinit-status" id="infopanel-for-dom-responseinit-status" role="dialog">
+   <span id="infopaneltitle-for-dom-responseinit-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-responseinit-status">#dom-responseinit-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-responseinit-status">5.5. Response class</a> <a href="#ref-for-dom-responseinit-status①">(2)</a> <a href="#ref-for-dom-responseinit-status②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-responseinit-statustext">
-   <b><a href="#dom-responseinit-statustext">#dom-responseinit-statustext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-responseinit-statustext" class="dfn-panel" data-for="dom-responseinit-statustext" id="infopanel-for-dom-responseinit-statustext" role="dialog">
+   <span id="infopaneltitle-for-dom-responseinit-statustext" style="display:none">Info about the 'statusText' definition.</span><b><a href="#dom-responseinit-statustext">#dom-responseinit-statustext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-responseinit-statustext">5.5. Response class</a> <a href="#ref-for-dom-responseinit-statustext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-responseinit-headers">
-   <b><a href="#dom-responseinit-headers">#dom-responseinit-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-responseinit-headers" class="dfn-panel" data-for="dom-responseinit-headers" id="infopanel-for-dom-responseinit-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-responseinit-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#dom-responseinit-headers">#dom-responseinit-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-responseinit-headers">5.5. Response class</a> <a href="#ref-for-dom-responseinit-headers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="responsetype">
-   <b><a href="#responsetype">#responsetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-responsetype" class="dfn-panel" data-for="responsetype" id="infopanel-for-responsetype" role="dialog">
+   <span id="infopaneltitle-for-responsetype" style="display:none">Info about the 'ResponseType' definition.</span><b><a href="#responsetype">#responsetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-responsetype">5.5. Response class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-response-response">
-   <b><a href="#concept-response-response">#concept-response-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-response-response" class="dfn-panel" data-for="concept-response-response" id="infopanel-for-concept-response-response" role="dialog">
+   <span id="infopaneltitle-for-concept-response-response" style="display:none">Info about the 'response' definition.</span><b><a href="#concept-response-response">#concept-response-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-response">5.5. Response class</a> <a href="#ref-for-concept-response-response①">(2)</a> <a href="#ref-for-concept-response-response②">(3)</a> <a href="#ref-for-concept-response-response③">(4)</a> <a href="#ref-for-concept-response-response④">(5)</a> <a href="#ref-for-concept-response-response⑤">(6)</a> <a href="#ref-for-concept-response-response⑥">(7)</a> <a href="#ref-for-concept-response-response⑦">(8)</a> <a href="#ref-for-concept-response-response⑧">(9)</a> <a href="#ref-for-concept-response-response⑨">(10)</a> <a href="#ref-for-concept-response-response①⓪">(11)</a> <a href="#ref-for-concept-response-response①①">(12)</a> <a href="#ref-for-concept-response-response①②">(13)</a> <a href="#ref-for-concept-response-response①③">(14)</a> <a href="#ref-for-concept-response-response①④">(15)</a> <a href="#ref-for-concept-response-response①⑤">(16)</a> <a href="#ref-for-concept-response-response①⑥">(17)</a> <a href="#ref-for-concept-response-response①⑦">(18)</a> <a href="#ref-for-concept-response-response①⑧">(19)</a> <a href="#ref-for-concept-response-response①⑨">(20)</a>
     <li><a href="#ref-for-concept-response-response②⓪">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-headers">
-   <b><a href="#response-headers">#response-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-headers" class="dfn-panel" data-for="response-headers" id="infopanel-for-response-headers" role="dialog">
+   <span id="infopaneltitle-for-response-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#response-headers">#response-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-headers">5.5. Response class</a> <a href="#ref-for-response-headers①">(2)</a> <a href="#ref-for-response-headers②">(3)</a> <a href="#ref-for-response-headers③">(4)</a> <a href="#ref-for-response-headers④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-create">
-   <b><a href="#response-create">#response-create</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-create" class="dfn-panel" data-for="response-create" id="infopanel-for-response-create" role="dialog">
+   <span id="infopaneltitle-for-response-create" style="display:none">Info about the 'create' definition.</span><b><a href="#response-create">#response-create</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-create">5.5. Response class</a> <a href="#ref-for-response-create①">(2)</a> <a href="#ref-for-response-create②">(3)</a>
     <li><a href="#ref-for-response-create③">5.6. Fetch method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response">
-   <b><a href="#dom-response">#dom-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response" class="dfn-panel" data-for="dom-response" id="infopanel-for-dom-response" role="dialog">
+   <span id="infopaneltitle-for-dom-response" style="display:none">Info about the 'new Response(body, init)' definition.</span><b><a href="#dom-response">#dom-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response">5.5. Response class</a> <a href="#ref-for-dom-response①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-error">
-   <b><a href="#dom-response-error">#dom-response-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-error" class="dfn-panel" data-for="dom-response-error" id="infopanel-for-dom-response-error" role="dialog">
+   <span id="infopaneltitle-for-dom-response-error" style="display:none">Info about the 'error()' definition.</span><b><a href="#dom-response-error">#dom-response-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-error">5.5. Response class</a> <a href="#ref-for-dom-response-error①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-redirect">
-   <b><a href="#dom-response-redirect">#dom-response-redirect</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-redirect" class="dfn-panel" data-for="dom-response-redirect" id="infopanel-for-dom-response-redirect" role="dialog">
+   <span id="infopaneltitle-for-dom-response-redirect" style="display:none">Info about the 'redirect(url, status)' definition.</span><b><a href="#dom-response-redirect">#dom-response-redirect</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-redirect">5.5. Response class</a> <a href="#ref-for-dom-response-redirect①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-type">
-   <b><a href="#dom-response-type">#dom-response-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-type" class="dfn-panel" data-for="dom-response-type" id="infopanel-for-dom-response-type" role="dialog">
+   <span id="infopaneltitle-for-dom-response-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-response-type">#dom-response-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-type">5.5. Response class</a> <a href="#ref-for-dom-response-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-url">
-   <b><a href="#dom-response-url">#dom-response-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-url" class="dfn-panel" data-for="dom-response-url" id="infopanel-for-dom-response-url" role="dialog">
+   <span id="infopaneltitle-for-dom-response-url" style="display:none">Info about the 'url' definition.</span><b><a href="#dom-response-url">#dom-response-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-url">5.5. Response class</a> <a href="#ref-for-dom-response-url①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-redirected">
-   <b><a href="#dom-response-redirected">#dom-response-redirected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-redirected" class="dfn-panel" data-for="dom-response-redirected" id="infopanel-for-dom-response-redirected" role="dialog">
+   <span id="infopaneltitle-for-dom-response-redirected" style="display:none">Info about the 'redirected' definition.</span><b><a href="#dom-response-redirected">#dom-response-redirected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-redirected">5.5. Response class</a> <a href="#ref-for-dom-response-redirected①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-status">
-   <b><a href="#dom-response-status">#dom-response-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-status" class="dfn-panel" data-for="dom-response-status" id="infopanel-for-dom-response-status" role="dialog">
+   <span id="infopaneltitle-for-dom-response-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-response-status">#dom-response-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-status">5.5. Response class</a> <a href="#ref-for-dom-response-status①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-ok">
-   <b><a href="#dom-response-ok">#dom-response-ok</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-ok" class="dfn-panel" data-for="dom-response-ok" id="infopanel-for-dom-response-ok" role="dialog">
+   <span id="infopaneltitle-for-dom-response-ok" style="display:none">Info about the 'ok' definition.</span><b><a href="#dom-response-ok">#dom-response-ok</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-ok">2.2.6. Responses</a>
     <li><a href="#ref-for-dom-response-ok①">5.5. Response class</a> <a href="#ref-for-dom-response-ok②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-statustext">
-   <b><a href="#dom-response-statustext">#dom-response-statustext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-statustext" class="dfn-panel" data-for="dom-response-statustext" id="infopanel-for-dom-response-statustext" role="dialog">
+   <span id="infopaneltitle-for-dom-response-statustext" style="display:none">Info about the 'statusText' definition.</span><b><a href="#dom-response-statustext">#dom-response-statustext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-statustext">5.5. Response class</a> <a href="#ref-for-dom-response-statustext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-headers">
-   <b><a href="#dom-response-headers">#dom-response-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-headers" class="dfn-panel" data-for="dom-response-headers" id="infopanel-for-dom-response-headers" role="dialog">
+   <span id="infopaneltitle-for-dom-response-headers" style="display:none">Info about the 'headers' definition.</span><b><a href="#dom-response-headers">#dom-response-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-headers">5.5. Response class</a> <a href="#ref-for-dom-response-headers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-response-clone">
-   <b><a href="#dom-response-clone">#dom-response-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-response-clone" class="dfn-panel" data-for="dom-response-clone" id="infopanel-for-dom-response-clone" role="dialog">
+   <span id="infopaneltitle-for-dom-response-clone" style="display:none">Info about the 'clone()' definition.</span><b><a href="#dom-response-clone">#dom-response-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-response-clone">5.5. Response class</a> <a href="#ref-for-dom-response-clone①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-global-fetch">
-   <b><a href="#dom-global-fetch">#dom-global-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-global-fetch" class="dfn-panel" data-for="dom-global-fetch" id="infopanel-for-dom-global-fetch" role="dialog">
+   <span id="infopaneltitle-for-dom-global-fetch" style="display:none">Info about the 'fetch(input, init)' definition.</span><b><a href="#dom-global-fetch">#dom-global-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-global-fetch">1. Preface</a>
     <li><a href="#ref-for-dom-global-fetch①">2.2.5. Requests</a> <a href="#ref-for-dom-global-fetch②">(2)</a>
@@ -11898,73 +11900,73 @@ response to request be blocked due to nosniff?</a>
     <li><a href="#ref-for-dom-global-fetch⑦">5.7. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-fetch">
-   <b><a href="#abort-fetch">#abort-fetch</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-fetch" class="dfn-panel" data-for="abort-fetch" id="infopanel-for-abort-fetch" role="dialog">
+   <span id="infopaneltitle-for-abort-fetch" style="display:none">Info about the 'abort fetch' definition.</span><b><a href="#abort-fetch">#abort-fetch</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-fetch">5.6. Fetch method</a> <a href="#ref-for-abort-fetch①">(2)</a> <a href="#ref-for-abort-fetch②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-websocket-connection-obtain">
-   <b><a href="#concept-websocket-connection-obtain">#concept-websocket-connection-obtain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-websocket-connection-obtain" class="dfn-panel" data-for="concept-websocket-connection-obtain" id="infopanel-for-concept-websocket-connection-obtain" role="dialog">
+   <span id="infopaneltitle-for-concept-websocket-connection-obtain" style="display:none">Info about the 'obtain a WebSocket connection' definition.</span><b><a href="#concept-websocket-connection-obtain">#concept-websocket-connection-obtain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-websocket-connection-obtain">4.7. HTTP-network fetch</a>
     <li><a href="#ref-for-concept-websocket-connection-obtain①">6.1. Connections</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-websocket-establish">
-   <b><a href="#concept-websocket-establish">#concept-websocket-establish</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-websocket-establish" class="dfn-panel" data-for="concept-websocket-establish" id="infopanel-for-concept-websocket-establish" role="dialog">
+   <span id="infopaneltitle-for-concept-websocket-establish" style="display:none">Info about the 'establish a WebSocket connection' definition.</span><b><a href="#concept-websocket-establish">#concept-websocket-establish</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-websocket-establish">2.2.2. Headers</a>
     <li><a href="#ref-for-concept-websocket-establish①">2.2.5. Requests</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fail-the-websocket-connection">
-   <b><a href="#fail-the-websocket-connection">#fail-the-websocket-connection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fail-the-websocket-connection" class="dfn-panel" data-for="fail-the-websocket-connection" id="infopanel-for-fail-the-websocket-connection" role="dialog">
+   <span id="infopaneltitle-for-fail-the-websocket-connection" style="display:none">Info about the 'Fail the WebSocket connection' definition.</span><b><a href="#fail-the-websocket-connection">#fail-the-websocket-connection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fail-the-websocket-connection">6.2. Opening handshake</a> <a href="#ref-for-fail-the-websocket-connection①">(2)</a> <a href="#ref-for-fail-the-websocket-connection②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-websocket-connection-is-established">
-   <b><a href="#the-websocket-connection-is-established">#the-websocket-connection-is-established</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-websocket-connection-is-established" class="dfn-panel" data-for="the-websocket-connection-is-established" id="infopanel-for-the-websocket-connection-is-established" role="dialog">
+   <span id="infopaneltitle-for-the-websocket-connection-is-established" style="display:none">Info about the 'the WebSocket connection is established' definition.</span><b><a href="#the-websocket-connection-is-established">#the-websocket-connection-is-established</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-websocket-connection-is-established">6.2. Opening handshake</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-url-struct">
-   <b><a href="#data-url-struct">#data-url-struct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-url-struct" class="dfn-panel" data-for="data-url-struct" id="infopanel-for-data-url-struct" role="dialog">
+   <span id="infopaneltitle-for-data-url-struct" style="display:none">Info about the 'data: URL struct' definition.</span><b><a href="#data-url-struct">#data-url-struct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-url-struct">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-url-struct-mime-type">
-   <b><a href="#data-url-struct-mime-type">#data-url-struct-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-url-struct-mime-type" class="dfn-panel" data-for="data-url-struct-mime-type" id="infopanel-for-data-url-struct-mime-type" role="dialog">
+   <span id="infopaneltitle-for-data-url-struct-mime-type" style="display:none">Info about the 'MIME type' definition.</span><b><a href="#data-url-struct-mime-type">#data-url-struct-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-url-struct-mime-type">4.2. Scheme fetch</a>
     <li><a href="#ref-for-data-url-struct-mime-type①">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-url-struct-body">
-   <b><a href="#data-url-struct-body">#data-url-struct-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-url-struct-body" class="dfn-panel" data-for="data-url-struct-body" id="infopanel-for-data-url-struct-body" role="dialog">
+   <span id="infopaneltitle-for-data-url-struct-body" style="display:none">Info about the 'body' definition.</span><b><a href="#data-url-struct-body">#data-url-struct-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-url-struct-body">4.2. Scheme fetch</a>
     <li><a href="#ref-for-data-url-struct-body①">7. data: URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data-url-processor">
-   <b><a href="#data-url-processor">#data-url-processor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data-url-processor" class="dfn-panel" data-for="data-url-processor" id="infopanel-for-data-url-processor" role="dialog">
+   <span id="infopaneltitle-for-data-url-processor" style="display:none">Info about the 'data: URL processor' definition.</span><b><a href="#data-url-processor">#data-url-processor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data-url-processor">4.2. Scheme fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-header-layer-division">
-   <b><a href="#http-header-layer-division">#http-header-layer-division</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-header-layer-division" class="dfn-panel" data-for="http-header-layer-division" id="infopanel-for-http-header-layer-division" role="dialog">
+   <span id="infopaneltitle-for-http-header-layer-division" style="display:none">Info about the 'HTTP header layer division' definition.</span><b><a href="#http-header-layer-division">#http-header-layer-division</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-header-layer-division">4.6. HTTP-network-or-cache fetch</a>
     <li><a href="#ref-for-http-header-layer-division">HTTP header layer division</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="atomic-http-redirect-handling">
-   <b><a href="#atomic-http-redirect-handling">#atomic-http-redirect-handling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-atomic-http-redirect-handling" class="dfn-panel" data-for="atomic-http-redirect-handling" id="infopanel-for-atomic-http-redirect-handling" role="dialog">
+   <span id="infopaneltitle-for-atomic-http-redirect-handling" style="display:none">Info about the 'Atomic HTTP redirect handling' definition.</span><b><a href="#atomic-http-redirect-handling">#atomic-http-redirect-handling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-atomic-http-redirect-handling">2.2.5. Requests</a>
     <li><a href="#ref-for-atomic-http-redirect-handling①">2.2.6. Responses</a>
@@ -11973,57 +11975,113 @@ response to request be blocked due to nosniff?</a>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/fullscreen/fullscreen.html
+++ b/tests/github/whatwg/fullscreen/fullscreen.html
@@ -874,63 +874,63 @@ if ("serviceWorker" in navigator) {
    <li><a href="#unfullscreen-a-document">unfullscreen a document</a><span>, in § 2</span>
    <li><a href="#unfullscreen-an-element">unfullscreen an element</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dfn-triggered-by-a-user-generated-orientation-change">
-   <a href="https://w3c.github.io/screen-orientation/#dfn-triggered-by-a-user-generated-orientation-change">https://w3c.github.io/screen-orientation/#dfn-triggered-by-a-user-generated-orientation-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-triggered-by-a-user-generated-orientation-change" class="dfn-panel" data-for="term-for-dfn-triggered-by-a-user-generated-orientation-change" id="infopanel-for-term-for-dfn-triggered-by-a-user-generated-orientation-change" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-triggered-by-a-user-generated-orientation-change" style="display:none">Info about the 'triggered by a user generated orientation change' external reference.</span><a href="https://w3c.github.io/screen-orientation/#dfn-triggered-by-a-user-generated-orientation-change">https://w3c.github.io/screen-orientation/#dfn-triggered-by-a-user-generated-orientation-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-triggered-by-a-user-generated-orientation-change">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. API</a> <a href="#ref-for-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-documentorshadowroot">
-   <a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-documentorshadowroot" class="dfn-panel" data-for="term-for-documentorshadowroot" id="infopanel-for-term-for-documentorshadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-documentorshadowroot" style="display:none">Info about the 'DocumentOrShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#documentorshadowroot">https://dom.spec.whatwg.org/#documentorshadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documentorshadowroot">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element">
-   <a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element" class="dfn-panel" data-for="term-for-element" id="infopanel-for-term-for-element" role="menu">
+   <span id="infopaneltitle-for-term-for-element" style="display:none">Info about the 'Element' external reference.</span><a href="https://dom.spec.whatwg.org/#element">https://dom.spec.whatwg.org/#element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element">3. API</a> <a href="#ref-for-element①">(2)</a> <a href="#ref-for-element②">(3)</a> <a href="#ref-for-element③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shadowroot">
-   <a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shadowroot" class="dfn-panel" data-for="term-for-shadowroot" id="infopanel-for-term-for-shadowroot" role="menu">
+   <span id="infopaneltitle-for-term-for-shadowroot" style="display:none">Info about the 'ShadowRoot' external reference.</span><a href="https://dom.spec.whatwg.org/#shadowroot">https://dom.spec.whatwg.org/#shadowroot</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shadowroot">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-ancestor">https://dom.spec.whatwg.org/#concept-tree-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-ancestor" class="dfn-panel" data-for="term-for-concept-tree-ancestor" id="infopanel-for-term-for-concept-tree-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-ancestor" style="display:none">Info about the 'ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-ancestor">https://dom.spec.whatwg.org/#concept-tree-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-ancestor">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-composed">
-   <a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-composed" class="dfn-panel" data-for="term-for-dom-event-composed" id="infopanel-for-term-for-dom-event-composed" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-composed" style="display:none">Info about the 'composed' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-composed">https://dom.spec.whatwg.org/#dom-event-composed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-composed">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-connected">
-   <a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-connected" class="dfn-panel" data-for="term-for-connected" id="infopanel-for-term-for-connected" role="menu">
+   <span id="infopaneltitle-for-term-for-connected" style="display:none">Info about the 'connected' external reference.</span><a href="https://dom.spec.whatwg.org/#connected">https://dom.spec.whatwg.org/#connected</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-connected">2. Model</a>
     <li><a href="#ref-for-connected①">3. API</a> <a href="#ref-for-connected②">(2)</a> <a href="#ref-for-connected③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">2. Model</a> <a href="#ref-for-concept-document①">(2)</a> <a href="#ref-for-concept-document②">(3)</a> <a href="#ref-for-concept-document③">(4)</a> <a href="#ref-for-concept-document④">(5)</a>
     <li><a href="#ref-for-concept-document⑤">3. API</a> <a href="#ref-for-concept-document⑥">(2)</a> <a href="#ref-for-concept-document⑦">(3)</a> <a href="#ref-for-concept-document⑧">(4)</a>
@@ -940,196 +940,196 @@ Integration</a>
     <li><a href="#ref-for-concept-document①①">7. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element">
-   <a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element" class="dfn-panel" data-for="term-for-concept-element" id="infopanel-for-term-for-concept-element" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element" style="display:none">Info about the 'element' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element">https://dom.spec.whatwg.org/#concept-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element">2. Model</a> <a href="#ref-for-concept-element①">(2)</a> <a href="#ref-for-concept-element②">(3)</a> <a href="#ref-for-concept-element③">(4)</a> <a href="#ref-for-concept-element④">(5)</a>
     <li><a href="#ref-for-concept-element⑤">3. API</a> <a href="#ref-for-concept-element⑥">(2)</a> <a href="#ref-for-concept-element⑦">(3)</a> <a href="#ref-for-concept-element⑧">(4)</a> <a href="#ref-for-concept-element⑨">(5)</a> <a href="#ref-for-concept-element①⓪">(6)</a>
     <li><a href="#ref-for-concept-element①①">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-documentfragment-host">
-   <a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-documentfragment-host" class="dfn-panel" data-for="term-for-concept-documentfragment-host" id="infopanel-for-term-for-concept-documentfragment-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-documentfragment-host" style="display:none">Info about the 'host' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-documentfragment-host">https://dom.spec.whatwg.org/#concept-documentfragment-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-documentfragment-host">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-element-namespace">
-   <a href="https://dom.spec.whatwg.org/#concept-element-namespace">https://dom.spec.whatwg.org/#concept-element-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-element-namespace" class="dfn-panel" data-for="term-for-concept-element-namespace" id="infopanel-for-term-for-concept-element-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-element-namespace" style="display:none">Info about the 'namespace' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-element-namespace">https://dom.spec.whatwg.org/#concept-element-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-element-namespace">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-document">
-   <a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-document" class="dfn-panel" data-for="term-for-concept-node-document" id="infopanel-for-term-for-concept-node-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-document" style="display:none">Info about the 'node document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-document">https://dom.spec.whatwg.org/#concept-node-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-document">2. Model</a> <a href="#ref-for-concept-node-document①">(2)</a> <a href="#ref-for-concept-node-document②">(3)</a> <a href="#ref-for-concept-node-document③">(4)</a>
     <li><a href="#ref-for-concept-node-document④">3. API</a> <a href="#ref-for-concept-node-document⑤">(2)</a> <a href="#ref-for-concept-node-document⑥">(3)</a> <a href="#ref-for-concept-node-document⑦">(4)</a> <a href="#ref-for-concept-node-document⑧">(5)</a>
     <li><a href="#ref-for-concept-node-document⑨">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-node-remove-ext">
-   <a href="https://dom.spec.whatwg.org/#concept-node-remove-ext">https://dom.spec.whatwg.org/#concept-node-remove-ext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-node-remove-ext" class="dfn-panel" data-for="term-for-concept-node-remove-ext" id="infopanel-for-term-for-concept-node-remove-ext" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-node-remove-ext" style="display:none">Info about the 'removing steps' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-node-remove-ext">https://dom.spec.whatwg.org/#concept-node-remove-ext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-node-remove-ext">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-retarget">
-   <a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-retarget" class="dfn-panel" data-for="term-for-retarget" id="infopanel-for-term-for-retarget" role="menu">
+   <span id="infopaneltitle-for-term-for-retarget" style="display:none">Info about the 'retargeting' external reference.</span><a href="https://dom.spec.whatwg.org/#retarget">https://dom.spec.whatwg.org/#retarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-retarget">3. API</a>
     <li><a href="#ref-for-retarget①">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-root">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-root" class="dfn-panel" data-for="term-for-concept-tree-root" id="infopanel-for-term-for-concept-tree-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-root" style="display:none">Info about the 'root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-root">https://dom.spec.whatwg.org/#concept-tree-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-root">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-element-shadow-host">
-   <a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-element-shadow-host" class="dfn-panel" data-for="term-for-element-shadow-host" id="infopanel-for-term-for-element-shadow-host" role="menu">
+   <span id="infopaneltitle-for-term-for-element-shadow-host" style="display:none">Info about the 'shadow host' external reference.</span><a href="https://dom.spec.whatwg.org/#element-shadow-host">https://dom.spec.whatwg.org/#element-shadow-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-shadow-host">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-root">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-root" class="dfn-panel" data-for="term-for-concept-shadow-root" id="infopanel-for-term-for-concept-shadow-root" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-root" style="display:none">Info about the 'shadow root' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-root">https://dom.spec.whatwg.org/#concept-shadow-root</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-root">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-ancestor">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-inclusive-ancestor" class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-ancestor" id="infopanel-for-term-for-concept-shadow-including-inclusive-ancestor" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-inclusive-ancestor" style="display:none">Info about the 'shadow-including inclusive ancestor' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-inclusive-ancestor">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-descendant">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-inclusive-descendant" class="dfn-panel" data-for="term-for-concept-shadow-including-inclusive-descendant" id="infopanel-for-term-for-concept-shadow-including-inclusive-descendant" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-inclusive-descendant" style="display:none">Info about the 'shadow-including inclusive descendant' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant">https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-inclusive-descendant">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-shadow-including-tree-order" class="dfn-panel" data-for="term-for-concept-shadow-including-tree-order" id="infopanel-for-term-for-concept-shadow-including-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-shadow-including-tree-order" style="display:none">Info about the 'shadow-including tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-shadow-including-tree-order">https://dom.spec.whatwg.org/#concept-shadow-including-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-shadow-including-tree-order">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree">
-   <a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree" class="dfn-panel" data-for="term-for-concept-tree" id="infopanel-for-term-for-concept-tree" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree" style="display:none">Info about the 'tree' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree">https://dom.spec.whatwg.org/#concept-tree</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-order">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-order" class="dfn-panel" data-for="term-for-concept-tree-order" id="infopanel-for-term-for-concept-tree-order" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-order" style="display:none">Info about the 'tree order' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-order">https://dom.spec.whatwg.org/#concept-tree-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-order">3. API</a> <a href="#ref-for-concept-tree-order①">(2)</a> <a href="#ref-for-concept-tree-order②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. API</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-nav-document">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-nav-document" class="dfn-panel" data-for="term-for-nav-document" id="infopanel-for-term-for-nav-document" role="menu">
+   <span id="infopaneltitle-for-term-for-nav-document" style="display:none">Info about the 'active document' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document">https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-nav-document">3. API</a> <a href="#ref-for-nav-document①">(2)</a> <a href="#ref-for-nav-document②">(3)</a>
     <li><a href="#ref-for-nav-document③">4. UI</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-allow">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-allow" class="dfn-panel" data-for="term-for-attr-iframe-allow" id="infopanel-for-term-for-attr-iframe-allow" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-allow" style="display:none">Info about the 'allow' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-allow">6. Permissions Policy
 Integration</a>
     <li><a href="#ref-for-attr-iframe-allow①">7. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-allowed-to-use">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-allowed-to-use" class="dfn-panel" data-for="term-for-allowed-to-use" id="infopanel-for-term-for-allowed-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-allowed-to-use" style="display:none">Info about the 'allowed to use' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#allowed-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-allowed-to-use">3. API</a> <a href="#ref-for-allowed-to-use①">(2)</a>
     <li><a href="#ref-for-allowed-to-use②">6. Permissions Policy
 Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-iframe-allowfullscreen">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-iframe-allowfullscreen" class="dfn-panel" data-for="term-for-attr-iframe-allowfullscreen" id="infopanel-for-term-for-attr-iframe-allowfullscreen" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-iframe-allowfullscreen" style="display:none">Info about the 'allowfullscreen' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-iframe-allowfullscreen">6. Permissions Policy
 Integration</a> <a href="#ref-for-attr-iframe-allowfullscreen①">(2)</a>
     <li><a href="#ref-for-attr-iframe-allowfullscreen②">7. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">1. Terminology</a> <a href="#ref-for-browsing-context①">(2)</a>
     <li><a href="#ref-for-browsing-context②">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-dialog-element">
-   <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-dialog-element" class="dfn-panel" data-for="term-for-the-dialog-element" id="infopanel-for-term-for-the-dialog-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-dialog-element" style="display:none">Info about the 'dialog' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-dialog-element">2. Model</a>
     <li><a href="#ref-for-the-dialog-element①">3. API</a> <a href="#ref-for-the-dialog-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3. API</a> <a href="#ref-for-event-handlers①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-content-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-content-attributes" class="dfn-panel" data-for="term-for-event-handler-content-attributes" id="infopanel-for-term-for-event-handler-content-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-content-attributes" style="display:none">Info about the 'event handler content attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-content-attributes">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3. API</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-idl-attributes">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-idl-attributes" class="dfn-panel" data-for="term-for-event-handler-idl-attributes" id="infopanel-for-term-for-event-handler-idl-attributes" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-idl-attributes" style="display:none">Info about the 'event handler idl attribute' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-idl-attributes">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-loop">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-loop" class="dfn-panel" data-for="term-for-event-loop" id="infopanel-for-term-for-event-loop" role="menu">
+   <span id="infopaneltitle-for-term-for-event-loop" style="display:none">Info about the 'event loop' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop">https://html.spec.whatwg.org/multipage/webappapis.html#event-loop</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-loop">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">3. API</a> <a href="#ref-for-fully-active①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-iframe-element">
-   <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-iframe-element" class="dfn-panel" data-for="term-for-the-iframe-element" id="infopanel-for-term-for-the-iframe-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-iframe-element" style="display:none">Info about the 'iframe' external reference.</span><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-iframe-element">2. Model</a>
     <li><a href="#ref-for-the-iframe-element①">3. API</a>
@@ -1138,168 +1138,168 @@ Integration</a>
     <li><a href="#ref-for-the-iframe-element③">7. Security and Privacy Considerations</a> <a href="#ref-for-the-iframe-element④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3. API</a> <a href="#ref-for-in-parallel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-permissions-policy">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-permissions-policy" class="dfn-panel" data-for="term-for-concept-document-permissions-policy" id="infopanel-for-term-for-concept-document-permissions-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-permissions-policy" style="display:none">Info about the 'permissions policy' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy">https://html.spec.whatwg.org/multipage/dom.html#concept-document-permissions-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-permissions-policy">6. Permissions Policy
 Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-top-level-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-top-level-browsing-context" class="dfn-panel" data-for="term-for-top-level-browsing-context" id="infopanel-for-term-for-top-level-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-top-level-browsing-context" style="display:none">Info about the 'top-level browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">3. API</a> <a href="#ref-for-top-level-browsing-context①">(2)</a>
     <li><a href="#ref-for-top-level-browsing-context②">4. UI</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transient-activation">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transient-activation" class="dfn-panel" data-for="term-for-transient-activation" id="infopanel-for-term-for-transient-activation" role="menu">
+   <span id="infopaneltitle-for-term-for-transient-activation" style="display:none">Info about the 'transient activation' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#transient-activation">https://html.spec.whatwg.org/multipage/interaction.html#transient-activation</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transient-activation">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps">
-   <a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unloading-document-cleanup-steps" class="dfn-panel" data-for="term-for-unloading-document-cleanup-steps" id="infopanel-for-term-for-unloading-document-cleanup-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-unloading-document-cleanup-steps" style="display:none">Info about the 'unloading document cleanup steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps">https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unloading-document-cleanup-steps">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">3. API</a> <a href="#ref-for-set-append①">(2)</a> <a href="#ref-for-set-append②">(3)</a> <a href="#ref-for-set-append③">(4)</a> <a href="#ref-for-set-append④">(5)</a> <a href="#ref-for-set-append⑤">(6)</a> <a href="#ref-for-set-append⑥">(7)</a>
     <li><a href="#ref-for-set-append⑦">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3. API</a> <a href="#ref-for-iteration-break①">(2)</a> <a href="#ref-for-iteration-break②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">2. Model</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">3. API</a> <a href="#ref-for-list-iterate③">(2)</a> <a href="#ref-for-list-iterate④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-namespace">
-   <a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-namespace" class="dfn-panel" data-for="term-for-html-namespace" id="infopanel-for-term-for-html-namespace" role="menu">
+   <span id="infopaneltitle-for-term-for-html-namespace" style="display:none">Info about the 'html namespace' external reference.</span><a href="https://infra.spec.whatwg.org/#html-namespace">https://infra.spec.whatwg.org/#html-namespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-namespace">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">2. Model</a>
     <li><a href="#ref-for-ordered-set①">3. API</a> <a href="#ref-for-ordered-set②">(2)</a> <a href="#ref-for-ordered-set③">(3)</a>
     <li><a href="#ref-for-ordered-set④">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">2. Model</a> <a href="#ref-for-list-remove①">(2)</a>
     <li><a href="#ref-for-list-remove②">5.1. New stacking layer</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-while">
-   <a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-while" class="dfn-panel" data-for="term-for-iteration-while" id="infopanel-for-term-for-iteration-while" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-while" style="display:none">Info about the 'while' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">3. API</a> <a href="#ref-for-iteration-while①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-container-policy">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#container-policy">https://w3c.github.io/webappsec-permissions-policy/#container-policy</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-container-policy" class="dfn-panel" data-for="term-for-container-policy" id="infopanel-for-term-for-container-policy" role="menu">
+   <span id="infopaneltitle-for-term-for-container-policy" style="display:none">Info about the 'container policy' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#container-policy">https://w3c.github.io/webappsec-permissions-policy/#container-policy</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-container-policy">6. Permissions Policy
 Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-default-allowlist">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-default-allowlist" class="dfn-panel" data-for="term-for-default-allowlist" id="infopanel-for-term-for-default-allowlist" role="menu">
+   <span id="infopaneltitle-for-term-for-default-allowlist" style="display:none">Info about the 'default allowlist' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#default-allowlist">https://w3c.github.io/webappsec-permissions-policy/#default-allowlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-allowlist">6. Permissions Policy
 Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-permissions-policy-header">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header">https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-permissions-policy-header" class="dfn-panel" data-for="term-for-permissions-policy-header" id="infopanel-for-term-for-permissions-policy-header" role="menu">
+   <span id="infopaneltitle-for-term-for-permissions-policy-header" style="display:none">Info about the 'permissions-policy' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header">https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permissions-policy-header">7. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-policy-controlled-feature">
-   <a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-policy-controlled-feature" class="dfn-panel" data-for="term-for-policy-controlled-feature" id="infopanel-for-term-for-policy-controlled-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-policy-controlled-feature" style="display:none">Info about the 'policy-controlled feature' external reference.</span><a href="https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature">https://w3c.github.io/webappsec-permissions-policy/#policy-controlled-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-policy-controlled-feature">6. Permissions Policy
 Integration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyLenientSetter">
-   <a href="https://webidl.spec.whatwg.org/#LegacyLenientSetter">https://webidl.spec.whatwg.org/#LegacyLenientSetter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyLenientSetter" class="dfn-panel" data-for="term-for-LegacyLenientSetter" id="infopanel-for-term-for-LegacyLenientSetter" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyLenientSetter" style="display:none">Info about the 'LegacyLenientSetter' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyLenientSetter">https://webidl.spec.whatwg.org/#LegacyLenientSetter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyLenientSetter">3. API</a> <a href="#ref-for-LegacyLenientSetter①">(2)</a> <a href="#ref-for-LegacyLenientSetter②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. API</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Unscopable">
-   <a href="https://webidl.spec.whatwg.org/#Unscopable">https://webidl.spec.whatwg.org/#Unscopable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Unscopable" class="dfn-panel" data-for="term-for-Unscopable" id="infopanel-for-term-for-Unscopable" role="menu">
+   <span id="infopaneltitle-for-term-for-Unscopable" style="display:none">Info about the 'Unscopable' external reference.</span><a href="https://webidl.spec.whatwg.org/#Unscopable">https://webidl.spec.whatwg.org/#Unscopable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Unscopable">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. API</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. API</a> <a href="#ref-for-idl-undefined①">(2)</a>
    </ul>
@@ -1450,165 +1450,165 @@ Integration</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="descendant-browsing-context">
-   <b><a href="#descendant-browsing-context">#descendant-browsing-context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descendant-browsing-context" class="dfn-panel" data-for="descendant-browsing-context" id="infopanel-for-descendant-browsing-context" role="dialog">
+   <span id="infopaneltitle-for-descendant-browsing-context" style="display:none">Info about the 'descendant browsing context' definition.</span><b><a href="#descendant-browsing-context">#descendant-browsing-context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descendant-browsing-context">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-flag">
-   <b><a href="#fullscreen-flag">#fullscreen-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-flag" class="dfn-panel" data-for="fullscreen-flag" id="infopanel-for-fullscreen-flag" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-flag" style="display:none">Info about the 'fullscreen flag' definition.</span><b><a href="#fullscreen-flag">#fullscreen-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-flag">2. Model</a> <a href="#ref-for-fullscreen-flag①">(2)</a> <a href="#ref-for-fullscreen-flag②">(3)</a> <a href="#ref-for-fullscreen-flag③">(4)</a> <a href="#ref-for-fullscreen-flag④">(5)</a> <a href="#ref-for-fullscreen-flag⑤">(6)</a>
     <li><a href="#ref-for-fullscreen-flag⑥">3. API</a> <a href="#ref-for-fullscreen-flag⑦">(2)</a>
     <li><a href="#ref-for-fullscreen-flag⑧">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iframe-fullscreen-flag">
-   <b><a href="#iframe-fullscreen-flag">#iframe-fullscreen-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iframe-fullscreen-flag" class="dfn-panel" data-for="iframe-fullscreen-flag" id="infopanel-for-iframe-fullscreen-flag" role="dialog">
+   <span id="infopaneltitle-for-iframe-fullscreen-flag" style="display:none">Info about the 'iframe fullscreen flag' definition.</span><b><a href="#iframe-fullscreen-flag">#iframe-fullscreen-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iframe-fullscreen-flag">2. Model</a>
     <li><a href="#ref-for-iframe-fullscreen-flag①">3. API</a> <a href="#ref-for-iframe-fullscreen-flag②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-element">
-   <b><a href="#fullscreen-element">#fullscreen-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-element" class="dfn-panel" data-for="fullscreen-element" id="infopanel-for-fullscreen-element" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-element" style="display:none">Info about the 'fullscreen element' definition.</span><b><a href="#fullscreen-element">#fullscreen-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-element">2. Model</a> <a href="#ref-for-fullscreen-element①">(2)</a> <a href="#ref-for-fullscreen-element②">(3)</a> <a href="#ref-for-fullscreen-element③">(4)</a> <a href="#ref-for-fullscreen-element④">(5)</a>
     <li><a href="#ref-for-fullscreen-element⑤">3. API</a> <a href="#ref-for-fullscreen-element⑥">(2)</a> <a href="#ref-for-fullscreen-element⑦">(3)</a> <a href="#ref-for-fullscreen-element⑧">(4)</a> <a href="#ref-for-fullscreen-element⑨">(5)</a> <a href="#ref-for-fullscreen-element①⓪">(6)</a> <a href="#ref-for-fullscreen-element①①">(7)</a> <a href="#ref-for-fullscreen-element①②">(8)</a> <a href="#ref-for-fullscreen-element①③">(9)</a> <a href="#ref-for-fullscreen-element①④">(10)</a> <a href="#ref-for-fullscreen-element①⑤">(11)</a> <a href="#ref-for-fullscreen-element①⑥">(12)</a> <a href="#ref-for-fullscreen-element①⑦">(13)</a> <a href="#ref-for-fullscreen-element①⑧">(14)</a> <a href="#ref-for-fullscreen-element①⑨">(15)</a> <a href="#ref-for-fullscreen-element②⓪">(16)</a> <a href="#ref-for-fullscreen-element②①">(17)</a>
     <li><a href="#ref-for-fullscreen-element②②">5.3. :fullscreen pseudo-class</a> <a href="#ref-for-fullscreen-element②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-pending-fullscreen-events">
-   <b><a href="#list-of-pending-fullscreen-events">#list-of-pending-fullscreen-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-pending-fullscreen-events" class="dfn-panel" data-for="list-of-pending-fullscreen-events" id="infopanel-for-list-of-pending-fullscreen-events" role="dialog">
+   <span id="infopaneltitle-for-list-of-pending-fullscreen-events" style="display:none">Info about the 'list of pending fullscreen events' definition.</span><b><a href="#list-of-pending-fullscreen-events">#list-of-pending-fullscreen-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-pending-fullscreen-events">2. Model</a> <a href="#ref-for-list-of-pending-fullscreen-events①">(2)</a>
     <li><a href="#ref-for-list-of-pending-fullscreen-events②">3. API</a> <a href="#ref-for-list-of-pending-fullscreen-events③">(2)</a> <a href="#ref-for-list-of-pending-fullscreen-events④">(3)</a> <a href="#ref-for-list-of-pending-fullscreen-events⑤">(4)</a> <a href="#ref-for-list-of-pending-fullscreen-events⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-an-element">
-   <b><a href="#fullscreen-an-element">#fullscreen-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-an-element" class="dfn-panel" data-for="fullscreen-an-element" id="infopanel-for-fullscreen-an-element" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-an-element" style="display:none">Info about the 'fullscreen an element' definition.</span><b><a href="#fullscreen-an-element">#fullscreen-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-an-element">3. API</a> <a href="#ref-for-fullscreen-an-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unfullscreen-an-element">
-   <b><a href="#unfullscreen-an-element">#unfullscreen-an-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unfullscreen-an-element" class="dfn-panel" data-for="unfullscreen-an-element" id="infopanel-for-unfullscreen-an-element" role="dialog">
+   <span id="infopaneltitle-for-unfullscreen-an-element" style="display:none">Info about the 'unfullscreen an element' definition.</span><b><a href="#unfullscreen-an-element">#unfullscreen-an-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unfullscreen-an-element">2. Model</a> <a href="#ref-for-unfullscreen-an-element①">(2)</a> <a href="#ref-for-unfullscreen-an-element②">(3)</a>
     <li><a href="#ref-for-unfullscreen-an-element③">3. API</a> <a href="#ref-for-unfullscreen-an-element④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="unfullscreen-a-document">
-   <b><a href="#unfullscreen-a-document">#unfullscreen-a-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-unfullscreen-a-document" class="dfn-panel" data-for="unfullscreen-a-document" id="infopanel-for-unfullscreen-a-document" role="dialog">
+   <span id="infopaneltitle-for-unfullscreen-a-document" style="display:none">Info about the 'unfullscreen a document' definition.</span><b><a href="#unfullscreen-a-document">#unfullscreen-a-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unfullscreen-a-document">3. API</a> <a href="#ref-for-unfullscreen-a-document①">(2)</a> <a href="#ref-for-unfullscreen-a-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fully-exit-fullscreen">
-   <b><a href="#fully-exit-fullscreen">#fully-exit-fullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fully-exit-fullscreen" class="dfn-panel" data-for="fully-exit-fullscreen" id="infopanel-for-fully-exit-fullscreen" role="dialog">
+   <span id="infopaneltitle-for-fully-exit-fullscreen" style="display:none">Info about the 'fully exit fullscreen' definition.</span><b><a href="#fully-exit-fullscreen">#fully-exit-fullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-exit-fullscreen">2. Model</a>
     <li><a href="#ref-for-fully-exit-fullscreen①">4. UI</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-is-supported">
-   <b><a href="#fullscreen-is-supported">#fullscreen-is-supported</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-is-supported" class="dfn-panel" data-for="fullscreen-is-supported" id="infopanel-for-fullscreen-is-supported" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-is-supported" style="display:none">Info about the 'Fullscreen is supported' definition.</span><b><a href="#fullscreen-is-supported">#fullscreen-is-supported</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-is-supported">3. API</a> <a href="#ref-for-fullscreen-is-supported①">(2)</a> <a href="#ref-for-fullscreen-is-supported②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="run-the-fullscreen-steps">
-   <b><a href="#run-the-fullscreen-steps">#run-the-fullscreen-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-run-the-fullscreen-steps" class="dfn-panel" data-for="run-the-fullscreen-steps" id="infopanel-for-run-the-fullscreen-steps" role="dialog">
+   <span id="infopaneltitle-for-run-the-fullscreen-steps" style="display:none">Info about the 'run the fullscreen steps' definition.</span><b><a href="#run-the-fullscreen-steps">#run-the-fullscreen-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-run-the-fullscreen-steps">3. API</a> <a href="#ref-for-run-the-fullscreen-steps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-fullscreennavigationui">
-   <b><a href="#enumdef-fullscreennavigationui">#enumdef-fullscreennavigationui</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-fullscreennavigationui" class="dfn-panel" data-for="enumdef-fullscreennavigationui" id="infopanel-for-enumdef-fullscreennavigationui" role="dialog">
+   <span id="infopaneltitle-for-enumdef-fullscreennavigationui" style="display:none">Info about the 'FullscreenNavigationUI' definition.</span><b><a href="#enumdef-fullscreennavigationui">#enumdef-fullscreennavigationui</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-fullscreennavigationui">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-fullscreenoptions">
-   <b><a href="#dictdef-fullscreenoptions">#dictdef-fullscreenoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-fullscreenoptions" class="dfn-panel" data-for="dictdef-fullscreenoptions" id="infopanel-for-dictdef-fullscreenoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-fullscreenoptions" style="display:none">Info about the 'FullscreenOptions' definition.</span><b><a href="#dictdef-fullscreenoptions">#dictdef-fullscreenoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-fullscreenoptions">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-element-ready-check">
-   <b><a href="#fullscreen-element-ready-check">#fullscreen-element-ready-check</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-element-ready-check" class="dfn-panel" data-for="fullscreen-element-ready-check" id="infopanel-for-fullscreen-element-ready-check" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-element-ready-check" style="display:none">Info about the 'fullscreen element ready check' definition.</span><b><a href="#fullscreen-element-ready-check">#fullscreen-element-ready-check</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-element-ready-check">3. API</a> <a href="#ref-for-fullscreen-element-ready-check①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-element-requestfullscreen">
-   <b><a href="#dom-element-requestfullscreen">#dom-element-requestfullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-element-requestfullscreen" class="dfn-panel" data-for="dom-element-requestfullscreen" id="infopanel-for-dom-element-requestfullscreen" role="dialog">
+   <span id="infopaneltitle-for-dom-element-requestfullscreen" style="display:none">Info about the 'requestFullscreen(options)' definition.</span><b><a href="#dom-element-requestfullscreen">#dom-element-requestfullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-element-requestfullscreen">3. API</a> <a href="#ref-for-dom-element-requestfullscreen①">(2)</a>
     <li><a href="#ref-for-dom-element-requestfullscreen②">4. UI</a> <a href="#ref-for-dom-element-requestfullscreen③">(2)</a>
     <li><a href="#ref-for-dom-element-requestfullscreen④">7. Security and Privacy Considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-fullscreenenabled">
-   <b><a href="#dom-document-fullscreenenabled">#dom-document-fullscreenenabled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-fullscreenenabled" class="dfn-panel" data-for="dom-document-fullscreenenabled" id="infopanel-for-dom-document-fullscreenenabled" role="dialog">
+   <span id="infopaneltitle-for-dom-document-fullscreenenabled" style="display:none">Info about the 'fullscreenEnabled' definition.</span><b><a href="#dom-document-fullscreenenabled">#dom-document-fullscreenenabled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-fullscreenenabled">3. API</a> <a href="#ref-for-dom-document-fullscreenenabled①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-fullscreen">
-   <b><a href="#dom-document-fullscreen">#dom-document-fullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-fullscreen" class="dfn-panel" data-for="dom-document-fullscreen" id="infopanel-for-dom-document-fullscreen" role="dialog">
+   <span id="infopaneltitle-for-dom-document-fullscreen" style="display:none">Info about the 'fullscreen' definition.</span><b><a href="#dom-document-fullscreen">#dom-document-fullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-fullscreen">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-fullscreenelement">
-   <b><a href="#dom-document-fullscreenelement">#dom-document-fullscreenelement</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-fullscreenelement" class="dfn-panel" data-for="dom-document-fullscreenelement" id="infopanel-for-dom-document-fullscreenelement" role="dialog">
+   <span id="infopaneltitle-for-dom-document-fullscreenelement" style="display:none">Info about the 'fullscreenElement' definition.</span><b><a href="#dom-document-fullscreenelement">#dom-document-fullscreenelement</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-fullscreenelement">3. API</a> <a href="#ref-for-dom-document-fullscreenelement①">(2)</a> <a href="#ref-for-dom-document-fullscreenelement②">(3)</a> <a href="#ref-for-dom-document-fullscreenelement③">(4)</a>
     <li><a href="#ref-for-dom-document-fullscreenelement④">5.3. :fullscreen pseudo-class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="simple-fullscreen-document">
-   <b><a href="#simple-fullscreen-document">#simple-fullscreen-document</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-simple-fullscreen-document" class="dfn-panel" data-for="simple-fullscreen-document" id="infopanel-for-simple-fullscreen-document" role="dialog">
+   <span id="infopaneltitle-for-simple-fullscreen-document" style="display:none">Info about the 'simple fullscreen document' definition.</span><b><a href="#simple-fullscreen-document">#simple-fullscreen-document</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-simple-fullscreen-document">3. API</a> <a href="#ref-for-simple-fullscreen-document①">(2)</a> <a href="#ref-for-simple-fullscreen-document②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-documents-to-unfullscreen">
-   <b><a href="#collect-documents-to-unfullscreen">#collect-documents-to-unfullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-documents-to-unfullscreen" class="dfn-panel" data-for="collect-documents-to-unfullscreen" id="infopanel-for-collect-documents-to-unfullscreen" role="dialog">
+   <span id="infopaneltitle-for-collect-documents-to-unfullscreen" style="display:none">Info about the 'collect documents to unfullscreen' definition.</span><b><a href="#collect-documents-to-unfullscreen">#collect-documents-to-unfullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-documents-to-unfullscreen">3. API</a> <a href="#ref-for-collect-documents-to-unfullscreen①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="exit-fullscreen">
-   <b><a href="#exit-fullscreen">#exit-fullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-exit-fullscreen" class="dfn-panel" data-for="exit-fullscreen" id="infopanel-for-exit-fullscreen" role="dialog">
+   <span id="infopaneltitle-for-exit-fullscreen" style="display:none">Info about the 'exit fullscreen' definition.</span><b><a href="#exit-fullscreen">#exit-fullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exit-fullscreen">2. Model</a> <a href="#ref-for-exit-fullscreen①">(2)</a>
     <li><a href="#ref-for-exit-fullscreen②">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-exitfullscreen">
-   <b><a href="#dom-document-exitfullscreen">#dom-document-exitfullscreen</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-document-exitfullscreen" class="dfn-panel" data-for="dom-document-exitfullscreen" id="infopanel-for-dom-document-exitfullscreen" role="dialog">
+   <span id="infopaneltitle-for-dom-document-exitfullscreen" style="display:none">Info about the 'exitFullscreen()' definition.</span><b><a href="#dom-document-exitfullscreen">#dom-document-exitfullscreen</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-document-exitfullscreen">3. API</a> <a href="#ref-for-dom-document-exitfullscreen①">(2)</a>
     <li><a href="#ref-for-dom-document-exitfullscreen②">4. UI</a> <a href="#ref-for-dom-document-exitfullscreen③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-document-onfullscreenchange">
-   <b><a href="#handler-document-onfullscreenchange">#handler-document-onfullscreenchange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-document-onfullscreenchange" class="dfn-panel" data-for="handler-document-onfullscreenchange" id="infopanel-for-handler-document-onfullscreenchange" role="dialog">
+   <span id="infopaneltitle-for-handler-document-onfullscreenchange" style="display:none">Info about the 'onfullscreenchange' definition.</span><b><a href="#handler-document-onfullscreenchange">#handler-document-onfullscreenchange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-document-onfullscreenchange">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-document-onfullscreenerror">
-   <b><a href="#handler-document-onfullscreenerror">#handler-document-onfullscreenerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-document-onfullscreenerror" class="dfn-panel" data-for="handler-document-onfullscreenerror" id="infopanel-for-handler-document-onfullscreenerror" role="dialog">
+   <span id="infopaneltitle-for-handler-document-onfullscreenerror" style="display:none">Info about the 'onfullscreenerror' definition.</span><b><a href="#handler-document-onfullscreenerror">#handler-document-onfullscreenerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-document-onfullscreenerror">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="top-layer">
-   <b><a href="#top-layer">#top-layer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-top-layer" class="dfn-panel" data-for="top-layer" id="infopanel-for-top-layer" role="dialog">
+   <span id="infopaneltitle-for-top-layer" style="display:none">Info about the 'top layer' definition.</span><b><a href="#top-layer">#top-layer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-layer">2. Model</a> <a href="#ref-for-top-layer①">(2)</a> <a href="#ref-for-top-layer②">(3)</a> <a href="#ref-for-top-layer③">(4)</a> <a href="#ref-for-top-layer④">(5)</a> <a href="#ref-for-top-layer⑤">(6)</a> <a href="#ref-for-top-layer⑥">(7)</a> <a href="#ref-for-top-layer⑦">(8)</a>
     <li><a href="#ref-for-top-layer⑧">3. API</a> <a href="#ref-for-top-layer⑨">(2)</a> <a href="#ref-for-top-layer①⓪">(3)</a>
@@ -1617,81 +1617,137 @@ Integration</a>
     <li><a href="#ref-for-top-layer①⑥">5.2. ::backdrop pseudo-element</a> <a href="#ref-for-top-layer①⑦">(2)</a> <a href="#ref-for-top-layer①⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="top-layer-add">
-   <b><a href="#top-layer-add">#top-layer-add</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-top-layer-add" class="dfn-panel" data-for="top-layer-add" id="infopanel-for-top-layer-add" role="dialog">
+   <span id="infopaneltitle-for-top-layer-add" style="display:none">Info about the 'add' definition.</span><b><a href="#top-layer-add">#top-layer-add</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-layer-add">2. Model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="css-pe-backdrop">
-   <b><a href="#css-pe-backdrop">#css-pe-backdrop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-css-pe-backdrop" class="dfn-panel" data-for="css-pe-backdrop" id="infopanel-for-css-pe-backdrop" role="dialog">
+   <span id="infopaneltitle-for-css-pe-backdrop" style="display:none">Info about the '::backdrop' definition.</span><b><a href="#css-pe-backdrop">#css-pe-backdrop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-css-pe-backdrop">5. Rendering</a>
     <li><a href="#ref-for-css-pe-backdrop①">5.1. New stacking layer</a> <a href="#ref-for-css-pe-backdrop②">(2)</a>
     <li><a href="#ref-for-css-pe-backdrop③">5.2. ::backdrop pseudo-element</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fullscreen-feature">
-   <b><a href="#fullscreen-feature">#fullscreen-feature</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fullscreen-feature" class="dfn-panel" data-for="fullscreen-feature" id="infopanel-for-fullscreen-feature" role="dialog">
+   <span id="infopaneltitle-for-fullscreen-feature" style="display:none">Info about the 'fullscreen' definition.</span><b><a href="#fullscreen-feature">#fullscreen-feature</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fullscreen-feature">3. API</a> <a href="#ref-for-fullscreen-feature①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/whatwg/infra/infra.html
+++ b/tests/github/whatwg/infra/infra.html
@@ -1639,98 +1639,98 @@ if ("serviceWorker" in navigator) {
    <li><a href="#xml-namespace">XML namespace</a><span>, in § 8</span>
    <li><a href="#xmlns-namespace">XMLNS namespace</a><span>, in § 8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-json.parse">
-   <a href="https://tc39.github.io/ecma262/#sec-json.parse">https://tc39.github.io/ecma262/#sec-json.parse</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-json.parse" class="dfn-panel" data-for="term-for-sec-json.parse" id="infopanel-for-term-for-sec-json.parse" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-json.parse" style="display:none">Info about the '%json.parse%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-json.parse">https://tc39.github.io/ecma262/#sec-json.parse</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-json.parse">6. JSON</a> <a href="#ref-for-sec-json.parse①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-json.stringify">
-   <a href="https://tc39.github.io/ecma262/#sec-json.stringify">https://tc39.github.io/ecma262/#sec-json.stringify</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-json.stringify" class="dfn-panel" data-for="term-for-sec-json.stringify" id="infopanel-for-term-for-sec-json.stringify" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-json.stringify" style="display:none">Info about the '%json.stringify%' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-json.stringify">https://tc39.github.io/ecma262/#sec-json.stringify</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-json.stringify">6. JSON</a> <a href="#ref-for-sec-json.stringify①">(2)</a> <a href="#ref-for-sec-json.stringify②">(3)</a> <a href="#ref-for-sec-json.stringify③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraycreate">
-   <a href="https://tc39.github.io/ecma262/#sec-arraycreate">https://tc39.github.io/ecma262/#sec-arraycreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraycreate" class="dfn-panel" data-for="term-for-sec-arraycreate" id="infopanel-for-term-for-sec-arraycreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraycreate" style="display:none">Info about the 'ArrayCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-arraycreate">https://tc39.github.io/ecma262/#sec-arraycreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraycreate">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-call">
-   <a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-call" class="dfn-panel" data-for="term-for-sec-call" id="infopanel-for-term-for-sec-call" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-call" style="display:none">Info about the 'Call' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-call">https://tc39.github.io/ecma262/#sec-call</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-call">6. JSON</a> <a href="#ref-for-sec-call①">(2)</a> <a href="#ref-for-sec-call②">(3)</a> <a href="#ref-for-sec-call③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdatapropertyorthrow">
-   <a href="https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow">https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdatapropertyorthrow" class="dfn-panel" data-for="term-for-sec-createdatapropertyorthrow" id="infopanel-for-term-for-sec-createdatapropertyorthrow" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdatapropertyorthrow" style="display:none">Info about the 'CreateDataPropertyOrThrow' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow">https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdatapropertyorthrow">6. JSON</a> <a href="#ref-for-sec-createdatapropertyorthrow①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'Get' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-get-o-p">https://tc39.github.io/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">6. JSON</a> <a href="#ref-for-sec-get-o-p①">(2)</a> <a href="#ref-for-sec-get-o-p②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isarray">
-   <a href="https://tc39.github.io/ecma262/#sec-isarray">https://tc39.github.io/ecma262/#sec-isarray</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isarray" class="dfn-panel" data-for="term-for-sec-isarray" id="infopanel-for-term-for-sec-isarray" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isarray" style="display:none">Info about the 'IsArray' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-isarray">https://tc39.github.io/ecma262/#sec-isarray</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isarray">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate">
-   <a href="https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate">https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate" id="infopanel-for-term-for-sec-ordinaryobjectcreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" style="display:none">Info about the 'OrdinaryObjectCreate' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate">https://tc39.github.io/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinaryobjectcreate">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tolength">
-   <a href="https://tc39.github.io/ecma262/#sec-tolength">https://tc39.github.io/ecma262/#sec-tolength</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tolength" class="dfn-panel" data-for="term-for-sec-tolength" id="infopanel-for-term-for-sec-tolength" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tolength" style="display:none">Info about the 'ToLength' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tolength">https://tc39.github.io/ecma262/#sec-tolength</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tolength">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-tostring">
-   <a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-tostring" class="dfn-panel" data-for="term-for-sec-tostring" id="infopanel-for-term-for-sec-tostring" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-tostring" style="display:none">Info about the 'ToString' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-tostring">https://tc39.github.io/ecma262/#sec-tostring</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-tostring">6. JSON</a> <a href="#ref-for-sec-tostring①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'Type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type">
-   <a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">https://tc39.github.io/ecma262/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-list-and-record-specification-type" class="dfn-panel" data-for="term-for-sec-list-and-record-specification-type" id="infopanel-for-term-for-sec-list-and-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-list-and-record-specification-type" style="display:none">Info about the 'list' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">https://tc39.github.io/ecma262/#sec-list-and-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-list-and-record-specification-type">5.1. Lists</a> <a href="#ref-for-sec-list-and-record-specification-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-realm">
-   <a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-realm" class="dfn-panel" data-for="term-for-realm" id="infopanel-for-term-for-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-realm" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.github.io/ecma262/#realm">https://tc39.github.io/ecma262/#realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-realm">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.sort">
-   <a href="https://tc39.github.io/ecma262/#sec-array.prototype.sort">https://tc39.github.io/ecma262/#sec-array.prototype.sort</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.sort" class="dfn-panel" data-for="term-for-sec-array.prototype.sort" id="infopanel-for-term-for-sec-array.prototype.sort" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.sort" style="display:none">Info about the 'sort()' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-array.prototype.sort">https://tc39.github.io/ecma262/#sec-array.prototype.sort</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.sort">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-string-type">
-   <a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-string-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-string-type" id="infopanel-for-term-for-sec-ecmascript-language-types-string-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-string-type" style="display:none">Info about the 'the string type' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type">https://tc39.github.io/ecma262/#sec-ecmascript-language-types-string-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-string-type">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode" class="dfn-panel" data-for="term-for-utf-8-decode" id="infopanel-for-term-for-utf-8-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode" style="display:none">Info about the 'utf-8 decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode">https://encoding.spec.whatwg.org/#utf-8-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode">3.4. Variables</a>
     <li><a href="#ref-for-utf-8-decode①">4.3. Bytes</a>
@@ -1738,16 +1738,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-8-decode③">6. JSON</a> <a href="#ref-for-utf-8-decode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">4.4. Byte sequences</a>
     <li><a href="#ref-for-utf-8-encode①">4.6. Strings</a> <a href="#ref-for-utf-8-encode②">(2)</a>
     <li><a href="#ref-for-utf-8-encode③">6. JSON</a> <a href="#ref-for-utf-8-encode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6. JSON</a>
    </ul>
@@ -1818,39 +1818,39 @@ if ("serviceWorker" in navigator) {
    <dt id="biblio-storage">[STORAGE]
    <dd>Anne van Kesteren. <a href="https://storage.spec.whatwg.org/"><cite>Storage Standard</cite></a>. Living Standard. URL: <a href="https://storage.spec.whatwg.org/">https://storage.spec.whatwg.org/</a>
   </dl>
-  <aside class="dfn-panel" data-for="willful-violation">
-   <b><a href="#willful-violation">#willful-violation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-willful-violation" class="dfn-panel" data-for="willful-violation" id="infopanel-for-willful-violation" role="dialog">
+   <span id="infopaneltitle-for-willful-violation" style="display:none">Info about the 'willful violation' definition.</span><b><a href="#willful-violation">#willful-violation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-willful-violation">2.1. Conformance</a>
     <li><a href="#ref-for-willful-violation①">2.2. Compliance with other specifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent">
-   <b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent" class="dfn-panel" data-for="user-agent" id="infopanel-for-user-agent" role="dialog">
+   <span id="infopaneltitle-for-user-agent" style="display:none">Info about the 'user agent' definition.</span><b><a href="#user-agent">#user-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">2.3. Terminology</a> <a href="#ref-for-user-agent①">(2)</a> <a href="#ref-for-user-agent②">(3)</a> <a href="#ref-for-user-agent③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="implementation-defined">
-   <b><a href="#implementation-defined">#implementation-defined</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-implementation-defined" class="dfn-panel" data-for="implementation-defined" id="infopanel-for-implementation-defined" role="dialog">
+   <span id="infopaneltitle-for-implementation-defined" style="display:none">Info about the 'implementation-defined' definition.</span><b><a href="#implementation-defined">#implementation-defined</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">2.3. Terminology</a> <a href="#ref-for-implementation-defined①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-when">
-   <b><a href="#abort-when">#abort-when</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-when" class="dfn-panel" data-for="abort-when" id="infopanel-for-abort-when" role="dialog">
+   <span id="infopaneltitle-for-abort-when" style="display:none">Info about the 'abort when' definition.</span><b><a href="#abort-when">#abort-when</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-when">3.6. Conditional abort</a> <a href="#ref-for-abort-when①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="if-aborted">
-   <b><a href="#if-aborted">#if-aborted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-if-aborted" class="dfn-panel" data-for="if-aborted" id="infopanel-for-if-aborted" role="dialog">
+   <span id="infopaneltitle-for-if-aborted" style="display:none">Info about the 'if aborted' definition.</span><b><a href="#if-aborted">#if-aborted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-if-aborted">3.6. Conditional abort</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-while">
-   <b><a href="#iteration-while">#iteration-while</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-while" class="dfn-panel" data-for="iteration-while" id="infopanel-for-iteration-while" role="dialog">
+   <span id="infopaneltitle-for-iteration-while" style="display:none">Info about the 'While' definition.</span><b><a href="#iteration-while">#iteration-while</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">4.4. Byte sequences</a>
     <li><a href="#ref-for-iteration-while①">4.6. Strings</a>
@@ -1858,20 +1858,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-iteration-while③">5.1.2. Queues</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-continue">
-   <b><a href="#iteration-continue">#iteration-continue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-continue" class="dfn-panel" data-for="iteration-continue" id="infopanel-for-iteration-continue" role="dialog">
+   <span id="infopaneltitle-for-iteration-continue" style="display:none">Info about the 'continue' definition.</span><b><a href="#iteration-continue">#iteration-continue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">3.7. Iteration</a> <a href="#ref-for-iteration-continue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="iteration-break">
-   <b><a href="#iteration-break">#iteration-break</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-iteration-break" class="dfn-panel" data-for="iteration-break" id="infopanel-for-iteration-break" role="dialog">
+   <span id="infopaneltitle-for-iteration-break" style="display:none">Info about the 'break' definition.</span><b><a href="#iteration-break">#iteration-break</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3.7. Iteration</a> <a href="#ref-for-iteration-break①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="assert">
-   <b><a href="#assert">#assert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-assert" class="dfn-panel" data-for="assert" id="infopanel-for-assert" role="dialog">
+   <span id="infopaneltitle-for-assert" style="display:none">Info about the 'Assert' definition.</span><b><a href="#assert">#assert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-assert">3.4. Variables</a>
     <li><a href="#ref-for-assert①">3.8. Assertions</a>
@@ -1880,38 +1880,38 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-assert⑨">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="boolean">
-   <b><a href="#boolean">#boolean</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-boolean" class="dfn-panel" data-for="boolean" id="infopanel-for-boolean" role="dialog">
+   <span id="infopaneltitle-for-boolean" style="display:none">Info about the 'boolean' definition.</span><b><a href="#boolean">#boolean</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-boolean">3.3. Parameters</a> <a href="#ref-for-boolean①">(2)</a>
     <li><a href="#ref-for-boolean②">6. JSON</a> <a href="#ref-for-boolean③">(2)</a> <a href="#ref-for-boolean④">(3)</a> <a href="#ref-for-boolean⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte">
-   <b><a href="#byte">#byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte" class="dfn-panel" data-for="byte" id="infopanel-for-byte" role="dialog">
+   <span id="infopaneltitle-for-byte" style="display:none">Info about the 'byte' definition.</span><b><a href="#byte">#byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">4.3. Bytes</a> <a href="#ref-for-byte①">(2)</a> <a href="#ref-for-byte②">(3)</a>
     <li><a href="#ref-for-byte③">4.4. Byte sequences</a> <a href="#ref-for-byte④">(2)</a> <a href="#ref-for-byte⑤">(3)</a> <a href="#ref-for-byte⑥">(4)</a> <a href="#ref-for-byte⑦">(5)</a> <a href="#ref-for-byte⑧">(6)</a> <a href="#ref-for-byte⑨">(7)</a> <a href="#ref-for-byte①⓪">(8)</a>
     <li><a href="#ref-for-byte①①">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-value">
-   <b><a href="#byte-value">#byte-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-value" class="dfn-panel" data-for="byte-value" id="infopanel-for-byte-value" role="dialog">
+   <span id="infopaneltitle-for-byte-value" style="display:none">Info about the 'value' definition.</span><b><a href="#byte-value">#byte-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-value">4.3. Bytes</a>
     <li><a href="#ref-for-byte-value①">4.4. Byte sequences</a>
     <li><a href="#ref-for-byte-value②">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-byte">
-   <b><a href="#ascii-byte">#ascii-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-byte" class="dfn-panel" data-for="ascii-byte" id="infopanel-for-ascii-byte" role="dialog">
+   <span id="infopaneltitle-for-ascii-byte" style="display:none">Info about the 'ASCII byte' definition.</span><b><a href="#ascii-byte">#ascii-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-byte">4.3. Bytes</a>
     <li><a href="#ref-for-ascii-byte①">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-sequence">
-   <b><a href="#byte-sequence">#byte-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-sequence" class="dfn-panel" data-for="byte-sequence" id="infopanel-for-byte-sequence" role="dialog">
+   <span id="infopaneltitle-for-byte-sequence" style="display:none">Info about the 'byte sequence' definition.</span><b><a href="#byte-sequence">#byte-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3.2. Declaration</a> <a href="#ref-for-byte-sequence①">(2)</a> <a href="#ref-for-byte-sequence②">(3)</a>
     <li><a href="#ref-for-byte-sequence③">4.4. Byte sequences</a> <a href="#ref-for-byte-sequence④">(2)</a> <a href="#ref-for-byte-sequence⑤">(3)</a> <a href="#ref-for-byte-sequence⑥">(4)</a> <a href="#ref-for-byte-sequence⑦">(5)</a> <a href="#ref-for-byte-sequence⑧">(6)</a> <a href="#ref-for-byte-sequence⑨">(7)</a> <a href="#ref-for-byte-sequence①⓪">(8)</a> <a href="#ref-for-byte-sequence①①">(9)</a> <a href="#ref-for-byte-sequence①②">(10)</a> <a href="#ref-for-byte-sequence①③">(11)</a> <a href="#ref-for-byte-sequence①④">(12)</a>
@@ -1921,34 +1921,34 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte-sequence②①">7. Forgiving base64</a> <a href="#ref-for-byte-sequence②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-sequence-length">
-   <b><a href="#byte-sequence-length">#byte-sequence-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-sequence-length" class="dfn-panel" data-for="byte-sequence-length" id="infopanel-for-byte-sequence-length" role="dialog">
+   <span id="infopaneltitle-for-byte-sequence-length" style="display:none">Info about the 'length' definition.</span><b><a href="#byte-sequence-length">#byte-sequence-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">4.4. Byte sequences</a> <a href="#ref-for-byte-sequence-length①">(2)</a> <a href="#ref-for-byte-sequence-length②">(3)</a>
     <li><a href="#ref-for-byte-sequence-length③">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-lowercase">
-   <b><a href="#byte-lowercase">#byte-lowercase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-lowercase" class="dfn-panel" data-for="byte-lowercase" id="infopanel-for-byte-lowercase" role="dialog">
+   <span id="infopaneltitle-for-byte-lowercase" style="display:none">Info about the 'byte-lowercase' definition.</span><b><a href="#byte-lowercase">#byte-lowercase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-lowercase">4.4. Byte sequences</a> <a href="#ref-for-byte-lowercase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-sequence-prefix">
-   <b><a href="#byte-sequence-prefix">#byte-sequence-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-sequence-prefix" class="dfn-panel" data-for="byte-sequence-prefix" id="infopanel-for-byte-sequence-prefix" role="dialog">
+   <span id="infopaneltitle-for-byte-sequence-prefix" style="display:none">Info about the 'prefix' definition.</span><b><a href="#byte-sequence-prefix">#byte-sequence-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-prefix">4.4. Byte sequences</a> <a href="#ref-for-byte-sequence-prefix①">(2)</a> <a href="#ref-for-byte-sequence-prefix②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isomorphic-decode">
-   <b><a href="#isomorphic-decode">#isomorphic-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isomorphic-decode" class="dfn-panel" data-for="isomorphic-decode" id="infopanel-for-isomorphic-decode" role="dialog">
+   <span id="infopaneltitle-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' definition.</span><b><a href="#isomorphic-decode">#isomorphic-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">3.2. Declaration</a>
     <li><a href="#ref-for-isomorphic-decode①">4.6. Strings</a> <a href="#ref-for-isomorphic-decode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-point">
-   <b><a href="#code-point">#code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-point" class="dfn-panel" data-for="code-point" id="infopanel-for-code-point" role="dialog">
+   <span id="infopaneltitle-for-code-point" style="display:none">Info about the 'code point' definition.</span><b><a href="#code-point">#code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">4.3. Bytes</a>
     <li><a href="#ref-for-code-point①">4.4. Byte sequences</a>
@@ -1957,92 +1957,92 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-code-point⑤⓪">7. Forgiving base64</a> <a href="#ref-for-code-point⑤①">(2)</a> <a href="#ref-for-code-point⑤②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-point-value">
-   <b><a href="#code-point-value">#code-point-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-point-value" class="dfn-panel" data-for="code-point-value" id="infopanel-for-code-point-value" role="dialog">
+   <span id="infopaneltitle-for-code-point-value" style="display:none">Info about the 'value' definition.</span><b><a href="#code-point-value">#code-point-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point-value">4.4. Byte sequences</a>
     <li><a href="#ref-for-code-point-value①">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="surrogate">
-   <b><a href="#surrogate">#surrogate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-surrogate" class="dfn-panel" data-for="surrogate" id="infopanel-for-surrogate" role="dialog">
+   <span id="infopaneltitle-for-surrogate" style="display:none">Info about the 'surrogate' definition.</span><b><a href="#surrogate">#surrogate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-surrogate">4.5. Code points</a>
     <li><a href="#ref-for-surrogate①">4.6. Strings</a> <a href="#ref-for-surrogate②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scalar-value">
-   <b><a href="#scalar-value">#scalar-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scalar-value" class="dfn-panel" data-for="scalar-value" id="infopanel-for-scalar-value" role="dialog">
+   <span id="infopaneltitle-for-scalar-value" style="display:none">Info about the 'scalar value' definition.</span><b><a href="#scalar-value">#scalar-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value">4.6. Strings</a> <a href="#ref-for-scalar-value①">(2)</a> <a href="#ref-for-scalar-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-code-point">
-   <b><a href="#ascii-code-point">#ascii-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-code-point" class="dfn-panel" data-for="ascii-code-point" id="infopanel-for-ascii-code-point" role="dialog">
+   <span id="infopaneltitle-for-ascii-code-point" style="display:none">Info about the 'ASCII code point' definition.</span><b><a href="#ascii-code-point">#ascii-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-code-point">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-whitespace">
-   <b><a href="#ascii-whitespace">#ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-whitespace" class="dfn-panel" data-for="ascii-whitespace" id="infopanel-for-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-ascii-whitespace" style="display:none">Info about the 'ASCII whitespace' definition.</span><b><a href="#ascii-whitespace">#ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">4.6. Strings</a> <a href="#ref-for-ascii-whitespace①">(2)</a> <a href="#ref-for-ascii-whitespace②">(3)</a> <a href="#ref-for-ascii-whitespace③">(4)</a> <a href="#ref-for-ascii-whitespace④">(5)</a> <a href="#ref-for-ascii-whitespace⑤">(6)</a>
     <li><a href="#ref-for-ascii-whitespace⑥">7. Forgiving base64</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="c0-control">
-   <b><a href="#c0-control">#c0-control</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-c0-control" class="dfn-panel" data-for="c0-control" id="infopanel-for-c0-control" role="dialog">
+   <span id="infopaneltitle-for-c0-control" style="display:none">Info about the 'C0 control' definition.</span><b><a href="#c0-control">#c0-control</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c0-control">4.5. Code points</a> <a href="#ref-for-c0-control①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-digit">
-   <b><a href="#ascii-digit">#ascii-digit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-digit" class="dfn-panel" data-for="ascii-digit" id="infopanel-for-ascii-digit" role="dialog">
+   <span id="infopaneltitle-for-ascii-digit" style="display:none">Info about the 'ASCII digit' definition.</span><b><a href="#ascii-digit">#ascii-digit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-digit">4.5. Code points</a> <a href="#ref-for-ascii-digit①">(2)</a> <a href="#ref-for-ascii-digit②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-upper-hex-digit">
-   <b><a href="#ascii-upper-hex-digit">#ascii-upper-hex-digit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-upper-hex-digit" class="dfn-panel" data-for="ascii-upper-hex-digit" id="infopanel-for-ascii-upper-hex-digit" role="dialog">
+   <span id="infopaneltitle-for-ascii-upper-hex-digit" style="display:none">Info about the 'ASCII upper hex digit' definition.</span><b><a href="#ascii-upper-hex-digit">#ascii-upper-hex-digit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-upper-hex-digit">4.3. Bytes</a>
     <li><a href="#ref-for-ascii-upper-hex-digit①">4.5. Code points</a> <a href="#ref-for-ascii-upper-hex-digit②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-lower-hex-digit">
-   <b><a href="#ascii-lower-hex-digit">#ascii-lower-hex-digit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-lower-hex-digit" class="dfn-panel" data-for="ascii-lower-hex-digit" id="infopanel-for-ascii-lower-hex-digit" role="dialog">
+   <span id="infopaneltitle-for-ascii-lower-hex-digit" style="display:none">Info about the 'ASCII lower hex digit' definition.</span><b><a href="#ascii-lower-hex-digit">#ascii-lower-hex-digit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lower-hex-digit">4.5. Code points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-upper-alpha">
-   <b><a href="#ascii-upper-alpha">#ascii-upper-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-upper-alpha" class="dfn-panel" data-for="ascii-upper-alpha" id="infopanel-for-ascii-upper-alpha" role="dialog">
+   <span id="infopaneltitle-for-ascii-upper-alpha" style="display:none">Info about the 'ASCII upper alpha' definition.</span><b><a href="#ascii-upper-alpha">#ascii-upper-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-upper-alpha">4.5. Code points</a>
     <li><a href="#ref-for-ascii-upper-alpha①">4.6. Strings</a> <a href="#ref-for-ascii-upper-alpha②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-lower-alpha">
-   <b><a href="#ascii-lower-alpha">#ascii-lower-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-lower-alpha" class="dfn-panel" data-for="ascii-lower-alpha" id="infopanel-for-ascii-lower-alpha" role="dialog">
+   <span id="infopaneltitle-for-ascii-lower-alpha" style="display:none">Info about the 'ASCII lower alpha' definition.</span><b><a href="#ascii-lower-alpha">#ascii-lower-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lower-alpha">4.5. Code points</a>
     <li><a href="#ref-for-ascii-lower-alpha①">4.6. Strings</a> <a href="#ref-for-ascii-lower-alpha②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-alpha">
-   <b><a href="#ascii-alpha">#ascii-alpha</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-alpha" class="dfn-panel" data-for="ascii-alpha" id="infopanel-for-ascii-alpha" role="dialog">
+   <span id="infopaneltitle-for-ascii-alpha" style="display:none">Info about the 'ASCII alpha' definition.</span><b><a href="#ascii-alpha">#ascii-alpha</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alpha">4.5. Code points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-alphanumeric">
-   <b><a href="#ascii-alphanumeric">#ascii-alphanumeric</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-alphanumeric" class="dfn-panel" data-for="ascii-alphanumeric" id="infopanel-for-ascii-alphanumeric" role="dialog">
+   <span id="infopaneltitle-for-ascii-alphanumeric" style="display:none">Info about the 'ASCII alphanumeric' definition.</span><b><a href="#ascii-alphanumeric">#ascii-alphanumeric</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alphanumeric">7. Forgiving base64</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string">
-   <b><a href="#string">#string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string" class="dfn-panel" data-for="string" id="infopanel-for-string" role="dialog">
+   <span id="infopaneltitle-for-string" style="display:none">Info about the 'string' definition.</span><b><a href="#string">#string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">3.2. Declaration</a>
     <li><a href="#ref-for-string①">3.4. Variables</a> <a href="#ref-for-string②">(2)</a>
@@ -2052,133 +2052,135 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-string⑤⑦">6. JSON</a> <a href="#ref-for-string⑤⑧">(2)</a> <a href="#ref-for-string⑤⑨">(3)</a> <a href="#ref-for-string⑥⓪">(4)</a> <a href="#ref-for-string⑥①">(5)</a> <a href="#ref-for-string⑥②">(6)</a> <a href="#ref-for-string⑥③">(7)</a> <a href="#ref-for-string⑥④">(8)</a> <a href="#ref-for-string⑥⑤">(9)</a> <a href="#ref-for-string⑥⑥">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-unit">
-   <b><a href="#code-unit">#code-unit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-unit" class="dfn-panel" data-for="code-unit" id="infopanel-for-code-unit" role="dialog">
+   <span id="infopaneltitle-for-code-unit" style="display:none">Info about the 'code units' definition.</span><b><a href="#code-unit">#code-unit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit">4.6. Strings</a> <a href="#ref-for-code-unit①">(2)</a> <a href="#ref-for-code-unit②">(3)</a> <a href="#ref-for-code-unit③">(4)</a> <a href="#ref-for-code-unit④">(5)</a> <a href="#ref-for-code-unit⑤">(6)</a> <a href="#ref-for-code-unit⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-length">
-   <b><a href="#string-length">#string-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-length" class="dfn-panel" data-for="string-length" id="infopanel-for-string-length" role="dialog">
+   <span id="infopaneltitle-for-string-length" style="display:none">Info about the 'length' definition.</span><b><a href="#string-length">#string-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">4.6. Strings</a> <a href="#ref-for-string-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-code-point-length">
-   <b><a href="#string-code-point-length">#string-code-point-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-code-point-length" class="dfn-panel" data-for="string-code-point-length" id="infopanel-for-string-code-point-length" role="dialog">
+   <span id="infopaneltitle-for-string-code-point-length" style="display:none">Info about the 'code point length' definition.</span><b><a href="#string-code-point-length">#string-code-point-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-code-point-length">4.4. Byte sequences</a>
     <li><a href="#ref-for-string-code-point-length①">4.6. Strings</a>
     <li><a href="#ref-for-string-code-point-length②">7. Forgiving base64</a> <a href="#ref-for-string-code-point-length③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scalar-value-string">
-   <b><a href="#scalar-value-string">#scalar-value-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scalar-value-string" class="dfn-panel" data-for="scalar-value-string" id="infopanel-for-scalar-value-string" role="dialog">
+   <span id="infopaneltitle-for-scalar-value-string" style="display:none">Info about the 'scalar value string' definition.</span><b><a href="#scalar-value-string">#scalar-value-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scalar-value-string">4.6. Strings</a> <a href="#ref-for-scalar-value-string①">(2)</a> <a href="#ref-for-scalar-value-string②">(3)</a> <a href="#ref-for-scalar-value-string③">(4)</a> <a href="#ref-for-scalar-value-string④">(5)</a> <a href="#ref-for-scalar-value-string⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="javascript-string-convert">
-   <b><a href="#javascript-string-convert">#javascript-string-convert</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-javascript-string-convert" class="dfn-panel" data-for="javascript-string-convert" id="infopanel-for-javascript-string-convert" role="dialog">
+   <span id="infopaneltitle-for-javascript-string-convert" style="display:none">Info about the 'convert' definition.</span><b><a href="#javascript-string-convert">#javascript-string-convert</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-is">
-   <b><a href="#string-is">#string-is</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-is" class="dfn-panel" data-for="string-is" id="infopanel-for-string-is" role="dialog">
+   <span id="infopaneltitle-for-string-is" style="display:none">Info about the 'is' definition.</span><b><a href="#string-is">#string-is</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-is">4.6. Strings</a> <a href="#ref-for-string-is①">(2)</a> <a href="#ref-for-string-is②">(3)</a> <a href="#ref-for-string-is③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-unit-prefix">
-   <b><a href="#code-unit-prefix">#code-unit-prefix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-unit-prefix" class="dfn-panel" data-for="code-unit-prefix" id="infopanel-for-code-unit-prefix" role="dialog">
+   <span id="infopaneltitle-for-code-unit-prefix" style="display:none">Info about the 'code unit prefix' definition.</span><b><a href="#code-unit-prefix">#code-unit-prefix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit-prefix">4.6. Strings</a> <a href="#ref-for-code-unit-prefix①">(2)</a> <a href="#ref-for-code-unit-prefix②">(3)</a> <a href="#ref-for-code-unit-prefix③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-starts-with">
-   <b><a href="#string-starts-with">#string-starts-with</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-starts-with" class="dfn-panel" data-for="string-starts-with" id="infopanel-for-string-starts-with" role="dialog">
+   <span id="infopaneltitle-for-string-starts-with" style="display:none">Info about the 'starts with' definition.</span><b><a href="#string-starts-with">#string-starts-with</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-starts-with">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="code-unit-less-than">
-   <b><a href="#code-unit-less-than">#code-unit-less-than</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-code-unit-less-than" class="dfn-panel" data-for="code-unit-less-than" id="infopanel-for-code-unit-less-than" role="dialog">
+   <span id="infopaneltitle-for-code-unit-less-than" style="display:none">Info about the 'code unit less than' definition.</span><b><a href="#code-unit-less-than">#code-unit-less-than</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-unit-less-than">5.1. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="isomorphic-encode">
-   <b><a href="#isomorphic-encode">#isomorphic-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-isomorphic-encode" class="dfn-panel" data-for="isomorphic-encode" id="infopanel-for-isomorphic-encode" role="dialog">
+   <span id="infopaneltitle-for-isomorphic-encode" style="display:none">Info about the 'isomorphic encode' definition.</span><b><a href="#isomorphic-encode">#isomorphic-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-encode">4.4. Byte sequences</a>
     <li><a href="#ref-for-isomorphic-encode①">4.6. Strings</a> <a href="#ref-for-isomorphic-encode②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-string">
-   <b><a href="#ascii-string">#ascii-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-string" class="dfn-panel" data-for="ascii-string" id="infopanel-for-ascii-string" role="dialog">
+   <span id="infopaneltitle-for-ascii-string" style="display:none">Info about the 'ASCII string' definition.</span><b><a href="#ascii-string">#ascii-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-lowercase">
-   <b><a href="#ascii-lowercase">#ascii-lowercase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-lowercase" class="dfn-panel" data-for="ascii-lowercase" id="infopanel-for-ascii-lowercase" role="dialog">
+   <span id="infopaneltitle-for-ascii-lowercase" style="display:none">Info about the 'ASCII lowercase' definition.</span><b><a href="#ascii-lowercase">#ascii-lowercase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.6. Strings</a> <a href="#ref-for-ascii-lowercase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ascii-uppercase">
-   <b><a href="#ascii-uppercase">#ascii-uppercase</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ascii-uppercase" class="dfn-panel" data-for="ascii-uppercase" id="infopanel-for-ascii-uppercase" role="dialog">
+   <span id="infopaneltitle-for-ascii-uppercase" style="display:none">Info about the 'ASCII uppercase' definition.</span><b><a href="#ascii-uppercase">#ascii-uppercase</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-uppercase">3.2. Declaration</a>
     <li><a href="#ref-for-ascii-uppercase①">4.5. Code points</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="strip-leading-and-trailing-ascii-whitespace">
-   <b><a href="#strip-leading-and-trailing-ascii-whitespace">#strip-leading-and-trailing-ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-strip-leading-and-trailing-ascii-whitespace" class="dfn-panel" data-for="strip-leading-and-trailing-ascii-whitespace" id="infopanel-for-strip-leading-and-trailing-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-strip-leading-and-trailing-ascii-whitespace" style="display:none">Info about the 'strip leading and trailing ASCII whitespace' definition.</span><b><a href="#strip-leading-and-trailing-ascii-whitespace">#strip-leading-and-trailing-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strip-leading-and-trailing-ascii-whitespace">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="collect-a-sequence-of-code-points">
-   <b><a href="#collect-a-sequence-of-code-points">#collect-a-sequence-of-code-points</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="collect-a-sequence-of-code-points" id="infopanel-for-collect-a-sequence-of-code-points" role="dialog">
+   <span id="infopaneltitle-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collect a sequence of code points' definition.</span><b><a href="#collect-a-sequence-of-code-points">#collect-a-sequence-of-code-points</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">4.6. Strings</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points②">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points③">(4)</a> <a href="#ref-for-collect-a-sequence-of-code-points④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-position-variable">
-   <b><a href="#string-position-variable">#string-position-variable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-position-variable" class="dfn-panel" data-for="string-position-variable" id="infopanel-for-string-position-variable" role="dialog">
+   <span id="infopaneltitle-for-string-position-variable" style="display:none">Info about the 'position variable' definition.</span><b><a href="#string-position-variable">#string-position-variable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-position-variable">4.6. Strings</a> <a href="#ref-for-string-position-variable①">(2)</a> <a href="#ref-for-string-position-variable②">(3)</a> <a href="#ref-for-string-position-variable③">(4)</a> <a href="#ref-for-string-position-variable④">(5)</a>
     <li><a href="#ref-for-string-position-variable⑤">7. Forgiving base64</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="skip-ascii-whitespace">
-   <b><a href="#skip-ascii-whitespace">#skip-ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-skip-ascii-whitespace" class="dfn-panel" data-for="skip-ascii-whitespace" id="infopanel-for-skip-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-skip-ascii-whitespace" style="display:none">Info about the 'skip ASCII whitespace' definition.</span><b><a href="#skip-ascii-whitespace">#skip-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skip-ascii-whitespace">4.6. Strings</a> <a href="#ref-for-skip-ascii-whitespace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="split-on-ascii-whitespace">
-   <b><a href="#split-on-ascii-whitespace">#split-on-ascii-whitespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-split-on-ascii-whitespace" class="dfn-panel" data-for="split-on-ascii-whitespace" id="infopanel-for-split-on-ascii-whitespace" role="dialog">
+   <span id="infopaneltitle-for-split-on-ascii-whitespace" style="display:none">Info about the 'split a
+string input on ASCII whitespace' definition.</span><b><a href="#split-on-ascii-whitespace">#split-on-ascii-whitespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-ascii-whitespace">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="split-on-commas">
-   <b><a href="#split-on-commas">#split-on-commas</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-split-on-commas" class="dfn-panel" data-for="split-on-commas" id="infopanel-for-split-on-commas" role="dialog">
+   <span id="infopaneltitle-for-split-on-commas" style="display:none">Info about the 'split a string
+input on commas' definition.</span><b><a href="#split-on-commas">#split-on-commas</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-split-on-commas">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-concatenate">
-   <b><a href="#string-concatenate">#string-concatenate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-concatenate" class="dfn-panel" data-for="string-concatenate" id="infopanel-for-string-concatenate" role="dialog">
+   <span id="infopaneltitle-for-string-concatenate" style="display:none">Info about the 'concatenate' definition.</span><b><a href="#string-concatenate">#string-concatenate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-concatenate">4.6. Strings</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list">
-   <b><a href="#list">#list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list" class="dfn-panel" data-for="list" id="infopanel-for-list" role="dialog">
+   <span id="infopaneltitle-for-list" style="display:none">Info about the 'list' definition.</span><b><a href="#list">#list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.4. Variables</a>
     <li><a href="#ref-for-list①">3.6. Conditional abort</a> <a href="#ref-for-list②">(2)</a>
@@ -2192,8 +2194,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list④⑧">6. JSON</a> <a href="#ref-for-list④⑨">(2)</a> <a href="#ref-for-list⑤⓪">(3)</a> <a href="#ref-for-list⑤①">(4)</a> <a href="#ref-for-list⑤②">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-item">
-   <b><a href="#list-item">#list-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-item" class="dfn-panel" data-for="list-item" id="infopanel-for-list-item" role="dialog">
+   <span id="infopaneltitle-for-list-item" style="display:none">Info about the 'items' definition.</span><b><a href="#list-item">#list-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">4.6. Strings</a>
     <li><a href="#ref-for-list-item①">5. Data structures</a>
@@ -2204,8 +2206,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-item②①">5.2. Maps</a> <a href="#ref-for-list-item②②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-append">
-   <b><a href="#list-append">#list-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-append" class="dfn-panel" data-for="list-append" id="infopanel-for-list-append" role="dialog">
+   <span id="infopaneltitle-for-list-append" style="display:none">Info about the 'append' definition.</span><b><a href="#list-append">#list-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.6. Conditional abort</a> <a href="#ref-for-list-append①">(2)</a> <a href="#ref-for-list-append②">(3)</a> <a href="#ref-for-list-append③">(4)</a> <a href="#ref-for-list-append④">(5)</a> <a href="#ref-for-list-append⑤">(6)</a> <a href="#ref-for-list-append⑥">(7)</a> <a href="#ref-for-list-append⑦">(8)</a>
     <li><a href="#ref-for-list-append⑧">4.6. Strings</a> <a href="#ref-for-list-append⑨">(2)</a> <a href="#ref-for-list-append①⓪">(3)</a> <a href="#ref-for-list-append①①">(4)</a>
@@ -2217,14 +2219,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-append②⓪">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-extend">
-   <b><a href="#list-extend">#list-extend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-extend" class="dfn-panel" data-for="list-extend" id="infopanel-for-list-extend" role="dialog">
+   <span id="infopaneltitle-for-list-extend" style="display:none">Info about the 'extend' definition.</span><b><a href="#list-extend">#list-extend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-extend">5.1. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-prepend">
-   <b><a href="#list-prepend">#list-prepend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-prepend" class="dfn-panel" data-for="list-prepend" id="infopanel-for-list-prepend" role="dialog">
+   <span id="infopaneltitle-for-list-prepend" style="display:none">Info about the 'prepend' definition.</span><b><a href="#list-prepend">#list-prepend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-prepend">5.1. Lists</a>
     <li><a href="#ref-for-list-prepend①">5.1.1. Stacks</a>
@@ -2232,8 +2234,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-prepend③">5.1.3. Sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-remove">
-   <b><a href="#list-remove">#list-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-remove" class="dfn-panel" data-for="list-remove" id="infopanel-for-list-remove" role="dialog">
+   <span id="infopaneltitle-for-list-remove" style="display:none">Info about the 'remove' definition.</span><b><a href="#list-remove">#list-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">5.1. Lists</a> <a href="#ref-for-list-remove①">(2)</a> <a href="#ref-for-list-remove②">(3)</a>
     <li><a href="#ref-for-list-remove③">5.1.1. Stacks</a> <a href="#ref-for-list-remove④">(2)</a>
@@ -2241,31 +2243,31 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-remove⑦">5.1.3. Sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-contain">
-   <b><a href="#list-contain">#list-contain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-contain" class="dfn-panel" data-for="list-contain" id="infopanel-for-list-contain" role="dialog">
+   <span id="infopaneltitle-for-list-contain" style="display:none">Info about the 'contains' definition.</span><b><a href="#list-contain">#list-contain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">5. Data structures</a>
     <li><a href="#ref-for-list-contain①">5.1. Lists</a> <a href="#ref-for-list-contain②">(2)</a> <a href="#ref-for-list-contain③">(3)</a> <a href="#ref-for-list-contain④">(4)</a>
     <li><a href="#ref-for-list-contain⑤">5.1.3. Sets</a> <a href="#ref-for-list-contain⑥">(2)</a> <a href="#ref-for-list-contain⑦">(3)</a> <a href="#ref-for-list-contain⑧">(4)</a> <a href="#ref-for-list-contain⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-size">
-   <b><a href="#list-size">#list-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-size" class="dfn-panel" data-for="list-size" id="infopanel-for-list-size" role="dialog">
+   <span id="infopaneltitle-for-list-size" style="display:none">Info about the 'size' definition.</span><b><a href="#list-size">#list-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">5.1. Lists</a> <a href="#ref-for-list-size①">(2)</a>
     <li><a href="#ref-for-list-size②">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-is-empty">
-   <b><a href="#list-is-empty">#list-is-empty</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-is-empty" class="dfn-panel" data-for="list-is-empty" id="infopanel-for-list-is-empty" role="dialog">
+   <span id="infopaneltitle-for-list-is-empty" style="display:none">Info about the 'is empty' definition.</span><b><a href="#list-is-empty">#list-is-empty</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4.6. Strings</a>
     <li><a href="#ref-for-list-is-empty①">5.1.1. Stacks</a>
     <li><a href="#ref-for-list-is-empty②">5.1.2. Queues</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-iterate">
-   <b><a href="#list-iterate">#list-iterate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-iterate" class="dfn-panel" data-for="list-iterate" id="infopanel-for-list-iterate" role="dialog">
+   <span id="infopaneltitle-for-list-iterate" style="display:none">Info about the 'iterate' definition.</span><b><a href="#list-iterate">#list-iterate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.7. Iteration</a> <a href="#ref-for-list-iterate①">(2)</a> <a href="#ref-for-list-iterate②">(3)</a> <a href="#ref-for-list-iterate③">(4)</a>
     <li><a href="#ref-for-list-iterate④">5.1. Lists</a> <a href="#ref-for-list-iterate⑤">(2)</a> <a href="#ref-for-list-iterate⑥">(3)</a>
@@ -2275,46 +2277,46 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-iterate①③">6. JSON</a> <a href="#ref-for-list-iterate①④">(2)</a> <a href="#ref-for-list-iterate①⑤">(3)</a> <a href="#ref-for-list-iterate①⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-clone">
-   <b><a href="#list-clone">#list-clone</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-clone" class="dfn-panel" data-for="list-clone" id="infopanel-for-list-clone" role="dialog">
+   <span id="infopaneltitle-for-list-clone" style="display:none">Info about the 'clone' definition.</span><b><a href="#list-clone">#list-clone</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">5.1. Lists</a>
     <li><a href="#ref-for-list-clone①">5.1.3. Sets</a>
     <li><a href="#ref-for-list-clone②">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-sort-in-ascending-order">
-   <b><a href="#list-sort-in-ascending-order">#list-sort-in-ascending-order</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-sort-in-ascending-order" class="dfn-panel" data-for="list-sort-in-ascending-order" id="infopanel-for-list-sort-in-ascending-order" role="dialog">
+   <span id="infopaneltitle-for-list-sort-in-ascending-order" style="display:none">Info about the 'sort in ascending order' definition.</span><b><a href="#list-sort-in-ascending-order">#list-sort-in-ascending-order</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-sort-in-ascending-order">5.1. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stack">
-   <b><a href="#stack">#stack</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stack" class="dfn-panel" data-for="stack" id="infopanel-for-stack" role="dialog">
+   <span id="infopaneltitle-for-stack" style="display:none">Info about the 'stacks' definition.</span><b><a href="#stack">#stack</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack">5.1.1. Stacks</a> <a href="#ref-for-stack①">(2)</a> <a href="#ref-for-stack②">(3)</a> <a href="#ref-for-stack③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="stack-pop">
-   <b><a href="#stack-pop">#stack-pop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-stack-pop" class="dfn-panel" data-for="stack-pop" id="infopanel-for-stack-pop" role="dialog">
+   <span id="infopaneltitle-for-stack-pop" style="display:none">Info about the 'pop' definition.</span><b><a href="#stack-pop">#stack-pop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-stack-pop">5.1.1. Stacks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue">
-   <b><a href="#queue">#queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue" class="dfn-panel" data-for="queue" id="infopanel-for-queue" role="dialog">
+   <span id="infopaneltitle-for-queue" style="display:none">Info about the 'queues' definition.</span><b><a href="#queue">#queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue">5.1.2. Queues</a> <a href="#ref-for-queue①">(2)</a> <a href="#ref-for-queue②">(3)</a> <a href="#ref-for-queue③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queue-dequeue">
-   <b><a href="#queue-dequeue">#queue-dequeue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queue-dequeue" class="dfn-panel" data-for="queue-dequeue" id="infopanel-for-queue-dequeue" role="dialog">
+   <span id="infopaneltitle-for-queue-dequeue" style="display:none">Info about the 'dequeue' definition.</span><b><a href="#queue-dequeue">#queue-dequeue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-dequeue">5.1.2. Queues</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ordered-set">
-   <b><a href="#ordered-set">#ordered-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ordered-set" class="dfn-panel" data-for="ordered-set" id="infopanel-for-ordered-set" role="dialog">
+   <span id="infopaneltitle-for-ordered-set" style="display:none">Info about the 'ordered sets' definition.</span><b><a href="#ordered-set">#ordered-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">5. Data structures</a>
     <li><a href="#ref-for-ordered-set①">5.1. Lists</a> <a href="#ref-for-ordered-set②">(2)</a> <a href="#ref-for-ordered-set③">(3)</a> <a href="#ref-for-ordered-set④">(4)</a> <a href="#ref-for-ordered-set⑤">(5)</a> <a href="#ref-for-ordered-set⑥">(6)</a>
@@ -2322,249 +2324,306 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ordered-set①⑧">5.2. Maps</a> <a href="#ref-for-ordered-set①⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-append">
-   <b><a href="#set-append">#set-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-append" class="dfn-panel" data-for="set-append" id="infopanel-for-set-append" role="dialog">
+   <span id="infopaneltitle-for-set-append" style="display:none">Info about the 'append' definition.</span><b><a href="#set-append">#set-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">5. Data structures</a>
     <li><a href="#ref-for-set-append①">5.1. Lists</a>
     <li><a href="#ref-for-set-append②">5.1.3. Sets</a> <a href="#ref-for-set-append③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-prepend">
-   <b><a href="#set-prepend">#set-prepend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-prepend" class="dfn-panel" data-for="set-prepend" id="infopanel-for-set-prepend" role="dialog">
+   <span id="infopaneltitle-for-set-prepend" style="display:none">Info about the 'prepend' definition.</span><b><a href="#set-prepend">#set-prepend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-prepend">5.1. Lists</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-replace">
-   <b><a href="#set-replace">#set-replace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-replace" class="dfn-panel" data-for="set-replace" id="infopanel-for-set-replace" role="dialog">
+   <span id="infopaneltitle-for-set-replace" style="display:none">Info about the 'replace' definition.</span><b><a href="#set-replace">#set-replace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-replace">5.1. Lists</a> <a href="#ref-for-set-replace①">(2)</a>
     <li><a href="#ref-for-set-replace②">5.1.3. Sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-subset">
-   <b><a href="#set-subset">#set-subset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-subset" class="dfn-panel" data-for="set-subset" id="infopanel-for-set-subset" role="dialog">
+   <span id="infopaneltitle-for-set-subset" style="display:none">Info about the 'subset' definition.</span><b><a href="#set-subset">#set-subset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-subset">5.1.3. Sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-superset">
-   <b><a href="#set-superset">#set-superset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-superset" class="dfn-panel" data-for="set-superset" id="infopanel-for-set-superset" role="dialog">
+   <span id="infopaneltitle-for-set-superset" style="display:none">Info about the 'superset' definition.</span><b><a href="#set-superset">#set-superset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-superset">5.1.3. Sets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="the-range">
-   <b><a href="#the-range">#the-range</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-the-range" class="dfn-panel" data-for="the-range" id="infopanel-for-the-range" role="dialog">
+   <span id="infopaneltitle-for-the-range" style="display:none">Info about the 'The range' definition.</span><b><a href="#the-range">#the-range</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-range">5.1.3. Sets</a>
     <li><a href="#ref-for-the-range①">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ordered-map">
-   <b><a href="#ordered-map">#ordered-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ordered-map" class="dfn-panel" data-for="ordered-map" id="infopanel-for-ordered-map" role="dialog">
+   <span id="infopaneltitle-for-ordered-map" style="display:none">Info about the 'ordered map' definition.</span><b><a href="#ordered-map">#ordered-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">5. Data structures</a>
     <li><a href="#ref-for-ordered-map①">5.2. Maps</a> <a href="#ref-for-ordered-map②">(2)</a> <a href="#ref-for-ordered-map③">(3)</a> <a href="#ref-for-ordered-map④">(4)</a> <a href="#ref-for-ordered-map⑤">(5)</a> <a href="#ref-for-ordered-map⑥">(6)</a> <a href="#ref-for-ordered-map⑦">(7)</a> <a href="#ref-for-ordered-map⑧">(8)</a> <a href="#ref-for-ordered-map⑨">(9)</a> <a href="#ref-for-ordered-map①⓪">(10)</a> <a href="#ref-for-ordered-map①①">(11)</a> <a href="#ref-for-ordered-map①②">(12)</a> <a href="#ref-for-ordered-map①③">(13)</a> <a href="#ref-for-ordered-map①④">(14)</a> <a href="#ref-for-ordered-map①⑤">(15)</a> <a href="#ref-for-ordered-map①⑥">(16)</a> <a href="#ref-for-ordered-map①⑦">(17)</a> <a href="#ref-for-ordered-map①⑧">(18)</a> <a href="#ref-for-ordered-map①⑨">(19)</a> <a href="#ref-for-ordered-map②⓪">(20)</a> <a href="#ref-for-ordered-map②①">(21)</a> <a href="#ref-for-ordered-map②②">(22)</a> <a href="#ref-for-ordered-map②③">(23)</a> <a href="#ref-for-ordered-map②④">(24)</a>
     <li><a href="#ref-for-ordered-map②⑤">6. JSON</a> <a href="#ref-for-ordered-map②⑥">(2)</a> <a href="#ref-for-ordered-map②⑦">(3)</a> <a href="#ref-for-ordered-map②⑧">(4)</a> <a href="#ref-for-ordered-map②⑨">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-key">
-   <b><a href="#map-key">#map-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-key" class="dfn-panel" data-for="map-key" id="infopanel-for-map-key" role="dialog">
+   <span id="infopaneltitle-for-map-key" style="display:none">Info about the 'key' definition.</span><b><a href="#map-key">#map-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">5.2. Maps</a> <a href="#ref-for-map-key①">(2)</a> <a href="#ref-for-map-key②">(3)</a> <a href="#ref-for-map-key③">(4)</a> <a href="#ref-for-map-key④">(5)</a> <a href="#ref-for-map-key⑤">(6)</a> <a href="#ref-for-map-key⑥">(7)</a> <a href="#ref-for-map-key⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-value">
-   <b><a href="#map-value">#map-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-value" class="dfn-panel" data-for="map-value" id="infopanel-for-map-value" role="dialog">
+   <span id="infopaneltitle-for-map-value" style="display:none">Info about the 'value' definition.</span><b><a href="#map-value">#map-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">5.2. Maps</a> <a href="#ref-for-map-value①">(2)</a> <a href="#ref-for-map-value②">(3)</a> <a href="#ref-for-map-value③">(4)</a> <a href="#ref-for-map-value④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-entry">
-   <b><a href="#map-entry">#map-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-entry" class="dfn-panel" data-for="map-entry" id="infopanel-for-map-entry" role="dialog">
+   <span id="infopaneltitle-for-map-entry" style="display:none">Info about the 'entry' definition.</span><b><a href="#map-entry">#map-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-entry">5.2. Maps</a> <a href="#ref-for-map-entry①">(2)</a> <a href="#ref-for-map-entry②">(3)</a> <a href="#ref-for-map-entry③">(4)</a> <a href="#ref-for-map-entry④">(5)</a> <a href="#ref-for-map-entry⑤">(6)</a> <a href="#ref-for-map-entry⑥">(7)</a> <a href="#ref-for-map-entry⑦">(8)</a> <a href="#ref-for-map-entry⑧">(9)</a> <a href="#ref-for-map-entry⑨">(10)</a> <a href="#ref-for-map-entry①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-get">
-   <b><a href="#map-get">#map-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-get" class="dfn-panel" data-for="map-get" id="infopanel-for-map-get" role="dialog">
+   <span id="infopaneltitle-for-map-get" style="display:none">Info about the 'get the value of an entry' definition.</span><b><a href="#map-get">#map-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-get">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-set">
-   <b><a href="#map-set">#map-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-set" class="dfn-panel" data-for="map-set" id="infopanel-for-map-set" role="dialog">
+   <span id="infopaneltitle-for-map-set" style="display:none">Info about the 'set the value of an entry' definition.</span><b><a href="#map-set">#map-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">5.2. Maps</a> <a href="#ref-for-map-set①">(2)</a> <a href="#ref-for-map-set②">(3)</a>
     <li><a href="#ref-for-map-set③">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-remove">
-   <b><a href="#map-remove">#map-remove</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-remove" class="dfn-panel" data-for="map-remove" id="infopanel-for-map-remove" role="dialog">
+   <span id="infopaneltitle-for-map-remove" style="display:none">Info about the 'remove an entry' definition.</span><b><a href="#map-remove">#map-remove</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-exists">
-   <b><a href="#map-exists">#map-exists</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-exists" class="dfn-panel" data-for="map-exists" id="infopanel-for-map-exists" role="dialog">
+   <span id="infopaneltitle-for-map-exists" style="display:none">Info about the 'contains an
+entry with a given key' definition.</span><b><a href="#map-exists">#map-exists</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">5.2. Maps</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-getting-the-keys">
-   <b><a href="#map-getting-the-keys">#map-getting-the-keys</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-getting-the-keys" class="dfn-panel" data-for="map-getting-the-keys" id="infopanel-for-map-getting-the-keys" role="dialog">
+   <span id="infopaneltitle-for-map-getting-the-keys" style="display:none">Info about the 'get the keys' definition.</span><b><a href="#map-getting-the-keys">#map-getting-the-keys</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-size">
-   <b><a href="#map-size">#map-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-size" class="dfn-panel" data-for="map-size" id="infopanel-for-map-size" role="dialog">
+   <span id="infopaneltitle-for-map-size" style="display:none">Info about the 'size' definition.</span><b><a href="#map-size">#map-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-size">5.2. Maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="map-iterate">
-   <b><a href="#map-iterate">#map-iterate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-map-iterate" class="dfn-panel" data-for="map-iterate" id="infopanel-for-map-iterate" role="dialog">
+   <span id="infopaneltitle-for-map-iterate" style="display:none">Info about the 'iterate' definition.</span><b><a href="#map-iterate">#map-iterate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">3.7. Iteration</a>
     <li><a href="#ref-for-map-iterate①">5.2. Maps</a> <a href="#ref-for-map-iterate②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="struct">
-   <b><a href="#struct">#struct</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-struct" class="dfn-panel" data-for="struct" id="infopanel-for-struct" role="dialog">
+   <span id="infopaneltitle-for-struct" style="display:none">Info about the 'struct' definition.</span><b><a href="#struct">#struct</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">3.3. Parameters</a>
     <li><a href="#ref-for-struct①">5.3. Structs</a> <a href="#ref-for-struct②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="struct-item">
-   <b><a href="#struct-item">#struct-item</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-struct-item" class="dfn-panel" data-for="struct-item" id="infopanel-for-struct-item" role="dialog">
+   <span id="infopaneltitle-for-struct-item" style="display:none">Info about the 'items' definition.</span><b><a href="#struct-item">#struct-item</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">5.1. Lists</a> <a href="#ref-for-struct-item①">(2)</a>
     <li><a href="#ref-for-struct-item②">5.3. Structs</a> <a href="#ref-for-struct-item③">(2)</a> <a href="#ref-for-struct-item④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="struct-name">
-   <b><a href="#struct-name">#struct-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-struct-name" class="dfn-panel" data-for="struct-name" id="infopanel-for-struct-name" role="dialog">
+   <span id="infopaneltitle-for-struct-name" style="display:none">Info about the 'name' definition.</span><b><a href="#struct-name">#struct-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-name">5.3. Structs</a> <a href="#ref-for-struct-name①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tuple">
-   <b><a href="#tuple">#tuple</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tuple" class="dfn-panel" data-for="tuple" id="infopanel-for-tuple" role="dialog">
+   <span id="infopaneltitle-for-tuple" style="display:none">Info about the 'tuples' definition.</span><b><a href="#tuple">#tuple</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tuple">5.3. Structs</a> <a href="#ref-for-tuple①">(2)</a> <a href="#ref-for-tuple②">(3)</a> <a href="#ref-for-tuple③">(4)</a> <a href="#ref-for-tuple④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pair">
-   <b><a href="#pair">#pair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pair" class="dfn-panel" data-for="pair" id="infopanel-for-pair" role="dialog">
+   <span id="infopaneltitle-for-pair" style="display:none">Info about the 'pairs' definition.</span><b><a href="#pair">#pair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pair">5.3. Structs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-json-string-to-a-javascript-value">
-   <b><a href="#parse-a-json-string-to-a-javascript-value">#parse-a-json-string-to-a-javascript-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-json-string-to-a-javascript-value" class="dfn-panel" data-for="parse-a-json-string-to-a-javascript-value" id="infopanel-for-parse-a-json-string-to-a-javascript-value" role="dialog">
+   <span id="infopaneltitle-for-parse-a-json-string-to-a-javascript-value" style="display:none">Info about the 'parse a JSON string to a JavaScript value' definition.</span><b><a href="#parse-a-json-string-to-a-javascript-value">#parse-a-json-string-to-a-javascript-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-json-string-to-a-javascript-value">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-javascript-value-to-a-json-string">
-   <b><a href="#serialize-a-javascript-value-to-a-json-string">#serialize-a-javascript-value-to-a-json-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-javascript-value-to-a-json-string" class="dfn-panel" data-for="serialize-a-javascript-value-to-a-json-string" id="infopanel-for-serialize-a-javascript-value-to-a-json-string" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-javascript-value-to-a-json-string" style="display:none">Info about the 'serialize a JavaScript value to a JSON string' definition.</span><b><a href="#serialize-a-javascript-value-to-a-json-string">#serialize-a-javascript-value-to-a-json-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-javascript-value-to-a-json-string">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-json-string-to-an-infra-value">
-   <b><a href="#parse-a-json-string-to-an-infra-value">#parse-a-json-string-to-an-infra-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-json-string-to-an-infra-value" class="dfn-panel" data-for="parse-a-json-string-to-an-infra-value" id="infopanel-for-parse-a-json-string-to-an-infra-value" role="dialog">
+   <span id="infopaneltitle-for-parse-a-json-string-to-an-infra-value" style="display:none">Info about the 'parse a JSON string to an Infra value' definition.</span><b><a href="#parse-a-json-string-to-an-infra-value">#parse-a-json-string-to-an-infra-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-json-string-to-an-infra-value">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-a-json-derived-javascript-value-to-an-infra-value">
-   <b><a href="#convert-a-json-derived-javascript-value-to-an-infra-value">#convert-a-json-derived-javascript-value-to-an-infra-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-a-json-derived-javascript-value-to-an-infra-value" class="dfn-panel" data-for="convert-a-json-derived-javascript-value-to-an-infra-value" id="infopanel-for-convert-a-json-derived-javascript-value-to-an-infra-value" role="dialog">
+   <span id="infopaneltitle-for-convert-a-json-derived-javascript-value-to-an-infra-value" style="display:none">Info about the 'convert a JSON-derived JavaScript value to an Infra value' definition.</span><b><a href="#convert-a-json-derived-javascript-value-to-an-infra-value">#convert-a-json-derived-javascript-value-to-an-infra-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-a-json-derived-javascript-value-to-an-infra-value">6. JSON</a> <a href="#ref-for-convert-a-json-derived-javascript-value-to-an-infra-value①">(2)</a> <a href="#ref-for-convert-a-json-derived-javascript-value-to-an-infra-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-an-infra-value-to-a-json-string">
-   <b><a href="#serialize-an-infra-value-to-a-json-string">#serialize-an-infra-value-to-a-json-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-an-infra-value-to-a-json-string" class="dfn-panel" data-for="serialize-an-infra-value-to-a-json-string" id="infopanel-for-serialize-an-infra-value-to-a-json-string" role="dialog">
+   <span id="infopaneltitle-for-serialize-an-infra-value-to-a-json-string" style="display:none">Info about the 'serialize an Infra value to a JSON string' definition.</span><b><a href="#serialize-an-infra-value-to-a-json-string">#serialize-an-infra-value-to-a-json-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-infra-value-to-a-json-string">6. JSON</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="convert-an-infra-value-to-a-json-compatible-javascript-value">
-   <b><a href="#convert-an-infra-value-to-a-json-compatible-javascript-value">#convert-an-infra-value-to-a-json-compatible-javascript-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-convert-an-infra-value-to-a-json-compatible-javascript-value" class="dfn-panel" data-for="convert-an-infra-value-to-a-json-compatible-javascript-value" id="infopanel-for-convert-an-infra-value-to-a-json-compatible-javascript-value" role="dialog">
+   <span id="infopaneltitle-for-convert-an-infra-value-to-a-json-compatible-javascript-value" style="display:none">Info about the 'convert an Infra value to a JSON-compatible JavaScript value' definition.</span><b><a href="#convert-an-infra-value-to-a-json-compatible-javascript-value">#convert-an-infra-value-to-a-json-compatible-javascript-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-convert-an-infra-value-to-a-json-compatible-javascript-value">6. JSON</a> <a href="#ref-for-convert-an-infra-value-to-a-json-compatible-javascript-value①">(2)</a> <a href="#ref-for-convert-an-infra-value-to-a-json-compatible-javascript-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forgiving-base64-encode">
-   <b><a href="#forgiving-base64-encode">#forgiving-base64-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forgiving-base64-encode" class="dfn-panel" data-for="forgiving-base64-encode" id="infopanel-for-forgiving-base64-encode" role="dialog">
+   <span id="infopaneltitle-for-forgiving-base64-encode" style="display:none">Info about the 'forgiving-base64 encode' definition.</span><b><a href="#forgiving-base64-encode">#forgiving-base64-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forgiving-base64-encode">7. Forgiving base64</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forgiving-base64-decode">
-   <b><a href="#forgiving-base64-decode">#forgiving-base64-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forgiving-base64-decode" class="dfn-panel" data-for="forgiving-base64-decode" id="infopanel-for-forgiving-base64-decode" role="dialog">
+   <span id="infopaneltitle-for-forgiving-base64-decode" style="display:none">Info about the 'forgiving-base64 decode' definition.</span><b><a href="#forgiving-base64-decode">#forgiving-base64-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forgiving-base64-decode">7. Forgiving base64</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/mimesniff/mimesniff.html
+++ b/tests/github/whatwg/mimesniff/mimesniff.html
@@ -1734,95 +1734,95 @@ if ("serviceWorker" in navigator) {
    <li><a href="#xml-mime-type">XML MIME type</a><span>, in § 4.6</span>
    <li><a href="#zip-based-mime-type">ZIP-based MIME type</a><span>, in § 4.6</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-collect-an-http-quoted-string">
-   <a href="https://fetch.spec.whatwg.org/#collect-an-http-quoted-string">https://fetch.spec.whatwg.org/#collect-an-http-quoted-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-an-http-quoted-string" class="dfn-panel" data-for="term-for-collect-an-http-quoted-string" id="infopanel-for-term-for-collect-an-http-quoted-string" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-an-http-quoted-string" style="display:none">Info about the 'collecting an http quoted string' external reference.</span><a href="https://fetch.spec.whatwg.org/#collect-an-http-quoted-string">https://fetch.spec.whatwg.org/#collect-an-http-quoted-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-an-http-quoted-string">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">8.4. Sniffing in a plugin context</a>
     <li><a href="#ref-for-concept-fetch①">8.5. Sniffing in a style context</a>
     <li><a href="#ref-for-concept-fetch②">8.6. Sniffing in a script context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-http-whitespace">
-   <a href="https://fetch.spec.whatwg.org/#http-whitespace">https://fetch.spec.whatwg.org/#http-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-http-whitespace" class="dfn-panel" data-for="term-for-http-whitespace" id="infopanel-for-term-for-http-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-http-whitespace" style="display:none">Info about the 'http whitespace' external reference.</span><a href="https://fetch.spec.whatwg.org/#http-whitespace">https://fetch.spec.whatwg.org/#http-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-whitespace">4.4. Parsing a MIME type</a> <a href="#ref-for-http-whitespace①">(2)</a> <a href="#ref-for-http-whitespace②">(3)</a> <a href="#ref-for-http-whitespace③">(4)</a> <a href="#ref-for-http-whitespace④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-script">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-script" class="dfn-panel" data-for="term-for-script" id="infopanel-for-term-for-script" role="menu">
+   <span id="infopaneltitle-for-term-for-script" style="display:none">Info about the 'script' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#script">https://html.spec.whatwg.org/multipage/scripting.html#script</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-script">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attr-script-type">
-   <a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type">https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attr-script-type" class="dfn-panel" data-for="term-for-attr-script-type" id="infopanel-for-term-for-attr-script-type" role="menu">
+   <span id="infopaneltitle-for-term-for-attr-script-type" style="display:none">Info about the 'type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type">https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-script-type">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.1.1.1">
-   <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">https://tools.ietf.org/html/rfc7231#section-3.1.1.1</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.1.1.1" class="dfn-panel" data-for="term-for-section-3.1.1.1" id="infopanel-for-term-for-section-3.1.1.1" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.1.1.1" style="display:none">Info about the 'media-type' external reference.</span><a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">https://tools.ietf.org/html/rfc7231#section-3.1.1.1</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.1.1.1">4.3. MIME type writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6" style="display:none">Info about the 'quoted-string' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">3. Terminology</a> <a href="#ref-for-section-3.2.6①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-section-3.2.6">
-   <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-section-3.2.6" class="dfn-panel" data-for="term-for-section-3.2.6" id="infopanel-for-term-for-section-3.2.6①" role="menu">
+   <span id="infopaneltitle-for-term-for-section-3.2.6①" style="display:none">Info about the 'token' external reference.</span><a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">https://tools.ietf.org/html/rfc7230#section-3.2.6</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-section-3.2.6">3. Terminology</a> <a href="#ref-for-section-3.2.6①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-alphanumeric">
-   <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-alphanumeric" class="dfn-panel" data-for="term-for-ascii-alphanumeric" id="infopanel-for-term-for-ascii-alphanumeric" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-alphanumeric" style="display:none">Info about the 'ascii alphanumeric' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alphanumeric">3. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.4. Parsing a MIME type</a> <a href="#ref-for-ascii-lowercase①">(2)</a> <a href="#ref-for-ascii-lowercase②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">4.1. MIME type representation</a> <a href="#ref-for-ascii-string①">(2)</a> <a href="#ref-for-ascii-string②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-whitespace" class="dfn-panel" data-for="term-for-ascii-whitespace" id="infopanel-for-term-for-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-whitespace" style="display:none">Info about the 'ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-whitespace">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">4.4. Parsing a MIME type</a>
     <li><a href="#ref-for-iteration-break①">6. Matching a MIME type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte">
-   <a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte" class="dfn-panel" data-for="term-for-byte" id="infopanel-for-term-for-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">3. Terminology</a> <a href="#ref-for-byte①">(2)</a> <a href="#ref-for-byte②">(3)</a> <a href="#ref-for-byte③">(4)</a> <a href="#ref-for-byte④">(5)</a> <a href="#ref-for-byte⑤">(6)</a>
     <li><a href="#ref-for-byte⑥">5.1. Interpreting the resource metadata</a>
@@ -1840,8 +1840,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte④⑦">7.3. Sniffing a mislabeled feed</a> <a href="#ref-for-byte④⑧">(2)</a> <a href="#ref-for-byte④⑨">(3)</a> <a href="#ref-for-byte⑤⓪">(4)</a> <a href="#ref-for-byte⑤①">(5)</a> <a href="#ref-for-byte⑤②">(6)</a> <a href="#ref-for-byte⑤③">(7)</a> <a href="#ref-for-byte⑤④">(8)</a> <a href="#ref-for-byte⑤⑤">(9)</a> <a href="#ref-for-byte⑤⑥">(10)</a> <a href="#ref-for-byte⑤⑦">(11)</a> <a href="#ref-for-byte⑤⑧">(12)</a> <a href="#ref-for-byte⑤⑨">(13)</a> <a href="#ref-for-byte⑥⓪">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">4.4. Parsing a MIME type</a>
     <li><a href="#ref-for-byte-sequence①">5.2. Reading the resource header</a> <a href="#ref-for-byte-sequence②">(2)</a>
@@ -1859,111 +1859,111 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte-sequence②③">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">3. Terminology</a> <a href="#ref-for-code-point①">(2)</a>
     <li><a href="#ref-for-code-point②">4.4. Parsing a MIME type</a> <a href="#ref-for-code-point③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" style="display:none">Info about the 'collect a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">4.4. Parsing a MIME type</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points②">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points③">(4)</a> <a href="#ref-for-collect-a-sequence-of-code-points④">(5)</a> <a href="#ref-for-collect-a-sequence-of-code-points⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
-   <a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-collect-a-sequence-of-code-points" class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points" id="infopanel-for-term-for-collect-a-sequence-of-code-points①" role="menu">
+   <span id="infopaneltitle-for-term-for-collect-a-sequence-of-code-points①" style="display:none">Info about the 'collecting a sequence of code points' external reference.</span><a href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points">https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-collect-a-sequence-of-code-points">4.4. Parsing a MIME type</a> <a href="#ref-for-collect-a-sequence-of-code-points①">(2)</a> <a href="#ref-for-collect-a-sequence-of-code-points②">(3)</a> <a href="#ref-for-collect-a-sequence-of-code-points③">(4)</a> <a href="#ref-for-collect-a-sequence-of-code-points④">(5)</a> <a href="#ref-for-collect-a-sequence-of-code-points⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">6. Matching a MIME type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">4.4. Parsing a MIME type</a> <a href="#ref-for-iteration-continue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.5. Serializing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-decode" class="dfn-panel" data-for="term-for-isomorphic-decode" id="infopanel-for-term-for-isomorphic-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-encode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-encode">https://infra.spec.whatwg.org/#isomorphic-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-encode" class="dfn-panel" data-for="term-for-isomorphic-encode" id="infopanel-for-term-for-isomorphic-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-encode" style="display:none">Info about the 'isomorphic encode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-encode">https://infra.spec.whatwg.org/#isomorphic-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-encode">4.5. Serializing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-keys">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-keys" class="dfn-panel" data-for="term-for-map-getting-the-keys" id="infopanel-for-term-for-map-getting-the-keys" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-keys" style="display:none">Info about the 'keys' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-keys">https://infra.spec.whatwg.org/#map-getting-the-keys</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-keys">4.1. MIME type representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">6. Matching a MIME type pattern</a> <a href="#ref-for-byte-sequence-length①">(2)</a> <a href="#ref-for-byte-sequence-length②">(3)</a> <a href="#ref-for-byte-sequence-length③">(4)</a> <a href="#ref-for-byte-sequence-length④">(5)</a> <a href="#ref-for-byte-sequence-length⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'ordered map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4.1. MIME type representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-position-variable">
-   <a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-position-variable" class="dfn-panel" data-for="term-for-string-position-variable" id="infopanel-for-term-for-string-position-variable" role="menu">
+   <span id="infopaneltitle-for-term-for-string-position-variable" style="display:none">Info about the 'position variable' external reference.</span><a href="https://infra.spec.whatwg.org/#string-position-variable">https://infra.spec.whatwg.org/#string-position-variable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-position-variable">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">6. Matching a MIME type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-skip-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">https://infra.spec.whatwg.org/#skip-ascii-whitespace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-skip-ascii-whitespace" class="dfn-panel" data-for="term-for-skip-ascii-whitespace" id="infopanel-for-term-for-skip-ascii-whitespace" role="menu">
+   <span id="infopaneltitle-for-term-for-skip-ascii-whitespace" style="display:none">Info about the 'skip ascii whitespace' external reference.</span><a href="https://infra.spec.whatwg.org/#skip-ascii-whitespace">https://infra.spec.whatwg.org/#skip-ascii-whitespace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-skip-ascii-whitespace">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-getting-the-values">
-   <a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-getting-the-values" class="dfn-panel" data-for="term-for-map-getting-the-values" id="infopanel-for-term-for-map-getting-the-values" role="menu">
+   <span id="infopaneltitle-for-term-for-map-getting-the-values" style="display:none">Info about the 'values' external reference.</span><a href="https://infra.spec.whatwg.org/#map-getting-the-values">https://infra.spec.whatwg.org/#map-getting-the-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-getting-the-values">4.1. MIME type representation</a>
    </ul>
@@ -2054,42 +2054,42 @@ if ("serviceWorker" in navigator) {
    <dt id="biblio-mediaqueries">[MEDIAQUERIES]
    <dd>Florian Rivoal; Tab Atkins Jr.. <a href="https://drafts.csswg.org/mediaqueries-4/"><cite>Media Queries Level 4</cite></a>. URL: <a href="https://drafts.csswg.org/mediaqueries-4/">https://drafts.csswg.org/mediaqueries-4/</a>
   </dl>
-  <aside class="dfn-panel" data-for="http-token-code-point">
-   <b><a href="#http-token-code-point">#http-token-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-token-code-point" class="dfn-panel" data-for="http-token-code-point" id="infopanel-for-http-token-code-point" role="dialog">
+   <span id="infopaneltitle-for-http-token-code-point" style="display:none">Info about the 'HTTP token code point' definition.</span><b><a href="#http-token-code-point">#http-token-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-token-code-point">3. Terminology</a>
     <li><a href="#ref-for-http-token-code-point①">4.4. Parsing a MIME type</a> <a href="#ref-for-http-token-code-point②">(2)</a> <a href="#ref-for-http-token-code-point③">(3)</a>
     <li><a href="#ref-for-http-token-code-point④">4.5. Serializing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-quoted-string-token-code-point">
-   <b><a href="#http-quoted-string-token-code-point">#http-quoted-string-token-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-quoted-string-token-code-point" class="dfn-panel" data-for="http-quoted-string-token-code-point" id="infopanel-for-http-quoted-string-token-code-point" role="dialog">
+   <span id="infopaneltitle-for-http-quoted-string-token-code-point" style="display:none">Info about the 'HTTP quoted-string token code point' definition.</span><b><a href="#http-quoted-string-token-code-point">#http-quoted-string-token-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-quoted-string-token-code-point">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="binary-data-byte">
-   <b><a href="#binary-data-byte">#binary-data-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-binary-data-byte" class="dfn-panel" data-for="binary-data-byte" id="infopanel-for-binary-data-byte" role="dialog">
+   <span id="infopaneltitle-for-binary-data-byte" style="display:none">Info about the 'binary data byte' definition.</span><b><a href="#binary-data-byte">#binary-data-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-binary-data-byte">7.1. Identifying a resource with an unknown MIME type</a>
     <li><a href="#ref-for-binary-data-byte①">7.2. Sniffing a mislabeled binary resource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="whitespace-byte">
-   <b><a href="#whitespace-byte">#whitespace-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-whitespace-byte" class="dfn-panel" data-for="whitespace-byte" id="infopanel-for-whitespace-byte" role="dialog">
+   <span id="infopaneltitle-for-whitespace-byte" style="display:none">Info about the 'whitespace byte' definition.</span><b><a href="#whitespace-byte">#whitespace-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-whitespace-byte">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-whitespace-byte①">(2)</a> <a href="#ref-for-whitespace-byte②">(3)</a> <a href="#ref-for-whitespace-byte③">(4)</a> <a href="#ref-for-whitespace-byte④">(5)</a> <a href="#ref-for-whitespace-byte⑤">(6)</a> <a href="#ref-for-whitespace-byte⑥">(7)</a> <a href="#ref-for-whitespace-byte⑦">(8)</a> <a href="#ref-for-whitespace-byte⑧">(9)</a> <a href="#ref-for-whitespace-byte⑨">(10)</a> <a href="#ref-for-whitespace-byte①⓪">(11)</a> <a href="#ref-for-whitespace-byte①①">(12)</a> <a href="#ref-for-whitespace-byte①②">(13)</a> <a href="#ref-for-whitespace-byte①③">(14)</a> <a href="#ref-for-whitespace-byte①④">(15)</a> <a href="#ref-for-whitespace-byte①⑤">(16)</a> <a href="#ref-for-whitespace-byte①⑥">(17)</a> <a href="#ref-for-whitespace-byte①⑦">(18)</a>
     <li><a href="#ref-for-whitespace-byte①⑧">7.3. Sniffing a mislabeled feed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tag-terminating-byte">
-   <b><a href="#tag-terminating-byte">#tag-terminating-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tag-terminating-byte" class="dfn-panel" data-for="tag-terminating-byte" id="infopanel-for-tag-terminating-byte" role="dialog">
+   <span id="infopaneltitle-for-tag-terminating-byte" style="display:none">Info about the 'tag-terminating byte' definition.</span><b><a href="#tag-terminating-byte">#tag-terminating-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tag-terminating-byte">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-tag-terminating-byte①">(2)</a> <a href="#ref-for-tag-terminating-byte②">(3)</a> <a href="#ref-for-tag-terminating-byte③">(4)</a> <a href="#ref-for-tag-terminating-byte④">(5)</a> <a href="#ref-for-tag-terminating-byte⑤">(6)</a> <a href="#ref-for-tag-terminating-byte⑥">(7)</a> <a href="#ref-for-tag-terminating-byte⑦">(8)</a> <a href="#ref-for-tag-terminating-byte⑧">(9)</a> <a href="#ref-for-tag-terminating-byte⑨">(10)</a> <a href="#ref-for-tag-terminating-byte①⓪">(11)</a> <a href="#ref-for-tag-terminating-byte①①">(12)</a> <a href="#ref-for-tag-terminating-byte①②">(13)</a> <a href="#ref-for-tag-terminating-byte①③">(14)</a> <a href="#ref-for-tag-terminating-byte①④">(15)</a> <a href="#ref-for-tag-terminating-byte①⑤">(16)</a> <a href="#ref-for-tag-terminating-byte①⑥">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mime-type">
-   <b><a href="#mime-type">#mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mime-type" class="dfn-panel" data-for="mime-type" id="infopanel-for-mime-type" role="dialog">
+   <span id="infopaneltitle-for-mime-type" style="display:none">Info about the 'MIME type' definition.</span><b><a href="#mime-type">#mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">4.1. MIME type representation</a> <a href="#ref-for-mime-type①">(2)</a> <a href="#ref-for-mime-type②">(3)</a> <a href="#ref-for-mime-type③">(4)</a> <a href="#ref-for-mime-type④">(5)</a>
     <li><a href="#ref-for-mime-type⑤">4.2. MIME type miscellaneous</a> <a href="#ref-for-mime-type⑥">(2)</a> <a href="#ref-for-mime-type⑦">(3)</a>
@@ -2103,8 +2103,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-mime-type③⓪">8. Context-specific sniffing</a> <a href="#ref-for-mime-type③①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="type">
-   <b><a href="#type">#type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-type" class="dfn-panel" data-for="type" id="infopanel-for-type" role="dialog">
+   <span id="infopaneltitle-for-type" style="display:none">Info about the 'type' definition.</span><b><a href="#type">#type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type">4.2. MIME type miscellaneous</a>
     <li><a href="#ref-for-type①">4.4. Parsing a MIME type</a>
@@ -2112,8 +2112,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-type③">4.6. MIME type groups</a> <a href="#ref-for-type④">(2)</a> <a href="#ref-for-type⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="subtype">
-   <b><a href="#subtype">#subtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-subtype" class="dfn-panel" data-for="subtype" id="infopanel-for-subtype" role="dialog">
+   <span id="infopaneltitle-for-subtype" style="display:none">Info about the 'subtype' definition.</span><b><a href="#subtype">#subtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-subtype">4.2. MIME type miscellaneous</a>
     <li><a href="#ref-for-subtype①">4.4. Parsing a MIME type</a>
@@ -2121,77 +2121,77 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-subtype③">4.6. MIME type groups</a> <a href="#ref-for-subtype④">(2)</a> <a href="#ref-for-subtype⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parameters">
-   <b><a href="#parameters">#parameters</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parameters" class="dfn-panel" data-for="parameters" id="infopanel-for-parameters" role="dialog">
+   <span id="infopaneltitle-for-parameters" style="display:none">Info about the 'parameters' definition.</span><b><a href="#parameters">#parameters</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">4.3. MIME type writing</a>
     <li><a href="#ref-for-parameters①">4.4. Parsing a MIME type</a> <a href="#ref-for-parameters②">(2)</a>
     <li><a href="#ref-for-parameters③">4.5. Serializing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mime-type-essence">
-   <b><a href="#mime-type-essence">#mime-type-essence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mime-type-essence" class="dfn-panel" data-for="mime-type-essence" id="infopanel-for-mime-type-essence" role="dialog">
+   <span id="infopaneltitle-for-mime-type-essence" style="display:none">Info about the 'essence' definition.</span><b><a href="#mime-type-essence">#mime-type-essence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type-essence">4.6. MIME type groups</a> <a href="#ref-for-mime-type-essence①">(2)</a> <a href="#ref-for-mime-type-essence②">(3)</a> <a href="#ref-for-mime-type-essence③">(4)</a> <a href="#ref-for-mime-type-essence④">(5)</a> <a href="#ref-for-mime-type-essence⑤">(6)</a> <a href="#ref-for-mime-type-essence⑥">(7)</a> <a href="#ref-for-mime-type-essence⑦">(8)</a> <a href="#ref-for-mime-type-essence⑧">(9)</a>
     <li><a href="#ref-for-mime-type-essence⑨">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-mime-type-essence①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supported-by-the-user-agent">
-   <b><a href="#supported-by-the-user-agent">#supported-by-the-user-agent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supported-by-the-user-agent" class="dfn-panel" data-for="supported-by-the-user-agent" id="infopanel-for-supported-by-the-user-agent" role="dialog">
+   <span id="infopaneltitle-for-supported-by-the-user-agent" style="display:none">Info about the 'supported by the user agent' definition.</span><b><a href="#supported-by-the-user-agent">#supported-by-the-user-agent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supported-by-the-user-agent">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-supported-by-the-user-agent①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-mime-type">
-   <b><a href="#valid-mime-type">#valid-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-mime-type" class="dfn-panel" data-for="valid-mime-type" id="infopanel-for-valid-mime-type" role="dialog">
+   <span id="infopaneltitle-for-valid-mime-type" style="display:none">Info about the 'valid MIME type string' definition.</span><b><a href="#valid-mime-type">#valid-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-mime-type">4.3. MIME type writing</a> <a href="#ref-for-valid-mime-type①">(2)</a> <a href="#ref-for-valid-mime-type②">(3)</a> <a href="#ref-for-valid-mime-type③">(4)</a> <a href="#ref-for-valid-mime-type④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-mime-type">
-   <b><a href="#parse-a-mime-type">#parse-a-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-mime-type" class="dfn-panel" data-for="parse-a-mime-type" id="infopanel-for-parse-a-mime-type" role="dialog">
+   <span id="infopaneltitle-for-parse-a-mime-type" style="display:none">Info about the 'parse a MIME type' definition.</span><b><a href="#parse-a-mime-type">#parse-a-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type">4.3. MIME type writing</a>
     <li><a href="#ref-for-parse-a-mime-type①">4.4. Parsing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="serialize-a-mime-type">
-   <b><a href="#serialize-a-mime-type">#serialize-a-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-a-mime-type" class="dfn-panel" data-for="serialize-a-mime-type" id="infopanel-for-serialize-a-mime-type" role="dialog">
+   <span id="infopaneltitle-for-serialize-a-mime-type" style="display:none">Info about the 'serialize a MIME type' definition.</span><b><a href="#serialize-a-mime-type">#serialize-a-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-mime-type">4.5. Serializing a MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-mime-type">
-   <b><a href="#image-mime-type">#image-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-mime-type" class="dfn-panel" data-for="image-mime-type" id="infopanel-for-image-mime-type" role="dialog">
+   <span id="infopaneltitle-for-image-mime-type" style="display:none">Info about the 'image MIME type' definition.</span><b><a href="#image-mime-type">#image-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-mime-type">6.1. Matching an image type pattern</a> <a href="#ref-for-image-mime-type①">(2)</a>
     <li><a href="#ref-for-image-mime-type②">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-image-mime-type③">8.2. Sniffing in an image context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audio-or-video-mime-type">
-   <b><a href="#audio-or-video-mime-type">#audio-or-video-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audio-or-video-mime-type" class="dfn-panel" data-for="audio-or-video-mime-type" id="infopanel-for-audio-or-video-mime-type" role="dialog">
+   <span id="infopaneltitle-for-audio-or-video-mime-type" style="display:none">Info about the 'audio or video MIME type' definition.</span><b><a href="#audio-or-video-mime-type">#audio-or-video-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio-or-video-mime-type">6.2. Matching an audio or video type pattern</a> <a href="#ref-for-audio-or-video-mime-type①">(2)</a>
     <li><a href="#ref-for-audio-or-video-mime-type②">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-audio-or-video-mime-type③">8.3. Sniffing in an audio or video context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-mime-type">
-   <b><a href="#font-mime-type">#font-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-mime-type" class="dfn-panel" data-for="font-mime-type" id="infopanel-for-font-mime-type" role="dialog">
+   <span id="infopaneltitle-for-font-mime-type" style="display:none">Info about the 'font MIME type' definition.</span><b><a href="#font-mime-type">#font-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-mime-type">6.3. Matching a font type pattern</a> <a href="#ref-for-font-mime-type①">(2)</a>
     <li><a href="#ref-for-font-mime-type②">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="archive-mime-type">
-   <b><a href="#archive-mime-type">#archive-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-archive-mime-type" class="dfn-panel" data-for="archive-mime-type" id="infopanel-for-archive-mime-type" role="dialog">
+   <span id="infopaneltitle-for-archive-mime-type" style="display:none">Info about the 'archive MIME type' definition.</span><b><a href="#archive-mime-type">#archive-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-archive-mime-type">6.4. Matching an archive type pattern</a> <a href="#ref-for-archive-mime-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xml-mime-type">
-   <b><a href="#xml-mime-type">#xml-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xml-mime-type" class="dfn-panel" data-for="xml-mime-type" id="infopanel-for-xml-mime-type" role="dialog">
+   <span id="infopaneltitle-for-xml-mime-type" style="display:none">Info about the 'XML MIME type' definition.</span><b><a href="#xml-mime-type">#xml-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-mime-type">4.6. MIME type groups</a>
     <li><a href="#ref-for-xml-mime-type①">7. Determining the computed MIME type of a resource</a>
@@ -2200,27 +2200,27 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-xml-mime-type④">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="html-mime-type">
-   <b><a href="#html-mime-type">#html-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-html-mime-type" class="dfn-panel" data-for="html-mime-type" id="infopanel-for-html-mime-type" role="dialog">
+   <span id="infopaneltitle-for-html-mime-type" style="display:none">Info about the 'HTML MIME type' definition.</span><b><a href="#html-mime-type">#html-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-mime-type">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scriptable-mime-type">
-   <b><a href="#scriptable-mime-type">#scriptable-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scriptable-mime-type" class="dfn-panel" data-for="scriptable-mime-type" id="infopanel-for-scriptable-mime-type" role="dialog">
+   <span id="infopaneltitle-for-scriptable-mime-type" style="display:none">Info about the 'scriptable MIME type' definition.</span><b><a href="#scriptable-mime-type">#scriptable-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scriptable-mime-type">7.1. Identifying a resource with an unknown MIME type</a>
     <li><a href="#ref-for-scriptable-mime-type①">7.2. Sniffing a mislabeled binary resource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="javascript-mime-type">
-   <b><a href="#javascript-mime-type">#javascript-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-javascript-mime-type" class="dfn-panel" data-for="javascript-mime-type" id="infopanel-for-javascript-mime-type" role="dialog">
+   <span id="infopaneltitle-for-javascript-mime-type" style="display:none">Info about the 'JavaScript MIME type' definition.</span><b><a href="#javascript-mime-type">#javascript-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-mime-type">4.6. MIME type groups</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resource">
-   <b><a href="#resource">#resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resource" class="dfn-panel" data-for="resource" id="infopanel-for-resource" role="dialog">
+   <span id="infopaneltitle-for-resource" style="display:none">Info about the 'resource' definition.</span><b><a href="#resource">#resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resource">4.2. MIME type miscellaneous</a>
     <li><a href="#ref-for-resource①">5. Handling a resource</a> <a href="#ref-for-resource②">(2)</a> <a href="#ref-for-resource③">(3)</a> <a href="#ref-for-resource④">(4)</a>
@@ -2238,8 +2238,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-resource③①">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supplied-mime-type">
-   <b><a href="#supplied-mime-type">#supplied-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supplied-mime-type" class="dfn-panel" data-for="supplied-mime-type" id="infopanel-for-supplied-mime-type" role="dialog">
+   <span id="infopaneltitle-for-supplied-mime-type" style="display:none">Info about the 'supplied MIME type' definition.</span><b><a href="#supplied-mime-type">#supplied-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supplied-mime-type">5.1. Interpreting the resource metadata</a> <a href="#ref-for-supplied-mime-type①">(2)</a> <a href="#ref-for-supplied-mime-type②">(3)</a> <a href="#ref-for-supplied-mime-type③">(4)</a> <a href="#ref-for-supplied-mime-type④">(5)</a>
     <li><a href="#ref-for-supplied-mime-type⑤">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-supplied-mime-type⑥">(2)</a> <a href="#ref-for-supplied-mime-type⑦">(3)</a> <a href="#ref-for-supplied-mime-type⑧">(4)</a> <a href="#ref-for-supplied-mime-type⑨">(5)</a> <a href="#ref-for-supplied-mime-type①⓪">(6)</a> <a href="#ref-for-supplied-mime-type①①">(7)</a> <a href="#ref-for-supplied-mime-type①②">(8)</a> <a href="#ref-for-supplied-mime-type①③">(9)</a>
@@ -2252,21 +2252,21 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-supplied-mime-type③⑦">8.7. Sniffing in a font context</a> <a href="#ref-for-supplied-mime-type③⑧">(2)</a> <a href="#ref-for-supplied-mime-type③⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="check-for-apache-bug-flag">
-   <b><a href="#check-for-apache-bug-flag">#check-for-apache-bug-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-check-for-apache-bug-flag" class="dfn-panel" data-for="check-for-apache-bug-flag" id="infopanel-for-check-for-apache-bug-flag" role="dialog">
+   <span id="infopaneltitle-for-check-for-apache-bug-flag" style="display:none">Info about the 'check-for-apache-bug flag' definition.</span><b><a href="#check-for-apache-bug-flag">#check-for-apache-bug-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-check-for-apache-bug-flag">5.1. Interpreting the resource metadata</a>
     <li><a href="#ref-for-check-for-apache-bug-flag①">7. Determining the computed MIME type of a resource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-sniff-flag">
-   <b><a href="#no-sniff-flag">#no-sniff-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-sniff-flag" class="dfn-panel" data-for="no-sniff-flag" id="infopanel-for-no-sniff-flag" role="dialog">
+   <span id="infopaneltitle-for-no-sniff-flag" style="display:none">Info about the 'no-sniff flag' definition.</span><b><a href="#no-sniff-flag">#no-sniff-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-sniff-flag">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-no-sniff-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="computed-mime-type">
-   <b><a href="#computed-mime-type">#computed-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-computed-mime-type" class="dfn-panel" data-for="computed-mime-type" id="infopanel-for-computed-mime-type" role="dialog">
+   <span id="infopaneltitle-for-computed-mime-type" style="display:none">Info about the 'computed MIME type' definition.</span><b><a href="#computed-mime-type">#computed-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-mime-type">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-computed-mime-type①">(2)</a> <a href="#ref-for-computed-mime-type②">(3)</a> <a href="#ref-for-computed-mime-type③">(4)</a> <a href="#ref-for-computed-mime-type④">(5)</a> <a href="#ref-for-computed-mime-type⑤">(6)</a>
     <li><a href="#ref-for-computed-mime-type⑥">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-computed-mime-type⑦">(2)</a> <a href="#ref-for-computed-mime-type⑧">(3)</a> <a href="#ref-for-computed-mime-type⑨">(4)</a>
@@ -2283,15 +2283,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-computed-mime-type⑤②">8.9. Sniffing in a cache manifest context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="supplied-mime-type-detection-algorithm">
-   <b><a href="#supplied-mime-type-detection-algorithm">#supplied-mime-type-detection-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-supplied-mime-type-detection-algorithm" class="dfn-panel" data-for="supplied-mime-type-detection-algorithm" id="infopanel-for-supplied-mime-type-detection-algorithm" role="dialog">
+   <span id="infopaneltitle-for-supplied-mime-type-detection-algorithm" style="display:none">Info about the 'supplied MIME type detection
+ algorithm' definition.</span><b><a href="#supplied-mime-type-detection-algorithm">#supplied-mime-type-detection-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-supplied-mime-type-detection-algorithm">5. Handling a resource</a>
     <li><a href="#ref-for-supplied-mime-type-detection-algorithm①">5.1. Interpreting the resource metadata</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="resource-header">
-   <b><a href="#resource-header">#resource-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-resource-header" class="dfn-panel" data-for="resource-header" id="infopanel-for-resource-header" role="dialog">
+   <span id="infopaneltitle-for-resource-header" style="display:none">Info about the 'resource header' definition.</span><b><a href="#resource-header">#resource-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resource-header">5.2. Reading the resource header</a> <a href="#ref-for-resource-header①">(2)</a>
     <li><a href="#ref-for-resource-header②">7. Determining the computed MIME type of a resource</a> <a href="#ref-for-resource-header③">(2)</a>
@@ -2303,14 +2304,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-resource-header①⑦">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-the-resource-header">
-   <b><a href="#read-the-resource-header">#read-the-resource-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-the-resource-header" class="dfn-panel" data-for="read-the-resource-header" id="infopanel-for-read-the-resource-header" role="dialog">
+   <span id="infopaneltitle-for-read-the-resource-header" style="display:none">Info about the 'read the resource header' definition.</span><b><a href="#read-the-resource-header">#read-the-resource-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-the-resource-header">5.2. Reading the resource header</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-pattern">
-   <b><a href="#byte-pattern">#byte-pattern</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-pattern" class="dfn-panel" data-for="byte-pattern" id="infopanel-for-byte-pattern" role="dialog">
+   <span id="infopaneltitle-for-byte-pattern" style="display:none">Info about the 'byte pattern' definition.</span><b><a href="#byte-pattern">#byte-pattern</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-pattern">6. Matching a MIME type pattern</a> <a href="#ref-for-byte-pattern①">(2)</a> <a href="#ref-for-byte-pattern②">(3)</a>
     <li><a href="#ref-for-byte-pattern③">6.1. Matching an image type pattern</a> <a href="#ref-for-byte-pattern④">(2)</a>
@@ -2320,8 +2321,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-byte-pattern①①">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-byte-pattern①②">(2)</a> <a href="#ref-for-byte-pattern①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pattern-mask">
-   <b><a href="#pattern-mask">#pattern-mask</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pattern-mask" class="dfn-panel" data-for="pattern-mask" id="infopanel-for-pattern-mask" role="dialog">
+   <span id="infopaneltitle-for-pattern-mask" style="display:none">Info about the 'pattern mask' definition.</span><b><a href="#pattern-mask">#pattern-mask</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pattern-mask">6. Matching a MIME type pattern</a> <a href="#ref-for-pattern-mask①">(2)</a>
     <li><a href="#ref-for-pattern-mask②">6.1. Matching an image type pattern</a>
@@ -2331,8 +2332,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-pattern-mask⑥">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-pattern-mask⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pattern-matching-algorithm">
-   <b><a href="#pattern-matching-algorithm">#pattern-matching-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pattern-matching-algorithm" class="dfn-panel" data-for="pattern-matching-algorithm" id="infopanel-for-pattern-matching-algorithm" role="dialog">
+   <span id="infopaneltitle-for-pattern-matching-algorithm" style="display:none">Info about the 'pattern matching algorithm' definition.</span><b><a href="#pattern-matching-algorithm">#pattern-matching-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pattern-matching-algorithm">6. Matching a MIME type pattern</a> <a href="#ref-for-pattern-matching-algorithm①">(2)</a>
     <li><a href="#ref-for-pattern-matching-algorithm②">6.1. Matching an image type pattern</a>
@@ -2342,84 +2343,89 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-pattern-matching-algorithm⑥">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-pattern-matching-algorithm⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-type-pattern-matching-algorithm">
-   <b><a href="#image-type-pattern-matching-algorithm">#image-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-type-pattern-matching-algorithm" class="dfn-panel" data-for="image-type-pattern-matching-algorithm" id="infopanel-for-image-type-pattern-matching-algorithm" role="dialog">
+   <span id="infopaneltitle-for-image-type-pattern-matching-algorithm" style="display:none">Info about the 'image type pattern matching algorithm' definition.</span><b><a href="#image-type-pattern-matching-algorithm">#image-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-type-pattern-matching-algorithm">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-image-type-pattern-matching-algorithm①">7.1. Identifying a resource with an unknown MIME type</a>
     <li><a href="#ref-for-image-type-pattern-matching-algorithm②">8.2. Sniffing in an image context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="audio-or-video-type-pattern-matching-algorithm">
-   <b><a href="#audio-or-video-type-pattern-matching-algorithm">#audio-or-video-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-audio-or-video-type-pattern-matching-algorithm" class="dfn-panel" data-for="audio-or-video-type-pattern-matching-algorithm" id="infopanel-for-audio-or-video-type-pattern-matching-algorithm" role="dialog">
+   <span id="infopaneltitle-for-audio-or-video-type-pattern-matching-algorithm" style="display:none">Info about the 'audio or video type pattern matching
+algorithm' definition.</span><b><a href="#audio-or-video-type-pattern-matching-algorithm">#audio-or-video-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-audio-or-video-type-pattern-matching-algorithm">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-audio-or-video-type-pattern-matching-algorithm①">7.1. Identifying a resource with an unknown MIME type</a>
     <li><a href="#ref-for-audio-or-video-type-pattern-matching-algorithm②">8.3. Sniffing in an audio or video context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-the-signature-for-mp4">
-   <b><a href="#matches-the-signature-for-mp4">#matches-the-signature-for-mp4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-the-signature-for-mp4" class="dfn-panel" data-for="matches-the-signature-for-mp4" id="infopanel-for-matches-the-signature-for-mp4" role="dialog">
+   <span id="infopaneltitle-for-matches-the-signature-for-mp4" style="display:none">Info about the 'matches the signature
+ for MP4' definition.</span><b><a href="#matches-the-signature-for-mp4">#matches-the-signature-for-mp4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-the-signature-for-mp4">6.2. Matching an audio or video type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-the-signature-for-webm">
-   <b><a href="#matches-the-signature-for-webm">#matches-the-signature-for-webm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-the-signature-for-webm" class="dfn-panel" data-for="matches-the-signature-for-webm" id="infopanel-for-matches-the-signature-for-webm" role="dialog">
+   <span id="infopaneltitle-for-matches-the-signature-for-webm" style="display:none">Info about the 'matches the signature
+ for WebM' definition.</span><b><a href="#matches-the-signature-for-webm">#matches-the-signature-for-webm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-the-signature-for-webm">6.2. Matching an audio or video type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-a-vint">
-   <b><a href="#parse-a-vint">#parse-a-vint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-a-vint" class="dfn-panel" data-for="parse-a-vint" id="infopanel-for-parse-a-vint" role="dialog">
+   <span id="infopaneltitle-for-parse-a-vint" style="display:none">Info about the 'parse a vint' definition.</span><b><a href="#parse-a-vint">#parse-a-vint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-vint">6.2.2. Signature for WebM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matching-a-padded-sequence">
-   <b><a href="#matching-a-padded-sequence">#matching-a-padded-sequence</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matching-a-padded-sequence" class="dfn-panel" data-for="matching-a-padded-sequence" id="infopanel-for-matching-a-padded-sequence" role="dialog">
+   <span id="infopaneltitle-for-matching-a-padded-sequence" style="display:none">Info about the 'Matching a padded sequence' definition.</span><b><a href="#matching-a-padded-sequence">#matching-a-padded-sequence</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matching-a-padded-sequence">6.2.2. Signature for WebM</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="matches-the-signature-for-mp3-without-id3">
-   <b><a href="#matches-the-signature-for-mp3-without-id3">#matches-the-signature-for-mp3-without-id3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-matches-the-signature-for-mp3-without-id3" class="dfn-panel" data-for="matches-the-signature-for-mp3-without-id3" id="infopanel-for-matches-the-signature-for-mp3-without-id3" role="dialog">
+   <span id="infopaneltitle-for-matches-the-signature-for-mp3-without-id3" style="display:none">Info about the 'matches the signature
+for MP3 without ID3' definition.</span><b><a href="#matches-the-signature-for-mp3-without-id3">#matches-the-signature-for-mp3-without-id3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-matches-the-signature-for-mp3-without-id3">6.2. Matching an audio or video type pattern</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="match-an-mp3-header">
-   <b><a href="#match-an-mp3-header">#match-an-mp3-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-match-an-mp3-header" class="dfn-panel" data-for="match-an-mp3-header" id="infopanel-for-match-an-mp3-header" role="dialog">
+   <span id="infopaneltitle-for-match-an-mp3-header" style="display:none">Info about the 'match an mp3 header' definition.</span><b><a href="#match-an-mp3-header">#match-an-mp3-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-match-an-mp3-header">6.2.3. Signature for MP3 without ID3</a> <a href="#ref-for-match-an-mp3-header">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="compute-an-mp3-frame-size">
-   <b><a href="#compute-an-mp3-frame-size">#compute-an-mp3-frame-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-compute-an-mp3-frame-size" class="dfn-panel" data-for="compute-an-mp3-frame-size" id="infopanel-for-compute-an-mp3-frame-size" role="dialog">
+   <span id="infopaneltitle-for-compute-an-mp3-frame-size" style="display:none">Info about the 'compute an mp3 frame size' definition.</span><b><a href="#compute-an-mp3-frame-size">#compute-an-mp3-frame-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compute-an-mp3-frame-size">6.2.3. Signature for MP3 without ID3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="parse-an-mp3-frame">
-   <b><a href="#parse-an-mp3-frame">#parse-an-mp3-frame</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-parse-an-mp3-frame" class="dfn-panel" data-for="parse-an-mp3-frame" id="infopanel-for-parse-an-mp3-frame" role="dialog">
+   <span id="infopaneltitle-for-parse-an-mp3-frame" style="display:none">Info about the 'parse an mp3 frame' definition.</span><b><a href="#parse-an-mp3-frame">#parse-an-mp3-frame</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-an-mp3-frame">6.2.3. Signature for MP3 without ID3</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="font-type-pattern-matching-algorithm">
-   <b><a href="#font-type-pattern-matching-algorithm">#font-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-font-type-pattern-matching-algorithm" class="dfn-panel" data-for="font-type-pattern-matching-algorithm" id="infopanel-for-font-type-pattern-matching-algorithm" role="dialog">
+   <span id="infopaneltitle-for-font-type-pattern-matching-algorithm" style="display:none">Info about the 'font type pattern matching algorithm' definition.</span><b><a href="#font-type-pattern-matching-algorithm">#font-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-font-type-pattern-matching-algorithm">8.7. Sniffing in a font context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="archive-type-pattern-matching-algorithm">
-   <b><a href="#archive-type-pattern-matching-algorithm">#archive-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-archive-type-pattern-matching-algorithm" class="dfn-panel" data-for="archive-type-pattern-matching-algorithm" id="infopanel-for-archive-type-pattern-matching-algorithm" role="dialog">
+   <span id="infopaneltitle-for-archive-type-pattern-matching-algorithm" style="display:none">Info about the 'archive type pattern matching
+algorithm' definition.</span><b><a href="#archive-type-pattern-matching-algorithm">#archive-type-pattern-matching-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-archive-type-pattern-matching-algorithm">7.1. Identifying a resource with an unknown MIME type</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="mime-type-sniffing-algorithm">
-   <b><a href="#mime-type-sniffing-algorithm">#mime-type-sniffing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-mime-type-sniffing-algorithm" class="dfn-panel" data-for="mime-type-sniffing-algorithm" id="infopanel-for-mime-type-sniffing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-mime-type-sniffing-algorithm" style="display:none">Info about the 'MIME type sniffing algorithm' definition.</span><b><a href="#mime-type-sniffing-algorithm">#mime-type-sniffing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type-sniffing-algorithm">5. Handling a resource</a> <a href="#ref-for-mime-type-sniffing-algorithm①">(2)</a>
     <li><a href="#ref-for-mime-type-sniffing-algorithm②">5.2. Reading the resource header</a>
@@ -2427,99 +2433,158 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-mime-type-sniffing-algorithm④">8.1. Sniffing in a browsing context</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="sniff-scriptable-flag">
-   <b><a href="#sniff-scriptable-flag">#sniff-scriptable-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-sniff-scriptable-flag" class="dfn-panel" data-for="sniff-scriptable-flag" id="infopanel-for-sniff-scriptable-flag" role="dialog">
+   <span id="infopaneltitle-for-sniff-scriptable-flag" style="display:none">Info about the 'sniff-scriptable flag' definition.</span><b><a href="#sniff-scriptable-flag">#sniff-scriptable-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sniff-scriptable-flag">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-sniff-scriptable-flag①">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-sniff-scriptable-flag②">(2)</a> <a href="#ref-for-sniff-scriptable-flag③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rules-for-identifying-an-unknown-mime-type">
-   <b><a href="#rules-for-identifying-an-unknown-mime-type">#rules-for-identifying-an-unknown-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rules-for-identifying-an-unknown-mime-type" class="dfn-panel" data-for="rules-for-identifying-an-unknown-mime-type" id="infopanel-for-rules-for-identifying-an-unknown-mime-type" role="dialog">
+   <span id="infopaneltitle-for-rules-for-identifying-an-unknown-mime-type" style="display:none">Info about the 'rules for identifying an unknown MIME
+type' definition.</span><b><a href="#rules-for-identifying-an-unknown-mime-type">#rules-for-identifying-an-unknown-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-identifying-an-unknown-mime-type">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-rules-for-identifying-an-unknown-mime-type①">7.1. Identifying a resource with an unknown MIME type</a> <a href="#ref-for-rules-for-identifying-an-unknown-mime-type②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rules-for-text-or-binary">
-   <b><a href="#rules-for-text-or-binary">#rules-for-text-or-binary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rules-for-text-or-binary" class="dfn-panel" data-for="rules-for-text-or-binary" id="infopanel-for-rules-for-text-or-binary" role="dialog">
+   <span id="infopaneltitle-for-rules-for-text-or-binary" style="display:none">Info about the 'rules for
+ distinguishing if a resource is text or binary' definition.</span><b><a href="#rules-for-text-or-binary">#rules-for-text-or-binary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-text-or-binary">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-rules-for-text-or-binary①">7.2. Sniffing a mislabeled binary resource</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rules-for-distinguishing-if-a-resource-is-a-feed-or-html">
-   <b><a href="#rules-for-distinguishing-if-a-resource-is-a-feed-or-html">#rules-for-distinguishing-if-a-resource-is-a-feed-or-html</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rules-for-distinguishing-if-a-resource-is-a-feed-or-html" class="dfn-panel" data-for="rules-for-distinguishing-if-a-resource-is-a-feed-or-html" id="infopanel-for-rules-for-distinguishing-if-a-resource-is-a-feed-or-html" role="dialog">
+   <span id="infopaneltitle-for-rules-for-distinguishing-if-a-resource-is-a-feed-or-html" style="display:none">Info about the 'rules for distinguishing if a resource is a feed or
+ HTML' definition.</span><b><a href="#rules-for-distinguishing-if-a-resource-is-a-feed-or-html">#rules-for-distinguishing-if-a-resource-is-a-feed-or-html</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rules-for-distinguishing-if-a-resource-is-a-feed-or-html">7. Determining the computed MIME type of a resource</a>
     <li><a href="#ref-for-rules-for-distinguishing-if-a-resource-is-a-feed-or-html①">7.3. Sniffing a mislabeled feed</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="context">
-   <b><a href="#context">#context</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-context" class="dfn-panel" data-for="context" id="infopanel-for-context" role="dialog">
+   <span id="infopaneltitle-for-context" style="display:none">Info about the 'context' definition.</span><b><a href="#context">#context</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-context">8. Context-specific sniffing</a> <a href="#ref-for-context①">(2)</a> <a href="#ref-for-context②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="context-specific-sniffing-algorithm">
-   <b><a href="#context-specific-sniffing-algorithm">#context-specific-sniffing-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-context-specific-sniffing-algorithm" class="dfn-panel" data-for="context-specific-sniffing-algorithm" id="infopanel-for-context-specific-sniffing-algorithm" role="dialog">
+   <span id="infopaneltitle-for-context-specific-sniffing-algorithm" style="display:none">Info about the 'context-specific sniffing algorithm' definition.</span><b><a href="#context-specific-sniffing-algorithm">#context-specific-sniffing-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-context-specific-sniffing-algorithm">8. Context-specific sniffing</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/notifications/notifications.html
+++ b/tests/github/whatwg/notifications/notifications.html
@@ -1597,58 +1597,58 @@ if ("serviceWorker" in navigator) {
     </ul>
    <li><a href="#vibration-pattern">vibration pattern</a><span>, in § 2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-def-vibratepattern">
-   <a href="https://w3c.github.io/vibration/#idl-def-vibratepattern">https://w3c.github.io/vibration/#idl-def-vibratepattern</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-def-vibratepattern" class="dfn-panel" data-for="term-for-idl-def-vibratepattern" id="infopanel-for-term-for-idl-def-vibratepattern" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-def-vibratepattern" style="display:none">Info about the 'VibratePattern' external reference.</span><a href="https://w3c.github.io/vibration/#idl-def-vibratepattern">https://w3c.github.io/vibration/#idl-def-vibratepattern</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-def-vibratepattern">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-entry-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-entry-settings-object" class="dfn-panel" data-for="term-for-entry-settings-object" id="infopanel-for-term-for-entry-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-entry-settings-object" style="display:none">Info about the 'entry settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#entry-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entry-settings-object">2. Notifications</a> <a href="#ref-for-entry-settings-object①">(2)</a>
     <li><a href="#ref-for-entry-settings-object②">3.3. Static members</a> <a href="#ref-for-entry-settings-object③">(2)</a> <a href="#ref-for-entry-settings-object④">(3)</a> <a href="#ref-for-entry-settings-object⑤">(4)</a>
     <li><a href="#ref-for-entry-settings-object⑥">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object.freeze">
-   <a href="https://tc39.github.io/ecma262/#sec-object.freeze">https://tc39.github.io/ecma262/#sec-object.freeze</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object.freeze" class="dfn-panel" data-for="term-for-sec-object.freeze" id="infopanel-for-term-for-sec-object.freeze" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object.freeze" style="display:none">Info about the 'freeze' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-object.freeze">https://tc39.github.io/ecma262/#sec-object.freeze</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object.freeze">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-vibration">
-   <a href="https://w3c.github.io/vibration/#dfn-perform-vibration">https://w3c.github.io/vibration/#dfn-perform-vibration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-vibration" class="dfn-panel" data-for="term-for-dfn-perform-vibration" id="infopanel-for-term-for-dfn-perform-vibration" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-vibration" style="display:none">Info about the 'perform vibration' external reference.</span><a href="https://w3c.github.io/vibration/#dfn-perform-vibration">https://w3c.github.io/vibration/#dfn-perform-vibration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-vibration">2.9. Alerting the user</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-validate-and-normalize">
-   <a href="https://w3c.github.io/vibration/#dfn-validate-and-normalize">https://w3c.github.io/vibration/#dfn-validate-and-normalize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-validate-and-normalize" class="dfn-panel" data-for="term-for-dfn-validate-and-normalize" id="infopanel-for-term-for-dfn-validate-and-normalize" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-validate-and-normalize" style="display:none">Info about the 'validate and normalize' external reference.</span><a href="https://w3c.github.io/vibration/#dfn-validate-and-normalize">https://w3c.github.io/vibration/#dfn-validate-and-normalize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-validate-and-normalize">2. Notifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">2.7. Activating a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">3.1. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">2.6. Showing a notification</a>
     <li><a href="#ref-for-concept-event-fire①">2.7. Activating a notification</a>
@@ -1656,84 +1656,84 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-event-fire③">3.2. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">2.5. Resources</a> <a href="#ref-for-concept-fetch①">(2)</a> <a href="#ref-for-concept-fetch②">(3)</a> <a href="#ref-for-concept-fetch③">(4)</a>
     <li><a href="#ref-for-concept-fetch④">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-internal-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-internal-response" class="dfn-panel" data-for="term-for-concept-internal-response" id="infopanel-for-term-for-concept-internal-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-internal-response" style="display:none">Info about the 'internal response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-internal-response">https://fetch.spec.whatwg.org/#concept-internal-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-internal-response">2.5. Resources</a> <a href="#ref-for-concept-internal-response①">(2)</a> <a href="#ref-for-concept-internal-response②">(3)</a> <a href="#ref-for-concept-internal-response③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">2.5. Resources</a> <a href="#ref-for-concept-response①">(2)</a> <a href="#ref-for-concept-response②">(3)</a> <a href="#ref-for-concept-response③">(4)</a> <a href="#ref-for-concept-response④">(5)</a> <a href="#ref-for-concept-response⑤">(6)</a> <a href="#ref-for-concept-response⑥">(7)</a> <a href="#ref-for-concept-response⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-type" class="dfn-panel" data-for="term-for-concept-response-type" id="infopanel-for-term-for-concept-response-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-type" style="display:none">Info about the 'type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-type">https://fetch.spec.whatwg.org/#concept-response-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-type">2.5. Resources</a> <a href="#ref-for-concept-response-type①">(2)</a> <a href="#ref-for-concept-response-type②">(3)</a> <a href="#ref-for-concept-response-type③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. API</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a>
     <li><a href="#ref-for-eventhandler④">4. Service worker API</a> <a href="#ref-for-eventhandler⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializeforstorage">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializeforstorage" class="dfn-panel" data-for="term-for-structuredserializeforstorage" id="infopanel-for-term-for-structuredserializeforstorage" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializeforstorage" style="display:none">Info about the 'StructuredSerializeForStorage' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeforstorage</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializeforstorage">2. Notifications</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-browsing-context">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-browsing-context" class="dfn-panel" data-for="term-for-browsing-context" id="infopanel-for-term-for-browsing-context" role="menu">
+   <span id="infopaneltitle-for-term-for-browsing-context" style="display:none">Info about the 'browsing context' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context">https://html.spec.whatwg.org/multipage/document-sequences.html#browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-context">2.7. Activating a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3.2. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.4. Object members</a> <a href="#ref-for-event-handlers①">(2)</a>
     <li><a href="#ref-for-event-handlers②">4. Service worker API</a> <a href="#ref-for-event-handlers③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.4. Object members</a> <a href="#ref-for-event-handler-event-type①">(2)</a>
     <li><a href="#ref-for-event-handler-event-type②">4. Service worker API</a> <a href="#ref-for-event-handler-event-type③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-window-focus">
-   <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-window-focus" class="dfn-panel" data-for="term-for-dom-window-focus" id="infopanel-for-term-for-dom-window-focus" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-window-focus" style="display:none">Info about the 'focus()' external reference.</span><a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus">https://html.spec.whatwg.org/multipage/interaction.html#dom-window-focus</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-window-focus">2.7. Activating a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">2.5. Resources</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a> <a href="#ref-for-in-parallel③">(4)</a>
     <li><a href="#ref-for-in-parallel④">3.2. Constructors</a>
@@ -1741,22 +1741,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-in-parallel⑥">4. Service worker API</a> <a href="#ref-for-in-parallel⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin①">2.2. Permission model</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">2. Notifications</a>
     <li><a href="#ref-for-concept-settings-object-origin①">3.3. Static members</a> <a href="#ref-for-concept-settings-object-origin②">(2)</a> <a href="#ref-for-concept-settings-object-origin③">(3)</a> <a href="#ref-for-concept-settings-object-origin④">(4)</a>
     <li><a href="#ref-for-concept-settings-object-origin⑤">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">2.6. Showing a notification</a>
     <li><a href="#ref-for-queue-a-task①">2.7. Activating a notification</a>
@@ -1765,193 +1765,193 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-queue-a-task④">3.3. Static members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-report-the-exception">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-report-the-exception" class="dfn-panel" data-for="term-for-report-the-exception" id="infopanel-for-term-for-report-the-exception" role="menu">
+   <span id="infopaneltitle-for-term-for-report-the-exception" style="display:none">Info about the 'report the exception' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception">https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-report-the-exception">3.3. Static members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">2.8. Closing a notification</a>
     <li><a href="#ref-for-list-contain①">3.1. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">2.1. Lifetime and UI integration</a>
     <li><a href="#ref-for-list①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">2.6. Showing a notification</a>
     <li><a href="#ref-for-list-remove①">2.8. Closing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-replace">
-   <a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-replace" class="dfn-panel" data-for="term-for-list-replace" id="infopanel-for-term-for-list-replace" role="menu">
+   <span id="infopaneltitle-for-term-for-list-replace" style="display:none">Info about the 'replace' external reference.</span><a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-replace">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-extendableevent">
-   <a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-extendableevent" class="dfn-panel" data-for="term-for-extendableevent" id="infopanel-for-term-for-extendableevent" role="menu">
+   <span id="infopaneltitle-for-term-for-extendableevent" style="display:none">Info about the 'ExtendableEvent' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#extendableevent">https://w3c.github.io/ServiceWorker/#extendableevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-extendableevent">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-extendableeventinit">
-   <a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-extendableeventinit" class="dfn-panel" data-for="term-for-dictdef-extendableeventinit" id="infopanel-for-term-for-dictdef-extendableeventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-extendableeventinit" style="display:none">Info about the 'ExtendableEventInit' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit">https://w3c.github.io/ServiceWorker/#dictdef-extendableeventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-extendableeventinit">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerglobalscope">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerglobalscope" class="dfn-panel" data-for="term-for-serviceworkerglobalscope" id="infopanel-for-term-for-serviceworkerglobalscope" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerglobalscope" style="display:none">Info about the 'ServiceWorkerGlobalScope' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope">https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerglobalscope">3.2. Constructors</a>
     <li><a href="#ref-for-serviceworkerglobalscope①">3.5.2. Using actions from a service worker</a>
     <li><a href="#ref-for-serviceworkerglobalscope②">4. Service worker API</a> <a href="#ref-for-serviceworkerglobalscope③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serviceworkerregistration">
-   <a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serviceworkerregistration" class="dfn-panel" data-for="term-for-serviceworkerregistration" id="infopanel-for-term-for-serviceworkerregistration" role="menu">
+   <span id="infopaneltitle-for-term-for-serviceworkerregistration" style="display:none">Info about the 'ServiceWorkerRegistration' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#serviceworkerregistration">https://w3c.github.io/ServiceWorker/#serviceworkerregistration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serviceworkerregistration">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-active-worker">
-   <a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-active-worker" class="dfn-panel" data-for="term-for-dfn-active-worker" id="infopanel-for-term-for-dfn-active-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-active-worker" style="display:none">Info about the 'active worker' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#dfn-active-worker">https://w3c.github.io/ServiceWorker/#dfn-active-worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-active-worker">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fire-functional-event">
-   <a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fire-functional-event" class="dfn-panel" data-for="term-for-fire-functional-event" id="infopanel-for-term-for-fire-functional-event" role="menu">
+   <span id="infopaneltitle-for-term-for-fire-functional-event" style="display:none">Info about the 'fire functional event' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#fire-functional-event">https://w3c.github.io/ServiceWorker/#fire-functional-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-functional-event">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">2. Notifications</a> <a href="#ref-for-concept-url-parser①">(2)</a> <a href="#ref-for-concept-url-parser②">(3)</a> <a href="#ref-for-concept-url-parser③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3.4. Object members</a> <a href="#ref-for-concept-url-serializer①">(2)</a> <a href="#ref-for-concept-url-serializer②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. API</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a> <a href="#ref-for-idl-DOMString④">(5)</a> <a href="#ref-for-idl-DOMString⑤">(6)</a> <a href="#ref-for-idl-DOMString⑥">(7)</a> <a href="#ref-for-idl-DOMString⑦">(8)</a> <a href="#ref-for-idl-DOMString⑧">(9)</a> <a href="#ref-for-idl-DOMString⑨">(10)</a>
     <li><a href="#ref-for-idl-DOMString①⓪">4. Service worker API</a> <a href="#ref-for-idl-DOMString①①">(2)</a> <a href="#ref-for-idl-DOMString①②">(3)</a> <a href="#ref-for-idl-DOMString①③">(4)</a> <a href="#ref-for-idl-DOMString①④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. API</a> <a href="#ref-for-Exposed①">(2)</a>
     <li><a href="#ref-for-Exposed②">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-frozen-array" class="dfn-panel" data-for="term-for-idl-frozen-array" id="infopanel-for-term-for-idl-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-frozen-array" style="display:none">Info about the 'FrozenArray' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-frozen-array">https://webidl.spec.whatwg.org/#idl-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-frozen-array">3. API</a> <a href="#ref-for-idl-frozen-array①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">3. API</a>
     <li><a href="#ref-for-idl-promise①">4. Service worker API</a> <a href="#ref-for-idl-promise②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. API</a> <a href="#ref-for-SameObject①">(2)</a> <a href="#ref-for-SameObject②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. API</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a> <a href="#ref-for-idl-USVString④">(5)</a> <a href="#ref-for-idl-USVString⑤">(6)</a> <a href="#ref-for-idl-USVString⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3. API</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. API</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a> <a href="#ref-for-idl-boolean③">(4)</a> <a href="#ref-for-idl-boolean④">(5)</a> <a href="#ref-for-idl-boolean⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-create-frozen-array">
-   <a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-create-frozen-array" class="dfn-panel" data-for="term-for-dfn-create-frozen-array" id="infopanel-for-term-for-dfn-create-frozen-array" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-create-frozen-array" style="display:none">Info about the 'create a frozen array' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-create-frozen-array">https://webidl.spec.whatwg.org/#dfn-create-frozen-array</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-create-frozen-array">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">3. API</a>
     <li><a href="#ref-for-idl-sequence①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">2. Notifications</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">3.2. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. API</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3. API</a> <a href="#ref-for-idl-unsigned-long①">(2)</a>
    </ul>
@@ -2169,8 +2169,8 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="concept-notification">
-   <b><a href="#concept-notification">#concept-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-notification" class="dfn-panel" data-for="concept-notification" id="infopanel-for-concept-notification" role="dialog">
+   <span id="infopaneltitle-for-concept-notification" style="display:none">Info about the 'notification' definition.</span><b><a href="#concept-notification">#concept-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-notification">2. Notifications</a> <a href="#ref-for-concept-notification①">(2)</a> <a href="#ref-for-concept-notification②">(3)</a> <a href="#ref-for-concept-notification③">(4)</a> <a href="#ref-for-concept-notification④">(5)</a> <a href="#ref-for-concept-notification⑤">(6)</a> <a href="#ref-for-concept-notification⑥">(7)</a> <a href="#ref-for-concept-notification⑦">(8)</a> <a href="#ref-for-concept-notification⑧">(9)</a> <a href="#ref-for-concept-notification⑨">(10)</a> <a href="#ref-for-concept-notification①⓪">(11)</a> <a href="#ref-for-concept-notification①①">(12)</a> <a href="#ref-for-concept-notification①②">(13)</a> <a href="#ref-for-concept-notification①③">(14)</a> <a href="#ref-for-concept-notification①④">(15)</a> <a href="#ref-for-concept-notification①⑤">(16)</a> <a href="#ref-for-concept-notification①⑥">(17)</a> <a href="#ref-for-concept-notification①⑦">(18)</a> <a href="#ref-for-concept-notification①⑧">(19)</a> <a href="#ref-for-concept-notification①⑨">(20)</a> <a href="#ref-for-concept-notification②⓪">(21)</a> <a href="#ref-for-concept-notification②①">(22)</a> <a href="#ref-for-concept-notification②②">(23)</a> <a href="#ref-for-concept-notification②③">(24)</a> <a href="#ref-for-concept-notification②④">(25)</a>
     <li><a href="#ref-for-concept-notification②⑤">2.1. Lifetime and UI integration</a>
@@ -2186,15 +2186,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-notification⑥①">4. Service worker API</a> <a href="#ref-for-concept-notification⑥②">(2)</a> <a href="#ref-for-concept-notification⑥③">(3)</a> <a href="#ref-for-concept-notification⑥④">(4)</a> <a href="#ref-for-concept-notification⑥⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="service-worker-registration">
-   <b><a href="#service-worker-registration">#service-worker-registration</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-service-worker-registration" class="dfn-panel" data-for="service-worker-registration" id="infopanel-for-service-worker-registration" role="dialog">
+   <span id="infopaneltitle-for-service-worker-registration" style="display:none">Info about the 'service worker registration' definition.</span><b><a href="#service-worker-registration">#service-worker-registration</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-registration">2. Notifications</a> <a href="#ref-for-service-worker-registration①">(2)</a> <a href="#ref-for-service-worker-registration②">(3)</a>
     <li><a href="#ref-for-service-worker-registration③">4. Service worker API</a> <a href="#ref-for-service-worker-registration④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-title">
-   <b><a href="#concept-title">#concept-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-title" class="dfn-panel" data-for="concept-title" id="infopanel-for-concept-title" role="dialog">
+   <span id="infopaneltitle-for-concept-title" style="display:none">Info about the 'title' definition.</span><b><a href="#concept-title">#concept-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-title">2. Notifications</a>
     <li><a href="#ref-for-concept-title①">2.3. Direction</a> <a href="#ref-for-concept-title②">(2)</a>
@@ -2202,8 +2202,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-title⑤">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="body">
-   <b><a href="#body">#body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-body" class="dfn-panel" data-for="body" id="infopanel-for-body" role="dialog">
+   <span id="infopaneltitle-for-body" style="display:none">Info about the 'body' definition.</span><b><a href="#body">#body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body">2. Notifications</a>
     <li><a href="#ref-for-body①">2.3. Direction</a> <a href="#ref-for-body②">(2)</a>
@@ -2211,24 +2211,24 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-body④">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-direction">
-   <b><a href="#concept-direction">#concept-direction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-direction" class="dfn-panel" data-for="concept-direction" id="infopanel-for-concept-direction" role="dialog">
+   <span id="infopaneltitle-for-concept-direction" style="display:none">Info about the 'direction' definition.</span><b><a href="#concept-direction">#concept-direction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-direction">2. Notifications</a>
     <li><a href="#ref-for-concept-direction①">2.3. Direction</a> <a href="#ref-for-concept-direction②">(2)</a>
     <li><a href="#ref-for-concept-direction③">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-language">
-   <b><a href="#concept-language">#concept-language</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-language" class="dfn-panel" data-for="concept-language" id="infopanel-for-concept-language" role="dialog">
+   <span id="infopaneltitle-for-concept-language" style="display:none">Info about the 'language' definition.</span><b><a href="#concept-language">#concept-language</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-language">2. Notifications</a>
     <li><a href="#ref-for-concept-language①">2.4. Language</a>
     <li><a href="#ref-for-concept-language②">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tag">
-   <b><a href="#tag">#tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tag" class="dfn-panel" data-for="tag" id="infopanel-for-tag" role="dialog">
+   <span id="infopaneltitle-for-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#tag">#tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tag">2. Notifications</a> <a href="#ref-for-tag①">(2)</a>
     <li><a href="#ref-for-tag②">2.6. Showing a notification</a> <a href="#ref-for-tag③">(2)</a>
@@ -2236,22 +2236,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-tag⑤">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="data">
-   <b><a href="#data">#data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-data" class="dfn-panel" data-for="data" id="infopanel-for-data" role="dialog">
+   <span id="infopaneltitle-for-data" style="display:none">Info about the 'data' definition.</span><b><a href="#data">#data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-data">2. Notifications</a>
     <li><a href="#ref-for-data①">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timestamp">
-   <b><a href="#timestamp">#timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timestamp" class="dfn-panel" data-for="timestamp" id="infopanel-for-timestamp" role="dialog">
+   <span id="infopaneltitle-for-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#timestamp">#timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timestamp">2. Notifications</a> <a href="#ref-for-timestamp①">(2)</a>
     <li><a href="#ref-for-timestamp②">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-origin">
-   <b><a href="#concept-origin">#concept-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-origin" class="dfn-panel" data-for="concept-origin" id="infopanel-for-concept-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#concept-origin">#concept-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">2. Notifications</a>
     <li><a href="#ref-for-concept-origin②">2.6. Showing a notification</a> <a href="#ref-for-concept-origin③">(2)</a>
@@ -2259,86 +2259,86 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-origin⑤">4. Service worker API</a> <a href="#ref-for-concept-origin⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="renotify-preference-flag">
-   <b><a href="#renotify-preference-flag">#renotify-preference-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-renotify-preference-flag" class="dfn-panel" data-for="renotify-preference-flag" id="infopanel-for-renotify-preference-flag" role="dialog">
+   <span id="infopaneltitle-for-renotify-preference-flag" style="display:none">Info about the 'renotify preference flag' definition.</span><b><a href="#renotify-preference-flag">#renotify-preference-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-renotify-preference-flag">2. Notifications</a>
     <li><a href="#ref-for-renotify-preference-flag①">2.6. Showing a notification</a>
     <li><a href="#ref-for-renotify-preference-flag②">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="silent-preference-flag">
-   <b><a href="#silent-preference-flag">#silent-preference-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-silent-preference-flag" class="dfn-panel" data-for="silent-preference-flag" id="infopanel-for-silent-preference-flag" role="dialog">
+   <span id="infopaneltitle-for-silent-preference-flag" style="display:none">Info about the 'silent preference flag' definition.</span><b><a href="#silent-preference-flag">#silent-preference-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-silent-preference-flag">2. Notifications</a>
     <li><a href="#ref-for-silent-preference-flag①">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="require-interaction-preference-flag">
-   <b><a href="#require-interaction-preference-flag">#require-interaction-preference-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-require-interaction-preference-flag" class="dfn-panel" data-for="require-interaction-preference-flag" id="infopanel-for-require-interaction-preference-flag" role="dialog">
+   <span id="infopaneltitle-for-require-interaction-preference-flag" style="display:none">Info about the 'require interaction preference flag' definition.</span><b><a href="#require-interaction-preference-flag">#require-interaction-preference-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-require-interaction-preference-flag">2. Notifications</a>
     <li><a href="#ref-for-require-interaction-preference-flag①">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-url">
-   <b><a href="#image-url">#image-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-url" class="dfn-panel" data-for="image-url" id="infopanel-for-image-url" role="dialog">
+   <span id="infopaneltitle-for-image-url" style="display:none">Info about the 'image URL' definition.</span><b><a href="#image-url">#image-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-url">2. Notifications</a> <a href="#ref-for-image-url①">(2)</a>
     <li><a href="#ref-for-image-url②">2.5. Resources</a> <a href="#ref-for-image-url③">(2)</a>
     <li><a href="#ref-for-image-url④">3.4. Object members</a> <a href="#ref-for-image-url⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="icon-url">
-   <b><a href="#icon-url">#icon-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-icon-url" class="dfn-panel" data-for="icon-url" id="infopanel-for-icon-url" role="dialog">
+   <span id="infopaneltitle-for-icon-url" style="display:none">Info about the 'icon URL' definition.</span><b><a href="#icon-url">#icon-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-icon-url">2. Notifications</a> <a href="#ref-for-icon-url①">(2)</a>
     <li><a href="#ref-for-icon-url②">2.5. Resources</a> <a href="#ref-for-icon-url③">(2)</a>
     <li><a href="#ref-for-icon-url④">3.4. Object members</a> <a href="#ref-for-icon-url⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="badge-url">
-   <b><a href="#badge-url">#badge-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-badge-url" class="dfn-panel" data-for="badge-url" id="infopanel-for-badge-url" role="dialog">
+   <span id="infopaneltitle-for-badge-url" style="display:none">Info about the 'badge URL' definition.</span><b><a href="#badge-url">#badge-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-badge-url">2. Notifications</a> <a href="#ref-for-badge-url①">(2)</a>
     <li><a href="#ref-for-badge-url②">2.5. Resources</a> <a href="#ref-for-badge-url③">(2)</a>
     <li><a href="#ref-for-badge-url④">3.4. Object members</a> <a href="#ref-for-badge-url⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="image-resource">
-   <b><a href="#image-resource">#image-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-image-resource" class="dfn-panel" data-for="image-resource" id="infopanel-for-image-resource" role="dialog">
+   <span id="infopaneltitle-for-image-resource" style="display:none">Info about the 'image resource' definition.</span><b><a href="#image-resource">#image-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-image-resource">2. Notifications</a> <a href="#ref-for-image-resource①">(2)</a> <a href="#ref-for-image-resource②">(3)</a>
     <li><a href="#ref-for-image-resource③">2.5. Resources</a> <a href="#ref-for-image-resource④">(2)</a>
     <li><a href="#ref-for-image-resource⑤">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="icon-resource">
-   <b><a href="#icon-resource">#icon-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-icon-resource" class="dfn-panel" data-for="icon-resource" id="infopanel-for-icon-resource" role="dialog">
+   <span id="infopaneltitle-for-icon-resource" style="display:none">Info about the 'icon resource' definition.</span><b><a href="#icon-resource">#icon-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-icon-resource">2. Notifications</a> <a href="#ref-for-icon-resource①">(2)</a> <a href="#ref-for-icon-resource②">(3)</a> <a href="#ref-for-icon-resource③">(4)</a>
     <li><a href="#ref-for-icon-resource④">2.5. Resources</a> <a href="#ref-for-icon-resource⑤">(2)</a>
     <li><a href="#ref-for-icon-resource⑥">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="badge-resource">
-   <b><a href="#badge-resource">#badge-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-badge-resource" class="dfn-panel" data-for="badge-resource" id="infopanel-for-badge-resource" role="dialog">
+   <span id="infopaneltitle-for-badge-resource" style="display:none">Info about the 'badge resource' definition.</span><b><a href="#badge-resource">#badge-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-badge-resource">2. Notifications</a> <a href="#ref-for-badge-resource①">(2)</a> <a href="#ref-for-badge-resource②">(3)</a>
     <li><a href="#ref-for-badge-resource③">2.5. Resources</a> <a href="#ref-for-badge-resource④">(2)</a>
     <li><a href="#ref-for-badge-resource⑤">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="vibration-pattern">
-   <b><a href="#vibration-pattern">#vibration-pattern</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-vibration-pattern" class="dfn-panel" data-for="vibration-pattern" id="infopanel-for-vibration-pattern" role="dialog">
+   <span id="infopaneltitle-for-vibration-pattern" style="display:none">Info about the 'vibration pattern' definition.</span><b><a href="#vibration-pattern">#vibration-pattern</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vibration-pattern">2. Notifications</a> <a href="#ref-for-vibration-pattern①">(2)</a> <a href="#ref-for-vibration-pattern②">(3)</a>
     <li><a href="#ref-for-vibration-pattern③">2.9. Alerting the user</a>
     <li><a href="#ref-for-vibration-pattern④">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="actions">
-   <b><a href="#actions">#actions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-actions" class="dfn-panel" data-for="actions" id="infopanel-for-actions" role="dialog">
+   <span id="infopaneltitle-for-actions" style="display:none">Info about the 'actions' definition.</span><b><a href="#actions">#actions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-actions">2. Notifications</a> <a href="#ref-for-actions①">(2)</a> <a href="#ref-for-actions②">(3)</a> <a href="#ref-for-actions③">(4)</a> <a href="#ref-for-actions④">(5)</a>
     <li><a href="#ref-for-actions⑤">2.3. Direction</a> <a href="#ref-for-actions⑥">(2)</a> <a href="#ref-for-actions⑦">(3)</a>
@@ -2350,47 +2350,47 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-actions①⑤">3.5.2. Using actions from a service worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="action-title">
-   <b><a href="#action-title">#action-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-action-title" class="dfn-panel" data-for="action-title" id="infopanel-for-action-title" role="dialog">
+   <span id="infopaneltitle-for-action-title" style="display:none">Info about the 'title' definition.</span><b><a href="#action-title">#action-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-action-title">2. Notifications</a>
     <li><a href="#ref-for-action-title①">2.3. Direction</a> <a href="#ref-for-action-title②">(2)</a>
     <li><a href="#ref-for-action-title③">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="action-name">
-   <b><a href="#action-name">#action-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-action-name" class="dfn-panel" data-for="action-name" id="infopanel-for-action-name" role="dialog">
+   <span id="infopaneltitle-for-action-name" style="display:none">Info about the 'name' definition.</span><b><a href="#action-name">#action-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-action-name">2. Notifications</a>
     <li><a href="#ref-for-action-name①">2.7. Activating a notification</a>
     <li><a href="#ref-for-action-name②">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="action-icon-url">
-   <b><a href="#action-icon-url">#action-icon-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-action-icon-url" class="dfn-panel" data-for="action-icon-url" id="infopanel-for-action-icon-url" role="dialog">
+   <span id="infopaneltitle-for-action-icon-url" style="display:none">Info about the 'icon URL' definition.</span><b><a href="#action-icon-url">#action-icon-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-action-icon-url">2. Notifications</a> <a href="#ref-for-action-icon-url①">(2)</a>
     <li><a href="#ref-for-action-icon-url②">2.5. Resources</a> <a href="#ref-for-action-icon-url③">(2)</a>
     <li><a href="#ref-for-action-icon-url④">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="action-icon-resource">
-   <b><a href="#action-icon-resource">#action-icon-resource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-action-icon-resource" class="dfn-panel" data-for="action-icon-resource" id="infopanel-for-action-icon-resource" role="dialog">
+   <span id="infopaneltitle-for-action-icon-resource" style="display:none">Info about the 'icon resource' definition.</span><b><a href="#action-icon-resource">#action-icon-resource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-action-icon-resource">2. Notifications</a>
     <li><a href="#ref-for-action-icon-resource①">2.5. Resources</a> <a href="#ref-for-action-icon-resource②">(2)</a>
     <li><a href="#ref-for-action-icon-resource③">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="maximum-number-of-actions">
-   <b><a href="#maximum-number-of-actions">#maximum-number-of-actions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-maximum-number-of-actions" class="dfn-panel" data-for="maximum-number-of-actions" id="infopanel-for-maximum-number-of-actions" role="dialog">
+   <span id="infopaneltitle-for-maximum-number-of-actions" style="display:none">Info about the 'maximum number of actions' definition.</span><b><a href="#maximum-number-of-actions">#maximum-number-of-actions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-maximum-number-of-actions">2. Notifications</a>
     <li><a href="#ref-for-maximum-number-of-actions①">3.3. Static members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="non-persistent-notification">
-   <b><a href="#non-persistent-notification">#non-persistent-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-non-persistent-notification" class="dfn-panel" data-for="non-persistent-notification" id="infopanel-for-non-persistent-notification" role="dialog">
+   <span id="infopaneltitle-for-non-persistent-notification" style="display:none">Info about the 'non-persistent notification' definition.</span><b><a href="#non-persistent-notification">#non-persistent-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-non-persistent-notification">2.1. Lifetime and UI integration</a> <a href="#ref-for-non-persistent-notification①">(2)</a>
     <li><a href="#ref-for-non-persistent-notification②">2.6. Showing a notification</a>
@@ -2399,8 +2399,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-non-persistent-notification⑤">3.5.1. Using events from a page</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="persistent-notification">
-   <b><a href="#persistent-notification">#persistent-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-persistent-notification" class="dfn-panel" data-for="persistent-notification" id="infopanel-for-persistent-notification" role="dialog">
+   <span id="infopaneltitle-for-persistent-notification" style="display:none">Info about the 'persistent notification' definition.</span><b><a href="#persistent-notification">#persistent-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-persistent-notification">2. Notifications</a>
     <li><a href="#ref-for-persistent-notification①">2.1. Lifetime and UI integration</a> <a href="#ref-for-persistent-notification②">(2)</a> <a href="#ref-for-persistent-notification③">(3)</a>
@@ -2410,15 +2410,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-persistent-notification⑦">3.5.2. Using actions from a service worker</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-notification">
-   <b><a href="#create-a-notification">#create-a-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-notification" class="dfn-panel" data-for="create-a-notification" id="infopanel-for-create-a-notification" role="dialog">
+   <span id="infopaneltitle-for-create-a-notification" style="display:none">Info about the 'create a notification' definition.</span><b><a href="#create-a-notification">#create-a-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-notification">3.2. Constructors</a>
     <li><a href="#ref-for-create-a-notification①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="list-of-notifications">
-   <b><a href="#list-of-notifications">#list-of-notifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-list-of-notifications" class="dfn-panel" data-for="list-of-notifications" id="infopanel-for-list-of-notifications" role="dialog">
+   <span id="infopaneltitle-for-list-of-notifications" style="display:none">Info about the 'list of notifications' definition.</span><b><a href="#list-of-notifications">#list-of-notifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-of-notifications">2.1. Lifetime and UI integration</a>
     <li><a href="#ref-for-list-of-notifications①">2.6. Showing a notification</a> <a href="#ref-for-list-of-notifications②">(2)</a> <a href="#ref-for-list-of-notifications③">(3)</a> <a href="#ref-for-list-of-notifications④">(4)</a>
@@ -2427,8 +2427,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-of-notifications⑧">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="permission">
-   <b><a href="#permission">#permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-permission" class="dfn-panel" data-for="permission" id="infopanel-for-permission" role="dialog">
+   <span id="infopaneltitle-for-permission" style="display:none">Info about the 'permission' definition.</span><b><a href="#permission">#permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-permission">2.2. Permission model</a> <a href="#ref-for-permission①">(2)</a>
     <li><a href="#ref-for-permission②">3.2. Constructors</a>
@@ -2436,44 +2436,44 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-permission⑥">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fetch-steps">
-   <b><a href="#fetch-steps">#fetch-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fetch-steps" class="dfn-panel" data-for="fetch-steps" id="infopanel-for-fetch-steps" role="dialog">
+   <span id="infopaneltitle-for-fetch-steps" style="display:none">Info about the 'fetch steps' definition.</span><b><a href="#fetch-steps">#fetch-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-steps">3.2. Constructors</a>
     <li><a href="#ref-for-fetch-steps①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="show-steps">
-   <b><a href="#show-steps">#show-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-show-steps" class="dfn-panel" data-for="show-steps" id="infopanel-for-show-steps" role="dialog">
+   <span id="infopaneltitle-for-show-steps" style="display:none">Info about the 'show steps' definition.</span><b><a href="#show-steps">#show-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-show-steps">2. Notifications</a>
     <li><a href="#ref-for-show-steps①">3.2. Constructors</a>
     <li><a href="#ref-for-show-steps②">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="close-steps">
-   <b><a href="#close-steps">#close-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-close-steps" class="dfn-panel" data-for="close-steps" id="infopanel-for-close-steps" role="dialog">
+   <span id="infopaneltitle-for-close-steps" style="display:none">Info about the 'close steps' definition.</span><b><a href="#close-steps">#close-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-steps">2.1. Lifetime and UI integration</a>
     <li><a href="#ref-for-close-steps①">2.8. Closing a notification</a>
     <li><a href="#ref-for-close-steps②">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-close-events">
-   <b><a href="#handle-close-events">#handle-close-events</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-close-events" class="dfn-panel" data-for="handle-close-events" id="infopanel-for-handle-close-events" role="dialog">
+   <span id="infopaneltitle-for-handle-close-events" style="display:none">Info about the 'handle close events' definition.</span><b><a href="#handle-close-events">#handle-close-events</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-close-events">2.6. Showing a notification</a>
     <li><a href="#ref-for-handle-close-events①">2.8. Closing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="alert-steps">
-   <b><a href="#alert-steps">#alert-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-alert-steps" class="dfn-panel" data-for="alert-steps" id="infopanel-for-alert-steps" role="dialog">
+   <span id="infopaneltitle-for-alert-steps" style="display:none">Info about the 'alert steps' definition.</span><b><a href="#alert-steps">#alert-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-alert-steps">2.6. Showing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notification">
-   <b><a href="#notification">#notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notification" class="dfn-panel" data-for="notification" id="infopanel-for-notification" role="dialog">
+   <span id="infopaneltitle-for-notification" style="display:none">Info about the 'Notification' definition.</span><b><a href="#notification">#notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notification">2.1. Lifetime and UI integration</a>
     <li><a href="#ref-for-notification①">2.6. Showing a notification</a>
@@ -2487,317 +2487,373 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-notification①①">4. Service worker API</a> <a href="#ref-for-notification①②">(2)</a> <a href="#ref-for-notification①③">(3)</a> <a href="#ref-for-notification①④">(4)</a> <a href="#ref-for-notification①⑤">(5)</a> <a href="#ref-for-notification①⑥">(6)</a> <a href="#ref-for-notification①⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-notificationoptions">
-   <b><a href="#dictdef-notificationoptions">#dictdef-notificationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-notificationoptions" class="dfn-panel" data-for="dictdef-notificationoptions" id="infopanel-for-dictdef-notificationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-notificationoptions" style="display:none">Info about the 'NotificationOptions' definition.</span><b><a href="#dictdef-notificationoptions">#dictdef-notificationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-notificationoptions">3. API</a>
     <li><a href="#ref-for-dictdef-notificationoptions①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-notificationpermission">
-   <b><a href="#enumdef-notificationpermission">#enumdef-notificationpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-notificationpermission" class="dfn-panel" data-for="enumdef-notificationpermission" id="infopanel-for-enumdef-notificationpermission" role="dialog">
+   <span id="infopaneltitle-for-enumdef-notificationpermission" style="display:none">Info about the 'NotificationPermission' definition.</span><b><a href="#enumdef-notificationpermission">#enumdef-notificationpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-notificationpermission">3. API</a> <a href="#ref-for-enumdef-notificationpermission①">(2)</a> <a href="#ref-for-enumdef-notificationpermission②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-notificationdirection">
-   <b><a href="#enumdef-notificationdirection">#enumdef-notificationdirection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-notificationdirection" class="dfn-panel" data-for="enumdef-notificationdirection" id="infopanel-for-enumdef-notificationdirection" role="dialog">
+   <span id="infopaneltitle-for-enumdef-notificationdirection" style="display:none">Info about the 'NotificationDirection' definition.</span><b><a href="#enumdef-notificationdirection">#enumdef-notificationdirection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-notificationdirection">3. API</a> <a href="#ref-for-enumdef-notificationdirection①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-notificationaction">
-   <b><a href="#dictdef-notificationaction">#dictdef-notificationaction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-notificationaction" class="dfn-panel" data-for="dictdef-notificationaction" id="infopanel-for-dictdef-notificationaction" role="dialog">
+   <span id="infopaneltitle-for-dictdef-notificationaction" style="display:none">Info about the 'NotificationAction' definition.</span><b><a href="#dictdef-notificationaction">#dictdef-notificationaction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-notificationaction">3. API</a> <a href="#ref-for-dictdef-notificationaction①">(2)</a>
     <li><a href="#ref-for-dictdef-notificationaction②">3.4. Object members</a> <a href="#ref-for-dictdef-notificationaction③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notificationaction-action">
-   <b><a href="#dom-notificationaction-action">#dom-notificationaction-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notificationaction-action" class="dfn-panel" data-for="dom-notificationaction-action" id="infopanel-for-dom-notificationaction-action" role="dialog">
+   <span id="infopaneltitle-for-dom-notificationaction-action" style="display:none">Info about the 'action' definition.</span><b><a href="#dom-notificationaction-action">#dom-notificationaction-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notificationaction-action">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notificationaction-title">
-   <b><a href="#dom-notificationaction-title">#dom-notificationaction-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notificationaction-title" class="dfn-panel" data-for="dom-notificationaction-title" id="infopanel-for-dom-notificationaction-title" role="dialog">
+   <span id="infopaneltitle-for-dom-notificationaction-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-notificationaction-title">#dom-notificationaction-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notificationaction-title">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notificationaction-icon">
-   <b><a href="#dom-notificationaction-icon">#dom-notificationaction-icon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notificationaction-icon" class="dfn-panel" data-for="dom-notificationaction-icon" id="infopanel-for-dom-notificationaction-icon" role="dialog">
+   <span id="infopaneltitle-for-dom-notificationaction-icon" style="display:none">Info about the 'icon' definition.</span><b><a href="#dom-notificationaction-icon">#dom-notificationaction-icon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notificationaction-icon">3.4. Object members</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-notificationpermissioncallback">
-   <b><a href="#callbackdef-notificationpermissioncallback">#callbackdef-notificationpermissioncallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-notificationpermissioncallback" class="dfn-panel" data-for="callbackdef-notificationpermissioncallback" id="infopanel-for-callbackdef-notificationpermissioncallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-notificationpermissioncallback" style="display:none">Info about the 'NotificationPermissionCallback' definition.</span><b><a href="#callbackdef-notificationpermissioncallback">#callbackdef-notificationpermissioncallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-notificationpermissioncallback">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-notification">
-   <b><a href="#dom-notification-notification">#dom-notification-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-notification" class="dfn-panel" data-for="dom-notification-notification" id="infopanel-for-dom-notification-notification" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-notification" style="display:none">Info about the 'Notification(title, options)' definition.</span><b><a href="#dom-notification-notification">#dom-notification-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-notification">3. API</a> <a href="#ref-for-dom-notification-notification①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-permission">
-   <b><a href="#dom-notification-permission">#dom-notification-permission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-permission" class="dfn-panel" data-for="dom-notification-permission" id="infopanel-for-dom-notification-permission" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-permission" style="display:none">Info about the 'permission' definition.</span><b><a href="#dom-notification-permission">#dom-notification-permission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-permission">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-requestpermission">
-   <b><a href="#dom-notification-requestpermission">#dom-notification-requestpermission</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-requestpermission" class="dfn-panel" data-for="dom-notification-requestpermission" id="infopanel-for-dom-notification-requestpermission" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-requestpermission" style="display:none">Info about the 'requestPermission(deprecatedCallback)' definition.</span><b><a href="#dom-notification-requestpermission">#dom-notification-requestpermission</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-requestpermission">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-maxactions">
-   <b><a href="#dom-notification-maxactions">#dom-notification-maxactions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-maxactions" class="dfn-panel" data-for="dom-notification-maxactions" id="infopanel-for-dom-notification-maxactions" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-maxactions" style="display:none">Info about the 'maxActions' definition.</span><b><a href="#dom-notification-maxactions">#dom-notification-maxactions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-maxactions">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-onclick">
-   <b><a href="#dom-notification-onclick">#dom-notification-onclick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-onclick" class="dfn-panel" data-for="dom-notification-onclick" id="infopanel-for-dom-notification-onclick" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-onclick" style="display:none">Info about the 'onclick' definition.</span><b><a href="#dom-notification-onclick">#dom-notification-onclick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-onclick">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-onshow">
-   <b><a href="#dom-notification-onshow">#dom-notification-onshow</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-onshow" class="dfn-panel" data-for="dom-notification-onshow" id="infopanel-for-dom-notification-onshow" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-onshow" style="display:none">Info about the 'onshow' definition.</span><b><a href="#dom-notification-onshow">#dom-notification-onshow</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-onshow">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-onerror">
-   <b><a href="#dom-notification-onerror">#dom-notification-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-onerror" class="dfn-panel" data-for="dom-notification-onerror" id="infopanel-for-dom-notification-onerror" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#dom-notification-onerror">#dom-notification-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-onerror">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-onclose">
-   <b><a href="#dom-notification-onclose">#dom-notification-onclose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-onclose" class="dfn-panel" data-for="dom-notification-onclose" id="infopanel-for-dom-notification-onclose" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-onclose" style="display:none">Info about the 'onclose' definition.</span><b><a href="#dom-notification-onclose">#dom-notification-onclose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-onclose">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-close">
-   <b><a href="#dom-notification-close">#dom-notification-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-close" class="dfn-panel" data-for="dom-notification-close" id="infopanel-for-dom-notification-close" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#dom-notification-close">#dom-notification-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-close">2.1. Lifetime and UI integration</a>
     <li><a href="#ref-for-dom-notification-close①">3. API</a>
     <li><a href="#ref-for-dom-notification-close②">3.5.4. Using the tag member for a single instance</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-title">
-   <b><a href="#dom-notification-title">#dom-notification-title</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-title" class="dfn-panel" data-for="dom-notification-title" id="infopanel-for-dom-notification-title" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-title" style="display:none">Info about the 'title' definition.</span><b><a href="#dom-notification-title">#dom-notification-title</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-title">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-dir">
-   <b><a href="#dom-notification-dir">#dom-notification-dir</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-dir" class="dfn-panel" data-for="dom-notification-dir" id="infopanel-for-dom-notification-dir" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-dir" style="display:none">Info about the 'dir' definition.</span><b><a href="#dom-notification-dir">#dom-notification-dir</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-dir">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-lang">
-   <b><a href="#dom-notification-lang">#dom-notification-lang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-lang" class="dfn-panel" data-for="dom-notification-lang" id="infopanel-for-dom-notification-lang" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-lang" style="display:none">Info about the 'lang' definition.</span><b><a href="#dom-notification-lang">#dom-notification-lang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-lang">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-body">
-   <b><a href="#dom-notification-body">#dom-notification-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-body" class="dfn-panel" data-for="dom-notification-body" id="infopanel-for-dom-notification-body" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-body" style="display:none">Info about the 'body' definition.</span><b><a href="#dom-notification-body">#dom-notification-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-body">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-tag">
-   <b><a href="#dom-notification-tag">#dom-notification-tag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-tag" class="dfn-panel" data-for="dom-notification-tag" id="infopanel-for-dom-notification-tag" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-tag" style="display:none">Info about the 'tag' definition.</span><b><a href="#dom-notification-tag">#dom-notification-tag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-tag">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-image">
-   <b><a href="#dom-notification-image">#dom-notification-image</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-image" class="dfn-panel" data-for="dom-notification-image" id="infopanel-for-dom-notification-image" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-image" style="display:none">Info about the 'image' definition.</span><b><a href="#dom-notification-image">#dom-notification-image</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-image">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-icon">
-   <b><a href="#dom-notification-icon">#dom-notification-icon</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-icon" class="dfn-panel" data-for="dom-notification-icon" id="infopanel-for-dom-notification-icon" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-icon" style="display:none">Info about the 'icon' definition.</span><b><a href="#dom-notification-icon">#dom-notification-icon</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-icon">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-badge">
-   <b><a href="#dom-notification-badge">#dom-notification-badge</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-badge" class="dfn-panel" data-for="dom-notification-badge" id="infopanel-for-dom-notification-badge" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-badge" style="display:none">Info about the 'badge' definition.</span><b><a href="#dom-notification-badge">#dom-notification-badge</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-badge">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-vibrate">
-   <b><a href="#dom-notification-vibrate">#dom-notification-vibrate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-vibrate" class="dfn-panel" data-for="dom-notification-vibrate" id="infopanel-for-dom-notification-vibrate" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-vibrate" style="display:none">Info about the 'vibrate' definition.</span><b><a href="#dom-notification-vibrate">#dom-notification-vibrate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-vibrate">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-timestamp">
-   <b><a href="#dom-notification-timestamp">#dom-notification-timestamp</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-timestamp" class="dfn-panel" data-for="dom-notification-timestamp" id="infopanel-for-dom-notification-timestamp" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-timestamp" style="display:none">Info about the 'timestamp' definition.</span><b><a href="#dom-notification-timestamp">#dom-notification-timestamp</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-timestamp">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-renotify">
-   <b><a href="#dom-notification-renotify">#dom-notification-renotify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-renotify" class="dfn-panel" data-for="dom-notification-renotify" id="infopanel-for-dom-notification-renotify" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-renotify" style="display:none">Info about the 'renotify' definition.</span><b><a href="#dom-notification-renotify">#dom-notification-renotify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-renotify">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-silent">
-   <b><a href="#dom-notification-silent">#dom-notification-silent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-silent" class="dfn-panel" data-for="dom-notification-silent" id="infopanel-for-dom-notification-silent" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-silent" style="display:none">Info about the 'silent' definition.</span><b><a href="#dom-notification-silent">#dom-notification-silent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-silent">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-requireinteraction">
-   <b><a href="#dom-notification-requireinteraction">#dom-notification-requireinteraction</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-requireinteraction" class="dfn-panel" data-for="dom-notification-requireinteraction" id="infopanel-for-dom-notification-requireinteraction" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-requireinteraction" style="display:none">Info about the 'requireInteraction' definition.</span><b><a href="#dom-notification-requireinteraction">#dom-notification-requireinteraction</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-requireinteraction">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-data">
-   <b><a href="#dom-notification-data">#dom-notification-data</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-data" class="dfn-panel" data-for="dom-notification-data" id="infopanel-for-dom-notification-data" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-data" style="display:none">Info about the 'data' definition.</span><b><a href="#dom-notification-data">#dom-notification-data</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-data">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notification-actions">
-   <b><a href="#dom-notification-actions">#dom-notification-actions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notification-actions" class="dfn-panel" data-for="dom-notification-actions" id="infopanel-for-dom-notification-actions" role="dialog">
+   <span id="infopaneltitle-for-dom-notification-actions" style="display:none">Info about the 'actions' definition.</span><b><a href="#dom-notification-actions">#dom-notification-actions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notification-actions">3. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-getnotificationoptions">
-   <b><a href="#dictdef-getnotificationoptions">#dictdef-getnotificationoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-getnotificationoptions" class="dfn-panel" data-for="dictdef-getnotificationoptions" id="infopanel-for-dictdef-getnotificationoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-getnotificationoptions" style="display:none">Info about the 'GetNotificationOptions' definition.</span><b><a href="#dictdef-getnotificationoptions">#dictdef-getnotificationoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-getnotificationoptions">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="notificationevent">
-   <b><a href="#notificationevent">#notificationevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-notificationevent" class="dfn-panel" data-for="notificationevent" id="infopanel-for-notificationevent" role="dialog">
+   <span id="infopaneltitle-for-notificationevent" style="display:none">Info about the 'NotificationEvent' definition.</span><b><a href="#notificationevent">#notificationevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notificationevent">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notificationevent-notification">
-   <b><a href="#dom-notificationevent-notification">#dom-notificationevent-notification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notificationevent-notification" class="dfn-panel" data-for="dom-notificationevent-notification" id="infopanel-for-dom-notificationevent-notification" role="dialog">
+   <span id="infopaneltitle-for-dom-notificationevent-notification" style="display:none">Info about the 'notification' definition.</span><b><a href="#dom-notificationevent-notification">#dom-notificationevent-notification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notificationevent-notification">4. Service worker API</a> <a href="#ref-for-dom-notificationevent-notification①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-notificationevent-action">
-   <b><a href="#dom-notificationevent-action">#dom-notificationevent-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-notificationevent-action" class="dfn-panel" data-for="dom-notificationevent-action" id="infopanel-for-dom-notificationevent-action" role="dialog">
+   <span id="infopaneltitle-for-dom-notificationevent-action" style="display:none">Info about the 'action' definition.</span><b><a href="#dom-notificationevent-action">#dom-notificationevent-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-notificationevent-action">4. Service worker API</a> <a href="#ref-for-dom-notificationevent-action①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-notificationeventinit">
-   <b><a href="#dictdef-notificationeventinit">#dictdef-notificationeventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-notificationeventinit" class="dfn-panel" data-for="dictdef-notificationeventinit" id="infopanel-for-dictdef-notificationeventinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-notificationeventinit" style="display:none">Info about the 'NotificationEventInit' definition.</span><b><a href="#dictdef-notificationeventinit">#dictdef-notificationeventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-notificationeventinit">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-shownotification">
-   <b><a href="#dom-serviceworkerregistration-shownotification">#dom-serviceworkerregistration-shownotification</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-shownotification" class="dfn-panel" data-for="dom-serviceworkerregistration-shownotification" id="infopanel-for-dom-serviceworkerregistration-shownotification" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-shownotification" style="display:none">Info about the 'showNotification(title, options)' definition.</span><b><a href="#dom-serviceworkerregistration-shownotification">#dom-serviceworkerregistration-shownotification</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-shownotification">3. API</a>
     <li><a href="#ref-for-dom-serviceworkerregistration-shownotification①">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerregistration-getnotifications">
-   <b><a href="#dom-serviceworkerregistration-getnotifications">#dom-serviceworkerregistration-getnotifications</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerregistration-getnotifications" class="dfn-panel" data-for="dom-serviceworkerregistration-getnotifications" id="infopanel-for-dom-serviceworkerregistration-getnotifications" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerregistration-getnotifications" style="display:none">Info about the 'getNotifications(filter)' definition.</span><b><a href="#dom-serviceworkerregistration-getnotifications">#dom-serviceworkerregistration-getnotifications</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerregistration-getnotifications">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fire-a-service-worker-notification-event">
-   <b><a href="#fire-a-service-worker-notification-event">#fire-a-service-worker-notification-event</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fire-a-service-worker-notification-event" class="dfn-panel" data-for="fire-a-service-worker-notification-event" id="infopanel-for-fire-a-service-worker-notification-event" role="dialog">
+   <span id="infopaneltitle-for-fire-a-service-worker-notification-event" style="display:none">Info about the 'fire a service worker notification event' definition.</span><b><a href="#fire-a-service-worker-notification-event">#fire-a-service-worker-notification-event</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fire-a-service-worker-notification-event">2.7. Activating a notification</a>
     <li><a href="#ref-for-fire-a-service-worker-notification-event①">2.8. Closing a notification</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onnotificationclick">
-   <b><a href="#dom-serviceworkerglobalscope-onnotificationclick">#dom-serviceworkerglobalscope-onnotificationclick</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onnotificationclick" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onnotificationclick" id="infopanel-for-dom-serviceworkerglobalscope-onnotificationclick" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onnotificationclick" style="display:none">Info about the 'onnotificationclick' definition.</span><b><a href="#dom-serviceworkerglobalscope-onnotificationclick">#dom-serviceworkerglobalscope-onnotificationclick</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onnotificationclick">4. Service worker API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-serviceworkerglobalscope-onnotificationclose">
-   <b><a href="#dom-serviceworkerglobalscope-onnotificationclose">#dom-serviceworkerglobalscope-onnotificationclose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-serviceworkerglobalscope-onnotificationclose" class="dfn-panel" data-for="dom-serviceworkerglobalscope-onnotificationclose" id="infopanel-for-dom-serviceworkerglobalscope-onnotificationclose" role="dialog">
+   <span id="infopaneltitle-for-dom-serviceworkerglobalscope-onnotificationclose" style="display:none">Info about the 'onnotificationclose' definition.</span><b><a href="#dom-serviceworkerglobalscope-onnotificationclose">#dom-serviceworkerglobalscope-onnotificationclose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-serviceworkerglobalscope-onnotificationclose">4. Service worker API</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/quirks/quirks.html
+++ b/tests/github/whatwg/quirks/quirks.html
@@ -498,109 +498,109 @@ if ("serviceWorker" in navigator) {
    <li><a href="#quirky-length-value">&lt;quirky-length></a><span>, in § 3.2</span>
    <li><a href="#quirky-length">quirky length</a><span>, in § 3.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-inline-intrinsic-min">
-   <a href="https://dbaron.org/css/intrinsic/#inline-intrinsic-min">https://dbaron.org/css/intrinsic/#inline-intrinsic-min</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-intrinsic-min" class="dfn-panel" data-for="term-for-inline-intrinsic-min" id="infopanel-for-term-for-inline-intrinsic-min" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-intrinsic-min" style="display:none">Info about the 'min-content width of an inline formatting context' external reference.</span><a href="https://dbaron.org/css/intrinsic/#inline-intrinsic-min">https://dbaron.org/css/intrinsic/#inline-intrinsic-min</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-intrinsic-min">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-autotable">
-   <a href="https://dbaron.org/css/intrinsic/#autotable">https://dbaron.org/css/intrinsic/#autotable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-autotable" class="dfn-panel" data-for="term-for-autotable" id="infopanel-for-term-for-autotable" role="menu">
+   <span id="infopaneltitle-for-term-for-autotable" style="display:none">Info about the 'outer min-content width of a table cell' external reference.</span><a href="https://dbaron.org/css/intrinsic/#autotable">https://dbaron.org/css/intrinsic/#autotable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-autotable">3.9. The table cell nowrap minimum width
 calculation quirk</a> <a href="#ref-for-autotable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-color" class="dfn-panel" data-for="term-for-propdef-background-color" id="infopanel-for-term-for-propdef-background-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-color" style="display:none">Info about the 'background-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-background-position">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-background-position" class="dfn-panel" data-for="term-for-propdef-background-position" id="infopanel-for-term-for-propdef-background-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-background-position" style="display:none">Info about the 'background-position' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position">https://drafts.csswg.org/css-backgrounds-3/#propdef-background-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-background-position">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-color" class="dfn-panel" data-for="term-for-propdef-border-bottom-color" id="infopanel-for-term-for-propdef-border-bottom-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-color" style="display:none">Info about the 'border-bottom-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-bottom-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-bottom-width" class="dfn-panel" data-for="term-for-propdef-border-bottom-width" id="infopanel-for-term-for-propdef-border-bottom-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-bottom-width" style="display:none">Info about the 'border-bottom-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-bottom-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-bottom-width">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-border-bottom-width①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-color" class="dfn-panel" data-for="term-for-propdef-border-color" id="infopanel-for-term-for-propdef-border-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-color" style="display:none">Info about the 'border-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-color" class="dfn-panel" data-for="term-for-propdef-border-left-color" id="infopanel-for-term-for-propdef-border-left-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-color" style="display:none">Info about the 'border-left-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-left-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-left-width" class="dfn-panel" data-for="term-for-propdef-border-left-width" id="infopanel-for-term-for-propdef-border-left-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-left-width" style="display:none">Info about the 'border-left-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-left-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-left-width">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-border-left-width①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-color" class="dfn-panel" data-for="term-for-propdef-border-right-color" id="infopanel-for-term-for-propdef-border-right-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-color" style="display:none">Info about the 'border-right-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-right-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-right-width" class="dfn-panel" data-for="term-for-propdef-border-right-width" id="infopanel-for-term-for-propdef-border-right-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-right-width" style="display:none">Info about the 'border-right-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-right-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-right-width">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-border-right-width①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-style">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-style" class="dfn-panel" data-for="term-for-propdef-border-style" id="infopanel-for-term-for-propdef-border-style" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-style" style="display:none">Info about the 'border-style' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-style</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-style">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-color">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-color" class="dfn-panel" data-for="term-for-propdef-border-top-color" id="infopanel-for-term-for-propdef-border-top-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-color" style="display:none">Info about the 'border-top-color' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-color">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-top-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-top-width" class="dfn-panel" data-for="term-for-propdef-border-top-width" id="infopanel-for-term-for-propdef-border-top-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-top-width" style="display:none">Info about the 'border-top-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-top-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-top-width">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-border-top-width①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-width">
-   <a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-width" class="dfn-panel" data-for="term-for-propdef-border-width" id="infopanel-for-term-for-propdef-border-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-width" style="display:none">Info about the 'border-width' external reference.</span><a href="https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width">https://drafts.csswg.org/css-backgrounds-3/#propdef-border-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-width">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin" class="dfn-panel" data-for="term-for-propdef-margin" id="infopanel-for-term-for-propdef-margin" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin" style="display:none">Info about the 'margin' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin">https://drafts.csswg.org/css-box-4/#propdef-margin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-bottom" class="dfn-panel" data-for="term-for-propdef-margin-bottom" id="infopanel-for-term-for-propdef-margin-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-bottom" style="display:none">Info about the 'margin-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-bottom">https://drafts.csswg.org/css-box-4/#propdef-margin-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-bottom">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-margin-bottom①">3.6. The html element fills the viewport
@@ -609,8 +609,8 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-left" class="dfn-panel" data-for="term-for-propdef-margin-left" id="infopanel-for-term-for-propdef-margin-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-left" style="display:none">Info about the 'margin-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-left">https://drafts.csswg.org/css-box-4/#propdef-margin-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-left">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-margin-left①">3.6. The html element fills the viewport
@@ -619,8 +619,8 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-right" class="dfn-panel" data-for="term-for-propdef-margin-right" id="infopanel-for-term-for-propdef-margin-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-right" style="display:none">Info about the 'margin-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-right">https://drafts.csswg.org/css-box-4/#propdef-margin-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-right">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-margin-right①">3.6. The html element fills the viewport
@@ -629,8 +629,8 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-margin-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-margin-top" class="dfn-panel" data-for="term-for-propdef-margin-top" id="infopanel-for-term-for-propdef-margin-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-margin-top" style="display:none">Info about the 'margin-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-margin-top">https://drafts.csswg.org/css-box-4/#propdef-margin-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-margin-top">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-margin-top①">3.6. The html element fills the viewport
@@ -639,42 +639,42 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding" class="dfn-panel" data-for="term-for-propdef-padding" id="infopanel-for-term-for-propdef-padding" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding" style="display:none">Info about the 'padding' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding">https://drafts.csswg.org/css-box-4/#propdef-padding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-bottom">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-bottom" class="dfn-panel" data-for="term-for-propdef-padding-bottom" id="infopanel-for-term-for-propdef-padding-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-bottom" style="display:none">Info about the 'padding-bottom' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-bottom">https://drafts.csswg.org/css-box-4/#propdef-padding-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-bottom">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-padding-bottom①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-left">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-left" class="dfn-panel" data-for="term-for-propdef-padding-left" id="infopanel-for-term-for-propdef-padding-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-left" style="display:none">Info about the 'padding-left' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-left">https://drafts.csswg.org/css-box-4/#propdef-padding-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-left">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-padding-left①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-right">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-right" class="dfn-panel" data-for="term-for-propdef-padding-right" id="infopanel-for-term-for-propdef-padding-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-right" style="display:none">Info about the 'padding-right' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-right">https://drafts.csswg.org/css-box-4/#propdef-padding-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-right">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-padding-right①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-padding-top">
-   <a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-padding-top" class="dfn-panel" data-for="term-for-propdef-padding-top" id="infopanel-for-term-for-propdef-padding-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-padding-top" style="display:none">Info about the 'padding-top' external reference.</span><a href="https://drafts.csswg.org/css-box-4/#propdef-padding-top">https://drafts.csswg.org/css-box-4/#propdef-padding-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-padding-top">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-padding-top①">3.3. The line height calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-computed-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-computed-value" class="dfn-panel" data-for="term-for-computed-value" id="infopanel-for-term-for-computed-value" role="menu">
+   <span id="infopaneltitle-for-term-for-computed-value" style="display:none">Info about the 'computed value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#computed-value">https://drafts.csswg.org/css-cascade-5/#computed-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-computed-value">3.5. The percentage height calculation
 quirk</a> <a href="#ref-for-computed-value①">(2)</a> <a href="#ref-for-computed-value②">(3)</a> <a href="#ref-for-computed-value③">(4)</a> <a href="#ref-for-computed-value④">(5)</a>
@@ -691,8 +691,8 @@ quirk</a> <a href="#ref-for-computed-value①⑥">(2)</a>
     <li><a href="#ref-for-computed-value①⑦">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-used-value">
-   <a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-used-value" class="dfn-panel" data-for="term-for-used-value" id="infopanel-for-term-for-used-value" role="menu">
+   <span id="infopaneltitle-for-term-for-used-value" style="display:none">Info about the 'used value' external reference.</span><a href="https://drafts.csswg.org/css-cascade-5/#used-value">https://drafts.csswg.org/css-cascade-5/#used-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-used-value">3.3. The line height calculation quirk</a> <a href="#ref-for-used-value①">(2)</a>
     <li><a href="#ref-for-used-value②">3.6. The html element fills the viewport
@@ -705,51 +705,51 @@ quirk</a>
     <li><a href="#ref-for-used-value⑨">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">3.1. The hashless hex color quirk</a> <a href="#ref-for-typedef-color①">(2)</a> <a href="#ref-for-typedef-color②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-color" class="dfn-panel" data-for="term-for-propdef-color" id="infopanel-for-term-for-propdef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-color" style="display:none">Info about the 'color' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#propdef-color">https://drafts.csswg.org/css-color-4/#propdef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-color">3.1. The hashless hex color quirk</a>
     <li><a href="#ref-for-propdef-color①">3.12. The tables inherit color from body
 quirk</a> <a href="#ref-for-propdef-color②">(2)</a> <a href="#ref-for-propdef-color③">(3)</a> <a href="#ref-for-propdef-color④">(4)</a> <a href="#ref-for-propdef-color⑤">(5)</a> <a href="#ref-for-propdef-color⑥">(6)</a> <a href="#ref-for-propdef-color⑦">(7)</a> <a href="#ref-for-propdef-color⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-at-ruledef-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-at-ruledef-supports" class="dfn-panel" data-for="term-for-at-ruledef-supports" id="infopanel-for-term-for-at-ruledef-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-at-ruledef-supports" style="display:none">Info about the '@supports' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports">https://drafts.csswg.org/css-conditional-3/#at-ruledef-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-supports">3.1. The hashless hex color quirk</a>
     <li><a href="#ref-for-at-ruledef-supports①">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-css-supports">
-   <a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports">https://drafts.csswg.org/css-conditional-3/#dom-css-supports</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-css-supports" class="dfn-panel" data-for="term-for-dom-css-supports" id="infopanel-for-term-for-dom-css-supports" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-css-supports" style="display:none">Info about the 'supports(property, value)' external reference.</span><a href="https://drafts.csswg.org/css-conditional-3/#dom-css-supports">https://drafts.csswg.org/css-conditional-3/#dom-css-supports</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-css-supports">3.1. The hashless hex color quirk</a>
     <li><a href="#ref-for-dom-css-supports①">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container">
-   <a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container" class="dfn-panel" data-for="term-for-block-container" id="infopanel-for-term-for-block-container" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container" style="display:none">Info about the 'block container' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#block-container">https://drafts.csswg.org/css-display-3/#block-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-containing-block" class="dfn-panel" data-for="term-for-containing-block" id="infopanel-for-term-for-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-containing-block" style="display:none">Info about the 'containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#containing-block">https://drafts.csswg.org/css-display-3/#containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-containing-block">3.5. The percentage height calculation
 quirk</a> <a href="#ref-for-containing-block①">(2)</a>
     <li><a href="#ref-for-containing-block②">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-display">
-   <a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-display" class="dfn-panel" data-for="term-for-propdef-display" id="infopanel-for-term-for-propdef-display" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-display" style="display:none">Info about the 'display' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#propdef-display">https://drafts.csswg.org/css-display-3/#propdef-display</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-display">3.5. The percentage height calculation
 quirk</a> <a href="#ref-for-propdef-display①">(2)</a>
@@ -757,8 +757,8 @@ quirk</a> <a href="#ref-for-propdef-display①">(2)</a>
     <li><a href="#ref-for-propdef-display③">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-initial-containing-block">
-   <a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-initial-containing-block" class="dfn-panel" data-for="term-for-initial-containing-block" id="infopanel-for-term-for-initial-containing-block" role="menu">
+   <span id="infopaneltitle-for-term-for-initial-containing-block" style="display:none">Info about the 'initial containing block' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#initial-containing-block">https://drafts.csswg.org/css-display-3/#initial-containing-block</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initial-containing-block">3.5. The percentage height calculation
 quirk</a>
@@ -766,14 +766,14 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-formatting-context">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-formatting-context" class="dfn-panel" data-for="term-for-inline-formatting-context" id="infopanel-for-term-for-inline-formatting-context" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-formatting-context" style="display:none">Info about the 'inline formatting context' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-formatting-context">https://drafts.csswg.org/css-display-3/#inline-formatting-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-formatting-context">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-inline-level">
-   <a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-inline-level" class="dfn-panel" data-for="term-for-inline-level" id="infopanel-for-term-for-inline-level" role="menu">
+   <span id="infopaneltitle-for-term-for-inline-level" style="display:none">Info about the 'inline-level' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#inline-level">https://drafts.csswg.org/css-display-3/#inline-level</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-inline-level">3.4. The blocks ignore line-height quirk</a>
     <li><a href="#ref-for-inline-level①">3.7. The body element fills the html element
@@ -781,98 +781,98 @@ quirk</a>
     <li><a href="#ref-for-inline-level②">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table" class="dfn-panel" data-for="term-for-valdef-display-table" id="infopanel-for-term-for-valdef-display-table" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table" style="display:none">Info about the 'table' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table">https://drafts.csswg.org/css-display-3/#valdef-display-table</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-caption">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-caption">https://drafts.csswg.org/css-display-3/#valdef-display-table-caption</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-caption" class="dfn-panel" data-for="term-for-valdef-display-table-caption" id="infopanel-for-term-for-valdef-display-table-caption" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-caption" style="display:none">Info about the 'table-caption' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-caption">https://drafts.csswg.org/css-display-3/#valdef-display-table-caption</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-caption">3.5. The percentage height calculation
 quirk</a>
     <li><a href="#ref-for-valdef-display-table-caption①">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-cell">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-cell" class="dfn-panel" data-for="term-for-valdef-display-table-cell" id="infopanel-for-term-for-valdef-display-table-cell" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-cell" style="display:none">Info about the 'table-cell' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-cell">https://drafts.csswg.org/css-display-3/#valdef-display-table-cell</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-cell">3.5. The percentage height calculation
 quirk</a> <a href="#ref-for-valdef-display-table-cell①">(2)</a>
     <li><a href="#ref-for-valdef-display-table-cell②">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column" class="dfn-panel" data-for="term-for-valdef-display-table-column" id="infopanel-for-term-for-valdef-display-table-column" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column" style="display:none">Info about the 'table-column' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column">https://drafts.csswg.org/css-display-3/#valdef-display-table-column</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-column-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-column-group" class="dfn-panel" data-for="term-for-valdef-display-table-column-group" id="infopanel-for-term-for-valdef-display-table-column-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-column-group" style="display:none">Info about the 'table-column-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-column-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-column-group">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-footer-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-footer-group" class="dfn-panel" data-for="term-for-valdef-display-table-footer-group" id="infopanel-for-term-for-valdef-display-table-footer-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-footer-group" style="display:none">Info about the 'table-footer-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-footer-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-footer-group">3.5. The percentage height calculation
 quirk</a>
     <li><a href="#ref-for-valdef-display-table-footer-group①">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-header-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-header-group" class="dfn-panel" data-for="term-for-valdef-display-table-header-group" id="infopanel-for-term-for-valdef-display-table-header-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-header-group" style="display:none">Info about the 'table-header-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-header-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-header-group">3.5. The percentage height calculation
 quirk</a>
     <li><a href="#ref-for-valdef-display-table-header-group①">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-row">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row">https://drafts.csswg.org/css-display-3/#valdef-display-table-row</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-row" class="dfn-panel" data-for="term-for-valdef-display-table-row" id="infopanel-for-term-for-valdef-display-table-row" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-row" style="display:none">Info about the 'table-row' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row">https://drafts.csswg.org/css-display-3/#valdef-display-table-row</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-row">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-display-table-row-group">
-   <a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-display-table-row-group" class="dfn-panel" data-for="term-for-valdef-display-table-row-group" id="infopanel-for-term-for-valdef-display-table-row-group" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-display-table-row-group" style="display:none">Info about the 'table-row-group' external reference.</span><a href="https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group">https://drafts.csswg.org/css-display-3/#valdef-display-table-row-group</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-display-table-row-group">3.5. The percentage height calculation
 quirk</a>
     <li><a href="#ref-for-valdef-display-table-row-group①">3.10. The collapsing table quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-font-size">
-   <a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-font-size" class="dfn-panel" data-for="term-for-propdef-font-size" id="infopanel-for-term-for-propdef-font-size" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-font-size" style="display:none">Info about the 'font-size' external reference.</span><a href="https://drafts.csswg.org/css-fonts-4/#propdef-font-size">https://drafts.csswg.org/css-fonts-4/#propdef-font-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-font-size">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-vertical-align">
-   <a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-vertical-align" class="dfn-panel" data-for="term-for-propdef-vertical-align" id="infopanel-for-term-for-propdef-vertical-align" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-vertical-align" style="display:none">Info about the 'vertical-align' external reference.</span><a href="https://drafts.csswg.org/css-inline-3/#propdef-vertical-align">https://drafts.csswg.org/css-inline-3/#propdef-vertical-align</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-vertical-align">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-clip">
-   <a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-clip" class="dfn-panel" data-for="term-for-propdef-clip" id="infopanel-for-term-for-propdef-clip" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-clip" style="display:none">Info about the 'clip' external reference.</span><a href="https://drafts.fxtf.org/css-masking-1/#propdef-clip">https://drafts.fxtf.org/css-masking-1/#propdef-clip</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-clip">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-float-none">
-   <a href="https://drafts.csswg.org/css-page-floats-3/#valdef-float-none">https://drafts.csswg.org/css-page-floats-3/#valdef-float-none</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-float-none" class="dfn-panel" data-for="term-for-valdef-float-none" id="infopanel-for-term-for-valdef-float-none" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-float-none" style="display:none">Info about the 'none' external reference.</span><a href="https://drafts.csswg.org/css-page-floats-3/#valdef-float-none">https://drafts.csswg.org/css-page-floats-3/#valdef-float-none</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-float-none">3.7. The body element fills the html element
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-absolute">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-absolute" class="dfn-panel" data-for="term-for-valdef-position-absolute" id="infopanel-for-term-for-valdef-position-absolute" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-absolute" style="display:none">Info about the 'absolute' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-absolute">https://drafts.csswg.org/css-position-3/#valdef-position-absolute</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-absolute">3.5. The percentage height calculation
 quirk</a>
@@ -880,27 +880,27 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-bottom">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-bottom" class="dfn-panel" data-for="term-for-propdef-bottom" id="infopanel-for-term-for-propdef-bottom" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-bottom" style="display:none">Info about the 'bottom' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-bottom">https://drafts.csswg.org/css-position-3/#propdef-bottom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-bottom">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-fixed">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-fixed" class="dfn-panel" data-for="term-for-valdef-position-fixed" id="infopanel-for-term-for-valdef-position-fixed" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-fixed" style="display:none">Info about the 'fixed' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-fixed">https://drafts.csswg.org/css-position-3/#valdef-position-fixed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-fixed">3.7. The body element fills the html element
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-left">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-left" class="dfn-panel" data-for="term-for-propdef-left" id="infopanel-for-term-for-propdef-left" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-left" style="display:none">Info about the 'left' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-left">https://drafts.csswg.org/css-position-3/#propdef-left</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-left">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-position">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-position" class="dfn-panel" data-for="term-for-propdef-position" id="infopanel-for-term-for-propdef-position" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-position" style="display:none">Info about the 'position' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-position">https://drafts.csswg.org/css-position-3/#propdef-position</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-position">3.5. The percentage height calculation
 quirk</a> <a href="#ref-for-propdef-position①">(2)</a>
@@ -908,40 +908,40 @@ quirk</a> <a href="#ref-for-propdef-position①">(2)</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-relative">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-relative" class="dfn-panel" data-for="term-for-valdef-position-relative" id="infopanel-for-term-for-valdef-position-relative" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-relative" style="display:none">Info about the 'relative' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-relative">https://drafts.csswg.org/css-position-3/#valdef-position-relative</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-relative">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-right">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-right" class="dfn-panel" data-for="term-for-propdef-right" id="infopanel-for-term-for-propdef-right" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-right" style="display:none">Info about the 'right' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-right">https://drafts.csswg.org/css-position-3/#propdef-right</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-right">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-position-static">
-   <a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-position-static" class="dfn-panel" data-for="term-for-valdef-position-static" id="infopanel-for-term-for-valdef-position-static" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-position-static" style="display:none">Info about the 'static' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#valdef-position-static">https://drafts.csswg.org/css-position-3/#valdef-position-static</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-position-static">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-top">
-   <a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-top" class="dfn-panel" data-for="term-for-propdef-top" id="infopanel-for-term-for-propdef-top" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-top" style="display:none">Info about the 'top' external reference.</span><a href="https://drafts.csswg.org/css-position-3/#propdef-top">https://drafts.csswg.org/css-position-3/#propdef-top</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-top">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect">
-   <a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-funcdef-basic-shape-rect" class="dfn-panel" data-for="term-for-funcdef-basic-shape-rect" id="infopanel-for-term-for-funcdef-basic-shape-rect" role="menu">
+   <span id="infopaneltitle-for-term-for-funcdef-basic-shape-rect" style="display:none">Info about the 'rect()' external reference.</span><a href="https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect">https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-basic-shape-rect">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-width-auto">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-width-auto" class="dfn-panel" data-for="term-for-valdef-width-auto" id="infopanel-for-term-for-valdef-width-auto" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-width-auto" style="display:none">Info about the 'auto' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-auto">https://drafts.csswg.org/css-sizing-3/#valdef-width-auto</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-width-auto">3.5. The percentage height calculation
 quirk</a>
@@ -952,20 +952,20 @@ quirk</a> <a href="#ref-for-valdef-width-auto④">(2)</a>
     <li><a href="#ref-for-valdef-width-auto⑤">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-box-sizing-border-box">
-   <a href="https://drafts.csswg.org/css-sizing-3/#valdef-box-sizing-border-box">https://drafts.csswg.org/css-sizing-3/#valdef-box-sizing-border-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-box-sizing-border-box" class="dfn-panel" data-for="term-for-valdef-box-sizing-border-box" id="infopanel-for-term-for-valdef-box-sizing-border-box" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-box-sizing-border-box" style="display:none">Info about the 'border-box' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#valdef-box-sizing-border-box">https://drafts.csswg.org/css-sizing-3/#valdef-box-sizing-border-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-box-sizing-border-box">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-box-sizing">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-box-sizing" class="dfn-panel" data-for="term-for-propdef-box-sizing" id="infopanel-for-term-for-propdef-box-sizing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-box-sizing" style="display:none">Info about the 'box-sizing' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing">https://drafts.csswg.org/css-sizing-3/#propdef-box-sizing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-box-sizing">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-height">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-height" class="dfn-panel" data-for="term-for-propdef-height" id="infopanel-for-term-for-propdef-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-height" style="display:none">Info about the 'height' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-height">https://drafts.csswg.org/css-sizing-3/#propdef-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-height">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-height①">3.5. The percentage height calculation
@@ -978,8 +978,8 @@ quirk</a>
     <li><a href="#ref-for-propdef-height⑦">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-width">
-   <a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-width" class="dfn-panel" data-for="term-for-propdef-width" id="infopanel-for-term-for-propdef-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-width" style="display:none">Info about the 'width' external reference.</span><a href="https://drafts.csswg.org/css-sizing-3/#propdef-width">https://drafts.csswg.org/css-sizing-3/#propdef-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-width">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-width①">3.6. The html element fills the viewport
@@ -991,105 +991,105 @@ quirk</a>
 calculation quirk</a> <a href="#ref-for-propdef-width⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-dimension-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-dimension-token" class="dfn-panel" data-for="term-for-typedef-dimension-token" id="infopanel-for-term-for-typedef-dimension-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-dimension-token" style="display:none">Info about the '&lt;dimension-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token">https://drafts.csswg.org/css-syntax-3/#typedef-dimension-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-dimension-token">3.1. The hashless hex color quirk</a> <a href="#ref-for-typedef-dimension-token①">(2)</a> <a href="#ref-for-typedef-dimension-token②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-ident-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-ident-token" class="dfn-panel" data-for="term-for-typedef-ident-token" id="infopanel-for-term-for-typedef-ident-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-ident-token" style="display:none">Info about the '&lt;ident-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-ident-token">https://drafts.csswg.org/css-syntax-3/#typedef-ident-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-ident-token">3.1. The hashless hex color quirk</a> <a href="#ref-for-typedef-ident-token①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedef-number-token">
-   <a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-number-token" class="dfn-panel" data-for="term-for-typedef-number-token" id="infopanel-for-term-for-typedef-number-token" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-number-token" style="display:none">Info about the '&lt;number-token>' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#typedef-number-token">https://drafts.csswg.org/css-syntax-3/#typedef-number-token</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-number-token">3.1. The hashless hex color quirk</a> <a href="#ref-for-typedef-number-token①">(2)</a>
     <li><a href="#ref-for-typedef-number-token②">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-component-value">
-   <a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-component-value" class="dfn-panel" data-for="term-for-component-value" id="infopanel-for-term-for-component-value" role="menu">
+   <span id="infopaneltitle-for-term-for-component-value" style="display:none">Info about the 'component value' external reference.</span><a href="https://drafts.csswg.org/css-syntax-3/#component-value">https://drafts.csswg.org/css-syntax-3/#component-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-value">3.1. The hashless hex color quirk</a> <a href="#ref-for-component-value①">(2)</a> <a href="#ref-for-component-value②">(3)</a>
     <li><a href="#ref-for-component-value③">3.2. The unitless length quirk</a> <a href="#ref-for-component-value④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-border-spacing">
-   <a href="https://drafts.csswg.org/css-tables-3/#propdef-border-spacing">https://drafts.csswg.org/css-tables-3/#propdef-border-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-border-spacing" class="dfn-panel" data-for="term-for-propdef-border-spacing" id="infopanel-for-term-for-propdef-border-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-border-spacing" style="display:none">Info about the 'border-spacing' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#propdef-border-spacing">https://drafts.csswg.org/css-tables-3/#propdef-border-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-border-spacing">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-wrapper-box">
-   <a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-wrapper-box" class="dfn-panel" data-for="term-for-table-wrapper-box" id="infopanel-for-term-for-table-wrapper-box" role="menu">
+   <span id="infopaneltitle-for-term-for-table-wrapper-box" style="display:none">Info about the 'table wrapper box' external reference.</span><a href="https://drafts.csswg.org/css-tables-3/#table-wrapper-box">https://drafts.csswg.org/css-tables-3/#table-wrapper-box</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-wrapper-box">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-letter-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-letter-spacing" class="dfn-panel" data-for="term-for-propdef-letter-spacing" id="infopanel-for-term-for-propdef-letter-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-letter-spacing" style="display:none">Info about the 'letter-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-letter-spacing">https://drafts.csswg.org/css-text-4/#propdef-letter-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-letter-spacing">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-soft-wrap-opportunity">
-   <a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-soft-wrap-opportunity" class="dfn-panel" data-for="term-for-soft-wrap-opportunity" id="infopanel-for-term-for-soft-wrap-opportunity" role="menu">
+   <span id="infopaneltitle-for-term-for-soft-wrap-opportunity" style="display:none">Info about the 'soft wrap opportunity' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity">https://drafts.csswg.org/css-text-4/#soft-wrap-opportunity</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-soft-wrap-opportunity">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-text-indent">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-text-indent" class="dfn-panel" data-for="term-for-propdef-text-indent" id="infopanel-for-term-for-propdef-text-indent" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-text-indent" style="display:none">Info about the 'text-indent' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-text-indent">https://drafts.csswg.org/css-text-4/#propdef-text-indent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-text-indent">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-word-spacing">
-   <a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-word-spacing" class="dfn-panel" data-for="term-for-propdef-word-spacing" id="infopanel-for-term-for-propdef-word-spacing" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-word-spacing" style="display:none">Info about the 'word-spacing' external reference.</span><a href="https://drafts.csswg.org/css-text-4/#propdef-word-spacing">https://drafts.csswg.org/css-text-4/#propdef-word-spacing</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-word-spacing">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-length-value">
-   <a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-length-value" class="dfn-panel" data-for="term-for-length-value" id="infopanel-for-term-for-length-value" role="menu">
+   <span id="infopaneltitle-for-term-for-length-value" style="display:none">Info about the '&lt;length>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#length-value">https://drafts.csswg.org/css-values-4/#length-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-length-value">3.2. The unitless length quirk</a> <a href="#ref-for-length-value①">(2)</a> <a href="#ref-for-length-value②">(3)</a>
     <li><a href="#ref-for-length-value③">3.9. The table cell nowrap minimum width
 calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-percentage-value">
-   <a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-percentage-value" class="dfn-panel" data-for="term-for-percentage-value" id="infopanel-for-term-for-percentage-value" role="menu">
+   <span id="infopaneltitle-for-term-for-percentage-value" style="display:none">Info about the '&lt;percentage>' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#percentage-value">https://drafts.csswg.org/css-values-4/#percentage-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percentage-value">3.5. The percentage height calculation
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-number">
-   <a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-number" class="dfn-panel" data-for="term-for-number" id="infopanel-for-term-for-number" role="menu">
+   <span id="infopaneltitle-for-term-for-number" style="display:none">Info about the 'number' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#number">https://drafts.csswg.org/css-values-4/#number</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-number">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-px">
-   <a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-px" class="dfn-panel" data-for="term-for-px" id="infopanel-for-term-for-px" role="menu">
+   <span id="infopaneltitle-for-term-for-px" style="display:none">Info about the 'px' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#px">https://drafts.csswg.org/css-values-4/#px</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-px">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">3.1. The hashless hex color quirk</a>
     <li><a href="#ref-for-comb-one①">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-flow-direction">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-flow-direction" class="dfn-panel" data-for="term-for-block-flow-direction" id="infopanel-for-term-for-block-flow-direction" role="menu">
+   <span id="infopaneltitle-for-term-for-block-flow-direction" style="display:none">Info about the 'block flow direction' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction">https://drafts.csswg.org/css-writing-modes-4/#block-flow-direction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-flow-direction">3.6. The html element fills the viewport
 quirk</a> <a href="#ref-for-block-flow-direction①">(2)</a>
@@ -1097,8 +1097,8 @@ quirk</a> <a href="#ref-for-block-flow-direction①">(2)</a>
 quirk</a> <a href="#ref-for-block-flow-direction③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-horizontal-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-horizontal-writing-mode" class="dfn-panel" data-for="term-for-horizontal-writing-mode" id="infopanel-for-term-for-horizontal-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-horizontal-writing-mode" style="display:none">Info about the 'horizontal writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#horizontal-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-horizontal-writing-mode">3.3. The line height calculation quirk</a>
     <li><a href="#ref-for-horizontal-writing-mode①">3.6. The html element fills the viewport
@@ -1107,8 +1107,8 @@ quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-vertical-writing-mode">
-   <a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-vertical-writing-mode" class="dfn-panel" data-for="term-for-vertical-writing-mode" id="infopanel-for-term-for-vertical-writing-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-vertical-writing-mode" style="display:none">Info about the 'vertical writing mode' external reference.</span><a href="https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode">https://drafts.csswg.org/css-writing-modes-4/#vertical-writing-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-vertical-writing-mode">3.3. The line height calculation quirk</a>
     <li><a href="#ref-for-vertical-writing-mode①">3.6. The html element fills the viewport
@@ -1117,14 +1117,14 @@ quirk</a> <a href="#ref-for-vertical-writing-mode②">(2)</a>
 quirk</a> <a href="#ref-for-vertical-writing-mode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-block-container-element">
-   <a href="https://drafts.csswg.org/css2/visuren.html#block-container-element">https://drafts.csswg.org/css2/visuren.html#block-container-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-block-container-element" class="dfn-panel" data-for="term-for-block-container-element" id="infopanel-for-term-for-block-container-element" role="menu">
+   <span id="infopaneltitle-for-term-for-block-container-element" style="display:none">Info about the 'block container element' external reference.</span><a href="https://drafts.csswg.org/css2/visuren.html#block-container-element">https://drafts.csswg.org/css2/visuren.html#block-container-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-block-container-element">3.4. The blocks ignore line-height quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-border-edge">
-   <a href="https://drafts.csswg.org/css2/box.html#border-edge">https://drafts.csswg.org/css2/box.html#border-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-border-edge" class="dfn-panel" data-for="term-for-border-edge" id="infopanel-for-term-for-border-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-border-edge" style="display:none">Info about the 'border box' external reference.</span><a href="https://drafts.csswg.org/css2/box.html#border-edge">https://drafts.csswg.org/css2/box.html#border-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-border-edge">3.6. The html element fills the viewport
 quirk</a> <a href="#ref-for-border-edge①">(2)</a>
@@ -1132,102 +1132,102 @@ quirk</a> <a href="#ref-for-border-edge①">(2)</a>
 quirk</a> <a href="#ref-for-border-edge③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-content-edge">
-   <a href="https://drafts.csswg.org/css2/box.html#content-edge">https://drafts.csswg.org/css2/box.html#content-edge</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-content-edge" class="dfn-panel" data-for="term-for-content-edge" id="infopanel-for-term-for-content-edge" role="menu">
+   <span id="infopaneltitle-for-term-for-content-edge" style="display:none">Info about the 'content box' external reference.</span><a href="https://drafts.csswg.org/css2/box.html#content-edge">https://drafts.csswg.org/css2/box.html#content-edge</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-content-edge">3.7. The body element fills the html element
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-illegal">
-   <a href="https://drafts.csswg.org/css2/conform.html#illegal">https://drafts.csswg.org/css2/conform.html#illegal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-illegal" class="dfn-panel" data-for="term-for-illegal" id="infopanel-for-term-for-illegal" role="menu">
+   <span id="infopaneltitle-for-term-for-illegal" style="display:none">Info about the 'illegal' external reference.</span><a href="https://drafts.csswg.org/css2/conform.html#illegal">https://drafts.csswg.org/css2/conform.html#illegal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-illegal">3.1. The hashless hex color quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-replaced-element">
-   <a href="https://drafts.csswg.org/css2/conform.html#replaced-element">https://drafts.csswg.org/css2/conform.html#replaced-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-replaced-element" class="dfn-panel" data-for="term-for-replaced-element" id="infopanel-for-term-for-replaced-element" role="menu">
+   <span id="infopaneltitle-for-term-for-replaced-element" style="display:none">Info about the 'replaced element' external reference.</span><a href="https://drafts.csswg.org/css2/conform.html#replaced-element">https://drafts.csswg.org/css2/conform.html#replaced-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-replaced-element">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-float">
-   <a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-float" class="dfn-panel" data-for="term-for-propdef-float" id="infopanel-for-term-for-propdef-float" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-float" style="display:none">Info about the 'float' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-float">https://drafts.csswg.org/css2/#propdef-float</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-float">3.7. The body element fills the html element
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-line-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-line-height" class="dfn-panel" data-for="term-for-propdef-line-height" id="infopanel-for-term-for-propdef-line-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-line-height" style="display:none">Info about the 'line-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-line-height">https://drafts.csswg.org/css2/#propdef-line-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-line-height">3.3. The line height calculation quirk</a>
     <li><a href="#ref-for-propdef-line-height①">3.4. The blocks ignore line-height quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-height" class="dfn-panel" data-for="term-for-propdef-max-height" id="infopanel-for-term-for-propdef-max-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-height" style="display:none">Info about the 'max-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-height">https://drafts.csswg.org/css2/#propdef-max-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-height">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-max-height①">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-max-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-max-width" class="dfn-panel" data-for="term-for-propdef-max-width" id="infopanel-for-term-for-propdef-max-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-max-width" style="display:none">Info about the 'max-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-max-width">https://drafts.csswg.org/css2/#propdef-max-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-max-width">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-height">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-height" class="dfn-panel" data-for="term-for-propdef-min-height" id="infopanel-for-term-for-propdef-min-height" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-height" style="display:none">Info about the 'min-height' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-height">https://drafts.csswg.org/css2/#propdef-min-height</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-height">3.2. The unitless length quirk</a>
     <li><a href="#ref-for-propdef-min-height①">3.13. The table cell height box sizing quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-min-width">
-   <a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-min-width" class="dfn-panel" data-for="term-for-propdef-min-width" id="infopanel-for-term-for-propdef-min-width" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-min-width" style="display:none">Info about the 'min-width' external reference.</span><a href="https://drafts.csswg.org/css2/#propdef-min-width">https://drafts.csswg.org/css2/#propdef-min-width</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-min-width">3.2. The unitless length quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-spanning-element">
-   <a href="https://drafts.csswg.org/css-multicol-1/#spanning-element">https://drafts.csswg.org/css-multicol-1/#spanning-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-spanning-element" class="dfn-panel" data-for="term-for-spanning-element" id="infopanel-for-term-for-spanning-element" role="menu">
+   <span id="infopaneltitle-for-term-for-spanning-element" style="display:none">Info about the 'spanning element' external reference.</span><a href="https://drafts.csswg.org/css-multicol-1/#spanning-element">https://drafts.csswg.org/css-multicol-1/#spanning-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-spanning-element">3.7. The body element fills the html element
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-tree-child">
-   <a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-tree-child" class="dfn-panel" data-for="term-for-concept-tree-child" id="infopanel-for-term-for-concept-tree-child" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-tree-child" style="display:none">Info about the 'child' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-tree-child">https://dom.spec.whatwg.org/#concept-tree-child</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-tree-child">2.2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-document-element">
-   <a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document-element" class="dfn-panel" data-for="term-for-document-element" id="infopanel-for-term-for-document-element" role="menu">
+   <span id="infopaneltitle-for-term-for-document-element" style="display:none">Info about the 'document element' external reference.</span><a href="https://dom.spec.whatwg.org/#document-element">https://dom.spec.whatwg.org/#document-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-element">2.2. Terminology</a> <a href="#ref-for-document-element①">(2)</a>
     <li><a href="#ref-for-document-element②">3.6. The html element fills the viewport
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-limited-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-limited-quirks">https://dom.spec.whatwg.org/#concept-document-limited-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-limited-quirks" class="dfn-panel" data-for="term-for-concept-document-limited-quirks" id="infopanel-for-term-for-concept-document-limited-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-limited-quirks" style="display:none">Info about the 'limited-quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-limited-quirks">https://dom.spec.whatwg.org/#concept-document-limited-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-limited-quirks">1.2. Goals</a>
     <li><a href="#ref-for-concept-document-limited-quirks①">3.3. The line height calculation quirk</a>
     <li><a href="#ref-for-concept-document-limited-quirks②">3.4. The blocks ignore line-height quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-no-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-no-quirks">https://dom.spec.whatwg.org/#concept-document-no-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-no-quirks" class="dfn-panel" data-for="term-for-concept-document-no-quirks" id="infopanel-for-term-for-concept-document-no-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-no-quirks" style="display:none">Info about the 'no-quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-no-quirks">https://dom.spec.whatwg.org/#concept-document-no-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-no-quirks">1.2. Goals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-quirks">
-   <a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-quirks" class="dfn-panel" data-for="term-for-concept-document-quirks" id="infopanel-for-term-for-concept-document-quirks" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-quirks" style="display:none">Info about the 'quirks mode' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-quirks">https://dom.spec.whatwg.org/#concept-document-quirks</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-quirks">1.2. Goals</a>
     <li><a href="#ref-for-concept-document-quirks①">3.1. The hashless hex color quirk</a>
@@ -1252,22 +1252,22 @@ quirk</a>
     <li><a href="#ref-for-concept-document-quirks①④">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element">
-   <a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element" class="dfn-panel" data-for="term-for-the-body-element" id="infopanel-for-term-for-the-body-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element" style="display:none">Info about the 'body' external reference.</span><a href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">https://html.spec.whatwg.org/multipage/sections.html#the-body-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element">2.2. Terminology</a>
     <li><a href="#ref-for-the-body-element①">3.7. The body element fills the html element
 quirk</a> <a href="#ref-for-the-body-element②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-frameset">
-   <a href="https://html.spec.whatwg.org/multipage/obsolete.html#frameset">https://html.spec.whatwg.org/multipage/obsolete.html#frameset</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-frameset" class="dfn-panel" data-for="term-for-frameset" id="infopanel-for-term-for-frameset" role="menu">
+   <span id="infopaneltitle-for-term-for-frameset" style="display:none">Info about the 'frameset' external reference.</span><a href="https://html.spec.whatwg.org/multipage/obsolete.html#frameset">https://html.spec.whatwg.org/multipage/obsolete.html#frameset</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-frameset">2.2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-html-element">
-   <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-html-element" class="dfn-panel" data-for="term-for-the-html-element" id="infopanel-for-term-for-the-html-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-html-element" style="display:none">Info about the 'html' external reference.</span><a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">https://html.spec.whatwg.org/multipage/semantics.html#the-html-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-html-element">2.2. Terminology</a>
     <li><a href="#ref-for-the-html-element①">3.6. The html element fills the viewport
@@ -1276,14 +1276,14 @@ quirk</a> <a href="#ref-for-the-html-element②">(2)</a>
 quirk</a> <a href="#ref-for-the-html-element④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">3.8. The table cell width calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-table-element">
-   <a href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">https://html.spec.whatwg.org/multipage/tables.html#the-table-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-table-element" class="dfn-panel" data-for="term-for-the-table-element" id="infopanel-for-term-for-the-table-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-table-element" style="display:none">Info about the 'table' external reference.</span><a href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">https://html.spec.whatwg.org/multipage/tables.html#the-table-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-table-element">3.11. The text decoration doesn’t propagate
 into tables quirk</a>
@@ -1291,88 +1291,88 @@ into tables quirk</a>
 quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-td-element">
-   <a href="https://html.spec.whatwg.org/multipage/tables.html#the-td-element">https://html.spec.whatwg.org/multipage/tables.html#the-td-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-td-element" class="dfn-panel" data-for="term-for-the-td-element" id="infopanel-for-term-for-the-td-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-td-element" style="display:none">Info about the 'td' external reference.</span><a href="https://html.spec.whatwg.org/multipage/tables.html#the-td-element">https://html.spec.whatwg.org/multipage/tables.html#the-td-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-td-element">3.9. The table cell nowrap minimum width
 calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-th-element">
-   <a href="https://html.spec.whatwg.org/multipage/tables.html#the-th-element">https://html.spec.whatwg.org/multipage/tables.html#the-th-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-th-element" class="dfn-panel" data-for="term-for-the-th-element" id="infopanel-for-term-for-the-th-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-th-element" style="display:none">Info about the 'th' external reference.</span><a href="https://html.spec.whatwg.org/multipage/tables.html#the-th-element">https://html.spec.whatwg.org/multipage/tables.html#the-th-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-th-element">3.9. The table cell nowrap minimum width
 calculation quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-body-element-2">
-   <a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-body-element-2" class="dfn-panel" data-for="term-for-the-body-element-2" id="infopanel-for-term-for-the-body-element-2" role="menu">
+   <span id="infopaneltitle-for-term-for-the-body-element-2" style="display:none">Info about the 'the body element' external reference.</span><a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-body-element-2">2.2. Terminology</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#active-pseudo">https://drafts.csswg.org/selectors-4/#active-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-active-pseudo" class="dfn-panel" data-for="term-for-active-pseudo" id="infopanel-for-term-for-active-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-active-pseudo" style="display:none">Info about the ':active' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#active-pseudo">https://drafts.csswg.org/selectors-4/#active-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active-pseudo">4.1. The :active and :hover quirk</a> <a href="#ref-for-active-pseudo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-any-link-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#any-link-pseudo">https://drafts.csswg.org/selectors-4/#any-link-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-any-link-pseudo" class="dfn-panel" data-for="term-for-any-link-pseudo" id="infopanel-for-term-for-any-link-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-any-link-pseudo" style="display:none">Info about the ':any-link' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#any-link-pseudo">https://drafts.csswg.org/selectors-4/#any-link-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-any-link-pseudo">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hover-pseudo">
-   <a href="https://drafts.csswg.org/selectors-4/#hover-pseudo">https://drafts.csswg.org/selectors-4/#hover-pseudo</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hover-pseudo" class="dfn-panel" data-for="term-for-hover-pseudo" id="infopanel-for-term-for-hover-pseudo" role="menu">
+   <span id="infopaneltitle-for-term-for-hover-pseudo" style="display:none">Info about the ':hover' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#hover-pseudo">https://drafts.csswg.org/selectors-4/#hover-pseudo</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hover-pseudo">4.1. The :active and :hover quirk</a> <a href="#ref-for-hover-pseudo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-attribute-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-attribute-selector" class="dfn-panel" data-for="term-for-attribute-selector" id="infopanel-for-term-for-attribute-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-attribute-selector" style="display:none">Info about the 'attribute selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#attribute-selector">https://drafts.csswg.org/selectors-4/#attribute-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attribute-selector">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-class-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#class-selector">https://drafts.csswg.org/selectors-4/#class-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-class-selector" class="dfn-panel" data-for="term-for-class-selector" id="infopanel-for-term-for-class-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-class-selector" style="display:none">Info about the 'class selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#class-selector">https://drafts.csswg.org/selectors-4/#class-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-class-selector">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compound">
-   <a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compound" class="dfn-panel" data-for="term-for-compound" id="infopanel-for-term-for-compound" role="menu">
+   <span id="infopaneltitle-for-term-for-compound" style="display:none">Info about the 'compound selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#compound">https://drafts.csswg.org/selectors-4/#compound</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compound">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-functional-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#functional-pseudo-class">https://drafts.csswg.org/selectors-4/#functional-pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-functional-pseudo-class" class="dfn-panel" data-for="term-for-functional-pseudo-class" id="infopanel-for-term-for-functional-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-functional-pseudo-class" style="display:none">Info about the 'functional pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#functional-pseudo-class">https://drafts.csswg.org/selectors-4/#functional-pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-functional-pseudo-class">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-id-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#id-selector">https://drafts.csswg.org/selectors-4/#id-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-id-selector" class="dfn-panel" data-for="term-for-id-selector" id="infopanel-for-term-for-id-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-id-selector" style="display:none">Info about the 'id selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#id-selector">https://drafts.csswg.org/selectors-4/#id-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-id-selector">4.1. The :active and :hover quirk</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-class">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-class" class="dfn-panel" data-for="term-for-pseudo-class" id="infopanel-for-term-for-pseudo-class" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-class" style="display:none">Info about the 'pseudo-class' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-class">https://drafts.csswg.org/selectors-4/#pseudo-class</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-class">4.1. The :active and :hover quirk</a> <a href="#ref-for-pseudo-class①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pseudo-element">
-   <a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pseudo-element" class="dfn-panel" data-for="term-for-pseudo-element" id="infopanel-for-term-for-pseudo-element" role="menu">
+   <span id="infopaneltitle-for-term-for-pseudo-element" style="display:none">Info about the 'pseudo-element' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#pseudo-element">https://drafts.csswg.org/selectors-4/#pseudo-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pseudo-element">4.1. The :active and :hover quirk</a> <a href="#ref-for-pseudo-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-type-selector">
-   <a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-type-selector" class="dfn-panel" data-for="term-for-type-selector" id="infopanel-for-term-for-type-selector" role="menu">
+   <span id="infopaneltitle-for-term-for-type-selector" style="display:none">Info about the 'type selector' external reference.</span><a href="https://drafts.csswg.org/selectors-4/#type-selector">https://drafts.csswg.org/selectors-4/#type-selector</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-selector">4.1. The :active and :hover quirk</a>
    </ul>
@@ -1666,8 +1666,8 @@ calculation quirk</a>
    <dt id="biblio-cssom-view">[CSSOM-VIEW]
    <dd>Simon Pieters. <a href="https://drafts.csswg.org/cssom-view/"><cite>CSSOM View Module</cite></a>. URL: <a href="https://drafts.csswg.org/cssom-view/">https://drafts.csswg.org/cssom-view/</a>
   </dl>
-  <aside class="dfn-panel" data-for="documents-body-element">
-   <b><a href="#documents-body-element">#documents-body-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-documents-body-element" class="dfn-panel" data-for="documents-body-element" id="infopanel-for-documents-body-element" role="dialog">
+   <span id="infopaneltitle-for-documents-body-element" style="display:none">Info about the 'document’s body element' definition.</span><b><a href="#documents-body-element">#documents-body-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-documents-body-element">2.2. Terminology</a>
     <li><a href="#ref-for-documents-body-element①">3.7. The body element fills the html element
@@ -1676,86 +1676,142 @@ quirk</a>
 quirk</a> <a href="#ref-for-documents-body-element③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quirky-color">
-   <b><a href="#quirky-color">#quirky-color</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quirky-color" class="dfn-panel" data-for="quirky-color" id="infopanel-for-quirky-color" role="dialog">
+   <span id="infopaneltitle-for-quirky-color" style="display:none">Info about the 'Quirky colors' definition.</span><b><a href="#quirky-color">#quirky-color</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quirky-color">1.2. Goals</a>
     <li><a href="#ref-for-quirky-color①">3.1. The hashless hex color quirk</a> <a href="#ref-for-quirky-color②">(2)</a> <a href="#ref-for-quirky-color③">(3)</a> <a href="#ref-for-quirky-color④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quirky-color-value">
-   <b><a href="#quirky-color-value">#quirky-color-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quirky-color-value" class="dfn-panel" data-for="quirky-color-value" id="infopanel-for-quirky-color-value" role="dialog">
+   <span id="infopaneltitle-for-quirky-color-value" style="display:none">Info about the '&lt;quirky-color>' definition.</span><b><a href="#quirky-color-value">#quirky-color-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quirky-color-value">3.1. The hashless hex color quirk</a> <a href="#ref-for-quirky-color-value①">(2)</a> <a href="#ref-for-quirky-color-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quirky-length">
-   <b><a href="#quirky-length">#quirky-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quirky-length" class="dfn-panel" data-for="quirky-length" id="infopanel-for-quirky-length" role="dialog">
+   <span id="infopaneltitle-for-quirky-length" style="display:none">Info about the 'Quirky lengths' definition.</span><b><a href="#quirky-length">#quirky-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quirky-length">3.2. The unitless length quirk</a> <a href="#ref-for-quirky-length①">(2)</a> <a href="#ref-for-quirky-length②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="quirky-length-value">
-   <b><a href="#quirky-length-value">#quirky-length-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-quirky-length-value" class="dfn-panel" data-for="quirky-length-value" id="infopanel-for-quirky-length-value" role="dialog">
+   <span id="infopaneltitle-for-quirky-length-value" style="display:none">Info about the '&lt;quirky-length>' definition.</span><b><a href="#quirky-length-value">#quirky-length-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-quirky-length-value">3.2. The unitless length quirk</a> <a href="#ref-for-quirky-length-value①">(2)</a> <a href="#ref-for-quirky-length-value②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/whatwg/storage/storage.html
+++ b/tests/github/whatwg/storage/storage.html
@@ -737,38 +737,38 @@ if ("serviceWorker" in navigator) {
    <li><a href="#storage-endpoint-types">types</a><span>, in § 4.1</span>
    <li><a href="#dom-storageestimate-usage">usage</a><span>, in § 8</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-agents">
-   <a href="https://tc39.github.io/ecma262/#sec-agents">https://tc39.github.io/ecma262/#sec-agents</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-agents" class="dfn-panel" data-for="term-for-sec-agents" id="infopanel-for-term-for-sec-agents" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-agents" style="display:none">Info about the 'agent' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-agents">https://tc39.github.io/ecma262/#sec-agents</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-agents">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-agent-clusters">
-   <a href="https://tc39.github.io/ecma262/#sec-agent-clusters">https://tc39.github.io/ecma262/#sec-agent-clusters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-agent-clusters" class="dfn-panel" data-for="term-for-sec-agent-clusters" id="infopanel-for-term-for-sec-agent-clusters" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-agent-clusters" style="display:none">Info about the 'agent cluster' external reference.</span><a href="https://tc39.github.io/ecma262/#sec-agent-clusters">https://tc39.github.io/ecma262/#sec-agent-clusters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-agent-clusters">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-navigator">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-navigator" class="dfn-panel" data-for="term-for-navigator" id="infopanel-for-term-for-navigator" role="menu">
+   <span id="infopaneltitle-for-term-for-navigator" style="display:none">Info about the 'Navigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#navigator">https://html.spec.whatwg.org/multipage/system-state.html#navigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigator">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-workernavigator">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-workernavigator" class="dfn-panel" data-for="term-for-workernavigator" id="infopanel-for-term-for-workernavigator" role="menu">
+   <span id="infopaneltitle-for-term-for-workernavigator" style="display:none">Info about the 'WorkerNavigator' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#workernavigator">https://html.spec.whatwg.org/multipage/workers.html#workernavigator</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workernavigator">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-settings-object" class="dfn-panel" data-for="term-for-current-settings-object" id="infopanel-for-term-for-current-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-settings-object" style="display:none">Info about the 'current settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-settings-object">5. Persistence permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-environment-settings-object" class="dfn-panel" data-for="term-for-environment-settings-object" id="infopanel-for-term-for-environment-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-environment-settings-object" style="display:none">Info about the 'environment settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">4. Model</a>
     <li><a href="#ref-for-environment-settings-object①">4.2. Storage keys</a>
@@ -778,20 +778,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-environment-settings-object⑧">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">8. API</a> <a href="#ref-for-in-parallel①">(2)</a> <a href="#ref-for-in-parallel②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">4.2. Storage keys</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">1. Introduction</a>
     <li><a href="#ref-for-concept-origin①">4.2. Storage keys</a>
@@ -800,88 +800,88 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-origin⑤">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.2. Storage keys</a>
     <li><a href="#ref-for-concept-settings-object-origin①">5. Persistence permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-task">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-task" class="dfn-panel" data-for="term-for-queue-a-task" id="infopanel-for-term-for-queue-a-task" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-task" style="display:none">Info about the 'queue a task' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-task">8. API</a> <a href="#ref-for-queue-a-task①">(2)</a> <a href="#ref-for-queue-a-task②">(3)</a> <a href="#ref-for-queue-a-task③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">8. API</a> <a href="#ref-for-relevant-settings-object①">(2)</a> <a href="#ref-for-relevant-settings-object②">(3)</a> <a href="#ref-for-relevant-settings-object③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">4.1. Storage endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-clone">
-   <a href="https://infra.spec.whatwg.org/#map-clone">https://infra.spec.whatwg.org/#map-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-clone" class="dfn-panel" data-for="term-for-map-clone" id="infopanel-for-term-for-map-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-map-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#map-clone">https://infra.spec.whatwg.org/#map-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-clone">4.3. Storage sheds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">4.3. Storage sheds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implementation-defined">
-   <a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implementation-defined" class="dfn-panel" data-for="term-for-implementation-defined" id="infopanel-for-term-for-implementation-defined" role="menu">
+   <span id="infopaneltitle-for-term-for-implementation-defined" style="display:none">Info about the 'implementation-defined' external reference.</span><a href="https://infra.spec.whatwg.org/#implementation-defined">https://infra.spec.whatwg.org/#implementation-defined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implementation-defined">4.6. Storage bottles</a>
     <li><a href="#ref-for-implementation-defined①">6. Usage and quota</a> <a href="#ref-for-implementation-defined②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-is-empty">
-   <a href="https://infra.spec.whatwg.org/#map-is-empty">https://infra.spec.whatwg.org/#map-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-is-empty" class="dfn-panel" data-for="term-for-map-is-empty" id="infopanel-for-term-for-map-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-map-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#map-is-empty">https://infra.spec.whatwg.org/#map-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-is-empty">7. Management</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-key">
-   <a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-key" class="dfn-panel" data-for="term-for-map-key" id="infopanel-for-term-for-map-key" role="menu">
+   <span id="infopaneltitle-for-term-for-map-key" style="display:none">Info about the 'key' external reference.</span><a href="https://infra.spec.whatwg.org/#map-key">https://infra.spec.whatwg.org/#map-key</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-key">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-map">
-   <a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-map" class="dfn-panel" data-for="term-for-ordered-map" id="infopanel-for-term-for-ordered-map" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-map" style="display:none">Info about the 'map' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-map">https://infra.spec.whatwg.org/#ordered-map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-map">4. Model</a>
     <li><a href="#ref-for-ordered-map①">4.3. Storage sheds</a>
@@ -890,113 +890,113 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ordered-map④">4.7. Storage proxy maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-remove">
-   <a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-remove" class="dfn-panel" data-for="term-for-map-remove" id="infopanel-for-term-for-map-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-map-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#map-remove">https://infra.spec.whatwg.org/#map-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-remove">7. Management</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">4.1. Storage endpoints</a> <a href="#ref-for-ordered-set①">(2)</a>
     <li><a href="#ref-for-ordered-set②">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-user-agent">
-   <a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-user-agent" class="dfn-panel" data-for="term-for-user-agent" id="infopanel-for-term-for-user-agent" role="menu">
+   <span id="infopaneltitle-for-term-for-user-agent" style="display:none">Info about the 'user agent' external reference.</span><a href="https://infra.spec.whatwg.org/#user-agent">https://infra.spec.whatwg.org/#user-agent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent">3. Lay of the land</a>
     <li><a href="#ref-for-user-agent①">4.3. Storage sheds</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-value">
-   <a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-value" class="dfn-panel" data-for="term-for-map-value" id="infopanel-for-term-for-map-value" role="menu">
+   <span id="infopaneltitle-for-term-for-map-value" style="display:none">Info about the 'value' external reference.</span><a href="https://infra.spec.whatwg.org/#map-value">https://infra.spec.whatwg.org/#map-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-value">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-permissionstate-granted">
-   <a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-permissionstate-granted" class="dfn-panel" data-for="term-for-dom-permissionstate-granted" id="infopanel-for-term-for-dom-permissionstate-granted" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-permissionstate-granted" style="display:none">Info about the 'granted' external reference.</span><a href="https://w3c.github.io/permissions/#dom-permissionstate-granted">https://w3c.github.io/permissions/#dom-permissionstate-granted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-permissionstate-granted">5. Persistence permission</a>
     <li><a href="#ref-for-dom-permissionstate-granted①">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" class="dfn-panel" data-for="term-for-dfn-permission-revocation-algorithm" id="infopanel-for-term-for-dfn-permission-revocation-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-revocation-algorithm" style="display:none">Info about the 'permission revocation algorithm' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm">https://w3c.github.io/permissions/#dfn-permission-revocation-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-revocation-algorithm">5. Persistence permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-permission-state">
-   <a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-permission-state" class="dfn-panel" data-for="term-for-dfn-permission-state" id="infopanel-for-term-for-dfn-permission-state" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-permission-state" style="display:none">Info about the 'permission state' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-permission-state">https://w3c.github.io/permissions/#dfn-permission-state</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-permission-state">5. Persistence permission</a> <a href="#ref-for-dfn-permission-state①">(2)</a> <a href="#ref-for-dfn-permission-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-powerful-feature">
-   <a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-powerful-feature" class="dfn-panel" data-for="term-for-dfn-powerful-feature" id="infopanel-for-term-for-dfn-powerful-feature" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-powerful-feature" style="display:none">Info about the 'powerful feature' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-powerful-feature">https://w3c.github.io/permissions/#dfn-powerful-feature</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-powerful-feature">5. Persistence permission</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-request-permission-to-use">
-   <a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-request-permission-to-use" class="dfn-panel" data-for="term-for-dfn-request-permission-to-use" id="infopanel-for-term-for-dfn-request-permission-to-use" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-request-permission-to-use" style="display:none">Info about the 'requesting permission to use' external reference.</span><a href="https://w3c.github.io/permissions/#dfn-request-permission-to-use">https://w3c.github.io/permissions/#dfn-request-permission-to-use</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-request-permission-to-use">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">8. API</a> <a href="#ref-for-Exposed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">8. API</a> <a href="#ref-for-idl-promise①">(2)</a> <a href="#ref-for-idl-promise②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SecureContext" class="dfn-panel" data-for="term-for-SecureContext" id="infopanel-for-term-for-SecureContext" role="menu">
+   <span id="infopaneltitle-for-term-for-SecureContext" style="display:none">Info about the 'SecureContext' external reference.</span><a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">8. API</a> <a href="#ref-for-SecureContext①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">8. API</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a> <a href="#ref-for-exceptiondef-typeerror③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">8. API</a> <a href="#ref-for-idl-boolean①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">8. API</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">8. API</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a>
    </ul>
@@ -1102,8 +1102,8 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="storage-endpoint">
-   <b><a href="#storage-endpoint">#storage-endpoint</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-endpoint" class="dfn-panel" data-for="storage-endpoint" id="infopanel-for-storage-endpoint" role="dialog">
+   <span id="infopaneltitle-for-storage-endpoint" style="display:none">Info about the 'storage endpoint' definition.</span><b><a href="#storage-endpoint">#storage-endpoint</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint">4. Model</a> <a href="#ref-for-storage-endpoint①">(2)</a>
     <li><a href="#ref-for-storage-endpoint②">4.1. Storage endpoints</a> <a href="#ref-for-storage-endpoint③">(2)</a> <a href="#ref-for-storage-endpoint④">(3)</a> <a href="#ref-for-storage-endpoint⑤">(4)</a> <a href="#ref-for-storage-endpoint⑥">(5)</a>
@@ -1111,37 +1111,37 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-endpoint⑧">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-endpoint-identifier">
-   <b><a href="#storage-endpoint-identifier">#storage-endpoint-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-endpoint-identifier" class="dfn-panel" data-for="storage-endpoint-identifier" id="infopanel-for-storage-endpoint-identifier" role="dialog">
+   <span id="infopaneltitle-for-storage-endpoint-identifier" style="display:none">Info about the 'identifier' definition.</span><b><a href="#storage-endpoint-identifier">#storage-endpoint-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-identifier">4.1. Storage endpoints</a>
     <li><a href="#ref-for-storage-endpoint-identifier①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-endpoint-types">
-   <b><a href="#storage-endpoint-types">#storage-endpoint-types</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-endpoint-types" class="dfn-panel" data-for="storage-endpoint-types" id="infopanel-for-storage-endpoint-types" role="dialog">
+   <span id="infopaneltitle-for-storage-endpoint-types" style="display:none">Info about the 'types' definition.</span><b><a href="#storage-endpoint-types">#storage-endpoint-types</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-types">4.1. Storage endpoints</a>
     <li><a href="#ref-for-storage-endpoint-types①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-endpoint-quota">
-   <b><a href="#storage-endpoint-quota">#storage-endpoint-quota</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-endpoint-quota" class="dfn-panel" data-for="storage-endpoint-quota" id="infopanel-for-storage-endpoint-quota" role="dialog">
+   <span id="infopaneltitle-for-storage-endpoint-quota" style="display:none">Info about the 'quota' definition.</span><b><a href="#storage-endpoint-quota">#storage-endpoint-quota</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-endpoint-quota">4.1. Storage endpoints</a>
     <li><a href="#ref-for-storage-endpoint-quota①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-identifier">
-   <b><a href="#storage-identifier">#storage-identifier</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-identifier" class="dfn-panel" data-for="storage-identifier" id="infopanel-for-storage-identifier" role="dialog">
+   <span id="infopaneltitle-for-storage-identifier" style="display:none">Info about the 'storage identifier' definition.</span><b><a href="#storage-identifier">#storage-identifier</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-identifier">4.1. Storage endpoints</a> <a href="#ref-for-storage-identifier①">(2)</a>
     <li><a href="#ref-for-storage-identifier②">4.5. Storage buckets</a>
     <li><a href="#ref-for-storage-identifier③">4.6. Storage bottles</a> <a href="#ref-for-storage-identifier④">(2)</a> <a href="#ref-for-storage-identifier⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-type">
-   <b><a href="#storage-type">#storage-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-type" class="dfn-panel" data-for="storage-type" id="infopanel-for-storage-type" role="dialog">
+   <span id="infopaneltitle-for-storage-type" style="display:none">Info about the 'storage type' definition.</span><b><a href="#storage-type">#storage-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-type">4. Model</a>
     <li><a href="#ref-for-storage-type①">4.1. Storage endpoints</a> <a href="#ref-for-storage-type②">(2)</a>
@@ -1150,15 +1150,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-type⑥">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="registered-storage-endpoints">
-   <b><a href="#registered-storage-endpoints">#registered-storage-endpoints</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-registered-storage-endpoints" class="dfn-panel" data-for="registered-storage-endpoints" id="infopanel-for-registered-storage-endpoints" role="dialog">
+   <span id="infopaneltitle-for-registered-storage-endpoints" style="display:none">Info about the 'registered storage endpoints' definition.</span><b><a href="#registered-storage-endpoints">#registered-storage-endpoints</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-registered-storage-endpoints">4. Model</a>
     <li><a href="#ref-for-registered-storage-endpoints①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-key">
-   <b><a href="#storage-key">#storage-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-key" class="dfn-panel" data-for="storage-key" id="infopanel-for-storage-key" role="dialog">
+   <span id="infopaneltitle-for-storage-key" style="display:none">Info about the 'storage key' definition.</span><b><a href="#storage-key">#storage-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-key">4. Model</a> <a href="#ref-for-storage-key①">(2)</a>
     <li><a href="#ref-for-storage-key②">4.3. Storage sheds</a>
@@ -1166,14 +1166,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-key④">7. Management</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-storage-key">
-   <b><a href="#obtain-a-storage-key">#obtain-a-storage-key</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-storage-key" class="dfn-panel" data-for="obtain-a-storage-key" id="infopanel-for-obtain-a-storage-key" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-storage-key" style="display:none">Info about the 'obtain a storage key' definition.</span><b><a href="#obtain-a-storage-key">#obtain-a-storage-key</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-storage-key">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-shed">
-   <b><a href="#storage-shed">#storage-shed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-shed" class="dfn-panel" data-for="storage-shed" id="infopanel-for-storage-shed" role="dialog">
+   <span id="infopaneltitle-for-storage-shed" style="display:none">Info about the 'storage shed' definition.</span><b><a href="#storage-shed">#storage-shed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-shed">4. Model</a>
     <li><a href="#ref-for-storage-shed①">4.3. Storage sheds</a> <a href="#ref-for-storage-shed②">(2)</a>
@@ -1181,37 +1181,37 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-shed⑤">7. Management</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="user-agent-storage-shed">
-   <b><a href="#user-agent-storage-shed">#user-agent-storage-shed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-user-agent-storage-shed" class="dfn-panel" data-for="user-agent-storage-shed" id="infopanel-for-user-agent-storage-shed" role="dialog">
+   <span id="infopaneltitle-for-user-agent-storage-shed" style="display:none">Info about the 'storage shed' definition.</span><b><a href="#user-agent-storage-shed">#user-agent-storage-shed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-user-agent-storage-shed">4.3. Storage sheds</a>
     <li><a href="#ref-for-user-agent-storage-shed①">4.4. Storage shelves</a>
     <li><a href="#ref-for-user-agent-storage-shed②">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-storage">
-   <b><a href="#local-storage">#local-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-local-storage" class="dfn-panel" data-for="local-storage" id="infopanel-for-local-storage" role="dialog">
+   <span id="infopaneltitle-for-local-storage" style="display:none">Info about the 'local storage' definition.</span><b><a href="#local-storage">#local-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-storage">4.1. Storage endpoints</a>
     <li><a href="#ref-for-local-storage①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="browsing-session-storage-shed">
-   <b><a href="#browsing-session-storage-shed">#browsing-session-storage-shed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-browsing-session-storage-shed" class="dfn-panel" data-for="browsing-session-storage-shed" id="infopanel-for-browsing-session-storage-shed" role="dialog">
+   <span id="infopaneltitle-for-browsing-session-storage-shed" style="display:none">Info about the 'storage shed' definition.</span><b><a href="#browsing-session-storage-shed">#browsing-session-storage-shed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-browsing-session-storage-shed">4.3. Storage sheds</a> <a href="#ref-for-browsing-session-storage-shed①">(2)</a> <a href="#ref-for-browsing-session-storage-shed②">(3)</a>
     <li><a href="#ref-for-browsing-session-storage-shed③">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-storage">
-   <b><a href="#session-storage">#session-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-storage" class="dfn-panel" data-for="session-storage" id="infopanel-for-session-storage" role="dialog">
+   <span id="infopaneltitle-for-session-storage" style="display:none">Info about the 'session storage' definition.</span><b><a href="#session-storage">#session-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-storage">4.1. Storage endpoints</a>
     <li><a href="#ref-for-session-storage①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-shelf">
-   <b><a href="#storage-shelf">#storage-shelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-shelf" class="dfn-panel" data-for="storage-shelf" id="infopanel-for-storage-shelf" role="dialog">
+   <span id="infopaneltitle-for-storage-shelf" style="display:none">Info about the 'storage shelf' definition.</span><b><a href="#storage-shelf">#storage-shelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-shelf">4. Model</a> <a href="#ref-for-storage-shelf①">(2)</a>
     <li><a href="#ref-for-storage-shelf②">4.3. Storage sheds</a>
@@ -1221,8 +1221,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-shelf⑨">7. Management</a> <a href="#ref-for-storage-shelf①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bucket-map">
-   <b><a href="#bucket-map">#bucket-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bucket-map" class="dfn-panel" data-for="bucket-map" id="infopanel-for-bucket-map" role="dialog">
+   <span id="infopaneltitle-for-bucket-map" style="display:none">Info about the 'bucket map' definition.</span><b><a href="#bucket-map">#bucket-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bucket-map">4.3. Storage sheds</a> <a href="#ref-for-bucket-map①">(2)</a>
     <li><a href="#ref-for-bucket-map②">4.4. Storage shelves</a> <a href="#ref-for-bucket-map③">(2)</a>
@@ -1232,29 +1232,29 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-bucket-map⑦">8. API</a> <a href="#ref-for-bucket-map⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-storage-shelf">
-   <b><a href="#obtain-a-storage-shelf">#obtain-a-storage-shelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-storage-shelf" class="dfn-panel" data-for="obtain-a-storage-shelf" id="infopanel-for-obtain-a-storage-shelf" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-storage-shelf" style="display:none">Info about the 'obtain a storage shelf' definition.</span><b><a href="#obtain-a-storage-shelf">#obtain-a-storage-shelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-storage-shelf">4.4. Storage shelves</a> <a href="#ref-for-obtain-a-storage-shelf①">(2)</a>
     <li><a href="#ref-for-obtain-a-storage-shelf②">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-local-storage-shelf">
-   <b><a href="#obtain-a-local-storage-shelf">#obtain-a-local-storage-shelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-local-storage-shelf" class="dfn-panel" data-for="obtain-a-local-storage-shelf" id="infopanel-for-obtain-a-local-storage-shelf" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-local-storage-shelf" style="display:none">Info about the 'obtain a local storage shelf' definition.</span><b><a href="#obtain-a-local-storage-shelf">#obtain-a-local-storage-shelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-local-storage-shelf">5. Persistence permission</a>
     <li><a href="#ref-for-obtain-a-local-storage-shelf①">8. API</a> <a href="#ref-for-obtain-a-local-storage-shelf②">(2)</a> <a href="#ref-for-obtain-a-local-storage-shelf③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-storage-shelf">
-   <b><a href="#create-a-storage-shelf">#create-a-storage-shelf</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-storage-shelf" class="dfn-panel" data-for="create-a-storage-shelf" id="infopanel-for-create-a-storage-shelf" role="dialog">
+   <span id="infopaneltitle-for-create-a-storage-shelf" style="display:none">Info about the 'create a storage shelf' definition.</span><b><a href="#create-a-storage-shelf">#create-a-storage-shelf</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-storage-shelf">4.3. Storage sheds</a>
     <li><a href="#ref-for-create-a-storage-shelf①">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-bucket">
-   <b><a href="#storage-bucket">#storage-bucket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-bucket" class="dfn-panel" data-for="storage-bucket" id="infopanel-for-storage-bucket" role="dialog">
+   <span id="infopaneltitle-for-storage-bucket" style="display:none">Info about the 'storage bucket' definition.</span><b><a href="#storage-bucket">#storage-bucket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bucket">4. Model</a> <a href="#ref-for-storage-bucket①">(2)</a> <a href="#ref-for-storage-bucket②">(3)</a>
     <li><a href="#ref-for-storage-bucket③">4.4. Storage shelves</a>
@@ -1263,45 +1263,45 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-bucket⑧">7. Management</a> <a href="#ref-for-storage-bucket⑨">(2)</a> <a href="#ref-for-storage-bucket①⓪">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bottle-map">
-   <b><a href="#bottle-map">#bottle-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bottle-map" class="dfn-panel" data-for="bottle-map" id="infopanel-for-bottle-map" role="dialog">
+   <span id="infopaneltitle-for-bottle-map" style="display:none">Info about the 'bottle map' definition.</span><b><a href="#bottle-map">#bottle-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bottle-map">4.3. Storage sheds</a> <a href="#ref-for-bottle-map①">(2)</a>
     <li><a href="#ref-for-bottle-map②">4.5. Storage buckets</a>
     <li><a href="#ref-for-bottle-map③">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bucket">
-   <b><a href="#bucket">#bucket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bucket" class="dfn-panel" data-for="bucket" id="infopanel-for-bucket" role="dialog">
+   <span id="infopaneltitle-for-bucket" style="display:none">Info about the 'local storage bucket' definition.</span><b><a href="#bucket">#bucket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bucket">4.5. Storage buckets</a> <a href="#ref-for-bucket①">(2)</a>
     <li><a href="#ref-for-bucket②">5. Persistence permission</a>
     <li><a href="#ref-for-bucket③">7.1. Storage pressure</a> <a href="#ref-for-bucket④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bucket-mode">
-   <b><a href="#bucket-mode">#bucket-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bucket-mode" class="dfn-panel" data-for="bucket-mode" id="infopanel-for-bucket-mode" role="dialog">
+   <span id="infopaneltitle-for-bucket-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#bucket-mode">#bucket-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bucket-mode">5. Persistence permission</a> <a href="#ref-for-bucket-mode①">(2)</a>
     <li><a href="#ref-for-bucket-mode②">7.1. Storage pressure</a> <a href="#ref-for-bucket-mode③">(2)</a>
     <li><a href="#ref-for-bucket-mode④">8. API</a> <a href="#ref-for-bucket-mode⑤">(2)</a> <a href="#ref-for-bucket-mode⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="session-storage-bucket">
-   <b><a href="#session-storage-bucket">#session-storage-bucket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-session-storage-bucket" class="dfn-panel" data-for="session-storage-bucket" id="infopanel-for-session-storage-bucket" role="dialog">
+   <span id="infopaneltitle-for-session-storage-bucket" style="display:none">Info about the 'session storage bucket' definition.</span><b><a href="#session-storage-bucket">#session-storage-bucket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-session-storage-bucket">4.5. Storage buckets</a>
     <li><a href="#ref-for-session-storage-bucket①">7.1. Storage pressure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-a-storage-bucket">
-   <b><a href="#create-a-storage-bucket">#create-a-storage-bucket</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-a-storage-bucket" class="dfn-panel" data-for="create-a-storage-bucket" id="infopanel-for-create-a-storage-bucket" role="dialog">
+   <span id="infopaneltitle-for-create-a-storage-bucket" style="display:none">Info about the 'create a storage bucket' definition.</span><b><a href="#create-a-storage-bucket">#create-a-storage-bucket</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-a-storage-bucket">4.4. Storage shelves</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-bottle">
-   <b><a href="#storage-bottle">#storage-bottle</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-bottle" class="dfn-panel" data-for="storage-bottle" id="infopanel-for-storage-bottle" role="dialog">
+   <span id="infopaneltitle-for-storage-bottle" style="display:none">Info about the 'storage bottle' definition.</span><b><a href="#storage-bottle">#storage-bottle</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bottle">4. Model</a>
     <li><a href="#ref-for-storage-bottle①">4.1. Storage endpoints</a> <a href="#ref-for-storage-bottle②">(2)</a>
@@ -1309,124 +1309,124 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-storage-bottle⑤">4.6. Storage bottles</a> <a href="#ref-for-storage-bottle⑥">(2)</a> <a href="#ref-for-storage-bottle⑦">(3)</a> <a href="#ref-for-storage-bottle⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-bottle-map">
-   <b><a href="#storage-bottle-map">#storage-bottle-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-bottle-map" class="dfn-panel" data-for="storage-bottle-map" id="infopanel-for-storage-bottle-map" role="dialog">
+   <span id="infopaneltitle-for-storage-bottle-map" style="display:none">Info about the 'map' definition.</span><b><a href="#storage-bottle-map">#storage-bottle-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bottle-map">4.3. Storage sheds</a> <a href="#ref-for-storage-bottle-map①">(2)</a>
     <li><a href="#ref-for-storage-bottle-map②">4.6. Storage bottles</a> <a href="#ref-for-storage-bottle-map③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-bottle-proxy-map-reference-set">
-   <b><a href="#storage-bottle-proxy-map-reference-set">#storage-bottle-proxy-map-reference-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-bottle-proxy-map-reference-set" class="dfn-panel" data-for="storage-bottle-proxy-map-reference-set" id="infopanel-for-storage-bottle-proxy-map-reference-set" role="dialog">
+   <span id="infopaneltitle-for-storage-bottle-proxy-map-reference-set" style="display:none">Info about the 'proxy map reference set' definition.</span><b><a href="#storage-bottle-proxy-map-reference-set">#storage-bottle-proxy-map-reference-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bottle-proxy-map-reference-set">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-bottle-quota">
-   <b><a href="#storage-bottle-quota">#storage-bottle-quota</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-bottle-quota" class="dfn-panel" data-for="storage-bottle-quota" id="infopanel-for-storage-bottle-quota" role="dialog">
+   <span id="infopaneltitle-for-storage-bottle-quota" style="display:none">Info about the 'quota' definition.</span><b><a href="#storage-bottle-quota">#storage-bottle-quota</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-bottle-quota">4.1. Storage endpoints</a>
     <li><a href="#ref-for-storage-bottle-quota①">4.5. Storage buckets</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-storage-bottle-map">
-   <b><a href="#obtain-a-storage-bottle-map">#obtain-a-storage-bottle-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-storage-bottle-map" class="dfn-panel" data-for="obtain-a-storage-bottle-map" id="infopanel-for-obtain-a-storage-bottle-map" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-storage-bottle-map" style="display:none">Info about the 'obtain a storage bottle map' definition.</span><b><a href="#obtain-a-storage-bottle-map">#obtain-a-storage-bottle-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-storage-bottle-map">4.6. Storage bottles</a> <a href="#ref-for-obtain-a-storage-bottle-map①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-local-storage-bottle-map">
-   <b><a href="#obtain-a-local-storage-bottle-map">#obtain-a-local-storage-bottle-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-local-storage-bottle-map" class="dfn-panel" data-for="obtain-a-local-storage-bottle-map" id="infopanel-for-obtain-a-local-storage-bottle-map" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-local-storage-bottle-map" style="display:none">Info about the 'obtain a local storage bottle map' definition.</span><b><a href="#obtain-a-local-storage-bottle-map">#obtain-a-local-storage-bottle-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-local-storage-bottle-map">4. Model</a>
     <li><a href="#ref-for-obtain-a-local-storage-bottle-map①">4.1. Storage endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="obtain-a-session-storage-bottle-map">
-   <b><a href="#obtain-a-session-storage-bottle-map">#obtain-a-session-storage-bottle-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-obtain-a-session-storage-bottle-map" class="dfn-panel" data-for="obtain-a-session-storage-bottle-map" id="infopanel-for-obtain-a-session-storage-bottle-map" role="dialog">
+   <span id="infopaneltitle-for-obtain-a-session-storage-bottle-map" style="display:none">Info about the 'obtain a session storage bottle map' definition.</span><b><a href="#obtain-a-session-storage-bottle-map">#obtain-a-session-storage-bottle-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-obtain-a-session-storage-bottle-map">4. Model</a>
     <li><a href="#ref-for-obtain-a-session-storage-bottle-map①">4.1. Storage endpoints</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-proxy-map">
-   <b><a href="#storage-proxy-map">#storage-proxy-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-proxy-map" class="dfn-panel" data-for="storage-proxy-map" id="infopanel-for-storage-proxy-map" role="dialog">
+   <span id="infopaneltitle-for-storage-proxy-map" style="display:none">Info about the 'storage proxy map' definition.</span><b><a href="#storage-proxy-map">#storage-proxy-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-proxy-map">4. Model</a>
     <li><a href="#ref-for-storage-proxy-map①">4.6. Storage bottles</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-proxy-map-backing-map">
-   <b><a href="#storage-proxy-map-backing-map">#storage-proxy-map-backing-map</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-proxy-map-backing-map" class="dfn-panel" data-for="storage-proxy-map-backing-map" id="infopanel-for-storage-proxy-map-backing-map" role="dialog">
+   <span id="infopaneltitle-for-storage-proxy-map-backing-map" style="display:none">Info about the 'backing map' definition.</span><b><a href="#storage-proxy-map-backing-map">#storage-proxy-map-backing-map</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-proxy-map-backing-map">4.6. Storage bottles</a>
     <li><a href="#ref-for-storage-proxy-map-backing-map①">4.7. Storage proxy maps</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-usage">
-   <b><a href="#storage-usage">#storage-usage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-usage" class="dfn-panel" data-for="storage-usage" id="infopanel-for-storage-usage" role="dialog">
+   <span id="infopaneltitle-for-storage-usage" style="display:none">Info about the 'storage usage' definition.</span><b><a href="#storage-usage">#storage-usage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-usage">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storage-quota">
-   <b><a href="#storage-quota">#storage-quota</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storage-quota" class="dfn-panel" data-for="storage-quota" id="infopanel-for-storage-quota" role="dialog">
+   <span id="infopaneltitle-for-storage-quota" style="display:none">Info about the 'storage quota' definition.</span><b><a href="#storage-quota">#storage-quota</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storage-quota">4.6. Storage bottles</a>
     <li><a href="#ref-for-storage-quota①">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="navigatorstorage">
-   <b><a href="#navigatorstorage">#navigatorstorage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-navigatorstorage" class="dfn-panel" data-for="navigatorstorage" id="infopanel-for-navigatorstorage" role="dialog">
+   <span id="infopaneltitle-for-navigatorstorage" style="display:none">Info about the 'NavigatorStorage' definition.</span><b><a href="#navigatorstorage">#navigatorstorage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-navigatorstorage">8. API</a> <a href="#ref-for-navigatorstorage①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-navigatorstorage-storage">
-   <b><a href="#dom-navigatorstorage-storage">#dom-navigatorstorage-storage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-navigatorstorage-storage" class="dfn-panel" data-for="dom-navigatorstorage-storage" id="infopanel-for-dom-navigatorstorage-storage" role="dialog">
+   <span id="infopaneltitle-for-dom-navigatorstorage-storage" style="display:none">Info about the 'storage' definition.</span><b><a href="#dom-navigatorstorage-storage">#dom-navigatorstorage-storage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigatorstorage-storage">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="storagemanager">
-   <b><a href="#storagemanager">#storagemanager</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-storagemanager" class="dfn-panel" data-for="storagemanager" id="infopanel-for-storagemanager" role="dialog">
+   <span id="infopaneltitle-for-storagemanager" style="display:none">Info about the 'StorageManager' definition.</span><b><a href="#storagemanager">#storagemanager</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-storagemanager">8. API</a> <a href="#ref-for-storagemanager①">(2)</a> <a href="#ref-for-storagemanager②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-storageestimate">
-   <b><a href="#dictdef-storageestimate">#dictdef-storageestimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-storageestimate" class="dfn-panel" data-for="dictdef-storageestimate" id="infopanel-for-dictdef-storageestimate" role="dialog">
+   <span id="infopaneltitle-for-dictdef-storageestimate" style="display:none">Info about the 'StorageEstimate' definition.</span><b><a href="#dictdef-storageestimate">#dictdef-storageestimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-storageestimate">8. API</a> <a href="#ref-for-dictdef-storageestimate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storageestimate-usage">
-   <b><a href="#dom-storageestimate-usage">#dom-storageestimate-usage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storageestimate-usage" class="dfn-panel" data-for="dom-storageestimate-usage" id="infopanel-for-dom-storageestimate-usage" role="dialog">
+   <span id="infopaneltitle-for-dom-storageestimate-usage" style="display:none">Info about the 'usage' definition.</span><b><a href="#dom-storageestimate-usage">#dom-storageestimate-usage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storageestimate-usage">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storageestimate-quota">
-   <b><a href="#dom-storageestimate-quota">#dom-storageestimate-quota</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storageestimate-quota" class="dfn-panel" data-for="dom-storageestimate-quota" id="infopanel-for-dom-storageestimate-quota" role="dialog">
+   <span id="infopaneltitle-for-dom-storageestimate-quota" style="display:none">Info about the 'quota' definition.</span><b><a href="#dom-storageestimate-quota">#dom-storageestimate-quota</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storageestimate-quota">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storagemanager-persisted">
-   <b><a href="#dom-storagemanager-persisted">#dom-storagemanager-persisted</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storagemanager-persisted" class="dfn-panel" data-for="dom-storagemanager-persisted" id="infopanel-for-dom-storagemanager-persisted" role="dialog">
+   <span id="infopaneltitle-for-dom-storagemanager-persisted" style="display:none">Info about the 'persisted()' definition.</span><b><a href="#dom-storagemanager-persisted">#dom-storagemanager-persisted</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storagemanager-persisted">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storagemanager-persist">
-   <b><a href="#dom-storagemanager-persist">#dom-storagemanager-persist</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storagemanager-persist" class="dfn-panel" data-for="dom-storagemanager-persist" id="infopanel-for-dom-storagemanager-persist" role="dialog">
+   <span id="infopaneltitle-for-dom-storagemanager-persist" style="display:none">Info about the 'persist()' definition.</span><b><a href="#dom-storagemanager-persist">#dom-storagemanager-persist</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storagemanager-persist">1. Introduction</a>
     <li><a href="#ref-for-dom-storagemanager-persist①">8. API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-storagemanager-estimate">
-   <b><a href="#dom-storagemanager-estimate">#dom-storagemanager-estimate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-storagemanager-estimate" class="dfn-panel" data-for="dom-storagemanager-estimate" id="infopanel-for-dom-storagemanager-estimate" role="dialog">
+   <span id="infopaneltitle-for-dom-storagemanager-estimate" style="display:none">Info about the 'estimate()' definition.</span><b><a href="#dom-storagemanager-estimate">#dom-storagemanager-estimate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-storagemanager-estimate">1. Introduction</a>
     <li><a href="#ref-for-dom-storagemanager-estimate①">8. API</a>
@@ -1434,59 +1434,115 @@ if ("serviceWorker" in navigator) {
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/whatwg/streams/index.html
+++ b/tests/github/whatwg/streams/index.html
@@ -9919,26 +9919,26 @@ if ("serviceWorker" in navigator) {
    <li><a href="#writablestream-writerequests">[[writeRequests]]</a><span>, in § 5.2.2</span>
    <li><a href="#writablestreamdefaultwriter-write-a-chunk">writing a chunk</a><span>, in § 9.2.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-dom-backgroundfetchmanager-fetch">
-   <a href="https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch">https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-backgroundfetchmanager-fetch" class="dfn-panel" data-for="term-for-dom-backgroundfetchmanager-fetch" id="infopanel-for-term-for-dom-backgroundfetchmanager-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-backgroundfetchmanager-fetch" style="display:none">Info about the 'fetch(id, requests)' external reference.</span><a href="https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch">https://wicg.github.io/background-fetch/#dom-backgroundfetchmanager-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-backgroundfetchmanager-fetch">6.1. Using transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-compressionstream">
-   <a href="https://wicg.github.io/compression/#compressionstream">https://wicg.github.io/compression/#compressionstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-compressionstream" class="dfn-panel" data-for="term-for-compressionstream" id="infopanel-for-term-for-compressionstream" role="menu">
+   <span id="infopaneltitle-for-term-for-compressionstream" style="display:none">Info about the 'CompressionStream' external reference.</span><a href="https://wicg.github.io/compression/#compressionstream">https://wicg.github.io/compression/#compressionstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-compressionstream">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortcontroller">
-   <a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortcontroller" class="dfn-panel" data-for="term-for-abortcontroller" id="infopanel-for-term-for-abortcontroller" role="menu">
+   <span id="infopaneltitle-for-term-for-abortcontroller" style="display:none">Info about the 'AbortController' external reference.</span><a href="https://dom.spec.whatwg.org/#abortcontroller">https://dom.spec.whatwg.org/#abortcontroller</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortcontroller">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal">
-   <a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal" class="dfn-panel" data-for="term-for-abortsignal" id="infopanel-for-term-for-abortsignal" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal" style="display:none">Info about the 'AbortSignal' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal">https://dom.spec.whatwg.org/#abortsignal</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal">4.2.1. Interface definition</a>
     <li><a href="#ref-for-abortsignal①">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-abortsignal②">(2)</a>
@@ -9946,40 +9946,40 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-abortsignal④">9.5. Piping</a> <a href="#ref-for-abortsignal⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-add">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-add" class="dfn-panel" data-for="term-for-abortsignal-add" id="infopanel-for-term-for-abortsignal-add" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-add" style="display:none">Info about the 'add' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-add">https://dom.spec.whatwg.org/#abortsignal-add</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-add">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-abortsignal-remove">
-   <a href="https://dom.spec.whatwg.org/#abortsignal-remove">https://dom.spec.whatwg.org/#abortsignal-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-abortsignal-remove" class="dfn-panel" data-for="term-for-abortsignal-remove" id="infopanel-for-term-for-abortsignal-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-abortsignal-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://dom.spec.whatwg.org/#abortsignal-remove">https://dom.spec.whatwg.org/#abortsignal-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abortsignal-remove">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor">
-   <a href="https://tc39.es/ecma262/#sec-arraybuffer-constructor">https://tc39.es/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-constructor" class="dfn-panel" data-for="term-for-sec-arraybuffer-constructor" id="infopanel-for-term-for-sec-arraybuffer-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-constructor" style="display:none">Info about the '%ArrayBuffer%' external reference.</span><a href="https://tc39.es/ecma262/#sec-arraybuffer-constructor">https://tc39.es/ecma262/#sec-arraybuffer-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-constructor">4.7.4. Internal methods</a>
     <li><a href="#ref-for-sec-arraybuffer-constructor①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-dataview-constructor">
-   <a href="https://tc39.es/ecma262/#sec-dataview-constructor">https://tc39.es/ecma262/#sec-dataview-constructor</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-dataview-constructor" class="dfn-panel" data-for="term-for-sec-dataview-constructor" id="infopanel-for-term-for-sec-dataview-constructor" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-dataview-constructor" style="display:none">Info about the '%DataView%' external reference.</span><a href="https://tc39.es/ecma262/#sec-dataview-constructor">https://tc39.es/ecma262/#sec-dataview-constructor</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-dataview-constructor">4.7.2. Internal slots</a>
     <li><a href="#ref-for-sec-dataview-constructor①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object">
-   <a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" class="dfn-panel" data-for="term-for-sec-properties-of-the-object-prototype-object" id="infopanel-for-term-for-sec-properties-of-the-object-prototype-object" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-properties-of-the-object-prototype-object" style="display:none">Info about the '%Object.prototype%' external reference.</span><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-properties-of-the-object-prototype-object">8.2. Transferable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-objects">
-   <a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-objects" class="dfn-panel" data-for="term-for-sec-typedarray-objects" id="infopanel-for-term-for-sec-typedarray-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-objects" style="display:none">Info about the '%Uint8Array%' external reference.</span><a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-objects">2. Model</a>
     <li><a href="#ref-for-sec-typedarray-objects①">4.1. Using readable streams</a>
@@ -9990,8 +9990,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-sec-typedarray-objects⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-arraybuffer-objects">
-   <a href="https://tc39.es/ecma262/#sec-arraybuffer-objects">https://tc39.es/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-arraybuffer-objects" class="dfn-panel" data-for="term-for-sec-arraybuffer-objects" id="infopanel-for-term-for-sec-arraybuffer-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-arraybuffer-objects" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://tc39.es/ecma262/#sec-arraybuffer-objects">https://tc39.es/ecma262/#sec-arraybuffer-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-arraybuffer-objects">4.1. Using readable streams</a> <a href="#ref-for-sec-arraybuffer-objects①">(2)</a>
     <li><a href="#ref-for-sec-arraybuffer-objects②">4.2.3. The underlying source API</a>
@@ -9999,118 +9999,118 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-sec-arraybuffer-objects⑤">8.3. Miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-clonearraybuffer">
-   <a href="https://tc39.es/ecma262/#sec-clonearraybuffer">https://tc39.es/ecma262/#sec-clonearraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-clonearraybuffer" class="dfn-panel" data-for="term-for-sec-clonearraybuffer" id="infopanel-for-term-for-sec-clonearraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-clonearraybuffer" style="display:none">Info about the 'CloneArrayBuffer' external reference.</span><a href="https://tc39.es/ecma262/#sec-clonearraybuffer">https://tc39.es/ecma262/#sec-clonearraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-clonearraybuffer">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-construct">
-   <a href="https://tc39.es/ecma262/#sec-construct">https://tc39.es/ecma262/#sec-construct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-construct" class="dfn-panel" data-for="term-for-sec-construct" id="infopanel-for-term-for-sec-construct" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-construct" style="display:none">Info about the 'Construct' external reference.</span><a href="https://tc39.es/ecma262/#sec-construct">https://tc39.es/ecma262/#sec-construct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-construct">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-sec-construct①">4.7.4. Internal methods</a> <a href="#ref-for-sec-construct②">(2)</a>
     <li><a href="#ref-for-sec-construct③">4.9.5. Byte stream controllers</a> <a href="#ref-for-sec-construct④">(2)</a> <a href="#ref-for-sec-construct⑤">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-copydatablockbytes">
-   <a href="https://tc39.es/ecma262/#sec-copydatablockbytes">https://tc39.es/ecma262/#sec-copydatablockbytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-copydatablockbytes" class="dfn-panel" data-for="term-for-sec-copydatablockbytes" id="infopanel-for-term-for-sec-copydatablockbytes" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-copydatablockbytes" style="display:none">Info about the 'CopyDataBlockBytes' external reference.</span><a href="https://tc39.es/ecma262/#sec-copydatablockbytes">https://tc39.es/ecma262/#sec-copydatablockbytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-copydatablockbytes">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createarrayfromlist">
-   <a href="https://tc39.es/ecma262/#sec-createarrayfromlist">https://tc39.es/ecma262/#sec-createarrayfromlist</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createarrayfromlist" class="dfn-panel" data-for="term-for-sec-createarrayfromlist" id="infopanel-for-term-for-sec-createarrayfromlist" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createarrayfromlist" style="display:none">Info about the 'CreateArrayFromList' external reference.</span><a href="https://tc39.es/ecma262/#sec-createarrayfromlist">https://tc39.es/ecma262/#sec-createarrayfromlist</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createarrayfromlist">4.9.1. Working with readable streams</a> <a href="#ref-for-sec-createarrayfromlist①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createbuiltinfunction">
-   <a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">https://tc39.es/ecma262/#sec-createbuiltinfunction</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createbuiltinfunction" class="dfn-panel" data-for="term-for-sec-createbuiltinfunction" id="infopanel-for-term-for-sec-createbuiltinfunction" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createbuiltinfunction" style="display:none">Info about the 'CreateBuiltinFunction' external reference.</span><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">https://tc39.es/ecma262/#sec-createbuiltinfunction</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createbuiltinfunction">7.2.2. Internal slots</a>
     <li><a href="#ref-for-sec-createbuiltinfunction①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-createdataproperty">
-   <a href="https://tc39.es/ecma262/#sec-createdataproperty">https://tc39.es/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-createdataproperty" class="dfn-panel" data-for="term-for-sec-createdataproperty" id="infopanel-for-term-for-sec-createdataproperty" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-createdataproperty" style="display:none">Info about the 'CreateDataProperty' external reference.</span><a href="https://tc39.es/ecma262/#sec-createdataproperty">https://tc39.es/ecma262/#sec-createdataproperty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-createdataproperty">8.2. Transferable streams</a> <a href="#ref-for-sec-createdataproperty①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-dataview-objects">
-   <a href="https://tc39.es/ecma262/#sec-dataview-objects">https://tc39.es/ecma262/#sec-dataview-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-dataview-objects" class="dfn-panel" data-for="term-for-sec-dataview-objects" id="infopanel-for-term-for-sec-dataview-objects" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-dataview-objects" style="display:none">Info about the 'DataView' external reference.</span><a href="https://tc39.es/ecma262/#sec-dataview-objects">https://tc39.es/ecma262/#sec-dataview-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-dataview-objects">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-detacharraybuffer">
-   <a href="https://tc39.es/ecma262/#sec-detacharraybuffer">https://tc39.es/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-detacharraybuffer" class="dfn-panel" data-for="term-for-sec-detacharraybuffer" id="infopanel-for-term-for-sec-detacharraybuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-detacharraybuffer" style="display:none">Info about the 'DetachArrayBuffer' external reference.</span><a href="https://tc39.es/ecma262/#sec-detacharraybuffer">https://tc39.es/ecma262/#sec-detacharraybuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-detacharraybuffer">8.3. Miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-get-o-p">
-   <a href="https://tc39.es/ecma262/#sec-get-o-p">https://tc39.es/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-get-o-p" class="dfn-panel" data-for="term-for-sec-get-o-p" id="infopanel-for-term-for-sec-get-o-p" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-get-o-p" style="display:none">Info about the 'Get' external reference.</span><a href="https://tc39.es/ecma262/#sec-get-o-p">https://tc39.es/ecma262/#sec-get-o-p</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-get-o-p">8.2. Transferable streams</a> <a href="#ref-for-sec-get-o-p①">(2)</a> <a href="#ref-for-sec-get-o-p②">(3)</a> <a href="#ref-for-sec-get-o-p③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-getv">
-   <a href="https://tc39.es/ecma262/#sec-getv">https://tc39.es/ecma262/#sec-getv</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-getv" class="dfn-panel" data-for="term-for-sec-getv" id="infopanel-for-term-for-sec-getv" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-getv" style="display:none">Info about the 'GetV' external reference.</span><a href="https://tc39.es/ecma262/#sec-getv">https://tc39.es/ecma262/#sec-getv</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-getv">7.2.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isdetachedbuffer">
-   <a href="https://tc39.es/ecma262/#sec-isdetachedbuffer">https://tc39.es/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isdetachedbuffer" class="dfn-panel" data-for="term-for-sec-isdetachedbuffer" id="infopanel-for-term-for-sec-isdetachedbuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isdetachedbuffer" style="display:none">Info about the 'IsDetachedBuffer' external reference.</span><a href="https://tc39.es/ecma262/#sec-isdetachedbuffer">https://tc39.es/ecma262/#sec-isdetachedbuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isdetachedbuffer">4.8.3. Methods and properties</a>
     <li><a href="#ref-for-sec-isdetachedbuffer①">8.3. Miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-isinteger">
-   <a href="https://tc39.es/ecma262/#sec-isinteger">https://tc39.es/ecma262/#sec-isinteger</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-isinteger" class="dfn-panel" data-for="term-for-sec-isinteger" id="infopanel-for-term-for-sec-isinteger" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-isinteger" style="display:none">Info about the 'IsInteger' external reference.</span><a href="https://tc39.es/ecma262/#sec-isinteger">https://tc39.es/ecma262/#sec-isinteger</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-isinteger">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type">
-   <a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type" id="infopanel-for-term-for-sec-ecmascript-language-types-number-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" style="display:none">Info about the 'Number' external reference.</span><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type">3. Conventions</a>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type①">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate">
-   <a href="https://tc39.es/ecma262/#sec-ordinaryobjectcreate">https://tc39.es/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" class="dfn-panel" data-for="term-for-sec-ordinaryobjectcreate" id="infopanel-for-term-for-sec-ordinaryobjectcreate" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ordinaryobjectcreate" style="display:none">Info about the 'OrdinaryObjectCreate' external reference.</span><a href="https://tc39.es/ecma262/#sec-ordinaryobjectcreate">https://tc39.es/ecma262/#sec-ordinaryobjectcreate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ordinaryobjectcreate">8.2. Transferable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setfunctionlength">
-   <a href="https://tc39.es/ecma262/#sec-setfunctionlength">https://tc39.es/ecma262/#sec-setfunctionlength</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setfunctionlength" class="dfn-panel" data-for="term-for-sec-setfunctionlength" id="infopanel-for-term-for-sec-setfunctionlength" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setfunctionlength" style="display:none">Info about the 'SetFunctionLength' external reference.</span><a href="https://tc39.es/ecma262/#sec-setfunctionlength">https://tc39.es/ecma262/#sec-setfunctionlength</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setfunctionlength">7.2.2. Internal slots</a>
     <li><a href="#ref-for-sec-setfunctionlength①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-setfunctionname">
-   <a href="https://tc39.es/ecma262/#sec-setfunctionname">https://tc39.es/ecma262/#sec-setfunctionname</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-setfunctionname" class="dfn-panel" data-for="term-for-sec-setfunctionname" id="infopanel-for-term-for-sec-setfunctionname" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-setfunctionname" style="display:none">Info about the 'SetFunctionName' external reference.</span><a href="https://tc39.es/ecma262/#sec-setfunctionname">https://tc39.es/ecma262/#sec-setfunctionname</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-setfunctionname">7.2.2. Internal slots</a>
     <li><a href="#ref-for-sec-setfunctionname①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values">
-   <a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" class="dfn-panel" data-for="term-for-sec-ecmascript-data-types-and-values" id="infopanel-for-term-for-sec-ecmascript-data-types-and-values" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-data-types-and-values" style="display:none">Info about the 'Type' external reference.</span><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values">8.2. Transferable streams</a> <a href="#ref-for-sec-ecmascript-data-types-and-values①">(2)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values②">(3)</a> <a href="#ref-for-sec-ecmascript-data-types-and-values③">(4)</a>
     <li><a href="#ref-for-sec-ecmascript-data-types-and-values④">8.3. Miscellaneous</a> <a href="#ref-for-sec-ecmascript-data-types-and-values⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror">
-   <a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" class="dfn-panel" data-for="term-for-sec-native-error-types-used-in-this-standard-typeerror" id="infopanel-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-native-error-types-used-in-this-standard-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror①">(2)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror②">(3)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror③">(4)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror④">(5)</a> <a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑤">(6)</a>
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑥">4.2.5. Asynchronous iteration</a>
@@ -10132,8 +10132,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-sec-native-error-types-used-in-this-standard-typeerror⑤⑧">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-objects">
-   <a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-objects" class="dfn-panel" data-for="term-for-sec-typedarray-objects" id="infopanel-for-term-for-sec-typedarray-objects①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-objects①" style="display:none">Info about the 'Uint8Array' external reference.</span><a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-objects">2. Model</a>
     <li><a href="#ref-for-sec-typedarray-objects①">4.1. Using readable streams</a>
@@ -10144,47 +10144,47 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-sec-typedarray-objects⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-algorithm-conventions-abstract-operations">
-   <a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-algorithm-conventions-abstract-operations" class="dfn-panel" data-for="term-for-sec-algorithm-conventions-abstract-operations" id="infopanel-for-term-for-sec-algorithm-conventions-abstract-operations" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-algorithm-conventions-abstract-operations" style="display:none">Info about the 'abstract operation' external reference.</span><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations">https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-algorithm-conventions-abstract-operations">3. Conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-completion-record-specification-type">
-   <a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">https://tc39.es/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-completion-record-specification-type" class="dfn-panel" data-for="term-for-sec-completion-record-specification-type" id="infopanel-for-term-for-sec-completion-record-specification-type" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-completion-record-specification-type" style="display:none">Info about the 'completion record' external reference.</span><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">https://tc39.es/ecma262/#sec-completion-record-specification-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-completion-record-specification-type">3. Conventions</a>
     <li><a href="#ref-for-sec-completion-record-specification-type①">4.9.4. Default controllers</a>
     <li><a href="#ref-for-sec-completion-record-specification-type②">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots">
-   <a href="https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" class="dfn-panel" data-for="term-for-sec-object-internal-methods-and-internal-slots" id="infopanel-for-term-for-sec-object-internal-methods-and-internal-slots" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-object-internal-methods-and-internal-slots" style="display:none">Info about the 'internal slot' external reference.</span><a href="https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots">https://tc39.es/ecma262/#sec-object-internal-methods-and-internal-slots</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-object-internal-methods-and-internal-slots">3. Conventions</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-array.prototype.map">
-   <a href="https://tc39.es/ecma262/#sec-array.prototype.map">https://tc39.es/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-array.prototype.map" class="dfn-panel" data-for="term-for-sec-array.prototype.map" id="infopanel-for-term-for-sec-array.prototype.map" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-array.prototype.map" style="display:none">Info about the 'map' external reference.</span><a href="https://tc39.es/ecma262/#sec-array.prototype.map">https://tc39.es/ecma262/#sec-array.prototype.map</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-array.prototype.map">10.10. A transform stream created from a sync mapper function</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type">
-   <a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type" class="dfn-panel" data-for="term-for-sec-ecmascript-language-types-number-type" id="infopanel-for-term-for-sec-ecmascript-language-types-number-type①" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-ecmascript-language-types-number-type①" style="display:none">Info about the 'number type' external reference.</span><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type">https://tc39.es/ecma262/#sec-ecmascript-language-types-number-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type">3. Conventions</a>
     <li><a href="#ref-for-sec-ecmascript-language-types-number-type①">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-code-realms">
-   <a href="https://tc39.es/ecma262/#sec-code-realms">https://tc39.es/ecma262/#sec-code-realms</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-code-realms" class="dfn-panel" data-for="term-for-sec-code-realms" id="infopanel-for-term-for-sec-code-realms" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-code-realms" style="display:none">Info about the 'realm' external reference.</span><a href="https://tc39.es/ecma262/#sec-code-realms">https://tc39.es/ecma262/#sec-code-realms</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-code-realms">8.2. Transferable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-realm">
-   <a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-realm" class="dfn-panel" data-for="term-for-current-realm" id="infopanel-for-term-for-current-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-current-realm" style="display:none">Info about the 'the current realm' external reference.</span><a href="https://tc39.es/ecma262/#current-realm">https://tc39.es/ecma262/#current-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-realm">4.2.6. Transfer via postMessage()</a> <a href="#ref-for-current-realm①">(2)</a> <a href="#ref-for-current-realm②">(3)</a> <a href="#ref-for-current-realm③">(4)</a>
     <li><a href="#ref-for-current-realm④">4.9.1. Working with readable streams</a>
@@ -10193,15 +10193,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-current-realm①①">8.3. Miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-table-49">
-   <a href="https://tc39.es/ecma262/#table-49">https://tc39.es/ecma262/#table-49</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-table-49" class="dfn-panel" data-for="term-for-table-49" id="infopanel-for-term-for-table-49" role="menu">
+   <span id="infopaneltitle-for-term-for-table-49" style="display:none">Info about the 'the typed array constructors table' external reference.</span><a href="https://tc39.es/ecma262/#table-49">https://tc39.es/ecma262/#table-49</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-table-49">4.7.2. Internal slots</a>
     <li><a href="#ref-for-table-49①">4.9.5. Byte stream controllers</a> <a href="#ref-for-table-49②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-sec-typedarray-objects">
-   <a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-typedarray-objects" class="dfn-panel" data-for="term-for-sec-typedarray-objects" id="infopanel-for-term-for-sec-typedarray-objects②" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-typedarray-objects②" style="display:none">Info about the 'typed array' external reference.</span><a href="https://tc39.es/ecma262/#sec-typedarray-objects">https://tc39.es/ecma262/#sec-typedarray-objects</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-typedarray-objects">2. Model</a>
     <li><a href="#ref-for-sec-typedarray-objects①">4.1. Using readable streams</a>
@@ -10212,169 +10212,169 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-sec-typedarray-objects⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-textdecoderstream">
-   <a href="https://encoding.spec.whatwg.org/#textdecoderstream">https://encoding.spec.whatwg.org/#textdecoderstream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-textdecoderstream" class="dfn-panel" data-for="term-for-textdecoderstream" id="infopanel-for-term-for-textdecoderstream" role="menu">
+   <span id="infopaneltitle-for-term-for-textdecoderstream" style="display:none">Info about the 'TextDecoderStream' external reference.</span><a href="https://encoding.spec.whatwg.org/#textdecoderstream">https://encoding.spec.whatwg.org/#textdecoderstream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-textdecoderstream">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-response">
-   <a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-response" class="dfn-panel" data-for="term-for-response" id="infopanel-for-term-for-response" role="menu">
+   <span id="infopaneltitle-for-term-for-response" style="display:none">Info about the 'Response' external reference.</span><a href="https://fetch.spec.whatwg.org/#response">https://fetch.spec.whatwg.org/#response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">6.1. Using transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-messageport">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-messageport" class="dfn-panel" data-for="term-for-messageport" id="infopanel-for-term-for-messageport" role="menu">
+   <span id="infopaneltitle-for-term-for-messageport" style="display:none">Info about the 'MessagePort' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#messageport">https://html.spec.whatwg.org/multipage/web-messaging.html#messageport</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-messageport">4.2.6. Transfer via postMessage()</a> <a href="#ref-for-messageport①">(2)</a>
     <li><a href="#ref-for-messageport②">5.2.5. Transfer via postMessage()</a> <a href="#ref-for-messageport③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserialize" class="dfn-panel" data-for="term-for-structureddeserialize" id="infopanel-for-term-for-structureddeserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserialize" style="display:none">Info about the 'StructuredDeserialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserialize">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structureddeserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structureddeserializewithtransfer" class="dfn-panel" data-for="term-for-structureddeserializewithtransfer" id="infopanel-for-term-for-structureddeserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structureddeserializewithtransfer" style="display:none">Info about the 'StructuredDeserializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structureddeserializewithtransfer">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-structureddeserializewithtransfer①">5.2.5. Transfer via postMessage()</a>
     <li><a href="#ref-for-structureddeserializewithtransfer②">6.2.5. Transfer via postMessage()</a> <a href="#ref-for-structureddeserializewithtransfer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserialize">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserialize" class="dfn-panel" data-for="term-for-structuredserialize" id="infopanel-for-term-for-structuredserialize" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserialize" style="display:none">Info about the 'StructuredSerialize' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserialize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserialize">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-structuredserializewithtransfer">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-structuredserializewithtransfer" class="dfn-panel" data-for="term-for-structuredserializewithtransfer" id="infopanel-for-term-for-structuredserializewithtransfer" role="menu">
+   <span id="infopaneltitle-for-term-for-structuredserializewithtransfer" style="display:none">Info about the 'StructuredSerializeWithTransfer' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-structuredserializewithtransfer">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-structuredserializewithtransfer①">5.2.5. Transfer via postMessage()</a>
     <li><a href="#ref-for-structuredserializewithtransfer②">6.2.5. Transfer via postMessage()</a> <a href="#ref-for-structuredserializewithtransfer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transferable">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#transferable">https://html.spec.whatwg.org/multipage/structured-data.html#transferable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transferable" class="dfn-panel" data-for="term-for-transferable" id="infopanel-for-term-for-transferable" role="menu">
+   <span id="infopaneltitle-for-term-for-transferable" style="display:none">Info about the 'Transferable' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#transferable">https://html.spec.whatwg.org/multipage/structured-data.html#transferable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transferable">4.2.1. Interface definition</a>
     <li><a href="#ref-for-transferable①">5.2.1. Interface definition</a>
     <li><a href="#ref-for-transferable②">6.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-entangle">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#entangle">https://html.spec.whatwg.org/multipage/web-messaging.html#entangle</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-entangle" class="dfn-panel" data-for="term-for-entangle" id="infopanel-for-term-for-entangle" role="menu">
+   <span id="infopaneltitle-for-term-for-entangle" style="display:none">Info about the 'entangle' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#entangle">https://html.spec.whatwg.org/multipage/web-messaging.html#entangle</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-entangle">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-entangle①">5.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-global-object" class="dfn-panel" data-for="term-for-global-object" id="infopanel-for-term-for-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-global-object" style="display:none">Info about the 'global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">https://html.spec.whatwg.org/multipage/webappapis.html#global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-global-object">7.2.2. Internal slots</a>
     <li><a href="#ref-for-global-object①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-img-element">
-   <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-img-element" class="dfn-panel" data-for="term-for-the-img-element" id="infopanel-for-term-for-the-img-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-img-element" style="display:none">Info about the 'img' external reference.</span><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-img-element">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-message">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-message" class="dfn-panel" data-for="term-for-event-message" id="infopanel-for-term-for-event-message" role="menu">
+   <span id="infopaneltitle-for-term-for-event-message" style="display:none">Info about the 'message' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-message">https://html.spec.whatwg.org/multipage/indices.html#event-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-message">8.2. Transferable streams</a> <a href="#ref-for-event-message①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-message-port-post-message-steps">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps">https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-message-port-post-message-steps" class="dfn-panel" data-for="term-for-message-port-post-message-steps" id="infopanel-for-term-for-message-port-post-message-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-message-port-post-message-steps" style="display:none">Info about the 'message port post message steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps">https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-message-port-post-message-steps">8.2. Transferable streams</a> <a href="#ref-for-message-port-post-message-steps①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-messageerror">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror">https://html.spec.whatwg.org/multipage/indices.html#event-messageerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-messageerror" class="dfn-panel" data-for="term-for-event-messageerror" id="infopanel-for-term-for-event-messageerror" role="menu">
+   <span id="infopaneltitle-for-term-for-event-messageerror" style="display:none">Info about the 'messageerror' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-messageerror">https://html.spec.whatwg.org/multipage/indices.html#event-messageerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-messageerror">8.2. Transferable streams</a> <a href="#ref-for-event-messageerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-port-message-queue">
-   <a href="https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue">https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-port-message-queue" class="dfn-panel" data-for="term-for-port-message-queue" id="infopanel-for-term-for-port-message-queue" role="menu">
+   <span id="infopaneltitle-for-term-for-port-message-queue" style="display:none">Info about the 'port message queue' external reference.</span><a href="https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue">https://html.spec.whatwg.org/multipage/web-messaging.html#port-message-queue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-port-message-queue">8.2. Transferable streams</a> <a href="#ref-for-port-message-queue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-queue-a-microtask">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-queue-a-microtask" class="dfn-panel" data-for="term-for-queue-a-microtask" id="infopanel-for-term-for-queue-a-microtask" role="menu">
+   <span id="infopaneltitle-for-term-for-queue-a-microtask" style="display:none">Info about the 'queue a microtask' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask">https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queue-a-microtask">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-queue-a-microtask①">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">7.2.3. Constructor and properties</a>
     <li><a href="#ref-for-concept-relevant-global①">7.3.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-realm">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-realm" class="dfn-panel" data-for="term-for-concept-relevant-realm" id="infopanel-for-term-for-concept-relevant-realm" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-realm" style="display:none">Info about the 'relevant realm' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-realm">7.2.2. Internal slots</a>
     <li><a href="#ref-for-concept-relevant-realm①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">7.2.2. Internal slots</a>
     <li><a href="#ref-for-relevant-settings-object①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transfer-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#transfer-steps">https://html.spec.whatwg.org/multipage/structured-data.html#transfer-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transfer-steps" class="dfn-panel" data-for="term-for-transfer-steps" id="infopanel-for-term-for-transfer-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-transfer-steps" style="display:none">Info about the 'transfer steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#transfer-steps">https://html.spec.whatwg.org/multipage/structured-data.html#transfer-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transfer-steps">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-transfer-steps①">5.2.5. Transfer via postMessage()</a>
     <li><a href="#ref-for-transfer-steps②">6.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-transfer-receiving-steps">
-   <a href="https://html.spec.whatwg.org/multipage/structured-data.html#transfer-receiving-steps">https://html.spec.whatwg.org/multipage/structured-data.html#transfer-receiving-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-transfer-receiving-steps" class="dfn-panel" data-for="term-for-transfer-receiving-steps" id="infopanel-for-term-for-transfer-receiving-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-transfer-receiving-steps" style="display:none">Info about the 'transfer-receiving steps' external reference.</span><a href="https://html.spec.whatwg.org/multipage/structured-data.html#transfer-receiving-steps">https://html.spec.whatwg.org/multipage/structured-data.html#transfer-receiving-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transfer-receiving-steps">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-transfer-receiving-steps①">5.2.5. Transfer via postMessage()</a>
     <li><a href="#ref-for-transfer-receiving-steps②">6.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-unhandledrejection">
-   <a href="https://html.spec.whatwg.org/multipage/indices.html#event-unhandledrejection">https://html.spec.whatwg.org/multipage/indices.html#event-unhandledrejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-unhandledrejection" class="dfn-panel" data-for="term-for-event-unhandledrejection" id="infopanel-for-term-for-event-unhandledrejection" role="menu">
+   <span id="infopaneltitle-for-term-for-event-unhandledrejection" style="display:none">Info about the 'unhandledrejection' external reference.</span><a href="https://html.spec.whatwg.org/multipage/indices.html#event-unhandledrejection">https://html.spec.whatwg.org/multipage/indices.html#event-unhandledrejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-unhandledrejection">5.1. Using writable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4.7.4. Internal methods</a>
     <li><a href="#ref-for-list-append①">4.9.2. Interfacing with controllers</a> <a href="#ref-for-list-append②">(2)</a>
@@ -10383,20 +10383,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-append⑦">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-append">
-   <a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-append" class="dfn-panel" data-for="term-for-set-append" id="infopanel-for-term-for-set-append" role="menu">
+   <span id="infopaneltitle-for-term-for-set-append" style="display:none">Info about the 'append (for set)' external reference.</span><a href="https://infra.spec.whatwg.org/#set-append">https://infra.spec.whatwg.org/#set-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-append">4.9.1. Working with readable streams</a> <a href="#ref-for-set-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">9.1.2. Reading</a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-map-exists①">(2)</a> <a href="#ref-for-map-exists②">(3)</a> <a href="#ref-for-map-exists③">(4)</a> <a href="#ref-for-map-exists④">(5)</a>
     <li><a href="#ref-for-map-exists⑤">4.9.4. Default controllers</a> <a href="#ref-for-map-exists⑥">(2)</a> <a href="#ref-for-map-exists⑦">(3)</a>
@@ -10408,15 +10408,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-map-exists②②">7.4. Abstract operations</a> <a href="#ref-for-map-exists②③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">4.9.2. Interfacing with controllers</a> <a href="#ref-for-list-iterate①">(2)</a> <a href="#ref-for-list-iterate②">(3)</a>
     <li><a href="#ref-for-list-iterate③">5.5.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-list-is-empty①">4.4.3. Constructor, methods, and properties</a>
@@ -10430,8 +10430,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-is-empty①④">8.1. Queue-with-sizes</a> <a href="#ref-for-list-is-empty①⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct-item">
-   <a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct-item" class="dfn-panel" data-for="term-for-struct-item" id="infopanel-for-term-for-struct-item" role="menu">
+   <span id="infopaneltitle-for-term-for-struct-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#struct-item">https://infra.spec.whatwg.org/#struct-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct-item">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-struct-item①">4.4.2. Internal slots</a>
@@ -10445,8 +10445,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-struct-item①⓪">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">4.4.2. Internal slots</a>
     <li><a href="#ref-for-list①">4.5.2. Internal slots</a>
@@ -10462,14 +10462,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list①⑥">8.1. Queue-with-sizes</a> <a href="#ref-for-list①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ordered-set">
-   <a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ordered-set" class="dfn-panel" data-for="term-for-ordered-set" id="infopanel-for-term-for-ordered-set" role="menu">
+   <span id="infopaneltitle-for-term-for-ordered-set" style="display:none">Info about the 'ordered set' external reference.</span><a href="https://infra.spec.whatwg.org/#ordered-set">https://infra.spec.whatwg.org/#ordered-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ordered-set">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4.7.4. Internal methods</a>
     <li><a href="#ref-for-list-remove①">4.9.2. Interfacing with controllers</a> <a href="#ref-for-list-remove②">(2)</a>
@@ -10478,14 +10478,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-remove⑥">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">4.9.2. Interfacing with controllers</a> <a href="#ref-for-list-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-struct">
-   <a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-struct" class="dfn-panel" data-for="term-for-struct" id="infopanel-for-term-for-struct" role="menu">
+   <span id="infopaneltitle-for-term-for-struct" style="display:none">Info about the 'struct' external reference.</span><a href="https://infra.spec.whatwg.org/#struct">https://infra.spec.whatwg.org/#struct</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-struct">4.4.2. Internal slots</a>
     <li><a href="#ref-for-struct①">4.5.2. Internal slots</a>
@@ -10494,26 +10494,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-struct⑤">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-while">
-   <a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-while" class="dfn-panel" data-for="term-for-iteration-while" id="infopanel-for-term-for-iteration-while" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-while" style="display:none">Info about the 'while' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-while">https://infra.spec.whatwg.org/#iteration-while</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-while">4.9.5. Byte stream controllers</a> <a href="#ref-for-iteration-while①">(2)</a> <a href="#ref-for-iteration-while②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-service-worker-global-scope-fetch-event">
-   <a href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event">https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-service-worker-global-scope-fetch-event" class="dfn-panel" data-for="term-for-service-worker-global-scope-fetch-event" id="infopanel-for-term-for-service-worker-global-scope-fetch-event" role="menu">
+   <span id="infopaneltitle-for-term-for-service-worker-global-scope-fetch-event" style="display:none">Info about the 'fetch' external reference.</span><a href="https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event">https://w3c.github.io/ServiceWorker/#service-worker-global-scope-fetch-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-service-worker-global-scope-fetch-event">1. Introduction</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ArrayBufferView">
-   <a href="https://webidl.spec.whatwg.org/#ArrayBufferView">https://webidl.spec.whatwg.org/#ArrayBufferView</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ArrayBufferView" class="dfn-panel" data-for="term-for-ArrayBufferView" id="infopanel-for-term-for-ArrayBufferView" role="menu">
+   <span id="infopaneltitle-for-term-for-ArrayBufferView" style="display:none">Info about the 'ArrayBufferView' external reference.</span><a href="https://webidl.spec.whatwg.org/#ArrayBufferView">https://webidl.spec.whatwg.org/#ArrayBufferView</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ArrayBufferView">4.5.1. Interface definition</a> <a href="#ref-for-ArrayBufferView①">(2)</a>
     <li><a href="#ref-for-ArrayBufferView②">4.7.1. Interface definition</a>
@@ -10522,8 +10522,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ArrayBufferView⑥">4.8.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-idl-DOMException①">4.9.1. Working with readable streams</a>
@@ -10532,8 +10532,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-DOMException⑤">8.2. Transferable streams</a> <a href="#ref-for-idl-DOMException⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-datacloneerror">
-   <a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-datacloneerror" class="dfn-panel" data-for="term-for-datacloneerror" id="infopanel-for-term-for-datacloneerror" role="menu">
+   <span id="infopaneltitle-for-term-for-datacloneerror" style="display:none">Info about the 'DataCloneError' external reference.</span><a href="https://webidl.spec.whatwg.org/#datacloneerror">https://webidl.spec.whatwg.org/#datacloneerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-datacloneerror">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-datacloneerror①">5.2.5. Transfer via postMessage()</a>
@@ -10541,15 +10541,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-datacloneerror④">8.2. Transferable streams</a> <a href="#ref-for-datacloneerror⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-EnforceRange">
-   <a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-EnforceRange" class="dfn-panel" data-for="term-for-EnforceRange" id="infopanel-for-term-for-EnforceRange" role="menu">
+   <span id="infopaneltitle-for-term-for-EnforceRange" style="display:none">Info about the 'EnforceRange' external reference.</span><a href="https://webidl.spec.whatwg.org/#EnforceRange">https://webidl.spec.whatwg.org/#EnforceRange</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-EnforceRange">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-EnforceRange①">4.8.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">4.2.1. Interface definition</a>
     <li><a href="#ref-for-Exposed①">4.4.1. Interface definition</a>
@@ -10566,8 +10566,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-Exposed①②">7.3.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Function">
-   <a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Function" class="dfn-panel" data-for="term-for-Function" id="infopanel-for-term-for-Function" role="menu">
+   <span id="infopaneltitle-for-term-for-Function" style="display:none">Info about the 'Function' external reference.</span><a href="https://webidl.spec.whatwg.org/#Function">https://webidl.spec.whatwg.org/#Function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Function">7.2.1. Interface definition</a>
     <li><a href="#ref-for-Function①">7.2.2. Internal slots</a> <a href="#ref-for-Function②">(2)</a>
@@ -10575,8 +10575,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-Function④">7.3.2. Internal slots</a> <a href="#ref-for-Function⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">4.2.1. Interface definition</a> <a href="#ref-for-idl-promise①">(2)</a>
     <li><a href="#ref-for-idl-promise②">4.2.3. The underlying source API</a> <a href="#ref-for-idl-promise③">(2)</a>
@@ -10591,8 +10591,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-promise②①">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-rangeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-rangeerror" class="dfn-panel" data-for="term-for-exceptiondef-rangeerror" id="infopanel-for-term-for-exceptiondef-rangeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-rangeerror" style="display:none">Info about the 'RangeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-rangeerror">https://webidl.spec.whatwg.org/#exceptiondef-rangeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-rangeerror">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-exceptiondef-rangeerror①">4.9.5. Byte stream controllers</a> <a href="#ref-for-exceptiondef-rangeerror②">(2)</a> <a href="#ref-for-exceptiondef-rangeerror③">(3)</a>
@@ -10602,8 +10602,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-exceptiondef-rangeerror⑧">8.1. Queue-with-sizes</a> <a href="#ref-for-exceptiondef-rangeerror⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-new-promise">
-   <a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-new-promise" class="dfn-panel" data-for="term-for-a-new-promise" id="infopanel-for-term-for-a-new-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-a-new-promise" style="display:none">Info about the 'a new promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-new-promise">https://webidl.spec.whatwg.org/#a-new-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-new-promise">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-a-new-promise①">4.4.3. Constructor, methods, and properties</a>
@@ -10618,8 +10618,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-a-new-promise①⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-rejected-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-rejected-with" class="dfn-panel" data-for="term-for-a-promise-rejected-with" id="infopanel-for-term-for-a-promise-rejected-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-rejected-with" style="display:none">Info about the 'a promise rejected with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-rejected-with">https://webidl.spec.whatwg.org/#a-promise-rejected-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-rejected-with">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-a-promise-rejected-with①">(2)</a> <a href="#ref-for-a-promise-rejected-with②">(3)</a>
     <li><a href="#ref-for-a-promise-rejected-with③">4.2.5. Asynchronous iteration</a>
@@ -10637,8 +10637,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-a-promise-rejected-with③④">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-promise-resolved-with">
-   <a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-promise-resolved-with" class="dfn-panel" data-for="term-for-a-promise-resolved-with" id="infopanel-for-term-for-a-promise-resolved-with" role="menu">
+   <span id="infopaneltitle-for-term-for-a-promise-resolved-with" style="display:none">Info about the 'a promise resolved with' external reference.</span><a href="https://webidl.spec.whatwg.org/#a-promise-resolved-with">https://webidl.spec.whatwg.org/#a-promise-resolved-with</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-promise-resolved-with">4.2.5. Asynchronous iteration</a> <a href="#ref-for-a-promise-resolved-with①">(2)</a>
     <li><a href="#ref-for-a-promise-resolved-with②">4.9.1. Working with readable streams</a> <a href="#ref-for-a-promise-resolved-with③">(2)</a> <a href="#ref-for-a-promise-resolved-with④">(3)</a> <a href="#ref-for-a-promise-resolved-with⑤">(4)</a>
@@ -10658,8 +10658,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-a-promise-resolved-with③⑦">9.3.1. Creation and manipulation</a> <a href="#ref-for-a-promise-resolved-with③⑧">(2)</a> <a href="#ref-for-a-promise-resolved-with③⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">4.2.1. Interface definition</a> <a href="#ref-for-idl-any①">(2)</a>
     <li><a href="#ref-for-idl-any②">4.2.3. The underlying source API</a> <a href="#ref-for-idl-any③">(2)</a>
@@ -10676,20 +10676,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-any②⑥">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps">
-   <a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" class="dfn-panel" data-for="term-for-asynchronous-iterator-initialization-steps" id="infopanel-for-term-for-asynchronous-iterator-initialization-steps" role="menu">
+   <span id="infopaneltitle-for-term-for-asynchronous-iterator-initialization-steps" style="display:none">Info about the 'asynchronous iterator initialization steps' external reference.</span><a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps">https://webidl.spec.whatwg.org/#asynchronous-iterator-initialization-steps</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-initialization-steps">4.2.5. Asynchronous iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-asynchronous-iterator-return">
-   <a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-return">https://webidl.spec.whatwg.org/#asynchronous-iterator-return</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-asynchronous-iterator-return" class="dfn-panel" data-for="term-for-asynchronous-iterator-return" id="infopanel-for-term-for-asynchronous-iterator-return" role="menu">
+   <span id="infopaneltitle-for-term-for-asynchronous-iterator-return" style="display:none">Info about the 'asynchronous iterator return' external reference.</span><a href="https://webidl.spec.whatwg.org/#asynchronous-iterator-return">https://webidl.spec.whatwg.org/#asynchronous-iterator-return</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-asynchronous-iterator-return">4.2.5. Asynchronous iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">4.2.1. Interface definition</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a> <a href="#ref-for-idl-boolean③">(4)</a> <a href="#ref-for-idl-boolean④">(5)</a>
     <li><a href="#ref-for-idl-boolean⑤">4.4.1. Interface definition</a>
@@ -10697,15 +10697,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-boolean⑦">5.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-context">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-context">https://webidl.spec.whatwg.org/#dfn-callback-context</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-context" class="dfn-panel" data-for="term-for-dfn-callback-context" id="infopanel-for-term-for-dfn-callback-context" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-context" style="display:none">Info about the 'callback context' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-context">https://webidl.spec.whatwg.org/#dfn-callback-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-context">7.2.2. Internal slots</a>
     <li><a href="#ref-for-dfn-callback-context①">7.3.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-callback-this-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-callback-this-value">https://webidl.spec.whatwg.org/#dfn-callback-this-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-callback-this-value" class="dfn-panel" data-for="term-for-dfn-callback-this-value" id="infopanel-for-term-for-dfn-callback-this-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-callback-this-value" style="display:none">Info about the 'callback this value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-callback-this-value">https://webidl.spec.whatwg.org/#dfn-callback-this-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-callback-this-value">4.9.4. Default controllers</a> <a href="#ref-for-dfn-callback-this-value①">(2)</a> <a href="#ref-for-dfn-callback-this-value②">(3)</a>
     <li><a href="#ref-for-dfn-callback-this-value③">4.9.5. Byte stream controllers</a> <a href="#ref-for-dfn-callback-this-value④">(2)</a> <a href="#ref-for-dfn-callback-this-value⑤">(3)</a>
@@ -10714,40 +10714,40 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dfn-callback-this-value①①">6.4.2. Default controllers</a> <a href="#ref-for-dfn-callback-this-value①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value">
-   <a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" class="dfn-panel" data-for="term-for-dfn-convert-ecmascript-to-idl-value" id="infopanel-for-term-for-dfn-convert-ecmascript-to-idl-value" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-convert-ecmascript-to-idl-value" style="display:none">Info about the 'converted to an idl value' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value">https://webidl.spec.whatwg.org/#dfn-convert-ecmascript-to-idl-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value①">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-dfn-convert-ecmascript-to-idl-value②">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-detach">
-   <a href="https://webidl.spec.whatwg.org/#dfn-detach">https://webidl.spec.whatwg.org/#dfn-detach</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-detach" class="dfn-panel" data-for="term-for-dfn-detach" id="infopanel-for-term-for-dfn-detach" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-detach" style="display:none">Info about the 'detach' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-detach">https://webidl.spec.whatwg.org/#dfn-detach</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-detach">4.5.3. Constructor, methods, and properties</a> <a href="#ref-for-dfn-detach①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-end-of-iteration">
-   <a href="https://webidl.spec.whatwg.org/#end-of-iteration">https://webidl.spec.whatwg.org/#end-of-iteration</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-end-of-iteration" class="dfn-panel" data-for="term-for-end-of-iteration" id="infopanel-for-term-for-end-of-iteration" role="menu">
+   <span id="infopaneltitle-for-term-for-end-of-iteration" style="display:none">Info about the 'end of iteration' external reference.</span><a href="https://webidl.spec.whatwg.org/#end-of-iteration">https://webidl.spec.whatwg.org/#end-of-iteration</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-end-of-iteration">4.2.5. Asynchronous iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result">
-   <a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" class="dfn-panel" data-for="term-for-dfn-get-the-next-iteration-result" id="infopanel-for-term-for-dfn-get-the-next-iteration-result" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-get-the-next-iteration-result" style="display:none">Info about the 'get the next iteration result' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result">https://webidl.spec.whatwg.org/#dfn-get-the-next-iteration-result</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-get-the-next-iteration-result">4.2.5. Asynchronous iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-waiting-for-all-promise">
-   <a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-waiting-for-all-promise" class="dfn-panel" data-for="term-for-waiting-for-all-promise" id="infopanel-for-term-for-waiting-for-all-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-waiting-for-all-promise" style="display:none">Info about the 'getting a promise to wait for all' external reference.</span><a href="https://webidl.spec.whatwg.org/#waiting-for-all-promise">https://webidl.spec.whatwg.org/#waiting-for-all-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-waiting-for-all-promise">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-implements">
-   <a href="https://webidl.spec.whatwg.org/#implements">https://webidl.spec.whatwg.org/#implements</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-implements" class="dfn-panel" data-for="term-for-implements" id="infopanel-for-term-for-implements" role="menu">
+   <span id="infopaneltitle-for-term-for-implements" style="display:none">Info about the 'implements' external reference.</span><a href="https://webidl.spec.whatwg.org/#implements">https://webidl.spec.whatwg.org/#implements</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-implements">4.9.1. Working with readable streams</a> <a href="#ref-for-implements①">(2)</a> <a href="#ref-for-implements②">(3)</a> <a href="#ref-for-implements③">(4)</a> <a href="#ref-for-implements④">(5)</a>
     <li><a href="#ref-for-implements⑤">4.9.2. Interfacing with controllers</a> <a href="#ref-for-implements⑥">(2)</a> <a href="#ref-for-implements⑦">(3)</a> <a href="#ref-for-implements⑧">(4)</a> <a href="#ref-for-implements⑨">(5)</a> <a href="#ref-for-implements①⓪">(6)</a> <a href="#ref-for-implements①①">(7)</a>
@@ -10756,14 +10756,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-implements①④">6.4.2. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include">
-   <a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include" class="dfn-panel" data-for="term-for-include" id="infopanel-for-term-for-include" role="menu">
+   <span id="infopaneltitle-for-term-for-include" style="display:none">Info about the 'include' external reference.</span><a href="https://webidl.spec.whatwg.org/#include">https://webidl.spec.whatwg.org/#include</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invoke-a-callback-function">
-   <a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invoke-a-callback-function" class="dfn-panel" data-for="term-for-invoke-a-callback-function" id="infopanel-for-term-for-invoke-a-callback-function" role="menu">
+   <span id="infopaneltitle-for-term-for-invoke-a-callback-function" style="display:none">Info about the 'invoke' external reference.</span><a href="https://webidl.spec.whatwg.org/#invoke-a-callback-function">https://webidl.spec.whatwg.org/#invoke-a-callback-function</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invoke-a-callback-function">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-invoke-a-callback-function①">4.9.4. Default controllers</a> <a href="#ref-for-invoke-a-callback-function②">(2)</a> <a href="#ref-for-invoke-a-callback-function③">(3)</a>
@@ -10775,8 +10775,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-invoke-a-callback-function①⑥">7.4. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">4.2.6. Transfer via postMessage()</a> <a href="#ref-for-new①">(2)</a> <a href="#ref-for-new②">(3)</a>
     <li><a href="#ref-for-new③">4.7.3. Methods and properties</a>
@@ -10794,23 +10794,23 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-new③⓪">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-object">
-   <a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-object" class="dfn-panel" data-for="term-for-idl-object" id="infopanel-for-term-for-idl-object" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-object" style="display:none">Info about the 'object' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-object">https://webidl.spec.whatwg.org/#idl-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-object">4.2.1. Interface definition</a>
     <li><a href="#ref-for-idl-object①">5.2.1. Interface definition</a>
     <li><a href="#ref-for-idl-object②">6.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-platform-object">
-   <a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-platform-object" class="dfn-panel" data-for="term-for-dfn-platform-object" id="infopanel-for-term-for-dfn-platform-object" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-platform-object" style="display:none">Info about the 'platform object' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-platform-object">https://webidl.spec.whatwg.org/#dfn-platform-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-platform-object">3. Conventions</a>
     <li><a href="#ref-for-dfn-platform-object①">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled">
-   <a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" class="dfn-panel" data-for="term-for-dfn-perform-steps-once-promise-is-settled" id="infopanel-for-term-for-dfn-perform-steps-once-promise-is-settled" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-perform-steps-once-promise-is-settled" style="display:none">Info about the 'reacting' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled">https://webidl.spec.whatwg.org/#dfn-perform-steps-once-promise-is-settled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled">4.9.2. Interfacing with controllers</a>
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled①">6.4.2. Default controllers</a>
@@ -10818,8 +10818,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dfn-perform-steps-once-promise-is-settled④">8.2. Transferable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-reject">
-   <a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-reject" class="dfn-panel" data-for="term-for-reject" id="infopanel-for-term-for-reject" role="menu">
+   <span id="infopaneltitle-for-term-for-reject" style="display:none">Info about the 'reject' external reference.</span><a href="https://webidl.spec.whatwg.org/#reject">https://webidl.spec.whatwg.org/#reject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reject">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-reject①">4.4.3. Constructor, methods, and properties</a>
@@ -10832,8 +10832,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-reject①⑥">9.1.2. Reading</a> <a href="#ref-for-reject①⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-resolve">
-   <a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-resolve" class="dfn-panel" data-for="term-for-resolve" id="infopanel-for-term-for-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://webidl.spec.whatwg.org/#resolve">https://webidl.spec.whatwg.org/#resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-resolve">4.2.5. Asynchronous iteration</a> <a href="#ref-for-resolve①">(2)</a>
     <li><a href="#ref-for-resolve②">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-resolve③">(2)</a>
@@ -10848,14 +10848,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-resolve②④">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a> <a href="#ref-for-this⑧">(9)</a> <a href="#ref-for-this⑨">(10)</a> <a href="#ref-for-this①⓪">(11)</a> <a href="#ref-for-this①①">(12)</a> <a href="#ref-for-this①②">(13)</a>
     <li><a href="#ref-for-this①③">4.2.5. Asynchronous iteration</a>
@@ -10881,8 +10881,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-this①②⑧">9.3.2. Wrapping into a custom class</a> <a href="#ref-for-this①②⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">4.2.1. Interface definition</a> <a href="#ref-for-idl-undefined①">(2)</a>
     <li><a href="#ref-for-idl-undefined②">4.2.3. The underlying source API</a> <a href="#ref-for-idl-undefined③">(2)</a>
@@ -10900,8 +10900,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-undefined③⓪">6.3.1. Interface definition</a> <a href="#ref-for-idl-undefined③①">(2)</a> <a href="#ref-for-idl-undefined③②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unrestricted-double">
-   <a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unrestricted-double" class="dfn-panel" data-for="term-for-idl-unrestricted-double" id="infopanel-for-term-for-idl-unrestricted-double" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unrestricted-double" style="display:none">Info about the 'unrestricted double' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unrestricted-double">https://webidl.spec.whatwg.org/#idl-unrestricted-double</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unrestricted-double">3. Conventions</a>
     <li><a href="#ref-for-idl-unrestricted-double①">4.6.1. Interface definition</a>
@@ -10913,15 +10913,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-unrestricted-double①⓪">7.3.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">4.2.3. The underlying source API</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a>
     <li><a href="#ref-for-idl-unsigned-long-long②">4.8.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-fulfillment">
-   <a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-fulfillment" class="dfn-panel" data-for="term-for-upon-fulfillment" id="infopanel-for-term-for-upon-fulfillment" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-fulfillment" style="display:none">Info about the 'upon fulfillment' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-fulfillment">https://webidl.spec.whatwg.org/#upon-fulfillment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-fulfillment">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-upon-fulfillment①">4.9.4. Default controllers</a> <a href="#ref-for-upon-fulfillment②">(2)</a>
@@ -10930,8 +10930,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-upon-fulfillment⑥">5.5.4. Default controllers</a> <a href="#ref-for-upon-fulfillment⑦">(2)</a> <a href="#ref-for-upon-fulfillment⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-upon-rejection">
-   <a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-upon-rejection" class="dfn-panel" data-for="term-for-upon-rejection" id="infopanel-for-term-for-upon-rejection" role="menu">
+   <span id="infopaneltitle-for-term-for-upon-rejection" style="display:none">Info about the 'upon rejection' external reference.</span><a href="https://webidl.spec.whatwg.org/#upon-rejection">https://webidl.spec.whatwg.org/#upon-rejection</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upon-rejection">4.9.1. Working with readable streams</a> <a href="#ref-for-upon-rejection①">(2)</a>
     <li><a href="#ref-for-upon-rejection②">4.9.4. Default controllers</a> <a href="#ref-for-upon-rejection③">(2)</a>
@@ -10940,16 +10940,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-upon-rejection⑦">5.5.4. Default controllers</a> <a href="#ref-for-upon-rejection⑧">(2)</a> <a href="#ref-for-upon-rejection⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-websocket">
-   <a href="https://websockets.spec.whatwg.org/#websocket">https://websockets.spec.whatwg.org/#websocket</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-websocket" class="dfn-panel" data-for="term-for-websocket" id="infopanel-for-term-for-websocket" role="menu">
+   <span id="infopaneltitle-for-term-for-websocket" style="display:none">Info about the 'WebSocket' external reference.</span><a href="https://websockets.spec.whatwg.org/#websocket">https://websockets.spec.whatwg.org/#websocket</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-websocket">10.1. A readable stream with an underlying push source (no
 backpressure support)</a>
     <li><a href="#ref-for-websocket①">10.6. A writable stream with no backpressure or success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-websocket-bufferedamount">
-   <a href="https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount">https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-websocket-bufferedamount" class="dfn-panel" data-for="term-for-dom-websocket-bufferedamount" id="infopanel-for-term-for-dom-websocket-bufferedamount" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-websocket-bufferedamount" style="display:none">Info about the 'bufferedAmount' external reference.</span><a href="https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount">https://websockets.spec.whatwg.org/#dom-websocket-bufferedamount</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-websocket-bufferedamount">10.6. A writable stream with no backpressure or success signals</a>
    </ul>
@@ -11374,8 +11374,8 @@ backpressure support)</a>
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="chunk">
-   <b><a href="#chunk">#chunk</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-chunk" class="dfn-panel" data-for="chunk" id="infopanel-for-chunk" role="dialog">
+   <span id="infopaneltitle-for-chunk" style="display:none">Info about the 'chunk' definition.</span><b><a href="#chunk">#chunk</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-chunk">2.1. Readable streams</a> <a href="#ref-for-chunk①">(2)</a>
     <li><a href="#ref-for-chunk②">2.2. Writable streams</a>
@@ -11420,8 +11420,8 @@ support)</a>
     <li><a href="#ref-for-chunk⑧④">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream">
-   <b><a href="#readable-stream">#readable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream" class="dfn-panel" data-for="readable-stream" id="infopanel-for-readable-stream" role="dialog">
+   <span id="infopaneltitle-for-readable-stream" style="display:none">Info about the 'readable stream' definition.</span><b><a href="#readable-stream">#readable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream">1. Introduction</a>
     <li><a href="#ref-for-readable-stream①">2.1. Readable streams</a>
@@ -11444,8 +11444,8 @@ backpressure support</a>
 create new readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underlying-source">
-   <b><a href="#underlying-source">#underlying-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underlying-source" class="dfn-panel" data-for="underlying-source" id="infopanel-for-underlying-source" role="dialog">
+   <span id="infopaneltitle-for-underlying-source" style="display:none">Info about the 'underlying source' definition.</span><b><a href="#underlying-source">#underlying-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underlying-source">2.1. Readable streams</a> <a href="#ref-for-underlying-source①">(2)</a> <a href="#ref-for-underlying-source②">(3)</a>
     <li><a href="#ref-for-underlying-source③">2.4. Pipe chains and backpressure</a> <a href="#ref-for-underlying-source④">(2)</a>
@@ -11469,23 +11469,23 @@ create new readable streams</a>
 backpressure support</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="push-source">
-   <b><a href="#push-source">#push-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-push-source" class="dfn-panel" data-for="push-source" id="infopanel-for-push-source" role="dialog">
+   <span id="infopaneltitle-for-push-source" style="display:none">Info about the 'Push sources' definition.</span><b><a href="#push-source">#push-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-push-source">4.2.3. The underlying source API</a> <a href="#ref-for-push-source①">(2)</a>
     <li><a href="#ref-for-push-source②">10.1. A readable stream with an underlying push source (no
 backpressure support)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-source">
-   <b><a href="#pull-source">#pull-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-source" class="dfn-panel" data-for="pull-source" id="infopanel-for-pull-source" role="dialog">
+   <span id="infopaneltitle-for-pull-source" style="display:none">Info about the 'Pull sources' definition.</span><b><a href="#pull-source">#pull-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-source">4.2.3. The underlying source API</a> <a href="#ref-for-pull-source①">(2)</a>
     <li><a href="#ref-for-pull-source②">10.4. A readable stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="consumer">
-   <b><a href="#consumer">#consumer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-consumer" class="dfn-panel" data-for="consumer" id="infopanel-for-consumer" role="dialog">
+   <span id="infopaneltitle-for-consumer" style="display:none">Info about the 'consumer' definition.</span><b><a href="#consumer">#consumer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-consumer">2.6. Locking</a>
     <li><a href="#ref-for-consumer①">4.2.3. The underlying source API</a> <a href="#ref-for-consumer②">(2)</a>
@@ -11498,8 +11498,8 @@ backpressure support)</a>
 support)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cancel-a-readable-stream">
-   <b><a href="#cancel-a-readable-stream">#cancel-a-readable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cancel-a-readable-stream" class="dfn-panel" data-for="cancel-a-readable-stream" id="infopanel-for-cancel-a-readable-stream" role="dialog">
+   <span id="infopaneltitle-for-cancel-a-readable-stream" style="display:none">Info about the 'cancel' definition.</span><b><a href="#cancel-a-readable-stream">#cancel-a-readable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cancel-a-readable-stream">2.6. Locking</a>
     <li><a href="#ref-for-cancel-a-readable-stream①">4.2.3. The underlying source API</a>
@@ -11509,8 +11509,8 @@ support)</a>
     <li><a href="#ref-for-cancel-a-readable-stream①⓪">9.4.1. Duplex streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="tee-a-readable-stream">
-   <b><a href="#tee-a-readable-stream">#tee-a-readable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-tee-a-readable-stream" class="dfn-panel" data-for="tee-a-readable-stream" id="infopanel-for-tee-a-readable-stream" role="dialog">
+   <span id="infopaneltitle-for-tee-a-readable-stream" style="display:none">Info about the 'tee' definition.</span><b><a href="#tee-a-readable-stream">#tee-a-readable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tee-a-readable-stream">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-tee-a-readable-stream①">4.1. Using readable streams</a>
@@ -11518,14 +11518,14 @@ support)</a>
     <li><a href="#ref-for-tee-a-readable-stream③">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="branches-of-a-readable-stream-tee">
-   <b><a href="#branches-of-a-readable-stream-tee">#branches-of-a-readable-stream-tee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-branches-of-a-readable-stream-tee" class="dfn-panel" data-for="branches-of-a-readable-stream-tee" id="infopanel-for-branches-of-a-readable-stream-tee" role="dialog">
+   <span id="infopaneltitle-for-branches-of-a-readable-stream-tee" style="display:none">Info about the 'branches' definition.</span><b><a href="#branches-of-a-readable-stream-tee">#branches-of-a-readable-stream-tee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-branches-of-a-readable-stream-tee">2.4. Pipe chains and backpressure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underlying-byte-source">
-   <b><a href="#underlying-byte-source">#underlying-byte-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underlying-byte-source" class="dfn-panel" data-for="underlying-byte-source" id="infopanel-for-underlying-byte-source" role="dialog">
+   <span id="infopaneltitle-for-underlying-byte-source" style="display:none">Info about the 'underlying byte source' definition.</span><b><a href="#underlying-byte-source">#underlying-byte-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underlying-byte-source">4.7.2. Internal slots</a> <a href="#ref-for-underlying-byte-source①">(2)</a> <a href="#ref-for-underlying-byte-source②">(3)</a> <a href="#ref-for-underlying-byte-source③">(4)</a> <a href="#ref-for-underlying-byte-source④">(5)</a> <a href="#ref-for-underlying-byte-source⑤">(6)</a> <a href="#ref-for-underlying-byte-source⑥">(7)</a> <a href="#ref-for-underlying-byte-source⑦">(8)</a> <a href="#ref-for-underlying-byte-source⑧">(9)</a> <a href="#ref-for-underlying-byte-source⑨">(10)</a> <a href="#ref-for-underlying-byte-source①⓪">(11)</a>
     <li><a href="#ref-for-underlying-byte-source①①">4.7.3. Methods and properties</a>
@@ -11535,8 +11535,8 @@ support)</a>
     <li><a href="#ref-for-underlying-byte-source①⑤">10.5. A readable byte stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream">
-   <b><a href="#readable-byte-stream">#readable-byte-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream" class="dfn-panel" data-for="readable-byte-stream" id="infopanel-for-readable-byte-stream" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream" style="display:none">Info about the 'readable byte stream' definition.</span><b><a href="#readable-byte-stream">#readable-byte-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream">2.6. Locking</a>
     <li><a href="#ref-for-readable-byte-stream①">4.1. Using readable streams</a>
@@ -11556,8 +11556,8 @@ support)</a>
     <li><a href="#ref-for-readable-byte-stream①⑥">10.5. A readable byte stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream">
-   <b><a href="#writable-stream">#writable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream" class="dfn-panel" data-for="writable-stream" id="infopanel-for-writable-stream" role="dialog">
+   <span id="infopaneltitle-for-writable-stream" style="display:none">Info about the 'writable stream' definition.</span><b><a href="#writable-stream">#writable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream">1. Introduction</a>
     <li><a href="#ref-for-writable-stream①">2.3. Transform streams</a>
@@ -11576,8 +11576,8 @@ backpressure support)</a>
     <li><a href="#ref-for-writable-stream①⑥">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="underlying-sink">
-   <b><a href="#underlying-sink">#underlying-sink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-underlying-sink" class="dfn-panel" data-for="underlying-sink" id="infopanel-for-underlying-sink" role="dialog">
+   <span id="infopaneltitle-for-underlying-sink" style="display:none">Info about the 'underlying sink' definition.</span><b><a href="#underlying-sink">#underlying-sink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-underlying-sink">2.2. Writable streams</a> <a href="#ref-for-underlying-sink①">(2)</a>
     <li><a href="#ref-for-underlying-sink②">2.4. Pipe chains and backpressure</a>
@@ -11598,8 +11598,8 @@ backpressure support)</a>
     <li><a href="#ref-for-underlying-sink③③">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="producer">
-   <b><a href="#producer">#producer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-producer" class="dfn-panel" data-for="producer" id="infopanel-for-producer" role="dialog">
+   <span id="infopaneltitle-for-producer" style="display:none">Info about the 'producer' definition.</span><b><a href="#producer">#producer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-producer">2.6. Locking</a>
     <li><a href="#ref-for-producer①">5.1. Using writable streams</a>
@@ -11611,8 +11611,8 @@ backpressure support)</a>
     <li><a href="#ref-for-producer⑨">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abort-a-writable-stream">
-   <b><a href="#abort-a-writable-stream">#abort-a-writable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abort-a-writable-stream" class="dfn-panel" data-for="abort-a-writable-stream" id="infopanel-for-abort-a-writable-stream" role="dialog">
+   <span id="infopaneltitle-for-abort-a-writable-stream" style="display:none">Info about the 'abort' definition.</span><b><a href="#abort-a-writable-stream">#abort-a-writable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abort-a-writable-stream">2.6. Locking</a>
     <li><a href="#ref-for-abort-a-writable-stream①">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-abort-a-writable-stream②">(2)</a>
@@ -11624,8 +11624,8 @@ backpressure support)</a>
 create new readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream">
-   <b><a href="#transform-stream">#transform-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream" class="dfn-panel" data-for="transform-stream" id="infopanel-for-transform-stream" role="dialog">
+   <span id="infopaneltitle-for-transform-stream" style="display:none">Info about the 'transform stream' definition.</span><b><a href="#transform-stream">#transform-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream">1. Introduction</a>
     <li><a href="#ref-for-transform-stream①">4.2.4. Constructor, methods, and properties</a>
@@ -11639,8 +11639,8 @@ create new readable streams</a>
 backpressure support)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-side">
-   <b><a href="#writable-side">#writable-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-side" class="dfn-panel" data-for="writable-side" id="infopanel-for-writable-side" role="dialog">
+   <span id="infopaneltitle-for-writable-side" style="display:none">Info about the 'writable side' definition.</span><b><a href="#writable-side">#writable-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-side">2.3. Transform streams</a>
     <li><a href="#ref-for-writable-side①">6.1. Using transform streams</a>
@@ -11654,8 +11654,9 @@ backpressure support)</a>
 create new readable streams</a> <a href="#ref-for-writable-side①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-side">
-   <b><a href="#readable-side">#readable-side</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-side" class="dfn-panel" data-for="readable-side" id="infopanel-for-readable-side" role="dialog">
+   <span id="infopaneltitle-for-readable-side" style="display:none">Info about the 'readable
+side' definition.</span><b><a href="#readable-side">#readable-side</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-side">2.3. Transform streams</a>
     <li><a href="#ref-for-readable-side①">6.1. Using transform streams</a>
@@ -11670,8 +11671,8 @@ create new readable streams</a> <a href="#ref-for-writable-side①④">(2)</a>
 create new readable streams</a> <a href="#ref-for-readable-side①⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformer">
-   <b><a href="#transformer">#transformer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformer" class="dfn-panel" data-for="transformer" id="infopanel-for-transformer" role="dialog">
+   <span id="infopaneltitle-for-transformer" style="display:none">Info about the 'transformer' definition.</span><b><a href="#transformer">#transformer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformer">2.3. Transform streams</a>
     <li><a href="#ref-for-transformer①">6.2.3. The transformer API</a>
@@ -11683,8 +11684,8 @@ create new readable streams</a> <a href="#ref-for-readable-side①⑥">(2)</a>
     <li><a href="#ref-for-transformer⑧">10.9. A transform stream that replaces template tags</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="identity-transform-stream">
-   <b><a href="#identity-transform-stream">#identity-transform-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-identity-transform-stream" class="dfn-panel" data-for="identity-transform-stream" id="infopanel-for-identity-transform-stream" role="dialog">
+   <span id="infopaneltitle-for-identity-transform-stream" style="display:none">Info about the 'identity transform stream' definition.</span><b><a href="#identity-transform-stream">#identity-transform-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-identity-transform-stream">6.1. Using transform streams</a>
     <li><a href="#ref-for-identity-transform-stream①">6.2.4. Constructor and properties</a>
@@ -11692,8 +11693,8 @@ create new readable streams</a> <a href="#ref-for-readable-side①⑥">(2)</a>
 create new readable streams</a> <a href="#ref-for-identity-transform-stream③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="piping">
-   <b><a href="#piping">#piping</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-piping" class="dfn-panel" data-for="piping" id="infopanel-for-piping" role="dialog">
+   <span id="infopaneltitle-for-piping" style="display:none">Info about the 'piping' definition.</span><b><a href="#piping">#piping</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-piping">2.6. Locking</a> <a href="#ref-for-piping①">(2)</a>
     <li><a href="#ref-for-piping②">4.1. Using readable streams</a> <a href="#ref-for-piping③">(2)</a> <a href="#ref-for-piping④">(3)</a>
@@ -11706,28 +11707,28 @@ create new readable streams</a> <a href="#ref-for-identity-transform-stream③">
 backpressure support)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pipe-chain">
-   <b><a href="#pipe-chain">#pipe-chain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pipe-chain" class="dfn-panel" data-for="pipe-chain" id="infopanel-for-pipe-chain" role="dialog">
+   <span id="infopaneltitle-for-pipe-chain" style="display:none">Info about the 'pipe chain' definition.</span><b><a href="#pipe-chain">#pipe-chain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pipe-chain">1. Introduction</a>
     <li><a href="#ref-for-pipe-chain①">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-pipe-chain②">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="original-source">
-   <b><a href="#original-source">#original-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-original-source" class="dfn-panel" data-for="original-source" id="infopanel-for-original-source" role="dialog">
+   <span id="infopaneltitle-for-original-source" style="display:none">Info about the 'original source' definition.</span><b><a href="#original-source">#original-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-original-source">2.4. Pipe chains and backpressure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ultimate-sink">
-   <b><a href="#ultimate-sink">#ultimate-sink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ultimate-sink" class="dfn-panel" data-for="ultimate-sink" id="infopanel-for-ultimate-sink" role="dialog">
+   <span id="infopaneltitle-for-ultimate-sink" style="display:none">Info about the 'ultimate sink' definition.</span><b><a href="#ultimate-sink">#ultimate-sink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ultimate-sink">2.4. Pipe chains and backpressure</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="backpressure">
-   <b><a href="#backpressure">#backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-backpressure" class="dfn-panel" data-for="backpressure" id="infopanel-for-backpressure" role="dialog">
+   <span id="infopaneltitle-for-backpressure" style="display:none">Info about the 'backpressure' definition.</span><b><a href="#backpressure">#backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-backpressure">1. Introduction</a>
     <li><a href="#ref-for-backpressure①">2.4. Pipe chains and backpressure</a>
@@ -11751,8 +11752,8 @@ backpressure support</a>
     <li><a href="#ref-for-backpressure②③">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="internal-queues">
-   <b><a href="#internal-queues">#internal-queues</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-internal-queues" class="dfn-panel" data-for="internal-queues" id="infopanel-for-internal-queues" role="dialog">
+   <span id="infopaneltitle-for-internal-queues" style="display:none">Info about the 'internal queues' definition.</span><b><a href="#internal-queues">#internal-queues</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-internal-queues">2.2. Writable streams</a>
     <li><a href="#ref-for-internal-queues①">2.5. Internal queues and queuing strategies</a>
@@ -11768,8 +11769,8 @@ backpressure support</a>
 support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="queuing-strategy">
-   <b><a href="#queuing-strategy">#queuing-strategy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-queuing-strategy" class="dfn-panel" data-for="queuing-strategy" id="infopanel-for-queuing-strategy" role="dialog">
+   <span id="infopaneltitle-for-queuing-strategy" style="display:none">Info about the 'queuing strategy' definition.</span><b><a href="#queuing-strategy">#queuing-strategy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-queuing-strategy">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-queuing-strategy①">4.6.2. Internal slots</a> <a href="#ref-for-queuing-strategy②">(2)</a>
@@ -11782,8 +11783,8 @@ support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
     <li><a href="#ref-for-queuing-strategy①①">7.3. The CountQueuingStrategy class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="high-water-mark">
-   <b><a href="#high-water-mark">#high-water-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-high-water-mark" class="dfn-panel" data-for="high-water-mark" id="infopanel-for-high-water-mark" role="dialog">
+   <span id="infopaneltitle-for-high-water-mark" style="display:none">Info about the 'high water mark' definition.</span><b><a href="#high-water-mark">#high-water-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-high-water-mark">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-high-water-mark①">4.2.4. Constructor, methods, and properties</a>
@@ -11796,8 +11797,9 @@ support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
     <li><a href="#ref-for-high-water-mark①①">7.4. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="desired-size-to-fill-a-streams-internal-queue">
-   <b><a href="#desired-size-to-fill-a-streams-internal-queue">#desired-size-to-fill-a-streams-internal-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-desired-size-to-fill-a-streams-internal-queue" class="dfn-panel" data-for="desired-size-to-fill-a-streams-internal-queue" id="infopanel-for-desired-size-to-fill-a-streams-internal-queue" role="dialog">
+   <span id="infopaneltitle-for-desired-size-to-fill-a-streams-internal-queue" style="display:none">Info about the 'desired size to
+fill the stream’s queue' definition.</span><b><a href="#desired-size-to-fill-a-streams-internal-queue">#desired-size-to-fill-a-streams-internal-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-desired-size-to-fill-a-streams-internal-queue">4.2.3. The underlying source API</a> <a href="#ref-for-desired-size-to-fill-a-streams-internal-queue①">(2)</a>
     <li><a href="#ref-for-desired-size-to-fill-a-streams-internal-queue②">4.6.3. Methods and properties</a>
@@ -11808,8 +11810,8 @@ support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
     <li><a href="#ref-for-desired-size-to-fill-a-streams-internal-queue⑨">6.3.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reader">
-   <b><a href="#reader">#reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reader" class="dfn-panel" data-for="reader" id="infopanel-for-reader" role="dialog">
+   <span id="infopaneltitle-for-reader" style="display:none">Info about the 'readable stream reader' definition.</span><b><a href="#reader">#reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reader">1. Introduction</a>
     <li><a href="#ref-for-reader①">2.1. Readable streams</a>
@@ -11817,8 +11819,8 @@ support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
     <li><a href="#ref-for-reader③">4.7.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-readers">
-   <b><a href="#default-readers">#default-readers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-readers" class="dfn-panel" data-for="default-readers" id="infopanel-for-default-readers" role="dialog">
+   <span id="infopaneltitle-for-default-readers" style="display:none">Info about the 'default readers' definition.</span><b><a href="#default-readers">#default-readers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-readers">4.1. Using readable streams</a>
     <li><a href="#ref-for-default-readers①">4.2.3. The underlying source API</a>
@@ -11827,8 +11829,8 @@ support)</a> <a href="#ref-for-internal-queues①①">(2)</a>
     <li><a href="#ref-for-default-readers④">10.5. A readable byte stream with an underlying pull source</a> <a href="#ref-for-default-readers⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byob-readers">
-   <b><a href="#byob-readers">#byob-readers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byob-readers" class="dfn-panel" data-for="byob-readers" id="infopanel-for-byob-readers" role="dialog">
+   <span id="infopaneltitle-for-byob-readers" style="display:none">Info about the 'BYOB readers' definition.</span><b><a href="#byob-readers">#byob-readers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byob-readers">2.1. Readable streams</a>
     <li><a href="#ref-for-byob-readers①">4.1. Using readable streams</a>
@@ -11841,8 +11843,8 @@ support)</a> <a href="#ref-for-byob-readers⑧">(2)</a> <a href="#ref-for-byob-r
     <li><a href="#ref-for-byob-readers①⓪">10.5. A readable byte stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writer">
-   <b><a href="#writer">#writer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writer" class="dfn-panel" data-for="writer" id="infopanel-for-writer" role="dialog">
+   <span id="infopaneltitle-for-writer" style="display:none">Info about the 'writable stream writer' definition.</span><b><a href="#writer">#writer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writer">1. Introduction</a>
     <li><a href="#ref-for-writer①">5.1. Using writable streams</a> <a href="#ref-for-writer②">(2)</a>
@@ -11852,8 +11854,8 @@ support)</a> <a href="#ref-for-byob-readers⑧">(2)</a> <a href="#ref-for-byob-r
     <li><a href="#ref-for-writer⑥">10.6. A writable stream with no backpressure or success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="lock">
-   <b><a href="#lock">#lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-lock" class="dfn-panel" data-for="lock" id="infopanel-for-lock" role="dialog">
+   <span id="infopaneltitle-for-lock" style="display:none">Info about the 'locked' definition.</span><b><a href="#lock">#lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-lock">2.1. Readable streams</a>
     <li><a href="#ref-for-lock①">2.4. Pipe chains and backpressure</a>
@@ -11866,16 +11868,16 @@ support)</a> <a href="#ref-for-byob-readers⑧">(2)</a> <a href="#ref-for-byob-r
     <li><a href="#ref-for-lock①⑦">5.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="active">
-   <b><a href="#active">#active</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-active" class="dfn-panel" data-for="active" id="infopanel-for-active" role="dialog">
+   <span id="infopaneltitle-for-active" style="display:none">Info about the 'active' definition.</span><b><a href="#active">#active</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-active">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-active①">(2)</a>
     <li><a href="#ref-for-active②">4.5.3. Constructor, methods, and properties</a> <a href="#ref-for-active③">(2)</a>
     <li><a href="#ref-for-active④">5.3.3. Constructor, methods, and properties</a> <a href="#ref-for-active⑤">(2)</a> <a href="#ref-for-active⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="release-a-lock">
-   <b><a href="#release-a-lock">#release-a-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-release-a-lock" class="dfn-panel" data-for="release-a-lock" id="infopanel-for-release-a-lock" role="dialog">
+   <span id="infopaneltitle-for-release-a-lock" style="display:none">Info about the 'release its lock' definition.</span><b><a href="#release-a-lock">#release-a-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-release-a-lock">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-release-a-lock①">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-release-a-lock②">(2)</a>
@@ -11884,8 +11886,8 @@ support)</a> <a href="#ref-for-byob-readers⑧">(2)</a> <a href="#ref-for-byob-r
     <li><a href="#ref-for-release-a-lock⑥">5.3.3. Constructor, methods, and properties</a> <a href="#ref-for-release-a-lock⑦">(2)</a> <a href="#ref-for-release-a-lock⑧">(3)</a> <a href="#ref-for-release-a-lock⑨">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream">
-   <b><a href="#readablestream">#readablestream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream" class="dfn-panel" data-for="readablestream" id="infopanel-for-readablestream" role="dialog">
+   <span id="infopaneltitle-for-readablestream" style="display:none">Info about the 'ReadableStream' definition.</span><b><a href="#readablestream">#readablestream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream">1. Introduction</a>
     <li><a href="#ref-for-readablestream①">2.1. Readable streams</a>
@@ -11928,100 +11930,100 @@ support)</a>
     <li><a href="#ref-for-readablestream⑦⑦">10.5. A readable byte stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-readablestreamreader">
-   <b><a href="#typedefdef-readablestreamreader">#typedefdef-readablestreamreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-readablestreamreader" class="dfn-panel" data-for="typedefdef-readablestreamreader" id="infopanel-for-typedefdef-readablestreamreader" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-readablestreamreader" style="display:none">Info about the 'ReadableStreamReader' definition.</span><b><a href="#typedefdef-readablestreamreader">#typedefdef-readablestreamreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-readablestreamreader">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-readablestreamreadermode">
-   <b><a href="#enumdef-readablestreamreadermode">#enumdef-readablestreamreadermode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-readablestreamreadermode" class="dfn-panel" data-for="enumdef-readablestreamreadermode" id="infopanel-for-enumdef-readablestreamreadermode" role="dialog">
+   <span id="infopaneltitle-for-enumdef-readablestreamreadermode" style="display:none">Info about the 'ReadableStreamReaderMode' definition.</span><b><a href="#enumdef-readablestreamreadermode">#enumdef-readablestreamreadermode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-readablestreamreadermode">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamreadermode-byob">
-   <b><a href="#dom-readablestreamreadermode-byob">#dom-readablestreamreadermode-byob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamreadermode-byob" class="dfn-panel" data-for="dom-readablestreamreadermode-byob" id="infopanel-for-dom-readablestreamreadermode-byob" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamreadermode-byob" style="display:none">Info about the '"byob"' definition.</span><b><a href="#dom-readablestreamreadermode-byob">#dom-readablestreamreadermode-byob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamreadermode-byob">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreamreadermode-byob①">(2)</a>
     <li><a href="#ref-for-dom-readablestreamreadermode-byob②">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readablestreamgetreaderoptions">
-   <b><a href="#dictdef-readablestreamgetreaderoptions">#dictdef-readablestreamgetreaderoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readablestreamgetreaderoptions" class="dfn-panel" data-for="dictdef-readablestreamgetreaderoptions" id="infopanel-for-dictdef-readablestreamgetreaderoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readablestreamgetreaderoptions" style="display:none">Info about the 'ReadableStreamGetReaderOptions' definition.</span><b><a href="#dictdef-readablestreamgetreaderoptions">#dictdef-readablestreamgetreaderoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readablestreamgetreaderoptions">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamgetreaderoptions-mode">
-   <b><a href="#dom-readablestreamgetreaderoptions-mode">#dom-readablestreamgetreaderoptions-mode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamgetreaderoptions-mode" class="dfn-panel" data-for="dom-readablestreamgetreaderoptions-mode" id="infopanel-for-dom-readablestreamgetreaderoptions-mode" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamgetreaderoptions-mode" style="display:none">Info about the 'mode' definition.</span><b><a href="#dom-readablestreamgetreaderoptions-mode">#dom-readablestreamgetreaderoptions-mode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamgetreaderoptions-mode">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreamgetreaderoptions-mode①">(2)</a> <a href="#ref-for-dom-readablestreamgetreaderoptions-mode②">(3)</a>
     <li><a href="#ref-for-dom-readablestreamgetreaderoptions-mode③">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readablestreamiteratoroptions">
-   <b><a href="#dictdef-readablestreamiteratoroptions">#dictdef-readablestreamiteratoroptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readablestreamiteratoroptions" class="dfn-panel" data-for="dictdef-readablestreamiteratoroptions" id="infopanel-for-dictdef-readablestreamiteratoroptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readablestreamiteratoroptions" style="display:none">Info about the 'ReadableStreamIteratorOptions' definition.</span><b><a href="#dictdef-readablestreamiteratoroptions">#dictdef-readablestreamiteratoroptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readablestreamiteratoroptions">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamiteratoroptions-preventcancel">
-   <b><a href="#dom-readablestreamiteratoroptions-preventcancel">#dom-readablestreamiteratoroptions-preventcancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamiteratoroptions-preventcancel" class="dfn-panel" data-for="dom-readablestreamiteratoroptions-preventcancel" id="infopanel-for-dom-readablestreamiteratoroptions-preventcancel" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamiteratoroptions-preventcancel" style="display:none">Info about the 'preventCancel' definition.</span><b><a href="#dom-readablestreamiteratoroptions-preventcancel">#dom-readablestreamiteratoroptions-preventcancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamiteratoroptions-preventcancel">4.2.5. Asynchronous iteration</a> <a href="#ref-for-dom-readablestreamiteratoroptions-preventcancel①">(2)</a> <a href="#ref-for-dom-readablestreamiteratoroptions-preventcancel②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readablewritablepair">
-   <b><a href="#dictdef-readablewritablepair">#dictdef-readablewritablepair</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readablewritablepair" class="dfn-panel" data-for="dictdef-readablewritablepair" id="infopanel-for-dictdef-readablewritablepair" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readablewritablepair" style="display:none">Info about the 'ReadableWritablePair' definition.</span><b><a href="#dictdef-readablewritablepair">#dictdef-readablewritablepair</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readablewritablepair">4.2.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablewritablepair-readable">
-   <b><a href="#dom-readablewritablepair-readable">#dom-readablewritablepair-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablewritablepair-readable" class="dfn-panel" data-for="dom-readablewritablepair-readable" id="infopanel-for-dom-readablewritablepair-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-readablewritablepair-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-readablewritablepair-readable">#dom-readablewritablepair-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablewritablepair-readable">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablewritablepair-readable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablewritablepair-writable">
-   <b><a href="#dom-readablewritablepair-writable">#dom-readablewritablepair-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablewritablepair-writable" class="dfn-panel" data-for="dom-readablewritablepair-writable" id="infopanel-for-dom-readablewritablepair-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-readablewritablepair-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-readablewritablepair-writable">#dom-readablewritablepair-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablewritablepair-writable">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablewritablepair-writable①">(2)</a> <a href="#ref-for-dom-readablewritablepair-writable②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-streampipeoptions">
-   <b><a href="#dictdef-streampipeoptions">#dictdef-streampipeoptions</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-streampipeoptions" class="dfn-panel" data-for="dictdef-streampipeoptions" id="infopanel-for-dictdef-streampipeoptions" role="dialog">
+   <span id="infopaneltitle-for-dictdef-streampipeoptions" style="display:none">Info about the 'StreamPipeOptions' definition.</span><b><a href="#dictdef-streampipeoptions">#dictdef-streampipeoptions</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-streampipeoptions">4.2.1. Interface definition</a> <a href="#ref-for-dictdef-streampipeoptions①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-streampipeoptions-preventclose">
-   <b><a href="#dom-streampipeoptions-preventclose">#dom-streampipeoptions-preventclose</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-streampipeoptions-preventclose" class="dfn-panel" data-for="dom-streampipeoptions-preventclose" id="infopanel-for-dom-streampipeoptions-preventclose" role="dialog">
+   <span id="infopaneltitle-for-dom-streampipeoptions-preventclose" style="display:none">Info about the 'preventClose' definition.</span><b><a href="#dom-streampipeoptions-preventclose">#dom-streampipeoptions-preventclose</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-streampipeoptions-preventclose">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-streampipeoptions-preventclose①">(2)</a> <a href="#ref-for-dom-streampipeoptions-preventclose②">(3)</a> <a href="#ref-for-dom-streampipeoptions-preventclose③">(4)</a> <a href="#ref-for-dom-streampipeoptions-preventclose④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-streampipeoptions-preventabort">
-   <b><a href="#dom-streampipeoptions-preventabort">#dom-streampipeoptions-preventabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-streampipeoptions-preventabort" class="dfn-panel" data-for="dom-streampipeoptions-preventabort" id="infopanel-for-dom-streampipeoptions-preventabort" role="dialog">
+   <span id="infopaneltitle-for-dom-streampipeoptions-preventabort" style="display:none">Info about the 'preventAbort' definition.</span><b><a href="#dom-streampipeoptions-preventabort">#dom-streampipeoptions-preventabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-streampipeoptions-preventabort">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-streampipeoptions-preventabort①">(2)</a> <a href="#ref-for-dom-streampipeoptions-preventabort②">(3)</a> <a href="#ref-for-dom-streampipeoptions-preventabort③">(4)</a> <a href="#ref-for-dom-streampipeoptions-preventabort④">(5)</a> <a href="#ref-for-dom-streampipeoptions-preventabort⑤">(6)</a> <a href="#ref-for-dom-streampipeoptions-preventabort⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-streampipeoptions-preventcancel">
-   <b><a href="#dom-streampipeoptions-preventcancel">#dom-streampipeoptions-preventcancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-streampipeoptions-preventcancel" class="dfn-panel" data-for="dom-streampipeoptions-preventcancel" id="infopanel-for-dom-streampipeoptions-preventcancel" role="dialog">
+   <span id="infopaneltitle-for-dom-streampipeoptions-preventcancel" style="display:none">Info about the 'preventCancel' definition.</span><b><a href="#dom-streampipeoptions-preventcancel">#dom-streampipeoptions-preventcancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-streampipeoptions-preventcancel">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-streampipeoptions-preventcancel①">(2)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel②">(3)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel③">(4)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel④">(5)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel⑤">(6)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel⑥">(7)</a> <a href="#ref-for-dom-streampipeoptions-preventcancel⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-streampipeoptions-signal">
-   <b><a href="#dom-streampipeoptions-signal">#dom-streampipeoptions-signal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-streampipeoptions-signal" class="dfn-panel" data-for="dom-streampipeoptions-signal" id="infopanel-for-dom-streampipeoptions-signal" role="dialog">
+   <span id="infopaneltitle-for-dom-streampipeoptions-signal" style="display:none">Info about the 'signal' definition.</span><b><a href="#dom-streampipeoptions-signal">#dom-streampipeoptions-signal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-streampipeoptions-signal">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-streampipeoptions-signal①">(2)</a> <a href="#ref-for-dom-streampipeoptions-signal②">(3)</a> <a href="#ref-for-dom-streampipeoptions-signal③">(4)</a> <a href="#ref-for-dom-streampipeoptions-signal④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-controller">
-   <b><a href="#readablestream-controller">#readablestream-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-controller" class="dfn-panel" data-for="readablestream-controller" id="infopanel-for-readablestream-controller" role="dialog">
+   <span id="infopaneltitle-for-readablestream-controller" style="display:none">Info about the '[[controller]]' definition.</span><b><a href="#readablestream-controller">#readablestream-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-controller">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestream-controller①">(2)</a> <a href="#ref-for-readablestream-controller②">(3)</a> <a href="#ref-for-readablestream-controller③">(4)</a> <a href="#ref-for-readablestream-controller④">(5)</a> <a href="#ref-for-readablestream-controller⑤">(6)</a> <a href="#ref-for-readablestream-controller⑥">(7)</a>
     <li><a href="#ref-for-readablestream-controller⑦">4.9.2. Interfacing with controllers</a>
@@ -12035,8 +12037,8 @@ support)</a>
     <li><a href="#ref-for-readablestream-controller②⓪">9.1.1. Creation and manipulation</a> <a href="#ref-for-readablestream-controller②①">(2)</a> <a href="#ref-for-readablestream-controller②②">(3)</a> <a href="#ref-for-readablestream-controller②③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-disturbed">
-   <b><a href="#readablestream-disturbed">#readablestream-disturbed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-disturbed" class="dfn-panel" data-for="readablestream-disturbed" id="infopanel-for-readablestream-disturbed" role="dialog">
+   <span id="infopaneltitle-for-readablestream-disturbed" style="display:none">Info about the '[[disturbed]]' definition.</span><b><a href="#readablestream-disturbed">#readablestream-disturbed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-disturbed">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestream-disturbed①">(2)</a>
     <li><a href="#ref-for-readablestream-disturbed②">4.9.2. Interfacing with controllers</a>
@@ -12044,16 +12046,16 @@ support)</a>
     <li><a href="#ref-for-readablestream-disturbed⑤">9.1.3. Introspection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-reader">
-   <b><a href="#readablestream-reader">#readablestream-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-reader" class="dfn-panel" data-for="readablestream-reader" id="infopanel-for-readablestream-reader" role="dialog">
+   <span id="infopaneltitle-for-readablestream-reader" style="display:none">Info about the '[[reader]]' definition.</span><b><a href="#readablestream-reader">#readablestream-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-reader">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestream-reader①">(2)</a>
     <li><a href="#ref-for-readablestream-reader②">4.9.2. Interfacing with controllers</a> <a href="#ref-for-readablestream-reader③">(2)</a> <a href="#ref-for-readablestream-reader④">(3)</a> <a href="#ref-for-readablestream-reader⑤">(4)</a> <a href="#ref-for-readablestream-reader⑥">(5)</a> <a href="#ref-for-readablestream-reader⑦">(6)</a> <a href="#ref-for-readablestream-reader⑧">(7)</a> <a href="#ref-for-readablestream-reader⑨">(8)</a> <a href="#ref-for-readablestream-reader①⓪">(9)</a> <a href="#ref-for-readablestream-reader①①">(10)</a> <a href="#ref-for-readablestream-reader①②">(11)</a> <a href="#ref-for-readablestream-reader①③">(12)</a>
     <li><a href="#ref-for-readablestream-reader①④">4.9.3. Readers</a> <a href="#ref-for-readablestream-reader①⑤">(2)</a> <a href="#ref-for-readablestream-reader①⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-state">
-   <b><a href="#readablestream-state">#readablestream-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-state" class="dfn-panel" data-for="readablestream-state" id="infopanel-for-readablestream-state" role="dialog">
+   <span id="infopaneltitle-for-readablestream-state" style="display:none">Info about the '[[state]]' definition.</span><b><a href="#readablestream-state">#readablestream-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-state">4.7.3. Methods and properties</a> <a href="#ref-for-readablestream-state①">(2)</a>
     <li><a href="#ref-for-readablestream-state②">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestream-state③">(2)</a> <a href="#ref-for-readablestream-state④">(3)</a> <a href="#ref-for-readablestream-state⑤">(4)</a>
@@ -12065,8 +12067,8 @@ support)</a>
     <li><a href="#ref-for-readablestream-state③⑥">9.1.3. Introspection</a> <a href="#ref-for-readablestream-state③⑦">(2)</a> <a href="#ref-for-readablestream-state③⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-storederror">
-   <b><a href="#readablestream-storederror">#readablestream-storederror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-storederror" class="dfn-panel" data-for="readablestream-storederror" id="infopanel-for-readablestream-storederror" role="dialog">
+   <span id="infopaneltitle-for-readablestream-storederror" style="display:none">Info about the '[[storedError]]' definition.</span><b><a href="#readablestream-storederror">#readablestream-storederror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-storederror">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestream-storederror①">(2)</a> <a href="#ref-for-readablestream-storederror②">(3)</a> <a href="#ref-for-readablestream-storederror③">(4)</a>
     <li><a href="#ref-for-readablestream-storederror④">4.9.2. Interfacing with controllers</a> <a href="#ref-for-readablestream-storederror⑤">(2)</a>
@@ -12075,44 +12077,44 @@ support)</a>
     <li><a href="#ref-for-readablestream-storederror①⓪">6.4.3. Default sinks</a> <a href="#ref-for-readablestream-storederror①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-underlyingsource">
-   <b><a href="#dictdef-underlyingsource">#dictdef-underlyingsource</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-underlyingsource" class="dfn-panel" data-for="dictdef-underlyingsource" id="infopanel-for-dictdef-underlyingsource" role="dialog">
+   <span id="infopaneltitle-for-dictdef-underlyingsource" style="display:none">Info about the 'UnderlyingSource' definition.</span><b><a href="#dictdef-underlyingsource">#dictdef-underlyingsource</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-underlyingsource">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dictdef-underlyingsource①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedefdef-readablestreamcontroller">
-   <b><a href="#typedefdef-readablestreamcontroller">#typedefdef-readablestreamcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedefdef-readablestreamcontroller" class="dfn-panel" data-for="typedefdef-readablestreamcontroller" id="infopanel-for-typedefdef-readablestreamcontroller" role="dialog">
+   <span id="infopaneltitle-for-typedefdef-readablestreamcontroller" style="display:none">Info about the 'ReadableStreamController' definition.</span><b><a href="#typedefdef-readablestreamcontroller">#typedefdef-readablestreamcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-readablestreamcontroller">4.2.3. The underlying source API</a> <a href="#ref-for-typedefdef-readablestreamcontroller①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsourcestartcallback">
-   <b><a href="#callbackdef-underlyingsourcestartcallback">#callbackdef-underlyingsourcestartcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsourcestartcallback" class="dfn-panel" data-for="callbackdef-underlyingsourcestartcallback" id="infopanel-for-callbackdef-underlyingsourcestartcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsourcestartcallback" style="display:none">Info about the 'UnderlyingSourceStartCallback' definition.</span><b><a href="#callbackdef-underlyingsourcestartcallback">#callbackdef-underlyingsourcestartcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsourcestartcallback">4.2.3. The underlying source API</a> <a href="#ref-for-callbackdef-underlyingsourcestartcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsourcepullcallback">
-   <b><a href="#callbackdef-underlyingsourcepullcallback">#callbackdef-underlyingsourcepullcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsourcepullcallback" class="dfn-panel" data-for="callbackdef-underlyingsourcepullcallback" id="infopanel-for-callbackdef-underlyingsourcepullcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsourcepullcallback" style="display:none">Info about the 'UnderlyingSourcePullCallback' definition.</span><b><a href="#callbackdef-underlyingsourcepullcallback">#callbackdef-underlyingsourcepullcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsourcepullcallback">4.2.3. The underlying source API</a> <a href="#ref-for-callbackdef-underlyingsourcepullcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsourcecancelcallback">
-   <b><a href="#callbackdef-underlyingsourcecancelcallback">#callbackdef-underlyingsourcecancelcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsourcecancelcallback" class="dfn-panel" data-for="callbackdef-underlyingsourcecancelcallback" id="infopanel-for-callbackdef-underlyingsourcecancelcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsourcecancelcallback" style="display:none">Info about the 'UnderlyingSourceCancelCallback' definition.</span><b><a href="#callbackdef-underlyingsourcecancelcallback">#callbackdef-underlyingsourcecancelcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsourcecancelcallback">4.2.3. The underlying source API</a> <a href="#ref-for-callbackdef-underlyingsourcecancelcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enumdef-readablestreamtype">
-   <b><a href="#enumdef-readablestreamtype">#enumdef-readablestreamtype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-readablestreamtype" class="dfn-panel" data-for="enumdef-readablestreamtype" id="infopanel-for-enumdef-readablestreamtype" role="dialog">
+   <span id="infopaneltitle-for-enumdef-readablestreamtype" style="display:none">Info about the 'ReadableStreamType' definition.</span><b><a href="#enumdef-readablestreamtype">#enumdef-readablestreamtype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-readablestreamtype">4.2.3. The underlying source API</a> <a href="#ref-for-enumdef-readablestreamtype①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsource-start">
-   <b><a href="#dom-underlyingsource-start">#dom-underlyingsource-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsource-start" class="dfn-panel" data-for="dom-underlyingsource-start" id="infopanel-for-dom-underlyingsource-start" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsource-start" style="display:none">Info about the 'start(controller)' definition.</span><b><a href="#dom-underlyingsource-start">#dom-underlyingsource-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsource-start">4.2.3. The underlying source API</a> <a href="#ref-for-dom-underlyingsource-start①">(2)</a> <a href="#ref-for-dom-underlyingsource-start②">(3)</a> <a href="#ref-for-dom-underlyingsource-start③">(4)</a>
     <li><a href="#ref-for-dom-underlyingsource-start④">4.9.4. Default controllers</a> <a href="#ref-for-dom-underlyingsource-start⑤">(2)</a>
@@ -12122,8 +12124,8 @@ backpressure support)</a>
     <li><a href="#ref-for-dom-underlyingsource-start⑨">10.4. A readable stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsource-pull">
-   <b><a href="#dom-underlyingsource-pull">#dom-underlyingsource-pull</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsource-pull" class="dfn-panel" data-for="dom-underlyingsource-pull" id="infopanel-for-dom-underlyingsource-pull" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsource-pull" style="display:none">Info about the 'pull(controller)' definition.</span><b><a href="#dom-underlyingsource-pull">#dom-underlyingsource-pull</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsource-pull">4.2.3. The underlying source API</a> <a href="#ref-for-dom-underlyingsource-pull①">(2)</a> <a href="#ref-for-dom-underlyingsource-pull②">(3)</a> <a href="#ref-for-dom-underlyingsource-pull③">(4)</a>
     <li><a href="#ref-for-dom-underlyingsource-pull④">4.9.4. Default controllers</a> <a href="#ref-for-dom-underlyingsource-pull⑤">(2)</a>
@@ -12132,8 +12134,8 @@ backpressure support)</a>
     <li><a href="#ref-for-dom-underlyingsource-pull⑨">10.4. A readable stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsource-cancel">
-   <b><a href="#dom-underlyingsource-cancel">#dom-underlyingsource-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsource-cancel" class="dfn-panel" data-for="dom-underlyingsource-cancel" id="infopanel-for-dom-underlyingsource-cancel" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsource-cancel" style="display:none">Info about the 'cancel(reason)' definition.</span><b><a href="#dom-underlyingsource-cancel">#dom-underlyingsource-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsource-cancel">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-dom-underlyingsource-cancel①">4.2.4. Constructor, methods, and properties</a>
@@ -12141,30 +12143,30 @@ backpressure support)</a>
     <li><a href="#ref-for-dom-underlyingsource-cancel④">4.9.5. Byte stream controllers</a> <a href="#ref-for-dom-underlyingsource-cancel⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsource-type">
-   <b><a href="#dom-underlyingsource-type">#dom-underlyingsource-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsource-type" class="dfn-panel" data-for="dom-underlyingsource-type" id="infopanel-for-dom-underlyingsource-type" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsource-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-underlyingsource-type">#dom-underlyingsource-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsource-type">4.2.3. The underlying source API</a> <a href="#ref-for-dom-underlyingsource-type①">(2)</a> <a href="#ref-for-dom-underlyingsource-type②">(3)</a>
     <li><a href="#ref-for-dom-underlyingsource-type③">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dom-underlyingsource-type④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamtype-bytes">
-   <b><a href="#dom-readablestreamtype-bytes">#dom-readablestreamtype-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamtype-bytes" class="dfn-panel" data-for="dom-readablestreamtype-bytes" id="infopanel-for-dom-readablestreamtype-bytes" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamtype-bytes" style="display:none">Info about the 'bytes' definition.</span><b><a href="#dom-readablestreamtype-bytes">#dom-readablestreamtype-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamtype-bytes">4.2.3. The underlying source API</a> <a href="#ref-for-dom-readablestreamtype-bytes①">(2)</a> <a href="#ref-for-dom-readablestreamtype-bytes②">(3)</a>
     <li><a href="#ref-for-dom-readablestreamtype-bytes③">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsource-autoallocatechunksize">
-   <b><a href="#dom-underlyingsource-autoallocatechunksize">#dom-underlyingsource-autoallocatechunksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsource-autoallocatechunksize" class="dfn-panel" data-for="dom-underlyingsource-autoallocatechunksize" id="infopanel-for-dom-underlyingsource-autoallocatechunksize" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsource-autoallocatechunksize" style="display:none">Info about the 'autoAllocateChunkSize' definition.</span><b><a href="#dom-underlyingsource-autoallocatechunksize">#dom-underlyingsource-autoallocatechunksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsource-autoallocatechunksize">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-dom-underlyingsource-autoallocatechunksize①">4.9.5. Byte stream controllers</a>
     <li><a href="#ref-for-dom-underlyingsource-autoallocatechunksize②">10.5. A readable byte stream with an underlying pull source</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-constructor">
-   <b><a href="#rs-constructor">#rs-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-constructor" class="dfn-panel" data-for="rs-constructor" id="infopanel-for-rs-constructor" role="dialog">
+   <span id="infopaneltitle-for-rs-constructor" style="display:none">Info about the 'new ReadableStream(underlyingSource, strategy)' definition.</span><b><a href="#rs-constructor">#rs-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-constructor">2.1. Readable streams</a>
     <li><a href="#ref-for-rs-constructor①">4.2.1. Interface definition</a>
@@ -12173,16 +12175,16 @@ backpressure support)</a>
     <li><a href="#ref-for-rs-constructor⑥">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-locked">
-   <b><a href="#rs-locked">#rs-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-locked" class="dfn-panel" data-for="rs-locked" id="infopanel-for-rs-locked" role="dialog">
+   <span id="infopaneltitle-for-rs-locked" style="display:none">Info about the 'locked' definition.</span><b><a href="#rs-locked">#rs-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-locked">2.6. Locking</a>
     <li><a href="#ref-for-rs-locked①">4.2.1. Interface definition</a>
     <li><a href="#ref-for-rs-locked②">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-cancel">
-   <b><a href="#rs-cancel">#rs-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-cancel" class="dfn-panel" data-for="rs-cancel" id="infopanel-for-rs-cancel" role="dialog">
+   <span id="infopaneltitle-for-rs-cancel" style="display:none">Info about the 'cancel(reason)' definition.</span><b><a href="#rs-cancel">#rs-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-cancel">2.1. Readable streams</a>
     <li><a href="#ref-for-rs-cancel①">4.2.1. Interface definition</a>
@@ -12193,8 +12195,8 @@ backpressure support)</a>
     <li><a href="#ref-for-rs-cancel⑥">4.9.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-get-reader">
-   <b><a href="#rs-get-reader">#rs-get-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-get-reader" class="dfn-panel" data-for="rs-get-reader" id="infopanel-for-rs-get-reader" role="dialog">
+   <span id="infopaneltitle-for-rs-get-reader" style="display:none">Info about the 'getReader(options)' definition.</span><b><a href="#rs-get-reader">#rs-get-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-get-reader">2.1. Readable streams</a> <a href="#ref-for-rs-get-reader①">(2)</a>
     <li><a href="#ref-for-rs-get-reader②">2.6. Locking</a>
@@ -12205,8 +12207,8 @@ backpressure support)</a>
     <li><a href="#ref-for-rs-get-reader⑧">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-pipe-through">
-   <b><a href="#rs-pipe-through">#rs-pipe-through</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-pipe-through" class="dfn-panel" data-for="rs-pipe-through" id="infopanel-for-rs-pipe-through" role="dialog">
+   <span id="infopaneltitle-for-rs-pipe-through" style="display:none">Info about the 'pipeThrough(transform, options)' definition.</span><b><a href="#rs-pipe-through">#rs-pipe-through</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipe-through">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-rs-pipe-through①">4.2.1. Interface definition</a>
@@ -12215,8 +12217,8 @@ backpressure support)</a>
     <li><a href="#ref-for-rs-pipe-through⑤">9.4.2. Endpoint pairs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-pipe-to">
-   <b><a href="#rs-pipe-to">#rs-pipe-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-pipe-to" class="dfn-panel" data-for="rs-pipe-to" id="infopanel-for-rs-pipe-to" role="dialog">
+   <span id="infopaneltitle-for-rs-pipe-to" style="display:none">Info about the 'pipeTo(destination, options)' definition.</span><b><a href="#rs-pipe-to">#rs-pipe-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipe-to">2.4. Pipe chains and backpressure</a> <a href="#ref-for-rs-pipe-to①">(2)</a>
     <li><a href="#ref-for-rs-pipe-to②">4.2.1. Interface definition</a>
@@ -12228,28 +12230,28 @@ backpressure support)</a>
 create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-tee">
-   <b><a href="#rs-tee">#rs-tee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-tee" class="dfn-panel" data-for="rs-tee" id="infopanel-for-rs-tee" role="dialog">
+   <span id="infopaneltitle-for-rs-tee" style="display:none">Info about the 'tee()' definition.</span><b><a href="#rs-tee">#rs-tee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-tee">2.1. Readable streams</a>
     <li><a href="#ref-for-rs-tee①">4.2.1. Interface definition</a>
     <li><a href="#ref-for-rs-tee②">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-async-iterator-reader">
-   <b><a href="#readablestream-async-iterator-reader">#readablestream-async-iterator-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-async-iterator-reader" class="dfn-panel" data-for="readablestream-async-iterator-reader" id="infopanel-for-readablestream-async-iterator-reader" role="dialog">
+   <span id="infopaneltitle-for-readablestream-async-iterator-reader" style="display:none">Info about the 'reader' definition.</span><b><a href="#readablestream-async-iterator-reader">#readablestream-async-iterator-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-async-iterator-reader">4.2.5. Asynchronous iteration</a> <a href="#ref-for-readablestream-async-iterator-reader①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-async-iterator-prevent-cancel">
-   <b><a href="#readablestream-async-iterator-prevent-cancel">#readablestream-async-iterator-prevent-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-async-iterator-prevent-cancel" class="dfn-panel" data-for="readablestream-async-iterator-prevent-cancel" id="infopanel-for-readablestream-async-iterator-prevent-cancel" role="dialog">
+   <span id="infopaneltitle-for-readablestream-async-iterator-prevent-cancel" style="display:none">Info about the 'prevent cancel' definition.</span><b><a href="#readablestream-async-iterator-prevent-cancel">#readablestream-async-iterator-prevent-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-async-iterator-prevent-cancel">4.2.5. Asynchronous iteration</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamgenericreader">
-   <b><a href="#readablestreamgenericreader">#readablestreamgenericreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamgenericreader" class="dfn-panel" data-for="readablestreamgenericreader" id="infopanel-for-readablestreamgenericreader" role="dialog">
+   <span id="infopaneltitle-for-readablestreamgenericreader" style="display:none">Info about the 'ReadableStreamGenericReader' definition.</span><b><a href="#readablestreamgenericreader">#readablestreamgenericreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamgenericreader">4.3. The ReadableStreamGenericReader mixin</a> <a href="#ref-for-readablestreamgenericreader①">(2)</a>
     <li><a href="#ref-for-readablestreamgenericreader②">4.3.1. Mixin definition</a>
@@ -12260,8 +12262,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamgenericreader⑦">4.5.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamgenericreader-closedpromise">
-   <b><a href="#readablestreamgenericreader-closedpromise">#readablestreamgenericreader-closedpromise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamgenericreader-closedpromise" class="dfn-panel" data-for="readablestreamgenericreader-closedpromise" id="infopanel-for-readablestreamgenericreader-closedpromise" role="dialog">
+   <span id="infopaneltitle-for-readablestreamgenericreader-closedpromise" style="display:none">Info about the '[[closedPromise]]' definition.</span><b><a href="#readablestreamgenericreader-closedpromise">#readablestreamgenericreader-closedpromise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamgenericreader-closedpromise">4.3.3. Methods and properties</a>
     <li><a href="#ref-for-readablestreamgenericreader-closedpromise①">4.9.1. Working with readable streams</a> <a href="#ref-for-readablestreamgenericreader-closedpromise②">(2)</a>
@@ -12269,8 +12271,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamgenericreader-closedpromise⑥">4.9.3. Readers</a> <a href="#ref-for-readablestreamgenericreader-closedpromise⑦">(2)</a> <a href="#ref-for-readablestreamgenericreader-closedpromise⑧">(3)</a> <a href="#ref-for-readablestreamgenericreader-closedpromise⑨">(4)</a> <a href="#ref-for-readablestreamgenericreader-closedpromise①⓪">(5)</a> <a href="#ref-for-readablestreamgenericreader-closedpromise①①">(6)</a> <a href="#ref-for-readablestreamgenericreader-closedpromise①②">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamgenericreader-stream">
-   <b><a href="#readablestreamgenericreader-stream">#readablestreamgenericreader-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamgenericreader-stream" class="dfn-panel" data-for="readablestreamgenericreader-stream" id="infopanel-for-readablestreamgenericreader-stream" role="dialog">
+   <span id="infopaneltitle-for-readablestreamgenericreader-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#readablestreamgenericreader-stream">#readablestreamgenericreader-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamgenericreader-stream">4.2.5. Asynchronous iteration</a> <a href="#ref-for-readablestreamgenericreader-stream①">(2)</a>
     <li><a href="#ref-for-readablestreamgenericreader-stream②">4.3.3. Methods and properties</a>
@@ -12281,8 +12283,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamgenericreader-stream①⓪">4.9.3. Readers</a> <a href="#ref-for-readablestreamgenericreader-stream①①">(2)</a> <a href="#ref-for-readablestreamgenericreader-stream①②">(3)</a> <a href="#ref-for-readablestreamgenericreader-stream①③">(4)</a> <a href="#ref-for-readablestreamgenericreader-stream①④">(5)</a> <a href="#ref-for-readablestreamgenericreader-stream①⑤">(6)</a> <a href="#ref-for-readablestreamgenericreader-stream①⑥">(7)</a> <a href="#ref-for-readablestreamgenericreader-stream①⑦">(8)</a> <a href="#ref-for-readablestreamgenericreader-stream①⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generic-reader-closed">
-   <b><a href="#generic-reader-closed">#generic-reader-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generic-reader-closed" class="dfn-panel" data-for="generic-reader-closed" id="infopanel-for-generic-reader-closed" role="dialog">
+   <span id="infopaneltitle-for-generic-reader-closed" style="display:none">Info about the 'closed' definition.</span><b><a href="#generic-reader-closed">#generic-reader-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-reader-closed">4.3.1. Mixin definition</a>
     <li><a href="#ref-for-generic-reader-closed①">4.3.2. Internal slots</a>
@@ -12290,8 +12292,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-generic-reader-closed③">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generic-reader-cancel">
-   <b><a href="#generic-reader-cancel">#generic-reader-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generic-reader-cancel" class="dfn-panel" data-for="generic-reader-cancel" id="infopanel-for-generic-reader-cancel" role="dialog">
+   <span id="infopaneltitle-for-generic-reader-cancel" style="display:none">Info about the 'cancel(reason)' definition.</span><b><a href="#generic-reader-cancel">#generic-reader-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generic-reader-cancel">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-generic-reader-cancel①">4.3.1. Mixin definition</a>
@@ -12299,8 +12301,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-generic-reader-cancel③">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultreader">
-   <b><a href="#readablestreamdefaultreader">#readablestreamdefaultreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultreader" class="dfn-panel" data-for="readablestreamdefaultreader" id="infopanel-for-readablestreamdefaultreader" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultreader" style="display:none">Info about the 'ReadableStreamDefaultReader' definition.</span><b><a href="#readablestreamdefaultreader">#readablestreamdefaultreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader">2.6. Locking</a>
     <li><a href="#ref-for-readablestreamdefaultreader①">4.2.1. Interface definition</a>
@@ -12316,26 +12318,26 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamdefaultreader①⑥">9.1.2. Reading</a> <a href="#ref-for-readablestreamdefaultreader①⑦">(2)</a> <a href="#ref-for-readablestreamdefaultreader①⑧">(3)</a> <a href="#ref-for-readablestreamdefaultreader①⑨">(4)</a> <a href="#ref-for-readablestreamdefaultreader②⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readablestreamdefaultreadresult">
-   <b><a href="#dictdef-readablestreamdefaultreadresult">#dictdef-readablestreamdefaultreadresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readablestreamdefaultreadresult" class="dfn-panel" data-for="dictdef-readablestreamdefaultreadresult" id="infopanel-for-dictdef-readablestreamdefaultreadresult" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readablestreamdefaultreadresult" style="display:none">Info about the 'ReadableStreamDefaultReadResult' definition.</span><b><a href="#dictdef-readablestreamdefaultreadresult">#dictdef-readablestreamdefaultreadresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readablestreamdefaultreadresult">4.4.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamdefaultreadresult-value">
-   <b><a href="#dom-readablestreamdefaultreadresult-value">#dom-readablestreamdefaultreadresult-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamdefaultreadresult-value" class="dfn-panel" data-for="dom-readablestreamdefaultreadresult-value" id="infopanel-for-dom-readablestreamdefaultreadresult-value" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamdefaultreadresult-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-readablestreamdefaultreadresult-value">#dom-readablestreamdefaultreadresult-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamdefaultreadresult-value">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreamdefaultreadresult-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreamdefaultreadresult-done">
-   <b><a href="#dom-readablestreamdefaultreadresult-done">#dom-readablestreamdefaultreadresult-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreamdefaultreadresult-done" class="dfn-panel" data-for="dom-readablestreamdefaultreadresult-done" id="infopanel-for-dom-readablestreamdefaultreadresult-done" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreamdefaultreadresult-done" style="display:none">Info about the 'done' definition.</span><b><a href="#dom-readablestreamdefaultreadresult-done">#dom-readablestreamdefaultreadresult-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreamdefaultreadresult-done">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreamdefaultreadresult-done①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultreader-readrequests">
-   <b><a href="#readablestreamdefaultreader-readrequests">#readablestreamdefaultreader-readrequests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultreader-readrequests" class="dfn-panel" data-for="readablestreamdefaultreader-readrequests" id="infopanel-for-readablestreamdefaultreader-readrequests" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultreader-readrequests" style="display:none">Info about the '[[readRequests]]' definition.</span><b><a href="#readablestreamdefaultreader-readrequests">#readablestreamdefaultreader-readrequests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultreader-readrequests">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-readablestreamdefaultreader-readrequests①">4.4.3. Constructor, methods, and properties</a>
@@ -12343,8 +12345,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamdefaultreader-readrequests①①">4.9.3. Readers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-request">
-   <b><a href="#read-request">#read-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-request" class="dfn-panel" data-for="read-request" id="infopanel-for-read-request" role="dialog">
+   <span id="infopaneltitle-for-read-request" style="display:none">Info about the 'read request' definition.</span><b><a href="#read-request">#read-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-read-request①">4.4.2. Internal slots</a>
@@ -12353,8 +12355,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-request④">9.1.2. Reading</a> <a href="#ref-for-read-request⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-request-chunk-steps">
-   <b><a href="#read-request-chunk-steps">#read-request-chunk-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-request-chunk-steps" class="dfn-panel" data-for="read-request-chunk-steps" id="infopanel-for-read-request-chunk-steps" role="dialog">
+   <span id="infopaneltitle-for-read-request-chunk-steps" style="display:none">Info about the 'chunk steps' definition.</span><b><a href="#read-request-chunk-steps">#read-request-chunk-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-chunk-steps">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-read-request-chunk-steps①">4.4.3. Constructor, methods, and properties</a>
@@ -12365,8 +12367,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-request-chunk-steps⑥">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-request-close-steps">
-   <b><a href="#read-request-close-steps">#read-request-close-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-request-close-steps" class="dfn-panel" data-for="read-request-close-steps" id="infopanel-for-read-request-close-steps" role="dialog">
+   <span id="infopaneltitle-for-read-request-close-steps" style="display:none">Info about the 'close steps' definition.</span><b><a href="#read-request-close-steps">#read-request-close-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-close-steps">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-read-request-close-steps①">4.4.3. Constructor, methods, and properties</a>
@@ -12376,8 +12378,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-request-close-steps⑥">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-request-error-steps">
-   <b><a href="#read-request-error-steps">#read-request-error-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-request-error-steps" class="dfn-panel" data-for="read-request-error-steps" id="infopanel-for-read-request-error-steps" role="dialog">
+   <span id="infopaneltitle-for-read-request-error-steps" style="display:none">Info about the 'error steps' definition.</span><b><a href="#read-request-error-steps">#read-request-error-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-request-error-steps">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-read-request-error-steps①">4.4.3. Constructor, methods, and properties</a>
@@ -12388,30 +12390,30 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-request-error-steps⑥">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-reader-constructor">
-   <b><a href="#default-reader-constructor">#default-reader-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-reader-constructor" class="dfn-panel" data-for="default-reader-constructor" id="infopanel-for-default-reader-constructor" role="dialog">
+   <span id="infopaneltitle-for-default-reader-constructor" style="display:none">Info about the 'new ReadableStreamDefaultReader(stream)' definition.</span><b><a href="#default-reader-constructor">#default-reader-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-reader-constructor">4.4.1. Interface definition</a>
     <li><a href="#ref-for-default-reader-constructor①">4.4.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-reader-read">
-   <b><a href="#default-reader-read">#default-reader-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-reader-read" class="dfn-panel" data-for="default-reader-read" id="infopanel-for-default-reader-read" role="dialog">
+   <span id="infopaneltitle-for-default-reader-read" style="display:none">Info about the 'read()' definition.</span><b><a href="#default-reader-read">#default-reader-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-reader-read">4.4.1. Interface definition</a>
     <li><a href="#ref-for-default-reader-read①">4.4.3. Constructor, methods, and properties</a> <a href="#ref-for-default-reader-read②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-reader-release-lock">
-   <b><a href="#default-reader-release-lock">#default-reader-release-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-reader-release-lock" class="dfn-panel" data-for="default-reader-release-lock" id="infopanel-for-default-reader-release-lock" role="dialog">
+   <span id="infopaneltitle-for-default-reader-release-lock" style="display:none">Info about the 'releaseLock()' definition.</span><b><a href="#default-reader-release-lock">#default-reader-release-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-reader-release-lock">2.6. Locking</a>
     <li><a href="#ref-for-default-reader-release-lock①">4.4.1. Interface definition</a>
     <li><a href="#ref-for-default-reader-release-lock②">4.4.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreambyobreader">
-   <b><a href="#readablestreambyobreader">#readablestreambyobreader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreambyobreader" class="dfn-panel" data-for="readablestreambyobreader" id="infopanel-for-readablestreambyobreader" role="dialog">
+   <span id="infopaneltitle-for-readablestreambyobreader" style="display:none">Info about the 'ReadableStreamBYOBReader' definition.</span><b><a href="#readablestreambyobreader">#readablestreambyobreader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreambyobreader">2.6. Locking</a>
     <li><a href="#ref-for-readablestreambyobreader①">4.2.1. Interface definition</a>
@@ -12426,49 +12428,49 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreambyobreader①④">4.9.3. Readers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-readablestreambyobreadresult">
-   <b><a href="#dictdef-readablestreambyobreadresult">#dictdef-readablestreambyobreadresult</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-readablestreambyobreadresult" class="dfn-panel" data-for="dictdef-readablestreambyobreadresult" id="infopanel-for-dictdef-readablestreambyobreadresult" role="dialog">
+   <span id="infopaneltitle-for-dictdef-readablestreambyobreadresult" style="display:none">Info about the 'ReadableStreamBYOBReadResult' definition.</span><b><a href="#dictdef-readablestreambyobreadresult">#dictdef-readablestreambyobreadresult</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-readablestreambyobreadresult">4.5.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreambyobreadresult-value">
-   <b><a href="#dom-readablestreambyobreadresult-value">#dom-readablestreambyobreadresult-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreambyobreadresult-value" class="dfn-panel" data-for="dom-readablestreambyobreadresult-value" id="infopanel-for-dom-readablestreambyobreadresult-value" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreambyobreadresult-value" style="display:none">Info about the 'value' definition.</span><b><a href="#dom-readablestreambyobreadresult-value">#dom-readablestreambyobreadresult-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreambyobreadresult-value">4.5.3. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreambyobreadresult-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-readablestreambyobreadresult-done">
-   <b><a href="#dom-readablestreambyobreadresult-done">#dom-readablestreambyobreadresult-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-readablestreambyobreadresult-done" class="dfn-panel" data-for="dom-readablestreambyobreadresult-done" id="infopanel-for-dom-readablestreambyobreadresult-done" role="dialog">
+   <span id="infopaneltitle-for-dom-readablestreambyobreadresult-done" style="display:none">Info about the 'done' definition.</span><b><a href="#dom-readablestreambyobreadresult-done">#dom-readablestreambyobreadresult-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-readablestreambyobreadresult-done">4.5.3. Constructor, methods, and properties</a> <a href="#ref-for-dom-readablestreambyobreadresult-done①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreambyobreader-readintorequests">
-   <b><a href="#readablestreambyobreader-readintorequests">#readablestreambyobreader-readintorequests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreambyobreader-readintorequests" class="dfn-panel" data-for="readablestreambyobreader-readintorequests" id="infopanel-for-readablestreambyobreader-readintorequests" role="dialog">
+   <span id="infopaneltitle-for-readablestreambyobreader-readintorequests" style="display:none">Info about the '[[readIntoRequests]]' definition.</span><b><a href="#readablestreambyobreader-readintorequests">#readablestreambyobreader-readintorequests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreambyobreader-readintorequests">4.5.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-readablestreambyobreader-readintorequests①">4.9.2. Interfacing with controllers</a> <a href="#ref-for-readablestreambyobreader-readintorequests②">(2)</a> <a href="#ref-for-readablestreambyobreader-readintorequests③">(3)</a> <a href="#ref-for-readablestreambyobreader-readintorequests④">(4)</a> <a href="#ref-for-readablestreambyobreader-readintorequests⑤">(5)</a> <a href="#ref-for-readablestreambyobreader-readintorequests⑥">(6)</a> <a href="#ref-for-readablestreambyobreader-readintorequests⑦">(7)</a>
     <li><a href="#ref-for-readablestreambyobreader-readintorequests⑧">4.9.3. Readers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-into-request">
-   <b><a href="#read-into-request">#read-into-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-into-request" class="dfn-panel" data-for="read-into-request" id="infopanel-for-read-into-request" role="dialog">
+   <span id="infopaneltitle-for-read-into-request" style="display:none">Info about the 'read-into request' definition.</span><b><a href="#read-into-request">#read-into-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-into-request">4.5.2. Internal slots</a>
     <li><a href="#ref-for-read-into-request①">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-into-request-chunk-steps">
-   <b><a href="#read-into-request-chunk-steps">#read-into-request-chunk-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-into-request-chunk-steps" class="dfn-panel" data-for="read-into-request-chunk-steps" id="infopanel-for-read-into-request-chunk-steps" role="dialog">
+   <span id="infopaneltitle-for-read-into-request-chunk-steps" style="display:none">Info about the 'chunk steps' definition.</span><b><a href="#read-into-request-chunk-steps">#read-into-request-chunk-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-into-request-chunk-steps">4.5.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-read-into-request-chunk-steps①">4.9.2. Interfacing with controllers</a>
     <li><a href="#ref-for-read-into-request-chunk-steps②">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-into-request-close-steps">
-   <b><a href="#read-into-request-close-steps">#read-into-request-close-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-into-request-close-steps" class="dfn-panel" data-for="read-into-request-close-steps" id="infopanel-for-read-into-request-close-steps" role="dialog">
+   <span id="infopaneltitle-for-read-into-request-close-steps" style="display:none">Info about the 'close steps' definition.</span><b><a href="#read-into-request-close-steps">#read-into-request-close-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-into-request-close-steps">4.5.2. Internal slots</a>
     <li><a href="#ref-for-read-into-request-close-steps①">4.5.3. Constructor, methods, and properties</a>
@@ -12476,8 +12478,8 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-into-request-close-steps③">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-into-request-error-steps">
-   <b><a href="#read-into-request-error-steps">#read-into-request-error-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-into-request-error-steps" class="dfn-panel" data-for="read-into-request-error-steps" id="infopanel-for-read-into-request-error-steps" role="dialog">
+   <span id="infopaneltitle-for-read-into-request-error-steps" style="display:none">Info about the 'error steps' definition.</span><b><a href="#read-into-request-error-steps">#read-into-request-error-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-into-request-error-steps">4.5.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-read-into-request-error-steps①">4.9.2. Interfacing with controllers</a>
@@ -12485,15 +12487,15 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-read-into-request-error-steps③">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byob-reader-constructor">
-   <b><a href="#byob-reader-constructor">#byob-reader-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byob-reader-constructor" class="dfn-panel" data-for="byob-reader-constructor" id="infopanel-for-byob-reader-constructor" role="dialog">
+   <span id="infopaneltitle-for-byob-reader-constructor" style="display:none">Info about the 'new ReadableStreamBYOBReader(stream)' definition.</span><b><a href="#byob-reader-constructor">#byob-reader-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byob-reader-constructor">4.5.1. Interface definition</a>
     <li><a href="#ref-for-byob-reader-constructor①">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byob-reader-read">
-   <b><a href="#byob-reader-read">#byob-reader-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byob-reader-read" class="dfn-panel" data-for="byob-reader-read" id="infopanel-for-byob-reader-read" role="dialog">
+   <span id="infopaneltitle-for-byob-reader-read" style="display:none">Info about the 'read(view)' definition.</span><b><a href="#byob-reader-read">#byob-reader-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byob-reader-read">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-byob-reader-read①">4.5.1. Interface definition</a>
@@ -12501,16 +12503,16 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-byob-reader-read③">4.5.3. Constructor, methods, and properties</a> <a href="#ref-for-byob-reader-read④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byob-reader-release-lock">
-   <b><a href="#byob-reader-release-lock">#byob-reader-release-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byob-reader-release-lock" class="dfn-panel" data-for="byob-reader-release-lock" id="infopanel-for-byob-reader-release-lock" role="dialog">
+   <span id="infopaneltitle-for-byob-reader-release-lock" style="display:none">Info about the 'releaseLock()' definition.</span><b><a href="#byob-reader-release-lock">#byob-reader-release-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byob-reader-release-lock">2.6. Locking</a>
     <li><a href="#ref-for-byob-reader-release-lock①">4.5.1. Interface definition</a>
     <li><a href="#ref-for-byob-reader-release-lock②">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller">
-   <b><a href="#readablestreamdefaultcontroller">#readablestreamdefaultcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller" class="dfn-panel" data-for="readablestreamdefaultcontroller" id="infopanel-for-readablestreamdefaultcontroller" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller" style="display:none">Info about the 'ReadableStreamDefaultController' definition.</span><b><a href="#readablestreamdefaultcontroller">#readablestreamdefaultcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller">4.2.2. Internal slots</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller①">4.2.3. The underlying source API</a> <a href="#ref-for-readablestreamdefaultcontroller②">(2)</a>
@@ -12525,78 +12527,78 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller①④">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-cancelalgorithm">
-   <b><a href="#readablestreamdefaultcontroller-cancelalgorithm">#readablestreamdefaultcontroller-cancelalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-cancelalgorithm" class="dfn-panel" data-for="readablestreamdefaultcontroller-cancelalgorithm" id="infopanel-for-readablestreamdefaultcontroller-cancelalgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-cancelalgorithm" style="display:none">Info about the '[[cancelAlgorithm]]' definition.</span><b><a href="#readablestreamdefaultcontroller-cancelalgorithm">#readablestreamdefaultcontroller-cancelalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-cancelalgorithm">4.6.4. Internal methods</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller-cancelalgorithm①">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-cancelalgorithm②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-closerequested">
-   <b><a href="#readablestreamdefaultcontroller-closerequested">#readablestreamdefaultcontroller-closerequested</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-closerequested" class="dfn-panel" data-for="readablestreamdefaultcontroller-closerequested" id="infopanel-for-readablestreamdefaultcontroller-closerequested" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-closerequested" style="display:none">Info about the '[[closeRequested]]' definition.</span><b><a href="#readablestreamdefaultcontroller-closerequested">#readablestreamdefaultcontroller-closerequested</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-closerequested">4.6.4. Internal methods</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller-closerequested①">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-closerequested②">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-closerequested③">(3)</a> <a href="#ref-for-readablestreamdefaultcontroller-closerequested④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-pullagain">
-   <b><a href="#readablestreamdefaultcontroller-pullagain">#readablestreamdefaultcontroller-pullagain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-pullagain" class="dfn-panel" data-for="readablestreamdefaultcontroller-pullagain" id="infopanel-for-readablestreamdefaultcontroller-pullagain" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-pullagain" style="display:none">Info about the '[[pullAgain]]' definition.</span><b><a href="#readablestreamdefaultcontroller-pullagain">#readablestreamdefaultcontroller-pullagain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-pullagain">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-pullagain①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-pullagain②">(3)</a> <a href="#ref-for-readablestreamdefaultcontroller-pullagain③">(4)</a> <a href="#ref-for-readablestreamdefaultcontroller-pullagain④">(5)</a> <a href="#ref-for-readablestreamdefaultcontroller-pullagain⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-pullalgorithm">
-   <b><a href="#readablestreamdefaultcontroller-pullalgorithm">#readablestreamdefaultcontroller-pullalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-pullalgorithm" class="dfn-panel" data-for="readablestreamdefaultcontroller-pullalgorithm" id="infopanel-for-readablestreamdefaultcontroller-pullalgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-pullalgorithm" style="display:none">Info about the '[[pullAlgorithm]]' definition.</span><b><a href="#readablestreamdefaultcontroller-pullalgorithm">#readablestreamdefaultcontroller-pullalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-pullalgorithm">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-pullalgorithm①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-pullalgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-pulling">
-   <b><a href="#readablestreamdefaultcontroller-pulling">#readablestreamdefaultcontroller-pulling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-pulling" class="dfn-panel" data-for="readablestreamdefaultcontroller-pulling" id="infopanel-for-readablestreamdefaultcontroller-pulling" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-pulling" style="display:none">Info about the '[[pulling]]' definition.</span><b><a href="#readablestreamdefaultcontroller-pulling">#readablestreamdefaultcontroller-pulling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-pulling">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-pulling①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-pulling②">(3)</a> <a href="#ref-for-readablestreamdefaultcontroller-pulling③">(4)</a> <a href="#ref-for-readablestreamdefaultcontroller-pulling④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-queue">
-   <b><a href="#readablestreamdefaultcontroller-queue">#readablestreamdefaultcontroller-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-queue" class="dfn-panel" data-for="readablestreamdefaultcontroller-queue" id="infopanel-for-readablestreamdefaultcontroller-queue" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-queue" style="display:none">Info about the '[[queue]]' definition.</span><b><a href="#readablestreamdefaultcontroller-queue">#readablestreamdefaultcontroller-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-queue">4.6.2. Internal slots</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller-queue①">4.6.4. Internal methods</a> <a href="#ref-for-readablestreamdefaultcontroller-queue②">(2)</a>
     <li><a href="#ref-for-readablestreamdefaultcontroller-queue③">4.9.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-queuetotalsize">
-   <b><a href="#readablestreamdefaultcontroller-queuetotalsize">#readablestreamdefaultcontroller-queuetotalsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-queuetotalsize" class="dfn-panel" data-for="readablestreamdefaultcontroller-queuetotalsize" id="infopanel-for-readablestreamdefaultcontroller-queuetotalsize" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-queuetotalsize" style="display:none">Info about the '[[queueTotalSize]]' definition.</span><b><a href="#readablestreamdefaultcontroller-queuetotalsize">#readablestreamdefaultcontroller-queuetotalsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-queuetotalsize">4.9.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-started">
-   <b><a href="#readablestreamdefaultcontroller-started">#readablestreamdefaultcontroller-started</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-started" class="dfn-panel" data-for="readablestreamdefaultcontroller-started" id="infopanel-for-readablestreamdefaultcontroller-started" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-started" style="display:none">Info about the '[[started]]' definition.</span><b><a href="#readablestreamdefaultcontroller-started">#readablestreamdefaultcontroller-started</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-started">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-started①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-started②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-strategyhwm">
-   <b><a href="#readablestreamdefaultcontroller-strategyhwm">#readablestreamdefaultcontroller-strategyhwm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-strategyhwm" class="dfn-panel" data-for="readablestreamdefaultcontroller-strategyhwm" id="infopanel-for-readablestreamdefaultcontroller-strategyhwm" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-strategyhwm" style="display:none">Info about the '[[strategyHWM]]' definition.</span><b><a href="#readablestreamdefaultcontroller-strategyhwm">#readablestreamdefaultcontroller-strategyhwm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-strategyhwm">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-strategyhwm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-strategysizealgorithm">
-   <b><a href="#readablestreamdefaultcontroller-strategysizealgorithm">#readablestreamdefaultcontroller-strategysizealgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-strategysizealgorithm" class="dfn-panel" data-for="readablestreamdefaultcontroller-strategysizealgorithm" id="infopanel-for-readablestreamdefaultcontroller-strategysizealgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-strategysizealgorithm" style="display:none">Info about the '[[strategySizeAlgorithm]]' definition.</span><b><a href="#readablestreamdefaultcontroller-strategysizealgorithm">#readablestreamdefaultcontroller-strategysizealgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-strategysizealgorithm">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-strategysizealgorithm①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-strategysizealgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreamdefaultcontroller-stream">
-   <b><a href="#readablestreamdefaultcontroller-stream">#readablestreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreamdefaultcontroller-stream" class="dfn-panel" data-for="readablestreamdefaultcontroller-stream" id="infopanel-for-readablestreamdefaultcontroller-stream" role="dialog">
+   <span id="infopaneltitle-for-readablestreamdefaultcontroller-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#readablestreamdefaultcontroller-stream">#readablestreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreamdefaultcontroller-stream">4.9.4. Default controllers</a> <a href="#ref-for-readablestreamdefaultcontroller-stream①">(2)</a> <a href="#ref-for-readablestreamdefaultcontroller-stream②">(3)</a> <a href="#ref-for-readablestreamdefaultcontroller-stream③">(4)</a> <a href="#ref-for-readablestreamdefaultcontroller-stream④">(5)</a> <a href="#ref-for-readablestreamdefaultcontroller-stream⑤">(6)</a> <a href="#ref-for-readablestreamdefaultcontroller-stream⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-default-controller-desired-size">
-   <b><a href="#rs-default-controller-desired-size">#rs-default-controller-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-default-controller-desired-size" class="dfn-panel" data-for="rs-default-controller-desired-size" id="infopanel-for-rs-default-controller-desired-size" role="dialog">
+   <span id="infopaneltitle-for-rs-default-controller-desired-size" style="display:none">Info about the 'desiredSize' definition.</span><b><a href="#rs-default-controller-desired-size">#rs-default-controller-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-default-controller-desired-size">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-rs-default-controller-desired-size①">4.6.1. Interface definition</a>
@@ -12604,31 +12606,31 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-rs-default-controller-desired-size③">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-default-controller-close">
-   <b><a href="#rs-default-controller-close">#rs-default-controller-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-default-controller-close" class="dfn-panel" data-for="rs-default-controller-close" id="infopanel-for-rs-default-controller-close" role="dialog">
+   <span id="infopaneltitle-for-rs-default-controller-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#rs-default-controller-close">#rs-default-controller-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-default-controller-close">4.6.1. Interface definition</a>
     <li><a href="#ref-for-rs-default-controller-close①">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-rs-default-controller-close②">4.9.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-default-controller-enqueue">
-   <b><a href="#rs-default-controller-enqueue">#rs-default-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-default-controller-enqueue" class="dfn-panel" data-for="rs-default-controller-enqueue" id="infopanel-for-rs-default-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-rs-default-controller-enqueue" style="display:none">Info about the 'enqueue(chunk)' definition.</span><b><a href="#rs-default-controller-enqueue">#rs-default-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-default-controller-enqueue">4.6.1. Interface definition</a>
     <li><a href="#ref-for-rs-default-controller-enqueue①">4.6.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-default-controller-error">
-   <b><a href="#rs-default-controller-error">#rs-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-default-controller-error" class="dfn-panel" data-for="rs-default-controller-error" id="infopanel-for-rs-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-rs-default-controller-error" style="display:none">Info about the 'error(e)' definition.</span><b><a href="#rs-default-controller-error">#rs-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-default-controller-error">4.6.1. Interface definition</a>
     <li><a href="#ref-for-rs-default-controller-error①">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-rs-default-controller-error②">4.9.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller">
-   <b><a href="#readablebytestreamcontroller">#readablebytestreamcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller" class="dfn-panel" data-for="readablebytestreamcontroller" id="infopanel-for-readablebytestreamcontroller" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller" style="display:none">Info about the 'ReadableByteStreamController' definition.</span><b><a href="#readablebytestreamcontroller">#readablebytestreamcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller">4.2.2. Internal slots</a>
     <li><a href="#ref-for-readablebytestreamcontroller①">4.2.3. The underlying source API</a> <a href="#ref-for-readablebytestreamcontroller②">(2)</a>
@@ -12644,133 +12646,133 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-readablebytestreamcontroller①⑤">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-autoallocatechunksize">
-   <b><a href="#readablebytestreamcontroller-autoallocatechunksize">#readablebytestreamcontroller-autoallocatechunksize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-autoallocatechunksize" class="dfn-panel" data-for="readablebytestreamcontroller-autoallocatechunksize" id="infopanel-for-readablebytestreamcontroller-autoallocatechunksize" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-autoallocatechunksize" style="display:none">Info about the '[[autoAllocateChunkSize]]' definition.</span><b><a href="#readablebytestreamcontroller-autoallocatechunksize">#readablebytestreamcontroller-autoallocatechunksize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-autoallocatechunksize">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readablebytestreamcontroller-autoallocatechunksize①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-byobrequest">
-   <b><a href="#readablebytestreamcontroller-byobrequest">#readablebytestreamcontroller-byobrequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-byobrequest" class="dfn-panel" data-for="readablebytestreamcontroller-byobrequest" id="infopanel-for-readablebytestreamcontroller-byobrequest" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-byobrequest" style="display:none">Info about the '[[byobRequest]]' definition.</span><b><a href="#readablebytestreamcontroller-byobrequest">#readablebytestreamcontroller-byobrequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-byobrequest">4.7.3. Methods and properties</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest①">(2)</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest②">(3)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-byobrequest③">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest④">(2)</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest⑤">(3)</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest⑥">(4)</a> <a href="#ref-for-readablebytestreamcontroller-byobrequest⑦">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-cancelalgorithm">
-   <b><a href="#readablebytestreamcontroller-cancelalgorithm">#readablebytestreamcontroller-cancelalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-cancelalgorithm" class="dfn-panel" data-for="readablebytestreamcontroller-cancelalgorithm" id="infopanel-for-readablebytestreamcontroller-cancelalgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-cancelalgorithm" style="display:none">Info about the '[[cancelAlgorithm]]' definition.</span><b><a href="#readablebytestreamcontroller-cancelalgorithm">#readablebytestreamcontroller-cancelalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-cancelalgorithm">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readablebytestreamcontroller-cancelalgorithm①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-cancelalgorithm②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-closerequested">
-   <b><a href="#readablebytestreamcontroller-closerequested">#readablebytestreamcontroller-closerequested</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-closerequested" class="dfn-panel" data-for="readablebytestreamcontroller-closerequested" id="infopanel-for-readablebytestreamcontroller-closerequested" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-closerequested" style="display:none">Info about the '[[closeRequested]]' definition.</span><b><a href="#readablebytestreamcontroller-closerequested">#readablebytestreamcontroller-closerequested</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-closerequested">4.7.3. Methods and properties</a> <a href="#ref-for-readablebytestreamcontroller-closerequested①">(2)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-closerequested②">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-closerequested③">(2)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested④">(3)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested⑤">(4)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested⑥">(5)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested⑦">(6)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested⑧">(7)</a> <a href="#ref-for-readablebytestreamcontroller-closerequested⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-pullagain">
-   <b><a href="#readablebytestreamcontroller-pullagain">#readablebytestreamcontroller-pullagain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-pullagain" class="dfn-panel" data-for="readablebytestreamcontroller-pullagain" id="infopanel-for-readablebytestreamcontroller-pullagain" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-pullagain" style="display:none">Info about the '[[pullAgain]]' definition.</span><b><a href="#readablebytestreamcontroller-pullagain">#readablebytestreamcontroller-pullagain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-pullagain">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-pullagain①">(2)</a> <a href="#ref-for-readablebytestreamcontroller-pullagain②">(3)</a> <a href="#ref-for-readablebytestreamcontroller-pullagain③">(4)</a> <a href="#ref-for-readablebytestreamcontroller-pullagain④">(5)</a> <a href="#ref-for-readablebytestreamcontroller-pullagain⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-pullalgorithm">
-   <b><a href="#readablebytestreamcontroller-pullalgorithm">#readablebytestreamcontroller-pullalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-pullalgorithm" class="dfn-panel" data-for="readablebytestreamcontroller-pullalgorithm" id="infopanel-for-readablebytestreamcontroller-pullalgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-pullalgorithm" style="display:none">Info about the '[[pullAlgorithm]]' definition.</span><b><a href="#readablebytestreamcontroller-pullalgorithm">#readablebytestreamcontroller-pullalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-pullalgorithm">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-pullalgorithm①">(2)</a> <a href="#ref-for-readablebytestreamcontroller-pullalgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-pulling">
-   <b><a href="#readablebytestreamcontroller-pulling">#readablebytestreamcontroller-pulling</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-pulling" class="dfn-panel" data-for="readablebytestreamcontroller-pulling" id="infopanel-for-readablebytestreamcontroller-pulling" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-pulling" style="display:none">Info about the '[[pulling]]' definition.</span><b><a href="#readablebytestreamcontroller-pulling">#readablebytestreamcontroller-pulling</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-pulling">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-pulling①">(2)</a> <a href="#ref-for-readablebytestreamcontroller-pulling②">(3)</a> <a href="#ref-for-readablebytestreamcontroller-pulling③">(4)</a> <a href="#ref-for-readablebytestreamcontroller-pulling④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-pendingpullintos">
-   <b><a href="#readablebytestreamcontroller-pendingpullintos">#readablebytestreamcontroller-pendingpullintos</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-pendingpullintos" class="dfn-panel" data-for="readablebytestreamcontroller-pendingpullintos" id="infopanel-for-readablebytestreamcontroller-pendingpullintos" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-pendingpullintos" style="display:none">Info about the '[[pendingPullIntos]]' definition.</span><b><a href="#readablebytestreamcontroller-pendingpullintos">#readablebytestreamcontroller-pendingpullintos</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-pendingpullintos">4.7.3. Methods and properties</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①">(2)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-pendingpullintos②">4.7.4. Internal methods</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos③">(2)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos④">(3)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-pendingpullintos⑤">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos⑥">(2)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos⑦">(3)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos⑧">(4)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos⑨">(5)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⓪">(6)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①①">(7)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①②">(8)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①③">(9)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①④">(10)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⑤">(11)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⑥">(12)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⑦">(13)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⑧">(14)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos①⑨">(15)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos②⓪">(16)</a> <a href="#ref-for-readablebytestreamcontroller-pendingpullintos②①">(17)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-queue">
-   <b><a href="#readablebytestreamcontroller-queue">#readablebytestreamcontroller-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-queue" class="dfn-panel" data-for="readablebytestreamcontroller-queue" id="infopanel-for-readablebytestreamcontroller-queue" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-queue" style="display:none">Info about the '[[queue]]' definition.</span><b><a href="#readablebytestreamcontroller-queue">#readablebytestreamcontroller-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-queue">4.7.2. Internal slots</a> <a href="#ref-for-readablebytestreamcontroller-queue①">(2)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-queue②">4.7.4. Internal methods</a> <a href="#ref-for-readablebytestreamcontroller-queue③">(2)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-queue④">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-queue⑤">(2)</a> <a href="#ref-for-readablebytestreamcontroller-queue⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-queuetotalsize">
-   <b><a href="#readablebytestreamcontroller-queuetotalsize">#readablebytestreamcontroller-queuetotalsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-queuetotalsize" class="dfn-panel" data-for="readablebytestreamcontroller-queuetotalsize" id="infopanel-for-readablebytestreamcontroller-queuetotalsize" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-queuetotalsize" style="display:none">Info about the '[[queueTotalSize]]' definition.</span><b><a href="#readablebytestreamcontroller-queuetotalsize">#readablebytestreamcontroller-queuetotalsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-queuetotalsize">4.7.2. Internal slots</a>
     <li><a href="#ref-for-readablebytestreamcontroller-queuetotalsize①">4.7.4. Internal methods</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize②">(2)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize③">(3)</a>
     <li><a href="#ref-for-readablebytestreamcontroller-queuetotalsize④">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize⑤">(2)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize⑥">(3)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize⑦">(4)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize⑧">(5)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize⑨">(6)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize①⓪">(7)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize①①">(8)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize①②">(9)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize①③">(10)</a> <a href="#ref-for-readablebytestreamcontroller-queuetotalsize①④">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-started">
-   <b><a href="#readablebytestreamcontroller-started">#readablebytestreamcontroller-started</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-started" class="dfn-panel" data-for="readablebytestreamcontroller-started" id="infopanel-for-readablebytestreamcontroller-started" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-started" style="display:none">Info about the '[[started]]' definition.</span><b><a href="#readablebytestreamcontroller-started">#readablebytestreamcontroller-started</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-started">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-started①">(2)</a> <a href="#ref-for-readablebytestreamcontroller-started②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-strategyhwm">
-   <b><a href="#readablebytestreamcontroller-strategyhwm">#readablebytestreamcontroller-strategyhwm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-strategyhwm" class="dfn-panel" data-for="readablebytestreamcontroller-strategyhwm" id="infopanel-for-readablebytestreamcontroller-strategyhwm" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-strategyhwm" style="display:none">Info about the '[[strategyHWM]]' definition.</span><b><a href="#readablebytestreamcontroller-strategyhwm">#readablebytestreamcontroller-strategyhwm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-strategyhwm">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-strategyhwm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablebytestreamcontroller-stream">
-   <b><a href="#readablebytestreamcontroller-stream">#readablebytestreamcontroller-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablebytestreamcontroller-stream" class="dfn-panel" data-for="readablebytestreamcontroller-stream" id="infopanel-for-readablebytestreamcontroller-stream" role="dialog">
+   <span id="infopaneltitle-for-readablebytestreamcontroller-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#readablebytestreamcontroller-stream">#readablebytestreamcontroller-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablebytestreamcontroller-stream">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readablebytestreamcontroller-stream①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readablebytestreamcontroller-stream②">(2)</a> <a href="#ref-for-readablebytestreamcontroller-stream③">(3)</a> <a href="#ref-for-readablebytestreamcontroller-stream④">(4)</a> <a href="#ref-for-readablebytestreamcontroller-stream⑤">(5)</a> <a href="#ref-for-readablebytestreamcontroller-stream⑥">(6)</a> <a href="#ref-for-readablebytestreamcontroller-stream⑦">(7)</a> <a href="#ref-for-readablebytestreamcontroller-stream⑧">(8)</a> <a href="#ref-for-readablebytestreamcontroller-stream⑨">(9)</a> <a href="#ref-for-readablebytestreamcontroller-stream①⓪">(10)</a> <a href="#ref-for-readablebytestreamcontroller-stream①①">(11)</a> <a href="#ref-for-readablebytestreamcontroller-stream①②">(12)</a> <a href="#ref-for-readablebytestreamcontroller-stream①③">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-queue-entry">
-   <b><a href="#readable-byte-stream-queue-entry">#readable-byte-stream-queue-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-queue-entry" class="dfn-panel" data-for="readable-byte-stream-queue-entry" id="infopanel-for-readable-byte-stream-queue-entry" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-queue-entry" style="display:none">Info about the 'readable byte stream queue entry' definition.</span><b><a href="#readable-byte-stream-queue-entry">#readable-byte-stream-queue-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-queue-entry">4.7.2. Internal slots</a>
     <li><a href="#ref-for-readable-byte-stream-queue-entry①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-queue-entry-buffer">
-   <b><a href="#readable-byte-stream-queue-entry-buffer">#readable-byte-stream-queue-entry-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-queue-entry-buffer" class="dfn-panel" data-for="readable-byte-stream-queue-entry-buffer" id="infopanel-for-readable-byte-stream-queue-entry-buffer" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-queue-entry-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#readable-byte-stream-queue-entry-buffer">#readable-byte-stream-queue-entry-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-buffer">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-buffer①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-queue-entry-buffer②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-queue-entry-byte-offset">
-   <b><a href="#readable-byte-stream-queue-entry-byte-offset">#readable-byte-stream-queue-entry-byte-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-queue-entry-byte-offset" class="dfn-panel" data-for="readable-byte-stream-queue-entry-byte-offset" id="infopanel-for-readable-byte-stream-queue-entry-byte-offset" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-queue-entry-byte-offset" style="display:none">Info about the 'byte offset' definition.</span><b><a href="#readable-byte-stream-queue-entry-byte-offset">#readable-byte-stream-queue-entry-byte-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-byte-offset">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-byte-offset①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-offset②">(2)</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-offset③">(3)</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-offset④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-queue-entry-byte-length">
-   <b><a href="#readable-byte-stream-queue-entry-byte-length">#readable-byte-stream-queue-entry-byte-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-queue-entry-byte-length" class="dfn-panel" data-for="readable-byte-stream-queue-entry-byte-length" id="infopanel-for-readable-byte-stream-queue-entry-byte-length" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-queue-entry-byte-length" style="display:none">Info about the 'byte length' definition.</span><b><a href="#readable-byte-stream-queue-entry-byte-length">#readable-byte-stream-queue-entry-byte-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-byte-length">4.7.4. Internal methods</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-length①">(2)</a>
     <li><a href="#ref-for-readable-byte-stream-queue-entry-byte-length②">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-length③">(2)</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-length④">(3)</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-length⑤">(4)</a> <a href="#ref-for-readable-byte-stream-queue-entry-byte-length⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor">
-   <b><a href="#pull-into-descriptor">#pull-into-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor" class="dfn-panel" data-for="pull-into-descriptor" id="infopanel-for-pull-into-descriptor" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor" style="display:none">Info about the 'pull-into descriptor' definition.</span><b><a href="#pull-into-descriptor">#pull-into-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor">4.7.2. Internal slots</a>
     <li><a href="#ref-for-pull-into-descriptor①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor②">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-buffer">
-   <b><a href="#pull-into-descriptor-buffer">#pull-into-descriptor-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-buffer" class="dfn-panel" data-for="pull-into-descriptor-buffer" id="infopanel-for-pull-into-descriptor-buffer" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-buffer" style="display:none">Info about the 'buffer' definition.</span><b><a href="#pull-into-descriptor-buffer">#pull-into-descriptor-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-buffer">4.7.2. Internal slots</a> <a href="#ref-for-pull-into-descriptor-buffer①">(2)</a> <a href="#ref-for-pull-into-descriptor-buffer②">(3)</a> <a href="#ref-for-pull-into-descriptor-buffer③">(4)</a> <a href="#ref-for-pull-into-descriptor-buffer④">(5)</a>
     <li><a href="#ref-for-pull-into-descriptor-buffer⑤">4.7.3. Methods and properties</a>
@@ -12778,62 +12780,62 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
     <li><a href="#ref-for-pull-into-descriptor-buffer⑦">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-buffer⑧">(2)</a> <a href="#ref-for-pull-into-descriptor-buffer⑨">(3)</a> <a href="#ref-for-pull-into-descriptor-buffer①⓪">(4)</a> <a href="#ref-for-pull-into-descriptor-buffer①①">(5)</a> <a href="#ref-for-pull-into-descriptor-buffer①②">(6)</a> <a href="#ref-for-pull-into-descriptor-buffer①③">(7)</a> <a href="#ref-for-pull-into-descriptor-buffer①④">(8)</a> <a href="#ref-for-pull-into-descriptor-buffer①⑤">(9)</a> <a href="#ref-for-pull-into-descriptor-buffer①⑥">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-byte-offset">
-   <b><a href="#pull-into-descriptor-byte-offset">#pull-into-descriptor-byte-offset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-byte-offset" class="dfn-panel" data-for="pull-into-descriptor-byte-offset" id="infopanel-for-pull-into-descriptor-byte-offset" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-byte-offset" style="display:none">Info about the 'byte offset' definition.</span><b><a href="#pull-into-descriptor-byte-offset">#pull-into-descriptor-byte-offset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-byte-offset">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-pull-into-descriptor-byte-offset①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor-byte-offset②">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-byte-offset③">(2)</a> <a href="#ref-for-pull-into-descriptor-byte-offset④">(3)</a> <a href="#ref-for-pull-into-descriptor-byte-offset⑤">(4)</a> <a href="#ref-for-pull-into-descriptor-byte-offset⑥">(5)</a> <a href="#ref-for-pull-into-descriptor-byte-offset⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-byte-length">
-   <b><a href="#pull-into-descriptor-byte-length">#pull-into-descriptor-byte-length</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-byte-length" class="dfn-panel" data-for="pull-into-descriptor-byte-length" id="infopanel-for-pull-into-descriptor-byte-length" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-byte-length" style="display:none">Info about the 'byte length' definition.</span><b><a href="#pull-into-descriptor-byte-length">#pull-into-descriptor-byte-length</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-byte-length">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-pull-into-descriptor-byte-length①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor-byte-length②">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-byte-length③">(2)</a> <a href="#ref-for-pull-into-descriptor-byte-length④">(3)</a> <a href="#ref-for-pull-into-descriptor-byte-length⑤">(4)</a> <a href="#ref-for-pull-into-descriptor-byte-length⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-bytes-filled">
-   <b><a href="#pull-into-descriptor-bytes-filled">#pull-into-descriptor-bytes-filled</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-bytes-filled" class="dfn-panel" data-for="pull-into-descriptor-bytes-filled" id="infopanel-for-pull-into-descriptor-bytes-filled" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-bytes-filled" style="display:none">Info about the 'bytes filled' definition.</span><b><a href="#pull-into-descriptor-bytes-filled">#pull-into-descriptor-bytes-filled</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-bytes-filled">4.7.3. Methods and properties</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①">(2)</a>
     <li><a href="#ref-for-pull-into-descriptor-bytes-filled②">4.7.4. Internal methods</a> <a href="#ref-for-pull-into-descriptor-bytes-filled③">(2)</a>
     <li><a href="#ref-for-pull-into-descriptor-bytes-filled④">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-bytes-filled⑤">(2)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled⑥">(3)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled⑦">(4)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled⑧">(5)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled⑨">(6)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⓪">(7)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①①">(8)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①②">(9)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①③">(10)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①④">(11)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⑤">(12)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⑥">(13)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⑦">(14)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⑧">(15)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled①⑨">(16)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②⓪">(17)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②①">(18)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②②">(19)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②③">(20)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②④">(21)</a> <a href="#ref-for-pull-into-descriptor-bytes-filled②⑤">(22)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-element-size">
-   <b><a href="#pull-into-descriptor-element-size">#pull-into-descriptor-element-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-element-size" class="dfn-panel" data-for="pull-into-descriptor-element-size" id="infopanel-for-pull-into-descriptor-element-size" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-element-size" style="display:none">Info about the 'element size' definition.</span><b><a href="#pull-into-descriptor-element-size">#pull-into-descriptor-element-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-element-size">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor-element-size①">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-element-size②">(2)</a> <a href="#ref-for-pull-into-descriptor-element-size③">(3)</a> <a href="#ref-for-pull-into-descriptor-element-size④">(4)</a> <a href="#ref-for-pull-into-descriptor-element-size⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-view-constructor">
-   <b><a href="#pull-into-descriptor-view-constructor">#pull-into-descriptor-view-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-view-constructor" class="dfn-panel" data-for="pull-into-descriptor-view-constructor" id="infopanel-for-pull-into-descriptor-view-constructor" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-view-constructor" style="display:none">Info about the 'view constructor' definition.</span><b><a href="#pull-into-descriptor-view-constructor">#pull-into-descriptor-view-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-view-constructor">4.7.2. Internal slots</a>
     <li><a href="#ref-for-pull-into-descriptor-view-constructor①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor-view-constructor②">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-view-constructor③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pull-into-descriptor-reader-type">
-   <b><a href="#pull-into-descriptor-reader-type">#pull-into-descriptor-reader-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pull-into-descriptor-reader-type" class="dfn-panel" data-for="pull-into-descriptor-reader-type" id="infopanel-for-pull-into-descriptor-reader-type" role="dialog">
+   <span id="infopaneltitle-for-pull-into-descriptor-reader-type" style="display:none">Info about the 'reader type' definition.</span><b><a href="#pull-into-descriptor-reader-type">#pull-into-descriptor-reader-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pull-into-descriptor-reader-type">4.7.4. Internal methods</a>
     <li><a href="#ref-for-pull-into-descriptor-reader-type①">4.9.5. Byte stream controllers</a> <a href="#ref-for-pull-into-descriptor-reader-type②">(2)</a> <a href="#ref-for-pull-into-descriptor-reader-type③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rbs-controller-byob-request">
-   <b><a href="#rbs-controller-byob-request">#rbs-controller-byob-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rbs-controller-byob-request" class="dfn-panel" data-for="rbs-controller-byob-request" id="infopanel-for-rbs-controller-byob-request" role="dialog">
+   <span id="infopaneltitle-for-rbs-controller-byob-request" style="display:none">Info about the 'byobRequest' definition.</span><b><a href="#rbs-controller-byob-request">#rbs-controller-byob-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rbs-controller-byob-request">4.2.3. The underlying source API</a>
     <li><a href="#ref-for-rbs-controller-byob-request①">4.7.1. Interface definition</a>
     <li><a href="#ref-for-rbs-controller-byob-request②">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rbs-controller-desired-size">
-   <b><a href="#rbs-controller-desired-size">#rbs-controller-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rbs-controller-desired-size" class="dfn-panel" data-for="rbs-controller-desired-size" id="infopanel-for-rbs-controller-desired-size" role="dialog">
+   <span id="infopaneltitle-for-rbs-controller-desired-size" style="display:none">Info about the 'desiredSize' definition.</span><b><a href="#rbs-controller-desired-size">#rbs-controller-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rbs-controller-desired-size">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-rbs-controller-desired-size①">4.7.1. Interface definition</a>
@@ -12843,29 +12845,29 @@ create new readable streams</a> <a href="#ref-for-rs-pipe-to⑨">(2)</a>
 support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rbs-controller-close">
-   <b><a href="#rbs-controller-close">#rbs-controller-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rbs-controller-close" class="dfn-panel" data-for="rbs-controller-close" id="infopanel-for-rbs-controller-close" role="dialog">
+   <span id="infopaneltitle-for-rbs-controller-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#rbs-controller-close">#rbs-controller-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rbs-controller-close">4.7.1. Interface definition</a>
     <li><a href="#ref-for-rbs-controller-close①">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rbs-controller-enqueue">
-   <b><a href="#rbs-controller-enqueue">#rbs-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rbs-controller-enqueue" class="dfn-panel" data-for="rbs-controller-enqueue" id="infopanel-for-rbs-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-rbs-controller-enqueue" style="display:none">Info about the 'enqueue(chunk)' definition.</span><b><a href="#rbs-controller-enqueue">#rbs-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rbs-controller-enqueue">4.7.1. Interface definition</a>
     <li><a href="#ref-for-rbs-controller-enqueue①">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rbs-controller-error">
-   <b><a href="#rbs-controller-error">#rbs-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rbs-controller-error" class="dfn-panel" data-for="rbs-controller-error" id="infopanel-for-rbs-controller-error" role="dialog">
+   <span id="infopaneltitle-for-rbs-controller-error" style="display:none">Info about the 'error(e)' definition.</span><b><a href="#rbs-controller-error">#rbs-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rbs-controller-error">4.7.1. Interface definition</a>
     <li><a href="#ref-for-rbs-controller-error①">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreambyobrequest">
-   <b><a href="#readablestreambyobrequest">#readablestreambyobrequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreambyobrequest" class="dfn-panel" data-for="readablestreambyobrequest" id="infopanel-for-readablestreambyobrequest" role="dialog">
+   <span id="infopaneltitle-for-readablestreambyobrequest" style="display:none">Info about the 'ReadableStreamBYOBRequest' definition.</span><b><a href="#readablestreambyobrequest">#readablestreambyobrequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreambyobrequest">4.7.1. Interface definition</a>
     <li><a href="#ref-for-readablestreambyobrequest①">4.7.2. Internal slots</a>
@@ -12875,52 +12877,52 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readablestreambyobrequest⑥">4.8.2. Internal slots</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreambyobrequest-controller">
-   <b><a href="#readablestreambyobrequest-controller">#readablestreambyobrequest-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreambyobrequest-controller" class="dfn-panel" data-for="readablestreambyobrequest-controller" id="infopanel-for-readablestreambyobrequest-controller" role="dialog">
+   <span id="infopaneltitle-for-readablestreambyobrequest-controller" style="display:none">Info about the '[[controller]]' definition.</span><b><a href="#readablestreambyobrequest-controller">#readablestreambyobrequest-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreambyobrequest-controller">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-readablestreambyobrequest-controller①">4.8.3. Methods and properties</a> <a href="#ref-for-readablestreambyobrequest-controller②">(2)</a> <a href="#ref-for-readablestreambyobrequest-controller③">(3)</a> <a href="#ref-for-readablestreambyobrequest-controller④">(4)</a>
     <li><a href="#ref-for-readablestreambyobrequest-controller⑤">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestreambyobrequest-view">
-   <b><a href="#readablestreambyobrequest-view">#readablestreambyobrequest-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestreambyobrequest-view" class="dfn-panel" data-for="readablestreambyobrequest-view" id="infopanel-for-readablestreambyobrequest-view" role="dialog">
+   <span id="infopaneltitle-for-readablestreambyobrequest-view" style="display:none">Info about the '[[view]]' definition.</span><b><a href="#readablestreambyobrequest-view">#readablestreambyobrequest-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestreambyobrequest-view">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-readablestreambyobrequest-view①">4.8.3. Methods and properties</a> <a href="#ref-for-readablestreambyobrequest-view②">(2)</a> <a href="#ref-for-readablestreambyobrequest-view③">(3)</a> <a href="#ref-for-readablestreambyobrequest-view④">(4)</a>
     <li><a href="#ref-for-readablestreambyobrequest-view⑤">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-byob-request-view">
-   <b><a href="#rs-byob-request-view">#rs-byob-request-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-byob-request-view" class="dfn-panel" data-for="rs-byob-request-view" id="infopanel-for-rs-byob-request-view" role="dialog">
+   <span id="infopaneltitle-for-rs-byob-request-view" style="display:none">Info about the 'view' definition.</span><b><a href="#rs-byob-request-view">#rs-byob-request-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-byob-request-view">4.8.1. Interface definition</a>
     <li><a href="#ref-for-rs-byob-request-view①">4.8.3. Methods and properties</a> <a href="#ref-for-rs-byob-request-view②">(2)</a> <a href="#ref-for-rs-byob-request-view③">(3)</a> <a href="#ref-for-rs-byob-request-view④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-byob-request-respond">
-   <b><a href="#rs-byob-request-respond">#rs-byob-request-respond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-byob-request-respond" class="dfn-panel" data-for="rs-byob-request-respond" id="infopanel-for-rs-byob-request-respond" role="dialog">
+   <span id="infopaneltitle-for-rs-byob-request-respond" style="display:none">Info about the 'respond(bytesWritten)' definition.</span><b><a href="#rs-byob-request-respond">#rs-byob-request-respond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-byob-request-respond">4.8.1. Interface definition</a>
     <li><a href="#ref-for-rs-byob-request-respond①">4.8.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-byob-request-respond-with-new-view">
-   <b><a href="#rs-byob-request-respond-with-new-view">#rs-byob-request-respond-with-new-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-byob-request-respond-with-new-view" class="dfn-panel" data-for="rs-byob-request-respond-with-new-view" id="infopanel-for-rs-byob-request-respond-with-new-view" role="dialog">
+   <span id="infopaneltitle-for-rs-byob-request-respond-with-new-view" style="display:none">Info about the 'respondWithNewView(view)' definition.</span><b><a href="#rs-byob-request-respond-with-new-view">#rs-byob-request-respond-with-new-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-byob-request-respond-with-new-view">4.8.1. Interface definition</a>
     <li><a href="#ref-for-rs-byob-request-respond-with-new-view①">4.8.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acquire-readable-stream-byob-reader">
-   <b><a href="#acquire-readable-stream-byob-reader">#acquire-readable-stream-byob-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acquire-readable-stream-byob-reader" class="dfn-panel" data-for="acquire-readable-stream-byob-reader" id="infopanel-for-acquire-readable-stream-byob-reader" role="dialog">
+   <span id="infopaneltitle-for-acquire-readable-stream-byob-reader" style="display:none">Info about the 'AcquireReadableStreamBYOBReader(stream)' definition.</span><b><a href="#acquire-readable-stream-byob-reader">#acquire-readable-stream-byob-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acquire-readable-stream-byob-reader">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-acquire-readable-stream-byob-reader①">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acquire-readable-stream-reader">
-   <b><a href="#acquire-readable-stream-reader">#acquire-readable-stream-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acquire-readable-stream-reader" class="dfn-panel" data-for="acquire-readable-stream-reader" id="infopanel-for-acquire-readable-stream-reader" role="dialog">
+   <span id="infopaneltitle-for-acquire-readable-stream-reader" style="display:none">Info about the 'AcquireReadableStreamDefaultReader(stream)' definition.</span><b><a href="#acquire-readable-stream-reader">#acquire-readable-stream-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acquire-readable-stream-reader">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-acquire-readable-stream-reader①">4.2.5. Asynchronous iteration</a>
@@ -12928,15 +12930,16 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-acquire-readable-stream-reader⑤">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-readable-stream">
-   <b><a href="#create-readable-stream">#create-readable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-readable-stream" class="dfn-panel" data-for="create-readable-stream" id="infopanel-for-create-readable-stream" role="dialog">
+   <span id="infopaneltitle-for-create-readable-stream" style="display:none">Info about the 'CreateReadableStream(startAlgorithm, pullAlgorithm,
+ cancelAlgorithm[, highWaterMark, [, sizeAlgorithm]])' definition.</span><b><a href="#create-readable-stream">#create-readable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-readable-stream">4.9.1. Working with readable streams</a> <a href="#ref-for-create-readable-stream①">(2)</a>
     <li><a href="#ref-for-create-readable-stream②">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-readable-stream">
-   <b><a href="#initialize-readable-stream">#initialize-readable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-readable-stream" class="dfn-panel" data-for="initialize-readable-stream" id="infopanel-for-initialize-readable-stream" role="dialog">
+   <span id="infopaneltitle-for-initialize-readable-stream" style="display:none">Info about the 'InitializeReadableStream(stream)' definition.</span><b><a href="#initialize-readable-stream">#initialize-readable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-readable-stream">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-initialize-readable-stream①">4.9.1. Working with readable streams</a>
@@ -12944,8 +12947,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-initialize-readable-stream③">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-readable-stream-locked">
-   <b><a href="#is-readable-stream-locked">#is-readable-stream-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-readable-stream-locked" class="dfn-panel" data-for="is-readable-stream-locked" id="infopanel-for-is-readable-stream-locked" role="dialog">
+   <span id="infopaneltitle-for-is-readable-stream-locked" style="display:none">Info about the 'IsReadableStreamLocked(stream)' definition.</span><b><a href="#is-readable-stream-locked">#is-readable-stream-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-readable-stream-locked">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-is-readable-stream-locked①">(2)</a> <a href="#ref-for-is-readable-stream-locked②">(3)</a> <a href="#ref-for-is-readable-stream-locked③">(4)</a>
     <li><a href="#ref-for-is-readable-stream-locked④">4.2.6. Transfer via postMessage()</a>
@@ -12958,8 +12961,9 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-is-readable-stream-locked①③">9.5. Piping</a> <a href="#ref-for-is-readable-stream-locked①④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-pipe-to">
-   <b><a href="#readable-stream-pipe-to">#readable-stream-pipe-to</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-pipe-to" class="dfn-panel" data-for="readable-stream-pipe-to" id="infopanel-for-readable-stream-pipe-to" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-pipe-to" style="display:none">Info about the 'ReadableStreamPipeTo(source, dest, preventClose, preventAbort,
+ preventCancel[, signal])' definition.</span><b><a href="#readable-stream-pipe-to">#readable-stream-pipe-to</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-pipe-to">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-readable-stream-pipe-to①">(2)</a>
     <li><a href="#ref-for-readable-stream-pipe-to②">4.2.6. Transfer via postMessage()</a>
@@ -12967,62 +12971,64 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-pipe-to④">9.5. Piping</a> <a href="#ref-for-readable-stream-pipe-to⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-pipeTo-shutdown-with-action">
-   <b><a href="#rs-pipeTo-shutdown-with-action">#rs-pipeTo-shutdown-with-action</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-pipeTo-shutdown-with-action" class="dfn-panel" data-for="rs-pipeTo-shutdown-with-action" id="infopanel-for-rs-pipeTo-shutdown-with-action" role="dialog">
+   <span id="infopaneltitle-for-rs-pipeTo-shutdown-with-action" style="display:none">Info about the 'Shutdown with an action' definition.</span><b><a href="#rs-pipeTo-shutdown-with-action">#rs-pipeTo-shutdown-with-action</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipeTo-shutdown-with-action">4.9.1. Working with readable streams</a> <a href="#ref-for-rs-pipeTo-shutdown-with-action①">(2)</a> <a href="#ref-for-rs-pipeTo-shutdown-with-action②">(3)</a> <a href="#ref-for-rs-pipeTo-shutdown-with-action③">(4)</a> <a href="#ref-for-rs-pipeTo-shutdown-with-action④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-pipeTo-shutdown">
-   <b><a href="#rs-pipeTo-shutdown">#rs-pipeTo-shutdown</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-pipeTo-shutdown" class="dfn-panel" data-for="rs-pipeTo-shutdown" id="infopanel-for-rs-pipeTo-shutdown" role="dialog">
+   <span id="infopaneltitle-for-rs-pipeTo-shutdown" style="display:none">Info about the 'Shutdown' definition.</span><b><a href="#rs-pipeTo-shutdown">#rs-pipeTo-shutdown</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipeTo-shutdown">4.9.1. Working with readable streams</a> <a href="#ref-for-rs-pipeTo-shutdown①">(2)</a> <a href="#ref-for-rs-pipeTo-shutdown②">(3)</a> <a href="#ref-for-rs-pipeTo-shutdown③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-pipeTo-finalize">
-   <b><a href="#rs-pipeTo-finalize">#rs-pipeTo-finalize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-pipeTo-finalize" class="dfn-panel" data-for="rs-pipeTo-finalize" id="infopanel-for-rs-pipeTo-finalize" role="dialog">
+   <span id="infopaneltitle-for-rs-pipeTo-finalize" style="display:none">Info about the 'Finalize' definition.</span><b><a href="#rs-pipeTo-finalize">#rs-pipeTo-finalize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-pipeTo-finalize">4.9.1. Working with readable streams</a> <a href="#ref-for-rs-pipeTo-finalize①">(2)</a> <a href="#ref-for-rs-pipeTo-finalize②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-tee">
-   <b><a href="#readable-stream-tee">#readable-stream-tee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-tee" class="dfn-panel" data-for="readable-stream-tee" id="infopanel-for-readable-stream-tee" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-tee" style="display:none">Info about the 'ReadableStreamTee(stream,
+ cloneForBranch2)' definition.</span><b><a href="#readable-stream-tee">#readable-stream-tee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-tee">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-readable-stream-tee①">9.1.2. Reading</a> <a href="#ref-for-readable-stream-tee②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-readablestreamcontroller-cancelsteps">
-   <b><a href="#abstract-opdef-readablestreamcontroller-cancelsteps">#abstract-opdef-readablestreamcontroller-cancelsteps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-readablestreamcontroller-cancelsteps" class="dfn-panel" data-for="abstract-opdef-readablestreamcontroller-cancelsteps" id="infopanel-for-abstract-opdef-readablestreamcontroller-cancelsteps" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-readablestreamcontroller-cancelsteps" style="display:none">Info about the '[[CancelSteps]](reason)' definition.</span><b><a href="#abstract-opdef-readablestreamcontroller-cancelsteps">#abstract-opdef-readablestreamcontroller-cancelsteps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-cancelsteps">4.6.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-cancelsteps①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-cancelsteps②">4.9.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-readablestreamcontroller-pullsteps">
-   <b><a href="#abstract-opdef-readablestreamcontroller-pullsteps">#abstract-opdef-readablestreamcontroller-pullsteps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-readablestreamcontroller-pullsteps" class="dfn-panel" data-for="abstract-opdef-readablestreamcontroller-pullsteps" id="infopanel-for-abstract-opdef-readablestreamcontroller-pullsteps" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-readablestreamcontroller-pullsteps" style="display:none">Info about the '[[PullSteps]](readRequest)' definition.</span><b><a href="#abstract-opdef-readablestreamcontroller-pullsteps">#abstract-opdef-readablestreamcontroller-pullsteps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-pullsteps">4.6.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-pullsteps①">4.7.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-readablestreamcontroller-pullsteps②">4.9.3. Readers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-add-read-into-request">
-   <b><a href="#readable-stream-add-read-into-request">#readable-stream-add-read-into-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-add-read-into-request" class="dfn-panel" data-for="readable-stream-add-read-into-request" id="infopanel-for-readable-stream-add-read-into-request" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-add-read-into-request" style="display:none">Info about the 'ReadableStreamAddReadIntoRequest(stream,
+ readRequest)' definition.</span><b><a href="#readable-stream-add-read-into-request">#readable-stream-add-read-into-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-add-read-into-request">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-add-read-into-request①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-add-read-request">
-   <b><a href="#readable-stream-add-read-request">#readable-stream-add-read-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-add-read-request" class="dfn-panel" data-for="readable-stream-add-read-request" id="infopanel-for-readable-stream-add-read-request" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-add-read-request" style="display:none">Info about the 'ReadableStreamAddReadRequest(stream, readRequest' definition.</span><b><a href="#readable-stream-add-read-request">#readable-stream-add-read-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-add-read-request">4.6.4. Internal methods</a>
     <li><a href="#ref-for-readable-stream-add-read-request①">4.7.4. Internal methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-cancel">
-   <b><a href="#readable-stream-cancel">#readable-stream-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-cancel" class="dfn-panel" data-for="readable-stream-cancel" id="infopanel-for-readable-stream-cancel" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-cancel" style="display:none">Info about the 'ReadableStreamCancel(stream, reason)' definition.</span><b><a href="#readable-stream-cancel">#readable-stream-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-cancel">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-readable-stream-cancel①">4.9.1. Working with readable streams</a> <a href="#ref-for-readable-stream-cancel②">(2)</a> <a href="#ref-for-readable-stream-cancel③">(3)</a> <a href="#ref-for-readable-stream-cancel④">(4)</a> <a href="#ref-for-readable-stream-cancel⑤">(5)</a>
@@ -13030,8 +13036,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-cancel⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-close">
-   <b><a href="#readable-stream-close">#readable-stream-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-close" class="dfn-panel" data-for="readable-stream-close" id="infopanel-for-readable-stream-close" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-close" style="display:none">Info about the 'ReadableStreamClose(stream)' definition.</span><b><a href="#readable-stream-close">#readable-stream-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-close">4.6.4. Internal methods</a>
     <li><a href="#ref-for-readable-stream-close①">4.9.2. Interfacing with controllers</a>
@@ -13039,71 +13045,76 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-close③">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-close④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-error">
-   <b><a href="#readable-stream-error">#readable-stream-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-error" class="dfn-panel" data-for="readable-stream-error" id="infopanel-for-readable-stream-error" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-error" style="display:none">Info about the 'ReadableStreamError(stream,
+ e)' definition.</span><b><a href="#readable-stream-error">#readable-stream-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-error">4.9.4. Default controllers</a>
     <li><a href="#ref-for-readable-stream-error①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-fulfill-read-into-request">
-   <b><a href="#readable-stream-fulfill-read-into-request">#readable-stream-fulfill-read-into-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-fulfill-read-into-request" class="dfn-panel" data-for="readable-stream-fulfill-read-into-request" id="infopanel-for-readable-stream-fulfill-read-into-request" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-fulfill-read-into-request" style="display:none">Info about the 'ReadableStreamFulfillReadIntoRequest(stream,
+ chunk, done)' definition.</span><b><a href="#readable-stream-fulfill-read-into-request">#readable-stream-fulfill-read-into-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-fulfill-read-into-request">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-fulfill-read-request">
-   <b><a href="#readable-stream-fulfill-read-request">#readable-stream-fulfill-read-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-fulfill-read-request" class="dfn-panel" data-for="readable-stream-fulfill-read-request" id="infopanel-for-readable-stream-fulfill-read-request" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-fulfill-read-request" style="display:none">Info about the 'ReadableStreamFulfillReadRequest(stream, chunk,
+ done)' definition.</span><b><a href="#readable-stream-fulfill-read-request">#readable-stream-fulfill-read-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-fulfill-read-request">4.9.4. Default controllers</a>
     <li><a href="#ref-for-readable-stream-fulfill-read-request①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-fulfill-read-request②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-get-num-read-into-requests">
-   <b><a href="#readable-stream-get-num-read-into-requests">#readable-stream-get-num-read-into-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-get-num-read-into-requests" class="dfn-panel" data-for="readable-stream-get-num-read-into-requests" id="infopanel-for-readable-stream-get-num-read-into-requests" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-get-num-read-into-requests" style="display:none">Info about the 'ReadableStreamGetNumReadIntoRequests(stream)' definition.</span><b><a href="#readable-stream-get-num-read-into-requests">#readable-stream-get-num-read-into-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-get-num-read-into-requests">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-get-num-read-into-requests①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-get-num-read-requests">
-   <b><a href="#readable-stream-get-num-read-requests">#readable-stream-get-num-read-requests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-get-num-read-requests" class="dfn-panel" data-for="readable-stream-get-num-read-requests" id="infopanel-for-readable-stream-get-num-read-requests" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-get-num-read-requests" style="display:none">Info about the 'ReadableStreamGetNumReadRequests(stream)' definition.</span><b><a href="#readable-stream-get-num-read-requests">#readable-stream-get-num-read-requests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-get-num-read-requests">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-stream-get-num-read-requests①">4.9.4. Default controllers</a> <a href="#ref-for-readable-stream-get-num-read-requests②">(2)</a>
     <li><a href="#ref-for-readable-stream-get-num-read-requests③">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-get-num-read-requests④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-has-byob-reader">
-   <b><a href="#readable-stream-has-byob-reader">#readable-stream-has-byob-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-has-byob-reader" class="dfn-panel" data-for="readable-stream-has-byob-reader" id="infopanel-for-readable-stream-has-byob-reader" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-has-byob-reader" style="display:none">Info about the 'ReadableStreamHasBYOBReader(stream)' definition.</span><b><a href="#readable-stream-has-byob-reader">#readable-stream-has-byob-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-has-byob-reader">4.9.2. Interfacing with controllers</a> <a href="#ref-for-readable-stream-has-byob-reader①">(2)</a>
     <li><a href="#ref-for-readable-stream-has-byob-reader②">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-has-byob-reader③">(2)</a> <a href="#ref-for-readable-stream-has-byob-reader④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-has-default-reader">
-   <b><a href="#readable-stream-has-default-reader">#readable-stream-has-default-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-has-default-reader" class="dfn-panel" data-for="readable-stream-has-default-reader" id="infopanel-for-readable-stream-has-default-reader" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-has-default-reader" style="display:none">Info about the 'ReadableStreamHasDefaultReader(stream)' definition.</span><b><a href="#readable-stream-has-default-reader">#readable-stream-has-default-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-has-default-reader">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-stream-has-default-reader①">4.9.2. Interfacing with controllers</a> <a href="#ref-for-readable-stream-has-default-reader②">(2)</a>
     <li><a href="#ref-for-readable-stream-has-default-reader③">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-stream-has-default-reader④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-reader-generic-cancel">
-   <b><a href="#readable-stream-reader-generic-cancel">#readable-stream-reader-generic-cancel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-reader-generic-cancel" class="dfn-panel" data-for="readable-stream-reader-generic-cancel" id="infopanel-for-readable-stream-reader-generic-cancel" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-reader-generic-cancel" style="display:none">Info about the 'ReadableStreamReaderGenericCancel(reader,
+ reason)' definition.</span><b><a href="#readable-stream-reader-generic-cancel">#readable-stream-reader-generic-cancel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-reader-generic-cancel">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-readable-stream-reader-generic-cancel①">4.3.3. Methods and properties</a>
     <li><a href="#ref-for-readable-stream-reader-generic-cancel②">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-reader-generic-initialize">
-   <b><a href="#readable-stream-reader-generic-initialize">#readable-stream-reader-generic-initialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-reader-generic-initialize" class="dfn-panel" data-for="readable-stream-reader-generic-initialize" id="infopanel-for-readable-stream-reader-generic-initialize" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-reader-generic-initialize" style="display:none">Info about the 'ReadableStreamReaderGenericInitialize(reader,
+ stream)' definition.</span><b><a href="#readable-stream-reader-generic-initialize">#readable-stream-reader-generic-initialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-reader-generic-initialize">4.9.3. Readers</a> <a href="#ref-for-readable-stream-reader-generic-initialize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-reader-generic-release">
-   <b><a href="#readable-stream-reader-generic-release">#readable-stream-reader-generic-release</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-reader-generic-release" class="dfn-panel" data-for="readable-stream-reader-generic-release" id="infopanel-for-readable-stream-reader-generic-release" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-reader-generic-release" style="display:none">Info about the 'ReadableStreamReaderGenericRelease(reader)' definition.</span><b><a href="#readable-stream-reader-generic-release">#readable-stream-reader-generic-release</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-reader-generic-release">4.2.5. Asynchronous iteration</a> <a href="#ref-for-readable-stream-reader-generic-release①">(2)</a> <a href="#ref-for-readable-stream-reader-generic-release②">(3)</a> <a href="#ref-for-readable-stream-reader-generic-release③">(4)</a>
     <li><a href="#ref-for-readable-stream-reader-generic-release④">4.4.3. Constructor, methods, and properties</a>
@@ -13112,14 +13123,16 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-reader-generic-release⑦">9.1.2. Reading</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-byob-reader-read">
-   <b><a href="#readable-stream-byob-reader-read">#readable-stream-byob-reader-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-byob-reader-read" class="dfn-panel" data-for="readable-stream-byob-reader-read" id="infopanel-for-readable-stream-byob-reader-read" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-byob-reader-read" style="display:none">Info about the 'ReadableStreamBYOBReaderRead(reader, view,
+ readIntoRequest)' definition.</span><b><a href="#readable-stream-byob-reader-read">#readable-stream-byob-reader-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-byob-reader-read">4.5.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-reader-read">
-   <b><a href="#readable-stream-default-reader-read">#readable-stream-default-reader-read</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-reader-read" class="dfn-panel" data-for="readable-stream-default-reader-read" id="infopanel-for-readable-stream-default-reader-read" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-reader-read" style="display:none">Info about the 'ReadableStreamDefaultReaderRead(reader,
+ readRequest)' definition.</span><b><a href="#readable-stream-default-reader-read">#readable-stream-default-reader-read</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-reader-read">4.2.5. Asynchronous iteration</a>
     <li><a href="#ref-for-readable-stream-default-reader-read①">4.4.3. Constructor, methods, and properties</a>
@@ -13127,42 +13140,43 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-default-reader-read③">9.1.2. Reading</a> <a href="#ref-for-readable-stream-default-reader-read④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-stream-byob-reader">
-   <b><a href="#set-up-readable-stream-byob-reader">#set-up-readable-stream-byob-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-stream-byob-reader" class="dfn-panel" data-for="set-up-readable-stream-byob-reader" id="infopanel-for-set-up-readable-stream-byob-reader" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-stream-byob-reader" style="display:none">Info about the 'SetUpReadableStreamBYOBReader(reader, stream)' definition.</span><b><a href="#set-up-readable-stream-byob-reader">#set-up-readable-stream-byob-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-stream-byob-reader">4.5.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-set-up-readable-stream-byob-reader①">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-stream-default-reader">
-   <b><a href="#set-up-readable-stream-default-reader">#set-up-readable-stream-default-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-stream-default-reader" class="dfn-panel" data-for="set-up-readable-stream-default-reader" id="infopanel-for-set-up-readable-stream-default-reader" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-stream-default-reader" style="display:none">Info about the 'SetUpReadableStreamDefaultReader(reader,
+ stream)' definition.</span><b><a href="#set-up-readable-stream-default-reader">#set-up-readable-stream-default-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-stream-default-reader">4.4.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-set-up-readable-stream-default-reader①">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-call-pull-if-needed">
-   <b><a href="#readable-stream-default-controller-call-pull-if-needed">#readable-stream-default-controller-call-pull-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-call-pull-if-needed" class="dfn-panel" data-for="readable-stream-default-controller-call-pull-if-needed" id="infopanel-for-readable-stream-default-controller-call-pull-if-needed" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-call-pull-if-needed" style="display:none">Info about the 'ReadableStreamDefaultControllerCallPullIfNeeded(controller)' definition.</span><b><a href="#readable-stream-default-controller-call-pull-if-needed">#readable-stream-default-controller-call-pull-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-call-pull-if-needed">4.6.4. Internal methods</a> <a href="#ref-for-readable-stream-default-controller-call-pull-if-needed①">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-call-pull-if-needed②">4.9.4. Default controllers</a> <a href="#ref-for-readable-stream-default-controller-call-pull-if-needed③">(2)</a> <a href="#ref-for-readable-stream-default-controller-call-pull-if-needed④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-should-call-pull">
-   <b><a href="#readable-stream-default-controller-should-call-pull">#readable-stream-default-controller-should-call-pull</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-should-call-pull" class="dfn-panel" data-for="readable-stream-default-controller-should-call-pull" id="infopanel-for-readable-stream-default-controller-should-call-pull" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-should-call-pull" style="display:none">Info about the 'ReadableStreamDefaultControllerShouldCallPull(controller)' definition.</span><b><a href="#readable-stream-default-controller-should-call-pull">#readable-stream-default-controller-should-call-pull</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-should-call-pull">4.9.4. Default controllers</a> <a href="#ref-for-readable-stream-default-controller-should-call-pull①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-clear-algorithms">
-   <b><a href="#readable-stream-default-controller-clear-algorithms">#readable-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-clear-algorithms" class="dfn-panel" data-for="readable-stream-default-controller-clear-algorithms" id="infopanel-for-readable-stream-default-controller-clear-algorithms" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-clear-algorithms" style="display:none">Info about the 'ReadableStreamDefaultControllerClearAlgorithms(controller)' definition.</span><b><a href="#readable-stream-default-controller-clear-algorithms">#readable-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-clear-algorithms">4.6.4. Internal methods</a> <a href="#ref-for-readable-stream-default-controller-clear-algorithms①">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-clear-algorithms②">4.9.4. Default controllers</a> <a href="#ref-for-readable-stream-default-controller-clear-algorithms③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-close">
-   <b><a href="#readable-stream-default-controller-close">#readable-stream-default-controller-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-close" class="dfn-panel" data-for="readable-stream-default-controller-close" id="infopanel-for-readable-stream-default-controller-close" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-close" style="display:none">Info about the 'ReadableStreamDefaultControllerClose(controller)' definition.</span><b><a href="#readable-stream-default-controller-close">#readable-stream-default-controller-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-close">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-readable-stream-default-controller-close①">4.9.1. Working with readable streams</a> <a href="#ref-for-readable-stream-default-controller-close②">(2)</a>
@@ -13172,8 +13186,9 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-close⑥">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-enqueue">
-   <b><a href="#readable-stream-default-controller-enqueue">#readable-stream-default-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-enqueue" class="dfn-panel" data-for="readable-stream-default-controller-enqueue" id="infopanel-for-readable-stream-default-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-enqueue" style="display:none">Info about the 'ReadableStreamDefaultControllerEnqueue(controller,
+ chunk)' definition.</span><b><a href="#readable-stream-default-controller-enqueue">#readable-stream-default-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-enqueue">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-readable-stream-default-controller-enqueue①">4.9.1. Working with readable streams</a> <a href="#ref-for-readable-stream-default-controller-enqueue②">(2)</a>
@@ -13182,8 +13197,9 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-enqueue⑤">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-error">
-   <b><a href="#readable-stream-default-controller-error">#readable-stream-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-error" class="dfn-panel" data-for="readable-stream-default-controller-error" id="infopanel-for-readable-stream-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-error" style="display:none">Info about the 'ReadableStreamDefaultControllerError(controller,
+ e)' definition.</span><b><a href="#readable-stream-default-controller-error">#readable-stream-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-error">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-readable-stream-default-controller-error①">4.9.1. Working with readable streams</a> <a href="#ref-for-readable-stream-default-controller-error②">(2)</a>
@@ -13193,8 +13209,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-error①⓪">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-get-desired-size">
-   <b><a href="#readable-stream-default-controller-get-desired-size">#readable-stream-default-controller-get-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-get-desired-size" class="dfn-panel" data-for="readable-stream-default-controller-get-desired-size" id="infopanel-for-readable-stream-default-controller-get-desired-size" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-get-desired-size" style="display:none">Info about the 'ReadableStreamDefaultControllerGetDesiredSize(controller)' definition.</span><b><a href="#readable-stream-default-controller-get-desired-size">#readable-stream-default-controller-get-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-get-desired-size">4.6.3. Methods and properties</a>
     <li><a href="#ref-for-readable-stream-default-controller-get-desired-size①">4.9.4. Default controllers</a>
@@ -13202,22 +13218,24 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-get-desired-size③">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="rs-default-controller-has-backpressure">
-   <b><a href="#rs-default-controller-has-backpressure">#rs-default-controller-has-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-rs-default-controller-has-backpressure" class="dfn-panel" data-for="rs-default-controller-has-backpressure" id="infopanel-for-rs-default-controller-has-backpressure" role="dialog">
+   <span id="infopaneltitle-for-rs-default-controller-has-backpressure" style="display:none">Info about the 'ReadableStreamDefaultControllerHasBackpressure(controller)' definition.</span><b><a href="#rs-default-controller-has-backpressure">#rs-default-controller-has-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-rs-default-controller-has-backpressure">6.4.2. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-stream-default-controller-can-close-or-enqueue">
-   <b><a href="#readable-stream-default-controller-can-close-or-enqueue">#readable-stream-default-controller-can-close-or-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-stream-default-controller-can-close-or-enqueue" class="dfn-panel" data-for="readable-stream-default-controller-can-close-or-enqueue" id="infopanel-for-readable-stream-default-controller-can-close-or-enqueue" role="dialog">
+   <span id="infopaneltitle-for-readable-stream-default-controller-can-close-or-enqueue" style="display:none">Info about the 'ReadableStreamDefaultControllerCanCloseOrEnqueue(controller)' definition.</span><b><a href="#readable-stream-default-controller-can-close-or-enqueue">#readable-stream-default-controller-can-close-or-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue">4.6.3. Methods and properties</a> <a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue①">(2)</a>
     <li><a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue②">4.9.4. Default controllers</a> <a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue③">(2)</a> <a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue④">(3)</a>
     <li><a href="#ref-for-readable-stream-default-controller-can-close-or-enqueue⑤">6.4.2. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-stream-default-controller">
-   <b><a href="#set-up-readable-stream-default-controller">#set-up-readable-stream-default-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-stream-default-controller" class="dfn-panel" data-for="set-up-readable-stream-default-controller" id="infopanel-for-set-up-readable-stream-default-controller" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-stream-default-controller" style="display:none">Info about the 'SetUpReadableStreamDefaultController(stream,
+ controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark,
+ sizeAlgorithm)' definition.</span><b><a href="#set-up-readable-stream-default-controller">#set-up-readable-stream-default-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-stream-default-controller">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-set-up-readable-stream-default-controller①">4.9.4. Default controllers</a>
@@ -13225,169 +13243,185 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-set-up-readable-stream-default-controller③">9.1.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-stream-default-controller-from-underlying-source">
-   <b><a href="#set-up-readable-stream-default-controller-from-underlying-source">#set-up-readable-stream-default-controller-from-underlying-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-stream-default-controller-from-underlying-source" class="dfn-panel" data-for="set-up-readable-stream-default-controller-from-underlying-source" id="infopanel-for-set-up-readable-stream-default-controller-from-underlying-source" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-stream-default-controller-from-underlying-source" style="display:none">Info about the 'SetUpReadableStreamDefaultControllerFromUnderlyingSource(stream,
+ controller, underlyingSource, underlyingSourceDict, highWaterMark, sizeAlgorithm)' definition.</span><b><a href="#set-up-readable-stream-default-controller-from-underlying-source">#set-up-readable-stream-default-controller-from-underlying-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-stream-default-controller-from-underlying-source">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-call-pull-if-needed">
-   <b><a href="#readable-byte-stream-controller-call-pull-if-needed">#readable-byte-stream-controller-call-pull-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-call-pull-if-needed" class="dfn-panel" data-for="readable-byte-stream-controller-call-pull-if-needed" id="infopanel-for-readable-byte-stream-controller-call-pull-if-needed" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-call-pull-if-needed" style="display:none">Info about the 'ReadableByteStreamControllerCallPullIfNeeded(controller)' definition.</span><b><a href="#readable-byte-stream-controller-call-pull-if-needed">#readable-byte-stream-controller-call-pull-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed②">(2)</a> <a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed③">(3)</a> <a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed④">(4)</a> <a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed⑤">(5)</a> <a href="#ref-for-readable-byte-stream-controller-call-pull-if-needed⑥">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-clear-algorithms">
-   <b><a href="#readable-byte-stream-controller-clear-algorithms">#readable-byte-stream-controller-clear-algorithms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-clear-algorithms" class="dfn-panel" data-for="readable-byte-stream-controller-clear-algorithms" id="infopanel-for-readable-byte-stream-controller-clear-algorithms" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-clear-algorithms" style="display:none">Info about the 'ReadableByteStreamControllerClearAlgorithms(controller)' definition.</span><b><a href="#readable-byte-stream-controller-clear-algorithms">#readable-byte-stream-controller-clear-algorithms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-clear-algorithms">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-byte-stream-controller-clear-algorithms①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-clear-algorithms②">(2)</a> <a href="#ref-for-readable-byte-stream-controller-clear-algorithms③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-clear-pending-pull-intos">
-   <b><a href="#readable-byte-stream-controller-clear-pending-pull-intos">#readable-byte-stream-controller-clear-pending-pull-intos</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-clear-pending-pull-intos" class="dfn-panel" data-for="readable-byte-stream-controller-clear-pending-pull-intos" id="infopanel-for-readable-byte-stream-controller-clear-pending-pull-intos" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-clear-pending-pull-intos" style="display:none">Info about the 'ReadableByteStreamControllerClearPendingPullIntos(controller)' definition.</span><b><a href="#readable-byte-stream-controller-clear-pending-pull-intos">#readable-byte-stream-controller-clear-pending-pull-intos</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-clear-pending-pull-intos">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-close">
-   <b><a href="#readable-byte-stream-controller-close">#readable-byte-stream-controller-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-close" class="dfn-panel" data-for="readable-byte-stream-controller-close" id="infopanel-for-readable-byte-stream-controller-close" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-close" style="display:none">Info about the 'ReadableByteStreamControllerClose(controller)' definition.</span><b><a href="#readable-byte-stream-controller-close">#readable-byte-stream-controller-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-close">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-commit-pull-into-descriptor">
-   <b><a href="#readable-byte-stream-controller-commit-pull-into-descriptor">#readable-byte-stream-controller-commit-pull-into-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-commit-pull-into-descriptor" class="dfn-panel" data-for="readable-byte-stream-controller-commit-pull-into-descriptor" id="infopanel-for-readable-byte-stream-controller-commit-pull-into-descriptor" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-commit-pull-into-descriptor" style="display:none">Info about the 'ReadableByteStreamControllerCommitPullIntoDescriptor(stream,
+ pullIntoDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-commit-pull-into-descriptor">#readable-byte-stream-controller-commit-pull-into-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-commit-pull-into-descriptor">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-commit-pull-into-descriptor①">(2)</a> <a href="#ref-for-readable-byte-stream-controller-commit-pull-into-descriptor②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-convert-pull-into-descriptor">
-   <b><a href="#readable-byte-stream-controller-convert-pull-into-descriptor">#readable-byte-stream-controller-convert-pull-into-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-convert-pull-into-descriptor" class="dfn-panel" data-for="readable-byte-stream-controller-convert-pull-into-descriptor" id="infopanel-for-readable-byte-stream-controller-convert-pull-into-descriptor" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-convert-pull-into-descriptor" style="display:none">Info about the 'ReadableByteStreamControllerConvertPullIntoDescriptor(pullIntoDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-convert-pull-into-descriptor">#readable-byte-stream-controller-convert-pull-into-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-convert-pull-into-descriptor">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-convert-pull-into-descriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-enqueue">
-   <b><a href="#readable-byte-stream-controller-enqueue">#readable-byte-stream-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-enqueue" class="dfn-panel" data-for="readable-byte-stream-controller-enqueue" id="infopanel-for-readable-byte-stream-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-enqueue" style="display:none">Info about the 'ReadableByteStreamControllerEnqueue(controller,
+ chunk)' definition.</span><b><a href="#readable-byte-stream-controller-enqueue">#readable-byte-stream-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-enqueue">4.7.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-enqueue-chunk-to-queue">
-   <b><a href="#readable-byte-stream-controller-enqueue-chunk-to-queue">#readable-byte-stream-controller-enqueue-chunk-to-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-enqueue-chunk-to-queue" class="dfn-panel" data-for="readable-byte-stream-controller-enqueue-chunk-to-queue" id="infopanel-for-readable-byte-stream-controller-enqueue-chunk-to-queue" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-enqueue-chunk-to-queue" style="display:none">Info about the 'ReadableByteStreamControllerEnqueueChunkToQueue(controller,
+ buffer, byteOffset, byteLength)' definition.</span><b><a href="#readable-byte-stream-controller-enqueue-chunk-to-queue">#readable-byte-stream-controller-enqueue-chunk-to-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-enqueue-chunk-to-queue">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-enqueue-chunk-to-queue①">(2)</a> <a href="#ref-for-readable-byte-stream-controller-enqueue-chunk-to-queue②">(3)</a> <a href="#ref-for-readable-byte-stream-controller-enqueue-chunk-to-queue③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-error">
-   <b><a href="#readable-byte-stream-controller-error">#readable-byte-stream-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-error" class="dfn-panel" data-for="readable-byte-stream-controller-error" id="infopanel-for-readable-byte-stream-controller-error" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-error" style="display:none">Info about the 'ReadableByteStreamControllerError(controller,
+ e)' definition.</span><b><a href="#readable-byte-stream-controller-error">#readable-byte-stream-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-error">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-readable-byte-stream-controller-error①">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-error②">(2)</a> <a href="#ref-for-readable-byte-stream-controller-error③">(3)</a> <a href="#ref-for-readable-byte-stream-controller-error④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-fill-head-pull-into-descriptor">
-   <b><a href="#readable-byte-stream-controller-fill-head-pull-into-descriptor">#readable-byte-stream-controller-fill-head-pull-into-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-fill-head-pull-into-descriptor" class="dfn-panel" data-for="readable-byte-stream-controller-fill-head-pull-into-descriptor" id="infopanel-for-readable-byte-stream-controller-fill-head-pull-into-descriptor" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-fill-head-pull-into-descriptor" style="display:none">Info about the 'ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller,
+ size, pullIntoDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-fill-head-pull-into-descriptor">#readable-byte-stream-controller-fill-head-pull-into-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-fill-head-pull-into-descriptor">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-fill-head-pull-into-descriptor①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">
-   <b><a href="#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-fill-pull-into-descriptor-from-queue" class="dfn-panel" data-for="readable-byte-stream-controller-fill-pull-into-descriptor-from-queue" id="infopanel-for-readable-byte-stream-controller-fill-pull-into-descriptor-from-queue" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-fill-pull-into-descriptor-from-queue" style="display:none">Info about the 'ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller,
+ pullIntoDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">#readable-byte-stream-controller-fill-pull-into-descriptor-from-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-fill-pull-into-descriptor-from-queue">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-fill-pull-into-descriptor-from-queue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-get-desired-size">
-   <b><a href="#readable-byte-stream-controller-get-desired-size">#readable-byte-stream-controller-get-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-get-desired-size" class="dfn-panel" data-for="readable-byte-stream-controller-get-desired-size" id="infopanel-for-readable-byte-stream-controller-get-desired-size" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-get-desired-size" style="display:none">Info about the 'ReadableByteStreamControllerGetDesiredSize(controller)' definition.</span><b><a href="#readable-byte-stream-controller-get-desired-size">#readable-byte-stream-controller-get-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-get-desired-size">4.7.3. Methods and properties</a>
     <li><a href="#ref-for-readable-byte-stream-controller-get-desired-size①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-handle-queue-drain">
-   <b><a href="#readable-byte-stream-controller-handle-queue-drain">#readable-byte-stream-controller-handle-queue-drain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-handle-queue-drain" class="dfn-panel" data-for="readable-byte-stream-controller-handle-queue-drain" id="infopanel-for-readable-byte-stream-controller-handle-queue-drain" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-handle-queue-drain" style="display:none">Info about the 'ReadableByteStreamControllerHandleQueueDrain(controller)' definition.</span><b><a href="#readable-byte-stream-controller-handle-queue-drain">#readable-byte-stream-controller-handle-queue-drain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-handle-queue-drain">4.7.4. Internal methods</a>
     <li><a href="#ref-for-readable-byte-stream-controller-handle-queue-drain①">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-invalidate-byob-request">
-   <b><a href="#readable-byte-stream-controller-invalidate-byob-request">#readable-byte-stream-controller-invalidate-byob-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-invalidate-byob-request" class="dfn-panel" data-for="readable-byte-stream-controller-invalidate-byob-request" id="infopanel-for-readable-byte-stream-controller-invalidate-byob-request" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-invalidate-byob-request" style="display:none">Info about the 'ReadableByteStreamControllerInvalidateBYOBRequest(controller)' definition.</span><b><a href="#readable-byte-stream-controller-invalidate-byob-request">#readable-byte-stream-controller-invalidate-byob-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-invalidate-byob-request">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-invalidate-byob-request①">(2)</a> <a href="#ref-for-readable-byte-stream-controller-invalidate-byob-request②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-process-pull-into-descriptors-using-queue">
-   <b><a href="#readable-byte-stream-controller-process-pull-into-descriptors-using-queue">#readable-byte-stream-controller-process-pull-into-descriptors-using-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-process-pull-into-descriptors-using-queue" class="dfn-panel" data-for="readable-byte-stream-controller-process-pull-into-descriptors-using-queue" id="infopanel-for-readable-byte-stream-controller-process-pull-into-descriptors-using-queue" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-process-pull-into-descriptors-using-queue" style="display:none">Info about the 'ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller)' definition.</span><b><a href="#readable-byte-stream-controller-process-pull-into-descriptors-using-queue">#readable-byte-stream-controller-process-pull-into-descriptors-using-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-process-pull-into-descriptors-using-queue">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-process-pull-into-descriptors-using-queue①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-pull-into">
-   <b><a href="#readable-byte-stream-controller-pull-into">#readable-byte-stream-controller-pull-into</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-pull-into" class="dfn-panel" data-for="readable-byte-stream-controller-pull-into" id="infopanel-for-readable-byte-stream-controller-pull-into" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-pull-into" style="display:none">Info about the 'ReadableByteStreamControllerPullInto(controller,
+ view, readIntoRequest)' definition.</span><b><a href="#readable-byte-stream-controller-pull-into">#readable-byte-stream-controller-pull-into</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-pull-into">4.9.3. Readers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-respond">
-   <b><a href="#readable-byte-stream-controller-respond">#readable-byte-stream-controller-respond</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-respond" class="dfn-panel" data-for="readable-byte-stream-controller-respond" id="infopanel-for-readable-byte-stream-controller-respond" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-respond" style="display:none">Info about the 'ReadableByteStreamControllerRespond(controller,
+ bytesWritten)' definition.</span><b><a href="#readable-byte-stream-controller-respond">#readable-byte-stream-controller-respond</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-respond">4.8.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-respond-in-closed-state">
-   <b><a href="#readable-byte-stream-controller-respond-in-closed-state">#readable-byte-stream-controller-respond-in-closed-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-respond-in-closed-state" class="dfn-panel" data-for="readable-byte-stream-controller-respond-in-closed-state" id="infopanel-for-readable-byte-stream-controller-respond-in-closed-state" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-respond-in-closed-state" style="display:none">Info about the 'ReadableByteStreamControllerRespondInClosedState(controller,
+ firstDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-respond-in-closed-state">#readable-byte-stream-controller-respond-in-closed-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-respond-in-closed-state">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-respond-in-readable-state">
-   <b><a href="#readable-byte-stream-controller-respond-in-readable-state">#readable-byte-stream-controller-respond-in-readable-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-respond-in-readable-state" class="dfn-panel" data-for="readable-byte-stream-controller-respond-in-readable-state" id="infopanel-for-readable-byte-stream-controller-respond-in-readable-state" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-respond-in-readable-state" style="display:none">Info about the 'ReadableByteStreamControllerRespondInReadableState(controller,
+ bytesWritten, pullIntoDescriptor)' definition.</span><b><a href="#readable-byte-stream-controller-respond-in-readable-state">#readable-byte-stream-controller-respond-in-readable-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-respond-in-readable-state">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-respond-internal">
-   <b><a href="#readable-byte-stream-controller-respond-internal">#readable-byte-stream-controller-respond-internal</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-respond-internal" class="dfn-panel" data-for="readable-byte-stream-controller-respond-internal" id="infopanel-for-readable-byte-stream-controller-respond-internal" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-respond-internal" style="display:none">Info about the 'ReadableByteStreamControllerRespondInternal(controller,
+ bytesWritten)' definition.</span><b><a href="#readable-byte-stream-controller-respond-internal">#readable-byte-stream-controller-respond-internal</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-respond-internal">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-respond-internal①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-respond-with-new-view">
-   <b><a href="#readable-byte-stream-controller-respond-with-new-view">#readable-byte-stream-controller-respond-with-new-view</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-respond-with-new-view" class="dfn-panel" data-for="readable-byte-stream-controller-respond-with-new-view" id="infopanel-for-readable-byte-stream-controller-respond-with-new-view" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-respond-with-new-view" style="display:none">Info about the 'ReadableByteStreamControllerRespondWithNewView(controller,
+ view)' definition.</span><b><a href="#readable-byte-stream-controller-respond-with-new-view">#readable-byte-stream-controller-respond-with-new-view</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-respond-with-new-view">4.8.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-shift-pending-pull-into">
-   <b><a href="#readable-byte-stream-controller-shift-pending-pull-into">#readable-byte-stream-controller-shift-pending-pull-into</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-shift-pending-pull-into" class="dfn-panel" data-for="readable-byte-stream-controller-shift-pending-pull-into" id="infopanel-for-readable-byte-stream-controller-shift-pending-pull-into" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-shift-pending-pull-into" style="display:none">Info about the 'ReadableByteStreamControllerShiftPendingPullInto(controller)' definition.</span><b><a href="#readable-byte-stream-controller-shift-pending-pull-into">#readable-byte-stream-controller-shift-pending-pull-into</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-shift-pending-pull-into">4.9.5. Byte stream controllers</a> <a href="#ref-for-readable-byte-stream-controller-shift-pending-pull-into①">(2)</a> <a href="#ref-for-readable-byte-stream-controller-shift-pending-pull-into②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readable-byte-stream-controller-should-call-pull">
-   <b><a href="#readable-byte-stream-controller-should-call-pull">#readable-byte-stream-controller-should-call-pull</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readable-byte-stream-controller-should-call-pull" class="dfn-panel" data-for="readable-byte-stream-controller-should-call-pull" id="infopanel-for-readable-byte-stream-controller-should-call-pull" role="dialog">
+   <span id="infopaneltitle-for-readable-byte-stream-controller-should-call-pull" style="display:none">Info about the 'ReadableByteStreamControllerShouldCallPull(controller)' definition.</span><b><a href="#readable-byte-stream-controller-should-call-pull">#readable-byte-stream-controller-should-call-pull</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readable-byte-stream-controller-should-call-pull">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-byte-stream-controller">
-   <b><a href="#set-up-readable-byte-stream-controller">#set-up-readable-byte-stream-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-byte-stream-controller" class="dfn-panel" data-for="set-up-readable-byte-stream-controller" id="infopanel-for-set-up-readable-byte-stream-controller" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-byte-stream-controller" style="display:none">Info about the 'SetUpReadableByteStreamController(stream,
+ controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark,
+ autoAllocateChunkSize)' definition.</span><b><a href="#set-up-readable-byte-stream-controller">#set-up-readable-byte-stream-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-byte-stream-controller">4.9.5. Byte stream controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-readable-byte-stream-controller-from-underlying-source">
-   <b><a href="#set-up-readable-byte-stream-controller-from-underlying-source">#set-up-readable-byte-stream-controller-from-underlying-source</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-readable-byte-stream-controller-from-underlying-source" class="dfn-panel" data-for="set-up-readable-byte-stream-controller-from-underlying-source" id="infopanel-for-set-up-readable-byte-stream-controller-from-underlying-source" role="dialog">
+   <span id="infopaneltitle-for-set-up-readable-byte-stream-controller-from-underlying-source" style="display:none">Info about the 'SetUpReadableByteStreamControllerFromUnderlyingSource(stream,
+ underlyingSource, underlyingSourceDict, highWaterMark)' definition.</span><b><a href="#set-up-readable-byte-stream-controller-from-underlying-source">#set-up-readable-byte-stream-controller-from-underlying-source</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-readable-byte-stream-controller-from-underlying-source">4.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream">
-   <b><a href="#writablestream">#writablestream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream" class="dfn-panel" data-for="writablestream" id="infopanel-for-writablestream" role="dialog">
+   <span id="infopaneltitle-for-writablestream" style="display:none">Info about the 'WritableStream' definition.</span><b><a href="#writablestream">#writablestream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream">2.2. Writable streams</a>
     <li><a href="#ref-for-writablestream①">4.2.1. Interface definition</a> <a href="#ref-for-writablestream②">(2)</a>
@@ -13419,23 +13453,23 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream④③">10. Examples of creating streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-backpressure">
-   <b><a href="#writablestream-backpressure">#writablestream-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-backpressure" class="dfn-panel" data-for="writablestream-backpressure" id="infopanel-for-writablestream-backpressure" role="dialog">
+   <span id="infopaneltitle-for-writablestream-backpressure" style="display:none">Info about the '[[backpressure]]' definition.</span><b><a href="#writablestream-backpressure">#writablestream-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-backpressure">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-backpressure①">(2)</a> <a href="#ref-for-writablestream-backpressure②">(3)</a>
     <li><a href="#ref-for-writablestream-backpressure③">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-backpressure④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-closerequest">
-   <b><a href="#writablestream-closerequest">#writablestream-closerequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-closerequest" class="dfn-panel" data-for="writablestream-closerequest" id="infopanel-for-writablestream-closerequest" role="dialog">
+   <span id="infopaneltitle-for-writablestream-closerequest" style="display:none">Info about the '[[closeRequest]]' definition.</span><b><a href="#writablestream-closerequest">#writablestream-closerequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-closerequest">5.2.2. Internal slots</a>
     <li><a href="#ref-for-writablestream-closerequest①">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-closerequest②">(2)</a>
     <li><a href="#ref-for-writablestream-closerequest③">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-closerequest④">(2)</a> <a href="#ref-for-writablestream-closerequest⑤">(3)</a> <a href="#ref-for-writablestream-closerequest⑥">(4)</a> <a href="#ref-for-writablestream-closerequest⑦">(5)</a> <a href="#ref-for-writablestream-closerequest⑧">(6)</a> <a href="#ref-for-writablestream-closerequest⑨">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-controller">
-   <b><a href="#writablestream-controller">#writablestream-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-controller" class="dfn-panel" data-for="writablestream-controller" id="infopanel-for-writablestream-controller" role="dialog">
+   <span id="infopaneltitle-for-writablestream-controller" style="display:none">Info about the '[[controller]]' definition.</span><b><a href="#writablestream-controller">#writablestream-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-controller">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-controller①">(2)</a>
     <li><a href="#ref-for-writablestream-controller②">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-controller③">(2)</a> <a href="#ref-for-writablestream-controller④">(3)</a> <a href="#ref-for-writablestream-controller⑤">(4)</a>
@@ -13444,8 +13478,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream-controller①⓪">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-inflightwriterequest">
-   <b><a href="#writablestream-inflightwriterequest">#writablestream-inflightwriterequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-inflightwriterequest" class="dfn-panel" data-for="writablestream-inflightwriterequest" id="infopanel-for-writablestream-inflightwriterequest" role="dialog">
+   <span id="infopaneltitle-for-writablestream-inflightwriterequest" style="display:none">Info about the '[[inFlightWriteRequest]]' definition.</span><b><a href="#writablestream-inflightwriterequest">#writablestream-inflightwriterequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-inflightwriterequest">5.2.2. Internal slots</a>
     <li><a href="#ref-for-writablestream-inflightwriterequest①">5.5.1. Working with writable streams</a>
@@ -13453,23 +13487,23 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream-inflightwriterequest①①">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-inflightcloserequest">
-   <b><a href="#writablestream-inflightcloserequest">#writablestream-inflightcloserequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-inflightcloserequest" class="dfn-panel" data-for="writablestream-inflightcloserequest" id="infopanel-for-writablestream-inflightcloserequest" role="dialog">
+   <span id="infopaneltitle-for-writablestream-inflightcloserequest" style="display:none">Info about the '[[inFlightCloseRequest]]' definition.</span><b><a href="#writablestream-inflightcloserequest">#writablestream-inflightcloserequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-inflightcloserequest">5.2.2. Internal slots</a>
     <li><a href="#ref-for-writablestream-inflightcloserequest①">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-writablestream-inflightcloserequest②">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-inflightcloserequest③">(2)</a> <a href="#ref-for-writablestream-inflightcloserequest④">(3)</a> <a href="#ref-for-writablestream-inflightcloserequest⑤">(4)</a> <a href="#ref-for-writablestream-inflightcloserequest⑥">(5)</a> <a href="#ref-for-writablestream-inflightcloserequest⑦">(6)</a> <a href="#ref-for-writablestream-inflightcloserequest⑧">(7)</a> <a href="#ref-for-writablestream-inflightcloserequest⑨">(8)</a> <a href="#ref-for-writablestream-inflightcloserequest①⓪">(9)</a> <a href="#ref-for-writablestream-inflightcloserequest①①">(10)</a> <a href="#ref-for-writablestream-inflightcloserequest①②">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-pendingabortrequest">
-   <b><a href="#writablestream-pendingabortrequest">#writablestream-pendingabortrequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-pendingabortrequest" class="dfn-panel" data-for="writablestream-pendingabortrequest" id="infopanel-for-writablestream-pendingabortrequest" role="dialog">
+   <span id="infopaneltitle-for-writablestream-pendingabortrequest" style="display:none">Info about the '[[pendingAbortRequest]]' definition.</span><b><a href="#writablestream-pendingabortrequest">#writablestream-pendingabortrequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-pendingabortrequest">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-pendingabortrequest①">(2)</a> <a href="#ref-for-writablestream-pendingabortrequest②">(3)</a> <a href="#ref-for-writablestream-pendingabortrequest③">(4)</a>
     <li><a href="#ref-for-writablestream-pendingabortrequest④">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-pendingabortrequest⑤">(2)</a> <a href="#ref-for-writablestream-pendingabortrequest⑥">(3)</a> <a href="#ref-for-writablestream-pendingabortrequest⑦">(4)</a> <a href="#ref-for-writablestream-pendingabortrequest⑧">(5)</a> <a href="#ref-for-writablestream-pendingabortrequest⑨">(6)</a> <a href="#ref-for-writablestream-pendingabortrequest①⓪">(7)</a> <a href="#ref-for-writablestream-pendingabortrequest①①">(8)</a> <a href="#ref-for-writablestream-pendingabortrequest①②">(9)</a> <a href="#ref-for-writablestream-pendingabortrequest①③">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-state">
-   <b><a href="#writablestream-state">#writablestream-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-state" class="dfn-panel" data-for="writablestream-state" id="infopanel-for-writablestream-state" role="dialog">
+   <span id="infopaneltitle-for-writablestream-state" style="display:none">Info about the '[[state]]' definition.</span><b><a href="#writablestream-state">#writablestream-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-state">4.9.1. Working with readable streams</a> <a href="#ref-for-writablestream-state①">(2)</a> <a href="#ref-for-writablestream-state②">(3)</a> <a href="#ref-for-writablestream-state③">(4)</a> <a href="#ref-for-writablestream-state④">(5)</a>
     <li><a href="#ref-for-writablestream-state⑤">5.4.3. Methods</a>
@@ -13480,8 +13514,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream-state③④">6.4.3. Default sinks</a> <a href="#ref-for-writablestream-state③⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-storederror">
-   <b><a href="#writablestream-storederror">#writablestream-storederror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-storederror" class="dfn-panel" data-for="writablestream-storederror" id="infopanel-for-writablestream-storederror" role="dialog">
+   <span id="infopaneltitle-for-writablestream-storederror" style="display:none">Info about the '[[storedError]]' definition.</span><b><a href="#writablestream-storederror">#writablestream-storederror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-storederror">4.9.1. Working with readable streams</a> <a href="#ref-for-writablestream-storederror①">(2)</a> <a href="#ref-for-writablestream-storederror②">(3)</a>
     <li><a href="#ref-for-writablestream-storederror③">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-storederror④">(2)</a> <a href="#ref-for-writablestream-storederror⑤">(3)</a>
@@ -13490,8 +13524,8 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream-storederror①⑥">6.4.3. Default sinks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-writer">
-   <b><a href="#writablestream-writer">#writablestream-writer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-writer" class="dfn-panel" data-for="writablestream-writer" id="infopanel-for-writablestream-writer" role="dialog">
+   <span id="infopaneltitle-for-writablestream-writer" style="display:none">Info about the '[[writer]]' definition.</span><b><a href="#writablestream-writer">#writablestream-writer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-writer">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writablestream-writer①">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestream-writer②">(2)</a> <a href="#ref-for-writablestream-writer③">(3)</a> <a href="#ref-for-writablestream-writer④">(4)</a>
@@ -13499,81 +13533,82 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-writablestream-writer⑨">5.5.3. Writers</a> <a href="#ref-for-writablestream-writer①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-writerequests">
-   <b><a href="#writablestream-writerequests">#writablestream-writerequests</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-writerequests" class="dfn-panel" data-for="writablestream-writerequests" id="infopanel-for-writablestream-writerequests" role="dialog">
+   <span id="infopaneltitle-for-writablestream-writerequests" style="display:none">Info about the '[[writeRequests]]' definition.</span><b><a href="#writablestream-writerequests">#writablestream-writerequests</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-writerequests">5.2.2. Internal slots</a>
     <li><a href="#ref-for-writablestream-writerequests①">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-writablestream-writerequests②">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writablestream-writerequests③">(2)</a> <a href="#ref-for-writablestream-writerequests④">(3)</a> <a href="#ref-for-writablestream-writerequests⑤">(4)</a> <a href="#ref-for-writablestream-writerequests⑥">(5)</a> <a href="#ref-for-writablestream-writerequests⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-abort-request">
-   <b><a href="#pending-abort-request">#pending-abort-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-abort-request" class="dfn-panel" data-for="pending-abort-request" id="infopanel-for-pending-abort-request" role="dialog">
+   <span id="infopaneltitle-for-pending-abort-request" style="display:none">Info about the 'pending abort request' definition.</span><b><a href="#pending-abort-request">#pending-abort-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-abort-request">5.2.2. Internal slots</a>
     <li><a href="#ref-for-pending-abort-request①">5.5.1. Working with writable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-abort-request-promise">
-   <b><a href="#pending-abort-request-promise">#pending-abort-request-promise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-abort-request-promise" class="dfn-panel" data-for="pending-abort-request-promise" id="infopanel-for-pending-abort-request-promise" role="dialog">
+   <span id="infopaneltitle-for-pending-abort-request-promise" style="display:none">Info about the 'promise' definition.</span><b><a href="#pending-abort-request-promise">#pending-abort-request-promise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-abort-request-promise">5.5.1. Working with writable streams</a> <a href="#ref-for-pending-abort-request-promise①">(2)</a>
     <li><a href="#ref-for-pending-abort-request-promise②">5.5.2. Interfacing with controllers</a> <a href="#ref-for-pending-abort-request-promise③">(2)</a> <a href="#ref-for-pending-abort-request-promise④">(3)</a> <a href="#ref-for-pending-abort-request-promise⑤">(4)</a> <a href="#ref-for-pending-abort-request-promise⑥">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-abort-request-reason">
-   <b><a href="#pending-abort-request-reason">#pending-abort-request-reason</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-abort-request-reason" class="dfn-panel" data-for="pending-abort-request-reason" id="infopanel-for-pending-abort-request-reason" role="dialog">
+   <span id="infopaneltitle-for-pending-abort-request-reason" style="display:none">Info about the 'reason' definition.</span><b><a href="#pending-abort-request-reason">#pending-abort-request-reason</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-abort-request-reason">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-pending-abort-request-reason①">5.5.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pending-abort-request-was-already-erroring">
-   <b><a href="#pending-abort-request-was-already-erroring">#pending-abort-request-was-already-erroring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pending-abort-request-was-already-erroring" class="dfn-panel" data-for="pending-abort-request-was-already-erroring" id="infopanel-for-pending-abort-request-was-already-erroring" role="dialog">
+   <span id="infopaneltitle-for-pending-abort-request-was-already-erroring" style="display:none">Info about the 'was already erroring' definition.</span><b><a href="#pending-abort-request-was-already-erroring">#pending-abort-request-was-already-erroring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pending-abort-request-was-already-erroring">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-pending-abort-request-was-already-erroring①">5.5.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-underlyingsink">
-   <b><a href="#dictdef-underlyingsink">#dictdef-underlyingsink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-underlyingsink" class="dfn-panel" data-for="dictdef-underlyingsink" id="infopanel-for-dictdef-underlyingsink" role="dialog">
+   <span id="infopaneltitle-for-dictdef-underlyingsink" style="display:none">Info about the 'UnderlyingSink' definition.</span><b><a href="#dictdef-underlyingsink">#dictdef-underlyingsink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-underlyingsink">5.2.4. Constructor, methods, and properties</a> <a href="#ref-for-dictdef-underlyingsink①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsinkstartcallback">
-   <b><a href="#callbackdef-underlyingsinkstartcallback">#callbackdef-underlyingsinkstartcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsinkstartcallback" class="dfn-panel" data-for="callbackdef-underlyingsinkstartcallback" id="infopanel-for-callbackdef-underlyingsinkstartcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsinkstartcallback" style="display:none">Info about the 'UnderlyingSinkStartCallback' definition.</span><b><a href="#callbackdef-underlyingsinkstartcallback">#callbackdef-underlyingsinkstartcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsinkstartcallback">5.2.3. The underlying sink API</a> <a href="#ref-for-callbackdef-underlyingsinkstartcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsinkwritecallback">
-   <b><a href="#callbackdef-underlyingsinkwritecallback">#callbackdef-underlyingsinkwritecallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsinkwritecallback" class="dfn-panel" data-for="callbackdef-underlyingsinkwritecallback" id="infopanel-for-callbackdef-underlyingsinkwritecallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsinkwritecallback" style="display:none">Info about the 'UnderlyingSinkWriteCallback' definition.</span><b><a href="#callbackdef-underlyingsinkwritecallback">#callbackdef-underlyingsinkwritecallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsinkwritecallback">5.2.3. The underlying sink API</a> <a href="#ref-for-callbackdef-underlyingsinkwritecallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsinkclosecallback">
-   <b><a href="#callbackdef-underlyingsinkclosecallback">#callbackdef-underlyingsinkclosecallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsinkclosecallback" class="dfn-panel" data-for="callbackdef-underlyingsinkclosecallback" id="infopanel-for-callbackdef-underlyingsinkclosecallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsinkclosecallback" style="display:none">Info about the 'UnderlyingSinkCloseCallback' definition.</span><b><a href="#callbackdef-underlyingsinkclosecallback">#callbackdef-underlyingsinkclosecallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsinkclosecallback">5.2.3. The underlying sink API</a> <a href="#ref-for-callbackdef-underlyingsinkclosecallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-underlyingsinkabortcallback">
-   <b><a href="#callbackdef-underlyingsinkabortcallback">#callbackdef-underlyingsinkabortcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-underlyingsinkabortcallback" class="dfn-panel" data-for="callbackdef-underlyingsinkabortcallback" id="infopanel-for-callbackdef-underlyingsinkabortcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-underlyingsinkabortcallback" style="display:none">Info about the 'UnderlyingSinkAbortCallback' definition.</span><b><a href="#callbackdef-underlyingsinkabortcallback">#callbackdef-underlyingsinkabortcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-underlyingsinkabortcallback">5.2.3. The underlying sink API</a> <a href="#ref-for-callbackdef-underlyingsinkabortcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsink-start">
-   <b><a href="#dom-underlyingsink-start">#dom-underlyingsink-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsink-start" class="dfn-panel" data-for="dom-underlyingsink-start" id="infopanel-for-dom-underlyingsink-start" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsink-start" style="display:none">Info about the 'start(controller)' definition.</span><b><a href="#dom-underlyingsink-start">#dom-underlyingsink-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsink-start">5.2.3. The underlying sink API</a> <a href="#ref-for-dom-underlyingsink-start①">(2)</a> <a href="#ref-for-dom-underlyingsink-start②">(3)</a>
     <li><a href="#ref-for-dom-underlyingsink-start③">5.5.4. Default controllers</a> <a href="#ref-for-dom-underlyingsink-start④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsink-write">
-   <b><a href="#dom-underlyingsink-write">#dom-underlyingsink-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsink-write" class="dfn-panel" data-for="dom-underlyingsink-write" id="infopanel-for-dom-underlyingsink-write" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsink-write" style="display:none">Info about the 'write(chunk,
+  controller)' definition.</span><b><a href="#dom-underlyingsink-write">#dom-underlyingsink-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsink-write">4.1. Using readable streams</a>
     <li><a href="#ref-for-dom-underlyingsink-write①">5.2.3. The underlying sink API</a> <a href="#ref-for-dom-underlyingsink-write②">(2)</a>
@@ -13582,29 +13617,29 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-dom-underlyingsink-write⑥">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsink-close">
-   <b><a href="#dom-underlyingsink-close">#dom-underlyingsink-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsink-close" class="dfn-panel" data-for="dom-underlyingsink-close" id="infopanel-for-dom-underlyingsink-close" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsink-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#dom-underlyingsink-close">#dom-underlyingsink-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsink-close">5.2.3. The underlying sink API</a> <a href="#ref-for-dom-underlyingsink-close①">(2)</a> <a href="#ref-for-dom-underlyingsink-close②">(3)</a>
     <li><a href="#ref-for-dom-underlyingsink-close③">5.5.4. Default controllers</a> <a href="#ref-for-dom-underlyingsink-close④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsink-abort">
-   <b><a href="#dom-underlyingsink-abort">#dom-underlyingsink-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsink-abort" class="dfn-panel" data-for="dom-underlyingsink-abort" id="infopanel-for-dom-underlyingsink-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsink-abort" style="display:none">Info about the 'abort(reason)' definition.</span><b><a href="#dom-underlyingsink-abort">#dom-underlyingsink-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsink-abort">5.2.3. The underlying sink API</a> <a href="#ref-for-dom-underlyingsink-abort①">(2)</a>
     <li><a href="#ref-for-dom-underlyingsink-abort②">5.5.4. Default controllers</a> <a href="#ref-for-dom-underlyingsink-abort③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-underlyingsink-type">
-   <b><a href="#dom-underlyingsink-type">#dom-underlyingsink-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-underlyingsink-type" class="dfn-panel" data-for="dom-underlyingsink-type" id="infopanel-for-dom-underlyingsink-type" role="dialog">
+   <span id="infopaneltitle-for-dom-underlyingsink-type" style="display:none">Info about the 'type' definition.</span><b><a href="#dom-underlyingsink-type">#dom-underlyingsink-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-underlyingsink-type">5.2.3. The underlying sink API</a>
     <li><a href="#ref-for-dom-underlyingsink-type①">5.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-constructor">
-   <b><a href="#ws-constructor">#ws-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-constructor" class="dfn-panel" data-for="ws-constructor" id="infopanel-for-ws-constructor" role="dialog">
+   <span id="infopaneltitle-for-ws-constructor" style="display:none">Info about the 'new WritableStream(underlyingSink, strategy)' definition.</span><b><a href="#ws-constructor">#ws-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-constructor">2.2. Writable streams</a>
     <li><a href="#ref-for-ws-constructor①">5.2.1. Interface definition</a>
@@ -13613,16 +13648,16 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
     <li><a href="#ref-for-ws-constructor⑤">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-locked">
-   <b><a href="#ws-locked">#ws-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-locked" class="dfn-panel" data-for="ws-locked" id="infopanel-for-ws-locked" role="dialog">
+   <span id="infopaneltitle-for-ws-locked" style="display:none">Info about the 'locked' definition.</span><b><a href="#ws-locked">#ws-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-locked">2.6. Locking</a>
     <li><a href="#ref-for-ws-locked①">5.2.1. Interface definition</a>
     <li><a href="#ref-for-ws-locked②">5.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-abort">
-   <b><a href="#ws-abort">#ws-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-abort" class="dfn-panel" data-for="ws-abort" id="infopanel-for-ws-abort" role="dialog">
+   <span id="infopaneltitle-for-ws-abort" style="display:none">Info about the 'abort(reason)' definition.</span><b><a href="#ws-abort">#ws-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-abort">2.2. Writable streams</a>
     <li><a href="#ref-for-ws-abort①">5.2.1. Interface definition</a>
@@ -13633,24 +13668,24 @@ support)</a> <a href="#ref-for-rbs-controller-desired-size⑤">(2)</a>
 create new readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-close">
-   <b><a href="#ws-close">#ws-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-close" class="dfn-panel" data-for="ws-close" id="infopanel-for-ws-close" role="dialog">
+   <span id="infopaneltitle-for-ws-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#ws-close">#ws-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-close">5.2.1. Interface definition</a>
     <li><a href="#ref-for-ws-close①">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-ws-close②">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-get-writer">
-   <b><a href="#ws-get-writer">#ws-get-writer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-get-writer" class="dfn-panel" data-for="ws-get-writer" id="infopanel-for-ws-get-writer" role="dialog">
+   <span id="infopaneltitle-for-ws-get-writer" style="display:none">Info about the 'getWriter()' definition.</span><b><a href="#ws-get-writer">#ws-get-writer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-get-writer">5.2.1. Interface definition</a>
     <li><a href="#ref-for-ws-get-writer①">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-ws-get-writer②">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultwriter">
-   <b><a href="#writablestreamdefaultwriter">#writablestreamdefaultwriter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultwriter" class="dfn-panel" data-for="writablestreamdefaultwriter" id="infopanel-for-writablestreamdefaultwriter" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultwriter" style="display:none">Info about the 'WritableStreamDefaultWriter' definition.</span><b><a href="#writablestreamdefaultwriter">#writablestreamdefaultwriter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter">2.6. Locking</a>
     <li><a href="#ref-for-writablestreamdefaultwriter①">5.1. Using writable streams</a>
@@ -13665,8 +13700,8 @@ create new readable streams</a>
     <li><a href="#ref-for-writablestreamdefaultwriter①①">9.2.2. Writing</a> <a href="#ref-for-writablestreamdefaultwriter①②">(2)</a> <a href="#ref-for-writablestreamdefaultwriter①③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultwriter-closedpromise">
-   <b><a href="#writablestreamdefaultwriter-closedpromise">#writablestreamdefaultwriter-closedpromise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultwriter-closedpromise" class="dfn-panel" data-for="writablestreamdefaultwriter-closedpromise" id="infopanel-for-writablestreamdefaultwriter-closedpromise" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultwriter-closedpromise" style="display:none">Info about the '[[closedPromise]]' definition.</span><b><a href="#writablestreamdefaultwriter-closedpromise">#writablestreamdefaultwriter-closedpromise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-closedpromise">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-closedpromise①">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise②">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise③">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise④">(4)</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise⑤">(5)</a>
@@ -13674,8 +13709,8 @@ create new readable streams</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-closedpromise⑨">5.5.3. Writers</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise①⓪">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise①①">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-closedpromise①②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultwriter-readypromise">
-   <b><a href="#writablestreamdefaultwriter-readypromise">#writablestreamdefaultwriter-readypromise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultwriter-readypromise" class="dfn-panel" data-for="writablestreamdefaultwriter-readypromise" id="infopanel-for-writablestreamdefaultwriter-readypromise" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultwriter-readypromise" style="display:none">Info about the '[[readyPromise]]' definition.</span><b><a href="#writablestreamdefaultwriter-readypromise">#writablestreamdefaultwriter-readypromise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-readypromise">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-readypromise①">5.5.1. Working with writable streams</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise②">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise③">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise④">(4)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise⑤">(5)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise⑥">(6)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise⑦">(7)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise⑧">(8)</a>
@@ -13683,31 +13718,31 @@ create new readable streams</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-readypromise①①">5.5.3. Writers</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise①②">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise①③">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-readypromise①④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultwriter-stream">
-   <b><a href="#writablestreamdefaultwriter-stream">#writablestreamdefaultwriter-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultwriter-stream" class="dfn-panel" data-for="writablestreamdefaultwriter-stream" id="infopanel-for-writablestreamdefaultwriter-stream" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultwriter-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#writablestreamdefaultwriter-stream">#writablestreamdefaultwriter-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultwriter-stream">5.3.3. Constructor, methods, and properties</a> <a href="#ref-for-writablestreamdefaultwriter-stream①">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-stream②">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-stream③">(4)</a> <a href="#ref-for-writablestreamdefaultwriter-stream④">(5)</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-stream⑤">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-writablestreamdefaultwriter-stream⑥">5.5.3. Writers</a> <a href="#ref-for-writablestreamdefaultwriter-stream⑦">(2)</a> <a href="#ref-for-writablestreamdefaultwriter-stream⑧">(3)</a> <a href="#ref-for-writablestreamdefaultwriter-stream⑨">(4)</a> <a href="#ref-for-writablestreamdefaultwriter-stream①⓪">(5)</a> <a href="#ref-for-writablestreamdefaultwriter-stream①①">(6)</a> <a href="#ref-for-writablestreamdefaultwriter-stream①②">(7)</a> <a href="#ref-for-writablestreamdefaultwriter-stream①③">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-constructor">
-   <b><a href="#default-writer-constructor">#default-writer-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-constructor" class="dfn-panel" data-for="default-writer-constructor" id="infopanel-for-default-writer-constructor" role="dialog">
+   <span id="infopaneltitle-for-default-writer-constructor" style="display:none">Info about the 'new WritableStreamDefaultWriter(stream)' definition.</span><b><a href="#default-writer-constructor">#default-writer-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-constructor">5.3.1. Interface definition</a>
     <li><a href="#ref-for-default-writer-constructor①">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-closed">
-   <b><a href="#default-writer-closed">#default-writer-closed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-closed" class="dfn-panel" data-for="default-writer-closed" id="infopanel-for-default-writer-closed" role="dialog">
+   <span id="infopaneltitle-for-default-writer-closed" style="display:none">Info about the 'closed' definition.</span><b><a href="#default-writer-closed">#default-writer-closed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-closed">5.3.1. Interface definition</a>
     <li><a href="#ref-for-default-writer-closed①">5.3.2. Internal slots</a>
     <li><a href="#ref-for-default-writer-closed②">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-desired-size">
-   <b><a href="#default-writer-desired-size">#default-writer-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-desired-size" class="dfn-panel" data-for="default-writer-desired-size" id="infopanel-for-default-writer-desired-size" role="dialog">
+   <span id="infopaneltitle-for-default-writer-desired-size" style="display:none">Info about the 'desiredSize' definition.</span><b><a href="#default-writer-desired-size">#default-writer-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-desired-size">2.4. Pipe chains and backpressure</a>
     <li><a href="#ref-for-default-writer-desired-size①">5.1. Using writable streams</a> <a href="#ref-for-default-writer-desired-size②">(2)</a> <a href="#ref-for-default-writer-desired-size③">(3)</a>
@@ -13717,8 +13752,8 @@ create new readable streams</a>
     <li><a href="#ref-for-default-writer-desired-size⑦">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-ready">
-   <b><a href="#default-writer-ready">#default-writer-ready</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-ready" class="dfn-panel" data-for="default-writer-ready" id="infopanel-for-default-writer-ready" role="dialog">
+   <span id="infopaneltitle-for-default-writer-ready" style="display:none">Info about the 'ready' definition.</span><b><a href="#default-writer-ready">#default-writer-ready</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-ready">5.1. Using writable streams</a> <a href="#ref-for-default-writer-ready①">(2)</a> <a href="#ref-for-default-writer-ready②">(3)</a> <a href="#ref-for-default-writer-ready③">(4)</a> <a href="#ref-for-default-writer-ready④">(5)</a> <a href="#ref-for-default-writer-ready⑤">(6)</a> <a href="#ref-for-default-writer-ready⑥">(7)</a>
     <li><a href="#ref-for-default-writer-ready⑦">5.3.1. Interface definition</a>
@@ -13728,8 +13763,8 @@ create new readable streams</a>
     <li><a href="#ref-for-default-writer-ready①①">10.7. A writable stream with backpressure and success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-abort">
-   <b><a href="#default-writer-abort">#default-writer-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-abort" class="dfn-panel" data-for="default-writer-abort" id="infopanel-for-default-writer-abort" role="dialog">
+   <span id="infopaneltitle-for-default-writer-abort" style="display:none">Info about the 'abort(reason)' definition.</span><b><a href="#default-writer-abort">#default-writer-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-abort">5.2.2. Internal slots</a>
     <li><a href="#ref-for-default-writer-abort①">5.2.3. The underlying sink API</a> <a href="#ref-for-default-writer-abort②">(2)</a>
@@ -13737,8 +13772,8 @@ create new readable streams</a>
     <li><a href="#ref-for-default-writer-abort④">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-close">
-   <b><a href="#default-writer-close">#default-writer-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-close" class="dfn-panel" data-for="default-writer-close" id="infopanel-for-default-writer-close" role="dialog">
+   <span id="infopaneltitle-for-default-writer-close" style="display:none">Info about the 'close()' definition.</span><b><a href="#default-writer-close">#default-writer-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-close">5.1. Using writable streams</a> <a href="#ref-for-default-writer-close①">(2)</a> <a href="#ref-for-default-writer-close②">(3)</a>
     <li><a href="#ref-for-default-writer-close③">5.2.2. Internal slots</a>
@@ -13747,16 +13782,16 @@ create new readable streams</a>
     <li><a href="#ref-for-default-writer-close⑦">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-release-lock">
-   <b><a href="#default-writer-release-lock">#default-writer-release-lock</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-release-lock" class="dfn-panel" data-for="default-writer-release-lock" id="infopanel-for-default-writer-release-lock" role="dialog">
+   <span id="infopaneltitle-for-default-writer-release-lock" style="display:none">Info about the 'releaseLock()' definition.</span><b><a href="#default-writer-release-lock">#default-writer-release-lock</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-release-lock">2.6. Locking</a>
     <li><a href="#ref-for-default-writer-release-lock①">5.3.1. Interface definition</a>
     <li><a href="#ref-for-default-writer-release-lock②">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-writer-write">
-   <b><a href="#default-writer-write">#default-writer-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-writer-write" class="dfn-panel" data-for="default-writer-write" id="infopanel-for-default-writer-write" role="dialog">
+   <span id="infopaneltitle-for-default-writer-write" style="display:none">Info about the 'write(chunk)' definition.</span><b><a href="#default-writer-write">#default-writer-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-writer-write">5.1. Using writable streams</a> <a href="#ref-for-default-writer-write①">(2)</a> <a href="#ref-for-default-writer-write②">(3)</a> <a href="#ref-for-default-writer-write③">(4)</a> <a href="#ref-for-default-writer-write④">(5)</a> <a href="#ref-for-default-writer-write⑤">(6)</a> <a href="#ref-for-default-writer-write⑥">(7)</a> <a href="#ref-for-default-writer-write⑦">(8)</a> <a href="#ref-for-default-writer-write⑧">(9)</a>
     <li><a href="#ref-for-default-writer-write⑨">5.2.3. The underlying sink API</a>
@@ -13766,8 +13801,8 @@ create new readable streams</a>
     <li><a href="#ref-for-default-writer-write①④">10.6. A writable stream with no backpressure or success signals</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller">
-   <b><a href="#writablestreamdefaultcontroller">#writablestreamdefaultcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller" class="dfn-panel" data-for="writablestreamdefaultcontroller" id="infopanel-for-writablestreamdefaultcontroller" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller" style="display:none">Info about the 'WritableStreamDefaultController' definition.</span><b><a href="#writablestreamdefaultcontroller">#writablestreamdefaultcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller">5.2.2. Internal slots</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller①">5.2.3. The underlying sink API</a> <a href="#ref-for-writablestreamdefaultcontroller②">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller③">(3)</a>
@@ -13782,93 +13817,94 @@ create new readable streams</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller①⑥">9.2.1. Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-abortalgorithm">
-   <b><a href="#writablestreamdefaultcontroller-abortalgorithm">#writablestreamdefaultcontroller-abortalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-abortalgorithm" class="dfn-panel" data-for="writablestreamdefaultcontroller-abortalgorithm" id="infopanel-for-writablestreamdefaultcontroller-abortalgorithm" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-abortalgorithm" style="display:none">Info about the '[[abortAlgorithm]]' definition.</span><b><a href="#writablestreamdefaultcontroller-abortalgorithm">#writablestreamdefaultcontroller-abortalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-abortalgorithm">5.4.4. Internal methods</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller-abortalgorithm①">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-abortalgorithm②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-closealgorithm">
-   <b><a href="#writablestreamdefaultcontroller-closealgorithm">#writablestreamdefaultcontroller-closealgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-closealgorithm" class="dfn-panel" data-for="writablestreamdefaultcontroller-closealgorithm" id="infopanel-for-writablestreamdefaultcontroller-closealgorithm" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-closealgorithm" style="display:none">Info about the '[[closeAlgorithm]]' definition.</span><b><a href="#writablestreamdefaultcontroller-closealgorithm">#writablestreamdefaultcontroller-closealgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-closealgorithm">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-closealgorithm①">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller-closealgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-queue">
-   <b><a href="#writablestreamdefaultcontroller-queue">#writablestreamdefaultcontroller-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-queue" class="dfn-panel" data-for="writablestreamdefaultcontroller-queue" id="infopanel-for-writablestreamdefaultcontroller-queue" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-queue" style="display:none">Info about the '[[queue]]' definition.</span><b><a href="#writablestreamdefaultcontroller-queue">#writablestreamdefaultcontroller-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-queue">5.4.2. Internal slots</a> <a href="#ref-for-writablestreamdefaultcontroller-queue①">(2)</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller-queue②">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-queue③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-queuetotalsize">
-   <b><a href="#writablestreamdefaultcontroller-queuetotalsize">#writablestreamdefaultcontroller-queuetotalsize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-queuetotalsize" class="dfn-panel" data-for="writablestreamdefaultcontroller-queuetotalsize" id="infopanel-for-writablestreamdefaultcontroller-queuetotalsize" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-queuetotalsize" style="display:none">Info about the '[[queueTotalSize]]' definition.</span><b><a href="#writablestreamdefaultcontroller-queuetotalsize">#writablestreamdefaultcontroller-queuetotalsize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-queuetotalsize">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-started">
-   <b><a href="#writablestreamdefaultcontroller-started">#writablestreamdefaultcontroller-started</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-started" class="dfn-panel" data-for="writablestreamdefaultcontroller-started" id="infopanel-for-writablestreamdefaultcontroller-started" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-started" style="display:none">Info about the '[[started]]' definition.</span><b><a href="#writablestreamdefaultcontroller-started">#writablestreamdefaultcontroller-started</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-started">5.5.2. Interfacing with controllers</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller-started①">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-started②">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller-started③">(3)</a> <a href="#ref-for-writablestreamdefaultcontroller-started④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-strategyhwm">
-   <b><a href="#writablestreamdefaultcontroller-strategyhwm">#writablestreamdefaultcontroller-strategyhwm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-strategyhwm" class="dfn-panel" data-for="writablestreamdefaultcontroller-strategyhwm" id="infopanel-for-writablestreamdefaultcontroller-strategyhwm" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-strategyhwm" style="display:none">Info about the '[[strategyHWM]]' definition.</span><b><a href="#writablestreamdefaultcontroller-strategyhwm">#writablestreamdefaultcontroller-strategyhwm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-strategyhwm">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-strategyhwm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-strategysizealgorithm">
-   <b><a href="#writablestreamdefaultcontroller-strategysizealgorithm">#writablestreamdefaultcontroller-strategysizealgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-strategysizealgorithm" class="dfn-panel" data-for="writablestreamdefaultcontroller-strategysizealgorithm" id="infopanel-for-writablestreamdefaultcontroller-strategysizealgorithm" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-strategysizealgorithm" style="display:none">Info about the '[[strategySizeAlgorithm]]' definition.</span><b><a href="#writablestreamdefaultcontroller-strategysizealgorithm">#writablestreamdefaultcontroller-strategysizealgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-strategysizealgorithm">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-strategysizealgorithm①">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller-strategysizealgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-stream">
-   <b><a href="#writablestreamdefaultcontroller-stream">#writablestreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-stream" class="dfn-panel" data-for="writablestreamdefaultcontroller-stream" id="infopanel-for-writablestreamdefaultcontroller-stream" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#writablestreamdefaultcontroller-stream">#writablestreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-stream">5.4.3. Methods</a>
     <li><a href="#ref-for-writablestreamdefaultcontroller-stream①">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-stream②">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller-stream③">(3)</a> <a href="#ref-for-writablestreamdefaultcontroller-stream④">(4)</a> <a href="#ref-for-writablestreamdefaultcontroller-stream⑤">(5)</a> <a href="#ref-for-writablestreamdefaultcontroller-stream⑥">(6)</a> <a href="#ref-for-writablestreamdefaultcontroller-stream⑦">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestreamdefaultcontroller-writealgorithm">
-   <b><a href="#writablestreamdefaultcontroller-writealgorithm">#writablestreamdefaultcontroller-writealgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestreamdefaultcontroller-writealgorithm" class="dfn-panel" data-for="writablestreamdefaultcontroller-writealgorithm" id="infopanel-for-writablestreamdefaultcontroller-writealgorithm" role="dialog">
+   <span id="infopaneltitle-for-writablestreamdefaultcontroller-writealgorithm" style="display:none">Info about the '[[writeAlgorithm]]' definition.</span><b><a href="#writablestreamdefaultcontroller-writealgorithm">#writablestreamdefaultcontroller-writealgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestreamdefaultcontroller-writealgorithm">5.5.4. Default controllers</a> <a href="#ref-for-writablestreamdefaultcontroller-writealgorithm①">(2)</a> <a href="#ref-for-writablestreamdefaultcontroller-writealgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="close-sentinel">
-   <b><a href="#close-sentinel">#close-sentinel</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-close-sentinel" class="dfn-panel" data-for="close-sentinel" id="infopanel-for-close-sentinel" role="dialog">
+   <span id="infopaneltitle-for-close-sentinel" style="display:none">Info about the 'close sentinel' definition.</span><b><a href="#close-sentinel">#close-sentinel</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-close-sentinel">5.5.4. Default controllers</a> <a href="#ref-for-close-sentinel①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ws-default-controller-error">
-   <b><a href="#ws-default-controller-error">#ws-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ws-default-controller-error" class="dfn-panel" data-for="ws-default-controller-error" id="infopanel-for-ws-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-ws-default-controller-error" style="display:none">Info about the 'error(e)' definition.</span><b><a href="#ws-default-controller-error">#ws-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ws-default-controller-error">5.4.1. Interface definition</a>
     <li><a href="#ref-for-ws-default-controller-error①">5.4.3. Methods</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="acquire-writable-stream-default-writer">
-   <b><a href="#acquire-writable-stream-default-writer">#acquire-writable-stream-default-writer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-acquire-writable-stream-default-writer" class="dfn-panel" data-for="acquire-writable-stream-default-writer" id="infopanel-for-acquire-writable-stream-default-writer" role="dialog">
+   <span id="infopaneltitle-for-acquire-writable-stream-default-writer" style="display:none">Info about the 'AcquireWritableStreamDefaultWriter(stream)' definition.</span><b><a href="#acquire-writable-stream-default-writer">#acquire-writable-stream-default-writer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-acquire-writable-stream-default-writer">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-acquire-writable-stream-default-writer①">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-acquire-writable-stream-default-writer②">9.2.2. Writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-writable-stream">
-   <b><a href="#create-writable-stream">#create-writable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-writable-stream" class="dfn-panel" data-for="create-writable-stream" id="infopanel-for-create-writable-stream" role="dialog">
+   <span id="infopaneltitle-for-create-writable-stream" style="display:none">Info about the 'CreateWritableStream(startAlgorithm, writeAlgorithm,
+ closeAlgorithm, abortAlgorithm, highWaterMark, sizeAlgorithm)' definition.</span><b><a href="#create-writable-stream">#create-writable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-writable-stream">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-writable-stream">
-   <b><a href="#initialize-writable-stream">#initialize-writable-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-writable-stream" class="dfn-panel" data-for="initialize-writable-stream" id="infopanel-for-initialize-writable-stream" role="dialog">
+   <span id="infopaneltitle-for-initialize-writable-stream" style="display:none">Info about the 'InitializeWritableStream(stream)' definition.</span><b><a href="#initialize-writable-stream">#initialize-writable-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-writable-stream">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-initialize-writable-stream①">5.5.1. Working with writable streams</a>
@@ -13876,8 +13912,8 @@ create new readable streams</a>
     <li><a href="#ref-for-initialize-writable-stream③">9.2.1. Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-writable-stream-locked">
-   <b><a href="#is-writable-stream-locked">#is-writable-stream-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-writable-stream-locked" class="dfn-panel" data-for="is-writable-stream-locked" id="infopanel-for-is-writable-stream-locked" role="dialog">
+   <span id="infopaneltitle-for-is-writable-stream-locked" style="display:none">Info about the 'IsWritableStreamLocked(stream)' definition.</span><b><a href="#is-writable-stream-locked">#is-writable-stream-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-writable-stream-locked">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-is-writable-stream-locked①">(2)</a>
     <li><a href="#ref-for-is-writable-stream-locked②">4.9.1. Working with readable streams</a>
@@ -13889,15 +13925,16 @@ create new readable streams</a>
     <li><a href="#ref-for-is-writable-stream-locked①⓪">9.5. Piping</a> <a href="#ref-for-is-writable-stream-locked①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-writable-stream-default-writer">
-   <b><a href="#set-up-writable-stream-default-writer">#set-up-writable-stream-default-writer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-writable-stream-default-writer" class="dfn-panel" data-for="set-up-writable-stream-default-writer" id="infopanel-for-set-up-writable-stream-default-writer" role="dialog">
+   <span id="infopaneltitle-for-set-up-writable-stream-default-writer" style="display:none">Info about the 'SetUpWritableStreamDefaultWriter(writer,
+ stream)' definition.</span><b><a href="#set-up-writable-stream-default-writer">#set-up-writable-stream-default-writer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-writable-stream-default-writer">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-set-up-writable-stream-default-writer①">5.5.1. Working with writable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-abort">
-   <b><a href="#writable-stream-abort">#writable-stream-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-abort" class="dfn-panel" data-for="writable-stream-abort" id="infopanel-for-writable-stream-abort" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-abort" style="display:none">Info about the 'WritableStreamAbort(stream, reason)' definition.</span><b><a href="#writable-stream-abort">#writable-stream-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-abort">4.9.1. Working with readable streams</a> <a href="#ref-for-writable-stream-abort①">(2)</a>
     <li><a href="#ref-for-writable-stream-abort②">5.2.2. Internal slots</a> <a href="#ref-for-writable-stream-abort③">(2)</a> <a href="#ref-for-writable-stream-abort④">(3)</a>
@@ -13906,36 +13943,36 @@ create new readable streams</a>
     <li><a href="#ref-for-writable-stream-abort⑦">9.2.2. Writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-close">
-   <b><a href="#writable-stream-close">#writable-stream-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-close" class="dfn-panel" data-for="writable-stream-close" id="infopanel-for-writable-stream-close" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-close" style="display:none">Info about the 'WritableStreamClose(stream)' definition.</span><b><a href="#writable-stream-close">#writable-stream-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-close">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writable-stream-close①">5.5.3. Writers</a>
     <li><a href="#ref-for-writable-stream-close②">9.2.2. Writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-writablestreamcontroller-abortsteps">
-   <b><a href="#abstract-opdef-writablestreamcontroller-abortsteps">#abstract-opdef-writablestreamcontroller-abortsteps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-writablestreamcontroller-abortsteps" class="dfn-panel" data-for="abstract-opdef-writablestreamcontroller-abortsteps" id="infopanel-for-abstract-opdef-writablestreamcontroller-abortsteps" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-writablestreamcontroller-abortsteps" style="display:none">Info about the '[[AbortSteps]](reason)' definition.</span><b><a href="#abstract-opdef-writablestreamcontroller-abortsteps">#abstract-opdef-writablestreamcontroller-abortsteps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-writablestreamcontroller-abortsteps">5.4.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-writablestreamcontroller-abortsteps①">5.5.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-writablestreamcontroller-errorsteps">
-   <b><a href="#abstract-opdef-writablestreamcontroller-errorsteps">#abstract-opdef-writablestreamcontroller-errorsteps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-writablestreamcontroller-errorsteps" class="dfn-panel" data-for="abstract-opdef-writablestreamcontroller-errorsteps" id="infopanel-for-abstract-opdef-writablestreamcontroller-errorsteps" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-writablestreamcontroller-errorsteps" style="display:none">Info about the '[[ErrorSteps]]()' definition.</span><b><a href="#abstract-opdef-writablestreamcontroller-errorsteps">#abstract-opdef-writablestreamcontroller-errorsteps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-writablestreamcontroller-errorsteps">5.4.4. Internal methods</a>
     <li><a href="#ref-for-abstract-opdef-writablestreamcontroller-errorsteps①">5.5.2. Interfacing with controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-add-write-request">
-   <b><a href="#writable-stream-add-write-request">#writable-stream-add-write-request</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-add-write-request" class="dfn-panel" data-for="writable-stream-add-write-request" id="infopanel-for-writable-stream-add-write-request" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-add-write-request" style="display:none">Info about the 'WritableStreamAddWriteRequest(stream)' definition.</span><b><a href="#writable-stream-add-write-request">#writable-stream-add-write-request</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-add-write-request">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-close-queued-or-in-flight">
-   <b><a href="#writable-stream-close-queued-or-in-flight">#writable-stream-close-queued-or-in-flight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-close-queued-or-in-flight" class="dfn-panel" data-for="writable-stream-close-queued-or-in-flight" id="infopanel-for-writable-stream-close-queued-or-in-flight" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-close-queued-or-in-flight" style="display:none">Info about the 'WritableStreamCloseQueuedOrInFlight(stream)' definition.</span><b><a href="#writable-stream-close-queued-or-in-flight">#writable-stream-close-queued-or-in-flight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-close-queued-or-in-flight">4.9.1. Working with readable streams</a> <a href="#ref-for-writable-stream-close-queued-or-in-flight①">(2)</a> <a href="#ref-for-writable-stream-close-queued-or-in-flight②">(3)</a>
     <li><a href="#ref-for-writable-stream-close-queued-or-in-flight③">5.2.4. Constructor, methods, and properties</a>
@@ -13946,138 +13983,146 @@ create new readable streams</a>
     <li><a href="#ref-for-writable-stream-close-queued-or-in-flight①⓪">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-close-queued-or-in-flight①①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-deal-with-rejection">
-   <b><a href="#writable-stream-deal-with-rejection">#writable-stream-deal-with-rejection</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-deal-with-rejection" class="dfn-panel" data-for="writable-stream-deal-with-rejection" id="infopanel-for-writable-stream-deal-with-rejection" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-deal-with-rejection" style="display:none">Info about the 'WritableStreamDealWithRejection(stream, error)' definition.</span><b><a href="#writable-stream-deal-with-rejection">#writable-stream-deal-with-rejection</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-deal-with-rejection">5.5.2. Interfacing with controllers</a>
     <li><a href="#ref-for-writable-stream-deal-with-rejection①">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-finish-erroring">
-   <b><a href="#writable-stream-finish-erroring">#writable-stream-finish-erroring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-finish-erroring" class="dfn-panel" data-for="writable-stream-finish-erroring" id="infopanel-for-writable-stream-finish-erroring" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-finish-erroring" style="display:none">Info about the 'WritableStreamFinishErroring(stream, reason)' definition.</span><b><a href="#writable-stream-finish-erroring">#writable-stream-finish-erroring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-finish-erroring">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writable-stream-finish-erroring①">(2)</a>
     <li><a href="#ref-for-writable-stream-finish-erroring②">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-finish-in-flight-close">
-   <b><a href="#writable-stream-finish-in-flight-close">#writable-stream-finish-in-flight-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-finish-in-flight-close" class="dfn-panel" data-for="writable-stream-finish-in-flight-close" id="infopanel-for-writable-stream-finish-in-flight-close" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-finish-in-flight-close" style="display:none">Info about the 'WritableStreamFinishInFlightClose(stream)' definition.</span><b><a href="#writable-stream-finish-in-flight-close">#writable-stream-finish-in-flight-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-finish-in-flight-close">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-finish-in-flight-close-with-error">
-   <b><a href="#writable-stream-finish-in-flight-close-with-error">#writable-stream-finish-in-flight-close-with-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-finish-in-flight-close-with-error" class="dfn-panel" data-for="writable-stream-finish-in-flight-close-with-error" id="infopanel-for-writable-stream-finish-in-flight-close-with-error" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-finish-in-flight-close-with-error" style="display:none">Info about the 'WritableStreamFinishInFlightCloseWithError(stream,
+ error)' definition.</span><b><a href="#writable-stream-finish-in-flight-close-with-error">#writable-stream-finish-in-flight-close-with-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-finish-in-flight-close-with-error">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-finish-in-flight-write">
-   <b><a href="#writable-stream-finish-in-flight-write">#writable-stream-finish-in-flight-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-finish-in-flight-write" class="dfn-panel" data-for="writable-stream-finish-in-flight-write" id="infopanel-for-writable-stream-finish-in-flight-write" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-finish-in-flight-write" style="display:none">Info about the 'WritableStreamFinishInFlightWrite(stream)' definition.</span><b><a href="#writable-stream-finish-in-flight-write">#writable-stream-finish-in-flight-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-finish-in-flight-write">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-finish-in-flight-write-with-error">
-   <b><a href="#writable-stream-finish-in-flight-write-with-error">#writable-stream-finish-in-flight-write-with-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-finish-in-flight-write-with-error" class="dfn-panel" data-for="writable-stream-finish-in-flight-write-with-error" id="infopanel-for-writable-stream-finish-in-flight-write-with-error" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-finish-in-flight-write-with-error" style="display:none">Info about the 'WritableStreamFinishInFlightWriteWithError(stream,
+ error)' definition.</span><b><a href="#writable-stream-finish-in-flight-write-with-error">#writable-stream-finish-in-flight-write-with-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-finish-in-flight-write-with-error">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-has-operation-marked-in-flight">
-   <b><a href="#writable-stream-has-operation-marked-in-flight">#writable-stream-has-operation-marked-in-flight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-has-operation-marked-in-flight" class="dfn-panel" data-for="writable-stream-has-operation-marked-in-flight" id="infopanel-for-writable-stream-has-operation-marked-in-flight" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-has-operation-marked-in-flight" style="display:none">Info about the 'WritableStreamHasOperationMarkedInFlight(stream)' definition.</span><b><a href="#writable-stream-has-operation-marked-in-flight">#writable-stream-has-operation-marked-in-flight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-has-operation-marked-in-flight">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writable-stream-has-operation-marked-in-flight①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-mark-close-request-in-flight">
-   <b><a href="#writable-stream-mark-close-request-in-flight">#writable-stream-mark-close-request-in-flight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-mark-close-request-in-flight" class="dfn-panel" data-for="writable-stream-mark-close-request-in-flight" id="infopanel-for-writable-stream-mark-close-request-in-flight" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-mark-close-request-in-flight" style="display:none">Info about the 'WritableStreamMarkCloseRequestInFlight(stream)' definition.</span><b><a href="#writable-stream-mark-close-request-in-flight">#writable-stream-mark-close-request-in-flight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-mark-close-request-in-flight">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-mark-first-write-request-in-flight">
-   <b><a href="#writable-stream-mark-first-write-request-in-flight">#writable-stream-mark-first-write-request-in-flight</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-mark-first-write-request-in-flight" class="dfn-panel" data-for="writable-stream-mark-first-write-request-in-flight" id="infopanel-for-writable-stream-mark-first-write-request-in-flight" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-mark-first-write-request-in-flight" style="display:none">Info about the 'WritableStreamMarkFirstWriteRequestInFlight(stream)' definition.</span><b><a href="#writable-stream-mark-first-write-request-in-flight">#writable-stream-mark-first-write-request-in-flight</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-mark-first-write-request-in-flight">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-reject-close-and-closed-promise-if-needed">
-   <b><a href="#writable-stream-reject-close-and-closed-promise-if-needed">#writable-stream-reject-close-and-closed-promise-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-reject-close-and-closed-promise-if-needed" class="dfn-panel" data-for="writable-stream-reject-close-and-closed-promise-if-needed" id="infopanel-for-writable-stream-reject-close-and-closed-promise-if-needed" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-reject-close-and-closed-promise-if-needed" style="display:none">Info about the 'WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream)' definition.</span><b><a href="#writable-stream-reject-close-and-closed-promise-if-needed">#writable-stream-reject-close-and-closed-promise-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-reject-close-and-closed-promise-if-needed">5.5.2. Interfacing with controllers</a> <a href="#ref-for-writable-stream-reject-close-and-closed-promise-if-needed①">(2)</a> <a href="#ref-for-writable-stream-reject-close-and-closed-promise-if-needed②">(3)</a> <a href="#ref-for-writable-stream-reject-close-and-closed-promise-if-needed③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-start-erroring">
-   <b><a href="#writable-stream-start-erroring">#writable-stream-start-erroring</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-start-erroring" class="dfn-panel" data-for="writable-stream-start-erroring" id="infopanel-for-writable-stream-start-erroring" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-start-erroring" style="display:none">Info about the 'WritableStreamStartErroring(stream, reason)' definition.</span><b><a href="#writable-stream-start-erroring">#writable-stream-start-erroring</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-start-erroring">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-writable-stream-start-erroring①">5.5.2. Interfacing with controllers</a>
     <li><a href="#ref-for-writable-stream-start-erroring②">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-update-backpressure">
-   <b><a href="#writable-stream-update-backpressure">#writable-stream-update-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-update-backpressure" class="dfn-panel" data-for="writable-stream-update-backpressure" id="infopanel-for-writable-stream-update-backpressure" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-update-backpressure" style="display:none">Info about the 'WritableStreamUpdateBackpressure(stream,
+ backpressure)' definition.</span><b><a href="#writable-stream-update-backpressure">#writable-stream-update-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-update-backpressure">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-update-backpressure①">(2)</a> <a href="#ref-for-writable-stream-update-backpressure②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-abort">
-   <b><a href="#writable-stream-default-writer-abort">#writable-stream-default-writer-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-abort" class="dfn-panel" data-for="writable-stream-default-writer-abort" id="infopanel-for-writable-stream-default-writer-abort" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-abort" style="display:none">Info about the 'WritableStreamDefaultWriterAbort(writer,
+ reason)' definition.</span><b><a href="#writable-stream-default-writer-abort">#writable-stream-default-writer-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-abort">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-close">
-   <b><a href="#writable-stream-default-writer-close">#writable-stream-default-writer-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-close" class="dfn-panel" data-for="writable-stream-default-writer-close" id="infopanel-for-writable-stream-default-writer-close" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-close" style="display:none">Info about the 'WritableStreamDefaultWriterClose(writer)' definition.</span><b><a href="#writable-stream-default-writer-close">#writable-stream-default-writer-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-close">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writable-stream-default-writer-close①">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-close-with-error-propagation">
-   <b><a href="#writable-stream-default-writer-close-with-error-propagation">#writable-stream-default-writer-close-with-error-propagation</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-close-with-error-propagation" class="dfn-panel" data-for="writable-stream-default-writer-close-with-error-propagation" id="infopanel-for-writable-stream-default-writer-close-with-error-propagation" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-close-with-error-propagation" style="display:none">Info about the 'WritableStreamDefaultWriterCloseWithErrorPropagation(writer)' definition.</span><b><a href="#writable-stream-default-writer-close-with-error-propagation">#writable-stream-default-writer-close-with-error-propagation</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-close-with-error-propagation">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-ensure-closed-promise-rejected">
-   <b><a href="#writable-stream-default-writer-ensure-closed-promise-rejected">#writable-stream-default-writer-ensure-closed-promise-rejected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-ensure-closed-promise-rejected" class="dfn-panel" data-for="writable-stream-default-writer-ensure-closed-promise-rejected" id="infopanel-for-writable-stream-default-writer-ensure-closed-promise-rejected" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-ensure-closed-promise-rejected" style="display:none">Info about the 'WritableStreamDefaultWriterEnsureClosedPromiseRejected(writer,
+ error)' definition.</span><b><a href="#writable-stream-default-writer-ensure-closed-promise-rejected">#writable-stream-default-writer-ensure-closed-promise-rejected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-ensure-closed-promise-rejected">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-ensure-ready-promise-rejected">
-   <b><a href="#writable-stream-default-writer-ensure-ready-promise-rejected">#writable-stream-default-writer-ensure-ready-promise-rejected</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-ensure-ready-promise-rejected" class="dfn-panel" data-for="writable-stream-default-writer-ensure-ready-promise-rejected" id="infopanel-for-writable-stream-default-writer-ensure-ready-promise-rejected" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-ensure-ready-promise-rejected" style="display:none">Info about the 'WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer,
+ error)' definition.</span><b><a href="#writable-stream-default-writer-ensure-ready-promise-rejected">#writable-stream-default-writer-ensure-ready-promise-rejected</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-ensure-ready-promise-rejected">5.5.2. Interfacing with controllers</a>
     <li><a href="#ref-for-writable-stream-default-writer-ensure-ready-promise-rejected①">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-get-desired-size">
-   <b><a href="#writable-stream-default-writer-get-desired-size">#writable-stream-default-writer-get-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-get-desired-size" class="dfn-panel" data-for="writable-stream-default-writer-get-desired-size" id="infopanel-for-writable-stream-default-writer-get-desired-size" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-get-desired-size" style="display:none">Info about the 'WritableStreamDefaultWriterGetDesiredSize(writer)' definition.</span><b><a href="#writable-stream-default-writer-get-desired-size">#writable-stream-default-writer-get-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-get-desired-size">4.9.1. Working with readable streams</a> <a href="#ref-for-writable-stream-default-writer-get-desired-size①">(2)</a>
     <li><a href="#ref-for-writable-stream-default-writer-get-desired-size②">5.3.3. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-release">
-   <b><a href="#writable-stream-default-writer-release">#writable-stream-default-writer-release</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-release" class="dfn-panel" data-for="writable-stream-default-writer-release" id="infopanel-for-writable-stream-default-writer-release" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-release" style="display:none">Info about the 'WritableStreamDefaultWriterRelease(writer)' definition.</span><b><a href="#writable-stream-default-writer-release">#writable-stream-default-writer-release</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-release">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-writable-stream-default-writer-release①">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writable-stream-default-writer-release②">9.2.2. Writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-writer-write">
-   <b><a href="#writable-stream-default-writer-write">#writable-stream-default-writer-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-writer-write" class="dfn-panel" data-for="writable-stream-default-writer-write" id="infopanel-for-writable-stream-default-writer-write" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-writer-write" style="display:none">Info about the 'WritableStreamDefaultWriterWrite(writer, chunk)' definition.</span><b><a href="#writable-stream-default-writer-write">#writable-stream-default-writer-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-writer-write">5.3.3. Constructor, methods, and properties</a>
     <li><a href="#ref-for-writable-stream-default-writer-write①">9.2.2. Writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-writable-stream-default-controller">
-   <b><a href="#set-up-writable-stream-default-controller">#set-up-writable-stream-default-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-writable-stream-default-controller" class="dfn-panel" data-for="set-up-writable-stream-default-controller" id="infopanel-for-set-up-writable-stream-default-controller" role="dialog">
+   <span id="infopaneltitle-for-set-up-writable-stream-default-controller" style="display:none">Info about the 'SetUpWritableStreamDefaultController(stream,
+ controller, startAlgorithm, writeAlgorithm, closeAlgorithm, abortAlgorithm,
+ highWaterMark, sizeAlgorithm)' definition.</span><b><a href="#set-up-writable-stream-default-controller">#set-up-writable-stream-default-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-writable-stream-default-controller">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-set-up-writable-stream-default-controller①">5.5.4. Default controllers</a>
@@ -14085,85 +14130,91 @@ create new readable streams</a>
     <li><a href="#ref-for-set-up-writable-stream-default-controller③">9.2.1. Creation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-writable-stream-default-controller-from-underlying-sink">
-   <b><a href="#set-up-writable-stream-default-controller-from-underlying-sink">#set-up-writable-stream-default-controller-from-underlying-sink</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-writable-stream-default-controller-from-underlying-sink" class="dfn-panel" data-for="set-up-writable-stream-default-controller-from-underlying-sink" id="infopanel-for-set-up-writable-stream-default-controller-from-underlying-sink" role="dialog">
+   <span id="infopaneltitle-for-set-up-writable-stream-default-controller-from-underlying-sink" style="display:none">Info about the 'SetUpWritableStreamDefaultControllerFromUnderlyingSink(stream,
+ underlyingSink, underlyingSinkDict, highWaterMark, sizeAlgorithm)' definition.</span><b><a href="#set-up-writable-stream-default-controller-from-underlying-sink">#set-up-writable-stream-default-controller-from-underlying-sink</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-writable-stream-default-controller-from-underlying-sink">5.2.4. Constructor, methods, and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-advance-queue-if-needed">
-   <b><a href="#writable-stream-default-controller-advance-queue-if-needed">#writable-stream-default-controller-advance-queue-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-advance-queue-if-needed" class="dfn-panel" data-for="writable-stream-default-controller-advance-queue-if-needed" id="infopanel-for-writable-stream-default-controller-advance-queue-if-needed" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-advance-queue-if-needed" style="display:none">Info about the 'WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller)' definition.</span><b><a href="#writable-stream-default-controller-advance-queue-if-needed">#writable-stream-default-controller-advance-queue-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-advance-queue-if-needed">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-default-controller-advance-queue-if-needed①">(2)</a> <a href="#ref-for-writable-stream-default-controller-advance-queue-if-needed②">(3)</a> <a href="#ref-for-writable-stream-default-controller-advance-queue-if-needed③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-clear-algorithms">
-   <b><a href="#writable-stream-default-controller-clear-algorithms">#writable-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-clear-algorithms" class="dfn-panel" data-for="writable-stream-default-controller-clear-algorithms" id="infopanel-for-writable-stream-default-controller-clear-algorithms" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-clear-algorithms" style="display:none">Info about the 'WritableStreamDefaultControllerClearAlgorithms(controller)' definition.</span><b><a href="#writable-stream-default-controller-clear-algorithms">#writable-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-clear-algorithms">5.4.4. Internal methods</a>
     <li><a href="#ref-for-writable-stream-default-controller-clear-algorithms①">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-default-controller-clear-algorithms②">(2)</a> <a href="#ref-for-writable-stream-default-controller-clear-algorithms③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-close">
-   <b><a href="#writable-stream-default-controller-close">#writable-stream-default-controller-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-close" class="dfn-panel" data-for="writable-stream-default-controller-close" id="infopanel-for-writable-stream-default-controller-close" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-close" style="display:none">Info about the 'WritableStreamDefaultControllerClose(controller)' definition.</span><b><a href="#writable-stream-default-controller-close">#writable-stream-default-controller-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-close">5.5.1. Working with writable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-error">
-   <b><a href="#writable-stream-default-controller-error">#writable-stream-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-error" class="dfn-panel" data-for="writable-stream-default-controller-error" id="infopanel-for-writable-stream-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-error" style="display:none">Info about the 'WritableStreamDefaultControllerError(controller,
+ error)' definition.</span><b><a href="#writable-stream-default-controller-error">#writable-stream-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-error">5.4.3. Methods</a>
     <li><a href="#ref-for-writable-stream-default-controller-error①">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-error-if-needed">
-   <b><a href="#writable-stream-default-controller-error-if-needed">#writable-stream-default-controller-error-if-needed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-error-if-needed" class="dfn-panel" data-for="writable-stream-default-controller-error-if-needed" id="infopanel-for-writable-stream-default-controller-error-if-needed" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-error-if-needed" style="display:none">Info about the 'WritableStreamDefaultControllerErrorIfNeeded(controller,
+ error)' definition.</span><b><a href="#writable-stream-default-controller-error-if-needed">#writable-stream-default-controller-error-if-needed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-error-if-needed">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-default-controller-error-if-needed①">(2)</a>
     <li><a href="#ref-for-writable-stream-default-controller-error-if-needed②">6.4.1. Working with transform streams</a>
     <li><a href="#ref-for-writable-stream-default-controller-error-if-needed③">8.2. Transferable streams</a> <a href="#ref-for-writable-stream-default-controller-error-if-needed④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-get-backpressure">
-   <b><a href="#writable-stream-default-controller-get-backpressure">#writable-stream-default-controller-get-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-get-backpressure" class="dfn-panel" data-for="writable-stream-default-controller-get-backpressure" id="infopanel-for-writable-stream-default-controller-get-backpressure" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-get-backpressure" style="display:none">Info about the 'WritableStreamDefaultControllerGetBackpressure(controller)' definition.</span><b><a href="#writable-stream-default-controller-get-backpressure">#writable-stream-default-controller-get-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-get-backpressure">5.5.4. Default controllers</a> <a href="#ref-for-writable-stream-default-controller-get-backpressure①">(2)</a> <a href="#ref-for-writable-stream-default-controller-get-backpressure②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-get-chunk-size">
-   <b><a href="#writable-stream-default-controller-get-chunk-size">#writable-stream-default-controller-get-chunk-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-get-chunk-size" class="dfn-panel" data-for="writable-stream-default-controller-get-chunk-size" id="infopanel-for-writable-stream-default-controller-get-chunk-size" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-get-chunk-size" style="display:none">Info about the 'WritableStreamDefaultControllerGetChunkSize(controller,
+ chunk)' definition.</span><b><a href="#writable-stream-default-controller-get-chunk-size">#writable-stream-default-controller-get-chunk-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-get-chunk-size">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-get-desired-size">
-   <b><a href="#writable-stream-default-controller-get-desired-size">#writable-stream-default-controller-get-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-get-desired-size" class="dfn-panel" data-for="writable-stream-default-controller-get-desired-size" id="infopanel-for-writable-stream-default-controller-get-desired-size" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-get-desired-size" style="display:none">Info about the 'WritableStreamDefaultControllerGetDesiredSize(controller)' definition.</span><b><a href="#writable-stream-default-controller-get-desired-size">#writable-stream-default-controller-get-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-get-desired-size">5.5.3. Writers</a>
     <li><a href="#ref-for-writable-stream-default-controller-get-desired-size①">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-process-close">
-   <b><a href="#writable-stream-default-controller-process-close">#writable-stream-default-controller-process-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-process-close" class="dfn-panel" data-for="writable-stream-default-controller-process-close" id="infopanel-for-writable-stream-default-controller-process-close" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-process-close" style="display:none">Info about the 'WritableStreamDefaultControllerProcessClose(controller)' definition.</span><b><a href="#writable-stream-default-controller-process-close">#writable-stream-default-controller-process-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-process-close">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-process-write">
-   <b><a href="#writable-stream-default-controller-process-write">#writable-stream-default-controller-process-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-process-write" class="dfn-panel" data-for="writable-stream-default-controller-process-write" id="infopanel-for-writable-stream-default-controller-process-write" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-process-write" style="display:none">Info about the 'WritableStreamDefaultControllerProcessWrite(controller,
+ chunk)' definition.</span><b><a href="#writable-stream-default-controller-process-write">#writable-stream-default-controller-process-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-process-write">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writable-stream-default-controller-write">
-   <b><a href="#writable-stream-default-controller-write">#writable-stream-default-controller-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writable-stream-default-controller-write" class="dfn-panel" data-for="writable-stream-default-controller-write" id="infopanel-for-writable-stream-default-controller-write" role="dialog">
+   <span id="infopaneltitle-for-writable-stream-default-controller-write" style="display:none">Info about the 'WritableStreamDefaultControllerWrite(controller,
+ chunk, chunkSize)' definition.</span><b><a href="#writable-stream-default-controller-write">#writable-stream-default-controller-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writable-stream-default-controller-write">5.5.3. Writers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream">
-   <b><a href="#transformstream">#transformstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream" class="dfn-panel" data-for="transformstream" id="infopanel-for-transformstream" role="dialog">
+   <span id="infopaneltitle-for-transformstream" style="display:none">Info about the 'TransformStream' definition.</span><b><a href="#transformstream">#transformstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream">2.3. Transform streams</a> <a href="#ref-for-transformstream①">(2)</a>
     <li><a href="#ref-for-transformstream②">4.9.4. Default controllers</a>
@@ -14185,8 +14236,8 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream③⑥">10.10. A transform stream created from a sync mapper function</a> <a href="#ref-for-transformstream③⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-backpressure">
-   <b><a href="#transformstream-backpressure">#transformstream-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-backpressure" class="dfn-panel" data-for="transformstream-backpressure" id="infopanel-for-transformstream-backpressure" role="dialog">
+   <span id="infopaneltitle-for-transformstream-backpressure" style="display:none">Info about the '[[backpressure]]' definition.</span><b><a href="#transformstream-backpressure">#transformstream-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-backpressure">6.2.2. Internal slots</a>
     <li><a href="#ref-for-transformstream-backpressure①">6.2.5. Transfer via postMessage()</a> <a href="#ref-for-transformstream-backpressure②">(2)</a>
@@ -14196,8 +14247,8 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream-backpressure①①">6.4.4. Default sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-backpressurechangepromise">
-   <b><a href="#transformstream-backpressurechangepromise">#transformstream-backpressurechangepromise</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-backpressurechangepromise" class="dfn-panel" data-for="transformstream-backpressurechangepromise" id="infopanel-for-transformstream-backpressurechangepromise" role="dialog">
+   <span id="infopaneltitle-for-transformstream-backpressurechangepromise" style="display:none">Info about the '[[backpressureChangePromise]]' definition.</span><b><a href="#transformstream-backpressurechangepromise">#transformstream-backpressurechangepromise</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-backpressurechangepromise">6.2.5. Transfer via postMessage()</a> <a href="#ref-for-transformstream-backpressurechangepromise①">(2)</a>
     <li><a href="#ref-for-transformstream-backpressurechangepromise②">6.4.1. Working with transform streams</a> <a href="#ref-for-transformstream-backpressurechangepromise③">(2)</a> <a href="#ref-for-transformstream-backpressurechangepromise④">(3)</a> <a href="#ref-for-transformstream-backpressurechangepromise⑤">(4)</a> <a href="#ref-for-transformstream-backpressurechangepromise⑥">(5)</a>
@@ -14205,8 +14256,8 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream-backpressurechangepromise⑧">6.4.4. Default sources</a> <a href="#ref-for-transformstream-backpressurechangepromise⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-controller">
-   <b><a href="#transformstream-controller">#transformstream-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-controller" class="dfn-panel" data-for="transformstream-controller" id="infopanel-for-transformstream-controller" role="dialog">
+   <span id="infopaneltitle-for-transformstream-controller" style="display:none">Info about the '[[controller]]' definition.</span><b><a href="#transformstream-controller">#transformstream-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-controller">6.2.4. Constructor and properties</a>
     <li><a href="#ref-for-transformstream-controller①">6.2.5. Transfer via postMessage()</a> <a href="#ref-for-transformstream-controller②">(2)</a>
@@ -14216,8 +14267,8 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream-controller⑨">9.3.1. Creation and manipulation</a> <a href="#ref-for-transformstream-controller①⓪">(2)</a> <a href="#ref-for-transformstream-controller①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-readable">
-   <b><a href="#transformstream-readable">#transformstream-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-readable" class="dfn-panel" data-for="transformstream-readable" id="infopanel-for-transformstream-readable" role="dialog">
+   <span id="infopaneltitle-for-transformstream-readable" style="display:none">Info about the '[[readable]]' definition.</span><b><a href="#transformstream-readable">#transformstream-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-readable">6.2.2. Internal slots</a> <a href="#ref-for-transformstream-readable①">(2)</a>
     <li><a href="#ref-for-transformstream-readable②">6.2.4. Constructor and properties</a>
@@ -14230,8 +14281,8 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream-readable①③">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-writable">
-   <b><a href="#transformstream-writable">#transformstream-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-writable" class="dfn-panel" data-for="transformstream-writable" id="infopanel-for-transformstream-writable" role="dialog">
+   <span id="infopaneltitle-for-transformstream-writable" style="display:none">Info about the '[[writable]]' definition.</span><b><a href="#transformstream-writable">#transformstream-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-writable">6.2.2. Internal slots</a>
     <li><a href="#ref-for-transformstream-writable①">6.2.4. Constructor and properties</a>
@@ -14242,69 +14293,70 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstream-writable⑨">9.5. Piping</a> <a href="#ref-for-transformstream-writable①⓪">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-transformer">
-   <b><a href="#dictdef-transformer">#dictdef-transformer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-transformer" class="dfn-panel" data-for="dictdef-transformer" id="infopanel-for-dictdef-transformer" role="dialog">
+   <span id="infopaneltitle-for-dictdef-transformer" style="display:none">Info about the 'Transformer' definition.</span><b><a href="#dictdef-transformer">#dictdef-transformer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-transformer">6.2.4. Constructor and properties</a> <a href="#ref-for-dictdef-transformer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-transformerstartcallback">
-   <b><a href="#callbackdef-transformerstartcallback">#callbackdef-transformerstartcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-transformerstartcallback" class="dfn-panel" data-for="callbackdef-transformerstartcallback" id="infopanel-for-callbackdef-transformerstartcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-transformerstartcallback" style="display:none">Info about the 'TransformerStartCallback' definition.</span><b><a href="#callbackdef-transformerstartcallback">#callbackdef-transformerstartcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-transformerstartcallback">6.2.3. The transformer API</a> <a href="#ref-for-callbackdef-transformerstartcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-transformerflushcallback">
-   <b><a href="#callbackdef-transformerflushcallback">#callbackdef-transformerflushcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-transformerflushcallback" class="dfn-panel" data-for="callbackdef-transformerflushcallback" id="infopanel-for-callbackdef-transformerflushcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-transformerflushcallback" style="display:none">Info about the 'TransformerFlushCallback' definition.</span><b><a href="#callbackdef-transformerflushcallback">#callbackdef-transformerflushcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-transformerflushcallback">6.2.3. The transformer API</a> <a href="#ref-for-callbackdef-transformerflushcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-transformertransformcallback">
-   <b><a href="#callbackdef-transformertransformcallback">#callbackdef-transformertransformcallback</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-transformertransformcallback" class="dfn-panel" data-for="callbackdef-transformertransformcallback" id="infopanel-for-callbackdef-transformertransformcallback" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-transformertransformcallback" style="display:none">Info about the 'TransformerTransformCallback' definition.</span><b><a href="#callbackdef-transformertransformcallback">#callbackdef-transformertransformcallback</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-transformertransformcallback">6.2.3. The transformer API</a> <a href="#ref-for-callbackdef-transformertransformcallback①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transformer-start">
-   <b><a href="#dom-transformer-start">#dom-transformer-start</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transformer-start" class="dfn-panel" data-for="dom-transformer-start" id="infopanel-for-dom-transformer-start" role="dialog">
+   <span id="infopaneltitle-for-dom-transformer-start" style="display:none">Info about the 'start(controller)' definition.</span><b><a href="#dom-transformer-start">#dom-transformer-start</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transformer-start">6.2.3. The transformer API</a> <a href="#ref-for-dom-transformer-start①">(2)</a> <a href="#ref-for-dom-transformer-start②">(3)</a>
     <li><a href="#ref-for-dom-transformer-start③">6.2.4. Constructor and properties</a> <a href="#ref-for-dom-transformer-start④">(2)</a>
     <li><a href="#ref-for-dom-transformer-start⑤">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transformer-transform">
-   <b><a href="#dom-transformer-transform">#dom-transformer-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transformer-transform" class="dfn-panel" data-for="dom-transformer-transform" id="infopanel-for-dom-transformer-transform" role="dialog">
+   <span id="infopaneltitle-for-dom-transformer-transform" style="display:none">Info about the 'transform(chunk, controller)' definition.</span><b><a href="#dom-transformer-transform">#dom-transformer-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transformer-transform">2.3. Transform streams</a>
     <li><a href="#ref-for-dom-transformer-transform①">6.2.3. The transformer API</a> <a href="#ref-for-dom-transformer-transform②">(2)</a> <a href="#ref-for-dom-transformer-transform③">(3)</a> <a href="#ref-for-dom-transformer-transform④">(4)</a>
     <li><a href="#ref-for-dom-transformer-transform⑤">6.4.2. Default controllers</a> <a href="#ref-for-dom-transformer-transform⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transformer-flush">
-   <b><a href="#dom-transformer-flush">#dom-transformer-flush</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transformer-flush" class="dfn-panel" data-for="dom-transformer-flush" id="infopanel-for-dom-transformer-flush" role="dialog">
+   <span id="infopaneltitle-for-dom-transformer-flush" style="display:none">Info about the 'flush(controller)' definition.</span><b><a href="#dom-transformer-flush">#dom-transformer-flush</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transformer-flush">6.2.3. The transformer API</a> <a href="#ref-for-dom-transformer-flush①">(2)</a> <a href="#ref-for-dom-transformer-flush②">(3)</a> <a href="#ref-for-dom-transformer-flush③">(4)</a>
     <li><a href="#ref-for-dom-transformer-flush④">6.4.2. Default controllers</a> <a href="#ref-for-dom-transformer-flush⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transformer-readabletype">
-   <b><a href="#dom-transformer-readabletype">#dom-transformer-readabletype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transformer-readabletype" class="dfn-panel" data-for="dom-transformer-readabletype" id="infopanel-for-dom-transformer-readabletype" role="dialog">
+   <span id="infopaneltitle-for-dom-transformer-readabletype" style="display:none">Info about the 'readableType' definition.</span><b><a href="#dom-transformer-readabletype">#dom-transformer-readabletype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transformer-readabletype">6.2.3. The transformer API</a>
     <li><a href="#ref-for-dom-transformer-readabletype①">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-transformer-writabletype">
-   <b><a href="#dom-transformer-writabletype">#dom-transformer-writabletype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-transformer-writabletype" class="dfn-panel" data-for="dom-transformer-writabletype" id="infopanel-for-dom-transformer-writabletype" role="dialog">
+   <span id="infopaneltitle-for-dom-transformer-writabletype" style="display:none">Info about the 'writableType' definition.</span><b><a href="#dom-transformer-writabletype">#dom-transformer-writabletype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-transformer-writabletype">6.2.3. The transformer API</a>
     <li><a href="#ref-for-dom-transformer-writabletype①">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-constructor">
-   <b><a href="#ts-constructor">#ts-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-constructor" class="dfn-panel" data-for="ts-constructor" id="infopanel-for-ts-constructor" role="dialog">
+   <span id="infopaneltitle-for-ts-constructor" style="display:none">Info about the 'new TransformStream(transformer, writableStrategy,
+ readableStrategy)' definition.</span><b><a href="#ts-constructor">#ts-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-constructor">2.3. Transform streams</a>
     <li><a href="#ref-for-ts-constructor①">6.2.1. Interface definition</a>
@@ -14313,24 +14365,24 @@ create new readable streams</a>
     <li><a href="#ref-for-ts-constructor⑤">7.1. The queuing strategy API</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-readable">
-   <b><a href="#ts-readable">#ts-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-readable" class="dfn-panel" data-for="ts-readable" id="infopanel-for-ts-readable" role="dialog">
+   <span id="infopaneltitle-for-ts-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#ts-readable">#ts-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-readable">6.1. Using transform streams</a>
     <li><a href="#ref-for-ts-readable①">6.2.1. Interface definition</a>
     <li><a href="#ref-for-ts-readable②">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-writable">
-   <b><a href="#ts-writable">#ts-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-writable" class="dfn-panel" data-for="ts-writable" id="infopanel-for-ts-writable" role="dialog">
+   <span id="infopaneltitle-for-ts-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#ts-writable">#ts-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-writable">6.1. Using transform streams</a>
     <li><a href="#ref-for-ts-writable①">6.2.1. Interface definition</a>
     <li><a href="#ref-for-ts-writable②">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstreamdefaultcontroller">
-   <b><a href="#transformstreamdefaultcontroller">#transformstreamdefaultcontroller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstreamdefaultcontroller" class="dfn-panel" data-for="transformstreamdefaultcontroller" id="infopanel-for-transformstreamdefaultcontroller" role="dialog">
+   <span id="infopaneltitle-for-transformstreamdefaultcontroller" style="display:none">Info about the 'TransformStreamDefaultController' definition.</span><b><a href="#transformstreamdefaultcontroller">#transformstreamdefaultcontroller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstreamdefaultcontroller">6.2.2. Internal slots</a>
     <li><a href="#ref-for-transformstreamdefaultcontroller①">6.2.3. The transformer API</a> <a href="#ref-for-transformstreamdefaultcontroller②">(2)</a> <a href="#ref-for-transformstreamdefaultcontroller③">(3)</a> <a href="#ref-for-transformstreamdefaultcontroller④">(4)</a>
@@ -14341,159 +14393,170 @@ create new readable streams</a>
     <li><a href="#ref-for-transformstreamdefaultcontroller①②">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstreamdefaultcontroller-flushalgorithm">
-   <b><a href="#transformstreamdefaultcontroller-flushalgorithm">#transformstreamdefaultcontroller-flushalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstreamdefaultcontroller-flushalgorithm" class="dfn-panel" data-for="transformstreamdefaultcontroller-flushalgorithm" id="infopanel-for-transformstreamdefaultcontroller-flushalgorithm" role="dialog">
+   <span id="infopaneltitle-for-transformstreamdefaultcontroller-flushalgorithm" style="display:none">Info about the '[[flushAlgorithm]]' definition.</span><b><a href="#transformstreamdefaultcontroller-flushalgorithm">#transformstreamdefaultcontroller-flushalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstreamdefaultcontroller-flushalgorithm">6.4.2. Default controllers</a> <a href="#ref-for-transformstreamdefaultcontroller-flushalgorithm①">(2)</a>
     <li><a href="#ref-for-transformstreamdefaultcontroller-flushalgorithm②">6.4.3. Default sinks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstreamdefaultcontroller-stream">
-   <b><a href="#transformstreamdefaultcontroller-stream">#transformstreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstreamdefaultcontroller-stream" class="dfn-panel" data-for="transformstreamdefaultcontroller-stream" id="infopanel-for-transformstreamdefaultcontroller-stream" role="dialog">
+   <span id="infopaneltitle-for-transformstreamdefaultcontroller-stream" style="display:none">Info about the '[[stream]]' definition.</span><b><a href="#transformstreamdefaultcontroller-stream">#transformstreamdefaultcontroller-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstreamdefaultcontroller-stream">6.3.3. Methods and properties</a>
     <li><a href="#ref-for-transformstreamdefaultcontroller-stream①">6.4.2. Default controllers</a> <a href="#ref-for-transformstreamdefaultcontroller-stream②">(2)</a> <a href="#ref-for-transformstreamdefaultcontroller-stream③">(3)</a> <a href="#ref-for-transformstreamdefaultcontroller-stream④">(4)</a> <a href="#ref-for-transformstreamdefaultcontroller-stream⑤">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstreamdefaultcontroller-transformalgorithm">
-   <b><a href="#transformstreamdefaultcontroller-transformalgorithm">#transformstreamdefaultcontroller-transformalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstreamdefaultcontroller-transformalgorithm" class="dfn-panel" data-for="transformstreamdefaultcontroller-transformalgorithm" id="infopanel-for-transformstreamdefaultcontroller-transformalgorithm" role="dialog">
+   <span id="infopaneltitle-for-transformstreamdefaultcontroller-transformalgorithm" style="display:none">Info about the '[[transformAlgorithm]]' definition.</span><b><a href="#transformstreamdefaultcontroller-transformalgorithm">#transformstreamdefaultcontroller-transformalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstreamdefaultcontroller-transformalgorithm">6.4.2. Default controllers</a> <a href="#ref-for-transformstreamdefaultcontroller-transformalgorithm①">(2)</a> <a href="#ref-for-transformstreamdefaultcontroller-transformalgorithm②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-default-controller-desired-size">
-   <b><a href="#ts-default-controller-desired-size">#ts-default-controller-desired-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-default-controller-desired-size" class="dfn-panel" data-for="ts-default-controller-desired-size" id="infopanel-for-ts-default-controller-desired-size" role="dialog">
+   <span id="infopaneltitle-for-ts-default-controller-desired-size" style="display:none">Info about the 'desiredSize' definition.</span><b><a href="#ts-default-controller-desired-size">#ts-default-controller-desired-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-default-controller-desired-size">6.3.1. Interface definition</a>
     <li><a href="#ref-for-ts-default-controller-desired-size①">6.3.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-default-controller-enqueue">
-   <b><a href="#ts-default-controller-enqueue">#ts-default-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-default-controller-enqueue" class="dfn-panel" data-for="ts-default-controller-enqueue" id="infopanel-for-ts-default-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-ts-default-controller-enqueue" style="display:none">Info about the 'enqueue(chunk)' definition.</span><b><a href="#ts-default-controller-enqueue">#ts-default-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-default-controller-enqueue">6.2.3. The transformer API</a> <a href="#ref-for-ts-default-controller-enqueue①">(2)</a> <a href="#ref-for-ts-default-controller-enqueue②">(3)</a>
     <li><a href="#ref-for-ts-default-controller-enqueue③">6.3.1. Interface definition</a>
     <li><a href="#ref-for-ts-default-controller-enqueue④">6.3.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-default-controller-error">
-   <b><a href="#ts-default-controller-error">#ts-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-default-controller-error" class="dfn-panel" data-for="ts-default-controller-error" id="infopanel-for-ts-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-ts-default-controller-error" style="display:none">Info about the 'error(e)' definition.</span><b><a href="#ts-default-controller-error">#ts-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-default-controller-error">6.3.1. Interface definition</a>
     <li><a href="#ref-for-ts-default-controller-error①">6.3.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ts-default-controller-terminate">
-   <b><a href="#ts-default-controller-terminate">#ts-default-controller-terminate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ts-default-controller-terminate" class="dfn-panel" data-for="ts-default-controller-terminate" id="infopanel-for-ts-default-controller-terminate" role="dialog">
+   <span id="infopaneltitle-for-ts-default-controller-terminate" style="display:none">Info about the 'terminate()' definition.</span><b><a href="#ts-default-controller-terminate">#ts-default-controller-terminate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ts-default-controller-terminate">6.2.3. The transformer API</a>
     <li><a href="#ref-for-ts-default-controller-terminate①">6.3.1. Interface definition</a>
     <li><a href="#ref-for-ts-default-controller-terminate②">6.3.3. Methods and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="initialize-transform-stream">
-   <b><a href="#initialize-transform-stream">#initialize-transform-stream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-initialize-transform-stream" class="dfn-panel" data-for="initialize-transform-stream" id="infopanel-for-initialize-transform-stream" role="dialog">
+   <span id="infopaneltitle-for-initialize-transform-stream" style="display:none">Info about the 'InitializeTransformStream(stream, startPromise,
+ writableHighWaterMark, writableSizeAlgorithm, readableHighWaterMark,
+ readableSizeAlgorithm)' definition.</span><b><a href="#initialize-transform-stream">#initialize-transform-stream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-initialize-transform-stream">6.2.4. Constructor and properties</a>
     <li><a href="#ref-for-initialize-transform-stream①">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-error">
-   <b><a href="#transform-stream-error">#transform-stream-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-error" class="dfn-panel" data-for="transform-stream-error" id="infopanel-for-transform-stream-error" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-error" style="display:none">Info about the 'TransformStreamError(stream, e)' definition.</span><b><a href="#transform-stream-error">#transform-stream-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-error">6.4.2. Default controllers</a> <a href="#ref-for-transform-stream-error①">(2)</a>
     <li><a href="#ref-for-transform-stream-error②">6.4.3. Default sinks</a> <a href="#ref-for-transform-stream-error③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-error-writable-and-unblock-write">
-   <b><a href="#transform-stream-error-writable-and-unblock-write">#transform-stream-error-writable-and-unblock-write</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-error-writable-and-unblock-write" class="dfn-panel" data-for="transform-stream-error-writable-and-unblock-write" id="infopanel-for-transform-stream-error-writable-and-unblock-write" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-error-writable-and-unblock-write" style="display:none">Info about the 'TransformStreamErrorWritableAndUnblockWrite(stream,
+ e)' definition.</span><b><a href="#transform-stream-error-writable-and-unblock-write">#transform-stream-error-writable-and-unblock-write</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-error-writable-and-unblock-write">6.4.1. Working with transform streams</a> <a href="#ref-for-transform-stream-error-writable-and-unblock-write①">(2)</a>
     <li><a href="#ref-for-transform-stream-error-writable-and-unblock-write②">6.4.2. Default controllers</a> <a href="#ref-for-transform-stream-error-writable-and-unblock-write③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-set-backpressure">
-   <b><a href="#transform-stream-set-backpressure">#transform-stream-set-backpressure</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-set-backpressure" class="dfn-panel" data-for="transform-stream-set-backpressure" id="infopanel-for-transform-stream-set-backpressure" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-set-backpressure" style="display:none">Info about the 'TransformStreamSetBackpressure(stream,
+ backpressure)' definition.</span><b><a href="#transform-stream-set-backpressure">#transform-stream-set-backpressure</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-set-backpressure">6.4.1. Working with transform streams</a> <a href="#ref-for-transform-stream-set-backpressure①">(2)</a> <a href="#ref-for-transform-stream-set-backpressure②">(3)</a> <a href="#ref-for-transform-stream-set-backpressure③">(4)</a>
     <li><a href="#ref-for-transform-stream-set-backpressure④">6.4.2. Default controllers</a>
     <li><a href="#ref-for-transform-stream-set-backpressure⑤">6.4.4. Default sources</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-transform-stream-default-controller">
-   <b><a href="#set-up-transform-stream-default-controller">#set-up-transform-stream-default-controller</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-transform-stream-default-controller" class="dfn-panel" data-for="set-up-transform-stream-default-controller" id="infopanel-for-set-up-transform-stream-default-controller" role="dialog">
+   <span id="infopaneltitle-for-set-up-transform-stream-default-controller" style="display:none">Info about the 'SetUpTransformStreamDefaultController(stream,
+ controller, transformAlgorithm, flushAlgorithm)' definition.</span><b><a href="#set-up-transform-stream-default-controller">#set-up-transform-stream-default-controller</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-transform-stream-default-controller">6.4.2. Default controllers</a>
     <li><a href="#ref-for-set-up-transform-stream-default-controller①">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-up-transform-stream-default-controller-from-transformer">
-   <b><a href="#set-up-transform-stream-default-controller-from-transformer">#set-up-transform-stream-default-controller-from-transformer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-up-transform-stream-default-controller-from-transformer" class="dfn-panel" data-for="set-up-transform-stream-default-controller-from-transformer" id="infopanel-for-set-up-transform-stream-default-controller-from-transformer" role="dialog">
+   <span id="infopaneltitle-for-set-up-transform-stream-default-controller-from-transformer" style="display:none">Info about the 'SetUpTransformStreamDefaultControllerFromTransformer(stream,
+ transformer, transformerDict)' definition.</span><b><a href="#set-up-transform-stream-default-controller-from-transformer">#set-up-transform-stream-default-controller-from-transformer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-up-transform-stream-default-controller-from-transformer">6.2.4. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-controller-clear-algorithms">
-   <b><a href="#transform-stream-default-controller-clear-algorithms">#transform-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-controller-clear-algorithms" class="dfn-panel" data-for="transform-stream-default-controller-clear-algorithms" id="infopanel-for-transform-stream-default-controller-clear-algorithms" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-controller-clear-algorithms" style="display:none">Info about the 'TransformStreamDefaultControllerClearAlgorithms(controller)' definition.</span><b><a href="#transform-stream-default-controller-clear-algorithms">#transform-stream-default-controller-clear-algorithms</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-controller-clear-algorithms">6.4.1. Working with transform streams</a>
     <li><a href="#ref-for-transform-stream-default-controller-clear-algorithms①">6.4.3. Default sinks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-controller-enqueue">
-   <b><a href="#transform-stream-default-controller-enqueue">#transform-stream-default-controller-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-controller-enqueue" class="dfn-panel" data-for="transform-stream-default-controller-enqueue" id="infopanel-for-transform-stream-default-controller-enqueue" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-controller-enqueue" style="display:none">Info about the 'TransformStreamDefaultControllerEnqueue(controller,
+ chunk)' definition.</span><b><a href="#transform-stream-default-controller-enqueue">#transform-stream-default-controller-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-controller-enqueue">6.3.3. Methods and properties</a>
     <li><a href="#ref-for-transform-stream-default-controller-enqueue①">6.4.2. Default controllers</a>
     <li><a href="#ref-for-transform-stream-default-controller-enqueue②">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-controller-error">
-   <b><a href="#transform-stream-default-controller-error">#transform-stream-default-controller-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-controller-error" class="dfn-panel" data-for="transform-stream-default-controller-error" id="infopanel-for-transform-stream-default-controller-error" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-controller-error" style="display:none">Info about the 'TransformStreamDefaultControllerError(controller,
+ e)' definition.</span><b><a href="#transform-stream-default-controller-error">#transform-stream-default-controller-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-controller-error">6.3.3. Methods and properties</a>
     <li><a href="#ref-for-transform-stream-default-controller-error①">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-controller-perform-transform">
-   <b><a href="#transform-stream-default-controller-perform-transform">#transform-stream-default-controller-perform-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-controller-perform-transform" class="dfn-panel" data-for="transform-stream-default-controller-perform-transform" id="infopanel-for-transform-stream-default-controller-perform-transform" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-controller-perform-transform" style="display:none">Info about the 'TransformStreamDefaultControllerPerformTransform(controller,
+ chunk)' definition.</span><b><a href="#transform-stream-default-controller-perform-transform">#transform-stream-default-controller-perform-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-controller-perform-transform">6.4.3. Default sinks</a> <a href="#ref-for-transform-stream-default-controller-perform-transform①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-controller-terminate">
-   <b><a href="#transform-stream-default-controller-terminate">#transform-stream-default-controller-terminate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-controller-terminate" class="dfn-panel" data-for="transform-stream-default-controller-terminate" id="infopanel-for-transform-stream-default-controller-terminate" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-controller-terminate" style="display:none">Info about the 'TransformStreamDefaultControllerTerminate(controller)' definition.</span><b><a href="#transform-stream-default-controller-terminate">#transform-stream-default-controller-terminate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-controller-terminate">6.3.3. Methods and properties</a>
     <li><a href="#ref-for-transform-stream-default-controller-terminate①">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-sink-write-algorithm">
-   <b><a href="#transform-stream-default-sink-write-algorithm">#transform-stream-default-sink-write-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-sink-write-algorithm" class="dfn-panel" data-for="transform-stream-default-sink-write-algorithm" id="infopanel-for-transform-stream-default-sink-write-algorithm" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-sink-write-algorithm" style="display:none">Info about the 'TransformStreamDefaultSinkWriteAlgorithm(stream,
+ chunk)' definition.</span><b><a href="#transform-stream-default-sink-write-algorithm">#transform-stream-default-sink-write-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-sink-write-algorithm">6.4.1. Working with transform streams</a> <a href="#ref-for-transform-stream-default-sink-write-algorithm①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-sink-abort-algorithm">
-   <b><a href="#transform-stream-default-sink-abort-algorithm">#transform-stream-default-sink-abort-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-sink-abort-algorithm" class="dfn-panel" data-for="transform-stream-default-sink-abort-algorithm" id="infopanel-for-transform-stream-default-sink-abort-algorithm" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-sink-abort-algorithm" style="display:none">Info about the 'TransformStreamDefaultSinkAbortAlgorithm(stream,
+ reason)' definition.</span><b><a href="#transform-stream-default-sink-abort-algorithm">#transform-stream-default-sink-abort-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-sink-abort-algorithm">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-sink-close-algorithm">
-   <b><a href="#transform-stream-default-sink-close-algorithm">#transform-stream-default-sink-close-algorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-sink-close-algorithm" class="dfn-panel" data-for="transform-stream-default-sink-close-algorithm" id="infopanel-for-transform-stream-default-sink-close-algorithm" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-sink-close-algorithm" style="display:none">Info about the 'TransformStreamDefaultSinkCloseAlgorithm(stream)' definition.</span><b><a href="#transform-stream-default-sink-close-algorithm">#transform-stream-default-sink-close-algorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-sink-close-algorithm">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transform-stream-default-source-pull">
-   <b><a href="#transform-stream-default-source-pull">#transform-stream-default-source-pull</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transform-stream-default-source-pull" class="dfn-panel" data-for="transform-stream-default-source-pull" id="infopanel-for-transform-stream-default-source-pull" role="dialog">
+   <span id="infopaneltitle-for-transform-stream-default-source-pull" style="display:none">Info about the 'TransformStreamDefaultSourcePullAlgorithm(stream)' definition.</span><b><a href="#transform-stream-default-source-pull">#transform-stream-default-source-pull</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transform-stream-default-source-pull">6.4.1. Working with transform streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-queuingstrategy">
-   <b><a href="#dictdef-queuingstrategy">#dictdef-queuingstrategy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-queuingstrategy" class="dfn-panel" data-for="dictdef-queuingstrategy" id="infopanel-for-dictdef-queuingstrategy" role="dialog">
+   <span id="infopaneltitle-for-dictdef-queuingstrategy" style="display:none">Info about the 'QueuingStrategy' definition.</span><b><a href="#dictdef-queuingstrategy">#dictdef-queuingstrategy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-queuingstrategy">4.2.1. Interface definition</a>
     <li><a href="#ref-for-dictdef-queuingstrategy①">5.2.1. Interface definition</a>
@@ -14501,22 +14564,22 @@ create new readable streams</a>
     <li><a href="#ref-for-dictdef-queuingstrategy④">7.4. Abstract operations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="callbackdef-queuingstrategysize">
-   <b><a href="#callbackdef-queuingstrategysize">#callbackdef-queuingstrategysize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-callbackdef-queuingstrategysize" class="dfn-panel" data-for="callbackdef-queuingstrategysize" id="infopanel-for-callbackdef-queuingstrategysize" role="dialog">
+   <span id="infopaneltitle-for-callbackdef-queuingstrategysize" style="display:none">Info about the 'QueuingStrategySize' definition.</span><b><a href="#callbackdef-queuingstrategysize">#callbackdef-queuingstrategysize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-callbackdef-queuingstrategysize">7.1. The queuing strategy API</a> <a href="#ref-for-callbackdef-queuingstrategysize①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-queuingstrategy-highwatermark">
-   <b><a href="#dom-queuingstrategy-highwatermark">#dom-queuingstrategy-highwatermark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-queuingstrategy-highwatermark" class="dfn-panel" data-for="dom-queuingstrategy-highwatermark" id="infopanel-for-dom-queuingstrategy-highwatermark" role="dialog">
+   <span id="infopaneltitle-for-dom-queuingstrategy-highwatermark" style="display:none">Info about the 'highWaterMark' definition.</span><b><a href="#dom-queuingstrategy-highwatermark">#dom-queuingstrategy-highwatermark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-queuingstrategy-highwatermark">2.5. Internal queues and queuing strategies</a> <a href="#ref-for-dom-queuingstrategy-highwatermark①">(2)</a> <a href="#ref-for-dom-queuingstrategy-highwatermark②">(3)</a>
     <li><a href="#ref-for-dom-queuingstrategy-highwatermark③">7.1. The queuing strategy API</a>
     <li><a href="#ref-for-dom-queuingstrategy-highwatermark④">7.4. Abstract operations</a> <a href="#ref-for-dom-queuingstrategy-highwatermark⑤">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-queuingstrategy-size">
-   <b><a href="#dom-queuingstrategy-size">#dom-queuingstrategy-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-queuingstrategy-size" class="dfn-panel" data-for="dom-queuingstrategy-size" id="infopanel-for-dom-queuingstrategy-size" role="dialog">
+   <span id="infopaneltitle-for-dom-queuingstrategy-size" style="display:none">Info about the 'size(chunk)' definition.</span><b><a href="#dom-queuingstrategy-size">#dom-queuingstrategy-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-queuingstrategy-size">2.5. Internal queues and queuing strategies</a>
     <li><a href="#ref-for-dom-queuingstrategy-size①">4.2.4. Constructor, methods, and properties</a>
@@ -14524,22 +14587,22 @@ create new readable streams</a>
     <li><a href="#ref-for-dom-queuingstrategy-size③">7.4. Abstract operations</a> <a href="#ref-for-dom-queuingstrategy-size④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-queuingstrategyinit">
-   <b><a href="#dictdef-queuingstrategyinit">#dictdef-queuingstrategyinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-queuingstrategyinit" class="dfn-panel" data-for="dictdef-queuingstrategyinit" id="infopanel-for-dictdef-queuingstrategyinit" role="dialog">
+   <span id="infopaneltitle-for-dictdef-queuingstrategyinit" style="display:none">Info about the 'QueuingStrategyInit' definition.</span><b><a href="#dictdef-queuingstrategyinit">#dictdef-queuingstrategyinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-queuingstrategyinit">7.2.1. Interface definition</a>
     <li><a href="#ref-for-dictdef-queuingstrategyinit①">7.3.1. Interface definition</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-queuingstrategyinit-highwatermark">
-   <b><a href="#dom-queuingstrategyinit-highwatermark">#dom-queuingstrategyinit-highwatermark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-queuingstrategyinit-highwatermark" class="dfn-panel" data-for="dom-queuingstrategyinit-highwatermark" id="infopanel-for-dom-queuingstrategyinit-highwatermark" role="dialog">
+   <span id="infopaneltitle-for-dom-queuingstrategyinit-highwatermark" style="display:none">Info about the 'highWaterMark' definition.</span><b><a href="#dom-queuingstrategyinit-highwatermark">#dom-queuingstrategyinit-highwatermark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-queuingstrategyinit-highwatermark">7.2.3. Constructor and properties</a> <a href="#ref-for-dom-queuingstrategyinit-highwatermark①">(2)</a>
     <li><a href="#ref-for-dom-queuingstrategyinit-highwatermark②">7.3.3. Constructor and properties</a> <a href="#ref-for-dom-queuingstrategyinit-highwatermark③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bytelengthqueuingstrategy">
-   <b><a href="#bytelengthqueuingstrategy">#bytelengthqueuingstrategy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bytelengthqueuingstrategy" class="dfn-panel" data-for="bytelengthqueuingstrategy" id="infopanel-for-bytelengthqueuingstrategy" role="dialog">
+   <span id="infopaneltitle-for-bytelengthqueuingstrategy" style="display:none">Info about the 'ByteLengthQueuingStrategy' definition.</span><b><a href="#bytelengthqueuingstrategy">#bytelengthqueuingstrategy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bytelengthqueuingstrategy">7.1. The queuing strategy API</a>
     <li><a href="#ref-for-bytelengthqueuingstrategy①">7.2. The ByteLengthQueuingStrategy class</a> <a href="#ref-for-bytelengthqueuingstrategy②">(2)</a> <a href="#ref-for-bytelengthqueuingstrategy③">(3)</a>
@@ -14548,43 +14611,44 @@ create new readable streams</a>
     <li><a href="#ref-for-bytelengthqueuingstrategy⑥">7.2.3. Constructor and properties</a> <a href="#ref-for-bytelengthqueuingstrategy⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bytelengthqueuingstrategy-highwatermark">
-   <b><a href="#bytelengthqueuingstrategy-highwatermark">#bytelengthqueuingstrategy-highwatermark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bytelengthqueuingstrategy-highwatermark" class="dfn-panel" data-for="bytelengthqueuingstrategy-highwatermark" id="infopanel-for-bytelengthqueuingstrategy-highwatermark" role="dialog">
+   <span id="infopaneltitle-for-bytelengthqueuingstrategy-highwatermark" style="display:none">Info about the '[[highWaterMark]]' definition.</span><b><a href="#bytelengthqueuingstrategy-highwatermark">#bytelengthqueuingstrategy-highwatermark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bytelengthqueuingstrategy-highwatermark">7.2.3. Constructor and properties</a> <a href="#ref-for-bytelengthqueuingstrategy-highwatermark①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="byte-length-queuing-strategy-size-function">
-   <b><a href="#byte-length-queuing-strategy-size-function">#byte-length-queuing-strategy-size-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-byte-length-queuing-strategy-size-function" class="dfn-panel" data-for="byte-length-queuing-strategy-size-function" id="infopanel-for-byte-length-queuing-strategy-size-function" role="dialog">
+   <span id="infopaneltitle-for-byte-length-queuing-strategy-size-function" style="display:none">Info about the 'byte length queuing
+ strategy size function' definition.</span><b><a href="#byte-length-queuing-strategy-size-function">#byte-length-queuing-strategy-size-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-length-queuing-strategy-size-function">7.2.2. Internal slots</a>
     <li><a href="#ref-for-byte-length-queuing-strategy-size-function①">7.2.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blqs-constructor">
-   <b><a href="#blqs-constructor">#blqs-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blqs-constructor" class="dfn-panel" data-for="blqs-constructor" id="infopanel-for-blqs-constructor" role="dialog">
+   <span id="infopaneltitle-for-blqs-constructor" style="display:none">Info about the 'new ByteLengthQueuingStrategy(init)' definition.</span><b><a href="#blqs-constructor">#blqs-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blqs-constructor">7.2.1. Interface definition</a>
     <li><a href="#ref-for-blqs-constructor①">7.2.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blqs-high-water-mark">
-   <b><a href="#blqs-high-water-mark">#blqs-high-water-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blqs-high-water-mark" class="dfn-panel" data-for="blqs-high-water-mark" id="infopanel-for-blqs-high-water-mark" role="dialog">
+   <span id="infopaneltitle-for-blqs-high-water-mark" style="display:none">Info about the 'highWaterMark' definition.</span><b><a href="#blqs-high-water-mark">#blqs-high-water-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blqs-high-water-mark">7.2.1. Interface definition</a>
     <li><a href="#ref-for-blqs-high-water-mark①">7.2.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blqs-size">
-   <b><a href="#blqs-size">#blqs-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blqs-size" class="dfn-panel" data-for="blqs-size" id="infopanel-for-blqs-size" role="dialog">
+   <span id="infopaneltitle-for-blqs-size" style="display:none">Info about the 'size' definition.</span><b><a href="#blqs-size">#blqs-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blqs-size">7.2.1. Interface definition</a>
     <li><a href="#ref-for-blqs-size①">7.2.2. Internal slots</a>
     <li><a href="#ref-for-blqs-size②">7.2.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="countqueuingstrategy">
-   <b><a href="#countqueuingstrategy">#countqueuingstrategy</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-countqueuingstrategy" class="dfn-panel" data-for="countqueuingstrategy" id="infopanel-for-countqueuingstrategy" role="dialog">
+   <span id="infopaneltitle-for-countqueuingstrategy" style="display:none">Info about the 'CountQueuingStrategy' definition.</span><b><a href="#countqueuingstrategy">#countqueuingstrategy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-countqueuingstrategy">2.5. Internal queues and queuing strategies</a>
     <li><a href="#ref-for-countqueuingstrategy①">4.2.4. Constructor, methods, and properties</a>
@@ -14597,97 +14661,98 @@ create new readable streams</a>
     <li><a href="#ref-for-countqueuingstrategy⑧">7.3.3. Constructor and properties</a> <a href="#ref-for-countqueuingstrategy⑨">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="countqueuingstrategy-highwatermark">
-   <b><a href="#countqueuingstrategy-highwatermark">#countqueuingstrategy-highwatermark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-countqueuingstrategy-highwatermark" class="dfn-panel" data-for="countqueuingstrategy-highwatermark" id="infopanel-for-countqueuingstrategy-highwatermark" role="dialog">
+   <span id="infopaneltitle-for-countqueuingstrategy-highwatermark" style="display:none">Info about the '[[highWaterMark]]' definition.</span><b><a href="#countqueuingstrategy-highwatermark">#countqueuingstrategy-highwatermark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-countqueuingstrategy-highwatermark">7.3.3. Constructor and properties</a> <a href="#ref-for-countqueuingstrategy-highwatermark①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="count-queuing-strategy-size-function">
-   <b><a href="#count-queuing-strategy-size-function">#count-queuing-strategy-size-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-count-queuing-strategy-size-function" class="dfn-panel" data-for="count-queuing-strategy-size-function" id="infopanel-for-count-queuing-strategy-size-function" role="dialog">
+   <span id="infopaneltitle-for-count-queuing-strategy-size-function" style="display:none">Info about the 'count queuing strategy
+ size function' definition.</span><b><a href="#count-queuing-strategy-size-function">#count-queuing-strategy-size-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-count-queuing-strategy-size-function">7.3.2. Internal slots</a>
     <li><a href="#ref-for-count-queuing-strategy-size-function①">7.3.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cqs-constructor">
-   <b><a href="#cqs-constructor">#cqs-constructor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cqs-constructor" class="dfn-panel" data-for="cqs-constructor" id="infopanel-for-cqs-constructor" role="dialog">
+   <span id="infopaneltitle-for-cqs-constructor" style="display:none">Info about the 'new CountQueuingStrategy(init)' definition.</span><b><a href="#cqs-constructor">#cqs-constructor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cqs-constructor">7.3.1. Interface definition</a>
     <li><a href="#ref-for-cqs-constructor①">7.3.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cqs-high-water-mark">
-   <b><a href="#cqs-high-water-mark">#cqs-high-water-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cqs-high-water-mark" class="dfn-panel" data-for="cqs-high-water-mark" id="infopanel-for-cqs-high-water-mark" role="dialog">
+   <span id="infopaneltitle-for-cqs-high-water-mark" style="display:none">Info about the 'highWaterMark' definition.</span><b><a href="#cqs-high-water-mark">#cqs-high-water-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cqs-high-water-mark">7.3.1. Interface definition</a>
     <li><a href="#ref-for-cqs-high-water-mark①">7.3.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cqs-size">
-   <b><a href="#cqs-size">#cqs-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cqs-size" class="dfn-panel" data-for="cqs-size" id="infopanel-for-cqs-size" role="dialog">
+   <span id="infopaneltitle-for-cqs-size" style="display:none">Info about the 'size' definition.</span><b><a href="#cqs-size">#cqs-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cqs-size">7.3.1. Interface definition</a>
     <li><a href="#ref-for-cqs-size①">7.3.2. Internal slots</a>
     <li><a href="#ref-for-cqs-size②">7.3.3. Constructor and properties</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validate-and-normalize-high-water-mark">
-   <b><a href="#validate-and-normalize-high-water-mark">#validate-and-normalize-high-water-mark</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validate-and-normalize-high-water-mark" class="dfn-panel" data-for="validate-and-normalize-high-water-mark" id="infopanel-for-validate-and-normalize-high-water-mark" role="dialog">
+   <span id="infopaneltitle-for-validate-and-normalize-high-water-mark" style="display:none">Info about the 'ExtractHighWaterMark(strategy, defaultHWM)' definition.</span><b><a href="#validate-and-normalize-high-water-mark">#validate-and-normalize-high-water-mark</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validate-and-normalize-high-water-mark">4.2.4. Constructor, methods, and properties</a> <a href="#ref-for-validate-and-normalize-high-water-mark①">(2)</a>
     <li><a href="#ref-for-validate-and-normalize-high-water-mark②">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-validate-and-normalize-high-water-mark③">6.2.4. Constructor and properties</a> <a href="#ref-for-validate-and-normalize-high-water-mark④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="make-size-algorithm-from-size-function">
-   <b><a href="#make-size-algorithm-from-size-function">#make-size-algorithm-from-size-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-make-size-algorithm-from-size-function" class="dfn-panel" data-for="make-size-algorithm-from-size-function" id="infopanel-for-make-size-algorithm-from-size-function" role="dialog">
+   <span id="infopaneltitle-for-make-size-algorithm-from-size-function" style="display:none">Info about the 'ExtractSizeAlgorithm(strategy)' definition.</span><b><a href="#make-size-algorithm-from-size-function">#make-size-algorithm-from-size-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-make-size-algorithm-from-size-function">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-make-size-algorithm-from-size-function①">5.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-make-size-algorithm-from-size-function②">6.2.4. Constructor and properties</a> <a href="#ref-for-make-size-algorithm-from-size-function③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-with-size">
-   <b><a href="#value-with-size">#value-with-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-with-size" class="dfn-panel" data-for="value-with-size" id="infopanel-for-value-with-size" role="dialog">
+   <span id="infopaneltitle-for-value-with-size" style="display:none">Info about the 'value-with-size' definition.</span><b><a href="#value-with-size">#value-with-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-with-size">8.1. Queue-with-sizes</a> <a href="#ref-for-value-with-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-with-size-value">
-   <b><a href="#value-with-size-value">#value-with-size-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-with-size-value" class="dfn-panel" data-for="value-with-size-value" id="infopanel-for-value-with-size-value" role="dialog">
+   <span id="infopaneltitle-for-value-with-size-value" style="display:none">Info about the 'value' definition.</span><b><a href="#value-with-size-value">#value-with-size-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-with-size-value">8.1. Queue-with-sizes</a> <a href="#ref-for-value-with-size-value①">(2)</a> <a href="#ref-for-value-with-size-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="value-with-size-size">
-   <b><a href="#value-with-size-size">#value-with-size-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-value-with-size-size" class="dfn-panel" data-for="value-with-size-size" id="infopanel-for-value-with-size-size" role="dialog">
+   <span id="infopaneltitle-for-value-with-size-size" style="display:none">Info about the 'size' definition.</span><b><a href="#value-with-size-size">#value-with-size-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-value-with-size-size">8.1. Queue-with-sizes</a> <a href="#ref-for-value-with-size-size①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dequeue-value">
-   <b><a href="#dequeue-value">#dequeue-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dequeue-value" class="dfn-panel" data-for="dequeue-value" id="infopanel-for-dequeue-value" role="dialog">
+   <span id="infopaneltitle-for-dequeue-value" style="display:none">Info about the 'DequeueValue(container)' definition.</span><b><a href="#dequeue-value">#dequeue-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dequeue-value">4.6.4. Internal methods</a>
     <li><a href="#ref-for-dequeue-value①">5.5.4. Default controllers</a> <a href="#ref-for-dequeue-value②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="enqueue-value-with-size">
-   <b><a href="#enqueue-value-with-size">#enqueue-value-with-size</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enqueue-value-with-size" class="dfn-panel" data-for="enqueue-value-with-size" id="infopanel-for-enqueue-value-with-size" role="dialog">
+   <span id="infopaneltitle-for-enqueue-value-with-size" style="display:none">Info about the 'EnqueueValueWithSize(container, value, size)' definition.</span><b><a href="#enqueue-value-with-size">#enqueue-value-with-size</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enqueue-value-with-size">4.9.4. Default controllers</a>
     <li><a href="#ref-for-enqueue-value-with-size①">5.5.4. Default controllers</a> <a href="#ref-for-enqueue-value-with-size②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="peek-queue-value">
-   <b><a href="#peek-queue-value">#peek-queue-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-peek-queue-value" class="dfn-panel" data-for="peek-queue-value" id="infopanel-for-peek-queue-value" role="dialog">
+   <span id="infopaneltitle-for-peek-queue-value" style="display:none">Info about the 'PeekQueueValue(container)' definition.</span><b><a href="#peek-queue-value">#peek-queue-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-peek-queue-value">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="reset-queue">
-   <b><a href="#reset-queue">#reset-queue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-reset-queue" class="dfn-panel" data-for="reset-queue" id="infopanel-for-reset-queue" role="dialog">
+   <span id="infopaneltitle-for-reset-queue" style="display:none">Info about the 'ResetQueue(container)' definition.</span><b><a href="#reset-queue">#reset-queue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-reset-queue">4.6.4. Internal methods</a>
     <li><a href="#ref-for-reset-queue①">4.7.4. Internal methods</a>
@@ -14697,48 +14762,52 @@ create new readable streams</a>
     <li><a href="#ref-for-reset-queue⑦">5.5.4. Default controllers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-crossrealmtransformsenderror">
-   <b><a href="#abstract-opdef-crossrealmtransformsenderror">#abstract-opdef-crossrealmtransformsenderror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-crossrealmtransformsenderror" class="dfn-panel" data-for="abstract-opdef-crossrealmtransformsenderror" id="infopanel-for-abstract-opdef-crossrealmtransformsenderror" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-crossrealmtransformsenderror" style="display:none">Info about the 'CrossRealmTransformSendError(port,
+ error)' definition.</span><b><a href="#abstract-opdef-crossrealmtransformsenderror">#abstract-opdef-crossrealmtransformsenderror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-crossrealmtransformsenderror">8.2. Transferable streams</a> <a href="#ref-for-abstract-opdef-crossrealmtransformsenderror①">(2)</a> <a href="#ref-for-abstract-opdef-crossrealmtransformsenderror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-packandpostmessage">
-   <b><a href="#abstract-opdef-packandpostmessage">#abstract-opdef-packandpostmessage</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-packandpostmessage" class="dfn-panel" data-for="abstract-opdef-packandpostmessage" id="infopanel-for-abstract-opdef-packandpostmessage" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-packandpostmessage" style="display:none">Info about the 'PackAndPostMessage(port, type, value)' definition.</span><b><a href="#abstract-opdef-packandpostmessage">#abstract-opdef-packandpostmessage</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-packandpostmessage">8.2. Transferable streams</a> <a href="#ref-for-abstract-opdef-packandpostmessage①">(2)</a> <a href="#ref-for-abstract-opdef-packandpostmessage②">(3)</a> <a href="#ref-for-abstract-opdef-packandpostmessage③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-packandpostmessagehandlingerror">
-   <b><a href="#abstract-opdef-packandpostmessagehandlingerror">#abstract-opdef-packandpostmessagehandlingerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-packandpostmessagehandlingerror" class="dfn-panel" data-for="abstract-opdef-packandpostmessagehandlingerror" id="infopanel-for-abstract-opdef-packandpostmessagehandlingerror" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-packandpostmessagehandlingerror" style="display:none">Info about the 'PackAndPostMessageHandlingError(port,
+ type, value)' definition.</span><b><a href="#abstract-opdef-packandpostmessagehandlingerror">#abstract-opdef-packandpostmessagehandlingerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-packandpostmessagehandlingerror">8.2. Transferable streams</a> <a href="#ref-for-abstract-opdef-packandpostmessagehandlingerror①">(2)</a> <a href="#ref-for-abstract-opdef-packandpostmessagehandlingerror②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-setupcrossrealmtransformreadable">
-   <b><a href="#abstract-opdef-setupcrossrealmtransformreadable">#abstract-opdef-setupcrossrealmtransformreadable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-setupcrossrealmtransformreadable" class="dfn-panel" data-for="abstract-opdef-setupcrossrealmtransformreadable" id="infopanel-for-abstract-opdef-setupcrossrealmtransformreadable" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-setupcrossrealmtransformreadable" style="display:none">Info about the 'SetUpCrossRealmTransformReadable(stream,
+ port)' definition.</span><b><a href="#abstract-opdef-setupcrossrealmtransformreadable">#abstract-opdef-setupcrossrealmtransformreadable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-setupcrossrealmtransformreadable">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-abstract-opdef-setupcrossrealmtransformreadable①">5.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-setupcrossrealmtransformwritable">
-   <b><a href="#abstract-opdef-setupcrossrealmtransformwritable">#abstract-opdef-setupcrossrealmtransformwritable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-setupcrossrealmtransformwritable" class="dfn-panel" data-for="abstract-opdef-setupcrossrealmtransformwritable" id="infopanel-for-abstract-opdef-setupcrossrealmtransformwritable" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-setupcrossrealmtransformwritable" style="display:none">Info about the 'SetUpCrossRealmTransformWritable(stream,
+ port)' definition.</span><b><a href="#abstract-opdef-setupcrossrealmtransformwritable">#abstract-opdef-setupcrossrealmtransformwritable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-setupcrossrealmtransformwritable">4.2.6. Transfer via postMessage()</a>
     <li><a href="#ref-for-abstract-opdef-setupcrossrealmtransformwritable①">5.2.5. Transfer via postMessage()</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-non-negative-number">
-   <b><a href="#is-non-negative-number">#is-non-negative-number</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-non-negative-number" class="dfn-panel" data-for="is-non-negative-number" id="infopanel-for-is-non-negative-number" role="dialog">
+   <span id="infopaneltitle-for-is-non-negative-number" style="display:none">Info about the 'IsNonNegativeNumber(v)' definition.</span><b><a href="#is-non-negative-number">#is-non-negative-number</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-non-negative-number">4.9.1. Working with readable streams</a>
     <li><a href="#ref-for-is-non-negative-number①">5.5.1. Working with writable streams</a>
     <li><a href="#ref-for-is-non-negative-number②">8.1. Queue-with-sizes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transfer-array-buffer">
-   <b><a href="#transfer-array-buffer">#transfer-array-buffer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transfer-array-buffer" class="dfn-panel" data-for="transfer-array-buffer" id="infopanel-for-transfer-array-buffer" role="dialog">
+   <span id="infopaneltitle-for-transfer-array-buffer" style="display:none">Info about the 'TransferArrayBuffer(O)' definition.</span><b><a href="#transfer-array-buffer">#transfer-array-buffer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transfer-array-buffer">4.1. Using readable streams</a>
     <li><a href="#ref-for-transfer-array-buffer">4.7.2. Internal slots</a>
@@ -14746,129 +14815,130 @@ create new readable streams</a>
     <li><a href="#ref-for-transfer-array-buffer">4.9.5. Byte stream controllers</a> <a href="#ref-for-transfer-array-buffer①">(2)</a> <a href="#ref-for-transfer-array-buffer②">(3)</a> <a href="#ref-for-transfer-array-buffer③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-set-up">
-   <b><a href="#readablestream-set-up">#readablestream-set-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-set-up" class="dfn-panel" data-for="readablestream-set-up" id="infopanel-for-readablestream-set-up" role="dialog">
+   <span id="infopaneltitle-for-readablestream-set-up" style="display:none">Info about the 'set up' definition.</span><b><a href="#readablestream-set-up">#readablestream-set-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up">9.1.1. Creation and manipulation</a> <a href="#ref-for-readablestream-set-up①">(2)</a> <a href="#ref-for-readablestream-set-up②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-set-up-cancelalgorithm">
-   <b><a href="#readablestream-set-up-cancelalgorithm">#readablestream-set-up-cancelalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-set-up-cancelalgorithm" class="dfn-panel" data-for="readablestream-set-up-cancelalgorithm" id="infopanel-for-readablestream-set-up-cancelalgorithm" role="dialog">
+   <span id="infopaneltitle-for-readablestream-set-up-cancelalgorithm" style="display:none">Info about the 'cancelAlgorithm' definition.</span><b><a href="#readablestream-set-up-cancelalgorithm">#readablestream-set-up-cancelalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-set-up-cancelalgorithm">9.4.1. Duplex streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-get-a-reader">
-   <b><a href="#readablestream-get-a-reader">#readablestream-get-a-reader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-get-a-reader" class="dfn-panel" data-for="readablestream-get-a-reader" id="infopanel-for-readablestream-get-a-reader" role="dialog">
+   <span id="infopaneltitle-for-readablestream-get-a-reader" style="display:none">Info about the 'get a reader' definition.</span><b><a href="#readablestream-get-a-reader">#readablestream-get-a-reader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-get-a-reader">9.1.3. Introspection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="read-loop">
-   <b><a href="#read-loop">#read-loop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-read-loop" class="dfn-panel" data-for="read-loop" id="infopanel-for-read-loop" role="dialog">
+   <span id="infopaneltitle-for-read-loop" style="display:none">Info about the 'read-loop' definition.</span><b><a href="#read-loop">#read-loop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-read-loop">9.1.2. Reading</a> <a href="#ref-for-read-loop①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-tee">
-   <b><a href="#readablestream-tee">#readablestream-tee</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-tee" class="dfn-panel" data-for="readablestream-tee" id="infopanel-for-readablestream-tee" role="dialog">
+   <span id="infopaneltitle-for-readablestream-tee" style="display:none">Info about the 'tee' definition.</span><b><a href="#readablestream-tee">#readablestream-tee</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-tee">4.9.1. Working with readable streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-readable">
-   <b><a href="#readablestream-readable">#readablestream-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-readable" class="dfn-panel" data-for="readablestream-readable" id="infopanel-for-readablestream-readable" role="dialog">
+   <span id="infopaneltitle-for-readablestream-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#readablestream-readable">#readablestream-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-readable">9.1.1. Creation and manipulation</a>
     <li><a href="#ref-for-readablestream-readable①">9.1.3. Introspection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-locked">
-   <b><a href="#readablestream-locked">#readablestream-locked</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-locked" class="dfn-panel" data-for="readablestream-locked" id="infopanel-for-readablestream-locked" role="dialog">
+   <span id="infopaneltitle-for-readablestream-locked" style="display:none">Info about the 'locked' definition.</span><b><a href="#readablestream-locked">#readablestream-locked</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-locked">9.1.2. Reading</a>
     <li><a href="#ref-for-readablestream-locked①">9.1.3. Introspection</a>
     <li><a href="#ref-for-readablestream-locked②">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-readable-stream-disturbed">
-   <b><a href="#is-readable-stream-disturbed">#is-readable-stream-disturbed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-readable-stream-disturbed" class="dfn-panel" data-for="is-readable-stream-disturbed" id="infopanel-for-is-readable-stream-disturbed" role="dialog">
+   <span id="infopaneltitle-for-is-readable-stream-disturbed" style="display:none">Info about the 'disturbed' definition.</span><b><a href="#is-readable-stream-disturbed">#is-readable-stream-disturbed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-readable-stream-disturbed">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-set-up">
-   <b><a href="#writablestream-set-up">#writablestream-set-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-set-up" class="dfn-panel" data-for="writablestream-set-up" id="infopanel-for-writablestream-set-up" role="dialog">
+   <span id="infopaneltitle-for-writablestream-set-up" style="display:none">Info about the 'set up' definition.</span><b><a href="#writablestream-set-up">#writablestream-set-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-set-up">9.2.1. Creation</a> <a href="#ref-for-writablestream-set-up①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="writablestream-close">
-   <b><a href="#writablestream-close">#writablestream-close</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-writablestream-close" class="dfn-panel" data-for="writablestream-close" id="infopanel-for-writablestream-close" role="dialog">
+   <span id="infopaneltitle-for-writablestream-close" style="display:none">Info about the 'close' definition.</span><b><a href="#writablestream-close">#writablestream-close</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-writablestream-close">9.4.1. Duplex streams</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-set-up">
-   <b><a href="#transformstream-set-up">#transformstream-set-up</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-set-up" class="dfn-panel" data-for="transformstream-set-up" id="infopanel-for-transformstream-set-up" role="dialog">
+   <span id="infopaneltitle-for-transformstream-set-up" style="display:none">Info about the 'set up' definition.</span><b><a href="#transformstream-set-up">#transformstream-set-up</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up">9.3.1. Creation and manipulation</a> <a href="#ref-for-transformstream-set-up①">(2)</a> <a href="#ref-for-transformstream-set-up②">(3)</a> <a href="#ref-for-transformstream-set-up③">(4)</a>
     <li><a href="#ref-for-transformstream-set-up④">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-set-up-transformalgorithm">
-   <b><a href="#transformstream-set-up-transformalgorithm">#transformstream-set-up-transformalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-set-up-transformalgorithm" class="dfn-panel" data-for="transformstream-set-up-transformalgorithm" id="infopanel-for-transformstream-set-up-transformalgorithm" role="dialog">
+   <span id="infopaneltitle-for-transformstream-set-up-transformalgorithm" style="display:none">Info about the 'transformAlgorithm' definition.</span><b><a href="#transformstream-set-up-transformalgorithm">#transformstream-set-up-transformalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up-transformalgorithm">9.3.1. Creation and manipulation</a> <a href="#ref-for-transformstream-set-up-transformalgorithm①">(2)</a>
     <li><a href="#ref-for-transformstream-set-up-transformalgorithm②">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-set-up-flushalgorithm">
-   <b><a href="#transformstream-set-up-flushalgorithm">#transformstream-set-up-flushalgorithm</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-set-up-flushalgorithm" class="dfn-panel" data-for="transformstream-set-up-flushalgorithm" id="infopanel-for-transformstream-set-up-flushalgorithm" role="dialog">
+   <span id="infopaneltitle-for-transformstream-set-up-flushalgorithm" style="display:none">Info about the 'flushAlgorithm' definition.</span><b><a href="#transformstream-set-up-flushalgorithm">#transformstream-set-up-flushalgorithm</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-set-up-flushalgorithm">9.3.1. Creation and manipulation</a>
     <li><a href="#ref-for-transformstream-set-up-flushalgorithm①">9.3.2. Wrapping into a custom class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-identity-transformstream">
-   <b><a href="#create-an-identity-transformstream">#create-an-identity-transformstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-identity-transformstream" class="dfn-panel" data-for="create-an-identity-transformstream" id="infopanel-for-create-an-identity-transformstream" role="dialog">
+   <span id="infopaneltitle-for-create-an-identity-transformstream" style="display:none">Info about the 'create
+ an identity TransformStream' definition.</span><b><a href="#create-an-identity-transformstream">#create-an-identity-transformstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-identity-transformstream">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transformstream-enqueue">
-   <b><a href="#transformstream-enqueue">#transformstream-enqueue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transformstream-enqueue" class="dfn-panel" data-for="transformstream-enqueue" id="infopanel-for-transformstream-enqueue" role="dialog">
+   <span id="infopaneltitle-for-transformstream-enqueue" style="display:none">Info about the 'enqueue' definition.</span><b><a href="#transformstream-enqueue">#transformstream-enqueue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transformstream-enqueue">9.3.1. Creation and manipulation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generictransformstream">
-   <b><a href="#generictransformstream">#generictransformstream</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generictransformstream" class="dfn-panel" data-for="generictransformstream" id="infopanel-for-generictransformstream" role="dialog">
+   <span id="infopaneltitle-for-generictransformstream" style="display:none">Info about the 'GenericTransformStream' definition.</span><b><a href="#generictransformstream">#generictransformstream</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream">2.3. Transform streams</a>
     <li><a href="#ref-for-generictransformstream①">9.3.2. Wrapping into a custom class</a> <a href="#ref-for-generictransformstream②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generictransformstream-transform">
-   <b><a href="#generictransformstream-transform">#generictransformstream-transform</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generictransformstream-transform" class="dfn-panel" data-for="generictransformstream-transform" id="infopanel-for-generictransformstream-transform" role="dialog">
+   <span id="infopaneltitle-for-generictransformstream-transform" style="display:none">Info about the 'transform' definition.</span><b><a href="#generictransformstream-transform">#generictransformstream-transform</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generictransformstream-transform">9.3.2. Wrapping into a custom class</a> <a href="#ref-for-generictransformstream-transform①">(2)</a> <a href="#ref-for-generictransformstream-transform②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-generictransformstream-readable">
-   <b><a href="#dom-generictransformstream-readable">#dom-generictransformstream-readable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-generictransformstream-readable" class="dfn-panel" data-for="dom-generictransformstream-readable" id="infopanel-for-dom-generictransformstream-readable" role="dialog">
+   <span id="infopaneltitle-for-dom-generictransformstream-readable" style="display:none">Info about the 'readable' definition.</span><b><a href="#dom-generictransformstream-readable">#dom-generictransformstream-readable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-generictransformstream-readable">9.3.2. Wrapping into a custom class</a> <a href="#ref-for-dom-generictransformstream-readable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-generictransformstream-writable">
-   <b><a href="#dom-generictransformstream-writable">#dom-generictransformstream-writable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-generictransformstream-writable" class="dfn-panel" data-for="dom-generictransformstream-writable" id="infopanel-for-dom-generictransformstream-writable" role="dialog">
+   <span id="infopaneltitle-for-dom-generictransformstream-writable" style="display:none">Info about the 'writable' definition.</span><b><a href="#dom-generictransformstream-writable">#dom-generictransformstream-writable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-generictransformstream-writable">9.3.2. Wrapping into a custom class</a> <a href="#ref-for-dom-generictransformstream-writable①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-pipe">
-   <b><a href="#readablestream-pipe">#readablestream-pipe</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-pipe" class="dfn-panel" data-for="readablestream-pipe" id="infopanel-for-readablestream-pipe" role="dialog">
+   <span id="infopaneltitle-for-readablestream-pipe" style="display:none">Info about the 'piped to' definition.</span><b><a href="#readablestream-pipe">#readablestream-pipe</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-pipe">4.2.4. Constructor, methods, and properties</a>
     <li><a href="#ref-for-readablestream-pipe①">6.1. Using transform streams</a>
@@ -14876,67 +14946,123 @@ create new readable streams</a>
     <li><a href="#ref-for-readablestream-pipe③">9.5. Piping</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="readablestream-pipe-through">
-   <b><a href="#readablestream-pipe-through">#readablestream-pipe-through</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-readablestream-pipe-through" class="dfn-panel" data-for="readablestream-pipe-through" id="infopanel-for-readablestream-pipe-through" role="dialog">
+   <span id="infopaneltitle-for-readablestream-pipe-through" style="display:none">Info about the 'piped through' definition.</span><b><a href="#readablestream-pipe-through">#readablestream-pipe-through</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-readablestream-pipe-through">9.5. Piping</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>
 <script>/* script-var-click-highlighting */
 

--- a/tests/github/whatwg/url/url.html
+++ b/tests/github/whatwg/url/url.html
@@ -3421,20 +3421,20 @@ if ("serviceWorker" in navigator) {
    <li><a href="#webkiturl">webkitURL</a><span>, in § 6.1</span>
    <li><a href="#windows-drive-letter">Windows drive letter</a><span>, in § 4.2</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-sec-encodeuricomponent-uricomponent">
-   <a href="https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent">https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-sec-encodeuricomponent-uricomponent" class="dfn-panel" data-for="term-for-sec-encodeuricomponent-uricomponent" id="infopanel-for-term-for-sec-encodeuricomponent-uricomponent" role="menu">
+   <span id="infopaneltitle-for-term-for-sec-encodeuricomponent-uricomponent" style="display:none">Info about the '"encodeURIComponent() [sic]"' external reference.</span><a href="https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent">https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-sec-encodeuricomponent-uricomponent">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-encode-or-fail">
-   <a href="https://encoding.spec.whatwg.org/#encode-or-fail">https://encoding.spec.whatwg.org/#encode-or-fail</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-encode-or-fail" class="dfn-panel" data-for="term-for-encode-or-fail" id="infopanel-for-term-for-encode-or-fail" role="menu">
+   <span id="infopaneltitle-for-term-for-encode-or-fail" style="display:none">Info about the 'encode or fail' external reference.</span><a href="https://encoding.spec.whatwg.org/#encode-or-fail">https://encoding.spec.whatwg.org/#encode-or-fail</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode-or-fail">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-encoding">
-   <a href="https://encoding.spec.whatwg.org/#encoding">https://encoding.spec.whatwg.org/#encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-encoding" class="dfn-panel" data-for="term-for-encoding" id="infopanel-for-term-for-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-encoding" style="display:none">Info about the 'encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#encoding">https://encoding.spec.whatwg.org/#encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encoding">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-encoding①">4.4. URL parsing</a> <a href="#ref-for-encoding②">(2)</a>
@@ -3442,45 +3442,45 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-encoding④">5.2. application/x-www-form-urlencoded serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-an-output-encoding">
-   <a href="https://encoding.spec.whatwg.org/#get-an-output-encoding">https://encoding.spec.whatwg.org/#get-an-output-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-an-output-encoding" class="dfn-panel" data-for="term-for-get-an-output-encoding" id="infopanel-for-term-for-get-an-output-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-get-an-output-encoding" style="display:none">Info about the 'get an output encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#get-an-output-encoding">https://encoding.spec.whatwg.org/#get-an-output-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-output-encoding">4.4. URL parsing</a>
     <li><a href="#ref-for-get-an-output-encoding①">5.2. application/x-www-form-urlencoded serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-get-an-encoder">
-   <a href="https://encoding.spec.whatwg.org/#get-an-encoder">https://encoding.spec.whatwg.org/#get-an-encoder</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-get-an-encoder" class="dfn-panel" data-for="term-for-get-an-encoder" id="infopanel-for-term-for-get-an-encoder" role="menu">
+   <span id="infopaneltitle-for-term-for-get-an-encoder" style="display:none">Info about the 'getting an encoder' external reference.</span><a href="https://encoding.spec.whatwg.org/#get-an-encoder">https://encoding.spec.whatwg.org/#get-an-encoder</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-get-an-encoder">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-stream">
-   <a href="https://encoding.spec.whatwg.org/#concept-stream">https://encoding.spec.whatwg.org/#concept-stream</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-stream" class="dfn-panel" data-for="term-for-concept-stream" id="infopanel-for-term-for-concept-stream" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-stream" style="display:none">Info about the 'i/o queue' external reference.</span><a href="https://encoding.spec.whatwg.org/#concept-stream">https://encoding.spec.whatwg.org/#concept-stream</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-stream">1.3. Percent-encoded bytes</a> <a href="#ref-for-concept-stream①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iso-2022-jp">
-   <a href="https://encoding.spec.whatwg.org/#iso-2022-jp">https://encoding.spec.whatwg.org/#iso-2022-jp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iso-2022-jp" class="dfn-panel" data-for="term-for-iso-2022-jp" id="infopanel-for-term-for-iso-2022-jp" role="menu">
+   <span id="infopaneltitle-for-term-for-iso-2022-jp" style="display:none">Info about the 'iso-2022-jp' external reference.</span><a href="https://encoding.spec.whatwg.org/#iso-2022-jp">https://encoding.spec.whatwg.org/#iso-2022-jp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iso-2022-jp-encoder">
-   <a href="https://encoding.spec.whatwg.org/#iso-2022-jp-encoder">https://encoding.spec.whatwg.org/#iso-2022-jp-encoder</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iso-2022-jp-encoder" class="dfn-panel" data-for="term-for-iso-2022-jp-encoder" id="infopanel-for-term-for-iso-2022-jp-encoder" role="menu">
+   <span id="infopaneltitle-for-term-for-iso-2022-jp-encoder" style="display:none">Info about the 'iso-2022-jp encoder' external reference.</span><a href="https://encoding.spec.whatwg.org/#iso-2022-jp-encoder">https://encoding.spec.whatwg.org/#iso-2022-jp-encoder</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iso-2022-jp-encoder">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-shift_jis">
-   <a href="https://encoding.spec.whatwg.org/#shift_jis">https://encoding.spec.whatwg.org/#shift_jis</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-shift_jis" class="dfn-panel" data-for="term-for-shift_jis" id="infopanel-for-term-for-shift_jis" role="menu">
+   <span id="infopaneltitle-for-term-for-shift_jis" style="display:none">Info about the 'shift_jis' external reference.</span><a href="https://encoding.spec.whatwg.org/#shift_jis">https://encoding.spec.whatwg.org/#shift_jis</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shift_jis">1.3. Percent-encoded bytes</a> <a href="#ref-for-shift_jis①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">1.3. Percent-encoded bytes</a> <a href="#ref-for-utf-8①">(2)</a> <a href="#ref-for-utf-8②">(3)</a>
     <li><a href="#ref-for-utf-8③">4.3. URL writing</a>
@@ -3490,133 +3490,133 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-utf-8①①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom" id="infopanel-for-term-for-utf-8-decode-without-bom" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom" style="display:none">Info about the 'utf-8 decode without bom' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-utf-8-decode-without-bom①">3.5. Host parsing</a>
     <li><a href="#ref-for-utf-8-decode-without-bom②">5.1. application/x-www-form-urlencoded parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-decode-without-bom-or-fail">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-decode-without-bom-or-fail" class="dfn-panel" data-for="term-for-utf-8-decode-without-bom-or-fail" id="infopanel-for-term-for-utf-8-decode-without-bom-or-fail" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-decode-without-bom-or-fail" style="display:none">Info about the 'utf-8 decode without bom or fail' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail">https://encoding.spec.whatwg.org/#utf-8-decode-without-bom-or-fail</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-decode-without-bom-or-fail">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-utf-8-decode-without-bom-or-fail①">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-utf-8-encode①">5.3. Hooks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-entry">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-entry">https://w3c.github.io/FileAPI/#blob-url-entry</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-entry" class="dfn-panel" data-for="term-for-blob-url-entry" id="infopanel-for-term-for-blob-url-entry" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-entry" style="display:none">Info about the 'blob url entry' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-entry">https://w3c.github.io/FileAPI/#blob-url-entry</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-BlobURLStore">
-   <a href="https://w3c.github.io/FileAPI/#BlobURLStore">https://w3c.github.io/FileAPI/#BlobURLStore</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-BlobURLStore" class="dfn-panel" data-for="term-for-BlobURLStore" id="infopanel-for-term-for-BlobURLStore" role="menu">
+   <span id="infopaneltitle-for-term-for-BlobURLStore" style="display:none">Info about the 'blob url store' external reference.</span><a href="https://w3c.github.io/FileAPI/#BlobURLStore">https://w3c.github.io/FileAPI/#BlobURLStore</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-BlobURLStore">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-entry-environment">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-entry-environment">https://w3c.github.io/FileAPI/#blob-url-entry-environment</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-entry-environment" class="dfn-panel" data-for="term-for-blob-url-entry-environment" id="infopanel-for-term-for-blob-url-entry-environment" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-entry-environment" style="display:none">Info about the 'environment' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-entry-environment">https://w3c.github.io/FileAPI/#blob-url-entry-environment</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-entry-environment">4.7. Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-blob-url-resolve">
-   <a href="https://w3c.github.io/FileAPI/#blob-url-resolve">https://w3c.github.io/FileAPI/#blob-url-resolve</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-blob-url-resolve" class="dfn-panel" data-for="term-for-blob-url-resolve" id="infopanel-for-term-for-blob-url-resolve" role="menu">
+   <span id="infopaneltitle-for-term-for-blob-url-resolve" style="display:none">Info about the 'resolve' external reference.</span><a href="https://w3c.github.io/FileAPI/#blob-url-resolve">https://w3c.github.io/FileAPI/#blob-url-resolve</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blob-url-resolve">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventsource">
-   <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventsource" class="dfn-panel" data-for="term-for-eventsource" id="infopanel-for-term-for-eventsource" role="menu">
+   <span id="infopaneltitle-for-term-for-eventsource" style="display:none">Info about the 'EventSource' external reference.</span><a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource">https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsource</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventsource">6.3. URL APIs elsewhere</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-hashchangeevent">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-hashchangeevent" class="dfn-panel" data-for="term-for-hashchangeevent" id="infopanel-for-term-for-hashchangeevent" role="menu">
+   <span id="infopaneltitle-for-term-for-hashchangeevent" style="display:none">Info about the 'HashChangeEvent' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent">https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hashchangeevent">6.3. URL APIs elsewhere</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-location">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-location" class="dfn-panel" data-for="term-for-location" id="infopanel-for-term-for-location" role="menu">
+   <span id="infopaneltitle-for-term-for-location" style="display:none">Info about the 'Location' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#location">https://html.spec.whatwg.org/multipage/nav-history-apis.html#location</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-location">4.4. URL parsing</a> <a href="#ref-for-location①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin-opaque">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin-opaque" class="dfn-panel" data-for="term-for-concept-origin-opaque" id="infopanel-for-term-for-concept-origin-opaque" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin-opaque" style="display:none">Info about the 'opaque origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-opaque</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin-opaque">4.7. Origin</a> <a href="#ref-for-concept-origin-opaque①">(2)</a> <a href="#ref-for-concept-origin-opaque②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-origin" class="dfn-panel" data-for="term-for-concept-origin" id="infopanel-for-term-for-concept-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-origin">https://html.spec.whatwg.org/multipage/browsers.html#concept-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-origin">3.2. Host miscellaneous</a>
     <li><a href="#ref-for-concept-origin①">4.7. Origin</a> <a href="#ref-for-concept-origin②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin (for environment settings object)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">4.7. Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-location-protocol">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-protocol">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-protocol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-location-protocol" class="dfn-panel" data-for="term-for-dom-location-protocol" id="infopanel-for-term-for-dom-location-protocol" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-location-protocol" style="display:none">Info about the 'protocol' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-protocol">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-protocol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-location-protocol">4.4. URL parsing</a> <a href="#ref-for-dom-location-protocol①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-navigator-registerprotocolhandler">
-   <a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-registerprotocolhandler">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-registerprotocolhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-navigator-registerprotocolhandler" class="dfn-panel" data-for="term-for-dom-navigator-registerprotocolhandler" id="infopanel-for-term-for-dom-navigator-registerprotocolhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-navigator-registerprotocolhandler" style="display:none">Info about the 'registerProtocolHandler(scheme, url)' external reference.</span><a href="https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-registerprotocolhandler">https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-registerprotocolhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-navigator-registerprotocolhandler">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-same-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-same-origin" class="dfn-panel" data-for="term-for-same-origin" id="infopanel-for-term-for-same-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-same-origin" style="display:none">Info about the 'same origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#same-origin">https://html.spec.whatwg.org/multipage/browsers.html#same-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-same-origin">4.7. Origin</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-site-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-site-same-site" class="dfn-panel" data-for="term-for-concept-site-same-site" id="infopanel-for-term-for-concept-site-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-site-same-site" style="display:none">Info about the 'same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site">https://html.spec.whatwg.org/multipage/browsers.html#concept-site-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-site-same-site">3.2. Host miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-schemelessly-same-site">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site">https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-schemelessly-same-site" class="dfn-panel" data-for="term-for-schemelessly-same-site" id="infopanel-for-term-for-schemelessly-same-site" role="menu">
+   <span id="infopaneltitle-for-term-for-schemelessly-same-site" style="display:none">Info about the 'schemelessly same site' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site">https://html.spec.whatwg.org/multipage/browsers.html#schemelessly-same-site</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-schemelessly-same-site">3.2. Host miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" class="dfn-panel" data-for="term-for-ascii-serialisation-of-an-origin" id="infopanel-for-term-for-ascii-serialisation-of-an-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-serialisation-of-an-origin" style="display:none">Info about the 'serialization of an origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-serialisation-of-an-origin">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-surrogate">
-   <a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-surrogate" class="dfn-panel" data-for="term-for-dfn-surrogate" id="infopanel-for-term-for-dfn-surrogate" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-surrogate" style="display:none">Info about the 'surrogates' external reference.</span><a href="https://w3c.github.io/i18n-glossary/#dfn-surrogate">https://w3c.github.io/i18n-glossary/#dfn-surrogate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-surrogate">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">3.5. Host parsing</a>
     <li><a href="#ref-for-list-append①">4.4. URL parsing</a> <a href="#ref-for-list-append②">(2)</a> <a href="#ref-for-list-append③">(3)</a> <a href="#ref-for-list-append④">(4)</a> <a href="#ref-for-list-append⑤">(5)</a>
@@ -3624,42 +3624,42 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-append⑦">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-alpha">
-   <a href="https://infra.spec.whatwg.org/#ascii-alpha">https://infra.spec.whatwg.org/#ascii-alpha</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-alpha" class="dfn-panel" data-for="term-for-ascii-alpha" id="infopanel-for-term-for-ascii-alpha" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-alpha" style="display:none">Info about the 'ascii alpha' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-alpha">https://infra.spec.whatwg.org/#ascii-alpha</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alpha">4.2. URL miscellaneous</a>
     <li><a href="#ref-for-ascii-alpha①">4.3. URL writing</a>
     <li><a href="#ref-for-ascii-alpha②">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-alphanumeric">
-   <a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-alphanumeric" class="dfn-panel" data-for="term-for-ascii-alphanumeric" id="infopanel-for-term-for-ascii-alphanumeric" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-alphanumeric" style="display:none">Info about the 'ascii alphanumeric' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-alphanumeric">https://infra.spec.whatwg.org/#ascii-alphanumeric</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-alphanumeric">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-ascii-alphanumeric①">4.3. URL writing</a> <a href="#ref-for-ascii-alphanumeric②">(2)</a>
     <li><a href="#ref-for-ascii-alphanumeric③">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-byte">
-   <a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-byte" class="dfn-panel" data-for="term-for-ascii-byte" id="infopanel-for-term-for-ascii-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-byte" style="display:none">Info about the 'ascii byte' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-byte">https://infra.spec.whatwg.org/#ascii-byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-byte">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">4.3. URL writing</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a> <a href="#ref-for-ascii-case-insensitive②">(3)</a> <a href="#ref-for-ascii-case-insensitive③">(4)</a> <a href="#ref-for-ascii-case-insensitive④">(5)</a> <a href="#ref-for-ascii-case-insensitive⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-code-point">
-   <a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-code-point" class="dfn-panel" data-for="term-for-ascii-code-point" id="infopanel-for-term-for-ascii-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-code-point" style="display:none">Info about the 'ascii code point' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-code-point">https://infra.spec.whatwg.org/#ascii-code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-code-point">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-digit">
-   <a href="https://infra.spec.whatwg.org/#ascii-digit">https://infra.spec.whatwg.org/#ascii-digit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-digit" class="dfn-panel" data-for="term-for-ascii-digit" id="infopanel-for-term-for-ascii-digit" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-digit" style="display:none">Info about the 'ascii digit' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-digit">https://infra.spec.whatwg.org/#ascii-digit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-digit">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-ascii-digit①">3.4. Host writing</a>
@@ -3668,22 +3668,22 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ascii-digit⑤">4.4. URL parsing</a> <a href="#ref-for-ascii-digit⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-hex-digit">
-   <a href="https://infra.spec.whatwg.org/#ascii-hex-digit">https://infra.spec.whatwg.org/#ascii-hex-digit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-hex-digit" class="dfn-panel" data-for="term-for-ascii-hex-digit" id="infopanel-for-term-for-ascii-hex-digit" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-hex-digit" style="display:none">Info about the 'ascii hex digit' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-hex-digit">https://infra.spec.whatwg.org/#ascii-hex-digit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-hex-digit">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-ascii-hex-digit①">3.5. Host parsing</a> <a href="#ref-for-ascii-hex-digit②">(2)</a> <a href="#ref-for-ascii-hex-digit③">(3)</a>
     <li><a href="#ref-for-ascii-hex-digit④">4.4. URL parsing</a> <a href="#ref-for-ascii-hex-digit⑤">(2)</a> <a href="#ref-for-ascii-hex-digit⑥">(3)</a> <a href="#ref-for-ascii-hex-digit⑦">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
-   <a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-lowercase" class="dfn-panel" data-for="term-for-ascii-lowercase" id="infopanel-for-term-for-ascii-lowercase" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-lowercase" style="display:none">Info about the 'ascii lowercase' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-lowercase">https://infra.spec.whatwg.org/#ascii-lowercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-lowercase">4.4. URL parsing</a> <a href="#ref-for-ascii-lowercase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-string">
-   <a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-string" class="dfn-panel" data-for="term-for-ascii-string" id="infopanel-for-term-for-ascii-string" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-string" style="display:none">Info about the 'ascii string' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-string">https://infra.spec.whatwg.org/#ascii-string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-string">3.1. Host representation</a> <a href="#ref-for-ascii-string①">(2)</a>
     <li><a href="#ref-for-ascii-string②">3.2. Host miscellaneous</a> <a href="#ref-for-ascii-string③">(2)</a>
@@ -3692,56 +3692,56 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-ascii-string①①">4.5. URL serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-tab-or-newline">
-   <a href="https://infra.spec.whatwg.org/#ascii-tab-or-newline">https://infra.spec.whatwg.org/#ascii-tab-or-newline</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-tab-or-newline" class="dfn-panel" data-for="term-for-ascii-tab-or-newline" id="infopanel-for-term-for-ascii-tab-or-newline" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-tab-or-newline" style="display:none">Info about the 'ascii tab or newline' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-tab-or-newline">https://infra.spec.whatwg.org/#ascii-tab-or-newline</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-tab-or-newline">4.4. URL parsing</a> <a href="#ref-for-ascii-tab-or-newline①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-upper-hex-digit">
-   <a href="https://infra.spec.whatwg.org/#ascii-upper-hex-digit">https://infra.spec.whatwg.org/#ascii-upper-hex-digit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-upper-hex-digit" class="dfn-panel" data-for="term-for-ascii-upper-hex-digit" id="infopanel-for-term-for-ascii-upper-hex-digit" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-upper-hex-digit" style="display:none">Info about the 'ascii upper hex digit' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-upper-hex-digit">https://infra.spec.whatwg.org/#ascii-upper-hex-digit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-upper-hex-digit">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-break">
-   <a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-break" class="dfn-panel" data-for="term-for-iteration-break" id="infopanel-for-term-for-iteration-break" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-break" style="display:none">Info about the 'break' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-break">https://infra.spec.whatwg.org/#iteration-break</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-break">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte">
-   <a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte" class="dfn-panel" data-for="term-for-byte" id="infopanel-for-term-for-byte" role="menu">
+   <span id="infopaneltitle-for-term-for-byte" style="display:none">Info about the 'byte' external reference.</span><a href="https://infra.spec.whatwg.org/#byte">https://infra.spec.whatwg.org/#byte</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">1.3. Percent-encoded bytes</a> <a href="#ref-for-byte-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-c0-control">
-   <a href="https://infra.spec.whatwg.org/#c0-control">https://infra.spec.whatwg.org/#c0-control</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-c0-control" class="dfn-panel" data-for="term-for-c0-control" id="infopanel-for-term-for-c0-control" role="menu">
+   <span id="infopaneltitle-for-term-for-c0-control" style="display:none">Info about the 'c0 control' external reference.</span><a href="https://infra.spec.whatwg.org/#c0-control">https://infra.spec.whatwg.org/#c0-control</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c0-control">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-c0-control-or-space">
-   <a href="https://infra.spec.whatwg.org/#c0-control-or-space">https://infra.spec.whatwg.org/#c0-control-or-space</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-c0-control-or-space" class="dfn-panel" data-for="term-for-c0-control-or-space" id="infopanel-for-term-for-c0-control-or-space" role="menu">
+   <span id="infopaneltitle-for-term-for-c0-control-or-space" style="display:none">Info about the 'c0 control or space' external reference.</span><a href="https://infra.spec.whatwg.org/#c0-control-or-space">https://infra.spec.whatwg.org/#c0-control-or-space</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c0-control-or-space">4.4. URL parsing</a> <a href="#ref-for-c0-control-or-space①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-clone">
-   <a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-clone" class="dfn-panel" data-for="term-for-list-clone" id="infopanel-for-term-for-list-clone" role="menu">
+   <span id="infopaneltitle-for-term-for-list-clone" style="display:none">Info about the 'clone' external reference.</span><a href="https://infra.spec.whatwg.org/#list-clone">https://infra.spec.whatwg.org/#list-clone</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-clone">4.4. URL parsing</a> <a href="#ref-for-list-clone①">(2)</a> <a href="#ref-for-list-clone②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point">
-   <a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point" class="dfn-panel" data-for="term-for-code-point" id="infopanel-for-term-for-code-point" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point" style="display:none">Info about the 'code point' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point">https://infra.spec.whatwg.org/#code-point</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point">1.2. Parsers</a> <a href="#ref-for-code-point①">(2)</a>
     <li><a href="#ref-for-code-point②">1.3. Percent-encoded bytes</a> <a href="#ref-for-code-point③">(2)</a> <a href="#ref-for-code-point④">(3)</a>
@@ -3750,20 +3750,20 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-code-point⑧">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-code-point-length">
-   <a href="https://infra.spec.whatwg.org/#string-code-point-length">https://infra.spec.whatwg.org/#string-code-point-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-code-point-length" class="dfn-panel" data-for="term-for-string-code-point-length" id="infopanel-for-term-for-string-code-point-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-code-point-length" style="display:none">Info about the 'code point length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-code-point-length">https://infra.spec.whatwg.org/#string-code-point-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-code-point-length">1.2. Parsers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-contain">
-   <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-contain" class="dfn-panel" data-for="term-for-list-contain" id="infopanel-for-term-for-list-contain" role="menu">
+   <span id="infopaneltitle-for-term-for-list-contain" style="display:none">Info about the 'contain' external reference.</span><a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-contain">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-iteration-continue" class="dfn-panel" data-for="term-for-iteration-continue" id="infopanel-for-term-for-iteration-continue" role="menu">
+   <span id="infopaneltitle-for-term-for-iteration-continue" style="display:none">Info about the 'continue' external reference.</span><a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-iteration-continue">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-iteration-continue①">3.5. Host parsing</a>
@@ -3772,8 +3772,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-iteration-continue⑤">5.1. application/x-www-form-urlencoded parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each (for list)' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.5. Host parsing</a> <a href="#ref-for-list-iterate①">(2)</a>
     <li><a href="#ref-for-list-iterate②">3.6. Host serializing</a> <a href="#ref-for-list-iterate③">(2)</a>
@@ -3783,14 +3783,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-iterate⑦">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-iterate">
-   <a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-iterate" class="dfn-panel" data-for="term-for-map-iterate" id="infopanel-for-term-for-map-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-map-iterate" style="display:none">Info about the 'for each (for map)' external reference.</span><a href="https://infra.spec.whatwg.org/#map-iterate">https://infra.spec.whatwg.org/#map-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-iterate">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-is-empty">
-   <a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-is-empty" class="dfn-panel" data-for="term-for-list-is-empty" id="infopanel-for-term-for-list-is-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-is-empty" style="display:none">Info about the 'is empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-is-empty">https://infra.spec.whatwg.org/#list-is-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-is-empty">4.1. URL representation</a>
     <li><a href="#ref-for-list-is-empty①">4.2. URL miscellaneous</a>
@@ -3798,26 +3798,26 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list-is-empty③">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-isomorphic-decode">
-   <a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-isomorphic-decode" class="dfn-panel" data-for="term-for-isomorphic-decode" id="infopanel-for-term-for-isomorphic-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-isomorphic-decode" style="display:none">Info about the 'isomorphic decode' external reference.</span><a href="https://infra.spec.whatwg.org/#isomorphic-decode">https://infra.spec.whatwg.org/#isomorphic-decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-isomorphic-decode">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-item">
-   <a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-item" class="dfn-panel" data-for="term-for-list-item" id="infopanel-for-term-for-list-item" role="menu">
+   <span id="infopaneltitle-for-term-for-list-item" style="display:none">Info about the 'item' external reference.</span><a href="https://infra.spec.whatwg.org/#list-item">https://infra.spec.whatwg.org/#list-item</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-item">3.5. Host parsing</a> <a href="#ref-for-list-item①">(2)</a> <a href="#ref-for-list-item②">(3)</a> <a href="#ref-for-list-item③">(4)</a> <a href="#ref-for-list-item④">(5)</a> <a href="#ref-for-list-item⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string-length">
-   <a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string-length" class="dfn-panel" data-for="term-for-string-length" id="infopanel-for-term-for-string-length" role="menu">
+   <span id="infopaneltitle-for-term-for-string-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#string-length">https://infra.spec.whatwg.org/#string-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-length">4.2. URL miscellaneous</a> <a href="#ref-for-string-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">3.1. Host representation</a>
     <li><a href="#ref-for-list①">3.5. Host parsing</a>
@@ -3826,140 +3826,140 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-list④">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-noncharacter">
-   <a href="https://infra.spec.whatwg.org/#noncharacter">https://infra.spec.whatwg.org/#noncharacter</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-noncharacter" class="dfn-panel" data-for="term-for-noncharacter" id="infopanel-for-term-for-noncharacter" role="menu">
+   <span id="infopaneltitle-for-term-for-noncharacter" style="display:none">Info about the 'noncharacter' external reference.</span><a href="https://infra.spec.whatwg.org/#noncharacter">https://infra.spec.whatwg.org/#noncharacter</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-noncharacter">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">3.5. Host parsing</a> <a href="#ref-for-list-remove①">(2)</a>
     <li><a href="#ref-for-list-remove②">4.2. URL miscellaneous</a>
     <li><a href="#ref-for-list-remove③">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-size">
-   <a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-size" class="dfn-panel" data-for="term-for-list-size" id="infopanel-for-term-for-list-size" role="menu">
+   <span id="infopaneltitle-for-term-for-list-size" style="display:none">Info about the 'size' external reference.</span><a href="https://infra.spec.whatwg.org/#list-size">https://infra.spec.whatwg.org/#list-size</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-size">3.5. Host parsing</a> <a href="#ref-for-list-size①">(2)</a> <a href="#ref-for-list-size②">(3)</a>
     <li><a href="#ref-for-list-size③">4.2. URL miscellaneous</a>
     <li><a href="#ref-for-list-size④">4.5. URL serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-strictly-split">
-   <a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-strictly-split" class="dfn-panel" data-for="term-for-strictly-split" id="infopanel-for-term-for-strictly-split" role="menu">
+   <span id="infopaneltitle-for-term-for-strictly-split" style="display:none">Info about the 'strictly split' external reference.</span><a href="https://infra.spec.whatwg.org/#strictly-split">https://infra.spec.whatwg.org/#strictly-split</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-strictly-split">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-string">
-   <a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-string" class="dfn-panel" data-for="term-for-string" id="infopanel-for-term-for-string" role="menu">
+   <span id="infopaneltitle-for-term-for-string" style="display:none">Info about the 'string' external reference.</span><a href="https://infra.spec.whatwg.org/#string">https://infra.spec.whatwg.org/#string</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string">1.2. Parsers</a> <a href="#ref-for-string①">(2)</a>
     <li><a href="#ref-for-string②">1.3. Percent-encoded bytes</a> <a href="#ref-for-string③">(2)</a> <a href="#ref-for-string④">(3)</a> <a href="#ref-for-string⑤">(4)</a> <a href="#ref-for-string⑥">(5)</a>
     <li><a href="#ref-for-string⑦">3.3. IDNA</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-value">
-   <a href="https://infra.spec.whatwg.org/#byte-value">https://infra.spec.whatwg.org/#byte-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-value" class="dfn-panel" data-for="term-for-byte-value" id="infopanel-for-term-for-byte-value" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-value" style="display:none">Info about the 'value (for byte)' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-value">https://infra.spec.whatwg.org/#byte-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-value">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-code-point-value">
-   <a href="https://infra.spec.whatwg.org/#code-point-value">https://infra.spec.whatwg.org/#code-point-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-code-point-value" class="dfn-panel" data-for="term-for-code-point-value" id="infopanel-for-term-for-code-point-value" role="menu">
+   <span id="infopaneltitle-for-term-for-code-point-value" style="display:none">Info about the 'value (for code point)' external reference.</span><a href="https://infra.spec.whatwg.org/#code-point-value">https://infra.spec.whatwg.org/#code-point-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-code-point-value">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ToASCII">
-   <a href="https://www.unicode.org/reports/tr46/#ToASCII">https://www.unicode.org/reports/tr46/#ToASCII</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ToASCII" class="dfn-panel" data-for="term-for-ToASCII" id="infopanel-for-term-for-ToASCII" role="menu">
+   <span id="infopaneltitle-for-term-for-ToASCII" style="display:none">Info about the 'ToASCII' external reference.</span><a href="https://www.unicode.org/reports/tr46/#ToASCII">https://www.unicode.org/reports/tr46/#ToASCII</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ToASCII">3.3. IDNA</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ToUnicode">
-   <a href="https://www.unicode.org/reports/tr46/#ToUnicode">https://www.unicode.org/reports/tr46/#ToUnicode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ToUnicode" class="dfn-panel" data-for="term-for-ToUnicode" id="infopanel-for-term-for-ToUnicode" role="menu">
+   <span id="infopaneltitle-for-term-for-ToUnicode" style="display:none">Info about the 'ToUnicode' external reference.</span><a href="https://www.unicode.org/reports/tr46/#ToUnicode">https://www.unicode.org/reports/tr46/#ToUnicode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ToUnicode">3.3. IDNA</a>
     <li><a href="#ref-for-ToUnicode①">3.4. Host writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">6.1. URL class</a>
     <li><a href="#ref-for-Exposed①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-LegacyWindowAlias">
-   <a href="https://webidl.spec.whatwg.org/#LegacyWindowAlias">https://webidl.spec.whatwg.org/#LegacyWindowAlias</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-LegacyWindowAlias" class="dfn-panel" data-for="term-for-LegacyWindowAlias" id="infopanel-for-term-for-LegacyWindowAlias" role="menu">
+   <span id="infopaneltitle-for-term-for-LegacyWindowAlias" style="display:none">Info about the 'LegacyWindowAlias' external reference.</span><a href="https://webidl.spec.whatwg.org/#LegacyWindowAlias">https://webidl.spec.whatwg.org/#LegacyWindowAlias</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-LegacyWindowAlias">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-exceptiondef-typeerror">
-   <a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-exceptiondef-typeerror" class="dfn-panel" data-for="term-for-exceptiondef-typeerror" id="infopanel-for-term-for-exceptiondef-typeerror" role="menu">
+   <span id="infopaneltitle-for-term-for-exceptiondef-typeerror" style="display:none">Info about the 'TypeError' external reference.</span><a href="https://webidl.spec.whatwg.org/#exceptiondef-typeerror">https://webidl.spec.whatwg.org/#exceptiondef-typeerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-exceptiondef-typeerror">6.1. URL class</a> <a href="#ref-for-exceptiondef-typeerror①">(2)</a> <a href="#ref-for-exceptiondef-typeerror②">(3)</a>
     <li><a href="#ref-for-exceptiondef-typeerror③">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">6.1. URL class</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a> <a href="#ref-for-idl-USVString④">(5)</a> <a href="#ref-for-idl-USVString⑤">(6)</a> <a href="#ref-for-idl-USVString⑥">(7)</a> <a href="#ref-for-idl-USVString⑦">(8)</a> <a href="#ref-for-idl-USVString⑧">(9)</a> <a href="#ref-for-idl-USVString⑨">(10)</a> <a href="#ref-for-idl-USVString①⓪">(11)</a> <a href="#ref-for-idl-USVString①①">(12)</a> <a href="#ref-for-idl-USVString①②">(13)</a> <a href="#ref-for-idl-USVString①③">(14)</a>
     <li><a href="#ref-for-idl-USVString①④">6.2. URLSearchParams class</a> <a href="#ref-for-idl-USVString①⑤">(2)</a> <a href="#ref-for-idl-USVString①⑥">(3)</a> <a href="#ref-for-idl-USVString①⑦">(4)</a> <a href="#ref-for-idl-USVString①⑧">(5)</a> <a href="#ref-for-idl-USVString①⑨">(6)</a> <a href="#ref-for-idl-USVString②⓪">(7)</a> <a href="#ref-for-idl-USVString②①">(8)</a> <a href="#ref-for-idl-USVString②②">(9)</a> <a href="#ref-for-idl-USVString②③">(10)</a> <a href="#ref-for-idl-USVString②④">(11)</a> <a href="#ref-for-idl-USVString②⑤">(12)</a> <a href="#ref-for-idl-USVString②⑥">(13)</a> <a href="#ref-for-idl-USVString②⑦">(14)</a> <a href="#ref-for-idl-USVString②⑧">(15)</a> <a href="#ref-for-idl-USVString②⑨">(16)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">6.2. URLSearchParams class</a> <a href="#ref-for-idl-record①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">6.2. URLSearchParams class</a> <a href="#ref-for-idl-sequence①">(2)</a> <a href="#ref-for-idl-sequence②">(3)</a> <a href="#ref-for-idl-sequence③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">6.1. URL class</a> <a href="#ref-for-this①">(2)</a> <a href="#ref-for-this②">(3)</a> <a href="#ref-for-this③">(4)</a> <a href="#ref-for-this④">(5)</a> <a href="#ref-for-this⑤">(6)</a> <a href="#ref-for-this⑥">(7)</a> <a href="#ref-for-this⑦">(8)</a> <a href="#ref-for-this⑧">(9)</a> <a href="#ref-for-this⑨">(10)</a> <a href="#ref-for-this①⓪">(11)</a> <a href="#ref-for-this①①">(12)</a> <a href="#ref-for-this①②">(13)</a> <a href="#ref-for-this①③">(14)</a> <a href="#ref-for-this①④">(15)</a> <a href="#ref-for-this①⑤">(16)</a> <a href="#ref-for-this①⑥">(17)</a> <a href="#ref-for-this①⑦">(18)</a> <a href="#ref-for-this①⑧">(19)</a> <a href="#ref-for-this①⑨">(20)</a> <a href="#ref-for-this②⓪">(21)</a> <a href="#ref-for-this②①">(22)</a> <a href="#ref-for-this②②">(23)</a> <a href="#ref-for-this②③">(24)</a> <a href="#ref-for-this②④">(25)</a> <a href="#ref-for-this②⑤">(26)</a> <a href="#ref-for-this②⑥">(27)</a> <a href="#ref-for-this②⑦">(28)</a> <a href="#ref-for-this②⑧">(29)</a> <a href="#ref-for-this②⑨">(30)</a> <a href="#ref-for-this③⓪">(31)</a> <a href="#ref-for-this③①">(32)</a> <a href="#ref-for-this③②">(33)</a> <a href="#ref-for-this③③">(34)</a> <a href="#ref-for-this③④">(35)</a> <a href="#ref-for-this③⑤">(36)</a> <a href="#ref-for-this③⑥">(37)</a> <a href="#ref-for-this③⑦">(38)</a> <a href="#ref-for-this③⑧">(39)</a> <a href="#ref-for-this③⑨">(40)</a> <a href="#ref-for-this④⓪">(41)</a> <a href="#ref-for-this④①">(42)</a> <a href="#ref-for-this④②">(43)</a> <a href="#ref-for-this④③">(44)</a> <a href="#ref-for-this④④">(45)</a> <a href="#ref-for-this④⑤">(46)</a> <a href="#ref-for-this④⑥">(47)</a> <a href="#ref-for-this④⑦">(48)</a> <a href="#ref-for-this④⑧">(49)</a> <a href="#ref-for-this④⑨">(50)</a>
     <li><a href="#ref-for-this⑤⓪">6.2. URLSearchParams class</a> <a href="#ref-for-this⑤①">(2)</a> <a href="#ref-for-this⑤②">(3)</a> <a href="#ref-for-this⑤③">(4)</a> <a href="#ref-for-this⑤④">(5)</a> <a href="#ref-for-this⑤⑤">(6)</a> <a href="#ref-for-this⑤⑥">(7)</a> <a href="#ref-for-this⑤⑦">(8)</a> <a href="#ref-for-this⑤⑧">(9)</a> <a href="#ref-for-this⑤⑨">(10)</a> <a href="#ref-for-this⑥⓪">(11)</a> <a href="#ref-for-this⑥①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">6.1. URL class</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a>
     <li><a href="#ref-for-dfn-throw③">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">6.2. URLSearchParams class</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over">
-   <a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over" id="infopanel-for-term-for-dfn-value-pairs-to-iterate-over" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">6.2. URLSearchParams class</a>
    </ul>
@@ -4174,16 +4174,16 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="serialize-an-integer">
-   <b><a href="#serialize-an-integer">#serialize-an-integer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-serialize-an-integer" class="dfn-panel" data-for="serialize-an-integer" id="infopanel-for-serialize-an-integer" role="dialog">
+   <span id="infopaneltitle-for-serialize-an-integer" style="display:none">Info about the 'serialize an integer' definition.</span><b><a href="#serialize-an-integer">#serialize-an-integer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-an-integer">3.6. Host serializing</a>
     <li><a href="#ref-for-serialize-an-integer①">4.5. URL serializing</a>
     <li><a href="#ref-for-serialize-an-integer②">6.1. URL class</a> <a href="#ref-for-serialize-an-integer③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="validation-error">
-   <b><a href="#validation-error">#validation-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-validation-error" class="dfn-panel" data-for="validation-error" id="infopanel-for-validation-error" role="dialog">
+   <span id="infopaneltitle-for-validation-error" style="display:none">Info about the 'validation error' definition.</span><b><a href="#validation-error">#validation-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-validation-error">1.1. Writing</a> <a href="#ref-for-validation-error①">(2)</a>
     <li><a href="#ref-for-validation-error②">3. Hosts (domains and IP addresses)</a>
@@ -4193,150 +4193,150 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-validation-error③⓪">4.4. URL parsing</a> <a href="#ref-for-validation-error③①">(2)</a> <a href="#ref-for-validation-error③②">(3)</a> <a href="#ref-for-validation-error③③">(4)</a> <a href="#ref-for-validation-error③④">(5)</a> <a href="#ref-for-validation-error③⑤">(6)</a> <a href="#ref-for-validation-error③⑥">(7)</a> <a href="#ref-for-validation-error③⑦">(8)</a> <a href="#ref-for-validation-error③⑧">(9)</a> <a href="#ref-for-validation-error③⑨">(10)</a> <a href="#ref-for-validation-error④⓪">(11)</a> <a href="#ref-for-validation-error④①">(12)</a> <a href="#ref-for-validation-error④②">(13)</a> <a href="#ref-for-validation-error④③">(14)</a> <a href="#ref-for-validation-error④④">(15)</a> <a href="#ref-for-validation-error④⑤">(16)</a> <a href="#ref-for-validation-error④⑥">(17)</a> <a href="#ref-for-validation-error④⑦">(18)</a> <a href="#ref-for-validation-error④⑧">(19)</a> <a href="#ref-for-validation-error④⑨">(20)</a> <a href="#ref-for-validation-error⑤⓪">(21)</a> <a href="#ref-for-validation-error⑤①">(22)</a> <a href="#ref-for-validation-error⑤②">(23)</a> <a href="#ref-for-validation-error⑤③">(24)</a> <a href="#ref-for-validation-error⑤④">(25)</a> <a href="#ref-for-validation-error⑤⑤">(26)</a> <a href="#ref-for-validation-error⑤⑥">(27)</a> <a href="#ref-for-validation-error⑤⑦">(28)</a> <a href="#ref-for-validation-error⑤⑧">(29)</a> <a href="#ref-for-validation-error⑤⑨">(30)</a> <a href="#ref-for-validation-error⑥⓪">(31)</a> <a href="#ref-for-validation-error⑥①">(32)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="eof-code-point">
-   <b><a href="#eof-code-point">#eof-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-eof-code-point" class="dfn-panel" data-for="eof-code-point" id="infopanel-for-eof-code-point" role="dialog">
+   <span id="infopaneltitle-for-eof-code-point" style="display:none">Info about the 'EOF code point' definition.</span><b><a href="#eof-code-point">#eof-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eof-code-point">1.2. Parsers</a> <a href="#ref-for-eof-code-point①">(2)</a> <a href="#ref-for-eof-code-point②">(3)</a>
     <li><a href="#ref-for-eof-code-point③">3.5. Host parsing</a> <a href="#ref-for-eof-code-point④">(2)</a> <a href="#ref-for-eof-code-point⑤">(3)</a> <a href="#ref-for-eof-code-point⑥">(4)</a>
     <li><a href="#ref-for-eof-code-point⑦">4.4. URL parsing</a> <a href="#ref-for-eof-code-point⑧">(2)</a> <a href="#ref-for-eof-code-point⑨">(3)</a> <a href="#ref-for-eof-code-point①⓪">(4)</a> <a href="#ref-for-eof-code-point①①">(5)</a> <a href="#ref-for-eof-code-point①②">(6)</a> <a href="#ref-for-eof-code-point①③">(7)</a> <a href="#ref-for-eof-code-point①④">(8)</a> <a href="#ref-for-eof-code-point①⑤">(9)</a> <a href="#ref-for-eof-code-point①⑥">(10)</a> <a href="#ref-for-eof-code-point①⑦">(11)</a> <a href="#ref-for-eof-code-point①⑧">(12)</a> <a href="#ref-for-eof-code-point①⑨">(13)</a> <a href="#ref-for-eof-code-point②⓪">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="pointer">
-   <b><a href="#pointer">#pointer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-pointer" class="dfn-panel" data-for="pointer" id="infopanel-for-pointer" role="dialog">
+   <span id="infopaneltitle-for-pointer" style="display:none">Info about the 'pointer' definition.</span><b><a href="#pointer">#pointer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pointer">1.2. Parsers</a> <a href="#ref-for-pointer①">(2)</a> <a href="#ref-for-pointer②">(3)</a> <a href="#ref-for-pointer③">(4)</a> <a href="#ref-for-pointer④">(5)</a> <a href="#ref-for-pointer⑤">(6)</a>
     <li><a href="#ref-for-pointer⑥">3.5. Host parsing</a>
     <li><a href="#ref-for-pointer⑦">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="c">
-   <b><a href="#c">#c</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-c" class="dfn-panel" data-for="c" id="infopanel-for-c" role="dialog">
+   <span id="infopaneltitle-for-c" style="display:none">Info about the 'c' definition.</span><b><a href="#c">#c</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c">1.2. Parsers</a> <a href="#ref-for-c①">(2)</a> <a href="#ref-for-c②">(3)</a> <a href="#ref-for-c③">(4)</a> <a href="#ref-for-c④">(5)</a> <a href="#ref-for-c⑤">(6)</a>
     <li><a href="#ref-for-c⑥">3.5. Host parsing</a> <a href="#ref-for-c⑦">(2)</a> <a href="#ref-for-c⑧">(3)</a> <a href="#ref-for-c⑨">(4)</a> <a href="#ref-for-c①⓪">(5)</a> <a href="#ref-for-c①①">(6)</a> <a href="#ref-for-c①②">(7)</a> <a href="#ref-for-c①③">(8)</a> <a href="#ref-for-c①④">(9)</a> <a href="#ref-for-c①⑤">(10)</a> <a href="#ref-for-c①⑥">(11)</a> <a href="#ref-for-c①⑦">(12)</a> <a href="#ref-for-c①⑧">(13)</a> <a href="#ref-for-c①⑨">(14)</a>
     <li><a href="#ref-for-c②⓪">4.4. URL parsing</a> <a href="#ref-for-c②①">(2)</a> <a href="#ref-for-c②②">(3)</a> <a href="#ref-for-c②③">(4)</a> <a href="#ref-for-c②④">(5)</a> <a href="#ref-for-c②⑤">(6)</a> <a href="#ref-for-c②⑥">(7)</a> <a href="#ref-for-c②⑦">(8)</a> <a href="#ref-for-c②⑧">(9)</a> <a href="#ref-for-c②⑨">(10)</a> <a href="#ref-for-c③⓪">(11)</a> <a href="#ref-for-c③①">(12)</a> <a href="#ref-for-c③②">(13)</a> <a href="#ref-for-c③③">(14)</a> <a href="#ref-for-c③④">(15)</a> <a href="#ref-for-c③⑤">(16)</a> <a href="#ref-for-c③⑥">(17)</a> <a href="#ref-for-c③⑦">(18)</a> <a href="#ref-for-c③⑧">(19)</a> <a href="#ref-for-c③⑨">(20)</a> <a href="#ref-for-c④⓪">(21)</a> <a href="#ref-for-c④①">(22)</a> <a href="#ref-for-c④②">(23)</a> <a href="#ref-for-c④③">(24)</a> <a href="#ref-for-c④④">(25)</a> <a href="#ref-for-c④⑤">(26)</a> <a href="#ref-for-c④⑥">(27)</a> <a href="#ref-for-c④⑦">(28)</a> <a href="#ref-for-c④⑧">(29)</a> <a href="#ref-for-c④⑨">(30)</a> <a href="#ref-for-c⑤⓪">(31)</a> <a href="#ref-for-c⑤①">(32)</a> <a href="#ref-for-c⑤②">(33)</a> <a href="#ref-for-c⑤③">(34)</a> <a href="#ref-for-c⑤④">(35)</a> <a href="#ref-for-c⑤⑤">(36)</a> <a href="#ref-for-c⑤⑥">(37)</a> <a href="#ref-for-c⑤⑦">(38)</a> <a href="#ref-for-c⑤⑧">(39)</a> <a href="#ref-for-c⑤⑨">(40)</a> <a href="#ref-for-c⑥⓪">(41)</a> <a href="#ref-for-c⑥①">(42)</a> <a href="#ref-for-c⑥②">(43)</a> <a href="#ref-for-c⑥③">(44)</a> <a href="#ref-for-c⑥④">(45)</a> <a href="#ref-for-c⑥⑤">(46)</a> <a href="#ref-for-c⑥⑥">(47)</a> <a href="#ref-for-c⑥⑦">(48)</a> <a href="#ref-for-c⑥⑧">(49)</a> <a href="#ref-for-c⑥⑨">(50)</a> <a href="#ref-for-c⑦⓪">(51)</a> <a href="#ref-for-c⑦①">(52)</a> <a href="#ref-for-c⑦②">(53)</a> <a href="#ref-for-c⑦③">(54)</a> <a href="#ref-for-c⑦④">(55)</a> <a href="#ref-for-c⑦⑤">(56)</a> <a href="#ref-for-c⑦⑥">(57)</a> <a href="#ref-for-c⑦⑦">(58)</a> <a href="#ref-for-c⑦⑧">(59)</a> <a href="#ref-for-c⑦⑨">(60)</a> <a href="#ref-for-c⑧⓪">(61)</a> <a href="#ref-for-c⑧①">(62)</a> <a href="#ref-for-c⑧②">(63)</a> <a href="#ref-for-c⑧③">(64)</a> <a href="#ref-for-c⑧④">(65)</a> <a href="#ref-for-c⑧⑤">(66)</a> <a href="#ref-for-c⑧⑥">(67)</a> <a href="#ref-for-c⑧⑦">(68)</a> <a href="#ref-for-c⑧⑧">(69)</a> <a href="#ref-for-c⑧⑨">(70)</a> <a href="#ref-for-c⑨⓪">(71)</a> <a href="#ref-for-c⑨①">(72)</a> <a href="#ref-for-c⑨②">(73)</a> <a href="#ref-for-c⑨③">(74)</a> <a href="#ref-for-c⑨④">(75)</a> <a href="#ref-for-c⑨⑤">(76)</a> <a href="#ref-for-c⑨⑥">(77)</a> <a href="#ref-for-c⑨⑦">(78)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="remaining">
-   <b><a href="#remaining">#remaining</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-remaining" class="dfn-panel" data-for="remaining" id="infopanel-for-remaining" role="dialog">
+   <span id="infopaneltitle-for-remaining" style="display:none">Info about the 'remaining' definition.</span><b><a href="#remaining">#remaining</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-remaining">1.2. Parsers</a> <a href="#ref-for-remaining①">(2)</a> <a href="#ref-for-remaining②">(3)</a>
     <li><a href="#ref-for-remaining③">3.5. Host parsing</a>
     <li><a href="#ref-for-remaining④">4.4. URL parsing</a> <a href="#ref-for-remaining⑤">(2)</a> <a href="#ref-for-remaining⑥">(3)</a> <a href="#ref-for-remaining⑦">(4)</a> <a href="#ref-for-remaining⑧">(5)</a> <a href="#ref-for-remaining⑨">(6)</a> <a href="#ref-for-remaining①⓪">(7)</a> <a href="#ref-for-remaining①①">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percent-encoded-byte">
-   <b><a href="#percent-encoded-byte">#percent-encoded-byte</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percent-encoded-byte" class="dfn-panel" data-for="percent-encoded-byte" id="infopanel-for-percent-encoded-byte" role="dialog">
+   <span id="infopaneltitle-for-percent-encoded-byte" style="display:none">Info about the 'percent-encoded byte' definition.</span><b><a href="#percent-encoded-byte">#percent-encoded-byte</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-encoded-byte">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-percent-encoded-byte①">4.3. URL writing</a> <a href="#ref-for-percent-encoded-byte②">(2)</a> <a href="#ref-for-percent-encoded-byte③">(3)</a> <a href="#ref-for-percent-encoded-byte④">(4)</a>
     <li><a href="#ref-for-percent-encoded-byte⑤">4.8.3. Internationalization and special characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percent-encode">
-   <b><a href="#percent-encode">#percent-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percent-encode" class="dfn-panel" data-for="percent-encode" id="infopanel-for-percent-encode" role="dialog">
+   <span id="infopaneltitle-for-percent-encode" style="display:none">Info about the 'percent-encode' definition.</span><b><a href="#percent-encode">#percent-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-encode">1.3. Percent-encoded bytes</a> <a href="#ref-for-percent-encode①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="percent-decode">
-   <b><a href="#percent-decode">#percent-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-percent-decode" class="dfn-panel" data-for="percent-decode" id="infopanel-for-percent-decode" role="dialog">
+   <span id="infopaneltitle-for-percent-decode" style="display:none">Info about the 'percent-decode' definition.</span><b><a href="#percent-decode">#percent-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-percent-decode">1.3. Percent-encoded bytes</a> <a href="#ref-for-percent-decode①">(2)</a>
     <li><a href="#ref-for-percent-decode②">5.1. application/x-www-form-urlencoded parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-percent-decode">
-   <b><a href="#string-percent-decode">#string-percent-decode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-percent-decode" class="dfn-panel" data-for="string-percent-decode" id="infopanel-for-string-percent-decode" role="dialog">
+   <span id="infopaneltitle-for-string-percent-decode" style="display:none">Info about the 'percent-decode' definition.</span><b><a href="#string-percent-decode">#string-percent-decode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-percent-decode">1.3. Percent-encoded bytes</a> <a href="#ref-for-string-percent-decode①">(2)</a>
     <li><a href="#ref-for-string-percent-decode②">3.5. Host parsing</a>
     <li><a href="#ref-for-string-percent-decode③">4.8.3. Internationalization and special characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="c0-control-percent-encode-set">
-   <b><a href="#c0-control-percent-encode-set">#c0-control-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-c0-control-percent-encode-set" class="dfn-panel" data-for="c0-control-percent-encode-set" id="infopanel-for-c0-control-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-c0-control-percent-encode-set" style="display:none">Info about the 'C0 control percent-encode set' definition.</span><b><a href="#c0-control-percent-encode-set">#c0-control-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-c0-control-percent-encode-set">1.3. Percent-encoded bytes</a> <a href="#ref-for-c0-control-percent-encode-set①">(2)</a>
     <li><a href="#ref-for-c0-control-percent-encode-set②">3.5. Host parsing</a>
     <li><a href="#ref-for-c0-control-percent-encode-set③">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-percent-encode-set">
-   <b><a href="#fragment-percent-encode-set">#fragment-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment-percent-encode-set" class="dfn-panel" data-for="fragment-percent-encode-set" id="infopanel-for-fragment-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-fragment-percent-encode-set" style="display:none">Info about the 'fragment percent-encode set' definition.</span><b><a href="#fragment-percent-encode-set">#fragment-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-percent-encode-set">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-fragment-percent-encode-set①">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-percent-encode-set">
-   <b><a href="#query-percent-encode-set">#query-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-percent-encode-set" class="dfn-panel" data-for="query-percent-encode-set" id="infopanel-for-query-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-query-percent-encode-set" style="display:none">Info about the 'query percent-encode set' definition.</span><b><a href="#query-percent-encode-set">#query-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-percent-encode-set">1.3. Percent-encoded bytes</a> <a href="#ref-for-query-percent-encode-set①">(2)</a> <a href="#ref-for-query-percent-encode-set②">(3)</a>
     <li><a href="#ref-for-query-percent-encode-set③">4.4. URL parsing</a>
     <li><a href="#ref-for-query-percent-encode-set④">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="special-query-percent-encode-set">
-   <b><a href="#special-query-percent-encode-set">#special-query-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-special-query-percent-encode-set" class="dfn-panel" data-for="special-query-percent-encode-set" id="infopanel-for-special-query-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-special-query-percent-encode-set" style="display:none">Info about the 'special-query percent-encode set' definition.</span><b><a href="#special-query-percent-encode-set">#special-query-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-query-percent-encode-set">4.4. URL parsing</a>
     <li><a href="#ref-for-special-query-percent-encode-set①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-percent-encode-set">
-   <b><a href="#path-percent-encode-set">#path-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-percent-encode-set" class="dfn-panel" data-for="path-percent-encode-set" id="infopanel-for-path-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-path-percent-encode-set" style="display:none">Info about the 'path percent-encode set' definition.</span><b><a href="#path-percent-encode-set">#path-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-percent-encode-set">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-path-percent-encode-set①">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="userinfo-percent-encode-set">
-   <b><a href="#userinfo-percent-encode-set">#userinfo-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-userinfo-percent-encode-set" class="dfn-panel" data-for="userinfo-percent-encode-set" id="infopanel-for-userinfo-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-userinfo-percent-encode-set" style="display:none">Info about the 'userinfo percent-encode set' definition.</span><b><a href="#userinfo-percent-encode-set">#userinfo-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-userinfo-percent-encode-set">1.3. Percent-encoded bytes</a> <a href="#ref-for-userinfo-percent-encode-set①">(2)</a> <a href="#ref-for-userinfo-percent-encode-set②">(3)</a> <a href="#ref-for-userinfo-percent-encode-set③">(4)</a> <a href="#ref-for-userinfo-percent-encode-set④">(5)</a> <a href="#ref-for-userinfo-percent-encode-set⑤">(6)</a>
     <li><a href="#ref-for-userinfo-percent-encode-set⑥">4.4. URL parsing</a> <a href="#ref-for-userinfo-percent-encode-set⑦">(2)</a> <a href="#ref-for-userinfo-percent-encode-set⑧">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="component-percent-encode-set">
-   <b><a href="#component-percent-encode-set">#component-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-component-percent-encode-set" class="dfn-panel" data-for="component-percent-encode-set" id="infopanel-for-component-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-component-percent-encode-set" style="display:none">Info about the 'component percent-encode set' definition.</span><b><a href="#component-percent-encode-set">#component-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-component-percent-encode-set">1.3. Percent-encoded bytes</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="application-x-www-form-urlencoded-percent-encode-set">
-   <b><a href="#application-x-www-form-urlencoded-percent-encode-set">#application-x-www-form-urlencoded-percent-encode-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-application-x-www-form-urlencoded-percent-encode-set" class="dfn-panel" data-for="application-x-www-form-urlencoded-percent-encode-set" id="infopanel-for-application-x-www-form-urlencoded-percent-encode-set" role="dialog">
+   <span id="infopaneltitle-for-application-x-www-form-urlencoded-percent-encode-set" style="display:none">Info about the 'application/x-www-form-urlencoded percent-encode set' definition.</span><b><a href="#application-x-www-form-urlencoded-percent-encode-set">#application-x-www-form-urlencoded-percent-encode-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-application-x-www-form-urlencoded-percent-encode-set">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-application-x-www-form-urlencoded-percent-encode-set①">5.2. application/x-www-form-urlencoded serializing</a> <a href="#ref-for-application-x-www-form-urlencoded-percent-encode-set②">(2)</a>
     <li><a href="#ref-for-application-x-www-form-urlencoded-percent-encode-set③">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-percent-encode-after-encoding">
-   <b><a href="#string-percent-encode-after-encoding">#string-percent-encode-after-encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-percent-encode-after-encoding" class="dfn-panel" data-for="string-percent-encode-after-encoding" id="infopanel-for-string-percent-encode-after-encoding" role="dialog">
+   <span id="infopaneltitle-for-string-percent-encode-after-encoding" style="display:none">Info about the 'percent-encode after encoding' definition.</span><b><a href="#string-percent-encode-after-encoding">#string-percent-encode-after-encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-percent-encode-after-encoding">1.3. Percent-encoded bytes</a> <a href="#ref-for-string-percent-encode-after-encoding①">(2)</a> <a href="#ref-for-string-percent-encode-after-encoding②">(3)</a> <a href="#ref-for-string-percent-encode-after-encoding③">(4)</a> <a href="#ref-for-string-percent-encode-after-encoding④">(5)</a>
     <li><a href="#ref-for-string-percent-encode-after-encoding⑤">4.4. URL parsing</a>
     <li><a href="#ref-for-string-percent-encode-after-encoding⑥">5.2. application/x-www-form-urlencoded serializing</a> <a href="#ref-for-string-percent-encode-after-encoding⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="utf-8-percent-encode">
-   <b><a href="#utf-8-percent-encode">#utf-8-percent-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-utf-8-percent-encode" class="dfn-panel" data-for="utf-8-percent-encode" id="infopanel-for-utf-8-percent-encode" role="dialog">
+   <span id="infopaneltitle-for-utf-8-percent-encode" style="display:none">Info about the 'UTF-8 percent-encode' definition.</span><b><a href="#utf-8-percent-encode">#utf-8-percent-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-percent-encode">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-utf-8-percent-encode①">4.4. URL parsing</a> <a href="#ref-for-utf-8-percent-encode②">(2)</a> <a href="#ref-for-utf-8-percent-encode③">(3)</a> <a href="#ref-for-utf-8-percent-encode④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="string-utf-8-percent-encode">
-   <b><a href="#string-utf-8-percent-encode">#string-utf-8-percent-encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-string-utf-8-percent-encode" class="dfn-panel" data-for="string-utf-8-percent-encode" id="infopanel-for-string-utf-8-percent-encode" role="dialog">
+   <span id="infopaneltitle-for-string-utf-8-percent-encode" style="display:none">Info about the 'UTF-8 percent-encode' definition.</span><b><a href="#string-utf-8-percent-encode">#string-utf-8-percent-encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-string-utf-8-percent-encode">1.3. Percent-encoded bytes</a> <a href="#ref-for-string-utf-8-percent-encode①">(2)</a>
     <li><a href="#ref-for-string-utf-8-percent-encode②">3.5. Host parsing</a>
     <li><a href="#ref-for-string-utf-8-percent-encode③">4.4. URL parsing</a> <a href="#ref-for-string-utf-8-percent-encode④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-host">
-   <b><a href="#concept-host">#concept-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-host" class="dfn-panel" data-for="concept-host" id="infopanel-for-concept-host" role="dialog">
+   <span id="infopaneltitle-for-concept-host" style="display:none">Info about the 'host' definition.</span><b><a href="#concept-host">#concept-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-host">2. Security considerations</a>
     <li><a href="#ref-for-concept-host①">3. Hosts (domains and IP addresses)</a> <a href="#ref-for-concept-host②">(2)</a> <a href="#ref-for-concept-host③">(3)</a> <a href="#ref-for-concept-host④">(4)</a> <a href="#ref-for-concept-host⑤">(5)</a>
@@ -4347,8 +4347,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-host①③">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-domain">
-   <b><a href="#concept-domain">#concept-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-domain" class="dfn-panel" data-for="concept-domain" id="infopanel-for-concept-domain" role="dialog">
+   <span id="infopaneltitle-for-concept-domain" style="display:none">Info about the 'domain' definition.</span><b><a href="#concept-domain">#concept-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain">3.1. Host representation</a> <a href="#ref-for-concept-domain①">(2)</a>
     <li><a href="#ref-for-concept-domain②">3.2. Host miscellaneous</a> <a href="#ref-for-concept-domain③">(2)</a>
@@ -4358,8 +4358,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-domain⑦">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv4">
-   <b><a href="#concept-ipv4">#concept-ipv4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv4" class="dfn-panel" data-for="concept-ipv4" id="infopanel-for-concept-ipv4" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv4" style="display:none">Info about the 'IPv4 address' definition.</span><b><a href="#concept-ipv4">#concept-ipv4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv4">3.1. Host representation</a>
     <li><a href="#ref-for-concept-ipv4①">3.5. Host parsing</a> <a href="#ref-for-concept-ipv4②">(2)</a>
@@ -4367,8 +4367,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-ipv4⑤">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv6">
-   <b><a href="#concept-ipv6">#concept-ipv6</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv6" class="dfn-panel" data-for="concept-ipv6" id="infopanel-for-concept-ipv6" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv6" style="display:none">Info about the 'IPv6 address' definition.</span><b><a href="#concept-ipv6">#concept-ipv6</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6">3.1. Host representation</a>
     <li><a href="#ref-for-concept-ipv6①">3.5. Host parsing</a>
@@ -4376,15 +4376,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-ipv6④">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv6-piece">
-   <b><a href="#concept-ipv6-piece">#concept-ipv6-piece</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv6-piece" class="dfn-panel" data-for="concept-ipv6-piece" id="infopanel-for-concept-ipv6-piece" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv6-piece" style="display:none">Info about the 'IPv6 pieces' definition.</span><b><a href="#concept-ipv6-piece">#concept-ipv6-piece</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6-piece">3.5. Host parsing</a>
     <li><a href="#ref-for-concept-ipv6-piece①">3.6. Host serializing</a> <a href="#ref-for-concept-ipv6-piece②">(2)</a> <a href="#ref-for-concept-ipv6-piece③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-host">
-   <b><a href="#opaque-host">#opaque-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-host" class="dfn-panel" data-for="opaque-host" id="infopanel-for-opaque-host" role="dialog">
+   <span id="infopaneltitle-for-opaque-host" style="display:none">Info about the 'opaque host' definition.</span><b><a href="#opaque-host">#opaque-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-host">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-opaque-host①">3.1. Host representation</a>
@@ -4392,8 +4392,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-opaque-host③">4.1. URL representation</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="empty-host">
-   <b><a href="#empty-host">#empty-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-empty-host" class="dfn-panel" data-for="empty-host" id="infopanel-for-empty-host" role="dialog">
+   <span id="infopaneltitle-for-empty-host" style="display:none">Info about the 'empty host' definition.</span><b><a href="#empty-host">#empty-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-empty-host">3.1. Host representation</a>
     <li><a href="#ref-for-empty-host①">3.6. Host serializing</a>
@@ -4402,139 +4402,139 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-empty-host⑤">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="forbidden-host-code-point">
-   <b><a href="#forbidden-host-code-point">#forbidden-host-code-point</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-forbidden-host-code-point" class="dfn-panel" data-for="forbidden-host-code-point" id="infopanel-for-forbidden-host-code-point" role="dialog">
+   <span id="infopaneltitle-for-forbidden-host-code-point" style="display:none">Info about the 'forbidden host code point' definition.</span><b><a href="#forbidden-host-code-point">#forbidden-host-code-point</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forbidden-host-code-point">3.4. Host writing</a>
     <li><a href="#ref-for-forbidden-host-code-point①">3.5. Host parsing</a> <a href="#ref-for-forbidden-host-code-point②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-public-suffix">
-   <b><a href="#host-public-suffix">#host-public-suffix</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-public-suffix" class="dfn-panel" data-for="host-public-suffix" id="infopanel-for-host-public-suffix" role="dialog">
+   <span id="infopaneltitle-for-host-public-suffix" style="display:none">Info about the 'public suffix' definition.</span><b><a href="#host-public-suffix">#host-public-suffix</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-public-suffix">3.2. Host miscellaneous</a> <a href="#ref-for-host-public-suffix①">(2)</a> <a href="#ref-for-host-public-suffix②">(3)</a> <a href="#ref-for-host-public-suffix③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-registrable-domain">
-   <b><a href="#host-registrable-domain">#host-registrable-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-registrable-domain" class="dfn-panel" data-for="host-registrable-domain" id="infopanel-for-host-registrable-domain" role="dialog">
+   <span id="infopaneltitle-for-host-registrable-domain" style="display:none">Info about the 'registrable domain' definition.</span><b><a href="#host-registrable-domain">#host-registrable-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-registrable-domain">3.2. Host miscellaneous</a> <a href="#ref-for-host-registrable-domain①">(2)</a>
     <li><a href="#ref-for-host-registrable-domain②">4.8.1. Simplify non-human-readable or irrelevant components</a>
     <li><a href="#ref-for-host-registrable-domain③">4.8.2. Elision</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-domain-to-ascii">
-   <b><a href="#concept-domain-to-ascii">#concept-domain-to-ascii</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-domain-to-ascii" class="dfn-panel" data-for="concept-domain-to-ascii" id="infopanel-for-concept-domain-to-ascii" role="dialog">
+   <span id="infopaneltitle-for-concept-domain-to-ascii" style="display:none">Info about the 'domain to ASCII' definition.</span><b><a href="#concept-domain-to-ascii">#concept-domain-to-ascii</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain-to-ascii">3.4. Host writing</a>
     <li><a href="#ref-for-concept-domain-to-ascii①">3.5. Host parsing</a> <a href="#ref-for-concept-domain-to-ascii②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-domain-to-unicode">
-   <b><a href="#concept-domain-to-unicode">#concept-domain-to-unicode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-domain-to-unicode" class="dfn-panel" data-for="concept-domain-to-unicode" id="infopanel-for-concept-domain-to-unicode" role="dialog">
+   <span id="infopaneltitle-for-concept-domain-to-unicode" style="display:none">Info about the 'domain to Unicode' definition.</span><b><a href="#concept-domain-to-unicode">#concept-domain-to-unicode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-domain-to-unicode">4.8.3. Internationalization and special characters</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-host-string">
-   <b><a href="#valid-host-string">#valid-host-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-host-string" class="dfn-panel" data-for="valid-host-string" id="infopanel-for-valid-host-string" role="dialog">
+   <span id="infopaneltitle-for-valid-host-string" style="display:none">Info about the 'valid host string' definition.</span><b><a href="#valid-host-string">#valid-host-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-host-string">3. Hosts (domains and IP addresses)</a> <a href="#ref-for-valid-host-string①">(2)</a>
     <li><a href="#ref-for-valid-host-string②">3.4. Host writing</a>
     <li><a href="#ref-for-valid-host-string③">4.3. URL writing</a> <a href="#ref-for-valid-host-string④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-domain">
-   <b><a href="#valid-domain">#valid-domain</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-domain" class="dfn-panel" data-for="valid-domain" id="infopanel-for-valid-domain" role="dialog">
+   <span id="infopaneltitle-for-valid-domain" style="display:none">Info about the 'valid domain' definition.</span><b><a href="#valid-domain">#valid-domain</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-domain">3.4. Host writing</a> <a href="#ref-for-valid-domain①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-domain-string">
-   <b><a href="#valid-domain-string">#valid-domain-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-domain-string" class="dfn-panel" data-for="valid-domain-string" id="infopanel-for-valid-domain-string" role="dialog">
+   <span id="infopaneltitle-for-valid-domain-string" style="display:none">Info about the 'valid domain string' definition.</span><b><a href="#valid-domain-string">#valid-domain-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-domain-string">3.4. Host writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-ipv4-address-string">
-   <b><a href="#valid-ipv4-address-string">#valid-ipv4-address-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-ipv4-address-string" class="dfn-panel" data-for="valid-ipv4-address-string" id="infopanel-for-valid-ipv4-address-string" role="dialog">
+   <span id="infopaneltitle-for-valid-ipv4-address-string" style="display:none">Info about the 'valid IPv4-address string' definition.</span><b><a href="#valid-ipv4-address-string">#valid-ipv4-address-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-ipv4-address-string">3.4. Host writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-ipv6-address-string">
-   <b><a href="#valid-ipv6-address-string">#valid-ipv6-address-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-ipv6-address-string" class="dfn-panel" data-for="valid-ipv6-address-string" id="infopanel-for-valid-ipv6-address-string" role="dialog">
+   <span id="infopaneltitle-for-valid-ipv6-address-string" style="display:none">Info about the 'valid IPv6-address string' definition.</span><b><a href="#valid-ipv6-address-string">#valid-ipv6-address-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-ipv6-address-string">3.4. Host writing</a> <a href="#ref-for-valid-ipv6-address-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-opaque-host-string">
-   <b><a href="#valid-opaque-host-string">#valid-opaque-host-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-opaque-host-string" class="dfn-panel" data-for="valid-opaque-host-string" id="infopanel-for-valid-opaque-host-string" role="dialog">
+   <span id="infopaneltitle-for-valid-opaque-host-string" style="display:none">Info about the 'valid opaque-host string' definition.</span><b><a href="#valid-opaque-host-string">#valid-opaque-host-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-opaque-host-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-host-parser">
-   <b><a href="#concept-host-parser">#concept-host-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-host-parser" class="dfn-panel" data-for="concept-host-parser" id="infopanel-for-concept-host-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-host-parser" style="display:none">Info about the 'host parser' definition.</span><b><a href="#concept-host-parser">#concept-host-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-host-parser">3. Hosts (domains and IP addresses)</a> <a href="#ref-for-concept-host-parser①">(2)</a> <a href="#ref-for-concept-host-parser②">(3)</a> <a href="#ref-for-concept-host-parser③">(4)</a>
     <li><a href="#ref-for-concept-host-parser④">3.5. Host parsing</a>
     <li><a href="#ref-for-concept-host-parser⑤">4.4. URL parsing</a> <a href="#ref-for-concept-host-parser⑥">(2)</a> <a href="#ref-for-concept-host-parser⑦">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv4-parser">
-   <b><a href="#concept-ipv4-parser">#concept-ipv4-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv4-parser" class="dfn-panel" data-for="concept-ipv4-parser" id="infopanel-for-concept-ipv4-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv4-parser" style="display:none">Info about the 'IPv4 parser' definition.</span><b><a href="#concept-ipv4-parser">#concept-ipv4-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv4-parser">3.5. Host parsing</a> <a href="#ref-for-concept-ipv4-parser①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="ipv4-number-parser">
-   <b><a href="#ipv4-number-parser">#ipv4-number-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-ipv4-number-parser" class="dfn-panel" data-for="ipv4-number-parser" id="infopanel-for-ipv4-number-parser" role="dialog">
+   <span id="infopaneltitle-for-ipv4-number-parser" style="display:none">Info about the 'IPv4 number parser' definition.</span><b><a href="#ipv4-number-parser">#ipv4-number-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ipv4-number-parser">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv6-parser">
-   <b><a href="#concept-ipv6-parser">#concept-ipv6-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv6-parser" class="dfn-panel" data-for="concept-ipv6-parser" id="infopanel-for-concept-ipv6-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv6-parser" style="display:none">Info about the 'IPv6 parser' definition.</span><b><a href="#concept-ipv6-parser">#concept-ipv6-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6-parser">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-opaque-host-parser">
-   <b><a href="#concept-opaque-host-parser">#concept-opaque-host-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-opaque-host-parser" class="dfn-panel" data-for="concept-opaque-host-parser" id="infopanel-for-concept-opaque-host-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-opaque-host-parser" style="display:none">Info about the 'opaque-host parser' definition.</span><b><a href="#concept-opaque-host-parser">#concept-opaque-host-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-opaque-host-parser">3.5. Host parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-host-serializer">
-   <b><a href="#concept-host-serializer">#concept-host-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-host-serializer" class="dfn-panel" data-for="concept-host-serializer" id="infopanel-for-concept-host-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-host-serializer" style="display:none">Info about the 'host serializer' definition.</span><b><a href="#concept-host-serializer">#concept-host-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-host-serializer">3. Hosts (domains and IP addresses)</a> <a href="#ref-for-concept-host-serializer①">(2)</a> <a href="#ref-for-concept-host-serializer②">(3)</a>
     <li><a href="#ref-for-concept-host-serializer③">4.5. URL serializing</a>
     <li><a href="#ref-for-concept-host-serializer④">6.1. URL class</a> <a href="#ref-for-concept-host-serializer⑤">(2)</a> <a href="#ref-for-concept-host-serializer⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv4-serializer">
-   <b><a href="#concept-ipv4-serializer">#concept-ipv4-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv4-serializer" class="dfn-panel" data-for="concept-ipv4-serializer" id="infopanel-for-concept-ipv4-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv4-serializer" style="display:none">Info about the 'IPv4 serializer' definition.</span><b><a href="#concept-ipv4-serializer">#concept-ipv4-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv4-serializer">3.6. Host serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-ipv6-serializer">
-   <b><a href="#concept-ipv6-serializer">#concept-ipv6-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-ipv6-serializer" class="dfn-panel" data-for="concept-ipv6-serializer" id="infopanel-for-concept-ipv6-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-ipv6-serializer" style="display:none">Info about the 'IPv6 serializer' definition.</span><b><a href="#concept-ipv6-serializer">#concept-ipv6-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-ipv6-serializer">3.6. Host serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-host-equals">
-   <b><a href="#concept-host-equals">#concept-host-equals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-host-equals" class="dfn-panel" data-for="concept-host-equals" id="infopanel-for-concept-host-equals" role="dialog">
+   <span id="infopaneltitle-for-concept-host-equals" style="display:none">Info about the 'equals' definition.</span><b><a href="#concept-host-equals">#concept-host-equals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-host-equals">3. Hosts (domains and IP addresses)</a>
     <li><a href="#ref-for-concept-host-equals①">3.2. Host miscellaneous</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url">
-   <b><a href="#concept-url">#concept-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url" class="dfn-panel" data-for="concept-url" id="infopanel-for-concept-url" role="dialog">
+   <span id="infopaneltitle-for-concept-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-url">#concept-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-concept-url①">2. Security considerations</a> <a href="#ref-for-concept-url②">(2)</a> <a href="#ref-for-concept-url③">(3)</a> <a href="#ref-for-concept-url④">(4)</a> <a href="#ref-for-concept-url⑤">(5)</a> <a href="#ref-for-concept-url⑥">(6)</a>
@@ -4556,8 +4556,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url⑦①">Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-scheme">
-   <b><a href="#concept-url-scheme">#concept-url-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-scheme" class="dfn-panel" data-for="concept-url-scheme" id="infopanel-for-concept-url-scheme" role="dialog">
+   <span id="infopaneltitle-for-concept-url-scheme" style="display:none">Info about the 'scheme' definition.</span><b><a href="#concept-url-scheme">#concept-url-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-scheme">4.1. URL representation</a> <a href="#ref-for-concept-url-scheme①">(2)</a> <a href="#ref-for-concept-url-scheme②">(3)</a>
     <li><a href="#ref-for-concept-url-scheme③">4.2. URL miscellaneous</a> <a href="#ref-for-concept-url-scheme④">(2)</a> <a href="#ref-for-concept-url-scheme⑤">(3)</a> <a href="#ref-for-concept-url-scheme⑥">(4)</a> <a href="#ref-for-concept-url-scheme⑦">(5)</a> <a href="#ref-for-concept-url-scheme⑧">(6)</a>
@@ -4569,8 +4569,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-scheme③⑤">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-username">
-   <b><a href="#concept-url-username">#concept-url-username</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-username" class="dfn-panel" data-for="concept-url-username" id="infopanel-for-concept-url-username" role="dialog">
+   <span id="infopaneltitle-for-concept-url-username" style="display:none">Info about the 'username' definition.</span><b><a href="#concept-url-username">#concept-url-username</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-username">4.1. URL representation</a>
     <li><a href="#ref-for-concept-url-username①">4.2. URL miscellaneous</a>
@@ -4581,8 +4581,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-username①①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-password">
-   <b><a href="#concept-url-password">#concept-url-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-password" class="dfn-panel" data-for="concept-url-password" id="infopanel-for-concept-url-password" role="dialog">
+   <span id="infopaneltitle-for-concept-url-password" style="display:none">Info about the 'password' definition.</span><b><a href="#concept-url-password">#concept-url-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-password">4.1. URL representation</a>
     <li><a href="#ref-for-concept-url-password①">4.2. URL miscellaneous</a>
@@ -4593,8 +4593,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-password①②">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-host">
-   <b><a href="#concept-url-host">#concept-url-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-host" class="dfn-panel" data-for="concept-url-host" id="infopanel-for-concept-url-host" role="dialog">
+   <span id="infopaneltitle-for-concept-url-host" style="display:none">Info about the 'host' definition.</span><b><a href="#concept-url-host">#concept-url-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">4.1. URL representation</a> <a href="#ref-for-concept-url-host①">(2)</a> <a href="#ref-for-concept-url-host②">(3)</a>
     <li><a href="#ref-for-concept-url-host③">4.2. URL miscellaneous</a>
@@ -4608,8 +4608,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-host②⑨">6.1. URL class</a> <a href="#ref-for-concept-url-host③⓪">(2)</a> <a href="#ref-for-concept-url-host③①">(3)</a> <a href="#ref-for-concept-url-host③②">(4)</a> <a href="#ref-for-concept-url-host③③">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-port">
-   <b><a href="#concept-url-port">#concept-url-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-port" class="dfn-panel" data-for="concept-url-port" id="infopanel-for-concept-url-port" role="dialog">
+   <span id="infopaneltitle-for-concept-url-port" style="display:none">Info about the 'port' definition.</span><b><a href="#concept-url-port">#concept-url-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-port">4.1. URL representation</a>
     <li><a href="#ref-for-concept-url-port①">4.2. URL miscellaneous</a> <a href="#ref-for-concept-url-port②">(2)</a>
@@ -4619,8 +4619,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-port①⑤">6.1. URL class</a> <a href="#ref-for-concept-url-port①⑥">(2)</a> <a href="#ref-for-concept-url-port①⑦">(3)</a> <a href="#ref-for-concept-url-port①⑧">(4)</a> <a href="#ref-for-concept-url-port①⑨">(5)</a> <a href="#ref-for-concept-url-port②⓪">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-path">
-   <b><a href="#concept-url-path">#concept-url-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-path" class="dfn-panel" data-for="concept-url-path" id="infopanel-for-concept-url-path" role="dialog">
+   <span id="infopaneltitle-for-concept-url-path" style="display:none">Info about the 'path' definition.</span><b><a href="#concept-url-path">#concept-url-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-path">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-concept-url-path①">4.1. URL representation</a> <a href="#ref-for-concept-url-path②">(2)</a>
@@ -4632,8 +4632,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-path②⑨">6.1. URL class</a> <a href="#ref-for-concept-url-path③⓪">(2)</a> <a href="#ref-for-concept-url-path③①">(3)</a> <a href="#ref-for-concept-url-path③②">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-query">
-   <b><a href="#concept-url-query">#concept-url-query</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-query" class="dfn-panel" data-for="concept-url-query" id="infopanel-for-concept-url-query" role="dialog">
+   <span id="infopaneltitle-for-concept-url-query" style="display:none">Info about the 'query' definition.</span><b><a href="#concept-url-query">#concept-url-query</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-concept-url-query①">4.1. URL representation</a>
@@ -4644,8 +4644,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-query②⑤">6.2. URLSearchParams class</a> <a href="#ref-for-concept-url-query②⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-fragment">
-   <b><a href="#concept-url-fragment">#concept-url-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-fragment" class="dfn-panel" data-for="concept-url-fragment" id="infopanel-for-concept-url-fragment" role="dialog">
+   <span id="infopaneltitle-for-concept-url-fragment" style="display:none">Info about the 'fragment' definition.</span><b><a href="#concept-url-fragment">#concept-url-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-fragment">1.3. Percent-encoded bytes</a>
     <li><a href="#ref-for-concept-url-fragment①">4.1. URL representation</a>
@@ -4654,8 +4654,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-fragment①②">6.1. URL class</a> <a href="#ref-for-concept-url-fragment①③">(2)</a> <a href="#ref-for-concept-url-fragment①④">(3)</a> <a href="#ref-for-concept-url-fragment①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-cannot-be-a-base-url-flag">
-   <b><a href="#url-cannot-be-a-base-url-flag">#url-cannot-be-a-base-url-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-cannot-be-a-base-url-flag" class="dfn-panel" data-for="url-cannot-be-a-base-url-flag" id="infopanel-for-url-cannot-be-a-base-url-flag" role="dialog">
+   <span id="infopaneltitle-for-url-cannot-be-a-base-url-flag" style="display:none">Info about the 'cannot-be-a-base-URL' definition.</span><b><a href="#url-cannot-be-a-base-url-flag">#url-cannot-be-a-base-url-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-cannot-be-a-base-url-flag">4.1. URL representation</a>
     <li><a href="#ref-for-url-cannot-be-a-base-url-flag①">4.2. URL miscellaneous</a>
@@ -4664,16 +4664,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-url-cannot-be-a-base-url-flag⑧">6.1. URL class</a> <a href="#ref-for-url-cannot-be-a-base-url-flag⑨">(2)</a> <a href="#ref-for-url-cannot-be-a-base-url-flag①⓪">(3)</a> <a href="#ref-for-url-cannot-be-a-base-url-flag①①">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-blob-entry">
-   <b><a href="#concept-url-blob-entry">#concept-url-blob-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-blob-entry" class="dfn-panel" data-for="concept-url-blob-entry" id="infopanel-for-concept-url-blob-entry" role="dialog">
+   <span id="infopaneltitle-for-concept-url-blob-entry" style="display:none">Info about the 'blob URL entry' definition.</span><b><a href="#concept-url-blob-entry">#concept-url-blob-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-blob-entry">4.1. URL representation</a>
     <li><a href="#ref-for-concept-url-blob-entry①">4.4. URL parsing</a>
     <li><a href="#ref-for-concept-url-blob-entry②">4.7. Origin</a> <a href="#ref-for-concept-url-blob-entry③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="special-scheme">
-   <b><a href="#special-scheme">#special-scheme</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-special-scheme" class="dfn-panel" data-for="special-scheme" id="infopanel-for-special-scheme" role="dialog">
+   <span id="infopaneltitle-for-special-scheme" style="display:none">Info about the 'special scheme' definition.</span><b><a href="#special-scheme">#special-scheme</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-scheme">4.1. URL representation</a>
     <li><a href="#ref-for-special-scheme①">4.2. URL miscellaneous</a> <a href="#ref-for-special-scheme②">(2)</a> <a href="#ref-for-special-scheme③">(3)</a>
@@ -4681,41 +4681,41 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-special-scheme⑦">4.4. URL parsing</a> <a href="#ref-for-special-scheme⑧">(2)</a> <a href="#ref-for-special-scheme⑨">(3)</a> <a href="#ref-for-special-scheme①⓪">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="default-port">
-   <b><a href="#default-port">#default-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-default-port" class="dfn-panel" data-for="default-port" id="infopanel-for-default-port" role="dialog">
+   <span id="infopaneltitle-for-default-port" style="display:none">Info about the 'default port' definition.</span><b><a href="#default-port">#default-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-default-port">4.4. URL parsing</a> <a href="#ref-for-default-port①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-special">
-   <b><a href="#is-special">#is-special</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-special" class="dfn-panel" data-for="is-special" id="infopanel-for-is-special" role="dialog">
+   <span id="infopaneltitle-for-is-special" style="display:none">Info about the 'is special' definition.</span><b><a href="#is-special">#is-special</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-special">4.1. URL representation</a>
     <li><a href="#ref-for-is-special①">4.4. URL parsing</a> <a href="#ref-for-is-special②">(2)</a> <a href="#ref-for-is-special③">(3)</a> <a href="#ref-for-is-special④">(4)</a> <a href="#ref-for-is-special⑤">(5)</a> <a href="#ref-for-is-special⑥">(6)</a> <a href="#ref-for-is-special⑦">(7)</a> <a href="#ref-for-is-special⑧">(8)</a> <a href="#ref-for-is-special⑨">(9)</a> <a href="#ref-for-is-special①⓪">(10)</a> <a href="#ref-for-is-special①①">(11)</a> <a href="#ref-for-is-special①②">(12)</a> <a href="#ref-for-is-special①③">(13)</a> <a href="#ref-for-is-special①④">(14)</a>
     <li><a href="#ref-for-is-special①⑤">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="is-not-special">
-   <b><a href="#is-not-special">#is-not-special</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-is-not-special" class="dfn-panel" data-for="is-not-special" id="infopanel-for-is-not-special" role="dialog">
+   <span id="infopaneltitle-for-is-not-special" style="display:none">Info about the 'is not special' definition.</span><b><a href="#is-not-special">#is-not-special</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-is-not-special">4.4. URL parsing</a> <a href="#ref-for-is-not-special①">(2)</a> <a href="#ref-for-is-not-special②">(3)</a> <a href="#ref-for-is-not-special③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="include-credentials">
-   <b><a href="#include-credentials">#include-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-include-credentials" class="dfn-panel" data-for="include-credentials" id="infopanel-for-include-credentials" role="dialog">
+   <span id="infopaneltitle-for-include-credentials" style="display:none">Info about the 'includes credentials' definition.</span><b><a href="#include-credentials">#include-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include-credentials">4.4. URL parsing</a> <a href="#ref-for-include-credentials①">(2)</a>
     <li><a href="#ref-for-include-credentials②">4.5. URL serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cannot-have-a-username-password-port">
-   <b><a href="#cannot-have-a-username-password-port">#cannot-have-a-username-password-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cannot-have-a-username-password-port" class="dfn-panel" data-for="cannot-have-a-username-password-port" id="infopanel-for-cannot-have-a-username-password-port" role="dialog">
+   <span id="infopaneltitle-for-cannot-have-a-username-password-port" style="display:none">Info about the 'cannot have a username/password/port' definition.</span><b><a href="#cannot-have-a-username-password-port">#cannot-have-a-username-password-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cannot-have-a-username-password-port">6.1. URL class</a> <a href="#ref-for-cannot-have-a-username-password-port①">(2)</a> <a href="#ref-for-cannot-have-a-username-password-port②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-base-url">
-   <b><a href="#concept-base-url">#concept-base-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-base-url" class="dfn-panel" data-for="concept-base-url" id="infopanel-for-concept-base-url" role="dialog">
+   <span id="infopaneltitle-for-concept-base-url" style="display:none">Info about the 'base URL' definition.</span><b><a href="#concept-base-url">#concept-base-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-base-url">4.2. URL miscellaneous</a>
     <li><a href="#ref-for-concept-base-url①">4.3. URL writing</a> <a href="#ref-for-concept-base-url②">(2)</a> <a href="#ref-for-concept-base-url③">(3)</a> <a href="#ref-for-concept-base-url④">(4)</a>
@@ -4723,178 +4723,178 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-base-url⑦">6.1. URL class</a> <a href="#ref-for-concept-base-url⑧">(2)</a> <a href="#ref-for-concept-base-url⑨">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="windows-drive-letter">
-   <b><a href="#windows-drive-letter">#windows-drive-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-windows-drive-letter" class="dfn-panel" data-for="windows-drive-letter" id="infopanel-for-windows-drive-letter" role="dialog">
+   <span id="infopaneltitle-for-windows-drive-letter" style="display:none">Info about the 'Windows drive letter' definition.</span><b><a href="#windows-drive-letter">#windows-drive-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-windows-drive-letter">4.2. URL miscellaneous</a> <a href="#ref-for-windows-drive-letter①">(2)</a>
     <li><a href="#ref-for-windows-drive-letter②">4.3. URL writing</a>
     <li><a href="#ref-for-windows-drive-letter③">4.4. URL parsing</a> <a href="#ref-for-windows-drive-letter④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="normalized-windows-drive-letter">
-   <b><a href="#normalized-windows-drive-letter">#normalized-windows-drive-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-normalized-windows-drive-letter" class="dfn-panel" data-for="normalized-windows-drive-letter" id="infopanel-for-normalized-windows-drive-letter" role="dialog">
+   <span id="infopaneltitle-for-normalized-windows-drive-letter" style="display:none">Info about the 'normalized Windows drive letter' definition.</span><b><a href="#normalized-windows-drive-letter">#normalized-windows-drive-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-normalized-windows-drive-letter">4.2. URL miscellaneous</a> <a href="#ref-for-normalized-windows-drive-letter①">(2)</a>
     <li><a href="#ref-for-normalized-windows-drive-letter②">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="start-with-a-windows-drive-letter">
-   <b><a href="#start-with-a-windows-drive-letter">#start-with-a-windows-drive-letter</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-start-with-a-windows-drive-letter" class="dfn-panel" data-for="start-with-a-windows-drive-letter" id="infopanel-for-start-with-a-windows-drive-letter" role="dialog">
+   <span id="infopaneltitle-for-start-with-a-windows-drive-letter" style="display:none">Info about the 'starts with a Windows drive letter' definition.</span><b><a href="#start-with-a-windows-drive-letter">#start-with-a-windows-drive-letter</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-start-with-a-windows-drive-letter">4.4. URL parsing</a> <a href="#ref-for-start-with-a-windows-drive-letter①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="shorten-a-urls-path">
-   <b><a href="#shorten-a-urls-path">#shorten-a-urls-path</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-shorten-a-urls-path" class="dfn-panel" data-for="shorten-a-urls-path" id="infopanel-for-shorten-a-urls-path" role="dialog">
+   <span id="infopaneltitle-for-shorten-a-urls-path" style="display:none">Info about the 'shorten a url’s path' definition.</span><b><a href="#shorten-a-urls-path">#shorten-a-urls-path</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-shorten-a-urls-path">4.4. URL parsing</a> <a href="#ref-for-shorten-a-urls-path①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valid-url-string">
-   <b><a href="#valid-url-string">#valid-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valid-url-string" class="dfn-panel" data-for="valid-url-string" id="infopanel-for-valid-url-string" role="dialog">
+   <span id="infopaneltitle-for-valid-url-string" style="display:none">Info about the 'valid URL string' definition.</span><b><a href="#valid-url-string">#valid-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valid-url-string">4. URLs</a> <a href="#ref-for-valid-url-string①">(2)</a>
     <li><a href="#ref-for-valid-url-string②">4.1. URL representation</a> <a href="#ref-for-valid-url-string③">(2)</a>
     <li><a href="#ref-for-valid-url-string④">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-url-with-fragment-string">
-   <b><a href="#absolute-url-with-fragment-string">#absolute-url-with-fragment-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-url-with-fragment-string" class="dfn-panel" data-for="absolute-url-with-fragment-string" id="infopanel-for-absolute-url-with-fragment-string" role="dialog">
+   <span id="infopaneltitle-for-absolute-url-with-fragment-string" style="display:none">Info about the 'absolute-URL-with-fragment string' definition.</span><b><a href="#absolute-url-with-fragment-string">#absolute-url-with-fragment-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-with-fragment-string">4.3. URL writing</a>
     <li><a href="#ref-for-absolute-url-with-fragment-string①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="absolute-url-string">
-   <b><a href="#absolute-url-string">#absolute-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-absolute-url-string" class="dfn-panel" data-for="absolute-url-string" id="infopanel-for-absolute-url-string" role="dialog">
+   <span id="infopaneltitle-for-absolute-url-string" style="display:none">Info about the 'absolute-URL string' definition.</span><b><a href="#absolute-url-string">#absolute-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-absolute-url-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-scheme-string">
-   <b><a href="#url-scheme-string">#url-scheme-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-scheme-string" class="dfn-panel" data-for="url-scheme-string" id="infopanel-for-url-scheme-string" role="dialog">
+   <span id="infopaneltitle-for-url-scheme-string" style="display:none">Info about the 'URL-scheme string' definition.</span><b><a href="#url-scheme-string">#url-scheme-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-scheme-string">4.3. URL writing</a> <a href="#ref-for-url-scheme-string①">(2)</a> <a href="#ref-for-url-scheme-string②">(3)</a> <a href="#ref-for-url-scheme-string③">(4)</a> <a href="#ref-for-url-scheme-string④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-url-with-fragment-string">
-   <b><a href="#relative-url-with-fragment-string">#relative-url-with-fragment-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-url-with-fragment-string" class="dfn-panel" data-for="relative-url-with-fragment-string" id="infopanel-for-relative-url-with-fragment-string" role="dialog">
+   <span id="infopaneltitle-for-relative-url-with-fragment-string" style="display:none">Info about the 'relative-URL-with-fragment string' definition.</span><b><a href="#relative-url-with-fragment-string">#relative-url-with-fragment-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-url-with-fragment-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-url-string">
-   <b><a href="#relative-url-string">#relative-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-url-string" class="dfn-panel" data-for="relative-url-string" id="infopanel-for-relative-url-string" role="dialog">
+   <span id="infopaneltitle-for-relative-url-string" style="display:none">Info about the 'relative-URL string' definition.</span><b><a href="#relative-url-string">#relative-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-url-string">4.2. URL miscellaneous</a>
     <li><a href="#ref-for-relative-url-string①">4.3. URL writing</a> <a href="#ref-for-relative-url-string②">(2)</a> <a href="#ref-for-relative-url-string③">(3)</a>
     <li><a href="#ref-for-relative-url-string④">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-relative-special-url-string">
-   <b><a href="#scheme-relative-special-url-string">#scheme-relative-special-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-relative-special-url-string" class="dfn-panel" data-for="scheme-relative-special-url-string" id="infopanel-for-scheme-relative-special-url-string" role="dialog">
+   <span id="infopaneltitle-for-scheme-relative-special-url-string" style="display:none">Info about the 'scheme-relative-special-URL string' definition.</span><b><a href="#scheme-relative-special-url-string">#scheme-relative-special-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-relative-special-url-string">4.3. URL writing</a> <a href="#ref-for-scheme-relative-special-url-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-port-string">
-   <b><a href="#url-port-string">#url-port-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-port-string" class="dfn-panel" data-for="url-port-string" id="infopanel-for-url-port-string" role="dialog">
+   <span id="infopaneltitle-for-url-port-string" style="display:none">Info about the 'URL-port string' definition.</span><b><a href="#url-port-string">#url-port-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-port-string">4.3. URL writing</a> <a href="#ref-for-url-port-string①">(2)</a>
     <li><a href="#ref-for-url-port-string②">6.1. URL class</a> <a href="#ref-for-url-port-string③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-relative-url-string">
-   <b><a href="#scheme-relative-url-string">#scheme-relative-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-relative-url-string" class="dfn-panel" data-for="scheme-relative-url-string" id="infopanel-for-scheme-relative-url-string" role="dialog">
+   <span id="infopaneltitle-for-scheme-relative-url-string" style="display:none">Info about the 'scheme-relative-URL string' definition.</span><b><a href="#scheme-relative-url-string">#scheme-relative-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-relative-url-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="opaque-host-and-port-string">
-   <b><a href="#opaque-host-and-port-string">#opaque-host-and-port-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-opaque-host-and-port-string" class="dfn-panel" data-for="opaque-host-and-port-string" id="infopanel-for-opaque-host-and-port-string" role="dialog">
+   <span id="infopaneltitle-for-opaque-host-and-port-string" style="display:none">Info about the 'opaque-host-and-port string' definition.</span><b><a href="#opaque-host-and-port-string">#opaque-host-and-port-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-opaque-host-and-port-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-relative-file-url-string">
-   <b><a href="#scheme-relative-file-url-string">#scheme-relative-file-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-relative-file-url-string" class="dfn-panel" data-for="scheme-relative-file-url-string" id="infopanel-for-scheme-relative-file-url-string" role="dialog">
+   <span id="infopaneltitle-for-scheme-relative-file-url-string" style="display:none">Info about the 'scheme-relative-file-URL string' definition.</span><b><a href="#scheme-relative-file-url-string">#scheme-relative-file-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-relative-file-url-string">4.3. URL writing</a> <a href="#ref-for-scheme-relative-file-url-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-absolute-url-string">
-   <b><a href="#path-absolute-url-string">#path-absolute-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-absolute-url-string" class="dfn-panel" data-for="path-absolute-url-string" id="infopanel-for-path-absolute-url-string" role="dialog">
+   <span id="infopaneltitle-for-path-absolute-url-string" style="display:none">Info about the 'path-absolute-URL string' definition.</span><b><a href="#path-absolute-url-string">#path-absolute-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-absolute-url-string">4.3. URL writing</a> <a href="#ref-for-path-absolute-url-string①">(2)</a> <a href="#ref-for-path-absolute-url-string②">(3)</a> <a href="#ref-for-path-absolute-url-string③">(4)</a> <a href="#ref-for-path-absolute-url-string④">(5)</a> <a href="#ref-for-path-absolute-url-string⑤">(6)</a> <a href="#ref-for-path-absolute-url-string⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-absolute-non-windows-file-url-string">
-   <b><a href="#path-absolute-non-windows-file-url-string">#path-absolute-non-windows-file-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-absolute-non-windows-file-url-string" class="dfn-panel" data-for="path-absolute-non-windows-file-url-string" id="infopanel-for-path-absolute-non-windows-file-url-string" role="dialog">
+   <span id="infopaneltitle-for-path-absolute-non-windows-file-url-string" style="display:none">Info about the 'path-absolute-non-Windows-file-URL string' definition.</span><b><a href="#path-absolute-non-windows-file-url-string">#path-absolute-non-windows-file-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-absolute-non-windows-file-url-string">4.3. URL writing</a> <a href="#ref-for-path-absolute-non-windows-file-url-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-relative-url-string">
-   <b><a href="#path-relative-url-string">#path-relative-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-relative-url-string" class="dfn-panel" data-for="path-relative-url-string" id="infopanel-for-path-relative-url-string" role="dialog">
+   <span id="infopaneltitle-for-path-relative-url-string" style="display:none">Info about the 'path-relative-URL string' definition.</span><b><a href="#path-relative-url-string">#path-relative-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-relative-url-string">4.3. URL writing</a> <a href="#ref-for-path-relative-url-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-relative-scheme-less-url-string">
-   <b><a href="#path-relative-scheme-less-url-string">#path-relative-scheme-less-url-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-relative-scheme-less-url-string" class="dfn-panel" data-for="path-relative-scheme-less-url-string" id="infopanel-for-path-relative-scheme-less-url-string" role="dialog">
+   <span id="infopaneltitle-for-path-relative-scheme-less-url-string" style="display:none">Info about the 'path-relative-scheme-less-URL string' definition.</span><b><a href="#path-relative-scheme-less-url-string">#path-relative-scheme-less-url-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-relative-scheme-less-url-string">4.3. URL writing</a> <a href="#ref-for-path-relative-scheme-less-url-string①">(2)</a> <a href="#ref-for-path-relative-scheme-less-url-string②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-path-segment-string">
-   <b><a href="#url-path-segment-string">#url-path-segment-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-path-segment-string" class="dfn-panel" data-for="url-path-segment-string" id="infopanel-for-url-path-segment-string" role="dialog">
+   <span id="infopaneltitle-for-url-path-segment-string" style="display:none">Info about the 'URL-path-segment string' definition.</span><b><a href="#url-path-segment-string">#url-path-segment-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-path-segment-string">4.3. URL writing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="single-dot-path-segment">
-   <b><a href="#single-dot-path-segment">#single-dot-path-segment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-single-dot-path-segment" class="dfn-panel" data-for="single-dot-path-segment" id="infopanel-for-single-dot-path-segment" role="dialog">
+   <span id="infopaneltitle-for-single-dot-path-segment" style="display:none">Info about the 'single-dot path segment' definition.</span><b><a href="#single-dot-path-segment">#single-dot-path-segment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-single-dot-path-segment">4.3. URL writing</a> <a href="#ref-for-single-dot-path-segment①">(2)</a>
     <li><a href="#ref-for-single-dot-path-segment②">4.4. URL parsing</a> <a href="#ref-for-single-dot-path-segment③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="double-dot-path-segment">
-   <b><a href="#double-dot-path-segment">#double-dot-path-segment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-double-dot-path-segment" class="dfn-panel" data-for="double-dot-path-segment" id="infopanel-for-double-dot-path-segment" role="dialog">
+   <span id="infopaneltitle-for-double-dot-path-segment" style="display:none">Info about the 'double-dot path segment' definition.</span><b><a href="#double-dot-path-segment">#double-dot-path-segment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-double-dot-path-segment">4.3. URL writing</a> <a href="#ref-for-double-dot-path-segment①">(2)</a>
     <li><a href="#ref-for-double-dot-path-segment②">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-query-string">
-   <b><a href="#url-query-string">#url-query-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-query-string" class="dfn-panel" data-for="url-query-string" id="infopanel-for-url-query-string" role="dialog">
+   <span id="infopaneltitle-for-url-query-string" style="display:none">Info about the 'URL-query string' definition.</span><b><a href="#url-query-string">#url-query-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-query-string">4.3. URL writing</a> <a href="#ref-for-url-query-string①">(2)</a> <a href="#ref-for-url-query-string②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-fragment-string">
-   <b><a href="#url-fragment-string">#url-fragment-string</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-fragment-string" class="dfn-panel" data-for="url-fragment-string" id="infopanel-for-url-fragment-string" role="dialog">
+   <span id="infopaneltitle-for-url-fragment-string" style="display:none">Info about the 'URL-fragment string' definition.</span><b><a href="#url-fragment-string">#url-fragment-string</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-fragment-string">4.3. URL writing</a> <a href="#ref-for-url-fragment-string①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-code-points">
-   <b><a href="#url-code-points">#url-code-points</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-code-points" class="dfn-panel" data-for="url-code-points" id="infopanel-for-url-code-points" role="dialog">
+   <span id="infopaneltitle-for-url-code-points" style="display:none">Info about the 'URL code points' definition.</span><b><a href="#url-code-points">#url-code-points</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-code-points">3.5. Host parsing</a>
     <li><a href="#ref-for-url-code-points①">4.3. URL writing</a> <a href="#ref-for-url-code-points②">(2)</a>
     <li><a href="#ref-for-url-code-points③">4.4. URL parsing</a> <a href="#ref-for-url-code-points④">(2)</a> <a href="#ref-for-url-code-points⑤">(3)</a> <a href="#ref-for-url-code-points⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-units">
-   <b><a href="#url-units">#url-units</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-units" class="dfn-panel" data-for="url-units" id="infopanel-for-url-units" role="dialog">
+   <span id="infopaneltitle-for-url-units" style="display:none">Info about the 'URL units' definition.</span><b><a href="#url-units">#url-units</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-units">3.4. Host writing</a>
     <li><a href="#ref-for-url-units①">4.3. URL writing</a> <a href="#ref-for-url-units②">(2)</a> <a href="#ref-for-url-units③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-parser">
-   <b><a href="#concept-url-parser">#concept-url-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-parser" class="dfn-panel" data-for="concept-url-parser" id="infopanel-for-concept-url-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-url-parser" style="display:none">Info about the 'URL parser' definition.</span><b><a href="#concept-url-parser">#concept-url-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">4. URLs</a> <a href="#ref-for-concept-url-parser①">(2)</a> <a href="#ref-for-concept-url-parser②">(3)</a> <a href="#ref-for-concept-url-parser③">(4)</a>
     <li><a href="#ref-for-concept-url-parser④">4.1. URL representation</a> <a href="#ref-for-concept-url-parser⑤">(2)</a>
@@ -4903,173 +4903,173 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-parser⑨">4.5. URL serializing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-basic-url-parser">
-   <b><a href="#concept-basic-url-parser">#concept-basic-url-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-basic-url-parser" class="dfn-panel" data-for="concept-basic-url-parser" id="infopanel-for-concept-basic-url-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-basic-url-parser" style="display:none">Info about the 'basic URL parser' definition.</span><b><a href="#concept-basic-url-parser">#concept-basic-url-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-basic-url-parser">4.4. URL parsing</a> <a href="#ref-for-concept-basic-url-parser①">(2)</a> <a href="#ref-for-concept-basic-url-parser②">(3)</a>
     <li><a href="#ref-for-concept-basic-url-parser③">4.7. Origin</a>
     <li><a href="#ref-for-concept-basic-url-parser④">6.1. URL class</a> <a href="#ref-for-concept-basic-url-parser⑤">(2)</a> <a href="#ref-for-concept-basic-url-parser⑥">(3)</a> <a href="#ref-for-concept-basic-url-parser⑦">(4)</a> <a href="#ref-for-concept-basic-url-parser⑧">(5)</a> <a href="#ref-for-concept-basic-url-parser⑨">(6)</a> <a href="#ref-for-concept-basic-url-parser①⓪">(7)</a> <a href="#ref-for-concept-basic-url-parser①①">(8)</a> <a href="#ref-for-concept-basic-url-parser①②">(9)</a> <a href="#ref-for-concept-basic-url-parser①③">(10)</a> <a href="#ref-for-concept-basic-url-parser①④">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="basic-url-parser-url">
-   <b><a href="#basic-url-parser-url">#basic-url-parser-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-basic-url-parser-url" class="dfn-panel" data-for="basic-url-parser-url" id="infopanel-for-basic-url-parser-url" role="dialog">
+   <span id="infopaneltitle-for-basic-url-parser-url" style="display:none">Info about the 'url' definition.</span><b><a href="#basic-url-parser-url">#basic-url-parser-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-url-parser-url">6.1. URL class</a> <a href="#ref-for-basic-url-parser-url①">(2)</a> <a href="#ref-for-basic-url-parser-url②">(3)</a> <a href="#ref-for-basic-url-parser-url③">(4)</a> <a href="#ref-for-basic-url-parser-url④">(5)</a> <a href="#ref-for-basic-url-parser-url⑤">(6)</a> <a href="#ref-for-basic-url-parser-url⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="basic-url-parser-state-override">
-   <b><a href="#basic-url-parser-state-override">#basic-url-parser-state-override</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-basic-url-parser-state-override" class="dfn-panel" data-for="basic-url-parser-state-override" id="infopanel-for-basic-url-parser-state-override" role="dialog">
+   <span id="infopaneltitle-for-basic-url-parser-state-override" style="display:none">Info about the 'state override' definition.</span><b><a href="#basic-url-parser-state-override">#basic-url-parser-state-override</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-basic-url-parser-state-override">6.1. URL class</a> <a href="#ref-for-basic-url-parser-state-override①">(2)</a> <a href="#ref-for-basic-url-parser-state-override②">(3)</a> <a href="#ref-for-basic-url-parser-state-override③">(4)</a> <a href="#ref-for-basic-url-parser-state-override④">(5)</a> <a href="#ref-for-basic-url-parser-state-override⑤">(6)</a> <a href="#ref-for-basic-url-parser-state-override⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-start-state">
-   <b><a href="#scheme-start-state">#scheme-start-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-start-state" class="dfn-panel" data-for="scheme-start-state" id="infopanel-for-scheme-start-state" role="dialog">
+   <span id="infopaneltitle-for-scheme-start-state" style="display:none">Info about the 'scheme start state' definition.</span><b><a href="#scheme-start-state">#scheme-start-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-start-state">4.4. URL parsing</a>
     <li><a href="#ref-for-scheme-start-state①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="scheme-state">
-   <b><a href="#scheme-state">#scheme-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-scheme-state" class="dfn-panel" data-for="scheme-state" id="infopanel-for-scheme-state" role="dialog">
+   <span id="infopaneltitle-for-scheme-state" style="display:none">Info about the 'scheme state' definition.</span><b><a href="#scheme-state">#scheme-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-scheme-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="no-scheme-state">
-   <b><a href="#no-scheme-state">#no-scheme-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-no-scheme-state" class="dfn-panel" data-for="no-scheme-state" id="infopanel-for-no-scheme-state" role="dialog">
+   <span id="infopaneltitle-for-no-scheme-state" style="display:none">Info about the 'no scheme state' definition.</span><b><a href="#no-scheme-state">#no-scheme-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-no-scheme-state">4.4. URL parsing</a> <a href="#ref-for-no-scheme-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="special-relative-or-authority-state">
-   <b><a href="#special-relative-or-authority-state">#special-relative-or-authority-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-special-relative-or-authority-state" class="dfn-panel" data-for="special-relative-or-authority-state" id="infopanel-for-special-relative-or-authority-state" role="dialog">
+   <span id="infopaneltitle-for-special-relative-or-authority-state" style="display:none">Info about the 'special relative or authority state' definition.</span><b><a href="#special-relative-or-authority-state">#special-relative-or-authority-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-relative-or-authority-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-or-authority-state">
-   <b><a href="#path-or-authority-state">#path-or-authority-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-or-authority-state" class="dfn-panel" data-for="path-or-authority-state" id="infopanel-for-path-or-authority-state" role="dialog">
+   <span id="infopaneltitle-for-path-or-authority-state" style="display:none">Info about the 'path or authority state' definition.</span><b><a href="#path-or-authority-state">#path-or-authority-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-or-authority-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-state">
-   <b><a href="#relative-state">#relative-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-state" class="dfn-panel" data-for="relative-state" id="infopanel-for-relative-state" role="dialog">
+   <span id="infopaneltitle-for-relative-state" style="display:none">Info about the 'relative state' definition.</span><b><a href="#relative-state">#relative-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-state">4.4. URL parsing</a> <a href="#ref-for-relative-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="relative-slash-state">
-   <b><a href="#relative-slash-state">#relative-slash-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-relative-slash-state" class="dfn-panel" data-for="relative-slash-state" id="infopanel-for-relative-slash-state" role="dialog">
+   <span id="infopaneltitle-for-relative-slash-state" style="display:none">Info about the 'relative slash state' definition.</span><b><a href="#relative-slash-state">#relative-slash-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relative-slash-state">4.4. URL parsing</a> <a href="#ref-for-relative-slash-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="special-authority-slashes-state">
-   <b><a href="#special-authority-slashes-state">#special-authority-slashes-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-special-authority-slashes-state" class="dfn-panel" data-for="special-authority-slashes-state" id="infopanel-for-special-authority-slashes-state" role="dialog">
+   <span id="infopaneltitle-for-special-authority-slashes-state" style="display:none">Info about the 'special authority slashes state' definition.</span><b><a href="#special-authority-slashes-state">#special-authority-slashes-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-authority-slashes-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="special-authority-ignore-slashes-state">
-   <b><a href="#special-authority-ignore-slashes-state">#special-authority-ignore-slashes-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-special-authority-ignore-slashes-state" class="dfn-panel" data-for="special-authority-ignore-slashes-state" id="infopanel-for-special-authority-ignore-slashes-state" role="dialog">
+   <span id="infopaneltitle-for-special-authority-ignore-slashes-state" style="display:none">Info about the 'special authority ignore slashes state' definition.</span><b><a href="#special-authority-ignore-slashes-state">#special-authority-ignore-slashes-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-special-authority-ignore-slashes-state">4.4. URL parsing</a> <a href="#ref-for-special-authority-ignore-slashes-state①">(2)</a> <a href="#ref-for-special-authority-ignore-slashes-state②">(3)</a> <a href="#ref-for-special-authority-ignore-slashes-state③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="authority-state">
-   <b><a href="#authority-state">#authority-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-authority-state" class="dfn-panel" data-for="authority-state" id="infopanel-for-authority-state" role="dialog">
+   <span id="infopaneltitle-for-authority-state" style="display:none">Info about the 'authority state' definition.</span><b><a href="#authority-state">#authority-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-authority-state">4.4. URL parsing</a> <a href="#ref-for-authority-state①">(2)</a> <a href="#ref-for-authority-state②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="host-state">
-   <b><a href="#host-state">#host-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-host-state" class="dfn-panel" data-for="host-state" id="infopanel-for-host-state" role="dialog">
+   <span id="infopaneltitle-for-host-state" style="display:none">Info about the 'host state' definition.</span><b><a href="#host-state">#host-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-host-state">4.4. URL parsing</a>
     <li><a href="#ref-for-host-state①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="hostname-state">
-   <b><a href="#hostname-state">#hostname-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-hostname-state" class="dfn-panel" data-for="hostname-state" id="infopanel-for-hostname-state" role="dialog">
+   <span id="infopaneltitle-for-hostname-state" style="display:none">Info about the 'hostname state' definition.</span><b><a href="#hostname-state">#hostname-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-hostname-state">4.4. URL parsing</a>
     <li><a href="#ref-for-hostname-state①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="port-state">
-   <b><a href="#port-state">#port-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-port-state" class="dfn-panel" data-for="port-state" id="infopanel-for-port-state" role="dialog">
+   <span id="infopaneltitle-for-port-state" style="display:none">Info about the 'port state' definition.</span><b><a href="#port-state">#port-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-port-state">4.4. URL parsing</a>
     <li><a href="#ref-for-port-state①">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-state">
-   <b><a href="#file-state">#file-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-state" class="dfn-panel" data-for="file-state" id="infopanel-for-file-state" role="dialog">
+   <span id="infopaneltitle-for-file-state" style="display:none">Info about the 'file state' definition.</span><b><a href="#file-state">#file-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-state">4.4. URL parsing</a> <a href="#ref-for-file-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-slash-state">
-   <b><a href="#file-slash-state">#file-slash-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-slash-state" class="dfn-panel" data-for="file-slash-state" id="infopanel-for-file-slash-state" role="dialog">
+   <span id="infopaneltitle-for-file-slash-state" style="display:none">Info about the 'file slash state' definition.</span><b><a href="#file-slash-state">#file-slash-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-slash-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="file-host-state">
-   <b><a href="#file-host-state">#file-host-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-file-host-state" class="dfn-panel" data-for="file-host-state" id="infopanel-for-file-host-state" role="dialog">
+   <span id="infopaneltitle-for-file-host-state" style="display:none">Info about the 'file host state' definition.</span><b><a href="#file-host-state">#file-host-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-file-host-state">4.4. URL parsing</a> <a href="#ref-for-file-host-state①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-start-state">
-   <b><a href="#path-start-state">#path-start-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-start-state" class="dfn-panel" data-for="path-start-state" id="infopanel-for-path-start-state" role="dialog">
+   <span id="infopaneltitle-for-path-start-state" style="display:none">Info about the 'path start state' definition.</span><b><a href="#path-start-state">#path-start-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-start-state">4.4. URL parsing</a> <a href="#ref-for-path-start-state①">(2)</a> <a href="#ref-for-path-start-state②">(3)</a> <a href="#ref-for-path-start-state③">(4)</a>
     <li><a href="#ref-for-path-start-state④">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="path-state">
-   <b><a href="#path-state">#path-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-path-state" class="dfn-panel" data-for="path-state" id="infopanel-for-path-state" role="dialog">
+   <span id="infopaneltitle-for-path-state" style="display:none">Info about the 'path state' definition.</span><b><a href="#path-state">#path-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-path-state">4.4. URL parsing</a> <a href="#ref-for-path-state①">(2)</a> <a href="#ref-for-path-state②">(3)</a> <a href="#ref-for-path-state③">(4)</a> <a href="#ref-for-path-state④">(5)</a> <a href="#ref-for-path-state⑤">(6)</a> <a href="#ref-for-path-state⑥">(7)</a> <a href="#ref-for-path-state⑦">(8)</a> <a href="#ref-for-path-state⑧">(9)</a> <a href="#ref-for-path-state⑨">(10)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cannot-be-a-base-url-path-state">
-   <b><a href="#cannot-be-a-base-url-path-state">#cannot-be-a-base-url-path-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cannot-be-a-base-url-path-state" class="dfn-panel" data-for="cannot-be-a-base-url-path-state" id="infopanel-for-cannot-be-a-base-url-path-state" role="dialog">
+   <span id="infopaneltitle-for-cannot-be-a-base-url-path-state" style="display:none">Info about the 'cannot-be-a-base-URL path state' definition.</span><b><a href="#cannot-be-a-base-url-path-state">#cannot-be-a-base-url-path-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cannot-be-a-base-url-path-state">4.4. URL parsing</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="query-state">
-   <b><a href="#query-state">#query-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-query-state" class="dfn-panel" data-for="query-state" id="infopanel-for-query-state" role="dialog">
+   <span id="infopaneltitle-for-query-state" style="display:none">Info about the 'query state' definition.</span><b><a href="#query-state">#query-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-query-state">4.4. URL parsing</a> <a href="#ref-for-query-state①">(2)</a> <a href="#ref-for-query-state②">(3)</a> <a href="#ref-for-query-state③">(4)</a> <a href="#ref-for-query-state④">(5)</a>
     <li><a href="#ref-for-query-state⑤">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="fragment-state">
-   <b><a href="#fragment-state">#fragment-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-fragment-state" class="dfn-panel" data-for="fragment-state" id="infopanel-for-fragment-state" role="dialog">
+   <span id="infopaneltitle-for-fragment-state" style="display:none">Info about the 'fragment state' definition.</span><b><a href="#fragment-state">#fragment-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fragment-state">4.4. URL parsing</a> <a href="#ref-for-fragment-state①">(2)</a> <a href="#ref-for-fragment-state②">(3)</a> <a href="#ref-for-fragment-state③">(4)</a> <a href="#ref-for-fragment-state④">(5)</a> <a href="#ref-for-fragment-state⑤">(6)</a> <a href="#ref-for-fragment-state⑥">(7)</a>
     <li><a href="#ref-for-fragment-state⑦">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-username">
-   <b><a href="#set-the-username">#set-the-username</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-username" class="dfn-panel" data-for="set-the-username" id="infopanel-for-set-the-username" role="dialog">
+   <span id="infopaneltitle-for-set-the-username" style="display:none">Info about the 'set the username' definition.</span><b><a href="#set-the-username">#set-the-username</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-username">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="set-the-password">
-   <b><a href="#set-the-password">#set-the-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-set-the-password" class="dfn-panel" data-for="set-the-password" id="infopanel-for-set-the-password" role="dialog">
+   <span id="infopaneltitle-for-set-the-password" style="display:none">Info about the 'set the password' definition.</span><b><a href="#set-the-password">#set-the-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-password">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-serializer">
-   <b><a href="#concept-url-serializer">#concept-url-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-serializer" class="dfn-panel" data-for="concept-url-serializer" id="infopanel-for-concept-url-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-url-serializer" style="display:none">Info about the 'URL serializer' definition.</span><b><a href="#concept-url-serializer">#concept-url-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">4. URLs</a> <a href="#ref-for-concept-url-serializer①">(2)</a> <a href="#ref-for-concept-url-serializer②">(3)</a> <a href="#ref-for-concept-url-serializer③">(4)</a>
     <li><a href="#ref-for-concept-url-serializer④">4.5. URL serializing</a>
@@ -5079,52 +5079,52 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-url-serializer⑨">6.3. URL APIs elsewhere</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url-serializer-exclude-fragment">
-   <b><a href="#url-serializer-exclude-fragment">#url-serializer-exclude-fragment</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url-serializer-exclude-fragment" class="dfn-panel" data-for="url-serializer-exclude-fragment" id="infopanel-for-url-serializer-exclude-fragment" role="dialog">
+   <span id="infopaneltitle-for-url-serializer-exclude-fragment" style="display:none">Info about the 'exclude fragment' definition.</span><b><a href="#url-serializer-exclude-fragment">#url-serializer-exclude-fragment</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url-serializer-exclude-fragment">4.6. URL equivalence</a> <a href="#ref-for-url-serializer-exclude-fragment①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-equals">
-   <b><a href="#concept-url-equals">#concept-url-equals</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-equals" class="dfn-panel" data-for="concept-url-equals" id="infopanel-for-concept-url-equals" role="dialog">
+   <span id="infopaneltitle-for-concept-url-equals" style="display:none">Info about the 'equals' definition.</span><b><a href="#concept-url-equals">#concept-url-equals</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-equals">4. URLs</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-origin">
-   <b><a href="#concept-url-origin">#concept-url-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-origin" class="dfn-panel" data-for="concept-url-origin" id="infopanel-for-concept-url-origin" role="dialog">
+   <span id="infopaneltitle-for-concept-url-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#concept-url-origin">#concept-url-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-origin">4.7. Origin</a> <a href="#ref-for-concept-url-origin①">(2)</a>
     <li><a href="#ref-for-concept-url-origin②">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlencoded">
-   <b><a href="#concept-urlencoded">#concept-urlencoded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlencoded" class="dfn-panel" data-for="concept-urlencoded" id="infopanel-for-concept-urlencoded" role="dialog">
+   <span id="infopaneltitle-for-concept-urlencoded" style="display:none">Info about the 'application/x-www-form-urlencoded' definition.</span><b><a href="#concept-urlencoded">#concept-urlencoded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlencoded-parser">
-   <b><a href="#concept-urlencoded-parser">#concept-urlencoded-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlencoded-parser" class="dfn-panel" data-for="concept-urlencoded-parser" id="infopanel-for-concept-urlencoded-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-urlencoded-parser" style="display:none">Info about the 'application/x-www-form-urlencoded parser' definition.</span><b><a href="#concept-urlencoded-parser">#concept-urlencoded-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded-parser">5.3. Hooks</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlencoded-serializer">
-   <b><a href="#concept-urlencoded-serializer">#concept-urlencoded-serializer</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlencoded-serializer" class="dfn-panel" data-for="concept-urlencoded-serializer" id="infopanel-for-concept-urlencoded-serializer" role="dialog">
+   <span id="infopaneltitle-for-concept-urlencoded-serializer" style="display:none">Info about the 'application/x-www-form-urlencoded serializer' definition.</span><b><a href="#concept-urlencoded-serializer">#concept-urlencoded-serializer</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded-serializer">6.2. URLSearchParams class</a> <a href="#ref-for-concept-urlencoded-serializer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlencoded-string-parser">
-   <b><a href="#concept-urlencoded-string-parser">#concept-urlencoded-string-parser</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlencoded-string-parser" class="dfn-panel" data-for="concept-urlencoded-string-parser" id="infopanel-for-concept-urlencoded-string-parser" role="dialog">
+   <span id="infopaneltitle-for-concept-urlencoded-string-parser" style="display:none">Info about the 'application/x-www-form-urlencoded string parser' definition.</span><b><a href="#concept-urlencoded-string-parser">#concept-urlencoded-string-parser</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlencoded-string-parser">6.1. URL class</a> <a href="#ref-for-concept-urlencoded-string-parser①">(2)</a>
     <li><a href="#ref-for-concept-urlencoded-string-parser②">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="url">
-   <b><a href="#url">#url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-url" class="dfn-panel" data-for="url" id="infopanel-for-url" role="dialog">
+   <span id="infopaneltitle-for-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#url">#url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-url">Goals</a>
     <li><a href="#ref-for-url①">6.1. URL class</a> <a href="#ref-for-url②">(2)</a> <a href="#ref-for-url③">(3)</a> <a href="#ref-for-url④">(4)</a>
@@ -5132,247 +5132,303 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-url⑦">6.3. URL APIs elsewhere</a> <a href="#ref-for-url⑧">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-url">
-   <b><a href="#concept-url-url">#concept-url-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-url" class="dfn-panel" data-for="concept-url-url" id="infopanel-for-concept-url-url" role="dialog">
+   <span id="infopaneltitle-for-concept-url-url" style="display:none">Info about the 'URL' definition.</span><b><a href="#concept-url-url">#concept-url-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-url">6.1. URL class</a> <a href="#ref-for-concept-url-url①">(2)</a> <a href="#ref-for-concept-url-url②">(3)</a> <a href="#ref-for-concept-url-url③">(4)</a> <a href="#ref-for-concept-url-url④">(5)</a> <a href="#ref-for-concept-url-url⑤">(6)</a> <a href="#ref-for-concept-url-url⑥">(7)</a> <a href="#ref-for-concept-url-url⑦">(8)</a> <a href="#ref-for-concept-url-url⑧">(9)</a> <a href="#ref-for-concept-url-url⑨">(10)</a> <a href="#ref-for-concept-url-url①⓪">(11)</a> <a href="#ref-for-concept-url-url①①">(12)</a> <a href="#ref-for-concept-url-url①②">(13)</a> <a href="#ref-for-concept-url-url①③">(14)</a> <a href="#ref-for-concept-url-url①④">(15)</a> <a href="#ref-for-concept-url-url①⑤">(16)</a> <a href="#ref-for-concept-url-url①⑥">(17)</a> <a href="#ref-for-concept-url-url①⑦">(18)</a> <a href="#ref-for-concept-url-url①⑧">(19)</a> <a href="#ref-for-concept-url-url①⑨">(20)</a> <a href="#ref-for-concept-url-url②⓪">(21)</a> <a href="#ref-for-concept-url-url②①">(22)</a> <a href="#ref-for-concept-url-url②②">(23)</a> <a href="#ref-for-concept-url-url②③">(24)</a> <a href="#ref-for-concept-url-url②④">(25)</a> <a href="#ref-for-concept-url-url②⑤">(26)</a> <a href="#ref-for-concept-url-url②⑥">(27)</a> <a href="#ref-for-concept-url-url②⑦">(28)</a> <a href="#ref-for-concept-url-url②⑧">(29)</a> <a href="#ref-for-concept-url-url②⑨">(30)</a> <a href="#ref-for-concept-url-url③⓪">(31)</a> <a href="#ref-for-concept-url-url③①">(32)</a> <a href="#ref-for-concept-url-url③②">(33)</a> <a href="#ref-for-concept-url-url③③">(34)</a> <a href="#ref-for-concept-url-url③④">(35)</a> <a href="#ref-for-concept-url-url③⑤">(36)</a> <a href="#ref-for-concept-url-url③⑥">(37)</a> <a href="#ref-for-concept-url-url③⑦">(38)</a> <a href="#ref-for-concept-url-url③⑧">(39)</a> <a href="#ref-for-concept-url-url③⑨">(40)</a> <a href="#ref-for-concept-url-url④⓪">(41)</a>
     <li><a href="#ref-for-concept-url-url④①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-url-query-object">
-   <b><a href="#concept-url-query-object">#concept-url-query-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-url-query-object" class="dfn-panel" data-for="concept-url-query-object" id="infopanel-for-concept-url-query-object" role="dialog">
+   <span id="infopaneltitle-for-concept-url-query-object" style="display:none">Info about the 'query object' definition.</span><b><a href="#concept-url-query-object">#concept-url-query-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-query-object">6.1. URL class</a> <a href="#ref-for-concept-url-query-object①">(2)</a> <a href="#ref-for-concept-url-query-object②">(3)</a> <a href="#ref-for-concept-url-query-object③">(4)</a> <a href="#ref-for-concept-url-query-object④">(5)</a> <a href="#ref-for-concept-url-query-object⑤">(6)</a> <a href="#ref-for-concept-url-query-object⑥">(7)</a> <a href="#ref-for-concept-url-query-object⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-url">
-   <b><a href="#dom-url-url">#dom-url-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-url" class="dfn-panel" data-for="dom-url-url" id="infopanel-for-dom-url-url" role="dialog">
+   <span id="infopaneltitle-for-dom-url-url" style="display:none">Info about the 'new URL(url, base)' definition.</span><b><a href="#dom-url-url">#dom-url-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-url">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-href">
-   <b><a href="#dom-url-href">#dom-url-href</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-href" class="dfn-panel" data-for="dom-url-href" id="infopanel-for-dom-url-href" role="dialog">
+   <span id="infopaneltitle-for-dom-url-href" style="display:none">Info about the 'href' definition.</span><b><a href="#dom-url-href">#dom-url-href</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-href">6.1. URL class</a> <a href="#ref-for-dom-url-href①">(2)</a> <a href="#ref-for-dom-url-href②">(3)</a>
     <li><a href="#ref-for-dom-url-href③">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-tojson">
-   <b><a href="#dom-url-tojson">#dom-url-tojson</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-tojson" class="dfn-panel" data-for="dom-url-tojson" id="infopanel-for-dom-url-tojson" role="dialog">
+   <span id="infopaneltitle-for-dom-url-tojson" style="display:none">Info about the 'toJSON()' definition.</span><b><a href="#dom-url-tojson">#dom-url-tojson</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-tojson">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-origin">
-   <b><a href="#dom-url-origin">#dom-url-origin</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-origin" class="dfn-panel" data-for="dom-url-origin" id="infopanel-for-dom-url-origin" role="dialog">
+   <span id="infopaneltitle-for-dom-url-origin" style="display:none">Info about the 'origin' definition.</span><b><a href="#dom-url-origin">#dom-url-origin</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-origin">6.1. URL class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-protocol">
-   <b><a href="#dom-url-protocol">#dom-url-protocol</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-protocol" class="dfn-panel" data-for="dom-url-protocol" id="infopanel-for-dom-url-protocol" role="dialog">
+   <span id="infopaneltitle-for-dom-url-protocol" style="display:none">Info about the 'protocol' definition.</span><b><a href="#dom-url-protocol">#dom-url-protocol</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-protocol">6.1. URL class</a> <a href="#ref-for-dom-url-protocol①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-username">
-   <b><a href="#dom-url-username">#dom-url-username</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-username" class="dfn-panel" data-for="dom-url-username" id="infopanel-for-dom-url-username" role="dialog">
+   <span id="infopaneltitle-for-dom-url-username" style="display:none">Info about the 'username' definition.</span><b><a href="#dom-url-username">#dom-url-username</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-username">6.1. URL class</a> <a href="#ref-for-dom-url-username①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-password">
-   <b><a href="#dom-url-password">#dom-url-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-password" class="dfn-panel" data-for="dom-url-password" id="infopanel-for-dom-url-password" role="dialog">
+   <span id="infopaneltitle-for-dom-url-password" style="display:none">Info about the 'password' definition.</span><b><a href="#dom-url-password">#dom-url-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-password">6.1. URL class</a> <a href="#ref-for-dom-url-password①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-host">
-   <b><a href="#dom-url-host">#dom-url-host</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-host" class="dfn-panel" data-for="dom-url-host" id="infopanel-for-dom-url-host" role="dialog">
+   <span id="infopaneltitle-for-dom-url-host" style="display:none">Info about the 'host' definition.</span><b><a href="#dom-url-host">#dom-url-host</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-host">6.1. URL class</a> <a href="#ref-for-dom-url-host①">(2)</a> <a href="#ref-for-dom-url-host②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-hostname">
-   <b><a href="#dom-url-hostname">#dom-url-hostname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-hostname" class="dfn-panel" data-for="dom-url-hostname" id="infopanel-for-dom-url-hostname" role="dialog">
+   <span id="infopaneltitle-for-dom-url-hostname" style="display:none">Info about the 'hostname' definition.</span><b><a href="#dom-url-hostname">#dom-url-hostname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-hostname">6.1. URL class</a> <a href="#ref-for-dom-url-hostname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-port">
-   <b><a href="#dom-url-port">#dom-url-port</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-port" class="dfn-panel" data-for="dom-url-port" id="infopanel-for-dom-url-port" role="dialog">
+   <span id="infopaneltitle-for-dom-url-port" style="display:none">Info about the 'port' definition.</span><b><a href="#dom-url-port">#dom-url-port</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-port">6.1. URL class</a> <a href="#ref-for-dom-url-port①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-pathname">
-   <b><a href="#dom-url-pathname">#dom-url-pathname</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-pathname" class="dfn-panel" data-for="dom-url-pathname" id="infopanel-for-dom-url-pathname" role="dialog">
+   <span id="infopaneltitle-for-dom-url-pathname" style="display:none">Info about the 'pathname' definition.</span><b><a href="#dom-url-pathname">#dom-url-pathname</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-pathname">6.1. URL class</a> <a href="#ref-for-dom-url-pathname①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-search">
-   <b><a href="#dom-url-search">#dom-url-search</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-search" class="dfn-panel" data-for="dom-url-search" id="infopanel-for-dom-url-search" role="dialog">
+   <span id="infopaneltitle-for-dom-url-search" style="display:none">Info about the 'search' definition.</span><b><a href="#dom-url-search">#dom-url-search</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-search">6.1. URL class</a> <a href="#ref-for-dom-url-search①">(2)</a>
     <li><a href="#ref-for-dom-url-search②">6.2. URLSearchParams class</a> <a href="#ref-for-dom-url-search③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-searchparams">
-   <b><a href="#dom-url-searchparams">#dom-url-searchparams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-searchparams" class="dfn-panel" data-for="dom-url-searchparams" id="infopanel-for-dom-url-searchparams" role="dialog">
+   <span id="infopaneltitle-for-dom-url-searchparams" style="display:none">Info about the 'searchParams' definition.</span><b><a href="#dom-url-searchparams">#dom-url-searchparams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-searchparams">6.1. URL class</a>
     <li><a href="#ref-for-dom-url-searchparams①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-url-hash">
-   <b><a href="#dom-url-hash">#dom-url-hash</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-url-hash" class="dfn-panel" data-for="dom-url-hash" id="infopanel-for-dom-url-hash" role="dialog">
+   <span id="infopaneltitle-for-dom-url-hash" style="display:none">Info about the 'hash' definition.</span><b><a href="#dom-url-hash">#dom-url-hash</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-url-hash">6.1. URL class</a> <a href="#ref-for-dom-url-hash①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="urlsearchparams">
-   <b><a href="#urlsearchparams">#urlsearchparams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-urlsearchparams" class="dfn-panel" data-for="urlsearchparams" id="infopanel-for-urlsearchparams" role="dialog">
+   <span id="infopaneltitle-for-urlsearchparams" style="display:none">Info about the 'URLSearchParams' definition.</span><b><a href="#urlsearchparams">#urlsearchparams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-urlsearchparams">6.1. URL class</a> <a href="#ref-for-urlsearchparams①">(2)</a> <a href="#ref-for-urlsearchparams②">(3)</a>
     <li><a href="#ref-for-urlsearchparams③">6.2. URLSearchParams class</a> <a href="#ref-for-urlsearchparams④">(2)</a> <a href="#ref-for-urlsearchparams⑤">(3)</a> <a href="#ref-for-urlsearchparams⑥">(4)</a> <a href="#ref-for-urlsearchparams⑦">(5)</a> <a href="#ref-for-urlsearchparams⑧">(6)</a> <a href="#ref-for-urlsearchparams⑨">(7)</a> <a href="#ref-for-urlsearchparams①⓪">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlsearchparams-list">
-   <b><a href="#concept-urlsearchparams-list">#concept-urlsearchparams-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlsearchparams-list" class="dfn-panel" data-for="concept-urlsearchparams-list" id="infopanel-for-concept-urlsearchparams-list" role="dialog">
+   <span id="infopaneltitle-for-concept-urlsearchparams-list" style="display:none">Info about the 'list' definition.</span><b><a href="#concept-urlsearchparams-list">#concept-urlsearchparams-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlsearchparams-list">6.1. URL class</a> <a href="#ref-for-concept-urlsearchparams-list①">(2)</a> <a href="#ref-for-concept-urlsearchparams-list②">(3)</a> <a href="#ref-for-concept-urlsearchparams-list③">(4)</a>
     <li><a href="#ref-for-concept-urlsearchparams-list④">6.2. URLSearchParams class</a> <a href="#ref-for-concept-urlsearchparams-list⑤">(2)</a> <a href="#ref-for-concept-urlsearchparams-list⑥">(3)</a> <a href="#ref-for-concept-urlsearchparams-list⑦">(4)</a> <a href="#ref-for-concept-urlsearchparams-list⑧">(5)</a> <a href="#ref-for-concept-urlsearchparams-list⑨">(6)</a> <a href="#ref-for-concept-urlsearchparams-list①⓪">(7)</a> <a href="#ref-for-concept-urlsearchparams-list①①">(8)</a> <a href="#ref-for-concept-urlsearchparams-list①②">(9)</a> <a href="#ref-for-concept-urlsearchparams-list①③">(10)</a> <a href="#ref-for-concept-urlsearchparams-list①④">(11)</a> <a href="#ref-for-concept-urlsearchparams-list①⑤">(12)</a> <a href="#ref-for-concept-urlsearchparams-list①⑥">(13)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlsearchparams-url-object">
-   <b><a href="#concept-urlsearchparams-url-object">#concept-urlsearchparams-url-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlsearchparams-url-object" class="dfn-panel" data-for="concept-urlsearchparams-url-object" id="infopanel-for-concept-urlsearchparams-url-object" role="dialog">
+   <span id="infopaneltitle-for-concept-urlsearchparams-url-object" style="display:none">Info about the 'URL object' definition.</span><b><a href="#concept-urlsearchparams-url-object">#concept-urlsearchparams-url-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlsearchparams-url-object">6.1. URL class</a>
     <li><a href="#ref-for-concept-urlsearchparams-url-object①">6.2. URLSearchParams class</a> <a href="#ref-for-concept-urlsearchparams-url-object②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="urlsearchparams-initialize">
-   <b><a href="#urlsearchparams-initialize">#urlsearchparams-initialize</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-urlsearchparams-initialize" class="dfn-panel" data-for="urlsearchparams-initialize" id="infopanel-for-urlsearchparams-initialize" role="dialog">
+   <span id="infopaneltitle-for-urlsearchparams-initialize" style="display:none">Info about the 'initialize' definition.</span><b><a href="#urlsearchparams-initialize">#urlsearchparams-initialize</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-urlsearchparams-initialize">6.1. URL class</a>
     <li><a href="#ref-for-urlsearchparams-initialize①">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-urlsearchparams-update">
-   <b><a href="#concept-urlsearchparams-update">#concept-urlsearchparams-update</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-urlsearchparams-update" class="dfn-panel" data-for="concept-urlsearchparams-update" id="infopanel-for-concept-urlsearchparams-update" role="dialog">
+   <span id="infopaneltitle-for-concept-urlsearchparams-update" style="display:none">Info about the 'update' definition.</span><b><a href="#concept-urlsearchparams-update">#concept-urlsearchparams-update</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-urlsearchparams-update">6.2. URLSearchParams class</a> <a href="#ref-for-concept-urlsearchparams-update①">(2)</a> <a href="#ref-for-concept-urlsearchparams-update②">(3)</a> <a href="#ref-for-concept-urlsearchparams-update③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-urlsearchparams">
-   <b><a href="#dom-urlsearchparams-urlsearchparams">#dom-urlsearchparams-urlsearchparams</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-urlsearchparams" class="dfn-panel" data-for="dom-urlsearchparams-urlsearchparams" id="infopanel-for-dom-urlsearchparams-urlsearchparams" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-urlsearchparams" style="display:none">Info about the 'new URLSearchParams(init)' definition.</span><b><a href="#dom-urlsearchparams-urlsearchparams">#dom-urlsearchparams-urlsearchparams</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-urlsearchparams">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-append">
-   <b><a href="#dom-urlsearchparams-append">#dom-urlsearchparams-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-append" class="dfn-panel" data-for="dom-urlsearchparams-append" id="infopanel-for-dom-urlsearchparams-append" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-append" style="display:none">Info about the 'append(name, value)' definition.</span><b><a href="#dom-urlsearchparams-append">#dom-urlsearchparams-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-append">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-delete">
-   <b><a href="#dom-urlsearchparams-delete">#dom-urlsearchparams-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-delete" class="dfn-panel" data-for="dom-urlsearchparams-delete" id="infopanel-for-dom-urlsearchparams-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-delete" style="display:none">Info about the 'delete(name)' definition.</span><b><a href="#dom-urlsearchparams-delete">#dom-urlsearchparams-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-delete">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-get">
-   <b><a href="#dom-urlsearchparams-get">#dom-urlsearchparams-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-get" class="dfn-panel" data-for="dom-urlsearchparams-get" id="infopanel-for-dom-urlsearchparams-get" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-get" style="display:none">Info about the 'get(name)' definition.</span><b><a href="#dom-urlsearchparams-get">#dom-urlsearchparams-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-get">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-getall">
-   <b><a href="#dom-urlsearchparams-getall">#dom-urlsearchparams-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-getall" class="dfn-panel" data-for="dom-urlsearchparams-getall" id="infopanel-for-dom-urlsearchparams-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-getall" style="display:none">Info about the 'getAll(name)' definition.</span><b><a href="#dom-urlsearchparams-getall">#dom-urlsearchparams-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-getall">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-has">
-   <b><a href="#dom-urlsearchparams-has">#dom-urlsearchparams-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-has" class="dfn-panel" data-for="dom-urlsearchparams-has" id="infopanel-for-dom-urlsearchparams-has" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-has" style="display:none">Info about the 'has(name)' definition.</span><b><a href="#dom-urlsearchparams-has">#dom-urlsearchparams-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-has">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-set">
-   <b><a href="#dom-urlsearchparams-set">#dom-urlsearchparams-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-set" class="dfn-panel" data-for="dom-urlsearchparams-set" id="infopanel-for-dom-urlsearchparams-set" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-set" style="display:none">Info about the 'set(name, value)' definition.</span><b><a href="#dom-urlsearchparams-set">#dom-urlsearchparams-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-set">6.2. URLSearchParams class</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-urlsearchparams-sort">
-   <b><a href="#dom-urlsearchparams-sort">#dom-urlsearchparams-sort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-urlsearchparams-sort" class="dfn-panel" data-for="dom-urlsearchparams-sort" id="infopanel-for-dom-urlsearchparams-sort" role="dialog">
+   <span id="infopaneltitle-for-dom-urlsearchparams-sort" style="display:none">Info about the 'sort()' definition.</span><b><a href="#dom-urlsearchparams-sort">#dom-urlsearchparams-sort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-urlsearchparams-sort">6.2. URLSearchParams class</a> <a href="#ref-for-dom-urlsearchparams-sort①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="urlsearchparams-stringification-behavior">
-   <b><a href="#urlsearchparams-stringification-behavior">#urlsearchparams-stringification-behavior</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-urlsearchparams-stringification-behavior" class="dfn-panel" data-for="urlsearchparams-stringification-behavior" id="infopanel-for-urlsearchparams-stringification-behavior" role="dialog">
+   <span id="infopaneltitle-for-urlsearchparams-stringification-behavior" style="display:none">Info about the 'stringification behavior' definition.</span><b><a href="#urlsearchparams-stringification-behavior">#urlsearchparams-stringification-behavior</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-urlsearchparams-stringification-behavior">6.2. URLSearchParams class</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/github/whatwg/xhr/xhr.html
+++ b/tests/github/whatwg/xhr/xhr.html
@@ -2532,234 +2532,234 @@ if ("serviceWorker" in navigator) {
    <li><a href="#xmlhttprequestresponsetype">XMLHttpRequestResponseType</a><span>, in § 3</span>
    <li><a href="#xmlhttprequestupload">XMLHttpRequestUpload</a><span>, in § 3</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-document">
-   <a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-document" class="dfn-panel" data-for="term-for-document" id="infopanel-for-term-for-document" role="menu">
+   <span id="infopaneltitle-for-term-for-document" style="display:none">Info about the 'Document' external reference.</span><a href="https://dom.spec.whatwg.org/#document">https://dom.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">3. Interface XMLHttpRequest</a> <a href="#ref-for-document①">(2)</a>
     <li><a href="#ref-for-document②">3.5.6. The send() method</a> <a href="#ref-for-document③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event">
-   <a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event" class="dfn-panel" data-for="term-for-event" id="infopanel-for-term-for-event" role="menu">
+   <span id="infopaneltitle-for-term-for-event" style="display:none">Info about the 'Event' external reference.</span><a href="https://dom.spec.whatwg.org/#event">https://dom.spec.whatwg.org/#event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event">5. Interface ProgressEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dictdef-eventinit">
-   <a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dictdef-eventinit" class="dfn-panel" data-for="term-for-dictdef-eventinit" id="infopanel-for-term-for-dictdef-eventinit" role="menu">
+   <span id="infopaneltitle-for-term-for-dictdef-eventinit" style="display:none">Info about the 'EventInit' external reference.</span><a href="https://dom.spec.whatwg.org/#dictdef-eventinit">https://dom.spec.whatwg.org/#dictdef-eventinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-eventinit">5. Interface ProgressEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventtarget">
-   <a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventtarget" class="dfn-panel" data-for="term-for-eventtarget" id="infopanel-for-term-for-eventtarget" role="menu">
+   <span id="infopaneltitle-for-term-for-eventtarget" style="display:none">Info about the 'EventTarget' external reference.</span><a href="https://dom.spec.whatwg.org/#eventtarget">https://dom.spec.whatwg.org/#eventtarget</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventtarget">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-bubbles">
-   <a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-bubbles" class="dfn-panel" data-for="term-for-dom-event-bubbles" id="infopanel-for-term-for-dom-event-bubbles" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-bubbles" style="display:none">Info about the 'bubbles' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-bubbles">https://dom.spec.whatwg.org/#dom-event-bubbles</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-bubbles">5.2. Suggested names for events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-cancelable">
-   <a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-cancelable" class="dfn-panel" data-for="term-for-dom-event-cancelable" id="infopanel-for-term-for-dom-event-cancelable" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-cancelable" style="display:none">Info about the 'cancelable' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-cancelable">https://dom.spec.whatwg.org/#dom-event-cancelable</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-cancelable">5.2. Suggested names for events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-content-type">
-   <a href="https://dom.spec.whatwg.org/#concept-document-content-type">https://dom.spec.whatwg.org/#concept-document-content-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-content-type" class="dfn-panel" data-for="term-for-concept-document-content-type" id="infopanel-for-term-for-concept-document-content-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-content-type" style="display:none">Info about the 'content type' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-content-type">https://dom.spec.whatwg.org/#concept-document-content-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-content-type">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-dispatch">
-   <a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-dispatch" class="dfn-panel" data-for="term-for-concept-event-dispatch" id="infopanel-for-term-for-concept-event-dispatch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-dispatch" style="display:none">Info about the 'dispatch' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-dispatch">https://dom.spec.whatwg.org/#concept-event-dispatch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-dispatch">3.5.3. The timeout getter and setter</a>
     <li><a href="#ref-for-concept-event-dispatch①">5.2. Suggested names for events using the ProgressEvent interface</a> <a href="#ref-for-concept-event-dispatch②">(2)</a> <a href="#ref-for-concept-event-dispatch③">(3)</a>
     <li><a href="#ref-for-concept-event-dispatch④">5.3. Security considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document">
-   <a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document" class="dfn-panel" data-for="term-for-concept-document" id="infopanel-for-term-for-concept-document" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document" style="display:none">Info about the 'document' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document">https://dom.spec.whatwg.org/#concept-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document">3.6.6. Response body</a> <a href="#ref-for-concept-document①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-encoding">
-   <a href="https://dom.spec.whatwg.org/#concept-document-encoding">https://dom.spec.whatwg.org/#concept-document-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-encoding" class="dfn-panel" data-for="term-for-concept-document-encoding" id="infopanel-for-term-for-concept-document-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-encoding" style="display:none">Info about the 'encoding' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-encoding">https://dom.spec.whatwg.org/#concept-document-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-encoding">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event">
-   <a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event" class="dfn-panel" data-for="term-for-concept-event" id="infopanel-for-term-for-concept-event" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event" style="display:none">Info about the 'event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event">https://dom.spec.whatwg.org/#concept-event</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event">5. Interface ProgressEvent</a>
     <li><a href="#ref-for-concept-event①">5.2. Suggested names for events using the ProgressEvent interface</a> <a href="#ref-for-concept-event②">(2)</a>
     <li><a href="#ref-for-concept-event③">5.3. Security considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-listener">
-   <a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-listener" class="dfn-panel" data-for="term-for-concept-event-listener" id="infopanel-for-term-for-concept-event-listener" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-listener" style="display:none">Info about the 'event listener' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-listener">https://dom.spec.whatwg.org/#concept-event-listener</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-listener">3.2. Garbage collection</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-event-fire">
-   <a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-event-fire" class="dfn-panel" data-for="term-for-concept-event-fire" id="infopanel-for-term-for-concept-event-fire" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-event-fire" style="display:none">Info about the 'fire an event' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-event-fire">https://dom.spec.whatwg.org/#concept-event-fire</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire">3.5.1. The open() method</a>
     <li><a href="#ref-for-concept-event-fire①">3.5.6. The send() method</a> <a href="#ref-for-concept-event-fire②">(2)</a> <a href="#ref-for-concept-event-fire③">(3)</a> <a href="#ref-for-concept-event-fire④">(4)</a>
     <li><a href="#ref-for-concept-event-fire⑤">5.1. Firing events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-document">
-   <a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-document" class="dfn-panel" data-for="term-for-html-document" id="infopanel-for-term-for-html-document" role="menu">
+   <span id="infopaneltitle-for-term-for-html-document" style="display:none">Info about the 'html document' external reference.</span><a href="https://dom.spec.whatwg.org/#html-document">https://dom.spec.whatwg.org/#html-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-document">3.5.6. The send() method</a>
     <li><a href="#ref-for-html-document①">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-origin">
-   <a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-origin" class="dfn-panel" data-for="term-for-concept-document-origin" id="infopanel-for-term-for-concept-document-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-origin">https://dom.spec.whatwg.org/#concept-document-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-origin">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dom-event-type">
-   <a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dom-event-type" class="dfn-panel" data-for="term-for-dom-event-type" id="infopanel-for-term-for-dom-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dom-event-type" style="display:none">Info about the 'type' external reference.</span><a href="https://dom.spec.whatwg.org/#dom-event-type">https://dom.spec.whatwg.org/#dom-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-event-type">5.2. Suggested names for events using the ProgressEvent interface</a> <a href="#ref-for-dom-event-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-document-url">
-   <a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-document-url" class="dfn-panel" data-for="term-for-concept-document-url" id="infopanel-for-term-for-concept-document-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-document-url" style="display:none">Info about the 'url' external reference.</span><a href="https://dom.spec.whatwg.org/#concept-document-url">https://dom.spec.whatwg.org/#concept-document-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-url">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-document">
-   <a href="https://dom.spec.whatwg.org/#xml-document">https://dom.spec.whatwg.org/#xml-document</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-document" class="dfn-panel" data-for="term-for-xml-document" id="infopanel-for-term-for-xml-document" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-document" style="display:none">Info about the 'xml document' external reference.</span><a href="https://dom.spec.whatwg.org/#xml-document">https://dom.spec.whatwg.org/#xml-document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-document">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-fragment-serializing-algorithm">
-   <a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm">https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-fragment-serializing-algorithm" class="dfn-panel" data-for="term-for-dfn-fragment-serializing-algorithm" id="infopanel-for-term-for-dfn-fragment-serializing-algorithm" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-fragment-serializing-algorithm" style="display:none">Info about the 'fragment serializing algorithm' external reference.</span><a href="https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm">https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-fragment-serializing-algorithm">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-decode">
-   <a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-decode" class="dfn-panel" data-for="term-for-decode" id="infopanel-for-term-for-decode" role="menu">
+   <span id="infopaneltitle-for-term-for-decode" style="display:none">Info about the 'decode' external reference.</span><a href="https://encoding.spec.whatwg.org/#decode">https://encoding.spec.whatwg.org/#decode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-decode">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-encoding-get">
-   <a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-encoding-get" class="dfn-panel" data-for="term-for-concept-encoding-get" id="infopanel-for-term-for-concept-encoding-get" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-encoding-get" style="display:none">Info about the 'getting an encoding' external reference.</span><a href="https://encoding.spec.whatwg.org/#concept-encoding-get">https://encoding.spec.whatwg.org/#concept-encoding-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-encoding-get">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8">
-   <a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8" class="dfn-panel" data-for="term-for-utf-8" id="infopanel-for-term-for-utf-8" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8" style="display:none">Info about the 'utf-8' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8">https://encoding.spec.whatwg.org/#utf-8</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8">3.6.6. Response body</a> <a href="#ref-for-utf-8①">(2)</a> <a href="#ref-for-utf-8②">(3)</a> <a href="#ref-for-utf-8③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-utf-8-encode">
-   <a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-utf-8-encode" class="dfn-panel" data-for="term-for-utf-8-encode" id="infopanel-for-term-for-utf-8-encode" role="menu">
+   <span id="infopaneltitle-for-term-for-utf-8-encode" style="display:none">Info about the 'utf-8 encode' external reference.</span><a href="https://encoding.spec.whatwg.org/#utf-8-encode">https://encoding.spec.whatwg.org/#utf-8-encode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-utf-8-encode">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-typedefdef-xmlhttprequestbodyinit">
-   <a href="https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit">https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedefdef-xmlhttprequestbodyinit" class="dfn-panel" data-for="term-for-typedefdef-xmlhttprequestbodyinit" id="infopanel-for-term-for-typedefdef-xmlhttprequestbodyinit" role="menu">
+   <span id="infopaneltitle-for-term-for-typedefdef-xmlhttprequestbodyinit" style="display:none">Info about the 'XMLHttpRequestBodyInit' external reference.</span><a href="https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit">https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedefdef-xmlhttprequestbodyinit">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-aborted">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-aborted" class="dfn-panel" data-for="term-for-concept-response-aborted" id="infopanel-for-term-for-concept-response-aborted" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-aborted" style="display:none">Info about the 'aborted flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-aborted">https://fetch.spec.whatwg.org/#concept-response-aborted</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-aborted">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-body" class="dfn-panel" data-for="term-for-concept-request-body" id="infopanel-for-term-for-concept-request-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-body" style="display:none">Info about the 'body (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-body">https://fetch.spec.whatwg.org/#concept-request-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-body">3.5.6. The send() method</a> <a href="#ref-for-concept-request-body①">(2)</a> <a href="#ref-for-concept-request-body②">(3)</a> <a href="#ref-for-concept-request-body③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-body">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-body" class="dfn-panel" data-for="term-for-concept-response-body" id="infopanel-for-term-for-concept-response-body" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-body" style="display:none">Info about the 'body (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-body">https://fetch.spec.whatwg.org/#concept-response-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-body">3.5.6. The send() method</a> <a href="#ref-for-concept-response-body①">(2)</a>
     <li><a href="#ref-for-concept-response-body②">3.6.6. Response body</a> <a href="#ref-for-concept-response-body③">(2)</a>
     <li><a href="#ref-for-concept-response-body④">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-client">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-client" class="dfn-panel" data-for="term-for-concept-request-client" id="infopanel-for-term-for-concept-request-client" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-client" style="display:none">Info about the 'client' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-client">https://fetch.spec.whatwg.org/#concept-request-client</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-client">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-combine">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-combine" class="dfn-panel" data-for="term-for-concept-header-list-combine" id="infopanel-for-term-for-concept-header-list-combine" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-combine" style="display:none">Info about the 'combine' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-combine">https://fetch.spec.whatwg.org/#concept-header-list-combine</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-combine">3.5.2. The setRequestHeader() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-protocol">
-   <a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-protocol" class="dfn-panel" data-for="term-for-cors-protocol" id="infopanel-for-term-for-cors-protocol" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-protocol" style="display:none">Info about the 'cors protocol' external reference.</span><a href="https://fetch.spec.whatwg.org/#cors-protocol">https://fetch.spec.whatwg.org/#cors-protocol</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-protocol">5.3. Security considerations</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-cors-preflight-request">
-   <a href="https://fetch.spec.whatwg.org/#cors-preflight-request">https://fetch.spec.whatwg.org/#cors-preflight-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-cors-preflight-request" class="dfn-panel" data-for="term-for-cors-preflight-request" id="infopanel-for-term-for-cors-preflight-request" role="menu">
+   <span id="infopaneltitle-for-term-for-cors-preflight-request" style="display:none">Info about the 'cors-preflight request' external reference.</span><a href="https://fetch.spec.whatwg.org/#cors-preflight-request">https://fetch.spec.whatwg.org/#cors-preflight-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cors-preflight-request">3.5. Request</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-credentials">
-   <a href="https://fetch.spec.whatwg.org/#credentials">https://fetch.spec.whatwg.org/#credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-credentials" class="dfn-panel" data-for="term-for-credentials" id="infopanel-for-term-for-credentials" role="menu">
+   <span id="infopaneltitle-for-term-for-credentials" style="display:none">Info about the 'credentials' external reference.</span><a href="https://fetch.spec.whatwg.org/#credentials">https://fetch.spec.whatwg.org/#credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-credentials">3.5.4. The withCredentials getter and setter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-credentials-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-credentials-mode" class="dfn-panel" data-for="term-for-concept-request-credentials-mode" id="infopanel-for-term-for-concept-request-credentials-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-credentials-mode" style="display:none">Info about the 'credentials mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-credentials-mode">https://fetch.spec.whatwg.org/#concept-request-credentials-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-credentials-mode">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-done-flag">
-   <a href="https://fetch.spec.whatwg.org/#done-flag">https://fetch.spec.whatwg.org/#done-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-done-flag" class="dfn-panel" data-for="term-for-done-flag" id="infopanel-for-term-for-done-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-done-flag" style="display:none">Info about the 'done flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#done-flag">https://fetch.spec.whatwg.org/#done-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-done-flag">3.5.6. The send() method</a> <a href="#ref-for-done-flag①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-header-list-extract-a-length">
-   <a href="https://fetch.spec.whatwg.org/#header-list-extract-a-length">https://fetch.spec.whatwg.org/#header-list-extract-a-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-header-list-extract-a-length" class="dfn-panel" data-for="term-for-header-list-extract-a-length" id="infopanel-for-term-for-header-list-extract-a-length" role="menu">
+   <span id="infopaneltitle-for-term-for-header-list-extract-a-length" style="display:none">Info about the 'extracting a length' external reference.</span><a href="https://fetch.spec.whatwg.org/#header-list-extract-a-length">https://fetch.spec.whatwg.org/#header-list-extract-a-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-header-list-extract-a-length">3.5.6. The send() method</a> <a href="#ref-for-header-list-extract-a-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-extract-mime-type">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-extract-mime-type" class="dfn-panel" data-for="term-for-concept-header-extract-mime-type" id="infopanel-for-term-for-concept-header-extract-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-extract-mime-type" style="display:none">Info about the 'extracting a mime type' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-extract-mime-type">https://fetch.spec.whatwg.org/#concept-header-extract-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-extract-mime-type">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-fetch">
-   <a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-fetch" class="dfn-panel" data-for="term-for-concept-fetch" id="infopanel-for-term-for-concept-fetch" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-fetch" style="display:none">Info about the 'fetch' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-fetch">https://fetch.spec.whatwg.org/#concept-fetch</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-fetch">1. Introduction</a>
     <li><a href="#ref-for-concept-fetch①">3.5.1. The open() method</a>
@@ -2768,39 +2768,39 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-fetch⑨">5.4. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-forbidden-method">
-   <a href="https://fetch.spec.whatwg.org/#forbidden-method">https://fetch.spec.whatwg.org/#forbidden-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-forbidden-method" class="dfn-panel" data-for="term-for-forbidden-method" id="infopanel-for-term-for-forbidden-method" role="menu">
+   <span id="infopaneltitle-for-term-for-forbidden-method" style="display:none">Info about the 'forbidden method' external reference.</span><a href="https://fetch.spec.whatwg.org/#forbidden-method">https://fetch.spec.whatwg.org/#forbidden-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-forbidden-method">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-get">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-get">https://fetch.spec.whatwg.org/#concept-header-list-get</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-get" class="dfn-panel" data-for="term-for-concept-header-list-get" id="infopanel-for-term-for-concept-header-list-get" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-get" style="display:none">Info about the 'get' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-get">https://fetch.spec.whatwg.org/#concept-header-list-get</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-get">3.5.6. The send() method</a>
     <li><a href="#ref-for-concept-header-list-get①">3.6.4. The getResponseHeader() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header">
-   <a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header" class="dfn-panel" data-for="term-for-concept-header" id="infopanel-for-term-for-concept-header" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header" style="display:none">Info about the 'header' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header">https://fetch.spec.whatwg.org/#concept-header</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-concept-header①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list">https://fetch.spec.whatwg.org/#concept-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list" class="dfn-panel" data-for="term-for-concept-header-list" id="infopanel-for-term-for-concept-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list" style="display:none">Info about the 'header list' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list">https://fetch.spec.whatwg.org/#concept-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-header-list" class="dfn-panel" data-for="term-for-concept-request-header-list" id="infopanel-for-term-for-concept-request-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-header-list" style="display:none">Info about the 'header list (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-header-list">https://fetch.spec.whatwg.org/#concept-request-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-header-list">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-header-list">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-header-list" class="dfn-panel" data-for="term-for-concept-response-header-list" id="infopanel-for-term-for-concept-response-header-list" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-header-list" style="display:none">Info about the 'header list (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-header-list">https://fetch.spec.whatwg.org/#concept-response-header-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-header-list">3.5.6. The send() method</a> <a href="#ref-for-concept-response-header-list①">(2)</a>
     <li><a href="#ref-for-concept-response-header-list②">3.6.4. The getResponseHeader() method</a> <a href="#ref-for-concept-response-header-list③">(2)</a>
@@ -2808,46 +2808,46 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-response-header-list⑥">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-body-incrementally-read">
-   <a href="https://fetch.spec.whatwg.org/#body-incrementally-read">https://fetch.spec.whatwg.org/#body-incrementally-read</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-body-incrementally-read" class="dfn-panel" data-for="term-for-body-incrementally-read" id="infopanel-for-term-for-body-incrementally-read" role="menu">
+   <span id="infopaneltitle-for-term-for-body-incrementally-read" style="display:none">Info about the 'incrementally read' external reference.</span><a href="https://fetch.spec.whatwg.org/#body-incrementally-read">https://fetch.spec.whatwg.org/#body-incrementally-read</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-body-incrementally-read">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-body-total-bytes">
-   <a href="https://fetch.spec.whatwg.org/#concept-body-total-bytes">https://fetch.spec.whatwg.org/#concept-body-total-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-body-total-bytes" class="dfn-panel" data-for="term-for-concept-body-total-bytes" id="infopanel-for-term-for-concept-body-total-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-body-total-bytes" style="display:none">Info about the 'length' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-body-total-bytes">https://fetch.spec.whatwg.org/#concept-body-total-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-body-total-bytes">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-method">https://fetch.spec.whatwg.org/#concept-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-method" class="dfn-panel" data-for="term-for-concept-method" id="infopanel-for-term-for-concept-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-method" style="display:none">Info about the 'method' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-method">https://fetch.spec.whatwg.org/#concept-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-method">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-concept-method①">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-method">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-method" class="dfn-panel" data-for="term-for-concept-request-method" id="infopanel-for-term-for-concept-request-method" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-method" style="display:none">Info about the 'method (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-method">https://fetch.spec.whatwg.org/#concept-request-method</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-method">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-mode">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-mode" class="dfn-panel" data-for="term-for-concept-request-mode" id="infopanel-for-term-for-concept-request-mode" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-mode" style="display:none">Info about the 'mode' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-mode">https://fetch.spec.whatwg.org/#concept-request-mode</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-mode">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-name">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-name" class="dfn-panel" data-for="term-for-concept-header-name" id="infopanel-for-term-for-concept-header-name" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-name" style="display:none">Info about the 'name' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-name">https://fetch.spec.whatwg.org/#concept-header-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-name">3.5.2. The setRequestHeader() method</a>
     <li><a href="#ref-for-concept-header-name①">3.6.5. The getAllResponseHeaders() method</a> <a href="#ref-for-concept-header-name②">(2)</a> <a href="#ref-for-concept-header-name③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-network-error">
-   <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-network-error" class="dfn-panel" data-for="term-for-concept-network-error" id="infopanel-for-term-for-concept-network-error" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-network-error" style="display:none">Info about the 'network error' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-network-error">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-concept-network-error①">3.5.1. The open() method</a>
@@ -2855,472 +2855,472 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-network-error⑦">3.5.7. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-method-normalize">
-   <a href="https://fetch.spec.whatwg.org/#concept-method-normalize">https://fetch.spec.whatwg.org/#concept-method-normalize</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-method-normalize" class="dfn-panel" data-for="term-for-concept-method-normalize" id="infopanel-for-term-for-concept-method-normalize" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-method-normalize" style="display:none">Info about the 'normalize' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-method-normalize">https://fetch.spec.whatwg.org/#concept-method-normalize</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-method-normalize">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-request-end-of-body">
-   <a href="https://fetch.spec.whatwg.org/#process-request-end-of-body">https://fetch.spec.whatwg.org/#process-request-end-of-body</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-request-end-of-body" class="dfn-panel" data-for="term-for-process-request-end-of-body" id="infopanel-for-term-for-process-request-end-of-body" role="menu">
+   <span id="infopaneltitle-for-term-for-process-request-end-of-body" style="display:none">Info about the 'processrequestendofbody' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-request-end-of-body">https://fetch.spec.whatwg.org/#process-request-end-of-body</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-request-end-of-body">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-process-response">
-   <a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-process-response" class="dfn-panel" data-for="term-for-process-response" id="infopanel-for-term-for-process-response" role="menu">
+   <span id="infopaneltitle-for-term-for-process-response" style="display:none">Info about the 'processresponse' external reference.</span><a href="https://fetch.spec.whatwg.org/#process-response">https://fetch.spec.whatwg.org/#process-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-process-response">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-processresponseendofbody">
-   <a href="https://fetch.spec.whatwg.org/#fetch-processresponseendofbody">https://fetch.spec.whatwg.org/#fetch-processresponseendofbody</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-processresponseendofbody" class="dfn-panel" data-for="term-for-fetch-processresponseendofbody" id="infopanel-for-term-for-fetch-processresponseendofbody" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-processresponseendofbody" style="display:none">Info about the 'processresponseendofbody' external reference.</span><a href="https://fetch.spec.whatwg.org/#fetch-processresponseendofbody">https://fetch.spec.whatwg.org/#fetch-processresponseendofbody</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-processresponseendofbody">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request">
-   <a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request" class="dfn-panel" data-for="term-for-concept-request" id="infopanel-for-term-for-concept-request" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request" style="display:none">Info about the 'request' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request">https://fetch.spec.whatwg.org/#concept-request</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response">
-   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response" class="dfn-panel" data-for="term-for-concept-response" id="infopanel-for-term-for-concept-response" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response" style="display:none">Info about the 'response' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-bodyinit-safely-extract">
-   <a href="https://fetch.spec.whatwg.org/#bodyinit-safely-extract">https://fetch.spec.whatwg.org/#bodyinit-safely-extract</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-bodyinit-safely-extract" class="dfn-panel" data-for="term-for-bodyinit-safely-extract" id="infopanel-for-term-for-bodyinit-safely-extract" role="menu">
+   <span id="infopaneltitle-for-term-for-bodyinit-safely-extract" style="display:none">Info about the 'safely extract' external reference.</span><a href="https://fetch.spec.whatwg.org/#bodyinit-safely-extract">https://fetch.spec.whatwg.org/#bodyinit-safely-extract</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bodyinit-safely-extract">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-set">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-set">https://fetch.spec.whatwg.org/#concept-header-list-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-set" class="dfn-panel" data-for="term-for-concept-header-list-set" id="infopanel-for-term-for-concept-header-list-set" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-set" style="display:none">Info about the 'set' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-set">https://fetch.spec.whatwg.org/#concept-header-list-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-set">3.5.6. The send() method</a> <a href="#ref-for-concept-header-list-set①">(2)</a> <a href="#ref-for-concept-header-list-set②">(3)</a> <a href="#ref-for-concept-header-list-set③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-list-sort-and-combine">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine">https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-list-sort-and-combine" class="dfn-panel" data-for="term-for-concept-header-list-sort-and-combine" id="infopanel-for-term-for-concept-header-list-sort-and-combine" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-list-sort-and-combine" style="display:none">Info about the 'sort and combine' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine">https://fetch.spec.whatwg.org/#concept-header-list-sort-and-combine</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-sort-and-combine">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status" class="dfn-panel" data-for="term-for-concept-response-status" id="infopanel-for-term-for-concept-response-status" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status" style="display:none">Info about the 'status' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status">https://fetch.spec.whatwg.org/#concept-response-status</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status">3.6.2. The status getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-status-message">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-status-message">https://fetch.spec.whatwg.org/#concept-response-status-message</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-status-message" class="dfn-panel" data-for="term-for-concept-response-status-message" id="infopanel-for-term-for-concept-response-status-message" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-status-message" style="display:none">Info about the 'status message' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-status-message">https://fetch.spec.whatwg.org/#concept-response-status-message</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-status-message">3.6.3. The statusText getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-unsafe-request-flag">
-   <a href="https://fetch.spec.whatwg.org/#unsafe-request-flag">https://fetch.spec.whatwg.org/#unsafe-request-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-unsafe-request-flag" class="dfn-panel" data-for="term-for-unsafe-request-flag" id="infopanel-for-term-for-unsafe-request-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-unsafe-request-flag" style="display:none">Info about the 'unsafe-request flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#unsafe-request-flag">https://fetch.spec.whatwg.org/#unsafe-request-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-unsafe-request-flag">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-url" class="dfn-panel" data-for="term-for-concept-request-url" id="infopanel-for-term-for-concept-request-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-url" style="display:none">Info about the 'url (for request)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-url">https://fetch.spec.whatwg.org/#concept-request-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-url">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-response-url">
-   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-response-url" class="dfn-panel" data-for="term-for-concept-response-url" id="infopanel-for-term-for-concept-response-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-response-url" style="display:none">Info about the 'url (for response)' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-response-url">3.6.1. The responseURL getter</a>
     <li><a href="#ref-for-concept-response-url①">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-use-cors-preflight-flag">
-   <a href="https://fetch.spec.whatwg.org/#use-cors-preflight-flag">https://fetch.spec.whatwg.org/#use-cors-preflight-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-use-cors-preflight-flag" class="dfn-panel" data-for="term-for-use-cors-preflight-flag" id="infopanel-for-term-for-use-cors-preflight-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-use-cors-preflight-flag" style="display:none">Info about the 'use-cors-preflight flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#use-cors-preflight-flag">https://fetch.spec.whatwg.org/#use-cors-preflight-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-use-cors-preflight-flag">3.5. Request</a>
     <li><a href="#ref-for-use-cors-preflight-flag①">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag">
-   <a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" class="dfn-panel" data-for="term-for-concept-request-use-url-credentials-flag" id="infopanel-for-term-for-concept-request-use-url-credentials-flag" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-request-use-url-credentials-flag" style="display:none">Info about the 'use-url-credentials flag' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag">https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-request-use-url-credentials-flag">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fetch-useparallelqueue">
-   <a href="https://fetch.spec.whatwg.org/#fetch-useparallelqueue">https://fetch.spec.whatwg.org/#fetch-useparallelqueue</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fetch-useparallelqueue" class="dfn-panel" data-for="term-for-fetch-useparallelqueue" id="infopanel-for-term-for-fetch-useparallelqueue" role="menu">
+   <span id="infopaneltitle-for-term-for-fetch-useparallelqueue" style="display:none">Info about the 'useparallelqueue' external reference.</span><a href="https://fetch.spec.whatwg.org/#fetch-useparallelqueue">https://fetch.spec.whatwg.org/#fetch-useparallelqueue</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fetch-useparallelqueue">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-header-value">
-   <a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-header-value" class="dfn-panel" data-for="term-for-concept-header-value" id="infopanel-for-term-for-concept-header-value" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-header-value" style="display:none">Info about the 'value' external reference.</span><a href="https://fetch.spec.whatwg.org/#concept-header-value">https://fetch.spec.whatwg.org/#concept-header-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-value">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-concept-header-value①">(2)</a>
     <li><a href="#ref-for-concept-header-value②">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-Blob">
-   <a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-Blob" class="dfn-panel" data-for="term-for-dfn-Blob" id="infopanel-for-term-for-dfn-Blob" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-Blob" style="display:none">Info about the 'Blob' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-Blob">https://w3c.github.io/FileAPI/#dfn-Blob</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-Blob">3.6.9. The response getter</a>
     <li><a href="#ref-for-dfn-Blob①">4. Interface FormData</a> <a href="#ref-for-dfn-Blob②">(2)</a> <a href="#ref-for-dfn-Blob③">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-file">
-   <a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-file" class="dfn-panel" data-for="term-for-dfn-file" id="infopanel-for-term-for-dfn-file" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-file" style="display:none">Info about the 'File' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-file">https://w3c.github.io/FileAPI/#dfn-file</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-file">4. Interface FormData</a> <a href="#ref-for-dfn-file①">(2)</a> <a href="#ref-for-dfn-file②">(3)</a> <a href="#ref-for-dfn-file③">(4)</a> <a href="#ref-for-dfn-file④">(5)</a> <a href="#ref-for-dfn-file⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-name">
-   <a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-name" class="dfn-panel" data-for="term-for-dfn-name" id="infopanel-for-term-for-dfn-name" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-name" style="display:none">Info about the 'name' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-name">https://w3c.github.io/FileAPI/#dfn-name</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-name">4. Interface FormData</a> <a href="#ref-for-dfn-name①">(2)</a> <a href="#ref-for-dfn-name②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-type">
-   <a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-type" class="dfn-panel" data-for="term-for-dfn-type" id="infopanel-for-term-for-dfn-type" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-type" style="display:none">Info about the 'type' external reference.</span><a href="https://w3c.github.io/FileAPI/#dfn-type">https://w3c.github.io/FileAPI/#dfn-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-type">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-eventhandler">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-eventhandler" class="dfn-panel" data-for="term-for-eventhandler" id="infopanel-for-term-for-eventhandler" role="menu">
+   <span id="infopaneltitle-for-term-for-eventhandler" style="display:none">Info about the 'EventHandler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-eventhandler">3. Interface XMLHttpRequest</a> <a href="#ref-for-eventhandler①">(2)</a> <a href="#ref-for-eventhandler②">(3)</a> <a href="#ref-for-eventhandler③">(4)</a> <a href="#ref-for-eventhandler④">(5)</a> <a href="#ref-for-eventhandler⑤">(6)</a> <a href="#ref-for-eventhandler⑥">(7)</a> <a href="#ref-for-eventhandler⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-htmlformelement">
-   <a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-htmlformelement" class="dfn-panel" data-for="term-for-htmlformelement" id="infopanel-for-term-for-htmlformelement" role="menu">
+   <span id="infopaneltitle-for-term-for-htmlformelement" style="display:none">Info about the 'HTMLFormElement' external reference.</span><a href="https://html.spec.whatwg.org/multipage/forms.html#htmlformelement">https://html.spec.whatwg.org/multipage/forms.html#htmlformelement</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-htmlformelement">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">3.5.1. The open() method</a> <a href="#ref-for-window①">(2)</a> <a href="#ref-for-window②">(3)</a>
     <li><a href="#ref-for-window③">3.5.3. The timeout getter and setter</a> <a href="#ref-for-window④">(2)</a>
     <li><a href="#ref-for-window⑤">3.6.8. The responseType getter and setter</a> <a href="#ref-for-window⑥">(2)</a> <a href="#ref-for-window⑦">(3)</a> <a href="#ref-for-window⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-a-known-definite-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#a-known-definite-encoding">https://html.spec.whatwg.org/multipage/parsing.html#a-known-definite-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-known-definite-encoding" class="dfn-panel" data-for="term-for-a-known-definite-encoding" id="infopanel-for-term-for-a-known-definite-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-a-known-definite-encoding" style="display:none">Info about the 'a known definite encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#a-known-definite-encoding">https://html.spec.whatwg.org/multipage/parsing.html#a-known-definite-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-known-definite-encoding">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-base-url">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-base-url" class="dfn-panel" data-for="term-for-api-base-url" id="infopanel-for-term-for-api-base-url" role="menu">
+   <span id="infopaneltitle-for-term-for-api-base-url" style="display:none">Info about the 'api base url' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url">https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-base-url">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-api-url-character-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-api-url-character-encoding" class="dfn-panel" data-for="term-for-api-url-character-encoding" id="infopanel-for-term-for-api-url-character-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-api-url-character-encoding" style="display:none">Info about the 'api url character encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding">https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-api-url-character-encoding">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-constructing-the-form-data-set">
-   <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-constructing-the-form-data-set" class="dfn-panel" data-for="term-for-constructing-the-form-data-set" id="infopanel-for-term-for-constructing-the-form-data-set" role="menu">
+   <span id="infopaneltitle-for-term-for-constructing-the-form-data-set" style="display:none">Info about the 'constructing the entry list' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set">https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-constructing-the-form-data-set">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-current-global-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-current-global-object" class="dfn-panel" data-for="term-for-current-global-object" id="infopanel-for-term-for-current-global-object" role="menu">
+   <span id="infopaneltitle-for-term-for-current-global-object" style="display:none">Info about the 'current global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object">https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-current-global-object">3.5.1. The open() method</a> <a href="#ref-for-current-global-object①">(2)</a> <a href="#ref-for-current-global-object②">(3)</a>
     <li><a href="#ref-for-current-global-object③">3.5.3. The timeout getter and setter</a> <a href="#ref-for-current-global-object④">(2)</a>
     <li><a href="#ref-for-current-global-object⑤">3.6.8. The responseType getter and setter</a> <a href="#ref-for-current-global-object⑥">(2)</a> <a href="#ref-for-current-global-object⑦">(3)</a> <a href="#ref-for-current-global-object⑧">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handlers">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handlers" class="dfn-panel" data-for="term-for-event-handlers" id="infopanel-for-term-for-event-handlers" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handlers" style="display:none">Info about the 'event handler' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handlers">3.3. Event handlers</a> <a href="#ref-for-event-handlers①">(2)</a> <a href="#ref-for-event-handlers②">(3)</a> <a href="#ref-for-event-handlers③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-event-handler-event-type">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-event-handler-event-type" class="dfn-panel" data-for="term-for-event-handler-event-type" id="infopanel-for-term-for-event-handler-event-type" role="menu">
+   <span id="infopaneltitle-for-term-for-event-handler-event-type" style="display:none">Info about the 'event handler event type' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-handler-event-type">3.3. Event handlers</a> <a href="#ref-for-event-handler-event-type①">(2)</a> <a href="#ref-for-event-handler-event-type②">(3)</a> <a href="#ref-for-event-handler-event-type③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-fully-active">
-   <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-fully-active" class="dfn-panel" data-for="term-for-fully-active" id="infopanel-for-term-for-fully-active" role="menu">
+   <span id="infopaneltitle-for-term-for-fully-active" style="display:none">Info about the 'fully active' external reference.</span><a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-fully-active">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-in-parallel">
-   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-in-parallel" class="dfn-panel" data-for="term-for-in-parallel" id="infopanel-for-term-for-in-parallel" role="menu">
+   <span id="infopaneltitle-for-term-for-in-parallel" style="display:none">Info about the 'in parallel' external reference.</span><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-in-parallel">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-settings-object-origin">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-settings-object-origin" class="dfn-panel" data-for="term-for-concept-settings-object-origin" id="infopanel-for-term-for-concept-settings-object-origin" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-settings-object-origin" style="display:none">Info about the 'origin' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin">https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-settings-object-origin">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-pause">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#pause">https://html.spec.whatwg.org/multipage/webappapis.html#pause</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-pause" class="dfn-panel" data-for="term-for-pause" id="infopanel-for-term-for-pause" role="menu">
+   <span id="infopaneltitle-for-term-for-pause" style="display:none">Info about the 'pause' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#pause">https://html.spec.whatwg.org/multipage/webappapis.html#pause</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-pause">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-prescan-a-byte-stream-to-determine-its-encoding">
-   <a href="https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding">https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-prescan-a-byte-stream-to-determine-its-encoding" class="dfn-panel" data-for="term-for-prescan-a-byte-stream-to-determine-its-encoding" id="infopanel-for-term-for-prescan-a-byte-stream-to-determine-its-encoding" role="menu">
+   <span id="infopaneltitle-for-term-for-prescan-a-byte-stream-to-determine-its-encoding" style="display:none">Info about the 'prescan a byte stream to determine its encoding' external reference.</span><a href="https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding">https://html.spec.whatwg.org/multipage/parsing.html#prescan-a-byte-stream-to-determine-its-encoding</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-prescan-a-byte-stream-to-determine-its-encoding">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-the-progress-element">
-   <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-the-progress-element" class="dfn-panel" data-for="term-for-the-progress-element" id="infopanel-for-term-for-the-progress-element" role="menu">
+   <span id="infopaneltitle-for-term-for-the-progress-element" style="display:none">Info about the 'progress' external reference.</span><a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-the-progress-element">5.4. Example</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-relevant-global">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-relevant-global" class="dfn-panel" data-for="term-for-concept-relevant-global" id="infopanel-for-term-for-concept-relevant-global" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-relevant-global" style="display:none">Info about the 'relevant global object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-relevant-global">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-relevant-settings-object">
-   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-relevant-settings-object" class="dfn-panel" data-for="term-for-relevant-settings-object" id="infopanel-for-term-for-relevant-settings-object" role="menu">
+   <span id="infopaneltitle-for-term-for-relevant-settings-object" style="display:none">Info about the 'relevant settings object' external reference.</span><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-relevant-settings-object">3.5.1. The open() method</a>
     <li><a href="#ref-for-relevant-settings-object①">3.5.6. The send() method</a>
     <li><a href="#ref-for-relevant-settings-object②">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-parser">
-   <a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser">https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-parser" class="dfn-panel" data-for="term-for-xml-parser" id="infopanel-for-term-for-xml-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-parser" style="display:none">Info about the 'xml parser' external reference.</span><a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser">https://html.spec.whatwg.org/multipage/xhtml.html#xml-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-parser">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-scripting-support-disabled">
-   <a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-scripting-support-disabled">https://html.spec.whatwg.org/multipage/xhtml.html#xml-scripting-support-disabled</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-scripting-support-disabled" class="dfn-panel" data-for="term-for-xml-scripting-support-disabled" id="infopanel-for-term-for-xml-scripting-support-disabled" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-scripting-support-disabled" style="display:none">Info about the 'xml scripting support disabled' external reference.</span><a href="https://html.spec.whatwg.org/multipage/xhtml.html#xml-scripting-support-disabled">https://html.spec.whatwg.org/multipage/xhtml.html#xml-scripting-support-disabled</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-scripting-support-disabled">3.6.6. Response body</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-append">
-   <a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-append" class="dfn-panel" data-for="term-for-list-append" id="infopanel-for-term-for-list-append" role="menu">
+   <span id="infopaneltitle-for-term-for-list-append" style="display:none">Info about the 'append' external reference.</span><a href="https://infra.spec.whatwg.org/#list-append">https://infra.spec.whatwg.org/#list-append</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-append">4. Interface FormData</a> <a href="#ref-for-list-append①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
-   <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-ascii-case-insensitive" class="dfn-panel" data-for="term-for-ascii-case-insensitive" id="infopanel-for-term-for-ascii-case-insensitive" role="menu">
+   <span id="infopaneltitle-for-term-for-ascii-case-insensitive" style="display:none">Info about the 'ascii case-insensitive' external reference.</span><a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ascii-case-insensitive">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-less-than">
-   <a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-less-than" class="dfn-panel" data-for="term-for-byte-less-than" id="infopanel-for-term-for-byte-less-than" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-less-than" style="display:none">Info about the 'byte less than' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-less-than">https://infra.spec.whatwg.org/#byte-less-than</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-less-than">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence" class="dfn-panel" data-for="term-for-byte-sequence" id="infopanel-for-term-for-byte-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence" style="display:none">Info about the 'byte sequence' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence">https://infra.spec.whatwg.org/#byte-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-byte-sequence①">3.5.6. The send() method</a>
     <li><a href="#ref-for-byte-sequence②">3.6.5. The getAllResponseHeaders() method</a> <a href="#ref-for-byte-sequence③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-uppercase">
-   <a href="https://infra.spec.whatwg.org/#byte-uppercase">https://infra.spec.whatwg.org/#byte-uppercase</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-uppercase" class="dfn-panel" data-for="term-for-byte-uppercase" id="infopanel-for-term-for-byte-uppercase" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-uppercase" style="display:none">Info about the 'byte-uppercase' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-uppercase">https://infra.spec.whatwg.org/#byte-uppercase</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-uppercase">3.6.5. The getAllResponseHeaders() method</a> <a href="#ref-for-byte-uppercase①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-javascript-string-convert">
-   <a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-javascript-string-convert" class="dfn-panel" data-for="term-for-javascript-string-convert" id="infopanel-for-term-for-javascript-string-convert" role="menu">
+   <span id="infopaneltitle-for-term-for-javascript-string-convert" style="display:none">Info about the 'convert' external reference.</span><a href="https://infra.spec.whatwg.org/#javascript-string-convert">https://infra.spec.whatwg.org/#javascript-string-convert</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-javascript-string-convert">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-empty">
-   <a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-empty" class="dfn-panel" data-for="term-for-list-empty" id="infopanel-for-term-for-list-empty" role="menu">
+   <span id="infopaneltitle-for-term-for-list-empty" style="display:none">Info about the 'empty' external reference.</span><a href="https://infra.spec.whatwg.org/#list-empty">https://infra.spec.whatwg.org/#list-empty</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-empty">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-exists">
-   <a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-exists" class="dfn-panel" data-for="term-for-map-exists" id="infopanel-for-term-for-map-exists" role="menu">
+   <span id="infopaneltitle-for-term-for-map-exists" style="display:none">Info about the 'exist' external reference.</span><a href="https://infra.spec.whatwg.org/#map-exists">https://infra.spec.whatwg.org/#map-exists</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-exists">3.5.6. The send() method</a>
     <li><a href="#ref-for-map-exists①">3.6.6. Response body</a> <a href="#ref-for-map-exists②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-iterate">
-   <a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-iterate" class="dfn-panel" data-for="term-for-list-iterate" id="infopanel-for-term-for-list-iterate" role="menu">
+   <span id="infopaneltitle-for-term-for-list-iterate" style="display:none">Info about the 'for each' external reference.</span><a href="https://infra.spec.whatwg.org/#list-iterate">https://infra.spec.whatwg.org/#list-iterate</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-iterate">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-byte-sequence-length">
-   <a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-byte-sequence-length" class="dfn-panel" data-for="term-for-byte-sequence-length" id="infopanel-for-term-for-byte-sequence-length" role="menu">
+   <span id="infopaneltitle-for-term-for-byte-sequence-length" style="display:none">Info about the 'length' external reference.</span><a href="https://infra.spec.whatwg.org/#byte-sequence-length">https://infra.spec.whatwg.org/#byte-sequence-length</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-byte-sequence-length">3.5.6. The send() method</a> <a href="#ref-for-byte-sequence-length①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list">
-   <a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list" class="dfn-panel" data-for="term-for-list" id="infopanel-for-term-for-list" role="menu">
+   <span id="infopaneltitle-for-term-for-list" style="display:none">Info about the 'list' external reference.</span><a href="https://infra.spec.whatwg.org/#list">https://infra.spec.whatwg.org/#list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-json-bytes-to-a-javascript-value">
-   <a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-json-bytes-to-a-javascript-value" class="dfn-panel" data-for="term-for-parse-json-bytes-to-a-javascript-value" id="infopanel-for-term-for-parse-json-bytes-to-a-javascript-value" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-json-bytes-to-a-javascript-value" style="display:none">Info about the 'parse json from bytes' external reference.</span><a href="https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value">https://infra.spec.whatwg.org/#parse-json-bytes-to-a-javascript-value</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-json-bytes-to-a-javascript-value">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-remove">
-   <a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-remove" class="dfn-panel" data-for="term-for-list-remove" id="infopanel-for-term-for-list-remove" role="menu">
+   <span id="infopaneltitle-for-term-for-list-remove" style="display:none">Info about the 'remove' external reference.</span><a href="https://infra.spec.whatwg.org/#list-remove">https://infra.spec.whatwg.org/#list-remove</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-remove">4. Interface FormData</a> <a href="#ref-for-list-remove①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-replace">
-   <a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-replace" class="dfn-panel" data-for="term-for-list-replace" id="infopanel-for-term-for-list-replace" role="menu">
+   <span id="infopaneltitle-for-term-for-list-replace" style="display:none">Info about the 'replace' external reference.</span><a href="https://infra.spec.whatwg.org/#list-replace">https://infra.spec.whatwg.org/#list-replace</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-replace">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-map-set">
-   <a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-map-set" class="dfn-panel" data-for="term-for-map-set" id="infopanel-for-term-for-map-set" role="menu">
+   <span id="infopaneltitle-for-term-for-map-set" style="display:none">Info about the 'set' external reference.</span><a href="https://infra.spec.whatwg.org/#map-set">https://infra.spec.whatwg.org/#map-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-map-set">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-list-sort-in-ascending-order">
-   <a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-list-sort-in-ascending-order" class="dfn-panel" data-for="term-for-list-sort-in-ascending-order" id="infopanel-for-term-for-list-sort-in-ascending-order" role="menu">
+   <span id="infopaneltitle-for-term-for-list-sort-in-ascending-order" style="display:none">Info about the 'sorting' external reference.</span><a href="https://infra.spec.whatwg.org/#list-sort-in-ascending-order">https://infra.spec.whatwg.org/#list-sort-in-ascending-order</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-list-sort-in-ascending-order">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-html-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#html-mime-type">https://mimesniff.spec.whatwg.org/#html-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-html-mime-type" class="dfn-panel" data-for="term-for-html-mime-type" id="infopanel-for-term-for-html-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-html-mime-type" style="display:none">Info about the 'html mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#html-mime-type">https://mimesniff.spec.whatwg.org/#html-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-html-mime-type">3.6.6. Response body</a> <a href="#ref-for-html-mime-type①">(2)</a> <a href="#ref-for-html-mime-type②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-mime-type" class="dfn-panel" data-for="term-for-mime-type" id="infopanel-for-term-for-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-mime-type" style="display:none">Info about the 'mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#mime-type">https://mimesniff.spec.whatwg.org/#mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-mime-type">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parameters">
-   <a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parameters" class="dfn-panel" data-for="term-for-parameters" id="infopanel-for-term-for-parameters" role="menu">
+   <span id="infopaneltitle-for-term-for-parameters" style="display:none">Info about the 'parameters' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parameters">https://mimesniff.spec.whatwg.org/#parameters</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parameters">3.5.6. The send() method</a> <a href="#ref-for-parameters①">(2)</a> <a href="#ref-for-parameters②">(3)</a>
     <li><a href="#ref-for-parameters③">3.6.6. Response body</a> <a href="#ref-for-parameters④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-mime-type" class="dfn-panel" data-for="term-for-parse-a-mime-type" id="infopanel-for-term-for-parse-a-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-mime-type" style="display:none">Info about the 'parse a mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type">https://mimesniff.spec.whatwg.org/#parse-a-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type">3.6.7. The overrideMimeType() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-parse-a-mime-type-from-bytes">
-   <a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type-from-bytes">https://mimesniff.spec.whatwg.org/#parse-a-mime-type-from-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-parse-a-mime-type-from-bytes" class="dfn-panel" data-for="term-for-parse-a-mime-type-from-bytes" id="infopanel-for-term-for-parse-a-mime-type-from-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-parse-a-mime-type-from-bytes" style="display:none">Info about the 'parse a mime type from bytes' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#parse-a-mime-type-from-bytes">https://mimesniff.spec.whatwg.org/#parse-a-mime-type-from-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-a-mime-type-from-bytes">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-serialize-a-mime-type-to-bytes">
-   <a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-serialize-a-mime-type-to-bytes" class="dfn-panel" data-for="term-for-serialize-a-mime-type-to-bytes" id="infopanel-for-term-for-serialize-a-mime-type-to-bytes" role="menu">
+   <span id="infopaneltitle-for-term-for-serialize-a-mime-type-to-bytes" style="display:none">Info about the 'serialize a mime type to bytes' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes">https://mimesniff.spec.whatwg.org/#serialize-a-mime-type-to-bytes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-serialize-a-mime-type-to-bytes">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-xml-mime-type">
-   <a href="https://mimesniff.spec.whatwg.org/#xml-mime-type">https://mimesniff.spec.whatwg.org/#xml-mime-type</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-xml-mime-type" class="dfn-panel" data-for="term-for-xml-mime-type" id="infopanel-for-term-for-xml-mime-type" role="menu">
+   <span id="infopaneltitle-for-term-for-xml-mime-type" style="display:none">Info about the 'xml mime type' external reference.</span><a href="https://mimesniff.spec.whatwg.org/#xml-mime-type">https://mimesniff.spec.whatwg.org/#xml-mime-type</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xml-mime-type">3.6.6. Response body</a> <a href="#ref-for-xml-mime-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-host">
-   <a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-host" class="dfn-panel" data-for="term-for-concept-url-host" id="infopanel-for-term-for-concept-url-host" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-host" style="display:none">Info about the 'host' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-host">https://url.spec.whatwg.org/#concept-url-host</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-host">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-include-credentials">
-   <a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-include-credentials" class="dfn-panel" data-for="term-for-include-credentials" id="infopanel-for-term-for-include-credentials" role="menu">
+   <span id="infopaneltitle-for-term-for-include-credentials" style="display:none">Info about the 'includes credentials' external reference.</span><a href="https://url.spec.whatwg.org/#include-credentials">https://url.spec.whatwg.org/#include-credentials</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-include-credentials">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-password">
-   <a href="https://url.spec.whatwg.org/#set-the-password">https://url.spec.whatwg.org/#set-the-password</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-password" class="dfn-panel" data-for="term-for-set-the-password" id="infopanel-for-term-for-set-the-password" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-password" style="display:none">Info about the 'set the password' external reference.</span><a href="https://url.spec.whatwg.org/#set-the-password">https://url.spec.whatwg.org/#set-the-password</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-password">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-set-the-username">
-   <a href="https://url.spec.whatwg.org/#set-the-username">https://url.spec.whatwg.org/#set-the-username</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-set-the-username" class="dfn-panel" data-for="term-for-set-the-username" id="infopanel-for-term-for-set-the-username" role="menu">
+   <span id="infopaneltitle-for-term-for-set-the-username" style="display:none">Info about the 'set the username' external reference.</span><a href="https://url.spec.whatwg.org/#set-the-username">https://url.spec.whatwg.org/#set-the-username</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-set-the-username">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url">
-   <a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url" class="dfn-panel" data-for="term-for-concept-url" id="infopanel-for-term-for-concept-url" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url" style="display:none">Info about the 'url' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url">https://url.spec.whatwg.org/#concept-url</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-parser">
-   <a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-parser" class="dfn-panel" data-for="term-for-concept-url-parser" id="infopanel-for-term-for-concept-url-parser" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-parser" style="display:none">Info about the 'url parser' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-parser">https://url.spec.whatwg.org/#concept-url-parser</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-parser">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-concept-url-serializer">
-   <a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-concept-url-serializer" class="dfn-panel" data-for="term-for-concept-url-serializer" id="infopanel-for-term-for-concept-url-serializer" role="menu">
+   <span id="infopaneltitle-for-term-for-concept-url-serializer" style="display:none">Info about the 'url serializer' external reference.</span><a href="https://url.spec.whatwg.org/#concept-url-serializer">https://url.spec.whatwg.org/#concept-url-serializer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-url-serializer">3.6.1. The responseURL getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-aborterror">
-   <a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-aborterror" class="dfn-panel" data-for="term-for-aborterror" id="infopanel-for-term-for-aborterror" role="menu">
+   <span id="infopaneltitle-for-term-for-aborterror" style="display:none">Info about the 'AbortError' external reference.</span><a href="https://webidl.spec.whatwg.org/#aborterror">https://webidl.spec.whatwg.org/#aborterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-aborterror">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ArrayBuffer">
-   <a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ArrayBuffer" class="dfn-panel" data-for="term-for-idl-ArrayBuffer" id="infopanel-for-term-for-idl-ArrayBuffer" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ArrayBuffer" style="display:none">Info about the 'ArrayBuffer' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ArrayBuffer">https://webidl.spec.whatwg.org/#idl-ArrayBuffer</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ArrayBuffer">3.6.9. The response getter</a> <a href="#ref-for-idl-ArrayBuffer①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-ByteString">
-   <a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-ByteString" class="dfn-panel" data-for="term-for-idl-ByteString" id="infopanel-for-term-for-idl-ByteString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-ByteString" style="display:none">Info about the 'ByteString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-ByteString">https://webidl.spec.whatwg.org/#idl-ByteString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-ByteString">3. Interface XMLHttpRequest</a> <a href="#ref-for-idl-ByteString①">(2)</a> <a href="#ref-for-idl-ByteString②">(3)</a> <a href="#ref-for-idl-ByteString③">(4)</a> <a href="#ref-for-idl-ByteString④">(5)</a> <a href="#ref-for-idl-ByteString⑤">(6)</a> <a href="#ref-for-idl-ByteString⑥">(7)</a> <a href="#ref-for-idl-ByteString⑦">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMException" class="dfn-panel" data-for="term-for-idl-DOMException" id="infopanel-for-term-for-idl-DOMException" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMException" style="display:none">Info about the 'DOMException' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">3.5.1. The open() method</a> <a href="#ref-for-idl-DOMException①">(2)</a> <a href="#ref-for-idl-DOMException②">(3)</a> <a href="#ref-for-idl-DOMException③">(4)</a> <a href="#ref-for-idl-DOMException④">(5)</a> <a href="#ref-for-idl-DOMException⑤">(6)</a> <a href="#ref-for-idl-DOMException⑥">(7)</a> <a href="#ref-for-idl-DOMException⑦">(8)</a> <a href="#ref-for-idl-DOMException⑧">(9)</a>
     <li><a href="#ref-for-idl-DOMException⑨">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-idl-DOMException①⓪">(2)</a> <a href="#ref-for-idl-DOMException①①">(3)</a> <a href="#ref-for-idl-DOMException①②">(4)</a> <a href="#ref-for-idl-DOMException①③">(5)</a>
@@ -3334,31 +3334,31 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-idl-DOMException③⑥">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-idl-DOMString①">5. Interface ProgressEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">3. Interface XMLHttpRequest</a> <a href="#ref-for-Exposed①">(2)</a> <a href="#ref-for-Exposed②">(3)</a> <a href="#ref-for-Exposed③">(4)</a>
     <li><a href="#ref-for-Exposed④">4. Interface FormData</a>
     <li><a href="#ref-for-Exposed⑤">5. Interface ProgressEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidaccesserror">
-   <a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidaccesserror" class="dfn-panel" data-for="term-for-invalidaccesserror" id="infopanel-for-term-for-invalidaccesserror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidaccesserror" style="display:none">Info about the 'InvalidAccessError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidaccesserror">https://webidl.spec.whatwg.org/#invalidaccesserror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidaccesserror">3.5.1. The open() method</a> <a href="#ref-for-invalidaccesserror①">(2)</a> <a href="#ref-for-invalidaccesserror②">(3)</a>
     <li><a href="#ref-for-invalidaccesserror③">3.5.3. The timeout getter and setter</a> <a href="#ref-for-invalidaccesserror④">(2)</a>
     <li><a href="#ref-for-invalidaccesserror⑤">3.6.8. The responseType getter and setter</a> <a href="#ref-for-invalidaccesserror⑥">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-invalidstateerror">
-   <a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-invalidstateerror" class="dfn-panel" data-for="term-for-invalidstateerror" id="infopanel-for-term-for-invalidstateerror" role="menu">
+   <span id="infopaneltitle-for-term-for-invalidstateerror" style="display:none">Info about the 'InvalidStateError' external reference.</span><a href="https://webidl.spec.whatwg.org/#invalidstateerror">https://webidl.spec.whatwg.org/#invalidstateerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-invalidstateerror">3.5.1. The open() method</a>
     <li><a href="#ref-for-invalidstateerror①">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-invalidstateerror②">(2)</a> <a href="#ref-for-invalidstateerror③">(3)</a>
@@ -3371,75 +3371,75 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-invalidstateerror①⑧">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-networkerror">
-   <a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-networkerror" class="dfn-panel" data-for="term-for-networkerror" id="infopanel-for-term-for-networkerror" role="menu">
+   <span id="infopaneltitle-for-term-for-networkerror" style="display:none">Info about the 'NetworkError' external reference.</span><a href="https://webidl.spec.whatwg.org/#networkerror">https://webidl.spec.whatwg.org/#networkerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-networkerror">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-SameObject">
-   <a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-SameObject" class="dfn-panel" data-for="term-for-SameObject" id="infopanel-for-term-for-SameObject" role="menu">
+   <span id="infopaneltitle-for-term-for-SameObject" style="display:none">Info about the 'SameObject' external reference.</span><a href="https://webidl.spec.whatwg.org/#SameObject">https://webidl.spec.whatwg.org/#SameObject</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SameObject">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-securityerror">
-   <a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-securityerror" class="dfn-panel" data-for="term-for-securityerror" id="infopanel-for-term-for-securityerror" role="menu">
+   <span id="infopaneltitle-for-term-for-securityerror" style="display:none">Info about the 'SecurityError' external reference.</span><a href="https://webidl.spec.whatwg.org/#securityerror">https://webidl.spec.whatwg.org/#securityerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-securityerror">3.5.1. The open() method</a> <a href="#ref-for-securityerror①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-syntaxerror">
-   <a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-syntaxerror" class="dfn-panel" data-for="term-for-syntaxerror" id="infopanel-for-term-for-syntaxerror" role="menu">
+   <span id="infopaneltitle-for-term-for-syntaxerror" style="display:none">Info about the 'SyntaxError' external reference.</span><a href="https://webidl.spec.whatwg.org/#syntaxerror">https://webidl.spec.whatwg.org/#syntaxerror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-syntaxerror">3.5.1. The open() method</a> <a href="#ref-for-syntaxerror①">(2)</a> <a href="#ref-for-syntaxerror②">(3)</a>
     <li><a href="#ref-for-syntaxerror③">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-syntaxerror④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-timeouterror">
-   <a href="https://webidl.spec.whatwg.org/#timeouterror">https://webidl.spec.whatwg.org/#timeouterror</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-timeouterror" class="dfn-panel" data-for="term-for-timeouterror" id="infopanel-for-term-for-timeouterror" role="menu">
+   <span id="infopaneltitle-for-term-for-timeouterror" style="display:none">Info about the 'TimeoutError' external reference.</span><a href="https://webidl.spec.whatwg.org/#timeouterror">https://webidl.spec.whatwg.org/#timeouterror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeouterror">3.5.3. The timeout getter and setter</a>
     <li><a href="#ref-for-timeouterror①">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-USVString" class="dfn-panel" data-for="term-for-idl-USVString" id="infopanel-for-term-for-idl-USVString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-USVString" style="display:none">Info about the 'USVString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">3. Interface XMLHttpRequest</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a> <a href="#ref-for-idl-USVString④">(5)</a> <a href="#ref-for-idl-USVString⑤">(6)</a>
     <li><a href="#ref-for-idl-USVString⑥">3.5.6. The send() method</a>
     <li><a href="#ref-for-idl-USVString⑦">4. Interface FormData</a> <a href="#ref-for-idl-USVString⑧">(2)</a> <a href="#ref-for-idl-USVString⑨">(3)</a> <a href="#ref-for-idl-USVString①⓪">(4)</a> <a href="#ref-for-idl-USVString①①">(5)</a> <a href="#ref-for-idl-USVString①②">(6)</a> <a href="#ref-for-idl-USVString①③">(7)</a> <a href="#ref-for-idl-USVString①④">(8)</a> <a href="#ref-for-idl-USVString①⑤">(9)</a> <a href="#ref-for-idl-USVString①⑥">(10)</a> <a href="#ref-for-idl-USVString①⑦">(11)</a> <a href="#ref-for-idl-USVString①⑧">(12)</a> <a href="#ref-for-idl-USVString①⑨">(13)</a> <a href="#ref-for-idl-USVString②⓪">(14)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">3. Interface XMLHttpRequest</a> <a href="#ref-for-idl-boolean①">(2)</a>
     <li><a href="#ref-for-idl-boolean②">4. Interface FormData</a>
     <li><a href="#ref-for-idl-boolean③">5. Interface ProgressEvent</a> <a href="#ref-for-idl-boolean④">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-new">
-   <a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-new" class="dfn-panel" data-for="term-for-new" id="infopanel-for-term-for-new" role="menu">
+   <span id="infopaneltitle-for-term-for-new" style="display:none">Info about the 'new' external reference.</span><a href="https://webidl.spec.whatwg.org/#new">https://webidl.spec.whatwg.org/#new</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-new">3.1. Constructors</a>
     <li><a href="#ref-for-new①">3.6.9. The response getter</a> <a href="#ref-for-new②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-this">
-   <a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-this" class="dfn-panel" data-for="term-for-this" id="infopanel-for-term-for-this" role="menu">
+   <span id="infopaneltitle-for-term-for-this" style="display:none">Info about the 'this' external reference.</span><a href="https://webidl.spec.whatwg.org/#this">https://webidl.spec.whatwg.org/#this</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-this">3.1. Constructors</a>
     <li><a href="#ref-for-this①">3.4. States</a>
@@ -3463,8 +3463,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-this①⑤①">4. Interface FormData</a> <a href="#ref-for-this①⑤②">(2)</a> <a href="#ref-for-this①⑤③">(3)</a> <a href="#ref-for-this①⑤④">(4)</a> <a href="#ref-for-this①⑤⑤">(5)</a> <a href="#ref-for-this①⑤⑥">(6)</a> <a href="#ref-for-this①⑤⑦">(7)</a> <a href="#ref-for-this①⑤⑧">(8)</a> <a href="#ref-for-this①⑤⑨">(9)</a> <a href="#ref-for-this①⑥⓪">(10)</a> <a href="#ref-for-this①⑥①">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-throw">
-   <a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-throw" class="dfn-panel" data-for="term-for-dfn-throw" id="infopanel-for-term-for-dfn-throw" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-throw" style="display:none">Info about the 'throw' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-throw">https://webidl.spec.whatwg.org/#dfn-throw</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-throw">3.5.1. The open() method</a> <a href="#ref-for-dfn-throw①">(2)</a> <a href="#ref-for-dfn-throw②">(3)</a> <a href="#ref-for-dfn-throw③">(4)</a> <a href="#ref-for-dfn-throw④">(5)</a> <a href="#ref-for-dfn-throw⑤">(6)</a>
     <li><a href="#ref-for-dfn-throw⑥">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-dfn-throw⑦">(2)</a> <a href="#ref-for-dfn-throw⑧">(3)</a>
@@ -3478,33 +3478,33 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dfn-throw②①">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">3. Interface XMLHttpRequest</a> <a href="#ref-for-idl-undefined①">(2)</a> <a href="#ref-for-idl-undefined②">(3)</a> <a href="#ref-for-idl-undefined③">(4)</a> <a href="#ref-for-idl-undefined④">(5)</a> <a href="#ref-for-idl-undefined⑤">(6)</a>
     <li><a href="#ref-for-idl-undefined⑥">4. Interface FormData</a> <a href="#ref-for-idl-undefined⑦">(2)</a> <a href="#ref-for-idl-undefined⑧">(3)</a> <a href="#ref-for-idl-undefined⑨">(4)</a> <a href="#ref-for-idl-undefined①⓪">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long-long" class="dfn-panel" data-for="term-for-idl-unsigned-long-long" id="infopanel-for-term-for-idl-unsigned-long-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long-long" style="display:none">Info about the 'unsigned long long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long-long">https://webidl.spec.whatwg.org/#idl-unsigned-long-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long-long">5. Interface ProgressEvent</a> <a href="#ref-for-idl-unsigned-long-long①">(2)</a> <a href="#ref-for-idl-unsigned-long-long②">(3)</a> <a href="#ref-for-idl-unsigned-long-long③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-short" class="dfn-panel" data-for="term-for-idl-unsigned-short" id="infopanel-for-term-for-idl-unsigned-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-short" style="display:none">Info about the 'unsigned short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-short">https://webidl.spec.whatwg.org/#idl-unsigned-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-short">3. Interface XMLHttpRequest</a> <a href="#ref-for-idl-unsigned-short①">(2)</a> <a href="#ref-for-idl-unsigned-short②">(3)</a> <a href="#ref-for-idl-unsigned-short③">(4)</a> <a href="#ref-for-idl-unsigned-short④">(5)</a> <a href="#ref-for-idl-unsigned-short⑤">(6)</a> <a href="#ref-for-idl-unsigned-short⑥">(7)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over">
-   <a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" class="dfn-panel" data-for="term-for-dfn-value-pairs-to-iterate-over" id="infopanel-for-term-for-dfn-value-pairs-to-iterate-over" role="menu">
+   <span id="infopaneltitle-for-term-for-dfn-value-pairs-to-iterate-over" style="display:none">Info about the 'value pairs to iterate over' external reference.</span><a href="https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over">https://webidl.spec.whatwg.org/#dfn-value-pairs-to-iterate-over</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn-value-pairs-to-iterate-over">4. Interface FormData</a>
    </ul>
@@ -3826,15 +3826,15 @@ if ("serviceWorker" in navigator) {
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="xmlhttprequesteventtarget">
-   <b><a href="#xmlhttprequesteventtarget">#xmlhttprequesteventtarget</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmlhttprequesteventtarget" class="dfn-panel" data-for="xmlhttprequesteventtarget" id="infopanel-for-xmlhttprequesteventtarget" role="dialog">
+   <span id="infopaneltitle-for-xmlhttprequesteventtarget" style="display:none">Info about the 'XMLHttpRequestEventTarget' definition.</span><b><a href="#xmlhttprequesteventtarget">#xmlhttprequesteventtarget</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequesteventtarget">3. Interface XMLHttpRequest</a> <a href="#ref-for-xmlhttprequesteventtarget①">(2)</a>
     <li><a href="#ref-for-xmlhttprequesteventtarget②">3.3. Event handlers</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xmlhttprequestupload">
-   <b><a href="#xmlhttprequestupload">#xmlhttprequestupload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmlhttprequestupload" class="dfn-panel" data-for="xmlhttprequestupload" id="infopanel-for-xmlhttprequestupload" role="dialog">
+   <span id="infopaneltitle-for-xmlhttprequestupload" style="display:none">Info about the 'XMLHttpRequestUpload' definition.</span><b><a href="#xmlhttprequestupload">#xmlhttprequestupload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequestupload">3. Interface XMLHttpRequest</a> <a href="#ref-for-xmlhttprequestupload①">(2)</a>
     <li><a href="#ref-for-xmlhttprequestupload②">3.5. Request</a>
@@ -3842,14 +3842,14 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-xmlhttprequestupload④">3.7. Events summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xmlhttprequestresponsetype">
-   <b><a href="#xmlhttprequestresponsetype">#xmlhttprequestresponsetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmlhttprequestresponsetype" class="dfn-panel" data-for="xmlhttprequestresponsetype" id="infopanel-for-xmlhttprequestresponsetype" role="dialog">
+   <span id="infopaneltitle-for-xmlhttprequestresponsetype" style="display:none">Info about the 'XMLHttpRequestResponseType' definition.</span><b><a href="#xmlhttprequestresponsetype">#xmlhttprequestresponsetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequestresponsetype">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="xmlhttprequest">
-   <b><a href="#xmlhttprequest">#xmlhttprequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-xmlhttprequest" class="dfn-panel" data-for="xmlhttprequest" id="infopanel-for-xmlhttprequest" role="dialog">
+   <span id="infopaneltitle-for-xmlhttprequest" style="display:none">Info about the 'XMLHttpRequest' definition.</span><b><a href="#xmlhttprequest">#xmlhttprequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-xmlhttprequest">1. Introduction</a> <a href="#ref-for-xmlhttprequest①">(2)</a>
     <li><a href="#ref-for-xmlhttprequest②">1.1. Specification history</a> <a href="#ref-for-xmlhttprequest③">(2)</a> <a href="#ref-for-xmlhttprequest④">(3)</a>
@@ -3865,16 +3865,16 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-xmlhttprequest②④">Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upload-object">
-   <b><a href="#upload-object">#upload-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upload-object" class="dfn-panel" data-for="upload-object" id="infopanel-for-upload-object" role="dialog">
+   <span id="infopaneltitle-for-upload-object" style="display:none">Info about the 'upload object' definition.</span><b><a href="#upload-object">#upload-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upload-object">3.1. Constructors</a>
     <li><a href="#ref-for-upload-object①">3.5.5. The upload getter</a>
     <li><a href="#ref-for-upload-object②">3.5.6. The send() method</a> <a href="#ref-for-upload-object③">(2)</a> <a href="#ref-for-upload-object④">(3)</a> <a href="#ref-for-upload-object⑤">(4)</a> <a href="#ref-for-upload-object⑥">(5)</a> <a href="#ref-for-upload-object⑦">(6)</a> <a href="#ref-for-upload-object⑧">(7)</a> <a href="#ref-for-upload-object⑨">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-xmlhttprequest-state">
-   <b><a href="#concept-xmlhttprequest-state">#concept-xmlhttprequest-state</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-xmlhttprequest-state" class="dfn-panel" data-for="concept-xmlhttprequest-state" id="infopanel-for-concept-xmlhttprequest-state" role="dialog">
+   <span id="infopaneltitle-for-concept-xmlhttprequest-state" style="display:none">Info about the 'state' definition.</span><b><a href="#concept-xmlhttprequest-state">#concept-xmlhttprequest-state</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-xmlhttprequest-state">3.2. Garbage collection</a>
     <li><a href="#ref-for-concept-xmlhttprequest-state①">3.4. States</a> <a href="#ref-for-concept-xmlhttprequest-state②">(2)</a>
@@ -3890,8 +3890,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-concept-xmlhttprequest-state②⑨">3.6.11. The responseXML getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="send-flag">
-   <b><a href="#send-flag">#send-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-send-flag" class="dfn-panel" data-for="send-flag" id="infopanel-for-send-flag" role="dialog">
+   <span id="infopaneltitle-for-send-flag" style="display:none">Info about the 'send() flag' definition.</span><b><a href="#send-flag">#send-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-send-flag">3.2. Garbage collection</a>
     <li><a href="#ref-for-send-flag①">3.5.1. The open() method</a>
@@ -3901,51 +3901,51 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-send-flag①③">3.5.7. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timeout">
-   <b><a href="#timeout">#timeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timeout" class="dfn-panel" data-for="timeout" id="infopanel-for-timeout" role="dialog">
+   <span id="infopaneltitle-for-timeout" style="display:none">Info about the 'timeout' definition.</span><b><a href="#timeout">#timeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timeout">3.5.1. The open() method</a>
     <li><a href="#ref-for-timeout①">3.5.3. The timeout getter and setter</a> <a href="#ref-for-timeout②">(2)</a>
     <li><a href="#ref-for-timeout③">3.5.6. The send() method</a> <a href="#ref-for-timeout④">(2)</a> <a href="#ref-for-timeout⑤">(3)</a> <a href="#ref-for-timeout⑥">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="cross-origin-credentials">
-   <b><a href="#cross-origin-credentials">#cross-origin-credentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-cross-origin-credentials" class="dfn-panel" data-for="cross-origin-credentials" id="infopanel-for-cross-origin-credentials" role="dialog">
+   <span id="infopaneltitle-for-cross-origin-credentials" style="display:none">Info about the 'cross-origin credentials' definition.</span><b><a href="#cross-origin-credentials">#cross-origin-credentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cross-origin-credentials">3.5.4. The withCredentials getter and setter</a> <a href="#ref-for-cross-origin-credentials①">(2)</a>
     <li><a href="#ref-for-cross-origin-credentials②">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-method">
-   <b><a href="#request-method">#request-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-method" class="dfn-panel" data-for="request-method" id="infopanel-for-request-method" role="dialog">
+   <span id="infopaneltitle-for-request-method" style="display:none">Info about the 'request method' definition.</span><b><a href="#request-method">#request-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-method">3.5.1. The open() method</a> <a href="#ref-for-request-method①">(2)</a>
     <li><a href="#ref-for-request-method②">3.5.6. The send() method</a> <a href="#ref-for-request-method③">(2)</a> <a href="#ref-for-request-method④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-url">
-   <b><a href="#request-url">#request-url</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-url" class="dfn-panel" data-for="request-url" id="infopanel-for-request-url" role="dialog">
+   <span id="infopaneltitle-for-request-url" style="display:none">Info about the 'request URL' definition.</span><b><a href="#request-url">#request-url</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-url">3.5.1. The open() method</a> <a href="#ref-for-request-url①">(2)</a>
     <li><a href="#ref-for-request-url②">3.5.6. The send() method</a> <a href="#ref-for-request-url③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="author-request-headers">
-   <b><a href="#author-request-headers">#author-request-headers</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-author-request-headers" class="dfn-panel" data-for="author-request-headers" id="infopanel-for-author-request-headers" role="dialog">
+   <span id="infopaneltitle-for-author-request-headers" style="display:none">Info about the 'author request headers' definition.</span><b><a href="#author-request-headers">#author-request-headers</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-author-request-headers">3.5.1. The open() method</a>
     <li><a href="#ref-for-author-request-headers①">3.5.2. The setRequestHeader() method</a> <a href="#ref-for-author-request-headers②">(2)</a>
     <li><a href="#ref-for-author-request-headers③">3.5.6. The send() method</a> <a href="#ref-for-author-request-headers④">(2)</a> <a href="#ref-for-author-request-headers⑤">(3)</a> <a href="#ref-for-author-request-headers⑥">(4)</a> <a href="#ref-for-author-request-headers⑦">(5)</a> <a href="#ref-for-author-request-headers⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-body">
-   <b><a href="#request-body">#request-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-body" class="dfn-panel" data-for="request-body" id="infopanel-for-request-body" role="dialog">
+   <span id="infopaneltitle-for-request-body" style="display:none">Info about the 'request body' definition.</span><b><a href="#request-body">#request-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-body">3.5.6. The send() method</a> <a href="#ref-for-request-body①">(2)</a> <a href="#ref-for-request-body②">(3)</a> <a href="#ref-for-request-body③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="synchronous-flag">
-   <b><a href="#synchronous-flag">#synchronous-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-synchronous-flag" class="dfn-panel" data-for="synchronous-flag" id="infopanel-for-synchronous-flag" role="dialog">
+   <span id="infopaneltitle-for-synchronous-flag" style="display:none">Info about the 'synchronous flag' definition.</span><b><a href="#synchronous-flag">#synchronous-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-synchronous-flag">3.5.1. The open() method</a> <a href="#ref-for-synchronous-flag①">(2)</a> <a href="#ref-for-synchronous-flag②">(3)</a>
     <li><a href="#ref-for-synchronous-flag③">3.5.3. The timeout getter and setter</a> <a href="#ref-for-synchronous-flag④">(2)</a> <a href="#ref-for-synchronous-flag⑤">(3)</a>
@@ -3953,28 +3953,28 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-synchronous-flag①①">3.6.8. The responseType getter and setter</a> <a href="#ref-for-synchronous-flag①②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upload-complete-flag">
-   <b><a href="#upload-complete-flag">#upload-complete-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upload-complete-flag" class="dfn-panel" data-for="upload-complete-flag" id="infopanel-for-upload-complete-flag" role="dialog">
+   <span id="infopaneltitle-for-upload-complete-flag" style="display:none">Info about the 'upload complete flag' definition.</span><b><a href="#upload-complete-flag">#upload-complete-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upload-complete-flag">3.5.6. The send() method</a> <a href="#ref-for-upload-complete-flag①">(2)</a> <a href="#ref-for-upload-complete-flag②">(3)</a> <a href="#ref-for-upload-complete-flag③">(4)</a> <a href="#ref-for-upload-complete-flag④">(5)</a> <a href="#ref-for-upload-complete-flag⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="upload-listener-flag">
-   <b><a href="#upload-listener-flag">#upload-listener-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-upload-listener-flag" class="dfn-panel" data-for="upload-listener-flag" id="infopanel-for-upload-listener-flag" role="dialog">
+   <span id="infopaneltitle-for-upload-listener-flag" style="display:none">Info about the 'upload listener flag' definition.</span><b><a href="#upload-listener-flag">#upload-listener-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-upload-listener-flag">3.5. Request</a>
     <li><a href="#ref-for-upload-listener-flag①">3.5.1. The open() method</a>
     <li><a href="#ref-for-upload-listener-flag②">3.5.6. The send() method</a> <a href="#ref-for-upload-listener-flag③">(2)</a> <a href="#ref-for-upload-listener-flag④">(3)</a> <a href="#ref-for-upload-listener-flag⑤">(4)</a> <a href="#ref-for-upload-listener-flag⑥">(5)</a> <a href="#ref-for-upload-listener-flag⑦">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="timed-out-flag">
-   <b><a href="#timed-out-flag">#timed-out-flag</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-timed-out-flag" class="dfn-panel" data-for="timed-out-flag" id="infopanel-for-timed-out-flag" role="dialog">
+   <span id="infopaneltitle-for-timed-out-flag" style="display:none">Info about the 'timed out flag' definition.</span><b><a href="#timed-out-flag">#timed-out-flag</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-timed-out-flag">3.5.6. The send() method</a> <a href="#ref-for-timed-out-flag①">(2)</a> <a href="#ref-for-timed-out-flag②">(3)</a> <a href="#ref-for-timed-out-flag③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response">
-   <b><a href="#response">#response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response" class="dfn-panel" data-for="response" id="infopanel-for-response" role="dialog">
+   <span id="infopaneltitle-for-response" style="display:none">Info about the 'response' definition.</span><b><a href="#response">#response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response">3.5.1. The open() method</a>
     <li><a href="#ref-for-response①">3.5.6. The send() method</a> <a href="#ref-for-response②">(2)</a> <a href="#ref-for-response③">(3)</a> <a href="#ref-for-response④">(4)</a> <a href="#ref-for-response⑤">(5)</a> <a href="#ref-for-response⑥">(6)</a> <a href="#ref-for-response⑦">(7)</a> <a href="#ref-for-response⑧">(8)</a> <a href="#ref-for-response⑨">(9)</a> <a href="#ref-for-response①⓪">(10)</a> <a href="#ref-for-response①①">(11)</a> <a href="#ref-for-response①②">(12)</a>
@@ -3988,8 +3988,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-response②⑤">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="received-bytes">
-   <b><a href="#received-bytes">#received-bytes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-received-bytes" class="dfn-panel" data-for="received-bytes" id="infopanel-for-received-bytes" role="dialog">
+   <span id="infopaneltitle-for-received-bytes" style="display:none">Info about the 'received bytes' definition.</span><b><a href="#received-bytes">#received-bytes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-received-bytes">3.5.1. The open() method</a>
     <li><a href="#ref-for-received-bytes①">3.5.6. The send() method</a> <a href="#ref-for-received-bytes②">(2)</a> <a href="#ref-for-received-bytes③">(3)</a> <a href="#ref-for-received-bytes④">(4)</a>
@@ -3997,8 +3997,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-received-bytes⑨">3.6.9. The response getter</a> <a href="#ref-for-received-bytes①⓪">(2)</a> <a href="#ref-for-received-bytes①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-type">
-   <b><a href="#response-type">#response-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-type" class="dfn-panel" data-for="response-type" id="infopanel-for-response-type" role="dialog">
+   <span id="infopaneltitle-for-response-type" style="display:none">Info about the 'response type' definition.</span><b><a href="#response-type">#response-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-type">3.5.1. The open() method</a>
     <li><a href="#ref-for-response-type①">3.6.6. Response body</a> <a href="#ref-for-response-type②">(2)</a> <a href="#ref-for-response-type③">(3)</a> <a href="#ref-for-response-type④">(4)</a> <a href="#ref-for-response-type⑤">(5)</a>
@@ -4008,8 +4008,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-response-type①④">3.6.11. The responseXML getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-object">
-   <b><a href="#response-object">#response-object</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-object" class="dfn-panel" data-for="response-object" id="infopanel-for-response-object" role="dialog">
+   <span id="infopaneltitle-for-response-object" style="display:none">Info about the 'response object' definition.</span><b><a href="#response-object">#response-object</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-object">3.5.1. The open() method</a>
     <li><a href="#ref-for-response-object①">3.6.6. Response body</a>
@@ -4017,154 +4017,154 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-response-object⑨">3.6.11. The responseXML getter</a> <a href="#ref-for-response-object①⓪">(2)</a> <a href="#ref-for-response-object①①">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="override-mime-type">
-   <b><a href="#override-mime-type">#override-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-override-mime-type" class="dfn-panel" data-for="override-mime-type" id="infopanel-for-override-mime-type" role="dialog">
+   <span id="infopaneltitle-for-override-mime-type" style="display:none">Info about the 'override MIME type' definition.</span><b><a href="#override-mime-type">#override-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-override-mime-type">3.5.1. The open() method</a>
     <li><a href="#ref-for-override-mime-type①">3.6.6. Response body</a> <a href="#ref-for-override-mime-type②">(2)</a> <a href="#ref-for-override-mime-type③">(3)</a>
     <li><a href="#ref-for-override-mime-type④">3.6.7. The overrideMimeType() method</a> <a href="#ref-for-override-mime-type⑤">(2)</a> <a href="#ref-for-override-mime-type⑥">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest">
-   <b><a href="#dom-xmlhttprequest">#dom-xmlhttprequest</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest" class="dfn-panel" data-for="dom-xmlhttprequest" id="infopanel-for-dom-xmlhttprequest" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest" style="display:none">Info about the 'new XMLHttpRequest()' definition.</span><b><a href="#dom-xmlhttprequest">#dom-xmlhttprequest</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest①">3.1. Constructors</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onloadstart">
-   <b><a href="#handler-xhr-onloadstart">#handler-xhr-onloadstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onloadstart" class="dfn-panel" data-for="handler-xhr-onloadstart" id="infopanel-for-handler-xhr-onloadstart" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onloadstart" style="display:none">Info about the 'onloadstart' definition.</span><b><a href="#handler-xhr-onloadstart">#handler-xhr-onloadstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onloadstart">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onprogress">
-   <b><a href="#handler-xhr-onprogress">#handler-xhr-onprogress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onprogress" class="dfn-panel" data-for="handler-xhr-onprogress" id="infopanel-for-handler-xhr-onprogress" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onprogress" style="display:none">Info about the 'onprogress' definition.</span><b><a href="#handler-xhr-onprogress">#handler-xhr-onprogress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onprogress">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onabort">
-   <b><a href="#handler-xhr-onabort">#handler-xhr-onabort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onabort" class="dfn-panel" data-for="handler-xhr-onabort" id="infopanel-for-handler-xhr-onabort" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onabort" style="display:none">Info about the 'onabort' definition.</span><b><a href="#handler-xhr-onabort">#handler-xhr-onabort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onabort">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onerror">
-   <b><a href="#handler-xhr-onerror">#handler-xhr-onerror</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onerror" class="dfn-panel" data-for="handler-xhr-onerror" id="infopanel-for-handler-xhr-onerror" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onerror" style="display:none">Info about the 'onerror' definition.</span><b><a href="#handler-xhr-onerror">#handler-xhr-onerror</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onerror">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onload">
-   <b><a href="#handler-xhr-onload">#handler-xhr-onload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onload" class="dfn-panel" data-for="handler-xhr-onload" id="infopanel-for-handler-xhr-onload" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onload" style="display:none">Info about the 'onload' definition.</span><b><a href="#handler-xhr-onload">#handler-xhr-onload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onload">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-ontimeout">
-   <b><a href="#handler-xhr-ontimeout">#handler-xhr-ontimeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-ontimeout" class="dfn-panel" data-for="handler-xhr-ontimeout" id="infopanel-for-handler-xhr-ontimeout" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-ontimeout" style="display:none">Info about the 'ontimeout' definition.</span><b><a href="#handler-xhr-ontimeout">#handler-xhr-ontimeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-ontimeout">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onloadend">
-   <b><a href="#handler-xhr-onloadend">#handler-xhr-onloadend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onloadend" class="dfn-panel" data-for="handler-xhr-onloadend" id="infopanel-for-handler-xhr-onloadend" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onloadend" style="display:none">Info about the 'onloadend' definition.</span><b><a href="#handler-xhr-onloadend">#handler-xhr-onloadend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onloadend">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handler-xhr-onreadystatechange">
-   <b><a href="#handler-xhr-onreadystatechange">#handler-xhr-onreadystatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handler-xhr-onreadystatechange" class="dfn-panel" data-for="handler-xhr-onreadystatechange" id="infopanel-for-handler-xhr-onreadystatechange" role="dialog">
+   <span id="infopaneltitle-for-handler-xhr-onreadystatechange" style="display:none">Info about the 'onreadystatechange' definition.</span><b><a href="#handler-xhr-onreadystatechange">#handler-xhr-onreadystatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handler-xhr-onreadystatechange">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-readystate">
-   <b><a href="#dom-xmlhttprequest-readystate">#dom-xmlhttprequest-readystate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-readystate" class="dfn-panel" data-for="dom-xmlhttprequest-readystate" id="infopanel-for-dom-xmlhttprequest-readystate" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-readystate" style="display:none">Info about the 'readyState' definition.</span><b><a href="#dom-xmlhttprequest-readystate">#dom-xmlhttprequest-readystate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-readystate">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-readystate①">3.4. States</a>
     <li><a href="#ref-for-dom-xmlhttprequest-readystate②">3.7. Events summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-unsent">
-   <b><a href="#dom-xmlhttprequest-unsent">#dom-xmlhttprequest-unsent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-unsent" class="dfn-panel" data-for="dom-xmlhttprequest-unsent" id="infopanel-for-dom-xmlhttprequest-unsent" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-unsent" style="display:none">Info about the 'UNSENT' definition.</span><b><a href="#dom-xmlhttprequest-unsent">#dom-xmlhttprequest-unsent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-unsent">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-unsent①">3.7. Events summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-opened">
-   <b><a href="#dom-xmlhttprequest-opened">#dom-xmlhttprequest-opened</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-opened" class="dfn-panel" data-for="dom-xmlhttprequest-opened" id="infopanel-for-dom-xmlhttprequest-opened" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-opened" style="display:none">Info about the 'OPENED' definition.</span><b><a href="#dom-xmlhttprequest-opened">#dom-xmlhttprequest-opened</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-opened">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-headers_received">
-   <b><a href="#dom-xmlhttprequest-headers_received">#dom-xmlhttprequest-headers_received</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-headers_received" class="dfn-panel" data-for="dom-xmlhttprequest-headers_received" id="infopanel-for-dom-xmlhttprequest-headers_received" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-headers_received" style="display:none">Info about the 'HEADERS_RECEIVED' definition.</span><b><a href="#dom-xmlhttprequest-headers_received">#dom-xmlhttprequest-headers_received</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-headers_received">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-loading">
-   <b><a href="#dom-xmlhttprequest-loading">#dom-xmlhttprequest-loading</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-loading" class="dfn-panel" data-for="dom-xmlhttprequest-loading" id="infopanel-for-dom-xmlhttprequest-loading" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-loading" style="display:none">Info about the 'LOADING' definition.</span><b><a href="#dom-xmlhttprequest-loading">#dom-xmlhttprequest-loading</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-loading">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-done">
-   <b><a href="#dom-xmlhttprequest-done">#dom-xmlhttprequest-done</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-done" class="dfn-panel" data-for="dom-xmlhttprequest-done" id="infopanel-for-dom-xmlhttprequest-done" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-done" style="display:none">Info about the 'DONE' definition.</span><b><a href="#dom-xmlhttprequest-done">#dom-xmlhttprequest-done</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-done">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-open">
-   <b><a href="#dom-xmlhttprequest-open">#dom-xmlhttprequest-open</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-open" class="dfn-panel" data-for="dom-xmlhttprequest-open" id="infopanel-for-dom-xmlhttprequest-open" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-open" style="display:none">Info about the 'open(method, url)' definition.</span><b><a href="#dom-xmlhttprequest-open">#dom-xmlhttprequest-open</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-open">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-open①">3.4. States</a>
     <li><a href="#ref-for-dom-xmlhttprequest-open②">3.5.1. The open() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-open-method-url-async-username-password">
-   <b><a href="#dom-xmlhttprequest-open-method-url-async-username-password">#dom-xmlhttprequest-open-method-url-async-username-password</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-open-method-url-async-username-password" class="dfn-panel" data-for="dom-xmlhttprequest-open-method-url-async-username-password" id="infopanel-for-dom-xmlhttprequest-open-method-url-async-username-password" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-open-method-url-async-username-password" style="display:none">Info about the 'open(method, url, async, username, password)' definition.</span><b><a href="#dom-xmlhttprequest-open-method-url-async-username-password">#dom-xmlhttprequest-open-method-url-async-username-password</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-open-method-url-async-username-password">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-setrequestheader">
-   <b><a href="#dom-xmlhttprequest-setrequestheader">#dom-xmlhttprequest-setrequestheader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-setrequestheader" class="dfn-panel" data-for="dom-xmlhttprequest-setrequestheader" id="infopanel-for-dom-xmlhttprequest-setrequestheader" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-setrequestheader" style="display:none">Info about the 'setRequestHeader(name, value)' definition.</span><b><a href="#dom-xmlhttprequest-setrequestheader">#dom-xmlhttprequest-setrequestheader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-setrequestheader">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-setrequestheader①">3.4. States</a>
     <li><a href="#ref-for-dom-xmlhttprequest-setrequestheader②">3.5.2. The setRequestHeader() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-timeout">
-   <b><a href="#dom-xmlhttprequest-timeout">#dom-xmlhttprequest-timeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-timeout" class="dfn-panel" data-for="dom-xmlhttprequest-timeout" id="infopanel-for-dom-xmlhttprequest-timeout" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-timeout" style="display:none">Info about the 'timeout' definition.</span><b><a href="#dom-xmlhttprequest-timeout">#dom-xmlhttprequest-timeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-timeout">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-timeout①">3.5.1. The open() method</a>
     <li><a href="#ref-for-dom-xmlhttprequest-timeout②">3.5.3. The timeout getter and setter</a> <a href="#ref-for-dom-xmlhttprequest-timeout③">(2)</a> <a href="#ref-for-dom-xmlhttprequest-timeout④">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-withcredentials">
-   <b><a href="#dom-xmlhttprequest-withcredentials">#dom-xmlhttprequest-withcredentials</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-withcredentials" class="dfn-panel" data-for="dom-xmlhttprequest-withcredentials" id="infopanel-for-dom-xmlhttprequest-withcredentials" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-withcredentials" style="display:none">Info about the 'withCredentials' definition.</span><b><a href="#dom-xmlhttprequest-withcredentials">#dom-xmlhttprequest-withcredentials</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-withcredentials">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-withcredentials①">3.5.4. The withCredentials getter and setter</a> <a href="#ref-for-dom-xmlhttprequest-withcredentials②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-upload">
-   <b><a href="#dom-xmlhttprequest-upload">#dom-xmlhttprequest-upload</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-upload" class="dfn-panel" data-for="dom-xmlhttprequest-upload" id="infopanel-for-dom-xmlhttprequest-upload" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-upload" style="display:none">Info about the 'upload' definition.</span><b><a href="#dom-xmlhttprequest-upload">#dom-xmlhttprequest-upload</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-upload">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-upload①">3.5.5. The upload getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-send">
-   <b><a href="#dom-xmlhttprequest-send">#dom-xmlhttprequest-send</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-send" class="dfn-panel" data-for="dom-xmlhttprequest-send" id="infopanel-for-dom-xmlhttprequest-send" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-send" style="display:none">Info about the 'send(body)' definition.</span><b><a href="#dom-xmlhttprequest-send">#dom-xmlhttprequest-send</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-send">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-send①">3.4. States</a>
@@ -4172,111 +4172,111 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dom-xmlhttprequest-send③">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-response-end-of-body">
-   <b><a href="#handle-response-end-of-body">#handle-response-end-of-body</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-response-end-of-body" class="dfn-panel" data-for="handle-response-end-of-body" id="infopanel-for-handle-response-end-of-body" role="dialog">
+   <span id="infopaneltitle-for-handle-response-end-of-body" style="display:none">Info about the 'handle response end-of-body' definition.</span><b><a href="#handle-response-end-of-body">#handle-response-end-of-body</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-response-end-of-body">3.5.6. The send() method</a> <a href="#ref-for-handle-response-end-of-body①">(2)</a> <a href="#ref-for-handle-response-end-of-body②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="handle-errors">
-   <b><a href="#handle-errors">#handle-errors</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-handle-errors" class="dfn-panel" data-for="handle-errors" id="infopanel-for-handle-errors" role="dialog">
+   <span id="infopaneltitle-for-handle-errors" style="display:none">Info about the 'handle errors' definition.</span><b><a href="#handle-errors">#handle-errors</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-handle-errors">3.5.6. The send() method</a> <a href="#ref-for-handle-errors①">(2)</a> <a href="#ref-for-handle-errors②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="request-error-steps">
-   <b><a href="#request-error-steps">#request-error-steps</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-request-error-steps" class="dfn-panel" data-for="request-error-steps" id="infopanel-for-request-error-steps" role="dialog">
+   <span id="infopaneltitle-for-request-error-steps" style="display:none">Info about the 'request error steps' definition.</span><b><a href="#request-error-steps">#request-error-steps</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-request-error-steps">3.5.6. The send() method</a> <a href="#ref-for-request-error-steps①">(2)</a> <a href="#ref-for-request-error-steps②">(3)</a>
     <li><a href="#ref-for-request-error-steps③">3.5.7. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-abort">
-   <b><a href="#dom-xmlhttprequest-abort">#dom-xmlhttprequest-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-abort" class="dfn-panel" data-for="dom-xmlhttprequest-abort" id="infopanel-for-dom-xmlhttprequest-abort" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-abort" style="display:none">Info about the 'abort()' definition.</span><b><a href="#dom-xmlhttprequest-abort">#dom-xmlhttprequest-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-abort">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-abort①">3.5.7. The abort() method</a>
     <li><a href="#ref-for-dom-xmlhttprequest-abort②">3.7. Events summary</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-responseurl">
-   <b><a href="#dom-xmlhttprequest-responseurl">#dom-xmlhttprequest-responseurl</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-responseurl" class="dfn-panel" data-for="dom-xmlhttprequest-responseurl" id="infopanel-for-dom-xmlhttprequest-responseurl" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-responseurl" style="display:none">Info about the 'responseURL' definition.</span><b><a href="#dom-xmlhttprequest-responseurl">#dom-xmlhttprequest-responseurl</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-responseurl">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-status">
-   <b><a href="#dom-xmlhttprequest-status">#dom-xmlhttprequest-status</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-status" class="dfn-panel" data-for="dom-xmlhttprequest-status" id="infopanel-for-dom-xmlhttprequest-status" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-status" style="display:none">Info about the 'status' definition.</span><b><a href="#dom-xmlhttprequest-status">#dom-xmlhttprequest-status</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-status">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-statustext">
-   <b><a href="#dom-xmlhttprequest-statustext">#dom-xmlhttprequest-statustext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-statustext" class="dfn-panel" data-for="dom-xmlhttprequest-statustext" id="infopanel-for-dom-xmlhttprequest-statustext" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-statustext" style="display:none">Info about the 'statusText' definition.</span><b><a href="#dom-xmlhttprequest-statustext">#dom-xmlhttprequest-statustext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-statustext">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-getresponseheader">
-   <b><a href="#dom-xmlhttprequest-getresponseheader">#dom-xmlhttprequest-getresponseheader</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-getresponseheader" class="dfn-panel" data-for="dom-xmlhttprequest-getresponseheader" id="infopanel-for-dom-xmlhttprequest-getresponseheader" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-getresponseheader" style="display:none">Info about the 'getResponseHeader(name)' definition.</span><b><a href="#dom-xmlhttprequest-getresponseheader">#dom-xmlhttprequest-getresponseheader</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-getresponseheader">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="legacy-uppercased-byte-less-than">
-   <b><a href="#legacy-uppercased-byte-less-than">#legacy-uppercased-byte-less-than</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-legacy-uppercased-byte-less-than" class="dfn-panel" data-for="legacy-uppercased-byte-less-than" id="infopanel-for-legacy-uppercased-byte-less-than" role="dialog">
+   <span id="infopaneltitle-for-legacy-uppercased-byte-less-than" style="display:none">Info about the 'legacy-uppercased-byte less than' definition.</span><b><a href="#legacy-uppercased-byte-less-than">#legacy-uppercased-byte-less-than</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-legacy-uppercased-byte-less-than">3.6.5. The getAllResponseHeaders() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-getallresponseheaders">
-   <b><a href="#dom-xmlhttprequest-getallresponseheaders">#dom-xmlhttprequest-getallresponseheaders</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-getallresponseheaders" class="dfn-panel" data-for="dom-xmlhttprequest-getallresponseheaders" id="infopanel-for-dom-xmlhttprequest-getallresponseheaders" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-getallresponseheaders" style="display:none">Info about the 'getAllResponseHeaders()' definition.</span><b><a href="#dom-xmlhttprequest-getallresponseheaders">#dom-xmlhttprequest-getallresponseheaders</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-getallresponseheaders">3. Interface XMLHttpRequest</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-mime-type">
-   <b><a href="#response-mime-type">#response-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-response-mime-type" class="dfn-panel" data-for="response-mime-type" id="infopanel-for-response-mime-type" role="dialog">
+   <span id="infopaneltitle-for-response-mime-type" style="display:none">Info about the 'get a response MIME type' definition.</span><b><a href="#response-mime-type">#response-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-response-mime-type">3.6.6. Response body</a> <a href="#ref-for-response-mime-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="final-mime-type">
-   <b><a href="#final-mime-type">#final-mime-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-final-mime-type" class="dfn-panel" data-for="final-mime-type" id="infopanel-for-final-mime-type" role="dialog">
+   <span id="infopaneltitle-for-final-mime-type" style="display:none">Info about the 'get a final MIME type' definition.</span><b><a href="#final-mime-type">#final-mime-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-final-mime-type">3.6.6. Response body</a> <a href="#ref-for-final-mime-type①">(2)</a> <a href="#ref-for-final-mime-type②">(3)</a>
     <li><a href="#ref-for-final-mime-type③">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="final-charset">
-   <b><a href="#final-charset">#final-charset</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-final-charset" class="dfn-panel" data-for="final-charset" id="infopanel-for-final-charset" role="dialog">
+   <span id="infopaneltitle-for-final-charset" style="display:none">Info about the 'get a final encoding' definition.</span><b><a href="#final-charset">#final-charset</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-final-charset">3.6.6. Response body</a> <a href="#ref-for-final-charset①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-response">
-   <b><a href="#document-response">#document-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-document-response" class="dfn-panel" data-for="document-response" id="infopanel-for-document-response" role="dialog">
+   <span id="infopaneltitle-for-document-response" style="display:none">Info about the 'set a document response' definition.</span><b><a href="#document-response">#document-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document-response">3.6.9. The response getter</a>
     <li><a href="#ref-for-document-response①">3.6.11. The responseXML getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="text-response">
-   <b><a href="#text-response">#text-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-text-response" class="dfn-panel" data-for="text-response" id="infopanel-for-text-response" role="dialog">
+   <span id="infopaneltitle-for-text-response" style="display:none">Info about the 'get a text response' definition.</span><b><a href="#text-response">#text-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-text-response">3.6.9. The response getter</a>
     <li><a href="#ref-for-text-response①">3.6.10. The responseText getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-overridemimetype">
-   <b><a href="#dom-xmlhttprequest-overridemimetype">#dom-xmlhttprequest-overridemimetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-overridemimetype" class="dfn-panel" data-for="dom-xmlhttprequest-overridemimetype" id="infopanel-for-dom-xmlhttprequest-overridemimetype" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-overridemimetype" style="display:none">Info about the 'overrideMimeType(mime)' definition.</span><b><a href="#dom-xmlhttprequest-overridemimetype">#dom-xmlhttprequest-overridemimetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-overridemimetype">3. Interface XMLHttpRequest</a> <a href="#ref-for-dom-xmlhttprequest-overridemimetype①">(2)</a>
     <li><a href="#ref-for-dom-xmlhttprequest-overridemimetype②">3.6.7. The overrideMimeType() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-responsetype">
-   <b><a href="#dom-xmlhttprequest-responsetype">#dom-xmlhttprequest-responsetype</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-responsetype" class="dfn-panel" data-for="dom-xmlhttprequest-responsetype" id="infopanel-for-dom-xmlhttprequest-responsetype" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-responsetype" style="display:none">Info about the 'responseType' definition.</span><b><a href="#dom-xmlhttprequest-responsetype">#dom-xmlhttprequest-responsetype</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-responsetype">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-responsetype①">3.5.1. The open() method</a>
@@ -4285,29 +4285,29 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-dom-xmlhttprequest-responsetype⑤">3.6.11. The responseXML getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-response">
-   <b><a href="#dom-xmlhttprequest-response">#dom-xmlhttprequest-response</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-response" class="dfn-panel" data-for="dom-xmlhttprequest-response" id="infopanel-for-dom-xmlhttprequest-response" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-response" style="display:none">Info about the 'response' definition.</span><b><a href="#dom-xmlhttprequest-response">#dom-xmlhttprequest-response</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-response">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-response①">3.6.9. The response getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-responsetext">
-   <b><a href="#dom-xmlhttprequest-responsetext">#dom-xmlhttprequest-responsetext</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-responsetext" class="dfn-panel" data-for="dom-xmlhttprequest-responsetext" id="infopanel-for-dom-xmlhttprequest-responsetext" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-responsetext" style="display:none">Info about the 'responseText' definition.</span><b><a href="#dom-xmlhttprequest-responsetext">#dom-xmlhttprequest-responsetext</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-responsetext">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-responsetext①">3.6.10. The responseText getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-xmlhttprequest-responsexml">
-   <b><a href="#dom-xmlhttprequest-responsexml">#dom-xmlhttprequest-responsexml</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-xmlhttprequest-responsexml" class="dfn-panel" data-for="dom-xmlhttprequest-responsexml" id="infopanel-for-dom-xmlhttprequest-responsexml" role="dialog">
+   <span id="infopaneltitle-for-dom-xmlhttprequest-responsexml" style="display:none">Info about the 'responseXML' definition.</span><b><a href="#dom-xmlhttprequest-responsexml">#dom-xmlhttprequest-responsexml</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-xmlhttprequest-responsexml">3. Interface XMLHttpRequest</a>
     <li><a href="#ref-for-dom-xmlhttprequest-responsexml①">3.6.11. The responseXML getter</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-readystatechange">
-   <b><a href="#event-xhr-readystatechange">#event-xhr-readystatechange</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-readystatechange" class="dfn-panel" data-for="event-xhr-readystatechange" id="infopanel-for-event-xhr-readystatechange" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-readystatechange" style="display:none">Info about the 'readystatechange' definition.</span><b><a href="#event-xhr-readystatechange">#event-xhr-readystatechange</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-readystatechange">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-readystatechange①">3.3. Event handlers</a>
@@ -4316,15 +4316,15 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-event-xhr-readystatechange⑧">3.5.7. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-loadstart">
-   <b><a href="#event-xhr-loadstart">#event-xhr-loadstart</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-loadstart" class="dfn-panel" data-for="event-xhr-loadstart" id="infopanel-for-event-xhr-loadstart" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-loadstart" style="display:none">Info about the 'loadstart' definition.</span><b><a href="#event-xhr-loadstart">#event-xhr-loadstart</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-loadstart">3.3. Event handlers</a>
     <li><a href="#ref-for-event-xhr-loadstart①">3.5.6. The send() method</a> <a href="#ref-for-event-xhr-loadstart②">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-progress">
-   <b><a href="#event-xhr-progress">#event-xhr-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-progress" class="dfn-panel" data-for="event-xhr-progress" id="infopanel-for-event-xhr-progress" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-progress" style="display:none">Info about the 'progress' definition.</span><b><a href="#event-xhr-progress">#event-xhr-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-progress">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-progress①">3.3. Event handlers</a>
@@ -4332,8 +4332,8 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-event-xhr-progress⑥">5.2. Suggested names for events using the ProgressEvent interface</a> <a href="#ref-for-event-xhr-progress⑦">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-abort">
-   <b><a href="#event-xhr-abort">#event-xhr-abort</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-abort" class="dfn-panel" data-for="event-xhr-abort" id="infopanel-for-event-xhr-abort" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-abort" style="display:none">Info about the 'abort' definition.</span><b><a href="#event-xhr-abort">#event-xhr-abort</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-abort">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-abort①">3.3. Event handlers</a>
@@ -4341,24 +4341,24 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-event-xhr-abort③">3.5.7. The abort() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-error">
-   <b><a href="#event-xhr-error">#event-xhr-error</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-error" class="dfn-panel" data-for="event-xhr-error" id="infopanel-for-event-xhr-error" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-error" style="display:none">Info about the 'error' definition.</span><b><a href="#event-xhr-error">#event-xhr-error</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-error">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-error①">3.3. Event handlers</a>
     <li><a href="#ref-for-event-xhr-error②">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-load">
-   <b><a href="#event-xhr-load">#event-xhr-load</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-load" class="dfn-panel" data-for="event-xhr-load" id="infopanel-for-event-xhr-load" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-load" style="display:none">Info about the 'load' definition.</span><b><a href="#event-xhr-load">#event-xhr-load</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-load">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-load①">3.3. Event handlers</a>
     <li><a href="#ref-for-event-xhr-load②">3.5.6. The send() method</a> <a href="#ref-for-event-xhr-load③">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-timeout">
-   <b><a href="#event-xhr-timeout">#event-xhr-timeout</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-timeout" class="dfn-panel" data-for="event-xhr-timeout" id="infopanel-for-event-xhr-timeout" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-timeout" style="display:none">Info about the 'timeout' definition.</span><b><a href="#event-xhr-timeout">#event-xhr-timeout</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-timeout">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-timeout①">3.3. Event handlers</a>
@@ -4366,112 +4366,112 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-event-xhr-timeout③">3.5.6. The send() method</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="event-xhr-loadend">
-   <b><a href="#event-xhr-loadend">#event-xhr-loadend</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-event-xhr-loadend" class="dfn-panel" data-for="event-xhr-loadend" id="infopanel-for-event-xhr-loadend" role="dialog">
+   <span id="infopaneltitle-for-event-xhr-loadend" style="display:none">Info about the 'loadend' definition.</span><b><a href="#event-xhr-loadend">#event-xhr-loadend</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-event-xhr-loadend">3.2. Garbage collection</a>
     <li><a href="#ref-for-event-xhr-loadend①">3.3. Event handlers</a>
     <li><a href="#ref-for-event-xhr-loadend②">3.5.6. The send() method</a> <a href="#ref-for-event-xhr-loadend③">(2)</a> <a href="#ref-for-event-xhr-loadend④">(3)</a> <a href="#ref-for-event-xhr-loadend⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formdataentryvalue">
-   <b><a href="#formdataentryvalue">#formdataentryvalue</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formdataentryvalue" class="dfn-panel" data-for="formdataentryvalue" id="infopanel-for-formdataentryvalue" role="dialog">
+   <span id="infopaneltitle-for-formdataentryvalue" style="display:none">Info about the 'FormDataEntryValue' definition.</span><b><a href="#formdataentryvalue">#formdataentryvalue</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formdataentryvalue">4. Interface FormData</a> <a href="#ref-for-formdataentryvalue①">(2)</a> <a href="#ref-for-formdataentryvalue②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="formdata">
-   <b><a href="#formdata">#formdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-formdata" class="dfn-panel" data-for="formdata" id="infopanel-for-formdata" role="dialog">
+   <span id="infopaneltitle-for-formdata" style="display:none">Info about the 'FormData' definition.</span><b><a href="#formdata">#formdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-formdata">4. Interface FormData</a> <a href="#ref-for-formdata①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-formdata-entry-list">
-   <b><a href="#concept-formdata-entry-list">#concept-formdata-entry-list</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-formdata-entry-list" class="dfn-panel" data-for="concept-formdata-entry-list" id="infopanel-for-concept-formdata-entry-list" role="dialog">
+   <span id="infopaneltitle-for-concept-formdata-entry-list" style="display:none">Info about the 'entry list' definition.</span><b><a href="#concept-formdata-entry-list">#concept-formdata-entry-list</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-formdata-entry-list">4. Interface FormData</a> <a href="#ref-for-concept-formdata-entry-list①">(2)</a> <a href="#ref-for-concept-formdata-entry-list②">(3)</a> <a href="#ref-for-concept-formdata-entry-list③">(4)</a> <a href="#ref-for-concept-formdata-entry-list④">(5)</a> <a href="#ref-for-concept-formdata-entry-list⑤">(6)</a> <a href="#ref-for-concept-formdata-entry-list⑥">(7)</a> <a href="#ref-for-concept-formdata-entry-list⑦">(8)</a> <a href="#ref-for-concept-formdata-entry-list⑧">(9)</a> <a href="#ref-for-concept-formdata-entry-list⑨">(10)</a> <a href="#ref-for-concept-formdata-entry-list①⓪">(11)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-formdata-entry">
-   <b><a href="#concept-formdata-entry">#concept-formdata-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-formdata-entry" class="dfn-panel" data-for="concept-formdata-entry" id="infopanel-for-concept-formdata-entry" role="dialog">
+   <span id="infopaneltitle-for-concept-formdata-entry" style="display:none">Info about the 'entry' definition.</span><b><a href="#concept-formdata-entry">#concept-formdata-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-formdata-entry">4. Interface FormData</a> <a href="#ref-for-concept-formdata-entry①">(2)</a> <a href="#ref-for-concept-formdata-entry②">(3)</a> <a href="#ref-for-concept-formdata-entry③">(4)</a> <a href="#ref-for-concept-formdata-entry④">(5)</a> <a href="#ref-for-concept-formdata-entry⑤">(6)</a> <a href="#ref-for-concept-formdata-entry⑥">(7)</a> <a href="#ref-for-concept-formdata-entry⑦">(8)</a> <a href="#ref-for-concept-formdata-entry⑧">(9)</a> <a href="#ref-for-concept-formdata-entry⑨">(10)</a> <a href="#ref-for-concept-formdata-entry①⓪">(11)</a> <a href="#ref-for-concept-formdata-entry①①">(12)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-formdata-entry-name">
-   <b><a href="#concept-formdata-entry-name">#concept-formdata-entry-name</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-formdata-entry-name" class="dfn-panel" data-for="concept-formdata-entry-name" id="infopanel-for-concept-formdata-entry-name" role="dialog">
+   <span id="infopaneltitle-for-concept-formdata-entry-name" style="display:none">Info about the 'name' definition.</span><b><a href="#concept-formdata-entry-name">#concept-formdata-entry-name</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-formdata-entry-name">4. Interface FormData</a> <a href="#ref-for-concept-formdata-entry-name①">(2)</a> <a href="#ref-for-concept-formdata-entry-name②">(3)</a> <a href="#ref-for-concept-formdata-entry-name③">(4)</a> <a href="#ref-for-concept-formdata-entry-name④">(5)</a> <a href="#ref-for-concept-formdata-entry-name⑤">(6)</a> <a href="#ref-for-concept-formdata-entry-name⑥">(7)</a> <a href="#ref-for-concept-formdata-entry-name⑦">(8)</a> <a href="#ref-for-concept-formdata-entry-name⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-formdata-entry-value">
-   <b><a href="#concept-formdata-entry-value">#concept-formdata-entry-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-formdata-entry-value" class="dfn-panel" data-for="concept-formdata-entry-value" id="infopanel-for-concept-formdata-entry-value" role="dialog">
+   <span id="infopaneltitle-for-concept-formdata-entry-value" style="display:none">Info about the 'value' definition.</span><b><a href="#concept-formdata-entry-value">#concept-formdata-entry-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-formdata-entry-value">4. Interface FormData</a> <a href="#ref-for-concept-formdata-entry-value①">(2)</a> <a href="#ref-for-concept-formdata-entry-value②">(3)</a> <a href="#ref-for-concept-formdata-entry-value③">(4)</a> <a href="#ref-for-concept-formdata-entry-value④">(5)</a> <a href="#ref-for-concept-formdata-entry-value⑤">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="create-an-entry">
-   <b><a href="#create-an-entry">#create-an-entry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-create-an-entry" class="dfn-panel" data-for="create-an-entry" id="infopanel-for-create-an-entry" role="dialog">
+   <span id="infopaneltitle-for-create-an-entry" style="display:none">Info about the 'create an entry' definition.</span><b><a href="#create-an-entry">#create-an-entry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-create-an-entry">4. Interface FormData</a> <a href="#ref-for-create-an-entry①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata">
-   <b><a href="#dom-formdata">#dom-formdata</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata" class="dfn-panel" data-for="dom-formdata" id="infopanel-for-dom-formdata" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata" style="display:none">Info about the 'new FormData(form)' definition.</span><b><a href="#dom-formdata">#dom-formdata</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-append">
-   <b><a href="#dom-formdata-append">#dom-formdata-append</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-append" class="dfn-panel" data-for="dom-formdata-append" id="infopanel-for-dom-formdata-append" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-append" style="display:none">Info about the 'append(name, value)' definition.</span><b><a href="#dom-formdata-append">#dom-formdata-append</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-append">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-append-blob">
-   <b><a href="#dom-formdata-append-blob">#dom-formdata-append-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-append-blob" class="dfn-panel" data-for="dom-formdata-append-blob" id="infopanel-for-dom-formdata-append-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-append-blob" style="display:none">Info about the 'append(name, blobValue, filename)' definition.</span><b><a href="#dom-formdata-append-blob">#dom-formdata-append-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-append-blob">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-delete">
-   <b><a href="#dom-formdata-delete">#dom-formdata-delete</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-delete" class="dfn-panel" data-for="dom-formdata-delete" id="infopanel-for-dom-formdata-delete" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-delete" style="display:none">Info about the 'delete(name)' definition.</span><b><a href="#dom-formdata-delete">#dom-formdata-delete</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-delete">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-get">
-   <b><a href="#dom-formdata-get">#dom-formdata-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-get" class="dfn-panel" data-for="dom-formdata-get" id="infopanel-for-dom-formdata-get" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-get" style="display:none">Info about the 'get(name)' definition.</span><b><a href="#dom-formdata-get">#dom-formdata-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-get">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-getall">
-   <b><a href="#dom-formdata-getall">#dom-formdata-getall</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-getall" class="dfn-panel" data-for="dom-formdata-getall" id="infopanel-for-dom-formdata-getall" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-getall" style="display:none">Info about the 'getAll(name)' definition.</span><b><a href="#dom-formdata-getall">#dom-formdata-getall</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-getall">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-has">
-   <b><a href="#dom-formdata-has">#dom-formdata-has</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-has" class="dfn-panel" data-for="dom-formdata-has" id="infopanel-for-dom-formdata-has" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-has" style="display:none">Info about the 'has(name)' definition.</span><b><a href="#dom-formdata-has">#dom-formdata-has</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-has">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-set">
-   <b><a href="#dom-formdata-set">#dom-formdata-set</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-set" class="dfn-panel" data-for="dom-formdata-set" id="infopanel-for-dom-formdata-set" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-set" style="display:none">Info about the 'set(name, value)' definition.</span><b><a href="#dom-formdata-set">#dom-formdata-set</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-set">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-formdata-set-blob">
-   <b><a href="#dom-formdata-set-blob">#dom-formdata-set-blob</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-formdata-set-blob" class="dfn-panel" data-for="dom-formdata-set-blob" id="infopanel-for-dom-formdata-set-blob" role="dialog">
+   <span id="infopaneltitle-for-dom-formdata-set-blob" style="display:none">Info about the 'set(name, blobValue, filename)' definition.</span><b><a href="#dom-formdata-set-blob">#dom-formdata-set-blob</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-formdata-set-blob">4. Interface FormData</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="progressevent">
-   <b><a href="#progressevent">#progressevent</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-progressevent" class="dfn-panel" data-for="progressevent" id="infopanel-for-progressevent" role="dialog">
+   <span id="infopaneltitle-for-progressevent" style="display:none">Info about the 'ProgressEvent' definition.</span><b><a href="#progressevent">#progressevent</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-progressevent">3.7. Events summary</a> <a href="#ref-for-progressevent①">(2)</a> <a href="#ref-for-progressevent②">(3)</a> <a href="#ref-for-progressevent③">(4)</a> <a href="#ref-for-progressevent④">(5)</a> <a href="#ref-for-progressevent⑤">(6)</a> <a href="#ref-for-progressevent⑥">(7)</a>
     <li><a href="#ref-for-progressevent⑦">5. Interface ProgressEvent</a> <a href="#ref-for-progressevent⑧">(2)</a>
@@ -4481,92 +4481,148 @@ if ("serviceWorker" in navigator) {
     <li><a href="#ref-for-progressevent①⑤">Acknowledgments</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="progresseventinit">
-   <b><a href="#progresseventinit">#progresseventinit</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-progresseventinit" class="dfn-panel" data-for="progresseventinit" id="infopanel-for-progresseventinit" role="dialog">
+   <span id="infopaneltitle-for-progresseventinit" style="display:none">Info about the 'ProgressEventInit' definition.</span><b><a href="#progresseventinit">#progresseventinit</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-progresseventinit">5. Interface ProgressEvent</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-progressevent-lengthcomputable">
-   <b><a href="#dom-progressevent-lengthcomputable">#dom-progressevent-lengthcomputable</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-progressevent-lengthcomputable" class="dfn-panel" data-for="dom-progressevent-lengthcomputable" id="infopanel-for-dom-progressevent-lengthcomputable" role="dialog">
+   <span id="infopaneltitle-for-dom-progressevent-lengthcomputable" style="display:none">Info about the 'lengthComputable' definition.</span><b><a href="#dom-progressevent-lengthcomputable">#dom-progressevent-lengthcomputable</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-progressevent-lengthcomputable">5. Interface ProgressEvent</a>
     <li><a href="#ref-for-dom-progressevent-lengthcomputable①">5.1. Firing events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-progressevent-loaded">
-   <b><a href="#dom-progressevent-loaded">#dom-progressevent-loaded</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-progressevent-loaded" class="dfn-panel" data-for="dom-progressevent-loaded" id="infopanel-for-dom-progressevent-loaded" role="dialog">
+   <span id="infopaneltitle-for-dom-progressevent-loaded" style="display:none">Info about the 'loaded' definition.</span><b><a href="#dom-progressevent-loaded">#dom-progressevent-loaded</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-progressevent-loaded">5. Interface ProgressEvent</a>
     <li><a href="#ref-for-dom-progressevent-loaded①">5.1. Firing events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-progressevent-total">
-   <b><a href="#dom-progressevent-total">#dom-progressevent-total</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-progressevent-total" class="dfn-panel" data-for="dom-progressevent-total" id="infopanel-for-dom-progressevent-total" role="dialog">
+   <span id="infopaneltitle-for-dom-progressevent-total" style="display:none">Info about the 'total' definition.</span><b><a href="#dom-progressevent-total">#dom-progressevent-total</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-progressevent-total">5. Interface ProgressEvent</a>
     <li><a href="#ref-for-dom-progressevent-total①">5.1. Firing events using the ProgressEvent interface</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="concept-event-fire-progress">
-   <b><a href="#concept-event-fire-progress">#concept-event-fire-progress</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-concept-event-fire-progress" class="dfn-panel" data-for="concept-event-fire-progress" id="infopanel-for-concept-event-fire-progress" role="dialog">
+   <span id="infopaneltitle-for-concept-event-fire-progress" style="display:none">Info about the 'fire a progress event' definition.</span><b><a href="#concept-event-fire-progress">#concept-event-fire-progress</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-event-fire-progress">3.5.6. The send() method</a> <a href="#ref-for-concept-event-fire-progress①">(2)</a> <a href="#ref-for-concept-event-fire-progress②">(3)</a> <a href="#ref-for-concept-event-fire-progress③">(4)</a> <a href="#ref-for-concept-event-fire-progress④">(5)</a> <a href="#ref-for-concept-event-fire-progress⑤">(6)</a> <a href="#ref-for-concept-event-fire-progress⑥">(7)</a> <a href="#ref-for-concept-event-fire-progress⑦">(8)</a> <a href="#ref-for-concept-event-fire-progress⑧">(9)</a> <a href="#ref-for-concept-event-fire-progress⑨">(10)</a> <a href="#ref-for-concept-event-fire-progress①⓪">(11)</a> <a href="#ref-for-concept-event-fire-progress①①">(12)</a> <a href="#ref-for-concept-event-fire-progress①②">(13)</a> <a href="#ref-for-concept-event-fire-progress①③">(14)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl001.html
+++ b/tests/idl001.html
@@ -657,26 +657,26 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-foo-get">get(a)</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-or">or</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">Unnamed section</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
@@ -708,95 +708,151 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-barenum">
-   <b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-barenum" class="dfn-panel" data-for="enumdef-barenum" id="infopanel-for-enumdef-barenum" role="dialog">
+   <span id="infopaneltitle-for-enumdef-barenum" style="display:none">Info about the 'BarEnum' definition.</span><b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-barenum">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the 'Foo' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-foo">
-   <b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-foo" class="dfn-panel" data-for="dom-foo-foo" id="infopanel-for-dom-foo-foo" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-or">
-   <b><a href="#dom-foo-or">#dom-foo-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-or" class="dfn-panel" data-for="dom-foo-or" id="infopanel-for-dom-foo-or" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-or" style="display:none">Info about the '_or' definition.</span><b><a href="#dom-foo-or">#dom-foo-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-or">Unnamed section</a> <a href="#ref-for-dom-foo-or①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-get">
-   <b><a href="#dom-foo-get">#dom-foo-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-get" class="dfn-panel" data-for="dom-foo-get" id="infopanel-for-dom-foo-get" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-get" style="display:none">Info about the 'get' definition.</span><b><a href="#dom-foo-get">#dom-foo-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-get">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-get-a-a">
-   <b><a href="#dom-foo-get-a-a">#dom-foo-get-a-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-get-a-a" class="dfn-panel" data-for="dom-foo-get-a-a" id="infopanel-for-dom-foo-get-a-a" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-get-a-a" style="display:none">Info about the 'a' definition.</span><b><a href="#dom-foo-get-a-a">#dom-foo-get-a-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-get-a-a">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl002.html
+++ b/tests/idl002.html
@@ -650,20 +650,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-foo-baz">baz(qux1, qux2, qux3)</a><span>, in § Unnumbered section</span>
    <li><a href="#foo">Foo</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">Unnamed section</a>
    </ul>
@@ -693,57 +693,113 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </pre>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl003.html
+++ b/tests/idl003.html
@@ -667,20 +667,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-foo-get">get(a)</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-or">or</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">Unnamed section</a>
    </ul>
@@ -715,101 +715,157 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-barenum">
-   <b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-barenum" class="dfn-panel" data-for="enumdef-barenum" id="infopanel-for-enumdef-barenum" role="dialog">
+   <span id="infopaneltitle-for-enumdef-barenum" style="display:none">Info about the 'BarEnum' definition.</span><b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-barenum">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the 'Foo' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-foo">
-   <b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-foo" class="dfn-panel" data-for="dom-foo-foo" id="infopanel-for-dom-foo-foo" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-or">
-   <b><a href="#dom-foo-or">#dom-foo-or</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-or" class="dfn-panel" data-for="dom-foo-or" id="infopanel-for-dom-foo-or" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-or" style="display:none">Info about the '_or' definition.</span><b><a href="#dom-foo-or">#dom-foo-or</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-or">Unnamed section</a> <a href="#ref-for-dom-foo-or①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-get">
-   <b><a href="#dom-foo-get">#dom-foo-get</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-get" class="dfn-panel" data-for="dom-foo-get" id="infopanel-for-dom-foo-get" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-get" style="display:none">Info about the 'get' definition.</span><b><a href="#dom-foo-get">#dom-foo-get</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-get">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-get-a-a">
-   <b><a href="#dom-foo-get-a-a">#dom-foo-get-a-a</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-get-a-a" class="dfn-panel" data-for="dom-foo-get-a-a" id="infopanel-for-dom-foo-get-a-a" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-get-a-a" style="display:none">Info about the 'a' definition.</span><b><a href="#dom-foo-get-a-a">#dom-foo-get-a-a</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-get-a-a">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="namespacedef-foonamespace">
-   <b><a href="#namespacedef-foonamespace">#namespacedef-foonamespace</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namespacedef-foonamespace" class="dfn-panel" data-for="namespacedef-foonamespace" id="infopanel-for-namespacedef-foonamespace" role="dialog">
+   <span id="infopaneltitle-for-namespacedef-foonamespace" style="display:none">Info about the 'FooNamespace' definition.</span><b><a href="#namespacedef-foonamespace">#namespacedef-foonamespace</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-foonamespace">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl004.html
+++ b/tests/idl004.html
@@ -492,65 +492,121 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#this-should-have-one-code">this should have one code</a><span>, in § 1</span>
    <li><a href="#foo">this shouldn’t have a code</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the '1. this shouldn’t have a code' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">1. this shouldn’t have a code</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl005.html
+++ b/tests/idl005.html
@@ -640,26 +640,26 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-foo-method">method(bar)</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-method">method(bar, baz)</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">Unnamed section</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">Unnamed section</a>
    </ul>
@@ -689,71 +689,127 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-foo-foo">
-   <b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-foo" class="dfn-panel" data-for="dom-foo-foo" id="infopanel-for-dom-foo-foo" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-foo" style="display:none">Info about the 'constructor' definition.</span><b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-foo">Unnamed section</a> <a href="#ref-for-dom-foo-foo①">(2)</a> <a href="#ref-for-dom-foo-foo②">(3)</a> <a href="#ref-for-dom-foo-foo③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-baz">
-   <b><a href="#dom-foo-baz">#dom-foo-baz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-baz" class="dfn-panel" data-for="dom-foo-baz" id="infopanel-for-dom-foo-baz" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-baz" style="display:none">Info about the 'baz' definition.</span><b><a href="#dom-foo-baz">#dom-foo-baz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-baz">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl006.html
+++ b/tests/idl006.html
@@ -651,38 +651,38 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#dom-test-member6">member6</a><span>, in § Unnumbered section</span>
    <li><a href="#dictdef-test">test</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">Unnamed section</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-boolean">
-   <a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-boolean" class="dfn-panel" data-for="term-for-idl-boolean" id="infopanel-for-term-for-idl-boolean" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-boolean" style="display:none">Info about the 'boolean' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-boolean">https://webidl.spec.whatwg.org/#idl-boolean</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-boolean">Unnamed section</a> <a href="#ref-for-idl-boolean①">(2)</a> <a href="#ref-for-idl-boolean②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">Unnamed section</a> <a href="#ref-for-idl-long①">(2)</a> <a href="#ref-for-idl-long②">(3)</a> <a href="#ref-for-idl-long③">(4)</a> <a href="#ref-for-idl-long④">(5)</a> <a href="#ref-for-idl-long⑤">(6)</a> <a href="#ref-for-idl-long⑥">(7)</a> <a href="#ref-for-idl-long⑦">(8)</a> <a href="#ref-for-idl-long⑧">(9)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">Unnamed section</a> <a href="#ref-for-idl-record①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">Unnamed section</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
@@ -717,95 +717,151 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="dom-test-member1">
-   <b><a href="#dom-test-member1">#dom-test-member1</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member1" class="dfn-panel" data-for="dom-test-member1" id="infopanel-for-dom-test-member1" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member1" style="display:none">Info about the 'member1' definition.</span><b><a href="#dom-test-member1">#dom-test-member1</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member1">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-test-member2">
-   <b><a href="#dom-test-member2">#dom-test-member2</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member2" class="dfn-panel" data-for="dom-test-member2" id="infopanel-for-dom-test-member2" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member2" style="display:none">Info about the 'member2' definition.</span><b><a href="#dom-test-member2">#dom-test-member2</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member2">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-test-member3">
-   <b><a href="#dom-test-member3">#dom-test-member3</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member3" class="dfn-panel" data-for="dom-test-member3" id="infopanel-for-dom-test-member3" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member3" style="display:none">Info about the 'member3' definition.</span><b><a href="#dom-test-member3">#dom-test-member3</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member3">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-test-member4">
-   <b><a href="#dom-test-member4">#dom-test-member4</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member4" class="dfn-panel" data-for="dom-test-member4" id="infopanel-for-dom-test-member4" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member4" style="display:none">Info about the 'member4' definition.</span><b><a href="#dom-test-member4">#dom-test-member4</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member4">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-test-member5">
-   <b><a href="#dom-test-member5">#dom-test-member5</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member5" class="dfn-panel" data-for="dom-test-member5" id="infopanel-for-dom-test-member5" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member5" style="display:none">Info about the 'member5' definition.</span><b><a href="#dom-test-member5">#dom-test-member5</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member5">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-test-member6">
-   <b><a href="#dom-test-member6">#dom-test-member6</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-test-member6" class="dfn-panel" data-for="dom-test-member6" id="infopanel-for-dom-test-member6" role="dialog">
+   <span id="infopaneltitle-for-dom-test-member6" style="display:none">Info about the 'member6' definition.</span><b><a href="#dom-test-member6">#dom-test-member6</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-test-member6">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/idl007.html
+++ b/tests/idl007.html
@@ -666,74 +666,74 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#foo">Foo</a><span>, in § Unnumbered section</span>
    <li><a href="#dom-foo-foo">foo(a, b, c)</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-window">
-   <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-window" class="dfn-panel" data-for="term-for-window" id="infopanel-for-term-for-window" role="menu">
+   <span id="infopaneltitle-for-term-for-window" style="display:none">Info about the 'Window' external reference.</span><a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#window">https://html.spec.whatwg.org/multipage/nav-history-apis.html#window</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-window">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-worker" class="dfn-panel" data-for="term-for-worker" id="infopanel-for-term-for-worker" role="menu">
+   <span id="infopaneltitle-for-term-for-worker" style="display:none">Info about the 'Worker' external reference.</span><a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-worker">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Clamp">
-   <a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Clamp" class="dfn-panel" data-for="term-for-Clamp" id="infopanel-for-term-for-Clamp" role="menu">
+   <span id="infopaneltitle-for-term-for-Clamp" style="display:none">Info about the 'Clamp' external reference.</span><a href="https://webidl.spec.whatwg.org/#Clamp">https://webidl.spec.whatwg.org/#Clamp</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Clamp">Unnamed section</a> <a href="#ref-for-Clamp①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a> <a href="#ref-for-idl-DOMString①">(2)</a> <a href="#ref-for-idl-DOMString②">(3)</a> <a href="#ref-for-idl-DOMString③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">Unnamed section</a> <a href="#ref-for-Exposed①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-promise" class="dfn-panel" data-for="term-for-idl-promise" id="infopanel-for-term-for-idl-promise" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-promise" style="display:none">Info about the 'Promise' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">Unnamed section</a> <a href="#ref-for-idl-promise①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-any">
-   <a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-any" class="dfn-panel" data-for="term-for-idl-any" id="infopanel-for-term-for-idl-any" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-any" style="display:none">Info about the 'any' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-any">https://webidl.spec.whatwg.org/#idl-any</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-any">Unnamed section</a> <a href="#ref-for-idl-any①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-record">
-   <a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-record" class="dfn-panel" data-for="term-for-idl-record" id="infopanel-for-term-for-idl-record" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-record" style="display:none">Info about the 'record' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-record">https://webidl.spec.whatwg.org/#idl-record</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-record">Unnamed section</a> <a href="#ref-for-idl-record①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">Unnamed section</a> <a href="#ref-for-idl-sequence①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-short">
-   <a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-short" class="dfn-panel" data-for="term-for-idl-short" id="infopanel-for-term-for-idl-short" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-short" style="display:none">Info about the 'short' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-short">https://webidl.spec.whatwg.org/#idl-short</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-short">Unnamed section</a> <a href="#ref-for-idl-short①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-undefined">
-   <a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-undefined" class="dfn-panel" data-for="term-for-idl-undefined" id="infopanel-for-term-for-idl-undefined" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-undefined" style="display:none">Info about the 'undefined' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-undefined">https://webidl.spec.whatwg.org/#idl-undefined</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-undefined">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-unsigned-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-unsigned-long" class="dfn-panel" data-for="term-for-idl-unsigned-long" id="infopanel-for-term-for-idl-unsigned-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-unsigned-long" style="display:none">Info about the 'unsigned long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-unsigned-long">https://webidl.spec.whatwg.org/#idl-unsigned-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-unsigned-long">Unnamed section</a> <a href="#ref-for-idl-unsigned-long①">(2)</a> <a href="#ref-for-idl-unsigned-long②">(3)</a> <a href="#ref-for-idl-unsigned-long③">(4)</a>
    </ul>
@@ -780,71 +780,127 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="enumdef-barenum">
-   <b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-enumdef-barenum" class="dfn-panel" data-for="enumdef-barenum" id="infopanel-for-enumdef-barenum" role="dialog">
+   <span id="infopaneltitle-for-enumdef-barenum" style="display:none">Info about the 'BarEnum' definition.</span><b><a href="#enumdef-barenum">#enumdef-barenum</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-enumdef-barenum">Unnamed section</a> <a href="#ref-for-enumdef-barenum①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-foo">
-   <b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-foo" class="dfn-panel" data-for="dom-foo-foo" id="infopanel-for-dom-foo-foo" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#dom-foo-foo">#dom-foo-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-foo">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/index002.html
+++ b/tests/index002.html
@@ -493,14 +493,14 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="dfn" href="https://drafts.csswg.org/css-flexbox-1/#flex-container" id="ref-for-flex-container">flex container</a> <a class="property css" data-link-type="property" href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change" id="ref-for-propdef-will-change">will-change</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-propdef-will-change">
-   <a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-propdef-will-change" class="dfn-panel" data-for="term-for-propdef-will-change" id="infopanel-for-term-for-propdef-will-change" role="menu">
+   <span id="infopaneltitle-for-term-for-propdef-will-change" style="display:none">Info about the 'will-change' external reference.</span><a href="https://drafts.csswg.org/css-will-change-1/#propdef-will-change">https://drafts.csswg.org/css-will-change-1/#propdef-will-change</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-will-change">Unnamed section</a>
    </ul>
@@ -528,57 +528,113 @@ dfn > a.self-link::before      { content: "#"; }
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/index003.html
+++ b/tests/index003.html
@@ -493,8 +493,8 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="dfn" href="https://example.test/foo/#term" id="ref-for-term">term</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-term">
-   <a href="https://example.test/foo/#term">https://example.test/foo/#term</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-term" class="dfn-panel" data-for="term-for-term" id="infopanel-for-term-for-term" role="menu">
+   <span id="infopaneltitle-for-term-for-term" style="display:none">Info about the 'term' external reference.</span><a href="https://example.test/foo/#term">https://example.test/foo/#term</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-term">Unnamed section</a>
    </ul>
@@ -515,57 +515,113 @@ dfn > a.self-link::before      { content: "#"; }
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/link-shorthands001.html
+++ b/tests/link-shorthands001.html
@@ -629,233 +629,289 @@ dfn > a.self-link::before      { content: "#"; }
     </ul>
    <li><a href="#attr-valuedef-element-attribute-val-with-spaces">val with spaces</a><span>, in § 1</span>
   </ul>
-  <aside class="dfn-panel" data-for="propdef-property">
-   <b><a href="#propdef-property">#propdef-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-property" class="dfn-panel" data-for="propdef-property" id="infopanel-for-propdef-property" role="dialog">
+   <span id="infopaneltitle-for-propdef-property" style="display:none">Info about the 'property' definition.</span><b><a href="#propdef-property">#propdef-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-property">1. Test</a> <a href="#ref-for-propdef-property①">(2)</a> <a href="#ref-for-propdef-property②">(3)</a> <a href="#ref-for-propdef-property③">(4)</a> <a href="#ref-for-propdef-property④">(5)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descdef-at-rule-descriptor">
-   <b><a href="#descdef-at-rule-descriptor">#descdef-at-rule-descriptor</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descdef-at-rule-descriptor" class="dfn-panel" data-for="descdef-at-rule-descriptor" id="infopanel-for-descdef-at-rule-descriptor" role="dialog">
+   <span id="infopaneltitle-for-descdef-at-rule-descriptor" style="display:none">Info about the 'descriptor' definition.</span><b><a href="#descdef-at-rule-descriptor">#descdef-at-rule-descriptor</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descdef-at-rule-descriptor">1. Test</a> <a href="#ref-for-descdef-at-rule-descriptor①">(2)</a> <a href="#ref-for-descdef-at-rule-descriptor②">(3)</a> <a href="#ref-for-descdef-at-rule-descriptor③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="at-ruledef-at-rule">
-   <b><a href="#at-ruledef-at-rule">#at-ruledef-at-rule</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-at-ruledef-at-rule" class="dfn-panel" data-for="at-ruledef-at-rule" id="infopanel-for-at-ruledef-at-rule" role="dialog">
+   <span id="infopaneltitle-for-at-ruledef-at-rule" style="display:none">Info about the '@at-rule' definition.</span><b><a href="#at-ruledef-at-rule">#at-ruledef-at-rule</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-at-ruledef-at-rule">1. Test</a> <a href="#ref-for-at-ruledef-at-rule①">(2)</a> <a href="#ref-for-at-ruledef-at-rule②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="typedef-type">
-   <b><a href="#typedef-type">#typedef-type</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-typedef-type" class="dfn-panel" data-for="typedef-type" id="infopanel-for-typedef-type" role="dialog">
+   <span id="infopaneltitle-for-typedef-type" style="display:none">Info about the '&lt;type>' definition.</span><b><a href="#typedef-type">#typedef-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-type">1. Test</a> <a href="#ref-for-typedef-type①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="funcdef-function">
-   <b><a href="#funcdef-function">#funcdef-function</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-funcdef-function" class="dfn-panel" data-for="funcdef-function" id="infopanel-for-funcdef-function" role="dialog">
+   <span id="infopaneltitle-for-funcdef-function" style="display:none">Info about the 'function(foo)' definition.</span><b><a href="#funcdef-function">#funcdef-function</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-funcdef-function">1. Test</a> <a href="#ref-for-funcdef-function①">(2)</a> <a href="#ref-for-funcdef-function②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="property-value">
-   <b><a href="#property-value">#property-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-property-value" class="dfn-panel" data-for="property-value" id="infopanel-for-property-value" role="dialog">
+   <span id="infopaneltitle-for-property-value" style="display:none">Info about the 'value for property' definition.</span><b><a href="#property-value">#property-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-property-value">1. Test</a> <a href="#ref-for-property-value①">(2)</a> <a href="#ref-for-property-value②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="descriptor-value">
-   <b><a href="#descriptor-value">#descriptor-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-descriptor-value" class="dfn-panel" data-for="descriptor-value" id="infopanel-for-descriptor-value" role="dialog">
+   <span id="infopaneltitle-for-descriptor-value" style="display:none">Info about the 'value for descriptor' definition.</span><b><a href="#descriptor-value">#descriptor-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-descriptor-value">1. Test</a> <a href="#ref-for-descriptor-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="type-value">
-   <b><a href="#type-value">#type-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-type-value" class="dfn-panel" data-for="type-value" id="infopanel-for-type-value" role="dialog">
+   <span id="infopaneltitle-for-type-value" style="display:none">Info about the 'value for &lt;type>' definition.</span><b><a href="#type-value">#type-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-type-value">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-property-property">
-   <b><a href="#valdef-property-property">#valdef-property-property</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-property-property" class="dfn-panel" data-for="valdef-property-property" id="infopanel-for-valdef-property-property" role="dialog">
+   <span id="infopaneltitle-for-valdef-property-property" style="display:none">Info about the 'value named "property"' definition.</span><b><a href="#valdef-property-property">#valdef-property-property</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-property-property">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-property-different-value">
-   <b><a href="#valdef-property-different-value">#valdef-property-different-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-property-different-value" class="dfn-panel" data-for="valdef-property-different-value" id="infopanel-for-valdef-property-different-value" role="dialog">
+   <span id="infopaneltitle-for-valdef-property-different-value" style="display:none">Info about the 'different-value' definition.</span><b><a href="#valdef-property-different-value">#valdef-property-different-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-property-different-value">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-property-bang">
-   <b><a href="#valdef-property-bang">#valdef-property-bang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-property-bang" class="dfn-panel" data-for="valdef-property-bang" id="infopanel-for-valdef-property-bang" role="dialog">
+   <span id="infopaneltitle-for-valdef-property-bang" style="display:none">Info about the '!bang' definition.</span><b><a href="#valdef-property-bang">#valdef-property-bang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-property-bang">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="valdef-property-double-bang">
-   <b><a href="#valdef-property-double-bang">#valdef-property-double-bang</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-valdef-property-double-bang" class="dfn-panel" data-for="valdef-property-double-bang" id="infopanel-for-valdef-property-double-bang" role="dialog">
+   <span id="infopaneltitle-for-valdef-property-double-bang" style="display:none">Info about the '!!double-bang' definition.</span><b><a href="#valdef-property-double-bang">#valdef-property-double-bang</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-property-double-bang">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface">
-   <b><a href="#interface">#interface</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface" class="dfn-panel" data-for="interface" id="infopanel-for-interface" role="dialog">
+   <span id="infopaneltitle-for-interface" style="display:none">Info about the 'Interface' definition.</span><b><a href="#interface">#interface</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-interface-attribute">
-   <b><a href="#dom-interface-attribute">#dom-interface-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-interface-attribute" class="dfn-panel" data-for="dom-interface-attribute" id="infopanel-for-dom-interface-attribute" role="dialog">
+   <span id="infopaneltitle-for-dom-interface-attribute" style="display:none">Info about the 'attribute' definition.</span><b><a href="#dom-interface-attribute">#dom-interface-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-interface-attribute">1. Test</a> <a href="#ref-for-dom-interface-attribute①">(2)</a> <a href="#ref-for-dom-interface-attribute②">(3)</a> <a href="#ref-for-dom-interface-attribute③">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-interface-method">
-   <b><a href="#dom-interface-method">#dom-interface-method</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-interface-method" class="dfn-panel" data-for="dom-interface-method" id="infopanel-for-dom-interface-method" role="dialog">
+   <span id="infopaneltitle-for-dom-interface-method" style="display:none">Info about the 'method()' definition.</span><b><a href="#dom-interface-method">#dom-interface-method</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-interface-method">1. Test</a> <a href="#ref-for-dom-interface-method①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dictdef-dictionary">
-   <b><a href="#dictdef-dictionary">#dictdef-dictionary</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dictdef-dictionary" class="dfn-panel" data-for="dictdef-dictionary" id="infopanel-for-dictdef-dictionary" role="dialog">
+   <span id="infopaneltitle-for-dictdef-dictionary" style="display:none">Info about the 'Dictionary' definition.</span><b><a href="#dictdef-dictionary">#dictdef-dictionary</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dictdef-dictionary">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="interface-attr">
-   <b><a href="#interface-attr">#interface-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-interface-attr" class="dfn-panel" data-for="interface-attr" id="infopanel-for-interface-attr" role="dialog">
+   <span id="infopaneltitle-for-interface-attr" style="display:none">Info about the 'attribute for Interface' definition.</span><b><a href="#interface-attr">#interface-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-interface-attr">1. Test</a> <a href="#ref-for-interface-attr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dict-attr">
-   <b><a href="#dict-attr">#dict-attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dict-attr" class="dfn-panel" data-for="dict-attr" id="infopanel-for-dict-attr" role="dialog">
+   <span id="infopaneltitle-for-dict-attr" style="display:none">Info about the 'attribute for Dictionary' definition.</span><b><a href="#dict-attr">#dict-attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dict-attr">1. Test</a> <a href="#ref-for-dict-attr①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-element">
-   <b><a href="#elementdef-element">#elementdef-element</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-element" class="dfn-panel" data-for="elementdef-element" id="infopanel-for-elementdef-element" role="dialog">
+   <span id="infopaneltitle-for-elementdef-element" style="display:none">Info about the 'element' definition.</span><b><a href="#elementdef-element">#elementdef-element</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-element">1. Test</a> <a href="#ref-for-elementdef-element①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-element-attribute">
-   <b><a href="#element-attrdef-element-attribute">#element-attrdef-element-attribute</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-element-attribute" class="dfn-panel" data-for="element-attrdef-element-attribute" id="infopanel-for-element-attrdef-element-attribute" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-element-attribute" style="display:none">Info about the 'attribute' definition.</span><b><a href="#element-attrdef-element-attribute">#element-attrdef-element-attribute</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-element-attribute">1. Test</a> <a href="#ref-for-element-attrdef-element-attribute①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-elements-can-have-dashes-too">
-   <b><a href="#elementdef-elements-can-have-dashes-too">#elementdef-elements-can-have-dashes-too</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-elements-can-have-dashes-too" class="dfn-panel" data-for="elementdef-elements-can-have-dashes-too" id="infopanel-for-elementdef-elements-can-have-dashes-too" role="dialog">
+   <span id="infopaneltitle-for-elementdef-elements-can-have-dashes-too" style="display:none">Info about the 'elements-can-have-dashes-too' definition.</span><b><a href="#elementdef-elements-can-have-dashes-too">#elementdef-elements-can-have-dashes-too</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-elements-can-have-dashes-too">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">
-   <b><a href="#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes" class="dfn-panel" data-for="element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes" id="infopanel-for-element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes" role="dialog">
+   <span id="infopaneltitle-for-element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes" style="display:none">Info about the 'attribute-with-dashes-because-attributes-can-have-dashes' definition.</span><b><a href="#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">#element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-element-attrdef-element-attribute-with-dashes-because-attributes-can-have-dashes">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr-valuedef-element-attribute-value">
-   <b><a href="#attr-valuedef-element-attribute-value">#attr-valuedef-element-attribute-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr-valuedef-element-attribute-value" class="dfn-panel" data-for="attr-valuedef-element-attribute-value" id="infopanel-for-attr-valuedef-element-attribute-value" role="dialog">
+   <span id="infopaneltitle-for-attr-valuedef-element-attribute-value" style="display:none">Info about the 'value' definition.</span><b><a href="#attr-valuedef-element-attribute-value">#attr-valuedef-element-attribute-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-valuedef-element-attribute-value">1. Test</a> <a href="#ref-for-attr-valuedef-element-attribute-value①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr-valuedef-element-attribute-val-with-spaces">
-   <b><a href="#attr-valuedef-element-attribute-val-with-spaces">#attr-valuedef-element-attribute-val-with-spaces</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr-valuedef-element-attribute-val-with-spaces" class="dfn-panel" data-for="attr-valuedef-element-attribute-val-with-spaces" id="infopanel-for-attr-valuedef-element-attribute-val-with-spaces" role="dialog">
+   <span id="infopaneltitle-for-attr-valuedef-element-attribute-val-with-spaces" style="display:none">Info about the 'val with spaces' definition.</span><b><a href="#attr-valuedef-element-attribute-val-with-spaces">#attr-valuedef-element-attribute-val-with-spaces</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-valuedef-element-attribute-val-with-spaces">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value">
-   <b><a href="#attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value">#attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value" class="dfn-panel" data-for="attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value" id="infopanel-for-attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value" role="dialog">
+   <span id="infopaneltitle-for-attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value" style="display:none">Info about the 'another value' definition.</span><b><a href="#attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value">#attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-attr-valuedef-elements-can-have-dashes-too-attribute-with-dashes-because-attributes-can-have-dashes-another-value">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dfn">
-   <b><a href="#dfn">#dfn</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dfn" class="dfn-panel" data-for="dfn" id="infopanel-for-dfn" role="dialog">
+   <span id="infopaneltitle-for-dfn" style="display:none">Info about the 'dfn' definition.</span><b><a href="#dfn">#dfn</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dfn">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-abstractop">
-   <b><a href="#abstract-opdef-abstractop">#abstract-opdef-abstractop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-abstract-opdef-abstractop" class="dfn-panel" data-for="abstract-opdef-abstractop" id="infopanel-for-abstract-opdef-abstractop" role="dialog">
+   <span id="infopaneltitle-for-abstract-opdef-abstractop" style="display:none">Info about the 'AbstractOp' definition.</span><b><a href="#abstract-opdef-abstractop">#abstract-opdef-abstractop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-abstractop">1. Test</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-header">
-   <b><a href="#http-headerdef-header">#http-headerdef-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-header" class="dfn-panel" data-for="http-headerdef-header" id="infopanel-for-http-headerdef-header" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-header" style="display:none">Info about the 'header' definition.</span><b><a href="#http-headerdef-header">#http-headerdef-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-header">1. Test</a> <a href="#ref-for-http-headerdef-header①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="http-headerdef-pseudo-header">
-   <b><a href="#http-headerdef-pseudo-header">#http-headerdef-pseudo-header</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-http-headerdef-pseudo-header" class="dfn-panel" data-for="http-headerdef-pseudo-header" id="infopanel-for-http-headerdef-pseudo-header" role="dialog">
+   <span id="infopaneltitle-for-http-headerdef-pseudo-header" style="display:none">Info about the ':pseudo-header' definition.</span><b><a href="#http-headerdef-pseudo-header">#http-headerdef-pseudo-header</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-http-headerdef-pseudo-header">1. Test</a> <a href="#ref-for-http-headerdef-pseudo-header①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links001.html
+++ b/tests/links001.html
@@ -499,8 +499,8 @@ dfn > a.self-link::before      { content: "#"; }
   <ul class="index">
    <li><a href="#propdef-flex-container">flex container</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-flex-container">
-   <a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-flex-container" class="dfn-panel" data-for="term-for-flex-container" id="infopanel-for-term-for-flex-container" role="menu">
+   <span id="infopaneltitle-for-term-for-flex-container" style="display:none">Info about the 'flex container' external reference.</span><a href="https://drafts.csswg.org/css-flexbox-1/#flex-container">https://drafts.csswg.org/css-flexbox-1/#flex-container</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-flex-container">Unnamed section</a>
    </ul>
@@ -521,57 +521,113 @@ dfn > a.self-link::before      { content: "#"; }
   </dl>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links002.html
+++ b/tests/links002.html
@@ -488,14 +488,14 @@ dfn > a.self-link::before      { content: "#"; }
    <p><a data-link-type="dfn" href="https://example.com/spec/#a-concept" id="ref-for-a-concept">a concept</a> <a data-link-type="dfn" href="https://example.com/spec/page2.html#another-concept" id="ref-for-another-concept">another concept</a></p>
   </main>
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span></h2>
-  <aside class="dfn-panel" data-for="term-for-a-concept">
-   <a href="https://example.com/spec/#a-concept">https://example.com/spec/#a-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-a-concept" class="dfn-panel" data-for="term-for-a-concept" id="infopanel-for-term-for-a-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-a-concept" style="display:none">Info about the 'a concept' external reference.</span><a href="https://example.com/spec/#a-concept">https://example.com/spec/#a-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-a-concept">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-another-concept">
-   <a href="https://example.com/spec/page2.html#another-concept">https://example.com/spec/page2.html#another-concept</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-another-concept" class="dfn-panel" data-for="term-for-another-concept" id="infopanel-for-term-for-another-concept" role="menu">
+   <span id="infopaneltitle-for-term-for-another-concept" style="display:none">Info about the 'another concept' external reference.</span><a href="https://example.com/spec/page2.html#another-concept">https://example.com/spec/page2.html#another-concept</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-another-concept">Unnamed section</a>
    </ul>
@@ -511,57 +511,113 @@ dfn > a.self-link::before      { content: "#"; }
   </ul>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links003.html
+++ b/tests/links003.html
@@ -497,20 +497,20 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#link-with-dashes①">link-with-dashes</a><span>, in § Unnumbered section</span>
    <li><a href="#propdef-property-with-dashes">property-with-dashes</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-anchor-with-dashes">
-   <a href="https://example.com/spec/#anchor-with-dashes">https://example.com/spec/#anchor-with-dashes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anchor-with-dashes" class="dfn-panel" data-for="term-for-anchor-with-dashes" id="infopanel-for-term-for-anchor-with-dashes" role="menu">
+   <span id="infopaneltitle-for-term-for-anchor-with-dashes" style="display:none">Info about the 'anchor with dashes' external reference.</span><a href="https://example.com/spec/#anchor-with-dashes">https://example.com/spec/#anchor-with-dashes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-with-dashes">Unnamed section</a> <a href="#ref-for-anchor-with-dashes①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anchor-property-with-dashes">
-   <a href="https://example.com/spec/#anchor-property-with-dashes">https://example.com/spec/#anchor-property-with-dashes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anchor-property-with-dashes" class="dfn-panel" data-for="term-for-anchor-property-with-dashes" id="infopanel-for-term-for-anchor-property-with-dashes" role="menu">
+   <span id="infopaneltitle-for-term-for-anchor-property-with-dashes" style="display:none">Info about the 'anchor-property-with-dashes' external reference.</span><a href="https://example.com/spec/#anchor-property-with-dashes">https://example.com/spec/#anchor-property-with-dashes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-property-with-dashes">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-anchor-with-dashes">
-   <a href="https://example.com/spec/#anchor-with-dashes">https://example.com/spec/#anchor-with-dashes</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-anchor-with-dashes" class="dfn-panel" data-for="term-for-anchor-with-dashes" id="infopanel-for-term-for-anchor-with-dashes①" role="menu">
+   <span id="infopaneltitle-for-term-for-anchor-with-dashes①" style="display:none">Info about the 'anchor-with-dashes' external reference.</span><a href="https://example.com/spec/#anchor-with-dashes">https://example.com/spec/#anchor-with-dashes</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-anchor-with-dashes">Unnamed section</a> <a href="#ref-for-anchor-with-dashes①">(2)</a>
    </ul>
@@ -525,77 +525,133 @@ dfn > a.self-link::before      { content: "#"; }
      <li><span class="dfn-paneled" id="term-for-anchor-with-dashes①">anchor-with-dashes</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="link-with-dashes">
-   <b><a href="#link-with-dashes">#link-with-dashes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-link-with-dashes" class="dfn-panel" data-for="link-with-dashes" id="infopanel-for-link-with-dashes" role="dialog">
+   <span id="infopaneltitle-for-link-with-dashes" style="display:none">Info about the 'link with dashes' definition.</span><b><a href="#link-with-dashes">#link-with-dashes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-with-dashes">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="link-with-dashes①">
-   <b><a href="#link-with-dashes①">#link-with-dashes①</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-link-with-dashes①" class="dfn-panel" data-for="link-with-dashes①" id="infopanel-for-link-with-dashes①" role="dialog">
+   <span id="infopaneltitle-for-link-with-dashes①" style="display:none">Info about the 'link-with-dashes' definition.</span><b><a href="#link-with-dashes①">#link-with-dashes①</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-link-with-dashes①">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-property-with-dashes">
-   <b><a href="#propdef-property-with-dashes">#propdef-property-with-dashes</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-property-with-dashes" class="dfn-panel" data-for="propdef-property-with-dashes" id="infopanel-for-propdef-property-with-dashes" role="dialog">
+   <span id="infopaneltitle-for-propdef-property-with-dashes" style="display:none">Info about the 'property-with-dashes' definition.</span><b><a href="#propdef-property-with-dashes">#propdef-property-with-dashes</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-property-with-dashes">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links004.html
+++ b/tests/links004.html
@@ -495,71 +495,127 @@ dfn > a.self-link::before      { content: "#"; }
      <li><a href="#foo-bar">dfn for bar</a><span>, in § Unnumbered section</span>
     </ul>
   </ul>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the 'foo' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foo-bar">
-   <b><a href="#foo-bar">#foo-bar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo-bar" class="dfn-panel" data-for="foo-bar" id="infopanel-for-foo-bar" role="dialog">
+   <span id="infopaneltitle-for-foo-bar" style="display:none">Info about the 'foo' definition.</span><b><a href="#foo-bar">#foo-bar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo-bar">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links005.html
+++ b/tests/links005.html
@@ -505,113 +505,169 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#snap">snap</a><span>, in § Unnumbered section</span>
    <li><a href="#zero">zero</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="berry">
-   <b><a href="#berry">#berry</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-berry" class="dfn-panel" data-for="berry" id="infopanel-for-berry" role="dialog">
+   <span id="infopaneltitle-for-berry" style="display:none">Info about the 'berry' definition.</span><b><a href="#berry">#berry</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-berry">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="blockify">
-   <b><a href="#blockify">#blockify</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-blockify" class="dfn-panel" data-for="blockify" id="infopanel-for-blockify" role="dialog">
+   <span id="infopaneltitle-for-blockify" style="display:none">Info about the 'blockify' definition.</span><b><a href="#blockify">#blockify</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-blockify">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="zero">
-   <b><a href="#zero">#zero</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-zero" class="dfn-panel" data-for="zero" id="infopanel-for-zero" role="dialog">
+   <span id="infopaneltitle-for-zero" style="display:none">Info about the 'zero' definition.</span><b><a href="#zero">#zero</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-zero">Unnamed section</a> <a href="#ref-for-zero①">(2)</a> <a href="#ref-for-zero②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="bikeshed">
-   <b><a href="#bikeshed">#bikeshed</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-bikeshed" class="dfn-panel" data-for="bikeshed" id="infopanel-for-bikeshed" role="dialog">
+   <span id="infopaneltitle-for-bikeshed" style="display:none">Info about the 'bikeshed' definition.</span><b><a href="#bikeshed">#bikeshed</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-bikeshed">Unnamed section</a> <a href="#ref-for-bikeshed①">(2)</a> <a href="#ref-for-bikeshed②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foos">
-   <b><a href="#foos">#foos</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foos" class="dfn-panel" data-for="foos" id="infopanel-for-foos" role="dialog">
+   <span id="infopaneltitle-for-foos" style="display:none">Info about the 'foos' definition.</span><b><a href="#foos">#foos</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foos">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="snap">
-   <b><a href="#snap">#snap</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-snap" class="dfn-panel" data-for="snap" id="infopanel-for-snap" role="dialog">
+   <span id="infopaneltitle-for-snap" style="display:none">Info about the 'snap' definition.</span><b><a href="#snap">#snap</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-snap">Unnamed section</a> <a href="#ref-for-snap①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="generate">
-   <b><a href="#generate">#generate</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-generate" class="dfn-panel" data-for="generate" id="infopanel-for-generate" role="dialog">
+   <span id="infopaneltitle-for-generate" style="display:none">Info about the 'generate' definition.</span><b><a href="#generate">#generate</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-generate">Unnamed section</a> <a href="#ref-for-generate①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-interf-_attr">
-   <b><a href="#dom-interf-_attr">#dom-interf-_attr</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-interf-_attr" class="dfn-panel" data-for="dom-interf-_attr" id="infopanel-for-dom-interf-_attr" role="dialog">
+   <span id="infopaneltitle-for-dom-interf-_attr" style="display:none">Info about the '_attr' definition.</span><b><a href="#dom-interf-_attr">#dom-interf-_attr</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-interf-_attr">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="foo-the-bar">
-   <b><a href="#foo-the-bar">#foo-the-bar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo-the-bar" class="dfn-panel" data-for="foo-the-bar" id="infopanel-for-foo-the-bar" role="dialog">
+   <span id="infopaneltitle-for-foo-the-bar" style="display:none">Info about the 'foo the bar' definition.</span><b><a href="#foo-the-bar">#foo-the-bar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo-the-bar">Unnamed section</a> <a href="#ref-for-foo-the-bar①">(2)</a> <a href="#ref-for-foo-the-bar②">(3)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links006.html
+++ b/tests/links006.html
@@ -498,83 +498,139 @@ dfn > a.self-link::before      { content: "#"; }
    <li><a href="#encoding">encoding</a><span>, in § Unnumbered section</span>
    <li><a href="#transcoding">transcoding</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="encode">
-   <b><a href="#encode">#encode</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encode" class="dfn-panel" data-for="encode" id="infopanel-for-encode" role="dialog">
+   <span id="infopaneltitle-for-encode" style="display:none">Info about the 'encode' definition.</span><b><a href="#encode">#encode</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encode">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="encoding">
-   <b><a href="#encoding">#encoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-encoding" class="dfn-panel" data-for="encoding" id="infopanel-for-encoding" role="dialog">
+   <span id="infopaneltitle-for-encoding" style="display:none">Info about the 'encoding' definition.</span><b><a href="#encoding">#encoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-encoding">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="define">
-   <b><a href="#define">#define</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-define" class="dfn-panel" data-for="define" id="infopanel-for-define" role="dialog">
+   <span id="infopaneltitle-for-define" style="display:none">Info about the 'define' definition.</span><b><a href="#define">#define</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-define">Unnamed section</a> <a href="#ref-for-define①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="transcoding">
-   <b><a href="#transcoding">#transcoding</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-transcoding" class="dfn-panel" data-for="transcoding" id="infopanel-for-transcoding" role="dialog">
+   <span id="infopaneltitle-for-transcoding" style="display:none">Info about the 'transcoding' definition.</span><b><a href="#transcoding">#transcoding</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-transcoding">Unnamed section</a> <a href="#ref-for-transcoding①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/links007.html
+++ b/tests/links007.html
@@ -650,20 +650,20 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#propdef-prop">prop</a><span>, in § Unnumbered section</span>
    <li><a href="#valdef-color-transparent">transparent</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-typedef-color">
-   <a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-typedef-color" class="dfn-panel" data-for="term-for-typedef-color" id="infopanel-for-term-for-typedef-color" role="menu">
+   <span id="infopaneltitle-for-term-for-typedef-color" style="display:none">Info about the '&lt;color>' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#typedef-color">https://drafts.csswg.org/css-color-4/#typedef-color</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-typedef-color">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-valdef-color-transparent">
-   <a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-valdef-color-transparent" class="dfn-panel" data-for="term-for-valdef-color-transparent" id="infopanel-for-term-for-valdef-color-transparent" role="menu">
+   <span id="infopaneltitle-for-term-for-valdef-color-transparent" style="display:none">Info about the 'transparent' external reference.</span><a href="https://drafts.csswg.org/css-color-4/#valdef-color-transparent">https://drafts.csswg.org/css-color-4/#valdef-color-transparent</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-valdef-color-transparent">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-long">
-   <a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-long" class="dfn-panel" data-for="term-for-idl-long" id="infopanel-for-term-for-idl-long" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-long" style="display:none">Info about the 'long' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-long">https://webidl.spec.whatwg.org/#idl-long</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-long">Unnamed section</a> <a href="#ref-for-idl-long①">(2)</a>
    </ul>
@@ -697,89 +697,145 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="foo">
-   <b><a href="#foo">#foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-foo" class="dfn-panel" data-for="foo" id="infopanel-for-foo" role="dialog">
+   <span id="infopaneltitle-for-foo" style="display:none">Info about the 'Foo' definition.</span><b><a href="#foo">#foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-foo">Unnamed section</a> <a href="#ref-for-foo①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-bar">
-   <b><a href="#dom-foo-bar">#dom-foo-bar</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-bar" class="dfn-panel" data-for="dom-foo-bar" id="infopanel-for-dom-foo-bar" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-bar" style="display:none">Info about the 'bar' definition.</span><b><a href="#dom-foo-bar">#dom-foo-bar</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-bar">Unnamed section</a> <a href="#ref-for-dom-foo-bar①">(2)</a> <a href="#ref-for-dom-foo-bar②">(3)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-foo-baz">
-   <b><a href="#dom-foo-baz">#dom-foo-baz</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-dom-foo-baz" class="dfn-panel" data-for="dom-foo-baz" id="infopanel-for-dom-foo-baz" role="dialog">
+   <span id="infopaneltitle-for-dom-foo-baz" style="display:none">Info about the 'baz' definition.</span><b><a href="#dom-foo-baz">#dom-foo-baz</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-dom-foo-baz">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="elementdef-el">
-   <b><a href="#elementdef-el">#elementdef-el</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-elementdef-el" class="dfn-panel" data-for="elementdef-el" id="infopanel-for-elementdef-el" role="dialog">
+   <span id="infopaneltitle-for-elementdef-el" style="display:none">Info about the 'el' definition.</span><b><a href="#elementdef-el">#elementdef-el</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-elementdef-el">Unnamed section</a> <a href="#ref-for-elementdef-el①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="propdef-prop">
-   <b><a href="#propdef-prop">#propdef-prop</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-propdef-prop" class="dfn-panel" data-for="propdef-prop" id="infopanel-for-propdef-prop" role="dialog">
+   <span id="infopaneltitle-for-propdef-prop" style="display:none">Info about the 'prop' definition.</span><b><a href="#propdef-prop">#propdef-prop</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-propdef-prop">Unnamed section</a> <a href="#ref-for-propdef-prop①">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/lint001.html
+++ b/tests/lint001.html
@@ -650,8 +650,8 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
    <li><a href="#good2">Good2</a><span>, in § Unnumbered section</span>
    <li><a href="#good3">Good3</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-Exposed" class="dfn-panel" data-for="term-for-Exposed" id="infopanel-for-term-for-Exposed" role="menu">
+   <span id="infopaneltitle-for-term-for-Exposed" style="display:none">Info about the 'Exposed' external reference.</span><a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">Unnamed section</a> <a href="#ref-for-Exposed①">(2)</a>
    </ul>
@@ -681,57 +681,113 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 </pre>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>

--- a/tests/pre002.html
+++ b/tests/pre002.html
@@ -671,20 +671,20 @@ baz
    <li><a href="#dom-foo-foo">foo(foo)</a><span>, in § Unnumbered section</span>
    <li><a href="#propdef-justify-self">justify-self</a><span>, in § Unnumbered section</span>
   </ul>
-  <aside class="dfn-panel" data-for="term-for-comb-one">
-   <a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-comb-one" class="dfn-panel" data-for="term-for-comb-one" id="infopanel-for-term-for-comb-one" role="menu">
+   <span id="infopaneltitle-for-term-for-comb-one" style="display:none">Info about the '|' external reference.</span><a href="https://drafts.csswg.org/css-values-4/#comb-one">https://drafts.csswg.org/css-values-4/#comb-one</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-comb-one">Unnamed section</a> <a href="#ref-for-comb-one①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-DOMString" class="dfn-panel" data-for="term-for-idl-DOMString" id="infopanel-for-term-for-idl-DOMString" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-DOMString" style="display:none">Info about the 'DOMString' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">Unnamed section</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-term-for-idl-sequence" class="dfn-panel" data-for="term-for-idl-sequence" id="infopanel-for-term-for-idl-sequence" role="menu">
+   <span id="infopaneltitle-for-term-for-idl-sequence" style="display:none">Info about the 'sequence' external reference.</span><a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">Unnamed section</a>
    </ul>
@@ -747,65 +747,121 @@ baz
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="namespacedef-foo">
-   <b><a href="#namespacedef-foo">#namespacedef-foo</a></b><b>Referenced in:</b>
+  <aside aria-labelledby="infopaneltitle-for-namespacedef-foo" class="dfn-panel" data-for="namespacedef-foo" id="infopanel-for-namespacedef-foo" role="dialog">
+   <span id="infopaneltitle-for-namespacedef-foo" style="display:none">Info about the 'Foo' definition.</span><b><a href="#namespacedef-foo">#namespacedef-foo</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-namespacedef-foo">Unnamed section</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */
 
-document.body.addEventListener("click", function(e) {
-    var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
-    // Find the dfn element or panel, if any, that was clicked on.
-    var el = e.target;
-    var target;
-    var hitALink = false;
-    while(el.parentElement) {
-        if(el.tagName == "A") {
-            // Clicking on a link in a <dfn> shouldn't summon the panel
-            hitALink = true;
-        }
-        if(el.classList.contains("dfn-paneled")) {
-            target = "dfn";
-            break;
-        }
-        if(el.classList.contains("dfn-panel")) {
-            target = "dfn-panel";
-            break;
-        }
-        el = el.parentElement;
-    }
-    if(target != "dfn-panel") {
-        // Turn off any currently "on" or "activated" panels.
-        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
-            el.classList.remove("on");
-            el.classList.remove("activated");
-        });
-    }
-    if(target == "dfn" && !hitALink) {
-        // open the panel
-        var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
-        if(dfnPanel) {
-            dfnPanel.classList.add("on");
-            var rect = el.getBoundingClientRect();
-            dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
-            dfnPanel.style.top = window.scrollY + rect.top + "px";
-            var panelRect = dfnPanel.getBoundingClientRect();
-            var panelWidth = panelRect.right - panelRect.left;
-            if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
-                // Reposition, because the panel is overflowing
-                dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
-            }
-        } else {
-            console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
-        }
-    } else if(target == "dfn-panel") {
-        // Switch it to "activated" state, which pins it.
-        el.classList.add("activated");
-        el.style.left = null;
-        el.style.top = null;
+"use strict";
+{
+    function queryAll(sel) {
+        return [].slice.call(document.querySelectorAll(sel));
     }
 
-});
+    // Add popup behavior to all dfns to show the corresponding dfn-panel.
+    var dfns = document.querySelectorAll('.dfn-paneled');
+    for (let dfn of dfns) { insertDfnPopupAction(dfn); }
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+
+    function hideAllDfnPanels() {
+        // Turn off any currently "on" or "activated" panels.
+        queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>hideDfnPanel(el));
+    }
+
+    function showDfnPanel(dfnPanel, dfn) {
+        hideAllDfnPanels(); // Only display one at this time.
+        dfn.setAttribute("aria-expanded", "true");
+        dfnPanel.classList.add("on");
+        dfnPanel.style.left = "5px";
+        dfnPanel.style.top = "0px";
+        const panelRect = dfnPanel.getBoundingClientRect();
+        const panelWidth = panelRect.right - panelRect.left;
+        if (panelRect.right > document.body.scrollWidth) {
+            // Panel's overflowing the screen.
+            // Just drop it below the dfn and flip it rightward instead.
+            // This still wont' fix things if the screen is *really* wide,
+            // but fixing that's a lot harder without 'anchor()'.
+            dfnPanel.style.top = "1.5em";
+            dfnPanel.style.left = "auto";
+            dfnPanel.style.right = "0px";
+        }
+    }
+
+    function pinDfnPanel(dfnPanel) {
+        // Switch it to "activated" state, which pins it.
+        dfnPanel.classList.add("activated");
+        dfnPanel.style.left = null;
+        dfnPanel.style.top = null;
+    }
+
+    function hideDfnPanel(dfnPanel, dfn) {
+        if(!dfn) {
+            dfn = document.getElementById(dfnPanel.getAttribute("data-for"));
+        }
+        dfn.setAttribute("aria-expanded", "false")
+        dfnPanel.classList.remove("on");
+        dfnPanel.classList.remove("activated");
+    }
+
+    function toggleDfnPanel(dfnPanel, dfn) {
+        if(dfnPanel.classList.contains("on")) {
+            hideDfnPanel(dfnPanel, dfn);
+        } else {
+            showDfnPanel(dfnPanel, dfn);
+        }
+    }
+
+    function insertDfnPopupAction(dfn) {
+        // Find dfn panel
+        const dfnPanel = document.querySelector(`.dfn-panel[data-for='${dfn.id}']`);
+        if (dfnPanel) {
+            const panelWrapper = document.createElement('span');
+            panelWrapper.appendChild(dfnPanel);
+            panelWrapper.style.position = "relative";
+            panelWrapper.style.height = "0px";
+            dfn.insertAdjacentElement("afterend", panelWrapper);
+            dfn.setAttribute('role', 'button');
+            dfn.setAttribute('aria-haspopup', 'menu');
+            dfn.setAttribute('aria-expanded', 'false')
+            dfn.tabIndex = 0;
+            dfn.classList.add('has-dfn-panel');
+            dfn.addEventListener('click', (event) => {
+                showDfnPanel(dfnPanel, dfn);
+                event.stopPropagation();
+            });
+            dfn.addEventListener('keypress', (event) => {
+                const kc = event.keyCode;
+                // 32->Space, 13->Enter
+                if(kc == 32 || kc == 13) {
+                    toggleDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            });
+
+            dfnPanel.addEventListener('click', (event) => {
+                pinDfnPanel(dfnPanel);
+                event.stopPropagation();
+            });
+
+            dfnPanel.addEventListener('keydown', (event) => {
+                if(event.keyCode == 27) { // Escape key
+                    hideDfnPanel(dfnPanel, dfn);
+                    event.stopPropagation();
+                    event.preventDefault();
+                }
+            })
+
+        } else {
+            console.log("Couldn't find .dfn-panel[data-for='" + dfn.id + "']");
+        }
+    }
+}
 </script>


### PR DESCRIPTION
This PR preserves the current behavior of dfn and panels, but adds a11y support, tabindex support, and a visual clue that the dfn acts like a "button".    Notice the outset outline around "sequence":

![image](https://user-images.githubusercontent.com/570125/217643672-ba9051ba-b7af-47e8-b416-9f4d285d4576.png)

This change should fix #1681, if I did it right.
